### PR TITLE
[Merged by Bors] - chore: bump leantar 0.1.13

### DIFF
--- a/Cache/IO.lean
+++ b/Cache/IO.lean
@@ -70,7 +70,7 @@ def CURLBIN :=
 
 /-- leantar version at https://github.com/digama0/leangz -/
 def LEANTARVERSION :=
-  "0.1.12"
+  "0.1.13"
 
 def EXE := if System.Platform.isWindows then ".exe" else ""
 


### PR DESCRIPTION
The latest version of leantar [includes](https://github.com/digama0/leangz/compare/v0.1.12...v0.1.13) the following features and bug fixes:

* Fix to the `-k` comment parsing mode which powers `lake exe cache lookup` broken in v0.1.12
* Ignore unparseable `.trace` files instead of failing, to prevent a future [forward compatibility issue](https://leanprover.zulipchat.com/#narrow/stream/287929-mathlib4/topic/ltar.20error.20aften.20lean.234402/near/444803915)

This is a forward and backward compatible release, because it makes no parsing changes relevant for `cache get` or `cache put`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
