### PR TITLE
[Merged by Bors] - chore(Data/UInt): make instCommRing a def, and explain why

### DIFF
--- a/Mathlib/Data/UInt.lean
+++ b/Mathlib/Data/UInt.lean
@@ -100,9 +100,11 @@ run_cmd
       | ⟨_, _⟩ => rfl
 
     namespace Cast
+      @[nolint docBlame]
       scoped instance : NatCast $typeName where
         natCast n := mk n
 
+      @[nolint docBlame]
       scoped instance : IntCast $typeName where
         intCast z := mk z
 
@@ -114,6 +116,7 @@ run_cmd
 
     namespace CommRing
       open Cast in
+      @[nolint docBlame]
       scoped instance instCommRing : CommRing $typeName :=
         Function.Injective.commRing val val_injective
           rfl rfl (fun _ _ => rfl) (fun _ _ => rfl) (fun _ => rfl) (fun _ _ => rfl)

--- a/Mathlib/Data/UInt.lean
+++ b/Mathlib/Data/UInt.lean
@@ -19,7 +19,7 @@ tactic will not work on `UIntX` types without `open scoped UIntX.Ring`.
 This is because the presence of these casting operations contradicts assumptions made by the
 expression tree elaborator, namely that coercions do not form a cycle.
 
-This issue also arises for `CommRing (Fin n)`, but Mathlib has come to rely upon this. The UInt
+The UInt
 version also interferes more with software-verification use-cases, which is reason to be more
 cautious here.
 -/

--- a/Mathlib/Data/UInt.lean
+++ b/Mathlib/Data/UInt.lean
@@ -103,6 +103,15 @@ run_cmd
       @[simp] lemma mk_val_eq : ∀ (a : $typeName), mk a.val = a
       | ⟨_, _⟩ => rfl
 
+      instance instCommMonoid : CommMonoid $typeName :=
+        Function.Injective.commMonoid val val_injective
+          rfl (fun _ _ => rfl) (fun _ _ => rfl)
+
+      instance instNonUnitalCommRing : NonUnitalCommRing $typeName :=
+        Function.Injective.nonUnitalCommRing val val_injective
+          rfl (fun _ _ => rfl) (fun _ _ => rfl) (fun _ => rfl) (fun _ _ => rfl)
+          (fun _ _ => rfl) (fun _ _ => rfl)
+
       local instance instNatCast : NatCast $typeName where
         natCast n := mk n
 

--- a/Mathlib/Data/UInt.lean
+++ b/Mathlib/Data/UInt.lean
@@ -97,7 +97,14 @@ run_cmd
       @[simp] lemma mk_val_eq : ∀ (a : $typeName), mk a.val = a
       | ⟨_, _⟩ => rfl
 
-      instance : CommRing $typeName :=
+      /--
+      This is not an instance; it is not needed in Mathlib,
+      and moreover results in a `Nat → $typeName` coercion which breaks assumptions made in the
+      expression tree elaborator.
+
+      Use with caution, only in downstream projects.
+      -/
+      def instCommRing : CommRing $typeName :=
         Function.Injective.commRing val val_injective
           rfl rfl (fun _ _ => rfl) (fun _ _ => rfl) (fun _ => rfl) (fun _ _ => rfl)
           (fun _ _ => rfl) (fun _ _ => rfl) (fun _ _ => rfl) (fun _ => rfl) (fun _ => rfl)

--- a/Mathlib/Data/UInt.lean
+++ b/Mathlib/Data/UInt.lean
@@ -103,11 +103,9 @@ run_cmd
       @[simp] lemma mk_val_eq : ∀ (a : $typeName), mk a.val = a
       | ⟨_, _⟩ => rfl
 
-      @[nolint docBlame]
       local instance instNatCast : NatCast $typeName where
         natCast n := mk n
 
-      @[nolint docBlame]
       local instance instIntCast : IntCast $typeName where
         intCast z := mk z
 
@@ -115,7 +113,6 @@ run_cmd
 
       lemma intCast_def (z : ℤ) : (z : $typeName) = ⟨z⟩ := rfl
 
-      @[nolint docBlame]
       local instance instCommRing : CommRing $typeName :=
         Function.Injective.commRing val val_injective
           rfl rfl (fun _ _ => rfl) (fun _ _ => rfl) (fun _ => rfl) (fun _ _ => rfl)


### PR DESCRIPTION
These instances are now in the `UIntX.CommRing` scope.

This is because the presence of these casting operations contradicts assumptions made by the
expression tree elaborator, namely that coercions do not form a cycle.
This happens in `Fin` and `BitVector` too, but those are problems for another PR.

After this change, `ring`, `norm_num`, and `rw [mul_add_one]` no longer work out of the box on these types.
To avoid further fallout (`rw [mul_one]`, `abel`, ...), `CommMonoid` and `NonUnitalCommRing` instances are provided, which fall just short of enabling the unwanted cast operators.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
