### PR TITLE
[Merged by Bors] - feat(lint-style): rewrite the 'broad imports' linters in Lean

### DIFF
--- a/Mathlib/Tactic/Linter/TextBased.lean
+++ b/Mathlib/Tactic/Linter/TextBased.lean
@@ -22,6 +22,15 @@ further linters will be ported in subsequent PRs.
 
 open Lean Elab System
 
+/-- Different kinds of "broad imports" that are linted against. -/
+inductive BroadImports
+  /-- Importing the entire "Mathlib.Tactic" folder -/
+  | TacticFolder
+  /-- Importing any module in `Lake`, unless carefully measured
+  This has caused unexpected regressions in the past. -/
+  | Lake
+deriving BEq
+
 /-- Possible errors that text-based linters can report. -/
 -- We collect these in one inductive type to centralise error reporting.
 inductive StyleError where
@@ -33,11 +42,14 @@ inductive StyleError where
   /-- The bare string "Adaptation note" (or variants thereof): instead, the
   #adaptation_note command should be used. -/
   | adaptationNote
+  /-- Lint against "too broad" imports, such as `Mathlib.Tactic` or any module in `Lake`
+  (unless carefully measured) -/
+  | broadImport (module : BroadImports)
   /-- The current file was too large: this error contains the current number of lines
   as well as a size limit (slightly larger). On future runs, this linter will allow this file
   to grow up to this limit. -/
   | fileTooLong (number_lines : ℕ) (new_size_limit : ℕ) : StyleError
-  deriving BEq
+deriving BEq
 
 /-- How to format style errors -/
 inductive ErrorFormat
@@ -58,6 +70,11 @@ def StyleError.errorMessage (err : StyleError) (style : ErrorFormat) : String :=
   | StyleError.authors =>
     "Authors line should look like: 'Authors: Jean Dupont, Иван Иванович Иванов'"
   | StyleError.adaptationNote => "Found the string \"Adaptation note:\", please use the #adaptation_note command instead"
+  | StyleError.broadImport BroadImports.TacticFolder => "Files in mathlib cannot import the whole tactic folder"
+  | StyleError.broadImport BroadImports.Lake =>
+      "In the past, importing 'Lake' in mathlib has led to dramatic slow-downs of the linter (see \
+      e.g. mathlib4#13779). Please consider carefully if this import is useful and make sure to \
+      benchmark it. If this is fine, feel free to allow this linter."
   | StyleError.fileTooLong current_size size_limit =>
     match style with
     | ErrorFormat.github =>
@@ -73,6 +90,7 @@ def StyleError.errorCode (err : StyleError) : String := match err with
   | StyleError.copyright _ => "ERR_COP"
   | StyleError.authors => "ERR_AUT"
   | StyleError.adaptationNote => "ERR_ADN"
+  | StyleError.broadImport _ => "ERR_IMP"
   | StyleError.fileTooLong _ _ => "ERR_NUM_LIN"
 
 /-- Context for a style error: the actual error, the line number in the file we're reading
@@ -80,7 +98,7 @@ and the path to the file. -/
 structure ErrorContext where
   /-- The underlying `StyleError`-/
   error : StyleError
-  /-- The line number of the error -/
+  /-- The line number of the error (1-based) -/
   lineNumber : ℕ
   /-- The path to the file which was linted -/
   path : FilePath
@@ -138,6 +156,12 @@ def parse?_errorContext (line : String) : Option ErrorContext := Id.run do
         | "ERR_COP" => some (StyleError.copyright "")
         | "ERR_AUT" => some (StyleError.authors)
         | "ERR_ADN" => some (StyleError.adaptationNote)
+        | "ERR_IMP" =>
+          -- XXX tweak exceptions messages to ease parsing?
+          if (error_message.get! 0).containsSubstr "tactic" then
+            some (StyleError.broadImport BroadImports.TacticFolder)
+          else
+            some (StyleError.broadImport BroadImports.Lake)
         | "ERR_NUM_LIN" =>
           -- Parse the error message in the script. `none` indicates invalid input.
           match (error_message.get? 0, error_message.get? 3) with
@@ -229,6 +253,34 @@ def adaptationNoteLinter : TextbasedLinter := fun lines ↦ Id.run do
     if line.containsSubstr "daptation note" then
       errors := errors.push (StyleError.adaptationNote, lineNumber)
     lineNumber := lineNumber + 1
+  return errors
+
+/-- Lint a collection of input strings if one of them contains an unnecessarily broad import. -/
+def broadImportsLinter : TextbasedLinter := fun lines ↦ Id.run do
+  let mut errors := Array.mkEmpty 0
+  -- All import statements must be placed "at the beginning" of the file:
+  -- we can have any number of blank lines, imports and single or multi-line comments.
+  -- Doc comments, however, are not allowed: there is no item they could document.
+  let mut inDocComment : Bool := False
+  let mut lineNumber := 1
+  for line in lines do
+    if inDocComment then
+      if line.endsWith "-/" then
+        inDocComment := False
+    else
+      -- If `line` is just a single-line comment (starts with "--"), we just continue.
+      if line.startsWith "/-" then
+        inDocComment := True
+      else if let some (rest) := line.dropPrefix? "import " then
+          -- If there is any in-line or beginning doc comment on that line, trim that.
+          -- Small hack: just split the string on space, "/" and "-":
+          -- none of these occur in module names, so this is safe.
+          if let some name := ((toString rest).split (" /-".contains ·)).head? then
+            if name == "Mathlib.Tactic" then
+              errors := errors.push (StyleError.broadImport BroadImports.TacticFolder, lineNumber)
+            else if name == "Lake" || name.startsWith "Lake." then
+              errors := errors.push (StyleError.broadImport BroadImports.Lake, lineNumber)
+      lineNumber := lineNumber + 1
   return errors
 
 /-- Whether a collection of lines consists *only* of imports, blank lines and single-line comments.

--- a/Mathlib/Tactic/Linter/TextBased.lean
+++ b/Mathlib/Tactic/Linter/TextBased.lean
@@ -30,6 +30,9 @@ inductive StyleError where
   | copyright (context : Option String)
   /-- Malformed authors line in the copyright header -/
   | authors
+  /-- The bare string "Adaptation note" (or variants thereof): instead, the
+  #adaptation_note command should be used. -/
+  | adaptationNote
   /-- The current file was too large: this error contains the current number of lines
   as well as a size limit (slightly larger). On future runs, this linter will allow this file
   to grow up to this limit. -/
@@ -51,9 +54,10 @@ inductive ErrorFormat
 /-- Create the underlying error message for a given `StyleError`. -/
 def StyleError.errorMessage (err : StyleError) (style : ErrorFormat) : String := match err with
   | StyleError.copyright (some context) => s!"Malformed or missing copyright header: {context}"
-  | StyleError.copyright none => s!"Malformed or missing copyright header"
+  | StyleError.copyright none => "Malformed or missing copyright header"
   | StyleError.authors =>
     "Authors line should look like: 'Authors: Jean Dupont, Иван Иванович Иванов'"
+  | StyleError.adaptationNote => "Found the string \"Adaptation note:\", please use the #adaptation_note command instead"
   | StyleError.fileTooLong current_size size_limit =>
     match style with
     | ErrorFormat.github =>
@@ -68,6 +72,7 @@ def StyleError.errorMessage (err : StyleError) (style : ErrorFormat) : String :=
 def StyleError.errorCode (err : StyleError) : String := match err with
   | StyleError.copyright _ => "ERR_COP"
   | StyleError.authors => "ERR_AUT"
+  | StyleError.adaptationNote => "ERR_ADN"
   | StyleError.fileTooLong _ _ => "ERR_NUM_LIN"
 
 /-- Context for a style error: the actual error, the line number in the file we're reading
@@ -132,6 +137,7 @@ def parse?_errorContext (line : String) : Option ErrorContext := Id.run do
         -- NB: keep this in sync with `normalise` above!
         | "ERR_COP" => some (StyleError.copyright "")
         | "ERR_AUT" => some (StyleError.authors)
+        | "ERR_ADN" => some (StyleError.adaptationNote)
         | "ERR_NUM_LIN" =>
           -- Parse the error message in the script. `none` indicates invalid input.
           match (error_message.get? 0, error_message.get? 3) with
@@ -214,6 +220,17 @@ def copyrightHeaderLinter : TextbasedLinter := fun lines ↦ Id.run do
         output := output.push (StyleError.authors, 4)
   return output
 
+/-- Lint on any occurrences of the string "Adaptation note:" or variants thereof. -/
+def adaptationNoteLinter : TextbasedLinter := fun lines ↦ Id.run do
+  let mut errors := Array.mkEmpty 0
+  let mut lineNumber := 1
+  for line in lines do
+    -- We make this shorter to catch "Adaptation note", "adaptation note" and a missing colon.
+    if line.containsSubstr "daptation note" then
+      errors := errors.push (StyleError.adaptationNote, lineNumber)
+    lineNumber := lineNumber + 1
+  return errors
+
 /-- Whether a collection of lines consists *only* of imports, blank lines and single-line comments.
 In practice, this means it's an imports-only file and exempt from almost all linting. -/
 def isImportsOnlyFile (lines : Array String) : Bool :=
@@ -240,7 +257,9 @@ def checkFileLength (lines : Array String) (existing_limit : Option ℕ) : Optio
 end
 
 /-- All text-based linters registered in this file. -/
-def allLinters : Array TextbasedLinter := #[copyrightHeaderLinter]
+def allLinters : Array TextbasedLinter := #[
+    copyrightHeaderLinter, adaptationNoteLinter
+  ]
 
 /-- Read a file, apply all text-based linters and print the formatted errors.
 `sizeLimit` is any pre-existing limit on this file's size.

--- a/scripts/lint-style.py
+++ b/scripts/lint-style.py
@@ -66,10 +66,8 @@ with SCRIPTS_DIR.joinpath("style-exceptions.txt").open(encoding="utf-8") as f:
             exceptions += [(ERR_MOD, path, None)]
         elif errno == "ERR_LIN":
             exceptions += [(ERR_LIN, path, None)]
-        elif errno == "ERR_OPT":
-            exceptions += [(ERR_OPT, path, None)]
         elif errno == "ERR_ADN":
-            exceptions += [(ERR_ADN, path, None)]
+            pass # maintained by the Lean style linter now
         elif errno == "ERR_TAC":
             exceptions += [(ERR_TAC, path, None)]
         elif errno == "ERR_TAC2":

--- a/scripts/lint-style.py
+++ b/scripts/lint-style.py
@@ -51,7 +51,6 @@ ERR_CLN = 16 # line starts with a colon
 ERR_IND = 17 # second line not correctly indented
 ERR_ARR = 18 # space after "←"
 ERR_NSP = 20 # non-terminal simp
-ERR_ADN = 25 # the string "Adaptation note"
 
 exceptions = []
 
@@ -331,14 +330,6 @@ def left_arrow_check(lines, path):
         newlines.append((line_nr, new_line))
     return errors, newlines
 
-def adaptation_note_check(lines, path):
-    errors = []
-    for line_nr, line in lines:
-        # We make this shorter to catch "Adaptation note", "adaptation note" and a missing colon.
-        if "daptation note" in line:
-            errors += [(ERR_ADN, line_nr, path)]
-    return errors, lines
-
 def output_message(path, line_nr, code, msg):
     if len(exceptions) == 0:
         # we are generating a new exceptions file
@@ -387,8 +378,6 @@ def format_errors(errors):
             output_message(path, line_nr, "ERR_ARR", "Missing space after '←'.")
         if errno == ERR_NSP:
             output_message(path, line_nr, "ERR_NSP", "Non-terminal simp. Replace with `simp?` and use the suggested output")
-        if errno == ERR_ADN:
-            output_message(path, line_nr, "ERR_ADN", 'Found the string "Adaptation note:", please use the #adaptation_note command instead')
 
 def lint(path, fix=False):
     global new_exceptions
@@ -403,7 +392,6 @@ def lint(path, fix=False):
                             long_lines_check,
                             isolated_by_dot_semicolon_check,
                             left_arrow_check,
-                            adaptation_note_check,
                             nonterminal_simp_check]:
             errs, newlines = error_check(newlines, path)
             format_errors(errs)

--- a/scripts/lint-style.py
+++ b/scripts/lint-style.py
@@ -39,8 +39,6 @@ import shutil
 
 ERR_MOD = 2 # module docstring
 ERR_LIN = 3 # line length
-ERR_TAC = 9 # imported Mathlib.Tactic
-ERR_TAC2 = 10 # imported Lake in Mathlib
 ERR_IBY = 11 # isolated by
 ERR_IWH = 22 # isolated where
 ERR_DOT = 12 # isolated or low focusing dot
@@ -67,11 +65,7 @@ with SCRIPTS_DIR.joinpath("style-exceptions.txt").open(encoding="utf-8") as f:
         elif errno == "ERR_LIN":
             exceptions += [(ERR_LIN, path, None)]
         elif errno == "ERR_ADN":
-            pass # maintained by the Lean style linter now
-        elif errno == "ERR_TAC":
-            exceptions += [(ERR_TAC, path, None)]
-        elif errno == "ERR_TAC2":
-            exceptions += [(ERR_TAC2, path, None)]
+            pass # maintained by the Lean style Linter now
         elif errno == "ERR_NUM_LIN":
             pass # maintained by the Lean style linter now
         else:
@@ -352,10 +346,6 @@ def format_errors(errors):
             output_message(path, line_nr, "ERR_MOD", "Module docstring missing, or too late")
         if errno == ERR_LIN:
             output_message(path, line_nr, "ERR_LIN", "Line has more than 100 characters")
-        if errno == ERR_TAC:
-            output_message(path, line_nr, "ERR_TAC", "Files in mathlib cannot import the whole tactic folder")
-        if errno == ERR_TAC2:
-            output_message(path, line_nr, "ERR_TAC2", "In the past, importing 'Lake' in mathlib has led to dramatic slow-downs of the linter (see e.g. mathlib4#13779). Please consider carefully if this import is useful and make sure to benchmark it. If this is fine, feel free to allow this linter.")
         if errno == ERR_IBY:
             output_message(path, line_nr, "ERR_IBY", "Line is an isolated 'by'")
         if errno == ERR_IWH:

--- a/scripts/nolints-style.txt
+++ b/scripts/nolints-style.txt
@@ -15,3 +15,17 @@ Mathlib/Tactic/Linter.lean : line 4 : ERR_COP : Malformed or missing copyright h
 Archive/Sensitivity.lean : line 2 : ERR_COP : Malformed or missing copyright header: Copyright line is malformed
 Archive/Sensitivity.lean : line 3 : ERR_COP : Malformed or missing copyright header: Second line should be "Released under Apache 2.0 license as described in the file LICENSE."
 Archive/Sensitivity.lean : line 4 : ERR_COP : Malformed or missing copyright header: The third line should describe the file's main authors
+
+-- The linter for the string "adaptation note" fires in the implementation of the linter,
+-- and in the implementation of the #adaptation_note tactic: this is as expected.
+Mathlib/Tactic/AdaptationNote.lean : line 9 : ERR_ADN : Found the string "Adaptation note:", please use the #adaptation_note command instead
+Mathlib/Tactic/AdaptationNote.lean : line 12 : ERR_ADN : Found the string "Adaptation note:", please use the #adaptation_note command instead
+Mathlib/Tactic/AdaptationNote.lean : line 21 : ERR_ADN : Found the string "Adaptation note:", please use the #adaptation_note command instead
+Mathlib/Tactic/AdaptationNote.lean : line 27 : ERR_ADN : Found the string "Adaptation note:", please use the #adaptation_note command instead
+Mathlib/Tactic/AdaptationNote.lean : line 39 : ERR_ADN : Found the string "Adaptation note:", please use the #adaptation_note command instead
+Mathlib/Tactic/AdaptationNote.lean : line 52 : ERR_ADN : Found the string "Adaptation note:", please use the #adaptation_note command instead
+Mathlib/Tactic/Linter/TextBased.lean : line 33 : ERR_ADN : Found the string "Adaptation note:", please use the #adaptation_note command instead
+Mathlib/Tactic/Linter/TextBased.lean : line 60 : ERR_ADN : Found the string "Adaptation note:", please use the #adaptation_note command instead
+Mathlib/Tactic/Linter/TextBased.lean : line 222 : ERR_ADN : Found the string "Adaptation note:", please use the #adaptation_note command instead
+Mathlib/Tactic/Linter/TextBased.lean : line 227 : ERR_ADN : Found the string "Adaptation note:", please use the #adaptation_note command instead
+Mathlib/Tactic/Linter/TextBased.lean : line 228 : ERR_ADN : Found the string "Adaptation note:", please use the #adaptation_note command instead


### PR DESCRIPTION
This time, the error codes are intentionally changed, as the old ones feel actively misleading.

---

- [x] depends on: #14058 for simplicity (a minor merge conflict in changing lint-style)

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
