### PR TITLE
[Merged by Bors] - feat: add unitor functor for product of categories

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -1591,9 +1591,9 @@ import Mathlib.CategoryTheory.Preadditive.Yoneda.Injective
 import Mathlib.CategoryTheory.Preadditive.Yoneda.Limits
 import Mathlib.CategoryTheory.Preadditive.Yoneda.Projective
 import Mathlib.CategoryTheory.Products.Associator
-import Mathlib.CategoryTheory.Products.Unitor
 import Mathlib.CategoryTheory.Products.Basic
 import Mathlib.CategoryTheory.Products.Bifunctor
+import Mathlib.CategoryTheory.Products.Unitor
 import Mathlib.CategoryTheory.Quotient
 import Mathlib.CategoryTheory.Quotient.Linear
 import Mathlib.CategoryTheory.Quotient.Preadditive

--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -1591,6 +1591,7 @@ import Mathlib.CategoryTheory.Preadditive.Yoneda.Injective
 import Mathlib.CategoryTheory.Preadditive.Yoneda.Limits
 import Mathlib.CategoryTheory.Preadditive.Yoneda.Projective
 import Mathlib.CategoryTheory.Products.Associator
+import Mathlib.CategoryTheory.Products.Unitor
 import Mathlib.CategoryTheory.Products.Basic
 import Mathlib.CategoryTheory.Products.Bifunctor
 import Mathlib.CategoryTheory.Quotient

--- a/Mathlib/CategoryTheory/Products/Associator.lean
+++ b/Mathlib/CategoryTheory/Products/Associator.lean
@@ -54,40 +54,36 @@ instance inverseAssociatorIsEquivalence : (inverseAssociator C D E).IsEquivalenc
   (by infer_instance : (associativity C D E).inverse.IsEquivalence)
 #align category_theory.prod.inverse_associator_is_equivalence CategoryTheory.prod.inverseAssociatorIsEquivalence
 
-/-- The left unitor functor `1 × C ⥤ C`
--/
+/-- The left unitor functor `1 × C ⥤ C` -/
 @[simps]
 def leftUnitor : Discrete PUnit × C ⥤ C where
   obj X := X.2
   map f := f.2
 #align category_theory.prod.left_unitor CategoryTheory.prod.leftUnitor
 
-/-- The right unitor functor `C × 1 ⥤ C`
--/
+/-- The right unitor functor `C × 1 ⥤ C` -/
 @[simps]
 def rightUnitor : C × Discrete PUnit ⥤ C where
   obj X := X.1
   map f := f.1
 #align category_theory.prod.right_unitor CategoryTheory.prod.rightUnitor
 
-/-- The left inverse unitor `C ⥤ 1 × C`
--/
+/-- The left inverse unitor `C ⥤ 1 × C` -/
 @[simps]
 def leftInverseUnitor : C ⥤ Discrete PUnit × C where
   obj X := ⟨⟨PUnit.unit⟩, X⟩
   map f := ⟨𝟙 _, f⟩
 #align category_theory.prod.left_inverse_unitor CategoryTheory.prod.leftInverseUnitor
 
-/-- The right inverse unitor `C ⥤ C × 1`
--/
+/-- The right inverse unitor `C ⥤ C × 1` -/
 @[simps]
 def rightInverseUnitor : C ⥤ C × Discrete PUnit where
   obj X := ⟨X, ⟨PUnit.unit⟩⟩
   map f := ⟨f, 𝟙 _⟩
 #align category_theory.prod.right_inverse_unitor CategoryTheory.prod.rightInverseUnitor
 
-/-- The equivalence of categories expressing left unity of products of categories.
--/
+/-- The equivalence of categories expressing left unity of products of categories.  -/
+@[simps]
 def leftUnitorEquivalence : Discrete PUnit × C ≌ C where
   functor := leftUnitor C
   inverse := leftInverseUnitor C
@@ -95,8 +91,8 @@ def leftUnitorEquivalence : Discrete PUnit × C ≌ C where
   counitIso := Iso.refl _
 #align category_theory.prod.left_unitor_equivalence CategoryTheory.prod.leftUnitorEquivalence
 
-/-- The equivalence of categories expressing right unity of products of categories.
--/
+/-- The equivalence of categories expressing right unity of products of categories.  -/
+@[simps]
 def rightUnitorEquivalence : C × Discrete PUnit ≌ C where
   functor := rightUnitor C
   inverse := rightInverseUnitor C
@@ -104,13 +100,13 @@ def rightUnitorEquivalence : C × Discrete PUnit ≌ C where
   counitIso := Iso.refl _
 #align category_theory.prod.right_unitor_equivalence CategoryTheory.prod.rightUnitorEquivalence
 
-instance leftUnitorIsEquivalence : (leftUnitor C).IsEquivalence :=
+instance leftUnitor_isEquivalence : (leftUnitor C).IsEquivalence :=
   (leftUnitorEquivalence C).isEquivalence_functor
-#align category_theory.prod.left_unitor_is_equivalence CategoryTheory.prod.leftUnitorIsEquivalence
+#align category_theory.prod.left_unitor_is_equivalence CategoryTheory.prod.leftUnitor_isEquivalence
 
-instance rightUnitorIsEquivalence : (rightUnitor C).IsEquivalence :=
+instance rightUnitor_isEquivalence : (rightUnitor C).IsEquivalence :=
   (rightUnitorEquivalence C).isEquivalence_functor
-#align category_theory.prod.right_unitor_is_equivalence CategoryTheory.prod.rightUnitorIsEquivalence
+#align category_theory.prod.right_unitor_is_equivalence CategoryTheory.prod.rightUnitor_isEquivalence
 
 -- TODO pentagon natural transformation? ...satisfying?
 end CategoryTheory.prod

--- a/Mathlib/CategoryTheory/Products/Associator.lean
+++ b/Mathlib/CategoryTheory/Products/Associator.lean
@@ -4,7 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Stephen Morgan, Scott Morrison
 -/
 import Mathlib.CategoryTheory.Products.Basic
-import Mathlib.CategoryTheory.DiscreteCategory
 
 #align_import category_theory.products.associator from "leanprover-community/mathlib"@"dc6c365e751e34d100e80fe6e314c3c3e0fd2988"
 
@@ -53,60 +52,6 @@ instance associatorIsEquivalence : (associator C D E).IsEquivalence :=
 instance inverseAssociatorIsEquivalence : (inverseAssociator C D E).IsEquivalence :=
   (by infer_instance : (associativity C D E).inverse.IsEquivalence)
 #align category_theory.prod.inverse_associator_is_equivalence CategoryTheory.prod.inverseAssociatorIsEquivalence
-
-/-- The left unitor functor `1 × C ⥤ C` -/
-@[simps]
-def leftUnitor : Discrete PUnit × C ⥤ C where
-  obj X := X.2
-  map f := f.2
-#align category_theory.prod.left_unitor CategoryTheory.prod.leftUnitor
-
-/-- The right unitor functor `C × 1 ⥤ C` -/
-@[simps]
-def rightUnitor : C × Discrete PUnit ⥤ C where
-  obj X := X.1
-  map f := f.1
-#align category_theory.prod.right_unitor CategoryTheory.prod.rightUnitor
-
-/-- The left inverse unitor `C ⥤ 1 × C` -/
-@[simps]
-def leftInverseUnitor : C ⥤ Discrete PUnit × C where
-  obj X := ⟨⟨PUnit.unit⟩, X⟩
-  map f := ⟨𝟙 _, f⟩
-#align category_theory.prod.left_inverse_unitor CategoryTheory.prod.leftInverseUnitor
-
-/-- The right inverse unitor `C ⥤ C × 1` -/
-@[simps]
-def rightInverseUnitor : C ⥤ C × Discrete PUnit where
-  obj X := ⟨X, ⟨PUnit.unit⟩⟩
-  map f := ⟨f, 𝟙 _⟩
-#align category_theory.prod.right_inverse_unitor CategoryTheory.prod.rightInverseUnitor
-
-/-- The equivalence of categories expressing left unity of products of categories.  -/
-@[simps]
-def leftUnitorEquivalence : Discrete PUnit × C ≌ C where
-  functor := leftUnitor C
-  inverse := leftInverseUnitor C
-  unitIso := Iso.refl _
-  counitIso := Iso.refl _
-#align category_theory.prod.left_unitor_equivalence CategoryTheory.prod.leftUnitorEquivalence
-
-/-- The equivalence of categories expressing right unity of products of categories.  -/
-@[simps]
-def rightUnitorEquivalence : C × Discrete PUnit ≌ C where
-  functor := rightUnitor C
-  inverse := rightInverseUnitor C
-  unitIso := Iso.refl _
-  counitIso := Iso.refl _
-#align category_theory.prod.right_unitor_equivalence CategoryTheory.prod.rightUnitorEquivalence
-
-instance leftUnitor_isEquivalence : (leftUnitor C).IsEquivalence :=
-  (leftUnitorEquivalence C).isEquivalence_functor
-#align category_theory.prod.left_unitor_is_equivalence CategoryTheory.prod.leftUnitor_isEquivalence
-
-instance rightUnitor_isEquivalence : (rightUnitor C).IsEquivalence :=
-  (rightUnitorEquivalence C).isEquivalence_functor
-#align category_theory.prod.right_unitor_is_equivalence CategoryTheory.prod.rightUnitor_isEquivalence
 
 -- TODO pentagon natural transformation? ...satisfying?
 end CategoryTheory.prod

--- a/Mathlib/CategoryTheory/Products/Associator.lean
+++ b/Mathlib/CategoryTheory/Products/Associator.lean
@@ -59,7 +59,7 @@ instance inverseAssociatorIsEquivalence : (inverseAssociator C D E).IsEquivalenc
 @[simps]
 def leftUnitor : Discrete PUnit × C ⥤ C where
   obj X := X.2
-  map := @fun _ _ f => f.2
+  map f := f.2
 #align category_theory.prod.left_unitor CategoryTheory.prod.leftUnitor
 
 /-- The right unitor functor `C × 1 ⥤ C`
@@ -67,7 +67,7 @@ def leftUnitor : Discrete PUnit × C ⥤ C where
 @[simps]
 def rightUnitor : C × Discrete PUnit ⥤ C where
   obj X := X.1
-  map := @fun _ _ f => f.1
+  map f := f.1
 #align category_theory.prod.right_unitor CategoryTheory.prod.rightUnitor
 
 /-- The left inverse unitor `C ⥤ 1 × C`
@@ -75,7 +75,7 @@ def rightUnitor : C × Discrete PUnit ⥤ C where
 @[simps]
 def leftInverseUnitor : C ⥤ Discrete PUnit × C where
   obj X := ⟨⟨PUnit.unit⟩, X⟩
-  map := @fun _ _ f =>  ⟨𝟙 _, f⟩
+  map f := ⟨𝟙 _, f⟩
 #align category_theory.prod.left_inverse_unitor CategoryTheory.prod.leftInverseUnitor
 
 /-- The right inverse unitor `C ⥤ C × 1`
@@ -83,31 +83,31 @@ def leftInverseUnitor : C ⥤ Discrete PUnit × C where
 @[simps]
 def rightInverseUnitor : C ⥤ C × Discrete PUnit where
   obj X := ⟨X, ⟨PUnit.unit⟩⟩
-  map := @fun _ _ f =>  ⟨f, 𝟙 _⟩
+  map f := ⟨f, 𝟙 _⟩
 #align category_theory.prod.right_inverse_unitor CategoryTheory.prod.rightInverseUnitor
 
 /-- The equivalence of categories expressing left unity of products of categories.
 -/
-def leftUnity : Discrete PUnit × C ≌ C :=
+def leftUnitEquivalence : Discrete PUnit × C ≌ C :=
   Equivalence.mk (leftUnitor C) (leftInverseUnitor C)
     (NatIso.ofComponents fun X => eqToIso (by simp))
     (NatIso.ofComponents fun X => eqToIso (by simp))
-#align category_theory.prod.left_unity CategoryTheory.prod.leftUnity
+#align category_theory.prod.left_unit_equivalence CategoryTheory.prod.leftUnitEquivalence
 
 /-- The equivalence of categories expressing right unity of products of categories.
 -/
-def rightUnity : C × Discrete PUnit ≌ C :=
+def rightUnitEquivalence : C × Discrete PUnit ≌ C :=
   Equivalence.mk (rightUnitor C) (rightInverseUnitor C)
     (NatIso.ofComponents fun X => eqToIso (by simp))
     (NatIso.ofComponents fun X => eqToIso (by simp))
-#align category_theory.prod.right_unity CategoryTheory.prod.rightUnity
+#align category_theory.prod.right_unit_equivalence CategoryTheory.prod.rightUnitEquivalence
 
 instance leftUnitorIsEquivalence : (leftUnitor C).IsEquivalence :=
-  (by infer_instance : (leftUnity C).functor.IsEquivalence)
+  (by infer_instance : (leftUnitEquivalence C).functor.IsEquivalence)
 #align category_theory.prod.left_unitor_is_equivalence CategoryTheory.prod.leftUnitorIsEquivalence
 
 instance rightUnitorIsEquivalence : (rightUnitor C).IsEquivalence :=
-  (by infer_instance : (rightUnity C).functor.IsEquivalence)
+  (by infer_instance : (rightUnitEquivalence C).functor.IsEquivalence)
 #align category_theory.prod.right_unitor_is_equivalence CategoryTheory.prod.rightUnitorIsEquivalence
 
 -- TODO pentagon natural transformation? ...satisfying?

--- a/Mathlib/CategoryTheory/Products/Associator.lean
+++ b/Mathlib/CategoryTheory/Products/Associator.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Stephen Morgan, Scott Morrison
 -/
 import Mathlib.CategoryTheory.Products.Basic
+import Mathlib.CategoryTheory.DiscreteCategory
 
 #align_import category_theory.products.associator from "leanprover-community/mathlib"@"dc6c365e751e34d100e80fe6e314c3c3e0fd2988"
 
@@ -53,6 +54,49 @@ instance inverseAssociatorIsEquivalence : (inverseAssociator C D E).IsEquivalenc
   (by infer_instance : (associativity C D E).inverse.IsEquivalence)
 #align category_theory.prod.inverse_associator_is_equivalence CategoryTheory.prod.inverseAssociatorIsEquivalence
 
--- TODO unitors?
+@[simps]
+def leftUnitor : Discrete PUnit × C ⥤ C where
+  obj X := X.2
+  map := @fun _ _ f => f.2
+#align category_theory.prod.left_unitor CategoryTheory.prod.leftUnitor
+
+@[simps]
+def rightUnitor : C × Discrete PUnit ⥤ C where
+  obj X := X.1
+  map := @fun _ _ f => f.1
+#align category_theory.prod.right_unitor CategoryTheory.prod.rightUnitor
+
+@[simps]
+def leftInverseUnitor : C ⥤ Discrete PUnit × C where
+  obj X := ⟨⟨PUnit.unit⟩, X⟩
+  map := @fun _ _ f =>  ⟨𝟙 _, f⟩
+#align category_theory.prod.left_inverse_unitor CategoryTheory.prod.leftInverseUnitor
+
+@[simps]
+def rightInverseUnitor : C ⥤ C × Discrete PUnit where
+  obj X := ⟨X, ⟨PUnit.unit⟩⟩
+  map := @fun _ _ f =>  ⟨f, 𝟙 _⟩
+#align category_theory.prod.right_inverse_unitor CategoryTheory.prod.rightInverseUnitor
+
+def leftUnity : Discrete PUnit × C ≌ C :=
+  Equivalence.mk (leftUnitor C) (leftInverseUnitor C)
+    (NatIso.ofComponents fun X => eqToIso (by simp))
+    (NatIso.ofComponents fun X => eqToIso (by simp))
+#align category_theory.prod.left_unity CategoryTheory.prod.leftUnity
+
+def rightUnity : C × Discrete PUnit ≌ C :=
+  Equivalence.mk (rightUnitor C) (rightInverseUnitor C)
+    (NatIso.ofComponents fun X => eqToIso (by simp))
+    (NatIso.ofComponents fun X => eqToIso (by simp))
+#align category_theory.prod.right_unity CategoryTheory.prod.rightUnity
+
+instance leftUnitorIsEquivalence : (leftUnitor C).IsEquivalence :=
+  (by infer_instance : (leftUnity C).functor.IsEquivalence)
+#align category_theory.prod.left_unitor_is_equivalence CategoryTheory.prod.leftUnitorIsEquivalence
+
+instance rightUnitorIsEquivalence : (rightUnitor C).IsEquivalence :=
+  (by infer_instance : (rightUnity C).functor.IsEquivalence)
+#align category_theory.prod.right_unitor_is_equivalence CategoryTheory.prod.rightUnitorIsEquivalence
+
 -- TODO pentagon natural transformation? ...satisfying?
 end CategoryTheory.prod

--- a/Mathlib/CategoryTheory/Products/Associator.lean
+++ b/Mathlib/CategoryTheory/Products/Associator.lean
@@ -88,26 +88,28 @@ def rightInverseUnitor : C ⥤ C × Discrete PUnit where
 
 /-- The equivalence of categories expressing left unity of products of categories.
 -/
-def leftUnitEquivalence : Discrete PUnit × C ≌ C :=
-  Equivalence.mk (leftUnitor C) (leftInverseUnitor C)
-    (NatIso.ofComponents fun X => eqToIso (by simp))
-    (NatIso.ofComponents fun X => eqToIso (by simp))
-#align category_theory.prod.left_unit_equivalence CategoryTheory.prod.leftUnitEquivalence
+def leftUnitorEquivalence : Discrete PUnit × C ≌ C where
+  functor := leftUnitor C
+  inverse := leftInverseUnitor C
+  unitIso := Iso.refl _
+  counitIso := Iso.refl _
+#align category_theory.prod.left_unitor_equivalence CategoryTheory.prod.leftUnitorEquivalence
 
 /-- The equivalence of categories expressing right unity of products of categories.
 -/
-def rightUnitEquivalence : C × Discrete PUnit ≌ C :=
-  Equivalence.mk (rightUnitor C) (rightInverseUnitor C)
-    (NatIso.ofComponents fun X => eqToIso (by simp))
-    (NatIso.ofComponents fun X => eqToIso (by simp))
-#align category_theory.prod.right_unit_equivalence CategoryTheory.prod.rightUnitEquivalence
+def rightUnitorEquivalence : C × Discrete PUnit ≌ C where
+  functor := rightUnitor C
+  inverse := rightInverseUnitor C
+  unitIso := Iso.refl _
+  counitIso := Iso.refl _
+#align category_theory.prod.right_unitor_equivalence CategoryTheory.prod.rightUnitorEquivalence
 
 instance leftUnitorIsEquivalence : (leftUnitor C).IsEquivalence :=
-  (by infer_instance : (leftUnitEquivalence C).functor.IsEquivalence)
+  (leftUnitorEquivalence C).isEquivalence_functor
 #align category_theory.prod.left_unitor_is_equivalence CategoryTheory.prod.leftUnitorIsEquivalence
 
 instance rightUnitorIsEquivalence : (rightUnitor C).IsEquivalence :=
-  (by infer_instance : (rightUnitEquivalence C).functor.IsEquivalence)
+  (rightUnitorEquivalence C).isEquivalence_functor
 #align category_theory.prod.right_unitor_is_equivalence CategoryTheory.prod.rightUnitorIsEquivalence
 
 -- TODO pentagon natural transformation? ...satisfying?

--- a/Mathlib/CategoryTheory/Products/Associator.lean
+++ b/Mathlib/CategoryTheory/Products/Associator.lean
@@ -54,36 +54,48 @@ instance inverseAssociatorIsEquivalence : (inverseAssociator C D E).IsEquivalenc
   (by infer_instance : (associativity C D E).inverse.IsEquivalence)
 #align category_theory.prod.inverse_associator_is_equivalence CategoryTheory.prod.inverseAssociatorIsEquivalence
 
+/-- The left unitor functor `1 × C ⥤ C`
+-/
 @[simps]
 def leftUnitor : Discrete PUnit × C ⥤ C where
   obj X := X.2
   map := @fun _ _ f => f.2
 #align category_theory.prod.left_unitor CategoryTheory.prod.leftUnitor
 
+/-- The right unitor functor `C × 1 ⥤ C`
+-/
 @[simps]
 def rightUnitor : C × Discrete PUnit ⥤ C where
   obj X := X.1
   map := @fun _ _ f => f.1
 #align category_theory.prod.right_unitor CategoryTheory.prod.rightUnitor
 
+/-- The left inverse unitor `C ⥤ 1 × C`
+-/
 @[simps]
 def leftInverseUnitor : C ⥤ Discrete PUnit × C where
   obj X := ⟨⟨PUnit.unit⟩, X⟩
   map := @fun _ _ f =>  ⟨𝟙 _, f⟩
 #align category_theory.prod.left_inverse_unitor CategoryTheory.prod.leftInverseUnitor
 
+/-- The right inverse unitor `C ⥤ C × 1`
+-/
 @[simps]
 def rightInverseUnitor : C ⥤ C × Discrete PUnit where
   obj X := ⟨X, ⟨PUnit.unit⟩⟩
   map := @fun _ _ f =>  ⟨f, 𝟙 _⟩
 #align category_theory.prod.right_inverse_unitor CategoryTheory.prod.rightInverseUnitor
 
+/-- The equivalence of categories expressing left unity of products of categories.
+-/
 def leftUnity : Discrete PUnit × C ≌ C :=
   Equivalence.mk (leftUnitor C) (leftInverseUnitor C)
     (NatIso.ofComponents fun X => eqToIso (by simp))
     (NatIso.ofComponents fun X => eqToIso (by simp))
 #align category_theory.prod.left_unity CategoryTheory.prod.leftUnity
 
+/-- The equivalence of categories expressing right unity of products of categories.
+-/
 def rightUnity : C × Discrete PUnit ≌ C :=
   Equivalence.mk (rightUnitor C) (rightInverseUnitor C)
     (NatIso.ofComponents fun X => eqToIso (by simp))

--- a/Mathlib/CategoryTheory/Products/Unitor.lean
+++ b/Mathlib/CategoryTheory/Products/Unitor.lean
@@ -6,7 +6,9 @@ Authors: Shanghe Chen
 import Mathlib.CategoryTheory.Products.Basic
 import Mathlib.CategoryTheory.DiscreteCategory
 
-/-!  The left/right unitor functors `1 × C ⥤ C`, `C × 1 ⥤ C`, and their inverses form an equivalence respectively.  -/
+/-!
+# The left/right unitor equivalences `1 × C ≌ C` and `C × 1 ≌ C`.
+-/
 
 universe v u
 

--- a/Mathlib/CategoryTheory/Products/Unitor.lean
+++ b/Mathlib/CategoryTheory/Products/Unitor.lean
@@ -1,0 +1,65 @@
+/-
+Copyright (c) 2024 Shanghe Chen. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Shanghe Chen
+-/
+import Mathlib.CategoryTheory.Products.Basic
+import Mathlib.CategoryTheory.DiscreteCategory
+
+/-!  The left/right unitor functors `1 × C ⥤ C`, `C × 1 ⥤ C`, and their inverses form an equivalence respectively.  -/
+
+universe v u
+
+open CategoryTheory
+
+namespace CategoryTheory.prod
+
+variable (C : Type u) [Category.{v} C]
+
+/-- The left unitor functor `1 × C ⥤ C` -/
+@[simps]
+def leftUnitor : Discrete PUnit × C ⥤ C where
+  obj X := X.2
+  map f := f.2
+
+/-- The right unitor functor `C × 1 ⥤ C` -/
+@[simps]
+def rightUnitor : C × Discrete PUnit ⥤ C where
+  obj X := X.1
+  map f := f.1
+
+/-- The left inverse unitor `C ⥤ 1 × C` -/
+@[simps]
+def leftInverseUnitor : C ⥤ Discrete PUnit × C where
+  obj X := ⟨⟨PUnit.unit⟩, X⟩
+  map f := ⟨𝟙 _, f⟩
+
+/-- The right inverse unitor `C ⥤ C × 1` -/
+@[simps]
+def rightInverseUnitor : C ⥤ C × Discrete PUnit where
+  obj X := ⟨X, ⟨PUnit.unit⟩⟩
+  map f := ⟨f, 𝟙 _⟩
+
+/-- The equivalence of categories expressing left unity of products of categories.  -/
+@[simps]
+def leftUnitorEquivalence : Discrete PUnit × C ≌ C where
+  functor := leftUnitor C
+  inverse := leftInverseUnitor C
+  unitIso := Iso.refl _
+  counitIso := Iso.refl _
+
+/-- The equivalence of categories expressing right unity of products of categories.  -/
+@[simps]
+def rightUnitorEquivalence : C × Discrete PUnit ≌ C where
+  functor := rightUnitor C
+  inverse := rightInverseUnitor C
+  unitIso := Iso.refl _
+  counitIso := Iso.refl _
+
+instance leftUnitor_isEquivalence : (leftUnitor C).IsEquivalence :=
+  (leftUnitorEquivalence C).isEquivalence_functor
+
+instance rightUnitor_isEquivalence : (rightUnitor C).IsEquivalence :=
+  (rightUnitorEquivalence C).isEquivalence_functor
+
+end CategoryTheory.prod

--- a/Mathlib/CategoryTheory/Products/Unitor.lean
+++ b/Mathlib/CategoryTheory/Products/Unitor.lean
@@ -10,7 +10,7 @@ import Mathlib.CategoryTheory.DiscreteCategory
 # The left/right unitor equivalences `1 × C ≌ C` and `C × 1 ≌ C`.
 -/
 
-universe v u
+universe w v u
 
 open CategoryTheory
 
@@ -20,31 +20,31 @@ variable (C : Type u) [Category.{v} C]
 
 /-- The left unitor functor `1 × C ⥤ C` -/
 @[simps]
-def leftUnitor : Discrete PUnit × C ⥤ C where
+def leftUnitor : Discrete (PUnit: Type w) × C ⥤ C where
   obj X := X.2
   map f := f.2
 
 /-- The right unitor functor `C × 1 ⥤ C` -/
 @[simps]
-def rightUnitor : C × Discrete PUnit ⥤ C where
+def rightUnitor : C × Discrete (PUnit: Type w) ⥤ C where
   obj X := X.1
   map f := f.1
 
 /-- The left inverse unitor `C ⥤ 1 × C` -/
 @[simps]
-def leftInverseUnitor : C ⥤ Discrete PUnit × C where
+def leftInverseUnitor : C ⥤ Discrete (PUnit: Type w) × C where
   obj X := ⟨⟨PUnit.unit⟩, X⟩
   map f := ⟨𝟙 _, f⟩
 
 /-- The right inverse unitor `C ⥤ C × 1` -/
 @[simps]
-def rightInverseUnitor : C ⥤ C × Discrete PUnit where
+def rightInverseUnitor : C ⥤ C × Discrete (PUnit: Type w) where
   obj X := ⟨X, ⟨PUnit.unit⟩⟩
   map f := ⟨f, 𝟙 _⟩
 
 /-- The equivalence of categories expressing left unity of products of categories.  -/
 @[simps]
-def leftUnitorEquivalence : Discrete PUnit × C ≌ C where
+def leftUnitorEquivalence : Discrete (PUnit: Type w) × C ≌ C where
   functor := leftUnitor C
   inverse := leftInverseUnitor C
   unitIso := Iso.refl _
@@ -52,7 +52,7 @@ def leftUnitorEquivalence : Discrete PUnit × C ≌ C where
 
 /-- The equivalence of categories expressing right unity of products of categories.  -/
 @[simps]
-def rightUnitorEquivalence : C × Discrete PUnit ≌ C where
+def rightUnitorEquivalence : C × Discrete (PUnit: Type w) ≌ C where
   functor := rightUnitor C
   inverse := rightInverseUnitor C
   unitIso := Iso.refl _

--- a/Mathlib/CategoryTheory/Products/Unitor.lean
+++ b/Mathlib/CategoryTheory/Products/Unitor.lean
@@ -20,31 +20,31 @@ variable (C : Type u) [Category.{v} C]
 
 /-- The left unitor functor `1 × C ⥤ C` -/
 @[simps]
-def leftUnitor : Discrete (PUnit: Type w) × C ⥤ C where
+def leftUnitor : Discrete (PUnit : Type w) × C ⥤ C where
   obj X := X.2
   map f := f.2
 
 /-- The right unitor functor `C × 1 ⥤ C` -/
 @[simps]
-def rightUnitor : C × Discrete (PUnit: Type w) ⥤ C where
+def rightUnitor : C × Discrete (PUnit : Type w) ⥤ C where
   obj X := X.1
   map f := f.1
 
 /-- The left inverse unitor `C ⥤ 1 × C` -/
 @[simps]
-def leftInverseUnitor : C ⥤ Discrete (PUnit: Type w) × C where
+def leftInverseUnitor : C ⥤ Discrete (PUnit : Type w) × C where
   obj X := ⟨⟨PUnit.unit⟩, X⟩
   map f := ⟨𝟙 _, f⟩
 
 /-- The right inverse unitor `C ⥤ C × 1` -/
 @[simps]
-def rightInverseUnitor : C ⥤ C × Discrete (PUnit: Type w) where
+def rightInverseUnitor : C ⥤ C × Discrete (PUnit : Type w) where
   obj X := ⟨X, ⟨PUnit.unit⟩⟩
   map f := ⟨f, 𝟙 _⟩
 
 /-- The equivalence of categories expressing left unity of products of categories.  -/
 @[simps]
-def leftUnitorEquivalence : Discrete (PUnit: Type w) × C ≌ C where
+def leftUnitorEquivalence : Discrete (PUnit : Type w) × C ≌ C where
   functor := leftUnitor C
   inverse := leftInverseUnitor C
   unitIso := Iso.refl _
@@ -52,7 +52,7 @@ def leftUnitorEquivalence : Discrete (PUnit: Type w) × C ≌ C where
 
 /-- The equivalence of categories expressing right unity of products of categories.  -/
 @[simps]
-def rightUnitorEquivalence : C × Discrete (PUnit: Type w) ≌ C where
+def rightUnitorEquivalence : C × Discrete (PUnit : Type w) ≌ C where
   functor := rightUnitor C
   inverse := rightInverseUnitor C
   unitIso := Iso.refl _


### PR DESCRIPTION
left and right unitor functors for product of categories

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)

The implementation is copying from the same file for the associator. I am not sure if the category "1" , i.e., `Discrete Punit` should take universe parameter or not, and if it should have some notation like U+1D7CF 𝟏 or something else.