### PR TITLE
[Merged by Bors] - chore(Data/Bool/Basic): deprecate duplicate definitions

### DIFF
--- a/Mathlib/Computability/RegularExpressions.lean
+++ b/Mathlib/Computability/RegularExpressions.lean
@@ -245,7 +245,7 @@ theorem char_rmatch_iff (a : α) (x : List α) : rmatch (char a) x ↔ x = [a] :
 theorem add_rmatch_iff (P Q : RegularExpression α) (x : List α) :
     (P + Q).rmatch x ↔ P.rmatch x ∨ Q.rmatch x := by
   induction' x with _ _ ih generalizing P Q
-  · simp only [rmatch, matchEpsilon, Bool.coe_or_iff]
+  · simp only [rmatch, matchEpsilon, Bool.or_eq_true_iff]
   · repeat rw [rmatch]
     rw [deriv_add]
     exact ih _ _
@@ -259,7 +259,7 @@ theorem mul_rmatch_iff (P Q : RegularExpression α) (x : List α) :
     · intro h
       refine ⟨[], [], rfl, ?_⟩
       rw [rmatch, rmatch]
-      rwa [Bool.coe_and_iff] at h
+      rwa [Bool.and_eq_true_iff] at h
     · rintro ⟨t, u, h₁, h₂⟩
       cases' List.append_eq_nil.1 h₁.symm with ht hu
       subst ht

--- a/Mathlib/Data/Bool/AllAny.lean
+++ b/Mathlib/Data/Bool/AllAny.lean
@@ -3,9 +3,7 @@ Copyright (c) 2017 Mario Carneiro. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Mario Carneiro
 -/
-import Mathlib.Data.Bool.Basic
 import Mathlib.Data.List.Basic
-import Mathlib.Init.Data.Bool.Lemmas
 
 #align_import data.bool.all_any from "leanprover-community/mathlib"@"5a3e819569b0f12cbec59d740a2613018e7b8eec"
 
@@ -29,11 +27,11 @@ namespace List
 theorem all_iff_forall {p : α → Bool} : all l p ↔ ∀ a ∈ l, p a := by
   induction' l with a l ih
   · exact iff_of_true rfl (forall_mem_nil _)
-  simp only [all_cons, Bool.coe_and_iff, ih, forall_mem_cons]
+  simp only [all_cons, Bool.and_eq_true_iff, ih, forall_mem_cons]
 #align list.all_iff_forall List.all_iff_forall
 
 theorem all_iff_forall_prop : (all l fun a => p a) ↔ ∀ a ∈ l, p a := by
-  simp only [all_iff_forall, Bool.of_decide_iff]
+  simp only [all_iff_forall, decide_eq_true_iff]
 #align list.all_iff_forall_prop List.all_iff_forall_prop
 
 -- Porting note: in Batteries
@@ -43,8 +41,8 @@ theorem all_iff_forall_prop : (all l fun a => p a) ↔ ∀ a ∈ l, p a := by
 
 theorem any_iff_exists {p : α → Bool} : any l p ↔ ∃ a ∈ l, p a := by
   induction' l with a l ih
-  · exact iff_of_false Bool.not_false' (not_exists_mem_nil _)
-  simp only [any_cons, Bool.coe_or_iff, ih, exists_mem_cons_iff]
+  · exact iff_of_false Bool.false_ne_true (not_exists_mem_nil _)
+  simp only [any_cons, Bool.or_eq_true_iff, ih, exists_mem_cons_iff]
 #align list.any_iff_exists List.any_iff_exists
 
 theorem any_iff_exists_prop : (any l fun a => p a) ↔ ∃ a ∈ l, p a := by simp [any_iff_exists]

--- a/Mathlib/Data/Bool/Basic.lean
+++ b/Mathlib/Data/Bool/Basic.lean
@@ -21,44 +21,36 @@ bool, boolean, Bool, De Morgan
 
 namespace Bool
 
-theorem decide_True {h} : @decide True h = true :=
-  _root_.decide_eq_true True.intro
-#align bool.to_bool_true Bool.decide_True
+@[deprecated (since := "2024-06-07")] alias decide_True := decide_true_eq_true
+#align bool.to_bool_true decide_true_eq_true
 
-theorem decide_False {h} : @decide False h = false :=
-  _root_.decide_eq_false id
-#align bool.to_bool_false Bool.decide_False
+@[deprecated (since := "2024-06-07")] alias decide_False := decide_false_eq_false
+#align bool.to_bool_false decide_false_eq_false
 
 #align bool.to_bool_coe Bool.decide_coe
 
-theorem coe_decide (p : Prop) [d : Decidable p] : decide p ↔ p :=
-  match d with
-  | isTrue hp => ⟨fun _ ↦ hp, fun _ ↦ rfl⟩
-  | isFalse hnp => ⟨fun h ↦ Bool.noConfusion h, fun hp ↦ (hnp hp).elim⟩
-#align bool.coe_to_bool Bool.coe_decide
+@[deprecated (since := "2024-06-07")] alias coe_decide := decide_eq_true_iff
+#align bool.coe_to_bool decide_eq_true_iff
 
-theorem of_decide_iff {p : Prop} [Decidable p] : decide p ↔ p :=
-  coe_decide p
-#align bool.of_to_bool_iff Bool.of_decide_iff
+@[deprecated decide_eq_true_iff (since := "2024-06-07")]
+alias of_decide_iff := decide_eq_true_iff
+#align bool.of_to_bool_iff decide_eq_true_iff
 
 #align bool.tt_eq_to_bool_iff true_eq_decide_iff
 #align bool.ff_eq_to_bool_iff false_eq_decide_iff
 
-theorem decide_not (p : Prop) [Decidable p] : (decide ¬p) = !(decide p) := by
-  by_cases p <;> simp [*]
-#align bool.to_bool_not Bool.decide_not
+@[deprecated (since := "2024-06-07")] alias decide_not := decide_not
+#align bool.to_bool_not decide_not
 
 #align bool.to_bool_and Bool.decide_and
 #align bool.to_bool_or Bool.decide_or
 
 #align bool.to_bool_eq decide_eq_decide
 
-theorem not_false' : ¬false := nofun
-#align bool.not_ff Bool.not_false'
+@[deprecated (since := "2024-06-07")] alias not_false' := false_ne_true
+#align bool.not_ff Bool.false_ne_true
 
--- Porting note (#10756): new theorem
-theorem eq_iff_eq_true_iff {a b : Bool} : a = b ↔ ((a = true) ↔ (b = true)) := by
-  cases a <;> cases b <;> simp
+@[deprecated (since := "2024-06-07")] alias eq_iff_eq_true_iff := eq_iff_iff
 
 #align bool.default_bool Bool.default_bool
 
@@ -82,15 +74,8 @@ theorem exists_bool {p : Bool → Prop} : (∃ b, p b) ↔ p false ∨ p true :=
   exists_bool' false
 #align bool.exists_bool Bool.exists_bool
 
-/-- If `p b` is decidable for all `b : Bool`, then `∀ b, p b` is decidable -/
-instance decidableForallBool {p : Bool → Prop} [∀ b, Decidable (p b)] : Decidable (∀ b, p b) :=
-  decidable_of_decidable_of_iff forall_bool.symm
-#align bool.decidable_forall_bool Bool.decidableForallBool
-
-/-- If `p b` is decidable for all `b : Bool`, then `∃ b, p b` is decidable -/
-instance decidableExistsBool {p : Bool → Prop} [∀ b, Decidable (p b)] : Decidable (∃ b, p b) :=
-  decidable_of_decidable_of_iff exists_bool.symm
-#align bool.decidable_exists_bool Bool.decidableExistsBool
+#align bool.decidable_forall_bool Bool.instDecidableForallOfDecidablePred
+#align bool.decidable_exists_bool Bool.instDecidableExistsOfDecidablePred
 
 #align bool.cond_eq_ite Bool.cond_eq_ite
 #align bool.cond_to_bool Bool.cond_decide
@@ -101,11 +86,11 @@ theorem not_ne_id : not ≠ id := fun h ↦ false_ne_true <| congrFun h true
 
 #align bool.coe_bool_iff Bool.coe_iff_coe
 
-theorem eq_true_of_ne_false : ∀ {a : Bool}, a ≠ false → a = true := by decide
-#align bool.eq_tt_of_ne_ff Bool.eq_true_of_ne_false
+@[deprecated (since := "2024-06-07")] alias eq_true_of_ne_false := eq_true_of_ne_false
+#align bool.eq_tt_of_ne_ff eq_true_of_ne_false
 
-theorem eq_false_of_ne_true : ∀ {a : Bool}, a ≠ true → a = false := by decide
-#align bool.eq_ff_of_ne_tt Bool.eq_false_of_ne_true
+@[deprecated (since := "2024-06-07")] alias eq_false_of_ne_true := eq_false_of_ne_true
+#align bool.eq_ff_of_ne_tt eq_true_of_ne_false
 
 #align bool.bor_comm Bool.or_comm
 #align bool.bor_assoc Bool.or_assoc
@@ -150,8 +135,8 @@ theorem ne_not {a b : Bool} : a ≠ !b ↔ a = b :=
   not_eq_not
 #align bool.ne_bnot Bool.ne_not
 
-theorem not_ne : ∀ {a b : Bool}, (!a) ≠ b ↔ a = b := not_not_eq
-#align bool.bnot_ne Bool.not_ne
+@[deprecated (since := "2024-06-07")] alias not_ne := not_not_eq
+#align bool.bnot_ne Bool.not_not_eq
 
 lemma not_ne_self : ∀ b : Bool, (!b) ≠ b := by decide
 #align bool.bnot_ne_self Bool.not_ne_self
@@ -202,12 +187,8 @@ theorem xor_iff_ne : ∀ {x y : Bool}, xor x y = true ↔ x ≠ y := by decide
 
 /-! ### De Morgan's laws for booleans-/
 
-attribute [simp] not_and
 #align bool.bnot_band Bool.not_and
-
-attribute [simp] not_or
 #align bool.bnot_bor Bool.not_or
-
 #align bool.bnot_inj Bool.not_inj
 
 instance linearOrder : LinearOrder Bool where
@@ -222,8 +203,6 @@ instance linearOrder : LinearOrder Bool where
   max_def := by decide
   min_def := by decide
 #align bool.linear_order Bool.linearOrder
-
-attribute [simp] Bool.max_eq_or Bool.min_eq_and
 
 #align bool.ff_le Bool.false_le
 #align bool.le_tt Bool.le_true

--- a/Mathlib/Data/Bool/Set.lean
+++ b/Mathlib/Data/Bool/Set.lean
@@ -3,7 +3,6 @@ Copyright (c) 2021 Yury G. Kudryashov. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Yury G. Kudryashov
 -/
-import Mathlib.Data.Bool.Basic
 import Mathlib.Data.Set.Image
 
 #align_import data.bool.set from "leanprover-community/mathlib"@"ed60ee25ed00d7a62a0d1e5808092e1324cee451"

--- a/Mathlib/Data/List/Perm.lean
+++ b/Mathlib/Data/List/Perm.lean
@@ -689,7 +689,7 @@ private theorem DecEq_eq {α : Type*} [DecidableEq α] :
   congr_arg BEq.mk <| by
     funext l₁ l₂
     show (l₁ == l₂) = _
-    rw [Bool.eq_iff_eq_true_iff, @beq_iff_eq _ (_), decide_eq_true_iff]
+    rw [Bool.eq_iff_iff, @beq_iff_eq _ (_), decide_eq_true_iff]
 
 theorem perm_permutations'Aux_comm (a b : α) (l : List α) :
     (permutations'Aux a l).bind (permutations'Aux b) ~

--- a/Mathlib/Data/Nat/Bitwise.lean
+++ b/Mathlib/Data/Nat/Bitwise.lean
@@ -3,7 +3,6 @@ Copyright (c) 2020 Markus Himmel. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Markus Himmel, Alex Keizer
 -/
-import Mathlib.Data.Bool.Basic
 import Mathlib.Data.List.GetD
 import Mathlib.Data.Nat.Bits
 import Mathlib.Algebra.Ring.Nat

--- a/Mathlib/Data/Num/Bitwise.lean
+++ b/Mathlib/Data/Num/Bitwise.lean
@@ -4,7 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Mario Carneiro
 -/
 import Mathlib.Data.Num.Basic
-import Mathlib.Data.Bool.Basic
 import Mathlib.Data.Vector.Basic
 
 #align_import data.num.bitwise from "leanprover-community/mathlib"@"f7fc89d5d5ff1db2d1242c7bb0e9062ce47ef47c"

--- a/Mathlib/Init/Data/Bool/Lemmas.lean
+++ b/Mathlib/Init/Data/Bool/Lemmas.lean
@@ -132,18 +132,15 @@ theorem of_decide_false {p : Prop} [Decidable p] : decide p = false → ¬p :=
   (decide_false_iff p).1
 #align of_to_bool_ff Bool.of_decide_false
 
-theorem decide_congr {p q : Prop} [Decidable p] [Decidable q] (h : p ↔ q) :
-    decide p = decide q := by
-  cases h' : decide q with
-  | false => exact decide_false (mt h.1 <| of_decide_false h')
-  | true => exact decide_true (h.2 <| of_decide_true h')
+theorem decide_congr {p q : Prop} [Decidable p] [Decidable q] (h : p ↔ q) : decide p = decide q :=
+  decide_eq_decide.mpr h
 #align to_bool_congr Bool.decide_congr
 
-theorem coe_or_iff (a b : Bool) : a || b ↔ a ∨ b := by simp
-#align bor_coe_iff Bool.coe_or_iff
+@[deprecated (since := "2024-06-07")] alias coe_or_iff := or_eq_true_iff
+#align bor_coe_iff Bool.or_eq_true_iff
 
-theorem coe_and_iff (a b : Bool) : a && b ↔ a ∧ b := by simp
-#align band_coe_iff Bool.coe_and_iff
+@[deprecated (since := "2024-06-07")] alias coe_and_iff := and_eq_true_iff
+#align band_coe_iff Bool.and_eq_true_iff
 
 theorem coe_xor_iff (a b : Bool) : xor a b ↔ Xor' (a = true) (b = true) := by
   cases a <;> cases b <;> decide


### PR DESCRIPTION
Deprecates theorems in favour of the versions in the Lean repository.

This is actually pretty close to making `Data.Bool.Basic` a leaf file. We'd just need to move the LinearOrder instance elsewhere, and `injective_iff`.