### PR TITLE
[Merged by Bors] - feat: Monotonicity of the slope of a convex function

### DIFF
--- a/Mathlib/Analysis/Convex/Deriv.lean
+++ b/Mathlib/Analysis/Convex/Deriv.lean
@@ -384,10 +384,14 @@ section slope
 
 variable {𝕜 : Type*} [LinearOrderedField 𝕜] {s : Set 𝕜} {f : 𝕜 → 𝕜} {x : 𝕜}
 
+/-- If `f : 𝕜 → 𝕜` is convex on `s`, then for any point `a ∈ s` the slope of the secant line of `f`
+through `a` is monotone on `s \ {a}`. -/
 lemma ConvexOn.slope_mono (hfc : ConvexOn 𝕜 s f) (hx : x ∈ s) : MonotoneOn (slope f x) (s \ {x}) :=
   (slope_fun_def_field f _).symm ▸ fun _ hy _ hz hz' ↦ hfc.secant_mono hx (mem_of_mem_diff hy)
     (mem_of_mem_diff hz) (not_mem_of_mem_diff hy :) (not_mem_of_mem_diff hz :) hz'
 
+/-- If `f : 𝕜 → 𝕜` is concave on `s`, then for any point `a ∈ s` the slope of the secant line of `f`
+through `a` is antitone on `s \ {a}`. -/
 lemma ConcaveOn.slope_anti (hfc : ConcaveOn 𝕜 s f) (hx : x ∈ s) :
     AntitoneOn (slope f x) (s \ {x}) := by
   rw [← neg_neg f, slope_neg_fun]

--- a/Mathlib/Analysis/Convex/Deriv.lean
+++ b/Mathlib/Analysis/Convex/Deriv.lean
@@ -380,6 +380,21 @@ lines, and deduce that if `f` is convex then its derivative is monotone (and sim
 convexity / strict monotonicity).
 -/
 
+section slope
+
+variable {𝕜 : Type*} [LinearOrderedField 𝕜] {s : Set 𝕜} {f : 𝕜 → 𝕜} {x : 𝕜}
+
+lemma ConvexOn.slope_mono (hfc : ConvexOn 𝕜 s f) (hx : x ∈ s) : MonotoneOn (slope f x) (s \ {x}) :=
+  (slope_fun_def_field f _).symm ▸ fun _ hy _ hz hz' ↦ hfc.secant_mono hx (mem_of_mem_diff hy)
+    (mem_of_mem_diff hz) (not_mem_of_mem_diff hy :) (not_mem_of_mem_diff hz :) hz'
+
+lemma ConcaveOn.slope_anti (hfc : ConcaveOn 𝕜 s f) (hx : x ∈ s) :
+    AntitoneOn (slope f x) (s \ {x}) := by
+  rw [← neg_neg f, slope_neg_fun]
+  exact (ConvexOn.slope_mono hfc.neg hx).neg
+
+end slope
+
 namespace ConvexOn
 
 variable {S : Set ℝ} {f : ℝ → ℝ} {x y f' : ℝ}

--- a/Mathlib/Analysis/Convex/Deriv.lean
+++ b/Mathlib/Analysis/Convex/Deriv.lean
@@ -384,8 +384,8 @@ section slope
 
 variable {𝕜 : Type*} [LinearOrderedField 𝕜] {s : Set 𝕜} {f : 𝕜 → 𝕜} {x : 𝕜}
 
-/-- If `f : 𝕜 → 𝕜` is convex on `s`, then for any point `a ∈ s` the slope of the secant line of `f`
-through `a` is monotone on `s \ {a}`. -/
+/-- If `f : 𝕜 → 𝕜` is convex on `s`, then for any point `x ∈ s` the slope of the secant line of `f`
+through `x` is monotone on `s \ {x}`. -/
 lemma ConvexOn.slope_mono (hfc : ConvexOn 𝕜 s f) (hx : x ∈ s) : MonotoneOn (slope f x) (s \ {x}) :=
   (slope_fun_def_field f _).symm ▸ fun _ hy _ hz hz' ↦ hfc.secant_mono hx (mem_of_mem_diff hy)
     (mem_of_mem_diff hz) (not_mem_of_mem_diff hy :) (not_mem_of_mem_diff hz :) hz'

--- a/Mathlib/Analysis/Convex/Deriv.lean
+++ b/Mathlib/Analysis/Convex/Deriv.lean
@@ -390,8 +390,8 @@ lemma ConvexOn.slope_mono (hfc : ConvexOn 𝕜 s f) (hx : x ∈ s) : MonotoneOn 
   (slope_fun_def_field f _).symm ▸ fun _ hy _ hz hz' ↦ hfc.secant_mono hx (mem_of_mem_diff hy)
     (mem_of_mem_diff hz) (not_mem_of_mem_diff hy :) (not_mem_of_mem_diff hz :) hz'
 
-/-- If `f : 𝕜 → 𝕜` is concave on `s`, then for any point `a ∈ s` the slope of the secant line of `f`
-through `a` is antitone on `s \ {a}`. -/
+/-- If `f : 𝕜 → 𝕜` is concave on `s`, then for any point `x ∈ s` the slope of the secant line of `f`
+through `x` is antitone on `s \ {x}`. -/
 lemma ConcaveOn.slope_anti (hfc : ConcaveOn 𝕜 s f) (hx : x ∈ s) :
     AntitoneOn (slope f x) (s \ {x}) := by
   rw [← neg_neg f, slope_neg_fun]

--- a/Mathlib/LinearAlgebra/AffineSpace/Slope.lean
+++ b/Mathlib/LinearAlgebra/AffineSpace/Slope.lean
@@ -96,6 +96,9 @@ theorem slope_comm (f : k → PE) (a b : k) : slope f a b = slope f b a := by
 @[simp] lemma slope_neg (f : k → E) (x y : k) : slope (fun t ↦ -f t) x y = -slope f x y := by
   simp only [slope_def_module, neg_sub_neg, ← smul_neg, neg_sub]
 
+@[simp] lemma slope_neg_fun (f : k → E) : slope (-f) = -slope f := by
+  ext x y; exact slope_neg f x y
+
 /-- `slope f a c` is a linear combination of `slope f a b` and `slope f b c`. This version
 explicitly provides coefficients. If `a ≠ c`, then the sum of the coefficients is `1`, so it is
 actually an affine combination, see `lineMap_slope_slope_sub_div_sub`. -/


### PR DESCRIPTION
- Add `slope_neg_fun`
- Add `ConvexOn.slope_mono` and `ConcaveOn.slope_anti` in a new separate section called `slope`

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
