### PR TITLE
[Merged by Bors] - chore: fix dsimp lemmas that cause loops

### DIFF
--- a/Mathlib/Algebra/Algebra/Equiv.lean
+++ b/Mathlib/Algebra/Algebra/Equiv.lean
@@ -360,14 +360,26 @@ theorem mk_coe' (e : A₁ ≃ₐ[R] A₂) (f h₁ h₂ h₃ h₄ h₅) :
   symm_bijective.injective <| ext fun _ => rfl
 #align alg_equiv.mk_coe' AlgEquiv.mk_coe'
 
+/-- Auxilliary definition to avoid looping in `dsimp` with `AlgEquiv.symm_mk`. -/
+protected def symm_mk.aux (f f') (h₁ h₂ h₃ h₄ h₅) :=
+  (⟨⟨f, f', h₁, h₂⟩, h₃, h₄, h₅⟩ : A₁ ≃ₐ[R] A₂).symm
+
 @[simp]
 theorem symm_mk (f f') (h₁ h₂ h₃ h₄ h₅) :
     (⟨⟨f, f', h₁, h₂⟩, h₃, h₄, h₅⟩ : A₁ ≃ₐ[R] A₂).symm =
-      {(⟨⟨f, f', h₁, h₂⟩, h₃, h₄, h₅⟩ : A₁ ≃ₐ[R] A₂).symm with
+      { symm_mk.aux f f' h₁ h₂ h₃ h₄ h₅ with
         toFun := f'
         invFun := f } :=
   rfl
 #align alg_equiv.symm_mk AlgEquiv.symm_mk
+
+-- remove before merging
+theorem symm_mk_test (f f') (h₁ h₂ h₃ h₄ h₅) :
+    (⟨⟨f, f', h₁, h₂⟩, h₃, h₄, h₅⟩ : A₁ ≃ₐ[R] A₂).symm =
+      { symm_mk.aux f f' h₁ h₂ h₃ h₄ h₅ with
+        toFun := f'
+        invFun := f } := by
+  dsimp
 
 @[simp]
 theorem refl_symm : (AlgEquiv.refl : A₁ ≃ₐ[R] A₁).symm = AlgEquiv.refl :=
@@ -624,7 +636,8 @@ section OfLinearEquiv
 
 variable (l : A₁ ≃ₗ[R] A₂) (map_one : l 1 = 1) (map_mul : ∀ x y : A₁, l (x * y) = l x * l y)
 
-/-- Upgrade a linear equivalence to an algebra equivalence,
+/--
+Upgrade a linear equivalence to an algebra equivalence,
 given that it distributes over multiplication and the identity
 -/
 @[simps apply]
@@ -636,11 +649,15 @@ def ofLinearEquiv : A₁ ≃ₐ[R] A₂ :=
     commutes' := (AlgHom.ofLinearMap l map_one map_mul : A₁ →ₐ[R] A₂).commutes }
 #align alg_equiv.of_linear_equiv AlgEquiv.ofLinearEquivₓ
 
+/-- Auxilliary definition to avoid looping in `dsimp` with `AlgEquiv.ofLinearEquiv_symm`. -/
+protected def ofLinearEquiv_symm.aux := (ofLinearEquiv l map_one map_mul).symm
+
 @[simp]
 theorem ofLinearEquiv_symm :
     (ofLinearEquiv l map_one map_mul).symm =
-      ofLinearEquiv l.symm (ofLinearEquiv l map_one map_mul).symm.map_one
-        (ofLinearEquiv l map_one map_mul).symm.map_mul :=
+      ofLinearEquiv l.symm
+        (ofLinearEquiv_symm.aux l map_one map_mul).map_one
+        (ofLinearEquiv_symm.aux l map_one map_mul).map_mul :=
   rfl
 #align alg_equiv.of_linear_equiv_symm AlgEquiv.ofLinearEquiv_symm
 

--- a/Mathlib/Algebra/Algebra/Equiv.lean
+++ b/Mathlib/Algebra/Algebra/Equiv.lean
@@ -373,14 +373,6 @@ theorem symm_mk (f f') (h₁ h₂ h₃ h₄ h₅) :
   rfl
 #align alg_equiv.symm_mk AlgEquiv.symm_mk
 
--- remove before merging
-theorem symm_mk_test (f f') (h₁ h₂ h₃ h₄ h₅) :
-    (⟨⟨f, f', h₁, h₂⟩, h₃, h₄, h₅⟩ : A₁ ≃ₐ[R] A₂).symm =
-      { symm_mk.aux f f' h₁ h₂ h₃ h₄ h₅ with
-        toFun := f'
-        invFun := f } := by
-  dsimp
-
 @[simp]
 theorem refl_symm : (AlgEquiv.refl : A₁ ≃ₐ[R] A₁).symm = AlgEquiv.refl :=
   rfl

--- a/Mathlib/Algebra/Module/Equiv.lean
+++ b/Mathlib/Algebra/Module/Equiv.lean
@@ -532,12 +532,13 @@ theorem mk_coe' (f h₁ h₂ h₃ h₄) :
   symm_bijective.injective <| ext fun _ => rfl
 #align linear_equiv.mk_coe' LinearEquiv.mk_coe'
 
+/-- Auxilliary definition to avoid looping in `dsimp` with `LinearEquiv.symm_mk`. -/
+protected def symm_mk.aux (f h₁ h₂ h₃ h₄) := (⟨⟨⟨e, h₁⟩, h₂⟩, f, h₃, h₄⟩ : M ≃ₛₗ[σ] M₂).symm
+
 @[simp]
 theorem symm_mk (f h₁ h₂ h₃ h₄) :
     (⟨⟨⟨e, h₁⟩, h₂⟩, f, h₃, h₄⟩ : M ≃ₛₗ[σ] M₂).symm =
-      {
-        (⟨⟨⟨e, h₁⟩, h₂⟩, f, h₃, h₄⟩ : M ≃ₛₗ[σ]
-              M₂).symm with
+      { symm_mk.aux e f h₁ h₂ h₃ h₄ with
         toFun := f
         invFun := e } :=
   rfl

--- a/Mathlib/Topology/FiberBundle/Trivialization.lean
+++ b/Mathlib/Topology/FiberBundle/Trivialization.lean
@@ -504,10 +504,14 @@ theorem sourceHomeomorphBaseSetProd_apply (p : e.source) :
   e.preimageHomeomorph_apply subset_rfl ⟨p, e.mem_source.mp p.2⟩
 #align trivialization.source_homeomorph_base_set_prod_apply Trivialization.sourceHomeomorphBaseSetProd_apply
 
+/-- Auxilliary definition to avoid looping in `dsimp`
+with `Trivialization.sourceHomeomorphBaseSetProd_symm_apply`. -/
+protected def sourceHomeomorphBaseSetProd_symm_apply.aux := e.sourceHomeomorphBaseSetProd.symm
+
 @[simp]
 theorem sourceHomeomorphBaseSetProd_symm_apply (p : e.baseSet × F) :
     e.sourceHomeomorphBaseSetProd.symm p =
-      ⟨e.symm (p.1, p.2), (e.sourceHomeomorphBaseSetProd.symm p).2⟩ :=
+      ⟨e.symm (p.1, p.2), (sourceHomeomorphBaseSetProd_symm_apply.aux e p).2⟩ :=
   rfl
 #align trivialization.source_homeomorph_base_set_prod_symm_apply Trivialization.sourceHomeomorphBaseSetProd_symm_apply
 


### PR DESCRIPTION
These dsimp lemmas had a proof subterm in their RHS that contained a
copy of the LHS, which causes dsimp to enter an infinite loop.

Nb: dsimp visits all sub-terms, even proofs: it is used to eliminate (artificial) dependencies


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
