### PR TITLE
perf(RingTheory.OreLocalization): make data irreducible 

### DIFF
--- a/Mathlib/GroupTheory/MonoidLocalization.lean
+++ b/Mathlib/GroupTheory/MonoidLocalization.lean
@@ -2168,18 +2168,18 @@ variable (R) [CommMonoid R] (S : Submonoid R)
 /-- The morphism `numeratorHom` is a monoid localization map in the case of commutative `R`. -/
 protected def localizationMap : S.LocalizationMap R[S⁻¹] where
   toFun := numeratorHom
-  map_one' := rfl
+  map_one' := by with_unfolding_all rfl
   map_mul' r₁ r₂ := by simp
   map_units' := numerator_isUnit
   surj' z := by
     induction' z using OreLocalization.ind with r s
     use (r, s); dsimp
-    rw [numeratorHom_apply, numeratorHom_apply, OreLocalization.expand' r 1 s]
+    erw [numeratorHom_apply, numeratorHom_apply, OreLocalization.expand' r 1 s]
     simp only [mul_div_one, mul_one, Submonoid.smul_def, smul_eq_mul, mul_comm r]
   exists_of_eq r₁ r₂ := by
     dsimp
     intro h
-    rw [numeratorHom_apply, numeratorHom_apply, oreDiv_eq_iff] at h
+    erw [numeratorHom_apply, numeratorHom_apply, oreDiv_eq_iff] at h
     rcases h with ⟨u, v, h₁, h₂⟩
     dsimp at h₂
     rw [mul_one, mul_one] at h₂

--- a/Mathlib/RingTheory/OreLocalization/Basic.lean
+++ b/Mathlib/RingTheory/OreLocalization/Basic.lean
@@ -257,7 +257,8 @@ private def smul'' (r : R) (s : S) : X[S⁻¹] → X[S⁻¹] :=
     rw [mul_assoc (s₄' : R), h₃, ← mul_assoc]
 
 /-- The scalar multiplication on the Ore localization of monoids. -/
-@[to_additive "the vector addition on the Ore localization of additive monoids."]
+@[to_additive (attr := irreducible)
+  "the vector addition on the Ore localization of additive monoids."]
 protected def smul : R[S⁻¹] → X[S⁻¹] → X[S⁻¹] :=
   liftExpand smul'' fun r₁ r₂ s hs => by
     ext x
@@ -291,13 +292,13 @@ instance : Mul R[S⁻¹] :=
 
 @[to_additive]
 theorem oreDiv_smul_oreDiv {r₁ : R} {r₂ : X} {s₁ s₂ : S} :
-    (r₁ /ₒ s₁) • (r₂ /ₒ s₂) = oreNum r₁ s₂ • r₂ /ₒ (oreDenom r₁ s₂ * s₁) :=
-  rfl
+    (r₁ /ₒ s₁) • (r₂ /ₒ s₂) = oreNum r₁ s₂ • r₂ /ₒ (oreDenom r₁ s₂ * s₁) := by
+  with_unfolding_all rfl
 
 @[to_additive]
 theorem oreDiv_mul_oreDiv {r₁ : R} {r₂ : R} {s₁ s₂ : S} :
-    (r₁ /ₒ s₁) * (r₂ /ₒ s₂) = oreNum r₁ s₂ * r₂ /ₒ (oreDenom r₁ s₂ * s₁) :=
-  rfl
+    (r₁ /ₒ s₁) * (r₂ /ₒ s₂) = oreNum r₁ s₂ * r₂ /ₒ (oreDenom r₁ s₂ * s₁) := by
+  with_unfolding_all rfl
 #align ore_localization.ore_div_mul_ore_div OreLocalization.oreDiv_mul_oreDiv
 
 /-- A characterization lemma for the scalar multiplication on the Ore localization,
@@ -305,16 +306,16 @@ allowing for a choice of Ore numerator and Ore denominator. -/
 @[to_additive "A characterization lemma for the vector addition on the Ore localization,
 allowing for a choice of Ore minuend and Ore subtrahend."]
 theorem oreDiv_smul_char (r₁ : R) (r₂ : X) (s₁ s₂ : S) (r' : R) (s' : S) (huv : s' * r₁ = r' * s₂) :
-    (r₁ /ₒ s₁) • (r₂ /ₒ s₂) = r' • r₂ /ₒ (s' * s₁) :=
-  smul'_char r₁ r₂ s₁ s₂ s' r' huv
+    (r₁ /ₒ s₁) • (r₂ /ₒ s₂) = r' • r₂ /ₒ (s' * s₁) := by
+  with_unfolding_all exact smul'_char r₁ r₂ s₁ s₂ s' r' huv
 
 /-- A characterization lemma for the multiplication on the Ore localization, allowing for a choice
 of Ore numerator and Ore denominator. -/
 @[to_additive "A characterization lemma for the addition on the Ore localization,
 allowing for a choice of Ore minuend and Ore subtrahend."]
 theorem oreDiv_mul_char (r₁ r₂ : R) (s₁ s₂ : S) (r' : R) (s' : S) (huv : s' * r₁ = r' * s₂) :
-    r₁ /ₒ s₁ * (r₂ /ₒ s₂) = r' * r₂ /ₒ (s' * s₁) :=
-  smul'_char r₁ r₂ s₁ s₂ s' r' huv
+    r₁ /ₒ s₁ * (r₂ /ₒ s₂) = r' * r₂ /ₒ (s' * s₁) := by
+  with_unfolding_all exact smul'_char r₁ r₂ s₁ s₂ s' r' huv
 #align ore_localization.ore_div_mul_char OreLocalization.oreDiv_mul_char
 
 /-- Another characterization lemma for the scalar multiplication on the Ore localizaion delivering
@@ -334,13 +335,16 @@ def oreDivMulChar' (r₁ r₂ : R) (s₁ s₂ : S) :
   ⟨oreNum r₁ s₂, oreDenom r₁ s₂, ore_eq r₁ s₂, oreDiv_mul_oreDiv⟩
 #align ore_localization.ore_div_mul_char' OreLocalization.oreDivMulChar'
 
+@[irreducible]
+private def one : R[S⁻¹] := 1 /ₒ 1
+
 @[to_additive AddOreLocalization.instZeroAddOreLocalization]
 instance : One R[S⁻¹] :=
-  ⟨1 /ₒ 1⟩
+  ⟨one⟩
 
 @[to_additive]
-protected theorem one_def : (1 : R[S⁻¹]) = 1 /ₒ 1 :=
-  rfl
+protected theorem one_def : (1 : R[S⁻¹]) = 1 /ₒ 1 := by
+  with_unfolding_all rfl
 #align ore_localization.one_def OreLocalization.one_def
 
 @[to_additive]
@@ -449,17 +453,20 @@ theorem mul_div_one {p r : R} {s : S} : (p /ₒ s) * (r /ₒ 1) = (p * r) /ₒ s
   simp [oreDiv_mul_char p r s 1 p 1 (by simp)]
 #align ore_localization.div_one_mul OreLocalization.mul_div_one
 
-@[to_additive]
-instance : SMul R X[S⁻¹] where
-  smul r := liftExpand (fun x s ↦ oreNum r s • x /ₒ (oreDenom r s)) (by
+@[to_additive (attr := irreducible)]
+private def smulAux (r : R) : OreLocalization S X → OreLocalization S X :=
+  liftExpand (fun x s ↦ oreNum r s • x /ₒ (oreDenom r s)) (by
     intro x r' s h
     dsimp only
     rw [← mul_one (oreDenom r s), ← oreDiv_smul_oreDiv, ← mul_one (oreDenom _ _),
       ← oreDiv_smul_oreDiv, ← OreLocalization.expand])
 
 @[to_additive]
-theorem smul_oreDiv (r : R) (x : X) (s : S) : r • (x /ₒ s) = oreNum r s • x /ₒ (oreDenom r s) :=
-  rfl
+instance : SMul R X[S⁻¹] := ⟨smulAux⟩
+
+@[to_additive]
+theorem smul_oreDiv (r : R) (x : X) (s : S) : r • (x /ₒ s) = oreNum r s • x /ₒ (oreDenom r s) := by
+  with_unfolding_all rfl
 
 @[to_additive (attr := simp)]
 theorem oreDiv_one_smul (r : R) (x : X[S⁻¹]) : (r /ₒ (1 : S)) • x = r • x := by
@@ -492,7 +499,7 @@ fraction `r /ₒ 1`. -/
   mapping `r : R` to the difference `r -ₒ 0`."]
 def numeratorHom : R →* R[S⁻¹] where
   toFun r := r /ₒ 1
-  map_one' := rfl
+  map_one' := by with_unfolding_all rfl
   map_mul' _ _ := mul_div_one.symm
 #align ore_localization.numerator_hom OreLocalization.numeratorHom
 
@@ -637,6 +644,7 @@ private def add' (r₂ : X) (s₂ : S) : X[S⁻¹] → X[S⁻¹] :=
     rw [this, hc, mul_assoc]
 
 /-- The addition on the Ore localization. -/
+@[irreducible]
 private def add : X[S⁻¹] → X[S⁻¹] → X[S⁻¹] := fun x =>
   Quotient.lift (fun rs : X × S => add' rs.1 rs.2 x)
     (by
@@ -661,14 +669,14 @@ instance : Add X[S⁻¹] :=
 
 theorem oreDiv_add_oreDiv {r r' : X} {s s' : S} :
     r /ₒ s + r' /ₒ s' =
-      (oreDenom (s : R) s' • r + oreNum (s : R) s' • r') /ₒ (oreDenom (s : R) s' * s) :=
-  rfl
+      (oreDenom (s : R) s' • r + oreNum (s : R) s' • r') /ₒ (oreDenom (s : R) s' * s) := by
+  with_unfolding_all rfl
 #align ore_localization.ore_div_add_ore_div OreLocalization.oreDiv_add_oreDiv
 
 theorem oreDiv_add_char' {r r' : X} (s s' : S) (rb : R) (sb : R)
     (h : sb * s = rb * s') (h' : sb * s ∈ S) :
-    r /ₒ s + r' /ₒ s' = (sb • r + rb • r') /ₒ ⟨sb * s, h'⟩ :=
-  add''_char r s r' s' rb sb h h'
+    r /ₒ s + r' /ₒ s' = (sb • r + rb • r') /ₒ ⟨sb * s, h'⟩ := by
+  with_unfolding_all exact add''_char r s r' s' rb sb h h'
 
 /-- A characterization of the addition on the Ore localizaion, allowing for arbitrary Ore
 numerator and Ore denominator. -/
@@ -703,13 +711,14 @@ protected theorem add_assoc (x y z : X[S⁻¹]) : x + y + z = x + (y + z) := by
   · rw [OreLocalization.expand r₃ s₃ rc (hc.symm ▸ (sc * (sa * s₁)).2)]; congr; ext; exact hc
 #align ore_localization.add_assoc OreLocalization.add_assoc
 
+@[irreducible]
 private def zero : X[S⁻¹] := 0 /ₒ 1
 
 instance : Zero X[S⁻¹] :=
   ⟨zero⟩
 
-protected theorem zero_def : (0 : X[S⁻¹]) = 0 /ₒ 1 :=
-  rfl
+protected theorem zero_def : (0 : X[S⁻¹]) = 0 /ₒ 1 := by
+  with_unfolding_all rfl
 #align ore_localization.zero_def OreLocalization.zero_def
 
 @[simp]
@@ -783,6 +792,7 @@ variable {R : Type*} [Monoid R] {S : Submonoid R} [OreSet S]
 variable {X : Type*} [AddGroup X] [DistribMulAction R X]
 
 /-- Negation on the Ore localization is defined via negation on the numerator. -/
+@[irreducible]
 protected def neg : X[S⁻¹] → X[S⁻¹] :=
   liftExpand (fun (r : X) (s : S) => -r /ₒ s) fun r t s ht => by
     -- Porting note(#12129): additional beta reduction needed
@@ -794,8 +804,8 @@ instance instNegOreLocalization : Neg X[S⁻¹] :=
   ⟨OreLocalization.neg⟩
 
 @[simp]
-protected theorem neg_def (r : X) (s : S) : -(r /ₒ s) = -r /ₒ s :=
-  rfl
+protected theorem neg_def (r : X) (s : S) : -(r /ₒ s) = -r /ₒ s := by
+  with_unfolding_all rfl
 #align ore_localization.neg_def OreLocalization.neg_def
 
 protected theorem add_left_neg (x : X[S⁻¹]) : -x + x = 0 := by

--- a/Mathlib/RingTheory/OreLocalization/Ring.lean
+++ b/Mathlib/RingTheory/OreLocalization/Ring.lean
@@ -211,6 +211,7 @@ variable [NoZeroDivisors R]
 
 /-- The inversion of Ore fractions for a ring without zero divisors, satisying `0⁻¹ = 0` and
 `(r /ₒ r')⁻¹ = r' /ₒ r` for `r ≠ 0`. -/
+@[irreducible]
 protected def inv : R[R⁰⁻¹] → R[R⁰⁻¹] :=
   liftExpand
     (fun r s =>
@@ -234,8 +235,8 @@ instance inv' : Inv R[R⁰⁻¹] :=
 protected theorem inv_def {r : R} {s : R⁰} :
     (r /ₒ s)⁻¹ =
       if hr : r = (0 : R) then (0 : R[R⁰⁻¹])
-      else s /ₒ ⟨r, fun _ => eq_zero_of_ne_zero_of_mul_right_eq_zero hr⟩ :=
-  rfl
+      else s /ₒ ⟨r, fun _ => eq_zero_of_ne_zero_of_mul_right_eq_zero hr⟩ := by
+  with_unfolding_all rfl
 #align ore_localization.inv_def OreLocalization.inv_def
 
 protected theorem mul_inv_cancel (x : R[R⁰⁻¹]) (h : x ≠ 0) : x * x⁻¹ = 1 := by
@@ -246,7 +247,7 @@ protected theorem mul_inv_cancel (x : R[R⁰⁻¹]) (h : x ≠ 0) : x * x⁻¹ =
     apply h
     simp [hr]
   · simp only [hr, ↓reduceDite]
-    apply OreLocalization.mul_inv ⟨r, _⟩
+    with_unfolding_all apply OreLocalization.mul_inv ⟨r, _⟩
 #align ore_localization.mul_inv_cancel OreLocalization.mul_inv_cancel
 
 protected theorem inv_zero : (0 : R[R⁰⁻¹])⁻¹ = 0 := by


### PR DESCRIPTION
We generally do not want to unfold operations passing through `Quotient` if we can avoid it for performance reasons.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
