### PR TITLE
[Merged by Bors] - chore(TwoSidedIdeal/Basic): apply forgotten review comments

### DIFF
--- a/Mathlib/RingTheory/TwoSidedIdeal/Basic.lean
+++ b/Mathlib/RingTheory/TwoSidedIdeal/Basic.lean
@@ -96,7 +96,7 @@ instance : AddSubgroupClass (TwoSidedIdeal R) R where
   add_mem := @add_mem _ _
   neg_mem := @neg_mem _ _
 
-lemma sub_mem {x y} (hx : x ∈ I) (hy : y ∈ I) : x - y ∈ I := by simpa using I.ringCon.sub hx hy
+lemma sub_mem {x y} (hx : x ∈ I) (hy : y ∈ I) : x - y ∈ I := _root_.sub_mem hx hy
 
 lemma mul_mem_left (x y) (hy : y ∈ I) : x * y ∈ I := by
   simpa using I.ringCon.mul (I.ringCon.refl x) hy
@@ -104,9 +104,9 @@ lemma mul_mem_left (x y) (hy : y ∈ I) : x * y ∈ I := by
 lemma mul_mem_right (x y) (hx : x ∈ I) : x * y ∈ I := by
   simpa using I.ringCon.mul hx (I.ringCon.refl y)
 
-lemma nsmul_mem {x} (n : ℕ) (hx : x ∈ I) : n • x ∈ I := by simpa using I.ringCon.nsmul _ hx
+lemma nsmul_mem {x} (n : ℕ) (hx : x ∈ I) : n • x ∈ I := _root_.nsmul_mem hx _
 
-lemma zsmul_mem {x} (n : ℤ) (hx : x ∈ I) : n • x ∈ I := by simpa using I.ringCon.zsmul _ hx
+lemma zsmul_mem {x} (n : ℤ) (hx : x ∈ I) : n • x ∈ I := _root_.zsmul_mem hx _
 
 /--
 The "set-theoretic-way" of constructing a two-sided ideal by providing:

--- a/Mathlib/RingTheory/TwoSidedIdeal/Basic.lean
+++ b/Mathlib/RingTheory/TwoSidedIdeal/Basic.lean
@@ -15,9 +15,10 @@ In this file, for any `Ring R`, we reinterpret `I : RingCon R` as a two-sided-id
 
 ## Main definitions and results
 
-* `TwoSidedIdeal`: For any `NonUnitalNonAssocRing R`, `TwoSidedIdeal R` is the exactly `RingCon R`.
+* `TwoSidedIdeal`: For any `NonUnitalNonAssocRing R`, `TwoSidedIdeal R` is a wrapper around
+  `RingCon R`.
 * `TwoSidedIdeal.setLike`: Every `I : TwoSidedIdeal R` can be interpreted as a set of `R` where
-  `x ∈ I` if and only if `I x 0`.
+  `x ∈ I` if and only if `I.ringCon x 0`.
 * `TwoSidedIdeal.addCommGroup`: Every `I : TwoSidedIdeal R` is an abelian group.
 
 
@@ -90,6 +91,11 @@ lemma add_mem {x y} (hx : x ∈ I) (hy : y ∈ I) : x + y ∈ I := by simpa usin
 
 lemma neg_mem {x} (hx : x ∈ I) : -x ∈ I := by simpa using I.ringCon.neg hx
 
+instance : AddSubgroupClass (TwoSidedIdeal R) R where
+  zero_mem := zero_mem
+  add_mem := @add_mem _ _
+  neg_mem := @neg_mem _ _
+
 lemma sub_mem {x y} (hx : x ∈ I) (hy : y ∈ I) : x - y ∈ I := by simpa using I.ringCon.sub hx hy
 
 lemma mul_mem_left (x y) (hy : y ∈ I) : x * y ∈ I := by
@@ -141,11 +147,6 @@ lemma mem_mk' (carrier : Set R)
     x ∈ mk' carrier zero_mem add_mem neg_mem mul_mem_left mul_mem_right ↔ x ∈ carrier := by
   rw [mem_iff]
   simp [mk']
-
-instance : AddSubgroupClass (TwoSidedIdeal R) R where
-  zero_mem := zero_mem
-  add_mem := @add_mem _ _
-  neg_mem := @neg_mem _ _
 
 instance : SMulMemClass (TwoSidedIdeal R) R R where
   smul_mem _ _ h := TwoSidedIdeal.mul_mem_left _ _ _ h


### PR DESCRIPTION
After being delegated, I forgot to apply the suggestions from #13902 by @jcommelin ....

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks, and is labeled with `awaiting-review`.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
