### PR TITLE
[Merged by Bors] - chore: split some lemmas out of Topology.MetricSpace.ProperSpace

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -4331,6 +4331,7 @@ import Mathlib.Topology.MetricSpace.Perfect
 import Mathlib.Topology.MetricSpace.PiNat
 import Mathlib.Topology.MetricSpace.Polish
 import Mathlib.Topology.MetricSpace.ProperSpace
+import Mathlib.Topology.MetricSpace.ProperSpace.Lemmas
 import Mathlib.Topology.MetricSpace.Pseudo.Constructions
 import Mathlib.Topology.MetricSpace.Pseudo.Defs
 import Mathlib.Topology.MetricSpace.Pseudo.Lemmas

--- a/Mathlib/Analysis/Complex/OpenMapping.lean
+++ b/Mathlib/Analysis/Complex/OpenMapping.lean
@@ -6,6 +6,7 @@ Authors: Vincent Beffara
 import Mathlib.Analysis.Analytic.IsolatedZeros
 import Mathlib.Analysis.Complex.CauchyIntegral
 import Mathlib.Analysis.Complex.AbsMax
+import Mathlib.Topology.MetricSpace.ProperSpace.Lemmas
 
 #align_import analysis.complex.open_mapping from "leanprover-community/mathlib"@"f9dd3204df14a0749cd456fac1e6849dfe7d2b88"
 

--- a/Mathlib/Analysis/InnerProductSpace/EuclideanDist.lean
+++ b/Mathlib/Analysis/InnerProductSpace/EuclideanDist.lean
@@ -5,6 +5,7 @@ Authors: Yury Kudryashov
 -/
 import Mathlib.Analysis.InnerProductSpace.Calculus
 import Mathlib.Analysis.InnerProductSpace.PiL2
+import Mathlib.Topology.MetricSpace.ProperSpace.Lemmas
 
 #align_import analysis.inner_product_space.euclidean_dist from "leanprover-community/mathlib"@"9425b6f8220e53b059f5a4904786c3c4b50fc057"
 

--- a/Mathlib/Geometry/Manifold/BumpFunction.lean
+++ b/Mathlib/Geometry/Manifold/BumpFunction.lean
@@ -6,6 +6,7 @@ Authors: Yury Kudryashov
 import Mathlib.Analysis.Calculus.BumpFunction.FiniteDimension
 import Mathlib.Geometry.Manifold.ContMDiff.Atlas
 import Mathlib.Geometry.Manifold.ContMDiff.NormedSpace
+import Mathlib.Topology.MetricSpace.ProperSpace.Lemmas
 
 #align_import geometry.manifold.bump_function from "leanprover-community/mathlib"@"b018406ad2f2a73223a3a9e198ccae61e6f05318"
 

--- a/Mathlib/Topology/MetricSpace/Bounded.lean
+++ b/Mathlib/Topology/MetricSpace/Bounded.lean
@@ -3,6 +3,7 @@ Copyright (c) 2015, 2017 Jeremy Avigad. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Jeremy Avigad, Robert Y. Lewis, Johannes Hölzl, Mario Carneiro, Sébastien Gouëzel
 -/
+import Mathlib.Topology.Algebra.Order.Compact
 import Mathlib.Topology.MetricSpace.ProperSpace
 import Mathlib.Topology.MetricSpace.Cauchy
 

--- a/Mathlib/Topology/MetricSpace/ProperSpace.lean
+++ b/Mathlib/Topology/MetricSpace/ProperSpace.lean
@@ -3,8 +3,10 @@ Copyright (c) 2018 Sébastien Gouëzel. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Sébastien Gouëzel
 -/
-import Mathlib.Topology.Algebra.Order.Compact
+
 import Mathlib.Topology.MetricSpace.Pseudo.Lemmas
+import Mathlib.Topology.Order.IsLUB
+import Mathlib.Topology.Support
 
 /-! ## Proper spaces
 
@@ -127,43 +129,7 @@ instance pi_properSpace {π : β → Type*} [Fintype β] [∀ b, PseudoMetricSpa
   exact isCompact_univ_pi fun _ => isCompact_closedBall _ _
 #align pi_proper_space pi_properSpace
 
-variable [ProperSpace α] {x : α} {r : ℝ} {s : Set α}
-
-/-- If a nonempty ball in a proper space includes a closed set `s`, then there exists a nonempty
-ball with the same center and a strictly smaller radius that includes `s`. -/
-theorem exists_pos_lt_subset_ball (hr : 0 < r) (hs : IsClosed s) (h : s ⊆ ball x r) :
-    ∃ r' ∈ Ioo 0 r, s ⊆ ball x r' := by
-  rcases eq_empty_or_nonempty s with (rfl | hne)
-  · exact ⟨r / 2, ⟨half_pos hr, half_lt_self hr⟩, empty_subset _⟩
-  have : IsCompact s :=
-    (isCompact_closedBall x r).of_isClosed_subset hs (h.trans ball_subset_closedBall)
-  obtain ⟨y, hys, hy⟩ : ∃ y ∈ s, s ⊆ closedBall x (dist y x) :=
-    this.exists_isMaxOn hne (continuous_id.dist continuous_const).continuousOn
-  have hyr : dist y x < r := h hys
-  rcases exists_between hyr with ⟨r', hyr', hrr'⟩
-  exact ⟨r', ⟨dist_nonneg.trans_lt hyr', hrr'⟩, hy.trans <| closedBall_subset_ball hyr'⟩
-#align exists_pos_lt_subset_ball exists_pos_lt_subset_ball
-
-/-- If a ball in a proper space includes a closed set `s`, then there exists a ball with the same
-center and a strictly smaller radius that includes `s`. -/
-theorem exists_lt_subset_ball (hs : IsClosed s) (h : s ⊆ ball x r) : ∃ r' < r, s ⊆ ball x r' := by
-  rcases le_or_lt r 0 with hr | hr
-  · rw [ball_eq_empty.2 hr, subset_empty_iff] at h
-    subst s
-    exact (exists_lt r).imp fun r' hr' => ⟨hr', empty_subset _⟩
-  · exact (exists_pos_lt_subset_ball hr hs h).imp fun r' hr' => ⟨hr'.1.2, hr'.2⟩
-#align exists_lt_subset_ball exists_lt_subset_ball
-
 end ProperSpace
-
-theorem Metric.exists_isLocalMin_mem_ball [PseudoMetricSpace α] [ProperSpace α] [TopologicalSpace β]
-    [ConditionallyCompleteLinearOrder β] [OrderTopology β] {f : α → β} {a z : α} {r : ℝ}
-    (hf : ContinuousOn f (closedBall a r)) (hz : z ∈ closedBall a r)
-    (hf1 : ∀ z' ∈ sphere a r, f z < f z') : ∃ z ∈ ball a r, IsLocalMin f z := by
-  simp_rw [← closedBall_diff_ball] at hf1
-  exact (isCompact_closedBall a r).exists_isLocalMin_mem_open ball_subset_closedBall hf hz hf1
-    isOpen_ball
-#align metric.exists_local_min_mem_ball Metric.exists_isLocalMin_mem_ball
 
 instance [PseudoMetricSpace X] [ProperSpace X] : ProperSpace (Additive X) := ‹ProperSpace X›
 instance [PseudoMetricSpace X] [ProperSpace X] : ProperSpace (Multiplicative X) := ‹ProperSpace X›

--- a/Mathlib/Topology/MetricSpace/ProperSpace/Lemmas.lean
+++ b/Mathlib/Topology/MetricSpace/ProperSpace/Lemmas.lean
@@ -1,0 +1,60 @@
+/-
+Copyright (c) 2018 Sébastien Gouëzel. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Sébastien Gouëzel
+-/
+
+import Mathlib.Topology.Algebra.Order.Compact
+import Mathlib.Topology.MetricSpace.ProperSpace
+import Mathlib.Topology.Order.IntermediateValue
+import Mathlib.Topology.Order.LocalExtr
+
+/-!
+# Proper spaces
+
+This file contains some more involved results about `ProperSpace`s.
+
+## Main definitions and results
+
+* `exists_pos_lt_subset_ball`
+* `exists_lt_subset_ball`
+* `Metric.exists_isLocalMin_mem_ball`
+-/
+
+open Set Metric
+
+variable {α : Type*} {β : Type*} [PseudoMetricSpace α] [ProperSpace α] {x : α} {r : ℝ} {s : Set α}
+
+/-- If a nonempty ball in a proper space includes a closed set `s`, then there exists a nonempty
+ball with the same center and a strictly smaller radius that includes `s`. -/
+theorem exists_pos_lt_subset_ball (hr : 0 < r) (hs : IsClosed s) (h : s ⊆ ball x r) :
+    ∃ r' ∈ Ioo 0 r, s ⊆ ball x r' := by
+  rcases eq_empty_or_nonempty s with (rfl | hne)
+  · exact ⟨r / 2, ⟨half_pos hr, half_lt_self hr⟩, empty_subset _⟩
+  have : IsCompact s :=
+    (isCompact_closedBall x r).of_isClosed_subset hs (h.trans ball_subset_closedBall)
+  obtain ⟨y, hys, hy⟩ : ∃ y ∈ s, s ⊆ closedBall x (dist y x) :=
+    this.exists_isMaxOn (β := α) (α := ℝ) hne (continuous_id.dist continuous_const).continuousOn
+  have hyr : dist y x < r := h hys
+  rcases exists_between hyr with ⟨r', hyr', hrr'⟩
+  exact ⟨r', ⟨dist_nonneg.trans_lt hyr', hrr'⟩, hy.trans <| closedBall_subset_ball hyr'⟩
+#align exists_pos_lt_subset_ball exists_pos_lt_subset_ball
+
+/-- If a ball in a proper space includes a closed set `s`, then there exists a ball with the same
+center and a strictly smaller radius that includes `s`. -/
+theorem exists_lt_subset_ball (hs : IsClosed s) (h : s ⊆ ball x r) : ∃ r' < r, s ⊆ ball x r' := by
+  rcases le_or_lt r 0 with hr | hr
+  · rw [ball_eq_empty.2 hr, subset_empty_iff] at h
+    subst s
+    exact (exists_lt r).imp fun r' hr' => ⟨hr', empty_subset _⟩
+  · exact (exists_pos_lt_subset_ball hr hs h).imp fun r' hr' => ⟨hr'.1.2, hr'.2⟩
+#align exists_lt_subset_ball exists_lt_subset_ball
+
+theorem Metric.exists_isLocalMin_mem_ball [TopologicalSpace β]
+    [ConditionallyCompleteLinearOrder β] [OrderTopology β] {f : α → β} {a z : α} {r : ℝ}
+    (hf : ContinuousOn f (closedBall a r)) (hz : z ∈ closedBall a r)
+    (hf1 : ∀ z' ∈ sphere a r, f z < f z') : ∃ z ∈ ball a r, IsLocalMin f z := by
+  simp_rw [← closedBall_diff_ball] at hf1
+  exact (isCompact_closedBall a r).exists_isLocalMin_mem_open ball_subset_closedBall hf hz hf1
+    isOpen_ball
+#align metric.exists_local_min_mem_ball Metric.exists_isLocalMin_mem_ball

--- a/Mathlib/Topology/MetricSpace/ShrinkingLemma.lean
+++ b/Mathlib/Topology/MetricSpace/ShrinkingLemma.lean
@@ -5,7 +5,7 @@ Authors: Yury G. Kudryashov
 -/
 import Mathlib.Topology.EMetricSpace.Paracompact
 import Mathlib.Topology.MetricSpace.Basic
-import Mathlib.Topology.MetricSpace.ProperSpace
+import Mathlib.Topology.MetricSpace.ProperSpace.Lemmas
 import Mathlib.Topology.ShrinkingLemma
 
 #align_import topology.metric_space.shrinking_lemma from "leanprover-community/mathlib"@"f2ce6086713c78a7f880485f7917ea547a215982"


### PR DESCRIPTION
This removes Mathlib.Topology.MetricSpace.ProperSpace from the longest pole.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
