### PR TITLE
[Merged by Bors] - feat(Combinatorics/SimpleGraph): If a graph has a Walk starting and ending in the same vertex then the chromatic number is grater than two

### DIFF
--- a/Mathlib/Combinatorics/SimpleGraph/ConcreteColorings.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/ConcreteColorings.lean
@@ -5,6 +5,7 @@ Authors: Iván Renison
 -/
 import Mathlib.Combinatorics.SimpleGraph.Coloring
 import Mathlib.Combinatorics.SimpleGraph.Hasse
+import Mathlib.Logic.Equiv.Fin
 
 /-!
 # Concrete colorings of common graphs
@@ -63,5 +64,14 @@ theorem Coloring.odd_length_iff_not_congr {α} {G : SimpleGraph α}
     Odd p.length ↔ (¬c u ↔ c v) := by
   rw [Nat.odd_iff_not_even, c.even_length_iff_congr p]
   tauto
+
+theorem Walk.two_le_chromaticNumber_of_odd_self {α} {G : SimpleGraph α} {u : α} (p : G.Walk u u)
+    (hOdd : Odd p.length) : 2 < G.chromaticNumber := Classical.by_contradiction <| by
+  intro h
+  simp only [not_lt] at h
+  let c : G.Coloring (Fin 2) := (chromaticNumber_le_iff_colorable.mp h).some
+  let c' : G.Coloring Bool := recolorOfEquiv G finTwoEquiv c
+  have : ¬c' u ↔ c' u := (c'.odd_length_iff_not_congr p).mp hOdd
+  simp_all
 
 end SimpleGraph

--- a/Mathlib/Combinatorics/SimpleGraph/ConcreteColorings.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/ConcreteColorings.lean
@@ -65,11 +65,11 @@ theorem Coloring.odd_length_iff_not_congr {α} {G : SimpleGraph α}
   rw [Nat.odd_iff_not_even, c.even_length_iff_congr p]
   tauto
 
-theorem Walk.two_le_chromaticNumber_of_odd_loop {α} {G : SimpleGraph α} {u : α} (p : G.Walk u u)
-    (hOdd : Odd p.length) : 2 < G.chromaticNumber := Classical.by_contradiction <| by
+theorem Walk.three_le_chromaticNumber_of_odd_loop {α} {G : SimpleGraph α} {u : α} (p : G.Walk u u)
+    (hOdd : Odd p.length) : 3 ≤ G.chromaticNumber := Classical.by_contradiction <| by
   intro h
-  simp only [not_lt] at h
-  let c : G.Coloring (Fin 2) := (chromaticNumber_le_iff_colorable.mp h).some
+  have h' : G.chromaticNumber ≤ 2 := ENat.le_of_lt_add_one <| not_le.mp h
+  let c : G.Coloring (Fin 2) := (chromaticNumber_le_iff_colorable.mp h').some
   let c' : G.Coloring Bool := recolorOfEquiv G finTwoEquiv c
   have : ¬c' u ↔ c' u := (c'.odd_length_iff_not_congr p).mp hOdd
   simp_all

--- a/Mathlib/Combinatorics/SimpleGraph/ConcreteColorings.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/ConcreteColorings.lean
@@ -65,7 +65,7 @@ theorem Coloring.odd_length_iff_not_congr {α} {G : SimpleGraph α}
   rw [Nat.odd_iff_not_even, c.even_length_iff_congr p]
   tauto
 
-theorem Walk.two_lt_chromaticNumber_of_odd_closed {α} {G : SimpleGraph α} {u : α} (p : G.Walk u u)
+theorem Walk.two_le_chromaticNumber_of_odd_loop {α} {G : SimpleGraph α} {u : α} (p : G.Walk u u)
     (hOdd : Odd p.length) : 2 < G.chromaticNumber := Classical.by_contradiction <| by
   intro h
   simp only [not_lt] at h

--- a/Mathlib/Combinatorics/SimpleGraph/ConcreteColorings.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/ConcreteColorings.lean
@@ -65,7 +65,7 @@ theorem Coloring.odd_length_iff_not_congr {α} {G : SimpleGraph α}
   rw [Nat.odd_iff_not_even, c.even_length_iff_congr p]
   tauto
 
-theorem Walk.two_le_chromaticNumber_of_odd_self {α} {G : SimpleGraph α} {u : α} (p : G.Walk u u)
+theorem Walk.two_lt_chromaticNumber_of_odd_closed {α} {G : SimpleGraph α} {u : α} (p : G.Walk u u)
     (hOdd : Odd p.length) : 2 < G.chromaticNumber := Classical.by_contradiction <| by
   intro h
   simp only [not_lt] at h


### PR DESCRIPTION
---
The theorem is named `Walk.three_le_chromaticNumber_of_odd_loop`, but I'm not sure if that is the best name. I didn't use the word cycle because in `Connectivity.lean` a cycle is defined as a `Walk` that start and ends in the same vertex and has no other repeated vertex, so it's not what I'm using here.
Zulip discussion about the name: https://leanprover.zulipchat.com/#narrow/stream/252551-graph-theory
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
