### PR TITLE
[Merged by Bors] - chore: mark `IsProperMap` with `fun_prop`

### DIFF
--- a/Mathlib/Topology/ProperMap.lean
+++ b/Mathlib/Topology/ProperMap.lean
@@ -129,7 +129,7 @@ lemma IsProperMap.ultrafilter_le_nhds_of_tendsto (h : IsProperMap f) ⦃𝒰 : U
 /-- The composition of two proper maps is proper. -/
 lemma IsProperMap.comp (hf : IsProperMap f) (hg : IsProperMap g) :
     IsProperMap (g ∘ f) := by
-  refine ⟨by continuity, fun ℱ z h ↦ ?_⟩
+  refine ⟨by fun_prop, fun ℱ z h ↦ ?_⟩
   rw [mapClusterPt_comp] at h
   rcases hg.clusterPt_of_mapClusterPt h with ⟨y, rfl, hy⟩
   rcases hf.clusterPt_of_mapClusterPt hy with ⟨x, rfl, hx⟩

--- a/Mathlib/Topology/ProperMap.lean
+++ b/Mathlib/Topology/ProperMap.lean
@@ -78,7 +78,7 @@ universe u v
 /-- A map `f : X → Y` between two topological spaces is said to be **proper** if it is continuous
 and, for all `ℱ : Filter X`, any cluster point of `map f ℱ` is the image by `f` of a cluster point
 of `ℱ`. -/
-@[mk_iff isProperMap_iff_clusterPt]
+@[mk_iff isProperMap_iff_clusterPt, fun_prop]
 structure IsProperMap (f : X → Y) extends Continuous f : Prop where
   /-- By definition, if `f` is a proper map and `ℱ` is any filter on `X`, then any cluster point of
   `map f ℱ` is the image by `f` of some cluster point of `ℱ`. -/
@@ -90,7 +90,7 @@ for closed maps. -/
 add_decl_doc isProperMap_iff_clusterPt
 
 /-- By definition, a proper map is continuous. -/
-@[continuity, fun_prop]
+@[fun_prop]
 lemma IsProperMap.continuous (h : IsProperMap f) : Continuous f := h.toContinuous
 
 /-- A proper map is closed. -/


### PR DESCRIPTION
This removes the `continuity` attribute from `IsProperMap.continuous`, because it is a disaster to mark it as such (it gets a `safe apply` attribute for `aesop`, but it is definitely not safe).

In addition, although `IsProperMap.continuous` was already marked as `fun_prop`, this is actually the incorrect approach unless `IsProperMap` is *also* marked as `fun_prop`, which we do here.

The reason for this is that without `IsProperMap` being marked `fun_prop`, then `IsProperMap.continuous` gets marked as an application theorem for `fun_prop` (much like wth `aesop [safe apply]`). But, when `IsProperMap` is marked as `fun_prop`, then this is marked internally by `fun_prop` as a "transition" theorem.

Consequently, this prevents `fun_prop` from getting stuck with goals of `IsProperMap f` when there is no possible way `f` could be a proper map. Instead, it will get stuck with `Continuous f`, which may be provable.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
