### PR TITLE
[Merged by Bors] - fix: add missing instantiateMVars in split_ifs

### DIFF
--- a/Mathlib/GroupTheory/Perm/Support.lean
+++ b/Mathlib/GroupTheory/Perm/Support.lean
@@ -250,7 +250,7 @@ theorem ne_and_ne_of_swap_mul_apply_ne_self {f : Perm α} {x y : α} (hy : (swap
   simp only [swap_apply_def, mul_apply, f.injective.eq_iff] at *
   by_cases h : f y = x
   · constructor <;> intro <;> simp_all only [if_true, eq_self_iff_true, not_true, Ne]
-  · split_ifs at hy with h h <;> try { simp [*] at * }
+  · split_ifs at hy with h <;> try { simp [*] at * }
 #align equiv.perm.ne_and_ne_of_swap_mul_apply_ne_self Equiv.Perm.ne_and_ne_of_swap_mul_apply_ne_self
 
 end IsSwap
@@ -495,9 +495,8 @@ theorem mem_support_swap_mul_imp_mem_support_ne {x y : α} (hy : y ∈ support (
   simp only [mem_support, swap_apply_def, mul_apply, f.injective.eq_iff] at *
   by_cases h : f y = x
   · constructor <;> intro <;> simp_all only [if_true, eq_self_iff_true, not_true, Ne]
-  · split_ifs at hy with hf heq <;>
-    simp_all only [not_true]
-    · exact ⟨h, hy⟩
+  · split_ifs at hy with heq
+    · subst heq; exact ⟨h, hy⟩
     · exact ⟨hy, heq⟩
 #align equiv.perm.mem_support_swap_mul_imp_mem_support_ne Equiv.Perm.mem_support_swap_mul_imp_mem_support_ne
 

--- a/Mathlib/NumberTheory/Padics/PadicNumbers.lean
+++ b/Mathlib/NumberTheory/Padics/PadicNumbers.lean
@@ -124,7 +124,6 @@ theorem norm_zero_iff (f : PadicSeq p) : f.norm = 0 ↔ f ≈ 0 := by
     by_contra hf
     unfold norm at h
     split_ifs at h
-    · contradiction
     apply hf
     intro ε hε
     exists stationaryPoint hf
@@ -609,7 +608,6 @@ theorem defn (f : PadicSeq p) {ε : ℚ} (hε : 0 < ε) :
     rw [PadicSeq.norm, dif_pos h] at hge
     exact not_lt_of_ge hge hε
   unfold PadicSeq.norm at hge; split_ifs at hge
-  · exact not_le_of_gt hε hge
   apply not_le_of_gt _ hge
   cases' _root_.em (N ≤ stationaryPoint hne) with hgen hngen
   · apply hN _ hgen _ hi

--- a/Mathlib/Tactic/SplitIfs.lean
+++ b/Mathlib/Tactic/SplitIfs.lean
@@ -101,10 +101,12 @@ private def getNextName (hNames: IO.Ref (List (TSyntax `Lean.binderIdent))) : Me
 /-- Returns `true` if the condition or its negation already appears as a hypothesis.
 -/
 private def valueKnown (cond : Expr) : TacticM Bool := do
-  let hTypes ← (((← getLCtx).getFVarIds.map mkFVar).mapM inferType : MetaM _)
-  let hTypes := hTypes.toList
   let not_cond := mkApp (mkConst `Not) cond
-  return (hTypes.contains cond) || (hTypes.contains not_cond)
+  for h in ← getLocalHyps do
+    let ty ← instantiateMVars (← inferType h)
+    if cond == ty then return true
+    if not_cond == ty then return true
+  return false
 
 /-- Main loop of split_ifs. Pulls names for new hypotheses from `hNames`.
 Stops if it encounters a condition in the passed-in `List Expr`.

--- a/Mathlib/Topology/Sheaves/Skyscraper.lean
+++ b/Mathlib/Topology/Sheaves/Skyscraper.lean
@@ -86,7 +86,7 @@ def SkyscraperPresheafFunctor.map' {a b : C} (f : a ⟶ b) :
     else ((if_neg h).symm.ndrec terminalIsTerminal).from _
   naturality U V i := by
     simp only [skyscraperPresheaf_map]; by_cases hV : p₀ ∈ V.unop
-    · have hU : p₀ ∈ U.unop := leOfHom i.unop hV; split_ifs <;>
+    · have hU : p₀ ∈ U.unop := leOfHom i.unop hV; split_ifs
       simp only [eqToHom_trans_assoc, Category.assoc, eqToHom_trans]
     · apply ((if_neg hV).symm.ndrec terminalIsTerminal).hom_ext
 #align skyscraper_presheaf_functor.map' SkyscraperPresheafFunctor.map'
@@ -273,11 +273,9 @@ def toSkyscraperPresheaf {𝓕 : Presheaf C X} {c : C} (f : 𝓕.stalk p₀ ⟶ 
     by_cases hV : p₀ ∈ V.unop
     · have hU : p₀ ∈ U.unop := leOfHom inc.unop hV
       split_ifs
-      · erw [← Category.assoc, 𝓕.germ_res inc.unop, Category.assoc, Category.assoc, eqToHom_trans]
-      · aesop_cat
+      erw [← Category.assoc, 𝓕.germ_res inc.unop, Category.assoc, Category.assoc, eqToHom_trans]
     · split_ifs
-      · exact ((if_neg hV).symm.ndrec terminalIsTerminal).hom_ext ..
-      · aesop_cat
+      exact ((if_neg hV).symm.ndrec terminalIsTerminal).hom_ext ..
 #align stalk_skyscraper_presheaf_adjunction_auxs.to_skyscraper_presheaf StalkSkyscraperPresheafAdjunctionAuxs.toSkyscraperPresheaf
 
 /-- If `f : 𝓕 ⟶ skyscraperPresheaf p₀ c` is a natural transformation, then there is a morphism

--- a/test/SplitIfs.lean
+++ b/test/SplitIfs.lean
@@ -72,3 +72,10 @@ example (P Q : Prop) (w : if P then (if Q then true else true) else true = true)
   · trivial
   · trivial
   · trivial
+
+example (u : Nat) : (if u = u then 0 else 1) = 0 := by
+  have h : u = u := by rfl
+  split_ifs
+  -- only one goal here
+  rfl
+  done


### PR DESCRIPTION
Fixes the bug reported on zulip [here](https://leanprover.zulipchat.com/#narrow/stream/287929-mathlib4/topic/split_ifs/near/445173774).

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
