### PR TITLE
[Merged by Bors] - feat(AlgebraicGeometry/ProjectiveSpectrum/Scheme): morphism of locally ringed space $\mathrm{Proj}|_{D(f)} -> \mathrm{Spec} A^0_f$

### DIFF
--- a/Mathlib/AlgebraicGeometry/ProjectiveSpectrum/Scheme.lean
+++ b/Mathlib/AlgebraicGeometry/ProjectiveSpectrum/Scheme.lean
@@ -613,8 +613,6 @@ lemma awayToSection_germ (f x) :
   ext z
   apply (Proj.stalkIso' 𝒜 x).eq_symm_apply.mpr
   apply Proj.stalkIso'_germ
-
-
 /--
 The ring map from `A⁰_ f` to the global sections of the structure sheaf of the projective spectrum
 of `A` restricted to the basic open set `D(f)`.

--- a/Mathlib/AlgebraicGeometry/ProjectiveSpectrum/Scheme.lean
+++ b/Mathlib/AlgebraicGeometry/ProjectiveSpectrum/Scheme.lean
@@ -81,6 +81,7 @@ If we further assume `m` is positive
 * `ProjIsoSpec.toSpec`: the morphism of locally ringed spaces between `Proj| pbo f` and `Spec A⁰_f`
   corresponding to the ring map `A⁰_f → Γ(Proj, pbo f)` under the Gamma-Spec adjunction defined by
   sending `s` to the section `x ↦ s` on `pbo f`.
+  
 ## Reference
 * [Robin Hartshorne, *Algebraic Geometry*][Har77]: Chapter II.2 Proposition 2.5
 -/

--- a/Mathlib/AlgebraicGeometry/ProjectiveSpectrum/Scheme.lean
+++ b/Mathlib/AlgebraicGeometry/ProjectiveSpectrum/Scheme.lean
@@ -81,7 +81,7 @@ If we further assume `m` is positive
 * `ProjIsoSpec.toSpec`: the morphism of locally ringed spaces between `Proj| pbo f` and `Spec A⁰_f`
   corresponding to the ring map `A⁰_f → Γ(Proj, pbo f)` under the Gamma-Spec adjunction defined by
   sending `s` to the section `x ↦ s` on `pbo f`.
-  
+
 ## Reference
 * [Robin Hartshorne, *Algebraic Geometry*][Har77]: Chapter II.2 Proposition 2.5
 -/

--- a/Mathlib/AlgebraicGeometry/ProjectiveSpectrum/Scheme.lean
+++ b/Mathlib/AlgebraicGeometry/ProjectiveSpectrum/Scheme.lean
@@ -78,6 +78,9 @@ If we further assume `m` is positive
   We also denote this map as `φ`
 * `projIsoSpecTopComponent`: the homeomorphism `Proj.T| pbo f ≅ Spec.T A⁰_f` obtained by `φ` and
   `ψ`.
+* `ProjIsoSpec.toSpec`: the morphism of locally ringed spaces between `Proj| pbo f` and `Spec A⁰_f`
+  corresponding to the ring map `A⁰_f → Γ(Proj, pbo f)` under the Gamma-Spec adjunction defined by
+  sending `s` to the section `x ↦ s` on `pbo f`.
 ## Reference
 * [Robin Hartshorne, *Algebraic Geometry*][Har77]: Chapter II.2 Proposition 2.5
 -/

--- a/Mathlib/AlgebraicGeometry/ProjectiveSpectrum/Scheme.lean
+++ b/Mathlib/AlgebraicGeometry/ProjectiveSpectrum/Scheme.lean
@@ -78,7 +78,7 @@ If we further assume `m` is positive
   We also denote this map as `φ`
 * `projIsoSpecTopComponent`: the homeomorphism `Proj.T| pbo f ≅ Spec.T A⁰_f` obtained by `φ` and
   `ψ`.
-* `ProjIsoSpec.toSpec`: the morphism of locally ringed spaces between `Proj| pbo f` and `Spec A⁰_f`
+* `ProjectiveSpectrum.Proj.toSpec`: the morphism of locally ringed spaces between `Proj| pbo f` and `Spec A⁰_f`
   corresponding to the ring map `A⁰_f → Γ(Proj, pbo f)` under the Gamma-Spec adjunction defined by
   sending `s` to the section `x ↦ s` on `pbo f`.
 

--- a/Mathlib/AlgebraicGeometry/ProjectiveSpectrum/Scheme.lean
+++ b/Mathlib/AlgebraicGeometry/ProjectiveSpectrum/Scheme.lean
@@ -78,9 +78,9 @@ If we further assume `m` is positive
   We also denote this map as `φ`
 * `projIsoSpecTopComponent`: the homeomorphism `Proj.T| pbo f ≅ Spec.T A⁰_f` obtained by `φ` and
   `ψ`.
-* `ProjectiveSpectrum.Proj.toSpec`: the morphism of locally ringed spaces between `Proj| pbo f` and `Spec A⁰_f`
-  corresponding to the ring map `A⁰_f → Γ(Proj, pbo f)` under the Gamma-Spec adjunction defined by
-  sending `s` to the section `x ↦ s` on `pbo f`.
+* `ProjectiveSpectrum.Proj.toSpec`: the morphism of locally ringed spaces between `Proj| pbo f` 
+  and `Spec A⁰_f` corresponding to the ring map `A⁰_f → Γ(Proj, pbo f)` under the Gamma-Spec 
+  adjunction defined by sending `s` to the section `x ↦ s` on `pbo f`.
 
 ## Reference
 * [Robin Hartshorne, *Algebraic Geometry*][Har77]: Chapter II.2 Proposition 2.5

--- a/Mathlib/AlgebraicGeometry/ProjectiveSpectrum/Scheme.lean
+++ b/Mathlib/AlgebraicGeometry/ProjectiveSpectrum/Scheme.lean
@@ -78,8 +78,8 @@ If we further assume `m` is positive
   We also denote this map as `φ`
 * `projIsoSpecTopComponent`: the homeomorphism `Proj.T| pbo f ≅ Spec.T A⁰_f` obtained by `φ` and
   `ψ`.
-* `ProjectiveSpectrum.Proj.toSpec`: the morphism of locally ringed spaces between `Proj| pbo f` 
-  and `Spec A⁰_f` corresponding to the ring map `A⁰_f → Γ(Proj, pbo f)` under the Gamma-Spec 
+* `ProjectiveSpectrum.Proj.toSpec`: the morphism of locally ringed spaces between `Proj| pbo f`
+  and `Spec A⁰_f` corresponding to the ring map `A⁰_f → Γ(Proj, pbo f)` under the Gamma-Spec
   adjunction defined by sending `s` to the section `x ↦ s` on `pbo f`.
 
 ## Reference


### PR DESCRIPTION
We construct a morphism of locally ringed spaces `α : Proj| (pbo f) ⟶ Spec.T A⁰_f` as the following: by the Gamma-Spec adjunction, it is sufficient to construct a ring map `A⁰_f → Γ(Proj, pbo f)` from the ring of homogeneous localization of `A` away from `f` to the local sections of structure sheaf of projective spectrum on the basic open set around `f`. The map `A⁰_f → Γ(Proj, pbo f)` is constructed in `awayToΓ` and is defined by sending `s ∈ A⁰_f` to the section `x ↦ s` on `pbo f`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

Co-authored-by: Andrew Yang <the.erd.one@gmail.com>

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
