### PR TITLE
[Merged by Bors] - feat: commutation with shifts of functors from quotient categories

### DIFF
--- a/Mathlib/CategoryTheory/Quotient.lean
+++ b/Mathlib/CategoryTheory/Quotient.lean
@@ -220,6 +220,9 @@ theorem lift.isLift_inv (X : C) : (lift.isLift r F H).inv.app X = 𝟙 (F.obj X)
   rfl
 #align category_theory.quotient.lift.is_lift_inv CategoryTheory.Quotient.lift.isLift_inv
 
+theorem lift_obj_functor_obj (X : C) :
+    (lift r F H).obj ((functor r).obj X) = F.obj X := rfl
+
 theorem lift_map_functor_map {X Y : C} (f : X ⟶ Y) :
     (lift r F H).map ((functor r).map f) = F.map f := by
   rw [← NatIso.naturality_1 (lift.isLift r F H)]

--- a/Mathlib/CategoryTheory/Shift/Quotient.lean
+++ b/Mathlib/CategoryTheory/Shift/Quotient.lean
@@ -3,6 +3,7 @@ Copyright (c) 2023 Joël Riou. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Joël Riou
 -/
+import Mathlib.CategoryTheory.Shift.CommShift
 import Mathlib.CategoryTheory.Shift.Induced
 import Mathlib.CategoryTheory.Quotient
 
@@ -20,12 +21,12 @@ the shift can be automatically infered on the quotient category.
 
 -/
 
-universe v u w
+universe v v' u u' w
 
-open CategoryTheory
+open CategoryTheory Category
 
-variable {C : Type u} [Category.{v} C]
-  (r : HomRel C) (A : Type w) [AddMonoid A] [HasShift C A]
+variable {C : Type u} [Category.{v} C] {D : Type u'} [Category.{v'} D]
+  (F : C ⥤ D) (r : HomRel C) (A : Type w) [AddMonoid A] [HasShift C A] [HasShift D A]
 
 namespace HomRel
 
@@ -55,5 +56,94 @@ noncomputable instance Quotient.functor_commShift [r.IsCompatibleWithShift A] :
 
 -- the construction is made irreducible in order to prevent timeouts and abuse of defeq
 attribute [irreducible] HasShift.quotient Quotient.functor_commShift
+
+namespace Quotient
+
+variable [r.IsCompatibleWithShift A] [F.CommShift A]
+    (hF : ∀ (x y : C) (f₁ f₂ : x ⟶ y), r f₁ f₂ → F.map f₁ = F.map f₂)
+
+namespace LiftCommShift
+
+variable {A}
+
+/-- Auxiliary definition for `Quotient.liftCommShift`. -/
+noncomputable def iso (a : A) :
+    shiftFunctor (Quotient r) a ⋙ lift r F hF ≅ lift r F hF ⋙ shiftFunctor D a :=
+  natIsoLift r ((Functor.associator _ _ _).symm ≪≫
+    isoWhiskerRight ((functor r).commShiftIso a).symm _ ≪≫
+    Functor.associator _ _ _ ≪≫ isoWhiskerLeft _ (lift.isLift r F hF) ≪≫ F.commShiftIso a ≪≫
+    isoWhiskerRight (lift.isLift r F hF).symm _ ≪≫ Functor.associator _ _ _)
+
+@[simp]
+lemma iso_hom_app (a : A) (X : C) :
+    (iso F r hF a).hom.app ((functor r).obj X) =
+      (lift r F hF).map (((functor r).commShiftIso a).inv.app X) ≫
+      (F.commShiftIso a).hom.app X := by
+  dsimp only [iso, natIsoLift]
+  rw [natTransLift_app]
+  dsimp
+  erw [comp_id, id_comp, id_comp, id_comp, Functor.map_id, comp_id]
+
+@[simp]
+lemma iso_inv_app (a : A) (X : C) :
+    (iso F r hF a).inv.app ((functor r).obj X) =
+      (F.commShiftIso a).inv.app X ≫
+      (lift r F hF).map (((functor r).commShiftIso a).hom.app X) := by
+  dsimp only [iso, natIsoLift]
+  rw [natTransLift_app]
+  dsimp
+  erw [id_comp, comp_id, comp_id, comp_id, Functor.map_id, id_comp]
+
+attribute [irreducible] iso
+
+end LiftCommShift
+
+/-- When `r : HomRel C` is compatible with the shift by an additive monoid, and
+`F : C ⥤ D` is a functor which commutes with the shift and is compatible with `r`, then
+the induced functor `Quotient.lift r F _ : Quotient r ⥤ D` also commutes with the shift. -/
+noncomputable instance liftCommShift :
+    (Quotient.lift r F hF).CommShift A where
+  iso := LiftCommShift.iso F r hF
+  zero := by
+    ext1
+    apply natTrans_ext
+    ext X
+    dsimp
+    rw [LiftCommShift.iso_hom_app, (functor r).commShiftIso_zero,
+      Functor.CommShift.isoZero_hom_app, Functor.CommShift.isoZero_inv_app,
+      Functor.map_comp, assoc, F.commShiftIso_zero, Functor.CommShift.isoZero_hom_app,
+      lift_map_functor_map, ← F.map_comp_assoc, Iso.inv_hom_id_app]
+    dsimp [lift_obj_functor_obj]
+    rw [F.map_id, id_comp]
+  add a b := by
+    ext1
+    apply natTrans_ext
+    ext X
+    dsimp
+    rw [LiftCommShift.iso_hom_app, (functor r).commShiftIso_add, F.commShiftIso_add,
+      Functor.CommShift.isoAdd_hom_app, Functor.CommShift.isoAdd_hom_app,
+      Functor.CommShift.isoAdd_inv_app, Functor.map_comp, Functor.map_comp,
+      Functor.map_comp, assoc, assoc, assoc, LiftCommShift.iso_hom_app, lift_map_functor_map]
+    congr 1
+    rw [← cancel_epi ((shiftFunctor (Quotient r) b ⋙ lift r F hF).map
+      (NatTrans.app (Functor.commShiftIso (functor r) a).hom X))]
+    erw [(LiftCommShift.iso F r hF b).hom.naturality_assoc
+      (((functor r).commShiftIso a).hom.app X), LiftCommShift.iso_hom_app,
+      ← Functor.map_comp_assoc, Iso.hom_inv_id_app]
+    dsimp
+    simp only [Functor.comp_obj, assoc, ← Functor.map_comp_assoc, Iso.inv_hom_id_app,
+      Functor.map_id, id_comp, Iso.hom_inv_id_app, lift_obj_functor_obj]
+
+instance liftCommShift_compatibility :
+    NatTrans.CommShift (Quotient.lift.isLift r F hF).hom A where
+  comm' a := by
+    ext X
+    dsimp
+    erw [Functor.map_id, id_comp, comp_id]
+    rw [Functor.commShiftIso_comp_hom_app]
+    erw [LiftCommShift.iso_hom_app]
+    rw [← Functor.map_comp_assoc, Iso.hom_inv_id_app, Functor.map_id, id_comp]
+
+end Quotient
 
 end CategoryTheory


### PR DESCRIPTION
When a relation on morphisms `r : HomRel C` is compatible with the shift by an additive monoid, and `F : C ⥤ D` is a functor which commutes with the shift and is compatible with `r`, then the induced functor `Quotient.lift r F _ : Quotient r ⥤ D` also commutes with the shift.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
