### PR TITLE
feat(Algebra/Category): Direct construction of colimits in algebraic categories

### DIFF
--- a/Mathlib/Algebra/DirectSum/Module.lean
+++ b/Mathlib/Algebra/DirectSum/Module.lean
@@ -6,6 +6,7 @@ Authors: Kenny Lau
 import Mathlib.Algebra.DirectSum.Basic
 import Mathlib.LinearAlgebra.DFinsupp
 import Mathlib.LinearAlgebra.Basis
+import Mathlib.RingTheory.Finiteness
 
 #align_import algebra.direct_sum.module from "leanprover-community/mathlib"@"6623e6af705e97002a9054c1c05a980180276fc1"
 
@@ -51,6 +52,12 @@ instance {S : Type*} [Semiring S] [SMul R S] [∀ i, Module S (M i)] [∀ i, IsS
 
 instance [∀ i, Module Rᵐᵒᵖ (M i)] [∀ i, IsCentralScalar R (M i)] : IsCentralScalar R (⨁ i, M i) :=
   DFinsupp.isCentralScalar
+
+open DFinsupp in
+instance [Fintype ι] [∀ i, Module.Finite R (M i)] : Module.Finite R (⨁ i, M i) :=
+  have : (Π₀ (i : ι), M i) ≃ₗ[R] ((i : ι) → M i) :=
+    Equiv.toLinearEquiv equivFunOnFintype (by constructor <;> simp [equivFunOnFintype])
+  Module.Finite.equiv this.symm
 
 theorem smul_apply (b : R) (v : ⨁ i, M i) (i : ι) : (b • v) i = b • v i :=
   DFinsupp.smul_apply _ _ _

--- a/Mathlib/LinearAlgebra/FreeModule/Basic.lean
+++ b/Mathlib/LinearAlgebra/FreeModule/Basic.lean
@@ -140,14 +140,14 @@ instance prod [Module.Free R N] : Module.Free R (M × N) :=
 #align module.free.prod Module.Free.prod
 
 /-- The product of finitely many free modules is free. -/
-instance pi (M : ι → Type*) [Finite ι] [∀ i : ι, AddCommMonoid (M i)] [∀ i : ι, Module R (M i)]
+instance pi (M : ι → Type*) [Fintype ι] [∀ i : ι, AddCommMonoid (M i)] [∀ i : ι, Module R (M i)]
     [∀ i : ι, Module.Free R (M i)] : Module.Free R (∀ i, M i) :=
   let ⟨_⟩ := nonempty_fintype ι
   of_basis <| Pi.basis fun i => chooseBasis R (M i)
 #align module.free.pi Module.Free.pi
 
 /-- The module of finite matrices is free. -/
-instance matrix {m n : Type*} [Finite m] [Finite n] : Module.Free R (Matrix m n M) :=
+instance matrix {m n : Type*} [Fintype m] [Fintype n] : Module.Free R (Matrix m n M) :=
   Module.Free.pi R _
 #align module.free.matrix Module.Free.matrix
 
@@ -157,7 +157,7 @@ variable (ι)
 
 /-- The product of finitely many free modules is free (non-dependent version to help with typeclass
 search). -/
-instance function [Finite ι] : Module.Free R (ι → M) :=
+instance function [Fintype ι] : Module.Free R (ι → M) :=
   Free.pi _ _
 #align module.free.function Module.Free.function
 


### PR DESCRIPTION
(Below I only write about colimits since that's what I'm familiar with after working on it the last few days, but maybe it's the same for other categorical constructions)

**Main feature:** Construct colimits in `AddCommGrp`/`ModuleCat`/`FGModuleCat`(/...) directly as coequalizer (i.e. cokernel i.e. quotient) of two maps, allowing one to say $\coprod_j M_j \cong *$

Currently, if you look at how colimits are constructed for [AddCommGrp](https://github.com/leanprover-community/mathlib4/blob/master/Mathlib/Algebra/Category/Grp/Colimits.lean#L69-L92), you see this massive block of code of all relations generating the quotient relation, but that's kind of bad, you can't say anything concretely about it.

Also as noted in the TODOs of a few files:
```
TODO:
In fact, in `ModuleCat R` there is a much nicer model of colimits as quotients
of finitely supported functions, and we really should implement this as well.
```

I wrote it down [here](https://leanprover.zulipchat.com/#narrow/stream/287929-mathlib4/topic/Braided.20left.20rigid.20categories.20are.20right.20rigid/near/447490672), and **have formalised it** in a small file already [here](https://gist.github.com/grhkm21/5b2d938753c0ce0900d21c93a39e3b7d#file-addcommgrpcolimits-lean-L162-L163) (I also have a `ModuleCat` version, and proving existence of colimits in `FGModuleCat` from it).

Usually I will try to merge the file into Mathlib directly (preferably in one sitting), but I have been trying for a while now and been struggling. One issue is I am struggling to understand universes, which I asked [here](https://leanprover.zulipchat.com/#narrow/stream/113489-new-members/topic/Universe.20constraints!/near/448049266) along with many other places. A more concrete issue is that

- [ ] FGModuleCat (and `FullSubcategory` in general) requires morphism and objects to be on the same universe, whereas generally `Category.{v, u}` don't.

So that seems to limit what I can express, and maybe I have to fix it first.

Here are a few more TODOs just so I don't forget, probably done before the one above:

- [ ] Generalise `cokernelIsoQuotient` to other categories.
- [ ] Also prove `coproductIsoDirectSum`
- [ ] Also prove coequalizer (f + h) (g + h) ~ coequalizer f g ~ cokernel (f - g) 0
- [ ] Fix typo `FGModuleCatCat`

If anyone is familiar with universe stuff and can answer my many questions that'll be great too. I need help understanding just [these five lines](https://github.com/leanprover-community/mathlib4/blob/master/Mathlib/Algebra/Category/Grp/Colimits.lean#L267-L271)