### PR TITLE
feat(CategoryTheory/Adjunction): define the notion of a discrete object

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -1223,6 +1223,7 @@ import Mathlib.CategoryTheory.Adhesive
 import Mathlib.CategoryTheory.Adjunction.AdjointFunctorTheorems
 import Mathlib.CategoryTheory.Adjunction.Basic
 import Mathlib.CategoryTheory.Adjunction.Comma
+import Mathlib.CategoryTheory.Adjunction.DiscreteObjects
 import Mathlib.CategoryTheory.Adjunction.Evaluation
 import Mathlib.CategoryTheory.Adjunction.FullyFaithful
 import Mathlib.CategoryTheory.Adjunction.Lifting

--- a/Mathlib/CategoryTheory/Adjunction/DiscreteObjects.lean
+++ b/Mathlib/CategoryTheory/Adjunction/DiscreteObjects.lean
@@ -1,0 +1,104 @@
+/-
+Copyright (c) 2024 Dagur Asgeirsson. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Dagur Asgeirsson
+-/
+import Mathlib.CategoryTheory.Adjunction.FullyFaithful
+import Mathlib.CategoryTheory.Adjunction.Unique
+/-!
+
+# Discrete objects
+
+This file defines the property of a functor of having discrete objects. This simply means that it
+has a fully faithful left adjoint.
+
+We also define a predicate `IsDiscrete` on objects saying that the counit of the adjunction applied
+to `X` is an isomorphism. This is equivalent to being in the essential image of the left adjoint
+(see `isDiscrete_iff_mem_essImage`).
+-/
+
+open CategoryTheory
+
+variable {C D : Type*} [Category C] [Category D] (U : C ⥤ D)
+
+namespace CategoryTheory.Functor
+
+/-- A functor is said to have discrete objects if it has a fully faithful left adjoint. -/
+class HasDiscreteObjects : Prop where
+  isRightAdjoint : IsRightAdjoint U := by infer_instance
+  faithful : (leftAdjoint U).Faithful := by infer_instance
+  full : (leftAdjoint U).Full := by infer_instance
+
+attribute [instance] HasDiscreteObjects.isRightAdjoint
+attribute [instance] HasDiscreteObjects.faithful
+attribute [instance] HasDiscreteObjects.full
+
+variable {U} in
+/-- The property of having discrete objects is invariant under natural isomorphism. -/
+lemma hasDiscreteObjectsOfNatIso {U' : C ⥤ D} (i : U ≅ U') [HasDiscreteObjects U] :
+    HasDiscreteObjects U' where
+  isRightAdjoint := ⟨leftAdjoint U,
+    ⟨Adjunction.ofNatIsoRight (Adjunction.ofIsRightAdjoint U) i⟩⟩
+  faithful := Faithful.of_iso (leftAdjointCongr i)
+  full := Full.of_iso (leftAdjointCongr i)
+
+variable {U} in
+lemma hasDiscreteObjects_iff_of_natIso {U' : C ⥤ D} (i : U ≅ U') :
+    HasDiscreteObjects U ↔ HasDiscreteObjects U' :=
+  ⟨fun _ ↦ hasDiscreteObjectsOfNatIso i,  fun _ ↦ hasDiscreteObjectsOfNatIso i.symm⟩
+
+/-- A constructor for `HasDiscreteObjects` given an explicit adjunction. -/
+lemma HasDiscreteObjects.mk' {L : D ⥤ C} (adj : L ⊣ U) [L.Full] [L.Faithful] :
+    HasDiscreteObjects U where
+  isRightAdjoint := adj.isRightAdjoint
+  faithful := Faithful.of_iso (adj.leftAdjointCongr)
+  full := Full.of_iso (adj.leftAdjointCongr)
+
+end Functor
+
+/--
+Given a functor `U` which has discrete objects, `IsDiscrete U X` is the predicate on objects saying
+that the counit of the adjunction applied to `X` is an isomorphism.
+
+In fact, it is enough that the object `X` is in the essential image of the left adjoint, see e.g.
+`isDiscrete_iff_mem_essImage`.
+-/
+class IsDiscrete [U.HasDiscreteObjects] (X : C) : Prop where
+  isIso_counit : IsIso <| (Adjunction.ofIsRightAdjoint U).counit.app X := by infer_instance
+
+attribute [instance] IsDiscrete.isIso_counit
+
+open Adjunction
+
+theorem isDiscrete_of_iso [U.HasDiscreteObjects] {X : C} {Y : D}
+    (i : X ≅ U.leftAdjoint.obj Y) : IsDiscrete U X where
+  isIso_counit := isIso_counit_app_of_iso _ i
+
+theorem isDiscrete_iff_mem_essImage {L : D ⥤ C} (adj : L ⊣ U) [L.Full] [L.Faithful] (X : C) :
+    haveI : U.HasDiscreteObjects := Functor.HasDiscreteObjects.mk' _ adj
+    IsDiscrete U X ↔ X ∈ L.essImage := by
+  haveI := Functor.HasDiscreteObjects.mk' _ adj
+  refine ⟨fun h ↦ ⟨U.obj X, ⟨?_⟩⟩, fun ⟨Y, ⟨i⟩⟩ ↦ ?_⟩
+  · refine adj.leftAdjointCongr.app _ ≪≫
+      asIso ((Adjunction.ofIsRightAdjoint _).counit.app _)
+  · exact isDiscrete_of_iso U (i.symm ≪≫ adj.leftAdjointCongr.app _)
+
+theorem isDiscrete_iff_isIso_counit_app {L : D ⥤ C} (adj : L ⊣ U) [L.Full] [L.Faithful] (X : C) :
+    haveI : U.HasDiscreteObjects := Functor.HasDiscreteObjects.mk' _ adj
+    IsDiscrete U X ↔ IsIso (adj.counit.app X) := by
+  rw [isIso_counit_app_iff_mem_essImage]
+  exact isDiscrete_iff_mem_essImage _ adj _
+
+theorem isDiscrete_congr [U.HasDiscreteObjects] {X Y : C} (i : X ≅ Y) [IsDiscrete U X] :
+    IsDiscrete U Y :=
+  isDiscrete_of_iso U (i.symm ≪≫ (asIso ((Adjunction.ofIsRightAdjoint U).counit.app X)).symm)
+
+theorem isDiscrete_of_natIso [U.HasDiscreteObjects] (U' : C ⥤ D) (i : U ≅ U') (X : C)
+    [IsDiscrete U X] :
+    haveI : U'.HasDiscreteObjects := Functor.hasDiscreteObjectsOfNatIso i
+    IsDiscrete U' X :=
+  haveI : U'.HasDiscreteObjects := Functor.hasDiscreteObjectsOfNatIso i
+  isDiscrete_of_iso U' ((asIso ((Adjunction.ofIsRightAdjoint U).counit.app X)).symm ≪≫
+    ((Functor.leftAdjointCongr i)).app _)
+
+end CategoryTheory

--- a/Mathlib/CategoryTheory/Adjunction/Unique.lean
+++ b/Mathlib/CategoryTheory/Adjunction/Unique.lean
@@ -113,6 +113,22 @@ def leftAdjointUniq {F F' : C ⥤ D} {G : D ⥤ C} (adj1 : F ⊣ G) (adj2 : F' �
   (natIsoEquiv adj1 adj2 (Iso.refl _)).symm
 #align category_theory.adjunction.left_adjoint_uniq CategoryTheory.Adjunction.leftAdjointUniq
 
+/-- If `F` is left adjoint to `G`, then it isomorphic to `G.leftAdjoint`. -/
+noncomputable abbrev leftAdjointCongr {F : C ⥤ D} {G : D ⥤ C} (adj : F ⊣ G) :
+    haveI : G.IsRightAdjoint := adj.isRightAdjoint
+    F ≅ G.leftAdjoint :=
+  haveI : G.IsRightAdjoint := adj.isRightAdjoint
+  adj.leftAdjointUniq (Adjunction.ofIsRightAdjoint G)
+
+/-- If `F` and `G` are naturally isomorphic and one of them is a right adjoint, their left adjoints
+are isomorphic. -/
+noncomputable abbrev _root_.CategoryTheory.Functor.leftAdjointCongr
+    {F G : D ⥤ C} (i : F ≅ G) [F.IsRightAdjoint] :
+    haveI := Functor.isRightAdjoint_of_iso i
+    F.leftAdjoint ≅ G.leftAdjoint :=
+  haveI := Functor.isRightAdjoint_of_iso i
+  ((Adjunction.ofIsRightAdjoint F).ofNatIsoRight i).leftAdjointUniq (Adjunction.ofIsRightAdjoint G)
+
 -- Porting note (#10618): removed simp as simp can prove this
 theorem homEquiv_leftAdjointUniq_hom_app {F F' : C ⥤ D} {G : D ⥤ C} (adj1 : F ⊣ G) (adj2 : F' ⊣ G)
     (x : C) : adj1.homEquiv _ _ ((leftAdjointUniq adj1 adj2).hom.app x) = adj2.unit.app x := by
@@ -185,6 +201,22 @@ theorem leftAdjointUniq_refl {F : C ⥤ D} {G : D ⥤ C} (adj1 : F ⊣ G) :
 def rightAdjointUniq {F : C ⥤ D} {G G' : D ⥤ C} (adj1 : F ⊣ G) (adj2 : F ⊣ G') : G ≅ G' :=
   (natIsoEquiv adj1 adj2).symm (Iso.refl _)
 #align category_theory.adjunction.right_adjoint_uniq CategoryTheory.Adjunction.rightAdjointUniq
+
+/-- If `G` is right adjoint to `F`, then it isomorphic to `F.rightAdjoint`. -/
+noncomputable abbrev rightAdjointCongr {F : C ⥤ D} {G : D ⥤ C} (adj : F ⊣ G) :
+    haveI : F.IsLeftAdjoint := adj.isLeftAdjoint
+    F.rightAdjoint ≅ G :=
+  haveI : F.IsLeftAdjoint := adj.isLeftAdjoint
+  (adj.rightAdjointUniq (Adjunction.ofIsLeftAdjoint F)).symm
+
+/-- If `F` and `G` are naturally isomorphic and one of them is a left adjoint, their right adjoints
+are isomorphic. -/
+noncomputable abbrev _root_.CategoryTheory.Functor.rightAdjointCongr
+    {F G : D ⥤ C} (i : F ≅ G) [F.IsLeftAdjoint] :
+    haveI := Functor.isLeftAdjoint_of_iso i
+    F.rightAdjoint ≅ G.rightAdjoint :=
+  haveI := Functor.isLeftAdjoint_of_iso i
+  ((Adjunction.ofIsLeftAdjoint F).ofNatIsoLeft i).rightAdjointUniq (Adjunction.ofIsLeftAdjoint G)
 
 -- Porting note (#10618): simp can prove this
 theorem homEquiv_symm_rightAdjointUniq_hom_app {F : C ⥤ D} {G G' : D ⥤ C} (adj1 : F ⊣ G)


### PR DESCRIPTION
This PR defines the notion of a discrete object with respect to a functor. This is an object in the essential image of a fully faithful left adjoint. 

---
The followup PR #13922 develops this API further for sheaf categories and #13925 provides an example (`TopCat`) showing that this notion is sensible.

- [x] depends on: #13923 

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
