### PR TITLE
[Merged by Bors] - chore/perf(Analysis): replace continuity -> fun_prop

### DIFF
--- a/Mathlib/Analysis/Calculus/FDeriv/Measurable.lean
+++ b/Mathlib/Analysis/Calculus/FDeriv/Measurable.lean
@@ -854,11 +854,7 @@ lemma isOpen_A_with_param {r s : ℝ} (hf : Continuous f.uncurry) (L : E →L[�
   rcases exists_between hrt with ⟨t', hrt', ht't⟩
   obtain ⟨b, b_lt, hb⟩ : ∃ b, b < s * r ∧ ∀ y ∈ closedBall x t, ∀ z ∈ closedBall x t,
       ‖f a z - f a y - (L z - L y)‖ ≤ b := by
-    have B : Continuous (fun (p : E × E) ↦ ‖f a p.2 - f a p.1 - (L p.2 - L p.1)‖) := by
-      -- `continuity` took several seconds to solve this.
-      refine continuous_norm.comp' <| Continuous.sub ?_ ?_
-      · exact ha.comp' continuous_snd |>.sub <| ha.comp' continuous_fst
-      · exact L.continuous.comp' continuous_snd |>.sub <| L.continuous.comp' continuous_fst
+    have B : Continuous (fun (p : E × E) ↦ ‖f a p.2 - f a p.1 - (L p.2 - L p.1)‖) := by fun_prop
     have C : (closedBall x t ×ˢ closedBall x t).Nonempty := by simp; linarith
     rcases ((isCompact_closedBall x t).prod (isCompact_closedBall x t)).exists_isMaxOn
       C B.continuousOn with ⟨p, pt, hp⟩
@@ -871,9 +867,7 @@ lemma isOpen_A_with_param {r s : ℝ} (hf : Continuous f.uncurry) (L : E →L[�
     ⟨(s * r - b) / 3, by linarith, by linarith⟩
   obtain ⟨u, u_open, au, hu⟩ : ∃ u, IsOpen u ∧ a ∈ u ∧ ∀ (p : α × E),
       p.1 ∈ u → p.2 ∈ closedBall x t → dist (f.uncurry p) (f.uncurry (a, p.2)) < ε := by
-    have C : Continuous (fun (p : α × E) ↦ f a p.2) :=
-      -- `continuity` took several seconds to solve this.
-      ha.comp' continuous_snd
+    have C : Continuous (fun (p : α × E) ↦ f a p.2) := by fun_prop
     have D : ({a} ×ˢ closedBall x t).EqOn f.uncurry (fun p ↦ f a p.2) := by
       rintro ⟨b, y⟩ ⟨hb, -⟩
       simp only [mem_singleton_iff] at hb

--- a/Mathlib/Analysis/Calculus/LineDeriv/Basic.lean
+++ b/Mathlib/Analysis/Calculus/LineDeriv/Basic.lean
@@ -237,7 +237,7 @@ theorem HasLineDerivWithinAt.mono_of_mem
     HasLineDerivWithinAt 𝕜 f f' s x v := by
   apply HasDerivWithinAt.mono_of_mem h
   apply ContinuousWithinAt.preimage_mem_nhdsWithin'' _ hst (by simp)
-  apply Continuous.continuousWithinAt; continuity
+  apply Continuous.continuousWithinAt; fun_prop
 
 theorem HasLineDerivWithinAt.hasLineDerivAt
     (h : HasLineDerivWithinAt 𝕜 f f' s x v) (hs : s ∈ 𝓝 x) :
@@ -276,7 +276,7 @@ theorem lineDerivWithin_of_mem_nhds (h : s ∈ 𝓝 x) :
     lineDerivWithin 𝕜 f s x v = lineDeriv 𝕜 f x v := by
   apply derivWithin_of_mem_nhds
   apply (Continuous.continuousAt _).preimage_mem_nhds (by simpa using h)
-  continuity
+  fun_prop
 
 theorem lineDerivWithin_of_isOpen (hs : IsOpen s) (hx : x ∈ s) :
     lineDerivWithin 𝕜 f s x v = lineDeriv 𝕜 f x v :=
@@ -286,7 +286,7 @@ theorem hasLineDerivWithinAt_congr_set (h : s =ᶠ[𝓝 x] t) :
     HasLineDerivWithinAt 𝕜 f f' s x v ↔ HasLineDerivWithinAt 𝕜 f f' t x v := by
   apply hasDerivWithinAt_congr_set
   let F := fun (t : 𝕜) ↦ x + t • v
-  have B : ContinuousAt F 0 := by apply Continuous.continuousAt; continuity
+  have B : ContinuousAt F 0 := by apply Continuous.continuousAt; fun_prop
   have : s =ᶠ[𝓝 (F 0)] t := by convert h; simp [F]
   exact B.preimage_mem_nhds this
 
@@ -301,7 +301,7 @@ theorem lineDerivWithin_congr_set (h : s =ᶠ[𝓝 x] t) :
     lineDerivWithin 𝕜 f s x v = lineDerivWithin 𝕜 f t x v := by
   apply derivWithin_congr_set
   let F := fun (t : 𝕜) ↦ x + t • v
-  have B : ContinuousAt F 0 := by apply Continuous.continuousAt; continuity
+  have B : ContinuousAt F 0 := by apply Continuous.continuousAt; fun_prop
   have : s =ᶠ[𝓝 (F 0)] t := by convert h; simp [F]
   exact B.preimage_mem_nhds this
 
@@ -309,7 +309,7 @@ theorem Filter.EventuallyEq.hasLineDerivAt_iff (h : f₀ =ᶠ[𝓝 x] f₁) :
     HasLineDerivAt 𝕜 f₀ f' x v ↔ HasLineDerivAt 𝕜 f₁ f' x v := by
   apply hasDerivAt_iff
   let F := fun (t : 𝕜) ↦ x + t • v
-  have B : ContinuousAt F 0 := by apply Continuous.continuousAt; continuity
+  have B : ContinuousAt F 0 := by apply Continuous.continuousAt; fun_prop
   have : f₀ =ᶠ[𝓝 (F 0)] f₁ := by convert h; simp [F]
   exact B.preimage_mem_nhds this
 
@@ -321,7 +321,7 @@ theorem Filter.EventuallyEq.lineDifferentiableAt_iff (h : f₀ =ᶠ[𝓝 x] f₁
 theorem Filter.EventuallyEq.hasLineDerivWithinAt_iff (h : f₀ =ᶠ[𝓝[s] x] f₁) (hx : f₀ x = f₁ x) :
     HasLineDerivWithinAt 𝕜 f₀ f' s x v ↔ HasLineDerivWithinAt 𝕜 f₁ f' s x v := by
   apply hasDerivWithinAt_iff
-  · have A : Continuous (fun (t : 𝕜) ↦ x + t • v) := by continuity
+  · have A : Continuous (fun (t : 𝕜) ↦ x + t • v) := by fun_prop
     exact A.continuousWithinAt.preimage_mem_nhdsWithin'' h (by simp)
   · simpa using hx
 
@@ -343,7 +343,7 @@ theorem Filter.EventuallyEq.lineDifferentiableWithinAt_iff_of_mem
 lemma HasLineDerivWithinAt.congr_of_eventuallyEq (hf : HasLineDerivWithinAt 𝕜 f f' s x v)
     (h'f : f₁ =ᶠ[𝓝[s] x] f) (hx : f₁ x = f x) : HasLineDerivWithinAt 𝕜 f₁ f' s x v := by
   apply HasDerivWithinAt.congr_of_eventuallyEq hf _ (by simp [hx])
-  have A : Continuous (fun (t : 𝕜) ↦ x + t • v) := by continuity
+  have A : Continuous (fun (t : 𝕜) ↦ x + t • v) := by fun_prop
   exact A.continuousWithinAt.preimage_mem_nhdsWithin'' h'f (by simp)
 
 theorem HasLineDerivAt.congr_of_eventuallyEq (h : HasLineDerivAt 𝕜 f f' x v) (h₁ : f₁ =ᶠ[𝓝 x] f) :
@@ -351,7 +351,7 @@ theorem HasLineDerivAt.congr_of_eventuallyEq (h : HasLineDerivAt 𝕜 f f' x v) 
   apply HasDerivAt.congr_of_eventuallyEq h
   let F := fun (t : 𝕜) ↦ x + t • v
   rw [show x = F 0 by simp [F]] at h₁
-  exact (Continuous.continuousAt (by continuity)).preimage_mem_nhds h₁
+  exact (Continuous.continuousAt (by fun_prop)).preimage_mem_nhds h₁
 
 theorem LineDifferentiableWithinAt.congr_of_eventuallyEq (h : LineDifferentiableWithinAt 𝕜 f s x v)
     (h₁ : f₁ =ᶠ[𝓝[s] x] f) (hx : f₁ x = f x) : LineDifferentiableWithinAt 𝕜 f₁ s x v :=
@@ -363,12 +363,12 @@ theorem LineDifferentiableAt.congr_of_eventuallyEq
   apply DifferentiableAt.congr_of_eventuallyEq h
   let F := fun (t : 𝕜) ↦ x + t • v
   rw [show x = F 0 by simp [F]] at hL
-  exact (Continuous.continuousAt (by continuity)).preimage_mem_nhds hL
+  exact (Continuous.continuousAt (by fun_prop)).preimage_mem_nhds hL
 
 theorem Filter.EventuallyEq.lineDerivWithin_eq (hs : f₁ =ᶠ[𝓝[s] x] f) (hx : f₁ x = f x) :
     lineDerivWithin 𝕜 f₁ s x v = lineDerivWithin 𝕜 f s x v := by
   apply derivWithin_eq ?_ (by simpa using hx)
-  have A : Continuous (fun (t : 𝕜) ↦ x + t • v) := by continuity
+  have A : Continuous (fun (t : 𝕜) ↦ x + t • v) := by fun_prop
   exact A.continuousWithinAt.preimage_mem_nhdsWithin'' hs (by simp)
 
 theorem Filter.EventuallyEq.lineDerivWithin_eq_nhds (h : f₁ =ᶠ[𝓝 x] f) :
@@ -387,7 +387,7 @@ theorem HasLineDerivAt.le_of_lip' {f : E → F} {f' : F} {x₀ : E} (hf : HasLin
     {C : ℝ} (hC₀ : 0 ≤ C) (hlip : ∀ᶠ x in 𝓝 x₀, ‖f x - f x₀‖ ≤ C * ‖x - x₀‖) :
     ‖f'‖ ≤ C * ‖v‖ := by
   apply HasDerivAt.le_of_lip' hf (by positivity)
-  have A : Continuous (fun (t : 𝕜) ↦ x₀ + t • v) := by continuity
+  have A : Continuous (fun (t : 𝕜) ↦ x₀ + t • v) := by fun_prop
   have : ∀ᶠ x in 𝓝 (x₀ + (0 : 𝕜) • v), ‖f x - f x₀‖ ≤ C * ‖x - x₀‖ := by simpa using hlip
   filter_upwards [(A.continuousAt (x := 0)).preimage_mem_nhds this] with t ht
   simp only [preimage_setOf_eq, add_sub_cancel_left, norm_smul, mem_setOf_eq, mul_comm (‖t‖)] at ht
@@ -422,7 +422,7 @@ theorem norm_lineDeriv_le_of_lip' {f : E → F} {x₀ : E}
     {C : ℝ} (hC₀ : 0 ≤ C) (hlip : ∀ᶠ x in 𝓝 x₀, ‖f x - f x₀‖ ≤ C * ‖x - x₀‖) :
     ‖lineDeriv 𝕜 f x₀ v‖ ≤ C * ‖v‖ := by
   apply norm_deriv_le_of_lip' (by positivity)
-  have A : Continuous (fun (t : 𝕜) ↦ x₀ + t • v) := by continuity
+  have A : Continuous (fun (t : 𝕜) ↦ x₀ + t • v) := by fun_prop
   have : ∀ᶠ x in 𝓝 (x₀ + (0 : 𝕜) • v), ‖f x - f x₀‖ ≤ C * ‖x - x₀‖ := by simpa using hlip
   filter_upwards [(A.continuousAt (x := 0)).preimage_mem_nhds this] with t ht
   simp only [preimage_setOf_eq, add_sub_cancel_left, norm_smul, mem_setOf_eq, mul_comm (‖t‖)] at ht

--- a/Mathlib/Analysis/Calculus/LineDeriv/Measurable.lean
+++ b/Mathlib/Analysis/Calculus/LineDeriv/Measurable.lean
@@ -34,21 +34,21 @@ theorem measurableSet_lineDifferentiableAt (hf : Continuous f) :
     MeasurableSet {x : E | LineDifferentiableAt 𝕜 f x v} := by
   borelize 𝕜
   let g : E → 𝕜 → F := fun x t ↦ f (x + t • v)
-  have hg : Continuous g.uncurry := by apply hf.comp; continuity
+  have hg : Continuous g.uncurry := by fun_prop
   exact measurable_prod_mk_right (measurableSet_of_differentiableAt_with_param 𝕜 hg)
 
 theorem measurable_lineDeriv [MeasurableSpace F] [BorelSpace F]
     (hf : Continuous f) : Measurable (fun x ↦ lineDeriv 𝕜 f x v) := by
   borelize 𝕜
   let g : E → 𝕜 → F := fun x t ↦ f (x + t • v)
-  have hg : Continuous g.uncurry := by apply hf.comp; continuity
+  have hg : Continuous g.uncurry := by fun_prop
   exact (measurable_deriv_with_param hg).comp measurable_prod_mk_right
 
 theorem stronglyMeasurable_lineDeriv [SecondCountableTopologyEither E F] (hf : Continuous f) :
     StronglyMeasurable (fun x ↦ lineDeriv 𝕜 f x v) := by
   borelize 𝕜
   let g : E → 𝕜 → F := fun x t ↦ f (x + t • v)
-  have hg : Continuous g.uncurry := by apply hf.comp; continuity
+  have hg : Continuous g.uncurry := by fun_prop
   exact (stronglyMeasurable_deriv_with_param hg).comp_measurable measurable_prod_mk_right
 
 theorem aemeasurable_lineDeriv [MeasurableSpace F] [BorelSpace F]

--- a/Mathlib/Analysis/Calculus/Taylor.lean
+++ b/Mathlib/Analysis/Calculus/Taylor.lean
@@ -266,9 +266,7 @@ theorem taylor_mean_remainder_lagrange {f : ℝ → ℝ} {x x₀ : ℝ} {n : ℕ
     (hf' : DifferentiableOn ℝ (iteratedDerivWithin n f (Icc x₀ x)) (Ioo x₀ x)) :
     ∃ x' ∈ Ioo x₀ x, f x - taylorWithinEval f n (Icc x₀ x) x₀ x =
       iteratedDerivWithin (n + 1) f (Icc x₀ x) x' * (x - x₀) ^ (n + 1) / (n + 1)! := by
-  have gcont : ContinuousOn (fun t : ℝ => (x - t) ^ (n + 1)) (Icc x₀ x) := by
-    refine Continuous.continuousOn ?_
-    exact (continuous_const.sub continuous_id').pow _ -- Porting note: was `continuity`
+  have gcont : ContinuousOn (fun t : ℝ => (x - t) ^ (n + 1)) (Icc x₀ x) := by fun_prop
   have xy_ne : ∀ y : ℝ, y ∈ Ioo x₀ x → (x - y) ^ n ≠ 0 := by
     intro y hy
     refine pow_ne_zero _ ?_
@@ -298,7 +296,7 @@ theorem taylor_mean_remainder_cauchy {f : ℝ → ℝ} {x x₀ : ℝ} {n : ℕ} 
     (hf' : DifferentiableOn ℝ (iteratedDerivWithin n f (Icc x₀ x)) (Ioo x₀ x)) :
     ∃ x' ∈ Ioo x₀ x, f x - taylorWithinEval f n (Icc x₀ x) x₀ x =
       iteratedDerivWithin (n + 1) f (Icc x₀ x) x' * (x - x') ^ n / n ! * (x - x₀) := by
-  have gcont : ContinuousOn id (Icc x₀ x) := Continuous.continuousOn (by continuity)
+  have gcont : ContinuousOn id (Icc x₀ x) := by fun_prop
   have gdiff : ∀ x_1 : ℝ, x_1 ∈ Ioo x₀ x → HasDerivAt id ((fun _ : ℝ => (1 : ℝ)) x_1) x_1 :=
     fun _ _ => hasDerivAt_id _
   -- We apply the general theorem with g = id

--- a/Mathlib/Analysis/Complex/Tietze.lean
+++ b/Mathlib/Analysis/Complex/Tietze.lean
@@ -57,7 +57,7 @@ instance Set.instTietzeExtensionUnitClosedBall {𝕜 : Type v} [RCLike 𝕜] {E 
   let g : E → E := fun x ↦ ‖x‖⁻¹ • x
   classical
   suffices this : Continuous (piecewise (Metric.closedBall 0 1) id g) by
-    refine .of_retract ⟨Subtype.val, by continuity⟩ ⟨_, this.codRestrict fun x ↦ ?_⟩ ?_
+    refine .of_retract ⟨Subtype.val, by fun_prop⟩ ⟨_, this.codRestrict fun x ↦ ?_⟩ ?_
     · by_cases hx : x ∈ Metric.closedBall 0 1
       · simpa [piecewise_eq_of_mem (hi := hx)] using hx
       · simp only [g, piecewise_eq_of_not_mem (hi := hx), RCLike.real_smul_eq_coe_smul (K := 𝕜)]

--- a/Mathlib/Analysis/Convex/Gauge.lean
+++ b/Mathlib/Analysis/Convex/Gauge.lean
@@ -417,7 +417,7 @@ theorem mem_closure_of_gauge_le_one (hc : Convex ℝ s) (hs₀ : 0 ∈ s) (ha : 
     rw [mem_setOf_eq, gauge_smul_of_nonneg hr₀]
     exact mul_lt_one_of_nonneg_of_lt_one_left hr₀ hr₁ h
   refine mem_closure_of_tendsto ?_ this
-  exact Filter.Tendsto.mono_left (Continuous.tendsto' (by continuity) _ _ (one_smul _ _))
+  exact Filter.Tendsto.mono_left (Continuous.tendsto' (by fun_prop) _ _ (one_smul _ _))
     inf_le_left
 
 theorem mem_frontier_of_gauge_eq_one (hc : Convex ℝ s) (hs₀ : 0 ∈ s) (ha : Absorbent ℝ s)

--- a/Mathlib/Analysis/Convex/Topology.lean
+++ b/Mathlib/Analysis/Convex/Topology.lean
@@ -94,7 +94,7 @@ variable [LinearOrderedRing 𝕜] [DenselyOrdered 𝕜] [TopologicalSpace 𝕜] 
 
 theorem segment_subset_closure_openSegment : [x -[𝕜] y] ⊆ closure (openSegment 𝕜 x y) := by
   rw [segment_eq_image, openSegment_eq_image, ← closure_Ioo (zero_ne_one' 𝕜)]
-  exact image_closure_subset_closure_image (by continuity)
+  exact image_closure_subset_closure_image (by fun_prop)
 #align segment_subset_closure_open_segment segment_subset_closure_openSegment
 
 end TopologicalSpace
@@ -109,7 +109,7 @@ variable [LinearOrderedRing 𝕜] [DenselyOrdered 𝕜] [PseudoMetricSpace 𝕜]
 theorem closure_openSegment (x y : E) : closure (openSegment 𝕜 x y) = [x -[𝕜] y] := by
   rw [segment_eq_image, openSegment_eq_image, ← closure_Ioo (zero_ne_one' 𝕜)]
   exact (image_closure_of_isCompact (isBounded_Ioo _ _).isCompact_closure <|
-    Continuous.continuousOn <| by continuity).symm
+    Continuous.continuousOn <| by fun_prop).symm
 #align closure_open_segment closure_openSegment
 
 end PseudoMetricSpace
@@ -349,7 +349,7 @@ theorem Convex.subset_interior_image_homothety_of_one_lt {s : Set E} (hs : Conve
 theorem JoinedIn.of_segment_subset {E : Type*} [AddCommGroup E] [Module ℝ E]
     [TopologicalSpace E] [ContinuousAdd E] [ContinuousSMul ℝ E]
     {x y : E} {s : Set E} (h : [x -[ℝ] y] ⊆ s) : JoinedIn s x y := by
-  have A : Continuous (fun t ↦ (1 - t) • x + t • y : ℝ → E) := by continuity
+  have A : Continuous (fun t ↦ (1 - t) • x + t • y : ℝ → E) := by fun_prop
   apply JoinedIn.ofLine A.continuousOn (by simp) (by simp)
   convert h
   rw [segment_eq_image ℝ x y]

--- a/Mathlib/Analysis/Fourier/Inversion.lean
+++ b/Mathlib/Analysis/Fourier/Inversion.lean
@@ -56,7 +56,7 @@ lemma tendsto_integral_cexp_sq_smul (hf : Integrable f) :
     apply (Tendsto.cexp _).smul_const
     exact tendsto_inv_atTop_zero.ofReal.neg.mul_const _
   · filter_upwards with c using
-      AEStronglyMeasurable.smul (Continuous.aestronglyMeasurable (by continuity)) hf.1
+      AEStronglyMeasurable.smul (Continuous.aestronglyMeasurable (by fun_prop)) hf.1
   · filter_upwards [Ici_mem_atTop (0 : ℝ)] with c (hc : 0 ≤ c)
     filter_upwards with v
     simp only [ofReal_inv, neg_mul, norm_smul, Complex.norm_eq_abs]

--- a/Mathlib/Analysis/InnerProductSpace/LinearPMap.lean
+++ b/Mathlib/Analysis/InnerProductSpace/LinearPMap.lean
@@ -172,8 +172,7 @@ theorem mem_adjoint_domain_of_exists (y : F) (h : ∃ w : E, ∀ x : T.domain, �
     y ∈ T†.domain := by
   cases' h with w hw
   rw [T.mem_adjoint_domain_iff]
-  -- Porting note: was `by continuity`
-  have : Continuous ((innerSL 𝕜 w).comp T.domain.subtypeL) := ContinuousLinearMap.continuous _
+  have : Continuous ((innerSL 𝕜 w).comp T.domain.subtypeL) := by fun_prop
   convert this using 1
   exact funext fun x => (hw x).symm
 #align linear_pmap.mem_adjoint_domain_of_exists LinearPMap.mem_adjoint_domain_of_exists

--- a/Mathlib/Analysis/InnerProductSpace/Projection.lean
+++ b/Mathlib/Analysis/InnerProductSpace/Projection.lean
@@ -163,7 +163,7 @@ theorem exists_norm_eq_iInf_of_complete_convex {K : Set F} (ne : K.Nonempty) (h�
     -- third goal : `Tendsto (fun (n : ℕ) => √(b n)) atTop (𝓝 0)`
     suffices Tendsto (fun x ↦ √(8 * δ * x + 4 * x * x) : ℝ → ℝ) (𝓝 0) (𝓝 0)
       from this.comp tendsto_one_div_add_atTop_nhds_zero_nat
-    exact Continuous.tendsto' (by continuity) _ _ (by simp)
+    exact Continuous.tendsto' (by fun_prop) _ _ (by simp)
   -- Step 3: By completeness of `K`, let `w : ℕ → K` converge to some `v : K`.
   -- Prove that it satisfies all requirements.
   rcases cauchySeq_tendsto_of_isComplete h₁ (fun n => Subtype.mem _) seq_is_cauchy with

--- a/Mathlib/Analysis/NormedSpace/BoundedLinearMaps.lean
+++ b/Mathlib/Analysis/NormedSpace/BoundedLinearMaps.lean
@@ -529,7 +529,7 @@ theorem ContinuousOn.clm_comp {X} [TopologicalSpace X] {g : X → F →L[𝕜] G
   (compL 𝕜 E F G).continuous₂.comp_continuousOn (hg.prod hf)
 #align continuous_on.clm_comp ContinuousOn.clm_comp
 
-@[continuity]
+@[continuity, fun_prop]
 theorem Continuous.clm_apply {X} [TopologicalSpace X] {f : X → (E →L[𝕜] F)} {g : X → E}
     (hf : Continuous f) (hg : Continuous g) : Continuous (fun x ↦ (f x) (g x)) :=
   isBoundedBilinearMap_apply.continuous.comp₂ hf hg

--- a/Mathlib/Analysis/NormedSpace/HahnBanach/SeparatingDual.lean
+++ b/Mathlib/Analysis/NormedSpace/HahnBanach/SeparatingDual.lean
@@ -162,7 +162,7 @@ lemma completeSpace_of_completeSpace_continuousLinearMap [CompleteSpace (E →L[
   obtain ⟨a, ha⟩ : ∃ a, Tendsto g atTop (𝓝 a) := cauchy_iff_exists_le_nhds.mp this
   refine ⟨a v, ?_⟩
   have : Tendsto (fun n ↦ g n v) atTop (𝓝 (a v)) := by
-    have : Continuous (fun (i : E →L[𝕜] F) ↦ i v) := by continuity
+    have : Continuous (fun (i : E →L[𝕜] F) ↦ i v) := by fun_prop
     exact (this.tendsto _).comp ha
   simpa [g, ContinuousLinearMap.smulRightL, hφ]
 

--- a/Mathlib/Analysis/NormedSpace/SphereNormEquiv.lean
+++ b/Mathlib/Analysis/NormedSpace/SphereNormEquiv.lean
@@ -40,7 +40,7 @@ noncomputable def homeomorphUnitSphereProd :
   continuous_toFun := by
     refine .prod_mk (.codRestrict (.smul (.inv₀ ?_ ?_) ?_) _) ?_
     · fun_prop
-    · continuity
+    · simp
     · fun_prop
-    · apply Continuous.subtype_mk (by fun_prop)
+    · fun_prop
   continuous_invFun := by apply Continuous.subtype_mk (by fun_prop)

--- a/Mathlib/Analysis/NormedSpace/SphereNormEquiv.lean
+++ b/Mathlib/Analysis/NormedSpace/SphereNormEquiv.lean
@@ -38,5 +38,9 @@ noncomputable def homeomorphUnitSphereProd :
     rw [mem_Ioi] at hr
     ext <;> simp [hx, norm_smul, hr.le, abs_of_pos hr, hr.ne']
   continuous_toFun := by
-    refine .prod_mk (.codRestrict (.smul (.inv₀ ?_ ?_) ?_) _) ?_ <;> continuity
-  continuous_invFun := by continuity
+    refine .prod_mk (.codRestrict (.smul (.inv₀ ?_ ?_) ?_) _) ?_
+    · fun_prop
+    · continuity
+    · fun_prop
+    · apply Continuous.subtype_mk (by fun_prop)
+  continuous_invFun := by apply Continuous.subtype_mk (by fun_prop)

--- a/Mathlib/Analysis/ODE/PicardLindelof.lean
+++ b/Mathlib/Analysis/ODE/PicardLindelof.lean
@@ -147,7 +147,7 @@ theorem proj_of_mem {t : ℝ} (ht : t ∈ Icc v.tMin v.tMax) : ↑(v.proj t) = t
   simp only [proj, projIcc_of_mem v.tMin_le_tMax ht]
 #align picard_lindelof.proj_of_mem PicardLindelof.proj_of_mem
 
-@[continuity]
+@[continuity, fun_prop]
 theorem continuous_proj : Continuous v.proj :=
   continuous_projIcc
 #align picard_lindelof.continuous_proj PicardLindelof.continuous_proj
@@ -304,8 +304,7 @@ theorem dist_next_apply_le_of_le {f₁ f₂ : FunSpace v} {n : ℕ} {d : ℝ}
       refine norm_integral_le_of_norm_le (Continuous.integrableOn_uIoc ?_) ?_
       · -- Porting note: was `continuity`
         refine .mul continuous_const <| .mul (.div_const ?_ _) continuous_const
-        refine .pow (.mul continuous_const <| .abs <| ?_) _
-        exact .sub continuous_id continuous_const
+        fun_prop
       · refine (ae_restrict_mem measurableSet_Ioc).mono fun τ hτ => ?_
         refine (v.lipschitzOnWith (v.proj τ).2).norm_sub_le_of_le (f₁.mem_closedBall _)
             (f₂.mem_closedBall _) ((h _).trans_eq ?_)

--- a/Mathlib/Analysis/ODE/PicardLindelof.lean
+++ b/Mathlib/Analysis/ODE/PicardLindelof.lean
@@ -301,15 +301,12 @@ theorem dist_next_apply_le_of_le {f₁ f₂ : FunSpace v} {n : ℕ} {d : ℝ}
   calc
     ‖∫ τ in Ι (v.t₀ : ℝ) t, f₁.vComp τ - f₂.vComp τ‖ ≤
         ∫ τ in Ι (v.t₀ : ℝ) t, v.L * ((v.L * |τ - v.t₀|) ^ n / n ! * d) := by
-      refine norm_integral_le_of_norm_le (Continuous.integrableOn_uIoc ?_) ?_
-      · -- Porting note: was `continuity`
-        refine .mul continuous_const <| .mul (.div_const ?_ _) continuous_const
-        fun_prop
-      · refine (ae_restrict_mem measurableSet_Ioc).mono fun τ hτ => ?_
-        refine (v.lipschitzOnWith (v.proj τ).2).norm_sub_le_of_le (f₁.mem_closedBall _)
-            (f₂.mem_closedBall _) ((h _).trans_eq ?_)
-        rw [v.proj_of_mem]
-        exact uIcc_subset_Icc v.t₀.2 t.2 <| Ioc_subset_Icc_self hτ
+      refine norm_integral_le_of_norm_le (Continuous.integrableOn_uIoc (by fun_prop)) ?_
+      refine (ae_restrict_mem measurableSet_Ioc).mono fun τ hτ ↦ ?_
+      refine (v.lipschitzOnWith (v.proj τ).2).norm_sub_le_of_le (f₁.mem_closedBall _)
+          (f₂.mem_closedBall _) ((h _).trans_eq ?_)
+      rw [v.proj_of_mem]
+      exact uIcc_subset_Icc v.t₀.2 t.2 <| Ioc_subset_Icc_self hτ
     _ = (v.L * |t.1 - v.t₀|) ^ (n + 1) / (n + 1)! * d := by
       simp_rw [mul_pow, div_eq_mul_inv, mul_assoc, MeasureTheory.integral_mul_left,
         MeasureTheory.integral_mul_right, integral_pow_abs_sub_uIoc, div_eq_mul_inv,

--- a/Mathlib/Analysis/SpecialFunctions/Complex/LogBounds.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Complex/LogBounds.lean
@@ -30,7 +30,7 @@ namespace Complex
 
 lemma continuousOn_one_add_mul_inv {z : ℂ} (hz : 1 + z ∈ slitPlane) :
     ContinuousOn (fun t : ℝ ↦ (1 + t • z)⁻¹) (Set.Icc 0 1) :=
-  ContinuousOn.inv₀ (Continuous.continuousOn (by continuity))
+  ContinuousOn.inv₀ (by fun_prop)
     (fun t ht ↦ slitPlane_ne_zero <| StarConvex.add_smul_mem starConvex_one_slitPlane hz ht.1 ht.2)
 
 open intervalIntegral in
@@ -125,8 +125,7 @@ lemma integrable_pow_mul_norm_one_add_mul_inv (n : ℕ) {z : ℂ} (hz : ‖z‖ 
     IntervalIntegrable (fun t : ℝ ↦ t ^ n * ‖(1 + t * z)⁻¹‖) MeasureTheory.volume 0 1 := by
   have := continuousOn_one_add_mul_inv <| mem_slitPlane_of_norm_lt_one hz
   rw [← Set.uIcc_of_le zero_le_one] at this
-  exact ContinuousOn.intervalIntegrable <|
-    Continuous.continuousOn (by continuity) |>.mul <| ContinuousOn.norm this
+  exact ContinuousOn.intervalIntegrable (by fun_prop)
 
 open intervalIntegral in
 /-- The difference of `log (1+z)` and its `(n+1)`st Taylor polynomial can be bounded in
@@ -134,7 +133,7 @@ terms of `‖z‖`. -/
 lemma norm_log_sub_logTaylor_le (n : ℕ) {z : ℂ} (hz : ‖z‖ < 1) :
     ‖log (1 + z) - logTaylor (n + 1) z‖ ≤ ‖z‖ ^ (n + 1) * (1 - ‖z‖)⁻¹ / (n + 1) := by
   have help : IntervalIntegrable (fun t : ℝ ↦ t ^ n * (1 - ‖z‖)⁻¹) MeasureTheory.volume 0 1 :=
-    IntervalIntegrable.mul_const (Continuous.intervalIntegrable (by continuity) 0 1) (1 - ‖z‖)⁻¹
+    IntervalIntegrable.mul_const (Continuous.intervalIntegrable (by fun_prop) 0 1) (1 - ‖z‖)⁻¹
   let f (z : ℂ) : ℂ := log (1 + z) - logTaylor (n + 1) z
   let f' (z : ℂ) : ℂ := (-z) ^ n * (1 + z)⁻¹
   have hderiv : ∀ t ∈ Set.Icc (0 : ℝ) 1, HasDerivAt f (f' (0 + t * z)) (0 + t * z) := by
@@ -144,7 +143,7 @@ lemma norm_log_sub_logTaylor_le (n : ℕ) {z : ℂ} (hz : ‖z‖ < 1) :
       StarConvex.add_smul_mem starConvex_one_slitPlane (mem_slitPlane_of_norm_lt_one hz) ht.1 ht.2
   have hcont : ContinuousOn (fun t : ℝ ↦ f' (0 + t * z)) (Set.Icc 0 1) := by
     simp only [zero_add, zero_le_one, not_true_eq_false]
-    exact (Continuous.continuousOn (by continuity)).mul <|
+    exact (Continuous.continuousOn (by fun_prop)).mul <|
       continuousOn_one_add_mul_inv <| mem_slitPlane_of_norm_lt_one hz
   have H : f z = z * ∫ t in (0 : ℝ)..1, (-(t * z)) ^ n * (1 + t * z)⁻¹ := by
     convert (integral_unitInterval_deriv_eq_sub hcont hderiv).symm using 1

--- a/Mathlib/Analysis/SpecialFunctions/Integrals.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Integrals.lean
@@ -261,7 +261,7 @@ theorem intervalIntegrable_cos : IntervalIntegrable cos μ a b :=
 theorem intervalIntegrable_one_div_one_add_sq :
     IntervalIntegrable (fun x : ℝ => 1 / (↑1 + x ^ 2)) μ a b := by
   refine (continuous_const.div ?_ fun x => ?_).intervalIntegrable a b
-  · continuity
+  · fun_prop
   · nlinarith
 #align interval_integral.interval_integrable_one_div_one_add_sq intervalIntegral.intervalIntegrable_one_div_one_add_sq
 
@@ -500,7 +500,7 @@ theorem integral_exp_mul_complex {c : ℂ} (hc : c ≠ 0) :
     simpa only [mul_one] using ((hasDerivAt_id (x : ℂ)).const_mul _).comp_ofReal
   rw [integral_deriv_eq_sub' _ (funext fun x => (D x).deriv) fun x _ => (D x).differentiableAt]
   · ring
-  · apply Continuous.continuousOn; continuity
+  · fun_prop
 #align integral_exp_mul_complex integral_exp_mul_complex
 
 @[simp]
@@ -572,7 +572,7 @@ theorem integral_one_div_one_add_sq :
     (∫ x : ℝ in a..b, ↑1 / (↑1 + x ^ 2)) = arctan b - arctan a := by
   refine integral_deriv_eq_sub' _ Real.deriv_arctan (fun _ _ => differentiableAt_arctan _)
     (continuous_const.div ?_ fun x => ?_).continuousOn
-  · continuity
+  · fun_prop
   · nlinarith
 #align integral_one_div_one_add_sq integral_one_div_one_add_sq
 
@@ -661,7 +661,7 @@ theorem integral_sin_pow_aux :
         simp [cos_sq', sub_mul, ← pow_add, add_comm]
       _ = (C + (↑n + 1) * ∫ x in a..b, sin x ^ n) - (↑n + 1) * ∫ x in a..b, sin x ^ (n + 2) := by
         rw [integral_sub, mul_sub, add_sub_assoc] <;>
-          apply Continuous.intervalIntegrable <;> continuity
+          apply Continuous.intervalIntegrable <;> fun_prop
   all_goals apply Continuous.intervalIntegrable; fun_prop
 #align integral_sin_pow_aux integral_sin_pow_aux
 
@@ -738,8 +738,8 @@ theorem integral_cos_pow_aux :
         simp [sin_sq, sub_mul, ← pow_add, add_comm]
       _ = (C + (n + 1) * ∫ x in a..b, cos x ^ n) - (n + 1) * ∫ x in a..b, cos x ^ (n + 2) := by
         rw [integral_sub, mul_sub, add_sub_assoc] <;>
-          apply Continuous.intervalIntegrable <;> continuity
-  all_goals apply Continuous.intervalIntegrable; continuity
+          apply Continuous.intervalIntegrable <;> fun_prop
+  all_goals apply Continuous.intervalIntegrable; fun_prop
 #align integral_cos_pow_aux integral_cos_pow_aux
 
 /-- The reduction formula for the integral of `cos x ^ n` for any natural `n ≥ 2`. -/
@@ -763,7 +763,7 @@ theorem integral_cos_sq : ∫ x in a..b, cos x ^ 2 = (cos b * sin b - cos a * si
 /-- Simplification of the integral of `sin x ^ m * cos x ^ n`, case `n` is odd. -/
 theorem integral_sin_pow_mul_cos_pow_odd (m n : ℕ) :
     (∫ x in a..b, sin x ^ m * cos x ^ (2 * n + 1)) = ∫ u in sin a..sin b, u^m * (↑1 - u ^ 2) ^ n :=
-  have hc : Continuous fun u : ℝ => u ^ m * (↑1 - u ^ 2) ^ n := by continuity
+  have hc : Continuous fun u : ℝ => u ^ m * (↑1 - u ^ 2) ^ n := by fun_prop
   calc
     (∫ x in a..b, sin x ^ m * cos x ^ (2 * n + 1)) =
         ∫ x in a..b, sin x ^ m * (↑1 - sin x ^ 2) ^ n * cos x := by
@@ -799,7 +799,7 @@ theorem integral_cos_pow_three :
 /-- Simplification of the integral of `sin x ^ m * cos x ^ n`, case `m` is odd. -/
 theorem integral_sin_pow_odd_mul_cos_pow (m n : ℕ) :
     (∫ x in a..b, sin x ^ (2 * m + 1) * cos x ^ n) = ∫ u in cos b..cos a, u^n * (↑1 - u ^ 2) ^ m :=
-  have hc : Continuous fun u : ℝ => u ^ n * (↑1 - u ^ 2) ^ m := by continuity
+  have hc : Continuous fun u : ℝ => u ^ n * (↑1 - u ^ 2) ^ m := by fun_prop
   calc
     (∫ x in a..b, sin x ^ (2 * m + 1) * cos x ^ n) =
         -∫ x in b..a, sin x ^ (2 * m + 1) * cos x ^ n := by rw [integral_symm]
@@ -845,7 +845,7 @@ theorem integral_sin_sq_mul_cos_sq :
     ∫ x in a..b, sin x ^ 2 * cos x ^ 2 = (b - a) / 8 - (sin (4 * b) - sin (4 * a)) / 32 := by
   convert integral_sin_pow_even_mul_cos_pow_even 1 1 using 1
   have h1 : ∀ c : ℝ, (↑1 - c) / ↑2 * ((↑1 + c) / ↑2) = (↑1 - c ^ 2) / 4 := fun c => by ring
-  have h2 : Continuous fun x => cos (2 * x) ^ 2 := by continuity
+  have h2 : Continuous fun x => cos (2 * x) ^ 2 := by fun_prop
   have h3 : ∀ x, cos x * sin x = sin (2 * x) / 2 := by intro; rw [sin_two_mul]; ring
   have h4 : ∀ d : ℝ, 2 * (2 * d) = 4 * d := fun d => by ring
   -- Porting note: was
@@ -866,7 +866,7 @@ theorem integral_sqrt_one_sub_sq : ∫ x in (-1 : ℝ)..1, √(1 - x ^ 2 : ℝ) 
     _ = ∫ x in sin (-(π / 2)).. sin (π / 2), √(1 - x ^ 2 : ℝ) := by rw [sin_neg, sin_pi_div_two]
     _ = ∫ x in (-(π / 2))..(π / 2), √(1 - sin x ^ 2 : ℝ) * cos x :=
           (integral_comp_mul_deriv (fun x _ => hasDerivAt_sin x) continuousOn_cos
-            (by continuity)).symm
+            (by fun_prop)).symm
     _ = ∫ x in (-(π / 2))..(π / 2), cos x ^ 2 := by
           refine integral_congr_ae (MeasureTheory.ae_of_all _ fun _ h => ?_)
           rw [uIoc_of_le (neg_le_self (le_of_lt (half_pos Real.pi_pos))), Set.mem_Ioc] at h

--- a/Mathlib/Analysis/SpecialFunctions/Integrals.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Integrals.lean
@@ -643,8 +643,6 @@ theorem integral_sin_pow_aux :
     (∫ x in a..b, sin x ^ (n + 2)) =
       (sin a ^ (n + 1) * cos a - sin b ^ (n + 1) * cos b + (↑n + 1) * ∫ x in a..b, sin x ^ n) -
         (↑n + 1) * ∫ x in a..b, sin x ^ (n + 2) := by
-  have continuous_sin_pow : ∀ (k : ℕ), (Continuous fun x => sin x ^ k) :=
-    fun k => continuous_sin.pow k
   let C := sin a ^ (n + 1) * cos a - sin b ^ (n + 1) * cos b
   have h : ∀ α β γ : ℝ, β * α * γ * α = β * (α * α * γ) := fun α β γ => by ring
   have hu : ∀ x ∈ [[a, b]],
@@ -720,8 +718,6 @@ theorem integral_cos_pow_aux :
     (∫ x in a..b, cos x ^ (n + 2)) =
       (cos b ^ (n + 1) * sin b - cos a ^ (n + 1) * sin a + (n + 1) * ∫ x in a..b, cos x ^ n) -
         (n + 1) * ∫ x in a..b, cos x ^ (n + 2) := by
-  have continuous_cos_pow : ∀ (k : ℕ), (Continuous fun x => cos x ^ k) :=
-    fun k => continuous_cos.pow k
   let C := cos b ^ (n + 1) * sin b - cos a ^ (n + 1) * sin a
   have h : ∀ α β γ : ℝ, β * α * γ * α = β * (α * α * γ) := fun α β γ => by ring
   have hu : ∀ x ∈ [[a, b]],

--- a/Mathlib/Analysis/SpecialFunctions/Trigonometric/Bounds.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Trigonometric/Bounds.lean
@@ -63,8 +63,7 @@ lemma one_sub_sq_div_two_le_cos : 1 - x ^ 2 / 2 ≤ cos x := by
   suffices MonotoneOn (fun x ↦ cos x + x ^ 2 / 2) (Ici 0) by
     simpa using this left_mem_Ici hx₀ hx₀
   refine monotoneOn_of_hasDerivWithinAt_nonneg
-    (convex_Ici _)
-    (Continuous.continuousOn <| by continuity)
+    (convex_Ici _) (by fun_prop)
     (fun x _ ↦ ((hasDerivAt_cos ..).add <| (hasDerivAt_pow ..).div_const _).hasDerivWithinAt)
     fun x hx ↦ ?_
   simpa [mul_div_cancel_left₀] using sin_le <| interior_subset hx
@@ -75,7 +74,7 @@ lemma two_div_pi_mul_le_sin (hx₀ : 0 ≤ x) (hx : x ≤ π / 2) : 2 / π * x �
   suffices ConcaveOn ℝ (Icc 0 (π / 2)) (fun x ↦ sin x - 2 / π * x) by
     refine (le_min ?_ ?_).trans $ this.min_le_of_mem_Icc ⟨hx₀, hx⟩ <;> field_simp
   exact concaveOn_of_hasDerivWithinAt2_nonpos (convex_Icc ..)
-    (Continuous.continuousOn $ by continuity)
+    (Continuous.continuousOn $ by fun_prop)
     (fun x _ ↦ ((hasDerivAt_sin ..).sub $ (hasDerivAt_id ..).const_mul (2 / π)).hasDerivWithinAt)
     (fun x _ ↦ (hasDerivAt_cos ..).hasDerivWithinAt.sub_const _)
     fun x hx ↦ neg_nonpos.2 $ sin_nonneg_of_mem_Icc $ Icc_subset_Icc_right (by linarith) $
@@ -102,7 +101,7 @@ lemma cos_quadratic_upper_bound (hx : |x| ≤ π) : cos x ≤ 1 - 2 / π ^ 2 * x
   have hmono : MonotoneOn (fun x ↦ 1 - 2 / π ^ 2 * x ^ 2 - cos x) (Icc 0 (π / 2)) := by
     refine monotoneOn_of_hasDerivWithinAt_nonneg
       (convex_Icc ..)
-      (Continuous.continuousOn $ by continuity)
+      (Continuous.continuousOn $ by fun_prop)
       (fun x _ ↦ (hderiv _).hasDerivWithinAt)
       fun x hx ↦ sub_nonneg.2 ?_
     have ⟨hx₀, hx⟩ := interior_subset hx
@@ -114,7 +113,7 @@ lemma cos_quadratic_upper_bound (hx : |x| ≤ π) : cos x ≤ 1 - 2 / π ^ 2 * x
   have hconc : ConcaveOn ℝ (Icc (π / 2) π) (fun x ↦ 1 - 2 / π ^ 2 * x ^ 2 - cos x) := by
     set_option tactic.skipAssignedInstances false in
     refine concaveOn_of_hasDerivWithinAt2_nonpos (convex_Icc ..)
-      (Continuous.continuousOn $ by continuity) (fun x _ ↦ (hderiv _).hasDerivWithinAt)
+      (Continuous.continuousOn $ by fun_prop) (fun x _ ↦ (hderiv _).hasDerivWithinAt)
       (fun x _ ↦ ((hasDerivAt_sin ..).sub $ (hasDerivAt_id ..).const_mul _).hasDerivWithinAt)
       fun x hx ↦ ?_
     have ⟨hx, hx'⟩ := interior_subset hx

--- a/Mathlib/Topology/Algebra/GroupWithZero.lean
+++ b/Mathlib/Topology/Algebra/GroupWithZero.lean
@@ -71,7 +71,7 @@ theorem ContinuousOn.div_const (hf : ContinuousOn f s) (y : G₀) :
   simpa only [div_eq_mul_inv] using hf.mul continuousOn_const
 #align continuous_on.div_const ContinuousOn.div_const
 
-@[continuity]
+@[continuity, fun_prop]
 theorem Continuous.div_const (hf : Continuous f) (y : G₀) : Continuous fun x => f x / y := by
   simpa only [div_eq_mul_inv] using hf.mul continuous_const
 #align continuous.div_const Continuous.div_const

--- a/Mathlib/Topology/Algebra/Module/Basic.lean
+++ b/Mathlib/Topology/Algebra/Module/Basic.lean
@@ -437,7 +437,7 @@ theorem coe_mk' (f : M₁ →ₛₗ[σ₁₂] M₂) (h) : (mk f h : M₁ → M�
   rfl
 #align continuous_linear_map.coe_mk' ContinuousLinearMap.coe_mk'
 
-@[continuity]
+@[continuity, fun_prop]
 protected theorem continuous (f : M₁ →SL[σ₁₂] M₂) : Continuous f :=
   f.2
 #align continuous_linear_map.continuous ContinuousLinearMap.continuous


### PR DESCRIPTION
This is exhaustive, with the exception of one goal where the `continuity` proof is seemingly not about continuity at all...
We tag two lemmas with `fun_prop` which were continuity lemmas.

In some cases, this speeds up proofs significantly; we also resolve two porting notes about continuity not applying.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
