### PR TITLE
[Merged by Bors] - feat: mapComposableArrows is essentially surjective for localization functors when there is a calculus of fractions

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -1461,6 +1461,7 @@ import Mathlib.CategoryTheory.Linear.Yoneda
 import Mathlib.CategoryTheory.Localization.Adjunction
 import Mathlib.CategoryTheory.Localization.Bousfield
 import Mathlib.CategoryTheory.Localization.CalculusOfFractions
+import Mathlib.CategoryTheory.Localization.CalculusOfFractions.ComposableArrows
 import Mathlib.CategoryTheory.Localization.CalculusOfFractions.Fractions
 import Mathlib.CategoryTheory.Localization.CalculusOfFractions.Preadditive
 import Mathlib.CategoryTheory.Localization.Composition

--- a/Mathlib/CategoryTheory/Category/Preorder.lean
+++ b/Mathlib/CategoryTheory/Category/Preorder.lean
@@ -164,6 +164,7 @@ theorem Monotone.functor_obj {f : X → Y} (h : Monotone f) : h.functor.obj = f 
 instance (f : X ↪o Y) : f.monotone.functor.Full where
   map_surjective h := ⟨homOfLE (f.map_rel_iff.1 h.le), rfl⟩
 
+/-- The equivalence of categories `X ≌ Y` induced by `e : X ≃o Y`. -/
 @[simps]
 def OrderIso.equivalence (e : X ≃o Y) : X ≌ Y where
   functor := e.monotone.functor

--- a/Mathlib/CategoryTheory/Category/Preorder.lean
+++ b/Mathlib/CategoryTheory/Category/Preorder.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Stephen Morgan, Scott Morrison, Johannes Hölzl, Reid Barton
 -/
 import Mathlib.CategoryTheory.Equivalence
+import Mathlib.CategoryTheory.EqToHom
 import Mathlib.Order.Hom.Basic
 import Mathlib.Data.ULift
 
@@ -125,6 +126,20 @@ instance uniqueFromBot [OrderBot X] {x : X} : Unique (⊥ ⟶ x) where
   uniq := fun a => by rfl
 #align category_theory.unique_from_bot CategoryTheory.uniqueFromBot
 
+variable (X) in
+/-- The equivalence of categories from the order dual of a preordered type `X`
+to the opposite category of the preorder `X`. -/
+@[simps]
+def orderDualEquivalence : Xᵒᵈ ≌ Xᵒᵖ where
+  functor :=
+    { obj := fun x => op (OrderDual.ofDual x)
+      map := fun f => (homOfLE (leOfHom f)).op }
+  inverse :=
+    { obj := fun x => OrderDual.toDual x.unop
+      map := fun f => (homOfLE (leOfHom f.unop)) }
+  unitIso := Iso.refl _
+  counitIso := Iso.refl _
+
 end CategoryTheory
 
 section
@@ -148,6 +163,13 @@ theorem Monotone.functor_obj {f : X → Y} (h : Monotone f) : h.functor.obj = f 
 -- Faithfulness is automatic because preorder categories are thin
 instance (f : X ↪o Y) : f.monotone.functor.Full where
   map_surjective h := ⟨homOfLE (f.map_rel_iff.1 h.le), rfl⟩
+
+@[simps]
+def OrderIso.equivalence (e : X ≃o Y) : X ≌ Y where
+  functor := e.monotone.functor
+  inverse := e.symm.monotone.functor
+  unitIso := NatIso.ofComponents (fun _ ↦ eqToIso (by simp))
+  counitIso := NatIso.ofComponents (fun _ ↦ eqToIso (by simp))
 
 end
 

--- a/Mathlib/CategoryTheory/ComposableArrows.lean
+++ b/Mathlib/CategoryTheory/ComposableArrows.lean
@@ -885,15 +885,39 @@ lemma mkOfObjOfMapSucc_arrow (i : ℕ) (hi : i < n := by valid) :
 
 end mkOfObjOfMapSucc
 
+variable (C n) in
+/-- The equivalence `(ComposableArrows C n)ᵒᵖ ≌ ComposableArrows Cᵒᵖ n` obtained
+by reversing the arrows. -/
+@[simps!]
+def opEquivalence : (ComposableArrows C n)ᵒᵖ ≌ ComposableArrows Cᵒᵖ n :=
+  ((orderDualEquivalence (Fin (n + 1))).symm.trans
+      Fin.revOrderIso.equivalence).symm.congrLeft.op.trans
+    (Functor.leftOpRightOpEquiv (Fin (n + 1)) C)
+
 end ComposableArrows
 
 variable {C}
 
+section
+
+open ComposableArrows
+
+variable {D : Type*} [Category D] (G : C ⥤ D) (n : ℕ)
+
 /-- The functor `ComposableArrows C n ⥤ ComposableArrows D n` obtained by postcomposition
 with a functor `C ⥤ D`. -/
 @[simps!]
-def Functor.mapComposableArrows {D : Type*} [Category D] (G : C ⥤ D) (n : ℕ) :
+def Functor.mapComposableArrows :
     ComposableArrows C n ⥤ ComposableArrows D n :=
   (whiskeringRight _ _ _).obj G
+
+/-- The functor `ComposableArrows C n ⥤ ComposableArrows D n` induced by `G : C ⥤ D`
+commutes with `opEquivalence`. -/
+def Functor.mapComposableArrowsOpIso :
+    G.mapComposableArrows n ⋙ (opEquivalence D n).functor.rightOp ≅
+      (opEquivalence C n).functor.rightOp ⋙ (G.op.mapComposableArrows n).op :=
+  Iso.refl _
+
+end
 
 end CategoryTheory

--- a/Mathlib/CategoryTheory/EssentialImage.lean
+++ b/Mathlib/CategoryTheory/EssentialImage.lean
@@ -178,6 +178,10 @@ instance essSurj_comp (F : C ⥤ D) (G : D ⥤ E) [F.EssSurj] [G.EssSurj] :
     (F ⋙ G).EssSurj where
   mem_essImage Z := ⟨_, ⟨G.mapIso (F.objObjPreimageIso _) ≪≫ G.objObjPreimageIso Z⟩⟩
 
+lemma essSurf_of_comp_fully_faithful (F : C ⥤ D) (G : D ⥤ E) [(F ⋙ G).EssSurj]
+    [G.Faithful] [G.Full] : F.EssSurj where
+  mem_essImage X := ⟨_, ⟨G.preimageIso ((F ⋙ G).objObjPreimageIso (G.obj X))⟩⟩
+
 end Functor
 
 -- deprecated on 2024-04-06

--- a/Mathlib/CategoryTheory/EssentialImage.lean
+++ b/Mathlib/CategoryTheory/EssentialImage.lean
@@ -178,7 +178,7 @@ instance essSurj_comp (F : C ⥤ D) (G : D ⥤ E) [F.EssSurj] [G.EssSurj] :
     (F ⋙ G).EssSurj where
   mem_essImage Z := ⟨_, ⟨G.mapIso (F.objObjPreimageIso _) ≪≫ G.objObjPreimageIso Z⟩⟩
 
-lemma essSurf_of_comp_fully_faithful (F : C ⥤ D) (G : D ⥤ E) [(F ⋙ G).EssSurj]
+lemma essSurj_of_comp_fully_faithful (F : C ⥤ D) (G : D ⥤ E) [(F ⋙ G).EssSurj]
     [G.Faithful] [G.Full] : F.EssSurj where
   mem_essImage X := ⟨_, ⟨G.preimageIso ((F ⋙ G).objObjPreimageIso (G.obj X))⟩⟩
 

--- a/Mathlib/CategoryTheory/Localization/CalculusOfFractions/ComposableArrows.lean
+++ b/Mathlib/CategoryTheory/Localization/CalculusOfFractions/ComposableArrows.lean
@@ -1,0 +1,53 @@
+/-
+Copyright (c) 2024 Joël Riou. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Joël Riou, Andrew Yang
+-/
+import Mathlib.CategoryTheory.ComposableArrows
+import Mathlib.CategoryTheory.Localization.CalculusOfFractions
+
+/-! # Essential surjectivity of the functor induced on tuples of composable arrows
+
+Assuming that `L : C ⥤ D` is a localization functor for a class of morphisms `W`
+that has a calculus of left *or* right fractions, we show in this file
+that the functor `L.mapComposableArrows n : ComposableArrows C n ⥤ ComposableArrows D n`
+is essentially surjective for any `n : ℕ`.
+
+-/
+
+namespace CategoryTheory
+
+namespace Localization
+
+variable {C D : Type*} [Category C] [Category D] (L : C ⥤ D) (W : MorphismProperty C)
+  [L.IsLocalization W]
+
+open ComposableArrows
+
+lemma essSurj_mapComposableArrows_of_hasRightCalculusOfFractions
+    [W.HasRightCalculusOfFractions] (n : ℕ) :
+    (L.mapComposableArrows n).EssSurj where
+  mem_essImage Y := by
+    have := essSurj L W
+    induction n
+    · obtain ⟨Y, rfl⟩ := mk₀_surjective Y
+      exact ⟨mk₀ _, ⟨isoMk₀ (L.objObjPreimageIso Y)⟩⟩
+    · next n hn =>
+      obtain ⟨Y, Z, f, rfl⟩ := ComposableArrows.precomp_surjective Y
+      obtain ⟨Y', ⟨e⟩⟩ := hn Y
+      obtain ⟨f', hf'⟩ := exists_rightFraction L W
+        ((L.objObjPreimageIso Z).hom ≫ f ≫ (e.app 0).inv)
+      refine ⟨Y'.precomp f'.f,
+        ⟨isoMkSucc (isoOfHom L W _ f'.hs ≪≫ L.objObjPreimageIso Z) e ?_⟩⟩
+      dsimp at hf' ⊢
+      simp [← cancel_mono (e.inv.app 0), hf']
+
+lemma essSurj_mapComposableArrows [W.HasLeftCalculusOfFractions] (n : ℕ) :
+    (L.mapComposableArrows n).EssSurj := by
+  have := essSurj_mapComposableArrows_of_hasRightCalculusOfFractions L.op W.op n
+  have := Functor.essSurj_of_iso (L.mapComposableArrowsOpIso n).symm
+  exact Functor.essSurf_of_comp_fully_faithful _ (opEquivalence D n).functor.rightOp
+
+end Localization
+
+end CategoryTheory

--- a/Mathlib/CategoryTheory/Localization/CalculusOfFractions/ComposableArrows.lean
+++ b/Mathlib/CategoryTheory/Localization/CalculusOfFractions/ComposableArrows.lean
@@ -46,7 +46,7 @@ lemma essSurj_mapComposableArrows [W.HasLeftCalculusOfFractions] (n : ℕ) :
     (L.mapComposableArrows n).EssSurj := by
   have := essSurj_mapComposableArrows_of_hasRightCalculusOfFractions L.op W.op n
   have := Functor.essSurj_of_iso (L.mapComposableArrowsOpIso n).symm
-  exact Functor.essSurf_of_comp_fully_faithful _ (opEquivalence D n).functor.rightOp
+  exact Functor.essSurj_of_comp_fully_faithful _ (opEquivalence D n).functor.rightOp
 
 end Localization
 

--- a/Mathlib/CategoryTheory/Localization/CalculusOfFractions/ComposableArrows.lean
+++ b/Mathlib/CategoryTheory/Localization/CalculusOfFractions/ComposableArrows.lean
@@ -6,7 +6,7 @@ Authors: Joël Riou, Andrew Yang
 import Mathlib.CategoryTheory.ComposableArrows
 import Mathlib.CategoryTheory.Localization.CalculusOfFractions
 
-/-! # Essential surjectivity of the functor induced on tuples of composable arrows
+/-! # Essential surjectivity of the functor induced on composable arrows
 
 Assuming that `L : C ⥤ D` is a localization functor for a class of morphisms `W`
 that has a calculus of left *or* right fractions, we show in this file

--- a/Mathlib/CategoryTheory/Opposites.lean
+++ b/Mathlib/CategoryTheory/Opposites.lean
@@ -266,6 +266,13 @@ instance leftOp_faithful {F : C ⥤ Dᵒᵖ} [Faithful F] : Faithful F.leftOp wh
   map_injective h := Quiver.Hom.unop_inj (map_injective F (Quiver.Hom.unop_inj h))
 #align category_theory.functor.left_op_faithful CategoryTheory.Functor.leftOp_faithful
 
+instance rightOp_full {F : Cᵒᵖ ⥤ D} [Full F] : Full F.rightOp where
+  map_surjective f := ⟨(F.preimage f.unop).unop, by simp⟩
+
+instance leftOp_full {F : C ⥤ Dᵒᵖ} [Full F] : Full F.leftOp where
+  map_surjective f := ⟨(F.preimage f.op).op, by simp⟩
+
+
 /-- The isomorphism between `F.leftOp.rightOp` and `F`. -/
 @[simps!]
 def leftOpRightOpIso (F : C ⥤ Dᵒᵖ) : F.leftOp.rightOp ≅ F :=
@@ -641,6 +648,21 @@ def leftOpRightOpEquiv : (Cᵒᵖ ⥤ D)ᵒᵖ ≌ C ⥤ Dᵒᵖ where
         aesop_cat)
   counitIso := NatIso.ofComponents fun F => F.leftOpRightOpIso
 #align category_theory.functor.left_op_right_op_equiv CategoryTheory.Functor.leftOpRightOpEquiv
+
+instance {F : C ⥤ D} [EssSurj F] : EssSurj F.op where
+  mem_essImage X := ⟨op _, ⟨(F.objObjPreimageIso X.unop).op.symm⟩⟩
+
+instance {F : Cᵒᵖ ⥤ D} [EssSurj F] : EssSurj F.rightOp where
+  mem_essImage X := ⟨_, ⟨(F.objObjPreimageIso X.unop).op.symm⟩⟩
+
+instance {F : C ⥤ Dᵒᵖ} [EssSurj F] : EssSurj F.leftOp where
+  mem_essImage X := ⟨op _, ⟨(F.objObjPreimageIso (op X)).unop.symm⟩⟩
+
+instance {F : C ⥤ D} [IsEquivalence F] : IsEquivalence F.op where
+
+instance {F : Cᵒᵖ ⥤ D} [IsEquivalence F] : IsEquivalence F.rightOp where
+
+instance {F : C ⥤ Dᵒᵖ} [IsEquivalence F] : IsEquivalence F.leftOp where
 
 end Functor
 


### PR DESCRIPTION
If `L` is a localization functor with respect to a class of morphisms `W` that a left *or* right calculus of fractions, then the induced functors on `ComposableArrows _ n` is essentially surjective for all natural numbers `n`.

(This was initially written only for `n = 2` when there was both a calculus of left and right fractions, but Andrew Yang simplified the argument.)

Co-authored-by: Andrew Yang <the.erd.one@gmail.com>

---

This is used in the construction of the derived category #11806 and #11786

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
