### PR TITLE
[Merged by Bors] - chore(Data/Set): golf and add decidability of insert

### DIFF
--- a/Mathlib/Data/Set/Basic.lean
+++ b/Mathlib/Data/Set/Basic.lean
@@ -2530,38 +2530,40 @@ end Subsingleton
 
 namespace Set
 
-variable {α : Type u} (s t : Set α) (a : α)
+variable {α : Type u} (s t : Set α) (a b : α)
 
 instance decidableSdiff [Decidable (a ∈ s)] [Decidable (a ∈ t)] : Decidable (a ∈ s \ t) :=
-  (by infer_instance : Decidable (a ∈ s ∧ a ∉ t))
+  inferInstanceAs (Decidable (a ∈ s ∧ a ∉ t))
 #align set.decidable_sdiff Set.decidableSdiff
 
 instance decidableInter [Decidable (a ∈ s)] [Decidable (a ∈ t)] : Decidable (a ∈ s ∩ t) :=
-  (by infer_instance : Decidable (a ∈ s ∧ a ∈ t))
+  inferInstanceAs (Decidable (a ∈ s ∧ a ∈ t))
 #align set.decidable_inter Set.decidableInter
 
 instance decidableUnion [Decidable (a ∈ s)] [Decidable (a ∈ t)] : Decidable (a ∈ s ∪ t) :=
-  (by infer_instance : Decidable (a ∈ s ∨ a ∈ t))
+  inferInstanceAs (Decidable (a ∈ s ∨ a ∈ t))
 #align set.decidable_union Set.decidableUnion
 
 instance decidableCompl [Decidable (a ∈ s)] : Decidable (a ∈ sᶜ) :=
-  (by infer_instance : Decidable (a ∉ s))
+  inferInstanceAs (Decidable (a ∉ s))
 #align set.decidable_compl Set.decidableCompl
 
-instance decidableEmptyset : DecidablePred (· ∈ (∅ : Set α)) := fun _ => Decidable.isFalse (by simp)
+instance decidableEmptyset : Decidable (a ∈ (∅ : Set α)) := Decidable.isFalse (by simp)
 #align set.decidable_emptyset Set.decidableEmptyset
 
-instance decidableUniv : DecidablePred (· ∈ (Set.univ : Set α)) := fun _ =>
-  Decidable.isTrue (by simp)
+instance decidableUniv : Decidable (a ∈ univ) := Decidable.isTrue (by simp)
 #align set.decidable_univ Set.decidableUniv
+
+instance decidableInsert [Decidable (a = b)] [Decidable (a ∈ s)] : Decidable (a ∈ insert b s) :=
+  inferInstanceAs (Decidable (_ ∨ _))
+
+-- Porting note: Lean 3 unfolded `{a}` before finding instances but Lean 4 needs additional help
+instance decidableSingleton [Decidable (a = b)] : Decidable (a ∈ ({b} : Set α)) :=
+  inferInstanceAs (Decidable (a = b))
 
 instance decidableSetOf (p : α → Prop) [Decidable (p a)] : Decidable (a ∈ { a | p a }) := by
   assumption
 #align set.decidable_set_of Set.decidableSetOf
-
--- Porting note: Lean 3 unfolded `{a}` before finding instances but Lean 4 needs additional help
-instance decidableMemSingleton {a b : α} [DecidableEq α] :
-    Decidable (a ∈ ({b} : Set α)) := decidableSetOf _ (· = b)
 
 end Set
 


### PR DESCRIPTION
Adds the insert version, golfs existing versions using `inferInstanceAs`.
Makes the lemmas all consistent about using `Decidable` vs `DecidablePred`.

These decidability instances are useful in downstream applications. 

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks, and is labeled with `awaiting-review`.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
