### PR TITLE
[Merged by Bors] - chore(NumberTheory/MulChar): deprecate `IsNontrivial`, fix `isPrimitive`

### DIFF
--- a/Mathlib/NumberTheory/DirichletCharacter/Basic.lean
+++ b/Mathlib/NumberTheory/DirichletCharacter/Basic.lean
@@ -18,7 +18,7 @@ Main definitions:
 - `DirichletCharacter`: The type representing a Dirichlet character.
 - `changeLevel`: Extend the Dirichlet character χ of level `n` to level `m`, where `n` divides `m`.
 - `conductor`: The conductor of a Dirichlet character.
-- `isPrimitive`: If the level is equal to the conductor.
+- `IsPrimitive`: If the level is equal to the conductor.
 
 ## Tags
 
@@ -226,14 +226,16 @@ lemma conductor_le_conductor_mem_conductorSet {d : ℕ} (hd : d ∈ conductorSet
 variable (χ)
 
 /-- A character is primitive if its level is equal to its conductor. -/
-def isPrimitive : Prop := conductor χ = n
+def IsPrimitive : Prop := conductor χ = n
 
-lemma isPrimitive_def : isPrimitive χ ↔ conductor χ = n := Iff.rfl
+@[deprecated (since := "2024-06-16")] alias isPrimitive := IsPrimitive
 
-lemma isPrimitive_one_level_one : isPrimitive (1 : DirichletCharacter R 1) :=
+lemma isPrimitive_def : IsPrimitive χ ↔ conductor χ = n := Iff.rfl
+
+lemma isPrimitive_one_level_one : IsPrimitive (1 : DirichletCharacter R 1) :=
   Nat.dvd_one.mp (conductor_dvd_level _)
 
-lemma isPritive_one_level_zero : isPrimitive (1 : DirichletCharacter R 0) :=
+lemma isPritive_one_level_zero : IsPrimitive (1 : DirichletCharacter R 0) :=
   conductor_eq_zero_iff_level_eq_zero.mpr rfl
 
 lemma conductor_one_dvd (n : ℕ) : conductor (1 : DirichletCharacter R 1) ∣ n := by
@@ -244,7 +246,7 @@ lemma conductor_one_dvd (n : ℕ) : conductor (1 : DirichletCharacter R 1) ∣ n
 noncomputable def primitiveCharacter : DirichletCharacter R χ.conductor :=
   Classical.choose (factorsThrough_conductor χ).choose_spec
 
-lemma primitiveCharacter_isPrimitive : isPrimitive (χ.primitiveCharacter) := by
+lemma primitiveCharacter_isPrimitive : IsPrimitive (χ.primitiveCharacter) := by
   by_cases h : χ.conductor = 0
   · rw [isPrimitive_def]
     convert conductor_eq_zero_iff_level_eq_zero.mpr h
@@ -273,8 +275,8 @@ lemma mul_def {n m : ℕ} {χ : DirichletCharacter R n} {ψ : DirichletCharacter
     χ.primitive_mul ψ = primitiveCharacter (mul χ ψ) :=
   rfl
 
-lemma isPrimitive.primitive_mul {m : ℕ} (ψ : DirichletCharacter R m) :
-    (primitive_mul χ ψ).isPrimitive :=
+lemma primitive_mul_isPrimitive {m : ℕ} (ψ : DirichletCharacter R m) :
+    IsPrimitive (primitive_mul χ ψ) :=
   primitiveCharacter_isPrimitive _
 
 /-

--- a/Mathlib/NumberTheory/DirichletCharacter/Basic.lean
+++ b/Mathlib/NumberTheory/DirichletCharacter/Basic.lean
@@ -279,6 +279,8 @@ lemma primitive_mul_isPrimitive {m : ℕ} (ψ : DirichletCharacter R m) :
     IsPrimitive (primitive_mul χ ψ) :=
   primitiveCharacter_isPrimitive _
 
+@[deprecated (since := "2024-06-16")] alias isPrimitive.primitive_mul := primitive_mul_isPrimitive
+
 /-
 ### Even and odd characters
 -/

--- a/Mathlib/NumberTheory/DirichletCharacter/GaussSum.lean
+++ b/Mathlib/NumberTheory/DirichletCharacter/GaussSum.lean
@@ -9,9 +9,9 @@ import Mathlib.NumberTheory.GaussSum
 /-!
 # Gauss sums for Dirichlet characters
 -/
-variable {N : ℕ+} {R : Type*} [CommRing R] (e : AddChar (ZMod N) R)
+variable {N : ℕ} [NeZero N] {R : Type*} [CommRing R] (e : AddChar (ZMod N) R)
 
-open AddChar
+open AddChar DirichletCharacter
 
 lemma gaussSum_aux_of_mulShift (χ : DirichletCharacter R N) {d : ℕ}
     (hd : d ∣ N) (he : e.mulShift d = 1) {u : (ZMod N)ˣ} (hu : ZMod.unitsMap hd u = 1) :
@@ -43,7 +43,7 @@ lemma factorsThrough_of_gaussSum_ne_zero [IsDomain R] {χ : DirichletCharacter R
 
 /-- If `χ` is primitive, but `e` is not, then `gaussSum χ e = 0`. -/
 lemma gaussSum_eq_zero_of_isPrimitive_of_not_isPrimitive [IsDomain R]
-    {χ : DirichletCharacter R N} (hχ : χ.isPrimitive) (he : ¬e.IsPrimitive) :
+    {χ : DirichletCharacter R N} (hχ : IsPrimitive χ) (he : ¬IsPrimitive e) :
     gaussSum χ e = 0 := by
   contrapose! hχ
   rcases e.exists_divisor_of_not_isPrimitive he with ⟨d, hd₁, hd₂, hed⟩
@@ -53,7 +53,7 @@ lemma gaussSum_eq_zero_of_isPrimitive_of_not_isPrimitive [IsDomain R]
 /-- If `χ` is a primitive character, then the function `a ↦ gaussSum χ (e.mulShift a)`, for any
 fixed additive character `e`, is a constant multiple of `χ⁻¹`. -/
 lemma gaussSum_mulShift_of_isPrimitive [IsDomain R] {χ : DirichletCharacter R N}
-    (hχ : χ.isPrimitive) (a : ZMod N) :
+    (hχ : IsPrimitive χ) (a : ZMod N) :
     gaussSum χ (e.mulShift a) = χ⁻¹ a * gaussSum χ e := by
   by_cases ha : IsUnit a
   · conv_rhs => rw [← gaussSum_mulShift χ e ha.unit]

--- a/Mathlib/NumberTheory/GaussSum.lean
+++ b/Mathlib/NumberTheory/GaussSum.lean
@@ -92,21 +92,20 @@ variable {R : Type u} [Field R] [Fintype R] {R' : Type v} [CommRing R'] [IsDomai
 
 -- A helper lemma for `gaussSum_mul_gaussSum_eq_card` below
 -- Is this useful enough in other contexts to be public?
-private theorem gaussSum_mul_aux {χ : MulChar R R'} (hχ : χ.IsNontrivial) (ψ : AddChar R R')
+private theorem gaussSum_mul_aux {χ : MulChar R R'} (hχ : χ ≠ 1) (ψ : AddChar R R')
     (b : R) :
     ∑ a, χ (a * b⁻¹) * ψ (a - b) = ∑ c, χ c * ψ (b * (c - 1)) := by
   rcases eq_or_ne b 0 with hb | hb
   · -- case `b = 0`
     simp only [hb, inv_zero, mul_zero, MulChar.map_zero, zero_mul,
-      Finset.sum_const_zero, map_zero_eq_one, mul_one]
-    exact (hχ.sum_eq_zero).symm
+      Finset.sum_const_zero, map_zero_eq_one, mul_one, χ.sum_eq_zero_of_ne_one hχ]
   · -- case `b ≠ 0`
     refine (Fintype.sum_bijective _ (mulLeft_bijective₀ b hb) _ _ fun x ↦ ?_).symm
     rw [mul_assoc, mul_comm x, ← mul_assoc, mul_inv_cancel hb, one_mul, mul_sub, mul_one]
 
 /-- We have `gaussSum χ ψ * gaussSum χ⁻¹ ψ⁻¹ = Fintype.card R`
 when `χ` is nontrivial and `ψ` is primitive (and `R` is a field). -/
-theorem gaussSum_mul_gaussSum_eq_card {χ : MulChar R R'} (hχ : χ.IsNontrivial) {ψ : AddChar R R'}
+theorem gaussSum_mul_gaussSum_eq_card {χ : MulChar R R'} (hχ : χ ≠ 1) {ψ : AddChar R R'}
     (hψ : IsPrimitive ψ) :
     gaussSum χ ψ * gaussSum χ⁻¹ ψ⁻¹ = Fintype.card R := by
   simp only [gaussSum, AddChar.inv_apply, Finset.sum_mul, Finset.mul_sum, MulChar.inv_apply']
@@ -124,7 +123,7 @@ theorem gaussSum_mul_gaussSum_eq_card {χ : MulChar R R'} (hχ : χ.IsNontrivial
 
 /-- When `χ` is a nontrivial quadratic character, then the square of `gaussSum χ ψ`
 is `χ(-1)` times the cardinality of `R`. -/
-theorem gaussSum_sq {χ : MulChar R R'} (hχ₁ : χ.IsNontrivial) (hχ₂ : IsQuadratic χ)
+theorem gaussSum_sq {χ : MulChar R R'} (hχ₁ : χ ≠ 1) (hχ₂ : IsQuadratic χ)
     {ψ : AddChar R R'} (hψ : IsPrimitive ψ) :
     gaussSum χ ψ ^ 2 = χ (-1) * Fintype.card R := by
   rw [pow_two, ← gaussSum_mul_gaussSum_eq_card hχ₁ hψ, hχ₂.inv, mul_rotate']
@@ -212,7 +211,7 @@ theorem Char.card_pow_char_pow {χ : MulChar R R'} (hχ : IsQuadratic χ) (ψ : 
 /-- When `F` and `F'` are finite fields and `χ : F → F'` is a nontrivial quadratic character,
 then `(χ(-1) * #F)^(#F'/2) = χ #F'`. -/
 theorem Char.card_pow_card {F : Type*} [Field F] [Fintype F] {F' : Type*} [Field F'] [Fintype F']
-    {χ : MulChar F F'} (hχ₁ : χ.IsNontrivial) (hχ₂ : IsQuadratic χ)
+    {χ : MulChar F F'} (hχ₁ : χ ≠ 1) (hχ₂ : IsQuadratic χ)
     (hch₁ : ringChar F' ≠ ringChar F) (hch₂ : ringChar F' ≠ 2) :
     (χ (-1) * Fintype.card F) ^ (Fintype.card F' / 2) = χ (Fintype.card F') := by
   obtain ⟨n, hp, hc⟩ := FiniteField.card F (ringChar F)
@@ -227,7 +226,7 @@ theorem Char.card_pow_card {F : Type*} [Field F] [Fintype F] {F' : Type*} [Field
   have := Fact.mk (hchar.subst hp')
   rw [Ne, ← Nat.prime_dvd_prime_iff_eq hp' hp, ← isUnit_iff_not_dvd_char, hchar] at hch₁
   exact Char.card_pow_char_pow (hχ₂.comp _) ψ.char (ringChar FF') n' hch₁ (hchar ▸ hch₂)
-       (gaussSum_sq (hχ₁.comp <| RingHom.injective _) (hχ₂.comp _) ψ.prim)
+       (gaussSum_sq ((ringHomComp_ne_one_iff (RingHom.injective _)).mpr hχ₁) (hχ₂.comp _) ψ.prim)
 #align char.card_pow_card Char.card_pow_card
 
 end GaussSumValues

--- a/Mathlib/NumberTheory/LegendreSymbol/AddCharacter.lean
+++ b/Mathlib/NumberTheory/LegendreSymbol/AddCharacter.lean
@@ -206,7 +206,7 @@ theorem zmodChar_primitive_of_primitive_root (n : ℕ) [NeZero n] {ζ : C} (h : 
 does not divide `n` -/
 noncomputable def primitiveZModChar (n : ℕ+) (F' : Type v) [Field F'] (h : (n : F') ≠ 0) :
     PrimitiveAddChar (ZMod n) F' :=
-  haveI : NeZero (n : F') := ⟨h⟩
+  have : NeZero (n : F') := ⟨h⟩
   ⟨n, zmodChar n (IsCyclotomicExtension.zeta_pow n F' _),
     zmodChar_primitive_of_primitive_root n (IsCyclotomicExtension.zeta_spec n F' _)⟩
 #align add_char.primitive_zmod_char AddChar.primitiveZModChar

--- a/Mathlib/NumberTheory/LegendreSymbol/AddCharacter.lean
+++ b/Mathlib/NumberTheory/LegendreSymbol/AddCharacter.lean
@@ -118,7 +118,7 @@ structure PrimitiveAddChar (R : Type u) [CommRing R] (R' : Type v) [Field R'] wh
 
 section ZMod
 
-variable {N : ℕ+} {R : Type*} [CommRing R] (e : AddChar (ZMod N) R)
+variable {N : ℕ} [NeZero N] {R : Type*} [CommRing R] (e : AddChar (ZMod N) R)
 
 /-- If `e` is not primitive, then `e.mulShift d = 1` for some proper divisor `d` of `N`. -/
 lemma exists_divisor_of_not_isPrimitive (he : ¬e.IsPrimitive) :
@@ -127,7 +127,7 @@ lemma exists_divisor_of_not_isPrimitive (he : ¬e.IsPrimitive) :
   rcases he with ⟨b, hb_ne, hb⟩
   -- We have `AddChar.mulShift e b = 1`, but `b ≠ 0`.
   obtain ⟨d, hd, u, hu, rfl⟩ := b.eq_unit_mul_divisor
-  refine ⟨d, hd, lt_of_le_of_ne (Nat.le_of_dvd N.pos hd) ?_, ?_⟩
+  refine ⟨d, hd, lt_of_le_of_ne (Nat.le_of_dvd (NeZero.pos _) hd) ?_, ?_⟩
   · exact fun h ↦ by simp only [h, ZMod.natCast_self, mul_zero, ne_eq, not_true_eq_false] at hb_ne
   · rw [← mulShift_unit_eq_one_iff _ hu, ← hb, mul_comm]
     ext1 y
@@ -143,19 +143,19 @@ section ZModCharDef
 
 
 /-- We can define an additive character on `ZMod n` when we have an `n`th root of unity `ζ : C`. -/
-def zmodChar (n : ℕ+) {ζ : C} (hζ : ζ ^ (n : ℕ) = 1) : AddChar (ZMod n) C where
+def zmodChar (n : ℕ) [NeZero n] {ζ : C} (hζ : ζ ^ n = 1) : AddChar (ZMod n) C where
   toFun a := ζ ^ a.val
   map_zero_eq_one' := by simp only [ZMod.val_zero, pow_zero]
   map_add_eq_mul' x y := by simp only [ZMod.val_add, ← pow_eq_pow_mod _ hζ, ← pow_add]
 #align add_char.zmod_char AddChar.zmodChar
 
 /-- The additive character on `ZMod n` defined using `ζ` sends `a` to `ζ^a`. -/
-theorem zmodChar_apply {n : ℕ+} {ζ : C} (hζ : ζ ^ (n : ℕ) = 1) (a : ZMod n) :
+theorem zmodChar_apply {n : ℕ} [NeZero n] {ζ : C} (hζ : ζ ^ n = 1) (a : ZMod n) :
     zmodChar n hζ a = ζ ^ a.val :=
   rfl
 #align add_char.zmod_char_apply AddChar.zmodChar_apply
 
-theorem zmodChar_apply' {n : ℕ+} {ζ : C} (hζ : ζ ^ (n : ℕ) = 1) (a : ℕ) :
+theorem zmodChar_apply' {n : ℕ} [NeZero n] {ζ : C} (hζ : ζ ^ n = 1) (a : ℕ) :
     zmodChar n hζ a = ζ ^ a := by
   rw [pow_eq_pow_mod a hζ, zmodChar_apply, ZMod.val_natCast a]
 #align add_char.zmod_char_apply' AddChar.zmodChar_apply'
@@ -163,7 +163,7 @@ theorem zmodChar_apply' {n : ℕ+} {ζ : C} (hζ : ζ ^ (n : ℕ) = 1) (a : ℕ)
 end ZModCharDef
 
 /-- An additive character on `ZMod n` is nontrivial iff it takes a value `≠ 1` on `1`. -/
-theorem zmod_char_ne_one_iff (n : ℕ+) (ψ : AddChar (ZMod n) C) : ψ ≠ 1 ↔ ψ 1 ≠ 1 := by
+theorem zmod_char_ne_one_iff (n : ℕ) [NeZero n] (ψ : AddChar (ZMod n) C) : ψ ≠ 1 ↔ ψ 1 ≠ 1 := by
   rw [ne_one_iff]
   refine ⟨?_, fun h => ⟨_, h⟩⟩
   contrapose!
@@ -174,8 +174,9 @@ theorem zmod_char_ne_one_iff (n : ℕ+) (ψ : AddChar (ZMod n) C) : ψ ≠ 1 ↔
 #align add_char.zmod_char_is_nontrivial_iff AddChar.zmod_char_ne_one_iff
 
 /-- A primitive additive character on `ZMod n` takes the value `1` only at `0`. -/
-theorem IsPrimitive.zmod_char_eq_one_iff (n : ℕ+) {ψ : AddChar (ZMod n) C} (hψ : IsPrimitive ψ)
-    (a : ZMod n) : ψ a = 1 ↔ a = 0 := by
+theorem IsPrimitive.zmod_char_eq_one_iff (n : ℕ) [NeZero n]
+    {ψ : AddChar (ZMod n) C} (hψ : IsPrimitive ψ) (a : ZMod n) :
+    ψ a = 1 ↔ a = 0 := by
   refine ⟨fun h => not_imp_comm.mp (@hψ a) ?_, fun ha => by rw [ha, map_zero_eq_one]⟩
   rw [zmod_char_ne_one_iff n (mulShift ψ a), mulShift_apply, mul_one, h, Classical.not_not]
 #align add_char.is_primitive.zmod_char_eq_one_iff AddChar.IsPrimitive.zmod_char_eq_one_iff
@@ -193,19 +194,19 @@ theorem zmod_char_primitive_of_eq_one_only_at_zero (n : ℕ) (ψ : AddChar (ZMod
 
 /-- The additive character on `ZMod n` associated to a primitive `n`th root of unity
 is primitive -/
-theorem zmodChar_primitive_of_primitive_root (n : ℕ+) {ζ : C} (h : IsPrimitiveRoot ζ n) :
+theorem zmodChar_primitive_of_primitive_root (n : ℕ) [NeZero n] {ζ : C} (h : IsPrimitiveRoot ζ n) :
     IsPrimitive (zmodChar n ((IsPrimitiveRoot.iff_def ζ n).mp h).left) := by
   apply zmod_char_primitive_of_eq_one_only_at_zero
   intro a ha
   rw [zmodChar_apply, ← pow_zero ζ] at ha
-  exact (ZMod.val_eq_zero a).mp (IsPrimitiveRoot.pow_inj h (ZMod.val_lt a) n.pos ha)
+  exact (ZMod.val_eq_zero a).mp (IsPrimitiveRoot.pow_inj h (ZMod.val_lt a) (NeZero.pos _) ha)
 #align add_char.zmod_char_primitive_of_primitive_root AddChar.zmodChar_primitive_of_primitive_root
 
 /-- There is a primitive additive character on `ZMod n` if the characteristic of the target
 does not divide `n` -/
 noncomputable def primitiveZModChar (n : ℕ+) (F' : Type v) [Field F'] (h : (n : F') ≠ 0) :
     PrimitiveAddChar (ZMod n) F' :=
-  haveI : NeZero ((n : ℕ) : F') := ⟨h⟩
+  haveI : NeZero (n : F') := ⟨h⟩
   ⟨n, zmodChar n (IsCyclotomicExtension.zeta_pow n F' _),
     zmodChar_primitive_of_primitive_root n (IsCyclotomicExtension.zeta_spec n F' _)⟩
 #align add_char.primitive_zmod_char AddChar.primitiveZModChar

--- a/Mathlib/NumberTheory/LegendreSymbol/QuadraticChar/Basic.lean
+++ b/Mathlib/NumberTheory/LegendreSymbol/QuadraticChar/Basic.lean
@@ -187,6 +187,12 @@ theorem quadraticChar_exists_neg_one (hF : ringChar F ≠ 2) : ∃ a, quadraticC
   (FiniteField.exists_nonsquare hF).imp fun _ h₁ ↦ quadraticChar_neg_one_iff_not_isSquare.mpr h₁
 #align quadratic_char_exists_neg_one quadraticChar_exists_neg_one
 
+/-- If `F` has odd characteristic, then `quadraticChar F` takes the value `-1` on some unit. -/
+lemma quadraticChar_exists_neg_one' (hF : ringChar F ≠ 2) : ∃ a : Fˣ, quadraticChar F a = -1 := by
+  refine (fun ⟨a, ha⟩ ↦ ⟨IsUnit.unit ?_, ha⟩) (quadraticChar_exists_neg_one hF)
+  contrapose ha
+  exact ne_of_eq_of_ne ((quadraticChar F).map_nonunit ha) (mt zero_eq_neg.mp one_ne_zero)
+
 /-- If `ringChar F = 2`, then `quadraticChar F` takes the value `1` on nonzero elements. -/
 theorem quadraticChar_eq_one_of_char_two (hF : ringChar F = 2) {a : F} (ha : a ≠ 0) :
     quadraticChar F a = 1 :=
@@ -228,10 +234,9 @@ variable {F}
 /-- The quadratic character is nontrivial as a multiplicative character
 when the domain has odd characteristic. -/
 theorem quadraticChar_ne_one (hF : ringChar F ≠ 2) : quadraticChar F ≠ 1 := by
-  rcases quadraticChar_exists_neg_one hF with ⟨a, ha⟩
-  have hu : IsUnit a := by by_contra hf; rw [MulChar.map_nonunit _ hf] at ha; omega
+  rcases quadraticChar_exists_neg_one' hF with ⟨a, ha⟩
   intro hχ
-  simp only [hχ, one_apply hu, eq_neg_self_iff, one_ne_zero] at ha
+  simp only [hχ, one_apply a.isUnit, eq_neg_self_iff, one_ne_zero] at ha
 #align quadratic_char_is_nontrivial quadraticChar_ne_one
 
 set_option linter.deprecated false in

--- a/Mathlib/NumberTheory/LegendreSymbol/QuadraticChar/Basic.lean
+++ b/Mathlib/NumberTheory/LegendreSymbol/QuadraticChar/Basic.lean
@@ -227,11 +227,17 @@ variable {F}
 
 /-- The quadratic character is nontrivial as a multiplicative character
 when the domain has odd characteristic. -/
-theorem quadraticChar_isNontrivial (hF : ringChar F ≠ 2) : (quadraticChar F).IsNontrivial := by
+theorem quadraticChar_ne_one (hF : ringChar F ≠ 2) : quadraticChar F ≠ 1 := by
   rcases quadraticChar_exists_neg_one hF with ⟨a, ha⟩
   have hu : IsUnit a := by by_contra hf; rw [MulChar.map_nonunit _ hf] at ha; omega
-  exact ⟨hu.unit, (show quadraticChar F a ≠ 1 by rw [ha]; omega)⟩
-#align quadratic_char_is_nontrivial quadraticChar_isNontrivial
+  intro hχ
+  simp only [hχ, one_apply hu, eq_neg_self_iff, one_ne_zero] at ha
+#align quadratic_char_is_nontrivial quadraticChar_ne_one
+
+set_option linter.deprecated false in
+@[deprecated quadraticChar_ne_one (since := "2024-06-16")]
+theorem quadraticChar_isNontrivial (hF : ringChar F ≠ 2) : (quadraticChar F).IsNontrivial :=
+  (isNontrivial_iff _).mpr <| quadraticChar_ne_one hF
 
 open Finset in
 /-- The number of solutions to `x^2 = a` is determined by the quadratic character. -/
@@ -267,7 +273,7 @@ theorem quadraticChar_card_sqrts (hF : ringChar F ≠ 2) (a : F) :
 
 /-- The sum over the values of the quadratic character is zero when the characteristic is odd. -/
 theorem quadraticChar_sum_zero (hF : ringChar F ≠ 2) : ∑ a : F, quadraticChar F a = 0 :=
-  IsNontrivial.sum_eq_zero (quadraticChar_isNontrivial hF)
+  sum_eq_zero_of_ne_one (quadraticChar_ne_one hF)
 #align quadratic_char_sum_zero quadraticChar_sum_zero
 
 end quadraticChar

--- a/Mathlib/NumberTheory/LegendreSymbol/QuadraticChar/GaussSum.lean
+++ b/Mathlib/NumberTheory/LegendreSymbol/QuadraticChar/GaussSum.lean
@@ -51,14 +51,7 @@ theorem FiniteField.isSquare_two_iff :
     have h := FiniteField.odd_card_of_char_ne_two hF
     rw [← quadraticChar_one_iff_isSquare (Ring.two_ne_zero hF), quadraticChar_two hF,
       χ₈_nat_eq_if_mod_eight]
-    simp only [h, Nat.one_ne_zero, if_false, ite_eq_left_iff, Ne, (by decide : (-1 : ℤ) ≠ 1),
-      imp_false, Classical.not_not]
-  all_goals
-    rw [← Nat.mod_mod_of_dvd _ (by decide : 2 ∣ 8)] at h
-    have h₁ := Nat.mod_lt (Fintype.card F) (by decide : 0 < 8)
-    revert h₁ h
-    generalize Fintype.card F % 8 = n
-    intros; interval_cases n <;> simp_all -- Porting note (#11043): was `decide!`
+  all_goals omega
 #align finite_field.is_square_two_iff FiniteField.isSquare_two_iff
 
 /-- The value of the quadratic character at `-2` -/
@@ -81,14 +74,7 @@ theorem FiniteField.isSquare_neg_two_iff :
     have h := FiniteField.odd_card_of_char_ne_two hF
     rw [← quadraticChar_one_iff_isSquare (neg_ne_zero.mpr (Ring.two_ne_zero hF)),
       quadraticChar_neg_two hF, χ₈'_nat_eq_if_mod_eight]
-    simp only [h, Nat.one_ne_zero, if_false, ite_eq_left_iff, Ne, (by decide : (-1 : ℤ) ≠ 1),
-      imp_false, Classical.not_not]
-  all_goals
-    rw [← Nat.mod_mod_of_dvd _ (by decide : 2 ∣ 8)] at h
-    have h₁ := Nat.mod_lt (Fintype.card F) (by decide : 0 < 8)
-    revert h₁ h
-    generalize Fintype.card F % 8 = n
-    intros; interval_cases n <;> simp_all -- Porting note (#11043): was `decide!`
+  all_goals omega
 #align finite_field.is_square_neg_two_iff FiniteField.isSquare_neg_two_iff
 
 /-- The relation between the values of the quadratic character of one field `F` at the
@@ -99,16 +85,15 @@ theorem quadraticChar_card_card [DecidableEq F] (hF : ringChar F ≠ 2) {F' : Ty
     quadraticChar F (Fintype.card F') =
     quadraticChar F' (quadraticChar F (-1) * Fintype.card F) := by
   let χ := (quadraticChar F).ringHomComp (algebraMap ℤ F')
-  have hχ₁ : χ.IsNontrivial := by
+  have hχ₁ : χ ≠ 1 := by
     obtain ⟨a, ha⟩ := quadraticChar_exists_neg_one hF
     have hu : IsUnit a := by
       contrapose ha
       exact ne_of_eq_of_ne (map_nonunit (quadraticChar F) ha) (mt zero_eq_neg.mp one_ne_zero)
-    use hu.unit
-    simp only [χ, IsUnit.unit_spec, ringHomComp_apply, eq_intCast, Ne, ha]
-    rw [Int.cast_neg, Int.cast_one]
-    exact Ring.neg_one_ne_one_of_char_ne_two hF'
-  have hχ₂ : χ.IsQuadratic := IsQuadratic.comp (quadraticChar_isQuadratic F) _
+    refine ne_one_iff.mpr ⟨hu.unit, ?_⟩
+    simpa only [χ, IsUnit.unit_spec, ringHomComp_apply, eq_intCast, ha, Int.cast_neg, Int.cast_one]
+      using Ring.neg_one_ne_one_of_char_ne_two hF'
+  have hχ₂ : χ.IsQuadratic := (quadraticChar_isQuadratic F).comp _
   have h := Char.card_pow_card hχ₁ hχ₂ h hF'
   rw [← quadraticChar_eq_pow_of_char_ne_two' hF'] at h
   exact (IsQuadratic.eq_of_eq_coe (quadraticChar_isQuadratic F')

--- a/Mathlib/NumberTheory/LegendreSymbol/QuadraticChar/GaussSum.lean
+++ b/Mathlib/NumberTheory/LegendreSymbol/QuadraticChar/GaussSum.lean
@@ -43,15 +43,13 @@ theorem FiniteField.isSquare_two_iff :
     IsSquare (2 : F) ↔ Fintype.card F % 8 ≠ 3 ∧ Fintype.card F % 8 ≠ 5 := by
   classical
   by_cases hF : ringChar F = 2
-  focus
-    have h := FiniteField.even_card_of_char_two hF
+  · have h := FiniteField.even_card_of_char_two hF
     simp only [FiniteField.isSquare_of_char_two hF, true_iff_iff]
-  rotate_left
-  focus
-    have h := FiniteField.odd_card_of_char_ne_two hF
+    omega
+  · have h := FiniteField.odd_card_of_char_ne_two hF
     rw [← quadraticChar_one_iff_isSquare (Ring.two_ne_zero hF), quadraticChar_two hF,
       χ₈_nat_eq_if_mod_eight]
-  all_goals omega
+    omega
 #align finite_field.is_square_two_iff FiniteField.isSquare_two_iff
 
 /-- The value of the quadratic character at `-2` -/
@@ -66,15 +64,13 @@ theorem FiniteField.isSquare_neg_two_iff :
     IsSquare (-2 : F) ↔ Fintype.card F % 8 ≠ 5 ∧ Fintype.card F % 8 ≠ 7 := by
   classical
   by_cases hF : ringChar F = 2
-  focus
-    have h := FiniteField.even_card_of_char_two hF
+  · have h := FiniteField.even_card_of_char_two hF
     simp only [FiniteField.isSquare_of_char_two hF, true_iff_iff]
-  rotate_left
-  focus
-    have h := FiniteField.odd_card_of_char_ne_two hF
+    omega
+  · have h := FiniteField.odd_card_of_char_ne_two hF
     rw [← quadraticChar_one_iff_isSquare (neg_ne_zero.mpr (Ring.two_ne_zero hF)),
       quadraticChar_neg_two hF, χ₈'_nat_eq_if_mod_eight]
-  all_goals omega
+    omega
 #align finite_field.is_square_neg_two_iff FiniteField.isSquare_neg_two_iff
 
 /-- The relation between the values of the quadratic character of one field `F` at the
@@ -86,15 +82,11 @@ theorem quadraticChar_card_card [DecidableEq F] (hF : ringChar F ≠ 2) {F' : Ty
     quadraticChar F' (quadraticChar F (-1) * Fintype.card F) := by
   let χ := (quadraticChar F).ringHomComp (algebraMap ℤ F')
   have hχ₁ : χ ≠ 1 := by
-    obtain ⟨a, ha⟩ := quadraticChar_exists_neg_one hF
-    have hu : IsUnit a := by
-      contrapose ha
-      exact ne_of_eq_of_ne (map_nonunit (quadraticChar F) ha) (mt zero_eq_neg.mp one_ne_zero)
-    refine ne_one_iff.mpr ⟨hu.unit, ?_⟩
-    simpa only [χ, IsUnit.unit_spec, ringHomComp_apply, eq_intCast, ha, Int.cast_neg, Int.cast_one]
-      using Ring.neg_one_ne_one_of_char_ne_two hF'
-  have hχ₂ : χ.IsQuadratic := (quadraticChar_isQuadratic F).comp _
-  have h := Char.card_pow_card hχ₁ hχ₂ h hF'
+    obtain ⟨a, ha⟩ := quadraticChar_exists_neg_one' hF
+    refine ne_one_iff.mpr ⟨a, ?_⟩
+    simpa only [ringHomComp_apply, ha, eq_intCast, Int.cast_neg, Int.cast_one, χ] using
+      Ring.neg_one_ne_one_of_char_ne_two hF'
+  have h := Char.card_pow_card hχ₁ ((quadraticChar_isQuadratic F).comp _) h hF'
   rw [← quadraticChar_eq_pow_of_char_ne_two' hF'] at h
   exact (IsQuadratic.eq_of_eq_coe (quadraticChar_isQuadratic F')
     (quadraticChar_isQuadratic F) hF' h).symm

--- a/Mathlib/NumberTheory/MulChar/Basic.lean
+++ b/Mathlib/NumberTheory/MulChar/Basic.lean
@@ -430,12 +430,21 @@ section nontrivial
 
 variable {R : Type*} [CommMonoid R] {R' : Type*} [CommMonoidWithZero R']
 
+lemma eq_one_iff {χ : MulChar R R'} : χ = 1 ↔ ∀ a : Rˣ, χ a = 1 := by
+  simp only [Ne, ext_iff, not_forall, one_apply_coe]
+
+lemma ne_one_iff {χ : MulChar R R'} : χ ≠ 1 ↔ ∃ a : Rˣ, χ a ≠ 1 := by
+  simp only [Ne, eq_one_iff, not_forall]
+
 /-- A multiplicative character is *nontrivial* if it takes a value `≠ 1` on a unit. -/
+@[deprecated (since := "2024-06-16")]
 def IsNontrivial (χ : MulChar R R') : Prop :=
   ∃ a : Rˣ, χ a ≠ 1
 #align mul_char.is_nontrivial MulChar.IsNontrivial
 
+set_option linter.deprecated false in
 /-- A multiplicative character is nontrivial iff it is not the trivial character. -/
+@[deprecated (since := "2024-06-16")]
 theorem isNontrivial_iff (χ : MulChar R R') : χ.IsNontrivial ↔ χ ≠ 1 := by
   simp only [IsNontrivial, Ne, ext_iff, not_forall, one_apply_coe]
 #align mul_char.is_nontrivial_iff MulChar.isNontrivial_iff
@@ -467,7 +476,23 @@ def ringHomComp (χ : MulChar R R') (f : R' →+* R'') : MulChar R R'' :=
     map_nonunit' := fun a ha => by simp only [map_nonunit χ ha, map_zero] }
 #align mul_char.ring_hom_comp MulChar.ringHomComp
 
+lemma injective_ringHomComp {f : R' →+* R''} (hf : Function.Injective f) :
+    Function.Injective (ringHomComp (R := R) · f) := by
+  simpa only [Function.Injective, ext_iff, ringHomComp, coe_mk, MonoidHom.coe_mk, OneHom.coe_mk]
+    using fun χ χ' h a ↦ hf (h a)
+
+lemma ringHomComp_eq_one_iff {f : R' →+* R''} (hf : Function.Injective f) {χ : MulChar R R'} :
+    χ.ringHomComp f = 1 ↔ χ = 1 := by
+  conv_lhs => rw [← (show  (1 : MulChar R R').ringHomComp f = 1 by ext; simp)]
+  exact (injective_ringHomComp hf).eq_iff
+
+lemma ringHomComp_ne_one_iff {f : R' →+* R''} (hf : Function.Injective f) {χ : MulChar R R'} :
+    χ.ringHomComp f ≠ 1 ↔ χ ≠ 1 := by
+  simp only [Ne, ringHomComp_eq_one_iff, hf]
+
+set_option linter.deprecated false in
 /-- Composition with an injective ring homomorphism preserves nontriviality. -/
+@[deprecated ringHomComp_ne_one_iff (since := "2024-06-16")]
 theorem IsNontrivial.comp {χ : MulChar R R'} (hχ : χ.IsNontrivial) {f : R' →+* R''}
     (hf : Function.Injective f) : (χ.ringHomComp f).IsNontrivial := by
   obtain ⟨a, ha⟩ := hχ
@@ -565,13 +590,17 @@ variable {R : Type*} [CommMonoid R] [Fintype R] {R' : Type*} [CommRing R']
 
 /-- The sum over all values of a nontrivial multiplicative character on a finite ring is zero
 (when the target is a domain). -/
-theorem IsNontrivial.sum_eq_zero [IsDomain R'] {χ : MulChar R R'}
-    (hχ : χ.IsNontrivial) : ∑ a, χ a = 0 := by
-  rcases hχ with ⟨b, hb⟩
+theorem sum_eq_zero_of_ne_one [IsDomain R'] {χ : MulChar R R'} (hχ : χ ≠ 1) : ∑ a, χ a = 0 := by
+  rcases ne_one_iff.mp hχ with ⟨b, hb⟩
   refine eq_zero_of_mul_eq_self_left hb ?_
-  simp only [Finset.mul_sum, ← map_mul]
-  exact Fintype.sum_bijective _ (Units.mulLeft_bijective b) _ _ fun x => rfl
-#align mul_char.is_nontrivial.sum_eq_zero MulChar.IsNontrivial.sum_eq_zero
+  simpa only [Finset.mul_sum, ← map_mul] using b.mulLeft_bijective.sum_comp _
+#align mul_char.is_nontrivial.sum_eq_zero MulChar.sum_eq_zero_of_ne_one
+
+set_option linter.deprecated false in
+@[deprecated (since := "2024-06-16")]
+def IsNontrivial.sum_eq_zero [IsDomain R'] {χ : MulChar R R'} (hχ : χ.IsNontrivial) : 
+    ∑ a, χ a = 0 := 
+  sum_eq_zero_of_ne_one ((isNontrivial_iff _).mp hχ)
 
 /-- The sum over all values of the trivial multiplicative character on a finite ring is
 the cardinality of its unit group. -/

--- a/Mathlib/NumberTheory/MulChar/Basic.lean
+++ b/Mathlib/NumberTheory/MulChar/Basic.lean
@@ -598,8 +598,8 @@ theorem sum_eq_zero_of_ne_one [IsDomain R'] {χ : MulChar R R'} (hχ : χ ≠ 1)
 
 set_option linter.deprecated false in
 @[deprecated (since := "2024-06-16")]
-def IsNontrivial.sum_eq_zero [IsDomain R'] {χ : MulChar R R'} (hχ : χ.IsNontrivial) : 
-    ∑ a, χ a = 0 := 
+def IsNontrivial.sum_eq_zero [IsDomain R'] {χ : MulChar R R'} (hχ : χ.IsNontrivial) :
+    ∑ a, χ a = 0 :=
   sum_eq_zero_of_ne_one ((isNontrivial_iff _).mp hχ)
 
 /-- The sum over all values of the trivial multiplicative character on a finite ring is

--- a/Mathlib/NumberTheory/MulChar/Basic.lean
+++ b/Mathlib/NumberTheory/MulChar/Basic.lean
@@ -431,7 +431,7 @@ section nontrivial
 variable {R : Type*} [CommMonoid R] {R' : Type*} [CommMonoidWithZero R']
 
 lemma eq_one_iff {χ : MulChar R R'} : χ = 1 ↔ ∀ a : Rˣ, χ a = 1 := by
-  simp only [Ne, ext_iff, not_forall, one_apply_coe]
+  simp only [ext_iff, one_apply_coe]
 
 lemma ne_one_iff {χ : MulChar R R'} : χ ≠ 1 ↔ ∃ a : Rˣ, χ a ≠ 1 := by
   simp only [Ne, eq_one_iff, not_forall]
@@ -487,8 +487,8 @@ lemma ringHomComp_eq_one_iff {f : R' →+* R''} (hf : Function.Injective f) {χ 
   exact (injective_ringHomComp hf).eq_iff
 
 lemma ringHomComp_ne_one_iff {f : R' →+* R''} (hf : Function.Injective f) {χ : MulChar R R'} :
-    χ.ringHomComp f ≠ 1 ↔ χ ≠ 1 := by
-  simp only [Ne, ringHomComp_eq_one_iff, hf]
+    χ.ringHomComp f ≠ 1 ↔ χ ≠ 1 :=
+  (ringHomComp_eq_one_iff hf).not
 
 set_option linter.deprecated false in
 /-- Composition with an injective ring homomorphism preserves nontriviality. -/

--- a/Mathlib/NumberTheory/MulChar/Basic.lean
+++ b/Mathlib/NumberTheory/MulChar/Basic.lean
@@ -598,7 +598,7 @@ theorem sum_eq_zero_of_ne_one [IsDomain R'] {χ : MulChar R R'} (hχ : χ ≠ 1)
 
 set_option linter.deprecated false in
 @[deprecated (since := "2024-06-16")]
-def IsNontrivial.sum_eq_zero [IsDomain R'] {χ : MulChar R R'} (hχ : χ.IsNontrivial) :
+lemma IsNontrivial.sum_eq_zero [IsDomain R'] {χ : MulChar R R'} (hχ : χ.IsNontrivial) :
     ∑ a, χ a = 0 :=
   sum_eq_zero_of_ne_one ((isNontrivial_iff _).mp hχ)
 


### PR DESCRIPTION
- Deprecate `MulChar.IsNontrivial` (following the analogous change for `AddChar`'s a few days ago);
- fix capitalisation of `DirichletCharacter.isPrimitive`; 
- adjust some lemmas to take a `Nat` argument with a `NeZero` instance, rather than a `PNat`, which is more general and flexible.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
