### PR TITLE
[Merged by Bors] - chore(Logic): reduce use of autoImplicit

### DIFF
--- a/Mathlib/Logic/Basic.lean
+++ b/Mathlib/Logic/Basic.lean
@@ -1048,12 +1048,12 @@ def choice_of_byContradiction' {α : Sort*} (contra : ¬(α → False) → α) :
 
 end Classical
 
-set_option autoImplicit true in
 /-- This function has the same type as `Exists.recOn`, and can be used to case on an equality,
 but `Exists.recOn` can only eliminate into Prop, while this version eliminates into any universe
 using the axiom of choice. -/
 -- @[elab_as_elim] -- FIXME
-noncomputable def Exists.classicalRecOn {p : α → Prop} (h : ∃ a, p a) {C} (H : ∀ a, p a → C) : C :=
+noncomputable def Exists.classicalRecOn {α : Sort*} {p : α → Prop} (h : ∃ a, p a)
+    {C : Sort*} (H : ∀ a, p a → C) : C :=
   H (Classical.choose h) (Classical.choose_spec h)
 #align exists.classical_rec_on Exists.classicalRecOn
 

--- a/Mathlib/Logic/Small/Group.lean
+++ b/Mathlib/Logic/Small/Group.lean
@@ -10,9 +10,9 @@ import Mathlib.Logic.Equiv.TransferInstance
 # Transfer group structures from `α` to `Shrink α`.
 -/
 
-set_option autoImplicit true
-
 noncomputable section
+
+variable {α : Type*}
 
 -- FIXME: here and below, why doesn't `to_additive` work?
 -- We're waiting on the fix for https://github.com/leanprover/lean4/issues/2077 to arrive.

--- a/Mathlib/Logic/Small/Module.lean
+++ b/Mathlib/Logic/Small/Module.lean
@@ -10,9 +10,9 @@ import Mathlib.Logic.Small.Ring
 # Transfer module and algebra structures from `α` to `Shrink α`.
 -/
 
-set_option autoImplicit true
-
 noncomputable section
+
+variable {α β : Type*}
 
 instance [Semiring α] [AddCommMonoid β] [Module α β] [Small β] : Module α (Shrink β) :=
   (equivShrink _).symm.module α

--- a/Mathlib/Logic/Small/Ring.lean
+++ b/Mathlib/Logic/Small/Ring.lean
@@ -10,9 +10,9 @@ import Mathlib.Logic.Equiv.TransferInstance
 # Transfer ring structures from `α` to `Shrink α`.
 -/
 
-set_option autoImplicit true
-
 noncomputable section
+
+variable {α : Type*}
 
 instance [NonUnitalNonAssocSemiring α] [Small α] : NonUnitalNonAssocSemiring (Shrink α) :=
   (equivShrink _).symm.nonUnitalNonAssocSemiring


### PR DESCRIPTION
The remaining uses are
- three declarations in Logic/Basic (which need it, somehow)
- in UnivLE, where removing this yields funky errors related to explicit universe levels
- in Logic/Equiv/Basic, which is a huge file; fixing it is less trivial


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
