### PR TITLE
[Merged by Bors] - feat(Topology/Category): category of finite topological spaces

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -4016,6 +4016,7 @@ import Mathlib.Topology.Category.CompHaus.EffectiveEpi
 import Mathlib.Topology.Category.CompHaus.Limits
 import Mathlib.Topology.Category.CompHaus.Projective
 import Mathlib.Topology.Category.Compactum
+import Mathlib.Topology.Category.FinTopCat
 import Mathlib.Topology.Category.LightProfinite.Basic
 import Mathlib.Topology.Category.LightProfinite.EffectiveEpi
 import Mathlib.Topology.Category.LightProfinite.IsLight

--- a/Mathlib/Topology/Category/FinTopCat.lean
+++ b/Mathlib/Topology/Category/FinTopCat.lean
@@ -1,0 +1,77 @@
+/-
+Copyright (c) 2024 Christian Merten. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Christian Merten
+-/
+import Mathlib.CategoryTheory.FintypeCat
+import Mathlib.Topology.Category.TopCat.Basic
+
+/-!
+# Category of finite topological spaces
+
+Definition of the category of finite topological spaces with the canonical
+forgetful functors.
+
+-/
+
+
+universe u
+
+open CategoryTheory
+
+/-- A bundled finite topological space. -/
+structure FinTopCat where
+  /-- carrier of a finite topological space. -/
+  α : Type u
+  [fintype : Fintype α]
+  [topologicalSpace : TopologicalSpace α]
+
+namespace FinTopCat
+
+instance : Inhabited FinTopCat :=
+  ⟨⟨PUnit⟩⟩
+
+instance : CoeSort FinTopCat (Type u) :=
+  ⟨FinTopCat.α⟩
+
+attribute [instance] fintype topologicalSpace
+
+instance : Category FinTopCat.{u} where
+  Hom X Y := { f : X → Y // Continuous f }
+  id X := ⟨id, by continuity⟩
+  comp f g := ⟨g.val.comp f.val, g.property.comp f.property⟩
+
+instance : ConcreteCategory FinTopCat.{u} where
+  forget := { obj := fun X ↦ X.α, map := fun f ↦ f.val }
+  forget_faithful := ⟨fun {_ _ a b} h ↦ Subtype.ext h⟩
+
+instance (X : FinTopCat) : TopologicalSpace ((forget FinTopCat).obj X) :=
+  X.topologicalSpace
+
+instance (X : FinTopCat) : Fintype ((forget FinTopCat).obj X) :=
+  X.fintype
+
+/-- Construct a bundled `FinTopCat` from the underlying type and the appropriate typeclasses. -/
+def of (X : Type u) [Fintype X] [TopologicalSpace X] : FinTopCat :=
+  ⟨X⟩
+
+@[simp]
+theorem coe_of (X : Type u) [Fintype X] [TopologicalSpace X] :
+    (of X : Type u) = X :=
+  rfl
+
+/-- The forgetful functor to `FintypeCat`. -/
+instance : HasForget₂ FinTopCat FintypeCat :=
+  HasForget₂.mk' (fun X ↦ FintypeCat.of X) (fun _ ↦ rfl) (fun f ↦ f.val) HEq.rfl
+
+instance (X : FinTopCat) : TopologicalSpace ((forget₂ FinTopCat FintypeCat).obj X) :=
+  X.topologicalSpace
+
+/-- The forgetful functor to `TopCat`. -/
+instance : HasForget₂ FinTopCat TopCat :=
+  HasForget₂.mk' (fun R ↦ TopCat.of R) (fun _ ↦ rfl) (fun f ↦ ⟨f.1, f.2⟩) HEq.rfl
+
+instance (X : FinTopCat) : Fintype ((forget₂ FinTopCat TopCat).obj X) :=
+  X.fintype
+
+end FinTopCat

--- a/Mathlib/Topology/Category/FinTopCat.lean
+++ b/Mathlib/Topology/Category/FinTopCat.lean
@@ -22,38 +22,35 @@ open CategoryTheory
 /-- A bundled finite topological space. -/
 structure FinTopCat where
   /-- carrier of a finite topological space. -/
-  α : Type u
-  [fintype : Fintype α]
-  [topologicalSpace : TopologicalSpace α]
+  toTop : TopCat.{u}
+  [fintype : Fintype toTop]
 
 namespace FinTopCat
 
 instance : Inhabited FinTopCat :=
-  ⟨⟨PUnit⟩⟩
+  ⟨{ toTop := { α := PEmpty } }⟩
 
 instance : CoeSort FinTopCat (Type u) :=
-  ⟨FinTopCat.α⟩
+  ⟨fun X => X.toTop⟩
 
-attribute [instance] fintype topologicalSpace
+attribute [instance] fintype
 
-instance : Category FinTopCat.{u} where
-  Hom X Y := { f : X → Y // Continuous f }
-  id X := ⟨id, by continuity⟩
-  comp f g := ⟨g.val.comp f.val, g.property.comp f.property⟩
+instance : Category FinTopCat :=
+  InducedCategory.category toTop
 
-instance : ConcreteCategory FinTopCat.{u} where
-  forget := { obj := fun X ↦ X.α, map := fun f ↦ f.val }
-  forget_faithful := ⟨fun {_ _ a b} h ↦ Subtype.ext h⟩
+instance : ConcreteCategory FinTopCat :=
+  InducedCategory.concreteCategory _
 
 instance (X : FinTopCat) : TopologicalSpace ((forget FinTopCat).obj X) :=
-  X.topologicalSpace
+  inferInstanceAs <| TopologicalSpace X
 
 instance (X : FinTopCat) : Fintype ((forget FinTopCat).obj X) :=
   X.fintype
 
 /-- Construct a bundled `FinTopCat` from the underlying type and the appropriate typeclasses. -/
-def of (X : Type u) [Fintype X] [TopologicalSpace X] : FinTopCat :=
-  ⟨X⟩
+def of (X : Type u) [Fintype X] [TopologicalSpace X] : FinTopCat where
+  toTop := TopCat.of X
+  fintype := ‹_›
 
 @[simp]
 theorem coe_of (X : Type u) [Fintype X] [TopologicalSpace X] :
@@ -62,14 +59,14 @@ theorem coe_of (X : Type u) [Fintype X] [TopologicalSpace X] :
 
 /-- The forgetful functor to `FintypeCat`. -/
 instance : HasForget₂ FinTopCat FintypeCat :=
-  HasForget₂.mk' (fun X ↦ FintypeCat.of X) (fun _ ↦ rfl) (fun f ↦ f.val) HEq.rfl
+  HasForget₂.mk' (fun X ↦ FintypeCat.of X) (fun _ ↦ rfl) (fun f ↦ f.toFun) HEq.rfl
 
 instance (X : FinTopCat) : TopologicalSpace ((forget₂ FinTopCat FintypeCat).obj X) :=
-  X.topologicalSpace
+  inferInstanceAs <| TopologicalSpace X
 
 /-- The forgetful functor to `TopCat`. -/
 instance : HasForget₂ FinTopCat TopCat :=
-  HasForget₂.mk' (fun R ↦ TopCat.of R) (fun _ ↦ rfl) (fun f ↦ ⟨f.1, f.2⟩) HEq.rfl
+  InducedCategory.hasForget₂ _
 
 instance (X : FinTopCat) : Fintype ((forget₂ FinTopCat TopCat).obj X) :=
   X.fintype


### PR DESCRIPTION
The category of finite topological spaces.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->
This is needed to obtain the category of finite continuous `G`-types for a topological group `G`. This would then be
`ContAction FinTopCat G`.

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
