### PR TITLE
[Merged by Bors] - chore: remove unnecessary term or tactic `set_option in` with backwards-compatibility flags

### DIFF
--- a/Archive/Examples/IfNormalization/Result.lean
+++ b/Archive/Examples/IfNormalization/Result.lean
@@ -58,7 +58,6 @@ We don't want a `simp` lemma for `(ite i t e).eval` in general, only once we kno
   | var _ => 1
   | .ite i t e => 2 * normSize i + max (normSize t) (normSize e) + 1
 
-set_option tactic.skipAssignedInstances false in
 /-- Normalizes the expression at the same time as assigning all variables in
 `e` to the literal booleans given by `l` -/
 def normalize (l : AList (fun _ : ℕ => Bool)) :

--- a/Archive/Wiedijk100Theorems/AbelRuffini.lean
+++ b/Archive/Wiedijk100Theorems/AbelRuffini.lean
@@ -104,7 +104,6 @@ theorem irreducible_Phi (p : ℕ) (hp : p.Prime) (hpa : p ∣ a) (hpb : p ∣ b)
   all_goals exact Monic.isPrimitive (monic_Phi a b)
 #align abel_ruffini.irreducible_Phi AbelRuffini.irreducible_Phi
 
-set_option tactic.skipAssignedInstances false in
 theorem real_roots_Phi_le : Fintype.card ((Φ ℚ a b).rootSet ℝ) ≤ 3 := by
   rw [← map_Phi a b (algebraMap ℤ ℚ), Φ, ← one_mul (X ^ 5), ← C_1]
   apply (card_rootSet_le_derivative _).trans
@@ -116,7 +115,6 @@ theorem real_roots_Phi_le : Fintype.card ((Φ ℚ a b).rootSet ℝ) ≤ 3 := by
   norm_num
 #align abel_ruffini.real_roots_Phi_le AbelRuffini.real_roots_Phi_le
 
-set_option tactic.skipAssignedInstances false in
 theorem real_roots_Phi_ge_aux (hab : b < a) :
     ∃ x y : ℝ, x ≠ y ∧ aeval x (Φ ℚ a b) = 0 ∧ aeval y (Φ ℚ a b) = 0 := by
   let f : ℝ → ℝ := fun x : ℝ => aeval x (Φ ℚ a b)

--- a/Archive/Wiedijk100Theorems/PerfectNumbers.lean
+++ b/Archive/Wiedijk100Theorems/PerfectNumbers.lean
@@ -41,7 +41,7 @@ open ArithmeticFunction Finset
 
 theorem sigma_two_pow_eq_mersenne_succ (k : ℕ) : σ 1 (2 ^ k) = mersenne (k + 1) := by
   simp_rw [sigma_one_apply, mersenne, show 2 = 1 + 1 from rfl, ← geom_sum_mul_add 1 (k + 1)]
-  set_option tactic.skipAssignedInstances false in norm_num
+  norm_num
 #align theorems_100.nat.sigma_two_pow_eq_mersenne_succ Theorems100.Nat.sigma_two_pow_eq_mersenne_succ
 
 /-- Euclid's theorem that Mersenne primes induce perfect numbers -/

--- a/Counterexamples/Cyclotomic105.lean
+++ b/Counterexamples/Cyclotomic105.lean
@@ -45,7 +45,6 @@ theorem properDivisors_35 : Nat.properDivisors 35 = {1, 5, 7} :=
   rfl
 #align counterexample.proper_divisors_35 Counterexample.properDivisors_35
 
-set_option maxRecDepth 1024 in
 theorem properDivisors_105 : Nat.properDivisors 105 = {1, 3, 5, 7, 15, 21, 35} :=
   rfl
 #align counterexample.proper_divisors_105 Counterexample.properDivisors_105

--- a/Counterexamples/Phillips.lean
+++ b/Counterexamples/Phillips.lean
@@ -413,8 +413,7 @@ section
 
 
 theorem norm_indicator_le_one (s : Set α) (x : α) : ‖(indicator s (1 : α → ℝ)) x‖ ≤ 1 := by
-  simp only [indicator, Pi.one_apply]; split_ifs <;>
-  set_option tactic.skipAssignedInstances false in norm_num
+  simp only [indicator, Pi.one_apply]; split_ifs <;> norm_num
 #align counterexample.phillips_1940.norm_indicator_le_one Counterexample.Phillips1940.norm_indicator_le_one
 
 /-- A functional in the dual space of bounded functions gives rise to a bounded additive measure,

--- a/Mathlib/Algebra/Category/ModuleCat/ChangeOfRings.lean
+++ b/Mathlib/Algebra/Category/ModuleCat/ChangeOfRings.lean
@@ -529,7 +529,6 @@ def app' (Y : ModuleCat S) : Y →ₗ[S] (restrictScalars f ⋙ coextendScalars 
     map_add' := fun y1 y2 =>
       LinearMap.ext fun s : S => by
         -- Porting note: double dsimp seems odd
-        set_option tactic.skipAssignedInstances false in
         dsimp only [AddHom.toFun_eq_coe, AddHom.coe_mk, RingHom.id_apply,
           RingHom.toMonoidHom_eq_coe, OneHom.toFun_eq_coe, MonoidHom.toOneHom_coe,
           MonoidHom.coe_coe, ZeroHom.coe_mk, smul_eq_mul, id_eq, eq_mpr_eq_cast, cast_eq,

--- a/Mathlib/Algebra/CubicDiscriminant.lean
+++ b/Mathlib/Algebra/CubicDiscriminant.lean
@@ -87,7 +87,7 @@ section Coeff
 private theorem coeffs : (∀ n > 3, P.toPoly.coeff n = 0) ∧ P.toPoly.coeff 3 = P.a ∧
     P.toPoly.coeff 2 = P.b ∧ P.toPoly.coeff 1 = P.c ∧ P.toPoly.coeff 0 = P.d := by
   simp only [toPoly, coeff_add, coeff_C, coeff_C_mul_X, coeff_C_mul_X_pow]
-  set_option tactic.skipAssignedInstances false in norm_num
+  norm_num
   intro n hn
   repeat' rw [if_neg]
   any_goals linarith only [hn]

--- a/Mathlib/AlgebraicTopology/FundamentalGroupoid/Basic.lean
+++ b/Mathlib/AlgebraicTopology/FundamentalGroupoid/Basic.lean
@@ -107,7 +107,6 @@ def reflTransSymm (p : Path x₀ x₁) : Homotopy (Path.refl x₀) (p.trans p.sy
     cases hx with
     | inl hx
     | inr hx =>
-      set_option tactic.skipAssignedInstances false in
       rw [hx]
       norm_num [reflTransSymmAux]
 #align path.homotopy.refl_trans_symm Path.Homotopy.reflTransSymm

--- a/Mathlib/AlgebraicTopology/FundamentalGroupoid/Basic.lean
+++ b/Mathlib/AlgebraicTopology/FundamentalGroupoid/Basic.lean
@@ -142,11 +142,11 @@ set_option linter.uppercaseLean3 false in
 #align path.homotopy.trans_refl_reparam_aux_mem_I Path.Homotopy.transReflReparamAux_mem_I
 
 theorem transReflReparamAux_zero : transReflReparamAux 0 = 0 := by
-  set_option tactic.skipAssignedInstances false in norm_num [transReflReparamAux]
+  norm_num [transReflReparamAux]
 #align path.homotopy.trans_refl_reparam_aux_zero Path.Homotopy.transReflReparamAux_zero
 
 theorem transReflReparamAux_one : transReflReparamAux 1 = 1 := by
-  set_option tactic.skipAssignedInstances false in norm_num [transReflReparamAux]
+  norm_num [transReflReparamAux]
 #align path.homotopy.trans_refl_reparam_aux_one Path.Homotopy.transReflReparamAux_one
 
 theorem trans_refl_reparam (p : Path x₀ x₁) :
@@ -194,7 +194,7 @@ theorem continuous_transAssocReparamAux : Continuous transAssocReparamAux := by
     [continuity; continuity; continuity; continuity; continuity; continuity; continuity; skip;
       skip] <;>
     · intro x hx
-      set_option tactic.skipAssignedInstances false in norm_num [hx]
+      norm_num [hx]
 #align path.homotopy.continuous_trans_assoc_reparam_aux Path.Homotopy.continuous_transAssocReparamAux
 
 theorem transAssocReparamAux_mem_I (t : I) : transAssocReparamAux t ∈ I := by
@@ -204,11 +204,11 @@ set_option linter.uppercaseLean3 false in
 #align path.homotopy.trans_assoc_reparam_aux_mem_I Path.Homotopy.transAssocReparamAux_mem_I
 
 theorem transAssocReparamAux_zero : transAssocReparamAux 0 = 0 := by
-  set_option tactic.skipAssignedInstances false in norm_num [transAssocReparamAux]
+  norm_num [transAssocReparamAux]
 #align path.homotopy.trans_assoc_reparam_aux_zero Path.Homotopy.transAssocReparamAux_zero
 
 theorem transAssocReparamAux_one : transAssocReparamAux 1 = 1 := by
-  set_option tactic.skipAssignedInstances false in norm_num [transAssocReparamAux]
+  norm_num [transAssocReparamAux]
 #align path.homotopy.trans_assoc_reparam_aux_one Path.Homotopy.transAssocReparamAux_one
 
 theorem trans_assoc_reparam {x₀ x₁ x₂ x₃ : X} (p : Path x₀ x₁) (q : Path x₁ x₂) (r : Path x₂ x₃) :

--- a/Mathlib/Analysis/Analytic/Inverse.lean
+++ b/Mathlib/Analysis/Analytic/Inverse.lean
@@ -568,7 +568,7 @@ theorem radius_rightInv_pos_of_radius_pos (p : FormalMultilinearSeries 𝕜 E F)
       _ ≤ ∑ k ∈ Ico 1 (n + 1), a ^ k * ‖p.rightInv i k‖ :=
         (haveI : ∀ k ∈ Ico 1 (n + 1), 0 ≤ a ^ k * ‖p.rightInv i k‖ := fun k _ => by positivity
         single_le_sum this (by simp [one_le_n]))
-      _ ≤ (I + 1) * a := IRec (n + 1) (by set_option tactic.skipAssignedInstances false in norm_num)
+      _ ≤ (I + 1) * a := IRec (n + 1) (by norm_num)
 #align formal_multilinear_series.radius_right_inv_pos_of_radius_pos FormalMultilinearSeries.radius_rightInv_pos_of_radius_pos
 
 end FormalMultilinearSeries

--- a/Mathlib/Analysis/Convex/Uniform.lean
+++ b/Mathlib/Analysis/Convex/Uniform.lean
@@ -104,7 +104,7 @@ theorem exists_forall_closed_ball_dist_add_le_two_sub (hε : 0 < ε) :
       refine sub_le_sub_left ?_ _
       ring_nf
       rw [← mul_div_cancel₀ δ three_ne_zero]
-      set_option tactic.skipAssignedInstances false in norm_num
+      norm_num
       -- Porting note: these three extra lines needed to make `exact` work
       have : 3 * (δ / 3) * (1 / 3) = δ / 3 := by linarith
       rw [this, mul_comm]

--- a/Mathlib/Analysis/InnerProductSpace/Projection.lean
+++ b/Mathlib/Analysis/InnerProductSpace/Projection.lean
@@ -238,7 +238,6 @@ theorem norm_eq_iInf_iff_real_inner_le_zero {K : Set F} (h : Convex ℝ K) {u : 
       have : 2 * p ≤ p :=
         calc
           2 * p ≤ θ * q := by
-            set_option tactic.skipAssignedInstances false in
             exact this θ (lt_min (by norm_num) (div_pos hp q_pos)) (by norm_num [θ])
           _ ≤ p := eq₁
       linarith

--- a/Mathlib/Analysis/NormedSpace/lpSpace.lean
+++ b/Mathlib/Analysis/NormedSpace/lpSpace.lean
@@ -760,7 +760,7 @@ instance [hp : Fact (1 ≤ p)] : NormedStarGroup (lp E p) where
     rcases p.trichotomy with (rfl | rfl | h)
     · exfalso
       have := ENNReal.toReal_mono ENNReal.zero_ne_top hp.elim
-      set_option tactic.skipAssignedInstances false in norm_num at this
+      norm_num at this
     · simp only [lp.norm_eq_ciSup, lp.star_apply, norm_star]
     · simp only [lp.norm_eq_tsum_rpow h, lp.star_apply, norm_star]
 

--- a/Mathlib/Analysis/SpecialFunctions/Complex/Arctan.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Complex/Arctan.lean
@@ -72,7 +72,7 @@ theorem arctan_tan {z : ℂ} (h₀ : z ≠ π / 2) (h₁ : -(π / 2) < z.re) (h�
     rw [sub_eq_add_neg, ← neg_mul, ← sin_neg, ← cos_neg]
   rw [← exp_mul_I, ← exp_mul_I, ← exp_sub, show z * I - -z * I = 2 * (I * z) by ring, log_exp,
     show -I / 2 * (2 * (I * z)) = -(I * I) * z by ring, I_mul_I, neg_neg, one_mul]
-  all_goals set_option tactic.skipAssignedInstances false in norm_num
+  all_goals norm_num
   · rwa [← div_lt_iff' two_pos, neg_div]
   · rwa [← le_div_iff' two_pos]
 

--- a/Mathlib/Analysis/SpecialFunctions/Trigonometric/Angle.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Trigonometric/Angle.lean
@@ -692,8 +692,7 @@ theorem toReal_coe_eq_self_sub_two_pi_iff {θ : ℝ} :
 
 theorem toReal_coe_eq_self_add_two_pi_iff {θ : ℝ} :
     (θ : Angle).toReal = θ + 2 * π ↔ θ ∈ Set.Ioc (-3 * π) (-π) := by
-  convert @toReal_coe_eq_self_sub_two_mul_int_mul_pi_iff θ (-1) using 2 <;>
-    set_option tactic.skipAssignedInstances false in norm_num
+  convert @toReal_coe_eq_self_sub_two_mul_int_mul_pi_iff θ (-1) using 2 <;> norm_num
 #align real.angle.to_real_coe_eq_self_add_two_pi_iff Real.Angle.toReal_coe_eq_self_add_two_pi_iff
 
 theorem two_nsmul_toReal_eq_two_mul_sub_two_pi {θ : Angle} :

--- a/Mathlib/Analysis/SpecialFunctions/Trigonometric/Arctan.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Trigonometric/Arctan.lean
@@ -81,7 +81,7 @@ theorem continuousOn_tan_Ioo : ContinuousOn tan (Ioo (-(π / 2)) (π / 2)) := by
       mul_le_mul_right (half_pos pi_pos)]
     have hr_le : r ≤ -1 := by rwa [Int.lt_iff_add_one_le, ← le_neg_iff_add_nonpos_right] at h
     rw [← le_sub_iff_add_le, mul_comm, ← le_div_iff]
-    · set_option tactic.skipAssignedInstances false in norm_num
+    · norm_num
       rw [← Int.cast_one, ← Int.cast_neg]; norm_cast
     · exact zero_lt_two
 #align real.continuous_on_tan_Ioo Real.continuousOn_tan_Ioo

--- a/Mathlib/Analysis/SpecialFunctions/Trigonometric/Bounds.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Trigonometric/Bounds.lean
@@ -112,7 +112,6 @@ lemma cos_quadratic_upper_bound (hx : |x| ≤ π) : cos x ≤ 1 - 2 / π ^ 2 * x
           gcongr; exacts [div_le_one_of_le two_le_pi (by positivity), two_div_pi_mul_le_sin hx₀ hx]
       _ = sin x := one_mul _
   have hconc : ConcaveOn ℝ (Icc (π / 2) π) (fun x ↦ 1 - 2 / π ^ 2 * x ^ 2 - cos x) := by
-    set_option tactic.skipAssignedInstances false in
     refine concaveOn_of_hasDerivWithinAt2_nonpos (convex_Icc ..)
       (Continuous.continuousOn $ by continuity) (fun x _ ↦ (hderiv _).hasDerivWithinAt)
       (fun x _ ↦ ((hasDerivAt_sin ..).sub $ (hasDerivAt_id ..).const_mul _).hasDerivWithinAt)
@@ -127,8 +126,7 @@ lemma cos_quadratic_upper_bound (hx : |x| ≤ π) : cos x ≤ 1 - 2 / π ^ 2 * x
   rw [← sub_nonneg]
   obtain hx' | hx' := le_total x (π / 2)
   · simpa using hmono (left_mem_Icc.2 $ by positivity) ⟨hx₀, hx'⟩ hx₀
-  · set_option tactic.skipAssignedInstances false in
-    refine (le_min ?_ ?_).trans $ hconc.min_le_of_mem_Icc ⟨hx', hx⟩ <;> field_simp <;> norm_num
+  · refine (le_min ?_ ?_).trans $ hconc.min_le_of_mem_Icc ⟨hx', hx⟩ <;> field_simp <;> norm_num
 
 /-- For 0 < x ≤ 1 we have x - x ^ 3 / 4 < sin x.
 

--- a/Mathlib/Analysis/SpecialFunctions/Trigonometric/Bounds.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Trigonometric/Bounds.lean
@@ -100,6 +100,8 @@ lemma cos_quadratic_upper_bound (hx : |x| ≤ π) : cos x ≤ 1 - 2 / π ^ 2 * x
   simp only [Nat.cast_ofNat, Nat.succ_sub_succ_eq_sub, tsub_zero, pow_one, ← neg_sub', neg_sub,
     ← mul_assoc] at hderiv
   have hmono : MonotoneOn (fun x ↦ 1 - 2 / π ^ 2 * x ^ 2 - cos x) (Icc 0 (π / 2)) := by
+    -- Compiles without this option, but somewhat slower.
+    set_option tactic.skipAssignedInstances false in
     refine monotoneOn_of_hasDerivWithinAt_nonneg
       (convex_Icc ..)
       (Continuous.continuousOn $ by continuity)
@@ -112,6 +114,8 @@ lemma cos_quadratic_upper_bound (hx : |x| ≤ π) : cos x ≤ 1 - 2 / π ^ 2 * x
           gcongr; exacts [div_le_one_of_le two_le_pi (by positivity), two_div_pi_mul_le_sin hx₀ hx]
       _ = sin x := one_mul _
   have hconc : ConcaveOn ℝ (Icc (π / 2) π) (fun x ↦ 1 - 2 / π ^ 2 * x ^ 2 - cos x) := by
+    -- Compiles without this option, but somewhat slower.
+    set_option tactic.skipAssignedInstances false in
     refine concaveOn_of_hasDerivWithinAt2_nonpos (convex_Icc ..)
       (Continuous.continuousOn $ by continuity) (fun x _ ↦ (hderiv _).hasDerivWithinAt)
       (fun x _ ↦ ((hasDerivAt_sin ..).sub $ (hasDerivAt_id ..).const_mul _).hasDerivWithinAt)

--- a/Mathlib/Analysis/SpecificLimits/Normed.lean
+++ b/Mathlib/Analysis/SpecificLimits/Normed.lean
@@ -686,7 +686,7 @@ theorem Antitone.cauchySeq_series_mul_of_tendsto_zero_of_bounded (hfa : Antitone
 
 theorem norm_sum_neg_one_pow_le (n : ℕ) : ‖∑ i ∈ range n, (-1 : ℝ) ^ i‖ ≤ 1 := by
   rw [neg_one_geom_sum]
-  split_ifs <;> set_option tactic.skipAssignedInstances false in norm_num
+  split_ifs <;> norm_num
 #align norm_sum_neg_one_pow_le norm_sum_neg_one_pow_le
 
 /-- The **alternating series test** for monotone sequences.

--- a/Mathlib/Combinatorics/Additive/AP/Three/Behrend.lean
+++ b/Mathlib/Combinatorics/Additive/AP/Three/Behrend.lean
@@ -287,7 +287,7 @@ theorem exists_large_sphere (n d : ℕ) :
   apply one_le_mul_of_one_le_of_one_le
   · rwa [one_le_cast]
   rw [_root_.le_sub_iff_add_le]
-  set_option tactic.skipAssignedInstances false in norm_num
+  norm_num
   exact one_le_cast.2 hd
 #align behrend.exists_large_sphere Behrend.exists_large_sphere
 
@@ -452,7 +452,7 @@ theorem bound (hN : 4096 ≤ N) : (N : ℝ) ^ (nValue N : ℝ)⁻¹ / exp 1 < dV
   rw [← log_le_log_iff, log_rpow, mul_comm, ← div_eq_mul_inv]
   · apply le_trans _ (div_le_div_of_nonneg_left _ _ (ceil_lt_mul _).le)
     · rw [mul_comm, ← div_div, div_sqrt, le_div_iff]
-      · set_option tactic.skipAssignedInstances false in norm_num; exact le_sqrt_log hN
+      · norm_num; exact le_sqrt_log hN
       · norm_num1
     · apply log_nonneg
       rw [one_le_cast]

--- a/Mathlib/Combinatorics/SimpleGraph/Regularity/Chunk.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Regularity/Chunk.lean
@@ -233,7 +233,7 @@ private theorem one_sub_le_m_div_m_add_one_sq [Nonempty α]
   rw [sub_le_sub_iff_left, ← le_div_iff' (show (0 : ℝ) < 2 by norm_num), div_div,
     one_div_le coe_m_add_one_pos, one_div_div]
   · refine le_trans ?_ (le_add_of_nonneg_right zero_le_one)
-    set_option tactic.skipAssignedInstances false in norm_num
+    norm_num
     apply hundred_div_ε_pow_five_le_m hPα hPε
   sz_positivity
 
@@ -457,7 +457,7 @@ private theorem edgeDensity_star_not_uniform [Nonempty α]
     have := average_density_near_total_density hPα hPε hε₁
       (Subset.refl (chunk hP G ε hU).parts) (Subset.refl (chunk hP G ε hV).parts)
     simp_rw [← sup_eq_biUnion, sup_parts, card_chunk (m_pos hPα).ne', cast_pow] at this
-    set_option tactic.skipAssignedInstances false in norm_num at this
+    norm_num at this
     exact this
   have hε' : ε ^ 5 ≤ ε := by
     simpa using pow_le_pow_of_le_one (by sz_positivity) hε₁ (show 1 ≤ 5 by norm_num)

--- a/Mathlib/Combinatorics/SimpleGraph/Regularity/Lemma.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Regularity/Lemma.lean
@@ -134,7 +134,7 @@ theorem szemeredi_regularity (hε : 0 < ε) (hl : l ≤ card α) :
   have hi : (i : ℝ) ≤ 4 / ε ^ 5 := by
     have hi : ε ^ 5 / 4 * ↑i ≤ 1 := hP₄.trans (mod_cast P.energy_le_one G)
     rw [div_mul_eq_mul_div, div_le_iff (show (0 : ℝ) < 4 by norm_num)] at hi
-    set_option tactic.skipAssignedInstances false in norm_num at hi
+    norm_num at hi
     rwa [le_div_iff' (pow_pos hε _)]
   have hsize : P.parts.card ≤ stepBound^[⌊4 / ε ^ 5⌋₊] t :=
     hP₃.trans (monotone_iterate_of_id_le le_stepBound (Nat.le_floor hi) _)

--- a/Mathlib/Computability/AkraBazzi/GrowsPolynomially.lean
+++ b/Mathlib/Computability/AkraBazzi/GrowsPolynomially.lean
@@ -197,7 +197,6 @@ lemma eventually_atTop_nonneg_or_nonpos (hf : GrowsPolynomially f) :
         intro n hn hyp_ind z hz
         have z_nonneg : 0 ≤ z := by
           calc (0:ℝ) ≤ (2:ℝ)^n * max n₀ 2 := by
-                        set_option tactic.skipAssignedInstances false in
                         exact mul_nonneg (pow_nonneg (by norm_num) _) (by norm_num)
                   _ ≤ z := by exact_mod_cast hz.1
         have le_2n : max n₀ 2 ≤ (2:ℝ)^n * max n₀ 2 := by

--- a/Mathlib/Data/Complex/Exponential.lean
+++ b/Mathlib/Data/Complex/Exponential.lean
@@ -1616,7 +1616,7 @@ theorem cos_one_le : cos 1 ≤ 2 / 3 :=
   calc
     cos 1 ≤ |(1 : ℝ)| ^ 4 * (5 / 96) + (1 - 1 ^ 2 / 2) :=
       sub_le_iff_le_add.1 (abs_sub_le_iff.1 (cos_bound (by simp))).1
-    _ ≤ 2 / 3 := by set_option tactic.skipAssignedInstances false in norm_num
+    _ ≤ 2 / 3 := by norm_num
 #align real.cos_one_le Real.cos_one_le
 
 theorem cos_one_pos : 0 < cos 1 :=
@@ -1645,7 +1645,7 @@ theorem exp_bound_div_one_sub_of_interval' {x : ℝ} (h1 : 0 < x) (h2 : x < 1) :
       -- This proof should be restored after the norm_num plugin for big operators is ported.
       -- (It may also need the positivity extensions in #3907.)
       repeat erw [Finset.sum_range_succ]
-      set_option tactic.skipAssignedInstances false in norm_num [Nat.factorial]
+      norm_num [Nat.factorial]
       nlinarith
     _ < 1 / (1 - x) := by rw [lt_div_iff] <;> nlinarith
 #align real.exp_bound_div_one_sub_of_interval' Real.exp_bound_div_one_sub_of_interval'

--- a/Mathlib/Data/Finset/Pointwise.lean
+++ b/Mathlib/Data/Finset/Pointwise.lean
@@ -1036,6 +1036,8 @@ theorem mem_prod_list_ofFn {a : α} {s : Fin n → Finset α} :
 @[to_additive]
 theorem mem_pow {a : α} {n : ℕ} :
     a ∈ s ^ n ↔ ∃ f : Fin n → s, (List.ofFn fun i => ↑(f i)).prod = a := by
+  -- Also compiles without the option, but much slower.
+  set_option tactic.skipAssignedInstances false in
   simp [← mem_coe, coe_pow, Set.mem_pow]
 #align finset.mem_pow Finset.mem_pow
 #align finset.mem_nsmul Finset.mem_nsmul

--- a/Mathlib/Data/Finset/Pointwise.lean
+++ b/Mathlib/Data/Finset/Pointwise.lean
@@ -1036,7 +1036,6 @@ theorem mem_prod_list_ofFn {a : α} {s : Fin n → Finset α} :
 @[to_additive]
 theorem mem_pow {a : α} {n : ℕ} :
     a ∈ s ^ n ↔ ∃ f : Fin n → s, (List.ofFn fun i => ↑(f i)).prod = a := by
-  set_option tactic.skipAssignedInstances false in
   simp [← mem_coe, coe_pow, Set.mem_pow]
 #align finset.mem_pow Finset.mem_pow
 #align finset.mem_nsmul Finset.mem_nsmul

--- a/Mathlib/GroupTheory/Perm/Cycle/Concrete.lean
+++ b/Mathlib/GroupTheory/Perm/Cycle/Concrete.lean
@@ -72,9 +72,9 @@ theorem formPerm_disjoint_iff (hl : Nodup l) (hl' : Nodup l') (hn : 2 ≤ l.leng
 
 theorem isCycle_formPerm (hl : Nodup l) (hn : 2 ≤ l.length) : IsCycle (formPerm l) := by
   cases' l with x l
-  · set_option tactic.skipAssignedInstances false in norm_num at hn
+  · norm_num at hn
   induction' l with y l generalizing x
-  · set_option tactic.skipAssignedInstances false in norm_num at hn
+  · norm_num at hn
   · use x
     constructor
     · rwa [formPerm_apply_mem_ne_self_iff _ hl _ (mem_cons_self _ _)]

--- a/Mathlib/GroupTheory/SpecificGroups/Quaternion.lean
+++ b/Mathlib/GroupTheory/SpecificGroups/Quaternion.lean
@@ -261,7 +261,6 @@ theorem orderOf_a [NeZero n] (i : ZMod (2 * n)) :
 
 theorem exponent : Monoid.exponent (QuaternionGroup n) = 2 * lcm n 2 := by
   rw [← normalize_eq 2, ← lcm_mul_left, normalize_eq]
-  set_option tactic.skipAssignedInstances false in
   norm_num
   cases' eq_zero_or_neZero n with hn hn
   · subst hn

--- a/Mathlib/LinearAlgebra/CrossProduct.lean
+++ b/Mathlib/LinearAlgebra/CrossProduct.lean
@@ -102,7 +102,7 @@ theorem cross_self (v : Fin 3 → R) : v ×₃ v = 0 := by
 @[simp 1100, nolint simpNF] -- Porting note: increase priority so that the LHS doesn't simplify
 theorem dot_self_cross (v w : Fin 3 → R) : v ⬝ᵥ v ×₃ w = 0 := by
   rw [cross_apply, vec3_dotProduct]
-  set_option tactic.skipAssignedInstances false in norm_num
+  norm_num
   ring
 #align dot_self_cross dot_self_cross
 

--- a/Mathlib/MeasureTheory/Function/UniformIntegrable.lean
+++ b/Mathlib/MeasureTheory/Function/UniformIntegrable.lean
@@ -649,7 +649,7 @@ theorem unifIntegrable_of' (hp : 1 ≤ p) (hp' : p ≠ ∞) {f : ι → α → �
   by_cases hμs' : μ s = 0
   · rw [(snorm_eq_zero_iff ((hf i).indicator hs).aestronglyMeasurable hpzero).2
         (indicator_meas_zero hμs')]
-    set_option tactic.skipAssignedInstances false in norm_num
+    norm_num
   calc
     snorm (Set.indicator s (f i)) p μ ≤
         snorm (Set.indicator (s ∩ { x | C ≤ ‖f i x‖₊ }) (f i)) p μ +

--- a/Mathlib/MeasureTheory/Integral/MeanInequalities.lean
+++ b/Mathlib/MeasureTheory/Integral/MeanInequalities.lean
@@ -471,7 +471,7 @@ theorem lintegral_Lp_add_le_of_le_one {p : ℝ} {f g : α → ℝ≥0∞} (hf : 
       (2 : ℝ≥0∞) ^ (1 / p - 1) * ((∫⁻ a, f a ^ p ∂μ) ^ (1 / p) + (∫⁻ a, g a ^ p ∂μ) ^ (1 / p)) := by
   rcases eq_or_lt_of_le hp0 with (rfl | hp)
   · simp only [Pi.add_apply, rpow_zero, lintegral_one, _root_.div_zero, zero_sub]
-    set_option tactic.skipAssignedInstances false in norm_num
+    norm_num
     rw [rpow_neg, rpow_one, ENNReal.inv_mul_cancel two_ne_zero two_ne_top]
   calc
     (∫⁻ a, (f + g) a ^ p ∂μ) ^ (1 / p) ≤ ((∫⁻ a, f a ^ p ∂μ) + ∫⁻ a, g a ^ p ∂μ) ^ (1 / p) := by

--- a/Mathlib/NumberTheory/FermatPsp.lean
+++ b/Mathlib/NumberTheory/FermatPsp.lean
@@ -126,8 +126,7 @@ theorem coprime_of_fermatPsp {n b : ℕ} (h : FermatPsp n b) (h₁ : 1 ≤ b) : 
 -/
 theorem fermatPsp_base_one {n : ℕ} (h₁ : 1 < n) (h₂ : ¬n.Prime) : FermatPsp n 1 := by
   refine ⟨show n ∣ 1 ^ (n - 1) - 1 from ?_, h₂, h₁⟩
-  exact show 0 = 1 ^ (n - 1) - 1 by
-    set_option tactic.skipAssignedInstances false in norm_num ▸ dvd_zero n
+  exact show 0 = 1 ^ (n - 1) - 1 by norm_num ▸ dvd_zero n
 #align fermat_psp.base_one Nat.fermatPsp_base_one
 
 -- Lemmas that are needed to prove statements in this file, but aren't directly related to Fermat

--- a/Mathlib/NumberTheory/NumberField/CanonicalEmbedding/ConvexBody.lean
+++ b/Mathlib/NumberTheory/NumberField/CanonicalEmbedding/ConvexBody.lean
@@ -588,7 +588,7 @@ theorem exists_primitive_element_lt_of_isComplex {w₀ : InfinitePlace K} (hw₀
         exact h_le₀.2
     · refine lt_of_lt_of_le (if_neg h_eq ▸ h_le w h_eq) ?_
       rw [NNReal.coe_one, Real.le_sqrt' zero_lt_one, one_pow]
-      set_option tactic.skipAssignedInstances false in norm_num
+      norm_num
 
 /-- Let `I` be a fractional ideal of `K`. Assume that `B : ℝ` is such that
 `minkowskiBound K I < volume (convexBodySum K B)` where `convexBodySum K B` is the set of points

--- a/Mathlib/NumberTheory/Padics/PadicIntegers.lean
+++ b/Mathlib/NumberTheory/Padics/PadicIntegers.lean
@@ -81,8 +81,8 @@ variable (p)
 /-- The `p`-adic integers as a subring of `ℚ_[p]`. -/
 def subring : Subring ℚ_[p] where
   carrier := { x : ℚ_[p] | ‖x‖ ≤ 1 }
-  zero_mem' := by set_option tactic.skipAssignedInstances false in norm_num
-  one_mem' := by set_option tactic.skipAssignedInstances false in norm_num
+  zero_mem' := by norm_num
+  one_mem' := by norm_num
   add_mem' hx hy := (padicNormE.nonarchimedean _ _).trans <| max_le_iff.2 ⟨hx, hy⟩
   mul_mem' hx hy := (padicNormE.mul _ _).trans_le <| mul_le_one hx (norm_nonneg _) hy
   neg_mem' hx := (norm_neg _).trans_le hx

--- a/Mathlib/NumberTheory/Padics/PadicNumbers.lean
+++ b/Mathlib/NumberTheory/Padics/PadicNumbers.lean
@@ -896,7 +896,7 @@ theorem norm_rat_le_one : ∀ {q : ℚ} (_ : ¬p ∣ q.den), ‖(q : ℚ_[p])‖
   | ⟨n, d, hn, hd⟩ => fun hq : ¬p ∣ d ↦
     if hnz : n = 0 then by
       have : (⟨n, d, hn, hd⟩ : ℚ) = 0 := Rat.zero_iff_num_zero.mpr hnz
-      set_option tactic.skipAssignedInstances false in norm_num [this]
+      norm_num [this]
     else by
       have hnz' : (⟨n, d, hn, hd⟩ : ℚ) ≠ 0 := mt Rat.zero_iff_num_zero.1 hnz
       rw [padicNormE.eq_padicNorm]

--- a/Mathlib/Probability/Distributions/Exponential.lean
+++ b/Mathlib/Probability/Distributions/Exponential.lean
@@ -145,8 +145,7 @@ lemma lintegral_exponentialPDF_eq_antiDeriv {r : ℝ} (hr : 0 < r) (x : ℝ) :
       rw [integral_Icc_eq_integral_Ioc, ← uIoc_of_le h, this]
       rw [intervalIntegral.integral_eq_sub_of_hasDeriv_right_of_le h
         (f := fun a ↦ -1 * rexp (-(r * a))) _ _]
-      · rw [ENNReal.toReal_ofReal_eq_iff.2
-          (by set_option tactic.skipAssignedInstances false in norm_num; positivity)]
+      · rw [ENNReal.toReal_ofReal_eq_iff.2 (by norm_num; positivity)]
         norm_num; ring
       · simp only [intervalIntegrable_iff, uIoc_of_le h]
         exact Integrable.const_mul (exp_neg_integrableOn_Ioc hr) _

--- a/Mathlib/RingTheory/Polynomial/ScaleRoots.lean
+++ b/Mathlib/RingTheory/Polynomial/ScaleRoots.lean
@@ -170,6 +170,8 @@ theorem scaleRoots_aeval_eq_zero [Algebra R A] {p : R[X]} {a : A} {r : R} (ha : 
 theorem scaleRoots_eval₂_eq_zero_of_eval₂_div_eq_zero {p : S[X]} {f : S →+* K}
     (hf : Function.Injective f) {r s : S} (hr : eval₂ f (f r / f s) p = 0)
     (hs : s ∈ nonZeroDivisors S) : eval₂ f (f r) (scaleRoots p s) = 0 := by
+  -- The proof works without this option, but *much* slower.
+  set_option tactic.skipAssignedInstances false in
   nontriviality S using Subsingleton.eq_zero
   convert @scaleRoots_eval₂_eq_zero _ _ _ _ p f _ s hr
   rw [← mul_div_assoc, mul_comm, mul_div_cancel_right₀]

--- a/Mathlib/RingTheory/Polynomial/ScaleRoots.lean
+++ b/Mathlib/RingTheory/Polynomial/ScaleRoots.lean
@@ -170,7 +170,6 @@ theorem scaleRoots_aeval_eq_zero [Algebra R A] {p : R[X]} {a : A} {r : R} (ha : 
 theorem scaleRoots_eval₂_eq_zero_of_eval₂_div_eq_zero {p : S[X]} {f : S →+* K}
     (hf : Function.Injective f) {r s : S} (hr : eval₂ f (f r / f s) p = 0)
     (hs : s ∈ nonZeroDivisors S) : eval₂ f (f r) (scaleRoots p s) = 0 := by
-  set_option tactic.skipAssignedInstances false in
   nontriviality S using Subsingleton.eq_zero
   convert @scaleRoots_eval₂_eq_zero _ _ _ _ p f _ s hr
   rw [← mul_div_assoc, mul_comm, mul_div_cancel_right₀]

--- a/Mathlib/Topology/Algebra/Polynomial.lean
+++ b/Mathlib/Topology/Algebra/Polynomial.lean
@@ -211,7 +211,7 @@ theorem coeff_bdd_of_roots_le {B : ℝ} {d : ℕ} (f : F →+* K) {p : F[X]} (h1
   · rw [eq_one_of_roots_le hB h1 h2 h4, Polynomial.map_one, coeff_one]
     refine _root_.trans ?_
       (one_le_mul_of_one_le_of_one_le (one_le_pow_of_one_le (le_max_right B 1) d) ?_)
-    · split_ifs <;> set_option tactic.skipAssignedInstances false in norm_num
+    · split_ifs <;> norm_num
     · exact mod_cast Nat.succ_le_iff.mpr (Nat.choose_pos (d.div_le_self 2))
 #align polynomial.coeff_bdd_of_roots_le Polynomial.coeff_bdd_of_roots_le
 

--- a/Mathlib/Topology/Homotopy/Basic.lean
+++ b/Mathlib/Topology/Homotopy/Basic.lean
@@ -241,8 +241,8 @@ def trans {f₀ f₁ f₂ : C(X, Y)} (F : Homotopy f₀ f₁) (G : Homotopy f₁
         (G.continuous.comp (by continuity)).continuousOn ?_
     rintro x hx
     norm_num [hx]
-  map_zero_left x := by set_option tactic.skipAssignedInstances false in norm_num
-  map_one_left x := by set_option tactic.skipAssignedInstances false in norm_num
+  map_zero_left x := by norm_num
+  map_one_left x := by norm_num
 #align continuous_map.homotopy.trans ContinuousMap.Homotopy.trans
 
 theorem trans_apply {f₀ f₁ f₂ : C(X, Y)} (F : Homotopy f₀ f₁) (G : Homotopy f₁ f₂) (x : I × X) :

--- a/Mathlib/Topology/Homotopy/Path.lean
+++ b/Mathlib/Topology/Homotopy/Path.lean
@@ -168,9 +168,9 @@ def hcomp (F : Homotopy p₀ q₀) (G : Homotopy p₁ q₁) : Homotopy (p₀.tra
   map_one_left x := by simp [Path.trans]
   prop' x t ht := by
     cases' ht with ht ht
-    · set_option tactic.skipAssignedInstances false in norm_num [ht]
+    · norm_num [ht]
     · rw [Set.mem_singleton_iff] at ht
-      set_option tactic.skipAssignedInstances false in norm_num [ht]
+      norm_num [ht]
 #align path.homotopy.hcomp Path.Homotopy.hcomp
 
 theorem hcomp_apply (F : Homotopy p₀ q₀) (G : Homotopy p₁ q₁) (x : I × I) :

--- a/Mathlib/Topology/MetricSpace/Gluing.lean
+++ b/Mathlib/Topology/MetricSpace/Gluing.lean
@@ -263,15 +263,12 @@ def metricSpaceSum : MetricSpace (X ⊕ Y) where
   dist_triangle
     | .inl p, .inl q, .inl r => dist_triangle p q r
     | .inl p, .inr q, _ => by
-      set_option tactic.skipAssignedInstances false in
       simp only [Sum.dist_eq_glueDist p q]
       exact glueDist_triangle _ _ _ (by norm_num) _ _ _
     | _, .inl q, .inr r => by
-      set_option tactic.skipAssignedInstances false in
       simp only [Sum.dist_eq_glueDist q r]
       exact glueDist_triangle _ _ _ (by norm_num) _ _ _
     | .inr p, _, .inl r => by
-      set_option tactic.skipAssignedInstances false in
       simp only [Sum.dist_eq_glueDist r p]
       exact glueDist_triangle _ _ _ (by norm_num) _ _ _
     | .inr p, .inr q, .inr r => dist_triangle p q r

--- a/Mathlib/Topology/MetricSpace/ThickenedIndicator.lean
+++ b/Mathlib/Topology/MetricSpace/ThickenedIndicator.lean
@@ -63,7 +63,7 @@ theorem continuous_thickenedIndicatorAux {δ : ℝ} (δ_pos : 0 < δ) (E : Set �
   rw [show (fun x : α => (1 : ℝ≥0∞) - infEdist x E / ENNReal.ofReal δ) = sub ∘ f by rfl]
   apply (@ENNReal.continuous_nnreal_sub 1).comp
   apply (ENNReal.continuous_div_const (ENNReal.ofReal δ) _).comp continuous_infEdist
-  set_option tactic.skipAssignedInstances false in norm_num [δ_pos]
+  norm_num [δ_pos]
 #align continuous_thickened_indicator_aux continuous_thickenedIndicatorAux
 
 theorem thickenedIndicatorAux_le_one (δ : ℝ) (E : Set α) (x : α) :

--- a/Mathlib/Topology/UrysohnsLemma.lean
+++ b/Mathlib/Topology/UrysohnsLemma.lean
@@ -187,7 +187,6 @@ theorem approx_le_one (c : CU P) (n : ℕ) (x : X) : c.approx n x ≤ 1 := by
   · exact indicator_apply_le' (fun _ => le_rfl) fun _ => zero_le_one
   · simp only [approx, midpoint_eq_smul_add, invOf_eq_inv, smul_eq_mul, ← div_eq_inv_mul]
     have := add_le_add (ihn (left c)) (ihn (right c))
-    set_option tactic.skipAssignedInstances false in
     norm_num at this
     exact Iff.mpr (div_le_one zero_lt_two) this
 #align urysohns.CU.approx_le_one Urysohns.CU.approx_le_one


### PR DESCRIPTION
As far as I can tell, this removes all `set_option ... false in norm_num` :tada:

Inspired by the linter in #13653 (but not covered by it yet; so far, that linter only checks the set_option *command*).

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
