### PR TITLE
[Merged by Bors] - feat(RingTheory/Valuation/Basic): add lemmas

### DIFF
--- a/Mathlib/RingTheory/Valuation/Basic.lean
+++ b/Mathlib/RingTheory/Valuation/Basic.lean
@@ -293,11 +293,9 @@ theorem map_sub_swap (x y : R) : v (x - y) = v (y - x) :=
   v.toMonoidWithZeroHom.toMonoidHom.map_sub_swap x y
 #align valuation.map_sub_swap Valuation.map_sub_swap
 
-@[simp]
 theorem map_inv {R : Type*} [DivisionRing R] (v : Valuation R Γ₀) : ∀ x, v x⁻¹ = (v x)⁻¹ :=
   map_inv₀ _
 
-@[simp]
 theorem map_div {R : Type*} [DivisionRing R] (v : Valuation R Γ₀) : ∀ x y, v (x / y) = v x / v y :=
   map_div₀ _
 

--- a/Mathlib/RingTheory/Valuation/Basic.lean
+++ b/Mathlib/RingTheory/Valuation/Basic.lean
@@ -293,6 +293,14 @@ theorem map_sub_swap (x y : R) : v (x - y) = v (y - x) :=
   v.toMonoidWithZeroHom.toMonoidHom.map_sub_swap x y
 #align valuation.map_sub_swap Valuation.map_sub_swap
 
+@[simp]
+theorem map_inv {R : Type*} [DivisionRing R] (v : Valuation R Γ₀) : ∀ x, v x⁻¹ = (v x)⁻¹ :=
+  map_inv₀ _
+
+@[simp]
+theorem map_div {R : Type*} [DivisionRing R] (v : Valuation R Γ₀) : ∀ x y, v (x / y) = v x / v y :=
+  map_div₀ _
+
 theorem map_sub (x y : R) : v (x - y) ≤ max (v x) (v y) :=
   calc
     v (x - y) = v (x + -y) := by rw [sub_eq_add_neg]
@@ -808,6 +816,10 @@ theorem map_inv (v : AddValuation K Γ₀) {x : K} : v x⁻¹ = - (v x) :=
 #align add_valuation.map_inv AddValuation.map_inv
 
 @[simp]
+theorem map_div (v : AddValuation K Γ₀) {x y : K} : v (x / y) = (v x) - (v y) :=
+  map_div₀ v.valuation x y
+
+@[simp]
 theorem map_neg (x : R) : v (-x) = v x :=
   Valuation.map_neg v x
 #align add_valuation.map_neg AddValuation.map_neg
@@ -827,6 +839,24 @@ theorem map_le_sub {x y : R} {g : Γ₀} (hx : g ≤ v x) (hy : g ≤ v y) : g �
 theorem map_add_of_distinct_val (h : v x ≠ v y) : v (x + y) = @Min.min Γ₀ _ (v x) (v y) :=
   Valuation.map_add_of_distinct_val v h
 #align add_valuation.map_add_of_distinct_val AddValuation.map_add_of_distinct_val
+
+theorem map_add_eq_of_lt_left {x y : R} (h : v x < v y) :
+    v (x + y) = v x := by
+  rw [map_add_of_distinct_val]
+  simp [le_of_lt, h]
+  simp [ne_of_lt, h]
+
+theorem map_add_eq_of_lt_right {x y : R} (hx : v y < v x) :
+    v (x + y) = v y := add_comm y x ▸ map_add_eq_of_lt_left v hx
+
+theorem map_sub_eq_of_lt_left {x y : R} (hx : v x < v y) :
+    v (x - y) = v x := by
+  rw [sub_eq_add_neg]
+  apply map_add_eq_of_lt_left
+  rwa [map_neg]
+
+theorem map_sub_eq_of_lt_right {x y : R} (hx : v y < v x) :
+    v (x - y) = v y := map_sub_swap v x y ▸ map_sub_eq_of_lt_left v hx
 
 theorem map_eq_of_lt_sub (h : v x < v (y - x)) : v y = v x :=
   Valuation.map_eq_of_sub_lt v h

--- a/Mathlib/RingTheory/Valuation/Basic.lean
+++ b/Mathlib/RingTheory/Valuation/Basic.lean
@@ -822,7 +822,7 @@ theorem map_inv (v : AddValuation K Γ₀) {x : K} : v x⁻¹ = - (v x) :=
 #align add_valuation.map_inv AddValuation.map_inv
 
 @[simp]
-theorem map_div (v : AddValuation K Γ₀) {x y : K} : v (x / y) = (v x) - (v y) :=
+theorem map_div (v : AddValuation K Γ₀) {x y : K} : v (x / y) = v x - v y :=
   map_div₀ v.valuation x y
 
 @[simp]

--- a/Mathlib/RingTheory/Valuation/Basic.lean
+++ b/Mathlib/RingTheory/Valuation/Basic.lean
@@ -336,6 +336,14 @@ theorem map_add_eq_of_lt_left (h : v y < v x) : v (x + y) = v x := by
   rw [add_comm]; exact map_add_eq_of_lt_right _ h
 #align valuation.map_add_eq_of_lt_left Valuation.map_add_eq_of_lt_left
 
+theorem map_sub_eq_of_lt_right (h : v x < v y) : v (x - y) = v y := by
+  rw [sub_eq_add_neg, map_add_eq_of_lt_right, map_neg]
+  rwa [map_neg]
+
+theorem map_sub_eq_of_lt_left (h : v y < v x) : v (x - y) = v x := by
+  rw [sub_eq_add_neg, map_add_eq_of_lt_left]
+  rwa [map_neg]
+
 theorem map_eq_of_sub_lt (h : v (y - x) < v x) : v y = v x := by
   have := Valuation.map_add_of_distinct_val v (ne_of_gt h).symm
   rw [max_eq_right (le_of_lt h)] at this


### PR DESCRIPTION
Add `map_inv` to `Valuation` (previously it existed only for `AddValuation`), and add `map_div` for both. Additionally, add `AddValuation` versions of `map_add_eq_of_lt_right`, `map_add_eq_of_lt_left`, and `map_sub_eq` versions to both `Valuation` and `AddValuation`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
