### PR TITLE
[Merged by Bors] - fix(nlinarith): make `findSquares` deterministic

### DIFF
--- a/Mathlib/Tactic/Linarith/Preprocessing.lean
+++ b/Mathlib/Tactic/Linarith/Preprocessing.lean
@@ -350,11 +350,8 @@ def nlinarithExtras : GlobalPreprocessor where
       let si ← ls.foldrM (fun h s' => do findSquares s' (← instantiateMVars (← inferType h)))
         HashSet.empty
       si.toList.mapM fun (i, is_sq) => return ((← get).atoms[i]!, is_sq)
-    let new_es ← s.filterMapM fun (e, is_sq) => do
-      try
-        mkAppM (if is_sq then ``sq_nonneg else ``mul_self_nonneg) #[e]
-      catch _ =>
-        pure none
+    let new_es ← s.filterMapM fun (e, is_sq) =>
+      observing? <| mkAppM (if is_sq then ``sq_nonneg else ``mul_self_nonneg) #[e]
     let new_es ← compWithZero.globalize.transform new_es
     trace[linarith] "nlinarith preprocessing found squares"
     trace[linarith] "{s}"

--- a/Mathlib/Tactic/Linarith/Preprocessing.lean
+++ b/Mathlib/Tactic/Linarith/Preprocessing.lean
@@ -307,7 +307,7 @@ section nlinarith
 /--
 `findSquares s e` collects all terms of the form `a ^ 2` and `a * a` that appear in `e`
 and adds them to the set `s`.
-A pair `(i, true)` is idded to `s` when `atoms[i]^2` appears in `e`,
+A pair `(i, true)` is added to `s` when `atoms[i]^2` appears in `e`,
 and `(i, false)` is added to `s` when `atoms[i]*atoms[i]` appears in `e`.  -/
 partial def findSquares (s : HashSet (Nat × Bool)) (e : Expr) : AtomM (HashSet (Nat × Bool)) :=
   -- Completely traversing the expression is non-ideal,

--- a/Mathlib/Tactic/Linarith/Preprocessing.lean
+++ b/Mathlib/Tactic/Linarith/Preprocessing.lean
@@ -34,6 +34,7 @@ namespace Linarith
 open Lean hiding Rat
 open Elab Tactic Meta
 open Qq
+open Mathlib.Tactic (AtomM)
 
 /-- Processor that recursively replaces `P ∧ Q` hypotheses with the pair `P` and `Q`. -/
 partial def splitConjunctions : Preprocessor where
@@ -306,9 +307,9 @@ section nlinarith
 /--
 `findSquares s e` collects all terms of the form `a ^ 2` and `a * a` that appear in `e`
 and adds them to the set `s`.
-A pair `(a, true)` is added to `s` when `a^2` appears in `e`,
-and `(a, false)` is added to `s` when `a*a` appears in `e`.  -/
-partial def findSquares (s : HashSet (Expr × Bool)) (e : Expr) : MetaM (HashSet (Expr × Bool)) :=
+A pair `(i, true)` is idded to `s` when `atoms[i]^2` appears in `e`,
+and `(i, false)` is added to `s` when `atoms[i]*atoms[i]` appears in `e`.  -/
+partial def findSquares (s : HashSet (Nat × Bool)) (e : Expr) : AtomM (HashSet (Nat × Bool)) :=
   -- Completely traversing the expression is non-ideal,
   -- as we can descend into expressions that could not possibly be seen by `linarith`.
   -- As a result we visit expressions with bvars, which then cause panics.
@@ -319,11 +320,15 @@ partial def findSquares (s : HashSet (Expr × Bool)) (e : Expr) : MetaM (HashSet
   | (``HPow.hPow, #[_, _, _, _, a, b]) => match b.numeral? with
     | some 2 => do
       let s ← findSquares s a
-      return (s.insert (a, true))
+      let ai ← AtomM.addAtom a
+      return (s.insert (ai, true))
     | _ => e.foldlM findSquares s
-  | (``HMul.hMul, #[_, _, _, _, a, b]) => if a.equal b then do
+  | (``HMul.hMul, #[_, _, _, _, a, b]) => do
+    let ai ← AtomM.addAtom a
+    let bi ← AtomM.addAtom b
+    if ai = bi then do
       let s ← findSquares s a
-      return (s.insert (a, false))
+      return (s.insert (ai, false))
     else
       e.foldlM findSquares s
   | _ => e.foldlM findSquares s
@@ -340,15 +345,19 @@ This preprocessor is typically run last, after all inputs have been canonized.
 def nlinarithExtras : GlobalPreprocessor where
   name := "nonlinear arithmetic extras"
   transform ls := do
-    let s ← ls.foldrM (fun h s' => do findSquares s' (← instantiateMVars (← inferType h)))
-      HashSet.empty
-    let new_es ← s.foldM (fun new_es (⟨e, is_sq⟩ : Expr × Bool) =>
-      ((do
-        let p ← mkAppM (if is_sq then ``sq_nonneg else ``mul_self_nonneg) #[e]
-        pure <| p::new_es) <|> pure new_es)) ([] : List Expr)
+    -- find the squares in `AtomM` to ensure deterministic behavior
+    let s ← AtomM.run .reducible do
+      let si ← ls.foldrM (fun h s' => do findSquares s' (← instantiateMVars (← inferType h)))
+        HashSet.empty
+      si.toList.mapM fun (i, is_sq) => return ((← get).atoms[i]!, is_sq)
+    let new_es ← s.filterMapM fun (e, is_sq) => do
+      try
+        mkAppM (if is_sq then ``sq_nonneg else ``mul_self_nonneg) #[e]
+      catch _ =>
+        pure none
     let new_es ← compWithZero.globalize.transform new_es
     trace[linarith] "nlinarith preprocessing found squares"
-    trace[linarith] "{s.toList}"
+    trace[linarith] "{s}"
     linarithTraceProofs "so we added proofs" new_es
     let with_comps ← (new_es ++ ls).mapM (fun e => do
       let tp ← inferType e

--- a/test/linarith.lean
+++ b/test/linarith.lean
@@ -704,3 +704,23 @@ example {x1 x2 x3 x4 x5 x6 x7 x8 : ℚ} :
     x7 - x5 < 0 → False := by
   intros
   linarith (config := { oracle := .fourierMotzkin })
+
+section findSquares
+
+private abbrev wrapped (z : ℤ) : ℤ := z
+/-- the `findSquares` preprocessor can look through reducible defeq -/
+example (x : ℤ) : 0 ≤ x * wrapped x := by nlinarith
+
+private def tightlyWrapped (z : ℤ) : ℤ := z
+/--
+error: linarith failed to find a contradiction
+case a
+x : ℤ
+a✝ : 0 > x * tightlyWrapped x
+⊢ False
+failed
+-/
+#guard_msgs in
+example (x : ℤ) : 0 ≤ x * tightlyWrapped x := by nlinarith
+
+end findSquares


### PR DESCRIPTION
Previously the order in which the assumptions were added was determined by `Expr` hashes, which while deterministic are not part of the user's mental model.

This matters (see [Zulip](https://leanprover.zulipchat.com/#narrow/stream/287929-mathlib4/topic/nlinarith.20is.20affected.20by.20.60example.60s/near/449994710)) because it then affects the order in which metavariables are unified.

As a bonus(?), this now means that squares are now found up to reducible defeq.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks, and is labeled with `awaiting-review`.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
