### PR TITLE
[Merged by Bors] - chore(*): drop some bit0/bit1 lemmas

### DIFF
--- a/Mathlib/Algebra/Algebra/Hom.lean
+++ b/Mathlib/Algebra/Algebra/Hom.lean
@@ -270,15 +270,8 @@ protected theorem map_finsupp_sum {α : Type*} [Zero α] {ι : Type*} (f : ι �
   map_finsupp_sum _ _ _
 #align alg_hom.map_finsupp_sum AlgHom.map_finsupp_sum
 
-set_option linter.deprecated false in
-protected theorem map_bit0 (x) : φ (bit0 x) = bit0 (φ x) :=
-  map_bit0 _ _
-#align alg_hom.map_bit0 AlgHom.map_bit0
-
-set_option linter.deprecated false in
-protected theorem map_bit1 (x) : φ (bit1 x) = bit1 (φ x) :=
-  map_bit1 _ _
-#align alg_hom.map_bit1 AlgHom.map_bit1
+#noalign alg_hom.map_bit0
+#noalign alg_hom.map_bit1
 
 /-- If a `RingHom` is `R`-linear, then it is an `AlgHom`. -/
 def mk' (f : A →+* B) (h : ∀ (c : R) (x), f (c • x) = c • f x) : A →ₐ[R] B :=

--- a/Mathlib/Algebra/Order/Monoid/WithTop.lean
+++ b/Mathlib/Algebra/Order/Monoid/WithTop.lean
@@ -116,20 +116,8 @@ instance add : Add (WithTop α) :=
 @[simp, norm_cast] lemma coe_add (a b : α) : ↑(a + b) = (a + b : WithTop α) := rfl
 #align with_top.coe_add WithTop.coe_add
 
-section deprecated
-set_option linter.deprecated false
-
-@[norm_cast, deprecated]
-theorem coe_bit0 : ((bit0 x : α) : WithTop α) = (bit0 x : WithTop α) :=
-  rfl
-#align with_top.coe_bit0 WithTop.coe_bit0
-
-@[norm_cast, deprecated]
-theorem coe_bit1 [One α] {a : α} : ((bit1 a : α) : WithTop α) = (bit1 a : WithTop α) :=
-  rfl
-#align with_top.coe_bit1 WithTop.coe_bit1
-
-end deprecated
+#noalign with_top.coe_bit0
+#noalign with_top.coe_bit1
 
 @[simp]
 theorem top_add (a : WithTop α) : ⊤ + a = ⊤ :=
@@ -604,22 +592,8 @@ theorem coe_add (a b : α) : ((a + b : α) : WithBot α) = a + b :=
   rfl
 #align with_bot.coe_add WithBot.coe_add
 
-section deprecated
-set_option linter.deprecated false
-
--- Porting note: added norm_cast
-@[norm_cast, deprecated]
-theorem coe_bit0 : ((bit0 x : α) : WithBot α) = (bit0 x : WithBot α) :=
-  rfl
-#align with_bot.coe_bit0 WithBot.coe_bit0
-
--- Porting note: added norm_cast
-@[norm_cast, deprecated]
-theorem coe_bit1 [One α] {a : α} : ((bit1 a : α) : WithBot α) = (bit1 a : WithBot α) :=
-  rfl
-#align with_bot.coe_bit1 WithBot.coe_bit1
-
-end deprecated
+#noalign with_bot.coe_bit0
+#noalign with_bot.coe_bit1
 
 @[simp]
 theorem bot_add (a : WithBot α) : ⊥ + a = ⊥ :=

--- a/Mathlib/Algebra/Polynomial/AlgebraMap.lean
+++ b/Mathlib/Algebra/Polynomial/AlgebraMap.lean
@@ -238,22 +238,8 @@ theorem aeval_one : aeval x (1 : R[X]) = 1 :=
   AlgHom.map_one _
 #align polynomial.aeval_one Polynomial.aeval_one
 
-section deprecated
-set_option linter.deprecated false
-
--- Porting note: removed `@[simp]` because `simp` can prove this
-@[deprecated]
-theorem aeval_bit0 : aeval x (bit0 p) = bit0 (aeval x p) :=
-  AlgHom.map_bit0 _ _
-#align polynomial.aeval_bit0 Polynomial.aeval_bit0
-
--- Porting note: removed `@[simp]` because `simp` can prove this
-@[deprecated]
-theorem aeval_bit1 : aeval x (bit1 p) = bit1 (aeval x p) :=
-  AlgHom.map_bit1 _ _
-#align polynomial.aeval_bit1 Polynomial.aeval_bit1
-
-end deprecated
+#noalign polynomial.aeval_bit0
+#noalign polynomial.aeval_bit1
 
 -- Porting note: removed `@[simp]` because `simp` can prove this
 theorem aeval_natCast (n : ℕ) : aeval x (n : R[X]) = n :=

--- a/Mathlib/Algebra/Polynomial/Derivative.lean
+++ b/Mathlib/Algebra/Polynomial/Derivative.lean
@@ -137,15 +137,8 @@ theorem derivative_one : derivative (1 : R[X]) = 0 :=
   derivative_C
 #align polynomial.derivative_one Polynomial.derivative_one
 
-set_option linter.deprecated false in
--- Porting note (#10618): removed `simp`: `simp` can prove it.
-theorem derivative_bit0 {a : R[X]} : derivative (bit0 a) = bit0 (derivative a) := by simp [bit0]
-#align polynomial.derivative_bit0 Polynomial.derivative_bit0
-
-set_option linter.deprecated false in
--- Porting note (#10618): removed `simp`: `simp` can prove it.
-theorem derivative_bit1 {a : R[X]} : derivative (bit1 a) = bit0 (derivative a) := by simp [bit1]
-#align polynomial.derivative_bit1 Polynomial.derivative_bit1
+#noalign polynomial.derivative_bit0
+#noalign polynomial.derivative_bit1
 
 -- Porting note (#10618): removed `simp`: `simp` can prove it.
 theorem derivative_add {f g : R[X]} : derivative (f + g) = derivative f + derivative g :=

--- a/Mathlib/Algebra/Polynomial/Eval.lean
+++ b/Mathlib/Algebra/Polynomial/Eval.lean
@@ -810,17 +810,8 @@ protected theorem map_ofNat (n : ℕ) [n.AtLeastTwo] :
     (no_index (OfNat.ofNat n) : R[X]).map f = OfNat.ofNat n :=
   show (n : R[X]).map f = n by rw [Polynomial.map_natCast]
 
-set_option linter.deprecated false in
-@[simp]
-protected theorem map_bit0 : (bit0 p).map f = bit0 (p.map f) :=
-  map_bit0 (mapRingHom f) p
-#align polynomial.map_bit0 Polynomial.map_bit0
-
-set_option linter.deprecated false in
-@[simp]
-protected theorem map_bit1 : (bit1 p).map f = bit1 (p.map f) :=
-  map_bit1 (mapRingHom f) p
-#align polynomial.map_bit1 Polynomial.map_bit1
+#noalign polynomial.map_bit0
+#noalign polynomial.map_bit1
 
 --TODO rename to `map_dvd_map`
 theorem map_dvd (f : R →+* S) {x y : R[X]} : x ∣ y → x.map f ∣ y.map f :=

--- a/Mathlib/Algebra/Ring/Basic.lean
+++ b/Mathlib/Algebra/Ring/Basic.lean
@@ -51,12 +51,7 @@ section AddHomClass
 variable {α β F : Type*} [NonAssocSemiring α] [NonAssocSemiring β]
   [FunLike F α β] [AddHomClass F α β]
 
-set_option linter.deprecated false in
-/-- Additive homomorphisms preserve `bit0`. -/
-@[deprecated, simp]
-theorem map_bit0 (f : F) (a : α) : (f (bit0 a) : β) = bit0 (f a) :=
-  map_add _ _ _
-#align map_bit0 map_bit0
+#noalign map_bit0
 
 end AddHomClass
 

--- a/Mathlib/Algebra/Ring/Hom/Defs.lean
+++ b/Mathlib/Algebra/Ring/Hom/Defs.lean
@@ -379,11 +379,7 @@ class RingHomClass (F : Type*) (α β : outParam Type*)
 
 variable [FunLike F α β]
 
-set_option linter.deprecated false in
-/-- Ring homomorphisms preserve `bit1`. -/
-@[simp] lemma map_bit1 [NonAssocSemiring α] [NonAssocSemiring β] [RingHomClass F α β]
-    (f : F) (a : α) : (f (bit1 a) : β) = bit1 (f a) := by simp [bit1]
-#align map_bit1 map_bit1
+#noalign map_bit1
 
 -- Porting note: marked `{}` rather than `[]` to prevent dangerous instances
 variable {_ : NonAssocSemiring α} {_ : NonAssocSemiring β} [RingHomClass F α β]

--- a/Mathlib/Algebra/Star/Basic.lean
+++ b/Mathlib/Algebra/Star/Basic.lean
@@ -451,21 +451,8 @@ theorem star_div' [Semifield R] [StarRing R] (x y : R) : star (x / y) = star x /
   rw [division_def, op_div, mul_comm, star_mul, star_inv', op_mul, op_inv]
 #align star_div' star_div'
 
-section
-
-set_option linter.deprecated false
-
-@[simp]
-theorem star_bit0 [AddMonoid R] [StarAddMonoid R] (r : R) : star (bit0 r) = bit0 (star r) := by
-  simp [bit0]
-#align star_bit0 star_bit0
-
-@[simp]
-theorem star_bit1 [Semiring R] [StarRing R] (r : R) : star (bit1 r) = bit1 (star r) := by
-  simp [bit1]
-#align star_bit1 star_bit1
-
-end
+#noalign star_bit0
+#noalign star_bit1
 
 /-- Any commutative semiring admits the trivial `*`-structure.
 

--- a/Mathlib/Algebra/Star/Module.lean
+++ b/Mathlib/Algebra/Star/Module.lean
@@ -119,8 +119,7 @@ variable {A} [Invertible (2 : R)]
 def selfAdjointPart : A →ₗ[R] selfAdjoint A where
   toFun x :=
     ⟨(⅟ 2 : R) • (x + star x), by
-      simp only [selfAdjoint.mem_iff, star_smul, add_comm, StarAddMonoid.star_add, star_inv',
-        star_bit0, star_one, star_star, star_invOf (2 : R), star_trivial]⟩
+      rw [selfAdjoint.mem_iff, star_smul, star_trivial, star_add, star_star, add_comm]⟩
   map_add' x y := by
     ext
     simp [add_add_add_comm]

--- a/Mathlib/Algebra/Star/SelfAdjoint.lean
+++ b/Mathlib/Algebra/Star/SelfAdjoint.lean
@@ -126,11 +126,7 @@ theorem add {x y : R} (hx : IsSelfAdjoint x) (hy : IsSelfAdjoint y) : IsSelfAdjo
   simp only [isSelfAdjoint_iff, star_add, hx.star_eq, hy.star_eq]
 #align is_self_adjoint.add IsSelfAdjoint.add
 
-set_option linter.deprecated false in
-@[deprecated]
-theorem bit0 {x : R} (hx : IsSelfAdjoint x) : IsSelfAdjoint (bit0 x) := by
-  simp only [isSelfAdjoint_iff, star_bit0, hx.star_eq]
-#align is_self_adjoint.bit0 IsSelfAdjoint.bit0
+#noalign is_self_adjoint.bit0
 
 end AddMonoid
 
@@ -206,11 +202,7 @@ section Semiring
 
 variable [Semiring R] [StarRing R]
 
-set_option linter.deprecated false in
-@[deprecated]
-theorem bit1 {x : R} (hx : IsSelfAdjoint x) : IsSelfAdjoint (bit1 x) := by
-  simp only [isSelfAdjoint_iff, star_bit1, hx.star_eq]
-#align is_self_adjoint.bit1 IsSelfAdjoint.bit1
+#noalign is_self_adjoint.bit1
 
 @[simp]
 theorem _root_.isSelfAdjoint_natCast (n : ℕ) : IsSelfAdjoint (n : R) :=
@@ -513,11 +505,7 @@ theorem star_val_eq {x : skewAdjoint R} : star (x : R) = -x :=
 instance : Inhabited (skewAdjoint R) :=
   ⟨0⟩
 
-set_option linter.deprecated false in
-@[deprecated]
-theorem bit0_mem {x : R} (hx : x ∈ skewAdjoint R) : bit0 x ∈ skewAdjoint R := by
-  rw [mem_iff, star_bit0, mem_iff.mp hx, bit0, bit0, neg_add]
-#align skew_adjoint.bit0_mem skewAdjoint.bit0_mem
+#noalign skew_adjoint.bit0_mem
 
 end AddGroup
 

--- a/Mathlib/Analysis/SpecificLimits/Normed.lean
+++ b/Mathlib/Analysis/SpecificLimits/Normed.lean
@@ -5,6 +5,7 @@ Authors: Anatole Dedecker, Sébastien Gouëzel, Yury G. Kudryashov, Dylan MacKen
 -/
 import Mathlib.Algebra.BigOperators.Module
 import Mathlib.Algebra.Order.Field.Basic
+import Mathlib.Order.Filter.ModEq
 import Mathlib.Analysis.Asymptotics.Asymptotics
 import Mathlib.Analysis.SpecificLimits.Basic
 import Mathlib.Data.List.TFAE

--- a/Mathlib/NumberTheory/Zsqrtd/Basic.lean
+++ b/Mathlib/NumberTheory/Zsqrtd/Basic.lean
@@ -121,29 +121,10 @@ theorem add_im (z w : ℤ√d) : (z + w).im = z.im + w.im :=
   rfl
 #align zsqrtd.add_im Zsqrtd.add_im
 
-section bit
-set_option linter.deprecated false
-
-@[simp]
-theorem bit0_re (z) : (bit0 z : ℤ√d).re = bit0 z.re :=
-  rfl
-#align zsqrtd.bit0_re Zsqrtd.bit0_re
-
-@[simp]
-theorem bit0_im (z) : (bit0 z : ℤ√d).im = bit0 z.im :=
-  rfl
-#align zsqrtd.bit0_im Zsqrtd.bit0_im
-
-@[simp]
-theorem bit1_re (z) : (bit1 z : ℤ√d).re = bit1 z.re :=
-  rfl
-#align zsqrtd.bit1_re Zsqrtd.bit1_re
-
-@[simp]
-theorem bit1_im (z) : (bit1 z : ℤ√d).im = bit0 z.im := by simp [bit1]
-#align zsqrtd.bit1_im Zsqrtd.bit1_im
-
-end bit
+#noalign zsqrtd.bit0_re
+#noalign zsqrtd.bit0_im
+#noalign zsqrtd.bit1_re
+#noalign zsqrtd.bit1_im
 
 /-- Negation in `ℤ√d` -/
 instance : Neg (ℤ√d) :=

--- a/Mathlib/Order/Filter/AtTopBot.lean
+++ b/Mathlib/Order/Filter/AtTopBot.lean
@@ -924,10 +924,7 @@ section OrderedSemiring
 
 variable [OrderedSemiring α] {l : Filter β} {f g : β → α}
 
-set_option linter.deprecated false in
-@[deprecated] theorem tendsto_bit1_atTop : Tendsto bit1 (atTop : Filter α) atTop :=
-  tendsto_atTop_add_nonneg_right tendsto_bit0_atTop fun _ => zero_le_one
-#align filter.tendsto_bit1_at_top Filter.tendsto_bit1_atTop
+#noalign filter.tendsto_bit1_at_top
 
 theorem Tendsto.atTop_mul_atTop (hf : Tendsto f l atTop) (hg : Tendsto g l atTop) :
     Tendsto (fun x => f x * g x) l atTop := by
@@ -1028,14 +1025,6 @@ theorem tendsto_pow_atTop_iff {n : ℕ} : Tendsto (fun x : α => x ^ n) atTop at
 #align filter.tendsto_pow_at_top_iff Filter.tendsto_pow_atTop_iff
 
 end LinearOrderedSemiring
-
--- Porting note (#11215): TODO: make `Odd` and `Even` available here, drop `bit1`
-set_option linter.deprecated false in
-theorem nonneg_of_eventually_pow_nonneg [LinearOrderedRing α] {a : α}
-    (h : ∀ᶠ n in atTop, 0 ≤ a ^ (n : ℕ)) : 0 ≤ a :=
-  let ⟨_n, hn⟩ := (tendsto_bit1_atTop.eventually h).exists
-  pow_bit1_nonneg_iff.1 hn
-#align filter.nonneg_of_eventually_pow_nonneg Filter.nonneg_of_eventually_pow_nonneg
 
 theorem not_tendsto_pow_atTop_atBot [LinearOrderedRing α] :
     ∀ {n : ℕ}, ¬Tendsto (fun x : α => x ^ n) atTop atBot

--- a/Mathlib/Order/Filter/AtTopBot.lean
+++ b/Mathlib/Order/Filter/AtTopBot.lean
@@ -735,15 +735,8 @@ theorem Tendsto.nsmul_atBot (hf : Tendsto f l atBot) {n : ℕ} (hn : 0 < n) :
   @Tendsto.nsmul_atTop α βᵒᵈ _ l f hf n hn
 #align filter.tendsto.nsmul_at_bot Filter.Tendsto.nsmul_atBot
 
-set_option linter.deprecated false in
-@[deprecated] theorem tendsto_bit0_atTop : Tendsto bit0 (atTop : Filter β) atTop :=
-  tendsto_atTop_add tendsto_id tendsto_id
-#align filter.tendsto_bit0_at_top Filter.tendsto_bit0_atTop
-
-set_option linter.deprecated false in
-@[deprecated] theorem tendsto_bit0_atBot : Tendsto bit0 (atBot : Filter β) atBot :=
-  tendsto_atBot_add tendsto_id tendsto_id
-#align filter.tendsto_bit0_at_bot Filter.tendsto_bit0_atBot
+#noalign filter.tendsto_bit0_at_top
+#noalign filter.tendsto_bit0_at_bot
 
 end OrderedAddCommMonoid
 

--- a/Mathlib/Order/Filter/ModEq.lean
+++ b/Mathlib/Order/Filter/ModEq.lean
@@ -39,3 +39,9 @@ theorem frequently_odd : ∃ᶠ m : ℕ in atTop, Odd m := by
 #align nat.frequently_odd Nat.frequently_odd
 
 end Nat
+
+theorem Filter.nonneg_of_eventually_pow_nonneg {α : Type*} [LinearOrderedRing α] {a : α}
+    (h : ∀ᶠ n in atTop, 0 ≤ a ^ (n : ℕ)) : 0 ≤ a :=
+  let ⟨_n, ho, hn⟩ := (Nat.frequently_odd.and_eventually h).exists
+  ho.pow_nonneg_iff.1 hn
+#align filter.nonneg_of_eventually_pow_nonneg Filter.nonneg_of_eventually_pow_nonneg


### PR DESCRIPTION
Since `bit0` and `bit1` are deprecated in Lean 4, these lemmas were deprecated for a long time.

Also move `Filter.nonneg_of_eventually_pow_nonneg` to `Order/Filter/ModEq`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
