### PR TITLE
[Merged by Bors] - feat: add `LinearMap.IsAlt.eq_of_add_add_eq_zero`

### DIFF
--- a/Mathlib/LinearAlgebra/BilinearForm/Properties.lean
+++ b/Mathlib/LinearAlgebra/BilinearForm/Properties.lean
@@ -158,11 +158,7 @@ theorem isRefl (H : B₁.IsAlt) : B₁.IsRefl := LinearMap.IsAlt.isRefl H
 #align bilin_form.is_alt.is_refl LinearMap.BilinForm.IsAlt.isRefl
 
 theorem eq_of_add_add_eq_zero [IsCancelAdd R] {a b c : M} (H : B.IsAlt) (hAdd : a + b + c = 0) :
-    B a b = B b c := by
-  have : B a a + B a b + B a c = B a c + B b c + B c c := by
-    simp_rw [← map_add, ← map_add₂, hAdd, map_zero, LinearMap.zero_apply]
-  rw [H, H, zero_add, add_zero, add_comm] at this
-  exact add_left_cancel this
+    B a b = B b c := LinearMap.eq_of_add_add_eq_zero H hAdd
 
 protected theorem add {B₁ B₂ : BilinForm R M} (hB₁ : B₁.IsAlt) (hB₂ : B₂.IsAlt) : (B₁ + B₂).IsAlt :=
   fun x => (congr_arg₂ (· + ·) (hB₁ x) (hB₂ x) : _).trans <| add_zero _

--- a/Mathlib/LinearAlgebra/BilinearForm/Properties.lean
+++ b/Mathlib/LinearAlgebra/BilinearForm/Properties.lean
@@ -186,7 +186,7 @@ theorem isAlt_neg {B : BilinForm R₁ M₁} : (-B).IsAlt ↔ B.IsAlt :=
 #align bilin_form.is_alt_neg LinearMap.BilinForm.isAlt_neg
 
 theorem Alt_eq_of_sum_zero {B : BilinForm R₁ M₁} {a b c : M₁} (hB : B.IsAlt) (hSum : a + b + c = 0) :
-  B a b = B b c := by
+    B a b = B b c := by
   rw [← neg_eq_iff_add_eq_zero] at hSum
   rw [← hSum, B.neg_right, B.add_right, hB.self_eq_zero, ← hB.neg_eq, add_zero]
 

--- a/Mathlib/LinearAlgebra/BilinearForm/Properties.lean
+++ b/Mathlib/LinearAlgebra/BilinearForm/Properties.lean
@@ -185,6 +185,11 @@ theorem isAlt_neg {B : BilinForm R₁ M₁} : (-B).IsAlt ↔ B.IsAlt :=
   ⟨fun h => neg_neg B ▸ h.neg, IsAlt.neg⟩
 #align bilin_form.is_alt_neg LinearMap.BilinForm.isAlt_neg
 
+theorem Alt_eq_of_sum_zero {B : BilinForm R₁ M₁} {a b c : M₁} (hB : B.IsAlt) (hSum : a + b + c = 0) :
+  B a b = B b c := by
+  rw [← neg_eq_iff_add_eq_zero] at hSum
+  rw [← hSum, B.neg_right, B.add_right, hB.self_eq_zero, ← hB.neg_eq, add_zero]
+
 /-! ### Linear adjoints -/
 
 

--- a/Mathlib/LinearAlgebra/BilinearForm/Properties.lean
+++ b/Mathlib/LinearAlgebra/BilinearForm/Properties.lean
@@ -158,7 +158,7 @@ theorem isRefl (H : B₁.IsAlt) : B₁.IsRefl := LinearMap.IsAlt.isRefl H
 #align bilin_form.is_alt.is_refl LinearMap.BilinForm.IsAlt.isRefl
 
 theorem eq_of_add_add_eq_zero [IsCancelAdd R] {a b c : M} (H : B.IsAlt) (hAdd : a + b + c = 0) :
-    B a b = B b c := LinearMap.eq_of_add_add_eq_zero H hAdd
+    B a b = B b c := LinearMap.IsAlt.eq_of_add_add_eq_zero H hAdd
 
 protected theorem add {B₁ B₂ : BilinForm R M} (hB₁ : B₁.IsAlt) (hB₂ : B₂.IsAlt) : (B₁ + B₂).IsAlt :=
   fun x => (congr_arg₂ (· + ·) (hB₁ x) (hB₂ x) : _).trans <| add_zero _

--- a/Mathlib/LinearAlgebra/BilinearForm/Properties.lean
+++ b/Mathlib/LinearAlgebra/BilinearForm/Properties.lean
@@ -157,6 +157,13 @@ theorem neg_eq (H : B₁.IsAlt) (x y : M₁) : -B₁ x y = B₁ y x := LinearMap
 theorem isRefl (H : B₁.IsAlt) : B₁.IsRefl := LinearMap.IsAlt.isRefl H
 #align bilin_form.is_alt.is_refl LinearMap.BilinForm.IsAlt.isRefl
 
+theorem eq_of_add_add_eq_zero [IsCancelAdd R] {a b c : M} (H : B.IsAlt) (hAdd : a + b + c = 0) :
+    B a b = B b c := by
+  have : B a a + B a b + B a c = B a c + B b c + B c c := by
+    simp_rw [← map_add, ← map_add₂, hAdd, map_zero, LinearMap.zero_apply]
+  rw [H, H, zero_add, add_zero, add_comm] at this
+  exact add_left_cancel this
+
 protected theorem add {B₁ B₂ : BilinForm R M} (hB₁ : B₁.IsAlt) (hB₂ : B₂.IsAlt) : (B₁ + B₂).IsAlt :=
   fun x => (congr_arg₂ (· + ·) (hB₁ x) (hB₂ x) : _).trans <| add_zero _
 #align bilin_form.is_alt.add LinearMap.BilinForm.IsAlt.add
@@ -184,11 +191,6 @@ theorem isAlt_zero : (0 : BilinForm R M).IsAlt := fun _ => rfl
 theorem isAlt_neg {B : BilinForm R₁ M₁} : (-B).IsAlt ↔ B.IsAlt :=
   ⟨fun h => neg_neg B ▸ h.neg, IsAlt.neg⟩
 #align bilin_form.is_alt_neg LinearMap.BilinForm.isAlt_neg
-
-theorem Alt_eq_of_sum_zero {B : BilinForm R₁ M₁} {a b c : M₁} (hB : B.IsAlt) (hSum : a + b + c = 0) :
-    B a b = B b c := by
-  rw [← neg_eq_iff_add_eq_zero] at hSum
-  rw [← hSum, B.neg_right, B.add_right, hB.self_eq_zero, ← hB.neg_eq, add_zero]
 
 /-! ### Linear adjoints -/
 

--- a/Mathlib/LinearAlgebra/SesquilinearForm.lean
+++ b/Mathlib/LinearAlgebra/SesquilinearForm.lean
@@ -276,7 +276,7 @@ theorem IsAlt.self_eq_zero (x : M₁) : B x x = 0 :=
   H x
 #align linear_map.is_alt.self_eq_zero LinearMap.IsAlt.self_eq_zero
 
-theorem eq_of_add_add_eq_zero [IsCancelAdd M] {a b c : M₁} (hAdd : a + b + c = 0) :
+theorem IsAlt.eq_of_add_add_eq_zero [IsCancelAdd M] {a b c : M₁} (hAdd : a + b + c = 0) :
     B a b = B b c := by
   have : B a a + B a b + B a c = B a c + B b c + B c c := by
     simp_rw [← map_add, ← map_add₂, hAdd, map_zero, LinearMap.zero_apply]

--- a/Mathlib/LinearAlgebra/SesquilinearForm.lean
+++ b/Mathlib/LinearAlgebra/SesquilinearForm.lean
@@ -276,8 +276,8 @@ theorem IsAlt.self_eq_zero (x : M₁) : B x x = 0 :=
   H x
 #align linear_map.is_alt.self_eq_zero LinearMap.IsAlt.self_eq_zero
 
-theorem eq_of_add_add_eq_zero [IsCancelAdd M] {a b c : M₁} (hAdd : a + b + c = 0) : B a b = B b c
-    := by
+theorem eq_of_add_add_eq_zero [IsCancelAdd M] {a b c : M₁} (hAdd : a + b + c = 0) :
+    B a b = B b c := by
   have : B a a + B a b + B a c = B a c + B b c + B c c := by
     simp_rw [← map_add, ← map_add₂, hAdd, map_zero, LinearMap.zero_apply]
   rw [H, H, zero_add, add_zero, add_comm] at this

--- a/Mathlib/LinearAlgebra/SesquilinearForm.lean
+++ b/Mathlib/LinearAlgebra/SesquilinearForm.lean
@@ -276,7 +276,8 @@ theorem IsAlt.self_eq_zero (x : M₁) : B x x = 0 :=
   H x
 #align linear_map.is_alt.self_eq_zero LinearMap.IsAlt.self_eq_zero
 
-theorem eq_of_add_add_eq_zero [IsCancelAdd M] {a b c : M₁} (hAdd : a + b + c = 0) : B a b = B b c := by
+theorem eq_of_add_add_eq_zero [IsCancelAdd M] {a b c : M₁} (hAdd : a + b + c = 0) : B a b = B b c
+    := by
   have : B a a + B a b + B a c = B a c + B b c + B c c := by
     simp_rw [← map_add, ← map_add₂, hAdd, map_zero, LinearMap.zero_apply]
   rw [H, H, zero_add, add_zero, add_comm] at this

--- a/Mathlib/LinearAlgebra/SesquilinearForm.lean
+++ b/Mathlib/LinearAlgebra/SesquilinearForm.lean
@@ -304,6 +304,12 @@ theorem ortho_comm {x y} : IsOrtho B x y ↔ IsOrtho B y x :=
   H.isRefl.ortho_comm
 #align linear_map.is_alt.ortho_comm LinearMap.IsAlt.ortho_comm
 
+theorem eq_of_add_add_eq_zero {a b c : M₁} (hAdd : a + b + c = 0) : B a b = B b c := by
+  have : B a a + B a b + B a c = B a c + B b c + B c c := by
+    simp_rw [← map_add, ← map_add₂, hAdd, map_zero, LinearMap.zero_apply]
+  rw [H, H, zero_add, add_zero, add_comm] at this
+  exact add_left_cancel this
+
 end IsAlt
 
 end AddCommGroup

--- a/Mathlib/LinearAlgebra/SesquilinearForm.lean
+++ b/Mathlib/LinearAlgebra/SesquilinearForm.lean
@@ -276,6 +276,12 @@ theorem IsAlt.self_eq_zero (x : M₁) : B x x = 0 :=
   H x
 #align linear_map.is_alt.self_eq_zero LinearMap.IsAlt.self_eq_zero
 
+theorem eq_of_add_add_eq_zero [IsCancelAdd M] {a b c : M₁} (hAdd : a + b + c = 0) : B a b = B b c := by
+  have : B a a + B a b + B a c = B a c + B b c + B c c := by
+    simp_rw [← map_add, ← map_add₂, hAdd, map_zero, LinearMap.zero_apply]
+  rw [H, H, zero_add, add_zero, add_comm] at this
+  exact add_left_cancel this
+
 end AddCommMonoid
 
 section AddCommGroup
@@ -303,12 +309,6 @@ theorem isRefl : B.IsRefl := by
 theorem ortho_comm {x y} : IsOrtho B x y ↔ IsOrtho B y x :=
   H.isRefl.ortho_comm
 #align linear_map.is_alt.ortho_comm LinearMap.IsAlt.ortho_comm
-
-theorem eq_of_add_add_eq_zero {a b c : M₁} (hAdd : a + b + c = 0) : B a b = B b c := by
-  have : B a a + B a b + B a c = B a c + B b c + B c c := by
-    simp_rw [← map_add, ← map_add₂, hAdd, map_zero, LinearMap.zero_apply]
-  rw [H, H, zero_add, add_zero, add_comm] at this
-  exact add_left_cancel this
 
 end IsAlt
 


### PR DESCRIPTION
For an alternating form $B : M \times M \to R$ and $a, b, c \in M$ with $a + b+ c = 0$, we have $B(a, b) = B(b, c)$.
This can be used to prove the same property of Wronskian: see #14243.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
