### PR TITLE
[Merged by Bors] - chore: remove `@[simp]` from `List.replicate_succ`

### DIFF
--- a/Archive/Wiedijk100Theorems/BallotProblem.lean
+++ b/Archive/Wiedijk100Theorems/BallotProblem.lean
@@ -210,7 +210,7 @@ theorem first_vote_pos :
       0 < p + q → condCount (countedSequence p q : Set (List ℤ)) {l | l.headI = 1} = p / (p + q)
   | p + 1, 0, _ => by
     rw [counted_right_zero, condCount_singleton]
-    simp [ENNReal.div_self _ _]
+    simp [ENNReal.div_self _ _, List.replicate_succ]
   | 0, q + 1, _ => by
     rw [counted_left_zero, condCount_singleton]
     simp only [List.replicate, Nat.add_eq, add_zero, mem_setOf_eq, List.headI_cons, Nat.cast_zero,

--- a/Mathlib/Data/List/Basic.lean
+++ b/Mathlib/Data/List/Basic.lean
@@ -406,7 +406,6 @@ theorem append_left_injective (t : List α) : Injective fun s ↦ s ++ t :=
 
 #align list.replicate_zero List.replicate_zero
 
-attribute [simp] replicate_succ
 #align list.replicate_succ List.replicate_succ
 
 #align list.replicate_one List.replicate_one
@@ -417,7 +416,7 @@ attribute [simp] replicate_succ
 
 theorem eq_replicate_length {a : α} : ∀ {l : List α}, l = replicate l.length a ↔ ∀ b ∈ l, b = a
   | [] => by simp
-  | (b :: l) => by simp [eq_replicate_length]
+  | (b :: l) => by simp [eq_replicate_length, replicate_succ]
 #align list.eq_replicate_length List.eq_replicate_length
 
 #align list.eq_replicate_of_mem List.eq_replicate_of_mem
@@ -472,7 +471,7 @@ theorem replicate_left_inj {a : α} {n m : ℕ} : replicate n a = replicate m a 
 #align list.replicate_left_inj List.replicate_left_inj
 
 @[simp] theorem head_replicate (n : ℕ) (a : α) (h) : head (replicate n a) h = a := by
-  cases n <;> simp at h ⊢
+  cases n <;> simp [replicate_succ] at h ⊢
 
 /-! ### pure -/
 

--- a/Mathlib/Data/List/Duplicate.lean
+++ b/Mathlib/Data/List/Duplicate.lean
@@ -139,7 +139,7 @@ theorem Duplicate.not_nodup (h : x ∈+ l) : ¬Nodup l := fun H =>
 #align list.duplicate.not_nodup List.Duplicate.not_nodup
 
 theorem duplicate_iff_two_le_count [DecidableEq α] : x ∈+ l ↔ 2 ≤ count x l := by
-  simp [duplicate_iff_sublist, le_count_iff_replicate_sublist]
+  simp [replicate_succ, duplicate_iff_sublist, le_count_iff_replicate_sublist]
 #align list.duplicate_iff_two_le_count List.duplicate_iff_two_le_count
 
 instance decidableDuplicate [DecidableEq α] (x : α) : ∀ l : List α, Decidable (x ∈+ l)


### PR DESCRIPTION
I may be tilting at windmills, but I've removed `@[simp]` from `List.replicate_succ` in Lean, and I think it results in slightly better simp normal forms in some situations. We don't yet have automatic post-Mathlib testing of simp normal forms, but I hope we will eventually.

In the meantime, this removes an inconsistency by cancelling Mathlib's downstream addition of `@[simp]` to `List.replicate.succ`. Mathlib doesn't mind much.