### PR TITLE
[Merged by Bors] - chore: add missing spaces around = or :=

### DIFF
--- a/Mathlib/Algebra/Algebra/NonUnitalHom.lean
+++ b/Mathlib/Algebra/Algebra/NonUnitalHom.lean
@@ -340,7 +340,7 @@ variable {φ' : S →* R} {ψ : S →* T} {χ : R →* T}
 
 set_option linter.unusedVariables false in
 /-- The composition of morphisms is a morphism. -/
-def comp (f : B →ₛₙₐ[ψ] C) (g : A →ₛₙₐ[φ] B) [κ : MonoidHom.CompTriple φ ψ χ]:
+def comp (f : B →ₛₙₐ[ψ] C) (g : A →ₛₙₐ[φ] B) [κ : MonoidHom.CompTriple φ ψ χ] :
     A →ₛₙₐ[χ] C :=
   { (f : B →ₙ* C).comp (g : A →ₙ* B), (f : B →ₑ+[ψ] C).comp (g : A →ₑ+[φ] B) with }
 #align non_unital_alg_hom.comp NonUnitalAlgHom.comp

--- a/Mathlib/Algebra/Category/ModuleCat/Sheaf/PushforwardContinuous.lean
+++ b/Mathlib/Algebra/Category/ModuleCat/Sheaf/PushforwardContinuous.lean
@@ -38,7 +38,7 @@ noncomputable def pushforward : SheafOfModules.{v} R ⥤ SheafOfModules.{v} S wh
     { val := (PresheafOfModules.pushforward φ.val).obj M.val
       isSheaf := ((F.sheafPushforwardContinuous _ J K).obj ⟨_, M.isSheaf⟩).cond }
   map f :=
-    { val :=(PresheafOfModules.pushforward φ.val).map f.val }
+    { val := (PresheafOfModules.pushforward φ.val).map f.val }
 
 /-- Given `M : SheafOfModules R` and `X : D`, this is the restriction of `M`
 over the sheaf of rings `R.over X` on the category `Over X`. -/

--- a/Mathlib/Algebra/GradedMonoid.lean
+++ b/Mathlib/Algebra/GradedMonoid.lean
@@ -238,7 +238,7 @@ class GMonoid [AddMonoid ι] extends GMul A, GOne A where
   /-- Successor powers behave as expected -/
   gnpow_succ' :
     ∀ (n : ℕ) (a : GradedMonoid A),
-      (GradedMonoid.mk _ <| gnpow n.succ a.snd) = ⟨_, gnpow n a.snd⟩ * a:= by
+      (GradedMonoid.mk _ <| gnpow n.succ a.snd) = ⟨_, gnpow n a.snd⟩ * a := by
     apply_gmonoid_gnpowRec_succ_tac
 #align graded_monoid.gmonoid GradedMonoid.GMonoid
 

--- a/Mathlib/Algebra/Group/Indicator.lean
+++ b/Mathlib/Algebra/Group/Indicator.lean
@@ -528,7 +528,7 @@ theorem mulIndicator_diff' (h : s ⊆ t) (f : α → G) :
 open scoped symmDiff in
 @[to_additive]
 theorem apply_mulIndicator_symmDiff {g : G → β} (hg : ∀ x, g x⁻¹ = g x)
-    (s t : Set α) (f : α → G) (x : α):
+    (s t : Set α) (f : α → G) (x : α) :
     g (mulIndicator (s ∆ t) f x) = g (mulIndicator s f x / mulIndicator t f x) := by
   by_cases hs : x ∈ s <;> by_cases ht : x ∈ t <;> simp [mem_symmDiff, *]
 

--- a/Mathlib/Algebra/Group/Submonoid/Units.lean
+++ b/Mathlib/Algebra/Group/Submonoid/Units.lean
@@ -120,7 +120,7 @@ lemma mk_mul_mk_inv_eq_one (S : Submonoid M) {x : Mˣ} (h : x ∈ S.units) :
     (⟨_, h.1⟩ : S) * ⟨_, h.2⟩ = 1 := Subtype.ext x.mul_inv
 
 @[to_additive]
-lemma mul_mem_units (S : Submonoid M) {x y : Mˣ} (h₁ : x ∈ S.units) (h₂ : y ∈ S.units):
+lemma mul_mem_units (S : Submonoid M) {x y : Mˣ} (h₁ : x ∈ S.units) (h₂ : y ∈ S.units) :
     x * y ∈ S.units := mul_mem h₁ h₂
 
 @[to_additive]

--- a/Mathlib/Algebra/Homology/BifunctorHomotopy.lean
+++ b/Mathlib/Algebra/Homology/BifunctorHomotopy.lean
@@ -47,7 +47,7 @@ lemma ιMapBifunctor_hom₁ (i₁ i₁' : I₁) (i₂ : I₂) (j j' : J)
     (h : ComplexShape.π c₁ c₂ c (i₁', i₂) = j) (h' : c₁.prev i₁' = i₁) :
     ιMapBifunctor K₁ K₂ F c i₁' i₂ j h ≫ hom₁ h₁ f₂ F c j j' = ComplexShape.ε₁ c₁ c₂ c (i₁, i₂) •
       (F.map (h₁.hom i₁' i₁)).app (K₂.X i₂) ≫ (F.obj (L₁.X i₁)).map (f₂.f i₂) ≫
-        ιMapBifunctorOrZero L₁ L₂ F c _ _ j':= by
+        ιMapBifunctorOrZero L₁ L₂ F c _ _ j' := by
   subst h'
   simp [hom₁]
 

--- a/Mathlib/Algebra/Homology/HomotopyCategory/HomComplexShift.lean
+++ b/Mathlib/Algebra/Homology/HomotopyCategory/HomComplexShift.lean
@@ -160,7 +160,7 @@ lemma leftShift_add (a n' : ℤ) (hn' : n + a = n') :
 
 @[simp]
 lemma shift_add (a : ℤ) :
-    (γ₁ + γ₂).shift a = γ₁.shift a + γ₂.shift a:= by
+    (γ₁ + γ₂).shift a = γ₁.shift a + γ₂.shift a := by
   ext p q hpq
   simp [shift_v']
 

--- a/Mathlib/Algebra/Homology/HomotopyCategory/ShiftSequence.lean
+++ b/Mathlib/Algebra/Homology/HomotopyCategory/ShiftSequence.lean
@@ -85,13 +85,13 @@ noncomputable def shiftIso (n a a' : ℤ) (ha' : n + a = a') :
       (ShortComplex.homologyFunctor C) ≪≫
     (homologyFunctorIso C (ComplexShape.up ℤ) a').symm
 
-lemma shiftIso_hom_app (n a a' : ℤ) (ha' : n + a = a') (K : CochainComplex C ℤ):
+lemma shiftIso_hom_app (n a a' : ℤ) (ha' : n + a = a') (K : CochainComplex C ℤ) :
     (shiftIso C n a a' ha').hom.app K =
       ShortComplex.homologyMap ((shiftShortComplexFunctorIso C n a a' ha').hom.app K) := by
   dsimp [shiftIso]
   erw [id_comp, id_comp, comp_id]
 
-lemma shiftIso_inv_app (n a a' : ℤ) (ha' : n + a = a') (K : CochainComplex C ℤ):
+lemma shiftIso_inv_app (n a a' : ℤ) (ha' : n + a = a') (K : CochainComplex C ℤ) :
     (shiftIso C n a a' ha').inv.app K =
       ShortComplex.homologyMap ((shiftShortComplexFunctorIso C n a a' ha').inv.app K) := by
   dsimp [shiftIso]

--- a/Mathlib/Algebra/Homology/HomotopyCofiber.lean
+++ b/Mathlib/Algebra/Homology/HomotopyCofiber.lean
@@ -191,7 +191,7 @@ lemma inlX_d (i j k : ι) (hij : c.Rel i j) (hjk : c.Rel j k) :
   · simp [d_sndX φ _ _ hij]
 
 @[reassoc]
-lemma inlX_d' (i j : ι) (hij : c.Rel i j) (hj : ¬ c.Rel j (c.next j)):
+lemma inlX_d' (i j : ι) (hij : c.Rel i j) (hj : ¬ c.Rel j (c.next j)) :
     inlX φ j i hij ≫ d φ i j = φ.f j ≫ inrX φ j := by
   apply ext_to_X' _ _ hj
   simp [d_sndX φ i j hij]

--- a/Mathlib/Algebra/Homology/ShortComplex/Homology.lean
+++ b/Mathlib/Algebra/Homology/ShortComplex/Homology.lean
@@ -839,7 +839,7 @@ noncomputable def homologyι : S.homology ⟶ S.opcycles :=
   S.rightHomologyIso.inv ≫ S.rightHomologyι
 
 @[reassoc (attr := simp)]
-lemma homologyπ_comp_leftHomologyIso_inv:
+lemma homologyπ_comp_leftHomologyIso_inv :
     S.homologyπ ≫ S.leftHomologyIso.inv = S.leftHomologyπ := by
   dsimp only [homologyπ]
   simp only [assoc, Iso.hom_inv_id, comp_id]

--- a/Mathlib/Algebra/Order/Antidiag/Prod.lean
+++ b/Mathlib/Algebra/Order/Antidiag/Prod.lean
@@ -76,7 +76,7 @@ lemma hasAntidiagonal_congr (A : Type*) [AddMonoid A]
     [H1 : HasAntidiagonal A] [H2 : HasAntidiagonal A] :
     H1.antidiagonal = H2.antidiagonal := by congr!; subsingleton
 
-theorem swap_mem_antidiagonal [AddCommMonoid A] [HasAntidiagonal A] {n : A} {xy : A × A}:
+theorem swap_mem_antidiagonal [AddCommMonoid A] [HasAntidiagonal A] {n : A} {xy : A × A} :
     xy.swap ∈ antidiagonal n ↔ xy ∈ antidiagonal n := by
   simp [add_comm]
 

--- a/Mathlib/Algebra/Order/GroupWithZero/WithZero.lean
+++ b/Mathlib/Algebra/Order/GroupWithZero/WithZero.lean
@@ -28,7 +28,7 @@ theory. These instances enable lemmas such as `mul_pos` to fire on `ℤₘ₀`.
 assert_not_exists Ring
 
 -- this makes `mul_lt_mul_left`, `mul_pos` etc work on `ℤₘ₀`
-instance {α : Type*} [Mul α] [Preorder α] [CovariantClass α α (· * ·) (· < ·)]:
+instance {α : Type*} [Mul α] [Preorder α] [CovariantClass α α (· * ·) (· < ·)] :
     PosMulStrictMono (WithZero α) where
   elim := @fun
     | ⟨(x : α), hx⟩, 0, (b : α), _ => by
@@ -39,7 +39,7 @@ instance {α : Type*} [Mul α] [Preorder α] [CovariantClass α α (· * ·) (·
         exact mul_lt_mul_left' h x
 
 open Function in
-instance {α : Type*} [Mul α] [Preorder α] [CovariantClass α α (swap (· * ·)) (· < ·)]:
+instance {α : Type*} [Mul α] [Preorder α] [CovariantClass α α (swap (· * ·)) (· < ·)] :
     MulPosStrictMono (WithZero α) where
   elim := @fun
     | ⟨(x : α), hx⟩, 0, (b : α), _ => by
@@ -49,7 +49,7 @@ instance {α : Type*} [Mul α] [Preorder α] [CovariantClass α α (swap (· * �
         norm_cast at h ⊢
         exact mul_lt_mul_right' h x
 
-instance {α : Type*} [Mul α] [Preorder α] [CovariantClass α α (· * ·) (· ≤ ·)]:
+instance {α : Type*} [Mul α] [Preorder α] [CovariantClass α α (· * ·) (· ≤ ·)] :
     PosMulMono (WithZero α) where
   elim := @fun
     | ⟨0, _⟩, a, b, _ => by
@@ -65,7 +65,7 @@ instance {α : Type*} [Mul α] [Preorder α] [CovariantClass α α (· * ·) (·
 
 -- This makes `lt_mul_of_le_of_one_lt'` work on `ℤₘ₀`
 open Function in
-instance {α : Type*} [Mul α] [Preorder α] [CovariantClass α α (swap (· * ·)) (· ≤ ·)]:
+instance {α : Type*} [Mul α] [Preorder α] [CovariantClass α α (swap (· * ·)) (· ≤ ·)] :
     MulPosMono (WithZero α) where
   elim := @fun
     | ⟨0, _⟩, a, b, _ => by

--- a/Mathlib/Algebra/Order/Ring/Defs.lean
+++ b/Mathlib/Algebra/Order/Ring/Defs.lean
@@ -1204,7 +1204,7 @@ lemma max_mul_mul_le_max_mul_max (b c : α) (ha : 0 ≤ a) (hd : 0 ≤ d) :
   max_le (by simpa [mul_comm, max_comm] using ba) (by simpa [mul_comm, max_comm] using cd)
 #align max_mul_mul_le_max_mul_max max_mul_mul_le_max_mul_max
 
-lemma min_mul_min_le_mul_min_min {b c} (ha : 0 ≤ a) (hb : 0 ≤ b) (hc : 0 ≤ c) (hd : 0 ≤ d):
+lemma min_mul_min_le_mul_min_min {b c} (ha : 0 ≤ a) (hb : 0 ≤ b) (hc : 0 ≤ c) (hd : 0 ≤ d) :
     min a c * min b d ≤ min (a * b) (c * d) :=
   have ab : min a c * min b d ≤ a * b :=
     mul_le_mul (min_le_left a c) (min_le_left b d) (le_min hb hd) ha

--- a/Mathlib/Algebra/Ring/Center.lean
+++ b/Mathlib/Algebra/Ring/Center.lean
@@ -22,7 +22,7 @@ variable (M)
 
 @[simp]
 theorem natCast_mem_center [NonAssocSemiring M] (n : ℕ) : (n : M) ∈ Set.center M where
-  comm _:= by rw [Nat.commute_cast]
+  comm _ := by rw [Nat.commute_cast]
   left_assoc _ _ := by
     induction n with
     | zero => rw [Nat.cast_zero, zero_mul, zero_mul, zero_mul]

--- a/Mathlib/Algebra/Ring/CentroidHom.lean
+++ b/Mathlib/Algebra/Ring/CentroidHom.lean
@@ -457,7 +457,7 @@ instance applyModule : Module (CentroidHom α) α where
   add_smul _ _ _ := rfl
   zero_smul _ := rfl
   one_smul _ := rfl
-  mul_smul _ _ _:= rfl
+  mul_smul _ _ _ := rfl
   smul_zero := map_zero
   smul_add := map_add
 

--- a/Mathlib/Algebra/Ring/Invertible.lean
+++ b/Mathlib/Algebra/Ring/Invertible.lean
@@ -42,7 +42,7 @@ theorem pos_of_invertible_cast [Semiring α] [Nontrivial α] (n : ℕ) [Invertib
   Nat.zero_lt_of_ne_zero fun h => nonzero_of_invertible (n : α) (h ▸ Nat.cast_zero)
 
 theorem invOf_add_invOf [Semiring α] (a b : α) [Invertible a] [Invertible b] :
-    ⅟a + ⅟b = ⅟a * (a + b) * ⅟b:= by
+    ⅟a + ⅟b = ⅟a * (a + b) * ⅟b := by
   rw [mul_add, invOf_mul_self, add_mul, one_mul, mul_assoc, mul_invOf_self, mul_one, add_comm]
 
 /-- A version of `inv_sub_inv'` for `invOf`. -/

--- a/Mathlib/AlgebraicGeometry/AffineScheme.lean
+++ b/Mathlib/AlgebraicGeometry/AffineScheme.lean
@@ -288,7 +288,7 @@ theorem range_fromSpec :
 theorem opensRange_fromSpec : Scheme.Hom.opensRange hU.fromSpec = U := Opens.ext (range_fromSpec hU)
 
 @[reassoc (attr := simp)]
-theorem map_fromSpec {V : Opens X} (hV : IsAffineOpen V) (f : op U ⟶ op V):
+theorem map_fromSpec {V : Opens X} (hV : IsAffineOpen V) (f : op U ⟶ op V) :
     Spec.map (X.presheaf.map f) ≫ hU.fromSpec = hV.fromSpec := by
   have : IsAffine (X.restrictFunctor.obj U).left := hU
   haveI : IsAffine _ := hV
@@ -424,7 +424,7 @@ theorem basicOpen :
   exact Opens.ext (PrimeSpectrum.localization_away_comap_range (Localization.Away f) f).symm
 #align algebraic_geometry.is_affine_open.basic_open_is_affine AlgebraicGeometry.IsAffineOpen.basicOpen
 
-theorem ιOpens_basicOpen_preimage (r : Γ(X, ⊤)):
+theorem ιOpens_basicOpen_preimage (r : Γ(X, ⊤)) :
     IsAffineOpen (Scheme.ιOpens (X.basicOpen r) ⁻¹ᵁ U) := by
   apply (Scheme.ιOpens (X.basicOpen r)).isAffineOpen_iff_of_isOpenImmersion.mp
   dsimp [Scheme.Hom.opensFunctor, LocallyRingedSpace.IsOpenImmersion.opensFunctor]

--- a/Mathlib/AlgebraicGeometry/ProjectiveSpectrum/Scheme.lean
+++ b/Mathlib/AlgebraicGeometry/ProjectiveSpectrum/Scheme.lean
@@ -534,7 +534,7 @@ lemma toSpec_surjective {f : A} {m : ℕ} (f_deg : f ∈ 𝒜 m) (hm : 0 < m) :
   Function.surjective_iff_hasRightInverse |>.mpr
     ⟨FromSpec.toFun f_deg hm, toSpec_fromSpec 𝒜 f_deg hm⟩
 
-lemma toSpec_bijective {f : A} {m : ℕ} (f_deg : f ∈ 𝒜 m) (hm : 0 < m):
+lemma toSpec_bijective {f : A} {m : ℕ} (f_deg : f ∈ 𝒜 m) (hm : 0 < m) :
     Function.Bijective (toSpec (𝒜 := 𝒜) (f := f)) :=
   ⟨toSpec_injective 𝒜 f_deg hm, toSpec_surjective 𝒜 f_deg hm⟩
 

--- a/Mathlib/Analysis/Calculus/FDeriv/Prod.lean
+++ b/Mathlib/Analysis/Calculus/FDeriv/Prod.lean
@@ -409,10 +409,10 @@ theorem hasStrictFDerivAt_pi'' (hφ : ∀ i, HasStrictFDerivAt (fun x => Φ x i)
 
 @[fun_prop]
 theorem hasStrictFDerivAt_apply (i : ι) (f : ∀ i, F' i) :
-    HasStrictFDerivAt (𝕜:=𝕜) (fun f : ∀ i, F' i => f i) (proj i) f := by
+    HasStrictFDerivAt (𝕜 := 𝕜) (fun f : ∀ i, F' i => f i) (proj i) f := by
   let id' := ContinuousLinearMap.id 𝕜 (∀ i, F' i)
   have h := ((hasStrictFDerivAt_pi'
-             (Φ := fun (f : ∀ i, F' i) (i' : ι) => f i') (Φ':=id') (x:=f))).1
+             (Φ := fun (f : ∀ i, F' i) (i' : ι) => f i') (Φ' := id') (x := f))).1
   have h' : comp (proj i) id' = proj i := by rfl
   rw [← h']; apply h; apply hasStrictFDerivAt_id
 
@@ -449,7 +449,7 @@ theorem hasFDerivAt_pi'' (hφ : ∀ i, HasFDerivAt (fun x => Φ x i) ((proj i).c
 
 @[fun_prop]
 theorem hasFDerivAt_apply (i : ι) (f : ∀ i, F' i) :
-    HasFDerivAt (𝕜:=𝕜) (fun f : ∀ i, F' i => f i) (proj i) f := by
+    HasFDerivAt (𝕜 := 𝕜) (fun f : ∀ i, F' i => f i) (proj i) f := by
   apply HasStrictFDerivAt.hasFDerivAt
   apply hasStrictFDerivAt_apply
 
@@ -472,10 +472,10 @@ theorem hasFDerivWithinAt_pi''
 
 @[fun_prop]
 theorem hasFDerivWithinAt_apply (i : ι) (f : ∀ i, F' i) (s' : Set (∀ i, F' i)) :
-    HasFDerivWithinAt (𝕜:=𝕜) (fun f : ∀ i, F' i => f i) (proj i) s' f := by
+    HasFDerivWithinAt (𝕜 := 𝕜) (fun f : ∀ i, F' i => f i) (proj i) s' f := by
   let id' := ContinuousLinearMap.id 𝕜 (∀ i, F' i)
   have h := ((hasFDerivWithinAt_pi'
-             (Φ := fun (f : ∀ i, F' i) (i' : ι) => f i') (Φ':=id') (x:=f) (s:=s'))).1
+             (Φ := fun (f : ∀ i, F' i) (i' : ι) => f i') (Φ' := id') (x := f) (s := s'))).1
   have h' : comp (proj i) id' = proj i := by rfl
   rw [← h']; apply h; apply hasFDerivWithinAt_id
 
@@ -498,7 +498,7 @@ theorem differentiableWithinAt_pi'' (hφ : ∀ i, DifferentiableWithinAt 𝕜 (f
 
 @[fun_prop]
 theorem differentiableWithinAt_apply (i : ι) (f : ∀ i, F' i) (s' : Set (∀ i, F' i)) :
-    DifferentiableWithinAt (𝕜:=𝕜) (fun f : ∀ i, F' i => f i) s' f := by
+    DifferentiableWithinAt (𝕜 := 𝕜) (fun f : ∀ i, F' i => f i) s' f := by
   apply HasFDerivWithinAt.differentiableWithinAt
   fun_prop
 
@@ -514,9 +514,9 @@ theorem differentiableAt_pi'' (hφ : ∀ i, DifferentiableAt 𝕜 (fun x => Φ x
 
 @[fun_prop]
 theorem differentiableAt_apply (i : ι) (f : ∀ i, F' i) :
-    DifferentiableAt (𝕜:=𝕜) (fun f : ∀ i, F' i => f i) f := by
-  have h := ((differentiableAt_pi (𝕜:=𝕜)
-             (Φ := fun (f : ∀ i, F' i) (i' : ι) => f i') (x:=f))).1
+    DifferentiableAt (𝕜 := 𝕜) (fun f : ∀ i, F' i => f i) f := by
+  have h := ((differentiableAt_pi (𝕜 := 𝕜)
+             (Φ := fun (f : ∀ i, F' i) (i' : ι) => f i') (x := f))).1
   apply h; apply differentiableAt_id
 
 theorem differentiableOn_pi : DifferentiableOn 𝕜 Φ s ↔ ∀ i, DifferentiableOn 𝕜 (fun x => Φ x i) s :=
@@ -530,9 +530,9 @@ theorem differentiableOn_pi'' (hφ : ∀ i, DifferentiableOn 𝕜 (fun x => Φ x
 
 @[fun_prop]
 theorem differentiableOn_apply (i : ι) (s' : Set (∀ i, F' i)) :
-    DifferentiableOn (𝕜:=𝕜) (fun f : ∀ i, F' i => f i) s' := by
-  have h := ((differentiableOn_pi (𝕜:=𝕜)
-             (Φ := fun (f : ∀ i, F' i) (i' : ι) => f i') (s:=s'))).1
+    DifferentiableOn (𝕜 := 𝕜) (fun f : ∀ i, F' i => f i) s' := by
+  have h := ((differentiableOn_pi (𝕜 := 𝕜)
+             (Φ := fun (f : ∀ i, F' i) (i' : ι) => f i') (s := s'))).1
   apply h; apply differentiableOn_id
 
 theorem differentiable_pi : Differentiable 𝕜 Φ ↔ ∀ i, Differentiable 𝕜 fun x => Φ x i :=
@@ -545,7 +545,7 @@ theorem differentiable_pi'' (hφ : ∀ i, Differentiable 𝕜 fun x => Φ x i) :
 
 @[fun_prop]
 theorem differentiable_apply (i : ι) :
-    Differentiable (𝕜:=𝕜) (fun f : ∀ i, F' i => f i) := by intro x; apply differentiableAt_apply
+    Differentiable (𝕜 := 𝕜) (fun f : ∀ i, F' i => f i) := by intro x; apply differentiableAt_apply
 
 -- TODO: find out which version (`φ` or `Φ`) works better with `rw`/`simp`
 theorem fderivWithin_pi (h : ∀ i, DifferentiableWithinAt 𝕜 (φ i) s x)

--- a/Mathlib/Analysis/Complex/Hadamard.lean
+++ b/Mathlib/Analysis/Complex/Hadamard.lean
@@ -252,7 +252,7 @@ lemma interpStrip_eq_of_zero (z : ℂ) (h : sSupNormIm f 0 = 0 ∨ sSupNormIm f 
   if_pos h
 
 /-- Rewrite for `InterpStrip` on the open vertical strip. -/
-lemma interpStrip_eq_of_mem_verticalStrip (z : ℂ) (hz : z ∈ verticalStrip 0 1):
+lemma interpStrip_eq_of_mem_verticalStrip (z : ℂ) (hz : z ∈ verticalStrip 0 1) :
     interpStrip f z = (sSupNormIm f 0) ^ (1 - z) * (sSupNormIm f 1) ^ z := by
   by_cases h : sSupNormIm f 0 = 0 ∨ sSupNormIm f 1 = 0
   · rw [interpStrip_eq_of_zero _ z h]

--- a/Mathlib/Analysis/FunctionalSpaces/SobolevInequality.lean
+++ b/Mathlib/Analysis/FunctionalSpaces/SobolevInequality.lean
@@ -134,7 +134,7 @@ theorem T_insert_le_T_lmarginal_singleton (hp₀ : 0 ≤ p) (s : Finset ι)
             simp only [Pi.mul_apply, Pi.pow_apply, Finset.prod_apply]
             refine (hf.pow_const _).mul <| Finset.measurable_prod _ ?_
             exact fun _ _ ↦ hf.lmarginal μ |>.pow_const _
-    _ ≤ T μ p (∫⋯∫⁻_{i}, f ∂μ) s := lmarginal_mono (s:=s) (fun x ↦ ?_)
+    _ ≤ T μ p (∫⋯∫⁻_{i}, f ∂μ) s := lmarginal_mono (s := s) (fun x ↦ ?_)
   -- The remainder of the computation happens within an `|s|`-fold iterated integral
   simp only [Pi.mul_apply, Pi.pow_apply, Finset.prod_apply]
   set X := update x i

--- a/Mathlib/Analysis/NormedSpace/PiTensorProduct/InjectiveSeminorm.lean
+++ b/Mathlib/Analysis/NormedSpace/PiTensorProduct/InjectiveSeminorm.lean
@@ -445,7 +445,7 @@ noncomputable def mapLMultilinear : ContinuousMultilinearMap 𝕜 (fun (i : ι) 
     ((⨂[𝕜] i, E i) →L[𝕜] ⨂[𝕜] i, E' i) :=
   MultilinearMap.mkContinuous
   { toFun := mapL
-    map_smul':= fun _ _ _ _ ↦ PiTensorProduct.mapL_smul _ _ _ _
+    map_smul' := fun _ _ _ _ ↦ PiTensorProduct.mapL_smul _ _ _ _
     map_add' := fun _ _ _ _ ↦ PiTensorProduct.mapL_add _ _ _ _ }
   1 (fun f ↦ by rw [one_mul]; exact mapL_opNorm f)
 

--- a/Mathlib/CategoryTheory/Abelian/Ext.lean
+++ b/Mathlib/CategoryTheory/Abelian/Ext.lean
@@ -67,7 +67,7 @@ variable {R C}
 which in degree `i` consists of the module of morphisms `X.X i ⟶ Y`. -/
 @[simps! X d]
 def ChainComplex.linearYonedaObj {α : Type*} [AddRightCancelSemigroup α] [One α]
-    (X : ChainComplex C α) (A : Type*) [Ring A] [Linear A C] (Y : C):
+    (X : ChainComplex C α) (A : Type*) [Ring A] [Linear A C] (Y : C) :
     CochainComplex (ModuleCat A) α :=
   ((((linearYoneda A C).obj Y).rightOp.mapHomologicalComplex _).obj X).unop
 

--- a/Mathlib/CategoryTheory/Closed/Ideal.lean
+++ b/Mathlib/CategoryTheory/Closed/Ideal.lean
@@ -150,7 +150,7 @@ itself cartesian closed.
 def cartesianClosedOfReflective : CartesianClosed D :=
   { __ := monoidalOfHasFiniteProducts D -- Porting note (#10754): added this instance
     closed := fun B =>
-      { rightAdj :=i ⋙ exp (i.obj B) ⋙ reflector i
+      { rightAdj := i ⋙ exp (i.obj B) ⋙ reflector i
         adj := by
           apply (exp.adjunction (i.obj B)).restrictFullyFaithful i.fullyFaithfulOfReflective
             i.fullyFaithfulOfReflective

--- a/Mathlib/CategoryTheory/ComposableArrows.lean
+++ b/Mathlib/CategoryTheory/ComposableArrows.lean
@@ -401,7 +401,7 @@ def mk₄ {X₀ X₁ X₂ X₃ X₄ : C} (f : X₀ ⟶ X₁) (g : X₁ ⟶ X₂)
 /-- Constructor for `ComposableArrows C 5`. -/
 @[simp]
 def mk₅ {X₀ X₁ X₂ X₃ X₄ X₅ : C} (f : X₀ ⟶ X₁) (g : X₁ ⟶ X₂) (h : X₂ ⟶ X₃)
-    (i : X₃ ⟶ X₄) (j : X₄ ⟶ X₅):
+    (i : X₃ ⟶ X₄) (j : X₄ ⟶ X₅) :
     ComposableArrows C 5 :=
   (mk₄ g h i j).precomp f
 
@@ -607,7 +607,7 @@ lemma ext₂ {f g : ComposableArrows C 2}
   ext_succ h₀ (ext₁ h₁ h₂ w₁) w₀
 
 lemma mk₂_surjective (X : ComposableArrows C 2) :
-    ∃ (X₀ X₁ X₂ : C) (f₀ : X₀ ⟶ X₁) (f₁ : X₁ ⟶ X₂), X = mk₂ f₀ f₁:=
+    ∃ (X₀ X₁ X₂ : C) (f₀ : X₀ ⟶ X₁) (f₁ : X₁ ⟶ X₂), X = mk₂ f₀ f₁ :=
   ⟨_, _, _, X.map' 0 1, X.map' 1 2, ext₂ rfl rfl rfl (by simp) (by simp)⟩
 
 section

--- a/Mathlib/CategoryTheory/FiberedCategory/BasedCategory.lean
+++ b/Mathlib/CategoryTheory/FiberedCategory/BasedCategory.lean
@@ -203,7 +203,7 @@ instance : (forgetful 𝒳 𝒴).ReflectsIsomorphisms where
       isHomLift' := fun a ↦ by simp [lift_id_inv_isIso] }
     aesop
 
-instance {F G : 𝒳 ⥤ᵇ 𝒴} (α : F ⟶ G) [IsIso α] : IsIso (X:=F.toFunctor) α.toNatTrans := by
+instance {F G : 𝒳 ⥤ᵇ 𝒴} (α : F ⟶ G) [IsIso α] : IsIso (X := F.toFunctor) α.toNatTrans := by
   rw [← forgetful_map]; infer_instance
 
 end BasedNatTrans

--- a/Mathlib/CategoryTheory/FiberedCategory/Cartesian.lean
+++ b/Mathlib/CategoryTheory/FiberedCategory/Cartesian.lean
@@ -47,21 +47,21 @@ variable {a' : 𝒳} (φ' : a' ⟶ b) [IsHomLift p f φ']
 lifting `𝟙 R`, then `IsCartesian.map f φ φ'` is the morphism `a' ⟶ a` obtained from the universal
 property of `φ`. -/
 protected noncomputable def map : a' ⟶ a :=
-  Classical.choose <| IsCartesian.universal_property (p:=p) (f:=f) (φ:=φ) φ'
+  Classical.choose <| IsCartesian.universal_property (p := p) (f := f) (φ := φ) φ'
 
 instance map_isHomLift : IsHomLift p (𝟙 R) (IsCartesian.map p f φ φ') :=
-  (Classical.choose_spec <| IsCartesian.universal_property (p:=p) (f:=f) (φ:=φ) φ').1.1
+  (Classical.choose_spec <| IsCartesian.universal_property (p := p) (f := f) (φ := φ) φ').1.1
 
 @[reassoc (attr := simp)]
 lemma fac : IsCartesian.map p f φ φ' ≫ φ = φ' :=
-  (Classical.choose_spec <| IsCartesian.universal_property (p:=p) (f:=f) (φ:=φ) φ').1.2
+  (Classical.choose_spec <| IsCartesian.universal_property (p := p) (f := f) (φ := φ) φ').1.2
 
 /-- Given a cartesian arrow `φ : a ⟶ b` lying over `f : R ⟶ S` in `𝒳`, a morphism `φ' : a' ⟶ b`
 lifting `𝟙 R`, and a morphism `ψ : a' ⟶ a` such that `g ≫ ψ = φ'`. Then `ψ` is the map induced
 by the universal property of `φ`. -/
 lemma map_uniq (ψ : a' ⟶ a) [IsHomLift p (𝟙 R) ψ] (hψ : ψ ≫ φ = φ') :
     ψ = IsCartesian.map p f φ φ' :=
-  (Classical.choose_spec <| IsCartesian.universal_property (p:=p) (f:=f) (φ:=φ) φ').2
+  (Classical.choose_spec <| IsCartesian.universal_property (p := p) (f := f) (φ := φ) φ').2
     ψ ⟨inferInstance, hψ⟩
 
 /-- Given a cartesian arrow `φ : a ⟶ b` lying over `f : R ⟶ S` in `𝒳`, a morphism `φ' : a' ⟶ b`

--- a/Mathlib/CategoryTheory/FiberedCategory/HomLift.lean
+++ b/Mathlib/CategoryTheory/FiberedCategory/HomLift.lean
@@ -53,7 +53,7 @@ class Functor.IsHomLift {R S : 𝒮} {a b : 𝒳} (f : R ⟶ S) (φ : a ⟶ b) :
 
 /-- `subst_hom_lift p f φ` tries to substitute `f` with `p(φ)` by using `p.IsHomLift f φ` -/
 macro "subst_hom_lift" p:ident f:ident φ:ident : tactic =>
-  `(tactic| obtain ⟨⟩ := Functor.IsHomLift.cond (p:=$p) (f:=$f) (φ:=$φ))
+  `(tactic| obtain ⟨⟩ := Functor.IsHomLift.cond (p := $p) (f := $f) (φ := $φ))
 
 /-- For any arrow `φ : a ⟶ b` in `𝒳`, `φ` lifts the arrow `p.map φ` in the base `𝒮`-/
 @[simp]

--- a/Mathlib/CategoryTheory/Functor/Derived/RightDerived.lean
+++ b/Mathlib/CategoryTheory/Functor/Derived/RightDerived.lean
@@ -86,7 +86,7 @@ lemma rightDerived_fac (G : D ⥤ H) (β : F ⟶ L ⋙ G) :
   RF.descOfIsLeftKanExtension_fac α G β
 
 @[reassoc (attr := simp)]
-lemma rightDerived_fac_app (G : D ⥤ H) (β : F ⟶ L ⋙ G) (X : C):
+lemma rightDerived_fac_app (G : D ⥤ H) (β : F ⟶ L ⋙ G) (X : C) :
     α.app X ≫ (RF.rightDerivedDesc α W G β).app (L.obj X) = β.app X :=
   have := IsRightDerivedFunctor.isLeftKanExtension RF α W
   RF.descOfIsLeftKanExtension_fac_app α G β X
@@ -119,7 +119,7 @@ lemma rightDerivedNatTrans_id :
     rightDerivedNatTrans RF RF α α W (𝟙 F) = 𝟙 RF :=
   rightDerived_ext RF α W _ _ _ (by aesop_cat)
 
-@[reassoc (attr:= simp)]
+@[reassoc (attr := simp)]
 lemma rightDerivedNatTrans_comp (τ : F ⟶ F') (τ' : F' ⟶ F'') :
     rightDerivedNatTrans RF RF' α α' W τ ≫ rightDerivedNatTrans RF' RF'' α' α'' W τ' =
     rightDerivedNatTrans RF RF'' α α'' W (τ ≫ τ') :=

--- a/Mathlib/CategoryTheory/Functor/KanExtension/Pointwise.lean
+++ b/Mathlib/CategoryTheory/Functor/KanExtension/Pointwise.lean
@@ -387,7 +387,7 @@ noncomputable def pointwiseRightKanExtensionCounit :
     L ⋙ pointwiseRightKanExtension L F ⟶ F where
   app X := limit.π (StructuredArrow.proj (L.obj X) L ⋙ F)
     (StructuredArrow.mk (𝟙 (L.obj X)))
-  naturality {X₁ X₂} f:= by
+  naturality {X₁ X₂} f := by
     simp only [comp_obj, pointwiseRightKanExtension_obj, comp_map,
       pointwiseRightKanExtension_map, limit.lift_π, StructuredArrow.map_mk]
     rw [comp_id]

--- a/Mathlib/CategoryTheory/Limits/Presheaf.lean
+++ b/Mathlib/CategoryTheory/Limits/Presheaf.lean
@@ -315,7 +315,7 @@ noncomputable def uniqueExtensionAlongYoneda (L : (Cᵒᵖ ⥤ Type v₁) ⥤ �
 #align category_theory.unique_extension_along_yoneda CategoryTheory.Presheaf.uniqueExtensionAlongYoneda
 
 instance (L : (Cᵒᵖ ⥤ Type v₁) ⥤ ℰ) [PreservesColimitsOfSize.{v₁, max u₁ v₁} L]
-    [yoneda.HasPointwiseLeftKanExtension (yoneda ⋙ L)]:
+    [yoneda.HasPointwiseLeftKanExtension (yoneda ⋙ L)] :
     L.IsLeftKanExtension (𝟙 _ : yoneda ⋙ L ⟶ _) :=
   isLeftKanExtension_of_preservesColimits _ (Iso.refl _)
 

--- a/Mathlib/CategoryTheory/Limits/Shapes/FunctorToTypes.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/FunctorToTypes.lean
@@ -188,7 +188,7 @@ def coprod.desc {F₁ F₂ : C ⥤ Type w} (τ₁ : F₁ ⟶ F) (τ₂ : F₂ �
      cases x with
      | inl x => exact τ₁.app a x
      | inr x => exact τ₂.app a x
-  naturality _ _ _:= by
+  naturality _ _ _ := by
     ext x
     cases x with | _ => simp only [coprod, types_comp_apply, FunctorToTypes.naturality]
 

--- a/Mathlib/CategoryTheory/Limits/Shapes/Multiequalizer.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/Multiequalizer.lean
@@ -406,7 +406,7 @@ def IsLimit.lift (hK : IsLimit K) {T : C} (k : ∀ a, T ⟶ I.left a)
 
 @[reassoc (attr := simp)]
 lemma IsLimit.fac (hK : IsLimit K) {T : C} (k : ∀ a, T ⟶ I.left a)
-    (hk : ∀ b, k (I.fstTo b) ≫ I.fst b = k (I.sndTo b) ≫ I.snd b) (a : I.L):
+    (hk : ∀ b, k (I.fstTo b) ≫ I.fst b = k (I.sndTo b) ≫ I.snd b) (a : I.L) :
     IsLimit.lift hK k hk ≫ K.ι a = k a :=
   hK.fac _ _
 

--- a/Mathlib/CategoryTheory/Localization/Predicate.lean
+++ b/Mathlib/CategoryTheory/Localization/Predicate.lean
@@ -491,7 +491,7 @@ variable {X Y : C} (f g : X ⟶ Y)
 /-- The property that two morphisms become equal in the localized category. -/
 def AreEqualizedByLocalization : Prop := W.Q.map f = W.Q.map g
 
-lemma areEqualizedByLocalization_iff [L.IsLocalization W]:
+lemma areEqualizedByLocalization_iff [L.IsLocalization W] :
     AreEqualizedByLocalization W f g ↔ L.map f = L.map g := by
   dsimp [AreEqualizedByLocalization]
   constructor

--- a/Mathlib/CategoryTheory/Monad/Adjunction.lean
+++ b/Mathlib/CategoryTheory/Monad/Adjunction.lean
@@ -343,7 +343,7 @@ instance comparison_essSurj [Reflective R] :
   apply (X.unit_assoc _).symm
 #align category_theory.reflective.comparison_ess_surj CategoryTheory.Reflective.comparison_essSurj
 
-lemma comparison_full [R.Full] {L : C ⥤ D} (adj : L ⊣ R):
+lemma comparison_full [R.Full] {L : C ⥤ D} (adj : L ⊣ R) :
     (Monad.comparison adj).Full where
   map_surjective f := ⟨R.preimage f.f, by aesop_cat⟩
 #align category_theory.reflective.comparison_full CategoryTheory.Reflective.comparison_full

--- a/Mathlib/CategoryTheory/Monoidal/Category.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Category.lean
@@ -428,7 +428,7 @@ theorem whiskerLeft_dite {P : Prop} [Decidable P]
   split_ifs <;> rfl
 
 theorem dite_whiskerRight {P : Prop} [Decidable P]
-    {X Y : C} (f : P → (X ⟶ Y)) (f' : ¬P → (X ⟶ Y)) (Z : C):
+    {X Y : C} (f : P → (X ⟶ Y)) (f' : ¬P → (X ⟶ Y)) (Z : C) :
       (if h : P then f h else f' h) ▷ Z = if h : P then f h ▷ Z else f' h ▷ Z := by
   split_ifs <;> rfl
 

--- a/Mathlib/CategoryTheory/Monoidal/Limits.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Limits.lean
@@ -59,7 +59,7 @@ instance limitLaxMonoidal : LaxMonoidal fun F : J ⥤ C => limit F := .ofTensorH
             naturality := fun j j' f => by
               dsimp
               simp only [Category.id_comp, ← tensor_comp, limit.w] } })
-  (μ_natural:= fun f g => by
+  (μ_natural := fun f g => by
     ext; dsimp
     simp only [limit.lift_π, Cones.postcompose_obj_π, Monoidal.tensorHom_app, limit.lift_map,
       NatTrans.comp_app, Category.assoc, ← tensor_comp, limMap_π])

--- a/Mathlib/CategoryTheory/Preadditive/InjectiveResolution.lean
+++ b/Mathlib/CategoryTheory/Preadditive/InjectiveResolution.lean
@@ -88,7 +88,7 @@ lemma cocomplex_exactAt_succ (n : ℕ) :
   rw [← quasiIsoAt_iff_exactAt I.ι (n + 1) (exactAt_succ_single_obj _ _)]
   infer_instance
 
-lemma exact_succ (n : ℕ):
+lemma exact_succ (n : ℕ) :
     (ShortComplex.mk _ _ (I.cocomplex.d_comp_d n (n + 1) (n + 2))).Exact :=
   (HomologicalComplex.exactAt_iff' _ n (n + 1) (n + 2) (by simp)
     (by simp only [CochainComplex.next]; rfl)).1 (I.cocomplex_exactAt_succ n)

--- a/Mathlib/CategoryTheory/Preadditive/ProjectiveResolution.lean
+++ b/Mathlib/CategoryTheory/Preadditive/ProjectiveResolution.lean
@@ -80,7 +80,7 @@ lemma complex_exactAt_succ (n : ℕ) :
   rw [← quasiIsoAt_iff_exactAt' P.π (n + 1) (exactAt_succ_single_obj _ _)]
   infer_instance
 
-lemma exact_succ (n : ℕ):
+lemma exact_succ (n : ℕ) :
     (ShortComplex.mk _ _ (P.complex.d_comp_d (n + 2) (n + 1) n)).Exact :=
   ((HomologicalComplex.exactAt_iff' _ (n + 2) (n + 1) n) (by simp only [prev]; rfl)
     (by simp)).1 (P.complex_exactAt_succ n)

--- a/Mathlib/CategoryTheory/Quotient.lean
+++ b/Mathlib/CategoryTheory/Quotient.lean
@@ -116,7 +116,7 @@ def functor : C ⥤ Quotient r where
 #align category_theory.quotient.functor CategoryTheory.Quotient.functor
 
 instance full_functor : (functor r).Full where
-  map_surjective f:= ⟨Quot.out f, by simp [functor]⟩
+  map_surjective f := ⟨Quot.out f, by simp [functor]⟩
 
 instance essSurj_functor : (functor r).EssSurj where
   mem_essImage Y :=

--- a/Mathlib/CategoryTheory/Shift/SingleFunctors.lean
+++ b/Mathlib/CategoryTheory/Shift/SingleFunctors.lean
@@ -245,7 +245,7 @@ def postcompPostcompIso (G : D ⥤ E) (G' : E ⥤ E') [G.CommShift A] [G'.CommSh
 which commutes with the shift. -/
 @[simps!]
 def postcompIsoOfIso {G G' : D ⥤ E} (e : G ≅ G') [G.CommShift A] [G'.CommShift A]
-    [NatTrans.CommShift e.hom A]:
+    [NatTrans.CommShift e.hom A] :
     F.postcomp G ≅ F.postcomp G' :=
   isoMk (fun a => isoWhiskerLeft (F.functor a) e) (fun n a a' ha' => by
     ext X

--- a/Mathlib/CategoryTheory/Sites/Coverage.lean
+++ b/Mathlib/CategoryTheory/Sites/Coverage.lean
@@ -101,7 +101,7 @@ lemma isSheafFor_of_factorsThru
     (P : Cᵒᵖ ⥤ Type*)
     (H : S.FactorsThru T) (hS : S.IsSheafFor P)
     (h : ∀ ⦃Y : C⦄ ⦃f : Y ⟶ X⦄, T f → ∃ (R : Presieve Y),
-      R.IsSeparatedFor P ∧ R.FactorsThruAlong S f):
+      R.IsSeparatedFor P ∧ R.FactorsThruAlong S f) :
     T.IsSheafFor P := by
   simp only [← Presieve.isSeparatedFor_and_exists_isAmalgamation_iff_isSheafFor] at *
   choose W i e h1 h2 using H

--- a/Mathlib/CategoryTheory/Sites/PreservesSheafification.lean
+++ b/Mathlib/CategoryTheory/Sites/PreservesSheafification.lean
@@ -158,7 +158,7 @@ left adjoints to the forget functors `sheafToPresheaf`. -/
 def sheafComposeNatTrans :
     (whiskeringRight Cᵒᵖ A B).obj F ⋙ G₂ ⟶ G₁ ⋙ sheafCompose J F where
   app P := (adj₂.homEquiv _ _).symm (whiskerRight (adj₁.unit.app P) F)
-  naturality {P Q} f:= by
+  naturality {P Q} f := by
     dsimp
     erw [← adj₂.homEquiv_naturality_left_symm,
       ← adj₂.homEquiv_naturality_right_symm]

--- a/Mathlib/CategoryTheory/Sums/Basic.lean
+++ b/Mathlib/CategoryTheory/Sums/Basic.lean
@@ -176,7 +176,7 @@ def sum (F : A ⥤ B) (G : C ⥤ D) : Sum A C ⥤ Sum B D where
     | inl X, inl Y, f => F.map f
     | inr X, inr Y, f => G.map f
   map_id {X} := by cases X <;> (erw [Functor.map_id]; rfl)
-  map_comp {X Y Z} f g:=
+  map_comp {X Y Z} f g :=
     match X, Y, Z, f, g with
     | inl X, inl Y, inl Z, f, g => by erw [F.map_comp]; rfl
     | inr X, inr Y, inr Z, f, g => by erw [G.map_comp]; rfl

--- a/Mathlib/Combinatorics/Colex.lean
+++ b/Mathlib/Combinatorics/Colex.lean
@@ -242,11 +242,11 @@ lemma toColex_sdiff_lt_toColex_sdiff (hus : u ⊆ s) (hut : u ⊆ t) :
 
 @[simp] lemma toColex_sdiff_le_toColex_sdiff' :
     toColex (s \ t) ≤ toColex (t \ s) ↔ toColex s ≤ toColex t := by
-  simpa using toColex_sdiff_le_toColex_sdiff (inter_subset_left (s₁:=s)) inter_subset_right
+  simpa using toColex_sdiff_le_toColex_sdiff (inter_subset_left (s₁ := s)) inter_subset_right
 
 @[simp] lemma toColex_sdiff_lt_toColex_sdiff' :
  toColex (s \ t) < toColex (t \ s) ↔ toColex s < toColex t := by
-  simpa using toColex_sdiff_lt_toColex_sdiff (inter_subset_left (s₁:=s)) inter_subset_right
+  simpa using toColex_sdiff_lt_toColex_sdiff (inter_subset_left (s₁ := s)) inter_subset_right
 
 end PartialOrder
 

--- a/Mathlib/Combinatorics/SetFamily/Shatter.lean
+++ b/Mathlib/Combinatorics/SetFamily/Shatter.lean
@@ -165,7 +165,7 @@ lemma Shatters.of_compression (hs : (𝓓 a 𝒜).Shatters s) : 𝒜.Shatters s 
       rintro ha
       rw [insert_eq_self.2 (mem_inter.1 ha).2] at hu
       exact hu.1 hu.2
-    rw [insert_eq_self.2 <| inter_subset_right (s₁:=s) ?_] at hv
+    rw [insert_eq_self.2 <| inter_subset_right (s₁ := s) ?_] at hv
     cases hv.1 hv.2
     rw [hsv]
     exact mem_insert_self _ _

--- a/Mathlib/Computability/AkraBazzi/AkraBazzi.lean
+++ b/Mathlib/Computability/AkraBazzi/AkraBazzi.lean
@@ -775,7 +775,7 @@ The next several lemmas are technical lemmas leading up to `rpow_p_mul_one_sub_s
 -/
 
 lemma isBigO_apply_r_sub_b (q : ℝ → ℝ) (hq_diff : DifferentiableOn ℝ q (Set.Ioi 1))
-    (hq_poly : GrowsPolynomially fun x => ‖deriv q x‖) (i : α):
+    (hq_poly : GrowsPolynomially fun x => ‖deriv q x‖) (i : α) :
     (fun n => q (r i n) - q (b i * n)) =O[atTop] fun n => (deriv q n) * (r i n - b i * n) := by
   let b' := b (min_bi b) / 2
   have hb_pos : 0 < b' := by have := R.b_pos (min_bi b); positivity

--- a/Mathlib/Computability/AkraBazzi/GrowsPolynomially.lean
+++ b/Mathlib/Computability/AkraBazzi/GrowsPolynomially.lean
@@ -475,7 +475,7 @@ lemma GrowsPolynomially.add_isLittleO {f g : ℝ → ℝ} (hf : GrowsPolynomiall
                   rwa [neg_neg, ← neg_mul, ← neg_div]
            _ = 3/2 * f x := by ring
     intro u ⟨hu_lb, hu_ub⟩
-    have hfu_nonpos : f u ≤ 0:= hf₂ _ hu_lb
+    have hfu_nonpos : f u ≤ 0 := hf₂ _ hu_lb
     have hfg₃ : ‖g u‖ ≤ -1/2 * f u := by
       calc ‖g u‖ ≤ 1/2 * ‖f u‖ := hfg' _ hu_lb
            _ = 1/2 * (-f u) := by congr; exact norm_of_nonpos hfu_nonpos

--- a/Mathlib/Data/Finset/Lattice.lean
+++ b/Mathlib/Data/Finset/Lattice.lean
@@ -983,7 +983,7 @@ lemma sup'_comp_eq_map {s : Finset γ} {f : γ ↪ β} (g : β → α) (hs : s.N
     s.sup' hs (g ∘ f) = (s.map f).sup' (map_nonempty.2 hs) g :=
   .symm <| sup'_map _ _
 
-theorem sup'_mono {s₁ s₂ : Finset β} (h : s₁ ⊆ s₂) (h₁ : s₁.Nonempty):
+theorem sup'_mono {s₁ s₂ : Finset β} (h : s₁ ⊆ s₂) (h₁ : s₁.Nonempty) :
     s₁.sup' h₁ f ≤ s₂.sup' (h₁.mono h) f :=
   Finset.sup'_le h₁ _ (fun _ hb => le_sup' _ (h hb))
 

--- a/Mathlib/Data/Finset/Sups.lean
+++ b/Mathlib/Data/Finset/Sups.lean
@@ -444,7 +444,7 @@ variable {𝒜 ℬ : Finset (Finset α)} {s t : Finset α} {a : α}
 @[simp] lemma powerset_union (s t : Finset α) : (s ∪ t).powerset = s.powerset ⊻ t.powerset := by
   ext u
   simp only [mem_sups, mem_powerset, le_eq_subset, sup_eq_union]
-  refine ⟨fun h ↦ ⟨_, inter_subset_left (s₂:=u), _, inter_subset_left (s₂:=u), ?_⟩, ?_⟩
+  refine ⟨fun h ↦ ⟨_, inter_subset_left (s₂ := u), _, inter_subset_left (s₂ := u), ?_⟩, ?_⟩
   · rwa [← union_inter_distrib_right, inter_eq_right]
   · rintro ⟨v, hv, w, hw, rfl⟩
     exact union_subset_union hv hw
@@ -452,7 +452,7 @@ variable {𝒜 ℬ : Finset (Finset α)} {s t : Finset α} {a : α}
 @[simp] lemma powerset_inter (s t : Finset α) : (s ∩ t).powerset = s.powerset ⊼ t.powerset := by
   ext u
   simp only [mem_infs, mem_powerset, le_eq_subset, inf_eq_inter]
-  refine ⟨fun h ↦ ⟨_, inter_subset_left (s₂:=u), _, inter_subset_left (s₂:=u), ?_⟩, ?_⟩
+  refine ⟨fun h ↦ ⟨_, inter_subset_left (s₂ := u), _, inter_subset_left (s₂ := u), ?_⟩, ?_⟩
   · rwa [← inter_inter_distrib_right, inter_eq_right]
   · rintro ⟨v, hv, w, hw, rfl⟩
     exact inter_subset_inter hv hw

--- a/Mathlib/Data/Finsupp/Basic.lean
+++ b/Mathlib/Data/Finsupp/Basic.lean
@@ -349,7 +349,7 @@ theorem equivMapDomain_zero {f : α ≃ β} : equivMapDomain f (0 : α →₀ M)
 #align finsupp.equiv_map_domain_zero Finsupp.equivMapDomain_zero
 
 @[to_additive (attr := simp)]
-theorem prod_equivMapDomain [CommMonoid N] (f : α ≃ β) (l : α →₀ M) (g : β → M → N):
+theorem prod_equivMapDomain [CommMonoid N] (f : α ≃ β) (l : α →₀ M) (g : β → M → N) :
     prod (equivMapDomain f l) g = prod l (fun a m => g (f a) m) := by
   simp [prod, equivMapDomain]
 

--- a/Mathlib/Data/Finsupp/Multiset.lean
+++ b/Mathlib/Data/Finsupp/Multiset.lean
@@ -203,7 +203,7 @@ theorem Finsupp.toMultiset_toFinsupp [DecidableEq α] (f : α →₀ ℕ) :
   Multiset.toFinsupp.apply_symm_apply _
 #align finsupp.to_multiset_to_finsupp Finsupp.toMultiset_toFinsupp
 
-theorem Finsupp.toMultiset_eq_iff [DecidableEq α] {f : α →₀ ℕ} {s : Multiset α}:
+theorem Finsupp.toMultiset_eq_iff [DecidableEq α] {f : α →₀ ℕ} {s : Multiset α} :
     Finsupp.toMultiset f = s ↔ f = Multiset.toFinsupp s :=
   Multiset.toFinsupp.symm_apply_eq
 

--- a/Mathlib/Data/List/Basic.lean
+++ b/Mathlib/Data/List/Basic.lean
@@ -983,7 +983,7 @@ theorem bidirectionalRec_nil {motive : List α → Sort*}
 @[simp]
 theorem bidirectionalRec_singleton {motive : List α → Sort*}
     (nil : motive []) (singleton : ∀ a : α, motive [a])
-    (cons_append : ∀ (a : α) (l : List α) (b : α), motive l → motive (a :: (l ++ [b]))) (a : α):
+    (cons_append : ∀ (a : α) (l : List α) (b : α), motive l → motive (a :: (l ++ [b]))) (a : α) :
     bidirectionalRec nil singleton cons_append [a] = singleton a := by
   simp [bidirectionalRec]
 

--- a/Mathlib/Data/List/DropRight.lean
+++ b/Mathlib/Data/List/DropRight.lean
@@ -251,7 +251,7 @@ lemma rdrop_add (i j : ℕ) : (l.rdrop i).rdrop j = l.rdrop (i + j) := by
 
 @[simp]
 lemma rdrop_append_length {l₁ l₂ : List α} :
-    List.rdrop (l₁ ++ l₂) (List.length l₂) = l₁:= by
+    List.rdrop (l₁ ++ l₂) (List.length l₂) = l₁ := by
   rw [rdrop_eq_reverse_drop_reverse, ← length_reverse l₂,
       reverse_append, drop_left, reverse_reverse]
 
@@ -264,7 +264,7 @@ lemma rdrop_append_of_le_length {l₁ l₂ : List α} (k : ℕ) :
 
 @[simp]
 lemma rdrop_append_length_add {l₁ l₂ : List α} (k : ℕ) :
-    List.rdrop (l₁ ++ l₂) (length l₂ + k)  = List.rdrop l₁ k:= by
+    List.rdrop (l₁ ++ l₂) (length l₂ + k) = List.rdrop l₁ k := by
   rw [← rdrop_add, rdrop_append_length]
 
 end List

--- a/Mathlib/Data/List/InsertNth.lean
+++ b/Mathlib/Data/List/InsertNth.lean
@@ -196,7 +196,7 @@ theorem getElem_insertNth_add_succ (l : List α) (x : α) (n k : ℕ) (hk' : n +
 
 theorem get_insertNth_add_succ (l : List α) (x : α) (n k : ℕ) (hk' : n + k < l.length)
     (hk : n + k + 1 < (insertNth n x l).length := (by
-      rwa [length_insertNth _ _ (by omega), Nat.succ_lt_succ_iff])):
+      rwa [length_insertNth _ _ (by omega), Nat.succ_lt_succ_iff])) :
     (insertNth n x l).get ⟨n + k + 1, hk⟩ = get l ⟨n + k, hk'⟩ := by
   simp [getElem_insertNth_add_succ, hk, hk']
 

--- a/Mathlib/Data/Matrix/Kronecker.lean
+++ b/Mathlib/Data/Matrix/Kronecker.lean
@@ -357,7 +357,7 @@ theorem natCast_kronecker [NonAssocSemiring α] [DecidableEq l] (a : ℕ) (B : M
 
 theorem kronecker_ofNat [Semiring α] [DecidableEq n] (A : Matrix l m α) (b : ℕ) [b.AtLeastTwo] :
     A ⊗ₖ (no_index (OfNat.ofNat b) : Matrix n n α) =
-      blockDiagonal fun _ => A <• (OfNat.ofNat b : α):=
+      blockDiagonal fun _ => A <• (OfNat.ofNat b : α) :=
   kronecker_diagonal _ _
 
 theorem ofNat_kronecker [Semiring α] [DecidableEq l] (a : ℕ) [a.AtLeastTwo] (B : Matrix m n α) :

--- a/Mathlib/Data/Matroid/Basic.lean
+++ b/Mathlib/Data/Matroid/Basic.lean
@@ -776,11 +776,11 @@ theorem Basis'.insert_not_indep (hI : M.Basis' I X) (he : e ∈ X \ I) : ¬ M.In
   fun hi ↦ he.2 <| insert_eq_self.1 <| Eq.symm <|
     hI.eq_of_subset_indep hi (subset_insert _ _) (insert_subset he.1 hI.subset)
 
-theorem basis_iff_mem_maximals (hX : X ⊆ M.E := by aesop_mat):
+theorem basis_iff_mem_maximals (hX : X ⊆ M.E := by aesop_mat) :
     M.Basis I X ↔ I ∈ maximals (· ⊆ ·) {I | M.Indep I ∧ I ⊆ X} := by
   rw [Basis, and_iff_left hX]
 
-theorem basis_iff_mem_maximals_Prop (hX : X ⊆ M.E := by aesop_mat):
+theorem basis_iff_mem_maximals_Prop (hX : X ⊆ M.E := by aesop_mat) :
     M.Basis I X ↔ I ∈ maximals (· ⊆ ·) (fun I ↦ M.Indep I ∧ I ⊆ X) :=
   basis_iff_mem_maximals
 

--- a/Mathlib/Data/Matroid/Dual.lean
+++ b/Mathlib/Data/Matroid/Dual.lean
@@ -200,7 +200,7 @@ theorem Base.compl_inter_basis_of_inter_basis (hB : M.Base B) (hBX : M.Basis (B 
       mem_inter_iff, iff_false_intro he.1.2, and_false, not_false_iff]
   exact hfb.2 (hBX.mem_of_insert_indep (Or.elim (hem.1 hfb.1) (False.elim ∘ hfb.2) id) hi).1
 
-theorem Base.inter_basis_iff_compl_inter_basis_dual (hB : M.Base B) (hX : X ⊆ M.E := by aesop_mat):
+theorem Base.inter_basis_iff_compl_inter_basis_dual (hB : M.Base B) (hX : X ⊆ M.E := by aesop_mat) :
     M.Basis (B ∩ X) X ↔ M✶.Basis ((M.E \ B) ∩ (M.E \ X)) (M.E \ X) := by
   refine ⟨hB.compl_inter_basis_of_inter_basis, fun h ↦ ?_⟩
   simpa [inter_eq_self_of_subset_right hX, inter_eq_self_of_subset_right hB.subset_ground] using

--- a/Mathlib/Data/Nat/Defs.lean
+++ b/Mathlib/Data/Nat/Defs.lean
@@ -753,7 +753,7 @@ lemma pow_left_injective (hn : n ≠ 0) : Injective (fun a : ℕ ↦ a ^ n) := b
   simp [Injective, le_antisymm_iff, Nat.pow_le_pow_iff_left hn]
 #align nat.pow_left_injective Nat.pow_left_injective
 
-protected lemma pow_right_injective (ha : 2 ≤ a) : Injective (a ^ ·) :=by
+protected lemma pow_right_injective (ha : 2 ≤ a) : Injective (a ^ ·) := by
   simp [Injective, le_antisymm_iff, Nat.pow_le_pow_iff_right ha]
 #align nat.pow_right_injective Nat.pow_right_injective
 

--- a/Mathlib/Data/Nat/Digits.lean
+++ b/Mathlib/Data/Nat/Digits.lean
@@ -560,7 +560,7 @@ lemma ofDigits_div_pow_eq_ofDigits_drop
 
 /-- Dividing `n` by `p^i` is like truncating the first `i` digits of `n` in base `p`.
 -/
-lemma self_div_pow_eq_ofDigits_drop {p : ℕ} (i n : ℕ) (h : 2 ≤ p):
+lemma self_div_pow_eq_ofDigits_drop {p : ℕ} (i n : ℕ) (h : 2 ≤ p) :
     n / p ^ i = ofDigits p ((p.digits n).drop i) := by
   convert ofDigits_div_pow_eq_ofDigits_drop i (zero_lt_of_lt h) (p.digits n)
     (fun l hl ↦ digits_lt_base h hl)

--- a/Mathlib/Data/Nat/Factorial/Basic.lean
+++ b/Mathlib/Data/Nat/Factorial/Basic.lean
@@ -269,7 +269,7 @@ theorem ascFactorial_eq_div' (n k : ℕ) (h : 0 < n) :
   Nat.eq_div_of_mul_eq_right (n - 1).factorial_ne_zero (factorial_mul_ascFactorial' _ _ h)
 #align nat.asc_factorial_eq_div Nat.ascFactorial_eq_div
 
-theorem ascFactorial_of_sub {n k : ℕ}:
+theorem ascFactorial_of_sub {n k : ℕ} :
     (n - k) * (n - k + 1).ascFactorial k = (n - k).ascFactorial (k + 1) := by
   rw [succ_ascFactorial, ascFactorial_succ]
 #align nat.asc_factorial_of_sub Nat.ascFactorial_of_sub

--- a/Mathlib/Dynamics/BirkhoffSum/NormedSpace.lean
+++ b/Mathlib/Dynamics/BirkhoffSum/NormedSpace.lean
@@ -90,7 +90,7 @@ tends to zero.
 
 See also `tendsto_birkhoffAverage_apply_sub_birkhoffAverage`. -/
 theorem tendsto_birkhoffAverage_apply_sub_birkhoffAverage' {g : α → E}
-    (h : Bornology.IsBounded (range g)) (f : α → α) (x : α):
+    (h : Bornology.IsBounded (range g)) (f : α → α) (x : α) :
     Tendsto (fun n ↦ birkhoffAverage 𝕜 f g n (f x) - birkhoffAverage 𝕜 f g n x) atTop (𝓝 0) :=
   tendsto_birkhoffAverage_apply_sub_birkhoffAverage _ <| h.subset <| range_comp_subset_range _ _
 

--- a/Mathlib/FieldTheory/IntermediateField.lean
+++ b/Mathlib/FieldTheory/IntermediateField.lean
@@ -602,7 +602,7 @@ theorem toSubalgebra_injective :
   rw [← mem_toSubalgebra, ← mem_toSubalgebra, h]
 #align intermediate_field.to_subalgebra_injective IntermediateField.toSubalgebra_injective
 
-theorem map_injective (f : L →ₐ[K] L'):
+theorem map_injective (f : L →ₐ[K] L') :
     Function.Injective (map f) := by
   intro _ _ h
   rwa [← toSubalgebra_injective.eq_iff, toSubalgebra_map, toSubalgebra_map,

--- a/Mathlib/Geometry/Manifold/LocalDiffeomorph.lean
+++ b/Mathlib/Geometry/Manifold/LocalDiffeomorph.lean
@@ -207,7 +207,7 @@ lemma Diffeomorph.isLocalDiffeomorph (Φ : M ≃ₘ^n⟮I, J⟯ N) : IsLocalDiff
 -- FUTURE: if useful, also add "a `PartialDiffeomorph` is a local diffeomorphism on its source"
 
 /-- A local diffeomorphism on `s` is a local homeomorphism on `s`. -/
-theorem IsLocalDiffeomorphOn.isLocalHomeomorphOn {s : Set M} (hf : IsLocalDiffeomorphOn I J n f s):
+theorem IsLocalDiffeomorphOn.isLocalHomeomorphOn {s : Set M} (hf : IsLocalDiffeomorphOn I J n f s) :
     IsLocalHomeomorphOn f s := by
   apply IsLocalHomeomorphOn.mk
   intro x hx

--- a/Mathlib/GroupTheory/Coxeter/Basic.lean
+++ b/Mathlib/GroupTheory/Coxeter/Basic.lean
@@ -302,7 +302,7 @@ private def restrictUnit {G : Type*} [Monoid G] {f : B → G} (hf : IsLiftable M
   val_inv := pow_one (f i * f i) ▸ M.diagonal i ▸ hf i i
   inv_val := pow_one (f i * f i) ▸ M.diagonal i ▸ hf i i
 
-private theorem toMonoidHom_apply_symm_apply (a : PresentedGroup (M.relationsSet)):
+private theorem toMonoidHom_apply_symm_apply (a : PresentedGroup (M.relationsSet)) :
     (MulEquiv.toMonoidHom cs.mulEquiv : W →* PresentedGroup (M.relationsSet))
     ((MulEquiv.symm cs.mulEquiv) a) = a := calc
   _ = cs.mulEquiv ((MulEquiv.symm cs.mulEquiv) a) := by rfl

--- a/Mathlib/GroupTheory/Coxeter/Length.lean
+++ b/Mathlib/GroupTheory/Coxeter/Length.lean
@@ -122,7 +122,7 @@ def lengthParity : W →* Multiplicative (ZMod 2) := cs.lift ⟨fun _ ↦ Multip
   simp_rw [CoxeterMatrix.IsLiftable, ← ofAdd_add, (by decide : (1 + 1 : ZMod 2) = 0)]
   simp⟩
 
-theorem lengthParity_simple (i : B):
+theorem lengthParity_simple (i : B) :
     cs.lengthParity (s i) = Multiplicative.ofAdd 1 := cs.lift_apply_simple _ _
 
 theorem lengthParity_comp_simple :

--- a/Mathlib/GroupTheory/MonoidLocalization.lean
+++ b/Mathlib/GroupTheory/MonoidLocalization.lean
@@ -1861,7 +1861,7 @@ theorem leftCancelMulZero_of_le_isLeftRegular
       _ = a * g b.2 * (z * g x.2 * g y.2) := by
         rw [mul_assoc a, mul_comm z, ← mul_assoc a, mul_assoc, mul_assoc z]
       _ = g b.1 * g (y.2 * x.1) := by rw [hx, hb, mul_comm (g x.1), ← map_mul g]
-      _ = g (b.1 * (y.2 * x.1)):= by rw [← map_mul g]
+      _ = g (b.1 * (y.2 * x.1)) := by rw [← map_mul g]
  -- The hypothesis `h` gives that `f` (so, `g`) is injective, and we can cancel out `b.1`.
   exact (IsLeftCancelMulZero.mul_left_cancel_of_ne_zero b1ne0
       ((LocalizationMap.toMap_injective_iff fl).mpr h main)).symm

--- a/Mathlib/GroupTheory/NoncommCoprod.lean
+++ b/Mathlib/GroupTheory/NoncommCoprod.lean
@@ -88,7 +88,7 @@ theorem noncommCoprod_unique (f : M × N →* P) :
   ext fun x => by simp [coprod_apply, inl_apply, inr_apply, ← map_mul]
 
 @[to_additive (attr := simp)]
-theorem noncommCoprod_inl_inr {M N : Type*} [Monoid M] [Monoid N]:
+theorem noncommCoprod_inl_inr {M N : Type*} [Monoid M] [Monoid N] :
     (inl M N).noncommCoprod (inr M N) commute_inl_inr = id (M × N) :=
   noncommCoprod_unique <| .id (M × N)
 

--- a/Mathlib/GroupTheory/Perm/DomMulAct.lean
+++ b/Mathlib/GroupTheory/Perm/DomMulAct.lean
@@ -94,7 +94,7 @@ open Nat
 variable (f)
 
 /-- The cardinality of the type of permutations preserving a function -/
-theorem stabilizer_card:
+theorem stabilizer_card :
     Fintype.card {g : Perm α // f ∘ g = f} = ∏ i, (Fintype.card {a // f a = i})! := by
   -- rewriting via Nat.card because Fintype instance is not found
   rw [← Nat.card_eq_fintype_card, Nat.card_congr (subtypeEquiv mk fun _ ↦ ?_),

--- a/Mathlib/LinearAlgebra/AffineSpace/Independent.lean
+++ b/Mathlib/LinearAlgebra/AffineSpace/Independent.lean
@@ -189,11 +189,11 @@ theorem affineIndependent_iff_indicator_eq_of_affineCombination_eq (p : ι → P
       ext i
       by_cases hi : i ∈ s1 ∪ s2
       · rw [← sub_eq_zero]
-        rw [← Finset.sum_indicator_subset w1 (s1.subset_union_left (s₂:=s2))] at hw1
+        rw [← Finset.sum_indicator_subset w1 (s1.subset_union_left (s₂ := s2))] at hw1
         rw [← Finset.sum_indicator_subset w2 (s1.subset_union_right)] at hw2
         have hws : (∑ i ∈ s1 ∪ s2, (Set.indicator (↑s1) w1 - Set.indicator (↑s2) w2) i) = 0 := by
           simp [hw1, hw2]
-        rw [Finset.affineCombination_indicator_subset w1 p (s1.subset_union_left (s₂:=s2)),
+        rw [Finset.affineCombination_indicator_subset w1 p (s1.subset_union_left (s₂ := s2)),
           Finset.affineCombination_indicator_subset w2 p s1.subset_union_right,
           ← @vsub_eq_zero_iff_eq V, Finset.affineCombination_vsub] at heq
         exact ha (s1 ∪ s2) (Set.indicator (↑s1) w1 - Set.indicator (↑s2) w2) hws heq i hi

--- a/Mathlib/LinearAlgebra/Finsupp.lean
+++ b/Mathlib/LinearAlgebra/Finsupp.lean
@@ -355,7 +355,7 @@ variable {M R}
 section
 
 @[simp]
-theorem restrictDom_apply (s : Set α) (l : α →₀ M) [DecidablePred (· ∈ s)]:
+theorem restrictDom_apply (s : Set α) (l : α →₀ M) [DecidablePred (· ∈ s)] :
     (restrictDom M R s l : α →₀ M) = Finsupp.filter (· ∈ s) l := rfl
 #align finsupp.restrict_dom_apply Finsupp.restrictDom_apply
 

--- a/Mathlib/LinearAlgebra/Matrix/GeneralLinearGroup/Card.lean
+++ b/Mathlib/LinearAlgebra/Matrix/GeneralLinearGroup/Card.lean
@@ -45,7 +45,7 @@ theorem card_linearIndependent {k : ℕ} (hk : k ≤ n) :
           card ((Submodule.span K (Set.range (s : Fin k → V)))ᶜ : Set (V)) =
           (q) ^ n - (q) ^ k := by
             rw [card_compl_set, card_eq_pow_finrank (K := K)
-            (V:=((Submodule.span K (Set.range (s : Fin k → V))) : Set (V)))]
+            (V := ((Submodule.span K (Set.range (s : Fin k → V))) : Set (V)))]
             simp only [SetLike.coe_sort_coe, finrank_span_eq_card s.2, card_fin]
             rw [card_eq_pow_finrank (K := K)]
       simp [card_congr (equiv_linearIndependent k), sum_congr _ _ this, ih (Nat.le_of_succ_le hk),

--- a/Mathlib/LinearAlgebra/Matrix/PosDef.lean
+++ b/Mathlib/LinearAlgebra/Matrix/PosDef.lean
@@ -74,7 +74,7 @@ lemma conjTranspose_mul_mul_same {A : Matrix n n R} (hA : PosSemidef A)
     simpa only [star_mulVec, dotProduct_mulVec, vecMul_vecMul] using hA.2 (B *ᵥ x)
 
 lemma mul_mul_conjTranspose_same {A : Matrix n n R} (hA : PosSemidef A)
-    {m : Type*} [Fintype m] (B : Matrix m n R):
+    {m : Type*} [Fintype m] (B : Matrix m n R) :
     PosSemidef (B * A * Bᴴ) := by
   simpa only [conjTranspose_conjTranspose] using hA.conjTranspose_mul_mul_same Bᴴ
 

--- a/Mathlib/LinearAlgebra/Matrix/SpecialLinearGroup.lean
+++ b/Mathlib/LinearAlgebra/Matrix/SpecialLinearGroup.lean
@@ -439,7 +439,7 @@ variable {R : Type*} [CommRing R]
 
 /-- Given any pair of coprime elements of `R`, there exists a matrix in `SL(2, R)` having those
 entries as its left or right column. -/
-lemma exists_SL2_col {a b : R} (hab : IsCoprime a b) (j : Fin 2):
+lemma exists_SL2_col {a b : R} (hab : IsCoprime a b) (j : Fin 2) :
     ∃ g : SL(2, R), g 0 j = a ∧ g 1 j = b := by
   obtain ⟨u, v, h⟩ := hab
   refine match j with
@@ -450,7 +450,7 @@ lemma exists_SL2_col {a b : R} (hab : IsCoprime a b) (j : Fin 2):
 
 /-- Given any pair of coprime elements of `R`, there exists a matrix in `SL(2, R)` having those
 entries as its top or bottom row. -/
-lemma exists_SL2_row {a b : R} (hab : IsCoprime a b) (i : Fin 2):
+lemma exists_SL2_row {a b : R} (hab : IsCoprime a b) (i : Fin 2) :
     ∃ g : SL(2, R), g i 0 = a ∧ g i 1 = b := by
   obtain ⟨u, v, h⟩ := hab
   refine match i with

--- a/Mathlib/LinearAlgebra/Matrix/Spectrum.lean
+++ b/Mathlib/LinearAlgebra/Matrix/Spectrum.lean
@@ -130,7 +130,7 @@ theorem spectral_theorem :
 
 theorem eigenvalues_eq (i : n) :
     (hA.eigenvalues i) = RCLike.re (Matrix.dotProduct (star ⇑(hA.eigenvectorBasis i))
-    (A *ᵥ ⇑(hA.eigenvectorBasis i))):= by
+    (A *ᵥ ⇑(hA.eigenvectorBasis i))) := by
   simp only [mulVec_eigenvectorBasis, dotProduct_smul,← EuclideanSpace.inner_eq_star_dotProduct,
     inner_self_eq_norm_sq_to_K, RCLike.smul_re, hA.eigenvectorBasis.orthonormal.1 i,
     mul_one, algebraMap.coe_one, one_pow, RCLike.one_re]

--- a/Mathlib/LinearAlgebra/PiTensorProduct.lean
+++ b/Mathlib/LinearAlgebra/PiTensorProduct.lean
@@ -665,7 +665,7 @@ This is `PiTensorProduct.map` for two arbitrary families of modules.
 This is `TensorProduct.map₂` for families of modules.
 -/
 def map₂ (f : Π i, s i →ₗ[R] t i →ₗ[R] t' i) :
-    (⨂[R] i, s i) →ₗ[R] (⨂[R] i, t i) →ₗ[R] ⨂[R] i, t' i:=
+    (⨂[R] i, s i) →ₗ[R] (⨂[R] i, t i) →ₗ[R] ⨂[R] i, t' i :=
   lift <| LinearMap.compMultilinearMap piTensorHomMap <| (tprod R).compLinearMap f
 
 lemma map₂_tprod_tprod (f : Π i, s i →ₗ[R] t i →ₗ[R] t' i) (x : Π i, s i) (y : Π i, t i) :

--- a/Mathlib/LinearAlgebra/QuadraticForm/Basic.lean
+++ b/Mathlib/LinearAlgebra/QuadraticForm/Basic.lean
@@ -970,7 +970,7 @@ theorem isOrtho_comm {x y : M} : IsOrtho Q x y ↔ IsOrtho Q y x := by simp_rw [
 alias ⟨IsOrtho.symm, _⟩ := isOrtho_comm
 
 theorem _root_.LinearMap.BilinForm.toQuadraticForm_isOrtho [IsCancelAdd R]
-    [NoZeroDivisors R] [CharZero R] {B : BilinForm R M} {x y : M} (h : B.IsSymm):
+    [NoZeroDivisors R] [CharZero R] {B : BilinForm R M} {x y : M} (h : B.IsSymm) :
     B.toQuadraticForm.IsOrtho x y ↔ B.IsOrtho x y := by
   letI : AddCancelMonoid R := { ‹IsCancelAdd R›, (inferInstanceAs <| AddCommMonoid R) with }
   simp_rw [isOrtho_def, LinearMap.isOrtho_def, toQuadraticForm_apply, map_add,

--- a/Mathlib/LinearAlgebra/QuadraticForm/TensorProduct/Isometries.lean
+++ b/Mathlib/LinearAlgebra/QuadraticForm/TensorProduct/Isometries.lean
@@ -123,7 +123,7 @@ theorem tmul_comp_tensorAssoc
 @[simp]
 theorem tmul_tensorAssoc_apply
     (Q₁ : QuadraticForm R M₁) (Q₂ : QuadraticForm R M₂) (Q₃ : QuadraticForm R M₃)
-    (x : (M₁ ⊗[R] M₂) ⊗[R] M₃):
+    (x : (M₁ ⊗[R] M₂) ⊗[R] M₃) :
     Q₁.tmul (Q₂.tmul Q₃) (TensorProduct.assoc R M₁ M₂ M₃ x) = (Q₁.tmul Q₂).tmul Q₃ x :=
   DFunLike.congr_fun (tmul_comp_tensorAssoc Q₁ Q₂ Q₃) x
 
@@ -166,7 +166,7 @@ theorem tmul_tensorRId_apply
 
 /-- `TensorProduct.rid` preserves tensor products of quadratic forms. -/
 @[simps toLinearEquiv]
-def tensorRId (Q₁ : QuadraticForm R M₁):
+def tensorRId (Q₁ : QuadraticForm R M₁) :
     (Q₁.tmul (sq (R := R))).IsometryEquiv Q₁ where
   toLinearEquiv := TensorProduct.rid R M₁
   map_app' := tmul_tensorRId_apply Q₁
@@ -199,7 +199,7 @@ theorem tmul_tensorLId_apply
 
 /-- `TensorProduct.lid` preserves tensor products of quadratic forms. -/
 @[simps toLinearEquiv]
-def tensorLId (Q₂ : QuadraticForm R M₂):
+def tensorLId (Q₂ : QuadraticForm R M₂) :
     ((sq (R := R)).tmul Q₂).IsometryEquiv Q₂ where
   toLinearEquiv := TensorProduct.lid R M₂
   map_app' := tmul_tensorLId_apply Q₂

--- a/Mathlib/LinearAlgebra/TensorProduct/Basic.lean
+++ b/Mathlib/LinearAlgebra/TensorProduct/Basic.lean
@@ -815,7 +815,7 @@ lemma map_comp_comm_eq (f : M →ₗ[R] P) (g : N →ₗ[R] Q) :
     map f g ∘ₗ TensorProduct.comm R N M = TensorProduct.comm R Q P ∘ₗ map g f :=
   ext rfl
 
-lemma map_comm (f : M →ₗ[R] P) (g : N →ₗ[R] Q) (x : N ⊗[R] M):
+lemma map_comm (f : M →ₗ[R] P) (g : N →ₗ[R] Q) (x : N ⊗[R] M) :
     map f g (TensorProduct.comm R N M x) = TensorProduct.comm R Q P (map g f x) :=
   DFunLike.congr_fun (map_comp_comm_eq _ _) _
 

--- a/Mathlib/LinearAlgebra/TensorProduct/DirectLimit.lean
+++ b/Mathlib/LinearAlgebra/TensorProduct/DirectLimit.lean
@@ -99,7 +99,7 @@ noncomputable def directLimitRight :
     Module.DirectLimit.congr (fun i ↦ TensorProduct.comm _ _ _)
       (fun i j h ↦ TensorProduct.ext <| DFunLike.ext _ _ <| by aesop)
 
-@[simp] lemma directLimitRight_tmul_of {i : ι} (m : M) (g : G i):
+@[simp] lemma directLimitRight_tmul_of {i : ι} (m : M) (g : G i) :
     directLimitRight f M (m ⊗ₜ of _ _ _ _ _ g) = of _ _ _ _ i (m ⊗ₜ g) := by
   simp [directLimitRight, congr_apply_of]
 

--- a/Mathlib/LinearAlgebra/TensorProduct/Tower.lean
+++ b/Mathlib/LinearAlgebra/TensorProduct/Tower.lean
@@ -394,7 +394,7 @@ theorem leftComm_tmul (m : M) (p : P) (q : Q) :
   rfl
 
 @[simp]
-theorem leftComm_symm_tmul (m : M) (p : P) (q : Q):
+theorem leftComm_symm_tmul (m : M) (p : P) (q : Q) :
     (leftComm R A M P Q).symm (p ⊗ₜ (m ⊗ₜ q)) = m ⊗ₜ (p ⊗ₜ q) :=
   rfl
 
@@ -425,7 +425,7 @@ theorem rightComm_tmul (m : M) (p : P) (q : Q) :
   rfl
 
 @[simp]
-theorem rightComm_symm_tmul (m : M) (p : P) (q : Q):
+theorem rightComm_symm_tmul (m : M) (p : P) (q : Q) :
     (rightComm R A M P Q).symm ((m ⊗ₜ q) ⊗ₜ p) = (m ⊗ₜ p) ⊗ₜ q :=
   rfl
 

--- a/Mathlib/MeasureTheory/Constructions/Projective.lean
+++ b/Mathlib/MeasureTheory/Constructions/Projective.lean
@@ -61,7 +61,7 @@ lemma measure_univ_eq (hP : IsProjectiveMeasureFamily P) (I J : Finset ι) :
     P I univ = P J univ := by
   classical
   rw [← hP.measure_univ_eq_of_subset I.subset_union_left,
-    ← hP.measure_univ_eq_of_subset (I.subset_union_right (s₂:= J))]
+    ← hP.measure_univ_eq_of_subset (I.subset_union_right (s₂ := J))]
 
 lemma congr_cylinder_of_subset (hP : IsProjectiveMeasureFamily P)
     {S : Set (∀ i : I, α i)} {T : Set (∀ i : J, α i)} (hT : MeasurableSet T)

--- a/Mathlib/MeasureTheory/Integral/PeakFunction.lean
+++ b/Mathlib/MeasureTheory/Integral/PeakFunction.lean
@@ -105,7 +105,7 @@ theorem tendsto_setIntegral_peak_smul_of_integrableOn_of_tendsto_aux
     (hmg : IntegrableOn g s μ) (hcg : Tendsto g (𝓝[s] x₀) (𝓝 0)) :
     Tendsto (fun i : ι => ∫ x in s, φ i x • g x ∂μ) l (𝓝 0) := by
   refine Metric.tendsto_nhds.2 fun ε εpos => ?_
-  obtain ⟨δ, hδ, δpos, δone⟩ : ∃ δ, (δ * ∫ x in s, ‖g x‖ ∂μ) + 2 * δ < ε ∧ 0 < δ ∧ δ < 1:= by
+  obtain ⟨δ, hδ, δpos, δone⟩ : ∃ δ, (δ * ∫ x in s, ‖g x‖ ∂μ) + 2 * δ < ε ∧ 0 < δ ∧ δ < 1 := by
     have A :
       Tendsto (fun δ => (δ * ∫ x in s, ‖g x‖ ∂μ) + 2 * δ) (𝓝[>] 0)
         (𝓝 ((0 * ∫ x in s, ‖g x‖ ∂μ) + 2 * 0)) := by

--- a/Mathlib/MeasureTheory/Measure/FiniteMeasureProd.lean
+++ b/Mathlib/MeasureTheory/Measure/FiniteMeasureProd.lean
@@ -71,7 +71,7 @@ lemma prod_prod (s : Set α) (t : Set β) : μ.prod ν (s ×ˢ t) = μ s * ν t 
 @[simp] lemma map_snd_prod : (μ.prod ν).map Prod.snd = μ univ • ν := by ext; simp
 
 lemma map_prod_map {α' : Type*} [MeasurableSpace α'] {β' : Type*} [MeasurableSpace β']
-    {f : α → α'} {g : β → β'}  (f_mble : Measurable f) (g_mble : Measurable g):
+    {f : α → α'} {g : β → β'}  (f_mble : Measurable f) (g_mble : Measurable g) :
     (μ.map f).prod (ν.map g) = (μ.prod ν).map (Prod.map f g) := by
   apply Subtype.ext
   simp only [val_eq_toMeasure, toMeasure_prod, toMeasure_map]

--- a/Mathlib/MeasureTheory/SetSemiring.lean
+++ b/Mathlib/MeasureTheory/SetSemiring.lean
@@ -158,7 +158,7 @@ lemma exists_disjoint_finset_diff_eq (hC : IsSetSemiring C) (hs : s ∈ C) (hI :
   have hJu_sUnion : ∀ (u) (hu : u ∈ C), ⋃₀ (Ju u hu : Set (Set α)) = u \ t :=
     fun u hu ↦ hC.sUnion_diffFinset hu ht
   have hJu_disj' : ∀ (u) (hu : u ∈ C) (v) (hv : v ∈ C) (_h_dis : Disjoint u v),
-      Disjoint (⋃₀ (Ju u hu : Set (Set α))) (⋃₀ ↑(Ju v hv)) :=by
+      Disjoint (⋃₀ (Ju u hu : Set (Set α))) (⋃₀ ↑(Ju v hv)) := by
     intro u hu v hv huv_disj
     rw [hJu_sUnion, hJu_sUnion]
     exact disjoint_of_subset Set.diff_subset Set.diff_subset huv_disj

--- a/Mathlib/NumberTheory/ArithmeticFunction.lean
+++ b/Mathlib/NumberTheory/ArithmeticFunction.lean
@@ -799,7 +799,7 @@ theorem prodPrimeFactors_add_of_squarefree [CommSemiring R] {f g : ArithmeticFun
     (hf : IsMultiplicative f) (hg : IsMultiplicative g) {n : ℕ} (hn : Squarefree n) :
     ∏ᵖ p ∣ n, (f + g) p = (f * g) n := by
   rw [prodPrimeFactors_apply hn.ne_zero]
-  simp_rw [add_apply (f:=f) (g:=g)]
+  simp_rw [add_apply (f := f) (g := g)]
   rw [Finset.prod_add, mul_apply, sum_divisorsAntidiagonal (f · * g ·),
     ← divisors_filter_squarefree_of_squarefree hn, sum_divisors_filter_squarefree hn.ne_zero,
     factors_eq]
@@ -1369,7 +1369,7 @@ theorem prod_eq_iff_prod_pow_moebius_eq_on [CommGroup R] {f g : ℕ → R}
 a well-behaved set. -/
 theorem prod_eq_iff_prod_pow_moebius_eq_on_of_nonzero [CommGroupWithZero R]
     (s : Set ℕ) (hs : ∀ m n, m ∣ n → n ∈ s → m ∈ s) {f g : ℕ → R}
-    (hf : ∀ n > 0, f n ≠ 0) (hg : ∀ n > 0, g n ≠ 0):
+    (hf : ∀ n > 0, f n ≠ 0) (hg : ∀ n > 0, g n ≠ 0) :
     (∀ n > 0, n ∈ s → (∏ i ∈ n.divisors, f i) = g n) ↔
       ∀ n > 0, n ∈ s → (∏ x ∈ n.divisorsAntidiagonal, g x.snd ^ μ x.fst) = f n := by
   refine

--- a/Mathlib/NumberTheory/LSeries/Dirichlet.lean
+++ b/Mathlib/NumberTheory/LSeries/Dirichlet.lean
@@ -92,11 +92,11 @@ lemma ArithmeticFunction.const_one_eq_zeta {R : Type*} [Semiring R] {n : ℕ} (h
     (1 : ℕ → R) n = (ζ ·) n := by
   simp only [Pi.one_apply, zeta_apply, hn, ↓reduceIte, cast_one]
 
-lemma LSeries.one_convolution_eq_zeta_convolution {R : Type*} [Semiring R] (f : ℕ → R):
+lemma LSeries.one_convolution_eq_zeta_convolution {R : Type*} [Semiring R] (f : ℕ → R) :
     (1 : ℕ → R) ⍟ f = ((ArithmeticFunction.zeta ·) : ℕ → R) ⍟ f :=
   convolution_congr ArithmeticFunction.const_one_eq_zeta fun _ ↦ rfl
 
-lemma LSeries.convolution_one_eq_convolution_zeta {R : Type*} [Semiring R] (f : ℕ → R):
+lemma LSeries.convolution_one_eq_convolution_zeta {R : Type*} [Semiring R] (f : ℕ → R) :
     f ⍟ (1 : ℕ → R) = f ⍟ ((ArithmeticFunction.zeta ·) : ℕ → R) :=
   convolution_congr (fun _ ↦ rfl) ArithmeticFunction.const_one_eq_zeta
 

--- a/Mathlib/NumberTheory/ModularForms/JacobiTheta/TwoVariable.lean
+++ b/Mathlib/NumberTheory/ModularForms/JacobiTheta/TwoVariable.lean
@@ -431,7 +431,7 @@ lemma jacobiTheta₂'_add_left' (z τ : ℂ) :
   · simp_rw [jacobiTheta₂_undef _ hτ, jacobiTheta₂'_undef _ hτ, mul_zero, sub_zero, mul_zero]
   have (n : ℤ) : jacobiTheta₂'_term n (z + τ) τ =
       cexp (-π * I * (τ + 2 * z)) * (jacobiTheta₂'_term (n + 1) z τ -
-      2 * π * I * jacobiTheta₂_term (n + 1) z τ):= by
+      2 * π * I * jacobiTheta₂_term (n + 1) z τ) := by
     simp only [jacobiTheta₂'_term, jacobiTheta₂_term]
     conv_rhs => rw [← sub_mul, mul_comm, mul_assoc, ← Complex.exp_add, Int.cast_add, Int.cast_one,
       mul_add, mul_one, add_sub_cancel_right]

--- a/Mathlib/NumberTheory/NumberField/CanonicalEmbedding/Basic.lean
+++ b/Mathlib/NumberTheory/NumberField/CanonicalEmbedding/Basic.lean
@@ -307,7 +307,7 @@ theorem normAtPlace_real (w : InfinitePlace K) (c : ℝ) :
   rw [show ((fun _ ↦ c, fun _ ↦ c) : (E K)) = c • 1 by ext <;> simp, normAtPlace_smul, map_one,
     mul_one]
 
-theorem normAtPlace_apply_isReal {w : InfinitePlace K} (hw : IsReal w) (x : E K):
+theorem normAtPlace_apply_isReal {w : InfinitePlace K} (hw : IsReal w) (x : E K) :
     normAtPlace w x = ‖x.1 ⟨w, hw⟩‖ := by
   rw [normAtPlace, MonoidWithZeroHom.coe_mk, ZeroHom.coe_mk, dif_pos]
 

--- a/Mathlib/NumberTheory/NumberField/CanonicalEmbedding/ConvexBody.lean
+++ b/Mathlib/NumberTheory/NumberField/CanonicalEmbedding/ConvexBody.lean
@@ -517,7 +517,7 @@ smaller than `1` at some fixed complex place. This is useful to ensure that `a` 
 theorem exists_ne_zero_mem_ideal_lt' (w₀ : {w : InfinitePlace K // IsComplex w})
     (h : minkowskiBound K I < volume (convexBodyLT' K f w₀)) :
     ∃ a ∈ (I : FractionalIdeal (𝓞 K)⁰ K), a ≠ 0 ∧ (∀ w : InfinitePlace K, w ≠ w₀ → w a < f w) ∧
-      |(w₀.val.embedding a).re| < 1 ∧ |(w₀.val.embedding a).im| < (f w₀ : ℝ) ^ 2:= by
+      |(w₀.val.embedding a).re| < 1 ∧ |(w₀.val.embedding a).im| < (f w₀ : ℝ) ^ 2 := by
   have h_fund := Zspan.isAddFundamentalDomain (fractionalIdealLatticeBasis K I) volume
   have : Countable (span ℤ (Set.range (fractionalIdealLatticeBasis K I))).toAddSubgroup := by
     change Countable (span ℤ (Set.range (fractionalIdealLatticeBasis K I)) : Set (E K))

--- a/Mathlib/NumberTheory/Padics/PadicVal.lean
+++ b/Mathlib/NumberTheory/Padics/PadicVal.lean
@@ -712,7 +712,7 @@ theorem padicValNat_factorial {n b : ℕ} [hp : Fact p.Prime] (hnb : log p n < b
 
 Taking (`p - 1`) times the `p`-adic valuation of `n!` equals `n` minus the sum of base `p` digits
 of `n`. -/
-theorem sub_one_mul_padicValNat_factorial [hp : Fact p.Prime] (n : ℕ):
+theorem sub_one_mul_padicValNat_factorial [hp : Fact p.Prime] (n : ℕ) :
     (p - 1) * padicValNat p (n !) = n - (p.digits n).sum := by
   rw [padicValNat_factorial <| lt_succ_of_lt <| lt.base (log p n)]
   nth_rw 2 [← zero_add 1]

--- a/Mathlib/Order/Filter/Basic.lean
+++ b/Mathlib/Order/Filter/Basic.lean
@@ -1569,7 +1569,7 @@ theorem EventuallyEq.mul [Mul β] {f f' g g' : α → β} {l : Filter α} (h : f
 #align filter.eventually_eq.add Filter.EventuallyEq.add
 
 @[to_additive const_smul]
-theorem EventuallyEq.pow_const {γ} [Pow β γ] {f g : α → β} {l : Filter α} (h : f =ᶠ[l] g) (c : γ):
+theorem EventuallyEq.pow_const {γ} [Pow β γ] {f g : α → β} {l : Filter α} (h : f =ᶠ[l] g) (c : γ) :
     (fun x => f x ^ c) =ᶠ[l] fun x => g x ^ c :=
   h.fun_comp (· ^ c)
 #align filter.eventually_eq.const_smul Filter.EventuallyEq.const_smul

--- a/Mathlib/Order/LiminfLimsup.lean
+++ b/Mathlib/Order/LiminfLimsup.lean
@@ -576,7 +576,7 @@ theorem liminf_le_of_le {f : Filter β} {u : β → α} {a}
 
 theorem limsInf_le_limsSup {f : Filter α} [NeBot f]
     (h₁ : f.IsBounded (· ≤ ·) := by isBoundedDefault)
-    (h₂ : f.IsBounded (· ≥ ·) := by isBoundedDefault):
+    (h₂ : f.IsBounded (· ≥ ·) := by isBoundedDefault) :
     limsInf f ≤ limsSup f :=
   liminf_le_of_le h₂ fun a₀ ha₀ =>
     le_limsup_of_le h₁ fun a₁ ha₁ =>
@@ -588,7 +588,7 @@ set_option linter.uppercaseLean3 false in
 
 theorem liminf_le_limsup {f : Filter β} [NeBot f] {u : β → α}
     (h : f.IsBoundedUnder (· ≤ ·) u := by isBoundedDefault)
-    (h' : f.IsBoundedUnder (· ≥ ·) u := by isBoundedDefault):
+    (h' : f.IsBoundedUnder (· ≥ ·) u := by isBoundedDefault) :
     liminf u f ≤ limsup u f :=
   limsInf_le_limsSup h h'
 #align filter.liminf_le_limsup Filter.liminf_le_limsup
@@ -1404,7 +1404,7 @@ theorem HasBasis.liminf_eq_ciSup_ciInf {v : Filter ι}
 linear order. A reparametrization trick is needed to avoid taking the infimum of sets which are
 not bounded below. -/
 theorem HasBasis.liminf_eq_ite {v : Filter ι} {p : ι' → Prop} {s : ι' → Set ι}
-    [Countable (Subtype p)] [Nonempty (Subtype p)] (hv : v.HasBasis p s) (f : ι → α):
+    [Countable (Subtype p)] [Nonempty (Subtype p)] (hv : v.HasBasis p s) (f : ι → α) :
     liminf f v = if ∃ (j : Subtype p), s j = ∅ then sSup univ else
       if ∀ (j : Subtype p), ¬BddBelow (range (fun (i : s j) ↦ f i)) then sSup ∅
       else ⨆ (j : Subtype p), ⨅ (i : s (liminf_reparam f s p j)), f i := by

--- a/Mathlib/Probability/Kernel/Disintegration/MeasurableStieltjes.lean
+++ b/Mathlib/Probability/Kernel/Disintegration/MeasurableStieltjes.lean
@@ -98,7 +98,7 @@ lemma measurableSet_isRatStieltjesPoint (hf : Measurable f) :
   · exact ⟨h.1.1.1, h.1.1.2, h.1.2, h.2⟩
 
 lemma IsRatStieltjesPoint.ite {f g : α → ℚ → ℝ} {a : α} (p : α → Prop) [DecidablePred p]
-    (hf : p a → IsRatStieltjesPoint f a) (hg : ¬ p a → IsRatStieltjesPoint g a):
+    (hf : p a → IsRatStieltjesPoint f a) (hg : ¬ p a → IsRatStieltjesPoint g a) :
     IsRatStieltjesPoint (fun a ↦ if p a then f a else g a) a where
   mono := by split_ifs with h; exacts [(hf h).mono, (hg h).mono]
   tendsto_atTop_one := by

--- a/Mathlib/RingTheory/MvPolynomial/Homogeneous.lean
+++ b/Mathlib/RingTheory/MvPolynomial/Homogeneous.lean
@@ -278,7 +278,7 @@ theorem totalDegree (hφ : IsHomogeneous φ n) (h : φ ≠ 0) : totalDegree φ =
   exact Finset.le_sup (f := fun s ↦ ∑ x ∈ s.support, s x) hd
 #align mv_polynomial.is_homogeneous.total_degree MvPolynomial.IsHomogeneous.totalDegree
 
-theorem rename_isHomogeneous {f : σ → τ} (h : φ.IsHomogeneous n):
+theorem rename_isHomogeneous {f : σ → τ} (h : φ.IsHomogeneous n) :
     (rename f φ).IsHomogeneous n := by
   rw [← φ.support_sum_monomial_coeff, map_sum]; simp_rw [rename_monomial]
   apply IsHomogeneous.sum _ _ _ fun d hd ↦ isHomogeneous_monomial _ _

--- a/Mathlib/RingTheory/MvPolynomial/WeightedHomogeneous.lean
+++ b/Mathlib/RingTheory/MvPolynomial/WeightedHomogeneous.lean
@@ -65,7 +65,7 @@ def weightedDegree (w : σ → M) : (σ →₀ ℕ) →+ M :=
   (Finsupp.total σ M ℕ w).toAddMonoidHom
 #align mv_polynomial.weighted_degree' MvPolynomial.weightedDegree
 
-theorem weightedDegree_apply (w : σ → M) (f : σ →₀ ℕ):
+theorem weightedDegree_apply (w : σ → M) (f : σ →₀ ℕ) :
     weightedDegree w f = Finsupp.sum f (fun i c => c • w i) := by
   rfl
 section SemilatticeSup

--- a/Mathlib/RingTheory/Polynomial/Nilpotent.lean
+++ b/Mathlib/RingTheory/Polynomial/Nilpotent.lean
@@ -88,7 +88,7 @@ protected lemma isNilpotent_iff :
     · simp
     simpa using hnp (isNilpotent_mul_X_iff.mp hpX) i
 
-@[simp] lemma isNilpotent_reflect_iff {P : R[X]} {N : ℕ} (hN : P.natDegree ≤ N):
+@[simp] lemma isNilpotent_reflect_iff {P : R[X]} {N : ℕ} (hN : P.natDegree ≤ N) :
     IsNilpotent (reflect N P) ↔ IsNilpotent P := by
   simp only [Polynomial.isNilpotent_iff, coeff_reverse]
   refine ⟨fun h i ↦ ?_, fun h i ↦ ?_⟩ <;> rcases le_or_lt i N with hi | hi

--- a/Mathlib/RingTheory/TensorProduct/MvPolynomial.lean
+++ b/Mathlib/RingTheory/TensorProduct/MvPolynomial.lean
@@ -100,15 +100,15 @@ lemma scalarRTensor_apply_tmul (p : MvPolynomial σ R) (n : N) :
     scalarRTensor (p ⊗ₜ[R] n) = p.sum (fun i m ↦ Finsupp.single i (m • n)) :=
   TensorProduct.finsuppScalarLeft_apply_tmul p n
 
-lemma scalarRTensor_apply_tmul_apply (p : MvPolynomial σ R) (n : N) (d : σ →₀ ℕ):
+lemma scalarRTensor_apply_tmul_apply (p : MvPolynomial σ R) (n : N) (d : σ →₀ ℕ) :
     scalarRTensor (p ⊗ₜ[R] n) d = coeff d p • n :=
   TensorProduct.finsuppScalarLeft_apply_tmul_apply p n d
 
-lemma scalarRTensor_apply_monomial_tmul (e : σ →₀ ℕ) (r : R) (n : N) (d : σ →₀ ℕ):
+lemma scalarRTensor_apply_monomial_tmul (e : σ →₀ ℕ) (r : R) (n : N) (d : σ →₀ ℕ) :
     scalarRTensor (monomial e r ⊗ₜ[R] n) d = if e = d then r • n else 0 := by
   rw [scalarRTensor_apply_tmul_apply, coeff_monomial, ite_smul, zero_smul]
 
-lemma scalarRTensor_apply_X_tmul_apply (s : σ) (n : N) (d : σ →₀ ℕ):
+lemma scalarRTensor_apply_X_tmul_apply (s : σ) (n : N) (d : σ →₀ ℕ) :
     scalarRTensor (X s ⊗ₜ[R] n) d = if Finsupp.single s 1 = d then n else 0 := by
   rw [scalarRTensor_apply_tmul_apply, coeff_X', ite_smul, one_smul, zero_smul]
 

--- a/Mathlib/RingTheory/UniqueFactorizationDomain.lean
+++ b/Mathlib/RingTheory/UniqueFactorizationDomain.lean
@@ -1191,8 +1191,8 @@ theorem multiplicative_of_coprime (f : α → β) (a b : α) (h0 : f 0 = 0)
     congr
     rw [← (normalizedFactors a).map_id, ← (normalizedFactors b).map_id,
       Finset.prod_multiset_map_count, Finset.prod_multiset_map_count,
-      Finset.prod_subset (Finset.subset_union_left (s₂:=(normalizedFactors b).toFinset)),
-      Finset.prod_subset (Finset.subset_union_right (s₂:=(normalizedFactors b).toFinset)), ←
+      Finset.prod_subset (Finset.subset_union_left (s₂ := (normalizedFactors b).toFinset)),
+      Finset.prod_subset (Finset.subset_union_right (s₂ := (normalizedFactors b).toFinset)), ←
       Finset.prod_mul_distrib]
     · simp_rw [id, ← pow_add, this]
     all_goals simp only [Multiset.mem_toFinset]

--- a/Mathlib/SetTheory/Ordinal/FixedPointApproximants.lean
+++ b/Mathlib/SetTheory/Ordinal/FixedPointApproximants.lean
@@ -251,7 +251,7 @@ lemma gfpApprox_ord_mem_fixedPoint (h_init : f x ≤ x) :
 /-- Every value of the ordinal approximants are greater or equal than every fixed point of f
   that is smaller then the initial value -/
 lemma le_gfpApprox_of_mem_fixedPoints {a : α}
-    (h_a : a ∈ fixedPoints f) (h_le_init : a ≤ x) (i : Ordinal) : a ≤ gfpApprox f x i:=
+    (h_a : a ∈ fixedPoints f) (h_le_init : a ≤ x) (i : Ordinal) : a ≤ gfpApprox f x i :=
   lfpApprox_le_of_mem_fixedPoints (OrderHom.dual f) x h_a h_le_init i
 
 /-- The greatest fixed point of f is reached after the successor of the domains cardinality -/

--- a/Mathlib/Tactic/FunProp/Core.lean
+++ b/Mathlib/Tactic/FunProp/Core.lean
@@ -391,7 +391,7 @@ def getLocalTheorems (funPropDecl : FunPropDecl) (funOrigin : Origin)
       let .some (decl,f) ← getFunProp? b | return none
       unless decl.funPropName = funPropDecl.funPropName do return none
 
-      let .data fData ← getFunctionData? f (← unfoldNamePred) {zeta:=false} | return none
+      let .data fData ← getFunctionData? f (← unfoldNamePred) {zeta := false} | return none
       unless (fData.getFnOrigin == funOrigin) do return none
 
       unless isOrderedSubsetOf mainArgs fData.mainArgs do return none
@@ -611,7 +611,7 @@ mutual
         let e' := e.setArg funPropDecl.funArgId b
         funProp (← mkLambdaFVars xs e')
 
-    match ← getFunctionData? f (← unfoldNamePred) {zeta:=false} with
+    match ← getFunctionData? f (← unfoldNamePred) {zeta := false} with
     | .letE f =>
       trace[Meta.Tactic.fun_prop.step] "let case on {← ppExpr f}"
       let e := e.setArg funPropDecl.funArgId f -- update e with reduced f

--- a/Mathlib/Tactic/FunProp/Elab.lean
+++ b/Mathlib/Tactic/FunProp/Elab.lean
@@ -37,7 +37,7 @@ def funPropTac : Tactic
       | none => pure emptyDischarge
       | some d =>
         match d with
-        | `(discharger| (discharger:=$tac)) => pure <| tacticToDischarge (← `(tactic| ($tac)))
+        | `(discharger| (discharger := $tac)) => pure <| tacticToDischarge (← `(tactic| ($tac)))
         | _ => pure emptyDischarge
 
     let namesToUnfold : Array Name :=

--- a/Mathlib/Tactic/FunProp/FunctionData.lean
+++ b/Mathlib/Tactic/FunProp/FunctionData.lean
@@ -273,7 +273,7 @@ def FunctionData.decompositionOverArgs (fData : FunctionData) (args : Array Nat)
     withLocalDeclD `y (← inferType gx) fun y => do
 
       let ys ← mkProdSplitElem y gxs.size
-      let args' := (args.zip ys).foldl (init:=fData.args)
+      let args' := (args.zip ys).foldl (init := fData.args)
           (fun args' (i,y) => args'.set! i { expr := y, coe := args'[i]!.coe })
 
       let f ← mkLambdaFVars #[y] (Mor.mkAppN fData.fn args')

--- a/Mathlib/Tactic/FunProp/Theorems.lean
+++ b/Mathlib/Tactic/FunProp/Theorems.lean
@@ -329,7 +329,7 @@ def getTheoremFromConst (declName : Name) (prio : Nat := eval_prio default) : Me
       | throwError "unrecognized function property `{← ppExpr b}`"
     let funPropName := decl.funPropName
 
-    let fData? ← getFunctionData? f defaultUnfoldPred {zeta:=false}
+    let fData? ← getFunctionData? f defaultUnfoldPred {zeta := false}
 
     if let .some thmArgs ← detectLambdaTheoremArgs (← fData?.get) xs then
       return .lam {

--- a/Mathlib/Tactic/Linter/UnusedTactic.lean
+++ b/Mathlib/Tactic/Linter/UnusedTactic.lean
@@ -67,7 +67,7 @@ namespace UnusedTactic
 abbrev M := StateRefT (HashMap String.Range Syntax) IO
 
 /-- `Parser`s allowed to not change the tactic state. -/
-def allowed : HashSet SyntaxNodeKind:= HashSet.empty
+def allowed : HashSet SyntaxNodeKind := HashSet.empty
   |>.insert `Mathlib.Tactic.Says.says
   |>.insert `Batteries.Tactic.«tacticOn_goal-_=>_»
   -- attempt to speed up, by ignoring more tactics

--- a/Mathlib/Topology/Algebra/InfiniteSum/GroupCompletion.lean
+++ b/Mathlib/Topology/Algebra/InfiniteSum/GroupCompletion.lean
@@ -16,7 +16,7 @@ variable {α β : Type*} [AddCommGroup α] [UniformSpace α] [UniformAddGroup α
 
 /-- A function `f` has a sum in an uniform additive group `α` if and only if it has that sum in the
 completion of `α`. -/
-theorem hasSum_iff_hasSum_compl (f : β → α) (a : α):
+theorem hasSum_iff_hasSum_compl (f : β → α) (a : α) :
     HasSum (toCompl ∘ f) a ↔ HasSum f a := (denseInducing_toCompl α).hasSum_iff f a
 
 /-- A function `f` is summable in a uniform additive group `α` if and only if it is summable in

--- a/Mathlib/Topology/Category/Profinite/Limits.lean
+++ b/Mathlib/Topology/Category/Profinite/Limits.lean
@@ -223,7 +223,7 @@ instance : PreservesFiniteCoproducts profiniteToCompHaus := by
   exact CompHaus.finiteCoproduct.isColimit _
 
 noncomputable instance : PreservesFiniteCoproducts Profinite.toTopCat.{u} where
-  preserves _ _:= (inferInstance :
+  preserves _ _ := (inferInstance :
     PreservesColimitsOfShape _ (profiniteToCompHaus.{u} ⋙ compHausToTop.{u}))
 
 instance : FinitaryExtensive Profinite :=

--- a/Mathlib/Topology/Compactness/Lindelof.lean
+++ b/Mathlib/Topology/Compactness/Lindelof.lean
@@ -707,7 +707,7 @@ instance (priority := 100) HereditarilyLindelof.to_Lindelof [HereditarilyLindelo
     LindelofSpace X where
   isLindelof_univ := HereditarilyLindelofSpace.isHereditarilyLindelof_univ.isLindelof
 
-theorem HereditarilyLindelof_LindelofSets [HereditarilyLindelofSpace X] (s : Set X):
+theorem HereditarilyLindelof_LindelofSets [HereditarilyLindelofSpace X] (s : Set X) :
     IsLindelof s := by
   apply HereditarilyLindelofSpace.isHereditarilyLindelof_univ
   exact subset_univ s

--- a/Mathlib/Topology/Inseparable.lean
+++ b/Mathlib/Topology/Inseparable.lean
@@ -721,14 +721,14 @@ theorem tendsto_lift_nhdsWithin_mk {f : X → α} {hf : ∀ x y, (x ~ᵢ y) → 
 #align separation_quotient.tendsto_lift_nhds_within_mk SeparationQuotient.tendsto_lift_nhdsWithin_mk
 
 @[simp]
-theorem continuousAt_lift {hf : ∀ x y, (x ~ᵢ y) → f x = f y}:
+theorem continuousAt_lift {hf : ∀ x y, (x ~ᵢ y) → f x = f y} :
     ContinuousAt (lift f hf) (mk x) ↔ ContinuousAt f x :=
   tendsto_lift_nhds_mk
 #align separation_quotient.continuous_at_lift SeparationQuotient.continuousAt_lift
 
 @[simp]
 theorem continuousWithinAt_lift {hf : ∀ x y, (x ~ᵢ y) → f x = f y}
-    {s : Set (SeparationQuotient X)}:
+    {s : Set (SeparationQuotient X)} :
     ContinuousWithinAt (lift f hf) s (mk x) ↔ ContinuousWithinAt f (mk ⁻¹' s) x :=
   tendsto_lift_nhdsWithin_mk
 #align separation_quotient.continuous_within_at_lift SeparationQuotient.continuousWithinAt_lift

--- a/Mathlib/Topology/Instances/ENNReal.lean
+++ b/Mathlib/Topology/Instances/ENNReal.lean
@@ -1663,13 +1663,13 @@ lemma liminf_sub_const (F : Filter ι) [NeBot F] (f : ι → ℝ≥0∞) (c : �
     (fun _ _ h ↦ tsub_le_tsub_right h c) (continuous_sub_right c).continuousAt).symm
 
 lemma limsup_const_sub (F : Filter ι) [NeBot F] (f : ι → ℝ≥0∞)
-    {c : ℝ≥0∞} (c_ne_top : c ≠ ∞):
+    {c : ℝ≥0∞} (c_ne_top : c ≠ ∞) :
     Filter.limsup (fun i ↦ c - f i) F = c - Filter.liminf f F :=
   (Antitone.map_limsInf_of_continuousAt (F := F.map f) (f := fun (x : ℝ≥0∞) ↦ c - x)
     (fun _ _ h ↦ tsub_le_tsub_left h c) (continuous_sub_left c_ne_top).continuousAt).symm
 
 lemma liminf_const_sub (F : Filter ι) [NeBot F] (f : ι → ℝ≥0∞)
-    {c : ℝ≥0∞} (c_ne_top : c ≠ ∞):
+    {c : ℝ≥0∞} (c_ne_top : c ≠ ∞) :
     Filter.liminf (fun i ↦ c - f i) F = c - Filter.limsup f F :=
   (Antitone.map_limsSup_of_continuousAt (F := F.map f) (f := fun (x : ℝ≥0∞) ↦ c - x)
     (fun _ _ h ↦ tsub_le_tsub_left h c) (continuous_sub_left c_ne_top).continuousAt).symm

--- a/Mathlib/Topology/Metrizable/Uniformity.lean
+++ b/Mathlib/Topology/Metrizable/Uniformity.lean
@@ -282,7 +282,7 @@ theorem UniformSpace.metrizableSpace [UniformSpace X] [IsCountablyGenerated (�
 /-- A totally bounded set is separable in countably generated uniform spaces. This can be obtained
 from the more general `EMetric.subset_countable_closure_of_almost_dense_set`.-/
 lemma TotallyBounded.isSeparable [UniformSpace X] [i : IsCountablyGenerated (𝓤 X)]
-    {s : Set X} (h : TotallyBounded s) : TopologicalSpace.IsSeparable s:= by
+    {s : Set X} (h : TotallyBounded s) : TopologicalSpace.IsSeparable s := by
   letI := (UniformSpace.pseudoMetricSpace (X := X)).toPseudoEMetricSpace
   rw [EMetric.totallyBounded_iff] at h
   have h' : ∀ ε > 0, ∃ t, Set.Countable t ∧ s ⊆ ⋃ y ∈ t, EMetric.closedBall y ε := by

--- a/Mathlib/Topology/Separation.lean
+++ b/Mathlib/Topology/Separation.lean
@@ -1141,7 +1141,7 @@ theorem specializes_iff_not_disjoint : x ⤳ y ↔ ¬Disjoint (𝓝 x) (𝓝 y) 
 theorem disjoint_nhds_nhds_iff_not_inseparable : Disjoint (𝓝 x) (𝓝 y) ↔ ¬Inseparable x y := by
   rw [disjoint_nhds_nhds_iff_not_specializes, specializes_iff_inseparable]
 
-theorem r1Space_iff_inseparable_or_disjoint_nhds {X : Type*} [TopologicalSpace X]:
+theorem r1Space_iff_inseparable_or_disjoint_nhds {X : Type*} [TopologicalSpace X] :
     R1Space X ↔ ∀ x y : X, Inseparable x y ∨ Disjoint (𝓝 x) (𝓝 y) :=
   ⟨fun _h x y ↦ (specializes_or_disjoint_nhds x y).imp_left Specializes.inseparable, fun h ↦
     ⟨fun x y ↦ (h x y).imp_left Inseparable.specializes⟩⟩
@@ -1929,7 +1929,7 @@ theorem IsCompact.preimage_continuous [CompactSpace X] [T2Space Y] {f : X → Y}
 
 lemma Pi.isCompact_iff {ι : Type*} {π : ι → Type*} [∀ i, TopologicalSpace (π i)]
     [∀ i, T2Space (π i)] {s : Set (Π i, π i)} :
-    IsCompact s ↔ IsClosed s ∧ ∀ i, IsCompact (eval i '' s):= by
+    IsCompact s ↔ IsClosed s ∧ ∀ i, IsCompact (eval i '' s) := by
   constructor <;> intro H
   · exact ⟨H.isClosed, fun i ↦ H.image <| continuous_apply i⟩
   · exact IsCompact.of_isClosed_subset (isCompact_univ_pi H.2) H.1 (subset_pi_eval_image univ s)

--- a/scripts/lint-style.py
+++ b/scripts/lint-style.py
@@ -48,6 +48,8 @@ ERR_CLN = 16 # line starts with a colon
 ERR_IND = 17 # second line not correctly indented
 ERR_ARR = 18 # space after "←"
 ERR_NSP = 20 # non-terminal simp
+ERR_MISSING_SPACE = 21 # missing spaces around colon or colon-equals
+ERR_DOUBLE_SPACE = 22 # double space (when not part of manual alignment)
 
 exceptions = []
 
@@ -277,6 +279,86 @@ def isolated_by_dot_semicolon_check(lines, path):
         newlines.append((line_nr, line))
     return errors, newlines
 
+'''Split of an inline Lean comment or beginning multi-line comment:
+return a tuple (before, spaces, comment) consisting of
+the string before the comment marked (right-trimmed), any space before the comment marked
+and the comment itself (including the comment marker).
+'''
+def split_inline_comment(line):
+    # Split off any in-line comment or beginning /-:
+    # this check ignores in-line string literals, but is good enough for our purposes.
+    before = line
+    spaces = ""
+    comment = ""
+    # Idx is the index of the first of "--" and "/-" (and -1 if neither occurs).
+    idx = line.find("--")
+    idx2 = line.find("/-")
+    if idx >= 0 and idx2 >= 0:
+        idx = min(idx, idx2)
+    else:
+        idx = max(idx, idx2)
+    if idx >= 0:
+        comment = line[idx:]
+        before = line[:idx]
+        # Make sure to preserve the number of spaces before the comment marked.
+        if before.endswith(" "):
+            num_spaces = len(before) - len(before.rstrip())
+            spaces = before[-num_spaces:]
+            before = before.rstrip()
+    assert f"{before}{spaces}{comment}" == line, f"bug in comment splitting: input is {line}, output is ('{before}', '{spaces}', '{comment}')"
+    return (before, spaces, comment)
+
+
+'''Error if a colon or colon-equals is not surrounded by spaces. '''
+def missing_spaces_around_operators(lines, path):
+    errors = []
+    newlines = []
+    for line_nr, line, is_comment, in_string in annotate_strings(annotate_comments(lines)):
+        if is_comment or in_string:
+            newlines.append((line_nr, line))
+            continue
+        num_spaces = len(line) - len(line.lstrip())
+        new_line = line.strip()
+        (before_comment, spaces, comment) = split_inline_comment(new_line)
+
+        # Handle := not surrounded by spaces.
+        if ":=" in before_comment:
+            left = before_comment.count(":=")
+            # Treat := as line ending separately.
+            if before_comment.endswith(":="):
+                left -= 1
+                if not before_comment.endswith(" :="):
+                    errors += [(ERR_MISSING_SPACE, line_nr, path)]
+                    before_comment = f"{before_comment[:-2]} :="
+            if left != before_comment.count(" := "):
+                errors += [(ERR_MISSING_SPACE, line_nr, path)]
+                # This replacement is approximate (e.g. doesn't handle purposeful double spaces).
+                before_comment = before_comment.replace(":=", " := ").replace("  ", " ").rstrip()
+        # Handle : which are not part of :=
+        if ":" in before_comment:
+            left = before_comment.count(":") - before_comment.count(":=") - (2 * before_comment.count("::"))
+            # Handle a line ending in a colon or double colon separately.
+            if before_comment.endswith("::"):
+                left -= 1
+                if not before_comment.endswith(" ::"):
+                    errors += [(ERR_MISSING_SPACE, line_nr, path)]
+                    before_comment = f"{before_comment[:-2]} ::"
+            elif before_comment.endswith(":"):
+                left -= 1
+                if not before_comment.endswith(" :"):
+                    errors += [(ERR_MISSING_SPACE, line_nr, path)]
+                    before_comment = f"{before_comment[:-1]} :"
+            # # TODO: need to handle ::, here and below!
+            if left != before_comment.count(" : "):
+                if "Tactic" in str(path):
+                    newlines.append((line_nr, line))
+                    continue # for now
+                # errors += [(ERR_MISSING_SPACE, line_nr, path)]
+                # This replacement is approximate (e.g. doesn't handle purposeful double spaces).
+                # before_comment = before_comment.replace(":", " : ").replace("  ", " ").rstrip()
+        newlines.append((line_nr, f'{line[:num_spaces]}{before_comment}{spaces}{comment}\n'))
+    return errors, newlines
+
 def left_arrow_check(lines, path):
     errors = []
     newlines = []
@@ -334,6 +416,8 @@ def format_errors(errors):
             output_message(path, line_nr, "ERR_ARR", "Missing space after '←'.")
         if errno == ERR_NSP:
             output_message(path, line_nr, "ERR_NSP", "Non-terminal simp. Replace with `simp?` and use the suggested output")
+        if errno == ERR_MISSING_SPACE:
+            output_message(path, line_nr, "ERR_MISSING_SPACE", "Please put spaces around colons and colon-equals signs")
 
 def lint(path, fix=False):
     global new_exceptions
@@ -344,10 +428,10 @@ def lint(path, fix=False):
         enum_lines = enumerate(lines, 1)
         newlines = enum_lines
         for error_check in [line_endings_check,
-                            four_spaces_in_second_line,
-                            isolated_by_dot_semicolon_check,
-                            left_arrow_check,
-                            nonterminal_simp_check]:
+                            #four_spaces_in_second_line,
+                            #isolated_by_dot_semicolon_check,
+                            #left_arrow_check,
+                            missing_spaces_around_operators]:#nonterminal_simp_check]:
             errs, newlines = error_check(newlines, path)
             format_errors(errs)
 

--- a/scripts/lint-style.py
+++ b/scripts/lint-style.py
@@ -48,8 +48,6 @@ ERR_CLN = 16 # line starts with a colon
 ERR_IND = 17 # second line not correctly indented
 ERR_ARR = 18 # space after "←"
 ERR_NSP = 20 # non-terminal simp
-ERR_MISSING_SPACE = 21 # missing spaces around colon or colon-equals
-ERR_DOUBLE_SPACE = 22 # double space (when not part of manual alignment)
 
 exceptions = []
 
@@ -279,86 +277,6 @@ def isolated_by_dot_semicolon_check(lines, path):
         newlines.append((line_nr, line))
     return errors, newlines
 
-'''Split of an inline Lean comment or beginning multi-line comment:
-return a tuple (before, spaces, comment) consisting of
-the string before the comment marked (right-trimmed), any space before the comment marked
-and the comment itself (including the comment marker).
-'''
-def split_inline_comment(line):
-    # Split off any in-line comment or beginning /-:
-    # this check ignores in-line string literals, but is good enough for our purposes.
-    before = line
-    spaces = ""
-    comment = ""
-    # Idx is the index of the first of "--" and "/-" (and -1 if neither occurs).
-    idx = line.find("--")
-    idx2 = line.find("/-")
-    if idx >= 0 and idx2 >= 0:
-        idx = min(idx, idx2)
-    else:
-        idx = max(idx, idx2)
-    if idx >= 0:
-        comment = line[idx:]
-        before = line[:idx]
-        # Make sure to preserve the number of spaces before the comment marked.
-        if before.endswith(" "):
-            num_spaces = len(before) - len(before.rstrip())
-            spaces = before[-num_spaces:]
-            before = before.rstrip()
-    assert f"{before}{spaces}{comment}" == line, f"bug in comment splitting: input is {line}, output is ('{before}', '{spaces}', '{comment}')"
-    return (before, spaces, comment)
-
-
-'''Error if a colon or colon-equals is not surrounded by spaces. '''
-def missing_spaces_around_operators(lines, path):
-    errors = []
-    newlines = []
-    for line_nr, line, is_comment, in_string in annotate_strings(annotate_comments(lines)):
-        if is_comment or in_string:
-            newlines.append((line_nr, line))
-            continue
-        num_spaces = len(line) - len(line.lstrip())
-        new_line = line.strip()
-        (before_comment, spaces, comment) = split_inline_comment(new_line)
-
-        # Handle := not surrounded by spaces.
-        if ":=" in before_comment:
-            left = before_comment.count(":=")
-            # Treat := as line ending separately.
-            if before_comment.endswith(":="):
-                left -= 1
-                if not before_comment.endswith(" :="):
-                    errors += [(ERR_MISSING_SPACE, line_nr, path)]
-                    before_comment = f"{before_comment[:-2]} :="
-            if left != before_comment.count(" := "):
-                errors += [(ERR_MISSING_SPACE, line_nr, path)]
-                # This replacement is approximate (e.g. doesn't handle purposeful double spaces).
-                before_comment = before_comment.replace(":=", " := ").replace("  ", " ").rstrip()
-        # Handle : which are not part of :=
-        if ":" in before_comment:
-            left = before_comment.count(":") - before_comment.count(":=") - (2 * before_comment.count("::"))
-            # Handle a line ending in a colon or double colon separately.
-            if before_comment.endswith("::"):
-                left -= 1
-                if not before_comment.endswith(" ::"):
-                    errors += [(ERR_MISSING_SPACE, line_nr, path)]
-                    before_comment = f"{before_comment[:-2]} ::"
-            elif before_comment.endswith(":"):
-                left -= 1
-                if not before_comment.endswith(" :"):
-                    errors += [(ERR_MISSING_SPACE, line_nr, path)]
-                    before_comment = f"{before_comment[:-1]} :"
-            # # TODO: need to handle ::, here and below!
-            if left != before_comment.count(" : "):
-                if "Tactic" in str(path):
-                    newlines.append((line_nr, line))
-                    continue # for now
-                # errors += [(ERR_MISSING_SPACE, line_nr, path)]
-                # This replacement is approximate (e.g. doesn't handle purposeful double spaces).
-                # before_comment = before_comment.replace(":", " : ").replace("  ", " ").rstrip()
-        newlines.append((line_nr, f'{line[:num_spaces]}{before_comment}{spaces}{comment}\n'))
-    return errors, newlines
-
 def left_arrow_check(lines, path):
     errors = []
     newlines = []
@@ -416,8 +334,6 @@ def format_errors(errors):
             output_message(path, line_nr, "ERR_ARR", "Missing space after '←'.")
         if errno == ERR_NSP:
             output_message(path, line_nr, "ERR_NSP", "Non-terminal simp. Replace with `simp?` and use the suggested output")
-        if errno == ERR_MISSING_SPACE:
-            output_message(path, line_nr, "ERR_MISSING_SPACE", "Please put spaces around colons and colon-equals signs")
 
 def lint(path, fix=False):
     global new_exceptions
@@ -428,10 +344,10 @@ def lint(path, fix=False):
         enum_lines = enumerate(lines, 1)
         newlines = enum_lines
         for error_check in [line_endings_check,
-                            #four_spaces_in_second_line,
-                            #isolated_by_dot_semicolon_check,
-                            #left_arrow_check,
-                            missing_spaces_around_operators]:#nonterminal_simp_check]:
+                            four_spaces_in_second_line,
+                            isolated_by_dot_semicolon_check,
+                            left_arrow_check,
+                            nonterminal_simp_check]:
             errs, newlines = error_check(newlines, path)
             format_errors(errs)
 


### PR DESCRIPTION
Follow mathlib style slightly better: "Use spaces on both sides of ":", ":=" or infix operators."

Automatically generated. Not exhaustive, as doing that everywhere has false positives with meta code.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks, and is labeled with `awaiting-review`.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
