### PR TITLE
[Merged by Bors] - promoting the Grothendieck construction into a functor

### DIFF
--- a/Mathlib/CategoryTheory/Grothendieck.lean
+++ b/Mathlib/CategoryTheory/Grothendieck.lean
@@ -198,8 +198,7 @@ theorem map_obj {α : F ⟶ G} (X : Grothendieck F) :
 
 theorem map_map {α : F ⟶ G} {X Y : Grothendieck F} {f : X ⟶ Y} :
     (Grothendieck.map α).map f =
-    ⟨f.base, (eqToHom (α.naturality f.base).symm).app X.fiber ≫ (α.app Y.base).map f.fiber⟩ := by
-  rfl
+    ⟨f.base, (eqToHom (α.naturality f.base).symm).app X.fiber ≫ (α.app Y.base).map f.fiber⟩ := rfl
 
 /-- The functor `Grothendieck.map α : Grothendieck F ⥤ Grothendieck G` lies over `C`.-/
 theorem functor_comp_forget {α : F ⟶ G} :

--- a/Mathlib/CategoryTheory/Grothendieck.lean
+++ b/Mathlib/CategoryTheory/Grothendieck.lean
@@ -184,7 +184,7 @@ def map (α : F ⟶ G) : Grothendieck F ⥤ Grothendieck G where
     dsimp
     congr 1
     simp only [comp_fiber' f g, ← Category.assoc, Functor.map_comp, eqToHom_map]
-    apply congrFun (congrArg (. ≫ .) ?_) ((α.app Z.base).map g.fiber)
+    apply congrFun (congrArg (· ≫ ·) ?_) ((α.app Z.base).map g.fiber)
     have H := Functor.congr_hom (α.naturality g.base).symm f.fiber
     erw [H, eqToHom_app, eqToHom_app]
     simp only [Cat.comp_obj, eqToHom_trans, eqToHom_map, Cat.comp_map, eqToHom_trans_assoc,

--- a/Mathlib/CategoryTheory/Grothendieck.lean
+++ b/Mathlib/CategoryTheory/Grothendieck.lean
@@ -193,8 +193,7 @@ def map (α : F ⟶ G) : Grothendieck F ⥤ Grothendieck G where
     simp
 
 theorem map_obj {α : F ⟶ G} (X : Grothendieck F) :
-    (Grothendieck.map α).obj X = ⟨X.base, (α.app X.base).obj X.fiber⟩ := by
-  rfl
+    (Grothendieck.map α).obj X = ⟨X.base, (α.app X.base).obj X.fiber⟩ := rfl
 
 theorem map_map {α : F ⟶ G} {X Y : Grothendieck F} {f : X ⟶ Y} :
     (Grothendieck.map α).map f =

--- a/Mathlib/CategoryTheory/Grothendieck.lean
+++ b/Mathlib/CategoryTheory/Grothendieck.lean
@@ -173,8 +173,8 @@ def map (α : F ⟶ G) : Grothendieck F ⥤ Grothendieck G where
   obj X :=
   { base := X.base
     fiber := (α.app X.base).obj X.fiber }
-  map {X Y} f := {
-    base := f.base
+  map {X Y} f :=
+  { base := f.base
     fiber := (eqToHom (α.naturality f.base).symm).app X.fiber ≫ (α.app Y.base).map f.fiber }
   map_id X := by
     simp only [Cat.comp_obj, id_fiber', eqToHom_map]

--- a/Mathlib/CategoryTheory/Grothendieck.lean
+++ b/Mathlib/CategoryTheory/Grothendieck.lean
@@ -184,12 +184,11 @@ def map (α : F ⟶ G) : Grothendieck F ⥤ Grothendieck G where
     dsimp
     congr 1
     simp only [comp_fiber' f g, ← Category.assoc, Functor.map_comp, eqToHom_map]
-    apply congrFun (congrArg (· ≫ ·) ?_) ((α.app Z.base).map g.fiber)
-    have H := Functor.congr_hom (α.naturality g.base).symm f.fiber
-    erw [H, eqToHom_app, eqToHom_app]
+    congr 1
     simp only [Cat.comp_obj, eqToHom_trans, eqToHom_map, Cat.comp_map, eqToHom_trans_assoc,
       Category.assoc]
-    erw [eqToHom_app]
+    rw [eqToHom_app, eqToHom_app, eqToHom_app]
+    erw [Functor.congr_hom (α.naturality g.base).symm f.fiber]
     simp
 
 theorem map_obj {α : F ⟶ G} (X : Grothendieck F) :

--- a/Mathlib/CategoryTheory/Grothendieck.lean
+++ b/Mathlib/CategoryTheory/Grothendieck.lean
@@ -170,8 +170,8 @@ a functor `Grothendieck.map : Grothendieck F ⥤ Grothendieck G`.
 -/
 @[simps!]
 def map (α : F ⟶ G) : Grothendieck F ⥤ Grothendieck G where
-  obj X := {
-    base := X.base
+  obj X :=
+  { base := X.base
     fiber := (α.app X.base).obj X.fiber }
   map {X Y} f := {
     base := f.base

--- a/Mathlib/CategoryTheory/Grothendieck.lean
+++ b/Mathlib/CategoryTheory/Grothendieck.lean
@@ -237,8 +237,8 @@ universe v
 
 /-- The Grothendieck construction as a functor from the functor category `E ⥤ Cat` to the
 over category `Over E`. -/
-def functor {E : Cat.{v,u}} : (E ⥤ Cat.{v,u}) ⥤ Over (T:= Cat.{v,u}) E where
-  obj F := Over.mk (X:= E) (Y := Cat.of (Grothendieck F))  (Grothendieck.forget F)
+def functor {E : Cat.{v,u}} : (E ⥤ Cat.{v,u}) ⥤ Over (T := Cat.{v,u}) E where
+  obj F := Over.mk (X := E) (Y := Cat.of (Grothendieck F)) (Grothendieck.forget F)
   map {F G} α := Over.homMk (X:= E) (Grothendieck.map α) Grothendieck.functor_comp_forget
   map_id F := by
     ext

--- a/Mathlib/CategoryTheory/Grothendieck.lean
+++ b/Mathlib/CategoryTheory/Grothendieck.lean
@@ -217,7 +217,7 @@ theorem map_id_eq : map (𝟙 F) = 𝟙 (Cat.of <| Grothendieck <| F) := by
 
 /-- Making the equality of functors into an isomorphism. Note: we should avoid equality of functors
 if possible, and we should prefer `map_id_iso` to `map_id_eq` whenever we can. -/
-def map_id_iso : map (𝟙 F) ≅ 𝟙 (Cat.of <| Grothendieck <| F) := eqToIso map_id_eq
+def mapIdIso : map (𝟙 F) ≅ 𝟙 (Cat.of <| Grothendieck <| F) := eqToIso map_id_eq
 
 variable {H : C ⥤ Cat}
 

--- a/Mathlib/CategoryTheory/Grothendieck.lean
+++ b/Mathlib/CategoryTheory/Grothendieck.lean
@@ -215,6 +215,8 @@ theorem map_id_eq : map (𝟙 F) = 𝟙 (Cat.of <| Grothendieck <| F) := by
     erw [NatTrans.id_app]
     simp
 
+/-- Making the equality of functors into an isomorphism. Note: we should avoid equality of functors
+if possible, and we should prefer `map_id_iso` to `map_id_eq` whenever we can. -/
 def map_id_iso : map (𝟙 F) ≅ 𝟙 (Cat.of <| Grothendieck <| F) := eqToIso map_id_eq
 
 variable {H : C ⥤ Cat}
@@ -232,6 +234,8 @@ theorem map_comp_eq (α : F ⟶ G) (β : G ⟶ H) :
       erw [eqToHom_app, eqToHom_app, eqToHom_app, eqToHom_map]
       simp [eqToHom_trans]
 
+/-- Making the equality of functors into an isomorphism. Note: we should avoid equality of functors
+if possible, and we should prefer `map_comp_iso` to `map_comp_eq` whenever we can. -/
 def map_comp_iso (α : F ⟶ G) (β : G ⟶ H) : map (α ≫ β) ≅ map α ⋙ map β := eqToIso (map_comp_eq α β)
 
 end

--- a/Mathlib/CategoryTheory/Grothendieck.lean
+++ b/Mathlib/CategoryTheory/Grothendieck.lean
@@ -228,12 +228,13 @@ theorem map_comp_eq (α : F ⟶ G) (β : G ⟶ H) :
   · intro X
     rfl
   · intro X Y f
-    simp [map_map]
+    simp only [map_map, map_obj_base, NatTrans.comp_app, Cat.comp_obj, Cat.comp_map,
+      eqToHom_refl, Functor.comp_map, Functor.map_comp, Category.comp_id, Category.id_comp]
     fapply Grothendieck.ext
     · rfl
-    · simp
+    · simp only [eqToHom_refl, Category.id_comp]
       erw [eqToHom_app, eqToHom_app, eqToHom_app, eqToHom_map]
-      simp [eqToHom_trans]
+      simp only [Cat.comp_obj, eqToHom_trans_assoc]
 
 /-- Making the equality of functors into an isomorphism. Note: we should avoid equality of functors
 if possible, and we should prefer `map_comp_iso` to `map_comp_eq` whenever we can. -/

--- a/Mathlib/CategoryTheory/Grothendieck.lean
+++ b/Mathlib/CategoryTheory/Grothendieck.lean
@@ -133,6 +133,14 @@ theorem id_fiber' (X : Grothendieck F) :
   id_fiber X
 #align category_theory.grothendieck.id_fiber' CategoryTheory.Grothendieck.id_fiber'
 
+@[simp]
+theorem comp_fiber' {X Y Z : Grothendieck F} (f : X ⟶ Y) (g : Y ⟶ Z) :
+    Hom.fiber (f ≫ g) =
+    eqToHom (by erw [Functor.map_comp, Functor.comp_obj]) ≫
+    (F.map g.base).map f.fiber ≫ g.fiber :=
+  comp_fiber f g
+
+
 theorem congr {X Y : Grothendieck F} {f g : X ⟶ Y} (h : f = g) :
     f.fiber = eqToHom (by subst h; rfl) ≫ g.fiber := by
   subst h
@@ -175,8 +183,7 @@ def map (α : F ⟶ G) : Grothendieck F ⥤ Grothendieck G where
   map_comp {X Y Z} f g := by
     dsimp
     congr 1
-    erw [comp_fiber f g]
-    simp only [← Category.assoc, Functor.map_comp, eqToHom_map]
+    simp only [comp_fiber' f g, ← Category.assoc, Functor.map_comp, eqToHom_map]
     apply congrFun (congrArg (. ≫ .) ?_) ((α.app Z.base).map g.fiber)
     have H := Functor.congr_hom (α.naturality g.base).symm f.fiber
     erw [H, eqToHom_app, eqToHom_app]
@@ -206,7 +213,8 @@ theorem map_id_eq : map (𝟙 F) = 𝟙 (Cat.of <| Grothendieck <| F) := by
   · intro X Y f
     simp [map_map]
     congr
-    simp [NatTrans.id_app]
+    erw [NatTrans.id_app]
+    simp
 
 /-- Making the equality of functors into an isomorphism. Note: we should avoid equality of functors
 if possible, and we should prefer `map_id_iso` to `map_id_eq` whenever we can. -/

--- a/Mathlib/CategoryTheory/Grothendieck.lean
+++ b/Mathlib/CategoryTheory/Grothendieck.lean
@@ -213,7 +213,7 @@ theorem map_id_eq : map (𝟙 F) = 𝟙 (Cat.of <| Grothendieck <| F) := by
   · intro X Y f
     simp [map_map]
     congr
-    erw [NatTrans.id_app]
+    rw [NatTrans.id_app]
     simp
 
 /-- Making the equality of functors into an isomorphism. Note: we should avoid equality of functors

--- a/Mathlib/CategoryTheory/Grothendieck.lean
+++ b/Mathlib/CategoryTheory/Grothendieck.lean
@@ -244,8 +244,7 @@ def functor {E : Cat.{v,u}} : (E ⥤ Cat.{v,u}) ⥤ Over (T:= Cat.{v,u}) E where
   map_id F := by
     ext
     exact Grothendieck.map_id_eq (F:= F)
-  map_comp := by
-    intro F G H α β
+  map_comp α β := by
     simp [Grothendieck.map_comp_eq α β]
     rfl
 

--- a/Mathlib/CategoryTheory/Grothendieck.lean
+++ b/Mathlib/CategoryTheory/Grothendieck.lean
@@ -164,32 +164,26 @@ a functor `Grothendieck.map : Grothendieck F ⥤ Grothendieck G`.
 def map (α : F ⟶ G) : Grothendieck F ⥤ Grothendieck G where
   obj X := {
     base := X.base
-    fiber := (α.app X.base).obj X.fiber
-  }
+    fiber := (α.app X.base).obj X.fiber }
   map {X Y} f := {
     base := f.base
-    fiber := (eqToHom (α.naturality f.base).symm).app X.fiber ≫ (α.app Y.base).map f.fiber
-  }
-  map_id := by
-    intro X
-    dsimp
-    simp [eqToHom_map]
+    fiber := (eqToHom (α.naturality f.base).symm).app X.fiber ≫ (α.app Y.base).map f.fiber }
+  map_id X := by
+    simp only [Cat.comp_obj, id_fiber', eqToHom_map]
     congr 1
-    · rw [eqToHom_app, eqToHom_trans]
-  map_comp := by
-    intro X Y Z f g
+    rw [eqToHom_app, eqToHom_trans]
+  map_comp {X Y Z} f g := by
     dsimp
     congr 1
     erw [comp_fiber f g]
-    simp [Functor.comp_map, ← Category.assoc]
+    simp only [← Category.assoc, Functor.map_comp, eqToHom_map]
     apply congrFun (congrArg (. ≫ .) ?_) ((α.app Z.base).map g.fiber)
-    slice_rhs 3 3 =>
-      rw [← Functor.comp_map _ _]
-    have H :=  Functor.congr_hom (α.naturality g.base).symm f.fiber
+    have H := Functor.congr_hom (α.naturality g.base).symm f.fiber
     erw [H, eqToHom_app, eqToHom_app]
-    simp [Functor.comp_map]
+    simp only [Cat.comp_obj, eqToHom_trans, eqToHom_map, Cat.comp_map, eqToHom_trans_assoc,
+      Category.assoc]
     erw [eqToHom_app]
-    simp only [Cat.comp_obj, eqToHom_trans, eqToHom_refl, Category.comp_id]
+    simp
 
 theorem map_obj {α : F ⟶ G} (X : Grothendieck F) :
     (Grothendieck.map α).obj X = ⟨X.base, (α.app X.base).obj X.fiber⟩ := by

--- a/Mathlib/CategoryTheory/Grothendieck.lean
+++ b/Mathlib/CategoryTheory/Grothendieck.lean
@@ -203,8 +203,7 @@ theorem map_map {α : F ⟶ G} {X Y : Grothendieck F} {f : X ⟶ Y} :
 
 /-- The functor `Grothendieck.map α : Grothendieck F ⥤ Grothendieck G` lies over `C`.-/
 theorem functor_comp_forget {α : F ⟶ G} :
-    Grothendieck.map α ⋙ Grothendieck.forget G = Grothendieck.forget F := by
-  rfl
+    Grothendieck.map α ⋙ Grothendieck.forget G = Grothendieck.forget F := rfl
 
 theorem map_id_eq : map (𝟙 F) = 𝟙 (Cat.of <| Grothendieck <| F) := by
   fapply Functor.ext

--- a/Mathlib/CategoryTheory/Grothendieck.lean
+++ b/Mathlib/CategoryTheory/Grothendieck.lean
@@ -230,7 +230,7 @@ theorem map_comp_eq (α : F ⟶ G) (β : G ⟶ H) :
 
 /-- Making the equality of functors into an isomorphism. Note: we should avoid equality of functors
 if possible, and we should prefer `map_comp_iso` to `map_comp_eq` whenever we can. -/
-def map_comp_iso (α : F ⟶ G) (β : G ⟶ H) : map (α ≫ β) ≅ map α ⋙ map β := eqToIso (map_comp_eq α β)
+def mapCompIso (α : F ⟶ G) (β : G ⟶ H) : map (α ≫ β) ≅ map α ⋙ map β := eqToIso (map_comp_eq α β)
 
 end
 

--- a/Mathlib/CategoryTheory/Grothendieck.lean
+++ b/Mathlib/CategoryTheory/Grothendieck.lean
@@ -206,8 +206,7 @@ theorem map_id_eq : map (𝟙 F) = 𝟙 (Cat.of <| Grothendieck <| F) := by
   · intro X Y f
     simp [map_map]
     congr
-    erw [NatTrans.id_app]
-    simp
+    simp [NatTrans.id_app]
 
 /-- Making the equality of functors into an isomorphism. Note: we should avoid equality of functors
 if possible, and we should prefer `map_id_iso` to `map_id_eq` whenever we can. -/


### PR DESCRIPTION
This PR adds the functoriality of the Grothendieck construction by providing 
```
map (α : F ⟶ G) : Grothendieck F ⥤ Grothendieck G
```
and then promotes the Grothendieck construction into a functor from the functor category
`C ⥤ Cat` to the over category `Over C` in the category of categories:

```
def functor {E : Cat.{v,u}} : (E ⥤ Cat.{v,u}) ⥤ Over (T:= Cat.{v,u}) E
```

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
