### PR TITLE
[Merged by Bors] - chore: move ProperSpace instances to ProperSpace.lean

### DIFF
--- a/Mathlib/Analysis/Convex/Extrema.lean
+++ b/Mathlib/Analysis/Convex/Extrema.lean
@@ -6,6 +6,7 @@ Authors: Frédéric Dupuis
 import Mathlib.Analysis.Convex.Function
 import Mathlib.Topology.Algebra.Affine
 import Mathlib.Topology.MetricSpace.PseudoMetric
+import Mathlib.Topology.Order.LocalExtr
 
 #align_import analysis.convex.extrema from "leanprover-community/mathlib"@"f2ce6086713c78a7f880485f7917ea547a215982"
 

--- a/Mathlib/Topology/MetricSpace/Basic.lean
+++ b/Mathlib/Topology/MetricSpace/Basic.lean
@@ -3,7 +3,7 @@ Copyright (c) 2015, 2017 Jeremy Avigad. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Jeremy Avigad, Robert Y. Lewis, Johannes Hölzl, Mario Carneiro, Sébastien Gouëzel
 -/
-import Mathlib.Topology.MetricSpace.ProperSpace
+import Mathlib.Topology.MetricSpace.PseudoMetric
 
 #align_import topology.metric_space.basic from "leanprover-community/mathlib"@"c8f305514e0d47dfaa710f5a52f0d21b588e6328"
 
@@ -436,9 +436,6 @@ end
 instance [MetricSpace X] : MetricSpace (Additive X) := ‹MetricSpace X›
 instance [MetricSpace X] : MetricSpace (Multiplicative X) := ‹MetricSpace X›
 
-instance [PseudoMetricSpace X] [ProperSpace X] : ProperSpace (Additive X) := ‹ProperSpace X›
-instance [PseudoMetricSpace X] [ProperSpace X] : ProperSpace (Multiplicative X) := ‹ProperSpace X›
-
 instance MulOpposite.instMetricSpace [MetricSpace X] : MetricSpace Xᵐᵒᵖ :=
   MetricSpace.induced unop unop_injective ‹_›
 
@@ -479,5 +476,3 @@ instance : PseudoMetricSpace Xᵒᵈ := ‹PseudoMetricSpace X›
 end
 
 instance [MetricSpace X] : MetricSpace Xᵒᵈ := ‹MetricSpace X›
-
-instance [PseudoMetricSpace X] [ProperSpace X] : ProperSpace Xᵒᵈ := ‹ProperSpace X›

--- a/Mathlib/Topology/MetricSpace/Bounded.lean
+++ b/Mathlib/Topology/MetricSpace/Bounded.lean
@@ -330,9 +330,25 @@ theorem compactSpace_iff_isBounded_univ [ProperSpace α] :
   ⟨@isBounded_of_compactSpace α _ _, fun hb => ⟨isCompact_of_isClosed_isBounded isClosed_univ hb⟩⟩
 #align metric.compact_space_iff_bounded_univ Metric.compactSpace_iff_isBounded_univ
 
-section ConditionallyCompleteLinearOrder
+section CompactIccSpace
 
 variable [Preorder α] [CompactIccSpace α]
+
+theorem _root_.totallyBounded_Icc (a b : α) : TotallyBounded (Icc a b) :=
+  isCompact_Icc.totallyBounded
+#align totally_bounded_Icc totallyBounded_Icc
+
+theorem _root_.totallyBounded_Ico (a b : α) : TotallyBounded (Ico a b) :=
+  totallyBounded_subset Ico_subset_Icc_self (totallyBounded_Icc a b)
+#align totally_bounded_Ico totallyBounded_Ico
+
+theorem _root_.totallyBounded_Ioc (a b : α) : TotallyBounded (Ioc a b) :=
+  totallyBounded_subset Ioc_subset_Icc_self (totallyBounded_Icc a b)
+#align totally_bounded_Ioc totallyBounded_Ioc
+
+theorem _root_.totallyBounded_Ioo (a b : α) : TotallyBounded (Ioo a b) :=
+  totallyBounded_subset Ioo_subset_Icc_self (totallyBounded_Icc a b)
+#align totally_bounded_Ioo totallyBounded_Ioo
 
 theorem isBounded_Icc (a b : α) : IsBounded (Icc a b) :=
   (totallyBounded_Icc a b).isBounded
@@ -359,7 +375,7 @@ theorem isBounded_of_bddAbove_of_bddBelow {s : Set α} (h₁ : BddAbove s) (h₂
   (isBounded_Icc l u).subset (fun _x hx => mem_Icc.mpr ⟨hl hx, hu hx⟩)
 #align metric.bounded_of_bdd_above_of_bdd_below Metric.isBounded_of_bddAbove_of_bddBelow
 
-end ConditionallyCompleteLinearOrder
+end CompactIccSpace
 
 end Bounded
 

--- a/Mathlib/Topology/MetricSpace/ProperSpace.lean
+++ b/Mathlib/Topology/MetricSpace/ProperSpace.lean
@@ -164,3 +164,7 @@ theorem Metric.exists_isLocalMin_mem_ball [PseudoMetricSpace α] [ProperSpace α
   exact (isCompact_closedBall a r).exists_isLocalMin_mem_open ball_subset_closedBall hf hz hf1
     isOpen_ball
 #align metric.exists_local_min_mem_ball Metric.exists_isLocalMin_mem_ball
+
+instance [PseudoMetricSpace X] [ProperSpace X] : ProperSpace (Additive X) := ‹ProperSpace X›
+instance [PseudoMetricSpace X] [ProperSpace X] : ProperSpace (Multiplicative X) := ‹ProperSpace X›
+instance [PseudoMetricSpace X] [ProperSpace X] : ProperSpace Xᵒᵈ := ‹ProperSpace X›

--- a/Mathlib/Topology/MetricSpace/ProperSpace.lean
+++ b/Mathlib/Topology/MetricSpace/ProperSpace.lean
@@ -3,6 +3,7 @@ Copyright (c) 2018 Sébastien Gouëzel. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Sébastien Gouëzel
 -/
+import Mathlib.Topology.Algebra.Order.Compact
 import Mathlib.Topology.MetricSpace.PseudoMetric
 
 /-! ## Proper spaces

--- a/Mathlib/Topology/MetricSpace/PseudoMetric.lean
+++ b/Mathlib/Topology/MetricSpace/PseudoMetric.lean
@@ -2099,3 +2099,7 @@ theorem lebesgue_number_lemma_of_metric_sUnion {s : Set α} {c : Set (Set α)} (
     (hc₁ : ∀ t ∈ c, IsOpen t) (hc₂ : s ⊆ ⋃₀ c) : ∃ δ > 0, ∀ x ∈ s, ∃ t ∈ c, ball x δ ⊆ t := by
   rw [sUnion_eq_iUnion] at hc₂; simpa using lebesgue_number_lemma_of_metric hs (by simpa) hc₂
 #align lebesgue_number_lemma_of_metric_sUnion lebesgue_number_lemma_of_metric_sUnion
+
+instance [PseudoMetricSpace X] : PseudoMetricSpace (Additive X) := ‹PseudoMetricSpace X›
+instance [PseudoMetricSpace X] : PseudoMetricSpace (Multiplicative X) := ‹PseudoMetricSpace X›
+instance [PseudoMetricSpace X] : PseudoMetricSpace Xᵒᵈ := ‹PseudoMetricSpace X›

--- a/Mathlib/Topology/MetricSpace/PseudoMetric.lean
+++ b/Mathlib/Topology/MetricSpace/PseudoMetric.lean
@@ -3,7 +3,6 @@ Copyright (c) 2015, 2017 Jeremy Avigad. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Jeremy Avigad, Robert Y. Lewis, Johannes Hölzl, Mario Carneiro, Sébastien Gouëzel
 -/
-import Mathlib.Topology.Algebra.Order.Compact
 import Mathlib.Topology.EMetricSpace.Basic
 import Mathlib.Topology.Bornology.Constructions
 import Mathlib.Data.Set.Pointwise.Interval
@@ -1406,28 +1405,6 @@ theorem Real.Icc_eq_closedBall (x y : ℝ) : Icc x y = closedBall ((x + y) / 2) 
   rw [Real.closedBall_eq_Icc, ← sub_div, add_comm, ← sub_add, add_sub_cancel_left, add_self_div_two,
     ← add_div, add_assoc, add_sub_cancel, add_self_div_two]
 #align real.Icc_eq_closed_ball Real.Icc_eq_closedBall
-
-section MetricOrdered
-
-variable [Preorder α] [CompactIccSpace α]
-
-theorem totallyBounded_Icc (a b : α) : TotallyBounded (Icc a b) :=
-  isCompact_Icc.totallyBounded
-#align totally_bounded_Icc totallyBounded_Icc
-
-theorem totallyBounded_Ico (a b : α) : TotallyBounded (Ico a b) :=
-  totallyBounded_subset Ico_subset_Icc_self (totallyBounded_Icc a b)
-#align totally_bounded_Ico totallyBounded_Ico
-
-theorem totallyBounded_Ioc (a b : α) : TotallyBounded (Ioc a b) :=
-  totallyBounded_subset Ioc_subset_Icc_self (totallyBounded_Icc a b)
-#align totally_bounded_Ioc totallyBounded_Ioc
-
-theorem totallyBounded_Ioo (a b : α) : TotallyBounded (Ioo a b) :=
-  totallyBounded_subset Ioo_subset_Icc_self (totallyBounded_Icc a b)
-#align totally_bounded_Ioo totallyBounded_Ioo
-
-end MetricOrdered
 
 /-- Special case of the sandwich theorem; see `tendsto_of_tendsto_of_tendsto_of_le_of_le'` for the
 general case. -/

--- a/Mathlib/Topology/MetricSpace/ShrinkingLemma.lean
+++ b/Mathlib/Topology/MetricSpace/ShrinkingLemma.lean
@@ -3,8 +3,9 @@ Copyright (c) 2021 Yury G. Kudryashov. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Yury G. Kudryashov
 -/
-import Mathlib.Topology.MetricSpace.Basic
 import Mathlib.Topology.EMetricSpace.Paracompact
+import Mathlib.Topology.MetricSpace.Basic
+import Mathlib.Topology.MetricSpace.ProperSpace
 import Mathlib.Topology.ShrinkingLemma
 
 #align_import topology.metric_space.shrinking_lemma from "leanprover-community/mathlib"@"f2ce6086713c78a7f880485f7917ea547a215982"


### PR DESCRIPTION
This means `MetricSpace.Basic` no longer needs to depend on `MetricSpace.ProperSpace`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

- [x] depends on: #13631 

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
