### PR TITLE
[Merged by Bors] - chore: Improved nth_rewrite and nth_rw docstrings

### DIFF
--- a/Mathlib/Tactic/NthRewrite.lean
+++ b/Mathlib/Tactic/NthRewrite.lean
@@ -18,8 +18,8 @@ namespace Mathlib.Tactic
 open Lean Elab Tactic Meta Parser.Tactic
 
 /-- `nth_rewrite` is a variant of `rewrite` that only changes the nth occurrence of the expression
-to be rewritten.  `nth_rewrite n [eq₁, eq₂,...]` will rewrite the `n`ᵗʰ occurrence
-of the equalities `eq₁`, `eq₂`,... etc.
+to be rewritten. `nth_rewrite n [eq₁, eq₂, ..., eqₘ]` will rewrite the `n`ᵗʰ occurrence
+of each of the `m` equalities `eqᵢ`.
 
 Note: The occurrences are counted beginning with `1` and not `0`, this is different than in
 mathlib3. The translation will be handled by mathport. -/

--- a/Mathlib/Tactic/NthRewrite.lean
+++ b/Mathlib/Tactic/NthRewrite.lean
@@ -17,11 +17,13 @@ namespace Mathlib.Tactic
 
 open Lean Elab Tactic Meta Parser.Tactic
 
-/-- `nth_rewrite` is a variant of `rewrite` that only changes the nth occurrence of the expression
-to be rewritten. `nth_rewrite n [eq₁, eq₂, ..., eqₘ]` will rewrite the `n`ᵗʰ occurrence
-of each of the `m` equalities `eqᵢ`.
+/-- `nth_rewrite` is a variant of `rewrite` that only changes the `n`ᵗʰ _occurrence_ of the
+expression to be rewritten. `nth_rewrite n [eq₁, eq₂, ..., eqₘ]` will rewrite the `n`ᵗʰ _occurrence_
+of each of the `m` equalities `eqᵢ`in that order. Occurrences are counted beginning with `1`.
+If a term `t` is introduced by rewriting with `eqᵢ`, then this instance of `t` will be counted
+as an _occurrence_ of `t`for all subsequent rewrites of `t` with `eqⱼ` for `j > i`.
 
-Note: The occurrences are counted beginning with `1` and not `0`, this is different than in
+Note : The occurrences are counted beginning with `1` and not `0`, this is different than in
 mathlib3. The translation will be handled by mathport. -/
 syntax (name := nthRewriteSeq) "nth_rewrite" (config)? ppSpace num rwRuleSeq (location)? : tactic
 
@@ -43,8 +45,11 @@ syntax (name := nthRewriteSeq) "nth_rewrite" (config)? ppSpace num rwRuleSeq (lo
 
 /--
 `nth_rw` is a variant of `nth_rewrite` that also tries to close the goal by trying `rfl` afterwards.
-`nth_rw n [eq₁, eq₂,...]` rewrites the `n`ᵗʰ occurrence of each equality `eq₁`, `eq₂`,... etc.
-Occurrences are counted beginning with `1`.
+`nth_rw n [eq₁, eq₂,..., eqₘ]` will rewrite the `n`ᵗʰ _occurrence_ of each of the `m` equalities
+`eqᵢ`in that order. Occurrences are counted beginning with `1`. If a term `t` is introduced
+by rewriting with `eqᵢ`, then this instance of `t` will be counted as an _occurrence_ of `t` for all
+subsequent rewrites of `t` with `eqⱼ` for `j > i`. Further, `nth_rw` will close the remaining goal
+with `rfl` if possible.
 -/
 macro (name := nthRwSeq) "nth_rw" c:(config)? ppSpace n:num s:rwRuleSeq l:(location)? : tactic =>
   -- Note: This is a direct copy of `nth_rw` from core.

--- a/Mathlib/Tactic/NthRewrite.lean
+++ b/Mathlib/Tactic/NthRewrite.lean
@@ -43,7 +43,7 @@ syntax (name := nthRewriteSeq) "nth_rewrite" (config)? ppSpace num rwRuleSeq (lo
 
 /--
 `nth_rw` is a variant of `nth_rewrite` that also tries to close the goal by trying `rfl` afterwards.
-`nth_rw n [eq₁, eq₂,...]` rewrites the `nᵗʰ` occurrence of each equality `eq₁`, `eq₂`,... etc.
+`nth_rw n [eq₁, eq₂,...]` rewrites the `n`ᵗʰ occurrence of each equality `eq₁`, `eq₂`,... etc.
 Occurrences are counted beginning with `1`.
 -/
 macro (name := nthRwSeq) "nth_rw" c:(config)? ppSpace n:num s:rwRuleSeq l:(location)? : tactic =>

--- a/Mathlib/Tactic/NthRewrite.lean
+++ b/Mathlib/Tactic/NthRewrite.lean
@@ -23,7 +23,7 @@ of each of the `m` equalities `eqᵢ`in that order. Occurrences are counted begi
 If a term `t` is introduced by rewriting with `eqᵢ`, then this instance of `t` will be counted
 as an _occurrence_ of `t`for all subsequent rewrites of `t` with `eqⱼ` for `j > i`.
 
-Note : The occurrences are counted beginning with `1` and not `0`, this is different than in
+Note: The occurrences are counted beginning with `1` and not `0`, this is different than in
 mathlib3. The translation will be handled by mathport. -/
 syntax (name := nthRewriteSeq) "nth_rewrite" (config)? ppSpace num rwRuleSeq (location)? : tactic
 

--- a/Mathlib/Tactic/NthRewrite.lean
+++ b/Mathlib/Tactic/NthRewrite.lean
@@ -18,7 +18,8 @@ namespace Mathlib.Tactic
 open Lean Elab Tactic Meta Parser.Tactic
 
 /-- `nth_rewrite` is a variant of `rewrite` that only changes the nth occurrence of the expression
-to be rewritten.
+to be rewritten.  `nth_rewrite n [eq₁, eq₂,...]` will rewrite the `n`ᵗʰ occurrence
+of the equalities `eq₁`, `eq₂`,... etc.
 
 Note: The occurrences are counted beginning with `1` and not `0`, this is different than in
 mathlib3. The translation will be handled by mathport. -/
@@ -41,7 +42,9 @@ syntax (name := nthRewriteSeq) "nth_rewrite" (config)? ppSpace num rwRuleSeq (lo
   | _ => throwUnsupportedSyntax
 
 /--
-`nth_rw` is like `nth_rewrite`, but also tries to close the goal by trying `rfl` afterwards.
+`nth_rw` is a variant of `nth_rewrite` that also tries to close the goal by trying `rfl` afterwards.
+`nth_rw n [eq₁, eq₂,...]` rewrites the `nᵗʰ` occurrence of each equality `eq₁`, `eq₂`,... etc.
+Occurrences are counted beginning with `1`.
 -/
 macro (name := nthRwSeq) "nth_rw" c:(config)? ppSpace n:num s:rwRuleSeq l:(location)? : tactic =>
   -- Note: This is a direct copy of `nth_rw` from core.

--- a/Mathlib/Tactic/NthRewrite.lean
+++ b/Mathlib/Tactic/NthRewrite.lean
@@ -87,7 +87,7 @@ syntax (name := nthRewriteSeq) "nth_rewrite" (config)? ppSpace num rwRuleSeq (lo
 
 /--
 `nth_rw` is a variant of `rw` that only changes the `n`ᵗʰ _occurrence_ of the expression to be
-rewritten. Like `rw`, unlike `nth_rewrite` it will try to close the goal by trying `rfl` afterwards.
+rewritten. Like `rw`, unlike `nth_rewrite`, it will try to close the goal by trying `rfl` afterwards.
 `nth_rw n [eq₁, eq₂,..., eqₘ]` will rewrite the `n`ᵗʰ _occurrence_ of each of the `m` equalities
 `eqᵢ`in that order. Occurrences are counted beginning with `1` in order of precedence. For example,
 ```lean

--- a/Mathlib/Tactic/NthRewrite.lean
+++ b/Mathlib/Tactic/NthRewrite.lean
@@ -20,7 +20,7 @@ open Lean Elab Tactic Meta Parser.Tactic
 /-- `nth_rewrite` is a variant of `rewrite` that only changes the `n`ᵗʰ _occurrence_ of the
 expression to be rewritten. `nth_rewrite n [eq₁, eq₂, ..., eqₘ]` will rewrite the `n`ᵗʰ _occurrence_
 of each of the `m` equalities `eqᵢ`in that order. Occurrences are counted beginning with `1`.
-Occurrences are counted beginning with `1`. For example,
+For example,
 ```lean
 example (h : a = 1) : a + a + a + a + a = 5 := by
   nth_rewrite 2 [h]

--- a/Mathlib/Tactic/NthRewrite.lean
+++ b/Mathlib/Tactic/NthRewrite.lean
@@ -55,8 +55,8 @@ h: a = a + b
 ⊢ a + a + (a + b + b) + a + a = 0
 -/
 ```
-Here, the first `nth_rewrite` with `h` introduces an additional occurrence of `a` in the goal. That is,
-the goal state after the first rewrite looks like below
+Here, the first `nth_rewrite` with `h` introduces an additional occurrence of `a` in the goal.
+That is, the goal state after the first rewrite looks like below
 ```lean
 /-
 a b: ℕ

--- a/Mathlib/Tactic/NthRewrite.lean
+++ b/Mathlib/Tactic/NthRewrite.lean
@@ -87,9 +87,10 @@ syntax (name := nthRewriteSeq) "nth_rewrite" (config)? ppSpace num rwRuleSeq (lo
 
 /--
 `nth_rw` is a variant of `rw` that only changes the `n`ᵗʰ _occurrence_ of the expression to be
-rewritten. Like `rw`, unlike `nth_rewrite`, it will try to close the goal by trying `rfl` afterwards.
-`nth_rw n [eq₁, eq₂,..., eqₘ]` will rewrite the `n`ᵗʰ _occurrence_ of each of the `m` equalities
-`eqᵢ`in that order. Occurrences are counted beginning with `1` in order of precedence. For example,
+rewritten. Like `rw`, and unlike `nth_rewrite`, it will try to close the goal by trying `rfl` 
+afterwards. `nth_rw n [eq₁, eq₂,..., eqₘ]` will rewrite the `n`ᵗʰ _occurrence_ of each of the 
+`m` equalities `eqᵢ`in that order. Occurrences are counted beginning with `1` in 
+order of precedence. For example,
 ```lean
 example (h : a = 1) : a + a + a + a + a = 5 := by
   nth_rw 2 [h]

--- a/Mathlib/Tactic/NthRewrite.lean
+++ b/Mathlib/Tactic/NthRewrite.lean
@@ -87,9 +87,9 @@ syntax (name := nthRewriteSeq) "nth_rewrite" (config)? ppSpace num rwRuleSeq (lo
 
 /--
 `nth_rw` is a variant of `rw` that only changes the `n`ᵗʰ _occurrence_ of the expression to be
-rewritten. Like `rw`, and unlike `nth_rewrite`, it will try to close the goal by trying `rfl` 
-afterwards. `nth_rw n [eq₁, eq₂,..., eqₘ]` will rewrite the `n`ᵗʰ _occurrence_ of each of the 
-`m` equalities `eqᵢ`in that order. Occurrences are counted beginning with `1` in 
+rewritten. Like `rw`, and unlike `nth_rewrite`, it will try to close the goal by trying `rfl`
+afterwards. `nth_rw n [eq₁, eq₂,..., eqₘ]` will rewrite the `n`ᵗʰ _occurrence_ of each of the
+`m` equalities `eqᵢ`in that order. Occurrences are counted beginning with `1` in
 order of precedence. For example,
 ```lean
 example (h : a = 1) : a + a + a + a + a = 5 := by

--- a/Mathlib/Tactic/NthRewrite.lean
+++ b/Mathlib/Tactic/NthRewrite.lean
@@ -106,7 +106,7 @@ To understand the importance of order of precedence, consider the example below
 example (a b c : Nat) : (a + b) + c = (b + a) + c := by
   nth_rewrite 2 [Nat.add_comm] -- ⊢ (b + a) + c = (b + a) + c
 ```
-Here, although the occurrence parameter is `2`, `(a + b)` is rewritten to `(b + a)`. This happens,
+Here, although the occurrence parameter is `2`, `(a + b)` is rewritten to `(b + a)`. This happens
 because in order of precedence, the first occurrence of `_ + _` is the one that adds `a + b` to `c`.
 The occurrence in `a + b` counts as the second occurrence.
 

--- a/Mathlib/Tactic/NthRewrite.lean
+++ b/Mathlib/Tactic/NthRewrite.lean
@@ -66,15 +66,6 @@ h: a = a + b
 ```
 This new instance of `a` also turns out to be the third _occurrence_ of `a`.  Therefore,
 the next `nth_rewrite` with `h` rewrites this `a`.
-```lean
-/-
-a b: ℕ
-h: a = a + b
-⊢ a + a + (a + b + b) + a + a = 0
--/
-```
-This new instance of `a` also turns out to be the third _occurrence_ of `a`.  Therefore,
-the next `nth_rewrite` with `h` rewrites this `a`.
 -/
 syntax (name := nthRewriteSeq) "nth_rewrite" (config)? ppSpace num rwRuleSeq (location)? : tactic
 

--- a/Mathlib/Tactic/NthRewrite.lean
+++ b/Mathlib/Tactic/NthRewrite.lean
@@ -39,7 +39,7 @@ To understand the importance of order of precedence, consider the example below
 example (a b c : Nat) : (a + b) + c = (b + a) + c := by
   nth_rewrite 2 [Nat.add_comm] -- ⊢ (b + a) + c = (b + a) + c
 ```
-Here, although the occurrence parameter is `2`, `(a + b)` is rewritten to `(b + a)`. This happens,
+Here, although the occurrence parameter is `2`, `(a + b)` is rewritten to `(b + a)`. This happens
 because in order of precedence, the first occurrence of `_ + _` is the one that adds `a + b` to `c`.
 The occurrence in `a + b` counts as the second occurrence.
 

--- a/Mathlib/Tactic/NthRewrite.lean
+++ b/Mathlib/Tactic/NthRewrite.lean
@@ -70,7 +70,7 @@ the next `nth_rewrite` with `h` rewrites this `a`.
 /-
 a b: ℕ
 h: a = a + b
-⊢ a + a + (a + b) + a + a = 0
+⊢ a + a + (a + b + b) + a + a = 0
 -/
 ```
 This new instance of `a` also turns out to be the third _occurrence_ of `a`.  Therefore,

--- a/Mathlib/Tactic/NthRewrite.lean
+++ b/Mathlib/Tactic/NthRewrite.lean
@@ -86,7 +86,8 @@ syntax (name := nthRewriteSeq) "nth_rewrite" (config)? ppSpace num rwRuleSeq (lo
   | _ => throwUnsupportedSyntax
 
 /--
-`nth_rw` is a variant of `nth_rewrite` that also tries to close the goal by trying `rfl` afterwards.
+`nth_rw` is a variant of `rw` that only changes the `n`ᵗʰ _occurrence_ of the expression to be
+rewritten. Like `rw`, unlike `nth_rewrite` it will try to close the goal by trying `rfl` afterwards.
 `nth_rw n [eq₁, eq₂,..., eqₘ]` will rewrite the `n`ᵗʰ _occurrence_ of each of the `m` equalities
 `eqᵢ`in that order. Occurrences are counted beginning with `1` in order of precedence. For example,
 ```lean

--- a/Mathlib/Tactic/NthRewrite.lean
+++ b/Mathlib/Tactic/NthRewrite.lean
@@ -21,7 +21,7 @@ open Lean Elab Tactic Meta Parser.Tactic
 expression to be rewritten. `nth_rewrite n [eq₁, eq₂, ..., eqₘ]` will rewrite the `n`ᵗʰ _occurrence_
 of each of the `m` equalities `eqᵢ`in that order. Occurrences are counted beginning with `1`.
 If a term `t` is introduced by rewriting with `eqᵢ`, then this instance of `t` will be counted
-as an _occurrence_ of `t`for all subsequent rewrites of `t` with `eqⱼ` for `j > i`.
+as an _occurrence_ of `t` for all subsequent rewrites of `t` with `eqⱼ` for `j > i`.
 
 Note: The occurrences are counted beginning with `1` and not `0`, this is different than in
 mathlib3. The translation will be handled by mathport. -/

--- a/Mathlib/Tactic/NthRewrite.lean
+++ b/Mathlib/Tactic/NthRewrite.lean
@@ -35,20 +35,17 @@ Notice that the second occurrence of `a` from the left has been rewritten by `nt
 If a term `t` is introduced by rewriting with `eqᵢ`, then this instance of `t` will be counted
 as an _occurrence_ of `t` for all subsequent rewrites of `t` with `eqⱼ` for `j > i`. This behaviour
 is illustrated by the example below
-
 ```lean
 example (h : a = a + b) : a + a + a + a + a = 0 := by
-  nth_rewrite 3 [h, h, h, h]
-
+  nth_rewrite 3 [h, h]
 /-
 a b: ℕ
 h: a = a + b
-⊢ a + a + (a + b + b + b + b) + a + a = 0
+⊢ a + a + (a + b + b) + a + a = 0
 -/
 ```
 In this example, the first `nth_rewrite` with `h` introduces an additional occurrence of `a` in
 the goal. That is, the goal state after the first rewrite looks like below
-
 ```lean
 /-
 a b: ℕ
@@ -84,7 +81,6 @@ syntax (name := nthRewriteSeq) "nth_rewrite" (config)? ppSpace num rwRuleSeq (lo
 `nth_rw` is a variant of `nth_rewrite` that also tries to close the goal by trying `rfl` afterwards.
 `nth_rw n [eq₁, eq₂,..., eqₘ]` will rewrite the `n`ᵗʰ _occurrence_ of each of the `m` equalities
 `eqᵢ`in that order. Occurrences are counted beginning with `1`. For example,
-
 ```lean
 example (h : a = 1) : a + a + a + a + a = 5 := by
   nth_rw 2 [h]
@@ -94,26 +90,22 @@ h: a = 1
 ⊢ a + 1 + a + a + a = 5
 -/
 ```
-
 Notice that the second occurrence of `a` from the left has been rewritten by `nth_rewrite`.
 
 If a term `t` is introduced by rewriting with `eqᵢ`, then this instance of `t` will be counted as an
 _occurrence_ of `t` for all subsequent rewrites of `t` with `eqⱼ` for `j > i`. This behaviour is
 illustrated by the example below
-
 ```lean
 example (h : a = a + b) : a + a + a + a + a = 0 := by
-  nth_rw 3 [h, h, h, h]
+  nth_rw 3 [h, h]
 /-
 a b: ℕ
 h: a = a + b
-⊢ a + a + (a + b + b + b + b) + a + a = 0
+⊢ a + a + (a + b + b) + a + a = 0
 -/
 ```
-
 In this example, the first `nth_rw` with `h` introduces an additional occurrence of `a` in
 the goal. That is, the goal state after the first rewrite looks like below
-
 ```lean
 /-
 a b: ℕ

--- a/Mathlib/Tactic/NthRewrite.lean
+++ b/Mathlib/Tactic/NthRewrite.lean
@@ -23,11 +23,11 @@ of each of the `m` equalities `eqᵢ`in that order. Occurrences are counted begi
 Occurrences are counted beginning with `1`. For example,
 ```lean
 example (h : a = 1) : a + a + a + a + a = 5 := by
-  nth_rewrite 3 [h]
+  nth_rewrite 2 [h]
 /-
 a: ℕ
 h: a = 1
-⊢ a + a + 1 + a + a = 5
+⊢ a + 1 + a + a + a = 5
 -/
 ```
 Notice that the second occurrence of `a` from the left has been rewritten by `nth_rewrite`.

--- a/Mathlib/Tactic/NthRewrite.lean
+++ b/Mathlib/Tactic/NthRewrite.lean
@@ -75,9 +75,6 @@ h: a = a + b
 ```
 This new instance of `a` also turns out to be the third _occurrence_ of `a`.  Therefore,
 the next `nth_rewrite` with `h` rewrites this `a`.
-
-Note: The occurrences are counted beginning with `1` and not `0`, this is different from
-mathlib3. The translation will be handled by mathport.
 -/
 syntax (name := nthRewriteSeq) "nth_rewrite" (config)? ppSpace num rwRuleSeq (location)? : tactic
 


### PR DESCRIPTION
[Zulip thread of discussion](https://leanprover.zulipchat.com/#narrow/stream/287929-mathlib4/topic/docstrings.20of.20.60nth_rewrite.60.20and.20.60nth_rw.60/near/444853793)


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
