### PR TITLE
[Merged by Bors] - chore: remove porting notes 'in std'

### DIFF
--- a/Mathlib/Data/List/Basic.lean
+++ b/Mathlib/Data/List/Basic.lean
@@ -1801,7 +1801,7 @@ theorem takeD_length : ∀ n l a, length (@takeD α n l a) = n
   | 0, _, _ => rfl
   | _ + 1, _, _ => congr_arg succ (takeD_length _ _ _)
 
--- Porting note: `takeD_nil` is already in std
+-- `takeD_nil` is already in batteries
 
 theorem takeD_eq_take : ∀ {n} {l : List α} a, n ≤ length l → takeD n l a = take n l
   | 0, _, _, _ => rfl
@@ -2201,13 +2201,9 @@ section FoldlMFoldrM
 variable {m : Type v → Type w} [Monad m]
 
 #align list.mfoldl_nil List.foldlM_nil
--- Porting note: now in std
 #align list.mfoldr_nil List.foldrM_nil
 #align list.mfoldl_cons List.foldlM_cons
 
-/- Porting note: now in std; now assumes an instance of `LawfulMonad m`, so we make everything
-  `foldrM_eq_foldr` depend on one as well. (An instance of `LawfulMonad m` was already present for
-  everything following; this just moves it a few lines up.) -/
 #align list.mfoldr_cons List.foldrM_cons
 
 variable [LawfulMonad m]
@@ -2228,10 +2224,7 @@ theorem foldlM_eq_foldl (f : β → α → m β) (b l) :
   | cons _ _ l_ih => intro; simp only [List.foldlM, foldl, ← l_ih, functor_norm]
 #align list.mfoldl_eq_foldl List.foldlM_eq_foldl
 
--- Porting note: now in std
 #align list.mfoldl_append List.foldlM_append
-
--- Porting note: now in std
 #align list.mfoldr_append List.foldrM_append
 
 end FoldlMFoldrM

--- a/Mathlib/Geometry/RingedSpace/Stalks.lean
+++ b/Mathlib/Geometry/RingedSpace/Stalks.lean
@@ -229,7 +229,7 @@ theorem stalkSpecializes_stalkMap {X Y : PresheafedSpace.{_, _, v} C}
   -- Porting note: the original one liner `dsimp [stalkMap]; simp [stalkMap]` doesn't work,
   -- I had to uglify this
   dsimp [stalkSpecializes, stalkMap, stalkFunctor, stalkPushforward]
-  -- We can't use `ext` here due to https://github.com/leanprover/std4/pull/159
+  -- We can't use `ext` here due to https://github.com/leanprover/batteries/pull/159
   refine colimit.hom_ext fun j => ?_
   induction j with | h j => ?_
   dsimp

--- a/Mathlib/Geometry/RingedSpace/Stalks.lean
+++ b/Mathlib/Geometry/RingedSpace/Stalks.lean
@@ -229,7 +229,7 @@ theorem stalkSpecializes_stalkMap {X Y : PresheafedSpace.{_, _, v} C}
   -- Porting note: the original one liner `dsimp [stalkMap]; simp [stalkMap]` doesn't work,
   -- I had to uglify this
   dsimp [stalkSpecializes, stalkMap, stalkFunctor, stalkPushforward]
-  -- We can't use `ext` here due to https://github.com/leanprover/batteries/pull/159
+  -- We can't use `ext` here due to https://github.com/leanprover-community/batteries/pull/159
   refine colimit.hom_ext fun j => ?_
   induction j with | h j => ?_
   dsimp


### PR DESCRIPTION
These don't seem actionable at this point.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks, and is labeled with `awaiting-review`.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
