### PR TITLE
[Merged by Bors] - feat(ContinuousFunctionalCalculus): When `cfc` is applied to a function that maps zero to zero, it is equal to `cfcₙ`

### DIFF
--- a/Mathlib/Topology/ContinuousFunction/NonUnitalFunctionalCalculus.lean
+++ b/Mathlib/Topology/ContinuousFunction/NonUnitalFunctionalCalculus.lean
@@ -667,10 +667,10 @@ instance ContinuousFunctionalCalculus.toNonUnital : NonUnitalContinuousFunctiona
   predicate_zero := cfc_predicate_zero R
   exists_cfc_of_predicate _ ha :=
     ⟨cfcₙHom_of_cfcHom R ha,
-            closedEmbedding_cfcₙHom_of_cfcHom ha,
-            cfcHom_id ha,
-            cfcₙHom_of_cfcHom_map_quasispectrum ha,
-            fun _ ↦ cfcHom_predicate ha _⟩
+      closedEmbedding_cfcₙHom_of_cfcHom ha,
+      cfcHom_id ha,
+      cfcₙHom_of_cfcHom_map_quasispectrum ha,
+      fun _ ↦ cfcHom_predicate ha _⟩
 
 lemma cfcₙHom_eq_cfcₙHom_of_cfcHom [UniqueNonUnitalContinuousFunctionalCalculus R A] {a : A}
     (ha : p a) : cfcₙHom (R := R) ha = cfcₙHom_of_cfcHom R ha := by

--- a/Mathlib/Topology/ContinuousFunction/NonUnitalFunctionalCalculus.lean
+++ b/Mathlib/Topology/ContinuousFunction/NonUnitalFunctionalCalculus.lean
@@ -691,10 +691,10 @@ lemma cfcₙ_eq_cfc [UniqueNonUnitalContinuousFunctionalCalculus R A] {f : R →
     (hf : ContinuousOn f (σₙ R a) := by cfc_cont_tac) (hf0 : f 0 = 0 := by cfc_zero_tac) :
     cfcₙ f a = cfc f a := by
   by_cases ha : p a
-  · have hf' : ContinuousOn f (spectrum R a) :=
-      ContinuousOn.mono hf <| spectrum_subset_quasispectrum R a
+  · have hf' := hf.mono <| spectrum_subset_quasispectrum R a
     rw [cfc_apply f a ha hf', cfcₙ_apply f a hf, cfcₙHom_eq_cfcₙHom_of_cfcHom, cfcₙHom_of_cfcHom]
-    dsimp
+    dsimp only [NonUnitalStarAlgHom.comp_apply, toContinuousMapHom_apply,
+      NonUnitalStarAlgHom.coe_coe, compStarAlgHom'_apply]
     congr
   · simp [cfc_apply_of_not_predicate a ha, cfcₙ_apply_of_not_predicate (R := R) a ha]
 

--- a/Mathlib/Topology/ContinuousFunction/NonUnitalFunctionalCalculus.lean
+++ b/Mathlib/Topology/ContinuousFunction/NonUnitalFunctionalCalculus.lean
@@ -600,57 +600,68 @@ variable [TopologicalRing R] [ContinuousStar R] [Ring A] [StarRing A] [Topologic
 variable [Algebra R A] [ContinuousFunctionalCalculus R p]
 variable [h_cpct : ∀ a : A, CompactSpace (spectrum R a)]
 
+variable (R) in
+noncomputable def cfcₙHom_of_cfcHom {a : A} (ha : p a) : C(σₙ R a, R)₀ →⋆ₙₐ[R] A :=
+  let e := ContinuousMapZero.toContinuousMapHom (X := quasispectrum R a) (R := R)
+  let f : C(spectrum R a, quasispectrum R a) :=
+    ⟨_, continuous_inclusion <| spectrum_subset_quasispectrum R a⟩
+  let ψ := ContinuousMap.compStarAlgHom' R R f
+  (cfcHom ha (R := R) : C(spectrum R a, R) →⋆ₙₐ[R] A).comp <|
+    (ψ : C(quasispectrum R a, R) →⋆ₙₐ[R] C(spectrum R a, R)).comp e
+
+lemma closedEmbedding_cfcₙHom_of_cfcHom {a : A} (ha : p a) :
+    ClosedEmbedding (cfcₙHom_of_cfcHom R ha) := by
+  let f : C(spectrum R a, quasispectrum R a) :=
+    ⟨_, continuous_inclusion <| spectrum_subset_quasispectrum R a⟩
+  have h_cpct' : CompactSpace (quasispectrum R a) := by
+    specialize h_cpct a
+    simp_rw [← isCompact_iff_compactSpace, quasispectrum_eq_spectrum_union_zero] at h_cpct ⊢
+    exact h_cpct.union isCompact_singleton
+  refine (cfcHom_closedEmbedding ha).comp <|
+    (UniformInducing.uniformEmbedding ⟨?_⟩).toClosedEmbedding
+  have := uniformSpace_eq_inf_precomp_of_cover (β := R) f (0 : C(Unit, σₙ R a))
+    (map_continuous f).isProperMap (map_continuous 0).isProperMap <| by
+      simp only [← Subtype.val_injective.image_injective.eq_iff, f, ContinuousMap.coe_mk,
+        ContinuousMap.coe_zero, range_zero, image_union, image_singleton,
+        quasispectrum.coe_zero, ← range_comp, val_comp_inclusion, image_univ, Subtype.range_coe,
+        quasispectrum_eq_spectrum_union_zero]
+  simp_rw [ContinuousMapZero.instUniformSpace, this, uniformity_comap,
+    @inf_uniformity _ (.comap _ _) (.comap _ _), uniformity_comap, Filter.comap_inf,
+    Filter.comap_comap]
+  refine .symm <| inf_eq_left.mpr <| le_top.trans <| eq_top_iff.mp ?_
+  have : ∀ U ∈ 𝓤 (C(Unit, R)), (0, 0) ∈ U := fun U hU ↦ refl_mem_uniformity hU
+  convert Filter.comap_const_of_mem this with ⟨u, v⟩ <;>
+  ext ⟨x, rfl⟩ <;> [exact map_zero u; exact map_zero v]
+
+lemma cfcₙHom_of_cfcHom_map_quasispectrum {a : A} (ha : p a) :
+    ∀ f : C(σₙ R a, R)₀, σₙ R (cfcₙHom_of_cfcHom R ha f) = range f := by
+  intro f
+  simp only [cfcₙHom_of_cfcHom]
+  rw [quasispectrum_eq_spectrum_union_zero]
+  simp only [NonUnitalStarAlgHom.comp_assoc, NonUnitalStarAlgHom.comp_apply,
+    NonUnitalStarAlgHom.coe_coe]
+  rw [cfcHom_map_spectrum ha]
+  ext x
+  constructor
+  · rintro (⟨x, rfl⟩ | rfl)
+    · exact ⟨⟨x.1, spectrum_subset_quasispectrum R a x.2⟩, rfl⟩
+    · exact ⟨0, map_zero f⟩
+  · rintro ⟨x, rfl⟩
+    have hx := x.2
+    simp_rw [quasispectrum_eq_spectrum_union_zero R a] at hx
+    obtain (hx | hx) := hx
+    · exact Or.inl ⟨⟨x.1, hx⟩, rfl⟩
+    · apply Or.inr
+      simp only [Set.mem_singleton_iff] at hx ⊢
+      rw [show x = 0 from Subtype.val_injective hx, map_zero]
+
 instance ContinuousFunctionalCalculus.toNonUnital : NonUnitalContinuousFunctionalCalculus R p where
   predicate_zero := cfc_predicate_zero R
-  exists_cfc_of_predicate a ha := by
-    have h_cpct' : CompactSpace (quasispectrum R a) := by
-      specialize h_cpct a
-      simp_rw [← isCompact_iff_compactSpace, quasispectrum_eq_spectrum_union_zero] at h_cpct ⊢
-      exact h_cpct.union isCompact_singleton
-    let e := ContinuousMapZero.toContinuousMapHom (X := quasispectrum R a) (R := R)
-    let f : C(spectrum R a, quasispectrum R a) :=
-      ⟨_, continuous_inclusion <| spectrum_subset_quasispectrum R a⟩
-    let ψ := ContinuousMap.compStarAlgHom' R R f
-    let ψ' := (cfcHom ha (R := R) : C(spectrum R a, R) →⋆ₙₐ[R] A).comp <|
-      (ψ : C(quasispectrum R a, R) →⋆ₙₐ[R] C(spectrum R a, R)).comp e
-    refine ⟨ψ', ?closedEmbedding, ?map_id, ?map_spectrum, ?predicate⟩
-    case closedEmbedding =>
-      refine (cfcHom_closedEmbedding ha).comp <|
-        (UniformInducing.uniformEmbedding ⟨?_⟩).toClosedEmbedding
-      have := uniformSpace_eq_inf_precomp_of_cover (β := R) f (0 : C(Unit, σₙ R a))
-        (map_continuous f).isProperMap (map_continuous 0).isProperMap <| by
-          simp only [← Subtype.val_injective.image_injective.eq_iff, f, ContinuousMap.coe_mk,
-            ContinuousMap.coe_zero, range_zero, image_union, image_singleton,
-            quasispectrum.coe_zero, ← range_comp, val_comp_inclusion, image_univ, Subtype.range_coe,
-            quasispectrum_eq_spectrum_union_zero]
-      simp_rw [ContinuousMapZero.instUniformSpace, this, uniformity_comap,
-        @inf_uniformity _ (.comap _ _) (.comap _ _), uniformity_comap, Filter.comap_inf,
-        Filter.comap_comap]
-      refine .symm <| inf_eq_left.mpr <| le_top.trans <| eq_top_iff.mp ?_
-      have : ∀ U ∈ 𝓤 (C(Unit, R)), (0, 0) ∈ U := fun U hU ↦ refl_mem_uniformity hU
-      convert Filter.comap_const_of_mem this with ⟨u, v⟩ <;>
-      ext ⟨x, rfl⟩ <;> [exact map_zero u; exact map_zero v]
-    case map_id => exact cfcHom_id ha
-    case map_spectrum =>
-      intro f
-      simp only [ψ']
-      rw [quasispectrum_eq_spectrum_union_zero]
-      simp only [NonUnitalStarAlgHom.comp_assoc, NonUnitalStarAlgHom.comp_apply,
-        NonUnitalStarAlgHom.coe_coe]
-      rw [cfcHom_map_spectrum ha]
-      ext x
-      constructor
-      · rintro (⟨x, rfl⟩ | rfl)
-        · exact ⟨⟨x.1, spectrum_subset_quasispectrum R a x.2⟩, rfl⟩
-        · exact ⟨0, map_zero f⟩
-      · rintro ⟨x, rfl⟩
-        have hx := x.2
-        simp_rw [quasispectrum_eq_spectrum_union_zero R a] at hx
-        obtain (hx | hx) := hx
-        · exact Or.inl ⟨⟨x.1, hx⟩, rfl⟩
-        · apply Or.inr
-          simp only [Set.mem_singleton_iff] at hx ⊢
-          rw [show x = 0 from Subtype.val_injective hx, map_zero]
-    case predicate => exact fun f ↦ cfcHom_predicate ha _
+  exists_cfc_of_predicate _ ha :=
+    ⟨cfcₙHom_of_cfcHom R ha,
+            closedEmbedding_cfcₙHom_of_cfcHom ha,
+            cfcHom_id ha,
+            cfcₙHom_of_cfcHom_map_quasispectrum ha,
+            fun _ ↦ cfcHom_predicate ha _⟩
 
 end UnitalToNonUnital

--- a/Mathlib/Topology/ContinuousFunction/NonUnitalFunctionalCalculus.lean
+++ b/Mathlib/Topology/ContinuousFunction/NonUnitalFunctionalCalculus.lean
@@ -602,18 +602,23 @@ variable [h_cpct : ∀ a : A, CompactSpace (spectrum R a)]
 
 variable (R) in
 noncomputable def cfcₙHom_of_cfcHom {a : A} (ha : p a) : C(σₙ R a, R)₀ →⋆ₙₐ[R] A :=
-  let e := ContinuousMapZero.toContinuousMapHom (X := quasispectrum R a) (R := R)
+  let e := ContinuousMapZero.toContinuousMapHom (X := σₙ R a) (R := R)
   let f : C(spectrum R a, quasispectrum R a) :=
     ⟨_, continuous_inclusion <| spectrum_subset_quasispectrum R a⟩
   let ψ := ContinuousMap.compStarAlgHom' R R f
   (cfcHom ha (R := R) : C(spectrum R a, R) →⋆ₙₐ[R] A).comp <|
-    (ψ : C(quasispectrum R a, R) →⋆ₙₐ[R] C(spectrum R a, R)).comp e
+    (ψ : C(σₙ R a, R) →⋆ₙₐ[R] C(spectrum R a, R)).comp e
+
+lemma cfcₙHom_of_cfcHom_map_id {a : A} (ha : p a) :
+    cfcₙHom_of_cfcHom R ha (⟨.restrict (σₙ R a) <| .id R, by simp⟩) = a := by
+  simp [cfcₙHom_of_cfcHom]
+  sorry
 
 lemma closedEmbedding_cfcₙHom_of_cfcHom {a : A} (ha : p a) :
     ClosedEmbedding (cfcₙHom_of_cfcHom R ha) := by
-  let f : C(spectrum R a, quasispectrum R a) :=
+  let f : C(spectrum R a, σₙ R a) :=
     ⟨_, continuous_inclusion <| spectrum_subset_quasispectrum R a⟩
-  have h_cpct' : CompactSpace (quasispectrum R a) := by
+  have h_cpct' : CompactSpace (σₙ R a) := by
     specialize h_cpct a
     simp_rw [← isCompact_iff_compactSpace, quasispectrum_eq_spectrum_union_zero] at h_cpct ⊢
     exact h_cpct.union isCompact_singleton
@@ -663,5 +668,29 @@ instance ContinuousFunctionalCalculus.toNonUnital : NonUnitalContinuousFunctiona
             cfcHom_id ha,
             cfcₙHom_of_cfcHom_map_quasispectrum ha,
             fun _ ↦ cfcHom_predicate ha _⟩
+
+lemma cfcₙHom_eq_cfcₙHom_of_cfcHom [UniqueNonUnitalContinuousFunctionalCalculus R A] {a : A}
+    (ha : p a) : cfcₙHom (R := R) ha = cfcₙHom_of_cfcHom R ha := by
+  have h_cpct' : CompactSpace (σₙ R a) := by
+    specialize h_cpct a
+    simp_rw [← isCompact_iff_compactSpace, quasispectrum_eq_spectrum_union_zero] at h_cpct ⊢
+    exact h_cpct.union isCompact_singleton
+  refine UniqueNonUnitalContinuousFunctionalCalculus.eq_of_continuous_of_map_id
+      (σₙ R a) ?_ _ _ ?_ ?_ ?_
+  · simp
+  · exact (cfcₙHom_closedEmbedding (R := R) ha).continuous
+  · exact (closedEmbedding_cfcₙHom_of_cfcHom ha).continuous
+  · simp only [cfcₙHom_id, cfcₙHom_of_cfcHom_map_id]
+
+lemma cfcₙ_eq_cfc [UniqueNonUnitalContinuousFunctionalCalculus R A] {f : R → R} {a : A}
+    (hf : ContinuousOn f (σₙ R a) := by cfc_cont_tac) (hf0 : f 0 = 0 := by cfc_zero_tac) :
+    cfcₙ f a = cfc f a := by
+  by_cases ha : p a
+  · have hf' : ContinuousOn f (spectrum R a) :=
+      ContinuousOn.mono hf <| spectrum_subset_quasispectrum R a
+    rw [cfc_apply f a ha hf', cfcₙ_apply f a hf, cfcₙHom_eq_cfcₙHom_of_cfcHom, cfcₙHom_of_cfcHom]
+    dsimp
+    congr
+  · simp [cfc_apply_of_not_predicate a ha, cfcₙ_apply_of_not_predicate (R := R) a ha]
 
 end UnitalToNonUnital

--- a/Mathlib/Topology/ContinuousFunction/NonUnitalFunctionalCalculus.lean
+++ b/Mathlib/Topology/ContinuousFunction/NonUnitalFunctionalCalculus.lean
@@ -683,7 +683,7 @@ lemma cfcₙHom_eq_cfcₙHom_of_cfcHom [UniqueNonUnitalContinuousFunctionalCalcu
   · simp
   · exact (cfcₙHom_closedEmbedding (R := R) ha).continuous
   · exact (closedEmbedding_cfcₙHom_of_cfcHom ha).continuous
-  · simp only [cfcₙHom_id, cfcₙHom_of_cfcHom_map_id]
+  · simpa only [cfcₙHom_id (R := R) ha] using (cfcHom_id ha).symm
 
 /-- When `cfc` is applied to a function that maps zero to zero, it is equivalent to using
 `cfcₙ`. -/

--- a/Mathlib/Topology/ContinuousFunction/NonUnitalFunctionalCalculus.lean
+++ b/Mathlib/Topology/ContinuousFunction/NonUnitalFunctionalCalculus.lean
@@ -613,12 +613,6 @@ noncomputable def cfcₙHom_of_cfcHom {a : A} (ha : p a) : C(σₙ R a, R)₀ �
   (cfcHom ha (R := R) : C(spectrum R a, R) →⋆ₙₐ[R] A).comp <|
     (ψ : C(σₙ R a, R) →⋆ₙₐ[R] C(spectrum R a, R)).comp e
 
-lemma cfcₙHom_of_cfcHom_map_id {a : A} (ha : p a) :
-    cfcₙHom_of_cfcHom R ha (⟨.restrict (σₙ R a) <| .id R, by simp⟩) = a := by
-  simp only [cfcₙHom_of_cfcHom, NonUnitalStarAlgHom.comp_apply, toContinuousMapHom_apply,
-    NonUnitalStarAlgHom.coe_coe, compStarAlgHom'_apply]
-  exact cfcHom_id ha
-
 lemma closedEmbedding_cfcₙHom_of_cfcHom {a : A} (ha : p a) :
     ClosedEmbedding (cfcₙHom_of_cfcHom R ha) := by
   let f : C(spectrum R a, σₙ R a) :=

--- a/Mathlib/Topology/ContinuousFunction/NonUnitalFunctionalCalculus.lean
+++ b/Mathlib/Topology/ContinuousFunction/NonUnitalFunctionalCalculus.lean
@@ -601,6 +601,8 @@ variable [Algebra R A] [ContinuousFunctionalCalculus R p]
 variable [h_cpct : ∀ a : A, CompactSpace (spectrum R a)]
 
 variable (R) in
+/-- The non-unital functional calculus obtained by restricting a unital calculus to functions
+that map zero to zero. -/
 noncomputable def cfcₙHom_of_cfcHom {a : A} (ha : p a) : C(σₙ R a, R)₀ →⋆ₙₐ[R] A :=
   let e := ContinuousMapZero.toContinuousMapHom (X := σₙ R a) (R := R)
   let f : C(spectrum R a, quasispectrum R a) :=
@@ -611,8 +613,9 @@ noncomputable def cfcₙHom_of_cfcHom {a : A} (ha : p a) : C(σₙ R a, R)₀ �
 
 lemma cfcₙHom_of_cfcHom_map_id {a : A} (ha : p a) :
     cfcₙHom_of_cfcHom R ha (⟨.restrict (σₙ R a) <| .id R, by simp⟩) = a := by
-  simp [cfcₙHom_of_cfcHom]
-  sorry
+  simp only [cfcₙHom_of_cfcHom, NonUnitalStarAlgHom.comp_apply, toContinuousMapHom_apply,
+    NonUnitalStarAlgHom.coe_coe, compStarAlgHom'_apply]
+  exact cfcHom_id ha
 
 lemma closedEmbedding_cfcₙHom_of_cfcHom {a : A} (ha : p a) :
     ClosedEmbedding (cfcₙHom_of_cfcHom R ha) := by
@@ -682,6 +685,8 @@ lemma cfcₙHom_eq_cfcₙHom_of_cfcHom [UniqueNonUnitalContinuousFunctionalCalcu
   · exact (closedEmbedding_cfcₙHom_of_cfcHom ha).continuous
   · simp only [cfcₙHom_id, cfcₙHom_of_cfcHom_map_id]
 
+/-- When `cfc` is applied to a function that maps zero to zero, it is equivalent to using
+`cfcₙ`. -/
 lemma cfcₙ_eq_cfc [UniqueNonUnitalContinuousFunctionalCalculus R A] {f : R → R} {a : A}
     (hf : ContinuousOn f (σₙ R a) := by cfc_cont_tac) (hf0 : f 0 = 0 := by cfc_zero_tac) :
     cfcₙ f a = cfc f a := by

--- a/Mathlib/Topology/ContinuousFunction/NonUnitalFunctionalCalculus.lean
+++ b/Mathlib/Topology/ContinuousFunction/NonUnitalFunctionalCalculus.lean
@@ -601,8 +601,10 @@ variable [Algebra R A] [ContinuousFunctionalCalculus R p]
 variable [h_cpct : ∀ a : A, CompactSpace (spectrum R a)]
 
 variable (R) in
-/-- The non-unital functional calculus obtained by restricting a unital calculus to functions
-that map zero to zero. -/
+/-- The non-unital continuous functional calculus obtained by restricting a unital calculus
+to functions that map zero to zero. This is an auxiliary definition and is not
+intended for use outside this file. The equality between the non-unital and unital
+calculi in this case is encoded in the lemma `cfcₙ_eq_cfc`. -/
 noncomputable def cfcₙHom_of_cfcHom {a : A} (ha : p a) : C(σₙ R a, R)₀ →⋆ₙₐ[R] A :=
   let e := ContinuousMapZero.toContinuousMapHom (X := σₙ R a) (R := R)
   let f : C(spectrum R a, quasispectrum R a) :=


### PR DESCRIPTION
This PR shows that `cfcₙ f a = cfc f a` whenever `f` maps zero to zero (and the usual continuity conditions apply).

This required refactoring the proof that a unital CFC implies a non-unital one, since we need reuse the objects that were defined locally inside the proof.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
