### PR TITLE
chore(Data/UInt): deprecate UInt8.isUpper etc

### DIFF
--- a/Mathlib/Data/Char.lean
+++ b/Mathlib/Data/Char.lean
@@ -19,6 +19,12 @@ Provides an additional definition to truncate a `Char` to `UInt8` and a theorem 
 /-- Convert a character into a `UInt8`, by truncating (reducing modulo 256) if necessary. -/
 def Char.toUInt8 (n : Char) : UInt8 := n.1.toUInt8
 
+/-- The numbers from 0 to 256 are all valid UTF-8 characters, so we can embed one in the other. -/
+def Char.ofUInt8 (n : UInt8) : Char := ⟨n.toUInt32, .inl (n.1.2.trans (by decide))⟩
+
+@[deprecated Char.ofUInt8 (since := "2024-06-05")]
+alias UInt8.toChar := Char.ofUInt8
+
 theorem Char.utf8Size_pos (c : Char) : 0 < c.utf8Size := by
   simp only [utf8Size]
   repeat (split; decide)

--- a/Mathlib/Data/Char.lean
+++ b/Mathlib/Data/Char.lean
@@ -19,7 +19,7 @@ Provides an additional definition to truncate a `Char` to `UInt8` and a theorem 
 /-- Convert a character into a `UInt8`, by truncating (reducing modulo 256) if necessary. -/
 def Char.toUInt8 (n : Char) : UInt8 := n.1.toUInt8
 
-/-- The numbers from 0 to 256 are all valid UTF-8 characters, so we can embed one in the other. -/
+/-- The numbers from 0 to 256 are all valid Unicode codepoints, so we can embed one in the other. -/
 def Char.ofUInt8 (n : UInt8) : Char := ⟨n.toUInt32, .inl (n.1.2.trans (by decide))⟩
 
 @[deprecated Char.ofUInt8 (since := "2024-06-05")]

--- a/Mathlib/Data/UInt.lean
+++ b/Mathlib/Data/UInt.lean
@@ -108,26 +108,28 @@ run_cmd
 namespace UInt8
 
 /-- Is this an uppercase ASCII letter? -/
+@[deprecated "Use `(Char.ofUInt8 i).isUpper` instead." (since := "2024-06-05")]
 def isUpper (c : UInt8) : Bool :=
   c ≥ 65 && c ≤ 90
 
 /-- Is this a lowercase ASCII letter? -/
+@[deprecated "Use `(Char.ofUInt8 i).isLower` instead." (since := "2024-06-05")]
 def isLower (c : UInt8) : Bool :=
   c ≥ 97 && c ≤ 122
 
 /-- Is this an alphabetic ASCII character? -/
+@[deprecated "Use `(Char.ofUInt8 i).isAlpha` instead." (since := "2024-06-05")]
 def isAlpha (c : UInt8) : Bool :=
   c.isUpper || c.isLower
 
 /-- Is this an ASCII digit character? -/
+@[deprecated "Use `(Char.ofUInt8 i).isDigit` instead." (since := "2024-06-05")]
 def isDigit (c : UInt8) : Bool :=
   c ≥ 48 && c ≤ 57
 
 /-- Is this an alphanumeric ASCII character? -/
+@[deprecated "Use `(Char.ofUInt8 i).isAlphanum` instead." (since := "2024-06-05")]
 def isAlphanum (c : UInt8) : Bool :=
   c.isAlpha || c.isDigit
-
-/-- The numbers from 0 to 256 are all valid UTF-8 characters, so we can embed one in the other. -/
-def toChar (n : UInt8) : Char := ⟨n.toUInt32, .inl (n.1.2.trans (by decide))⟩
 
 end UInt8


### PR DESCRIPTION
I will be moving `Char.toUInt8` and `Char.ofUInt8` up to Lean shortly. (Done now in https://github.com/leanprover/lean4/pull/4348.) This deprecates some functions that have bad semantics: if you want to treat your UInt8 as a Char, do that explicitly!

This will be a short deprecation cycle, as we'd like to get this stuff out of Mathlib asap.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
