### PR TITLE
[Merged by Bors] - chore: remove unused countLocalHypsUsed

### DIFF
--- a/Mathlib/Init/Align.lean
+++ b/Mathlib/Init/Align.lean
@@ -5,6 +5,7 @@ Authors: Daniel Selsam, Mario Carneiro
 -/
 import Batteries.Data.Option.Lemmas
 import Batteries.Data.Nat.Lemmas
+import Batteries.Data.List.Basic
 import Mathlib.Mathport.Rename
 import Mathlib.Init.Logic
 import Mathlib.Tactic.Relation.Trans

--- a/Mathlib/Init/Logic.lean
+++ b/Mathlib/Init/Logic.lean
@@ -8,6 +8,9 @@ import Mathlib.Mathport.Attributes
 import Mathlib.Mathport.Rename
 import Mathlib.Tactic.Relation.Trans
 import Mathlib.Tactic.ProjectionNotation
+import Batteries.Tactic.Alias
+import Batteries.Tactic.Lint.Misc
+import Batteries.Logic -- Only needed for #align
 
 set_option autoImplicit true
 

--- a/Mathlib/Lean/Meta.lean
+++ b/Mathlib/Lean/Meta.lean
@@ -7,8 +7,6 @@ import Lean.Elab.Term
 import Lean.Elab.Tactic.Basic
 import Lean.Meta.Tactic.Assert
 import Lean.Meta.Tactic.Clear
-import Batteries.Data.List.Basic
-import Batteries.Logic
 
 /-! ## Additional utilities in `Lean.MVarId` -/
 
@@ -52,11 +50,6 @@ where
 end Lean.MVarId
 
 namespace Lean.Meta
-
-/-- Count how many local hypotheses appear in an expression. -/
-def countLocalHypsUsed [Monad m] [MonadLCtx m] [MonadMCtx m] (e : Expr) : m Nat := do
-  let e' ← instantiateMVars e
-  return (← getLocalHyps).toList.countP fun h => h.occurs e'
 
 /-- Get the type the given metavariable after instantiating metavariables and cleaning up
 annotations. -/

--- a/Mathlib/Tactic/Relation/Trans.lean
+++ b/Mathlib/Tactic/Relation/Trans.lean
@@ -5,6 +5,7 @@ Authors: Siddhartha Gadgil, Mario Carneiro
 -/
 import Mathlib.Lean.Meta
 import Mathlib.Lean.Elab.Tactic.Basic
+import Lean.Elab.Tactic.ElabTerm
 
 /-!
 # `trans` tactic

--- a/scripts/noshake.json
+++ b/scripts/noshake.json
@@ -292,6 +292,7 @@
   "Mathlib.Lean.Meta": ["Batteries.Logic"],
   "Mathlib.Lean.Expr.ExtraRecognizers": ["Mathlib.Data.Set.Defs"],
   "Mathlib.Lean.Expr.Basic": ["Batteries.Logic"],
+  "Mathlib.Init.Logic": ["Batteries.Logic"],
   "Mathlib.Init.Function": ["Mathlib.Tactic.AdaptationNote"],
   "Mathlib.Init.Data.Nat.Lemmas": ["Batteries.Data.Nat.Lemmas", "Batteries.WF"],
   "Mathlib.Init.Data.Nat.GCD": ["Batteries.Data.Nat.Gcd"],


### PR DESCRIPTION
This is an orphaned meta function, that used to be used in `rw?`, which has since moved to core. I wrote it, and I'm pretty sure I was the only user, so I would like to just delete it without a deprecation.