### PR TITLE
[Merged by Bors] - feat: if the body constrains universes, make it explicit in the signature.

### DIFF
--- a/Mathlib/Algebra/Category/ModuleCat/ChangeOfRings.lean
+++ b/Mathlib/Algebra/Category/ModuleCat/ChangeOfRings.lean
@@ -50,7 +50,7 @@ open CategoryTheory Limits
 
 namespace ModuleCat
 
-universe v u₁ u₂ u₃
+universe v u₁ u₂ u₃ w
 
 namespace RestrictScalars
 
@@ -619,11 +619,11 @@ def restrictCoextendScalarsAdj {R : Type u₁} {S : Type u₂} [Ring R] [Ring S]
 #align category_theory.Module.restrict_coextend_scalars_adj ModuleCat.restrictCoextendScalarsAdj
 
 instance {R : Type u₁} {S : Type u₂} [Ring R] [Ring S] (f : R →+* S) :
-    (restrictScalars f).IsLeftAdjoint  :=
+    (restrictScalars.{max u₂ w} f).IsLeftAdjoint  :=
   (restrictCoextendScalarsAdj f).isLeftAdjoint
 
 instance {R : Type u₁} {S : Type u₂} [Ring R] [Ring S] (f : R →+* S) :
-    (coextendScalars f).IsRightAdjoint  :=
+    (coextendScalars.{u₁, u₂, max u₂ w} f).IsRightAdjoint  :=
   (restrictCoextendScalarsAdj f).isRightAdjoint
 
 namespace ExtendRestrictScalarsAdj
@@ -858,11 +858,11 @@ def extendRestrictScalarsAdj {R : Type u₁} {S : Type u₂} [CommRing R] [CommR
 #align category_theory.Module.extend_restrict_scalars_adj ModuleCat.extendRestrictScalarsAdj
 
 instance {R : Type u₁} {S : Type u₂} [CommRing R] [CommRing S] (f : R →+* S) :
-    (extendScalars f).IsLeftAdjoint :=
+    (extendScalars.{u₁, u₂, max u₂ w} f).IsLeftAdjoint :=
   (extendRestrictScalarsAdj f).isLeftAdjoint
 
 instance {R : Type u₁} {S : Type u₂} [CommRing R] [CommRing S] (f : R →+* S) :
-    (restrictScalars f).IsRightAdjoint :=
+    (restrictScalars.{max u₂ w, u₁, u₂} f).IsRightAdjoint :=
   (extendRestrictScalarsAdj f).isRightAdjoint
 
 noncomputable instance preservesLimitRestrictScalars

--- a/Mathlib/CategoryTheory/Category/Grpd.lean
+++ b/Mathlib/CategoryTheory/Category/Grpd.lean
@@ -135,7 +135,7 @@ def piLimitFanIsLimit ⦃J : Type u⦄ (F : J → Grpd.{u, u}) : Limits.IsLimit 
 set_option linter.uppercaseLean3 false in
 #align category_theory.Groupoid.pi_limit_fan_is_limit CategoryTheory.Grpd.piLimitFanIsLimit
 
-instance has_pi : Limits.HasProducts Grpd.{u, u} :=
+instance has_pi : Limits.HasProducts.{u} Grpd.{u, u} :=
   Limits.hasProducts_of_limit_fans (by apply piLimitFan) (by apply piLimitFanIsLimit)
 set_option linter.uppercaseLean3 false in
 #align category_theory.Groupoid.has_pi CategoryTheory.Grpd.has_pi

--- a/Mathlib/CategoryTheory/EffectiveEpi/Preserves.lean
+++ b/Mathlib/CategoryTheory/EffectiveEpi/Preserves.lean
@@ -103,11 +103,11 @@ class PreservesEffectiveEpiFamilies (F : C ⥤ D) : Prop where
   A functor preserves effective epimorphic families if it maps effective epimorphic families to
   effective epimorphic families.
   -/
-  preserves : ∀ {α : Type*} {B : C} (X : α → C) (π : (a : α) → (X a ⟶ B)) [EffectiveEpiFamily X π],
+  preserves : ∀ {α : Type u} {B : C} (X : α → C) (π : (a : α) → (X a ⟶ B)) [EffectiveEpiFamily X π],
     EffectiveEpiFamily (fun a ↦ F.obj (X a)) (fun a  ↦ F.map (π a))
 
-instance map_effectiveEpiFamily (F : C ⥤ D) [F.PreservesEffectiveEpiFamilies]
-    {α : Type*} {B : C} (X : α → C) (π : (a : α) → (X a ⟶ B)) [EffectiveEpiFamily X π] :
+instance map_effectiveEpiFamily (F : C ⥤ D) [PreservesEffectiveEpiFamilies.{u} F]
+    {α : Type u} {B : C} (X : α → C) (π : (a : α) → (X a ⟶ B)) [EffectiveEpiFamily X π] :
     EffectiveEpiFamily (fun a ↦ F.obj (X a)) (fun a  ↦ F.map (π a)) :=
   PreservesEffectiveEpiFamilies.preserves X π
 
@@ -128,7 +128,8 @@ instance map_finite_effectiveEpiFamily (F : C ⥤ D) [F.PreservesFiniteEffective
     EffectiveEpiFamily (fun a ↦ F.obj (X a)) (fun a  ↦ F.map (π a)) :=
   PreservesFiniteEffectiveEpiFamilies.preserves X π
 
-instance (F : C ⥤ D) [PreservesEffectiveEpiFamilies F] : PreservesFiniteEffectiveEpiFamilies F where
+instance (F : C ⥤ D) [PreservesEffectiveEpiFamilies.{0} F] :
+    PreservesFiniteEffectiveEpiFamilies F where
   preserves _ _ := inferInstance
 
 instance (F : C ⥤ D) [PreservesFiniteEffectiveEpiFamilies F] : PreservesEffectiveEpis F where
@@ -191,7 +192,8 @@ lemma finite_effectiveEpiFamily_of_map (F : C ⥤ D) [ReflectsFiniteEffectiveEpi
     EffectiveEpiFamily X π :=
   ReflectsFiniteEffectiveEpiFamilies.reflects X π h
 
-instance (F : C ⥤ D) [ReflectsEffectiveEpiFamilies F] : ReflectsFiniteEffectiveEpiFamilies F where
+instance (F : C ⥤ D) [ReflectsEffectiveEpiFamilies.{0} F] :
+    ReflectsFiniteEffectiveEpiFamilies F where
   reflects _ _ h := by
     have := F.effectiveEpiFamily_of_map _ _ h
     infer_instance

--- a/Mathlib/CategoryTheory/EffectiveEpi/Preserves.lean
+++ b/Mathlib/CategoryTheory/EffectiveEpi/Preserves.lean
@@ -106,7 +106,7 @@ class PreservesEffectiveEpiFamilies (F : C ⥤ D) : Prop where
   preserves : ∀ {α : Type u} {B : C} (X : α → C) (π : (a : α) → (X a ⟶ B)) [EffectiveEpiFamily X π],
     EffectiveEpiFamily (fun a ↦ F.obj (X a)) (fun a  ↦ F.map (π a))
 
-instance map_effectiveEpiFamily (F : C ⥤ D) [PreservesEffectiveEpiFamilies.{u} F]
+instance map_effectiveEpiFamily (F : C ⥤ D) [PreservesEffectiveEpiFamilies.{_, _, u} F]
     {α : Type u} {B : C} (X : α → C) (π : (a : α) → (X a ⟶ B)) [EffectiveEpiFamily X π] :
     EffectiveEpiFamily (fun a ↦ F.obj (X a)) (fun a  ↦ F.map (π a)) :=
   PreservesEffectiveEpiFamilies.preserves X π
@@ -128,7 +128,7 @@ instance map_finite_effectiveEpiFamily (F : C ⥤ D) [F.PreservesFiniteEffective
     EffectiveEpiFamily (fun a ↦ F.obj (X a)) (fun a  ↦ F.map (π a)) :=
   PreservesFiniteEffectiveEpiFamilies.preserves X π
 
-instance (F : C ⥤ D) [PreservesEffectiveEpiFamilies.{0} F] :
+instance (F : C ⥤ D) [PreservesEffectiveEpiFamilies.{_, _, 0} F] :
     PreservesFiniteEffectiveEpiFamilies F where
   preserves _ _ := inferInstance
 
@@ -192,7 +192,7 @@ lemma finite_effectiveEpiFamily_of_map (F : C ⥤ D) [ReflectsFiniteEffectiveEpi
     EffectiveEpiFamily X π :=
   ReflectsFiniteEffectiveEpiFamilies.reflects X π h
 
-instance (F : C ⥤ D) [ReflectsEffectiveEpiFamilies.{0} F] :
+instance (F : C ⥤ D) [ReflectsEffectiveEpiFamilies.{_, _, 0} F] :
     ReflectsFiniteEffectiveEpiFamilies F where
   reflects _ _ h := by
     have := F.effectiveEpiFamily_of_map _ _ h

--- a/Mathlib/CategoryTheory/EssentiallySmall.lean
+++ b/Mathlib/CategoryTheory/EssentiallySmall.lean
@@ -96,7 +96,7 @@ class LocallySmall (C : Type u) [Category.{v} C] : Prop where
   hom_small : ∀ X Y : C, Small.{w} (X ⟶ Y) := by infer_instance
 #align category_theory.locally_small CategoryTheory.LocallySmall
 
-instance (C : Type u) [Category.{v} C] [LocallySmall.{w} C] (X Y : C) : Small (X ⟶ Y) :=
+instance (C : Type u) [Category.{v} C] [LocallySmall.{w} C] (X Y : C) : Small.{w, v} (X ⟶ Y) :=
   LocallySmall.hom_small X Y
 
 theorem locallySmall_of_faithful {C : Type u} [Category.{v} C] {D : Type u'} [Category.{v'} D]

--- a/Mathlib/CategoryTheory/Limits/Constructions/Over/Basic.lean
+++ b/Mathlib/CategoryTheory/Limits/Constructions/Over/Basic.lean
@@ -51,7 +51,7 @@ instance hasFiniteLimits {B : C} [HasFiniteWidePullbacks C] : HasFiniteLimits (O
     exact ConstructProducts.over_binaryProduct_of_pullback
 #align category_theory.over.has_finite_limits CategoryTheory.Over.hasFiniteLimits
 
-instance hasLimits {B : C} [HasWidePullbacks.{w} C] : HasLimitsOfSize.{w} (Over B) := by
+instance hasLimits {B : C} [HasWidePullbacks.{w} C] : HasLimitsOfSize.{w, w} (Over B) := by
   apply @has_limits_of_hasEqualizers_and_products _ _ ?_ ?_
   · exact ConstructProducts.over_products_of_widePullbacks
   · apply @hasEqualizers_of_hasPullbacks_and_binary_products _ _ ?_ _

--- a/Mathlib/CategoryTheory/Sites/Adjunction.lean
+++ b/Mathlib/CategoryTheory/Sites/Adjunction.lean
@@ -20,10 +20,10 @@ namespace CategoryTheory
 
 open GrothendieckTopology CategoryTheory Limits Opposite
 
-universe v u
+universe v₁ v₂ u₁ u₂
 
-variable {C : Type u} [Category.{v} C] (J : GrothendieckTopology C)
-variable {D : Type*} [Category D]
+variable {C : Type u₁} [Category.{v₁} C] (J : GrothendieckTopology C)
+variable {D : Type u₂} [Category.{v₂} D]
 variable {E : Type*} [Category E]
 variable {F : D ⥤ E} {G : E ⥤ D}
 variable [HasWeakSheafify J D]
@@ -116,24 +116,24 @@ instance [G.IsLeftAdjoint] : J.PreservesSheafification G :=
 
 section ForgetToType
 
-variable [ConcreteCategory D] [HasSheafCompose J (forget D)]
+variable [ConcreteCategory.{max u₁ v₁, v₂, u₂} D] [HasSheafCompose.{v₁, v₂, max u₁ v₁, u₁, u₂, (max u₁ v₁) + 1} J (forget.{max u₁ v₁, v₂, u₂} D)]
 
 /-- This is the functor sending a sheaf of types `X` to the sheafification of `X ⋙ G`. -/
-abbrev composeAndSheafifyFromTypes (G : Type max v u ⥤ D) : SheafOfTypes J ⥤ Sheaf J D :=
+abbrev composeAndSheafifyFromTypes (G : Type max v₁ u₁ ⥤ D) : SheafOfTypes J ⥤ Sheaf J D :=
   (sheafEquivSheafOfTypes J).inverse ⋙ composeAndSheafify _ G
 set_option linter.uppercaseLean3 false in
 #align category_theory.Sheaf.compose_and_sheafify_from_types CategoryTheory.Sheaf.composeAndSheafifyFromTypes
 
 /-- A variant of the adjunction between sheaf categories, in the case where the right adjoint
 is the forgetful functor to sheaves of types. -/
-def adjunctionToTypes {G : Type max v u ⥤ D} (adj : G ⊣ forget D) :
+def adjunctionToTypes {G : Type max v₁ u₁ ⥤ D} (adj : G ⊣ forget D) :
     composeAndSheafifyFromTypes J G ⊣ sheafForget J :=
   (sheafEquivSheafOfTypes J).symm.toAdjunction.comp (adjunction J adj)
 set_option linter.uppercaseLean3 false in
 #align category_theory.Sheaf.adjunction_to_types CategoryTheory.Sheaf.adjunctionToTypes
 
 @[simp]
-theorem adjunctionToTypes_unit_app_val {G : Type max v u ⥤ D} (adj : G ⊣ forget D)
+theorem adjunctionToTypes_unit_app_val {G : Type max v₁ u₁ ⥤ D} (adj : G ⊣ forget D)
     (Y : SheafOfTypes J) :
     ((adjunctionToTypes J adj).unit.app Y).val =
       (adj.whiskerRight _).unit.app ((sheafOfTypesToPresheaf J).obj Y) ≫
@@ -145,7 +145,7 @@ set_option linter.uppercaseLean3 false in
 #align category_theory.Sheaf.adjunction_to_types_unit_app_val CategoryTheory.Sheaf.adjunctionToTypes_unit_app_val
 
 @[simp]
-theorem adjunctionToTypes_counit_app_val {G : Type max v u ⥤ D} (adj : G ⊣ forget D)
+theorem adjunctionToTypes_counit_app_val {G : Type max v₁ u₁ ⥤ D} (adj : G ⊣ forget D)
     (X : Sheaf J D) :
     ((adjunctionToTypes J adj).counit.app X).val =
       sheafifyLift J ((Functor.associator _ _ _).hom ≫ (adj.whiskerRight _).counit.app _) X.2 := by
@@ -159,10 +159,7 @@ theorem adjunctionToTypes_counit_app_val {G : Type max v u ⥤ D} (adj : G ⊣ f
     NatIso.ofComponents, Adjunction.whiskerRight, Adjunction.mkOfUnitCounit]
   simp
 
-set_option linter.uppercaseLean3 false in
-#align category_theory.Sheaf.adjunction_to_types_counit_app_val CategoryTheory.Sheaf.adjunctionToTypes_counit_app_val
-
-instance [(forget D).IsRightAdjoint ] : (sheafForget J : Sheaf J D ⥤ _).IsRightAdjoint  :=
+instance [(forget D).IsRightAdjoint] : (sheafForget (D := D) J).IsRightAdjoint :=
   (adjunctionToTypes J (Adjunction.ofIsRightAdjoint (forget D))).isRightAdjoint
 
 end ForgetToType

--- a/Mathlib/CategoryTheory/Sites/Adjunction.lean
+++ b/Mathlib/CategoryTheory/Sites/Adjunction.lean
@@ -116,7 +116,7 @@ instance [G.IsLeftAdjoint] : J.PreservesSheafification G :=
 
 section ForgetToType
 
-variable [ConcreteCategory.{max u₁ v₁, v₂, u₂} D] [HasSheafCompose.{v₁, v₂, max u₁ v₁, u₁, u₂, (max u₁ v₁) + 1} J (forget.{max u₁ v₁, v₂, u₂} D)]
+variable [ConcreteCategory D] [HasSheafCompose J (forget D)]
 
 /-- This is the functor sending a sheaf of types `X` to the sheafification of `X ⋙ G`. -/
 abbrev composeAndSheafifyFromTypes (G : Type max v₁ u₁ ⥤ D) : SheafOfTypes J ⥤ Sheaf J D :=

--- a/Mathlib/CategoryTheory/Sites/Equivalence.lean
+++ b/Mathlib/CategoryTheory/Sites/Equivalence.lean
@@ -36,15 +36,15 @@ sufficiently small limits in the sheaf category on the essentially small site.
 
 -/
 
-universe u
+universe v₁ v₂ v₃ u₁ u₂ u₃ w
 
 namespace CategoryTheory
 
 open Functor Limits GrothendieckTopology
 
-variable {C : Type*} [Category C] (J : GrothendieckTopology C)
-variable {D : Type*} [Category D] (K : GrothendieckTopology D) (e : C ≌ D) (G : D ⥤ C)
-variable (A : Type*) [Category A]
+variable {C : Type u₁} [Category.{v₁} C] (J : GrothendieckTopology C)
+variable {D : Type u₂} [Category.{v₂} D] (K : GrothendieckTopology D) (e : C ≌ D) (G : D ⥤ C)
+variable (A : Type u₃) [Category.{v₃} A]
 
 namespace Equivalence
 
@@ -213,7 +213,7 @@ theorem hasSheafCompose : J.HasSheafCompose F where
 
 end Equivalence
 
-variable [EssentiallySmall C]
+variable [EssentiallySmall.{w} C]
 variable (B : Type*) [Category B] (F : A ⥤ B)
 variable [HasSheafify ((equivSmallModel C).locallyCoverDense J).inducedTopology A]
 variable [((equivSmallModel C).locallyCoverDense J).inducedTopology.HasSheafCompose F]
@@ -239,13 +239,13 @@ instance hasSheafComposeEssentiallySmallSite : HasSheafCompose J F :=
 
 instance hasLimitsEssentiallySmallSite
     [HasLimits <| Sheaf ((equivSmallModel C).locallyCoverDense J).inducedTopology A] :
-    HasLimitsOfSize <| Sheaf J A :=
+    HasLimitsOfSize.{max v₃ w, max v₃ w} <| Sheaf J A :=
   Adjunction.has_limits_of_equivalence ((equivSmallModel C).sheafCongr J
     ((equivSmallModel C).locallyCoverDense J).inducedTopology A).functor
 
 instance hasColimitsEssentiallySmallSite
     [HasColimits <| Sheaf ((equivSmallModel C).locallyCoverDense J).inducedTopology A] :
-    HasColimitsOfSize <| Sheaf J A :=
+    HasColimitsOfSize.{max v₃ w, max v₃ w} <| Sheaf J A :=
   Adjunction.has_colimits_of_equivalence ((equivSmallModel C).sheafCongr J
     ((equivSmallModel C).locallyCoverDense J).inducedTopology A).functor
 

--- a/Mathlib/Condensed/Limits.lean
+++ b/Mathlib/Condensed/Limits.lean
@@ -20,7 +20,8 @@ instance : HasLimits CondensedSet.{u} := by
   change HasLimits (Sheaf _ _)
   infer_instance
 
-instance : HasLimitsOfSize.{u, u + 1} CondensedSet.{u} := hasLimitsOfSizeShrink.{u, u+1, u+1, u} _
+instance : HasLimitsOfSize.{u, u + 1} CondensedSet.{u} :=
+  hasLimitsOfSizeShrink.{u, u+1, u+1, u} _
 
 variable (R : Type (u+1)) [Ring R]
 
@@ -28,4 +29,5 @@ instance : HasLimits (CondensedMod.{u} R) := by
   change HasLimits (Sheaf _ _)
   infer_instance
 
-instance : HasLimitsOfSize.{u, u + 1} (CondensedMod.{u} R) := hasLimitsOfSizeShrink.{u, u+1, u+1, u} _
+instance : HasLimitsOfSize.{u, u + 1} (CondensedMod.{u} R) :=
+  hasLimitsOfSizeShrink.{u, u+1, u+1, u} _

--- a/Mathlib/Condensed/Limits.lean
+++ b/Mathlib/Condensed/Limits.lean
@@ -20,7 +20,7 @@ instance : HasLimits CondensedSet.{u} := by
   change HasLimits (Sheaf _ _)
   infer_instance
 
-instance : HasLimitsOfSize.{u} CondensedSet.{u} := hasLimitsOfSizeShrink.{u, u+1, u+1, u} _
+instance : HasLimitsOfSize.{u, u + 1} CondensedSet.{u} := hasLimitsOfSizeShrink.{u, u+1, u+1, u} _
 
 variable (R : Type (u+1)) [Ring R]
 
@@ -28,4 +28,4 @@ instance : HasLimits (CondensedMod.{u} R) := by
   change HasLimits (Sheaf _ _)
   infer_instance
 
-instance : HasLimitsOfSize.{u} (CondensedMod.{u} R) := hasLimitsOfSizeShrink.{u, u+1, u+1, u} _
+instance : HasLimitsOfSize.{u, u + 1} (CondensedMod.{u} R) := hasLimitsOfSizeShrink.{u, u+1, u+1, u} _

--- a/Mathlib/Data/Fintype/Prod.lean
+++ b/Mathlib/Data/Fintype/Prod.lean
@@ -85,14 +85,14 @@ instance Pi.infinite_of_left {ι : Sort*} {π : ι → Sort _} [∀ i, Nontrivia
 #align pi.infinite_of_left Pi.infinite_of_left
 
 /-- If at least one `π i` is infinite and the rest nonempty, the pi type of all `π` is infinite. -/
-theorem Pi.infinite_of_exists_right {ι : Type*} {π : ι → Type*} (i : ι) [Infinite <| π i]
+theorem Pi.infinite_of_exists_right {ι : Sort _} {π : ι → Sort _} (i : ι) [Infinite <| π i]
     [∀ i, Nonempty <| π i] : Infinite (∀ i : ι, π i) :=
   let ⟨m⟩ := @Pi.instNonempty ι π _
   Infinite.of_injective _ (update_injective m i)
 #align pi.infinite_of_exists_right Pi.infinite_of_exists_right
 
 /-- See `Pi.infinite_of_exists_right` for the case that only one `π i` is infinite. -/
-instance Pi.infinite_of_right {ι : Sort _} {π : ι → Sort _} [∀ i, Infinite <| π i] [Nonempty ι] :
+instance Pi.infinite_of_right {ι : Sort _} {π : ι → Type _} [∀ i, Infinite <| π i] [Nonempty ι] :
     Infinite (∀ i : ι, π i) :=
   Pi.infinite_of_exists_right (Classical.arbitrary ι)
 #align pi.infinite_of_right Pi.infinite_of_right
@@ -103,7 +103,8 @@ instance Function.infinite_of_left {ι π : Sort _} [Nontrivial π] [Infinite ι
 #align function.infinite_of_left Function.infinite_of_left
 
 /-- Non-dependent version of `Pi.infinite_of_exists_right` and `Pi.infinite_of_right`. -/
-instance Function.infinite_of_right {ι π : Sort _} [Infinite π] [Nonempty ι] : Infinite (ι → π) :=
+instance Function.infinite_of_right {ι : Sort _} {π : Type _} [Infinite π] [Nonempty ι] :
+    Infinite (ι → π) :=
   Pi.infinite_of_right
 #align function.infinite_of_right Function.infinite_of_right
 

--- a/Mathlib/Data/Fintype/Prod.lean
+++ b/Mathlib/Data/Fintype/Prod.lean
@@ -85,14 +85,14 @@ instance Pi.infinite_of_left {ι : Sort*} {π : ι → Sort _} [∀ i, Nontrivia
 #align pi.infinite_of_left Pi.infinite_of_left
 
 /-- If at least one `π i` is infinite and the rest nonempty, the pi type of all `π` is infinite. -/
-theorem Pi.infinite_of_exists_right {ι : Sort _} {π : ι → Sort _} (i : ι) [Infinite <| π i]
+theorem Pi.infinite_of_exists_right {ι : Sort*} {π : ι → Sort*} (i : ι) [Infinite <| π i]
     [∀ i, Nonempty <| π i] : Infinite (∀ i : ι, π i) :=
   let ⟨m⟩ := @Pi.instNonempty ι π _
   Infinite.of_injective _ (update_injective m i)
 #align pi.infinite_of_exists_right Pi.infinite_of_exists_right
 
 /-- See `Pi.infinite_of_exists_right` for the case that only one `π i` is infinite. -/
-instance Pi.infinite_of_right {ι : Sort _} {π : ι → Type _} [∀ i, Infinite <| π i] [Nonempty ι] :
+instance Pi.infinite_of_right {ι : Sort*} {π : ι → Type*} [∀ i, Infinite <| π i] [Nonempty ι] :
     Infinite (∀ i : ι, π i) :=
   Pi.infinite_of_exists_right (Classical.arbitrary ι)
 #align pi.infinite_of_right Pi.infinite_of_right
@@ -103,7 +103,7 @@ instance Function.infinite_of_left {ι π : Sort _} [Nontrivial π] [Infinite ι
 #align function.infinite_of_left Function.infinite_of_left
 
 /-- Non-dependent version of `Pi.infinite_of_exists_right` and `Pi.infinite_of_right`. -/
-instance Function.infinite_of_right {ι : Sort _} {π : Type _} [Infinite π] [Nonempty ι] :
+instance Function.infinite_of_right {ι : Sort*} {π : Type*} [Infinite π] [Nonempty ι] :
     Infinite (ι → π) :=
   Pi.infinite_of_right
 #align function.infinite_of_right Function.infinite_of_right

--- a/Mathlib/Data/Fintype/Prod.lean
+++ b/Mathlib/Data/Fintype/Prod.lean
@@ -76,7 +76,7 @@ theorem infinite_prod : Infinite (α × β) ↔ Infinite α ∧ Nonempty β ∨ 
   exact H'.false
 #align infinite_prod infinite_prod
 
-instance Pi.infinite_of_left {ι : Sort*} {π : ι → Sort _} [∀ i, Nontrivial <| π i] [Infinite ι] :
+instance Pi.infinite_of_left {ι : Sort*} {π : ι → Type*} [∀ i, Nontrivial <| π i] [Infinite ι] :
     Infinite (∀ i : ι, π i) := by
   choose m n hm using fun i => exists_pair_ne (π i)
   refine Infinite.of_injective (fun i => update m i (n i)) fun x y h => of_not_not fun hne => ?_
@@ -98,7 +98,8 @@ instance Pi.infinite_of_right {ι : Sort*} {π : ι → Type*} [∀ i, Infinite 
 #align pi.infinite_of_right Pi.infinite_of_right
 
 /-- Non-dependent version of `Pi.infinite_of_left`. -/
-instance Function.infinite_of_left {ι π : Sort _} [Nontrivial π] [Infinite ι] : Infinite (ι → π) :=
+instance Function.infinite_of_left {ι : Sort*} {π : Type*} [Nontrivial π] [Infinite ι] :
+    Infinite (ι → π) :=
   Pi.infinite_of_left
 #align function.infinite_of_left Function.infinite_of_left
 

--- a/Mathlib/Geometry/RingedSpace/Basic.lean
+++ b/Mathlib/Geometry/RingedSpace/Basic.lean
@@ -37,7 +37,7 @@ namespace AlgebraicGeometry
 
 /-- The type of Ringed spaces, as an abbreviation for `SheafedSpace CommRingCat`. -/
 abbrev RingedSpace : TypeMax.{u+1, v+1} :=
-  SheafedSpace.{_, v, u} CommRingCat.{v}
+  SheafedSpace.{v+1, v, u} CommRingCat.{v}
 set_option linter.uppercaseLean3 false in
 #align algebraic_geometry.RingedSpace AlgebraicGeometry.RingedSpace
 

--- a/Mathlib/Geometry/RingedSpace/SheafedSpace.lean
+++ b/Mathlib/Geometry/RingedSpace/SheafedSpace.lean
@@ -21,7 +21,10 @@ presheaves.
 open CategoryTheory TopCat TopologicalSpace Opposite CategoryTheory.Limits CategoryTheory.Category
   CategoryTheory.Functor
 
-variable (C : Type*) [Category C]
+universe u v
+
+variable (C : Type u) [Category.{v} C]
+
 
 -- Porting note: removed
 -- local attribute [tidy] tactic.op_induction'
@@ -245,7 +248,7 @@ noncomputable instance [HasLimits C] :
           limit_isSheaf _ fun j => Sheaf.pushforward_sheaf_of_sheaf _ (K.obj (unop j)).2⟩
         (colimit.isoColimitCocone ⟨_, PresheafedSpace.colimitCoconeIsColimit _⟩).symm⟩⟩
 
-instance [HasLimits C] : HasColimits (SheafedSpace C) :=
+instance [HasLimits C] : HasColimits.{v} (SheafedSpace C) :=
   hasColimits_of_hasColimits_createsColimits forgetToPresheafedSpace
 
 noncomputable instance [HasLimits C] : PreservesColimits (forget C) :=

--- a/Mathlib/GroupTheory/FreeGroup/NielsenSchreier.lean
+++ b/Mathlib/GroupTheory/FreeGroup/NielsenSchreier.lean
@@ -296,8 +296,9 @@ instance generators_connected (G) [Groupoid.{u, u} G] [IsConnected G] [IsFreeGro
 
 /-- A vertex group in a free connected groupoid is free. With some work one could drop the
 connectedness assumption, by looking at connected components. -/
-instance endIsFreeOfConnectedFree {G} [Groupoid G] [IsConnected G] [IsFreeGroupoid G] (r : G) :
-    IsFreeGroup (End r) :=
+instance endIsFreeOfConnectedFree
+    {G : Type u} [Groupoid G] [IsConnected G] [IsFreeGroupoid G] (r : G) :
+    IsFreeGroup.{u} (End r) :=
   SpanningTree.endIsFree <| geodesicSubtree (symgen r)
 #align is_free_groupoid.End_is_free_of_connected_free IsFreeGroupoid.endIsFreeOfConnectedFree
 

--- a/Mathlib/Logic/Equiv/Basic.lean
+++ b/Mathlib/Logic/Equiv/Basic.lean
@@ -1976,7 +1976,7 @@ end
 
 section BinaryOp
 
-variable (e : α₁ ≃ β₁) (f : α₁ → α₁ → α₁)
+variable {α₁ β₁ : Type _} (e : α₁ ≃ β₁) (f : α₁ → α₁ → α₁)
 
 theorem semiconj_conj (f : α₁ → α₁) : Semiconj e f (e.conj f) := fun x => by simp
 #align equiv.semiconj_conj Equiv.semiconj_conj

--- a/Mathlib/Logic/Equiv/Basic.lean
+++ b/Mathlib/Logic/Equiv/Basic.lean
@@ -1976,7 +1976,7 @@ end
 
 section BinaryOp
 
-variable {α₁ β₁ : Type _} (e : α₁ ≃ β₁) (f : α₁ → α₁ → α₁)
+variable {α₁ β₁ : Type*} (e : α₁ ≃ β₁) (f : α₁ → α₁ → α₁)
 
 theorem semiconj_conj (f : α₁ → α₁) : Semiconj e f (e.conj f) := fun x => by simp
 #align equiv.semiconj_conj Equiv.semiconj_conj

--- a/Mathlib/Logic/Nonempty.lean
+++ b/Mathlib/Logic/Nonempty.lean
@@ -20,13 +20,8 @@ This file proves a few extra facts about `Nonempty`, which is defined in core Le
   instance.
 -/
 
-variable {α β : Type*} {γ : α → Type*}
-
-instance (priority := 20) Zero.instNonempty [Zero α] : Nonempty α :=
-  ⟨0⟩
-
-instance (priority := 20) One.instNonempty [One α] : Nonempty α :=
-  ⟨1⟩
+section
+variable {α β : Sort*}
 
 @[simp]
 theorem Nonempty.forall {α} {p : Nonempty α → Prop} : (∀ h : Nonempty α, p h) ↔ ∀ a, p ⟨a⟩ :=
@@ -55,11 +50,6 @@ theorem not_nonempty_iff_imp_false {α : Sort*} : ¬Nonempty α ↔ α → False
 #align not_nonempty_iff_imp_false not_nonempty_iff_imp_false
 
 @[simp]
-theorem nonempty_sigma : Nonempty (Σa : α, γ a) ↔ ∃ a : α, Nonempty (γ a) :=
-  Iff.intro (fun ⟨⟨a, c⟩⟩ ↦ ⟨a, ⟨c⟩⟩) fun ⟨a, ⟨c⟩⟩ ↦ ⟨⟨a, c⟩⟩
-#align nonempty_sigma nonempty_sigma
-
-@[simp]
 theorem nonempty_psigma {α} {β : α → Sort*} : Nonempty (PSigma β) ↔ ∃ a : α, Nonempty (β a) :=
   Iff.intro (fun ⟨⟨a, c⟩⟩ ↦ ⟨a, ⟨c⟩⟩) fun ⟨a, ⟨c⟩⟩ ↦ ⟨⟨a, c⟩⟩
 #align nonempty_psigma nonempty_psigma
@@ -70,27 +60,9 @@ theorem nonempty_subtype {α} {p : α → Prop} : Nonempty (Subtype p) ↔ ∃ a
 #align nonempty_subtype nonempty_subtype
 
 @[simp]
-theorem nonempty_prod : Nonempty (α × β) ↔ Nonempty α ∧ Nonempty β :=
-  Iff.intro (fun ⟨⟨a, b⟩⟩ ↦ ⟨⟨a⟩, ⟨b⟩⟩) fun ⟨⟨a⟩, ⟨b⟩⟩ ↦ ⟨⟨a, b⟩⟩
-#align nonempty_prod nonempty_prod
-
-@[simp]
 theorem nonempty_pprod {α β} : Nonempty (PProd α β) ↔ Nonempty α ∧ Nonempty β :=
   Iff.intro (fun ⟨⟨a, b⟩⟩ ↦ ⟨⟨a⟩, ⟨b⟩⟩) fun ⟨⟨a⟩, ⟨b⟩⟩ ↦ ⟨⟨a, b⟩⟩
 #align nonempty_pprod nonempty_pprod
-
-@[simp]
-theorem nonempty_sum : Nonempty (Sum α β) ↔ Nonempty α ∨ Nonempty β :=
-  Iff.intro
-    (fun ⟨h⟩ ↦
-      match h with
-      | Sum.inl a => Or.inl ⟨a⟩
-      | Sum.inr b => Or.inr ⟨b⟩)
-    fun h ↦
-    match h with
-    | Or.inl ⟨a⟩ => ⟨Sum.inl a⟩
-    | Or.inr ⟨b⟩ => ⟨Sum.inr b⟩
-#align nonempty_sum nonempty_sum
 
 @[simp]
 theorem nonempty_psum {α β} : Nonempty (PSum α β) ↔ Nonempty α ∨ Nonempty β :=
@@ -104,11 +76,6 @@ theorem nonempty_psum {α β} : Nonempty (PSum α β) ↔ Nonempty α ∨ Nonemp
     | Or.inl ⟨a⟩ => ⟨PSum.inl a⟩
     | Or.inr ⟨b⟩ => ⟨PSum.inr b⟩
 #align nonempty_psum nonempty_psum
-
-@[simp]
-theorem nonempty_ulift : Nonempty (ULift α) ↔ Nonempty α :=
-  Iff.intro (fun ⟨⟨a⟩⟩ ↦ ⟨a⟩) fun ⟨a⟩ ↦ ⟨⟨a⟩⟩
-#align nonempty_ulift nonempty_ulift
 
 @[simp]
 theorem nonempty_plift {α} : Nonempty (PLift α) ↔ Nonempty α :=
@@ -174,3 +141,44 @@ theorem Function.Surjective.nonempty [h : Nonempty β] {f : α → β} (hf : Fun
   let ⟨x, _⟩ := hf y
   ⟨x⟩
 #align function.surjective.nonempty Function.Surjective.nonempty
+
+end
+
+section
+variable {α β : Type*} {γ : α → Type*}
+
+instance (priority := 20) Zero.instNonempty [Zero α] : Nonempty α :=
+  ⟨0⟩
+
+instance (priority := 20) One.instNonempty [One α] : Nonempty α :=
+  ⟨1⟩
+
+@[simp]
+theorem nonempty_sigma : Nonempty (Σa : α, γ a) ↔ ∃ a : α, Nonempty (γ a) :=
+  Iff.intro (fun ⟨⟨a, c⟩⟩ ↦ ⟨a, ⟨c⟩⟩) fun ⟨a, ⟨c⟩⟩ ↦ ⟨⟨a, c⟩⟩
+#align nonempty_sigma nonempty_sigma
+
+@[simp]
+theorem nonempty_sum : Nonempty (Sum α β) ↔ Nonempty α ∨ Nonempty β :=
+  Iff.intro
+    (fun ⟨h⟩ ↦
+      match h with
+      | Sum.inl a => Or.inl ⟨a⟩
+      | Sum.inr b => Or.inr ⟨b⟩)
+    fun h ↦
+    match h with
+    | Or.inl ⟨a⟩ => ⟨Sum.inl a⟩
+    | Or.inr ⟨b⟩ => ⟨Sum.inr b⟩
+#align nonempty_sum nonempty_sum
+
+@[simp]
+theorem nonempty_prod : Nonempty (α × β) ↔ Nonempty α ∧ Nonempty β :=
+  Iff.intro (fun ⟨⟨a, b⟩⟩ ↦ ⟨⟨a⟩, ⟨b⟩⟩) fun ⟨⟨a⟩, ⟨b⟩⟩ ↦ ⟨⟨a, b⟩⟩
+#align nonempty_prod nonempty_prod
+
+@[simp]
+theorem nonempty_ulift : Nonempty (ULift α) ↔ Nonempty α :=
+  Iff.intro (fun ⟨⟨a⟩⟩ ↦ ⟨a⟩) fun ⟨a⟩ ↦ ⟨⟨a⟩⟩
+#align nonempty_ulift nonempty_ulift
+
+end

--- a/Mathlib/ModelTheory/Bundled.lean
+++ b/Mathlib/ModelTheory/Bundled.lean
@@ -23,7 +23,7 @@ This file bundles types together with their first-order structure.
 
 set_option linter.uppercaseLean3 false
 
-universe u v w w'
+universe u v w w' x
 
 variable {L : FirstOrder.Language.{u, v}}
 
@@ -224,7 +224,7 @@ def ElementarySubstructure.toModel {M : T.ModelType} (S : L.ElementarySubstructu
 #align first_order.language.elementary_substructure.to_Model FirstOrder.Language.ElementarySubstructure.toModel
 
 instance ElementarySubstructure.toModel.instSmall {M : T.ModelType}
-    (S : L.ElementarySubstructure M) [h : Small S] : Small (S.toModel T) :=
+    (S : L.ElementarySubstructure M) [h : Small.{w, x} S] : Small.{w, x} (S.toModel T) :=
   h
 #align first_order.language.to_Model.small FirstOrder.Language.ElementarySubstructure.toModel.instSmall
 

--- a/Mathlib/ModelTheory/Skolem.lean
+++ b/Mathlib/ModelTheory/Skolem.lean
@@ -113,7 +113,7 @@ open Substructure
 variable (L) (M)
 
 instance Substructure.elementarySkolem₁Reduct.instSmall :
-    Small (⊥ : (L.sum L.skolem₁).Substructure M).elementarySkolem₁Reduct := by
+    Small.{max u v} (⊥ : (L.sum L.skolem₁).Substructure M).elementarySkolem₁Reduct := by
   rw [coeSort_elementarySkolem₁Reduct]
   infer_instance
 #align first_order.language.elementary_skolem₁_reduct.small FirstOrder.Language.Substructure.elementarySkolem₁Reduct.instSmall

--- a/Mathlib/Topology/Category/LightProfinite/Basic.lean
+++ b/Mathlib/Topology/Category/LightProfinite/Basic.lean
@@ -493,10 +493,10 @@ instance : LightDiagram'.toLightFunctor.IsEquivalence where
 def LightDiagram.equivSmall : LightDiagram.{u} ≌ LightDiagram'.{u} :=
   LightDiagram'.toLightFunctor.asEquivalence.symm
 
-instance : EssentiallySmall LightDiagram.{u} where
+instance : EssentiallySmall.{u} LightDiagram.{u} where
   equiv_smallCategory := ⟨LightDiagram', inferInstance, ⟨LightDiagram.equivSmall⟩⟩
 
-instance : EssentiallySmall LightProfinite.{u} where
+instance : EssentiallySmall.{u} LightProfinite.{u} where
   equiv_smallCategory := ⟨LightDiagram', inferInstance,
     ⟨LightProfinite.equivDiagram.trans LightDiagram.equivSmall⟩⟩
 

--- a/Mathlib/Topology/Category/TopCat/Limits/Basic.lean
+++ b/Mathlib/Topology/Category/TopCat/Limits/Basic.lean
@@ -110,7 +110,7 @@ def limitConeInfiIsLimit (F : J ⥤ TopCat.{max v u}) : IsLimit (limitConeInfi.{
   · rfl
 #align Top.limit_cone_infi_is_limit TopCat.limitConeInfiIsLimit
 
-instance topCat_hasLimitsOfSize : HasLimitsOfSize.{v} TopCat.{max v u} where
+instance topCat_hasLimitsOfSize : HasLimitsOfSize.{v, v} TopCat.{max v u} where
   has_limits_of_shape _ :=
     { has_limit := fun F =>
         HasLimit.mk

--- a/Mathlib/Topology/Sheaves/Forget.lean
+++ b/Mathlib/Topology/Sheaves/Forget.lean
@@ -65,14 +65,11 @@ set_option linter.uppercaseLean3 false in
 As an example, we now have everything we need to check the sheaf condition
 for a presheaf of commutative rings, merely by checking the sheaf condition
 for the underlying sheaf of types.
-```lean
-example (X : TopCat) (F : Presheaf CommRingCat X)
-    (h : Presheaf.IsSheaf (F ⋙ (forget CommRingCat))) :
-    F.IsSheaf :=
-(isSheaf_iff_isSheaf_comp (forget CommRingCat) F).mpr h
-```
+
+Note that the universes for `TopCat` and `CommRingCat` must be the same for this argument
+to go through.
 -/
-example (X : TopCat) (F : Presheaf CommRingCat X)
+example (X : TopCat.{u₁}) (F : Presheaf CommRingCat.{u₁} X)
     (h : Presheaf.IsSheaf (F ⋙ (forget CommRingCat))) :
     F.IsSheaf :=
 (isSheaf_iff_isSheaf_comp (forget CommRingCat) F).mpr h

--- a/Mathlib/Topology/Sheaves/Limits.lean
+++ b/Mathlib/Topology/Sheaves/Limits.lean
@@ -16,7 +16,7 @@ import Mathlib.CategoryTheory.Limits.FunctorCategory
 
 noncomputable section
 
-universe v u
+universe v u w
 
 open CategoryTheory
 
@@ -26,16 +26,16 @@ variable {C : Type u} [Category.{v} C] {J : Type v} [SmallCategory J]
 
 namespace TopCat
 
-instance [HasLimits C] (X : TopCat) : HasLimits (Presheaf C X) :=
+instance [HasLimits C] (X : TopCat.{v}) : HasLimits.{v} (Presheaf C X) :=
   Limits.functorCategoryHasLimitsOfSize.{v, v}
 
-instance [HasColimits C] (X : TopCat) : HasColimitsOfSize.{v} (Presheaf C X) :=
+instance [HasColimits.{v, u} C] (X : TopCat.{w}) : HasColimitsOfSize.{v, v} (Presheaf C X) :=
   Limits.functorCategoryHasColimitsOfSize
 
-instance [HasLimits C] (X : TopCat) : CreatesLimits (Sheaf.forget C X) :=
+instance [HasLimits C] (X : TopCat) : CreatesLimits.{v, v} (Sheaf.forget C X) :=
   Sheaf.createsLimits.{u, v, v}
 
-instance [HasLimits C] (X : TopCat) : HasLimitsOfSize.{v} (Sheaf.{v} C X) :=
+instance [HasLimits C] (X : TopCat.{v}) : HasLimitsOfSize.{v, v} (Sheaf.{v} C X) :=
   hasLimits_of_hasLimits_createsLimits (Sheaf.forget C X)
 
 theorem isSheaf_of_isLimit [HasLimits C] {X : TopCat} (F : J ⥤ Presheaf.{v} C X)

--- a/Mathlib/Topology/TietzeExtension.lean
+++ b/Mathlib/Topology/TietzeExtension.lean
@@ -112,7 +112,7 @@ theorem ContinuousMap.exists_extension_forall_mem {Y : Type v} [TopologicalSpace
   exact ⟨comp ⟨Subtype.val, by continuity⟩ g, by simp, by ext x; congrm(($(hg) x : Y))⟩
 
 instance Pi.instTietzeExtension {ι : Type*} {Y : ι → Type v} [∀ i, TopologicalSpace (Y i)]
-    [∀ i, TietzeExtension (Y i)] : TietzeExtension (∀ i, Y i) where
+    [∀ i, TietzeExtension.{u} (Y i)] : TietzeExtension.{u} (∀ i, Y i) where
   exists_restrict_eq' s hs f := by
     obtain ⟨g', hg'⟩ := Classical.skolem.mp <| fun i ↦
       ContinuousMap.exists_restrict_eq hs (ContinuousMap.piEquiv _ _ |>.symm f i)
@@ -120,7 +120,7 @@ instance Pi.instTietzeExtension {ι : Type*} {Y : ι → Type v} [∀ i, Topolog
 
 instance Prod.instTietzeExtension {Y : Type v} {Z : Type w} [TopologicalSpace Y]
     [TietzeExtension.{u, v} Y] [TopologicalSpace Z] [TietzeExtension.{u, w} Z] :
-    TietzeExtension (Y × Z) where
+    TietzeExtension.{u, max w v} (Y × Z) where
   exists_restrict_eq' s hs f := by
     obtain ⟨g₁, hg₁⟩ := (ContinuousMap.fst.comp f).exists_restrict_eq hs
     obtain ⟨g₂, hg₂⟩ := (ContinuousMap.snd.comp f).exists_restrict_eq hs


### PR DESCRIPTION
In many places in Mathlib universes in the type signature are invisibly constrained by the RHS of the `def`.

This PR makes all these explicit in the type signature.

Likely we will change the Lean behaviour to disallow this in https://github.com/leanprover/lean4/pull/4482 (i.e. this is the backport to `master` of the fixes required for that).

