### PR TITLE
[Merged by Bors] - chore: Rename `Nat.factors` to `Nat.primeFactorsList`

### DIFF
--- a/Archive/Wiedijk100Theorems/SumOfPrimeReciprocalsDiverges.lean
+++ b/Archive/Wiedijk100Theorems/SumOfPrimeReciprocalsDiverges.lean
@@ -150,16 +150,16 @@ theorem card_le_two_pow {x k : ℕ} :
     intro m hm
     simp only [f, K, M₁, M, mem_filter, mem_range, mem_powerset, mem_image, exists_prop] at hm ⊢
     obtain ⟨⟨-, hmp⟩, hms⟩ := hm
-    use! (m + 1).factors
-    · rwa [Multiset.coe_nodup, ← Nat.squarefree_iff_nodup_factors m.succ_ne_zero]
+    use! (m + 1).primeFactorsList
+    · rwa [Multiset.coe_nodup, ← Nat.squarefree_iff_nodup_primeFactorsList m.succ_ne_zero]
     refine ⟨fun p => ?_, ?_⟩
-    · suffices p ∈ (m + 1).factors → ∃ a : ℕ, a < k ∧ a.succ = p by simpa
-      simp only [Nat.mem_factors m.succ_ne_zero]
+    · suffices p ∈ (m + 1).primeFactorsList → ∃ a : ℕ, a < k ∧ a.succ = p by simpa
+      simp only [Nat.mem_primeFactorsList m.succ_ne_zero]
       intro hp
       exact
         ⟨p.pred, (Nat.pred_lt (Nat.Prime.ne_zero hp.1)).trans_le ((hmp p) hp),
           Nat.succ_pred_eq_of_pos (Nat.Prime.pos hp.1)⟩
-    · simp [Nat.prod_factors m.succ_ne_zero, m.add_one_sub_one]
+    · simp [Nat.prod_primeFactorsList m.succ_ne_zero, m.add_one_sub_one]
   -- The number of elements of `M x k` with `e + 1` squarefree is bounded by the number of subsets
   -- of `[1, k]`.
   calc

--- a/Mathlib/Data/Nat/Factorization/Basic.lean
+++ b/Mathlib/Data/Nat/Factorization/Basic.lean
@@ -123,7 +123,7 @@ theorem factorization_one : factorization 1 = 0 := by ext; simp [factorization]
 
 #noalign nat.support_factorization
 
-#align nat.factor_iff_mem_factorization Nat.mem_primeFactors_iff_mem_factors
+#align nat.factor_iff_mem_factorization Nat.mem_primeFactors_iff_mem_primeFactorsList
 #align nat.prime_of_mem_factorization Nat.prime_of_mem_primeFactors
 #align nat.pos_of_mem_factorization Nat.pos_of_mem_primeFactors
 #align nat.le_of_mem_factorization Nat.le_of_mem_primeFactors
@@ -160,7 +160,7 @@ theorem factorization_one_right (n : ℕ) : n.factorization 1 = 0 :=
 #align nat.factorization_one_right Nat.factorization_one_right
 
 theorem dvd_of_factorization_pos {n p : ℕ} (hn : n.factorization p ≠ 0) : p ∣ n :=
-  dvd_of_mem_primeFactorsList <| mem_primeFactors_iff_mem_factors.1 <| mem_support_iff.2 hn
+  dvd_of_mem_primeFactorsList <| mem_primeFactors_iff_mem_primeFactorsList.1 <| mem_support_iff.2 hn
 #align nat.dvd_of_factorization_pos Nat.dvd_of_factorization_pos
 
 theorem Prime.factorization_pos_of_dvd {n p : ℕ} (hp : p.Prime) (hn : n ≠ 0) (h : p ∣ n) :

--- a/Mathlib/Data/Nat/Factorization/Basic.lean
+++ b/Mathlib/Data/Nat/Factorization/Basic.lean
@@ -87,6 +87,10 @@ theorem factorization_eq_primeFactorsList_multiset (n : ℕ) :
   simp
 #align nat.factorization_eq_factors_multiset Nat.factorization_eq_primeFactorsList_multiset
 
+@[deprecated (since := "2024-07-16")] alias factors_count_eq := primeFactorsList_count_eq
+@[deprecated (since := "2024-07-16")]
+alias factorization_eq_factors_multiset := factorization_eq_primeFactorsList_multiset
+
 theorem multiplicity_eq_factorization {n p : ℕ} (pp : p.Prime) (hn : n ≠ 0) :
     multiplicity p n = n.factorization p := by
   simp [factorization, pp, padicValNat_def' pp.ne_one hn.bot_lt]

--- a/Mathlib/Data/Nat/Factorization/Basic.lean
+++ b/Mathlib/Data/Nat/Factorization/Basic.lean
@@ -64,28 +64,28 @@ theorem factorization_def (n : ℕ) {p : ℕ} (pp : p.Prime) : n.factorization p
 /-- We can write both `n.factorization p` and `n.factors.count p` to represent the power
 of `p` in the factorization of `n`: we declare the former to be the simp-normal form. -/
 @[simp]
-theorem factors_count_eq {n p : ℕ} : n.factors.count p = n.factorization p := by
+theorem primeFactorsList_count_eq {n p : ℕ} : n.primeFactorsList.count p = n.factorization p := by
   rcases n.eq_zero_or_pos with (rfl | hn0)
   · simp [factorization, count]
   if pp : p.Prime then ?_ else
-    rw [count_eq_zero_of_not_mem (mt prime_of_mem_factors pp)]
+    rw [count_eq_zero_of_not_mem (mt prime_of_mem_primeFactorsList pp)]
     simp [factorization, pp]
   simp only [factorization_def _ pp]
   apply _root_.le_antisymm
-  · rw [le_padicValNat_iff_replicate_subperm_factors pp hn0.ne']
+  · rw [le_padicValNat_iff_replicate_subperm_primeFactorsList pp hn0.ne']
     exact List.le_count_iff_replicate_sublist.mp le_rfl |>.subperm
   · rw [← Nat.lt_add_one_iff, lt_iff_not_ge, ge_iff_le,
-      le_padicValNat_iff_replicate_subperm_factors pp hn0.ne']
+      le_padicValNat_iff_replicate_subperm_primeFactorsList pp hn0.ne']
     intro h
     have := h.count_le p
     simp at this
-#align nat.factors_count_eq Nat.factors_count_eq
+#align nat.factors_count_eq Nat.primeFactorsList_count_eq
 
-theorem factorization_eq_factors_multiset (n : ℕ) :
-    n.factorization = Multiset.toFinsupp (n.factors : Multiset ℕ) := by
+theorem factorization_eq_primeFactorsList_multiset (n : ℕ) :
+    n.factorization = Multiset.toFinsupp (n.primeFactorsList : Multiset ℕ) := by
   ext p
   simp
-#align nat.factorization_eq_factors_multiset Nat.factorization_eq_factors_multiset
+#align nat.factorization_eq_factors_multiset Nat.factorization_eq_primeFactorsList_multiset
 
 theorem multiplicity_eq_factorization {n p : ℕ} (pp : p.Prime) (hn : n ≠ 0) :
     multiplicity p n = n.factorization p := by
@@ -97,14 +97,15 @@ theorem multiplicity_eq_factorization {n p : ℕ} (pp : p.Prime) (hn : n ≠ 0) 
 
 @[simp]
 theorem factorization_prod_pow_eq_self {n : ℕ} (hn : n ≠ 0) : n.factorization.prod (· ^ ·) = n := by
-  rw [factorization_eq_factors_multiset n]
+  rw [factorization_eq_primeFactorsList_multiset n]
   simp only [← prod_toMultiset, factorization, Multiset.prod_coe, Multiset.toFinsupp_toMultiset]
-  exact prod_factors hn
+  exact prod_primeFactorsList hn
 #align nat.factorization_prod_pow_eq_self Nat.factorization_prod_pow_eq_self
 
 theorem eq_of_factorization_eq {a b : ℕ} (ha : a ≠ 0) (hb : b ≠ 0)
     (h : ∀ p : ℕ, a.factorization p = b.factorization p) : a = b :=
-  eq_of_perm_factors ha hb (by simpa only [List.perm_iff_count, factors_count_eq] using h)
+  eq_of_perm_primeFactorsList ha hb
+    (by simpa only [List.perm_iff_count, primeFactorsList_count_eq] using h)
 #align nat.eq_of_factorization_eq Nat.eq_of_factorization_eq
 
 /-- Every nonzero natural number has a unique prime factorization -/
@@ -159,12 +160,12 @@ theorem factorization_one_right (n : ℕ) : n.factorization 1 = 0 :=
 #align nat.factorization_one_right Nat.factorization_one_right
 
 theorem dvd_of_factorization_pos {n p : ℕ} (hn : n.factorization p ≠ 0) : p ∣ n :=
-  dvd_of_mem_factors <| mem_primeFactors_iff_mem_factors.1 <| mem_support_iff.2 hn
+  dvd_of_mem_primeFactorsList <| mem_primeFactors_iff_mem_factors.1 <| mem_support_iff.2 hn
 #align nat.dvd_of_factorization_pos Nat.dvd_of_factorization_pos
 
 theorem Prime.factorization_pos_of_dvd {n p : ℕ} (hp : p.Prime) (hn : n ≠ 0) (h : p ∣ n) :
     0 < n.factorization p := by
-    rwa [← factors_count_eq, count_pos_iff_mem, mem_factors_iff_dvd hn hp]
+    rwa [← primeFactorsList_count_eq, count_pos_iff_mem, mem_primeFactorsList_iff_dvd hn hp]
 #align nat.prime.factorization_pos_of_dvd Nat.Prime.factorization_pos_of_dvd
 
 theorem factorization_eq_zero_of_remainder {p r : ℕ} (i : ℕ) (hr : ¬p ∣ r) :
@@ -186,7 +187,7 @@ theorem factorization_eq_zero_iff_remainder {p r : ℕ} (i : ℕ) (pp : p.Prime)
 
 /-- The only numbers with empty prime factorization are `0` and `1` -/
 theorem factorization_eq_zero_iff' (n : ℕ) : n.factorization = 0 ↔ n = 0 ∨ n = 1 := by
-  rw [factorization_eq_factors_multiset n]
+  rw [factorization_eq_primeFactorsList_multiset n]
   simp [factorization, AddEquiv.map_eq_zero_iff, Multiset.coe_eq_zero]
 #align nat.factorization_eq_zero_iff' Nat.factorization_eq_zero_iff'
 
@@ -198,8 +199,8 @@ theorem factorization_eq_zero_iff' (n : ℕ) : n.factorization = 0 ↔ n = 0 ∨
 theorem factorization_mul {a b : ℕ} (ha : a ≠ 0) (hb : b ≠ 0) :
     (a * b).factorization = a.factorization + b.factorization := by
   ext p
-  simp only [add_apply, ← factors_count_eq, perm_iff_count.mp (perm_factors_mul ha hb) p,
-    count_append]
+  simp only [add_apply, ← primeFactorsList_count_eq,
+    perm_iff_count.mp (perm_primeFactorsList_mul ha hb) p, count_append]
 #align nat.factorization_mul Nat.factorization_mul
 
 #align nat.factorization_mul_support Nat.primeFactors_mul
@@ -244,8 +245,8 @@ theorem factorization_pow (n k : ℕ) : factorization (n ^ k) = k • n.factoriz
 @[simp]
 protected theorem Prime.factorization {p : ℕ} (hp : Prime p) : p.factorization = single p 1 := by
   ext q
-  rw [← factors_count_eq, factors_prime hp, single_apply, count_singleton', if_congr eq_comm] <;>
-    rfl
+  rw [← primeFactorsList_count_eq, primeFactorsList_prime hp, single_apply, count_singleton',
+    if_congr eq_comm] <;> rfl
 #align nat.prime.factorization Nat.Prime.factorization
 
 /-- The multiplicity of prime `p` in `p` is `1` -/
@@ -339,9 +340,9 @@ theorem ord_compl_of_not_prime (n p : ℕ) (hp : ¬p.Prime) : ord_compl[p] n = n
 
 theorem ord_proj_dvd (n p : ℕ) : ord_proj[p] n ∣ n := by
   if hp : p.Prime then ?_ else simp [hp]
-  rw [← factors_count_eq]
-  apply dvd_of_factors_subperm (pow_ne_zero _ hp.ne_zero)
-  rw [hp.factors_pow, List.subperm_ext_iff]
+  rw [← primeFactorsList_count_eq]
+  apply dvd_of_primeFactorsList_subperm (pow_ne_zero _ hp.ne_zero)
+  rw [hp.primeFactorsList_pow, List.subperm_ext_iff]
   intro q hq
   simp [List.eq_of_mem_replicate hq]
 #align nat.ord_proj_dvd Nat.ord_proj_dvd
@@ -622,7 +623,7 @@ theorem prod_primeFactors_dvd (n : ℕ) : ∏ p ∈ n.primeFactors, p ∣ n := b
   by_cases hn : n = 0
   · subst hn
     simp
-  simpa [prod_factors hn] using Multiset.toFinset_prod_dvd_prod (n.factors : Multiset ℕ)
+  · simpa [prod_primeFactorsList hn] using (n.primeFactorsList : Multiset ℕ).toFinset_prod_dvd_prod
 #align nat.prod_prime_factors_dvd Nat.prod_primeFactors_dvd
 
 theorem factorization_gcd {a b : ℕ} (ha_pos : a ≠ 0) (hb_pos : b ≠ 0) :
@@ -631,8 +632,8 @@ theorem factorization_gcd {a b : ℕ} (ha_pos : a ≠ 0) (hb_pos : b ≠ 0) :
   let d := dfac.prod (· ^ ·)
   have dfac_prime : ∀ p : ℕ, p ∈ dfac.support → Prime p := by
     intro p hp
-    have : p ∈ a.factors ∧ p ∈ b.factors := by simpa [dfac] using hp
-    exact prime_of_mem_factors this.1
+    have : p ∈ a.primeFactorsList ∧ p ∈ b.primeFactorsList := by simpa [dfac] using hp
+    exact prime_of_mem_primeFactorsList this.1
   have h1 : d.factorization = dfac := prod_pow_factorization_eq_self dfac_prime
   have hd_pos : d ≠ 0 := (factorizationEquiv.invFun ⟨dfac, dfac_prime⟩).2.ne'
   suffices d = gcd a b by rwa [← this]
@@ -814,7 +815,8 @@ theorem Ico_filter_pow_dvd_eq {n p b : ℕ} (pp : p.Prime) (hn : n ≠ 0) (hb : 
 /-- For coprime `a` and `b`, the power of `p` in `a * b` is the sum of the powers in `a` and `b` -/
 theorem factorization_mul_apply_of_coprime {p a b : ℕ} (hab : Coprime a b) :
     (a * b).factorization p = a.factorization p + b.factorization p := by
-  simp only [← factors_count_eq, perm_iff_count.mp (perm_factors_mul_of_coprime hab), count_append]
+  simp only [← primeFactorsList_count_eq,
+    perm_iff_count.mp (perm_primeFactorsList_mul_of_coprime hab), count_append]
 #align nat.factorization_mul_apply_of_coprime Nat.factorization_mul_apply_of_coprime
 
 /-- For coprime `a` and `b`, the power of `p` in `a * b` is the sum of the powers in `a` and `b` -/
@@ -826,16 +828,17 @@ theorem factorization_mul_of_coprime {a b : ℕ} (hab : Coprime a b) :
 
 /-- If `p` is a prime factor of `a` then the power of `p` in `a` is the same that in `a * b`,
 for any `b` coprime to `a`. -/
-theorem factorization_eq_of_coprime_left {p a b : ℕ} (hab : Coprime a b) (hpa : p ∈ a.factors) :
-    (a * b).factorization p = a.factorization p := by
-  rw [factorization_mul_apply_of_coprime hab, ← factors_count_eq, ← factors_count_eq,
-    count_eq_zero_of_not_mem (coprime_factors_disjoint hab hpa), add_zero]
+theorem factorization_eq_of_coprime_left {p a b : ℕ} (hab : Coprime a b)
+    (hpa : p ∈ a.primeFactorsList) : (a * b).factorization p = a.factorization p := by
+  rw [factorization_mul_apply_of_coprime hab, ← primeFactorsList_count_eq,
+    ← primeFactorsList_count_eq,
+    count_eq_zero_of_not_mem (coprime_primeFactorsList_disjoint hab hpa), add_zero]
 #align nat.factorization_eq_of_coprime_left Nat.factorization_eq_of_coprime_left
 
 /-- If `p` is a prime factor of `b` then the power of `p` in `b` is the same that in `a * b`,
 for any `a` coprime to `b`. -/
-theorem factorization_eq_of_coprime_right {p a b : ℕ} (hab : Coprime a b) (hpb : p ∈ b.factors) :
-    (a * b).factorization p = b.factorization p := by
+theorem factorization_eq_of_coprime_right {p a b : ℕ} (hab : Coprime a b)
+    (hpb : p ∈ b.primeFactorsList) : (a * b).factorization p = b.factorization p := by
   rw [mul_comm]
   exact factorization_eq_of_coprime_left (coprime_comm.mp hab) hpb
 #align nat.factorization_eq_of_coprime_right Nat.factorization_eq_of_coprime_right

--- a/Mathlib/Data/Nat/Factorization/PrimePow.lean
+++ b/Mathlib/Data/Nat/Factorization/PrimePow.lean
@@ -100,10 +100,10 @@ theorem isPrimePow_iff_unique_prime_dvd {n : ℕ} : IsPrimePow n ↔ ∃! p : �
   simp only [and_imp] at hq
   apply Nat.dvd_antisymm (Nat.ord_proj_dvd _ _)
   -- We need to show n ∣ p ^ n.factorization p
-  apply Nat.dvd_of_factors_subperm hn₀
-  rw [hp.factors_pow, List.subperm_ext_iff]
+  apply Nat.dvd_of_primeFactorsList_subperm hn₀
+  rw [hp.primeFactorsList_pow, List.subperm_ext_iff]
   intro q hq'
-  rw [Nat.mem_factors hn₀] at hq'
+  rw [Nat.mem_primeFactorsList hn₀] at hq'
   cases hq _ hq'.1 hq'.2
   simp
 #align is_prime_pow_iff_unique_prime_dvd isPrimePow_iff_unique_prime_dvd

--- a/Mathlib/Data/Nat/Factors.lean
+++ b/Mathlib/Data/Nat/Factors.lean
@@ -31,28 +31,30 @@ namespace Nat
 
 attribute [instance 0] instBEqNat
 
-/-- `factors n` is the prime factorization of `n`, listed in increasing order. -/
-def factors : ℕ → List ℕ
+/-- `primeFactorsList n` is the prime factorization of `n`, listed in increasing order. -/
+def primeFactorsList : ℕ → List ℕ
   | 0 => []
   | 1 => []
   | k + 2 =>
     let m := minFac (k + 2)
-    m :: factors ((k + 2) / m)
+    m :: primeFactorsList ((k + 2) / m)
 decreasing_by show (k + 2) / m < (k + 2); exact factors_lemma
-#align nat.factors Nat.factors
+#align nat.factors Nat.primeFactorsList
+
+@[deprecated (since := "2024-06-14")] alias factors := primeFactorsList
 
 @[simp]
-theorem factors_zero : factors 0 = [] := by rw [factors]
-#align nat.factors_zero Nat.factors_zero
+theorem primeFactorsList_zero : primeFactorsList 0 = [] := by rw [primeFactorsList]
+#align nat.factors_zero Nat.primeFactorsList_zero
 
 @[simp]
-theorem factors_one : factors 1 = [] := by rw [factors]
-#align nat.factors_one Nat.factors_one
+theorem primeFactorsList_one : primeFactorsList 1 = [] := by rw [primeFactorsList]
+#align nat.factors_one Nat.primeFactorsList_one
 
 @[simp]
-theorem factors_two : factors 2 = [2] := by simp [factors]
+theorem primeFactorsList_two : primeFactorsList 2 = [2] := by simp [primeFactorsList]
 
-theorem prime_of_mem_factors {n : ℕ} : ∀ {p : ℕ}, (h : p ∈ factors n) → Prime p := by
+theorem prime_of_mem_primeFactorsList {n : ℕ} : ∀ {p : ℕ}, p ∈ primeFactorsList n → Prime p := by
   match n with
   | 0 => simp
   | 1 => simp
@@ -60,38 +62,39 @@ theorem prime_of_mem_factors {n : ℕ} : ∀ {p : ℕ}, (h : p ∈ factors n) �
       intro p h
       let m := minFac (k + 2)
       have : (k + 2) / m < (k + 2) := factors_lemma
-      have h₁ : p = m ∨ p ∈ factors ((k + 2) / m) :=
-        List.mem_cons.1 (by rwa [factors] at h)
-      exact Or.casesOn h₁ (fun h₂ => h₂.symm ▸ minFac_prime (by simp)) prime_of_mem_factors
-#align nat.prime_of_mem_factors Nat.prime_of_mem_factors
+      have h₁ : p = m ∨ p ∈ primeFactorsList ((k + 2) / m) :=
+        List.mem_cons.1 (by rwa [primeFactorsList] at h)
+      exact Or.casesOn h₁ (fun h₂ => h₂.symm ▸ minFac_prime (by simp)) prime_of_mem_primeFactorsList
+#align nat.prime_of_mem_factors Nat.prime_of_mem_primeFactorsList
 
-theorem pos_of_mem_factors {n p : ℕ} (h : p ∈ factors n) : 0 < p :=
-  Prime.pos (prime_of_mem_factors h)
-#align nat.pos_of_mem_factors Nat.pos_of_mem_factors
+theorem pos_of_mem_primeFactorsList {n p : ℕ} (h : p ∈ primeFactorsList n) : 0 < p :=
+  Prime.pos (prime_of_mem_primeFactorsList h)
+#align nat.pos_of_mem_factors Nat.pos_of_mem_primeFactorsList
 
-theorem prod_factors : ∀ {n}, n ≠ 0 → List.prod (factors n) = n
+theorem prod_primeFactorsList : ∀ {n}, n ≠ 0 → List.prod (primeFactorsList n) = n
   | 0 => by simp
   | 1 => by simp
   | k + 2 => fun _ =>
     let m := minFac (k + 2)
     have : (k + 2) / m < (k + 2) := factors_lemma
-    show (factors (k + 2)).prod = (k + 2) by
+    show (primeFactorsList (k + 2)).prod = (k + 2) by
       have h₁ : (k + 2) / m ≠ 0 := fun h => by
         have : (k + 2) = 0 * m := (Nat.div_eq_iff_eq_mul_left (minFac_pos _) (minFac_dvd _)).1 h
         rw [zero_mul] at this; exact (show k + 2 ≠ 0 by simp) this
-      rw [factors, List.prod_cons, prod_factors h₁, Nat.mul_div_cancel' (minFac_dvd _)]
-#align nat.prod_factors Nat.prod_factors
+      rw [primeFactorsList, List.prod_cons, prod_primeFactorsList h₁,
+        Nat.mul_div_cancel' (minFac_dvd _)]
+#align nat.prod_factors Nat.prod_primeFactorsList
 
-theorem factors_prime {p : ℕ} (hp : Nat.Prime p) : p.factors = [p] := by
+theorem primeFactorsList_prime {p : ℕ} (hp : Nat.Prime p) : p.primeFactorsList = [p] := by
   have : p = p - 2 + 2 := (tsub_eq_iff_eq_add_of_le hp.two_le).mp rfl
-  rw [this, Nat.factors]
+  rw [this, primeFactorsList]
   simp only [Eq.symm this]
   have : Nat.minFac p = p := (Nat.prime_def_minFac.mp hp).2
-  simp only [this, Nat.factors, Nat.div_self (Nat.Prime.pos hp)]
-#align nat.factors_prime Nat.factors_prime
+  simp only [this, primeFactorsList, Nat.div_self (Nat.Prime.pos hp)]
+#align nat.factors_prime Nat.primeFactorsList_prime
 
-theorem factors_chain {n : ℕ} :
-    ∀ {a}, (∀ p, Prime p → p ∣ n → a ≤ p) → List.Chain (· ≤ ·) a (factors n) := by
+theorem primeFactorsList_chain {n : ℕ} :
+    ∀ {a}, (∀ p, Prime p → p ∣ n → a ≤ p) → List.Chain (· ≤ ·) a (primeFactorsList n) := by
   match n with
   | 0 => simp
   | 1 => simp
@@ -99,228 +102,240 @@ theorem factors_chain {n : ℕ} :
       intro a h
       let m := minFac (k + 2)
       have : (k + 2) / m < (k + 2) := factors_lemma
-      rw [factors]
-      refine List.Chain.cons ((le_minFac.2 h).resolve_left (by simp)) (factors_chain ?_)
+      rw [primeFactorsList]
+      refine List.Chain.cons ((le_minFac.2 h).resolve_left (by simp)) (primeFactorsList_chain ?_)
       exact fun p pp d => minFac_le_of_dvd pp.two_le (d.trans <| div_dvd_of_dvd <| minFac_dvd _)
-#align nat.factors_chain Nat.factors_chain
+#align nat.factors_chain Nat.primeFactorsList_chain
 
-theorem factors_chain_2 (n) : List.Chain (· ≤ ·) 2 (factors n) :=
-  factors_chain fun _ pp _ => pp.two_le
-#align nat.factors_chain_2 Nat.factors_chain_2
+theorem primeFactorsList_chain_2 (n) : List.Chain (· ≤ ·) 2 (primeFactorsList n) :=
+  primeFactorsList_chain fun _ pp _ => pp.two_le
+#align nat.factors_chain_2 Nat.primeFactorsList_chain_2
 
-theorem factors_chain' (n) : List.Chain' (· ≤ ·) (factors n) :=
-  @List.Chain'.tail _ _ (_ :: _) (factors_chain_2 _)
-#align nat.factors_chain' Nat.factors_chain'
+theorem primeFactorsList_chain' (n) : List.Chain' (· ≤ ·) (primeFactorsList n) :=
+  @List.Chain'.tail _ _ (_ :: _) (primeFactorsList_chain_2 _)
+#align nat.factors_chain' Nat.primeFactorsList_chain'
 
-theorem factors_sorted (n : ℕ) : List.Sorted (· ≤ ·) (factors n) :=
-  List.chain'_iff_pairwise.1 (factors_chain' _)
-#align nat.factors_sorted Nat.factors_sorted
+theorem primeFactorsList_sorted (n : ℕ) : List.Sorted (· ≤ ·) (primeFactorsList n) :=
+  List.chain'_iff_pairwise.1 (primeFactorsList_chain' _)
+#align nat.factors_sorted Nat.primeFactorsList_sorted
 
-/-- `factors` can be constructed inductively by extracting `minFac`, for sufficiently large `n`. -/
-theorem factors_add_two (n : ℕ) :
-    factors (n + 2) = minFac (n + 2) :: factors ((n + 2) / minFac (n + 2)) := by rw [factors]
-#align nat.factors_add_two Nat.factors_add_two
+/-- `primeFactorsList` can be constructed inductively by extracting `minFac`, for sufficiently
+large `n`. -/
+theorem primeFactorsList_add_two (n : ℕ) :
+    primeFactorsList (n + 2) = minFac (n + 2) :: primeFactorsList ((n + 2) / minFac (n + 2)) := by
+  rw [primeFactorsList]
+#align nat.factors_add_two Nat.primeFactorsList_add_two
 
 @[simp]
-theorem factors_eq_nil (n : ℕ) : n.factors = [] ↔ n = 0 ∨ n = 1 := by
+theorem primeFactorsList_eq_nil (n : ℕ) : n.primeFactorsList = [] ↔ n = 0 ∨ n = 1 := by
   constructor <;> intro h
   · rcases n with (_ | _ | n)
     · exact Or.inl rfl
     · exact Or.inr rfl
-    · rw [factors] at h
+    · rw [primeFactorsList] at h
       injection h
   · rcases h with (rfl | rfl)
-    · exact factors_zero
-    · exact factors_one
-#align nat.factors_eq_nil Nat.factors_eq_nil
+    · exact primeFactorsList_zero
+    · exact primeFactorsList_one
+#align nat.factors_eq_nil Nat.primeFactorsList_eq_nil
 
 open scoped List in
-theorem eq_of_perm_factors {a b : ℕ} (ha : a ≠ 0) (hb : b ≠ 0) (h : a.factors ~ b.factors) :
-    a = b := by simpa [prod_factors ha, prod_factors hb] using List.Perm.prod_eq h
-#align nat.eq_of_perm_factors Nat.eq_of_perm_factors
+theorem eq_of_perm_primeFactorsList {a b : ℕ} (ha : a ≠ 0) (hb : b ≠ 0)
+    (h : a.primeFactorsList ~ b.primeFactorsList) : a = b := by
+  simpa [prod_primeFactorsList ha, prod_primeFactorsList hb] using List.Perm.prod_eq h
+#align nat.eq_of_perm_factors Nat.eq_of_perm_primeFactorsList
 
 section
 
 open List
 
-theorem mem_factors_iff_dvd {n p : ℕ} (hn : n ≠ 0) (hp : Prime p) : p ∈ factors n ↔ p ∣ n :=
-  ⟨fun h => prod_factors hn ▸ List.dvd_prod h, fun h =>
-    mem_list_primes_of_dvd_prod (prime_iff.mp hp) (fun _ h => prime_iff.mp (prime_of_mem_factors h))
-      ((prod_factors hn).symm ▸ h)⟩
-#align nat.mem_factors_iff_dvd Nat.mem_factors_iff_dvd
+theorem mem_primeFactorsList_iff_dvd {n p : ℕ} (hn : n ≠ 0) (hp : Prime p) :
+    p ∈ primeFactorsList n ↔ p ∣ n where
+  mp h := prod_primeFactorsList hn ▸ List.dvd_prod h
+  mpr h := mem_list_primes_of_dvd_prod (prime_iff.mp hp)
+    (fun _ h ↦ prime_iff.mp (prime_of_mem_primeFactorsList h)) ((prod_primeFactorsList hn).symm ▸ h)
+#align nat.mem_factors_iff_dvd Nat.mem_primeFactorsList_iff_dvd
 
-theorem dvd_of_mem_factors {n p : ℕ} (h : p ∈ n.factors) : p ∣ n := by
+theorem dvd_of_mem_primeFactorsList {n p : ℕ} (h : p ∈ n.primeFactorsList) : p ∣ n := by
   rcases n.eq_zero_or_pos with (rfl | hn)
   · exact dvd_zero p
-  · rwa [← mem_factors_iff_dvd hn.ne' (prime_of_mem_factors h)]
-#align nat.dvd_of_mem_factors Nat.dvd_of_mem_factors
+  · rwa [← mem_primeFactorsList_iff_dvd hn.ne' (prime_of_mem_primeFactorsList h)]
+#align nat.dvd_of_mem_factors Nat.dvd_of_mem_primeFactorsList
 
-theorem mem_factors {n p} (hn : n ≠ 0) : p ∈ factors n ↔ Prime p ∧ p ∣ n :=
-  ⟨fun h => ⟨prime_of_mem_factors h, dvd_of_mem_factors h⟩, fun ⟨hprime, hdvd⟩ =>
-    (mem_factors_iff_dvd hn hprime).mpr hdvd⟩
-#align nat.mem_factors Nat.mem_factors
+theorem mem_primeFactorsList {n p} (hn : n ≠ 0) : p ∈ primeFactorsList n ↔ Prime p ∧ p ∣ n :=
+  ⟨fun h => ⟨prime_of_mem_primeFactorsList h, dvd_of_mem_primeFactorsList h⟩, fun ⟨hprime, hdvd⟩ =>
+    (mem_primeFactorsList_iff_dvd hn hprime).mpr hdvd⟩
+#align nat.mem_factors Nat.mem_primeFactorsList
 
-@[simp] lemma mem_factors' {n p} : p ∈ n.factors ↔ p.Prime ∧ p ∣ n ∧ n ≠ 0 := by
-  cases n <;> simp [mem_factors, *]
+@[simp] lemma mem_primeFactorsList' {n p} : p ∈ n.primeFactorsList ↔ p.Prime ∧ p ∣ n ∧ n ≠ 0 := by
+  cases n <;> simp [mem_primeFactorsList, *]
 
-theorem le_of_mem_factors {n p : ℕ} (h : p ∈ n.factors) : p ≤ n := by
+theorem le_of_mem_primeFactorsList {n p : ℕ} (h : p ∈ n.primeFactorsList) : p ≤ n := by
   rcases n.eq_zero_or_pos with (rfl | hn)
-  · rw [factors_zero] at h
+  · rw [primeFactorsList_zero] at h
     cases h
-  · exact le_of_dvd hn (dvd_of_mem_factors h)
-#align nat.le_of_mem_factors Nat.le_of_mem_factors
+  · exact le_of_dvd hn (dvd_of_mem_primeFactorsList h)
+#align nat.le_of_mem_factors Nat.le_of_mem_primeFactorsList
 
 /-- **Fundamental theorem of arithmetic**-/
-theorem factors_unique {n : ℕ} {l : List ℕ} (h₁ : prod l = n) (h₂ : ∀ p ∈ l, Prime p) :
-    l ~ factors n := by
+theorem primeFactorsList_unique {n : ℕ} {l : List ℕ} (h₁ : prod l = n) (h₂ : ∀ p ∈ l, Prime p) :
+    l ~ primeFactorsList n := by
   refine perm_of_prod_eq_prod ?_ ?_ ?_
   · rw [h₁]
-    refine (prod_factors ?_).symm
+    refine (prod_primeFactorsList ?_).symm
     rintro rfl
     rw [prod_eq_zero_iff] at h₁
     exact Prime.ne_zero (h₂ 0 h₁) rfl
   · simp_rw [← prime_iff]
     exact h₂
   · simp_rw [← prime_iff]
-    exact fun p => prime_of_mem_factors
-#align nat.factors_unique Nat.factors_unique
+    exact fun p => prime_of_mem_primeFactorsList
+#align nat.factors_unique Nat.primeFactorsList_unique
 
-theorem Prime.factors_pow {p : ℕ} (hp : p.Prime) (n : ℕ) :
-    (p ^ n).factors = List.replicate n p := by
+theorem Prime.primeFactorsList_pow {p : ℕ} (hp : p.Prime) (n : ℕ) :
+    (p ^ n).primeFactorsList = List.replicate n p := by
   symm
   rw [← List.replicate_perm]
-  apply Nat.factors_unique (List.prod_replicate n p)
+  apply Nat.primeFactorsList_unique (List.prod_replicate n p)
   intro q hq
   rwa [eq_of_mem_replicate hq]
-#align nat.prime.factors_pow Nat.Prime.factors_pow
+#align nat.prime.factors_pow Nat.Prime.primeFactorsList_pow
 
 theorem eq_prime_pow_of_unique_prime_dvd {n p : ℕ} (hpos : n ≠ 0)
-    (h : ∀ {d}, Nat.Prime d → d ∣ n → d = p) : n = p ^ n.factors.length := by
-  set k := n.factors.length
-  rw [← prod_factors hpos, ← prod_replicate k p,
-    eq_replicate_of_mem fun d hd => h (prime_of_mem_factors hd) (dvd_of_mem_factors hd)]
+    (h : ∀ {d}, Nat.Prime d → d ∣ n → d = p) : n = p ^ n.primeFactorsList.length := by
+  set k := n.primeFactorsList.length
+  rw [← prod_primeFactorsList hpos, ← prod_replicate k p, eq_replicate_of_mem fun d hd =>
+    h (prime_of_mem_primeFactorsList hd) (dvd_of_mem_primeFactorsList hd)]
 #align nat.eq_prime_pow_of_unique_prime_dvd Nat.eq_prime_pow_of_unique_prime_dvd
 
 /-- For positive `a` and `b`, the prime factors of `a * b` are the union of those of `a` and `b` -/
-theorem perm_factors_mul {a b : ℕ} (ha : a ≠ 0) (hb : b ≠ 0) :
-    (a * b).factors ~ a.factors ++ b.factors := by
-  refine (factors_unique ?_ ?_).symm
-  · rw [List.prod_append, prod_factors ha, prod_factors hb]
+theorem perm_primeFactorsList_mul {a b : ℕ} (ha : a ≠ 0) (hb : b ≠ 0) :
+    (a * b).primeFactorsList ~ a.primeFactorsList ++ b.primeFactorsList := by
+  refine (primeFactorsList_unique ?_ ?_).symm
+  · rw [List.prod_append, prod_primeFactorsList ha, prod_primeFactorsList hb]
   · intro p hp
     rw [List.mem_append] at hp
-    cases' hp with hp' hp' <;> exact prime_of_mem_factors hp'
-#align nat.perm_factors_mul Nat.perm_factors_mul
+    cases' hp with hp' hp' <;> exact prime_of_mem_primeFactorsList hp'
+#align nat.perm_factors_mul Nat.perm_primeFactorsList_mul
 
 /-- For coprime `a` and `b`, the prime factors of `a * b` are the union of those of `a` and `b` -/
-theorem perm_factors_mul_of_coprime {a b : ℕ} (hab : Coprime a b) :
-    (a * b).factors ~ a.factors ++ b.factors := by
+theorem perm_primeFactorsList_mul_of_coprime {a b : ℕ} (hab : Coprime a b) :
+    (a * b).primeFactorsList ~ a.primeFactorsList ++ b.primeFactorsList := by
   rcases a.eq_zero_or_pos with (rfl | ha)
   · simp [(coprime_zero_left _).mp hab]
   rcases b.eq_zero_or_pos with (rfl | hb)
   · simp [(coprime_zero_right _).mp hab]
-  exact perm_factors_mul ha.ne' hb.ne'
-#align nat.perm_factors_mul_of_coprime Nat.perm_factors_mul_of_coprime
+  exact perm_primeFactorsList_mul ha.ne' hb.ne'
+#align nat.perm_factors_mul_of_coprime Nat.perm_primeFactorsList_mul_of_coprime
 
-theorem factors_sublist_right {n k : ℕ} (h : k ≠ 0) : n.factors <+ (n * k).factors := by
+theorem primeFactorsList_sublist_right {n k : ℕ} (h : k ≠ 0) :
+    n.primeFactorsList <+ (n * k).primeFactorsList := by
   cases' n with hn
   · simp [zero_mul]
-  apply sublist_of_subperm_of_sorted _ (factors_sorted _) (factors_sorted _)
-  simp only [(perm_factors_mul (Nat.succ_ne_zero _) h).subperm_left]
+  apply sublist_of_subperm_of_sorted _ (primeFactorsList_sorted _) (primeFactorsList_sorted _)
+  simp only [(perm_primeFactorsList_mul (Nat.succ_ne_zero _) h).subperm_left]
   exact (sublist_append_left _ _).subperm
-#align nat.factors_sublist_right Nat.factors_sublist_right
+#align nat.factors_sublist_right Nat.primeFactorsList_sublist_right
 
-theorem factors_sublist_of_dvd {n k : ℕ} (h : n ∣ k) (h' : k ≠ 0) : n.factors <+ k.factors := by
+theorem primeFactorsList_sublist_of_dvd {n k : ℕ} (h : n ∣ k) (h' : k ≠ 0) :
+    n.primeFactorsList <+ k.primeFactorsList := by
   obtain ⟨a, rfl⟩ := h
-  exact factors_sublist_right (right_ne_zero_of_mul h')
-#align nat.factors_sublist_of_dvd Nat.factors_sublist_of_dvd
+  exact primeFactorsList_sublist_right (right_ne_zero_of_mul h')
+#align nat.factors_sublist_of_dvd Nat.primeFactorsList_sublist_of_dvd
 
-theorem factors_subset_right {n k : ℕ} (h : k ≠ 0) : n.factors ⊆ (n * k).factors :=
-  (factors_sublist_right h).subset
-#align nat.factors_subset_right Nat.factors_subset_right
+theorem primeFactorsList_subset_right {n k : ℕ} (h : k ≠ 0) :
+    n.primeFactorsList ⊆ (n * k).primeFactorsList :=
+  (primeFactorsList_sublist_right h).subset
+#align nat.factors_subset_right Nat.primeFactorsList_subset_right
 
-theorem factors_subset_of_dvd {n k : ℕ} (h : n ∣ k) (h' : k ≠ 0) : n.factors ⊆ k.factors :=
-  (factors_sublist_of_dvd h h').subset
-#align nat.factors_subset_of_dvd Nat.factors_subset_of_dvd
+theorem primeFactorsList_subset_of_dvd {n k : ℕ} (h : n ∣ k) (h' : k ≠ 0) :
+    n.primeFactorsList ⊆ k.primeFactorsList :=
+  (primeFactorsList_sublist_of_dvd h h').subset
+#align nat.factors_subset_of_dvd Nat.primeFactorsList_subset_of_dvd
 
-theorem dvd_of_factors_subperm {a b : ℕ} (ha : a ≠ 0) (h : a.factors <+~ b.factors) : a ∣ b := by
+theorem dvd_of_primeFactorsList_subperm {a b : ℕ} (ha : a ≠ 0)
+    (h : a.primeFactorsList <+~ b.primeFactorsList) : a ∣ b := by
   rcases b.eq_zero_or_pos with (rfl | hb)
   · exact dvd_zero _
   rcases a with (_ | _ | a)
   · exact (ha rfl).elim
   · exact one_dvd _
   -- Porting note: previous proof
-  --use (b.factors.diff a.succ.succ.factors).prod
-  use (@List.diff _ instBEqOfDecidableEq b.factors a.succ.succ.factors).prod
-  nth_rw 1 [← Nat.prod_factors ha]
+  --use (b.primeFactorsList.diff a.succ.succ.primeFactorsList).prod
+  use (@List.diff _ instBEqOfDecidableEq b.primeFactorsList a.succ.succ.primeFactorsList).prod
+  nth_rw 1 [← Nat.prod_primeFactorsList ha]
   rw [← List.prod_append,
     List.Perm.prod_eq <| List.subperm_append_diff_self_of_count_le <| List.subperm_ext_iff.mp h,
-    Nat.prod_factors hb.ne']
-#align nat.dvd_of_factors_subperm Nat.dvd_of_factors_subperm
+    Nat.prod_primeFactorsList hb.ne']
+#align nat.dvd_of_factors_subperm Nat.dvd_of_primeFactorsList_subperm
 
-theorem replicate_subperm_factors_iff {a b n : ℕ} (ha : Prime a) (hb : b ≠ 0) :
-    replicate n a <+~ factors b ↔ a ^ n ∣ b := by
+theorem replicate_subperm_primeFactorsList_iff {a b n : ℕ} (ha : Prime a) (hb : b ≠ 0) :
+    replicate n a <+~ primeFactorsList b ↔ a ^ n ∣ b := by
   induction n generalizing b with
   | zero => simp
   | succ n ih =>
     constructor
     · rw [List.subperm_iff]
       rintro ⟨u, hu1, hu2⟩
-      rw [← Nat.prod_factors hb, ← hu1.prod_eq, ← prod_replicate]
+      rw [← Nat.prod_primeFactorsList hb, ← hu1.prod_eq, ← prod_replicate]
       exact hu2.prod_dvd_prod
     · rintro ⟨c, rfl⟩
       rw [Ne, pow_succ', mul_assoc, mul_eq_zero, _root_.not_or] at hb
-      rw [pow_succ', mul_assoc, replicate_succ, (Nat.perm_factors_mul hb.1 hb.2).subperm_left,
-        factors_prime ha, singleton_append, subperm_cons, ih hb.2]
+      rw [pow_succ', mul_assoc, replicate_succ,
+        (Nat.perm_primeFactorsList_mul hb.1 hb.2).subperm_left, primeFactorsList_prime ha,
+        singleton_append, subperm_cons, ih hb.2]
       exact dvd_mul_right _ _
 
 end
 
-theorem mem_factors_mul {a b : ℕ} (ha : a ≠ 0) (hb : b ≠ 0) {p : ℕ} :
-    p ∈ (a * b).factors ↔ p ∈ a.factors ∨ p ∈ b.factors := by
-  rw [mem_factors (mul_ne_zero ha hb), mem_factors ha, mem_factors hb, ← and_or_left]
+theorem mem_primeFactorsList_mul {a b : ℕ} (ha : a ≠ 0) (hb : b ≠ 0) {p : ℕ} :
+    p ∈ (a * b).primeFactorsList ↔ p ∈ a.primeFactorsList ∨ p ∈ b.primeFactorsList := by
+  rw [mem_primeFactorsList (mul_ne_zero ha hb), mem_primeFactorsList ha, mem_primeFactorsList hb,
+    ← and_or_left]
   simpa only [and_congr_right_iff] using Prime.dvd_mul
-#align nat.mem_factors_mul Nat.mem_factors_mul
+#align nat.mem_factors_mul Nat.mem_primeFactorsList_mul
 
 /-- The sets of factors of coprime `a` and `b` are disjoint -/
-theorem coprime_factors_disjoint {a b : ℕ} (hab : a.Coprime b) :
-    List.Disjoint a.factors b.factors := by
+theorem coprime_primeFactorsList_disjoint {a b : ℕ} (hab : a.Coprime b) :
+    List.Disjoint a.primeFactorsList b.primeFactorsList := by
   intro q hqa hqb
   apply not_prime_one
-  rw [← eq_one_of_dvd_coprimes hab (dvd_of_mem_factors hqa) (dvd_of_mem_factors hqb)]
-  exact prime_of_mem_factors hqa
-#align nat.coprime_factors_disjoint Nat.coprime_factors_disjoint
+  rw [← eq_one_of_dvd_coprimes hab (dvd_of_mem_primeFactorsList hqa)
+    (dvd_of_mem_primeFactorsList hqb)]
+  exact prime_of_mem_primeFactorsList hqa
+#align nat.coprime_factors_disjoint Nat.coprime_primeFactorsList_disjoint
 
-theorem mem_factors_mul_of_coprime {a b : ℕ} (hab : Coprime a b) (p : ℕ) :
-    p ∈ (a * b).factors ↔ p ∈ a.factors ∪ b.factors := by
+theorem mem_primeFactorsList_mul_of_coprime {a b : ℕ} (hab : Coprime a b) (p : ℕ) :
+    p ∈ (a * b).primeFactorsList ↔ p ∈ a.primeFactorsList ∪ b.primeFactorsList := by
   rcases a.eq_zero_or_pos with (rfl | ha)
   · simp [(coprime_zero_left _).mp hab]
   rcases b.eq_zero_or_pos with (rfl | hb)
   · simp [(coprime_zero_right _).mp hab]
-  rw [mem_factors_mul ha.ne' hb.ne', List.mem_union_iff]
-#align nat.mem_factors_mul_of_coprime Nat.mem_factors_mul_of_coprime
+  rw [mem_primeFactorsList_mul ha.ne' hb.ne', List.mem_union_iff]
+#align nat.mem_factors_mul_of_coprime Nat.mem_primeFactorsList_mul_of_coprime
 
 open List
 
 /-- If `p` is a prime factor of `a` then `p` is also a prime factor of `a * b` for any `b > 0` -/
-theorem mem_factors_mul_left {p a b : ℕ} (hpa : p ∈ a.factors) (hb : b ≠ 0) :
-    p ∈ (a * b).factors := by
+theorem mem_primeFactorsList_mul_left {p a b : ℕ} (hpa : p ∈ a.primeFactorsList) (hb : b ≠ 0) :
+    p ∈ (a * b).primeFactorsList := by
   rcases eq_or_ne a 0 with (rfl | ha)
   · simp at hpa
-  apply (mem_factors_mul ha hb).2 (Or.inl hpa)
-#align nat.mem_factors_mul_left Nat.mem_factors_mul_left
+  apply (mem_primeFactorsList_mul ha hb).2 (Or.inl hpa)
+#align nat.mem_factors_mul_left Nat.mem_primeFactorsList_mul_left
 
 /-- If `p` is a prime factor of `b` then `p` is also a prime factor of `a * b` for any `a > 0` -/
-theorem mem_factors_mul_right {p a b : ℕ} (hpb : p ∈ b.factors) (ha : a ≠ 0) :
-    p ∈ (a * b).factors := by
+theorem mem_primeFactorsList_mul_right {p a b : ℕ} (hpb : p ∈ b.primeFactorsList) (ha : a ≠ 0) :
+    p ∈ (a * b).primeFactorsList := by
   rw [mul_comm]
-  exact mem_factors_mul_left hpb ha
-#align nat.mem_factors_mul_right Nat.mem_factors_mul_right
+  exact mem_primeFactorsList_mul_left hpb ha
+#align nat.mem_factors_mul_right Nat.mem_primeFactorsList_mul_right
 
 theorem eq_two_pow_or_exists_odd_prime_and_dvd (n : ℕ) :
     (∃ k : ℕ, n = 2 ^ k) ∨ ∃ p, Nat.Prime p ∧ p ∣ n ∧ Odd p :=
   (eq_or_ne n 0).elim (fun hn => Or.inr ⟨3, prime_three, hn.symm ▸ dvd_zero 3, ⟨1, rfl⟩⟩) fun hn =>
     or_iff_not_imp_right.mpr fun H =>
-      ⟨n.factors.length,
+      ⟨n.primeFactorsList.length,
         eq_prime_pow_of_unique_prime_dvd hn fun {_} hprime hdvd =>
           hprime.eq_two_or_odd'.resolve_right fun hodd => H ⟨_, hprime, hdvd, hodd⟩⟩
 #align nat.eq_two_pow_or_exists_odd_prime_and_dvd Nat.eq_two_pow_or_exists_odd_prime_and_dvd

--- a/Mathlib/Data/Nat/PrimeFin.lean
+++ b/Mathlib/Data/Nat/PrimeFin.lean
@@ -31,12 +31,12 @@ instance Primes.infinite : Infinite Primes := infinite_setOf_prime.to_subtype
 instance Primes.countable : Countable Primes := ⟨⟨coeNat.coe, coe_nat_injective⟩⟩
 
 /-- The prime factors of a natural number as a finset. -/
-def primeFactors (n : ℕ) : Finset ℕ := n.factors.toFinset
+def primeFactors (n : ℕ) : Finset ℕ := n.primeFactorsList.toFinset
 
-@[simp] lemma toFinset_factors (n : ℕ) : n.factors.toFinset = n.primeFactors := rfl
+@[simp] lemma toFinset_factors (n : ℕ) : n.primeFactorsList.toFinset = n.primeFactors := rfl
 
 @[simp] lemma mem_primeFactors : p ∈ n.primeFactors ↔ p.Prime ∧ p ∣ n ∧ n ≠ 0 := by
-  simp_rw [← toFinset_factors, List.mem_toFinset, mem_factors']
+  simp_rw [← toFinset_factors, List.mem_toFinset, mem_primeFactorsList']
 
 lemma mem_primeFactors_of_ne_zero (hn : n ≠ 0) : p ∈ n.primeFactors ↔ p.Prime ∧ p ∣ n := by
   simp [hn]
@@ -45,7 +45,7 @@ lemma primeFactors_mono (hmn : m ∣ n) (hn : n ≠ 0) : primeFactors m ⊆ prim
   simp only [subset_iff, mem_primeFactors, and_imp]
   exact fun p hp hpm _ ↦ ⟨hp, hpm.trans hmn, hn⟩
 
-lemma mem_primeFactors_iff_mem_factors : p ∈ n.primeFactors ↔ p ∈ n.factors := by
+lemma mem_primeFactors_iff_mem_factors : p ∈ n.primeFactors ↔ p ∈ n.primeFactorsList := by
   simp only [primeFactors, List.mem_toFinset]
 
 lemma prime_of_mem_primeFactors (hp : p ∈ n.primeFactors) : p.Prime := (mem_primeFactors.1 hp).1
@@ -79,16 +79,17 @@ lemma nonempty_primeFactors {n : ℕ} : n.primeFactors.Nonempty ↔ 1 < n := by
     Nat.le_one_iff_eq_zero_or_eq_one]
 
 @[simp] protected lemma Prime.primeFactors (hp : p.Prime) : p.primeFactors = {p} := by
-  simp [Nat.primeFactors, factors_prime hp]
+  simp [Nat.primeFactors, primeFactorsList_prime hp]
 
 lemma primeFactors_mul (ha : a ≠ 0) (hb : b ≠ 0) :
     (a * b).primeFactors = a.primeFactors ∪ b.primeFactors := by
-  ext; simp only [Finset.mem_union, mem_primeFactors_iff_mem_factors, mem_factors_mul ha hb]
+  ext; simp only [Finset.mem_union, mem_primeFactors_iff_mem_factors,
+    mem_primeFactorsList_mul ha hb]
 #align nat.factors_mul_to_finset Nat.primeFactors_mul
 
 lemma Coprime.primeFactors_mul {a b : ℕ} (hab : Coprime a b) :
     (a * b).primeFactors = a.primeFactors ∪ b.primeFactors :=
-  (List.toFinset.ext <| mem_factors_mul_of_coprime hab).trans <| List.toFinset_union _ _
+  (List.toFinset.ext <| mem_primeFactorsList_mul_of_coprime hab).trans <| List.toFinset_union _ _
 #align nat.factors_mul_to_finset_of_coprime Nat.Coprime.primeFactors_mul
 
 lemma primeFactors_gcd (ha : a ≠ 0) (hb : b ≠ 0) :
@@ -102,7 +103,7 @@ lemma primeFactors_gcd (ha : a ≠ 0) (hb : b ≠ 0) :
 
 protected lemma Coprime.disjoint_primeFactors (hab : Coprime a b) :
     Disjoint a.primeFactors b.primeFactors :=
-  List.disjoint_toFinset_iff_disjoint.2 <| coprime_factors_disjoint hab
+  List.disjoint_toFinset_iff_disjoint.2 <| coprime_primeFactorsList_disjoint hab
 
 lemma primeFactors_pow_succ (n k : ℕ) : (n ^ (k + 1)).primeFactors = n.primeFactors := by
   rcases eq_or_ne n 0 with (rfl | hn)

--- a/Mathlib/Data/Nat/PrimeFin.lean
+++ b/Mathlib/Data/Nat/PrimeFin.lean
@@ -48,6 +48,9 @@ lemma primeFactors_mono (hmn : m ∣ n) (hn : n ≠ 0) : primeFactors m ⊆ prim
 lemma mem_primeFactors_iff_mem_primeFactorsList : p ∈ n.primeFactors ↔ p ∈ n.primeFactorsList := by
   simp only [primeFactors, List.mem_toFinset]
 
+@[deprecated (since := "2024-07-16")]
+alias mem_primeFactors_iff_mem_factors := mem_primeFactors_iff_mem_primeFactorsList
+
 lemma prime_of_mem_primeFactors (hp : p ∈ n.primeFactors) : p.Prime := (mem_primeFactors.1 hp).1
 lemma dvd_of_mem_primeFactors (hp : p ∈ n.primeFactors) : p ∣ n := (mem_primeFactors.1 hp).2.1
 

--- a/Mathlib/Data/Nat/PrimeFin.lean
+++ b/Mathlib/Data/Nat/PrimeFin.lean
@@ -45,7 +45,7 @@ lemma primeFactors_mono (hmn : m ∣ n) (hn : n ≠ 0) : primeFactors m ⊆ prim
   simp only [subset_iff, mem_primeFactors, and_imp]
   exact fun p hp hpm _ ↦ ⟨hp, hpm.trans hmn, hn⟩
 
-lemma mem_primeFactors_iff_mem_factors : p ∈ n.primeFactors ↔ p ∈ n.primeFactorsList := by
+lemma mem_primeFactors_iff_mem_primeFactorsList : p ∈ n.primeFactors ↔ p ∈ n.primeFactorsList := by
   simp only [primeFactors, List.mem_toFinset]
 
 lemma prime_of_mem_primeFactors (hp : p ∈ n.primeFactors) : p.Prime := (mem_primeFactors.1 hp).1
@@ -83,7 +83,7 @@ lemma nonempty_primeFactors {n : ℕ} : n.primeFactors.Nonempty ↔ 1 < n := by
 
 lemma primeFactors_mul (ha : a ≠ 0) (hb : b ≠ 0) :
     (a * b).primeFactors = a.primeFactors ∪ b.primeFactors := by
-  ext; simp only [Finset.mem_union, mem_primeFactors_iff_mem_factors,
+  ext; simp only [Finset.mem_union, mem_primeFactors_iff_mem_primeFactorsList,
     mem_primeFactorsList_mul ha hb]
 #align nat.factors_mul_to_finset Nat.primeFactors_mul
 

--- a/Mathlib/Data/Nat/Squarefree.lean
+++ b/Mathlib/Data/Nat/Squarefree.lean
@@ -31,10 +31,16 @@ theorem squarefree_iff_nodup_primeFactorsList {n : ℕ} (h0 : n ≠ 0) :
   simp
 #align nat.squarefree_iff_nodup_factors Nat.squarefree_iff_nodup_primeFactorsList
 
+@[deprecated (since := "2024-07-17")]
+alias squarefree_iff_nodup_factors := squarefree_iff_nodup_primeFactorsList
+
 end Nat
 
 theorem Squarefree.nodup_primeFactorsList {n : ℕ} (hn : Squarefree n) : n.primeFactorsList.Nodup :=
   (Nat.squarefree_iff_nodup_primeFactorsList hn.ne_zero).mp hn
+
+@[deprecated (since := "2024-07-17")]
+alias Squarefree.nodup_factors := Squarefree.nodup_primeFactorsList
 
 namespace Nat
 variable {s : Finset ℕ} {m n p : ℕ}

--- a/Mathlib/Data/Nat/Squarefree.lean
+++ b/Mathlib/Data/Nat/Squarefree.lean
@@ -13,7 +13,7 @@ import Mathlib.Data.Nat.Factorization.PrimePow
 A number is squarefree when it is not divisible by any squares except the squares of units.
 
 ## Main Results
- - `Nat.squarefree_iff_nodup_factors`: A positive natural number `x` is squarefree iff
+ - `Nat.squarefree_iff_nodup_primeFactorsList`: A positive natural number `x` is squarefree iff
   the list `factors x` has no duplicate factors.
 
 ## Tags
@@ -25,15 +25,16 @@ open Finset
 
 namespace Nat
 
-theorem squarefree_iff_nodup_factors {n : ℕ} (h0 : n ≠ 0) : Squarefree n ↔ n.factors.Nodup := by
+theorem squarefree_iff_nodup_primeFactorsList {n : ℕ} (h0 : n ≠ 0) :
+    Squarefree n ↔ n.primeFactorsList.Nodup := by
   rw [UniqueFactorizationMonoid.squarefree_iff_nodup_normalizedFactors h0, Nat.factors_eq]
   simp
-#align nat.squarefree_iff_nodup_factors Nat.squarefree_iff_nodup_factors
+#align nat.squarefree_iff_nodup_factors Nat.squarefree_iff_nodup_primeFactorsList
 
 end Nat
 
-theorem Squarefree.nodup_factors {n : ℕ} (hn : Squarefree n) : n.factors.Nodup :=
-  (Nat.squarefree_iff_nodup_factors hn.ne_zero).mp hn
+theorem Squarefree.nodup_primeFactorsList {n : ℕ} (hn : Squarefree n) : n.primeFactorsList.Nodup :=
+  (Nat.squarefree_iff_nodup_primeFactorsList hn.ne_zero).mp hn
 
 namespace Nat
 variable {s : Finset ℕ} {m n p : ℕ}
@@ -62,9 +63,9 @@ lemma factorization_eq_one_of_squarefree (hn : Squarefree n) (hp : p.Prime) (hpn
 
 theorem squarefree_of_factorization_le_one {n : ℕ} (hn : n ≠ 0) (hn' : ∀ p, n.factorization p ≤ 1) :
     Squarefree n := by
-  rw [squarefree_iff_nodup_factors hn, List.nodup_iff_count_le_one]
+  rw [squarefree_iff_nodup_primeFactorsList hn, List.nodup_iff_count_le_one]
   intro a
-  rw [factors_count_eq]
+  rw [primeFactorsList_count_eq]
   apply hn'
 #align nat.squarefree_of_factorization_le_one Nat.squarefree_of_factorization_le_one
 
@@ -255,7 +256,7 @@ instance : DecidablePred (Squarefree : ℕ → Prop) := fun _ =>
   decidable_of_iff' _ squarefree_iff_minSqFac
 
 theorem squarefree_two : Squarefree 2 := by
-  rw [squarefree_iff_nodup_factors] <;> simp
+  rw [squarefree_iff_nodup_primeFactorsList] <;> simp
 #align nat.squarefree_two Nat.squarefree_two
 
 theorem divisors_filter_squarefree_of_squarefree {n : ℕ} (hn : Squarefree n) :
@@ -392,8 +393,8 @@ lemma coprime_div_gcd_of_squarefree (hm : Squarefree m) (hn : n ≠ 0) : Coprime
     (coprime_div_gcd_div_gcd (m := m) (gcd_ne_zero_right hn).bot_lt).mul_right this
 
 lemma prod_primeFactors_of_squarefree (hn : Squarefree n) : ∏ p ∈ n.primeFactors, p = n := by
-  rw [← toFinset_factors, List.prod_toFinset _ hn.nodup_factors, List.map_id',
-    Nat.prod_factors hn.ne_zero]
+  rw [← toFinset_factors, List.prod_toFinset _ hn.nodup_primeFactorsList,
+    List.map_id', Nat.prod_primeFactorsList hn.ne_zero]
 
 lemma primeFactors_prod (hs : ∀ p ∈ s, p.Prime) : primeFactors (∏ p ∈ s, p) = s := by
   have hn : ∏ p ∈ s, p ≠ 0 := prod_ne_zero_iff.2 fun p hp ↦ (hs _ hp).ne_zero
@@ -425,7 +426,7 @@ theorem prod_primeFactors_sdiff_of_squarefree {n : ℕ} (hn : Squarefree n) {t :
     (ht : t ⊆ n.primeFactors) :
     ∏ a ∈ (n.primeFactors \ t), a = n / ∏ a ∈ t, a := by
   refine symm <| Nat.div_eq_of_eq_mul_left (Finset.prod_pos
-    fun p hp => (prime_of_mem_factors (List.mem_toFinset.mp (ht hp))).pos) ?_
+    fun p hp => (prime_of_mem_primeFactorsList (List.mem_toFinset.mp (ht hp))).pos) ?_
   rw [Finset.prod_sdiff ht, prod_primeFactors_of_squarefree hn]
 
 end Nat

--- a/Mathlib/Data/Nat/Totient.lean
+++ b/Mathlib/Data/Nat/Totient.lean
@@ -322,7 +322,7 @@ theorem totient_eq_mul_prod_factors (n : ℕ) :
   simp only [totient_eq_div_primeFactors_mul n, prod_primeFactors_dvd n, cast_mul, cast_prod,
     cast_div_charZero, mul_comm_div, mul_right_inj' hn', div_eq_iff hpQ, ← prod_mul_distrib]
   refine prod_congr rfl fun p hp => ?_
-  have hp := pos_of_mem_factors (List.mem_toFinset.mp hp)
+  have hp := pos_of_mem_primeFactorsList (List.mem_toFinset.mp hp)
   have hp' : (p : ℚ) ≠ 0 := cast_ne_zero.mpr hp.ne.symm
   rw [sub_mul, one_mul, mul_comm, mul_inv_cancel hp', cast_pred hp]
 #align nat.totient_eq_mul_prod_factors Nat.totient_eq_mul_prod_factors

--- a/Mathlib/Data/PNat/Factors.lean
+++ b/Mathlib/Data/PNat/Factors.lean
@@ -234,7 +234,7 @@ namespace PNat
 
 /-- The prime factors of n, regarded as a multiset -/
 def factorMultiset (n : ℕ+) : PrimeMultiset :=
-  PrimeMultiset.ofNatList (Nat.factors n) (@Nat.prime_of_mem_factors n)
+  PrimeMultiset.ofNatList (Nat.primeFactorsList n) (@Nat.prime_of_mem_primeFactorsList n)
 #align pnat.factor_multiset PNat.factorMultiset
 
 /-- The product of the factors is the original number -/
@@ -242,12 +242,12 @@ theorem prod_factorMultiset (n : ℕ+) : (factorMultiset n).prod = n :=
   eq <| by
     dsimp [factorMultiset]
     rw [PrimeMultiset.prod_ofNatList]
-    exact Nat.prod_factors n.ne_zero
+    exact Nat.prod_primeFactorsList n.ne_zero
 #align pnat.prod_factor_multiset PNat.prod_factorMultiset
 
 theorem coeNat_factorMultiset (n : ℕ+) :
-    (factorMultiset n : Multiset ℕ) = (Nat.factors n : Multiset ℕ) :=
-  PrimeMultiset.to_ofNatMultiset (Nat.factors n) (@Nat.prime_of_mem_factors n)
+    (factorMultiset n : Multiset ℕ) = (Nat.primeFactorsList n : Multiset ℕ) :=
+  PrimeMultiset.to_ofNatMultiset (Nat.primeFactorsList n) (@Nat.prime_of_mem_primeFactorsList n)
 #align pnat.coe_nat_factor_multiset PNat.coeNat_factorMultiset
 
 end PNat
@@ -268,7 +268,7 @@ theorem factorMultiset_prod (v : PrimeMultiset) : v.prod.factorMultiset = v := b
   have : ∀ p : ℕ, p ∈ l' → p.Prime := fun p hp => by
     rcases List.mem_map.mp hp with ⟨⟨_, hp'⟩, ⟨_, h_eq⟩⟩
     exact h_eq ▸ hp'
-  exact Multiset.coe_eq_coe.mpr (@Nat.factors_unique _ l' rfl this).symm
+  exact Multiset.coe_eq_coe.mpr (@Nat.primeFactorsList_unique _ l' rfl this).symm
 #align prime_multiset.factor_multiset_prod PrimeMultiset.factorMultiset_prod
 
 end PrimeMultiset

--- a/Mathlib/GroupTheory/Exponent.lean
+++ b/Mathlib/GroupTheory/Exponent.lean
@@ -465,12 +465,12 @@ theorem exists_orderOf_eq_exponent (hG : ExponentExists G) : ∃ g : G, orderOf 
   obtain ⟨t, ht⟩ := hne.csSup_mem hfin
   use t
   apply Nat.dvd_antisymm (order_dvd_exponent _)
-  refine Nat.dvd_of_factors_subperm he ?_
+  refine Nat.dvd_of_primeFactorsList_subperm he ?_
   rw [List.subperm_ext_iff]
   by_contra! h
   obtain ⟨p, hp, hpe⟩ := h
-  replace hp := Nat.prime_of_mem_factors hp
-  simp only [Nat.factors_count_eq] at hpe
+  replace hp := Nat.prime_of_mem_primeFactorsList hp
+  simp only [Nat.primeFactorsList_count_eq] at hpe
   set k := (orderOf t).factorization p with hk
   obtain ⟨g, hg⟩ := hp.exists_orderOf_eq_pow_factorization_exponent G
   suffices orderOf t < orderOf (t ^ p ^ k * g) by

--- a/Mathlib/GroupTheory/PGroup.lean
+++ b/Mathlib/GroupTheory/PGroup.lean
@@ -53,11 +53,11 @@ theorem of_bot : IsPGroup p (⊥ : Subgroup G) :=
 theorem iff_card [Fact p.Prime] [Finite G] : IsPGroup p G ↔ ∃ n : ℕ, Nat.card G = p ^ n := by
   have hG : Nat.card G ≠ 0 := Nat.card_pos.ne'
   refine ⟨fun h => ?_, fun ⟨n, hn⟩ => of_card hn⟩
-  suffices ∀ q ∈ Nat.factors (Nat.card G), q = p by
-    use (Nat.card G).factors.length
-    rw [← List.prod_replicate, ← List.eq_replicate_of_mem this, Nat.prod_factors hG]
+  suffices ∀ q ∈ (Nat.card G).primeFactorsList, q = p by
+    use (Nat.card G).primeFactorsList.length
+    rw [← List.prod_replicate, ← List.eq_replicate_of_mem this, Nat.prod_primeFactorsList hG]
   intro q hq
-  obtain ⟨hq1, hq2⟩ := (Nat.mem_factors hG).mp hq
+  obtain ⟨hq1, hq2⟩ := (Nat.mem_primeFactorsList hG).mp hq
   haveI : Fact q.Prime := ⟨hq1⟩
   obtain ⟨g, hg⟩ := exists_prime_orderOf_dvd_card' q hq2
   obtain ⟨k, hk⟩ := (iff_orderOf.mp h) g

--- a/Mathlib/NumberTheory/ArithmeticFunction.lean
+++ b/Mathlib/NumberTheory/ArithmeticFunction.lean
@@ -949,7 +949,7 @@ theorem isMultiplicative_sigma {k : ℕ} : IsMultiplicative (σ k) := by
 
 /-- `Ω n` is the number of prime factors of `n`. -/
 def cardFactors : ArithmeticFunction ℕ :=
-  ⟨fun n => n.factors.length, by simp⟩
+  ⟨fun n => n.primeFactorsList.length, by simp⟩
 #align nat.arithmetic_function.card_factors ArithmeticFunction.cardFactors
 
 @[inherit_doc]
@@ -958,7 +958,7 @@ scoped[ArithmeticFunction] notation "Ω" => ArithmeticFunction.cardFactors
 @[inherit_doc]
 scoped[ArithmeticFunction.Omega] notation "Ω" => ArithmeticFunction.cardFactors
 
-theorem cardFactors_apply {n : ℕ} : Ω n = n.factors.length :=
+theorem cardFactors_apply {n : ℕ} : Ω n = n.primeFactorsList.length :=
   rfl
 #align nat.arithmetic_function.card_factors_apply ArithmeticFunction.cardFactors_apply
 
@@ -969,12 +969,12 @@ lemma cardFactors_zero : Ω 0 = 0 := by simp
 
 @[simp]
 theorem cardFactors_eq_one_iff_prime {n : ℕ} : Ω n = 1 ↔ n.Prime := by
-  refine ⟨fun h => ?_, fun h => List.length_eq_one.2 ⟨n, factors_prime h⟩⟩
+  refine ⟨fun h => ?_, fun h => List.length_eq_one.2 ⟨n, primeFactorsList_prime h⟩⟩
   cases' n with n
   · simp at h
   rcases List.length_eq_one.1 h with ⟨x, hx⟩
-  rw [← prod_factors n.add_one_ne_zero, hx, List.prod_singleton]
-  apply prime_of_mem_factors
+  rw [← prod_primeFactorsList n.add_one_ne_zero, hx, List.prod_singleton]
+  apply prime_of_mem_primeFactorsList
   rw [hx, List.mem_singleton]
 #align nat.arithmetic_function.card_factors_eq_one_iff_prime ArithmeticFunction.cardFactors_eq_one_iff_prime
 
@@ -998,12 +998,12 @@ theorem cardFactors_apply_prime {p : ℕ} (hp : p.Prime) : Ω p = 1 :=
 
 @[simp]
 theorem cardFactors_apply_prime_pow {p k : ℕ} (hp : p.Prime) : Ω (p ^ k) = k := by
-  rw [cardFactors_apply, hp.factors_pow, List.length_replicate]
+  rw [cardFactors_apply, hp.primeFactorsList_pow, List.length_replicate]
 #align nat.arithmetic_function.card_factors_apply_prime_pow ArithmeticFunction.cardFactors_apply_prime_pow
 
 /-- `ω n` is the number of distinct prime factors of `n`. -/
 def cardDistinctFactors : ArithmeticFunction ℕ :=
-  ⟨fun n => n.factors.dedup.length, by simp⟩
+  ⟨fun n => n.primeFactorsList.dedup.length, by simp⟩
 #align nat.arithmetic_function.card_distinct_factors ArithmeticFunction.cardDistinctFactors
 
 @[inherit_doc]
@@ -1019,15 +1019,15 @@ theorem cardDistinctFactors_zero : ω 0 = 0 := by simp
 theorem cardDistinctFactors_one : ω 1 = 0 := by simp [cardDistinctFactors]
 #align nat.arithmetic_function.card_distinct_factors_one ArithmeticFunction.cardDistinctFactors_one
 
-theorem cardDistinctFactors_apply {n : ℕ} : ω n = n.factors.dedup.length :=
+theorem cardDistinctFactors_apply {n : ℕ} : ω n = n.primeFactorsList.dedup.length :=
   rfl
 #align nat.arithmetic_function.card_distinct_factors_apply ArithmeticFunction.cardDistinctFactors_apply
 
 theorem cardDistinctFactors_eq_cardFactors_iff_squarefree {n : ℕ} (h0 : n ≠ 0) :
     ω n = Ω n ↔ Squarefree n := by
-  rw [squarefree_iff_nodup_factors h0, cardDistinctFactors_apply]
+  rw [squarefree_iff_nodup_primeFactorsList h0, cardDistinctFactors_apply]
   constructor <;> intro h
-  · rw [← n.factors.dedup_sublist.eq_of_length h]
+  · rw [← n.primeFactorsList.dedup_sublist.eq_of_length h]
     apply List.nodup_dedup
   · rw [h.dedup]
     rfl
@@ -1036,7 +1036,8 @@ theorem cardDistinctFactors_eq_cardFactors_iff_squarefree {n : ℕ} (h0 : n ≠ 
 @[simp]
 theorem cardDistinctFactors_apply_prime_pow {p k : ℕ} (hp : p.Prime) (hk : k ≠ 0) :
     ω (p ^ k) = 1 := by
-  rw [cardDistinctFactors_apply, hp.factors_pow, List.replicate_dedup hk, List.length_singleton]
+  rw [cardDistinctFactors_apply, hp.primeFactorsList_pow, List.replicate_dedup hk,
+    List.length_singleton]
 #align nat.arithmetic_function.card_distinct_factors_apply_prime_pow ArithmeticFunction.cardDistinctFactors_apply_prime_pow
 
 @[simp]
@@ -1149,7 +1150,7 @@ theorem IsMultiplicative.prodPrimeFactors_one_add_of_squarefree [CommSemiring R]
   trans (∏ᵖ p ∣ n, ((ζ : ArithmeticFunction R) + f) p)
   · simp_rw [prodPrimeFactors_apply hn.ne_zero, add_apply, natCoe_apply]
     apply Finset.prod_congr rfl; intro p hp
-    rw [zeta_apply_ne (prime_of_mem_factors <| List.mem_toFinset.mp hp).ne_zero, cast_one]
+    rw [zeta_apply_ne (prime_of_mem_primeFactorsList <| List.mem_toFinset.mp hp).ne_zero, cast_one]
   rw [isMultiplicative_zeta.natCast.prodPrimeFactors_add_of_squarefree h_mult hn,
     coe_zeta_mul_apply]
 
@@ -1159,7 +1160,7 @@ theorem IsMultiplicative.prodPrimeFactors_one_sub_of_squarefree [CommRing R]
   trans (∏ p ∈ n.primeFactors, (1 + (ArithmeticFunction.pmul (μ : ArithmeticFunction R) f) p))
   · apply Finset.prod_congr rfl; intro p hp
     rw [pmul_apply, intCoe_apply, ArithmeticFunction.moebius_apply_prime
-        (prime_of_mem_factors (List.mem_toFinset.mp hp))]
+        (prime_of_mem_primeFactorsList (List.mem_toFinset.mp hp))]
     ring
   · rw [(isMultiplicative_moebius.intCast.pmul hf).prodPrimeFactors_one_add_of_squarefree hn]
     simp_rw [pmul_apply, intCoe_apply]

--- a/Mathlib/NumberTheory/Cyclotomic/PrimitiveRoots.lean
+++ b/Mathlib/NumberTheory/Cyclotomic/PrimitiveRoots.lean
@@ -377,7 +377,7 @@ theorem sub_one_norm_isPrimePow (hn : IsPrimePow (n : ℕ)) [IsCyclotomicExtensi
     exists_eq_succ_of_ne_zero
       (((n : ℕ).factorization.mem_support_toFun (n : ℕ).minFac).1 <|
         mem_primeFactors_iff_mem_factors.2 <|
-          (mem_factors (IsPrimePow.ne_zero hn)).2 ⟨hprime.out, minFac_dvd _⟩)
+          (mem_primeFactorsList (IsPrimePow.ne_zero hn)).2 ⟨hprime.out, minFac_dvd _⟩)
   simp [hk, sub_one_norm_eq_eval_cyclotomic hζ this hirr]
 #align is_primitive_root.sub_one_norm_is_prime_pow IsPrimitiveRoot.sub_one_norm_isPrimePow
 

--- a/Mathlib/NumberTheory/Cyclotomic/PrimitiveRoots.lean
+++ b/Mathlib/NumberTheory/Cyclotomic/PrimitiveRoots.lean
@@ -376,7 +376,7 @@ theorem sub_one_norm_isPrimePow (hn : IsPrimePow (n : ℕ)) [IsCyclotomicExtensi
   obtain ⟨k, hk⟩ : ∃ k, (n : ℕ).factorization (n : ℕ).minFac = k + 1 :=
     exists_eq_succ_of_ne_zero
       (((n : ℕ).factorization.mem_support_toFun (n : ℕ).minFac).1 <|
-        mem_primeFactors_iff_mem_factors.2 <|
+        mem_primeFactors_iff_mem_primeFactorsList.2 <|
           (mem_primeFactorsList (IsPrimePow.ne_zero hn)).2 ⟨hprime.out, minFac_dvd _⟩)
   simp [hk, sub_one_norm_eq_eval_cyclotomic hζ this hirr]
 #align is_primitive_root.sub_one_norm_is_prime_pow IsPrimitiveRoot.sub_one_norm_isPrimePow

--- a/Mathlib/NumberTheory/Divisors.lean
+++ b/Mathlib/NumberTheory/Divisors.lean
@@ -4,8 +4,8 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Aaron Anderson
 -/
 import Mathlib.Algebra.Order.BigOperators.Group.Finset
-import Mathlib.Data.Nat.Factors
 import Mathlib.Data.Nat.Prime.Basic
+import Mathlib.Data.Nat.PrimeFin
 import Mathlib.Order.Interval.Finset.Nat
 
 #align_import number_theory.divisors from "leanprover-community/mathlib"@"e8638a0fcaf73e4500469f368ef9494e495099b3"
@@ -536,17 +536,17 @@ theorem prod_divisorsAntidiagonal' {M : Type*} [CommMonoid M] (f : ℕ → ℕ �
 #align nat.sum_divisors_antidiagonal' Nat.sum_divisorsAntidiagonal'
 
 /-- The factors of `n` are the prime divisors -/
-theorem prime_divisors_eq_to_filter_divisors_prime (n : ℕ) :
-    n.factors.toFinset = (divisors n).filter Prime := by
+theorem primeFactors_eq_to_filter_divisors_prime (n : ℕ) :
+    n.primeFactors = (divisors n).filter Prime := by
   rcases n.eq_zero_or_pos with (rfl | hn)
   · simp
   · ext q
-    simpa [hn, hn.ne', mem_factors] using and_comm
-#align nat.prime_divisors_eq_to_filter_divisors_prime Nat.prime_divisors_eq_to_filter_divisors_prime
+    simpa [hn, hn.ne', mem_primeFactorsList] using and_comm
+#align nat.prime_divisors_eq_to_filter_divisors_prime Nat.primeFactors_eq_to_filter_divisors_prime
 
-lemma prime_divisors_filter_dvd_of_dvd {m n : ℕ} (hn : n ≠ 0) (hmn : m ∣ n) :
-    n.factors.toFinset.filter (· ∣ m) = m.factors.toFinset := by
-  simp_rw [prime_divisors_eq_to_filter_divisors_prime, filter_comm,
+lemma primeFactors_filter_dvd_of_dvd {m n : ℕ} (hn : n ≠ 0) (hmn : m ∣ n) :
+    n.primeFactors.filter (· ∣ m) = m.primeFactors := by
+  simp_rw [primeFactors_eq_to_filter_divisors_prime, filter_comm,
     divisors_filter_dvd_of_dvd hn hmn]
 
 @[simp]

--- a/Mathlib/NumberTheory/Divisors.lean
+++ b/Mathlib/NumberTheory/Divisors.lean
@@ -544,10 +544,16 @@ theorem primeFactors_eq_to_filter_divisors_prime (n : ℕ) :
     simpa [hn, hn.ne', mem_primeFactorsList] using and_comm
 #align nat.prime_divisors_eq_to_filter_divisors_prime Nat.primeFactors_eq_to_filter_divisors_prime
 
+@[deprecated (since := "2024-07-17")]
+alias prime_divisors_eq_to_filter_divisors_prime := primeFactors_eq_to_filter_divisors_prime
+
 lemma primeFactors_filter_dvd_of_dvd {m n : ℕ} (hn : n ≠ 0) (hmn : m ∣ n) :
     n.primeFactors.filter (· ∣ m) = m.primeFactors := by
   simp_rw [primeFactors_eq_to_filter_divisors_prime, filter_comm,
     divisors_filter_dvd_of_dvd hn hmn]
+
+@[deprecated (since := "2024-07-17")]
+alias prime_divisors_filter_dvd_of_dvd := primeFactors_filter_dvd_of_dvd
 
 @[simp]
 theorem image_div_divisors_eq_divisors (n : ℕ) :

--- a/Mathlib/NumberTheory/Padics/PadicVal.lean
+++ b/Mathlib/NumberTheory/Padics/PadicVal.lean
@@ -310,11 +310,19 @@ theorem le_multiplicity_iff_replicate_subperm_primeFactorsList {a b : ℕ} {n : 
   (replicate_subperm_primeFactorsList_iff ha hb).trans
     multiplicity.pow_dvd_iff_le_multiplicity |>.symm
 
+@[deprecated (since := "2024-07-17")]
+alias le_multiplicity_iff_replicate_subperm_factors :=
+  le_multiplicity_iff_replicate_subperm_primeFactorsList
+
 theorem le_padicValNat_iff_replicate_subperm_primeFactorsList {a b : ℕ} {n : ℕ} (ha : a.Prime)
     (hb : b ≠ 0) :
     n ≤ padicValNat a b ↔ replicate n a <+~ b.primeFactorsList := by
   rw [← le_multiplicity_iff_replicate_subperm_primeFactorsList ha hb,
     ← padicValNat_def' ha.ne_one (Nat.pos_of_ne_zero hb), Nat.cast_le]
+
+@[deprecated (since := "2024-07-17")]
+alias le_padicValNat_iff_replicate_subperm_factors :=
+  le_padicValNat_iff_replicate_subperm_primeFactorsList
 
 end padicValNat
 

--- a/Mathlib/NumberTheory/Padics/PadicVal.lean
+++ b/Mathlib/NumberTheory/Padics/PadicVal.lean
@@ -304,15 +304,16 @@ theorem dvd_iff_padicValNat_ne_zero {p n : ℕ} [Fact p.Prime] (hn0 : n ≠ 0) :
 
 open List
 
-theorem le_multiplicity_iff_replicate_subperm_factors {a b : ℕ} {n : ℕ} (ha : a.Prime)
+theorem le_multiplicity_iff_replicate_subperm_primeFactorsList {a b : ℕ} {n : ℕ} (ha : a.Prime)
     (hb : b ≠ 0) :
-    ↑n ≤ multiplicity a b ↔ replicate n a <+~ b.factors :=
-  (replicate_subperm_factors_iff ha hb).trans multiplicity.pow_dvd_iff_le_multiplicity |>.symm
+    ↑n ≤ multiplicity a b ↔ replicate n a <+~ b.primeFactorsList :=
+  (replicate_subperm_primeFactorsList_iff ha hb).trans
+    multiplicity.pow_dvd_iff_le_multiplicity |>.symm
 
-theorem le_padicValNat_iff_replicate_subperm_factors {a b : ℕ} {n : ℕ} (ha : a.Prime)
+theorem le_padicValNat_iff_replicate_subperm_primeFactorsList {a b : ℕ} {n : ℕ} (ha : a.Prime)
     (hb : b ≠ 0) :
-    n ≤ padicValNat a b ↔ replicate n a <+~ b.factors := by
-  rw [← le_multiplicity_iff_replicate_subperm_factors ha hb,
+    n ≤ padicValNat a b ↔ replicate n a <+~ b.primeFactorsList := by
+  rw [← le_multiplicity_iff_replicate_subperm_primeFactorsList ha hb,
     ← padicValNat_def' ha.ne_one (Nat.pos_of_ne_zero hb), Nat.cast_le]
 
 end padicValNat

--- a/Mathlib/NumberTheory/SmoothNumbers.lean
+++ b/Mathlib/NumberTheory/SmoothNumbers.lean
@@ -62,15 +62,15 @@ lemma not_mem_primesBelow (n : ℕ) : n ∉ primesBelow n :=
 
 /-- `factoredNumbers s`, for a finite set `s` of natural numbers, is the set of positive natural
 numbers all of whose prime factors are in `s`. -/
-def factoredNumbers (s : Finset ℕ) : Set ℕ := {m | m ≠ 0 ∧ ∀ p ∈ factors m, p ∈ s}
+def factoredNumbers (s : Finset ℕ) : Set ℕ := {m | m ≠ 0 ∧ ∀ p ∈ primeFactorsList m, p ∈ s}
 
 lemma mem_factoredNumbers {s : Finset ℕ} {m : ℕ} :
-    m ∈ factoredNumbers s ↔ m ≠ 0 ∧ ∀ p ∈ factors m, p ∈ s :=
+    m ∈ factoredNumbers s ↔ m ≠ 0 ∧ ∀ p ∈ primeFactorsList m, p ∈ s :=
   Iff.rfl
 
 /-- Membership in `Nat.factoredNumbers n` is decidable. -/
 instance (s : Finset ℕ) : DecidablePred (· ∈ factoredNumbers s) :=
-  inferInstanceAs <| DecidablePred fun x ↦ x ∈ {m | m ≠ 0 ∧ ∀ p ∈ factors m, p ∈ s}
+  inferInstanceAs <| DecidablePred fun x ↦ x ∈ {m | m ≠ 0 ∧ ∀ p ∈ primeFactorsList m, p ∈ s}
 
 /-- A number that divides an `s`-factored number is itself `s`-factored. -/
 lemma mem_factoredNumbers_of_dvd {s : Finset ℕ} {m k : ℕ} (h : m ∈ factoredNumbers s)
@@ -79,14 +79,14 @@ lemma mem_factoredNumbers_of_dvd {s : Finset ℕ} {m k : ℕ} (h : m ∈ factore
   obtain ⟨h₁, h₂⟩ := h
   have hk := ne_zero_of_dvd_ne_zero h₁ h'
   refine ⟨hk, fun p hp ↦ h₂ p ?_⟩
-  rw [mem_factors <| by assumption] at hp ⊢
+  rw [mem_primeFactorsList <| by assumption] at hp ⊢
   exact ⟨hp.1, hp.2.trans h'⟩
 
 /-- `m` is `s`-factored if and only if `m` is nonzero and all prime divisors `≤ m` of `m`
 are in `s`. -/
 lemma mem_factoredNumbers_iff_forall_le {s : Finset ℕ} {m : ℕ} :
     m ∈ factoredNumbers s ↔ m ≠ 0 ∧ ∀ p ≤ m, p.Prime → p ∣ m → p ∈ s := by
-  simp_rw [mem_factoredNumbers, mem_factors']
+  simp_rw [mem_factoredNumbers, mem_primeFactorsList']
   exact ⟨fun ⟨H₀, H₁⟩ ↦ ⟨H₀, fun p _ hp₂ hp₃ ↦ H₁ p ⟨hp₂, hp₃, H₀⟩⟩,
     fun ⟨H₀, H₁⟩ ↦
       ⟨H₀, fun p ⟨hp₁, hp₂, hp₃⟩ ↦ H₁ p (le_of_dvd (Nat.pos_of_ne_zero hp₃) hp₂) hp₁ hp₂⟩⟩
@@ -132,8 +132,8 @@ lemma mem_factoredNumbers_iff_primeFactors_subset {s : Finset ℕ} {m : ℕ} :
 lemma factoredNumbers_empty : factoredNumbers ∅ = {1} := by
   ext m
   simp only [mem_factoredNumbers, Finset.not_mem_empty, ← List.eq_nil_iff_forall_not_mem,
-    factors_eq_nil, and_or_left, not_and_self_iff, ne_and_eq_iff_right zero_ne_one, false_or,
-    Set.mem_singleton_iff]
+    primeFactorsList_eq_nil, and_or_left, not_and_self_iff, ne_and_eq_iff_right zero_ne_one,
+    false_or, Set.mem_singleton_iff]
 
 /-- The product of two `s`-factored numbers is again `s`-factored. -/
 lemma mul_mem_factoredNumbers {s : Finset ℕ} {m n : ℕ} (hm : m ∈ factoredNumbers s)
@@ -146,22 +146,23 @@ lemma mul_mem_factoredNumbers {s : Finset ℕ} {m n : ℕ} (hm : m ∈ factoredN
 
 /-- The product of the prime factors of `n` that are in `s` is an `s`-factored number. -/
 lemma prod_mem_factoredNumbers (s : Finset ℕ) (n : ℕ) :
-    (n.factors.filter (· ∈ s)).prod ∈ factoredNumbers s := by
-  have h₀ : (n.factors.filter (· ∈ s)).prod ≠ 0 :=
-    List.prod_ne_zero fun h ↦ (pos_of_mem_factors (List.mem_of_mem_filter h)).false
+    (n.primeFactorsList.filter (· ∈ s)).prod ∈ factoredNumbers s := by
+  have h₀ : (n.primeFactorsList.filter (· ∈ s)).prod ≠ 0 :=
+    List.prod_ne_zero fun h ↦ (pos_of_mem_primeFactorsList (List.mem_of_mem_filter h)).false
   refine ⟨h₀, fun p hp ↦ ?_⟩
-  obtain ⟨H₁, H₂⟩ := (mem_factors h₀).mp hp
+  obtain ⟨H₁, H₂⟩ := (mem_primeFactorsList h₀).mp hp
   simpa only [decide_eq_true_eq] using List.of_mem_filter <| mem_list_primes_of_dvd_prod H₁.prime
-    (fun _ hq ↦ (prime_of_mem_factors (List.mem_of_mem_filter hq)).prime) H₂
+    (fun _ hq ↦ (prime_of_mem_primeFactorsList (List.mem_of_mem_filter hq)).prime) H₂
 
 /-- The sets of `s`-factored and of `s ∪ {N}`-factored numbers are the same when `N` is not prime.
-See `Nat.equivProdNatFactoredNumbers` for when `N` is prime. -/
+  See `Nat.equivProdNatFactoredNumbers` for when `N` is prime. -/
 lemma factoredNumbers_insert (s : Finset ℕ) {N : ℕ} (hN : ¬ N.Prime) :
     factoredNumbers (insert N s) = factoredNumbers s := by
   ext m
   refine ⟨fun hm ↦ ⟨hm.1, fun p hp ↦ ?_⟩,
           fun hm ↦ ⟨hm.1, fun p hp ↦ Finset.mem_insert_of_mem <| hm.2 p hp⟩⟩
-  exact Finset.mem_of_mem_insert_of_ne (hm.2 p hp) fun h ↦ hN <| h ▸ prime_of_mem_factors hp
+  exact Finset.mem_of_mem_insert_of_ne (hm.2 p hp)
+    fun h ↦ hN <| h ▸ prime_of_mem_primeFactorsList hp
 
 @[gcongr] lemma factoredNumbers_mono {s t : Finset ℕ} (hst : s ≤ t) :
     factoredNumbers s ⊆ factoredNumbers t :=
@@ -177,8 +178,8 @@ lemma factoredNumbers_compl {N : ℕ} {s : Finset ℕ} (h : primesBelow N ≤ s)
   obtain ⟨p, hp₁, hp₂⟩ := hn.1 hn.2
   have : N ≤ p := by
     contrapose! hp₂
-    exact h <| mem_primesBelow.mpr ⟨hp₂, prime_of_mem_factors hp₁⟩
-  exact this.trans <| le_of_mem_factors hp₁
+    exact h <| mem_primesBelow.mpr ⟨hp₂, prime_of_mem_primeFactorsList hp₁⟩
+  exact this.trans <| le_of_mem_primeFactorsList hp₁
 
 /-- If `p` is a prime and `n` is `s`-factored, then every product `p^e * n`
 is `s ∪ {p}`-factored. -/
@@ -187,8 +188,8 @@ lemma pow_mul_mem_factoredNumbers {s : Finset ℕ} {p n : ℕ} (hp : p.Prime) (e
     p ^ e * n ∈ factoredNumbers (insert p s) := by
   have hp' := pow_ne_zero e hp.ne_zero
   refine ⟨mul_ne_zero hp' hn.1, fun q hq ↦ ?_⟩
-  rcases (mem_factors_mul hp' hn.1).mp hq with H | H
-  · rw [mem_factors hp'] at H
+  rcases (mem_primeFactorsList_mul hp' hn.1).mp hq with H | H
+  · rw [mem_primeFactorsList hp'] at H
     rw [(prime_dvd_prime_iff_eq H.1 hp).mp <| H.1.dvd_of_dvd_pow H.2]
     exact Finset.mem_insert_self p s
   · exact Finset.mem_insert_of_mem <| hn.2 _ H
@@ -197,7 +198,7 @@ lemma pow_mul_mem_factoredNumbers {s : Finset ℕ} {p n : ℕ} (hp : p.Prime) (e
 lemma Prime.factoredNumbers_coprime {s : Finset ℕ} {p n : ℕ} (hp : p.Prime) (hs : p ∉ s)
     (hn : n ∈ factoredNumbers s) :
     Nat.Coprime p n := by
-  rw [hp.coprime_iff_not_dvd, ← mem_factors_iff_dvd hn.1 hp]
+  rw [hp.coprime_iff_not_dvd, ← mem_primeFactorsList_iff_dvd hn.1 hp]
   exact fun H ↦ hs <| hn.2 p H
 
 /-- If `f : ℕ → F` is multiplicative on coprime arguments, `p ∉ s` is a prime and `m`
@@ -216,7 +217,7 @@ def equivProdNatFactoredNumbers {s : Finset ℕ} {p : ℕ} (hp : p.Prime) (hs : 
     ℕ × factoredNumbers s ≃ factoredNumbers (insert p s) where
   toFun := fun ⟨e, n⟩ ↦ ⟨p ^ e * n, pow_mul_mem_factoredNumbers hp e n.2⟩
   invFun := fun ⟨m, _⟩  ↦ (m.factorization p,
-                            ⟨(m.factors.filter (· ∈ s)).prod, prod_mem_factoredNumbers ..⟩)
+                            ⟨(m.primeFactorsList.filter (· ∈ s)).prod, prod_mem_factoredNumbers ..⟩)
   left_inv := by
     rintro ⟨e, m, hm₀, hm⟩
     simp (config := { etaStruct := .all }) only
@@ -226,28 +227,29 @@ def equivProdNatFactoredNumbers {s : Finset ℕ} {p : ℕ} (hp : p.Prime) (hs : 
       simp only [factorization_pow, Finsupp.coe_add, Finsupp.coe_smul, nsmul_eq_mul,
         Pi.natCast_def, cast_id, Pi.add_apply, Pi.mul_apply, hp.factorization_self,
         mul_one, add_right_eq_self]
-      rw [← factors_count_eq, count_eq_zero]
+      rw [← primeFactorsList_count_eq, count_eq_zero]
       exact fun H ↦ hs (hm p H)
-    · nth_rewrite 2 [← prod_factors hm₀]
-      refine prod_eq <| (filter _ <| perm_factors_mul (pow_ne_zero e hp.ne_zero) hm₀).trans ?_
-      rw [filter_append, hp.factors_pow,
+    · nth_rewrite 2 [← prod_primeFactorsList hm₀]
+      refine prod_eq <|
+        (filter _ <| perm_primeFactorsList_mul (pow_ne_zero e hp.ne_zero) hm₀).trans ?_
+      rw [filter_append, hp.primeFactorsList_pow,
           filter_eq_nil.mpr fun q hq ↦ by rw [mem_replicate] at hq; simp [hq.2, hs],
           nil_append, filter_eq_self.mpr fun q hq ↦ by simp only [hm q hq, decide_True]]
   right_inv := by
     rintro ⟨m, hm₀, hm⟩
     simp only [Set.coe_setOf, Set.mem_setOf_eq, Subtype.mk.injEq]
-    rw [← factors_count_eq, ← prod_replicate, ← prod_append]
-    nth_rewrite 3 [← prod_factors hm₀]
-    have : m.factors.filter (· = p) = m.factors.filter (¬ · ∈ s) := by
+    rw [← primeFactorsList_count_eq, ← prod_replicate, ← prod_append]
+    nth_rewrite 3 [← prod_primeFactorsList hm₀]
+    have : m.primeFactorsList.filter (· = p) = m.primeFactorsList.filter (¬ · ∈ s) := by
       refine (filter_congr fun q hq ↦ ?_).symm
       simp only [decide_not, Bool.not_eq_true', decide_eq_false_iff_not, decide_eq_true_eq]
       rcases Finset.mem_insert.mp <| hm _ hq with h | h
       · simp only [h, hs, decide_False, Bool.not_false, decide_True]
       · simp only [h, decide_True, Bool.not_true, false_eq_decide_iff]
         exact fun H ↦ hs <| H ▸ h
-    refine prod_eq <| (filter_eq m.factors p).symm ▸ this ▸ perm_append_comm.trans ?_
+    refine prod_eq <| (filter_eq m.primeFactorsList p).symm ▸ this ▸ perm_append_comm.trans ?_
     simp only [decide_not]
-    exact filter_append_perm (· ∈ s) (factors m)
+    exact filter_append_perm (· ∈ s) (primeFactorsList m)
 
 @[simp]
 lemma equivProdNatFactoredNumbers_apply {s : Finset ℕ} {p e m : ℕ} (hp : p.Prime) (hs : p ∉ s)
@@ -266,15 +268,16 @@ lemma equivProdNatFactoredNumbers_apply' {s : Finset ℕ} {p : ℕ} (hp : p.Prim
 
 /-- `smoothNumbers n` is the set of *`n`-smooth positive natural numbers*, i.e., the
 positive natural numbers all of whose prime factors are less than `n`. -/
-def smoothNumbers (n : ℕ) : Set ℕ := {m | m ≠ 0 ∧ ∀ p ∈ factors m, p < n}
+def smoothNumbers (n : ℕ) : Set ℕ := {m | m ≠ 0 ∧ ∀ p ∈ primeFactorsList m, p < n}
 
-lemma mem_smoothNumbers {n m : ℕ} : m ∈ smoothNumbers n ↔ m ≠ 0 ∧ ∀ p ∈ factors m, p < n :=
+lemma mem_smoothNumbers {n m : ℕ} : m ∈ smoothNumbers n ↔ m ≠ 0 ∧ ∀ p ∈ primeFactorsList m, p < n :=
   Iff.rfl
 
 /-- The `n`-smooth numbers agree with the `Finset.range n`-factored numbers. -/
 lemma smoothNumbers_eq_factoredNumbers (n : ℕ) :
     smoothNumbers n = factoredNumbers (Finset.range n) := by
-  simp only [smoothNumbers, ne_eq, mem_factors', and_imp, factoredNumbers, Finset.mem_range]
+  simp only [smoothNumbers, ne_eq, mem_primeFactorsList', and_imp, factoredNumbers,
+    Finset.mem_range]
 
 /-- The `n`-smooth numbers agree with the `primesBelow n`-factored numbers. -/
 lemma smmoothNumbers_eq_factoredNumbers_primesBelow (n : ℕ) :
@@ -286,7 +289,7 @@ lemma smmoothNumbers_eq_factoredNumbers_primesBelow (n : ℕ) :
 
 /-- Membership in `Nat.smoothNumbers n` is decidable. -/
 instance (n : ℕ) : DecidablePred (· ∈ smoothNumbers n) :=
-  inferInstanceAs <| DecidablePred fun x ↦ x ∈ {m | m ≠ 0 ∧ ∀ p ∈ factors m, p < n}
+  inferInstanceAs <| DecidablePred fun x ↦ x ∈ {m | m ≠ 0 ∧ ∀ p ∈ primeFactorsList m, p < n}
 
 /-- A number that divides an `n`-smooth number is itself `n`-smooth. -/
 lemma mem_smoothNumbers_of_dvd {n m k : ℕ} (h : m ∈ smoothNumbers n) (h' : k ∣ m) :
@@ -337,7 +340,8 @@ theorem mul_mem_smoothNumbers {m₁ m₂ n : ℕ}
   exact mul_mem_factoredNumbers hm1 hm2
 
 /-- The product of the prime factors of `n` that are less than `N` is an `N`-smooth number. -/
-lemma prod_mem_smoothNumbers (n N : ℕ) : (n.factors.filter (· < N)).prod ∈ smoothNumbers N := by
+lemma prod_mem_smoothNumbers (n N : ℕ) :
+    (n.primeFactorsList.filter (· < N)).prod ∈ smoothNumbers N := by
   simp only [smoothNumbers_eq_factoredNumbers, ← Finset.mem_range, prod_mem_factoredNumbers]
 
 /-- The sets of `N`-smooth and of `(N+1)`-smooth numbers are the same when `N` is not prime.
@@ -355,7 +359,7 @@ lemma smoothNumbers_succ {N : ℕ} (hN : ¬ N.Prime) : N.succ.smoothNumbers = N.
 /-- All `m`, `0 < m < n` are `n`-smooth numbers -/
 lemma mem_smoothNumbers_of_lt {m n : ℕ} (hm : 0 < m) (hmn : m < n) : m ∈ n.smoothNumbers :=
   smoothNumbers_eq_factoredNumbers _ ▸ ⟨not_eq_zero_of_lt hm,
-  fun _ h => Finset.mem_range.mpr <| lt_of_le_of_lt (le_of_mem_factors h) hmn⟩
+  fun _ h => Finset.mem_range.mpr <| lt_of_le_of_lt (le_of_mem_primeFactorsList h) hmn⟩
 
 /-- The non-zero non-`N`-smooth numbers are `≥ N`. -/
 lemma smoothNumbers_compl (N : ℕ) : (N.smoothNumbers)ᶜ \ {0} ⊆ {n | N ≤ n} := by
@@ -369,8 +373,8 @@ lemma pow_mul_mem_smoothNumbers {p n : ℕ} (hp : p ≠ 0) (e : ℕ) (hn : n ∈
   have : NoZeroDivisors ℕ := inferInstance -- this is needed twice --> speed-up
   have hp' := pow_ne_zero e hp
   refine ⟨mul_ne_zero hp' hn.1, fun q hq ↦ ?_⟩
-  rcases (mem_factors_mul hp' hn.1).mp hq with H | H
-  · rw [mem_factors hp'] at H
+  rcases (mem_primeFactorsList_mul hp' hn.1).mp hq with H | H
+  · rw [mem_primeFactorsList hp'] at H
     exact lt_succ.mpr <| le_of_dvd hp.bot_lt <| H.1.dvd_of_dvd_pow H.2
   · exact (hn.2 q H).trans <| lt_succ_self p
 
@@ -445,7 +449,7 @@ lemma eq_prod_primes_mul_sq_of_mem_smoothNumbers {n k : ℕ} (h : n ∈ smoothNu
     ∃ s ∈ k.primesBelow.powerset, ∃ m, n = m ^ 2 * (s.prod id) := by
   obtain ⟨l, m, H₁, H₂⟩ := sq_mul_squarefree n
   have hl : l ∈ smoothNumbers k := mem_smoothNumbers_of_dvd h (Dvd.intro_left (m ^ 2) H₁)
-  refine ⟨l.factors.toFinset, ?_,  m, ?_⟩
+  refine ⟨l.primeFactorsList.toFinset, ?_,  m, ?_⟩
   · simp only [toFinset_factors, Finset.mem_powerset]
     refine fun p hp ↦ mem_primesBelow.mpr ⟨?_, (mem_primeFactors.mp hp).1⟩
     rw [mem_primeFactors] at hp

--- a/Mathlib/NumberTheory/SmoothNumbers.lean
+++ b/Mathlib/NumberTheory/SmoothNumbers.lean
@@ -155,7 +155,7 @@ lemma prod_mem_factoredNumbers (s : Finset ℕ) (n : ℕ) :
     (fun _ hq ↦ (prime_of_mem_primeFactorsList (List.mem_of_mem_filter hq)).prime) H₂
 
 /-- The sets of `s`-factored and of `s ∪ {N}`-factored numbers are the same when `N` is not prime.
-  See `Nat.equivProdNatFactoredNumbers` for when `N` is prime. -/
+See `Nat.equivProdNatFactoredNumbers` for when `N` is prime. -/
 lemma factoredNumbers_insert (s : Finset ℕ) {N : ℕ} (hN : ¬ N.Prime) :
     factoredNumbers (insert N s) = factoredNumbers s := by
   ext m

--- a/Mathlib/NumberTheory/SmoothNumbers.lean
+++ b/Mathlib/NumberTheory/SmoothNumbers.lean
@@ -111,7 +111,7 @@ lemma primeFactors_subset_of_mem_factoredNumbers {s : Finset ℕ} {m : ℕ}
     (hm : m ∈ factoredNumbers s) :
     m.primeFactors ⊆ s := by
   rw [mem_factoredNumbers] at hm
-  exact fun n hn ↦ hm.2 n (mem_primeFactors_iff_mem_factors.mp hn)
+  exact fun n hn ↦ hm.2 n (mem_primeFactors_iff_mem_primeFactorsList.mp hn)
 
 /-- If `m ≠ 0` and the `Finset` of prime factors of `m` is contained in `s`, then `m`
 is `s`-factored. -/
@@ -119,7 +119,7 @@ lemma mem_factoredNumbers_of_primeFactors_subset {s : Finset ℕ} {m : ℕ} (hm 
     (hp : m.primeFactors ⊆ s) :
     m ∈ factoredNumbers s := by
   rw [mem_factoredNumbers]
-  exact ⟨hm, fun p hp' ↦ hp <| mem_primeFactors_iff_mem_factors.mpr hp'⟩
+  exact ⟨hm, fun p hp' ↦ hp <| mem_primeFactors_iff_mem_primeFactorsList.mpr hp'⟩
 
 /-- `m` is `s`-factored if and only if `m ≠ 0` and its `Finset` of prime factors
 is contained in `s`. -/

--- a/Mathlib/RingTheory/UniqueFactorizationDomain.lean
+++ b/Mathlib/RingTheory/UniqueFactorizationDomain.lean
@@ -2119,16 +2119,16 @@ instance instUniqueFactorizationMonoid : UniqueFactorizationMonoid ℕ where
 
 open UniqueFactorizationMonoid
 
-lemma factors_eq : ∀ n : ℕ, normalizedFactors n = n.factors
+lemma factors_eq : ∀ n : ℕ, normalizedFactors n = n.primeFactorsList
   | 0 => by simp
   | n + 1 => by
     rw [← Multiset.rel_eq, ← associated_eq_eq]
     apply UniqueFactorizationMonoid.factors_unique irreducible_of_normalized_factor _
-    · rw [Multiset.prod_coe, Nat.prod_factors n.succ_ne_zero]
+    · rw [Multiset.prod_coe, Nat.prod_primeFactorsList n.succ_ne_zero]
       exact normalizedFactors_prod n.succ_ne_zero
     · intro x hx
       rw [Nat.irreducible_iff_prime, ← Nat.prime_iff]
-      exact Nat.prime_of_mem_factors hx
+      exact Nat.prime_of_mem_primeFactorsList hx
 #align nat.factors_eq Nat.factors_eq
 
 lemma factors_multiset_prod_of_irreducible {s : Multiset ℕ} (h : ∀ x : ℕ, x ∈ s → Irreducible x) :

--- a/docs/100.yaml
+++ b/docs/100.yaml
@@ -314,7 +314,7 @@
 80:
   title  : The Fundamental Theorem of Arithmetic
   decls  :
-    - Nat.factors_unique
+    - Nat.primeFactorsList_unique
     - Int.euclideanDomain
     - EuclideanDomain.to_principal_ideal_domain
     - UniqueFactorizationMonoid


### PR DESCRIPTION
`Nat.factors` was a very generic name that didn't emphasize that
* It is a list
* It is not all factors but only the prime ones


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
