### PR TITLE
chore: correct `CompletelyNormalSpace` API to match `NormalSpace` by using `SeparatedNhds`

### DIFF
--- a/Counterexamples/SorgenfreyLine.lean
+++ b/Counterexamples/SorgenfreyLine.lean
@@ -203,7 +203,7 @@ instance : CompletelyNormalSpace ℝₗ := by
     exists_Ico_disjoint_closed isClosed_closure (disjoint_left.1 hd₂ hx)
   choose! Y hY hYd using fun y (hy : y ∈ t) =>
     exists_Ico_disjoint_closed isClosed_closure (disjoint_right.1 hd₁ hy)
-  refine disjoint_of_disjoint_of_mem ?_
+  refine separatedNhds_iff_disjoint.mpr <| disjoint_of_disjoint_of_mem ?_
     (bUnion_mem_nhdsSet fun x hx => (isOpen_Ico x (X x)).mem_nhds <| left_mem_Ico.2 (hX x hx))
     (bUnion_mem_nhdsSet fun y hy => (isOpen_Ico y (Y y)).mem_nhds <| left_mem_Ico.2 (hY y hy))
   simp only [disjoint_iUnion_left, disjoint_iUnion_right, Ico_disjoint_Ico]

--- a/Counterexamples/SorgenfreyLine.lean
+++ b/Counterexamples/SorgenfreyLine.lean
@@ -190,7 +190,7 @@ instance : FirstCountableTopology ℝₗ :=
 
 /-- Sorgenfrey line is a completely normal topological space.
     (Hausdorff follows as TotallyDisconnectedSpace → T₁) -/
-instance : CompletelyNormalSpace ℝₗ := by
+instance : CompletelyNormalSpace ℝₗ where completely_normal s t hd₁ hd₂ := by
   /-
   Let `s` and `t` be disjoint closed sets.
   For each `x ∈ s` we choose `X x` such that `Set.Ico x (X x)` is disjoint with `t`.
@@ -198,7 +198,6 @@ instance : CompletelyNormalSpace ℝₗ := by
   Then `⋃ x ∈ s, Ico x (X x)` and `⋃ y ∈ t, Ico y (Y y)` are
   disjoint open sets that include `s` and `t`.
   -/
-  refine ⟨fun s t hd₁ hd₂ => ?_⟩
   choose! X hX hXd using fun x (hx : x ∈ s) =>
     exists_Ico_disjoint_closed isClosed_closure (disjoint_left.1 hd₂ hx)
   choose! Y hY hYd using fun y (hy : y ∈ t) =>

--- a/Counterexamples/SorgenfreyLine.lean
+++ b/Counterexamples/SorgenfreyLine.lean
@@ -190,7 +190,7 @@ instance : FirstCountableTopology ℝₗ :=
 
 /-- Sorgenfrey line is a completely normal topological space.
     (Hausdorff follows as TotallyDisconnectedSpace → T₁) -/
-instance : CompletelyNormalSpace ℝₗ where completely_normal s t hd₁ hd₂ := by
+instance : CompletelyNormalSpace ℝₗ := by
   /-
   Let `s` and `t` be disjoint closed sets.
   For each `x ∈ s` we choose `X x` such that `Set.Ico x (X x)` is disjoint with `t`.
@@ -198,23 +198,24 @@ instance : CompletelyNormalSpace ℝₗ where completely_normal s t hd₁ hd₂ 
   Then `⋃ x ∈ s, Ico x (X x)` and `⋃ y ∈ t, Ico y (Y y)` are
   disjoint open sets that include `s` and `t`.
   -/
-  choose! X hX hXd using fun x (hx : x ∈ s) =>
+  refine ⟨fun s t hd₁ hd₂ ↦ ?_⟩
+  choose! X hX hXd using fun x (hx : x ∈ s) ↦
     exists_Ico_disjoint_closed isClosed_closure (disjoint_left.1 hd₂ hx)
-  choose! Y hY hYd using fun y (hy : y ∈ t) =>
+  choose! Y hY hYd using fun y (hy : y ∈ t) ↦
     exists_Ico_disjoint_closed isClosed_closure (disjoint_right.1 hd₁ hy)
   refine separatedNhds_iff_disjoint.mpr <| disjoint_of_disjoint_of_mem ?_
-    (bUnion_mem_nhdsSet fun x hx => (isOpen_Ico x (X x)).mem_nhds <| left_mem_Ico.2 (hX x hx))
-    (bUnion_mem_nhdsSet fun y hy => (isOpen_Ico y (Y y)).mem_nhds <| left_mem_Ico.2 (hY y hy))
+    (bUnion_mem_nhdsSet fun x hx ↦ (isOpen_Ico x (X x)).mem_nhds <| left_mem_Ico.2 (hX x hx))
+    (bUnion_mem_nhdsSet fun y hy ↦ (isOpen_Ico y (Y y)).mem_nhds <| left_mem_Ico.2 (hY y hy))
   simp only [disjoint_iUnion_left, disjoint_iUnion_right, Ico_disjoint_Ico]
   intro y hy x hx
   rcases le_total x y with hle | hle
   · calc
       min (X x) (Y y) ≤ X x := min_le_left _ _
-      _ ≤ y := (not_lt.1 fun hyx => (hXd x hx).le_bot ⟨⟨hle, hyx⟩, subset_closure hy⟩)
+      _ ≤ y := (not_lt.1 fun hyx ↦ (hXd x hx).le_bot ⟨⟨hle, hyx⟩, subset_closure hy⟩)
       _ ≤ max x y := le_max_right _ _
   · calc
       min (X x) (Y y) ≤ Y y := min_le_right _ _
-      _ ≤ x := (not_lt.1 fun hxy => (hYd y hy).le_bot ⟨⟨hle, hxy⟩, subset_closure hx⟩)
+      _ ≤ x := (not_lt.1 fun hxy ↦ (hYd y hy).le_bot ⟨⟨hle, hxy⟩, subset_closure hx⟩)
       _ ≤ max x y := le_max_left _ _
 
 theorem denseRange_ratCast : DenseRange ((↑) : ℚ → ℝₗ) := by

--- a/Counterexamples/SorgenfreyLine.lean
+++ b/Counterexamples/SorgenfreyLine.lean
@@ -188,25 +188,36 @@ instance : TotallyDisconnectedSpace ℝₗ :=
 instance : FirstCountableTopology ℝₗ :=
   ⟨fun x => (nhds_basis_Ico_rat x).isCountablyGenerated⟩
 
+
+/-- Applies Ico to each point of a set; used to witness SeparatedNhds in proof
+of `CompletelyNormalSpace ℝₗ`.-/
+def SetIco (s : Set ℝₗ) (X : ℝₗ → ℝₗ) := ⋃ x ∈ s, Ico x (X x)
+
+theorem isOpen_SetIco {s : Set ℝₗ} {X : ℝₗ → ℝₗ} : IsOpen (SetIco s X) :=
+    isOpen_biUnion fun x _ ↦ isOpen_Ico x (X x)
+
+theorem subset_SetIco {s : Set ℝₗ} {X : ℝₗ → ℝₗ} (h : ∀ x ∈ s, X x > x) : s ⊆ SetIco s X :=
+    fun x xins ↦ mem_biUnion xins <| left_mem_Ico.2 (h x xins).gt
+
+
 /-- Sorgenfrey line is a completely normal topological space.
     (Hausdorff follows as TotallyDisconnectedSpace → T₁) -/
 instance : CompletelyNormalSpace ℝₗ := by
   /-
-  Let `s` and `t` be disjoint closed sets.
-  For each `x ∈ s` we choose `X x` such that `Set.Ico x (X x)` is disjoint with `t`.
-  Similarly, for each `y ∈ t` we choose `Y y` such that `Set.Ico y (Y y)` is disjoint with `s`.
-  Then `⋃ x ∈ s, Ico x (X x)` and `⋃ y ∈ t, Ico y (Y y)` are
-  disjoint open sets that include `s` and `t`.
+  Let `s` and `t` be sets where `Disjoint s (closure t)` and `Disjoint (closure s) t`.
+  For each `x ∈ s` we choose `X x` such that `Set.Ico x (X x)` is disjoint with `closure t`.
+  Similarly, for each `y ∈ t` we choose `Y y` such that `Set.Ico y (Y y)` is disjoint with
+  `closure s`. Then `SetIco s X := ⋃ x ∈ s, Ico x (X x)` and
+  `SetIco t Y := ⋃ y ∈ t, Ico y (Y y)` are disjoint open sets that include `s` and `t`.
   -/
   refine ⟨fun s t hd₁ hd₂ ↦ ?_⟩
   choose! X hX hXd using fun x (hx : x ∈ s) ↦
     exists_Ico_disjoint_closed isClosed_closure (disjoint_left.1 hd₂ hx)
   choose! Y hY hYd using fun y (hy : y ∈ t) ↦
     exists_Ico_disjoint_closed isClosed_closure (disjoint_right.1 hd₁ hy)
-  refine separatedNhds_iff_disjoint.mpr <| disjoint_of_disjoint_of_mem ?_
-    (bUnion_mem_nhdsSet fun x hx ↦ (isOpen_Ico x (X x)).mem_nhds <| left_mem_Ico.2 (hX x hx))
-    (bUnion_mem_nhdsSet fun y hy ↦ (isOpen_Ico y (Y y)).mem_nhds <| left_mem_Ico.2 (hY y hy))
-  simp only [disjoint_iUnion_left, disjoint_iUnion_right, Ico_disjoint_Ico]
+  refine
+    ⟨SetIco s X, SetIco t Y, isOpen_SetIco, isOpen_SetIco, subset_SetIco hX, subset_SetIco hY, ?_⟩
+  simp only [SetIco, disjoint_iUnion_left, disjoint_iUnion_right, Ico_disjoint_Ico]
   intro y hy x hx
   rcases le_total x y with hle | hle
   · calc

--- a/Counterexamples/SorgenfreyLine.lean
+++ b/Counterexamples/SorgenfreyLine.lean
@@ -188,36 +188,25 @@ instance : TotallyDisconnectedSpace ℝₗ :=
 instance : FirstCountableTopology ℝₗ :=
   ⟨fun x => (nhds_basis_Ico_rat x).isCountablyGenerated⟩
 
-
-/-- Applies Ico to each point of a set; used to witness SeparatedNhds in proof
-of `CompletelyNormalSpace ℝₗ`.-/
-def SetIco (s : Set ℝₗ) (X : ℝₗ → ℝₗ) := ⋃ x ∈ s, Ico x (X x)
-
-theorem isOpen_SetIco {s : Set ℝₗ} {X : ℝₗ → ℝₗ} : IsOpen (SetIco s X) :=
-    isOpen_biUnion fun x _ ↦ isOpen_Ico x (X x)
-
-theorem subset_SetIco {s : Set ℝₗ} {X : ℝₗ → ℝₗ} (h : ∀ x ∈ s, X x > x) : s ⊆ SetIco s X :=
-    fun x xins ↦ mem_biUnion xins <| left_mem_Ico.2 (h x xins).gt
-
-
 /-- Sorgenfrey line is a completely normal topological space.
     (Hausdorff follows as TotallyDisconnectedSpace → T₁) -/
 instance : CompletelyNormalSpace ℝₗ := by
   /-
-  Let `s` and `t` be sets where `Disjoint s (closure t)` and `Disjoint (closure s) t`.
-  For each `x ∈ s` we choose `X x` such that `Set.Ico x (X x)` is disjoint with `closure t`.
-  Similarly, for each `y ∈ t` we choose `Y y` such that `Set.Ico y (Y y)` is disjoint with
-  `closure s`. Then `SetIco s X := ⋃ x ∈ s, Ico x (X x)` and
-  `SetIco t Y := ⋃ y ∈ t, Ico y (Y y)` are disjoint open sets that include `s` and `t`.
+  Let `s` and `t` be disjoint closed sets.
+  For each `x ∈ s` we choose `X x` such that `Set.Ico x (X x)` is disjoint with `t`.
+  Similarly, for each `y ∈ t` we choose `Y y` such that `Set.Ico y (Y y)` is disjoint with `s`.
+  Then `⋃ x ∈ s, Ico x (X x)` and `⋃ y ∈ t, Ico y (Y y)` are
+  disjoint open sets that include `s` and `t`.
   -/
   refine ⟨fun s t hd₁ hd₂ ↦ ?_⟩
   choose! X hX hXd using fun x (hx : x ∈ s) ↦
     exists_Ico_disjoint_closed isClosed_closure (disjoint_left.1 hd₂ hx)
   choose! Y hY hYd using fun y (hy : y ∈ t) ↦
     exists_Ico_disjoint_closed isClosed_closure (disjoint_right.1 hd₁ hy)
-  refine
-    ⟨SetIco s X, SetIco t Y, isOpen_SetIco, isOpen_SetIco, subset_SetIco hX, subset_SetIco hY, ?_⟩
-  simp only [SetIco, disjoint_iUnion_left, disjoint_iUnion_right, Ico_disjoint_Ico]
+  refine separatedNhds_iff_disjoint.mpr <| disjoint_of_disjoint_of_mem ?_
+    (bUnion_mem_nhdsSet fun x hx ↦ (isOpen_Ico x (X x)).mem_nhds <| left_mem_Ico.2 (hX x hx))
+    (bUnion_mem_nhdsSet fun y hy ↦ (isOpen_Ico y (Y y)).mem_nhds <| left_mem_Ico.2 (hY y hy))
+  simp only [disjoint_iUnion_left, disjoint_iUnion_right, Ico_disjoint_Ico]
   intro y hy x hx
   rcases le_total x y with hle | hle
   · calc

--- a/Mathlib/Topology/Algebra/WithZeroTopology.lean
+++ b/Mathlib/Topology/Algebra/WithZeroTopology.lean
@@ -169,8 +169,10 @@ scoped instance (priority := 100) t5Space : T5Space Γ₀ where
   completely_normal := fun s t h₁ h₂ => by
     by_cases hs : 0 ∈ s
     · have ht : 0 ∉ t := fun ht => disjoint_left.1 h₁ (subset_closure hs) ht
-      rwa [(isOpen_iff.2 (.inl ht)).nhdsSet_eq, disjoint_nhdsSet_principal]
-    · rwa [(isOpen_iff.2 (.inl hs)).nhdsSet_eq, disjoint_principal_nhdsSet]
+      rwa [separatedNhds_iff_disjoint, (isOpen_iff.2 (.inl ht)).nhdsSet_eq,
+        disjoint_nhdsSet_principal]
+    · rwa [separatedNhds_iff_disjoint, (isOpen_iff.2 (.inl hs)).nhdsSet_eq,
+        disjoint_principal_nhdsSet]
 
 /-- The topology on a linearly ordered group with zero element adjoined is T₃. -/
 @[deprecated t5Space (since := "2023-03-17")] lemma t3Space : T3Space Γ₀ := inferInstance

--- a/Mathlib/Topology/Algebra/WithZeroTopology.lean
+++ b/Mathlib/Topology/Algebra/WithZeroTopology.lean
@@ -166,7 +166,7 @@ scoped instance (priority := 100) orderClosedTopology : OrderClosedTopology Γ�
 /-- The topology on a linearly ordered group with zero element adjoined is T₅. -/
 @[nolint defLemma]
 scoped instance (priority := 100) t5Space : T5Space Γ₀ where
-  completely_normal := fun s t h₁ h₂ => by
+  completely_normal s t h₁ h₂ := by
     by_cases hs : 0 ∈ s
     · have ht : 0 ∉ t := fun ht => disjoint_left.1 h₁ (subset_closure hs) ht
       rwa [separatedNhds_iff_disjoint, (isOpen_iff.2 (.inl ht)).nhdsSet_eq,

--- a/Mathlib/Topology/Order/T5.lean
+++ b/Mathlib/Topology/Order/T5.lean
@@ -93,7 +93,7 @@ open Set
 
 /-- A linear order with order topology is a completely normal Hausdorff topological space. -/
 instance (priority := 100) OrderTopology.completelyNormalSpace : CompletelyNormalSpace X :=
-  ⟨fun s t h₁ h₂ => Filter.disjoint_iff.2
+  ⟨fun s t h₁ h₂ => separatedNhds_iff_disjoint.2 <| Filter.disjoint_iff.2
     ⟨ordT5Nhd s t, ordT5Nhd_mem_nhdsSet h₂, ordT5Nhd t s, ordT5Nhd_mem_nhdsSet h₁.symm,
       disjoint_ordT5Nhd⟩⟩
 

--- a/Mathlib/Topology/Order/T5.lean
+++ b/Mathlib/Topology/Order/T5.lean
@@ -87,6 +87,7 @@ theorem ordT5Nhd_mem_nhdsSet (hd : Disjoint s (closure t)) : ordT5Nhd s t ‚àà ù
     (compl_section_ordSeparatingSet_mem_nhds hd hx)
 #align set.ord_t5_nhd_mem_nhds_set Set.ordT5Nhd_mem_nhdsSet
 
+/-- Refines ordT5Nhd to satisfy `IsOpen` -/
 def ordT5OpenNhd (s t : Set X) : Set X := interior <| ordT5Nhd s t
 
 theorem disjoint_ordT5OpenNhd : Disjoint (ordT5OpenNhd s t) (ordT5OpenNhd t s) :=

--- a/Mathlib/Topology/Order/T5.lean
+++ b/Mathlib/Topology/Order/T5.lean
@@ -87,23 +87,15 @@ theorem ordT5Nhd_mem_nhdsSet (hd : Disjoint s (closure t)) : ordT5Nhd s t ∈ �
     (compl_section_ordSeparatingSet_mem_nhds hd hx)
 #align set.ord_t5_nhd_mem_nhds_set Set.ordT5Nhd_mem_nhdsSet
 
-/-- Refines ordT5Nhd to satisfy `IsOpen` -/
-def ordT5OpenNhd (s t : Set X) : Set X := interior <| ordT5Nhd s t
-
-theorem disjoint_ordT5OpenNhd : Disjoint (ordT5OpenNhd s t) (ordT5OpenNhd t s) :=
-    disjoint_ordT5Nhd.mono interior_subset interior_subset
-
-theorem subset_ordT5OpenNhd (hd : Disjoint s (closure t)) : s ⊆ ordT5OpenNhd s t :=
-  subset_interior_iff_mem_nhdsSet.mpr <| ordT5Nhd_mem_nhdsSet hd
-
 end Set
 
 open Set
 
 /-- A linear order with order topology is a completely normal Hausdorff topological space. -/
 instance (priority := 100) OrderTopology.completelyNormalSpace : CompletelyNormalSpace X :=
-  ⟨fun s t h₁ h₂ ↦ ⟨ordT5OpenNhd s t, ordT5OpenNhd t s, isOpen_interior, isOpen_interior,
-    subset_ordT5OpenNhd h₂, subset_ordT5OpenNhd h₁.symm, disjoint_ordT5OpenNhd⟩⟩
+  ⟨fun s t h₁ h₂ => separatedNhds_iff_disjoint.2 <| Filter.disjoint_iff.2
+    ⟨ordT5Nhd s t, ordT5Nhd_mem_nhdsSet h₂, ordT5Nhd t s, ordT5Nhd_mem_nhdsSet h₁.symm,
+      disjoint_ordT5Nhd⟩⟩
 
 instance (priority := 100) OrderTopology.t5Space : T5Space X := T5Space.mk
 #align order_topology.t5_space OrderTopology.t5Space

--- a/Mathlib/Topology/Order/T5.lean
+++ b/Mathlib/Topology/Order/T5.lean
@@ -87,6 +87,14 @@ theorem ordT5Nhd_mem_nhdsSet (hd : Disjoint s (closure t)) : ordT5Nhd s t ∈ �
     (compl_section_ordSeparatingSet_mem_nhds hd hx)
 #align set.ord_t5_nhd_mem_nhds_set Set.ordT5Nhd_mem_nhdsSet
 
+def ordT5OpenNhd (s t : Set X) : Set X := interior <| ordT5Nhd s t
+
+theorem disjoint_ordT5OpenNhd : Disjoint (ordT5OpenNhd s t) (ordT5OpenNhd t s) :=
+    disjoint_ordT5Nhd.mono interior_subset interior_subset
+
+theorem subset_ordT5OpenNhd (hd : Disjoint s (closure t)) : s ⊆ ordT5OpenNhd s t :=
+  subset_interior_iff_mem_nhdsSet.mpr <| ordT5Nhd_mem_nhdsSet hd
+
 end Set
 
 open Set

--- a/Mathlib/Topology/Order/T5.lean
+++ b/Mathlib/Topology/Order/T5.lean
@@ -87,14 +87,6 @@ theorem ordT5Nhd_mem_nhdsSet (hd : Disjoint s (closure t)) : ordT5Nhd s t ∈ �
     (compl_section_ordSeparatingSet_mem_nhds hd hx)
 #align set.ord_t5_nhd_mem_nhds_set Set.ordT5Nhd_mem_nhdsSet
 
-def ordT5OpenNhd (s t : Set X) : Set X := interior <| ordT5Nhd s t
-
-theorem disjoint_ordT5OpenNhd : Disjoint (ordT5OpenNhd s t) (ordT5OpenNhd t s) :=
-    disjoint_ordT5Nhd.mono interior_subset interior_subset
-
-theorem subset_ordT5OpenNhd (hd : Disjoint s (closure t)) : s ⊆ ordT5OpenNhd s t :=
-  subset_interior_iff_mem_nhdsSet.mpr <| ordT5Nhd_mem_nhdsSet hd
-
 end Set
 
 open Set

--- a/Mathlib/Topology/Order/T5.lean
+++ b/Mathlib/Topology/Order/T5.lean
@@ -87,15 +87,22 @@ theorem ordT5Nhd_mem_nhdsSet (hd : Disjoint s (closure t)) : ordT5Nhd s t ∈ �
     (compl_section_ordSeparatingSet_mem_nhds hd hx)
 #align set.ord_t5_nhd_mem_nhds_set Set.ordT5Nhd_mem_nhdsSet
 
+def ordT5OpenNhd (s t : Set X) : Set X := interior <| ordT5Nhd s t
+
+theorem disjoint_ordT5OpenNhd : Disjoint (ordT5OpenNhd s t) (ordT5OpenNhd t s) :=
+    disjoint_ordT5Nhd.mono interior_subset interior_subset
+
+theorem subset_ordT5OpenNhd (hd : Disjoint s (closure t)) : s ⊆ ordT5OpenNhd s t :=
+  subset_interior_iff_mem_nhdsSet.mpr <| ordT5Nhd_mem_nhdsSet hd
+
 end Set
 
 open Set
 
 /-- A linear order with order topology is a completely normal Hausdorff topological space. -/
 instance (priority := 100) OrderTopology.completelyNormalSpace : CompletelyNormalSpace X :=
-  ⟨fun s t h₁ h₂ => separatedNhds_iff_disjoint.2 <| Filter.disjoint_iff.2
-    ⟨ordT5Nhd s t, ordT5Nhd_mem_nhdsSet h₂, ordT5Nhd t s, ordT5Nhd_mem_nhdsSet h₁.symm,
-      disjoint_ordT5Nhd⟩⟩
+  ⟨fun s t h₁ h₂ ↦ ⟨ordT5OpenNhd s t, ordT5OpenNhd t s, isOpen_interior, isOpen_interior,
+    subset_ordT5OpenNhd h₂, subset_ordT5OpenNhd h₁.symm, disjoint_ordT5OpenNhd⟩⟩
 
 instance (priority := 100) OrderTopology.t5Space : T5Space X := T5Space.mk
 #align order_topology.t5_space OrderTopology.t5Space

--- a/Mathlib/Topology/Separation.lean
+++ b/Mathlib/Topology/Separation.lean
@@ -2388,7 +2388,7 @@ class CompletelyNormalSpace (X : Type u) [TopologicalSpace X] : Prop where
   /-- If `closure s` is disjoint with `t`, and `s` is disjoint with `closure t`, then `s` and `t`
   admit disjoint neighbourhoods. -/
   completely_normal :
-    ∀ ⦃s t : Set X⦄, Disjoint (closure s) t → Disjoint s (closure t) → Disjoint (𝓝ˢ s) (𝓝ˢ t)
+    ∀ ⦃s t : Set X⦄, Disjoint (closure s) t → Disjoint s (closure t) → SeparatedNhds s t
 
 export CompletelyNormalSpace (completely_normal)
 
@@ -2396,14 +2396,14 @@ export CompletelyNormalSpace (completely_normal)
 /-- A completely normal space is a normal space. -/
 instance (priority := 100) CompletelyNormalSpace.toNormalSpace
     [CompletelyNormalSpace X] : NormalSpace X where
-  normal s t hs ht hd := separatedNhds_iff_disjoint.2 <|
-    completely_normal (by rwa [hs.closure_eq]) (by rwa [ht.closure_eq])
+  normal s t hs ht hd := completely_normal (by rwa [hs.closure_eq]) (by rwa [ht.closure_eq])
 
 theorem Embedding.completelyNormalSpace [TopologicalSpace Y] [CompletelyNormalSpace Y] {e : X → Y}
     (he : Embedding e) : CompletelyNormalSpace X := by
   refine ⟨fun s t hd₁ hd₂ => ?_⟩
+  rw [separatedNhds_iff_disjoint]
   simp only [he.toInducing.nhdsSet_eq_comap]
-  refine disjoint_comap (completely_normal ?_ ?_)
+  refine disjoint_comap <| separatedNhds_iff_disjoint.1 <| completely_normal ?_ ?_
   · rwa [← subset_compl_iff_disjoint_left, image_subset_iff, preimage_compl,
       ← he.closure_eq_preimage_closure_image, subset_compl_iff_disjoint_left]
   · rwa [← subset_compl_iff_disjoint_right, image_subset_iff, preimage_compl,
@@ -2449,7 +2449,8 @@ instance [CompletelyNormalSpace X] [R0Space X] : T5Space (SeparationQuotient X) 
   t1 := by
     rwa [((t1Space_TFAE (SeparationQuotient X)).out 1 0 :), SeparationQuotient.t1Space_iff]
   completely_normal s t hd₁ hd₂ := by
-    rw [← disjoint_comap_iff surjective_mk, comap_mk_nhdsSet, comap_mk_nhdsSet]
+    rw [separatedNhds_iff_disjoint, ← disjoint_comap_iff surjective_mk, comap_mk_nhdsSet, comap_mk_nhdsSet]
+    apply separatedNhds_iff_disjoint.1
     apply completely_normal <;> rw [← preimage_mk_closure]
     exacts [hd₁.preimage mk, hd₂.preimage mk]
 

--- a/Mathlib/Topology/Separation.lean
+++ b/Mathlib/Topology/Separation.lean
@@ -2400,10 +2400,9 @@ instance (priority := 100) CompletelyNormalSpace.toNormalSpace
 
 theorem Embedding.completelyNormalSpace [TopologicalSpace Y] [CompletelyNormalSpace Y] {e : X → Y}
     (he : Embedding e) : CompletelyNormalSpace X := by
-  refine ⟨fun s t hd₁ hd₂ => ?_⟩
-  rw [separatedNhds_iff_disjoint]
+  refine ⟨fun s t hd₁ hd₂ => separatedNhds_iff_disjoint.mpr ?_⟩
   simp only [he.toInducing.nhdsSet_eq_comap]
-  refine disjoint_comap <| separatedNhds_iff_disjoint.1 <| completely_normal ?_ ?_
+  refine disjoint_comap <| separatedNhds_iff_disjoint.mp <| completely_normal ?_ ?_
   · rwa [← subset_compl_iff_disjoint_left, image_subset_iff, preimage_compl,
       ← he.closure_eq_preimage_closure_image, subset_compl_iff_disjoint_left]
   · rwa [← subset_compl_iff_disjoint_right, image_subset_iff, preimage_compl,
@@ -2449,7 +2448,8 @@ instance [CompletelyNormalSpace X] [R0Space X] : T5Space (SeparationQuotient X) 
   t1 := by
     rwa [((t1Space_TFAE (SeparationQuotient X)).out 1 0 :), SeparationQuotient.t1Space_iff]
   completely_normal s t hd₁ hd₂ := by
-    rw [separatedNhds_iff_disjoint, ← disjoint_comap_iff surjective_mk, comap_mk_nhdsSet, comap_mk_nhdsSet]
+    rw [separatedNhds_iff_disjoint, ← disjoint_comap_iff surjective_mk, comap_mk_nhdsSet,
+      comap_mk_nhdsSet]
     apply separatedNhds_iff_disjoint.1
     apply completely_normal <;> rw [← preimage_mk_closure]
     exacts [hd₁.preimage mk, hd₂.preimage mk]


### PR DESCRIPTION
The current behavior for CompletelyNormalSpace is to prove `Disjoint (𝓝ˢ s) (𝓝ˢ t)`, while NormalSpace uses a proof of the (equivalent) `SeparatedNhds s t`. This changes aligns both separation axioms to use `SeparatedNhds s t`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
