### PR TITLE
[Merged by Bors] - chore: deprecate AlgHom.map_* lemmas

### DIFF
--- a/Mathlib/Algebra/Algebra/Bilinear.lean
+++ b/Mathlib/Algebra/Algebra/Bilinear.lean
@@ -234,7 +234,7 @@ theorem mulRight_one : mulRight R (1 : A) = LinearMap.id := by
 
 @[simp]
 theorem pow_mulLeft (a : A) (n : ℕ) : mulLeft R a ^ n = mulLeft R (a ^ n) := by
-  simpa only [mulLeft, ← Algebra.coe_lmul_eq_mul] using ((Algebra.lmul R A).map_pow a n).symm
+  simpa only [mulLeft, ← Algebra.coe_lmul_eq_mul] using (map_pow (Algebra.lmul R A) a n).symm
 #align linear_map.pow_mul_left LinearMap.pow_mulLeft
 
 @[simp]

--- a/Mathlib/Algebra/Algebra/Hom.lean
+++ b/Mathlib/Algebra/Algebra/Hom.lean
@@ -235,36 +235,44 @@ theorem comp_algebraMap : (φ : A →+* B).comp (algebraMap R A) = algebraMap R 
   RingHom.ext <| φ.commutes
 #align alg_hom.comp_algebra_map AlgHom.comp_algebraMap
 
+@[deprecated map_add (since := "2024-06-26")]
 protected theorem map_add (r s : A) : φ (r + s) = φ r + φ s :=
   map_add _ _ _
 #align alg_hom.map_add AlgHom.map_add
 
+@[deprecated map_zero (since := "2024-06-26")]
 protected theorem map_zero : φ 0 = 0 :=
   map_zero _
 #align alg_hom.map_zero AlgHom.map_zero
 
+@[deprecated map_mul (since := "2024-06-26")]
 protected theorem map_mul (x y) : φ (x * y) = φ x * φ y :=
   map_mul _ _ _
 #align alg_hom.map_mul AlgHom.map_mul
 
+@[deprecated map_one (since := "2024-06-26")]
 protected theorem map_one : φ 1 = 1 :=
   map_one _
 #align alg_hom.map_one AlgHom.map_one
 
+@[deprecated map_pow (since := "2024-06-26")]
 protected theorem map_pow (x : A) (n : ℕ) : φ (x ^ n) = φ x ^ n :=
   map_pow _ _ _
 #align alg_hom.map_pow AlgHom.map_pow
 
 -- @[simp] -- Porting note (#10618): simp can prove this
+@[deprecated map_smul (since := "2024-06-26")]
 protected theorem map_smul (r : R) (x : A) : φ (r • x) = r • φ x :=
   map_smul _ _ _
 #align alg_hom.map_smul AlgHom.map_smul
 
+@[deprecated map_sum (since := "2024-06-26")]
 protected theorem map_sum {ι : Type*} (f : ι → A) (s : Finset ι) :
     φ (∑ x ∈ s, f x) = ∑ x ∈ s, φ (f x) :=
   map_sum _ _ _
 #align alg_hom.map_sum AlgHom.map_sum
 
+@[deprecated map_finsupp_sum (since := "2024-06-26")]
 protected theorem map_finsupp_sum {α : Type*} [Zero α] {ι : Type*} (f : ι →₀ α) (g : ι → α → A) :
     φ (f.sum g) = f.sum fun i a => φ (g i a) :=
   map_finsupp_sum _ _ _
@@ -409,7 +417,8 @@ theorem map_smul_of_tower {R'} [SMul R' A] [SMul R' B] [LinearMap.CompatibleSMul
   φ.toLinearMap.map_smul_of_tower r x
 #align alg_hom.map_smul_of_tower AlgHom.map_smul_of_tower
 
-nonrec theorem map_list_prod (s : List A) : φ s.prod = (s.map φ).prod :=
+@[deprecated map_list_prod (since := "2024-06-26")]
+protected theorem map_list_prod (s : List A) : φ s.prod = (s.map φ).prod :=
   map_list_prod φ s
 #align alg_hom.map_list_prod AlgHom.map_list_prod
 
@@ -444,15 +453,18 @@ section CommSemiring
 variable [CommSemiring R] [CommSemiring A] [CommSemiring B]
 variable [Algebra R A] [Algebra R B] (φ : A →ₐ[R] B)
 
+@[deprecated map_multiset_prod (since := "2024-06-26")]
 protected theorem map_multiset_prod (s : Multiset A) : φ s.prod = (s.map φ).prod :=
   map_multiset_prod _ _
 #align alg_hom.map_multiset_prod AlgHom.map_multiset_prod
 
+@[deprecated map_prod (since := "2024-06-26")]
 protected theorem map_prod {ι : Type*} (f : ι → A) (s : Finset ι) :
     φ (∏ x ∈ s, f x) = ∏ x ∈ s, φ (f x) :=
   map_prod _ _ _
 #align alg_hom.map_prod AlgHom.map_prod
 
+@[deprecated map_finsupp_prod (since := "2024-06-26")]
 protected theorem map_finsupp_prod {α : Type*} [Zero α] {ι : Type*} (f : ι →₀ α) (g : ι → α → A) :
     φ (f.prod g) = f.prod fun i a => φ (g i a) :=
   map_finsupp_prod _ _ _
@@ -465,10 +477,12 @@ section Ring
 variable [CommSemiring R] [Ring A] [Ring B]
 variable [Algebra R A] [Algebra R B] (φ : A →ₐ[R] B)
 
+@[deprecated map_neg (since := "2024-06-26")]
 protected theorem map_neg (x) : φ (-x) = -φ x :=
   map_neg _ _
 #align alg_hom.map_neg AlgHom.map_neg
 
+@[deprecated map_sub (since := "2024-06-26")]
 protected theorem map_sub (x y) : φ (x - y) = φ x - φ y :=
   map_sub _ _ _
 #align alg_hom.map_sub AlgHom.map_sub
@@ -563,8 +577,8 @@ instance : MulDistribMulAction (A →ₐ[R] A) Aˣ where
   smul := fun f => Units.map f
   one_smul := fun x => by ext; rfl
   mul_smul := fun x y z => by ext; rfl
-  smul_mul := fun x y z => by ext; exact x.map_mul _ _
-  smul_one := fun x => by ext; exact x.map_one
+  smul_mul := fun x y z => by ext; exact map_mul _ _ _
+  smul_one := fun x => by ext; exact map_one _
 
 @[simp]
 theorem smul_units_def (f : A →ₐ[R] A) (x : Aˣ) :

--- a/Mathlib/Algebra/Algebra/Subalgebra/Basic.lean
+++ b/Mathlib/Algebra/Algebra/Subalgebra/Basic.lean
@@ -657,9 +657,9 @@ def equalizer (ϕ ψ : A →ₐ[R] B) : Subalgebra R A where
   zero_mem' := by simp only [Set.mem_setOf_eq, map_zero]
   one_mem' := by simp only [Set.mem_setOf_eq, map_one]
   add_mem' {x y} (hx : ϕ x = ψ x) (hy : ϕ y = ψ y) := by
-    rw [Set.mem_setOf_eq, ϕ.map_add, ψ.map_add, hx, hy]
+    rw [Set.mem_setOf_eq, map_add, map_add, hx, hy]
   mul_mem' {x y} (hx : ϕ x = ψ x) (hy : ϕ y = ψ y) := by
-    rw [Set.mem_setOf_eq, ϕ.map_mul, ψ.map_mul, hx, hy]
+    rw [Set.mem_setOf_eq, map_mul, map_mul, hx, hy]
   algebraMap_mem' x := by rw [Set.mem_setOf_eq, AlgHom.commutes, AlgHom.commutes]
 #align alg_hom.equalizer AlgHom.equalizer
 

--- a/Mathlib/Algebra/FreeAlgebra.lean
+++ b/Mathlib/Algebra/FreeAlgebra.lean
@@ -384,12 +384,12 @@ def lift : (X → A) ≃ (FreeAlgebra R X →ₐ[R] A) :=
         let fa : FreeAlgebra R X := Quot.mk (Rel R X) a
         let fb : FreeAlgebra R X := Quot.mk (Rel R X) b
         change liftAux R (F ∘ ι R) (fa + fb) = F (fa + fb)
-        rw [AlgHom.map_add, AlgHom.map_add, ha, hb]
+        rw [map_add, map_add, ha, hb]
       | mul a b ha hb =>
         let fa : FreeAlgebra R X := Quot.mk (Rel R X) a
         let fb : FreeAlgebra R X := Quot.mk (Rel R X) b
         change liftAux R (F ∘ ι R) (fa * fb) = F (fa * fb)
-        rw [AlgHom.map_mul, AlgHom.map_mul, ha, hb] }
+        rw [map_mul, map_mul, ha, hb] }
 #align free_algebra.lift FreeAlgebra.lift
 
 @[simp]

--- a/Mathlib/Algebra/Lie/UniversalEnveloping.lean
+++ b/Mathlib/Algebra/Lie/UniversalEnveloping.lean
@@ -93,7 +93,7 @@ def ι : L →ₗ⁅R⁆ UniversalEnvelopingAlgebra R L :=
   { (mkAlgHom R L).toLinearMap.comp ιₜ with
     map_lie' := fun {x y} => by
       suffices mkAlgHom R L (ιₜ ⁅x, y⁆ + ιₜ y * ιₜ x) = mkAlgHom R L (ιₜ x * ιₜ y) by
-        rw [AlgHom.map_mul] at this; simp [LieRing.of_associative_ring_bracket, ← this]
+        rw [map_mul] at this; simp [LieRing.of_associative_ring_bracket, ← this]
       exact RingQuot.mkAlgHom_rel _ (Rel.lie_compat x y) }
 #align universal_enveloping_algebra.ι UniversalEnvelopingAlgebra.ι
 

--- a/Mathlib/Algebra/Module/LocalizedModule.lean
+++ b/Mathlib/Algebra/Module/LocalizedModule.lean
@@ -1054,7 +1054,7 @@ theorem mk'_mul_mk'_of_map_mul {M M' : Type*} [Semiring M] [Semiring M'] [Module
 theorem mk'_mul_mk' {M M' : Type*} [Semiring M] [Semiring M'] [Algebra R M] [Algebra R M']
     (f : M →ₐ[R] M') [IsLocalizedModule S f.toLinearMap] (m₁ m₂ : M) (s₁ s₂ : S) :
     mk' f.toLinearMap m₁ s₁ * mk' f.toLinearMap m₂ s₂ = mk' f.toLinearMap (m₁ * m₂) (s₁ * s₂) :=
-  mk'_mul_mk'_of_map_mul f.toLinearMap f.map_mul m₁ m₂ s₁ s₂
+  mk'_mul_mk'_of_map_mul f.toLinearMap (map_mul f) m₁ m₂ s₁ s₂
 #align is_localized_module.mk'_mul_mk' IsLocalizedModule.mk'_mul_mk'
 
 variable {f}

--- a/Mathlib/Algebra/MonoidAlgebra/Grading.lean
+++ b/Mathlib/Algebra/MonoidAlgebra/Grading.lean
@@ -169,7 +169,7 @@ theorem decomposeAux_coe {i : ι} (x : gradeBy R f i) :
       rwa [Finsupp.support_single_ne_zero _ hb, Finset.coe_singleton, Set.singleton_subset_iff]
         at h1
     subst this
-    simp only [AlgHom.map_add, Submodule.coe_mk, decomposeAux_single f m]
+    simp only [map_add, Submodule.coe_mk, decomposeAux_single f m]
     let ih' := ih h2
     dsimp at ih'
     rw [ih', ← AddMonoidHom.map_add]

--- a/Mathlib/Algebra/MvPolynomial/Basic.lean
+++ b/Mathlib/Algebra/MvPolynomial/Basic.lean
@@ -1647,13 +1647,13 @@ theorem aeval_eq_zero [Algebra R S₂] (f : σ → S₂) (φ : MvPolynomial σ R
 
 theorem aeval_sum {ι : Type*} (s : Finset ι) (φ : ι → MvPolynomial σ R) :
     aeval f (∑ i ∈ s, φ i) = ∑ i ∈ s, aeval f (φ i) :=
-  (MvPolynomial.aeval f).map_sum _ _
+  map_sum (MvPolynomial.aeval f) _ _
 #align mv_polynomial.aeval_sum MvPolynomial.aeval_sum
 
 @[to_additive existing]
 theorem aeval_prod {ι : Type*} (s : Finset ι) (φ : ι → MvPolynomial σ R) :
     aeval f (∏ i ∈ s, φ i) = ∏ i ∈ s, aeval f (φ i) :=
-  (MvPolynomial.aeval f).map_prod _ _
+  map_prod (MvPolynomial.aeval f) _ _
 #align mv_polynomial.aeval_prod MvPolynomial.aeval_prod
 
 variable (R)

--- a/Mathlib/Algebra/MvPolynomial/Funext.lean
+++ b/Mathlib/Algebra/MvPolynomial/Funext.lean
@@ -51,7 +51,7 @@ theorem funext {σ : Type*} {p q : MvPolynomial σ R} (h : ∀ x : σ → R, eva
   clear h p q
   intro p h
   obtain ⟨n, f, hf, p, rfl⟩ := exists_fin_rename p
-  suffices p = 0 by rw [this, AlgHom.map_zero]
+  suffices p = 0 by rw [this, map_zero]
   apply funext_fin
   intro x
   classical

--- a/Mathlib/Algebra/MvPolynomial/Monad.lean
+++ b/Mathlib/Algebra/MvPolynomial/Monad.lean
@@ -332,8 +332,8 @@ set_option linter.uppercaseLean3 false in
 
 theorem bind₁_monomial (f : σ → MvPolynomial τ R) (d : σ →₀ ℕ) (r : R) :
     bind₁ f (monomial d r) = C r * ∏ i ∈ d.support, f i ^ d i := by
-  simp only [monomial_eq, AlgHom.map_mul, bind₁_C_right, Finsupp.prod, AlgHom.map_prod,
-    AlgHom.map_pow, bind₁_X_right]
+  simp only [monomial_eq, map_mul, bind₁_C_right, Finsupp.prod, map_prod,
+    map_pow, bind₁_X_right]
 #align mv_polynomial.bind₁_monomial MvPolynomial.bind₁_monomial
 
 theorem bind₂_monomial (f : R →+* MvPolynomial σ S) (d : σ →₀ ℕ) (r : R) :
@@ -353,7 +353,7 @@ theorem vars_bind₁ [DecidableEq τ] (f : σ → MvPolynomial τ R) (φ : MvPol
     (bind₁ f φ).vars ⊆ φ.vars.biUnion fun i => (f i).vars := by
   calc (bind₁ f φ).vars
     _ = (φ.support.sum fun x : σ →₀ ℕ => (bind₁ f) (monomial x (coeff x φ))).vars := by
-      rw [← AlgHom.map_sum, ← φ.as_sum]
+      rw [← map_sum, ← φ.as_sum]
     _ ≤ φ.support.biUnion fun i : σ →₀ ℕ => ((bind₁ f) (monomial i (coeff i φ))).vars :=
       (vars_sum_subset _ _)
     _ = φ.support.biUnion fun d : σ →₀ ℕ => vars (C (coeff d φ) * ∏ i ∈ d.support, f i ^ d i) := by

--- a/Mathlib/Algebra/MvPolynomial/Rename.lean
+++ b/Mathlib/Algebra/MvPolynomial/Rename.lean
@@ -68,8 +68,8 @@ theorem map_rename (f : R →+* S) (g : σ → τ) (p : MvPolynomial σ R) :
     map f (rename g p) = rename g (map f p) := by
   apply MvPolynomial.induction_on p
     (fun a => by simp only [map_C, rename_C])
-    (fun p q hp hq => by simp only [hp, hq, AlgHom.map_add, RingHom.map_add]) fun p n hp => by
-    simp only [hp, rename_X, map_X, RingHom.map_mul, AlgHom.map_mul]
+    (fun p q hp hq => by simp only [hp, hq, map_add]) fun p n hp => by
+    simp only [hp, rename_X, map_X, map_mul]
 #align mv_polynomial.map_rename MvPolynomial.map_rename
 
 @[simp]
@@ -236,14 +236,14 @@ theorem exists_finset_rename (p : MvPolynomial σ R) :
     · refine rename (Subtype.map id ?_) p + rename (Subtype.map id ?_) q <;>
         simp (config := { contextual := true }) only [id, true_or_iff, or_true_iff,
           Finset.mem_union, forall_true_iff]
-    · simp only [rename_rename, AlgHom.map_add]
+    · simp only [rename_rename, map_add]
       rfl
   · rintro p n ⟨s, p, rfl⟩
     refine ⟨insert n s, ⟨?_, ?_⟩⟩
     · refine rename (Subtype.map id ?_) p * X ⟨n, s.mem_insert_self n⟩
       simp (config := { contextual := true }) only [id, or_true_iff, Finset.mem_insert,
         forall_true_iff]
-    · simp only [rename_rename, rename_X, Subtype.coe_mk, AlgHom.map_mul]
+    · simp only [rename_rename, rename_X, Subtype.coe_mk, map_mul]
       rfl
 #align mv_polynomial.exists_finset_rename MvPolynomial.exists_finset_rename
 
@@ -284,7 +284,7 @@ end Rename
 theorem eval₂_cast_comp (f : σ → τ) (c : ℤ →+* R) (g : τ → R) (p : MvPolynomial σ ℤ) :
     eval₂ c (g ∘ f) p = eval₂ c g (rename f p) := by
   apply MvPolynomial.induction_on p (fun n => by simp only [eval₂_C, rename_C])
-    (fun p q hp hq => by simp only [hp, hq, rename, eval₂_add, AlgHom.map_add])
+    (fun p q hp hq => by simp only [hp, hq, rename, eval₂_add, map_add])
     fun p n hp => by simp only [eval₂_mul, hp, eval₂_X, comp_apply, map_mul, rename_X, eval₂_mul]
 #align mv_polynomial.eval₂_cast_comp MvPolynomial.eval₂_cast_comp
 
@@ -300,7 +300,7 @@ theorem coeff_rename_mapDomain (f : σ → τ) (hf : Injective f) (φ : MvPolyno
     rw [rename_monomial, coeff_monomial, coeff_monomial]
     simp only [(Finsupp.mapDomain_injective hf).eq_iff]
   · intros
-    simp only [*, AlgHom.map_add, coeff_add]
+    simp only [*, map_add, coeff_add]
 #align mv_polynomial.coeff_rename_map_domain MvPolynomial.coeff_rename_mapDomain
 
 @[simp]
@@ -334,9 +334,9 @@ theorem constantCoeff_rename {τ : Type*} (f : σ → τ) (φ : MvPolynomial σ 
   · intro a
     simp only [constantCoeff_C, rename_C]
   · intro p q hp hq
-    simp only [hp, hq, RingHom.map_add, AlgHom.map_add]
+    simp only [hp, hq, map_add]
   · intro p n hp
-    simp only [hp, rename_X, constantCoeff_X, RingHom.map_mul, AlgHom.map_mul]
+    simp only [hp, rename_X, constantCoeff_X, map_mul]
 #align mv_polynomial.constant_coeff_rename MvPolynomial.constantCoeff_rename
 
 end Coeff

--- a/Mathlib/Algebra/Polynomial/AlgebraMap.lean
+++ b/Mathlib/Algebra/Polynomial/AlgebraMap.lean
@@ -124,7 +124,7 @@ theorem algHom_eval₂_algebraMap {R A B : Type*} [CommSemiring R] [Semiring A] 
     [Algebra R A] [Algebra R B] (p : R[X]) (f : A →ₐ[R] B) (a : A) :
     f (eval₂ (algebraMap R A) a p) = eval₂ (algebraMap R B) (f a) p := by
   simp only [eval₂_eq_sum, sum_def]
-  simp only [f.map_sum, f.map_mul, f.map_pow, eq_intCast, map_intCast, AlgHom.commutes]
+  simp only [map_sum, map_mul, map_pow, eq_intCast, map_intCast, AlgHom.commutes]
 #align polynomial.alg_hom_eval₂_algebra_map Polynomial.algHom_eval₂_algebraMap
 
 @[simp]
@@ -132,7 +132,7 @@ theorem eval₂_algebraMap_X {R A : Type*} [CommSemiring R] [Semiring A] [Algebr
     (f : R[X] →ₐ[R] A) : eval₂ (algebraMap R A) (f X) p = f p := by
   conv_rhs => rw [← Polynomial.sum_C_mul_X_pow_eq p]
   simp only [eval₂_eq_sum, sum_def]
-  simp only [f.map_sum, f.map_mul, f.map_pow, eq_intCast, map_intCast]
+  simp only [map_sum, map_mul, map_pow, eq_intCast, map_intCast]
   simp [Polynomial.C_eq_algebraMap]
 set_option linter.uppercaseLean3 false in
 #align polynomial.eval₂_algebra_map_X Polynomial.eval₂_algebraMap_X
@@ -202,7 +202,7 @@ theorem aeval_def (p : R[X]) : aeval x p = eval₂ (algebraMap R A) x p :=
 
 -- Porting note: removed `@[simp]` because `simp` can prove this
 theorem aeval_zero : aeval x (0 : R[X]) = 0 :=
-  AlgHom.map_zero (aeval x)
+  map_zero (aeval x)
 #align polynomial.aeval_zero Polynomial.aeval_zero
 
 @[simp]
@@ -230,12 +230,12 @@ set_option linter.uppercaseLean3 false in
 
 -- Porting note: removed `@[simp]` because `simp` can prove this
 theorem aeval_add : aeval x (p + q) = aeval x p + aeval x q :=
-  AlgHom.map_add _ _ _
+  map_add _ _ _
 #align polynomial.aeval_add Polynomial.aeval_add
 
 -- Porting note: removed `@[simp]` because `simp` can prove this
 theorem aeval_one : aeval x (1 : R[X]) = 1 :=
-  AlgHom.map_one _
+  map_one _
 #align polynomial.aeval_one Polynomial.aeval_one
 
 #noalign polynomial.aeval_bit0
@@ -250,7 +250,7 @@ theorem aeval_natCast (n : ℕ) : aeval x (n : R[X]) = n :=
 alias aeval_nat_cast := aeval_natCast
 
 theorem aeval_mul : aeval x (p * q) = aeval x p * aeval x q :=
-  AlgHom.map_mul _ _ _
+  map_mul _ _ _
 #align polynomial.aeval_mul Polynomial.aeval_mul
 
 theorem comp_eq_aeval : p.comp q = aeval q p := rfl
@@ -376,7 +376,7 @@ instance instCommSemiringAdjoinSingleton :
   { mul_comm := fun ⟨p, hp⟩ ⟨q, hq⟩ ↦ by
       obtain ⟨p', rfl⟩ := Algebra.adjoin_singleton_eq_range_aeval R x ▸ hp
       obtain ⟨q', rfl⟩ := Algebra.adjoin_singleton_eq_range_aeval R x ▸ hq
-      simp only [AlgHom.toRingHom_eq_coe, RingHom.coe_coe, Submonoid.mk_mul_mk, ← AlgHom.map_mul,
+      simp only [AlgHom.toRingHom_eq_coe, RingHom.coe_coe, Submonoid.mk_mul_mk, ← map_mul,
         mul_comm p' q'] }
 
 instance instCommRingAdjoinSingleton {R A : Type*} [CommRing R] [Ring A] [Algebra R A] (x : A) :

--- a/Mathlib/Algebra/Polynomial/Expand.lean
+++ b/Mathlib/Algebra/Polynomial/Expand.lean
@@ -63,13 +63,13 @@ set_option linter.uppercaseLean3 false in
 
 @[simp]
 theorem expand_monomial (r : R) : expand R p (monomial q r) = monomial (q * p) r := by
-  simp_rw [← smul_X_eq_monomial, AlgHom.map_smul, AlgHom.map_pow, expand_X, mul_comm, pow_mul]
+  simp_rw [← smul_X_eq_monomial, map_smul, map_pow, expand_X, mul_comm, pow_mul]
 #align polynomial.expand_monomial Polynomial.expand_monomial
 
 theorem expand_expand (f : R[X]) : expand R p (expand R q f) = expand R (p * q) f :=
   Polynomial.induction_on f (fun r => by simp_rw [expand_C])
-    (fun f g ihf ihg => by simp_rw [AlgHom.map_add, ihf, ihg]) fun n r _ => by
-    simp_rw [AlgHom.map_mul, expand_C, AlgHom.map_pow, expand_X, AlgHom.map_pow, expand_X, pow_mul]
+    (fun f g ihf ihg => by simp_rw [map_add, ihf, ihg]) fun n r _ => by
+    simp_rw [map_mul, expand_C, map_pow, expand_X, map_pow, expand_X, pow_mul]
 #align polynomial.expand_expand Polynomial.expand_expand
 
 theorem expand_mul (f : R[X]) : expand R (p * q) f = expand R p (expand R q f) :=
@@ -83,8 +83,8 @@ theorem expand_zero (f : R[X]) : expand R 0 f = C (eval 1 f) := by simp [expand]
 @[simp]
 theorem expand_one (f : R[X]) : expand R 1 f = f :=
   Polynomial.induction_on f (fun r => by rw [expand_C])
-    (fun f g ihf ihg => by rw [AlgHom.map_add, ihf, ihg]) fun n r _ => by
-    rw [AlgHom.map_mul, expand_C, AlgHom.map_pow, expand_X, pow_one]
+    (fun f g ihf ihg => by rw [map_add, ihf, ihg]) fun n r _ => by
+    rw [map_mul, expand_C, map_pow, expand_X, pow_one]
 #align polynomial.expand_one Polynomial.expand_one
 
 theorem expand_pow (f : R[X]) : expand R (p ^ q) f = (expand R p)^[q] f :=
@@ -154,7 +154,7 @@ theorem natDegree_expand (p : ℕ) (f : R[X]) : (expand R p f).natDegree = f.nat
   rcases p.eq_zero_or_pos with hp | hp
   · rw [hp, coe_expand, pow_zero, mul_zero, ← C_1, eval₂_hom, natDegree_C]
   by_cases hf : f = 0
-  · rw [hf, AlgHom.map_zero, natDegree_zero, zero_mul]
+  · rw [hf, map_zero, natDegree_zero, zero_mul]
   have hf1 : expand R p f ≠ 0 := mt (expand_eq_zero hp).1 hf
   rw [← WithBot.coe_eq_coe]
   convert (degree_eq_natDegree hf1).symm -- Porting note: was `rw [degree_eq_natDegree hf1]`
@@ -194,14 +194,14 @@ theorem map_expand {p : ℕ} {f : R →+* S} {q : R[X]} :
 @[simp]
 theorem expand_eval (p : ℕ) (P : R[X]) (r : R) : eval r (expand R p P) = eval (r ^ p) P := by
   refine Polynomial.induction_on P (fun a => by simp) (fun f g hf hg => ?_) fun n a _ => by simp
-  rw [AlgHom.map_add, eval_add, eval_add, hf, hg]
+  rw [map_add, eval_add, eval_add, hf, hg]
 #align polynomial.expand_eval Polynomial.expand_eval
 
 @[simp]
 theorem expand_aeval {A : Type*} [Semiring A] [Algebra R A] (p : ℕ) (P : R[X]) (r : A) :
     aeval r (expand R p P) = aeval (r ^ p) P := by
   refine Polynomial.induction_on P (fun a => by simp) (fun f g hf hg => ?_) fun n a _ => by simp
-  rw [AlgHom.map_add, aeval_add, aeval_add, hf, hg]
+  rw [map_add, aeval_add, aeval_add, hf, hg]
 #align polynomial.expand_aeval Polynomial.expand_aeval
 
 /-- The opposite of `expand`: sends `∑ aₙ xⁿᵖ` to `∑ aₙ xⁿ`. -/
@@ -262,7 +262,7 @@ theorem expand_contract' [NoZeroDivisors R] {f : R[X]} (hf : Polynomial.derivati
 
 theorem expand_char (f : R[X]) : map (frobenius R p) (expand R p f) = f ^ p := by
   refine f.induction_on' (fun a b ha hb => ?_) fun n a => ?_
-  · rw [AlgHom.map_add, Polynomial.map_add, ha, hb, add_pow_expChar]
+  · rw [map_add, Polynomial.map_add, ha, hb, add_pow_expChar]
   · rw [expand_monomial, map_monomial, ← C_mul_X_pow_eq_monomial, ← C_mul_X_pow_eq_monomial,
       mul_pow, ← C.map_pow, frobenius_def]
     ring

--- a/Mathlib/Algebra/QuaternionBasis.lean
+++ b/Mathlib/Algebra/QuaternionBasis.lean
@@ -154,12 +154,12 @@ def liftHom : ℍ[R,c₁,c₂] →ₐ[R] A :=
 @[simps i j k]
 def compHom (F : A →ₐ[R] B) : Basis B c₁ c₂ where
   i := F q.i
-  i_mul_i := by rw [← F.map_mul, q.i_mul_i, F.map_smul, F.map_one]
+  i_mul_i := by rw [← map_mul, q.i_mul_i, map_smul, map_one]
   j := F q.j
-  j_mul_j := by rw [← F.map_mul, q.j_mul_j, F.map_smul, F.map_one]
+  j_mul_j := by rw [← map_mul, q.j_mul_j, map_smul, map_one]
   k := F q.k
-  i_mul_j := by rw [← F.map_mul, q.i_mul_j]
-  j_mul_i := by rw [← F.map_mul, q.j_mul_i, F.map_neg]
+  i_mul_j := by rw [← map_mul, q.i_mul_j]
+  j_mul_i := by rw [← map_mul, q.j_mul_i, map_neg]
 #align quaternion_algebra.basis.comp_hom QuaternionAlgebra.Basis.compHom
 
 end Basis
@@ -174,7 +174,7 @@ def lift : Basis A c₁ c₂ ≃ (ℍ[R,c₁,c₂] →ₐ[R] A) where
     ext
     dsimp [Basis.lift]
     rw [← F.commutes]
-    simp only [← F.commutes, ← F.map_smul, ← F.map_add, mk_add_mk, smul_mk, smul_zero,
+    simp only [← F.commutes, ← map_smul, ← map_add, mk_add_mk, smul_mk, smul_zero,
       algebraMap_eq]
     congr <;> simp
 #align quaternion_algebra.lift QuaternionAlgebra.lift

--- a/Mathlib/Algebra/RingQuot.lean
+++ b/Mathlib/Algebra/RingQuot.lean
@@ -614,14 +614,14 @@ irreducible_def preLiftAlgHom {s : A → A → Prop} { f : A →ₐ[S] B }
               | mul_left _ r' => simp only [map_mul, r']
               | mul_right _ r' => simp only [map_mul, r'])
             x.toQuot
-  map_zero' := by simp only [← zero_quot, f.map_zero]
+  map_zero' := by simp only [← zero_quot, map_zero]
   map_add' := by
     rintro ⟨⟨x⟩⟩ ⟨⟨y⟩⟩
-    simp only [add_quot, f.map_add x y]
-  map_one' := by simp only [← one_quot, f.map_one]
+    simp only [add_quot, map_add _ x y]
+  map_one' := by simp only [← one_quot, map_one]
   map_mul' := by
     rintro ⟨⟨x⟩⟩ ⟨⟨y⟩⟩
-    simp only [mul_quot, f.map_mul x y]
+    simp only [mul_quot, map_mul _ x y]
   commutes' := by
     rintro x
     simp [← one_quot, smul_quot, Algebra.algebraMap_eq_smul_one] }

--- a/Mathlib/Algebra/TrivSqZeroExt.lean
+++ b/Mathlib/Algebra/TrivSqZeroExt.lean
@@ -951,7 +951,7 @@ def lift (f : R →ₐ[S] A) (g : M →ₗ[S] A)
         dsimp
         simp only [add_zero, zero_add, add_mul, mul_add, smul_mul_smul, hg, smul_zero,
           op_smul_eq_smul]
-        rw [← AlgHom.map_mul, LinearMap.map_add, add_comm (g _), add_assoc, hfg, hgf])
+        rw [← map_mul, LinearMap.map_add, add_comm (g _), add_assoc, hfg, hgf])
 #align triv_sq_zero_ext.lift_aux TrivSqZeroExt.lift
 
 theorem lift_def (f : R →ₐ[S] A) (g : M →ₗ[S] A)
@@ -1022,9 +1022,9 @@ def liftEquiv :
   invFun F :=
     ⟨(F.comp (inlAlgHom _ _ _), F.toLinearMap ∘ₗ (inrHom _ _ |>.restrictScalars _)),
       (fun _x _y =>
-        (F.map_mul _ _).symm.trans <| (F.congr_arg <| inr_mul_inr _ _ _).trans F.map_zero),
-      (fun _r _x => (F.congr_arg (inl_mul_inr _ _).symm).trans (F.map_mul _ _)),
-      (fun _r _x => (F.congr_arg (inr_mul_inl _ _).symm).trans (F.map_mul _ _))⟩
+        (map_mul F _ _).symm.trans <| (F.congr_arg <| inr_mul_inr _ _ _).trans (map_zero F)),
+      (fun _r _x => (F.congr_arg (inl_mul_inr _ _).symm).trans (map_mul F _ _)),
+      (fun _r _x => (F.congr_arg (inr_mul_inl _ _).symm).trans (map_mul F _ _))⟩
   left_inv _f := Subtype.ext <| Prod.ext (lift_comp_inlHom _ _ _ _ _) (lift_comp_inrHom _ _ _ _ _)
   right_inv _F := algHom_ext' (lift_comp_inlHom _ _ _ _ _) (lift_comp_inrHom _ _ _ _ _)
 

--- a/Mathlib/Analysis/Complex/Polynomial.lean
+++ b/Mathlib/Analysis/Complex/Polynomial.lean
@@ -89,13 +89,13 @@ theorem card_complex_roots_eq_card_real_add_card_not_gal_inv (p : ℚ[X]) :
     simp_rw [b, Finset.mem_image, Set.mem_toFinset, mem_rootSet_of_ne hp]
     constructor
     · rintro ⟨w, hw, rfl⟩
-      exact ⟨by rw [aeval_algHom_apply, hw, AlgHom.map_zero], rfl⟩
+      exact ⟨by rw [aeval_algHom_apply, hw, map_zero], rfl⟩
     · rintro ⟨hz1, hz2⟩
       have key : IsScalarTower.toAlgHom ℚ ℝ ℂ z.re = z := by
         ext
         · rfl
         · rw [hz2]; rfl
-      exact ⟨z.re, inj (by rwa [← aeval_algHom_apply, key, AlgHom.map_zero]), key⟩
+      exact ⟨z.re, inj (by rwa [← aeval_algHom_apply, key, map_zero]), key⟩
   have hc0 :
     ∀ w : p.rootSet ℂ, galActionHom p ℂ (restrict p ℂ (Complex.conjAe.restrictScalars ℚ)) w = w ↔
         w.val.im = 0 := by

--- a/Mathlib/CategoryTheory/Monoidal/Internal/Module.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Internal/Module.lean
@@ -165,7 +165,7 @@ def inverse : AlgebraCat.{u} R ⥤ Mon_ (ModuleCat.{u} R) where
   map f :=
     { hom := f.toLinearMap
       one_hom := LinearMap.ext f.commutes
-      mul_hom := TensorProduct.ext <| LinearMap.ext₂ <| f.map_mul }
+      mul_hom := TensorProduct.ext <| LinearMap.ext₂ <| map_mul f }
 #align Module.Mon_Module_equivalence_Algebra.inverse ModuleCat.MonModuleEquivalenceAlgebra.inverse
 
 end MonModuleEquivalenceAlgebra

--- a/Mathlib/Data/Complex/Module.lean
+++ b/Mathlib/Data/Complex/Module.lean
@@ -125,7 +125,7 @@ theorem _root_.AlgHom.map_coe_real_complex (f : ℂ →ₐ[ℝ] A) (x : ℝ) : f
 @[ext]
 theorem algHom_ext ⦃f g : ℂ →ₐ[ℝ] A⦄ (h : f I = g I) : f = g := by
   ext ⟨x, y⟩
-  simp only [mk_eq_add_mul_I, AlgHom.map_add, AlgHom.map_coe_real_complex, AlgHom.map_mul, h]
+  simp only [mk_eq_add_mul_I, map_add, AlgHom.map_coe_real_complex, map_mul, h]
 #align complex.alg_hom_ext Complex.algHom_ext
 
 end
@@ -344,7 +344,7 @@ This isomorphism is named to match the very similar `Zsqrtd.lift`. -/
 @[simps (config := { simpRhs := true })]
 def lift : { I' : A // I' * I' = -1 } ≃ (ℂ →ₐ[ℝ] A) where
   toFun I' := liftAux I' I'.prop
-  invFun F := ⟨F I, by rw [← F.map_mul, I_mul_I, AlgHom.map_neg, AlgHom.map_one]⟩
+  invFun F := ⟨F I, by rw [← map_mul, I_mul_I, map_neg, map_one]⟩
   left_inv I' := Subtype.ext <| liftAux_apply_I (I' : A) I'.prop
   right_inv F := algHom_ext <| liftAux_apply_I _ _
 #align complex.lift Complex.lift

--- a/Mathlib/Data/Matrix/Basic.lean
+++ b/Mathlib/Data/Matrix/Basic.lean
@@ -1614,7 +1614,7 @@ coefficients. This is `Matrix.map` as an `AlgHom`. -/
 def mapMatrix (f : α →ₐ[R] β) : Matrix m m α →ₐ[R] Matrix m m β :=
   { f.toRingHom.mapMatrix with
     toFun := fun M => M.map f
-    commutes' := fun r => Matrix.map_algebraMap r f f.map_zero (f.commutes r) }
+    commutes' := fun r => Matrix.map_algebraMap r f (map_zero _) (f.commutes r) }
 #align alg_hom.map_matrix AlgHom.mapMatrix
 
 @[simp]

--- a/Mathlib/FieldTheory/AbelRuffini.lean
+++ b/Mathlib/FieldTheory/AbelRuffini.lean
@@ -132,7 +132,7 @@ theorem gal_X_pow_sub_C_isSolvable_aux (n : ℕ) (a : F)
       (c ^ n = 1 → (∃ d, algebraMap F (X ^ n - C a).SplittingField d = c)) := fun {c} hc =>
     RingHom.mem_range.mp (minpoly.mem_range_of_degree_eq_one F c (h.def.resolve_left hn'''
       (minpoly.irreducible ((SplittingField.instNormal (X ^ n - C a)).isIntegral c))
-      (minpoly.dvd F c (by rwa [map_id, AlgHom.map_sub, sub_eq_zero, aeval_X_pow, aeval_one]))))
+      (minpoly.dvd F c (by rwa [map_id, map_sub, sub_eq_zero, aeval_X_pow, aeval_one]))))
   apply isSolvable_of_comm
   intro σ τ
   ext b hb
@@ -349,7 +349,7 @@ theorem induction2 {α β γ : solvableByRad F E} (hγ : γ ∈ F⟮α, β⟯) (
     refine minpoly.eq_of_irreducible_of_monic
       (minpoly.irreducible (isIntegral γ)) ?_ (minpoly.monic (isIntegral γ))
     suffices aeval (⟨γ, hγ⟩ : F⟮α, β⟯) (minpoly F γ) = 0 by
-      rw [aeval_algHom_apply, this, AlgHom.map_zero]
+      rw [aeval_algHom_apply, this, map_zero]
     apply (algebraMap (↥F⟮α, β⟯) (solvableByRad F E)).injective
     simp only [map_zero, _root_.map_eq_zero]
     -- Porting note: end of the proof was `exact minpoly.aeval F γ`.

--- a/Mathlib/FieldTheory/Finite/GaloisField.lean
+++ b/Mathlib/FieldTheory/Finite/GaloisField.lean
@@ -131,14 +131,14 @@ theorem finrank {n} (h : n ≠ 0) : FiniteDimensional.finrank (ZMod p) (GaloisFi
     intro hn
     exact Nat.not_lt_zero 1 (pow_eq_zero hn.symm ▸ hp)
   · simp [g_poly]
-  · simp only [g_poly, aeval_X_pow, aeval_X, AlgHom.map_sub, add_pow_char_pow, sub_eq_zero]
+  · simp only [g_poly, aeval_X_pow, aeval_X, map_sub, add_pow_char_pow, sub_eq_zero]
     intro x y hx hy
     rw [hx, hy]
   · intro x hx
-    simp only [g_poly, sub_eq_zero, aeval_X_pow, aeval_X, AlgHom.map_sub, sub_neg_eq_add] at *
+    simp only [g_poly, sub_eq_zero, aeval_X_pow, aeval_X, map_sub, sub_neg_eq_add] at *
     rw [neg_pow, hx, CharP.neg_one_pow_char_pow]
     simp
-  · simp only [g_poly, aeval_X_pow, aeval_X, AlgHom.map_sub, mul_pow, sub_eq_zero]
+  · simp only [g_poly, aeval_X_pow, aeval_X, map_sub, mul_pow, sub_eq_zero]
     intro x y hx hy
     rw [hx, hy]
 #align galois_field.finrank GaloisField.finrank

--- a/Mathlib/FieldTheory/Finite/Polynomial.lean
+++ b/Mathlib/FieldTheory/Finite/Polynomial.lean
@@ -33,8 +33,8 @@ variable {p : ℕ} [Fact p.Prime]
 theorem frobenius_zmod (f : MvPolynomial σ (ZMod p)) : frobenius _ p f = expand p f := by
   apply induction_on f
   · intro a; rw [expand_C, frobenius_def, ← C_pow, ZMod.pow_card]
-  · simp only [AlgHom.map_add, RingHom.map_add]; intro _ _ hf hg; rw [hf, hg]
-  · simp only [expand_X, RingHom.map_mul, AlgHom.map_mul]
+  · simp only [map_add]; intro _ _ hf hg; rw [hf, hg]
+  · simp only [expand_X, map_mul]
     intro _ _ hf; rw [hf, frobenius_def]
 #align mv_polynomial.frobenius_zmod MvPolynomial.frobenius_zmod
 

--- a/Mathlib/FieldTheory/IsAlgClosed/AlgebraicClosure.lean
+++ b/Mathlib/FieldTheory/IsAlgClosed/AlgebraicClosure.lean
@@ -87,10 +87,10 @@ theorem spanEval_ne_top : spanEval k ≠ ⊤ := by
     Finsupp.mem_span_image_iff_total]
   rintro ⟨v, _, hv⟩
   replace hv := congr_arg (toSplittingField k v.support) hv
-  rw [AlgHom.map_one, Finsupp.total_apply, Finsupp.sum, AlgHom.map_sum, Finset.sum_eq_zero] at hv
+  rw [map_one, Finsupp.total_apply, Finsupp.sum, map_sum, Finset.sum_eq_zero] at hv
   · exact zero_ne_one hv
   intro j hj
-  rw [smul_eq_mul, AlgHom.map_mul, toSplittingField_evalXSelf (s := v.support) hj,
+  rw [smul_eq_mul, map_mul, toSplittingField_evalXSelf (s := v.support) hj,
     mul_zero]
 #align algebraic_closure.span_eval_ne_top AlgebraicClosure.spanEval_ne_top
 

--- a/Mathlib/FieldTheory/IsAlgClosed/Spectrum.lean
+++ b/Mathlib/FieldTheory/IsAlgClosed/Spectrum.lean
@@ -55,10 +55,10 @@ local notation "↑ₐ" => algebraMap R A
 theorem exists_mem_of_not_isUnit_aeval_prod [IsDomain R] {p : R[X]} {a : A}
     (h : ¬IsUnit (aeval a (Multiset.map (fun x : R => X - C x) p.roots).prod)) :
     ∃ k : R, k ∈ σ a ∧ eval k p = 0 := by
-  rw [← Multiset.prod_toList, AlgHom.map_list_prod] at h
+  rw [← Multiset.prod_toList, map_list_prod] at h
   replace h := mt List.prod_isUnit h
   simp only [not_forall, exists_prop, aeval_C, Multiset.mem_toList, List.mem_map, aeval_X,
-    exists_exists_and_eq_and, Multiset.mem_map, AlgHom.map_sub] at h
+    exists_exists_and_eq_and, Multiset.mem_map, map_sub] at h
   rcases h with ⟨r, r_mem, r_nu⟩
   exact ⟨r, by rwa [mem_iff, ← IsUnit.sub_iff], (mem_roots'.1 r_mem).2⟩
 #align spectrum.exists_mem_of_not_is_unit_aeval_prod spectrum.exists_mem_of_not_isUnit_aeval_prodₓ
@@ -84,11 +84,11 @@ theorem subset_polynomial_aeval (a : A) (p : 𝕜[X]) : (eval · p) '' σ a ⊆ 
   have hroot : IsRoot q k := by simp only [q, eval_C, eval_sub, sub_self, IsRoot.def]
   rw [← mul_div_eq_iff_isRoot, ← neg_mul_neg, neg_sub] at hroot
   have aeval_q_eq : ↑ₐ (eval k p) - aeval a p = aeval a q := by
-    simp only [q, aeval_C, AlgHom.map_sub, sub_left_inj]
+    simp only [q, aeval_C, map_sub, sub_left_inj]
   rw [mem_iff, aeval_q_eq, ← hroot, aeval_mul]
   have hcomm := (Commute.all (C k - X) (-(q / (X - C k)))).map (aeval a : 𝕜[X] →ₐ[𝕜] A)
   apply mt fun h => (hcomm.isUnit_mul_iff.mp h).1
-  simpa only [aeval_X, aeval_C, AlgHom.map_sub] using hk
+  simpa only [aeval_X, aeval_C, map_sub] using hk
 #align spectrum.subset_polynomial_aeval spectrum.subset_polynomial_aeval
 
 /-- The *spectral mapping theorem* for polynomials.  Note: the assumption `degree p > 0`
@@ -107,7 +107,7 @@ theorem map_polynomial_aeval_of_degree_pos [IsAlgClosed 𝕜] (a : A) (p : 𝕜[
   /- leading coefficient is a unit so product of linear factors is not a unit;
     apply `exists_mem_of_not_is_unit_aeval_prod`. -/
   have p_a_eq : aeval a (C k - p) = ↑ₐ k - aeval a p := by
-    simp only [aeval_C, AlgHom.map_sub, sub_left_inj]
+    simp only [aeval_C, map_sub, sub_left_inj]
   rw [mem_iff, ← p_a_eq, hprod, aeval_mul,
     ((Commute.all _ _).map (aeval a : 𝕜[X] →ₐ[𝕜] A)).isUnit_mul_iff, aeval_C] at hk
   replace hk := exists_mem_of_not_isUnit_aeval_prod (not_and.mp hk lead_unit)

--- a/Mathlib/FieldTheory/Minpoly/Basic.lean
+++ b/Mathlib/FieldTheory/Minpoly/Basic.lean
@@ -196,7 +196,7 @@ theorem natDegree_pos [Nontrivial B] (hx : IsIntegral A x) : 0 < natDegree (minp
     rw [eq_C_of_natDegree_eq_zero ndeg_eq_zero]
     convert C_1 (R := A)
     simpa only [ndeg_eq_zero.symm] using (monic hx).leadingCoeff
-  simpa only [eq_one, AlgHom.map_one, one_ne_zero] using aeval A x
+  simpa only [eq_one, map_one, one_ne_zero] using aeval A x
 #align minpoly.nat_degree_pos minpoly.natDegree_pos
 
 /-- The degree of a minimal polynomial is positive. -/

--- a/Mathlib/FieldTheory/Minpoly/Field.lean
+++ b/Mathlib/FieldTheory/Minpoly/Field.lean
@@ -251,7 +251,7 @@ theorem root {x : B} (hx : IsIntegral A x) {y : A} (h : IsRoot (minpoly A x) y) 
     (associated_of_dvd_dvd ((irreducible_X_sub_C y).dvd_symm (irreducible hx) (dvd_iff_isRoot.2 h))
       (dvd_iff_isRoot.2 h))
   have := aeval A x
-  rwa [key, AlgHom.map_sub, aeval_X, aeval_C, sub_eq_zero, eq_comm] at this
+  rwa [key, map_sub, aeval_X, aeval_C, sub_eq_zero, eq_comm] at this
 #align minpoly.root minpoly.root
 
 /-- The constant coefficient of the minimal polynomial of `x` is `0` if and only if `x = 0`. -/
@@ -284,7 +284,7 @@ variable {K L} [Field K] [CommRing L] [IsDomain L] [Algebra K L]
 lemma minpoly_algEquiv_toLinearMap (σ : L ≃ₐ[K] L) (hσ : IsOfFinOrder σ) :
     minpoly K σ.toLinearMap = X ^ (orderOf σ) - C 1 := by
   refine (minpoly.unique _ _ (monic_X_pow_sub_C _ hσ.orderOf_pos.ne.symm) ?_ ?_).symm
-  · rw [(aeval σ.toLinearMap).map_sub (X ^ orderOf σ) (C (1 : K))]
+  · rw [map_sub]
     simp [← AlgEquiv.pow_toLinearMap, pow_orderOf_eq_one]
   · intros q hq hs
     rw [degree_eq_natDegree hq.ne_zero, degree_X_pow_sub_C hσ.orderOf_pos, Nat.cast_le, ← not_lt]

--- a/Mathlib/FieldTheory/Normal.lean
+++ b/Mathlib/FieldTheory/Normal.lean
@@ -77,7 +77,7 @@ theorem Normal.exists_isSplittingField [h : Normal F K] [FiniteDimensional F K] 
               mt (Polynomial.map_eq_zero <| algebraMap F K).1 <|
                 Finset.prod_ne_zero_iff.2 fun x _ => ?_).2 ?_)
   · exact minpoly.ne_zero (h.isIntegral (s x))
-  rw [IsRoot.def, eval_map, ← aeval_def, AlgHom.map_prod]
+  rw [IsRoot.def, eval_map, ← aeval_def, map_prod]
   exact Finset.prod_eq_zero (Finset.mem_univ _) (minpoly.aeval _ _)
 #align normal.exists_is_splitting_field Normal.exists_isSplittingField
 
@@ -228,10 +228,10 @@ def AlgHom.restrictNormalAux [h : Normal F E] :
       simp only [AlgHom.toRingHom_eq_coe, AlgHom.coe_toRingHom]
       suffices IsIntegral F _ by exact this.tower_top
       exact ((h.isIntegral z).map <| toAlgHom F E K₁).map ϕ⟩
-  map_zero' := Subtype.ext ϕ.map_zero
-  map_one' := Subtype.ext ϕ.map_one
-  map_add' x y := Subtype.ext (ϕ.map_add x y)
-  map_mul' x y := Subtype.ext (ϕ.map_mul x y)
+  map_zero' := Subtype.ext (map_zero _)
+  map_one' := Subtype.ext (map_one _)
+  map_add' x y := Subtype.ext <| by simp
+  map_mul' x y := Subtype.ext <| by simp
   commutes' x := Subtype.ext (ϕ.commutes x)
 #align alg_hom.restrict_normal_aux AlgHom.restrictNormalAux
 

--- a/Mathlib/FieldTheory/Perfect.lean
+++ b/Mathlib/FieldTheory/Perfect.lean
@@ -215,7 +215,7 @@ instance toPerfectRing (p : ℕ) [ExpChar K p] : PerfectRing K p := by
     rw [degree_X_pow_sub_C (expChar_pos K p) y, p.cast_ne_zero]; exact (expChar_pos K p).ne'
   let a : L := f.rootOfSplits ι (SplittingField.splits f) hf_deg
   have hfa : aeval a f = 0 := by rw [aeval_def, map_rootOfSplits _ (SplittingField.splits f) hf_deg]
-  have ha_pow : a ^ p = ι y := by rwa [AlgHom.map_sub, aeval_X_pow, aeval_C, sub_eq_zero] at hfa
+  have ha_pow : a ^ p = ι y := by rwa [map_sub, aeval_X_pow, aeval_C, sub_eq_zero] at hfa
   let g : K[X] := minpoly K a
   suffices (g.map ι).natDegree = 1 by
     rw [g.natDegree_map, ← degree_eq_iff_natDegree_eq_of_pos Nat.one_pos] at this

--- a/Mathlib/LinearAlgebra/Charpoly/Basic.lean
+++ b/Mathlib/LinearAlgebra/Charpoly/Basic.lean
@@ -112,7 +112,7 @@ theorem minpoly_coeff_zero_of_injective (hf : Function.Injective f) :
       rwa [Monic.def, hP, mul_comm, leadingCoeff_mul_X, ← Monic.def] at this
     exact minpoly.monic (isIntegral f)
   have hzero : aeval f (minpoly R f) = 0 := minpoly.aeval _ _
-  simp only [hP, mul_eq_comp, ext_iff, hf, aeval_X, map_eq_zero_iff, coe_comp, AlgHom.map_mul,
+  simp only [hP, mul_eq_comp, ext_iff, hf, aeval_X, map_eq_zero_iff, coe_comp, _root_.map_mul,
     zero_apply, Function.comp_apply] at hzero
   exact not_le.2 hdegP (minpoly.min _ _ hPmonic (ext hzero))
 #align linear_map.minpoly_coeff_zero_of_injective LinearMap.minpoly_coeff_zero_of_injective

--- a/Mathlib/LinearAlgebra/CliffordAlgebra/Basic.lean
+++ b/Mathlib/LinearAlgebra/CliffordAlgebra/Basic.lean
@@ -115,7 +115,10 @@ def ι : M →ₗ[R] CliffordAlgebra Q :=
 /-- As well as being linear, `ι Q` squares to the quadratic form -/
 @[simp]
 theorem ι_sq_scalar (m : M) : ι Q m * ι Q m = algebraMap R _ (Q m) := by
-  erw [← AlgHom.map_mul, RingQuot.mkAlgHom_rel R (Rel.of m), AlgHom.commutes]
+  rw [ι]
+  erw [LinearMap.comp_apply]
+  rw [AlgHom.toLinearMap_apply, ← map_mul (RingQuot.mkAlgHom R (Rel Q)),
+    RingQuot.mkAlgHom_rel R (Rel.of m), AlgHom.commutes]
   rfl
 #align clifford_algebra.ι_sq_scalar CliffordAlgebra.ι_sq_scalar
 
@@ -124,7 +127,7 @@ variable {Q} {A : Type*} [Semiring A] [Algebra R A]
 @[simp]
 theorem comp_ι_sq_scalar (g : CliffordAlgebra Q →ₐ[R] A) (m : M) :
     g (ι Q m) * g (ι Q m) = algebraMap _ _ (Q m) := by
-  rw [← AlgHom.map_mul, ι_sq_scalar, AlgHom.commutes]
+  rw [← map_mul, ι_sq_scalar, AlgHom.commutes]
 #align clifford_algebra.comp_ι_sq_scalar CliffordAlgebra.comp_ι_sq_scalar
 
 variable (Q)
@@ -140,7 +143,7 @@ def lift :
     RingQuot.liftAlgHom R
       ⟨TensorAlgebra.lift R (f : M →ₗ[R] A), fun x y (h : Rel Q x y) => by
         induction h
-        rw [AlgHom.commutes, AlgHom.map_mul, TensorAlgebra.lift_ι_apply, f.prop]⟩
+        rw [AlgHom.commutes, map_mul, TensorAlgebra.lift_ι_apply, f.prop]⟩
   invFun F :=
     ⟨F.toLinearMap.comp (ι Q), fun m => by
       rw [LinearMap.comp_apply, AlgHom.toLinearMap_apply, comp_ι_sq_scalar]⟩

--- a/Mathlib/LinearAlgebra/CliffordAlgebra/Conjugation.lean
+++ b/Mathlib/LinearAlgebra/CliffordAlgebra/Conjugation.lean
@@ -119,13 +119,13 @@ theorem reverse.commutes (r : R) :
 
 @[simp]
 theorem reverse.map_one : reverse (1 : CliffordAlgebra Q) = 1 :=
-  op_injective reverseOp.map_one
+  op_injective (_root_.map_one reverseOp)
 #align clifford_algebra.reverse.map_one CliffordAlgebra.reverse.map_one
 
 @[simp]
 theorem reverse.map_mul (a b : CliffordAlgebra Q) :
     reverse (a * b) = reverse b * reverse a :=
-  op_injective (reverseOp.map_mul a b)
+  op_injective (_root_.map_mul reverseOp a b)
 #align clifford_algebra.reverse.map_mul CliffordAlgebra.reverse.map_mul
 
 @[simp]
@@ -157,8 +157,8 @@ theorem reverse_comp_involute :
   induction x using CliffordAlgebra.induction with
   | algebraMap => simp
   | ι => simp
-  | mul a b ha hb => simp only [ha, hb, reverse.map_mul, AlgHom.map_mul]
-  | add a b ha hb => simp only [ha, hb, reverse.map_add, AlgHom.map_add]
+  | mul a b ha hb => simp only [ha, hb, reverse.map_mul, map_mul]
+  | add a b ha hb => simp only [ha, hb, reverse.map_add, map_add]
 #align clifford_algebra.reverse_comp_involute CliffordAlgebra.reverse_comp_involute
 
 /-- `CliffordAlgebra.reverse` and `CliffordAlgebra.involute` commute. Note that the composition

--- a/Mathlib/LinearAlgebra/CliffordAlgebra/Equivs.lean
+++ b/Mathlib/LinearAlgebra/CliffordAlgebra/Equivs.lean
@@ -157,7 +157,7 @@ theorem toComplex_ι (r : ℝ) : toComplex (ι Q r) = r • Complex.I :=
 theorem toComplex_involute (c : CliffordAlgebra Q) :
     toComplex (involute c) = conj (toComplex c) := by
   have : toComplex (involute (ι Q 1)) = conj (toComplex (ι Q 1)) := by
-    simp only [involute_ι, toComplex_ι, AlgHom.map_neg, one_smul, Complex.conj_I]
+    simp only [involute_ι, toComplex_ι, map_neg, one_smul, Complex.conj_I]
   suffices toComplex.comp involute = Complex.conjAe.toAlgHom.comp toComplex by
     exact AlgHom.congr_fun this c
   ext : 2
@@ -316,10 +316,10 @@ theorem toQuaternion_star (c : CliffordAlgebra (Q c₁ c₂)) :
     simp only [reverse.commutes, AlgHom.commutes, QuaternionAlgebra.coe_algebraMap,
       QuaternionAlgebra.star_coe]
   | ι x =>
-    rw [reverse_ι, involute_ι, toQuaternion_ι, AlgHom.map_neg, toQuaternion_ι,
+    rw [reverse_ι, involute_ι, toQuaternion_ι, map_neg, toQuaternion_ι,
       QuaternionAlgebra.neg_mk, star_mk, neg_zero]
-  | mul x₁ x₂ hx₁ hx₂ => simp only [reverse.map_mul, AlgHom.map_mul, hx₁, hx₂, star_mul]
-  | add x₁ x₂ hx₁ hx₂ => simp only [reverse.map_add, AlgHom.map_add, hx₁, hx₂, star_add]
+  | mul x₁ x₂ hx₁ hx₂ => simp only [reverse.map_mul, map_mul, hx₁, hx₂, star_mul]
+  | add x₁ x₂ hx₁ hx₂ => simp only [reverse.map_add, map_add, hx₁, hx₂, star_add]
 #align clifford_algebra_quaternion.to_quaternion_star CliffordAlgebraQuaternion.toQuaternion_star
 
 /-- Map a quaternion into the clifford algebra. -/

--- a/Mathlib/LinearAlgebra/CliffordAlgebra/Even.lean
+++ b/Mathlib/LinearAlgebra/CliffordAlgebra/Even.lean
@@ -82,7 +82,7 @@ def EvenHom.compr₂ (g : EvenHom Q A) (f : A →ₐ[R] B) : EvenHom Q B where
   bilin := g.bilin.compr₂ f.toLinearMap
   contract _m := (f.congr_arg <| g.contract _).trans <| f.commutes _
   contract_mid _m₁ _m₂ _m₃ :=
-    (f.map_mul _ _).symm.trans <| (f.congr_arg <| g.contract_mid _ _ _).trans <| f.map_smul _ _
+    (map_mul f _ _).symm.trans <| (f.congr_arg <| g.contract_mid _ _ _).trans <| map_smul f _ _
 #align clifford_algebra.even_hom.compr₂ CliffordAlgebra.EvenHom.compr₂
 
 variable (Q)
@@ -122,10 +122,10 @@ theorem even.algHom_ext ⦃f g : even Q →ₐ[R] A⦄ (h : (even.ι Q).compr₂
     exact (f.commutes r).trans (g.commutes r).symm
   | add x y hx hy ihx ihy =>
     have := congr_arg₂ (· + ·) ihx ihy
-    exact (f.map_add _ _).trans (this.trans <| (g.map_add _ _).symm)
+    exact (map_add f _ _).trans (this.trans <| (map_add g _ _).symm)
   | ι_mul_ι_mul m₁ m₂ x hx ih =>
     have := congr_arg₂ (· * ·) (LinearMap.congr_fun (LinearMap.congr_fun h m₁) m₂) ih
-    exact (f.map_mul _ _).trans (this.trans <| (g.map_mul _ _).symm)
+    exact (map_mul f _ _).trans (this.trans <| (map_mul g _ _).symm)
 #align clifford_algebra.even.alg_hom_ext CliffordAlgebra.even.algHom_ext
 
 variable {Q}

--- a/Mathlib/LinearAlgebra/CliffordAlgebra/EvenEquiv.lean
+++ b/Mathlib/LinearAlgebra/CliffordAlgebra/EvenEquiv.lean
@@ -193,7 +193,7 @@ theorem toEven_comp_ofEven : (toEven Q).comp (ofEven Q) = AlgHom.id R _ :=
             calc
               ↑(toEven Q (ofEven Q ((even.ι (Q' Q)).bilin (m₁, r₁) (m₂, r₂)))) =
                   (e0 Q * v Q m₁ + algebraMap R _ r₁) * (e0 Q * v Q m₂ - algebraMap R _ r₂) := by
-                rw [ofEven_ι, AlgHom.map_mul, AlgHom.map_add, AlgHom.map_sub, AlgHom.commutes,
+                rw [ofEven_ι, map_mul, map_add, map_sub, AlgHom.commutes,
                   AlgHom.commutes, Subalgebra.coe_mul, Subalgebra.coe_add, Subalgebra.coe_sub,
                   toEven_ι, toEven_ι, Subalgebra.coe_algebraMap, Subalgebra.coe_algebraMap]
               _ =

--- a/Mathlib/LinearAlgebra/CliffordAlgebra/Fold.lean
+++ b/Mathlib/LinearAlgebra/CliffordAlgebra/Fold.lean
@@ -64,13 +64,13 @@ theorem foldr_algebraMap (f : M →ₗ[R] N →ₗ[R] N) (hf) (n : N) (r : R) :
 
 @[simp]
 theorem foldr_one (f : M →ₗ[R] N →ₗ[R] N) (hf) (n : N) : foldr Q f hf n 1 = n :=
-  LinearMap.congr_fun (AlgHom.map_one _) n
+  LinearMap.congr_fun (map_one (lift Q _)) n
 #align clifford_algebra.foldr_one CliffordAlgebra.foldr_one
 
 @[simp]
 theorem foldr_mul (f : M →ₗ[R] N →ₗ[R] N) (hf) (n : N) (a b : CliffordAlgebra Q) :
     foldr Q f hf n (a * b) = foldr Q f hf (foldr Q f hf n b) a :=
-  LinearMap.congr_fun (AlgHom.map_mul _ _ _) n
+  LinearMap.congr_fun (map_mul (lift Q _) _ _) n
 #align clifford_algebra.foldr_mul CliffordAlgebra.foldr_mul
 
 /-- This lemma demonstrates the origin of the `foldr` name. -/

--- a/Mathlib/LinearAlgebra/CliffordAlgebra/Grading.lean
+++ b/Mathlib/LinearAlgebra/CliffordAlgebra/Grading.lean
@@ -88,6 +88,7 @@ nonrec theorem GradedAlgebra.ι_sq_scalar (m : M) :
   exact DirectSum.of_eq_of_gradedMonoid_eq (Sigma.subtype_ext rfl <| ι_sq_scalar _ _)
 #align clifford_algebra.graded_algebra.ι_sq_scalar CliffordAlgebra.GradedAlgebra.ι_sq_scalar
 
+set_option linter.deprecated false in
 theorem GradedAlgebra.lift_ι_eq (i' : ZMod 2) (x' : evenOdd Q i') :
     -- Porting note: added a second `by apply`
     lift Q ⟨by apply GradedAlgebra.ι Q, by apply GradedAlgebra.ι_sq_scalar Q⟩ x' =

--- a/Mathlib/LinearAlgebra/Eigenspace/Minpoly.lean
+++ b/Mathlib/LinearAlgebra/Eigenspace/Minpoly.lean
@@ -57,7 +57,7 @@ theorem aeval_apply_of_hasEigenvector {f : End K V} {p : K[X]} {μ : K} {x : V}
   · intro a; simp [Module.algebraMap_end_apply]
   · intro p q hp hq; simp [hp, hq, add_smul]
   · intro n a hna
-    rw [mul_comm, pow_succ', mul_assoc, AlgHom.map_mul, LinearMap.mul_apply, mul_comm, hna]
+    rw [mul_comm, pow_succ', mul_assoc, map_mul, LinearMap.mul_apply, mul_comm, hna]
     simp only [mem_eigenspace_iff.1 h.1, smul_smul, aeval_X, eval_mul, eval_C, eval_pow, eval_X,
       LinearMap.map_smulₛₗ, RingHom.id_apply, mul_comm]
 #align module.End.aeval_apply_of_has_eigenvector Module.End.aeval_apply_of_hasEigenvector

--- a/Mathlib/LinearAlgebra/ExteriorAlgebra/Basic.lean
+++ b/Mathlib/LinearAlgebra/ExteriorAlgebra/Basic.lean
@@ -95,7 +95,7 @@ variable {A : Type*} [Semiring A] [Algebra R A]
 
 -- @[simp] -- Porting note (#10618): simp can prove this
 theorem comp_ι_sq_zero (g : ExteriorAlgebra R M →ₐ[R] A) (m : M) : g (ι R m) * g (ι R m) = 0 := by
-  rw [← AlgHom.map_mul, ι_sq_zero, AlgHom.map_zero]
+  rw [← map_mul, ι_sq_zero, map_zero]
 #align exterior_algebra.comp_ι_sq_zero ExteriorAlgebra.comp_ι_sq_zero
 
 variable (R)

--- a/Mathlib/LinearAlgebra/ExteriorAlgebra/Grading.lean
+++ b/Mathlib/LinearAlgebra/ExteriorAlgebra/Grading.lean
@@ -61,6 +61,7 @@ def GradedAlgebra.liftι :
   lift R ⟨by apply GradedAlgebra.ι R M, GradedAlgebra.ι_sq_zero R M⟩
 #align exterior_algebra.graded_algebra.lift_ι ExteriorAlgebra.GradedAlgebra.liftι
 
+set_option linter.deprecated false in
 theorem GradedAlgebra.liftι_eq (i : ℕ) (x : ⋀[R]^i M) :
     GradedAlgebra.liftι R M x = DirectSum.of (fun i => ⋀[R]^i M) i x := by
   cases' x with x hx

--- a/Mathlib/LinearAlgebra/JordanChevalley.lean
+++ b/Mathlib/LinearAlgebra/JordanChevalley.lean
@@ -47,7 +47,7 @@ theorem exists_isNilpotent_isSemisimple_of_separable_of_dvd_pow {P : K[X]} {k : 
   have nil' : IsNilpotent (aeval ff P) := by
     use k
     obtain ⟨q, hq⟩ := nil
-    rw [← AlgHom.map_pow, Subtype.ext_iff]
+    rw [← map_pow, Subtype.ext_iff]
     simp [ff, hq]
   have sep' : IsUnit (aeval ff P') := by
     obtain ⟨a, b, h⟩ : IsCoprime (P ^ k) P' := sep.pow_left

--- a/Mathlib/LinearAlgebra/Matrix/Adjugate.lean
+++ b/Mathlib/LinearAlgebra/Matrix/Adjugate.lean
@@ -380,7 +380,7 @@ theorem det_adjugate (A : Matrix n n α) : (adjugate A).det = A.det ^ (Fintype.c
   let A' := mvPolynomialX n n ℤ
   suffices A'.adjugate.det = A'.det ^ (Fintype.card n - 1) by
     rw [← mvPolynomialX_mapMatrix_aeval ℤ A, ← AlgHom.map_adjugate, ← AlgHom.map_det, ←
-      AlgHom.map_det, ← AlgHom.map_pow, this]
+      AlgHom.map_det, ← map_pow, this]
   apply mul_left_cancel₀ (show A'.det ≠ 0 from det_mvPolynomialX_ne_zero n ℤ)
   calc
     A'.det * A'.adjugate.det = (A' * adjugate A').det := (det_mul _ _).symm
@@ -546,8 +546,8 @@ theorem adjugate_adjugate (A : Matrix n n α) (h : Fintype.card n ≠ 1) :
   let A' := mvPolynomialX n n ℤ
   suffices adjugate (adjugate A') = det A' ^ (Fintype.card n - 2) • A' by
     rw [← mvPolynomialX_mapMatrix_aeval ℤ A, ← AlgHom.map_adjugate, ← AlgHom.map_adjugate, this,
-      ← AlgHom.map_det, ← AlgHom.map_pow, AlgHom.mapMatrix_apply, AlgHom.mapMatrix_apply,
-      Matrix.map_smul' _ _ _ (_root_.map_mul _)]
+      ← AlgHom.map_det, ← map_pow (MvPolynomial.aeval _), AlgHom.mapMatrix_apply,
+      AlgHom.mapMatrix_apply, Matrix.map_smul' _ _ _ (_root_.map_mul _)]
   have h_card' : Fintype.card n - 2 + 1 = Fintype.card n - 1 := by simp [h_card]
   have is_reg : IsSMulRegular (MvPolynomial (n × n) ℤ) (det A') := fun x y =>
     mul_left_cancel₀ (det_mvPolynomialX_ne_zero n ℤ)

--- a/Mathlib/LinearAlgebra/Matrix/Charpoly/Coeff.lean
+++ b/Mathlib/LinearAlgebra/Matrix/Charpoly/Coeff.lean
@@ -265,11 +265,10 @@ theorem matPolyEquiv_eq_X_pow_sub_C {K : Type*} (k : ℕ) [Field K] (M : Matrix 
   rw [coeff_sub, coeff_C, matPolyEquiv_coeff_apply, RingHom.mapMatrix_apply, Matrix.map_apply,
     AlgHom.coe_toRingHom, DMatrix.sub_apply, coeff_X_pow]
   by_cases hij : i = j
-  · rw [hij, charmatrix_apply_eq, AlgHom.map_sub, expand_C, expand_X, coeff_sub, coeff_X_pow,
-      coeff_C]
+  · rw [hij, charmatrix_apply_eq, map_sub, expand_C, expand_X, coeff_sub, coeff_X_pow, coeff_C]
                              -- Porting note: the second `Matrix.` was `DMatrix.`
     split_ifs with mp m0 <;> simp only [Matrix.one_apply_eq, Matrix.zero_apply]
-  · rw [charmatrix_apply_ne _ _ _ hij, AlgHom.map_neg, expand_C, coeff_neg, coeff_C]
+  · rw [charmatrix_apply_ne _ _ _ hij, map_neg, expand_C, coeff_neg, coeff_C]
     split_ifs with m0 mp <;>
       -- Porting note: again, the first `Matrix.` that was `DMatrix.`
       simp only [hij, zero_sub, Matrix.zero_apply, sub_zero, neg_zero, Matrix.one_apply_ne, Ne,

--- a/Mathlib/LinearAlgebra/Matrix/ToLin.lean
+++ b/Mathlib/LinearAlgebra/Matrix/ToLin.lean
@@ -903,16 +903,16 @@ noncomputable def leftMulMatrix : S →ₐ[R] Matrix m m R where
   toFun x := LinearMap.toMatrix b b (Algebra.lmul R S x)
   map_zero' := by
     dsimp only  -- porting node: needed due to new-style structures
-    rw [AlgHom.map_zero, LinearEquiv.map_zero]
+    rw [_root_.map_zero, LinearEquiv.map_zero]
   map_one' := by
     dsimp only  -- porting node: needed due to new-style structures
-    rw [AlgHom.map_one, LinearMap.toMatrix_one]
+    rw [_root_.map_one, LinearMap.toMatrix_one]
   map_add' x y := by
     dsimp only  -- porting node: needed due to new-style structures
-    rw [AlgHom.map_add, LinearEquiv.map_add]
+    rw [map_add, LinearEquiv.map_add]
   map_mul' x y := by
     dsimp only  -- porting node: needed due to new-style structures
-    rw [AlgHom.map_mul, LinearMap.toMatrix_mul]
+    rw [_root_.map_mul, LinearMap.toMatrix_mul]
   commutes' r := by
     dsimp only  -- porting node: needed due to new-style structures
     ext

--- a/Mathlib/LinearAlgebra/Semisimple.lean
+++ b/Mathlib/LinearAlgebra/Semisimple.lean
@@ -207,7 +207,7 @@ theorem IsSemisimple.of_mem_adjoin_pair {a : End K M} (ha : a ∈ Algebra.adjoin
   obtain ⟨p, rfl⟩ := (AlgHom.mem_range _).mp (this ha)
   refine isSemisimple_of_squarefree_aeval_eq_zero
     ((minpoly.isRadical K p).squarefree <| minpoly.ne_zero <| .of_finite K p) ?_
-  rw [aeval_algHom, φ.comp_apply, minpoly.aeval, φ.map_zero]
+  rw [aeval_algHom, φ.comp_apply, minpoly.aeval, map_zero]
 
 theorem IsSemisimple.add_of_commute : (f + g).IsSemisimple := .of_mem_adjoin_pair
   comm hf hg <| add_mem (Algebra.subset_adjoin <| .inl rfl) (Algebra.subset_adjoin <| .inr rfl)

--- a/Mathlib/LinearAlgebra/TensorAlgebra/Basic.lean
+++ b/Mathlib/LinearAlgebra/TensorAlgebra/Basic.lean
@@ -108,10 +108,10 @@ variable {M}
 irreducible_def ι : M →ₗ[R] TensorAlgebra R M :=
   { toFun := fun m => RingQuot.mkAlgHom R _ (FreeAlgebra.ι R m)
     map_add' := fun x y => by
-      rw [← (RingQuot.mkAlgHom R (Rel R M)).map_add]
+      rw [← map_add (RingQuot.mkAlgHom R (Rel R M))]
       exact RingQuot.mkAlgHom_rel R Rel.add
     map_smul' := fun r x => by
-      rw [← (RingQuot.mkAlgHom R (Rel R M)).map_smul]
+      rw [← map_smul (RingQuot.mkAlgHom R (Rel R M))]
       exact RingQuot.mkAlgHom_rel R Rel.smul }
 #align tensor_algebra.ι TensorAlgebra.ι
 

--- a/Mathlib/LinearAlgebra/TensorAlgebra/Grading.lean
+++ b/Mathlib/LinearAlgebra/TensorAlgebra/Grading.lean
@@ -60,11 +60,11 @@ instance gradedAlgebra :
     | add x y i hx hy ihx ihy =>
       -- Note: #8386 had to specialize `map_add` to avoid a timeout
       -- (the extra typeclass search seems to have pushed this already slow proof over the edge)
-      rw [AlgHom.map_add, ihx, ihy, ← AddMonoidHom.map_add]
+      rw [map_add, ihx, ihy, ← AddMonoidHom.map_add]
       rfl
     | mem_mul m hm i x hx ih =>
       obtain ⟨_, rfl⟩ := hm
-      rw [AlgHom.map_mul, ih, lift_ι_apply, GradedAlgebra.ι_apply R M, DirectSum.of_mul_of]
+      rw [map_mul, ih, lift_ι_apply, GradedAlgebra.ι_apply R M, DirectSum.of_mul_of]
       exact DirectSum.of_eq_of_gradedMonoid_eq (Sigma.subtype_ext (add_comm _ _) rfl)
 #align tensor_algebra.graded_algebra TensorAlgebra.gradedAlgebra
 

--- a/Mathlib/LinearAlgebra/TensorAlgebra/ToTensorPower.lean
+++ b/Mathlib/LinearAlgebra/TensorAlgebra/ToTensorPower.lean
@@ -154,7 +154,7 @@ theorem _root_.TensorPower.list_prod_gradedMonoid_mk_single (n : ℕ) (x : Fin n
 
 theorem toDirectSum_tensorPower_tprod {n} (x : Fin n → M) :
     toDirectSum (tprod R M n x) = DirectSum.of _ n (PiTensorProduct.tprod R x) := by
-  rw [tprod_apply, AlgHom.map_list_prod, List.map_ofFn]
+  rw [tprod_apply, map_list_prod, List.map_ofFn]
   simp_rw [Function.comp, toDirectSum_ι]
   rw [DirectSum.list_prod_ofFn_of_eq_dProd]
   apply DirectSum.of_eq_of_gradedMonoid_eq

--- a/Mathlib/LinearAlgebra/TensorProduct/Graded/Internal.lean
+++ b/Mathlib/LinearAlgebra/TensorProduct/Graded/Internal.lean
@@ -338,14 +338,14 @@ def liftEquiv :
   toFun fg := lift 𝒜 ℬ _ _ fg.prop
   invFun F := ⟨(F.comp (includeLeft 𝒜 ℬ), F.comp (includeRight 𝒜 ℬ)), fun i j a b => by
     dsimp
-    rw [← F.map_mul, ← F.map_mul, tmul_coe_mul_coe_tmul, one_mul, mul_one, AlgHom.map_smul_of_tower,
-      tmul_one_mul_one_tmul, smul_smul, Int.units_mul_self, one_smul]⟩
+    rw [← _root_.map_mul, ← _root_.map_mul F, tmul_coe_mul_coe_tmul, one_mul, mul_one,
+      AlgHom.map_smul_of_tower, tmul_one_mul_one_tmul, smul_smul, Int.units_mul_self, one_smul]⟩
   left_inv fg := by ext <;> (dsimp; simp only [_root_.map_one, mul_one, one_mul])
   right_inv F := by
     apply AlgHom.toLinearMap_injective
     ext
     dsimp
-    rw [← F.map_mul, tmul_one_mul_one_tmul]
+    rw [← _root_.map_mul, tmul_one_mul_one_tmul]
 
 /-- Two algebra morphism from the graded tensor product agree if their compositions with the left
 and right inclusions agree. -/

--- a/Mathlib/NumberTheory/BernoulliPolynomials.lean
+++ b/Mathlib/NumberTheory/BernoulliPolynomials.lean
@@ -243,7 +243,7 @@ theorem bernoulli_generating_function (t : A) :
     mul_one_div_cancel (show (n ! : ℚ) ≠ 0 from cast_ne_zero.2 (factorial_ne_zero n)), mul_one,
     mul_comm (t ^ n), ← aeval_monomial, cast_add, cast_one]
   -- But this is the RHS of `Polynomial.sum_bernoulli`
-  rw [← sum_bernoulli, Finset.mul_sum, AlgHom.map_sum]
+  rw [← sum_bernoulli, Finset.mul_sum, map_sum]
   -- and now we have to prove a sum is a sum, but all the terms are equal.
   apply Finset.sum_congr rfl
   -- The rest is just trivialities, hampered by the fact that we're coercing
@@ -251,7 +251,7 @@ theorem bernoulli_generating_function (t : A) :
   intro i hi
   -- deal with coefficients of e^X-1
   simp only [Nat.cast_choose ℚ (mem_range_le hi), coeff_mk, if_neg (mem_range_sub_ne_zero hi),
-    one_div, AlgHom.map_smul, PowerSeries.coeff_one, coeff_exp, sub_zero, LinearMap.map_sub,
+    one_div, map_smul, PowerSeries.coeff_one, coeff_exp, sub_zero, LinearMap.map_sub,
     Algebra.smul_mul_assoc, Algebra.smul_def, mul_right_comm _ ((aeval t) _), ← mul_assoc, ←
     RingHom.map_mul, succ_eq_add_one, ← Polynomial.C_eq_algebraMap, Polynomial.aeval_mul,
     Polynomial.aeval_C]

--- a/Mathlib/NumberTheory/ClassNumber/Finite.lean
+++ b/Mathlib/NumberTheory/ClassNumber/Finite.lean
@@ -77,8 +77,8 @@ theorem norm_le (a : S) {y : ℤ} (hy : ∀ k, abv (bS.repr a k) ≤ y) :
     abv (Algebra.norm R a) ≤ normBound abv bS * y ^ Fintype.card ι := by
   conv_lhs => rw [← bS.sum_repr a]
   rw [Algebra.norm_apply, ← LinearMap.det_toMatrix bS]
-  simp only [Algebra.norm_apply, AlgHom.map_sum, AlgHom.map_smul, map_sum,
-    map_smul, Algebra.toMatrix_lmul_eq, normBound, smul_mul_assoc, ← mul_pow]
+  simp only [Algebra.norm_apply, map_sum, map_smul, map_sum, map_smul, Algebra.toMatrix_lmul_eq,
+    normBound, smul_mul_assoc, ← mul_pow]
   convert Matrix.det_sum_smul_le Finset.univ _ hy using 3
   · rw [Finset.card_univ, smul_mul_assoc, mul_comm]
   · intro i j k

--- a/Mathlib/NumberTheory/Cyclotomic/Basic.lean
+++ b/Mathlib/NumberTheory/Cyclotomic/Basic.lean
@@ -147,7 +147,7 @@ theorem trans (C : Type w) [CommRing C] [Algebra A C] [Algebra B C] [IsScalarTow
     rw [IsScalarTower.toAlgHom_apply, ← adjoin_image] at hb
     refine adjoin_mono (fun y hy => ?_) hb
     obtain ⟨b₁, ⟨⟨n, hn⟩, h₁⟩⟩ := hy
-    exact ⟨n, ⟨mem_union_left T hn.1, by rw [← h₁, ← AlgHom.map_pow, hn.2, AlgHom.map_one]⟩⟩
+    exact ⟨n, ⟨mem_union_left T hn.1, by rw [← h₁, ← map_pow, hn.2, map_one]⟩⟩
 #align is_cyclotomic_extension.trans IsCyclotomicExtension.trans
 
 @[nontriviality]

--- a/Mathlib/NumberTheory/Cyclotomic/PrimitiveRoots.lean
+++ b/Mathlib/NumberTheory/Cyclotomic/PrimitiveRoots.lean
@@ -349,7 +349,7 @@ theorem sub_one_norm_eq_eval_cyclotomic [IsCyclotomicExtension {n} K L] (h : 2 <
     congr
     rfl
     ext
-    rw [← neg_sub, AlgHom.map_neg, AlgHom.map_sub, AlgHom.map_one, neg_eq_neg_one_mul]
+    rw [← neg_sub, map_neg, map_sub, map_one, neg_eq_neg_one_mul]
   rw [prod_mul_distrib, prod_const, card_univ, AlgHom.card, IsCyclotomicExtension.finrank L hirr,
     (totient_even h).neg_one_pow, one_mul]
   have Hprod : (Finset.univ.prod fun σ : L →ₐ[K] E => 1 - σ ζ) = eval 1 (cyclotomic' n E) := by

--- a/Mathlib/NumberTheory/KummerDedekind.lean
+++ b/Mathlib/NumberTheory/KummerDedekind.lean
@@ -169,7 +169,7 @@ theorem comap_map_eq_map_adjoin_of_coprime_conductor
           (show z ∈ I.map (algebraMap R S) by rwa [Ideal.mem_comap] at hy))
       use a + algebraMap R R<x> q * ⟨z, hz⟩
       refine ⟨Ideal.add_mem (I.map (algebraMap R R<x>)) ha.left ?_, by
-          simp only [ha.right, map_add, AlgHom.map_mul, add_right_inj]; rfl⟩
+          simp only [ha.right, map_add, _root_.map_mul, add_right_inj]; rfl⟩
       rw [mul_comm]
       exact Ideal.mul_mem_left (I.map (algebraMap R R<x>)) _ (Ideal.mem_map_of_mem _ hq)
     refine ⟨fun h => ?_,

--- a/Mathlib/RepresentationTheory/Basic.lean
+++ b/Mathlib/RepresentationTheory/Basic.lean
@@ -229,8 +229,7 @@ theorem ofModule_asAlgebraHom_apply_apply (r : MonoidAlgebra k G)
   · intro f g fw gw
     simp only [fw, gw, map_add, add_smul, LinearMap.add_apply]
   · intro r f w
-    simp only [w, AlgHom.map_smul, LinearMap.smul_apply,
-      RestrictScalars.addEquiv_symm_map_smul_smul]
+    simp only [w, map_smul, LinearMap.smul_apply, RestrictScalars.addEquiv_symm_map_smul_smul]
 #align representation.of_module_as_algebra_hom_apply_apply Representation.ofModule_asAlgebraHom_apply_apply
 
 @[simp]

--- a/Mathlib/RepresentationTheory/Rep.lean
+++ b/Mathlib/RepresentationTheory/Rep.lean
@@ -607,7 +607,7 @@ theorem to_Module_monoidAlgebra_map_aux {k G : Type*} [CommRing k] [Monoid G] (V
     exact LinearMap.congr_fun (w g) x
   · intro g h gw hw; simp only [map_add, add_left_inj, LinearMap.add_apply, hw, gw]
   · intro r g w
-    simp only [AlgHom.map_smul, w, RingHom.id_apply, LinearMap.smul_apply, LinearMap.map_smulₛₗ]
+    simp only [map_smul, w, RingHom.id_apply, LinearMap.smul_apply, LinearMap.map_smulₛₗ]
 set_option linter.uppercaseLean3 false in
 #align Rep.to_Module_monoid_algebra_map_aux Rep.to_Module_monoidAlgebra_map_aux
 

--- a/Mathlib/RingTheory/AdjoinRoot.lean
+++ b/Mathlib/RingTheory/AdjoinRoot.lean
@@ -227,9 +227,8 @@ theorem aeval_eq (p : R[X]) : aeval (root f) p = mk f p :=
     (fun x => by
       rw [aeval_C]
       rfl)
-    (fun p q ihp ihq => by rw [AlgHom.map_add, RingHom.map_add, ihp, ihq]) fun n x _ => by
-    rw [AlgHom.map_mul, aeval_C, AlgHom.map_pow, aeval_X, RingHom.map_mul, mk_C, RingHom.map_pow,
-      mk_X]
+    (fun p q ihp ihq => by rw [map_add, RingHom.map_add, ihp, ihq]) fun n x _ => by
+    rw [_root_.map_mul, aeval_C, map_pow, aeval_X, RingHom.map_mul, mk_C, RingHom.map_pow, mk_X]
     rfl
 #align adjoin_root.aeval_eq AdjoinRoot.aeval_eq
 
@@ -357,8 +356,8 @@ theorem algHom_subsingleton {S : Type*} [CommRing S] [Algebra R S] {r : R} :
   ⟨fun f g =>
     algHom_ext
       (@inv_unique _ _ (algebraMap R S r) _ _
-        (by rw [← f.commutes, ← f.map_mul, algebraMap_eq, root_isInv, map_one])
-        (by rw [← g.commutes, ← g.map_mul, algebraMap_eq, root_isInv, map_one]))⟩
+        (by rw [← f.commutes, ← _root_.map_mul, algebraMap_eq, root_isInv, map_one])
+        (by rw [← g.commutes, ← _root_.map_mul, algebraMap_eq, root_isInv, map_one]))⟩
 #align adjoin_root.alg_hom_subsingleton AdjoinRoot.algHom_subsingleton
 
 end AdjoinInv
@@ -546,7 +545,7 @@ theorem isIntegral_root (hf : f ≠ 0) : IsIntegral K (root f) :=
 theorem minpoly_root (hf : f ≠ 0) : minpoly K (root f) = f * C f.leadingCoeff⁻¹ := by
   have f'_monic : Monic _ := monic_mul_leadingCoeff_inv hf
   refine (minpoly.unique K _ f'_monic ?_ ?_).symm
-  · rw [AlgHom.map_mul, aeval_eq, mk_self, zero_mul]
+  · rw [_root_.map_mul, aeval_eq, mk_self, zero_mul]
   intro q q_monic q_aeval
   have commutes : (lift (algebraMap K (AdjoinRoot f)) (root f) q_aeval).comp (mk q) = mk f := by
     ext

--- a/Mathlib/RingTheory/Algebraic.lean
+++ b/Mathlib/RingTheory/Algebraic.lean
@@ -70,7 +70,7 @@ theorem Subalgebra.isAlgebraic_iff (S : Subalgebra R A) :
   rw [Subtype.forall', Algebra.isAlgebraic_def]
   refine forall_congr' fun x => exists_congr fun p => and_congr Iff.rfl ?_
   have h : Function.Injective S.val := Subtype.val_injective
-  conv_rhs => rw [← h.eq_iff, AlgHom.map_zero]
+  conv_rhs => rw [← h.eq_iff, map_zero]
   rw [← aeval_algHom_apply, S.val_apply]
 #align subalgebra.is_algebraic_iff Subalgebra.isAlgebraic_iff
 
@@ -223,7 +223,7 @@ theorem isAlgebraic_iff_isIntegral {x : A} : IsAlgebraic K x ↔ IsIntegral K x 
   refine ⟨?_, IsIntegral.isAlgebraic⟩
   rintro ⟨p, hp, hpx⟩
   refine ⟨_, monic_mul_leadingCoeff_inv hp, ?_⟩
-  rw [← aeval_def, AlgHom.map_mul, hpx, zero_mul]
+  rw [← aeval_def, map_mul, hpx, zero_mul]
 #align is_algebraic_iff_is_integral isAlgebraic_iff_isIntegral
 
 protected theorem Algebra.isAlgebraic_iff_isIntegral :
@@ -431,7 +431,7 @@ theorem inv_eq_of_aeval_divX_ne_zero {x : L} {p : K[X]} (aeval_ne : aeval x (div
     x⁻¹ = aeval x (divX p) / (aeval x p - algebraMap _ _ (p.coeff 0)) := by
   rw [inv_eq_iff_eq_inv, inv_div, eq_comm, div_eq_iff, sub_eq_iff_eq_add, mul_comm]
   conv_lhs => rw [← divX_mul_X_add p]
-  · rw [AlgHom.map_add, AlgHom.map_mul, aeval_X, aeval_C]
+  · rw [map_add, map_mul, aeval_X, aeval_C]
   · exact aeval_ne
 set_option linter.uppercaseLean3 false in
 #align inv_eq_of_aeval_div_X_ne_zero inv_eq_of_aeval_divX_ne_zero
@@ -444,7 +444,7 @@ theorem inv_eq_of_root_of_coeff_zero_ne_zero {x : L} {p : K[X]} (aeval_eq : aeva
   rw [RingHom.map_zero]
   convert aeval_eq
   conv_rhs => rw [← divX_mul_X_add p]
-  rw [AlgHom.map_add, AlgHom.map_mul, h, zero_mul, zero_add, aeval_C]
+  rw [map_add, map_mul, h, zero_mul, zero_add, aeval_C]
 #align inv_eq_of_root_of_coeff_zero_ne_zero inv_eq_of_root_of_coeff_zero_ne_zero
 
 theorem Subalgebra.inv_mem_of_root_of_coeff_zero_ne_zero {x : A} {p : K[X]}
@@ -472,7 +472,7 @@ theorem Subalgebra.inv_mem_of_algebraic {x : A} (hx : _root_.IsAlgebraic K (x : 
     refine A.inv_mem_of_root_of_coeff_zero_ne_zero aeval_eq ?_
     rwa [coeff_add, hp, zero_add, coeff_C, if_pos rfl]
   · intro p hp ih _ne_zero aeval_eq
-    rw [AlgHom.map_mul, aeval_X, mul_eq_zero] at aeval_eq
+    rw [map_mul, aeval_X, mul_eq_zero] at aeval_eq
     cases' aeval_eq with aeval_eq x_eq
     · exact ih hp aeval_eq
     · rw [x_eq, Subalgebra.coe_zero, inv_zero]

--- a/Mathlib/RingTheory/Bialgebra/Basic.lean
+++ b/Mathlib/RingTheory/Bialgebra/Basic.lean
@@ -135,10 +135,10 @@ variable {R A}
   map_natCast (comulAlgHom R A) _
 
 @[simp] lemma counit_pow (a : A) (n : ℕ) : counit (R := R) (a ^ n) = counit a ^ n :=
-  (counitAlgHom R A).map_pow a n
+  map_pow (counitAlgHom R A) a n
 
 @[simp] lemma comul_pow (a : A) (n : ℕ) : comul (R := R) (a ^ n) = comul a ^ n :=
-  (comulAlgHom R A).map_pow a n
+  map_pow (comulAlgHom R A) a n
 
 end Bialgebra
 

--- a/Mathlib/RingTheory/FiniteType.lean
+++ b/Mathlib/RingTheory/FiniteType.lean
@@ -457,17 +457,17 @@ theorem mvPolynomial_aeval_of_surjective_of_closure [AddCommMonoid M] [CommSemir
   · have : m ∈ closure S := hS.symm ▸ mem_top _
     refine AddSubmonoid.closure_induction this (fun m hm => ?_) ?_ ?_
     · exact ⟨MvPolynomial.X ⟨m, hm⟩, MvPolynomial.aeval_X _ _⟩
-    · exact ⟨1, AlgHom.map_one _⟩
+    · exact ⟨1, map_one _⟩
     · rintro m₁ m₂ ⟨P₁, hP₁⟩ ⟨P₂, hP₂⟩
       exact
         ⟨P₁ * P₂, by
-          rw [AlgHom.map_mul, hP₁, hP₂, of_apply, of_apply, of_apply, single_mul_single,
+          rw [map_mul, hP₁, hP₂, of_apply, of_apply, of_apply, single_mul_single,
             one_mul]; rfl⟩
   · rcases ihf with ⟨P, rfl⟩
     rcases ihg with ⟨Q, rfl⟩
-    exact ⟨P + Q, AlgHom.map_add _ _ _⟩
+    exact ⟨P + Q, map_add _ _ _⟩
   · rcases ih with ⟨P, rfl⟩
-    exact ⟨r • P, AlgHom.map_smul _ _ _⟩
+    exact ⟨r • P, map_smul _ _ _⟩
 #align add_monoid_algebra.mv_polynomial_aeval_of_surjective_of_closure AddMonoidAlgebra.mvPolynomial_aeval_of_surjective_of_closure
 
 variable [AddMonoid M]
@@ -483,17 +483,17 @@ theorem freeAlgebra_lift_of_surjective_of_closure [CommSemiring R] {S : Set M}
   · have : m ∈ closure S := hS.symm ▸ mem_top _
     refine AddSubmonoid.closure_induction this (fun m hm => ?_) ?_ ?_
     · exact ⟨FreeAlgebra.ι R ⟨m, hm⟩, FreeAlgebra.lift_ι_apply _ _⟩
-    · exact ⟨1, AlgHom.map_one _⟩
+    · exact ⟨1, map_one _⟩
     · rintro m₁ m₂ ⟨P₁, hP₁⟩ ⟨P₂, hP₂⟩
       exact
         ⟨P₁ * P₂, by
-          rw [AlgHom.map_mul, hP₁, hP₂, of_apply, of_apply, of_apply, single_mul_single,
+          rw [map_mul, hP₁, hP₂, of_apply, of_apply, of_apply, single_mul_single,
             one_mul]; rfl⟩
   · rcases ihf with ⟨P, rfl⟩
     rcases ihg with ⟨Q, rfl⟩
-    exact ⟨P + Q, AlgHom.map_add _ _ _⟩
+    exact ⟨P + Q, map_add _ _ _⟩
   · rcases ih with ⟨P, rfl⟩
-    exact ⟨r • P, AlgHom.map_smul _ _ _⟩
+    exact ⟨r • P, map_smul _ _ _⟩
 
 variable (R M)
 
@@ -636,15 +636,15 @@ theorem mvPolynomial_aeval_of_surjective_of_closure [CommMonoid M] [CommSemiring
   · have : m ∈ closure S := hS.symm ▸ mem_top _
     refine Submonoid.closure_induction this (fun m hm => ?_) ?_ ?_
     · exact ⟨MvPolynomial.X ⟨m, hm⟩, MvPolynomial.aeval_X _ _⟩
-    · exact ⟨1, AlgHom.map_one _⟩
+    · exact ⟨1, map_one _⟩
     · rintro m₁ m₂ ⟨P₁, hP₁⟩ ⟨P₂, hP₂⟩
       exact
         ⟨P₁ * P₂, by
-          rw [AlgHom.map_mul, hP₁, hP₂, of_apply, of_apply, of_apply, single_mul_single, one_mul]⟩
+          rw [map_mul, hP₁, hP₂, of_apply, of_apply, of_apply, single_mul_single, one_mul]⟩
   · rcases ihf with ⟨P, rfl⟩; rcases ihg with ⟨Q, rfl⟩
-    exact ⟨P + Q, AlgHom.map_add _ _ _⟩
+    exact ⟨P + Q, map_add _ _ _⟩
   · rcases ih with ⟨P, rfl⟩
-    exact ⟨r • P, AlgHom.map_smul _ _ _⟩
+    exact ⟨r • P, map_smul _ _ _⟩
 #align monoid_algebra.mv_polynomial_aeval_of_surjective_of_closure MonoidAlgebra.mvPolynomial_aeval_of_surjective_of_closure
 
 
@@ -661,16 +661,16 @@ theorem freeAlgebra_lift_of_surjective_of_closure [CommSemiring R] {S : Set M}
   · have : m ∈ closure S := hS.symm ▸ mem_top _
     refine Submonoid.closure_induction this (fun m hm => ?_) ?_ ?_
     · exact ⟨FreeAlgebra.ι R ⟨m, hm⟩, FreeAlgebra.lift_ι_apply _ _⟩
-    · exact ⟨1, AlgHom.map_one _⟩
+    · exact ⟨1, map_one _⟩
     · rintro m₁ m₂ ⟨P₁, hP₁⟩ ⟨P₂, hP₂⟩
       exact
         ⟨P₁ * P₂, by
-          rw [AlgHom.map_mul, hP₁, hP₂, of_apply, of_apply, of_apply, single_mul_single, one_mul]⟩
+          rw [map_mul, hP₁, hP₂, of_apply, of_apply, of_apply, single_mul_single, one_mul]⟩
   · rcases ihf with ⟨P, rfl⟩
     rcases ihg with ⟨Q, rfl⟩
-    exact ⟨P + Q, AlgHom.map_add _ _ _⟩
+    exact ⟨P + Q, map_add _ _ _⟩
   · rcases ih with ⟨P, rfl⟩
-    exact ⟨r • P, AlgHom.map_smul _ _ _⟩
+    exact ⟨r • P, map_smul _ _ _⟩
 
 /-- If a monoid `M` is finitely generated then `MonoidAlgebra R M` is of finite type. -/
 instance finiteType_of_fg [CommRing R] [Monoid.FG M] : FiniteType R (MonoidAlgebra R M) :=

--- a/Mathlib/RingTheory/FractionalIdeal/Operations.lean
+++ b/Mathlib/RingTheory/FractionalIdeal/Operations.lean
@@ -55,7 +55,7 @@ theorem _root_.IsFractional.map (g : P →ₐ[R] P') {I : Submodule R P} :
       rw [AlgHom.toLinearMap_apply] at hb'
       obtain ⟨x, hx⟩ := hI b' b'_mem
       use x
-      rw [← g.commutes, hx, g.map_smul, hb']⟩
+      rw [← g.commutes, hx, _root_.map_smul, hb']⟩
 #align is_fractional.map IsFractional.map
 
 /-- `I.map g` is the pushforward of the fractional ideal `I` along the algebra morphism `g` -/

--- a/Mathlib/RingTheory/GradedAlgebra/Basic.lean
+++ b/Mathlib/RingTheory/GradedAlgebra/Basic.lean
@@ -199,7 +199,7 @@ an algebra to a direct sum of components. -/
 def decomposeAlgEquiv : A ≃ₐ[R] ⨁ i, 𝒜 i :=
   AlgEquiv.symm
     { (decomposeAddEquiv 𝒜).symm with
-      map_mul' := (coeAlgHom 𝒜).map_mul
+      map_mul' := map_mul (coeAlgHom 𝒜)
       commutes' := (coeAlgHom 𝒜).commutes }
 #align direct_sum.decompose_alg_equiv DirectSum.decomposeAlgEquiv
 

--- a/Mathlib/RingTheory/Ideal/Cotangent.lean
+++ b/Mathlib/RingTheory/Ideal/Cotangent.lean
@@ -207,7 +207,7 @@ def mapCotangent (I₁ : Ideal A) (I₂ : Ideal B) (f : A →ₐ[R] B) (h : I₁
     convert (Submodule.smul_mem_smul (M := I₂) (r := f a)
       (n := ⟨f b, h hb⟩) (h ha) (Submodule.mem_top)) using 1
     ext
-    exact f.map_mul a b
+    exact _root_.map_mul f a b
 
 @[simp]
 lemma mapCotangent_toCotangent

--- a/Mathlib/RingTheory/Ideal/QuotientOperations.lean
+++ b/Mathlib/RingTheory/Ideal/QuotientOperations.lean
@@ -452,7 +452,7 @@ theorem Quotient.liftₐ_comp (I : Ideal A) (f : A →ₐ[R₁] B) (hI : ∀ a :
 theorem KerLift.map_smul (f : A →ₐ[R₁] B) (r : R₁) (x : A ⧸ (RingHom.ker f)) :
     f.kerLift (r • x) = r • f.kerLift x := by
   obtain ⟨a, rfl⟩ := Quotient.mkₐ_surjective R₁ _ x
-  exact f.map_smul _ _
+  exact _root_.map_smul f _ _
 #align ideal.ker_lift.map_smul Ideal.KerLift.map_smul
 
 /-- The induced algebras morphism from the quotient by the kernel to the codomain.

--- a/Mathlib/RingTheory/IsAdjoinRoot.lean
+++ b/Mathlib/RingTheory/IsAdjoinRoot.lean
@@ -149,8 +149,8 @@ theorem map_self (h : IsAdjoinRoot S f) : h.map f = 0 := h.map_eq_zero_iff.mpr d
 @[simp]
 theorem aeval_eq (h : IsAdjoinRoot S f) (p : R[X]) : aeval h.root p = h.map p :=
   Polynomial.induction_on p (fun x => by rw [aeval_C, h.algebraMap_apply])
-    (fun p q ihp ihq => by rw [AlgHom.map_add, RingHom.map_add, ihp, ihq]) fun n x _ => by
-    rw [AlgHom.map_mul, aeval_C, AlgHom.map_pow, aeval_X, RingHom.map_mul, ← h.algebraMap_apply,
+    (fun p q ihp ihq => by rw [map_add, RingHom.map_add, ihp, ihq]) fun n x _ => by
+    rw [map_mul, aeval_C, map_pow, aeval_X, RingHom.map_mul, ← h.algebraMap_apply,
       RingHom.map_pow, map_X]
 #align is_adjoin_root.aeval_eq IsAdjoinRoot.aeval_eq
 

--- a/Mathlib/RingTheory/IsTensorProduct.lean
+++ b/Mathlib/RingTheory/IsTensorProduct.lean
@@ -328,7 +328,7 @@ theorem IsBaseChange.comp {f : M →ₗ[R] N} (hf : IsBaseChange S f) {g : N →
   have : IsScalarTower R S Q := by
     refine ⟨fun x y z => ?_⟩
     change (IsScalarTower.toAlgHom R S T) (x • y) • z = x • algebraMap S T y • z
-    rw [AlgHom.map_smul, smul_assoc]
+    rw [map_smul, smul_assoc]
     rfl
   refine
     ⟨hg.lift (hf.lift i), by
@@ -421,12 +421,12 @@ noncomputable def Algebra.pushoutDesc [H : Algebra.IsPushout R S R' S'] {A : Typ
   letI := Module.compHom A f.toRingHom
   haveI : IsScalarTower R S A :=
     { smul_assoc := fun r s a =>
-        show f (r • s) * a = r • (f s * a) by rw [f.map_smul, smul_mul_assoc] }
+        show f (r • s) * a = r • (f s * a) by rw [map_smul, smul_mul_assoc] }
   haveI : IsScalarTower S A A := { smul_assoc := fun r a b => mul_assoc _ _ _ }
   have : ∀ x, H.out.lift g.toLinearMap (algebraMap R' S' x) = g x := H.out.lift_eq _
   refine AlgHom.ofLinearMap ((H.out.lift g.toLinearMap).restrictScalars R) ?_ ?_
   · dsimp only [LinearMap.restrictScalars_apply]
-    rw [← (algebraMap R' S').map_one, this, g.map_one]
+    rw [← (algebraMap R' S').map_one, this, _root_.map_one]
   · intro x y
     refine H.out.inductionOn x ?_ ?_ ?_ ?_
     · rw [zero_mul, map_zero, zero_mul]
@@ -460,7 +460,7 @@ theorem Algebra.pushoutDesc_left [H : Algebra.IsPushout R S R' S'] {A : Type*} [
   letI := Module.compHom A f.toRingHom
   haveI : IsScalarTower R S A :=
     { smul_assoc := fun r s a =>
-        show f (r • s) * a = r • (f s * a) by rw [f.map_smul, smul_mul_assoc] }
+        show f (r • s) * a = r • (f s * a) by rw [map_smul, smul_mul_assoc] }
   haveI : IsScalarTower S A A := { smul_assoc := fun r a b => mul_assoc _ _ _ }
   rw [Algebra.algebraMap_eq_smul_one, pushoutDesc_apply, map_smul, ←
     Algebra.pushoutDesc_apply S' f g H, _root_.map_one]
@@ -480,7 +480,7 @@ theorem Algebra.pushoutDesc_right [H : Algebra.IsPushout R S R' S'] {A : Type*} 
   letI := Module.compHom A f.toRingHom
   haveI : IsScalarTower R S A :=
     { smul_assoc := fun r s a =>
-        show f (r • s) * a = r • (f s * a) by rw [f.map_smul, smul_mul_assoc] }
+        show f (r • s) * a = r • (f s * a) by rw [map_smul, smul_mul_assoc] }
   IsBaseChange.lift_eq _ _ _
 #align algebra.pushout_desc_right Algebra.pushoutDesc_right
 
@@ -499,7 +499,7 @@ theorem Algebra.IsPushout.algHom_ext [H : Algebra.IsPushout R S R' S'] {A : Type
   · simp only [map_zero]
   · exact AlgHom.congr_fun h₁
   · intro s s' e
-    rw [Algebra.smul_def, f.map_mul, g.map_mul, e]
+    rw [Algebra.smul_def, _root_.map_mul, _root_.map_mul, e]
     congr 1
     exact (AlgHom.congr_fun h₂ s : _)
   · intro s₁ s₂ e₁ e₂

--- a/Mathlib/RingTheory/LaurentSeries.lean
+++ b/Mathlib/RingTheory/LaurentSeries.lean
@@ -324,7 +324,7 @@ theorem coe_coe (P : Polynomial F) : (P : LaurentSeries F) = (P : RatFunc F) := 
 
 @[simp, norm_cast]
 theorem coe_zero : ((0 : RatFunc F) : LaurentSeries F) = 0 :=
-  (coeAlgHom F).map_zero
+  map_zero (coeAlgHom F)
 #align ratfunc.coe_zero RatFunc.coe_zero
 
 theorem coe_ne_zero {f : Polynomial F} (hf : f ≠ 0) : (↑f : PowerSeries F) ≠ 0 := by
@@ -332,32 +332,32 @@ theorem coe_ne_zero {f : Polynomial F} (hf : f ≠ 0) : (↑f : PowerSeries F) �
 
 @[simp, norm_cast]
 theorem coe_one : ((1 : RatFunc F) : LaurentSeries F) = 1 :=
-  (coeAlgHom F).map_one
+  map_one (coeAlgHom F)
 #align ratfunc.coe_one RatFunc.coe_one
 
 @[simp, norm_cast]
 theorem coe_add : ((f + g : RatFunc F) : LaurentSeries F) = f + g :=
-  (coeAlgHom F).map_add _ _
+  map_add (coeAlgHom F) _ _
 #align ratfunc.coe_add RatFunc.coe_add
 
 @[simp, norm_cast]
 theorem coe_sub : ((f - g : RatFunc F) : LaurentSeries F) = f - g :=
-  (coeAlgHom F).map_sub _ _
+  map_sub (coeAlgHom F) _ _
 #align ratfunc.coe_sub RatFunc.coe_sub
 
 @[simp, norm_cast]
 theorem coe_neg : ((-f : RatFunc F) : LaurentSeries F) = -f :=
-  (coeAlgHom F).map_neg _
+  map_neg (coeAlgHom F) _
 #align ratfunc.coe_neg RatFunc.coe_neg
 
 @[simp, norm_cast]
 theorem coe_mul : ((f * g : RatFunc F) : LaurentSeries F) = f * g :=
-  (coeAlgHom F).map_mul _ _
+  map_mul (coeAlgHom F) _ _
 #align ratfunc.coe_mul RatFunc.coe_mul
 
 @[simp, norm_cast]
 theorem coe_pow (n : ℕ) : ((f ^ n : RatFunc F) : LaurentSeries F) = (f : LaurentSeries F) ^ n :=
-  (coeAlgHom F).map_pow _ _
+  map_pow (coeAlgHom F) _ _
 #align ratfunc.coe_pow RatFunc.coe_pow
 
 @[simp, norm_cast]

--- a/Mathlib/RingTheory/LocalProperties.lean
+++ b/Mathlib/RingTheory/LocalProperties.lean
@@ -462,7 +462,7 @@ theorem IsLocalization.smul_mem_finsetIntegerMultiple_span [Algebra R S] [Algebr
   rw [Submodule.span_smul] at hx₁
   replace hx : _ ∈ y' • Submodule.span R (s : Set S') := Set.smul_mem_smul_set hx
   rw [hx₁] at hx
-  erw [← g.map_smul, ← Submodule.map_span (g : S →ₗ[R] S')] at hx
+  erw [← _root_.map_smul g, ← Submodule.map_span (g : S →ₗ[R] S')] at hx
   -- Since `x` falls in the span of `s` in `S'`, `y' • x : S` falls in the span of `s'` in `S'`.
   -- That is, there exists some `x' : S` in the span of `s'` in `S` and `x' = y' • x` in `S'`.
   -- Thus `a • (y' • x) = a • x' ∈ span s'` in `S` for some `a ∈ M`.

--- a/Mathlib/RingTheory/MatrixAlgebra.lean
+++ b/Mathlib/RingTheory/MatrixAlgebra.lean
@@ -111,7 +111,7 @@ theorem invFun_algebraMap (M : Matrix n n R) : invFun R A n (M.map (algebraMap R
 #align matrix_equiv_tensor.inv_fun_algebra_map MatrixEquivTensor.invFun_algebraMap
 
 theorem right_inv (M : Matrix n n A) : (toFunAlgHom R A n) (invFun R A n M) = M := by
-  simp only [invFun, AlgHom.map_sum, stdBasisMatrix, apply_ite ↑(algebraMap R A), smul_eq_mul,
+  simp only [invFun, map_sum, stdBasisMatrix, apply_ite ↑(algebraMap R A), smul_eq_mul,
     mul_boole, toFunAlgHom_apply, RingHom.map_zero, RingHom.map_one, Matrix.map_apply,
     Pi.smul_def]
   convert Finset.sum_product (β := Matrix n n A)

--- a/Mathlib/RingTheory/MvPolynomial/Symmetric.lean
+++ b/Mathlib/RingTheory/MvPolynomial/Symmetric.lean
@@ -85,8 +85,8 @@ variable (σ R)
 def symmetricSubalgebra [CommSemiring R] : Subalgebra R (MvPolynomial σ R) where
   carrier := setOf IsSymmetric
   algebraMap_mem' r e := rename_C e r
-  mul_mem' ha hb e := by rw [AlgHom.map_mul, ha, hb]
-  add_mem' ha hb e := by rw [AlgHom.map_add, ha, hb]
+  mul_mem' ha hb e := by rw [map_mul, ha, hb]
+  add_mem' ha hb e := by rw [map_add, ha, hb]
 #align mv_polynomial.symmetric_subalgebra MvPolynomial.symmetricSubalgebra
 
 variable {σ R}

--- a/Mathlib/RingTheory/PolynomialAlgebra.lean
+++ b/Mathlib/RingTheory/PolynomialAlgebra.lean
@@ -157,13 +157,13 @@ theorem left_inv (x : A ⊗ R[X]) : invFun R A ((toFunAlgHom R A) x) = x := by
     simp only [Algebra.smul_def]
     rfl
   · intro p q hp hq
-    simp only [AlgHom.map_add, invFun_add, hp, hq]
+    simp only [map_add, invFun_add, hp, hq]
 #align poly_equiv_tensor.left_inv PolyEquivTensor.left_inv
 
 theorem right_inv (x : A[X]) : (toFunAlgHom R A) (invFun R A x) = x := by
   refine Polynomial.induction_on' x ?_ ?_
   · intro p q hp hq
-    simp only [invFun_add, AlgHom.map_add, hp, hq]
+    simp only [invFun_add, map_add, hp, hq]
   · intro n a
     rw [invFun_monomial, Algebra.TensorProduct.tmul_pow,
         one_pow, Algebra.TensorProduct.tmul_mul_tmul, mul_one, one_mul, toFunAlgHom_apply_tmul,

--- a/Mathlib/RingTheory/PowerBasis.lean
+++ b/Mathlib/RingTheory/PowerBasis.lean
@@ -153,8 +153,7 @@ noncomputable def minpolyGen (pb : PowerBasis A S) : A[X] :=
 #align power_basis.minpoly_gen PowerBasis.minpolyGen
 
 theorem aeval_minpolyGen (pb : PowerBasis A S) : aeval pb.gen (minpolyGen pb) = 0 := by
-  simp_rw [minpolyGen, AlgHom.map_sub, AlgHom.map_sum, AlgHom.map_mul, AlgHom.map_pow, aeval_C, ←
-    Algebra.smul_def, aeval_X]
+  simp_rw [minpolyGen, map_sub, map_sum, map_mul, map_pow, aeval_C, ← Algebra.smul_def, aeval_X]
   refine sub_eq_zero.mpr ((pb.basis.total_repr (pb.gen ^ pb.dim)).symm.trans ?_)
   rw [Finsupp.total_apply, Finsupp.sum_fintype] <;>
     simp only [pb.coe_basis, zero_smul, eq_self_iff_true, imp_true_iff]
@@ -250,7 +249,7 @@ theorem constr_pow_aeval (pb : PowerBasis A S) {y : S'} (hy : aeval y (minpoly A
   rw [← aeval_modByMonic_eq_self_of_root (minpoly.monic pb.isIntegral_gen) (minpoly.aeval _ _), ←
     @aeval_modByMonic_eq_self_of_root _ _ _ _ _ f _ (minpoly.monic pb.isIntegral_gen) y hy]
   by_cases hf : f %ₘ minpoly A pb.gen = 0
-  · simp only [hf, AlgHom.map_zero, LinearMap.map_zero]
+  · simp only [hf, map_zero]
   have : (f %ₘ minpoly A pb.gen).natDegree < pb.dim := by
     rw [← pb.natDegree_minpoly]
     apply natDegree_lt_natDegree hf
@@ -317,7 +316,7 @@ see `liftEquiv'` for the corresponding statement.
 @[simps]
 noncomputable def liftEquiv (pb : PowerBasis A S) :
     (S →ₐ[A] S') ≃ { y : S' // aeval y (minpoly A pb.gen) = 0 } where
-  toFun f := ⟨f pb.gen, by rw [aeval_algHom_apply, minpoly.aeval, f.map_zero]⟩
+  toFun f := ⟨f pb.gen, by rw [aeval_algHom_apply, minpoly.aeval, map_zero]⟩
   invFun y := pb.lift y y.2
   left_inv f := pb.algHom_ext <| lift_gen _ _ _
   right_inv y := Subtype.ext <| lift_gen _ _ y.prop
@@ -447,7 +446,7 @@ theorem IsIntegral.mem_span_pow [Nontrivial R] {x y : S} (hx : IsIntegral R x)
   have := minpoly.monic hx
   refine ⟨f %ₘ minpoly R x, (degree_modByMonic_lt _ this).trans_le degree_le_natDegree, ?_⟩
   conv_lhs => rw [← modByMonic_add_div f this]
-  simp only [add_zero, zero_mul, minpoly.aeval, aeval_add, AlgHom.map_mul]
+  simp only [add_zero, zero_mul, minpoly.aeval, aeval_add, map_mul]
 #align is_integral.mem_span_pow IsIntegral.mem_span_pow
 
 namespace PowerBasis

--- a/Mathlib/RingTheory/RootsOfUnity/Minpoly.lean
+++ b/Mathlib/RingTheory/RootsOfUnity/Minpoly.lean
@@ -55,7 +55,7 @@ theorem minpoly_dvd_x_pow_sub_one : minpoly ℤ μ ∣ X ^ n - 1 := by
   · simp
   apply minpoly.isIntegrallyClosed_dvd (isIntegral h h0)
   simp only [((IsPrimitiveRoot.iff_def μ n).mp h).left, aeval_X_pow, eq_intCast, Int.cast_one,
-    aeval_one, AlgHom.map_sub, sub_self]
+    aeval_one, map_sub, sub_self]
 set_option linter.uppercaseLean3 false in
 #align is_primitive_root.minpoly_dvd_X_pow_sub_one IsPrimitiveRoot.minpoly_dvd_x_pow_sub_one
 

--- a/Mathlib/RingTheory/TensorProduct/Basic.lean
+++ b/Mathlib/RingTheory/TensorProduct/Basic.lean
@@ -445,7 +445,7 @@ theorem ext ⦃f g : (A ⊗[R] B) →ₐ[S] C⦄
   ext a b
   have := congr_arg₂ HMul.hMul (AlgHom.congr_fun ha a) (AlgHom.congr_fun hb b)
   dsimp at *
-  rwa [← f.map_mul, ← g.map_mul, tmul_mul_tmul, _root_.one_mul, _root_.mul_one] at this
+  rwa [← _root_.map_mul, ← _root_.map_mul, tmul_mul_tmul, _root_.one_mul, _root_.mul_one] at this
 
 theorem ext' {g h : A ⊗[R] B →ₐ[S] C} (H : ∀ a b, g (a ⊗ₜ b) = h (a ⊗ₜ b)) : g = h :=
   ext (AlgHom.ext fun _ => H _ _) (AlgHom.ext fun _ => H _ _)
@@ -684,8 +684,8 @@ def lift (f : A →ₐ[S] C) (g : B →ₐ[R] C) (hfg : ∀ x y, Commute (f x) (
           map_smul' := fun c g => LinearMap.ext fun x => rfl }
       LinearMap.flip <| (restr ∘ₗ LinearMap.mul S C ∘ₗ f.toLinearMap).flip ∘ₗ g)
     (fun a₁ a₂ b₁ b₂ => show f (a₁ * a₂) * g (b₁ * b₂) = f a₁ * g b₁ * (f a₂ * g b₂) by
-      rw [f.map_mul, g.map_mul, (hfg a₂ b₁).mul_mul_mul_comm])
-    (show f 1 * g 1 = 1 by rw [f.map_one, g.map_one, one_mul])
+      rw [_root_.map_mul, _root_.map_mul, (hfg a₂ b₁).mul_mul_mul_comm])
+    (show f 1 * g 1 = 1 by rw [_root_.map_one, _root_.map_one, one_mul])
 
 @[simp]
 theorem lift_tmul (f : A →ₐ[S] C) (g : B →ₐ[R] C) (hfg : ∀ x y, Commute (f x) (g y))

--- a/Mathlib/RingTheory/Trace/Defs.lean
+++ b/Mathlib/RingTheory/Trace/Defs.lean
@@ -121,9 +121,8 @@ theorem trace_trace_of_basis [Algebra S T] [IsScalarTower R S T] {ι κ : Type*}
   rw [trace_eq_matrix_trace (b.smul c), trace_eq_matrix_trace b, trace_eq_matrix_trace c,
     Matrix.trace, Matrix.trace, Matrix.trace, ← Finset.univ_product_univ, Finset.sum_product]
   refine Finset.sum_congr rfl fun i _ ↦ ?_
-  simp only [AlgHom.map_sum, smul_leftMulMatrix, Finset.sum_apply,
-    Matrix.diag, Finset.sum_apply
-      i (Finset.univ : Finset κ) fun y => leftMulMatrix b (leftMulMatrix c x y y)]
+  simp only [map_sum, smul_leftMulMatrix, Finset.sum_apply, Matrix.diag,
+    Finset.sum_apply i (Finset.univ : Finset κ) fun y => leftMulMatrix b (leftMulMatrix c x y y)]
 #align algebra.trace_trace_of_basis Algebra.trace_trace_of_basis
 
 theorem trace_comp_trace_of_basis [Algebra S T] [IsScalarTower R S T] {ι κ : Type*} [Finite ι]

--- a/Mathlib/RingTheory/WittVector/Defs.lean
+++ b/Mathlib/RingTheory/WittVector/Defs.lean
@@ -224,25 +224,25 @@ section WittStructureSimplifications
 @[simp]
 theorem wittZero_eq_zero (n : ℕ) : wittZero p n = 0 := by
   apply MvPolynomial.map_injective (Int.castRingHom ℚ) Int.cast_injective
-  simp only [wittZero, wittStructureRat, bind₁, aeval_zero', constantCoeff_xInTermsOfW,
-    RingHom.map_zero, AlgHom.map_zero, map_wittStructureInt]
+  simp only [wittZero, wittStructureRat, bind₁, aeval_zero', constantCoeff_xInTermsOfW, map_zero,
+    map_wittStructureInt]
 #align witt_vector.witt_zero_eq_zero WittVector.wittZero_eq_zero
 
 @[simp]
 theorem wittOne_zero_eq_one : wittOne p 0 = 1 := by
   apply MvPolynomial.map_injective (Int.castRingHom ℚ) Int.cast_injective
-  simp only [wittOne, wittStructureRat, xInTermsOfW_zero, AlgHom.map_one, RingHom.map_one,
-    bind₁_X_right, map_wittStructureInt]
+  simp only [wittOne, wittStructureRat, xInTermsOfW_zero, map_one, bind₁_X_right,
+    map_wittStructureInt]
 #align witt_vector.witt_one_zero_eq_one WittVector.wittOne_zero_eq_one
 
 @[simp]
 theorem wittOne_pos_eq_zero (n : ℕ) (hn : 0 < n) : wittOne p n = 0 := by
   apply MvPolynomial.map_injective (Int.castRingHom ℚ) Int.cast_injective
-  simp only [wittOne, wittStructureRat, RingHom.map_zero, AlgHom.map_one, RingHom.map_one,
+  simp only [wittOne, wittStructureRat, RingHom.map_zero, map_one, RingHom.map_one,
     map_wittStructureInt]
   induction n using Nat.strong_induction_on with | h n IH => ?_
   rw [xInTermsOfW_eq]
-  simp only [AlgHom.map_mul, AlgHom.map_sub, AlgHom.map_sum, AlgHom.map_pow, bind₁_X_right,
+  simp only [map_mul, map_sub, map_sum, map_pow, bind₁_X_right,
     bind₁_C_right]
   rw [sub_mul, one_mul]
   rw [Finset.sum_eq_single 0]
@@ -257,29 +257,29 @@ theorem wittOne_pos_eq_zero (n : ℕ) (hn : 0 < n) : wittOne p n = 0 := by
 @[simp]
 theorem wittAdd_zero : wittAdd p 0 = X (0, 0) + X (1, 0) := by
   apply MvPolynomial.map_injective (Int.castRingHom ℚ) Int.cast_injective
-  simp only [wittAdd, wittStructureRat, AlgHom.map_add, RingHom.map_add, rename_X,
-    xInTermsOfW_zero, map_X, wittPolynomial_zero, bind₁_X_right, map_wittStructureInt]
+  simp only [wittAdd, wittStructureRat, map_add, rename_X, xInTermsOfW_zero, map_X,
+    wittPolynomial_zero, bind₁_X_right, map_wittStructureInt]
 #align witt_vector.witt_add_zero WittVector.wittAdd_zero
 
 @[simp]
 theorem wittSub_zero : wittSub p 0 = X (0, 0) - X (1, 0) := by
   apply MvPolynomial.map_injective (Int.castRingHom ℚ) Int.cast_injective
-  simp only [wittSub, wittStructureRat, AlgHom.map_sub, RingHom.map_sub, rename_X,
-    xInTermsOfW_zero, map_X, wittPolynomial_zero, bind₁_X_right, map_wittStructureInt]
+  simp only [wittSub, wittStructureRat, map_sub, rename_X, xInTermsOfW_zero, map_X,
+    wittPolynomial_zero, bind₁_X_right, map_wittStructureInt]
 #align witt_vector.witt_sub_zero WittVector.wittSub_zero
 
 @[simp]
 theorem wittMul_zero : wittMul p 0 = X (0, 0) * X (1, 0) := by
   apply MvPolynomial.map_injective (Int.castRingHom ℚ) Int.cast_injective
   simp only [wittMul, wittStructureRat, rename_X, xInTermsOfW_zero, map_X, wittPolynomial_zero,
-    RingHom.map_mul, bind₁_X_right, AlgHom.map_mul, map_wittStructureInt]
+    map_mul, bind₁_X_right, map_wittStructureInt]
 #align witt_vector.witt_mul_zero WittVector.wittMul_zero
 
 @[simp]
 theorem wittNeg_zero : wittNeg p 0 = -X (0, 0) := by
   apply MvPolynomial.map_injective (Int.castRingHom ℚ) Int.cast_injective
   simp only [wittNeg, wittStructureRat, rename_X, xInTermsOfW_zero, map_X, wittPolynomial_zero,
-    RingHom.map_neg, AlgHom.map_neg, bind₁_X_right, map_wittStructureInt]
+    map_neg, bind₁_X_right, map_wittStructureInt]
 #align witt_vector.witt_neg_zero WittVector.wittNeg_zero
 
 @[simp]
@@ -326,17 +326,17 @@ variable (R)
 
 @[simp]
 theorem zero_coeff (n : ℕ) : (0 : 𝕎 R).coeff n = 0 :=
-  show (aeval _ (wittZero p n) : R) = 0 by simp only [wittZero_eq_zero, AlgHom.map_zero]
+  show (aeval _ (wittZero p n) : R) = 0 by simp only [wittZero_eq_zero, map_zero]
 #align witt_vector.zero_coeff WittVector.zero_coeff
 
 @[simp]
 theorem one_coeff_zero : (1 : 𝕎 R).coeff 0 = 1 :=
-  show (aeval _ (wittOne p 0) : R) = 1 by simp only [wittOne_zero_eq_one, AlgHom.map_one]
+  show (aeval _ (wittOne p 0) : R) = 1 by simp only [wittOne_zero_eq_one, map_one]
 #align witt_vector.one_coeff_zero WittVector.one_coeff_zero
 
 @[simp]
 theorem one_coeff_eq_of_pos (n : ℕ) (hn : 0 < n) : coeff (1 : 𝕎 R) n = 0 :=
-  show (aeval _ (wittOne p n) : R) = 0 by simp only [hn, wittOne_pos_eq_zero, AlgHom.map_zero]
+  show (aeval _ (wittOne p n) : R) = 0 by simp only [hn, wittOne_pos_eq_zero, map_zero]
 #align witt_vector.one_coeff_eq_of_pos WittVector.one_coeff_eq_of_pos
 
 variable {p R}

--- a/Mathlib/RingTheory/WittVector/Frobenius.lean
+++ b/Mathlib/RingTheory/WittVector/Frobenius.lean
@@ -147,7 +147,7 @@ theorem map_frobeniusPoly (n : ℕ) :
   refine Nat.strong_induction_on n ?_; clear n
   intro n IH
   rw [xInTermsOfW_eq]
-  simp only [AlgHom.map_sum, AlgHom.map_sub, AlgHom.map_mul, AlgHom.map_pow, bind₁_C_right]
+  simp only [map_sum, map_sub, map_mul, map_pow (bind₁ _), bind₁_C_right]
   have h1 : (p : ℚ) ^ n * ⅟ (p : ℚ) ^ n = 1 := by rw [← mul_pow, mul_invOf_self, one_pow]
   rw [bind₁_X_right, Function.comp_apply, wittPolynomial_eq_sum_C_mul_X_pow, sum_range_succ,
     sum_range_succ, tsub_self, add_tsub_cancel_left, pow_zero, pow_one, pow_one, sub_mul, add_mul,

--- a/Mathlib/RingTheory/WittVector/InitTail.lean
+++ b/Mathlib/RingTheory/WittVector/InitTail.lean
@@ -73,8 +73,8 @@ theorem coeff_select (x : 𝕎 R) (n : ℕ) :
     (select P x).coeff n = aeval x.coeff (selectPoly P n) := by
   dsimp [select, selectPoly]
   split_ifs with hi
-  · rw [aeval_X, mk]; simp only [hi]; rfl
-  · rw [AlgHom.map_zero, mk]; simp only [hi]; rfl
+  · rw [aeval_X, mk]; simp only [hi, if_true]
+  · rw [map_zero, mk]; simp only [hi, if_false]
 #align witt_vector.coeff_select WittVector.coeff_select
 
 -- Porting note: replaced `@[is_poly]` with `instance`. Made the argument `P` implicit in doing so.
@@ -98,9 +98,9 @@ theorem select_add_select_not : ∀ x : 𝕎 R, select P x + select (fun i => ¬
         (bind₁ (selectPoly fun i => ¬P i)) (wittPolynomial p ℤ n) =
       wittPolynomial p ℤ n by
     apply_fun aeval x.coeff at this
-    simpa only [AlgHom.map_add, aeval_bind₁, ← coeff_select]
-  simp only [wittPolynomial_eq_sum_C_mul_X_pow, selectPoly, AlgHom.map_sum, AlgHom.map_pow,
-    AlgHom.map_mul, bind₁_X_right, bind₁_C_right, ← Finset.sum_add_distrib, ← mul_add]
+    simpa only [map_add, aeval_bind₁, ← coeff_select]
+  simp only [wittPolynomial_eq_sum_C_mul_X_pow, selectPoly, map_sum, map_pow, map_mul,
+    bind₁_X_right, bind₁_C_right, ← Finset.sum_add_distrib, ← mul_add]
   apply Finset.sum_congr rfl
   refine fun m _ => mul_eq_mul_left_iff.mpr (Or.inl ?_)
   rw [ite_pow, zero_pow (pow_ne_zero _ hp.out.ne_zero)]

--- a/Mathlib/RingTheory/WittVector/IsPoly.lean
+++ b/Mathlib/RingTheory/WittVector/IsPoly.lean
@@ -289,7 +289,7 @@ section ZeroOne
 we model them as constant unary functions. -/
 /-- The function that is constantly zero on Witt vectors is a polynomial function. -/
 instance zeroIsPoly [Fact p.Prime] : IsPoly p fun _ _ _ => 0 :=
-  ⟨⟨0, by intros; funext n; simp only [Pi.zero_apply, AlgHom.map_zero, zero_coeff]⟩⟩
+  ⟨⟨0, by intros; funext n; simp only [Pi.zero_apply, map_zero, zero_coeff]⟩⟩
 #align witt_vector.zero_is_poly WittVector.zeroIsPoly
 
 @[simp]
@@ -306,12 +306,12 @@ def onePoly (n : ℕ) : MvPolynomial ℕ ℤ :=
 @[simp]
 theorem bind₁_onePoly_wittPolynomial [hp : Fact p.Prime] (n : ℕ) :
     bind₁ onePoly (wittPolynomial p ℤ n) = 1 := by
-  rw [wittPolynomial_eq_sum_C_mul_X_pow, AlgHom.map_sum, Finset.sum_eq_single 0]
-  · simp only [onePoly, one_pow, one_mul, AlgHom.map_pow, C_1, pow_zero, bind₁_X_right, if_true,
+  rw [wittPolynomial_eq_sum_C_mul_X_pow, map_sum, Finset.sum_eq_single 0]
+  · simp only [onePoly, one_pow, one_mul, map_pow, C_1, pow_zero, bind₁_X_right, if_true,
       eq_self_iff_true]
   · intro i _hi hi0
-    simp only [onePoly, if_neg hi0, zero_pow (pow_ne_zero _ hp.1.ne_zero), mul_zero,
-      AlgHom.map_pow, bind₁_X_right, AlgHom.map_mul]
+    simp only [onePoly, if_neg hi0, zero_pow (pow_ne_zero _ hp.1.ne_zero), mul_zero, map_pow,
+      bind₁_X_right, map_mul]
   · simp
 #align witt_vector.bind₁_one_poly_witt_polynomial WittVector.bind₁_onePoly_wittPolynomial
 

--- a/Mathlib/RingTheory/WittVector/MulCoeff.lean
+++ b/Mathlib/RingTheory/WittVector/MulCoeff.lean
@@ -122,7 +122,7 @@ theorem mul_polyOfInterest_aux1 (n : ℕ) :
   simp only [wittPolyProd]
   convert wittStructureInt_prop p (X (0 : Fin 2) * X 1) n using 1
   · simp only [wittPolynomial, wittMul]
-    rw [AlgHom.map_sum]
+    rw [map_sum]
     congr 1 with i
     congr 1
     have hsupp : (Finsupp.single i (p ^ (n - i))).support = {i} := by
@@ -152,7 +152,7 @@ theorem mul_polyOfInterest_aux3 (n : ℕ) : wittPolyProd p (n + 1) =
   -- Porting note: the original proof applies `sum_range_succ` through a non-`conv` rewrite,
   -- but this does not work in Lean 4; the whole proof also times out very badly. The proof has been
   -- nearly totally rewritten here and now finishes quite fast.
-  rw [wittPolyProd, wittPolynomial, AlgHom.map_sum, AlgHom.map_sum]
+  rw [wittPolyProd, wittPolynomial, map_sum, map_sum]
   conv_lhs =>
     arg 1
     rw [sum_range_succ, ← C_mul_X_pow_eq_monomial, tsub_self, pow_zero, pow_one, map_mul,

--- a/Mathlib/RingTheory/WittVector/MulP.lean
+++ b/Mathlib/RingTheory/WittVector/MulP.lean
@@ -50,8 +50,7 @@ variable {p}
 theorem mulN_coeff (n : ℕ) (x : 𝕎 R) (k : ℕ) :
     (x * n).coeff k = aeval x.coeff (wittMulN p n k) := by
   induction' n with n ih generalizing k
-  · simp only [Nat.zero_eq, Nat.cast_zero, mul_zero, zero_coeff, wittMulN,
-      AlgHom.map_zero, Pi.zero_apply]
+  · simp only [Nat.cast_zero, mul_zero, zero_coeff, wittMulN, Pi.zero_apply, map_zero]
   · rw [wittMulN, Nat.cast_add, Nat.cast_one, mul_add, mul_one, aeval_bind₁, add_coeff]
     apply eval₂Hom_congr (RingHom.ext_int _ _) _ rfl
     ext1 ⟨b, i⟩
@@ -74,7 +73,7 @@ theorem bind₁_wittMulN_wittPolynomial (n k : ℕ) :
   induction' n with n ih
   · simp [wittMulN, Nat.cast_zero, zero_mul, bind₁_zero_wittPolynomial]
   · rw [wittMulN, ← bind₁_bind₁, wittAdd, wittStructureInt_prop]
-    simp only [AlgHom.map_add, Nat.cast_succ, bind₁_X_right]
+    simp only [map_add, Nat.cast_succ, bind₁_X_right]
     rw [add_mul, one_mul, bind₁_rename, bind₁_rename]
     simp only [ih, Function.uncurry, Function.comp, bind₁_X_left, AlgHom.id_apply,
       Matrix.cons_val_zero, Matrix.head_cons, Matrix.cons_val_one]

--- a/Mathlib/RingTheory/WittVector/StructurePolynomial.lean
+++ b/Mathlib/RingTheory/WittVector/StructurePolynomial.lean
@@ -168,11 +168,11 @@ theorem wittStructureRat_rec_aux (Φ : MvPolynomial idx ℚ) (n : ℕ) :
         ∑ i ∈ range n, C ((p : ℚ) ^ i) * wittStructureRat p Φ i ^ p ^ (n - i) := by
   have := xInTermsOfW_aux p ℚ n
   replace := congr_arg (bind₁ fun k : ℕ => bind₁ (fun i => rename (Prod.mk i) (W_ ℚ k)) Φ) this
-  rw [AlgHom.map_mul, bind₁_C_right] at this
+  rw [map_mul, bind₁_C_right] at this
   rw [wittStructureRat, this]; clear this
-  conv_lhs => simp only [AlgHom.map_sub, bind₁_X_right]
+  conv_lhs => simp only [map_sub, bind₁_X_right]
   rw [sub_right_inj]
-  simp only [AlgHom.map_sum, AlgHom.map_mul, bind₁_C_right, AlgHom.map_pow]
+  simp only [map_sum, map_mul, bind₁_C_right, map_pow]
   rfl
 #align witt_structure_rat_rec_aux wittStructureRat_rec_aux
 

--- a/Mathlib/RingTheory/WittVector/WittPolynomial.lean
+++ b/Mathlib/RingTheory/WittVector/WittPolynomial.lean
@@ -145,7 +145,7 @@ theorem wittPolynomial_one : wittPolynomial p R 1 = C (p : R) * X 1 + X 0 ^ p :=
 
 theorem aeval_wittPolynomial {A : Type*} [CommRing A] [Algebra R A] (f : ℕ → A) (n : ℕ) :
     aeval f (W_ R n) = ∑ i ∈ range (n + 1), (p : A) ^ i * f i ^ p ^ (n - i) := by
-  simp [wittPolynomial, AlgHom.map_sum, aeval_monomial, Finsupp.prod_single_index]
+  simp [wittPolynomial, map_sum, aeval_monomial, Finsupp.prod_single_index]
 #align aeval_witt_polynomial aeval_wittPolynomial
 
 /-- Over the ring `ZMod (p^(n+1))`, we produce the `n+1`st Witt polynomial
@@ -155,9 +155,9 @@ theorem wittPolynomial_zmod_self (n : ℕ) :
     W_ (ZMod (p ^ (n + 1))) (n + 1) = expand p (W_ (ZMod (p ^ (n + 1))) n) := by
   simp only [wittPolynomial_eq_sum_C_mul_X_pow]
   rw [sum_range_succ, ← Nat.cast_pow, CharP.cast_eq_zero (ZMod (p ^ (n + 1))) (p ^ (n + 1)), C_0,
-    zero_mul, add_zero, AlgHom.map_sum, sum_congr rfl]
+    zero_mul, add_zero, map_sum, sum_congr rfl]
   intro k hk
-  rw [AlgHom.map_mul, AlgHom.map_pow, expand_X, algHom_C, ← pow_mul, ← pow_succ']
+  rw [map_mul (expand p), map_pow (expand p), expand_X, algHom_C, ← pow_mul, ← pow_succ']
   congr
   rw [mem_range] at hk
   rw [add_comm, add_tsub_assoc_of_le (Nat.lt_succ_iff.mp hk), ← add_comm]
@@ -293,8 +293,8 @@ set_option linter.uppercaseLean3 false in
 @[simp]
 theorem bind₁_xInTermsOfW_wittPolynomial [Invertible (p : R)] (k : ℕ) :
     bind₁ (xInTermsOfW p R) (W_ R k) = X k := by
-  rw [wittPolynomial_eq_sum_C_mul_X_pow, AlgHom.map_sum]
-  simp only [Nat.cast_pow, AlgHom.map_pow, C_pow, AlgHom.map_mul, algHom_C, algebraMap_eq]
+  rw [wittPolynomial_eq_sum_C_mul_X_pow, map_sum]
+  simp only [Nat.cast_pow, map_pow, C_pow, map_mul, algHom_C, algebraMap_eq]
   rw [sum_range_succ_comm, tsub_self, pow_zero, pow_one, bind₁_X_right, mul_comm, ← C_pow,
     xInTermsOfW_aux]
   simp only [Nat.cast_pow, C_pow, bind₁_X_right, sub_add_cancel]
@@ -307,7 +307,7 @@ theorem bind₁_wittPolynomial_xInTermsOfW [Invertible (p : R)] (n : ℕ) :
   apply Nat.strongInductionOn n
   clear n
   intro n H
-  rw [xInTermsOfW_eq, AlgHom.map_mul, AlgHom.map_sub, bind₁_X_right, algHom_C, AlgHom.map_sum,
+  rw [xInTermsOfW_eq, map_mul, map_sub, bind₁_X_right, algHom_C, map_sum,
     show X n = (X n * C ((p : R) ^ n)) * C ((⅟p : R) ^ n) by
       rw [mul_assoc, ← C_mul, ← mul_pow, mul_invOf_self, one_pow, map_one, mul_one]]
   congr 1
@@ -316,6 +316,6 @@ theorem bind₁_wittPolynomial_xInTermsOfW [Invertible (p : R)] (n : ℕ) :
   apply sum_congr rfl
   intro i h
   rw [mem_range] at h
-  rw [AlgHom.map_mul, AlgHom.map_pow, algHom_C, H i h, algebraMap_eq]
+  rw [map_mul, map_pow (bind₁ _), algHom_C, H i h, algebraMap_eq]
 set_option linter.uppercaseLean3 false in
 #align bind₁_witt_polynomial_X_in_terms_of_W bind₁_wittPolynomial_xInTermsOfW


### PR DESCRIPTION
These are redundant. Unfortunately there's two cases involving `GradedAlgebra` where a direct replacement times out, so I ignored those for now.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
