### PR TITLE
[Merged by Bors] - chore(AlgebraicGeometry): Fix wrong names

### DIFF
--- a/Mathlib/AlgebraicGeometry/AffineScheme.lean
+++ b/Mathlib/AlgebraicGeometry/AffineScheme.lean
@@ -189,7 +189,7 @@ instance {Y : Scheme.{u}} (U : Y.affineOpens) :
   U.property
 
 theorem isAffineOpen_opensRange {X Y : Scheme} [IsAffine X] (f : X ⟶ Y)
-    [H : IsOpenImmersion f] : IsAffineOpen f.opensRange := by
+    [H : IsOpenImmersion f] : IsAffineOpen (Scheme.Hom.opensRange f) := by
   refine isAffine_of_isIso (IsOpenImmersion.isoOfRangeEq f (Y.ofRestrict _) ?_).inv
   exact Subtype.range_val.symm
 #align algebraic_geometry.range_is_affine_open_of_open_immersion AlgebraicGeometry.isAffineOpen_opensRange

--- a/Mathlib/AlgebraicGeometry/AffineScheme.lean
+++ b/Mathlib/AlgebraicGeometry/AffineScheme.lean
@@ -648,9 +648,9 @@ theorem of_affine_open_cover {X : Scheme} (V : X.affineOpens) (S : Set X.affineO
   exact ⟨_, hf₁ ⟨x, hx⟩⟩
 #align algebraic_geometry.of_affine_open_cover AlgebraicGeometry.of_affine_open_cover
 
-@[deprecated (since := "2024-06-21")]
+@[deprecated (since := "2024-06-21"), nolint defLemma]
 alias isAffineAffineScheme := isAffine_affineScheme
-@[deprecated (since := "2024-06-21")]
+@[deprecated (since := "2024-06-21"), nolint defLemma]
 alias SpecIsAffine := isAffine_Spec
 @[deprecated (since := "2024-06-21")]
 alias isAffineOfIso := isAffine_of_isIso
@@ -658,15 +658,15 @@ alias isAffineOfIso := isAffine_of_isIso
 alias rangeIsAffineOpenOfOpenImmersion := isAffineOpen_opensRange
 @[deprecated (since := "2024-06-21")]
 alias topIsAffineOpen := isAffineOpen_top
-@[deprecated (since := "2024-06-21")]
+@[deprecated (since := "2024-06-21"), nolint defLemma]
 alias Scheme.affineCoverIsAffine := Scheme.isAffine_affineCover
-@[deprecated (since := "2024-06-21")]
+@[deprecated (since := "2024-06-21"), nolint defLemma]
 alias Scheme.affineBasisCoverIsAffine := Scheme.isAffine_affineBasisCover
 @[deprecated (since := "2024-06-21")]
 alias IsAffineOpen.fromSpec_range := IsAffineOpen.range_fromSpec
 @[deprecated (since := "2024-06-21")]
 alias IsAffineOpen.imageIsOpenImmersion := IsAffineOpen.image_of_isOpenImmersion
-@[deprecated (since := "2024-06-21")]
+@[deprecated (since := "2024-06-21"), nolint defLemma]
 alias Scheme.quasi_compact_of_affine := Scheme.compactSpace_of_isAffine
 @[deprecated (since := "2024-06-21")]
 alias IsAffineOpen.fromSpec_base_preimage := IsAffineOpen.fromSpec_preimage_self

--- a/Mathlib/AlgebraicGeometry/AffineScheme.lean
+++ b/Mathlib/AlgebraicGeometry/AffineScheme.lean
@@ -37,6 +37,9 @@ We also define predicates about affine schemes and affine open sets.
 
 set_option linter.uppercaseLean3 false
 
+set_option allowUnsafeReducibility true in
+attribute [local reducible] Quiver.Hom
+
 noncomputable section
 
 open CategoryTheory CategoryTheory.Limits Opposite TopologicalSpace
@@ -91,17 +94,17 @@ theorem mem_Spec_essImage (X : Scheme) : X ∈ Scheme.Spec.essImage ↔ IsAffine
     fun _ => ΓSpec.adjunction.mem_essImage_of_unit_isIso _⟩
 #align algebraic_geometry.mem_Spec_ess_image AlgebraicGeometry.mem_Spec_essImage
 
-instance isAffineAffineScheme (X : AffineScheme.{u}) : IsAffine X.obj :=
+instance isAffine_affineScheme (X : AffineScheme.{u}) : IsAffine X.obj :=
   ⟨Functor.essImage.unit_isIso X.property⟩
-#align algebraic_geometry.is_affine_AffineScheme AlgebraicGeometry.isAffineAffineScheme
+#align algebraic_geometry.is_affine_AffineScheme AlgebraicGeometry.isAffine_affineScheme
 
-instance SpecIsAffine (R : CommRingCatᵒᵖ) : IsAffine (Scheme.Spec.obj R) :=
-  AlgebraicGeometry.isAffineAffineScheme ⟨_, Scheme.Spec.obj_mem_essImage R⟩
-#align algebraic_geometry.Spec_is_affine AlgebraicGeometry.SpecIsAffine
+instance isAffine_Spec (R : CommRingCatᵒᵖ) : IsAffine (Scheme.Spec.obj R) :=
+  AlgebraicGeometry.isAffine_affineScheme ⟨_, Scheme.Spec.obj_mem_essImage R⟩
+#align algebraic_geometry.Spec_is_affine AlgebraicGeometry.isAffine_Spec
 
-theorem isAffineOfIso {X Y : Scheme} (f : X ⟶ Y) [IsIso f] [h : IsAffine Y] : IsAffine X := by
+theorem isAffine_of_isIso {X Y : Scheme} (f : X ⟶ Y) [IsIso f] [h : IsAffine Y] : IsAffine X := by
   rw [← mem_Spec_essImage] at h ⊢; exact Functor.essImage.ofIso (asIso f).symm h
-#align algebraic_geometry.is_affine_of_iso AlgebraicGeometry.isAffineOfIso
+#align algebraic_geometry.is_affine_of_iso AlgebraicGeometry.isAffine_of_isIso
 
 namespace AffineScheme
 
@@ -185,27 +188,27 @@ instance {Y : Scheme.{u}} (U : Y.affineOpens) :
     IsAffine (Scheme.restrict Y <| Opens.openEmbedding U.val) :=
   U.property
 
-theorem rangeIsAffineOpenOfOpenImmersion {X Y : Scheme} [IsAffine X] (f : X ⟶ Y)
-    [H : IsOpenImmersion f] : IsAffineOpen (Scheme.Hom.opensRange f) := by
-  refine isAffineOfIso (IsOpenImmersion.isoOfRangeEq f (Y.ofRestrict _) ?_).inv
+theorem isAffineOpen_opensRange {X Y : Scheme} [IsAffine X] (f : X ⟶ Y)
+    [H : IsOpenImmersion f] : IsAffineOpen f.opensRange := by
+  refine isAffine_of_isIso (IsOpenImmersion.isoOfRangeEq f (Y.ofRestrict _) ?_).inv
   exact Subtype.range_val.symm
-#align algebraic_geometry.range_is_affine_open_of_open_immersion AlgebraicGeometry.rangeIsAffineOpenOfOpenImmersion
+#align algebraic_geometry.range_is_affine_open_of_open_immersion AlgebraicGeometry.isAffineOpen_opensRange
 
-theorem topIsAffineOpen (X : Scheme) [IsAffine X] : IsAffineOpen (⊤ : Opens X) := by
-  convert rangeIsAffineOpenOfOpenImmersion (𝟙 X)
+theorem isAffineOpen_top (X : Scheme) [IsAffine X] : IsAffineOpen (⊤ : Opens X) := by
+  convert isAffineOpen_opensRange (𝟙 X)
   ext1
   exact Set.range_id.symm
-#align algebraic_geometry.top_is_affine_open AlgebraicGeometry.topIsAffineOpen
+#align algebraic_geometry.top_is_affine_open AlgebraicGeometry.isAffineOpen_top
 
-instance Scheme.affineCoverIsAffine (X : Scheme) (i : X.affineCover.J) :
+instance Scheme.isAffine_affineCover (X : Scheme) (i : X.affineCover.J) :
     IsAffine (X.affineCover.obj i) :=
-  AlgebraicGeometry.SpecIsAffine _
-#align algebraic_geometry.Scheme.affine_cover_is_affine AlgebraicGeometry.Scheme.affineCoverIsAffine
+  isAffine_Spec _
+#align algebraic_geometry.Scheme.affine_cover_is_affine AlgebraicGeometry.Scheme.isAffine_affineCover
 
-instance Scheme.affineBasisCoverIsAffine (X : Scheme) (i : X.affineBasisCover.J) :
+instance Scheme.isAffine_affineBasisCover (X : Scheme) (i : X.affineBasisCover.J) :
     IsAffine (X.affineBasisCover.obj i) :=
-  AlgebraicGeometry.SpecIsAffine _
-#align algebraic_geometry.Scheme.affine_basis_cover_is_affine AlgebraicGeometry.Scheme.affineBasisCoverIsAffine
+  isAffine_Spec _
+#align algebraic_geometry.Scheme.affine_basis_cover_is_affine AlgebraicGeometry.Scheme.isAffine_affineBasisCover
 
 theorem isBasis_affine_open (X : Scheme) : Opens.IsBasis X.affineOpens := by
   rw [Opens.isBasis_iff_nbhd]
@@ -213,7 +216,7 @@ theorem isBasis_affine_open (X : Scheme) : Opens.IsBasis X.affineOpens := by
   obtain ⟨S, hS, hxS, hSU⟩ := X.affineBasisCover_is_basis.exists_subset_of_mem_open hU U.isOpen
   refine ⟨⟨S, X.affineBasisCover_is_basis.isOpen hS⟩, ?_, hxS, hSU⟩
   rcases hS with ⟨i, rfl⟩
-  exact rangeIsAffineOpenOfOpenImmersion _
+  exact isAffineOpen_opensRange _
 #align algebraic_geometry.is_basis_affine_open AlgebraicGeometry.isBasis_affine_open
 
 theorem Scheme.map_PrimeSpectrum_basicOpen_of_affine
@@ -271,42 +274,42 @@ instance isOpenImmersion_fromSpec :
   infer_instance
 #align algebraic_geometry.is_affine_open.is_open_immersion_from_Spec AlgebraicGeometry.IsAffineOpen.isOpenImmersion_fromSpec
 
-theorem fromSpec_range :
+theorem range_fromSpec :
     Set.range hU.fromSpec.1.base = (U : Set X) := by
   delta IsAffineOpen.fromSpec; dsimp
   rw [Function.comp.assoc, Set.range_comp, Set.range_iff_surjective.mpr, Set.image_univ]
   · exact Subtype.range_coe
   erw [← coe_comp, ← TopCat.epi_iff_surjective] -- now `erw` after #13170
   infer_instance
-#align algebraic_geometry.is_affine_open.from_Spec_range AlgebraicGeometry.IsAffineOpen.fromSpec_range
+#align algebraic_geometry.is_affine_open.from_Spec_range AlgebraicGeometry.IsAffineOpen.range_fromSpec
 
 theorem fromSpec_image_top :
     hU.fromSpec.opensFunctor.obj ⊤ = U := by
-  ext1; exact Set.image_univ.trans hU.fromSpec_range
+  ext1; exact Set.image_univ.trans hU.range_fromSpec
 #align algebraic_geometry.is_affine_open.from_Spec_image_top AlgebraicGeometry.IsAffineOpen.fromSpec_image_top
 
 protected theorem isCompact :
     IsCompact (U : Set X) := by
   convert @IsCompact.image _ _ _ _ Set.univ hU.fromSpec.1.base PrimeSpectrum.compactSpace.1
     (by fun_prop)
-  convert hU.fromSpec_range.symm
+  convert hU.range_fromSpec.symm
   exact Set.image_univ
 #align algebraic_geometry.is_affine_open.is_compact AlgebraicGeometry.IsAffineOpen.isCompact
 
-theorem imageIsOpenImmersion (f : X ⟶ Y) [H : IsOpenImmersion f] :
+theorem image_of_isOpenImmersion (f : X ⟶ Y) [H : IsOpenImmersion f] :
     IsAffineOpen (f.opensFunctor.obj U) := by
   have : IsAffine _ := hU
-  convert rangeIsAffineOpenOfOpenImmersion (X.ofRestrict U.openEmbedding ≫ f)
+  convert isAffineOpen_opensRange (X.ofRestrict U.openEmbedding ≫ f)
   ext1
   exact Set.image_eq_range _ _
-#align algebraic_geometry.is_affine_open.image_is_open_immersion AlgebraicGeometry.IsAffineOpen.imageIsOpenImmersion
+#align algebraic_geometry.is_affine_open.image_is_open_immersion AlgebraicGeometry.IsAffineOpen.image_of_isOpenImmersion
 
 theorem _root_.AlgebraicGeometry.Scheme.Hom.isAffineOpen_iff_of_isOpenImmersion
     (f : AlgebraicGeometry.Scheme.Hom X Y) [H : IsOpenImmersion f] {U : Opens X} :
     IsAffineOpen (f.opensFunctor.obj U) ↔ IsAffineOpen U := by
-  refine ⟨fun hU => @isAffineOfIso _ _
+  refine ⟨fun hU => @isAffine_of_isIso _ _
     (IsOpenImmersion.isoOfRangeEq (X.ofRestrict U.openEmbedding ≫ f) (Y.ofRestrict _) ?_).hom ?_ hU,
-    fun hU => hU.imageIsOpenImmersion f⟩
+    fun hU => hU.image_of_isOpenImmersion f⟩
   · erw [Scheme.comp_val_base, coe_comp, Set.range_comp] -- now `erw` after #13170
     dsimp [Opens.coe_inclusion, Scheme.restrict]
     erw [Subtype.range_coe, Subtype.range_coe] -- now `erw` after #13170
@@ -314,17 +317,17 @@ theorem _root_.AlgebraicGeometry.Scheme.Hom.isAffineOpen_iff_of_isOpenImmersion
   · infer_instance
 #align algebraic_geometry.is_affine_open_iff_of_is_open_immersion AlgebraicGeometry.Scheme.Hom.isAffineOpen_iff_of_isOpenImmersion
 
-instance _root_.AlgebraicGeometry.Scheme.quasi_compact_of_affine (X : Scheme) [IsAffine X] :
+instance _root_.AlgebraicGeometry.Scheme.compactSpace_of_isAffine (X : Scheme) [IsAffine X] :
     CompactSpace X :=
-  ⟨(topIsAffineOpen X).isCompact⟩
-#align algebraic_geometry.Scheme.quasi_compact_of_affine AlgebraicGeometry.Scheme.quasi_compact_of_affine
+  ⟨(isAffineOpen_top X).isCompact⟩
+#align algebraic_geometry.Scheme.quasi_compact_of_affine AlgebraicGeometry.Scheme.compactSpace_of_isAffine
 
-theorem fromSpec_base_preimage :
+theorem fromSpec_preimage_self :
     hU.fromSpec ⁻¹ᵁ U = ⊤ := by
   ext1
-  rw [Opens.map_coe, Opens.coe_top, ← hU.fromSpec_range, ← Set.image_univ]
+  rw [Opens.map_coe, Opens.coe_top, ← hU.range_fromSpec, ← Set.image_univ]
   exact Set.preimage_image_eq _ PresheafedSpace.IsOpenImmersion.base_open.inj
-#align algebraic_geometry.is_affine_open.from_Spec_base_preimage AlgebraicGeometry.IsAffineOpen.fromSpec_base_preimage
+#align algebraic_geometry.is_affine_open.from_Spec_base_preimage AlgebraicGeometry.IsAffineOpen.fromSpec_preimage_self
 
 #adaptation_note /-- 2024-04-23
 The backwards compatibility flags don't help here. -/
@@ -333,7 +336,7 @@ set_option maxHeartbeats 400000 in
 @[nolint unusedHavesSuffices]
 theorem SpecΓIdentity_hom_app_fromSpec :
     SpecΓIdentity.hom.app (X.presheaf.obj <| op U) ≫ hU.fromSpec.1.c.app (op U) =
-      (𝖲𝗉𝖾𝖼 𝓞ₓ(U)).presheaf.map (eqToHom hU.fromSpec_base_preimage).op := by
+      (𝖲𝗉𝖾𝖼 𝓞ₓ(U)).presheaf.map (eqToHom hU.fromSpec_preimage_self).op := by
   have : IsAffine _ := hU
   delta IsAffineOpen.fromSpec Scheme.isoSpec
   rw [Scheme.comp_val_c_app, Scheme.comp_val_c_app, SpecΓIdentity_hom_app_presheaf_obj,
@@ -348,29 +351,29 @@ theorem SpecΓIdentity_hom_app_fromSpec :
 @[elementwise]
 theorem fromSpec_app_self :
     hU.fromSpec.1.c.app (op U) = SpecΓIdentity.inv.app (X.presheaf.obj <| op U) ≫
-    (𝖲𝗉𝖾𝖼 𝓞ₓ(U)).presheaf.map (eqToHom hU.fromSpec_base_preimage).op := by
+    (𝖲𝗉𝖾𝖼 𝓞ₓ(U)).presheaf.map (eqToHom hU.fromSpec_preimage_self).op := by
   rw [← hU.SpecΓIdentity_hom_app_fromSpec, ← NatTrans.comp_app_assoc, Iso.inv_hom_id,
     NatTrans.id_app, Category.id_comp]
 #align algebraic_geometry.is_affine_open.from_Spec_app_eq AlgebraicGeometry.IsAffineOpen.fromSpec_app_self
 
-theorem fromSpec_map_basicOpen' :
+theorem fromSpec_preimage_basicOpen' :
     hU.fromSpec ⁻¹ᵁ X.basicOpen f =
       (𝖲𝗉𝖾𝖼 𝓞ₓ(U)).basicOpen (SpecΓIdentity.inv.app (X.presheaf.obj (op U)) f) := by
   rw [Scheme.preimage_basicOpen, hU.fromSpec_app_self]
-  exact Scheme.basicOpen_res_eq _ _ (eqToHom hU.fromSpec_base_preimage).op
-#align algebraic_geometry.is_affine_open.opens_map_from_Spec_basic_open AlgebraicGeometry.IsAffineOpen.fromSpec_map_basicOpen'
+  exact Scheme.basicOpen_res_eq _ _ (eqToHom hU.fromSpec_preimage_self).op
+#align algebraic_geometry.is_affine_open.opens_map_from_Spec_basic_open AlgebraicGeometry.IsAffineOpen.fromSpec_preimage_basicOpen'
 
-theorem fromSpec_map_basicOpen :
+theorem fromSpec_preimage_basicOpen :
     hU.fromSpec ⁻¹ᵁ X.basicOpen f = PrimeSpectrum.basicOpen f := by
-  rw [fromSpec_map_basicOpen', ← basicOpen_eq_of_affine, NatIso.app_inv]
-#align algebraic_geometry.is_affine_open.from_Spec_map_basic_open AlgebraicGeometry.IsAffineOpen.fromSpec_map_basicOpen
+  rw [fromSpec_preimage_basicOpen', ← basicOpen_eq_of_affine, NatIso.app_inv]
+#align algebraic_geometry.is_affine_open.from_Spec_map_basic_open AlgebraicGeometry.IsAffineOpen.fromSpec_preimage_basicOpen
 
-theorem opensFunctor_map_basicOpen :
+theorem fromSpec_image_basicOpen :
     hU.fromSpec.opensFunctor.obj (PrimeSpectrum.basicOpen f) = X.basicOpen f := by
-  rw [← hU.fromSpec_map_basicOpen]
+  rw [← hU.fromSpec_preimage_basicOpen]
   ext1
   change hU.fromSpec.val.base '' (hU.fromSpec.val.base ⁻¹' (X.basicOpen f : Set X)) = _
-  rw [Set.image_preimage_eq_inter_range, Set.inter_eq_left, hU.fromSpec_range]
+  rw [Set.image_preimage_eq_inter_range, Set.inter_eq_left, hU.range_fromSpec]
   exact Scheme.basicOpen_le _ _
 
 -- Porting note: linter complains that LHS is not in simp-normal-form. However, the error provided
@@ -381,25 +384,25 @@ theorem opensFunctor_map_basicOpen :
 theorem basicOpen_fromSpec_app :
     (𝖲𝗉𝖾𝖼 𝓞ₓ(U)).basicOpen (hU.fromSpec.1.c.app (op U) f) =
       PrimeSpectrum.basicOpen f := by
-  rw [← hU.fromSpec_map_basicOpen, Scheme.preimage_basicOpen]
+  rw [← hU.fromSpec_preimage_basicOpen, Scheme.preimage_basicOpen]
 #align algebraic_geometry.is_affine_open.basic_open_from_Spec_app AlgebraicGeometry.IsAffineOpen.basicOpen_fromSpec_app
 
-theorem basicOpenIsAffine :
+theorem basicOpen :
     IsAffineOpen (X.basicOpen f) := by
-  rw [← hU.opensFunctor_map_basicOpen, Scheme.Hom.isAffineOpen_iff_of_isOpenImmersion]
-  convert rangeIsAffineOpenOfOpenImmersion (Scheme.Spec.map
+  rw [← hU.fromSpec_image_basicOpen, Scheme.Hom.isAffineOpen_iff_of_isOpenImmersion]
+  convert isAffineOpen_opensRange (Scheme.Spec.map
     (CommRingCat.ofHom <| algebraMap (X.presheaf.obj (op U)) (Localization.Away f)).op)
   exact Opens.ext (PrimeSpectrum.localization_away_comap_range (Localization.Away f) f).symm
-#align algebraic_geometry.is_affine_open.basic_open_is_affine AlgebraicGeometry.IsAffineOpen.basicOpenIsAffine
+#align algebraic_geometry.is_affine_open.basic_open_is_affine AlgebraicGeometry.IsAffineOpen.basicOpen
 
-theorem mapRestrictBasicOpen (r : X.presheaf.obj (op ⊤)) :
+theorem ιOpens_preimage (r : X.presheaf.obj (op ⊤)) :
     IsAffineOpen (Scheme.ιOpens (X.basicOpen r) ⁻¹ᵁ U) := by
   apply (Scheme.ιOpens (X.basicOpen r)).isAffineOpen_iff_of_isOpenImmersion.mp
   dsimp [Scheme.Hom.opensFunctor, PresheafedSpace.IsOpenImmersion.openFunctor]
   rw [Opens.functor_obj_map_obj, Opens.openEmbedding_obj_top, inf_comm,
     ← Scheme.basicOpen_res _ _ (homOfLE le_top).op]
-  exact hU.basicOpenIsAffine _
-#align algebraic_geometry.is_affine_open.map_restrict_basic_open AlgebraicGeometry.IsAffineOpen.mapRestrictBasicOpen
+  exact hU.basicOpen _
+#align algebraic_geometry.is_affine_open.map_restrict_basic_open AlgebraicGeometry.IsAffineOpen.ιOpens_preimage
 
 theorem exists_basicOpen_le {V : Opens X} (x : V) (h : ↑x ∈ U) :
     ∃ f : X.presheaf.obj (op U), X.basicOpen f ≤ V ∧ ↑x ∈ X.basicOpen f := by
@@ -428,7 +431,7 @@ def basicOpenSectionsToAffine :
     X.presheaf.obj (op <| X.basicOpen f) ⟶
       (𝖲𝗉𝖾𝖼 𝓞ₓ(U)).presheaf.obj (op <| PrimeSpectrum.basicOpen f) :=
   hU.fromSpec.1.c.app (op <| X.basicOpen f) ≫
-    (𝖲𝗉𝖾𝖼 𝓞ₓ(U)).presheaf.map (eqToHom <| (hU.fromSpec_map_basicOpen f).symm).op
+    (𝖲𝗉𝖾𝖼 𝓞ₓ(U)).presheaf.map (eqToHom <| (hU.fromSpec_preimage_basicOpen f).symm).op
 #align algebraic_geometry.basic_open_sections_to_affine AlgebraicGeometry.IsAffineOpen.basicOpenSectionsToAffine
 
 instance basicOpenSectionsToAffine_isIso :
@@ -436,7 +439,7 @@ instance basicOpenSectionsToAffine_isIso :
   delta basicOpenSectionsToAffine
   apply (config := { allowSynthFailures := true }) IsIso.comp_isIso
   apply PresheafedSpace.IsOpenImmersion.isIso_of_subset
-  rw [hU.fromSpec_range]
+  rw [hU.range_fromSpec]
   exact RingedSpace.basicOpen_le _ _
 
 theorem isLocalization_basicOpen :
@@ -461,7 +464,7 @@ theorem isLocalization_basicOpen :
 instance _root_.AlgebraicGeometry.isLocalization_away_of_isAffine
     [IsAffine X] (r : X.presheaf.obj (op ⊤)) :
     IsLocalization.Away r (X.presheaf.obj (op <| X.basicOpen r)) :=
-  isLocalization_basicOpen (topIsAffineOpen X) r
+  isLocalization_basicOpen (isAffineOpen_top X) r
 
 theorem isLocalization_of_eq_basicOpen {V : Opens X} (i : V ⟶ U) (e : V = X.basicOpen f) :
     @IsLocalization.Away _ _ f (X.presheaf.obj (op V)) _ (X.presheaf.map i.op).toAlgebra := by
@@ -471,7 +474,7 @@ theorem isLocalization_of_eq_basicOpen {V : Opens X} (i : V ⟶ U) (e : V = X.ba
 instance _root_.AlgebraicGeometry.Γ_restrict_isLocalization
     (X : Scheme.{u}) [IsAffine X] (r : Scheme.Γ.obj (op X)) :
     IsLocalization.Away r (Scheme.Γ.obj (op (X ∣_ᵤ X.basicOpen r))) :=
-  (topIsAffineOpen X).isLocalization_of_eq_basicOpen r _ (Opens.openEmbedding_obj_top _)
+  (isAffineOpen_top X).isLocalization_of_eq_basicOpen r _ (Opens.openEmbedding_obj_top _)
 #align algebraic_geometry.Γ_restrict_is_localization AlgebraicGeometry.Γ_restrict_isLocalization
 
 theorem basicOpen_basicOpen_is_basicOpen (g : X.presheaf.obj (op <| X.basicOpen f)) :
@@ -562,7 +565,7 @@ theorem isLocalization_stalk (x : U) :
 @[simps]
 def _root_.AlgebraicGeometry.Scheme.affineBasicOpen
     (X : Scheme) {U : X.affineOpens} (f : X.presheaf.obj <| op U) : X.affineOpens :=
-  ⟨X.basicOpen f, U.prop.basicOpenIsAffine f⟩
+  ⟨X.basicOpen f, U.prop.basicOpen f⟩
 #align algebraic_geometry.Scheme.affine_basic_open AlgebraicGeometry.Scheme.affineBasicOpen
 
 theorem basicOpen_union_eq_self_iff (s : Set (X.presheaf.obj <| op U)) :
@@ -574,7 +577,7 @@ theorem basicOpen_union_eq_self_iff (s : Set (X.presheaf.obj <| op U)) :
     · refine ⟨fun h => by rw [h], ?_⟩
       intro h
       apply_fun Set.image hU.fromSpec.1.base at h
-      rw [Set.image_preimage_eq_inter_range, Set.image_preimage_eq_inter_range, hU.fromSpec_range]
+      rw [Set.image_preimage_eq_inter_range, Set.image_preimage_eq_inter_range, hU.range_fromSpec]
         at h
       simp only [Set.inter_self, Opens.carrier_eq_coe, Set.inter_eq_right] at h
       ext1
@@ -586,8 +589,8 @@ theorem basicOpen_union_eq_self_iff (s : Set (X.presheaf.obj <| op U)) :
       congr! 1
       · refine congr_arg (Set.iUnion ·) ?_
         ext1 x
-        exact congr_arg Opens.carrier (hU.fromSpec_map_basicOpen _)
-      · exact congr_arg Opens.carrier hU.fromSpec_base_preimage
+        exact congr_arg Opens.carrier (hU.fromSpec_preimage_basicOpen _)
+      · exact congr_arg Opens.carrier hU.fromSpec_preimage_self
   · simp only [Opens.carrier_eq_coe, PrimeSpectrum.basicOpen_eq_zeroLocus_compl]
     rw [← Set.compl_iInter, Set.compl_univ_iff, ← PrimeSpectrum.zeroLocus_iUnion, ←
       PrimeSpectrum.zeroLocus_empty_iff_eq_top, PrimeSpectrum.zeroLocus_span]
@@ -644,5 +647,38 @@ theorem of_affine_open_cover {X : Scheme} (V : X.affineOpens) (S : Set X.affineO
   rw [iSup_range', SetLike.mem_coe, Opens.mem_iSup]
   exact ⟨_, hf₁ ⟨x, hx⟩⟩
 #align algebraic_geometry.of_affine_open_cover AlgebraicGeometry.of_affine_open_cover
+
+@[deprecated (since := "2024-06-21")]
+alias isAffineAffineScheme := isAffine_affineScheme
+@[deprecated (since := "2024-06-21")]
+alias SpecIsAffine := isAffine_Spec
+@[deprecated (since := "2024-06-21")]
+alias isAffineOfIso := isAffine_of_isIso
+@[deprecated (since := "2024-06-21")]
+alias rangeIsAffineOpenOfOpenImmersion := isAffineOpen_opensRange
+@[deprecated (since := "2024-06-21")]
+alias topIsAffineOpen := isAffineOpen_top
+@[deprecated (since := "2024-06-21")]
+alias Scheme.affineCoverIsAffine := Scheme.isAffine_affineCover
+@[deprecated (since := "2024-06-21")]
+alias Scheme.affineBasisCoverIsAffine := Scheme.isAffine_affineBasisCover
+@[deprecated (since := "2024-06-21")]
+alias IsAffineOpen.fromSpec_range := IsAffineOpen.range_fromSpec
+@[deprecated (since := "2024-06-21")]
+alias IsAffineOpen.imageIsOpenImmersion := IsAffineOpen.image_of_isOpenImmersion
+@[deprecated (since := "2024-06-21")]
+alias Scheme.quasi_compact_of_affine := Scheme.compactSpace_of_isAffine
+@[deprecated (since := "2024-06-21")]
+alias IsAffineOpen.fromSpec_base_preimage := IsAffineOpen.fromSpec_preimage_self
+@[deprecated (since := "2024-06-21")]
+alias IsAffineOpen.fromSpec_map_basicOpen' := IsAffineOpen.fromSpec_preimage_basicOpen'
+@[deprecated (since := "2024-06-21")]
+alias IsAffineOpen.fromSpec_map_basicOpen := IsAffineOpen.fromSpec_preimage_basicOpen
+@[deprecated (since := "2024-06-21")]
+alias IsAffineOpen.opensFunctor_map_basicOpen := IsAffineOpen.fromSpec_image_basicOpen
+@[deprecated (since := "2024-06-21")]
+alias IsAffineOpen.basicOpenIsAffine := IsAffineOpen.basicOpen
+@[deprecated (since := "2024-06-21")]
+alias IsAffineOpen.mapRestrictBasicOpen := IsAffineOpen.ιOpens_preimage
 
 end AlgebraicGeometry

--- a/Mathlib/AlgebraicGeometry/FunctionField.lean
+++ b/Mathlib/AlgebraicGeometry/FunctionField.lean
@@ -170,14 +170,14 @@ theorem functionField_isFractionRing_of_isAffineOpen [IsIntegral X] (U : Opens X
 #align algebraic_geometry.function_field_is_fraction_ring_of_is_affine_open AlgebraicGeometry.functionField_isFractionRing_of_isAffineOpen
 
 instance (x : X.carrier) : IsAffine (X.affineCover.obj x) :=
-  AlgebraicGeometry.SpecIsAffine _
+  AlgebraicGeometry.isAffine_Spec _
 
 instance [IsIntegral X] (x : X.carrier) :
     IsFractionRing (X.presheaf.stalk x) X.functionField :=
   let U : Opens X.carrier :=
     ⟨Set.range (X.affineCover.map x).1.base,
       PresheafedSpace.IsOpenImmersion.base_open.isOpen_range⟩
-  have hU : IsAffineOpen U := rangeIsAffineOpenOfOpenImmersion (X.affineCover.map x)
+  have hU : IsAffineOpen U := isAffineOpen_opensRange (X.affineCover.map x)
   let x : U := ⟨x, X.affineCover.Covers x⟩
   have : Nonempty U := ⟨x⟩
   let M := (hU.primeIdealOf x).asIdeal.primeCompl

--- a/Mathlib/AlgebraicGeometry/FunctionField.lean
+++ b/Mathlib/AlgebraicGeometry/FunctionField.lean
@@ -136,7 +136,7 @@ instance functionField_isFractionRing_of_affine (R : CommRingCat.{u}) [IsDomain 
 instance {X : Scheme} [IsIntegral X] {U : Opens X.carrier} [hU : Nonempty U] :
     IsIntegral (X.restrict U.openEmbedding) :=
   haveI : Nonempty (X.restrict U.openEmbedding).carrier := hU
-  isIntegralOfOpenImmersion (X.ofRestrict U.openEmbedding)
+  isIntegral_of_isOpenImmersion (X.ofRestrict U.openEmbedding)
 
 theorem IsAffineOpen.primeIdealOf_genericPoint {X : Scheme} [IsIntegral X] {U : Opens X.carrier}
     (hU : IsAffineOpen U) [h : Nonempty U] :
@@ -161,7 +161,7 @@ theorem functionField_isFractionRing_of_isAffineOpen [IsIntegral X] (U : Opens X
   haveI : IsAffine _ := hU
   haveI : Nonempty (X.restrict U.openEmbedding).carrier := hU'
   haveI : IsIntegral (X.restrict U.openEmbedding) :=
-    @isIntegralOfIsAffineIsDomain _ _ _
+    @isIntegral_of_isAffine_of_isDomain _ _ _
       (by dsimp; rw [Opens.openEmbedding_obj_top]; infer_instance)
   delta IsFractionRing Scheme.functionField
   convert hU.isLocalization_stalk ⟨genericPoint X.carrier, _⟩ using 1

--- a/Mathlib/AlgebraicGeometry/Limits.lean
+++ b/Mathlib/AlgebraicGeometry/Limits.lean
@@ -137,7 +137,7 @@ theorem isAffineOpen_bot (X : Scheme) : IsAffineOpen (⊥ : Opens X.carrier) := 
   erw [Set.mem_empty_iff_false]
   rw [false_iff_iff]
   exact fun x => isEmptyElim (show (⊥_ Scheme).carrier from x.choose)
-#align algebraic_geometry.bot_is_affine_open AlgebraicGeometry.bot_isAffineOpen
+#align algebraic_geometry.bot_is_affine_open AlgebraicGeometry.isAffineOpen_bot
 
 instance : HasStrictInitialObjects Scheme :=
   hasStrictInitialObjects_of_initial_is_strict fun A f => by infer_instance

--- a/Mathlib/AlgebraicGeometry/Limits.lean
+++ b/Mathlib/AlgebraicGeometry/Limits.lean
@@ -44,7 +44,7 @@ instance : HasTerminal Scheme :=
   hasTerminal_of_hasTerminal_of_preservesLimit Scheme.Spec
 
 instance : IsAffine (⊤_ Scheme.{u}) :=
-  isAffineOfIso (PreservesTerminal.iso Scheme.Spec).inv
+  isAffine_of_isIso (PreservesTerminal.iso Scheme.Spec).inv
 
 instance : HasFiniteLimits Scheme :=
   hasFiniteLimits_of_hasTerminal_and_pullbacks
@@ -117,7 +117,7 @@ noncomputable def specPunitIsInitial : IsInitial (Scheme.Spec.obj (op <| CommRin
 #align algebraic_geometry.Spec_punit_is_initial AlgebraicGeometry.specPunitIsInitial
 
 instance (priority := 100) isAffine_of_isEmpty {X : Scheme} [IsEmpty X.carrier] : IsAffine X :=
-  isAffineOfIso
+  isAffine_of_isIso
     (inv (emptyIsInitial.to X) ≫ emptyIsInitial.to (Scheme.Spec.obj (op <| CommRingCat.of PUnit)))
 #align algebraic_geometry.is_affine_of_is_empty AlgebraicGeometry.isAffine_of_isEmpty
 
@@ -130,8 +130,8 @@ instance initial_isEmpty : IsEmpty (⊥_ Scheme).carrier :=
   ⟨fun x => ((initial.to Scheme.empty : _).1.base x).elim⟩
 #align algebraic_geometry.initial_is_empty AlgebraicGeometry.initial_isEmpty
 
-theorem bot_isAffineOpen (X : Scheme) : IsAffineOpen (⊥ : Opens X.carrier) := by
-  convert rangeIsAffineOpenOfOpenImmersion (initial.to X)
+theorem isAffineOpen_bot (X : Scheme) : IsAffineOpen (⊥ : Opens X.carrier) := by
+  convert isAffineOpen_opensRange (initial.to X)
   ext
   -- Porting note: added this `erw` to turn LHS to `False`
   erw [Set.mem_empty_iff_false]

--- a/Mathlib/AlgebraicGeometry/Morphisms/Basic.lean
+++ b/Mathlib/AlgebraicGeometry/Morphisms/Basic.lean
@@ -109,11 +109,11 @@ theorem affine_cancel_right_isIso {P : AffineTargetMorphismProperty} (hP : P.toP
 theorem AffineTargetMorphismProperty.respectsIso_mk {P : AffineTargetMorphismProperty}
     (h₁ : ∀ {X Y Z} (e : X ≅ Y) (f : Y ⟶ Z) [IsAffine Z], P f → P (e.hom ≫ f))
     (h₂ : ∀ {X Y Z} (e : Y ≅ Z) (f : X ⟶ Y) [h : IsAffine Y],
-      P f → @P _ _ (f ≫ e.hom) (isAffineOfIso e.inv)) :
+      P f → @P _ _ (f ≫ e.hom) (isAffine_of_isIso e.inv)) :
     P.toProperty.RespectsIso := by
   constructor
   · rintro X Y Z e f ⟨a, h⟩; exact ⟨a, h₁ e f h⟩
-  · rintro X Y Z e f ⟨a, h⟩; exact ⟨isAffineOfIso e.inv, h₂ e f h⟩
+  · rintro X Y Z e f ⟨a, h⟩; exact ⟨isAffine_of_isIso e.inv, h₂ e f h⟩
 #align algebraic_geometry.affine_target_morphism_property.respects_iso_mk AlgebraicGeometry.AffineTargetMorphismProperty.respectsIso_mk
 
 /-- For a `P : AffineTargetMorphismProperty`, `targetAffineLocally P` holds for
@@ -125,7 +125,7 @@ def targetAffineLocally (P : AffineTargetMorphismProperty) : MorphismProperty Sc
 theorem IsAffineOpen.map_isIso {X Y : Scheme} {U : Opens Y.carrier} (hU : IsAffineOpen U)
     (f : X ⟶ Y) [IsIso f] : IsAffineOpen ((Opens.map f.1.base).obj U) :=
   haveI : IsAffine _ := hU
-  isAffineOfIso (f ∣_ U)
+  isAffine_of_isIso (f ∣_ U)
 #align algebraic_geometry.is_affine_open.map_is_iso AlgebraicGeometry.IsAffineOpen.map_isIso
 
 theorem targetAffineLocally_respectsIso {P : AffineTargetMorphismProperty}
@@ -154,13 +154,13 @@ structure AffineTargetMorphismProperty.IsLocal (P : AffineTargetMorphismProperty
   /-- `P` is stable under restriction to basic open set of global sections. -/
   toBasicOpen :
     ∀ {X Y : Scheme} [IsAffine Y] (f : X ⟶ Y) (r : Y.presheaf.obj <| op ⊤),
-      P f → @P _ _ (f ∣_ Y.basicOpen r) ((topIsAffineOpen Y).basicOpenIsAffine _)
+      P f → @P _ _ (f ∣_ Y.basicOpen r) ((isAffineOpen_top Y).basicOpen _)
   /-- `P` for `f` if `P` holds for `f` restricted to basic sets of a spanning set of the global
     sections -/
   ofBasicOpenCover :
     ∀ {X Y : Scheme} [IsAffine Y] (f : X ⟶ Y) (s : Finset (Y.presheaf.obj <| op ⊤))
       (_ : Ideal.span (s : Set (Y.presheaf.obj <| op ⊤)) = ⊤),
-      (∀ r : s, @P _ _ (f ∣_ Y.basicOpen r.1) ((topIsAffineOpen Y).basicOpenIsAffine _)) → P f
+      (∀ r : s, @P _ _ (f ∣_ Y.basicOpen r.1) ((isAffineOpen_top Y).basicOpen _)) → P f
 #align algebraic_geometry.affine_target_morphism_property.is_local AlgebraicGeometry.AffineTargetMorphismProperty.IsLocal
 
 /-- Specialization of `ConcreteCategory.id_apply` because `simp` can't see through the defeq. -/
@@ -171,8 +171,7 @@ theorem targetAffineLocallyOfOpenCover {P : AffineTargetMorphismProperty} (hP : 
     (h𝒰 : ∀ i, P (pullback.snd : (𝒰.pullbackCover f).obj i ⟶ 𝒰.obj i)) :
     targetAffineLocally P f := by
   classical
-  let S i := (⟨⟨Set.range (𝒰.map i).1.base, (𝒰.IsOpen i).base_open.isOpen_range⟩,
-    rangeIsAffineOpenOfOpenImmersion (𝒰.map i)⟩ : Y.affineOpens)
+  let S i := (⟨_, isAffineOpen_opensRange (𝒰.map i)⟩ : Y.affineOpens)
   intro U
   apply of_affine_open_cover (P := _) U (Set.range S)
   · intro U r h
@@ -226,7 +225,7 @@ theorem AffineTargetMorphismProperty.IsLocal.affine_openCover_TFAE
           ∀ i, @P _ _ (f ∣_ U i) (hU' i)] := by
   tfae_have 1 → 4
   · intro H U g h₁ h₂
-    replace H := H ⟨⟨_, h₂.base_open.isOpen_range⟩, rangeIsAffineOpenOfOpenImmersion g⟩
+    replace H := H ⟨_, isAffineOpen_opensRange g⟩
     rw [← P.toProperty_apply] at H ⊢
     rwa [← hP.1.arrow_mk_iso_iff (morphismRestrictOpensRange f _)]
   tfae_have 4 → 3
@@ -248,9 +247,9 @@ theorem AffineTargetMorphismProperty.IsLocal.affine_openCover_TFAE
   tfae_have 1 → 5
   · intro H
     refine ⟨Y.carrier, fun x => (Scheme.Hom.opensRange <| Y.affineCover.map x),
-      ?_, fun i => rangeIsAffineOpenOfOpenImmersion _, ?_⟩
+      ?_, fun i => isAffineOpen_opensRange _, ?_⟩
     · rw [eq_top_iff]; intro x _; erw [Opens.mem_iSup]; exact ⟨x, Y.affineCover.Covers x⟩
-    · intro i; exact H ⟨_, rangeIsAffineOpenOfOpenImmersion _⟩
+    · intro i; exact H ⟨_, isAffineOpen_opensRange _⟩
   tfae_finish
 #align algebraic_geometry.affine_target_morphism_property.is_local.affine_open_cover_tfae AlgebraicGeometry.AffineTargetMorphismProperty.IsLocal.affine_openCover_TFAE
 
@@ -264,7 +263,7 @@ theorem AffineTargetMorphismProperty.isLocalOfOpenCoverImply (P : AffineTargetMo
     P.IsLocal := by
   refine ⟨hP, ?_, ?_⟩
   · introv h
-    haveI : IsAffine _ := (topIsAffineOpen Y).basicOpenIsAffine r
+    haveI : IsAffine _ := (isAffineOpen_top Y).basicOpen r
     delta morphismRestrict
     rw [affine_cancel_left_isIso hP]
     refine @H _ _ f ⟨Scheme.openCoverOfIsIso (𝟙 Y), ?_, ?_⟩ _ (Y.ofRestrict _) _ _
@@ -272,14 +271,14 @@ theorem AffineTargetMorphismProperty.isLocalOfOpenCoverImply (P : AffineTargetMo
     · intro i; dsimp
       rwa [← Category.comp_id pullback.snd, ← pullback.condition, affine_cancel_left_isIso hP]
   · introv hs hs'
-    replace hs := ((topIsAffineOpen Y).basicOpen_union_eq_self_iff _).mpr hs
+    replace hs := ((isAffineOpen_top Y).basicOpen_union_eq_self_iff _).mpr hs
     have := H f ⟨Y.openCoverOfSuprEqTop _ hs, ?_, ?_⟩ (𝟙 _)
     · rwa [← Category.comp_id pullback.snd, ← pullback.condition, affine_cancel_left_isIso hP]
         at this
-    · intro i; exact (topIsAffineOpen Y).basicOpenIsAffine _
+    · intro i; exact (isAffineOpen_top Y).basicOpen _
     · rintro (i : s)
       specialize hs' i
-      haveI : IsAffine _ := (topIsAffineOpen Y).basicOpenIsAffine i.1
+      haveI : IsAffine _ := (isAffineOpen_top Y).basicOpen i.1
       delta morphismRestrict at hs'
       rwa [affine_cancel_left_isIso hP] at hs'
 #align algebraic_geometry.affine_target_morphism_property.is_local_of_open_cover_imply AlgebraicGeometry.AffineTargetMorphismProperty.isLocalOfOpenCoverImply
@@ -334,14 +333,14 @@ lemma propertyIsLocalAtTarget_of_morphismRestrict (P : MorphismProperty Scheme)
     simp_rw [hP₁.arrow_mk_iso_iff (morphismRestrictOpensRange f _)]
     exact h𝒰
 
-theorem AffineTargetMorphismProperty.IsLocal.targetAffineLocallyIsLocal
+theorem AffineTargetMorphismProperty.IsLocal.targetAffineLocally_isLocal
     {P : AffineTargetMorphismProperty} (hP : P.IsLocal) :
     PropertyIsLocalAtTarget (targetAffineLocally P) := by
   constructor
   · exact targetAffineLocally_respectsIso hP.1
   · intro X Y f U H V
     rw [← P.toProperty_apply (i := V.2), hP.1.arrow_mk_iso_iff (morphismRestrictRestrict f _ _)]
-    convert H ⟨_, IsAffineOpen.imageIsOpenImmersion V.2 (Y.ofRestrict _)⟩
+    convert H ⟨_, V.2.image_of_isOpenImmersion (Y.ofRestrict _)⟩
     rw [← P.toProperty_apply]
   · rintro X Y f 𝒰 h𝒰
     -- Porting note: rewrite `[(hP.affine_openCover_TFAE f).out 0 1` directly complains about
@@ -368,7 +367,7 @@ theorem AffineTargetMorphismProperty.IsLocal.targetAffineLocallyIsLocal
       rw [← affine_cancel_left_isIso hP.1 e] at h𝒰
       convert h𝒰 using 1
       simp [e]
-#align algebraic_geometry.affine_target_morphism_property.is_local.target_affine_locally_is_local AlgebraicGeometry.AffineTargetMorphismProperty.IsLocal.targetAffineLocallyIsLocal
+#align algebraic_geometry.affine_target_morphism_property.is_local.target_affine_locally_is_local AlgebraicGeometry.AffineTargetMorphismProperty.IsLocal.targetAffineLocally_isLocal
 
 open List in
 theorem PropertyIsLocalAtTarget.openCover_TFAE {P : MorphismProperty Scheme}
@@ -431,7 +430,7 @@ def StableUnderBaseChange (P : AffineTargetMorphismProperty) : Prop :=
     P g → P (pullback.fst : pullback f g ⟶ X)
 #align algebraic_geometry.affine_target_morphism_property.stable_under_base_change AlgebraicGeometry.AffineTargetMorphismProperty.StableUnderBaseChange
 
-theorem IsLocal.targetAffineLocallyPullbackFstOfRightOfStableUnderBaseChange
+theorem IsLocal.targetAffineLocally_pullback_fst_of_right_of_stableUnderBaseChange
     {P : AffineTargetMorphismProperty} (hP : P.IsLocal) (hP' : P.StableUnderBaseChange)
     {X Y S : Scheme} (f : X ⟶ S) (g : Y ⟶ S) [IsAffine S] (H : P g) :
     targetAffineLocally P (pullback.fst : pullback f g ⟶ X) := by
@@ -444,7 +443,7 @@ theorem IsLocal.targetAffineLocallyPullbackFstOfRightOfStableUnderBaseChange
   have : e.hom ≫ pullback.fst = pullback.snd := by simp [e]
   rw [← this, affine_cancel_left_isIso hP.1]
   apply hP'; assumption
-#align algebraic_geometry.affine_target_morphism_property.is_local.target_affine_locally_pullback_fst_of_right_of_stable_under_base_change AlgebraicGeometry.AffineTargetMorphismProperty.IsLocal.targetAffineLocallyPullbackFstOfRightOfStableUnderBaseChange
+#align algebraic_geometry.affine_target_morphism_property.is_local.target_affine_locally_pullback_fst_of_right_of_stable_under_base_change AlgebraicGeometry.AffineTargetMorphismProperty.IsLocal.targetAffineLocally_pullback_fst_of_right_of_stableUnderBaseChange
 
 theorem IsLocal.stableUnderBaseChange {P : AffineTargetMorphismProperty} (hP : P.IsLocal)
     (hP' : P.StableUnderBaseChange) : (targetAffineLocally P).StableUnderBaseChange :=
@@ -452,7 +451,7 @@ theorem IsLocal.stableUnderBaseChange {P : AffineTargetMorphismProperty} (hP : P
     (fun X Y S f g H => by
       -- Porting note: rewrite `(...openCover_TFAE).out 0 1` directly doesn't work, complains about
       -- metavariable
-      have h01 := (hP.targetAffineLocallyIsLocal.openCover_TFAE
+      have h01 := (hP.targetAffineLocally_isLocal.openCover_TFAE
         (pullback.fst : pullback f g ⟶ X)).out 0 1
       rw [h01]
       use S.affineCover.pullbackCover f
@@ -470,7 +469,7 @@ theorem IsLocal.stableUnderBaseChange {P : AffineTargetMorphismProperty} (hP : P
           (pullback.map _ _ _ _ (𝟙 _) (𝟙 _) (𝟙 _) (by simpa using pullback.condition) (by simp))
       have : e.hom ≫ pullback.fst = pullback.snd := by simp [e]
       rw [← this, (targetAffineLocally_respectsIso hP.1).cancel_left_isIso]
-      apply hP.targetAffineLocallyPullbackFstOfRightOfStableUnderBaseChange hP'
+      apply hP.targetAffineLocally_pullback_fst_of_right_of_stableUnderBaseChange hP'
       rw [← pullbackSymmetry_hom_comp_snd, affine_cancel_left_isIso hP.1]
       apply H)
 #align algebraic_geometry.affine_target_morphism_property.is_local.stable_under_base_change AlgebraicGeometry.AffineTargetMorphismProperty.IsLocal.stableUnderBaseChange
@@ -499,12 +498,12 @@ theorem AffineTargetMorphismProperty.diagonal_respectsIso (P : AffineTargetMorph
     apply H
   · introv H _ _
     -- Porting note: add the following two instances
-    have _ : IsAffine Z := isAffineOfIso e.inv
+    have _ : IsAffine Z := isAffine_of_isIso e.inv
     rw [pullback.mapDesc_comp, affine_cancel_right_isIso hP]
     apply H
 #align algebraic_geometry.affine_target_morphism_property.diagonal_respects_iso AlgebraicGeometry.AffineTargetMorphismProperty.diagonal_respectsIso
 
-theorem diagonalTargetAffineLocallyOfOpenCover (P : AffineTargetMorphismProperty) (hP : P.IsLocal)
+theorem diagonal_targetAffineLocally_of_openCover (P : AffineTargetMorphismProperty) (hP : P.IsLocal)
     {X Y : Scheme.{u}} (f : X ⟶ Y) (𝒰 : Scheme.OpenCover.{u} Y) [∀ i, IsAffine (𝒰.obj i)]
     (𝒰' : ∀ i, Scheme.OpenCover.{u} (pullback f (𝒰.map i))) [∀ i j, IsAffine ((𝒰' i).obj j)]
     (h𝒰' : ∀ i j k, P (pullback.mapDesc ((𝒰' i).map j) ((𝒰' i).map k) pullback.snd)) :
@@ -522,9 +521,9 @@ theorem diagonalTargetAffineLocallyOfOpenCover (P : AffineTargetMorphismProperty
   all_goals apply pullback.hom_ext <;>
   simp only [Category.assoc, pullback.lift_fst, pullback.lift_snd, pullback.lift_fst_assoc,
     pullback.lift_snd_assoc]
-#align algebraic_geometry.diagonal_target_affine_locally_of_open_cover AlgebraicGeometry.diagonalTargetAffineLocallyOfOpenCover
+#align algebraic_geometry.diagonal_target_affine_locally_of_open_cover AlgebraicGeometry.diagonal_targetAffineLocally_of_openCover
 
-theorem AffineTargetMorphismProperty.diagonalOfTargetAffineLocally
+theorem AffineTargetMorphismProperty.diagonal_of_targetAffineLocally
     (P : AffineTargetMorphismProperty) (hP : P.IsLocal) {X Y U : Scheme.{u}} (f : X ⟶ Y) (g : U ⟶ Y)
     [IsAffine U] [IsOpenImmersion g] (H : (targetAffineLocally P).diagonal f) :
     P.diagonal (pullback.snd : pullback f g ⟶ _) := by
@@ -541,7 +540,7 @@ theorem AffineTargetMorphismProperty.diagonalOfTargetAffineLocally
     simp only [Category.assoc, pullback.lift_fst, pullback.lift_snd, pullback.lift_fst_assoc,
       pullback.lift_snd_assoc, Category.comp_id, pullbackDiagonalMapIso_hom_fst,
       pullbackDiagonalMapIso_hom_snd]
-#align algebraic_geometry.affine_target_morphism_property.diagonal_of_target_affine_locally AlgebraicGeometry.AffineTargetMorphismProperty.diagonalOfTargetAffineLocally
+#align algebraic_geometry.affine_target_morphism_property.diagonal_of_target_affine_locally AlgebraicGeometry.AffineTargetMorphismProperty.diagonal_of_targetAffineLocally
 
 open List in
 theorem AffineTargetMorphismProperty.IsLocal.diagonal_affine_openCover_TFAE
@@ -558,7 +557,7 @@ theorem AffineTargetMorphismProperty.IsLocal.diagonal_affine_openCover_TFAE
           ∀ i, Scheme.OpenCover.{u} (pullback f (𝒰.map i))) (_ : ∀ i j, IsAffine ((𝒰' i).obj j)),
           ∀ i j k, P (pullback.mapDesc ((𝒰' i).map j) ((𝒰' i).map k) pullback.snd)] := by
   tfae_have 1 → 4
-  · introv H hU hg _ _; apply P.diagonalOfTargetAffineLocally <;> assumption
+  · introv H hU hg _ _; apply P.diagonal_of_targetAffineLocally <;> assumption
   tfae_have 4 → 3
   · introv H h𝒰; apply H
   tfae_have 3 → 2
@@ -570,7 +569,7 @@ theorem AffineTargetMorphismProperty.IsLocal.diagonal_affine_openCover_TFAE
     apply H
   tfae_have 5 → 1
   · rintro ⟨𝒰, _, 𝒰', _, H⟩
-    exact diagonalTargetAffineLocallyOfOpenCover P hP f 𝒰 𝒰' H
+    exact diagonal_targetAffineLocally_of_openCover P hP f 𝒰 𝒰' H
   tfae_finish
 #align algebraic_geometry.affine_target_morphism_property.is_local.diagonal_affine_open_cover_tfae AlgebraicGeometry.AffineTargetMorphismProperty.IsLocal.diagonal_affine_openCover_TFAE
 
@@ -587,7 +586,7 @@ theorem diagonal_targetAffineLocally_eq_targetAffineLocally (P : AffineTargetMor
     ((hP.diagonal.affine_openCover_TFAE f).out 1 0)
 #align algebraic_geometry.diagonal_target_affine_locally_eq_target_affine_locally AlgebraicGeometry.diagonal_targetAffineLocally_eq_targetAffineLocally
 
-theorem universallyIsLocalAtTarget (P : MorphismProperty Scheme)
+theorem universally_isLocalAtTarget (P : MorphismProperty Scheme)
     (hP : ∀ {X Y : Scheme.{u}} (f : X ⟶ Y) (𝒰 : Scheme.OpenCover.{u} Y),
       (∀ i : 𝒰.J, P (pullback.snd : (𝒰.pullbackCover f).obj i ⟶ 𝒰.obj i)) → P f) :
     PropertyIsLocalAtTarget P.universally := by
@@ -603,17 +602,17 @@ theorem universallyIsLocalAtTarget (P : MorphismProperty Scheme)
   refine (IsPullback.of_right ?_ (pullback.lift_snd _ _ _) (IsPullback.of_hasPullback _ _)).flip
   rw [pullback.lift_fst, ← pullback.condition]
   exact (IsPullback.of_hasPullback _ _).paste_horiz H.flip
-#align algebraic_geometry.universally_is_local_at_target AlgebraicGeometry.universallyIsLocalAtTarget
+#align algebraic_geometry.universally_is_local_at_target AlgebraicGeometry.universally_isLocalAtTarget
 
-theorem universallyIsLocalAtTargetOfMorphismRestrict (P : MorphismProperty Scheme)
+theorem universally_isLocalAtTarget_of_morphismRestrict (P : MorphismProperty Scheme)
     (hP₁ : P.RespectsIso)
     (hP₂ : ∀ {X Y : Scheme.{u}} (f : X ⟶ Y) {ι : Type u} (U : ι → Opens Y.carrier)
       (_ : iSup U = ⊤), (∀ i, P (f ∣_ U i)) → P f) : PropertyIsLocalAtTarget P.universally :=
-  universallyIsLocalAtTarget P (fun f 𝒰 h𝒰 => by
+  universally_isLocalAtTarget P (fun f 𝒰 h𝒰 => by
     apply hP₂ f (fun i : 𝒰.J => Scheme.Hom.opensRange (𝒰.map i)) 𝒰.iSup_opensRange
     simp_rw [hP₁.arrow_mk_iso_iff (morphismRestrictOpensRange f _)]
     exact h𝒰)
-#align algebraic_geometry.universally_is_local_at_target_of_morphism_restrict AlgebraicGeometry.universallyIsLocalAtTargetOfMorphismRestrict
+#align algebraic_geometry.universally_is_local_at_target_of_morphism_restrict AlgebraicGeometry.universally_isLocalAtTarget_of_morphismRestrict
 
 theorem morphismRestrict_base {X Y : Scheme} (f : X ⟶ Y) (U : Opens Y.carrier) :
     ⇑(f ∣_ U).1.base = U.1.restrictPreimage f.1.1 :=
@@ -679,5 +678,28 @@ lemma MorphismProperty.topologically_propertyIsLocalAtTarget
     · intro i
       rw [← morphismRestrict_base]
       exact hf i
+
+@[deprecated (since := "2024-06-22")]
+alias AffineTargetMorphismProperty.IsLocal.targetAffineLocallyIsLocal :=
+    AffineTargetMorphismProperty.IsLocal.targetAffineLocally_isLocal
+
+open AffineTargetMorphismProperty.IsLocal in
+@[deprecated (since := "2024-06-22")]
+alias AffineTargetMorphismProperty.IsLocal.targetAffineLocallyPullbackFstOfRightOfStableUnderBaseChange :=
+  AffineTargetMorphismProperty.IsLocal.targetAffineLocally_pullback_fst_of_right_of_stableUnderBaseChange
+
+@[deprecated (since := "2024-06-22")]
+alias diagonalTargetAffineLocallyOfOpenCover := diagonal_targetAffineLocally_of_openCover
+
+@[deprecated (since := "2024-06-22")]
+alias AffineTargetMorphismProperty.diagonalOfTargetAffineLocally :=
+  AffineTargetMorphismProperty.diagonal_of_targetAffineLocally
+
+@[deprecated (since := "2024-06-22")]
+alias universallyIsLocalAtTarget := universally_isLocalAtTarget
+
+@[deprecated (since := "2024-06-22")]
+alias universallyIsLocalAtTargetOfMorphismRestrict :=
+  universally_isLocalAtTarget_of_morphismRestrict
 
 end AlgebraicGeometry

--- a/Mathlib/AlgebraicGeometry/Morphisms/Basic.lean
+++ b/Mathlib/AlgebraicGeometry/Morphisms/Basic.lean
@@ -503,7 +503,8 @@ theorem AffineTargetMorphismProperty.diagonal_respectsIso (P : AffineTargetMorph
     apply H
 #align algebraic_geometry.affine_target_morphism_property.diagonal_respects_iso AlgebraicGeometry.AffineTargetMorphismProperty.diagonal_respectsIso
 
-theorem diagonal_targetAffineLocally_of_openCover (P : AffineTargetMorphismProperty) (hP : P.IsLocal)
+theorem diagonal_targetAffineLocally_of_openCover
+    (P : AffineTargetMorphismProperty) (hP : P.IsLocal)
     {X Y : Scheme.{u}} (f : X ⟶ Y) (𝒰 : Scheme.OpenCover.{u} Y) [∀ i, IsAffine (𝒰.obj i)]
     (𝒰' : ∀ i, Scheme.OpenCover.{u} (pullback f (𝒰.map i))) [∀ i j, IsAffine ((𝒰' i).obj j)]
     (h𝒰' : ∀ i j k, P (pullback.mapDesc ((𝒰' i).map j) ((𝒰' i).map k) pullback.snd)) :
@@ -679,14 +680,16 @@ lemma MorphismProperty.topologically_propertyIsLocalAtTarget
       rw [← morphismRestrict_base]
       exact hf i
 
-@[deprecated (since := "2024-06-22")]
-alias AffineTargetMorphismProperty.IsLocal.targetAffineLocallyIsLocal :=
-    AffineTargetMorphismProperty.IsLocal.targetAffineLocally_isLocal
+namespace AffineTargetMorphismProperty.IsLocal
 
-open AffineTargetMorphismProperty.IsLocal in
 @[deprecated (since := "2024-06-22")]
-alias AffineTargetMorphismProperty.IsLocal.targetAffineLocallyPullbackFstOfRightOfStableUnderBaseChange :=
-  AffineTargetMorphismProperty.IsLocal.targetAffineLocally_pullback_fst_of_right_of_stableUnderBaseChange
+alias targetAffineLocallyIsLocal := targetAffineLocally_isLocal
+
+@[deprecated (since := "2024-06-22")]
+alias targetAffineLocallyPullbackFstOfRightOfStableUnderBaseChange :=
+  targetAffineLocally_pullback_fst_of_right_of_stableUnderBaseChange
+
+end AffineTargetMorphismProperty.IsLocal
 
 @[deprecated (since := "2024-06-22")]
 alias diagonalTargetAffineLocallyOfOpenCover := diagonal_targetAffineLocally_of_openCover

--- a/Mathlib/AlgebraicGeometry/Morphisms/Basic.lean
+++ b/Mathlib/AlgebraicGeometry/Morphisms/Basic.lean
@@ -48,7 +48,7 @@ satisfies the assumptions of the affine communication lemma
   `targetAffineLocally P f`, then `P.IsLocal`.
 - `AlgebraicGeometry.AffineTargetMorphismProperty.IsLocal.affine_target_iff`:
   If `Y` is affine and `f : X ⟶ Y`, then `targetAffineLocally P f ↔ P f` provided `P.IsLocal`.
-- `AlgebraicGeometry.AffineTargetMorphismProperty.IsLocal.targetAffineLocallyIsLocal` :
+- `AlgebraicGeometry.AffineTargetMorphismProperty.IsLocal.targetAffineLocally_isLocal` :
   If `P.IsLocal`, then `PropertyIsLocalAtTarget (targetAffineLocally P)`.
 - `AlgebraicGeometry.PropertyIsLocalAtTarget.openCover_TFAE`:
   If `PropertyIsLocalAtTarget P`, then `P f` iff there exists an open cover `{ Uᵢ }` of `Y`

--- a/Mathlib/AlgebraicGeometry/Morphisms/OpenImmersion.lean
+++ b/Mathlib/AlgebraicGeometry/Morphisms/OpenImmersion.lean
@@ -72,7 +72,7 @@ theorem isOpenImmersion_isLocalAtTarget : PropertyIsLocalAtTarget @IsOpenImmersi
         (isOpenImmersion_respectsIso.arrow_iso_iff
           (morphismRestrictOpensRange f (𝒰.map _))).mpr (H _)
       infer_instance
-#align algebraic_geometry.is_open_immersion_is_local_at_target AlgebraicGeometry.isOpenImmersion_is_local_at_target
+#align algebraic_geometry.is_open_immersion_is_local_at_target AlgebraicGeometry.isOpenImmersion_isLocalAtTarget
 
 theorem IsOpenImmersion.openCover_TFAE {X Y : Scheme.{u}} (f : X ⟶ Y) : List.TFAE
     [IsOpenImmersion f,
@@ -85,13 +85,13 @@ theorem IsOpenImmersion.openCover_TFAE {X Y : Scheme.{u}} (f : X ⟶ Y) : List.T
       IsOpenImmersion (pullback.snd : pullback f g ⟶ _),
     ∃ (ι : Type u) (U : ι → Opens Y.carrier) (_ : iSup U = ⊤),
       ∀ i, IsOpenImmersion (f ∣_ U i)] :=
-  isOpenImmersion_is_local_at_target.openCover_TFAE f
+  isOpenImmersion_isLocalAtTarget.openCover_TFAE f
 #align algebraic_geometry.is_open_immersion.open_cover_tfae AlgebraicGeometry.IsOpenImmersion.openCover_TFAE
 
 theorem IsOpenImmersion.openCover_iff {X Y : Scheme.{u}} (𝒰 : Scheme.OpenCover.{u} Y)
     (f : X ⟶ Y) :
     IsOpenImmersion f ↔ ∀ i, IsOpenImmersion (pullback.snd : pullback f (𝒰.map i) ⟶ _) :=
-  isOpenImmersion_is_local_at_target.openCover_iff f 𝒰
+  isOpenImmersion_isLocalAtTarget.openCover_iff f 𝒰
 #align algebraic_geometry.is_open_immersion.open_cover_iff AlgebraicGeometry.IsOpenImmersion.openCover_iff
 
 theorem isOpenImmersion_stableUnderBaseChange :

--- a/Mathlib/AlgebraicGeometry/Morphisms/OpenImmersion.lean
+++ b/Mathlib/AlgebraicGeometry/Morphisms/OpenImmersion.lean
@@ -50,7 +50,7 @@ theorem isOpenImmersion_respectsIso : MorphismProperty.RespectsIso @IsOpenImmers
   infer_instance
 #align algebraic_geometry.is_open_immersion_respects_iso AlgebraicGeometry.isOpenImmersion_respectsIso
 
-theorem isOpenImmersion_is_local_at_target : PropertyIsLocalAtTarget @IsOpenImmersion := by
+theorem isOpenImmersion_isLocalAtTarget : PropertyIsLocalAtTarget @IsOpenImmersion := by
   constructor
   · exact isOpenImmersion_respectsIso
   · intros; infer_instance

--- a/Mathlib/AlgebraicGeometry/Morphisms/QuasiCompact.lean
+++ b/Mathlib/AlgebraicGeometry/Morphisms/QuasiCompact.lean
@@ -88,7 +88,7 @@ theorem isCompact_open_iff_eq_basicOpen_union {X : Scheme} [IsAffine X] (U : Set
       ∃ s : Set (X.presheaf.obj (op ⊤)),
         s.Finite ∧ U = ⋃ (i : X.presheaf.obj (op ⊤)) (_ : i ∈ s), X.basicOpen i :=
   (isBasis_basicOpen X).isCompact_open_iff_eq_finite_iUnion _
-    (fun _ => ((topIsAffineOpen _).basicOpenIsAffine _).isCompact) _
+    (fun _ => ((isAffineOpen_top _).basicOpenIsAffine _).isCompact) _
 #align algebraic_geometry.is_compact_open_iff_eq_basic_open_union AlgebraicGeometry.isCompact_open_iff_eq_basicOpen_union
 
 theorem quasiCompact_iff_forall_affine :
@@ -176,7 +176,7 @@ theorem QuasiCompact.affineProperty_isLocal : (QuasiCompact.affineProperty : _).
       dsimp [Opens.map]
       simp only [Opens.iSup_mk, Opens.carrier_eq_coe, Opens.coe_mk, Set.preimage_iUnion]
       exact isCompact_iUnion fun i => isCompact_iff_compactSpace.mpr (hS' i)
-    · exact topIsAffineOpen _
+    · exact isAffineOpen_top _
 #align algebraic_geometry.quasi_compact.affine_property_is_local AlgebraicGeometry.QuasiCompact.affineProperty_isLocal
 
 theorem QuasiCompact.affine_openCover_tfae {X Y : Scheme.{u}} (f : X ⟶ Y) :
@@ -193,10 +193,10 @@ theorem QuasiCompact.affine_openCover_tfae {X Y : Scheme.{u}} (f : X ⟶ Y) :
   quasiCompact_eq_affineProperty.symm ▸ QuasiCompact.affineProperty_isLocal.affine_openCover_TFAE f
 #align algebraic_geometry.quasi_compact.affine_open_cover_tfae AlgebraicGeometry.QuasiCompact.affine_openCover_tfae
 
-theorem QuasiCompact.is_local_at_target : PropertyIsLocalAtTarget @QuasiCompact :=
+theorem QuasiCompact.isLocalAtTarget : PropertyIsLocalAtTarget @QuasiCompact :=
   quasiCompact_eq_affineProperty.symm ▸
-    QuasiCompact.affineProperty_isLocal.targetAffineLocallyIsLocal
-#align algebraic_geometry.quasi_compact.is_local_at_target AlgebraicGeometry.QuasiCompact.is_local_at_target
+    QuasiCompact.affineProperty_isLocal.targetAffineLocally_isLocal
+#align algebraic_geometry.quasi_compact.is_local_at_target AlgebraicGeometry.QuasiCompact.isLocalAtTarget
 
 theorem QuasiCompact.openCover_tfae {X Y : Scheme.{u}} (f : X ⟶ Y) :
     List.TFAE
@@ -210,7 +210,7 @@ theorem QuasiCompact.openCover_tfae {X Y : Scheme.{u}} (f : X ⟶ Y) :
           QuasiCompact (pullback.snd : pullback f g ⟶ _),
         ∃ (ι : Type u) (U : ι → Opens Y.carrier) (_ : iSup U = ⊤), ∀ i, QuasiCompact (f ∣_ U i)] :=
   quasiCompact_eq_affineProperty.symm ▸
-    QuasiCompact.affineProperty_isLocal.targetAffineLocallyIsLocal.openCover_TFAE f
+    QuasiCompact.affineProperty_isLocal.targetAffineLocally_isLocal.openCover_TFAE f
 #align algebraic_geometry.quasi_compact.open_cover_tfae AlgebraicGeometry.QuasiCompact.openCover_tfae
 
 theorem quasiCompact_over_affine_iff {X Y : Scheme} (f : X ⟶ Y) [IsAffine Y] :
@@ -232,7 +232,7 @@ theorem QuasiCompact.affine_openCover_iff {X Y : Scheme.{u}} (𝒰 : Scheme.Open
 theorem QuasiCompact.openCover_iff {X Y : Scheme.{u}} (𝒰 : Scheme.OpenCover.{u} Y) (f : X ⟶ Y) :
     QuasiCompact f ↔ ∀ i, QuasiCompact (pullback.snd : pullback f (𝒰.map i) ⟶ _) :=
   quasiCompact_eq_affineProperty.symm ▸
-    QuasiCompact.affineProperty_isLocal.targetAffineLocallyIsLocal.openCover_iff f 𝒰
+    QuasiCompact.affineProperty_isLocal.targetAffineLocally_isLocal.openCover_iff f 𝒰
 #align algebraic_geometry.quasi_compact.open_cover_iff AlgebraicGeometry.QuasiCompact.openCover_iff
 
 theorem quasiCompact_respectsIso : MorphismProperty.RespectsIso @QuasiCompact :=

--- a/Mathlib/AlgebraicGeometry/Morphisms/QuasiCompact.lean
+++ b/Mathlib/AlgebraicGeometry/Morphisms/QuasiCompact.lean
@@ -88,7 +88,7 @@ theorem isCompact_open_iff_eq_basicOpen_union {X : Scheme} [IsAffine X] (U : Set
       ∃ s : Set (X.presheaf.obj (op ⊤)),
         s.Finite ∧ U = ⋃ (i : X.presheaf.obj (op ⊤)) (_ : i ∈ s), X.basicOpen i :=
   (isBasis_basicOpen X).isCompact_open_iff_eq_finite_iUnion _
-    (fun _ => ((isAffineOpen_top _).basicOpenIsAffine _).isCompact) _
+    (fun _ => ((isAffineOpen_top _).basicOpen _).isCompact) _
 #align algebraic_geometry.is_compact_open_iff_eq_basic_open_union AlgebraicGeometry.isCompact_open_iff_eq_basicOpen_union
 
 theorem quasiCompact_iff_forall_affine :
@@ -136,7 +136,7 @@ theorem isCompact_basicOpen (X : Scheme) {U : Opens X.carrier} (hU : IsCompact (
       convert Set.subset_iUnion₂ (s := fun (U : X.affineOpens) (_ : U ∈ s) => (U : Set X.carrier))
         V V.prop using 1
     erw [← X.toLocallyRingedSpace.toRingedSpace.basicOpen_res this.op]
-    exact IsAffineOpen.basicOpenIsAffine V.1.prop _
+    exact IsAffineOpen.basicOpen V.1.prop _
   haveI : Finite s := hs.to_subtype
   refine ⟨Set.range g, Set.finite_range g, ?_⟩
   refine (Set.inter_eq_right.mpr

--- a/Mathlib/AlgebraicGeometry/Morphisms/QuasiSeparated.lean
+++ b/Mathlib/AlgebraicGeometry/Morphisms/QuasiSeparated.lean
@@ -265,7 +265,7 @@ instance quasiSeparatedSpace_of_isAffine (X : Scheme) [IsAffine X] :
   intro i' _
   change IsCompact (X.basicOpen i ⊓ X.basicOpen i').1
   rw [← Scheme.basicOpen_mul]
-  exact ((isAffineOpen_top _).basicOpenIsAffine _).isCompact
+  exact ((isAffineOpen_top _).basicOpen _).isCompact
 #align algebraic_geometry.quasi_separated_space_of_is_affine AlgebraicGeometry.quasiSeparatedSpace_of_isAffine
 
 theorem IsAffineOpen.isQuasiSeparated {X : Scheme} {U : Opens X.carrier} (hU : IsAffineOpen U) :

--- a/Mathlib/AlgebraicGeometry/Morphisms/QuasiSeparated.lean
+++ b/Mathlib/AlgebraicGeometry/Morphisms/QuasiSeparated.lean
@@ -109,8 +109,8 @@ theorem quasi_compact_affineProperty_iff_quasiSeparatedSpace {X Y : Scheme} [IsA
     simp_rw [isCompact_iff_compactSpace] at H
     exact
       @Homeomorph.compactSpace _ _ _ _
-        (H ⟨⟨_, h₁.base_open.isOpen_range⟩, rangeIsAffineOpenOfOpenImmersion _⟩
-          ⟨⟨_, h₂.base_open.isOpen_range⟩, rangeIsAffineOpenOfOpenImmersion _⟩)
+        (H ⟨⟨_, h₁.base_open.isOpen_range⟩, isAffineOpen_opensRange _⟩
+          ⟨⟨_, h₂.base_open.isOpen_range⟩, isAffineOpen_opensRange _⟩)
         e.symm
 #align algebraic_geometry.quasi_compact_affine_property_iff_quasi_separated_space AlgebraicGeometry.quasi_compact_affineProperty_iff_quasiSeparatedSpace
 
@@ -186,10 +186,10 @@ theorem QuasiSeparated.affine_openCover_TFAE {X Y : Scheme.{u}} (f : X ⟶ Y) :
   exact this
 #align algebraic_geometry.quasi_separated.affine_open_cover_tfae AlgebraicGeometry.QuasiSeparated.affine_openCover_TFAE
 
-theorem QuasiSeparated.is_local_at_target : PropertyIsLocalAtTarget @QuasiSeparated :=
+theorem QuasiSeparated.isLocalAtTarget : PropertyIsLocalAtTarget @QuasiSeparated :=
   quasiSeparated_eq_affineProperty_diagonal.symm ▸
-    QuasiCompact.affineProperty_isLocal.diagonal.targetAffineLocallyIsLocal
-#align algebraic_geometry.quasi_separated.is_local_at_target AlgebraicGeometry.QuasiSeparated.is_local_at_target
+    QuasiCompact.affineProperty_isLocal.diagonal.targetAffineLocally_isLocal
+#align algebraic_geometry.quasi_separated.is_local_at_target AlgebraicGeometry.QuasiSeparated.isLocalAtTarget
 
 open List in
 theorem QuasiSeparated.openCover_TFAE {X Y : Scheme.{u}} (f : X ⟶ Y) :
@@ -204,7 +204,7 @@ theorem QuasiSeparated.openCover_TFAE {X Y : Scheme.{u}} (f : X ⟶ Y) :
           QuasiSeparated (pullback.snd : pullback f g ⟶ _),
         ∃ (ι : Type u) (U : ι → Opens Y.carrier) (_ : iSup U = ⊤),
           ∀ i, QuasiSeparated (f ∣_ U i)] :=
-  QuasiSeparated.is_local_at_target.openCover_TFAE f
+  QuasiSeparated.isLocalAtTarget.openCover_TFAE f
 #align algebraic_geometry.quasi_separated.open_cover_tfae AlgebraicGeometry.QuasiSeparated.openCover_TFAE
 
 theorem quasiSeparated_over_affine_iff {X Y : Scheme} (f : X ⟶ Y) [IsAffine Y] :
@@ -228,7 +228,7 @@ theorem QuasiSeparated.affine_openCover_iff {X Y : Scheme.{u}} (𝒰 : Scheme.Op
 
 theorem QuasiSeparated.openCover_iff {X Y : Scheme.{u}} (𝒰 : Scheme.OpenCover.{u} Y) (f : X ⟶ Y) :
     QuasiSeparated f ↔ ∀ i, QuasiSeparated (pullback.snd : pullback f (𝒰.map i) ⟶ _) :=
-  QuasiSeparated.is_local_at_target.openCover_iff f 𝒰
+  QuasiSeparated.isLocalAtTarget.openCover_iff f 𝒰
 #align algebraic_geometry.quasi_separated.open_cover_iff AlgebraicGeometry.QuasiSeparated.openCover_iff
 
 instance {X Y S : Scheme} (f : X ⟶ S) (g : Y ⟶ S) [QuasiSeparated g] :
@@ -265,7 +265,7 @@ instance quasiSeparatedSpace_of_isAffine (X : Scheme) [IsAffine X] :
   intro i' _
   change IsCompact (X.basicOpen i ⊓ X.basicOpen i').1
   rw [← Scheme.basicOpen_mul]
-  exact ((topIsAffineOpen _).basicOpenIsAffine _).isCompact
+  exact ((isAffineOpen_top _).basicOpenIsAffine _).isCompact
 #align algebraic_geometry.quasi_separated_space_of_is_affine AlgebraicGeometry.quasiSeparatedSpace_of_isAffine
 
 theorem IsAffineOpen.isQuasiSeparated {X : Scheme} {U : Opens X.carrier} (hU : IsAffineOpen U) :

--- a/Mathlib/AlgebraicGeometry/Morphisms/RingHomProperties.lean
+++ b/Mathlib/AlgebraicGeometry/Morphisms/RingHomProperties.lean
@@ -197,7 +197,7 @@ theorem affineLocally_iff_affineOpens_le
       · simp only [Scheme.ofRestrict_val_c_app, Scheme.restrict_presheaf_map, ← X.presheaf.map_comp]
         congr 1
   · intro H V
-    specialize H ⟨_, V.2.imageIsOpenImmersion (X.ofRestrict _)⟩ (Subtype.coe_image_subset _ _)
+    specialize H ⟨_, V.2.image_of_isOpenImmersion (X.ofRestrict _)⟩ (Subtype.coe_image_subset _ _)
     rw [← hP.cancel_right_isIso _ (X.presheaf.map (eqToHom _)), Category.assoc]
     · convert H
       simp only [Scheme.ofRestrict_val_c_app, Scheme.restrict_presheaf_map, ← X.presheaf.map_comp]
@@ -211,12 +211,12 @@ theorem scheme_restrict_basicOpen_of_localizationPreserves (h₁ : RingHom.Respe
     (U : (X.restrict ((Opens.map f.1.base).obj <| Y.basicOpen r).openEmbedding).affineOpens) :
     P (Scheme.Γ.map ((X.restrict ((Opens.map f.1.base).obj <|
       Y.basicOpen r).openEmbedding).ofRestrict U.1.openEmbedding ≫ f ∣_ Y.basicOpen r).op) := by
-  specialize H ⟨_, U.2.imageIsOpenImmersion (X.ofRestrict _)⟩
+  specialize H ⟨_, U.2.image_of_isOpenImmersion (X.ofRestrict _)⟩
   letI i1 : Algebra (Y.presheaf.obj <| Opposite.op ⊤) (Localization.Away r) := Localization.algebra
   exact (h₁.ofRestrict_morphismRestrict_iff f r
     ((Scheme.Hom.opensFunctor
       (X.ofRestrict ((Opens.map f.1.base).obj <| Y.basicOpen r).openEmbedding)).obj U.1)
-    (IsAffineOpen.imageIsOpenImmersion U.2
+    (IsAffineOpen.image_of_isOpenImmersion U.2
       (X.ofRestrict ((Opens.map f.1.base).obj <| Y.basicOpen r).openEmbedding))
     (Opens.ext (Set.preimage_image_eq _ Subtype.coe_injective).symm)).mpr (h₂.away r H)
 set_option linter.uppercaseLean3 false in

--- a/Mathlib/AlgebraicGeometry/Morphisms/RingHomProperties.lean
+++ b/Mathlib/AlgebraicGeometry/Morphisms/RingHomProperties.lean
@@ -242,7 +242,7 @@ theorem sourceAffineLocally_isLocal (h₁ : RingHom.RespectsIso @P)
         intro V hV
         rw [Scheme.preimage_basicOpen] at hV
         subst hV
-        exact U.2.mapRestrictBasicOpen (Scheme.Γ.map f.op r.1)
+        exact U.2.ιOpens_preimage (Scheme.Γ.map f.op r.1)
 #align algebraic_geometry.source_affine_locally_is_local AlgebraicGeometry.sourceAffineLocally_isLocal
 
 variable (hP : RingHom.PropertyIsLocal @P)

--- a/Mathlib/AlgebraicGeometry/Morphisms/RingHomProperties.lean
+++ b/Mathlib/AlgebraicGeometry/Morphisms/RingHomProperties.lean
@@ -274,7 +274,7 @@ theorem isOpenImmersionCat_comp_of_sourceAffineLocally (h₁ : RingHom.RespectsI
   rw [← h₁.cancel_right_isIso _
     (Scheme.Γ.map (IsOpenImmersion.isoOfRangeEq (Y.ofRestrict _) f _).hom.op),
     ← Functor.map_comp, ← op_comp]
-  · convert h₂ ⟨_, rangeIsAffineOpenOfOpenImmersion f⟩ using 3
+  · convert h₂ ⟨_, isAffineOpen_opensRange f⟩ using 3
     · rw [IsOpenImmersion.isoOfRangeEq_hom_fac_assoc]
       exact Subtype.range_coe
 #align algebraic_geometry.is_open_immersion_comp_of_source_affine_locally AlgebraicGeometry.isOpenImmersionCat_comp_of_sourceAffineLocally
@@ -291,7 +291,7 @@ theorem sourceAffineLocally_of_source_openCover {X Y : Scheme.{u}} (f : X ⟶ Y)
     (𝒰 : X.OpenCover) [∀ i, IsAffine (𝒰.obj i)] (H : ∀ i, P (Scheme.Γ.map (𝒰.map i ≫ f).op)) :
     sourceAffineLocally (@P) f := by
   let S i := (⟨⟨Set.range (𝒰.map i).1.base, (𝒰.IsOpen i).base_open.isOpen_range⟩,
-    rangeIsAffineOpenOfOpenImmersion (𝒰.map i)⟩ : X.affineOpens)
+    isAffineOpen_opensRange (𝒰.map i)⟩ : X.affineOpens)
   intro U
   -- Porting note: here is what we are eliminating into Lean
   apply of_affine_open_cover
@@ -360,7 +360,7 @@ theorem affine_openCover_TFAE {X Y : Scheme.{u}} [IsAffine Y] (f : X ⟶ Y) :
           P (Scheme.Γ.map (g ≫ f).op)] := by
   tfae_have 1 → 4
   · intro H U g _ hg
-    specialize H ⟨⟨_, hg.base_open.isOpen_range⟩, rangeIsAffineOpenOfOpenImmersion g⟩
+    specialize H ⟨⟨_, hg.base_open.isOpen_range⟩, isAffineOpen_opensRange g⟩
     rw [← hP.respectsIso.cancel_right_isIso _ (Scheme.Γ.map (IsOpenImmersion.isoOfRangeEq g
       (X.ofRestrict (Opens.openEmbedding ⟨_, hg.base_open.isOpen_range⟩))
       Subtype.range_coe.symm).hom.op),
@@ -446,7 +446,7 @@ theorem isLocal_sourceAffineLocally : (sourceAffineLocally @P).IsLocal :=
 #align ring_hom.property_is_local.is_local_source_affine_locally RingHom.PropertyIsLocal.isLocal_sourceAffineLocally
 
 theorem is_local_affineLocally : PropertyIsLocalAtTarget (affineLocally @P) :=
-  hP.isLocal_sourceAffineLocally.targetAffineLocallyIsLocal
+  hP.isLocal_sourceAffineLocally.targetAffineLocally_isLocal
 #align ring_hom.property_is_local.is_local_affine_locally RingHom.PropertyIsLocal.is_local_affineLocally
 
 theorem affine_openCover_iff {X Y : Scheme.{u}} (f : X ⟶ Y) (𝒰 : Scheme.OpenCover.{u} Y)

--- a/Mathlib/AlgebraicGeometry/Morphisms/UniversallyClosed.lean
+++ b/Mathlib/AlgebraicGeometry/Morphisms/UniversallyClosed.lean
@@ -85,19 +85,19 @@ instance universallyClosedSnd {X Y Z : Scheme} (f : X ⟶ Z) (g : Y ⟶ Z) [hf :
   universallyClosed_stableUnderBaseChange.snd f g hf
 #align algebraic_geometry.universally_closed_snd AlgebraicGeometry.universallyClosedSnd
 
-theorem universallyClosed_is_local_at_target : PropertyIsLocalAtTarget @UniversallyClosed := by
+theorem universallyClosed_isLocalAtTarget : PropertyIsLocalAtTarget @UniversallyClosed := by
   rw [universallyClosed_eq]
-  apply universallyIsLocalAtTargetOfMorphismRestrict
+  apply universally_isLocalAtTarget_of_morphismRestrict
   · exact topologically_isClosedMap_respectsIso
   · intro X Y f ι U hU H
     simp_rw [topologically, morphismRestrict_base] at H
     exact (isClosedMap_iff_isClosedMap_of_iSup_eq_top hU).mpr H
-#align algebraic_geometry.universally_closed_is_local_at_target AlgebraicGeometry.universallyClosed_is_local_at_target
+#align algebraic_geometry.universally_closed_is_local_at_target AlgebraicGeometry.universallyClosed_isLocalAtTarget
 
 theorem UniversallyClosed.openCover_iff {X Y : Scheme.{u}} (f : X ⟶ Y)
     (𝒰 : Scheme.OpenCover.{u} Y) :
     UniversallyClosed f ↔ ∀ i, UniversallyClosed (pullback.snd : pullback f (𝒰.map i) ⟶ _) :=
-  universallyClosed_is_local_at_target.openCover_iff f 𝒰
+  universallyClosed_isLocalAtTarget.openCover_iff f 𝒰
 #align algebraic_geometry.universally_closed.open_cover_iff AlgebraicGeometry.UniversallyClosed.openCover_iff
 
 end AlgebraicGeometry

--- a/Mathlib/AlgebraicGeometry/PrimeSpectrum/Basic.lean
+++ b/Mathlib/AlgebraicGeometry/PrimeSpectrum/Basic.lean
@@ -64,6 +64,8 @@ structure PrimeSpectrum [CommSemiring R] where
   isPrime : asIdeal.IsPrime
 #align prime_spectrum PrimeSpectrum
 
+@[deprecated (since := "2024-06-22")] alias PrimeSpectrum.IsPrime := PrimeSpectrum.isPrime
+
 attribute [instance] PrimeSpectrum.isPrime
 
 namespace PrimeSpectrum

--- a/Mathlib/AlgebraicGeometry/PrimeSpectrum/Basic.lean
+++ b/Mathlib/AlgebraicGeometry/PrimeSpectrum/Basic.lean
@@ -61,10 +61,10 @@ It is a fundamental building block in algebraic geometry. -/
 @[ext]
 structure PrimeSpectrum [CommSemiring R] where
   asIdeal : Ideal R
-  IsPrime : asIdeal.IsPrime
+  isPrime : asIdeal.IsPrime
 #align prime_spectrum PrimeSpectrum
 
-attribute [instance] PrimeSpectrum.IsPrime
+attribute [instance] PrimeSpectrum.isPrime
 
 namespace PrimeSpectrum
 
@@ -79,7 +79,7 @@ instance [Nontrivial R] : Nonempty <| PrimeSpectrum R :=
 
 /-- The prime spectrum of the zero ring is empty. -/
 instance [Subsingleton R] : IsEmpty (PrimeSpectrum R) :=
-  ⟨fun x ↦ x.IsPrime.ne_top <| SetLike.ext' <| Subsingleton.eq_univ_of_nonempty x.asIdeal.nonempty⟩
+  ⟨fun x ↦ x.isPrime.ne_top <| SetLike.ext' <| Subsingleton.eq_univ_of_nonempty x.asIdeal.nonempty⟩
 #noalign prime_spectrum.punit
 
 variable (R S)
@@ -158,11 +158,11 @@ At a point `x` (a prime ideal) the function (i.e., element) `f` takes values in 
 consisting of all "functions" that vanish on all of `t`.
 -/
 def vanishingIdeal (t : Set (PrimeSpectrum R)) : Ideal R :=
-  ⨅ (x : PrimeSpectrum R) (_ : x ∈ t), x.asIdeal
+  ⨅ x ∈ t, x.asIdeal
 #align prime_spectrum.vanishing_ideal PrimeSpectrum.vanishingIdeal
 
 theorem coe_vanishingIdeal (t : Set (PrimeSpectrum R)) :
-    (vanishingIdeal t : Set R) = { f : R | ∀ x : PrimeSpectrum R, x ∈ t → f ∈ x.asIdeal } := by
+    (vanishingIdeal t : Set R) = { f : R | ∀ x ∈ t, f ∈ x.asIdeal } := by
   ext f
   rw [vanishingIdeal, SetLike.mem_coe, Submodule.mem_iInf]
   apply forall_congr'; intro x
@@ -170,7 +170,7 @@ theorem coe_vanishingIdeal (t : Set (PrimeSpectrum R)) :
 #align prime_spectrum.coe_vanishing_ideal PrimeSpectrum.coe_vanishingIdeal
 
 theorem mem_vanishingIdeal (t : Set (PrimeSpectrum R)) (f : R) :
-    f ∈ vanishingIdeal t ↔ ∀ x : PrimeSpectrum R, x ∈ t → f ∈ x.asIdeal := by
+    f ∈ vanishingIdeal t ↔ ∀ x ∈ t, f ∈ x.asIdeal := by
   rw [← SetLike.mem_coe, coe_vanishingIdeal, Set.mem_setOf_eq]
 #align prime_spectrum.mem_vanishing_ideal PrimeSpectrum.mem_vanishingIdeal
 
@@ -277,9 +277,9 @@ theorem zeroLocus_empty : zeroLocus (∅ : Set R) = Set.univ :=
 #align prime_spectrum.zero_locus_empty PrimeSpectrum.zeroLocus_empty
 
 @[simp]
-theorem vanishingIdeal_univ : vanishingIdeal (∅ : Set (PrimeSpectrum R)) = ⊤ := by
+theorem vanishingIdeal_empty : vanishingIdeal (∅ : Set (PrimeSpectrum R)) = ⊤ := by
   simpa using (gc R).u_top
-#align prime_spectrum.vanishing_ideal_univ PrimeSpectrum.vanishingIdeal_univ
+#align prime_spectrum.vanishing_ideal_univ PrimeSpectrum.vanishingIdeal_empty
 
 theorem zeroLocus_empty_of_one_mem {s : Set R} (h : (1 : R) ∈ s) : zeroLocus s = ∅ := by
   rw [Set.eq_empty_iff_forall_not_mem]

--- a/Mathlib/AlgebraicGeometry/PrimeSpectrum/IsOpenComapC.lean
+++ b/Mathlib/AlgebraicGeometry/PrimeSpectrum/IsOpenComapC.lean
@@ -54,7 +54,7 @@ morphism `C⁺ : Spec R[x] → Spec R`. -/
 theorem imageOfDf_eq_comap_C_compl_zeroLocus :
     imageOfDf f = PrimeSpectrum.comap (C : R →+* R[X]) '' (zeroLocus {f})ᶜ := by
   ext x
-  refine ⟨fun hx => ⟨⟨map C x.asIdeal, isPrime_map_C_of_isPrime x.IsPrime⟩, ⟨?_, ?_⟩⟩, ?_⟩
+  refine ⟨fun hx => ⟨⟨map C x.asIdeal, isPrime_map_C_of_isPrime x.isPrime⟩, ⟨?_, ?_⟩⟩, ?_⟩
   · rw [mem_compl_iff, mem_zeroLocus, singleton_subset_iff]
     cases' hx with i hi
     exact fun a => hi (mem_map_C_iff.mp a i)

--- a/Mathlib/AlgebraicGeometry/ProjectiveSpectrum/Scheme.lean
+++ b/Mathlib/AlgebraicGeometry/ProjectiveSpectrum/Scheme.lean
@@ -444,7 +444,7 @@ def carrier.asHomogeneousIdeal : HomogeneousIdeal 𝒜 :=
 #align algebraic_geometry.Proj_iso_Spec_Top_component.from_Spec.carrier.as_homogeneous_ideal AlgebraicGeometry.ProjIsoSpecTopComponent.FromSpec.carrier.asHomogeneousIdeal
 
 theorem carrier.denom_not_mem : f ∉ carrier.asIdeal f_deg hm q := fun rid =>
-  q.IsPrime.ne_top <|
+  q.isPrime.ne_top <|
     (Ideal.eq_top_iff_one _).mpr
       (by
         convert rid m

--- a/Mathlib/AlgebraicGeometry/Properties.lean
+++ b/Mathlib/AlgebraicGeometry/Properties.lean
@@ -66,7 +66,7 @@ theorem isReduced_of_isReduced_stalk [∀ x : X.carrier, _root_.IsReduced (X.pre
   rw [RingHom.map_zero]
   change X.presheaf.germ x s = 0
   exact (hs.map _).eq_zero
-#align algebraic_geometry.is_reduced_of_stalk_is_reduced AlgebraicGeometry.isReducedOfStalkIsReduced
+#align algebraic_geometry.is_reduced_of_stalk_is_reduced AlgebraicGeometry.isReduced_of_isReduced_stalk
 
 instance isReduced_stalk_of_isReduced [IsReduced X] (x : X.carrier) :
     _root_.IsReduced (X.presheaf.stalk x) := by
@@ -118,7 +118,7 @@ theorem isReduced_of_isAffine_isReduced [IsAffine X]
   haveI : IsReduced (Scheme.Spec.obj (op (Scheme.Γ.obj (op X)))) := by
     rw [affine_isReduced_iff]; exact h
   isReduced_of_isOpenImmersion X.isoSpec.hom
-#align algebraic_geometry.is_reduced_of_is_affine_is_reduced AlgebraicGeometry.isReducedOfIsAffineIsReduced
+#align algebraic_geometry.is_reduced_of_is_affine_is_reduced AlgebraicGeometry.isReduced_of_isAffine_isReduced
 
 /-- To show that a statement `P` holds for all open subsets of all schemes, it suffices to show that
 1. In any scheme `X`, if `P` holds for an open cover of `U`, then `P` holds for `U`.
@@ -256,7 +256,7 @@ instance irreducibleSpace_of_isIntegral [IsIntegral X] : IrreducibleSpace X.carr
       exacts [hS h, hT h]
     · intro x
       exact x.rec (by contradiction)
-#align algebraic_geometry.is_irreducible_of_is_integral AlgebraicGeometry.is_irreducible_of_isIntegral
+#align algebraic_geometry.is_irreducible_of_is_integral AlgebraicGeometry.irreducibleSpace_of_isIntegral
 
 theorem isIntegral_of_irreducibleSpace_of_isReduced [IsReduced X] [H : IrreducibleSpace X.carrier] :
     IsIntegral X := by

--- a/Mathlib/AlgebraicGeometry/Properties.lean
+++ b/Mathlib/AlgebraicGeometry/Properties.lean
@@ -58,7 +58,7 @@ class IsReduced : Prop where
 
 attribute [instance] IsReduced.component_reduced
 
-theorem isReducedOfStalkIsReduced [∀ x : X.carrier, _root_.IsReduced (X.presheaf.stalk x)] :
+theorem isReduced_of_isReduced_stalk [∀ x : X.carrier, _root_.IsReduced (X.presheaf.stalk x)] :
     IsReduced X := by
   refine ⟨fun U => ⟨fun s hs => ?_⟩⟩
   apply Presheaf.section_ext X.sheaf U s 0
@@ -68,7 +68,7 @@ theorem isReducedOfStalkIsReduced [∀ x : X.carrier, _root_.IsReduced (X.preshe
   exact (hs.map _).eq_zero
 #align algebraic_geometry.is_reduced_of_stalk_is_reduced AlgebraicGeometry.isReducedOfStalkIsReduced
 
-instance stalk_isReduced_of_reduced [IsReduced X] (x : X.carrier) :
+instance isReduced_stalk_of_isReduced [IsReduced X] (x : X.carrier) :
     _root_.IsReduced (X.presheaf.stalk x) := by
   constructor
   rintro g ⟨n, e⟩
@@ -81,7 +81,7 @@ instance stalk_isReduced_of_reduced [IsReduced X] (x : X.carrier) :
   rw [comp_apply, e', map_zero]
 #align algebraic_geometry.stalk_is_reduced_of_reduced AlgebraicGeometry.stalk_isReduced_of_reduced
 
-theorem isReducedOfOpenImmersion {X Y : Scheme} (f : X ⟶ Y) [H : IsOpenImmersion f]
+theorem isReduced_of_isOpenImmersion {X Y : Scheme} (f : X ⟶ Y) [H : IsOpenImmersion f]
     [IsReduced Y] : IsReduced X := by
   constructor
   intro U
@@ -91,10 +91,10 @@ theorem isReducedOfOpenImmersion {X Y : Scheme} (f : X ⟶ Y) [H : IsOpenImmersi
   exact isReduced_of_injective (inv <| f.1.c.app (op <| H.base_open.isOpenMap.functor.obj U))
     (asIso <| f.1.c.app (op <| H.base_open.isOpenMap.functor.obj U) :
       Y.presheaf.obj _ ≅ _).symm.commRingCatIsoToRingEquiv.injective
-#align algebraic_geometry.is_reduced_of_open_immersion AlgebraicGeometry.isReducedOfOpenImmersion
+#align algebraic_geometry.is_reduced_of_open_immersion AlgebraicGeometry.isReduced_of_isOpenImmersion
 
 instance {R : CommRingCat.{u}} [H : _root_.IsReduced R] : IsReduced (Scheme.Spec.obj <| op R) := by
-  apply (config := { allowSynthFailures := true }) isReducedOfStalkIsReduced
+  apply (config := { allowSynthFailures := true }) isReduced_of_isReduced_stalk
   intro x; dsimp
   have : _root_.IsReduced (CommRingCat.of <| Localization.AtPrime (PrimeSpectrum.asIdeal x)) := by
     dsimp; infer_instance
@@ -112,11 +112,12 @@ theorem affine_isReduced_iff (R : CommRingCat) :
   exact isReduced_of_injective (toSpecΓ R) (asIso <| toSpecΓ R).commRingCatIsoToRingEquiv.injective
 #align algebraic_geometry.affine_is_reduced_iff AlgebraicGeometry.affine_isReduced_iff
 
-theorem isReducedOfIsAffineIsReduced [IsAffine X] [h : _root_.IsReduced (X.presheaf.obj (op ⊤))] :
+theorem isReduced_of_isAffine_isReduced [IsAffine X]
+    [h : _root_.IsReduced (X.presheaf.obj (op ⊤))] :
     IsReduced X :=
   haveI : IsReduced (Scheme.Spec.obj (op (Scheme.Γ.obj (op X)))) := by
     rw [affine_isReduced_iff]; exact h
-  isReducedOfOpenImmersion X.isoSpec.hom
+  isReduced_of_isOpenImmersion X.isoSpec.hom
 #align algebraic_geometry.is_reduced_of_is_affine_is_reduced AlgebraicGeometry.isReducedOfIsAffineIsReduced
 
 /-- To show that a statement `P` holds for all open subsets of all schemes, it suffices to show that
@@ -177,7 +178,7 @@ theorem eq_zero_of_basicOpen_eq_bot {X : Scheme} [hX : IsReduced X] {U : Opens X
       rw [← Set.image_univ, Set.preimage_image_eq _ hf.base_open.inj]
     refine ⟨_, _, e, rfl, ?_⟩
     rintro H hX s hs ⟨_, x, rfl⟩
-    haveI := isReducedOfOpenImmersion f
+    haveI := isReduced_of_isOpenImmersion f
     specialize H (f.1.c.app _ s) _ ⟨x, by rw [Opens.mem_mk, e]; trivial⟩
     · rw [← Scheme.preimage_basicOpen, hs]; ext1; simp [Opens.map]
     · erw [← PresheafedSpace.stalkMap_germ_apply f.1 ⟨_, _⟩ ⟨x, _⟩] at H
@@ -216,7 +217,7 @@ instance [h : IsIntegral X] : IsDomain (X.presheaf.obj (op ⊤)) :=
   @IsIntegral.component_integral _ _ _ (by
     simp only [Set.univ_nonempty, Opens.nonempty_coeSort, Opens.coe_top])
 
-instance (priority := 900) isReducedOfIsIntegral [IsIntegral X] : IsReduced X := by
+instance (priority := 900) isReduced_of_isIntegral [IsIntegral X] : IsReduced X := by
   constructor
   intro U
   rcases U.1.eq_empty_or_nonempty with h | h
@@ -228,7 +229,7 @@ instance (priority := 900) isReducedOfIsIntegral [IsIntegral X] : IsReduced X :=
     infer_instance
 #align algebraic_geometry.is_reduced_of_is_integral AlgebraicGeometry.isReducedOfIsIntegral
 
-instance is_irreducible_of_isIntegral [IsIntegral X] : IrreducibleSpace X.carrier := by
+instance irreducibleSpace_of_isIntegral [IsIntegral X] : IrreducibleSpace X.carrier := by
   by_contra H
   replace H : ¬IsPreirreducible (⊤ : Set X.carrier) := fun h =>
     H { toPreirreducibleSpace := ⟨h⟩
@@ -257,7 +258,7 @@ instance is_irreducible_of_isIntegral [IsIntegral X] : IrreducibleSpace X.carrie
       exact x.rec (by contradiction)
 #align algebraic_geometry.is_irreducible_of_is_integral AlgebraicGeometry.is_irreducible_of_isIntegral
 
-theorem isIntegralOfIsIrreducibleIsReduced [IsReduced X] [H : IrreducibleSpace X.carrier] :
+theorem isIntegral_of_irreducibleSpace_of_isReduced [IsReduced X] [H : IrreducibleSpace X.carrier] :
     IsIntegral X := by
   constructor; · infer_instance
   intro U hU
@@ -277,15 +278,15 @@ theorem isIntegralOfIsIrreducibleIsReduced [IsReduced X] [H : IrreducibleSpace X
     convert hx₁.mul hx₂
     exact e.symm
   exact NoZeroDivisors.to_isDomain _
-#align algebraic_geometry.is_integral_of_is_irreducible_is_reduced AlgebraicGeometry.isIntegralOfIsIrreducibleIsReduced
+#align algebraic_geometry.is_integral_of_is_irreducible_is_reduced AlgebraicGeometry.isIntegral_of_irreducibleSpace_of_isReduced
 
-theorem isIntegral_iff_is_irreducible_and_isReduced :
+theorem isIntegral_iff_irreducibleSpace_and_isReduced :
     IsIntegral X ↔ IrreducibleSpace X.carrier ∧ IsReduced X :=
   ⟨fun _ => ⟨inferInstance, inferInstance⟩, fun ⟨_, _⟩ =>
-    isIntegralOfIsIrreducibleIsReduced X⟩
-#align algebraic_geometry.is_integral_iff_is_irreducible_and_is_reduced AlgebraicGeometry.isIntegral_iff_is_irreducible_and_isReduced
+    isIntegral_of_irreducibleSpace_of_isReduced X⟩
+#align algebraic_geometry.is_integral_iff_is_irreducible_and_is_reduced AlgebraicGeometry.isIntegral_iff_irreducibleSpace_and_isReduced
 
-theorem isIntegralOfOpenImmersion {X Y : Scheme} (f : X ⟶ Y) [H : IsOpenImmersion f]
+theorem isIntegral_of_isOpenImmersion {X Y : Scheme} (f : X ⟶ Y) [H : IsOpenImmersion f]
     [IsIntegral Y] [Nonempty X.carrier] : IsIntegral X := by
   constructor; · infer_instance
   intro U hU
@@ -297,14 +298,14 @@ theorem isIntegralOfOpenImmersion {X Y : Scheme} (f : X ⟶ Y) [H : IsOpenImmers
     exact ⟨⟨_, _, hU.some.prop, rfl⟩⟩
   exact (asIso <| f.1.c.app (op <| H.base_open.isOpenMap.functor.obj U) :
     Y.presheaf.obj _ ≅ _).symm.commRingCatIsoToRingEquiv.toMulEquiv.isDomain _
-#align algebraic_geometry.is_integral_of_open_immersion AlgebraicGeometry.isIntegralOfOpenImmersion
+#align algebraic_geometry.is_integral_of_open_immersion AlgebraicGeometry.isIntegral_of_isOpenImmersion
 
 instance {R : CommRingCat} [H : IsDomain R] :
     IrreducibleSpace (Scheme.Spec.obj <| op R).carrier := by
   convert PrimeSpectrum.irreducibleSpace (R := R)
 
 instance {R : CommRingCat} [IsDomain R] : IsIntegral (Scheme.Spec.obj <| op R) :=
-  isIntegralOfIsIrreducibleIsReduced _
+  isIntegral_of_irreducibleSpace_of_isReduced _
 
 theorem affine_isIntegral_iff (R : CommRingCat) :
     IsIntegral (Scheme.Spec.obj <| op R) ↔ IsDomain R :=
@@ -312,12 +313,12 @@ theorem affine_isIntegral_iff (R : CommRingCat) :
     (asIso <| toSpecΓ R).commRingCatIsoToRingEquiv.toMulEquiv, fun _ => inferInstance⟩
 #align algebraic_geometry.affine_is_integral_iff AlgebraicGeometry.affine_isIntegral_iff
 
-theorem isIntegralOfIsAffineIsDomain [IsAffine X] [Nonempty X.carrier]
+theorem isIntegral_of_isAffine_of_isDomain [IsAffine X] [Nonempty X.carrier]
     [h : IsDomain (X.presheaf.obj (op ⊤))] : IsIntegral X :=
   haveI : IsIntegral (Scheme.Spec.obj (op (Scheme.Γ.obj (op X)))) := by
     rw [affine_isIntegral_iff]; exact h
-  isIntegralOfOpenImmersion X.isoSpec.hom
-#align algebraic_geometry.is_integral_of_is_affine_is_domain AlgebraicGeometry.isIntegralOfIsAffineIsDomain
+  isIntegral_of_isOpenImmersion X.isoSpec.hom
+#align algebraic_geometry.is_integral_of_is_affine_is_domain AlgebraicGeometry.isIntegral_of_isAffine_of_isDomain
 
 theorem map_injective_of_isIntegral [IsIntegral X] {U V : Opens X.carrier} (i : U ⟶ V)
     [H : Nonempty U] : Function.Injective (X.presheaf.map i.op) := by

--- a/Mathlib/AlgebraicGeometry/Properties.lean
+++ b/Mathlib/AlgebraicGeometry/Properties.lean
@@ -79,7 +79,7 @@ instance isReduced_stalk_of_isReduced [IsReduced X] (x : X.carrier) :
   replace e' := (IsNilpotent.mk _ _ e').eq_zero (R := X.presheaf.obj <| op V)
   erw [← ConcreteCategory.congr_hom (X.presheaf.germ_res iU ⟨x, hxV⟩) s]
   rw [comp_apply, e', map_zero]
-#align algebraic_geometry.stalk_is_reduced_of_reduced AlgebraicGeometry.stalk_isReduced_of_reduced
+#align algebraic_geometry.stalk_is_reduced_of_reduced AlgebraicGeometry.isReduced_stalk_of_isReduced
 
 theorem isReduced_of_isOpenImmersion {X Y : Scheme} (f : X ⟶ Y) [H : IsOpenImmersion f]
     [IsReduced Y] : IsReduced X := by
@@ -227,7 +227,7 @@ instance (priority := 900) isReduced_of_isIntegral [IsIntegral X] : IsReduced X 
     infer_instance
   · haveI : Nonempty U := by simpa
     infer_instance
-#align algebraic_geometry.is_reduced_of_is_integral AlgebraicGeometry.isReducedOfIsIntegral
+#align algebraic_geometry.is_reduced_of_is_integral AlgebraicGeometry.isReduced_of_isIntegral
 
 instance irreducibleSpace_of_isIntegral [IsIntegral X] : IrreducibleSpace X.carrier := by
   by_contra H

--- a/Mathlib/AlgebraicGeometry/Pullbacks.lean
+++ b/Mathlib/AlgebraicGeometry/Pullbacks.lean
@@ -502,7 +502,7 @@ instance : HasPullbacks Scheme :=
 instance isAffine_of_isAffine_isAffine_isAffine {X Y Z : Scheme}
     (f : X ⟶ Z) (g : Y ⟶ Z) [IsAffine X] [IsAffine Y] [IsAffine Z] :
     IsAffine (pullback f g) :=
-  isAffineOfIso
+  isAffine_of_isIso
     (pullback.map f g (Spec.map (Γ.map f.op).op) (Spec.map (Γ.map g.op).op)
         (ΓSpec.adjunction.unit.app X) (ΓSpec.adjunction.unit.app Y) (ΓSpec.adjunction.unit.app Z)
         (ΓSpec.adjunction.unit.naturality f) (ΓSpec.adjunction.unit.naturality g) ≫

--- a/Mathlib/AlgebraicGeometry/StructureSheaf.lean
+++ b/Mathlib/AlgebraicGeometry/StructureSheaf.lean
@@ -167,11 +167,11 @@ def sectionsSubring (U : (Opens (PrimeSpectrum.Top R))ᵒᵖ) :
   carrier := { f | (isLocallyFraction R).pred f }
   zero_mem' := by
     refine fun x => ⟨unop U, x.2, 𝟙 _, 0, 1, fun y => ⟨?_, ?_⟩⟩
-    · rw [← Ideal.ne_top_iff_one]; exact y.1.IsPrime.1
+    · rw [← Ideal.ne_top_iff_one]; exact y.1.isPrime.1
     · simp
   one_mem' := by
     refine fun x => ⟨unop U, x.2, 𝟙 _, 1, 1, fun y => ⟨?_, ?_⟩⟩
-    · rw [← Ideal.ne_top_iff_one]; exact y.1.IsPrime.1
+    · rw [← Ideal.ne_top_iff_one]; exact y.1.isPrime.1
     · simp
   add_mem' := by
     intro a b ha hb x
@@ -182,7 +182,7 @@ def sectionsSubring (U : (Opens (PrimeSpectrum.Top R))ᵒᵖ) :
     rcases wa (Opens.infLELeft _ _ y) with ⟨nma, wa⟩
     rcases wb (Opens.infLERight _ _ y) with ⟨nmb, wb⟩
     fconstructor
-    · intro H; cases y.1.IsPrime.mem_or_mem H <;> contradiction
+    · intro H; cases y.1.isPrime.mem_or_mem H <;> contradiction
     · simp only [add_mul, RingHom.map_add, Pi.add_apply, RingHom.map_mul]
       erw [← wa, ← wb]
       simp only [mul_assoc]
@@ -208,7 +208,7 @@ def sectionsSubring (U : (Opens (PrimeSpectrum.Top R))ᵒᵖ) :
     rcases wa (Opens.infLELeft _ _ y) with ⟨nma, wa⟩
     rcases wb (Opens.infLERight _ _ y) with ⟨nmb, wb⟩
     fconstructor
-    · intro H; cases y.1.IsPrime.mem_or_mem H <;> contradiction
+    · intro H; cases y.1.isPrime.mem_or_mem H <;> contradiction
     · simp only [Pi.mul_apply, RingHom.map_mul]
       erw [← wa, ← wb]
       simp only [mul_left_comm, mul_assoc, mul_comm]

--- a/Mathlib/RingTheory/DedekindDomain/Ideal.lean
+++ b/Mathlib/RingTheory/DedekindDomain/Ideal.lean
@@ -388,7 +388,7 @@ theorem exists_multiset_prod_cons_le_and_prod_not_le [IsDedekindDomain A] (hNF :
       rwa [Ne, ← Multiset.cons_erase hPZ', Multiset.prod_cons, Ideal.mul_eq_bot, not_or, ←
         this] at hprodZ
     -- By maximality of `P` and `M`, we have that `P ≤ M` implies `P = M`.
-    have hPM' := (P.IsPrime.isMaximal hP0).eq_of_le hM.ne_top hPM
+    have hPM' := (P.isPrime.isMaximal hP0).eq_of_le hM.ne_top hPM
     subst hPM'
     -- By minimality of `Z`, erasing `P` from `Z` is exactly what we need.
     refine ⟨Z.erase P, ?_, ?_⟩


### PR DESCRIPTION
`PrimeSpectrum.IsPrime` -> `PrimeSpectrum.isPrime`
`PrimeSpectrum.vanishingIdeal_univ` -> `PrimeSpectrum.vanishingIdeal_empty`
`isAffineAffineScheme` -> `isAffine_affineScheme`
`SpecIsAffine` -> `isAffine_Spec`
`isAffineOfIso` -> `isAffine_of_isIso`
`rangeIsAffineOpenOfOpenImmersion` -> `isAffineOpen_opensRange`
`topIsAffineOpen` -> `isAffineOpen_top`
`Scheme.affineCoverIsAffine` -> `Scheme.isAffine_affineCover`
`Scheme.affineBasisCoverIsAffine` -> `Scheme.isAffine_affineBasisCover`
`IsAffineOpen.fromSpec_range` -> `IsAffineOpen.range_fromSpec`
`IsAffineOpen.imageIsOpenImmersion` -> `IsAffineOpen.image_of_isOpenImmersion`
`Scheme.quasi_compact_of_affine` -> `Scheme.compactSpace_of_isAffine`
`IsAffineOpen.fromSpec_base_preimage` -> `IsAffineOpen.fromSpec_preimage_self`
`IsAffineOpen.fromSpec_map_basicOpen'` -> `IsAffineOpen.fromSpec_preimage_basicOpen'`
`IsAffineOpen.fromSpec_map_basicOpen` -> `IsAffineOpen.fromSpec_preimage_basicOpen`
`IsAffineOpen.opensFunctor_map_basicOpen` -> `IsAffineOpen.fromSpec_image_basicOpen`
`IsAffineOpen.basicOpenIsAffine` -> `IsAffineOpen.basicOpen`
`IsAffineOpen.mapRestrictBasicOpen` -> `IsAffineOpen.ιOpens_preimage`
`AffineTargetMorphismProperty.IsLocal.targetAffineLocallyIsLocal` -> `AffineTargetMorphismProperty.IsLocal.targetAffineLocally_isLocal`
`AffineTargetMorphismProperty.IsLocal.targetAffineLocallyPullbackFstOfRightOfStableUnderBaseChange` -> `AffineTargetMorphismProperty.IsLocal.targetAffineLocally_pullback_fst_of_right_of_stableUnderBaseChange`
`diagonalTargetAffineLocallyOfOpenCover` -> `diagonal_targetAffineLocally_of_openCover`
`AffineTargetMorphismProperty.diagonalOfTargetAffineLocally` -> `AffineTargetMorphismProperty.diagonal_of_targetAffineLocally`
`universallyIsLocalAtTarget` -> `universally_isLocalAtTarget`
`universallyIsLocalAtTargetOfMorphismRestrict` -> `universally_isLocalAtTarget_of_morphismRestrict`
`bot_isAffineOpen` -> `isAffineOpen_bot`
`isOpenImmersion_is_local_at_target` -> `isOpenImmersion_isLocalAtTarget`
`QuasiCompact.is_local_at_target` -> `QuasiCompact.isLocalAtTarget`
`QuasiSeparated.is_local_at_target` -> `QuasiSeparated.isLocalAtTarget`
`universallyClosed_is_local_at_target` -> `universallyClosed_isLocalAtTarget`
`isReducedOfStalkIsReduced` -> `isReduced_of_isReduced_stalk`
`stalk_isReduced_of_reduced` -> `isReduced_stalk_of_isReduced`
`isReducedOfOpenImmersion` -> `isReduced_of_isOpenImmersion`
`isReducedOfIsAffineIsReduced` -> `isReduced_of_isAffine_isReduced`
`isReducedOfIsIntegral` -> `isReduced_of_isIntegral`
`is_irreducible_of_isIntegral` -> `irreducibleSpace_of_isIntegral`
`isIntegralOfIsIrreducibleIsReduced` -> `isIntegral_of_irreducibleSpace_of_isReduced`
`isIntegral_iff_is_irreducible_and_isReduced` -> `isIntegral_iff_irreducibleSpace_and_isReduced`
`isIntegralOfOpenImmersion` -> `isIntegral_of_isOpenImmersion`
`isIntegralOfIsAffineIsDomain` -> `isIntegral_of_isAffine_of_isDomain`

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
