### PR TITLE
[Merged by Bors] - feat(CategoryTheory/Sites): reflecting and preserving local injectivity and surjectivity

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -1631,6 +1631,7 @@ import Mathlib.CategoryTheory.Sites.OneHypercover
 import Mathlib.CategoryTheory.Sites.Over
 import Mathlib.CategoryTheory.Sites.Plus
 import Mathlib.CategoryTheory.Sites.Preserves
+import Mathlib.CategoryTheory.Sites.PreservesLocallyBijective
 import Mathlib.CategoryTheory.Sites.PreservesSheafification
 import Mathlib.CategoryTheory.Sites.Pretopology
 import Mathlib.CategoryTheory.Sites.Pullback

--- a/Mathlib/CategoryTheory/Sites/PreservesLocallyBijective.lean
+++ b/Mathlib/CategoryTheory/Sites/PreservesLocallyBijective.lean
@@ -1,0 +1,78 @@
+/-
+Copyright (c) 2024 Dagur Asgeirsson. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Dagur Asgeirsson
+-/
+import Mathlib.CategoryTHeory.Sites.DenseSubsite
+import Mathlib.CategoryTheory.Sites.LocallySurjective
+/-!
+
+# Preserving and reflecting local injectivity and surjectivity
+
+This file proves that precomposition with a cocontinuous functor preserves local injectivity and
+surjectivity of morphisms of presheaves, and that precomposition with a cover preserving and cover
+dense functor reflects the same properties.
+-/
+
+open CategoryTheory Functor
+
+variable {C D A : Type*} [Category C] [Category D] [Category A]
+  (J : GrothendieckTopology C) (K : GrothendieckTopology D)
+  (H : C ⥤ D) {F G : Dᵒᵖ ⥤ A} (f : F ⟶ G)
+
+namespace CategoryTheory
+
+namespace Presheaf
+
+variable [ConcreteCategory A]
+
+lemma isLocallyInjective_whisker [H.IsCocontinuous J K] [IsLocallyInjective K f] :
+    IsLocallyInjective J (whiskerLeft H.op f) where
+  equalizerSieve_mem x y h := H.cover_lift J K (equalizerSieve_mem K f x y h)
+
+lemma isLocallyInjective_of_whisker (hH : CoverPreserving J K H)
+    [H.IsCoverDense K] [IsLocallyInjective J (whiskerLeft H.op f)] : IsLocallyInjective K f where
+  equalizerSieve_mem {X} a b h := by
+    apply K.transitive (H.is_cover_of_isCoverDense K X.unop)
+    intro Y g ⟨⟨Z, lift, map, fac⟩⟩
+    rw [← fac, Sieve.pullback_comp]
+    apply K.pullback_stable
+    refine K.superset_covering (Sieve.functorPullback_pushforward_le H _) ?_
+    refine K.superset_covering (Sieve.functorPushforward_monotone H _ ?_)
+      (hH.cover_preserve <| equalizerSieve_mem J (whiskerLeft H.op f)
+        ((forget A).map (F.map map.op) a) ((forget A).map (F.map map.op) b) ?_)
+    · intro W q hq
+      simpa using hq
+    · simp only [comp_obj, op_obj, whiskerLeft_app, Opposite.op_unop]
+      erw [NatTrans.naturality_apply, NatTrans.naturality_apply, h]
+
+lemma isLocallyInjective_iff_whisker (hH : CoverPreserving J K H) [H.IsCocontinuous J K]
+    [H.IsCoverDense K] : IsLocallyInjective K f ↔ IsLocallyInjective J (whiskerLeft H.op f) :=
+  ⟨fun _ ↦ isLocallyInjective_whisker J K H f,
+    fun _ ↦ isLocallyInjective_of_whisker J K H f hH⟩
+
+lemma isLocallySurjective_whisker [H.IsCocontinuous J K] [IsLocallySurjective K f] :
+    IsLocallySurjective J (whiskerLeft H.op f) where
+  imageSieve_mem a := H.cover_lift J K (imageSieve_mem K f a)
+
+lemma isLocallySurjective_of_whisker (hH : CoverPreserving J K H)
+    [H.IsCoverDense K] [IsLocallySurjective J (whiskerLeft H.op f)] : IsLocallySurjective K f where
+  imageSieve_mem {X} a := by
+    apply K.transitive (H.is_cover_of_isCoverDense K X)
+    intro Y g ⟨⟨Z, lift, map, fac⟩⟩
+    rw [← fac, Sieve.pullback_comp]
+    apply K.pullback_stable
+    have hh := hH.cover_preserve <|
+      imageSieve_mem J (whiskerLeft H.op f) ((forget A).map (G.map map.op) a)
+    refine K.superset_covering (Sieve.functorPullback_pushforward_le H _) ?_
+    refine K.superset_covering (Sieve.functorPushforward_monotone H _ ?_) hh
+    intro W q ⟨x, h⟩
+    simp only [Sieve.functorPullback_apply, Presieve.functorPullback_mem, Sieve.pullback_apply]
+    exact ⟨x, by simpa using h⟩
+
+lemma isLocallySurjective_iff_whisker (hH : CoverPreserving J K H) [H.IsCocontinuous J K]
+    [H.IsCoverDense K] : IsLocallySurjective K f ↔ IsLocallySurjective J (whiskerLeft H.op f) :=
+  ⟨fun _ ↦ isLocallySurjective_whisker J K H f,
+    fun _ ↦ isLocallySurjective_of_whisker J K H f hH⟩
+
+end Presheaf

--- a/Mathlib/CategoryTheory/Sites/PreservesLocallyBijective.lean
+++ b/Mathlib/CategoryTheory/Sites/PreservesLocallyBijective.lean
@@ -76,3 +76,5 @@ lemma isLocallySurjective_iff_whisker (hH : CoverPreserving J K H) [H.IsCocontin
     fun _ ↦ isLocallySurjective_of_whisker J K H f hH⟩
 
 end Presheaf
+
+end CategoryTheory

--- a/Mathlib/CategoryTheory/Sites/PreservesLocallyBijective.lean
+++ b/Mathlib/CategoryTheory/Sites/PreservesLocallyBijective.lean
@@ -3,7 +3,7 @@ Copyright (c) 2024 Dagur Asgeirsson. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Dagur Asgeirsson
 -/
-import Mathlib.CategoryTHeory.Sites.DenseSubsite
+import Mathlib.CategoryTheory.Sites.DenseSubsite
 import Mathlib.CategoryTheory.Sites.LocallySurjective
 /-!
 

--- a/Mathlib/CategoryTheory/Sites/PreservesLocallyBijective.lean
+++ b/Mathlib/CategoryTheory/Sites/PreservesLocallyBijective.lean
@@ -46,10 +46,10 @@ lemma isLocallyInjective_of_whisker (hH : CoverPreserving J K H)
     · simp only [comp_obj, op_obj, whiskerLeft_app, Opposite.op_unop]
       erw [NatTrans.naturality_apply, NatTrans.naturality_apply, h]
 
-lemma isLocallyInjective_iff_whisker (hH : CoverPreserving J K H) [H.IsCocontinuous J K]
-    [H.IsCoverDense K] : IsLocallyInjective K f ↔ IsLocallyInjective J (whiskerLeft H.op f) :=
-  ⟨fun _ ↦ isLocallyInjective_whisker J K H f,
-    fun _ ↦ isLocallyInjective_of_whisker J K H f hH⟩
+lemma isLocallyInjective_whisker_iff (hH : CoverPreserving J K H) [H.IsCocontinuous J K]
+    [H.IsCoverDense K] : IsLocallyInjective J (whiskerLeft H.op f) ↔ IsLocallyInjective K f :=
+  ⟨fun _ ↦ isLocallyInjective_of_whisker J K H f hH,
+    fun _ ↦ isLocallyInjective_whisker J K H f⟩
 
 lemma isLocallySurjective_whisker [H.IsCocontinuous J K] [IsLocallySurjective K f] :
     IsLocallySurjective J (whiskerLeft H.op f) where
@@ -70,10 +70,10 @@ lemma isLocallySurjective_of_whisker (hH : CoverPreserving J K H)
     simp only [Sieve.functorPullback_apply, Presieve.functorPullback_mem, Sieve.pullback_apply]
     exact ⟨x, by simpa using h⟩
 
-lemma isLocallySurjective_iff_whisker (hH : CoverPreserving J K H) [H.IsCocontinuous J K]
-    [H.IsCoverDense K] : IsLocallySurjective K f ↔ IsLocallySurjective J (whiskerLeft H.op f) :=
-  ⟨fun _ ↦ isLocallySurjective_whisker J K H f,
-    fun _ ↦ isLocallySurjective_of_whisker J K H f hH⟩
+lemma isLocallySurjective_whisker_iff (hH : CoverPreserving J K H) [H.IsCocontinuous J K]
+    [H.IsCoverDense K] : IsLocallySurjective J (whiskerLeft H.op f) ↔ IsLocallySurjective K f :=
+  ⟨fun _ ↦ isLocallySurjective_of_whisker J K H f hH,
+    fun _ ↦ isLocallySurjective_whisker J K H f⟩
 
 end Presheaf
 


### PR DESCRIPTION
This PR proves that precomposition with a cocontinuous functor preserves local injectivity and surjectivity of morphisms of presheaves, and that precomposition with a cover preserving and cover dense functor reflects the same properties.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
