### PR TITLE
[Merged by Bors] - perf(GroupCohomology/Resolution; Algebra/Lie/Classical): use suppress_compilation

### DIFF
--- a/Mathlib/Algebra/Lie/Classical.lean
+++ b/Mathlib/Algebra/Lie/Classical.lean
@@ -211,7 +211,7 @@ theorem indefiniteDiagonal_transform {i : R} (hi : i * i = -1) :
 
 /-- An equivalence between the indefinite and definite orthogonal Lie algebras, over a ring
 containing a square root of -1. -/
-def soIndefiniteEquiv {i : R} (hi : i * i = -1) : so' p q R ≃ₗ⁅R⁆ so (Sum p q) R := by
+noncomputable def soIndefiniteEquiv {i : R} (hi : i * i = -1) : so' p q R ≃ₗ⁅R⁆ so (Sum p q) R := by
   apply
     (skewAdjointMatricesLieSubalgebraEquiv (indefiniteDiagonal p q R) (Pso p q R i)
         (invertiblePso p q R hi)).trans
@@ -284,7 +284,7 @@ instance invertiblePD [Fintype l] [Invertible (2 : R)] : Invertible (PD l R) :=
 #align lie_algebra.orthogonal.invertible_PD LieAlgebra.Orthogonal.invertiblePD
 
 /-- An equivalence between two possible definitions of the classical Lie algebra of type D. -/
-def typeDEquivSo' [Fintype l] [Invertible (2 : R)] : typeD l R ≃ₗ⁅R⁆ so' l l R := by
+noncomputable def typeDEquivSo' [Fintype l] [Invertible (2 : R)] : typeD l R ≃ₗ⁅R⁆ so' l l R := by
   apply (skewAdjointMatricesLieSubalgebraEquiv (JD l R) (PD l R) (by infer_instance)).trans
   apply LieEquiv.ofEq
   ext A
@@ -369,7 +369,7 @@ theorem indefiniteDiagonal_assoc :
 #align lie_algebra.orthogonal.indefinite_diagonal_assoc LieAlgebra.Orthogonal.indefiniteDiagonal_assoc
 
 /-- An equivalence between two possible definitions of the classical Lie algebra of type B. -/
-def typeBEquivSo' [Invertible (2 : R)] : typeB l R ≃ₗ⁅R⁆ so' (Sum Unit l) l R := by
+noncomputable def typeBEquivSo' [Invertible (2 : R)] : typeB l R ≃ₗ⁅R⁆ so' (Sum Unit l) l R := by
   apply (skewAdjointMatricesLieSubalgebraEquiv (JB l R) (PB l R) (by infer_instance)).trans
   symm
   apply

--- a/Mathlib/RepresentationTheory/GroupCohomology/Resolution.lean
+++ b/Mathlib/RepresentationTheory/GroupCohomology/Resolution.lean
@@ -61,6 +61,9 @@ over `k`.
 /- Porting note: most altered proofs in this file involved changing `simp` to `rw` or `erw`, so
 https://github.com/leanprover-community/mathlib4/issues/5026 and
 https://github.com/leanprover-community/mathlib4/issues/5164 are relevant. -/
+
+suppress_compilation
+
 noncomputable section
 
 universe u v w


### PR DESCRIPTION
These took 10 resp. 18 seconds to compile in mathlib's CI; it seems this computability is not actually needed.

---

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
