### PR TITLE
[Merged by Bors] - fix: add space in no_lost_declarations regex

### DIFF
--- a/scripts/no_lost_declarations.sh
+++ b/scripts/no_lost_declarations.sh
@@ -132,5 +132,5 @@ instance (priority := high) {to be a nameless} instance :=
 def testingLongDiff1 im a def
 def testingLongDiff2 im a def
 def testingLongDiff3 im a def
-def testingLongDiff4 im a def
+@[trying to fool you] instance. the messing dot
 ReferenceTest

--- a/scripts/no_lost_declarations.sh
+++ b/scripts/no_lost_declarations.sh
@@ -18,9 +18,9 @@ else
 fi |
   ## purge `@[...]`, to attempt to catch declaration names
   sed 's=@\[[^]]*\] ==; s=noncomputable ==; s=nonrec ==; s=protected ==' |
-  ## extract lines that begin with '[+-]' followed by the input `theorem` or `lemma`
-  ## in the `git diff`
-  awk -v regex="^[+-]${begs}" 'BEGIN{ paired=0; added=0; removed=0 }
+  ## extract lines that begin with '[+-]' followed by the input `theorem`, `lemma`,...
+  ## and then a space in the `git diff`
+  awk -v regex="^[+-]${begs} " 'BEGIN{ paired=0; added=0; removed=0 }
     /^--- a\//    { minusFile=$2 }  ## the path to the old file
     /^\+\+\+ b\// { plusFile=$2 }   ## the path to the new file
     ($0 ~ regex){


### PR DESCRIPTION
As [reported](https://github.com/leanprover-community/mathlib4/pull/14048#issuecomment-2185315293) and [requested](https://github.com/leanprover-community/mathlib4/pull/14048#issuecomment-2185933007) by Yael!

I think that this change is an improvement, but I would be happier if there was a consensus that the `def`, `theorem`, `structure`,... keywords are followed by a space and not a line break before their identifier.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
