### PR TITLE
feat(Order/Monotone/Basic): add `prod_map_iterate`

### DIFF
--- a/Mathlib/Order/Monotone/Basic.lean
+++ b/Mathlib/Order/Monotone/Basic.lean
@@ -1256,3 +1256,10 @@ theorem const_strictMono [Nonempty β] : StrictMono (const β : α → β → α
 #align function.const_strict_mono Function.const_strictMono
 
 end Function
+
+theorem prod_map_iterate {X Y : Type _} (S : X → X) (T : Y → Y) (n : ℕ) :
+    (Prod.map S T)^[n] = Prod.map S^[n] T^[n] := by
+  induction' n with n hn
+  · rw [Function.iterate_zero, Function.iterate_zero, Function.iterate_zero, Prod.map_id]
+  · rw [Function.iterate_succ, hn, Prod.map_comp_map, ← Function.iterate_succ,
+    ← Function.iterate_succ]

--- a/Mathlib/Order/Monotone/Basic.lean
+++ b/Mathlib/Order/Monotone/Basic.lean
@@ -1257,9 +1257,9 @@ theorem const_strictMono [Nonempty β] : StrictMono (const β : α → β → α
 
 end Function
 
-theorem prod_map_iterate {X Y : Type _} (S : X → X) (T : Y → Y) (n : ℕ) :
+theorem prod_map_iterate (S : α → α) (T : β → β) (n : ℕ) :
     (Prod.map S T)^[n] = Prod.map S^[n] T^[n] := by
-  induction' n with n hn
-  · rw [Function.iterate_zero, Function.iterate_zero, Function.iterate_zero, Prod.map_id]
-  · rw [Function.iterate_succ, hn, Prod.map_comp_map, ← Function.iterate_succ,
+  induction n with
+  | zero => rw [Function.iterate_zero, Function.iterate_zero, Function.iterate_zero, Prod.map_id]
+  | succ n hn => rw [Function.iterate_succ, hn, Prod.map_comp_map, ← Function.iterate_succ,
     ← Function.iterate_succ]


### PR DESCRIPTION
This PR adds `prod_map_iterate`.

I don't know what is supposed to be the optimal location for this theorem.

`#find_home! prod_map_iterate` suggested this file, but I am not sure where exactly it should be put within that file.

Co-authored-by: @D-Thomine 

---

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
