### PR TITLE
[Merged by Bors] - feat(Algebra/Algebra/Defs): add missing coe lemmas for algebraMap

### DIFF
--- a/Mathlib/Algebra/Algebra/Defs.lean
+++ b/Mathlib/Algebra/Algebra/Defs.lean
@@ -137,7 +137,7 @@ theorem coe_one : (↑(1 : R) : A) = 1 :=
   map_one (algebraMap R A)
 #align algebra_map.coe_one algebraMap.coe_one
 
-@[simp, norm_cast]
+@[norm_cast]
 theorem coe_natCast (a : ℕ) : (↑(a : R) : A) = a :=
   map_natCast (algebraMap R A) a
 

--- a/Mathlib/Algebra/Algebra/Defs.lean
+++ b/Mathlib/Algebra/Algebra/Defs.lean
@@ -163,6 +163,11 @@ theorem coe_neg (x : R) : (↑(-x : R) : A) = -↑x :=
   map_neg (algebraMap R A) x
 #align algebra_map.coe_neg algebraMap.coe_neg
 
+@[norm_cast]
+theorem coe_sub (a b : R) :
+    (↑(a - b : R) : A) = ↑a - ↑b :=
+  map_sub (algebraMap R A) a b
+
 end CommRingRing
 
 section CommSemiringCommSemiring
@@ -409,5 +414,12 @@ end id
 end Semiring
 
 end Algebra
+
+@[norm_cast]
+theorem algebraMap.coe_smul (A B C : Type*) [SMul A B] [CommSemiring B] [Semiring C] [Algebra B C]
+    [SMul A C] [IsScalarTower A B C] (a : A) (b : B) : (a • b : B) = a • (b : C) := calc
+  ((a • b : B) : C) = (a • b) • 1 := Algebra.algebraMap_eq_smul_one _
+  _ = a • (b • 1) := smul_assoc ..
+  _ = a • (b : C) := congrArg _ (Algebra.algebraMap_eq_smul_one b).symm
 
 assert_not_exists Module.End

--- a/Mathlib/Algebra/Algebra/Defs.lean
+++ b/Mathlib/Algebra/Algebra/Defs.lean
@@ -137,6 +137,10 @@ theorem coe_one : (↑(1 : R) : A) = 1 :=
   map_one (algebraMap R A)
 #align algebra_map.coe_one algebraMap.coe_one
 
+@[simp, norm_cast]
+theorem coe_natCast (a : ℕ) : (↑(a : R) : A) = a :=
+  map_natCast (algebraMap R A) a
+
 @[norm_cast]
 theorem coe_add (a b : R) : (↑(a + b : R) : A) = ↑a + ↑b :=
   map_add (algebraMap R A) a b

--- a/Mathlib/Analysis/RCLike/Basic.lean
+++ b/Mathlib/Analysis/RCLike/Basic.lean
@@ -628,7 +628,7 @@ instance (priority := 100) : CstarRing K where
 
 /-! ### Cast lemmas -/
 
-@[simp, rclike_simps, norm_cast]
+@[rclike_simps, norm_cast]
 theorem ofReal_natCast (n : ℕ) : ((n : ℝ) : K) = n :=
   map_natCast (algebraMap ℝ K) n
 #align is_R_or_C.of_real_nat_cast RCLike.ofReal_natCast


### PR DESCRIPTION
Add lemmas `algebraMap.coe_sub`, `algebraMap.coe_natCast` and `algebraMap.coe_smul`

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
