### PR TITLE
[Merged by Bors] - doc: add definition of upper/lower set to UpperSet, LowerSet

### DIFF
--- a/Mathlib/Order/UpperLower/Basic.lean
+++ b/Mathlib/Order/UpperLower/Basic.lean
@@ -511,12 +511,7 @@ section LE
 
 variable [LE α]
 
-/--
-The type of upper sets of an order.
-
-An upper set in an order is a subset such that any element greater than one of its members is
-also a member. Also called up-set, upward-closed set.
--/
+@[inherit_doc IsUpperSet]
 structure UpperSet (α : Type*) [LE α] where
   /-- The carrier of an `UpperSet`. -/
   carrier : Set α
@@ -524,18 +519,17 @@ structure UpperSet (α : Type*) [LE α] where
   upper' : IsUpperSet carrier
 #align upper_set UpperSet
 
-/--
-The type of lower sets of an order.
+extend_docs UpperSet before "The type of upper sets of an order."
 
-A lower set in an order is a subset such that any element less than one of its members is also
-a member. Also called down-set, downward-closed set.
--/
+@[inherit_doc IsLowerSet]
 structure LowerSet (α : Type*) [LE α] where
   /-- The carrier of a `LowerSet`. -/
   carrier : Set α
   /-- The carrier of a `LowerSet` is a lower set. -/
   lower' : IsLowerSet carrier
 #align lower_set LowerSet
+
+extend_docs LowerSet before "The type of lower sets of an order."
 
 namespace UpperSet
 

--- a/Mathlib/Order/UpperLower/Basic.lean
+++ b/Mathlib/Order/UpperLower/Basic.lean
@@ -511,7 +511,12 @@ section LE
 
 variable [LE α]
 
-/-- The type of upper sets of an order. -/
+/--
+The type of upper sets of an order.
+
+An upper set in an order is a subset such that any element greater than one of its members is
+also a member. Also called up-set, upward-closed set.
+-/
 structure UpperSet (α : Type*) [LE α] where
   /-- The carrier of an `UpperSet`. -/
   carrier : Set α
@@ -519,7 +524,12 @@ structure UpperSet (α : Type*) [LE α] where
   upper' : IsUpperSet carrier
 #align upper_set UpperSet
 
-/-- The type of lower sets of an order. -/
+/--
+The type of lower sets of an order.
+
+A lower set in an order is a subset such that any element less than one of its members is also
+a member. Also called down-set, downward-closed set.
+-/
 structure LowerSet (α : Type*) [LE α] where
   /-- The carrier of a `LowerSet`. -/
   carrier : Set α


### PR DESCRIPTION
Explanations are there in the docstring to `IsUpperSet` and `IsLowerSet` but there's no reason they can't be here as well (indeed `UpperSet` came up in a Zulip discussion and the current docstring is in some sense content-free; perhaps the term is standard amongst order theorists but I didn't know what it meant and it's not hard to explain). 

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks, and is labeled with `awaiting-review`.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
