### PR TITLE
[Merged by Bors] - chore: remove unnecessary @[simps]

### DIFF
--- a/Mathlib/RepresentationTheory/GroupCohomology/LowDegree.lean
+++ b/Mathlib/RepresentationTheory/GroupCohomology/LowDegree.lean
@@ -699,7 +699,6 @@ lemma dZero_comp_H0_subtype : dZero A ∘ₗ (H0 A).subtype = 0 := by
   exact hx
 
 /-- The (exact) short complex `A.ρ.invariants ⟶ A ⟶ (G → A)`. -/
-@[simps!]
 def shortComplexH0 : ShortComplex (ModuleCat k) :=
   ShortComplex.moduleCatMk _ _ (dZero_comp_H0_subtype A)
 


### PR DESCRIPTION
This `@[simps]` is apparently unnecessary, and on a nightly generates lemmas that the linter doesn't like, so just remove it.