### PR TITLE
[Merged by Bors] - feat(Algebra/Homology) the single complex functor preserves (co)limits

### DIFF
--- a/Mathlib/Algebra/Homology/HomologicalComplexLimits.lean
+++ b/Mathlib/Algebra/Homology/HomologicalComplexLimits.lean
@@ -3,7 +3,7 @@ Copyright (c) 2023 Joël Riou. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Joël Riou
 -/
-import Mathlib.Algebra.Homology.HomologicalComplex
+import Mathlib.Algebra.Homology.Single
 import Mathlib.CategoryTheory.Limits.Shapes.FiniteLimits
 import Mathlib.CategoryTheory.Limits.Preserves.Finite
 
@@ -192,5 +192,29 @@ def preservesColimitsOfShapeOfEval {D : Type*} [Category D]
     PreservesColimitsOfShape J G :=
   ⟨fun {_} => ⟨fun hs ↦ isColimitOfEval _ _
     (fun i => isColimitOfPreserves (G ⋙ eval C c i) hs)⟩⟩
+
+section
+
+variable [HasZeroObject C] [DecidableEq ι] (i : ι)
+
+noncomputable instance : PreservesLimitsOfShape J (single C c i) :=
+  preservesLimitsOfShapeOfEval _ (fun j => by
+    by_cases h : j = i
+    · subst h
+      exact preservesLimitsOfShapeOfNatIso (singleCompEvalIsoSelf C c j).symm
+    · exact Functor.preservesLimitsOfShapeOfIsZero _ (isZero_single_comp_eval C c _ _ h))
+
+noncomputable instance : PreservesColimitsOfShape J (single C c i) :=
+  preservesColimitsOfShapeOfEval _ (fun j => by
+    by_cases h : j = i
+    · subst h
+      exact preservesColimitsOfShapeOfNatIso (singleCompEvalIsoSelf C c j).symm
+    · exact Functor.preservesColimitsOfShapeOfIsZero _ (isZero_single_comp_eval C c _ _ h))
+
+noncomputable instance : PreservesFiniteLimits (single C c i) := ⟨by intros; infer_instance⟩
+
+noncomputable instance : PreservesFiniteColimits (single C c i) := ⟨by intros; infer_instance⟩
+
+end
 
 end HomologicalComplex

--- a/Mathlib/Algebra/Homology/HomologicalComplexLimits.lean
+++ b/Mathlib/Algebra/Homology/HomologicalComplexLimits.lean
@@ -202,14 +202,14 @@ noncomputable instance : PreservesLimitsOfShape J (single C c i) :=
     by_cases h : j = i
     · subst h
       exact preservesLimitsOfShapeOfNatIso (singleCompEvalIsoSelf C c j).symm
-    · exact Functor.preservesLimitsOfShapeOfIsZero _ (isZero_single_comp_eval C c _ _ h))
+    · exact Functor.preservesLimitsOfShapeOfIsZero _ _ (isZero_single_comp_eval C c _ _ h))
 
 noncomputable instance : PreservesColimitsOfShape J (single C c i) :=
   preservesColimitsOfShapeOfEval _ (fun j => by
     by_cases h : j = i
     · subst h
       exact preservesColimitsOfShapeOfNatIso (singleCompEvalIsoSelf C c j).symm
-    · exact Functor.preservesColimitsOfShapeOfIsZero _ (isZero_single_comp_eval C c _ _ h))
+    · exact Functor.preservesColimitsOfShapeOfIsZero _ _ (isZero_single_comp_eval C c _ _ h))
 
 noncomputable instance : PreservesFiniteLimits (single C c i) := ⟨by intros; infer_instance⟩
 

--- a/Mathlib/Algebra/Homology/HomologicalComplexLimits.lean
+++ b/Mathlib/Algebra/Homology/HomologicalComplexLimits.lean
@@ -202,14 +202,14 @@ noncomputable instance : PreservesLimitsOfShape J (single C c i) :=
     by_cases h : j = i
     · subst h
       exact preservesLimitsOfShapeOfNatIso (singleCompEvalIsoSelf C c j).symm
-    · exact Functor.preservesLimitsOfShapeOfIsZero _ _ (isZero_single_comp_eval C c _ _ h))
+    · exact Functor.preservesLimitsOfShapeOfIsZero _ (isZero_single_comp_eval C c _ _ h) _)
 
 noncomputable instance : PreservesColimitsOfShape J (single C c i) :=
   preservesColimitsOfShapeOfEval _ (fun j => by
     by_cases h : j = i
     · subst h
       exact preservesColimitsOfShapeOfNatIso (singleCompEvalIsoSelf C c j).symm
-    · exact Functor.preservesColimitsOfShapeOfIsZero _ _ (isZero_single_comp_eval C c _ _ h))
+    · exact Functor.preservesColimitsOfShapeOfIsZero _ (isZero_single_comp_eval C c _ _ h) _)
 
 noncomputable instance : PreservesFiniteLimits (single C c i) := ⟨by intros; infer_instance⟩
 

--- a/Mathlib/Algebra/Homology/Single.lean
+++ b/Mathlib/Algebra/Homology/Single.lean
@@ -96,6 +96,20 @@ theorem single_map_f_self (j : ι) {A B : V} (f : A ⟶ B) :
   rfl
 #align homological_complex.single_map_f_self HomologicalComplex.single_map_f_self
 
+variable (V)
+
+/-- The natural isomorphism `single V c j ⋙ eval V c j ≅ 𝟭 V`. -/
+@[simps!]
+noncomputable def singleCompEvalIsoSelf (j : ι) : single V c j ⋙ eval V c j ≅ 𝟭 V :=
+  NatIso.ofComponents (singleObjXSelf c j) (fun {A B} f => by simp [single_map_f_self])
+
+lemma isZero_single_comp_eval (j i : ι) (hi : i ≠ j) : IsZero (single V c j ⋙ eval V c i) := by
+  rw [Functor.isZero_iff]
+  intro A
+  exact isZero_single_obj_X c _ _ _ hi
+
+variable {V c}
+
 @[ext]
 lemma from_single_hom_ext {K : HomologicalComplex V c} {j : ι} {A : V}
     {f g : (single V c j).obj A ⟶ K} (hfg : f.f j = g.f j) : f = g := by
@@ -125,8 +139,6 @@ instance (j : ι) : (single V c j).Full where
     ⟨(singleObjXSelf c j A).inv ≫ f.f j ≫ (singleObjXSelf c j B).hom, by
       ext
       simp [single_map_f_self]⟩
-
-variable {c}
 
 /-- Constructor for morphisms to a single homological complex. -/
 noncomputable def mkHomToSingle {K : HomologicalComplex V c} {j : ι} {A : V} (φ : K.X j ⟶ A)

--- a/Mathlib/Algebra/Homology/Single.lean
+++ b/Mathlib/Algebra/Homology/Single.lean
@@ -103,10 +103,8 @@ variable (V)
 noncomputable def singleCompEvalIsoSelf (j : ι) : single V c j ⋙ eval V c j ≅ 𝟭 V :=
   NatIso.ofComponents (singleObjXSelf c j) (fun {A B} f => by simp [single_map_f_self])
 
-lemma isZero_single_comp_eval (j i : ι) (hi : i ≠ j) : IsZero (single V c j ⋙ eval V c i) := by
-  rw [Functor.isZero_iff]
-  intro A
-  exact isZero_single_obj_X c _ _ _ hi
+lemma isZero_single_comp_eval (j i : ι) (hi : i ≠ j) : IsZero (single V c j ⋙ eval V c i) :=
+  Functor.isZero _ (fun _ ↦ isZero_single_obj_X c _ _ _ hi)
 
 variable {V c}
 

--- a/Mathlib/CategoryTheory/Limits/Preserves/Shapes/Zero.lean
+++ b/Mathlib/CategoryTheory/Limits/Preserves/Shapes/Zero.lean
@@ -180,4 +180,29 @@ def preservesInitialObjectOfPreservesZeroMorphisms [PreservesZeroMorphisms F] :
 
 end ZeroObject
 
+section
+
+variable {J : Type*} [Category J] [HasZeroObject D] [HasZeroMorphisms D]
+  (G : C ⥤ D) (hG : IsZero G)
+
+/-- A zero functor preserves limits. -/
+def preservesLimitsOfShapeOfIsZero : PreservesLimitsOfShape J G where
+  preservesLimit := ⟨fun hc => by
+    rw [Functor.isZero_iff] at hG
+    refine IsLimit.ofIsZero _ ?_ (hG _)
+    rw [Functor.isZero_iff]
+    intro X
+    apply hG⟩
+
+/-- A zero functor preserves colimits. -/
+def preservesColimitsOfShapeOfIsZero : PreservesColimitsOfShape J G where
+  preservesColimit := ⟨fun hc => by
+    rw [Functor.isZero_iff] at hG
+    refine IsColimit.ofIsZero _ ?_ (hG _)
+    rw [Functor.isZero_iff]
+    intro X
+    apply hG⟩
+
+end
+
 end CategoryTheory.Functor

--- a/Mathlib/CategoryTheory/Limits/Preserves/Shapes/Zero.lean
+++ b/Mathlib/CategoryTheory/Limits/Preserves/Shapes/Zero.lean
@@ -25,7 +25,7 @@ We provide the following results:
 -/
 
 
-universe v₁ v₂ v₃ u₁ u₂ u₃
+universe v u v₁ v₂ v₃ u₁ u₂ u₃
 
 noncomputable section
 
@@ -182,8 +182,8 @@ end ZeroObject
 
 section
 
-variable (J : Type*) [Category J] [HasZeroObject D] [HasZeroMorphisms D]
-  (G : C ⥤ D) (hG : IsZero G)
+variable [HasZeroObject D] [HasZeroMorphisms D]
+  (G : C ⥤ D) (hG : IsZero G) (J : Type*) [Category J]
 
 /-- A zero functor preserves limits. -/
 def preservesLimitsOfShapeOfIsZero : PreservesLimitsOfShape J G where
@@ -196,6 +196,14 @@ def preservesColimitsOfShapeOfIsZero : PreservesColimitsOfShape J G where
   preservesColimit {K} := ⟨fun hc => by
     rw [Functor.isZero_iff] at hG
     exact IsColimit.ofIsZero _ ((K ⋙ G).isZero (fun X ↦ hG _)) (hG _)⟩
+
+/-- A zero functor preserves limits. -/
+def preservesLimitsOfSizeOfIsZero : PreservesLimitsOfSize.{v, u} G where
+  preservesLimitsOfShape := G.preservesLimitsOfShapeOfIsZero hG _
+
+/-- A zero functor preserves colimits. -/
+def preservesColimitsOfSizeOfIsZero : PreservesColimitsOfSize.{v, u} G where
+  preservesColimitsOfShape := G.preservesColimitsOfShapeOfIsZero hG _
 
 end
 

--- a/Mathlib/CategoryTheory/Limits/Preserves/Shapes/Zero.lean
+++ b/Mathlib/CategoryTheory/Limits/Preserves/Shapes/Zero.lean
@@ -182,7 +182,7 @@ end ZeroObject
 
 section
 
-variable {J : Type*} [Category J] [HasZeroObject D] [HasZeroMorphisms D]
+variable (J : Type*) [Category J] [HasZeroObject D] [HasZeroMorphisms D]
   (G : C ⥤ D) (hG : IsZero G)
 
 /-- A zero functor preserves limits. -/

--- a/Mathlib/CategoryTheory/Limits/Preserves/Shapes/Zero.lean
+++ b/Mathlib/CategoryTheory/Limits/Preserves/Shapes/Zero.lean
@@ -189,17 +189,13 @@ variable (J : Type*) [Category J] [HasZeroObject D] [HasZeroMorphisms D]
 def preservesLimitsOfShapeOfIsZero : PreservesLimitsOfShape J G where
   preservesLimit {K} := ⟨fun hc => by
     rw [Functor.isZero_iff] at hG
-    refine IsLimit.ofIsZero _ ?_ (hG _)
-    apply (K ⋙ G).isZero (fun X ↦ hG _)⟩
+    exact IsLimit.ofIsZero _ ((K ⋙ G).isZero (fun X ↦ hG _)) (hG _)⟩
 
 /-- A zero functor preserves colimits. -/
 def preservesColimitsOfShapeOfIsZero : PreservesColimitsOfShape J G where
-  preservesColimit := ⟨fun hc => by
+  preservesColimit {K} := ⟨fun hc => by
     rw [Functor.isZero_iff] at hG
-    refine IsColimit.ofIsZero _ ?_ (hG _)
-    rw [Functor.isZero_iff]
-    intro X
-    apply hG⟩
+    exact IsColimit.ofIsZero _ ((K ⋙ G).isZero (fun X ↦ hG _)) (hG _)⟩
 
 end
 

--- a/Mathlib/CategoryTheory/Limits/Preserves/Shapes/Zero.lean
+++ b/Mathlib/CategoryTheory/Limits/Preserves/Shapes/Zero.lean
@@ -187,12 +187,10 @@ variable (J : Type*) [Category J] [HasZeroObject D] [HasZeroMorphisms D]
 
 /-- A zero functor preserves limits. -/
 def preservesLimitsOfShapeOfIsZero : PreservesLimitsOfShape J G where
-  preservesLimit := ⟨fun hc => by
+  preservesLimit {K} := ⟨fun hc => by
     rw [Functor.isZero_iff] at hG
     refine IsLimit.ofIsZero _ ?_ (hG _)
-    rw [Functor.isZero_iff]
-    intro X
-    apply hG⟩
+    apply (K ⋙ G).isZero (fun X ↦ hG _)⟩
 
 /-- A zero functor preserves colimits. -/
 def preservesColimitsOfShapeOfIsZero : PreservesColimitsOfShape J G where

--- a/Mathlib/CategoryTheory/Limits/Shapes/ZeroMorphisms.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/ZeroMorphisms.lean
@@ -665,4 +665,23 @@ instance isSplitEpi_prod_snd [HasZeroMorphisms C] {X Y : C} [HasLimit (pair X Y)
   IsSplitEpi.mk' { section_ := prod.lift 0 (𝟙 Y) }
 #align category_theory.limits.is_split_epi_prod_snd CategoryTheory.Limits.isSplitEpi_prod_snd
 
+
+section
+
+variable [HasZeroMorphisms C] [HasZeroObject C] {F : D ⥤ C}
+
+/-- If a functor `F` is zero, then any cone for `F` with a zero point is limit. -/
+def IsLimit.ofIsZero (c : Cone F) (hF : IsZero F) (hc : IsZero c.pt) : IsLimit c where
+  lift _ := 0
+  fac _ j := (F.isZero_iff.1 hF j).eq_of_tgt _ _
+  uniq _ _ _ := hc.eq_of_tgt _ _
+
+/-- If a functor `F` is zero, then any cocone for `F` with a zero point is colimit. -/
+def IsColimit.ofIsZero (c : Cocone F) (hF : IsZero F) (hc : IsZero c.pt) : IsColimit c where
+  desc _ := 0
+  fac _ j := (F.isZero_iff.1 hF j).eq_of_src _ _
+  uniq _ _ _ := hc.eq_of_src _ _
+
+end
+
 end CategoryTheory.Limits

--- a/Mathlib/CategoryTheory/Limits/Shapes/ZeroMorphisms.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/ZeroMorphisms.lean
@@ -682,6 +682,14 @@ def IsColimit.ofIsZero (c : Cocone F) (hF : IsZero F) (hc : IsZero c.pt) : IsCol
   fac _ j := (F.isZero_iff.1 hF j).eq_of_src _ _
   uniq _ _ _ := hc.eq_of_src _ _
 
+lemma IsLimit.isZero_pt {c : Cone F} (hc : IsLimit c) (hF : IsZero F) : IsZero c.pt :=
+  (isZero_zero C).of_iso (IsLimit.conePointUniqueUpToIso hc
+    (IsLimit.ofIsZero (Cone.mk 0 0) hF (isZero_zero C)))
+
+lemma IsColimit.isZero_pt {c : Cocone F} (hc : IsColimit c) (hF : IsZero F) : IsZero c.pt :=
+  (isZero_zero C).of_iso (IsColimit.coconePointUniqueUpToIso hc
+    (IsColimit.ofIsZero (Cocone.mk 0 0) hF (isZero_zero C)))
+
 end
 
 end CategoryTheory.Limits


### PR DESCRIPTION
In this PR, it is shown that the single functors `C ⥤ HomologicalComplex C c` preserves limits and colimits.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
