### PR TITLE
[Merged by Bors] - feat(AddChar): Various improvements

### DIFF
--- a/Mathlib/Algebra/Group/AddChar.lean
+++ b/Mathlib/Algebra/Group/AddChar.lean
@@ -155,6 +155,7 @@ def toAddMonoidHom (φ : AddChar A M) : A →+ Additive M where
   map_add' := φ.map_add_eq_mul'
 
 @[simp] lemma coe_toAddMonoidHom (ψ : AddChar A M) : ⇑ψ.toAddMonoidHom = Additive.ofMul ∘ ψ := rfl
+
 @[simp] lemma toAddMonoidHom_apply (ψ : AddChar A M) (a : A) :
     ψ.toAddMonoidHom a = Additive.ofMul (ψ a) := rfl
 
@@ -213,7 +214,7 @@ lemma _root_.MonoidHom.compAddChar_injective_right (f : M →* N) (hf : Injectiv
 
 /-- Composing an `AddChar` with an `AddMonoidHom` yields another `AddChar`. -/
 def compAddMonoidHom (φ : AddChar B M) (f : A →+ B) : AddChar A M :=
-  (toAddMonoidHomEquiv).symm (φ.toAddMonoidHom.comp f)
+  toAddMonoidHomEquiv.symm (φ.toAddMonoidHom.comp f)
 
 @[simp, norm_cast]
 lemma coe_compAddMonoidHom (φ : AddChar B M) (f : A →+ B) : φ.compAddMonoidHom f = φ ∘ f := rfl
@@ -227,7 +228,8 @@ lemma compAddMonoidHom_injective_left (f : A →+ B) (hf : Surjective f) :
 
 lemma compAddMonoidHom_injective_right (ψ : AddChar B M) (hψ : Injective ψ) :
     Injective fun f : A →+ B ↦ ψ.compAddMonoidHom f := by
-  rintro f g h; rw [DFunLike.ext'_iff] at h ⊢; exact hψ.comp_left h
+  rintro f g h
+  rw [DFunLike.ext'_iff] at h ⊢; exact hψ.comp_left h
 
 lemma eq_one_iff : ψ = 1 ↔ ∀ x, ψ x = 1 := DFunLike.ext_iff
 lemma ne_one_iff : ψ ≠ 1 ↔ ∃ x, ψ x ≠ 1 := DFunLike.ne_iff

--- a/Mathlib/Algebra/Group/AddChar.lean
+++ b/Mathlib/Algebra/Group/AddChar.lean
@@ -34,7 +34,7 @@ additive character
 ### Definitions related to and results on additive characters
 -/
 
-open Multiplicative
+open Function Multiplicative
 
 section AddCharDef
 
@@ -74,7 +74,7 @@ namespace AddChar
 section Basic
 -- results which don't require commutativity or inverses
 
-variable {A M : Type*} [AddMonoid A] [Monoid M]
+variable {A B M N : Type*} [AddMonoid A] [AddMonoid B] [Monoid M] [Monoid N] {ψ : AddChar A M}
 
 /-- Define coercion to a function. -/
 instance instFunLike : FunLike (AddChar A M) A M where
@@ -125,7 +125,6 @@ lemma map_nsmul_eq_pow (ψ : AddChar A M) (n : ℕ) (x : A) : ψ (n • x) = ψ 
 
 @[deprecated (since := "2024-06-06")] alias map_nsmul_pow := map_nsmul_eq_pow
 
-variable (A M) in
 /-- Additive characters `A → M` are the same thing as monoid homomorphisms from `Multiplicative A`
 to `M`. -/
 def toMonoidHomEquiv : AddChar A M ≃ (Multiplicative A →* M) where
@@ -137,15 +136,28 @@ def toMonoidHomEquiv : AddChar A M ≃ (Multiplicative A →* M) where
   left_inv _ := rfl
   right_inv _ := rfl
 
+@[simp, norm_cast] lemma coe_toMonoidHomEquiv (ψ : AddChar A M) :
+    ⇑(toMonoidHomEquiv ψ) = ψ ∘ Multiplicative.toAdd := rfl
+
+@[simp, norm_cast] lemma coe_toMonoidHomEquiv_symm (ψ : Multiplicative A →* M) :
+    ⇑(toMonoidHomEquiv.symm ψ) = ψ ∘ Multiplicative.ofAdd := rfl
+
+@[simp] lemma toMonoidHomEquiv_apply (ψ : AddChar A M) (a : Multiplicative A) :
+    toMonoidHomEquiv ψ a = ψ (Multiplicative.toAdd a) := rfl
+
+@[simp] lemma toMonoidHomEquiv_symm_apply (ψ : Multiplicative A →* M) (a : A) :
+    toMonoidHomEquiv.symm ψ a = ψ (Multiplicative.ofAdd a) := rfl
+
 /-- Interpret an additive character as a monoid homomorphism. -/
 def toAddMonoidHom (φ : AddChar A M) : A →+ Additive M where
   toFun := φ.toFun
   map_zero' := φ.map_zero_eq_one'
   map_add' := φ.map_add_eq_mul'
 
-@[simp] lemma toAddMonoidHom_apply (ψ : AddChar A M) (a : A) : ψ.toAddMonoidHom a = ψ a := rfl
+@[simp] lemma coe_toAddMonoidHom (ψ : AddChar A M) : ⇑ψ.toAddMonoidHom = Additive.ofMul ∘ ψ := rfl
+@[simp] lemma toAddMonoidHom_apply (ψ : AddChar A M) (a : A) :
+    ψ.toAddMonoidHom a = Additive.ofMul (ψ a) := rfl
 
-variable (A M) in
 /-- Additive characters `A → M` are the same thing as additive homomorphisms from `A` to
 `Additive M`. -/
 def toAddMonoidHomEquiv : AddChar A M ≃ (A →+ Additive M) where
@@ -157,36 +169,77 @@ def toAddMonoidHomEquiv : AddChar A M ≃ (A →+ Additive M) where
   left_inv _ := rfl
   right_inv _ := rfl
 
-/-- The trivial additive character (sending everything to `1`) is `(1 : AddChar A M).` -/
-instance instOne : One (AddChar A M) := (toMonoidHomEquiv A M).one
+@[simp, norm_cast]
+lemma coe_toAddMonoidHomEquiv (ψ : AddChar A M) :
+    ⇑(toAddMonoidHomEquiv ψ) = Additive.ofMul ∘ ψ := rfl
 
--- Porting note: added
+@[simp, norm_cast] lemma coe_toAddMonoidHomEquiv_symm (ψ : A →+ Additive M) :
+    ⇑(toAddMonoidHomEquiv.symm ψ) = Additive.toMul ∘ ψ := rfl
+
+@[simp] lemma toAddMonoidHomEquiv_apply (ψ : AddChar A M) (a : A) :
+    toAddMonoidHomEquiv ψ a = Additive.ofMul (ψ a) := rfl
+
+@[simp] lemma toAddMonoidHomEquiv_symm_apply (ψ : A →+ Additive M) (a : A) :
+    toAddMonoidHomEquiv.symm ψ a = Additive.toMul (ψ a) := rfl
+
+/-- The trivial additive character (sending everything to `1`) is `(1 : AddChar A M).` -/
+instance instOne : One (AddChar A M) := toMonoidHomEquiv.one
+
+@[simp, norm_cast] lemma coe_one : ⇑(1 : AddChar A M) = 1 := rfl
 @[simp] lemma one_apply (a : A) : (1 : AddChar A M) a = 1 := rfl
 
 instance instInhabited : Inhabited (AddChar A M) := ⟨1⟩
 
 /-- Composing a `MonoidHom` with an `AddChar` yields another `AddChar`. -/
 def _root_.MonoidHom.compAddChar {N : Type*} [Monoid N] (f : M →* N) (φ : AddChar A M) :
-    AddChar A N :=
-  (toMonoidHomEquiv A N).symm (f.comp φ.toMonoidHom)
+    AddChar A N := toMonoidHomEquiv.symm (f.comp φ.toMonoidHom)
 
-@[simp]
+@[simp, norm_cast]
 lemma _root_.MonoidHom.coe_compAddChar {N : Type*} [Monoid N] (f : M →* N) (φ : AddChar A M) :
     f.compAddChar φ = f ∘ φ :=
   rfl
 
-/-- Composing an `AddChar` with an `AddMonoidHom` yields another `AddChar`. -/
-def compAddMonoidHom {B : Type*} [AddMonoid B] (φ : AddChar B M) (f : A →+ B) : AddChar A M :=
-  (toAddMonoidHomEquiv A M).symm (φ.toAddMonoidHom.comp f)
+@[simp, norm_cast]
+lemma _root_.MonoidHom.compAddChar_apply (f : M →* N) (φ : AddChar A M) : f.compAddChar φ = f ∘ φ :=
+  rfl
 
-@[simp] lemma coe_compAddMonoidHom {B : Type*} [AddMonoid B] (φ : AddChar B M) (f : A →+ B) :
-    φ.compAddMonoidHom f = φ ∘ f := rfl
+lemma _root_.MonoidHom.compAddChar_injective_left (ψ : AddChar A M) (hψ : Surjective ψ) :
+    Injective fun f : M →* N ↦ f.compAddChar ψ := by
+  rintro f g h; rw [DFunLike.ext'_iff] at h ⊢; exact hψ.injective_comp_right h
+
+lemma _root_.MonoidHom.compAddChar_injective_right (f : M →* N) (hf : Injective f) :
+    Injective fun ψ : AddChar B M ↦ f.compAddChar ψ := by
+  rintro ψ χ h; rw [DFunLike.ext'_iff] at h ⊢; exact hf.comp_left h
+
+/-- Composing an `AddChar` with an `AddMonoidHom` yields another `AddChar`. -/
+def compAddMonoidHom (φ : AddChar B M) (f : A →+ B) : AddChar A M :=
+  (toAddMonoidHomEquiv).symm (φ.toAddMonoidHom.comp f)
+
+@[simp, norm_cast]
+lemma coe_compAddMonoidHom (φ : AddChar B M) (f : A →+ B) : φ.compAddMonoidHom f = φ ∘ f := rfl
+
+@[simp] lemma compAddMonoidHom_apply (ψ : AddChar B M) (f : A →+ B)
+    (a : A) : ψ.compAddMonoidHom f a = ψ (f a) := rfl
+
+lemma compAddMonoidHom_injective_left (f : A →+ B) (hf : Surjective f) :
+    Injective fun ψ : AddChar B M ↦ ψ.compAddMonoidHom f := by
+  rintro ψ χ h; rw [DFunLike.ext'_iff] at h ⊢; exact hf.injective_comp_right h
+
+lemma compAddMonoidHom_injective_right (ψ : AddChar B M) (hψ : Injective ψ) :
+    Injective fun f : A →+ B ↦ ψ.compAddMonoidHom f := by
+  rintro f g h; rw [DFunLike.ext'_iff] at h ⊢; exact hψ.comp_left h
+
+lemma eq_one_iff : ψ = 1 ↔ ∀ x, ψ x = 1 := DFunLike.ext_iff
+lemma ne_one_iff : ψ ≠ 1 ↔ ∃ x, ψ x ≠ 1 := DFunLike.ne_iff
 
 /-- An additive character is *nontrivial* if it takes a value `≠ 1`. -/
+@[deprecated (since := "2024-06-06")]
 def IsNontrivial (ψ : AddChar A M) : Prop := ∃ a : A, ψ a ≠ 1
 #align add_char.is_nontrivial AddChar.IsNontrivial
 
+set_option linter.deprecated false in
 /-- An additive character is nontrivial iff it is not the trivial character. -/
+@[deprecated ne_one_iff (since := "2024-06-06")]
 lemma isNontrivial_iff_ne_trivial (ψ : AddChar A M) : IsNontrivial ψ ↔ ψ ≠ 1 :=
   not_forall.symm.trans (DFunLike.ext_iff (f := ψ) (g := 1)).symm.not
 
@@ -199,23 +252,21 @@ section toCommMonoid
 variable {A M : Type*} [AddMonoid A] [CommMonoid M]
 
 /-- When `M` is commutative, `AddChar A M` is a commutative monoid. -/
-instance instCommMonoid : CommMonoid (AddChar A M) := (toMonoidHomEquiv A M).commMonoid
+instance instCommMonoid : CommMonoid (AddChar A M) := toMonoidHomEquiv.commMonoid
 
--- Porting note: added
-@[simp] lemma mul_apply (ψ φ : AddChar A M) (a : A) : (ψ * φ) a = ψ a * φ a := rfl
-
-@[simp] lemma pow_apply (ψ : AddChar A M) (n : ℕ) (a : A) : (ψ ^ n) a = (ψ a) ^ n := rfl
-
-variable (A M)
+@[simp, norm_cast] lemma coe_mul (ψ χ : AddChar A M) : ⇑(ψ * χ) = ψ * χ := rfl
+@[simp, norm_cast] lemma coe_pow (ψ : AddChar A M) (n : ℕ) : ⇑(ψ ^ n) = ψ ^ n := rfl
+@[simp, norm_cast] lemma mul_apply (ψ φ : AddChar A M) (a : A) : (ψ * φ) a = ψ a * φ a := rfl
+@[simp, norm_cast] lemma pow_apply (ψ : AddChar A M) (n : ℕ) (a : A) : (ψ ^ n) a = (ψ a) ^ n := rfl
 
 /-- The natural equivalence to `(Multiplicative A →* M)` is a monoid isomorphism. -/
 def toMonoidHomMulEquiv : AddChar A M ≃* (Multiplicative A →* M) :=
-  { toMonoidHomEquiv A M with map_mul' := fun φ ψ ↦ by rfl }
+  { toMonoidHomEquiv with map_mul' := fun φ ψ ↦ by rfl }
 
 /-- Additive characters `A → M` are the same thing as additive homomorphisms from `A` to
 `Additive M`. -/
 def toAddMonoidAddEquiv : Additive (AddChar A M) ≃+ (A →+ Additive M) :=
-  { toAddMonoidHomEquiv A M with map_add' := fun φ ψ ↦ by rfl }
+  { toAddMonoidHomEquiv with map_add' := fun φ ψ ↦ by rfl }
 
 end toCommMonoid
 
@@ -274,6 +325,12 @@ section fromAddGrouptoDivisionCommMonoid
 variable {A M : Type*} [AddCommGroup A] [DivisionCommMonoid M]
 
 lemma inv_apply' (ψ : AddChar A M) (x : A) : ψ⁻¹ x = (ψ x)⁻¹ := by rw [inv_apply, map_neg_eq_inv]
+
+lemma map_sub_eq_div (ψ : AddChar A M) (a b : A) : ψ (a - b) = ψ a / ψ b :=
+  ψ.toMonoidHom.map_div _ _
+
+lemma injective_iff {ψ : AddChar A M} : Injective ψ ↔ ∀ ⦃x⦄, ψ x = 1 → x = 0 :=
+  ψ.toMonoidHom.ker_eq_bot_iff.symm.trans eq_bot_iff
 
 end fromAddGrouptoDivisionCommMonoid
 

--- a/Mathlib/NumberTheory/GaussSum.lean
+++ b/Mathlib/NumberTheory/GaussSum.lean
@@ -92,7 +92,7 @@ variable {R : Type u} [Field R] [Fintype R] {R' : Type v} [CommRing R'] [IsDomai
 
 -- A helper lemma for `gaussSum_mul_gaussSum_eq_card` below
 -- Is this useful enough in other contexts to be public?
-private theorem gaussSum_mul_aux {χ : MulChar R R'} (hχ : IsNontrivial χ) (ψ : AddChar R R')
+private theorem gaussSum_mul_aux {χ : MulChar R R'} (hχ : χ.IsNontrivial) (ψ : AddChar R R')
     (b : R) : ∑ a, χ (a * b⁻¹) * ψ (a - b) = ∑ c, χ c * ψ (b * (c - 1)) := by
   rcases eq_or_ne b 0 with hb | hb
   · -- case `b = 0`
@@ -105,7 +105,7 @@ private theorem gaussSum_mul_aux {χ : MulChar R R'} (hχ : IsNontrivial χ) (ψ
 
 /-- We have `gaussSum χ ψ * gaussSum χ⁻¹ ψ⁻¹ = Fintype.card R`
 when `χ` is nontrivial and `ψ` is primitive (and `R` is a field). -/
-theorem gaussSum_mul_gaussSum_eq_card {χ : MulChar R R'} (hχ : IsNontrivial χ) {ψ : AddChar R R'}
+theorem gaussSum_mul_gaussSum_eq_card {χ : MulChar R R'} (hχ : χ.IsNontrivial) {ψ : AddChar R R'}
     (hψ : IsPrimitive ψ) : gaussSum χ ψ * gaussSum χ⁻¹ ψ⁻¹ = Fintype.card R := by
   simp only [gaussSum, AddChar.inv_apply, Finset.sum_mul, Finset.mul_sum, MulChar.inv_apply']
   conv =>
@@ -124,7 +124,7 @@ theorem gaussSum_mul_gaussSum_eq_card {χ : MulChar R R'} (hχ : IsNontrivial χ
 
 /-- When `χ` is a nontrivial quadratic character, then the square of `gaussSum χ ψ`
 is `χ(-1)` times the cardinality of `R`. -/
-theorem gaussSum_sq {χ : MulChar R R'} (hχ₁ : IsNontrivial χ) (hχ₂ : IsQuadratic χ)
+theorem gaussSum_sq {χ : MulChar R R'} (hχ₁ : χ.IsNontrivial) (hχ₂ : IsQuadratic χ)
     {ψ : AddChar R R'} (hψ : IsPrimitive ψ) : gaussSum χ ψ ^ 2 = χ (-1) * Fintype.card R := by
   rw [pow_two, ← gaussSum_mul_gaussSum_eq_card hχ₁ hψ, hχ₂.inv, mul_rotate']
   congr
@@ -209,7 +209,7 @@ theorem Char.card_pow_char_pow {χ : MulChar R R'} (hχ : IsQuadratic χ) (ψ : 
 /-- When `F` and `F'` are finite fields and `χ : F → F'` is a nontrivial quadratic character,
 then `(χ(-1) * #F)^(#F'/2) = χ(#F')`. -/
 theorem Char.card_pow_card {F : Type*} [Field F] [Fintype F] {F' : Type*} [Field F'] [Fintype F']
-    {χ : MulChar F F'} (hχ₁ : IsNontrivial χ) (hχ₂ : IsQuadratic χ)
+    {χ : MulChar F F'} (hχ₁ : χ.IsNontrivial) (hχ₂ : IsQuadratic χ)
     (hch₁ : ringChar F' ≠ ringChar F) (hch₂ : ringChar F' ≠ 2) :
     (χ (-1) * Fintype.card F) ^ (Fintype.card F' / 2) = χ (Fintype.card F') := by
   obtain ⟨n, hp, hc⟩ := FiniteField.card F (ringChar F)

--- a/Mathlib/NumberTheory/LegendreSymbol/AddCharacter.lean
+++ b/Mathlib/NumberTheory/LegendreSymbol/AddCharacter.lean
@@ -56,20 +56,15 @@ lemma val_mem_rootsOfUnity (φ : AddChar R R') (a : R) (h : 0 < ringChar R) :
 
 /-- An additive character is *primitive* iff all its multiplicative shifts by nonzero
 elements are nontrivial. -/
-def IsPrimitive (ψ : AddChar R R') : Prop :=
-  ∀ a : R, a ≠ 0 → IsNontrivial (mulShift ψ a)
+def IsPrimitive (ψ : AddChar R R') : Prop := ∀ ⦃a : R⦄, a ≠ 0 → mulShift ψ a ≠ 1
 #align add_char.is_primitive AddChar.IsPrimitive
 
 /-- The composition of a primitive additive character with an injective mooid homomorphism
 is also primitive. -/
 lemma IsPrimitive.compMulHom_of_isPrimitive {R'' : Type*} [CommMonoid R''] {φ : AddChar R R'}
     {f : R' →* R''} (hφ : φ.IsPrimitive) (hf : Function.Injective f) :
-    (f.compAddChar φ).IsPrimitive := by
-  intro a a_ne_zero
-  obtain ⟨r, ne_one⟩ := hφ a a_ne_zero
-  rw [mulShift_apply] at ne_one
-  simp only [IsNontrivial, mulShift_apply, f.coe_compAddChar, Function.comp_apply]
-  exact ⟨r, fun H ↦ ne_one <| hf <| f.map_one ▸ H⟩
+    (f.compAddChar φ).IsPrimitive := fun a ha ↦ by
+  simpa [DFunLike.ext_iff] using (MonoidHom.compAddChar_injective_right f hf).ne (hφ ha)
 
 /-- The map associating to `a : R` the multiplicative shift of `ψ` by `a`
 is injective when `ψ` is primitive. -/
@@ -77,10 +72,8 @@ theorem to_mulShift_inj_of_isPrimitive {ψ : AddChar R R'} (hψ : IsPrimitive ψ
     Function.Injective ψ.mulShift := by
   intro a b h
   apply_fun fun x => x * mulShift ψ (-b) at h
-  simp only [mulShift_mul, mulShift_zero, add_right_neg] at h
-  have h₂ := hψ (a + -b)
-  rw [h, isNontrivial_iff_ne_trivial, ← sub_eq_add_neg, sub_ne_zero] at h₂
-  exact not_not.mp fun h => h₂ h rfl
+  simp only [mulShift_mul, mulShift_zero, add_right_neg, mulShift_apply] at h
+  simpa [← sub_eq_add_neg, sub_eq_zero] using (hψ . h)
 #align add_char.to_mul_shift_inj_of_is_primitive AddChar.to_mulShift_inj_of_isPrimitive
 
 -- `AddCommGroup.equiv_direct_sum_zmod_of_fintype`
@@ -88,13 +81,10 @@ theorem to_mulShift_inj_of_isPrimitive {ψ : AddChar R R'} (hψ : IsPrimitive ψ
 -- This could be used to show that the map above is a bijection.
 -- We leave this for a later occasion.
 /-- When `R` is a field `F`, then a nontrivial additive character is primitive -/
-theorem IsNontrivial.isPrimitive {F : Type u} [Field F] {ψ : AddChar F R'} (hψ : IsNontrivial ψ) :
-    IsPrimitive ψ := by
-  intro a ha
-  cases' hψ with x h
-  use a⁻¹ * x
-  rwa [mulShift_apply, mul_inv_cancel_left₀ ha]
-#align add_char.is_nontrivial.is_primitive AddChar.IsNontrivial.isPrimitive
+theorem IsPrimitive.of_ne_one {F : Type u} [Field F] {ψ : AddChar F R'} (hψ : ψ ≠ 1) :
+    IsPrimitive ψ :=
+  fun a ha h ↦ hψ $ by simpa [mulShift_mulShift, ha] using congr_arg (mulShift · a⁻¹) h
+#align add_char.is_nontrivial.is_primitive AddChar.IsPrimitive.of_ne_one
 
 /-- If `r` is not a unit, then `e.mulShift r` is not primitive. -/
 lemma not_isPrimitive_mulShift [Finite R] (e : AddChar R R') {r : R}
@@ -102,8 +92,7 @@ lemma not_isPrimitive_mulShift [Finite R] (e : AddChar R R') {r : R}
   simp only [IsPrimitive, not_forall]
   simp only [isUnit_iff_mem_nonZeroDivisors_of_finite, mem_nonZeroDivisors_iff, not_forall] at hr
   rcases hr with ⟨x, h, h'⟩
-  exact ⟨x, h', by simp only [mulShift_mulShift, mul_comm r, h, mulShift_zero, not_ne_iff,
-    isNontrivial_iff_ne_trivial]⟩
+  exact ⟨x, h', by simp only [mulShift_mulShift, mul_comm r, h, mulShift_zero, not_ne_iff]⟩
 
 /-- Definition for a primitive additive character on a finite ring `R` into a cyclotomic extension
 of a field `R'`. It records which cyclotomic extension it is, the character, and the
@@ -134,7 +123,7 @@ variable {N : ℕ+} {R : Type*} [CommRing R] (e : AddChar (ZMod N) R)
 /-- If `e` is not primitive, then `e.mulShift d = 1` for some proper divisor `d` of `N`. -/
 lemma exists_divisor_of_not_isPrimitive (he : ¬e.IsPrimitive) :
     ∃ d : ℕ, d ∣ N ∧ d < N ∧ e.mulShift d = 1 := by
-  simp_rw [IsPrimitive, not_forall, isNontrivial_iff_ne_trivial, not_ne_iff] at he
+  simp_rw [IsPrimitive, not_forall, not_ne_iff] at he
   rcases he with ⟨b, hb_ne, hb⟩
   -- We have `AddChar.mulShift e b = 1`, but `b ≠ 0`.
   obtain ⟨d, hd, u, hu, rfl⟩ := b.eq_unit_mul_divisor
@@ -174,29 +163,28 @@ theorem zmodChar_apply' {n : ℕ+} {ζ : C} (hζ : ζ ^ (n : ℕ) = 1) (a : ℕ)
 end ZModCharDef
 
 /-- An additive character on `ZMod n` is nontrivial iff it takes a value `≠ 1` on `1`. -/
-theorem zmod_char_isNontrivial_iff (n : ℕ+) (ψ : AddChar (ZMod n) C) :
-    IsNontrivial ψ ↔ ψ 1 ≠ 1 := by
-  refine ⟨?_, fun h => ⟨1, h⟩⟩
+theorem zmod_char_ne_one_iff (n : ℕ+) (ψ : AddChar (ZMod n) C) : ψ ≠ 1 ↔ ψ 1 ≠ 1 := by
+  rw [ne_one_iff]
+  refine ⟨?_, fun h => ⟨_, h⟩⟩
   contrapose!
-  rintro h₁ ⟨a, ha⟩
+  rintro h₁ a
   have ha₁ : a = a.val • (1 : ZMod ↑n) := by
     rw [nsmul_eq_mul, mul_one]; exact (ZMod.natCast_zmod_val a).symm
-  rw [ha₁, map_nsmul_eq_pow, h₁, one_pow] at ha
-  exact ha rfl
-#align add_char.zmod_char_is_nontrivial_iff AddChar.zmod_char_isNontrivial_iff
+  rw [ha₁, map_nsmul_eq_pow, h₁, one_pow]
+#align add_char.zmod_char_is_nontrivial_iff AddChar.zmod_char_ne_one_iff
 
 /-- A primitive additive character on `ZMod n` takes the value `1` only at `0`. -/
 theorem IsPrimitive.zmod_char_eq_one_iff (n : ℕ+) {ψ : AddChar (ZMod n) C} (hψ : IsPrimitive ψ)
     (a : ZMod n) : ψ a = 1 ↔ a = 0 := by
-  refine ⟨fun h => not_imp_comm.mp (hψ a) ?_, fun ha => by rw [ha, map_zero_eq_one]⟩
-  rw [zmod_char_isNontrivial_iff n (mulShift ψ a), mulShift_apply, mul_one, h, Classical.not_not]
+  refine ⟨fun h => not_imp_comm.mp (@hψ a) ?_, fun ha => by rw [ha, map_zero_eq_one]⟩
+  rw [zmod_char_ne_one_iff n (mulShift ψ a), mulShift_apply, mul_one, h, Classical.not_not]
 #align add_char.is_primitive.zmod_char_eq_one_iff AddChar.IsPrimitive.zmod_char_eq_one_iff
 
 /-- The converse: if the additive character takes the value `1` only at `0`,
 then it is primitive. -/
 theorem zmod_char_primitive_of_eq_one_only_at_zero (n : ℕ) (ψ : AddChar (ZMod n) C)
     (hψ : ∀ a, ψ a = 1 → a = 0) : IsPrimitive ψ := by
-  refine fun a ha => (isNontrivial_iff_ne_trivial _).mpr fun hf => ?_
+  refine fun a ha hf => ?_
   have h : mulShift ψ a 1 = (1 : AddChar (ZMod n) C) (1 : ZMod n) :=
     congr_fun (congr_arg (↑) hf) 1
   rw [mulShift_apply, mul_one] at h; norm_cast at h
@@ -248,11 +236,12 @@ noncomputable def FiniteField.primitiveChar (F F' : Type*) [Field F] [Finite F] 
   let ψ := primitiveZModChar pp F' (neZero_iff.mp (NeZero.of_not_dvd F' hp₂))
   letI : Algebra (ZMod p) F := ZMod.algebra _ _
   let ψ' := ψ.char.compAddMonoidHom (Algebra.trace (ZMod p) F).toAddMonoidHom
-  have hψ' : IsNontrivial ψ' := by
+  have hψ' : ψ' ≠ 1 := by
     obtain ⟨a, ha⟩ := FiniteField.trace_to_zmod_nondegenerate F one_ne_zero
     rw [one_mul] at ha
-    exact ⟨a, fun hf => ha <| (ψ.prim.zmod_char_eq_one_iff pp <| Algebra.trace (ZMod p) F a).mp hf⟩
-  exact ⟨ψ.n, ψ', hψ'.isPrimitive⟩
+    exact ne_one_iff.2
+      ⟨a, fun hf => ha <| (ψ.prim.zmod_char_eq_one_iff pp <| Algebra.trace (ZMod p) F a).mp hf⟩
+  exact ⟨ψ.n, ψ', IsPrimitive.of_ne_one hψ'⟩
 #align add_char.primitive_char_finite_field AddChar.FiniteField.primitiveChar
 @[deprecated (since := "2024-05-30")] alias primitiveCharFiniteField := FiniteField.primitiveChar
 
@@ -266,25 +255,20 @@ variable {R : Type*} [AddGroup R] [Fintype R] {R' : Type*} [CommRing R']
 
 /-- The sum over the values of a nontrivial additive character vanishes if the target ring
 is a domain. -/
-theorem sum_eq_zero_of_isNontrivial [IsDomain R'] {ψ : AddChar R R'} (hψ : IsNontrivial ψ) :
-    ∑ a, ψ a = 0 := by
-  rcases hψ with ⟨b, hb⟩
+theorem sum_eq_zero_of_ne_one [IsDomain R'] {ψ : AddChar R R'} (hψ : ψ ≠ 1) : ∑ a, ψ a = 0 := by
+  rcases ne_one_iff.1 hψ with ⟨b, hb⟩
   have h₁ : ∑ a : R, ψ (b + a) = ∑ a : R, ψ a :=
     Fintype.sum_bijective _ (AddGroup.addLeft_bijective b) _ _ fun x => rfl
   simp_rw [map_add_eq_mul] at h₁
   have h₂ : ∑ a : R, ψ a = Finset.univ.sum ↑ψ := rfl
   rw [← Finset.mul_sum, h₂] at h₁
   exact eq_zero_of_mul_eq_self_left hb h₁
-#align add_char.sum_eq_zero_of_is_nontrivial AddChar.sum_eq_zero_of_isNontrivial
+#align add_char.sum_eq_zero_of_is_nontrivial AddChar.sum_eq_zero_of_ne_one
 
 /-- The sum over the values of the trivial additive character is the cardinality of the source. -/
-theorem sum_eq_card_of_is_trivial {ψ : AddChar R R'} (hψ : ¬IsNontrivial ψ) :
-    ∑ a, ψ a = Fintype.card R := by
-  simp only [IsNontrivial] at hψ
-  push_neg at hψ
-  simp only [hψ, Finset.sum_const, Nat.smul_one_eq_cast]
-  rfl
-#align add_char.sum_eq_card_of_is_trivial AddChar.sum_eq_card_of_is_trivial
+theorem sum_eq_card_of_eq_one {ψ : AddChar R R'} (hψ : ψ = 1) :
+    ∑ a, ψ a = Fintype.card R := by simp [hψ]
+#align add_char.sum_eq_card_of_is_trivial AddChar.sum_eq_card_of_eq_one
 
 end sum
 
@@ -299,7 +283,7 @@ theorem sum_mulShift {R : Type*} [CommRing R] [Fintype R] [DecidableEq R]
     rfl
   · -- case `b ≠ 0`
     simp_rw [mul_comm]
-    exact mod_cast sum_eq_zero_of_isNontrivial (hψ b h)
+    exact mod_cast sum_eq_zero_of_ne_one (hψ h)
 #align add_char.sum_mul_shift AddChar.sum_mulShift
 
 /-!

--- a/Mathlib/NumberTheory/LegendreSymbol/AddCharacter.lean
+++ b/Mathlib/NumberTheory/LegendreSymbol/AddCharacter.lean
@@ -83,7 +83,7 @@ theorem to_mulShift_inj_of_isPrimitive {ψ : AddChar R R'} (hψ : IsPrimitive ψ
 /-- When `R` is a field `F`, then a nontrivial additive character is primitive -/
 theorem IsPrimitive.of_ne_one {F : Type u} [Field F] {ψ : AddChar F R'} (hψ : ψ ≠ 1) :
     IsPrimitive ψ :=
-  fun a ha h ↦ hψ $ by simpa [mulShift_mulShift, ha] using congr_arg (mulShift · a⁻¹) h
+  fun a ha h ↦ hψ <| by simpa [mulShift_mulShift, ha] using congr_arg (mulShift · a⁻¹) h
 #align add_char.is_nontrivial.is_primitive AddChar.IsPrimitive.of_ne_one
 
 /-- If `r` is not a unit, then `e.mulShift r` is not primitive. -/


### PR DESCRIPTION
* Add a bunch of missing `simp` and `norm_cast` lemmas.
* Get rid of `IsNontrivial ψ` since it's just `ψ ≠ 1`. This simplifies proofs.
* Remove explicit arguments to `toMonoidHomEquiv`/`toAddMonoidHomEquiv`. We basically never need to provide them explicitly since unification usually does the job.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->
- [x] depends on: #13576

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
