### PR TITLE
[Merged by Bors] - chore: refactor LinarithConfig object so defaults are easier to find

### DIFF
--- a/Mathlib/Tactic/Linarith/Datatypes.lean
+++ b/Mathlib/Tactic/Linarith/Datatypes.lean
@@ -313,46 +313,6 @@ structure CertificateOracle : Type where
   This map represents that we can find a contradiction by taking the sum `∑ (coeff i) * hyps[i]`. -/
   produceCertificate (hyps : List Comp) (max_var : Nat) : MetaM (Batteries.HashMap Nat Nat)
 
-<<<<<<< robertylewis/linarith-oracle-default -- Incoming Change
-=======
-open Meta
-
-/-- A configuration object for `linarith`. -/
-structure LinarithConfig : Type where
-  /-- Discharger to prove that a candidate linear combination of hypothesis is zero. -/
-  -- TODO There should be a def for this, rather than calling `evalTactic`?
-  discharger : TacticM Unit := do evalTactic (← `(tactic| ring1))
-  -- We can't actually store a `Type` here,
-  -- as we want `LinarithConfig : Type` rather than ` : Type 1`,
-  -- so that we can define `elabLinarithConfig : Lean.Syntax → Lean.Elab.TermElabM LinarithConfig`.
-  -- For now, we simply don't support restricting the type.
-  -- (restrict_type : Option Type := none)
-  /-- Prove goals which are not linear comparisons by first calling `exfalso`. -/
-  exfalso : Bool := true
-  /-- Transparency mode for identifying atomic expressions in comparisons. -/
-  transparency : TransparencyMode := .reducible
-  /-- Split conjunctions in hypotheses. -/
-  splitHypotheses : Bool := true
-  /-- Split `≠` in hypotheses, by branching in cases `<` and `>`. -/
-  splitNe : Bool := false
-  /-- Override the list of preprocessors. -/
-  preprocessors : Option (List GlobalBranchingPreprocessor) := none
-  /-- Specify an oracle for identifying candidate contradictions.
-  `.simplexAlgorithmSparse`, `.simplexAlgorithmSparse`, and `.fourierMotzkin` are available. -/
-  oracle : Option CertificateOracle := none
-
-/--
-`cfg.updateReducibility reduce_default` will change the transparency setting of `cfg` to
-`default` if `reduce_default` is true. In this case, it also sets the discharger to `ring!`,
-since this is typically needed when using stronger unification.
--/
-def LinarithConfig.updateReducibility (cfg : LinarithConfig) (reduce_default : Bool) :
-    LinarithConfig :=
-  if reduce_default then
-    { cfg with transparency := .default, discharger := do evalTactic (← `(tactic| ring1!)) }
-  else cfg
-
->>>>>>> master -- Current Change
 /-!
 ### Auxiliary functions
 

--- a/Mathlib/Tactic/Linarith/Datatypes.lean
+++ b/Mathlib/Tactic/Linarith/Datatypes.lean
@@ -312,43 +312,6 @@ structure CertificateOracle : Type where
   This map represents that we can find a contradiction by taking the sum `∑ (coeff i) * hyps[i]`. -/
   produceCertificate (hyps : List Comp) (max_var : Nat) : MetaM (Batteries.HashMap Nat Nat)
 
-open Meta
-
-/-- A configuration object for `linarith`. -/
-structure LinarithConfig : Type where
-  /-- Discharger to prove that a candidate linear combination of hypothesis is zero. -/
-  -- TODO There should be a def for this, rather than calling `evalTactic`?
-  discharger : TacticM Unit := do evalTactic (← `(tactic| ring1))
-  -- We can't actually store a `Type` here,
-  -- as we want `LinarithConfig : Type` rather than ` : Type 1`,
-  -- so that we can define `elabLinarithConfig : Lean.Syntax → Lean.Elab.TermElabM LinarithConfig`.
-  -- For now, we simply don't support restricting the type.
-  -- (restrict_type : Option Type := none)
-  /-- Prove goals which are not linear comparisons by first calling `exfalso`. -/
-  exfalso : Bool := true
-  /-- Transparency mode for identifying atomic expressions in comparisons. -/
-  transparency : TransparencyMode := .reducible
-  /-- Split conjunctions in hypotheses. -/
-  splitHypotheses : Bool := true
-  /-- Split `≠` in hypotheses, by branching in cases `<` and `>`. -/
-  splitNe : Bool := false
-  /-- Override the list of preprocessors. -/
-  preprocessors : Option (List GlobalBranchingPreprocessor) := none
-  /-- Specify an oracle for identifying candidate contradictions.
-  `.simplexAlgorithm` and `.fourierMotzkin` are both available. -/
-  oracle : Option CertificateOracle := none
-
-/--
-`cfg.updateReducibility reduce_default` will change the transparency setting of `cfg` to
-`default` if `reduce_default` is true. In this case, it also sets the discharger to `ring!`,
-since this is typically needed when using stronger unification.
--/
-def LinarithConfig.updateReducibility (cfg : LinarithConfig) (reduce_default : Bool) :
-    LinarithConfig :=
-  if reduce_default then
-    { cfg with transparency := .default, discharger := do evalTactic (← `(tactic| ring1!)) }
-  else cfg
-
 /-!
 ### Auxiliary functions
 

--- a/Mathlib/Tactic/Linarith/Frontend.lean
+++ b/Mathlib/Tactic/Linarith/Frontend.lean
@@ -6,6 +6,7 @@ Authors: Robert Y. Lewis
 import Mathlib.Control.Basic
 import Mathlib.Tactic.Linarith.Verification
 import Mathlib.Tactic.Linarith.Preprocessing
+import Mathlib.Tactic.Linarith.Oracle.SimplexAlgorithm
 
 /-!
 # `linarith`: solving linear arithmetic goals
@@ -123,6 +124,53 @@ open Batteries
 
 namespace Linarith
 
+/-! ### Config objects
+
+The config object is defined in the frontend, instead of in `Datatypes.lean`, since the oracles must
+be in context to choose a default.
+
+-/
+
+section
+open Meta
+
+/-- A configuration object for `linarith`. -/
+structure LinarithConfig : Type where
+  /-- Discharger to prove that a candidate linear combination of hypothesis is zero. -/
+  -- TODO There should be a def for this, rather than calling `evalTactic`?
+  discharger : TacticM Unit := do evalTactic (← `(tactic| ring1))
+  -- We can't actually store a `Type` here,
+  -- as we want `LinarithConfig : Type` rather than ` : Type 1`,
+  -- so that we can define `elabLinarithConfig : Lean.Syntax → Lean.Elab.TermElabM LinarithConfig`.
+  -- For now, we simply don't support restricting the type.
+  -- (restrict_type : Option Type := none)
+  /-- Prove goals which are not linear comparisons by first calling `exfalso`. -/
+  exfalso : Bool := true
+  /-- Transparency mode for identifying atomic expressions in comparisons. -/
+  transparency : TransparencyMode := .reducible
+  /-- Split conjunctions in hypotheses. -/
+  splitHypotheses : Bool := true
+  /-- Split `≠` in hypotheses, by branching in cases `<` and `>`. -/
+  splitNe : Bool := false
+  /-- Override the list of preprocessors. -/
+  preprocessors : List GlobalBranchingPreprocessor := defaultPreprocessors
+  /-- Specify an oracle for identifying candidate contradictions.
+  `.simplexAlgorithm` and `.fourierMotzkin` are both available. -/
+  oracle : CertificateOracle := .simplexAlgorithm
+
+/--
+`cfg.updateReducibility reduce_default` will change the transparency setting of `cfg` to
+`default` if `reduce_default` is true. In this case, it also sets the discharger to `ring!`,
+since this is typically needed when using stronger unification.
+-/
+def LinarithConfig.updateReducibility (cfg : LinarithConfig) (reduce_default : Bool) :
+    LinarithConfig :=
+  if reduce_default then
+    { cfg with transparency := .default, discharger := do evalTactic (← `(tactic| ring1!)) }
+  else cfg
+
+end
+
 /-! ### Control -/
 
 /--
@@ -202,7 +250,7 @@ prove `False` by calling `linarith` on each list in succession. It will stop at 
 def findLinarithContradiction (cfg : LinarithConfig) (g : MVarId) (ls : List (List Expr)) :
     MetaM Expr :=
   try
-    ls.firstM (fun L => proveFalseByLinarith cfg g L)
+    ls.firstM (fun L => proveFalseByLinarith cfg.transparency cfg.oracle cfg.discharger g L)
   catch e => throwError "linarith failed to find a contradiction\n{g}\n{e.toMessageData}"
 
 
@@ -225,10 +273,10 @@ def runLinarith (cfg : LinarithConfig) (prefType : Option Expr) (g : MVarId)
     trace[linarith] "hypotheses appear in {hyp_set.size} different types"
       if let some t := prefType then
         let (i, vs) ← hyp_set.find t
-        proveFalseByLinarith cfg g vs <|>
+        proveFalseByLinarith cfg.transparency cfg.oracle cfg.discharger g vs <|>
         findLinarithContradiction cfg g ((hyp_set.eraseIdx i).toList.map (·.2))
       else findLinarithContradiction cfg g (hyp_set.toList.map (·.2))
-  let mut preprocessors := cfg.preprocessors.getD defaultPreprocessors
+  let mut preprocessors := cfg.preprocessors
   if cfg.splitNe then
     preprocessors := Linarith.removeNe :: preprocessors
   if cfg.splitHypotheses then
@@ -420,8 +468,7 @@ elab_rules : tactic
     let args ← ((args.map (TSepArray.getElems)).getD {}).mapM (elabLinarithArg `nlinarith)
     let cfg := (← elabLinarithConfig (mkOptionalNode cfg)).updateReducibility bang.isSome
     let cfg := { cfg with
-      preprocessors := some (cfg.preprocessors.getD defaultPreprocessors ++
-        [(nlinarithExtras : GlobalBranchingPreprocessor)]) }
+      preprocessors := cfg.preprocessors.concat nlinarithExtras }
     commitIfNoEx do liftMetaFinishingTactic <| Linarith.linarith o.isSome args.toList cfg
 
 -- TODO restore this when `add_tactic_doc` is ported

--- a/Mathlib/Tactic/Linarith/Frontend.lean
+++ b/Mathlib/Tactic/Linarith/Frontend.lean
@@ -153,10 +153,10 @@ structure LinarithConfig : Type where
   /-- Split `≠` in hypotheses, by branching in cases `<` and `>`. -/
   splitNe : Bool := false
   /-- Override the list of preprocessors. -/
-  preprocessors : List GlobalBranchingPreprocessor := defaultPreprocessors
+  preprocessors : Option (List GlobalBranchingPreprocessor) := none
   /-- Specify an oracle for identifying candidate contradictions.
-  `.simplexAlgorithm` and `.fourierMotzkin` are both available. -/
-  oracle : CertificateOracle := .simplexAlgorithm
+  `.simplexAlgorithmSparse`, `.simplexAlgorithmSparse`, and `.fourierMotzkin` are available. -/
+  oracle : Option CertificateOracle := none
 
 /--
 `cfg.updateReducibility reduce_default` will change the transparency setting of `cfg` to

--- a/Mathlib/Tactic/Linarith/Frontend.lean
+++ b/Mathlib/Tactic/Linarith/Frontend.lean
@@ -153,10 +153,10 @@ structure LinarithConfig : Type where
   /-- Split `≠` in hypotheses, by branching in cases `<` and `>`. -/
   splitNe : Bool := false
   /-- Override the list of preprocessors. -/
-  preprocessors : Option (List GlobalBranchingPreprocessor) := none
+  preprocessors : List GlobalBranchingPreprocessor := defaultPreprocessors
   /-- Specify an oracle for identifying candidate contradictions.
   `.simplexAlgorithmSparse`, `.simplexAlgorithmSparse`, and `.fourierMotzkin` are available. -/
-  oracle : Option CertificateOracle := none
+  oracle : CertificateOracle := .simplexAlgorithmSparse
 
 /--
 `cfg.updateReducibility reduce_default` will change the transparency setting of `cfg` to

--- a/Mathlib/Tactic/Linarith/Verification.lean
+++ b/Mathlib/Tactic/Linarith/Verification.lean
@@ -4,8 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Robert Y. Lewis
 -/
 
--- import Mathlib.Tactic.Linarith.Oracle.FourierMotzkin
-import Mathlib.Tactic.Linarith.Oracle.SimplexAlgorithm
 import Mathlib.Tactic.Linarith.Parsing
 import Mathlib.Util.Qq
 
@@ -170,9 +168,7 @@ def proveEqZeroUsing (tac : TacticM Unit) (e : Expr) : MetaM Expr := do
 Given a list `l` of proofs of `tᵢ Rᵢ 0`,
 it tries to derive a contradiction from `l` and use this to produce a proof of `False`.
 
-An oracle is used to search for a certificate of unsatisfiability.
-In the current implementation, this is the Fourier Motzkin elimination routine in
-`Elimination.lean`, but other oracles could easily be swapped in.
+`oracle : CertificateOracle` is used to search for a certificate of unsatisfiability.
 
 The returned certificate is a map `m` from hypothesis indices to natural number coefficients.
 If our set of hypotheses has the form `{tᵢ Rᵢ 0}`,
@@ -185,11 +181,13 @@ We have also that
 since for each `i`, `(m i)*tᵢ ≤ 0` and at least one is strictly negative.
 So we conclude a contradiction `0 < 0`.
 
-It remains to produce proofs of (1) and (2). (1) is verified by calling the `discharger` tactic
-of the `LinarithConfig` object, which is typically `ring`. We prove (2) by folding over the
-set of hypotheses.
+It remains to produce proofs of (1) and (2). (1) is verified by calling the provided `discharger`
+tactic, which is typically `ring`. We prove (2) by folding over the set of hypotheses.
+
+`transparency : TransparencyMode` controls the transparency level with which atoms are identified.
 -/
-def proveFalseByLinarith (cfg : LinarithConfig) : MVarId → List Expr → MetaM Expr
+def proveFalseByLinarith (transparency : TransparencyMode) (oracle : CertificateOracle)
+  (discharger : TacticM Unit) : MVarId → List Expr → MetaM Expr
   | _, [] => throwError "no args to linarith"
   | g, l@(h::_) => do
       trace[linarith.detail] "Beginning work in `proveFalseByLinarith`."
@@ -200,10 +198,9 @@ def proveFalseByLinarith (cfg : LinarithConfig) : MVarId → List Expr → MetaM
       let inputs := (← mkNegOneLtZeroProof (← typeOfIneqProof h))::l'.reverse
       trace[linarith.detail] "... finished `mkNegOneLtZeroProof`."
       trace[linarith.detail] (← inputs.mapM inferType)
-      let (comps, max_var) ← linearFormsAndMaxVar cfg.transparency inputs
+      let (comps, max_var) ← linearFormsAndMaxVar transparency inputs
       trace[linarith.detail] "... finished `linearFormsAndMaxVar`."
       trace[linarith.detail] "{comps}"
-      let oracle := cfg.oracle.getD (.simplexAlgorithm)
       -- perform the elimination and fail if no contradiction is found.
       let certificate : Batteries.HashMap Nat Nat ← try
         oracle.produceCertificate comps max_var
@@ -220,7 +217,7 @@ def proveFalseByLinarith (cfg : LinarithConfig) : MVarId → List Expr → MetaM
       -- let sm ← instantiateMVars sm
       trace[linarith] "The expression\n  {sm}\nshould be both 0 and negative"
       -- we prove that `sm = 0`, typically with `ring`.
-      let sm_eq_zero ← proveEqZeroUsing cfg.discharger sm
+      let sm_eq_zero ← proveEqZeroUsing discharger sm
       -- we also prove that `sm < 0`
       let sm_lt_zero ← mkLTZeroProof zip
       -- this is a contradiction.

--- a/Mathlib/Tactic/Linarith/Verification.lean
+++ b/Mathlib/Tactic/Linarith/Verification.lean
@@ -187,7 +187,7 @@ tactic, which is typically `ring`. We prove (2) by folding over the set of hypot
 `transparency : TransparencyMode` controls the transparency level with which atoms are identified.
 -/
 def proveFalseByLinarith (transparency : TransparencyMode) (oracle : CertificateOracle)
-  (discharger : TacticM Unit) : MVarId → List Expr → MetaM Expr
+    (discharger : TacticM Unit) : MVarId → List Expr → MetaM Expr
   | _, [] => throwError "no args to linarith"
   | g, l@(h::_) => do
       trace[linarith.detail] "Beginning work in `proveFalseByLinarith`."

--- a/Mathlib/Tactic/Linarith/Verification.lean
+++ b/Mathlib/Tactic/Linarith/Verification.lean
@@ -201,10 +201,6 @@ def proveFalseByLinarith (transparency : TransparencyMode) (oracle : Certificate
       let (comps, max_var) ← linearFormsAndMaxVar transparency inputs
       trace[linarith.detail] "... finished `linearFormsAndMaxVar`."
       trace[linarith.detail] "{comps}"
-<<<<<<< robertylewis/linarith-oracle-default -- Incoming Change
-=======
-      let oracle := cfg.oracle.getD (.simplexAlgorithmSparse)
->>>>>>> master -- Current Change
       -- perform the elimination and fail if no contradiction is found.
       let certificate : Batteries.HashMap Nat Nat ← try
         oracle.produceCertificate comps max_var

--- a/test/linarith.lean
+++ b/test/linarith.lean
@@ -440,7 +440,7 @@ example (p q r s t u v w : ℕ) (h1 : p + u = q + t) (h2 : r + w = s + v) :
 -- `nlinarith` because it passes large and sparse matrices to the oracle.
 example (p q r s t u v w : ℕ) (h1 : p + u = q + t) (h2 : r + w = s + v) :
     p * r + q * s + (t * w + u * v) = p * s + q * r + (t * v + u * w) := by
-  nlinarith (config := { oracle := some .fourierMotzkin })
+  nlinarith (config := { oracle := .fourierMotzkin })
 
 section
 -- Tests involving a norm, including that squares in a type where `sq_nonneg` does not apply
@@ -663,7 +663,7 @@ example (a b c d e : ℚ)
     (hd : a + b + c + 2 * d + e = 7)
     (he : a + b + c + d + 2 * e = 8) :
     e = 3 := by
-  linarith (config := { oracle := some .fourierMotzkin })
+  linarith (config := { oracle := .fourierMotzkin })
 
 -- TODO: still broken with Fourier-Motzkin
 /--
@@ -696,4 +696,4 @@ example {x1 x2 x3 x4 x5 x6 x7 x8 : ℚ} :
     -x8 + x7 - x5 + x1 < 0 →
     x7 - x5 < 0 → False := by
   intros
-  linarith (config := { oracle := some .fourierMotzkin })
+  linarith (config := { oracle := .fourierMotzkin })


### PR DESCRIPTION
`LinarithConfig` was defined before `CertificateOracle` was instantiated, so it couldn't have a proper default. The default was chosen inline in the middle of a long function. Now that we have multiple oracles, it's important to make the default choice visible!

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

Addresses a comment at https://github.com/leanprover-community/mathlib4/pull/12819#issuecomment-2165185245

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
