### PR TITLE
[Merged by Bors] - doc(Analysis/Convex/Slope) : fix a typo, add docstrings

### DIFF
--- a/Mathlib/Analysis/Convex/Slope.lean
+++ b/Mathlib/Analysis/Convex/Slope.lean
@@ -267,6 +267,8 @@ theorem ConvexOn.secant_mono_aux3 (hf : ConvexOn 𝕜 s f) {x y z : 𝕜} (hx : 
   linarith only [hf.secant_mono_aux1 hx hz hxy hyz]
 #align convex_on.secant_mono_aux3 ConvexOn.secant_mono_aux3
 
+/-- If `f : 𝕜 → 𝕜` is convex, then for any point `a` the slope of the secant line of `f` through `a`
+and `b ≠ a` is monotone with respect to `b`. -/
 theorem ConvexOn.secant_mono (hf : ConvexOn 𝕜 s f) {a x y : 𝕜} (ha : a ∈ s) (hx : x ∈ s)
     (hy : y ∈ s) (hxa : x ≠ a) (hya : y ≠ a) (hxy : x ≤ y) :
     (f x - f a) / (x - a) ≤ (f y - f a) / (y - a) := by
@@ -317,6 +319,8 @@ theorem StrictConvexOn.secant_strict_mono_aux3 (hf : StrictConvexOn 𝕜 s f) {x
   linarith only [hf.secant_strict_mono_aux1 hx hz hxy hyz]
 #align strict_convex_on.secant_strict_mono_aux3 StrictConvexOn.secant_strict_mono_aux3
 
+/-- If `f : 𝕜 → 𝕜` is strictly convex, then for any point `a` the slope of the secant line of `f`
+through `a` and `b` is strictly monotone with respect to `b`. -/
 theorem StrictConvexOn.secant_strict_mono (hf : StrictConvexOn 𝕜 s f) {a x y : 𝕜} (ha : a ∈ s)
     (hx : x ∈ s) (hy : y ∈ s) (hxa : x ≠ a) (hya : y ≠ a) (hxy : x < y) :
     (f x - f a) / (x - a) < (f y - f a) / (y - a) := by
@@ -329,6 +333,8 @@ theorem StrictConvexOn.secant_strict_mono (hf : StrictConvexOn 𝕜 s f) {a x y 
   · exact hf.secant_strict_mono_aux2 ha hy hxa hxy
 #align strict_convex_on.secant_strict_mono StrictConvexOn.secant_strict_mono
 
+/-- If `f : 𝕜 → 𝕜` is strictly concave, then for any point `a` the slope of the secant line of `f`
+through `a` and `b` is strictly antitone with respect to `b`. -/
 theorem StrictConcaveOn.secant_strict_mono (hf : StrictConcaveOn 𝕜 s f) {a x y : 𝕜} (ha : a ∈ s)
     (hx : x ∈ s) (hy : y ∈ s) (hxa : x ≠ a) (hya : y ≠ a) (hxy : x < y) :
     (f y - f a) / (y - a) < (f x - f a) / (x - a) := by

--- a/Mathlib/Analysis/Convex/Slope.lean
+++ b/Mathlib/Analysis/Convex/Slope.lean
@@ -22,7 +22,7 @@ The main use is to show convexity/concavity from monotonicity of the derivative.
 variable {𝕜 : Type*} [LinearOrderedField 𝕜] {s : Set 𝕜} {f : 𝕜 → 𝕜}
 
 /-- If `f : 𝕜 → 𝕜` is convex, then for any three points `x < y < z` the slope of the secant line of
-`f` on `[x, y]` is less than the slope of the secant line of `f` on `[x, z]`. -/
+`f` on `[x, y]` is less than the slope of the secant line of `f` on `[y, z]`. -/
 theorem ConvexOn.slope_mono_adjacent (hf : ConvexOn 𝕜 s f) {x y z : 𝕜} (hx : x ∈ s) (hz : z ∈ s)
     (hxy : x < y) (hyz : y < z) : (f y - f x) / (y - x) ≤ (f z - f y) / (z - y) := by
   have hxz := hxy.trans hyz
@@ -46,7 +46,7 @@ theorem ConvexOn.slope_mono_adjacent (hf : ConvexOn 𝕜 s f) {x y z : 𝕜} (hx
 #align convex_on.slope_mono_adjacent ConvexOn.slope_mono_adjacent
 
 /-- If `f : 𝕜 → 𝕜` is concave, then for any three points `x < y < z` the slope of the secant line of
-`f` on `[x, y]` is greater than the slope of the secant line of `f` on `[x, z]`. -/
+`f` on `[x, y]` is greater than the slope of the secant line of `f` on `[y, z]`. -/
 theorem ConcaveOn.slope_anti_adjacent (hf : ConcaveOn 𝕜 s f) {x y z : 𝕜} (hx : x ∈ s) (hz : z ∈ s)
     (hxy : x < y) (hyz : y < z) : (f z - f y) / (z - y) ≤ (f y - f x) / (y - x) := by
   have := neg_le_neg (ConvexOn.slope_mono_adjacent hf.neg hx hz hxy hyz)
@@ -56,7 +56,7 @@ theorem ConcaveOn.slope_anti_adjacent (hf : ConcaveOn 𝕜 s f) {x y z : 𝕜} (
 
 /-- If `f : 𝕜 → 𝕜` is strictly convex, then for any three points `x < y < z` the slope of the
 secant line of `f` on `[x, y]` is strictly less than the slope of the secant line of `f` on
-`[x, z]`. -/
+`[y, z]`. -/
 theorem StrictConvexOn.slope_strict_mono_adjacent (hf : StrictConvexOn 𝕜 s f) {x y z : 𝕜}
     (hx : x ∈ s) (hz : z ∈ s) (hxy : x < y) (hyz : y < z) :
     (f y - f x) / (y - x) < (f z - f y) / (z - y) := by
@@ -82,7 +82,7 @@ theorem StrictConvexOn.slope_strict_mono_adjacent (hf : StrictConvexOn 𝕜 s f)
 
 /-- If `f : 𝕜 → 𝕜` is strictly concave, then for any three points `x < y < z` the slope of the
 secant line of `f` on `[x, y]` is strictly greater than the slope of the secant line of `f` on
-`[x, z]`. -/
+`[y, z]`. -/
 theorem StrictConcaveOn.slope_anti_adjacent (hf : StrictConcaveOn 𝕜 s f) {x y z : 𝕜} (hx : x ∈ s)
     (hz : z ∈ s) (hxy : x < y) (hyz : y < z) : (f z - f y) / (z - y) < (f y - f x) / (y - x) := by
   have := neg_lt_neg (StrictConvexOn.slope_strict_mono_adjacent hf.neg hx hz hxy hyz)
@@ -91,7 +91,7 @@ theorem StrictConcaveOn.slope_anti_adjacent (hf : StrictConcaveOn 𝕜 s f) {x y
 #align strict_concave_on.slope_anti_adjacent StrictConcaveOn.slope_anti_adjacent
 
 /-- If for any three points `x < y < z`, the slope of the secant line of `f : 𝕜 → 𝕜` on `[x, y]` is
-less than the slope of the secant line of `f` on `[x, z]`, then `f` is convex. -/
+less than the slope of the secant line of `f` on `[y, z]`, then `f` is convex. -/
 theorem convexOn_of_slope_mono_adjacent (hs : Convex 𝕜 s)
     (hf :
       ∀ {x y z : 𝕜},
@@ -124,7 +124,7 @@ theorem convexOn_of_slope_mono_adjacent (hs : Convex 𝕜 s)
 #align convex_on_of_slope_mono_adjacent convexOn_of_slope_mono_adjacent
 
 /-- If for any three points `x < y < z`, the slope of the secant line of `f : 𝕜 → 𝕜` on `[x, y]` is
-greater than the slope of the secant line of `f` on `[x, z]`, then `f` is concave. -/
+greater than the slope of the secant line of `f` on `[y, z]`, then `f` is concave. -/
 theorem concaveOn_of_slope_anti_adjacent (hs : Convex 𝕜 s)
     (hf :
       ∀ {x y z : 𝕜},
@@ -138,7 +138,7 @@ theorem concaveOn_of_slope_anti_adjacent (hs : Convex 𝕜 s)
 #align concave_on_of_slope_anti_adjacent concaveOn_of_slope_anti_adjacent
 
 /-- If for any three points `x < y < z`, the slope of the secant line of `f : 𝕜 → 𝕜` on `[x, y]` is
-strictly less than the slope of the secant line of `f` on `[x, z]`, then `f` is strictly convex. -/
+strictly less than the slope of the secant line of `f` on `[y, z]`, then `f` is strictly convex. -/
 theorem strictConvexOn_of_slope_strict_mono_adjacent (hs : Convex 𝕜 s)
     (hf :
       ∀ {x y z : 𝕜},
@@ -171,7 +171,7 @@ theorem strictConvexOn_of_slope_strict_mono_adjacent (hs : Convex 𝕜 s)
 #align strict_convex_on_of_slope_strict_mono_adjacent strictConvexOn_of_slope_strict_mono_adjacent
 
 /-- If for any three points `x < y < z`, the slope of the secant line of `f : 𝕜 → 𝕜` on `[x, y]` is
-strictly greater than the slope of the secant line of `f` on `[x, z]`, then `f` is strictly concave.
+strictly greater than the slope of the secant line of `f` on `[y, z]`, then `f` is strictly concave.
 -/
 theorem strictConcaveOn_of_slope_strict_anti_adjacent (hs : Convex 𝕜 s)
     (hf :
@@ -186,7 +186,7 @@ theorem strictConcaveOn_of_slope_strict_anti_adjacent (hs : Convex 𝕜 s)
 #align strict_concave_on_of_slope_strict_anti_adjacent strictConcaveOn_of_slope_strict_anti_adjacent
 
 /-- A function `f : 𝕜 → 𝕜` is convex iff for any three points `x < y < z` the slope of the secant
-line of `f` on `[x, y]` is less than the slope of the secant line of `f` on `[x, z]`. -/
+line of `f` on `[x, y]` is less than the slope of the secant line of `f` on `[y, z]`. -/
 theorem convexOn_iff_slope_mono_adjacent :
     ConvexOn 𝕜 s f ↔
       Convex 𝕜 s ∧ ∀ ⦃x y z : 𝕜⦄,
@@ -196,7 +196,7 @@ theorem convexOn_iff_slope_mono_adjacent :
 #align convex_on_iff_slope_mono_adjacent convexOn_iff_slope_mono_adjacent
 
 /-- A function `f : 𝕜 → 𝕜` is concave iff for any three points `x < y < z` the slope of the secant
-line of `f` on `[x, y]` is greater than the slope of the secant line of `f` on `[x, z]`. -/
+line of `f` on `[x, y]` is greater than the slope of the secant line of `f` on `[y, z]`. -/
 theorem concaveOn_iff_slope_anti_adjacent :
     ConcaveOn 𝕜 s f ↔
       Convex 𝕜 s ∧
@@ -208,7 +208,7 @@ theorem concaveOn_iff_slope_anti_adjacent :
 
 /-- A function `f : 𝕜 → 𝕜` is strictly convex iff for any three points `x < y < z` the slope of
 the secant line of `f` on `[x, y]` is strictly less than the slope of the secant line of `f` on
-`[x, z]`. -/
+`[y, z]`. -/
 theorem strictConvexOn_iff_slope_strict_mono_adjacent :
     StrictConvexOn 𝕜 s f ↔
       Convex 𝕜 s ∧
@@ -220,7 +220,7 @@ theorem strictConvexOn_iff_slope_strict_mono_adjacent :
 
 /-- A function `f : 𝕜 → 𝕜` is strictly concave iff for any three points `x < y < z` the slope of
 the secant line of `f` on `[x, y]` is strictly greater than the slope of the secant line of `f` on
-`[x, z]`. -/
+`[y, z]`. -/
 theorem strictConcaveOn_iff_slope_strict_anti_adjacent :
     StrictConcaveOn 𝕜 s f ↔
       Convex 𝕜 s ∧

--- a/Mathlib/Analysis/Convex/Slope.lean
+++ b/Mathlib/Analysis/Convex/Slope.lean
@@ -245,9 +245,7 @@ theorem ConvexOn.secant_mono_aux1 (hf : ConvexOn 𝕜 s f) {x y z : 𝕜} (hx : 
   · congr 1
     field_simp
     ring
-  · -- Porting note: this `show` wasn't needed in Lean 3
-    show (z - y) / (z - x) + (y - x) / (z - x) = 1
-    field_simp
+  · field_simp
   · field_simp
 #align convex_on.secant_mono_aux1 ConvexOn.secant_mono_aux1
 
@@ -297,9 +295,7 @@ theorem StrictConvexOn.secant_strict_mono_aux1 (hf : StrictConvexOn 𝕜 s f) {x
   · congr 1
     field_simp
     ring
-  · -- Porting note: this `show` wasn't needed in Lean 3
-    show (z - y) / (z - x) + (y - x) / (z - x) = 1
-    field_simp
+  · field_simp
   · field_simp
 #align strict_convex_on.secant_strict_mono_aux1 StrictConvexOn.secant_strict_mono_aux1
 


### PR DESCRIPTION
- Fix a typo in the docstrings (`[x, z]` instead of `[y, z]`). Happens multiple times in the file.
- Add docstrings for `ConvexOn.secant_mono`, `StrictConvexOn.secant_strict_mono` and `StrictConcaveOn.secant_strict_mono`.
- Remove a `show` tactic. It was added during the porting, but it seems that it is no longer needed. Happens twice.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
