### PR TITLE
[Merged by Bors] - chore: soften `set_option` linter message

### DIFF
--- a/Mathlib/Tactic/Linter/Style.lean
+++ b/Mathlib/Tactic/Linter/Style.lean
@@ -65,8 +65,8 @@ def setOptionLinter : Linter where run := withSetOptionIn fun stx => do
           Linter.logLint linter.setOption head
             m!"Setting options starting with '{"', '".intercalate (forbidden.map (·.toString))}' \
                is only intended for development and not for final code. \
-               If you intend to submit this contribution to the Mathlib project, please remove
-               'set_option {name}'."
+               If you intend to submit this contribution to the Mathlib project, \
+               please remove 'set_option {name}'."
 
 initialize addLinter setOptionLinter
 

--- a/Mathlib/Tactic/Linter/Style.lean
+++ b/Mathlib/Tactic/Linter/Style.lean
@@ -61,7 +61,10 @@ def setOptionLinter : Linter where run := withSetOptionIn fun stx => do
     if let some (head) := stx.find? is_set_option then
       if let some (name) := parse_set_option head then
         if #[`pp, `profiler, `trace, `debug].contains name.getRoot then
-          Linter.logLint linter.setOption head m!"Forbidden set_option `{name}`; please remove"
+          Linter.logLint linter.setOption head
+            m!"'set_option {name}' is only intended for development: \
+               unless you remove this 'set_option' or you silence the linter, \
+               `Mathlib` CI will flag this use."
 
 initialize addLinter setOptionLinter
 

--- a/Mathlib/Tactic/Linter/Style.lean
+++ b/Mathlib/Tactic/Linter/Style.lean
@@ -58,13 +58,15 @@ def setOptionLinter : Linter where run := withSetOptionIn fun stx => do
       return
     if (← MonadState.get).messages.hasErrors then
       return
-    if let some (head) := stx.find? is_set_option then
-      if let some (name) := parse_set_option head then
-        if #[`pp, `profiler, `trace, `debug].contains name.getRoot then
+    if let some head := stx.find? is_set_option then
+      if let some name := parse_set_option head then
+        let forbidden := [`debug, `pp, `profiler, `trace]
+        if forbidden.contains name.getRoot then
           Linter.logLint linter.setOption head
-            m!"'set_option {name}' is only intended for development: \
-               unless you remove this 'set_option' or you silence the linter, \
-               `Mathlib` CI will flag this use."
+            m!"Setting options starting with '{"', '".intercalate (forbidden.map (·.toString))}' \
+               is only intended for development and not for final code. \
+               If you intend to submit this contribution to the Mathlib project, please remove
+               'set_option {name}'."
 
 initialize addLinter setOptionLinter
 

--- a/test/LintStyle.lean
+++ b/test/LintStyle.lean
@@ -16,8 +16,9 @@ set_option linter.setOption false
 -- On the top level, i.e. as commands.
 
 /--
-warning: 'set_option pp.all' is only intended for development: unless you remove
-this 'set_option' or you silence the linter, `Mathlib` CI will flag this use.
+warning: Setting options starting with 'debug', 'pp', 'profiler', 'trace' is only intended
+for development and not for final code. If you intend to submit this contribution to the
+Mathlib project, please remove 'set_option pp.all'.
 note: this linter can be disabled with `set_option linter.setOption false`
 -/
 #guard_msgs in
@@ -25,8 +26,9 @@ set_option linter.setOption true in
 set_option pp.all true
 
 /--
-warning: 'set_option profiler' is only intended for development: unless you remove
-this 'set_option' or you silence the linter, `Mathlib` CI will flag this use.
+warning: Setting options starting with 'debug', 'pp', 'profiler', 'trace' is only intended
+for development and not for final code. If you intend to submit this contribution to the
+Mathlib project, please remove 'set_option profiler'.
 note: this linter can be disabled with `set_option linter.setOption false`
 -/
 #guard_msgs in
@@ -34,8 +36,9 @@ set_option linter.setOption true in
 set_option profiler false
 
 /--
-warning: 'set_option pp.all' is only intended for development: unless you remove
-this 'set_option' or you silence the linter, `Mathlib` CI will flag this use.
+warning: Setting options starting with 'debug', 'pp', 'profiler', 'trace' is only intended
+for development and not for final code. If you intend to submit this contribution to the
+Mathlib project, please remove 'set_option pp.all'.
 note: this linter can be disabled with `set_option linter.setOption false`
 -/
 #guard_msgs in
@@ -43,8 +46,9 @@ set_option linter.setOption true in
 set_option pp.all false
 
 /--
-warning: 'set_option profiler.threshold' is only intended for development: unless you remove
-this 'set_option' or you silence the linter, `Mathlib` CI will flag this use.
+warning: Setting options starting with 'debug', 'pp', 'profiler', 'trace' is only intended
+for development and not for final code. If you intend to submit this contribution to the
+Mathlib project, please remove 'set_option profiler.threshold'.
 note: this linter can be disabled with `set_option linter.setOption false`
 -/
 #guard_msgs in
@@ -52,8 +56,9 @@ set_option linter.setOption true in
 set_option profiler.threshold 50
 
 /--
-warning: 'set_option trace.profiler.output' is only intended for development: unless you remove
-this 'set_option' or you silence the linter, `Mathlib` CI will flag this use.
+warning: Setting options starting with 'debug', 'pp', 'profiler', 'trace' is only intended
+for development and not for final code. If you intend to submit this contribution to the
+Mathlib project, please remove 'set_option trace.profiler.output'.
 note: this linter can be disabled with `set_option linter.setOption false`
 -/
 #guard_msgs in
@@ -61,8 +66,9 @@ set_option linter.setOption true in
 set_option trace.profiler.output "foo"
 
 /--
-warning: 'set_option debug.moduleNameAtTimeout' is only intended for development: unless you remove
-this 'set_option' or you silence the linter, `Mathlib` CI will flag this use.
+warning: Setting options starting with 'debug', 'pp', 'profiler', 'trace' is only intended
+for development and not for final code. If you intend to submit this contribution to the
+Mathlib project, please remove 'set_option debug.moduleNameAtTimeout'.
 note: this linter can be disabled with `set_option linter.setOption false`
 -/
 #guard_msgs in
@@ -75,8 +81,9 @@ set_option autoImplicit false
 -- We also cover set_option tactics.
 
 /--
-warning: 'set_option pp.all' is only intended for development: unless you remove
-this 'set_option' or you silence the linter, `Mathlib` CI will flag this use.
+warning: Setting options starting with 'debug', 'pp', 'profiler', 'trace' is only intended
+for development and not for final code. If you intend to submit this contribution to the
+Mathlib project, please remove 'set_option pp.all'.
 note: this linter can be disabled with `set_option linter.setOption false`
 -/
 #guard_msgs in
@@ -86,8 +93,9 @@ lemma tactic : True := by
   trivial
 
 /--
-warning: 'set_option pp.raw.maxDepth' is only intended for development: unless you remove
-this 'set_option' or you silence the linter, `Mathlib` CI will flag this use.
+warning: Setting options starting with 'debug', 'pp', 'profiler', 'trace' is only intended
+for development and not for final code. If you intend to submit this contribution to the
+Mathlib project, please remove 'set_option pp.raw.maxDepth'.
 note: this linter can be disabled with `set_option linter.setOption false`
 -/
 #guard_msgs in
@@ -97,8 +105,9 @@ lemma tactic2 : True := by
   trivial
 
 /--
-warning: 'set_option pp.all' is only intended for development: unless you remove
-this 'set_option' or you silence the linter, `Mathlib` CI will flag this use.
+warning: Setting options starting with 'debug', 'pp', 'profiler', 'trace' is only intended
+for development and not for final code. If you intend to submit this contribution to the
+Mathlib project, please remove 'set_option pp.all'.
 note: this linter can be disabled with `set_option linter.setOption false`
 -/
 #guard_msgs in
@@ -108,8 +117,9 @@ lemma tactic3 : True := by
   trivial
 
 /--
-warning: 'set_option trace.profiler.output' is only intended for development: unless you remove
-this 'set_option' or you silence the linter, `Mathlib` CI will flag this use.
+warning: Setting options starting with 'debug', 'pp', 'profiler', 'trace' is only intended
+for development and not for final code. If you intend to submit this contribution to the
+Mathlib project, please remove 'set_option trace.profiler.output'.
 note: this linter can be disabled with `set_option linter.setOption false`
 -/
 #guard_msgs in

--- a/test/LintStyle.lean
+++ b/test/LintStyle.lean
@@ -16,7 +16,8 @@ set_option linter.setOption false
 -- On the top level, i.e. as commands.
 
 /--
-warning: Forbidden set_option `pp.all`; please remove
+warning: 'set_option pp.all' is only intended for development: unless you remove
+this 'set_option' or you silence the linter, `Mathlib` CI will flag this use.
 note: this linter can be disabled with `set_option linter.setOption false`
 -/
 #guard_msgs in
@@ -24,7 +25,8 @@ set_option linter.setOption true in
 set_option pp.all true
 
 /--
-warning: Forbidden set_option `profiler`; please remove
+warning: 'set_option profiler' is only intended for development: unless you remove
+this 'set_option' or you silence the linter, `Mathlib` CI will flag this use.
 note: this linter can be disabled with `set_option linter.setOption false`
 -/
 #guard_msgs in
@@ -32,7 +34,8 @@ set_option linter.setOption true in
 set_option profiler false
 
 /--
-warning: Forbidden set_option `pp.all`; please remove
+warning: 'set_option pp.all' is only intended for development: unless you remove
+this 'set_option' or you silence the linter, `Mathlib` CI will flag this use.
 note: this linter can be disabled with `set_option linter.setOption false`
 -/
 #guard_msgs in
@@ -40,7 +43,8 @@ set_option linter.setOption true in
 set_option pp.all false
 
 /--
-warning: Forbidden set_option `profiler.threshold`; please remove
+warning: 'set_option profiler.threshold' is only intended for development: unless you remove
+this 'set_option' or you silence the linter, `Mathlib` CI will flag this use.
 note: this linter can be disabled with `set_option linter.setOption false`
 -/
 #guard_msgs in
@@ -48,7 +52,8 @@ set_option linter.setOption true in
 set_option profiler.threshold 50
 
 /--
-warning: Forbidden set_option `trace.profiler.output`; please remove
+warning: 'set_option trace.profiler.output' is only intended for development: unless you remove
+this 'set_option' or you silence the linter, `Mathlib` CI will flag this use.
 note: this linter can be disabled with `set_option linter.setOption false`
 -/
 #guard_msgs in
@@ -56,7 +61,8 @@ set_option linter.setOption true in
 set_option trace.profiler.output "foo"
 
 /--
-warning: Forbidden set_option `debug.moduleNameAtTimeout`; please remove
+warning: 'set_option debug.moduleNameAtTimeout' is only intended for development: unless you remove
+this 'set_option' or you silence the linter, `Mathlib` CI will flag this use.
 note: this linter can be disabled with `set_option linter.setOption false`
 -/
 #guard_msgs in
@@ -69,7 +75,8 @@ set_option autoImplicit false
 -- We also cover set_option tactics.
 
 /--
-warning: Forbidden set_option `pp.all`; please remove
+warning: 'set_option pp.all' is only intended for development: unless you remove
+this 'set_option' or you silence the linter, `Mathlib` CI will flag this use.
 note: this linter can be disabled with `set_option linter.setOption false`
 -/
 #guard_msgs in
@@ -79,7 +86,8 @@ lemma tactic : True := by
   trivial
 
 /--
-warning: Forbidden set_option `pp.raw.maxDepth`; please remove
+warning: 'set_option pp.raw.maxDepth' is only intended for development: unless you remove
+this 'set_option' or you silence the linter, `Mathlib` CI will flag this use.
 note: this linter can be disabled with `set_option linter.setOption false`
 -/
 #guard_msgs in
@@ -89,7 +97,8 @@ lemma tactic2 : True := by
   trivial
 
 /--
-warning: Forbidden set_option `pp.all`; please remove
+warning: 'set_option pp.all' is only intended for development: unless you remove
+this 'set_option' or you silence the linter, `Mathlib` CI will flag this use.
 note: this linter can be disabled with `set_option linter.setOption false`
 -/
 #guard_msgs in
@@ -99,7 +108,8 @@ lemma tactic3 : True := by
   trivial
 
 /--
-warning: Forbidden set_option `trace.profiler.output`; please remove
+warning: 'set_option trace.profiler.output' is only intended for development: unless you remove
+this 'set_option' or you silence the linter, `Mathlib` CI will flag this use.
 note: this linter can be disabled with `set_option linter.setOption false`
 -/
 #guard_msgs in


### PR DESCRIPTION
[Zulip discussion](https://leanprover.zulipchat.com/#narrow/stream/287929-mathlib4/topic/.60pp.2Emvars.60.20forbidden.3F/near/449666047)

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks, and is labeled with `awaiting-review`.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
