### PR TITLE
[Merged by Bors] - fix: remove an unused import; add a missing docstring bracket

### DIFF
--- a/Mathlib/CategoryTheory/Limits/ConcreteCategory.lean
+++ b/Mathlib/CategoryTheory/Limits/ConcreteCategory.lean
@@ -7,7 +7,6 @@ import Mathlib.CategoryTheory.ConcreteCategory.Basic
 import Mathlib.CategoryTheory.Limits.Preserves.Basic
 import Mathlib.CategoryTheory.Limits.TypesFiltered
 import Mathlib.CategoryTheory.Limits.Yoneda
-import Mathlib.Tactic.ApplyFun
 
 #align_import category_theory.limits.concrete_category from "leanprover-community/mathlib"@"c3019c79074b0619edb4b27553a91b2e82242395"
 
@@ -27,7 +26,7 @@ attribute [local instance] ConcreteCategory.instFunLike ConcreteCategory.hasCoeT
 section Limits
 
 /-- If a functor `G : J ⥤ C` to a concrete category has a limit and that `forget C`
-is corepresentable, then `G ⋙ forget C).sections` is small. -/
+is corepresentable, then `(G ⋙ forget C).sections` is small. -/
 lemma Concrete.small_sections_of_hasLimit
     {C : Type u} [Category.{v} C] [ConcreteCategory.{v} C]
     [(forget C).Corepresentable] {J : Type w} [Category.{t} J] (G : J ⥤ C) [HasLimit G] :


### PR DESCRIPTION
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)

Two unrelated minor fixes which I noticed when reviewing another PR.