### PR TITLE
[Merged by Bors] - feat: Lemmas `DifferentiableAt.add_iff_left`, `DifferentiableAt.add_iff_right`

### DIFF
--- a/Mathlib/Analysis/Calculus/FDeriv/Add.lean
+++ b/Mathlib/Analysis/Calculus/FDeriv/Add.lean
@@ -559,6 +559,30 @@ theorem DifferentiableOn.sub (hf : DifferentiableOn 𝕜 f s) (hg : Differentiab
     DifferentiableOn 𝕜 (fun y => f y - g y) s := fun x hx => (hf x hx).sub (hg x hx)
 #align differentiable_on.sub DifferentiableOn.sub
 
+@[simp]
+lemma DifferentiableOn.add_iff_left (hg : DifferentiableOn 𝕜 g s) :
+    DifferentiableOn 𝕜 (fun y => f y + g y) s ↔ DifferentiableOn 𝕜 f s := by
+  refine ⟨fun h ↦ ?_, fun hf ↦ hf.add hg⟩
+  simpa only [add_sub_cancel_right] using h.sub hg
+
+@[simp]
+lemma DifferentiableOn.add_iff_right (hg : DifferentiableOn 𝕜 f s) :
+    DifferentiableOn 𝕜 (fun y => f y + g y) s ↔ DifferentiableOn 𝕜 g s := by
+  simp only [add_comm (f _), hg.add_iff_left]
+
+@[simp]
+lemma DifferentiableOn.sub_iff_left (hg : DifferentiableOn 𝕜 g s) :
+    DifferentiableOn 𝕜 (fun y => f y - g y) s ↔ DifferentiableOn 𝕜 f s := by
+  refine ⟨fun h ↦ ?_, fun hf ↦ hf.sub hg⟩
+  simpa only [sub_add_cancel] using h.add hg
+
+@[simp]
+lemma DifferentiableOn.sub_iff_right (hg : DifferentiableOn 𝕜 f s) :
+    DifferentiableOn 𝕜 (fun y => f y - g y) s ↔ DifferentiableOn 𝕜 g s := by
+  refine ⟨fun h ↦ ?_, fun hf ↦ hg.sub hf⟩
+  simpa only [sub_sub_cancel_left, differentiableOn_neg_iff] using h.sub hg
+
+
 @[simp, fun_prop]
 theorem Differentiable.sub (hf : Differentiable 𝕜 f) (hg : Differentiable 𝕜 g) :
     Differentiable 𝕜 fun y => f y - g y := fun x => (hf x).sub (hg x)

--- a/Mathlib/Analysis/Calculus/FDeriv/Add.lean
+++ b/Mathlib/Analysis/Calculus/FDeriv/Add.lean
@@ -534,13 +534,8 @@ theorem DifferentiableAt.sub (hf : DifferentiableAt 𝕜 f x) (hg : Differentiab
 @[simp]
 lemma DifferentiableAt.add_iff_left (hg : DifferentiableAt 𝕜 g x) :
     DifferentiableAt 𝕜 (fun y => f y + g y) x ↔ DifferentiableAt 𝕜 f x := by
-  constructor <;> intro h
-  · have f_eq_sum_sub_g: f = (fun y => f y + g y) - g := by
-      ext
-      simp only [Pi.sub_apply, add_sub_cancel_right]
-    rw [f_eq_sum_sub_g]
-    exact DifferentiableAt.sub h hg
-  · simp_all only [DifferentiableAt.add]
+  refine ⟨fun h ↦ ?_, fun hf ↦ hf.add hg⟩
+  simpa using h.sub hg
 
 @[simp]
 lemma DifferentiableAt.add_iff_right (hg : DifferentiableAt 𝕜 f x) :

--- a/Mathlib/Analysis/Calculus/FDeriv/Add.lean
+++ b/Mathlib/Analysis/Calculus/FDeriv/Add.lean
@@ -531,6 +531,23 @@ theorem DifferentiableAt.sub (hf : DifferentiableAt 𝕜 f x) (hg : Differentiab
   (hf.hasFDerivAt.sub hg.hasFDerivAt).differentiableAt
 #align differentiable_at.sub DifferentiableAt.sub
 
+@[simp]
+lemma DifferentiableAt.add_iff_left (hg : DifferentiableAt 𝕜 g x) :
+    DifferentiableAt 𝕜 (fun y => f y + g y) x ↔ DifferentiableAt 𝕜 f x := by
+  constructor <;> intro h
+  · have f_eq_sum_sub_g: f = (fun y => f y + g y) - g := by
+      ext
+      simp only [Pi.sub_apply, add_sub_cancel_right]
+    rw [f_eq_sum_sub_g]
+    exact DifferentiableAt.sub h hg
+  · simp_all only [DifferentiableAt.add]
+
+@[simp]
+lemma DifferentiableAt.add_iff_right (hg : DifferentiableAt 𝕜 f x) :
+    DifferentiableAt 𝕜 (fun y => f y + g y) x ↔ DifferentiableAt 𝕜 g x := by
+  rw [show (fun y ↦ f y + g y) = (fun y ↦ g y + f y) by ext; rw [add_comm]]
+  exact hg.add_iff_left
+
 @[fun_prop]
 theorem DifferentiableOn.sub (hf : DifferentiableOn 𝕜 f s) (hg : DifferentiableOn 𝕜 g s) :
     DifferentiableOn 𝕜 (fun y => f y - g y) s := fun x hx => (hf x hx).sub (hg x hx)

--- a/Mathlib/Analysis/Calculus/FDeriv/Add.lean
+++ b/Mathlib/Analysis/Calculus/FDeriv/Add.lean
@@ -540,8 +540,7 @@ lemma DifferentiableAt.add_iff_left (hg : DifferentiableAt 𝕜 g x) :
 @[simp]
 lemma DifferentiableAt.add_iff_right (hg : DifferentiableAt 𝕜 f x) :
     DifferentiableAt 𝕜 (fun y => f y + g y) x ↔ DifferentiableAt 𝕜 g x := by
-  rw [show (fun y ↦ f y + g y) = (fun y ↦ g y + f y) by ext; rw [add_comm]]
-  exact hg.add_iff_left
+  simp only [add_comm (f _), hg.add_iff_left]
 
 @[fun_prop]
 theorem DifferentiableOn.sub (hf : DifferentiableOn 𝕜 f s) (hg : DifferentiableOn 𝕜 g s) :

--- a/Mathlib/Analysis/Calculus/FDeriv/Add.lean
+++ b/Mathlib/Analysis/Calculus/FDeriv/Add.lean
@@ -673,7 +673,7 @@ theorem DifferentiableAt.sub_const (hf : DifferentiableAt 𝕜 f x) (c : F) :
 @[deprecated DifferentiableAt.sub_iff_left (since := "2024-07-11")]
 theorem differentiableAt_sub_const_iff (c : F) :
     DifferentiableAt 𝕜 (fun y => f y - c) x ↔ DifferentiableAt 𝕜 f x :=
-  DifferentiableAt.sub_iff_left (differentiableAt_const _)
+  (differentiableAt_const _).sub_iff_left
 #align differentiable_at_sub_const_iff differentiableAt_sub_const_iff
 
 @[fun_prop]
@@ -684,7 +684,7 @@ theorem DifferentiableOn.sub_const (hf : DifferentiableOn 𝕜 f s) (c : F) :
 @[deprecated DifferentiableOn.sub_iff_left (since := "2024-07-11")]
 theorem differentiableOn_sub_const_iff (c : F) :
     DifferentiableOn 𝕜 (fun y => f y - c) s ↔ DifferentiableOn 𝕜 f s :=
-  DifferentiableOn.sub_iff_left (differentiableOn_const _)
+  (differentiableOn_const _).sub_iff_left
 #align differentiable_on_sub_const_iff differentiableOn_sub_const_iff
 
 @[fun_prop]
@@ -695,7 +695,7 @@ theorem Differentiable.sub_const (hf : Differentiable 𝕜 f) (c : F) :
 @[deprecated Differentiable.sub_iff_left (since := "2024-07-11")]
 theorem differentiable_sub_const_iff (c : F) :
     (Differentiable 𝕜 fun y => f y - c) ↔ Differentiable 𝕜 f :=
-  Differentiable.sub_iff_left (differentiable_const _)
+  (differentiable_const _).sub_iff_left
 #align differentiable_sub_const_iff differentiable_sub_const_iff
 
 theorem fderivWithin_sub_const (hxs : UniqueDiffWithinAt 𝕜 s x) (c : F) :
@@ -751,7 +751,7 @@ theorem DifferentiableAt.const_sub (hf : DifferentiableAt 𝕜 f x) (c : F) :
 @[deprecated DifferentiableAt.sub_iff_right (since := "2024-07-11")]
 theorem differentiableAt_const_sub_iff (c : F) :
     DifferentiableAt 𝕜 (fun y => c - f y) x ↔ DifferentiableAt 𝕜 f x :=
-  DifferentiableAt.sub_iff_right (differentiableAt_const _)
+  (differentiableAt_const _).sub_iff_right
 #align differentiable_at_const_sub_iff differentiableAt_const_sub_iff
 
 @[fun_prop]
@@ -762,7 +762,7 @@ theorem DifferentiableOn.const_sub (hf : DifferentiableOn 𝕜 f s) (c : F) :
 @[deprecated DifferentiableOn.sub_iff_right (since := "2024-07-11")]
 theorem differentiableOn_const_sub_iff (c : F) :
     DifferentiableOn 𝕜 (fun y => c - f y) s ↔ DifferentiableOn 𝕜 f s :=
-  DifferentiableOn.sub_iff_right (differentiableOn_const _)
+  (differentiableOn_const _).sub_iff_right
 #align differentiable_on_const_sub_iff differentiableOn_const_sub_iff
 
 @[fun_prop]
@@ -773,7 +773,7 @@ theorem Differentiable.const_sub (hf : Differentiable 𝕜 f) (c : F) :
 @[deprecated Differentiable.sub_iff_right (since := "2024-07-11")]
 theorem differentiable_const_sub_iff (c : F) :
     (Differentiable 𝕜 fun y => c - f y) ↔ Differentiable 𝕜 f :=
-  Differentiable.sub_iff_right (differentiable_const _)
+  (differentiable_const _).sub_iff_right
 #align differentiable_const_sub_iff differentiable_const_sub_iff
 
 theorem fderivWithin_const_sub (hxs : UniqueDiffWithinAt 𝕜 s x) (c : F) :

--- a/Mathlib/Analysis/Calculus/FDeriv/Add.lean
+++ b/Mathlib/Analysis/Calculus/FDeriv/Add.lean
@@ -545,14 +545,12 @@ lemma DifferentiableAt.add_iff_right (hg : DifferentiableAt 𝕜 f x) :
 @[simp]
 lemma DifferentiableAt.sub_iff_left (hg : DifferentiableAt 𝕜 g x) :
     DifferentiableAt 𝕜 (fun y => f y - g y) x ↔ DifferentiableAt 𝕜 f x := by
-  refine ⟨fun h ↦ ?_, fun hf ↦ hf.sub hg⟩
-  simpa only [sub_add_cancel] using h.add hg
+  simp only [sub_eq_add_neg, differentiableAt_neg_iff, hg, add_iff_left]
 
 @[simp]
 lemma DifferentiableAt.sub_iff_right (hg : DifferentiableAt 𝕜 f x) :
     DifferentiableAt 𝕜 (fun y => f y - g y) x ↔ DifferentiableAt 𝕜 g x := by
-  refine ⟨fun h ↦ ?_, fun hf ↦ hg.sub hf⟩
-  simpa only [sub_sub_cancel_left, differentiableAt_neg_iff] using h.sub hg
+  simp only [sub_eq_add_neg, hg, add_iff_right, differentiableAt_neg_iff]
 
 @[fun_prop]
 theorem DifferentiableOn.sub (hf : DifferentiableOn 𝕜 f s) (hg : DifferentiableOn 𝕜 g s) :
@@ -573,14 +571,12 @@ lemma DifferentiableOn.add_iff_right (hg : DifferentiableOn 𝕜 f s) :
 @[simp]
 lemma DifferentiableOn.sub_iff_left (hg : DifferentiableOn 𝕜 g s) :
     DifferentiableOn 𝕜 (fun y => f y - g y) s ↔ DifferentiableOn 𝕜 f s := by
-  refine ⟨fun h ↦ ?_, fun hf ↦ hf.sub hg⟩
-  simpa only [sub_add_cancel] using h.add hg
+  simp only [sub_eq_add_neg, differentiableOn_neg_iff, hg, add_iff_left]
 
 @[simp]
 lemma DifferentiableOn.sub_iff_right (hg : DifferentiableOn 𝕜 f s) :
     DifferentiableOn 𝕜 (fun y => f y - g y) s ↔ DifferentiableOn 𝕜 g s := by
-  refine ⟨fun h ↦ ?_, fun hf ↦ hg.sub hf⟩
-  simpa only [sub_sub_cancel_left, differentiableOn_neg_iff] using h.sub hg
+  simp only [sub_eq_add_neg, differentiableOn_neg_iff, hg, add_iff_right]
 
 @[simp, fun_prop]
 theorem Differentiable.sub (hf : Differentiable 𝕜 f) (hg : Differentiable 𝕜 g) :
@@ -601,14 +597,12 @@ lemma Differentiable.add_iff_right (hg : Differentiable 𝕜 f) :
 @[simp]
 lemma Differentiable.sub_iff_left (hg : Differentiable 𝕜 g) :
     Differentiable 𝕜 (fun y => f y - g y) ↔ Differentiable 𝕜 f := by
-  refine ⟨fun h ↦ ?_, fun hf ↦ hf.sub hg⟩
-  simpa only [sub_add_cancel] using h.add hg
+  simp only [sub_eq_add_neg, differentiable_neg_iff, hg, add_iff_left]
 
 @[simp]
 lemma Differentiable.sub_iff_right (hg : Differentiable 𝕜 f) :
     Differentiable 𝕜 (fun y => f y - g y) ↔ Differentiable 𝕜 g := by
-  refine ⟨fun h ↦ ?_, fun hf ↦ hg.sub hf⟩
-  simpa only [sub_sub_cancel_left, differentiable_neg_iff] using h.sub hg
+  simp only [sub_eq_add_neg, differentiable_neg_iff, hg, add_iff_right]
 
 theorem fderivWithin_sub (hxs : UniqueDiffWithinAt 𝕜 s x) (hf : DifferentiableWithinAt 𝕜 f s x)
     (hg : DifferentiableWithinAt 𝕜 g s x) :

--- a/Mathlib/Analysis/Calculus/FDeriv/Add.lean
+++ b/Mathlib/Analysis/Calculus/FDeriv/Add.lean
@@ -750,8 +750,8 @@ theorem DifferentiableAt.const_sub (hf : DifferentiableAt 𝕜 f x) (c : F) :
 
 @[deprecated DifferentiableAt.sub_iff_right]
 theorem differentiableAt_const_sub_iff (c : F) :
-    DifferentiableAt 𝕜 (fun y => c - f y) x ↔ DifferentiableAt 𝕜 f x := by simp only [differentiableAt_const,
-      DifferentiableAt.sub_iff_right]
+    DifferentiableAt 𝕜 (fun y => c - f y) x ↔ DifferentiableAt 𝕜 f x := by
+  simp only [differentiableAt_const, DifferentiableAt.sub_iff_right]
 #align differentiable_at_const_sub_iff differentiableAt_const_sub_iff
 
 @[fun_prop]

--- a/Mathlib/Analysis/Calculus/FDeriv/Add.lean
+++ b/Mathlib/Analysis/Calculus/FDeriv/Add.lean
@@ -670,10 +670,10 @@ theorem DifferentiableAt.sub_const (hf : DifferentiableAt 𝕜 f x) (c : F) :
   (hf.hasFDerivAt.sub_const c).differentiableAt
 #align differentiable_at.sub_const DifferentiableAt.sub_const
 
-@[deprecated DifferentiableAt.sub_iff_left]
+@[deprecated DifferentiableAt.sub_iff_left (since := "2024-07-11")]
 theorem differentiableAt_sub_const_iff (c : F) :
-    DifferentiableAt 𝕜 (fun y => f y - c) x ↔ DifferentiableAt 𝕜 f x := by
-  simp only [sub_eq_add_neg, differentiableAt_add_const_iff]
+    DifferentiableAt 𝕜 (fun y => f y - c) x ↔ DifferentiableAt 𝕜 f x :=
+  DifferentiableAt.sub_iff_left (differentiableAt_const _)
 #align differentiable_at_sub_const_iff differentiableAt_sub_const_iff
 
 @[fun_prop]
@@ -681,10 +681,10 @@ theorem DifferentiableOn.sub_const (hf : DifferentiableOn 𝕜 f s) (c : F) :
     DifferentiableOn 𝕜 (fun y => f y - c) s := fun x hx => (hf x hx).sub_const c
 #align differentiable_on.sub_const DifferentiableOn.sub_const
 
-@[deprecated DifferentiableOn.sub_iff_left]
+@[deprecated DifferentiableOn.sub_iff_left (since := "2024-07-11")]
 theorem differentiableOn_sub_const_iff (c : F) :
-    DifferentiableOn 𝕜 (fun y => f y - c) s ↔ DifferentiableOn 𝕜 f s := by
-  simp only [sub_eq_add_neg, differentiableOn_add_const_iff]
+    DifferentiableOn 𝕜 (fun y => f y - c) s ↔ DifferentiableOn 𝕜 f s :=
+  DifferentiableOn.sub_iff_left (differentiableOn_const _)
 #align differentiable_on_sub_const_iff differentiableOn_sub_const_iff
 
 @[fun_prop]
@@ -692,10 +692,10 @@ theorem Differentiable.sub_const (hf : Differentiable 𝕜 f) (c : F) :
     Differentiable 𝕜 fun y => f y - c := fun x => (hf x).sub_const c
 #align differentiable.sub_const Differentiable.sub_const
 
-@[deprecated Differentiable.sub_iff_left]
+@[deprecated Differentiable.sub_iff_left (since := "2024-07-11")]
 theorem differentiable_sub_const_iff (c : F) :
-    (Differentiable 𝕜 fun y => f y - c) ↔ Differentiable 𝕜 f := by
-  simp only [sub_eq_add_neg, differentiable_add_const_iff]
+    (Differentiable 𝕜 fun y => f y - c) ↔ Differentiable 𝕜 f :=
+  Differentiable.sub_iff_left (differentiable_const _)
 #align differentiable_sub_const_iff differentiable_sub_const_iff
 
 theorem fderivWithin_sub_const (hxs : UniqueDiffWithinAt 𝕜 s x) (c : F) :
@@ -748,10 +748,10 @@ theorem DifferentiableAt.const_sub (hf : DifferentiableAt 𝕜 f x) (c : F) :
   (hf.hasFDerivAt.const_sub c).differentiableAt
 #align differentiable_at.const_sub DifferentiableAt.const_sub
 
-@[deprecated DifferentiableAt.sub_iff_right]
+@[deprecated DifferentiableAt.sub_iff_right (since := "2024-07-11")]
 theorem differentiableAt_const_sub_iff (c : F) :
-    DifferentiableAt 𝕜 (fun y => c - f y) x ↔ DifferentiableAt 𝕜 f x := by
-  simp only [differentiableAt_const, DifferentiableAt.sub_iff_right]
+    DifferentiableAt 𝕜 (fun y => c - f y) x ↔ DifferentiableAt 𝕜 f x :=
+  DifferentiableAt.sub_iff_right (differentiableAt_const _)
 #align differentiable_at_const_sub_iff differentiableAt_const_sub_iff
 
 @[fun_prop]
@@ -759,10 +759,10 @@ theorem DifferentiableOn.const_sub (hf : DifferentiableOn 𝕜 f s) (c : F) :
     DifferentiableOn 𝕜 (fun y => c - f y) s := fun x hx => (hf x hx).const_sub c
 #align differentiable_on.const_sub DifferentiableOn.const_sub
 
-@[deprecated DifferentiableOn.sub_iff_right]
+@[deprecated DifferentiableOn.sub_iff_right (since := "2024-07-11")]
 theorem differentiableOn_const_sub_iff (c : F) :
-    DifferentiableOn 𝕜 (fun y => c - f y) s ↔ DifferentiableOn 𝕜 f s := by
-  simp only [differentiableOn_const, DifferentiableOn.sub_iff_right]
+    DifferentiableOn 𝕜 (fun y => c - f y) s ↔ DifferentiableOn 𝕜 f s :=
+  DifferentiableOn.sub_iff_right (differentiableOn_const _)
 #align differentiable_on_const_sub_iff differentiableOn_const_sub_iff
 
 @[fun_prop]
@@ -770,9 +770,10 @@ theorem Differentiable.const_sub (hf : Differentiable 𝕜 f) (c : F) :
     Differentiable 𝕜 fun y => c - f y := fun x => (hf x).const_sub c
 #align differentiable.const_sub Differentiable.const_sub
 
-@[deprecated Differentiable.sub_iff_right]
+@[deprecated Differentiable.sub_iff_right (since := "2024-07-11")]
 theorem differentiable_const_sub_iff (c : F) :
-    (Differentiable 𝕜 fun y => c - f y) ↔ Differentiable 𝕜 f := by simp
+    (Differentiable 𝕜 fun y => c - f y) ↔ Differentiable 𝕜 f :=
+  Differentiable.sub_iff_right (differentiable_const _)
 #align differentiable_const_sub_iff differentiable_const_sub_iff
 
 theorem fderivWithin_const_sub (hxs : UniqueDiffWithinAt 𝕜 s x) (c : F) :

--- a/Mathlib/Analysis/Calculus/FDeriv/Add.lean
+++ b/Mathlib/Analysis/Calculus/FDeriv/Add.lean
@@ -535,12 +535,24 @@ theorem DifferentiableAt.sub (hf : DifferentiableAt 𝕜 f x) (hg : Differentiab
 lemma DifferentiableAt.add_iff_left (hg : DifferentiableAt 𝕜 g x) :
     DifferentiableAt 𝕜 (fun y => f y + g y) x ↔ DifferentiableAt 𝕜 f x := by
   refine ⟨fun h ↦ ?_, fun hf ↦ hf.add hg⟩
-  simpa using h.sub hg
+  simpa only [add_sub_cancel_right] using h.sub hg
 
 @[simp]
 lemma DifferentiableAt.add_iff_right (hg : DifferentiableAt 𝕜 f x) :
     DifferentiableAt 𝕜 (fun y => f y + g y) x ↔ DifferentiableAt 𝕜 g x := by
   simp only [add_comm (f _), hg.add_iff_left]
+
+@[simp]
+lemma DifferentiableAt.sub_iff_left (hg : DifferentiableAt 𝕜 g x) :
+    DifferentiableAt 𝕜 (fun y => f y - g y) x ↔ DifferentiableAt 𝕜 f x := by
+  refine ⟨fun h ↦ ?_, fun hf ↦ hf.sub hg⟩
+  simpa only [sub_add_cancel] using h.add hg
+
+@[simp]
+lemma DifferentiableAt.sub_iff_right (hg : DifferentiableAt 𝕜 f x) :
+    DifferentiableAt 𝕜 (fun y => f y - g y) x ↔ DifferentiableAt 𝕜 g x := by
+  refine ⟨fun h ↦ ?_, fun hf ↦ hg.sub hf⟩
+  simpa only [sub_sub_cancel_left, differentiableAt_neg_iff] using h.sub hg
 
 @[fun_prop]
 theorem DifferentiableOn.sub (hf : DifferentiableOn 𝕜 f s) (hg : DifferentiableOn 𝕜 g s) :

--- a/Mathlib/Analysis/Calculus/FDeriv/Add.lean
+++ b/Mathlib/Analysis/Calculus/FDeriv/Add.lean
@@ -582,11 +582,33 @@ lemma DifferentiableOn.sub_iff_right (hg : DifferentiableOn 𝕜 f s) :
   refine ⟨fun h ↦ ?_, fun hf ↦ hg.sub hf⟩
   simpa only [sub_sub_cancel_left, differentiableOn_neg_iff] using h.sub hg
 
-
 @[simp, fun_prop]
 theorem Differentiable.sub (hf : Differentiable 𝕜 f) (hg : Differentiable 𝕜 g) :
     Differentiable 𝕜 fun y => f y - g y := fun x => (hf x).sub (hg x)
 #align differentiable.sub Differentiable.sub
+
+@[simp]
+lemma Differentiable.add_iff_left (hg : Differentiable 𝕜 g) :
+    Differentiable 𝕜 (fun y => f y + g y) ↔ Differentiable 𝕜 f := by
+  refine ⟨fun h ↦ ?_, fun hf ↦ hf.add hg⟩
+  simpa only [add_sub_cancel_right] using h.sub hg
+
+@[simp]
+lemma Differentiable.add_iff_right (hg : Differentiable 𝕜 f) :
+    Differentiable 𝕜 (fun y => f y + g y) ↔ Differentiable 𝕜 g := by
+  simp only [add_comm (f _), hg.add_iff_left]
+
+@[simp]
+lemma Differentiable.sub_iff_left (hg : Differentiable 𝕜 g) :
+    Differentiable 𝕜 (fun y => f y - g y) ↔ Differentiable 𝕜 f := by
+  refine ⟨fun h ↦ ?_, fun hf ↦ hf.sub hg⟩
+  simpa only [sub_add_cancel] using h.add hg
+
+@[simp]
+lemma Differentiable.sub_iff_right (hg : Differentiable 𝕜 f) :
+    Differentiable 𝕜 (fun y => f y - g y) ↔ Differentiable 𝕜 g := by
+  refine ⟨fun h ↦ ?_, fun hf ↦ hg.sub hf⟩
+  simpa only [sub_sub_cancel_left, differentiable_neg_iff] using h.sub hg
 
 theorem fderivWithin_sub (hxs : UniqueDiffWithinAt 𝕜 s x) (hf : DifferentiableWithinAt 𝕜 f s x)
     (hg : DifferentiableWithinAt 𝕜 g s x) :

--- a/Mathlib/Analysis/Calculus/FDeriv/Add.lean
+++ b/Mathlib/Analysis/Calculus/FDeriv/Add.lean
@@ -670,7 +670,7 @@ theorem DifferentiableAt.sub_const (hf : DifferentiableAt 𝕜 f x) (c : F) :
   (hf.hasFDerivAt.sub_const c).differentiableAt
 #align differentiable_at.sub_const DifferentiableAt.sub_const
 
-@[simp]
+@[deprecated DifferentiableAt.sub_iff_left]
 theorem differentiableAt_sub_const_iff (c : F) :
     DifferentiableAt 𝕜 (fun y => f y - c) x ↔ DifferentiableAt 𝕜 f x := by
   simp only [sub_eq_add_neg, differentiableAt_add_const_iff]
@@ -681,7 +681,7 @@ theorem DifferentiableOn.sub_const (hf : DifferentiableOn 𝕜 f s) (c : F) :
     DifferentiableOn 𝕜 (fun y => f y - c) s := fun x hx => (hf x hx).sub_const c
 #align differentiable_on.sub_const DifferentiableOn.sub_const
 
-@[simp]
+@[deprecated DifferentiableOn.sub_iff_left]
 theorem differentiableOn_sub_const_iff (c : F) :
     DifferentiableOn 𝕜 (fun y => f y - c) s ↔ DifferentiableOn 𝕜 f s := by
   simp only [sub_eq_add_neg, differentiableOn_add_const_iff]
@@ -692,7 +692,7 @@ theorem Differentiable.sub_const (hf : Differentiable 𝕜 f) (c : F) :
     Differentiable 𝕜 fun y => f y - c := fun x => (hf x).sub_const c
 #align differentiable.sub_const Differentiable.sub_const
 
-@[simp]
+@[deprecated Differentiable.sub_iff_left]
 theorem differentiable_sub_const_iff (c : F) :
     (Differentiable 𝕜 fun y => f y - c) ↔ Differentiable 𝕜 f := by
   simp only [sub_eq_add_neg, differentiable_add_const_iff]
@@ -748,9 +748,10 @@ theorem DifferentiableAt.const_sub (hf : DifferentiableAt 𝕜 f x) (c : F) :
   (hf.hasFDerivAt.const_sub c).differentiableAt
 #align differentiable_at.const_sub DifferentiableAt.const_sub
 
-@[simp]
+@[deprecated DifferentiableAt.sub_iff_right]
 theorem differentiableAt_const_sub_iff (c : F) :
-    DifferentiableAt 𝕜 (fun y => c - f y) x ↔ DifferentiableAt 𝕜 f x := by simp [sub_eq_add_neg]
+    DifferentiableAt 𝕜 (fun y => c - f y) x ↔ DifferentiableAt 𝕜 f x := by simp only [differentiableAt_const,
+      DifferentiableAt.sub_iff_right]
 #align differentiable_at_const_sub_iff differentiableAt_const_sub_iff
 
 @[fun_prop]
@@ -758,9 +759,10 @@ theorem DifferentiableOn.const_sub (hf : DifferentiableOn 𝕜 f s) (c : F) :
     DifferentiableOn 𝕜 (fun y => c - f y) s := fun x hx => (hf x hx).const_sub c
 #align differentiable_on.const_sub DifferentiableOn.const_sub
 
-@[simp]
+@[deprecated DifferentiableOn.sub_iff_right]
 theorem differentiableOn_const_sub_iff (c : F) :
-    DifferentiableOn 𝕜 (fun y => c - f y) s ↔ DifferentiableOn 𝕜 f s := by simp [sub_eq_add_neg]
+    DifferentiableOn 𝕜 (fun y => c - f y) s ↔ DifferentiableOn 𝕜 f s := by
+  simp only [differentiableOn_const, DifferentiableOn.sub_iff_right]
 #align differentiable_on_const_sub_iff differentiableOn_const_sub_iff
 
 @[fun_prop]
@@ -768,9 +770,9 @@ theorem Differentiable.const_sub (hf : Differentiable 𝕜 f) (c : F) :
     Differentiable 𝕜 fun y => c - f y := fun x => (hf x).const_sub c
 #align differentiable.const_sub Differentiable.const_sub
 
-@[simp]
+@[deprecated Differentiable.sub_iff_right]
 theorem differentiable_const_sub_iff (c : F) :
-    (Differentiable 𝕜 fun y => c - f y) ↔ Differentiable 𝕜 f := by simp [sub_eq_add_neg]
+    (Differentiable 𝕜 fun y => c - f y) ↔ Differentiable 𝕜 f := by simp
 #align differentiable_const_sub_iff differentiable_const_sub_iff
 
 theorem fderivWithin_const_sub (hxs : UniqueDiffWithinAt 𝕜 s x) (c : F) :

--- a/Mathlib/Analysis/Calculus/FDeriv/Basic.lean
+++ b/Mathlib/Analysis/Calculus/FDeriv/Basic.lean
@@ -1200,7 +1200,7 @@ theorem differentiable_const (c : F) : Differentiable 𝕜 fun _ : E => c := fun
   differentiableAt_const _
 #align differentiable_const differentiable_const
 
-@[fun_prop]
+@[simp, fun_prop]
 theorem differentiableOn_const (c : F) : DifferentiableOn 𝕜 (fun _ => c) s :=
   (differentiable_const _).differentiableOn
 #align differentiable_on_const differentiableOn_const

--- a/Mathlib/Analysis/SpecialFunctions/Trigonometric/InverseDeriv.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Trigonometric/InverseDeriv.lean
@@ -169,7 +169,7 @@ theorem differentiableWithinAt_arccos_Iic {x : ℝ} :
 #align real.differentiable_within_at_arccos_Iic Real.differentiableWithinAt_arccos_Iic
 
 theorem differentiableAt_arccos {x : ℝ} : DifferentiableAt ℝ arccos x ↔ x ≠ -1 ∧ x ≠ 1 :=
-  (differentiableAt_const_sub_iff _).trans differentiableAt_arcsin
+  (DifferentiableAt.sub_iff_right (differentiableAt_const _)).trans differentiableAt_arcsin
 #align real.differentiable_at_arccos Real.differentiableAt_arccos
 
 @[simp]

--- a/Mathlib/Analysis/SpecialFunctions/Trigonometric/InverseDeriv.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Trigonometric/InverseDeriv.lean
@@ -169,7 +169,7 @@ theorem differentiableWithinAt_arccos_Iic {x : ℝ} :
 #align real.differentiable_within_at_arccos_Iic Real.differentiableWithinAt_arccos_Iic
 
 theorem differentiableAt_arccos {x : ℝ} : DifferentiableAt ℝ arccos x ↔ x ≠ -1 ∧ x ≠ 1 :=
-  (DifferentiableAt.sub_iff_right (differentiableAt_const _)).trans differentiableAt_arcsin
+  (differentiableAt_const _).sub_iff_right.trans differentiableAt_arcsin
 #align real.differentiable_at_arccos Real.differentiableAt_arccos
 
 @[simp]


### PR DESCRIPTION
Given a function differentiable at a point, the result of adding a second function is differentiable (there) iff the second function is differentiable (there).

---
The part that's new is: at a point, the sum of a differentiable and a non-differentiable function is non-differentiable.
The other direction of the `iff` is already covered by `DifferentiableAt.add`.

Lemmas are marked `@[simp]` because other `iff` lemmas in that file are marked as such.

Needed for #9734 

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks, and is labeled with `awaiting-review`.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
