### PR TITLE
[Merged by Bors] - chore: move two lemmas about the exponent and the rank of groups

### DIFF
--- a/Mathlib/GroupTheory/Exponent.lean
+++ b/Mathlib/GroupTheory/Exponent.lean
@@ -3,8 +3,6 @@ Copyright (c) 2021 Julian Kuelshammer. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Julian Kuelshammer
 -/
-import Mathlib.Data.ZMod.Quotient
-import Mathlib.GroupTheory.NoncommPiCoprod
 import Mathlib.GroupTheory.OrderOfElement
 import Mathlib.Algebra.GCDMonoid.Finset
 import Mathlib.Algebra.GCDMonoid.Nat
@@ -576,38 +574,6 @@ theorem Subgroup.pow_exponent_eq_one {H : Subgroup G} {g : G} (g_in_H : g ∈ H)
     g ^ Monoid.exponent H = 1 := exponent_toSubmonoid H ▸ Submonoid.pow_exponent_eq_one g_in_H
 
 end Group
-
-section CommGroup
-
-open Subgroup
-
-variable (G) [CommGroup G] [Group.FG G]
-
-@[to_additive]
-theorem card_dvd_exponent_pow_rank : Nat.card G ∣ Monoid.exponent G ^ Group.rank G := by
-  obtain ⟨S, hS1, hS2⟩ := Group.rank_spec G
-  rw [← hS1, ← Fintype.card_coe, ← Finset.card_univ, ← Finset.prod_const]
-  let f : (∀ g : S, zpowers (g : G)) →* G := noncommPiCoprod fun s t _ x y _ _ => mul_comm x _
-  have hf : Function.Surjective f := by
-    rw [← MonoidHom.range_top_iff_surjective, eq_top_iff, ← hS2, closure_le]
-    exact fun g hg => ⟨Pi.mulSingle ⟨g, hg⟩ ⟨g, mem_zpowers g⟩, noncommPiCoprod_mulSingle _ _⟩
-  replace hf := nat_card_dvd_of_surjective f hf
-  rw [Nat.card_pi] at hf
-  refine hf.trans (Finset.prod_dvd_prod_of_dvd _ _ fun g _ => ?_)
-  rw [Nat.card_zpowers]
-  exact Monoid.order_dvd_exponent (g : G)
-#align card_dvd_exponent_pow_rank card_dvd_exponent_pow_rank
-#align card_dvd_exponent_nsmul_rank card_dvd_exponent_nsmul_rank
-
-@[to_additive]
-theorem card_dvd_exponent_pow_rank' {n : ℕ} (hG : ∀ g : G, g ^ n = 1) :
-    Nat.card G ∣ n ^ Group.rank G :=
-  (card_dvd_exponent_pow_rank G).trans
-    (pow_dvd_pow_of_dvd (Monoid.exponent_dvd_of_forall_pow_eq_one hG) (Group.rank G))
-#align card_dvd_exponent_pow_rank' card_dvd_exponent_pow_rank'
-#align card_dvd_exponent_nsmul_rank' card_dvd_exponent_nsmul_rank'
-
-end CommGroup
 
 section PiProd
 

--- a/Mathlib/GroupTheory/Schreier.lean
+++ b/Mathlib/GroupTheory/Schreier.lean
@@ -28,6 +28,40 @@ In this file we prove Schreier's lemma.
 
 open scoped Pointwise
 
+section CommGroup
+
+open Subgroup
+
+open scoped Classical
+
+variable (G : Type*) [CommGroup G] [Group.FG G]
+
+@[to_additive]
+theorem card_dvd_exponent_pow_rank : Nat.card G ∣ Monoid.exponent G ^ Group.rank G := by
+  obtain ⟨S, hS1, hS2⟩ := Group.rank_spec G
+  rw [← hS1, ← Fintype.card_coe, ← Finset.card_univ, ← Finset.prod_const]
+  let f : (∀ g : S, zpowers (g : G)) →* G := noncommPiCoprod fun s t _ x y _ _ => mul_comm x _
+  have hf : Function.Surjective f := by
+    rw [← MonoidHom.range_top_iff_surjective, eq_top_iff, ← hS2, closure_le]
+    exact fun g hg => ⟨Pi.mulSingle ⟨g, hg⟩ ⟨g, mem_zpowers g⟩, noncommPiCoprod_mulSingle _ _⟩
+  replace hf := nat_card_dvd_of_surjective f hf
+  rw [Nat.card_pi] at hf
+  refine hf.trans (Finset.prod_dvd_prod_of_dvd _ _ fun g _ => ?_)
+  rw [Nat.card_zpowers]
+  exact Monoid.order_dvd_exponent (g : G)
+#align card_dvd_exponent_pow_rank card_dvd_exponent_pow_rank
+#align card_dvd_exponent_nsmul_rank card_dvd_exponent_nsmul_rank
+
+@[to_additive]
+theorem card_dvd_exponent_pow_rank' {n : ℕ} (hG : ∀ g : G, g ^ n = 1) :
+    Nat.card G ∣ n ^ Group.rank G :=
+  (card_dvd_exponent_pow_rank G).trans
+    (pow_dvd_pow_of_dvd (Monoid.exponent_dvd_of_forall_pow_eq_one hG) (Group.rank G))
+#align card_dvd_exponent_pow_rank' card_dvd_exponent_pow_rank'
+#align card_dvd_exponent_nsmul_rank' card_dvd_exponent_nsmul_rank'
+
+end CommGroup
+
 namespace Subgroup
 
 open MemRightTransversals

--- a/Mathlib/GroupTheory/SpecificGroups/Cyclic.lean
+++ b/Mathlib/GroupTheory/SpecificGroups/Cyclic.lean
@@ -5,6 +5,7 @@ Authors: Johannes Hölzl
 -/
 import Mathlib.Algebra.Order.BigOperators.Ring.Finset
 import Mathlib.Data.Nat.Totient
+import Mathlib.Data.ZMod.Quotient
 import Mathlib.GroupTheory.OrderOfElement
 import Mathlib.GroupTheory.Subgroup.Simple
 import Mathlib.Tactic.Group


### PR DESCRIPTION
These are strictly speaking not specific to Schreier's lemma, but are only used there and bring in somewhat heavy imports. This change flips the longest pole in mathlib back to topology/analysis.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
