### PR TITLE
[Merged by Bors] - docs(CategoryTheory): improve documentation in the effective epi file

### DIFF
--- a/Mathlib/CategoryTheory/EffectiveEpi/Basic.lean
+++ b/Mathlib/CategoryTheory/EffectiveEpi/Basic.lean
@@ -43,19 +43,20 @@ variable {C : Type*} [Category C]
 This structure encodes the data required for a morphism to be an effective epimorphism.
 -/
 structure EffectiveEpiStruct {X Y : C} (f : Y ⟶ X) where
+  /--
+  For every `W` with a morphism `e : Y ⟶ W` that coequalizes every pair of morphisms
+  `g₁ g₂ : Z ⟶ Y` which `f` coequalizes, `desc e h` is a morphism `X ⟶ W`... 
+  -/
   desc : ∀ {W : C} (e : Y ⟶ W),
     (∀ {Z : C} (g₁ g₂ : Z ⟶ Y), g₁ ≫ f = g₂ ≫ f → g₁ ≫ e = g₂ ≫ e) → (X ⟶ W)
+  /-- ...factorizing `e` through `f`... -/
   fac : ∀ {W : C} (e : Y ⟶ W)
     (h : ∀ {Z : C} (g₁ g₂ : Z ⟶ Y), g₁ ≫ f = g₂ ≫ f → g₁ ≫ e = g₂ ≫ e),
     f ≫ desc e h = e
+  /-- ...and as such, unique. -/
   uniq : ∀ {W : C} (e : Y ⟶ W)
     (h : ∀ {Z : C} (g₁ g₂ : Z ⟶ Y), g₁ ≫ f = g₂ ≫ f → g₁ ≫ e = g₂ ≫ e)
     (m : X ⟶ W), f ≫ m = e → m = desc e h
-
-attribute [nolint docBlame]
-  EffectiveEpiStruct.desc
-  EffectiveEpiStruct.fac
-  EffectiveEpiStruct.uniq
 
 /--
 A morphism `f : Y ⟶ X` is an effective epimorphism provided that `f` exhibits `X` as a colimit
@@ -64,9 +65,8 @@ If `f` has a kernel pair, then this is equivalent to showing that the correspond
 a colimit.
 -/
 class EffectiveEpi {X Y : C} (f : Y ⟶ X) : Prop where
+  /-- `f` is an effective epimorphism if there exists an `EffectiveEpiStruct` for `f`. -/
   effectiveEpi : Nonempty (EffectiveEpiStruct f)
-
-attribute [nolint docBlame] EffectiveEpi.effectiveEpi
 
 /-- Some chosen `EffectiveEpiStruct` associated to an effective epi. -/
 noncomputable
@@ -104,32 +104,33 @@ This structure encodes the data required for a family of morphisms to be effecti
 -/
 structure EffectiveEpiFamilyStruct {B : C} {α : Type*}
     (X : α → C) (π : (a : α) → (X a ⟶ B)) where
+  /--
+  For every `W` with a family of morphisms `e a : Y a ⟶ W` that coequalizes every pair of morphisms
+  `g₁ : Z ⟶ Y a₁`, `g₂ : Z ⟶ Y a₂` which the family `π` coequalizes, `desc e h` is a morphism
+  `X ⟶ W`... 
+  -/
   desc : ∀ {W} (e : (a : α) → (X a ⟶ W)),
           (∀ {Z : C} (a₁ a₂ : α) (g₁ : Z ⟶ X a₁) (g₂ : Z ⟶ X a₂),
       g₁ ≫ π _ = g₂ ≫ π _ → g₁ ≫ e _ = g₂ ≫ e _) → (B ⟶ W)
+  /-- ...factorizing the components of `e` through the components of `π`... -/
   fac : ∀ {W} (e : (a : α) → (X a ⟶ W))
           (h : ∀ {Z : C} (a₁ a₂ : α) (g₁ : Z ⟶ X a₁) (g₂ : Z ⟶ X a₂),
             g₁ ≫ π _ = g₂ ≫ π _ → g₁ ≫ e _ = g₂ ≫ e _)
           (a : α), π a ≫ desc e h = e a
+  /-- ...and as such, unique. -/
   uniq : ∀ {W} (e : (a : α) → (X a ⟶ W))
           (h : ∀ {Z : C} (a₁ a₂ : α) (g₁ : Z ⟶ X a₁) (g₂ : Z ⟶ X a₂),
             g₁ ≫ π _ = g₂ ≫ π _ → g₁ ≫ e _ = g₂ ≫ e _)
           (m : B ⟶ W), (∀ (a : α), π a ≫ m = e a) → m = desc e h
 
-attribute [nolint docBlame]
-  EffectiveEpiFamilyStruct.desc
-  EffectiveEpiFamilyStruct.fac
-  EffectiveEpiFamilyStruct.uniq
-
 /--
-A family of morphisms `f a : X a ⟶ B` indexed by `α` is effective epimorphic
-provided that the `f a` exhibit `B` as a colimit of the diagram of all "relations"
+A family of morphisms `π a : X a ⟶ B` indexed by `α` is effective epimorphic
+provided that the `π a` exhibit `B` as a colimit of the diagram of all "relations"
 `R → X a₁`, `R ⟶ X a₂` for all `a₁ a₂ : α`.
 -/
 class EffectiveEpiFamily {B : C} {α : Type*} (X : α → C) (π : (a : α) → (X a ⟶ B)) : Prop where
+  /-- `π` is an effective epimorphic family if there exists an `EffectiveEpiFamilyStruct` for `π` -/
   effectiveEpiFamily : Nonempty (EffectiveEpiFamilyStruct X π)
-
-attribute [nolint docBlame] EffectiveEpiFamily.effectiveEpiFamily
 
 /-- Some chosen `EffectiveEpiFamilyStruct` associated to an effective epi family. -/
 noncomputable
@@ -158,9 +159,9 @@ NOTE: The `simpNF` linter complains for some reason. See the two examples below.
 Zulip discussion:
 https://leanprover.zulipchat.com/#narrow/stream/287929-mathlib4/topic/simpNF.20bug.3F
 -/
-attribute [nolint simpNF]
-  EffectiveEpiFamily.fac
-  EffectiveEpiFamily.fac_assoc
+-- attribute [nolint simpNF]
+--   EffectiveEpiFamily.fac
+--   EffectiveEpiFamily.fac_assoc
 
 example {B W : C} {α : Type*} (X : α → C) (π : (a : α) → (X a ⟶ B))
     [EffectiveEpiFamily X π] (e : (a : α) → (X a ⟶ W))

--- a/Mathlib/CategoryTheory/EffectiveEpi/Basic.lean
+++ b/Mathlib/CategoryTheory/EffectiveEpi/Basic.lean
@@ -154,30 +154,6 @@ lemma EffectiveEpiFamily.fac {B W : C} {α : Type*} (X : α → C) (π : (a : α
     π a ≫ EffectiveEpiFamily.desc X π e h = e a :=
   (EffectiveEpiFamily.getStruct X π).fac e h a
 
-/-
-NOTE: The `simpNF` linter complains for some reason. See the two examples below.
-Zulip discussion:
-https://leanprover.zulipchat.com/#narrow/stream/287929-mathlib4/topic/simpNF.20bug.3F
--/
--- attribute [nolint simpNF]
---   EffectiveEpiFamily.fac
---   EffectiveEpiFamily.fac_assoc
-
-example {B W : C} {α : Type*} (X : α → C) (π : (a : α) → (X a ⟶ B))
-    [EffectiveEpiFamily X π] (e : (a : α) → (X a ⟶ W))
-    (h : ∀ {Z : C} (a₁ a₂ : α) (g₁ : Z ⟶ X a₁) (g₂ : Z ⟶ X a₂),
-      g₁ ≫ π _ = g₂ ≫ π _ → g₁ ≫ e _ = g₂ ≫ e _) (a : α) :
-    π a ≫ EffectiveEpiFamily.desc X π e h = e a := by
-  simp
-
-example {B W Q : C} {α : Type*} (X : α → C) (π : (a : α) → (X a ⟶ B))
-    [EffectiveEpiFamily X π] (e : (a : α) → (X a ⟶ W))
-    (h : ∀ {Z : C} (a₁ a₂ : α) (g₁ : Z ⟶ X a₁) (g₂ : Z ⟶ X a₂),
-      g₁ ≫ π _ = g₂ ≫ π _ → g₁ ≫ e _ = g₂ ≫ e _) (a : α)
-    (q : W ⟶ Q) :
-    π a ≫ EffectiveEpiFamily.desc X π e h ≫ q = e a ≫ q := by
-  simp
-
 lemma EffectiveEpiFamily.uniq {B W : C} {α : Type*} (X : α → C) (π : (a : α) → (X a ⟶ B))
     [EffectiveEpiFamily X π] (e : (a : α) → (X a ⟶ W))
     (h : ∀ {Z : C} (a₁ a₂ : α) (g₁ : Z ⟶ X a₁) (g₂ : Z ⟶ X a₂),


### PR DESCRIPTION
This PR improves some documentation in the effective epi file and removes some `nolint`s which are no longer necessary.

---

I have no idea how @adamtopaz got away with these `nolint docBlame`'s 😆 

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
