### PR TITLE
[Merged by Bors] - feat(Analysis/BoxIntegral/Basic): a bounded, a.e. continuous function is integrable on a box

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -1130,6 +1130,7 @@ import Mathlib.Analysis.NormedSpace.WithLp
 import Mathlib.Analysis.NormedSpace.lpSpace
 import Mathlib.Analysis.ODE.Gronwall
 import Mathlib.Analysis.ODE.PicardLindelof
+import Mathlib.Analysis.Oscillation
 import Mathlib.Analysis.PSeries
 import Mathlib.Analysis.PSeriesComplex
 import Mathlib.Analysis.Quaternion

--- a/Mathlib/Analysis/BoxIntegral/Basic.lean
+++ b/Mathlib/Analysis/BoxIntegral/Basic.lean
@@ -691,9 +691,9 @@ theorem integrable_of_bounded_and_ae_continuousWithinAt [CompleteSpace E] {I : B
   refine integrable_iff_cauchy_basis.2 fun ε ε0 ↦ ?_
   rcases exists_pos_mul_lt ε0 (2 * μ.toBoxAdditive I) with ⟨ε₁, ε₁0, hε₁⟩
   rcases hb with ⟨C, hC⟩
-  by_cases C0 : C ≥ 0; swap
-  · obtain ⟨x, hx⟩ := BoxIntegral.Box.nonempty_coe I
-    exact False.elim <| C0 <| le_trans (norm_nonneg (f x)) <| hC x (I.coe_subset_Icc hx)
+  have C0 : 0 ≤ C := by
+    obtain ⟨x, hx⟩ := BoxIntegral.Box.nonempty_coe I
+    exact le_trans (norm_nonneg (f x)) <| hC x (I.coe_subset_Icc hx)
   rcases exists_pos_mul_lt ε0 (4 * C) with ⟨ε₂, ε₂0, hε₂⟩
   have ε₂0': ENNReal.ofReal ε₂ ≠ 0 := fun h ↦ not_le_of_gt ε₂0 (ofReal_eq_zero.1 h)
 

--- a/Mathlib/Analysis/BoxIntegral/Basic.lean
+++ b/Mathlib/Analysis/BoxIntegral/Basic.lean
@@ -695,7 +695,7 @@ theorem integrable_of_bounded_and_ae_continuousWithinAt [CompleteSpace E] {I : B
     obtain ⟨x, hx⟩ := BoxIntegral.Box.nonempty_coe I
     exact le_trans (norm_nonneg (f x)) <| hC x (I.coe_subset_Icc hx)
   rcases exists_pos_mul_lt ε0 (4 * C) with ⟨ε₂, ε₂0, hε₂⟩
-  have ε₂0': ENNReal.ofReal ε₂ ≠ 0 := fun h ↦ not_le_of_gt ε₂0 (ofReal_eq_zero.1 h)
+  have ε₂0' : ENNReal.ofReal ε₂ ≠ 0 := ne_of_gt <| ofReal_pos.2 ε₂0
 
   -- The set of discontinuities of f is contained in an open set U with μ U < ε₂.
   let D := { x ∈ Box.Icc I | ¬ ContinuousWithinAt f (Box.Icc I) x }

--- a/Mathlib/Analysis/BoxIntegral/Basic.lean
+++ b/Mathlib/Analysis/BoxIntegral/Basic.lean
@@ -802,7 +802,7 @@ theorem integrable_of_continuousOn [CompleteSpace E] {I : Box ι} {f : ℝⁿ �
     (hc : ContinuousOn f (Box.Icc I)) (μ : Measure ℝⁿ) [IsLocallyFiniteMeasure μ] :
     Integrable.{u, v, v} I l f μ.toBoxAdditive.toSMul := by
   apply integrable_of_bounded_and_ae_continuousWithinAt
-  · obtain ⟨C, hC⟩ := (NormedSpace.isBounded_iff_subset_smul_closedBall ℝ E).1
+  · obtain ⟨C, hC⟩ := (NormedSpace.isBounded_iff_subset_smul_closedBall ℝ).1
                         (I.isCompact_Icc.image_of_continuousOn hc).isBounded
     use ‖C‖, fun x hx ↦ by
       simpa only [smul_closedUnitBall, mem_closedBall_zero_iff] using hC (Set.mem_image_of_mem f hx)

--- a/Mathlib/Analysis/BoxIntegral/Basic.lean
+++ b/Mathlib/Analysis/BoxIntegral/Basic.lean
@@ -5,6 +5,7 @@ Authors: Yury Kudryashov
 -/
 import Mathlib.Analysis.BoxIntegral.Partition.Filter
 import Mathlib.Analysis.BoxIntegral.Partition.Measure
+import Mathlib.Analysis.Oscillation
 import Mathlib.Topology.UniformSpace.Compact
 import Mathlib.Init.Data.Bool.Lemmas
 
@@ -673,8 +674,126 @@ open MeasureTheory
 ### Integrability conditions
 -/
 
+open Prepartition EMetric ENNReal BoxAdditiveMap Finset Metric TaggedPrepartition
 
 variable (l)
+
+/-- A function that is bounded and a.e. continuous on a box `I` is integrable on `I`. -/
+theorem integrable_of_bounded_and_ae_continuousWithinAt [CompleteSpace E] {I : Box ι} {f : ℝⁿ → E}
+    (hb : ∃ C : ℝ, ∀ x ∈ Box.Icc I, ‖f x‖ ≤ C) (μ : Measure ℝⁿ) [IsLocallyFiniteMeasure μ]
+    (hc : ∀ᵐ x ∂(μ.restrict (Box.Icc I)), ContinuousWithinAt f (Box.Icc I) x) :
+    Integrable I l f μ.toBoxAdditive.toSMul := by
+  /- We prove that f is integrable by proving that we can ensure that the integralSums over any
+     two tagged prepartitions π₁ and π₂ can be made ε-close by making the partitions
+     sufficiently fine.
+
+     Start by defining some constants C, ε₁, ε₂ that will be useful later. -/
+  refine integrable_iff_cauchy_basis.2 fun ε ε0 ↦ ?_
+  rcases exists_pos_mul_lt ε0 (2 * μ.toBoxAdditive I) with ⟨ε₁, ε₁0, hε₁⟩
+  rcases hb with ⟨C, hC⟩
+  by_cases C0 : C ≥ 0; swap
+  · obtain ⟨x, hx⟩ := BoxIntegral.Box.nonempty_coe I
+    exact False.elim <| C0 <| le_trans (norm_nonneg (f x)) <| hC x (I.coe_subset_Icc hx)
+  rcases exists_pos_mul_lt ε0 (4 * C) with ⟨ε₂, ε₂0, hε₂⟩
+  have ε₂0': ENNReal.ofReal ε₂ ≠ 0 := fun h ↦ not_le_of_gt ε₂0 (ofReal_eq_zero.1 h)
+
+  -- The set of discontinuities of f is contained in an open set U with μ U < ε₂.
+  let D := { x ∈ Box.Icc I | ¬ ContinuousWithinAt f (Box.Icc I) x }
+  let μ' := μ.restrict (Box.Icc I)
+  have μ'D : μ' D = 0 := by
+    rcases eventually_iff_exists_mem.1 hc with ⟨V, ae, hV⟩
+    exact eq_of_le_of_not_lt (mem_ae_iff.1 ae ▸ (μ'.mono <| fun x h xV ↦ h.2 (hV x xV))) not_lt_zero
+  obtain ⟨U, UD, Uopen, hU⟩ := Set.exists_isOpen_lt_add D (show μ' D ≠ ⊤ by simp [μ'D]) ε₂0'
+  rw [μ'D, zero_add] at hU
+
+  /- Box.Icc I \ U is compact and avoids discontinuities of f, so there exists r > 0 such that for
+     every x ∈ Box.Icc I \ U, the oscillation (within Box.Icc I) of f on the ball of radius r
+     centered at x is ≤ ε₁ -/
+  have comp : IsCompact (Box.Icc I \ U) :=
+    I.isCompact_Icc.of_isClosed_subset (I.isCompact_Icc.isClosed.sdiff Uopen) Set.diff_subset
+  have : ∀ x ∈ (Box.Icc I \ U), oscillationWithin f (Box.Icc I) x < (ENNReal.ofReal ε₁) := by
+    intro x hx
+    suffices oscillationWithin f (Box.Icc I) x = 0 by rw [this]; exact ofReal_pos.2 ε₁0
+    simpa [OscillationWithin.eq_zero_iff_continuousWithinAt, D, hx.1] using hx.2 ∘ (fun a ↦ UD a)
+  rcases comp.uniform_oscillationWithin this with ⟨r, r0, hr⟩
+
+  /- We prove the claim for partitions π₁ and π₂ subordinate to r/2, by writing the difference as
+     an integralSum over π₁ ⊓ π₂ and considering separately the boxes of π₁ ⊓ π₂ which are/aren't
+     fully contained within U. -/
+  refine ⟨fun _ _ ↦ ⟨r / 2, half_pos r0⟩, fun _ _ _ ↦ rfl, fun c₁ c₂ π₁ π₂ h₁ h₁p h₂ h₂p ↦ ?_⟩
+  simp only [dist_eq_norm, integralSum_sub_partitions _ _ h₁p h₂p, toSMul_apply, ← smul_sub]
+  have μI : μ I < ⊤ := lt_of_le_of_lt (μ.mono I.coe_subset_Icc) I.isCompact_Icc.measure_lt_top
+  let t₁ (J : Box ι) : ℝⁿ := (π₁.infPrepartition π₂.toPrepartition).tag J
+  let t₂ (J : Box ι) : ℝⁿ := (π₂.infPrepartition π₁.toPrepartition).tag J
+  let B := (π₁.toPrepartition ⊓ π₂.toPrepartition).boxes
+  let B' := B.filter (fun J ↦ J.toSet ⊆ U)
+  have hB' : B' ⊆ B := B.filter_subset (fun J ↦ J.toSet ⊆ U)
+  have μJ_ne_top : ∀ J ∈ B, μ J ≠ ⊤ :=
+    fun J hJ ↦ lt_top_iff_ne_top.1 <| lt_of_le_of_lt (μ.mono (Prepartition.le_of_mem' _ J hJ)) μI
+  have un : ∀ S ⊆ B, ⋃ J ∈ S, J.toSet ⊆ I.toSet :=
+    fun S hS ↦ iUnion_subset_iff.2 (fun J ↦ iUnion_subset_iff.2 fun hJ ↦ le_of_mem' _ J (hS hJ))
+  rw [← sum_sdiff hB', ← add_halves ε]
+  apply le_trans (norm_add_le _ _) (add_le_add ?_ ?_)
+
+  /- If a box J is not contained within U, then the oscillation of f on J is small, which bounds
+     the contribution of J to the overall sum. -/
+  · have : ∀ J ∈ B \ B', ‖μ.toBoxAdditive J • (f (t₁ J) - f (t₂ J))‖ ≤ μ.toBoxAdditive J * ε₁ := by
+      intro J hJ
+      rw [mem_sdiff, B.mem_filter, not_and] at hJ
+      rw [norm_smul, μ.toBoxAdditive_apply, Real.norm_of_nonneg toReal_nonneg]
+      refine mul_le_mul_of_nonneg_left ?_ toReal_nonneg
+      obtain ⟨x, xJ, xnU⟩ : ∃ x ∈ J, x ∉ U := Set.not_subset.1 (hJ.2 hJ.1)
+      have hx : x ∈ Box.Icc I \ U := ⟨Box.coe_subset_Icc ((le_of_mem' _ J hJ.1) xJ), xnU⟩
+      have ineq : edist (f (t₁ J)) (f (t₂ J)) ≤ EMetric.diam (f '' (ball x r ∩ (Box.Icc I))) := by
+        apply edist_le_diam_of_mem <;>
+          refine Set.mem_image_of_mem f ⟨?_, tag_mem_Icc _ J⟩ <;>
+          refine closedBall_subset_ball (div_two_lt_of_pos r0) <| mem_closedBall_comm.1 ?_
+        · exact h₁.isSubordinate.infPrepartition π₂.toPrepartition J hJ.1 (Box.coe_subset_Icc xJ)
+        · exact h₂.isSubordinate.infPrepartition π₁.toPrepartition J
+            ((π₁.mem_infPrepartition_comm).1 hJ.1) (Box.coe_subset_Icc xJ)
+      rw [← emetric_ball] at ineq
+      simpa only [edist_le_ofReal (le_of_lt ε₁0), dist_eq_norm, hJ.1] using ineq.trans (hr x hx)
+    refine (norm_sum_le _ _).trans <| (sum_le_sum this).trans ?_
+    rw [← sum_mul]
+    trans μ.toBoxAdditive I * ε₁; swap; linarith
+    simp_rw [mul_le_mul_right ε₁0, μ.toBoxAdditive_apply]
+    refine le_trans ?_ <| toReal_mono (lt_top_iff_ne_top.1 μI) <| μ.mono <| un (B \ B') sdiff_subset
+    rw [← toReal_sum (fun J hJ ↦ μJ_ne_top J (mem_sdiff.1 hJ).1), ← Finset.tsum_subtype]
+    refine (toReal_mono <| ne_of_lt <| lt_of_le_of_lt (μ.mono <| un (B \ B') sdiff_subset) μI) ?_
+    refine le_of_eq (measure_biUnion (countable_toSet _) ?_ (fun J _ ↦ J.measurableSet_coe)).symm
+    exact fun J hJ J' hJ' hJJ' ↦ pairwiseDisjoint _ (mem_sdiff.1 hJ).1 (mem_sdiff.1 hJ').1 hJJ'
+
+  -- The contribution of the boxes contained within U is bounded because f is bounded and μ U < ε₂.
+  · have : ∀ J ∈ B', ‖μ.toBoxAdditive J • (f (t₁ J) - f (t₂ J))‖ ≤ μ.toBoxAdditive J * (2 * C) := by
+      intro J _
+      rw [norm_smul, μ.toBoxAdditive_apply, Real.norm_of_nonneg toReal_nonneg, two_mul]
+      refine mul_le_mul_of_nonneg_left (le_trans (norm_sub_le _ _) (add_le_add ?_ ?_)) (by simp) <;>
+        exact hC _ (TaggedPrepartition.tag_mem_Icc _ J)
+    apply (norm_sum_le_of_le B' this).trans
+    simp_rw [← sum_mul, μ.toBoxAdditive_apply, ← toReal_sum (fun J hJ ↦ μJ_ne_top J (hB' hJ))]
+    suffices (∑ J in B', μ J).toReal ≤ ε₂ by
+      linarith [mul_le_mul_of_nonneg_right this <| (mul_nonneg_iff_of_pos_left two_pos).2 C0]
+    rw [← toReal_ofReal (le_of_lt ε₂0)]
+    refine toReal_mono ofReal_ne_top (le_trans ?_ (le_of_lt hU))
+    trans μ' (⋃ J ∈ B', J)
+    · simp only [μ', μ.restrict_eq_self <| (un _ hB').trans I.coe_subset_Icc]
+      exact le_of_eq <| Eq.symm <| measure_biUnion_finset
+        (fun J hJ K hK hJK ↦ pairwiseDisjoint _ (hB' hJ) (hB' hK) hJK) fun J _ ↦ J.measurableSet_coe
+    · apply μ'.mono
+      simp_rw [iUnion_subset_iff]
+      exact fun J hJ ↦ (mem_filter.1 hJ).2
+
+/-- A function that is bounded on a box `I` and a.e. continuous is integrable on `I`.
+
+This is a version of `integrable_of_bounded_and_ae_continuousWithinAt` with a stronger continuity
+assumption so that the user does not need to specialize the continuity assumption to each box on
+which the theorem is to be applied. -/
+theorem integrable_of_bounded_and_ae_continuous [CompleteSpace E] {I : Box ι} {f : ℝⁿ → E}
+    (hb : ∃ C : ℝ, ∀ x ∈ Box.Icc I, ‖f x‖ ≤ C) (μ : Measure ℝⁿ) [IsLocallyFiniteMeasure μ]
+    (hc : ∀ᵐ x ∂μ, ContinuousAt f x) : Integrable I l f μ.toBoxAdditive.toSMul :=
+  integrable_of_bounded_and_ae_continuousWithinAt l hb μ <|
+    Eventually.filter_mono (ae_mono μ.restrict_le_self) (hc.mono fun _ h ↦ h.continuousWithinAt)
+
 
 /-- A continuous function is box-integrable with respect to any locally finite measure.
 
@@ -748,7 +867,7 @@ theorem HasIntegral.of_bRiemann_eq_false_of_forall_isLittleO (hl : l.bRiemann = 
   simp only [Set.mem_iUnion, mem_inter_iff, mem_setOf_eq]
   rintro π ⟨c, hπδ, hπp⟩
   -- Now we split the sum into two parts based on whether `π.tag J` belongs to `s` or not.
-  rw [← g.sum_partition_boxes le_rfl hπp, mem_closedBall, integralSum,
+  rw [← g.sum_partition_boxes le_rfl hπp, Metric.mem_closedBall, integralSum,
     ← sum_filter_add_sum_filter_not π.boxes fun J => π.tag J ∈ s,
     ← sum_filter_add_sum_filter_not π.boxes fun J => π.tag J ∈ s, ← add_halves ε]
   refine dist_add_add_le_of_le ?_ ?_

--- a/Mathlib/Analysis/BoxIntegral/Basic.lean
+++ b/Mathlib/Analysis/BoxIntegral/Basic.lean
@@ -801,33 +801,13 @@ This is true for any volume with bounded variation. -/
 theorem integrable_of_continuousOn [CompleteSpace E] {I : Box ι} {f : ℝⁿ → E}
     (hc : ContinuousOn f (Box.Icc I)) (μ : Measure ℝⁿ) [IsLocallyFiniteMeasure μ] :
     Integrable.{u, v, v} I l f μ.toBoxAdditive.toSMul := by
-  have huc := I.isCompact_Icc.uniformContinuousOn_of_continuous hc
-  rw [Metric.uniformContinuousOn_iff_le] at huc
-  refine integrable_iff_cauchy_basis.2 fun ε ε0 => ?_
-  rcases exists_pos_mul_lt ε0 (μ.toBoxAdditive I) with ⟨ε', ε0', hε⟩
-  rcases huc ε' ε0' with ⟨δ, δ0 : 0 < δ, Hδ⟩
-  refine ⟨fun _ _ => ⟨δ / 2, half_pos δ0⟩, fun _ _ _ => rfl, fun c₁ c₂ π₁ π₂ h₁ h₁p h₂ h₂p => ?_⟩
-  simp only [dist_eq_norm, integralSum_sub_partitions _ _ h₁p h₂p, BoxAdditiveMap.toSMul_apply,
-    ← smul_sub]
-  have : ∀ J ∈ π₁.toPrepartition ⊓ π₂.toPrepartition,
-      ‖μ.toBoxAdditive J • (f ((π₁.infPrepartition π₂.toPrepartition).tag J) -
-        f ((π₂.infPrepartition π₁.toPrepartition).tag J))‖ ≤ μ.toBoxAdditive J * ε' := by
-    intro J hJ
-    have : 0 ≤ μ.toBoxAdditive J := ENNReal.toReal_nonneg
-    rw [norm_smul, Real.norm_eq_abs, abs_of_nonneg this, ← dist_eq_norm]
-    refine mul_le_mul_of_nonneg_left ?_ this
-    refine Hδ _ (TaggedPrepartition.tag_mem_Icc _ _) _ (TaggedPrepartition.tag_mem_Icc _ _) ?_
-    rw [← add_halves δ]
-    refine (dist_triangle_left _ _ J.upper).trans (add_le_add (h₁.1 _ ?_ ?_) (h₂.1 _ ?_ ?_))
-    · exact Prepartition.biUnionIndex_mem _ hJ
-    · exact Box.le_iff_Icc.1 (Prepartition.le_biUnionIndex _ hJ) J.upper_mem_Icc
-    · rw [_root_.inf_comm] at hJ
-      exact Prepartition.biUnionIndex_mem _ hJ
-    · rw [_root_.inf_comm] at hJ
-      exact Box.le_iff_Icc.1 (Prepartition.le_biUnionIndex _ hJ) J.upper_mem_Icc
-  refine (norm_sum_le_of_le _ this).trans ?_
-  rw [← Finset.sum_mul, μ.toBoxAdditive.sum_partition_boxes le_top (h₁p.inf h₂p)]
-  exact hε.le
+  apply integrable_of_bounded_and_ae_continuousWithinAt
+  · obtain ⟨C, hC⟩ := (NormedSpace.isBounded_iff_subset_smul_closedBall ℝ E).1
+                        (I.isCompact_Icc.image_of_continuousOn hc).isBounded
+    use ‖C‖, fun x hx ↦ by
+      simpa only [smul_closedUnitBall, mem_closedBall_zero_iff] using hC (Set.mem_image_of_mem f hx)
+  · refine eventually_of_mem ?_ (fun x hx ↦ hc.continuousWithinAt hx)
+    rw [mem_ae_iff, μ.restrict_apply] <;> simp [MeasurableSet.compl_iff.2 I.measurableSet_Icc]
 #align box_integral.integrable_of_continuous_on BoxIntegral.integrable_of_continuousOn
 
 variable {l}

--- a/Mathlib/Analysis/BoxIntegral/Integrability.lean
+++ b/Mathlib/Analysis/BoxIntegral/Integrability.lean
@@ -317,4 +317,33 @@ theorem ContinuousOn.hasBoxIntegral [CompleteSpace E] {f : (ι → ℝ) → E} (
     IntegrableOn.mono_set (hc.integrableOn_compact I.isCompact_Icc) Box.coe_subset_Icc
   exact HasIntegral.unique (IntegrableOn.hasBoxIntegral this ⊥ rfl) (HasIntegral.mono hy bot_le)
 
+/-- If `f : ℝⁿ → E` is a.e. continuous and bounded on a rectangular box `I`, then it is Box
+    integrable on `I` w.r.t. a locally finite measure `μ` with the same integral. -/
+theorem AEContinuous.hasBoxIntegral [CompleteSpace E] {f : (ι → ℝ) → E} (μ : Measure (ι → ℝ))
+    [IsLocallyFiniteMeasure μ] {I : Box ι} (hb : ∃ C : ℝ, ∀ x ∈ Box.Icc I, ‖f x‖ ≤ C)
+    (hc : ∀ᵐ x ∂μ, ContinuousAt f x) (l : IntegrationParams) :
+    HasIntegral.{u, v, v} I l f μ.toBoxAdditive.toSMul (∫ x in I, f x ∂μ) := by
+  obtain ⟨y, hy⟩ := integrable_of_bounded_and_ae_continuous l hb μ hc
+  convert hy
+  refine HasIntegral.unique (IntegrableOn.hasBoxIntegral ?_ ⊥ rfl) (HasIntegral.mono hy bot_le)
+  constructor
+  · let v := {x : (ι → ℝ) | ContinuousAt f x}
+    have : AEStronglyMeasurable f (μ.restrict v) :=
+      (ContinuousAt.continuousOn fun _ h ↦ h).aestronglyMeasurable (measurableSet_of_continuousAt f)
+    refine this.mono_measure (Measure.le_iff.2 fun s hs ↦ ?_)
+    repeat rw [μ.restrict_apply hs]
+    apply le_of_le_of_eq <| μ.mono (Set.inter_subset_left s I)
+    refine measure_eq_measure_of_null_diff (Set.inter_subset_left s v) ?_ |>.symm
+    rw [diff_self_inter, Set.diff_eq]
+    refine (le_antisymm (zero_le (μ (s ∩ vᶜ))) ?_).symm
+    exact le_trans (μ.mono (Set.inter_subset_right s vᶜ)) (nonpos_iff_eq_zero.2 hc)
+  · have : IsFiniteMeasure (μ.restrict (Box.Icc I)) :=
+      { measure_univ_lt_top := by simp [I.isCompact_Icc.measure_lt_top (μ := μ)] }
+    have : IsFiniteMeasure (μ.restrict I) :=
+      isFiniteMeasure_of_le (μ.restrict (Box.Icc I))
+                            (μ.restrict_mono Box.coe_subset_Icc (le_refl μ))
+    obtain ⟨C, hC⟩ := hb
+    refine hasFiniteIntegral_of_bounded (C := C) (Filter.eventually_iff_exists_mem.2 ?_)
+    use I, self_mem_ae_restrict I.measurableSet_coe, fun y hy ↦ hC y (I.coe_subset_Icc hy)
+
 end MeasureTheory

--- a/Mathlib/Analysis/BoxIntegral/Integrability.lean
+++ b/Mathlib/Analysis/BoxIntegral/Integrability.lean
@@ -332,11 +332,11 @@ theorem AEContinuous.hasBoxIntegral [CompleteSpace E] {f : (ι → ℝ) → E} (
       (ContinuousAt.continuousOn fun _ h ↦ h).aestronglyMeasurable (measurableSet_of_continuousAt f)
     refine this.mono_measure (Measure.le_iff.2 fun s hs ↦ ?_)
     repeat rw [μ.restrict_apply hs]
-    apply le_of_le_of_eq <| μ.mono (Set.inter_subset_left s I)
-    refine measure_eq_measure_of_null_diff (Set.inter_subset_left s v) ?_ |>.symm
+    apply le_of_le_of_eq <| μ.mono s.inter_subset_left
+    refine measure_eq_measure_of_null_diff s.inter_subset_left ?_ |>.symm
     rw [diff_self_inter, Set.diff_eq]
     refine (le_antisymm (zero_le (μ (s ∩ vᶜ))) ?_).symm
-    exact le_trans (μ.mono (Set.inter_subset_right s vᶜ)) (nonpos_iff_eq_zero.2 hc)
+    exact le_trans (μ.mono s.inter_subset_right) (nonpos_iff_eq_zero.2 hc)
   · have : IsFiniteMeasure (μ.restrict (Box.Icc I)) :=
       { measure_univ_lt_top := by simp [I.isCompact_Icc.measure_lt_top (μ := μ)] }
     have : IsFiniteMeasure (μ.restrict I) :=

--- a/Mathlib/Analysis/Oscillation.lean
+++ b/Mathlib/Analysis/Oscillation.lean
@@ -1,0 +1,154 @@
+/-
+Copyright (c) 2024 James Sundstrom. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: James Sundstrom
+-/
+import Mathlib.Topology.EMetricSpace.Basic
+import Mathlib.Order.WellFoundedSet
+
+/-!
+# Oscillation
+
+In this file we define the oscillation of a function `f: E → F` at a point `x` of `E`. (`E` is
+required to be a TopologicalSpace and `F` a PseudoEMetricSpace.) The oscillation of `f` at `x` is
+defined to be the infimum of `diam f '' N` for all neighborhoods `N` of `x`. We also define
+`oscillationWithin f D x`, which is the oscillation at `x` of `f` restricted to `D`.
+
+We also prove some simple facts about oscillation, most notably that the oscillation of `f`
+at `x` is 0 if and only if `f` is continuous at `x`, with versions for both `oscillation` and
+`oscillationWithin`.
+
+## Tags
+
+oscillation, oscillationWithin
+-/
+
+open Topology EMetric Set ENNReal
+
+universe u v
+
+variable {E : Type u} {F : Type v} [PseudoEMetricSpace F]
+
+/-- The oscillation of `f : E → F` at `x`. -/
+noncomputable def oscillation [TopologicalSpace E] (f : E → F) (x : E) : ENNReal :=
+  ⨅ S ∈ (𝓝 x).map f, diam S
+
+/-- The oscillation of `f : E → F` within `D` at `x`. -/
+noncomputable def oscillationWithin [TopologicalSpace E] (f : E → F) (D : Set E) (x : E) :
+  ENNReal := ⨅ S ∈ (𝓝[D] x).map f, diam S
+
+/-- The oscillation of `f` at `x` within a neighborhood `D` of `x` is equal to `oscillation f x` -/
+theorem oscillationWithin_nhd_eq_oscillation [TopologicalSpace E] (f : E → F) (D : Set E) (x : E)
+    (hD : D ∈ 𝓝 x) : oscillationWithin f D x = oscillation f x := by
+  rw [oscillation, oscillationWithin, nhdsWithin_eq_nhds.2 hD]
+
+/-- The oscillation of `f` at `x` within `univ` is equal to `oscillation f x` -/
+theorem oscillationWithin_univ_eq_oscillation [TopologicalSpace E] (f : E → F) (x : E) :
+    oscillationWithin f univ x = oscillation f x :=
+  oscillationWithin_nhd_eq_oscillation f univ x Filter.univ_mem
+
+namespace ContinuousWithinAt
+
+theorem oscillationWithin_eq_zero [TopologicalSpace E] {f : E → F} {D : Set E}
+    {x : E} (hf : ContinuousWithinAt f D x) : oscillationWithin f D x = 0 := by
+  refine le_antisymm (le_of_forall_pos_le_add fun ε hε _ ↦ ?_) (zero_le _)
+  rw [zero_add]
+  have : ball (f x) (ε / 2) ∈ (𝓝[D] x).map f := hf <| ball_mem_nhds _ (by simp [ne_of_gt hε])
+  refine (biInf_le diam this).trans (le_of_le_of_eq diam_ball ?_)
+  exact (ENNReal.mul_div_cancel' (by norm_num) (by norm_num))
+
+end ContinuousWithinAt
+
+namespace ContinuousAt
+
+theorem oscillation_eq_zero [TopologicalSpace E] {f : E → F} {x : E} (hf : ContinuousAt f x) :
+    oscillation f x = 0 := by
+  rw [← continuousWithinAt_univ f x] at hf
+  exact oscillationWithin_univ_eq_oscillation f x ▸ hf.oscillationWithin_eq_zero
+
+end ContinuousAt
+
+namespace OscillationWithin
+
+/-- The oscillation within `D` of `f` at `x ∈ D` is 0 if and only if `ContinuousWithinAt f D x`. -/
+theorem eq_zero_iff_continuousWithinAt [TopologicalSpace E] (f : E → F) {D : Set E}
+    {x : E} (xD : x ∈ D): oscillationWithin f D x = 0 ↔ ContinuousWithinAt f D x := by
+  refine ⟨fun hf ↦ EMetric.tendsto_nhds.mpr (fun ε ε0 ↦ ?_), fun hf ↦ hf.oscillationWithin_eq_zero⟩
+  simp_rw [← hf, oscillationWithin, iInf_lt_iff] at ε0
+  obtain ⟨S, hS, Sε⟩ := ε0
+  refine Filter.mem_of_superset hS (fun y hy ↦ lt_of_le_of_lt ?_ Sε)
+  exact edist_le_diam_of_mem (mem_preimage.1 hy) <| mem_preimage.1 (mem_of_mem_nhdsWithin xD hS)
+
+end OscillationWithin
+
+namespace Oscillation
+
+/-- The oscillation of `f` at `x` is 0 if and only if `f` is continuous at `x`. -/
+theorem eq_zero_iff_continuousAt [TopologicalSpace E] (f : E → F) (x : E) :
+    oscillation f x = 0 ↔ ContinuousAt f x := by
+  rw [← oscillationWithin_univ_eq_oscillation, ← continuousWithinAt_univ f x]
+  exact OscillationWithin.eq_zero_iff_continuousWithinAt f (mem_univ x)
+
+end Oscillation
+
+namespace IsCompact
+
+variable [PseudoEMetricSpace E] {K : Set E} (comp : IsCompact K)
+variable {f : E → F} {D : Set E} {ε : ENNReal}
+
+/-- If `oscillationWithin f D x < ε` at every `x` in a compact set `K`, then there exists `δ > 0`
+such that the oscillation of `f` on `ball x δ ∩ D` is less than `ε` for every `x` in `K`. -/
+theorem uniform_oscillationWithin (hK : ∀ x ∈ K, oscillationWithin f D x < ε) :
+    ∃ δ > 0, ∀ x ∈ K, diam (f '' (ball x (ENNReal.ofReal δ) ∩ D)) ≤ ε := by
+  let S := fun r ↦ { x : E | ∃ (a : ℝ), (a > r ∧ diam (f '' (ball x (ENNReal.ofReal a) ∩ D)) ≤ ε) }
+  have S_open : ∀ r > 0, IsOpen (S r) := by
+    refine fun r _ ↦ isOpen_iff.mpr fun x ⟨a, ar, ha⟩ ↦
+      ⟨ENNReal.ofReal ((a - r) / 2), by simp [ar], ?_⟩
+    refine fun y hy ↦ ⟨a - (a - r) / 2, by linarith,
+      le_trans (diam_mono (image_mono fun z hz ↦ ?_)) ha⟩
+    refine ⟨lt_of_le_of_lt (edist_triangle z y x) (lt_of_lt_of_eq (add_lt_add hz.1 hy) ?_),
+      hz.2⟩
+    rw [← ofReal_add (by linarith) (by linarith), sub_add_cancel]
+  have S_cover : K ⊆ ⋃ r > 0, S r := by
+    intro x hx
+    have : oscillationWithin f D x < ε := hK x hx
+    simp only [oscillationWithin, Filter.mem_map, iInf_lt_iff] at this
+    obtain ⟨n, hn₁, hn₂⟩ := this
+    obtain ⟨r, r0, hr⟩ := mem_nhdsWithin_iff.1 hn₁
+    simp only [gt_iff_lt, mem_iUnion, exists_prop]
+    have : ∀ r', (ENNReal.ofReal r') ≤ r → diam (f '' (ball x (ENNReal.ofReal r') ∩ D)) ≤ ε := by
+      intro r' hr'
+      refine le_trans (diam_mono (subset_trans ?_ (image_subset_iff.2 hr))) (le_of_lt hn₂)
+      exact image_mono (inter_subset_inter_left D (ball_subset_ball hr'))
+    by_cases r_top : r = ⊤
+    · use 1, one_pos, 2, one_lt_two, this 2 (by simp only [r_top, le_top])
+    · obtain ⟨r', hr'⟩ := exists_between (toReal_pos (ne_of_gt r0) r_top)
+      use r', hr'.1, r.toReal, hr'.2, this r.toReal ofReal_toReal_le
+  have S_antitone : ∀ (r₁ r₂ : ℝ), r₁ ≤ r₂ → S r₂ ⊆ S r₁ :=
+    fun r₁ r₂ hr x ⟨a, ar₂, ha⟩ ↦ ⟨a, lt_of_le_of_lt hr ar₂, ha⟩
+  obtain ⟨δ, δ0, hδ⟩ : ∃ r > 0, K ⊆ S r := by
+    obtain ⟨T, Tb, Tfin, hT⟩ := comp.elim_finite_subcover_image S_open S_cover
+    by_cases T_nonempty : T.Nonempty
+    · use Tfin.isWF.min T_nonempty, Tb (Tfin.isWF.min_mem T_nonempty)
+      intro x hx
+      obtain ⟨r, hr⟩ := mem_iUnion.1 (hT hx)
+      simp only [mem_iUnion, exists_prop] at hr
+      exact (S_antitone _ r (IsWF.min_le Tfin.isWF T_nonempty hr.1)) hr.2
+    · rw [not_nonempty_iff_eq_empty] at T_nonempty
+      use 1, one_pos, subset_trans hT (by simp [T_nonempty])
+  use δ, δ0
+  intro x xK
+  obtain ⟨a, δa, ha⟩ := hδ xK
+  exact (diam_mono <| image_mono <| inter_subset_inter_left D <| ball_subset_ball <|
+    coe_le_coe.2 <| Real.toNNReal_mono (le_of_lt δa)).trans ha
+
+/-- If `oscillation f x < ε` at every `x` in a compact set `K`, then there exists `δ > 0` such
+that the oscillation of `f` on `ball x δ` is less than `ε` for every `x` in `K`. -/
+theorem uniform_oscillation [PseudoEMetricSpace E] {K : Set E} (comp : IsCompact K)
+    {f : E → F} {ε : ENNReal} (hK : ∀ x ∈ K, oscillation f x < ε) :
+    ∃ δ > 0, ∀ x ∈ K, diam (f '' (ball x (ENNReal.ofReal δ))) ≤ ε := by
+  simp only [← oscillationWithin_univ_eq_oscillation] at hK
+  convert ← comp.uniform_oscillationWithin hK
+  exact inter_univ _
+
+end IsCompact


### PR DESCRIPTION
Prove that a function that is bounded and a.e. continuous within a box is integrable on that box. This generalizes integrable_of_continuousOn.

As an intermediate step, define the oscillation of a function at a point x (and oscillationWithin for the oscillation at x within a specific subset). Also prove some lemmas about oscillation, namely that oscillation is 0 at a point if and only if the function is continuous there, and a statement about uniformity of oscillation on a compact set, with versions for oscillation and oscillationWithin.

This is essentially the same as #13013, but I'm making a new PR because I messed up the other branch.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
