### PR TITLE
[Merged by Bors] - feat(lint-style): fix `update-style-exceptions.py`; produce human-readable output by default

### DIFF
--- a/Mathlib/Tactic/Linter/TextBased.lean
+++ b/Mathlib/Tactic/Linter/TextBased.lean
@@ -240,7 +240,7 @@ def lint_style : Cmd := `[Cli|
   FLAGS:
     github;     "Print errors in a format suitable for github problem matchers\n\
                  otherwise, produce human-readable output"
-    update;     "Print errors for the style exceptions file: mutually exclusive with the above"
+    update;     "Print errors solely for the style exceptions file"
 ]
 
 /-- The entry point to the `lake exe lint_style` command. -/

--- a/scripts/lint-style.sh
+++ b/scripts/lint-style.sh
@@ -43,7 +43,7 @@ git ls-files 'Archive/*.lean' | xargs ./scripts/lint-style.py "$@"
 git ls-files 'Counterexamples/*.lean' | xargs ./scripts/lint-style.py "$@"
 
 # Call the in-progress Lean rewrite of these Python lints.
-lake exe lint_style
+lake exe lint_style --github
 
 # 2. Global checks on the mathlib repository
 

--- a/scripts/update-style-exceptions.sh
+++ b/scripts/update-style-exceptions.sh
@@ -18,4 +18,4 @@
 find Mathlib -name '*.lean' | xargs ./scripts/lint-style.py | LC_ALL=C sort > scripts/style-exceptions.txt
 
 # Append the warnings of the Lean linter, on the file length.
-lake exe lint_style >> scripts/style-exceptions.txt
+lake exe lint_style --update >> scripts/style-exceptions.txt


### PR DESCRIPTION
- Fix the output of `update-style-exceptions.py` by making `lake exe lint_style` optionally produce output in the right format: this regressed in #13620
- The current error messages are tailored for github annotations, which are not very readable for running the linter locally. Produce a human-readable and clickable error by default, but add a flag (which CI sets) for producing github-style output.

This entails adding a small CLI for the lint-style executable.