### PR TITLE
[Merged by Bors] - feat: `0 < c * a * star c` in `StarOrderedRing`s

### DIFF
--- a/Mathlib/Algebra/Star/Order.lean
+++ b/Mathlib/Algebra/Star/Order.lean
@@ -246,7 +246,7 @@ theorem conjugate_lt_conjugate' {a b : R} (hab : a < b) {c : R} (hc : IsRegular 
 theorem conjugate_pos {a : R} (ha : 0 < a) {c : R} (hc : IsRegular c) : 0 < star c * a * c := by
   simpa only [mul_zero, zero_mul] using conjugate_lt_conjugate ha hc
 
-theorem conjugate_pos' {a : R} (ha : 0 < a) {c : R}  (hc : IsRegular c) : 0 < c * a * star c := by
+theorem conjugate_pos' {a : R} (ha : 0 < a) {c : R} (hc : IsRegular c) : 0 < c * a * star c := by
   simpa only [star_star] using conjugate_pos ha hc.star
 
 theorem star_mul_self_pos [Nontrivial R] {x : R} (hx : IsRegular x) : 0 < star x * x := by

--- a/Mathlib/Algebra/Star/Order.lean
+++ b/Mathlib/Algebra/Star/Order.lean
@@ -234,11 +234,19 @@ lemma IsSelfAdjoint.mono {x y : R} (h : x ≤ y) (hx : IsSelfAdjoint x) : IsSelf
 lemma IsSelfAdjoint.of_nonneg {x : R} (hx : 0 ≤ x) : IsSelfAdjoint x :=
   (isSelfAdjoint_zero R).mono hx
 
-theorem conjugate_pos {a : R} (ha : 0 < a) {c : R} (hc : IsRegular c) : 0 < star c * a * c := by
-  rw [(conjugate_nonneg ha.le _).lt_iff_ne]
+theorem conjugate_lt_conjugate {a b : R} (hab : a < b) {c : R} (hc : IsRegular c) :
+    star c * a * c < star c * b * c := by
+  rw [(conjugate_le_conjugate hab.le _).lt_iff_ne]
   intro h
-  rw [← mul_zero (star c), ← zero_mul c, mul_assoc, hc.star.left.eq_iff, hc.right.eq_iff] at h
-  exact ha.ne h
+  rw [hc.right.eq_iff, hc.star.left.eq_iff] at h
+  exact hab.ne h
+
+theorem conjugate_lt_conjugate' {a b : R} (hab : a < b) {c : R} (hc : IsRegular c) :
+    c * a * star c < c * b * star c := by
+  simpa only [star_star] using conjugate_lt_conjugate hab hc.star
+
+theorem conjugate_pos {a : R} (ha : 0 < a) {c : R} (hc : IsRegular c) : 0 < star c * a * c := by
+  simpa only [mul_zero, zero_mul] using conjugate_lt_conjugate ha hc
 
 theorem conjugate_pos' {a : R} (ha : 0 < a) {c : R}  (hc : IsRegular c) : 0 < c * a * star c := by
   simpa only [star_star] using conjugate_pos ha hc.star

--- a/Mathlib/Algebra/Star/Order.lean
+++ b/Mathlib/Algebra/Star/Order.lean
@@ -234,6 +234,15 @@ lemma IsSelfAdjoint.mono {x y : R} (h : x ≤ y) (hx : IsSelfAdjoint x) : IsSelf
 lemma IsSelfAdjoint.of_nonneg {x : R} (hx : 0 ≤ x) : IsSelfAdjoint x :=
   (isSelfAdjoint_zero R).mono hx
 
+theorem conjugate_pos {a : R} (ha : 0 < a) {c : R} (hc : IsRegular c) : 0 < star c * a * c := by
+  rw [(conjugate_nonneg ha.le _).lt_iff_ne]
+  intro h
+  rw [← mul_zero (star c), ← zero_mul c, mul_assoc, hc.star.left.eq_iff, hc.right.eq_iff] at h
+  exact ha.ne h
+
+theorem conjugate_pos' {a : R} (ha : 0 < a) {c : R}  (hc : IsRegular c) : 0 < c * a * star c := by
+  simpa only [star_star] using conjugate_pos ha hc.star
+
 theorem star_mul_self_pos [Nontrivial R] {x : R} (hx : IsRegular x) : 0 < star x * x := by
   rw [(star_mul_self_nonneg _).lt_iff_ne]
   intro h

--- a/Mathlib/Algebra/Star/Order.lean
+++ b/Mathlib/Algebra/Star/Order.lean
@@ -236,10 +236,8 @@ lemma IsSelfAdjoint.of_nonneg {x : R} (hx : 0 ≤ x) : IsSelfAdjoint x :=
 
 theorem conjugate_lt_conjugate {a b : R} (hab : a < b) {c : R} (hc : IsRegular c) :
     star c * a * c < star c * b * c := by
-  rw [(conjugate_le_conjugate hab.le _).lt_iff_ne]
-  intro h
-  rw [hc.right.eq_iff, hc.star.left.eq_iff] at h
-  exact hab.ne h
+  rw [(conjugate_le_conjugate hab.le _).lt_iff_ne, hc.right.ne_iff, hc.star.left.ne_iff]
+  exact hab.ne
 
 theorem conjugate_lt_conjugate' {a b : R} (hab : a < b) {c : R} (hc : IsRegular c) :
     c * a * star c < c * b * star c := by
@@ -252,10 +250,8 @@ theorem conjugate_pos' {a : R} (ha : 0 < a) {c : R}  (hc : IsRegular c) : 0 < c 
   simpa only [star_star] using conjugate_pos ha hc.star
 
 theorem star_mul_self_pos [Nontrivial R] {x : R} (hx : IsRegular x) : 0 < star x * x := by
-  rw [(star_mul_self_nonneg _).lt_iff_ne]
-  intro h
-  rw [← mul_zero (star x), hx.star.left.eq_iff] at h
-  exact hx.ne_zero h.symm
+  rw [(star_mul_self_nonneg _).lt_iff_ne, ← mul_zero (star x), hx.star.left.ne_iff]
+  exact hx.ne_zero.symm
 
 theorem mul_star_self_pos [Nontrivial R] {x : R} (hx : IsRegular x) : 0 < x * star x := by
   simpa using star_mul_self_pos hx.star


### PR DESCRIPTION
This is a prerequisite for showing when diagonal matrices are positive definite.

Missed from #13748

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
