### PR TITLE
[Merged by Bors] - doc: units of a trivial normed algebra are a thing

### DIFF
--- a/Mathlib/Geometry/Manifold/Instances/UnitsOfNormedAlgebra.lean
+++ b/Mathlib/Geometry/Manifold/Instances/UnitsOfNormedAlgebra.lean
@@ -20,7 +20,7 @@ over a field `𝕜`, the `𝕜`-linear endomorphisms of `V` are a normed `𝕜`-
 `ContinuousLinearMap.toNormedAlgebra`), so this construction provides a Lie group structure on
 its group of units, the general linear group GL(`𝕜`, `V`), as demonstrated by:
 ```
-example {V : Type*} [NormedAddCommGroup V] [NormedSpace 𝕜 V] [CompleteSpace V] [Nontrivial V] :
+example {V : Type*} [NormedAddCommGroup V] [NormedSpace 𝕜 V] [CompleteSpace V] :
     LieGroup 𝓘(𝕜, V →L[𝕜] V) (V →L[𝕜] V)ˣ := inferInstance
 ```
 -/

--- a/Mathlib/Geometry/Manifold/Instances/UnitsOfNormedAlgebra.lean
+++ b/Mathlib/Geometry/Manifold/Instances/UnitsOfNormedAlgebra.lean
@@ -20,8 +20,8 @@ over a field `𝕜`, the `𝕜`-linear endomorphisms of `V` are a normed `𝕜`-
 `ContinuousLinearMap.toNormedAlgebra`), so this construction provides a Lie group structure on
 its group of units, the general linear group GL(`𝕜`, `V`), as demonstrated by:
 ```
-variable {V : Type*} [NormedAddCommGroup V] [NormedSpace 𝕜 V] [CompleteSpace V] in
-#synth LieGroup 𝓘(𝕜, V →L[𝕜] V) (V →L[𝕜] V)ˣ
+example {V : Type*} [NormedAddCommGroup V] [NormedSpace 𝕜 V] [CompleteSpace V] [Nontrivial V] :
+    LieGroup 𝓘(𝕜, V →L[𝕜] V) (V →L[𝕜] V)ˣ := inferInstance
 ```
 -/
 

--- a/Mathlib/Geometry/Manifold/Instances/UnitsOfNormedAlgebra.lean
+++ b/Mathlib/Geometry/Manifold/Instances/UnitsOfNormedAlgebra.lean
@@ -20,8 +20,8 @@ over a field `𝕜`, the `𝕜`-linear endomorphisms of `V` are a normed `𝕜`-
 `ContinuousLinearMap.toNormedAlgebra`), so this construction provides a Lie group structure on
 its group of units, the general linear group GL(`𝕜`, `V`), as demonstrated by:
 ```
-example {V : Type*} [NormedAddCommGroup V] [NormedSpace 𝕜 V] [CompleteSpace V] [Nontrivial V] :
-  LieGroup 𝓘(𝕜, V →L[𝕜] V) (V →L[𝕜] V)ˣ := by infer_instance
+variable {V : Type*} [NormedAddCommGroup V] [NormedSpace 𝕜 V] [CompleteSpace V] in
+#synth LieGroup 𝓘(𝕜, V →L[𝕜] V) (V →L[𝕜] V)ˣ
 ```
 -/
 


### PR DESCRIPTION
Fix a comment.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)

This PR does two things: (1) removes `[Nontrivial V]` from an example in a comment (it's not used, and I need the trivial case!) and (2) changes a `by infer_instance` to `#synth` in the same comment.