### PR TITLE
chore: Merge `Trunc` to `Squash`

### DIFF
--- a/Mathlib/CategoryTheory/EpiMono.lean
+++ b/Mathlib/CategoryTheory/EpiMono.lean
@@ -203,15 +203,15 @@ theorem IsIso.of_epi_section {X Y : C} (f : X ⟶ Y) [hf : IsSplitEpi f] [hf' : 
 #align category_theory.is_iso.of_epi_section CategoryTheory.IsIso.of_epi_section
 
 -- FIXME this has unnecessarily become noncomputable!
-/-- A category where every morphism has a `Trunc` retraction is computably a groupoid. -/
-noncomputable def Groupoid.ofTruncSplitMono
-    (all_split_mono : ∀ {X Y : C} (f : X ⟶ Y), Trunc (IsSplitMono f)) : Groupoid.{v₁} C := by
+/-- A category where every morphism has a `Squash` retraction is computably a groupoid. -/
+noncomputable def Groupoid.ofSquashSplitMono
+    (all_split_mono : ∀ {X Y : C} (f : X ⟶ Y), Squash (IsSplitMono f)) : Groupoid.{v₁} C := by
   apply Groupoid.ofIsIso
   intro X Y f
-  have ⟨a,_⟩ := Trunc.exists_rep <| all_split_mono f
-  have ⟨b,_⟩ := Trunc.exists_rep <| all_split_mono <| retraction f
+  have ⟨a,_⟩ := Squash.exists_rep <| all_split_mono f
+  have ⟨b,_⟩ := Squash.exists_rep <| all_split_mono <| retraction f
   apply IsIso.of_mono_retraction
-#align category_theory.groupoid.of_trunc_split_mono CategoryTheory.Groupoid.ofTruncSplitMono
+#align category_theory.groupoid.of_trunc_split_mono CategoryTheory.Groupoid.ofSquashSplitMono
 
 section
 

--- a/Mathlib/CategoryTheory/Preadditive/Biproducts.lean
+++ b/Mathlib/CategoryTheory/Preadditive/Biproducts.lean
@@ -880,7 +880,7 @@ then there is some `t` in the target so that the `s, t` matrix entry of `f` is n
 -/
 def Biproduct.columnNonzeroOfIso {σ τ : Type} [Fintype τ] {S : σ → C} [HasBiproduct S] {T : τ → C}
     [HasBiproduct T] (s : σ) (nz : 𝟙 (S s) ≠ 0) (f : ⨁ S ⟶ ⨁ T) [IsIso f] :
-    Trunc (Σ't : τ, biproduct.ι S s ≫ f ≫ biproduct.π T t ≠ 0) := by
+    Squash (Σ't : τ, biproduct.ι S s ≫ f ≫ biproduct.π T t ≠ 0) := by
   classical
     apply truncSigmaOfExists
     have t := Biproduct.column_nonzero_of_iso'.{v} s f

--- a/Mathlib/Data/DFinsupp/Basic.lean
+++ b/Mathlib/Data/DFinsupp/Basic.lean
@@ -62,7 +62,7 @@ structure DFinsupp [∀ i, Zero (β i)] : Type max u v where mk' ::
   /-- The underlying function of a dependent function with finite support (aka `DFinsupp`). -/
   toFun : ∀ i, β i
   /-- The support of a dependent function with finite support (aka `DFinsupp`). -/
-  support' : Trunc { s : Multiset ι // ∀ i, i ∈ s ∨ toFun i = 0 }
+  support' : Squash { s : Multiset ι // ∀ i, i ∈ s ∨ toFun i = 0 }
 #align dfinsupp DFinsupp
 
 variable {β}

--- a/Mathlib/Data/DFinsupp/Basic.lean
+++ b/Mathlib/Data/DFinsupp/Basic.lean
@@ -104,7 +104,7 @@ theorem ext {f g : Π₀ i, β i} (h : ∀ i, f i = g i) : f = g :=
 lemma ne_iff {f g : Π₀ i, β i} : f ≠ g ↔ ∃ i, f i ≠ g i := DFunLike.ne_iff
 
 instance : Zero (Π₀ i, β i) :=
-  ⟨⟨0, Trunc.mk <| ⟨∅, fun _ => Or.inr rfl⟩⟩⟩
+  ⟨⟨0, Squash.mk <| ⟨∅, fun _ => Or.inr rfl⟩⟩⟩
 
 instance : Inhabited (Π₀ i, β i) :=
   ⟨0⟩
@@ -551,7 +551,7 @@ section Basic
 variable [∀ i, Zero (β i)]
 
 theorem finite_support (f : Π₀ i, β i) : Set.Finite { i | f i ≠ 0 } :=
-  Trunc.induction_on f.support' fun xs ↦
+  Squash.induction_on f.support' fun xs ↦
     xs.1.finite_toSet.subset fun i H ↦ ((xs.prop i).resolve_right H)
 #align dfinsupp.finite_support DFinsupp.finite_support
 
@@ -559,7 +559,7 @@ theorem finite_support (f : Π₀ i, β i) : Set.Finite { i | f i ≠ 0 } :=
 defined on this `Finset`. -/
 def mk (s : Finset ι) (x : ∀ i : (↑s : Set ι), β (i : ι)) : Π₀ i, β i :=
   ⟨fun i => if H : i ∈ s then x ⟨i, H⟩ else 0,
-    Trunc.mk ⟨s.1, fun i => if H : i ∈ s then Or.inl H else Or.inr <| dif_neg H⟩⟩
+    Squash.mk ⟨s.1, fun i => if H : i ∈ s then Or.inl H else Or.inr <| dif_neg H⟩⟩
 #align dfinsupp.mk DFinsupp.mk
 
 variable {s : Finset ι} {x : ∀ i : (↑s : Set ι), β i} {i : ι}
@@ -599,7 +599,7 @@ instance uniqueOfIsEmpty [IsEmpty ι] : Unique (Π₀ i, β i) :=
 @[simps apply]
 def equivFunOnFintype [Fintype ι] : (Π₀ i, β i) ≃ ∀ i, β i where
   toFun := (⇑)
-  invFun f := ⟨f, Trunc.mk ⟨Finset.univ.1, fun _ => Or.inl <| Finset.mem_univ_val _⟩⟩
+  invFun f := ⟨f, Squash.mk ⟨Finset.univ.1, fun _ => Or.inl <| Finset.mem_univ_val _⟩⟩
   left_inv _ := DFunLike.coe_injective rfl
   right_inv _ := rfl
 #align dfinsupp.equiv_fun_on_fintype DFinsupp.equivFunOnFintype
@@ -614,7 +614,7 @@ theorem equivFunOnFintype_symm_coe [Fintype ι] (f : Π₀ i, β i) : equivFunOn
 and all other points to `0`. -/
 def single (i : ι) (b : β i) : Π₀ i, β i :=
   ⟨Pi.single i b,
-    Trunc.mk ⟨{i}, fun j => (Decidable.eq_or_ne j i).imp (by simp) fun h => Pi.single_eq_of_ne h _⟩⟩
+    Squash.mk ⟨{i}, fun j => (Decidable.eq_or_ne j i).imp (by simp) fun h => Pi.single_eq_of_ne h _⟩⟩
 #align dfinsupp.single DFinsupp.single
 
 theorem single_eq_pi_single {i b} : ⇑(single i b : Π₀ i, β i) = Pi.single i b :=
@@ -947,14 +947,14 @@ theorem erase_add_single (i : ι) (f : Π₀ i, β i) : f.erase i + single i (f 
 protected theorem induction {p : (Π₀ i, β i) → Prop} (f : Π₀ i, β i) (h0 : p 0)
     (ha : ∀ (i b) (f : Π₀ i, β i), f i = 0 → b ≠ 0 → p f → p (single i b + f)) : p f := by
   cases' f with f s
-  induction' s using Trunc.induction_on with s
+  induction' s using Squash.induction_on with s
   cases' s with s H
   induction' s using Multiset.induction_on with i s ih generalizing f
   · have : f = 0 := funext fun i => (H i).resolve_left (Multiset.not_mem_zero _)
     subst this
     exact h0
-  have H2 : p (erase i ⟨f, Trunc.mk ⟨i ::ₘ s, H⟩⟩) := by
-    dsimp only [erase, Trunc.map, Trunc.bind, Trunc.liftOn, Trunc.lift_mk,
+  have H2 : p (erase i ⟨f, Squash.mk ⟨i ::ₘ s, H⟩⟩) := by
+    dsimp only [erase, Squash.map, Squash.bind, Squash.lift'On, Squash.lift'_mk,
       Function.comp, Subtype.coe_mk]
     have H2 : ∀ j, j ∈ s ∨ ite (j = i) 0 (f j) = 0 := by
       intro j
@@ -964,12 +964,12 @@ protected theorem induction {p : (Π₀ i, β i) → Prop} (f : Π₀ i, β i) (
         · left; exact H3
       right
       split_ifs <;> [rfl; exact H2]
-    have H3 : ∀ aux, (⟨fun j : ι => ite (j = i) 0 (f j), Trunc.mk ⟨i ::ₘ s, aux⟩⟩ : Π₀ i, β i) =
-        ⟨fun j : ι => ite (j = i) 0 (f j), Trunc.mk ⟨s, H2⟩⟩ :=
+    have H3 : ∀ aux, (⟨fun j : ι => ite (j = i) 0 (f j), Squash.mk ⟨i ::ₘ s, aux⟩⟩ : Π₀ i, β i) =
+        ⟨fun j : ι => ite (j = i) 0 (f j), Squash.mk ⟨s, H2⟩⟩ :=
       fun _ ↦ ext fun _ => rfl
     rw [H3]
     apply ih
-  have H3 : single i _ + _ = (⟨f, Trunc.mk ⟨i ::ₘ s, H⟩⟩ : Π₀ i, β i) := single_add_erase _ _
+  have H3 : single i _ + _ = (⟨f, Squash.mk ⟨i ::ₘ s, H⟩⟩ : Π₀ i, β i) := single_add_erase _ _
   rw [← H3]
   change p (single i (f i) + _)
   cases' Classical.em (f i = 0) with h h
@@ -1082,7 +1082,7 @@ variable [∀ i, Zero (β i)] [∀ (i) (x : β i), Decidable (x ≠ 0)]
 
 /-- Set `{i | f x ≠ 0}` as a `Finset`. -/
 def support (f : Π₀ i, β i) : Finset ι :=
-  (f.support'.lift fun xs => (Multiset.toFinset xs.1).filter fun i => f i ≠ 0) <| by
+  (f.support'.lift' fun xs => (Multiset.toFinset xs.1).filter fun i => f i ≠ 0) <| by
     rintro ⟨sx, hx⟩ ⟨sy, hy⟩
     dsimp only [Subtype.coe_mk, toFun_eq_coe] at *
     ext i; constructor
@@ -1101,15 +1101,15 @@ theorem support_mk_subset {s : Finset ι} {x : ∀ i : (↑s : Set ι), β i.1} 
 
 @[simp]
 theorem support_mk'_subset {f : ∀ i, β i} {s : Multiset ι} {h} :
-    (mk' f <| Trunc.mk ⟨s, h⟩).support ⊆ s.toFinset := fun i H =>
+    (mk' f <| Squash.mk ⟨s, h⟩).support ⊆ s.toFinset := fun i H =>
   Multiset.mem_toFinset.1 <| by simpa using (Finset.mem_filter.1 H).1
 #align dfinsupp.support_mk'_subset DFinsupp.support_mk'_subset
 
 @[simp]
 theorem mem_support_toFun (f : Π₀ i, β i) (i) : i ∈ f.support ↔ f i ≠ 0 := by
   cases' f with f s
-  induction' s using Trunc.induction_on with s
-  dsimp only [support, Trunc.lift_mk]
+  induction' s using Squash.induction_on with s
+  dsimp only [support, Squash.lift'_mk]
   rw [Finset.mem_filter, Multiset.mem_toFinset, coe_mk']
   exact and_iff_right_of_imp (s.prop i).resolve_right
 #align dfinsupp.mem_support_to_fun DFinsupp.mem_support_toFun
@@ -1874,7 +1874,7 @@ also an `AddMonoidHom`.
 def sumAddHom [∀ i, AddZeroClass (β i)] [AddCommMonoid γ] (φ : ∀ i, β i →+ γ) :
     (Π₀ i, β i) →+ γ where
   toFun f :=
-    (f.support'.lift fun s => ∑ i ∈ Multiset.toFinset s.1, φ i (f i)) <| by
+    (f.support'.lift' fun s => ∑ i ∈ Multiset.toFinset s.1, φ i (f i)) <| by
       rintro ⟨sx, hx⟩ ⟨sy, hy⟩
       dsimp only [Subtype.coe_mk, toFun_eq_coe] at *
       have H1 : sx.toFinset ∩ sy.toFinset ⊆ sx.toFinset := Finset.inter_subset_left
@@ -1920,7 +1920,7 @@ def sumAddHom [∀ i, AddZeroClass (β i)] [AddCommMonoid γ] (φ : ∀ i, β i 
 @[simp]
 theorem sumAddHom_single [∀ i, AddZeroClass (β i)] [AddCommMonoid γ] (φ : ∀ i, β i →+ γ) (i)
     (x : β i) : sumAddHom φ (single i x) = φ i x := by
-  dsimp [sumAddHom, single, Trunc.lift_mk]
+  dsimp [sumAddHom, single, Squash.lift'_mk]
   rw [Multiset.toFinset_singleton, Finset.sum_singleton, Pi.single_eq_same]
 #align dfinsupp.sum_add_hom_single DFinsupp.sumAddHom_single
 
@@ -2013,7 +2013,7 @@ theorem sumAddHom_comm {ι₁ ι₂ : Sort _} {β₁ : ι₁ → Type*} {β₂ :
       sumAddHom (fun i₁ => sumAddHom (fun i₂ => (h i₁ i₂).flip) f₂) f₁ := by
   obtain ⟨⟨f₁, s₁, h₁⟩, ⟨f₂, s₂, h₂⟩⟩ := f₁, f₂
   simp only [sumAddHom, AddMonoidHom.finset_sum_apply, Quotient.liftOn_mk, AddMonoidHom.coe_mk,
-    AddMonoidHom.flip_apply, Trunc.lift, toFun_eq_coe, ZeroHom.coe_mk, coe_mk']
+    AddMonoidHom.flip_apply, Squash.lift', toFun_eq_coe, ZeroHom.coe_mk, coe_mk']
   exact Finset.sum_comm
 #align dfinsupp.sum_add_hom_comm DFinsupp.sumAddHom_comm
 

--- a/Mathlib/Data/Fintype/Basic.lean
+++ b/Mathlib/Data/Fintype/Basic.lean
@@ -1185,32 +1185,32 @@ end BijectionInverse
 
 end Fintype
 
-section Trunc
+section Squash
 
-/-- For `s : Multiset α`, we can lift the existential statement that `∃ x, x ∈ s` to a `Trunc α`.
+/-- For `s : Multiset α`, we can lift the existential statement that `∃ x, x ∈ s` to a `Squash α`.
 -/
-def truncOfMultisetExistsMem {α} (s : Multiset α) : (∃ x, x ∈ s) → Trunc α :=
+def squashOfMultisetExistsMem {α} (s : Multiset α) : (∃ x, x ∈ s) → Squash α :=
   Quotient.recOnSubsingleton s fun l h =>
     match l, h with
     | [], _ => False.elim (by tauto)
-    | a :: _, _ => Trunc.mk a
-#align trunc_of_multiset_exists_mem truncOfMultisetExistsMem
+    | a :: _, _ => Squash.mk a
+#align trunc_of_multiset_exists_mem squashOfMultisetExistsMem
 
 /-- A `Nonempty` `Fintype` constructively contains an element.
 -/
-def truncOfNonemptyFintype (α) [Nonempty α] [Fintype α] : Trunc α :=
-  truncOfMultisetExistsMem Finset.univ.val (by simp)
-#align trunc_of_nonempty_fintype truncOfNonemptyFintype
+def squashOfNonemptyFintype (α) [Nonempty α] [Fintype α] : Squash α :=
+  squashOfMultisetExistsMem Finset.univ.val (by simp)
+#align trunc_of_nonempty_fintype squashOfNonemptyFintype
 
 /-- By iterating over the elements of a fintype, we can lift an existential statement `∃ a, P a`
-to `Trunc (Σ' a, P a)`, containing data.
+to `Squash (Σ' a, P a)`, containing data.
 -/
-def truncSigmaOfExists {α} [Fintype α] {P : α → Prop} [DecidablePred P] (h : ∃ a, P a) :
-    Trunc (Σ'a, P a) :=
-  @truncOfNonemptyFintype (Σ'a, P a) ((Exists.elim h) fun a ha => ⟨⟨a, ha⟩⟩) _
-#align trunc_sigma_of_exists truncSigmaOfExists
+def squashSigmaOfExists {α} [Fintype α] {P : α → Prop} [DecidablePred P] (h : ∃ a, P a) :
+    Squash (Σ'a, P a) :=
+  @squashOfNonemptyFintype (Σ'a, P a) ((Exists.elim h) fun a ha => ⟨⟨a, ha⟩⟩) _
+#align trunc_sigma_of_exists squashSigmaOfExists
 
-end Trunc
+end Squash
 
 namespace Multiset
 

--- a/Mathlib/Data/Fintype/Card.lean
+++ b/Mathlib/Data/Fintype/Card.lean
@@ -95,7 +95,7 @@ for an equiv `α ≃ Fin n` given `Fintype.card α = n`.
 -/
 noncomputable def equivFin (α) [Fintype α] : α ≃ Fin (card α) :=
   letI := Classical.decEq α
-  (truncEquivFin α).out
+  (squashEquivFin α).out
 #align fintype.equiv_fin Fintype.equivFin
 
 /-- There is (computably) a bijection between `Fin (card α)` and `α`.
@@ -206,7 +206,7 @@ end
 theorem card_eq {α β} [_F : Fintype α] [_G : Fintype β] : card α = card β ↔ Nonempty (α ≃ β) :=
   ⟨fun h =>
     haveI := Classical.propDecidable
-    (truncEquivOfCardEq h).nonempty,
+    (squashEquivOfCardEq h).nonempty,
     fun ⟨f⟩ => card_congr f⟩
 #align fintype.card_eq Fintype.card_eq
 
@@ -835,7 +835,7 @@ def squashOfCardLE [Fintype α] [Fintype β] [DecidableEq α] [DecidableEq β]
 #align function.embedding.trunc_of_card_le Function.Embedding.squashOfCardLE
 
 theorem nonempty_of_card_le [Fintype α] [Fintype β] (h : Fintype.card α ≤ Fintype.card β) :
-    Nonempty (α ↪ β) := by classical exact (truncOfCardLE h).nonempty
+    Nonempty (α ↪ β) := by classical exact (squashOfCardLE h).nonempty
 #align function.embedding.nonempty_of_card_le Function.Embedding.nonempty_of_card_le
 
 theorem nonempty_iff_card_le [Fintype α] [Fintype β] :

--- a/Mathlib/Data/Fintype/Card.lean
+++ b/Mathlib/Data/Fintype/Card.lean
@@ -67,30 +67,30 @@ def card (α) [Fintype α] : ℕ :=
 /-- There is (computably) an equivalence between `α` and `Fin (card α)`.
 
 Since it is not unique and depends on which permutation
-of the universe list is used, the equivalence is wrapped in `Trunc` to
+of the universe list is used, the equivalence is wrapped in `Squash` to
 preserve computability.
 
 See `Fintype.equivFin` for the noncomputable version,
-and `Fintype.truncEquivFinOfCardEq` and `Fintype.equivFinOfCardEq`
+and `Fintype.squashEquivFinOfCardEq` and `Fintype.equivFinOfCardEq`
 for an equiv `α ≃ Fin n` given `Fintype.card α = n`.
 
-See `Fintype.truncFinBijection` for a version without `[DecidableEq α]`.
+See `Fintype.squashFinBijection` for a version without `[DecidableEq α]`.
 -/
-def truncEquivFin (α) [DecidableEq α] [Fintype α] : Trunc (α ≃ Fin (card α)) := by
+def squashEquivFin (α) [DecidableEq α] [Fintype α] : Squash (α ≃ Fin (card α)) := by
   unfold card Finset.card
   exact
     Quot.recOnSubsingleton'
       (motive := fun s : Multiset α =>
-        (∀ x : α, x ∈ s) → s.Nodup → Trunc (α ≃ Fin (Multiset.card s)))
+        (∀ x : α, x ∈ s) → s.Nodup → Squash (α ≃ Fin (Multiset.card s)))
       univ.val
-      (fun l (h : ∀ x : α, x ∈ l) (nd : l.Nodup) => Trunc.mk (nd.getEquivOfForallMemList _ h).symm)
+      (fun l (h : ∀ x : α, x ∈ l) (nd : l.Nodup) => Squash.mk (nd.getEquivOfForallMemList _ h).symm)
       mem_univ_val univ.2
-#align fintype.trunc_equiv_fin Fintype.truncEquivFin
+#align fintype.trunc_equiv_fin Fintype.squashEquivFin
 
 /-- There is (noncomputably) an equivalence between `α` and `Fin (card α)`.
 
-See `Fintype.truncEquivFin` for the computable version,
-and `Fintype.truncEquivFinOfCardEq` and `Fintype.equivFinOfCardEq`
+See `Fintype.squashEquivFin` for the computable version,
+and `Fintype.squashEquivFinOfCardEq` and `Fintype.equivFinOfCardEq`
 for an equiv `α ≃ Fin n` given `Fintype.card α = n`.
 -/
 noncomputable def equivFin (α) [Fintype α] : α ≃ Fin (card α) :=
@@ -104,19 +104,19 @@ Since it is not unique and depends on which permutation
 of the universe list is used, the bijection is wrapped in `Trunc` to
 preserve computability.
 
-See `Fintype.truncEquivFin` for a version that gives an equivalence
+See `Fintype.squashEquivFin` for a version that gives an equivalence
 given `[DecidableEq α]`.
 -/
-def truncFinBijection (α) [Fintype α] : Trunc { f : Fin (card α) → α // Bijective f } := by
+def squashFinBijection (α) [Fintype α] : Squash { f : Fin (card α) → α // Bijective f } := by
   unfold card Finset.card
   refine
     Quot.recOnSubsingleton'
       (motive := fun s : Multiset α =>
-        (∀ x : α, x ∈ s) → s.Nodup → Trunc {f : Fin (Multiset.card s) → α // Bijective f})
+        (∀ x : α, x ∈ s) → s.Nodup → Squash {f : Fin (Multiset.card s) → α // Bijective f})
       univ.val
-      (fun l (h : ∀ x : α, x ∈ l) (nd : l.Nodup) => Trunc.mk (nd.getBijectionOfForallMemList _ h))
+      (fun l (h : ∀ x : α, x ∈ l) (nd : l.Nodup) => Squash.mk (nd.getBijectionOfForallMemList _ h))
       mem_univ_val univ.2
-#align fintype.trunc_fin_bijection Fintype.truncFinBijection
+#align fintype.trunc_fin_bijection Fintype.squashFinBijection
 
 theorem subtype_card {p : α → Prop} (s : Finset α) (H : ∀ x : α, x ∈ s ↔ p x) :
     @card { x // p x } (Fintype.subtype s H) = s.card :=
@@ -163,20 +163,20 @@ variable [Fintype α] [Fintype β]
 /-- If the cardinality of `α` is `n`, there is computably a bijection between `α` and `Fin n`.
 
 See `Fintype.equivFinOfCardEq` for the noncomputable definition,
-and `Fintype.truncEquivFin` and `Fintype.equivFin` for the bijection `α ≃ Fin (card α)`.
+and `Fintype.squashEquivFin` and `Fintype.equivFin` for the bijection `α ≃ Fin (card α)`.
 -/
-def truncEquivFinOfCardEq [DecidableEq α] {n : ℕ} (h : Fintype.card α = n) : Trunc (α ≃ Fin n) :=
-  (truncEquivFin α).map fun e => e.trans (finCongr h)
-#align fintype.trunc_equiv_fin_of_card_eq Fintype.truncEquivFinOfCardEq
+def squashEquivFinOfCardEq [DecidableEq α] {n : ℕ} (h : Fintype.card α = n) : Squash (α ≃ Fin n) :=
+  (squashEquivFin α).map fun e => e.trans (finCongr h)
+#align fintype.trunc_equiv_fin_of_card_eq Fintype.squashEquivFinOfCardEq
 
 /-- If the cardinality of `α` is `n`, there is noncomputably a bijection between `α` and `Fin n`.
 
-See `Fintype.truncEquivFinOfCardEq` for the computable definition,
-and `Fintype.truncEquivFin` and `Fintype.equivFin` for the bijection `α ≃ Fin (card α)`.
+See `Fintype.squashEquivFinOfCardEq` for the computable definition,
+and `Fintype.squashEquivFin` and `Fintype.equivFin` for the bijection `α ≃ Fin (card α)`.
 -/
 noncomputable def equivFinOfCardEq {n : ℕ} (h : Fintype.card α = n) : α ≃ Fin n :=
   letI := Classical.decEq α
-  (truncEquivFinOfCardEq h).out
+  (squashEquivFinOfCardEq h).out
 #align fintype.equiv_fin_of_card_eq Fintype.equivFinOfCardEq
 
 /-- Two `Fintype`s with the same cardinality are (computably) in bijection.
@@ -185,20 +185,20 @@ See `Fintype.equivOfCardEq` for the noncomputable version,
 and `Fintype.truncEquivFinOfCardEq` and `Fintype.equivFinOfCardEq` for
 the specialization to `Fin`.
 -/
-def truncEquivOfCardEq [DecidableEq α] [DecidableEq β] (h : card α = card β) : Trunc (α ≃ β) :=
-  (truncEquivFinOfCardEq h).bind fun e => (truncEquivFin β).map fun e' => e.trans e'.symm
-#align fintype.trunc_equiv_of_card_eq Fintype.truncEquivOfCardEq
+def squashEquivOfCardEq [DecidableEq α] [DecidableEq β] (h : card α = card β) : Squash (α ≃ β) :=
+  (squashEquivFinOfCardEq h).bind fun e => (squashEquivFin β).map fun e' => e.trans e'.symm
+#align fintype.trunc_equiv_of_card_eq Fintype.squashEquivOfCardEq
 
 /-- Two `Fintype`s with the same cardinality are (noncomputably) in bijection.
 
-See `Fintype.truncEquivOfCardEq` for the computable version,
-and `Fintype.truncEquivFinOfCardEq` and `Fintype.equivFinOfCardEq` for
+See `Fintype.squashEquivOfCardEq` for the computable version,
+and `Fintype.squashEquivFinOfCardEq` and `Fintype.equivFinOfCardEq` for
 the specialization to `Fin`.
 -/
 noncomputable def equivOfCardEq (h : card α = card β) : α ≃ β := by
   letI := Classical.decEq α
   letI := Classical.decEq β
-  exact (truncEquivOfCardEq h).out
+  exact (squashEquivOfCardEq h).out
 #align fintype.equiv_of_card_eq Fintype.equivOfCardEq
 
 end
@@ -827,12 +827,12 @@ theorem isEmpty_of_card_lt [Fintype α] [Fintype β] (h : Fintype.card β < Fint
 #align function.embedding.is_empty_of_card_lt Function.Embedding.isEmpty_of_card_lt
 
 /-- A constructive embedding of a fintype `α` in another fintype `β` when `card α ≤ card β`. -/
-def truncOfCardLE [Fintype α] [Fintype β] [DecidableEq α] [DecidableEq β]
-    (h : Fintype.card α ≤ Fintype.card β) : Trunc (α ↪ β) :=
-  (Fintype.truncEquivFin α).bind fun ea =>
-    (Fintype.truncEquivFin β).map fun eb =>
+def squashOfCardLE [Fintype α] [Fintype β] [DecidableEq α] [DecidableEq β]
+    (h : Fintype.card α ≤ Fintype.card β) : Squash (α ↪ β) :=
+  (Fintype.squashEquivFin α).bind fun ea =>
+    (Fintype.squashEquivFin β).map fun eb =>
       ea.toEmbedding.trans ((Fin.castLEEmb h).trans eb.symm.toEmbedding)
-#align function.embedding.trunc_of_card_le Function.Embedding.truncOfCardLE
+#align function.embedding.trunc_of_card_le Function.Embedding.squashOfCardLE
 
 theorem nonempty_of_card_le [Fintype α] [Fintype β] (h : Fintype.card α ≤ Fintype.card β) :
     Nonempty (α ↪ β) := by classical exact (truncOfCardLE h).nonempty
@@ -1265,16 +1265,16 @@ theorem List.exists_pw_disjoint_with_card {α : Type*} [Fintype α]
 
 end Ranges
 
-section Trunc
+section Squash
 
 /-- A `Fintype` with positive cardinality constructively contains an element.
 -/
-def truncOfCardPos {α} [Fintype α] (h : 0 < Fintype.card α) : Trunc α :=
+def squashOfCardPos {α} [Fintype α] (h : 0 < Fintype.card α) : Squash α :=
   letI := Fintype.card_pos_iff.mp h
-  truncOfNonemptyFintype α
-#align trunc_of_card_pos truncOfCardPos
+  squashOfNonemptyFintype α
+#align trunc_of_card_pos squashOfCardPos
 
-end Trunc
+end Squash
 
 /-- A custom induction principle for fintypes. The base case is a subsingleton type,
 and the induction step is for non-trivial types, and one can assume the hypothesis for

--- a/Mathlib/Data/Fintype/Option.lean
+++ b/Mathlib/Data/Fintype/Option.lean
@@ -101,7 +101,7 @@ theorem induction_empty_option {P : ∀ (α : Type u) [Fintype α], Prop}
           (∀ (h : Fintype α), P α) → ∀ (h : Fintype (Option α)), P (Option α)  := by
       rintro α hα - Pα hα'
       convert h_option α (Pα _)
-    @truncRecEmptyOption (fun α => ∀ h, @P α h) (@fun α β e hα hβ => @of_equiv α β hβ e (hα _))
+    @squashRecEmptyOption (fun α => ∀ h, @P α h) (@fun α β e hα hβ => @of_equiv α β hβ e (hα _))
       f_empty h_option α _ (Classical.decEq α)
   exact p _
   -- ·

--- a/Mathlib/Data/Fintype/Option.lean
+++ b/Mathlib/Data/Fintype/Option.lean
@@ -54,36 +54,36 @@ namespace Fintype
 
 /-- A recursor principle for finite types, analogous to `Nat.rec`. It effectively says
 that every `Fintype` is either `Empty` or `Option α`, up to an `Equiv`. -/
-def truncRecEmptyOption {P : Type u → Sort v} (of_equiv : ∀ {α β}, α ≃ β → P α → P β)
+def squashRecEmptyOption {P : Type u → Sort v} (of_equiv : ∀ {α β}, α ≃ β → P α → P β)
     (h_empty : P PEmpty) (h_option : ∀ {α} [Fintype α] [DecidableEq α], P α → P (Option α))
-    (α : Type u) [Fintype α] [DecidableEq α] : Trunc (P α) := by
-  suffices ∀ n : ℕ, Trunc (P (ULift <| Fin n)) by
-    apply Trunc.bind (this (Fintype.card α))
+    (α : Type u) [Fintype α] [DecidableEq α] : Squash (P α) := by
+  suffices ∀ n : ℕ, Squash (P (ULift <| Fin n)) by
+    apply Squash.bind (this (Fintype.card α))
     intro h
-    apply Trunc.map _ (Fintype.truncEquivFin α)
+    apply Squash.map _ (Fintype.squashEquivFin α)
     intro e
     exact of_equiv (Equiv.ulift.trans e.symm) h
   apply ind where
     -- Porting note: do a manual recursion, instead of `induction` tactic,
     -- to ensure the result is computable
     /-- Internal induction hypothesis -/
-    ind : ∀ n : ℕ, Trunc (P (ULift <| Fin n))
+    ind : ∀ n : ℕ, Squash (P (ULift <| Fin n))
     | Nat.zero => by
           have : card PEmpty = card (ULift (Fin 0)) := by simp only [card_fin, card_pempty,
                                                                      card_ulift]
-          apply Trunc.bind (truncEquivOfCardEq this)
+          apply Squash.bind (squashEquivOfCardEq this)
           intro e
-          apply Trunc.mk
+          apply Squash.mk
           exact of_equiv e h_empty
       | Nat.succ n => by
           have : card (Option (ULift (Fin n))) = card (ULift (Fin n.succ)) := by
             simp only [card_fin, card_option, card_ulift]
-          apply Trunc.bind (truncEquivOfCardEq this)
+          apply Squash.bind (squashEquivOfCardEq this)
           intro e
-          apply Trunc.map _ (ind n)
+          apply Squash.map _ (ind n)
           intro ih
           exact of_equiv e (h_option ih)
-#align fintype.trunc_rec_empty_option Fintype.truncRecEmptyOption
+#align fintype.trunc_rec_empty_option Fintype.squashRecEmptyOption
 
 -- Porting note: due to instance inference issues in `SetTheory.Cardinal.Basic`
 -- I had to explicitly name `h_fintype` in order to access it manually.

--- a/Mathlib/Data/Fintype/Perm.lean
+++ b/Mathlib/Data/Fintype/Perm.lean
@@ -153,8 +153,8 @@ def fintypePerm [Fintype α] : Fintype (Perm α) :=
 
 instance equivFintype [Fintype α] [Fintype β] : Fintype (α ≃ β) :=
   if h : Fintype.card β = Fintype.card α then
-    Trunc.recOnSubsingleton (Fintype.truncEquivFin α) fun eα =>
-      Trunc.recOnSubsingleton (Fintype.truncEquivFin β) fun eβ =>
+    Squash.recOnSubsingleton (Fintype.squashEquivFin α) fun eα =>
+      Squash.recOnSubsingleton (Fintype.squashEquivFin β) fun eβ =>
         @Fintype.ofEquiv _ (Perm α) fintypePerm
           (equivCongr (Equiv.refl α) (eα.trans (Eq.recOn h eβ.symm)) : α ≃ α ≃ (α ≃ β))
   else ⟨∅, fun x => False.elim (h (Fintype.card_eq.2 ⟨x.symm⟩))⟩

--- a/Mathlib/Data/Fintype/Quotient.lean
+++ b/Mathlib/Data/Fintype/Quotient.lean
@@ -86,11 +86,11 @@ theorem Quotient.finChoice_eq {ι : Type*} [DecidableEq ι] [Fintype ι] {α : �
 
 /-- Given a function that for each `i : ι` gives a term of the corresponding
 truncation type, then there is corresponding term in the truncation of the product. -/
-def Trunc.finChoice {ι : Type*} [DecidableEq ι] [Fintype ι] {α : ι → Type*}
-    (f : ∀ i, Trunc (α i)) : Trunc (∀ i, α i) :=
+def Squash.finChoice {ι : Type*} [DecidableEq ι] [Fintype ι] {α : ι → Type*}
+    (f : ∀ i, Squash (α i)) : Squash (∀ i, α i) :=
   Quotient.map' id (fun _ _ _ => trivial)
     (Quotient.finChoice f (S := fun _ => trueSetoid))
 
-theorem Trunc.finChoice_eq {ι : Type*} [DecidableEq ι] [Fintype ι] {α : ι → Type*}
-    (f : ∀ i, α i) : (Trunc.finChoice fun i => Trunc.mk (f i)) = Trunc.mk f :=
+theorem Squash.finChoice_eq {ι : Type*} [DecidableEq ι] [Fintype ι] {α : ι → Type*}
+    (f : ∀ i, α i) : (Squash.finChoice fun i => Squash.mk (f i)) = Squash.mk f :=
   Subsingleton.elim _ _

--- a/Mathlib/Data/Fintype/Quotient.lean
+++ b/Mathlib/Data/Fintype/Quotient.lean
@@ -88,7 +88,7 @@ theorem Quotient.finChoice_eq {ι : Type*} [DecidableEq ι] [Fintype ι] {α : �
 truncation type, then there is corresponding term in the truncation of the product. -/
 def Squash.finChoice {ι : Type*} [DecidableEq ι] [Fintype ι] {α : ι → Type*}
     (f : ∀ i, Squash (α i)) : Squash (∀ i, α i) :=
-  Quotient.map' id (fun _ _ _ => trivial)
+  Quot.map id (fun _ _ _ => trivial)
     (Quotient.finChoice f (S := fun _ => trueSetoid))
 
 theorem Squash.finChoice_eq {ι : Type*} [DecidableEq ι] [Fintype ι] {α : ι → Type*}

--- a/Mathlib/Data/Quot.lean
+++ b/Mathlib/Data/Quot.lean
@@ -465,135 +465,121 @@ def trueSetoid : Setoid α :=
   ⟨_, true_equivalence⟩
 #align true_setoid trueSetoid
 
-/-- `Trunc α` is the quotient of `α` by the always-true relation. This
-  is related to the propositional truncation in HoTT, and is similar
-  in effect to `Nonempty α`, but unlike `Nonempty α`, `Trunc α` is data,
-  so the VM representation is the same as `α`, and so this can be used to
-  maintain computability. -/
-def Trunc.{u} (α : Sort u) : Sort u :=
-  @Quotient α trueSetoid
-#align trunc Trunc
+#align trunc Squash
 
-namespace Trunc
+#align trunc.mk Squash.mk
 
-/-- Constructor for `Trunc α` -/
-def mk (a : α) : Trunc α :=
-  Quot.mk _ a
-#align trunc.mk Trunc.mk
+namespace Squash
 
-instance [Inhabited α] : Inhabited (Trunc α) :=
-  ⟨mk default⟩
+variable {α β : Type*}
+
+instance [Inhabited α] : Inhabited (Squash α) :=
+  ⟨.mk default⟩
 
 /-- Any constant function lifts to a function out of the truncation -/
-def lift (f : α → β) (c : ∀ a b : α, f a = f b) : Trunc α → β :=
+def lift' (f : α → β) (c : ∀ a b : α, f a = f b) : Squash α → β :=
   Quot.lift f fun a b _ ↦ c a b
-#align trunc.lift Trunc.lift
+#align trunc.lift Squash.lift'
 
-theorem ind {β : Trunc α → Prop} : (∀ a : α, β (mk a)) → ∀ q : Trunc α, β q :=
-  Quot.ind
-#align trunc.ind Trunc.ind
+#align trunc.ind Squash.ind
 
-protected theorem lift_mk (f : α → β) (c) (a : α) : lift f c (mk a) = f a :=
+protected theorem lift'_mk (f : α → β) (c) (a : α) : Squash.lift' f c (mk a) = f a :=
   rfl
-#align trunc.lift_mk Trunc.lift_mk
+#align trunc.lift_mk Squash.lift'_mk
 
-/-- Lift a constant function on `q : Trunc α`. -/
+/-- Lift a constant function on `q : Squash α`. -/
 -- Porting note: removed `@[elab_as_elim]` because it gave "unexpected eliminator resulting type"
 -- porting note (#11083): removed `@[reducible]` because it caused extremely slow `simp`
-protected def liftOn (q : Trunc α) (f : α → β) (c : ∀ a b : α, f a = f b) : β :=
-  lift f c q
-#align trunc.lift_on Trunc.liftOn
+protected def lift'On (q : Squash α) (f : α → β) (c : ∀ a b : α, f a = f b) : β :=
+  Squash.lift' f c q
+#align trunc.lift_on Squash.lift'On
 
 @[elab_as_elim]
-protected theorem induction_on {β : Trunc α → Prop} (q : Trunc α) (h : ∀ a, β (mk a)) : β q :=
+protected theorem induction_on {β : Squash α → Prop} (q : Squash α) (h : ∀ a, β (mk a)) : β q :=
   ind h q
-#align trunc.induction_on Trunc.induction_on
+#align trunc.induction_on Squash.induction_on
 
-theorem exists_rep (q : Trunc α) : ∃ a : α, mk a = q :=
+theorem exists_rep (q : Squash α) : ∃ a : α, mk a = q :=
   Quot.exists_rep q
-#align trunc.exists_rep Trunc.exists_rep
+#align trunc.exists_rep Squash.exists_rep
 
 @[elab_as_elim]
-protected theorem induction_on₂ {C : Trunc α → Trunc β → Prop} (q₁ : Trunc α) (q₂ : Trunc β)
+protected theorem induction_on₂ {C : Squash α → Squash β → Prop} (q₁ : Squash α) (q₂ : Squash β)
     (h : ∀ a b, C (mk a) (mk b)) : C q₁ q₂ :=
-  Trunc.induction_on q₁ fun a₁ ↦ Trunc.induction_on q₂ (h a₁)
-#align trunc.induction_on₂ Trunc.induction_on₂
+  Squash.induction_on q₁ fun a₁ ↦ Squash.induction_on q₂ (h a₁)
+#align trunc.induction_on₂ Squash.induction_on₂
 
-protected theorem eq (a b : Trunc α) : a = b :=
-  Trunc.induction_on₂ a b fun _ _ ↦ Quot.sound trivial
-#align trunc.eq Trunc.eq
+protected theorem eq (a b : Squash α) : a = b := Subsingleton.elim a b
+#align trunc.eq Squash.eq
 
-instance instSubsingletonTrunc : Subsingleton (Trunc α) :=
-  ⟨Trunc.eq⟩
+/-- The `bind` operator for the `Squash` monad. -/
+def bind (q : Squash α) (f : α → Squash β) : Squash β :=
+  Squash.lift'On q f fun _ _ ↦ Squash.eq _ _
+#align trunc.bind Squash.bind
 
-/-- The `bind` operator for the `Trunc` monad. -/
-def bind (q : Trunc α) (f : α → Trunc β) : Trunc β :=
-  Trunc.liftOn q f fun _ _ ↦ Trunc.eq _ _
-#align trunc.bind Trunc.bind
+/-- A function `f : α → β` defines a function `map f : Squash α → Squash β`. -/
+def map (f : α → β) (q : Squash α) : Squash β :=
+  bind q (Squash.mk ∘ f)
+#align trunc.map Squash.map
 
-/-- A function `f : α → β` defines a function `map f : Trunc α → Trunc β`. -/
-def map (f : α → β) (q : Trunc α) : Trunc β :=
-  bind q (Trunc.mk ∘ f)
-#align trunc.map Trunc.map
+instance : Monad Squash where
+  pure := @Squash.mk
+  bind := @Squash.bind
 
-instance : Monad Trunc where
-  pure := @Trunc.mk
-  bind := @Trunc.bind
-
-instance : LawfulMonad Trunc where
-  id_map _ := Trunc.eq _ _
+instance : LawfulMonad Squash where
+  id_map _ := Squash.eq _ _
   pure_bind _ _ := rfl
-  bind_assoc _ _ _ := Trunc.eq _ _
+  bind_assoc _ _ _ := Squash.eq _ _
   -- Porting note: the fields below are new in Lean 4
   map_const := rfl
-  seqLeft_eq _ _ := Trunc.eq _ _
-  seqRight_eq _ _ := Trunc.eq _ _
+  seqLeft_eq _ _ := Squash.eq _ _
+  seqRight_eq _ _ := Squash.eq _ _
   pure_seq _ _ := rfl
   bind_pure_comp _ _ := rfl
   bind_map _ _ := rfl
 
-variable {C : Trunc α → Sort*}
+variable {C : Squash α → Sort*}
 
-/-- Recursion/induction principle for `Trunc`. -/
+/-- Recursion/induction principle for `Squash`. -/
 -- porting note (#11083): removed `@[reducible]` because it caused extremely slow `simp`
 @[elab_as_elim]
 protected def rec (f : ∀ a, C (mk a))
-    (h : ∀ a b : α, (Eq.ndrec (f a) (Trunc.eq (mk a) (mk b)) : C (mk b)) = f b)
-    (q : Trunc α) : C q :=
+    (h : ∀ a b : α, (Eq.ndrec (f a) (Squash.eq (mk a) (mk b)) : C (mk b)) = f b)
+    (q : Squash α) : C q :=
   Quot.rec f (fun a b _ ↦ h a b) q
-#align trunc.rec Trunc.rec
+#align trunc.rec Squash.rec
 
-/-- A version of `Trunc.rec` taking `q : Trunc α` as the first argument. -/
+/-- A version of `Squash.rec` taking `q : Squash α` as the first argument. -/
 -- porting note (#11083): removed `@[reducible]` because it caused extremely slow `simp`
 @[elab_as_elim]
-protected def recOn (q : Trunc α) (f : ∀ a, C (mk a))
-    (h : ∀ a b : α, (Eq.ndrec (f a) (Trunc.eq (mk a) (mk b)) : C (mk b)) = f b) : C q :=
-  Trunc.rec f h q
-#align trunc.rec_on Trunc.recOn
+protected def recOn (q : Squash α) (f : ∀ a, C (mk a))
+    (h : ∀ a b : α, (Eq.ndrec (f a) (Squash.eq (mk a) (mk b)) : C (mk b)) = f b) : C q :=
+  Squash.rec f h q
+#align trunc.rec_on Squash.recOn
 
-/-- A version of `Trunc.recOn` assuming the codomain is a `Subsingleton`. -/
+/-- A version of `Squash.recOn` assuming the codomain is a `Subsingleton`. -/
 -- porting note (#11083)s: removed `@[reducible]` because it caused extremely slow `simp`
 @[elab_as_elim]
-protected def recOnSubsingleton [∀ a, Subsingleton (C (mk a))] (q : Trunc α) (f : ∀ a, C (mk a)) :
+protected def recOnSubsingleton [∀ a, Subsingleton (C (mk a))] (q : Squash α) (f : ∀ a, C (mk a)) :
     C q :=
-  Trunc.rec f (fun _ b ↦ Subsingleton.elim _ (f b)) q
-#align trunc.rec_on_subsingleton Trunc.recOnSubsingleton
+  Squash.rec f (fun _ b ↦ Subsingleton.elim _ (f b)) q
+#align trunc.rec_on_subsingleton Squash.recOnSubsingleton
 
-/-- Noncomputably extract a representative of `Trunc α` (using the axiom of choice). -/
-noncomputable def out : Trunc α → α :=
+/-- Noncomputably extract a representative of `Squash α` (using the axiom of choice). -/
+noncomputable def out : Squash α → α :=
   Quot.out
-#align trunc.out Trunc.out
+#align trunc.out Squash.out
 
 @[simp]
-theorem out_eq (q : Trunc α) : mk q.out = q :=
-  Trunc.eq _ _
-#align trunc.out_eq Trunc.out_eq
+theorem out_eq (q : Squash α) : mk q.out = q :=
+  Squash.eq _ _
+#align trunc.out_eq Squash.out_eq
 
-protected theorem nonempty (q : Trunc α) : Nonempty α :=
+protected theorem nonempty (q : Squash α) : Nonempty α :=
   nonempty_of_exists q.exists_rep
-#align trunc.nonempty Trunc.nonempty
+#align trunc.nonempty Squash.nonempty
 
-end Trunc
+end Squash
 
 /-! ### `Quotient` with implicit `Setoid` -/
 

--- a/Mathlib/Data/Semiquot.lean
+++ b/Mathlib/Data/Semiquot.lean
@@ -28,8 +28,8 @@ predicate `S`) but are not completely determined.
 structure Semiquot (α : Type*) where mk' ::
   /-- Set containing some element of `α`-/
   s : Set α
-  /-- Assertion of non-emptiness via `Trunc`-/
-  val : Trunc s
+  /-- Assertion of non-emptiness via `Squash`-/
+  val : Squash s
 #align semiquot Semiquot
 
 namespace Semiquot
@@ -47,7 +47,7 @@ def mk {a : α} {s : Set α} (h : a ∈ s) : Semiquot α :=
 theorem ext_s {q₁ q₂ : Semiquot α} : q₁ = q₂ ↔ q₁.s = q₂.s := by
   refine ⟨congr_arg _, fun h => ?_⟩
   cases' q₁ with _ v₁; cases' q₂ with _ v₂; congr
-  exact Subsingleton.helim (congrArg Trunc (congrArg Set.Elem h)) v₁ v₂
+  exact Subsingleton.helim (congrArg Squash (congrArg Set.Elem h)) v₁ v₂
 #align semiquot.ext_s Semiquot.ext_s
 
 theorem ext {q₁ q₂ : Semiquot α} : q₁ = q₂ ↔ ∀ a, a ∈ q₁ ↔ a ∈ q₂ :=
@@ -96,15 +96,15 @@ theorem mem_blur' (q : Semiquot α) {s : Set α} (h : q.s ⊆ s) {a : α} : a �
   Iff.rfl
 #align semiquot.mem_blur' Semiquot.mem_blur'
 
-/-- Convert a `Trunc α` to a `Semiquot α`. -/
-def ofTrunc (q : Trunc α) : Semiquot α :=
+/-- Convert a `Squash α` to a `Semiquot α`. -/
+def ofSquash (q : Squash α) : Semiquot α :=
   ⟨Set.univ, q.map fun a => ⟨a, trivial⟩⟩
-#align semiquot.of_trunc Semiquot.ofTrunc
+#align semiquot.of_trunc Semiquot.ofSquash
 
-/-- Convert a `Semiquot α` to a `Trunc α`. -/
-def toTrunc (q : Semiquot α) : Trunc α :=
+/-- Convert a `Semiquot α` to a `Squash α`. -/
+def toSquash (q : Semiquot α) : Squash α :=
   q.2.map Subtype.val
-#align semiquot.to_trunc Semiquot.toTrunc
+#align semiquot.to_trunc Semiquot.toSquash
 
 /-- If `f` is a constant on `q.s`, then `q.liftOn f` is the value of `f`
 at any point of `q`. -/

--- a/Mathlib/Data/Semiquot.lean
+++ b/Mathlib/Data/Semiquot.lean
@@ -41,7 +41,7 @@ instance : Membership α (Semiquot α) :=
 
 /-- Construct a `Semiquot α` from `h : a ∈ s` where `s : Set α`. -/
 def mk {a : α} {s : Set α} (h : a ∈ s) : Semiquot α :=
-  ⟨s, Trunc.mk ⟨a, h⟩⟩
+  ⟨s, Squash.mk ⟨a, h⟩⟩
 #align semiquot.mk Semiquot.mk
 
 theorem ext_s {q₁ q₂ : Semiquot α} : q₁ = q₂ ↔ q₁.s = q₂.s := by
@@ -79,7 +79,7 @@ theorem mem_pure' {a b : α} : a ∈ Semiquot.pure b ↔ a = b :=
 
 /-- Replace `s` in a `Semiquot` with a superset. -/
 def blur' (q : Semiquot α) {s : Set α} (h : q.s ⊆ s) : Semiquot α :=
-  ⟨s, Trunc.lift (fun a : q.s => Trunc.mk ⟨a.1, h a.2⟩) (fun _ _ => Trunc.eq _ _) q.2⟩
+  ⟨s, Squash.lift' (fun a : q.s => Squash.mk ⟨a.1, h a.2⟩) (fun _ _ => Squash.eq _ _) q.2⟩
 #align semiquot.blur' Semiquot.blur'
 
 /-- Replace `s` in a `q : Semiquot α` with a union `s ∪ q.s` -/
@@ -109,7 +109,7 @@ def toSquash (q : Semiquot α) : Squash α :=
 /-- If `f` is a constant on `q.s`, then `q.liftOn f` is the value of `f`
 at any point of `q`. -/
 def liftOn (q : Semiquot α) (f : α → β) (h : ∀ a ∈ q, ∀ b ∈ q, f a = f b) : β :=
-  Trunc.liftOn q.2 (fun x => f x.1) fun x y => h _ x.2 _ y.2
+  Squash.lift'On q.2 (fun x => f x.1) fun x y => h _ x.2 _ y.2
 #align semiquot.lift_on Semiquot.liftOn
 
 theorem liftOn_ofMem (q : Semiquot α) (f : α → β)

--- a/Mathlib/GroupTheory/Perm/Cycle/Factors.lean
+++ b/Mathlib/GroupTheory/Perm/Cycle/Factors.lean
@@ -435,11 +435,11 @@ def cycleFactors [Fintype α] [LinearOrder α] (f : Perm α) :
 
 /-- Factors a permutation `f` into a list of disjoint cyclic permutations that multiply to `f`,
   without a linear order. -/
-def truncCycleFactors [DecidableEq α] [Fintype α] (f : Perm α) :
-    Trunc { l : List (Perm α) // l.prod = f ∧ (∀ g ∈ l, IsCycle g) ∧ l.Pairwise Disjoint } :=
-  Quotient.recOnSubsingleton (@univ α _).1 (fun l h => Trunc.mk (cycleFactorsAux l f (h _)))
+def squashCycleFactors [DecidableEq α] [Fintype α] (f : Perm α) :
+    Squash { l : List (Perm α) // l.prod = f ∧ (∀ g ∈ l, IsCycle g) ∧ l.Pairwise Disjoint } :=
+  Quotient.recOnSubsingleton (@univ α _).1 (fun l h => Squash.mk (cycleFactorsAux l f (h _)))
     (show ∀ x, f x ≠ x → x ∈ (@univ α _).1 from fun _ _ => mem_univ _)
-#align equiv.perm.trunc_cycle_factors Equiv.Perm.truncCycleFactors
+#align equiv.perm.trunc_cycle_factors Equiv.Perm.squashCycleFactors
 
 section CycleFactorsFinset
 
@@ -448,7 +448,7 @@ variable [DecidableEq α] [Fintype α] (f : Perm α)
 /-- Factors a permutation `f` into a `Finset` of disjoint cyclic permutations that multiply to `f`.
 -/
 def cycleFactorsFinset : Finset (Perm α) :=
-  (truncCycleFactors f).lift
+  (squashCycleFactors f).lift'
     (fun l : { l : List (Perm α) // l.prod = f ∧ (∀ g ∈ l, IsCycle g) ∧ l.Pairwise Disjoint } =>
       l.val.toFinset)
     fun ⟨_, hl⟩ ⟨_, hl'⟩ =>

--- a/Mathlib/GroupTheory/Perm/Sign.lean
+++ b/Mathlib/GroupTheory/Perm/Sign.lean
@@ -114,7 +114,7 @@ theorem swap_induction_on [Finite α] {P : Perm α → Prop} (f : Perm α) :
 theorem mclosure_isSwap [Finite α] : Submonoid.closure { σ : Perm α | IsSwap σ } = ⊤ := by
   cases nonempty_fintype α
   refine top_unique fun x _ ↦ ?_
-  obtain ⟨h1, h2⟩ := Subtype.mem (truncSwapFactors x).out
+  obtain ⟨h1, h2⟩ := Subtype.mem (squashSwapFactors x).out
   rw [← h1]
   exact Submonoid.list_prod_mem _ fun y hy ↦ Submonoid.subset_closure (h2 y hy)
 
@@ -485,7 +485,7 @@ theorem eq_sign_of_surjective_hom {s : Perm α →* ℤˣ} (hs : Surjective s) :
           rw [← isConj_iff_eq, ← Or.resolve_right (Int.units_eq_one_or _) h, hab']
           exact s.map_isConj (isConj_swap hab hxy)
         let ⟨g, hg⟩ := hs (-1)
-        let ⟨l, hl⟩ := (truncSwapFactors g).out
+        let ⟨l, hl⟩ := (squashSwapFactors g).out
         have : ∀ a ∈ l.map s, a = (1 : ℤˣ) := fun a ha =>
           let ⟨g, hg⟩ := List.mem_map.1 ha
           hg.2 ▸ this _ (hl.2 _ hg.1)
@@ -494,7 +494,7 @@ theorem eq_sign_of_surjective_hom {s : Perm α →* ℤˣ} (hs : Surjective s) :
         rw [hl.1, hg] at this
         exact absurd this (by simp_all)
   MonoidHom.ext fun f => by
-    let ⟨l, hl₁, hl₂⟩ := (truncSwapFactors f).out
+    let ⟨l, hl₁, hl₂⟩ := (squashSwapFactors f).out
     have hsl : ∀ a ∈ l.map s, a = (-1 : ℤˣ) := fun a ha =>
       let ⟨g, hg⟩ := List.mem_map.1 ha
       hg.2 ▸ this (hl₂ _ hg.1)
@@ -504,7 +504,7 @@ theorem eq_sign_of_surjective_hom {s : Perm α →* ℤˣ} (hs : Surjective s) :
 
 theorem sign_subtypePerm (f : Perm α) {p : α → Prop} [DecidablePred p] (h₁ : ∀ x, p x ↔ p (f x))
     (h₂ : ∀ x, f x ≠ x → p x) : sign (subtypePerm f h₁) = sign f := by
-  let l := (truncSwapFactors (subtypePerm f h₁)).out
+  let l := (squashSwapFactors (subtypePerm f h₁)).out
   have hl' : ∀ g' ∈ l.1.map ofSubtype, IsSwap g' := fun g' hg' =>
     let ⟨g, hg⟩ := List.mem_map.1 hg'
     hg.2 ▸ (l.2.2 _ hg.1).of_subtype_isSwap

--- a/Mathlib/GroupTheory/Perm/Sign.lean
+++ b/Mathlib/GroupTheory/Perm/Sign.lean
@@ -80,7 +80,7 @@ def swapFactorsAux :
 
 /-- `swapFactors` represents a permutation as a product of a list of transpositions.
 The representation is non unique and depends on the linear order structure.
-For types without linear order `truncSwapFactors` can be used. -/
+For types without linear order `squashSwapFactors` can be used. -/
 def swapFactors [Fintype α] [LinearOrder α] (f : Perm α) :
     { l : List (Perm α) // l.prod = f ∧ ∀ g ∈ l, IsSwap g } :=
   swapFactorsAux ((@univ α _).sort (· ≤ ·)) f fun {_ _} => (mem_sort _).2 (mem_univ _)
@@ -88,11 +88,11 @@ def swapFactors [Fintype α] [LinearOrder α] (f : Perm α) :
 
 /-- This computably represents the fact that any permutation can be represented as the product of
   a list of transpositions. -/
-def truncSwapFactors [Fintype α] (f : Perm α) :
-    Trunc { l : List (Perm α) // l.prod = f ∧ ∀ g ∈ l, IsSwap g } :=
-  Quotient.recOnSubsingleton (@univ α _).1 (fun l h => Trunc.mk (swapFactorsAux l f (h _)))
+def squashSwapFactors [Fintype α] (f : Perm α) :
+    Squash { l : List (Perm α) // l.prod = f ∧ ∀ g ∈ l, IsSwap g } :=
+  Quotient.recOnSubsingleton (@univ α _).1 (fun l h => Squash.mk (swapFactorsAux l f (h _)))
     (show ∀ x, f x ≠ x → x ∈ (@univ α _).1 from fun _ _ => mem_univ _)
-#align equiv.perm.trunc_swap_factors Equiv.Perm.truncSwapFactors
+#align equiv.perm.trunc_swap_factors Equiv.Perm.squashSwapFactors
 
 /-- An induction principle for permutations. If `P` holds for the identity permutation, and
 is preserved under composition with a non-trivial swap, then `P` holds for all permutations. -/
@@ -100,7 +100,7 @@ is preserved under composition with a non-trivial swap, then `P` holds for all p
 theorem swap_induction_on [Finite α] {P : Perm α → Prop} (f : Perm α) :
     P 1 → (∀ f x y, x ≠ y → P f → P (swap x y * f)) → P f := by
   cases nonempty_fintype α
-  cases' (truncSwapFactors f).out with l hl
+  cases' (squashSwapFactors f).out with l hl
   induction' l with g l ih generalizing f
   · simp (config := { contextual := true }) only [hl.left.symm, List.prod_nil, forall_true_iff]
   · intro h1 hmul_swap

--- a/Mathlib/Logic/Equiv/List.lean
+++ b/Mathlib/Logic/Equiv/List.lean
@@ -133,9 +133,9 @@ def encodableOfList [DecidableEq α] (l : List α) (H : ∀ x, x ∈ l) : Encoda
 
 /-- A finite type is encodable. Because the encoding is not unique, we wrap it in `Trunc` to
 preserve computability. -/
-def _root_.Fintype.truncEncodable (α : Type*) [DecidableEq α] [Fintype α] : Trunc (Encodable α) :=
-  @Quot.recOnSubsingleton' _ _ (fun s : Multiset α => (∀ x : α, x ∈ s) → Trunc (Encodable α)) _
-    Finset.univ.1 (fun l H => Trunc.mk <| encodableOfList l H) Finset.mem_univ
+def _root_.Fintype.truncEncodable (α : Type*) [DecidableEq α] [Fintype α] : Squash (Encodable α) :=
+  @Quot.recOnSubsingleton' _ _ (fun s : Multiset α => (∀ x : α, x ∈ s) → Squash (Encodable α)) _
+    Finset.univ.1 (fun l H => Squash.mk <| encodableOfList l H) Finset.mem_univ
 #align fintype.trunc_encodable Fintype.truncEncodable
 
 /-- A noncomputable way to arbitrarily choose an ordering on a finite type.
@@ -180,18 +180,18 @@ instance _root_.Finset.countable [Countable α] : Countable (Finset α) :=
 /-- When `α` is finite and `β` is encodable, `α → β` is encodable too. Because the encoding is not
 unique, we wrap it in `Trunc` to preserve computability. -/
 def fintypeArrow (α : Type*) (β : Type*) [DecidableEq α] [Fintype α] [Encodable β] :
-    Trunc (Encodable (α → β)) :=
-  (Fintype.truncEquivFin α).map fun f =>
+    Squash (Encodable (α → β)) :=
+  (Fintype.squashEquivFin α).map fun f =>
     Encodable.ofEquiv (Fin (Fintype.card α) → β) <| Equiv.arrowCongr f (Equiv.refl _)
 #align encodable.fintype_arrow Encodable.fintypeArrow
 
 /-- When `α` is finite and all `π a` are encodable, `Π a, π a` is encodable too. Because the
 encoding is not unique, we wrap it in `Trunc` to preserve computability. -/
 def fintypePi (α : Type*) (π : α → Type*) [DecidableEq α] [Fintype α] [∀ a, Encodable (π a)] :
-    Trunc (Encodable (∀ a, π a)) :=
+    Squash (Encodable (∀ a, π a)) :=
   (Fintype.truncEncodable α).bind fun a =>
     (@fintypeArrow α (Σa, π a) _ _ (@Sigma.encodable _ _ a _)).bind fun f =>
-      Trunc.mk <|
+      Squash.mk <|
         @Encodable.ofEquiv _ _ (@Subtype.encodable _ _ f _)
           (Equiv.piEquivSubtypeSigma α π)
 #align encodable.fintype_pi Encodable.fintypePi


### PR DESCRIPTION
Remove `Trunc` and use `Squash` instead

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks, and is labeled with `awaiting-review`.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
