### PR TITLE
[Merged by Bors] - fix: make the allowed unused tactics extensible

### DIFF
--- a/Mathlib/Tactic/Linter/UnusedTactic.lean
+++ b/Mathlib/Tactic/Linter/UnusedTactic.lean
@@ -94,10 +94,12 @@ initialize allowedRef : IO.Ref (HashSet SyntaxNodeKind) ←
     |>.insert `change?
     |>.insert `«tactic#adaptation_note_»
 
-/-- `#allow_unused_tactic` takes an input a space-separated list of identifiers and extends
-the tactics that are allowed by the unused tactic linter to not modify goals using the
-input identifiers.
-For instance, you can allow `done` and `skip` to not emit warning using
+/-- `#allow_unused_tactic` takes an input a space-separated list of identifiers.
+These identifiers are then allowed by the unused tactic linter:
+even if these tactics do not modify goals, there will be no warning emitted.
+Note: for this to work, these identifiers should be the `SyntaxNodeKind` of each tactic.
+
+For instance, you can allow `done` and `skip` tactics using
 ```lean
 #allow_unused_tactic Lean.Parser.Tactic.done Lean.Parser.Tactic.skip
 ```

--- a/Mathlib/Tactic/Linter/UnusedTactic.lean
+++ b/Mathlib/Tactic/Linter/UnusedTactic.lean
@@ -99,7 +99,7 @@ These identifiers are then allowed by the unused tactic linter:
 even if these tactics do not modify goals, there will be no warning emitted.
 Note: for this to work, these identifiers should be the `SyntaxNodeKind` of each tactic.
 
-For instance, you can allow `done` and `skip` tactics using
+For instance, you can allow the `done` and `skip` tactics using
 ```lean
 #allow_unused_tactic Lean.Parser.Tactic.done Lean.Parser.Tactic.skip
 ```

--- a/test/UnusedTactic.lean
+++ b/test/UnusedTactic.lean
@@ -15,6 +15,9 @@ set_option linter.unusedTactic false
 /--
 warning: 'congr' tactic does nothing
 note: this linter can be disabled with `set_option linter.unusedTactic false`
+---
+warning: 'done' tactic does nothing
+note: this linter can be disabled with `set_option linter.unusedTactic false`
 -/
 #guard_msgs in
 set_option linter.unusedTactic true in
@@ -22,6 +25,7 @@ set_option linter.unusedTactic true in
 example : True := by
   congr
   constructor
+  done
 
 section allowing_more_unused_tactics
 --  test that allowing more unused tactics has the desired effect of silencing the linter
@@ -35,10 +39,3 @@ example : True := by
   done
 
 end allowing_more_unused_tactics
-
-#guard_msgs in
-set_option linter.unusedTactic true in
-example : True := by
-  skip
-  constructor
-  done

--- a/test/UnusedTactic.lean
+++ b/test/UnusedTactic.lean
@@ -22,3 +22,23 @@ set_option linter.unusedTactic true in
 example : True := by
   congr
   constructor
+
+section allowing_more_unused_tactics
+--  test that allowing more unused tactics has the desired effect of silencing the linter
+#allow_unused_tactic Lean.Parser.Tactic.done Lean.Parser.Tactic.skip
+
+#guard_msgs in
+set_option linter.unusedTactic true in
+example : True := by
+  skip
+  constructor
+  done
+
+end allowing_more_unused_tactics
+
+#guard_msgs in
+set_option linter.unusedTactic true in
+example : True := by
+  skip
+  constructor
+  done


### PR DESCRIPTION
This PR allows to change the tactics that the unused tactic linter ignores.

The main use-case is allowing `done` at the end of proofs, which is very useful for teaching purposes.  See for instance [this Zulip thread](https://leanprover.zulipchat.com/#narrow/stream/113488-general/topic/Disable.20.60linter.2EunusedTactic.60.20warning.20for.20.60done.60).

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks, and is labeled with `awaiting-review`.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
