### PR TITLE
feat: more robust ae notation

### DIFF
--- a/Mathlib/MeasureTheory/Integral/Bochner/L1.lean
+++ b/Mathlib/MeasureTheory/Integral/Bochner/L1.lean
@@ -341,8 +341,8 @@ lemma integral_mono {f g : α →ₛ F} (h : f ≤ᵐ[μ] g) (hf : Integrable f 
   rw [← sub_nonneg_ae] at h
   exact integral_nonneg h
 
-lemma integral_mono_measure {ν} {f : α →ₛ F} (hf : 0 ≤ᵐ[ν] f) (hμν : μ ≤ ν) (hfν : Integrable f ν) :
-    f.integral μ ≤ f.integral ν := by
+lemma integral_mono_measure {ν : Measure _} {f : α →ₛ F} (hf : 0 ≤ᵐ[ν] f) (hμν : μ ≤ ν)
+    (hfν : Integrable f ν) : f.integral μ ≤ f.integral ν := by
   simp only [integral_eq]
   apply Finset.sum_le_sum
   simp only [forall_mem_range]

--- a/Mathlib/MeasureTheory/Measure/Decomposition/IntegralRNDeriv.lean
+++ b/Mathlib/MeasureTheory/Measure/Decomposition/IntegralRNDeriv.lean
@@ -65,7 +65,7 @@ lemma mul_le_integral_rnDeriv_of_ac [IsFiniteMeasure μ] [IsFiniteMeasure ν]
   · simp [hν]
   have : NeZero ν := ⟨hν⟩
   let μ' := (ν univ)⁻¹ • μ
-  let ν' := (ν univ)⁻¹ • ν
+  let ν' : Measure α := (ν univ)⁻¹ • ν
   have : IsFiniteMeasure μ' := μ.smul_finite (by simp [hν])
   have hμν' : μ' ≪ ν' := hμν.smul _
   have h_rnDeriv_eq : μ'.rnDeriv ν' =ᵐ[ν] μ.rnDeriv ν := by

--- a/Mathlib/MeasureTheory/Measure/MeasureSpaceDef.lean
+++ b/Mathlib/MeasureTheory/Measure/MeasureSpaceDef.lean
@@ -95,27 +95,23 @@ def elabMeasure (μ : TSyntax `term) (expectedType? : Option Expr) : TermElabM E
     let _ ← mkFreshExprMVarQ q(MeasurableSpace $ty)
     elabTerm μ q(Measure $ty)
 
+/-- Try to elaborate `μ` as a term of type `T` where `OuterMeasureClass T ?Ω`. If that fails, try to
+elaborate `μ` as `Measure ?Ω`. -/
+elab "elab_as_measure% " t:term : term => do elabMeasure t ‹_›
+
 /-- `f =ᵐ[μ] g` means `f` and `g` are eventually equal along the a.e. filter,
 i.e. `f=g` away from a null set.
 
 This is notation for `Filter.EventuallyEq (MeasureTheory.ae μ) f g`. -/
-syntax:50 (name := aeEq) term:50 " =ᵐ[" term:50 "] " term:50 : term
+macro:50 (name := aeEq) f:term:50 " =ᵐ[" μ:term:50 "] " g:term:50 : term =>
+  `(Filter.EventuallyEq (MeasureTheory.ae (elab_as_measure% $μ)) $f $g)
 
 /-- `f ≤ᵐ[μ] g` means `f` is eventually less than `g` along the a.e. filter,
 i.e. `f ≤ g` away from a null set.
 
 This is notation for `Filter.EventuallyLE (MeasureTheory.ae μ) f g`. -/
-syntax:50 (name := aeLE) term:50 " ≤ᵐ[" term:50 "] " term:50 : term
-
-/-- Elaborate almost everywhere equal notation.
-
-We elabore `f =ᵐ[μ] g` as `Filter.EventuallyEq (MeasureTheory.ae μ) f g`. -/
-@[term_elab aeEq]
-def elabAEEq : TermElab
-  | `($f =ᵐ[$μ] $g), expectedType? => do
-    let μ' ← elabMeasure μ expectedType?
-    elabTerm (← `(Filter.EventuallyEq (MeasureTheory.ae $(← μ'.toSyntax)) $f $g)) expectedType?
-  | _, _ => throwUnsupportedSyntax
+macro:50 (name := aeLE) f:term:50 " ≤ᵐ[" μ:term:50 "] " g:term:50 : term =>
+  `(Filter.EventuallyLE (MeasureTheory.ae (elab_as_measure% $μ)) $f $g)
 
 /-- Elaborate almost everywhere equal notation.
 

--- a/Mathlib/MeasureTheory/Measure/MeasureSpaceDef.lean
+++ b/Mathlib/MeasureTheory/Measure/MeasureSpaceDef.lean
@@ -94,13 +94,14 @@ def elabMeasure (μ : TSyntax `term) (expectedType? : Option Expr) : TermElabM E
     let ty ← mkFreshExprMVarQ q(Type v)
     let _ ← mkFreshExprMVarQ q(MeasurableSpace $ty)
     elabTerm μ q(Measure $ty)
+  | _, _ => throwUnsupportedSyntax
 
 /-- Try to elaborate `μ` as a term of type `T` where `OuterMeasureClass T ?Ω`. If that fails, try to
 elaborate `μ` as `Measure ?Ω`. -/
 elab "elab_as_measure% " t:term : term => do elabMeasure t ‹_›
 
 /-- `f =ᵐ[μ] g` means `f` and `g` are eventually equal along the a.e. filter,
-i.e. `f=g` away from a null set.
+i.e. `f = g` away from a null set.
 
 This is notation for `Filter.EventuallyEq (MeasureTheory.ae μ) f g`. -/
 macro:50 (name := aeEq) f:term:50 " =ᵐ[" μ:term:50 "] " g:term:50 : term =>

--- a/Mathlib/MeasureTheory/Measure/MeasureSpaceDef.lean
+++ b/Mathlib/MeasureTheory/Measure/MeasureSpaceDef.lean
@@ -79,6 +79,58 @@ structure Measure (α : Type*) [MeasurableSpace α] extends OuterMeasure α wher
 /-- Notation for `Measure` with respect to a non-standard σ-algebra in the domain. -/
 scoped notation "Measure[" mα "] " α:arg => @Measure α mα
 
+end MeasureTheory
+
+namespace Mathlib.Meta
+open Lean Elab Term Meta Qq MeasureTheory
+
+/-- Try to elaborate `μ` as a term of type `T` where `OuterMeasureClass T ?Ω`. If that fails, try to
+elaborate `μ` as `Measure ?Ω`. -/
+def elabMeasure (μ : TSyntax `term) (expectedType? : Option Expr) : TermElabM Expr := do
+  let ⟨u, T, _⟩ ← inferTypeQ (← elabTerm μ expectedType?)
+  match u, T with
+  | .succ v, ~q(OuterMeasure $α) => elabTerm μ <| .some q(OuterMeasure $α)
+  | .succ v, _ =>
+    let ty ← mkFreshExprMVarQ q(Type v)
+    let _ ← mkFreshExprMVarQ q(MeasurableSpace $ty)
+    elabTerm μ q(Measure $ty)
+
+/-- `f =ᵐ[μ] g` means `f` and `g` are eventually equal along the a.e. filter,
+i.e. `f=g` away from a null set.
+
+This is notation for `Filter.EventuallyEq (MeasureTheory.ae μ) f g`. -/
+syntax:50 (name := aeEq) term:50 " =ᵐ[" term:50 "] " term:50 : term
+
+/-- `f ≤ᵐ[μ] g` means `f` is eventually less than `g` along the a.e. filter,
+i.e. `f ≤ g` away from a null set.
+
+This is notation for `Filter.EventuallyLE (MeasureTheory.ae μ) f g`. -/
+syntax:50 (name := aeLE) term:50 " ≤ᵐ[" term:50 "] " term:50 : term
+
+/-- Elaborate almost everywhere equal notation.
+
+We elabore `f =ᵐ[μ] g` as `Filter.EventuallyEq (MeasureTheory.ae μ) f g`. -/
+@[term_elab aeEq]
+def elabAEEq : TermElab
+  | `($f =ᵐ[$μ] $g), expectedType? => do
+    let μ' ← elabMeasure μ expectedType?
+    elabTerm (← `(Filter.EventuallyEq (MeasureTheory.ae $(← μ'.toSyntax)) $f $g)) expectedType?
+  | _, _ => throwUnsupportedSyntax
+
+/-- Elaborate almost everywhere equal notation.
+
+We elabore `f ≤ᵐ[μ] g` as `Filter.EventuallyEq (MeasureTheory.ae μ) f g`. -/
+@[term_elab aeLE]
+def elabAELE : TermElab
+  | `($f ≤ᵐ[$μ] $g), expectedType? => do
+    let μ' ← elabMeasure μ expectedType?
+    elabTerm (← `(Filter.EventuallyLE (MeasureTheory.ae $(← μ'.toSyntax)) $f $g)) expectedType?
+  | _, _ => throwUnsupportedSyntax
+
+end Mathlib.Meta
+
+namespace MeasureTheory
+
 theorem Measure.toOuterMeasure_injective [MeasurableSpace α] :
     Injective (toOuterMeasure : Measure α → OuterMeasure α)
   | ⟨_, _, _⟩, ⟨_, _, _⟩, rfl => rfl

--- a/Mathlib/MeasureTheory/Measure/MeasureSpaceDef.lean
+++ b/Mathlib/MeasureTheory/Measure/MeasureSpaceDef.lean
@@ -87,14 +87,13 @@ open Lean Elab Term Meta Qq MeasureTheory
 /-- Try to elaborate `μ` as a term of type `T` where `OuterMeasureClass T ?Ω`. If that fails, try to
 elaborate `μ` as `Measure ?Ω`. -/
 def elabMeasure (μ : TSyntax `term) (expectedType? : Option Expr) : TermElabM Expr := do
-  let ⟨u, T, _⟩ ← inferTypeQ (← elabTerm μ expectedType?)
-  match u, T with
-  | .succ v, ~q(OuterMeasure $α) => elabTerm μ <| .some q(OuterMeasure $α)
-  | .succ v, _ =>
-    let ty ← mkFreshExprMVarQ q(Type v)
+  let ⟨u, T, _⟩ ← inferTypeQ' (← elabTerm μ expectedType?)
+  match T with
+  | ~q(OuterMeasure $α) => elabTerm μ <| .some q(OuterMeasure $α)
+  | _ =>
+    let ty ← mkFreshExprMVarQ q(Type u)
     let _ ← mkFreshExprMVarQ q(MeasurableSpace $ty)
     elabTerm μ q(Measure $ty)
-  | _, _ => throwUnsupportedSyntax
 
 /-- Try to elaborate `μ` as a term of type `T` where `OuterMeasureClass T ?Ω`. If that fails, try to
 elaborate `μ` as `Measure ?Ω`. -/

--- a/Mathlib/MeasureTheory/OuterMeasure/AE.lean
+++ b/Mathlib/MeasureTheory/OuterMeasure/AE.lean
@@ -56,7 +56,7 @@ This is notation for `Filter.Frequently p (MeasureTheory.ae μ)`. -/
 notation3 "∃ᵐ "(...)" ∂"μ", "r:(scoped P => Filter.Frequently P <| MeasureTheory.ae μ) => r
 
 /-- `f =ᵐ[μ] g` means `f` and `g` are eventually equal along the a.e. filter,
-i.e. `f=g` away from a null set.
+i.e. `f = g` away from a null set.
 
 This is notation for `Filter.EventuallyEq (MeasureTheory.ae μ) f g`. -/
 local notation:50 f " =ᵐ[" μ:50 "] " g:50 => Filter.EventuallyEq (MeasureTheory.ae μ) f g

--- a/Mathlib/MeasureTheory/OuterMeasure/AE.lean
+++ b/Mathlib/MeasureTheory/OuterMeasure/AE.lean
@@ -59,13 +59,13 @@ notation3 "∃ᵐ "(...)" ∂"μ", "r:(scoped P => Filter.Frequently P <| Measur
 i.e. `f=g` away from a null set.
 
 This is notation for `Filter.EventuallyEq (MeasureTheory.ae μ) f g`. -/
-notation:50 f " =ᵐ[" μ:50 "] " g:50 => Filter.EventuallyEq (MeasureTheory.ae μ) f g
+local notation:50 f " =ᵐ[" μ:50 "] " g:50 => Filter.EventuallyEq (MeasureTheory.ae μ) f g
 
 /-- `f ≤ᵐ[μ] g` means `f` is eventually less than `g` along the a.e. filter,
 i.e. `f ≤ g` away from a null set.
 
 This is notation for `Filter.EventuallyLE (MeasureTheory.ae μ) f g`. -/
-notation:50 f " ≤ᵐ[" μ:50 "] " g:50 => Filter.EventuallyLE (MeasureTheory.ae μ) f g
+local notation:50 f " ≤ᵐ[" μ:50 "] " g:50 => Filter.EventuallyLE (MeasureTheory.ae μ) f g
 
 theorem mem_ae_iff {s : Set α} : s ∈ ae μ ↔ μ sᶜ = 0 :=
   Iff.rfl

--- a/Mathlib/MeasureTheory/OuterMeasure/AE.lean
+++ b/Mathlib/MeasureTheory/OuterMeasure/AE.lean
@@ -58,13 +58,15 @@ notation3 "∃ᵐ "(...)" ∂"μ", "r:(scoped P => Filter.Frequently P <| Measur
 /-- `f =ᵐ[μ] g` means `f` and `g` are eventually equal along the a.e. filter,
 i.e. `f = g` away from a null set.
 
-This is notation for `Filter.EventuallyEq (MeasureTheory.ae μ) f g`. -/
+This is local notation for `Filter.EventuallyEq (MeasureTheory.ae μ) f g` before we define the more
+general one in a later file knowing about `Measure`. -/
 local notation:50 f " =ᵐ[" μ:50 "] " g:50 => Filter.EventuallyEq (MeasureTheory.ae μ) f g
 
 /-- `f ≤ᵐ[μ] g` means `f` is eventually less than `g` along the a.e. filter,
 i.e. `f ≤ g` away from a null set.
 
-This is notation for `Filter.EventuallyLE (MeasureTheory.ae μ) f g`. -/
+This is local notation for `Filter.EventuallyLE (MeasureTheory.ae μ) f g` before we define the more
+general one in a later file knowing about `Measure`. -/
 local notation:50 f " ≤ᵐ[" μ:50 "] " g:50 => Filter.EventuallyLE (MeasureTheory.ae μ) f g
 
 theorem mem_ae_iff {s : Set α} : s ∈ ae μ ↔ μ sᶜ = 0 :=

--- a/Mathlib/MeasureTheory/OuterMeasure/BorelCantelli.lean
+++ b/Mathlib/MeasureTheory/OuterMeasure/BorelCantelli.lean
@@ -30,7 +30,8 @@ open scoped ENNReal Topology
 /-- `f =ᵐ[μ] g` means `f` and `g` are eventually equal along the a.e. filter,
 i.e. `f = g` away from a null set.
 
-This is notation for `Filter.EventuallyEq (MeasureTheory.ae μ) f g`. -/
+This is local notation for `Filter.EventuallyEq (MeasureTheory.ae μ) f g` before we define the more
+general one in a later file knowing about `Measure`. -/
 local notation:50 f " =ᵐ[" μ:50 "] " g:50 => Filter.EventuallyEq (MeasureTheory.ae μ) f g
 
 namespace MeasureTheory

--- a/Mathlib/MeasureTheory/OuterMeasure/BorelCantelli.lean
+++ b/Mathlib/MeasureTheory/OuterMeasure/BorelCantelli.lean
@@ -27,6 +27,12 @@ see `ProbabilityTheory.measure_limsup_eq_one`.
 open Filter Set
 open scoped ENNReal Topology
 
+/-- `f =ᵐ[μ] g` means `f` and `g` are eventually equal along the a.e. filter,
+i.e. `f=g` away from a null set.
+
+This is notation for `Filter.EventuallyEq (MeasureTheory.ae μ) f g`. -/
+local notation:50 f " =ᵐ[" μ:50 "] " g:50 => Filter.EventuallyEq (MeasureTheory.ae μ) f g
+
 namespace MeasureTheory
 
 variable {α ι F : Type*} [FunLike F (Set α) ℝ≥0∞] [OuterMeasureClass F α] [Countable ι] {μ : F}

--- a/Mathlib/MeasureTheory/OuterMeasure/BorelCantelli.lean
+++ b/Mathlib/MeasureTheory/OuterMeasure/BorelCantelli.lean
@@ -28,7 +28,7 @@ open Filter Set
 open scoped ENNReal Topology
 
 /-- `f =ᵐ[μ] g` means `f` and `g` are eventually equal along the a.e. filter,
-i.e. `f=g` away from a null set.
+i.e. `f = g` away from a null set.
 
 This is notation for `Filter.EventuallyEq (MeasureTheory.ae μ) f g`. -/
 local notation:50 f " =ᵐ[" μ:50 "] " g:50 => Filter.EventuallyEq (MeasureTheory.ae μ) f g

--- a/Mathlib/Probability/Notation.lean
+++ b/Mathlib/Probability/Notation.lean
@@ -55,9 +55,11 @@ scoped[ProbabilityTheory] notation "𝔼[" X "]" => ∫ a, (X : _ → _) a
 scoped[ProbabilityTheory] notation P "⟦" s "|" m "⟧" =>
   MeasureTheory.condExp m P (Set.indicator s fun ω => (1 : ℝ))
 
+set_option quotPrecheck false in
 /-- `X =ₐₛ Y` if `X = Y` almost surely. -/
 scoped[ProbabilityTheory] notation:50 X " =ₐₛ " Y:50 => X =ᵐ[MeasureTheory.MeasureSpace.volume] Y
 
+set_option quotPrecheck false in
 /-- `X ≤ₐₛ Y` if `X ≤ Y` almost surely. -/
 scoped[ProbabilityTheory] notation:50 X " ≤ₐₛ " Y:50 => X ≤ᵐ[MeasureTheory.MeasureSpace.volume] Y
 


### PR DESCRIPTION
Make sure that, when `μ : FiniteMeasure Ω`, `f =ᵐ[μ] g` elaborates to `f =ᵐ[↑μ] g` instead of complaining about `OuterMeasureClass (FiniteMeasure Ω) (Set Ω) ℝ≥0∞` not existing.

[Zulip](https://leanprover.zulipchat.com/#narrow/stream/287929-mathlib4/topic/ae.20of.20a.20finite.20measure)


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
