### PR TITLE
chore: run `lake update` when updating nightly-testing

### DIFF
--- a/.github/workflows/nightly_merge_master.yml
+++ b/.github/workflows/nightly_merge_master.yml
@@ -27,6 +27,9 @@ jobs:
           # If the merge goes badly, we proceed anyway via '|| true'.
           # CI will report failures on the 'nightly-testing' branch direct to Zulip.
           git merge master --strategy-option ours --no-commit --allow-unrelated-histories || true
+          # We aggressively run `lake update`, to avoid having to do this by hand.
+          # When Batteries changes break Mathlib, this will likely show up on nightly-testing first.
+          lake update
           git add .
           # If there's nothing to do (because there are no new commits from master),
           # that's okay, hence the '|| true'.


### PR DESCRIPTION
This will reduce the need to run `lake update` by hand in the `nightly-testing` branch. 

On the other hand, it will result in breaking changes from Batteries which are not immediately fixed on Mathlib `master` showing up more often in the `nightly-testing` automation.

As a partial solution to that, I think I am going to increase automation updating Mathlib's dependences.