### PR TITLE
feat(FermatLastTheorem): Generalize FLT statement

### DIFF
--- a/Mathlib/NumberTheory/FLT/Basic.lean
+++ b/Mathlib/NumberTheory/FLT/Basic.lean
@@ -40,7 +40,7 @@ any soultion `(a, b, c)` should be a common multiple of triples of zeroes or uni
 def FermatLastTheoremWithSolutionUnit (α : Type*) [Semiring α] (n : ℕ) : Prop :=
   FermatLastTheoremWithSolution α n (λ a b c ↦ ∃ d a' b' c' : α,
     (a = a' * d ∧ b = b' * d ∧ c = c' * d) ∧
-    (a = 0 ∨ IsUnit a) ∧ (b = 0 ∨ IsUnit b) ∧ (c = 0 ∨ IsUnit c))
+    (a' = 0 ∨ IsUnit a') ∧ (b' = 0 ∨ IsUnit b') ∧ (c' = 0 ∨ IsUnit c'))
 
 /-- Statement of Fermat's Last Theorem over the naturals for a given exponent. -/
 def FermatLastTheoremFor (n : ℕ) : Prop := FermatLastTheoremWithSolutionZero ℕ n
@@ -61,7 +61,7 @@ lemma not_fermatLastTheoremFor_two : ¬ FermatLastTheoremFor 2 := sorry
 variable {α : Type*} [Semiring α] [NoZeroDivisors α] {m n : ℕ}
 
 lemma FermatLastTheoremWithSolutionZero.mono (hmn : m ∣ n)
-  (hm : FermatLastTheoremWithSolutionZero α m) : FermatLastTheoremWithSolutionZero α n := by
+    (hm : FermatLastTheoremWithSolutionZero α m) : FermatLastTheoremWithSolutionZero α n := by
   rintro a b c heq
   obtain ⟨k, rfl⟩ := hmn
   simp_rw [pow_mul'] at heq
@@ -135,19 +135,19 @@ lemma fermatLastTheoremWith_nat_int_rat_tfae (n : ℕ) :
 -/
 
 lemma fermatLastTheoremFor_iff_nat {n : ℕ} :
-  FermatLastTheoremFor n ↔ FermatLastTheoremWithSolutionZero ℕ n := Iff.rfl
+    FermatLastTheoremFor n ↔ FermatLastTheoremWithSolutionZero ℕ n := Iff.rfl
 
 lemma fermatLastTheoremFor_iff_int {n : ℕ} :
-  FermatLastTheoremFor n ↔ FermatLastTheoremWithSolutionZero ℤ n :=
-    (fermatLastTheoremWith_nat_int_rat_tfae n).out 1 2
+    FermatLastTheoremFor n ↔ FermatLastTheoremWithSolutionZero ℤ n :=
+  (fermatLastTheoremWith_nat_int_rat_tfae n).out 1 2
 
 lemma fermatLastTheoremFor_iff_rat {n : ℕ} :
-  FermatLastTheoremFor n ↔ FermatLastTheoremWithSolutionZero ℚ n :=
-    (fermatLastTheoremWith_nat_int_rat_tfae n).out 1 3
+    FermatLastTheoremFor n ↔ FermatLastTheoremWithSolutionZero ℚ n :=
+  (fermatLastTheoremWith_nat_int_rat_tfae n).out 1 3
 
 /-- Fermat's Last Theorem for polynomials. This is a consequence of Mason--Stothers theorem. -/
 theorem fermatLastTheoremWithPolynomial {k : Type*} [Field k] {n : ℕ} (chn : ¬ringChar k ∣ n) :
-  FermatLastTheoremWithSolutionUnit k[X] n := sorry
+    FermatLastTheoremWithSolutionUnit k[X] n := sorry
 
 open Finset in
 /-- To prove Fermat Last Theorem in any semiring that is a `NormalizedGCDMonoid` one can assume


### PR DESCRIPTION
Generalize the statement of `FermatLastTheorem` to accommodate different kinds of rings (e.g. $R = k[X]$) and trivial solutions. A relevant Zulip discussion [here](https://leanprover.zulipchat.com/#narrow/stream/287929-mathlib4/topic/Mason-Stothers.20theorem.20and.20Polynomial.20FLT).

Fermat's Last Theorem states the following for ring $R = \mathbb{Z}$ (or semiring $R = \mathbb{N}$).

**Statement 1** ('zero' version): For any solutions to $a^n + b^n = c^n$ we have $abc=0$.

The Mason--Stothers theorem gives a polynomial variant of FLT for ring $R = k[X]$ with $k$ characteristic zero. But we have to change the notion of trivial solutions.

**Statement 2** ('unit' version):  For any solutions to $a^n + b^n = c^n$, the triple $(a, b, c)$ is a common multiple of $(a', b', c')$ where each $a', b', c'$ is either zero or unit.

We note the followings.

1. For $R =  \mathbb{N}, \mathbb{Z}$ the statements 1 and 2 are equivalent.
2. However, for $R = \mathbb{Q}$ statement 1 is equivalent to full FLT but statement 2 is trivial.
3. The equivalence of statements 1 and 2 for $R =  \mathbb{N}, \mathbb{Z}$ also requires a bit of juggling with definitions albeit trivial.
4. For $R =  k[X]$, statement 1 is likely false but statement 2 is true.
5. In "[Fermat's Last Theorem over Number Fields](https://revistas.rcaap.pt/boletimspm/article/view/21033/15548)" by N. Freitas, the author mostly mentions statement 1 as a generalization, but also mentions many 'trivial' solutions outside statement 1.

The relationship between statements 1 and 2 in general:

1. If $R$ is a Dedekind domain (e.g. integral ring) then it seems that zero version implies the unit version.
2. If the sum of two units in $R$ is never a unit in $R$, then the unit version implies the zero version. [Here](https://math.stackexchange.com/questions/2107233/when-are-u-and-1-u-never-both-units) it is mentioned that the integral ring of $\mathbb{Q}(\sqrt{d})$ for $d < 0$ satisfy the condition unless $d = 2, 3, 6$.

This PR attempts to capture such minor differences in the notion of 'trivial' solutions.

1. We provide a general statement for stating FLT with arbitrary notion of 'trivial' solutions. Then we give Statements 1 and 2 as specific instances.
3. Since we are much more familiar with 'zero' version (Statement 1), we define the main FLT for integers with Statement 1.
4. We show the equivalence between Statements 1 and 2 for $R =  \mathbb{N}, \mathbb{Z}$
5. We state the polynomial FLT with statement 2. This will be proved when we port the project I did with @seewoo5 [here](https://github.com/seewoo5/lean-poly-abc).

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
