### PR TITLE
[Merged by Bors] - chore: update `Finsupp.fun₀` comment after resolution of issue

### DIFF
--- a/Mathlib/Data/Finsupp/Notation.lean
+++ b/Mathlib/Data/Finsupp/Notation.lean
@@ -91,7 +91,8 @@ unsafe instance instRepr {α β} [Repr α] [Repr β] [Zero β] : Repr (α →₀
       if p ≥ leadPrec then Format.paren ret else ret
 #align finsupp.has_repr Finsupp.instRepr
 
--- lean4#3497 causes a PANIC if we put this in `Mathlib.Data.DFinsupp.Notation` where it belongs
+-- This cannot be put in `Mathlib.Data.DFinsupp.Notation` where it belongs, since doc-strings
+-- can only be added/modified in the file where the declaration is defined.
 extend_docs Finsupp.fun₀ after
   "If the expected type is `Π₀ i, α i` (`DFinsupp`)
   and `Mathlib.Data.DFinsupp.Notation` is imported,

--- a/Mathlib/Data/Finsupp/Notation.lean
+++ b/Mathlib/Data/Finsupp/Notation.lean
@@ -92,7 +92,7 @@ unsafe instance instRepr {α β} [Repr α] [Repr β] [Zero β] : Repr (α →₀
 #align finsupp.has_repr Finsupp.instRepr
 
 -- This cannot be put in `Mathlib.Data.DFinsupp.Notation` where it belongs, since doc-strings
--- can only be added/modified in the file where the declaration is defined.
+-- can only be added/modified in the file where the corresponding declaration is defined.
 extend_docs Finsupp.fun₀ after
   "If the expected type is `Π₀ i, α i` (`DFinsupp`)
   and `Mathlib.Data.DFinsupp.Notation` is imported,


### PR DESCRIPTION
The issue has been resolved, the panic is no longer there, but the doc-string can still only be modified in the file where it is defined.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks, and is labeled with `awaiting-review`.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
