### PR TITLE
[Merged by Bors] - Chore(RingTheory/Regular): Simplify some namespaces in IsSMulRegular

### DIFF
--- a/Mathlib/RingTheory/Regular/RegularSequence.lean
+++ b/Mathlib/RingTheory/Regular/RegularSequence.lean
@@ -579,13 +579,12 @@ private lemma IsWeaklyRegular.swap {a b : R} (h1 : IsWeaklyRegular M [a, b])
   obtain ⟨ha, hb⟩ := h1
   rw [← isSMulRegular_iff_torsionBy_eq_bot] at h2
   specialize h2 (le_antisymm ?_ (smul_le_self_of_tower a (torsionBy R M b)))
-  · refine le_of_eq_of_le ?_ <|
-      IsSMulRegular.smul_top_inf_eq_smul_of_isSMulRegular_on_quot <|
-        ha.of_injective _ <| ker_eq_bot.mp <| ker_liftQ_eq_bot' _ (lsmul R M b) rfl
-    rw [← (IsSMulRegular.isSMulRegular_on_quot_iff_lsmul_comap_eq _ _).mp hb]
+  · refine le_of_eq_of_le ?_ <| smul_top_inf_eq_smul_of_isSMulRegular_on_quot <|
+      ha.of_injective _ <| ker_eq_bot.mp <| ker_liftQ_eq_bot' _ (lsmul R M b) rfl
+    rw [← (isSMulRegular_on_quot_iff_lsmul_comap_eq _ _).mp hb]
     exact (inf_eq_right.mpr (ker_le_comap _)).symm
-  · rwa [ha.isSMulRegular_on_quot_iff_smul_top_inf_eq_smul_of_isSMulRegular, inf_comm, smul_comm,
-      ← h2.isSMulRegular_on_quot_iff_smul_top_inf_eq_smul_of_isSMulRegular, and_iff_left hb]
+  · rwa [ha.isSMulRegular_on_quot_iff_smul_top_inf_eq_smul, inf_comm, smul_comm,
+      ← h2.isSMulRegular_on_quot_iff_smul_top_inf_eq_smul, and_iff_left hb]
 
 -- TODO: Equivalence of permutability of regular sequences to regularity of
 -- subsequences and regularity on poly ring. See [07DW] in stacks project


### PR DESCRIPTION
Simplify some namespaces in `RingTheory/Regular/IsSMulRegular`

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

Minor refactor in line with @jcommelin's review on #12544, removing the `IsSMulRegular` namespace from lemmas that already start with `isSMulRegular`. 
No proofs or definitional equalities are changed in this PR, it only moves blocks of code around and renames some stuff. 

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
