### PR TITLE
[Merged by Bors] - chore(Data): reduce use of autoImplicit

### DIFF
--- a/Mathlib/Data/Array/ExtractLemmas.lean
+++ b/Mathlib/Data/Array/ExtractLemmas.lean
@@ -8,7 +8,9 @@ Authors: Jiecheng Zhao
 
 Some useful lemmas about Array.extract
 -/
-set_option autoImplicit true
+
+universe u
+variable {α : Type u} {i : Nat}
 
 namespace Array
 
@@ -37,11 +39,11 @@ theorem extract_append_right {a b : Array α} {i j : Nat} (h : a.size ≤ i) :
     congr
     omega
 
-theorem extract_eq_of_size_le_end {a : Array α} (h : a.size ≤ l) :
+theorem extract_eq_of_size_le_end {l p : Nat} {a : Array α} (h : a.size ≤ l) :
     a.extract p l = a.extract p a.size := by
   simp only [extract, Nat.min_eq_right h, Nat.sub_eq, mkEmpty_eq, Nat.min_self]
 
-theorem extract_extract {a : Array α} (h : s1 + e2 ≤ e1) :
+theorem extract_extract {s1 e2 e1 s2 : Nat} {a : Array α} (h : s1 + e2 ≤ e1) :
     (a.extract s1 e1).extract s2 e2 = a.extract (s1 + s2) (s1 + e2) := by
   apply ext
   · simp only [size_extract]

--- a/Mathlib/Data/ByteArray.lean
+++ b/Mathlib/Data/ByteArray.lean
@@ -4,8 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Mario Carneiro
 -/
 
-set_option autoImplicit true
-
 namespace Nat
 
 /- Up -/
@@ -51,9 +49,10 @@ def toArray : ByteSlice → ByteArray
 /-- Index into a byte slice. The `getOp` function allows the use of the `buf[i]` notation. -/
 @[inline] def getOp (self : ByteSlice) (idx : Nat) : UInt8 := self.arr.get! (self.off + idx)
 
+universe u v
 
 /-- The inner loop of the `forIn` implementation for byte slices. -/
-def forIn.loop [Monad m] (f : UInt8 → β → m (ForInStep β))
+def forIn.loop {m : Type u → Type v} {β : Type u} [Monad m] (f : UInt8 → β → m (ForInStep β))
     (arr : ByteArray) (off _end : Nat) (i : Nat) (b : β) : m β :=
   if h : i < _end then do
     match ← f (arr.get! i) b with
@@ -62,7 +61,7 @@ def forIn.loop [Monad m] (f : UInt8 → β → m (ForInStep β))
   else pure b
 termination_by _end - i
 
-instance : ForIn m ByteSlice UInt8 :=
+instance {m : Type u → Type v} : ForIn m ByteSlice UInt8 :=
   ⟨fun ⟨arr, off, len⟩ b f ↦ forIn.loop f arr off (off + len) off b⟩
 
 end ByteSlice

--- a/Mathlib/Data/List/Range.lean
+++ b/Mathlib/Data/List/Range.lean
@@ -22,9 +22,6 @@ tactics. `range' a b = [a, ..., a + b - 1]` is there to help prove properties ab
 Actual maths should use `List.Ico` instead.
 -/
 
-set_option autoImplicit true
-
-
 universe u
 
 open Nat
@@ -33,7 +30,7 @@ namespace List
 
 variable {α : Type u}
 
-@[simp] theorem range'_one {step} : range' s 1 step = [s] := rfl
+@[simp] theorem range'_one {s step : ℕ} : range' s 1 step = [s] := rfl
 
 #align list.length_range' List.length_range'
 #align list.range'_eq_nil List.range'_eq_nil
@@ -221,7 +218,7 @@ theorem nthLe_finRange {n : ℕ} {i : ℕ} (h) :
   get_finRange h
 #align list.nth_le_fin_range List.nthLe_finRange
 
-@[simp] theorem indexOf_finRange (i : Fin k) : (finRange k).indexOf i = i := by
+@[simp] theorem indexOf_finRange {k : ℕ} (i : Fin k) : (finRange k).indexOf i = i := by
   have : (finRange k).indexOf i < (finRange k).length := indexOf_lt_length.mpr (by simp)
   have h₁ : (finRange k).get ⟨(finRange k).indexOf i, this⟩ = i := indexOf_get this
   have h₂ : (finRange k).get ⟨i, by simp⟩ = i := get_finRange _

--- a/Mathlib/Data/Matroid/Basic.lean
+++ b/Mathlib/Data/Matroid/Basic.lean
@@ -160,8 +160,6 @@ There are a few design decisions worth discussing.
   Proc. Amer. Math. Soc. 144 (2016), 459-471]
 -/
 
-set_option autoImplicit true
-
 open Set
 
 /-- A predicate `P` on sets satisfies the **exchange property** if,
@@ -258,14 +256,14 @@ theorem rkPos_iff_empty_not_base : M.RkPos ↔ ¬M.Base ∅ :=
 section exchange
 namespace ExchangeProperty
 
-variable {Base : Set α → Prop} (exch : ExchangeProperty Base)
+variable {Base : Set α → Prop} (exch : ExchangeProperty Base) {B B' : Set α}
 
 /-- A family of sets with the exchange property is an antichain. -/
 theorem antichain (hB : Base B) (hB' : Base B') (h : B ⊆ B') : B = B' :=
   h.antisymm (fun x hx ↦ by_contra
     (fun hxB ↦ let ⟨_, hy, _⟩ := exch B' B hB' hB x ⟨hx, hxB⟩; hy.2 <| h hy.1))
 
-theorem encard_diff_le_aux (exch : ExchangeProperty Base) (hB₁ : Base B₁) (hB₂ : Base B₂) :
+theorem encard_diff_le_aux {B₁ B₂ : Set α} (exch : ExchangeProperty Base) (hB₁ : Base B₁) (hB₂ : Base B₂) :
     (B₁ \ B₂).encard ≤ (B₂ \ B₁).encard := by
   obtain (he | hinf | ⟨e, he, hcard⟩) :=
     (B₂ \ B₁).eq_empty_or_encard_eq_top_or_encard_diff_singleton_lt
@@ -284,6 +282,8 @@ theorem encard_diff_le_aux (exch : ExchangeProperty Base) (hB₁ : Base B₁) (h
   rw [← encard_diff_singleton_add_one he, ← encard_diff_singleton_add_one hf]
   exact add_le_add_right hencard 1
 termination_by (B₂ \ B₁).encard
+
+variable {B₁ B₂ : Set α}
 
 /-- For any two sets `B₁`, `B₂` in a family with the exchange property, the differences `B₁ \ B₂`
 and `B₂ \ B₁` have the same `ℕ∞`-cardinality. -/
@@ -311,6 +311,8 @@ macro (name := aesop_mat) "aesop_mat" c:Aesop.tactic_clause* : tactic =>
 
 /- We add a number of trivial lemmas (deliberately specialized to statements in terms of the
   ground set of a matroid) to the ruleset `Matroid` for `aesop`. -/
+
+variable {X Y : Set α} {e : α}
 
 @[aesop unsafe 5% (rule_sets := [Matroid])]
 private theorem inter_right_subset_ground (hX : X ⊆ M.E) :
@@ -352,17 +354,20 @@ private theorem ground_subset_ground {M : Matroid α} : M.E ⊆ M.E :=
 attribute [aesop safe (rule_sets := [Matroid])] empty_subset union_subset iUnion_subset
 
 end aesop
+
 section Base
+
+variable {B B₁ B₂ : Set α}
 
 @[aesop unsafe 10% (rule_sets := [Matroid])]
 theorem Base.subset_ground (hB : M.Base B) : B ⊆ M.E :=
   M.subset_ground B hB
 
-theorem Base.exchange (hB₁ : M.Base B₁) (hB₂ : M.Base B₂) (hx : e ∈ B₁ \ B₂) :
+theorem Base.exchange {e : α} (hB₁ : M.Base B₁) (hB₂ : M.Base B₂) (hx : e ∈ B₁ \ B₂) :
     ∃ y ∈ B₂ \ B₁, M.Base (insert y (B₁ \ {e}))  :=
   M.base_exchange B₁ B₂ hB₁ hB₂ _ hx
 
-theorem Base.exchange_mem (hB₁ : M.Base B₁) (hB₂ : M.Base B₂) (hxB₁ : e ∈ B₁) (hxB₂ : e ∉ B₂) :
+theorem Base.exchange_mem {e : α} (hB₁ : M.Base B₁) (hB₂ : M.Base B₂) (hxB₁ : e ∈ B₁) (hxB₂ : e ∉ B₂) :
     ∃ y, (y ∈ B₂ ∧ y ∉ B₁) ∧ M.Base (insert y (B₁ \ {e})) := by
   simpa using hB₁.exchange hB₂ ⟨hxB₁, hxB₂⟩
 
@@ -370,10 +375,10 @@ theorem Base.eq_of_subset_base (hB₁ : M.Base B₁) (hB₂ : M.Base B₂) (hB�
     B₁ = B₂ :=
   M.base_exchange.antichain hB₁ hB₂ hB₁B₂
 
-theorem Base.not_base_of_ssubset (hB : M.Base B) (hX : X ⊂ B) : ¬ M.Base X :=
+theorem Base.not_base_of_ssubset {X : Set α} (hB : M.Base B) (hX : X ⊂ B) : ¬ M.Base X :=
   fun h ↦ hX.ne (h.eq_of_subset_base hB hX.subset)
 
-theorem Base.insert_not_base (hB : M.Base B) (heB : e ∉ B) : ¬ M.Base (insert e B) :=
+theorem Base.insert_not_base {e : α} (hB : M.Base B) (heB : e ∉ B) : ¬ M.Base (insert e B) :=
   fun h ↦ h.not_base_of_ssubset (ssubset_insert heB) hB
 
 theorem Base.encard_diff_comm (hB₁ : M.Base B₁) (hB₂ : M.Base B₂) :
@@ -391,7 +396,7 @@ theorem Base.card_eq_card_of_base (hB₁ : M.Base B₁) (hB₂ : M.Base B₂) :
 theorem Base.ncard_eq_ncard_of_base (hB₁ : M.Base B₁) (hB₂ : M.Base B₂) : B₁.ncard = B₂.ncard := by
   rw [ncard_def B₁, hB₁.card_eq_card_of_base hB₂, ← ncard_def]
 
-theorem Base.finite_of_finite (hB : M.Base B) (h : B.Finite) (hB' : M.Base B') : B'.Finite :=
+theorem Base.finite_of_finite {B' : Set α} (hB : M.Base B) (h : B.Finite) (hB' : M.Base B') : B'.Finite :=
   (finite_iff_finite_of_encard_eq_encard (hB.card_eq_card_of_base hB')).mp h
 
 theorem Base.infinite_of_infinite (hB : M.Base B) (h : B.Infinite) (hB₁ : M.Base B₁) :
@@ -469,6 +474,8 @@ section dep_indep
 
 /-- A subset of `M.E` is `Dep`endent if it is not `Indep`endent . -/
 def Dep (M : Matroid α) (D : Set α) : Prop := ¬M.Indep D ∧ D ⊆ M.E
+
+variable {B B' I J D X : Set α} {e f : α}
 
 theorem indep_iff : M.Indep I ↔ ∃ B, M.Base B ∧ I ⊆ B :=
   M.indep_iff' (I := I)
@@ -634,7 +641,7 @@ theorem Indep.exists_insert_of_not_mem_maximals (M : Matroid α) ⦃I B : Set α
     exact hne <| hIb.eq_of_subset_indep hII' hI'
   exact hB.1.base_of_maximal fun J hJ hBJ ↦ hB.2 hJ hBJ
 
-theorem Indep.base_of_forall_insert {M : Matroid α} {B : Set α} (hB : M.Indep B)
+theorem Indep.base_of_forall_insert (hB : M.Indep B)
     (hBmax : ∀ e ∈ M.E \ B, ¬ M.Indep (insert e B)) : M.Base B := by
   refine by_contra fun hnb ↦ ?_
   obtain ⟨B', hB'⟩ := M.exists_base
@@ -702,6 +709,8 @@ def Basis (M : Matroid α) (I X : Set α) : Prop :=
   API building, especially when working with rank and closure.  -/
 def Basis' (M : Matroid α) (I X : Set α) : Prop :=
   I ∈ maximals (· ⊆ ·) {A | M.Indep A ∧ A ⊆ X}
+
+variable {B I J X Y : Set α} {e : α}
 
 theorem Basis'.indep (hI : M.Basis' I X) : M.Indep I :=
   hI.1.1

--- a/Mathlib/Data/Matroid/Basic.lean
+++ b/Mathlib/Data/Matroid/Basic.lean
@@ -263,7 +263,8 @@ theorem antichain (hB : Base B) (hB' : Base B') (h : B ⊆ B') : B = B' :=
   h.antisymm (fun x hx ↦ by_contra
     (fun hxB ↦ let ⟨_, hy, _⟩ := exch B' B hB' hB x ⟨hx, hxB⟩; hy.2 <| h hy.1))
 
-theorem encard_diff_le_aux {B₁ B₂ : Set α} (exch : ExchangeProperty Base) (hB₁ : Base B₁) (hB₂ : Base B₂) :
+theorem encard_diff_le_aux {B₁ B₂ : Set α}
+    (exch : ExchangeProperty Base) (hB₁ : Base B₁) (hB₂ : Base B₂) :
     (B₁ \ B₂).encard ≤ (B₂ \ B₁).encard := by
   obtain (he | hinf | ⟨e, he, hcard⟩) :=
     (B₂ \ B₁).eq_empty_or_encard_eq_top_or_encard_diff_singleton_lt
@@ -367,7 +368,8 @@ theorem Base.exchange {e : α} (hB₁ : M.Base B₁) (hB₂ : M.Base B₂) (hx :
     ∃ y ∈ B₂ \ B₁, M.Base (insert y (B₁ \ {e}))  :=
   M.base_exchange B₁ B₂ hB₁ hB₂ _ hx
 
-theorem Base.exchange_mem {e : α} (hB₁ : M.Base B₁) (hB₂ : M.Base B₂) (hxB₁ : e ∈ B₁) (hxB₂ : e ∉ B₂) :
+theorem Base.exchange_mem {e : α}
+    (hB₁ : M.Base B₁) (hB₂ : M.Base B₂) (hxB₁ : e ∈ B₁) (hxB₂ : e ∉ B₂) :
     ∃ y, (y ∈ B₂ ∧ y ∉ B₁) ∧ M.Base (insert y (B₁ \ {e})) := by
   simpa using hB₁.exchange hB₂ ⟨hxB₁, hxB₂⟩
 
@@ -396,7 +398,8 @@ theorem Base.card_eq_card_of_base (hB₁ : M.Base B₁) (hB₂ : M.Base B₂) :
 theorem Base.ncard_eq_ncard_of_base (hB₁ : M.Base B₁) (hB₂ : M.Base B₂) : B₁.ncard = B₂.ncard := by
   rw [ncard_def B₁, hB₁.card_eq_card_of_base hB₂, ← ncard_def]
 
-theorem Base.finite_of_finite {B' : Set α} (hB : M.Base B) (h : B.Finite) (hB' : M.Base B') : B'.Finite :=
+theorem Base.finite_of_finite {B' : Set α}
+    (hB : M.Base B) (h : B.Finite) (hB' : M.Base B') : B'.Finite :=
   (finite_iff_finite_of_encard_eq_encard (hB.card_eq_card_of_base hB')).mp h
 
 theorem Base.infinite_of_infinite (hB : M.Base B) (h : B.Infinite) (hB₁ : M.Base B₁) :

--- a/Mathlib/Data/Stream/Defs.lean
+++ b/Mathlib/Data/Stream/Defs.lean
@@ -16,7 +16,8 @@ infinite list. In this file we define `Stream'` and some functions that take and
 Note that we already have `Stream` to represent a similar object, hence the awkward naming.
 -/
 
-set_option autoImplicit true
+universe u v w
+variable {α : Type u} {β : Type v} {δ : Type w}
 
 /-- A stream `Stream' α` is an infinite sequence of elements of `α`. -/
 def Stream' (α : Type u) := ℕ → α

--- a/Mathlib/Data/Stream/Init.lean
+++ b/Mathlib/Data/Stream/Init.lean
@@ -17,12 +17,11 @@ Porting note:
 This file used to be in the core library. It was moved to `mathlib` and renamed to `init` to avoid
 name clashes.  -/
 
-set_option autoImplicit true
-
 open Nat Function Option
 
 namespace Stream'
 
+universe u v w
 variable {α : Type u} {β : Type v} {δ : Type w}
 
 instance [Inhabited α] : Inhabited (Stream' α) :=
@@ -66,12 +65,12 @@ theorem drop_drop (n m : Nat) (s : Stream' α) : drop n (drop m s) = drop (n + m
   ext; simp [Nat.add_assoc]
 #align stream.drop_drop Stream'.drop_drop
 
-@[simp] theorem get_tail {s : Stream' α} : s.tail.get n = s.get (n + 1) := rfl
+@[simp] theorem get_tail {n : ℕ} {s : Stream' α} : s.tail.get n = s.get (n + 1) := rfl
 
-@[simp] theorem tail_drop' {s : Stream' α} : tail (drop i s) = s.drop (i+1) := by
+@[simp] theorem tail_drop' {i : ℕ} {s : Stream' α} : tail (drop i s) = s.drop (i+1) := by
   ext; simp [Nat.add_comm, Nat.add_assoc, Nat.add_left_comm]
 
-@[simp] theorem drop_tail' {s : Stream' α} : drop i (tail s) = s.drop (i+1) := rfl
+@[simp] theorem drop_tail' {i : ℕ} {s : Stream' α} : drop i (tail s) = s.drop (i+1) := rfl
 
 theorem tail_drop (n : Nat) (s : Stream' α) : tail (drop n s) = drop n (tail s) := by simp
 #align stream.tail_drop Stream'.tail_drop
@@ -576,7 +575,8 @@ theorem take_succ (n : Nat) (s : Stream' α) : take (succ n) s = head s::take n 
   rfl
 #align stream.take_succ Stream'.take_succ
 
-@[simp] theorem take_succ_cons (n : Nat) (s : Stream' α) : take (n+1) (a::s) = a :: take n s := rfl
+@[simp] theorem take_succ_cons {a : α} (n : Nat) (s : Stream' α) :
+    take (n+1) (a::s) = a :: take n s := rfl
 
 theorem take_succ' {s : Stream' α} : ∀ n, s.take (n+1) = s.take n ++ [s.get n]
   | 0 => rfl
@@ -593,7 +593,7 @@ theorem take_take {s : Stream' α} : ∀ {m n}, (s.take n).take m = s.take (min 
   | m, 0 => by rw [Nat.zero_min, take_zero, List.take_nil]
   | m+1, n+1 => by rw [take_succ, List.take_cons, Nat.succ_min_succ, take_succ, take_take]
 
-@[simp] theorem concat_take_get {s : Stream' α} : s.take n ++ [s.get n] = s.take (n+1) :=
+@[simp] theorem concat_take_get {n : ℕ} {s : Stream' α} : s.take n ++ [s.get n] = s.take (n+1) :=
   (take_succ' n).symm
 
 theorem get?_take {s : Stream' α} : ∀ {k n}, k < n → (s.take n).get? k = s.get k
@@ -605,7 +605,7 @@ theorem get?_take_succ (n : Nat) (s : Stream' α) :
   get?_take (Nat.lt_succ_self n)
 #align stream.nth_take_succ Stream'.get?_take_succ
 
-@[simp] theorem dropLast_take {xs : Stream' α} :
+@[simp] theorem dropLast_take {n : ℕ} {xs : Stream' α} :
     (Stream'.take n xs).dropLast = Stream'.take (n-1) xs := by
   cases n with
   | zero => simp

--- a/Mathlib/Data/Stream/Init.lean
+++ b/Mathlib/Data/Stream/Init.lean
@@ -575,7 +575,7 @@ theorem take_succ (n : Nat) (s : Stream' α) : take (succ n) s = head s::take n 
   rfl
 #align stream.take_succ Stream'.take_succ
 
-@[simp] theorem take_succ_cons {a : α} (n : Nat) (s : Stream' α) :
+@[simp] theorem take_succ_cons {a : α} (n : ℕ) (s : Stream' α) :
     take (n+1) (a::s) = a :: take n s := rfl
 
 theorem take_succ' {s : Stream' α} : ∀ n, s.take (n+1) = s.take n ++ [s.get n]

--- a/Mathlib/Data/Sym/Basic.lean
+++ b/Mathlib/Data/Sym/Basic.lean
@@ -30,9 +30,6 @@ symmetric powers
 -/
 
 assert_not_exists MonoidWithZero
-
-set_option autoImplicit true
-
 open Mathlib (Vector)
 open Function
 
@@ -55,7 +52,7 @@ instance Sym.hasCoe (α : Type*) (n : ℕ) : CoeOut (Sym α n) (Multiset α) :=
 #align sym.has_coe Sym.hasCoe
 
 -- Porting note: instance needed for Data.Finset.Sym
-instance [DecidableEq α] : DecidableEq (Sym α n) :=
+instance {α : Type*} {n : ℕ} [DecidableEq α] : DecidableEq (Sym α n) :=
   inferInstanceAs <| DecidableEq <| Subtype _
 
 /-- This is the `List.Perm` setoid lifted to `Vector`.

--- a/Mathlib/Data/UnionFind.lean
+++ b/Mathlib/Data/UnionFind.lean
@@ -6,8 +6,6 @@ Authors: Mario Carneiro
 import Mathlib.Init.Data.Nat.Notation
 import Mathlib.Init.Order.Defs
 
-set_option autoImplicit true
-
 structure UFModel (n) where
   parent : Fin n → Fin n
   rank : Nat → Nat
@@ -64,6 +62,8 @@ structure UFNode (α : Type*) where
   parent : Nat
   value : α
   rank : Nat
+
+variable {α : Type*} {β : Sort*} {f : α → β} {n : ℕ}
 
 inductive UFModel.Agrees (arr : Array α) (f : α → β) : ∀ {n}, (Fin n → β) → Prop
   | mk : Agrees arr f fun i ↦ f (arr.get i)


### PR DESCRIPTION
This is not exhaustive: there are about ten remaining files in this directory.
`Data/Vector` may come in a follow-up PR (this is harder).

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
