### PR TITLE
[Merged by Bors] - doc(Data/Fin/Tuple/Basic): Compare start/end/middle addition of an entry in module doc

### DIFF
--- a/Mathlib/Data/Fin/Tuple/Basic.lean
+++ b/Mathlib/Data/Fin/Tuple/Basic.lean
@@ -19,14 +19,55 @@ We interpret maps `∀ i : Fin n, α i` as `n`-tuples of elements of possibly va
 In this case when `α i` is a constant map, then tuples are isomorphic (but not definitionally equal)
 to `Vector`s.
 
-We define the following operations:
+## Main declarations
 
-* `Fin.tail` : the tail of an `n+1` tuple, i.e., its last `n` entries;
-* `Fin.cons` : adding an element at the beginning of an `n`-tuple, to get an `n+1`-tuple;
-* `Fin.init` : the beginning of an `n+1` tuple, i.e., its first `n` entries;
-* `Fin.snoc` : adding an element at the end of an `n`-tuple, to get an `n+1`-tuple. The name `snoc`
-  comes from `cons` (i.e., adding an element to the left of a tuple) read in reverse order.
-* `Fin.insertNth` : insert an element to a tuple at a given position.
+There are three (main) ways to consider `Fin n` as a subtype of `Fin (n + 1)`, hence three (main)
+ways to move between tuples of length `n` and of length `n + 1` by adding/removing an entry.
+
+### Adding at the start
+
+* `Fin.succ`: Send `i : Fin n` to `i + 1 : Fin (n + 1)`. This is defined in Core.
+* `Fin.cases`: Induction/recursion principle for `Fin`: To prove a property/define a function for
+  all `Fin (n + 1)`, it is enough to prove/define it for `0` and for `i.succ` for all `i : Fin n`.
+  This is defined in Core.
+* `Fin.cons`: Turn a tuple `f : Fin n → α` and an entry `a : α` into a tuple
+  `Fin.cons a f : Fin (n + 1) → α` by adding `a` at the start. In general, tuples can be dependent
+  functions, in which case `f : ∀ i : Fin n, α i.succ` and `a : α 0`. This is a special case of
+  `Fin.cases`.
+* `Fin.tail`: Turn a tuple `f : Fin (n + 1) → α` into a tuple `Fin.tail f : Fin n → α` by forgetting
+  the start. In general, tuples can be dependent functions,
+  in which case `Fin.tail f : ∀ i : Fin n, α i.succ`.
+
+### Adding at the end
+
+* `Fin.castSucc`: Send `i : Fin n` to `i : Fin (n + 1)`. This is defined in Core.
+* **There is currently no equivalent of `Fin.cases`/`Fin.succAboveCases` for adding at the end.**
+* `Fin.snoc`: Turn a tuple `f : Fin n → α` and an entry `a : α` into a tuple
+  `Fin.snoc f a : Fin (n + 1) → α` by adding `a` at the end. In general, tuples can be dependent
+  functions, in which case `f : ∀ i : Fin n, α i.castSucc` and `a : α (last n)`.
+* `Fin.init`: Turn a tuple `f : Fin (n + 1) → α` into a tuple `Fin.init f : Fin n → α` by forgetting
+  the start. In general, tuples can be dependent functions,
+  in which case `Fin.init f : ∀ i : Fin n, α i.castSucc`.
+
+### Adding in the middle
+
+For a **pivot** `p : Fin (n + 1)`,
+* `Fin.succAbove`: Send `i : Fin n` to
+  * `i : Fin (n + 1)` if `i < p`,
+  * `i + 1 : Fin (n + 1)` if `p ≤ i`.
+* `Fin.succAboveCases`: Induction/recursion principle for `Fin`: To prove a property/define a
+  function for all `Fin (n + 1)`, it is enough to prove/define it for `p` and for `p.succAbove i`
+  for all `i : Fin n`.
+* `Fin.insertNth`: Turn a tuple `f : Fin n → α` and an entry `a : α` into a tuple
+  `Fin.insertNth f a : Fin (n + 1) → α` by adding `a` in position `p`. In general, tuples can be
+  dependent functions, in which case `f : ∀ i : Fin n, α (p.succAbove i)` and `a : α p`. This is a
+  special case of `Fin.succAboveCases`.
+* **There is currently no equivalent of `Fin.tail`/`Fin.init` for adding in the middle.**
+
+`p = 0` means we add at the start. `p = last n` means we add at the end.
+
+### Miscellaneous
+
 * `Fin.find p` : returns the first index `n` where `p n` is satisfied, and `none` if it is never
   satisfied.
 * `Fin.append a b` : append two tuples.

--- a/Mathlib/Data/Fin/Tuple/Basic.lean
+++ b/Mathlib/Data/Fin/Tuple/Basic.lean
@@ -46,7 +46,8 @@ ways to move between tuples of length `n` and of length `n + 1` by adding/removi
   `i : Fin n`. This is defined in Core.
 * `Fin.snoc`: Turn a tuple `f : Fin n → α` and an entry `a : α` into a tuple
   `Fin.snoc f a : Fin (n + 1) → α` by adding `a` at the end. In general, tuples can be dependent
-  functions, in which case `f : ∀ i : Fin n, α i.castSucc` and `a : α (last n)`.
+  functions, in which case `f : ∀ i : Fin n, α i.castSucc` and `a : α (last n)`. This is a
+  special case of `Fin.lastCases`.
 * `Fin.init`: Turn a tuple `f : Fin (n + 1) → α` into a tuple `Fin.init f : Fin n → α` by forgetting
   the start. In general, tuples can be dependent functions,
   in which case `Fin.init f : ∀ i : Fin n, α i.castSucc`.

--- a/Mathlib/Data/Fin/Tuple/Basic.lean
+++ b/Mathlib/Data/Fin/Tuple/Basic.lean
@@ -41,7 +41,9 @@ ways to move between tuples of length `n` and of length `n + 1` by adding/removi
 ### Adding at the end
 
 * `Fin.castSucc`: Send `i : Fin n` to `i : Fin (n + 1)`. This is defined in Core.
-* **There is currently no equivalent of `Fin.cases`/`Fin.succAboveCases` for adding at the end.**
+* `Fin.lastCases`: Induction/recursion principle for `Fin`: To prove a property/define a function
+  for all `Fin (n + 1)`, it is enough to prove/define it for `last n` and for `i.castSucc` for all
+  `i : Fin n`. This is defined in Core.
 * `Fin.snoc`: Turn a tuple `f : Fin n → α` and an entry `a : α` into a tuple
   `Fin.snoc f a : Fin (n + 1) → α` by adding `a` at the end. In general, tuples can be dependent
   functions, in which case `f : ∀ i : Fin n, α i.castSucc` and `a : α (last n)`.


### PR DESCRIPTION
Definitions around adding an entry to a `Fin`-indexed tuple are a mess. This PR documents the mess so that it's easier to fix in a later PR.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
