### PR TITLE
[Merged by Bors] - chore: bump toolchain to v4.9.0-rc3

### DIFF
--- a/lean-toolchain
+++ b/lean-toolchain
@@ -1,1 +1,1 @@
-leanprover/lean4:v4.9.0-rc2
+leanprover/lean4:v4.9.0-rc3


### PR DESCRIPTION
This only affects `lake` behaviour.