### PR TITLE
[Merged by Bors] - feat(Topology/Sequences): preservation of sequential compactness under continuous functions 

### DIFF
--- a/Mathlib/Topology/Defs/Sequences.lean
+++ b/Mathlib/Topology/Defs/Sequences.lean
@@ -76,6 +76,8 @@ class SeqCompactSpace : Prop where
 
 export SeqCompactSpace (isSeqCompact_univ)
 
+@[deprecated (since := "2024-07-25")] alias seq_compact_univ := isSeqCompact_univ
+
 /-- A topological space is called a *Fréchet-Urysohn space*, if the sequential closure of any set
 is equal to its closure. Since one of the inclusions is trivial, we require only the non-trivial one
 in the definition. -/

--- a/Mathlib/Topology/Defs/Sequences.lean
+++ b/Mathlib/Topology/Defs/Sequences.lean
@@ -72,9 +72,9 @@ variable (X)
 converging subsequence. -/
 @[mk_iff]
 class SeqCompactSpace : Prop where
-  seq_compact_univ : IsSeqCompact (univ : Set X)
+  isSeqCompact_univ : IsSeqCompact (univ : Set X)
 
-export SeqCompactSpace (seq_compact_univ)
+export SeqCompactSpace (isSeqCompact_univ)
 
 /-- A topological space is called a *Fréchet-Urysohn space*, if the sequential closure of any set
 is equal to its closure. Since one of the inclusions is trivial, we require only the non-trivial one

--- a/Mathlib/Topology/Metrizable/Basic.lean
+++ b/Mathlib/Topology/Metrizable/Basic.lean
@@ -49,11 +49,6 @@ theorem _root_.Inducing.pseudoMetrizableSpace [PseudoMetrizableSpace Y] {f : X �
   letI : PseudoMetricSpace Y := pseudoMetrizableSpacePseudoMetric Y
   ⟨⟨hf.comapPseudoMetricSpace, rfl⟩⟩
 
-theorem Inducing.metrizableSpace [MetrizableSpace Y] {f : X → Y}
-    (hf : Inducing f) (inj : Function.Injective f) : MetrizableSpace X :=
-  letI : MetricSpace Y := metrizableSpaceMetric 
-  ⟨@Inducing.comapMetricSpace X Y _ _ f hf inj, rfl⟩
-
 /-- Every pseudo-metrizable space is first countable. -/
 instance (priority := 100) PseudoMetrizableSpace.firstCountableTopology
     [h : PseudoMetrizableSpace X] : FirstCountableTopology X := by

--- a/Mathlib/Topology/Metrizable/Basic.lean
+++ b/Mathlib/Topology/Metrizable/Basic.lean
@@ -49,6 +49,11 @@ theorem _root_.Inducing.pseudoMetrizableSpace [PseudoMetrizableSpace Y] {f : X �
   letI : PseudoMetricSpace Y := pseudoMetrizableSpacePseudoMetric Y
   ⟨⟨hf.comapPseudoMetricSpace, rfl⟩⟩
 
+theorem Inducing.metrizableSpace [MetrizableSpace Y] {f : X → Y}
+    (hf : Inducing f) (inj : Function.Injective f) : MetrizableSpace X :=
+  letI : MetricSpace Y := metrizableSpaceMetric 
+  ⟨@Inducing.comapMetricSpace X Y _ _ f hf inj, rfl⟩
+
 /-- Every pseudo-metrizable space is first countable. -/
 instance (priority := 100) PseudoMetrizableSpace.firstCountableTopology
     [h : PseudoMetrizableSpace X] : FirstCountableTopology X := by

--- a/Mathlib/Topology/Sequences.lean
+++ b/Mathlib/Topology/Sequences.lean
@@ -277,6 +277,41 @@ theorem CompactSpace.tendsto_subseq [CompactSpace X] (x : ℕ → X) :
 
 end FirstCountableTopology
 
+section Image
+
+/-- Sequential compactness of sets is preserved under sequentially continuous functions. -/
+theorem IsSeqCompact.image {X Y : Type*} [TopologicalSpace X] [TopologicalSpace Y] (f : X → Y)
+    (f_cont : SeqContinuous f) {K : Set X} (K_cpt : IsSeqCompact K) :
+    IsSeqCompact (f '' K) := by
+  intro ys ys_in_fK
+  choose xs xs_in_K fxs_eq_ys using fun n ↦ (ys_in_fK n)
+  simp only [Set.mem_image, exists_exists_and_eq_and]
+  obtain ⟨a, a_in_K, phi, phi_mono, xs_phi_lim⟩ := K_cpt xs_in_K
+  refine ⟨a, a_in_K, phi, phi_mono, ?_⟩
+  exact Filter.Tendsto.congr (fun x ↦ fxs_eq_ys (phi x)) (f_cont xs_phi_lim)
+
+/-- The range of sequentially continuous function on a sequentially compact space is sequentially
+compact. -/
+theorem isSeqCompact_range {X Y : Type*} [TopologicalSpace X] [TopologicalSpace Y]
+    [SeqCompactSpace X] (f : X → Y) (hf : SeqContinuous f) :
+    IsSeqCompact (Set.range f) := by
+  rw [← Set.image_univ]
+  exact IsSeqCompact.image f hf ((seqCompactSpace_iff X).mp ‹SeqCompactSpace X›)
+
+/-- Sequential compactness of sets is preserved under continuous functions. -/
+theorem IsSeqCompact.image_of_continuous {X Y : Type*} [TopologicalSpace X] [TopologicalSpace Y]
+    (f : X → Y) (f_cont : Continuous f) {K : Set X} (K_cpt : IsSeqCompact K) :
+    IsSeqCompact (f '' K) :=
+  IsSeqCompact.image f (Continuous.seqContinuous f_cont) K_cpt
+
+/-- The range of continuous function on a sequentially compact space is sequentially compact. -/
+theorem SeqCompactSpace.range_of_continuous {X Y : Type*} [TopologicalSpace X] [TopologicalSpace Y]
+    [SeqCompactSpace X] (f : X → Y) (f_cont : Continuous f) :
+    IsSeqCompact (Set.range f) :=
+  isSeqCompact_range f (Continuous.seqContinuous f_cont)
+
+end Image
+
 end SeqCompact
 
 section UniformSpaceSeqCompact

--- a/Mathlib/Topology/Sequences.lean
+++ b/Mathlib/Topology/Sequences.lean
@@ -302,7 +302,7 @@ theorem isSeqCompact_range [SeqCompactSpace X] (f_cont : SeqContinuous f) :
 theorem IsSeqCompact.image_of_continuous (f_cont : Continuous f) {K : Set X}
     (K_cpt : IsSeqCompact K) :
     IsSeqCompact (f '' K) :=
-  IsSeqCompact.image (Continuous.seqContinuous f_cont) K_cpt
+  K_cpt.image f_cont.seqContinuous
 
 /-- The range of continuous function on a sequentially compact space is sequentially compact. -/
 theorem isSeqCompact_range_of_continuous [SeqCompactSpace X] (f_cont : Continuous f) :

--- a/Mathlib/Topology/Sequences.lean
+++ b/Mathlib/Topology/Sequences.lean
@@ -243,7 +243,7 @@ theorem IsSeqCompact.subseq_of_frequently_in {s : Set X} (hs : IsSeqCompact s) {
 
 theorem SeqCompactSpace.tendsto_subseq [SeqCompactSpace X] (x : ℕ → X) :
     ∃ (a : X) (φ : ℕ → ℕ), StrictMono φ ∧ Tendsto (x ∘ φ) atTop (𝓝 a) :=
-  let ⟨a, _, φ, mono, h⟩ := seq_compact_univ fun n => mem_univ (x n)
+  let ⟨a, _, φ, mono, h⟩ := isSeqCompact_univ fun n => mem_univ (x n)
   ⟨a, φ, mono, h⟩
 
 section FirstCountableTopology

--- a/Mathlib/Topology/Sequences.lean
+++ b/Mathlib/Topology/Sequences.lean
@@ -292,21 +292,10 @@ theorem IsSeqCompact.image (f_cont : SeqContinuous f) {K : Set X} (K_cpt : IsSeq
 
 /-- The range of sequentially continuous function on a sequentially compact space is sequentially
 compact. -/
-theorem isSeqCompact_range [SeqCompactSpace X] (f_cont : SeqContinuous f) :
+theorem IsSeqCompact.range [SeqCompactSpace X] (f_cont : SeqContinuous f) :
     IsSeqCompact (Set.range f) := by
   rw [← Set.image_univ]
   exact IsSeqCompact.image f_cont ((seqCompactSpace_iff X).mp ‹SeqCompactSpace X›)
-
-/-- Sequential compactness of sets is preserved under continuous functions. -/
-theorem IsSeqCompact.image_of_continuous (f_cont : Continuous f) {K : Set X}
-    (K_cpt : IsSeqCompact K) :
-    IsSeqCompact (f '' K) :=
-  K_cpt.image f_cont.seqContinuous
-
-/-- The range of continuous function on a sequentially compact space is sequentially compact. -/
-theorem isSeqCompact_range_of_continuous [SeqCompactSpace X] (f_cont : Continuous f) :
-    IsSeqCompact (Set.range f) :=
-  isSeqCompact_range f_cont.seqContinuous
 
 end Image
 

--- a/Mathlib/Topology/Sequences.lean
+++ b/Mathlib/Topology/Sequences.lean
@@ -279,9 +279,10 @@ end FirstCountableTopology
 
 section Image
 
+variable {X Y : Type*} [TopologicalSpace X] [TopologicalSpace Y] {f : X → Y}
+
 /-- Sequential compactness of sets is preserved under sequentially continuous functions. -/
-theorem IsSeqCompact.image {X Y : Type*} [TopologicalSpace X] [TopologicalSpace Y] (f : X → Y)
-    (f_cont : SeqContinuous f) {K : Set X} (K_cpt : IsSeqCompact K) :
+theorem IsSeqCompact.image (f_cont : SeqContinuous f) {K : Set X} (K_cpt : IsSeqCompact K) :
     IsSeqCompact (f '' K) := by
   intro ys ys_in_fK
   choose xs xs_in_K fxs_eq_ys using fun n ↦ (ys_in_fK n)
@@ -292,23 +293,21 @@ theorem IsSeqCompact.image {X Y : Type*} [TopologicalSpace X] [TopologicalSpace 
 
 /-- The range of sequentially continuous function on a sequentially compact space is sequentially
 compact. -/
-theorem isSeqCompact_range {X Y : Type*} [TopologicalSpace X] [TopologicalSpace Y]
-    [SeqCompactSpace X] (f : X → Y) (hf : SeqContinuous f) :
+theorem isSeqCompact_range [SeqCompactSpace X] (f_cont : SeqContinuous f) :
     IsSeqCompact (Set.range f) := by
   rw [← Set.image_univ]
-  exact IsSeqCompact.image f hf ((seqCompactSpace_iff X).mp ‹SeqCompactSpace X›)
+  exact IsSeqCompact.image f_cont ((seqCompactSpace_iff X).mp ‹SeqCompactSpace X›)
 
 /-- Sequential compactness of sets is preserved under continuous functions. -/
-theorem IsSeqCompact.image_of_continuous {X Y : Type*} [TopologicalSpace X] [TopologicalSpace Y]
-    (f : X → Y) (f_cont : Continuous f) {K : Set X} (K_cpt : IsSeqCompact K) :
+theorem IsSeqCompact.image_of_continuous (f_cont : Continuous f) {K : Set X}
+    (K_cpt : IsSeqCompact K) :
     IsSeqCompact (f '' K) :=
-  IsSeqCompact.image f (Continuous.seqContinuous f_cont) K_cpt
+  IsSeqCompact.image (Continuous.seqContinuous f_cont) K_cpt
 
 /-- The range of continuous function on a sequentially compact space is sequentially compact. -/
-theorem SeqCompactSpace.range_of_continuous {X Y : Type*} [TopologicalSpace X] [TopologicalSpace Y]
-    [SeqCompactSpace X] (f : X → Y) (f_cont : Continuous f) :
+theorem SeqCompactSpace.range_of_continuous [SeqCompactSpace X] (f_cont : Continuous f) :
     IsSeqCompact (Set.range f) :=
-  isSeqCompact_range f (Continuous.seqContinuous f_cont)
+  isSeqCompact_range (Continuous.seqContinuous f_cont)
 
 end Image
 

--- a/Mathlib/Topology/Sequences.lean
+++ b/Mathlib/Topology/Sequences.lean
@@ -279,7 +279,7 @@ end FirstCountableTopology
 
 section Image
 
-variable {X Y : Type*} [TopologicalSpace X] [TopologicalSpace Y] {f : X → Y}
+variable [TopologicalSpace Y] {f : X → Y}
 
 /-- Sequential compactness of sets is preserved under sequentially continuous functions. -/
 theorem IsSeqCompact.image (f_cont : SeqContinuous f) {K : Set X} (K_cpt : IsSeqCompact K) :

--- a/Mathlib/Topology/Sequences.lean
+++ b/Mathlib/Topology/Sequences.lean
@@ -307,7 +307,7 @@ theorem IsSeqCompact.image_of_continuous (f_cont : Continuous f) {K : Set X}
 /-- The range of continuous function on a sequentially compact space is sequentially compact. -/
 theorem isSeqCompact_range_of_continuous [SeqCompactSpace X] (f_cont : Continuous f) :
     IsSeqCompact (Set.range f) :=
-  isSeqCompact_range (Continuous.seqContinuous f_cont)
+  isSeqCompact_range f_cont.seqContinuous
 
 end Image
 

--- a/Mathlib/Topology/Sequences.lean
+++ b/Mathlib/Topology/Sequences.lean
@@ -294,8 +294,7 @@ theorem IsSeqCompact.image (f_cont : SeqContinuous f) {K : Set X} (K_cpt : IsSeq
 compact. -/
 theorem IsSeqCompact.range [SeqCompactSpace X] (f_cont : SeqContinuous f) :
     IsSeqCompact (Set.range f) := by
-  rw [← Set.image_univ]
-  exact IsSeqCompact.image f_cont ((seqCompactSpace_iff X).mp ‹SeqCompactSpace X›)
+  simpa using isSeqCompact_univ.image f_cont
 
 end Image
 

--- a/Mathlib/Topology/Sequences.lean
+++ b/Mathlib/Topology/Sequences.lean
@@ -305,7 +305,7 @@ theorem IsSeqCompact.image_of_continuous (f_cont : Continuous f) {K : Set X}
   IsSeqCompact.image (Continuous.seqContinuous f_cont) K_cpt
 
 /-- The range of continuous function on a sequentially compact space is sequentially compact. -/
-theorem SeqCompactSpace.range_of_continuous [SeqCompactSpace X] (f_cont : Continuous f) :
+theorem isSeqCompact_range_of_continuous [SeqCompactSpace X] (f_cont : Continuous f) :
     IsSeqCompact (Set.range f) :=
   isSeqCompact_range (Continuous.seqContinuous f_cont)
 

--- a/Mathlib/Topology/Sequences.lean
+++ b/Mathlib/Topology/Sequences.lean
@@ -285,11 +285,10 @@ variable [TopologicalSpace Y] {f : X → Y}
 theorem IsSeqCompact.image (f_cont : SeqContinuous f) {K : Set X} (K_cpt : IsSeqCompact K) :
     IsSeqCompact (f '' K) := by
   intro ys ys_in_fK
-  choose xs xs_in_K fxs_eq_ys using fun n ↦ (ys_in_fK n)
-  simp only [Set.mem_image, exists_exists_and_eq_and]
+  choose xs xs_in_K fxs_eq_ys using ys_in_fK
   obtain ⟨a, a_in_K, phi, phi_mono, xs_phi_lim⟩ := K_cpt xs_in_K
-  refine ⟨a, a_in_K, phi, phi_mono, ?_⟩
-  exact Filter.Tendsto.congr (fun x ↦ fxs_eq_ys (phi x)) (f_cont xs_phi_lim)
+  refine ⟨f a, mem_image_of_mem f a_in_K, phi, phi_mono, ?_⟩
+  exact (f_cont xs_phi_lim).congr fun x ↦ fxs_eq_ys (phi x)
 
 /-- The range of sequentially continuous function on a sequentially compact space is sequentially
 compact. -/


### PR DESCRIPTION
Add four lemmas about preservation of sequential compactness under (sequentially) continuous functions. 
[Zulip discussion](https://leanprover.zulipchat.com/#narrow/stream/217875-Is-there-code-for-X.3F/topic/Sequential.20compactness.20under.20sequentially.20cont.20functions/near/449031782)

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks, and is labeled with `awaiting-review`.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
