### PR TITLE
[Merged by Bors] - fix: technical debts counter uses all git history

### DIFF
--- a/.github/workflows/technical_debt_metrics.yml
+++ b/.github/workflows/technical_debt_metrics.yml
@@ -11,6 +11,8 @@ jobs:
     steps:
     - name: Checkout code
       uses: actions/checkout@v4
+      with: # checkout all history so that we can compare across commits
+        fetch-depth: 0
 
     - name: Run script
       id: tech_debt


### PR DESCRIPTION
This should make the "change" in the technical debts counter actually have access to the relevant past commit.

[Zulip thread](https://leanprover.zulipchat.com/#narrow/stream/287929-mathlib4/topic/Technical.20Debt.20Counters/near/446524715)

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
