### PR TITLE
fix: checkout master in tech debts

### DIFF
--- a/.github/workflows/technical_debt_metrics.yml
+++ b/.github/workflows/technical_debt_metrics.yml
@@ -13,6 +13,7 @@ jobs:
       uses: actions/checkout@v4
       with: # checkout all history so that we can compare across commits
         fetch-depth: 0
+        ref: 'master'
 
     - name: Run script
       id: tech_debt


### PR DESCRIPTION
Prior to this PR, the tech-debts would report the "current" hash using a "detached head".  It should now report a valid hash from `master`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
