### PR TITLE
[Merged by Bors] - feat(Order/ModularLattice): alternative equality lemma

### DIFF
--- a/Mathlib/Order/ModularLattice.lean
+++ b/Mathlib/Order/ModularLattice.lean
@@ -238,7 +238,8 @@ theorem eq_of_le_of_inf_le_of_le_sup (hxy : x ≤ y) (hinf : y ⊓ z ≤ x) (hsu
 
 theorem eq_of_le_of_inf_le_of_sup_le (hxy : x ≤ y) (hinf : y ⊓ z ≤ x ⊓ z) (hsup : y ⊔ z ≤ x ⊔ z) :
     x = y :=
-  eq_of_le_of_inf_le_of_le_sup hxy (le_inf_iff.1 hinf).1 (sup_le_iff.1 hsup).1
+  eq_of_le_of_inf_le_of_le_sup hxy (hinf.trans inf_le_left) (le_sup_left.trans hsup)
+#align eq_of_le_of_inf_le_of_sup_le eq_of_le_of_inf_le_of_sup_le
 
 theorem sup_lt_sup_of_lt_of_inf_le_inf (hxy : x < y) (hinf : y ⊓ z ≤ x ⊓ z) : x ⊔ z < y ⊔ z :=
   lt_of_le_of_ne (sup_le_sup_right (le_of_lt hxy) _) fun hsup =>

--- a/Mathlib/Order/ModularLattice.lean
+++ b/Mathlib/Order/ModularLattice.lean
@@ -230,19 +230,15 @@ theorem IsModularLattice.sup_inf_sup_assoc : (x ⊔ z) ⊓ (y ⊔ z) = (x ⊔ z)
   @IsModularLattice.inf_sup_inf_assoc αᵒᵈ _ _ _ _ _
 #align is_modular_lattice.sup_inf_sup_assoc IsModularLattice.sup_inf_sup_assoc
 
+theorem eq_of_le_of_inf_le_of_le_sup (hxy : x ≤ y) (hinf : y ⊓ z ≤ x) (hsup : y ≤ x ⊔ z) :
+    x = y := by
+  refine hxy.antisymm ?_
+  rw [← inf_eq_right, sup_inf_assoc_of_le _ hxy] at hsup
+  rwa [← hsup, sup_le_iff, and_iff_right rfl.le, inf_comm]
+
 theorem eq_of_le_of_inf_le_of_sup_le (hxy : x ≤ y) (hinf : y ⊓ z ≤ x ⊓ z) (hsup : y ⊔ z ≤ x ⊔ z) :
     x = y :=
-  le_antisymm hxy <|
-    have h : y ≤ x ⊔ z :=
-      calc
-        y ≤ y ⊔ z := le_sup_left
-        _ ≤ x ⊔ z := hsup
-    calc
-      y ≤ (x ⊔ z) ⊓ y := le_inf h le_rfl
-      _ = x ⊔ z ⊓ y := sup_inf_assoc_of_le _ hxy
-      _ ≤ x ⊔ z ⊓ x := sup_le_sup_left (by rw [inf_comm, inf_comm z]; exact hinf) _
-      _ ≤ x := sup_le le_rfl inf_le_right
-#align eq_of_le_of_inf_le_of_sup_le eq_of_le_of_inf_le_of_sup_le
+  eq_of_le_of_inf_le_of_le_sup hxy (by simpa using hinf) (by simpa using hsup)
 
 theorem sup_lt_sup_of_lt_of_inf_le_inf (hxy : x < y) (hinf : y ⊓ z ≤ x ⊓ z) : x ⊔ z < y ⊔ z :=
   lt_of_le_of_ne (sup_le_sup_right (le_of_lt hxy) _) fun hsup =>

--- a/Mathlib/Order/ModularLattice.lean
+++ b/Mathlib/Order/ModularLattice.lean
@@ -238,7 +238,7 @@ theorem eq_of_le_of_inf_le_of_le_sup (hxy : x ≤ y) (hinf : y ⊓ z ≤ x) (hsu
 
 theorem eq_of_le_of_inf_le_of_sup_le (hxy : x ≤ y) (hinf : y ⊓ z ≤ x ⊓ z) (hsup : y ⊔ z ≤ x ⊔ z) :
     x = y :=
-  eq_of_le_of_inf_le_of_le_sup hxy (by simpa using hinf) (by simpa using hsup)
+  eq_of_le_of_inf_le_of_le_sup hxy (le_inf_iff.1 hinf).1 (sup_le_iff.1 hsup).1
 
 theorem sup_lt_sup_of_lt_of_inf_le_inf (hxy : x < y) (hinf : y ⊓ z ≤ x ⊓ z) : x ⊔ z < y ⊔ z :=
   lt_of_le_of_ne (sup_le_sup_right (le_of_lt hxy) _) fun hsup =>


### PR DESCRIPTION
We add a new lemma `eq_of_le_inf_le_of_le_sup` for proving two comparable elements are equal in a modular lattice.
It is the same as the existing `eq_of_le_inf_le_of_sup_le` but with the hypotheses in simp normal form, 
having`y ⊓ z ≤ x` and `y ≤ x ⊔ z` instead of `y ⊓ z ≤ x ⊓ z` and `y ⊔ z ≤ x ⊔ z`. The weaker hypotheses easily imply the stronger ones, and proving them in many applications involves slightly less boilerplate. 

We also golf the proof of the original lemma using the (shorter) proof of the new one. 

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
