### PR TITLE
[Merged by Bors] - feat(Order): sup/inf equal to top/bot if top/bot in set

### DIFF
--- a/Mathlib/Order/CompleteLattice.lean
+++ b/Mathlib/Order/CompleteLattice.lean
@@ -541,10 +541,10 @@ theorem sInf_eq_bot : sInf s = ⊥ ↔ ∀ b > ⊥, ∃ a ∈ s, a < b :=
 #align Inf_eq_bot sInf_eq_bot
 
 lemma sup_eq_top_of_top_mem (h : ⊤ ∈ s) : sSup s = ⊤ :=
-  sSup_eq_top.mpr fun _ _ => by use ⊤
+  sSup_eq_top.mpr fun _ _ ↦ by use ⊤
 
 lemma inf_eq_bot_of_bot_mem (h : ⊥ ∈ s) : sInf s = ⊥ :=
-  sInf_eq_bot.mpr fun _ _ => by use ⊥
+  sInf_eq_bot.mpr fun _ _ ↦ by use ⊥
 
 theorem lt_iSup_iff {f : ι → α} : a < iSup f ↔ ∃ i, a < f i :=
   lt_sSup_iff.trans exists_range_iff

--- a/Mathlib/Order/CompleteLattice.lean
+++ b/Mathlib/Order/CompleteLattice.lean
@@ -540,6 +540,12 @@ theorem sInf_eq_bot : sInf s = ⊥ ↔ ∀ b > ⊥, ∃ a ∈ s, a < b :=
   @sSup_eq_top αᵒᵈ _ _
 #align Inf_eq_bot sInf_eq_bot
 
+lemma sup_eq_top_of_top_mem (h : ⊤ ∈ s) : sSup s = ⊤ :=
+  sSup_eq_top.mpr fun _ _ => by use ⊤
+
+lemma inf_eq_bot_of_bot_mem (h : ⊥ ∈ s) : sInf s = ⊥ :=
+  sInf_eq_bot.mpr fun _ _ => by use ⊥
+
 theorem lt_iSup_iff {f : ι → α} : a < iSup f ↔ ∃ i, a < f i :=
   lt_sSup_iff.trans exists_range_iff
 #align lt_supr_iff lt_iSup_iff

--- a/Mathlib/Order/CompleteLattice.lean
+++ b/Mathlib/Order/CompleteLattice.lean
@@ -540,12 +540,6 @@ theorem sInf_eq_bot : sInf s = ⊥ ↔ ∀ b > ⊥, ∃ a ∈ s, a < b :=
   @sSup_eq_top αᵒᵈ _ _
 #align Inf_eq_bot sInf_eq_bot
 
-lemma sup_eq_top_of_top_mem (h : ⊤ ∈ s) : sSup s = ⊤ :=
-  sSup_eq_top.mpr fun _ _ ↦ by use ⊤
-
-lemma inf_eq_bot_of_bot_mem (h : ⊥ ∈ s) : sInf s = ⊥ :=
-  sInf_eq_bot.mpr fun _ _ ↦ by use ⊥
-
 theorem lt_iSup_iff {f : ι → α} : a < iSup f ↔ ∃ i, a < f i :=
   lt_sSup_iff.trans exists_range_iff
 #align lt_supr_iff lt_iSup_iff

--- a/Mathlib/Order/ConditionallyCompleteLattice/Basic.lean
+++ b/Mathlib/Order/ConditionallyCompleteLattice/Basic.lean
@@ -974,6 +974,12 @@ lemma Set.Ici_ciSup [Nonempty ι] {f : ι → α} (hf : BddAbove (range f)) :
     Ici (⨆ i, f i) = ⋂ i, Ici (f i) :=
   Iic_ciInf (α := αᵒᵈ) hf
 
+lemma sup_eq_top_of_top_mem [OrderTop α] (h : ⊤ ∈ s) : sSup s = ⊤ :=
+  top_unique <| le_csSup (OrderTop.bddAbove s) h
+
+lemma inf_eq_bot_of_bot_mem [OrderBot α] (h : ⊥ ∈ s) : sInf s = ⊥ :=
+  bot_unique <| csInf_le (OrderBot.bddBelow s) h
+
 end ConditionallyCompleteLattice
 
 instance Pi.conditionallyCompleteLattice {ι : Type*} {α : ι → Type*}


### PR DESCRIPTION
The sup lemma is needed in a proof related to `SimpleGraph.ediam` in #12058 

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
