### PR TITLE
feat: functors which preserves locally injective/surjective morphisms

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -1613,6 +1613,7 @@ import Mathlib.CategoryTheory.Sites.OneHypercover
 import Mathlib.CategoryTheory.Sites.Over
 import Mathlib.CategoryTheory.Sites.Plus
 import Mathlib.CategoryTheory.Sites.Preserves
+import Mathlib.CategoryTheory.Sites.PreservesLocallyBijective
 import Mathlib.CategoryTheory.Sites.PreservesSheafification
 import Mathlib.CategoryTheory.Sites.Pretopology
 import Mathlib.CategoryTheory.Sites.Pullback

--- a/Mathlib/CategoryTheory/Sites/Grothendieck.lean
+++ b/Mathlib/CategoryTheory/Sites/Grothendieck.lean
@@ -170,7 +170,7 @@ theorem intersection_covering_iff : R ⊓ S ∈ J X ↔ R ∈ J X ∧ S ∈ J X 
 #align category_theory.grothendieck_topology.intersection_covering_iff CategoryTheory.GrothendieckTopology.intersection_covering_iff
 
 lemma finite_intersection_covering
-     (S : Set (Sieve X)) (h : S.Finite) (hS : ∀ T, T ∈ S → T ∈ J X) : sInf S ∈ J X := by
+    (S : Set (Sieve X)) (h : S.Finite) (hS : ∀ T, T ∈ S → T ∈ J X) : sInf S ∈ J X := by
   sorry
 
 theorem bind_covering {S : Sieve X} {R : ∀ ⦃Y : C⦄ ⦃f : Y ⟶ X⦄, S f → Sieve Y} (hS : S ∈ J X)

--- a/Mathlib/CategoryTheory/Sites/Grothendieck.lean
+++ b/Mathlib/CategoryTheory/Sites/Grothendieck.lean
@@ -171,7 +171,12 @@ theorem intersection_covering_iff : R ⊓ S ∈ J X ↔ R ∈ J X ∧ S ∈ J X 
 
 lemma finite_intersection_covering
     (S : Set (Sieve X)) (h : S.Finite) (hS : ∀ T, T ∈ S → T ∈ J X) : sInf S ∈ J X := by
-  sorry
+  refine Set.Finite.induction_on' (h := h) (by simp) ?_
+  intro R T hR _ _ hT
+  refine J.superset_covering  ?_ (J.intersection_covering hT (hS R hR))
+  simp only [sInf_insert, le_inf_iff, inf_le_right, le_sInf_iff, true_and]
+  intro U hU
+  exact inf_le_left.trans (sInf_le hU)
 
 theorem bind_covering {S : Sieve X} {R : ∀ ⦃Y : C⦄ ⦃f : Y ⟶ X⦄, S f → Sieve Y} (hS : S ∈ J X)
     (hR : ∀ ⦃Y⦄ ⦃f : Y ⟶ X⦄ (H : S f), R H ∈ J Y) : Sieve.bind S R ∈ J X :=

--- a/Mathlib/CategoryTheory/Sites/Grothendieck.lean
+++ b/Mathlib/CategoryTheory/Sites/Grothendieck.lean
@@ -9,6 +9,7 @@ import Mathlib.CategoryTheory.Limits.Shapes.Multiequalizer
 import Mathlib.CategoryTheory.Category.Preorder
 import Mathlib.Order.Copy
 import Mathlib.Data.Set.Subsingleton
+import Mathlib.Data.Set.Finite
 
 #align_import category_theory.sites.grothendieck from "leanprover-community/mathlib"@"14b69e9f3c16630440a2cbd46f1ddad0d561dee7"
 
@@ -167,6 +168,10 @@ theorem intersection_covering_iff : R ⊓ S ∈ J X ↔ R ∈ J X ∧ S ∈ J X 
   ⟨fun h => ⟨J.superset_covering inf_le_left h, J.superset_covering inf_le_right h⟩, fun t =>
     intersection_covering _ t.1 t.2⟩
 #align category_theory.grothendieck_topology.intersection_covering_iff CategoryTheory.GrothendieckTopology.intersection_covering_iff
+
+lemma finite_intersection_covering
+     (S : Set (Sieve X)) (h : S.Finite) (hS : ∀ T, T ∈ S → T ∈ J X) : sInf S ∈ J X := by
+  sorry
 
 theorem bind_covering {S : Sieve X} {R : ∀ ⦃Y : C⦄ ⦃f : Y ⟶ X⦄, S f → Sieve Y} (hS : S ∈ J X)
     (hR : ∀ ⦃Y⦄ ⦃f : Y ⟶ X⦄ (H : S f), R H ∈ J Y) : Sieve.bind S R ∈ J X :=

--- a/Mathlib/CategoryTheory/Sites/PreservesLocallyBijective.lean
+++ b/Mathlib/CategoryTheory/Sites/PreservesLocallyBijective.lean
@@ -1,0 +1,130 @@
+/-
+Copyright (c) 2024 Joël Riou. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Joël Riou
+-/
+import Mathlib.CategoryTheory.Sites.LocallyBijective
+
+/-!
+# Functors which preserves locally bijective morphisms
+
+In this file, we define two structures `Functor.PreservesLocallyInjective`,
+`Functor.PreservesLocallySurjective` for a functor `F : A ⥤ B` between concrete
+categories. These structures contains technical conditions which imply that the
+post-composition with `F` on categories of presheaves preserve locally
+injective/surjective morphisms for any Grothendieck topology. In particular, we
+obtain that functors preserving locally injective and locally surjective
+morphisms preserve sheafification.
+
+## TODO
+* show that the free module functor `Type u ⥤ ModuleCat.{u} R` preserves
+locally injective and locally surjective maps, and thus preserves sheafification
+
+-/
+
+universe w₁ w₂ v₁ v₂ v u₁ u₂ u
+
+namespace CategoryTheory
+
+variable {A : Type u₁} {B : Type u₂} [Category.{v₁} A] [Category.{v₂} B]
+  [ConcreteCategory.{w₁} A] [ConcreteCategory.{w₂} B]
+
+attribute [local instance] ConcreteCategory.hasCoeToSort ConcreteCategory.instFunLike
+
+namespace Functor
+
+variable (F : A ⥤ B)
+
+/-- Technical condition on a functor `F : A ⥤ B` between concrete categories which
+implies that the postcomposition with `F` preserves locally surjective morphisms
+for any Grothendieck topology. -/
+structure PreservesLocallySurjective where
+  /-- given `x : F.obj X`, this is a finset of `X` such that for any `f : X ⟶ Y`
+  and `g : Z ⟶ Y` such that the image of this finset by `f` is contained in the
+  image of `g`, then `F.map f x` belongs to the image of `F.map g`. -/
+  G {X : A} (x : F.obj X) : Finset X
+  mem {X Y Z : A} (x : F.obj X) (f : X ⟶ Y) (g : Z ⟶ Y)
+      (hg : ∀ (a : G x), f a ∈ Set.range g) :
+      F.map f x ∈ Set.range (F.map g)
+
+namespace PreservesLocallySurjective
+
+variable {F}
+variable (hF : F.PreservesLocallySurjective)
+  {C : Type u} [Category.{v} C] (J : GrothendieckTopology C) {P Q : Cᵒᵖ ⥤ A}
+  (f : P ⟶ Q) [Presheaf.IsLocallySurjective J f]
+
+lemma isLocallySurjective : Presheaf.IsLocallySurjective J (whiskerRight f F) where
+  imageSieve_mem {U} x := by
+    classical
+    let S := (hF.G x).image (fun a ↦ Presheaf.imageSieve f a)
+    have hS := J.finite_intersection_covering _ (Finset.finite_toSet S) (fun T hT => by
+      simp only [Finset.coe_image, Set.mem_image, Finset.mem_coe, S] at hT
+      obtain ⟨a, _, rfl⟩ := hT
+      apply Presheaf.imageSieve_mem)
+    refine J.superset_covering ?_ hS
+    rintro Y φ hφ
+    apply hF.mem x (Q.map φ.op) (f.app _)
+    rintro ⟨a, ha⟩
+    exact hφ (Presheaf.imageSieve f a) (by
+      simp only [Finset.coe_image, Set.mem_image, Finset.mem_coe, S]
+      exact ⟨_, ha, rfl⟩)
+
+end PreservesLocallySurjective
+
+/-- Technical condition on a functor `F : A ⥤ B` between concrete categories which
+implies that the postcomposition with `F` preserves locally injective morphisms
+for any Grothendieck topology. -/
+structure PreservesLocallyInjective where
+  /-- Given elements `x₁` and `x₂` in `F.obj x` and `f : X ⟶ Y` such that
+  `F.map f x₁ = F.map f x₂`, this a finset of tuples `(r₁, r₂)` of elements in `X` such
+  that `f r₁ = f r₂` (see `eq`) and such that if `g : X ⟶ Z` is such that for
+  these tuples we have `g r₁ = g r₂`, then `F.map g x₁ = F.map g x₂`. In other
+  words, the identity `F.map f x₁ = F.map f x₂` can be "explained" by finitely
+  many identities `f r₁ = f r₂`. -/
+  R {X Y : A} (f : X ⟶ Y) {x₁ x₂ : F.obj X} (h : F.map f x₁ = F.map f x₂) : Finset (X × X)
+  eq {X Y : A} {f : X ⟶ Y} {x₁ x₂ : F.obj X} {h : F.map f x₁ = F.map f x₂} (r : R f h) :
+    f r.1.1 = f r.1.2
+  imp {X Y Z : A} (f : X ⟶ Y) {x₁ x₂ : F.obj X} (h : F.map f x₁ = F.map f x₂) (g : X ⟶ Z)
+      (hg : ∀ (r : R f h), g r.1.1 = g r.1.2) : F.map g x₁ = F.map g x₂
+
+namespace PreservesLocallyInjective
+
+variable {F}
+variable (hF : F.PreservesLocallyInjective)
+  {C : Type u} [Category.{v} C] (J : GrothendieckTopology C) {P Q : Cᵒᵖ ⥤ A}
+  (f : P ⟶ Q) [Presheaf.IsLocallyInjective J f]
+
+lemma isLocallyInjective : Presheaf.IsLocallyInjective J (whiskerRight f F) where
+  equalizerSieve_mem {U} x y h := by
+    classical
+    let S := (hF.R _ h).image (fun r => Presheaf.equalizerSieve r.1 r.2)
+    have hS := J.finite_intersection_covering _ (Finset.finite_toSet S) (fun T hT => by
+      simp only [Finset.coe_image, Set.mem_image, Finset.mem_coe, Prod.exists, S] at hT
+      obtain ⟨x₁, x₂, hx, rfl⟩ := hT
+      exact Presheaf.equalizerSieve_mem J f x₁ x₂ (hF.eq ⟨_, hx⟩))
+    refine J.superset_covering ?_ hS
+    rintro Y φ hφ
+    apply hF.imp _ h
+    rintro ⟨⟨x₁, x₂⟩, hx⟩
+    dsimp
+    exact hφ (Presheaf.equalizerSieve x₁ x₂) (by
+      simp only [Finset.coe_image, Set.mem_image, Finset.mem_coe, Prod.exists, S]
+      exact ⟨_, _, hx, rfl⟩)
+
+end PreservesLocallyInjective
+
+variable (hF₁ : F.PreservesLocallyInjective) (hF₂ : F.PreservesLocallySurjective)
+  {C : Type u} [Category.{v} C] (J : GrothendieckTopology C)
+  [J.WEqualsLocallyBijective A] [J.WEqualsLocallyBijective B]
+
+lemma preservesSheafification_of_preservesLocallyInjectiveSurjective :
+    J.PreservesSheafification F where
+  le _ _ f := by
+    simp only [MorphismProperty.inverseImage_iff, J.W_iff_isLocallyBijective]
+    rintro ⟨_, _⟩
+    exact ⟨hF₁.isLocallyInjective J f, hF₂.isLocallySurjective J f⟩
+
+end Functor
+
+end CategoryTheory

--- a/Mathlib/CategoryTheory/Sites/PreservesSheafification.lean
+++ b/Mathlib/CategoryTheory/Sites/PreservesSheafification.lean
@@ -31,8 +31,6 @@ suitable limits and colimits.
 
 ## TODO
 * construct an isomorphism `sheafCompose' J F ≅ sheafCompose J F`
-* show that the free module functor `Type u ⥤ ModuleCat.{u} R`
-preserves sheafification
 
 -/
 


### PR DESCRIPTION
---

(In order to be sure the definitions in this PR are good, before this PR is reviewed, we should wait for the subsequent PR where I shall show that the free module functors satisfy these properties defined here.)

Hmm, I may have a more formal argument in order to show that certain left adjoint functors preserve sheafification, and this make this PR unnecessary. See #13499 

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
