### PR TITLE
[Merged by Bors] - feat: the homology sequence of a distinguished triangle in the derived category

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -288,6 +288,7 @@ import Mathlib.Algebra.Homology.ComplexShape
 import Mathlib.Algebra.Homology.ComplexShapeSigns
 import Mathlib.Algebra.Homology.ConcreteCategory
 import Mathlib.Algebra.Homology.DerivedCategory.Basic
+import Mathlib.Algebra.Homology.DerivedCategory.HomologySequence
 import Mathlib.Algebra.Homology.DifferentialObject
 import Mathlib.Algebra.Homology.Embedding.Basic
 import Mathlib.Algebra.Homology.Exact

--- a/Mathlib/Algebra/Homology/DerivedCategory/Basic.lean
+++ b/Mathlib/Algebra/Homology/DerivedCategory/Basic.lean
@@ -46,7 +46,6 @@ instance should be obtained at the beginning of the proof, using the term
 
 ## TODO (@joelriou)
 
-- define the induced homological functor `DerivedCategory C ⥤ C`.
 - construct the distinguished triangle associated to a short exact sequence
 of cochain complexes, and compare the associated connecting homomorphism
 with the one defined in `Algebra.Homology.HomologySequence`.
@@ -184,5 +183,16 @@ instance : (Qh (C := C)).IsTriangulated :=
 noncomputable instance : IsTriangulated (DerivedCategory C) :=
   Triangulated.Localization.isTriangulated
     Qh (HomotopyCategory.subcategoryAcyclic C).W
+
+instance : (Qh (C := C)).mapArrow.EssSurj :=
+  Localization.essSurj_mapArrow _ (HomotopyCategory.subcategoryAcyclic C).W
+
+instance {D : Type*} [Category D] : ((whiskeringLeft _ _ D).obj (Qh (C := C))).Full :=
+  inferInstanceAs
+    (Localization.whiskeringLeftFunctor' _ (HomotopyCategory.quasiIso _ _) D).Full
+
+instance {D : Type*} [Category D] : ((whiskeringLeft _ _ D).obj (Qh (C := C))).Faithful :=
+  inferInstanceAs
+    (Localization.whiskeringLeftFunctor' _ (HomotopyCategory.quasiIso _ _) D).Faithful
 
 end DerivedCategory

--- a/Mathlib/Algebra/Homology/DerivedCategory/HomologySequence.lean
+++ b/Mathlib/Algebra/Homology/DerivedCategory/HomologySequence.lean
@@ -6,6 +6,15 @@ Authors: Joël Riou
 
 import Mathlib.Algebra.Homology.DerivedCategory.Basic
 
+/-! The homology sequence
+
+In this file, we construct `homologyFunctor C n : DerivedCategory C ⥤ C` for all `n : ℤ`,
+show that they are homological functors which form a shift sequence, and construct
+the long exact homology sequences associated to distinguished triangles in the
+derived category.
+
+-/
+
 universe w v u
 
 open CategoryTheory Pretriangulated

--- a/Mathlib/Algebra/Homology/DerivedCategory/HomologySequence.lean
+++ b/Mathlib/Algebra/Homology/DerivedCategory/HomologySequence.lean
@@ -59,17 +59,15 @@ lemma δ_comp : δ T n₀ n₁ h ≫ (homologyFunctor C n₁).map T.mor₁ = 0 :
   (homologyFunctor C 0).homologySequenceδ_comp _ hT _ _ h
 
 lemma exact₂ :
-  (ShortComplex.mk ((homologyFunctor C n₀).map T.mor₁) ((homologyFunctor C n₀).map T.mor₂)
-    (by simp only [← Functor.map_comp, comp_distTriang_mor_zero₁₂ _ hT,
-      Functor.map_zero])).Exact :=
+    (ShortComplex.mk ((homologyFunctor C n₀).map T.mor₁) ((homologyFunctor C n₀).map T.mor₂)
+      (by simp only [← Functor.map_comp, comp_distTriang_mor_zero₁₂ _ hT,
+        Functor.map_zero])).Exact :=
   (homologyFunctor C 0).homologySequence_exact₂ _ hT _
 
-lemma exact₃ :
-  (ShortComplex.mk _ _ (comp_δ T hT n₀ n₁ h)).Exact :=
+lemma exact₃ : (ShortComplex.mk _ _ (comp_δ T hT n₀ n₁ h)).Exact :=
   (homologyFunctor C 0).homologySequence_exact₃ _ hT _ _ h
 
-lemma exact₁ :
-  (ShortComplex.mk _ _ (δ_comp T hT n₀ n₁ h)).Exact :=
+lemma exact₁ : (ShortComplex.mk _ _ (δ_comp T hT n₀ n₁ h)).Exact :=
   (homologyFunctor C 0).homologySequence_exact₁ _ hT _ _ h
 
 lemma epi_homologyMap_mor₁_iff :

--- a/Mathlib/Algebra/Homology/DerivedCategory/HomologySequence.lean
+++ b/Mathlib/Algebra/Homology/DerivedCategory/HomologySequence.lean
@@ -62,9 +62,11 @@ triangle in the derived category. -/
 noncomputable def δ : (homologyFunctor C n₀).obj T.obj₃ ⟶ (homologyFunctor C n₁).obj T.obj₁ :=
   (homologyFunctor C 0).shiftMap T.mor₃ n₀ n₁ (by rw [add_comm 1, h])
 
+@[reassoc (attr := simp)]
 lemma comp_δ : (homologyFunctor C n₀).map T.mor₂ ≫ δ T n₀ n₁ h = 0 :=
   (homologyFunctor C 0).comp_homologySequenceδ _ hT _ _ h
 
+@[reassoc (attr := simp)]
 lemma δ_comp : δ T n₀ n₁ h ≫ (homologyFunctor C n₁).map T.mor₁ = 0 :=
   (homologyFunctor C 0).homologySequenceδ_comp _ hT _ _ h
 

--- a/Mathlib/Algebra/Homology/DerivedCategory/HomologySequence.lean
+++ b/Mathlib/Algebra/Homology/DerivedCategory/HomologySequence.lean
@@ -6,7 +6,8 @@ Authors: Joël Riou
 
 import Mathlib.Algebra.Homology.DerivedCategory.Basic
 
-/-! The homology sequence
+/-!
+# The homology sequence
 
 In this file, we construct `homologyFunctor C n : DerivedCategory C ⥤ C` for all `n : ℤ`,
 show that they are homological functors which form a shift sequence, and construct

--- a/Mathlib/Algebra/Homology/DerivedCategory/HomologySequence.lean
+++ b/Mathlib/Algebra/Homology/DerivedCategory/HomologySequence.lean
@@ -1,0 +1,93 @@
+/-
+Copyright (c) 2024 Joël Riou. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Joël Riou
+-/
+
+import Mathlib.Algebra.Homology.DerivedCategory.Basic
+
+universe w v u
+
+open CategoryTheory Pretriangulated
+
+variable (C : Type u) [Category.{v} C] [Abelian C] [HasDerivedCategory.{w} C]
+
+namespace DerivedCategory
+
+/-- The homology functor `DerivedCategory C ⥤ C` in degree `n : ℤ`. -/
+noncomputable def homologyFunctor (n : ℤ) : DerivedCategory C ⥤ C :=
+  HomologicalComplexUpToQuasiIso.homologyFunctor C (ComplexShape.up ℤ) n
+
+/-- The homology functor on the derived category is induced by the homology
+functor on the category of cochain complexes. -/
+noncomputable def homologyFunctorFactors (n : ℤ) : Q ⋙ homologyFunctor C n ≅
+    HomologicalComplex.homologyFunctor _ _ n :=
+  HomologicalComplexUpToQuasiIso.homologyFunctorFactors C (ComplexShape.up ℤ) n
+
+/-- The homology functor on the derived category is induced by the homology
+functor on the homotopy category of cochain complexes. -/
+noncomputable def homologyFunctorFactorsh (n : ℤ) : Qh ⋙ homologyFunctor C n ≅
+    HomotopyCategory.homologyFunctor _ _ n :=
+  HomologicalComplexUpToQuasiIso.homologyFunctorFactorsh C (ComplexShape.up ℤ) n
+
+instance (n : ℤ) : (homologyFunctor C n).IsHomological :=
+  Functor.isHomological_of_localization Qh
+    (homologyFunctor C n) _ (homologyFunctorFactorsh C n)
+
+/-- The functors `homologyFunctor C n : DerivedCategory C ⥤ C` for all `n : ℤ` are part
+of a "shift sequence", i.e. they satisfy compatiblities with shifts. -/
+noncomputable instance : (homologyFunctor C 0).ShiftSequence ℤ :=
+  Functor.ShiftSequence.induced (homologyFunctorFactorsh C 0) ℤ
+    (homologyFunctor C) (homologyFunctorFactorsh C)
+
+variable {C}
+
+namespace HomologySequence
+
+variable (T : Triangle (DerivedCategory C)) (hT : T ∈ distTriang _)
+  (n₀ n₁ : ℤ) (h : n₀ + 1 = n₁)
+
+/-- The connecting homomorphism on the homology sequence attached to a distinguished
+triangle in the derived category. -/
+noncomputable def δ : (homologyFunctor C n₀).obj T.obj₃ ⟶ (homologyFunctor C n₁).obj T.obj₁ :=
+  (homologyFunctor C 0).shiftMap T.mor₃ n₀ n₁ (by rw [add_comm 1, h])
+
+lemma comp_δ : (homologyFunctor C n₀).map T.mor₂ ≫ δ T n₀ n₁ h = 0 :=
+  (homologyFunctor C 0).comp_homologySequenceδ _ hT _ _ h
+
+lemma δ_comp : δ T n₀ n₁ h ≫ (homologyFunctor C n₁).map T.mor₁ = 0 :=
+  (homologyFunctor C 0).homologySequenceδ_comp _ hT _ _ h
+
+lemma exact₂ :
+  (ShortComplex.mk ((homologyFunctor C n₀).map T.mor₁) ((homologyFunctor C n₀).map T.mor₂)
+    (by simp only [← Functor.map_comp, comp_distTriang_mor_zero₁₂ _ hT,
+      Functor.map_zero])).Exact :=
+  (homologyFunctor C 0).homologySequence_exact₂ _ hT _
+
+lemma exact₃ :
+  (ShortComplex.mk _ _ (comp_δ T hT n₀ n₁ h)).Exact :=
+  (homologyFunctor C 0).homologySequence_exact₃ _ hT _ _ h
+
+lemma exact₁ :
+  (ShortComplex.mk _ _ (δ_comp T hT n₀ n₁ h)).Exact :=
+  (homologyFunctor C 0).homologySequence_exact₁ _ hT _ _ h
+
+lemma epi_homologyMap_mor₁_iff :
+    Epi ((homologyFunctor C n₀).map T.mor₁) ↔ (homologyFunctor C n₀).map T.mor₂ = 0 :=
+  (homologyFunctor C 0).homologySequence_epi_shift_map_mor₁_iff _ hT _
+
+lemma mono_homologyMap_mor₁_iff :
+    Mono ((homologyFunctor C n₁).map T.mor₁) ↔ δ T n₀ n₁ h = 0 :=
+  (homologyFunctor C 0).homologySequence_mono_shift_map_mor₁_iff _ hT _ _ h
+
+lemma epi_homologyMap_mor₂_iff :
+    Epi ((homologyFunctor C n₀).map T.mor₂) ↔ δ T n₀ n₁ h = 0 :=
+  (homologyFunctor C 0).homologySequence_epi_shift_map_mor₂_iff _ hT _ _ h
+
+lemma mono_homologyMap_mor₂_iff :
+    Mono ((homologyFunctor C n₀).map T.mor₂) ↔ (homologyFunctor C n₀).map T.mor₁ = 0 :=
+  (homologyFunctor C 0).homologySequence_mono_shift_map_mor₂_iff _ hT n₀
+
+end HomologySequence
+
+end DerivedCategory

--- a/Mathlib/CategoryTheory/Localization/Triangulated.lean
+++ b/Mathlib/CategoryTheory/Localization/Triangulated.lean
@@ -224,4 +224,23 @@ end Localization
 
 end Triangulated
 
+namespace Functor
+
+variable [HasZeroObject D] [Preadditive D] [∀ (n : ℤ), (shiftFunctor D n).Additive]
+  [Pretriangulated D] [L.mapArrow.EssSurj] [L.IsTriangulated]
+
+lemma distTriang_iff (T : Triangle D) :
+    (T ∈ distTriang D) ↔ T ∈ L.essImageDistTriang := by
+  constructor
+  · intro hT
+    let f := L.mapArrow.objPreimage T.mor₁
+    obtain ⟨Z, g : f.right ⟶ Z, h : Z ⟶ f.left⟦(1 : ℤ)⟧, mem⟩ :=
+      Pretriangulated.distinguished_cocone_triangle f.hom
+    exact ⟨_, (exists_iso_of_arrow_iso T _ hT (L.map_distinguished _ mem)
+      (L.mapArrow.objObjPreimageIso T.mor₁).symm).choose, mem⟩
+  · rintro ⟨T₀, e, hT₀⟩
+    exact isomorphic_distinguished _ (L.map_distinguished _ hT₀) _ e
+
+end Functor
+
 end CategoryTheory

--- a/Mathlib/CategoryTheory/Triangulated/HomologicalFunctor.lean
+++ b/Mathlib/CategoryTheory/Triangulated/HomologicalFunctor.lean
@@ -141,7 +141,7 @@ instance (priority := 100) [F.IsHomological] : F.Additive :=
   F.additive_of_preserves_binary_products
 
 lemma isHomological_of_localization (L : C ⥤ D)
-    [L.CommShift ℤ] [L.IsTriangulated] [L.mapArrow.EssSurj ] (F : D ⥤ A)
+    [L.CommShift ℤ] [L.IsTriangulated] [L.mapArrow.EssSurj] (F : D ⥤ A)
     (G : C ⥤ A) (e : L ⋙ F ≅ G) [G.IsHomological] :
     F.IsHomological := by
   have : F.PreservesZeroMorphisms := preservesZeroMorphisms_of_map_zero_object

--- a/Mathlib/CategoryTheory/Triangulated/HomologicalFunctor.lean
+++ b/Mathlib/CategoryTheory/Triangulated/HomologicalFunctor.lean
@@ -140,6 +140,18 @@ noncomputable instance (priority := 100) [F.IsHomological] :
 instance (priority := 100) [F.IsHomological] : F.Additive :=
   F.additive_of_preserves_binary_products
 
+lemma isHomological_of_localization (L : C ⥤ D)
+    [L.CommShift ℤ] [L.IsTriangulated] [L.mapArrow.EssSurj ] (F : D ⥤ A)
+    (G : C ⥤ A) (e : L ⋙ F ≅ G) [G.IsHomological] :
+    F.IsHomological := by
+  have : F.PreservesZeroMorphisms := preservesZeroMorphisms_of_map_zero_object
+    (F.mapIso L.mapZeroObject.symm ≪≫ e.app _ ≪≫ G.mapZeroObject)
+  have : (L ⋙ F).IsHomological := IsHomological.of_iso e.symm
+  refine IsHomological.mk' _ (fun T hT => ?_)
+  rw [L.distTriang_iff] at hT
+  obtain ⟨T₀, e, hT₀⟩ := hT
+  exact ⟨L.mapTriangle.obj T₀, e, (L ⋙ F).map_distinguished_exact _ hT₀⟩
+
 section
 
 variable [F.IsHomological] [F.ShiftSequence ℤ] (T T' : Triangle C) (hT : T ∈ distTriang C)


### PR DESCRIPTION
In this PR, we define `homologyFunctor C n : DerivedCategory C ⥤ C`, show they are homological functors and construct the long exact sequences associated to distinguished triangles in the derived category.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
