### PR TITLE
[Merged by Bors] - chore(Probability/Kernel) Fix typo in `kernel.prod_const`

### DIFF
--- a/Mathlib/Probability/Kernel/Composition.lean
+++ b/Mathlib/Probability/Kernel/Composition.lean
@@ -1149,7 +1149,7 @@ lemma prod_apply (κ : kernel α β) [IsSFiniteKernel κ] (η : kernel α γ) [I
   rw [prod_apply' _ _ _ hs, Measure.prod_apply hs]
   rfl
 
-lemma prod_const (μ : Measure α) [SFinite μ] (ν : Measure β) [SFinite ν] :
+lemma prod_const (μ : Measure β) [SFinite μ] (ν : Measure γ) [SFinite ν] :
     const α μ ×ₖ const α ν = const α (μ.prod ν) := by
   ext x
   rw [const_apply, prod_apply, const_apply, const_apply]


### PR DESCRIPTION
Generalize to where the measure μ doesn't need to be on the space α. I assume this was just a typo.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
