### PR TITLE
[Merged by Bors] - chore: address `@[pp_nodot]` porting notes

### DIFF
--- a/Mathlib/Algebra/Opposites.lean
+++ b/Mathlib/Algebra/Opposites.lean
@@ -64,9 +64,6 @@ reverses left and right in multiplication. -/
 def MulOpposite (α : Type*) : Type _ := PreOpposite α
 #align mul_opposite MulOpposite
 #align add_opposite AddOpposite
--- Porting note: the attribute `pp_nodot` does not exist yet; `op` and `unop` were
--- both tagged with it in mathlib3
-
 
 /-- Multiplicative opposite of a type. -/
 postfix:max "ᵐᵒᵖ" => MulOpposite
@@ -84,7 +81,7 @@ def op : α → αᵐᵒᵖ :=
 #align add_opposite.op AddOpposite.op
 
 /-- The element of `α` represented by `x : αᵐᵒᵖ`. -/
-@[to_additive "The element of `α` represented by `x : αᵃᵒᵖ`."]
+@[to_additive (attr := pp_nodot) "The element of `α` represented by `x : αᵃᵒᵖ`."]
 def unop : αᵐᵒᵖ → α :=
   PreOpposite.unop'
 #align mul_opposite.unop MulOpposite.unop

--- a/Mathlib/Algebra/Symmetrized.lean
+++ b/Mathlib/Algebra/Symmetrized.lean
@@ -46,13 +46,14 @@ variable {α : Type*}
 
 /-- The element of `SymAlg α` that represents `a : α`. -/
 @[match_pattern]
--- Porting note (#11180): removed @[pp_nodot]
 def sym : α ≃ αˢʸᵐ :=
   Equiv.refl _
 #align sym_alg.sym SymAlg.sym
 
 /-- The element of `α` represented by `x : αˢʸᵐ`. -/
--- Porting note (#11180): removed @[pp_nodot]
+-- Porting note (kmill): `pp_nodot` has no affect here
+-- unless RFC lean4#1910 leads to dot notation for CoeFun
+@[pp_nodot]
 def unsym : αˢʸᵐ ≃ α :=
   Equiv.refl _
 #align sym_alg.unsym SymAlg.unsym

--- a/Mathlib/Algebra/Tropical/Basic.lean
+++ b/Mathlib/Algebra/Tropical/Basic.lean
@@ -62,14 +62,13 @@ namespace Tropical
 /-- Reinterpret `x : R` as an element of `Tropical R`.
 See `Tropical.tropEquiv` for the equivalence.
 -/
---@[pp_nodot] Porting note: not implemented in Lean4
 def trop : R → Tropical R :=
   id
 #align tropical.trop Tropical.trop
 
 /-- Reinterpret `x : Tropical R` as an element of `R`.
 See `Tropical.tropEquiv` for the equivalence. -/
---@[pp_nodot] Porting note: not implemented in Lean4
+@[pp_nodot]
 def untrop : Tropical R → R :=
   id
 #align tropical.untrop Tropical.untrop

--- a/Mathlib/Analysis/SpecialFunctions/Arsinh.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Arsinh.lean
@@ -49,7 +49,7 @@ namespace Real
 variable {x y : ℝ}
 
 /-- `arsinh` is defined using a logarithm, `arsinh x = log (x + sqrt(1 + x^2))`. -/
--- @[pp_nodot] is no longer needed
+@[pp_nodot]
 def arsinh (x : ℝ) :=
   log (x + √(1 + x ^ 2))
 #align real.arsinh Real.arsinh

--- a/Mathlib/Analysis/SpecialFunctions/Complex/Log.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Complex/Log.lean
@@ -25,7 +25,7 @@ open scoped Real Topology ComplexConjugate
 
 /-- Inverse of the `exp` function. Returns values such that `(log x).im > - π` and `(log x).im ≤ π`.
   `log 0 = 0`-/
--- Porting note: @[pp_nodot] does not exist in mathlib4
+@[pp_nodot]
 noncomputable def log (x : ℂ) : ℂ :=
   x.abs.log + arg x * I
 #align complex.log Complex.log

--- a/Mathlib/Analysis/SpecialFunctions/Gamma/Basic.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Gamma/Basic.lean
@@ -303,7 +303,7 @@ theorem GammaAux_recurrence2 (s : ℂ) (n : ℕ) (h1 : -s.re < ↑n) :
 #align complex.Gamma_aux_recurrence2 Complex.GammaAux_recurrence2
 
 /-- The `Γ` function (of a complex variable `s`). -/
--- @[pp_nodot] -- Porting note: removed
+@[pp_nodot]
 irreducible_def Gamma (s : ℂ) : ℂ :=
   GammaAux ⌊1 - s.re⌋₊ s
 #align complex.Gamma Complex.Gamma
@@ -500,7 +500,7 @@ end Complex
 namespace Real
 
 /-- The `Γ` function (of a real variable `s`). -/
--- @[pp_nodot] -- Porting note: removed
+@[pp_nodot]
 def Gamma (s : ℝ) : ℝ :=
   (Complex.Gamma s).re
 #align real.Gamma Real.Gamma

--- a/Mathlib/Analysis/SpecialFunctions/Log/Base.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Log/Base.lean
@@ -36,7 +36,7 @@ variable {b x y : ℝ}
 
 /-- The real logarithm in a given base. As with the natural logarithm, we define `logb b x` to
 be `logb b |x|` for `x < 0`, and `0` for `x = 0`. -/
--- @[pp_nodot] -- Porting note: removed
+@[pp_nodot]
 noncomputable def logb (b x : ℝ) : ℝ :=
   log x / log b
 #align real.logb Real.logb

--- a/Mathlib/Analysis/SpecialFunctions/Log/Basic.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Log/Basic.lean
@@ -37,7 +37,7 @@ variable {x y : ℝ}
 to `log |x|` for `x < 0`, and to `0` for `0`. We use this unconventional extension to
 `(-∞, 0]` as it gives the formula `log (x * y) = log x + log y` for all nonzero `x` and `y`, and
 the derivative of `log` is `1/x` away from `0`. -/
--- @[pp_nodot] -- Porting note: removed
+@[pp_nodot]
 noncomputable def log (x : ℝ) : ℝ :=
   if hx : x = 0 then 0 else expOrderIso.symm ⟨|x|, abs_pos.2 hx⟩
 #align real.log Real.log

--- a/Mathlib/Analysis/SpecialFunctions/Trigonometric/Arctan.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Trigonometric/Arctan.lean
@@ -108,7 +108,7 @@ def tanOrderIso : Ioo (-(π / 2)) (π / 2) ≃o ℝ :=
 
 /-- Inverse of the `tan` function, returns values in the range `-π / 2 < arctan x` and
 `arctan x < π / 2` -/
--- @[pp_nodot] -- Porting note: removed
+@[pp_nodot]
 noncomputable def arctan (x : ℝ) : ℝ :=
   tanOrderIso.symm x
 #align real.arctan Real.arctan

--- a/Mathlib/Analysis/SpecialFunctions/Trigonometric/Inverse.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Trigonometric/Inverse.lean
@@ -32,7 +32,7 @@ variable {x y : ℝ}
 
 /-- Inverse of the `sin` function, returns values in the range `-π / 2 ≤ arcsin x ≤ π / 2`.
 It defaults to `-π / 2` on `(-∞, -1)` and to `π / 2` to `(1, ∞)`. -/
--- @[pp_nodot] Porting note: not implemented
+@[pp_nodot]
 noncomputable def arcsin : ℝ → ℝ :=
   Subtype.val ∘ IccExtend (neg_le_self zero_le_one) sinOrderIso.symm
 #align real.arcsin Real.arcsin
@@ -334,7 +334,7 @@ theorem tan_arcsin (x : ℝ) : tan (arcsin x) = x / √(1 - x ^ 2) := by
 
 /-- Inverse of the `cos` function, returns values in the range `0 ≤ arccos x` and `arccos x ≤ π`.
   It defaults to `π` on `(-∞, -1)` and to `0` to `(1, ∞)`. -/
--- @[pp_nodot] Porting note: not implemented
+@[pp_nodot]
 noncomputable def arccos (x : ℝ) : ℝ :=
   π / 2 - arcsin x
 #align real.arccos Real.arccos

--- a/Mathlib/Data/Complex/Basic.lean
+++ b/Mathlib/Data/Complex/Basic.lean
@@ -624,8 +624,7 @@ theorem star_def : (Star.star : ℂ → ℂ) = conj :=
 
 
 /-- The norm squared function. -/
--- Porting note: `@[pp_nodot]` not found
--- @[pp_nodot]
+@[pp_nodot]
 def normSq : ℂ →*₀ ℝ where
   toFun z := z.re * z.re + z.im * z.im
   map_zero' := by simp

--- a/Mathlib/Data/Complex/Exponential.lean
+++ b/Mathlib/Data/Complex/Exponential.lean
@@ -43,32 +43,32 @@ theorem isCauSeq_exp (z : ℂ) : IsCauSeq abs fun n => ∑ m ∈ range n, z ^ m 
 
 /-- The Cauchy sequence consisting of partial sums of the Taylor series of
 the complex exponential function -/
--- Porting note (#11180): removed `@[pp_nodot]`
+@[pp_nodot]
 def exp' (z : ℂ) : CauSeq ℂ Complex.abs :=
   ⟨fun n => ∑ m ∈ range n, z ^ m / m.factorial, isCauSeq_exp z⟩
 #align complex.exp' Complex.exp'
 
 /-- The complex exponential function, defined via its Taylor series -/
--- Porting note (#11180): removed `@[pp_nodot]`
 -- Porting note: removed `irreducible` attribute, so I can prove things
+@[pp_nodot]
 def exp (z : ℂ) : ℂ :=
   CauSeq.lim (exp' z)
 #align complex.exp Complex.exp
 
 /-- The complex sine function, defined via `exp` -/
--- Porting note (#11180): removed `@[pp_nodot]`
+@[pp_nodot]
 def sin (z : ℂ) : ℂ :=
   (exp (-z * I) - exp (z * I)) * I / 2
 #align complex.sin Complex.sin
 
 /-- The complex cosine function, defined via `exp` -/
--- Porting note (#11180): removed `@[pp_nodot]`
+@[pp_nodot]
 def cos (z : ℂ) : ℂ :=
   (exp (z * I) + exp (-z * I)) / 2
 #align complex.cos Complex.cos
 
 /-- The complex tangent function, defined as `sin z / cos z` -/
--- Porting note (#11180): removed `@[pp_nodot]`
+@[pp_nodot]
 def tan (z : ℂ) : ℂ :=
   sin z / cos z
 #align complex.tan Complex.tan
@@ -78,19 +78,19 @@ def cot (z : ℂ) : ℂ :=
   cos z / sin z
 
 /-- The complex hyperbolic sine function, defined via `exp` -/
--- Porting note (#11180): removed `@[pp_nodot]`
+@[pp_nodot]
 def sinh (z : ℂ) : ℂ :=
   (exp z - exp (-z)) / 2
 #align complex.sinh Complex.sinh
 
 /-- The complex hyperbolic cosine function, defined via `exp` -/
--- Porting note (#11180): removed `@[pp_nodot]`
+@[pp_nodot]
 def cosh (z : ℂ) : ℂ :=
   (exp z + exp (-z)) / 2
 #align complex.cosh Complex.cosh
 
 /-- The complex hyperbolic tangent function, defined as `sinh z / cosh z` -/
--- Porting note (#11180): removed `@[pp_nodot]`
+@[pp_nodot]
 def tanh (z : ℂ) : ℂ :=
   sinh z / cosh z
 #align complex.tanh Complex.tanh
@@ -109,25 +109,25 @@ open Complex
 noncomputable section
 
 /-- The real exponential function, defined as the real part of the complex exponential -/
--- Porting note (#11180): removed `@[pp_nodot]`
+@[pp_nodot]
 nonrec def exp (x : ℝ) : ℝ :=
   (exp x).re
 #align real.exp Real.exp
 
 /-- The real sine function, defined as the real part of the complex sine -/
--- Porting note (#11180): removed `@[pp_nodot]`
+@[pp_nodot]
 nonrec def sin (x : ℝ) : ℝ :=
   (sin x).re
 #align real.sin Real.sin
 
 /-- The real cosine function, defined as the real part of the complex cosine -/
--- Porting note (#11180): removed `@[pp_nodot]`
+@[pp_nodot]
 nonrec def cos (x : ℝ) : ℝ :=
   (cos x).re
 #align real.cos Real.cos
 
 /-- The real tangent function, defined as the real part of the complex tangent -/
--- Porting note (#11180): removed `@[pp_nodot]`
+@[pp_nodot]
 nonrec def tan (x : ℝ) : ℝ :=
   (tan x).re
 #align real.tan Real.tan
@@ -137,20 +137,20 @@ nonrec def cot (x : ℝ) : ℝ :=
   (cot x).re
 
 /-- The real hypebolic sine function, defined as the real part of the complex hyperbolic sine -/
--- Porting note (#11180): removed `@[pp_nodot]`
+@[pp_nodot]
 nonrec def sinh (x : ℝ) : ℝ :=
   (sinh x).re
 #align real.sinh Real.sinh
 
 /-- The real hypebolic cosine function, defined as the real part of the complex hyperbolic cosine -/
--- Porting note (#11180): removed `@[pp_nodot]`
+@[pp_nodot]
 nonrec def cosh (x : ℝ) : ℝ :=
   (cosh x).re
 #align real.cosh Real.cosh
 
 /-- The real hypebolic tangent function, defined as the real part of
 the complex hyperbolic tangent -/
--- Porting note (#11180): removed `@[pp_nodot]`
+@[pp_nodot]
 nonrec def tanh (x : ℝ) : ℝ :=
   (tanh x).re
 #align real.tanh Real.tanh

--- a/Mathlib/Data/Int/Sqrt.lean
+++ b/Mathlib/Data/Int/Sqrt.lean
@@ -22,7 +22,7 @@ namespace Int
 /-- `sqrt z` is the square root of an integer `z`. If `z` is positive, it returns the largest
 integer `r` such that `r * r ≤ n`. If it is negative, it returns `0`. For example, `sqrt (-1) = 0`,
 `sqrt 1 = 1`, `sqrt 2 = 1` -/
--- @[pp_nodot] porting note: unknown attribute
+@[pp_nodot]
 def sqrt (z : ℤ) : ℤ :=
   Nat.sqrt <| Int.toNat z
 #align int.sqrt Int.sqrt

--- a/Mathlib/Data/Matrix/Block.lean
+++ b/Mathlib/Data/Matrix/Block.lean
@@ -40,7 +40,7 @@ section BlockMatrices
 
 /-- We can form a single large matrix by flattening smaller 'block' matrices of compatible
 dimensions. -/
--- @[pp_nodot] -- Porting note: removed
+@[pp_nodot]
 def fromBlocks (A : Matrix n l α) (B : Matrix n m α) (C : Matrix o l α) (D : Matrix o m α) :
     Matrix (Sum n o) (Sum l m) α :=
   of <| Sum.elim (fun i => Sum.elim (A i) (B i)) fun i => Sum.elim (C i) (D i)

--- a/Mathlib/Data/NNRat/Defs.lean
+++ b/Mathlib/Data/NNRat/Defs.lean
@@ -338,7 +338,7 @@ theorem toNNRat_mul (hp : 0 ≤ p) : toNNRat (p * q) = toNNRat p * toNNRat q := 
 end Rat
 
 /-- The absolute value on `ℚ` as a map to `ℚ≥0`. -/
---@[pp_nodot]  -- Porting note: Commented out.
+@[pp_nodot]
 def Rat.nnabs (x : ℚ) : ℚ≥0 :=
   ⟨abs x, abs_nonneg x⟩
 #align rat.nnabs Rat.nnabs

--- a/Mathlib/Data/Nat/Fib/Basic.lean
+++ b/Mathlib/Data/Nat/Fib/Basic.lean
@@ -62,8 +62,7 @@ namespace Nat
 implementation.
 -/
 
--- Porting note: Lean cannot find pp_nodot at the time of this port.
--- @[pp_nodot]
+@[pp_nodot]
 def fib (n : ℕ) : ℕ :=
   ((fun p : ℕ × ℕ => (p.snd, p.fst + p.snd))^[n] (0, 1)).fst
 #align nat.fib Nat.fib

--- a/Mathlib/Data/Nat/Log.lean
+++ b/Mathlib/Data/Nat/Log.lean
@@ -28,7 +28,7 @@ namespace Nat
 
 /-- `log b n`, is the logarithm of natural number `n` in base `b`. It returns the largest `k : ℕ`
 such that `b^k ≤ n`, so if `b^k = n`, it returns exactly `k`. -/
---@[pp_nodot] porting note: unknown attribute
+@[pp_nodot]
 def log (b : ℕ) : ℕ → ℕ
   | n => if h : b ≤ n ∧ 1 < b then log b (n / b) + 1 else 0
 decreasing_by
@@ -237,7 +237,7 @@ theorem add_pred_div_lt {b n : ℕ} (hb : 1 < b) (hn : 2 ≤ n) : (n + b - 1) / 
 
 /-- `clog b n`, is the upper logarithm of natural number `n` in base `b`. It returns the smallest
 `k : ℕ` such that `n ≤ b^k`, so if `b^k = n`, it returns exactly `k`. -/
---@[pp_nodot]
+@[pp_nodot]
 def clog (b : ℕ) : ℕ → ℕ
   | n => if h : 1 < b ∧ 1 < n then clog b ((n + b - 1) / b) + 1 else 0
 decreasing_by

--- a/Mathlib/Data/Nat/Pairing.lean
+++ b/Mathlib/Data/Nat/Pairing.lean
@@ -31,15 +31,13 @@ open Prod Decidable Function
 namespace Nat
 
 /-- Pairing function for the natural numbers. -/
--- Porting note: no pp_nodot
---@[pp_nodot]
+@[pp_nodot]
 def pair (a b : ℕ) : ℕ :=
   if a < b then b * b + a else a * a + a + b
 #align nat.mkpair Nat.pair
 
 /-- Unpairing function for the natural numbers. -/
--- Porting note: no pp_nodot
---@[pp_nodot]
+@[pp_nodot]
 def unpair (n : ℕ) : ℕ × ℕ :=
   let s := sqrt n
   if n - s * s < s then (n - s * s, s) else (s, n - s * s - s)

--- a/Mathlib/Data/Nat/Prime.lean
+++ b/Mathlib/Data/Nat/Prime.lean
@@ -41,7 +41,7 @@ variable {n : ℕ}
 
 /-- `Nat.Prime p` means that `p` is a prime number, that is, a natural number
   at least 2 whose only divisors are `p` and `1`. -/
--- Porting note (#11180): removed @[pp_nodot]
+@[pp_nodot]
 def Prime (p : ℕ) :=
   Irreducible p
 #align nat.prime Nat.Prime

--- a/Mathlib/Data/Rat/Sqrt.lean
+++ b/Mathlib/Data/Rat/Sqrt.lean
@@ -23,7 +23,7 @@ namespace Rat
 
 /-- Square root function on rational numbers, defined by taking the (integer) square root of the
 numerator and the square root (on natural numbers) of the denominator. -/
--- @[pp_nodot] porting note: unknown attribute
+@[pp_nodot]
 def sqrt (q : ℚ) : ℚ := mkRat (Int.sqrt q.num) (Nat.sqrt q.den)
 #align rat.sqrt Rat.sqrt
 

--- a/Mathlib/Data/Real/NNReal.lean
+++ b/Mathlib/Data/Real/NNReal.lean
@@ -1186,7 +1186,9 @@ end Set
 namespace Real
 
 /-- The absolute value on `ℝ` as a map to `ℝ≥0`. -/
--- Porting note (#11180): removed @[pp_nodot]
+-- Porting note (kmill): `pp_nodot` has no affect here
+-- unless RFC lean4#1910 leads to dot notation for CoeFun
+@[pp_nodot]
 def nnabs : ℝ →*₀ ℝ≥0 where
   toFun x := ⟨|x|, abs_nonneg x⟩
   map_zero' := by ext; simp

--- a/Mathlib/Data/Real/Sqrt.lean
+++ b/Mathlib/Data/Real/Sqrt.lean
@@ -41,7 +41,9 @@ namespace NNReal
 variable {x y : ℝ≥0}
 
 /-- Square root of a nonnegative real number. -/
--- Porting note: was @[pp_nodot]
+-- Porting note (kmill): `pp_nodot` has no affect here
+-- unless RFC lean4#1910 leads to dot notation for CoeFun
+@[pp_nodot]
 noncomputable def sqrt : ℝ≥0 ≃o ℝ≥0 :=
   OrderIso.symm <| powOrderIso 2 two_ne_zero
 #align nnreal.sqrt NNReal.sqrt

--- a/Mathlib/Mathport/Syntax.lean
+++ b/Mathlib/Mathport/Syntax.lean
@@ -274,8 +274,6 @@ macro (name := moveAdd) "move_add " pats:rwRule,+ loc:(location)? : tactic =>
 
 /- M -/ syntax (name := notationClass) "notation_class" "*"? (ppSpace ident)? : attr
 
-/- N -/ syntax (name := pp_nodot) "pp_nodot" : attr
-
 /- N -/ syntax (name := addTacticDoc) (docComment)? "add_tactic_doc " term : command
 
 /- M -/ syntax (name := addHintTactic) "add_hint_tactic " tactic : command

--- a/Mathlib/SetTheory/Ordinal/CantorNormalForm.lean
+++ b/Mathlib/SetTheory/Ordinal/CantorNormalForm.lean
@@ -65,13 +65,13 @@ theorem CNFRec_pos (b : Ordinal) {o : Ordinal} {C : Ordinal → Sort*} (ho : o �
 set_option linter.uppercaseLean3 false in
 #align ordinal.CNF_rec_pos Ordinal.CNFRec_pos
 
--- Porting note: unknown attribute @[pp_nodot]
 /-- The Cantor normal form of an ordinal `o` is the list of coefficients and exponents in the
 base-`b` expansion of `o`.
 
 We special-case `CNF 0 o = CNF 1 o = [(0, o)]` for `o ≠ 0`.
 
 `CNF b (b ^ u₁ * v₁ + b ^ u₂ * v₂) = [(u₁, v₁), (u₂, v₂)]` -/
+@[pp_nodot]
 def CNF (b o : Ordinal) : List (Ordinal × Ordinal) :=
   CNFRec b [] (fun o _ho IH ↦ (log b o, o / b ^ log b o)::IH) o
 set_option linter.uppercaseLean3 false in

--- a/Mathlib/SetTheory/Ordinal/Exponential.lean
+++ b/Mathlib/SetTheory/Ordinal/Exponential.lean
@@ -253,7 +253,7 @@ theorem opow_mul (a b c : Ordinal) : a ^ (b * c) = (a ^ b) ^ c := by
 
 /-- The ordinal logarithm is the solution `u` to the equation `x = b ^ u * v + w` where `v < b` and
     `w < b ^ u`. -/
--- @[pp_nodot] -- Porting note: Unknown attribute.
+@[pp_nodot]
 def log (b : Ordinal) (x : Ordinal) : Ordinal :=
   if _h : 1 < b then pred (sInf { o | x < b ^ o }) else 0
 #align ordinal.log Ordinal.log

--- a/scripts/nolints.json
+++ b/scripts/nolints.json
@@ -655,7 +655,6 @@
  ["docBlame", "Mathlib.Tactic.parameter"],
  ["docBlame", "Mathlib.Tactic.piInstance"],
  ["docBlame", "Mathlib.Tactic.piInstanceDeriveField"],
- ["docBlame", "Mathlib.Tactic.pp_nodot"],
  ["docBlame", "Mathlib.Tactic.prettyCases"],
  ["docBlame", "Mathlib.Tactic.printSorryIn"],
  ["docBlame", "Mathlib.Tactic.propagateTags"],

--- a/test/Recall.lean
+++ b/test/Recall.lean
@@ -26,7 +26,7 @@ error: value mismatch
 has value
   id
 but is expected to have value
-  fun z ↦ z.exp'.lim
+  fun z ↦ (Complex.exp' z).lim
 -/
 #guard_msgs in recall Complex.exp : ℂ → ℂ := id
 


### PR DESCRIPTION
Adds in `@[pp_nodot]` wherever there was a porting note, except in some cases where by principle it can never have an affect (such as for `MulOpposite.op` or `SymAlg.sym`).

closes #11180


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
