### PR TITLE
[Merged by Bors] - chore: implement final style feedback from #13176

### DIFF
--- a/Mathlib/Topology/Separation.lean
+++ b/Mathlib/Topology/Separation.lean
@@ -171,12 +171,12 @@ theorem hasSeparatingCovers_iff_separatedNhds {s t : Set X} :
         exists_false, exists_const, not_false_eq_true]
     refine
       ⟨⋃ n : ℕ, u n \ (closure (⋃ m ≤ n, v m)),
-        ⋃ n : ℕ, v n \ (closure (⋃ m ≤ n, u m)),
-        open_lemma u (fun n ↦ ⋃ m ≤ n, v m) (fun n ↦ (u_props n).1),
-        open_lemma v (fun n ↦ ⋃ m ≤ n, u m) (fun n ↦ (v_props n).1),
-        cover_lemma s u v u_cov (fun n ↦ (v_props n).2),
-        cover_lemma t v u v_cov (fun n ↦ (u_props n).2),
-        ?_⟩
+       ⋃ n : ℕ, v n \ (closure (⋃ m ≤ n, u m)),
+       open_lemma u (fun n ↦ ⋃ m ≤ n, v m) (fun n ↦ (u_props n).1),
+       open_lemma v (fun n ↦ ⋃ m ≤ n, u m) (fun n ↦ (v_props n).1),
+       cover_lemma s u v u_cov (fun n ↦ (v_props n).2),
+       cover_lemma t v u v_cov (fun n ↦ (u_props n).2),
+       ?_⟩
     rw [Set.disjoint_left]
     rintro x ⟨un, ⟨n, rfl⟩, xinun⟩
     suffices ∀ (m : ℕ), x ∈ v m → x ∈ closure (⋃ m' ∈ {m' | m' ≤ m}, u m') by simpa
@@ -187,10 +187,12 @@ theorem hasSeparatingCovers_iff_separatedNhds {s t : Set X} :
     exact subset_closure (mem_biUnion n_le_m xinun.1)
   · rintro ⟨U, V, U_open, V_open, h_sub_U, k_sub_V, UV_dis⟩
     exact
-      ⟨⟨fun _ ↦ U, h_sub_U.trans (iUnion_const U).symm.subset,
+      ⟨⟨fun _ ↦ U,
+        h_sub_U.trans (iUnion_const U).symm.subset,
         fun _ ↦
           ⟨U_open, disjoint_of_subset (fun ⦃a⦄ a ↦ a) k_sub_V (UV_dis.closure_left V_open)⟩⟩,
-      ⟨fun _ ↦ V, k_sub_V.trans (iUnion_const V).symm.subset,
+       ⟨fun _ ↦ V,
+        k_sub_V.trans (iUnion_const V).symm.subset,
         fun _ ↦
           ⟨V_open, disjoint_of_subset (fun ⦃a⦄ a ↦ a) h_sub_U (UV_dis.closure_right U_open).symm⟩⟩⟩
 
@@ -2174,10 +2176,10 @@ lemma IsClosed.HasSeparatingCover {s t : Set X} [r: RegularSpace X] [LindelofSpa
       t_cl.compl_mem_nhds (disjoint_left.mp st_dis ains)
     exact
       ⟨interior n,
-        isOpen_interior,
-        disjoint_left.mpr fun ⦃_⦄ ain ↦
-          nsubkc <| (IsClosed.closure_subset_iff ncl).mpr interior_subset ain,
-        fun _ ↦ mem_interior_iff_mem_nhds.mpr nna⟩
+       isOpen_interior,
+       disjoint_left.mpr fun ⦃_⦄ ain ↦
+         nsubkc <| (IsClosed.closure_subset_iff ncl).mpr interior_subset ain,
+       fun _ ↦ mem_interior_iff_mem_nhds.mpr nna⟩
   -- By Lindelöf, we may obtain a countable subcover witnessing `HasSeparatingCover`
   choose u u_open u_dis u_nhd using this
   obtain ⟨f, f_cov⟩ := s_cl.isLindelof.indexed_countable_subcover


### PR DESCRIPTION
#13176 was merged (I think @PatrickMassot's instruction on how I could merge it myself triggered it) before I could implement [a final bit of feedback](https://github.com/leanprover-community/mathlib4/pull/13176#discussion_r1640999787) to align my contirbution to the mathlib style guide. This implements it.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
