### PR TITLE
fix: make concrete cycle notation local

### DIFF
--- a/Mathlib/GroupTheory/Perm/Cycle/Concrete.lean
+++ b/Mathlib/GroupTheory/Perm/Cycle/Concrete.lean
@@ -527,7 +527,7 @@ def isoCycle' : { f : Perm α // IsCycle f } ≃ { s : Cycle α // s.Nodup ∧ s
 
 -- mutes `'decide' tactic does nothing [linter.unusedTactic]`
 set_option linter.unusedTactic false in
-notation3 (prettyPrint := false) "c["(l", "* => foldr (h t => List.cons h t) List.nil)"]" =>
+local notation3 (prettyPrint := false) "c["(l", "* => foldr (h t => List.cons h t) List.nil)"]" =>
   Cycle.formPerm (Cycle.ofList l) (Iff.mpr Cycle.nodup_coe_iff (by decide))
 
 unsafe instance repr_perm [Repr α] : Repr (Perm α) :=


### PR DESCRIPTION
fix: make c[...] notation for concrete cycles local

---

The notation for concrete cycles prevents you using `c[i]` notation for `c : Array _`

This currently does not work
```
import Mathlib

variable (c : Array Nat) (i : Fin c.size)

#check c[i] -- breaks because of notation for concrete cycles
```
This PR just marks it as local to prevent this issue.


[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
