### PR TITLE
[Merged by Bors] - chore (Algebra.PUnitInstances): split file into `Algebra`, `Order`, and `Module` instance files 

### DIFF
--- a/Counterexamples/CharPZeroNeCharZero.lean
+++ b/Counterexamples/CharPZeroNeCharZero.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Damiano Testa, Eric Wieser
 -/
 import Mathlib.Algebra.CharP.Basic
-import Mathlib.Algebra.PUnitInstances
+import Mathlib.Algebra.PUnitInstances.Algebra
 
 #align_import char_p_zero_ne_char_zero from "leanprover-community/mathlib"@"328375597f2c0dd00522d9c2e5a33b6a6128feeb"
 

--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -618,7 +618,9 @@ import Mathlib.Algebra.Order.ToIntervalMod
 import Mathlib.Algebra.Order.UpperLower
 import Mathlib.Algebra.Order.ZeroLEOne
 import Mathlib.Algebra.PEmptyInstances
-import Mathlib.Algebra.PUnitInstances
+import Mathlib.Algebra.PUnitInstances.Algebra
+import Mathlib.Algebra.PUnitInstances.Module
+import Mathlib.Algebra.PUnitInstances.Order
 import Mathlib.Algebra.Periodic
 import Mathlib.Algebra.Pointwise.Stabilizer
 import Mathlib.Algebra.Polynomial.AlgebraMap

--- a/Mathlib/Algebra/Category/Grp/Basic.lean
+++ b/Mathlib/Algebra/Category/Grp/Basic.lean
@@ -6,6 +6,7 @@ Authors: Johan Commelin
 import Mathlib.Algebra.Category.MonCat.Basic
 import Mathlib.Algebra.Group.ULift
 import Mathlib.CategoryTheory.Endomorphism
+import Mathlib.Data.Int.Cast.Lemmas
 import Mathlib.GroupTheory.Perm.Basic
 
 #align_import algebra.category.Group.basic from "leanprover-community/mathlib"@"524793de15bc4c52ee32d254e7d7867c7176b3af"

--- a/Mathlib/Algebra/Category/ModuleCat/Basic.lean
+++ b/Mathlib/Algebra/Category/ModuleCat/Basic.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Robert A. Spencer, Markus Himmel
 -/
 import Mathlib.Algebra.Category.Grp.Preadditive
+import Mathlib.Algebra.PUnitInstances.Module
 import Mathlib.CategoryTheory.Conj
 import Mathlib.CategoryTheory.Linear.Basic
 import Mathlib.CategoryTheory.Preadditive.AdditiveFunctor

--- a/Mathlib/Algebra/Category/MonCat/Basic.lean
+++ b/Mathlib/Algebra/Category/MonCat/Basic.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Scott Morrison
 -/
 import Mathlib.CategoryTheory.ConcreteCategory.BundledHom
-import Mathlib.Algebra.PUnitInstances
+import Mathlib.Algebra.PUnitInstances.Algebra
 import Mathlib.Algebra.Group.ULift
 import Mathlib.CategoryTheory.Functor.ReflectsIso
 import Mathlib.Algebra.Ring.Action.Group

--- a/Mathlib/Algebra/Module/Submodule/Lattice.lean
+++ b/Mathlib/Algebra/Module/Submodule/Lattice.lean
@@ -5,7 +5,7 @@ Authors: Johannes Hölzl, Mario Carneiro, Kevin Buzzard, Yury Kudryashov
 -/
 import Mathlib.Algebra.Module.Equiv
 import Mathlib.Algebra.Module.Submodule.Basic
-import Mathlib.Algebra.PUnitInstances
+import Mathlib.Algebra.PUnitInstances.Module
 import Mathlib.Data.Set.Subsingleton
 import Mathlib.Order.ConditionallyCompleteLattice.Basic
 

--- a/Mathlib/Algebra/PUnitInstances/Algebra.lean
+++ b/Mathlib/Algebra/PUnitInstances/Algebra.lean
@@ -4,10 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Kenny Lau
 -/
 import Mathlib.Algebra.GCDMonoid.Basic
-import Mathlib.Algebra.Module.Defs
-import Mathlib.Algebra.Ring.Action.Basic
-import Mathlib.GroupTheory.GroupAction.Defs
-import Mathlib.Order.CompleteBooleanAlgebra
 
 #align_import algebra.punit_instances from "leanprover-community/mathlib"@"6cb77a8eaff0ddd100e87b1591c6d3ad319514ff"
 
@@ -78,6 +74,7 @@ instance commRing : CommRing PUnit where
 
 instance cancelCommMonoidWithZero : CancelCommMonoidWithZero PUnit where
 
+-- This is too high-powered and should be split off also
 instance normalizedGCDMonoid : NormalizedGCDMonoid PUnit where
   gcd _ _ := unit
   lcm _ _ := unit
@@ -108,73 +105,3 @@ theorem lcm_eq {x y : PUnit} : lcm x y = unit :=
 theorem norm_unit_eq {x : PUnit} : normUnit x = 1 :=
   rfl
 #align punit.norm_unit_eq PUnit.norm_unit_eq
-
-instance canonicallyOrderedAddCommMonoid : CanonicallyOrderedAddCommMonoid PUnit where
-  exists_add_of_le {_ _} _ := ⟨unit, by subsingleton⟩
-  add_le_add_left _ _ _ _ := trivial
-  le_self_add _ _ := trivial
-
-instance linearOrderedCancelAddCommMonoid : LinearOrderedCancelAddCommMonoid PUnit where
-  __ := PUnit.instLinearOrder
-  le_of_add_le_add_left _ _ _ _ := trivial
-  add_le_add_left := by intros; rfl
-
-instance : LinearOrderedAddCommMonoidWithTop PUnit where
-  top_add' _ := rfl
-
-variable {R S : Type*}
-
-@[to_additive]
-instance smul : SMul R PUnit :=
-  ⟨fun _ _ => unit⟩
-
-@[to_additive (attr := simp)]
-theorem smul_eq {R : Type*} (y : PUnit) (r : R) : r • y = unit :=
-  rfl
-#align punit.smul_eq PUnit.smul_eq
-#align punit.vadd_eq PUnit.vadd_eq
-
-@[to_additive]
-instance : IsCentralScalar R PUnit :=
-  ⟨fun _ _ => rfl⟩
-
-@[to_additive]
-instance : SMulCommClass R S PUnit :=
-  ⟨fun _ _ _ => rfl⟩
-
-@[to_additive]
-instance instIsScalarTowerOfSMul [SMul R S] : IsScalarTower R S PUnit :=
-  ⟨fun _ _ _ => rfl⟩
-
-instance smulWithZero [Zero R] : SMulWithZero R PUnit where
-  __ := PUnit.smul
-  smul_zero := by subsingleton
-  zero_smul := by subsingleton
-
-instance mulAction [Monoid R] : MulAction R PUnit where
-  __ := PUnit.smul
-  one_smul := by subsingleton
-  mul_smul := by subsingleton
-
-instance distribMulAction [Monoid R] : DistribMulAction R PUnit where
-  __ := PUnit.mulAction
-  smul_zero := by subsingleton
-  smul_add := by subsingleton
-
-instance mulDistribMulAction [Monoid R] : MulDistribMulAction R PUnit where
-  __ := PUnit.mulAction
-  smul_mul := by subsingleton
-  smul_one := by subsingleton
-
-instance mulSemiringAction [Semiring R] : MulSemiringAction R PUnit :=
-  { PUnit.distribMulAction, PUnit.mulDistribMulAction with }
-
-instance mulActionWithZero [MonoidWithZero R] : MulActionWithZero R PUnit :=
-  { PUnit.mulAction, PUnit.smulWithZero with }
-
-instance module [Semiring R] : Module R PUnit where
-  __ := PUnit.distribMulAction
-  add_smul := by subsingleton
-  zero_smul := by subsingleton
-
-end PUnit

--- a/Mathlib/Algebra/PUnitInstances/Module.lean
+++ b/Mathlib/Algebra/PUnitInstances/Module.lean
@@ -1,0 +1,75 @@
+/-
+Copyright (c) 2019 Kenny Lau. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kenny Lau
+-/
+import Mathlib.Algebra.PUnitInstances.Algebra
+import Mathlib.Algebra.Module.Defs
+import Mathlib.Algebra.Ring.Action.Basic
+
+#align_import algebra.punit_instances from "leanprover-community/mathlib"@"6cb77a8eaff0ddd100e87b1591c6d3ad319514ff"
+
+/-!
+# Instances on PUnit
+
+This file collects facts about module structures on the one-element type
+-/
+
+namespace PUnit
+
+variable {R S : Type*}
+
+@[to_additive]
+instance smul : SMul R PUnit :=
+  ⟨fun _ _ => unit⟩
+
+@[to_additive (attr := simp)]
+theorem smul_eq {R : Type*} (y : PUnit) (r : R) : r • y = unit :=
+  rfl
+#align punit.smul_eq PUnit.smul_eq
+#align punit.vadd_eq PUnit.vadd_eq
+
+@[to_additive]
+instance : IsCentralScalar R PUnit :=
+  ⟨fun _ _ => rfl⟩
+
+@[to_additive]
+instance : SMulCommClass R S PUnit :=
+  ⟨fun _ _ _ => rfl⟩
+
+@[to_additive]
+instance instIsScalarTowerOfSMul [SMul R S] : IsScalarTower R S PUnit :=
+  ⟨fun _ _ _ => rfl⟩
+
+instance smulWithZero [Zero R] : SMulWithZero R PUnit where
+  __ := PUnit.smul
+  smul_zero := by subsingleton
+  zero_smul := by subsingleton
+
+instance mulAction [Monoid R] : MulAction R PUnit where
+  __ := PUnit.smul
+  one_smul := by subsingleton
+  mul_smul := by subsingleton
+
+instance distribMulAction [Monoid R] : DistribMulAction R PUnit where
+  __ := PUnit.mulAction
+  smul_zero := by subsingleton
+  smul_add := by subsingleton
+
+instance mulDistribMulAction [Monoid R] : MulDistribMulAction R PUnit where
+  __ := PUnit.mulAction
+  smul_mul := by subsingleton
+  smul_one := by subsingleton
+
+instance mulSemiringAction [Semiring R] : MulSemiringAction R PUnit :=
+  { PUnit.distribMulAction, PUnit.mulDistribMulAction with }
+
+instance mulActionWithZero [MonoidWithZero R] : MulActionWithZero R PUnit :=
+  { PUnit.mulAction, PUnit.smulWithZero with }
+
+instance module [Semiring R] : Module R PUnit where
+  __ := PUnit.distribMulAction
+  add_smul := by subsingleton
+  zero_smul := by subsingleton
+
+end PUnit

--- a/Mathlib/Algebra/PUnitInstances/Module.lean
+++ b/Mathlib/Algebra/PUnitInstances/Module.lean
@@ -12,7 +12,7 @@ import Mathlib.Algebra.Ring.Action.Basic
 /-!
 # Instances on PUnit
 
-This file collects facts about module structures on the one-element type
+This file collects facts about module structures on the one-element type.
 -/
 
 namespace PUnit

--- a/Mathlib/Algebra/PUnitInstances/Order.lean
+++ b/Mathlib/Algebra/PUnitInstances/Order.lean
@@ -11,7 +11,7 @@ import Mathlib.Order.Heyting.Basic
 
 /-!
 # Instances on PUnit
-
+This file collects facts about ordered algebraic structures on the one-element type.
 This file collects facts about ordered algebraic structures on the one-element type
 -/
 

--- a/Mathlib/Algebra/PUnitInstances/Order.lean
+++ b/Mathlib/Algebra/PUnitInstances/Order.lean
@@ -1,0 +1,31 @@
+/-
+Copyright (c) 2019 Kenny Lau. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kenny Lau
+-/
+import Mathlib.Algebra.PUnitInstances.Algebra
+import Mathlib.Algebra.Order.Monoid.Defs
+import Mathlib.Order.BooleanAlgebra
+
+#align_import algebra.punit_instances from "leanprover-community/mathlib"@"6cb77a8eaff0ddd100e87b1591c6d3ad319514ff"
+
+/-!
+# Instances on PUnit
+
+This file collects facts about ordered algebraic structures on the one-element type
+-/
+
+namespace PUnit
+
+instance canonicallyOrderedAddCommMonoid : CanonicallyOrderedAddCommMonoid PUnit where
+  exists_add_of_le {_ _} _ := ⟨unit, by subsingleton⟩
+  add_le_add_left _ _ _ _ := trivial
+  le_self_add _ _ := trivial
+
+instance linearOrderedCancelAddCommMonoid : LinearOrderedCancelAddCommMonoid PUnit where
+  __ := PUnit.instLinearOrder
+  le_of_add_le_add_left _ _ _ _ := trivial
+  add_le_add_left := by intros; rfl
+
+instance : LinearOrderedAddCommMonoidWithTop PUnit where
+  top_add' _ := rfl

--- a/Mathlib/Algebra/PUnitInstances/Order.lean
+++ b/Mathlib/Algebra/PUnitInstances/Order.lean
@@ -5,7 +5,7 @@ Authors: Kenny Lau
 -/
 import Mathlib.Algebra.PUnitInstances.Algebra
 import Mathlib.Algebra.Order.Monoid.Defs
-import Mathlib.Order.BooleanAlgebra
+import Mathlib.Order.Heyting.Basic
 
 #align_import algebra.punit_instances from "leanprover-community/mathlib"@"6cb77a8eaff0ddd100e87b1591c6d3ad319514ff"
 

--- a/Mathlib/Algebra/Ring/BooleanRing.lean
+++ b/Mathlib/Algebra/Ring/BooleanRing.lean
@@ -3,7 +3,7 @@ Copyright (c) 2021 Bryan Gin-ge Chen. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Bryan Gin-ge Chen, Yaël Dillies
 -/
-import Mathlib.Algebra.PUnitInstances
+import Mathlib.Algebra.PUnitInstances.Algebra
 import Mathlib.Tactic.Abel
 import Mathlib.Tactic.Ring
 import Mathlib.Order.Hom.Lattice

--- a/Mathlib/Analysis/Normed/Group/Constructions.lean
+++ b/Mathlib/Analysis/Normed/Group/Constructions.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Patrick Massot, Johannes Hölzl, Yaël Dillies
 -/
 import Mathlib.Algebra.Group.ULift
-import Mathlib.Algebra.PUnitInstances
+import Mathlib.Algebra.PUnitInstances.Algebra
 import Mathlib.Analysis.Normed.Group.Basic
 
 /-!

--- a/Mathlib/CategoryTheory/Monoidal/Mon_.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Mon_.lean
@@ -7,7 +7,7 @@ import Mathlib.CategoryTheory.Monoidal.Braided.Basic
 import Mathlib.CategoryTheory.Monoidal.Discrete
 import Mathlib.CategoryTheory.Monoidal.CoherenceLemmas
 import Mathlib.CategoryTheory.Limits.Shapes.Terminal
-import Mathlib.Algebra.PUnitInstances
+import Mathlib.Algebra.PUnitInstances.Algebra
 
 #align_import category_theory.monoidal.Mon_ from "leanprover-community/mathlib"@"a836c6dba9bd1ee2a0cdc9af0006a596f243031c"
 

--- a/Mathlib/GroupTheory/Coprod/Basic.lean
+++ b/Mathlib/GroupTheory/Coprod/Basic.lean
@@ -5,7 +5,7 @@ Authors: Yury Kudryashov
 -/
 import Mathlib.Algebra.Group.Subgroup.Basic
 import Mathlib.Algebra.Group.Submonoid.Membership
-import Mathlib.Algebra.PUnitInstances
+import Mathlib.Algebra.PUnitInstances.Algebra
 import Mathlib.GroupTheory.Congruence.Basic
 
 /-!


### PR DESCRIPTION
When we need algebra structures on `PUnit`, we should be more surgical about what we are importing.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks, and is labeled with `awaiting-review`.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
