### PR TITLE
[Merged by Bors] - feat: the finite adele ring is an algebra over the finite integral adeles.

### DIFF
--- a/Mathlib/RingTheory/DedekindDomain/FiniteAdeleRing.lean
+++ b/Mathlib/RingTheory/DedekindDomain/FiniteAdeleRing.lean
@@ -313,21 +313,24 @@ open ProdAdicCompletions.IsFiniteAdele
 
 /-- The finite adèle ring of `R` is the restricted product over all maximal ideals `v` of `R`
 of `adicCompletion` with respect to `adicCompletionIntegers`. -/
-def FiniteAdeleRing : Type _ := (
-  { carrier := {x : K_hat R K | x.IsFiniteAdele}
-    mul_mem' := mul
-    one_mem' := one
-    add_mem' := add
-    zero_mem' := zero
-    algebraMap_mem' := algebraMap'
-  } : Subalgebra K (K_hat R K))
+def FiniteAdeleRing : Type _ := {x : K_hat R K // x.IsFiniteAdele}
 #align dedekind_domain.finite_adele_ring DedekindDomain.FiniteAdeleRing
 
 namespace FiniteAdeleRing
 
-instance : CommRing (FiniteAdeleRing R K) := Subalgebra.toCommRing _
+def subalgebra : Subalgebra K (K_hat R K) where
+  carrier := {x : K_hat R K | x.IsFiniteAdele}
+  mul_mem' := mul
+  one_mem' := one
+  add_mem' := add
+  zero_mem' := zero
+  algebraMap_mem' := algebraMap'
 
-instance : Algebra K (FiniteAdeleRing R K) := Subalgebra.algebra _
+instance : CommRing (FiniteAdeleRing R K) :=
+  Subalgebra.toCommRing (subalgebra R K)
+
+instance : Algebra K (FiniteAdeleRing R K) :=
+  Subalgebra.algebra (subalgebra R K)
 
 instance : Coe (FiniteAdeleRing R K) (K_hat R K) where
   coe := fun x ↦ x.1
@@ -337,25 +340,14 @@ lemma ext {a₁ a₂ : FiniteAdeleRing R K} (h : (a₁ : K_hat R K) = a₂) : a�
   Subtype.ext h
 
 @[simp]
-lemma mem_FiniteAdeleRing (x : K_hat R K) : x ∈ (
-    { carrier := {x : K_hat R K | x.IsFiniteAdele}
-      mul_mem' := mul
-      one_mem' := one
-      add_mem' := add
-      zero_mem' := zero
-      algebraMap_mem' := algebraMap'
-    } : Subalgebra K (K_hat R K)) ↔ {v | x v ∉ adicCompletionIntegers K v}.Finite := Iff.rfl
+lemma _root_.isFiniteAdele_iff (x : K_hat R K) :
+  x.IsFiniteAdele ↔ {v | x v ∉ adicCompletionIntegers K v}.Finite := Iff.rfl
 
 /-- The finite adele ring is an algebra over the finite integral adeles. -/
 instance : Algebra (R_hat R K) (FiniteAdeleRing R K) where
-  smul rhat fadele := ⟨fun v ↦ rhat v * fadele.1 v, by
-    have this := fadele.2
-    rw [mem_FiniteAdeleRing] at this ⊢
-    apply Finite.subset this (fun v hv ↦ ?_)
-    rw [mem_setOf_eq, mem_adicCompletionIntegers] at hv ⊢
-    contrapose! hv
-    rw [map_mul]
-    exact mul_le_one₀ (rhat v).2 hv
+  smul rhat fadele := ⟨fun v ↦ rhat v * fadele.1 v, Finite.subset fadele.2 <| fun v hv ↦ by
+    simp only [mem_adicCompletionIntegers, mem_compl_iff, mem_setOf_eq, map_mul] at hv ⊢
+    exact mt (mul_le_one₀ (rhat v).2) hv
     ⟩
   toFun r := ⟨r, by simp_all⟩
   map_one' := by ext; rfl
@@ -364,6 +356,7 @@ instance : Algebra (R_hat R K) (FiniteAdeleRing R K) where
   map_add' _ _ := by ext; rfl
   commutes' _ _ := mul_comm _ _
   smul_def' r x := rfl
+
 end FiniteAdeleRing
 
 end DedekindDomain

--- a/Mathlib/RingTheory/DedekindDomain/FiniteAdeleRing.lean
+++ b/Mathlib/RingTheory/DedekindDomain/FiniteAdeleRing.lean
@@ -197,6 +197,10 @@ def IsFiniteAdele (x : K_hat R K) :=
   ∀ᶠ v : HeightOneSpectrum R in Filter.cofinite, x v ∈ v.adicCompletionIntegers K
 #align dedekind_domain.prod_adic_completions.is_finite_adele DedekindDomain.ProdAdicCompletions.IsFiniteAdele
 
+@[simp]
+lemma isFiniteAdele_iff (x : K_hat R K) :
+    x.IsFiniteAdele ↔ {v | x v ∉ adicCompletionIntegers K v}.Finite := Iff.rfl
+
 namespace IsFiniteAdele
 
 /-- The sum of two finite adèles is a finite adèle. -/
@@ -338,10 +342,6 @@ instance : Coe (FiniteAdeleRing R K) (K_hat R K) where
 @[ext]
 lemma ext {a₁ a₂ : FiniteAdeleRing R K} (h : (a₁ : K_hat R K) = a₂) : a₁ = a₂ :=
   Subtype.ext h
-
-@[simp]
-lemma _root_.isFiniteAdele_iff (x : K_hat R K) :
-  x.IsFiniteAdele ↔ {v | x v ∉ adicCompletionIntegers K v}.Finite := Iff.rfl
 
 /-- The finite adele ring is an algebra over the finite integral adeles. -/
 instance : Algebra (R_hat R K) (FiniteAdeleRing R K) where

--- a/Mathlib/RingTheory/DedekindDomain/FiniteAdeleRing.lean
+++ b/Mathlib/RingTheory/DedekindDomain/FiniteAdeleRing.lean
@@ -336,6 +336,34 @@ instance : Coe (FiniteAdeleRing R K) (K_hat R K) where
 lemma ext {a₁ a₂ : FiniteAdeleRing R K} (h : (a₁ : K_hat R K) = a₂) : a₁ = a₂ :=
   Subtype.ext h
 
+@[simp]
+lemma mem_FiniteAdeleRing (x : K_hat R K) : x ∈ (
+    { carrier := {x : K_hat R K | x.IsFiniteAdele}
+      mul_mem' := mul
+      one_mem' := one
+      add_mem' := add
+      zero_mem' := zero
+      algebraMap_mem' := algebraMap'
+    } : Subalgebra K (K_hat R K)) ↔ {v | x v ∉ adicCompletionIntegers K v}.Finite := Iff.rfl
+
+/-- The finite adele ring is an algebra over the finite integral adeles. -/
+instance : Algebra (R_hat R K) (FiniteAdeleRing R K) where
+  smul rhat fadele := ⟨fun v ↦ rhat v * fadele.1 v, by
+    have this := fadele.2
+    rw [mem_FiniteAdeleRing] at this ⊢
+    apply Finite.subset this (fun v hv ↦ ?_)
+    rw [mem_setOf_eq, mem_adicCompletionIntegers] at hv ⊢
+    contrapose! hv
+    rw [map_mul]
+    exact mul_le_one₀ (rhat v).2 hv
+    ⟩
+  toFun r := ⟨r, by simp_all⟩
+  map_one' := by ext; rfl
+  map_mul' _ _ := by ext; rfl
+  map_zero' := by ext; rfl
+  map_add' _ _ := by ext; rfl
+  commutes' _ _ := mul_comm _ _
+  smul_def' r x := rfl
 end FiniteAdeleRing
 
 end DedekindDomain

--- a/Mathlib/RingTheory/DedekindDomain/FiniteAdeleRing.lean
+++ b/Mathlib/RingTheory/DedekindDomain/FiniteAdeleRing.lean
@@ -316,12 +316,14 @@ end ProdAdicCompletions
 open ProdAdicCompletions.IsFiniteAdele
 
 /-- The finite adèle ring of `R` is the restricted product over all maximal ideals `v` of `R`
-of `adicCompletion` with respect to `adicCompletionIntegers`. -/
+of `adicCompletion`, with respect to `adicCompletionIntegers`. -/
 def FiniteAdeleRing : Type _ := {x : K_hat R K // x.IsFiniteAdele}
 #align dedekind_domain.finite_adele_ring DedekindDomain.FiniteAdeleRing
 
 namespace FiniteAdeleRing
 
+/-- The finite adèle ring of `R`, regarded as a `K`-subalgebra of the
+product of the local completions of `K`. -/
 def subalgebra : Subalgebra K (K_hat R K) where
   carrier := {x : K_hat R K | x.IsFiniteAdele}
   mul_mem' := mul

--- a/Mathlib/RingTheory/DedekindDomain/FiniteAdeleRing.lean
+++ b/Mathlib/RingTheory/DedekindDomain/FiniteAdeleRing.lean
@@ -323,7 +323,11 @@ def FiniteAdeleRing : Type _ := {x : K_hat R K // x.IsFiniteAdele}
 namespace FiniteAdeleRing
 
 /-- The finite adèle ring of `R`, regarded as a `K`-subalgebra of the
-product of the local completions of `K`. -/
+product of the local completions of `K`.
+
+Note that this definition exists to streamline the proof that the finite adèles are an algebra over `K`,
+rather than to express their relationship to `K_hat R K` which is essentially a detail of their construction.
+-/
 def subalgebra : Subalgebra K (K_hat R K) where
   carrier := {x : K_hat R K | x.IsFiniteAdele}
   mul_mem' := mul

--- a/Mathlib/RingTheory/DedekindDomain/FiniteAdeleRing.lean
+++ b/Mathlib/RingTheory/DedekindDomain/FiniteAdeleRing.lean
@@ -325,8 +325,9 @@ namespace FiniteAdeleRing
 /-- The finite adèle ring of `R`, regarded as a `K`-subalgebra of the
 product of the local completions of `K`.
 
-Note that this definition exists to streamline the proof that the finite adèles are an algebra over `K`,
-rather than to express their relationship to `K_hat R K` which is essentially a detail of their construction.
+Note that this definition exists to streamline the proof that the finite adèles are an algebra
+over `K`, rather than to express their relationship to `K_hat R K` which is essentially a
+detail of their construction.
 -/
 def subalgebra : Subalgebra K (K_hat R K) where
   carrier := {x : K_hat R K | x.IsFiniteAdele}


### PR DESCRIPTION


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)

We change the definition of the finite adeles to a subtype, and rework the original construction to be a subalgebra with this underlying subtype. We then show that the finite adeles are an algebra over the finite integral adeles, in an attempt to demonstrate that this set-up works fine.