### PR TITLE
[Merged by Bors] - Removes non-printable characters U+200b and U+200c from docstrings

### DIFF
--- a/Mathlib/Data/List/Defs.lean
+++ b/Mathlib/Data/List/Defs.lean
@@ -453,7 +453,7 @@ def map₂Right' (f : Option α → β → γ) (as : List α) (bs : List β) : L
 
 
 /-- Left-biased version of `List.map₂`. `map₂Left f as bs` applies `f` to each pair
-`aᵢ ∈ as` and `bᵢ ‌∈ bs`. If `bs` is shorter than `as`, `f` is applied to `none`
+`aᵢ ∈ as` and `bᵢ ∈ bs`. If `bs` is shorter than `as`, `f` is applied to `none`
 for the remaining `aᵢ`.
 
 ```
@@ -472,7 +472,7 @@ def map₂Left (f : α → Option β → γ) : List α → List β → List γ
 #align list.map₂_left List.map₂Left
 
 /-- Right-biased version of `List.map₂`. `map₂Right f as bs` applies `f` to each
-pair `aᵢ ∈ as` and `bᵢ ‌∈ bs`. If `as` is shorter than `bs`, `f` is applied to
+pair `aᵢ ∈ as` and `bᵢ ∈ bs`. If `as` is shorter than `bs`, `f` is applied to
 `none` for the remaining `bᵢ`.
 
 ```

--- a/Mathlib/Data/Matrix/Basis.lean
+++ b/Mathlib/Data/Matrix/Basis.lean
@@ -243,7 +243,7 @@ theorem diag_eq_of_commute_stdBasisMatrix {i j : n} {M : Matrix n n α}
   have := ext_iff.mpr hM i j
   aesop
 
-/-- `M` is a scalar matrix if it commutes with every non-diagonal `stdBasisMatrix`. ​-/
+/-- `M` is a scalar matrix if it commutes with every non-diagonal `stdBasisMatrix`. -/
 theorem mem_range_scalar_of_commute_stdBasisMatrix {M : Matrix n n α}
     (hM : Pairwise fun i j => Commute (stdBasisMatrix i j 1) M) :
     M ∈ Set.range (Matrix.scalar n) := by
@@ -268,7 +268,7 @@ theorem mem_range_scalar_iff_commute_stdBasisMatrix {M : Matrix n n α} :
   rw [scalar_commute_iff]
   simp
 
-/-- `M` is a scalar matrix if and only if it commutes with every `stdBasisMatrix`.​ -/
+/-- `M` is a scalar matrix if and only if it commutes with every `stdBasisMatrix`. -/
 theorem mem_range_scalar_iff_commute_stdBasisMatrix' {M : Matrix n n α} :
     M ∈ Set.range (Matrix.scalar n) ↔ ∀ (i j : n), Commute (stdBasisMatrix i j 1) M := by
   refine ⟨fun ⟨r, hr⟩ i j => hr ▸ Commute.symm ?_,


### PR DESCRIPTION
Mathlib contains a few non-printable unicode characters in some docstrings. I'm not sure why these were put in (some of them seem to have been ported from Mathlib 3 and it's hard to trace back where they were added first).

The characters removed here are
- U+200b (​zero width space) 
- U+200c (zero-width non-joiner)

It might make sense to remove them, see the [Zulip discussion](https://leanprover.zulipchat.com/#narrow/stream/287929-mathlib4/topic/Whitelist.20for.20Unicode.3F).

If you review this PR, please also comment on whether you think a linter concerned with Unicode would be helpful. (e.g., warn on any *new* unicode characters being added to Mathlib, or, e.g., warn on any unicode characters being added that don't have a way to type using `\<combination>`)

---



<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks, and is labeled with `awaiting-review`.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
