### PR TITLE
[Merged by Bors] - fix(test/Lint.lean): re-enable test for duplicate namespaces

### DIFF
--- a/Mathlib/Tactic/Linter/Lint.lean
+++ b/Mathlib/Tactic/Linter/Lint.lean
@@ -76,7 +76,7 @@ def getLinterDupNamespace (o : Options) : Bool := Linter.getLinterValue linter.d
 If `stx` is an `alias` or an `export`, then it extracts an `ident`, instead of a `declId`. -/
 partial
 def getIds : Syntax → Array Syntax
-  | .node _ `Std.Tactic.Alias.alias args => #[args[2]!]
+  | .node _ `Batteries.Tactic.Alias.alias args => #[args[2]!]
   | .node _ ``Lean.Parser.Command.export args => #[args[3]![0]]
   | stx@(.node _ _ args) =>
     ((args.attach.map fun ⟨a, _⟩ => getIds a).foldl (· ++ ·) #[stx]).filter (·.getKind == ``declId)

--- a/test/Lint.lean
+++ b/test/Lint.lean
@@ -35,12 +35,10 @@ run_cmd Lean.Elab.Command.liftTermElabM do
 
 namespace Nat
 
--- TODO: this test should print the following (currently, doesn't warn at all)
--- delete this test, or fix and re-enable it!
--- /--
--- warning:
--- The namespace 'Nat' is duplicated in the declaration 'Foo.Nat.Nat.Nats' [linter.dupNamespace]
--- -/
+/--
+warning: The namespace 'Nat' is duplicated in the declaration 'Foo.Nat.Nat.Nats'
+note: this linter can be disabled with `set_option linter.dupNamespace false`
+-/
 #guard_msgs in
 set_option linter.dupNamespace true in
 alias Nat.Nats := Nat

--- a/test/Lint.lean
+++ b/test/Lint.lean
@@ -1,31 +1,28 @@
 import Mathlib.Tactic.Linter.Lint
 import Mathlib.Tactic.ToAdditive
-import Mathlib.Tactic.AdaptationNote
 
-#adaptation_note /-- test disabled.
-See https://leanprover.zulipchat.com/#narrow/stream/348111-std4/topic/.23guard_msgs.20doesn't.20silence.20warnings/near/423534679
-The linter warning is being printed twice, and #guard_msgs is only capturing one of them. -/
+-- TODO: the linter also runs on the #guard_msg, so disable it once
+-- See https://leanprover.zulipchat.com/#narrow/stream/348111-std4/topic/.23guard_msgs.20doesn't.20silence.20warnings/near/423534679
 
--- set_option linter.dupNamespace true in
--- /-- warning:
--- The namespace 'add' is duplicated in the declaration 'add.add'
--- [linter.dupNamespace]
--- -/
--- #guard_msgs in
--- def add.add := True
+set_option linter.dupNamespace false
+
+/--
+warning: The namespace 'add' is duplicated in the declaration 'add.add'
+note: this linter can be disabled with `set_option linter.dupNamespace false`
+-/
+#guard_msgs in
+set_option linter.dupNamespace true in
+def add.add := True
 
 namespace Foo
-#adaptation_note /-- test disabled.
-See https://leanprover.zulipchat.com/#narrow/stream/348111-std4/topic/.23guard_msgs.20doesn't.20silence.20warnings/near/423534679
-The linter warning is being printed twice, and #guard_msgs is only capturing one of them. -/
 
--- set_option linter.dupNamespace true in
--- /-- warning:
--- The namespace 'Foo' is duplicated in the declaration 'Foo.Foo.foo'
--- [linter.dupNamespace]
--- -/
--- #guard_msgs in
--- def Foo.foo := True
+/--
+warning: The namespace 'Foo' is duplicated in the declaration 'Foo.Foo.foo'
+note: this linter can be disabled with `set_option linter.dupNamespace false`
+-/
+#guard_msgs in
+set_option linter.dupNamespace true in
+def Foo.foo := True
 
 -- the `dupNamespace` linter does not notice that `to_additive` created `Foo.add.add`.
 #guard_msgs in
@@ -38,26 +35,25 @@ run_cmd Lean.Elab.Command.liftTermElabM do
 
 namespace Nat
 
-#adaptation_note /-- test disabled.
-See https://leanprover.zulipchat.com/#narrow/stream/348111-std4/topic/.23guard_msgs.20doesn't.20silence.20warnings/near/423534679
-The linter warning is being printed twice, and #guard_msgs is only capturing one of them. -/
+-- TODO: this test should print the following (currently, doesn't warn at all)
+-- delete this test, or fix and re-enable it!
 -- /--
 -- warning:
 -- The namespace 'Nat' is duplicated in the declaration 'Foo.Nat.Nat.Nats' [linter.dupNamespace]
 -- -/
--- #guard_msgs in
--- alias Nat.Nats := Nat
+#guard_msgs in
+set_option linter.dupNamespace true in
+alias Nat.Nats := Nat
 
 end Nat
 end Foo
 
 namespace add
 
-#adaptation_note /-- test disabled.
-See https://leanprover.zulipchat.com/#narrow/stream/348111-std4/topic/.23guard_msgs.20doesn't.20silence.20warnings/near/423534679
-The linter warning is being printed twice, and #guard_msgs is only capturing one of them. -/
--- /--
--- warning: The namespace 'add' is duplicated in the declaration 'add.add' [linter.dupNamespace]
--- -/
--- #guard_msgs in
--- export Nat (add)
+/--
+warning: The namespace 'add' is duplicated in the declaration 'add.add'
+note: this linter can be disabled with `set_option linter.dupNamespace false`
+-/
+#guard_msgs in
+set_option linter.dupNamespace true in
+export Nat (add)


### PR DESCRIPTION
There is a standard hack for dealing with linters running on #guard_msg themselves - so re-enable the test using it.
One test broke during the std->batteries rename; fix it.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
