### PR TITLE
[Merged by Bors] - chore(Topology/../Rat): drop a deprecated lemma

### DIFF
--- a/Mathlib/Topology/Instances/Rat.lean
+++ b/Mathlib/Topology/Instances/Rat.lean
@@ -110,9 +110,7 @@ theorem uniformContinuous_abs : UniformContinuous (abs : ℚ → ℚ) :=
 
 instance : TopologicalRing ℚ := inferInstance
 
-@[deprecated continuous_mul]
-protected theorem continuous_mul : Continuous fun p : ℚ × ℚ => p.1 * p.2 := continuous_mul
-#align rat.continuous_mul Rat.continuous_mul
+#align rat.continuous_mul continuous_mul
 
 nonrec theorem totallyBounded_Icc (a b : ℚ) : TotallyBounded (Icc a b) := by
   simpa only [preimage_cast_Icc] using


### PR DESCRIPTION
It was deprecated since I ported this file in #2643

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)