### PR TITLE
[Merged by Bors] - feat: the associator isomorphism for graded objects

### DIFF
--- a/Mathlib/CategoryTheory/GradedObject/Monoidal.lean
+++ b/Mathlib/CategoryTheory/GradedObject/Monoidal.lean
@@ -1,9 +1,9 @@
 /-
 Copyright (c) 2024 Joël Riou. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Joël Riou, Scott Morrison
+Authors: Joël Riou, Kim Morrison
 -/
-import Mathlib.CategoryTheory.GradedObject.Bifunctor
+import Mathlib.CategoryTheory.GradedObject.Unitor
 
 /-!
 # The monoidal category structures on graded objects
@@ -117,6 +117,161 @@ lemma tensorHom_def {X₁ X₂ Y₁ Y₂ : GradedObject I C} (f : X₁ ⟶ X₂)
     [HasTensor X₁ Y₁] [HasTensor X₂ Y₂] [HasTensor X₂ Y₁] :
     tensorHom f g = whiskerRight f Y₁ ≫ whiskerLeft X₂ g := by
   rw [← tensor_comp, id_comp, comp_id]
+
+/-- This is the addition map `I × I × I → I` for an additive monoid `I`. -/
+def r₁₂₃ : I × I × I → I := fun ⟨i, j, k⟩ => i + j + k
+
+/-- Auxiliary definition for `associator`. -/
+@[reducible] def ρ₁₂ : BifunctorComp₁₂IndexData (r₁₂₃ : _ → I) where
+  I₁₂ := I
+  p := fun ⟨i₁, i₂⟩ => i₁ + i₂
+  q := fun ⟨i₁₂, i₃⟩ => i₁₂ + i₃
+  hpq := fun _ => rfl
+
+/-- Auxiliary definition for `associator`. -/
+@[reducible] def ρ₂₃ : BifunctorComp₂₃IndexData (r₁₂₃ : _ → I) where
+  I₂₃ := I
+  p := fun ⟨i₂, i₃⟩ => i₂ + i₃
+  q := fun ⟨i₁₂, i₃⟩ => i₁₂ + i₃
+  hpq _ := (add_assoc _ _ _).symm
+
+variable (I) in
+/-- Auxiliary definition for `associator`. -/
+@[reducible]
+def triangleIndexData : TriangleIndexData (r₁₂₃ : _ → I) (fun ⟨i₁, i₃⟩ => i₁ + i₃) where
+  p₁₂ := fun ⟨i₁, i₂⟩ => i₁ + i₂
+  p₂₃ := fun ⟨i₂, i₃⟩ => i₂ + i₃
+  hp₁₂ := fun _ => rfl
+  hp₂₃ := fun _ => (add_assoc _ _ _).symm
+  h₁ := add_zero
+  h₃ := zero_add
+
+/-- Given three graded objects `X₁`, `X₂`, `X₃` in `GradedObject I C`, this is the
+assumption that for all `i₁₂ : I` and `i₃ : I`, the tensor product functor `- ⊗ X₃ i₃`
+commutes with the coproduct of the objects `X₁ i₁ ⊗ X₂ i₂` such that `i₁ + i₂ = i₁₂`. -/
+abbrev _root_.CategoryTheory.GradedObject.HasGoodTensor₁₂Tensor (X₁ X₂ X₃ : GradedObject I C) :=
+  HasGoodTrifunctor₁₂Obj (curriedTensor C) (curriedTensor C) ρ₁₂ X₁ X₂ X₃
+
+/-- Given three graded objects `X₁`, `X₂`, `X₃` in `GradedObject I C`, this is the
+assumption that for all `i₁ : I` and `i₂₃ : I`, the tensor product functor `X₁ i₁ ⊗ -`
+commutes with the coproduct of the objects `X₂ i₂ ⊗ X₃ i₃` such that `i₂ + i₃ = i₂₃`. -/
+abbrev _root_.CategoryTheory.GradedObject.HasGoodTensorTensor₂₃ (X₁ X₂ X₃ : GradedObject I C) :=
+  HasGoodTrifunctor₂₃Obj (curriedTensor C) (curriedTensor C) ρ₂₃ X₁ X₂ X₃
+
+section
+
+variable (Z : C) (X₁ X₂ X₃ : GradedObject I C) [HasTensor X₁ X₂] [HasTensor X₂ X₃]
+  [HasTensor (tensorObj X₁ X₂) X₃] [HasTensor X₁ (tensorObj X₂ X₃)]
+  {Y₁ Y₂ Y₃ : GradedObject I C} [HasTensor Y₁ Y₂] [HasTensor Y₂ Y₃]
+  [HasTensor (tensorObj Y₁ Y₂) Y₃] [HasTensor Y₁ (tensorObj Y₂ Y₃)]
+
+/-- The associator isomorphism for graded objects. -/
+noncomputable def associator [HasGoodTensor₁₂Tensor X₁ X₂ X₃] [HasGoodTensorTensor₂₃ X₁ X₂ X₃] :
+  tensorObj (tensorObj X₁ X₂) X₃ ≅ tensorObj X₁ (tensorObj X₂ X₃) :=
+    mapBifunctorAssociator (MonoidalCategory.curriedAssociatorNatIso C) ρ₁₂ ρ₂₃ X₁ X₂ X₃
+
+/-- The inclusion `X₁ i₁ ⊗ X₂ i₂ ⊗ X₃ i₃ ⟶ tensorObj X₁ (tensorObj X₂ X₃) j`
+when `i₁ + i₂ + i₃ = j`. -/
+noncomputable def ιTensorObj₃ (i₁ i₂ i₃ j : I) (h : i₁ + i₂ + i₃ = j) :
+    X₁ i₁ ⊗ X₂ i₂ ⊗ X₃ i₃ ⟶ tensorObj X₁ (tensorObj X₂ X₃) j :=
+  X₁ i₁ ◁ ιTensorObj X₂ X₃ i₂ i₃ _ rfl ≫ ιTensorObj X₁ (tensorObj X₂ X₃) i₁ (i₂ + i₃) j
+    (by rw [← add_assoc, h])
+
+@[reassoc]
+lemma ιTensorObj₃_eq (i₁ i₂ i₃ j : I) (h : i₁ + i₂ + i₃ = j) (i₂₃ : I) (h' : i₂ + i₃ = i₂₃) :
+    ιTensorObj₃ X₁ X₂ X₃ i₁ i₂ i₃ j h =
+      (X₁ i₁ ◁ ιTensorObj X₂ X₃ i₂ i₃ i₂₃ h') ≫
+        ιTensorObj X₁ (tensorObj X₂ X₃) i₁ i₂₃ j (by rw [← h', ← add_assoc, h]) := by
+  subst h'
+  rfl
+
+/-- The inclusion `X₁ i₁ ⊗ X₂ i₂ ⊗ X₃ i₃ ⟶ tensorObj (tensorObj X₁ X₂) X₃ j`
+when `i₁ + i₂ + i₃ = j`. -/
+noncomputable def ιTensorObj₃' (i₁ i₂ i₃ j : I) (h : i₁ + i₂ + i₃ = j) :
+    (X₁ i₁ ⊗ X₂ i₂) ⊗ X₃ i₃ ⟶ tensorObj (tensorObj X₁ X₂) X₃ j :=
+  (ιTensorObj X₁ X₂ i₁ i₂ (i₁ + i₂) rfl ▷ X₃ i₃) ≫
+    ιTensorObj (tensorObj X₁ X₂) X₃ (i₁ + i₂) i₃ j h
+
+@[reassoc]
+lemma ιTensorObj₃'_eq (i₁ i₂ i₃ j : I) (h : i₁ + i₂ + i₃ = j) (i₁₂ : I)
+    (h' : i₁ + i₂ = i₁₂) :
+    ιTensorObj₃' X₁ X₂ X₃ i₁ i₂ i₃ j h =
+      (ιTensorObj X₁ X₂ i₁ i₂ i₁₂ h' ▷ X₃ i₃) ≫
+        ιTensorObj (tensorObj X₁ X₂) X₃ i₁₂ i₃ j (by rw [← h', h]) := by
+  subst h'
+  rfl
+
+variable {X₁ X₂ X₃}
+
+@[reassoc (attr := simp)]
+lemma ιTensorObj₃_tensorHom (f₁ : X₁ ⟶ Y₁) (f₂ : X₂ ⟶ Y₂) (f₃ : X₃ ⟶ Y₃)
+    (i₁ i₂ i₃ j : I) (h : i₁ + i₂ + i₃ = j) :
+    ιTensorObj₃ X₁ X₂ X₃ i₁ i₂ i₃ j h ≫ tensorHom f₁ (tensorHom f₂ f₃) j =
+      (f₁ i₁ ⊗ f₂ i₂ ⊗ f₃ i₃) ≫ ιTensorObj₃ Y₁ Y₂ Y₃ i₁ i₂ i₃ j h := by
+  rw [ιTensorObj₃_eq _ _ _ i₁ i₂ i₃ j h _  rfl,
+    ιTensorObj₃_eq _ _ _ i₁ i₂ i₃ j h _  rfl, assoc, ι_tensorHom,
+    ← id_tensorHom, ← id_tensorHom, ← MonoidalCategory.tensor_comp_assoc, ι_tensorHom,
+    ← MonoidalCategory.tensor_comp_assoc, id_comp, comp_id]
+
+@[reassoc (attr := simp)]
+lemma ιTensorObj₃'_tensorHom (f₁ : X₁ ⟶ Y₁) (f₂ : X₂ ⟶ Y₂) (f₃ : X₃ ⟶ Y₃)
+    (i₁ i₂ i₃ j : I) (h : i₁ + i₂ + i₃ = j) :
+    ιTensorObj₃' X₁ X₂ X₃ i₁ i₂ i₃ j h ≫ tensorHom (tensorHom f₁ f₂) f₃ j =
+      ((f₁ i₁ ⊗ f₂ i₂) ⊗ f₃ i₃) ≫ ιTensorObj₃' Y₁ Y₂ Y₃ i₁ i₂ i₃ j h := by
+  rw [ιTensorObj₃'_eq _ _ _ i₁ i₂ i₃ j h _  rfl,
+    ιTensorObj₃'_eq _ _ _ i₁ i₂ i₃ j h _  rfl, assoc, ι_tensorHom,
+    ← tensorHom_id, ← tensorHom_id, ← MonoidalCategory.tensor_comp_assoc, id_comp,
+    ι_tensorHom, ← MonoidalCategory.tensor_comp_assoc, comp_id]
+
+@[ext]
+lemma tensorObj₃_ext {j : I} {A : C} (f g : tensorObj X₁ (tensorObj X₂ X₃) j ⟶ A)
+    [H : HasGoodTensorTensor₂₃ X₁ X₂ X₃]
+    (h : ∀ (i₁ i₂ i₃ : I) (hi : i₁ + i₂ + i₃ = j),
+      ιTensorObj₃ X₁ X₂ X₃ i₁ i₂ i₃ j hi ≫ f = ιTensorObj₃ X₁ X₂ X₃ i₁ i₂ i₃ j hi ≫ g) :
+      f = g := by
+  apply mapBifunctorBifunctor₂₃MapObj_ext (H := H)
+  intro i₁ i₂ i₃ hi
+  exact h i₁ i₂ i₃ hi
+
+@[ext]
+lemma tensorObj₃'_ext {j : I} {A : C} (f g : tensorObj (tensorObj X₁ X₂) X₃ j ⟶ A)
+    [H : HasGoodTensor₁₂Tensor X₁ X₂ X₃]
+    (h : ∀ (i₁ i₂ i₃ : I) (h : i₁ + i₂ + i₃ = j),
+      ιTensorObj₃' X₁ X₂ X₃ i₁ i₂ i₃ j h ≫ f = ιTensorObj₃' X₁ X₂ X₃ i₁ i₂ i₃ j h ≫ g) :
+      f = g := by
+  apply mapBifunctor₁₂BifunctorMapObj_ext (H := H)
+  intro i₁ i₂ i₃ hi
+  exact h i₁ i₂ i₃ hi
+
+variable (X₁ X₂ X₃)
+
+@[reassoc (attr := simp)]
+lemma ιTensorObj₃'_associator_hom
+    [HasGoodTensor₁₂Tensor X₁ X₂ X₃] [HasGoodTensorTensor₂₃ X₁ X₂ X₃]
+    (i₁ i₂ i₃ j : I) (h : i₁ + i₂ + i₃ = j) :
+    ιTensorObj₃' X₁ X₂ X₃ i₁ i₂ i₃ j h ≫ (associator X₁ X₂ X₃).hom j =
+      (α_ _ _ _).hom ≫ ιTensorObj₃ X₁ X₂ X₃ i₁ i₂ i₃ j h :=
+  ι_mapBifunctorAssociator_hom (MonoidalCategory.curriedAssociatorNatIso C)
+    ρ₁₂ ρ₂₃ X₁ X₂ X₃ i₁ i₂ i₃ j h
+
+@[reassoc (attr := simp)]
+lemma ιTensorObj₃_associator_inv
+    [HasGoodTensor₁₂Tensor X₁ X₂ X₃] [HasGoodTensorTensor₂₃ X₁ X₂ X₃]
+    (i₁ i₂ i₃ j : I) (h : i₁ + i₂ + i₃ = j) :
+    ιTensorObj₃ X₁ X₂ X₃ i₁ i₂ i₃ j h ≫ (associator X₁ X₂ X₃).inv j =
+      (α_ _ _ _).inv ≫ ιTensorObj₃' X₁ X₂ X₃ i₁ i₂ i₃ j h :=
+  ι_mapBifunctorAssociator_inv (MonoidalCategory.curriedAssociatorNatIso C)
+    ρ₁₂ ρ₂₃ X₁ X₂ X₃ i₁ i₂ i₃ j h
+
+variable {X₁ X₂ X₃}
+
+lemma associator_naturality (f₁ : X₁ ⟶ Y₁) (f₂ : X₂ ⟶ Y₂) (f₃ : X₃ ⟶ Y₃)
+    [HasGoodTensor₁₂Tensor X₁ X₂ X₃] [HasGoodTensorTensor₂₃ X₁ X₂ X₃]
+    [HasGoodTensor₁₂Tensor Y₁ Y₂ Y₃] [HasGoodTensorTensor₂₃ Y₁ Y₂ Y₃] :
+    tensorHom (tensorHom f₁ f₂) f₃ ≫ (associator Y₁ Y₂ Y₃).hom =
+      (associator X₁ X₂ X₃).hom ≫ tensorHom f₁ (tensorHom f₂ f₃) := by aesop_cat
+
+end
 
 end Monoidal
 


### PR DESCRIPTION
In this PR, we construct the associator isomorphism `tensorObj (tensorObj X₁ X₂) X₃ ≅ tensorObj X₁ (tensorObj X₂ X₃)` for graded objects indexed by an additive monoid.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
