### PR TITLE
[Merged by Bors] - chore(Algebra/Group/Hom/Instances): remove obsolete adaptation note

### DIFF
--- a/Mathlib/Algebra/Group/Hom/Instances.lean
+++ b/Mathlib/Algebra/Group/Hom/Instances.lean
@@ -67,13 +67,6 @@ instance MonoidHom.commGroup {M G} [MulOneClass M] [CommGroup G] : CommGroup (M 
       simp,
     zpow_succ' := fun n f => by
       ext x
-      -- Adaptation note: nightly-2024-03-24
-      -- We used to need a `simp [mul_comm]` after `simp [zpow_add_one]`.
-      -- Writing `simp [zpow_add_one, mul_comm]` still shows the bug mentioned below.
-      -- Adaptation note: nightly-2024-03-13
-      -- https://github.com/leanprover-community/mathlib4/issues/11357
-      -- If we add `mul_comm` to the simp call we reveal a bug: "unexpected bound variable #0"
-      -- Hopefully we can minimize this.
       simp [zpow_add_one],
     zpow_neg' := fun n f => by
       ext x


### PR DESCRIPTION
The underlying bug (#11357) has been fixed.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
