### PR TITLE
[Merged by Bors] - chore: Fix statement of `Finset.sum_boole_mul`

### DIFF
--- a/Mathlib/Algebra/BigOperators/Ring.lean
+++ b/Mathlib/Algebra/BigOperators/Ring.lean
@@ -105,7 +105,7 @@ lemma sum_mul_boole (s : Finset ι) (f : ι → α) (i : ι) :
 #align finset.sum_mul_boole Finset.sum_mul_boole
 
 lemma sum_boole_mul (s : Finset ι) (f : ι → α) (i : ι) :
-    ∑ j ∈ s, ite (i = j) 1 0 * f i = ite (i ∈ s) (f i) 0 := by simp
+    ∑ j ∈ s, ite (i = j) 1 0 * f j = ite (i ∈ s) (f i) 0 := by simp
 #align finset.sum_boole_mul Finset.sum_boole_mul
 
 end NonAssocSemiring


### PR DESCRIPTION
The sum incorrectly referred to the wrong variable Compare with `sum_mul_boole` just above.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
