### PR TITLE
[Merged by Bors] - feat(Data/Set/Function): extending bijectivity to supersets

### DIFF
--- a/Mathlib/Data/Set/Function.lean
+++ b/Mathlib/Data/Set/Function.lean
@@ -1462,6 +1462,36 @@ lemma exists_image_eq_injOn_of_subset_range (ht : t ⊆ range f) :
     ∃ s, f '' s = t ∧ InjOn f s :=
   image_preimage_eq_of_subset ht ▸ exists_image_eq_and_injOn _ _
 
+/-- If `f` maps `s` bijectively to `t` and a set `t'` is contained in the image of some `s₁ ⊇ s`,
+then `s₁` has a subset containing `s` that `f` maps bijectively to `t'`.-/
+theorem BijOn.exists_extend_of_subset {t' : Set β} (h : BijOn f s t) (hss₁ : s ⊆ s₁) (htt' : t ⊆ t')
+    (ht' : SurjOn f s₁ t') : ∃ s', s ⊆ s' ∧ s' ⊆ s₁ ∧ Set.BijOn f s' t' := by
+  obtain ⟨r, hrss, hbij⟩ := exists_subset_bijOn ((s₁ ∩ f ⁻¹' t') \ f ⁻¹' t) f
+  rw [image_diff_preimage, image_inter_preimage] at hbij
+  refine ⟨s ∪ r, subset_union_left, ?_, ?_, ?_, fun y hyt' ↦ ?_⟩
+  · exact union_subset hss₁ <| hrss.trans <| diff_subset.trans inter_subset_left
+  · rw [mapsTo', image_union, hbij.image_eq, h.image_eq, union_subset_iff]
+    exact ⟨htt', diff_subset.trans inter_subset_right⟩
+  · rw [injOn_union, and_iff_right h.injOn, and_iff_right hbij.injOn]
+    · refine fun x hxs y hyr hxy ↦ (hrss hyr).2 ?_
+      rw [← h.image_eq]
+      exact ⟨x, hxs, hxy⟩
+    exact (subset_diff.1 hrss).2.symm.mono_left h.mapsTo
+  rw [image_union, h.image_eq, hbij.image_eq, union_diff_self]
+  exact .inr ⟨ht' hyt', hyt'⟩
+
+/-- If `f` maps `s` bijectively to `t`, and `t'` is a superset of `t` contained in the range of `f`,
+then `f` maps some superset of `s` bijectively to `t'`. -/
+theorem BijOn.exists_extend {t' : Set β} (h : BijOn f s t) (htt' : t ⊆ t') (ht' : t' ⊆ range f) :
+    ∃ s', s ⊆ s' ∧ BijOn f s' t' := by
+  simpa using h.exists_extend_of_subset (subset_univ s) htt' (by simpa [SurjOn])
+
+theorem InjOn.exists_subset_injOn_subset_range_eq {r : Set α} (hinj : InjOn f r) (hrs : r ⊆ s) :
+    ∃ (u : Set α), r ⊆ u ∧ u ⊆ s ∧ f '' u = f '' s ∧ Set.InjOn f u := by
+  obtain ⟨u, hru, hus, h⟩ := hinj.bijOn_image.exists_extend_of_subset hrs
+    (image_subset f hrs) Subset.rfl
+  exact ⟨u, hru, hus, h.image_eq, h.injOn⟩
+
 theorem preimage_invFun_of_mem [n : Nonempty α] {f : α → β} (hf : Injective f) {s : Set α}
     (h : Classical.choice n ∈ s) : invFun f ⁻¹' s = f '' s ∪ (range f)ᶜ := by
   ext x

--- a/Mathlib/Data/Set/Function.lean
+++ b/Mathlib/Data/Set/Function.lean
@@ -1487,7 +1487,7 @@ theorem BijOn.exists_extend {t' : Set β} (h : BijOn f s t) (htt' : t ⊆ t') (h
   simpa using h.exists_extend_of_subset (subset_univ s) htt' (by simpa [SurjOn])
 
 theorem InjOn.exists_subset_injOn_subset_range_eq {r : Set α} (hinj : InjOn f r) (hrs : r ⊆ s) :
-    ∃ (u : Set α), r ⊆ u ∧ u ⊆ s ∧ f '' u = f '' s ∧ Set.InjOn f u := by
+    ∃ u : Set α, r ⊆ u ∧ u ⊆ s ∧ f '' u = f '' s ∧ InjOn f u := by
   obtain ⟨u, hru, hus, h⟩ := hinj.bijOn_image.exists_extend_of_subset hrs
     (image_subset f hrs) Subset.rfl
   exact ⟨u, hru, hus, h.image_eq, h.injOn⟩


### PR DESCRIPTION
the lemmas `exists_subset_bijOn` and similar show that for a function `f : α → β` and a set `t : Set β` contained in the range of `f`, we can choose a set `s` that `f` maps bijectively to `t`. We add a few lemmas stating that, under appropriate hypotheses, we can choose such an `s` to contain and/or be contained in prescribed sets in `α`. 

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
