### PR TITLE
[Merged by Bors] - feat(CategoryTheory): transposition of commutative squares across an adjunction

### DIFF
--- a/Mathlib/CategoryTheory/Adjunction/Basic.lean
+++ b/Mathlib/CategoryTheory/Adjunction/Basic.lean
@@ -176,11 +176,13 @@ theorem homEquiv_naturality_right_symm (f : X ⟶ G.obj Y) (g : Y ⟶ Y') :
   simp only [homEquiv_naturality_right,eq_self_iff_true,Equiv.apply_symm_apply]
 #align category_theory.adjunction.hom_equiv_naturality_right_symm CategoryTheory.Adjunction.homEquiv_naturality_right_symm
 
-theorem homEquiv_naturality_left_square (f : X' ⟶ X) (g : F.obj X ⟶ Y') (h : F.obj X' ⟶ Y) (k : Y ⟶ Y') (w : F.map f ≫ g = h ≫ k) : f ≫ (adj.homEquiv X Y') g = (adj.homEquiv X' Y) h ≫ G.map k := by
+theorem homEquiv_naturality_left_square (f : X' ⟶ X) (g : F.obj X ⟶ Y') (h : F.obj X' ⟶ Y) (k : Y ⟶ Y') (w : F.map f ≫ g = h ≫ k) :
+    f ≫ (adj.homEquiv X Y') g = (adj.homEquiv X' Y) h ≫ G.map k := by
   rw [← homEquiv_naturality_left, ← homEquiv_naturality_right]
   exact congrArg (adj.homEquiv X' Y') w
 
-theorem homEquiv_naturality_right_square (f : X' ⟶ X) (g : X ⟶ G.obj Y') (h : X' ⟶ G.obj Y) (k : Y ⟶ Y') (w : f ≫ g = h ≫ G.map k) : F.map f ≫ (adj.homEquiv X Y').symm g = (adj.homEquiv X' Y).symm h ≫ k := by
+theorem homEquiv_naturality_right_square (f : X' ⟶ X) (g : X ⟶ G.obj Y') (h : X' ⟶ G.obj Y) (k : Y ⟶ Y') (w : f ≫ g = h ≫ G.map k) :
+    F.map f ≫ (adj.homEquiv X Y').symm g = (adj.homEquiv X' Y).symm h ≫ k := by
   rw [← homEquiv_naturality_left_symm, ← homEquiv_naturality_right_symm]
   exact congrArg (adj.homEquiv X' Y').symm w
 

--- a/Mathlib/CategoryTheory/Adjunction/Basic.lean
+++ b/Mathlib/CategoryTheory/Adjunction/Basic.lean
@@ -176,6 +176,7 @@ theorem homEquiv_naturality_right_symm (f : X ⟶ G.obj Y) (g : Y ⟶ Y') :
   simp only [homEquiv_naturality_right,eq_self_iff_true,Equiv.apply_symm_apply]
 #align category_theory.adjunction.hom_equiv_naturality_right_symm CategoryTheory.Adjunction.homEquiv_naturality_right_symm
 
+@[reassoc]
 theorem homEquiv_naturality_left_square (f : X' ⟶ X) (g : F.obj X ⟶ Y')
     (h : F.obj X' ⟶ Y) (k : Y ⟶ Y') (w : F.map f ≫ g = h ≫ k) :
     f ≫ (adj.homEquiv X Y') g = (adj.homEquiv X' Y) h ≫ G.map k := by

--- a/Mathlib/CategoryTheory/Adjunction/Basic.lean
+++ b/Mathlib/CategoryTheory/Adjunction/Basic.lean
@@ -188,7 +188,7 @@ theorem homEquiv_naturality_right_square (f : X' ⟶ X) (g : X ⟶ G.obj Y')
     F.map f ≫ (adj.homEquiv X Y').symm g = (adj.homEquiv X' Y).symm h ≫ k := by
   rw [← homEquiv_naturality_left_symm, ← homEquiv_naturality_right_symm, w]
 
-theorem homEquiv_naturality_left_square_eq (f : X' ⟶ X) (g : F.obj X ⟶ Y')
+theorem homEquiv_naturality_left_square_iff (f : X' ⟶ X) (g : F.obj X ⟶ Y')
     (h : F.obj X' ⟶ Y) (k : Y ⟶ Y') :
     (F.map f ≫ g = h ≫ k) ↔
     (f ≫ (adj.homEquiv X Y') g = (adj.homEquiv X' Y) h ≫ G.map k) where
@@ -199,7 +199,7 @@ theorem homEquiv_naturality_left_square_eq (f : X' ⟶ X) (g : F.obj X ⟶ Y')
     simp only [Equiv.symm_apply_apply] at transposedw
     exact transposedw
 
-theorem homEquiv_naturality_right_square_eq (f : X' ⟶ X) (g : X ⟶ G.obj Y')
+theorem homEquiv_naturality_right_square_iff (f : X' ⟶ X) (g : X ⟶ G.obj Y')
     (h : X' ⟶ G.obj Y) (k : Y ⟶ Y') :
     (f ≫ g = h ≫ G.map k) ↔
     (F.map f ≫ (adj.homEquiv X Y').symm g = (adj.homEquiv X' Y).symm h ≫ k)

--- a/Mathlib/CategoryTheory/Adjunction/Basic.lean
+++ b/Mathlib/CategoryTheory/Adjunction/Basic.lean
@@ -198,15 +198,14 @@ theorem homEquiv_naturality_left_square_iff (f : X' ⟶ X) (g : F.obj X ⟶ Y')
 
 theorem homEquiv_naturality_right_square_iff (f : X' ⟶ X) (g : X ⟶ G.obj Y')
     (h : X' ⟶ G.obj Y) (k : Y ⟶ Y') :
-    (f ≫ g = h ≫ G.map k) ↔
-    (F.map f ≫ (adj.homEquiv X Y').symm g = (adj.homEquiv X' Y).symm h ≫ k)
-    where
-  mp := homEquiv_naturality_right_square adj f g h k
-  mpr := by
-    intro w
-    have transposedw := homEquiv_naturality_left_square adj _ _ _ _ w
-    simp only [Equiv.apply_symm_apply] at transposedw
-    exact transposedw
+    (F.map f ≫ (adj.homEquiv X Y').symm g = (adj.homEquiv X' Y).symm h ≫ k) ↔
+      (f ≫ g = h ≫ G.map k) := by
+  constructor
+  · intro w
+    have := homEquiv_naturality_left_square adj _ _ _ _ w
+    simp only [Equiv.apply_symm_apply] at this
+    exact this
+  · exact homEquiv_naturality_right_square adj f g h k
 
 @[simp]
 theorem left_triangle : whiskerRight adj.unit F ≫ whiskerLeft F adj.counit = 𝟙 _ := by

--- a/Mathlib/CategoryTheory/Adjunction/Basic.lean
+++ b/Mathlib/CategoryTheory/Adjunction/Basic.lean
@@ -180,8 +180,7 @@ theorem homEquiv_naturality_right_symm (f : X ⟶ G.obj Y) (g : Y ⟶ Y') :
 theorem homEquiv_naturality_left_square (f : X' ⟶ X) (g : F.obj X ⟶ Y')
     (h : F.obj X' ⟶ Y) (k : Y ⟶ Y') (w : F.map f ≫ g = h ≫ k) :
     f ≫ (adj.homEquiv X Y') g = (adj.homEquiv X' Y) h ≫ G.map k := by
-  rw [← homEquiv_naturality_left, ← homEquiv_naturality_right]
-  exact congrArg (adj.homEquiv X' Y') w
+  rw [← homEquiv_naturality_left, ← homEquiv_naturality_right, w]
 
 theorem homEquiv_naturality_right_square (f : X' ⟶ X) (g : X ⟶ G.obj Y')
     (h : X' ⟶ G.obj Y) (k : Y ⟶ Y') (w : f ≫ g = h ≫ G.map k) :

--- a/Mathlib/CategoryTheory/Adjunction/Basic.lean
+++ b/Mathlib/CategoryTheory/Adjunction/Basic.lean
@@ -176,12 +176,14 @@ theorem homEquiv_naturality_right_symm (f : X ⟶ G.obj Y) (g : Y ⟶ Y') :
   simp only [homEquiv_naturality_right,eq_self_iff_true,Equiv.apply_symm_apply]
 #align category_theory.adjunction.hom_equiv_naturality_right_symm CategoryTheory.Adjunction.homEquiv_naturality_right_symm
 
-theorem homEquiv_naturality_left_square (f : X' ⟶ X) (g : F.obj X ⟶ Y') (h : F.obj X' ⟶ Y) (k : Y ⟶ Y') (w : F.map f ≫ g = h ≫ k) :
+theorem homEquiv_naturality_left_square (f : X' ⟶ X) (g : F.obj X ⟶ Y')
+    (h : F.obj X' ⟶ Y) (k : Y ⟶ Y') (w : F.map f ≫ g = h ≫ k) :
     f ≫ (adj.homEquiv X Y') g = (adj.homEquiv X' Y) h ≫ G.map k := by
   rw [← homEquiv_naturality_left, ← homEquiv_naturality_right]
   exact congrArg (adj.homEquiv X' Y') w
 
-theorem homEquiv_naturality_right_square (f : X' ⟶ X) (g : X ⟶ G.obj Y') (h : X' ⟶ G.obj Y) (k : Y ⟶ Y') (w : f ≫ g = h ≫ G.map k) :
+theorem homEquiv_naturality_right_square (f : X' ⟶ X) (g : X ⟶ G.obj Y')
+    (h : X' ⟶ G.obj Y) (k : Y ⟶ Y') (w : f ≫ g = h ≫ G.map k) :
     F.map f ≫ (adj.homEquiv X Y').symm g = (adj.homEquiv X' Y).symm h ≫ k := by
   rw [← homEquiv_naturality_left_symm, ← homEquiv_naturality_right_symm]
   exact congrArg (adj.homEquiv X' Y').symm w

--- a/Mathlib/CategoryTheory/Adjunction/Basic.lean
+++ b/Mathlib/CategoryTheory/Adjunction/Basic.lean
@@ -176,6 +176,14 @@ theorem homEquiv_naturality_right_symm (f : X ⟶ G.obj Y) (g : Y ⟶ Y') :
   simp only [homEquiv_naturality_right,eq_self_iff_true,Equiv.apply_symm_apply]
 #align category_theory.adjunction.hom_equiv_naturality_right_symm CategoryTheory.Adjunction.homEquiv_naturality_right_symm
 
+theorem homEquiv_naturality_left_square (f : X' ⟶ X) (g : F.obj X ⟶ Y') (h : F.obj X' ⟶ Y) (k : Y ⟶ Y') (w : F.map f ≫ g = h ≫ k) : f ≫ (adj.homEquiv X Y') g = (adj.homEquiv X' Y) h ≫ G.map k := by
+  rw [← homEquiv_naturality_left, ← homEquiv_naturality_right]
+  exact congrArg (adj.homEquiv X' Y') w
+
+theorem homEquiv_naturality_right_square (f : X' ⟶ X) (g : X ⟶ G.obj Y') (h : X' ⟶ G.obj Y) (k : Y ⟶ Y') (w : f ≫ g = h ≫ G.map k) : F.map f ≫ (adj.homEquiv X Y').symm g = (adj.homEquiv X' Y).symm h ≫ k := by
+  rw [← homEquiv_naturality_left_symm, ← homEquiv_naturality_right_symm]
+  exact congrArg (adj.homEquiv X' Y').symm w
+
 @[simp]
 theorem left_triangle : whiskerRight adj.unit F ≫ whiskerLeft F adj.counit = 𝟙 _ := by
   ext; dsimp

--- a/Mathlib/CategoryTheory/Adjunction/Basic.lean
+++ b/Mathlib/CategoryTheory/Adjunction/Basic.lean
@@ -182,10 +182,34 @@ theorem homEquiv_naturality_left_square (f : X' ⟶ X) (g : F.obj X ⟶ Y')
     f ≫ (adj.homEquiv X Y') g = (adj.homEquiv X' Y) h ≫ G.map k := by
   rw [← homEquiv_naturality_left, ← homEquiv_naturality_right, w]
 
+@[reassoc]
 theorem homEquiv_naturality_right_square (f : X' ⟶ X) (g : X ⟶ G.obj Y')
     (h : X' ⟶ G.obj Y) (k : Y ⟶ Y') (w : f ≫ g = h ≫ G.map k) :
     F.map f ≫ (adj.homEquiv X Y').symm g = (adj.homEquiv X' Y).symm h ≫ k := by
   rw [← homEquiv_naturality_left_symm, ← homEquiv_naturality_right_symm, w]
+
+theorem homEquiv_naturality_left_square_eq (f : X' ⟶ X) (g : F.obj X ⟶ Y')
+    (h : F.obj X' ⟶ Y) (k : Y ⟶ Y') :
+    (F.map f ≫ g = h ≫ k) ↔
+    (f ≫ (adj.homEquiv X Y') g = (adj.homEquiv X' Y) h ≫ G.map k) where
+  mp := homEquiv_naturality_left_square adj f g h k
+  mpr := by
+    intro w
+    have transposedw := homEquiv_naturality_right_square adj _ _ _ _ w
+    simp only [Equiv.symm_apply_apply] at transposedw
+    exact transposedw
+
+theorem homEquiv_naturality_right_square_eq (f : X' ⟶ X) (g : X ⟶ G.obj Y')
+    (h : X' ⟶ G.obj Y) (k : Y ⟶ Y') :
+    (f ≫ g = h ≫ G.map k) ↔
+    (F.map f ≫ (adj.homEquiv X Y').symm g = (adj.homEquiv X' Y).symm h ≫ k)
+    where
+  mp := homEquiv_naturality_right_square adj f g h k
+  mpr := by
+    intro w
+    have transposedw := homEquiv_naturality_left_square adj _ _ _ _ w
+    simp only [Equiv.apply_symm_apply] at transposedw
+    exact transposedw
 
 @[simp]
 theorem left_triangle : whiskerRight adj.unit F ≫ whiskerLeft F adj.counit = 𝟙 _ := by

--- a/Mathlib/CategoryTheory/Adjunction/Basic.lean
+++ b/Mathlib/CategoryTheory/Adjunction/Basic.lean
@@ -190,14 +190,11 @@ theorem homEquiv_naturality_right_square (f : X' ⟶ X) (g : X ⟶ G.obj Y')
 
 theorem homEquiv_naturality_left_square_iff (f : X' ⟶ X) (g : F.obj X ⟶ Y')
     (h : F.obj X' ⟶ Y) (k : Y ⟶ Y') :
-    (F.map f ≫ g = h ≫ k) ↔
-    (f ≫ (adj.homEquiv X Y') g = (adj.homEquiv X' Y) h ≫ G.map k) where
-  mp := homEquiv_naturality_left_square adj f g h k
-  mpr := by
-    intro w
-    have transposedw := homEquiv_naturality_right_square adj _ _ _ _ w
-    simp only [Equiv.symm_apply_apply] at transposedw
-    exact transposedw
+    (f ≫ (adj.homEquiv X Y') g = (adj.homEquiv X' Y) h ≫ G.map k) ↔
+      (F.map f ≫ g = h ≫ k) :=
+  ⟨fun w ↦ by simpa only [Equiv.symm_apply_apply]
+      using homEquiv_naturality_right_square adj _ _ _ _ w,
+    homEquiv_naturality_left_square adj f g h k⟩
 
 theorem homEquiv_naturality_right_square_iff (f : X' ⟶ X) (g : X ⟶ G.obj Y')
     (h : X' ⟶ G.obj Y) (k : Y ⟶ Y') :

--- a/Mathlib/CategoryTheory/Adjunction/Basic.lean
+++ b/Mathlib/CategoryTheory/Adjunction/Basic.lean
@@ -185,8 +185,7 @@ theorem homEquiv_naturality_left_square (f : X' ⟶ X) (g : F.obj X ⟶ Y')
 theorem homEquiv_naturality_right_square (f : X' ⟶ X) (g : X ⟶ G.obj Y')
     (h : X' ⟶ G.obj Y) (k : Y ⟶ Y') (w : f ≫ g = h ≫ G.map k) :
     F.map f ≫ (adj.homEquiv X Y').symm g = (adj.homEquiv X' Y).symm h ≫ k := by
-  rw [← homEquiv_naturality_left_symm, ← homEquiv_naturality_right_symm]
-  exact congrArg (adj.homEquiv X' Y').symm w
+  rw [← homEquiv_naturality_left_symm, ← homEquiv_naturality_right_symm, w]
 
 @[simp]
 theorem left_triangle : whiskerRight adj.unit F ≫ whiskerLeft F adj.counit = 𝟙 _ := by

--- a/Mathlib/CategoryTheory/Adjunction/Basic.lean
+++ b/Mathlib/CategoryTheory/Adjunction/Basic.lean
@@ -199,13 +199,10 @@ theorem homEquiv_naturality_left_square_iff (f : X' ⟶ X) (g : F.obj X ⟶ Y')
 theorem homEquiv_naturality_right_square_iff (f : X' ⟶ X) (g : X ⟶ G.obj Y')
     (h : X' ⟶ G.obj Y) (k : Y ⟶ Y') :
     (F.map f ≫ (adj.homEquiv X Y').symm g = (adj.homEquiv X' Y).symm h ≫ k) ↔
-      (f ≫ g = h ≫ G.map k) := by
-  constructor
-  · intro w
-    have := homEquiv_naturality_left_square adj _ _ _ _ w
-    simp only [Equiv.apply_symm_apply] at this
-    exact this
-  · exact homEquiv_naturality_right_square adj f g h k
+      (f ≫ g = h ≫ G.map k) :=
+  ⟨fun w ↦ by simpa only [Equiv.apply_symm_apply]
+      using homEquiv_naturality_left_square adj _ _ _ _ w,
+    homEquiv_naturality_right_square adj f g h k⟩
 
 @[simp]
 theorem left_triangle : whiskerRight adj.unit F ≫ whiskerLeft F adj.counit = 𝟙 _ := by


### PR DESCRIPTION
In the presence of an adjunction `F ⊣ G` a square `F.map f ≫ g = h ≫ k` whose left map is in the image of the left adjoint commutes iff the transposed square `f ≫ (adj.homEquiv X Y') g = (adj.homEquiv X' Y) h ≫ G.map k` whose right map is in the image of the right adjoint commutes. The proof is by two instances of `homEquiv_naturality` and the `adj.homEquiv` bijection.

---

These short proofs could likely be simplified further. 

I defined two separate functions to be used to transpose squares in each direction, but perhaps this is better set up as an if and only if? If so I'd appreciate guidance on how to extract the functions in their current form for use in proofs.

Suggestions welcome.

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
