### PR TITLE
[Merged by Bors] - feat: Lemma for `fderiv` of scalar function

### DIFF
--- a/Mathlib/Analysis/Calculus/Deriv/Basic.lean
+++ b/Mathlib/Analysis/Calculus/Deriv/Basic.lean
@@ -489,12 +489,6 @@ lemma fderiv_deriv' {f : 𝕜 → 𝕜} {x y : 𝕜} : (fderiv 𝕜 f x : 𝕜 �
   simp only [ContinuousLinearMap.smulRight_apply, ContinuousLinearMap.one_apply, smul_eq_mul]
   ring
 
-@[simp]
-lemma fderiv_deriv'' {f : 𝕜 → 𝕜} {x : 𝕜} : (fderiv 𝕜 f x : 𝕜 → 𝕜) = ((deriv f x) * ·) := by
-  ext
-  simp_all only [fderiv_deriv']
-
-
 theorem norm_deriv_eq_norm_fderiv : ‖deriv f x‖ = ‖fderiv 𝕜 f x‖ := by
   simp [← deriv_fderiv]
 

--- a/Mathlib/Analysis/Calculus/Deriv/Basic.lean
+++ b/Mathlib/Analysis/Calculus/Deriv/Basic.lean
@@ -474,13 +474,11 @@ theorem derivWithin_fderivWithin :
 theorem norm_derivWithin_eq_norm_fderivWithin : ‖derivWithin f s x‖ = ‖fderivWithin 𝕜 f s x‖ := by
   simp [← derivWithin_fderivWithin]
 
-@[simp]
 theorem fderiv_deriv : (fderiv 𝕜 f x : 𝕜 → F) 1 = deriv f x :=
   rfl
 #align fderiv_deriv fderiv_deriv
 
-theorem deriv_fderiv : smulRight (1 : 𝕜 →L[𝕜] 𝕜) (deriv f x) = fderiv 𝕜 f x := by
-  simp only [deriv, ContinuousLinearMap.smulRight_one_one]
+theorem deriv_fderiv : smulRight (1 : 𝕜 →L[𝕜] 𝕜) (deriv f x) = fderiv 𝕜 f x := by simp [deriv]
 #align deriv_fderiv deriv_fderiv
 
 @[simp]

--- a/Mathlib/Analysis/Calculus/Deriv/Basic.lean
+++ b/Mathlib/Analysis/Calculus/Deriv/Basic.lean
@@ -474,11 +474,13 @@ theorem derivWithin_fderivWithin :
 theorem norm_derivWithin_eq_norm_fderivWithin : ‖derivWithin f s x‖ = ‖fderivWithin 𝕜 f s x‖ := by
   simp [← derivWithin_fderivWithin]
 
+@[simp]
 theorem fderiv_deriv : (fderiv 𝕜 f x : 𝕜 → F) 1 = deriv f x :=
   rfl
 #align fderiv_deriv fderiv_deriv
 
-theorem deriv_fderiv : smulRight (1 : 𝕜 →L[𝕜] 𝕜) (deriv f x) = fderiv 𝕜 f x := by simp [deriv]
+theorem deriv_fderiv : smulRight (1 : 𝕜 →L[𝕜] 𝕜) (deriv f x) = fderiv 𝕜 f x := by
+  simp only [deriv, ContinuousLinearMap.smulRight_one_one]
 #align deriv_fderiv deriv_fderiv
 
 @[simp]
@@ -486,6 +488,12 @@ lemma fderiv_deriv' {f : 𝕜 → 𝕜} {x y : 𝕜} : (fderiv 𝕜 f x : 𝕜 �
   rw [← deriv_fderiv]
   simp only [ContinuousLinearMap.smulRight_apply, ContinuousLinearMap.one_apply, smul_eq_mul]
   ring
+
+@[simp]
+lemma fderiv_deriv'' {f : 𝕜 → 𝕜} {x : 𝕜} : (fderiv 𝕜 f x : 𝕜 → 𝕜) = ((deriv f x) * ·) := by
+  ext
+  simp_all only [fderiv_deriv']
+
 
 theorem norm_deriv_eq_norm_fderiv : ‖deriv f x‖ = ‖fderiv 𝕜 f x‖ := by
   simp [← deriv_fderiv]

--- a/Mathlib/Analysis/Calculus/Deriv/Basic.lean
+++ b/Mathlib/Analysis/Calculus/Deriv/Basic.lean
@@ -478,14 +478,17 @@ theorem fderiv_deriv : (fderiv 𝕜 f x : 𝕜 → F) 1 = deriv f x :=
   rfl
 #align fderiv_deriv fderiv_deriv
 
-theorem deriv_fderiv : smulRight (1 : 𝕜 →L[𝕜] 𝕜) (deriv f x) = fderiv 𝕜 f x := by simp [deriv]
+@[simp]
+theorem fderiv_eq_smul_deriv (y : 𝕜) : (fderiv 𝕜 f x : 𝕜 → F) y = y • deriv f x := by
+  rw [← fderiv_deriv, ← ContinuousLinearMap.map_smul]
+  simp only [smul_eq_mul, mul_one]
+
+theorem deriv_fderiv : smulRight (1 : 𝕜 →L[𝕜] 𝕜) (deriv f x) = fderiv 𝕜 f x := by
+  simp only [deriv, ContinuousLinearMap.smulRight_one_one]
 #align deriv_fderiv deriv_fderiv
 
-@[simp]
-lemma fderiv_deriv' {f : 𝕜 → 𝕜} {x y : 𝕜} : (fderiv 𝕜 f x : 𝕜 → 𝕜) y = (deriv f x) * y := by
-  rw [← deriv_fderiv]
-  simp only [ContinuousLinearMap.smulRight_apply, ContinuousLinearMap.one_apply, smul_eq_mul]
-  ring
+lemma fderiv_eq_deriv_mul {f : 𝕜 → 𝕜} {x y : 𝕜} : (fderiv 𝕜 f x : 𝕜 → 𝕜) y = (deriv f x) * y := by
+  simp [mul_comm]
 
 theorem norm_deriv_eq_norm_fderiv : ‖deriv f x‖ = ‖fderiv 𝕜 f x‖ := by
   simp [← deriv_fderiv]

--- a/Mathlib/Analysis/Calculus/Deriv/Basic.lean
+++ b/Mathlib/Analysis/Calculus/Deriv/Basic.lean
@@ -481,6 +481,12 @@ theorem fderiv_deriv : (fderiv 𝕜 f x : 𝕜 → F) 1 = deriv f x :=
 theorem deriv_fderiv : smulRight (1 : 𝕜 →L[𝕜] 𝕜) (deriv f x) = fderiv 𝕜 f x := by simp [deriv]
 #align deriv_fderiv deriv_fderiv
 
+@[simp]
+lemma fderiv_deriv' {f : 𝕜 → 𝕜} {x y : 𝕜} : (fderiv 𝕜 f x : 𝕜 → 𝕜) y = (deriv f x) * y := by
+  rw [← deriv_fderiv]
+  simp only [ContinuousLinearMap.smulRight_apply, ContinuousLinearMap.one_apply, smul_eq_mul]
+  ring
+
 theorem norm_deriv_eq_norm_fderiv : ‖deriv f x‖ = ‖fderiv 𝕜 f x‖ := by
   simp [← deriv_fderiv]
 

--- a/Mathlib/Analysis/Calculus/IteratedDeriv/Defs.lean
+++ b/Mathlib/Analysis/Calculus/IteratedDeriv/Defs.lean
@@ -248,7 +248,7 @@ theorem iteratedDeriv_zero : iteratedDeriv 0 f = f := by ext x; simp [iteratedDe
 #align iterated_deriv_zero iteratedDeriv_zero
 
 @[simp]
-theorem iteratedDeriv_one : iteratedDeriv 1 f = deriv f := by ext x; simp [iteratedDeriv]; rfl
+theorem iteratedDeriv_one : iteratedDeriv 1 f = deriv f := by ext x; simp [iteratedDeriv]
 #align iterated_deriv_one iteratedDeriv_one
 
 /-- The property of being `C^n`, initially defined in terms of the Fréchet derivative, can be

--- a/Mathlib/Analysis/Calculus/IteratedDeriv/Defs.lean
+++ b/Mathlib/Analysis/Calculus/IteratedDeriv/Defs.lean
@@ -248,7 +248,9 @@ theorem iteratedDeriv_zero : iteratedDeriv 0 f = f := by ext x; simp [iteratedDe
 #align iterated_deriv_zero iteratedDeriv_zero
 
 @[simp]
-theorem iteratedDeriv_one : iteratedDeriv 1 f = deriv f := by ext x; simp [iteratedDeriv]; rfl
+theorem iteratedDeriv_one : iteratedDeriv 1 f = deriv f := by
+  ext x
+  simp only [iteratedDeriv, iteratedFDeriv_one_apply, fderiv_deriv]
 #align iterated_deriv_one iteratedDeriv_one
 
 /-- The property of being `C^n`, initially defined in terms of the Fréchet derivative, can be

--- a/Mathlib/Analysis/Calculus/IteratedDeriv/Defs.lean
+++ b/Mathlib/Analysis/Calculus/IteratedDeriv/Defs.lean
@@ -248,9 +248,7 @@ theorem iteratedDeriv_zero : iteratedDeriv 0 f = f := by ext x; simp [iteratedDe
 #align iterated_deriv_zero iteratedDeriv_zero
 
 @[simp]
-theorem iteratedDeriv_one : iteratedDeriv 1 f = deriv f := by
-  ext x
-  simp only [iteratedDeriv, iteratedFDeriv_one_apply, fderiv_deriv]
+theorem iteratedDeriv_one : iteratedDeriv 1 f = deriv f := by ext x; simp [iteratedDeriv]; rfl
 #align iterated_deriv_one iteratedDeriv_one
 
 /-- The property of being `C^n`, initially defined in terms of the Fréchet derivative, can be


### PR DESCRIPTION
Adds lemma for simplifying the Fréchet derivative when applied to a function maping scalars to scalars. 

This (currently named `fderiv_deriv'`) is a special case of `fderiv_deriv`. Neither of `simp`, `fun_prop`, `aesop`, `exact?` , `apply?` currently seems to make progress on it.

Possibly, it should be instead stated as `(fderiv 𝕜 f x : 𝕜 → 𝕜) = ((deriv f x) * ·)` if that makes it more likely to be applied by `simp`?

I think it should be marked `@[simp]` because one would basically always prefer the right hand side to the left hand side of the equality. Does that make sense?

I also think `fderiv_deriv` should be marked `@[simp]`, though maybe there is a reason why it isn't. Marking it such requires a change to the proof of `deriv_fderiv`, which was using a `simp` rather than a `simp only` (not a [non-terminal simp](https://leanprover-community.github.io/glossary.html#non-terminal-simp) but still to be avoided, I would assume?). Maybe other things are also likely to break, however, if those are added to simp?


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks, and is labeled with `awaiting-review`.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
