### PR TITLE
feat(CategoryTheory/Adjunction): leftAdjointCongr

### DIFF
--- a/Mathlib/CategoryTheory/Adjunction/Unique.lean
+++ b/Mathlib/CategoryTheory/Adjunction/Unique.lean
@@ -113,6 +113,22 @@ def leftAdjointUniq {F F' : C ⥤ D} {G : D ⥤ C} (adj1 : F ⊣ G) (adj2 : F' �
   (natIsoEquiv adj1 adj2 (Iso.refl _)).symm
 #align category_theory.adjunction.left_adjoint_uniq CategoryTheory.Adjunction.leftAdjointUniq
 
+/-- If `F` is left adjoint to `G`, then it isomorphic to `G.leftAdjoint`. -/
+noncomputable abbrev leftAdjointCongr {F : C ⥤ D} {G : D ⥤ C} (adj : F ⊣ G) :
+    haveI : G.IsRightAdjoint := adj.isRightAdjoint
+    F ≅ G.leftAdjoint :=
+  haveI : G.IsRightAdjoint := adj.isRightAdjoint
+  adj.leftAdjointUniq (Adjunction.ofIsRightAdjoint G)
+
+/-- If `F` and `G` are naturally isomorphic and one of them is a right adjoint, their left adjoints
+are isomorphic. -/
+noncomputable abbrev _root_.CategoryTheory.Functor.leftAdjointCongr
+    {F G : D ⥤ C} (i : F ≅ G) [F.IsRightAdjoint] :
+    haveI := Functor.isRightAdjoint_of_iso i
+    F.leftAdjoint ≅ G.leftAdjoint :=
+  haveI := Functor.isRightAdjoint_of_iso i
+  ((Adjunction.ofIsRightAdjoint F).ofNatIsoRight i).leftAdjointUniq (Adjunction.ofIsRightAdjoint G)
+
 -- Porting note (#10618): removed simp as simp can prove this
 theorem homEquiv_leftAdjointUniq_hom_app {F F' : C ⥤ D} {G : D ⥤ C} (adj1 : F ⊣ G) (adj2 : F' ⊣ G)
     (x : C) : adj1.homEquiv _ _ ((leftAdjointUniq adj1 adj2).hom.app x) = adj2.unit.app x := by
@@ -185,6 +201,22 @@ theorem leftAdjointUniq_refl {F : C ⥤ D} {G : D ⥤ C} (adj1 : F ⊣ G) :
 def rightAdjointUniq {F : C ⥤ D} {G G' : D ⥤ C} (adj1 : F ⊣ G) (adj2 : F ⊣ G') : G ≅ G' :=
   (natIsoEquiv adj1 adj2).symm (Iso.refl _)
 #align category_theory.adjunction.right_adjoint_uniq CategoryTheory.Adjunction.rightAdjointUniq
+
+/-- If `G` is right adjoint to `F`, then it isomorphic to `F.rightAdjoint`. -/
+noncomputable abbrev rightAdjointCongr {F : C ⥤ D} {G : D ⥤ C} (adj : F ⊣ G) :
+    haveI : F.IsLeftAdjoint := adj.isLeftAdjoint
+    F.rightAdjoint ≅ G :=
+  haveI : F.IsLeftAdjoint := adj.isLeftAdjoint
+  (adj.rightAdjointUniq (Adjunction.ofIsLeftAdjoint F)).symm
+
+/-- If `F` and `G` are naturally isomorphic and one of them is a left adjoint, their right adjoints
+are isomorphic. -/
+noncomputable abbrev _root_.CategoryTheory.Functor.rightAdjointCongr
+    {F G : D ⥤ C} (i : F ≅ G) [F.IsLeftAdjoint] :
+    haveI := Functor.isLeftAdjoint_of_iso i
+    F.rightAdjoint ≅ G.rightAdjoint :=
+  haveI := Functor.isLeftAdjoint_of_iso i
+  ((Adjunction.ofIsLeftAdjoint F).ofNatIsoLeft i).rightAdjointUniq (Adjunction.ofIsLeftAdjoint G)
 
 -- Porting note (#10618): simp can prove this
 theorem homEquiv_symm_rightAdjointUniq_hom_app {F : C ⥤ D} {G G' : D ⥤ C} (adj1 : F ⊣ G)


### PR DESCRIPTION
This PR adds an isomrphism `leftAdjointCongr`; given two isomorphic functors, one of which is a right adjoint (and hence also the other), their left adjoints are isomorphic. 

---
This is used in #13922 in the context of discrete objects with respect to a functor

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
