### PR TITLE
[Merged by Bors] - chore(RingTheory): remove use of autoImplicit

### DIFF
--- a/Mathlib/RingTheory/FinitePresentation.lean
+++ b/Mathlib/RingTheory/FinitePresentation.lean
@@ -25,8 +25,6 @@ In this file we define several notions of finiteness that are common in commutat
 
 -/
 
-set_option autoImplicit true
-
 open Function (Surjective)
 
 open Polynomial
@@ -102,7 +100,7 @@ theorem equiv [FinitePresentation R A] (e : A ≃ₐ[R] B) : FinitePresentation 
 variable (R)
 
 /-- The ring of polynomials in finitely many variables is finitely presented. -/
-protected instance mvPolynomial (ι : Type u_2) [Finite ι] :
+protected instance mvPolynomial (ι : Type*) [Finite ι] :
     FinitePresentation R (MvPolynomial ι R) where
   out := by
     cases nonempty_fintype ι
@@ -186,6 +184,7 @@ theorem iff_quotient_mvPolynomial' :
     -- exact RingHom.ker_coe_equiv equiv.symm.toRingEquiv
 #align algebra.finite_presentation.iff_quotient_mv_polynomial' Algebra.FinitePresentation.iff_quotient_mvPolynomial'
 
+universe v in
 -- Porting note: make universe level explicit to ensure `ι, ι'` has the same universe level
 /-- If `A` is a finitely presented `R`-algebra, then `MvPolynomial (Fin n) A` is finitely presented
 as `R`-algebra. -/

--- a/Mathlib/RingTheory/Jacobson.lean
+++ b/Mathlib/RingTheory/Jacobson.lean
@@ -35,8 +35,6 @@ Let `R` be a commutative ring. Jacobson rings are defined using the first of the
 Jacobson, Jacobson Ring
 -/
 
-set_option autoImplicit true
-
 universe u
 namespace Ideal
 
@@ -634,8 +632,7 @@ instance isJacobson {R : Type*} [CommRing R] {ι : Type*} [Finite ι] [IsJacobso
 
 variable {n : ℕ}
 
--- Porting note: split out `aux_IH` and `quotient_mk_comp_C_isIntegral_of_jacobson'`
--- from the long proof of `Ideal.MvPolynomial.quotient_mk_comp_C_isIntegral_of_jacobson`
+universe v w
 
 /-- The constant coefficient as an R-linear morphism -/
 private noncomputable def Cₐ (R : Type u) (S : Type v)

--- a/Mathlib/RingTheory/RingInvo.lean
+++ b/Mathlib/RingTheory/RingInvo.lean
@@ -27,10 +27,7 @@ We provide a coercion to a function `R → Rᵐᵒᵖ`.
 Ring involution
 -/
 
-set_option autoImplicit true
-
-
-variable (R : Type*)
+variable {F : Type*} (R : Type*)
 
 /-- A ring involution -/
 structure RingInvo [Semiring R] extends R ≃+* Rᵐᵒᵖ where

--- a/Mathlib/RingTheory/WittVector/Isocrystal.lean
+++ b/Mathlib/RingTheory/WittVector/Isocrystal.lean
@@ -52,9 +52,6 @@ This file introduces notation in the locale `Isocrystal`.
 
 -/
 
-set_option autoImplicit true
-
-
 noncomputable section
 
 open FiniteDimensional
@@ -167,9 +164,9 @@ def StandardOneDimIsocrystal (_m : ℤ) : Type _ :=
 -- Porting note(https://github.com/leanprover-community/mathlib4/issues/5020): added
 section Deriving
 
-instance : AddCommGroup (StandardOneDimIsocrystal p k m) :=
+instance {m : ℤ} : AddCommGroup (StandardOneDimIsocrystal p k m) :=
   inferInstanceAs (AddCommGroup K(p, k))
-instance : Module K(p, k) (StandardOneDimIsocrystal p k m) :=
+instance {m : ℤ} : Module K(p, k) (StandardOneDimIsocrystal p k m) :=
   inferInstanceAs (Module K(p, k) K(p, k))
 
 end Deriving


### PR DESCRIPTION
And delete one porting note which very surely seems non-actionable.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
