### PR TITLE
[Merged by Bors] - chore: tidy induction principles for Unitization and TrivSqZeroExt

### DIFF
--- a/Mathlib/Algebra/Algebra/Subalgebra/Unitization.lean
+++ b/Mathlib/Algebra/Algebra/Subalgebra/Unitization.lean
@@ -105,7 +105,7 @@ theorem lift_range_le {f : A →ₙₐ[R] C} {S : Subalgebra R C} :
   · rintro - ⟨x, rfl⟩
     exact @h (f x) ⟨x, by simp⟩
   · rintro - ⟨x, rfl⟩
-    induction x using ind with
+    induction x with
     | _ r a => simpa using add_mem (algebraMap_mem S r) (h ⟨a, rfl⟩)
 
 theorem lift_range (f : A →ₙₐ[R] C) :
@@ -360,7 +360,7 @@ theorem starLift_range_le
   · rintro - ⟨x, rfl⟩
     exact @h (f x) ⟨x, by simp⟩
   · rintro - ⟨x, rfl⟩
-    induction x using ind with
+    induction x with
     | _ r a => simpa using add_mem (algebraMap_mem S r) (h ⟨a, rfl⟩)
 
 theorem starLift_range (f : A →⋆ₙₐ[R] C) :

--- a/Mathlib/Algebra/Algebra/Subalgebra/Unitization.lean
+++ b/Mathlib/Algebra/Algebra/Subalgebra/Unitization.lean
@@ -148,7 +148,7 @@ theorem _root_.AlgHomClass.unitization_injective' {F R S A : Type*} [CommRing R]
     [FunLike F (Unitization R s) A] [AlgHomClass F R (Unitization R s) A]
     (f : F) (hf : ∀ x : s, f x = x) : Function.Injective f := by
   refine (injective_iff_map_eq_zero f).mpr fun x hx => ?_
-  induction' x using Unitization.ind with r a
+  induction' x with r a
   simp_rw [map_add, hf, ← Unitization.algebraMap_eq_inl, AlgHomClass.commutes] at hx
   rw [add_eq_zero_iff_eq_neg] at hx ⊢
   by_cases hr : r = 0

--- a/Mathlib/Algebra/Algebra/Unitization.lean
+++ b/Mathlib/Algebra/Algebra/Unitization.lean
@@ -327,10 +327,11 @@ theorem inl_fst_add_inr_snd_eq [AddZeroClass R] [AddZeroClass A] (x : Unitizatio
 /-- To show a property hold on all `Unitization R A` it suffices to show it holds
 on terms of the form `inl r + a`.
 
-This can be used as `induction x using Unitization.ind`. -/
+This can be used as `induction x`. -/
+@[elab_as_elim, induction_eliminator, cases_eliminator]
 theorem ind {R A} [AddZeroClass R] [AddZeroClass A] {P : Unitization R A → Prop}
-    (h : ∀ (r : R) (a : A), P (inl r + (a : Unitization R A))) (x) : P x :=
-  inl_fst_add_inr_snd_eq x ▸ h x.1 x.2
+    (inl_add_inr : ∀ (r : R) (a : A), P (inl r + (a : Unitization R A))) (x) : P x :=
+  inl_fst_add_inr_snd_eq x ▸ inl_add_inr x.1 x.2
 #align unitization.ind Unitization.ind
 
 /-- This cannot be marked `@[ext]` as it ends up being used instead of `LinearMap.prod_ext` when
@@ -600,11 +601,11 @@ variable (S R A : Type*) [CommSemiring S] [CommSemiring R] [NonUnitalSemiring A]
 instance instAlgebra : Algebra S (Unitization R A) :=
   { (Unitization.inlRingHom R A).comp (algebraMap S R) with
     commutes' := fun s x => by
-      induction' x using Unitization.ind with r a
+      induction' x with r a
       show inl (algebraMap S R s) * _ = _ * inl (algebraMap S R s)
       rw [mul_add, add_mul, inl_mul_inl, inl_mul_inl, inl_mul_inr, inr_mul_inl, mul_comm]
     smul_def' := fun s x => by
-      induction' x using Unitization.ind with r a
+      induction' x with r a
       show _ = inl (algebraMap S R s) * _
       rw [mul_add, smul_add,Algebra.algebraMap_eq_smul_one, inl_mul_inl, inl_mul_inr, smul_one_mul,
         inl_smul, inr_smul, smul_one_smul] }
@@ -677,7 +678,7 @@ theorem algHom_ext {F : Type*}
     (h' : ∀ r, φ (algebraMap R (Unitization R A) r) = ψ (algebraMap R (Unitization R A) r)) :
     φ = ψ := by
   refine DFunLike.ext φ ψ (fun x ↦ ?_)
-  induction x using Unitization.ind
+  induction x
   simp only [map_add, ← algebraMap_eq_inl, h, h']
 #align unitization.alg_hom_ext Unitization.algHom_ext
 
@@ -709,8 +710,8 @@ def _root_.NonUnitalAlgHom.toAlgHom (φ :A →ₙₐ[R] C) : Unitization R A →
   toFun := fun x => algebraMap R C x.fst + φ x.snd
   map_one' := by simp only [fst_one, map_one, snd_one, φ.map_zero, add_zero]
   map_mul' := fun x y => by
-    induction' x using Unitization.ind with x_r x_a
-    induction' y using Unitization.ind with y_r y_a
+    induction' x with x_r x_a
+    induction' y with y_r y_a
     simp only [fst_mul, fst_add, fst_inl, fst_inr, snd_mul, snd_add, snd_inl, snd_inr, add_zero,
       map_mul, zero_add, map_add, map_smul φ]
     rw [add_mul, mul_add, mul_add]
@@ -718,8 +719,8 @@ def _root_.NonUnitalAlgHom.toAlgHom (φ :A →ₙₐ[R] C) : Unitization R A →
     simp only [Algebra.algebraMap_eq_smul_one, smul_one_mul, add_assoc]
   map_zero' := by simp only [fst_zero, map_zero, snd_zero, φ.map_zero, add_zero]
   map_add' := fun x y => by
-    induction' x using Unitization.ind with x_r x_a
-    induction' y using Unitization.ind with y_r y_a
+    induction' x with x_r x_a
+    induction' y with y_r y_a
     simp only [fst_add, fst_inl, fst_inr, add_zero, map_add, snd_add, snd_inl, snd_inr,
       zero_add, φ.map_add]
     rw [add_add_add_comm]
@@ -771,7 +772,7 @@ def starLift : (A →⋆ₙₐ[R] C) ≃ (Unitization R A →⋆ₐ[R] C) :=
 { toFun := fun φ ↦
   { toAlgHom := Unitization.lift φ.toNonUnitalAlgHom
     map_star' := fun x => by
-      induction x using Unitization.ind
+      induction x
       simp [map_star] }
   invFun := fun φ ↦ φ.toNonUnitalStarAlgHom.comp (inrNonUnitalStarAlgHom R A),
   left_inv := fun φ => by ext; simp,

--- a/Mathlib/Algebra/TrivSqZeroExt.lean
+++ b/Mathlib/Algebra/TrivSqZeroExt.lean
@@ -390,12 +390,11 @@ theorem inl_fst_add_inr_snd_eq [AddZeroClass R] [AddZeroClass M] (x : tsze R M) 
 #align triv_sq_zero_ext.inl_fst_add_inr_snd_eq TrivSqZeroExt.inl_fst_add_inr_snd_eq
 
 /-- To show a property hold on all `TrivSqZeroExt R M` it suffices to show it holds
-on terms of the form `inl r + inr m`.
-
-This can be used as `induction x using TrivSqZeroExt.ind`. -/
+on terms of the form `inl r + inr m`. -/
+@[elab_as_elim, induction_eliminator, cases_eliminator]
 theorem ind {R M} [AddZeroClass R] [AddZeroClass M] {P : TrivSqZeroExt R M → Prop}
-    (h : ∀ r m, P (inl r + inr m)) (x) : P x :=
-  inl_fst_add_inr_snd_eq x ▸ h x.1 x.2
+    (inl_add_inr : ∀ r m, P (inl r + inr m)) (x) : P x :=
+  inl_fst_add_inr_snd_eq x ▸ inl_add_inr x.1 x.2
 #align triv_sq_zero_ext.ind TrivSqZeroExt.ind
 
 /-- This cannot be marked `@[ext]` as it ends up being used instead of `LinearMap.prod_ext` when

--- a/Mathlib/Analysis/NormedSpace/Unitization.lean
+++ b/Mathlib/Analysis/NormedSpace/Unitization.lean
@@ -91,7 +91,7 @@ theorem splitMul_injective_of_clm_mul_injective
     Function.Injective (splitMul 𝕜 A) := by
   rw [injective_iff_map_eq_zero]
   intro x hx
-  induction x using Unitization.ind
+  induction x
   rw [map_add] at hx
   simp only [splitMul_apply, fst_inl, snd_inl, map_zero, add_zero, fst_inr, snd_inr,
     zero_add, Prod.mk_add_mk, Prod.mk_eq_zero] at hx

--- a/Mathlib/Topology/Instances/TrivSqZeroExt.lean
+++ b/Mathlib/Topology/Instances/TrivSqZeroExt.lean
@@ -44,7 +44,7 @@ instance [T2Space R] [T2Space M] : T2Space (tsze R M) :=
   Prod.t2Space
 
 theorem nhds_def (x : tsze R M) : 𝓝 x = (𝓝 x.fst).prod (𝓝 x.snd) := by
-  cases x
+  cases x using Prod.rec
   exact nhds_prod_eq
 #align triv_sq_zero_ext.nhds_def TrivSqZeroExt.nhds_def
 


### PR DESCRIPTION
This adds `elab_as_elim`, `induction_eliminator`, and `cases_eliminator` attributes, which eliminates the need to use the `using` term of `induction`.

Also choose a better argument name, since this is used as the case name.

Split from #12605 

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
