### PR TITLE
[Merged by Bors] - feat(Data/Prod): add `map_comp_swap`

### DIFF
--- a/Mathlib/Data/Prod/Basic.lean
+++ b/Mathlib/Data/Prod/Basic.lean
@@ -209,7 +209,7 @@ theorem swap_inj {p q : α × β} : swap p = swap q ↔ p = q :=
   swap_injective.eq_iff
 #align prod.swap_inj Prod.swap_inj
 
-/--For two functions `f` and `g` of type `α → α`, the composition of `Prod.map f g` with `Prod.swap`
+/--For two functions `f` and `g`, the composition of `Prod.map f g` with `Prod.swap`
 is equal to the composition of `Prod.swap` with `Prod.map g f`.-/
 theorem map_comp_swap (f : α → β) (g : γ → δ) :
     Prod.map f g ∘ Prod.swap = Prod.swap ∘ Prod.map g f := rfl

--- a/Mathlib/Data/Prod/Basic.lean
+++ b/Mathlib/Data/Prod/Basic.lean
@@ -209,6 +209,8 @@ theorem swap_inj {p q : α × β} : swap p = swap q ↔ p = q :=
   swap_injective.eq_iff
 #align prod.swap_inj Prod.swap_inj
 
+theorem map_comp_swap (f g : α → α) : Prod.map f g ∘ Prod.swap = Prod.swap ∘ Prod.map g f := rfl
+
 theorem eq_iff_fst_eq_snd_eq : ∀ {p q : α × β}, p = q ↔ p.1 = q.1 ∧ p.2 = q.2
   | ⟨p₁, p₂⟩, ⟨q₁, q₂⟩ => by simp
 #align prod.eq_iff_fst_eq_snd_eq Prod.eq_iff_fst_eq_snd_eq

--- a/Mathlib/Data/Prod/Basic.lean
+++ b/Mathlib/Data/Prod/Basic.lean
@@ -209,6 +209,8 @@ theorem swap_inj {p q : α × β} : swap p = swap q ↔ p = q :=
   swap_injective.eq_iff
 #align prod.swap_inj Prod.swap_inj
 
+/--For two functions `f` and `g` of type `α → α`, the composition of `Prod.map f g` with `Prod.swap`
+is equal to the composition of `Prod.swap` with `Prod.map g f`.-/
 theorem map_comp_swap (f g : α → α) : Prod.map f g ∘ Prod.swap = Prod.swap ∘ Prod.map g f := rfl
 
 theorem eq_iff_fst_eq_snd_eq : ∀ {p q : α × β}, p = q ↔ p.1 = q.1 ∧ p.2 = q.2

--- a/Mathlib/Data/Prod/Basic.lean
+++ b/Mathlib/Data/Prod/Basic.lean
@@ -211,7 +211,8 @@ theorem swap_inj {p q : α × β} : swap p = swap q ↔ p = q :=
 
 /--For two functions `f` and `g` of type `α → α`, the composition of `Prod.map f g` with `Prod.swap`
 is equal to the composition of `Prod.swap` with `Prod.map g f`.-/
-theorem map_comp_swap (f g : α → α) : Prod.map f g ∘ Prod.swap = Prod.swap ∘ Prod.map g f := rfl
+theorem map_comp_swap (f : α → β) (g : γ → δ) :
+    Prod.map f g ∘ Prod.swap = Prod.swap ∘ Prod.map g f := rfl
 
 theorem eq_iff_fst_eq_snd_eq : ∀ {p q : α × β}, p = q ↔ p.1 = q.1 ∧ p.2 = q.2
   | ⟨p₁, p₂⟩, ⟨q₁, q₂⟩ => by simp


### PR DESCRIPTION
This PR adds theorem `Prod. map_comp_swap` stating that for two functions `f` and `g` of type `α → α`, the composition of `Prod.map f g` with `Prod.swap` is equal to the composition of `Prod.swap` with `Prod.map g f`.

Co-authored-by: @D-Thomine 

---

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
