### PR TITLE
[Merged by Bors] - feat(RingTheory/Smooth): define standard smooth algebras

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -3747,6 +3747,7 @@ import Mathlib.RingTheory.RootsOfUnity.Lemmas
 import Mathlib.RingTheory.RootsOfUnity.Minpoly
 import Mathlib.RingTheory.SimpleModule
 import Mathlib.RingTheory.Smooth.Basic
+import Mathlib.RingTheory.Smooth.StandardSmooth
 import Mathlib.RingTheory.TensorProduct.Basic
 import Mathlib.RingTheory.TensorProduct.MvPolynomial
 import Mathlib.RingTheory.Trace

--- a/Mathlib/RingTheory/Smooth/StandardSmooth.lean
+++ b/Mathlib/RingTheory/Smooth/StandardSmooth.lean
@@ -45,14 +45,15 @@ Furthermore, for algebras we define:
 - `IsStandardSmooth.relativeDimension`: If `S` is `R`-standard smooth this is the dimension
   of an arbitrary submersive `R`-presentation of `S`. This is independent of the choice
   of the presentation (TODO, see below).
+- `IsStandardSmoothOfRelativeDimension n`: `S` is `R`-standard smooth of relative dimension `n`
+  if it admits a submersive `R`-presentation of dimension `n`.
 
 Finally, in the `RingHom` namespace we define
 
 - `IsStandardSmooth`: A ring homomorphism `R →+* S` is standard smooth if `S` is standard smooth
   as `R`-algebra.
 - `IsStandardSmoothOfRelativeDimension n`: A ring homomorphism `R →+* S` is standard smooth of
-  relative dimension `n` if it is standard smooth and the relative dimension of `S` as an
-  `R`-algebra is `n`.
+  relative dimension `n` if `S` is standard smooth of relative dimension `n` as `R`-algebra.
 
 ## TODO
 
@@ -80,12 +81,14 @@ in June 2024.
 
 universe t t' w w' u v
 
-variable (R : Type u) [CommRing R]
-variable (S : Type v) [CommRing S] [Algebra R S]
-
 open TensorProduct
 
+variable (n : ℕ)
+
 namespace Algebra
+
+variable (R : Type u) [CommRing R]
+variable (S : Type v) [CommRing S] [Algebra R S]
 
 /--
 A `PreSubmersivePresentation` of an `R`-algebra `S` is a `Presentation`
@@ -180,17 +183,32 @@ class IsStandardSmooth : Prop where
 The relative dimension of a standard smooth `R`-algebra `S` is
 the dimension of an arbitrarily chosen submersive `R`-presentation of `S`.
 
-Note: This number is independent of the choice of the presentation as it is equal to
-the `S`-rank of `Ω[S/R]` (TODO).
+Note: If `S` is non-trivial, this number is independent of the choice of the presentation as it is
+equal to the `S`-rank of `Ω[S/R]` (TODO).
 -/
 noncomputable def IsStandardSmooth.relativeDimension [IsStandardSmooth R S] : ℕ :=
   ‹IsStandardSmooth R S›.out.some.dimension
+
+/--
+An `R`-algebra `S` is called standard smooth of relative dimension `n`, if there exists
+a submersive presentation of dimension `n`.
+-/
+class IsStandardSmoothOfRelativeDimension : Prop where
+  out : ∃ P : SubmersivePresentation.{t, w} R S, P.dimension = n
+
+variable {R} {S}
+
+lemma isStandardSmooth_of_isStandardSmoothOfRelativeDimension
+    [IsStandardSmoothOfRelativeDimension.{t, w} n R S] :
+    IsStandardSmooth.{t, w} R S :=
+  ⟨‹IsStandardSmoothOfRelativeDimension n R S›.out.nonempty⟩
 
 end Algebra
 
 namespace RingHom
 
-variable {R S}
+variable {R : Type u} [CommRing R]
+variable {S : Type v} [CommRing S]
 
 /-- A ring homomorphism `R →+* S` is standard smooth if `S` is standard smooth as `S`-algebra. -/
 def IsStandardSmooth (f : R →+* S) : Prop :=
@@ -198,9 +216,14 @@ def IsStandardSmooth (f : R →+* S) : Prop :=
 
 /-- A ring homomorphism `R →+* S` is standard smooth of relative dimension `n` if
 it is both standard smooth and is of relative dimension `n`. -/
-structure IsStandardSmoothOfRelativeDimension (n : ℕ) (f : R →+* S) : Prop where
-  isStandardSmooth : IsStandardSmooth.{t, w} f
-  relativeDimension_eq :
-    @Algebra.IsStandardSmooth.relativeDimension R _ S _ f.toAlgebra isStandardSmooth = n
+def IsStandardSmoothOfRelativeDimension (f : R →+* S) : Prop :=
+  @Algebra.IsStandardSmoothOfRelativeDimension.{t, w} n _ _ _ _ f.toAlgebra
+
+lemma isStandardSmooth_of_isStandardSmoothOfRelativeDimension (f : R →+* S)
+    (hf : IsStandardSmoothOfRelativeDimension.{t, w} n f) :
+    IsStandardSmooth.{t, w} f :=
+  letI : Algebra R S := f.toAlgebra
+  letI : Algebra.IsStandardSmoothOfRelativeDimension.{t, w} n R S := hf
+  Algebra.isStandardSmooth_of_isStandardSmoothOfRelativeDimension n
 
 end RingHom

--- a/Mathlib/RingTheory/Smooth/StandardSmooth.lean
+++ b/Mathlib/RingTheory/Smooth/StandardSmooth.lean
@@ -10,69 +10,66 @@ import Mathlib.RingTheory.Presentation
 /-!
 # Standard smooth algebras
 
-In this file we define standard smooth presentations for algebras. This notion
-is introduced for `SubmersivePresentations`, which is a `Presentation`
-that has less relations than generators. More precisely there exists
-an injective map from `P.relations` to `P.vars`.
+In this file we define standard smooth algebras. For this we introduce
+the notion of a `PreSubmersivePresentation`. This is a presentation `P` that has
+fewer relations than generators. More precisely there exists an injective map from `P.rels`
+to `P.vars`. To such a presentation we may associate a jacobian. `P` is then a submersive
+presentation, if its jacobian is invertible.
 
-Finally, we introduce the notion of standard smooth algebras, which are algebras that
-admit a standard smooth presentation.
+Finally, a standard smooth algebra is an algebra that admits a submersive presentation.
 
 ## Main definitions
 
 All of these are in the `Algebra` namespace. Let `S` be an `R`-algebra.
 
-- `SubmersivePresentation`: A `Presentation` of `S` as `R`-algebra, equipped with an injective map
-  from `P.relations` to `P.vars`. This map is used to define the differential of a submersive
-  presentation.
+- `PreSubmersivePresentation`: A `Presentation` of `S` as `R`-algebra, equipped with an injective
+  map `P.map` from `P.rels` to `P.vars`. This map is used to define the differential of a
+  presubmersive presentation.
 
-Let now `P` be a submersive presentation of `S` over `R`.
+For a presubmersive presentation `P` of `S` over `R` we make the following definitions:
 
-- `SubmersivePresentation.differential`: A linear endomorphism of `P.rels → P.ring` sending
+- `PreSubmersivePresentation.differential`: A linear endomorphism of `P.rels → P.Ring` sending
   the `j`-th standard basis vector, corresponding to the `j`-th relation, to the vector
   of partial derivatives of `P.relation j` with respect to the coordinates `P.map i` for
   `i : P.rels`.
-- `SubmersivePresentation.jacobian`: The determinant of `P.differential`.
-- `SubmersivePresentation.jacobiMatrix`: If `P.rels` has a `Fintype` instance, we may form
+- `PreSubmersivePresentation.jacobian`: The determinant of `P.differential`.
+- `PreSubmersivePresentation.jacobiMatrix`: If `P.rels` has a `Fintype` instance, we may form
   the matrix corresponding to `P.differential`. Its determinant is `P.jacobian`.
-- `SubmersivePresentation.IsStandardSmooth`: `P` is standard smooth, if it's jacobian
-  is a unit in `S` and it is finite.
+- `SubmersivePresentation`: A submersive presentation is a finite, presubmersive presentation `P`
+  with in `S` invertible jacobian.
 
-Furthermore, we define:
+Furthermore, for algebras we define:
 
-- `IsStandardSmooth`: `S` is `R`-standard smooth if `S` has a standard smooth submersive
+- `IsStandardSmooth`: `S` is `R`-standard smooth if `S` admits a submersive
   `R`-presentation.
-- `IsOfRelativeDimension n`: A standard smooth `R`-algebra `S` is of relative dimension `n`
-  if `S` has a standard smooth submersive `R`-presentation of dimension `n`. Equivalently,
-  that every standard smooth has dimension `n` (TODO, see below).
-- `IsStandardSmoothOfRelativeDimension n`: The combination of the first two.
+- `IsStandardSmooth.relativeDimension`: If `S` is `R`-standard smooth this is the dimension
+  of an arbitrary submersive `R`-presentation of `S`. This is independent of the choice
+  of the presentation (TODO, see below).
 
 Finally, in the `RingHom` namespace we define
 
-- `IsStandardSmooth`: A ring hom `R →+* S` is standard smooth if `S` is standard smooth as
-  `R`-algebra.
+- `IsStandardSmooth`: A ring homomorphism `R →+* S` is standard smooth if `S` is standard smooth
+  as `R`-algebra.
+- `IsStandardSmoothOfRelativeDimension n`: A ring homomorphism `R →+* S` is standard smooth of
+  relative dimension `n` if it is standard smooth and the relative dimension of `S` as an
+  `R`-algebra is `n`.
 
 ## TODO
 
 - Show that the canonical presentation for localization away from an element is standard smooth
   of relative dimension 0.
-- Show that the base change of a standard smooth presentation is standard smooth of equal relative
+- Show that the base change of a submersive presentation is submersive of equal relative
   dimension.
-- Show that the composition of standard smooth presentations of relative dimensions `n` and `m` is
-  standard smooth of relative dimension `n + m`.
-- Show that the Kaehler differentials of a standard smooth `R`-algebra `S` of relative dimension `n`
-  are `S`-free of rank `n`. In particular this shows that the relative dimension is independent
-  of the choice of the standard smooth presentation.
+- Show that the composition of submersive presentations of relative dimensions `n` and `m` is
+  submersive of relative dimension `n + m`.
+- Show that the module of Kaehler differentials of a standard smooth `R`-algebra `S` of relative
+  dimension `n` is `S`-free of rank `n`. In particular this shows that the relative dimension
+  is independent of the choice of the standard smooth presentation.
 
 ## Implementation details
 
-We don't bundle `IsStandardSmooth` and `IsOfRelativeDimension n` in one typeclass, because then
-`IsStandardSmooth` can't be inferred from `StandardSmoothOfRelativeDimension n` as Lean can't know
-which `n` to choose. Mathematically this is still correct, since the dimension
-does not depend on the choice of the standard smooth presentation.
-
-Standard smooth algebras and ring homs feature 4 universe levels: The universe levels of the rings
-involved and the universe levels of the types of the variables and relations.
+Standard smooth algebras and ring homomorphisms feature 4 universe levels: The universe levels of
+the rings involved and the universe levels of the types of the variables and relations.
 
 ## Notes
 
@@ -91,25 +88,25 @@ open TensorProduct
 namespace Algebra
 
 /--
-A `SubmersivePresentation` of an `R`-algebra `S` is a `Presentation`
+A `PreSubmersivePresentation` of an `R`-algebra `S` is a `Presentation`
 with finitely-many relations equipped with an injective `map : relations → vars`.
 
 This map determines how the differential of `P` is constructed. See
-`SubmersivePresentation.differential` for details.
+`PreSubmersivePresentation.differential` for details.
 -/
 @[nolint checkUnivs]
-structure SubmersivePresentation extends Algebra.Presentation.{t, w} R S where
+structure PreSubmersivePresentation extends Algebra.Presentation.{t, w} R S where
   /-- A map from the relations type to the variables type. Used to compute the differential. -/
   map : rels → vars
   map_inj : Function.Injective map
   relations_finite : Finite rels
 
-namespace SubmersivePresentation
+namespace PreSubmersivePresentation
 
 attribute [instance] relations_finite
 
 variable {R S}
-variable (P : SubmersivePresentation R S)
+variable (P : PreSubmersivePresentation R S)
 
 lemma card_relations_le_card_vars_of_isFinite [P.IsFinite] :
     Nat.card P.rels ≤ Nat.card P.vars :=
@@ -120,21 +117,21 @@ noncomputable abbrev basis : Basis P.rels P.Ring (P.rels → P.Ring) :=
   Pi.basisFun P.Ring P.rels
 
 /--
-The differential of a `P : SubmersivePresentation` is a `P.Ring`-linear map on
+The differential of a `P : PreSubmersivePresentation` is a `P.Ring`-linear map on
 `P.rels → P.Ring`:
 
-The `j`-th standard basis vector, corresponding to the `j`-th relation of `P` is mapped
+The `j`-th standard basis vector, corresponding to the `j`-th relation of `P`, is mapped
 to the vector of partial derivatives of `P.relation j` with respect
 to the coordinates `P.map i` for all `i : P.rels`.
 
-The determinant of this map is the jacobian of `P` used to define when a `SubmersivePresentation`
-is standard smooth. See `SubmersivePresentation.jacobian`.
+The determinant of this map is the jacobian of `P` used to define when a `PreSubmersivePresentation`
+is submersive. See `PreSubmersivePresentation.jacobian`.
 -/
 noncomputable def differential : (P.rels → P.Ring) →ₗ[P.Ring] (P.rels → P.Ring) :=
   Basis.constr P.basis P.Ring
     (fun j i : P.rels ↦ MvPolynomial.pderiv (P.map i) (P.relation j))
 
-/-- The jacobian of a `P : SubmersivePresentation` is the determinant
+/-- The jacobian of a `P : PreSubmersivePresentation` is the determinant
 of `P.linearMap` viewed as element of `S`. -/
 noncomputable def jacobian : S :=
   algebraMap P.Ring S <| LinearMap.det P.differential
@@ -159,34 +156,35 @@ lemma jacobiMatrix_apply (i j : P.rels) :
 
 end Matrix
 
+end PreSubmersivePresentation
+
 /--
-A `SubmersivePresentation` is standard smooth if its jacobian is a unit in `S`
+A `PreSubmersivePresentation` is submersive if its jacobian is a unit in `S`
 and the presentation is finite.
 -/
-class IsStandardSmooth : Prop where
-  jacobian_isUnit : IsUnit P.jacobian
-  isFinite : P.IsFinite := by infer_instance
+@[nolint checkUnivs]
+structure SubmersivePresentation extends PreSubmersivePresentation.{t, w} R S where
+  jacobian_isUnit : IsUnit toPreSubmersivePresentation.jacobian
+  isFinite : toPreSubmersivePresentation.IsFinite := by infer_instance
 
-attribute [instance] IsStandardSmooth.isFinite
-
-end SubmersivePresentation
+attribute [instance] SubmersivePresentation.isFinite
 
 /--
 An `R`-algebra `S` is called standard smooth, if there
-exists a standard smooth submersive presentation.
+exists a submersive presentation.
 -/
 class IsStandardSmooth : Prop where
-  out : ∃ (P : SubmersivePresentation.{t, w} R S), P.IsStandardSmooth
+  out : Nonempty (SubmersivePresentation.{t, w} R S)
 
 /--
 The relative dimension of a standard smooth `R`-algebra `S` is
-the dimension of an arbitrarily chosen standard smooth `R`-presentation of `S`.
+the dimension of an arbitrarily chosen submersive `R`-presentation of `S`.
 
 Note: This number is independent of the choice of the presentation as it is equal to
 the `S`-rank of `Ω[S/R]` (TODO).
 -/
 noncomputable def IsStandardSmooth.relativeDimension [IsStandardSmooth R S] : ℕ :=
-  ‹IsStandardSmooth R S›.out.choose.dimension
+  ‹IsStandardSmooth R S›.out.some.dimension
 
 end Algebra
 
@@ -194,11 +192,11 @@ namespace RingHom
 
 variable {R S}
 
-/-- A ring hom `R →+* S` is standard smooth if `S` is standard smooth as `S`-algebra. -/
+/-- A ring homomorphism `R →+* S` is standard smooth if `S` is standard smooth as `S`-algebra. -/
 def IsStandardSmooth (f : R →+* S) : Prop :=
   @Algebra.IsStandardSmooth.{t, w} _ _ _ _ f.toAlgebra
 
-/-- A ring hom `R →+* S` is standard smooth of relative dimension `n` if
+/-- A ring homomorphism `R →+* S` is standard smooth of relative dimension `n` if
 it is both standard smooth and is of relative dimension `n`. -/
 structure IsStandardSmoothOfRelativeDimension (n : ℕ) (f : R →+* S) : Prop where
   isStandardSmooth : IsStandardSmooth.{t, w} f

--- a/Mathlib/RingTheory/Smooth/StandardSmooth.lean
+++ b/Mathlib/RingTheory/Smooth/StandardSmooth.lean
@@ -210,12 +210,12 @@ namespace RingHom
 variable {R : Type u} [CommRing R]
 variable {S : Type v} [CommRing S]
 
-/-- A ring homomorphism `R →+* S` is standard smooth if `S` is standard smooth as `S`-algebra. -/
+/-- A ring homomorphism `R →+* S` is standard smooth if `S` is standard smooth as `R`-algebra. -/
 def IsStandardSmooth (f : R →+* S) : Prop :=
   @Algebra.IsStandardSmooth.{t, w} _ _ _ _ f.toAlgebra
 
 /-- A ring homomorphism `R →+* S` is standard smooth of relative dimension `n` if
-it is both standard smooth and is of relative dimension `n`. -/
+`S` is standard smooth of relative dimension `n` as `R`-algebra. -/
 def IsStandardSmoothOfRelativeDimension (f : R →+* S) : Prop :=
   @Algebra.IsStandardSmoothOfRelativeDimension.{t, w} n _ _ _ _ f.toAlgebra
 

--- a/Mathlib/RingTheory/Smooth/StandardSmooth.lean
+++ b/Mathlib/RingTheory/Smooth/StandardSmooth.lean
@@ -18,6 +18,10 @@ presentation, if its jacobian is invertible.
 
 Finally, a standard smooth algebra is an algebra that admits a submersive presentation.
 
+While every standard smooth algebra is smooth, the converse does not hold. But if `S` is `R`-smooth,
+then `S` is `R`-standard smooth locally on `S`, i.e. there exists a set `{ t }` of `S` that generates
+the unit ideal, such that `Sₜ` is `R`-standard smooth for every `t` (TODO, see below).
+
 ## Main definitions
 
 All of these are in the `Algebra` namespace. Let `S` be an `R`-algebra.
@@ -40,20 +44,21 @@ For a presubmersive presentation `P` of `S` over `R` we make the following defin
 
 Furthermore, for algebras we define:
 
-- `IsStandardSmooth`: `S` is `R`-standard smooth if `S` admits a submersive
+- `Algebra.IsStandardSmooth`: `S` is `R`-standard smooth if `S` admits a submersive
   `R`-presentation.
-- `IsStandardSmooth.relativeDimension`: If `S` is `R`-standard smooth this is the dimension
+- `Algebra.IsStandardSmooth.relativeDimension`: If `S` is `R`-standard smooth this is the dimension
   of an arbitrary submersive `R`-presentation of `S`. This is independent of the choice
   of the presentation (TODO, see below).
-- `IsStandardSmoothOfRelativeDimension n`: `S` is `R`-standard smooth of relative dimension `n`
-  if it admits a submersive `R`-presentation of dimension `n`.
+- `Algebra.IsStandardSmoothOfRelativeDimension n`: `S` is `R`-standard smooth of relative dimension
+  `n` if it admits a submersive `R`-presentation of dimension `n`.
 
-Finally, in the `RingHom` namespace we define
+Finally, for ring homomorphisms we define:
 
-- `IsStandardSmooth`: A ring homomorphism `R →+* S` is standard smooth if `S` is standard smooth
-  as `R`-algebra.
-- `IsStandardSmoothOfRelativeDimension n`: A ring homomorphism `R →+* S` is standard smooth of
-  relative dimension `n` if `S` is standard smooth of relative dimension `n` as `R`-algebra.
+- `RingHom.IsStandardSmooth`: A ring homomorphism `R →+* S` is standard smooth if `S` is standard
+  smooth as `R`-algebra.
+- `RingHom.IsStandardSmoothOfRelativeDimension n`: A ring homomorphism `R →+* S` is standard
+  smooth of relative dimension `n` if `S` is standard smooth of relative dimension `n` as
+  `R`-algebra.
 
 ## TODO
 
@@ -66,6 +71,9 @@ Finally, in the `RingHom` namespace we define
 - Show that the module of Kaehler differentials of a standard smooth `R`-algebra `S` of relative
   dimension `n` is `S`-free of rank `n`. In particular this shows that the relative dimension
   is independent of the choice of the standard smooth presentation.
+- Show that standard smooth algebras are smooth. This relies on the computation of the module of
+  Kaehler differentials.
+- Show that locally on the target, smooth algebras are standard smooth.
 
 ## Implementation details
 
@@ -135,7 +143,7 @@ noncomputable def differential : (P.rels → P.Ring) →ₗ[P.Ring] (P.rels → 
     (fun j i : P.rels ↦ MvPolynomial.pderiv (P.map i) (P.relation j))
 
 /-- The jacobian of a `P : PreSubmersivePresentation` is the determinant
-of `P.linearMap` viewed as element of `S`. -/
+of `P.differential` viewed as element of `S`. -/
 noncomputable def jacobian : S :=
   algebraMap P.Ring S <| LinearMap.det P.differential
 
@@ -198,7 +206,7 @@ class IsStandardSmoothOfRelativeDimension : Prop where
 
 variable {R} {S}
 
-lemma isStandardSmooth_of_isStandardSmoothOfRelativeDimension
+lemma IsStandardSmoothOfRelativeDimension.isStandardSmooth
     [IsStandardSmoothOfRelativeDimension.{t, w} n R S] :
     IsStandardSmooth.{t, w} R S :=
   ⟨‹IsStandardSmoothOfRelativeDimension n R S›.out.nonempty⟩
@@ -219,11 +227,11 @@ def IsStandardSmooth (f : R →+* S) : Prop :=
 def IsStandardSmoothOfRelativeDimension (f : R →+* S) : Prop :=
   @Algebra.IsStandardSmoothOfRelativeDimension.{t, w} n _ _ _ _ f.toAlgebra
 
-lemma isStandardSmooth_of_isStandardSmoothOfRelativeDimension (f : R →+* S)
+lemma IsStandardSmoothOfRelativeDimension.isStandardSmooth (f : R →+* S)
     (hf : IsStandardSmoothOfRelativeDimension.{t, w} n f) :
     IsStandardSmooth.{t, w} f :=
   letI : Algebra R S := f.toAlgebra
   letI : Algebra.IsStandardSmoothOfRelativeDimension.{t, w} n R S := hf
-  Algebra.isStandardSmooth_of_isStandardSmoothOfRelativeDimension n
+  Algebra.IsStandardSmoothOfRelativeDimension.isStandardSmooth n
 
 end RingHom

--- a/Mathlib/RingTheory/Smooth/StandardSmooth.lean
+++ b/Mathlib/RingTheory/Smooth/StandardSmooth.lean
@@ -45,6 +45,7 @@ Furthermore, we define:
 - `IsOfRelativeDimension n`: A standard smooth `R`-algebra `S` is of relative dimension `n`
   if `S` has a standard smooth submersive `R`-presentation of dimension `n`. Equivalently,
   that every standard smooth has dimension `n` (TODO, see below).
+- `IsStandardSmoothOfRelativeDimension n`: The combination of the first two.
 
 Finally, in the `RingHom` namespace we define
 
@@ -199,7 +200,13 @@ def IsStandardSmooth (f : R →+* S) : Prop :=
 
 /-- A standard smooth ring hom `R →+* S` is standard smooth of relative dimension `n`
 if `S` has relative dimension `n` as `R`-algebra. -/
-def IsOfRelativeDimension (n : ℕ) (f : R →+* S) (hf : f.IsStandardSmooth) : Prop :=
+def IsOfRelativeDimension (n : ℕ) (f : R →+* S) (hf : IsStandardSmooth.{t, w} f) : Prop :=
   @Algebra.IsOfRelativeDimension.{t, w} _ _ _ _ f.toAlgebra n hf
+
+/-- A ring hom `R →+* S` is standard smooth of relative dimension `n` if
+it is both standard smooth and is of relative dimension `n`. -/
+structure IsStandardSmoothOfRelativeDimension (n : ℕ) (f : R →+* S) : Prop where
+  isStandardSmooth : IsStandardSmooth.{t, w} f
+  isOfRelativeDimension : IsOfRelativeDimension.{t, w} n f isStandardSmooth
 
 end RingHom

--- a/Mathlib/RingTheory/Smooth/StandardSmooth.lean
+++ b/Mathlib/RingTheory/Smooth/StandardSmooth.lean
@@ -1,0 +1,164 @@
+/-
+Copyright (c) 2024 Christian Merten. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Jung Tao Cheng, Christian Merten, Andrew Yang
+-/
+import Mathlib.Algebra.MvPolynomial.PDeriv
+import Mathlib.LinearAlgebra.Determinant
+import Mathlib.RingTheory.Presentation
+
+/-!
+# Standard smooth algebras
+
+In this file we define standard smooth presentations for algebras. This notion
+is introduced for `SubmersivePresentations`, which is a `Presentation`
+that has less relations than generators. More precisely there exists
+an injective map from `P.relations` to `P.vars`.
+
+Finally, we introduce the notion of standard smooth algebras, which are algebras that
+admit a standard smooth presentation.
+
+## Main definitions
+
+All of these are in the `Algebra` namespace. Let `S` be an `R`-algebra.
+
+- `SubmersivePresentation`: A `Presentation` of `S` as `R`-algebra, equipped with an injective map
+  from `P.relations` to `P.vars`. This map is used to define the differential of a submersive
+  presentation.
+
+Let now `P` be a submersive presentation of `S` over `R`.
+
+- `SubmersivePresentation.differential`: A linear endomorphism of `P.rels → P.ring` sending
+  the `j`-th standard basis vector, corresponding to the `j`-th relation, to the vector
+  of partial derivatives of `P.relation j` with respect to the coordinates `P.map i` for
+  `i : P.rels`.
+- `SubmersivePresentation.jacobian`: The determinant of `P.differential`.
+- `SubmersivePresentation.jacobiMatrix`: If `P.rels` has a `Fintype` instance, we may form
+  the matrix corresponding to `P.differential`. Its determinant is `P.jacobian`.
+- `SubmersivePresentation.IsStandardSmooth`: `P` is standard smooth, if it's jacobian
+  is a unit in `S` and it is finite.
+
+Finally, we define:
+
+- `IsStandardSmooth`: `S` is `R`-standard smooth if `S` has a standard smooth submersive
+  `R`-presentation.
+- `IsOfRelativeDimension n`: A standard smooth `R`-algebra `S` is of relative dimension `n`
+  if `S` has a standard smooth submersive `R`-presentation of dimension `n`. Equivalently,
+  that every standard smooth has dimension `n` (TODO, see below).
+
+## TODO
+
+- Show that the canonical presentation for localization away from an element is standard smooth
+  of relative dimension 0.
+- Show that the base change of a standard smooth presentation is standard smooth of equal relative
+  dimension.
+- Show that the composition of standard smooth presentations of relative dimensions `n` and `m` is
+  standard smooth of relative dimension `n + m`.
+- Show that the Kaehler differentials of a standard smooth `R`-algebra `S` of relative dimension `n`
+  are `S`-free of rank `n`. In particular this shows that the relative dimension is independent
+  of the choice of the standard smooth presentation.
+
+-/
+
+universe t t' w w' u v
+
+variable (R : Type u) [CommRing R]
+variable (S : Type v) [CommRing S] [Algebra R S]
+
+open TensorProduct
+
+namespace Algebra
+
+/--
+A `SubmersivePresentation` of an `R`-algebra `S` is a `Presentation`
+with finitely-many relations equipped with an injective `map : relations → vars`.
+
+This map determines how the differential of `P` is constructed. See
+`SubmersivePresentation.differential` for details.
+-/
+@[nolint checkUnivs]
+structure SubmersivePresentation extends Algebra.Presentation.{t, w} R S where
+  /-- A map from the relations type to the variables type. Used to compute the differential. -/
+  map : rels → vars
+  map_inj : Function.Injective map
+  relations_finite : Finite rels
+
+namespace SubmersivePresentation
+
+attribute [instance] relations_finite
+
+variable {R S}
+variable (P : SubmersivePresentation R S)
+
+lemma card_relations_le_card_vars_of_isFinite [P.IsFinite] :
+    Nat.card P.rels ≤ Nat.card P.vars :=
+  Nat.card_le_card_of_injective P.map P.map_inj
+
+/-- The standard basis of `P.rels → P.ring`. -/
+noncomputable abbrev basis : Basis P.rels P.Ring (P.rels → P.Ring) :=
+  Pi.basisFun P.Ring P.rels
+
+/--
+The differential of a `P : SubmersivePresentation` is a `P.Ring`-linear map on
+`P.rels → P.Ring`:
+
+The `j`-th standard basis vector, corresponding to the `j`-th relation of `P` is mapped
+to the vector of partial derivatives of `P.relation j` with respect
+to the coordinates `P.map i` for all `i : P.rels`.
+
+The determinant of this map is the jacobian of `P` used to define when a `SubmersivePresentation`
+is standard smooth. See `SubmersivePresentation.jacobian`.
+-/
+noncomputable def differential : (P.rels → P.Ring) →ₗ[P.Ring] (P.rels → P.Ring) :=
+  Basis.constr P.basis P.Ring
+    (fun j i : P.rels ↦ MvPolynomial.pderiv (P.map i) (P.relation j))
+
+/-- The jacobian of a `P : SubmersivePresentation` is the determinant
+of `P.linearMap` viewed as element of `S`. -/
+noncomputable def jacobian : S :=
+  algebraMap P.Ring S <| LinearMap.det P.differential
+
+variable [Fintype P.rels] [DecidableEq P.rels]
+
+/--
+If `P.rels` has a `Fintype` and `DecidableEq` instance, the differential of `P`
+can be expressed in matrix form.
+-/
+noncomputable def jacobiMatrix : Matrix P.rels P.rels P.Ring :=
+  LinearMap.toMatrix P.basis P.basis P.differential
+
+lemma jacobian_eq_jacobiMatrix_det : P.jacobian = algebraMap P.Ring S P.jacobiMatrix.det := by
+   simp [jacobiMatrix, jacobian]
+
+lemma jacobiMatrix_apply (i j : P.rels) :
+    P.jacobiMatrix i j = MvPolynomial.pderiv (P.map i) (P.relation j) := by
+  simp [jacobiMatrix, LinearMap.toMatrix, differential]
+
+/--
+A `SubmersivePresentation` is standard smooth if its jacobian is a unit in `S`
+and the presentation is finite.
+-/
+class IsStandardSmooth : Prop where
+  jacobian_isUnit : IsUnit P.jacobian
+  isFinite : P.IsFinite := by infer_instance
+
+attribute [instance] IsStandardSmooth.isFinite
+
+end SubmersivePresentation
+
+/--
+An `R`-algebra `S` is called standard smooth, if there
+exists a standard smooth submersive presentation.
+-/
+class IsStandardSmooth : Prop where
+  out : ∃ (P : SubmersivePresentation.{t, w} R S), P.IsStandardSmooth
+
+/--
+A standard smooth `R`-algebra `S` is of relative dimension `n`, if there
+exists a standard smooth submersive presentation of dimension `n`.
+
+Note: The relative dimension of a standard smooth `R`-algebra `S` is independent of
+the choice of the presentation as it is equal to the `S`-rank of `Ω[S/R]` (TODO).
+-/
+class IsOfRelativeDimension (n : ℕ) [IsStandardSmooth R S] : Prop where
+  out : ∃ (P : SubmersivePresentation.{t, w} R S), P.IsStandardSmooth ∧ P.dimension = n

--- a/Mathlib/RingTheory/Smooth/StandardSmooth.lean
+++ b/Mathlib/RingTheory/Smooth/StandardSmooth.lean
@@ -38,13 +38,18 @@ Let now `P` be a submersive presentation of `S` over `R`.
 - `SubmersivePresentation.IsStandardSmooth`: `P` is standard smooth, if it's jacobian
   is a unit in `S` and it is finite.
 
-Finally, we define:
+Furthermore, we define:
 
 - `IsStandardSmooth`: `S` is `R`-standard smooth if `S` has a standard smooth submersive
   `R`-presentation.
 - `IsOfRelativeDimension n`: A standard smooth `R`-algebra `S` is of relative dimension `n`
   if `S` has a standard smooth submersive `R`-presentation of dimension `n`. Equivalently,
   that every standard smooth has dimension `n` (TODO, see below).
+
+Finally, in the `RingHom` namespace we define
+
+- `IsStandardSmooth`: A ring hom `R →+* S` is standard smooth if `S` is standard smooth as
+  `R`-algebra.
 
 ## TODO
 
@@ -57,6 +62,21 @@ Finally, we define:
 - Show that the Kaehler differentials of a standard smooth `R`-algebra `S` of relative dimension `n`
   are `S`-free of rank `n`. In particular this shows that the relative dimension is independent
   of the choice of the standard smooth presentation.
+
+## Implementation details
+
+We don't bundle `IsStandardSmooth` and `IsOfRelativeDimension n` in one typeclass, because then
+`IsStandardSmooth` can't be inferred from `StandardSmoothOfRelativeDimension n` as Lean can't know
+which `n` to choose. Mathematically this is still correct, since the dimension
+does not depend on the choice of the standard smooth presentation.
+
+Standard smooth algebras and ring homs feature 4 universe levels: The universe levels of the rings
+involved and the universe levels of the types of the variables and relations.
+
+## Notes
+
+This contribution was created as part of the AIM workshop "Formalizing algebraic geometry"
+in June 2024.
 
 -/
 
@@ -118,6 +138,8 @@ of `P.linearMap` viewed as element of `S`. -/
 noncomputable def jacobian : S :=
   algebraMap P.Ring S <| LinearMap.det P.differential
 
+section Matrix
+
 variable [Fintype P.rels] [DecidableEq P.rels]
 
 /--
@@ -133,6 +155,8 @@ lemma jacobian_eq_jacobiMatrix_det : P.jacobian = algebraMap P.Ring S P.jacobiMa
 lemma jacobiMatrix_apply (i j : P.rels) :
     P.jacobiMatrix i j = MvPolynomial.pderiv (P.map i) (P.relation j) := by
   simp [jacobiMatrix, LinearMap.toMatrix, differential]
+
+end Matrix
 
 /--
 A `SubmersivePresentation` is standard smooth if its jacobian is a unit in `S`
@@ -162,3 +186,15 @@ the choice of the presentation as it is equal to the `S`-rank of `Ω[S/R]` (TODO
 -/
 class IsOfRelativeDimension (n : ℕ) [IsStandardSmooth R S] : Prop where
   out : ∃ (P : SubmersivePresentation.{t, w} R S), P.IsStandardSmooth ∧ P.dimension = n
+
+end Algebra
+
+namespace RingHom
+
+variable {R S}
+
+/-- A ring hom `R →+* S` is standard smooth if `S` is standard smooth as `S`-algebra. -/
+def IsStandardSmooth (f : R →+* S) : Prop :=
+  @Algebra.IsStandardSmooth.{t, w} _ _ _ _ f.toAlgebra
+
+end RingHom

--- a/Mathlib/RingTheory/Smooth/StandardSmooth.lean
+++ b/Mathlib/RingTheory/Smooth/StandardSmooth.lean
@@ -197,4 +197,9 @@ variable {R S}
 def IsStandardSmooth (f : R →+* S) : Prop :=
   @Algebra.IsStandardSmooth.{t, w} _ _ _ _ f.toAlgebra
 
+/-- A standard smooth ring hom `R →+* S` is standard smooth of relative dimension `n`
+if `S` has relative dimension `n` as `R`-algebra. -/
+def IsOfRelativeDimension (n : ℕ) (f : R →+* S) (hf : f.IsStandardSmooth) : Prop :=
+  @Algebra.IsOfRelativeDimension.{t, w} _ _ _ _ f.toAlgebra n hf
+
 end RingHom

--- a/Mathlib/RingTheory/Smooth/StandardSmooth.lean
+++ b/Mathlib/RingTheory/Smooth/StandardSmooth.lean
@@ -179,14 +179,14 @@ class IsStandardSmooth : Prop where
   out : ∃ (P : SubmersivePresentation.{t, w} R S), P.IsStandardSmooth
 
 /--
-A standard smooth `R`-algebra `S` is of relative dimension `n`, if there
-exists a standard smooth submersive presentation of dimension `n`.
+The relative dimension of a standard smooth `R`-algebra `S` is
+the dimension of an arbitrarily chosen standard smooth `R`-presentation of `S`.
 
-Note: The relative dimension of a standard smooth `R`-algebra `S` is independent of
-the choice of the presentation as it is equal to the `S`-rank of `Ω[S/R]` (TODO).
+Note: This number is independent of the choice of the presentation as it is equal to
+the `S`-rank of `Ω[S/R]` (TODO).
 -/
-class IsOfRelativeDimension (n : ℕ) [IsStandardSmooth R S] : Prop where
-  out : ∃ (P : SubmersivePresentation.{t, w} R S), P.IsStandardSmooth ∧ P.dimension = n
+noncomputable def IsStandardSmooth.relativeDimension [IsStandardSmooth R S] : ℕ :=
+  ‹IsStandardSmooth R S›.out.choose.dimension
 
 end Algebra
 
@@ -198,15 +198,11 @@ variable {R S}
 def IsStandardSmooth (f : R →+* S) : Prop :=
   @Algebra.IsStandardSmooth.{t, w} _ _ _ _ f.toAlgebra
 
-/-- A standard smooth ring hom `R →+* S` is standard smooth of relative dimension `n`
-if `S` has relative dimension `n` as `R`-algebra. -/
-def IsOfRelativeDimension (n : ℕ) (f : R →+* S) (hf : IsStandardSmooth.{t, w} f) : Prop :=
-  @Algebra.IsOfRelativeDimension.{t, w} _ _ _ _ f.toAlgebra n hf
-
 /-- A ring hom `R →+* S` is standard smooth of relative dimension `n` if
 it is both standard smooth and is of relative dimension `n`. -/
 structure IsStandardSmoothOfRelativeDimension (n : ℕ) (f : R →+* S) : Prop where
   isStandardSmooth : IsStandardSmooth.{t, w} f
-  isOfRelativeDimension : IsOfRelativeDimension.{t, w} n f isStandardSmooth
+  relativeDimension_eq :
+    @Algebra.IsStandardSmooth.relativeDimension R _ S _ f.toAlgebra isStandardSmooth = n
 
 end RingHom


### PR DESCRIPTION
We define the notion of a submersive presentation and predicates when such a presentation is standard smooth. An algebra is called standard smooth if it admits a standard smooth presentation.

This contribution was created as part of the AIM workshop "Formalizing algebraic geometry" in June 2024.

Co-authored-by: Andrew Yang @erdOne
Co-authored-by: Jung Tao Cheng @rontaucheng  

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

This only contains definitions. Follow-up PRs are in the pipeline to resolve the first three TODOs in the module docstring.

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
