### PR TITLE
chore: make index of column/row matrix an optParam

### DIFF
--- a/Mathlib/Data/Matrix/RowCol.lean
+++ b/Mathlib/Data/Matrix/RowCol.lean
@@ -31,13 +31,13 @@ namespace Matrix
 
 To get a column matrix with exactly one column, `Matrix.col (Fin 1) u` is the canonical choice.
 -/
-def col (ι : Type*) (w : m → α) : Matrix m ι α :=
+def col (ι : Type := Fin 1) (w : m → α) : Matrix m ι α :=
   of fun x _ => w x
 #align matrix.col Matrix.col
 
 -- TODO: set as an equation lemma for `col`, see mathlib4#3024
 @[simp]
-theorem col_apply {ι : Type*} (w : m → α) (i) (j : ι) : col ι w i j = w i :=
+theorem col_apply {ι : Type} (w : m → α) (i) (j : ι) : col ι w i j = w i :=
   rfl
 #align matrix.col_apply Matrix.col_apply
 
@@ -46,11 +46,11 @@ theorem col_apply {ι : Type*} (w : m → α) (i) (j : ι) : col ι w i j = w i 
 
 To get a row matrix with exactly one row, `Matrix.row (Fin 1) u` is the canonical choice.
 -/
-def row (ι : Type*) (v : n → α) : Matrix ι n α :=
+def row (ι : Type := Fin 1) (v : n → α) : Matrix ι n α :=
   of fun _ y => v y
 #align matrix.row Matrix.row
 
-variable {ι : Type*}
+variable {ι : Type}
 
 -- TODO: set as an equation lemma for `row`, see mathlib4#3024
 @[simp]


### PR DESCRIPTION
This is an experiment if an `optParam` would work too, as having to specify the (unique) col/row index is wee annoying.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
