### PR TITLE
[Merged by Bors] - feat(Combinatorics/SimpleGraph): vertices are not reachable iff set of walks between them is empty

### DIFF
--- a/Mathlib/Combinatorics/SimpleGraph/Connectivity.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Connectivity.lean
@@ -2002,7 +2002,7 @@ theorem reachable_iff_nonempty_univ {u v : V} :
 #align simple_graph.reachable_iff_nonempty_univ SimpleGraph.reachable_iff_nonempty_univ
 
 lemma not_reachable_iff_isEmpty_walk {u v : V} : ¬G.Reachable u v ↔ IsEmpty (G.Walk u v) := by
-   rw [reachable_iff_nonempty_univ, ← Set.nonempty_iff_univ_nonempty, not_nonempty_iff]
+  rw [Reachable, not_nonempty_iff]
 
 protected theorem Reachable.elim {p : Prop} {u v : V} (h : G.Reachable u v)
     (hp : G.Walk u v → p) : p :=

--- a/Mathlib/Combinatorics/SimpleGraph/Connectivity.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Connectivity.lean
@@ -2001,8 +2001,8 @@ theorem reachable_iff_nonempty_univ {u v : V} :
   Set.nonempty_iff_univ_nonempty
 #align simple_graph.reachable_iff_nonempty_univ SimpleGraph.reachable_iff_nonempty_univ
 
-lemma not_reachable_iff_isEmpty_walk {u v : V} : ¬G.Reachable u v ↔ IsEmpty (G.Walk u v) := by
-  rw [Reachable, not_nonempty_iff]
+lemma not_reachable_iff_isEmpty_walk {u v : V} : ¬G.Reachable u v ↔ IsEmpty (G.Walk u v) :=
+  not_nonempty_iff
 
 protected theorem Reachable.elim {p : Prop} {u v : V} (h : G.Reachable u v)
     (hp : G.Walk u v → p) : p :=

--- a/Mathlib/Combinatorics/SimpleGraph/Connectivity.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Connectivity.lean
@@ -1,4 +1,4 @@
-not/-
+/-
 Copyright (c) 2021 Kyle Miller. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Kyle Miller

--- a/Mathlib/Combinatorics/SimpleGraph/Connectivity.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Connectivity.lean
@@ -1,4 +1,4 @@
-/-
+not/-
 Copyright (c) 2021 Kyle Miller. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Kyle Miller
@@ -2001,7 +2001,7 @@ theorem reachable_iff_nonempty_univ {u v : V} :
   Set.nonempty_iff_univ_nonempty
 #align simple_graph.reachable_iff_nonempty_univ SimpleGraph.reachable_iff_nonempty_univ
 
-lemma not_reachable_iff_Walk_isEmpty {u v : V} : ¬G.Reachable u v ↔ IsEmpty (G.Walk u v) := by
+lemma not_reachable_iff_isEmpty_walk {u v : V} : ¬G.Reachable u v ↔ IsEmpty (G.Walk u v) := by
    rw [reachable_iff_nonempty_univ, ← Set.nonempty_iff_univ_nonempty, not_nonempty_iff]
 
 protected theorem Reachable.elim {p : Prop} {u v : V} (h : G.Reachable u v)

--- a/Mathlib/Combinatorics/SimpleGraph/Connectivity.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Connectivity.lean
@@ -2001,6 +2001,10 @@ theorem reachable_iff_nonempty_univ {u v : V} :
   Set.nonempty_iff_univ_nonempty
 #align simple_graph.reachable_iff_nonempty_univ SimpleGraph.reachable_iff_nonempty_univ
 
+
+lemma not_reachable_iff_Walk_isEmpty {u v : V} : ¬G.Reachable u v ↔ IsEmpty (G.Walk u v) := by
+   rw [reachable_iff_nonempty_univ, ← Set.nonempty_iff_univ_nonempty, not_nonempty_iff]
+
 protected theorem Reachable.elim {p : Prop} {u v : V} (h : G.Reachable u v)
     (hp : G.Walk u v → p) : p :=
   Nonempty.elim h hp

--- a/Mathlib/Combinatorics/SimpleGraph/Connectivity.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Connectivity.lean
@@ -2001,7 +2001,6 @@ theorem reachable_iff_nonempty_univ {u v : V} :
   Set.nonempty_iff_univ_nonempty
 #align simple_graph.reachable_iff_nonempty_univ SimpleGraph.reachable_iff_nonempty_univ
 
-
 lemma not_reachable_iff_Walk_isEmpty {u v : V} : ¬G.Reachable u v ↔ IsEmpty (G.Walk u v) := by
    rw [reachable_iff_nonempty_univ, ← Set.nonempty_iff_univ_nonempty, not_nonempty_iff]
 


### PR DESCRIPTION
This lemma came up while extending `SimpleGraph.dist` to `ENat`.

Co-authored-by: Kyle Miller <kmill31415@gmail.com>

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
