### PR TITLE
[Merged by Bors] - chore(Data.Complex): add `@[simp]` to `Complex.conj_ofReal`

### DIFF
--- a/Mathlib/Data/Complex/Basic.lean
+++ b/Mathlib/Data/Complex/Basic.lean
@@ -569,6 +569,7 @@ theorem conj_im (z : ℂ) : (conj z).im = -z.im :=
   rfl
 #align complex.conj_im Complex.conj_im
 
+@[simp]
 theorem conj_ofReal (r : ℝ) : conj (r : ℂ) = r :=
   ext_iff.2 <| by simp [star]
 #align complex.conj_of_real Complex.conj_ofReal


### PR DESCRIPTION
This came up in #14601: it seems this `simp` lemma is missing, and as a consequence the `simp` set wouldn't converge.

Zulip discussion: https://leanprover.zulipchat.com/#narrow/stream/287929-mathlib4/topic/Should.20docs.23Complex.2Econj_ofReal.20be.20.60.40.5Bsimp.5D.60.3F


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
