### PR TITLE
[Merged by Bors] - chore (Data.Nat.Cast.Field): split into unbundled and bundled results 

### DIFF
--- a/Archive/OxfordInvariants/Summer2021/Week3P1.lean
+++ b/Archive/OxfordInvariants/Summer2021/Week3P1.lean
@@ -6,6 +6,7 @@ Authors: Yaël Dillies, Bhavik Mehta
 import Mathlib.Algebra.BigOperators.Ring
 import Mathlib.Algebra.Order.BigOperators.Group.Finset
 import Mathlib.Data.Nat.Cast.Field
+import Mathlib.Data.Nat.Cast.Order.Field
 
 #align_import oxford_invariants.«2021summer».week3_p1 from "leanprover-community/mathlib"@"328375597f2c0dd00522d9c2e5a33b6a6128feeb"
 

--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -2204,6 +2204,7 @@ import Mathlib.Data.Nat.Cast.Defs
 import Mathlib.Data.Nat.Cast.Field
 import Mathlib.Data.Nat.Cast.NeZero
 import Mathlib.Data.Nat.Cast.Order.Basic
+import Mathlib.Data.Nat.Cast.Order.Field
 import Mathlib.Data.Nat.Cast.Order.Ring
 import Mathlib.Data.Nat.Cast.Prod
 import Mathlib.Data.Nat.Cast.SetInterval

--- a/Mathlib/Algebra/CharZero/Lemmas.lean
+++ b/Mathlib/Algebra/CharZero/Lemmas.lean
@@ -4,8 +4,10 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Mario Carneiro
 -/
 import Mathlib.Algebra.Group.Support
+import Mathlib.Algebra.Order.Monoid.Unbundled.Pow
 import Mathlib.Algebra.Order.Monoid.WithTop
 import Mathlib.Data.Nat.Cast.Field
+import Mathlib.Algebra.Field.Basic
 
 #align_import algebra.char_zero.lemmas from "leanprover-community/mathlib"@"acee671f47b8e7972a1eb6f4eed74b4b3abce829"
 

--- a/Mathlib/Algebra/Order/Floor.lean
+++ b/Mathlib/Algebra/Order/Floor.lean
@@ -7,6 +7,7 @@ import Mathlib.Algebra.CharZero.Lemmas
 import Mathlib.Algebra.Order.Interval.Set.Group
 import Mathlib.Algebra.Group.Int
 import Mathlib.Data.Int.Lemmas
+import Mathlib.Data.Nat.Cast.Order.Field
 import Mathlib.Data.Set.Subsingleton
 import Mathlib.Init.Data.Nat.Lemmas
 import Mathlib.Order.GaloisConnection

--- a/Mathlib/Algebra/Order/Monoid/Unbundled/Basic.lean
+++ b/Mathlib/Algebra/Order/Monoid/Unbundled/Basic.lean
@@ -34,6 +34,20 @@ Almost no monoid is actually present in this file: most assumptions have been ge
 -- after the `ordered`-refactor is done.
 open Function
 
+section Nat
+
+instance Nat.instCovariantClassMulLE : CovariantClass ℕ ℕ (· * ·) (· ≤ ·) where
+  elim := fun _ _ _ h => mul_le_mul_left _ h
+
+end Nat
+
+section Int
+
+instance Int.instCovariantClassAddLE : CovariantClass ℤ ℤ ((· + ·)) (· ≤ ·) where
+  elim := fun _ _ _ h => Int.add_le_add_left h _
+
+end Int
+
 variable {α β : Type*}
 
 section Mul

--- a/Mathlib/Combinatorics/SimpleGraph/Coloring.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Coloring.lean
@@ -8,6 +8,7 @@ import Mathlib.Data.ENat.Lattice
 import Mathlib.Data.Nat.Lattice
 import Mathlib.Data.Setoid.Partition
 import Mathlib.Order.Antichain
+import Mathlib.Data.Nat.Cast.Order.Ring
 
 #align_import combinatorics.simple_graph.coloring from "leanprover-community/mathlib"@"70fd9563a21e7b963887c9360bd29b2393e6225a"
 

--- a/Mathlib/Combinatorics/SimpleGraph/Regularity/Uniform.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Regularity/Uniform.lean
@@ -5,7 +5,7 @@ Authors: Yaël Dillies, Bhavik Mehta
 -/
 import Mathlib.Algebra.BigOperators.Ring
 import Mathlib.Combinatorics.SimpleGraph.Density
-import Mathlib.Data.Nat.Cast.Field
+import Mathlib.Data.Nat.Cast.Order.Field
 import Mathlib.Order.Partition.Equipartition
 import Mathlib.SetTheory.Ordinal.Basic
 

--- a/Mathlib/Data/ENat/Basic.lean
+++ b/Mathlib/Data/ENat/Basic.lean
@@ -7,6 +7,7 @@ import Mathlib.Data.Nat.SuccPred
 import Mathlib.Algebra.CharZero.Lemmas
 import Mathlib.Algebra.Order.Sub.WithTop
 import Mathlib.Algebra.Order.Ring.WithTop
+import Mathlib.Data.Nat.Cast.Order.Basic
 
 #align_import data.enat.basic from "leanprover-community/mathlib"@"ceb887ddf3344dab425292e497fa2af91498437c"
 

--- a/Mathlib/Data/Int/Interval.lean
+++ b/Mathlib/Data/Int/Interval.lean
@@ -4,6 +4,8 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Yaël Dillies
 -/
 import Mathlib.Algebra.CharZero.Lemmas
+import Mathlib.Algebra.Order.Group.Int
+import Mathlib.Algebra.Ring.Int
 import Mathlib.Order.Interval.Finset.Basic
 
 #align_import data.int.interval from "leanprover-community/mathlib"@"1d29de43a5ba4662dd33b5cfeecfc2a27a5a8a29"

--- a/Mathlib/Data/Nat/Cast/Field.lean
+++ b/Mathlib/Data/Nat/Cast/Field.lean
@@ -33,7 +33,8 @@ theorem cast_div [DivisionSemiring α] {m n : ℕ} (n_dvd : n ∣ m) (hn : (n : 
     ((m / n : ℕ) : α) = m / n := by
   rcases n_dvd with ⟨k, rfl⟩
   have : n ≠ 0 := by rintro rfl; simp at hn
-  rw [Nat.mul_div_cancel_left _ <| zero_lt_of_ne_zero this, mul_comm n, cast_mul, mul_div_cancel_right₀ _ hn]
+  rw [Nat.mul_div_cancel_left _ <| zero_lt_of_ne_zero this, mul_comm n,
+    cast_mul, mul_div_cancel_right₀ _ hn]
 #align nat.cast_div Nat.cast_div
 
 theorem cast_div_div_div_cancel_right [DivisionSemiring α] [CharZero α] {m n d : ℕ}

--- a/Mathlib/Data/Nat/Cast/Field.lean
+++ b/Mathlib/Data/Nat/Cast/Field.lean
@@ -4,8 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Mario Carneiro, Yaël Dillies, Patrick Stevens
 -/
 import Mathlib.Algebra.CharZero.Defs
--- import Mathlib.Algebra.Order.Field.Basic
--- import Mathlib.Data.Nat.Cast.Order.Basic
 import Mathlib.Data.Nat.Cast.Basic
 import Mathlib.Tactic.Common
 import Mathlib.Algebra.Field.Defs

--- a/Mathlib/Data/Nat/Cast/Field.lean
+++ b/Mathlib/Data/Nat/Cast/Field.lean
@@ -4,12 +4,12 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Mario Carneiro, Yaël Dillies, Patrick Stevens
 -/
 import Mathlib.Algebra.CharZero.Defs
-import Mathlib.Algebra.Field.Basic
-import Mathlib.Order.BoundedOrder
 -- import Mathlib.Algebra.Order.Field.Basic
 -- import Mathlib.Data.Nat.Cast.Order.Basic
 import Mathlib.Data.Nat.Cast.Basic
 import Mathlib.Tactic.Common
+import Mathlib.Algebra.Field.Defs
+import Mathlib.Algebra.GroupWithZero.Units.Basic
 
 #align_import data.nat.cast.field from "leanprover-community/mathlib"@"acee671f47b8e7972a1eb6f4eed74b4b3abce829"
 

--- a/Mathlib/Data/Nat/Cast/Field.lean
+++ b/Mathlib/Data/Nat/Cast/Field.lean
@@ -3,8 +3,12 @@ Copyright (c) 2014 Mario Carneiro. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Mario Carneiro, Yaël Dillies, Patrick Stevens
 -/
-import Mathlib.Algebra.Order.Field.Basic
-import Mathlib.Data.Nat.Cast.Order.Basic
+import Mathlib.Algebra.CharZero.Defs
+import Mathlib.Algebra.Field.Basic
+import Mathlib.Order.BoundedOrder
+-- import Mathlib.Algebra.Order.Field.Basic
+-- import Mathlib.Data.Nat.Cast.Order.Basic
+import Mathlib.Data.Nat.Cast.Basic
 import Mathlib.Tactic.Common
 
 #align_import data.nat.cast.field from "leanprover-community/mathlib"@"acee671f47b8e7972a1eb6f4eed74b4b3abce829"
@@ -17,7 +21,6 @@ This file concerns the canonical homomorphism `ℕ → F`, where `F` is a field.
 ## Main results
 
  * `Nat.cast_div`: if `n` divides `m`, then `↑(m / n) = ↑m / ↑n`
- * `Nat.cast_div_le`: in all cases, `↑(m / n) ≤ ↑m / ↑ n`
 -/
 
 
@@ -30,7 +33,7 @@ theorem cast_div [DivisionSemiring α] {m n : ℕ} (n_dvd : n ∣ m) (hn : (n : 
     ((m / n : ℕ) : α) = m / n := by
   rcases n_dvd with ⟨k, rfl⟩
   have : n ≠ 0 := by rintro rfl; simp at hn
-  rw [Nat.mul_div_cancel_left _ this.bot_lt, mul_comm n, cast_mul, mul_div_cancel_right₀ _ hn]
+  rw [Nat.mul_div_cancel_left _ <| zero_lt_of_ne_zero this, mul_comm n, cast_mul, mul_div_cancel_right₀ _ hn]
 #align nat.cast_div Nat.cast_div
 
 theorem cast_div_div_div_cancel_right [DivisionSemiring α] [CharZero α] {m n d : ℕ}
@@ -40,45 +43,3 @@ theorem cast_div_div_div_cancel_right [DivisionSemiring α] [CharZero α] {m n d
   replace hd : (d : α) ≠ 0 := by norm_cast
   rw [cast_div hm, cast_div hn, div_div_div_cancel_right _ hd] <;> exact hd
 #align nat.cast_div_div_div_cancel_right Nat.cast_div_div_div_cancel_right
-
-section LinearOrderedSemifield
-
-variable [LinearOrderedSemifield α]
-
-lemma cast_inv_le_one : ∀ n : ℕ, (n⁻¹ : α) ≤ 1
-  | 0 => by simp
-  | n + 1 => inv_le_one $ by simp [Nat.cast_nonneg]
-
-/-- Natural division is always less than division in the field. -/
-theorem cast_div_le {m n : ℕ} : ((m / n : ℕ) : α) ≤ m / n := by
-  cases n
-  · rw [cast_zero, div_zero, Nat.div_zero, cast_zero]
-  rw [le_div_iff, ← Nat.cast_mul, @Nat.cast_le]
-  · exact Nat.div_mul_le_self m _
-  · exact Nat.cast_pos.2 (Nat.succ_pos _)
-#align nat.cast_div_le Nat.cast_div_le
-
-theorem inv_pos_of_nat {n : ℕ} : 0 < ((n : α) + 1)⁻¹ :=
-  inv_pos.2 <| add_pos_of_nonneg_of_pos n.cast_nonneg zero_lt_one
-#align nat.inv_pos_of_nat Nat.inv_pos_of_nat
-
-theorem one_div_pos_of_nat {n : ℕ} : 0 < 1 / ((n : α) + 1) := by
-  rw [one_div]
-  exact inv_pos_of_nat
-#align nat.one_div_pos_of_nat Nat.one_div_pos_of_nat
-
-theorem one_div_le_one_div {n m : ℕ} (h : n ≤ m) : 1 / ((m : α) + 1) ≤ 1 / ((n : α) + 1) := by
-  refine one_div_le_one_div_of_le ?_ ?_
-  · exact Nat.cast_add_one_pos _
-  · simpa
-#align nat.one_div_le_one_div Nat.one_div_le_one_div
-
-theorem one_div_lt_one_div {n m : ℕ} (h : n < m) : 1 / ((m : α) + 1) < 1 / ((n : α) + 1) := by
-  refine one_div_lt_one_div_of_lt ?_ ?_
-  · exact Nat.cast_add_one_pos _
-  · simpa
-#align nat.one_div_lt_one_div Nat.one_div_lt_one_div
-
-end LinearOrderedSemifield
-
-end Nat

--- a/Mathlib/Data/Nat/Cast/Order/Field.lean
+++ b/Mathlib/Data/Nat/Cast/Order/Field.lean
@@ -4,7 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Mario Carneiro, Yaël Dillies, Patrick Stevens
 -/
 import Mathlib.Algebra.Order.Field.Basic
-import Mathlib.Data.Nat.Cast.Field
 
 /-!
 # Cast of naturals into ordered fields

--- a/Mathlib/Data/Nat/Cast/OrderedField.lean
+++ b/Mathlib/Data/Nat/Cast/OrderedField.lean
@@ -1,0 +1,58 @@
+/-
+Copyright (c) 2014 Mario Carneiro. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Mario Carneiro, Yaël Dillies, Patrick Stevens
+-/
+import Mathlib.Algebra.Order.Field.Basic
+import Mathlib.Data.Nat.Cast.Field
+
+/-!
+# Cast of naturals into ordered fields
+
+This file concerns the canonical homomorphism `ℕ → F`, where `F` is a `LinearOrderedSemifield`.
+
+## Main results
+
+ * `Nat.cast_div_le`: in all cases, `↑(m / n) ≤ ↑m / ↑ n`
+-/
+
+
+namespace Nat
+
+variable {α : Type*} [LinearOrderedSemifield α]
+
+lemma cast_inv_le_one : ∀ n : ℕ, (n⁻¹ : α) ≤ 1
+  | 0 => by simp
+  | n + 1 => inv_le_one $ by simp [Nat.cast_nonneg]
+
+/-- Natural division is always less than division in the field. -/
+theorem cast_div_le {m n : ℕ} : ((m / n : ℕ) : α) ≤ m / n := by
+  cases n
+  · rw [cast_zero, div_zero, Nat.div_zero, cast_zero]
+  rw [le_div_iff, ← Nat.cast_mul, @Nat.cast_le]
+  · exact Nat.div_mul_le_self m _
+  · exact Nat.cast_pos.2 (Nat.succ_pos _)
+#align nat.cast_div_le Nat.cast_div_le
+
+theorem inv_pos_of_nat {n : ℕ} : 0 < ((n : α) + 1)⁻¹ :=
+  inv_pos.2 <| add_pos_of_nonneg_of_pos n.cast_nonneg zero_lt_one
+#align nat.inv_pos_of_nat Nat.inv_pos_of_nat
+
+theorem one_div_pos_of_nat {n : ℕ} : 0 < 1 / ((n : α) + 1) := by
+  rw [one_div]
+  exact inv_pos_of_nat
+#align nat.one_div_pos_of_nat Nat.one_div_pos_of_nat
+
+theorem one_div_le_one_div {n m : ℕ} (h : n ≤ m) : 1 / ((m : α) + 1) ≤ 1 / ((n : α) + 1) := by
+  refine one_div_le_one_div_of_le ?_ ?_
+  · exact Nat.cast_add_one_pos _
+  · simpa
+#align nat.one_div_le_one_div Nat.one_div_le_one_div
+
+theorem one_div_lt_one_div {n m : ℕ} (h : n < m) : 1 / ((m : α) + 1) < 1 / ((n : α) + 1) := by
+  refine one_div_lt_one_div_of_lt ?_ ?_
+  · exact Nat.cast_add_one_pos _
+  · simpa
+#align nat.one_div_lt_one_div Nat.one_div_lt_one_div
+
+end Nat


### PR DESCRIPTION
We split off the results depending on `LinearOrderedSemifield` into a separate file.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks, and is labeled with `awaiting-review`.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
