### PR TITLE
[Merged by Bors] - perf(Analysis/InnerProductSpace/OfNorm): replace slow continuity call…

### DIFF
--- a/Mathlib/Analysis/InnerProductSpace/OfNorm.lean
+++ b/Mathlib/Analysis/InnerProductSpace/OfNorm.lean
@@ -120,7 +120,6 @@ theorem innerProp_neg_one : innerProp' E ((-1 : ℤ) : 𝕜) := by
 theorem _root_.Continuous.inner_ {f g : ℝ → E} (hf : Continuous f) (hg : Continuous g) :
     Continuous fun x => inner_ 𝕜 (f x) (g x) := by
   unfold inner_
-  have := Continuous.const_smul (M := 𝕜) hf I
   fun_prop
 #align inner_product_spaceable.continuous.inner_ Continuous.inner_
 

--- a/Mathlib/Analysis/InnerProductSpace/OfNorm.lean
+++ b/Mathlib/Analysis/InnerProductSpace/OfNorm.lean
@@ -121,7 +121,7 @@ theorem _root_.Continuous.inner_ {f g : ℝ → E} (hf : Continuous f) (hg : Con
     Continuous fun x => inner_ 𝕜 (f x) (g x) := by
   unfold inner_
   have := Continuous.const_smul (M := 𝕜) hf I
-  continuity
+  fun_prop
 #align inner_product_spaceable.continuous.inner_ Continuous.inner_
 
 theorem inner_.norm_sq (x : E) : ‖x‖ ^ 2 = re (inner_ 𝕜 x x) := by


### PR DESCRIPTION
… by fun_prop. The `continuity` invocation took 2.8s on CI before, `fun_prop` takes perhaps 0.1s in this instance.
Speeds up the whole file by 27%.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
