### PR TITLE
[Merged by Bors] - feat(`Data/Fintype/Order`): Slightly strengthen `Fin.completeLinearOrder`.

### DIFF
--- a/Mathlib/Data/Fintype/Order.lean
+++ b/Mathlib/Data/Fintype/Order.lean
@@ -162,8 +162,7 @@ end Fintype
 
 /-! ### Concrete instances -/
 
-
-noncomputable instance Fin.completeLinearOrder {n : ℕ} : CompleteLinearOrder (Fin (n + 1)) :=
+noncomputable instance Fin.completeLinearOrder {n : ℕ} [NeZero n] : CompleteLinearOrder (Fin n) :=
   Fintype.toCompleteLinearOrder _
 
 noncomputable instance Bool.completeLinearOrder : CompleteLinearOrder Bool :=


### PR DESCRIPTION
Adds a `CompleteLinearOrder` instance for `[NeZero n] Fin n`.

---

Recently an instance of BoundedOrder was added for `[NeZero n] Fin n`, rather than just `Fin (n + 1)`. This adds the corresponding instance of `CompleteLinearOrder`.

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks, and is labeled with `awaiting-review`.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
