### PR TITLE
[Merged by Bors] - Expand documentation slightly

### DIFF
--- a/Mathlib/Analysis/Complex/Basic.lean
+++ b/Mathlib/Analysis/Complex/Basic.lean
@@ -13,26 +13,29 @@ import Mathlib.Topology.Instances.RealVectorSpace
 #align_import analysis.complex.basic from "leanprover-community/mathlib"@"3f655f5297b030a87d641ad4e825af8d9679eb0b"
 
 /-!
+
 # Normed space structure on `ℂ`.
 
-This file gathers basic facts on complex numbers of an analytic nature.
+This file gathers basic facts of analytic nature on the complex numbers.
 
 ## Main results
 
-This file registers `ℂ` as a normed field, expresses basic properties of the norm, and gives
-tools on the real vector space structure of `ℂ`. Notably, in the namespace `Complex`,
-it defines functions:
+This file registers `ℂ` as a normed field, expresses basic properties of the norm, and gives tools
+on the real vector space structure of `ℂ`. Notably, it defines the following functions in the
+namespace `Complex`.
 
-* `reCLM`
-* `imCLM`
-* `ofRealCLM`
-* `conjCLE`
-
-They are bundled versions of the real part, the imaginary part, the embedding of `ℝ` in `ℂ`, and
-the complex conjugate as continuous `ℝ`-linear maps. The last two are also bundled as linear
-isometries in `ofRealLI` and `conjLIE`.
+|Name              |Type         |Description                                             |
+|------------------|-------------|--------------------------------------------------------|
+|`equivRealProdCLM`|ℂ ≃L[ℝ] ℝ × ℝ|The natural `ContinuousLinearEquiv` from `ℂ` to `ℝ × ℝ` |
+|`reCLM`           |ℂ →L[ℝ] ℝ    |Real part function as a `ContinuousLinearMap`           |
+|`imCLM`           |ℂ →L[ℝ] ℝ    |Imaginary part function as a `ContinuousLinearMap`      |
+|`ofRealCLM`       |ℝ →L[ℝ] ℂ    |Embedding of the reals as a `ContinuousLinearMap`       |
+|`ofRealLI`        |ℝ →ₗᵢ[ℝ] ℂ   |Complex conjugation as a `LinearIsometry`               |
+|`conjCLE`         |ℂ ≃L[ℝ] ℂ    |Complex conjugation as a `ContinuousLinearEquiv`        |
+|`conjLIE`         |ℂ ≃ₗᵢ[ℝ] ℂ   |Complex conjugation as a `LinearIsometryEquiv`          |
 
 We also register the fact that `ℂ` is an `RCLike` field.
+
 -/
 
 


### PR DESCRIPTION
doc: Minor improvement

Mention equivRealProdCLM (=The natural continuous linear equiv from ℂ to ℝ × ℝ) prominently in the list of functions defined in Analysis/Complex/Basic.lean. For a better overview, list the functions in a table rather than a bullet point list.

---
[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
