### PR TITLE
[Merged by Bors] - feat(Analysis/MeanInequalities): HM-GM inequality

### DIFF
--- a/Mathlib/Analysis/MeanInequalities.lean
+++ b/Mathlib/Analysis/MeanInequalities.lean
@@ -14,8 +14,8 @@ import Mathlib.Data.Real.ConjExponents
 # Mean value inequalities
 
 In this file we prove several inequalities for finite sums, including AM-GM inequality,
-Young's inequality, Hölder inequality, and Minkowski inequality. Versions for integrals of some of
-these inequalities are available in `MeasureTheory.MeanInequalities`.
+HM-GM inequality, Young's inequality, Hölder inequality, and Minkowski inequality. Versions for
+integrals of some of these inequalities are available in `MeasureTheory.MeanInequalities`.
 
 ## Main theorems
 
@@ -37,6 +37,20 @@ a version for real-valued non-negative functions is in the `Real` namespace, and
 - `geom_mean_le_arith_mean2_weighted` : weighted version for two numbers;
 - `geom_mean_le_arith_mean3_weighted` : weighted version for three numbers;
 - `geom_mean_le_arith_mean4_weighted` : weighted version for four numbers.
+
+
+### HM-GM inequality:
+
+The inequality says that the harmonic mean of a tuple of positive numbers is less than or equal
+to their geometric mean. We prove the weighted version of this inequality: if $w$ and $z$
+are two positive vectors and $\sum_{i\in s} w_i=1$, then
+$$
+1/(\sum_{i\in s} w_i/z_i)  ≤ \prod_{i\in s} z_i^{w_i}
+$$
+The classical version is proven as a special case of this inequality for $w_i=\frac{1}{n}$.
+
+The inequalities are proven only for real valued positive functions on `Finset`s, and namespaced in
+`Real`. The weighted version follows as a corollary of the weighted AM-GM inequality.
 
 ### Young's inequality
 
@@ -252,6 +266,58 @@ theorem geom_mean_le_arith_mean4_weighted {w₁ w₂ w₃ w₄ p₁ p₂ p₃ p�
 end Real
 
 end GeomMeanLEArithMean
+
+section HarmMeanLEGeomMean
+
+/-! ### HM-GM inequality -/
+
+namespace Real
+
+/-- **HM-GM inequality**: The harmonic mean is less than or equal to the geometric mean, weighted
+version for real-valued nonnegative functions. -/
+theorem harm_mean_le_geom_mean_weighted (w z : ι → ℝ) (hs : s.Nonempty) (hw : ∀ i ∈ s, 0 < w i)
+    (hw' : ∑ i in s, w i = 1) (hz : ∀ i ∈ s, 0 < z i) :
+    1/(∑ i in s, w i / z i) ≤ ∏ i in s, z i ^ w i  := by
+    have : ∏ i in s, (1 / z) i ^ w i ≤ ∑ i in s, w i * (1 / z) i :=
+      geom_mean_le_arith_mean_weighted s w (1/z) (fun i hi ↦ le_of_lt (hw i hi)) hw'
+                                                 (fun i hi ↦ one_div_nonneg.2 (le_of_lt (hz i hi)))
+    have p_pos : 0 < ∏ i in s, (z i)⁻¹ ^ w i :=
+      prod_pos fun i hi => rpow_pos_of_pos (inv_pos.2 (hz i hi)) _
+    have s_pos : 0 < ∑ i in s, w i * (z i)⁻¹ :=
+      sum_pos (fun i hi => Real.mul_pos (hw i hi) (inv_pos.2 (hz i hi))) hs
+    norm_num at this
+    rw [← inv_le_inv s_pos p_pos, inv_eq_one_div] at this
+    apply le_trans this
+    have p_pos₂ : 0 < (∏ i in s, (z i) ^ w i)⁻¹ :=
+      inv_pos.2 (prod_pos fun i hi => rpow_pos_of_pos ((hz i hi)) _ )
+    rw [← inv_inv (∏ i in s, z i ^ w i), inv_le_inv p_pos p_pos₂, ← Finset.prod_inv_distrib]
+    gcongr
+    · refine fun i hi ↦ inv_nonneg.mpr (Real.rpow_nonneg (le_of_lt (hz i hi)) _)
+    · rw [Real.inv_rpow]
+      apply (fun i hi ↦ le_of_lt (hz i hi)); assumption
+
+
+/-- **HM-GM inequality**: The **harmonic mean is less than or equal to the geometric mean. --/
+theorem harm_mean_le_geom_mean {ι : Type*} (s : Finset ι) (hs : Finset.Nonempty s) (w : ι → ℝ)
+    (z : ι → ℝ) (hw : ∀ i ∈ s, 0 < w i) (hw' : 0 < ∑ i in s, w i) (hz : ∀ i ∈ s, 0 < z i) :
+    (∑ i in s, w i)/(∑ i in s, w i / z i) ≤ (∏ i in s, z i ^ w i) ^ (∑ i in s, w i)⁻¹ := by
+  have := harm_mean_le_geom_mean_weighted s (fun i => (w i) / ∑ i in s, w i) z hs ?_ ?_ hz
+  simp at this
+  set n := ∑ i in s, w i
+  · nth_rw 1 [div_eq_mul_inv, (show n = (n⁻¹)⁻¹ by norm_num), ←mul_inv, Finset.mul_sum _ _ n⁻¹]
+    simp_rw [inv_mul_eq_div n ((w _)/(z _)), div_right_comm _ _ n]
+    convert this
+    rw [← Real.finset_prod_rpow s _ (fun i hi ↦ Real.rpow_nonneg (le_of_lt <| hz i hi) _)]
+    refine Finset.prod_congr rfl (fun i hi => ?_)
+    rw [← Real.rpow_mul (le_of_lt <| hz i hi) (w _) n⁻¹, div_eq_mul_inv (w _) n]
+  · exact fun i hi ↦ div_pos (hw i hi) hw'
+  · simp_rw [div_eq_mul_inv (w _) (∑ i in s, w i), ← Finset.sum_mul _ _ (∑ i in s, w i)⁻¹]
+    rw [mul_inv_cancel (by apply ne_of_gt; assumption)]
+
+end Real
+
+end HarmMeanLEGeomMean
+
 
 section Young
 

--- a/Mathlib/Analysis/MeanInequalities.lean
+++ b/Mathlib/Analysis/MeanInequalities.lean
@@ -304,7 +304,7 @@ theorem harm_mean_le_geom_mean {ι : Type*} (s : Finset ι) (hs : Finset.Nonempt
   have := harm_mean_le_geom_mean_weighted s (fun i => (w i) / ∑ i in s, w i) z hs ?_ ?_ hz
   simp at this
   set n := ∑ i in s, w i
-  · nth_rw 1 [div_eq_mul_inv, (show n = (n⁻¹)⁻¹ by norm_num), ←mul_inv, Finset.mul_sum _ _ n⁻¹]
+  · nth_rw 1 [div_eq_mul_inv, (show n = (n⁻¹)⁻¹ by norm_num), ← mul_inv, Finset.mul_sum _ _ n⁻¹]
     simp_rw [inv_mul_eq_div n ((w _)/(z _)), div_right_comm _ _ n]
     convert this
     rw [← Real.finset_prod_rpow s _ (fun i hi ↦ Real.rpow_nonneg (le_of_lt <| hz i hi) _)]

--- a/Mathlib/Analysis/MeanInequalities.lean
+++ b/Mathlib/Analysis/MeanInequalities.lean
@@ -45,7 +45,7 @@ The inequality says that the harmonic mean of a tuple of positive numbers is les
 to their geometric mean. We prove the weighted version of this inequality: if $w$ and $z$
 are two positive vectors and $\sum_{i\in s} w_i=1$, then
 $$
-1/(\sum_{i\in s} w_i/z_i)  ≤ \prod_{i\in s} z_i^{w_i}
+1/(\sum_{i\in s} w_i/z_i) ≤ \prod_{i\in s} z_i^{w_i}
 $$
 The classical version is proven as a special case of this inequality for $w_i=\frac{1}{n}$.
 

--- a/Mathlib/Analysis/MeanInequalities.lean
+++ b/Mathlib/Analysis/MeanInequalities.lean
@@ -277,34 +277,33 @@ namespace Real
 version for real-valued nonnegative functions. -/
 theorem harm_mean_le_geom_mean_weighted (w z : ι → ℝ) (hs : s.Nonempty) (hw : ∀ i ∈ s, 0 < w i)
     (hw' : ∑ i in s, w i = 1) (hz : ∀ i ∈ s, 0 < z i) :
-    1/(∑ i in s, w i / z i) ≤ ∏ i in s, z i ^ w i  := by
+    (∑ i in s, w i / z i)⁻¹ ≤ ∏ i in s, z i ^ w i  := by
     have : ∏ i in s, (1 / z) i ^ w i ≤ ∑ i in s, w i * (1 / z) i :=
       geom_mean_le_arith_mean_weighted s w (1/z) (fun i hi ↦ le_of_lt (hw i hi)) hw'
-                                                 (fun i hi ↦ one_div_nonneg.2 (le_of_lt (hz i hi)))
+      (fun i hi ↦ one_div_nonneg.2 (le_of_lt (hz i hi)))
     have p_pos : 0 < ∏ i in s, (z i)⁻¹ ^ w i :=
       prod_pos fun i hi => rpow_pos_of_pos (inv_pos.2 (hz i hi)) _
     have s_pos : 0 < ∑ i in s, w i * (z i)⁻¹ :=
       sum_pos (fun i hi => Real.mul_pos (hw i hi) (inv_pos.2 (hz i hi))) hs
     norm_num at this
-    rw [← inv_le_inv s_pos p_pos, inv_eq_one_div] at this
+    rw [← inv_le_inv s_pos p_pos] at this
     apply le_trans this
     have p_pos₂ : 0 < (∏ i in s, (z i) ^ w i)⁻¹ :=
       inv_pos.2 (prod_pos fun i hi => rpow_pos_of_pos ((hz i hi)) _ )
     rw [← inv_inv (∏ i in s, z i ^ w i), inv_le_inv p_pos p_pos₂, ← Finset.prod_inv_distrib]
     gcongr
-    · refine fun i hi ↦ inv_nonneg.mpr (Real.rpow_nonneg (le_of_lt (hz i hi)) _)
-    · rw [Real.inv_rpow]
-      apply (fun i hi ↦ le_of_lt (hz i hi)); assumption
+    · exact fun i hi ↦ inv_nonneg.mpr (Real.rpow_nonneg (le_of_lt (hz i hi)) _)
+    · rw [Real.inv_rpow]; apply fun i hi ↦ le_of_lt (hz i hi); assumption
 
 
 /-- **HM-GM inequality**: The **harmonic mean is less than or equal to the geometric mean. --/
-theorem harm_mean_le_geom_mean {ι : Type*} (s : Finset ι) (hs : Finset.Nonempty s) (w : ι → ℝ)
+theorem harm_mean_le_geom_mean {ι : Type*} (s : Finset ι) (hs : s.Nonempty) (w : ι → ℝ)
     (z : ι → ℝ) (hw : ∀ i ∈ s, 0 < w i) (hw' : 0 < ∑ i in s, w i) (hz : ∀ i ∈ s, 0 < z i) :
-    (∑ i in s, w i)/(∑ i in s, w i / z i) ≤ (∏ i in s, z i ^ w i) ^ (∑ i in s, w i)⁻¹ := by
+    (∑ i in s, w i) / (∑ i in s, w i / z i) ≤ (∏ i in s, z i ^ w i) ^ (∑ i in s, w i)⁻¹ := by
   have := harm_mean_le_geom_mean_weighted s (fun i => (w i) / ∑ i in s, w i) z hs ?_ ?_ hz
-  simp at this
-  set n := ∑ i in s, w i
-  · nth_rw 1 [div_eq_mul_inv, (show n = (n⁻¹)⁻¹ by norm_num), ← mul_inv, Finset.mul_sum _ _ n⁻¹]
+  · simp only at this
+    set n := ∑ i in s, w i
+    nth_rw 1 [div_eq_mul_inv, (show n = (n⁻¹)⁻¹ by norm_num), ← mul_inv, Finset.mul_sum _ _ n⁻¹]
     simp_rw [inv_mul_eq_div n ((w _)/(z _)), div_right_comm _ _ n]
     convert this
     rw [← Real.finset_prod_rpow s _ (fun i hi ↦ Real.rpow_nonneg (le_of_lt <| hz i hi) _)]
@@ -312,7 +311,7 @@ theorem harm_mean_le_geom_mean {ι : Type*} (s : Finset ι) (hs : Finset.Nonempt
     rw [← Real.rpow_mul (le_of_lt <| hz i hi) (w _) n⁻¹, div_eq_mul_inv (w _) n]
   · exact fun i hi ↦ div_pos (hw i hi) hw'
   · simp_rw [div_eq_mul_inv (w _) (∑ i in s, w i), ← Finset.sum_mul _ _ (∑ i in s, w i)⁻¹]
-    rw [mul_inv_cancel (by apply ne_of_gt; assumption)]
+    exact mul_inv_cancel hw'.ne'
 
 end Real
 


### PR DESCRIPTION
We derive the inequality between the harmonic and geometric mean as a consequence of AM-GM for positive real valued functions from a `Finset`. We state a weighted as well as the classical version. 

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
