### PR TITLE
[Merged by Bors] - chore: deprecate redundant lattice lemmas

### DIFF
--- a/Mathlib/Order/Lattice.lean
+++ b/Mathlib/Order/Lattice.lean
@@ -112,19 +112,17 @@ variable [SemilatticeSup α] {a b c d : α}
 theorem le_sup_left : a ≤ a ⊔ b :=
   SemilatticeSup.le_sup_left a b
 #align le_sup_left le_sup_left
+#align le_sup_left' le_sup_left
 
-theorem le_sup_left' : a ≤ a ⊔ b :=
-  le_sup_left
-#align le_sup_left' le_sup_left'
+@[deprecated (since := "2024-06-04")] alias le_sup_left' := le_sup_left
 
 @[simp]
 theorem le_sup_right : b ≤ a ⊔ b :=
   SemilatticeSup.le_sup_right a b
 #align le_sup_right le_sup_right
+#align le_sup_right' le_sup_right
 
-theorem le_sup_right' : b ≤ a ⊔ b :=
-  le_sup_right
-#align le_sup_right' le_sup_right'
+@[deprecated (since := "2024-06-04")] alias le_sup_right' := le_sup_right
 
 theorem le_sup_of_le_left (h : c ≤ a) : c ≤ a ⊔ b :=
   le_trans h le_sup_left
@@ -360,19 +358,17 @@ variable [SemilatticeInf α] {a b c d : α}
 theorem inf_le_left : a ⊓ b ≤ a :=
   SemilatticeInf.inf_le_left a b
 #align inf_le_left inf_le_left
+#align inf_le_left' inf_le_left
 
-theorem inf_le_left' : a ⊓ b ≤ a :=
-  SemilatticeInf.inf_le_left a b
-#align inf_le_left' inf_le_left'
+@[deprecated (since := "2024-06-04")] alias inf_le_left' := inf_le_left
 
 @[simp]
 theorem inf_le_right : a ⊓ b ≤ b :=
   SemilatticeInf.inf_le_right a b
 #align inf_le_right inf_le_right
+#align inf_le_right' inf_le_right
 
-theorem inf_le_right' : a ⊓ b ≤ b :=
-  SemilatticeInf.inf_le_right a b
-#align inf_le_right' inf_le_right'
+@[deprecated (since := "2024-06-04")] alias inf_le_right' := inf_le_right
 
 theorem le_inf : a ≤ b → a ≤ c → a ≤ b ⊓ c :=
   SemilatticeInf.le_inf a b c


### PR DESCRIPTION
There were tagged with the ematch attribute in lean 3, but this no longer exists.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
