### PR TITLE
[Merged by Bors] - feat(RingTheory): localization and finiteness

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -413,6 +413,7 @@ import Mathlib.Algebra.Module.LinearMap.Basic
 import Mathlib.Algebra.Module.LinearMap.End
 import Mathlib.Algebra.Module.LinearMap.Polynomial
 import Mathlib.Algebra.Module.LocalizedModule
+import Mathlib.Algebra.Module.LocalizedModuleIntegers
 import Mathlib.Algebra.Module.MinimalAxioms
 import Mathlib.Algebra.Module.Opposites
 import Mathlib.Algebra.Module.PID
@@ -3614,6 +3615,7 @@ import Mathlib.RingTheory.Localization.Away.Basic
 import Mathlib.RingTheory.Localization.BaseChange
 import Mathlib.RingTheory.Localization.Basic
 import Mathlib.RingTheory.Localization.Cardinality
+import Mathlib.RingTheory.Localization.Finiteness
 import Mathlib.RingTheory.Localization.FractionRing
 import Mathlib.RingTheory.Localization.Ideal
 import Mathlib.RingTheory.Localization.Integer

--- a/Mathlib/Algebra/Module/LocalizedModuleIntegers.lean
+++ b/Mathlib/Algebra/Module/LocalizedModuleIntegers.lean
@@ -31,14 +31,10 @@ open Function
 
 namespace IsLocalizedModule
 
-section
-
 /-- Given `x : M'`, `M'` a localization of `M` via `f`, `IsInteger f x` iff `x` is in the image of
 the localization map `f`. -/
 def IsInteger (x : M') : Prop :=
   x ∈ LinearMap.range f
-
-end
 
 lemma isInteger_zero : IsInteger f (0 : M') :=
   Submodule.zero_mem _

--- a/Mathlib/Algebra/Module/LocalizedModuleIntegers.lean
+++ b/Mathlib/Algebra/Module/LocalizedModuleIntegers.lean
@@ -1,0 +1,144 @@
+/-
+Copyright (c) 2024 Christian Merten. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Christian Merten
+-/
+import Mathlib.Algebra.Module.LocalizedModule
+import Mathlib.Algebra.Module.Submodule.Pointwise
+
+/-!
+
+# Integer elements of a localized module
+
+This is a mirror of the corresponding notion for localizations of rings.
+
+## Main definitions
+
+ * `IsLocalizedModule.IsInteger` is a predicate stating that `m : M'` is in the image of `M`
+
+## Implementation details
+
+After `IsLocalizedModule` and `IsLocalization` are unified, the two `IsInteger` predicates
+can be unified.
+
+-/
+
+
+variable {R : Type*} [CommSemiring R] {S : Submonoid R} {M : Type*} [AddCommMonoid M]
+  [Module R M] {M' : Type*} [AddCommMonoid M'] [Module R M'] (f : M →ₗ[R] M')
+
+open Function
+
+namespace IsLocalizedModule
+
+section
+
+/-- Given `x : M'`, `M'` a localization of `M` via `f`, `IsInteger f x` iff `x` is in the image of
+the localization map `f`. -/
+def IsInteger (x : M') : Prop :=
+  x ∈ LinearMap.range f
+
+end
+
+lemma isInteger_zero : IsInteger f (0 : M') :=
+  Submodule.zero_mem _
+
+theorem isInteger_add {x y : M'} (hx : IsInteger f x) (hy : IsInteger f y) : IsInteger f (x + y) :=
+  Submodule.add_mem _ hx hy
+
+theorem isInteger_smul {a : R} {x : M'} (hx : IsInteger f x) : IsInteger f (a • x) := by
+  rcases hx with ⟨x', hx⟩
+  use a • x'
+  rw [← hx, LinearMapClass.map_smul]
+
+variable (S)
+variable [IsLocalizedModule S f]
+
+/-- Each element `x : M'` has an `S`-multiple which is an integer. -/
+theorem exists_integer_multiple (x : M') : ∃ a : S, IsInteger f (a.val • x) :=
+  let ⟨⟨Num, denom⟩, h⟩ := IsLocalizedModule.surj S f x
+  ⟨denom, Set.mem_range.mpr ⟨Num, h.symm⟩⟩
+
+/-- We can clear the denominators of a `Finset`-indexed family of fractions. -/
+theorem exist_integer_multiples {ι : Type*} (s : Finset ι) (g : ι → M') :
+    ∃ b : S, ∀ i ∈ s, IsInteger f (b.val • g i) := by
+  classical
+  choose sec hsec using (fun i ↦ IsLocalizedModule.surj S f (g i))
+  refine ⟨∏ i ∈ s, (sec i).2, fun i hi => ⟨?_, ?_⟩⟩
+  · exact (∏ j ∈ s.erase i, (sec j).2) • (sec i).1
+  · simp only [LinearMap.map_smul_of_tower, Submonoid.coe_finset_prod]
+    rw [← hsec, ← mul_smul, Submonoid.smul_def]
+    congr
+    simp only [Submonoid.coe_mul, Submonoid.coe_finset_prod, mul_comm]
+    rw [← Finset.prod_insert (f := fun i ↦ ((sec i).snd).val) (s.not_mem_erase i),
+      Finset.insert_erase hi]
+
+/-- We can clear the denominators of a finite indexed family of fractions. -/
+theorem exist_integer_multiples_of_finite {ι : Type*} [Finite ι] (g : ι → M') :
+    ∃ b : S, ∀ i, IsInteger f ((b : R) • g i) := by
+  cases nonempty_fintype ι
+  obtain ⟨b, hb⟩ := exist_integer_multiples S f Finset.univ g
+  exact ⟨b, fun i => hb i (Finset.mem_univ _)⟩
+
+/-- We can clear the denominators of a finite set of fractions. -/
+theorem exist_integer_multiples_of_finset (s : Finset M') :
+    ∃ b : S, ∀ a ∈ s, IsInteger f ((b : R) • a) :=
+  exist_integer_multiples S f s id
+
+/-- A choice of a common multiple of the denominators of a `Finset`-indexed family of fractions. -/
+noncomputable def commonDenom {ι : Type*} (s : Finset ι) (g : ι → M') : S :=
+  (exist_integer_multiples S f s g).choose
+
+/-- The numerator of a fraction after clearing the denominators
+of a `Finset`-indexed family of fractions. -/
+noncomputable def integerMultiple {ι : Type*} (s : Finset ι) (g : ι → M') (i : s) : M :=
+  ((exist_integer_multiples S f s g).choose_spec i i.prop).choose
+
+@[simp]
+theorem map_integerMultiple {ι : Type*} (s : Finset ι) (g : ι → M') (i : s) :
+    f (integerMultiple S f s g i) = commonDenom S f s g • g i :=
+  ((exist_integer_multiples S f s g).choose_spec _ i.prop).choose_spec
+
+/-- A choice of a common multiple of the denominators of a finite set of fractions. -/
+noncomputable def commonDenomOfFinset (s : Finset M') : S :=
+  commonDenom S f s id
+
+/-- The finset of numerators after clearing the denominators of a finite set of fractions. -/
+noncomputable def finsetIntegerMultiple [DecidableEq M] (s : Finset M') : Finset M :=
+  s.attach.image fun t => integerMultiple S f s id t
+
+open Pointwise
+
+theorem finsetIntegerMultiple_image [DecidableEq M] (s : Finset M') :
+    f '' finsetIntegerMultiple S f s = commonDenomOfFinset S f s • (s : Set M') := by
+  delta finsetIntegerMultiple commonDenom
+  rw [Finset.coe_image]
+  ext
+  constructor
+  · rintro ⟨_, ⟨x, -, rfl⟩, rfl⟩
+    rw [map_integerMultiple]
+    exact Set.mem_image_of_mem _ x.prop
+  · rintro ⟨x, hx, rfl⟩
+    exact ⟨_, ⟨⟨x, hx⟩, s.mem_attach _, rfl⟩, map_integerMultiple S f s id _⟩
+
+theorem smul_mem_finsetIntegerMultiple_span [DecidableEq M] (x : M) (s : Finset M')
+    (hx : f x ∈ Submodule.span R s) :
+    ∃ (m : S), m • x ∈ Submodule.span R (IsLocalizedModule.finsetIntegerMultiple S f s) := by
+  let y : S := IsLocalizedModule.commonDenomOfFinset S f s
+  have hx₁ : (y : R) • (s : Set M') = f '' _ :=
+    (IsLocalizedModule.finsetIntegerMultiple_image S f s).symm
+  apply congrArg (Submodule.span R) at hx₁
+  rw [Submodule.span_smul] at hx₁
+  replace hx : _ ∈ y • Submodule.span R (s : Set M') := Set.smul_mem_smul_set hx
+  erw [hx₁, ← f.map_smul, ← Submodule.map_span f] at hx
+  obtain ⟨x', hx', hx''⟩ := hx
+  obtain ⟨a, ha⟩ := (IsLocalizedModule.eq_iff_exists S f).mp hx''
+  use a * y
+  convert (Submodule.span R
+    (IsLocalizedModule.finsetIntegerMultiple S f s : Set M)).smul_mem
+      a hx' using 1
+  convert ha.symm using 1
+  simp only [Submonoid.coe_subtype, Submonoid.smul_def]
+  erw [← smul_smul]
+
+end IsLocalizedModule

--- a/Mathlib/RingTheory/LocalProperties.lean
+++ b/Mathlib/RingTheory/LocalProperties.lean
@@ -479,13 +479,15 @@ theorem IsLocalization.smul_mem_finsetIntegerMultiple_span [Algebra R S] [Algebr
   · exact Algebra.smul_def _ _
 #align is_localization.smul_mem_finset_integer_multiple_span IsLocalization.smul_mem_finsetIntegerMultiple_span
 
-/-- If `S` is an `R' = M⁻¹R` algebra, and `x ∈ span R' s`,
-then `t • x ∈ span R s` for some `t : M`. -/
-theorem multiple_mem_span_of_mem_localization_span [Algebra R' S] [Algebra R S]
-    [IsScalarTower R R' S] [IsLocalization M R'] (s : Set S) (x : S)
-    (hx : x ∈ Submodule.span R' s) : ∃ t : M, t • x ∈ Submodule.span R s := by
+/-- If `M` is an `R' = S⁻¹R` module, and `x ∈ span R' s`,
+then `t • x ∈ span R s` for some `t : S`. -/
+theorem multiple_mem_span_of_mem_localization_span
+    {N : Type*} [AddCommMonoid N] [Module R N] [Module R' N]
+    [IsScalarTower R R' N] [IsLocalization M R'] (s : Set N) (x : N)
+    (hx : x ∈ Submodule.span R' s) : ∃ (t : M), t • x ∈ Submodule.span R s := by
+  classical
   obtain ⟨s', hss', hs'⟩ := Submodule.mem_span_finite_of_mem_span hx
-  rsuffices ⟨t, ht⟩ : ∃ t : M, t • x ∈ Submodule.span R (s' : Set S)
+  rsuffices ⟨t, ht⟩ : ∃ t : M, t • x ∈ Submodule.span R (s' : Set N)
   · exact ⟨t, Submodule.span_mono hss' ht⟩
   clear hx hss' s
   induction s' using Finset.induction_on generalizing x
@@ -495,12 +497,12 @@ theorem multiple_mem_span_of_mem_localization_span [Algebra R' S] [Algebra R S]
     Submodule.mem_span_insert] at hs' ⊢
   rcases hs' with ⟨y, z, hz, rfl⟩
   rcases IsLocalization.surj M y with ⟨⟨y', s'⟩, e⟩
-  replace e : _ * a = _ * a := (congr_arg (fun x => algebraMap R' S x * a) e : _)
-  simp_rw [RingHom.map_mul, ← IsScalarTower.algebraMap_apply, mul_comm (algebraMap R' S y),
-    mul_assoc, ← Algebra.smul_def] at e
+  apply congrArg (fun x ↦ x • a) at e
+  simp only [algebraMap_smul] at e
   rcases hs _ hz with ⟨t, ht⟩
-  refine ⟨t * s', t * y', _, (Submodule.span R (s : Set S)).smul_mem s' ht, ?_⟩
-  rw [smul_add, ← smul_smul, mul_comm, ← smul_smul, ← smul_smul, ← e]
+  refine ⟨t * s', t * y', _, (Submodule.span R (s : Set N)).smul_mem s' ht, ?_⟩
+  rw [smul_add, ← smul_smul, mul_comm, ← smul_smul, ← smul_smul, ← e, mul_comm, ← Algebra.smul_def]
+  simp
   rfl
 #align multiple_mem_span_of_mem_localization_span multiple_mem_span_of_mem_localization_span
 

--- a/Mathlib/RingTheory/Localization/Finiteness.lean
+++ b/Mathlib/RingTheory/Localization/Finiteness.lean
@@ -1,0 +1,107 @@
+/-
+Copyright (c) 2024 Christian Merten. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Christian Merten
+-/
+import Mathlib.Algebra.Module.LocalizedModuleIntegers
+import Mathlib.RingTheory.LocalProperties
+
+/-!
+
+# Finiteness properties under localization
+
+In this file we establish behaviour of `Module.Finite` under localizations.
+
+## Main results
+
+- `Module.Finite.of_isLocalizedModule`: If `M` is a finite `R`-module,
+  `S` is a submonoid of `R`, `Rₚ` is the localization of `R` at `S`
+  and `Mₚ` is the localization of `M` at `S`, then `Mₚ` is a finite
+  `Rₚ`-module.
+- `Module.Finite.of_localizationSpan_finite`: If `M` is an `R`-module
+  and `{ r }` is a finite set generating the unit ideal such that
+  `Mᵣ` is a finite `Rᵣ`-module for each `r`, then `M` is a finite `R`-module.
+
+-/
+
+universe u v w t
+
+open Classical
+
+namespace Module.Finite
+
+section
+
+variable {R : Type u} [CommSemiring R] (S : Submonoid R)
+variable {Rₚ : Type v} [CommSemiring Rₚ] [Algebra R Rₚ] [IsLocalization S Rₚ]
+variable {M : Type w} [AddCommMonoid M] [Module R M]
+variable {Mₚ : Type t} [AddCommMonoid Mₚ] [Module R Mₚ] [Module Rₚ Mₚ] [IsScalarTower R Rₚ Mₚ]
+variable (f : M →ₗ[R] Mₚ) [IsLocalizedModule S f]
+
+lemma of_isLocalizedModule [Module.Finite R M] : Module.Finite Rₚ Mₚ := by
+  obtain ⟨T, hT⟩ := ‹Module.Finite R M›
+  use T.image f
+  rw [eq_top_iff]
+  rintro x -
+  obtain ⟨⟨y, m⟩, (hyx : IsLocalizedModule.mk' f y m = x)⟩ :=
+    IsLocalizedModule.mk'_surjective S f x
+  have hy : y ∈ Submodule.span R T := by rw [hT]; trivial
+  have : f y ∈ Submodule.map f (Submodule.span R T) := Submodule.mem_map_of_mem hy
+  rw [Submodule.map_span] at this
+  have H : Submodule.span R (f '' T) ≤
+      (Submodule.span Rₚ (f '' T)).restrictScalars R := by
+    rw [Submodule.span_le]; exact Submodule.subset_span
+  convert (Submodule.span Rₚ (f '' T)).smul_mem
+    (IsLocalization.mk' Rₚ (1 : R) m) (H this) using 1
+  · rw [← hyx, ← IsLocalizedModule.mk'_one S, IsLocalizedModule.mk'_smul_mk']
+    simp
+  · simp
+
+end
+
+variable {R : Type u} [CommRing R] (S : Submonoid R) {M : Type w} [AddCommMonoid M] [Module R M]
+
+/--
+If there exists a finite set `{ r }` of `R` such that `Mᵣ` is `Rᵣ`-finite for each `r`,
+then `M` is a finite `R`-module.
+
+General version for any modules `Mᵣ` and rings `Rᵣ` satisfying the correct universal properties.
+See `Module.Finite.of_localizationSpan_finite` for the specialized version.
+-/
+theorem of_localizationSpan_finite' (t : Finset R) (ht : Ideal.span (t : Set R) = ⊤)
+    {Mₚ : ∀ (_ : t), Type*} [∀ (g : t), AddCommMonoid (Mₚ g)] [∀ (g : t), Module R (Mₚ g)]
+    {Rₚ : ∀ (_ : t), Type u} [∀ (g : t), CommRing (Rₚ g)] [∀ (g : t), Algebra R (Rₚ g)]
+    [∀ (g : t), IsLocalization.Away g.val (Rₚ g)]
+    [∀ (g : t), Module (Rₚ g) (Mₚ g)] [∀ (g : t), IsScalarTower R (Rₚ g) (Mₚ g)]
+    (f : ∀ (g : t), M →ₗ[R] Mₚ g) [∀ (g : t), IsLocalizedModule (Submonoid.powers g.val) (f g)]
+    (H : ∀ (g : t), Module.Finite (Rₚ g) (Mₚ g)) :
+    Module.Finite R M := by
+  constructor
+  choose s₁ s₂ using (fun g ↦ (H g).1)
+  let sf := fun x : t ↦
+    IsLocalizedModule.finsetIntegerMultiple (Submonoid.powers x.val) (f x) (s₁ x)
+  use t.attach.biUnion sf
+  rw [Submodule.span_attach_biUnion, eq_top_iff]
+  rintro x -
+  refine Submodule.mem_of_span_eq_top_of_smul_pow_mem _ (t : Set R) ht _ (fun r ↦ ?_)
+  set S : Submonoid R := Submonoid.powers r.val
+  obtain ⟨⟨_, n₁, rfl⟩, hn₁⟩ := multiple_mem_span_of_mem_localization_span S (Rₚ r)
+    (s₁ r : Set (Mₚ r)) (IsLocalizedModule.mk' (f r) x (1 : S)) (by rw [s₂ r]; trivial)
+  rw [Submonoid.smul_def, ← IsLocalizedModule.mk'_smul, IsLocalizedModule.mk'_one] at hn₁
+  obtain ⟨⟨_, n₂, rfl⟩, hn₂⟩ := IsLocalizedModule.smul_mem_finsetIntegerMultiple_span
+    S (f r) _ (s₁ r) hn₁
+  rw [Submonoid.smul_def] at hn₂
+  use n₂ + n₁
+  apply le_iSup (fun x : t ↦ Submodule.span R (sf x : Set M)) r
+  rw [pow_add, mul_smul]
+  exact hn₂
+
+/-- If there exists a finite set `{ r }` of `R` such that `Mᵣ` is `Rᵣ`-finite for each `r`,
+then `M` is a finite `R`-module. -/
+theorem of_localizationSpan_finite (t : Finset R) (ht : Ideal.span (t : Set R) = ⊤)
+    (H : ∀ (g : t), Module.Finite (Localization.Away g.val)
+      (LocalizedModule (Submonoid.powers g.val) M)) :
+    Module.Finite R M :=
+  let f (g : t) : M →ₗ[R] LocalizedModule (Submonoid.powers g.val) M :=
+    LocalizedModule.mkLinearMap (Submonoid.powers g.val) M
+  of_localizationSpan_finite' t ht f H

--- a/Mathlib/RingTheory/Localization/Finiteness.lean
+++ b/Mathlib/RingTheory/Localization/Finiteness.lean
@@ -67,6 +67,8 @@ then `M` is a finite `R`-module.
 
 General version for any modules `Mᵣ` and rings `Rᵣ` satisfying the correct universal properties.
 See `Module.Finite.of_localizationSpan_finite` for the specialized version.
+
+See `of_localizationSpan'` for a version without the finite set assumption.
 -/
 theorem of_localizationSpan_finite' (t : Finset R) (ht : Ideal.span (t : Set R) = ⊤)
     {Mₚ : ∀ (_ : t), Type*} [∀ (g : t), AddCommMonoid (Mₚ g)] [∀ (g : t), Module R (Mₚ g)]
@@ -96,8 +98,36 @@ theorem of_localizationSpan_finite' (t : Finset R) (ht : Ideal.span (t : Set R) 
   rw [pow_add, mul_smul]
   exact hn₂
 
-/-- If there exists a finite set `{ r }` of `R` such that `Mᵣ` is `Rᵣ`-finite for each `r`,
-then `M` is a finite `R`-module. -/
+/--
+If there exists a set `{ r }` of `R` such that `Mᵣ` is `Rᵣ`-finite for each `r`,
+then `M` is a finite `R`-module.
+
+General version for any modules `Mᵣ` and rings `Rᵣ` satisfying the correct universal properties.
+See `Module.Finite.of_localizationSpan_finite` for the specialized version.
+-/
+theorem of_localizationSpan' (t : Set R) (ht : Ideal.span t = ⊤)
+    {Mₚ : ∀ (_ : t), Type*} [∀ (g : t), AddCommMonoid (Mₚ g)] [∀ (g : t), Module R (Mₚ g)]
+    {Rₚ : ∀ (_ : t), Type u} [∀ (g : t), CommRing (Rₚ g)] [∀ (g : t), Algebra R (Rₚ g)]
+    [h₁ : ∀ (g : t), IsLocalization.Away g.val (Rₚ g)]
+    [∀ (g : t), Module (Rₚ g) (Mₚ g)] [∀ (g : t), IsScalarTower R (Rₚ g) (Mₚ g)]
+    (f : ∀ (g : t), M →ₗ[R] Mₚ g) [h₂ : ∀ (g : t), IsLocalizedModule (Submonoid.powers g.val) (f g)]
+    (H : ∀ (g : t), Module.Finite (Rₚ g) (Mₚ g)) :
+    Module.Finite R M := by
+  rw [Ideal.span_eq_top_iff_finite] at ht
+  obtain ⟨t', hc, ht'⟩ := ht
+  have (g : t') : IsLocalization.Away g.val (Rₚ ⟨g.val, hc g.property⟩) :=
+    h₁ ⟨g.val, hc g.property⟩
+  have (g : t') : IsLocalizedModule (Submonoid.powers g.val)
+    ((fun g ↦ f ⟨g.val, hc g.property⟩) g) := h₂ ⟨g.val, hc g.property⟩
+  apply of_localizationSpan_finite' t' ht' (fun g ↦ f ⟨g.val, hc g.property⟩)
+    (fun g ↦ H ⟨g.val, hc g.property⟩)
+
+/--
+If there exists a finite set `{ r }` of `R` such that `Mᵣ` is `Rᵣ`-finite for each `r`,
+then `M` is a finite `R`-module.
+
+See `of_localizationSpan` for a version without the finite set assumption.
+-/
 theorem of_localizationSpan_finite (t : Finset R) (ht : Ideal.span (t : Set R) = ⊤)
     (H : ∀ (g : t), Module.Finite (Localization.Away g.val)
       (LocalizedModule (Submonoid.powers g.val) M)) :
@@ -105,3 +135,13 @@ theorem of_localizationSpan_finite (t : Finset R) (ht : Ideal.span (t : Set R) =
   let f (g : t) : M →ₗ[R] LocalizedModule (Submonoid.powers g.val) M :=
     LocalizedModule.mkLinearMap (Submonoid.powers g.val) M
   of_localizationSpan_finite' t ht f H
+
+/-- If there exists a set `{ r }` of `R` such that `Mᵣ` is `Rᵣ`-finite for each `r`,
+then `M` is a finite `R`-module. -/
+theorem of_localizationSpan (t : Set R) (ht : Ideal.span t = ⊤)
+    (H : ∀ (g : t), Module.Finite (Localization.Away g.val)
+      (LocalizedModule (Submonoid.powers g.val) M)) :
+    Module.Finite R M :=
+  let f (g : t) : M →ₗ[R] LocalizedModule (Submonoid.powers g.val) M :=
+    LocalizedModule.mkLinearMap (Submonoid.powers g.val) M
+  of_localizationSpan' t ht f H


### PR DESCRIPTION
We show that `Module.Finite` is preserved under localizations and that if a module is finite after localizing at a spanning set of elements of the ring, it is finite.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

The `LocalizedModuleIntegers` file is mostly a copy of [IsLocalization.IsInteger](https://leanprover-community.github.io/mathlib4_docs/Mathlib/RingTheory/Localization/Integer.html#IsLocalization.IsInteger).

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
