### PR TITLE
[Merged by Bors] - feat(Algebra/Lie/Normalizer): add `normalizer_mono` and use it to fix a porting note

### DIFF
--- a/Mathlib/Algebra/Lie/Nilpotent.lean
+++ b/Mathlib/Algebra/Lie/Nilpotent.lean
@@ -486,8 +486,7 @@ theorem ucs_mono (k : ℕ) (h : N₁ ≤ N₂) : N₁.ucs k ≤ N₂.ucs k := by
   induction' k with k ih
   · simpa
   simp only [ucs_succ]
-  -- Porting note: `mono` makes no progress
-  apply monotone_normalizer ih
+  mono
 #align lie_submodule.ucs_mono LieSubmodule.ucs_mono
 
 theorem ucs_eq_self_of_normalizer_eq_self (h : N₁.normalizer = N₁) (k : ℕ) : N₁.ucs k = N₁ := by

--- a/Mathlib/Algebra/Lie/Normalizer.lean
+++ b/Mathlib/Algebra/Lie/Normalizer.lean
@@ -72,11 +72,11 @@ theorem normalizer_inf : (N₁ ⊓ N₂).normalizer = N₁.normalizer ⊓ N₂.n
 #align lie_submodule.normalizer_inf LieSubmodule.normalizer_inf
 
 @[mono]
-theorem monotone_normalizer : Monotone (normalizer : LieSubmodule R L M → LieSubmodule R L M) := by
-  intro N₁ N₂ h m hm
+theorem monotone_normalizer (h : N₁ ≤ N₂) : normalizer N₁ ≤ normalizer N₂ := by
+  intro m hm
   rw [mem_normalizer] at hm ⊢
   exact fun x => h (hm x)
-#align lie_submodule.monotone_normalizer LieSubmodule.monotone_normalizer
+#align lie_submodule.monotone_normalizer LieSubmodule.monotone_normalizerₓ
 
 @[simp]
 theorem comap_normalizer (f : M' →ₗ⁅R,L⁆ M) : N.normalizer.comap f = (N.comap f).normalizer := by

--- a/Mathlib/Algebra/Lie/Normalizer.lean
+++ b/Mathlib/Algebra/Lie/Normalizer.lean
@@ -72,11 +72,14 @@ theorem normalizer_inf : (N₁ ⊓ N₂).normalizer = N₁.normalizer ⊓ N₂.n
 #align lie_submodule.normalizer_inf LieSubmodule.normalizer_inf
 
 @[mono]
-theorem monotone_normalizer (h : N₁ ≤ N₂) : normalizer N₁ ≤ normalizer N₂ := by
+theorem normalizer_mono (h : N₁ ≤ N₂) : normalizer N₁ ≤ normalizer N₂ := by
   intro m hm
   rw [mem_normalizer] at hm ⊢
   exact fun x => h (hm x)
-#align lie_submodule.monotone_normalizer LieSubmodule.monotone_normalizerₓ
+
+theorem monotone_normalizer : Monotone (normalizer : LieSubmodule R L M → LieSubmodule R L M) :=
+  fun _ _ h ↦ normalizer_mono h
+#align lie_submodule.monotone_normalizer LieSubmodule.monotone_normalizer
 
 @[simp]
 theorem comap_normalizer (f : M' →ₗ⁅R,L⁆ M) : N.normalizer.comap f = (N.comap f).normalizer := by

--- a/Mathlib/Algebra/Lie/Normalizer.lean
+++ b/Mathlib/Algebra/Lie/Normalizer.lean
@@ -78,7 +78,7 @@ theorem normalizer_mono (h : N₁ ≤ N₂) : normalizer N₁ ≤ normalizer N�
   exact fun x => h (hm x)
 
 theorem monotone_normalizer : Monotone (normalizer : LieSubmodule R L M → LieSubmodule R L M) :=
-  fun _ _ h ↦ normalizer_mono h
+  fun _ _ ↦ normalizer_mono
 #align lie_submodule.monotone_normalizer LieSubmodule.monotone_normalizer
 
 @[simp]


### PR DESCRIPTION
`mono` would not apply on `monotone_normalizer`, but does apply on `normalizer_mono`.

---------

A subsequent PR will replace `mono` by `gcongr`- which needs the same change (and whose error message exposed this).

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
