### PR TITLE
[Merged by Bors] - doc: add reassoc docstring

### DIFF
--- a/Mathlib/Tactic/CategoryTheory/Reassoc.lean
+++ b/Mathlib/Tactic/CategoryTheory/Reassoc.lean
@@ -12,9 +12,9 @@ import Mathlib.Lean.Meta.Simp
 
 Adding `@[reassoc]` to a lemma named `F` of shape `∀ .., f = g`,
 where `f g : X ⟶ Y` in some category
-will create a new lemmas named `F_assoc` of shape
+will create a new lemma named `F_assoc` of shape
 `∀ .. {Z : C} (h : Y ⟶ Z), f ≫ h = g ≫ h`
-but with the conclusions simplified used the axioms for a category
+but with the conclusions simplified using the axioms for a category
 (`Category.comp_id`, `Category.id_comp`, and `Category.assoc`).
 
 This is useful for generating lemmas which the simplifier can use even on expressions
@@ -48,7 +48,23 @@ but with compositions fully right associated and identities removed.
 def reassocExpr (e : Expr) : MetaM Expr := do
   mapForallTelescope (fun e => do simpType categorySimp (← mkAppM ``eq_whisker' #[e])) e
 
-/-- Syntax for the `reassoc` attribute -/
+/--
+Adding `@[reassoc]` to a lemma named `F` of shape `∀ .., f = g`, where `f g : X ⟶ Y` in some
+category, will create a new lemma named `F_assoc` of shape
+`∀ .. {Z : C} (h : Y ⟶ Z), f ≫ h = g ≫ h`
+but with the conclusions simplified using the axioms for a category
+(`Category.comp_id`, `Category.id_comp`, and `Category.assoc`).
+So, for example, if the conclusion of `F` is `a ≫ b = g` then
+the conclusion of `F_assoc` will be `a ≫ (b ≫ h) = g ≫ h` (note that `≫` reassociates
+to the right so the brackets will not appear in the statement).
+
+This attribute is useful for generating lemmas which the simplifier can use even on expressions
+that are already right associated.
+
+Note that if the lemma is a `simp` lemma, then probably the reassociated lemma should
+also be a `simp` lemma, and to ensure this you need to tag it `@[simp, reassoc]` with
+the tags in this order.
+-/
 syntax (name := reassoc) "reassoc" (" (" &"attr" ":=" Parser.Term.attrInstance,* ")")? : attr
 
 initialize registerBuiltinAttribute {

--- a/Mathlib/Tactic/CategoryTheory/Reassoc.lean
+++ b/Mathlib/Tactic/CategoryTheory/Reassoc.lean
@@ -63,7 +63,7 @@ that are already right associated.
 
 Note that if you want both the lemma and the reassociated lemma to be
 `simp` lemmas, you should tag the lemma `@[reassoc (attr := simp)]`.
-The variants `@[simp, reassoc]` and `@[reassoc, simp]` on a lemma `F` will tag `F` with `@[simp]`,
+The variant `@[simp, reassoc]` on a lemma `F` will tag `F` with `@[simp]`,
 but not `F_apply` (this is sometimes useful).
 -/
 syntax (name := reassoc) "reassoc" (" (" &"attr" ":=" Parser.Term.attrInstance,* ")")? : attr

--- a/Mathlib/Tactic/CategoryTheory/Reassoc.lean
+++ b/Mathlib/Tactic/CategoryTheory/Reassoc.lean
@@ -61,9 +61,8 @@ to the right so the brackets will not appear in the statement).
 This attribute is useful for generating lemmas which the simplifier can use even on expressions
 that are already right associated.
 
-Note that if the lemma is a `simp` lemma, then probably the reassociated lemma should
-also be a `simp` lemma, and to ensure this you need to tag it `@[simp, reassoc]` with
-the tags in this order.
+Note that if you want both the lemma and the reassociated lemma to be
+`simp` lemmas, you should tag the lemma `@[reassoc (attr := simp)]`.
 -/
 syntax (name := reassoc) "reassoc" (" (" &"attr" ":=" Parser.Term.attrInstance,* ")")? : attr
 

--- a/Mathlib/Tactic/CategoryTheory/Reassoc.lean
+++ b/Mathlib/Tactic/CategoryTheory/Reassoc.lean
@@ -49,8 +49,8 @@ def reassocExpr (e : Expr) : MetaM Expr := do
   mapForallTelescope (fun e => do simpType categorySimp (← mkAppM ``eq_whisker' #[e])) e
 
 /--
-Adding `@[reassoc]` to a lemma named `F` of shape `∀ .., f = g`, where `f g : X ⟶ Y` in some
-category, will create a new lemma named `F_assoc` of shape
+Adding `@[reassoc]` to a lemma named `F` of shape `∀ .., f = g`, where `f g : X ⟶ Y` are
+morphisms in some category, will create a new lemma named `F_assoc` of shape
 `∀ .. {Z : C} (h : Y ⟶ Z), f ≫ h = g ≫ h`
 but with the conclusions simplified using the axioms for a category
 (`Category.comp_id`, `Category.id_comp`, and `Category.assoc`).

--- a/Mathlib/Tactic/CategoryTheory/Reassoc.lean
+++ b/Mathlib/Tactic/CategoryTheory/Reassoc.lean
@@ -63,6 +63,8 @@ that are already right associated.
 
 Note that if you want both the lemma and the reassociated lemma to be
 `simp` lemmas, you should tag the lemma `@[reassoc (attr := simp)]`.
+The variants `@[simp, reassoc]` and `@[reassoc, simp]` on a lemma `F` will tag `F` with `@[simp]`,
+but not `F_apply` (this is sometimes useful).
 -/
 syntax (name := reassoc) "reassoc" (" (" &"attr" ":=" Parser.Term.attrInstance,* ")")? : attr
 


### PR DESCRIPTION
Add docstring for `@[reassoc]` attribute.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks, and is labeled with `awaiting-review`.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)

Note that, in contrast to when I'm adding maths docstrings, here I know far less about what I'm talking about (in particular I can't read the source code to verify that what I'm saying corresponds to what is written). I'm making this PR because of a general frustration about attributes not being documented properly. This PR makes the docstring added here appear when hovering over `@[reassoc]`. My sources are the [module docstring](https://leanprover-community.github.io/mathlib4_docs/Mathlib/Tactic/CategoryTheory/Reassoc.html) for the attribute, and the comment [here](https://leanprover.zulipchat.com/#narrow/stream/287929-mathlib4/topic/reassoc.20and.20simp/near/449310703) by Markus Himmel. I also fix a couple of typos in the module docstring.
