### PR TITLE
[Merged by Bors] - chore(Topology): remove all but one use of autoImplicit

### DIFF
--- a/Mathlib/Topology/Algebra/ConstMulAction.lean
+++ b/Mathlib/Topology/Algebra/ConstMulAction.lean
@@ -40,9 +40,6 @@ Hausdorff, discrete group, properly discontinuous, quotient space
 
 -/
 
-set_option autoImplicit true
-
-
 open Topology Pointwise Filter Set TopologicalSpace
 
 /-- Class `ContinuousConstSMul Γ T` says that the scalar multiplication `(•) : Γ → T → T`
@@ -192,7 +189,7 @@ theorem smul_closure_orbit_subset (c : M) (x : α) :
 #align smul_closure_orbit_subset smul_closure_orbit_subset
 #align vadd_closure_orbit_subset vadd_closure_orbit_subset
 
-theorem isClosed_setOf_map_smul [Monoid N] (α β) [MulAction M α] [MulAction N β]
+theorem isClosed_setOf_map_smul {N : Type*} [Monoid N] (α β) [MulAction M α] [MulAction N β]
     [TopologicalSpace β] [T2Space β] [ContinuousConstSMul N β] (σ : M → N) :
     IsClosed { f : α → β | ∀ c x, f (c • x) = σ c • f x } := by
   simp only [Set.setOf_forall]

--- a/Mathlib/Topology/Category/Stonean/Limits.lean
+++ b/Mathlib/Topology/Category/Stonean/Limits.lean
@@ -18,7 +18,7 @@ pullbacks where one of the maps is an open embedding
 
 -/
 
-set_option autoImplicit true
+universe u
 
 open CategoryTheory
 

--- a/Mathlib/Topology/Order/ExtendFrom.lean
+++ b/Mathlib/Topology/Order/ExtendFrom.lean
@@ -12,13 +12,9 @@ import Mathlib.Topology.Order.DenselyOrdered
 # Lemmas about `extendFrom` in an order topology.
 -/
 
-set_option autoImplicit true
+open Filter Set Topology
 
-
-open Filter Set TopologicalSpace
-
-open scoped Classical
-open Topology
+variable {α β : Type*}
 
 theorem continuousOn_Icc_extendFrom_Ioo [TopologicalSpace α] [LinearOrder α] [DenselyOrdered α]
     [OrderTopology α] [TopologicalSpace β] [RegularSpace β] {f : α → β} {a b : α} {la lb : β}

--- a/Mathlib/Topology/Sheaves/Presheaf.lean
+++ b/Mathlib/Topology/Sheaves/Presheaf.lean
@@ -30,9 +30,6 @@ We also define the functors `pushforward` and `pullback` between the categories
 `TopCat.Presheaf.pushforwardPullbackAdjunction`.
 -/
 
-set_option autoImplicit true
-
-
 universe w v u
 
 open CategoryTheory TopologicalSpace Opposite
@@ -55,11 +52,13 @@ variable {C}
 
 namespace Presheaf
 
-@[simp] theorem comp_app {P Q R : Presheaf C X} (f : P ⟶ Q) (g : Q ⟶ R) :
+@[simp] theorem comp_app {X : TopCat} {U : (Opens X)ᵒᵖ} {P Q R : Presheaf C X}
+    (f : P ⟶ Q) (g : Q ⟶ R) :
     (f ≫ g).app U = f.app U ≫ g.app U := rfl
 
 @[ext]
-lemma ext {P Q : Presheaf C X} {f g : P ⟶ Q} (w : ∀ U : Opens X, f.app (op U) = g.app (op U)) :
+lemma ext {X : TopCat} {P Q : Presheaf C X} {f g : P ⟶ Q}
+    (w : ∀ U : Opens X, f.app (op U) = g.app (op U)) :
     f = g := by
   apply NatTrans.ext
   ext U


### PR DESCRIPTION
And remove superfluous open's in Order/ExtendFrom.

---

The remaining use is scoped to a single declaration in `MetricSpace`, something to do with instance synthesis.

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
