### PR TITLE
[Merged by Bors] - fix(GetAllModules): sort module names instead of file names

### DIFF
--- a/Mathlib/Util/GetAllModules.lean
+++ b/Mathlib/Util/GetAllModules.lean
@@ -23,7 +23,7 @@ open Lean System.FilePath
 ```
 #[file₁, ..., fileₙ]
 ```
-of all their file names.
+of all their file names. These are not sorted in general.
 
 The input `git` is a `Bool`ean flag:
 * `true` means that the command uses `git ls-files` to find the relevant files;
@@ -39,8 +39,7 @@ def getAllFiles (git : Bool) (ml : String) : IO (Array System.FilePath) := do
     else do
       let all ← walkDir ml
       return all.filter (·.extension == some "lean"))
-  let files := (allModules.erase ml.lean).qsort (·.toString < ·.toString)
-  let existingFiles ← files.mapM fun f => do
+  let existingFiles ← (allModules.erase ml.lean).mapM fun f => do
     -- this check is helpful in case the `git` option is on and a local file has been removed
     if ← pathExists f then
       return f
@@ -48,9 +47,10 @@ def getAllFiles (git : Bool) (ml : String) : IO (Array System.FilePath) := do
   return existingFiles.filter (· != "")
 
 /-- Like `getAllFiles`, but return an array of *module* names instead,
-i.e. names of the form `"Mathlib.Algebra.Algebra.Basic"`. -/
-def getAllModules (git : Bool) (ml : String) : IO (Array String) := do
+i.e. names of the form `Mathlib.Algebra.Algebra.Basic`.
+In addition, these names are sorted in a platform-independent order. -/
+def getAllModulesSorted (git : Bool) (ml : String) : IO (Array String) := do
   let files ← getAllFiles git ml
-  return ← files.mapM fun f => do
+  let names := ← files.mapM fun f => do
      return (← moduleNameOfFileName f none).toString
-
+  return names.qsort (· < ·)

--- a/Mathlib/Util/GetAllModules.lean
+++ b/Mathlib/Util/GetAllModules.lean
@@ -39,12 +39,11 @@ def getAllFiles (git : Bool) (ml : String) : IO (Array System.FilePath) := do
     else do
       let all ← walkDir ml
       return all.filter (·.extension == some "lean"))
-  let existingFiles ← (allModules.erase ml.lean).mapM fun f => do
-    -- this check is helpful in case the `git` option is on and a local file has been removed
-    if ← pathExists f then
-      return f
-    else return ""
-  return existingFiles.filter (· != "")
+  -- Filter out all files which do not exist.
+  -- This check is helpful in case the `git` option is on and a local file has been removed.
+  return ← (allModules.erase ml.lean).filterMapM (fun f ↦ do
+    if ← pathExists f then pure (some f) else pure none
+  )
 
 /-- Like `getAllFiles`, but return an array of *module* names instead,
 i.e. names of the form `Mathlib.Algebra.Algebra.Basic`.

--- a/scripts/mk_all.lean
+++ b/scripts/mk_all.lean
@@ -48,7 +48,7 @@ def mkAllCLI (args : Parsed) : IO UInt32 := do
   let mut updates := 0
   for d in libs.reverse do  -- reverse to create `Mathlib/Tactic.lean` before `Mathlib.lean`
     let fileName := addExtension d "lean"
-    let allFiles ← getAllModules git d
+    let allFiles ← getAllModulesSorted git d
     let fileContent := ("\n".intercalate (allFiles.map ("import " ++ ·)).toList).push '\n'
     if !(← pathExists fileName) then
       IO.println s!"Creating '{fileName}'"


### PR DESCRIPTION
Different platforms have different path separators, making the sorting of files by their names platform-dependent.
This meant the output `mk_all` would depend on which platform it was run on.
To avoid this, we sort the resulting module names instead --- for which the path separators have been converted to dots.

To make this difference clear, mention this in the documentation and rename to `getAllModulesSorted`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
