### PR TITLE
[Merged by Bors] - chore: install elan when updating nightly-testing

### DIFF
--- a/.github/workflows/nightly_merge_master.yml
+++ b/.github/workflows/nightly_merge_master.yml
@@ -10,6 +10,13 @@ jobs:
   merge-to-nightly:
     runs-on: ubuntu-latest
     steps:
+      - name: install elan
+        run: |
+          set -o pipefail
+          curl -sSfL https://github.com/leanprover/elan/releases/download/v3.0.0/elan-x86_64-unknown-linux-gnu.tar.gz | tar xz
+          ./elan-init -y --default-toolchain none
+          echo "$HOME/.elan/bin" >> "${GITHUB_PATH}"
+
       - name: Checkout repository
         uses: actions/checkout@v4
         with:


### PR DESCRIPTION
Oops, updating nightly-testing was broken over the weekend.