### PR TITLE
[Merged by Bors] - feat: the forget functor from ModuleCat to AddCommGrp reflects all limits

### DIFF
--- a/Mathlib/Algebra/Category/ModuleCat/Abelian.lean
+++ b/Mathlib/Algebra/Category/ModuleCat/Abelian.lean
@@ -86,7 +86,7 @@ section ReflectsLimits
 
 -- Porting note: added to make the following definitions work
 instance : HasLimitsOfSize.{v,v} (ModuleCatMax.{v, w} R) :=
-  ModuleCat.hasLimitsOfSize.{v, max v w, _, v}
+  ModuleCat.hasLimitsOfSize.{v, v, max v w}
 
 /- We need to put this in this weird spot because we need to know that the category of modules
     is balanced. -/

--- a/Mathlib/Algebra/Category/ModuleCat/ChangeOfRings.lean
+++ b/Mathlib/Algebra/Category/ModuleCat/ChangeOfRings.lean
@@ -869,7 +869,6 @@ noncomputable instance preservesLimitRestrictScalars
     (F : J ⥤ ModuleCat.{v} S) [Small.{v} (F ⋙ forget _).sections] :
     PreservesLimit F (restrictScalars f) :=
   ⟨fun {c} hc => by
-    have : Small.{v} ((F ⋙ restrictScalars f) ⋙ forget _).sections := by assumption
     have hc' := isLimitOfPreserves (forget₂ _ AddCommGrp) hc
     exact isLimitOfReflects (forget₂ _ AddCommGrp) hc'⟩
 

--- a/Mathlib/Algebra/Category/ModuleCat/Limits.lean
+++ b/Mathlib/Algebra/Category/ModuleCat/Limits.lean
@@ -119,7 +119,7 @@ def limitCone : Cone F where
 /-- Witness that the limit cone in `ModuleCat R` is a limit cone.
 (Internal use only; use the limits API.)
 -/
-def limitConeIsLimit : IsLimit (limitCone.{v, w} F) := by
+def limitConeIsLimit : IsLimit (limitCone.{t, v, w} F) := by
   refine IsLimit.ofFaithful (forget (ModuleCat R)) (Types.Small.limitConeIsLimit.{v, w} _)
     (fun s => ⟨⟨(Types.Small.limitConeIsLimit.{v, w} _).lift
                 ((forget (ModuleCat R)).mapCone s), ?_⟩, ?_⟩)
@@ -155,7 +155,7 @@ lemma hasLimitsOfSize [UnivLE.{v, w}] : HasLimitsOfSize.{t, v} (ModuleCat.{w} R)
 #align Module.has_limits_of_size ModuleCat.hasLimitsOfSize
 
 instance hasLimits : HasLimits (ModuleCat.{w} R) :=
-  ModuleCat.hasLimitsOfSize.{w, w, u}
+  ModuleCat.hasLimitsOfSize.{w, w, w, u}
 #align Module.has_limits ModuleCat.hasLimits
 
 instance (priority := high) hasLimits' : HasLimits (ModuleCat.{u} R) :=

--- a/Mathlib/Algebra/Category/ModuleCat/Limits.lean
+++ b/Mathlib/Algebra/Category/ModuleCat/Limits.lean
@@ -61,6 +61,8 @@ instance : AddCommMonoid (F ⋙ forget (ModuleCat R)).sections :=
 instance : Module R (F ⋙ forget (ModuleCat R)).sections :=
   inferInstanceAs <| Module R (sectionsSubmodule F)
 
+section
+
 variable [Small.{w} (Functor.sections (F ⋙ forget (ModuleCat R)))]
 
 instance : Small.{w} (sectionsSubmodule F) :=
@@ -175,10 +177,6 @@ instance forget₂AddCommGroupPreservesLimit :
   preservesLimitOfPreservesLimitCone (limitConeIsLimit F)
     (forget₂AddCommGroupPreservesLimitsAux F)
 
-instance forget₂AddCommGroupReflectsLimit :
-    ReflectsLimit F (forget₂ (ModuleCat R) AddCommGrp) :=
-  reflectsLimitOfReflectsIsomorphisms _ _
-
 /-- The forgetful functor from R-modules to abelian groups preserves all limits.
 -/
 instance forget₂AddCommGroupPreservesLimitsOfSize [UnivLE.{v, w}] :
@@ -204,6 +202,23 @@ instance forgetPreservesLimitsOfSize [UnivLE.{v, w}] :
 instance forgetPreservesLimits : PreservesLimits (forget (ModuleCat.{w} R)) :=
   ModuleCat.forgetPreservesLimitsOfSize.{w, w}
 #align Module.forget_preserves_limits ModuleCat.forgetPreservesLimits
+
+end
+
+instance forget₂AddCommGroupReflectsLimit :
+    ReflectsLimit F (forget₂ (ModuleCat.{w} R) AddCommGrp) where
+  reflects {c} hc := by
+    have : HasLimit (F ⋙ forget₂ (ModuleCat R) AddCommGrp) := ⟨_, hc⟩
+    have : Small.{w} (Functor.sections (F ⋙ forget (ModuleCat R))) := by
+      simpa only [AddCommGrp.hasLimit_iff_small_sections] using this
+    have := reflectsLimitOfReflectsIsomorphisms F (forget₂ (ModuleCat R) AddCommGrp)
+    exact isLimitOfReflects _ hc
+
+instance forget₂AddCommGroupReflectsLimitOfShape :
+    ReflectsLimitsOfShape J (forget₂ (ModuleCat.{w} R) AddCommGrp) where
+
+instance forget₂AddCommGroupReflectsLimitOfSize :
+    ReflectsLimitsOfSize.{t, v} (forget₂ (ModuleCat.{w} R) AddCommGrp) where
 
 section DirectLimit
 

--- a/Mathlib/Algebra/Category/ModuleCat/Limits.lean
+++ b/Mathlib/Algebra/Category/ModuleCat/Limits.lean
@@ -21,7 +21,7 @@ open CategoryTheory
 
 open CategoryTheory.Limits
 
-universe v w u t
+universe t v w u
 
 -- `u` is determined by the ring, so can come later
 noncomputable section


### PR DESCRIPTION
The forget functor from the category of modules to abelian groups reflects all limits (regardless of universes).

This may reduce universe assumptions in #14254.

This contribution was created as part of the AIM workshop "Formalizing algebraic geometry" in June 2024.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
