### PR TITLE
[Merged by Bors] - chore: remove unneeded imports for Mathlib/Data/ByteArray

### DIFF
--- a/Mathlib/Data/ByteArray.lean
+++ b/Mathlib/Data/ByteArray.lean
@@ -3,9 +3,7 @@ Copyright (c) 2021 Mario Carneiro. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Mario Carneiro
 -/
-import Mathlib.Algebra.Group.Nat
 import Mathlib.Data.Char
-import Mathlib.Data.UInt
 
 set_option autoImplicit true
 


### PR DESCRIPTION
This verifies that almost no Mathlib imports are needed for this file, and in fact on Lean's `master` branch no Mathlib imports are needed at all. 

