### PR TITLE
[Merged by Bors] - feat: Order-connected sets in `ℝⁿ` are null-measurable

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -3068,6 +3068,7 @@ import Mathlib.MeasureTheory.Measure.WithDensityFinite
 import Mathlib.MeasureTheory.Measure.WithDensityVectorMeasure
 import Mathlib.MeasureTheory.Order.Group.Lattice
 import Mathlib.MeasureTheory.Order.Lattice
+import Mathlib.MeasureTheory.Order.UpperLower
 import Mathlib.MeasureTheory.OuterMeasure.AE
 import Mathlib.MeasureTheory.OuterMeasure.Basic
 import Mathlib.MeasureTheory.OuterMeasure.Caratheodory

--- a/Mathlib/MeasureTheory/Order/UpperLower.lean
+++ b/Mathlib/MeasureTheory/Order/UpperLower.lean
@@ -1,0 +1,147 @@
+/-
+Copyright (c) 2022 Yaël Dillies, Kexing Ying. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Yaël Dillies, Kexing Ying
+-/
+import Mathlib.Analysis.Normed.Order.UpperLower
+import Mathlib.Logic.Lemmas
+import Mathlib.MeasureTheory.Covering.BesicovitchVectorSpace
+import Mathlib.Topology.Order.DenselyOrdered
+
+#align_import measure_theory.order.upper_lower from "leanprover-community/mathlib"@"b1abe23ae96fef89ad30d9f4362c307f72a55010"
+
+/-!
+# Order-connected sets are null-measurable
+
+This file proves that order-connected sets in `ℝⁿ` under the pointwise order are null-measurable.
+Recall that `x ≤ y` iff `∀ i, x i ≤ y i`, and `s` is order-connected iff
+`∀ x y ∈ s, ∀ z, x ≤ z → z ≤ y → z ∈ s`.
+
+## Main declarations
+
+* `Set.OrdConnected.null_frontier`: The frontier of an order-connected set in `ℝⁿ` has measure `0`.
+
+## Notes
+
+We prove null-measurability in `ℝⁿ` with the `∞`-metric, but this transfers directly to `ℝⁿ` with
+the Euclidean metric because they have the same measurable sets.
+
+Null-measurability can't be strengthened to measurability because any antichain (and in particular
+any subset of the antidiagonal `{(x, y) | x + y = 0}`) is order-connected.
+
+## TODO
+
+Generalize so that it also applies to `ℝ × ℝ`, for example.
+-/
+
+open Filter MeasureTheory Metric Set
+open scoped Topology
+
+variable {ι : Type*} [Fintype ι] {s : Set (ι → ℝ)} {x y : ι → ℝ} {δ : ℝ}
+
+/-- If we can fit a small ball inside a set `s` intersected with any neighborhood of `x`, then the
+density of `s` near `x` is not `0`.
+
+Along with `aux₁`, this proves that `x` is a Lebesgue point of `s`. This will be used to prove that
+the frontier of an order-connected set is null. -/
+private lemma aux₀
+    (h : ∀ δ, 0 < δ →
+      ∃ y, closedBall y (δ / 4) ⊆ closedBall x δ ∧ closedBall y (δ / 4) ⊆ interior s) :
+    ¬Tendsto (fun r ↦ volume (closure s ∩ closedBall x r) / volume (closedBall x r)) (𝓝[>] 0)
+        (𝓝 0) := by
+  choose f hf₀ hf₁ using h
+  intro H
+  obtain ⟨ε, -, hε', hε₀⟩ := exists_seq_strictAnti_tendsto_nhdsWithin (0 : ℝ)
+  refine not_eventually.2
+    (frequently_of_forall fun _ ↦ lt_irrefl $ ENNReal.ofReal $ 4⁻¹ ^ Fintype.card ι)
+    ((Filter.Tendsto.eventually_lt (H.comp hε₀) tendsto_const_nhds ?_).mono fun n ↦
+      lt_of_le_of_lt ?_)
+  swap
+  calc
+    ENNReal.ofReal (4⁻¹ ^ Fintype.card ι)
+      = volume (closedBall (f (ε n) (hε' n)) (ε n / 4)) / volume (closedBall x (ε n)) := ?_
+    _ ≤ volume (closure s ∩ closedBall x (ε n)) / volume (closedBall x (ε n)) := by
+      gcongr; exact subset_inter ((hf₁ _ $ hε' n).trans interior_subset_closure) $ hf₀ _ $ hε' n
+  dsimp
+  have := hε' n
+  rw [Real.volume_pi_closedBall, Real.volume_pi_closedBall, ← ENNReal.ofReal_div_of_pos, ← div_pow,
+    mul_div_mul_left _ _ (two_ne_zero' ℝ), div_right_comm, div_self, one_div]
+  all_goals positivity
+
+/-- If we can fit a small ball inside a set `sᶜ` intersected with any neighborhood of `x`, then the
+density of `s` near `x` is not `1`.
+
+Along with `aux₀`, this proves that `x` is a Lebesgue point of `s`. This will be used to prove that
+the frontier of an order-connected set is null. -/
+private lemma aux₁
+    (h : ∀ δ, 0 < δ →
+      ∃ y, closedBall y (δ / 4) ⊆ closedBall x δ ∧ closedBall y (δ / 4) ⊆ interior sᶜ) :
+    ¬Tendsto (fun r ↦ volume (closure s ∩ closedBall x r) / volume (closedBall x r)) (𝓝[>] 0)
+        (𝓝 1) := by
+  choose f hf₀ hf₁ using h
+  intro H
+  obtain ⟨ε, -, hε', hε₀⟩ := exists_seq_strictAnti_tendsto_nhdsWithin (0 : ℝ)
+  refine
+    not_eventually.2
+      (frequently_of_forall fun _ ↦ lt_irrefl $ 1 - ENNReal.ofReal (4⁻¹ ^ Fintype.card ι))
+      ((Filter.Tendsto.eventually_lt tendsto_const_nhds (H.comp hε₀) $
+            ENNReal.sub_lt_self ENNReal.one_ne_top one_ne_zero ?_).mono
+        fun n ↦ lt_of_le_of_lt' ?_)
+  swap
+  calc
+    volume (closure s ∩ closedBall x (ε n)) / volume (closedBall x (ε n))
+      ≤ volume (closedBall x (ε n) \ closedBall (f (ε n) $ hε' n) (ε n / 4)) /
+        volume (closedBall x (ε n)) := by
+      gcongr
+      rw [diff_eq_compl_inter]
+      refine inter_subset_inter_left _ ?_
+      rw [subset_compl_comm, ← interior_compl]
+      exact hf₁ _ _
+    _ = 1 - ENNReal.ofReal (4⁻¹ ^ Fintype.card ι) := ?_
+  dsimp
+  have := hε' n
+  rw [measure_diff (hf₀ _ _) _ ((Real.volume_pi_closedBall _ _).trans_ne ENNReal.ofReal_ne_top),
+    Real.volume_pi_closedBall, Real.volume_pi_closedBall, ENNReal.sub_div fun _ _ ↦ _,
+    ENNReal.div_self _ ENNReal.ofReal_ne_top, ← ENNReal.ofReal_div_of_pos, ← div_pow,
+    mul_div_mul_left _ _ (two_ne_zero' ℝ), div_right_comm, div_self, one_div]
+  all_goals
+    first
+    | positivity
+    | measurability
+
+theorem IsUpperSet.null_frontier (hs : IsUpperSet s) : volume (frontier s) = 0 := by
+  refine measure_mono_null (fun x hx ↦ ?_)
+    (Besicovitch.ae_tendsto_measure_inter_div_of_measurableSet _
+      (isClosed_closure (s := s)).measurableSet)
+  by_cases h : x ∈ closure s <;> simp [h]
+  · refine aux₁ fun _ ↦ hs.compl.exists_subset_ball $ frontier_subset_closure ?_
+    rwa [frontier_compl]
+  · exact aux₀ fun _ ↦ hs.exists_subset_ball $ frontier_subset_closure hx
+#align is_upper_set.null_frontier IsUpperSet.null_frontier
+
+theorem IsLowerSet.null_frontier (hs : IsLowerSet s) : volume (frontier s) = 0 := by
+  refine measure_mono_null (fun x hx ↦ ?_)
+    (Besicovitch.ae_tendsto_measure_inter_div_of_measurableSet _
+      (isClosed_closure (s := s)).measurableSet)
+  by_cases h : x ∈ closure s <;> simp [h]
+  · refine aux₁ fun _ ↦ hs.compl.exists_subset_ball $ frontier_subset_closure ?_
+    rwa [frontier_compl]
+  · exact aux₀ fun _ ↦ hs.exists_subset_ball $ frontier_subset_closure hx
+#align is_lower_set.null_frontier IsLowerSet.null_frontier
+
+theorem Set.OrdConnected.null_frontier (hs : s.OrdConnected) : volume (frontier s) = 0 := by
+  rw [← hs.upperClosure_inter_lowerClosure]
+  exact measure_mono_null (frontier_inter_subset _ _) $ measure_union_null
+    (measure_inter_null_of_null_left _ (UpperSet.upper _).null_frontier)
+    (measure_inter_null_of_null_right _ (LowerSet.lower _).null_frontier)
+#align set.ord_connected.null_frontier Set.OrdConnected.null_frontier
+
+protected theorem Set.OrdConnected.nullMeasurableSet (hs : s.OrdConnected) : NullMeasurableSet s :=
+  nullMeasurableSet_of_null_frontier hs.null_frontier
+#align set.ord_connected.null_measurable_set Set.OrdConnected.nullMeasurableSet
+
+theorem IsAntichain.volume_eq_zero [Nonempty ι] (hs : IsAntichain (· ≤ ·) s) : volume s = 0 := by
+  refine measure_mono_null ?_ hs.ordConnected.null_frontier
+  rw [← closure_diff_interior, hs.interior_eq_empty, diff_empty]
+  exact subset_closure
+#align is_antichain.volume_eq_zero IsAntichain.volume_eq_zero

--- a/Mathlib/MeasureTheory/Order/UpperLower.lean
+++ b/Mathlib/MeasureTheory/Order/UpperLower.lean
@@ -4,7 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Yaël Dillies, Kexing Ying
 -/
 import Mathlib.Analysis.Normed.Order.UpperLower
-import Mathlib.Logic.Lemmas
 import Mathlib.MeasureTheory.Covering.BesicovitchVectorSpace
 import Mathlib.Topology.Order.DenselyOrdered
 
@@ -28,6 +27,20 @@ the Euclidean metric because they have the same measurable sets.
 
 Null-measurability can't be strengthened to measurability because any antichain (and in particular
 any subset of the antidiagonal `{(x, y) | x + y = 0}`) is order-connected.
+
+## Sketch proof
+
+1. To show an order-connected set is null-measurable, it is enough to show it has null frontier.
+2. Since an order-connected set is the intersection of its upper and lower closure, it's enough to
+  show that upper and lower sets have null frontier.
+3. WLOG let's prove it for an upper set `s`.
+4. By the Lebesgue density theorem, it is enough to show that any frontier point `x` of `s` is a
+  Lebesgue point, namely a point where the density of `s` over small balls centered at `x` does not
+  tend to either `0` or `1`.
+5. This is true, since by the upper setness of `s` we can intercalate a ball of radius `δ / 4` in
+  `s` intersected with the upper quadrant of the ball of radius `δ` centered at `x` (recall that the
+  balls are taken in the ∞-norm, so they are cubes), and another ball of radius `δ / 4` in `sᶜ` and
+  the lower quadrant of the ball of radius `δ` centered at `x`.
 
 ## TODO
 

--- a/Mathlib/MeasureTheory/Order/UpperLower.lean
+++ b/Mathlib/MeasureTheory/Order/UpperLower.lean
@@ -34,9 +34,9 @@ any subset of the antidiagonal `{(x, y) | x + y = 0}`) is order-connected.
 2. Since an order-connected set is the intersection of its upper and lower closure, it's enough to
   show that upper and lower sets have null frontier.
 3. WLOG let's prove it for an upper set `s`.
-4. By the Lebesgue density theorem, it is enough to show that any frontier point `x` of `s` is a
-  Lebesgue point, namely a point where the density of `s` over small balls centered at `x` does not
-  tend to either `0` or `1`.
+4. By the Lebesgue density theorem, it is enough to show that any frontier point `x` of `s` is not a
+  Lebesgue point, namely we want the density of `s` over small balls centered at `x` to not tend to
+  either `0` or `1`.
 5. This is true, since by the upper setness of `s` we can intercalate a ball of radius `δ / 4` in
   `s` intersected with the upper quadrant of the ball of radius `δ` centered at `x` (recall that the
   balls are taken in the ∞-norm, so they are cubes), and another ball of radius `δ / 4` in `sᶜ` and

--- a/Mathlib/Topology/Bases.lean
+++ b/Mathlib/Topology/Bases.lean
@@ -54,23 +54,6 @@ More fine grained instances for `FirstCountableTopology`,
 
 open Set Filter Function Topology
 
-namespace Set
-variable {ι : Type*} {α : ι → Type*} {i : ι} {s : Set ι} {t : ∀ i, Set (α i)}
-
-lemma eval_image_pi_of_not_mem [Decidable (s.pi t).Nonempty] (hi : i ∉ s) :
-    Function.eval i '' s.pi t = if (s.pi t).Nonempty then univ else ∅ := by
-  classical
-  ext xᵢ
-  simp only [eval, mem_image, mem_pi, Set.Nonempty, mem_ite_empty_right, mem_univ, and_true]
-  constructor
-  · rintro ⟨x, hx, rfl⟩
-    exact ⟨x, hx⟩
-  · rintro ⟨x, hx⟩
-    refine ⟨Function.update x i xᵢ, ?_⟩
-    simpa (config := { contextual := true }) [(ne_of_mem_of_not_mem · hi)]
-
-end Set
-
 noncomputable section
 
 namespace TopologicalSpace

--- a/Mathlib/Topology/Bases.lean
+++ b/Mathlib/Topology/Bases.lean
@@ -54,6 +54,23 @@ More fine grained instances for `FirstCountableTopology`,
 
 open Set Filter Function Topology
 
+namespace Set
+variable {ι : Type*} {α : ι → Type*} {i : ι} {s : Set ι} {t : ∀ i, Set (α i)}
+
+lemma eval_image_pi_of_not_mem [Decidable (s.pi t).Nonempty] (hi : i ∉ s) :
+    Function.eval i '' s.pi t = if (s.pi t).Nonempty then univ else ∅ := by
+  classical
+  ext xᵢ
+  simp only [eval, mem_image, mem_pi, Set.Nonempty, mem_ite_empty_right, mem_univ, and_true]
+  constructor
+  · rintro ⟨x, hx, rfl⟩
+    exact ⟨x, hx⟩
+  · rintro ⟨x, hx⟩
+    refine ⟨Function.update x i xᵢ, ?_⟩
+    simpa (config := { contextual := true }) [(ne_of_mem_of_not_mem · hi)]
+
+end Set
+
 noncomputable section
 
 namespace TopologicalSpace


### PR DESCRIPTION
Prove that the frontier of an order-connected set in `ℝⁿ` (with the `∞`-metric, but it doesn't actually matter) has measure zero. As a corollary, antichains in `ℝⁿ` have measure zero.

This is not so trivial as one might think. The proof Kexing and I came up with involves the Lebesgue density theorem.

Partially forward-port leanprover-community/mathlib#16976


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->
- [x] depends on: #13642

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
