### PR TITLE
[Merged by Bors] - perf (Algebra.AddConstMap): scope simp lemmas

### DIFF
--- a/Mathlib/Algebra/AddConstMap/Basic.lean
+++ b/Mathlib/Algebra/AddConstMap/Basic.lean
@@ -62,7 +62,7 @@ namespace AddConstMapClass
 In this section we prove properties like `f (x + n • a) = f x + n • b`.
 -/
 
-attribute [simp] map_add_const
+scoped [AddConstMapClass] attribute [simp] map_add_const
 
 variable {F G H : Type*} [FunLike F G H] {a : G} {b : H}
 
@@ -70,19 +70,19 @@ protected theorem semiconj [Add G] [Add H] [AddConstMapClass F G H a b] (f : F) 
     Semiconj f (· + a) (· + b) :=
   map_add_const f
 
-@[simp]
+@[scoped simp]
 theorem map_add_nsmul [AddMonoid G] [AddMonoid H] [AddConstMapClass F G H a b]
     (f : F) (x : G) (n : ℕ) : f (x + n • a) = f x + n • b := by
   simpa using (AddConstMapClass.semiconj f).iterate_right n x
 
-@[simp]
+@[scoped simp]
 theorem map_add_nat' [AddMonoidWithOne G] [AddMonoid H] [AddConstMapClass F G H 1 b]
     (f : F) (x : G) (n : ℕ) : f (x + n) = f x + n • b := by simp [← map_add_nsmul]
 
 theorem map_add_one [AddMonoidWithOne G] [Add H] [AddConstMapClass F G H 1 b]
     (f : F) (x : G) : f (x + 1) = f x + b := map_add_const f x
 
-@[simp]
+@[scoped simp]
 theorem map_add_ofNat' [AddMonoidWithOne G] [AddMonoid H] [AddConstMapClass F G H 1 b]
     (f : F) (x : G) (n : ℕ) [n.AtLeastTwo] :
     f (x + no_index (OfNat.ofNat n)) = f x + (OfNat.ofNat n : ℕ) • b :=
@@ -95,7 +95,7 @@ theorem map_add_ofNat [AddMonoidWithOne G] [AddMonoidWithOne H] [AddConstMapClas
     (f : F) (x : G) (n : ℕ) [n.AtLeastTwo] :
     f (x + OfNat.ofNat n) = f x + OfNat.ofNat n := map_add_nat f x n
 
-@[simp]
+@[scoped simp]
 theorem map_const [AddZeroClass G] [Add H] [AddConstMapClass F G H a b] (f : F) :
     f a = f 0 + b := by
   simpa using map_add_const f 0
@@ -104,12 +104,12 @@ theorem map_one [AddZeroClass G] [One G] [Add H] [AddConstMapClass F G H 1 b] (f
     f 1 = f 0 + b :=
   map_const f
 
-@[simp]
+@[scoped simp]
 theorem map_nsmul_const [AddMonoid G] [AddMonoid H] [AddConstMapClass F G H a b]
     (f : F) (n : ℕ) : f (n • a) = f 0 + n • b := by
   simpa using map_add_nsmul f 0 n
 
-@[simp]
+@[scoped simp]
 theorem map_nat' [AddMonoidWithOne G] [AddMonoid H] [AddConstMapClass F G H 1 b]
     (f : F) (n : ℕ) : f n = f 0 + n • b := by
   simpa using map_add_nat' f 0 n
@@ -126,7 +126,7 @@ theorem map_ofNat [AddMonoidWithOne G] [AddMonoidWithOne H] [AddConstMapClass F 
     (f : F) (n : ℕ) [n.AtLeastTwo] :
     f (OfNat.ofNat n) = f 0 + OfNat.ofNat n := map_nat f n
 
-@[simp]
+@[scoped simp]
 theorem map_const_add [AddCommSemigroup G] [Add H] [AddConstMapClass F G H a b]
     (f : F) (x : G) : f (a + x) = f x + b := by
   rw [add_comm, map_add_const]
@@ -134,12 +134,12 @@ theorem map_const_add [AddCommSemigroup G] [Add H] [AddConstMapClass F G H a b]
 theorem map_one_add [AddCommMonoidWithOne G] [Add H] [AddConstMapClass F G H 1 b]
     (f : F) (x : G) : f (1 + x) = f x + b := map_const_add f x
 
-@[simp]
+@[scoped simp]
 theorem map_nsmul_add [AddCommMonoid G] [AddMonoid H] [AddConstMapClass F G H a b]
     (f : F) (n : ℕ) (x : G) : f (n • a + x) = f x + n • b := by
   rw [add_comm, map_add_nsmul]
 
-@[simp]
+@[scoped simp]
 theorem map_nat_add' [AddCommMonoidWithOne G] [AddMonoid H] [AddConstMapClass F G H 1 b]
     (f : F) (n : ℕ) (x : G) : f (↑n + x) = f x + n • b := by
   simpa using map_nsmul_add f n x
@@ -157,12 +157,12 @@ theorem map_ofNat_add [AddCommMonoidWithOne G] [AddMonoidWithOne H] [AddConstMap
     f (OfNat.ofNat n + x) = f x + OfNat.ofNat n :=
   map_nat_add f n x
 
-@[simp]
+@[scoped simp]
 theorem map_sub_nsmul [AddGroup G] [AddGroup H] [AddConstMapClass F G H a b]
     (f : F) (x : G) (n : ℕ) : f (x - n • a) = f x - n • b := by
   conv_rhs => rw [← sub_add_cancel x (n • a), map_add_nsmul, add_sub_cancel_right]
 
-@[simp]
+@[scoped simp]
 theorem map_sub_const [AddGroup G] [AddGroup H] [AddConstMapClass F G H a b]
     (f : F) (x : G) : f (x - a) = f x - b := by
   simpa using map_sub_nsmul f x 1
@@ -171,29 +171,29 @@ theorem map_sub_one [AddGroup G] [One G] [AddGroup H] [AddConstMapClass F G H 1 
     (f : F) (x : G) : f (x - 1) = f x - b :=
   map_sub_const f x
 
-@[simp]
+@[scoped simp]
 theorem map_sub_nat' [AddGroupWithOne G] [AddGroup H] [AddConstMapClass F G H 1 b]
     (f : F) (x : G) (n : ℕ) : f (x - n) = f x - n • b := by
   simpa using map_sub_nsmul f x n
 
-@[simp]
+@[scoped simp]
 theorem map_sub_ofNat' [AddGroupWithOne G] [AddGroup H] [AddConstMapClass F G H 1 b]
     (f : F) (x : G) (n : ℕ) [n.AtLeastTwo] :
     f (x - no_index (OfNat.ofNat n)) = f x - OfNat.ofNat n • b :=
   map_sub_nat' f x n
 
-@[simp]
+@[scoped simp]
 theorem map_add_zsmul [AddGroup G] [AddGroup H] [AddConstMapClass F G H a b]
     (f : F) (x : G) : ∀ n : ℤ, f (x + n • a) = f x + n • b
   | (n : ℕ) => by simp
   | .negSucc n => by simp [← sub_eq_add_neg]
 
-@[simp]
+@[scoped simp]
 theorem map_zsmul_const [AddGroup G] [AddGroup H] [AddConstMapClass F G H a b]
     (f : F) (n : ℤ) : f (n • a) = f 0 + n • b := by
   simpa using map_add_zsmul f 0 n
 
-@[simp]
+@[scoped simp]
 theorem map_add_int' [AddGroupWithOne G] [AddGroup H] [AddConstMapClass F G H 1 b]
     (f : F) (x : G) (n : ℤ) : f (x + n) = f x + n • b := by
   rw [← map_add_zsmul f x n, zsmul_one]
@@ -201,12 +201,12 @@ theorem map_add_int' [AddGroupWithOne G] [AddGroup H] [AddConstMapClass F G H 1 
 theorem map_add_int [AddGroupWithOne G] [AddGroupWithOne H] [AddConstMapClass F G H 1 1]
     (f : F) (x : G) (n : ℤ) : f (x + n) = f x + n := by simp
 
-@[simp]
+@[scoped simp]
 theorem map_sub_zsmul [AddGroup G] [AddGroup H] [AddConstMapClass F G H a b]
     (f : F) (x : G) (n : ℤ) : f (x - n • a) = f x - n • b := by
   simpa [sub_eq_add_neg] using map_add_zsmul f x (-n)
 
-@[simp]
+@[scoped simp]
 theorem map_sub_int' [AddGroupWithOne G] [AddGroup H] [AddConstMapClass F G H 1 b]
     (f : F) (x : G) (n : ℤ) : f (x - n) = f x - n • b := by
   rw [← map_sub_zsmul, zsmul_one]
@@ -214,12 +214,12 @@ theorem map_sub_int' [AddGroupWithOne G] [AddGroup H] [AddConstMapClass F G H 1 
 theorem map_sub_int [AddGroupWithOne G] [AddGroupWithOne H] [AddConstMapClass F G H 1 1]
     (f : F) (x : G) (n : ℤ) : f (x - n) = f x - n := by simp
 
-@[simp]
+@[scoped simp]
 theorem map_zsmul_add [AddCommGroup G] [AddGroup H] [AddConstMapClass F G H a b]
     (f : F) (n : ℤ) (x : G) : f (n • a + x) = f x + n • b := by
   rw [add_comm, map_add_zsmul]
 
-@[simp]
+@[scoped simp]
 theorem map_int_add' [AddCommGroupWithOne G] [AddGroup H] [AddConstMapClass F G H 1 b]
     (f : F) (n : ℤ) (x : G) : f (↑n + x) = f x + n • b := by
   rw [← map_zsmul_add, zsmul_one]
@@ -314,9 +314,9 @@ instance : FunLike (G →+c[a, b] H) G H where
   coe := AddConstMap.toFun
   coe_injective' | ⟨_, _⟩, ⟨_, _⟩, rfl => rfl
 
-@[simp] theorem coe_mk (f : G → H) (hf) : ⇑(mk f hf : G →+c[a, b] H) = f := rfl
-@[simp] theorem mk_coe (f : G →+c[a, b] H) : mk f f.2 = f := rfl
-@[simp] theorem toFun_eq_coe (f : G →+c[a, b] H) : f.toFun = f := rfl
+@[scoped simp] theorem coe_mk (f : G → H) (hf) : ⇑(mk f hf : G →+c[a, b] H) = f := rfl
+@[scoped simp] theorem mk_coe (f : G →+c[a, b] H) : mk f f.2 = f := rfl
+@[scoped simp] theorem toFun_eq_coe (f : G →+c[a, b] H) : f.toFun = f := rfl
 
 instance : AddConstMapClass (G →+c[a, b] H) G H a b where
   map_add_const f := f.map_add_const'
@@ -342,8 +342,8 @@ def comp {K : Type*} [Add K] {c : K} (g : H →+c[b, c] K) (f : G →+c[a, b] H)
     G →+c[a, c] K :=
   ⟨g ∘ f, by simp⟩
 
-@[simp] theorem comp_id (f : G →+c[a, b] H) : f.comp .id = f := rfl
-@[simp] theorem id_comp (f : G →+c[a, b] H) : .comp .id f = f := rfl
+@[scoped simp] theorem comp_id (f : G →+c[a, b] H) : f.comp .id = f := rfl
+@[scoped simp] theorem id_comp (f : G →+c[a, b] H) : .comp .id f = f := rfl
 
 /-- Change constants `a` and `b` in `(f : G →+c[a, b] H)` to improve definitional equalities. -/
 @[simps (config := .asFn)]
@@ -360,7 +360,7 @@ def replaceConsts (f : G →+c[a, b] H) (a' b') (ha : a = a') (hb : b = b') :
 instance {K : Type*} [VAdd K H] [VAddAssocClass K H H] : VAdd K (G →+c[a, b] H) :=
   ⟨fun c f ↦ ⟨c +ᵥ ⇑f, fun x ↦ by simp [vadd_add_assoc]⟩⟩
 
-@[simp]
+@[scoped simp]
 theorem coe_vadd {K : Type*} [VAdd K H] [VAddAssocClass K H H] (c : K) (f : G →+c[a, b] H) :
     ⇑(c +ᵥ f) = c +ᵥ ⇑f :=
   rfl
@@ -383,12 +383,12 @@ instance : Monoid (G →+c[a, a] G) :=
   DFunLike.coe_injective.monoid (M₂ := Function.End G) _ rfl (fun _ _ ↦ rfl) fun _ _ ↦ rfl
 
 theorem mul_def (f g : G →+c[a, a] G) : f * g = f.comp g := rfl
-@[simp] theorem coe_mul (f g : G →+c[a, a] G) : ⇑(f * g) = f ∘ g := rfl
+@[scoped simp] theorem coe_mul (f g : G →+c[a, a] G) : ⇑(f * g) = f ∘ g := rfl
 
 theorem one_def : (1 : G →+c[a, a] G) = .id := rfl
-@[simp] theorem coe_one : ⇑(1 : G →+c[a, a] G) = id := rfl
+@[scoped simp] theorem coe_one : ⇑(1 : G →+c[a, a] G) = id := rfl
 
-@[simp] theorem coe_pow (f : G →+c[a, a] G) (n : ℕ) : ⇑(f ^ n) = f^[n] := rfl
+@[scoped simp] theorem coe_pow (f : G →+c[a, a] G) (n : ℕ) : ⇑(f ^ n) = f^[n] := rfl
 
 theorem pow_apply (f : G →+c[a, a] G) (n : ℕ) (x : G) : (f ^ n) x = f^[n] x := rfl
 
@@ -440,7 +440,7 @@ def conjNeg : (G →+c[a, b] H) ≃ (G →+c[a, b] H) :=
   Involutive.toPerm (fun f ↦ ⟨fun x ↦ - f (-x), fun _ ↦ by simp [neg_add_eq_sub]⟩) fun _ ↦
     AddConstMap.ext fun _ ↦ by simp
 
-@[simp] theorem conjNeg_symm : (conjNeg (a := a) (b := b)).symm = conjNeg := rfl
+@[scoped simp] theorem conjNeg_symm : (conjNeg (a := a) (b := b)).symm = conjNeg := rfl
 
 end AddCommGroup
 


### PR DESCRIPTION
The keys for these `simp` lemmas will match quite a bit. To avoid this, we scope them to the `AddConstMapClass` namespace so that you only have them when you need them and not when you don't.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
