### PR TITLE
[Merged by Bors] - feat(CategoryTheory/Adjunction): left adjoint is faithful iff unit is mono, etc.

### DIFF
--- a/Mathlib/CategoryTheory/Adjunction/FullyFaithful.lean
+++ b/Mathlib/CategoryTheory/Adjunction/FullyFaithful.lean
@@ -25,7 +25,8 @@ A right adjoint is
 This is Lemma 4.5.13 in Riehl's *Category Theory in Context* [riehl2017].
 See also https://stacks.math.columbia.edu/tag/07RB for the statements about fully faithful functors.
 
-In the file `Mathlib.CategoryTheory.Monad.Adjunction`, we prove that in fact, if there exists an isomorphism `L ⋙ R ≅ 𝟭 C`, then the unit is an isomorphism, and similarly for the counit.
+In the file `Mathlib.CategoryTheory.Monad.Adjunction`, we prove that in fact, if there exists an
+isomorphism `L ⋙ R ≅ 𝟭 C`, then the unit is an isomorphism, and similarly for the counit.
 -/
 
 

--- a/Mathlib/CategoryTheory/Adjunction/FullyFaithful.lean
+++ b/Mathlib/CategoryTheory/Adjunction/FullyFaithful.lean
@@ -131,13 +131,10 @@ lemma faithful_L_of_mono_unit_app [∀ X, Mono (h.unit.app X)] : L.Faithful wher
 lemma full_L_of_isSplitEpi_unit_app [∀ X, IsSplitEpi (h.unit.app X)] : L.Full where
   map_surjective {X Y} f := by
     use ((h.homEquiv X (L.obj Y)) f ≫ section_ (h.unit.app Y))
-    have h' : L.map (section_ (h.unit.app Y)) ≫ L.map (h.unit.app Y) = 𝟙 _ := by
-      simp [← Functor.map_comp]
-    have : L.map (section_ (h.unit.app Y)) = h.counit.app (L.obj Y) := by
-      rw [← comp_id (L.map (section_ (h.unit.app Y)))]
-      simp only [Functor.comp_obj, Functor.id_obj, comp_id,
-        ← h.left_triangle_components Y, ← assoc, h', id_comp]
-    simp [this]
+    suffices L.map (section_ (h.unit.app Y)) = h.counit.app (L.obj Y) by simp [this]
+    rw [← comp_id (L.map (section_ (h.unit.app Y)))]
+    simp only [Functor.comp_obj, Functor.id_obj, comp_id, ← h.left_triangle_components Y,
+      ← assoc, ← Functor.map_comp, IsSplitEpi.id, Functor.map_id, id_comp]
 
 /-- If the unit is an isomorphism, then the left adjoint is fully faithful. -/
 noncomputable def fullyFaithfulLOfIsIsoUnit [IsIso h.unit] : L.FullyFaithful where
@@ -154,13 +151,10 @@ lemma faithful_R_of_epi_counit_app [∀ X, Epi (h.counit.app X)] : R.Faithful wh
 lemma full_R_of_isSplitMono_counit_app [∀ X, IsSplitMono (h.counit.app X)] : R.Full where
   map_surjective {X Y} f := by
     use (retraction (h.counit.app X) ≫ (h.homEquiv (R.obj X) Y).symm f)
-    have h' : R.map (h.counit.app X) ≫ R.map (retraction (h.counit.app X)) = 𝟙 _ := by
-      simp [← Functor.map_comp]
-    have : R.map (retraction (h.counit.app X)) = h.unit.app (R.obj X) := by
-      rw [← id_comp (R.map (retraction (h.counit.app X)))]
-      simp only [Functor.id_obj, Functor.comp_obj, id_comp,
-        ← h.right_triangle_components X, assoc, h', comp_id]
-    simp [this]
+    suffices R.map (retraction (h.counit.app X)) = h.unit.app (R.obj X) by simp [this]
+    rw [← id_comp (R.map (retraction (h.counit.app X)))]
+    simp only [Functor.id_obj, Functor.comp_obj, id_comp, ← h.right_triangle_components X,
+      assoc, ← Functor.map_comp, IsSplitMono.id, Functor.map_id, comp_id]
 
 /-- If the counit is an isomorphism, then the right adjoint is fully faithful. -/
 noncomputable def fullyFaithfulROfIsIsoCounit [IsIso h.counit] : R.FullyFaithful where

--- a/Mathlib/CategoryTheory/Adjunction/FullyFaithful.lean
+++ b/Mathlib/CategoryTheory/Adjunction/FullyFaithful.lean
@@ -130,8 +130,8 @@ lemma faithful_L_of_mono_unit_app [∀ X, Mono (h.unit.app X)] : L.Faithful wher
 lemma full_L_of_isSplitEpi_unit_app [∀ X, IsSplitEpi (h.unit.app X)] : L.Full where
   map_surjective {X Y} f := by
     use ((h.homEquiv X (L.obj Y)) f ≫ section_ (h.unit.app Y))
-    have h' : L.map (section_ (h.unit.app Y)) ≫ L.map (h.unit.app Y) = 𝟙 _ :=
-      by simp [← Functor.map_comp]
+    have h' : L.map (section_ (h.unit.app Y)) ≫ L.map (h.unit.app Y) = 𝟙 _ := by
+      simp [← Functor.map_comp]
     have : L.map (section_ (h.unit.app Y)) = h.counit.app (L.obj Y) := by
       rw [← comp_id (L.map (section_ (h.unit.app Y)))]
       simp only [Functor.comp_obj, Functor.id_obj, comp_id,
@@ -153,8 +153,8 @@ lemma faithful_R_of_epi_counit_app [∀ X, Epi (h.counit.app X)] : R.Faithful wh
 lemma full_R_of_isSplitMono_counit_app [∀ X, IsSplitMono (h.counit.app X)] : R.Full where
   map_surjective {X Y} f := by
     use (retraction (h.counit.app X) ≫ (h.homEquiv (R.obj X) Y).symm f)
-    have h' : R.map (h.counit.app X) ≫ R.map (retraction (h.counit.app X)) = 𝟙 _ :=
-      by simp [← Functor.map_comp]
+    have h' : R.map (h.counit.app X) ≫ R.map (retraction (h.counit.app X)) = 𝟙 _ := by
+      simp [← Functor.map_comp]
     have : R.map (retraction (h.counit.app X)) = h.unit.app (R.obj X) := by
       rw [← id_comp (R.map (retraction (h.counit.app X)))]
       simp only [Functor.id_obj, Functor.comp_obj, id_comp,

--- a/Mathlib/CategoryTheory/Adjunction/FullyFaithful.lean
+++ b/Mathlib/CategoryTheory/Adjunction/FullyFaithful.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2019 Scott Morrison. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Scott Morrison
+Authors: Scott Morrison, Dagur Asgeirsson
 -/
 import Mathlib.CategoryTheory.Adjunction.Basic
 import Mathlib.CategoryTheory.MorphismProperty.Basic
@@ -12,12 +12,20 @@ import Mathlib.CategoryTheory.Yoneda
 /-!
 # Adjoints of fully faithful functors
 
-A left adjoint is fully faithful, if and only if the unit is an isomorphism
-(and similarly for right adjoints and the counit).
+A left adjoint is
+* faithful, if and only if the unit is a monomorphism
+* full, if and only if the unit is a split epimorphism
+* fully faithful, if and only if the unit is an isomorphism
 
-## Future work
+A right adjoint is
+* faithful, if and only if the counit is an epimorphism
+* full, if and only if the counit is a split monomorphism
+* fully faithful, if and only if the counit is an isomorphism
 
-The statements from Riehl 4.5.13 for adjoints which are either full, or faithful.
+This is Lemma 4.5.13 in Riehl's *Category Theory in Context* [riehl2017].
+See also https://stacks.math.columbia.edu/tag/07RB for the statements about fully faithful functors.
+
+In the file `Mathlib.CategoryTheory.Monad.Adjunction`, we prove that in fact, if there exists an isomorphism `L ⋙ R ≅ 𝟭 C`, then the unit is an isomorphism, and similarly for the counit.
 -/
 
 
@@ -35,50 +43,49 @@ variable {C : Type u₁} [Category.{v₁} C]
 variable {D : Type u₂} [Category.{v₂} D]
 variable {L : C ⥤ D} {R : D ⥤ C} (h : L ⊣ R)
 
-/-- If the left adjoint is fully faithful, then the unit is an isomorphism.
+/-- If the left adjoint is faithful, then each component of the unit is an monomorphism. -/
+instance unit_mono_of_L_faithful [L.Faithful] (X : C) : Mono (h.unit.app X) where
+  right_cancellation {Y} f g hfg := by
+    apply L.map_injective
+    apply (h.homEquiv Y (L.obj X)).injective
+    simpa using hfg
 
-See
-* Lemma 4.5.13 from [Riehl][riehl2017]
-* https://math.stackexchange.com/a/2727177
-* https://stacks.math.columbia.edu/tag/07RB (we only prove the forward direction!)
--/
-instance unit_isIso_of_L_fully_faithful [L.Full] [L.Faithful] : IsIso (Adjunction.unit h) :=
-  @NatIso.isIso_of_isIso_app _ _ _ _ _ _ (Adjunction.unit h) fun X =>
-    @Yoneda.isIso _ _ _ _ ((Adjunction.unit h).app X)
-      ⟨⟨{ app := fun Y f => L.preimage ((h.homEquiv (unop Y) (L.obj X)).symm f) },
-          ⟨by
-            ext x
-            apply L.map_injective
-            aesop_cat,
-           by
-            ext x
-            dsimp
-            simp only [Adjunction.homEquiv_counit, Functor.preimage_comp,
-              Functor.preimage_map, Category.assoc]
-            rw [← h.unit_naturality]
-            simp⟩⟩⟩
+/-- If the left adjoint is full, then each component of the unit is a split epimorphism.-/
+noncomputable def unitSplitEpiOfLFull [L.Full] (X : C) : SplitEpi (h.unit.app X) where
+  section_ := L.preimage (h.counit.app (L.obj X))
+  id := by simp [← h.unit_naturality (L.preimage (h.counit.app (L.obj X)))]
+
+/-- If the right adjoint is full, then each component of the counit is a split monomorphism. -/
+instance unit_isSplitEpi_of_L_full [L.Full] (X : C) : IsSplitEpi (h.unit.app X) :=
+  ⟨⟨h.unitSplitEpiOfLFull X⟩⟩
+
+/-- If the left adjoint is fully faithful, then the unit is an isomorphism. -/
+instance unit_isIso_of_L_fully_faithful [L.Full] [L.Faithful] : IsIso (Adjunction.unit h) := by
+  have : ∀ X, IsIso (h.unit.app X) := fun X ↦ isIso_of_mono_of_isSplitEpi _
+  apply NatIso.isIso_of_isIso_app
 set_option linter.uppercaseLean3 false in
 #align category_theory.unit_is_iso_of_L_fully_faithful CategoryTheory.Adjunction.unit_isIso_of_L_fully_faithful
 
-/-- If the right adjoint is fully faithful, then the counit is an isomorphism.
+/-- If the right adjoint is faithful, then each component of the counit is an epimorphism.-/
+instance counit_epi_of_R_faithful [R.Faithful] (X : D) : Epi (h.counit.app X) where
+  left_cancellation {Y} f g hfg := by
+    apply R.map_injective
+    apply (h.homEquiv (R.obj X) Y).symm.injective
+    simpa using hfg
 
-See <https://stacks.math.columbia.edu/tag/07RB> (we only prove the forward direction!)
--/
-instance counit_isIso_of_R_fully_faithful [R.Full] [R.Faithful] : IsIso (Adjunction.counit h) :=
-  @NatIso.isIso_of_isIso_app _ _ _ _ _ _ (Adjunction.counit h) fun X =>
-    @isIso_of_op _ _ _ _ _ <|
-      @Coyoneda.isIso _ _ _ _ ((Adjunction.counit h).app X).op
-        ⟨⟨{ app := fun Y f => R.preimage ((h.homEquiv (R.obj X) Y) f) },
-            ⟨by
-              ext x
-              apply R.map_injective
-              simp,
-             by
-              ext x
-              dsimp
-              simp only [Adjunction.homEquiv_unit, Functor.preimage_comp, Functor.preimage_map]
-              rw [← h.counit_naturality]
-              simp⟩⟩⟩
+/-- If the right adjoint is full, then each component of the counit is a split monomorphism. -/
+noncomputable def counitSplitMonoOfRFull [R.Full] (X : D) : SplitMono (h.counit.app X) where
+  retraction := R.preimage (h.unit.app (R.obj X))
+  id := by simp [← h.counit_naturality (R.preimage (h.unit.app (R.obj X)))]
+
+/-- If the right adjoint is full, then each component of the counit is a split monomorphism. -/
+instance counit_isSplitMono_of_R_full [R.Full] (X : D) : IsSplitMono (h.counit.app X) :=
+  ⟨⟨h.counitSplitMonoOfRFull X⟩⟩
+
+/-- If the right adjoint is fully faithful, then the counit is an isomorphism. -/
+instance counit_isIso_of_R_fully_faithful [R.Full] [R.Faithful] : IsIso (Adjunction.counit h) := by
+  have : ∀ X, IsIso (h.counit.app X) := fun X ↦ isIso_of_epi_of_isSplitMono _
+  apply NatIso.isIso_of_isIso_app
 set_option linter.uppercaseLean3 false in
 #align category_theory.counit_is_iso_of_R_fully_faithful CategoryTheory.Adjunction.counit_isIso_of_R_fully_faithful
 
@@ -112,9 +119,47 @@ noncomputable def whiskerLeftRUnitIsoOfIsIsoCounit [IsIso h.counit] : R ⋙ L �
 set_option linter.uppercaseLean3 false in
 #align category_theory.whisker_left_R_unit_iso_of_is_iso_counit CategoryTheory.Adjunction.whiskerLeftRUnitIsoOfIsIsoCounit
 
+/-- If each component the unit is a monomorphism, then the left adjoint is faithful. -/
+lemma faithful_L_of_mono_unit_app [∀ X, Mono (h.unit.app X)] : L.Faithful where
+  map_injective {X Y f g} hfg := by
+    apply Mono.right_cancellation (f := h.unit.app Y)
+    apply (h.homEquiv X (L.obj Y)).symm.injective
+    simpa using hfg
+
+/-- If each component the unit is a split epimorphism, then the left adjoint is full. -/
+lemma full_L_of_isSplitEpi_unit_app [∀ X, IsSplitEpi (h.unit.app X)] : L.Full where
+  map_surjective {X Y} f := by
+    use ((h.homEquiv X (L.obj Y)) f ≫ section_ (h.unit.app Y))
+    have h' : L.map (section_ (h.unit.app Y)) ≫ L.map (h.unit.app Y) = 𝟙 _ :=
+      by simp [← Functor.map_comp]
+    have : L.map (section_ (h.unit.app Y)) = h.counit.app (L.obj Y) := by
+      rw [← comp_id (L.map (section_ (h.unit.app Y)))]
+      simp only [Functor.comp_obj, Functor.id_obj, comp_id,
+        ← h.left_triangle_components Y, ← assoc, h', id_comp]
+    simp [this]
+
 /-- If the unit is an isomorphism, then the left adjoint is fully faithful. -/
 noncomputable def fullyFaithfulLOfIsIsoUnit [IsIso h.unit] : L.FullyFaithful where
   preimage {X Y} f := h.homEquiv _ (L.obj Y) f ≫ inv (h.unit.app Y)
+
+/-- If each component the counit is an epimorphism, then the right adjoint is faithful. -/
+lemma faithful_R_of_epi_counit_app [∀ X, Epi (h.counit.app X)] : R.Faithful where
+  map_injective {X Y f g} hfg := by
+    apply Epi.left_cancellation (f := h.counit.app X)
+    apply (h.homEquiv (R.obj X) Y).injective
+    simpa using hfg
+
+/-- If each component the counit is a split monomorphism, then the right adjoint is full. -/
+lemma full_R_of_isSplitMono_counit_app [∀ X, IsSplitMono (h.counit.app X)] : R.Full where
+  map_surjective {X Y} f := by
+    use (retraction (h.counit.app X) ≫ (h.homEquiv (R.obj X) Y).symm f)
+    have h' : R.map (h.counit.app X) ≫ R.map (retraction (h.counit.app X)) = 𝟙 _ :=
+      by simp [← Functor.map_comp]
+    have : R.map (retraction (h.counit.app X)) = h.unit.app (R.obj X) := by
+      rw [← id_comp (R.map (retraction (h.counit.app X)))]
+      simp only [Functor.id_obj, Functor.comp_obj, id_comp,
+        ← h.right_triangle_components X, assoc, h', comp_id]
+    simp [this]
 
 /-- If the counit is an isomorphism, then the right adjoint is fully faithful. -/
 noncomputable def fullyFaithfulROfIsIsoCounit [IsIso h.counit] : R.FullyFaithful where

--- a/Mathlib/CategoryTheory/Adjunction/FullyFaithful.lean
+++ b/Mathlib/CategoryTheory/Adjunction/FullyFaithful.lean
@@ -27,6 +27,8 @@ See also https://stacks.math.columbia.edu/tag/07RB for the statements about full
 
 In the file `Mathlib.CategoryTheory.Monad.Adjunction`, we prove that in fact, if there exists an
 isomorphism `L ⋙ R ≅ 𝟭 C`, then the unit is an isomorphism, and similarly for the counit.
+See `CategoryTheory.Adjunction.isIso_unit_of_iso` and
+`CategoryTheory.Adjunction.isIso_counit_of_iso`.
 -/
 
 
@@ -58,10 +60,12 @@ noncomputable def unitSplitEpiOfLFull [L.Full] (X : C) : SplitEpi (h.unit.app X)
 instance unit_isSplitEpi_of_L_full [L.Full] (X : C) : IsSplitEpi (h.unit.app X) :=
   ⟨⟨h.unitSplitEpiOfLFull X⟩⟩
 
+instance [L.Full] [L.Faithful] (X : C) : IsIso (h.unit.app X) :=
+  isIso_of_mono_of_isSplitEpi _
+
 /-- If the left adjoint is fully faithful, then the unit is an isomorphism. -/
-instance unit_isIso_of_L_fully_faithful [L.Full] [L.Faithful] : IsIso (Adjunction.unit h) := by
-  have : ∀ X, IsIso (h.unit.app X) := fun X ↦ isIso_of_mono_of_isSplitEpi _
-  apply NatIso.isIso_of_isIso_app
+instance unit_isIso_of_L_fully_faithful [L.Full] [L.Faithful] : IsIso (Adjunction.unit h) :=
+  NatIso.isIso_of_isIso_app _
 set_option linter.uppercaseLean3 false in
 #align category_theory.unit_is_iso_of_L_fully_faithful CategoryTheory.Adjunction.unit_isIso_of_L_fully_faithful
 
@@ -79,10 +83,12 @@ noncomputable def counitSplitMonoOfRFull [R.Full] (X : D) : SplitMono (h.counit.
 instance counit_isSplitMono_of_R_full [R.Full] (X : D) : IsSplitMono (h.counit.app X) :=
   ⟨⟨h.counitSplitMonoOfRFull X⟩⟩
 
+instance [R.Full] [R.Faithful] (X : D) : IsIso (h.counit.app X) :=
+  isIso_of_epi_of_isSplitMono _
+
 /-- If the right adjoint is fully faithful, then the counit is an isomorphism. -/
-instance counit_isIso_of_R_fully_faithful [R.Full] [R.Faithful] : IsIso (Adjunction.counit h) := by
-  have : ∀ X, IsIso (h.counit.app X) := fun X ↦ isIso_of_epi_of_isSplitMono _
-  apply NatIso.isIso_of_isIso_app
+instance counit_isIso_of_R_fully_faithful [R.Full] [R.Faithful] : IsIso (Adjunction.counit h) :=
+  NatIso.isIso_of_isIso_app _
 set_option linter.uppercaseLean3 false in
 #align category_theory.counit_is_iso_of_R_fully_faithful CategoryTheory.Adjunction.counit_isIso_of_R_fully_faithful
 

--- a/Mathlib/CategoryTheory/Adjunction/FullyFaithful.lean
+++ b/Mathlib/CategoryTheory/Adjunction/FullyFaithful.lean
@@ -5,7 +5,7 @@ Authors: Scott Morrison, Dagur Asgeirsson
 -/
 import Mathlib.CategoryTheory.Adjunction.Basic
 import Mathlib.CategoryTheory.MorphismProperty.Basic
-import Mathlib.CategoryTheory.Yoneda
+import Mathlib.CategoryTheory.EpiMono
 
 #align_import category_theory.adjunction.fully_faithful from "leanprover-community/mathlib"@"9e7c80f638149bfb3504ba8ff48dfdbfc949fb1a"
 

--- a/Mathlib/CategoryTheory/Adjunction/FullyFaithful.lean
+++ b/Mathlib/CategoryTheory/Adjunction/FullyFaithful.lean
@@ -46,10 +46,8 @@ variable {L : C ⥤ D} {R : D ⥤ C} (h : L ⊣ R)
 
 /-- If the left adjoint is faithful, then each component of the unit is an monomorphism. -/
 instance unit_mono_of_L_faithful [L.Faithful] (X : C) : Mono (h.unit.app X) where
-  right_cancellation {Y} f g hfg := by
-    apply L.map_injective
-    apply (h.homEquiv Y (L.obj X)).injective
-    simpa using hfg
+  right_cancellation {Y} f g hfg :=
+    L.map_injective <| (h.homEquiv Y (L.obj X)).injective <| by simpa using hfg
 
 /-- If the left adjoint is full, then each component of the unit is a split epimorphism.-/
 noncomputable def unitSplitEpiOfLFull [L.Full] (X : C) : SplitEpi (h.unit.app X) where
@@ -69,10 +67,8 @@ set_option linter.uppercaseLean3 false in
 
 /-- If the right adjoint is faithful, then each component of the counit is an epimorphism.-/
 instance counit_epi_of_R_faithful [R.Faithful] (X : D) : Epi (h.counit.app X) where
-  left_cancellation {Y} f g hfg := by
-    apply R.map_injective
-    apply (h.homEquiv (R.obj X) Y).symm.injective
-    simpa using hfg
+  left_cancellation {Y} f g hfg :=
+    R.map_injective <| (h.homEquiv (R.obj X) Y).symm.injective <| by simpa using hfg
 
 /-- If the right adjoint is full, then each component of the counit is a split monomorphism. -/
 noncomputable def counitSplitMonoOfRFull [R.Full] (X : D) : SplitMono (h.counit.app X) where
@@ -120,14 +116,14 @@ noncomputable def whiskerLeftRUnitIsoOfIsIsoCounit [IsIso h.counit] : R ⋙ L �
 set_option linter.uppercaseLean3 false in
 #align category_theory.whisker_left_R_unit_iso_of_is_iso_counit CategoryTheory.Adjunction.whiskerLeftRUnitIsoOfIsIsoCounit
 
-/-- If each component the unit is a monomorphism, then the left adjoint is faithful. -/
+/-- If each component of the unit is a monomorphism, then the left adjoint is faithful. -/
 lemma faithful_L_of_mono_unit_app [∀ X, Mono (h.unit.app X)] : L.Faithful where
   map_injective {X Y f g} hfg := by
     apply Mono.right_cancellation (f := h.unit.app Y)
     apply (h.homEquiv X (L.obj Y)).symm.injective
     simpa using hfg
 
-/-- If each component the unit is a split epimorphism, then the left adjoint is full. -/
+/-- If each component of the unit is a split epimorphism, then the left adjoint is full. -/
 lemma full_L_of_isSplitEpi_unit_app [∀ X, IsSplitEpi (h.unit.app X)] : L.Full where
   map_surjective {X Y} f := by
     use ((h.homEquiv X (L.obj Y)) f ≫ section_ (h.unit.app Y))
@@ -140,14 +136,14 @@ lemma full_L_of_isSplitEpi_unit_app [∀ X, IsSplitEpi (h.unit.app X)] : L.Full 
 noncomputable def fullyFaithfulLOfIsIsoUnit [IsIso h.unit] : L.FullyFaithful where
   preimage {X Y} f := h.homEquiv _ (L.obj Y) f ≫ inv (h.unit.app Y)
 
-/-- If each component the counit is an epimorphism, then the right adjoint is faithful. -/
+/-- If each component of the counit is an epimorphism, then the right adjoint is faithful. -/
 lemma faithful_R_of_epi_counit_app [∀ X, Epi (h.counit.app X)] : R.Faithful where
   map_injective {X Y f g} hfg := by
     apply Epi.left_cancellation (f := h.counit.app X)
     apply (h.homEquiv (R.obj X) Y).injective
     simpa using hfg
 
-/-- If each component the counit is a split monomorphism, then the right adjoint is full. -/
+/-- If each component of the counit is a split monomorphism, then the right adjoint is full. -/
 lemma full_R_of_isSplitMono_counit_app [∀ X, IsSplitMono (h.counit.app X)] : R.Full where
   map_surjective {X Y} f := by
     use (retraction (h.counit.app X) ≫ (h.homEquiv (R.obj X) Y).symm f)


### PR DESCRIPTION
We prove the full Lemma 4.5.13 in Riehl's *Category Theory in Context*, characterizing when a left/right adjoint is full, resp. faithful, resp fully faithful in terms of the unit/counit being various types of epi/mono/iso. Earlier we only had the statements for fully faithful functors.

---
This can be used to show that the functor from topological spaces to condensed sets is faithful, see #14455 

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks, and is labeled with `awaiting-review`.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
