### PR TITLE
feat(RingTheory/PowerSeries): two lemmas

### DIFF
--- a/Mathlib/RingTheory/PowerSeries/Basic.lean
+++ b/Mathlib/RingTheory/PowerSeries/Basic.lean
@@ -517,6 +517,20 @@ theorem eq_X_mul_shift_add_const (φ : R⟦X⟧) :
 set_option linter.uppercaseLean3 false in
 #align power_series.eq_X_mul_shift_add_const PowerSeries.eq_X_mul_shift_add_const
 
+@[simp]
+lemma constantCoeff_mul (φ ψ : R⟦X⟧) :
+    constantCoeff R (φ * ψ) = constantCoeff R φ * constantCoeff R ψ :=
+  RingHom.map_mul (constantCoeff R) φ ψ
+
+/-- For any `n`, the `n`-th power of a power series with constant coefficient 1
+    also has constant coefficient 1. -/
+@[simp]
+lemma constantCoeff_pow (n : ℕ) (φ : R⟦X⟧) (hC : constantCoeff R φ = 1) :
+    constantCoeff R (φ ^ n) = 1 := by
+  induction n
+  . exact rfl
+  . simp_all only [map_pow, one_pow]
+
 section Map
 
 variable {S : Type*} {T : Type*} [Semiring S] [Semiring T]

--- a/Mathlib/RingTheory/PowerSeries/Basic.lean
+++ b/Mathlib/RingTheory/PowerSeries/Basic.lean
@@ -528,8 +528,8 @@ lemma constantCoeff_mul (φ ψ : R⟦X⟧) :
 lemma constantCoeff_pow (n : ℕ) (φ : R⟦X⟧) (hC : constantCoeff R φ = 1) :
     constantCoeff R (φ ^ n) = 1 := by
   induction n
-  . exact rfl
-  . simp_all only [map_pow, one_pow]
+  · exact rfl
+  · simp_all only [map_pow, one_pow]
 
 section Map
 


### PR DESCRIPTION
Two missing elementary lemmas about the constant coefficient of products and powers of formal power series.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks, and is labeled with `awaiting-review`.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
