### PR TITLE
[Merged by Bors] - feat(FieldTheory/IntermediateField): add `restrict`

### DIFF
--- a/Mathlib/FieldTheory/IntermediateField.lean
+++ b/Mathlib/FieldTheory/IntermediateField.lean
@@ -743,6 +743,26 @@ theorem extendScalars_injective :
 
 end ExtendScalars
 
+section RestrictUniverse
+
+variable {F E : IntermediateField K L} (h : F ≤ E)
+
+/--
+If `F ≤ E` are two intermediate fields of `L / K`, then `F` is also an intermediate field of
+`E / K`. It can be viewed as a dual to `IntermediateField.extendScalars`.
+-/
+def restrictUniverse : IntermediateField K E :=
+  (IntermediateField.inclusion h).fieldRange
+
+/--
+`F` is equivalent to `F` as an intermediate field of `E / K`.
+-/
+noncomputable def restrictUniverse_algEquiv :
+    F ≃ₐ[K] ↥(IntermediateField.restrictUniverse h) :=
+  AlgEquiv.ofInjectiveField _
+
+end RestrictUniverse
+
 end Tower
 
 section FiniteDimensional

--- a/Mathlib/FieldTheory/IntermediateField.lean
+++ b/Mathlib/FieldTheory/IntermediateField.lean
@@ -743,25 +743,36 @@ theorem extendScalars_injective :
 
 end ExtendScalars
 
-section RestrictUniverse
+section Restrict
 
 variable {F E : IntermediateField K L} (h : F ≤ E)
 
 /--
 If `F ≤ E` are two intermediate fields of `L / K`, then `F` is also an intermediate field of
-`E / K`. It can be viewed as a dual to `IntermediateField.extendScalars`.
+`E / K`. It is an inverse of `IntermediateField.lift`, and can be viewed as a dual to
+`IntermediateField.extendScalars`.
 -/
-def restrictUniverse : IntermediateField K E :=
+protected def restrict : IntermediateField K E :=
   (IntermediateField.inclusion h).fieldRange
 
 /--
 `F` is equivalent to `F` as an intermediate field of `E / K`.
 -/
-noncomputable def restrictUniverse_algEquiv :
-    F ≃ₐ[K] ↥(IntermediateField.restrictUniverse h) :=
+noncomputable def restrict_algEquiv :
+    F ≃ₐ[K] ↥(IntermediateField.restrict h) :=
   AlgEquiv.ofInjectiveField _
 
-end RestrictUniverse
+@[simp]
+theorem lift_restrict : IntermediateField.lift (IntermediateField.restrict h) = F := by
+  ext
+  rw [← IntermediateField.mem_carrier]
+  simp only [lift, IntermediateField.restrict, toSubalgebra_map, AlgHom.fieldRange_toSubalgebra,
+    Subsemiring.coe_carrier_toSubmonoid, Subalgebra.coe_toSubsemiring, Subalgebra.coe_map, coe_val,
+    AlgHom.coe_range, Set.mem_image, Set.mem_range, Subtype.ext_iff, coe_inclusion, Subtype.exists,
+    exists_prop, exists_eq_right, exists_eq_right_right, and_iff_right_iff_imp]
+  exact fun x ↦ h x
+
+end Restrict
 
 end Tower
 

--- a/Mathlib/FieldTheory/IntermediateField.lean
+++ b/Mathlib/FieldTheory/IntermediateField.lean
@@ -649,12 +649,12 @@ theorem lift_injective (F : IntermediateField K L) : Function.Injective F.lift :
   map_injective F.val
 
 theorem lift_le {F : IntermediateField K L} (E : IntermediateField K F) : lift E ≤ F := by
-  intro _ h
-  obtain ⟨_, _, rfl⟩ := h
-  simp
+  rintro _ ⟨x, _, rfl⟩
+  exact x.2
 
 theorem mem_lift {F : IntermediateField K L} {E : IntermediateField K F} (x : F) :
-    x.1 ∈ lift E ↔ x ∈ E := Subtype.val_injective.mem_set_image
+    x.1 ∈ lift E ↔ x ∈ E :=
+  Subtype.val_injective.mem_set_image
 
 section RestrictScalars
 
@@ -763,11 +763,8 @@ If `F ≤ E` are two intermediate fields of `L / K`, then `F` is also an interme
 def restrict : IntermediateField K E :=
   (IntermediateField.inclusion h).fieldRange
 
-theorem mem_restrict (x : E) : x ∈ restrict h ↔ x.1 ∈ F := by
-  rw [restrict, AlgHom.mem_fieldRange]
-  refine ⟨?_, fun hx ↦ ⟨⟨x.1, hx⟩, rfl⟩⟩
-  rintro ⟨y, rfl⟩
-  exact y.2
+theorem mem_restrict (x : E) : x ∈ restrict h ↔ x.1 ∈ F :=
+  Set.ext_iff.mp (Set.range_inclusion h) x
 
 @[simp]
 theorem lift_restrict : lift (restrict h) = F := by
@@ -775,8 +772,8 @@ theorem lift_restrict : lift (restrict h) = F := by
   refine ⟨fun hx ↦ ?_, fun hx ↦ ?_⟩
   · let y : E := ⟨x, lift_le (restrict h) hx⟩
     exact (mem_restrict h y).1 ((mem_lift y).1 hx)
-  let y : E := ⟨x, h hx⟩
-  exact (mem_lift y).2 ((mem_restrict h y).2 hx)
+  · let y : E := ⟨x, h hx⟩
+    exact (mem_lift y).2 ((mem_restrict h y).2 hx)
 
 /--
 `F` is equivalent to `F` as an intermediate field of `E / K`.

--- a/Mathlib/FieldTheory/IntermediateField.lean
+++ b/Mathlib/FieldTheory/IntermediateField.lean
@@ -648,6 +648,14 @@ instance hasLift {F : IntermediateField K L} :
 theorem lift_injective (F : IntermediateField K L) : Function.Injective F.lift :=
   map_injective F.val
 
+theorem lift_le {F : IntermediateField K L} (E : IntermediateField K F) : lift E ≤ F := by
+  intro _ h
+  obtain ⟨_, _, rfl⟩ := h
+  simp
+
+theorem mem_lift {F : IntermediateField K L} {E : IntermediateField K F} (x : F) :
+    x.1 ∈ lift E ↔ x ∈ E := Subtype.val_injective.mem_set_image
+
 section RestrictScalars
 
 variable (K)
@@ -752,8 +760,23 @@ If `F ≤ E` are two intermediate fields of `L / K`, then `F` is also an interme
 `E / K`. It is an inverse of `IntermediateField.lift`, and can be viewed as a dual to
 `IntermediateField.extendScalars`.
 -/
-protected def restrict : IntermediateField K E :=
+def restrict : IntermediateField K E :=
   (IntermediateField.inclusion h).fieldRange
+
+theorem mem_restrict (x : E) : x ∈ restrict h ↔ x.1 ∈ F := by
+  rw [restrict, AlgHom.mem_fieldRange]
+  refine ⟨?_, fun hx ↦ ⟨⟨x.1, hx⟩, rfl⟩⟩
+  rintro ⟨y, rfl⟩
+  exact y.2
+
+@[simp]
+theorem lift_restrict : lift (restrict h) = F := by
+  ext x
+  refine ⟨fun hx ↦ ?_, fun hx ↦ ?_⟩
+  · let y : E := ⟨x, lift_le (restrict h) hx⟩
+    exact (mem_restrict h y).1 ((mem_lift y).1 hx)
+  let y : E := ⟨x, h hx⟩
+  exact (mem_lift y).2 ((mem_restrict h y).2 hx)
 
 /--
 `F` is equivalent to `F` as an intermediate field of `E / K`.
@@ -761,16 +784,6 @@ protected def restrict : IntermediateField K E :=
 noncomputable def restrict_algEquiv :
     F ≃ₐ[K] ↥(IntermediateField.restrict h) :=
   AlgEquiv.ofInjectiveField _
-
-@[simp]
-theorem lift_restrict : IntermediateField.lift (IntermediateField.restrict h) = F := by
-  ext
-  rw [← IntermediateField.mem_carrier]
-  simp only [lift, IntermediateField.restrict, toSubalgebra_map, AlgHom.fieldRange_toSubalgebra,
-    Subsemiring.coe_carrier_toSubmonoid, Subalgebra.coe_toSubsemiring, Subalgebra.coe_map, coe_val,
-    AlgHom.coe_range, Set.mem_image, Set.mem_range, Subtype.ext_iff, coe_inclusion, Subtype.exists,
-    exists_prop, exists_eq_right, exists_eq_right_right, and_iff_right_iff_imp]
-  exact fun x ↦ h x
 
 end Restrict
 


### PR DESCRIPTION
Add `IntermediateField.restrict`, which restricts the containing field of an intermediate field to another intermediate field which is greater than or equal to it.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
