### PR TITLE
doc(RingTheory/Flat/Algebra): fix docstring

### DIFF
--- a/Mathlib/RingTheory/Flat/Algebra.lean
+++ b/Mathlib/RingTheory/Flat/Algebra.lean
@@ -59,7 +59,7 @@ theorem isBaseChange [Algebra R S] (R' : Type w) (S' : Type t) [CommRing R'] [Co
 
 end Algebra.Flat
 
-/-- A `RingHom` is flat if `R` is flat as an `S` algebra. -/
+/-- A `RingHom` is flat if `S` is flat as an `R` algebra. -/
 class RingHom.Flat {R : Type u} {S : Type v} [CommRing R] [CommRing S] (f : R →+* S) : Prop where
   out : f.toAlgebra.Flat := by infer_instance
 


### PR DESCRIPTION
Switched the roles of R and S in the docstring of Algebra.lean line 62


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
