### PR TITLE
[Merged by Bors] - chore (Algebra.Order.Monoid.Unbundled): don't used bundled structured in unbundled

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -569,6 +569,7 @@ import Mathlib.Algebra.Order.Monoid.TypeTags
 import Mathlib.Algebra.Order.Monoid.Unbundled.Basic
 import Mathlib.Algebra.Order.Monoid.Unbundled.Defs
 import Mathlib.Algebra.Order.Monoid.Unbundled.MinMax
+import Mathlib.Algebra.Order.Monoid.Unbundled.OrderDual
 import Mathlib.Algebra.Order.Monoid.Unbundled.Pow
 import Mathlib.Algebra.Order.Monoid.Units
 import Mathlib.Algebra.Order.Monoid.WithTop

--- a/Mathlib/Algebra/Bounds.lean
+++ b/Mathlib/Algebra/Bounds.lean
@@ -4,10 +4,10 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Yury G. Kudryashov
 -/
 import Mathlib.Algebra.Order.Group.OrderIso
-import Mathlib.Algebra.Order.Monoid.OrderDual
 import Mathlib.Data.Set.Pointwise.Basic
 import Mathlib.Order.Bounds.OrderIso
 import Mathlib.Order.ConditionallyCompleteLattice.Basic
+import Mathlib.Algebra.Order.Monoid.Unbundled.OrderDual
 
 #align_import algebra.bounds from "leanprover-community/mathlib"@"dd71334db81d0bd444af1ee339a29298bef40734"
 

--- a/Mathlib/Algebra/Order/BigOperators/Group/List.lean
+++ b/Mathlib/Algebra/Order/BigOperators/Group/List.lean
@@ -5,7 +5,7 @@ Authors: Yakov Pechersky
 -/
 import Mathlib.Algebra.BigOperators.Group.List
 import Mathlib.Algebra.Order.Monoid.Canonical.Defs
-import Mathlib.Algebra.Order.Monoid.OrderDual
+import Mathlib.Algebra.Order.Monoid.Unbundled.OrderDual
 
 /-!
 # Big operators on a list in ordered groups

--- a/Mathlib/Algebra/Order/BigOperators/Group/Multiset.lean
+++ b/Mathlib/Algebra/Order/BigOperators/Group/Multiset.lean
@@ -8,6 +8,7 @@ import Mathlib.Algebra.Order.BigOperators.Group.List
 import Mathlib.Algebra.Order.Group.Abs
 import Mathlib.Data.List.MinMax
 import Mathlib.Data.Multiset.Fold
+import Mathlib.Algebra.Order.Monoid.OrderDual
 
 /-!
 # Big operators on a multiset in ordered groups

--- a/Mathlib/Algebra/Order/Group/DenselyOrdered.lean
+++ b/Mathlib/Algebra/Order/Group/DenselyOrdered.lean
@@ -5,7 +5,7 @@ Authors: Jeremy Avigad, Leonardo de Moura, Mario Carneiro, Johannes Hölzl
 -/
 import Mathlib.Algebra.Order.Monoid.Canonical.Defs
 import Mathlib.Algebra.Order.Group.Defs
-import Mathlib.Algebra.Order.Monoid.OrderDual
+import Mathlib.Algebra.Order.Monoid.Unbundled.OrderDual
 
 #align_import algebra.order.group.densely_ordered from "leanprover-community/mathlib"@"4e87c8477c6c38b753f050bc9664b94ee859896c"
 

--- a/Mathlib/Algebra/Order/Monoid/OrderDual.lean
+++ b/Mathlib/Algebra/Order/Monoid/OrderDual.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Jeremy Avigad, Leonardo de Moura, Mario Carneiro, Johannes Hölzl
 -/
 import Mathlib.Algebra.Order.Group.Synonym
+import Mathlib.Algebra.Order.Monoid.Unbundled.OrderDual
 import Mathlib.Algebra.Order.Monoid.Defs
 
 #align_import algebra.order.monoid.order_dual from "leanprover-community/mathlib"@"2258b40dacd2942571c8ce136215350c702dc78f"
@@ -18,66 +19,6 @@ variable {α : Type u}
 open Function
 
 namespace OrderDual
-
-@[to_additive]
-instance contravariantClass_mul_le [LE α] [Mul α] [c : ContravariantClass α α (· * ·) (· ≤ ·)] :
-    ContravariantClass αᵒᵈ αᵒᵈ (· * ·) (· ≤ ·) :=
-  ⟨c.1.flip⟩
-#align order_dual.contravariant_class_add_le OrderDual.contravariantClass_add_le
-#align order_dual.contravariant_class_mul_le OrderDual.contravariantClass_mul_le
-
-@[to_additive]
-instance covariantClass_mul_le [LE α] [Mul α] [c : CovariantClass α α (· * ·) (· ≤ ·)] :
-    CovariantClass αᵒᵈ αᵒᵈ (· * ·) (· ≤ ·) :=
-  ⟨c.1.flip⟩
-#align order_dual.covariant_class_add_le OrderDual.covariantClass_add_le
-#align order_dual.covariant_class_mul_le OrderDual.covariantClass_mul_le
-
-@[to_additive]
-instance contravariantClass_swap_mul_le [LE α] [Mul α]
-    [c : ContravariantClass α α (swap (· * ·)) (· ≤ ·)] :
-    ContravariantClass αᵒᵈ αᵒᵈ (swap (· * ·)) (· ≤ ·) :=
-  ⟨c.1.flip⟩
-#align order_dual.contravariant_class_swap_add_le OrderDual.contravariantClass_swap_add_le
-#align order_dual.contravariant_class_swap_mul_le OrderDual.contravariantClass_swap_mul_le
-
-@[to_additive]
-instance covariantClass_swap_mul_le [LE α] [Mul α]
-    [c : CovariantClass α α (swap (· * ·)) (· ≤ ·)] :
-    CovariantClass αᵒᵈ αᵒᵈ (swap (· * ·)) (· ≤ ·) :=
-  ⟨c.1.flip⟩
-#align order_dual.covariant_class_swap_add_le OrderDual.covariantClass_swap_add_le
-#align order_dual.covariant_class_swap_mul_le OrderDual.covariantClass_swap_mul_le
-
-@[to_additive]
-instance contravariantClass_mul_lt [LT α] [Mul α] [c : ContravariantClass α α (· * ·) (· < ·)] :
-    ContravariantClass αᵒᵈ αᵒᵈ (· * ·) (· < ·) :=
-  ⟨c.1.flip⟩
-#align order_dual.contravariant_class_add_lt OrderDual.contravariantClass_add_lt
-#align order_dual.contravariant_class_mul_lt OrderDual.contravariantClass_mul_lt
-
-@[to_additive]
-instance covariantClass_mul_lt [LT α] [Mul α] [c : CovariantClass α α (· * ·) (· < ·)] :
-    CovariantClass αᵒᵈ αᵒᵈ (· * ·) (· < ·) :=
-  ⟨c.1.flip⟩
-#align order_dual.covariant_class_add_lt OrderDual.covariantClass_add_lt
-#align order_dual.covariant_class_mul_lt OrderDual.covariantClass_mul_lt
-
-@[to_additive]
-instance contravariantClass_swap_mul_lt [LT α] [Mul α]
-    [c : ContravariantClass α α (swap (· * ·)) (· < ·)] :
-    ContravariantClass αᵒᵈ αᵒᵈ (swap (· * ·)) (· < ·) :=
-  ⟨c.1.flip⟩
-#align order_dual.contravariant_class_swap_add_lt OrderDual.contravariantClass_swap_add_lt
-#align order_dual.contravariant_class_swap_mul_lt OrderDual.contravariantClass_swap_mul_lt
-
-@[to_additive]
-instance covariantClass_swap_mul_lt [LT α] [Mul α]
-    [c : CovariantClass α α (swap (· * ·)) (· < ·)] :
-    CovariantClass αᵒᵈ αᵒᵈ (swap (· * ·)) (· < ·) :=
-  ⟨c.1.flip⟩
-#align order_dual.covariant_class_swap_add_lt OrderDual.covariantClass_swap_add_lt
-#align order_dual.covariant_class_swap_mul_lt OrderDual.covariantClass_swap_mul_lt
 
 @[to_additive]
 instance orderedCommMonoid [OrderedCommMonoid α] : OrderedCommMonoid αᵒᵈ :=

--- a/Mathlib/Algebra/Order/Monoid/Unbundled/OrderDual.lean
+++ b/Mathlib/Algebra/Order/Monoid/Unbundled/OrderDual.lean
@@ -1,0 +1,82 @@
+/-
+Copyright (c) 2016 Jeremy Avigad. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Jeremy Avigad, Leonardo de Moura, Mario Carneiro, Johannes Hölzl
+-/
+import Mathlib.Algebra.Order.Group.Synonym
+import Mathlib.Algebra.Order.Monoid.Unbundled.Defs
+
+#align_import algebra.order.monoid.order_dual from "leanprover-community/mathlib"@"2258b40dacd2942571c8ce136215350c702dc78f"
+
+/-! # Unbundled ordered monoid structures on the order dual. -/
+
+
+universe u
+
+variable {α : Type u}
+
+open Function
+
+namespace OrderDual
+
+@[to_additive]
+instance contravariantClass_mul_le [LE α] [Mul α] [c : ContravariantClass α α (· * ·) (· ≤ ·)] :
+    ContravariantClass αᵒᵈ αᵒᵈ (· * ·) (· ≤ ·) :=
+  ⟨c.1.flip⟩
+#align order_dual.contravariant_class_add_le OrderDual.contravariantClass_add_le
+#align order_dual.contravariant_class_mul_le OrderDual.contravariantClass_mul_le
+
+@[to_additive]
+instance covariantClass_mul_le [LE α] [Mul α] [c : CovariantClass α α (· * ·) (· ≤ ·)] :
+    CovariantClass αᵒᵈ αᵒᵈ (· * ·) (· ≤ ·) :=
+  ⟨c.1.flip⟩
+#align order_dual.covariant_class_add_le OrderDual.covariantClass_add_le
+#align order_dual.covariant_class_mul_le OrderDual.covariantClass_mul_le
+
+@[to_additive]
+instance contravariantClass_swap_mul_le [LE α] [Mul α]
+    [c : ContravariantClass α α (swap (· * ·)) (· ≤ ·)] :
+    ContravariantClass αᵒᵈ αᵒᵈ (swap (· * ·)) (· ≤ ·) :=
+  ⟨c.1.flip⟩
+#align order_dual.contravariant_class_swap_add_le OrderDual.contravariantClass_swap_add_le
+#align order_dual.contravariant_class_swap_mul_le OrderDual.contravariantClass_swap_mul_le
+
+@[to_additive]
+instance covariantClass_swap_mul_le [LE α] [Mul α]
+    [c : CovariantClass α α (swap (· * ·)) (· ≤ ·)] :
+    CovariantClass αᵒᵈ αᵒᵈ (swap (· * ·)) (· ≤ ·) :=
+  ⟨c.1.flip⟩
+#align order_dual.covariant_class_swap_add_le OrderDual.covariantClass_swap_add_le
+#align order_dual.covariant_class_swap_mul_le OrderDual.covariantClass_swap_mul_le
+
+@[to_additive]
+instance contravariantClass_mul_lt [LT α] [Mul α] [c : ContravariantClass α α (· * ·) (· < ·)] :
+    ContravariantClass αᵒᵈ αᵒᵈ (· * ·) (· < ·) :=
+  ⟨c.1.flip⟩
+#align order_dual.contravariant_class_add_lt OrderDual.contravariantClass_add_lt
+#align order_dual.contravariant_class_mul_lt OrderDual.contravariantClass_mul_lt
+
+@[to_additive]
+instance covariantClass_mul_lt [LT α] [Mul α] [c : CovariantClass α α (· * ·) (· < ·)] :
+    CovariantClass αᵒᵈ αᵒᵈ (· * ·) (· < ·) :=
+  ⟨c.1.flip⟩
+#align order_dual.covariant_class_add_lt OrderDual.covariantClass_add_lt
+#align order_dual.covariant_class_mul_lt OrderDual.covariantClass_mul_lt
+
+@[to_additive]
+instance contravariantClass_swap_mul_lt [LT α] [Mul α]
+    [c : ContravariantClass α α (swap (· * ·)) (· < ·)] :
+    ContravariantClass αᵒᵈ αᵒᵈ (swap (· * ·)) (· < ·) :=
+  ⟨c.1.flip⟩
+#align order_dual.contravariant_class_swap_add_lt OrderDual.contravariantClass_swap_add_lt
+#align order_dual.contravariant_class_swap_mul_lt OrderDual.contravariantClass_swap_mul_lt
+
+@[to_additive]
+instance covariantClass_swap_mul_lt [LT α] [Mul α]
+    [c : CovariantClass α α (swap (· * ·)) (· < ·)] :
+    CovariantClass αᵒᵈ αᵒᵈ (swap (· * ·)) (· < ·) :=
+  ⟨c.1.flip⟩
+#align order_dual.covariant_class_swap_add_lt OrderDual.covariantClass_swap_add_lt
+#align order_dual.covariant_class_swap_mul_lt OrderDual.covariantClass_swap_mul_lt
+
+

--- a/Mathlib/Algebra/Order/Monoid/Unbundled/Pow.lean
+++ b/Mathlib/Algebra/Order/Monoid/Unbundled/Pow.lean
@@ -3,7 +3,8 @@ Copyright (c) 2015 Jeremy Avigad. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Jeremy Avigad, Robert Y. Lewis, Yury G. Kudryashov
 -/
-import Mathlib.Algebra.Order.Monoid.OrderDual
+import Mathlib.Algebra.Order.Monoid.Unbundled.Basic
+import Mathlib.Algebra.Order.Monoid.Unbundled.OrderDual
 import Mathlib.Tactic.Lift
 import Mathlib.Tactic.Monotonicity.Attr
 

--- a/Mathlib/Algebra/Order/Monoid/WithTop.lean
+++ b/Mathlib/Algebra/Order/Monoid/WithTop.lean
@@ -6,10 +6,10 @@ Authors: Jeremy Avigad, Leonardo de Moura, Mario Carneiro, Johannes Hölzl
 import Mathlib.Algebra.CharZero.Defs
 import Mathlib.Algebra.Group.Hom.Defs
 import Mathlib.Algebra.Order.Monoid.Canonical.Defs
-import Mathlib.Algebra.Order.Monoid.OrderDual
 import Mathlib.Algebra.Order.ZeroLEOne
 import Mathlib.Data.Nat.Cast.Defs
 import Mathlib.Order.WithBot
+import Mathlib.Algebra.Order.Monoid.Unbundled.OrderDual
 
 #align_import algebra.order.monoid.with_top from "leanprover-community/mathlib"@"0111834459f5d7400215223ea95ae38a1265a907"
 

--- a/Mathlib/Order/ConditionallyCompleteLattice/Group.lean
+++ b/Mathlib/Order/ConditionallyCompleteLattice/Group.lean
@@ -5,7 +5,7 @@ Authors: Sébastien Gouëzel
 -/
 import Mathlib.Order.ConditionallyCompleteLattice.Basic
 import Mathlib.Algebra.Order.Group.Defs
-import Mathlib.Algebra.Order.Monoid.OrderDual
+import Mathlib.Algebra.Order.Monoid.Unbundled.OrderDual
 
 #align_import order.conditionally_complete_lattice.group from "leanprover-community/mathlib"@"46a64b5b4268c594af770c44d9e502afc6a515cb"
 


### PR DESCRIPTION
Using bundled ordered algebra in `Algebra.Order.Monoid.Unbundled.Pow` seems to defeat the purpose.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
