### PR TITLE
[Merged by Bors] - chore(Data/Nat): refactor import of `Nat/Prime` by `Nat/Factors`

### DIFF
--- a/Mathlib/Data/Nat/Factors.lean
+++ b/Mathlib/Data/Nat/Factors.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Leonardo de Moura, Jeremy Avigad, Mario Carneiro
 -/
 import Mathlib.Algebra.BigOperators.Ring.List
-import Mathlib.Data.Nat.Prime.Basic
+import Mathlib.Data.Nat.Prime.Defs
 import Mathlib.Data.List.Prime
 import Mathlib.Data.List.Sort
 import Mathlib.Data.List.Chain

--- a/Mathlib/Data/Nat/Prime/Basic.lean
+++ b/Mathlib/Data/Nat/Prime/Basic.lean
@@ -107,15 +107,6 @@ theorem not_bddAbove_setOf_prime : ¬BddAbove { p | Prime p } := by
   exact ⟨p, hp, hi⟩
 #align nat.not_bdd_above_set_of_prime Nat.not_bddAbove_setOf_prime
 
-theorem Prime.eq_two_or_odd {p : ℕ} (hp : Prime p) : p = 2 ∨ p % 2 = 1 :=
-  p.mod_two_eq_zero_or_one.imp_left fun h =>
-    ((hp.eq_one_or_self_of_dvd 2 (dvd_of_mod_eq_zero h)).resolve_left (by decide)).symm
-#align nat.prime.eq_two_or_odd Nat.Prime.eq_two_or_odd
-
-theorem Prime.eq_two_or_odd' {p : ℕ} (hp : Prime p) : p = 2 ∨ Odd p :=
-  Or.imp_right (fun h => ⟨p / 2, (div_add_mod p 2).symm.trans (congr_arg _ h)⟩) hp.eq_two_or_odd
-#align nat.prime.eq_two_or_odd' Nat.Prime.eq_two_or_odd'
-
 theorem Prime.even_iff {p : ℕ} (hp : Prime p) : Even p ↔ p = 2 := by
   rw [even_iff_two_dvd, prime_dvd_prime_iff_eq prime_two hp, eq_comm]
 #align nat.prime.even_iff Nat.Prime.even_iff
@@ -138,14 +129,6 @@ theorem Prime.mod_two_eq_one_iff_ne_two {p : ℕ} [Fact p.Prime] : p % 2 = 1 ↔
 theorem coprime_of_dvd' {m n : ℕ} (H : ∀ k, Prime k → k ∣ m → k ∣ n → k ∣ 1) : Coprime m n :=
   coprime_of_dvd fun k kp km kn => not_le_of_gt kp.one_lt <| le_of_dvd zero_lt_one <| H k kp km kn
 #align nat.coprime_of_dvd' Nat.coprime_of_dvd'
-
-theorem factors_lemma {k} : (k + 2) / minFac (k + 2) < k + 2 :=
-  div_lt_self (Nat.zero_lt_succ _) (minFac_prime (by
-      apply Nat.ne_of_gt
-      apply Nat.succ_lt_succ
-      apply Nat.zero_lt_succ
-      )).one_lt
-#align nat.factors_lemma Nat.factors_lemma
 
 theorem Prime.dvd_iff_not_coprime {p n : ℕ} (pp : Prime p) : p ∣ n ↔ ¬Coprime p n :=
   iff_not_comm.2 pp.coprime_iff_not_dvd
@@ -175,10 +158,6 @@ alias ⟨Coprime.odd_of_left, _root_.Odd.coprime_two_left⟩ := coprime_two_left
 alias ⟨Coprime.odd_of_right, _root_.Odd.coprime_two_right⟩ := coprime_two_right
 
 -- Porting note: attributes `protected`, `nolint dup_namespace` removed
-
-theorem irreducible_iff_prime {p : ℕ} : Irreducible p ↔ _root_.Prime p :=
-  prime_iff
-#align nat.irreducible_iff_prime Nat.irreducible_iff_prime
 
 theorem Prime.dvd_of_dvd_pow {p m n : ℕ} (pp : Prime p) (h : p ∣ m ^ n) : p ∣ m :=
   pp.prime.dvd_of_dvd_pow h

--- a/Mathlib/Data/Nat/Prime/Defs.lean
+++ b/Mathlib/Data/Nat/Prime/Defs.lean
@@ -207,6 +207,15 @@ theorem Prime.dvd_iff_eq {p a : ℕ} (hp : p.Prime) (a1 : a ≠ 1) : a ∣ p ↔
   · exact (a1 rfl).elim
 #align nat.prime.dvd_iff_eq Nat.Prime.dvd_iff_eq
 
+theorem Prime.eq_two_or_odd {p : ℕ} (hp : Prime p) : p = 2 ∨ p % 2 = 1 :=
+  p.mod_two_eq_zero_or_one.imp_left fun h =>
+    ((hp.eq_one_or_self_of_dvd 2 (dvd_of_mod_eq_zero h)).resolve_left (by decide)).symm
+#align nat.prime.eq_two_or_odd Nat.Prime.eq_two_or_odd
+
+theorem Prime.eq_two_or_odd' {p : ℕ} (hp : Prime p) : p = 2 ∨ Odd p :=
+  Or.imp_right (fun h => ⟨p / 2, (div_add_mod p 2).symm.trans (congr_arg _ h)⟩) hp.eq_two_or_odd
+#align nat.prime.eq_two_or_odd' Nat.Prime.eq_two_or_odd'
+
 section MinFac
 
 theorem minFac_lemma (n k : ℕ) (h : ¬n < k * k) : sqrt n - k < sqrt n + 2 - k :=
@@ -425,6 +434,14 @@ theorem minFac_eq_two_iff (n : ℕ) : minFac n = 2 ↔ 2 ∣ n := by
     exact not_lt_of_le (le_of_dvd zero_lt_one h) one_lt_two
 #align nat.min_fac_eq_two_iff Nat.minFac_eq_two_iff
 
+theorem factors_lemma {k} : (k + 2) / minFac (k + 2) < k + 2 :=
+  div_lt_self (Nat.zero_lt_succ _) (minFac_prime (by
+      apply Nat.ne_of_gt
+      apply Nat.succ_lt_succ
+      apply Nat.zero_lt_succ
+      )).one_lt
+#align nat.factors_lemma Nat.factors_lemma
+
 end MinFac
 
 theorem exists_prime_and_dvd {n : ℕ} (hn : n ≠ 1) : ∃ p, Prime p ∧ p ∣ n :=
@@ -457,6 +474,10 @@ theorem prime_iff {p : ℕ} : p.Prime ↔ _root_.Prime p :=
 alias ⟨Prime.prime, _root_.Prime.nat_prime⟩ := prime_iff
 #align nat.prime.prime Nat.Prime.prime
 #align prime.nat_prime Prime.nat_prime
+
+theorem irreducible_iff_prime {p : ℕ} : Irreducible p ↔ _root_.Prime p :=
+  prime_iff
+#align nat.irreducible_iff_prime Nat.irreducible_iff_prime
 
 /-- The type of prime numbers -/
 def Primes :=

--- a/Mathlib/Data/Nat/PrimeFin.lean
+++ b/Mathlib/Data/Nat/PrimeFin.lean
@@ -6,6 +6,7 @@ Authors: Leonardo de Moura, Jeremy Avigad, Mario Carneiro
 import Mathlib.Data.Countable.Defs
 import Mathlib.Data.Nat.Factors
 import Mathlib.Data.Set.Finite
+import Mathlib.Data.Nat.Prime.Basic
 
 #align_import data.nat.prime_fin from "leanprover-community/mathlib"@"d6fad0e5bf2d6f48da9175d25c3dc5706b3834ce"
 

--- a/Mathlib/NumberTheory/Divisors.lean
+++ b/Mathlib/NumberTheory/Divisors.lean
@@ -5,6 +5,7 @@ Authors: Aaron Anderson
 -/
 import Mathlib.Algebra.Order.BigOperators.Group.Finset
 import Mathlib.Data.Nat.Factors
+import Mathlib.Data.Nat.Prime.Basic
 import Mathlib.Order.Interval.Finset.Nat
 
 #align_import number_theory.divisors from "leanprover-community/mathlib"@"e8638a0fcaf73e4500469f368ef9494e495099b3"

--- a/Mathlib/RingTheory/Int/Basic.lean
+++ b/Mathlib/RingTheory/Int/Basic.lean
@@ -6,6 +6,7 @@ Authors: Johannes Hölzl, Jens Wagemaker, Aaron Anderson
 import Mathlib.Algebra.EuclideanDomain.Basic
 import Mathlib.RingTheory.PrincipalIdealDomain
 import Mathlib.Algebra.GCDMonoid.Nat
+import Mathlib.Data.Nat.Prime.Basic
 
 #align_import ring_theory.int.basic from "leanprover-community/mathlib"@"e655e4ea5c6d02854696f97494997ba4c31be802"
 


### PR DESCRIPTION
Further reduce imports of full `Prime.lean`. Here, `Data.Nat.Factors` now imports only `Prime/Defs`.
For this, four lemmas had to be added to `Prime/Defs` from `Prime/Basic`. Many modules import
`Data.Nat.Factors`, so their dependencies on `Prime` theorems are now uncovered. Still, this
change will reduce the amount of what is imported, in general.

Motivation is a circular dependency that would prevent me from adding a lemma to `Prime/Basic`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
