### PR TITLE
[Merged by Bors] - feat(RingTheory): presentations of algebras

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -3720,6 +3720,7 @@ import Mathlib.RingTheory.PowerSeries.Inverse
 import Mathlib.RingTheory.PowerSeries.Order
 import Mathlib.RingTheory.PowerSeries.Trunc
 import Mathlib.RingTheory.PowerSeries.WellKnown
+import Mathlib.RingTheory.Presentation
 import Mathlib.RingTheory.Prime
 import Mathlib.RingTheory.PrincipalIdealDomain
 import Mathlib.RingTheory.QuotSMulTop

--- a/Mathlib/RingTheory/Generators.lean
+++ b/Mathlib/RingTheory/Generators.lean
@@ -179,6 +179,8 @@ def extendScalars (P : Generators R T) : Generators S T where
   σ' x := map (algebraMap R S) (P.σ x)
   aeval_val_σ' s := by simp [@aeval_def S, ← IsScalarTower.algebraMap_eq, ← @aeval_def R]
 
+/-- If `P` is a family of generators of `S` over `R` and `T` is an `R`-algebra, we
+obtain a natural family of generators of `T ⊗[R] S` over `T`. -/
 noncomputable
 def baseChange {T} [CommRing T] [Algebra R T] (P : Generators R S) : Generators T (T ⊗[R] S) := by
   apply Generators.ofSurjective (fun x ↦ 1 ⊗ₜ[R] P.val x)

--- a/Mathlib/RingTheory/Generators.lean
+++ b/Mathlib/RingTheory/Generators.lean
@@ -6,7 +6,7 @@ Authors: Andrew Yang
 import Mathlib.RingTheory.Ideal.Cotangent
 import Mathlib.RingTheory.Localization.Away.Basic
 import Mathlib.RingTheory.MvPolynomial.Tower
-import Mathlib.RingTheory.TensorProduct.MvPolynomial
+import Mathlib.RingTheory.TensorProduct.Basic
 
 /-!
 

--- a/Mathlib/RingTheory/Generators.lean
+++ b/Mathlib/RingTheory/Generators.lean
@@ -93,7 +93,7 @@ lemma algebraMap_surjective : Function.Surjective (algebraMap P.Ring S) := (⟨_
 section Construction
 
 /-- Construct `Generators` from an assignment `I → S` such that `R[X] → S` is surjective. -/
-@[simps vars val]
+@[simps val, simps (config := .lemmasOnly) vars]
 noncomputable
 def ofSurjective {vars} (val : vars → S) (h : Function.Surjective (aeval (R := R) val)) :
     Generators R S where
@@ -131,7 +131,7 @@ variable (r : R) [IsLocalization.Away r S]
 
 /-- If `S` is the localization of `R` away from `r`, we obtain a canonical generator mapping
 to the inverse of `r`. -/
-@[simps vars val, simps (config := .lemmasOnly) σ]
+@[simps val, simps (config := .lemmasOnly) vars σ]
 noncomputable
 def localizationAway : Generators R S where
   vars := Unit
@@ -154,7 +154,7 @@ variable {T} [CommRing T] [Algebra R T] [Algebra S T] [IsScalarTower R S T]
 
 /-- Given two families of generators `S[X] → T` and `R[Y] → S`,
 we may constuct the family of generators `R[X, Y] → T`. -/
-@[simps vars val, simps (config := .lemmasOnly) σ]
+@[simps val, simps (config := .lemmasOnly) vars σ]
 noncomputable
 def comp (Q : Generators S T) (P : Generators R S) : Generators R T where
   vars := Q.vars ⊕ P.vars
@@ -171,7 +171,7 @@ def comp (Q : Generators S T) (P : Generators R S) : Generators R T where
 variable (S) in
 /-- If `R → S → T` is a tower of algebras, a family of generators `R[X] → T`
 gives a family of generators `S[X] → T`. -/
-@[simps vars val]
+@[simps val, simps (config := .lemmasOnly) vars]
 noncomputable
 def extendScalars (P : Generators R T) : Generators S T where
   vars := P.vars
@@ -181,6 +181,7 @@ def extendScalars (P : Generators R T) : Generators S T where
 
 /-- If `P` is a family of generators of `S` over `R` and `T` is an `R`-algebra, we
 obtain a natural family of generators of `T ⊗[R] S` over `T`. -/
+@[simps! val, simps! (config := .lemmasOnly) vars]
 noncomputable
 def baseChange {T} [CommRing T] [Algebra R T] (P : Generators R S) : Generators T (T ⊗[R] S) := by
   apply Generators.ofSurjective (fun x ↦ 1 ⊗ₜ[R] P.val x)
@@ -336,6 +337,9 @@ section Cotangent
 
 /-- The kernel of a presentation. -/
 abbrev ker : Ideal P.Ring := RingHom.ker (algebraMap P.Ring S)
+
+lemma ker_eq_ker_aeval_val : P.ker = RingHom.ker (aeval P.val) :=
+  rfl
 
 /-- The cotangent space of a presentation.
 This is a type synonym so that `P = R[X]` can act on it through the action of `S` without creating

--- a/Mathlib/RingTheory/Generators.lean
+++ b/Mathlib/RingTheory/Generators.lean
@@ -4,6 +4,9 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Andrew Yang
 -/
 import Mathlib.RingTheory.Ideal.Cotangent
+import Mathlib.RingTheory.Localization.Away.Basic
+import Mathlib.RingTheory.MvPolynomial.Tower
+import Mathlib.RingTheory.TensorProduct.MvPolynomial
 
 /-!
 
@@ -24,10 +27,6 @@ import Mathlib.RingTheory.Ideal.Cotangent
   A hom between `P` and `P'` is an assignment `X → P'` such that the arrows commute.
 - `Algebra.Generators.Cotangent`: The cotangent space wrt `P = R[X] → S`, i.e. the
   space `I/I²` with `I` being the kernel of the presentation.
-
-## TODO
-* Define `Algebra.Presentation` that extends `Generators` and contains the data of a family of
-  relations that spans the kernel of the presentation.
 
 -/
 
@@ -126,6 +125,31 @@ def self : Generators R S where
   σ' := X
   aeval_val_σ' := aeval_X _
 
+section Localization
+
+variable (r : R) [IsLocalization.Away r S]
+
+/-- If `S` is the localization of `R` away from `r`, we obtain a canonical generator mapping
+to the inverse of `r`. -/
+@[simps vars val, simps (config := .lemmasOnly) σ]
+noncomputable
+def localizationAway : Generators R S where
+  vars := Unit
+  val _ := IsLocalization.Away.invSelf r
+  σ' s :=
+    letI a : R := (IsLocalization.Away.sec r s).1
+    letI n : ℕ := (IsLocalization.Away.sec r s).2
+    C a * X () ^ n
+  aeval_val_σ' s := by
+    rw [_root_.map_mul, algHom_C, map_pow, aeval_X]
+    simp only [← IsLocalization.Away.sec_spec, map_pow, IsLocalization.Away.invSelf]
+    rw [← IsLocalization.mk'_pow, one_pow, ← IsLocalization.mk'_one (M := Submonoid.powers r) S r]
+    rw [← IsLocalization.mk'_pow, one_pow, mul_assoc, ← IsLocalization.mk'_mul]
+    rw [mul_one, one_mul, IsLocalization.mk'_pow]
+    simp
+
+end Localization
+
 variable {T} [CommRing T] [Algebra R T] [Algebra S T] [IsScalarTower R S T]
 
 /-- Given two families of generators `S[X] → T` and `R[Y] → S`,
@@ -154,6 +178,32 @@ def extendScalars (P : Generators R T) : Generators S T where
   val := P.val
   σ' x := map (algebraMap R S) (P.σ x)
   aeval_val_σ' s := by simp [@aeval_def S, ← IsScalarTower.algebraMap_eq, ← @aeval_def R]
+
+noncomputable
+def baseChange {T} [CommRing T] [Algebra R T] (P : Generators R S) : Generators T (T ⊗[R] S) := by
+  apply Generators.ofSurjective (fun x ↦ 1 ⊗ₜ[R] P.val x)
+  intro x
+  induction x using TensorProduct.induction_on with
+  | zero => exact ⟨0, map_zero _⟩
+  | tmul a b =>
+    let X := P.σ b
+    use a • MvPolynomial.map (algebraMap R T) X
+    simp only [LinearMapClass.map_smul, X, aeval_map_algebraMap]
+    have : ∀ y : P.Ring,
+      aeval (fun x ↦ (1 ⊗ₜ[R] P.val x : T ⊗[R] S)) y = 1 ⊗ₜ aeval (fun x ↦ P.val x) y := by
+      intro y
+      induction y using MvPolynomial.induction_on with
+      | h_C a =>
+        rw [aeval_C, aeval_C, TensorProduct.algebraMap_apply, algebraMap_eq_smul_one, smul_tmul,
+          algebraMap_eq_smul_one]
+      | h_add p q hp hq => simp [map_add, tmul_add, hp, hq]
+      | h_X p i hp => simp [hp]
+    rw [this, P.aeval_val_σ, smul_tmul', smul_eq_mul, mul_one]
+  | add x y ex ey =>
+    obtain ⟨a, ha⟩ := ex
+    obtain ⟨b, hb⟩ := ey
+    use (a + b)
+    rw [map_add, ha, hb]
 
 end Construction
 

--- a/Mathlib/RingTheory/Localization/Away/Basic.lean
+++ b/Mathlib/RingTheory/Localization/Away/Basic.lean
@@ -61,8 +61,8 @@ theorem mul_invSelf : algebraMap R S x * invSelf x = 1 := by
   apply IsLocalization.mk'_one
 #align is_localization.away.mul_inv_self IsLocalization.Away.mul_invSelf
 
-/-- For `s : S`, this is a choice of `(x, n) : R × ℕ` such that
-`s * algebraMap R S (s ^ n) = algebraMap R S r`. -/
+/-- For `s : S` with `S` being the localization of `R` away from `x`,
+this is a choice of `(r, n) : R × ℕ` such that `s * algebraMap R S (x ^ n) = algebraMap R S r`. -/
 noncomputable def sec (s : S) : R × ℕ :=
   ⟨(IsLocalization.sec (Submonoid.powers x) s).1,
    (IsLocalization.sec (Submonoid.powers x) s).2.property.choose⟩

--- a/Mathlib/RingTheory/Localization/Away/Basic.lean
+++ b/Mathlib/RingTheory/Localization/Away/Basic.lean
@@ -61,6 +61,18 @@ theorem mul_invSelf : algebraMap R S x * invSelf x = 1 := by
   apply IsLocalization.mk'_one
 #align is_localization.away.mul_inv_self IsLocalization.Away.mul_invSelf
 
+/-- For `s : S`, this is a choice of `(x, n) : R × ℕ` such that
+`s * algebraMap R S (s ^ n) = algebraMap R S r`. -/
+noncomputable def sec (s : S) : R × ℕ :=
+  ⟨(IsLocalization.sec (Submonoid.powers x) s).1,
+   (IsLocalization.sec (Submonoid.powers x) s).2.property.choose⟩
+
+lemma sec_spec (s : S) : s * (algebraMap R S) (x ^ (IsLocalization.Away.sec x s).2) =
+    algebraMap R S (IsLocalization.Away.sec x s).1 := by
+  simp only [IsLocalization.Away.sec, ← IsLocalization.sec_spec]
+  congr
+  exact (IsLocalization.sec (Submonoid.powers x) s).2.property.choose_spec
+
 variable {g : R →+* P}
 
 /-- Given `x : R`, a localization map `F : R →+* S` away from `x`, and a map of `CommSemiring`s

--- a/Mathlib/RingTheory/Localization/Basic.lean
+++ b/Mathlib/RingTheory/Localization/Basic.lean
@@ -297,6 +297,10 @@ theorem mk'_add_eq_iff_add_mul_eq_mul {x} {y : M} {z₁ z₂} :
   rw [← mk'_spec S x y, ← IsUnit.mul_left_inj (IsLocalization.map_units S y), right_distrib]
 #align is_localization.mk'_add_eq_iff_add_mul_eq_mul IsLocalization.mk'_add_eq_iff_add_mul_eq_mul
 
+theorem mk'_pow (x : R) (y : M) (n : ℕ) : mk' S (x ^ n) (y ^ n) = mk' S x y ^ n := by
+  simp_rw [IsLocalization.mk'_eq_iff_eq_mul, SubmonoidClass.coe_pow, map_pow, ← mul_pow]
+  simp
+
 variable (M)
 
 theorem mk'_surjective (z : S) : ∃ (x : _) (y : M), mk' S x y = z :=

--- a/Mathlib/RingTheory/MvPolynomial/Localization.lean
+++ b/Mathlib/RingTheory/MvPolynomial/Localization.lean
@@ -102,7 +102,7 @@ def auxHom : (MvPolynomial Unit R) ⧸ (Ideal.span { C r * X () - 1 }) →ₐ[R]
       simp [hx]
 
 @[simp]
-lemma auxHom_mk (p : MvPolynomial Unit R) :
+private lemma auxHom_mk (p : MvPolynomial Unit R) :
     auxHom S r p = aeval (S₁ := S) (fun _ ↦ invSelf r) p :=
   rfl
 

--- a/Mathlib/RingTheory/MvPolynomial/Localization.lean
+++ b/Mathlib/RingTheory/MvPolynomial/Localization.lean
@@ -3,24 +3,34 @@ Copyright (c) 2024 Christian Merten. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Christian Merten
 -/
+import Mathlib.Algebra.MvPolynomial.CommRing
+import Mathlib.RingTheory.Ideal.QuotientOperations
+import Mathlib.RingTheory.Localization.Away.Basic
 import Mathlib.RingTheory.Localization.Basic
 import Mathlib.RingTheory.MvPolynomial.Basic
 
 /-!
 
-# Localization of multivariate polynomial rings
+# Localization and multivariate polynomial rings
 
-If `S` is the localization of `R` at a submonoid `M`, then `MvPolynomial σ S`
-is the localization of `MvPolynomial σ R` at the image of `M` in `MvPolynomial σ R`.
+In this file we show some results connecting multivariate polynomial rings and localization.
+
+## Main results
+
+- `MvPolynomial.isLocalization`: If `S` is the localization of `R` at a submonoid `M`, then
+  `MvPolynomial σ S` is the localization of `MvPolynomial σ R` at the image of `M` in
+  `MvPolynomial σ R`.
 
 -/
 
 open Classical
 
+variable {σ R : Type*} [CommRing R] (M : Submonoid R)
+variable (S : Type*) [CommRing S] [Algebra R S]
+
 namespace MvPolynomial
 
-variable {σ R : Type*} [CommRing R] (M : Submonoid R)
-variable (S : Type*) [CommRing S] [Algebra R S] [IsLocalization M S]
+variable [IsLocalization M S]
 
 attribute [local instance] algebraMvPolynomial
 
@@ -69,3 +79,78 @@ lemma isLocalization_C_mk' (a : R) (m : M) :
     IsLocalization.mk'_spec]
 
 end MvPolynomial
+
+namespace IsLocalization.Away
+
+open MvPolynomial
+
+variable (r : R) [IsLocalization.Away r S]
+
+/-- The canonical algebra map from `MvPolynomial Unit R` quotiented by
+`C r * X () - 1` to the localization of `R` away from `r`. -/
+private noncomputable
+def auxHom : (MvPolynomial Unit R) ⧸ (Ideal.span { C r * X () - 1 }) →ₐ[R] S :=
+  Ideal.Quotient.liftₐ (Ideal.span { C r * X () - 1}) (aeval (fun _ ↦ invSelf r)) <| by
+    intro p hp
+    refine Submodule.span_induction hp ?_ ?_ ?_ ?_
+    · rintro p ⟨q, rfl⟩
+      simp
+    · simp
+    · intro p q hp hq
+      simp [hp, hq]
+    · intro a x hx
+      simp [hx]
+
+@[simp]
+lemma auxHom_mk (p : MvPolynomial Unit R) :
+    auxHom S r p = aeval (S₁ := S) (fun _ ↦ invSelf r) p :=
+  rfl
+
+private noncomputable
+def auxInv : S →+* (MvPolynomial Unit R) ⧸ Ideal.span { C r * X () - 1 } :=
+  letI g : R →+* MvPolynomial Unit R ⧸ (Ideal.span { C r * X () - 1 }) :=
+    (Ideal.Quotient.mk _).comp C
+  IsLocalization.Away.lift (S := S) (g := g) r <| by
+    simp only [RingHom.coe_comp, Function.comp_apply, g]
+    rw [isUnit_iff_exists_inv]
+    use (Ideal.Quotient.mk _ <| X ())
+    rw [← _root_.map_mul, ← map_one (Ideal.Quotient.mk _), Ideal.Quotient.mk_eq_mk_iff_sub_mem]
+    exact Ideal.mem_span_singleton_self (C r * X () - 1)
+
+private lemma auxHom_auxInv : (auxHom S r).toRingHom.comp (auxInv S r) = RingHom.id S := by
+  apply IsLocalization.ringHom_ext (Submonoid.powers r)
+  ext x
+  simp [auxInv]
+
+private lemma auxInv_auxHom : (auxInv S r).comp (auxHom (S := S) r).toRingHom = RingHom.id _ := by
+  rw [← RingHom.cancel_right (Ideal.Quotient.mk_surjective)]
+  ext x
+  · simp [auxInv]
+  · simp only [auxInv, AlgHom.toRingHom_eq_coe, RingHom.coe_comp, RingHom.coe_coe,
+      Function.comp_apply, auxHom_mk, aeval_X, RingHomCompTriple.comp_eq]
+    erw [IsLocalization.lift_mk'_spec]
+    simp only [map_one, RingHom.coe_comp, Function.comp_apply]
+    rw [← _root_.map_one (Ideal.Quotient.mk _)]
+    rw [← _root_.map_mul, Ideal.Quotient.mk_eq_mk_iff_sub_mem, ← Ideal.neg_mem_iff, neg_sub]
+    exact Ideal.mem_span_singleton_self (C r * X x - 1)
+
+/-- The canonical algebra isomorphism from `MvPolynomial Unit R` quotiented by
+`C r * X () - 1` to the localization of `R` away from `r`. -/
+noncomputable def mvPolynomialQuotientEquiv :
+    ((MvPolynomial Unit R) ⧸ Ideal.span { C r * X () - 1 }) ≃ₐ[R] S where
+  toFun := auxHom S r
+  invFun := auxInv S r
+  left_inv x := by
+    simpa using congrFun (congrArg DFunLike.coe <| auxInv_auxHom S r) x
+  right_inv s := by
+    simpa using congrFun (congrArg DFunLike.coe <| auxHom_auxInv S r) s
+  map_mul' := by simp
+  map_add' := by simp
+  commutes' := by simp
+
+@[simp]
+lemma mvPolynomialQuotientEquiv_apply (p : MvPolynomial Unit R) :
+    mvPolynomialQuotientEquiv S r (Ideal.Quotient.mk _ p) = aeval (S₁ := S) (fun _ ↦ invSelf r) p :=
+  rfl
+
+end IsLocalization.Away

--- a/Mathlib/RingTheory/Presentation.lean
+++ b/Mathlib/RingTheory/Presentation.lean
@@ -33,6 +33,9 @@ We also give constructors for localization and base change.
 
 - Define composition of presentations.
 - Define `Hom`s of presentations.
+## Notes
+This contribution was created as part of the AIM workshop
+"Formalizing algebraic geometry" in June 2024.
 
 -/
 

--- a/Mathlib/RingTheory/Presentation.lean
+++ b/Mathlib/RingTheory/Presentation.lean
@@ -33,9 +33,11 @@ We also give constructors for localization and base change.
 
 - Define composition of presentations.
 - Define `Hom`s of presentations.
+
 ## Notes
-This contribution was created as part of the AIM workshop
-"Formalizing algebraic geometry" in June 2024.
+
+This contribution was created as part of the AIM workshop "Formalizing algebraic geometry"
+in June 2024.
 
 -/
 
@@ -67,12 +69,9 @@ namespace Algebra.Presentation
 variable {R S}
 variable (P : Presentation.{t, w} R S)
 
-lemma ker_eq_span_range_relation : P.ker = Ideal.span (Set.range P.relation) :=
-  P.span_range_relation_eq_ker.symm
-
 @[simp]
 lemma aeval_val_relation (i) : aeval P.val (P.relation i) = 0 := by
-  rw [← RingHom.mem_ker, ← P.ker_eq_ker_aeval_val, ker_eq_span_range_relation]
+  rw [← RingHom.mem_ker, ← P.ker_eq_ker_aeval_val, ← P.span_range_relation_eq_ker]
   exact Ideal.subset_span ⟨i, rfl⟩
 
 /-- The polynomial algebra wrt a family of generators modulo a family of relations. -/

--- a/Mathlib/RingTheory/Presentation.lean
+++ b/Mathlib/RingTheory/Presentation.lean
@@ -1,0 +1,219 @@
+/-
+Copyright (c) 2024 Christian Merten. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Jung Tao Cheng, Christian Merten, Andrew Yang
+-/
+import Mathlib.LinearAlgebra.TensorProduct.RightExactness
+import Mathlib.RingTheory.FinitePresentation
+import Mathlib.RingTheory.Generators
+import Mathlib.RingTheory.MvPolynomial.Localization
+import Mathlib.RingTheory.TensorProduct.MvPolynomial
+
+/-!
+
+# Presentations of algebras
+
+A presentation of an `R`-algebra `S` is a distinguished family of generators and relations.
+
+## Main definition
+
+- `Algebra.Presentation`: A presentation of a `R`-algebra `S` is a family of
+  generators with
+  1. `relations`: The type of relations.
+  2. `relation : relations → MvPolynomial vars R`: The assignment of
+     each relation to a polynomial in the generators.
+- `Algebra.Presentation.IsFinite`: A presentation is called finite, if both variables and relations
+  are finite.
+- `Algebra.dimension`: The dimension of a presentation is the number of generators minus the number
+  of relations.
+
+We also give constructors for localization and base change.
+
+## TODO
+
+- Define composition of presentations.
+- Define `Hom`s of presentations.
+
+-/
+
+universe t w u v
+
+open TensorProduct MvPolynomial
+
+variable (R : Type u) (S : Type v) [CommRing R] [CommRing S] [Algebra R S]
+
+/--
+A presentation of a `R`-algebra `S` is a family of
+generators with
+1. `relations`: The type of relations.
+2. `relation : relations → MvPolynomial vars R`: The assignment of
+each relation to a polynomial in the generators.
+-/
+structure Algebra.Presentation extends Algebra.Generators.{w} R S where
+  /-- The type of relations.  -/
+  relations : Type t
+  /-- The assignment of each relation to a polynomial in the generators. -/
+  relation : relations → MvPolynomial vars R
+  /-- The relations span the kernel of the canonical map. -/
+  ker_algebraMap_eq_span_range_relation :
+    RingHom.ker (aeval val) = Ideal.span (Set.range <| relation)
+
+namespace Algebra.Presentation
+
+variable {R S}
+variable (P : Presentation.{t, w} R S)
+
+lemma ideal_eq_span_range_relation : P.ker = Ideal.span (Set.range <| P.relation) :=
+  P.ker_algebraMap_eq_span_range_relation
+
+lemma algebraMap_relation (i) : aeval P.val (P.relation i) = 0 := by
+  rw [← RingHom.mem_ker, ker_algebraMap_eq_span_range_relation]
+  exact Ideal.subset_span ⟨i, rfl⟩
+
+/-- The polynomial algebra wrt a family of generators module a family of relations. -/
+protected abbrev Quotient : Type (max w u) := P.Ring ⧸ P.ker
+
+/-- `P.Quotient` is `P.Ring`-isomorphic to `S` and in particular `R`-isomorphic to `S`. -/
+def quotientEquiv : P.Quotient ≃ₐ[P.Ring] S :=
+  Ideal.quotientKerAlgEquivOfRightInverse (f := Algebra.ofId P.Ring S) P.aeval_val_σ
+
+@[simp]
+lemma quotientEquiv_mk (p : P.Ring) : P.quotientEquiv p = algebraMap P.Ring S p :=
+  rfl
+
+@[simp]
+lemma quotientEquiv_symm (x : S) : P.quotientEquiv.symm x = P.σ x :=
+  rfl
+
+/--
+Dimension of a presentation defined as the cardinality of the generators
+minus the cardinality of the relations.
+
+Note: this definition is completely non-sensical for non-finite presentations and
+even then for this to make sense, you should assume that the presentation
+is standard smooth.
+-/
+noncomputable def dimension : ℕ :=
+  Nat.card P.vars - Nat.card P.relations
+
+/-- A presentation is called finite if there are only finitely-many
+relations and finitely-many relations. -/
+class IsFinite (P : Presentation.{t, w} R S) : Prop where
+  finite_vars : Finite P.vars
+  finite_relations : Finite P.relations
+
+attribute [instance] IsFinite.finite_vars IsFinite.finite_relations
+
+lemma ideal_fg_of_isFinite [P.IsFinite] : P.ker.FG := by
+  use (Set.finite_range P.relation).toFinset
+  simp [ideal_eq_span_range_relation]
+
+/-- If a presentation is finite, the corresponding quotient is
+of finite presentation. -/
+instance [P.IsFinite] : FinitePresentation R P.Quotient :=
+  FinitePresentation.quotient P.ideal_fg_of_isFinite
+
+lemma finitePresentation_of_presentation_of_isFinite [P.IsFinite] :
+    FinitePresentation R S :=
+  FinitePresentation.equiv (P.quotientEquiv.restrictScalars R)
+
+section Construction
+
+section Localization
+
+variable (r : R) [IsLocalization.Away r S]
+
+open IsLocalization.Away
+
+private lemma ker_algebraMap_eq_span_range_relation_localizationAway :
+    RingHom.ker (aeval (S₁ := S) (Generators.localizationAway r).val) =
+      Ideal.span { C r * X () - 1 } := by
+  have : aeval (S₁ := S) (Generators.localizationAway r).val =
+      (mvPolynomialQuotientEquiv S r).toAlgHom.comp
+        (Ideal.Quotient.mkₐ R (Ideal.span {C r * X () - 1})) := by
+    ext x
+    simp only [Generators.localizationAway_vars, aeval_X, Generators.localizationAway_val,
+      AlgEquiv.toAlgHom_eq_coe, AlgHom.coe_comp, AlgHom.coe_coe, Ideal.Quotient.mkₐ_eq_mk,
+      Function.comp_apply]
+    rw [IsLocalization.Away.mvPolynomialQuotientEquiv_apply, aeval_X]
+  rw [this]
+  erw [← RingHom.comap_ker]
+  simp only [Generators.localizationAway_vars, AlgEquiv.toAlgHom_eq_coe, AlgHom.toRingHom_eq_coe,
+    AlgEquiv.toAlgHom_toRingHom]
+  show Ideal.comap _ (RingHom.ker (mvPolynomialQuotientEquiv S r)) =
+    Ideal.span {C r * X () - 1}
+  simp [RingHom.ker_equiv, ← RingHom.ker_eq_comap_bot]
+
+/-- If `S` is the localization of `R` away from `r`, we can construct a natural
+presentation of `S` as `R`-algebra with a single generator `X` and the relation `r * X - 1 = 0`. -/
+@[simps relations relation]
+noncomputable def localizationAway : Presentation R S where
+  toGenerators := Generators.localizationAway r
+  relations := Unit
+  relation _ := C r * X () - 1
+  ker_algebraMap_eq_span_range_relation := by
+    simp only [Generators.localizationAway_vars, Set.range_const]
+    apply ker_algebraMap_eq_span_range_relation_localizationAway r
+
+instance localizationAway_isFinite : (localizationAway r (S := S)).IsFinite where
+  finite_vars := inferInstanceAs <| Finite Unit
+  finite_relations := inferInstanceAs <| Finite Unit
+
+@[simp]
+lemma localizationAway_dimension_zero : (localizationAway r (S := S)).dimension = 0 := by
+  simp [Presentation.dimension, localizationAway]
+
+end Localization
+
+variable {T} [CommRing T] [Algebra R T] (P : Presentation R S)
+
+private lemma ker_algebraMap_eq_span_range_relation_baseChange :
+    RingHom.ker (aeval (R := T) (S₁ := T ⊗[R] S) P.baseChange.val) =
+      Ideal.span (Set.range fun i ↦ (MvPolynomial.map (algebraMap R T)) (P.relation i)) := by
+  apply le_antisymm
+  · intro x hx
+    rw [RingHom.mem_ker] at hx
+    have H := Algebra.TensorProduct.lTensor_ker (A := T) (IsScalarTower.toAlgHom R P.Ring S)
+      P.algebraMap_surjective
+    let e := MvPolynomial.algebraTensorAlgEquiv (R := R) (σ := P.vars) (A := T)
+    have H' : e.symm x ∈ RingHom.ker (TensorProduct.map (AlgHom.id R T)
+        (IsScalarTower.toAlgHom R P.Ring S)) := by
+      rw [RingHom.mem_ker, ← hx]
+      clear hx
+      induction x using MvPolynomial.induction_on with
+      | h_C a =>
+        simp only [Generators.algebraMap_apply, algHom_C, TensorProduct.algebraMap_apply,
+          id.map_eq_id, RingHom.id_apply, e]
+        erw [← MvPolynomial.algebraMap_eq, AlgEquiv.commutes]
+        simp
+      | h_add p q hp hq => simp only [map_add, hp, hq]
+      | h_X p i hp =>
+        simp [_root_.map_mul, e, hp]
+        rfl
+    erw [H, ker_algebraMap_eq_span_range_relation] at H'
+    erw [← Ideal.mem_comap, Ideal.comap_symm, Ideal.map_map, Ideal.map_span, ← Set.range_comp] at H'
+    convert H'
+    simp
+    rfl
+  · rw [Ideal.span_le]
+    intro x ⟨y, hy⟩
+    have Z := algebraMap_relation P y
+    apply_fun TensorProduct.includeRight (R := R) (A := T) at Z
+    rw [map_zero] at Z
+    simp only [SetLike.mem_coe, RingHom.mem_ker, ← Z, ← hy, algebraMap_apply,
+      TensorProduct.includeRight_apply]
+    erw [aeval_map_algebraMap]
+    show _ = TensorProduct.includeRight _
+    erw [map_aeval, TensorProduct.includeRight.comp_algebraMap]
+    rfl
+
+/-- If `P` is a presentation of `S` over `R` and `T` is an `R`-algebra, we
+obtain a natural presentation of `T ⊗[R] S` over `T`. -/
+noncomputable
+def baseChange : Presentation T (T ⊗[R] S) where
+  __ := Generators.baseChange P.toGenerators
+  relations := P.relations
+  relation i := MvPolynomial.map (algebraMap R T) (P.relation i)
+  ker_algebraMap_eq_span_range_relation := P.ker_algebraMap_eq_span_range_relation_baseChange
+
+end Construction

--- a/Mathlib/RingTheory/Presentation.lean
+++ b/Mathlib/RingTheory/Presentation.lean
@@ -49,6 +49,7 @@ generators with
 2. `relation : relations → MvPolynomial vars R`: The assignment of
 each relation to a polynomial in the generators.
 -/
+@[nolint checkUnivs]
 structure Algebra.Presentation extends Algebra.Generators.{w} R S where
   /-- The type of relations.  -/
   relations : Type t

--- a/Mathlib/RingTheory/Presentation.lean
+++ b/Mathlib/RingTheory/Presentation.lean
@@ -17,7 +17,7 @@ A presentation of an `R`-algebra `S` is a distinguished family of generators and
 
 ## Main definition
 
-- `Algebra.Presentation`: A presentation of a `R`-algebra `S` is a family of
+- `Algebra.Presentation`: A presentation of an `R`-algebra `S` is a family of
   generators with
   1. `rels`: The type of relations.
   2. `relation : relations → MvPolynomial vars R`: The assignment of
@@ -43,7 +43,7 @@ open TensorProduct MvPolynomial
 variable (R : Type u) (S : Type v) [CommRing R] [CommRing S] [Algebra R S]
 
 /--
-A presentation of a `R`-algebra `S` is a family of
+A presentation of an `R`-algebra `S` is a family of
 generators with
 1. `rels`: The type of relations.
 2. `relation : relations → MvPolynomial vars R`: The assignment of

--- a/Mathlib/RingTheory/Presentation.lean
+++ b/Mathlib/RingTheory/Presentation.lean
@@ -197,8 +197,8 @@ private lemma span_range_relation_eq_ker_baseChange :
         simp only [Generators.algebraMap_apply, algHom_C, TensorProduct.algebraMap_apply,
           id.map_eq_id, RingHom.id_apply, e]
         erw [← MvPolynomial.algebraMap_eq, AlgEquiv.commutes]
-        simp only [TensorProduct.algebraMap_apply, id.map_eq_id, RingHom.id_apply, TensorProduct.map_tmul,
-          AlgHom.coe_id, id_eq, _root_.map_one, algebraMap_eq]
+        simp only [TensorProduct.algebraMap_apply, id.map_eq_id, RingHom.id_apply,
+          TensorProduct.map_tmul, AlgHom.coe_id, id_eq, _root_.map_one, algebraMap_eq]
         erw [aeval_C]
         simp
       | h_add p q hp hq => simp only [map_add, hp, hq]


### PR DESCRIPTION
Adds basic API for presentations of algebras and constructors for localization and base change.

This contribution was created as part of the AIM workshop "Formalizing algebraic geometry" in June 2024.

Co-authored-by: Andrew Yang @erdOne
Co-authored-by: Jung Tao Cheng @rontaucheng 

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
