### PR TITLE
[Merged by Bors] - fix: rename `orderOf_mk` to `Prod.orderOf_mk`

### DIFF
--- a/Mathlib/GroupTheory/OrderOfElement.lean
+++ b/Mathlib/GroupTheory/OrderOfElement.lean
@@ -1304,7 +1304,7 @@ theorem IsOfFinOrder.prod_mk : IsOfFinOrder a → IsOfFinOrder b → IsOfFinOrde
 #align is_of_fin_add_order.prod_mk IsOfFinAddOrder.prod_mk
 
 @[to_additive]
-lemma orderOf_mk {a : α} {b : β} : orderOf (a, b) = Nat.lcm (orderOf a) (orderOf b) :=
+lemma Prod.orderOf_mk : orderOf (a, b) = Nat.lcm (orderOf a) (orderOf b) :=
   (a, b).orderOf
 
 end Prod


### PR DESCRIPTION
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

I had somehow misread `section Prod` as `namespace Prod` and missed the namespace in the name of the lemma (#14104). Apologies.

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)