### PR TITLE
[Merged by Bors] - chore(Algebra/Homology): remove unnecessary ReflectsEpimorphisms instance

### DIFF
--- a/Mathlib/Algebra/Homology/ShortComplex/Exact.lean
+++ b/Mathlib/Algebra/Homology/ShortComplex/Exact.lean
@@ -941,8 +941,6 @@ instance : F.PreservesEpimorphisms where
     exact ((S.map F).exact_iff_epi (by simp)).1
       (((S.exact_iff_epi rfl).2 hf).map F)
 
--- This is true for any faithful functor.
-example [Faithful F] [CategoryWithHomology C] : F.ReflectsEpimorphisms := inferInstance
 
 end Functor
 

--- a/Mathlib/Algebra/Homology/ShortComplex/Exact.lean
+++ b/Mathlib/Algebra/Homology/ShortComplex/Exact.lean
@@ -934,12 +934,8 @@ instance : F.PreservesMonomorphisms where
     exact ((S.map F).exact_iff_mono (by simp)).1
       (((S.exact_iff_mono rfl).2 hf).map F)
 
-instance [Faithful F] [CategoryWithHomology C] : F.ReflectsMonomorphisms where
-  reflects {X Y} f hf := by
-    let S := ShortComplex.mk (0 : X ⟶ X) f zero_comp
-    exact (S.exact_iff_mono rfl).1
-      ((ShortComplex.exact_map_iff_of_faithful S F).1
-      (((S.map F).exact_iff_mono (by simp)).2 hf))
+-- This is true for any faithful functor.
+example [Faithful F] [CategoryWithHomology C] : F.ReflectsMonomorphisms := inferInstance
 
 instance : F.PreservesEpimorphisms where
   preserves {X Y} f hf := by
@@ -947,12 +943,8 @@ instance : F.PreservesEpimorphisms where
     exact ((S.map F).exact_iff_epi (by simp)).1
       (((S.exact_iff_epi rfl).2 hf).map F)
 
-instance [Faithful F] [CategoryWithHomology C] : F.ReflectsEpimorphisms where
-  reflects {X Y} f hf := by
-    let S := ShortComplex.mk f (0 : Y ⟶ Y) comp_zero
-    exact (S.exact_iff_epi rfl).1
-      ((ShortComplex.exact_map_iff_of_faithful S F).1
-      (((S.map F).exact_iff_epi (by simp)).2 hf))
+-- This is true for any faithful functor.
+example [Faithful F] [CategoryWithHomology C] : F.ReflectsEpimorphisms := inferInstance
 
 end Functor
 

--- a/Mathlib/Algebra/Homology/ShortComplex/Exact.lean
+++ b/Mathlib/Algebra/Homology/ShortComplex/Exact.lean
@@ -934,8 +934,6 @@ instance : F.PreservesMonomorphisms where
     exact ((S.map F).exact_iff_mono (by simp)).1
       (((S.exact_iff_mono rfl).2 hf).map F)
 
--- This is true for any faithful functor.
-example [Faithful F] [CategoryWithHomology C] : F.ReflectsMonomorphisms := inferInstance
 
 instance : F.PreservesEpimorphisms where
   preserves {X Y} f hf := by


### PR DESCRIPTION
---
I just randomly noticed that this was stated as an instance when it in fact holds in more generality

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
