### PR TITLE
[Merged by Bors] - chore(CategoryTheory/Sites): saturate -> Saturate

### DIFF
--- a/Mathlib/CategoryTheory/Sites/Coherent/CoherentTopology.lean
+++ b/Mathlib/CategoryTheory/Sites/Coherent/CoherentTopology.lean
@@ -55,8 +55,8 @@ theorem EffectiveEpiFamily.transitive_of_finite {α : Type} [Finite α] {Y : α 
     exact fun W => coherentTopology.isSheaf_yoneda_obj W _ h₂
   -- Show that a covering sieve is a colimit, which implies the original set of arrows is regular
   -- epimorphic. We use the transitivity property of saturation
-  apply Coverage.saturate.transitive X (Sieve.generate (Presieve.ofArrows Y π))
-  · apply Coverage.saturate.of
+  apply Coverage.Saturate.transitive X (Sieve.generate (Presieve.ofArrows Y π))
+  · apply Coverage.Saturate.of
     use α, inferInstance, Y, π
   · intro V f ⟨Y₁, h, g, ⟨hY, hf⟩⟩
     rw [← hf, Sieve.pullback_comp]

--- a/Mathlib/CategoryTheory/Sites/Coherent/Comparison.lean
+++ b/Mathlib/CategoryTheory/Sites/Coherent/Comparison.lean
@@ -61,19 +61,19 @@ theorem extensive_regular_generate_coherent [Preregular C] [FinitaryPreExtensive
   refine ⟨fun h ↦ ?_, fun h ↦ ?_⟩
   · induction h with
     | of Y T hT =>
-      apply Coverage.saturate.of
+      apply Coverage.Saturate.of
       simp only [Coverage.sup_covering, Set.mem_union] at hT
       exact Or.elim hT
         (fun ⟨α, x, X, π, ⟨h, _⟩⟩ ↦ ⟨α, x, X, π, ⟨h, inferInstance⟩⟩)
         (fun ⟨Z, f, ⟨h, _⟩⟩ ↦ ⟨Unit, inferInstance, fun _ ↦ Z, fun _ ↦ f, ⟨h, inferInstance⟩⟩)
-    | top => apply Coverage.saturate.top
-    | transitive Y T => apply Coverage.saturate.transitive Y T<;> [assumption; assumption]
+    | top => apply Coverage.Saturate.top
+    | transitive Y T => apply Coverage.Saturate.transitive Y T<;> [assumption; assumption]
   · induction h with
     | of Y T hT =>
       obtain ⟨I, _, X, f, rfl, hT⟩ := hT
-      apply Coverage.saturate.transitive Y (generate (Presieve.ofArrows
+      apply Coverage.Saturate.transitive Y (generate (Presieve.ofArrows
         (fun (_ : Unit) ↦ (∐ fun (i : I) => X i)) (fun (_ : Unit) ↦ Sigma.desc f)))
-      · apply Coverage.saturate.of
+      · apply Coverage.Saturate.of
         simp only [Coverage.sup_covering, extensiveCoverage, regularCoverage, Set.mem_union,
           Set.mem_setOf_eq]
         exact Or.inr ⟨_, Sigma.desc f, ⟨rfl, inferInstance⟩⟩
@@ -86,9 +86,9 @@ theorem extensive_regular_generate_coherent [Preregular C] [FinitaryPreExtensive
           rintro Q q ⟨E, e, r, ⟨hq, rfl⟩⟩
           exact ⟨E, e, r ≫ (Sigma.desc f), by cases hq; simpa using Presieve.ofArrows.mk _, by simp⟩
         apply Coverage.saturate_of_superset _ this
-        apply Coverage.saturate.of
+        apply Coverage.Saturate.of
         refine Or.inl ⟨I, inferInstance, _, _, ⟨rfl, ?_⟩⟩
         convert IsIso.id _
         aesop
-    | top => apply Coverage.saturate.top
-    | transitive Y T => apply Coverage.saturate.transitive Y T<;> [assumption; assumption]
+    | top => apply Coverage.Saturate.top
+    | transitive Y T => apply Coverage.Saturate.transitive Y T<;> [assumption; assumption]

--- a/Mathlib/CategoryTheory/Sites/Coherent/RegularTopology.lean
+++ b/Mathlib/CategoryTheory/Sites/Coherent/RegularTopology.lean
@@ -38,7 +38,7 @@ theorem mem_sieves_of_hasEffectiveEpi (S : Sieve X) :
     cases f
     exact ⟨π, ⟨h.2, Category.id_comp π⟩⟩
   apply Coverage.saturate_of_superset (regularCoverage C) h_le
-  exact Coverage.saturate.of X _ ⟨Y, π, rfl, h.1⟩
+  exact Coverage.Saturate.of X _ ⟨Y, π, rfl, h.1⟩
 
 /-- Effective epis in a preregular category are stable under composition. -/
 instance {Y Y' : C} (π : Y ⟶ X) [EffectiveEpi π]
@@ -49,9 +49,9 @@ instance {Y Y' : C} (π : Y ⟶ X) [EffectiveEpi π]
     change Nonempty _
     rw [← Sieve.forallYonedaIsSheaf_iff_colimit]
     exact fun W => regularTopology.isSheaf_yoneda_obj W _ h₂
-  apply Coverage.saturate.transitive X (Sieve.generate (Presieve.ofArrows (fun () ↦ Y)
+  apply Coverage.Saturate.transitive X (Sieve.generate (Presieve.ofArrows (fun () ↦ Y)
       (fun () ↦ π)))
-  · apply Coverage.saturate.of
+  · apply Coverage.Saturate.of
     use Y, π
   · intro V f ⟨Y₁, h, g, ⟨hY, hf⟩⟩
     rw [← hf, Sieve.pullback_comp]

--- a/Mathlib/CategoryTheory/Sites/Coherent/SheafComparison.lean
+++ b/Mathlib/CategoryTheory/Sites/Coherent/SheafComparison.lean
@@ -42,7 +42,7 @@ variable [F.PreservesFiniteEffectiveEpiFamilies] [F.ReflectsFiniteEffectiveEpiFa
 
 instance : F.IsCoverDense (coherentTopology _) := by
   refine F.isCoverDense_of_generate_singleton_functor_π_mem _ fun B ↦ ⟨_, F.effectiveEpiOver B, ?_⟩
-  apply Coverage.saturate.of
+  apply Coverage.Saturate.of
   refine ⟨Unit, inferInstance, fun _ => F.effectiveEpiOverObj B,
     fun _ => F.effectiveEpiOver B, ?_ , ?_⟩
   · funext; ext -- Do we want `Presieve.ext`?
@@ -151,7 +151,7 @@ variable [F.PreservesEffectiveEpis] [F.ReflectsEffectiveEpis] [F.Full] [F.Faithf
 
 instance : F.IsCoverDense (regularTopology _) := by
   refine F.isCoverDense_of_generate_singleton_functor_π_mem _ fun B ↦ ⟨_, F.effectiveEpiOver B, ?_⟩
-  apply Coverage.saturate.of
+  apply Coverage.Saturate.of
   refine ⟨F.effectiveEpiOverObj B, F.effectiveEpiOver B, ?_, inferInstance⟩
   funext; ext -- Do we want `Presieve.ext`?
   refine ⟨fun ⟨⟩ ↦ ⟨()⟩, ?_⟩

--- a/Mathlib/CategoryTheory/Sites/Coverage.lean
+++ b/Mathlib/CategoryTheory/Sites/Coverage.lean
@@ -178,13 +178,13 @@ lemma ofGrothendieck_iff {X : C} {S : Presieve X} (J : GrothendieckTopology C) :
 An auxiliary definition used to define the Grothendieck topology associated to a
 coverage. See `Coverage.toGrothendieck`.
 -/
-inductive saturate (K : Coverage C) : (X : C) → Sieve X → Prop where
-  | of (X : C) (S : Presieve X) (hS : S ∈ K X) : saturate K X (Sieve.generate S)
-  | top (X : C) : saturate K X ⊤
+inductive Saturate (K : Coverage C) : (X : C) → Sieve X → Prop where
+  | of (X : C) (S : Presieve X) (hS : S ∈ K X) : Saturate K X (Sieve.generate S)
+  | top (X : C) : Saturate K X ⊤
   | transitive (X : C) (R S : Sieve X) :
-    saturate K X R →
-    (∀ ⦃Y : C⦄ ⦃f : Y ⟶ X⦄, R f → saturate K Y (S.pullback f)) →
-    saturate K X S
+    Saturate K X R →
+    (∀ ⦃Y : C⦄ ⦃f : Y ⟶ X⦄, R f → Saturate K Y (S.pullback f)) →
+    Saturate K X S
 
 lemma eq_top_pullback {X Y : C} {S T : Sieve X} (h : S ≤ T) (f : Y ⟶ X) (hf : S f) :
     T.pullback f = ⊤ := by
@@ -195,11 +195,11 @@ lemma eq_top_pullback {X Y : C} {S T : Sieve X} (h : S ≤ T) (f : Y ⟶ X) (hf 
   exact hf
 
 lemma saturate_of_superset (K : Coverage C) {X : C} {S T : Sieve X} (h : S ≤ T)
-    (hS : saturate K X S) : saturate K X T := by
-  apply saturate.transitive _ _ _ hS
+    (hS : Saturate K X S) : Saturate K X T := by
+  apply Saturate.transitive _ _ _ hS
   intro Y g hg
   rw [eq_top_pullback (h := h)]
-  · apply saturate.top
+  · apply Saturate.top
   · assumption
 
 variable (C) in
@@ -216,7 +216,7 @@ associated Grothendieck topology is pullback stable, and so an additional constr
 in the inductive construction is not needed.
 -/
 def toGrothendieck (K : Coverage C) : GrothendieckTopology C where
-  sieves := saturate K
+  sieves := Saturate K
   top_mem' := .top
   pullback_stable' := by
     intro X Y S f hS
@@ -224,14 +224,14 @@ def toGrothendieck (K : Coverage C) : GrothendieckTopology C where
     | of X S hS =>
       obtain ⟨R,hR1,hR2⟩ := K.pullback f S hS
       suffices Sieve.generate R ≤ (Sieve.generate S).pullback f from
-        saturate_of_superset _ this (saturate.of _ _ hR1)
+        saturate_of_superset _ this (Saturate.of _ _ hR1)
       rintro Z g ⟨W, i, e, h1, h2⟩
       obtain ⟨WW, ii, ee, hh1, hh2⟩ := hR2 h1
       refine ⟨WW, i ≫ ii, ee, hh1, ?_⟩
       simp only [hh2, reassoc_of% h2, Category.assoc]
-    | top X => apply saturate.top
+    | top X => apply Saturate.top
     | transitive X R S _ hS H1 _ =>
-      apply saturate.transitive
+      apply Saturate.transitive
       · apply H1 f
       intro Z g hg
       rw [← Sieve.pullback_comp]
@@ -255,13 +255,13 @@ def gi : GaloisInsertion (toGrothendieck C) (ofGrothendieck C) where
   choice_eq := fun _ _ => rfl
   le_l_u J X S hS := by
     rw [← Sieve.generate_sieve S]
-    apply saturate.of
+    apply Saturate.of
     dsimp [ofGrothendieck]
     rwa [Sieve.generate_sieve S]
   gc K J := by
     constructor
     · intro H X S hS
-      exact H _ <| saturate.of _ _ hS
+      exact H _ <| Saturate.of _ _ hS
     · intro H X S hS
       induction hS with
       | of X S hS => exact H _ hS
@@ -283,7 +283,7 @@ theorem toGrothendieck_eq_sInf (K : Coverage C) : toGrothendieck _ K =
     | transitive X R S _ _ H1 H2 => exact J.transitive H1 _ H2
   · apply sInf_le
     intro X S hS
-    apply saturate.of _ _ hS
+    apply Saturate.of _ _ hS
 
 instance : SemilatticeSup (Coverage C) where
   sup x y :=
@@ -310,7 +310,7 @@ Grothendieck topology.
 -/
 theorem mem_toGrothendieck_sieves_of_superset (K : Coverage C) {X : C} {S : Sieve X}
     {R : Presieve X} (h : R ≤ S) (hR : R ∈ K.covering X) : S ∈ (K.toGrothendieck C).sieves X :=
-  K.saturate_of_superset ((Sieve.sets_iff_generate _ _).mpr h) (Coverage.saturate.of X _ hR)
+  K.saturate_of_superset ((Sieve.sets_iff_generate _ _).mpr h) (Coverage.Saturate.of X _ hR)
 
 end Coverage
 
@@ -329,7 +329,7 @@ theorem isSheaf_coverage (K : Coverage C) (P : Cᵒᵖ ⥤ Type*) :
   constructor
   · intro H X R hR
     rw [Presieve.isSheafFor_iff_generate]
-    apply H _ <| saturate.of _ _ hR
+    apply H _ <| Saturate.of _ _ hR
   · intro H X S hS
     -- This is the key point of the proof:
     -- We must generalize the induction in the correct way.


### PR DESCRIPTION
The old name didn't follow the naming convention, since it's a function taking values in `Prop`

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks, and is labeled with `awaiting-review`.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
