### PR TITLE
[Merged by Bors] - chore(Topology): tweak and factor out "pseudo-metrisable second countable spaces are Lindelöf"

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -4063,6 +4063,7 @@ import Mathlib.Topology.Compactness.Compact
 import Mathlib.Topology.Compactness.Lindelof
 import Mathlib.Topology.Compactness.LocallyCompact
 import Mathlib.Topology.Compactness.Paracompact
+import Mathlib.Topology.Compactness.PseudometrizableLindelof
 import Mathlib.Topology.Compactness.SigmaCompact
 import Mathlib.Topology.CompletelyRegular
 import Mathlib.Topology.Connected.Basic

--- a/Mathlib/Topology/Compactness/Lindelof.lean
+++ b/Mathlib/Topology/Compactness/Lindelof.lean
@@ -6,7 +6,6 @@ Authors: Josha Dekker
 import Mathlib.Topology.Bases
 import Mathlib.Order.Filter.CountableInter
 import Mathlib.Topology.Compactness.SigmaCompact
-import Mathlib.Topology.Metrizable.Basic
 
 /-!
 # Lindelöf sets and Lindelöf spaces
@@ -708,25 +707,6 @@ instance (priority := 100) SecondCountableTopology.toHereditarilyLindelof
     rcases this with ⟨t, ⟨htc, htu⟩⟩
     use t, htc
     exact subset_of_subset_of_eq hcover (id htu.symm)
-
-instance SecondCountableTopology.ofPseudoMetrizableSpaceLindelofSpace [PseudoMetrizableSpace X]
-    [LindelofSpace X] : SecondCountableTopology X := by
-  letI : PseudoMetricSpace X := TopologicalSpace.pseudoMetrizableSpacePseudoMetric X
-  have h_dense : ∀ ε > 0, ∃ s : Set X, s.Countable ∧ ∀ x, ∃ y ∈ s, dist x y ≤ ε := by
-    intro ε hpos
-    let U := fun (z : X) ↦ Metric.ball z ε
-    have hU : ∀ z, U z ∈ 𝓝 z := by
-      intro z
-      have : IsOpen (U z) := Metric.isOpen_ball
-      refine IsOpen.mem_nhds this ?hx
-      simp only [U, Metric.mem_ball, dist_self, hpos]
-    have ⟨t, hct, huniv⟩ := LindelofSpace.elim_nhds_subcover U hU
-    refine ⟨t, hct, ?_⟩
-    intro z
-    have ⟨y, ht, hzy⟩ : ∃ y ∈ t, z ∈ U y := exists_set_mem_of_union_eq_top t (fun i ↦ U i) huniv z
-    simp only [Metric.mem_ball, U] at hzy
-    exact ⟨y, ht, hzy.le⟩
-  exact Metric.secondCountable_of_almost_dense_set h_dense
 
 lemma eq_open_union_countable [HereditarilyLindelofSpace X] {ι : Type u} (U : ι → Set X)
     (h : ∀ i, IsOpen (U i)) : ∃ t : Set ι, t.Countable ∧ ⋃ i∈t, U i = ⋃ i, U i := by

--- a/Mathlib/Topology/Compactness/PseudometrizableLindelof.lean
+++ b/Mathlib/Topology/Compactness/PseudometrizableLindelof.lean
@@ -1,0 +1,38 @@
+/-
+Copyright (c) 2023 Josha Dekker. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Josha Dekker
+-/
+
+import Mathlib.Topology.Metrizable.Basic
+import Mathlib.Topology.Compactness.Lindelof
+
+/-!
+# Second-countability of pseduometrizable Lindelöf spaces
+
+Factored out from `Mathlib.Topology.Compactness.Lindelof`
+to avoid circular dependencies.
+-/
+
+variable {X : Type*} [TopologicalSpace X]
+
+open Set Filter Topology TopologicalSpace
+
+instance SecondCountableTopology.ofPseudoMetrizableSpaceLindelofSpace [PseudoMetrizableSpace X]
+    [LindelofSpace X] : SecondCountableTopology X := by
+  letI : PseudoMetricSpace X := TopologicalSpace.pseudoMetrizableSpacePseudoMetric X
+  have h_dense : ∀ ε > 0, ∃ s : Set X, s.Countable ∧ ∀ x, ∃ y ∈ s, dist x y ≤ ε := by
+    intro ε hpos
+    let U := fun (z : X) ↦ Metric.ball z ε
+    have hU : ∀ z, U z ∈ 𝓝 z := by
+      intro z
+      have : IsOpen (U z) := Metric.isOpen_ball
+      refine IsOpen.mem_nhds this ?hx
+      simp only [U, Metric.mem_ball, dist_self, hpos]
+    have ⟨t, hct, huniv⟩ := LindelofSpace.elim_nhds_subcover U hU
+    refine ⟨t, hct, ?_⟩
+    intro z
+    have ⟨y, ht, hzy⟩ : ∃ y ∈ t, z ∈ U y := exists_set_mem_of_union_eq_top t (fun i ↦ U i) huniv z
+    simp only [Metric.mem_ball, U] at hzy
+    exact ⟨y, ht, hzy.le⟩
+  exact Metric.secondCountable_of_almost_dense_set h_dense

--- a/Mathlib/Topology/Compactness/PseudometrizableLindelof.lean
+++ b/Mathlib/Topology/Compactness/PseudometrizableLindelof.lean
@@ -21,7 +21,7 @@ open Set Filter Topology TopologicalSpace
 instance SecondCountableTopology.ofPseudoMetrizableSpaceLindelofSpace [PseudoMetrizableSpace X]
     [LindelofSpace X] : SecondCountableTopology X := by
   letI : PseudoMetricSpace X := TopologicalSpace.pseudoMetrizableSpacePseudoMetric X
-  have h_dense (ε) (hpos: ε > 0): ∃ s : Set X, s.Countable ∧ ∀ x, ∃ y ∈ s, dist x y ≤ ε := by
+  have h_dense (ε) (hpos: 0 < ε) : ∃ s : Set X, s.Countable ∧ ∀ x, ∃ y ∈ s, dist x y ≤ ε := by
     let U := fun (z : X) ↦ Metric.ball z ε
     obtain ⟨t, hct, huniv⟩ := LindelofSpace.elim_nhds_subcover U
       (fun _ ↦ (Metric.isOpen_ball).mem_nhds (Metric.mem_ball_self hpos))

--- a/Mathlib/Topology/Compactness/PseudometrizableLindelof.lean
+++ b/Mathlib/Topology/Compactness/PseudometrizableLindelof.lean
@@ -21,18 +21,13 @@ open Set Filter Topology TopologicalSpace
 instance SecondCountableTopology.ofPseudoMetrizableSpaceLindelofSpace [PseudoMetrizableSpace X]
     [LindelofSpace X] : SecondCountableTopology X := by
   letI : PseudoMetricSpace X := TopologicalSpace.pseudoMetrizableSpacePseudoMetric X
-  have h_dense : ∀ ε > 0, ∃ s : Set X, s.Countable ∧ ∀ x, ∃ y ∈ s, dist x y ≤ ε := by
-    intro ε hpos
+  have h_dense (ε) (hpos: ε > 0): ∃ s : Set X, s.Countable ∧ ∀ x, ∃ y ∈ s, dist x y ≤ ε := by
     let U := fun (z : X) ↦ Metric.ball z ε
-    have hU : ∀ z, U z ∈ 𝓝 z := by
-      intro z
-      have : IsOpen (U z) := Metric.isOpen_ball
-      refine IsOpen.mem_nhds this ?hx
-      simp only [U, Metric.mem_ball, dist_self, hpos]
-    have ⟨t, hct, huniv⟩ := LindelofSpace.elim_nhds_subcover U hU
-    refine ⟨t, hct, ?_⟩
-    intro z
-    have ⟨y, ht, hzy⟩ : ∃ y ∈ t, z ∈ U y := exists_set_mem_of_union_eq_top t (fun i ↦ U i) huniv z
+    obtain ⟨t, hct, huniv⟩ := LindelofSpace.elim_nhds_subcover U
+      (fun _ ↦ (Metric.isOpen_ball).mem_nhds (Metric.mem_ball_self hpos))
+    refine ⟨t, hct, fun z ↦ ?_⟩
+    obtain ⟨y, ht, hzy⟩ : ∃ y ∈ t, z ∈ U y :=
+      exists_set_mem_of_union_eq_top t (fun i ↦ U i) huniv z
     simp only [Metric.mem_ball, U] at hzy
     exact ⟨y, ht, hzy.le⟩
   exact Metric.secondCountable_of_almost_dense_set h_dense

--- a/Mathlib/Topology/Compactness/PseudometrizableLindelof.lean
+++ b/Mathlib/Topology/Compactness/PseudometrizableLindelof.lean
@@ -8,7 +8,7 @@ import Mathlib.Topology.Metrizable.Basic
 import Mathlib.Topology.Compactness.Lindelof
 
 /-!
-# Second-countability of pseduometrizable Lindelöf spaces
+# Second-countability of pseudometrizable Lindelöf spaces
 
 Factored out from `Mathlib.Topology.Compactness.Lindelof`
 to avoid circular dependencies.

--- a/Mathlib/Topology/Compactness/PseudometrizableLindelof.lean
+++ b/Mathlib/Topology/Compactness/PseudometrizableLindelof.lean
@@ -28,6 +28,5 @@ instance SecondCountableTopology.ofPseudoMetrizableSpaceLindelofSpace [PseudoMet
     refine ⟨t, hct, fun z ↦ ?_⟩
     obtain ⟨y, ht, hzy⟩ : ∃ y ∈ t, z ∈ U y :=
       exists_set_mem_of_union_eq_top t (fun i ↦ U i) huniv z
-    simp only [Metric.mem_ball, U] at hzy
-    exact ⟨y, ht, hzy.le⟩
+    exact ⟨y, ht, (Metric.mem_ball.mp hzy).le⟩
   exact Metric.secondCountable_of_almost_dense_set h_dense


### PR DESCRIPTION
As discussed with @grunweg, this factors out a result to its own file in order to remove a circular dependency that otherwise blocks #13176

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
