### PR TITLE
[Merged by Bors] - chore: regularly update dependencies

### DIFF
--- a/.github/workflows/update_dependencies.yml
+++ b/.github/workflows/update_dependencies.yml
@@ -24,8 +24,8 @@ jobs:
         run: |
           prs=$(gh pr list --search "author:leanprover-community-mathlib4-bot state:open" --json title,headRefName)
           for pr in $(echo "$prs" | jq -c '.[]'); do
-            pr_title=$(echo $pr | jq -r '.title')
-            pr_branch=$(echo $pr | jq -r '.headRefName')
+            pr_title=$(echo "$pr" | jq -r '.title')
+            pr_branch=$(echo "$pr" | jq -r '.headRefName')
             if [[ "$pr_title" == *"update Mathlib dependencies"* ]] || [[ "$pr_branch" == update-dependencies-* ]]; then
               echo "Existing PR found with title or branch name indicating a dependency update. Stopping."
               echo "existing_pr=true" >> $GITHUB_ENV
@@ -64,7 +64,7 @@ jobs:
           echo "branch_name=$branch_name" >> $GITHUB_ENV
           git checkout -b "$branch_name"
           git add .
-          git commit -m "chore: update Mathlib dependencies $(date -u +"%Y-%m-%d")"
+          git commit -m "chore: update Mathlib dependencies $(date -u +\"%Y-%m-%d\")"
           git push origin "$branch_name"
 
       - name: Create Pull Request
@@ -72,7 +72,7 @@ jobs:
         uses: peter-evans/create-pull-request@v5
         with:
           token: ${{ secrets.NIGHTLY_TESTING }}
-          commit-message: "chore: update Mathlib dependencies $(date -u +"%Y-%m-%d")"
+          commit-message: "chore: update Mathlib dependencies ${{ steps.create_new_branch.outputs.branch_name }}"
           branch: ${{ env.branch_name }}
-          title: "chore: update Mathlib dependencies $(date -u +"%Y-%m-%d")"
+          title: "chore: update Mathlib dependencies ${{ steps.create_new_branch.outputs.branch_name }}"
           labels: "auto-merge-after-CI"

--- a/.github/workflows/update_dependencies.yml
+++ b/.github/workflows/update_dependencies.yml
@@ -1,0 +1,78 @@
+name: Update Mathlib Dependencies
+
+on:
+  schedule:
+    - cron: '0 * * * *'  # This will run every hour
+
+jobs:
+  update-dependencies:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.NIGHTLY_TESTING }}
+
+      - name: Configure Git User
+        run: |
+          git config user.name "leanprover-community-mathlib4-bot"
+          git config user.email "leanprover-community-mathlib4-bot@users.noreply.github.com"
+
+      - name: Check for existing PRs
+        id: check_pr
+        run: |
+          prs=$(gh pr list --search "author:leanprover-community-mathlib4-bot state:open" --json title,headRefName)
+          for pr in $(echo "$prs" | jq -c '.[]'); do
+            pr_title=$(echo $pr | jq -r '.title')
+            pr_branch=$(echo $pr | jq -r '.headRefName')
+            if [[ "$pr_title" == *"update Mathlib dependencies"* ]] || [[ "$pr_branch" == update-dependencies-* ]]; then
+              echo "Existing PR found with title or branch name indicating a dependency update. Stopping."
+              echo "existing_pr=true" >> $GITHUB_ENV
+              exit 0
+            fi
+          done
+          echo "existing_pr=false" >> $GITHUB_ENV
+
+      - name: Stop if PR exists
+        if: env.existing_pr == 'true'
+        run: echo "Stopping workflow due to existing PR."
+
+      - name: Update dependencies
+        if: env.existing_pr == 'false'
+        run: lake update
+
+      - name: Check for changes
+        id: check_changes
+        if: env.existing_pr == 'false'
+        run: |
+          if git diff-index --quiet HEAD --; then
+            echo "no_changes=true" >> $GITHUB_ENV
+          else
+            echo "no_changes=false" >> $GITHUB_ENV
+
+      - name: Stop if no changes
+        if: env.no_changes == 'true'
+        run: echo "No changes detected. Stopping."
+
+      - name: Create new branch
+        if: env.no_changes == 'false'
+        id: create_new_branch
+        run: |
+          timestamp=$(date -u +"%Y-%m-%d-%H-%M")
+          branch_name="update-dependencies-$timestamp"
+          echo "branch_name=$branch_name" >> $GITHUB_ENV
+          git checkout -b "$branch_name"
+          git add .
+          git commit -m "chore: update Mathlib dependencies $(date -u +"%Y-%m-%d")"
+          git push origin "$branch_name"
+
+      - name: Create Pull Request
+        if: env.no_changes == 'false'
+        uses: peter-evans/create-pull-request@v5
+        with:
+          token: ${{ secrets.NIGHTLY_TESTING }}
+          commit-message: "chore: update Mathlib dependencies $(date -u +"%Y-%m-%d")"
+          branch: ${{ env.branch_name }}
+          title: "chore: update Mathlib dependencies $(date -u +"%Y-%m-%d")"
+          labels: "auto-merge-after-CI"

--- a/.github/workflows/update_dependencies.yml
+++ b/.github/workflows/update_dependencies.yml
@@ -28,11 +28,11 @@ jobs:
             pr_branch=$(echo "$pr" | jq -r '.headRefName')
             if [[ "$pr_title" == *"update Mathlib dependencies"* ]] || [[ "$pr_branch" == update-dependencies-* ]]; then
               echo "Existing PR found with title or branch name indicating a dependency update. Stopping."
-              echo "existing_pr=true" >> $GITHUB_ENV
+              echo "existing_pr=true" >> "$GITHUB_ENV"
               exit 0
             fi
           done
-          echo "existing_pr=false" >> $GITHUB_ENV
+          echo "existing_pr=false" >> "$GITHUB_ENV"
 
       - name: Stop if PR exists
         if: env.existing_pr == 'true'
@@ -47,9 +47,9 @@ jobs:
         if: env.existing_pr == 'false'
         run: |
           if git diff-index --quiet HEAD --; then
-            echo "no_changes=true" >> $GITHUB_ENV
+            echo "no_changes=true" >> "$GITHUB_ENV"
           else
-            echo "no_changes=false" >> $GITHUB_ENV
+            echo "no_changes=false" >> "$GITHUB_ENV"
           fi
 
       - name: Stop if no changes
@@ -62,7 +62,7 @@ jobs:
         run: |
           timestamp=$(date -u +"%Y-%m-%d-%H-%M")
           branch_name="update-dependencies-$timestamp"
-          echo "branch_name=$branch_name" >> $GITHUB_ENV
+          echo "branch_name=$branch_name" >> "$GITHUB_ENV"
           git checkout -b "$branch_name"
           git add .
           git commit -m "chore: update Mathlib dependencies $(date -u +\"%Y-%m-%d\")"

--- a/.github/workflows/update_dependencies.yml
+++ b/.github/workflows/update_dependencies.yml
@@ -1,5 +1,8 @@
 name: Update Mathlib Dependencies
 
+# This action currently uses the NIGHTLY_TESTING secret, but could be moved to a separate secret.
+# Despite this, this action is acting on the `master` branch, not the `nightly-testing` branch.
+
 on:
   schedule:
     - cron: '0 * * * *'  # This will run every hour

--- a/.github/workflows/update_dependencies.yml
+++ b/.github/workflows/update_dependencies.yml
@@ -50,6 +50,7 @@ jobs:
             echo "no_changes=true" >> $GITHUB_ENV
           else
             echo "no_changes=false" >> $GITHUB_ENV
+          fi
 
       - name: Stop if no changes
         if: env.no_changes == 'true'
@@ -72,7 +73,7 @@ jobs:
         uses: peter-evans/create-pull-request@v5
         with:
           token: ${{ secrets.NIGHTLY_TESTING }}
-          commit-message: "chore: update Mathlib dependencies ${{ steps.create_new_branch.outputs.branch_name }}"
+          commit-message: "chore: update Mathlib dependencies $(date -u +\"%Y-%m-%d\")"
           branch: ${{ env.branch_name }}
-          title: "chore: update Mathlib dependencies ${{ steps.create_new_branch.outputs.branch_name }}"
+          title: "chore: update Mathlib dependencies $(date -u +\"%Y-%m-%d\")"
           labels: "auto-merge-after-CI"

--- a/.github/workflows/update_dependencies_zulip.yml
+++ b/.github/workflows/update_dependencies_zulip.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Update PR labels
         if: env.pr_number
         run: |
-          gh pr edit ${{ env.pr_number }} --remove-label "auto-merge-after-CI" --add-label "awaiting-CI,awaiting-review"
+          gh pr edit "${{ env.pr_number }}" --remove-label "auto-merge-after-CI" --add-label "awaiting-CI,awaiting-review"
 
       - name: Get CI URL
         id: ci_url

--- a/.github/workflows/update_dependencies_zulip.yml
+++ b/.github/workflows/update_dependencies_zulip.yml
@@ -32,9 +32,9 @@ jobs:
       - name: Get CI URL
         id: ci_url
         run: |
-          url=https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
-          curl -s "${url}" |
-            awk -v url="${url}" -F'/' '/^ *href/ {gsub(/"/, "", $NF); printf("summary<<EOF\n%s/job/%s\nEOF", url, $NF)}' >> "$GITHUB_OUTPUT"
+          url="https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          curl -s "$url" |
+            awk -v url="$url" -F'/' '/^ *href/ {gsub(/"/, "", $NF); printf("summary<<EOF\n%s/job/%s\nEOF", url, $NF)}' >> "$GITHUB_OUTPUT"
 
       - name: Send Zulip message
         uses: zulip/github-actions-zulip/send-message@v1
@@ -44,6 +44,6 @@ jobs:
           organization-url: 'https://leanprover.zulipchat.com'
           to: 'mathlib reviewers'
           type: 'stream'
-          topic: 'Mathlib lake update failure'
+          topic: 'Mathlib `lake update` failure'
           content: |
-            ❌ lake update [failed](${{ steps.ci_url.outputs.summary }}) on ${{ github.sha }}
+            ❌ `lake update` [failed](${{ steps.ci_url.outputs.summary }}) on ${{ github.sha }}

--- a/.github/workflows/update_dependencies_zulip.yml
+++ b/.github/workflows/update_dependencies_zulip.yml
@@ -22,7 +22,7 @@ jobs:
         id: get_pr
         run: |
           pr_number=$(gh pr list --state open --head "${{ github.repository }}:${{ github.event.workflow_run.head_branch }}" --json number -q '.[0].number')
-          echo "pr_number=$pr_number" >> $GITHUB_ENV
+          echo "pr_number=$pr_number" >> "$GITHUB_ENV"
 
       - name: Update PR labels
         if: env.pr_number

--- a/.github/workflows/update_dependencies_zulip.yml
+++ b/.github/workflows/update_dependencies_zulip.yml
@@ -1,0 +1,49 @@
+name: Monitor Dependency Update Failures
+
+on:
+  workflow_run:
+    workflows: ["Update Mathlib Dependencies"]
+    types:
+      - completed
+
+jobs:
+  monitor-failures:
+    runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'failure' && startsWith(github.event.workflow_run.head_branch, 'update-dependencies-') }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.NIGHTLY_TESTING }}
+
+      - name: Get PR number
+        id: get_pr
+        run: |
+          pr_number=$(gh pr list --state open --head "${{ github.repository }}:${{ github.event.workflow_run.head_branch }}" --json number -q '.[0].number')
+          echo "pr_number=$pr_number" >> $GITHUB_ENV
+
+      - name: Update PR labels
+        if: env.pr_number
+        run: |
+          gh pr edit ${{ env.pr_number }} --remove-label "auto-merge-after-CI" --add-label "awaiting-CI,awaiting-review"
+
+      - name: Get CI URL
+        id: ci_url
+        run: |
+          url=https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          curl -s "${url}" |
+            awk -v url="${url}" -F'/' '/^ *href/ {gsub(/"/, "", $NF); printf("summary<<EOF\n%s/job/%s\nEOF", url, $NF)}' >> "$GITHUB_OUTPUT"
+
+      - name: Send Zulip message
+        uses: zulip/github-actions-zulip/send-message@v1
+        with:
+          api-key: ${{ secrets.ZULIP_API_KEY }}
+          email: 'github-mathlib4-bot@leanprover.zulipchat.com'
+          organization-url: 'https://leanprover.zulipchat.com'
+          to: 'mathlib reviewers'
+          type: 'stream'
+          topic: 'Mathlib lake update failure'
+          content: |
+            ❌ lake update [failed](${{ steps.ci_url.outputs.summary }}) on ${{ github.sha }}

--- a/.github/workflows/update_dependencies_zulip.yml
+++ b/.github/workflows/update_dependencies_zulip.yml
@@ -1,5 +1,7 @@
 name: Monitor Dependency Update Failures
 
+# This action currently uses the NIGHTLY_TESTING secret, but could be moved to a separate secret.
+
 on:
   workflow_run:
     workflows: ["Update Mathlib Dependencies"]


### PR DESCRIPTION
If the update fails, it will leave the PR open, preventing the action from creating more such PRs.

Also adds a workflow action that reports on zulip if one of these PRs fails.