### PR TITLE
chore: Move Nat.instLinearOrder to Init.Order.Defs

### DIFF
--- a/Mathlib/Data/Char.lean
+++ b/Mathlib/Data/Char.lean
@@ -3,9 +3,9 @@ Copyright (c) 2018 Mario Carneiro. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Mario Carneiro
 -/
-import Mathlib.Init.Data.Nat.Lemmas
+import Mathlib.Init.Data.Nat.Notation
 import Mathlib.Init.Order.Defs
-import Mathlib.Data.Nat.Defs
+import Mathlib.Tactic.SplitIfs
 
 #align_import data.char from "leanprover-community/mathlib"@"c4658a649d216f57e99621708b09dcb3dcccbd23"
 
@@ -30,5 +30,7 @@ instance : LinearOrder Char where
   min := fun a b => if a ≤ b then a else b
   max := fun a b => if a ≤ b then b else a
   decidableLE := inferInstance
+  -- XXX why needed?
+  compare_eq_compareOfLessAndEq := fun a b => rfl
 
 #align char.of_nat_to_nat Char.ofNat_toNat

--- a/Mathlib/Data/Nat/Defs.lean
+++ b/Mathlib/Data/Nat/Defs.lean
@@ -9,6 +9,7 @@ import Mathlib.Logic.Nontrivial.Defs
 import Mathlib.Tactic.Cases
 import Mathlib.Tactic.GCongr.Core
 import Mathlib.Tactic.PushNeg
+import Mathlib.Tactic.SplitIfs
 import Mathlib.Util.AssertExists
 
 #align_import data.nat.basic from "leanprover-community/mathlib"@"bd835ef554f37ef9b804f0903089211f89cb370b"
@@ -63,20 +64,6 @@ open Function
 
 namespace Nat
 variable {a b c d m n k : ℕ} {p q : ℕ → Prop}
-
--- TODO: Move the `LinearOrder ℕ` instance to `Order.Nat` (#13092).
-instance instLinearOrder : LinearOrder ℕ where
-  le := Nat.le
-  le_refl := @Nat.le_refl
-  le_trans := @Nat.le_trans
-  le_antisymm := @Nat.le_antisymm
-  le_total := @Nat.le_total
-  lt := Nat.lt
-  lt_iff_le_not_le := @Nat.lt_iff_le_not_le
-  decidableLT := inferInstance
-  decidableLE := inferInstance
-  decidableEq := inferInstance
-#align nat.linear_order Nat.instLinearOrder
 
 instance instNontrivial : Nontrivial ℕ := ⟨⟨0, 1, Nat.zero_ne_one⟩⟩
 

--- a/Mathlib/Data/Nat/Set.lean
+++ b/Mathlib/Data/Nat/Set.lean
@@ -3,6 +3,7 @@ Copyright (c) 2020 Yury Kudryashov. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Yury Kudryashov
 -/
+import Mathlib.Data.Nat.Defs
 import Mathlib.Data.Set.Image
 
 #align_import data.nat.set from "leanprover-community/mathlib"@"cf9386b56953fb40904843af98b7a80757bbe7f9"

--- a/Mathlib/Data/PNat/Defs.lean
+++ b/Mathlib/Data/PNat/Defs.lean
@@ -4,7 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Mario Carneiro, Neil Strickland
 -/
 import Mathlib.Algebra.NeZero
-import Mathlib.Data.Nat.Defs
 import Mathlib.Order.Basic
 import Mathlib.Tactic.Coe
 import Mathlib.Tactic.Lift

--- a/Mathlib/Data/Tree/Get.lean
+++ b/Mathlib/Data/Tree/Get.lean
@@ -5,6 +5,7 @@ Authors: Mario Carneiro, Wojciech Nawrocki
 -/
 import Mathlib.Data.Num.Basic
 import Mathlib.Data.Tree.Basic
+import Mathlib.Init.Data.Ordering.Basic
 
 #align_import data.tree from "leanprover-community/mathlib"@"ed989ff568099019c6533a4d94b27d852a5710d8"
 

--- a/Mathlib/Init/Data/Int/Order.lean
+++ b/Mathlib/Init/Data/Int/Order.lean
@@ -6,6 +6,7 @@ Authors: Jeremy Avigad
 
 import Mathlib.Init.Order.Defs
 import Mathlib.Init.Data.Int.Basic
+import Batteries.Tactic.OpenPrivate
 
 /-! # The order relation on the integers -/
 

--- a/Mathlib/Init/Order/Defs.lean
+++ b/Mathlib/Init/Order/Defs.lean
@@ -3,12 +3,10 @@ Copyright (c) 2016 Microsoft Corporation. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Leonardo de Moura
 -/
+import Batteries.Tactic.Alias
 import Mathlib.Mathport.Rename
-import Mathlib.Init.Algebra.Classes
-import Mathlib.Init.Data.Ordering.Basic
-import Mathlib.Tactic.SplitIfs
+import Mathlib.Tactic.Relation.Trans
 import Mathlib.Tactic.TypeStar
-import Batteries.Classes.Order
 
 #align_import init.algebra.order from "leanprover-community/lean"@"c2bcdbcbe741ed37c361a30d38e179182b989f76"
 
@@ -263,7 +261,7 @@ implicit arguments, requires us to unfold the defs and split the `if`s in the de
   (useful when `compare` is defined via a `match` statement, as it is for `Bool`) -/
 macro "compareOfLessAndEq_rfl" : tactic =>
   `(tactic| (intros a b; first | rfl |
-    (simp only [compare, compareOfLessAndEq]; split_ifs <;> rfl) |
+    (simp only [compare, compareOfLessAndEq]; split <;> rfl) |
     (induction a <;> induction b <;> simp (config := {decide := true}) only [])))
 
 /-- A linear order is reflexive, transitive, antisymmetric and total relation `≤`.
@@ -389,21 +387,6 @@ theorem eq_or_lt_of_not_lt {a b : α} (h : ¬a < b) : a = b ∨ b < a :=
   if h₁ : a = b then Or.inl h₁ else Or.inr (lt_of_not_ge fun hge => h (lt_of_le_of_ne hge h₁))
 #align eq_or_lt_of_not_lt eq_or_lt_of_not_lt
 
-instance : IsTotalPreorder α (· ≤ ·) where
-  trans := @le_trans _ _
-  total := le_total
-
--- TODO(Leo): decide whether we should keep this instance or not
-instance isStrictWeakOrder_of_linearOrder : IsStrictWeakOrder α (· < ·) :=
-  have : IsTotalPreorder α (· ≤ ·) := by infer_instance -- Porting note: added
-  isStrictWeakOrder_of_isTotalPreorder lt_iff_not_ge
-#align is_strict_weak_order_of_linear_order isStrictWeakOrder_of_linearOrder
-
--- TODO(Leo): decide whether we should keep this instance or not
-instance isStrictTotalOrder_of_linearOrder : IsStrictTotalOrder α (· < ·) where
-  trichotomous := lt_trichotomy
-#align is_strict_total_order_of_linear_order isStrictTotalOrder_of_linearOrder
-
 /-- Perform a case-split on the ordering of `x` and `y` in a decidable linear order. -/
 def ltByCases (x y : α) {P : Sort*} (h₁ : x < y → P) (h₂ : x = y → P) (h₃ : y < x → P) : P :=
   if h : x < y then h₁ h
@@ -420,21 +403,22 @@ section Ord
 
 theorem compare_lt_iff_lt {a b : α} : (compare a b = .lt) ↔ a < b := by
   rw [LinearOrder.compare_eq_compareOfLessAndEq, compareOfLessAndEq]
-  split_ifs <;> simp only [*, lt_irrefl]
+  split <;> simp only [*, lt_irrefl]
+  split <;> simp
 
 theorem compare_gt_iff_gt {a b : α} : (compare a b = .gt) ↔ a > b := by
   rw [LinearOrder.compare_eq_compareOfLessAndEq, compareOfLessAndEq]
-  split_ifs <;> simp only [*, lt_irrefl, not_lt_of_gt]
+  split
+  · simp only [*, lt_irrefl, not_lt_of_gt]
+  split
+  · simp only [*, lt_irrefl, not_lt_of_gt]
+  simp only [gt_iff_lt, true_iff]
   case _ h₁ h₂ =>
-    have h : b < a := lt_trichotomy a b |>.resolve_left h₁ |>.resolve_left h₂
-    exact true_iff_iff.2 h
+    exact lt_trichotomy a b |>.resolve_left h₁ |>.resolve_left h₂
 
 theorem compare_eq_iff_eq {a b : α} : (compare a b = .eq) ↔ a = b := by
   rw [LinearOrder.compare_eq_compareOfLessAndEq, compareOfLessAndEq]
-  split_ifs <;> try simp only
-  case _ h   => exact false_iff_iff.2 <| ne_iff_lt_or_gt.2 <| .inl h
-  case _ _ h => exact true_iff_iff.2 h
-  case _ _ h => exact false_iff_iff.2 h
+  split <;> simp [*, ne_of_lt]
 
 theorem compare_le_iff_le {a b : α} : (compare a b ≠ .gt) ↔ a ≤ b := by
   cases h : compare a b <;> simp
@@ -448,22 +432,175 @@ theorem compare_ge_iff_ge {a b : α} : (compare a b ≠ .lt) ↔ a ≥ b := by
   · exact le_of_eq <| (·.symm) <| compare_eq_iff_eq.1 h
   · exact le_of_lt <| compare_gt_iff_gt.1 h
 
-theorem compare_iff (a b : α) {o : Ordering} : compare a b = o ↔ o.toRel a b := by
-  cases o <;> simp only [Ordering.toRel]
-  · exact compare_lt_iff_lt
-  · exact compare_eq_iff_eq
-  · exact compare_gt_iff_gt
-
-instance : Batteries.TransCmp (compare (α := α)) where
-  symm a b := by
-    cases h : compare a b <;>
-    simp only [Ordering.swap] <;> symm
-    · exact compare_gt_iff_gt.2 <| compare_lt_iff_lt.1 h
-    · exact compare_eq_iff_eq.2 <| compare_eq_iff_eq.1 h |>.symm
-    · exact compare_lt_iff_lt.2 <| compare_gt_iff_gt.1 h
-  le_trans := fun h₁ h₂ ↦
-    compare_le_iff_le.2 <| le_trans (compare_le_iff_le.1 h₁) (compare_le_iff_le.1 h₂)
-
 end Ord
 
 end LinearOrder
+
+instance Nat.instLinearOrder : LinearOrder Nat where
+  le := Nat.le
+  le_refl := @Nat.le_refl
+  le_trans := @Nat.le_trans
+  le_antisymm := @Nat.le_antisymm
+  le_total := @Nat.le_total
+  lt := Nat.lt
+  lt_iff_le_not_le := @Nat.lt_iff_le_not_le
+  decidableLT := inferInstance
+  decidableLE := inferInstance
+  decidableEq := inferInstance
+#align nat.linear_order Nat.instLinearOrder
+
+section
+
+open Decidable
+
+variable {α : Type u} [LinearOrder α]
+
+theorem min_def (a b : α) : min a b = if a ≤ b then a else b := by
+  rw [LinearOrder.min_def a]
+#align min_def min_def
+
+theorem max_def (a b : α) : max a b = if a ≤ b then b else a := by
+  rw [LinearOrder.max_def a]
+#align max_def max_def
+
+theorem min_le_left (a b : α) : min a b ≤ a := by
+  -- Porting note: no `min_tac` tactic
+  if h : a ≤ b
+  then simp [min_def, if_pos h, le_refl]
+  else simp [min_def, if_neg h]; exact le_of_not_le h
+#align min_le_left min_le_left
+
+theorem min_le_right (a b : α) : min a b ≤ b := by
+  -- Porting note: no `min_tac` tactic
+  if h : a ≤ b
+  then simp [min_def, if_pos h]; exact h
+  else simp [min_def, if_neg h, le_refl]
+#align min_le_right min_le_right
+
+theorem le_min {a b c : α} (h₁ : c ≤ a) (h₂ : c ≤ b) : c ≤ min a b := by
+  -- Porting note: no `min_tac` tactic
+  if h : a ≤ b
+  then simp [min_def, if_pos h]; exact h₁
+  else simp [min_def, if_neg h]; exact h₂
+#align le_min le_min
+
+theorem le_max_left (a b : α) : a ≤ max a b := by
+  -- Porting note: no `min_tac` tactic
+  if h : a ≤ b
+  then simp [max_def, if_pos h]; exact h
+  else simp [max_def, if_neg h, le_refl]
+#align le_max_left le_max_left
+
+theorem le_max_right (a b : α) : b ≤ max a b := by
+  -- Porting note: no `min_tac` tactic
+  if h : a ≤ b
+  then simp [max_def, if_pos h, le_refl]
+  else simp [max_def, if_neg h]; exact le_of_not_le h
+#align le_max_right le_max_right
+
+theorem max_le {a b c : α} (h₁ : a ≤ c) (h₂ : b ≤ c) : max a b ≤ c := by
+  -- Porting note: no `min_tac` tactic
+  if h : a ≤ b
+  then simp [max_def, if_pos h]; exact h₂
+  else simp [max_def, if_neg h]; exact h₁
+#align max_le max_le
+
+theorem eq_min {a b c : α} (h₁ : c ≤ a) (h₂ : c ≤ b) (h₃ : ∀ {d}, d ≤ a → d ≤ b → d ≤ c) :
+    c = min a b :=
+  le_antisymm (le_min h₁ h₂) (h₃ (min_le_left a b) (min_le_right a b))
+#align eq_min eq_min
+
+theorem min_comm (a b : α) : min a b = min b a :=
+  eq_min (min_le_right a b) (min_le_left a b) fun h₁ h₂ => le_min h₂ h₁
+#align min_comm min_comm
+
+theorem min_assoc (a b c : α) : min (min a b) c = min a (min b c) := by
+  apply eq_min
+  · apply le_trans; apply min_le_left; apply min_le_left
+  · apply le_min; apply le_trans; apply min_le_left; apply min_le_right; apply min_le_right
+  · intro d h₁ h₂; apply le_min; apply le_min h₁; apply le_trans h₂; apply min_le_left
+    apply le_trans h₂; apply min_le_right
+#align min_assoc min_assoc
+
+theorem min_left_comm (a b c : α) : min a (min b c) = min b (min a c) := by
+  rw [← min_assoc, min_comm a, min_assoc]
+#align min_left_comm min_left_comm
+
+@[simp]
+theorem min_self (a : α) : min a a = a := by simp [min_def]
+#align min_self min_self
+
+theorem min_eq_left {a b : α} (h : a ≤ b) : min a b = a := by
+  apply Eq.symm; apply eq_min (le_refl _) h; intros; assumption
+#align min_eq_left min_eq_left
+
+theorem min_eq_right {a b : α} (h : b ≤ a) : min a b = b :=
+  min_comm b a ▸ min_eq_left h
+#align min_eq_right min_eq_right
+
+theorem eq_max {a b c : α} (h₁ : a ≤ c) (h₂ : b ≤ c) (h₃ : ∀ {d}, a ≤ d → b ≤ d → c ≤ d) :
+    c = max a b :=
+  le_antisymm (h₃ (le_max_left a b) (le_max_right a b)) (max_le h₁ h₂)
+#align eq_max eq_max
+
+theorem max_comm (a b : α) : max a b = max b a :=
+  eq_max (le_max_right a b) (le_max_left a b) fun h₁ h₂ => max_le h₂ h₁
+#align max_comm max_comm
+
+theorem max_assoc (a b c : α) : max (max a b) c = max a (max b c) := by
+  apply eq_max
+  · apply le_trans; apply le_max_left a b; apply le_max_left
+  · apply max_le; apply le_trans; apply le_max_right a b; apply le_max_left; apply le_max_right
+  · intro d h₁ h₂; apply max_le; apply max_le h₁; apply le_trans (le_max_left _ _) h₂
+    apply le_trans (le_max_right _ _) h₂
+#align max_assoc max_assoc
+
+theorem max_left_comm (a b c : α) : max a (max b c) = max b (max a c) := by
+  rw [← max_assoc, max_comm a, max_assoc]
+#align max_left_comm max_left_comm
+
+@[simp]
+theorem max_self (a : α) : max a a = a := by simp [max_def]
+#align max_self max_self
+
+theorem max_eq_left {a b : α} (h : b ≤ a) : max a b = a := by
+  apply Eq.symm; apply eq_max (le_refl _) h; intros; assumption
+#align max_eq_left max_eq_left
+
+theorem max_eq_right {a b : α} (h : a ≤ b) : max a b = b :=
+  max_comm b a ▸ max_eq_left h
+#align max_eq_right max_eq_right
+
+-- these rely on lt_of_lt
+theorem min_eq_left_of_lt {a b : α} (h : a < b) : min a b = a :=
+  min_eq_left (le_of_lt h)
+#align min_eq_left_of_lt min_eq_left_of_lt
+
+theorem min_eq_right_of_lt {a b : α} (h : b < a) : min a b = b :=
+  min_eq_right (le_of_lt h)
+#align min_eq_right_of_lt min_eq_right_of_lt
+
+theorem max_eq_left_of_lt {a b : α} (h : b < a) : max a b = a :=
+  max_eq_left (le_of_lt h)
+#align max_eq_left_of_lt max_eq_left_of_lt
+
+theorem max_eq_right_of_lt {a b : α} (h : a < b) : max a b = b :=
+  max_eq_right (le_of_lt h)
+#align max_eq_right_of_lt max_eq_right_of_lt
+
+-- these use the fact that it is a linear ordering
+theorem lt_min {a b c : α} (h₁ : a < b) (h₂ : a < c) : a < min b c :=
+  -- Porting note: no `min_tac` tactic
+  Or.elim (le_or_gt b c)
+    (fun h : b ≤ c ↦ by rwa [min_eq_left h])
+    (fun h : b > c ↦ by rwa [min_eq_right_of_lt h])
+#align lt_min lt_min
+
+theorem max_lt {a b c : α} (h₁ : a < c) (h₂ : b < c) : max a b < c :=
+  -- Porting note: no `min_tac` tactic
+  Or.elim (le_or_gt a b)
+    (fun h : a ≤ b ↦ by rwa [max_eq_right h])
+    (fun h : a > b ↦ by rwa [max_eq_left_of_lt h])
+#align max_lt max_lt
+
+end

--- a/Mathlib/Init/Order/LinearOrder.lean
+++ b/Mathlib/Init/Order/LinearOrder.lean
@@ -1,173 +1,52 @@
 /-
 Copyright (c) 2016 Microsoft Corporation. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Jeremy Avigad, Leonardo de Moura
+Authors: Leonardo de Moura
 -/
-import Mathlib.Init.Order.Defs
 
-#align_import init.algebra.functions from "leanprover-community/lean"@"c2bcdbcbe741ed37c361a30d38e179182b989f76"
+import Batteries.Classes.Order
+import Mathlib.Init.Algebra.Classes
+import Mathlib.Init.Order.Defs
+import Mathlib.Init.Data.Ordering.Basic
 
 /-!
-# Basic lemmas about linear orders.
+# Orders
 
-The contents of this file came from `init.algebra.functions` in Lean 3,
-and it would be good to find everything a better home.
+Some slightly less basic lemmas about linear orders.
 -/
 
 universe u
+variable {α : Type u}
 
-section
+variable [LinearOrder α]
 
-open Decidable
+instance : IsTotalPreorder α (· ≤ ·) where
+  trans := @le_trans _ _
+  total := le_total
 
-variable {α : Type u} [LinearOrder α]
+-- TODO(Leo): decide whether we should keep this instance or not
+instance isStrictWeakOrder_of_linearOrder : IsStrictWeakOrder α (· < ·) :=
+  have : IsTotalPreorder α (· ≤ ·) := by infer_instance -- Porting note: added
+  isStrictWeakOrder_of_isTotalPreorder lt_iff_not_ge
+#align is_strict_weak_order_of_linear_order isStrictWeakOrder_of_linearOrder
 
-theorem min_def (a b : α) : min a b = if a ≤ b then a else b := by
-  rw [LinearOrder.min_def a]
-#align min_def min_def
+-- TODO(Leo): decide whether we should keep this instance or not
+instance isStrictTotalOrder_of_linearOrder : IsStrictTotalOrder α (· < ·) where
+  trichotomous := lt_trichotomy
+#align is_strict_total_order_of_linear_order isStrictTotalOrder_of_linearOrder
 
-theorem max_def (a b : α) : max a b = if a ≤ b then b else a := by
-  rw [LinearOrder.max_def a]
-#align max_def max_def
+theorem compare_iff (a b : α) {o : Ordering} : compare a b = o ↔ o.toRel a b := by
+  cases o <;> simp only [Ordering.toRel]
+  · exact compare_lt_iff_lt
+  · exact compare_eq_iff_eq
+  · exact compare_gt_iff_gt
 
-theorem min_le_left (a b : α) : min a b ≤ a := by
-  -- Porting note: no `min_tac` tactic
-  if h : a ≤ b
-  then simp [min_def, if_pos h, le_refl]
-  else simp [min_def, if_neg h]; exact le_of_not_le h
-#align min_le_left min_le_left
-
-theorem min_le_right (a b : α) : min a b ≤ b := by
-  -- Porting note: no `min_tac` tactic
-  if h : a ≤ b
-  then simp [min_def, if_pos h]; exact h
-  else simp [min_def, if_neg h, le_refl]
-#align min_le_right min_le_right
-
-theorem le_min {a b c : α} (h₁ : c ≤ a) (h₂ : c ≤ b) : c ≤ min a b := by
-  -- Porting note: no `min_tac` tactic
-  if h : a ≤ b
-  then simp [min_def, if_pos h]; exact h₁
-  else simp [min_def, if_neg h]; exact h₂
-#align le_min le_min
-
-theorem le_max_left (a b : α) : a ≤ max a b := by
-  -- Porting note: no `min_tac` tactic
-  if h : a ≤ b
-  then simp [max_def, if_pos h]; exact h
-  else simp [max_def, if_neg h, le_refl]
-#align le_max_left le_max_left
-
-theorem le_max_right (a b : α) : b ≤ max a b := by
-  -- Porting note: no `min_tac` tactic
-  if h : a ≤ b
-  then simp [max_def, if_pos h, le_refl]
-  else simp [max_def, if_neg h]; exact le_of_not_le h
-#align le_max_right le_max_right
-
-theorem max_le {a b c : α} (h₁ : a ≤ c) (h₂ : b ≤ c) : max a b ≤ c := by
-  -- Porting note: no `min_tac` tactic
-  if h : a ≤ b
-  then simp [max_def, if_pos h]; exact h₂
-  else simp [max_def, if_neg h]; exact h₁
-#align max_le max_le
-
-theorem eq_min {a b c : α} (h₁ : c ≤ a) (h₂ : c ≤ b) (h₃ : ∀ {d}, d ≤ a → d ≤ b → d ≤ c) :
-    c = min a b :=
-  le_antisymm (le_min h₁ h₂) (h₃ (min_le_left a b) (min_le_right a b))
-#align eq_min eq_min
-
-theorem min_comm (a b : α) : min a b = min b a :=
-  eq_min (min_le_right a b) (min_le_left a b) fun h₁ h₂ => le_min h₂ h₁
-#align min_comm min_comm
-
-theorem min_assoc (a b c : α) : min (min a b) c = min a (min b c) := by
-  apply eq_min
-  · apply le_trans; apply min_le_left; apply min_le_left
-  · apply le_min; apply le_trans; apply min_le_left; apply min_le_right; apply min_le_right
-  · intro d h₁ h₂; apply le_min; apply le_min h₁; apply le_trans h₂; apply min_le_left
-    apply le_trans h₂; apply min_le_right
-#align min_assoc min_assoc
-
-theorem min_left_comm : ∀ a b c : α, min a (min b c) = min b (min a c) :=
-  left_comm (@min α _) (@min_comm α _) (@min_assoc α _)
-#align min_left_comm min_left_comm
-
-@[simp]
-theorem min_self (a : α) : min a a = a := by simp [min_def]
-#align min_self min_self
-
-theorem min_eq_left {a b : α} (h : a ≤ b) : min a b = a := by
-  apply Eq.symm; apply eq_min (le_refl _) h; intros; assumption
-#align min_eq_left min_eq_left
-
-theorem min_eq_right {a b : α} (h : b ≤ a) : min a b = b :=
-  min_comm b a ▸ min_eq_left h
-#align min_eq_right min_eq_right
-
-theorem eq_max {a b c : α} (h₁ : a ≤ c) (h₂ : b ≤ c) (h₃ : ∀ {d}, a ≤ d → b ≤ d → c ≤ d) :
-    c = max a b :=
-  le_antisymm (h₃ (le_max_left a b) (le_max_right a b)) (max_le h₁ h₂)
-#align eq_max eq_max
-
-theorem max_comm (a b : α) : max a b = max b a :=
-  eq_max (le_max_right a b) (le_max_left a b) fun h₁ h₂ => max_le h₂ h₁
-#align max_comm max_comm
-
-theorem max_assoc (a b c : α) : max (max a b) c = max a (max b c) := by
-  apply eq_max
-  · apply le_trans; apply le_max_left a b; apply le_max_left
-  · apply max_le; apply le_trans; apply le_max_right a b; apply le_max_left; apply le_max_right
-  · intro d h₁ h₂; apply max_le; apply max_le h₁; apply le_trans (le_max_left _ _) h₂
-    apply le_trans (le_max_right _ _) h₂
-#align max_assoc max_assoc
-
-theorem max_left_comm : ∀ a b c : α, max a (max b c) = max b (max a c) :=
-  left_comm (@max α _) (@max_comm α _) (@max_assoc α _)
-#align max_left_comm max_left_comm
-
-@[simp]
-theorem max_self (a : α) : max a a = a := by simp [max_def]
-#align max_self max_self
-
-theorem max_eq_left {a b : α} (h : b ≤ a) : max a b = a := by
-  apply Eq.symm; apply eq_max (le_refl _) h; intros; assumption
-#align max_eq_left max_eq_left
-
-theorem max_eq_right {a b : α} (h : a ≤ b) : max a b = b :=
-  max_comm b a ▸ max_eq_left h
-#align max_eq_right max_eq_right
-
--- these rely on lt_of_lt
-theorem min_eq_left_of_lt {a b : α} (h : a < b) : min a b = a :=
-  min_eq_left (le_of_lt h)
-#align min_eq_left_of_lt min_eq_left_of_lt
-
-theorem min_eq_right_of_lt {a b : α} (h : b < a) : min a b = b :=
-  min_eq_right (le_of_lt h)
-#align min_eq_right_of_lt min_eq_right_of_lt
-
-theorem max_eq_left_of_lt {a b : α} (h : b < a) : max a b = a :=
-  max_eq_left (le_of_lt h)
-#align max_eq_left_of_lt max_eq_left_of_lt
-
-theorem max_eq_right_of_lt {a b : α} (h : a < b) : max a b = b :=
-  max_eq_right (le_of_lt h)
-#align max_eq_right_of_lt max_eq_right_of_lt
-
--- these use the fact that it is a linear ordering
-theorem lt_min {a b c : α} (h₁ : a < b) (h₂ : a < c) : a < min b c :=
-  -- Porting note: no `min_tac` tactic
-  Or.elim (le_or_gt b c)
-    (fun h : b ≤ c ↦ by rwa [min_eq_left h])
-    (fun h : b > c ↦ by rwa [min_eq_right_of_lt h])
-#align lt_min lt_min
-
-theorem max_lt {a b c : α} (h₁ : a < c) (h₂ : b < c) : max a b < c :=
-  -- Porting note: no `min_tac` tactic
-  Or.elim (le_or_gt a b)
-    (fun h : a ≤ b ↦ by rwa [max_eq_right h])
-    (fun h : a > b ↦ by rwa [max_eq_left_of_lt h])
-#align max_lt max_lt
-
-end
+instance : Batteries.TransCmp (compare (α := α)) where
+  symm a b := by
+    cases h : compare a b <;>
+    simp only [Ordering.swap] <;> apply Eq.symm
+    · exact compare_gt_iff_gt.2 <| compare_lt_iff_lt.1 h
+    · exact compare_eq_iff_eq.2 <| compare_eq_iff_eq.1 h |>.symm
+    · exact compare_lt_iff_lt.2 <| compare_gt_iff_gt.1 h
+  le_trans := fun h₁ h₂ ↦
+    compare_le_iff_le.2 <| le_trans (compare_le_iff_le.1 h₁) (compare_le_iff_le.1 h₂)

--- a/Mathlib/Logic/Equiv/Basic.lean
+++ b/Mathlib/Logic/Equiv/Basic.lean
@@ -12,12 +12,13 @@ import Mathlib.Data.Sum.Basic
 import Mathlib.Init.Data.Sigma.Basic
 import Mathlib.Logic.Equiv.Defs
 import Mathlib.Logic.Function.Conjugate
-import Mathlib.Tactic.Lift
+import Mathlib.Tactic.CC
 import Mathlib.Tactic.Convert
 import Mathlib.Tactic.Contrapose
 import Mathlib.Tactic.GeneralizeProofs
+import Mathlib.Tactic.Lift
 import Mathlib.Tactic.SimpRw
-import Mathlib.Tactic.CC
+import Mathlib.Tactic.SplitIfs
 
 #align_import logic.equiv.basic from "leanprover-community/mathlib"@"cd391184c85986113f8c00844cfe6dda1d34be3d"
 

--- a/Mathlib/Order/Basic.lean
+++ b/Mathlib/Order/Basic.lean
@@ -3,12 +3,13 @@ Copyright (c) 2014 Jeremy Avigad. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Jeremy Avigad, Mario Carneiro
 -/
-import Mathlib.Init.Order.LinearOrder
 import Mathlib.Data.Prod.Basic
 import Mathlib.Data.Subtype
-import Mathlib.Tactic.Spread
+import Mathlib.Init.Order.Defs
 import Mathlib.Tactic.Convert
 import Mathlib.Tactic.SimpRw
+import Mathlib.Tactic.SplitIfs
+import Mathlib.Tactic.Spread
 import Mathlib.Tactic.Cases
 import Mathlib.Order.Notation
 

--- a/Mathlib/Order/RelClasses.lean
+++ b/Mathlib/Order/RelClasses.lean
@@ -3,7 +3,7 @@ Copyright (c) 2020 Jeremy Avigad. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Jeremy Avigad, Mario Carneiro, Yury G. Kudryashov
 -/
-import Mathlib.Data.Nat.Defs
+import Mathlib.Init.Order.LinearOrder
 import Mathlib.Logic.IsEmpty
 import Mathlib.Logic.Relation
 import Mathlib.Order.Basic

--- a/Mathlib/Tactic/GCongr/Core.lean
+++ b/Mathlib/Tactic/GCongr/Core.lean
@@ -8,6 +8,8 @@ import Mathlib.Tactic.Core
 import Mathlib.Tactic.GCongr.ForwardAttr
 import Batteries.Lean.Except
 import Batteries.Tactic.Exact
+import Lean.Meta.Tactic.Symm
+import Lean.Meta.Tactic.Rfl
 
 /-!
 # The `gcongr` ("generalized congruence") tactic


### PR DESCRIPTION
It turns out that pushing the dependency out is quite annoying, so as an alternative, we propose considering Preorder, PartialOrder and LinearOrder to be foundational type classes that all of Mathlib can depend on.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
