### PR TITLE
[Merged by Bors] - chore: bump leantar 0.1.12

### DIFF
--- a/Cache/IO.lean
+++ b/Cache/IO.lean
@@ -70,7 +70,7 @@ def CURLBIN :=
 
 /-- leantar version at https://github.com/digama0/leangz -/
 def LEANTARVERSION :=
-  "0.1.11"
+  "0.1.12"
 
 def EXE := if System.Platform.isWindows then ".exe" else ""
 


### PR DESCRIPTION
The latest version of leantar [includes](https://github.com/digama0/leangz/compare/v0.1.11...v0.1.12) the following features and bug fixes:

* An improved `--help` output
* Faster performance on windows and slow networks by reducing the number of OS calls (see digama0/leangz#3)
* Support for a new trace file format due to land in leanprover/lean4#4402 (see [zulip discussion](https://leanprover.zulipchat.com/#narrow/stream/287929-mathlib4/topic/ltar.20error.20aften.20lean.234402/near/444379353))

This is a backward compatible release, meaning that v0.1.12 can understand .ltar files produced by v0.1.11 and previous versions. So there should not be any hiccups during the transition period.