### PR TITLE
[Merged by Bors] - feat(Algebra/BigOperators/Group/Finset): Lemma for product being a square

### DIFF
--- a/Mathlib/Algebra/BigOperators/Group/Finset.lean
+++ b/Mathlib/Algebra/BigOperators/Group/Finset.lean
@@ -2055,8 +2055,8 @@ lemma prod_mul_eq_prod_mul_of_exists [DecidableEq α] {s : Finset α} {f : α �
   rw [mul_assoc, mul_comm, mul_assoc, mul_comm b₁, h, ← mul_assoc, mul_comm _ (f a)]
 
 @[to_additive]
-lemma IsSquare_finset_prod {s : Finset ι} [CommMonoid α] (f : ι → α)
-    (h : ∀ (c : s), IsSquare (f c)) : IsSquare (∏ i ∈ s, f i) := by
+lemma isSquare_prod {s : Finset ι} [CommMonoid α] (f : ι → α)
+    (h : ∀ c ∈ s, IsSquare (f c)) : IsSquare (∏ i ∈ s, f i) := by
   rw [isSquare_iff_exists_sq]
   use (∏ x, ((isSquare_iff_exists_sq _).mp (h x)).choose)
   rw [@sq, ← Finset.prod_mul_distrib, ← Finset.prod_coe_sort]

--- a/Mathlib/Algebra/BigOperators/Group/Finset.lean
+++ b/Mathlib/Algebra/BigOperators/Group/Finset.lean
@@ -2058,12 +2058,12 @@ lemma prod_mul_eq_prod_mul_of_exists [DecidableEq α] {s : Finset α} {f : α �
 lemma isSquare_prod {s : Finset ι} [CommMonoid α] (f : ι → α)
     (h : ∀ c ∈ s, IsSquare (f c)) : IsSquare (∏ i ∈ s, f i) := by
   rw [isSquare_iff_exists_sq]
-  use (∏ x, ((isSquare_iff_exists_sq _).mp (h x)).choose)
+  use (∏ (x : s), ((isSquare_iff_exists_sq _).mp (h _ x.2)).choose)
   rw [@sq, ← Finset.prod_mul_distrib, ← Finset.prod_coe_sort]
   congr
   ext i
   rw [← @sq]
-  exact ((isSquare_iff_exists_sq _).mp (h i)).choose_spec
+  exact ((isSquare_iff_exists_sq _).mp (h _ i.2)).choose_spec
 
 end CommMonoid
 

--- a/Mathlib/Algebra/BigOperators/Group/Finset.lean
+++ b/Mathlib/Algebra/BigOperators/Group/Finset.lean
@@ -2054,6 +2054,17 @@ lemma prod_mul_eq_prod_mul_of_exists [DecidableEq α] {s : Finset α} {f : α �
   simp only [mem_erase, ne_eq, not_true_eq_false, false_and, not_false_eq_true, prod_insert]
   rw [mul_assoc, mul_comm, mul_assoc, mul_comm b₁, h, ← mul_assoc, mul_comm _ (f a)]
 
+@[to_additive]
+lemma IsSquare_finset_prod {s : Finset ι} [CommMonoid α] (f : ι → α)
+    (h : ∀ (c : s), IsSquare (f c)) : IsSquare (∏ i ∈ s, f i) := by
+  rw [isSquare_iff_exists_sq]
+  use (∏ x, ((isSquare_iff_exists_sq _).mp (h x)).choose)
+  rw [@sq, ← Finset.prod_mul_distrib, ← Finset.prod_coe_sort]
+  congr
+  ext i
+  rw [← @sq]
+  exact ((isSquare_iff_exists_sq _).mp (h i)).choose_spec
+
 end CommMonoid
 
 section CancelCommMonoid


### PR DESCRIPTION
Added a small lemma that shows a product is a square if all the terms are squares


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks, and is labeled with `awaiting-review`.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
