### PR TITLE
[Merged by Bors] - feat: `QuadraticForm.baseChange` is unique when it exists

### DIFF
--- a/Mathlib/LinearAlgebra/QuadraticForm/TensorProduct.lean
+++ b/Mathlib/LinearAlgebra/QuadraticForm/TensorProduct.lean
@@ -116,8 +116,7 @@ theorem baseChange_ext ⦃Q₁ Q₂ : QuadraticForm A (A ⊗[R] M₂)⦄
   replace h (a m) : Q₁ (a ⊗ₜ m) = Q₂ (a ⊗ₜ m) := by
     rw [← mul_one a, ← smul_eq_mul, ← smul_tmul', map_smul, map_smul, h]
   ext x
-  -- TODO: remove `using` after #14204 lands
-  induction x using TensorProduct.induction_on with
+  induction x with
   | tmul => simp [h]
   | zero => simp
   | add x y hx hy =>

--- a/Mathlib/LinearAlgebra/QuadraticForm/TensorProduct.lean
+++ b/Mathlib/LinearAlgebra/QuadraticForm/TensorProduct.lean
@@ -104,6 +104,30 @@ theorem polarBilin_baseChange [Invertible (2 : A)] (Q : QuadraticForm R M₂) :
     ← LinearMap.map_smul, smul_tmul', ← two_nsmul_associated R, coe_associatedHom, associated_sq,
     smul_comm, ← smul_assoc, two_smul, invOf_two_add_invOf_two, one_smul]
 
+/-- If two quadratic forms from `A ⊗[R] M₂` agree on elements of the form `1 ⊗ m`, they are equal.
+
+In other words, if a base change exists for a quadratic form, it is unique.
+
+Note that unlike `QuadraticForm.baseChange`, this does not need `Invertible (2 : R)`. -/
+theorem baseChange_ext ⦃Q₁ Q₂ : QuadraticForm A (A ⊗[R] M₂)⦄
+    (h : ∀ m, Q₁ (1 ⊗ₜ m) = Q₂ (1 ⊗ₜ m)) :
+    Q₁ = Q₂ := by
+  replace h (a m) : Q₁ (a ⊗ₜ m) = Q₂ (a ⊗ₜ m) := by
+    rw [← mul_one a, ← smul_eq_mul, ← smul_tmul', map_smul, map_smul, h]
+  ext x
+  -- TODO: remove `using` after #14204 lands
+  induction x using TensorProduct.induction_on with
+  | tmul => simp [h]
+  | zero => simp
+  | add x y hx hy =>
+    have : Q₁.polarBilin = Q₂.polarBilin := by
+      ext
+      dsimp [polar]
+      rw [← TensorProduct.tmul_add, h, h, h]
+    replace := congr($this x y)
+    dsimp [polar] at this
+    linear_combination this + hx + hy
+
 end CommRing
 
 end QuadraticForm

--- a/Mathlib/LinearAlgebra/QuadraticForm/TensorProduct.lean
+++ b/Mathlib/LinearAlgebra/QuadraticForm/TensorProduct.lean
@@ -109,6 +109,7 @@ theorem polarBilin_baseChange [Invertible (2 : A)] (Q : QuadraticForm R M₂) :
 In other words, if a base change exists for a quadratic form, it is unique.
 
 Note that unlike `QuadraticForm.baseChange`, this does not need `Invertible (2 : R)`. -/
+@[ext]
 theorem baseChange_ext ⦃Q₁ Q₂ : QuadraticForm A (A ⊗[R] M₂)⦄
     (h : ∀ m, Q₁ (1 ⊗ₜ m) = Q₂ (1 ⊗ₜ m)) :
     Q₁ = Q₂ := by


### PR DESCRIPTION
Proof adapted from @ScottCarnahan's [Zulip message](https://leanprover.zulipchat.com/#narrow/stream/217875-Is-there-code-for-X.3F/topic/Base.20change.20for.20bilinear.20maps.20and.20quadratic.20forms/near/375115826)

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #xyz [optional extra text]
-->
- [x] depends on: #14204

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
