### PR TITLE
chore (Algebra.Basic): split off results `Rat` algebras

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -13,6 +13,7 @@ import Mathlib.Algebra.Algebra.Opposite
 import Mathlib.Algebra.Algebra.Pi
 import Mathlib.Algebra.Algebra.Prod
 import Mathlib.Algebra.Algebra.Quasispectrum
+import Mathlib.Algebra.Algebra.Rat
 import Mathlib.Algebra.Algebra.RestrictScalars
 import Mathlib.Algebra.Algebra.Spectrum
 import Mathlib.Algebra.Algebra.Subalgebra.Basic

--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -4,6 +4,7 @@ import Mathlib.Algebra.Algebra.Basic
 import Mathlib.Algebra.Algebra.Bilinear
 import Mathlib.Algebra.Algebra.Defs
 import Mathlib.Algebra.Algebra.Equiv
+import Mathlib.Algebra.Algebra.Field
 import Mathlib.Algebra.Algebra.Hom
 import Mathlib.Algebra.Algebra.NonUnitalHom
 import Mathlib.Algebra.Algebra.NonUnitalSubalgebra

--- a/Mathlib/Algebra/Algebra/Basic.lean
+++ b/Mathlib/Algebra/Algebra/Basic.lean
@@ -10,7 +10,7 @@ import Mathlib.Algebra.Module.Submodule.RestrictScalars
 import Mathlib.Algebra.Module.ULift
 import Mathlib.Algebra.Ring.Subring.Basic
 import Mathlib.Data.Int.CharZero
-import Mathlib.Data.Rat.Cast.CharZero
+-- import Mathlib.Data.Rat.Cast.CharZero
 
 #align_import algebra.algebra.basic from "leanprover-community/mathlib"@"36b8aa61ea7c05727161f96a0532897bd72aedab"
 
@@ -262,46 +262,6 @@ instance nat_algebra_subsingleton : Subsingleton (Algebra ℕ R) :=
 #align nat_algebra_subsingleton nat_algebra_subsingleton
 
 end Nat
-
-namespace RingHom
-
-variable {R S : Type*}
-
--- Porting note: changed `[Ring R] [Ring S]` to `[Semiring R] [Semiring S]`
--- otherwise, Lean failed to find a `Subsingleton (ℚ →+* S)` instance
-@[simp]
-theorem map_rat_algebraMap [Semiring R] [Semiring S] [Algebra ℚ R] [Algebra ℚ S] (f : R →+* S)
-    (r : ℚ) : f (algebraMap ℚ R r) = algebraMap ℚ S r :=
-  RingHom.ext_iff.1 (Subsingleton.elim (f.comp (algebraMap ℚ R)) (algebraMap ℚ S)) r
-#align ring_hom.map_rat_algebra_map RingHom.map_rat_algebraMap
-
-end RingHom
-
-section Rat
-
-instance algebraRat {α} [DivisionRing α] [CharZero α] : Algebra ℚ α where
-  smul := (· • ·)
-  smul_def' := Rat.smul_def
-  toRingHom := Rat.castHom α
-  commutes' := Rat.cast_commute
-#align algebra_rat algebraRat
-
-/-- The rational numbers are an algebra over the non-negative rationals. -/
-instance : Algebra NNRat ℚ :=
-  NNRat.coeHom.toAlgebra
-
-/-- The two `Algebra ℚ ℚ` instances should coincide. -/
-example : algebraRat = Algebra.id ℚ :=
-  rfl
-
-@[simp] theorem algebraMap_rat_rat : algebraMap ℚ ℚ = RingHom.id ℚ := rfl
-#align algebra_map_rat_rat algebraMap_rat_rat
-
-instance algebra_rat_subsingleton {α} [Semiring α] : Subsingleton (Algebra ℚ α) :=
-  ⟨fun x y => Algebra.algebra_ext x y <| RingHom.congr_fun <| Subsingleton.elim _ _⟩
-#align algebra_rat_subsingleton algebra_rat_subsingleton
-
-end Rat
 
 section Int
 

--- a/Mathlib/Algebra/Algebra/Basic.lean
+++ b/Mathlib/Algebra/Algebra/Basic.lean
@@ -10,7 +10,6 @@ import Mathlib.Algebra.Module.Submodule.RestrictScalars
 import Mathlib.Algebra.Module.ULift
 import Mathlib.Algebra.Ring.Subring.Basic
 import Mathlib.Data.Int.CharZero
--- import Mathlib.Data.Rat.Cast.CharZero
 
 #align_import algebra.algebra.basic from "leanprover-community/mathlib"@"36b8aa61ea7c05727161f96a0532897bd72aedab"
 

--- a/Mathlib/Algebra/Algebra/Defs.lean
+++ b/Mathlib/Algebra/Algebra/Defs.lean
@@ -5,7 +5,6 @@ Authors: Kenny Lau, Yury Kudryashov
 -/
 import Mathlib.Algebra.BigOperators.Group.Finset
 import Mathlib.Algebra.Module.LinearMap.Defs
-import Mathlib.Data.Rat.Cast.Defs
 
 #align_import algebra.algebra.basic from "leanprover-community/mathlib"@"36b8aa61ea7c05727161f96a0532897bd72aedab"
 
@@ -185,53 +184,6 @@ theorem coe_sum {ι : Type*} {s : Finset ι} (a : ι → R) :
 -- Porting note: removed attribute [to_additive] coe_prod; why should this be a `to_additive`?
 
 end CommSemiringCommSemiring
-
-section FieldNontrivial
-
-variable {R A : Type*} [Field R] [CommSemiring A] [Nontrivial A] [Algebra R A]
-
-@[norm_cast, simp]
-theorem coe_inj {a b : R} : (↑a : A) = ↑b ↔ a = b :=
-  (algebraMap R A).injective.eq_iff
-#align algebra_map.coe_inj algebraMap.coe_inj
-
-@[norm_cast, simp]
-theorem lift_map_eq_zero_iff (a : R) : (↑a : A) = 0 ↔ a = 0 :=
-  map_eq_zero_iff _ (algebraMap R A).injective
-#align algebra_map.lift_map_eq_zero_iff algebraMap.lift_map_eq_zero_iff
-
-end FieldNontrivial
-
-section SemifieldSemidivisionRing
-
-variable {R : Type*} (A : Type*) [Semifield R] [DivisionSemiring A] [Algebra R A]
-
-@[norm_cast]
-theorem coe_inv (r : R) : ↑r⁻¹ = ((↑r)⁻¹ : A) :=
-  map_inv₀ (algebraMap R A) r
-#align algebra_map.coe_inv algebraMap.coe_inv
-
-@[norm_cast]
-theorem coe_div (r s : R) : ↑(r / s) = (↑r / ↑s : A) :=
-  map_div₀ (algebraMap R A) r s
-#align algebra_map.coe_div algebraMap.coe_div
-
-@[norm_cast]
-theorem coe_zpow (r : R) (z : ℤ) : ↑(r ^ z) = (r : A) ^ z :=
-  map_zpow₀ (algebraMap R A) r z
-#align algebra_map.coe_zpow algebraMap.coe_zpow
-
-end SemifieldSemidivisionRing
-
-section FieldDivisionRing
-
-variable (R A : Type*) [Field R] [DivisionRing A] [Algebra R A]
-
-@[norm_cast]
-theorem coe_ratCast (q : ℚ) : ↑(q : R) = (q : A) := map_ratCast (algebraMap R A) q
-#align algebra_map.coe_rat_cast algebraMap.coe_ratCast
-
-end FieldDivisionRing
 
 end algebraMap
 

--- a/Mathlib/Algebra/Algebra/Field.lean
+++ b/Mathlib/Algebra/Algebra/Field.lean
@@ -1,0 +1,64 @@
+/-
+Copyright (c) 2018 Kenny Lau. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kenny Lau, Yury Kudryashov
+-/
+import Mathlib.Algebra.Algebra.Basic
+import Mathlib.Data.Rat.Cast.Defs
+
+#align_import algebra.algebra.basic from "leanprover-community/mathlib"@"36b8aa61ea7c05727161f96a0532897bd72aedab"
+
+/-!
+# Algebras over semifields and fields
+
+-/
+
+namespace algebraMap
+
+section FieldNontrivial
+
+variable {R A : Type*} [Field R] [CommSemiring A] [Nontrivial A] [Algebra R A]
+
+@[norm_cast, simp]
+theorem coe_inj {a b : R} : (↑a : A) = ↑b ↔ a = b :=
+  (algebraMap R A).injective.eq_iff
+#align algebra_map.coe_inj algebraMap.coe_inj
+
+@[norm_cast, simp]
+theorem lift_map_eq_zero_iff (a : R) : (↑a : A) = 0 ↔ a = 0 :=
+  map_eq_zero_iff _ (algebraMap R A).injective
+#align algebra_map.lift_map_eq_zero_iff algebraMap.lift_map_eq_zero_iff
+
+end FieldNontrivial
+
+section SemifieldSemidivisionRing
+
+variable {R : Type*} (A : Type*) [Semifield R] [DivisionSemiring A] [Algebra R A]
+
+@[norm_cast]
+theorem coe_inv (r : R) : ↑r⁻¹ = ((↑r)⁻¹ : A) :=
+  map_inv₀ (algebraMap R A) r
+#align algebra_map.coe_inv algebraMap.coe_inv
+
+@[norm_cast]
+theorem coe_div (r s : R) : ↑(r / s) = (↑r / ↑s : A) :=
+  map_div₀ (algebraMap R A) r s
+#align algebra_map.coe_div algebraMap.coe_div
+
+@[norm_cast]
+theorem coe_zpow (r : R) (z : ℤ) : ↑(r ^ z) = (r : A) ^ z :=
+  map_zpow₀ (algebraMap R A) r z
+#align algebra_map.coe_zpow algebraMap.coe_zpow
+
+end SemifieldSemidivisionRing
+
+section FieldDivisionRing
+
+variable (R A : Type*) [Field R] [DivisionRing A] [Algebra R A]
+
+@[norm_cast]
+theorem coe_ratCast (q : ℚ) : ↑(q : R) = (q : A) := map_ratCast (algebraMap R A) q
+#align algebra_map.coe_rat_cast algebraMap.coe_ratCast
+
+end FieldDivisionRing
+

--- a/Mathlib/Algebra/Algebra/Field.lean
+++ b/Mathlib/Algebra/Algebra/Field.lean
@@ -6,8 +6,6 @@ Authors: Kenny Lau, Yury Kudryashov
 import Mathlib.Algebra.Algebra.Basic
 import Mathlib.Data.Rat.Cast.Defs
 
-#align_import algebra.algebra.basic from "leanprover-community/mathlib"@"36b8aa61ea7c05727161f96a0532897bd72aedab"
-
 /-!
 # Algebras over semifields and fields
 

--- a/Mathlib/Algebra/Algebra/Rat.lean
+++ b/Mathlib/Algebra/Algebra/Rat.lean
@@ -6,7 +6,6 @@ Authors: Kenny Lau, Yury Kudryashov
 import Mathlib.Algebra.Algebra.Basic
 import Mathlib.Data.Rat.Cast.CharZero
 
-#align_import algebra.algebra.basic from "leanprover-community/mathlib"@"36b8aa61ea7c05727161f96a0532897bd72aedab"
 
 /-!
 # Further basic results about `Algebra`'s over `ℚ`.

--- a/Mathlib/Algebra/Algebra/Rat.lean
+++ b/Mathlib/Algebra/Algebra/Rat.lean
@@ -1,0 +1,57 @@
+/-
+Copyright (c) 2018 Kenny Lau. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kenny Lau, Yury Kudryashov
+-/
+import Mathlib.Algebra.Algebra.Basic
+import Mathlib.Data.Rat.Cast.CharZero
+
+#align_import algebra.algebra.basic from "leanprover-community/mathlib"@"36b8aa61ea7c05727161f96a0532897bd72aedab"
+
+/-!
+# Further basic results about `Algebra`'s over `ℚ`.
+
+This file could usefully be split further.
+-/
+
+namespace RingHom
+
+variable {R S : Type*}
+
+-- Porting note: changed `[Ring R] [Ring S]` to `[Semiring R] [Semiring S]`
+-- otherwise, Lean failed to find a `Subsingleton (ℚ →+* S)` instance
+@[simp]
+theorem map_rat_algebraMap [Semiring R] [Semiring S] [Algebra ℚ R] [Algebra ℚ S] (f : R →+* S)
+    (r : ℚ) : f (algebraMap ℚ R r) = algebraMap ℚ S r :=
+  RingHom.ext_iff.1 (Subsingleton.elim (f.comp (algebraMap ℚ R)) (algebraMap ℚ S)) r
+#align ring_hom.map_rat_algebra_map RingHom.map_rat_algebraMap
+
+end RingHom
+
+section Rat
+
+instance algebraRat {α} [DivisionRing α] [CharZero α] : Algebra ℚ α where
+  smul := (· • ·)
+  smul_def' := Rat.smul_def
+  toRingHom := Rat.castHom α
+  commutes' := Rat.cast_commute
+#align algebra_rat algebraRat
+
+/-- The rational numbers are an algebra over the non-negative rationals. -/
+instance : Algebra NNRat ℚ :=
+  NNRat.coeHom.toAlgebra
+
+/-- The two `Algebra ℚ ℚ` instances should coincide. -/
+example : algebraRat = Algebra.id ℚ :=
+  rfl
+
+@[simp] theorem algebraMap_rat_rat : algebraMap ℚ ℚ = RingHom.id ℚ := rfl
+#align algebra_map_rat_rat algebraMap_rat_rat
+
+instance algebra_rat_subsingleton {α} [Semiring α] : Subsingleton (Algebra ℚ α) :=
+  ⟨fun x y => Algebra.algebra_ext x y <| RingHom.congr_fun <| Subsingleton.elim _ _⟩
+#align algebra_rat_subsingleton algebra_rat_subsingleton
+
+end Rat
+
+


### PR DESCRIPTION
By putting dependencies on `LinearOrderedField Rat` in `Algebra.Basic`, we import too much unnecessary machinery and carry it downstream. This splits off the `LinearOrderedField Rat` declaration into `Algebra.Algebra.Rat`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks, and is labeled with `awaiting-review`.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->
- [ ] depends on: #14465 

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
