### PR TITLE
[Merged by Bors] - chore: reduce import in NumberTheory.Divisors

### DIFF
--- a/Mathlib/Algebra/IsPrimePow.lean
+++ b/Mathlib/Algebra/IsPrimePow.lean
@@ -88,7 +88,7 @@ theorem isPrimePow_nat_iff_bounded (n : ℕ) :
   rintro ⟨p, k, hp, hk, rfl⟩
   refine ⟨p, ?_, k, (Nat.lt_pow_self hp.one_lt _).le, hp, hk, rfl⟩
   conv => { lhs; rw [← (pow_one p)] }
-  exact pow_le_pow_right hp.one_lt.le hk
+  exact Nat.pow_le_pow_right hp.one_lt.le hk
 #align is_prime_pow_nat_iff_bounded isPrimePow_nat_iff_bounded
 
 instance {n : ℕ} : Decidable (IsPrimePow n) :=

--- a/Mathlib/NumberTheory/Divisors.lean
+++ b/Mathlib/NumberTheory/Divisors.lean
@@ -4,7 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Aaron Anderson
 -/
 import Mathlib.Algebra.Order.BigOperators.Group.Finset
-import Mathlib.Algebra.Order.Ring.Basic
 import Mathlib.Data.Nat.Factors
 import Mathlib.Order.Interval.Finset.Nat
 
@@ -485,10 +484,10 @@ theorem mem_properDivisors_prime_pow {p : ℕ} (pp : p.Prime) (k : ℕ) {x : ℕ
   intro a
   constructor <;> intro h
   · rcases h with ⟨_h_left, rfl, h_right⟩
-    rw [pow_lt_pow_iff_right pp.one_lt] at h_right
-    exact ⟨h_right, by rfl⟩
+    rw [Nat.pow_lt_pow_iff_right pp.one_lt] at h_right
+    exact ⟨h_right, rfl⟩
   · rcases h with ⟨h_left, rfl⟩
-    rw [pow_lt_pow_iff_right pp.one_lt]
+    rw [Nat.pow_lt_pow_iff_right pp.one_lt]
     simp [h_left, le_of_lt]
 #align nat.mem_proper_divisors_prime_pow Nat.mem_properDivisors_prime_pow
 


### PR DESCRIPTION
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

I'm not entirely sure this is useful, but I noticed it in review and thought I'd try it. I wouldn't mind if we just said no either.

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
