### PR TITLE
[Merged by Bors] - feat(Matrix/Determinant): add `submatrix_succAbove_det_eq_negOnePow_submatrix_succAbove_det`

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -2667,8 +2667,7 @@ import Mathlib.LinearAlgebra.Coevaluation
 import Mathlib.LinearAlgebra.Contraction
 import Mathlib.LinearAlgebra.CrossProduct
 import Mathlib.LinearAlgebra.DFinsupp
-import Mathlib.LinearAlgebra.Determinant.Basic
-import Mathlib.LinearAlgebra.Determinant.Misc
+import Mathlib.LinearAlgebra.Determinant
 import Mathlib.LinearAlgebra.Dimension.Basic
 import Mathlib.LinearAlgebra.Dimension.Constructions
 import Mathlib.LinearAlgebra.Dimension.DivisionRing

--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -2667,7 +2667,8 @@ import Mathlib.LinearAlgebra.Coevaluation
 import Mathlib.LinearAlgebra.Contraction
 import Mathlib.LinearAlgebra.CrossProduct
 import Mathlib.LinearAlgebra.DFinsupp
-import Mathlib.LinearAlgebra.Determinant
+import Mathlib.LinearAlgebra.Determinant.Basic
+import Mathlib.LinearAlgebra.Determinant.Misc
 import Mathlib.LinearAlgebra.Dimension.Basic
 import Mathlib.LinearAlgebra.Dimension.Constructions
 import Mathlib.LinearAlgebra.Dimension.DivisionRing
@@ -2723,7 +2724,8 @@ import Mathlib.LinearAlgebra.Matrix.Charpoly.LinearMap
 import Mathlib.LinearAlgebra.Matrix.Charpoly.Minpoly
 import Mathlib.LinearAlgebra.Matrix.Charpoly.Univ
 import Mathlib.LinearAlgebra.Matrix.Circulant
-import Mathlib.LinearAlgebra.Matrix.Determinant
+import Mathlib.LinearAlgebra.Matrix.Determinant.Basic
+import Mathlib.LinearAlgebra.Matrix.Determinant.Misc
 import Mathlib.LinearAlgebra.Matrix.Diagonal
 import Mathlib.LinearAlgebra.Matrix.DotProduct
 import Mathlib.LinearAlgebra.Matrix.Dual

--- a/Mathlib/Data/Matrix/Kronecker.lean
+++ b/Mathlib/Data/Matrix/Kronecker.lean
@@ -5,7 +5,7 @@ Authors: Filippo A. E. Nuccio, Eric Wieser
 -/
 import Mathlib.Data.Matrix.Basic
 import Mathlib.Data.Matrix.Block
-import Mathlib.LinearAlgebra.Matrix.Determinant
+import Mathlib.LinearAlgebra.Matrix.Determinant.Basic
 import Mathlib.LinearAlgebra.Matrix.NonsingularInverse
 import Mathlib.LinearAlgebra.TensorProduct.Basic
 import Mathlib.RingTheory.TensorProduct.Basic

--- a/Mathlib/LinearAlgebra/CrossProduct.lean
+++ b/Mathlib/LinearAlgebra/CrossProduct.lean
@@ -5,7 +5,7 @@ Authors: Martin Dvorak, Kyle Miller, Eric Wieser
 -/
 import Mathlib.Data.Matrix.Notation
 import Mathlib.LinearAlgebra.BilinearMap
-import Mathlib.LinearAlgebra.Matrix.Determinant
+import Mathlib.LinearAlgebra.Matrix.Determinant.Basic
 import Mathlib.Algebra.Lie.Basic
 
 #align_import linear_algebra.cross_product from "leanprover-community/mathlib"@"91288e351d51b3f0748f0a38faa7613fb0ae2ada"

--- a/Mathlib/LinearAlgebra/Matrix/AbsoluteValue.lean
+++ b/Mathlib/LinearAlgebra/Matrix/AbsoluteValue.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Anne Baanen
 -/
 import Mathlib.Data.Int.AbsoluteValue
-import Mathlib.LinearAlgebra.Matrix.Determinant
+import Mathlib.LinearAlgebra.Matrix.Determinant.Basic
 
 #align_import linear_algebra.matrix.absolute_value from "leanprover-community/mathlib"@"ab0a2959c83b06280ef576bc830d4aa5fe8c8e61"
 

--- a/Mathlib/LinearAlgebra/Matrix/Determinant/Basic.lean
+++ b/Mathlib/LinearAlgebra/Matrix/Determinant/Basic.lean
@@ -3,6 +3,7 @@ Copyright (c) 2018 Kenny Lau. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Kenny Lau, Chris Hughes, Anne Baanen
 -/
+import Mathlib.Algebra.Ring.NegOnePow
 import Mathlib.Data.Matrix.Block
 import Mathlib.Data.Matrix.Notation
 import Mathlib.Data.Matrix.RowCol
@@ -376,6 +377,14 @@ theorem det_zero_of_column_eq (i_ne_j : i ≠ j) (hij : ∀ k, M k i = M k j) : 
   exact funext hij
 #align matrix.det_zero_of_column_eq Matrix.det_zero_of_column_eq
 
+/-- If we repeat a row of a matrix, we get a matrix of determinant zero. -/
+theorem det_updateRow_eq_zero (h : i ≠ j) :
+    (M.updateRow j (M i)).det = 0 := det_zero_of_row_eq h (by simp [h])
+
+/-- If we repeat a column of a matrix, we get a matrix of determinant zero. -/
+theorem det_updateColumn_eq_zero (h : i ≠ j) :
+    (M.updateColumn j (fun k ↦ M k i)).det = 0 := det_zero_of_column_eq h (by simp [h])
+
 end DetZero
 
 theorem det_updateRow_add (M : Matrix n n R) (j : n) (u v : n → R) :
@@ -410,6 +419,32 @@ theorem det_updateColumn_smul' (M : Matrix n n R) (j : n) (s : R) (u : n → R) 
   rw [← det_transpose, ← updateRow_transpose, transpose_smul, det_updateRow_smul']
   simp [updateRow_transpose, det_transpose]
 #align matrix.det_update_column_smul' Matrix.det_updateColumn_smul'
+
+theorem det_updateRow_sum_aux (M : Matrix n n R) {j : n} (s : Finset n) (hj : j ∉ s) (c : n → R)
+    (a : R) :
+    (M.updateRow j (a • M j + ∑ k ∈ s, (c k) • M k)).det = a • M.det := by
+  induction s using Finset.induction_on with
+  | empty => rw [Finset.sum_empty, add_zero, smul_eq_mul, det_updateRow_smul, updateRow_eq_self]
+  | @insert k _ hk h_ind =>
+      have h : k ≠ j := fun h ↦ (h ▸ hj) (Finset.mem_insert_self _ _)
+      rw [Finset.sum_insert hk, add_comm ((c k) • M k), ← add_assoc, det_updateRow_add,
+        det_updateRow_smul, det_updateRow_eq_zero h, mul_zero, add_zero, h_ind]
+      exact fun h ↦ hj (Finset.mem_insert_of_mem h)
+
+/-- If we replace a row of a matrix by a linear combination of its rows, then the determinant is
+multiplied by the coefficient of that row. -/
+theorem det_updateRow_sum (A : Matrix n n R) (j : n) (c : n → R) :
+    (A.updateRow j (∑ k, (c k) • A k)).det = (c j) • A.det := by
+  convert det_updateRow_sum_aux A (Finset.univ.erase j) (Finset.univ.not_mem_erase j) c (c j)
+  rw [← Finset.univ.add_sum_erase _ (Finset.mem_univ j)]
+
+/-- If we replace a column of a matrix by a linear combination of its columns, then the determinant
+is multiplied by the coefficient of that column. -/
+theorem det_updateColumn_sum (A : Matrix n n R) (j : n) (c : n → R) :
+    (A.updateColumn j (fun k ↦ ∑ i, (c i) • A k i)).det = (c j) • A.det := by
+  rw [← det_transpose, ← updateRow_transpose, ← det_transpose A]
+  convert det_updateRow_sum A.transpose j c
+  simp only [smul_eq_mul, Finset.sum_apply, Pi.smul_apply, transpose_apply]
 
 section DetEq
 

--- a/Mathlib/LinearAlgebra/Matrix/Determinant/Basic.lean
+++ b/Mathlib/LinearAlgebra/Matrix/Determinant/Basic.lean
@@ -3,7 +3,6 @@ Copyright (c) 2018 Kenny Lau. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Kenny Lau, Chris Hughes, Anne Baanen
 -/
-import Mathlib.Algebra.Ring.NegOnePow
 import Mathlib.Data.Matrix.Block
 import Mathlib.Data.Matrix.Notation
 import Mathlib.Data.Matrix.RowCol

--- a/Mathlib/LinearAlgebra/Matrix/Determinant/Misc.lean
+++ b/Mathlib/LinearAlgebra/Matrix/Determinant/Misc.lean
@@ -1,0 +1,58 @@
+/-
+Copyright (c) 2024 Xavier Roblot. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Xavier Roblot
+-/
+import Mathlib.LinearAlgebra.Matrix.Determinant.Basic
+import Mathlib.Algebra.Ring.NegOnePow
+
+/-!
+# Miscellaneous results about determinant
+
+In this file, we collect various formulas about determinant of matrices.
+-/
+
+namespace Matrix
+
+variable {R : Type*} [CommRing R]
+
+/-- Let `M` be a `(n+1) × n` matrix whose row sums to zero. Then matrices obtained by deleting one
+row all have the same determinant up to a sign. -/
+theorem submatrix_succAbove_det_eq_negOnePow_submatrix_succAbove_det {n : ℕ}
+    (M : Matrix (Fin (n + 1)) (Fin n) R) (hv : ∑ j, M j = 0) (j₁ j₂ : Fin (n + 1)) :
+    (M.submatrix (Fin.succAbove j₁) id).det =
+      Int.negOnePow (j₁ - j₂) • (M.submatrix (Fin.succAbove j₂) id).det := by
+  suffices ∀ j, (M.submatrix (Fin.succAbove j) id).det =
+      Int.negOnePow j • (M.submatrix (Fin.succAbove 0) id).det by
+    rw [this j₁, this j₂, smul_smul, ← Int.negOnePow_add, sub_add_cancel]
+  intro j
+  induction j using Fin.induction with
+  | zero => rw [Fin.val_zero, Nat.cast_zero, Int.negOnePow_zero, one_smul]
+  | succ i h_ind =>
+      rw [Fin.val_succ, Nat.cast_add, Nat.cast_one, Int.negOnePow_succ, Units.neg_smul,
+        ← neg_eq_iff_eq_neg, ← neg_one_smul R, ← det_updateRow_sum (M.submatrix i.succ.succAbove id)
+        i (fun _ ↦ -1), ← Fin.coe_castSucc i, ← h_ind]
+      congr
+      ext a b
+      simp_rw [neg_one_smul, updateRow_apply, Finset.sum_neg_distrib, Pi.neg_apply,
+        Finset.sum_apply, submatrix_apply, id_eq]
+      split_ifs with h
+      · replace hv := congr_fun hv b
+        rw [Fin.sum_univ_succAbove _ i.succ, Pi.add_apply, Finset.sum_apply] at hv
+        rwa [h, Fin.succAbove_castSucc_self, neg_eq_iff_add_eq_zero, add_comm]
+      · obtain h| h := ne_iff_lt_or_gt.mp h
+        · rw [Fin.succAbove_castSucc_of_lt _ _ h,  Fin.succAbove_of_succ_le _ _
+            (Fin.succ_lt_succ_iff.mpr h).le]
+        · rw [Fin.succAbove_succ_of_lt _ _ h, Fin.succAbove_castSucc_of_le _ _ h.le]
+
+/-- Let `M` be a `(n+1) × n` matrix whose column sums to zero. Then matrices obtained by deleting
+one column all have the same determinant up to a sign. -/
+theorem submatrix_succAbove_det_eq_negOnePow_submatrix_succAbove_det' {n : ℕ}
+    (M : Matrix (Fin n) (Fin (n + 1)) R) (hv : ∀ i, ∑ j, M i j = 0) (j₁ j₂ : Fin (n + 1)) :
+    (M.submatrix id (Fin.succAbove j₁)).det =
+      Int.negOnePow (j₁ - j₂) • (M.submatrix id (Fin.succAbove j₂)).det := by
+  rw [← det_transpose, transpose_submatrix,
+    submatrix_succAbove_det_eq_negOnePow_submatrix_succAbove_det M.transpose ?_ j₁ j₂,
+    ← det_transpose, transpose_submatrix, transpose_transpose]
+  ext
+  simp_rw [Finset.sum_apply, transpose_apply, hv, Pi.zero_apply]

--- a/Mathlib/LinearAlgebra/Matrix/Determinant/Misc.lean
+++ b/Mathlib/LinearAlgebra/Matrix/Determinant/Misc.lean
@@ -16,8 +16,8 @@ namespace Matrix
 
 variable {R : Type*} [CommRing R]
 
-/-- Let `M` be a `(n+1) × n` matrix whose row sums to zero. Then matrices obtained by deleting one
-row all have the same determinant up to a sign. -/
+/-- Let `M` be a `(n+1) × n` matrix whose row sums to zero. Then all the matrices obtained by
+deleting one row have the same determinant up to a sign. -/
 theorem submatrix_succAbove_det_eq_negOnePow_submatrix_succAbove_det {n : ℕ}
     (M : Matrix (Fin (n + 1)) (Fin n) R) (hv : ∑ j, M j = 0) (j₁ j₂ : Fin (n + 1)) :
     (M.submatrix (Fin.succAbove j₁) id).det =
@@ -46,8 +46,8 @@ theorem submatrix_succAbove_det_eq_negOnePow_submatrix_succAbove_det {n : ℕ}
             Fin.succAbove_of_succ_le _ _ (Fin.succ_lt_succ_iff.mpr h).le]
         · rw [Fin.succAbove_succ_of_lt _ _ h, Fin.succAbove_castSucc_of_le _ _ h.le]
 
-/-- Let `M` be a `(n+1) × n` matrix whose column sums to zero. Then matrices obtained by deleting
-one column all have the same determinant up to a sign. -/
+/-- Let `M` be a `(n+1) × n` matrix whose column sums to zero. Then all the matrices obtained by
+deleting one column have the same determinant up to a sign. -/
 theorem submatrix_succAbove_det_eq_negOnePow_submatrix_succAbove_det' {n : ℕ}
     (M : Matrix (Fin n) (Fin (n + 1)) R) (hv : ∀ i, ∑ j, M i j = 0) (j₁ j₂ : Fin (n + 1)) :
     (M.submatrix id (Fin.succAbove j₁)).det =

--- a/Mathlib/LinearAlgebra/Matrix/Determinant/Misc.lean
+++ b/Mathlib/LinearAlgebra/Matrix/Determinant/Misc.lean
@@ -30,8 +30,9 @@ theorem submatrix_succAbove_det_eq_negOnePow_submatrix_succAbove_det {n : ℕ}
   | zero => rw [Fin.val_zero, Nat.cast_zero, Int.negOnePow_zero, one_smul]
   | succ i h_ind =>
       rw [Fin.val_succ, Nat.cast_add, Nat.cast_one, Int.negOnePow_succ, Units.neg_smul,
-        ← neg_eq_iff_eq_neg, ← neg_one_smul R, ← det_updateRow_sum (M.submatrix i.succ.succAbove id)
-        i (fun _ ↦ -1), ← Fin.coe_castSucc i, ← h_ind]
+        ← neg_eq_iff_eq_neg, ← neg_one_smul R,
+        ← det_updateRow_sum (M.submatrix i.succ.succAbove id) i (fun _ ↦ -1),
+        ← Fin.coe_castSucc i, ← h_ind]
       congr
       ext a b
       simp_rw [neg_one_smul, updateRow_apply, Finset.sum_neg_distrib, Pi.neg_apply,
@@ -40,9 +41,9 @@ theorem submatrix_succAbove_det_eq_negOnePow_submatrix_succAbove_det {n : ℕ}
       · replace hv := congr_fun hv b
         rw [Fin.sum_univ_succAbove _ i.succ, Pi.add_apply, Finset.sum_apply] at hv
         rwa [h, Fin.succAbove_castSucc_self, neg_eq_iff_add_eq_zero, add_comm]
-      · obtain h| h := ne_iff_lt_or_gt.mp h
-        · rw [Fin.succAbove_castSucc_of_lt _ _ h,  Fin.succAbove_of_succ_le _ _
-            (Fin.succ_lt_succ_iff.mpr h).le]
+      · obtain h|h := ne_iff_lt_or_gt.mp h
+        · rw [Fin.succAbove_castSucc_of_lt _ _ h,
+            Fin.succAbove_of_succ_le _ _ (Fin.succ_lt_succ_iff.mpr h).le]
         · rw [Fin.succAbove_succ_of_lt _ _ h, Fin.succAbove_castSucc_of_le _ _ h.le]
 
 /-- Let `M` be a `(n+1) × n` matrix whose column sums to zero. Then matrices obtained by deleting

--- a/Mathlib/LinearAlgebra/Matrix/MvPolynomial.lean
+++ b/Mathlib/LinearAlgebra/Matrix/MvPolynomial.lean
@@ -5,7 +5,7 @@ Authors: Eric Wieser
 -/
 import Mathlib.Algebra.MvPolynomial.Basic
 import Mathlib.Algebra.MvPolynomial.CommRing
-import Mathlib.LinearAlgebra.Matrix.Determinant
+import Mathlib.LinearAlgebra.Matrix.Determinant.Basic
 
 #align_import linear_algebra.matrix.mv_polynomial from "leanprover-community/mathlib"@"3e068ece210655b7b9a9477c3aff38a492400aa1"
 

--- a/Mathlib/LinearAlgebra/Matrix/Nondegenerate.lean
+++ b/Mathlib/LinearAlgebra/Matrix/Nondegenerate.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Anne Baanen
 -/
 import Mathlib.Data.Matrix.Basic
-import Mathlib.LinearAlgebra.Matrix.Determinant
+import Mathlib.LinearAlgebra.Matrix.Determinant.Basic
 import Mathlib.LinearAlgebra.Matrix.Adjugate
 
 #align_import linear_algebra.matrix.nondegenerate from "leanprover-community/mathlib"@"2a32c70c78096758af93e997b978a5d461007b4f"

--- a/Mathlib/LinearAlgebra/Matrix/Permutation.lean
+++ b/Mathlib/LinearAlgebra/Matrix/Permutation.lean
@@ -6,7 +6,7 @@ Authors: Anne Baanen
 
 import Mathlib.Data.Matrix.PEquiv
 import Mathlib.Data.Set.Card
-import Mathlib.LinearAlgebra.Matrix.Determinant
+import Mathlib.LinearAlgebra.Matrix.Determinant.Basic
 import Mathlib.LinearAlgebra.Matrix.Trace
 
 /-!

--- a/Mathlib/LinearAlgebra/Matrix/Polynomial.lean
+++ b/Mathlib/LinearAlgebra/Matrix/Polynomial.lean
@@ -5,7 +5,7 @@ Authors: Yakov Pechersky
 -/
 import Mathlib.Algebra.Polynomial.BigOperators
 import Mathlib.Algebra.Polynomial.Degree.Lemmas
-import Mathlib.LinearAlgebra.Matrix.Determinant
+import Mathlib.LinearAlgebra.Matrix.Determinant.Basic
 import Mathlib.Tactic.ComputeDegree
 
 #align_import linear_algebra.matrix.polynomial from "leanprover-community/mathlib"@"70fd9563a21e7b963887c9360bd29b2393e6225a"

--- a/Mathlib/LinearAlgebra/Matrix/Reindex.lean
+++ b/Mathlib/LinearAlgebra/Matrix/Reindex.lean
@@ -3,7 +3,7 @@ Copyright (c) 2019 Johannes Hölzl. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johannes Hölzl, Patrick Massot, Casper Putz, Anne Baanen
 -/
-import Mathlib.LinearAlgebra.Matrix.Determinant
+import Mathlib.LinearAlgebra.Matrix.Determinant.Basic
 
 #align_import linear_algebra.matrix.reindex from "leanprover-community/mathlib"@"1cfdf5f34e1044ecb65d10be753008baaf118edf"
 

--- a/Mathlib/LinearAlgebra/Matrix/Transvection.lean
+++ b/Mathlib/LinearAlgebra/Matrix/Transvection.lean
@@ -5,7 +5,7 @@ Authors: Sébastien Gouëzel
 -/
 import Mathlib.Data.Matrix.Basis
 import Mathlib.Data.Matrix.DMatrix
-import Mathlib.LinearAlgebra.Matrix.Determinant
+import Mathlib.LinearAlgebra.Matrix.Determinant.Basic
 import Mathlib.LinearAlgebra.Matrix.Reindex
 import Mathlib.Tactic.FieldSimp
 

--- a/Mathlib/LinearAlgebra/QuadraticForm/Basic.lean
+++ b/Mathlib/LinearAlgebra/QuadraticForm/Basic.lean
@@ -3,7 +3,7 @@ Copyright (c) 2020 Anne Baanen. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Anne Baanen, Kexing Ying, Eric Wieser
 -/
-import Mathlib.LinearAlgebra.Matrix.Determinant
+import Mathlib.LinearAlgebra.Matrix.Determinant.Basic
 import Mathlib.LinearAlgebra.Matrix.SesquilinearForm
 import Mathlib.LinearAlgebra.Matrix.Symmetric
 

--- a/Mathlib/LinearAlgebra/Vandermonde.lean
+++ b/Mathlib/LinearAlgebra/Vandermonde.lean
@@ -6,7 +6,7 @@ Authors: Anne Baanen
 import Mathlib.Algebra.BigOperators.Fin
 import Mathlib.Algebra.GeomSum
 import Mathlib.LinearAlgebra.Matrix.Block
-import Mathlib.LinearAlgebra.Matrix.Determinant
+import Mathlib.LinearAlgebra.Matrix.Determinant.Basic
 import Mathlib.LinearAlgebra.Matrix.Nondegenerate
 
 #align_import linear_algebra.vandermonde from "leanprover-community/mathlib"@"70fd9563a21e7b963887c9360bd29b2393e6225a"

--- a/test/matrix.lean
+++ b/test/matrix.lean
@@ -4,7 +4,7 @@ https://github.com/leanprover-community/mathlib/blob/4f4a1c875d0baa92ab5d92f3fb1
 -/
 import Mathlib.Data.Matrix.Notation
 import Mathlib.GroupTheory.Perm.Fin
-import Mathlib.LinearAlgebra.Matrix.Determinant
+import Mathlib.LinearAlgebra.Matrix.Determinant.Basic
 import Qq
 
 open Qq


### PR DESCRIPTION
Let `M` be a `(n+1) × n` matrix whose row sums to zero. This PR proves that all the matrices obtained by deleting one
row have the same determinant up to a sign (and a similar result for columns).

This PR also move `Mathlib/LinearAlgebra/Matrix/Determinant.lean` to `Mathlib/LinearAlgebra/Matrix/Determinant/Basic.lean` and put the new result in a new file: `Mathlib/LinearAlgebra/Matrix/Determinant/Misc.lean` where various results about determinant should be added.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
