### PR TITLE
[Merged by Bors] - fix: add `-lLake` argument to `pole` and `mk_all`

### DIFF
--- a/lakefile.lean
+++ b/lakefile.lean
@@ -62,6 +62,7 @@ lean_exe checkYaml where
 lean_exe mk_all where
   srcDir := "scripts"
   supportInterpreter := true
+  weakLinkArgs := #["-lLake"]
 
 /-- `lake exe shake` checks files for unnecessary imports. -/
 lean_exe shake where
@@ -76,6 +77,7 @@ and then calculates the longest pole
 lean_exe pole where
   root := `LongestPole.Main
   supportInterpreter := true
+  weakLinkArgs := #["-lLake"]
 
 /--
 `lake exe test` is a thin wrapper around `lake exe batteries/test`, until

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -62,6 +62,7 @@ lean_exe checkYaml where
 lean_exe mk_all where
   srcDir := "scripts"
   supportInterpreter := true
+  -- Executables which import `Lake` must set `-lLake`.
   weakLinkArgs := #["-lLake"]
 
 /-- `lake exe shake` checks files for unnecessary imports. -/
@@ -77,6 +78,7 @@ and then calculates the longest pole
 lean_exe pole where
   root := `LongestPole.Main
   supportInterpreter := true
+  -- Executables which import `Lake` must set `-lLake`.
   weakLinkArgs := #["-lLake"]
 
 /--


### PR DESCRIPTION
Since Lean 4.9, the behaviour of `supportInterpreter` executables has changed, making this necessary:
both of these executables require modules from `lake`.
In contrast, `shake` also uses `supportInterpreter`, but does not depend on `lake`.
[zulip discussion](https://leanprover.zulipchat.com/#narrow/stream/113488-general/topic/automatically.20generate.20ProjectName.2Elean/near/444239597)

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
