### PR TITLE
[Merged by Bors] - chore: avoid instance names for DMatrix

### DIFF
--- a/Mathlib/Data/Matrix/DMatrix.lean
+++ b/Mathlib/Data/Matrix/DMatrix.lean
@@ -77,42 +77,41 @@ def row {α : n → Type v} (v : ∀ j, α j) : DMatrix Unit n fun _i j => α j
   | _x, y => v y
 #align dmatrix.row DMatrix.row
 
--- Porting note: Old proof is Pi.inhabited.
-instance [inst : ∀ i j, Inhabited (α i j)] : Inhabited (DMatrix m n α) :=
-  ⟨fun i j => (inst i j).default⟩
+instance [∀ i j, Inhabited (α i j)] : Inhabited (DMatrix m n α) :=
+  inferInstanceAs <| Inhabited <| ∀ i j, α i j
 
 instance [∀ i j, Add (α i j)] : Add (DMatrix m n α) :=
-  Pi.instAdd
+  inferInstanceAs <| Add <| ∀ i j, α i j
 
 instance [∀ i j, AddSemigroup (α i j)] : AddSemigroup (DMatrix m n α) :=
-  Pi.addSemigroup
+  inferInstanceAs <| AddSemigroup <| ∀ i j, α i j
 
 instance [∀ i j, AddCommSemigroup (α i j)] : AddCommSemigroup (DMatrix m n α) :=
-  Pi.addCommSemigroup
+  inferInstanceAs <| AddCommSemigroup <| ∀ i j, α i j
 
 instance [∀ i j, Zero (α i j)] : Zero (DMatrix m n α) :=
-  Pi.instZero
+  inferInstanceAs <| Zero <| ∀ i j, α i j
 
 instance [∀ i j, AddMonoid (α i j)] : AddMonoid (DMatrix m n α) :=
-  Pi.addMonoid
+  inferInstanceAs <| AddMonoid <| ∀ i j, α i j
 
 instance [∀ i j, AddCommMonoid (α i j)] : AddCommMonoid (DMatrix m n α) :=
-  Pi.addCommMonoid
+  inferInstanceAs <| AddCommMonoid <| ∀ i j, α i j
 
 instance [∀ i j, Neg (α i j)] : Neg (DMatrix m n α) :=
-  Pi.instNeg
+  inferInstanceAs <| Neg <| ∀ i j, α i j
 
 instance [∀ i j, Sub (α i j)] : Sub (DMatrix m n α) :=
-  Pi.instSub
+  inferInstanceAs <| Sub <| ∀ i j, α i j
 
 instance [∀ i j, AddGroup (α i j)] : AddGroup (DMatrix m n α) :=
-  Pi.addGroup
+  inferInstanceAs <| AddGroup <| ∀ i j, α i j
 
 instance [∀ i j, AddCommGroup (α i j)] : AddCommGroup (DMatrix m n α) :=
-  Pi.addCommGroup
+  inferInstanceAs <| AddCommGroup <| ∀ i j, α i j
 
 instance [∀ i j, Unique (α i j)] : Unique (DMatrix m n α) :=
-  Pi.unique
+  inferInstanceAs <| Unique <| ∀ i j, α i j
 
 instance [∀ i j, Subsingleton (α i j)] : Subsingleton (DMatrix m n α) :=
   inferInstanceAs <| Subsingleton <| ∀ i j, α i j


### PR DESCRIPTION
This should be more robust.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
