### PR TITLE
[Merged by Bors] - fix: add `assumption` to autoparam `isBoundedDefault`

### DIFF
--- a/Mathlib/Order/LiminfLimsup.lean
+++ b/Mathlib/Order/LiminfLimsup.lean
@@ -412,7 +412,8 @@ macro "isBoundedDefault" : tactic =>
     | apply isCobounded_le_of_bot
     | apply isCobounded_ge_of_top
     | apply isBounded_le_of_top
-    | apply isBounded_ge_of_bot)
+    | apply isBounded_ge_of_bot
+    | assumption)
 
 -- Porting note: The above is a lean 4 reconstruction of (note that applyc is not available (yet?)):
 -- unsafe def is_bounded_default : tactic Unit :=

--- a/test/IsBoundedDefault.lean
+++ b/test/IsBoundedDefault.lean
@@ -1,0 +1,14 @@
+import Mathlib.Data.Real.EReal
+import Mathlib.Order.LiminfLimsup
+
+open Filter
+
+variable {α : Type*} {f : Filter α} {u v : α → EReal} (h : u ≤ᶠ[f] v)
+-- proof term
+example : limsup u f ≤ limsup v f := limsup_le_limsup h
+
+-- exact
+example : limsup u f ≤ limsup v f := by exact limsup_le_limsup h
+
+-- apply
+example : limsup u f ≤ limsup v f := by apply limsup_le_limsup h


### PR DESCRIPTION
Maybe, `applyc` in lean3 also tried `assumption`, so I added it here!

[Zulip thread](https://leanprover.zulipchat.com/#narrow/stream/239415-metaprogramming-.2F-tactics/topic/isBoundedDefault.20not.20triggering)

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks, and is labeled with `awaiting-review`.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
