### PR TITLE
[Merged by Bors] - chore: Move antidiagonal material

### DIFF
--- a/Archive/Wiedijk100Theorems/Partition.lean
+++ b/Archive/Wiedijk100Theorems/Partition.lean
@@ -3,10 +3,10 @@ Copyright (c) 2020 Bhavik Mehta, Aaron Anderson. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Bhavik Mehta, Aaron Anderson
 -/
+import Mathlib.Algebra.Order.Antidiag.Finsupp
 import Mathlib.Algebra.Order.Ring.Abs
 import Mathlib.Combinatorics.Enumerative.Partition
 import Mathlib.Data.Finset.NatAntidiagonal
-import Mathlib.Data.Finset.PiAntidiagonal
 import Mathlib.Data.Fin.Tuple.NatAntidiagonal
 import Mathlib.RingTheory.PowerSeries.Inverse
 import Mathlib.RingTheory.PowerSeries.Order

--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -466,6 +466,9 @@ import Mathlib.Algebra.NeZero
 import Mathlib.Algebra.Opposites
 import Mathlib.Algebra.Order.AbsoluteValue
 import Mathlib.Algebra.Order.Algebra
+import Mathlib.Algebra.Order.Antidiag.Finsupp
+import Mathlib.Algebra.Order.Antidiag.Pi
+import Mathlib.Algebra.Order.Antidiag.Prod
 import Mathlib.Algebra.Order.Archimedean
 import Mathlib.Algebra.Order.BigOperators.Group.Finset
 import Mathlib.Algebra.Order.BigOperators.Group.List
@@ -1902,7 +1905,6 @@ import Mathlib.Data.Finite.Card
 import Mathlib.Data.Finite.Defs
 import Mathlib.Data.Finite.Set
 import Mathlib.Data.Finmap
-import Mathlib.Data.Finset.Antidiagonal
 import Mathlib.Data.Finset.Attr
 import Mathlib.Data.Finset.Basic
 import Mathlib.Data.Finset.Card
@@ -1924,7 +1926,6 @@ import Mathlib.Data.Finset.Order
 import Mathlib.Data.Finset.PImage
 import Mathlib.Data.Finset.Pairwise
 import Mathlib.Data.Finset.Pi
-import Mathlib.Data.Finset.PiAntidiagonal
 import Mathlib.Data.Finset.PiInduction
 import Mathlib.Data.Finset.Piecewise
 import Mathlib.Data.Finset.Pointwise

--- a/Mathlib/Algebra/Order/Antidiag/Finsupp.lean
+++ b/Mathlib/Algebra/Order/Antidiag/Finsupp.lean
@@ -27,9 +27,6 @@ but the `Finsupp` condition provides a natural `DecidableEq` instance.
   with finite support contained in `s` and such that the sum of its values equals `n : μ`
   That condition is expressed by `Finset.mem_finsuppAntidiag`
 * `Finset.mem_finsuppAntidiag'` rewrites the `Finsupp.sum` condition as a `Finset.sum`.
-* `Finset.finAntidiagonal`, a more general case of `Finset.Nat.antidiagonalTuple`
-  (TODO: deduplicate).
-
 -/
 
 namespace Finset

--- a/Mathlib/Algebra/Order/Antidiag/Finsupp.lean
+++ b/Mathlib/Algebra/Order/Antidiag/Finsupp.lean
@@ -3,8 +3,7 @@ Copyright (c) 2023 Antoine Chambert-Loir and María Inés de Frutos-Fernández. 
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Antoine Chambert-Loir, María Inés de Frutos-Fernández, Eric Wieser, Bhavik Mehta
 -/
-import Mathlib.Data.Finset.Antidiagonal
-import Mathlib.Data.Finsupp.Defs
+import Mathlib.Algebra.Order.Antidiag.Pi
 import Mathlib.Data.Finsupp.Basic
 
 /-!
@@ -42,49 +41,6 @@ open Function Finsupp
 section Fin
 
 variable [AddCommMonoid μ] [DecidableEq μ] [HasAntidiagonal μ]
-
-/-- `finAntidiagonal d n` is the type of `d`-tuples with sum `n`.
-
-TODO: deduplicate with the less general `Finset.Nat.antidiagonalTuple`. -/
-def finAntidiagonal (d : ℕ) (n : μ) : Finset (Fin d → μ) :=
-  aux d n
-where
-  /-- Auxiliary construction for `finAntidiagonal` that bundles a proof of lawfulness
-  (`mem_finAntidiagonal`), as this is needed to invoke `disjiUnion`. Using `Finset.disjiUnion` makes
-  this computationally much more efficient than using `Finset.biUnion`. -/
-  aux (d : ℕ) (n : μ) : {s : Finset (Fin d → μ) // ∀ f, f ∈ s ↔ ∑ i, f i = n} :=
-    match d with
-    | 0 =>
-      if h : n = 0 then
-        ⟨{0}, by simp [h, Subsingleton.elim finZeroElim ![]]⟩
-      else
-        ⟨∅, by simp [Ne.symm h]⟩
-    | d + 1 =>
-      { val := (antidiagonal n).disjiUnion
-          (fun ab => (aux d ab.2).1.map {
-              toFun := Fin.cons (ab.1)
-              inj' := Fin.cons_right_injective _ })
-          (fun i _hi j _hj hij => Finset.disjoint_left.2 fun t hti htj => hij <| by
-            simp_rw [Finset.mem_map, Embedding.coeFn_mk] at hti htj
-            obtain ⟨ai, hai, hij'⟩ := hti
-            obtain ⟨aj, haj, rfl⟩ := htj
-            rw [Fin.cons_eq_cons] at hij'
-            ext
-            · exact hij'.1
-            · obtain ⟨-, rfl⟩ := hij'
-              rw [← (aux d i.2).prop ai |>.mp hai, ← (aux d j.2).prop ai |>.mp haj])
-        property := fun f => by
-          simp_rw [mem_disjiUnion, mem_antidiagonal, mem_map, Embedding.coeFn_mk, Prod.exists,
-            (aux d _).prop, Fin.sum_univ_succ]
-          constructor
-          · rintro ⟨a, b, rfl, g, rfl, rfl⟩
-            simp only [Fin.cons_zero, Fin.cons_succ]
-          · intro hf
-            exact ⟨_, _, hf, _, rfl, Fin.cons_self_tail f⟩ }
-
-lemma mem_finAntidiagonal (d : ℕ) (n : μ) (f : Fin d → μ) :
-    f ∈ finAntidiagonal d n ↔ ∑ i, f i = n :=
-  (finAntidiagonal.aux d n).prop f
 
 /-- `finAntidiagonal₀ d n` is the type of d-tuples with sum `n` -/
 def finAntidiagonal₀ (d : ℕ) (n : μ) : Finset (Fin d →₀ μ) :=

--- a/Mathlib/Algebra/Order/Antidiag/Pi.lean
+++ b/Mathlib/Algebra/Order/Antidiag/Pi.lean
@@ -1,0 +1,86 @@
+/-
+Copyright (c) 2023 Antoine Chambert-Loir and María Inés de Frutos-Fernández. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Antoine Chambert-Loir, María Inés de Frutos-Fernández, Eric Wieser, Bhavik Mehta
+-/
+import Mathlib.Algebra.BigOperators.Fin
+import Mathlib.Algebra.Order.Antidiag.Prod
+
+/-!
+# Antidiagonal of functions as finsets
+
+This file provides the finset of functions summing to a specific value on a finset. Such finsets
+should be thought of as the "antidiagonals" in the space of functions.
+
+Precisely, for a commutative monoid `μ` with antidiagonals, `Finset.piAntidiag s n` is the finset of
+all functions `f : ι → μ` with support contained in `s` and such that the sum of its values equals
+`n : μ`.
+
+We define it recursively on `s` using `Finset.HasAntidiagonal.antidiagonal : μ → Finset (μ × μ)`.
+Technically, we non-canonically identify `s` with `Fin n` where `n = s.card`, recurse on `n` using
+that `(Fin (n + 1) → μ) ≃ (Fin n → μ) × μ`, and show the end result doesn't depend on our identification. See `Finset.finAntidiag` for the details.
+
+## TODO
+
+`Finset.finAntidiagonal` is strictly more general than `Finset.Nat.antidiagonalTuple`. Deduplicate.
+-/
+
+open Function
+
+variable {ι μ μ' : Type*}
+
+namespace Finset
+section AddCommMonoid
+variable [DecidableEq ι] [AddCommMonoid μ] [HasAntidiagonal μ] [DecidableEq μ] {n : μ}
+
+/-!
+### `Fin d → μ`
+
+In this section, we define the antidiagonals in `Fin d → μ` by recursion on `d`. Note that this is
+computationally efficient, although probably not as efficient as `Finset.Nat.antidiagonalTuple`.
+-/
+
+/-- `finAntidiagonal d n` is the type of `d`-tuples with sum `n`.
+
+TODO: deduplicate with the less general `Finset.Nat.antidiagonalTuple`. -/
+def finAntidiagonal (d : ℕ) (n : μ) : Finset (Fin d → μ) :=
+  aux d n
+where
+  /-- Auxiliary construction for `finAntidiagonal` that bundles a proof of lawfulness
+  (`mem_finAntidiagonal`), as this is needed to invoke `disjiUnion`. Using `Finset.disjiUnion` makes
+  this computationally much more efficient than using `Finset.biUnion`. -/
+  aux (d : ℕ) (n : μ) : {s : Finset (Fin d → μ) // ∀ f, f ∈ s ↔ ∑ i, f i = n} :=
+    match d with
+    | 0 =>
+      if h : n = 0 then
+        ⟨{0}, by simp [h, Subsingleton.elim finZeroElim ![]]⟩
+      else
+        ⟨∅, by simp [Ne.symm h]⟩
+    | d + 1 =>
+      { val := (antidiagonal n).disjiUnion
+          (fun ab => (aux d ab.2).1.map {
+              toFun := Fin.cons (ab.1)
+              inj' := Fin.cons_right_injective _ })
+          (fun i _hi j _hj hij => Finset.disjoint_left.2 fun t hti htj => hij $ by
+            simp_rw [Finset.mem_map, Embedding.coeFn_mk] at hti htj
+            obtain ⟨ai, hai, hij'⟩ := hti
+            obtain ⟨aj, haj, rfl⟩ := htj
+            rw [Fin.cons_eq_cons] at hij'
+            ext
+            · exact hij'.1
+            · obtain ⟨-, rfl⟩ := hij'
+              rw [← (aux d i.2).prop ai |>.mp hai, ← (aux d j.2).prop ai |>.mp haj])
+        property := fun f => by
+          simp_rw [mem_disjiUnion, mem_antidiagonal, mem_map, Embedding.coeFn_mk, Prod.exists,
+            (aux d _).prop, Fin.sum_univ_succ]
+          constructor
+          · rintro ⟨a, b, rfl, g, rfl, rfl⟩
+            simp only [Fin.cons_zero, Fin.cons_succ]
+          · intro hf
+            exact ⟨_, _, hf, _, rfl, Fin.cons_self_tail f⟩ }
+
+@[simp] lemma mem_finAntidiagonal {d : ℕ} {f : Fin d → μ} :
+    f ∈ finAntidiagonal d n ↔ ∑ i, f i = n := (finAntidiagonal.aux d n).prop f
+
+end AddCommMonoid
+end Finset

--- a/Mathlib/Algebra/Order/Antidiag/Pi.lean
+++ b/Mathlib/Algebra/Order/Antidiag/Pi.lean
@@ -12,14 +12,6 @@ import Mathlib.Algebra.Order.Antidiag.Prod
 This file provides the finset of functions summing to a specific value on a finset. Such finsets
 should be thought of as the "antidiagonals" in the space of functions.
 
-Precisely, for a commutative monoid `μ` with antidiagonals, `Finset.piAntidiag s n` is the finset of
-all functions `f : ι → μ` with support contained in `s` and such that the sum of its values equals
-`n : μ`.
-
-We define it recursively on `s` using `Finset.HasAntidiagonal.antidiagonal : μ → Finset (μ × μ)`.
-Technically, we non-canonically identify `s` with `Fin n` where `n = s.card`, recurse on `n` using
-that `(Fin (n + 1) → μ) ≃ (Fin n → μ) × μ`, and show the end result doesn't depend on our identification. See `Finset.finAntidiag` for the details.
-
 ## TODO
 
 `Finset.finAntidiagonal` is strictly more general than `Finset.Nat.antidiagonalTuple`. Deduplicate.

--- a/Mathlib/Algebra/Order/Antidiag/Prod.lean
+++ b/Mathlib/Algebra/Order/Antidiag/Prod.lean
@@ -3,7 +3,6 @@ Copyright (c) 2023 Antoine Chambert-Loir and María Inés de Frutos-Fernández. 
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Antoine Chambert-Loir, María Inés de Frutos-Fernández, Bhavik Mehta, Eric Wieser
 -/
-
 import Mathlib.Algebra.Order.Sub.Defs
 import Mathlib.Data.Finset.Basic
 import Mathlib.Order.Interval.Finset.Defs

--- a/Mathlib/Data/Finset/NatAntidiagonal.lean
+++ b/Mathlib/Data/Finset/NatAntidiagonal.lean
@@ -3,8 +3,8 @@ Copyright (c) 2019 Johan Commelin. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johan Commelin
 -/
+import Mathlib.Algebra.Order.Antidiag.Prod
 import Mathlib.Algebra.Order.Group.Nat
-import Mathlib.Data.Finset.Antidiagonal
 import Mathlib.Data.Finset.Card
 import Mathlib.Data.Multiset.NatAntidiagonal
 

--- a/Mathlib/RingTheory/MvPowerSeries/Basic.lean
+++ b/Mathlib/RingTheory/MvPowerSeries/Basic.lean
@@ -5,7 +5,7 @@ Authors: Johan Commelin, Kenny Lau
 -/
 
 import Mathlib.Algebra.MvPolynomial.Basic
-import Mathlib.Data.Finset.PiAntidiagonal
+import Mathlib.Algebra.Order.Antidiag.Finsupp
 import Mathlib.LinearAlgebra.StdBasis
 import Mathlib.Tactic.Linarith
 

--- a/test/antidiagonal.lean
+++ b/test/antidiagonal.lean
@@ -1,5 +1,5 @@
+import Mathlib.Algebra.Order.Antidiag.Finsupp
 import Mathlib.Data.Finset.Sort
-import Mathlib.Data.Finset.PiAntidiagonal
 import Mathlib.Data.Finsupp.Notation
 import Mathlib.Data.Fin.Tuple.NatAntidiagonal
 


### PR DESCRIPTION
* Rename `Data.Finset.Antidiagonal` to `Algebra.Order.Antidiag.Prod`
* Rename `Data.Finset.PiAntidiagonal` to `Algebra.Order.Antidiag.Finsupp`
* Move `Finset.finAntidiag` from the aforementioned to a new file `Algebra.Order.Antidiag.Pi`. This is in prevision of #13683.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
