### PR TITLE
Lean pr testing 4387

### DIFF
--- a/Mathlib/Analysis/Analytic/CPolynomial.lean
+++ b/Mathlib/Analysis/Analytic/CPolynomial.lean
@@ -259,7 +259,7 @@ theorem HasFiniteFPowerSeriesOnBall.eq_partialSum
     f (x + y) = p.partialSum m y :=
   fun y hy m hm ↦ (hf.hasSum hy).unique (hasSum_sum_of_ne_finset_zero
     (f := fun m => p m (fun _ => y)) (s := Finset.range m)
-    (fun N hN => by simp only [Finset.mem_range, not_lt] at hN
+    (fun N hN => by simp only; simp only [Finset.mem_range, not_lt] at hN
                     rw [hf.finite _ (le_trans hm hN), ContinuousMultilinearMap.zero_apply]))
 
 /-- Variant of the previous result with the variable expressed as `y` instead of `x + y`. -/

--- a/Mathlib/Analysis/Analytic/CPolynomial.lean
+++ b/Mathlib/Analysis/Analytic/CPolynomial.lean
@@ -259,7 +259,7 @@ theorem HasFiniteFPowerSeriesOnBall.eq_partialSum
     f (x + y) = p.partialSum m y :=
   fun y hy m hm ↦ (hf.hasSum hy).unique (hasSum_sum_of_ne_finset_zero
     (f := fun m => p m (fun _ => y)) (s := Finset.range m)
-    (fun N hN => by simp only; simp only [Finset.mem_range, not_lt] at hN
+    (fun N hN => by simp only [Finset.mem_range, not_lt] at hN
                     rw [hf.finite _ (le_trans hm hN), ContinuousMultilinearMap.zero_apply]))
 
 /-- Variant of the previous result with the variable expressed as `y` instead of `x + y`. -/

--- a/Mathlib/Analysis/Analytic/Composition.lean
+++ b/Mathlib/Analysis/Analytic/Composition.lean
@@ -492,7 +492,7 @@ theorem comp_summable_nnreal (q : FormalMultilinearSeries 𝕜 F G) (p : FormalM
           (‖q c.length‖₊ * ∏ i, ‖p (c.blocksFun i)‖₊) * r ^ n :=
         mul_le_mul' (q.compAlongComposition_nnnorm p c) le_rfl
       _ = ‖q c.length‖₊ * rq ^ n * ((∏ i, ‖p (c.blocksFun i)‖₊) * rp ^ n) * r0 ^ n := by
-        simp only [mul_pow]; ring
+        ring
       _ ≤ Cq * Cp ^ n * r0 ^ n := mul_le_mul' (mul_le_mul' A B) le_rfl
       _ = Cq / 4 ^ n := by
         simp only [r0]

--- a/Mathlib/Analysis/Calculus/ContDiff/Bounds.lean
+++ b/Mathlib/Analysis/Calculus/ContDiff/Bounds.lean
@@ -439,8 +439,7 @@ theorem norm_iteratedFDerivWithin_comp_le_aux {Fu Gu : Type u} [NormedAddCommGro
     -- assumption for `g' ∘ f`).
     _ ≤ ∑ i ∈ Finset.range (n + 1), (n.choose i : ℝ) * (i ! * C * D ^ i) * D ^ (n - i + 1) := by
       gcongr with i hi
-      · simp only [mul_assoc (n.choose i : ℝ)]
-        exact I i hi
+      · exact I i hi
       · exact J i
     -- We are left with trivial algebraic manipulations to see that this is smaller than
     -- the claimed bound.

--- a/Mathlib/Analysis/Calculus/UniformLimitsDeriv.lean
+++ b/Mathlib/Analysis/Calculus/UniformLimitsDeriv.lean
@@ -350,8 +350,7 @@ theorem hasFDerivAt_of_tendstoUniformlyOnFilter [NeBot l]
   have : 𝓝 (0 : G) = 𝓝 (0 + 0 + 0) := by simp only [add_zero]
   rw [this]
   refine Tendsto.add (Tendsto.add ?_ ?_) ?_
-  · simp only
-    have := difference_quotients_converge_uniformly hf' hf hfg
+  · have := difference_quotients_converge_uniformly hf' hf hfg
     rw [Metric.tendstoUniformlyOnFilter_iff] at this
     rw [Metric.tendsto_nhds]
     intro ε hε

--- a/Mathlib/Analysis/InnerProductSpace/LinearPMap.lean
+++ b/Mathlib/Analysis/InnerProductSpace/LinearPMap.lean
@@ -257,7 +257,8 @@ theorem _root_.IsSelfAdjoint.dense_domain (hA : IsSelfAdjoint A) : Dense (A.doma
     intro x
     rw [mem_adjoint_domain_iff, ← hA]
     refine (innerSL 𝕜 x).cont.comp ?_
-    simp [adjoint, h, continuous_const]
+    simp only [adjoint, h]
+    exact continuous_const
   simp [h'] at h
 
 end LinearPMap

--- a/Mathlib/Analysis/NormedSpace/Multilinear/Basic.lean
+++ b/Mathlib/Analysis/NormedSpace/Multilinear/Basic.lean
@@ -83,7 +83,6 @@ variable {𝕜 : Type u} {ι : Type v} {ι' : Type v'} {n : ℕ} {E : ι → Typ
   [Fintype ι'] [NontriviallyNormedField 𝕜] [∀ i, SeminormedAddCommGroup (E i)]
   [∀ i, NormedSpace 𝕜 (E i)] [∀ i, SeminormedAddCommGroup (E₁ i)] [∀ i, NormedSpace 𝕜 (E₁ i)]
   [∀ i, SeminormedAddCommGroup (E' i)] [∀ i, NormedSpace 𝕜 (E' i)]
-  [∀ i, SeminormedAddCommGroup (Ei i)] [∀ i, NormedSpace 𝕜 (Ei i)]
   [SeminormedAddCommGroup G] [NormedSpace 𝕜 G] [SeminormedAddCommGroup G'] [NormedSpace 𝕜 G']
 
 /-!
@@ -379,7 +378,7 @@ theorem le_opNorm_mul_pow_card_of_le {b : ℝ} (hm : ‖m‖ ≤ b) :
 
 @[deprecated] alias le_op_norm_mul_pow_card_of_le := le_opNorm_mul_pow_card_of_le -- 2024-02-02
 
-theorem le_opNorm_mul_pow_of_le {Ei : Fin n → Type*} [∀ i, NormedAddCommGroup (Ei i)]
+theorem le_opNorm_mul_pow_of_le {Ei : Fin n → Type*} [∀ i, SeminormedAddCommGroup (Ei i)]
     [∀ i, NormedSpace 𝕜 (Ei i)] (f : ContinuousMultilinearMap 𝕜 Ei G) {m : ∀ i, Ei i} {b : ℝ}
     (hm : ‖m‖ ≤ b) : ‖f m‖ ≤ ‖f‖ * b ^ n := by
   simpa only [Fintype.card_fin] using f.le_opNorm_mul_pow_card_of_le hm

--- a/Mathlib/CategoryTheory/Preadditive/Biproducts.lean
+++ b/Mathlib/CategoryTheory/Preadditive/Biproducts.lean
@@ -947,7 +947,7 @@ def preservesBiproductOfMonoBiproductComparison {f : J → C} [HasBiproduct f]
       (F.mapIso (biproduct.isoProduct f)).inv ≫
         biproductComparison F f ≫ (biproduct.isoProduct _).hom := by
     ext j
-    convert piComparison_comp_π F f j; simp [← Functor.map_comp]
+    convert piComparison_comp_π F f j; simp [← Function.comp_def, ← Functor.map_comp]
   haveI : IsIso (biproductComparison F f) := isIso_of_mono_of_isSplitEpi _
   haveI : IsIso (piComparison F f) := by
     rw [that]

--- a/Mathlib/Combinatorics/SimpleGraph/Triangle/Basic.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Triangle/Basic.lean
@@ -267,7 +267,7 @@ lemma FarFromTriangleFree.lt_half (hG : G.FarFromTriangleFree ε) : ε < 2⁻¹ 
     _ < card α ^ 2 := ?_
   rw [edgeFinset_top, filter_not, card_sdiff (subset_univ _), card_univ, Sym2.card,]
   simp_rw [choose_two_right, Nat.add_sub_cancel, Nat.mul_comm _ (card α),
-    Sym2.isDiag_iff_mem_range_diag, univ_filter_mem_range, mul_tsub,
+    funext (propext <| Sym2.isDiag_iff_mem_range_diag ·), univ_filter_mem_range, mul_tsub,
     Nat.mul_div_cancel' (card α).even_mul_succ_self.two_dvd]
   rw [card_image_of_injective _ Sym2.diag_injective, card_univ, mul_add_one (α := ℕ), two_mul, sq,
     add_tsub_add_eq_tsub_right]

--- a/Mathlib/Data/Finsupp/ToDFinsupp.lean
+++ b/Mathlib/Data/Finsupp/ToDFinsupp.lean
@@ -259,8 +259,7 @@ def finsuppLequivDFinsupp [DecidableEq ι] [Semiring R] [AddCommMonoid M]
 @[simp]
 theorem finsuppLequivDFinsupp_apply_apply [DecidableEq ι] [Semiring R] [AddCommMonoid M]
     [∀ m : M, Decidable (m ≠ 0)] [Module R M] :
-      (↑(finsuppLequivDFinsupp (M := M) R) : (ι →₀ M) → _) = Finsupp.toDFinsupp := by
-       simp only [@LinearEquiv.coe_coe]; rfl
+    (↑(finsuppLequivDFinsupp (M := M) R) : (ι →₀ M) → _) = Finsupp.toDFinsupp := rfl
 
 @[simp]
 theorem finsuppLequivDFinsupp_symm_apply [DecidableEq ι] [Semiring R] [AddCommMonoid M]

--- a/Mathlib/Data/Multiset/Fintype.lean
+++ b/Mathlib/Data/Multiset/Fintype.lean
@@ -227,8 +227,7 @@ theorem Multiset.map_univ_coe (m : Multiset α) :
 @[simp]
 theorem Multiset.map_univ {β : Type*} (m : Multiset α) (f : α → β) :
     ((Finset.univ : Finset m).val.map fun (x : m) ↦ f (x : α)) = m.map f := by
-  erw [← Multiset.map_map]
-  rw [Multiset.map_univ_coe]
+  erw [← Multiset.map_map, Multiset.map_univ_coe]
 #align multiset.map_univ Multiset.map_univ
 
 @[simp]

--- a/Mathlib/Data/Sym/Sym2.lean
+++ b/Mathlib/Data/Sym/Sym2.lean
@@ -470,8 +470,7 @@ theorem IsDiag.mem_range_diag {z : Sym2 α} : IsDiag z → z ∈ Set.range (@dia
   exact ⟨_, rfl⟩
 #align sym2.is_diag.mem_range_diag Sym2.IsDiag.mem_range_diag
 
-theorem
-isDiag_iff_mem_range_diag (z : Sym2 α) : IsDiag z ↔ z ∈ Set.range (@diag α) :=
+theorem isDiag_iff_mem_range_diag (z : Sym2 α) : IsDiag z ↔ z ∈ Set.range (@diag α) :=
   ⟨IsDiag.mem_range_diag, fun ⟨i, hi⟩ => hi ▸ diag_isDiag i⟩
 #align sym2.is_diag_iff_mem_range_diag Sym2.isDiag_iff_mem_range_diag
 

--- a/Mathlib/Data/Sym/Sym2.lean
+++ b/Mathlib/Data/Sym/Sym2.lean
@@ -470,7 +470,8 @@ theorem IsDiag.mem_range_diag {z : Sym2 α} : IsDiag z → z ∈ Set.range (@dia
   exact ⟨_, rfl⟩
 #align sym2.is_diag.mem_range_diag Sym2.IsDiag.mem_range_diag
 
-theorem isDiag_iff_mem_range_diag (z : Sym2 α) : IsDiag z ↔ z ∈ Set.range (@diag α) :=
+theorem
+isDiag_iff_mem_range_diag (z : Sym2 α) : IsDiag z ↔ z ∈ Set.range (@diag α) :=
   ⟨IsDiag.mem_range_diag, fun ⟨i, hi⟩ => hi ▸ diag_isDiag i⟩
 #align sym2.is_diag_iff_mem_range_diag Sym2.isDiag_iff_mem_range_diag
 

--- a/Mathlib/FieldTheory/PrimitiveElement.lean
+++ b/Mathlib/FieldTheory/PrimitiveElement.lean
@@ -62,7 +62,6 @@ theorem exists_primitive_element_of_finite_top [Finite E] : ∃ α : E, F⟮α�
   · rw [hx]
     exact F⟮α.val⟯.zero_mem
   · obtain ⟨n, hn⟩ := Set.mem_range.mp (hα (Units.mk0 x hx))
-    simp only at hn
     rw [show x = α ^ n by norm_cast; rw [hn, Units.val_mk0]]
     exact zpow_mem (mem_adjoin_simple_self F (E := E) ↑α) n
 #align field.exists_primitive_element_of_finite_top Field.exists_primitive_element_of_finite_top

--- a/Mathlib/Geometry/Manifold/ContMDiff/Basic.lean
+++ b/Mathlib/Geometry/Manifold/ContMDiff/Basic.lean
@@ -374,7 +374,8 @@ theorem ContMDiff.extend_one [T2Space M] [One M'] {n : ℕ∞} {U : Opens M} {f 
   refine contMDiff_of_mulTSupport (fun x h ↦ ?_) _
   lift x to U using Subtype.coe_image_subset _ _
     (supp.mulTSupport_extend_one_subset continuous_subtype_val h)
-  rw [← contMdiffAt_subtype_iff, ← comp_def, extend_comp Subtype.val_injective]
+  rw [← contMdiffAt_subtype_iff, ← comp_def]
+  erw [ extend_comp Subtype.val_injective]
   exact diff.contMDiffAt
 
 theorem contMDiff_inclusion {n : ℕ∞} {U V : Opens M} (h : U ≤ V) :

--- a/Mathlib/Geometry/Manifold/Instances/Real.lean
+++ b/Mathlib/Geometry/Manifold/Instances/Real.lean
@@ -126,8 +126,8 @@ def modelWithCornersEuclideanHalfSpace (n : ℕ) [Zero (Fin n)] :
         uniqueDiffOn_Ici 0
     simpa only [singleton_pi] using this
   continuous_toFun := continuous_subtype_val
-  continuous_invFun :=
-    (continuous_id.update 0 <| (continuous_apply 0).max continuous_const).subtype_mk _
+  continuous_invFun := by
+    exact (continuous_id.update 0 <| (continuous_apply 0).max continuous_const).subtype_mk _
 #align model_with_corners_euclidean_half_space modelWithCornersEuclideanHalfSpace
 
 /--

--- a/Mathlib/Logic/Basic.lean
+++ b/Mathlib/Logic/Basic.lean
@@ -1200,7 +1200,7 @@ theorem dite_eq_iff : dite P A B = c ↔ (∃ h, A h = c) ∨ ∃ h, B h = c := 
 #align dite_eq_iff dite_eq_iff
 
 theorem ite_eq_iff : ite P a b = c ↔ P ∧ a = c ∨ ¬P ∧ b = c :=
-  dite_eq_iff.trans <| by simp only; rw [exists_prop, exists_prop]
+  dite_eq_iff.trans <| by rw [exists_prop, exists_prop]
 #align ite_eq_iff ite_eq_iff
 
 theorem eq_ite_iff : a = ite P b c ↔ P ∧ a = b ∨ ¬P ∧ a = c :=
@@ -1229,11 +1229,11 @@ theorem dite_ne_right_iff : (dite P A fun _ ↦ b) ≠ b ↔ ∃ h, A h ≠ b :=
 #align dite_ne_right_iff dite_ne_right_iff
 
 theorem ite_ne_left_iff : ite P a b ≠ a ↔ ¬P ∧ a ≠ b :=
-  dite_ne_left_iff.trans <| by simp only; rw [exists_prop]
+  dite_ne_left_iff.trans <| by rw [exists_prop]
 #align ite_ne_left_iff ite_ne_left_iff
 
 theorem ite_ne_right_iff : ite P a b ≠ b ↔ P ∧ a ≠ b :=
-  dite_ne_right_iff.trans <| by simp only; rw [exists_prop]
+  dite_ne_right_iff.trans <| by rw [exists_prop]
 #align ite_ne_right_iff ite_ne_right_iff
 
 protected theorem Ne.dite_eq_left_iff (h : ∀ h, a ≠ B h) : dite P (fun _ ↦ a) B = a ↔ P :=

--- a/Mathlib/MeasureTheory/Constructions/Pi.lean
+++ b/Mathlib/MeasureTheory/Constructions/Pi.lean
@@ -103,7 +103,7 @@ theorem generateFrom_pi_eq {C : ∀ i, Set (Set (α i))} (hC : ∀ i, IsCountabl
   cases nonempty_encodable ι
   apply le_antisymm
   · refine iSup_le ?_; intro i; rw [comap_generateFrom]
-    apply generateFrom_le; rintro _ ⟨s, hs, rfl⟩; dsimp
+    apply generateFrom_le; rintro _ ⟨s, hs, rfl⟩
     choose t h1t h2t using hC
     simp_rw [eval_preimage, ← h2t]
     rw [← @iUnion_const _ ℕ _ s]

--- a/Mathlib/MeasureTheory/Decomposition/Lebesgue.lean
+++ b/Mathlib/MeasureTheory/Decomposition/Lebesgue.lean
@@ -847,7 +847,8 @@ theorem haveLebesgueDecomposition_of_finiteMeasure [IsFiniteMeasure μ] [IsFinit
         refine tendsto_of_tendsto_of_tendsto_of_le_of_le hg₂ tendsto_const_nhds ?_ ?_
         · intro n; rw [← hf₂ n]
           apply lintegral_mono
-          simp only [iSup_apply, iSup_le_le f n n le_rfl]
+          convert iSup_le_le f n n le_rfl
+          simp only [iSup_apply]
         · intro n
           exact le_sSup ⟨⨆ (k : ℕ) (_ : k ≤ n), f k, iSup_mem_measurableLE' _ hf₁ _, rfl⟩
       · intro n

--- a/Mathlib/MeasureTheory/Decomposition/RadonNikodym.lean
+++ b/Mathlib/MeasureTheory/Decomposition/RadonNikodym.lean
@@ -235,7 +235,6 @@ lemma rnDeriv_add_right_of_mutuallySingular' {ν' : Measure α}
   have h₁ := rnDeriv_add' (μ.singularPart ν) (ν.withDensity (μ.rnDeriv ν)) (ν + ν')
   have h₂ := rnDeriv_add' (μ.singularPart ν) (ν.withDensity (μ.rnDeriv ν)) ν
   refine (Filter.EventuallyEq.trans (h_ac.ae_le h₁) ?_).trans h₂.symm
-  simp only [Pi.add_apply]
   have h₃ := rnDeriv_add_right_of_absolutelyContinuous_of_mutuallySingular
     (withDensity_absolutelyContinuous ν (μ.rnDeriv ν)) hνν'
   have h₄ : (μ.singularPart ν).rnDeriv (ν + ν') =ᵐ[ν] 0 := by
@@ -244,7 +243,8 @@ lemma rnDeriv_add_right_of_mutuallySingular' {ν' : Measure α}
     exact ⟨mutuallySingular_singularPart μ ν, hμν'.singularPart ν⟩
   have h₅ : (μ.singularPart ν).rnDeriv ν =ᵐ[ν] 0 := rnDeriv_singularPart μ ν
   filter_upwards [h₃, h₄, h₅] with x hx₃ hx₄ hx₅
-  rw [hx₃, hx₄, Pi.add_apply, hx₅]
+  simp only [Pi.add_apply]
+  rw [hx₃, hx₄, hx₅]
 
 lemma rnDeriv_add_right_of_mutuallySingular {ν' : Measure α}
     [SigmaFinite μ] [SigmaFinite ν] [SigmaFinite ν'] (hνν' : ν ⟂ₘ ν') :

--- a/Mathlib/MeasureTheory/Integral/Bochner.lean
+++ b/Mathlib/MeasureTheory/Integral/Bochner.lean
@@ -662,8 +662,8 @@ def integralCLM : (α →₁[μ] E) →L[ℝ] E :=
 
 -- Porting note: added `(E := E)` in several places below.
 /-- The Bochner integral in L1 space -/
-irreducible_def integral (f : α →₁[μ] E) : E :=
-  integralCLM (E := E) f
+irreducible_def integral : (α →₁[μ] E) → E :=
+  integralCLM (E := E)
 #align measure_theory.L1.integral MeasureTheory.L1.integral
 
 theorem integral_eq (f : α →₁[μ] E) : integral f = integralCLM (E := E) f := by

--- a/Mathlib/MeasureTheory/Integral/CircleTransform.lean
+++ b/Mathlib/MeasureTheory/Integral/CircleTransform.lean
@@ -76,7 +76,7 @@ theorem continuous_circleTransform {R : ℝ} (hR : 0 < R) {f : ℂ → E} {z w :
     (hf : ContinuousOn f <| sphere z R) (hw : w ∈ ball z R) :
     Continuous (circleTransform R z w f) := by
   apply_rules [Continuous.smul, continuous_const]
-  · simp_rw [deriv_circleMap]
+  · rw [funext <| deriv_circleMap _ _]
     apply_rules [Continuous.mul, continuous_circleMap 0 R, continuous_const]
   · exact continuous_circleMap_inv hw
   · apply ContinuousOn.comp_continuous hf (continuous_circleMap z R)

--- a/Mathlib/NumberTheory/Harmonic/GammaDeriv.lean
+++ b/Mathlib/NumberTheory/Harmonic/GammaDeriv.lean
@@ -140,8 +140,9 @@ lemma hasDerivAt_Gamma_one_half : HasDerivAt Gamma (-√π * (γ + 2 * log 2)) (
     have := HasDerivAt.rpow (hasDerivAt_const (1 / 2 : ℝ) (2 : ℝ))
       (?_ : HasDerivAt (fun s : ℝ ↦ 1 - 2 * s) (-2) (1 / 2)) two_pos
     · norm_num at this; exact this
+    simp_rw [mul_comm (2 : ℝ) _]
     apply HasDerivAt.const_sub
-    simpa only [mul_comm (2 : ℝ) _] using hasDerivAt_mul_const (2 : ℝ)
+    exact hasDerivAt_mul_const (2 : ℝ)
   _ = -√π * (γ + 2 * log 2) := by ring
 
 end Real

--- a/Mathlib/NumberTheory/ModularForms/JacobiTheta/Bounds.lean
+++ b/Mathlib/NumberTheory/ModularForms/JacobiTheta/Bounds.lean
@@ -159,7 +159,8 @@ lemma F_nat_one_le {a : ℝ} (ha : 0 ≤ a) {t : ℝ} (ht : 0 < t) :
     ‖F_nat 1 a t‖ ≤ rexp (-π * (a ^ 2 + 1) * t) / (1 - rexp (-π * t)) ^ 2
       + a * rexp (-π * a ^ 2 * t) / (1 - rexp (-π * t)) := by
   refine tsum_of_norm_bounded ?_ (f_le_g_nat 1 ha ht)
-  simp_rw [g_nat, pow_one, add_mul]
+  unfold g_nat
+  simp_rw [pow_one, add_mul]
   apply HasSum.add
   · have h0' : ‖rexp (-π * t)‖ < 1 := by
       simpa only [norm_eq_abs, abs_exp] using exp_lt_aux ht

--- a/Mathlib/Order/CompleteBooleanAlgebra.lean
+++ b/Mathlib/Order/CompleteBooleanAlgebra.lean
@@ -137,7 +137,7 @@ instance (priority := 100) CompletelyDistribLattice.toCompleteDistribLattice
   inf_sSup_le_iSup_inf a s := calc
     _ = ⨅ x : Bool, ⨆ y : cond x PUnit s, match x with | true => a | false => y.1 := by
       simp_rw [iInf_bool_eq, cond, iSup_const, iSup_subtype, sSup_eq_iSup]
-    _ = _ := iInf_iSup_eq
+    _ = _ := by exact iInf_iSup_eq
     _ ≤ _ := by
       simp_rw [iInf_bool_eq]
       refine iSup_le fun g => le_trans ?_ (le_iSup _ (g false).1)

--- a/Mathlib/Order/Filter/ENNReal.lean
+++ b/Mathlib/Order/Filter/ENNReal.lean
@@ -54,7 +54,7 @@ theorem limsup_const_mul [CountableInterFilter f] {u : α → ℝ≥0∞} {a : �
   push_neg at ha_top
   by_cases hu : u =ᶠ[f] 0
   · have hau : (a * u ·) =ᶠ[f] 0 := hu.mono fun x hx => by simp [hx]
-    simp only [limsup_congr hu, limsup_congr hau, Pi.zero_apply, ← ENNReal.bot_eq_zero,
+    simp only [limsup_congr hu, limsup_congr hau, Pi.zero_def, ← ENNReal.bot_eq_zero,
       limsup_const_bot]
     simp
   · have hu_mul : ∃ᶠ x : α in f, ⊤ ≤ ite (u x = 0) (0 : ℝ≥0∞) ⊤ := by

--- a/Mathlib/Probability/Distributions/Gaussian.lean
+++ b/Mathlib/Probability/Distributions/Gaussian.lean
@@ -291,9 +291,8 @@ lemma gaussianReal_map_const_mul (c : ℝ) :
     exact fun _ ↦ HasDerivAt.const_mul _ (hasDerivAt_id _)
   change (gaussianReal μ v).map e.symm = gaussianReal (c * μ) (⟨c^2, sq_nonneg _⟩ * v)
   ext s' hs'
-  rw [MeasurableEquiv.gaussianReal_map_symm_apply hv e he' hs']
-  simp only [MeasurableEquiv.coe_mk, Equiv.coe_fn_mk, ne_eq, mul_eq_zero]
-  rw [gaussianReal_apply_eq_integral _ _ s']
+  rw [MeasurableEquiv.gaussianReal_map_symm_apply hv e he' hs',
+    gaussianReal_apply_eq_integral _ _ s']
   swap
   · simp only [ne_eq, mul_eq_zero, hv, or_false]
     rw [← NNReal.coe_inj]

--- a/Mathlib/Probability/Variance.lean
+++ b/Mathlib/Probability/Variance.lean
@@ -338,7 +338,7 @@ theorem IndepFun.variance_sum [@IsProbabilityMeasure Ω _ ℙ] {ι : Type*} {X :
           exact memℒp_finset_sum' _ fun i hi => hs _ (mem_insert_of_mem hi)
       · rw [mul_assoc]
         apply Integrable.const_mul _ (2 : ℝ)
-        simp only [mul_sum, sum_apply, Pi.mul_apply]
+        rw [mul_sum, sum_fn]
         apply integrable_finset_sum _ fun i hi => ?_
         apply IndepFun.integrable_mul _ (Memℒp.integrable one_le_two (hs _ (mem_insert_self _ _)))
           (Memℒp.integrable one_le_two (hs _ (mem_insert_of_mem hi)))

--- a/Mathlib/RingTheory/MvPowerSeries/Basic.lean
+++ b/Mathlib/RingTheory/MvPowerSeries/Basic.lean
@@ -135,7 +135,6 @@ theorem coeff_monomial [DecidableEq σ] (m n : σ →₀ ℕ) (a : R) :
     coeff R m (monomial R n a) = if m = n then a else 0 := by
   -- This used to be `rw`, but we need `erw` after leanprover/lean4#2644
   erw [coeff, monomial_def, LinearMap.proj_apply (i := m)]
-  dsimp only
   -- This used to be `rw`, but we need `erw` after leanprover/lean4#2644
   erw [LinearMap.stdBasis_apply, Function.update_apply, Pi.zero_apply]
 #align mv_power_series.coeff_monomial MvPowerSeries.coeff_monomial

--- a/Mathlib/RingTheory/WittVector/Verschiebung.lean
+++ b/Mathlib/RingTheory/WittVector/Verschiebung.lean
@@ -190,8 +190,8 @@ theorem bind₁_verschiebungPoly_wittPolynomial (n : ℕ) :
     calc
       _ = ghostComponent (n + 1) (verschiebung <| mk p x) := by
        apply eval₂Hom_congr (RingHom.ext_int _ _) _ rfl
-       simp only [← aeval_verschiebungPoly, coeff_mk]
        funext k
+       simp only [← aeval_verschiebungPoly]
        exact eval₂Hom_congr (RingHom.ext_int _ _) rfl rfl
       _ = _ := by rw [ghostComponent_verschiebung]; rfl
 #align witt_vector.bind₁_verschiebung_poly_witt_polynomial WittVector.bind₁_verschiebungPoly_wittPolynomial

--- a/Mathlib/Topology/Algebra/GroupCompletion.lean
+++ b/Mathlib/Topology/Algebra/GroupCompletion.lean
@@ -280,7 +280,7 @@ theorem AddMonoidHom.completion_zero :
   ext x
   refine Completion.induction_on x ?_ ?_
   · apply isClosed_eq (AddMonoidHom.continuous_completion (0 : α →+ β) continuous_const)
-    simp [continuous_const]
+    exact continuous_const
   · intro a
     simp [(0 : α →+ β).completion_coe continuous_const, coe_zero]
 #align add_monoid_hom.completion_zero AddMonoidHom.completion_zero

--- a/Mathlib/Topology/Algebra/InfiniteSum/Basic.lean
+++ b/Mathlib/Topology/Algebra/InfiniteSum/Basic.lean
@@ -499,7 +499,7 @@ theorem Function.Injective.tprod_eq {g : γ → β} (hg : Injective g) {f : β �
   · have hf_fin' : ¬ Set.Finite (mulSupport (f ∘ g)) := by
       rwa [this, Set.finite_image_iff hg.injOn] at hf_fin
     simp_rw [tprod_def, if_neg hf_fin, if_neg hf_fin', Multipliable,
-      hg.hasProd_iff (mulSupport_subset_iff'.1 hf)]
+      funext fun a => propext <| hg.hasProd_iff (mulSupport_subset_iff'.1 hf) (a := a)]
 
 @[to_additive]
 theorem Equiv.tprod_eq (e : γ ≃ β) (f : β → α) : ∏' c, f (e c) = ∏' b, f b :=

--- a/Mathlib/Topology/ContinuousFunction/Ideals.lean
+++ b/Mathlib/Topology/ContinuousFunction/Ideals.lean
@@ -417,7 +417,8 @@ def continuousMapEval : C(X, characterSpace 𝕜 C(X, 𝕜)) where
         map_smul' := fun z f => rfl
         cont := continuous_eval_const x }, by
         rw [CharacterSpace.eq_set_map_one_map_mul]; exact ⟨rfl, fun f g => rfl⟩⟩
-  continuous_toFun := by exact Continuous.subtype_mk (continuous_of_continuous_eval map_continuous) _
+  continuous_toFun := by
+    exact Continuous.subtype_mk (continuous_of_continuous_eval map_continuous) _
 #align weak_dual.character_space.continuous_map_eval WeakDual.CharacterSpace.continuousMapEval
 
 @[simp]

--- a/Mathlib/Topology/ContinuousFunction/Ideals.lean
+++ b/Mathlib/Topology/ContinuousFunction/Ideals.lean
@@ -417,7 +417,7 @@ def continuousMapEval : C(X, characterSpace 𝕜 C(X, 𝕜)) where
         map_smul' := fun z f => rfl
         cont := continuous_eval_const x }, by
         rw [CharacterSpace.eq_set_map_one_map_mul]; exact ⟨rfl, fun f g => rfl⟩⟩
-  continuous_toFun := Continuous.subtype_mk (continuous_of_continuous_eval map_continuous) _
+  continuous_toFun := by exact Continuous.subtype_mk (continuous_of_continuous_eval map_continuous) _
 #align weak_dual.character_space.continuous_map_eval WeakDual.CharacterSpace.continuousMapEval
 
 @[simp]

--- a/Mathlib/Topology/UniformSpace/Completion.lean
+++ b/Mathlib/Topology/UniformSpace/Completion.lean
@@ -194,9 +194,7 @@ theorem denseRange_pureCauchy : DenseRange (pureCauchy : α → CauchyFilter α)
   simp only [closure_eq_cluster_pts, ClusterPt, nhds_eq_uniformity, lift'_inf_principal_eq,
     Set.inter_comm _ (range pureCauchy), mem_setOf_eq]
   refine (lift'_neBot_iff ?_).mpr (fun s hs => ?_)
-  · refine monotone_const.inter ?_
-    simp_rw [UniformSpace.ball]
-    exact monotone_preimage
+  · exact monotone_const.inter monotone_preimage
   · let ⟨y, hy⟩ := h_ex s hs
     have : pureCauchy y ∈ range pureCauchy ∩ { y : CauchyFilter α | (f, y) ∈ s } :=
       ⟨mem_range_self y, hy⟩

--- a/lake-manifest.json
+++ b/lake-manifest.json
@@ -7,7 +7,7 @@
    "rev": "fb81a8f059f2dd78216229798e8a5285f1f095a2",
    "name": "batteries",
    "manifestFile": "lake-manifest.json",
-   "inputRev": "nightly-testing",
+   "inputRev": "nightly-testing-2024-06-06",
    "inherited": false,
    "configFile": "lakefile.lean"},
   {"url": "https://github.com/leanprover-community/quote4",

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -21,7 +21,7 @@ package mathlib where
 meta if get_config? doc = some "on" then -- do not download and build doc-gen4 by default
 require «doc-gen4» from git "https://github.com/leanprover/doc-gen4" @ "main"
 
-require batteries from git "https://github.com/leanprover-community/batteries" @ "nightly-testing"
+require batteries from git "https://github.com/leanprover-community/batteries" @ "nightly-testing-2024-06-06"
 require Qq from git "https://github.com/leanprover-community/quote4" @ "nightly-testing"
 require aesop from git "https://github.com/leanprover-community/aesop" @ "nightly-testing"
 require proofwidgets from git "https://github.com/leanprover-community/ProofWidgets4" @ "v0.0.36"

--- a/lean-toolchain
+++ b/lean-toolchain
@@ -1,1 +1,1 @@
-leanprover/lean4:nightly-2024-06-06
+leanprover/lean4-pr-releases:pr-release-4387


### PR DESCRIPTION
Made a fix to unification that removes some silly eta-unreduced terms from unification. Some proofs break because they used to need to some eta or beta reduction.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
