### PR TITLE
refactor: Primrec and Partrec

### DIFF
--- a/Mathlib/Computability/Ackermann.lean
+++ b/Mathlib/Computability/Ackermann.lean
@@ -388,5 +388,5 @@ theorem not_primrec_ack_self : ¬Primrec fun n => ack n n := by
 
 /-- The Ackermann function is not primitive recursive. -/
 theorem not_primrec₂_ack : ¬Primrec₂ ack := fun h =>
-  not_primrec_ack_self <| h.comp Primrec.id Primrec.id
+  not_primrec_ack_self <| h.comp₂ Primrec.id Primrec.id
 #align not_primrec₂_ack not_primrec₂_ack

--- a/Mathlib/Computability/Partrec.lean
+++ b/Mathlib/Computability/Partrec.lean
@@ -217,7 +217,7 @@ theorem ppred : Partrec fun n => ppred n :=
       (@PrimrecRel.comp _ _ _ _ _ _ _ _ _ _
         Primrec.eq Primrec.fst (_root_.Primrec.succ.comp Primrec.snd))
       (_root_.Primrec.const 0) (_root_.Primrec.const 1)).to₂
-  (of_primrec (Primrec₂.unpaired'.2 this)).rfind.of_eq fun n => by
+  (of_primrec (Primrec.unpaired'.2 this)).rfind.of_eq fun n => by
     cases n <;> simp
     · exact
         eq_none_iff.2 fun a ⟨⟨m, h, _⟩, _⟩ => by
@@ -239,7 +239,7 @@ def Partrec {α σ} [Primcodable α] [Primcodable σ] (f : α →. σ) :=
 #align partrec Partrec
 
 /-- Partially recursive partial functions `α → β → σ` between `Primcodable` types -/
-def Partrec₂ {α β σ} [Primcodable α] [Primcodable β] [Primcodable σ] (f : α → β →. σ) :=
+abbrev Partrec₂ {α β σ} [Primcodable α] [Primcodable β] [Primcodable σ] (f : α → β →. σ) :=
   Partrec fun p : α × β => f p.1 p.2
 #align partrec₂ Partrec₂
 
@@ -250,7 +250,7 @@ def Computable {α σ} [Primcodable α] [Primcodable σ] (f : α → σ) :=
 #align computable Computable
 
 /-- Computable functions `α → β → σ` between `Primcodable` types -/
-def Computable₂ {α β σ} [Primcodable α] [Primcodable β] [Primcodable σ] (f : α → β → σ) :=
+abbrev Computable₂ {α β σ} [Primcodable α] [Primcodable β] [Primcodable σ] (f : α → β → σ) :=
   Computable fun p : α × β => f p.1 p.2
 #align computable₂ Computable₂
 
@@ -259,21 +259,13 @@ theorem Primrec.to_comp {α σ} [Primcodable α] [Primcodable σ] {f : α → σ
   (Nat.Partrec.ppred.comp (Nat.Partrec.of_primrec hf)).of_eq fun n => by
     simp; cases decode (α := α) n <;> simp
 #align primrec.to_comp Primrec.to_comp
-
-nonrec theorem Primrec₂.to_comp {α β σ} [Primcodable α] [Primcodable β] [Primcodable σ]
-    {f : α → β → σ} (hf : Primrec₂ f) : Computable₂ f :=
-  hf.to_comp
-#align primrec₂.to_comp Primrec₂.to_comp
+#align primrec₂.to_comp Primrec.to_comp
 
 protected theorem Computable.partrec {α σ} [Primcodable α] [Primcodable σ] {f : α → σ}
     (hf : Computable f) : Partrec (f : α →. σ) :=
   hf
 #align computable.partrec Computable.partrec
-
-protected theorem Computable₂.partrec₂ {α β σ} [Primcodable α] [Primcodable β] [Primcodable σ]
-    {f : α → β → σ} (hf : Computable₂ f) : Partrec₂ fun a => (f a : β →. σ) :=
-  hf
-#align computable₂.partrec₂ Computable₂.partrec₂
+#align computable₂.partrec₂ Computable.partrec
 
 namespace Computable
 
@@ -295,7 +287,7 @@ theorem ofOption {f : α → Option β} (hf : Computable f) : Partrec fun a => (
 #align computable.of_option Computable.ofOption
 
 theorem to₂ {f : α × β → σ} (hf : Computable f) : Computable₂ fun a b => f (a, b) :=
-  hf.of_eq fun ⟨_, _⟩ => rfl
+  hf.of_eq fun _ => rfl
 #align computable.to₂ Computable.to₂
 
 protected theorem id : Computable (@id α) :=
@@ -465,8 +457,7 @@ theorem map {f : α →. β} {g : α → β → σ} (hf : Partrec f) (hg : Compu
   simpa [bind_some_eq_map] using @Partrec.bind _ _ _ _ _ _ _ (fun a => Part.some ∘ (g a)) hf hg
 #align partrec.map Partrec.map
 
-theorem to₂ {f : α × β →. σ} (hf : Partrec f) : Partrec₂ fun a b => f (a, b) :=
-  hf.of_eq fun ⟨_, _⟩ => rfl
+theorem to₂ {f : α × β →. σ} (hf : Partrec f) : Partrec₂ fun a b => f (a, b) := hf
 #align partrec.to₂ Partrec.to₂
 
 theorem nat_rec {f : α → ℕ} {g : α →. σ} {h : α → ℕ × σ →. σ} (hf : Computable f) (hg : Partrec g)
@@ -491,33 +482,22 @@ theorem map_encode_iff {f : α →. σ} : (Partrec fun a => (f a).map encode) �
   Iff.rfl
 #align partrec.map_encode_iff Partrec.map_encode_iff
 
-end Partrec
-
-namespace Partrec₂
-
-variable {α : Type*} {β : Type*} {γ : Type*} {δ : Type*} {σ : Type*}
-variable [Primcodable α] [Primcodable β] [Primcodable γ] [Primcodable δ] [Primcodable σ]
-
 theorem unpaired {f : ℕ → ℕ →. α} : Partrec (Nat.unpaired f) ↔ Partrec₂ f :=
-  ⟨fun h => by simpa using Partrec.comp (g := fun p : ℕ × ℕ => (p.1, p.2)) h Primrec₂.pair.to_comp,
+  ⟨fun h => by simpa using h.comp Primrec.natPair.to_comp,
     fun h => h.comp Primrec.unpair.to_comp⟩
-#align partrec₂.unpaired Partrec₂.unpaired
+#align partrec₂.unpaired Partrec.unpaired
 
 theorem unpaired' {f : ℕ → ℕ →. ℕ} : Nat.Partrec (Nat.unpaired f) ↔ Partrec₂ f :=
   Partrec.nat_iff.symm.trans unpaired
-#align partrec₂.unpaired' Partrec₂.unpaired'
+#align partrec₂.unpaired' Partrec.unpaired'
 
-nonrec theorem comp {f : β → γ →. σ} {g : α → β} {h : α → γ} (hf : Partrec₂ f) (hg : Computable g)
+nonrec theorem comp₂ {f : β → γ →. σ} {g : α → β} {h : α → γ} (hf : Partrec₂ f) (hg : Computable g)
     (hh : Computable h) : Partrec fun a => f (g a) (h a) :=
   hf.comp (hg.pair hh)
-#align partrec₂.comp Partrec₂.comp
+#align partrec₂.comp Partrec.comp₂
+#align partrec₂.comp₂ Partrec.comp₂
 
-theorem comp₂ {f : γ → δ →. σ} {g : α → β → γ} {h : α → β → δ} (hf : Partrec₂ f)
-    (hg : Computable₂ g) (hh : Computable₂ h) : Partrec₂ fun a b => f (g a b) (h a b) :=
-  hf.comp hg hh
-#align partrec₂.comp₂ Partrec₂.comp₂
-
-end Partrec₂
+end Partrec
 
 namespace Computable
 
@@ -528,32 +508,15 @@ nonrec theorem comp {f : β → σ} {g : α → β} (hf : Computable f) (hg : Co
     Computable fun a => f (g a) :=
   hf.comp hg
 #align computable.comp Computable.comp
+#align computable.comp₂ Computable.comp
 
-theorem comp₂ {f : γ → σ} {g : α → β → γ} (hf : Computable f) (hg : Computable₂ g) :
-    Computable₂ fun a b => f (g a b) :=
-  hf.comp hg
-#align computable.comp₂ Computable.comp₂
-
-end Computable
-
-namespace Computable₂
-
-variable {α : Type*} {β : Type*} {γ : Type*} {δ : Type*} {σ : Type*}
-variable [Primcodable α] [Primcodable β] [Primcodable γ] [Primcodable δ] [Primcodable σ]
-
-theorem mk {f : α → β → σ} (hf : Computable fun p : α × β => f p.1 p.2) : Computable₂ f := hf
-
-nonrec theorem comp {f : β → γ → σ} {g : α → β} {h : α → γ} (hf : Computable₂ f)
+nonrec theorem comp₂ {f : β → γ → σ} {g : α → β} {h : α → γ} (hf : Computable₂ f)
     (hg : Computable g) (hh : Computable h) : Computable fun a => f (g a) (h a) :=
   hf.comp (hg.pair hh)
-#align computable₂.comp Computable₂.comp
+#align computable₂.comp Computable.comp₂
+#align computable₂.comp₂ Computable.comp₂
 
-theorem comp₂ {f : γ → δ → σ} {g : α → β → γ} {h : α → β → δ} (hf : Computable₂ f)
-    (hg : Computable₂ g) (hh : Computable₂ h) : Computable₂ fun a b => f (g a b) (h a b) :=
-  hf.comp hg hh
-#align computable₂.comp₂ Computable₂.comp₂
-
-end Computable₂
+end Computable
 
 namespace Partrec
 
@@ -564,8 +527,8 @@ open Computable
 
 theorem rfind {p : α → ℕ →. Bool} (hp : Partrec₂ p) : Partrec fun a => Nat.rfind (p a) :=
   (Nat.Partrec.rfind <|
-        hp.map ((Primrec.dom_bool fun b => cond b 0 1).comp Primrec.snd).to₂.to_comp).of_eq
-    fun n => by
+      hp.map ((Primrec.dom_bool fun b => cond b 0 1).comp Primrec.snd).to_comp.to₂)
+  |>.of_eq fun n => by
     cases' e : decode (α := α) n with a <;> simp [e, Nat.rfind_zero_none, map_id']
     congr; funext n
     simp only [map_map, Function.comp]
@@ -580,7 +543,7 @@ theorem rfindOpt {f : α → ℕ → Option σ} (hf : Computable₂ f) :
 
 theorem nat_casesOn_right {f : α → ℕ} {g : α → σ} {h : α → ℕ →. σ} (hf : Computable f)
     (hg : Computable g) (hh : Partrec₂ h) : Partrec fun a => (f a).casesOn (some (g a)) (h a) :=
-  (nat_rec hf hg (hh.comp fst (pred.comp <| hf.comp fst)).to₂).of_eq fun a => by
+  (nat_rec hf hg (hh.comp₂ fst (pred.comp <| hf.comp fst)).to₂).of_eq fun a => by
     simp; cases' f a with n <;> simp
     refine ext fun b => ⟨fun H => ?_, fun H => ?_⟩
     · rcases mem_bind_iff.1 H with ⟨c, _, h₂⟩
@@ -607,11 +570,11 @@ theorem vector_mOfFn :
       (∀ i, Partrec (f i)) → Partrec fun a : α => Vector.mOfFn fun i => f i a
   | 0, _, _ => const _
   | n + 1, f, hf => by
-    simp only [Vector.mOfFn, Nat.add_eq, Nat.add_zero, pure_eq_some, bind_eq_bind]
+    dsimp only [Vector.mOfFn, Nat.add_eq, Nat.add_zero, pure_eq_some, bind_eq_bind]
     exact
       (hf 0).bind
         (Partrec.bind ((vector_mOfFn fun i => hf i.succ).comp fst)
-          (Primrec.vector_cons.to_comp.comp (snd.comp fst) snd))
+          (Primrec.vector_cons.to_comp.comp₂ (snd.comp fst) snd).to₂)
 #align partrec.vector_m_of_fn Partrec.vector_mOfFn
 
 end Partrec
@@ -638,10 +601,9 @@ theorem bind_decode_iff {f : α → β → Option σ} :
       (((Partrec.nat_iff.2
         (Nat.Partrec.ppred.comp <| Nat.Partrec.of_primrec <| Primcodable.prim (α := β))).comp
             snd).bind
-        (Computable.comp hf fst).to₂.partrec₂)
+        (hf.comp fst).partrec.to₂)
       fun n => by
-        simp; cases decode (α := α) n.unpair.1 <;> simp;
-          cases decode (α := β) n.unpair.2 <;> simp,
+        simp; cases decode (α := α) n.unpair.1 <;> simp; cases decode (α := β) n.unpair.2 <;> simp,
     fun hf => by
     have :
       Partrec fun a : α × ℕ =>
@@ -650,7 +612,7 @@ theorem bind_decode_iff {f : α → β → Option σ} :
       Partrec.nat_casesOn_right
         (h := fun (a : α × ℕ) (n : ℕ) ↦ map (fun b ↦ f a.1 b) (Part.ofOption (decode n)))
         (Primrec.encdec.to_comp.comp snd) (const Option.none)
-        ((ofOption (Computable.decode.comp snd)).map (hf.comp (fst.comp <| fst.comp fst) snd).to₂)
+        ((ofOption (Computable.decode.comp snd)).map (hf.comp₂ (fst.comp <| fst.comp fst) snd).to₂)
     refine this.of_eq fun a => ?_
     simp; cases decode (α := β) a.2 <;> simp [encodek]⟩
 #align computable.bind_decode_iff Computable.bind_decode_iff
@@ -664,13 +626,13 @@ theorem map_decode_iff {f : α → β → σ} :
 theorem nat_rec {f : α → ℕ} {g : α → σ} {h : α → ℕ × σ → σ} (hf : Computable f) (hg : Computable g)
     (hh : Computable₂ h) :
     Computable fun a => Nat.rec (motive := fun _ => σ) (g a) (fun y IH => h a (y, IH)) (f a) :=
-  (Partrec.nat_rec hf hg hh.partrec₂).of_eq fun a => by simp; induction f a <;> simp [*]
+  (Partrec.nat_rec hf hg hh.partrec.to₂).of_eq fun a => by simp; induction f a <;> simp [*]
 #align computable.nat_elim Computable.nat_rec
 
 theorem nat_casesOn {f : α → ℕ} {g : α → σ} {h : α → ℕ → σ} (hf : Computable f) (hg : Computable g)
     (hh : Computable₂ h) :
     Computable fun a => Nat.casesOn (motive := fun _ => σ) (f a) (g a) (h a) :=
-  nat_rec hf hg (hh.comp fst <| fst.comp snd).to₂
+  nat_rec hf hg (hh.comp₂ fst <| fst.comp snd).to₂
 #align computable.nat_cases Computable.nat_casesOn
 
 theorem cond {c : α → Bool} {f : α → σ} {g : α → σ} (hc : Computable c) (hf : Computable f)
@@ -693,7 +655,7 @@ theorem option_bind {f : α → Option β} {g : α → β → Option σ} (hf : C
 
 theorem option_map {f : α → Option β} {g : α → β → σ} (hf : Computable f) (hg : Computable₂ g) :
     Computable fun a => (f a).map (g a) := by
-  convert option_bind hf (option_some.comp₂ hg)
+  convert option_bind hf (option_some.comp hg).to₂
   apply Option.map_eq_bind
 #align computable.option_map Computable.option_map
 
@@ -724,15 +686,15 @@ theorem nat_strong_rec (f : α → ℕ → σ) {g : α → List σ → Option σ
     (H : ∀ a n, g a ((List.range n).map (f a)) = Option.some (f a n)) : Computable₂ f :=
   suffices Computable₂ fun a n => (List.range n).map (f a) from
     option_some_iff.1 <|
-      (list_get?.comp (this.comp fst (succ.comp snd)) snd).to₂.of_eq fun a => by
+      (list_get?.comp₂ (this.comp₂ fst (succ.comp snd)) snd).to₂.of_eq fun a => by
         simp [List.get?_range (Nat.lt_succ_self a.2)]
   option_some_iff.1 <|
     (nat_rec snd (const (Option.some []))
           (to₂ <|
             option_bind (snd.comp snd) <|
               to₂ <|
-                option_map (hg.comp (fst.comp <| fst.comp fst) snd)
-                  (to₂ <| list_concat.comp (snd.comp fst) snd))).of_eq
+                option_map (hg.comp₂ (fst.comp <| fst.comp fst) snd)
+                  (list_concat.comp₂ (snd.comp fst) snd).to₂)).of_eq
       fun a => by
       simp; induction' a.2 with n IH; · rfl
       simp [IH, H, List.range_succ]
@@ -746,7 +708,7 @@ theorem list_ofFn :
     exact const []
   | n + 1, f, hf => by
     simp only [List.ofFn_succ]
-    exact list_cons.comp (hf 0) (list_ofFn fun i => hf i.succ)
+    exact list_cons.comp₂ (hf 0) (list_ofFn fun i => hf i.succ)
 #align computable.list_of_fn Computable.list_ofFn
 
 theorem vector_ofFn {n} {f : Fin n → α → σ} (hf : ∀ i, Computable (f i)) :
@@ -780,7 +742,7 @@ theorem option_casesOn_right {o : α → Option β} {f : α → σ} {g : α → 
       Nat.casesOn (encode (o a)) (Part.some (f a)) (fun n => Part.bind (decode (α := β) n) (g a)) :=
     nat_casesOn_right (h := fun a n ↦ Part.bind (ofOption (decode n)) fun b ↦ g a b)
       (encode_iff.2 ho) hf.partrec <|
-        ((@Computable.decode β _).comp snd).ofOption.bind (hg.comp (fst.comp fst) snd).to₂
+        ((@Computable.decode β _).comp snd).ofOption.bind (hg.comp₂ (fst.comp fst) snd).to₂
   this.of_eq fun a => by cases' o a with b <;> simp [encodek]
 #align partrec.option_cases_right Partrec.option_casesOn_right
 

--- a/Mathlib/Computability/PartrecCode.lean
+++ b/Mathlib/Computability/PartrecCode.lean
@@ -666,8 +666,8 @@ theorem evaln_sound : ∀ {k c n x}, x ∈ evaln k c n → x ∈ eval c n
   | 0, _, n, x, h => by simp [evaln] at h
   | k + 1, c, n, x, h => by
     induction c generalizing x n with
-      simp [eval, evaln, Option.bind_eq_some, Seq.seq] at h ⊢ <;>
-      cases' h with _ h
+      (simp [eval, evaln, Option.bind_eq_some, Seq.seq] at h ⊢
+       cases' h with _ h)
     | pair cf cg hf hg =>
       rcases h with ⟨y, ef, z, eg, rfl⟩
       exact ⟨_, hf _ _ ef, _, hg _ _ eg, rfl⟩

--- a/Mathlib/Computability/PartrecCode.lean
+++ b/Mathlib/Computability/PartrecCode.lean
@@ -5,6 +5,7 @@ Authors: Mario Carneiro
 -/
 import Mathlib.Computability.Partrec
 import Mathlib.Data.Option.Basic
+import Batteries.Tactic.SqueezeScope
 
 #align_import computability.partrec_code from "leanprover-community/mathlib"@"6155d4351090a6fad236e3d2e4e0e4e7342668e8"
 
@@ -46,27 +47,18 @@ open Encodable Denumerable
 
 namespace Nat.Partrec
 
-theorem rfind' {f} (hf : Nat.Partrec f) :
-    Nat.Partrec
-      (Nat.unpaired fun a m =>
-        (Nat.rfind fun n => (fun m => m = 0) <$> f (Nat.pair a (n + m))).map (· + m)) :=
-  Partrec₂.unpaired'.2 <| by
-    refine
-      Partrec.map
-        ((@Partrec₂.unpaired' fun a b : ℕ =>
-              Nat.rfind fun n => (fun m => m = 0) <$> f (Nat.pair a (n + b))).1
-          ?_)
-        (Primrec.nat_add.comp Primrec.snd <| Primrec.snd.comp Primrec.fst).to_comp.to₂
-    have : Nat.Partrec (fun a => Nat.rfind (fun n => (fun m => decide (m = 0)) <$>
-      Nat.unpaired (fun a b => f (Nat.pair (Nat.unpair a).1 (b + (Nat.unpair a).2)))
-        (Nat.pair a n))) :=
-      rfind
-        (Partrec₂.unpaired'.2
-          ((Partrec.nat_iff.2 hf).comp
-              (Primrec₂.pair.comp (Primrec.fst.comp <| Primrec.unpair.comp Primrec.fst)
-                  (Primrec.nat_add.comp Primrec.snd
-                    (Primrec.snd.comp <| Primrec.unpair.comp Primrec.fst))).to_comp))
-    simp at this; exact this
+theorem rfind' {f} (hf : Nat.Partrec f) : Nat.Partrec (Nat.unpaired fun a m =>
+    (Nat.rfind fun n => (fun m => m = 0) <$> f (Nat.pair a (n + m))).map (· + m)) := by
+  refine Partrec.unpaired'.2 <|
+    ((@Partrec.unpaired' fun a b : ℕ =>
+        Nat.rfind fun n => (· = 0) <$> f (Nat.pair a (n + b))).1 ?_).map
+    (Primrec.nat_add.comp₂ Primrec.snd <| Primrec.snd.comp Primrec.fst).to_comp.to₂
+  simpa using rfind <| Partrec.unpaired'.2 <| Partrec.to₂ <|
+    (Partrec.nat_iff.2 hf).comp <| Primrec.to_comp <|
+    Primrec.natPair.comp₂
+      (Primrec.fst.comp <| Primrec.unpair.comp Primrec.fst)
+      (Primrec.nat_add.comp₂ Primrec.snd
+        (Primrec.snd.comp <| Primrec.unpair.comp Primrec.fst))
 #align nat.partrec.rfind' Nat.Partrec.rfind'
 
 /-- Code for partial recursive functions from ℕ to ℕ.
@@ -233,45 +225,34 @@ open Primrec
 namespace Nat.Partrec.Code
 
 theorem pair_prim : Primrec₂ pair :=
-  Primrec₂.ofNat_iff.2 <|
-    Primrec₂.encode_iff.1 <|
-      nat_add.comp
-        (nat_double.comp <|
-          nat_double.comp <|
-            Primrec₂.natPair.comp (encode_iff.2 <| (Primrec.ofNat Code).comp fst)
-              (encode_iff.2 <| (Primrec.ofNat Code).comp snd))
-        (Primrec₂.const 4)
+  Primrec.ofNat_iff₂.2 <| Primrec.encode_iff.1 <| nat_add.comp₂
+    (nat_double.comp <| nat_double.comp <| Primrec.natPair.comp₂
+      (encode_iff.2 <| (Primrec.ofNat Code).comp fst)
+      (encode_iff.2 <| (Primrec.ofNat Code).comp snd))
+    (.const 4)
 #align nat.partrec.code.pair_prim Nat.Partrec.Code.pair_prim
 
 theorem comp_prim : Primrec₂ comp :=
-  Primrec₂.ofNat_iff.2 <|
-    Primrec₂.encode_iff.1 <|
-      nat_add.comp
-        (nat_double.comp <|
-          nat_double_succ.comp <|
-            Primrec₂.natPair.comp (encode_iff.2 <| (Primrec.ofNat Code).comp fst)
-              (encode_iff.2 <| (Primrec.ofNat Code).comp snd))
-        (Primrec₂.const 4)
+  Primrec.ofNat_iff₂.2 <| Primrec.encode_iff.1 <| nat_add.comp₂
+    (nat_double.comp <| nat_double_succ.comp <| Primrec.natPair.comp₂
+      (encode_iff.2 <| (Primrec.ofNat Code).comp fst)
+      (encode_iff.2 <| (Primrec.ofNat Code).comp snd))
+    (.const 4)
 #align nat.partrec.code.comp_prim Nat.Partrec.Code.comp_prim
 
 theorem prec_prim : Primrec₂ prec :=
-  Primrec₂.ofNat_iff.2 <|
-    Primrec₂.encode_iff.1 <|
-      nat_add.comp
-        (nat_double_succ.comp <|
-          nat_double.comp <|
-            Primrec₂.natPair.comp (encode_iff.2 <| (Primrec.ofNat Code).comp fst)
-              (encode_iff.2 <| (Primrec.ofNat Code).comp snd))
-        (Primrec₂.const 4)
+  Primrec.ofNat_iff₂.2 <| Primrec.encode_iff.1 <| nat_add.comp₂
+    (nat_double_succ.comp <| nat_double.comp <| Primrec.natPair.comp₂
+        (encode_iff.2 <| (Primrec.ofNat Code).comp fst)
+        (encode_iff.2 <| (Primrec.ofNat Code).comp snd))
+    (.const 4)
 #align nat.partrec.code.prec_prim Nat.Partrec.Code.prec_prim
 
 theorem rfind_prim : Primrec rfind' :=
-  ofNat_iff.2 <|
-    encode_iff.1 <|
-      nat_add.comp
-        (nat_double_succ.comp <| nat_double_succ.comp <|
-          encode_iff.2 <| Primrec.ofNat Code)
-        (const 4)
+  ofNat_iff.2 <| encode_iff.1 <| nat_add.comp₂
+    (nat_double_succ.comp <| nat_double_succ.comp <|
+      encode_iff.2 <| Primrec.ofNat Code)
+    (const 4)
 #align nat.partrec.code.rfind_prim Nat.Partrec.Code.rfind_prim
 
 theorem rec_prim' {α σ} [Primcodable α] [Primcodable σ] {c : α → Code} (hc : Primrec c) {z : α → σ}
@@ -298,11 +279,11 @@ theorem rec_prim' {α σ} [Primcodable α] [Primcodable σ] {c : α → Code} (h
       (cond n.div2.bodd (co a (ofNat Code m.unpair.1, ofNat Code m.unpair.2, s₁, s₂))
         (pr a (ofNat Code m.unpair.1, ofNat Code m.unpair.2, s₁, s₂)))
   have : Primrec G₁ :=
-    option_bind (list_get?.comp (snd.comp fst) (snd.comp snd)) <| .mk <|
-    option_bind ((list_get?.comp (snd.comp fst)
-      (fst.comp <| Primrec.unpair.comp (snd.comp snd))).comp fst) <| .mk <|
-    option_map ((list_get?.comp (snd.comp fst)
-      (snd.comp <| Primrec.unpair.comp (snd.comp snd))).comp <| fst.comp fst) <| .mk <|
+    option_bind (list_get?.comp₂ (snd.comp fst) (snd.comp snd)) <| .to₂ <|
+    option_bind ((list_get?.comp₂ (snd.comp fst)
+      (fst.comp <| Primrec.unpair.comp (snd.comp snd))).comp fst) <| .to₂ <|
+    option_map ((list_get?.comp₂ (snd.comp fst)
+      (snd.comp <| Primrec.unpair.comp (snd.comp snd))).comp <| fst.comp fst) <| .to₂ <|
     have a := fst.comp (fst.comp <| fst.comp <| fst.comp fst)
     have n := fst.comp (snd.comp <| fst.comp <| fst.comp fst)
     have m := snd.comp (snd.comp <| fst.comp <| fst.comp fst)
@@ -313,13 +294,13 @@ theorem rec_prim' {α σ} [Primcodable α] [Primcodable σ] {c : α → Code} (h
     have s₂ := snd
     (nat_bodd.comp n).cond
       ((nat_bodd.comp <| nat_div2.comp n).cond
-        (hrf.comp a (((Primrec.ofNat Code).comp m).pair s))
-        (hpc.comp a (((Primrec.ofNat Code).comp m₁).pair <|
+        (hrf.comp₂ a (((Primrec.ofNat Code).comp m).pair s))
+        (hpc.comp₂ a (((Primrec.ofNat Code).comp m₁).pair <|
           ((Primrec.ofNat Code).comp m₂).pair <| s₁.pair s₂)))
       (Primrec.cond (nat_bodd.comp <| nat_div2.comp n)
-        (hco.comp a (((Primrec.ofNat Code).comp m₁).pair <|
+        (hco.comp₂ a (((Primrec.ofNat Code).comp m₁).pair <|
           ((Primrec.ofNat Code).comp m₂).pair <| s₁.pair s₂))
-        (hpr.comp a (((Primrec.ofNat Code).comp m₁).pair <|
+        (hpr.comp₂ a (((Primrec.ofNat Code).comp m₁).pair <|
           ((Primrec.ofNat Code).comp m₂).pair <| s₁.pair s₂)))
   let G : α → List σ → Option σ := fun a IH =>
     IH.length.casesOn (some (z a)) fun n =>
@@ -327,18 +308,17 @@ theorem rec_prim' {α σ} [Primcodable α] [Primcodable σ] {c : α → Code} (h
     n.casesOn (some (l a)) fun n =>
     n.casesOn (some (r a)) fun n =>
     G₁ ((a, IH), n, n.div2.div2)
-  have : Primrec₂ G := .mk <|
-    nat_casesOn (list_length.comp snd) (option_some_iff.2 (hz.comp fst)) <| .mk <|
-    nat_casesOn snd (option_some_iff.2 (hs.comp (fst.comp fst))) <| .mk <|
-    nat_casesOn snd (option_some_iff.2 (hl.comp (fst.comp <| fst.comp fst))) <| .mk <|
-    nat_casesOn snd (option_some_iff.2 (hr.comp (fst.comp <| fst.comp <| fst.comp fst))) <| .mk <|
+  have' : Primrec₂ G := .to₂ <|
+    nat_casesOn (list_length.comp snd) (option_some_iff.2 (hz.comp fst)) <| .to₂ <|
+    nat_casesOn snd (option_some_iff.2 (hs.comp (fst.comp fst))) <| .to₂ <|
+    nat_casesOn snd (option_some_iff.2 (hl.comp (fst.comp <| fst.comp fst))) <| .to₂ <|
+    nat_casesOn snd (option_some_iff.2 (hr.comp (fst.comp <| fst.comp <| fst.comp fst))) <| .to₂ <|
     this.comp <|
       ((fst.pair snd).comp <| fst.comp <| fst.comp <| fst.comp <| fst).pair <|
       snd.pair <| nat_div2.comp <| nat_div2.comp snd
   refine (nat_strong_rec (fun a n => F a (ofNat Code n)) this.to₂ fun a n => ?_)
-    |>.comp .id (encode_iff.2 hc) |>.of_eq fun a => by simp
-  simp
-  iterate 4 cases' n with n; · simp [ofNatCode_eq, ofNatCode]; rfl
+    |>.comp₂ .id (encode_iff.2 hc) |>.of_eq fun a => by simp
+  iterate 4 cases' n with n <;> [(simp [ofNatCode_eq, ofNatCode]; rfl); skip]
   simp only [G]; rw [List.length_map, List.length_range]
   let m := n.div2.div2
   show G₁ ((a, (List.range (n + 4)).map fun n => F a (ofNat Code n)), n, m)
@@ -350,9 +330,9 @@ theorem rec_prim' {α σ} [Primcodable α] [Primcodable σ] {c : α → Code} (h
       (Nat.succ_le_succ (Nat.le_add_right ..))
   have m1 : m.unpair.1 < n + 4 := lt_of_le_of_lt m.unpair_left_le hm
   have m2 : m.unpair.2 < n + 4 := lt_of_le_of_lt m.unpair_right_le hm
-  simp [G₁]; simp [m, List.get?_map, List.get?_range, hm, m1, m2]
+  simp only [List.get?_map, G₁, hm, List.get?_range, m1, m2, m]
   rw [show ofNat Code (n + 4) = ofNatCode (n + 4) from rfl]
-  simp [ofNatCode]
+  simp only [ofNatCode]
   cases n.bodd <;> cases n.div2.bodd <;> rfl
 #align nat.partrec.code.rec_prim' Nat.Partrec.Code.rec_prim'
 
@@ -370,10 +350,10 @@ theorem rec_prim {α σ} [Primcodable α] [Primcodable σ] {c : α → Code} (hc
       Nat.Partrec.Code.recOn c (z a) (s a) (l a) (r a) (pr a) (co a) (pc a) (rf a)
     Primrec fun a => F a (c a) :=
   rec_prim' hc hz hs hl hr
-    (pr := fun a b => pr a b.1 b.2.1 b.2.2.1 b.2.2.2) (.mk hpr)
-    (co := fun a b => co a b.1 b.2.1 b.2.2.1 b.2.2.2) (.mk hco)
-    (pc := fun a b => pc a b.1 b.2.1 b.2.2.1 b.2.2.2) (.mk hpc)
-    (rf := fun a b => rf a b.1 b.2) (.mk hrf)
+    (pr := fun a b => pr a b.1 b.2.1 b.2.2.1 b.2.2.2) hpr.to₂
+    (co := fun a b => co a b.1 b.2.1 b.2.2.1 b.2.2.2) hco.to₂
+    (pc := fun a b => pc a b.1 b.2.1 b.2.2.1 b.2.2.2) hpc.to₂
+    (rf := fun a b => rf a b.1 b.2) hrf.to₂
 #align nat.partrec.code.rec_prim Nat.Partrec.Code.rec_prim
 
 end Nat.Partrec.Code
@@ -409,49 +389,47 @@ theorem rec_computable {α σ} [Primcodable α] [Primcodable σ] {c : α → Cod
         (pc a (ofNat Code m.unpair.1, ofNat Code m.unpair.2, s₁, s₂)))
       (cond n.div2.bodd (co a (ofNat Code m.unpair.1, ofNat Code m.unpair.2, s₁, s₂))
         (pr a (ofNat Code m.unpair.1, ofNat Code m.unpair.2, s₁, s₂)))
-  have : Computable G₁ := by
-    refine option_bind (list_get?.comp (snd.comp fst) (snd.comp snd)) <| .mk ?_
-    refine option_bind ((list_get?.comp (snd.comp fst)
-      (fst.comp <| Computable.unpair.comp (snd.comp snd))).comp fst) <| .mk ?_
-    refine option_map ((list_get?.comp (snd.comp fst)
-      (snd.comp <| Computable.unpair.comp (snd.comp snd))).comp <| fst.comp fst) <| .mk ?_
-    exact
-      have a := fst.comp (fst.comp <| fst.comp <| fst.comp fst)
-      have n := fst.comp (snd.comp <| fst.comp <| fst.comp fst)
-      have m := snd.comp (snd.comp <| fst.comp <| fst.comp fst)
-      have m₁ := fst.comp (Computable.unpair.comp m)
-      have m₂ := snd.comp (Computable.unpair.comp m)
-      have s := snd.comp (fst.comp fst)
-      have s₁ := snd.comp fst
-      have s₂ := snd
-      (nat_bodd.comp n).cond
-        ((nat_bodd.comp <| nat_div2.comp n).cond
-          (hrf.comp a (((Computable.ofNat Code).comp m).pair s))
-          (hpc.comp a (((Computable.ofNat Code).comp m₁).pair <|
-            ((Computable.ofNat Code).comp m₂).pair <| s₁.pair s₂)))
-        (Computable.cond (nat_bodd.comp <| nat_div2.comp n)
-          (hco.comp a (((Computable.ofNat Code).comp m₁).pair <|
-            ((Computable.ofNat Code).comp m₂).pair <| s₁.pair s₂))
-          (hpr.comp a (((Computable.ofNat Code).comp m₁).pair <|
-            ((Computable.ofNat Code).comp m₂).pair <| s₁.pair s₂)))
+  have' : Computable (_ :  (α × List σ) × ℕ × ℕ → Option σ) :=
+    option_bind (list_get?.comp₂ (snd.comp fst) (snd.comp snd)) <| .to₂ <|
+    option_bind ((list_get?.comp₂ (snd.comp fst)
+      (fst.comp <| Computable.unpair.comp (snd.comp snd))).comp fst) <| .to₂ <|
+    option_map ((list_get?.comp₂ (snd.comp fst)
+      (snd.comp <| Computable.unpair.comp (snd.comp snd))).comp <| fst.comp fst) <| .to₂ <|
+    have a := fst.comp (fst.comp <| fst.comp <| fst.comp fst)
+    have n := fst.comp (snd.comp <| fst.comp <| fst.comp fst)
+    have m := snd.comp (snd.comp <| fst.comp <| fst.comp fst)
+    have m₁ := fst.comp (Computable.unpair.comp m)
+    have m₂ := snd.comp (Computable.unpair.comp m)
+    have s := snd.comp (fst.comp fst)
+    have s₁ := snd.comp fst
+    have s₂ := snd
+    (nat_bodd.comp n).cond
+      ((nat_bodd.comp <| nat_div2.comp n).cond
+        (hrf.comp₂ a (((Computable.ofNat Code).comp m).pair s))
+        (hpc.comp₂ a (((Computable.ofNat Code).comp m₁).pair <|
+          ((Computable.ofNat Code).comp m₂).pair <| s₁.pair s₂)))
+      (Computable.cond (nat_bodd.comp <| nat_div2.comp n)
+        (hco.comp₂ a (((Computable.ofNat Code).comp m₁).pair <|
+          ((Computable.ofNat Code).comp m₂).pair <| s₁.pair s₂))
+        (hpr.comp₂ a (((Computable.ofNat Code).comp m₁).pair <|
+          ((Computable.ofNat Code).comp m₂).pair <| s₁.pair s₂)))
   let G : α → List σ → Option σ := fun a IH =>
     IH.length.casesOn (some (z a)) fun n =>
     n.casesOn (some (s a)) fun n =>
     n.casesOn (some (l a)) fun n =>
     n.casesOn (some (r a)) fun n =>
     G₁ ((a, IH), n, n.div2.div2)
-  have : Computable₂ G := .mk <|
-    nat_casesOn (list_length.comp snd) (option_some_iff.2 (hz.comp fst)) <| .mk <|
-    nat_casesOn snd (option_some_iff.2 (hs.comp (fst.comp fst))) <| .mk <|
-    nat_casesOn snd (option_some_iff.2 (hl.comp (fst.comp <| fst.comp fst))) <| .mk <|
-    nat_casesOn snd (option_some_iff.2 (hr.comp (fst.comp <| fst.comp <| fst.comp fst))) <| .mk <|
+  have : Computable₂ G := .to₂ <|
+    nat_casesOn (list_length.comp snd) (option_some_iff.2 (hz.comp fst)) <| .to₂ <|
+    nat_casesOn snd (option_some_iff.2 (hs.comp (fst.comp fst))) <| .to₂ <|
+    nat_casesOn snd (option_some_iff.2 (hl.comp (fst.comp <| fst.comp fst))) <| .to₂ <|
+    nat_casesOn snd (option_some_iff.2 (hr.comp (fst.comp <| fst.comp <| fst.comp fst))) <| .to₂ <|
     this.comp <|
       ((fst.pair snd).comp <| fst.comp <| fst.comp <| fst.comp <| fst).pair <|
       snd.pair <| nat_div2.comp <| nat_div2.comp snd
   refine (nat_strong_rec (fun a n => F a (ofNat Code n)) this.to₂ fun a n => ?_)
-    |>.comp .id (encode_iff.2 hc) |>.of_eq fun a => by simp
-  simp
-  iterate 4 cases' n with n; · simp [ofNatCode_eq, ofNatCode]; rfl
+    |>.comp₂ .id (encode_iff.2 hc) |>.of_eq fun a => by simp
+  iterate 4 cases' n with n <;> [(simp [ofNatCode_eq, ofNatCode]; rfl); skip]
   simp only [G]; rw [List.length_map, List.length_range]
   let m := n.div2.div2
   show G₁ ((a, (List.range (n + 4)).map fun n => F a (ofNat Code n)), n, m)
@@ -463,9 +441,9 @@ theorem rec_computable {α σ} [Primcodable α] [Primcodable σ] {c : α → Cod
       (Nat.succ_le_succ (Nat.le_add_right ..))
   have m1 : m.unpair.1 < n + 4 := lt_of_le_of_lt m.unpair_left_le hm
   have m2 : m.unpair.2 < n + 4 := lt_of_le_of_lt m.unpair_right_le hm
-  simp [G₁]; simp [m, List.get?_map, List.get?_range, hm, m1, m2]
+  simp only [List.get?_map, G₁, hm, List.get?_range, m1, m2, m]
   rw [show ofNat Code (n + 4) = ofNatCode (n + 4) from rfl]
-  simp [ofNatCode]
+  simp only [ofNatCode]
   cases n.bodd <;> cases n.div2.bodd <;> rfl
 #align nat.partrec.code.rec_computable Nat.Partrec.Code.rec_computable
 
@@ -505,9 +483,7 @@ def eval : Code → ℕ →. ℕ
 /-- Helper lemma for the evaluation of `prec` in the base case. -/
 @[simp]
 theorem eval_prec_zero (cf cg : Code) (a : ℕ) : eval (prec cf cg) (Nat.pair a 0) = eval cf a := by
-  rw [eval, Nat.unpaired, Nat.unpair_pair]
-  simp (config := { Lean.Meta.Simp.neutralConfig with proj := true }) only []
-  rw [Nat.rec_zero]
+  rw [eval, Nat.unpaired, Nat.unpair_pair, Nat.rec_zero]
 #align nat.partrec.code.eval_prec_zero Nat.Partrec.Code.eval_prec_zero
 
 /-- Helper lemma for the evaluation of `prec` in the recursive case. -/
@@ -524,26 +500,27 @@ instance : Membership (ℕ →. ℕ) Code :=
 @[simp]
 theorem eval_const : ∀ n m, eval (Code.const n) m = Part.some n
   | 0, m => rfl
-  | n + 1, m => by simp! [eval_const n m]
+  | n + 1, m => by simp [eval, eval_const n m]
 #align nat.partrec.code.eval_const Nat.Partrec.Code.eval_const
 
 @[simp]
-theorem eval_id (n) : eval Code.id n = Part.some n := by simp! [Seq.seq]
+theorem eval_id (n) : eval Code.id n = Part.some n := by simp [eval, Seq.seq]
 #align nat.partrec.code.eval_id Nat.Partrec.Code.eval_id
 
 @[simp]
-theorem eval_curry (c n x) : eval (curry c n) x = eval c (Nat.pair n x) := by simp! [Seq.seq]
+theorem eval_curry (c n x) : eval (curry c n) x = eval c (Nat.pair n x) := by simp [eval, Seq.seq]
 #align nat.partrec.code.eval_curry Nat.Partrec.Code.eval_curry
 
 theorem const_prim : Primrec Code.const :=
-  (_root_.Primrec.id.nat_iterate (_root_.Primrec.const zero)
-    (comp_prim.comp (_root_.Primrec.const succ) Primrec.snd).to₂).of_eq
-    fun n => by simp; induction n <;>
+  _root_.Primrec.id.nat_iterate (.const zero) (comp_prim.comp₂ (.const succ) Primrec.snd).to₂
+  |>.of_eq fun n => by
+    simp only [id_eq]
+    induction n <;>
       simp [*, Code.const, Function.iterate_succ', -Function.iterate_succ]
 #align nat.partrec.code.const_prim Nat.Partrec.Code.const_prim
 
 theorem curry_prim : Primrec₂ curry :=
-  comp_prim.comp Primrec.fst <| pair_prim.comp (const_prim.comp Primrec.snd)
+  comp_prim.comp₂ Primrec.fst <| pair_prim.comp₂ (const_prim.comp Primrec.snd)
     (_root_.Primrec.const Code.id)
 #align nat.partrec.code.curry_prim Nat.Partrec.Code.curry_prim
 
@@ -560,7 +537,7 @@ program and a ℕ `n`, and returns a new program using `n` as the first argument
 -/
 theorem smn :
     ∃ f : Code → ℕ → Code, Computable₂ f ∧ ∀ c n x, eval (f c n) x = eval c (Nat.pair n x) :=
-  ⟨curry, Primrec₂.to_comp curry_prim, eval_curry⟩
+  ⟨curry, curry_prim.to_comp, eval_curry⟩
 #align nat.partrec.code.smn Nat.Partrec.Code.smn
 
 /-- A function is partial recursive if and only if there is a code implementing it. Therefore,
@@ -659,71 +636,72 @@ theorem evaln_mono : ∀ {k₁ k₂ c n x}, k₁ ≤ k₂ → x ∈ evaln k₁ c
         exists_const, and_imp]
       introv h h₁ h₂ h₃
       exact ⟨le_trans h₂ h, h₁ h₃⟩
-    simp? at h ⊢ says simp only [Option.mem_def] at h ⊢
+    simp only [Option.mem_def] at h ⊢
     induction' c with cf cg hf hg cf cg hf hg cf cg hf hg cf hf generalizing x n <;>
       rw [evaln] at h ⊢ <;> refine this hl' (fun h => ?_) h
     iterate 4 exact h
     · -- pair cf cg
-      simp? [Seq.seq, Option.bind_eq_some] at h ⊢ says
-        simp only [Seq.seq, Option.map_eq_map, Option.mem_def, Option.bind_eq_some,
-          Option.map_eq_some', exists_exists_and_eq_and] at h ⊢
+      simp only [Seq.seq, Option.map_eq_map, Option.mem_def, Option.bind_eq_some,
+        Option.map_eq_some', exists_exists_and_eq_and] at h ⊢
       exact h.imp fun a => And.imp (hf _ _) <| Exists.imp fun b => And.imp_left (hg _ _)
     · -- comp cf cg
-      simp? [Bind.bind, Option.bind_eq_some] at h ⊢ says
-        simp only [bind, Option.mem_def, Option.bind_eq_some] at h ⊢
+      simp only [bind, Option.mem_def, Option.bind_eq_some] at h ⊢
       exact h.imp fun a => And.imp (hg _ _) (hf _ _)
     · -- prec cf cg
       revert h
       simp only [unpaired, bind, Option.mem_def]
-      induction n.unpair.2 <;> simp [Option.bind_eq_some]
-      · apply hf
-      · exact fun y h₁ h₂ => ⟨y, evaln_mono hl' h₁, hg _ _ h₂⟩
+      cases n.unpair.2 with
+      | zero => apply hf
+      | succ =>
+        simp only [Option.bind_eq_some, rec_zero]
+        exact fun ⟨y, h₁, h₂⟩ => ⟨y, evaln_mono hl' h₁, hg _ _ h₂⟩
     · -- rfind' cf
-      simp? [Bind.bind, Option.bind_eq_some] at h ⊢ says
-        simp only [unpaired, bind, pair_unpair, Option.pure_def, Option.mem_def,
-          Option.bind_eq_some] at h ⊢
+      simp only [unpaired, bind, pair_unpair, Option.pure_def, Option.mem_def,
+        Option.bind_eq_some] at h ⊢
       refine h.imp fun x => And.imp (hf _ _) ?_
-      by_cases x0 : x = 0 <;> simp [x0]
-      exact evaln_mono hl'
+      split_ifs <;> [apply id; exact evaln_mono hl']
 #align nat.partrec.code.evaln_mono Nat.Partrec.Code.evaln_mono
 
 theorem evaln_sound : ∀ {k c n x}, x ∈ evaln k c n → x ∈ eval c n
   | 0, _, n, x, h => by simp [evaln] at h
   | k + 1, c, n, x, h => by
-    induction' c with cf cg hf hg cf cg hf hg cf cg hf hg cf hf generalizing x n <;>
-        simp [eval, evaln, Option.bind_eq_some, Seq.seq] at h ⊢ <;>
+    induction c generalizing x n with
+      simp [eval, evaln, Option.bind_eq_some, Seq.seq] at h ⊢ <;>
       cases' h with _ h
-    iterate 4 simpa [pure, PFun.pure, eq_comm] using h
-    · -- pair cf cg
+    | pair cf cg hf hg =>
       rcases h with ⟨y, ef, z, eg, rfl⟩
       exact ⟨_, hf _ _ ef, _, hg _ _ eg, rfl⟩
-    · --comp hf hg
+    | comp cf cg hf hg =>
       rcases h with ⟨y, eg, ef⟩
       exact ⟨_, hg _ _ eg, hf _ _ ef⟩
-    · -- prec cf cg
+    | prec cf cg hf hg =>
       revert h
-      induction' n.unpair.2 with m IH generalizing x <;> simp [Option.bind_eq_some]
-      · apply hf
-      · refine fun y h₁ h₂ => ⟨y, IH _ ?_, ?_⟩
-        · have := evaln_mono k.le_succ h₁
-          simp [evaln, Option.bind_eq_some] at this
-          exact this.2
-        · exact hg _ _ h₂
-    · -- rfind' cf
-      rcases h with ⟨m, h₁, h₂⟩
-      by_cases m0 : m = 0 <;> simp [m0] at h₂
-      · exact
-          ⟨0, ⟨by simpa [m0] using hf _ _ h₁, fun {m} => (Nat.not_lt_zero _).elim⟩, by simp [h₂]⟩
+      induction n.unpair.2 generalizing x with simp [Option.bind_eq_some]
+      | zero => apply hf
+      | succ m IH =>
+        refine fun y h₁ h₂ => ⟨y, IH _ ?_, hg _ _ h₂⟩
+        have := evaln_mono k.le_succ h₁
+        simp only [evaln, unpaired, unpair_pair, Option.bind_eq_bind,
+          Option.mem_def, Option.bind_eq_some, Option.guard_eq_some', exists_const] at this
+        exact this.2
+    | rfind' cf hf =>
+      let ⟨m, h₁, h₂⟩ := h
+      split_ifs at h₂ with m0
+      --  <;> simp only [m0, ↓reduceIte, Option.some.injEq] at h₂
+      · cases h₂
+        exact ⟨0, ⟨by simpa [m0] using hf _ _ h₁, fun {m} => (Nat.not_lt_zero _).elim⟩, by simp⟩
       · have := evaln_sound h₂
-        simp [eval] at this
-        rcases this with ⟨y, ⟨hy₁, hy₂⟩, rfl⟩
-        refine
-          ⟨y + 1, ⟨by simpa [add_comm, add_left_comm] using hy₁, fun {i} im => ?_⟩, by
-            simp [add_comm, add_left_comm]⟩
-        cases' i with i
-        · exact ⟨m, by simpa using hf _ _ h₁, m0⟩
-        · rcases hy₂ (Nat.lt_of_succ_lt_succ im) with ⟨z, hz, z0⟩
-          exact ⟨z, by simpa [Nat.succ_eq_add_one, add_comm, add_left_comm] using hz, z0⟩
+        simp only [eval, unpaired, unpair_pair, Part.map_eq_map, Part.mem_map_iff, mem_rfind,
+          decide_eq_true_eq, exists_eq_right, decide_eq_false_iff_not] at this
+        obtain ⟨y, ⟨hy₁, hy₂⟩, rfl⟩ := this
+        refine ⟨y + 1, ⟨by simpa [add_comm, add_left_comm] using hy₁, fun {i} im => ?_⟩, ?_⟩
+        · match i with
+          | 0 => exact ⟨m, by simpa using hf _ _ h₁, m0⟩
+          | i+1 =>
+            let ⟨z, hz, z0⟩ := hy₂ (Nat.lt_of_succ_lt_succ im)
+            exact ⟨z, by simpa [Nat.succ_eq_add_one, add_comm, add_left_comm] using hz, z0⟩
+        · simp [add_comm, add_left_comm]
+    | _ => simpa [pure, PFun.pure, eq_comm] using h
 #align nat.partrec.code.evaln_sound Nat.Partrec.Code.evaln_sound
 
 theorem evaln_complete {c n x} : x ∈ eval c n ↔ ∃ k, x ∈ evaln k c n := by
@@ -731,7 +709,7 @@ theorem evaln_complete {c n x} : x ∈ eval c n ↔ ∃ k, x ∈ evaln k c n := 
   rsuffices ⟨k, h⟩ : ∃ k, x ∈ evaln (k + 1) c n
   · exact ⟨k + 1, h⟩
   induction c generalizing n x with
-      simp [eval, evaln, pure, PFun.pure, Seq.seq, Option.bind_eq_some] at h ⊢
+    simp [eval, evaln, pure, PFun.pure, Seq.seq, Option.bind_eq_some] at h ⊢
   | pair cf cg hf hg =>
     rcases h with ⟨x, hx, y, hy, rfl⟩
     rcases hf hx with ⟨k₁, hk₁⟩; rcases hg hy with ⟨k₂, hk₂⟩
@@ -751,13 +729,16 @@ theorem evaln_complete {c n x} : x ∈ eval c n ↔ ∃ k, x ∈ evaln k c n := 
   | prec cf cg hf hg =>
     revert h
     generalize n.unpair.1 = n₁; generalize n.unpair.2 = n₂
-    induction' n₂ with m IH generalizing x n <;> simp [Option.bind_eq_some]
-    · intro h
+    induction n₂ generalizing x n with
+    | zero =>
+      intro h
       rcases hf h with ⟨k, hk⟩
       exact ⟨_, le_max_left _ _, evaln_mono (Nat.succ_le_succ <| le_max_right _ _) hk⟩
-    · intro y hy hx
-      rcases IH hy with ⟨k₁, nk₁, hk₁⟩
-      rcases hg hx with ⟨k₂, hk₂⟩
+    | succ m IH =>
+      simp only [Option.bind_eq_some, Part.mem_bind_iff]
+      intro ⟨y, hy, hx⟩
+      obtain ⟨k₁, nk₁, hk₁⟩ := IH hy
+      let ⟨k₂, hk₂⟩ := hg hx
       refine
         ⟨(max k₁ k₂).succ,
           Nat.le_succ_of_le <| le_max_of_le_left <|
@@ -774,24 +755,26 @@ theorem evaln_complete {c n x} : x ∈ eval c n ↔ ∃ k, x ∈ evaln k c n := 
     revert hy₁ hy₂
     generalize n.unpair.2 = m
     intro hy₁ hy₂
-    induction' y with y IH generalizing m <;> simp [evaln, Option.bind_eq_some]
-    · simp at hy₁
-      rcases hf hy₁ with ⟨k, hk⟩
+    induction y generalizing m with
+      simp only [evaln, unpair_pair, Option.bind_eq_bind, Option.mem_def,
+        Option.bind_eq_some, Option.guard_eq_some', exists_const]
+    | zero =>
+      let ⟨k, hk⟩ := hf hy₁
+      simp only [zero_add] at hk
       exact ⟨_, Nat.le_of_lt_succ <| evaln_bound hk, _, hk, by simp⟩
-    · rcases hy₂ (Nat.succ_pos _) with ⟨a, ha, a0⟩
-      rcases hf ha with ⟨k₁, hk₁⟩
-      rcases IH m.succ (by simpa [Nat.succ_eq_add_one, add_comm, add_left_comm] using hy₁)
-          fun {i} hi => by
-          simpa [Nat.succ_eq_add_one, add_comm, add_left_comm] using
-            hy₂ (Nat.succ_lt_succ hi) with
-        ⟨k₂, hk₂⟩
-      use (max k₁ k₂).succ
+    | succ y IH =>
+      let ⟨a, ha, a0⟩ := hy₂ (Nat.succ_pos _)
+      let ⟨k₁, hk₁⟩ := hf ha
+      let ⟨k₂, hk₂⟩ := IH m.succ
+        (by simpa [Nat.succ_eq_add_one, add_comm, add_left_comm] using hy₁)
+        (fun {i} hi => by
+          simpa [Nat.succ_eq_add_one, add_comm, add_left_comm] using hy₂ (Nat.succ_lt_succ hi))
       rw [zero_add] at hk₁
-      use Nat.le_succ_of_le <| le_max_of_le_left <| Nat.le_of_lt_succ <| evaln_bound hk₁
-      use a
-      use evaln_mono (Nat.succ_le_succ <| Nat.le_succ_of_le <| le_max_left _ _) hk₁
-      simpa [Nat.succ_eq_add_one, a0, -max_eq_left, -max_eq_right, add_comm, add_left_comm] using
-        evaln_mono (Nat.succ_le_succ <| le_max_right _ _) hk₂
+      refine ⟨(max k₁ k₂).succ, ?_, a, ?_, ?_⟩
+      · exact Nat.le_succ_of_le <| le_max_of_le_left <| Nat.le_of_lt_succ <| evaln_bound hk₁
+      · exact evaln_mono (Nat.succ_le_succ <| Nat.le_succ_of_le <| le_max_left _ _) hk₁
+      · simpa [Nat.succ_eq_add_one, a0, -max_eq_left, -max_eq_right, add_comm, add_left_comm] using
+          evaln_mono (Nat.succ_le_succ <| le_max_right _ _) hk₂
   | _ => exact ⟨⟨_, le_rfl⟩, h.symm⟩
 #align nat.partrec.code.evaln_complete Nat.Partrec.Code.evaln_complete
 
@@ -806,214 +789,160 @@ private def lup (L : List (List (Option ℕ))) (p : ℕ × Code) (n : ℕ) := do
 
 private theorem hlup : Primrec fun p : _ × (_ × _) × _ => lup p.1 p.2.1 p.2.2 :=
   Primrec.option_bind
-    (Primrec.list_get?.comp Primrec.fst (Primrec.encode.comp <| Primrec.fst.comp Primrec.snd))
-    (Primrec.option_bind (Primrec.list_get?.comp Primrec.snd <| Primrec.snd.comp <|
+    (Primrec.list_get?.comp₂ Primrec.fst (Primrec.encode.comp <| Primrec.fst.comp Primrec.snd))
+    (Primrec.option_bind (Primrec.list_get?.comp₂ Primrec.snd <| Primrec.snd.comp <|
       Primrec.snd.comp Primrec.fst) Primrec.snd)
 
 private def G (L : List (List (Option ℕ))) : Option (List (Option ℕ)) :=
-  Option.some <|
-    let a := ofNat (ℕ × Code) L.length
-    let k := a.1
-    let c := a.2
-    (List.range k).map fun n =>
-      k.casesOn Option.none fun k' =>
-        Nat.Partrec.Code.recOn c
-          (some 0) -- zero
-          (some (Nat.succ n))
-          (some n.unpair.1)
-          (some n.unpair.2)
-          (fun cf cg _ _ => do
-            let x ← lup L (k, cf) n
-            let y ← lup L (k, cg) n
-            some (Nat.pair x y))
-          (fun cf cg _ _ => do
-            let x ← lup L (k, cg) n
-            lup L (k, cf) x)
-          (fun cf cg _ _ =>
-            let z := n.unpair.1
-            n.unpair.2.casesOn (lup L (k, cf) z) fun y => do
-              let i ← lup L (k', c) (Nat.pair z y)
-              lup L (k, cg) (Nat.pair z (Nat.pair y i)))
-          (fun cf _ =>
-            let z := n.unpair.1
-            let m := n.unpair.2
-            do
-              let x ← lup L (k, cf) (Nat.pair z m)
-              x.casesOn (some m) fun _ => lup L (k', c) (Nat.pair z (m + 1)))
+  let a := ofNat (ℕ × Code) L.length
+  let k := a.1; let c := a.2
+  some <| (List.range k).map fun n =>
+  k.casesOn Option.none fun k' =>
+  Nat.Partrec.Code.recOn c
+    (some 0) -- zero
+    (some (Nat.succ n))
+    (some n.unpair.1)
+    (some n.unpair.2)
+    (fun cf cg _ _ => return Nat.pair (← lup L (k, cf) n) (← lup L (k, cg) n))
+    (fun cf cg _ _ => do lup L (k, cf) (← lup L (k, cg) n))
+    (fun cf cg _ _ =>
+      let z := n.unpair.1
+      n.unpair.2.casesOn (lup L (k, cf) z) fun y => do
+        lup L (k, cg) (Nat.pair z (Nat.pair y (← lup L (k', c) (Nat.pair z y)))))
+    (fun cf _ => do
+      let (z, m) := n.unpair
+      (← lup L (k, cf) (Nat.pair z m)).casesOn (some m) fun _ =>
+        lup L (k', c) (Nat.pair z (m + 1)))
 
 private theorem hG : Primrec G := by
   have a := (Primrec.ofNat (ℕ × Code)).comp (Primrec.list_length (α := List (Option ℕ)))
   have k := Primrec.fst.comp a
-  refine Primrec.option_some.comp (Primrec.list_map (Primrec.list_range.comp k) (?_ : Primrec _))
+  refine Primrec.option_some.comp <| Primrec.list_map (Primrec.list_range.comp k) ?_
   replace k := k.comp (Primrec.fst (β := ℕ))
   have n := Primrec.snd (α := List (List (Option ℕ))) (β := ℕ)
-  refine Primrec.nat_casesOn k (_root_.Primrec.const Option.none) (?_ : Primrec _)
+  refine Primrec.nat_casesOn k (_root_.Primrec.const Option.none) ?_
   have k := k.comp (Primrec.fst (β := ℕ))
   have n := n.comp (Primrec.fst (β := ℕ))
   have k' := Primrec.snd (α := List (List (Option ℕ)) × ℕ) (β := ℕ)
   have c := Primrec.snd.comp (a.comp <| (Primrec.fst (β := ℕ)).comp (Primrec.fst (β := ℕ)))
-  apply
-    Nat.Partrec.Code.rec_prim c
-      (_root_.Primrec.const (some 0))
-      (Primrec.option_some.comp (_root_.Primrec.succ.comp n))
-      (Primrec.option_some.comp (Primrec.fst.comp <| Primrec.unpair.comp n))
-      (Primrec.option_some.comp (Primrec.snd.comp <| Primrec.unpair.comp n))
-  · have L := (Primrec.fst.comp Primrec.fst).comp
-      (Primrec.fst (α := (List (List (Option ℕ)) × ℕ) × ℕ)
-        (β := Code × Code × Option ℕ × Option ℕ))
-    have k := k.comp (Primrec.fst (β := Code × Code × Option ℕ × Option ℕ))
-    have n := n.comp (Primrec.fst (β := Code × Code × Option ℕ × Option ℕ))
-    have cf := Primrec.fst.comp (Primrec.snd (α := (List (List (Option ℕ)) × ℕ) × ℕ)
-        (β := Code × Code × Option ℕ × Option ℕ))
-    have cg := (Primrec.fst.comp Primrec.snd).comp
-      (Primrec.snd (α := (List (List (Option ℕ)) × ℕ) × ℕ)
-        (β := Code × Code × Option ℕ × Option ℕ))
-    refine Primrec.option_bind (hlup.comp <| L.pair <| (k.pair cf).pair n) ?_
-    unfold Primrec₂
-    conv =>
-      congr
-      · ext p
-        dsimp only []
-        erw [Option.bind_eq_bind, ← Option.map_eq_bind]
-    refine Primrec.option_map ((hlup.comp <| L.pair <| (k.pair cg).pair n).comp Primrec.fst) ?_
-    unfold Primrec₂
-    exact Primrec₂.natPair.comp (Primrec.snd.comp Primrec.fst) Primrec.snd
-  · have L := (Primrec.fst.comp Primrec.fst).comp
-      (Primrec.fst (α := (List (List (Option ℕ)) × ℕ) × ℕ)
-        (β := Code × Code × Option ℕ × Option ℕ))
-    have k := k.comp (Primrec.fst (β := Code × Code × Option ℕ × Option ℕ))
-    have n := n.comp (Primrec.fst (β := Code × Code × Option ℕ × Option ℕ))
-    have cf := Primrec.fst.comp (Primrec.snd (α := (List (List (Option ℕ)) × ℕ) × ℕ)
-        (β := Code × Code × Option ℕ × Option ℕ))
-    have cg := (Primrec.fst.comp Primrec.snd).comp
-      (Primrec.snd (α := (List (List (Option ℕ)) × ℕ) × ℕ)
-        (β := Code × Code × Option ℕ × Option ℕ))
-    refine Primrec.option_bind (hlup.comp <| L.pair <| (k.pair cg).pair n) ?_
-    unfold Primrec₂
-    have h :=
-      hlup.comp ((L.comp Primrec.fst).pair <| ((k.pair cf).comp Primrec.fst).pair Primrec.snd)
-    exact h
-  · have L := (Primrec.fst.comp Primrec.fst).comp
-      (Primrec.fst (α := (List (List (Option ℕ)) × ℕ) × ℕ)
-        (β := Code × Code × Option ℕ × Option ℕ))
-    have k := k.comp (Primrec.fst (β := Code × Code × Option ℕ × Option ℕ))
-    have n := n.comp (Primrec.fst (β := Code × Code × Option ℕ × Option ℕ))
-    have cf := Primrec.fst.comp (Primrec.snd (α := (List (List (Option ℕ)) × ℕ) × ℕ)
-        (β := Code × Code × Option ℕ × Option ℕ))
-    have cg := (Primrec.fst.comp Primrec.snd).comp
-      (Primrec.snd (α := (List (List (Option ℕ)) × ℕ) × ℕ)
-        (β := Code × Code × Option ℕ × Option ℕ))
-    have z := Primrec.fst.comp (Primrec.unpair.comp n)
-    refine
-      Primrec.nat_casesOn (Primrec.snd.comp (Primrec.unpair.comp n))
-        (hlup.comp <| L.pair <| (k.pair cf).pair z)
-        (?_ : Primrec _)
-    have L := L.comp (Primrec.fst (β := ℕ))
-    have z := z.comp (Primrec.fst (β := ℕ))
-    have y := Primrec.snd
-      (α := ((List (List (Option ℕ)) × ℕ) × ℕ) × Code × Code × Option ℕ × Option ℕ) (β := ℕ)
-    have h₁ := hlup.comp <| L.pair <| (((k'.pair c).comp Primrec.fst).comp Primrec.fst).pair
-      (Primrec₂.natPair.comp z y)
-    refine Primrec.option_bind h₁ (?_ : Primrec _)
-    have z := z.comp (Primrec.fst (β := ℕ))
-    have y := y.comp (Primrec.fst (β := ℕ))
-    have i := Primrec.snd
-      (α := (((List (List (Option ℕ)) × ℕ) × ℕ) × Code × Code × Option ℕ × Option ℕ) × ℕ)
-      (β := ℕ)
-    have h₂ := hlup.comp ((L.comp Primrec.fst).pair <|
-      ((k.pair cg).comp <| Primrec.fst.comp Primrec.fst).pair <|
-        Primrec₂.natPair.comp z <| Primrec₂.natPair.comp y i)
-    exact h₂
-  · have L := (Primrec.fst.comp Primrec.fst).comp
-      (Primrec.fst (α := (List (List (Option ℕ)) × ℕ) × ℕ)
-        (β := Code × Option ℕ))
-    have k := k.comp (Primrec.fst (β := Code × Option ℕ))
-    have n := n.comp (Primrec.fst (β := Code × Option ℕ))
-    have cf := Primrec.fst.comp (Primrec.snd (α := (List (List (Option ℕ)) × ℕ) × ℕ)
-        (β := Code × Option ℕ))
-    have z := Primrec.fst.comp (Primrec.unpair.comp n)
-    have m := Primrec.snd.comp (Primrec.unpair.comp n)
-    have h₁ := hlup.comp <| L.pair <| (k.pair cf).pair (Primrec₂.natPair.comp z m)
-    refine Primrec.option_bind h₁ (?_ : Primrec _)
-    have m := m.comp (Primrec.fst (β := ℕ))
-    refine Primrec.nat_casesOn Primrec.snd (Primrec.option_some.comp m) ?_
-    unfold Primrec₂
-    exact (hlup.comp ((L.comp Primrec.fst).pair <|
-      ((k'.pair c).comp <| Primrec.fst.comp Primrec.fst).pair
-        (Primrec₂.natPair.comp (z.comp Primrec.fst) (_root_.Primrec.succ.comp m)))).comp
-      Primrec.fst
+  apply Nat.Partrec.Code.rec_prim c
+  · exact .const (some 0)
+  · exact Primrec.option_some.comp (_root_.Primrec.succ.comp n)
+  · exact Primrec.option_some.comp (Primrec.fst.comp <| Primrec.unpair.comp n)
+  · exact Primrec.option_some.comp (Primrec.snd.comp <| Primrec.unpair.comp n)
+  · simp only [Option.bind_eq_bind, bind_pure_comp, Option.map_eq_map]
+    exact
+      have L := (Primrec.fst.comp Primrec.fst).comp Primrec.fst
+      have k := k.comp Primrec.fst
+      have n := n.comp Primrec.fst
+      have cf := Primrec.fst.comp Primrec.snd
+      have cg := (Primrec.fst.comp Primrec.snd).comp Primrec.snd
+      Primrec.option_bind (hlup.comp <| L.pair <| (k.pair cf).pair n)
+      (Primrec.option_map ((hlup.comp <| L.pair <| (k.pair cg).pair n).comp Primrec.fst)
+      (Primrec.natPair.comp₂ (Primrec.snd.comp Primrec.fst) Primrec.snd).to₂).to₂
+  · exact
+      have L := (Primrec.fst.comp Primrec.fst).comp Primrec.fst
+      have k := k.comp Primrec.fst
+      have n := n.comp Primrec.fst
+      have cf := Primrec.fst.comp Primrec.snd
+      have cg := (Primrec.fst.comp Primrec.snd).comp Primrec.snd
+      Primrec.option_bind (hlup.comp <| L.pair <| (k.pair cg).pair n) <|
+      (hlup.comp <| (L.comp Primrec.fst).pair <|
+        ((k.pair cf).comp Primrec.fst).pair Primrec.snd).to₂
+  · exact
+      have L := (Primrec.fst.comp Primrec.fst).comp Primrec.fst
+      have k := k.comp Primrec.fst
+      have n := Primrec.unpair.comp (n.comp Primrec.fst)
+      have cf := Primrec.fst.comp Primrec.snd
+      have cg := (Primrec.fst.comp Primrec.snd).comp Primrec.snd
+      have z := Primrec.fst.comp n
+      Primrec.nat_casesOn (Primrec.snd.comp n)
+        (hlup.comp <| L.pair <| (k.pair cf).pair z) <|
+      have L := L.comp Primrec.fst
+      have z := z.comp Primrec.fst
+      have y := Primrec.snd
+      have h₁ := hlup.comp <| L.pair <| (((k'.pair c).comp Primrec.fst).comp Primrec.fst).pair
+        (Primrec.natPair.comp₂ z y)
+      Primrec.option_bind h₁ <|
+      have z := z.comp Primrec.fst
+      have y := y.comp Primrec.fst
+      have i := Primrec.snd
+      (hlup.comp ((L.comp Primrec.fst).pair <|
+        ((k.pair cg).comp <| Primrec.fst.comp Primrec.fst).pair <|
+          Primrec.natPair.comp₂ z <| Primrec.natPair.comp₂ y i) :)
+  · exact
+      have L := (Primrec.fst.comp Primrec.fst).comp Primrec.fst
+      have k := k.comp Primrec.fst
+      have n := Primrec.unpair.comp (n.comp Primrec.fst)
+      have cf := Primrec.fst.comp Primrec.snd
+      have z := Primrec.fst.comp n
+      have m := Primrec.snd.comp n
+      have h₁ := hlup.comp <| L.pair <| (k.pair cf).pair (Primrec.natPair.comp₂ z m)
+      Primrec.option_bind h₁ <|
+      have m := m.comp Primrec.fst
+      Primrec.nat_casesOn Primrec.snd (Primrec.option_some.comp m) <|
+      have := hlup.comp <| (L.comp Primrec.fst).pair <|
+        ((k'.pair c).comp <| Primrec.fst.comp Primrec.fst).pair <|
+        Primrec.natPair.comp₂ (z.comp Primrec.fst) (_root_.Primrec.succ.comp m)
+      (this.comp _root_.Primrec.fst).to₂
 
 private theorem evaln_map (k c n) :
     ((((List.range k).get? n).map (evaln k c)).bind fun b => b) = evaln k c n := by
-  by_cases kn : n < k
-  · simp [List.get?_range kn]
-  · rw [List.get?_len_le]
-    · cases e : evaln k c n
-      · rfl
-      exact kn.elim (evaln_bound e)
-    simpa using kn
+  if kn : n < k then simp [List.get?_range kn] else
+  rw [List.get?_len_le]
+  · cases e : evaln k c n <;> [rfl; exact kn.elim (evaln_bound e)]
+  · simpa using kn
 
 /-- The `Nat.Partrec.Code.evaln` function is primitive recursive. -/
-theorem evaln_prim : Primrec fun a : (ℕ × Code) × ℕ => evaln a.1.1 a.1.2 a.2 :=
-  have :
-    Primrec₂ fun (_ : Unit) (n : ℕ) =>
+theorem evaln_prim : Primrec fun a : (ℕ × Code) × ℕ => evaln a.1.1 a.1.2 a.2 := by
+  suffices Primrec₂ fun (_ : Unit) (n : ℕ) =>
       let a := ofNat (ℕ × Code) n
-      (List.range a.1).map (evaln a.1 a.2) :=
-    Primrec.nat_strong_rec _ (hG.comp Primrec.snd).to₂ fun _ p => by
-      simp only [G, prod_ofNat_val, ofNat_nat, List.length_map, List.length_range,
-        Nat.pair_unpair, Option.some_inj]
-      refine List.map_congr fun n => ?_
-      have : List.range p = List.range (Nat.pair p.unpair.1 (encode (ofNat Code p.unpair.2))) := by
-        simp
-      rw [this]
-      generalize p.unpair.1 = k
-      generalize ofNat Code p.unpair.2 = c
-      intro nk
-      cases' k with k'
-      · simp [evaln]
-      let k := k' + 1
-      simp only [show k'.succ = k from rfl]
-      simp? [Nat.lt_succ_iff] at nk says simp only [List.mem_range, Nat.lt_succ_iff] at nk
-      have hg :
-        ∀ {k' c' n},
-          Nat.pair k' (encode c') < Nat.pair k (encode c) →
-            lup ((List.range (Nat.pair k (encode c))).map fun n =>
-              (List.range n.unpair.1).map (evaln n.unpair.1 (ofNat Code n.unpair.2))) (k', c') n =
-            evaln k' c' n := by
-        intro k₁ c₁ n₁ hl
-        simp [lup, List.get?_range hl, evaln_map, Bind.bind]
-      cases' c with cf cg cf cg cf cg cf <;>
-        simp [evaln, nk, Bind.bind, Functor.map, Seq.seq, pure]
-      · cases' encode_lt_pair cf cg with lf lg
-        rw [hg (Nat.pair_lt_pair_right _ lf), hg (Nat.pair_lt_pair_right _ lg)]
-        cases evaln k cf n
-        · rfl
-        cases evaln k cg n <;> rfl
-      · cases' encode_lt_comp cf cg with lf lg
-        rw [hg (Nat.pair_lt_pair_right _ lg)]
-        cases evaln k cg n
-        · rfl
-        simp [hg (Nat.pair_lt_pair_right _ lf)]
-      · cases' encode_lt_prec cf cg with lf lg
-        rw [hg (Nat.pair_lt_pair_right _ lf)]
-        cases n.unpair.2
-        · rfl
-        simp only [decode_eq_ofNat, Option.some.injEq]
-        rw [hg (Nat.pair_lt_pair_left _ k'.lt_succ_self)]
-        cases evaln k' _ _
-        · rfl
-        simp [hg (Nat.pair_lt_pair_right _ lg)]
-      · have lf := encode_lt_rfind' cf
-        rw [hg (Nat.pair_lt_pair_right _ lf)]
-        cases' evaln k cf n with x
-        · rfl
-        simp only [decode_eq_ofNat, Option.some.injEq, Option.some_bind]
-        cases x <;> simp [Nat.succ_ne_zero]
-        rw [hg (Nat.pair_lt_pair_left _ k'.lt_succ_self)]
-  (Primrec.option_bind
-    (Primrec.list_get?.comp (this.comp (_root_.Primrec.const ())
-      (Primrec.encode_iff.2 Primrec.fst)) Primrec.snd) Primrec.snd.to₂).of_eq
-    fun ⟨⟨k, c⟩, n⟩ => by simp [evaln_map]
+      (List.range a.1).map (evaln a.1 a.2) from
+    (Primrec.option_bind
+      (Primrec.list_get?.comp₂ (this.comp₂ (_root_.Primrec.const ())
+        (Primrec.encode_iff.2 Primrec.fst)) Primrec.snd) Primrec.snd.to₂).of_eq
+      fun ⟨⟨k, c⟩, n⟩ => by simp [evaln_map]
+  refine Primrec.nat_strong_rec _ (hG.comp Primrec.snd).to₂ fun _ p => ?_
+  simp only [G, prod_ofNat_val, ofNat_nat, List.length_map, List.length_range,
+    Nat.pair_unpair, Option.some_inj]
+  refine List.map_congr fun n => ?_
+  have : List.range p = List.range (Nat.pair p.unpair.1 (encode (ofNat Code p.unpair.2))) := by
+    simp
+  rw [this]
+  generalize ofNat Code p.unpair.2 = c
+  match p.unpair.1 with | 0 => simp [evaln] | k' + 1 => ?_
+  set k := k' + 1
+  intro nk
+  simp only [List.mem_range, Nat.lt_succ_iff] at nk
+  have hg {k' c' n}
+      (hl : Nat.pair k' (encode c') < Nat.pair k (encode c)) :
+      lup ((List.range (Nat.pair k (encode c))).map fun n =>
+        (List.range n.unpair.1).map (evaln n.unpair.1 (ofNat Code n.unpair.2))) (k', c') n =
+        evaln k' c' n := by
+    simp [lup, List.get?_range hl, evaln_map, Bind.bind]
+  cases c with
+    simp only [bind, pure, evaln, nk, guard_true, unpaired, pair_unpair, Option.some_bind]
+  | pair cf cg =>
+    let ⟨lf, lg⟩ := encode_lt_pair cf cg
+    rw [hg (Nat.pair_lt_pair_right _ lf), hg (Nat.pair_lt_pair_right _ lg)]
+    cases evaln k cf n <;> [rfl; cases evaln k cg n <;> rfl]
+  | comp cf cg =>
+    let ⟨lf, lg⟩ := encode_lt_comp cf cg
+    rw [hg (Nat.pair_lt_pair_right _ lg)]
+    cases evaln k cg n <;> [rfl; simp [hg (Nat.pair_lt_pair_right _ lf)]]
+  | prec cf cg =>
+    let ⟨lf, lg⟩ := encode_lt_prec cf cg
+    rw [hg (Nat.pair_lt_pair_right _ lf)]
+    cases n.unpair.2 <;> [rfl; simp only [decode_eq_ofNat, Option.some.injEq]]
+    rw [hg (Nat.pair_lt_pair_left _ k'.lt_succ_self)]
+    cases evaln k' _ _ <;> [rfl; simp [hg (Nat.pair_lt_pair_right _ lg)]]
+  | rfind' cf =>
+    have lf := encode_lt_rfind' cf
+    rw [hg (Nat.pair_lt_pair_right _ lf)]
+    cases' evaln k cf n with x <;> [rfl; skip]
+    simp only [decode_eq_ofNat, Option.some.injEq, Option.some_bind]
+    cases x <;> simp only [rec_zero, reduceIte]
+    rw [hg (Nat.pair_lt_pair_left _ k'.lt_succ_self)]
 #align nat.partrec.code.evaln_prim Nat.Partrec.Code.evaln_prim
 
 end
@@ -1041,13 +970,13 @@ the same evaluation.
 theorem fixed_point {f : Code → Code} (hf : Computable f) : ∃ c : Code, eval (f c) = eval c :=
   let g (x y : ℕ) : Part ℕ := eval (ofNat Code x) x >>= fun b => eval (ofNat Code b) y
   have : Partrec₂ g :=
-    (eval_part.comp ((Computable.ofNat _).comp fst) fst).bind
-      (eval_part.comp ((Computable.ofNat _).comp snd) (snd.comp fst)).to₂
+    (eval_part.comp₂ ((Computable.ofNat _).comp fst) fst).bind
+      (eval_part.comp₂ ((Computable.ofNat _).comp snd) (snd.comp fst)).to₂
   let ⟨cg, eg⟩ := exists_code.1 this
   have eg' : ∀ a n, eval cg (Nat.pair a n) = Part.map encode (g a n) := by simp [eg]
   let F (x : ℕ) : Code := f (curry cg x)
   have : Computable F :=
-    hf.comp (curry_prim.comp (_root_.Primrec.const cg) _root_.Primrec.id).to_comp
+    hf.comp (curry_prim.comp₂ (_root_.Primrec.const cg) _root_.Primrec.id).to_comp
   let ⟨cF, eF⟩ := exists_code.1 this
   have eF' : eval cF (encode cF) = Part.some (encode (F (encode cF))) := by simp [eF]
   ⟨curry cg (encode cF),
@@ -1058,7 +987,7 @@ theorem fixed_point {f : Code → Code} (hf : Computable f) : ∃ c : Code, eval
 
 theorem fixed_point₂ {f : Code → ℕ →. ℕ} (hf : Partrec₂ f) : ∃ c : Code, eval c = f c :=
   let ⟨cf, ef⟩ := exists_code.1 hf
-  (fixed_point (curry_prim.comp (_root_.Primrec.const cf) Primrec.encode).to_comp).imp fun c e =>
+  (fixed_point (curry_prim.comp₂ (_root_.Primrec.const cf) Primrec.encode).to_comp).imp fun c e =>
     funext fun n => by simp [e.symm, ef, Part.map_id']
 #align nat.partrec.code.fixed_point₂ Nat.Partrec.Code.fixed_point₂
 

--- a/Mathlib/Computability/Primrec.lean
+++ b/Mathlib/Computability/Primrec.lean
@@ -29,7 +29,8 @@ for this.)
 -/
 
 
-open Denumerable Encodable Function
+open Encodable Function
+open Denumerable hiding pair
 
 namespace Nat
 
@@ -360,11 +361,10 @@ theorem snd {α β} [Primcodable α] [Primcodable β] : Primrec (@Prod.snd α β
 
 theorem pair {α β γ} [Primcodable α] [Primcodable β] [Primcodable γ] {f : α → β} {g : α → γ}
     (hf : Primrec f) (hg : Primrec g) : Primrec fun a => (f a, g a) :=
-  ((casesOn1 0
-            (Nat.Primrec.succ.comp <|
-              .pair (Nat.Primrec.pred.comp hf) (Nat.Primrec.pred.comp hg))).comp
-        (@Primcodable.prim α _)).of_eq
-    fun n => by cases @decode α _ n <;> simp [encodek]
+  ((casesOn1 0 <| Nat.Primrec.succ.comp <|
+      .pair (Nat.Primrec.pred.comp hf) (Nat.Primrec.pred.comp hg)).comp
+    (@Primcodable.prim α _))
+  |>.of_eq fun n => by cases @decode α _ n <;> simp [encodek]
 #align primrec.pair Primrec.pair
 
 theorem unpair : Primrec Nat.unpair :=
@@ -385,105 +385,86 @@ end Primrec
   This is technically unnecessary since we can always curry all
   the arguments together, but there are enough natural two-arg
   functions that it is convenient to express this directly. -/
-def Primrec₂ {α β σ} [Primcodable α] [Primcodable β] [Primcodable σ] (f : α → β → σ) :=
+abbrev Primrec₂ {α β σ} [Primcodable α] [Primcodable β] [Primcodable σ] (f : α → β → σ) :=
   Primrec fun p : α × β => f p.1 p.2
 #align primrec₂ Primrec₂
 
 /-- `PrimrecPred p` means `p : α → Prop` is a (decidable)
   primitive recursive predicate, which is to say that
   `decide ∘ p : α → Bool` is primitive recursive. -/
-def PrimrecPred {α} [Primcodable α] (p : α → Prop) [DecidablePred p] :=
+abbrev PrimrecPred {α} [Primcodable α] (p : α → Prop) [DecidablePred p] :=
   Primrec fun a => decide (p a)
 #align primrec_pred PrimrecPred
 
 /-- `PrimrecRel p` means `p : α → β → Prop` is a (decidable)
   primitive recursive relation, which is to say that
   `decide ∘ p : α → β → Bool` is primitive recursive. -/
-def PrimrecRel {α β} [Primcodable α] [Primcodable β] (s : α → β → Prop)
+abbrev PrimrecRel {α β} [Primcodable α] [Primcodable β] (s : α → β → Prop)
     [∀ a b, Decidable (s a b)] :=
   Primrec₂ fun a b => decide (s a b)
 #align primrec_rel PrimrecRel
 
-namespace Primrec₂
+namespace Primrec
 
 variable {α : Type*} {β : Type*} {σ : Type*}
 variable [Primcodable α] [Primcodable β] [Primcodable σ]
 
-theorem mk {f : α → β → σ} (hf : Primrec fun p : α × β => f p.1 p.2) : Primrec₂ f := hf
+#align primrec₂.of_eq Primrec.of_eq
+#align primrec₂.const Primrec.const
 
-theorem of_eq {f g : α → β → σ} (hg : Primrec₂ f) (H : ∀ a b, f a b = g a b) : Primrec₂ g :=
-  (by funext a b; apply H : f = g) ▸ hg
-#align primrec₂.of_eq Primrec₂.of_eq
-
-theorem const (x : σ) : Primrec₂ fun (_ : α) (_ : β) => x :=
-  Primrec.const _
-#align primrec₂.const Primrec₂.const
-
-protected theorem pair : Primrec₂ (@Prod.mk α β) :=
+protected theorem pair' : Primrec₂ (@Prod.mk α β) :=
   .pair .fst .snd
-#align primrec₂.pair Primrec₂.pair
+#align primrec₂.pair Primrec.pair'
 
-theorem left : Primrec₂ fun (a : α) (_ : β) => a :=
-  .fst
-#align primrec₂.left Primrec₂.left
-
-theorem right : Primrec₂ fun (_ : α) (b : β) => b :=
-  .snd
-#align primrec₂.right Primrec₂.right
+#align primrec₂.left Primrec.fst
+#align primrec₂.right Primrec.snd
 
 theorem natPair : Primrec₂ Nat.pair := by simp [Primrec₂, Primrec]; constructor
-#align primrec₂.mkpair Primrec₂.natPair
+#align primrec₂.mkpair Primrec.natPair
 
 theorem unpaired {f : ℕ → ℕ → α} : Primrec (Nat.unpaired f) ↔ Primrec₂ f :=
   ⟨fun h => by simpa using h.comp natPair, fun h => h.comp Primrec.unpair⟩
-#align primrec₂.unpaired Primrec₂.unpaired
+#align primrec₂.unpaired Primrec.unpaired
 
 theorem unpaired' {f : ℕ → ℕ → ℕ} : Nat.Primrec (Nat.unpaired f) ↔ Primrec₂ f :=
   Primrec.nat_iff.symm.trans unpaired
-#align primrec₂.unpaired' Primrec₂.unpaired'
+#align primrec₂.unpaired' Primrec.unpaired'
 
-theorem encode_iff {f : α → β → σ} : (Primrec₂ fun a b => encode (f a b)) ↔ Primrec₂ f :=
-  Primrec.encode_iff
-#align primrec₂.encode_iff Primrec₂.encode_iff
+-- theorem encode_iff {f : α → β → σ} : (Primrec₂ fun a b => encode (f a b)) ↔ Primrec₂ f :=
+--   Primrec.encode_iff
+-- #align primrec₂.encode_iff Primrec₂.encode_iff
 
-theorem option_some_iff {f : α → β → σ} : (Primrec₂ fun a b => some (f a b)) ↔ Primrec₂ f :=
-  Primrec.option_some_iff
-#align primrec₂.option_some_iff Primrec₂.option_some_iff
+-- theorem option_some_iff {f : α → β → σ} : (Primrec₂ fun a b => some (f a b)) ↔ Primrec₂ f :=
+--   Primrec.option_some_iff
+-- #align primrec₂.option_some_iff Primrec₂.option_some_iff
 
-theorem ofNat_iff {α β σ} [Denumerable α] [Denumerable β] [Primcodable σ] {f : α → β → σ} :
+theorem ofNat_iff₂ {α β σ} [Denumerable α] [Denumerable β] [Primcodable σ] {f : α → β → σ} :
     Primrec₂ f ↔ Primrec₂ fun m n : ℕ => f (ofNat α m) (ofNat β n) :=
   (Primrec.ofNat_iff.trans <| by simp).trans unpaired
-#align primrec₂.of_nat_iff Primrec₂.ofNat_iff
+#align primrec₂.of_nat_iff Primrec.ofNat_iff₂
 
 theorem uncurry {f : α → β → σ} : Primrec (Function.uncurry f) ↔ Primrec₂ f := by
-  rw [show Function.uncurry f = fun p : α × β => f p.1 p.2 from funext fun ⟨a, b⟩ => rfl]; rfl
-#align primrec₂.uncurry Primrec₂.uncurry
+  rw [show Function.uncurry f = fun p : α × β => f p.1 p.2 from funext fun ⟨a, b⟩ => rfl]
+#align primrec₂.uncurry Primrec.uncurry
 
 theorem curry {f : α × β → σ} : Primrec₂ (Function.curry f) ↔ Primrec f := by
   rw [← uncurry, Function.uncurry_curry]
-#align primrec₂.curry Primrec₂.curry
+#align primrec₂.curry Primrec.curry
 
-end Primrec₂
+end Primrec
 
 section Comp
 
 variable {α : Type*} {β : Type*} {γ : Type*} {δ : Type*} {σ : Type*}
 variable [Primcodable α] [Primcodable β] [Primcodable γ] [Primcodable δ] [Primcodable σ]
 
-theorem Primrec.comp₂ {f : γ → σ} {g : α → β → γ} (hf : Primrec f) (hg : Primrec₂ g) :
-    Primrec₂ fun a b => f (g a b) :=
-  hf.comp hg
-#align primrec.comp₂ Primrec.comp₂
+#align primrec.comp₂ Primrec.comp
 
-theorem Primrec₂.comp {f : β → γ → σ} {g : α → β} {h : α → γ} (hf : Primrec₂ f) (hg : Primrec g)
-    (hh : Primrec h) : Primrec fun a => f (g a) (h a) :=
+theorem Primrec.comp₂ {f : β × γ → σ} {g : α → β} {h : α → γ} (hf : Primrec f) (hg : Primrec g)
+    (hh : Primrec h) : Primrec fun a => f (g a, h a) :=
   Primrec.comp hf (hg.pair hh)
-#align primrec₂.comp Primrec₂.comp
-
-theorem Primrec₂.comp₂ {f : γ → δ → σ} {g : α → β → γ} {h : α → β → δ} (hf : Primrec₂ f)
-    (hg : Primrec₂ g) (hh : Primrec₂ h) : Primrec₂ fun a b => f (g a b) (h a b) :=
-  hf.comp hg hh
-#align primrec₂.comp₂ Primrec₂.comp₂
+#align primrec₂.comp Primrec.comp₂
+#align primrec₂.comp₂ Primrec.comp₂
 
 theorem PrimrecPred.comp {p : β → Prop} [DecidablePred p] {f : α → β} :
     PrimrecPred p → Primrec f → PrimrecPred fun a => p (f a) :=
@@ -492,29 +473,24 @@ theorem PrimrecPred.comp {p : β → Prop} [DecidablePred p] {f : α → β} :
 
 theorem PrimrecRel.comp {R : β → γ → Prop} [∀ a b, Decidable (R a b)] {f : α → β} {g : α → γ} :
     PrimrecRel R → Primrec f → Primrec g → PrimrecPred fun a => R (f a) (g a) :=
-  Primrec₂.comp
+  Primrec.comp₂
 #align primrec_rel.comp PrimrecRel.comp
-
-theorem PrimrecRel.comp₂ {R : γ → δ → Prop} [∀ a b, Decidable (R a b)] {f : α → β → γ}
-    {g : α → β → δ} :
-    PrimrecRel R → Primrec₂ f → Primrec₂ g → PrimrecRel fun a b => R (f a b) (g a b) :=
-  PrimrecRel.comp
-#align primrec_rel.comp₂ PrimrecRel.comp₂
+#align primrec_rel.comp₂ PrimrecRel.comp
 
 end Comp
 
-theorem PrimrecPred.of_eq {α} [Primcodable α] {p q : α → Prop} [DecidablePred p] [DecidablePred q]
+theorem Primrec.of_eq_pred {α} [Primcodable α] {p q : α → Prop} [DecidablePred p] [DecidablePred q]
     (hp : PrimrecPred p) (H : ∀ a, p a ↔ q a) : PrimrecPred q :=
   Primrec.of_eq hp fun a => Bool.decide_congr (H a)
-#align primrec_pred.of_eq PrimrecPred.of_eq
+#align primrec_pred.of_eq Primrec.of_eq_pred
 
-theorem PrimrecRel.of_eq {α β} [Primcodable α] [Primcodable β] {r s : α → β → Prop}
+theorem Primrec.of_eq_rel {α β} [Primcodable α] [Primcodable β] {r s : α → β → Prop}
     [∀ a b, Decidable (r a b)] [∀ a b, Decidable (s a b)] (hr : PrimrecRel r)
     (H : ∀ a b, r a b ↔ s a b) : PrimrecRel s :=
-  Primrec₂.of_eq hr fun a b => Bool.decide_congr (H a b)
-#align primrec_rel.of_eq PrimrecRel.of_eq
+  Primrec.of_eq hr fun (a, b) => Bool.decide_congr (H a b)
+#align primrec_rel.of_eq Primrec.of_eq_rel
 
-namespace Primrec₂
+namespace Primrec
 
 variable {α : Type*} {β : Type*} {σ : Type*}
 variable [Primcodable α] [Primcodable β] [Primcodable σ]
@@ -522,10 +498,10 @@ variable [Primcodable α] [Primcodable β] [Primcodable σ]
 open Nat.Primrec
 
 theorem swap {f : α → β → σ} (h : Primrec₂ f) : Primrec₂ (swap f) :=
-  h.comp₂ Primrec₂.right Primrec₂.left
-#align primrec₂.swap Primrec₂.swap
+  h.comp₂ Primrec.snd Primrec.fst
+#align primrec₂.swap Primrec.swap
 
-theorem nat_iff {f : α → β → σ} : Primrec₂ f ↔ Nat.Primrec
+theorem nat_iff₂ {f : α → β → σ} : Primrec₂ f ↔ Nat.Primrec
     (.unpaired fun m n => encode <| (@decode α _ m).bind fun a => (@decode β _ n).map (f a)) := by
   have :
     ∀ (a : Option α) (b : Option β),
@@ -534,28 +510,20 @@ theorem nat_iff {f : α → β → σ} : Primrec₂ f ↔ Nat.Primrec
         Option.bind a fun a => Option.map (f a) b := fun a b => by
           cases a <;> cases b <;> rfl
   simp [Primrec₂, Primrec, this]
-#align primrec₂.nat_iff Primrec₂.nat_iff
+#align primrec₂.nat_iff Primrec.nat_iff₂
 
-theorem nat_iff' {f : α → β → σ} :
+theorem nat_iff₂' {f : α → β → σ} :
     Primrec₂ f ↔
       Primrec₂ fun m n : ℕ => (@decode α _ m).bind fun a => Option.map (f a) (@decode β _ n) :=
-  nat_iff.trans <| unpaired'.trans encode_iff
-#align primrec₂.nat_iff' Primrec₂.nat_iff'
+  nat_iff₂.trans <| unpaired'.trans encode_iff
+#align primrec₂.nat_iff' Primrec.nat_iff₂'
 
-end Primrec₂
-
-namespace Primrec
-
-variable {α : Type*} {β : Type*} {γ : Type*} {δ : Type*} {σ : Type*}
-variable [Primcodable α] [Primcodable β] [Primcodable γ] [Primcodable δ] [Primcodable σ]
-
-theorem to₂ {f : α × β → σ} (hf : Primrec f) : Primrec₂ fun a b => f (a, b) :=
-  hf.of_eq fun _ => rfl
+theorem to₂ {f : α × β → σ} (hf : Primrec f) : Primrec₂ fun a b => f (a, b) := hf
 #align primrec.to₂ Primrec.to₂
 
 theorem nat_rec {f : α → β} {g : α → ℕ × β → β} (hf : Primrec f) (hg : Primrec₂ g) :
     Primrec₂ fun a (n : ℕ) => n.rec (motive := fun _ => β) (f a) fun n IH => g a (n, IH) :=
-  Primrec₂.nat_iff.2 <|
+  Primrec.nat_iff₂.2 <|
     ((Nat.Primrec.casesOn' .zero <|
               (Nat.Primrec.prec hf <|
                     .comp hg <|
@@ -577,44 +545,41 @@ theorem nat_rec {f : α → β} {g : α → ℕ × β → β} (hf : Primrec f) (
 theorem nat_rec' {f : α → ℕ} {g : α → β} {h : α → ℕ × β → β}
     (hf : Primrec f) (hg : Primrec g) (hh : Primrec₂ h) :
     Primrec fun a => (f a).rec (motive := fun _ => β) (g a) fun n IH => h a (n, IH) :=
-  (nat_rec hg hh).comp .id hf
+  (nat_rec hg hh).comp₂ .id hf
 #align primrec.nat_elim' Primrec.nat_rec'
 
 theorem nat_rec₁ {f : ℕ → α → α} (a : α) (hf : Primrec₂ f) : Primrec (Nat.rec a f) :=
-  nat_rec' .id (const a) <| comp₂ hf Primrec₂.right
+  nat_rec' .id (const a) (hf.comp snd).to₂
 #align primrec.nat_elim₁ Primrec.nat_rec₁
 
 theorem nat_casesOn' {f : α → β} {g : α → ℕ → β} (hf : Primrec f) (hg : Primrec₂ g) :
     Primrec₂ fun a (n : ℕ) => (n.casesOn (f a) (g a) : β) :=
-  nat_rec hf <| hg.comp₂ Primrec₂.left <| comp₂ fst Primrec₂.right
+  nat_rec hf (hg.comp₂ fst <| comp fst snd).to₂
 #align primrec.nat_cases' Primrec.nat_casesOn'
 
 theorem nat_casesOn {f : α → ℕ} {g : α → β} {h : α → ℕ → β} (hf : Primrec f) (hg : Primrec g)
     (hh : Primrec₂ h) : Primrec fun a => ((f a).casesOn (g a) (h a) : β) :=
-  (nat_casesOn' hg hh).comp .id hf
+  (nat_casesOn' hg hh.to₂).comp₂ .id hf
 #align primrec.nat_cases Primrec.nat_casesOn
 
 theorem nat_casesOn₁ {f : ℕ → α} (a : α) (hf : Primrec f) :
     Primrec (fun (n : ℕ) => (n.casesOn a f : α)) :=
-  nat_casesOn .id (const a) (comp₂ hf .right)
+  nat_casesOn .id (const a) (comp hf .snd)
 #align primrec.nat_cases₁ Primrec.nat_casesOn₁
 
 theorem nat_iterate {f : α → ℕ} {g : α → β} {h : α → β → β} (hf : Primrec f) (hg : Primrec g)
     (hh : Primrec₂ h) : Primrec fun a => (h a)^[f a] (g a) :=
-  (nat_rec' hf hg (hh.comp₂ Primrec₂.left <| snd.comp₂ Primrec₂.right)).of_eq fun a => by
+  (nat_rec' hf hg (hh.comp₂ fst <| snd.comp snd).to₂).of_eq fun a => by
     induction f a <;> simp [*, -Function.iterate_succ, Function.iterate_succ']
 #align primrec.nat_iterate Primrec.nat_iterate
 
 theorem option_casesOn {o : α → Option β} {f : α → σ} {g : α → β → σ} (ho : Primrec o)
     (hf : Primrec f) (hg : Primrec₂ g) :
-    @Primrec _ σ _ _ fun a => Option.casesOn (o a) (f a) (g a) :=
+    Primrec (β := σ) fun a => Option.casesOn (o a) (f a) (g a) :=
   encode_iff.1 <|
-    (nat_casesOn (encode_iff.2 ho) (encode_iff.2 hf) <|
-          pred.comp₂ <|
-            Primrec₂.encode_iff.2 <|
-              (Primrec₂.nat_iff'.1 hg).comp₂ ((@Primrec.encode α _).comp fst).to₂
-                Primrec₂.right).of_eq
-      fun a => by cases' o a with b <;> simp [encodek]
+    (nat_casesOn (encode_iff.2 ho) (encode_iff.2 hf) <| to₂ <| pred.comp <| encode_iff.2 <|
+      (nat_iff₂'.1 hg.to₂).comp₂ ((@Primrec.encode α _).comp fst) snd).of_eq
+    fun a => by cases' o a with b <;> simp [encodek]
 #align primrec.option_cases Primrec.option_casesOn
 
 theorem option_bind {f : α → Option β} {g : α → β → Option σ} (hf : Primrec f) (hg : Primrec₂ g) :
@@ -628,7 +593,7 @@ theorem option_bind₁ {f : α → Option σ} (hf : Primrec f) : Primrec fun o =
 
 theorem option_map {f : α → Option β} {g : α → β → σ} (hf : Primrec f) (hg : Primrec₂ g) :
     Primrec fun a => (f a).map (g a) :=
-  (option_bind hf (option_some.comp₂ hg)).of_eq fun x => by cases f x <;> rfl
+  (option_bind hf (option_some.comp hg)).of_eq fun x => by cases f x <;> rfl
 #align primrec.option_map Primrec.option_map
 
 theorem option_map₁ {f : α → σ} (hf : Primrec f) : Primrec (Option.map f) :=
@@ -636,7 +601,7 @@ theorem option_map₁ {f : α → σ} (hf : Primrec f) : Primrec (Option.map f) 
 #align primrec.option_map₁ Primrec.option_map₁
 
 theorem option_iget [Inhabited α] : Primrec (@Option.iget α _) :=
-  (option_casesOn .id (const <| @default α _) .right).of_eq fun o => by cases o <;> rfl
+  (option_casesOn .id (const <| @default α _) snd.to₂).of_eq fun o => by cases o <;> rfl
 #align primrec.option_iget Primrec.option_iget
 
 theorem option_isSome : Primrec (@Option.isSome α) :=
@@ -644,33 +609,33 @@ theorem option_isSome : Primrec (@Option.isSome α) :=
 #align primrec.option_is_some Primrec.option_isSome
 
 theorem option_getD : Primrec₂ (@Option.getD α) :=
-  Primrec.of_eq (option_casesOn Primrec₂.left Primrec₂.right .right) fun ⟨o, a⟩ => by
+  Primrec.of_eq (option_casesOn fst snd snd.to₂) fun ⟨o, a⟩ => by
     cases o <;> rfl
 #align primrec.option_get_or_else Primrec.option_getD
 
 theorem bind_decode_iff {f : α → β → Option σ} :
     (Primrec₂ fun a n => (@decode β _ n).bind (f a)) ↔ Primrec₂ f :=
-  ⟨fun h => by simpa [encodek] using h.comp fst ((@Primrec.encode β _).comp snd), fun h =>
-    option_bind (Primrec.decode.comp snd) <| h.comp (fst.comp fst) snd⟩
+  ⟨fun h => by simpa [encodek] using h.comp₂ fst ((@Primrec.encode β _).comp snd), fun h =>
+    option_bind (Primrec.decode.comp snd) <| h.comp₂ (fst.comp fst) snd⟩
 #align primrec.bind_decode_iff Primrec.bind_decode_iff
 
 theorem map_decode_iff {f : α → β → σ} :
     (Primrec₂ fun a n => (@decode β _ n).map (f a)) ↔ Primrec₂ f := by
   simp only [Option.map_eq_bind]
-  exact bind_decode_iff.trans Primrec₂.option_some_iff
+  exact bind_decode_iff.trans Primrec.option_some_iff
 
 #align primrec.map_decode_iff Primrec.map_decode_iff
 
 theorem nat_add : Primrec₂ ((· + ·) : ℕ → ℕ → ℕ) :=
-  Primrec₂.unpaired'.1 Nat.Primrec.add
+  Primrec.unpaired'.1 Nat.Primrec.add
 #align primrec.nat_add Primrec.nat_add
 
 theorem nat_sub : Primrec₂ ((· - ·) : ℕ → ℕ → ℕ) :=
-  Primrec₂.unpaired'.1 Nat.Primrec.sub
+  Primrec.unpaired'.1 Nat.Primrec.sub
 #align primrec.nat_sub Primrec.nat_sub
 
 theorem nat_mul : Primrec₂ ((· * ·) : ℕ → ℕ → ℕ) :=
-  Primrec₂.unpaired'.1 Nat.Primrec.mul
+  Primrec.unpaired'.1 Nat.Primrec.mul
 #align primrec.nat_mul Primrec.nat_mul
 
 theorem cond {c : α → Bool} {f : α → σ} {g : α → σ} (hc : Primrec c) (hf : Primrec f)
@@ -727,12 +692,12 @@ theorem _root_.PrimrecPred.not {p : α → Prop} [DecidablePred p] (hp : Primrec
 
 theorem _root_.PrimrecPred.and {p q : α → Prop} [DecidablePred p] [DecidablePred q]
     (hp : PrimrecPred p) (hq : PrimrecPred q) : PrimrecPred fun a => p a ∧ q a :=
-  (Primrec.and.comp hp hq).of_eq fun n => by simp
+  (Primrec.and.comp₂ hp hq).of_eq fun n => by simp
 #align primrec.and PrimrecPred.and
 
 theorem _root_.PrimrecPred.or {p q : α → Prop} [DecidablePred p] [DecidablePred q]
     (hp : PrimrecPred p) (hq : PrimrecPred q) : PrimrecPred fun a => p a ∨ q a :=
-  (Primrec.or.comp hp hq).of_eq fun n => by simp
+  (Primrec.or.comp₂ hp hq).of_eq fun n => by simp
 #align primrec.or PrimrecPred.or
 
 -- Porting note: It is unclear whether we want to boolean versions
@@ -742,8 +707,8 @@ theorem _root_.PrimrecPred.or {p q : α → Prop} [DecidablePred p] [DecidablePr
 protected theorem beq [DecidableEq α] : Primrec₂ (@BEq.beq α _) :=
   have : PrimrecRel fun a b : ℕ => a = b :=
     (PrimrecPred.and nat_le nat_le.swap).of_eq fun a => by simp [le_antisymm_iff]
-  (this.comp₂ (Primrec.encode.comp₂ Primrec₂.left) (Primrec.encode.comp₂ Primrec₂.right)).of_eq
-    fun a b => encode_injective.eq_iff
+  (this.comp₂ (Primrec.encode.comp fst) (Primrec.encode.comp snd)).of_eq_pred
+    fun _ => encode_injective.eq_iff
 
 protected theorem eq [DecidableEq α] : PrimrecRel (@Eq α) := Primrec.beq
 #align primrec.eq Primrec.eq
@@ -762,15 +727,15 @@ theorem option_orElse : Primrec₂ ((· <|> ·) : Option α → Option α → Op
 #align primrec.option_orelse Primrec.option_orElse
 
 protected theorem decode₂ : Primrec (decode₂ α) :=
-  option_bind .decode <|
-    option_guard (Primrec.beq.comp₂ (by exact encode_iff.mpr snd) (by exact fst.comp fst)) snd
+  (option_bind (σ := α) .decode <| to₂ <| option_guard (p := fun n a => encode a = n.1)
+    (Primrec.eq.comp (encode_iff.mpr snd) (fst.comp fst)) snd :)
 #align primrec.decode₂ Primrec.decode₂
 
 theorem list_findIdx₁ {p : α → β → Bool} (hp : Primrec₂ p) :
     ∀ l : List β, Primrec fun a => l.findIdx (p a)
 | [] => const 0
-| a :: l => (cond (hp.comp .id (const a)) (const 0) (succ.comp (list_findIdx₁ hp l))).of_eq fun n =>
-  by simp [List.findIdx_cons]
+| a :: l => cond (hp.comp₂ .id (const a)) (const 0) (succ.comp (list_findIdx₁ hp l))
+  |>.of_eq fun n => by simp [List.findIdx_cons]
 #align primrec.list_find_index₁ Primrec.list_findIdx₁
 
 theorem list_indexOf₁ [DecidableEq α] (l : List α) : Primrec fun a => l.indexOf a :=
@@ -785,13 +750,6 @@ theorem dom_fintype [Finite α] (f : α → σ) : Primrec f :=
     rw [List.get?_map, List.indexOf_get? (m a), Option.map_some']
 #align primrec.dom_fintype Primrec.dom_fintype
 
--- Porting note: These are new lemmas
--- I added it because it actually simplified the proofs
--- and because I couldn't understand the original proof
-/-- A function is `PrimrecBounded` if its size is bounded by a primitive recursive function -/
-def PrimrecBounded (f : α → β) : Prop :=
-  ∃ g : α → ℕ, Primrec g ∧ ∀ x, encode (f x) ≤ g x
-
 theorem nat_findGreatest {f : α → ℕ} {p : α → ℕ → Prop} [∀ x n, Decidable (p x n)]
     (hf : Primrec f) (hp : PrimrecRel p) : Primrec fun x => (f x).findGreatest (p x) :=
   (nat_rec' (h := fun x nih => if p x (nih.1 + 1) then nih.1 + 1 else nih.2)
@@ -801,23 +759,22 @@ theorem nat_findGreatest {f : α → ℕ} {p : α → ℕ → Prop} [∀ x n, De
 
 /-- To show a function `f : α → ℕ` is primitive recursive, it is enough to show that the function
   is bounded by a primitive recursive function and that its graph is primitive recursive -/
-theorem of_graph {f : α → ℕ} (h₁ : PrimrecBounded f)
+theorem of_graph {f g : α → ℕ} (hg : Primrec g) (bdd : ∀ x, encode (f x) ≤ g x)
     (h₂ : PrimrecRel fun a b => f a = b) : Primrec f := by
-  rcases h₁ with ⟨g, pg, hg : ∀ x, f x ≤ g x⟩
-  refine (nat_findGreatest pg h₂).of_eq fun n => ?_
-  exact (Nat.findGreatest_spec (P := fun b => f n = b) (hg n) rfl).symm
+  refine (nat_findGreatest hg h₂).of_eq fun n => ?_
+  exact (Nat.findGreatest_spec (P := fun b => f n = b) (bdd n) rfl).symm
 
 -- We show that division is primitive recursive by showing that the graph is
 theorem nat_div : Primrec₂ ((· / ·) : ℕ → ℕ → ℕ) := by
-  refine of_graph ⟨_, fst, fun p => Nat.div_le_self _ _⟩ ?_
+  refine of_graph fst (fun p => Nat.div_le_self _ _) ?_
   have : PrimrecRel fun (a : ℕ × ℕ) (b : ℕ) => (a.2 = 0 ∧ b = 0) ∨
       (0 < a.2 ∧ b * a.2 ≤ a.1 ∧ a.1 < (b + 1) * a.2) :=
     PrimrecPred.or
       (.and (const 0 |> Primrec.eq.comp (fst |> snd.comp)) (const 0 |> Primrec.eq.comp snd))
       (.and (nat_lt.comp (const 0) (fst |> snd.comp)) <|
-          .and (nat_le.comp (nat_mul.comp snd (fst |> snd.comp)) (fst |> fst.comp))
-          (nat_lt.comp (fst.comp fst) (nat_mul.comp (Primrec.succ.comp snd) (snd.comp fst))))
-  refine this.of_eq ?_
+          .and (nat_le.comp (nat_mul.comp₂ snd (fst |> snd.comp)) (fst |> fst.comp))
+          (nat_lt.comp (fst.comp fst) (nat_mul.comp₂ (Primrec.succ.comp snd) (snd.comp fst))))
+  refine this.of_eq_rel ?_
   rintro ⟨a, k⟩ q
   if H : k = 0 then simp [H, eq_comm]
   else
@@ -828,18 +785,18 @@ theorem nat_div : Primrec₂ ((· / ·) : ℕ → ℕ → ℕ) := by
 #align primrec.nat_div Primrec.nat_div
 
 theorem nat_mod : Primrec₂ ((· % ·) : ℕ → ℕ → ℕ) :=
-  (nat_sub.comp fst (nat_mul.comp snd nat_div)).to₂.of_eq fun m n => by
+  (nat_sub.comp₂ fst (nat_mul.comp₂ snd nat_div)).of_eq fun (m, n) => by
     apply Nat.sub_eq_of_eq_add
     simp [add_comm (m % n), Nat.div_add_mod]
 #align primrec.nat_mod Primrec.nat_mod
 
 theorem nat_bodd : Primrec Nat.bodd :=
-  (Primrec.beq.comp (nat_mod.comp .id (const 2)) (const 1)).of_eq fun n => by
+  (Primrec.beq.comp₂ (nat_mod.comp₂ .id (const 2)) (const 1)).of_eq fun n => by
     cases H : n.bodd <;> simp [Nat.mod_two_of_bodd, H]
 #align primrec.nat_bodd Primrec.nat_bodd
 
 theorem nat_div2 : Primrec Nat.div2 :=
-  (nat_div.comp .id (const 2)).of_eq fun n => n.div2_val.symm
+  (nat_div.comp₂ .id (const 2)).of_eq fun n => n.div2_val.symm
 #align primrec.nat_div2 Primrec.nat_div2
 
 -- Porting note: this is no longer used
@@ -848,7 +805,7 @@ theorem nat_div2 : Primrec Nat.div2 :=
 
 -- Porting note: bit0 is deprecated
 theorem nat_double : Primrec (fun n : ℕ => 2 * n) :=
-  nat_mul.comp (const _) Primrec.id
+  nat_mul.comp₂ (const _) Primrec.id
 #align primrec.nat_bit0 Primrec.nat_double
 
 -- Porting note: bit1 is deprecated
@@ -876,13 +833,8 @@ private theorem list_casesOn' {f : α → List β} {g : α → σ} {h : α → �
     (hf : haveI := prim H; Primrec f) (hg : Primrec g) (hh : haveI := prim H; Primrec₂ h) :
     @Primrec _ σ _ _ fun a => List.casesOn (f a) (g a) fun b l => h a (b, l) :=
   letI := prim H
-  have :
-    @Primrec _ (Option σ) _ _ fun a =>
-      (@decode (Option (β × List β)) _ (encode (f a))).map fun o => Option.casesOn o (g a) (h a) :=
-    ((@map_decode_iff _ (Option (β × List β)) _ _ _ _ _).2 <|
-      to₂ <|
-        option_casesOn snd (hg.comp fst) (hh.comp₂ (fst.comp₂ Primrec₂.left) Primrec₂.right)).comp
-      .id (encode_iff.2 hf)
+  have := option_casesOn snd (hg.comp fst) (hh.comp₂ (fst.comp fst) snd).to₂
+  have := (map_decode_iff.2 this.to₂).comp₂ .id (encode_iff.2 hf)
   option_some_iff.1 <| this.of_eq fun a => by cases' f a with b l <;> simp [encodek]
 
 private theorem list_foldl' {f : α → List β} {g : α → σ} {h : α → σ × β → σ}
@@ -890,10 +842,8 @@ private theorem list_foldl' {f : α → List β} {g : α → σ} {h : α → σ 
     Primrec fun a => (f a).foldl (fun s b => h a (s, b)) (g a) := by
   letI := prim H
   let G (a : α) (IH : σ × List β) : σ × List β := List.casesOn IH.2 IH fun b l => (h a (IH.1, b), l)
-  have hG : Primrec₂ G := list_casesOn' H (snd.comp snd) snd <|
-    to₂ <|
-    pair (hh.comp (fst.comp fst) <| pair ((fst.comp snd).comp fst) (fst.comp snd))
-      (snd.comp snd)
+  have hG : Primrec₂ G := list_casesOn' H (snd.comp snd) snd <| to₂ <|
+    pair (hh.comp₂ (fst.comp fst) <| pair ((fst.comp snd).comp fst) (fst.comp snd)) (snd.comp snd)
   let F := fun (a : α) (n : ℕ) => (G a)^[n] (g a, f a)
   have hF : Primrec fun a => (F a (encode (f a))).1 :=
     (fst.comp <|
@@ -913,13 +863,13 @@ private theorem list_foldl' {f : α → List β} {g : α → σ} {h : α → σ 
 
 private theorem list_cons' : (haveI := prim H; Primrec₂ (@List.cons β)) :=
   letI := prim H
-  encode_iff.1 (succ.comp <| Primrec₂.natPair.comp (encode_iff.2 fst) (encode_iff.2 snd))
+  encode_iff.1 (succ.comp <| Primrec.natPair.comp₂ (encode_iff.2 fst) (encode_iff.2 snd))
 
 private theorem list_reverse' :
     haveI := prim H
     Primrec (@List.reverse β) :=
   letI := prim H
-  (list_foldl' H .id (const []) <| to₂ <| ((list_cons' H).comp snd fst).comp snd).of_eq
+  (list_foldl' H .id (const []) <| to₂ <| ((list_cons' H).comp₂ snd fst).comp snd).of_eq
     (suffices ∀ l r, List.foldl (fun (s : List β) (b : β) => b :: s) r l = List.reverseAux l r from
       fun l => this l []
     fun l => by induction l <;> simp [*, List.reverseAux])
@@ -952,13 +902,13 @@ instance sum : Primcodable (Sum α β) :=
 instance list : Primcodable (List α) :=
   ⟨letI H := @Primcodable.prim (List ℕ) _
     have : Primrec₂ fun (a : α) (o : Option (List ℕ)) => o.map (List.cons (encode a)) :=
-      option_map snd <| (list_cons' H).comp ((@Primrec.encode α _).comp (fst.comp fst)) snd
+      option_map snd <| (list_cons' H).comp₂ ((@Primrec.encode α _).comp (fst.comp fst)) snd
     have :
       Primrec fun n =>
         (ofNat (List ℕ) n).reverse.foldl
           (fun o m => (@decode α _ m).bind fun a => o.map (List.cons (encode a))) (some []) :=
       list_foldl' H ((list_reverse' H).comp (.ofNat (List ℕ))) (const (some []))
-        (Primrec.comp₂ (bind_decode_iff.2 <| .swap this) Primrec₂.right)
+        (Primrec.comp (bind_decode_iff.2 <| .swap this) snd).to₂
     nat_iff.1 <|
       (encode_iff.2 this).of_eq fun n => by
         rw [List.foldl_reverse]
@@ -1025,7 +975,7 @@ theorem list_reverse : Primrec (@List.reverse α) :=
 theorem list_foldr {f : α → List β} {g : α → σ} {h : α → β × σ → σ} (hf : Primrec f)
     (hg : Primrec g) (hh : Primrec₂ h) :
     Primrec fun a => (f a).foldr (fun b s => h a (b, s)) (g a) :=
-  (list_foldl (list_reverse.comp hf) hg <| to₂ <| hh.comp fst <| (pair snd fst).comp snd).of_eq
+  (list_foldl (list_reverse.comp hf) hg <| to₂ <| hh.comp₂ fst <| (pair snd fst).comp snd).of_eq
     fun a => by simp [List.foldl_reverse]
 #align primrec.list_foldr Primrec.list_foldr
 
@@ -1048,7 +998,7 @@ theorem list_rec {f : α → List β} {g : α → σ} {h : α → β × List β 
   let F (a : α) := (f a).foldr (fun (b : β) (s : List β × σ) => (b :: s.1, h a (b, s))) ([], g a)
   have : Primrec F :=
     list_foldr hf (pair (const []) hg) <|
-      to₂ <| pair ((list_cons.comp fst (fst.comp snd)).comp snd) hh
+      to₂ <| pair ((list_cons.comp₂ fst (fst.comp snd)).comp snd) hh
   (snd.comp this).of_eq fun a => by
     suffices F a = (f a, List.recOn (f a) (g a) fun b l IH => h a (b, l, IH)) by rw [this]
     dsimp [F]
@@ -1069,7 +1019,7 @@ theorem list_get? : Primrec₂ (@List.get? α) :=
   have :
     @Primrec _ (Option α) _ _ fun p : List α × ℕ => Sum.casesOn (F p.1 p.2) (fun _ => none) some :=
     sum_casesOn hF (const none).to₂ (option_some.comp snd).to₂
-  this.to₂.of_eq fun l n => by
+  this.of_eq fun (l, n) => by
     dsimp; symm
     induction' l with a l IH generalizing n; · rfl
     cases' n with n
@@ -1089,23 +1039,23 @@ theorem list_getI [Inhabited α] : Primrec₂ (@List.getI α _) :=
 #align primrec.list_inth Primrec.list_getI
 
 theorem list_append : Primrec₂ ((· ++ ·) : List α → List α → List α) :=
-  (list_foldr fst snd <| to₂ <| comp (@list_cons α _) snd).to₂.of_eq fun l₁ l₂ => by
+  (list_foldr fst snd <| to₂ <| comp (@list_cons α _) snd).of_eq fun (l₁, l₂) => by
     induction l₁ <;> simp [*]
 #align primrec.list_append Primrec.list_append
 
 theorem list_concat : Primrec₂ fun l (a : α) => l ++ [a] :=
-  list_append.comp fst (list_cons.comp snd (const []))
+  list_append.comp₂ fst (list_cons.comp₂ snd (const []))
 #align primrec.list_concat Primrec.list_concat
 
 theorem list_map {f : α → List β} {g : α → β → σ} (hf : Primrec f) (hg : Primrec₂ g) :
     Primrec fun a => (f a).map (g a) :=
   (list_foldr hf (const []) <|
-        to₂ <| list_cons.comp (hg.comp fst (fst.comp snd)) (snd.comp snd)).of_eq
+        to₂ <| list_cons.comp₂ (hg.comp₂ fst (fst.comp snd)) (snd.comp snd)).of_eq
     fun a => by induction f a <;> simp [*]
 #align primrec.list_map Primrec.list_map
 
 theorem list_range : Primrec List.range :=
-  (nat_rec' .id (const []) ((list_concat.comp snd fst).comp snd).to₂).of_eq fun n => by
+  (nat_rec' .id (const []) ((list_concat.comp₂ snd fst).comp snd).to₂).of_eq fun n => by
     simp; induction n <;> simp [*, List.range_succ]
 #align primrec.list_range Primrec.list_range
 
@@ -1118,14 +1068,13 @@ theorem list_bind {f : α → List β} {g : α → β → List σ} (hf : Primrec
     Primrec (fun a => (f a).bind (g a)) := list_join.comp (list_map hf hg)
 
 theorem optionToList : Primrec (Option.toList : Option α → List α) :=
-  (option_casesOn Primrec.id (const [])
-    ((list_cons.comp Primrec.id (const [])).comp₂ Primrec₂.right)).of_eq
-  (fun o => by rcases o <;> simp)
+  (option_casesOn Primrec.id (const []) <| to₂ <|
+    (list_cons.comp₂ Primrec.id (const [])).comp snd)
+  |>.of_eq fun o => by rcases o <;> simp
 
 theorem listFilterMap {f : α → List β} {g : α → β → Option σ}
     (hf : Primrec f) (hg : Primrec₂ g) : Primrec fun a => (f a).filterMap (g a) :=
-  (list_bind hf (comp₂ optionToList hg)).of_eq
-    fun _ ↦ Eq.symm <| List.filterMap_eq_bind_toList _ _
+  (list_bind hf (optionToList.comp hg)).of_eq fun _ ↦ Eq.symm <| List.filterMap_eq_bind_toList ..
 
 theorem list_length : Primrec (@List.length α) :=
   (list_foldr (@Primrec.id (List α) _) (const 0) <| to₂ <| (succ.comp <| snd.comp snd).to₂).of_eq
@@ -1135,41 +1084,37 @@ theorem list_length : Primrec (@List.length α) :=
 theorem list_findIdx {f : α → List β} {p : α → β → Bool}
     (hf : Primrec f) (hp : Primrec₂ p) : Primrec fun a => (f a).findIdx (p a) :=
   (list_foldr hf (const 0) <|
-        to₂ <| cond (hp.comp fst <| fst.comp snd) (const 0) (succ.comp <| snd.comp snd)).of_eq
+        to₂ <| cond (hp.comp₂ fst <| fst.comp snd) (const 0) (succ.comp <| snd.comp snd)).of_eq
     fun a => by dsimp; induction f a <;> simp [List.findIdx_cons, *]
 #align primrec.list_find_index Primrec.list_findIdx
 
 theorem list_indexOf [DecidableEq α] : Primrec₂ (@List.indexOf α _) :=
-  to₂ <| list_findIdx snd <| Primrec.beq.comp₂ snd.to₂ (fst.comp fst).to₂
+  list_findIdx snd <| Primrec.beq.comp₂ snd.to₂ (fst.comp fst).to₂
 #align primrec.list_index_of Primrec.list_indexOfₓ
 
 theorem nat_strong_rec (f : α → ℕ → σ) {g : α → List σ → Option σ} (hg : Primrec₂ g)
     (H : ∀ a n, g a ((List.range n).map (f a)) = some (f a n)) : Primrec₂ f :=
   suffices Primrec₂ fun a n => (List.range n).map (f a) from
-    Primrec₂.option_some_iff.1 <|
-      (list_get?.comp (this.comp fst (succ.comp snd)) snd).to₂.of_eq fun a n => by
+    Primrec.option_some_iff.1 <|
+      (list_get?.comp₂ (this.comp₂ fst (succ.comp snd)) snd).of_eq fun (a, n) => by
         simp [List.get?_range (Nat.lt_succ_self n)]
-  Primrec₂.option_some_iff.1 <|
+  Primrec.option_some_iff.1 <|
     (nat_rec (const (some []))
-          (to₂ <|
-            option_bind (snd.comp snd) <|
-              to₂ <|
-                option_map (hg.comp (fst.comp fst) snd)
-                  (to₂ <| list_concat.comp (snd.comp fst) snd))).of_eq
-      fun a n => by
+      (to₂ <| option_bind (snd.comp snd) <|
+        to₂ <| option_map (hg.comp₂ (fst.comp fst) snd) <|
+        to₂ <| list_concat.comp₂ (snd.comp fst) snd)).of_eq fun (a, n) => by
       simp; induction' n with n IH; · rfl
       simp [IH, H, List.range_succ]
 #align primrec.nat_strong_rec Primrec.nat_strong_rec
 
 theorem listLookup [DecidableEq α] : Primrec₂ (List.lookup : α → List (α × β) → Option β) :=
   (to₂ <| list_rec snd (const none) <|
-    to₂ <|
-      cond (Primrec.beq.comp (fst.comp fst) (fst.comp $ fst.comp snd))
-        (option_some.comp $ snd.comp $ fst.comp snd)
-        (snd.comp $ snd.comp snd)).of_eq
-  fun a ps => by
-  induction' ps with p ps ih <;> simp[List.lookup, *]
-  cases ha : a == p.1 <;> simp[ha]
+    to₂ <| cond (Primrec.beq.comp₂ (fst.comp fst) (fst.comp <| fst.comp snd))
+        (option_some.comp <| snd.comp <| fst.comp snd)
+        (snd.comp <| snd.comp snd))
+  |>.of_eq fun (a, ps) => by
+    induction' ps with p ps ih <;> simp [List.lookup, *]
+    cases ha : a == p.1 <;> simp [ha]
 
 theorem nat_omega_rec' (f : β → σ) {m : β → ℕ} {l : β → List β} {g : β → List σ → Option σ}
     (hm : Primrec m) (hl : Primrec l) (hg : Primrec₂ g)
@@ -1179,25 +1124,25 @@ theorem nat_omega_rec' (f : β → σ) {m : β → ℕ} {l : β → List β} {g 
   let mapGraph (M : List (β × σ)) (bs : List β) : List σ := bs.bind (Option.toList <| M.lookup ·)
   let bindList (b : β) : ℕ → List β := fun n ↦ n.rec [b] fun _ bs ↦ bs.bind l
   let graph (b : β) : ℕ → List (β × σ) := fun i ↦ i.rec [] fun i ih ↦
-    (bindList b (m b - i)).filterMap fun b' ↦ (g b' $ mapGraph ih (l b')).map (b', ·)
+    (bindList b (m b - i)).filterMap fun b' ↦ (g b' <| mapGraph ih (l b')).map (b', ·)
   have mapGraph_primrec : Primrec₂ mapGraph :=
-    to₂ <| list_bind snd <| optionToList.comp₂ <| listLookup.comp₂ .right (fst.comp₂ .left)
-  have bindList_primrec : Primrec₂ (bindList) :=
+    list_bind snd <| optionToList.comp <| listLookup.comp₂ snd (fst.comp fst)
+  have bindList_primrec : Primrec₂ bindList :=
     nat_rec' snd
-      (list_cons.comp fst (const []))
-      (to₂ <| list_bind (snd.comp snd) (hl.comp₂ .right))
-  have graph_primrec : Primrec₂ (graph) :=
-    to₂ <| nat_rec' snd (const []) <|
-      to₂ <| listFilterMap
-        (bindList_primrec.comp
-          (fst.comp fst)
-          (nat_sub.comp (hm.comp $ fst.comp fst) (fst.comp snd))) <|
-            to₂ <| option_map
-              (hg.comp snd (mapGraph_primrec.comp (snd.comp $ snd.comp fst) (hl.comp snd)))
-              (Primrec₂.pair.comp₂ (snd.comp₂ .left) .right)
+      (list_cons.comp₂ fst (const []))
+      (to₂ <| list_bind (snd.comp snd) (hl.comp snd).to₂)
+  have graph_primrec : Primrec₂ graph :=
+    nat_rec' snd (const []) <| to₂ <|
+    listFilterMap
+      (bindList_primrec.comp₂
+        (fst.comp fst)
+        (nat_sub.comp₂ (hm.comp <| fst.comp fst) (fst.comp snd)))
+      (option_map
+        (hg.comp₂ snd (mapGraph_primrec.comp₂ (snd.comp <| snd.comp fst) (hl.comp snd)))
+        (pair (snd.comp fst) snd).to₂).to₂
   have : Primrec (fun b => ((graph b (m b + 1)).get? 0).map Prod.snd) :=
-    option_map (list_get?.comp (graph_primrec.comp Primrec.id (succ.comp hm)) (const 0))
-      (snd.comp₂ Primrec₂.right)
+    option_map (list_get?.comp₂ (graph_primrec.comp₂ Primrec.id (succ.comp hm)) (const 0))
+      (snd.comp snd)
   exact option_some_iff.mp <| this.of_eq <| fun b ↦ by
     have graph_eq_map_bindList (i : ℕ) (hi : i ≤ m b + 1) :
         graph b i = (bindList b (m b + 1 - i)).map fun x ↦ (x, f x) := by
@@ -1206,14 +1151,14 @@ theorem nat_omega_rec' (f : β → σ) {m : β → ℕ} {l : β → List β} {g 
           induction' k with k ih <;> simp [bindList]
           intro a₂ a₁ ha₁ ha₂
           have : k ≤ m b :=
-            Nat.lt_succ.mp (by simpa using Nat.add_lt_of_lt_sub $ Nat.zero_lt_of_lt (ih a₁ ha₁))
+            Nat.lt_succ.mp (by simpa using Nat.add_lt_of_lt_sub <| Nat.zero_lt_of_lt (ih a₁ ha₁))
           have : m a₁ ≤ m b - k :=
             Nat.lt_succ.mp (by rw [← Nat.succ_sub this]; simpa using ih a₁ ha₁)
           exact lt_of_lt_of_le (Ord a₁ a₂ ha₂) this
         List.eq_nil_iff_forall_not_mem.mpr
           (by intro b' ha'; by_contra; simpa using bindList_m_lt (m b + 1) b' ha')
       have mapGraph_graph {bs bs' : List β} (has : bs' ⊆ bs) :
-          mapGraph (bs.map $ fun x => (x, f x)) bs' = bs'.map f := by
+          mapGraph (bs.map <| fun x => (x, f x)) bs' = bs'.map f := by
         induction' bs' with b bs' ih <;> simp [mapGraph]
         · have : b ∈ bs ∧ bs' ⊆ bs := by simpa using has
           rcases this with ⟨ha, has'⟩
@@ -1237,12 +1182,11 @@ theorem nat_omega_rec (f : α → β → σ) {m : α → β → ℕ}
     (hm : Primrec₂ m) (hl : Primrec₂ l) (hg : Primrec₂ g)
     (Ord : ∀ a b, ∀ b' ∈ l a b, m a b' < m a b)
     (H : ∀ a b, g a (b, (l a b).map (f a)) = some (f a b)) : Primrec₂ f :=
-  Primrec₂.uncurry.mp <|
-    nat_omega_rec' (Function.uncurry f)
-      (Primrec₂.uncurry.mpr hm)
-      (list_map (hl.comp fst snd) (Primrec₂.pair.comp₂ (fst.comp₂ .left) .right))
-      (hg.comp₂ (fst.comp₂ .left) (Primrec₂.pair.comp₂ (snd.comp₂ .left) .right))
-      (by simpa using Ord) (by simpa[Function.comp] using H)
+  to₂ <| nat_omega_rec' (Function.uncurry f)
+    (Primrec.uncurry.mpr hm)
+    (list_map (hl.comp₂ fst snd) (pair (fst.comp fst) snd).to₂)
+    (hg.comp₂ (fst.comp fst) (pair (snd.comp fst) snd)).to₂
+    (by simpa using Ord) (by simpa [Function.comp] using H)
 
 end Primrec
 
@@ -1293,7 +1237,7 @@ theorem mem_range_encode : PrimrecPred (fun n => n ∈ Set.range (encode : α �
           (.ite (Primrec.eq.comp (Primrec.encode.comp .snd) .fst)
             (Primrec.option_some.comp .snd) (.const _)))
         (.const _))
-  this.of_eq fun _ => decode₂_ne_none_iff
+  this.of_eq_pred fun _ => decode₂_ne_none_iff
 
 instance ulower : Primcodable (ULower α) :=
   Primcodable.subtype mem_range_encode
@@ -1375,7 +1319,7 @@ theorem vector_toList_iff {n} {f : α → Vector β n} : (Primrec fun a => (f a)
 #align primrec.vector_to_list_iff Primrec.vector_toList_iff
 
 theorem vector_cons {n} : Primrec₂ (@Vector.cons α n) :=
-  vector_toList_iff.1 <| by simp; exact list_cons.comp fst (vector_toList_iff.2 snd)
+  vector_toList_iff.1 <| by simp; exact list_cons.comp₂ fst (vector_toList_iff.2 snd)
 #align primrec.vector_cons Primrec.vector_cons
 
 theorem vector_length {n} : Primrec (@Vector.length α n) :=
@@ -1392,7 +1336,7 @@ theorem vector_tail {n} : Primrec (@Vector.tail α n) :=
 
 theorem vector_get {n} : Primrec₂ (@Vector.get α n) :=
   option_some_iff.1 <|
-    (list_get?.comp (vector_toList.comp fst) (fin_val.comp snd)).of_eq fun a => by
+    (list_get?.comp₂ (vector_toList.comp fst) (fin_val.comp snd)).of_eq fun a => by
       rw [Vector.get_eq_get, ← List.get?_eq_get]
       rfl
 
@@ -1402,7 +1346,7 @@ theorem list_ofFn :
     ∀ {n} {f : Fin n → α → σ}, (∀ i, Primrec (f i)) → Primrec fun a => List.ofFn fun i => f i a
   | 0, _, _ => const []
   | n + 1, f, hf => by
-    simp [List.ofFn_succ]; exact list_cons.comp (hf 0) (list_ofFn fun i => hf i.succ)
+    simp [List.ofFn_succ]; exact list_cons.comp₂ (hf 0) (list_ofFn fun i => hf i.succ)
 #align primrec.list_of_fn Primrec.list_ofFn
 
 theorem vector_ofFn {n} {f : Fin n → α → σ} (hf : ∀ i, Primrec (f i)) :
@@ -1419,18 +1363,18 @@ theorem vector_ofFn' {n} : Primrec (@Vector.ofFn α n) :=
 #align primrec.vector_of_fn' Primrec.vector_ofFn'
 
 theorem fin_app {n} : Primrec₂ (@id (Fin n → σ)) :=
-  (vector_get.comp (vector_ofFn'.comp fst) snd).of_eq fun ⟨v, i⟩ => by simp
+  (vector_get.comp₂ (vector_ofFn'.comp fst) snd).of_eq fun ⟨v, i⟩ => by simp
 #align primrec.fin_app Primrec.fin_app
 
 theorem fin_curry₁ {n} {f : Fin n → α → σ} : Primrec₂ f ↔ ∀ i, Primrec (f i) :=
-  ⟨fun h i => h.comp (const i) .id, fun h =>
-    (vector_get.comp ((vector_ofFn h).comp snd) fst).of_eq fun a => by simp⟩
+  ⟨fun h i => h.comp₂ (const i) .id, fun h =>
+    (vector_get.comp₂ ((vector_ofFn h).comp snd) fst).of_eq fun a => by simp⟩
 #align primrec.fin_curry₁ Primrec.fin_curry₁
 
 theorem fin_curry {n} {f : α → Fin n → σ} : Primrec f ↔ Primrec₂ f :=
-  ⟨fun h => fin_app.comp (h.comp fst) snd, fun h =>
+  ⟨fun h => fin_app.comp₂ (h.comp fst) snd, fun h =>
     (vector_get'.comp
-          (vector_ofFn fun i => show Primrec fun a => f a i from h.comp .id (const i))).of_eq
+          (vector_ofFn fun i => show Primrec fun a => f a i from h.comp₂ .id (const i))).of_eq
       fun a => by funext i; simp⟩
 #align primrec.fin_curry Primrec.fin_curry
 
@@ -1468,14 +1412,14 @@ theorem to_prim {n f} (pf : @Nat.Primrec' n f) : Primrec f := by
   induction pf with
   | zero => exact .const 0
   | succ => exact _root_.Primrec.succ.comp .vector_head
-  | get i => exact Primrec.vector_get.comp .id (.const i)
+  | get i => exact Primrec.vector_get.comp₂ .id (.const i)
   | comp _ _ _ hf hg => exact hf.comp (.vector_ofFn fun i => hg i)
   | @prec n f g _ _ hf hg =>
     exact
       .nat_rec' .vector_head (hf.comp Primrec.vector_tail)
         (hg.comp <|
-          Primrec.vector_cons.comp (Primrec.fst.comp .snd) <|
-          Primrec.vector_cons.comp (Primrec.snd.comp .snd) <|
+          Primrec.vector_cons.comp₂ (Primrec.fst.comp .snd) <|
+          Primrec.vector_cons.comp₂ (Primrec.snd.comp .snd) <|
             (@Primrec.vector_tail _ _ (n + 1)).comp .fst).to₂
 #align nat.primrec'.to_prim Nat.Primrec'.to_prim
 
@@ -1641,14 +1585,14 @@ theorem prim_iff₁ {f : ℕ → ℕ} : (@Primrec' 1 fun v => f v.head) ↔ Prim
 
 theorem prim_iff₂ {f : ℕ → ℕ → ℕ} : (@Primrec' 2 fun v => f v.head v.tail.head) ↔ Primrec₂ f :=
   prim_iff.trans
-    ⟨fun h => (h.comp <| Primrec.vector_cons.comp .fst <|
-      Primrec.vector_cons.comp .snd (.const nil)).of_eq fun v => by simp,
-    fun h => h.comp .vector_head (Primrec.vector_head.comp .vector_tail)⟩
+    ⟨fun h => (h.comp <| Primrec.vector_cons.comp₂ .fst <|
+      Primrec.vector_cons.comp₂ .snd (.const nil)).of_eq fun v => by simp,
+    fun h => h.comp₂ .vector_head (Primrec.vector_head.comp .vector_tail)⟩
 #align nat.primrec'.prim_iff₂ Nat.Primrec'.prim_iff₂
 
 theorem vec_iff {m n f} : @Vec m n f ↔ Primrec f :=
   ⟨fun h => by simpa using Primrec.vector_ofFn fun i => to_prim (h i), fun h i =>
-    of_prim <| Primrec.vector_get.comp h (.const i)⟩
+    of_prim <| Primrec.vector_get.comp₂ h (.const i)⟩
 #align nat.primrec'.vec_iff Nat.Primrec'.vec_iff
 
 end Nat.Primrec'


### PR DESCRIPTION
General cleanup of the `Primrec` and `Partrec` files, to better adjust to lean 4 things. The main user-visible change is that `Primrec₂` is no longer a `def` but an `abbrev`, because it was causing inference issues in lean 4. I also removed all the nonterminal `simp`s in `PartrecCode.lean`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
