### PR TITLE
[Merged by Bors] - chore: move `lint_style` executable to the `scripts` directory

### DIFF
--- a/lakefile.lean
+++ b/lakefile.lean
@@ -70,7 +70,7 @@ lean_exe shake where
 
 /-- `lake exe lint_style` runs text-based style linters. -/
 lean_exe lint_style where
-  root := `Mathlib.Tactic.Linter.TextBased
+  srcDir := "scripts"
 
 /--
 `lake exe pole` queries the Mathlib speedcenter for build times for the current commit,

--- a/scripts/lint_style.lean
+++ b/scripts/lint_style.lean
@@ -1,0 +1,45 @@
+/-
+Copyright (c) 2024 Michael Rothgang. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Michael Rothgang
+-/
+
+import Mathlib.Tactic.Linter.TextBased
+import Cli.Basic
+
+/-!
+# Text-based style linters
+
+This files defines the `lint_style` executable which runs all text-based style linters.
+The linters themselves are defined in `Mathlib.Tactic.Linter.TextBased`.
+-/
+
+open Cli
+
+/-- Implementation of the `lint_style` command line program. -/
+def lintStyleCli (args : Cli.Parsed) : IO UInt32 := do
+  let errorStyle := match (args.hasFlag "github", args.hasFlag "update") with
+    | (true, _) => ErrorFormat.github
+    | (false, true) => ErrorFormat.exceptionsFile
+    | (false, false) => ErrorFormat.humanReadable
+  let mut numberErrorFiles : UInt32 := 0
+  for s in ["Archive.lean", "Counterexamples.lean", "Mathlib.lean"] do
+    let n ← lintAllFiles (System.mkFilePath [s]) errorStyle
+    numberErrorFiles := numberErrorFiles + n
+  return numberErrorFiles
+
+/-- Setting up command line options and help text for `lake exe lint_style`. -/
+-- so far, no help options or so: perhaps that is fine?
+def lint_style : Cmd := `[Cli|
+  lint_style VIA lintStyleCli; ["0.0.1"]
+  "Run text-based style linters on every Lean file in Mathlib/, Archive/ and Counterexamples/.
+  Print errors about any unexpected style errors to standard output."
+
+  FLAGS:
+    github;     "Print errors in a format suitable for github problem matchers\n\
+                 otherwise, produce human-readable output"
+    update;     "Print errors solely for the style exceptions file"
+]
+
+/-- The entry point to the `lake exe lint_style` command. -/
+def main (args : List String) : IO UInt32 := do lint_style.validate args


### PR DESCRIPTION
Otherwise, importing `Mathlib.Tactic` makes defining own executables impossible, as the `main` function in `Linter.TextBased` would collide with any other main function. Move the code for the lint_style executable to scripts (which arguably might be a better place anyway); we leave the text-based linters in Tactic/Linter.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
