### PR TITLE
[Merged by Bors] - doc: RingTheory/Generators clarification

### DIFF
--- a/Mathlib/RingTheory/Generators.lean
+++ b/Mathlib/RingTheory/Generators.lean
@@ -10,10 +10,13 @@ import Mathlib.RingTheory.Ideal.Cotangent
 # Generators of algebras
 
 ## Main definition
+
 - `Algebra.Generators`: A family of generators of a `R`-algebra `S` consists of
   1. `vars`: The type of variables.
   2. `val : vars → S`: The assignment of each variable to a value.
-  3. `σ`: A section of `R[X] → S`.
+  3. `σ`: A set-theoretic section of the induced `R`-algebra homomorphism `R[X] → S`, where we
+     write `R[X]` for `R[vars]`.
+
 - `Algebra.Generators.Hom`: Given a commuting square
   ```
   R --→ P = R[X] ---→ S
@@ -22,6 +25,7 @@ import Mathlib.RingTheory.Ideal.Cotangent
   R' -→ P' = R'[X'] → S
   ```
   A hom between `P` and `P'` is an assignment `X → P'` such that the arrows commute.
+
 - `Algebra.Generators.Cotangent`: The cotangent space wrt `P = R[X] → S`, i.e. the
   space `I/I²` with `I` being the kernel of the presentation.
 


### PR DESCRIPTION
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)

I've only just started looking at this material (I've had a hectic last few weeks) and my first reaction was "I don't even understand the module docstring".