### PR TITLE
[Merged by Bors] - feat(SetTheory/Game/PGame): inserting an option a game

### DIFF
--- a/Mathlib/SetTheory/Game/PGame.lean
+++ b/Mathlib/SetTheory/Game/PGame.lean
@@ -1909,7 +1909,7 @@ theorem lt_iff_sub_pos {x y : PGame} : x < y ↔ 0 < y - x :=
 /-- The pregame constructed by inserting `x'` as a new left option into x. -/
 def insertLeft (x x' : PGame.{u}) : PGame :=
   match x with
-  | mk xl xr xL xR => mk (Sum xl PUnit) xr (Sum.elim xL fun _ => x') xR
+  | mk xl xr xL xR => mk (xl ⊕ PUnit) xr (Sum.elim xL fun _ => x') xR
 
 /-- A new left option cannot hurt Left. -/
 lemma le_insertLeft (x x' : PGame) : x ≤ insertLeft x x' := by
@@ -1956,7 +1956,7 @@ lemma insertLeft_equiv_of_lf {x x' : PGame} (h : x' ⧏ x) : insertLeft x x' ≈
 /-- The pregame constructed by inserting `x'` as a new right option into x. -/
 def insertRight (x x' : PGame.{u}) : PGame :=
   match x with
-  | mk xl xr xL xR => mk xl (Sum xr PUnit) xL (Sum.elim xR fun _ => x')
+  | mk xl xr xL xR => mk xl (xr ⊕ PUnit) xL (Sum.elim xR fun _ => x')
 
 theorem neg_insertRight_neg (x x' : PGame.{u}) : (-x).insertRight (-x') = -x.insertLeft x' := by
   cases x

--- a/Mathlib/SetTheory/Game/PGame.lean
+++ b/Mathlib/SetTheory/Game/PGame.lean
@@ -1958,47 +1958,26 @@ def insertRight (x x' : PGame.{u}) : PGame :=
   match x with
   | mk xl xr xL xR => mk xl (Sum xr PUnit) xL (Sum.elim xR fun _ => x')
 
+theorem neg_insertRight_neg (x x' : PGame.{u}) : (-x).insertRight (-x') = -x.insertLeft x' := by
+  cases x
+  cases x'
+  dsimp [insertRight, insertLeft]
+  congr! with (i | j)
+
+theorem neg_insertLeft_neg (x x' : PGame.{u}) : (-x).insertLeft (-x') = -x.insertRight x' := by
+  rw [← neg_eq_iff_eq_neg, ← neg_insertRight_neg, neg_neg, neg_neg]
+
 /-- A new right option cannot hurt Right. -/
 lemma insertRight_le (x x' : PGame) : insertRight x x' ≤ x := by
-  rw [le_def]
-  constructor
-  · intro i
-    left
-    rcases x with ⟨xl, xr, xL, xR⟩
-    simp only [leftMoves_mk, insertRight, moveLeft_mk]
-    use i
-  · intro j
-    right
-    rcases x with ⟨xl, xr, xL, xR⟩
-    simp only [insertRight, rightMoves_mk, moveRight_mk, Sum.exists, Sum.elim_inl]
-    left
-    use j
+  rw [← neg_le_neg_iff, ← neg_insertLeft_neg]
+  exact le_insertLeft _ _
 
 /-- Adding a gift horse right option does not change the value of `x`. A gift horse right option is
  a game `x'` with `x ⧏ x'`. It is called "gift horse" because it seems like Right has gotten the
  "gift" of a new option, but actually the value of the game did not change. -/
 lemma equiv_insertRight_of_lf {x x' : PGame} (h : x ⧏ x') : x ≈ insertRight x x' := by
-  rw [equiv_def]
-  constructor
-  · rw [le_def]
-    constructor
-    · intro i
-      rcases x with ⟨xl, xr, xL, xR⟩
-      simp only [insertRight, leftMoves_mk, moveLeft_mk]
-      left
-      use i
-    · intro j
-      rcases x with ⟨xl, xr, xL, xR⟩
-      simp only [insertRight, moveRight_mk, rightMoves_mk]
-      rcases j with j | _
-      · simp only [Sum.elim_inl]
-        right
-        use j
-      · simp only [Sum.elim_inr]
-        rw [lf_iff_exists_le] at h
-        simp only [rightMoves_mk, moveRight_mk] at h
-        exact h
-  · apply insertRight_le
+  rw [← neg_equiv_neg_iff, ← neg_insertLeft_neg]
+  exact equiv_insertLeft_of_lf (neg_lf_neg_iff.mpr h)
 
 /-! ### Special pre-games -/
 

--- a/Mathlib/SetTheory/Game/PGame.lean
+++ b/Mathlib/SetTheory/Game/PGame.lean
@@ -1907,7 +1907,7 @@ theorem lt_iff_sub_pos {x y : PGame} : x < y ↔ 0 < y - x :=
 /-! ### Inserting an option -/
 
 /-- The pregame constructed by inserting x' as a new left option into x. -/
-def insertLeft (x : PGame) (x' : PGame) : PGame :=
+def insertLeft (x x' : PGame) : PGame :=
   match x with
   | mk xl xr xL xR => mk (Sum xl PUnit) xr (fun i' =>
       match i' with
@@ -1916,7 +1916,7 @@ def insertLeft (x : PGame) (x' : PGame) : PGame :=
     ) xR
 
 /-- A new left option cannot hurt Left. -/
-lemma insert_left (x : PGame) (x' : PGame) : x ≤ insertLeft x x' := by
+lemma le_insertLeft (x x' : PGame) : x ≤ insertLeft x x' := by
   rw [le_def]
   constructor
   · intro i
@@ -1931,11 +1931,13 @@ lemma insert_left (x : PGame) (x' : PGame) : x ≤ insertLeft x x' := by
     simp only [rightMoves_mk, moveRight_mk, insertLeft]
     use j
 
-/-- Adding a gift horse left option does not change the value of x. -/
-lemma insertLeft_giftHorse (x : PGame) (x' : PGame) (h : x' ⧏ x) : x ≈ insertLeft x x' := by
+/-- Adding a gift horse left option does not change the value of x. A gift horse left option is
+ a game x' with x' ⧏ x. It is called "gift horse" because it seems like Left has gotten the "gift"
+ of a new option, but actually the value of the game did not change. -/
+lemma equiv_insertLeft_of_lf {x x' : PGame} (h : x' ⧏ x) : x ≈ insertLeft x x' := by
   rw [equiv_def]
   constructor
-  · apply insert_left
+  · apply le_insertLeft
   · rw [le_def]
     constructor
     · intro i
@@ -1956,7 +1958,7 @@ lemma insertLeft_giftHorse (x : PGame) (x' : PGame) (h : x' ⧏ x) : x ≈ inser
       use j
 
 /-- The pregame constructed by inserting x' as a new right option into x. -/
-def insertRight (x : PGame) (x' : PGame) : PGame :=
+def insertRight (x x' : PGame) : PGame :=
   match x with
   | mk xl xr xL xR => mk xl (Sum xr PUnit) xL (fun i' =>
       match i' with
@@ -1965,7 +1967,7 @@ def insertRight (x : PGame) (x' : PGame) : PGame :=
     )
 
 /-- A new right option cannot hurt Right. -/
-lemma insert_right (x : PGame) (x' : PGame) : insertRight x x' ≤ x := by
+lemma insertRight_le (x x' : PGame) : insertRight x x' ≤ x := by
   rw [le_def]
   constructor
   · intro i
@@ -1980,8 +1982,10 @@ lemma insert_right (x : PGame) (x' : PGame) : insertRight x x' ≤ x := by
     left
     use j
 
-/-- Adding a gift horse right option does not change the value of x. -/
-lemma insertRight_giftHorse (x : PGame) (x' : PGame) (h : x ⧏ x') : x ≈ insertRight x x' := by
+/-- Adding a gift horse right option does not change the value of x. A gift horse right option is
+ a game x' with x ⧏ x'. It is called "gift horse" because it seems like Right has gotten the "gift"
+ of a new option, but actually the value of the game did not change. -/
+lemma equiv_insertRight_of_lf {x x' : PGame} (h : x ⧏ x') : x ≈ insertRight x x' := by
   rw [equiv_def]
   constructor
   · rw [le_def]
@@ -2002,7 +2006,7 @@ lemma insertRight_giftHorse (x : PGame) (x' : PGame) (h : x ⧏ x') : x ≈ inse
         rw [lf_iff_exists_le] at h
         simp only [rightMoves_mk, moveRight_mk] at h
         exact h
-  · apply insert_right
+  · apply insertRight_le
 
 /-! ### Special pre-games -/
 

--- a/Mathlib/SetTheory/Game/PGame.lean
+++ b/Mathlib/SetTheory/Game/PGame.lean
@@ -1979,6 +1979,12 @@ lemma equiv_insertRight_of_lf {x x' : PGame} (h : x ⧏ x') : x ≈ insertRight 
   rw [← neg_equiv_neg_iff, ← neg_insertLeft_neg]
   exact equiv_insertLeft_of_lf (neg_lf_neg_iff.mpr h)
 
+/-- Inserting on the left and right commutes. -/
+theorem insertRight_insertLeft {x x' x'' : PGame} :
+    insertRight (insertLeft x x') x'' = insertLeft (insertRight x x'') x' := by
+  cases x; cases x'; cases x''
+  dsimp [insertLeft, insertRight]
+
 /-! ### Special pre-games -/
 
 

--- a/Mathlib/SetTheory/Game/PGame.lean
+++ b/Mathlib/SetTheory/Game/PGame.lean
@@ -1906,7 +1906,7 @@ theorem lt_iff_sub_pos {x y : PGame} : x < y ↔ 0 < y - x :=
 
 /-! ### Inserting an option -/
 
-/-- The pregame constructed by inserting x' as a new left option into x. -/
+/-- The pregame constructed by inserting `x'` as a new left option into x. -/
 def insertLeft (x x' : PGame.{u}) : PGame :=
   match x with
   | mk xl xr xL xR => mk (Sum xl PUnit) xr (Sum.elim xL fun _ => x') xR
@@ -1927,9 +1927,9 @@ lemma le_insertLeft (x x' : PGame) : x ≤ insertLeft x x' := by
     simp only [rightMoves_mk, moveRight_mk, insertLeft]
     use j
 
-/-- Adding a gift horse left option does not change the value of x. A gift horse left option is
- a game x' with x' ⧏ x. It is called "gift horse" because it seems like Left has gotten the "gift"
- of a new option, but actually the value of the game did not change. -/
+/-- Adding a gift horse left option does not change the value of `x`. A gift horse left option is
+ a game `x'` with `x' ⧏ x`. It is called "gift horse" because it seems like Left has gotten the
+ "gift" of a new option, but actually the value of the game did not change. -/
 lemma equiv_insertLeft_of_lf {x x' : PGame} (h : x' ⧏ x) : x ≈ insertLeft x x' := by
   rw [equiv_def]
   constructor
@@ -1953,7 +1953,7 @@ lemma equiv_insertLeft_of_lf {x x' : PGame} (h : x' ⧏ x) : x ≈ insertLeft x 
       simp only [insertLeft, rightMoves_mk, moveRight_mk]
       use j
 
-/-- The pregame constructed by inserting x' as a new right option into x. -/
+/-- The pregame constructed by inserting `x'` as a new right option into x. -/
 def insertRight (x x' : PGame.{u}) : PGame :=
   match x with
   | mk xl xr xL xR => mk xl (Sum xr PUnit) xL (Sum.elim xR fun _ => x')
@@ -1974,9 +1974,9 @@ lemma insertRight_le (x x' : PGame) : insertRight x x' ≤ x := by
     left
     use j
 
-/-- Adding a gift horse right option does not change the value of x. A gift horse right option is
- a game x' with x ⧏ x'. It is called "gift horse" because it seems like Right has gotten the "gift"
- of a new option, but actually the value of the game did not change. -/
+/-- Adding a gift horse right option does not change the value of `x`. A gift horse right option is
+ a game `x'` with `x ⧏ x'`. It is called "gift horse" because it seems like Right has gotten the
+ "gift" of a new option, but actually the value of the game did not change. -/
 lemma equiv_insertRight_of_lf {x x' : PGame} (h : x ⧏ x') : x ≈ insertRight x x' := by
   rw [equiv_def]
   constructor

--- a/Mathlib/SetTheory/Game/PGame.lean
+++ b/Mathlib/SetTheory/Game/PGame.lean
@@ -1904,6 +1904,106 @@ theorem lt_iff_sub_pos {x y : PGame} : x < y ↔ 0 < y - x :=
       ⟩
 #align pgame.lt_iff_sub_pos SetTheory.PGame.lt_iff_sub_pos
 
+/-! ### Inserting an option -/
+
+/-- The pregame constructed by inserting x' as a new left option into x. -/
+def insertLeft (x : PGame) (x' : PGame) : PGame :=
+  match x with
+  | mk xl xr xL xR => mk (Sum xl PUnit) xr (fun i' =>
+      match i' with
+      | .inl i => xL i
+      | .inr () => x'
+    ) xR
+
+/-- A new left option cannot hurt Left. -/
+lemma insert_left (x : PGame) (x' : PGame) : x ≤ insertLeft x x' := by
+  rw [le_def]
+  constructor
+  · intro i
+    left
+    rcases x with ⟨xl, xr, xL, xR⟩
+    simp only [insertLeft, leftMoves_mk, moveLeft_mk, Sum.exists, exists_const]
+    left
+    use i
+  · intro j
+    right
+    rcases x with ⟨xl, xr, xL, xR⟩
+    simp only [rightMoves_mk, moveRight_mk, insertLeft]
+    use j
+
+/-- Adding a gift horse left option does not change the value of x. -/
+lemma insertLeft_giftHorse (x : PGame) (x' : PGame) (h : x' ⧏ x) : x ≈ insertLeft x x' := by
+  rw [equiv_def]
+  constructor
+  · apply insert_left
+  · rw [le_def]
+    constructor
+    · intro i
+      rcases x with ⟨xl, xr, xL, xR⟩
+      simp only [insertLeft, leftMoves_mk, moveLeft_mk] at i ⊢
+      rcases i with i | _
+      · simp only
+        left
+        use i
+      · simp only
+        rw [lf_iff_exists_le] at h
+        simp only [leftMoves_mk, moveLeft_mk] at h
+        exact h
+    · intro j
+      right
+      rcases x with ⟨xl, xr, xL, xR⟩
+      simp only [insertLeft, rightMoves_mk, moveRight_mk]
+      use j
+
+/-- The pregame constructed by inserting x' as a new right option into x. -/
+def insertRight (x : PGame) (x' : PGame) : PGame :=
+  match x with
+  | mk xl xr xL xR => mk xl (Sum xr PUnit) xL (fun i' =>
+      match i' with
+      | .inl i => xR i
+      | .inr () => x'
+    )
+
+/-- A new right option cannot hurt Right. -/
+lemma insert_right (x : PGame) (x' : PGame) : insertRight x x' ≤ x := by
+  rw [le_def]
+  constructor
+  · intro i
+    left
+    rcases x with ⟨xl, xr, xL, xR⟩
+    simp only [leftMoves_mk, insertRight, moveLeft_mk]
+    use i
+  · intro j
+    right
+    rcases x with ⟨xl, xr, xL, xR⟩
+    simp only [insertRight, rightMoves_mk, moveRight_mk, Sum.exists, exists_const]
+    left
+    use j
+
+/-- Adding a gift horse right option does not change the value of x. -/
+lemma insertRight_giftHorse (x : PGame) (x' : PGame) (h : x ⧏ x') : x ≈ insertRight x x' := by
+  rw [equiv_def]
+  constructor
+  · rw [le_def]
+    constructor
+    · intro i
+      rcases x with ⟨xl, xr, xL, xR⟩
+      simp only [insertRight, leftMoves_mk, moveLeft_mk]
+      left
+      use i
+    · intro j
+      rcases x with ⟨xl, xr, xL, xR⟩
+      simp only [insertRight, moveRight_mk, rightMoves_mk]
+      rcases j with j | _
+      · simp only
+        right
+        use j
+      · simp only
+        rw [lf_iff_exists_le] at h
+        simp only [rightMoves_mk, moveRight_mk] at h
+        exact h
+  · apply insert_right
+
 /-! ### Special pre-games -/
 
 

--- a/Mathlib/SetTheory/Game/PGame.lean
+++ b/Mathlib/SetTheory/Game/PGame.lean
@@ -1907,7 +1907,7 @@ theorem lt_iff_sub_pos {x y : PGame} : x < y ↔ 0 < y - x :=
 /-! ### Inserting an option -/
 
 /-- The pregame constructed by inserting x' as a new left option into x. -/
-def insertLeft (x x' : PGame) : PGame :=
+def insertLeft (x x' : PGame.{u}) : PGame :=
   match x with
   | mk xl xr xL xR => mk (Sum xl PUnit) xr (Sum.elim xL fun _ => x') xR
 
@@ -1954,7 +1954,7 @@ lemma equiv_insertLeft_of_lf {x x' : PGame} (h : x' ⧏ x) : x ≈ insertLeft x 
       use j
 
 /-- The pregame constructed by inserting x' as a new right option into x. -/
-def insertRight (x x' : PGame) : PGame :=
+def insertRight (x x' : PGame.{u}) : PGame :=
   match x with
   | mk xl xr xL xR => mk xl (Sum xr PUnit) xL (Sum.elim xR fun _ => x')
 

--- a/Mathlib/SetTheory/Game/PGame.lean
+++ b/Mathlib/SetTheory/Game/PGame.lean
@@ -1930,10 +1930,9 @@ lemma le_insertLeft (x x' : PGame) : x ≤ insertLeft x x' := by
 /-- Adding a gift horse left option does not change the value of `x`. A gift horse left option is
  a game `x'` with `x' ⧏ x`. It is called "gift horse" because it seems like Left has gotten the
  "gift" of a new option, but actually the value of the game did not change. -/
-lemma equiv_insertLeft_of_lf {x x' : PGame} (h : x' ⧏ x) : x ≈ insertLeft x x' := by
+lemma insertLeft_equiv_of_lf {x x' : PGame} (h : x' ⧏ x) : insertLeft x x' ≈ x := by
   rw [equiv_def]
   constructor
-  · apply le_insertLeft
   · rw [le_def]
     constructor
     · intro i
@@ -1952,6 +1951,7 @@ lemma equiv_insertLeft_of_lf {x x' : PGame} (h : x' ⧏ x) : x ≈ insertLeft x 
       rcases x with ⟨xl, xr, xL, xR⟩
       simp only [insertLeft, rightMoves_mk, moveRight_mk]
       use j
+  · apply le_insertLeft
 
 /-- The pregame constructed by inserting `x'` as a new right option into x. -/
 def insertRight (x x' : PGame.{u}) : PGame :=
@@ -1975,9 +1975,9 @@ lemma insertRight_le (x x' : PGame) : insertRight x x' ≤ x := by
 /-- Adding a gift horse right option does not change the value of `x`. A gift horse right option is
  a game `x'` with `x ⧏ x'`. It is called "gift horse" because it seems like Right has gotten the
  "gift" of a new option, but actually the value of the game did not change. -/
-lemma equiv_insertRight_of_lf {x x' : PGame} (h : x ⧏ x') : x ≈ insertRight x x' := by
+lemma insertRight_equiv_of_lf {x x' : PGame} (h : x ⧏ x') : insertRight x x' ≈ x := by
   rw [← neg_equiv_neg_iff, ← neg_insertLeft_neg]
-  exact equiv_insertLeft_of_lf (neg_lf_neg_iff.mpr h)
+  exact insertLeft_equiv_of_lf (neg_lf_neg_iff.mpr h)
 
 /-- Inserting on the left and right commutes. -/
 theorem insertRight_insertLeft {x x' x'' : PGame} :

--- a/Mathlib/SetTheory/Game/PGame.lean
+++ b/Mathlib/SetTheory/Game/PGame.lean
@@ -1909,11 +1909,7 @@ theorem lt_iff_sub_pos {x y : PGame} : x < y ↔ 0 < y - x :=
 /-- The pregame constructed by inserting x' as a new left option into x. -/
 def insertLeft (x x' : PGame) : PGame :=
   match x with
-  | mk xl xr xL xR => mk (Sum xl PUnit) xr (fun i' =>
-      match i' with
-      | .inl i => xL i
-      | .inr () => x'
-    ) xR
+  | mk xl xr xL xR => mk (Sum xl PUnit) xr (Sum.elim xL fun _ => x') xR
 
 /-- A new left option cannot hurt Left. -/
 lemma le_insertLeft (x x' : PGame) : x ≤ insertLeft x x' := by
@@ -1922,7 +1918,7 @@ lemma le_insertLeft (x x' : PGame) : x ≤ insertLeft x x' := by
   · intro i
     left
     rcases x with ⟨xl, xr, xL, xR⟩
-    simp only [insertLeft, leftMoves_mk, moveLeft_mk, Sum.exists, exists_const]
+    simp only [insertLeft, leftMoves_mk, moveLeft_mk, Sum.exists, Sum.elim_inl]
     left
     use i
   · intro j
@@ -1944,10 +1940,10 @@ lemma equiv_insertLeft_of_lf {x x' : PGame} (h : x' ⧏ x) : x ≈ insertLeft x 
       rcases x with ⟨xl, xr, xL, xR⟩
       simp only [insertLeft, leftMoves_mk, moveLeft_mk] at i ⊢
       rcases i with i | _
-      · simp only
+      · simp only [Sum.elim_inl]
         left
         use i
-      · simp only
+      · simp only [Sum.elim_inr]
         rw [lf_iff_exists_le] at h
         simp only [leftMoves_mk, moveLeft_mk] at h
         exact h
@@ -1960,11 +1956,7 @@ lemma equiv_insertLeft_of_lf {x x' : PGame} (h : x' ⧏ x) : x ≈ insertLeft x 
 /-- The pregame constructed by inserting x' as a new right option into x. -/
 def insertRight (x x' : PGame) : PGame :=
   match x with
-  | mk xl xr xL xR => mk xl (Sum xr PUnit) xL (fun i' =>
-      match i' with
-      | .inl i => xR i
-      | .inr () => x'
-    )
+  | mk xl xr xL xR => mk xl (Sum xr PUnit) xL (Sum.elim xR fun _ => x')
 
 /-- A new right option cannot hurt Right. -/
 lemma insertRight_le (x x' : PGame) : insertRight x x' ≤ x := by
@@ -1978,7 +1970,7 @@ lemma insertRight_le (x x' : PGame) : insertRight x x' ≤ x := by
   · intro j
     right
     rcases x with ⟨xl, xr, xL, xR⟩
-    simp only [insertRight, rightMoves_mk, moveRight_mk, Sum.exists, exists_const]
+    simp only [insertRight, rightMoves_mk, moveRight_mk, Sum.exists, Sum.elim_inl]
     left
     use j
 
@@ -1999,10 +1991,10 @@ lemma equiv_insertRight_of_lf {x x' : PGame} (h : x ⧏ x') : x ≈ insertRight 
       rcases x with ⟨xl, xr, xL, xR⟩
       simp only [insertRight, moveRight_mk, rightMoves_mk]
       rcases j with j | _
-      · simp only
+      · simp only [Sum.elim_inl]
         right
         use j
-      · simp only
+      · simp only [Sum.elim_inr]
         rw [lf_iff_exists_le] at h
         simp only [rightMoves_mk, moveRight_mk] at h
         exact h

--- a/Mathlib/SetTheory/Surreal/Basic.lean
+++ b/Mathlib/SetTheory/Surreal/Basic.lean
@@ -208,7 +208,7 @@ theorem numeric_of_insertLeft_numeric {x x' : PGame} (x_num : x.Numeric) (x'_num
   rw [le_iff_forall_lt x'_num x_num] at h
   unfold Numeric at x_num ⊢
   rcases x with ⟨xl, xr, xL, xR⟩
-  simp only [insertLeft, Sum.forall, forall_const] at x_num ⊢
+  simp only [insertLeft, Sum.forall, forall_const, Sum.elim_inl, Sum.elim_inr] at x_num ⊢
   constructor
   · simp only [x_num.1, implies_true, true_and]
     simp only [rightMoves_mk, moveRight_mk] at h
@@ -221,7 +221,7 @@ theorem numeric_of_insertRight_numeric {x x' : PGame} (x_num : x.Numeric) (x'_nu
   rw [le_iff_forall_lt x_num x'_num] at h
   unfold Numeric at x_num ⊢
   rcases x with ⟨xl, xr, xL, xR⟩
-  simp only [insertRight, Sum.forall, forall_const] at x_num ⊢
+  simp only [insertRight, Sum.forall, forall_const, Sum.elim_inl, Sum.elim_inr] at x_num ⊢
   constructor
   · simp only [x_num.1, implies_true, true_and]
     simp only [leftMoves_mk, moveLeft_mk] at h

--- a/Mathlib/SetTheory/Surreal/Basic.lean
+++ b/Mathlib/SetTheory/Surreal/Basic.lean
@@ -202,8 +202,8 @@ theorem numeric_of_isEmpty_rightMoves (x : PGame) [IsEmpty x.RightMoves]
   Numeric.mk (fun _ => isEmptyElim) H isEmptyElim
 #align pgame.numeric_of_is_empty_right_moves SetTheory.PGame.numeric_of_isEmpty_rightMoves
 
-/-- Inserting a smaller numeric left option into a numeric results in a numeric. -/
-theorem numeric_of_insertLeft_numeric {x x' : PGame} (x_num : x.Numeric) (x'_num : x'.Numeric)
+/-- Inserting a smaller numeric left option into a numeric game results in a numeric game. -/
+theorem insertLeft_numeric {x x' : PGame} (x_num : x.Numeric) (x'_num : x'.Numeric)
     (h : x' ≤ x) : (insertLeft x x').Numeric := by
   rw [le_iff_forall_lt x'_num x_num] at h
   unfold Numeric at x_num ⊢
@@ -215,8 +215,8 @@ theorem numeric_of_insertLeft_numeric {x x' : PGame} (x_num : x.Numeric) (x'_num
     exact h.2
   · simp only [x_num, implies_true, x'_num, and_self]
 
-/-- Inserting a larger numeric right option into a numeric results in a numeric. -/
-theorem numeric_of_insertRight_numeric {x x' : PGame} (x_num : x.Numeric) (x'_num : x'.Numeric)
+/-- Inserting a larger numeric right option into a numeric game results in a numeric game. -/
+theorem insertRight_numeric {x x' : PGame} (x_num : x.Numeric) (x'_num : x'.Numeric)
     (h : x ≤ x') : (insertRight x x').Numeric := by
   rw [le_iff_forall_lt x_num x'_num] at h
   unfold Numeric at x_num ⊢

--- a/Mathlib/SetTheory/Surreal/Basic.lean
+++ b/Mathlib/SetTheory/Surreal/Basic.lean
@@ -203,8 +203,8 @@ theorem numeric_of_isEmpty_rightMoves (x : PGame) [IsEmpty x.RightMoves]
 #align pgame.numeric_of_is_empty_right_moves SetTheory.PGame.numeric_of_isEmpty_rightMoves
 
 /-- Inserting a smaller numeric left option into a numeric results in a numeric. -/
-theorem numeric_of_insertLeft_numeric (x : PGame) (x_num : x.Numeric)
-    (x' : PGame) (x'_num : x'.Numeric) (h : x' ≤ x) : (insertLeft x x').Numeric := by
+theorem numeric_of_insertLeft_numeric {x x' : PGame} (x_num : x.Numeric) (x'_num : x'.Numeric)
+    (h : x' ≤ x) : (insertLeft x x').Numeric := by
   rw [le_iff_forall_lt x'_num x_num] at h
   unfold Numeric at x_num ⊢
   rcases x with ⟨xl, xr, xL, xR⟩
@@ -216,8 +216,8 @@ theorem numeric_of_insertLeft_numeric (x : PGame) (x_num : x.Numeric)
   · simp only [x_num, implies_true, x'_num, and_self]
 
 /-- Inserting a larger numeric right option into a numeric results in a numeric. -/
-theorem numeric_of_insertRight_numeric (x : PGame) (x_num : x.Numeric)
-    (x' : PGame) (x'_num : x'.Numeric) (h : x ≤ x') : (insertRight x x').Numeric := by
+theorem numeric_of_insertRight_numeric {x x' : PGame} (x_num : x.Numeric) (x'_num : x'.Numeric)
+    (h : x ≤ x') : (insertRight x x').Numeric := by
   rw [le_iff_forall_lt x_num x'_num] at h
   unfold Numeric at x_num ⊢
   rcases x with ⟨xl, xr, xL, xR⟩

--- a/Mathlib/SetTheory/Surreal/Basic.lean
+++ b/Mathlib/SetTheory/Surreal/Basic.lean
@@ -202,6 +202,19 @@ theorem numeric_of_isEmpty_rightMoves (x : PGame) [IsEmpty x.RightMoves]
   Numeric.mk (fun _ => isEmptyElim) H isEmptyElim
 #align pgame.numeric_of_is_empty_right_moves SetTheory.PGame.numeric_of_isEmpty_rightMoves
 
+theorem numeric_zero : Numeric 0 :=
+  numeric_of_isEmpty 0
+#align pgame.numeric_zero SetTheory.PGame.numeric_zero
+
+theorem numeric_one : Numeric 1 :=
+  numeric_of_isEmpty_rightMoves 1 fun _ => numeric_zero
+#align pgame.numeric_one SetTheory.PGame.numeric_one
+
+theorem Numeric.neg : ∀ {x : PGame} (_ : Numeric x), Numeric (-x)
+  | ⟨_, _, _, _⟩, o =>
+    ⟨fun j i => neg_lt_neg_iff.2 (o.1 i j), fun j => (o.2.2 j).neg, fun i => (o.2.1 i).neg⟩
+#align pgame.numeric.neg SetTheory.PGame.Numeric.neg
+
 /-- Inserting a smaller numeric left option into a numeric game results in a numeric game. -/
 theorem insertLeft_numeric {x x' : PGame} (x_num : x.Numeric) (x'_num : x'.Numeric)
     (h : x' ≤ x) : (insertLeft x x').Numeric := by
@@ -218,28 +231,9 @@ theorem insertLeft_numeric {x x' : PGame} (x_num : x.Numeric) (x'_num : x'.Numer
 /-- Inserting a larger numeric right option into a numeric game results in a numeric game. -/
 theorem insertRight_numeric {x x' : PGame} (x_num : x.Numeric) (x'_num : x'.Numeric)
     (h : x ≤ x') : (insertRight x x').Numeric := by
-  rw [le_iff_forall_lt x_num x'_num] at h
-  unfold Numeric at x_num ⊢
-  rcases x with ⟨xl, xr, xL, xR⟩
-  simp only [insertRight, Sum.forall, forall_const, Sum.elim_inl, Sum.elim_inr] at x_num ⊢
-  constructor
-  · simp only [x_num.1, implies_true, true_and]
-    simp only [leftMoves_mk, moveLeft_mk] at h
-    exact h.1
-  · simp only [x_num, implies_true, x'_num, and_self]
-
-theorem numeric_zero : Numeric 0 :=
-  numeric_of_isEmpty 0
-#align pgame.numeric_zero SetTheory.PGame.numeric_zero
-
-theorem numeric_one : Numeric 1 :=
-  numeric_of_isEmpty_rightMoves 1 fun _ => numeric_zero
-#align pgame.numeric_one SetTheory.PGame.numeric_one
-
-theorem Numeric.neg : ∀ {x : PGame} (_ : Numeric x), Numeric (-x)
-  | ⟨_, _, _, _⟩, o =>
-    ⟨fun j i => neg_lt_neg_iff.2 (o.1 i j), fun j => (o.2.2 j).neg, fun i => (o.2.1 i).neg⟩
-#align pgame.numeric.neg SetTheory.PGame.Numeric.neg
+  rw [← neg_neg (x.insertRight x'), ← neg_insertLeft_neg]
+  apply Numeric.neg
+  exact insertLeft_numeric (Numeric.neg x_num) (Numeric.neg x'_num) (neg_le_neg_iff.mpr h)
 
 namespace Numeric
 

--- a/Mathlib/SetTheory/Surreal/Basic.lean
+++ b/Mathlib/SetTheory/Surreal/Basic.lean
@@ -202,6 +202,32 @@ theorem numeric_of_isEmpty_rightMoves (x : PGame) [IsEmpty x.RightMoves]
   Numeric.mk (fun _ => isEmptyElim) H isEmptyElim
 #align pgame.numeric_of_is_empty_right_moves SetTheory.PGame.numeric_of_isEmpty_rightMoves
 
+/-- Inserting a smaller numeric left option into a numeric results in a numeric. -/
+theorem numeric_of_insertLeft_numeric (x : PGame) (x_num : x.Numeric)
+    (x' : PGame) (x'_num : x'.Numeric) (h : x' ≤ x) : (insertLeft x x').Numeric := by
+  rw [le_iff_forall_lt x'_num x_num] at h
+  unfold Numeric at x_num ⊢
+  rcases x with ⟨xl, xr, xL, xR⟩
+  simp only [insertLeft, Sum.forall, forall_const] at x_num ⊢
+  constructor
+  · simp only [x_num.1, implies_true, true_and]
+    simp only [rightMoves_mk, moveRight_mk] at h
+    exact h.2
+  · simp only [x_num, implies_true, x'_num, and_self]
+
+/-- Inserting a larger numeric right option into a numeric results in a numeric. -/
+theorem numeric_of_insertRight_numeric (x : PGame) (x_num : x.Numeric)
+    (x' : PGame) (x'_num : x'.Numeric) (h : x ≤ x') : (insertRight x x').Numeric := by
+  rw [le_iff_forall_lt x_num x'_num] at h
+  unfold Numeric at x_num ⊢
+  rcases x with ⟨xl, xr, xL, xR⟩
+  simp only [insertRight, Sum.forall, forall_const] at x_num ⊢
+  constructor
+  · simp only [x_num.1, implies_true, true_and]
+    simp only [leftMoves_mk, moveLeft_mk] at h
+    exact h.1
+  · simp only [x_num, implies_true, x'_num, and_self]
+
 theorem numeric_zero : Numeric 0 :=
   numeric_of_isEmpty 0
 #align pgame.numeric_zero SetTheory.PGame.numeric_zero


### PR DESCRIPTION
inserting an option into a game

---
This PR is split out of #14498. Here, we define the operation of inserting a left or right option into a game, and prove a few standard results about it.

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks, and is labeled with `awaiting-review`.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
