### PR TITLE
chore: reenable pp_nodot where porting note disabled it.

### DIFF
--- a/Mathlib/Algebra/Ring/Int.lean
+++ b/Mathlib/Algebra/Ring/Int.lean
@@ -210,6 +210,7 @@ alias ⟨_, _root_.Odd.natAbs⟩ := natAbs_odd
 -- Porting note: "protected"-attribute not implemented yet.
 -- mathlib3 had:
 -- `attribute [protected] Even.natAbs Odd.natAbs`
+#check Even.natAbs
 
 lemma four_dvd_add_or_sub_of_odd {a b : ℤ} (ha : Odd a) (hb : Odd b) :
     4 ∣ a + b ∨ 4 ∣ a - b := by

--- a/Mathlib/Algebra/Ring/Int.lean
+++ b/Mathlib/Algebra/Ring/Int.lean
@@ -210,7 +210,6 @@ alias ⟨_, _root_.Odd.natAbs⟩ := natAbs_odd
 -- Porting note: "protected"-attribute not implemented yet.
 -- mathlib3 had:
 -- `attribute [protected] Even.natAbs Odd.natAbs`
-#check Even.natAbs
 
 lemma four_dvd_add_or_sub_of_odd {a b : ℤ} (ha : Odd a) (hb : Odd b) :
     4 ∣ a + b ∨ 4 ∣ a - b := by

--- a/Mathlib/Algebra/Tropical/Basic.lean
+++ b/Mathlib/Algebra/Tropical/Basic.lean
@@ -62,14 +62,14 @@ namespace Tropical
 /-- Reinterpret `x : R` as an element of `Tropical R`.
 See `Tropical.tropEquiv` for the equivalence.
 -/
---@[pp_nodot] Porting note: not implemented in Lean4
+@[pp_nodot]
 def trop : R → Tropical R :=
   id
 #align tropical.trop Tropical.trop
 
 /-- Reinterpret `x : Tropical R` as an element of `R`.
 See `Tropical.tropEquiv` for the equivalence. -/
---@[pp_nodot] Porting note: not implemented in Lean4
+@[pp_nodot]
 def untrop : Tropical R → R :=
   id
 #align tropical.untrop Tropical.untrop

--- a/Mathlib/Analysis/SpecialFunctions/Arsinh.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Arsinh.lean
@@ -49,7 +49,7 @@ namespace Real
 variable {x y : ℝ}
 
 /-- `arsinh` is defined using a logarithm, `arsinh x = log (x + sqrt(1 + x^2))`. -/
--- @[pp_nodot] is no longer needed
+@[pp_nodot]
 def arsinh (x : ℝ) :=
   log (x + √(1 + x ^ 2))
 #align real.arsinh Real.arsinh

--- a/Mathlib/Analysis/SpecialFunctions/Gamma/Basic.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Gamma/Basic.lean
@@ -303,7 +303,7 @@ theorem GammaAux_recurrence2 (s : ℂ) (n : ℕ) (h1 : -s.re < ↑n) :
 #align complex.Gamma_aux_recurrence2 Complex.GammaAux_recurrence2
 
 /-- The `Γ` function (of a complex variable `s`). -/
--- @[pp_nodot] -- Porting note: removed
+@[pp_nodot]
 irreducible_def Gamma (s : ℂ) : ℂ :=
   GammaAux ⌊1 - s.re⌋₊ s
 #align complex.Gamma Complex.Gamma
@@ -500,7 +500,7 @@ end Complex
 namespace Real
 
 /-- The `Γ` function (of a real variable `s`). -/
--- @[pp_nodot] -- Porting note: removed
+@[pp_nodot]
 def Gamma (s : ℝ) : ℝ :=
   (Complex.Gamma s).re
 #align real.Gamma Real.Gamma

--- a/Mathlib/Analysis/SpecialFunctions/Log/Base.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Log/Base.lean
@@ -36,7 +36,7 @@ variable {b x y : ℝ}
 
 /-- The real logarithm in a given base. As with the natural logarithm, we define `logb b x` to
 be `logb b |x|` for `x < 0`, and `0` for `x = 0`. -/
--- @[pp_nodot] -- Porting note: removed
+@[pp_nodot]
 noncomputable def logb (b x : ℝ) : ℝ :=
   log x / log b
 #align real.logb Real.logb

--- a/Mathlib/Analysis/SpecialFunctions/Log/Basic.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Log/Basic.lean
@@ -37,7 +37,7 @@ variable {x y : ℝ}
 to `log |x|` for `x < 0`, and to `0` for `0`. We use this unconventional extension to
 `(-∞, 0]` as it gives the formula `log (x * y) = log x + log y` for all nonzero `x` and `y`, and
 the derivative of `log` is `1/x` away from `0`. -/
--- @[pp_nodot] -- Porting note: removed
+@[pp_nodot]
 noncomputable def log (x : ℝ) : ℝ :=
   if hx : x = 0 then 0 else expOrderIso.symm ⟨|x|, abs_pos.2 hx⟩
 #align real.log Real.log

--- a/Mathlib/Analysis/SpecialFunctions/Trigonometric/Arctan.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Trigonometric/Arctan.lean
@@ -108,7 +108,7 @@ def tanOrderIso : Ioo (-(π / 2)) (π / 2) ≃o ℝ :=
 
 /-- Inverse of the `tan` function, returns values in the range `-π / 2 < arctan x` and
 `arctan x < π / 2` -/
--- @[pp_nodot] -- Porting note: removed
+@[pp_nodot]
 noncomputable def arctan (x : ℝ) : ℝ :=
   tanOrderIso.symm x
 #align real.arctan Real.arctan

--- a/Mathlib/Analysis/SpecialFunctions/Trigonometric/Inverse.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Trigonometric/Inverse.lean
@@ -32,7 +32,7 @@ variable {x y : ℝ}
 
 /-- Inverse of the `sin` function, returns values in the range `-π / 2 ≤ arcsin x ≤ π / 2`.
 It defaults to `-π / 2` on `(-∞, -1)` and to `π / 2` to `(1, ∞)`. -/
--- @[pp_nodot] Porting note: not implemented
+@[pp_nodot]
 noncomputable def arcsin : ℝ → ℝ :=
   Subtype.val ∘ IccExtend (neg_le_self zero_le_one) sinOrderIso.symm
 #align real.arcsin Real.arcsin
@@ -334,7 +334,7 @@ theorem tan_arcsin (x : ℝ) : tan (arcsin x) = x / √(1 - x ^ 2) := by
 
 /-- Inverse of the `cos` function, returns values in the range `0 ≤ arccos x` and `arccos x ≤ π`.
   It defaults to `π` on `(-∞, -1)` and to `0` to `(1, ∞)`. -/
--- @[pp_nodot] Porting note: not implemented
+@[pp_nodot]
 noncomputable def arccos (x : ℝ) : ℝ :=
   π / 2 - arcsin x
 #align real.arccos Real.arccos

--- a/Mathlib/Data/Complex/Basic.lean
+++ b/Mathlib/Data/Complex/Basic.lean
@@ -615,8 +615,7 @@ theorem star_def : (Star.star : ℂ → ℂ) = conj :=
 
 
 /-- The norm squared function. -/
--- Porting note: `@[pp_nodot]` not found
--- @[pp_nodot]
+@[pp_nodot]
 def normSq : ℂ →*₀ ℝ where
   toFun z := z.re * z.re + z.im * z.im
   map_zero' := by simp

--- a/Mathlib/Data/Int/Sqrt.lean
+++ b/Mathlib/Data/Int/Sqrt.lean
@@ -22,7 +22,7 @@ namespace Int
 /-- `sqrt z` is the square root of an integer `z`. If `z` is positive, it returns the largest
 integer `r` such that `r * r ≤ n`. If it is negative, it returns `0`. For example, `sqrt (-1) = 0`,
 `sqrt 1 = 1`, `sqrt 2 = 1` -/
--- @[pp_nodot] porting note: unknown attribute
+@[pp_nodot]
 def sqrt (z : ℤ) : ℤ :=
   Nat.sqrt <| Int.toNat z
 #align int.sqrt Int.sqrt

--- a/Mathlib/Data/Matrix/Block.lean
+++ b/Mathlib/Data/Matrix/Block.lean
@@ -40,7 +40,7 @@ section BlockMatrices
 
 /-- We can form a single large matrix by flattening smaller 'block' matrices of compatible
 dimensions. -/
--- @[pp_nodot] -- Porting note: removed
+@[pp_nodot]
 def fromBlocks (A : Matrix n l α) (B : Matrix n m α) (C : Matrix o l α) (D : Matrix o m α) :
     Matrix (Sum n o) (Sum l m) α :=
   of <| Sum.elim (fun i => Sum.elim (A i) (B i)) fun i => Sum.elim (C i) (D i)

--- a/Mathlib/Data/Nat/Fib/Basic.lean
+++ b/Mathlib/Data/Nat/Fib/Basic.lean
@@ -62,8 +62,7 @@ namespace Nat
 implementation.
 -/
 
--- Porting note: Lean cannot find pp_nodot at the time of this port.
--- @[pp_nodot]
+@[pp_nodot]
 def fib (n : ℕ) : ℕ :=
   ((fun p : ℕ × ℕ => (p.snd, p.fst + p.snd))^[n] (0, 1)).fst
 #align nat.fib Nat.fib

--- a/Mathlib/Data/Rat/Sqrt.lean
+++ b/Mathlib/Data/Rat/Sqrt.lean
@@ -23,7 +23,7 @@ namespace Rat
 
 /-- Square root function on rational numbers, defined by taking the (integer) square root of the
 numerator and the square root (on natural numbers) of the denominator. -/
--- @[pp_nodot] porting note: unknown attribute
+@[pp_nodot]
 def sqrt (q : ℚ) : ℚ := mkRat (Int.sqrt q.num) (Nat.sqrt q.den)
 #align rat.sqrt Rat.sqrt
 

--- a/Mathlib/SetTheory/Ordinal/Exponential.lean
+++ b/Mathlib/SetTheory/Ordinal/Exponential.lean
@@ -253,7 +253,7 @@ theorem opow_mul (a b c : Ordinal) : a ^ (b * c) = (a ^ b) ^ c := by
 
 /-- The ordinal logarithm is the solution `u` to the equation `x = b ^ u * v + w` where `v < b` and
     `w < b ^ u`. -/
--- @[pp_nodot] -- Porting note: Unknown attribute.
+@[pp_nodot]
 def log (b : Ordinal) (x : Ordinal) : Ordinal :=
   if _h : 1 < b then pred (sInf { o | x < b ^ o }) else 0
 #align ordinal.log Ordinal.log

--- a/test/toAdditive.lean
+++ b/test/toAdditive.lean
@@ -221,8 +221,7 @@ run_cmd do liftCoreM <| successIfFail (getConstInfo `Test.add_some_def.in_namesp
 
 section
 
-set_option linter.unusedVariables false
--- Porting note: not sure what the tests do, but the linter complains.
+set_option linter.unusedVariables false in
 
 def foo_mul {I J K : Type} (n : ℕ) {f : I → Type} (L : Type) [∀ i, One (f i)]
   [Add I] [Mul L] : true := by trivial


### PR DESCRIPTION


---

Moreover, removing a stray porting note from a test about disabling the "unused variable" linter

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
