### PR TITLE
[Merged by Bors] - chore: fix junk value for `sInf` on `WithTop`

### DIFF
--- a/Mathlib/Data/ENNReal/Basic.lean
+++ b/Mathlib/Data/ENNReal/Basic.lean
@@ -753,8 +753,8 @@ theorem coe_sSup {s : Set ℝ≥0} : BddAbove s → (↑(sSup s) : ℝ≥0∞) =
   WithTop.coe_sSup
 #align ennreal.coe_Sup ENNReal.coe_sSup
 
-theorem coe_sInf {s : Set ℝ≥0} : s.Nonempty → (↑(sInf s) : ℝ≥0∞) = ⨅ a ∈ s, ↑a :=
-  WithTop.coe_sInf
+theorem coe_sInf {s : Set ℝ≥0} (hs : s.Nonempty) : (↑(sInf s) : ℝ≥0∞) = ⨅ a ∈ s, ↑a :=
+  WithTop.coe_sInf hs (OrderBot.bddBelow s)
 #align ennreal.coe_Inf ENNReal.coe_sInf
 
 theorem coe_iSup {ι : Sort*} {f : ι → ℝ≥0} (hf : BddAbove (range f)) :
@@ -764,7 +764,7 @@ theorem coe_iSup {ι : Sort*} {f : ι → ℝ≥0} (hf : BddAbove (range f)) :
 
 @[norm_cast]
 theorem coe_iInf {ι : Sort*} [Nonempty ι] (f : ι → ℝ≥0) : (↑(iInf f) : ℝ≥0∞) = ⨅ a, ↑(f a) :=
-  WithTop.coe_iInf f
+  WithTop.coe_iInf (OrderBot.bddBelow _)
 #align ennreal.coe_infi ENNReal.coe_iInf
 
 theorem coe_mem_upperBounds {s : Set ℝ≥0} :

--- a/Mathlib/Data/ENat/Lattice.lean
+++ b/Mathlib/Data/ENat/Lattice.lean
@@ -42,6 +42,7 @@ lemma coe_sInf (hs : s.Nonempty) : ↑(sInf s) = ⨅ a ∈ s, (a : ℕ∞) :=
 
 lemma coe_iSup : BddAbove (range f) → ↑(⨆ i, f i) = ⨆ i, (f i : ℕ∞) := WithTop.coe_iSup _
 
-@[norm_cast] lemma coe_iInf [Nonempty ι] : ↑(⨅ i, f i) = ⨅ i, (f i : ℕ∞) := WithTop.coe_iInf _
+@[norm_cast] lemma coe_iInf [Nonempty ι] : ↑(⨅ i, f i) = ⨅ i, (f i : ℕ∞) :=
+  WithTop.coe_iInf (OrderBot.bddBelow _)
 
 end ENat

--- a/Mathlib/Data/ENat/Lattice.lean
+++ b/Mathlib/Data/ENat/Lattice.lean
@@ -36,8 +36,12 @@ lemma iInf_coe_ne_top : ⨅ i, (f i : ℕ∞) ≠ ⊤ ↔ Nonempty ι := by
 lemma iInf_coe_lt_top : ⨅ i, (f i : ℕ∞) < ⊤ ↔ Nonempty ι := WithTop.iInf_coe_lt_top
 
 lemma coe_sSup : BddAbove s → ↑(sSup s) = ⨆ a ∈ s, (a : ℕ∞) := WithTop.coe_sSup
-lemma coe_sInf : s.Nonempty → ↑(sInf s) = ⨅ a ∈ s, (a : ℕ∞) := WithTop.coe_sInf
+
+lemma coe_sInf (hs : s.Nonempty) : ↑(sInf s) = ⨅ a ∈ s, (a : ℕ∞) :=
+  WithTop.coe_sInf hs (OrderBot.bddBelow s)
+
 lemma coe_iSup : BddAbove (range f) → ↑(⨆ i, f i) = ⨆ i, (f i : ℕ∞) := WithTop.coe_iSup _
+
 @[norm_cast] lemma coe_iInf [Nonempty ι] : ↑(⨅ i, f i) = ⨅ i, (f i : ℕ∞) := WithTop.coe_iInf _
 
 end ENat

--- a/Mathlib/Order/ConditionallyCompleteLattice/Basic.lean
+++ b/Mathlib/Order/ConditionallyCompleteLattice/Basic.lean
@@ -55,7 +55,7 @@ noncomputable instance WithTop.instSupSet [SupSet α] :
 noncomputable instance WithTop.instInfSet [InfSet α] : InfSet (WithTop α) :=
   ⟨fun S => if S ⊆ {⊤} ∨ ¬BddBelow S then ⊤ else ↑(sInf ((fun (a : α) ↦ ↑a) ⁻¹' S : Set α))⟩
 
-noncomputable instance WithBot.instSupSet[SupSet α] : SupSet (WithBot α) :=
+noncomputable instance WithBot.instSupSet [SupSet α] : SupSet (WithBot α) :=
   ⟨(WithTop.instInfSet (α := αᵒᵈ)).sInf⟩
 
 noncomputable instance WithBot.instInfSet [InfSet α] :

--- a/Mathlib/Order/ConditionallyCompleteLattice/Basic.lean
+++ b/Mathlib/Order/ConditionallyCompleteLattice/Basic.lean
@@ -97,12 +97,12 @@ theorem WithTop.coe_sInf' [InfSet α] {s : Set α} (hs : s.Nonempty) (h's : BddB
   obtain ⟨x, hx⟩ := hs
   change _ = ite _ _ _
   split_ifs with h
-  · cases h (mem_image_of_mem _ hx)
+  · rcases h with h1 | h2
+    · cases h1 (mem_image_of_mem _ hx)
+    · exact (h2 (Monotone.map_bddBelow coe_mono h's)).elim
   · rw [preimage_image_eq]
     exact Option.some_injective _
 #align with_top.coe_Inf' WithTop.coe_sInf'
-
-#exit
 
 -- Porting note: the mathlib3 proof uses `range_comp` in the opposite direction and
 -- does not need `rfl`.
@@ -129,9 +129,11 @@ theorem WithTop.coe_iSup [SupSet α] (f : ι → α) (h : BddAbove (Set.range f)
 #align with_top.coe_supr WithTop.coe_iSup
 
 @[simp]
-theorem WithBot.csSup_empty [SupSet α] : sSup (∅ : Set (WithBot α)) = ⊥ :=
-  if_pos <| Set.empty_subset _
-#align with_bot.cSup_empty WithBot.csSup_empty
+theorem WithBot.sSup_empty [SupSet α] : sSup (∅ : Set (WithBot α)) = ⊥ :=
+  WithTop.sInf_empty (α := αᵒᵈ)
+#align with_bot.cSup_empty WithBot.sSup_empty
+
+@[deprecated (since := "2024-06-10")] alias WithBot.csSup_empty := WithBot.sSup_empty
 
 @[simp]
 theorem WithBot.ciSup_empty [IsEmpty ι] [SupSet α] (f : ι → WithBot α) :

--- a/Mathlib/Order/ConditionallyCompleteLattice/Basic.lean
+++ b/Mathlib/Order/ConditionallyCompleteLattice/Basic.lean
@@ -107,9 +107,10 @@ theorem WithTop.coe_sInf' [InfSet α] {s : Set α} (hs : s.Nonempty) (h's : BddB
 -- Porting note: the mathlib3 proof uses `range_comp` in the opposite direction and
 -- does not need `rfl`.
 @[norm_cast]
-theorem WithTop.coe_iInf [Nonempty ι] [InfSet α] (f : ι → α) :
+theorem WithTop.coe_iInf [Nonempty ι] [InfSet α] {f : ι → α} (hf : BddBelow (range f)) :
     ↑(⨅ i, f i) = (⨅ i, f i : WithTop α) := by
-  rw [iInf, iInf, WithTop.coe_sInf' (range_nonempty f), ← range_comp]; rfl
+  rw [iInf, iInf, WithTop.coe_sInf' (range_nonempty f) hf, ← range_comp]
+  rfl
 #align with_top.coe_infi WithTop.coe_iInf
 
 theorem WithTop.coe_sSup' [SupSet α] {s : Set α} (hs : BddAbove s) :
@@ -142,15 +143,15 @@ theorem WithBot.ciSup_empty [IsEmpty ι] [SupSet α] (f : ι → WithBot α) :
 #align with_bot.csupr_empty WithBot.ciSup_empty
 
 @[norm_cast]
-theorem WithBot.coe_sSup' [SupSet α] {s : Set α} (hs : s.Nonempty) :
+theorem WithBot.coe_sSup' [SupSet α] {s : Set α} (hs : s.Nonempty) (h's : BddAbove s) :
     ↑(sSup s) = (sSup ((fun (a : α) ↦ ↑a) '' s) : WithBot α) :=
-  WithTop.coe_sInf' (α := αᵒᵈ) hs
+  WithTop.coe_sInf' (α := αᵒᵈ) hs h's
 #align with_bot.coe_Sup' WithBot.coe_sSup'
 
 @[norm_cast]
-theorem WithBot.coe_iSup [Nonempty ι] [SupSet α] (f : ι → α) :
+theorem WithBot.coe_iSup [Nonempty ι] [SupSet α] {f : ι → α} (hf : BddAbove (range f)) :
     ↑(⨆ i, f i) = (⨆ i, f i : WithBot α) :=
-  WithTop.coe_iInf (α := αᵒᵈ) _
+  WithTop.coe_iInf (α := αᵒᵈ) hf
 #align with_bot.coe_supr WithBot.coe_iSup
 
 @[norm_cast]
@@ -1340,6 +1341,7 @@ theorem isGLB_sInf' {β : Type*} [ConditionallyCompleteLattice β] {s : Set (Wit
     (hs : BddBelow s) : IsGLB s (sInf s) := by
   constructor
   · show ite _ _ _ ∈ _
+    simp only [hs, not_true_eq_false, or_false]
     split_ifs with h
     · intro a ha
       exact top_le_iff.2 (Set.mem_singleton_iff.1 (h ha))
@@ -1356,6 +1358,7 @@ theorem isGLB_sInf' {β : Type*} [ConditionallyCompleteLattice β] {s : Set (Wit
       intro c hc
       exact coe_le_coe.1 (hb hc)
   · show ite _ _ _ ∈ _
+    simp only [hs, not_true_eq_false, or_false]
     split_ifs with h
     · intro _ _
       exact le_top
@@ -1402,8 +1405,9 @@ theorem coe_sSup {s : Set α} (hb : BddAbove s) : ↑(sSup s) = (⨆ a ∈ s, �
 
 /-- A version of `WithTop.coe_sInf'` with a more convenient but less general statement. -/
 @[norm_cast]
-theorem coe_sInf {s : Set α} (hs : s.Nonempty) : ↑(sInf s) = (⨅ a ∈ s, ↑a : WithTop α) := by
-  rw [coe_sInf' hs, sInf_image]
+theorem coe_sInf {s : Set α} (hs : s.Nonempty) (h's : BddBelow s) :
+    ↑(sInf s) = (⨅ a ∈ s, ↑a : WithTop α) := by
+  rw [coe_sInf' hs h's, sInf_image]
 #align with_top.coe_Inf WithTop.coe_sInf
 
 end WithTop
@@ -1663,7 +1667,7 @@ noncomputable instance WithTop.WithBot.completeLattice {α : Type*}
           -- Porting note: previous proof relied on convert unfolding
           -- the definition of ⊥
           apply congr_arg
-          simp only [h, preimage_empty, WithBot.csSup_empty]
+          simp only [h, preimage_empty, WithBot.sSup_empty]
         · exfalso
           apply h₂
           use ⊥
@@ -1672,6 +1676,7 @@ noncomputable instance WithTop.WithBot.completeLattice {α : Type*}
       · exact (WithTop.isLUB_sSup' h).2 ha
     sInf_le := fun S a haS =>
       show ite _ _ _ ≤ a by
+        simp only [OrderBot.bddBelow, not_true_eq_false, or_false]
         split_ifs with h₁
         · cases' a with a
           · exact le_rfl


### PR DESCRIPTION
As pointed out in https://leanprover.zulipchat.com/#narrow/stream/113489-new-members/topic/Definition.20of.20.60WithTop.2EinstInfSet.60/near/443609808, the current choice of junk value for `sInf s` when `s : Set (WithTop α)` is not bounded below does not coincide with `sInf ∅`. This makes it impossible to get a `ConditionallyCompleteLinearOrder` structure on `WithTop α` as we require the junk values to coincide.

This PR fixes the choice of junk value for  `sInf s` when `s : Set (WithTop α)` is not bounded below, making it equal to `⊤ = sInf ∅`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
