### PR TITLE
[Merged by Bors] - feat: add a few analytic function lemmas for future AnalyticManifold use

### DIFF
--- a/Mathlib/Analysis/Analytic/Basic.lean
+++ b/Mathlib/Analysis/Analytic/Basic.lean
@@ -182,6 +182,11 @@ theorem constFormalMultilinearSeries_radius {v : F} :
     (by simp [constFormalMultilinearSeries])
 #align formal_multilinear_series.const_formal_multilinear_series_radius FormalMultilinearSeries.constFormalMultilinearSeries_radius
 
+/-- `0` has infinite radius of convergence -/
+@[simp] lemma zero_radius : (0 : FormalMultilinearSeries 𝕜 E F).radius = ∞ := by
+  rw [← constFormalMultilinearSeries_zero]
+  exact constFormalMultilinearSeries_radius
+
 /-- For `r` strictly smaller than the radius of `p`, then `‖pₙ‖ rⁿ` tends to zero exponentially:
 for some `0 < a < 1`, `‖p n‖ rⁿ = o(aⁿ)`. -/
 theorem isLittleO_of_lt_radius (h : ↑r < p.radius) :

--- a/Mathlib/Analysis/Analytic/Composition.lean
+++ b/Mathlib/Analysis/Analytic/Composition.lean
@@ -858,6 +858,12 @@ theorem AnalyticAt.comp {g : F → G} {f : E → F} {x : E} (hg : AnalyticAt �
   (hq.comp hp).analyticAt
 #align analytic_at.comp AnalyticAt.comp
 
+/-- Version of `AnalyticAt.comp` where point equality is a separate hypothesis. -/
+theorem AnalyticAt.comp_of_eq {g : F → G} {f : E → F} {y : F} {x : E} (hg : AnalyticAt 𝕜 g y)
+    (hf : AnalyticAt 𝕜 f x) (hy : f x = y) : AnalyticAt 𝕜 (g ∘ f) x := by
+  rw [← hy] at hg
+  exact hg.comp hf
+
 /-- If two functions `g` and `f` are analytic respectively on `s.image f` and `s`, then `g ∘ f` is
 analytic on `s`. -/
 theorem AnalyticOn.comp' {s : Set E} {g : F → G} {f : E → F} (hg : AnalyticOn 𝕜 g (s.image f))

--- a/Mathlib/Analysis/Calculus/FormalMultilinearSeries.lean
+++ b/Mathlib/Analysis/Calculus/FormalMultilinearSeries.lean
@@ -362,6 +362,17 @@ theorem constFormalMultilinearSeries_apply [NontriviallyNormedField 𝕜] [Norme
   Nat.casesOn n (fun hn => (hn rfl).elim) (fun _ _ => rfl) hn
 #align const_formal_multilinear_series_apply constFormalMultilinearSeries_apply
 
+@[simp]
+lemma constFormalMultilinearSeries_zero [NontriviallyNormedField 𝕜] [NormedAddCommGroup E ]
+    [NormedAddCommGroup F] [NormedSpace 𝕜 E] [NormedSpace 𝕜 F] :
+    constFormalMultilinearSeries 𝕜 E (0 : F) = 0 := by
+  ext n x
+  simp only [FormalMultilinearSeries.zero_apply, ContinuousMultilinearMap.zero_apply,
+    constFormalMultilinearSeries]
+  induction n
+  · simp only [Nat.zero_eq, ContinuousMultilinearMap.curry0_apply]
+  · simp only [constFormalMultilinearSeries.match_1.eq_2, ContinuousMultilinearMap.zero_apply]
+
 end Const
 
 section Linear


### PR DESCRIPTION
This is a few isolated lemmas split out of
https://github.com/leanprover-community/mathlib4/pull/10853.

1. AnalyticAt.comp_of_eq
2. FormalMultilinearSeries.zero_radius
3. constFormalMultilinearSeries_zero

---

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
