### PR TITLE
[Merged by Bors] - chore(build*.yml): only update Mathlib.lean once

### DIFF
--- a/.github/workflows/bors.yml
+++ b/.github/workflows/bors.yml
@@ -130,12 +130,6 @@ jobs:
 
       - uses: actions/checkout@v4
 
-      # We update `Mathlib.lean` as a convenience here,
-      # but verify that this didn't change anything in the `check_imported` job.
-      - name: update Mathlib.lean
-        run: |
-          lake exe mk_all --lib Mathlib
-
       - name: If using a lean-pr-release toolchain, uninstall
         run: |
           if [[ $(cat lean-toolchain) =~ ^leanprover/lean4-pr-releases:pr-release-[0-9]+$ ]]; then

--- a/.github/workflows/bors.yml
+++ b/.github/workflows/bors.yml
@@ -145,9 +145,6 @@ jobs:
       - name: update {Mathlib, Tactic, Counterexamples, Archive}.lean
         run: lake exe mk_all
 
-      - name: check_imported
-        run: git diff --exit-code
-
       - name: build cache
         run: |
           lake build cache

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -137,12 +137,6 @@ jobs:
 
       - uses: actions/checkout@v4
 
-      # We update `Mathlib.lean` as a convenience here,
-      # but verify that this didn't change anything in the `check_imported` job.
-      - name: update Mathlib.lean
-        run: |
-          lake exe mk_all --lib Mathlib
-
       - name: If using a lean-pr-release toolchain, uninstall
         run: |
           if [[ $(cat lean-toolchain) =~ ^leanprover/lean4-pr-releases:pr-release-[0-9]+$ ]]; then

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -152,9 +152,6 @@ jobs:
       - name: update {Mathlib, Tactic, Counterexamples, Archive}.lean
         run: lake exe mk_all
 
-      - name: check_imported
-        run: git diff --exit-code
-
       - name: build cache
         run: |
           lake build cache

--- a/.github/workflows/build.yml.in
+++ b/.github/workflows/build.yml.in
@@ -116,12 +116,6 @@ jobs:
 
       - uses: actions/checkout@v4
 
-      # We update `Mathlib.lean` as a convenience here,
-      # but verify that this didn't change anything in the `check_imported` job.
-      - name: update Mathlib.lean
-        run: |
-          lake exe mk_all --lib Mathlib
-
       - name: If using a lean-pr-release toolchain, uninstall
         run: |
           if [[ $(cat lean-toolchain) =~ ^leanprover/lean4-pr-releases:pr-release-[0-9]+$ ]]; then

--- a/.github/workflows/build.yml.in
+++ b/.github/workflows/build.yml.in
@@ -131,9 +131,6 @@ jobs:
       - name: update {Mathlib, Tactic, Counterexamples, Archive}.lean
         run: lake exe mk_all
 
-      - name: check_imported
-        run: git diff --exit-code
-
       - name: build cache
         run: |
           lake build cache

--- a/.github/workflows/build_fork.yml
+++ b/.github/workflows/build_fork.yml
@@ -134,12 +134,6 @@ jobs:
 
       - uses: actions/checkout@v4
 
-      # We update `Mathlib.lean` as a convenience here,
-      # but verify that this didn't change anything in the `check_imported` job.
-      - name: update Mathlib.lean
-        run: |
-          lake exe mk_all --lib Mathlib
-
       - name: If using a lean-pr-release toolchain, uninstall
         run: |
           if [[ $(cat lean-toolchain) =~ ^leanprover/lean4-pr-releases:pr-release-[0-9]+$ ]]; then

--- a/.github/workflows/build_fork.yml
+++ b/.github/workflows/build_fork.yml
@@ -149,9 +149,6 @@ jobs:
       - name: update {Mathlib, Tactic, Counterexamples, Archive}.lean
         run: lake exe mk_all
 
-      - name: check_imported
-        run: git diff --exit-code
-
       - name: build cache
         run: |
           lake build cache

--- a/.github/workflows/lint_and_suggest_pr.yml
+++ b/.github/workflows/lint_and_suggest_pr.yml
@@ -67,9 +67,6 @@ jobs:
       - name: update {Mathlib, Tactic, Counterexamples, Archive}.lean
         run: lake exe mk_all
 
-      - name: check_imported
-        run: git diff --exit-code
-
       - name: suggester / import list
         uses: reviewdog/action-suggester@v1
         with:


### PR DESCRIPTION
The current workflow updates `Mathlib.lean` twice: there's no reason to do so. Since 'check_imported' step moved into the 'build' step, any old reasons for this duplication are now obsolete.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
