### PR TITLE
[Merged by Bors] - chore(Control): reduce use of autoImplicit

### DIFF
--- a/Mathlib/Control/Monad/Basic.lean
+++ b/Mathlib/Control/Monad/Basic.lean
@@ -36,7 +36,8 @@ functor, applicative, monad, simp
 
 -/
 
-set_option autoImplicit true
+universe u v
+variable {α β σ : Type u}
 
 attribute [ext] ReaderT.ext StateT.ext ExceptT.ext
 
@@ -51,16 +52,19 @@ def StateT.eval {m : Type u → Type v} [Functor m] (cmd : StateT σ m α) (s : 
   Prod.fst <$> cmd.run s
 #align state_t.eval StateT.eval
 
+universe u₀ u₁ v₀ v₁
 /-- reduce the equivalence between two state monads to the equivalence between
 their respective function spaces -/
-def StateT.equiv {m₁ : Type u₀ → Type v₀} {m₂ : Type u₁ → Type v₁}
+def StateT.equiv {σ₁ α₁ : Type u₀} {σ₂ α₂ : Type u₁}
+    {m₁ : Type u₀ → Type v₀} {m₂ : Type u₁ → Type v₁}
     (F : (σ₁ → m₁ (α₁ × σ₁)) ≃ (σ₂ → m₂ (α₂ × σ₂))) : StateT σ₁ m₁ α₁ ≃ StateT σ₂ m₂ α₂ :=
   F
 #align state_t.equiv StateT.equiv
 
 /-- reduce the equivalence between two reader monads to the equivalence between
 their respective function spaces -/
-def ReaderT.equiv {m₁ : Type u₀ → Type v₀} {m₂ : Type u₁ → Type v₁}
+def ReaderT.equiv {ρ₁ α₁ : Type u₀} {ρ₂ α₂ : Type u₁}
+    {m₁ : Type u₀ → Type v₀} {m₂ : Type u₁ → Type v₁}
     (F : (ρ₁ → m₁ α₁) ≃ (ρ₂ → m₂ α₂)) : ReaderT ρ₁ m₁ α₁ ≃ ReaderT ρ₂ m₂ α₂ :=
   F
 #align reader_t.equiv ReaderT.equiv

--- a/Mathlib/Control/Monad/Writer.lean
+++ b/Mathlib/Control/Monad/Writer.lean
@@ -21,7 +21,7 @@ computation progresses.
 
 -/
 
-set_option autoImplicit true
+universe u v
 
 def WriterT (ω : Type u) (M : Type u → Type v) (α : Type u) : Type v :=
   M (α × ω)
@@ -35,7 +35,7 @@ class MonadWriter (ω : outParam (Type u)) (M : Type u → Type v) where
 
 export MonadWriter (tell listen pass)
 
-variable {M : Type u → Type v} [Monad M]
+variable {M : Type u → Type v} [Monad M] {α ω ρ σ : Type u}
 
 instance [MonadWriter ω M] : MonadWriter ω (ReaderT ρ M) where
   tell w := (tell w : M _)
@@ -99,7 +99,7 @@ instance : MonadWriter ω (WriterT ω M) where
   listen := fun cmd ↦ WriterT.mk <| (fun (a,w) ↦ ((a,w), w)) <$> cmd
   pass := fun cmd ↦ WriterT.mk <| (fun ((a,f), w) ↦ (a, f w)) <$> cmd
 
-instance [MonadExcept ε M] : MonadExcept ε (WriterT ω M) where
+instance {ε : Type*} [MonadExcept ε M] : MonadExcept ε (WriterT ω M) where
   throw := fun e ↦ WriterT.mk <| throw e
   tryCatch := fun cmd c ↦ WriterT.mk <| tryCatch cmd fun e ↦ (c e).run
 
@@ -128,6 +128,7 @@ class MonadWriterAdapter (ω : outParam (Type u)) (m : Type u → Type v) where
 
 export MonadWriterAdapter (adaptWriter)
 
+variable {m : Type u → Type*}
 /-- Transitivity.
 
 see Note [lower instance priority] -/
@@ -138,6 +139,7 @@ instance (priority := 100) monadWriterAdapterTrans {n : Type u → Type v}
 instance [Monad m] : MonadWriterAdapter ω (WriterT ω m) where
   adaptWriter := WriterT.adapt
 
+universe u₀ u₁ v₀ v₁ in
 /-- reduce the equivalence between two writer monads to the equivalence between
 their underlying monad -/
 def WriterT.equiv {m₁ : Type u₀ → Type v₀} {m₂ : Type u₁ → Type v₁}


### PR DESCRIPTION
Control/Random is left untouched for now; that file seems to use autoImplicits quite pervasively

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks, and is labeled with `awaiting-review`.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
