### PR TITLE
[Merged by Bors] - feat(Algebra/Homology): definition of Functor.mapDerivedCategory

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -292,6 +292,7 @@ import Mathlib.Algebra.Homology.ComplexShape
 import Mathlib.Algebra.Homology.ComplexShapeSigns
 import Mathlib.Algebra.Homology.ConcreteCategory
 import Mathlib.Algebra.Homology.DerivedCategory.Basic
+import Mathlib.Algebra.Homology.DerivedCategory.ExactFunctor
 import Mathlib.Algebra.Homology.DerivedCategory.HomologySequence
 import Mathlib.Algebra.Homology.DifferentialObject
 import Mathlib.Algebra.Homology.Embedding.Basic

--- a/Mathlib/Algebra/Homology/DerivedCategory/ExactFunctor.lean
+++ b/Mathlib/Algebra/Homology/DerivedCategory/ExactFunctor.lean
@@ -8,9 +8,9 @@ import Mathlib.Algebra.Homology.DerivedCategory.Basic
 /-!
 # An exact functor induces a functor on derived categories
 
-In this file, we show that if `F : C ⥤ D` is an exact functor between
+In this file, we show that if `F : C₁ ⥤ C₂` is an exact functor between
 abelian categories, then there is an induced functor
-`F.mapDerivedCategory : DerivedCategory C ⥤ DerivedCategory D`.
+`F.mapDerivedCategory : DerivedCategory C₁ ⥤ DerivedCategory C₂`.
 
 ## TODO
 * show that `F.mapDerivedCategory` is a triangulated functor

--- a/Mathlib/Algebra/Homology/DerivedCategory/ExactFunctor.lean
+++ b/Mathlib/Algebra/Homology/DerivedCategory/ExactFunctor.lean
@@ -1,0 +1,59 @@
+/-
+Copyright (c) 2024 Joël Riou. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Joël Riou
+-/
+import Mathlib.Algebra.Homology.DerivedCategory.Basic
+
+/-!
+# An exact functor induces a functor on derived categories
+
+In this file, we show that if `F : C ⥤ D` is an exact functor between
+abelian categories, then there is an induced functor
+`F.mapDerivedCategory : DerivedCategory C ⥤ DerivedCategory D`.
+
+## TODO
+* show that `F.mapDerivedCategory` is a triangulated functor
+
+-/
+
+universe w₁ w₂ v₁ v₂ u₁ u₂
+
+open CategoryTheory Limits
+
+variable {C₁ : Type u₁} [Category.{v₁} C₁] [Abelian C₁] [HasDerivedCategory.{w₁} C₁]
+  {C₂ : Type u₂} [Category.{v₂} C₂] [Abelian C₂] [HasDerivedCategory.{w₂} C₂]
+  (F : C₁ ⥤ C₂) [F.Additive] [PreservesFiniteLimits F] [PreservesFiniteColimits F]
+
+namespace CategoryTheory.Functor
+
+/-- The functor `DerivedCategory C₁ ⥤ DerivedCategory C₂` induced
+by an exact functor `F : C₁ ⥤ C₂` between abelian categories. -/
+noncomputable def mapDerivedCategory : DerivedCategory C₁ ⥤ DerivedCategory C₂ :=
+  F.mapHomologicalComplexUpToQuasiIso (ComplexShape.up ℤ)
+
+/-- The functor `F.mapDerivedCategory` is induced
+by `F.mapHomologicalComplex (ComplexShape.up ℤ)`. -/
+noncomputable def mapDerivedCategoryFactors :
+    DerivedCategory.Q ⋙ F.mapDerivedCategory ≅
+      F.mapHomologicalComplex (ComplexShape.up ℤ) ⋙ DerivedCategory.Q :=
+  F.mapHomologicalComplexUpToQuasiIsoFactors _
+
+noncomputable instance : Localization.Lifting DerivedCategory.Q
+      (HomologicalComplex.quasiIso C₁ (ComplexShape.up ℤ))
+      (F.mapHomologicalComplex _ ⋙ DerivedCategory.Q) F.mapDerivedCategory :=
+  ⟨F.mapDerivedCategoryFactors⟩
+
+/-- The functor `F.mapDerivedCategory` is induced
+by `F.mapHomotopyCategory (ComplexShape.up ℤ)`. -/
+noncomputable def mapDerivedCategoryFactorsh :
+    DerivedCategory.Qh ⋙ F.mapDerivedCategory ≅
+      F.mapHomotopyCategory (ComplexShape.up ℤ) ⋙ DerivedCategory.Qh :=
+  F.mapHomologicalComplexUpToQuasiIsoFactorsh _
+
+noncomputable instance : Localization.Lifting DerivedCategory.Qh
+      (HomotopyCategory.quasiIso C₁ (ComplexShape.up ℤ))
+      (F.mapHomotopyCategory _ ⋙ DerivedCategory.Qh) F.mapDerivedCategory :=
+  ⟨F.mapDerivedCategoryFactorsh⟩
+
+end CategoryTheory.Functor

--- a/Mathlib/Algebra/Homology/DerivedCategory/ExactFunctor.lean
+++ b/Mathlib/Algebra/Homology/DerivedCategory/ExactFunctor.lean
@@ -39,7 +39,8 @@ noncomputable def mapDerivedCategoryFactors :
       F.mapHomologicalComplex (ComplexShape.up ℤ) ⋙ DerivedCategory.Q :=
   F.mapHomologicalComplexUpToQuasiIsoFactors _
 
-noncomputable instance : Localization.Lifting DerivedCategory.Q
+noncomputable instance :
+    Localization.Lifting DerivedCategory.Q
       (HomologicalComplex.quasiIso C₁ (ComplexShape.up ℤ))
       (F.mapHomologicalComplex _ ⋙ DerivedCategory.Q) F.mapDerivedCategory :=
   ⟨F.mapDerivedCategoryFactors⟩
@@ -51,7 +52,8 @@ noncomputable def mapDerivedCategoryFactorsh :
       F.mapHomotopyCategory (ComplexShape.up ℤ) ⋙ DerivedCategory.Qh :=
   F.mapHomologicalComplexUpToQuasiIsoFactorsh _
 
-noncomputable instance : Localization.Lifting DerivedCategory.Qh
+noncomputable instance :
+    Localization.Lifting DerivedCategory.Qh
       (HomotopyCategory.quasiIso C₁ (ComplexShape.up ℤ))
       (F.mapHomotopyCategory _ ⋙ DerivedCategory.Qh) F.mapDerivedCategory :=
   ⟨F.mapDerivedCategoryFactorsh⟩

--- a/Mathlib/Algebra/Homology/Localization.lean
+++ b/Mathlib/Algebra/Homology/Localization.lean
@@ -291,3 +291,74 @@ example [(HomologicalComplex.quasiIso C (ComplexShape.up ℤ)).HasLocalization] 
   inferInstance
 
 end CochainComplex
+
+namespace CategoryTheory.Functor
+
+variable {C D : Type*} [Category C] [Category D] (F : C ⥤ D)
+  {ι : Type*} (c : ComplexShape ι)
+
+section
+
+variable [Preadditive C] [Preadditive D]
+  [CategoryWithHomology C] [CategoryWithHomology D]
+  [(HomologicalComplex.quasiIso C c).HasLocalization]
+  [(HomologicalComplex.quasiIso D c).HasLocalization]
+  [F.Additive] [F.PreservesHomology]
+
+lemma mapHomologicalComplex_upToQuasiIso_Q_inverts_quasiIso :
+    (HomologicalComplex.quasiIso C c).IsInvertedBy
+      (F.mapHomologicalComplex c ⋙ HomologicalComplexUpToQuasiIso.Q) := fun K L f hf ↦ by
+  apply Localization.inverts _ (HomologicalComplex.quasiIso D c)
+  have : QuasiIso f := hf
+  apply HomologicalComplex.quasiIso_map_of_preservesHomology
+
+/-- The functor `HomologicalComplexUpToQuasiIso C c ⥤ HomologicalComplexUpToQuasiIso D c`
+induced by a functor `F : C ⥤ D` whcih preserves homology. -/
+noncomputable def mapHomologicalComplexUpToQuasiIso :
+    HomologicalComplexUpToQuasiIso C c ⥤ HomologicalComplexUpToQuasiIso D c :=
+  Localization.lift _
+    (F.mapHomologicalComplex_upToQuasiIso_Q_inverts_quasiIso c)
+    HomologicalComplexUpToQuasiIso.Q
+
+noncomputable instance :
+    Localization.Lifting HomologicalComplexUpToQuasiIso.Q
+      (HomologicalComplex.quasiIso C c)
+      (F.mapHomologicalComplex c ⋙ HomologicalComplexUpToQuasiIso.Q)
+      (F.mapHomologicalComplexUpToQuasiIso c) := by
+  dsimp only [mapHomologicalComplexUpToQuasiIso]
+  infer_instance
+
+/-- The functor `F.mapHomologicalComplexUpToQuasiIso c` is induced by
+`F.mapHomologicalComplex c`. -/
+noncomputable def mapHomologicalComplexUpToQuasiIsoFactors :
+    HomologicalComplexUpToQuasiIso.Q ⋙ F.mapHomologicalComplexUpToQuasiIso c ≅
+      F.mapHomologicalComplex c ⋙ HomologicalComplexUpToQuasiIso.Q :=
+  Localization.Lifting.iso HomologicalComplexUpToQuasiIso.Q
+      (HomologicalComplex.quasiIso C c) _ _
+
+variable [c.QFactorsThroughHomotopy C] [c.QFactorsThroughHomotopy D]
+  [(HomotopyCategory.quotient C c).IsLocalization
+    (HomologicalComplex.homotopyEquivalences C c)]
+
+/-- The functor `F.mapHomologicalComplexUpToQuasiIso c` is induced by
+`F.mapHomotopyCategory c`. -/
+noncomputable def mapHomologicalComplexUpToQuasiIsoFactorsh :
+    HomologicalComplexUpToQuasiIso.Qh ⋙ F.mapHomologicalComplexUpToQuasiIso c ≅
+      F.mapHomotopyCategory c ⋙ HomologicalComplexUpToQuasiIso.Qh :=
+  Localization.liftNatIso (HomotopyCategory.quotient C c)
+    (HomologicalComplex.homotopyEquivalences C c)
+    (HomotopyCategory.quotient C c ⋙ HomologicalComplexUpToQuasiIso.Qh ⋙
+      F.mapHomologicalComplexUpToQuasiIso c)
+    (HomotopyCategory.quotient C c ⋙ F.mapHomotopyCategory c ⋙
+      HomologicalComplexUpToQuasiIso.Qh) _ _
+      (F.mapHomologicalComplexUpToQuasiIsoFactors c)
+
+noncomputable instance :
+    Localization.Lifting HomologicalComplexUpToQuasiIso.Qh (HomotopyCategory.quasiIso C c)
+      (F.mapHomotopyCategory c ⋙ HomologicalComplexUpToQuasiIso.Qh)
+      (F.mapHomologicalComplexUpToQuasiIso c) :=
+  ⟨F.mapHomologicalComplexUpToQuasiIsoFactorsh c⟩
+
+end
+
+end CategoryTheory.Functor


### PR DESCRIPTION
If `F` is an exact functor between abelian categories, we define the induced functor on the derived categories.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
