### PR TITLE
[Merged by Bors] - docs(README): Rename "Emeritus maintainers" to "Past maintainers"

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ For a list containing more detailed information, see https://leanprover-communit
 * Adam Topaz (@adamtopaz): algebra, category theory, algebraic geometry
 * Eric Wieser (@eric-wieser): algebra, infrastructure
 
-## Emeritus maintainers:
+## Past maintainers:
 
 * Jeremy Avigad (@avigad): analysis
 * Johannes Hölzl (@johoelzl): measure theory, topology

--- a/README.md
+++ b/README.md
@@ -154,3 +154,4 @@ For a list containing more detailed information, see https://leanprover-communit
 * Jeremy Avigad (@avigad): analysis
 * Johannes Hölzl (@johoelzl): measure theory, topology
 * Simon Hudon (@cipher1024): tactics
+* Chris Hughes (@ChrisHughes24): algebra


### PR DESCRIPTION
As discussed at the maintainers meeting. This more accurately reflects their position, in that they are not expected to remain involved in maintainer discussions.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks, and is labeled with `awaiting-review`.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
