### PR TITLE
[Merged by Bors] - feat: add Repr instance for quaternions

### DIFF
--- a/Mathlib/Algebra/Quaternion.lean
+++ b/Mathlib/Algebra/Quaternion.lean
@@ -1562,7 +1562,7 @@ theorem mk_univ_quaternionAlgebra_of_infinite [Infinite R] :
 For the typical case of quaternions over ℝ, each component will show as a Cauchy sequence due to
 the way Real numbers are represented.
 -/
-unsafe instance [Repr R] {a b : R} : Repr ℍ[R, a, b] where
+instance [Repr R] {a b : R} : Repr ℍ[R, a, b] where
   reprPrec q _ :=
     s!"\{ re := {repr q.re}, imI := {repr q.imI}, imJ := {repr q.imJ}, imK := {repr q.imK} }"
 

--- a/Mathlib/Algebra/Quaternion.lean
+++ b/Mathlib/Algebra/Quaternion.lean
@@ -1557,6 +1557,15 @@ theorem mk_univ_quaternionAlgebra_of_infinite [Infinite R] :
     #(Set.univ : Set ℍ[R,c₁,c₂]) = #R := by rw [mk_univ_quaternionAlgebra, pow_four]
 #align cardinal.mk_univ_quaternion_algebra_of_infinite Cardinal.mk_univ_quaternionAlgebra_of_infinite
 
+/-- Show the quaternion ⟨w, x, y, z⟩ as a string "{ re := w, imI := x, imJ := y, imK := z }".
+
+For the typical case of quaternions over ℝ, each component will show as a Cauchy sequence due to
+the way Real numbers are represented.
+-/
+unsafe instance [Repr R] {a b : R} : Repr ℍ[R, a, b] where
+  reprPrec q _ :=
+    s!"\{ re := {repr q.re}, imI := {repr q.imI}, imJ := {repr q.imJ}, imK := {repr q.imK} }"
+
 end QuaternionAlgebra
 
 section Quaternion

--- a/test/Quaternion.lean
+++ b/test/Quaternion.lean
@@ -1,0 +1,40 @@
+import Mathlib.Algebra.Quaternion
+import Mathlib.Data.Real.Basic
+import Mathlib.NumberTheory.Zsqrtd.GaussianInt
+
+open Quaternion
+/--
+info: { re := 0, imI := 0, imJ := 0, imK := 0 }
+-/
+#guard_msgs in
+#eval (0 : ℍ[ℚ])
+
+/--
+info: { re := 1, imI := 0, imJ := 0, imK := 0 }
+-/
+#guard_msgs in
+#eval (1 : ℍ[ℚ])
+
+/--
+info: { re := 4, imI := 0, imJ := 0, imK := 0 }
+-/
+#guard_msgs in
+#eval (4 : ℍ[ℚ])
+
+/--
+info: { re := Real.ofCauchy (sorry /- 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, ... -/), imI := Real.ofCauchy (sorry /- 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, ... -/), imJ := Real.ofCauchy (sorry /- 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, ... -/), imK := Real.ofCauchy (sorry /- 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, ... -/) }
+-/
+#guard_msgs in
+#eval (⟨0, 0, 0, 0⟩ : ℍ[ℝ])
+
+/--
+info: { re := Real.ofCauchy (sorry /- 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, ... -/), imI := Real.ofCauchy (sorry /- 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, ... -/), imJ := Real.ofCauchy (sorry /- 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, ... -/), imK := Real.ofCauchy (sorry /- 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, ... -/) }
+-/
+#guard_msgs in
+#eval (⟨1, 2, 3, 4⟩ : ℍ[ℝ])
+
+/--
+info: { re := ⟨0, 0⟩, imI := ⟨0, 0⟩, imJ := ⟨0, 0⟩, imK := ⟨0, 0⟩ }
+-/
+#guard_msgs in
+#eval (0 : ℍ[GaussianInt])


### PR DESCRIPTION
Adds a Repr instance for QuaternionAlgebra. A quaternion <w, x, y, z> is shown as "{ re := w, imI := x, imJ := y, imK := z }". The components are displayed as Cauchy sequences for quaternions over the Reals. 

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
