### PR TITLE
[Merged by Bors] - feat: dualising results in CategoryTheory.Functor.KanExtension.Basic

### DIFF
--- a/Mathlib/CategoryTheory/Functor/KanExtension/Basic.lean
+++ b/Mathlib/CategoryTheory/Functor/KanExtension/Basic.lean
@@ -83,6 +83,7 @@ a natural transformation, this is the induced morphism `G ⟶ F'`. -/
 noncomputable def liftOfIsRightKanExtension (G : D ⥤ H) (β : L ⋙ G ⟶ F) : G ⟶ F' :=
   (F'.isUniversalOfIsRightKanExtension α).lift (RightExtension.mk G β)
 
+@[reassoc (attr := simp)]
 lemma liftOfIsRightKanExtension_fac (G : D ⥤ H) (β : L ⋙ G ⟶ F) :
     whiskerLeft L (F'.liftOfIsRightKanExtension α G β) ≫ α = β :=
   (F'.isUniversalOfIsRightKanExtension α).fac (RightExtension.mk G β)
@@ -95,6 +96,15 @@ lemma liftOfIsRightKanExtension_fac_app (G : D ⥤ H) (β : L ⋙ G ⟶ F) (X : 
 lemma hom_ext_of_isRightKanExtension {G : D ⥤ H} (γ₁ γ₂ : G ⟶ F')
     (hγ : whiskerLeft L γ₁ ≫ α = whiskerLeft L γ₂ ≫ α) : γ₁ = γ₂ :=
   (F'.isUniversalOfIsRightKanExtension α).hom_ext hγ
+
+/-- If `(F', α)` is a right Kan extension of `F` along `L`, then this
+is the induced bijection `(G ⟶ F') ≃ (L ⋙ G ⟶ F)` for all `G`. -/
+noncomputable def homEquivOfIsRightKanExtension (G : D ⥤ H) :
+    (G ⟶ F') ≃ (L ⋙ G ⟶ F) where
+  toFun β := whiskerLeft _ β ≫ α
+  invFun β := liftOfIsRightKanExtension _ α _ β
+  left_inv β := Functor.hom_ext_of_isRightKanExtension _ α _ _ (by aesop_cat)
+  right_inv := by aesop_cat
 
 lemma isRightKanExtension_of_iso {F' F'' : D ⥤ H} (e : F' ≅ F'') {L : C ⥤ D} {F : C ⥤ H}
     (α : L ⋙ F' ⟶ F) (α' : L ⋙ F'' ⟶ F) (comm : whiskerLeft L e.hom ≫ α' = α)
@@ -112,6 +122,27 @@ lemma isRightKanExtension_iff_of_iso {F' F'' : D ⥤ H} (e : F' ≅ F'') {L : C 
     refine isRightKanExtension_of_iso e.symm α' α ?_
     rw [← comm, ← whiskerLeft_comp_assoc, Iso.symm_hom, e.inv_hom_id, whiskerLeft_id', id_comp]
 
+/-- Two right Kan extensions are (canonically) isomorphic. -/
+@[simps]
+noncomputable def rightKanExtensionUnique
+    (F'' : D ⥤ H) (α' : L ⋙ F'' ⟶ F) [F''.IsRightKanExtension α'] : F' ≅ F'' where
+  hom := F''.liftOfIsRightKanExtension α' F' α
+  inv := F'.liftOfIsRightKanExtension α F'' α'
+  hom_inv_id := F'.hom_ext_of_isRightKanExtension α _ _ (by simp)
+  inv_hom_id := F''.hom_ext_of_isRightKanExtension α' _ _ (by simp)
+
+lemma isRightKanExtension_iff_isIso {F' : D ⥤ H} {F'' : D ⥤ H} (φ : F'' ⟶ F')
+    {L : C ⥤ D} {F : C ⥤ H} (α : L ⋙ F' ⟶ F) (α' : L ⋙ F'' ⟶ F)
+    (comm : whiskerLeft L φ ≫ α = α') [F'.IsRightKanExtension α] :
+    F''.IsRightKanExtension α' ↔ IsIso φ := by
+  constructor
+  · intro
+    rw [F'.hom_ext_of_isRightKanExtension α φ (rightKanExtensionUnique _ α' _ α).hom
+      (by simp [comm])]
+    infer_instance
+  · intro
+    rw [isRightKanExtension_iff_of_iso (asIso φ) α' α comm]
+    infer_instance
 end
 
 section


### PR DESCRIPTION
In this PR, we make a left/right synchronization of the API in the file `CategoryTheory.Functor.KanExtension.Basic`: missing definitions/lemmas for right Kan extensions are introduced.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
