### PR TITLE
[Merged by Bors] - feat: `ExistsAddOfLE` lemmas

### DIFF
--- a/Mathlib/Algebra/Order/Monoid/Unbundled/ExistsOfLE.lean
+++ b/Mathlib/Algebra/Order/Monoid/Unbundled/ExistsOfLE.lean
@@ -1,8 +1,9 @@
 /-
-Copyright (c) 2016 Jeremy Avigad. All rights reserved.
+Copyright (c) 2021 Peter Nelson. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Jeremy Avigad, Leonardo de Moura, Mario Carneiro, Johannes Hölzl
+Authors: Peter Nelson, Yaël Dillies
 -/
+import Mathlib.Algebra.Order.Group.Synonym
 import Mathlib.Algebra.Order.Monoid.Unbundled.Basic
 import Mathlib.Order.MinMax
 
@@ -14,14 +15,6 @@ universe u
 
 
 variable {α : Type u}
-
-/-- An `OrderedCommMonoid` with one-sided 'division' in the sense that
-if `a ≤ b`, there is some `c` for which `a * c = b`. This is a weaker version
-of the condition on canonical orderings defined by `CanonicallyOrderedCommMonoid`. -/
-class ExistsMulOfLE (α : Type u) [Mul α] [LE α] : Prop where
-  /-- For `a ≤ b`, `a` left divides `b` -/
-  exists_mul_of_le : ∀ {a b : α}, a ≤ b → ∃ c : α, b = a * c
-
 /-- An `OrderedAddCommMonoid` with one-sided 'subtraction' in the sense that
 if `a ≤ b`, then there is some `c` for which `a + c = b`. This is a weaker version
 of the condition on canonical orderings defined by `CanonicallyOrderedAddCommMonoid`. -/
@@ -29,11 +22,52 @@ class ExistsAddOfLE (α : Type u) [Add α] [LE α] : Prop where
   /-- For `a ≤ b`, there is a `c` so `b = a + c`. -/
   exists_add_of_le : ∀ {a b : α}, a ≤ b → ∃ c : α, b = a + c
 
-attribute [to_additive] ExistsMulOfLE
+/-- An `OrderedCommMonoid` with one-sided 'division' in the sense that
+if `a ≤ b`, there is some `c` for which `a * c = b`. This is a weaker version
+of the condition on canonical orderings defined by `CanonicallyOrderedCommMonoid`. -/
+@[to_additive]
+class ExistsMulOfLE (α : Type u) [Mul α] [LE α] : Prop where
+  /-- For `a ≤ b`, `a` left divides `b` -/
+  exists_mul_of_le : ∀ {a b : α}, a ≤ b → ∃ c : α, b = a * c
+
+/-- Prop-valued mixin for the condition that either `α` or `αᵒᵈ` respects `ExistsAddOfLE`.
+
+This is useful to dualise results. -/
+class ExistsAddOfLEOrGE (α : Type u) [Add α] [LE α] : Prop where
+  exists_add_of_le_or_ge :
+    (∀ {a b : α}, a ≤ b → ∃ c, b = a + c) ∨ ∀ {a b : α}, b ≤ a → ∃ c, b = a + c
+
+/-- Prop-valued mixin for the condition that either `α` or `αᵒᵈ` respects `ExistsMulOfLE`.
+
+This is useful to dualise results. -/
+@[to_additive]
+class ExistsMulOfLEOrGE (α : Type u) [Mul α] [LE α] : Prop where
+  exists_mul_of_le_or_ge :
+    (∀ {a b : α}, a ≤ b → ∃ c, b = a * c) ∨ ∀ {a b : α}, b ≤ a → ∃ c, b = a * c
 
 export ExistsMulOfLE (exists_mul_of_le)
-
 export ExistsAddOfLE (exists_add_of_le)
+export ExistsMulOfLEOrGE (exists_mul_of_le_or_ge)
+export ExistsAddOfLEOrGE (exists_add_of_le_or_ge)
+
+section Mul
+variable [Mul α] [LE α]
+
+-- See note [lower instance priority]
+@[to_additive]
+instance (priority := 100) ExistsMulOfLE.toExistsMulOfLEOrGE [ExistsMulOfLE α] :
+    ExistsMulOfLEOrGE α where
+  exists_mul_of_le_or_ge := .inl exists_mul_of_le
+
+@[to_additive] instance OrderDual.instExistsMulOfLEOrGE [ExistsMulOfLEOrGE α] :
+    ExistsMulOfLEOrGE αᵒᵈ where
+  exists_mul_of_le_or_ge := (exists_mul_of_le_or_ge (α := α)).symm
+
+variable (α) in
+@[to_additive] lemma existsMulOfLE_or_existsMulOfLE_orderDual [ExistsMulOfLEOrGE α] :
+    ExistsMulOfLE α ∨ ExistsMulOfLE αᵒᵈ := exists_mul_of_le_or_ge.imp (⟨·⟩) (⟨·⟩)
+
+end Mul
 
 -- See note [lower instance priority]
 @[to_additive]
@@ -41,14 +75,23 @@ instance (priority := 100) Group.existsMulOfLE (α : Type u) [Group α] [LE α] 
   ⟨fun {a b} _ => ⟨a⁻¹ * b, (mul_inv_cancel_left _ _).symm⟩⟩
 
 section MulOneClass
+variable [MulOneClass α] [Preorder α] [ExistsMulOfLE α] {a b : α}
 
-variable [MulOneClass α] [Preorder α] [ContravariantClass α α (· * ·) (· < ·)] [ExistsMulOfLE α]
-  {a b : α}
+@[to_additive] lemma exists_one_le_mul_of_le [ContravariantClass α α (· * ·) (· ≤ ·)] (h : a ≤ b) :
+    ∃ c, 1 ≤ c ∧ a * c = b := by
+  obtain ⟨c, rfl⟩ := exists_mul_of_le h; exact ⟨c, one_le_of_le_mul_right h, rfl⟩
 
-@[to_additive]
-theorem exists_one_lt_mul_of_lt' (h : a < b) : ∃ c, 1 < c ∧ a * c = b := by
-  obtain ⟨c, rfl⟩ := exists_mul_of_le h.le
-  exact ⟨c, one_lt_of_lt_mul_right h, rfl⟩
+@[to_additive] lemma exists_one_lt_mul_of_lt' [ContravariantClass α α (· * ·) (· < ·)] (h : a < b) :
+    ∃ c, 1 < c ∧ a * c = b := by
+  obtain ⟨c, rfl⟩ := exists_mul_of_le h.le; exact ⟨c, one_lt_of_lt_mul_right h, rfl⟩
+
+@[to_additive] lemma le_iff_exists_one_le_mul [CovariantClass α α (· * ·) (· ≤ ·)]
+    [ContravariantClass α α (· * ·) (· ≤ ·)] : a ≤ b ↔ ∃ c, 1 ≤ c ∧ a * c = b :=
+  ⟨exists_one_le_mul_of_le, by rintro ⟨c, hc, rfl⟩; exact le_mul_of_one_le_right' hc⟩
+
+@[to_additive] lemma lt_iff_exists_one_lt_mul [CovariantClass α α (· * ·) (· < ·)]
+    [ContravariantClass α α (· * ·) (· < ·)] : a < b ↔ ∃ c, 1 < c ∧ a * c = b :=
+  ⟨exists_one_lt_mul_of_lt', by rintro ⟨c, hc, rfl⟩; exact lt_mul_of_one_lt_right' _ hc⟩
 
 end MulOneClass
 
@@ -72,5 +115,3 @@ theorem le_iff_forall_one_lt_lt_mul' : a ≤ b ↔ ∀ ε, 1 < ε → a < b * ε
   ⟨fun h _ => lt_mul_of_le_of_one_lt h, le_of_forall_one_lt_lt_mul'⟩
 
 end ExistsMulOfLE
-
-

--- a/Mathlib/Algebra/Order/Monoid/Unbundled/ExistsOfLE.lean
+++ b/Mathlib/Algebra/Order/Monoid/Unbundled/ExistsOfLE.lean
@@ -3,7 +3,6 @@ Copyright (c) 2021 Peter Nelson. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Peter Nelson, Yaël Dillies
 -/
-import Mathlib.Algebra.Order.Group.Synonym
 import Mathlib.Algebra.Order.Monoid.Unbundled.Basic
 import Mathlib.Order.MinMax
 

--- a/Mathlib/Algebra/Order/Monoid/Unbundled/ExistsOfLE.lean
+++ b/Mathlib/Algebra/Order/Monoid/Unbundled/ExistsOfLE.lean
@@ -9,12 +9,16 @@ import Mathlib.Order.MinMax
 
 /-!
 # Unbundled and weaker forms of canonically ordered monoids
+
+This file provides a Prop-valued mixin for monoids satisfying a one-sided cancellativity property,
+namely that there is some `c` such that `b = a + c` if `a ≤ b`. This is particularly useful for
+generalising statements from groups/rings/fields that don't mention negation or subtraction to
+monoids/semirings/semifields.
 -/
 
 universe u
-
-
 variable {α : Type u}
+
 /-- An `OrderedAddCommMonoid` with one-sided 'subtraction' in the sense that
 if `a ≤ b`, then there is some `c` for which `a + c = b`. This is a weaker version
 of the condition on canonical orderings defined by `CanonicallyOrderedAddCommMonoid`. -/
@@ -30,44 +34,8 @@ class ExistsMulOfLE (α : Type u) [Mul α] [LE α] : Prop where
   /-- For `a ≤ b`, `a` left divides `b` -/
   exists_mul_of_le : ∀ {a b : α}, a ≤ b → ∃ c : α, b = a * c
 
-/-- Prop-valued mixin for the condition that either `α` or `αᵒᵈ` respects `ExistsAddOfLE`.
-
-This is useful to dualise results. -/
-class ExistsAddOfLEOrGE (α : Type u) [Add α] [LE α] : Prop where
-  exists_add_of_le_or_ge :
-    (∀ {a b : α}, a ≤ b → ∃ c, b = a + c) ∨ ∀ {a b : α}, b ≤ a → ∃ c, b = a + c
-
-/-- Prop-valued mixin for the condition that either `α` or `αᵒᵈ` respects `ExistsMulOfLE`.
-
-This is useful to dualise results. -/
-@[to_additive]
-class ExistsMulOfLEOrGE (α : Type u) [Mul α] [LE α] : Prop where
-  exists_mul_of_le_or_ge :
-    (∀ {a b : α}, a ≤ b → ∃ c, b = a * c) ∨ ∀ {a b : α}, b ≤ a → ∃ c, b = a * c
-
 export ExistsMulOfLE (exists_mul_of_le)
 export ExistsAddOfLE (exists_add_of_le)
-export ExistsMulOfLEOrGE (exists_mul_of_le_or_ge)
-export ExistsAddOfLEOrGE (exists_add_of_le_or_ge)
-
-section Mul
-variable [Mul α] [LE α]
-
--- See note [lower instance priority]
-@[to_additive]
-instance (priority := 100) ExistsMulOfLE.toExistsMulOfLEOrGE [ExistsMulOfLE α] :
-    ExistsMulOfLEOrGE α where
-  exists_mul_of_le_or_ge := .inl exists_mul_of_le
-
-@[to_additive] instance OrderDual.instExistsMulOfLEOrGE [ExistsMulOfLEOrGE α] :
-    ExistsMulOfLEOrGE αᵒᵈ where
-  exists_mul_of_le_or_ge := (exists_mul_of_le_or_ge (α := α)).symm
-
-variable (α) in
-@[to_additive] lemma existsMulOfLE_or_existsMulOfLE_orderDual [ExistsMulOfLEOrGE α] :
-    ExistsMulOfLE α ∨ ExistsMulOfLE αᵒᵈ := exists_mul_of_le_or_ge.imp (⟨·⟩) (⟨·⟩)
-
-end Mul
 
 -- See note [lower instance priority]
 @[to_additive]

--- a/Mathlib/Algebra/Order/Ring/Unbundled/Basic.lean
+++ b/Mathlib/Algebra/Order/Ring/Unbundled/Basic.lean
@@ -362,16 +362,6 @@ theorem Antitone.mul [ExistsAddOfLE α] [PosMulMono α] [MulPosMono α]
     Monotone (f * g) := fun _ _ h => mul_le_mul_of_nonpos_of_nonpos (hf h) (hg h) (hf₀ _) (hg₀ _)
 
 end Monotone
-
-lemma le_iff_exists_nonneg_add
-    [ExistsAddOfLE α] [ContravariantClass α α (· + ·) (· ≤ ·)] [CovariantClass α α (· + ·) (· ≤ ·)]
-    (a b : α) : a ≤ b ↔ ∃ c ≥ 0, b = a + c := by
-  refine ⟨fun h ↦ ?_, ?_⟩
-  · obtain ⟨c, rfl⟩ := exists_add_of_le h
-    exact ⟨c, nonneg_of_le_add_right h, rfl⟩
-  · rintro ⟨c, hc, rfl⟩
-    exact le_add_of_nonneg_right hc
-
 end OrderedSemiring
 
 section OrderedCommRing
@@ -563,9 +553,9 @@ lemma mul_add_mul_le_mul_add_mul [ExistsAddOfLE α] [MulPosMono α]
     [CovariantClass α α (· + ·) (· ≤ ·)] [ContravariantClass α α (· + ·) (· ≤ ·)]
     (hab : a ≤ b) (hcd : c ≤ d) : a * d + b * c ≤ a * c + b * d := by
   obtain ⟨b, rfl⟩ := exists_add_of_le hab
-  obtain ⟨d, rfl⟩ := exists_add_of_le hcd
+  obtain ⟨d, hd, rfl⟩ := exists_nonneg_add_of_le hcd
   rw [mul_add, add_right_comm, mul_add, ← add_assoc]
-  exact add_le_add_left (mul_le_mul_of_nonneg_right hab <| (le_add_iff_nonneg_right _).1 hcd) _
+  exact add_le_add_left (mul_le_mul_of_nonneg_right hab hd) _
 
 /-- Binary **rearrangement inequality**. -/
 lemma mul_add_mul_le_mul_add_mul' [ExistsAddOfLE α] [MulPosMono α]
@@ -580,9 +570,9 @@ lemma mul_add_mul_lt_mul_add_mul [ExistsAddOfLE α] [MulPosStrictMono α]
     [CovariantClass α α (· + ·) (· < ·)]
     (hab : a < b) (hcd : c < d) : a * d + b * c < a * c + b * d := by
   obtain ⟨b, rfl⟩ := exists_add_of_le hab.le
-  obtain ⟨d, rfl⟩ := exists_add_of_le hcd.le
+  obtain ⟨d, hd, rfl⟩ := exists_pos_add_of_lt' hcd
   rw [mul_add, add_right_comm, mul_add, ← add_assoc]
-  exact add_lt_add_left (mul_lt_mul_of_pos_right hab <| (lt_add_iff_pos_right _).1 hcd) _
+  exact add_lt_add_left (mul_lt_mul_of_pos_right hab hd) _
 
 /-- Binary **rearrangement inequality**. -/
 lemma mul_add_mul_lt_mul_add_mul' [ExistsAddOfLE α] [MulPosStrictMono α]

--- a/Mathlib/Data/Int/Star.lean
+++ b/Mathlib/Data/Int/Star.lean
@@ -31,6 +31,6 @@ lemma addSubmonoid_closure_range_mul_self : closure (range fun x : ℤ ↦ x * x
   simpa only [sq] using addSubmonoid_closure_range_pow even_two
 
 instance instStarOrderedRing : StarOrderedRing ℤ where
-  le_iff a b := by simp [le_iff_exists_nonneg_add a b]
+  le_iff a b := by simp [eq_comm, le_iff_exists_nonneg_add (a := a)]
 
 end Int

--- a/Mathlib/Data/Rat/Star.lean
+++ b/Mathlib/Data/Rat/Star.lean
@@ -38,7 +38,7 @@ namespace NNRat
   simpa only [sq] using addSubmonoid_closure_range_pow two_ne_zero
 
 instance instStarOrderedRing : StarOrderedRing ℚ≥0 where
-  le_iff a b := by simp [le_iff_exists_nonneg_add a b]
+  le_iff a b := by simp [eq_comm, le_iff_exists_nonneg_add (a := a)]
 
 end NNRat
 
@@ -57,6 +57,6 @@ lemma addSubmonoid_closure_range_mul_self : closure (range fun x : ℚ ↦ x * x
   simpa only [sq] using addSubmonoid_closure_range_pow two_ne_zero even_two
 
 instance instStarOrderedRing : StarOrderedRing ℚ where
-  le_iff a b := by simp [le_iff_exists_nonneg_add a b]
+  le_iff a b := by simp [eq_comm, le_iff_exists_nonneg_add (a := a)]
 
 end Rat


### PR DESCRIPTION
Add a few convenient versions of `le_iff_exists_add`.

From LeanAPAP

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
