### PR TITLE
[Merged by Bors] - feat: maxHeartBeats in technical debts metrics

### DIFF
--- a/scripts/technical-debt-metrics.sh
+++ b/scripts/technical-debt-metrics.sh
@@ -36,6 +36,7 @@ titlesAndRegexes=(
   "disabled simpNF lints"          "nolint simpNF"
   "disabled deprecation lints"     "set_option linter.deprecated false"
   "erw"                            "erw \["
+  "maxHeartBeats modifications"    "^ *set_option .*maxHeartbeats"
 )
 
 printf '|Current number|Change|Type|\n|-:|:-:|:-|\n'


### PR DESCRIPTION
Adds `set_option .*maxHeartBeats` to the list of technical debt metrics tracked by the weekly report.

[Zulip discussion](https://leanprover.zulipchat.com/#narrow/stream/287929-mathlib4/topic/Technical.20Debt.20Counters/near/446519223)

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
