### PR TITLE
[Merged by Bors] - chore: Fix unicode issues in references.bib

### DIFF
--- a/Mathlib/Analysis/Analytic/Inverse.lean
+++ b/Mathlib/Analysis/Analytic/Inverse.lean
@@ -353,7 +353,7 @@ analytic function. Another option would be to compute explicitly its terms (with
 coefficients) to obtain an explicit geometric bound, but this would be very painful.
 
 Instead, we will use the above intuition, but in a slightly different form, with finite sums and an
-induction. I learnt this trick in [pöschel2017siegelsternberg]. Let
+induction. I learnt this trick in [poeschel2017siegelsternberg]. Let
 $S_n = \sum_{k=1}^n Q_k a^k$ (where `a` is a positive real parameter to be chosen suitably small).
 The above computation but with finite sums shows that
 

--- a/docs/references.bib
+++ b/docs/references.bib
@@ -2673,7 +2673,7 @@
   primaryclass  = {math.NT}
 }
 
-@Misc{            pöschel2017siegelsternberg,
+@Misc{            poeschel2017siegelsternberg,
   title         = {On the Siegel-Sternberg linearization theorem},
   author        = {Jürgen Pöschel},
   year          = {2017},

--- a/docs/references.bib
+++ b/docs/references.bib
@@ -1506,7 +1506,7 @@
 
 @InBook{          Graham1983,
   author        = "Graham, R. L.",
-  editor        = "Bachem, Achim and Korte, Bernhard and Gr{\"o}tschel,
+  editor        = "Bachem, Achim and Korte, Bernhard and Grötschel,
                   Martin",
   title         = "Applications of the FKG Inequality and Its Relatives",
   booktitle     = "Mathematical Programming The State of the Art: Bonn 1982",

--- a/docs/references.bib
+++ b/docs/references.bib
@@ -2663,6 +2663,15 @@
   isbn          = {9783034801539}
 }
 
+@Misc{            poeschel2017siegelsternberg,
+  title         = {On the Siegel-Sternberg linearization theorem},
+  author        = {Jürgen Pöschel},
+  year          = {2017},
+  eprint        = {1702.03691},
+  archiveprefix = {arXiv},
+  primaryclass  = {math.DS}
+}
+
 @Misc{            ponton2020chebyshev,
   title         = {Roots of {C}hebyshev polynomials: a purely algebraic
                   approach},
@@ -2671,15 +2680,6 @@
   eprint        = {2008.03575},
   archiveprefix = {arXiv},
   primaryclass  = {math.NT}
-}
-
-@Misc{            poeschel2017siegelsternberg,
-  title         = {On the Siegel-Sternberg linearization theorem},
-  author        = {Jürgen Pöschel},
-  year          = {2017},
-  eprint        = {1702.03691},
-  archiveprefix = {arXiv},
-  primaryclass  = {math.DS}
 }
 
 @InCollection{    ribenboim1971,

--- a/docs/references.bib
+++ b/docs/references.bib
@@ -1506,8 +1506,7 @@
 
 @InBook{          Graham1983,
   author        = "Graham, R. L.",
-  editor        = "Bachem, Achim and Korte, Bernhard and Grötschel,
-                  Martin",
+  editor        = "Bachem, Achim and Korte, Bernhard and Grötschel, Martin",
   title         = "Applications of the FKG Inequality and Its Relatives",
   booktitle     = "Mathematical Programming The State of the Art: Bonn 1982",
   year          = "1983",


### PR DESCRIPTION
This PR fixes two Unicode issues in references.bib, as per the discussion on [Zulip](https://leanprover.zulipchat.com/#narrow/stream/113488-general/topic/Contribution.20to.20doc-gen4.3F/near/446313567), with a view towards running a [bibtex parser](https://github.com/dupuisf/BibtexQuery) written in Lean on it:

- I removed one instance of an `ö` character in a citation key, which is anyway problematic for some implementations of bibtex (see e.g. [this thread](https://tex.stackexchange.com/questions/359215/utf8-character-in-citation-keys)). According to grep, this was only referenced in one file in mathlib, which I changed accordingly.
- The one other problematic entry for my bibtex parser is one where there is an `\"o` inside a string delimited using quotation marks. I have an upcoming fix for this in my parser, but using UTF-8 here is anyway cleaner.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
