### PR TITLE
[Merged by Bors] - feat(Data/Real/EReal): add simp theorems involving the sum of `⊤` and `x`

### DIFF
--- a/Mathlib/Data/Real/EReal.lean
+++ b/Mathlib/Data/Real/EReal.lean
@@ -808,10 +808,22 @@ theorem top_add_of_ne_bot {x : EReal} (h : x ≠ ⊥) : ⊤ + x = ⊤ := by
   · exact top_add_coe _
   · exact top_add_top
 
+/--For any extended real number `x`, the sum of `⊤` and `x` is equal to `⊤`
+if and only if `x` is not `⊥`.-/
+@[simp]
+theorem top_add_iff_ne_bot {x : EReal} : ⊤ + x = ⊤ ↔ x ≠ ⊥ := by
+  sorry
+
 /--For any extended real number `x` which is not `⊥`, the sum of `x` and `⊤` is equal to `⊤`.-/
 @[simp]
 theorem add_top_of_ne_bot {x : EReal} (h : x ≠ ⊥) : x + ⊤ = ⊤ := by
   rw [add_comm, top_add_of_ne_bot h]
+
+/--For any extended real number `x`, the sum of `x` and `⊤` is equal to `⊤`
+if and only if `x` is not `⊥`.-/
+@[simp]
+theorem add_top_iff_ne_bot {x : EReal} : x + ⊤ = ⊤ ↔ x ≠ ⊥ := by
+  sorry
 
 /--For any two extended real numbers `a` and `b`, if both `a` and `b` are greater than `0`,
 then their sum is also greater than `0`.-/
@@ -1106,6 +1118,16 @@ theorem top_mul_of_pos {x : EReal} (h : 0 < x) : ⊤ * x = ⊤ := by
   rw [EReal.mul_comm]
   exact mul_top_of_pos h
 #align ereal.top_mul_of_pos EReal.top_mul_of_pos
+
+/--The product of two positive extended real numbers is positive.-/
+theorem mul_pos {a b : EReal} (ha : 0 < a) (hb : 0 < b) : 0 < a * b := by
+  induction' a using EReal.rec with a
+  · exfalso; exact not_lt_bot ha
+  · induction' b using EReal.rec with b
+    · exfalso; exact not_lt_bot hb
+    · norm_cast at *; exact Left.mul_pos ha hb
+    · rw [EReal.mul_comm, top_mul_of_pos ha]; exact hb
+  · rw [top_mul_of_pos hb]; exact ha
 
 theorem top_mul_of_neg {x : EReal} (h : x < 0) : ⊤ * x = ⊥ := by
   rw [EReal.mul_comm]

--- a/Mathlib/Data/Real/EReal.lean
+++ b/Mathlib/Data/Real/EReal.lean
@@ -800,7 +800,7 @@ theorem top_add_coe (x : ℝ) : (⊤ : EReal) + x = ⊤ :=
   rfl
 #align ereal.top_add_coe EReal.top_add_coe
 
-/--For any extended real number `x` which is not `⊥`, the sum of `⊤` and `x` is equal to `⊤`.-/
+/-- For any extended real number `x` which is not `⊥`, the sum of `⊤` and `x` is equal to `⊤`. -/
 @[simp]
 theorem top_add_of_ne_bot {x : EReal} (h : x ≠ ⊥) : ⊤ + x = ⊤ := by
   induction x using EReal.rec

--- a/Mathlib/Data/Real/EReal.lean
+++ b/Mathlib/Data/Real/EReal.lean
@@ -837,8 +837,8 @@ theorem add_top_iff_ne_bot {x : EReal} : x + ⊤ = ⊤ ↔ x ≠ ⊥ := by
     case h_top => rfl
     case h_real r => exact top_add_of_ne_bot h
 
-/--For any two extended real numbers `a` and `b`, if both `a` and `b` are greater than `0`,
-then their sum is also greater than `0`.-/
+/-- For any two extended real numbers `a` and `b`, if both `a` and `b` are greater than `0`,
+then their sum is also greater than `0`. -/
 @[simp]
 theorem add_pos {a b : EReal} (ha : 0 < a) (hb : 0 < b) : 0 < a + b := by
   induction a using EReal.rec

--- a/Mathlib/Data/Real/EReal.lean
+++ b/Mathlib/Data/Real/EReal.lean
@@ -1131,7 +1131,7 @@ theorem top_mul_of_pos {x : EReal} (h : 0 < x) : ⊤ * x = ⊤ := by
   exact mul_top_of_pos h
 #align ereal.top_mul_of_pos EReal.top_mul_of_pos
 
-/--The product of two positive extended real numbers is positive.-/
+/-- The product of two positive extended real numbers is positive. -/
 @[simp]
 theorem mul_pos {a b : EReal} (ha : 0 < a) (hb : 0 < b) : 0 < a * b := by
   induction' a using EReal.rec with a

--- a/Mathlib/Data/Real/EReal.lean
+++ b/Mathlib/Data/Real/EReal.lean
@@ -810,7 +810,6 @@ theorem top_add_of_ne_bot {x : EReal} (h : x ≠ ⊥) : ⊤ + x = ⊤ := by
 
 /--For any extended real number `x`, the sum of `⊤` and `x` is equal to `⊤`
 if and only if `x` is not `⊥`.-/
-@[simp]
 theorem top_add_iff_ne_bot {x : EReal} : ⊤ + x = ⊤ ↔ x ≠ ⊥ := by
   constructor <;> intro h
   · by_contra h'
@@ -828,7 +827,6 @@ theorem add_top_of_ne_bot {x : EReal} (h : x ≠ ⊥) : x + ⊤ = ⊤ := by
 
 /--For any extended real number `x`, the sum of `x` and `⊤` is equal to `⊤`
 if and only if `x` is not `⊥`.-/
-@[simp]
 theorem add_top_iff_ne_bot {x : EReal} : x + ⊤ = ⊤ ↔ x ≠ ⊥ := by
   constructor <;> intro h
   · by_contra h'
@@ -1134,6 +1132,7 @@ theorem top_mul_of_pos {x : EReal} (h : 0 < x) : ⊤ * x = ⊤ := by
 #align ereal.top_mul_of_pos EReal.top_mul_of_pos
 
 /--The product of two positive extended real numbers is positive.-/
+@[simp]
 theorem mul_pos {a b : EReal} (ha : 0 < a) (hb : 0 < b) : 0 < a * b := by
   induction' a using EReal.rec with a
   · exfalso; exact not_lt_bot ha

--- a/Mathlib/Data/Real/EReal.lean
+++ b/Mathlib/Data/Real/EReal.lean
@@ -823,7 +823,15 @@ theorem add_top_of_ne_bot {x : EReal} (h : x ≠ ⊥) : x + ⊤ = ⊤ := by
 if and only if `x` is not `⊥`.-/
 @[simp]
 theorem add_top_iff_ne_bot {x : EReal} : x + ⊤ = ⊤ ↔ x ≠ ⊥ := by
-  sorry
+  -- Split the proof into two directions: (→) and (←)
+  constructor <;> intro h
+  · by_contra h'
+    rw [h', bot_add] at h
+    exact bot_ne_top h
+  · cases x
+    case h_bot => contradiction
+    case h_top => rfl
+    case h_real r => exact top_add_of_ne_bot h
 
 /--For any two extended real numbers `a` and `b`, if both `a` and `b` are greater than `0`,
 then their sum is also greater than `0`.-/

--- a/Mathlib/Data/Real/EReal.lean
+++ b/Mathlib/Data/Real/EReal.lean
@@ -808,8 +808,8 @@ theorem top_add_of_ne_bot {x : EReal} (h : x ≠ ⊥) : ⊤ + x = ⊤ := by
   · exact top_add_coe _
   · exact top_add_top
 
-/--For any extended real number `x`, the sum of `⊤` and `x` is equal to `⊤`
-if and only if `x` is not `⊥`.-/
+/-- For any extended real number `x`, the sum of `⊤` and `x` is equal to `⊤`
+if and only if `x` is not `⊥`. -/
 theorem top_add_iff_ne_bot {x : EReal} : ⊤ + x = ⊤ ↔ x ≠ ⊥ := by
   constructor <;> intro h
   · by_contra h'

--- a/Mathlib/Data/Real/EReal.lean
+++ b/Mathlib/Data/Real/EReal.lean
@@ -825,8 +825,8 @@ theorem top_add_iff_ne_bot {x : EReal} : ⊤ + x = ⊤ ↔ x ≠ ⊥ := by
 theorem add_top_of_ne_bot {x : EReal} (h : x ≠ ⊥) : x + ⊤ = ⊤ := by
   rw [add_comm, top_add_of_ne_bot h]
 
-/--For any extended real number `x`, the sum of `x` and `⊤` is equal to `⊤`
-if and only if `x` is not `⊥`.-/
+/-- For any extended real number `x`, the sum of `x` and `⊤` is equal to `⊤`
+if and only if `x` is not `⊥`. -/
 theorem add_top_iff_ne_bot {x : EReal} : x + ⊤ = ⊤ ↔ x ≠ ⊥ := by
   constructor <;> intro h
   · by_contra h'

--- a/Mathlib/Data/Real/EReal.lean
+++ b/Mathlib/Data/Real/EReal.lean
@@ -1123,7 +1123,6 @@ theorem top_mul_of_pos {x : EReal} (h : 0 < x) : ⊤ * x = ⊤ := by
 #align ereal.top_mul_of_pos EReal.top_mul_of_pos
 
 /-- The product of two positive extended real numbers is positive. -/
-@[simp]
 theorem mul_pos {a b : EReal} (ha : 0 < a) (hb : 0 < b) : 0 < a * b := by
   induction' a using EReal.rec with a
   · exfalso; exact not_lt_bot ha

--- a/Mathlib/Data/Real/EReal.lean
+++ b/Mathlib/Data/Real/EReal.lean
@@ -812,7 +812,14 @@ theorem top_add_of_ne_bot {x : EReal} (h : x ≠ ⊥) : ⊤ + x = ⊤ := by
 if and only if `x` is not `⊥`.-/
 @[simp]
 theorem top_add_iff_ne_bot {x : EReal} : ⊤ + x = ⊤ ↔ x ≠ ⊥ := by
-  sorry
+  constructor <;> intro h
+  · by_contra h'
+    rw [h', add_bot] at h
+    exact bot_ne_top h
+  · cases x
+    case h_bot => contradiction
+    case h_top => rfl
+    case h_real r => exact top_add_of_ne_bot h
 
 /--For any extended real number `x` which is not `⊥`, the sum of `x` and `⊤` is equal to `⊤`.-/
 @[simp]
@@ -823,7 +830,6 @@ theorem add_top_of_ne_bot {x : EReal} (h : x ≠ ⊥) : x + ⊤ = ⊤ := by
 if and only if `x` is not `⊥`.-/
 @[simp]
 theorem add_top_iff_ne_bot {x : EReal} : x + ⊤ = ⊤ ↔ x ≠ ⊥ := by
-  -- Split the proof into two directions: (→) and (←)
   constructor <;> intro h
   · by_contra h'
     rw [h', bot_add] at h

--- a/Mathlib/Data/Real/EReal.lean
+++ b/Mathlib/Data/Real/EReal.lean
@@ -808,6 +808,11 @@ theorem top_add_ne_bot {x : EReal} (h : x ≠ ⊥) : ⊤ + x = ⊤ := by
   · exact top_add_coe _
   · exact top_add_top
 
+/--For any extended real number `x` which is not `⊥`, the sum of `x` and `⊤` is equal to `⊤`.-/
+@[simp]
+theorem ne_bot_add_top {x : EReal} (h : x ≠ ⊥) : x + ⊤ = ⊤ := by
+  rw [add_comm, top_add_ne_bot h]
+
 @[simp]
 theorem coe_add_top (x : ℝ) : (x : EReal) + ⊤ = ⊤ :=
   rfl

--- a/Mathlib/Data/Real/EReal.lean
+++ b/Mathlib/Data/Real/EReal.lean
@@ -800,6 +800,14 @@ theorem top_add_coe (x : ℝ) : (⊤ : EReal) + x = ⊤ :=
   rfl
 #align ereal.top_add_coe EReal.top_add_coe
 
+/--For any extended real number `x` which is not `⊥`, the sum of `⊤` and `x` is equal to `⊤`.-/
+@[simp]
+theorem top_add_ne_bot {x : EReal} (h : x ≠ ⊥) : ⊤ + x = ⊤ := by
+  induction x using EReal.rec
+  · exfalso; exact h (Eq.refl ⊥)
+  · exact top_add_coe _
+  · exact top_add_top
+
 @[simp]
 theorem coe_add_top (x : ℝ) : (x : EReal) + ⊤ = ⊤ :=
   rfl

--- a/Mathlib/Data/Real/EReal.lean
+++ b/Mathlib/Data/Real/EReal.lean
@@ -820,7 +820,7 @@ theorem top_add_iff_ne_bot {x : EReal} : ⊤ + x = ⊤ ↔ x ≠ ⊥ := by
     case h_top => rfl
     case h_real r => exact top_add_of_ne_bot h
 
-/--For any extended real number `x` which is not `⊥`, the sum of `x` and `⊤` is equal to `⊤`.-/
+/-- For any extended real number `x` which is not `⊥`, the sum of `x` and `⊤` is equal to `⊤`. -/
 @[simp]
 theorem add_top_of_ne_bot {x : EReal} (h : x ≠ ⊥) : x + ⊤ = ⊤ := by
   rw [add_comm, top_add_of_ne_bot h]

--- a/Mathlib/Data/Real/EReal.lean
+++ b/Mathlib/Data/Real/EReal.lean
@@ -827,27 +827,18 @@ theorem add_top_of_ne_bot {x : EReal} (h : x ≠ ⊥) : x + ⊤ = ⊤ := by
 
 /-- For any extended real number `x`, the sum of `x` and `⊤` is equal to `⊤`
 if and only if `x` is not `⊥`. -/
-theorem add_top_iff_ne_bot {x : EReal} : x + ⊤ = ⊤ ↔ x ≠ ⊥ := by
-  constructor <;> intro h
-  · by_contra h'
-    rw [h', bot_add] at h
-    exact bot_ne_top h
-  · cases x
-    case h_bot => contradiction
-    case h_top => rfl
-    case h_real r => exact top_add_of_ne_bot h
+theorem add_top_iff_ne_bot {x : EReal} : x + ⊤ = ⊤ ↔ x ≠ ⊥ := by rw [add_comm, top_add_iff_ne_bot]
 
 /-- For any two extended real numbers `a` and `b`, if both `a` and `b` are greater than `0`,
 then their sum is also greater than `0`. -/
-@[simp]
 theorem add_pos {a b : EReal} (ha : 0 < a) (hb : 0 < b) : 0 < a + b := by
   induction a using EReal.rec
   · exfalso; exact not_lt_bot ha
   · induction b using EReal.rec
     · exfalso; exact not_lt_bot hb
     · norm_cast at *; exact Left.add_pos ha hb
-    · exact add_top_of_ne_bot (Ne.symm (ne_of_lt (lt_trans bot_lt_zero ha))) ▸ hb
-  · rw [top_add_of_ne_bot (Ne.symm (ne_of_lt (lt_trans bot_lt_zero hb)))]
+    · exact add_top_of_ne_bot (bot_lt_zero.trans ha).ne' ▸ hb
+  · rw [top_add_of_ne_bot (bot_lt_zero.trans hb).ne']
     exact ha
 
 @[simp]

--- a/Mathlib/Data/Real/EReal.lean
+++ b/Mathlib/Data/Real/EReal.lean
@@ -802,7 +802,7 @@ theorem top_add_coe (x : ℝ) : (⊤ : EReal) + x = ⊤ :=
 
 /--For any extended real number `x` which is not `⊥`, the sum of `⊤` and `x` is equal to `⊤`.-/
 @[simp]
-theorem top_add_ne_bot {x : EReal} (h : x ≠ ⊥) : ⊤ + x = ⊤ := by
+theorem top_add_of_ne_bot {x : EReal} (h : x ≠ ⊥) : ⊤ + x = ⊤ := by
   induction x using EReal.rec
   · exfalso; exact h (Eq.refl ⊥)
   · exact top_add_coe _
@@ -810,8 +810,21 @@ theorem top_add_ne_bot {x : EReal} (h : x ≠ ⊥) : ⊤ + x = ⊤ := by
 
 /--For any extended real number `x` which is not `⊥`, the sum of `x` and `⊤` is equal to `⊤`.-/
 @[simp]
-theorem ne_bot_add_top {x : EReal} (h : x ≠ ⊥) : x + ⊤ = ⊤ := by
-  rw [add_comm, top_add_ne_bot h]
+theorem add_top_of_ne_bot {x : EReal} (h : x ≠ ⊥) : x + ⊤ = ⊤ := by
+  rw [add_comm, top_add_of_ne_bot h]
+
+/--For any two extended real numbers `a` and `b`, if both `a` and `b` are greater than `0`,
+then their sum is also greater than `0`.-/
+@[simp]
+theorem add_pos {a b : EReal} (ha : 0 < a) (hb : 0 < b) : 0 < a + b := by
+  induction a using EReal.rec
+  · exfalso; exact not_lt_bot ha
+  · induction b using EReal.rec
+    · exfalso; exact not_lt_bot hb
+    · norm_cast at *; exact Left.add_pos ha hb
+    · exact add_top_of_ne_bot (Ne.symm (ne_of_lt (lt_trans bot_lt_zero ha))) ▸ hb
+  · rw [top_add_of_ne_bot (Ne.symm (ne_of_lt (lt_trans bot_lt_zero hb)))]
+    exact ha
 
 @[simp]
 theorem coe_add_top (x : ℝ) : (x : EReal) + ⊤ = ⊤ :=


### PR DESCRIPTION
- [x] Add the theorem `top_add_of_ne_bot` which states that for any extended real number `x` which is not `⊥`, the sum of `⊤` and `x` is equal to `⊤`.
- [x] Add the theorem `add_top_of_ne_bot` which states that for any extended real number `x` which is not `⊥`, the sum of `x` and `⊤` is equal to `⊤`.
- [x]  Add the theorem `add_pos` which states that for any two extended real numbers `a` and `b`, if both `a` and `b` are greater than `0`, then their sum is also greater than `0`.
- [x] Add the theorem `mul_pos` which states that the product of two positive extended real numbers is positive. 
- [x] Add the theorem `add_top_iff_ne_bot` which states that for any extended real number `x`, the sum of `x` and `⊤` is equal to `⊤` if and only if `x` is not `⊥`.
- [x] Add the theorem `top_add_iff_ne_bot` which states that for any extended real number `x`, the sum of `⊤` and `x` is equal to `⊤` if and only if `x` is not `⊥`.
 
Co-authored-by: @D-Thomine 

-- 

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
