### PR TITLE
[Merged by Bors] - chore(ContinuousMap): add `TopologicalRing` instance

### DIFF
--- a/Mathlib/Topology/ContinuousFunction/Algebra.lean
+++ b/Mathlib/Topology/ContinuousFunction/Algebra.lean
@@ -488,60 +488,69 @@ end Subtype
 
 namespace ContinuousMap
 
-instance {α : Type*} {β : Type*} [TopologicalSpace α] [TopologicalSpace β]
-    [NonUnitalNonAssocSemiring β] [TopologicalSemiring β] : NonUnitalNonAssocSemiring C(α, β) :=
+instance instNonUnitalNonAssocSemiring {α : Type*} {β : Type*} [TopologicalSpace α]
+    [TopologicalSpace β] [NonUnitalNonAssocSemiring β] [TopologicalSemiring β] :
+    NonUnitalNonAssocSemiring C(α, β) :=
   coe_injective.nonUnitalNonAssocSemiring _ coe_zero coe_add coe_mul coe_nsmul
 
-instance {α : Type*} {β : Type*} [TopologicalSpace α] [TopologicalSpace β] [NonUnitalSemiring β]
-    [TopologicalSemiring β] : NonUnitalSemiring C(α, β) :=
+instance instNonUnitalSemiring {α : Type*} {β : Type*} [TopologicalSpace α] [TopologicalSpace β]
+    [NonUnitalSemiring β] [TopologicalSemiring β] : NonUnitalSemiring C(α, β) :=
   coe_injective.nonUnitalSemiring _ coe_zero coe_add coe_mul coe_nsmul
 
-instance {α : Type*} {β : Type*} [TopologicalSpace α] [TopologicalSpace β] [AddMonoidWithOne β]
-    [ContinuousAdd β] : AddMonoidWithOne C(α, β) :=
+instance instAddMonoidWithOne {α : Type*} {β : Type*} [TopologicalSpace α] [TopologicalSpace β]
+    [AddMonoidWithOne β] [ContinuousAdd β] : AddMonoidWithOne C(α, β) :=
   coe_injective.addMonoidWithOne _ coe_zero coe_one coe_add coe_nsmul coe_natCast
 
-instance {α : Type*} {β : Type*} [TopologicalSpace α] [TopologicalSpace β] [NonAssocSemiring β]
-    [TopologicalSemiring β] : NonAssocSemiring C(α, β) :=
+instance instNonAssocSemiring {α : Type*} {β : Type*} [TopologicalSpace α] [TopologicalSpace β]
+    [NonAssocSemiring β] [TopologicalSemiring β] : NonAssocSemiring C(α, β) :=
   coe_injective.nonAssocSemiring _ coe_zero coe_one coe_add coe_mul coe_nsmul coe_natCast
 
-instance {α : Type*} {β : Type*} [TopologicalSpace α] [TopologicalSpace β] [Semiring β]
+instance instSemiring {α : Type*} {β : Type*} [TopologicalSpace α] [TopologicalSpace β] [Semiring β]
     [TopologicalSemiring β] : Semiring C(α, β) :=
   coe_injective.semiring _ coe_zero coe_one coe_add coe_mul coe_nsmul coe_pow coe_natCast
 
-instance {α : Type*} {β : Type*} [TopologicalSpace α] [TopologicalSpace β]
+instance instNonUnitalNonAssocRing {α : Type*} {β : Type*} [TopologicalSpace α] [TopologicalSpace β]
     [NonUnitalNonAssocRing β] [TopologicalRing β] : NonUnitalNonAssocRing C(α, β) :=
   coe_injective.nonUnitalNonAssocRing _ coe_zero coe_add coe_mul coe_neg coe_sub coe_nsmul coe_zsmul
 
-instance {α : Type*} {β : Type*} [TopologicalSpace α] [TopologicalSpace β] [NonUnitalRing β]
-    [TopologicalRing β] : NonUnitalRing C(α, β) :=
+instance instNonUnitalRing {α : Type*} {β : Type*} [TopologicalSpace α] [TopologicalSpace β]
+    [NonUnitalRing β] [TopologicalRing β] : NonUnitalRing C(α, β) :=
   coe_injective.nonUnitalRing _ coe_zero coe_add coe_mul coe_neg coe_sub coe_nsmul coe_zsmul
 
-instance {α : Type*} {β : Type*} [TopologicalSpace α] [TopologicalSpace β] [NonAssocRing β]
-    [TopologicalRing β] : NonAssocRing C(α, β) :=
+instance instNonAssocRing {α : Type*} {β : Type*} [TopologicalSpace α] [TopologicalSpace β]
+    [NonAssocRing β] [TopologicalRing β] : NonAssocRing C(α, β) :=
   coe_injective.nonAssocRing _ coe_zero coe_one coe_add coe_mul coe_neg coe_sub coe_nsmul coe_zsmul
     coe_natCast coe_intCast
 
-instance instRingContinuousMap {α : Type*} {β : Type*} [TopologicalSpace α] [TopologicalSpace β]
+instance instRing {α : Type*} {β : Type*} [TopologicalSpace α] [TopologicalSpace β]
     [Ring β] [TopologicalRing β] : Ring C(α, β) :=
   coe_injective.ring _ coe_zero coe_one coe_add coe_mul coe_neg coe_sub coe_nsmul coe_zsmul coe_pow
     coe_natCast coe_intCast
 
-instance {α : Type*} {β : Type*} [TopologicalSpace α] [TopologicalSpace β]
+instance instNonUnitalCommSemiring {α : Type*} {β : Type*} [TopologicalSpace α] [TopologicalSpace β]
     [NonUnitalCommSemiring β] [TopologicalSemiring β] : NonUnitalCommSemiring C(α, β) :=
   coe_injective.nonUnitalCommSemiring _ coe_zero coe_add coe_mul coe_nsmul
 
-instance {α : Type*} {β : Type*} [TopologicalSpace α] [TopologicalSpace β] [CommSemiring β]
-    [TopologicalSemiring β] : CommSemiring C(α, β) :=
+instance instCommSemiring {α : Type*} {β : Type*} [TopologicalSpace α] [TopologicalSpace β]
+    [CommSemiring β] [TopologicalSemiring β] : CommSemiring C(α, β) :=
   coe_injective.commSemiring _ coe_zero coe_one coe_add coe_mul coe_nsmul coe_pow coe_natCast
 
-instance {α : Type*} {β : Type*} [TopologicalSpace α] [TopologicalSpace β] [NonUnitalCommRing β]
-    [TopologicalRing β] : NonUnitalCommRing C(α, β) :=
+instance instNonUnitalCommRing {α : Type*} {β : Type*} [TopologicalSpace α] [TopologicalSpace β]
+    [NonUnitalCommRing β] [TopologicalRing β] : NonUnitalCommRing C(α, β) :=
   coe_injective.nonUnitalCommRing _ coe_zero coe_add coe_mul coe_neg coe_sub coe_nsmul coe_zsmul
 
-instance {α : Type*} {β : Type*} [TopologicalSpace α] [TopologicalSpace β] [CommRing β]
+instance instCommRing {α : Type*} {β : Type*} [TopologicalSpace α] [TopologicalSpace β] [CommRing β]
     [TopologicalRing β] : CommRing C(α, β) :=
   coe_injective.commRing _ coe_zero coe_one coe_add coe_mul coe_neg coe_sub coe_nsmul coe_zsmul
     coe_pow coe_natCast coe_intCast
+
+instance instTopologicalSemiring {α : Type*} {β : Type*} [TopologicalSpace α] [TopologicalSpace β]
+    [LocallyCompactSpace α] [NonUnitalSemiring β] [TopologicalSemiring β] :
+    TopologicalSemiring C(α, β) where
+
+instance instTopologicalRing {α : Type*} {β : Type*} [TopologicalSpace α] [TopologicalSpace β]
+    [LocallyCompactSpace α] [NonUnitalRing β] [TopologicalRing β] :
+    TopologicalRing C(α, β) where
 
 /-- Composition on the left by a (continuous) homomorphism of topological semirings, as a
 `RingHom`.  Similar to `RingHom.compLeft`. -/

--- a/Mathlib/Topology/ContinuousFunction/Algebra.lean
+++ b/Mathlib/Topology/ContinuousFunction/Algebra.lean
@@ -492,16 +492,16 @@ instance {α : Type*} {β : Type*} [TopologicalSpace α] [TopologicalSpace β]
     [NonUnitalNonAssocSemiring β] [TopologicalSemiring β] : NonUnitalNonAssocSemiring C(α, β) :=
   coe_injective.nonUnitalNonAssocSemiring _ coe_zero coe_add coe_mul coe_nsmul
 
-instance {α : Type*} {β : Type*} [TopologicalSpace α] [TopologicalSpace β]
-    [NonUnitalSemiring β] [TopologicalSemiring β] : NonUnitalSemiring C(α, β) :=
+instance {α : Type*} {β : Type*} [TopologicalSpace α] [TopologicalSpace β] [NonUnitalSemiring β]
+    [TopologicalSemiring β] : NonUnitalSemiring C(α, β) :=
   coe_injective.nonUnitalSemiring _ coe_zero coe_add coe_mul coe_nsmul
 
-instance {α : Type*} {β : Type*} [TopologicalSpace α] [TopologicalSpace β]
-    [AddMonoidWithOne β] [ContinuousAdd β] : AddMonoidWithOne C(α, β) :=
+instance {α : Type*} {β : Type*} [TopologicalSpace α] [TopologicalSpace β] [AddMonoidWithOne β]
+    [ContinuousAdd β] : AddMonoidWithOne C(α, β) :=
   coe_injective.addMonoidWithOne _ coe_zero coe_one coe_add coe_nsmul coe_natCast
 
-instance {α : Type*} {β : Type*} [TopologicalSpace α] [TopologicalSpace β]
-    [NonAssocSemiring β] [TopologicalSemiring β] : NonAssocSemiring C(α, β) :=
+instance {α : Type*} {β : Type*} [TopologicalSpace α] [TopologicalSpace β] [NonAssocSemiring β]
+    [TopologicalSemiring β] : NonAssocSemiring C(α, β) :=
   coe_injective.nonAssocSemiring _ coe_zero coe_one coe_add coe_mul coe_nsmul coe_natCast
 
 instance {α : Type*} {β : Type*} [TopologicalSpace α] [TopologicalSpace β] [Semiring β]
@@ -512,17 +512,17 @@ instance {α : Type*} {β : Type*} [TopologicalSpace α] [TopologicalSpace β]
     [NonUnitalNonAssocRing β] [TopologicalRing β] : NonUnitalNonAssocRing C(α, β) :=
   coe_injective.nonUnitalNonAssocRing _ coe_zero coe_add coe_mul coe_neg coe_sub coe_nsmul coe_zsmul
 
-instance {α : Type*} {β : Type*} [TopologicalSpace α] [TopologicalSpace β]
-    [NonUnitalRing β] [TopologicalRing β] : NonUnitalRing C(α, β) :=
+instance {α : Type*} {β : Type*} [TopologicalSpace α] [TopologicalSpace β] [NonUnitalRing β]
+    [TopologicalRing β] : NonUnitalRing C(α, β) :=
   coe_injective.nonUnitalRing _ coe_zero coe_add coe_mul coe_neg coe_sub coe_nsmul coe_zsmul
 
-instance {α : Type*} {β : Type*} [TopologicalSpace α] [TopologicalSpace β]
-    [NonAssocRing β] [TopologicalRing β] : NonAssocRing C(α, β) :=
+instance {α : Type*} {β : Type*} [TopologicalSpace α] [TopologicalSpace β] [NonAssocRing β]
+    [TopologicalRing β] : NonAssocRing C(α, β) :=
   coe_injective.nonAssocRing _ coe_zero coe_one coe_add coe_mul coe_neg coe_sub coe_nsmul coe_zsmul
     coe_natCast coe_intCast
 
-instance instRing {α : Type*} {β : Type*} [TopologicalSpace α] [TopologicalSpace β]
-    [Ring β] [TopologicalRing β] : Ring C(α, β) :=
+instance instRing {α : Type*} {β : Type*} [TopologicalSpace α] [TopologicalSpace β] [Ring β]
+    [TopologicalRing β] : Ring C(α, β) :=
   coe_injective.ring _ coe_zero coe_one coe_add coe_mul coe_neg coe_sub coe_nsmul coe_zsmul coe_pow
     coe_natCast coe_intCast
 
@@ -530,12 +530,12 @@ instance {α : Type*} {β : Type*} [TopologicalSpace α] [TopologicalSpace β]
     [NonUnitalCommSemiring β] [TopologicalSemiring β] : NonUnitalCommSemiring C(α, β) :=
   coe_injective.nonUnitalCommSemiring _ coe_zero coe_add coe_mul coe_nsmul
 
-instance {α : Type*} {β : Type*} [TopologicalSpace α] [TopologicalSpace β]
-    [CommSemiring β] [TopologicalSemiring β] : CommSemiring C(α, β) :=
+instance {α : Type*} {β : Type*} [TopologicalSpace α] [TopologicalSpace β] [CommSemiring β]
+    [TopologicalSemiring β] : CommSemiring C(α, β) :=
   coe_injective.commSemiring _ coe_zero coe_one coe_add coe_mul coe_nsmul coe_pow coe_natCast
 
-instance {α : Type*} {β : Type*} [TopologicalSpace α] [TopologicalSpace β]
-    [NonUnitalCommRing β] [TopologicalRing β] : NonUnitalCommRing C(α, β) :=
+instance {α : Type*} {β : Type*} [TopologicalSpace α] [TopologicalSpace β] [NonUnitalCommRing β]
+    [TopologicalRing β] : NonUnitalCommRing C(α, β) :=
   coe_injective.nonUnitalCommRing _ coe_zero coe_add coe_mul coe_neg coe_sub coe_nsmul coe_zsmul
 
 instance {α : Type*} {β : Type*} [TopologicalSpace α] [TopologicalSpace β] [CommRing β]
@@ -543,13 +543,11 @@ instance {α : Type*} {β : Type*} [TopologicalSpace α] [TopologicalSpace β] [
   coe_injective.commRing _ coe_zero coe_one coe_add coe_mul coe_neg coe_sub coe_nsmul coe_zsmul
     coe_pow coe_natCast coe_intCast
 
-instance {α : Type*} {β : Type*} [TopologicalSpace α] [TopologicalSpace β]
-    [LocallyCompactSpace α] [NonUnitalSemiring β] [TopologicalSemiring β] :
-    TopologicalSemiring C(α, β) where
+instance {α : Type*} {β : Type*} [TopologicalSpace α] [TopologicalSpace β] [LocallyCompactSpace α]
+    [NonUnitalSemiring β] [TopologicalSemiring β] : TopologicalSemiring C(α, β) where
 
-instance {α : Type*} {β : Type*} [TopologicalSpace α] [TopologicalSpace β]
-    [LocallyCompactSpace α] [NonUnitalRing β] [TopologicalRing β] :
-    TopologicalRing C(α, β) where
+instance {α : Type*} {β : Type*} [TopologicalSpace α] [TopologicalSpace β] [LocallyCompactSpace α]
+    [NonUnitalRing β] [TopologicalRing β] : TopologicalRing C(α, β) where
 
 /-- Composition on the left by a (continuous) homomorphism of topological semirings, as a
 `RingHom`.  Similar to `RingHom.compLeft`. -/

--- a/Mathlib/Topology/ContinuousFunction/Algebra.lean
+++ b/Mathlib/Topology/ContinuousFunction/Algebra.lean
@@ -488,36 +488,35 @@ end Subtype
 
 namespace ContinuousMap
 
-instance instNonUnitalNonAssocSemiring {α : Type*} {β : Type*} [TopologicalSpace α]
-    [TopologicalSpace β] [NonUnitalNonAssocSemiring β] [TopologicalSemiring β] :
-    NonUnitalNonAssocSemiring C(α, β) :=
+instance {α : Type*} {β : Type*} [TopologicalSpace α] [TopologicalSpace β]
+    [NonUnitalNonAssocSemiring β] [TopologicalSemiring β] : NonUnitalNonAssocSemiring C(α, β) :=
   coe_injective.nonUnitalNonAssocSemiring _ coe_zero coe_add coe_mul coe_nsmul
 
-instance instNonUnitalSemiring {α : Type*} {β : Type*} [TopologicalSpace α] [TopologicalSpace β]
+instance {α : Type*} {β : Type*} [TopologicalSpace α] [TopologicalSpace β]
     [NonUnitalSemiring β] [TopologicalSemiring β] : NonUnitalSemiring C(α, β) :=
   coe_injective.nonUnitalSemiring _ coe_zero coe_add coe_mul coe_nsmul
 
-instance instAddMonoidWithOne {α : Type*} {β : Type*} [TopologicalSpace α] [TopologicalSpace β]
+instance {α : Type*} {β : Type*} [TopologicalSpace α] [TopologicalSpace β]
     [AddMonoidWithOne β] [ContinuousAdd β] : AddMonoidWithOne C(α, β) :=
   coe_injective.addMonoidWithOne _ coe_zero coe_one coe_add coe_nsmul coe_natCast
 
-instance instNonAssocSemiring {α : Type*} {β : Type*} [TopologicalSpace α] [TopologicalSpace β]
+instance {α : Type*} {β : Type*} [TopologicalSpace α] [TopologicalSpace β]
     [NonAssocSemiring β] [TopologicalSemiring β] : NonAssocSemiring C(α, β) :=
   coe_injective.nonAssocSemiring _ coe_zero coe_one coe_add coe_mul coe_nsmul coe_natCast
 
-instance instSemiring {α : Type*} {β : Type*} [TopologicalSpace α] [TopologicalSpace β] [Semiring β]
+instance {α : Type*} {β : Type*} [TopologicalSpace α] [TopologicalSpace β] [Semiring β]
     [TopologicalSemiring β] : Semiring C(α, β) :=
   coe_injective.semiring _ coe_zero coe_one coe_add coe_mul coe_nsmul coe_pow coe_natCast
 
-instance instNonUnitalNonAssocRing {α : Type*} {β : Type*} [TopologicalSpace α] [TopologicalSpace β]
+instance {α : Type*} {β : Type*} [TopologicalSpace α] [TopologicalSpace β]
     [NonUnitalNonAssocRing β] [TopologicalRing β] : NonUnitalNonAssocRing C(α, β) :=
   coe_injective.nonUnitalNonAssocRing _ coe_zero coe_add coe_mul coe_neg coe_sub coe_nsmul coe_zsmul
 
-instance instNonUnitalRing {α : Type*} {β : Type*} [TopologicalSpace α] [TopologicalSpace β]
+instance {α : Type*} {β : Type*} [TopologicalSpace α] [TopologicalSpace β]
     [NonUnitalRing β] [TopologicalRing β] : NonUnitalRing C(α, β) :=
   coe_injective.nonUnitalRing _ coe_zero coe_add coe_mul coe_neg coe_sub coe_nsmul coe_zsmul
 
-instance instNonAssocRing {α : Type*} {β : Type*} [TopologicalSpace α] [TopologicalSpace β]
+instance {α : Type*} {β : Type*} [TopologicalSpace α] [TopologicalSpace β]
     [NonAssocRing β] [TopologicalRing β] : NonAssocRing C(α, β) :=
   coe_injective.nonAssocRing _ coe_zero coe_one coe_add coe_mul coe_neg coe_sub coe_nsmul coe_zsmul
     coe_natCast coe_intCast
@@ -527,28 +526,28 @@ instance instRing {α : Type*} {β : Type*} [TopologicalSpace α] [TopologicalSp
   coe_injective.ring _ coe_zero coe_one coe_add coe_mul coe_neg coe_sub coe_nsmul coe_zsmul coe_pow
     coe_natCast coe_intCast
 
-instance instNonUnitalCommSemiring {α : Type*} {β : Type*} [TopologicalSpace α] [TopologicalSpace β]
+instance {α : Type*} {β : Type*} [TopologicalSpace α] [TopologicalSpace β]
     [NonUnitalCommSemiring β] [TopologicalSemiring β] : NonUnitalCommSemiring C(α, β) :=
   coe_injective.nonUnitalCommSemiring _ coe_zero coe_add coe_mul coe_nsmul
 
-instance instCommSemiring {α : Type*} {β : Type*} [TopologicalSpace α] [TopologicalSpace β]
+instance {α : Type*} {β : Type*} [TopologicalSpace α] [TopologicalSpace β]
     [CommSemiring β] [TopologicalSemiring β] : CommSemiring C(α, β) :=
   coe_injective.commSemiring _ coe_zero coe_one coe_add coe_mul coe_nsmul coe_pow coe_natCast
 
-instance instNonUnitalCommRing {α : Type*} {β : Type*} [TopologicalSpace α] [TopologicalSpace β]
+instance {α : Type*} {β : Type*} [TopologicalSpace α] [TopologicalSpace β]
     [NonUnitalCommRing β] [TopologicalRing β] : NonUnitalCommRing C(α, β) :=
   coe_injective.nonUnitalCommRing _ coe_zero coe_add coe_mul coe_neg coe_sub coe_nsmul coe_zsmul
 
-instance instCommRing {α : Type*} {β : Type*} [TopologicalSpace α] [TopologicalSpace β] [CommRing β]
+instance {α : Type*} {β : Type*} [TopologicalSpace α] [TopologicalSpace β] [CommRing β]
     [TopologicalRing β] : CommRing C(α, β) :=
   coe_injective.commRing _ coe_zero coe_one coe_add coe_mul coe_neg coe_sub coe_nsmul coe_zsmul
     coe_pow coe_natCast coe_intCast
 
-instance instTopologicalSemiring {α : Type*} {β : Type*} [TopologicalSpace α] [TopologicalSpace β]
+instance {α : Type*} {β : Type*} [TopologicalSpace α] [TopologicalSpace β]
     [LocallyCompactSpace α] [NonUnitalSemiring β] [TopologicalSemiring β] :
     TopologicalSemiring C(α, β) where
 
-instance instTopologicalRing {α : Type*} {β : Type*} [TopologicalSpace α] [TopologicalSpace β]
+instance {α : Type*} {β : Type*} [TopologicalSpace α] [TopologicalSpace β]
     [LocallyCompactSpace α] [NonUnitalRing β] [TopologicalRing β] :
     TopologicalRing C(α, β) where
 

--- a/Mathlib/Topology/ContinuousFunction/Compact.lean
+++ b/Mathlib/Topology/ContinuousFunction/Compact.lean
@@ -253,7 +253,7 @@ section
 variable {R : Type*} [NormedRing R]
 
 instance : NormedRing C(α, R) :=
-  { (inferInstance : NormedAddCommGroup C(α, R)), ContinuousMap.instRingContinuousMap with
+  { (inferInstance : NormedAddCommGroup C(α, R)), ContinuousMap.instRing with
     norm_mul := fun f g => norm_mul_le (mkOfCompact f) (mkOfCompact g) }
 
 end


### PR DESCRIPTION
This PR adds `TopologicalSemiring` and `TopologicalRing` instances on `C(α, β)`, and also gives explicit names to various related instances on `C(α, β)`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
