### PR TITLE
hack: to_additive handles norm_cast attributes

### DIFF
--- a/Mathlib/Tactic/ToAdditive.lean
+++ b/Mathlib/Tactic/ToAdditive.lean
@@ -854,7 +854,7 @@ def additivizeLemmas [Monad m] [MonadError m] [MonadLiftT CoreM m]
       throwError "{names[0]!} and {nm} do not generate the same number of {desc}."
   for (srcLemmas, tgtLemmas) in auxLemmas.zip <| auxLemmas.eraseIdx 0 do
     for (srcLemma, tgtLemma) in srcLemmas.zip tgtLemmas do
-      insertTranslation srcLemma tgtLemma
+      insertTranslation srcLemma tgtLemma false
 
 /--
 Find the first argument of `nm` that has a multiplicative type-class on it.
@@ -1172,6 +1172,10 @@ partial def applyAttributes (stx : Syntax) (rawAttrs : Array Syntax) (thisAttr s
     if attr.name == `simp then
       additivizeLemmas allDecls "simp lemmas"
         (Meta.Simp.addSimpAttrFromSyntax · simpExtension attr.kind attr.stx)
+      return
+    if attr.name == `norm_cast then
+      additivizeLemmas allDecls "norm_cast lemmas"
+        (Meta.NormCast.addNormCastAttrFromSyntax · attr.kind attr.stx)
       return
     if attr.name == `simps then
       additivizeLemmas allDecls "simps lemmas" (simpsTacFromSyntax · attr.stx)


### PR DESCRIPTION
---

This PR is obsolete if [fvd/to_additive_unfold_aux](https://github.com/leanprover-community/mathlib4/tree/fvd/to_additive_unfold_aux) works well. 
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
