### PR TITLE
[Merged by Bors] - fix: split `alias` in `no_lost_declarations`

### DIFF
--- a/scripts/no_lost_declarations.sh
+++ b/scripts/no_lost_declarations.sh
@@ -16,6 +16,9 @@ full_output=$(if [ -n "${1}" ]; then
 else
   git diff origin/master...HEAD
 fi |
+  ## the first sed "splits" `[+-]alias ⟨d1, d2⟩ := d` into
+  ## `[+-]alias d1 := d` and `[+-]alias d2 := d`
+  sed 's=^\([+-]\)alias ⟨\([^,]*\), *\([^⟩]*\)⟩\(.*\)=\1alias \2\4\n\1alias \3\4=' |
   ## purge `@[...]`, to attempt to catch declaration names
   sed 's=@\[[^]]*\] ==; s=noncomputable ==; s=nonrec ==; s=protected ==' |
   ## extract lines that begin with '[+-]' followed by the input `theorem`, `lemma`,...

--- a/scripts/no_lost_declarations.sh
+++ b/scripts/no_lost_declarations.sh
@@ -136,4 +136,5 @@ def testingLongDiff1 im a def
 def testingLongDiff2 im a def
 def testingLongDiff3 im a def
 @[trying to fool you] instance. the messing dot
+alias ⟨d1, d2⟩ := d  check the "split an iff alias"
 ReferenceTest


### PR DESCRIPTION
This PR is a fix for the mislabeling reported in #13337.  It "splits"

```lean
[+-]alias ⟨d1, d2⟩ := d
```
into
```lean
[+-]alias d1 := d
[+-]alias d2 := d
```
before feeding it to the usual filter.  Presumably, reproducing the `:= d` parts is irrelevant, but it looks nicer!

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
