### PR TITLE
[Merged by Bors] - feat(CategoryTheory): generalise uniqueness of Kan extensions

### DIFF
--- a/Mathlib/CategoryTheory/Functor/KanExtension/Basic.lean
+++ b/Mathlib/CategoryTheory/Functor/KanExtension/Basic.lean
@@ -122,14 +122,21 @@ lemma isRightKanExtension_iff_of_iso {F' F'' : D ⥤ H} (e : F' ≅ F'') {L : C 
     refine isRightKanExtension_of_iso e.symm α' α ?_
     rw [← comm, ← whiskerLeft_comp_assoc, Iso.symm_hom, e.inv_hom_id, whiskerLeft_id', id_comp]
 
-/-- Two right Kan extensions are (canonically) isomorphic. -/
+/-- Left Kan extensions of isomorphic functors are isomorphic. -/
 @[simps]
-noncomputable def rightKanExtensionUnique
-    (F'' : D ⥤ H) (α' : L ⋙ F'' ⟶ F) [F''.IsRightKanExtension α'] : F' ≅ F'' where
-  hom := F''.liftOfIsRightKanExtension α' F' α
-  inv := F'.liftOfIsRightKanExtension α F'' α'
+noncomputable def rightKanExtensionUniqueOfIso {G : C ⥤ H} (i : F ≅ G) (G' : D ⥤ H)
+    (β : L ⋙ G' ⟶ G) [G'.IsRightKanExtension β] : F' ≅ G' where
+  hom := liftOfIsRightKanExtension _ β F' (α ≫ i.hom)
+  inv := liftOfIsRightKanExtension _ α G' (β ≫ i.inv)
   hom_inv_id := F'.hom_ext_of_isRightKanExtension α _ _ (by simp)
-  inv_hom_id := F''.hom_ext_of_isRightKanExtension α' _ _ (by simp)
+  inv_hom_id := G'.hom_ext_of_isRightKanExtension β _ _ (by simp)
+
+/-- Two right Kan extensions are (canonically) isomorphic. -/
+@[simps!]
+noncomputable def rightKanExtensionUnique
+    (F'' : D ⥤ H) (α' : L ⋙ F'' ⟶ F) [F''.IsRightKanExtension α'] : F' ≅ F'' :=
+  rightKanExtensionUniqueOfIso F' α (Iso.refl _) F'' α'
+
 
 lemma isRightKanExtension_iff_isIso {F' : D ⥤ H} {F'' : D ⥤ H} (φ : F'' ⟶ F')
     {L : C ⥤ D} {F : C ⥤ H} (α : L ⋙ F' ⟶ F) (α' : L ⋙ F'' ⟶ F)
@@ -208,14 +215,20 @@ lemma isLeftKanExtension_iff_of_iso {F' F'' : D ⥤ H} (e : F' ≅ F'')
     refine isLeftKanExtension_of_iso e.symm α' α ?_
     rw [← comm, assoc, ← whiskerLeft_comp, Iso.symm_hom, e.hom_inv_id, whiskerLeft_id', comp_id]
 
-/-- Two left Kan extensions are (canonically) isomorphic. -/
+/-- Left Kan extensions of isomorphic functors are isomorphic. -/
 @[simps]
-noncomputable def leftKanExtensionUnique
-    (F'' : D ⥤ H) (α' : F ⟶ L ⋙ F'') [F''.IsLeftKanExtension α'] : F' ≅ F'' where
-  hom := F'.descOfIsLeftKanExtension α F'' α'
-  inv := F''.descOfIsLeftKanExtension α' F' α
+noncomputable def leftKanExtensionUniqueOfIso {G : C ⥤ H} (i : F ≅ G) (G' : D ⥤ H)
+    (β : G ⟶ L ⋙ G') [G'.IsLeftKanExtension β] : F' ≅ G' where
+  hom := descOfIsLeftKanExtension _ α G' (i.hom ≫ β)
+  inv := descOfIsLeftKanExtension _ β F' (i.inv ≫ α)
   hom_inv_id := F'.hom_ext_of_isLeftKanExtension α _ _ (by simp)
-  inv_hom_id := F''.hom_ext_of_isLeftKanExtension α' _ _ (by simp)
+  inv_hom_id := G'.hom_ext_of_isLeftKanExtension β _ _ (by simp)
+
+/-- Two left Kan extensions are (canonically) isomorphic. -/
+@[simps!]
+noncomputable def leftKanExtensionUnique
+    (F'' : D ⥤ H) (α' : F ⟶ L ⋙ F'') [F''.IsLeftKanExtension α'] : F' ≅ F'' :=
+  leftKanExtensionUniqueOfIso F' α (Iso.refl _) F'' α'
 
 lemma isLeftKanExtension_iff_isIso {F' : D ⥤ H} {F'' : D ⥤ H} (φ : F' ⟶ F'')
     {L : C ⥤ D} {F : C ⥤ H} (α : F ⟶ L ⋙ F') (α' : F ⟶ L ⋙ F'')

--- a/Mathlib/CategoryTheory/Functor/KanExtension/Basic.lean
+++ b/Mathlib/CategoryTheory/Functor/KanExtension/Basic.lean
@@ -122,7 +122,7 @@ lemma isRightKanExtension_iff_of_iso {F' F'' : D ⥤ H} (e : F' ≅ F'') {L : C 
     refine isRightKanExtension_of_iso e.symm α' α ?_
     rw [← comm, ← whiskerLeft_comp_assoc, Iso.symm_hom, e.inv_hom_id, whiskerLeft_id', id_comp]
 
-/-- Left Kan extensions of isomorphic functors are isomorphic. -/
+/-- Right Kan extensions of isomorphic functors are isomorphic. -/
 @[simps]
 noncomputable def rightKanExtensionUniqueOfIso {G : C ⥤ H} (i : F ≅ G) (G' : D ⥤ H)
     (β : L ⋙ G' ⟶ G) [G'.IsRightKanExtension β] : F' ≅ G' where

--- a/Mathlib/CategoryTheory/Limits/Presheaf.lean
+++ b/Mathlib/CategoryTheory/Limits/Presheaf.lean
@@ -375,8 +375,7 @@ noncomputable def compYonedaIsoYonedaCompLan :
       rw [yonedaMap_app_apply] at eq₁
       simp only [yonedaMap_app_apply, Functor.map_id] at eq₂
       simp only [id_comp] at eq₃
-      dsimp [yonedaEquiv]
-      rw [id_comp, eq₁, eq₂, eq₃])
+      simp [yonedaEquiv, eq₁, eq₂, eq₃])
 
 @[simp]
 lemma compYonedaIsoYonedaCompLan_inv_app_app_apply_eq_id (X : C) :


### PR DESCRIPTION
Kan extensions of isomorphic functors are isomorphic

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
