### PR TITLE
[Merged by Bors] - feat(Algebra/Homology): support of embeddings of complex shapes

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -316,6 +316,7 @@ import Mathlib.Algebra.Homology.DerivedCategory.SingleTriangle
 import Mathlib.Algebra.Homology.DifferentialObject
 import Mathlib.Algebra.Homology.Embedding.Basic
 import Mathlib.Algebra.Homology.Embedding.Extend
+import Mathlib.Algebra.Homology.Embedding.IsSupported
 import Mathlib.Algebra.Homology.Embedding.Restriction
 import Mathlib.Algebra.Homology.ExactSequence
 import Mathlib.Algebra.Homology.Factorizations.Basic

--- a/Mathlib/Algebra/Homology/Embedding/Basic.lean
+++ b/Mathlib/Algebra/Homology/Embedding/Basic.lean
@@ -64,6 +64,13 @@ namespace Embedding
 variable {c c'}
 variable (e : Embedding c c')
 
+/-- The opposite embedding in `Embedding c.symm c'.symm` of `e : Embedding c c'`. -/
+@[simps]
+def op : Embedding c.symm c'.symm where
+  f := e.f
+  injective_f := e.injective_f
+  rel h := e.rel h
+
 /-- An embedding of complex shapes `e` satisfies `e.IsRelIff` if the implication
 `e.rel` is an equivalence. -/
 class IsRelIff : Prop where

--- a/Mathlib/Algebra/Homology/Embedding/IsSupported.lean
+++ b/Mathlib/Algebra/Homology/Embedding/IsSupported.lean
@@ -1,0 +1,129 @@
+/-
+Copyright (c) 2024 Joël Riou. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Joël Riou
+-/
+import Mathlib.Algebra.Homology.Embedding.Basic
+import Mathlib.Algebra.Homology.Opposite
+import Mathlib.Algebra.Homology.ShortComplex.HomologicalComplex
+
+/-! # Support of homological complexes
+
+Given an embedding `e : c.Embedding c'` of complex shapes, we say
+that `K : HomologicalComplex C c'` is supported (resp. strictly supported) on `e`
+if `K` is exact in degree `i'` (resp. `K.X i'` is zero) whenever `i'` is
+not of the form `e.f i`. This defines two typeclasses `K.IsSupported e`
+and `K.IsStrictlySupported e`.
+
+We also define predicates `K.IsSupportedOutside e` and `K.IsStrictlySupportedOutside e`
+when the conditions above are satisfied for those `i'` that are of the form `e.f i`.
+(These two predicates are not made typeclasses because in most practical applications,
+they are equivalent to `K.IsSupported e'` or `K.IsStrictlySupported e'` for a
+complementary embedding `e'`.)
+
+-/
+
+open CategoryTheory Limits ZeroObject
+
+variable {ι ι' : Type*} {c : ComplexShape ι} {c' : ComplexShape ι'}
+
+namespace HomologicalComplex
+
+section
+
+variable {C : Type*} [Category C] [HasZeroMorphisms C]
+  (K L : HomologicalComplex C c') (e' : K ≅ L) (e : c.Embedding c')
+
+/-- If `K : HomologicalComplex C c'`, then `K.IsStrictlySupported e` holds for
+an embedding `e : c.Embedding c'` of complex shapes if `K.X i'` is zero
+wheneverm `i'` is not of the form `e.f i` for some `i`.-/
+class IsStrictlySupported : Prop where
+  isZero (i' : ι') (hi' : ∀ i, e.f i ≠ i') : IsZero (K.X i')
+
+lemma isZero_X_of_isStrictlySupported [K.IsStrictlySupported e]
+    (i' : ι') (hi' : ∀ i, e.f i ≠ i') :
+    IsZero (K.X i') :=
+  IsStrictlySupported.isZero i' hi'
+
+variable {K L} in
+lemma isStrictlySupported_of_iso [K.IsStrictlySupported e] : L.IsStrictlySupported e where
+  isZero i' hi' := (K.isZero_X_of_isStrictlySupported e i' hi').of_iso
+    ((eval _ _ i').mapIso e'.symm)
+
+/-- If `K : HomologicalComplex C c'`, then `K.IsStrictlySupported e` holds for
+an embedding `e : c.Embedding c'` of complex shapes if `K` is exact at `i'`
+whenever `i'` is not of the form `e.f i` for some `i`.-/
+class IsSupported : Prop where
+  exactAt (i' : ι') (hi' : ∀ i, e.f i ≠ i') : K.ExactAt i'
+
+lemma exactAt_of_isSupported [K.IsSupported e] (i' : ι') (hi' : ∀ i, e.f i ≠ i') :
+    K.ExactAt i' :=
+  IsSupported.exactAt i' hi'
+
+variable {K L} in
+lemma isSupported_of_iso [K.IsSupported e] : L.IsSupported e where
+  exactAt i' hi' := (K.exactAt_of_isSupported e i' hi').of_iso e'
+
+instance [K.IsStrictlySupported e] : K.IsSupported e where
+  exactAt i' hi' := by
+    rw [exactAt_iff]
+    exact ShortComplex.exact_of_isZero_X₂ _ (K.isZero_X_of_isStrictlySupported e i' hi')
+
+/-- If `K : HomologicalComplex C c'`, then `K.IsStrictlySupportedOutside e` holds for
+an embedding `e : c.Embedding c'` of complex shapes if `K.X (e.f i)` is zero for all `i`. -/
+structure IsStrictlySupportedOutside : Prop where
+  isZero (i : ι) : IsZero (K.X (e.f i))
+
+/-- If `K : HomologicalComplex C c'`, then `K.IsSupportedOutside e` holds for
+an embedding `e : c.Embedding c'` of complex shapes if `K` is exact at `e.f i` for all `i`. -/
+structure IsSupportedOutside : Prop where
+  exactAt (i : ι) : K.ExactAt (e.f i)
+
+variable {K e} in
+lemma IsStrictlySupportedOutside.isSupportedOutside (h : K.IsStrictlySupportedOutside e) :
+    K.IsSupportedOutside e where
+  exactAt i := by
+    rw [exactAt_iff]
+    exact ShortComplex.exact_of_isZero_X₂ _ (h.isZero i)
+
+instance [HasZeroObject C] : (0 : HomologicalComplex C c').IsStrictlySupported e where
+  isZero i _ := (eval _ _ i).map_isZero (Limits.isZero_zero _)
+
+lemma isZero_iff_isStrictlySupported_and_isStrictlySupportedOutside :
+    IsZero K ↔ K.IsStrictlySupported e ∧ K.IsStrictlySupportedOutside e := by
+  constructor
+  · intro hK
+    constructor
+    all_goals
+      constructor
+      intros
+      exact (eval _ _ _).map_isZero hK
+  · rintro ⟨h₁, h₂⟩
+    rw [IsZero.iff_id_eq_zero]
+    ext n
+    apply IsZero.eq_of_src
+    by_cases hn : ∃ i, e.f i = n
+    · obtain ⟨i, rfl⟩ := hn
+      exact h₂.isZero i
+    · exact K.isZero_X_of_isStrictlySupported e _ (by simpa using hn)
+
+instance [K.IsStrictlySupported e] : K.op.IsStrictlySupported e.op where
+  isZero j hj' := (K.isZero_X_of_isStrictlySupported e j hj').op
+
+end
+
+section
+
+variable {C D : Type*} [Category C] [Category D] [HasZeroMorphisms C] [HasZeroMorphisms D]
+  (K : HomologicalComplex C c') (F : C ⥤ D) [F.PreservesZeroMorphisms] (e : c.Embedding c')
+
+instance map_isStrictlySupported [K.IsStrictlySupported e] :
+    ((F.mapHomologicalComplex c').obj K).IsStrictlySupported e where
+  isZero i' hi' := by
+    rw [IsZero.iff_id_eq_zero]
+    dsimp
+    rw [← F.map_id, (K.isZero_X_of_isStrictlySupported e i' hi').eq_of_src (𝟙 _) 0, F.map_zero]
+
+end
+
+end HomologicalComplex

--- a/Mathlib/Algebra/Homology/HomologicalComplex.lean
+++ b/Mathlib/Algebra/Homology/HomologicalComplex.lean
@@ -357,6 +357,8 @@ def eval (i : ι) : HomologicalComplex V c ⥤ V where
   map f := f.f i
 #align homological_complex.eval HomologicalComplex.eval
 
+instance (i : ι) : (eval V c i).PreservesZeroMorphisms where
+
 /-- The functor forgetting the differential in a complex, obtaining a graded object. -/
 @[simps]
 def forget : HomologicalComplex V c ⥤ GradedObject ι V where

--- a/Mathlib/Algebra/Homology/Opposite.lean
+++ b/Mathlib/Algebra/Homology/Opposite.lean
@@ -71,7 +71,7 @@ variable {ι V : Type*} [Category V] {c : ComplexShape ι}
 
 section
 
-variable [Preadditive V]
+variable [HasZeroMorphisms V]
 
 /-- Sends a complex `X` with objects in `V` to the corresponding complex with objects in `Vᵒᵖ`. -/
 @[simps]
@@ -223,14 +223,6 @@ def unopEquivalence : (HomologicalComplex Vᵒᵖ c)ᵒᵖ ≌ HomologicalComple
     exact Category.comp_id _
 #align homological_complex.unop_equivalence HomologicalComplex.unopEquivalence
 
-variable {V c}
-
-instance opFunctor_additive : (@opFunctor ι V _ c _).Additive where
-#align homological_complex.op_functor_additive HomologicalComplex.opFunctor_additive
-
-instance unopFunctor_additive : (@unopFunctor ι V _ c _).Additive where
-#align homological_complex.unop_functor_additive HomologicalComplex.unopFunctor_additive
-
 instance (K : HomologicalComplex V c) (i : ι) [K.HasHomology i] :
     K.op.HasHomology i :=
   (inferInstance : (K.sc i).op.HasHomology)
@@ -238,6 +230,8 @@ instance (K : HomologicalComplex V c) (i : ι) [K.HasHomology i] :
 instance (K : HomologicalComplex Vᵒᵖ c) (i : ι) [K.HasHomology i] :
     K.unop.HasHomology i :=
   (inferInstance : (K.sc i).unop.HasHomology)
+
+variable {V c}
 
 /-- If `K` is a homological complex, then the homology of `K.op` identifies to
 the opposite of the homology of `K`. -/
@@ -250,6 +244,18 @@ then the homology of `K.unop` identifies to the opposite of the homology of `K`.
 def homologyUnop (K : HomologicalComplex Vᵒᵖ c) (i : ι) [K.HasHomology i] :
     K.unop.homology i ≅ unop (K.homology i) :=
   (K.unop.homologyOp i).unop
+
+end
+
+section
+
+variable [Preadditive V]
+
+instance opFunctor_additive : (@opFunctor ι V _ c _).Additive where
+#align homological_complex.op_functor_additive HomologicalComplex.opFunctor_additive
+
+instance unopFunctor_additive : (@unopFunctor ι V _ c _).Additive where
+#align homological_complex.unop_functor_additive HomologicalComplex.unopFunctor_additive
 
 end
 

--- a/Mathlib/Algebra/Homology/ShortComplex/HomologicalComplex.lean
+++ b/Mathlib/Algebra/Homology/ShortComplex/HomologicalComplex.lean
@@ -578,6 +578,12 @@ def ExactAt := (K.sc i).Exact
 lemma exactAt_iff :
     K.ExactAt i ↔ (K.sc i).Exact := by rfl
 
+variable {K i} in
+lemma ExactAt.of_iso (hK : K.ExactAt i) {L : HomologicalComplex C c} (e : K ≅ L) :
+    L.ExactAt i := by
+  rw [exactAt_iff] at hK ⊢
+  exact ShortComplex.exact_of_iso ((shortComplexFunctor C c i).mapIso e) hK
+
 lemma exactAt_iff' (hi : c.prev j = i) (hk : c.next j = k) :
     K.ExactAt j ↔ (K.sc' i j k).Exact :=
   ShortComplex.exact_iff_of_iso (K.isoSc' i j k hi hk)


### PR DESCRIPTION
In this PR, given embeddings of complex shapes, we define predicates for homological complexes that are supported (resp. strictly supported) on/outside this embedding. In future PRs, this shall be used in order to define cochain complexes that are cohomologically `≤` or `≥` a certain integer. 


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
