### PR TITLE
[Merged by Bors] - feat(Algebra/Order/Ring/WithTop): add generalised and specialised power of top 

### DIFF
--- a/Mathlib/Algebra/Order/Ring/WithTop.lean
+++ b/Mathlib/Algebra/Order/Ring/WithTop.lean
@@ -167,12 +167,9 @@ instance instMonoidWithZero : MonoidWithZero (WithTop α) where
 
 @[simp, norm_cast] lemma coe_pow (a : α) (n : ℕ) : (↑(a ^ n) : WithTop α) = a ^ n := rfl
 
-theorem top_pow {n : ℕ} (n_pos : 0 < n) : (⊤ : WithTop α) ^ n = ⊤ := by
-  apply Nat.le_induction (P := fun m : ℕ ↦ fun _ : 1 ≤ m ↦
-    (⊤ : WithTop α) ^ m = ⊤) (pow_one ⊤) _ _ n_pos
-  intro m _ h
-  simp only [pow_add, h, pow_one]
-  exact top_mul_top
+theorem top_pow {n : ℕ} (n_pos : 0 < n) : (⊤ : WithTop α) ^ n = ⊤ :=
+  Nat.le_induction (pow_one _) (fun m _ hm => by rw [pow_succ, hm, top_mul_top]) _
+    (Nat.succ_le_of_lt n_pos)
 
 end MonoidWithZero
 

--- a/Mathlib/Algebra/Order/Ring/WithTop.lean
+++ b/Mathlib/Algebra/Order/Ring/WithTop.lean
@@ -167,6 +167,14 @@ instance instMonoidWithZero : MonoidWithZero (WithTop α) where
 
 @[simp, norm_cast] lemma coe_pow (a : α) (n : ℕ) : (↑(a ^ n) : WithTop α) = a ^ n := rfl
 
+theorem top_pow {n : ℕ} (n_pos : 0 < n) : (⊤ : WithTop α)^n = ⊤ := by
+  apply Nat.le_induction (P := fun m : ℕ ↦ fun _ : 1 ≤ m ↦
+    (⊤ : WithTop α) ^ m = ⊤) (pow_one ⊤) _ _ n_pos
+  intro m _ h
+  simp only [pow_add, h, pow_one]
+  exact top_mul_top
+#align withtop.top_pow WithTop.top_pow
+
 end MonoidWithZero
 
 instance instCommMonoidWithZero [CommMonoidWithZero α] [NoZeroDivisors α] [Nontrivial α] :

--- a/Mathlib/Algebra/Order/Ring/WithTop.lean
+++ b/Mathlib/Algebra/Order/Ring/WithTop.lean
@@ -167,13 +167,12 @@ instance instMonoidWithZero : MonoidWithZero (WithTop α) where
 
 @[simp, norm_cast] lemma coe_pow (a : α) (n : ℕ) : (↑(a ^ n) : WithTop α) = a ^ n := rfl
 
-theorem top_pow {n : ℕ} (n_pos : 0 < n) : (⊤ : WithTop α)^n = ⊤ := by
+theorem top_pow {n : ℕ} (n_pos : 0 < n) : (⊤ : WithTop α) ^ n = ⊤ := by
   apply Nat.le_induction (P := fun m : ℕ ↦ fun _ : 1 ≤ m ↦
     (⊤ : WithTop α) ^ m = ⊤) (pow_one ⊤) _ _ n_pos
   intro m _ h
   simp only [pow_add, h, pow_one]
   exact top_mul_top
-#align withtop.top_pow WithTop.top_pow
 
 end MonoidWithZero
 

--- a/Mathlib/Data/ENNReal/Basic.lean
+++ b/Mathlib/Data/ENNReal/Basic.lean
@@ -458,6 +458,9 @@ theorem one_lt_two : (1 : ℝ≥0∞) < 2 := Nat.one_lt_ofNat
 
 @[simp] theorem two_lt_top : (2 : ℝ≥0∞) < ∞ := coe_lt_top
 
+theorem top_pow {n : ℕ} (n_pos : 0 < n) : (⊤ : ℝ≥0∞)^n = ⊤ := WithTop.top_pow n_pos
+#align ennreal.top_pow ENNReal.top_pow
+
 /-- `(1 : ℝ≥0∞) ≤ 1`, recorded as a `Fact` for use with `Lp` spaces. -/
 instance _root_.fact_one_le_one_ennreal : Fact ((1 : ℝ≥0∞) ≤ 1) :=
   ⟨le_rfl⟩

--- a/Mathlib/Data/ENNReal/Basic.lean
+++ b/Mathlib/Data/ENNReal/Basic.lean
@@ -458,9 +458,6 @@ theorem one_lt_two : (1 : ℝ≥0∞) < 2 := Nat.one_lt_ofNat
 
 @[simp] theorem two_lt_top : (2 : ℝ≥0∞) < ∞ := coe_lt_top
 
-theorem top_pow {n : ℕ} (n_pos : 0 < n) : (⊤ : ℝ≥0∞)^n = ⊤ := WithTop.top_pow n_pos
-#align ennreal.top_pow ENNReal.top_pow
-
 /-- `(1 : ℝ≥0∞) ≤ 1`, recorded as a `Fact` for use with `Lp` spaces. -/
 instance _root_.fact_one_le_one_ennreal : Fact ((1 : ℝ≥0∞) ≤ 1) :=
   ⟨le_rfl⟩

--- a/Mathlib/Data/ENNReal/Operations.lean
+++ b/Mathlib/Data/ENNReal/Operations.lean
@@ -219,7 +219,7 @@ theorem top_mul_top : ∞ * ∞ = ∞ := WithTop.top_mul_top
 #align ennreal.top_mul_top ENNReal.top_mul_top
 
 -- Porting note (#11215): TODO: assume `n ≠ 0` instead of `0 < n`
-theorem top_pow {n : ℕ} (n_pos : 0 < n) : (⊤ : ∞) ^ n = ⊤ := WithTop.top_pow n_pos
+theorem top_pow {n : ℕ} (n_pos : 0 < n) : (∞ : ℝ≥0∞) ^ n = ∞ := WithTop.top_pow n_pos
 #align ennreal.top_pow ENNReal.top_pow
 
 theorem mul_eq_top : a * b = ∞ ↔ a ≠ 0 ∧ b = ∞ ∨ a = ∞ ∧ b ≠ 0 :=

--- a/Mathlib/Data/ENNReal/Operations.lean
+++ b/Mathlib/Data/ENNReal/Operations.lean
@@ -219,7 +219,7 @@ theorem top_mul_top : ∞ * ∞ = ∞ := WithTop.top_mul_top
 #align ennreal.top_mul_top ENNReal.top_mul_top
 
 -- Porting note (#11215): TODO: assume `n ≠ 0` instead of `0 < n`
-theorem top_pow {n : ℕ} (n_pos : 0 < n) : (⊤ : ℝ≥0∞)^n = ⊤ := WithTop.top_pow n_pos
+theorem top_pow {n : ℕ} (n_pos : 0 < n) : (⊤ : ∞) ^ n = ⊤ := WithTop.top_pow n_pos
 #align ennreal.top_pow ENNReal.top_pow
 
 theorem mul_eq_top : a * b = ∞ ↔ a ≠ 0 ∧ b = ∞ ∨ a = ∞ ∧ b ≠ 0 :=

--- a/Mathlib/Data/ENNReal/Operations.lean
+++ b/Mathlib/Data/ENNReal/Operations.lean
@@ -219,10 +219,7 @@ theorem top_mul_top : ∞ * ∞ = ∞ := WithTop.top_mul_top
 #align ennreal.top_mul_top ENNReal.top_mul_top
 
 -- Porting note (#11215): TODO: assume `n ≠ 0` instead of `0 < n`
--- Porting note (#11215): TODO: generalize to `WithTop`
-theorem top_pow {n : ℕ} (h : 0 < n) : ∞ ^ n = ∞ :=
-  Nat.le_induction (pow_one _) (fun m _ hm => by rw [pow_succ, hm, top_mul_top]) _
-    (Nat.succ_le_of_lt h)
+theorem top_pow {n : ℕ} (n_pos : 0 < n) : (⊤ : ℝ≥0∞)^n = ⊤ := WithTop.top_pow n_pos
 #align ennreal.top_pow ENNReal.top_pow
 
 theorem mul_eq_top : a * b = ∞ ↔ a ≠ 0 ∧ b = ∞ ∨ a = ∞ ∧ b ≠ 0 :=

--- a/Mathlib/Data/ENat/Basic.lean
+++ b/Mathlib/Data/ENat/Basic.lean
@@ -90,7 +90,6 @@ theorem coe_sub (m n : ℕ) : ↑(m - n) = (m - n : ℕ∞) :=
 @[simp] theorem top_mul (hm : m ≠ 0) : ⊤ * m = ⊤ := WithTop.top_mul hm
 
 theorem top_pow {n : ℕ} (n_pos : 0 < n) : (⊤ : ℕ∞) ^ n = ⊤ := WithTop.top_pow n_pos
-#align enat.top_pow ENat.top_pow
 
 instance canLift : CanLift ℕ∞ ℕ (↑) (· ≠ ⊤) := WithTop.canLift
 #align enat.can_lift ENat.canLift

--- a/Mathlib/Data/ENat/Basic.lean
+++ b/Mathlib/Data/ENat/Basic.lean
@@ -89,7 +89,7 @@ theorem coe_sub (m n : ℕ) : ↑(m - n) = (m - n : ℕ∞) :=
 @[simp] theorem mul_top (hm : m ≠ 0) : m * ⊤ = ⊤ := WithTop.mul_top hm
 @[simp] theorem top_mul (hm : m ≠ 0) : ⊤ * m = ⊤ := WithTop.top_mul hm
 
-theorem top_pow {n : ℕ} (n_pos : 0 < n) : (⊤ : ℕ∞)^n = ⊤ := WithTop.top_pow n_pos
+theorem top_pow {n : ℕ} (n_pos : 0 < n) : (⊤ : ℕ∞) ^ n = ⊤ := WithTop.top_pow n_pos
 #align enat.top_pow ENat.top_pow
 
 instance canLift : CanLift ℕ∞ ℕ (↑) (· ≠ ⊤) := WithTop.canLift

--- a/Mathlib/Data/ENat/Basic.lean
+++ b/Mathlib/Data/ENat/Basic.lean
@@ -89,6 +89,16 @@ theorem coe_sub (m n : ℕ) : ↑(m - n) = (m - n : ℕ∞) :=
 @[simp] theorem mul_top (hm : m ≠ 0) : m * ⊤ = ⊤ := WithTop.mul_top hm
 @[simp] theorem top_mul (hm : m ≠ 0) : ⊤ * m = ⊤ := WithTop.top_mul hm
 
+theorem top_pow {n : ℕ} (n_pos : 0 < n) : (⊤ : ℕ∞)^n = ⊤ := by
+  apply @Nat.le_induction 1 (fun m : ℕ ↦ fun _ : 1 ≤ m ↦ (⊤ : ℕ∞) ^ m = ⊤) (pow_one ⊤)
+  · intro m _ h
+    calc
+      (⊤ : ℕ∞)^(m + 1) = ⊤^m * ⊤^1 := by rw [pow_add ⊤ m 1]
+                     _ = ⊤ * ⊤^1   := by rw [h]
+                     _ = ⊤ * ⊤     := by rw [pow_one ⊤]
+                     _ = ⊤         := WithTop.top_mul_top
+  · exact n_pos
+
 instance canLift : CanLift ℕ∞ ℕ (↑) (· ≠ ⊤) := WithTop.canLift
 #align enat.can_lift ENat.canLift
 

--- a/Mathlib/Data/ENat/Basic.lean
+++ b/Mathlib/Data/ENat/Basic.lean
@@ -89,11 +89,8 @@ theorem coe_sub (m n : ℕ) : ↑(m - n) = (m - n : ℕ∞) :=
 @[simp] theorem mul_top (hm : m ≠ 0) : m * ⊤ = ⊤ := WithTop.mul_top hm
 @[simp] theorem top_mul (hm : m ≠ 0) : ⊤ * m = ⊤ := WithTop.top_mul hm
 
-theorem top_pow {n : ℕ} (n_pos : 0 < n) : (⊤ : ℕ∞)^n = ⊤ := by
-  apply Nat.le_induction (P := fun m : ℕ ↦ fun _ : 1 ≤ m ↦ (⊤ : ℕ∞) ^ m = ⊤) (pow_one ⊤) _ _ n_pos
-  intro m _ h
-  simp only [pow_add, h, pow_one]
-  exact WithTop.top_mul_top
+theorem top_pow {n : ℕ} (n_pos : 0 < n) : (⊤ : ℕ∞)^n = ⊤ := WithTop.top_pow n_pos
+#align enat.top_pow ENat.top_pow
 
 instance canLift : CanLift ℕ∞ ℕ (↑) (· ≠ ⊤) := WithTop.canLift
 #align enat.can_lift ENat.canLift

--- a/Mathlib/Data/ENat/Basic.lean
+++ b/Mathlib/Data/ENat/Basic.lean
@@ -90,14 +90,10 @@ theorem coe_sub (m n : ℕ) : ↑(m - n) = (m - n : ℕ∞) :=
 @[simp] theorem top_mul (hm : m ≠ 0) : ⊤ * m = ⊤ := WithTop.top_mul hm
 
 theorem top_pow {n : ℕ} (n_pos : 0 < n) : (⊤ : ℕ∞)^n = ⊤ := by
-  apply @Nat.le_induction 1 (fun m : ℕ ↦ fun _ : 1 ≤ m ↦ (⊤ : ℕ∞) ^ m = ⊤) (pow_one ⊤)
-  · intro m _ h
-    calc
-      (⊤ : ℕ∞)^(m + 1) = ⊤^m * ⊤^1 := by rw [pow_add ⊤ m 1]
-                     _ = ⊤ * ⊤^1   := by rw [h]
-                     _ = ⊤ * ⊤     := by rw [pow_one ⊤]
-                     _ = ⊤         := WithTop.top_mul_top
-  · exact n_pos
+  apply Nat.le_induction (P := fun m : ℕ ↦ fun _ : 1 ≤ m ↦ (⊤ : ℕ∞) ^ m = ⊤) (pow_one ⊤) _ _ n_pos
+  intro m _ h
+  simp only [pow_add, h, pow_one]
+  exact WithTop.top_mul_top
 
 instance canLift : CanLift ℕ∞ ℕ (↑) (· ≠ ⊤) := WithTop.canLift
 #align enat.can_lift ENat.canLift


### PR DESCRIPTION
- [x] Add generalised version of `top_pow` in `Algebra/Order/Ring/WithTop`
- [x] Add specialised version of `top_pow` in `Data/ENat/Basic.lean`
- [x] Add specialised version of `top_pow` in `Data/ENNReal/Operations.lean` 

Co-authored by @D-Thomine.