### PR TITLE
[Merged by Bors] - chore: update update_dependencies failure bot

### DIFF
--- a/.github/workflows/update_dependencies_zulip.yml
+++ b/.github/workflows/update_dependencies_zulip.yml
@@ -4,7 +4,7 @@ name: Monitor Dependency Update Failures
 
 on:
   workflow_run:
-    workflows: ["Update Mathlib Dependencies"]
+    workflows: ["continuous integration"]
     types:
       - completed
 


### PR DESCRIPTION
Was triggering on the wrong workflow.