### PR TITLE
[Merged by Bors] - chore: remove conditional dependency on doc-gen

### DIFF
--- a/lakefile.lean
+++ b/lakefile.lean
@@ -18,9 +18,6 @@ package mathlib where
 ## Mathlib dependencies on upstream projects.
 -/
 
-meta if get_config? doc = some "on" then -- do not download and build doc-gen4 by default
-require «doc-gen4» from git "https://github.com/leanprover/doc-gen4" @ "main"
-
 require batteries from git "https://github.com/leanprover-community/batteries" @ "main"
 require Qq from git "https://github.com/leanprover-community/quote4" @ "master"
 require aesop from git "https://github.com/leanprover-community/aesop" @ "master"


### PR DESCRIPTION
Mathlib's documentation generation CI uses a downstream repository, which just has a conventional `require` on both Mathlib and docgen.

As far as I'm aware (please correct me!) this isn't actually needed by anyone.

We are very keen to get rid of `meta if`, move to `lakefile.toml`s, and avoid instructing users to ever use `lake -R`.

If this change works, I hope that the downstream mathematical repositories that are also using docgen can all follow suit.