### PR TITLE
[Merged by Bors] - refactor: give `edist_dist` a default value

### DIFF
--- a/Mathlib/Analysis/Complex/UpperHalfPlane/Metric.lean
+++ b/Mathlib/Analysis/Complex/UpperHalfPlane/Metric.lean
@@ -128,7 +128,6 @@ def metricSpaceAux : MetricSpace ℍ where
   dist_triangle := UpperHalfPlane.dist_triangle
   eq_of_dist_eq_zero {z w} h := by
     simpa [dist_eq, Real.sqrt_eq_zero', (mul_pos z.im_pos w.im_pos).not_le, ext_iff] using h
-  edist_dist _ _ := by exact ENNReal.coe_nnreal_eq _
 #align upper_half_plane.metric_space_aux UpperHalfPlane.metricSpaceAux
 
 open Complex

--- a/Mathlib/Analysis/Convex/Body.lean
+++ b/Mathlib/Analysis/Convex/Body.lean
@@ -196,7 +196,6 @@ noncomputable instance : PseudoMetricSpace (ConvexBody V) where
   dist_self _ := Metric.hausdorffDist_self_zero
   dist_comm _ _ := Metric.hausdorffDist_comm
   dist_triangle K L M := Metric.hausdorffDist_triangle hausdorffEdist_ne_top
-  edist_dist _ _ := by exact ENNReal.coe_nnreal_eq _
 
 @[simp, norm_cast]
 theorem hausdorffDist_coe : Metric.hausdorffDist (K : Set V) L = dist K L :=

--- a/Mathlib/Analysis/Normed/Group/AddTorsor.lean
+++ b/Mathlib/Analysis/Normed/Group/AddTorsor.lean
@@ -206,8 +206,6 @@ is not an instance because it depends on `V` to define a `MetricSpace P`. -/
 def pseudoMetricSpaceOfNormedAddCommGroupOfAddTorsor (V P : Type*) [SeminormedAddCommGroup V]
     [AddTorsor V P] : PseudoMetricSpace P where
   dist x y := ‖(x -ᵥ y : V)‖
-  -- Porting note: `edist_dist` is no longer an `autoParam`
-  edist_dist _ _ := by simp only [← ENNReal.ofReal_eq_coe_nnreal]
   dist_self x := by simp
   dist_comm x y := by simp only [← neg_vsub_eq_vsub_rev y x, norm_neg]
   dist_triangle x y z := by
@@ -221,7 +219,6 @@ is not an instance because it depends on `V` to define a `MetricSpace P`. -/
 def metricSpaceOfNormedAddCommGroupOfAddTorsor (V P : Type*) [NormedAddCommGroup V]
     [AddTorsor V P] : MetricSpace P where
   dist x y := ‖(x -ᵥ y : V)‖
-  edist_dist _ _ := by simp only; rw [ENNReal.ofReal_eq_coe_nnreal]
   dist_self x := by simp
   eq_of_dist_eq_zero h := by simpa using h
   dist_comm x y := by simp only [← neg_vsub_eq_vsub_rev y x, norm_neg]

--- a/Mathlib/InformationTheory/Hamming.lean
+++ b/Mathlib/InformationTheory/Hamming.lean
@@ -425,7 +425,6 @@ instance : PseudoMetricSpace (Hamming β) where
   dist_triangle := by
     push_cast
     exact mod_cast hammingDist_triangle
-  edist_dist _ _ := by exact ENNReal.coe_nnreal_eq _
   toUniformSpace := ⊥
   uniformity_dist := uniformity_dist_of_mem_uniformity _ _ fun s => by
     push_cast

--- a/Mathlib/NumberTheory/Padics/PadicNumbers.lean
+++ b/Mathlib/NumberTheory/Padics/PadicNumbers.lean
@@ -773,8 +773,6 @@ instance metricSpace : MetricSpace ℚ_[p] where
     apply eq_of_sub_eq_zero
     apply padicNormE.eq_zero.1
     exact mod_cast h
-  -- Porting note: added because autoparam was not ported
-  edist_dist := by intros; exact (ENNReal.ofReal_eq_coe_nnreal _).symm
 
 instance : Norm ℚ_[p] :=
   ⟨fun x ↦ padicNormE x⟩

--- a/Mathlib/Topology/Algebra/Valued/NormedValued.lean
+++ b/Mathlib/Topology/Algebra/Valued/NormedValued.lean
@@ -88,7 +88,6 @@ def toNormedField : NormedField L :=
       simp only [← sub_add_sub_cancel x y z]
       exact le_trans (norm_add_le _ _)
         (max_le_add_of_nonneg (norm_nonneg _) (norm_nonneg _))
-    edist_dist := fun x y => by simp only [ENNReal.ofReal_eq_coe_nnreal (norm_nonneg _)]
     eq_of_dist_eq_zero := fun hxy => eq_of_sub_eq_zero (norm_eq_zero hxy)
     dist_eq := fun x y => rfl
     norm_mul' := fun x y => by simp only [norm, ← NNReal.coe_mul, _root_.map_mul]

--- a/Mathlib/Topology/MetricSpace/Basic.lean
+++ b/Mathlib/Topology/MetricSpace/Basic.lean
@@ -280,7 +280,6 @@ instance : MetricSpace Empty where
   dist_self _ := rfl
   dist_comm _ _ := rfl
   edist _ _ := 0
-  edist_dist _ _ := ENNReal.ofReal_zero.symm -- Porting note: should not be needed
   eq_of_dist_eq_zero _ := Subsingleton.elim _ _
   dist_triangle _ _ _ := show (0 : ℝ) ≤ 0 + 0 by rw [add_zero]
   toUniformSpace := inferInstance
@@ -291,7 +290,6 @@ instance : MetricSpace PUnit.{u + 1} where
   dist_self _ := rfl
   dist_comm _ _ := rfl
   edist _ _ := 0
-  edist_dist _ _ := ENNReal.ofReal_zero.symm -- Porting note: should not be needed
   eq_of_dist_eq_zero _ := Subsingleton.elim _ _
   dist_triangle _ _ _ := show (0 : ℝ) ≤ 0 + 0 by rw [add_zero]
   toUniformSpace := inferInstance

--- a/Mathlib/Topology/MetricSpace/Completion.lean
+++ b/Mathlib/Topology/MetricSpace/Completion.lean
@@ -165,8 +165,7 @@ instance instMetricSpace : MetricSpace (Completion α) :=
       dist_triangle := Completion.dist_triangle
       dist := dist
       toUniformSpace := inferInstance
-      uniformity_dist := Completion.uniformity_dist
-      edist_dist := fun x y ↦ rfl } _
+      uniformity_dist := Completion.uniformity_dist } _
 #align uniform_space.completion.metric_space UniformSpace.Completion.instMetricSpace
 
 @[deprecated eq_of_dist_eq_zero (since := "2024-03-10")]

--- a/Mathlib/Topology/MetricSpace/Gluing.lean
+++ b/Mathlib/Topology/MetricSpace/Gluing.lean
@@ -180,7 +180,6 @@ def glueMetricApprox (Φ : Z → X) (Ψ : Z → Y) (ε : ℝ) (ε0 : 0 < ε)
   dist_self := glueDist_self Φ Ψ ε
   dist_comm := glueDist_comm Φ Ψ ε
   dist_triangle := glueDist_triangle Φ Ψ ε H
-  edist_dist _ _ := by exact ENNReal.coe_nnreal_eq _
   eq_of_dist_eq_zero := eq_of_glueDist_eq_zero Φ Ψ ε ε0 _ _
   toUniformSpace := Sum.instUniformSpace
   uniformity_dist := uniformity_dist_of_mem_uniformity _ _ <| Sum.mem_uniformity_iff_glueDist ε0
@@ -278,7 +277,6 @@ def metricSpaceSum : MetricSpace (X ⊕ Y) where
     · exact eq_of_glueDist_eq_zero _ _ _ one_pos _ _ ((Sum.dist_eq_glueDist p q).symm.trans h)
     · exact eq_of_glueDist_eq_zero _ _ _ one_pos _ _ ((Sum.dist_eq_glueDist q p).symm.trans h)
     · rw [eq_of_dist_eq_zero h]
-  edist_dist _ _ := by exact ENNReal.coe_nnreal_eq _
   toUniformSpace := Sum.instUniformSpace
   uniformity_dist := uniformity_dist_of_mem_uniformity _ _ Sum.mem_uniformity
 #align metric.metric_space_sum Metric.metricSpaceSum
@@ -479,7 +477,6 @@ def gluePremetric (hΦ : Isometry Φ) (hΨ : Isometry Ψ) : PseudoMetricSpace (X
   dist_self := glueDist_self Φ Ψ 0
   dist_comm := glueDist_comm Φ Ψ 0
   dist_triangle := glueDist_triangle Φ Ψ 0 fun p q => by rw [hΦ.dist_eq, hΨ.dist_eq]; simp
-  edist_dist _ _ := by exact ENNReal.coe_nnreal_eq _
 #align metric.glue_premetric Metric.gluePremetric
 
 /-- Given two isometric embeddings `Φ : Z → X` and `Ψ : Z → Y`, we define a
@@ -609,7 +606,6 @@ def inductivePremetric (I : ∀ n, Isometry (f n)) : PseudoMetricSpace (Σn, X n
         (dist_triangle _ _ _)
       _ = inductiveLimitDist f x y + inductiveLimitDist f y z := by
         rw [inductiveLimitDist_eq_dist I x y m hx hy, inductiveLimitDist_eq_dist I y z m hy hz]
-  edist_dist _ _ := by exact ENNReal.coe_nnreal_eq _
 #align metric.inductive_premetric Metric.inductivePremetric
 
 attribute [local instance] inductivePremetric

--- a/Mathlib/Topology/MetricSpace/GromovHausdorff.lean
+++ b/Mathlib/Topology/MetricSpace/GromovHausdorff.lean
@@ -414,8 +414,6 @@ theorem ghDist_eq_hausdorffDist (X : Type u) [MetricSpace X] [CompactSpace X] [N
 /-- The Gromov-Hausdorff distance defines a genuine distance on the Gromov-Hausdorff space. -/
 instance : MetricSpace GHSpace where
   dist := dist
-  -- Porting note: why does Lean 4 want this?
-  edist_dist _ _ := by exact ENNReal.coe_nnreal_eq _
   dist_self x := by
     rcases exists_rep x with ⟨y, hy⟩
     refine le_antisymm ?_ ?_

--- a/Mathlib/Topology/MetricSpace/PiNat.lean
+++ b/Mathlib/Topology/MetricSpace/PiNat.lean
@@ -428,7 +428,6 @@ protected def metricSpaceOfDiscreteUniformity {E : ℕ → Type*} [∀ n, Unifor
     dist_comm := PiNat.dist_comm
     dist_self := PiNat.dist_self
     eq_of_dist_eq_zero := PiNat.eq_of_dist_eq_zero _ _
-    edist_dist := fun _ _ ↦ by exact ENNReal.coe_nnreal_eq _
     toUniformSpace := Pi.uniformSpace _
     uniformity_dist := by
       simp [Pi.uniformity, comap_iInf, gt_iff_lt, preimage_setOf_eq, comap_principal,
@@ -879,7 +878,6 @@ protected def metricSpace : MetricSpace (∀ i, F i) where
           min ((1 / 2) ^ encode i : ℝ) (dist (y i) (z i))) :=
         tsum_le_tsum I (dist_summable x z) ((dist_summable x y).add (dist_summable y z))
       _ = dist x y + dist y z := tsum_add (dist_summable x y) (dist_summable y z)
-  edist_dist _ _ := by exact ENNReal.coe_nnreal_eq _
   eq_of_dist_eq_zero hxy := by
     ext1 n
     rw [← dist_le_zero, ← hxy]

--- a/Mathlib/Topology/MetricSpace/Pseudo/Defs.lean
+++ b/Mathlib/Topology/MetricSpace/Pseudo/Defs.lean
@@ -96,7 +96,7 @@ private theorem dist_nonneg' {α} {x y : α} (dist : α → α → ℝ)
     _ = 2 * dist x y := by rw [two_mul, dist_comm]
   nonneg_of_mul_nonneg_right this two_pos
 
-#noalign pseudo_metric_space.edist_dist_tac -- Porting note (#11215): TODO: restore
+#noalign pseudo_metric_space.edist_dist_tac
 
 /-- Pseudo metric and Metric spaces
 
@@ -113,7 +113,8 @@ class PseudoMetricSpace (α : Type u) extends Dist α : Type u where
   dist_comm : ∀ x y : α, dist x y = dist y x
   dist_triangle : ∀ x y z : α, dist x z ≤ dist x y + dist y z
   edist : α → α → ℝ≥0∞ := fun x y => ENNReal.ofNNReal ⟨dist x y, dist_nonneg' _ ‹_› ‹_› ‹_›⟩
-  edist_dist : ∀ x y : α, edist x y = ENNReal.ofReal (dist x y)
+  edist_dist : ∀ x y : α, edist x y = ENNReal.ofReal (dist x y) := by
+    intros x y; exact ENNReal.coe_nnreal_eq _
   -- Porting note (#11215): TODO: add := by _
   toUniformSpace : UniformSpace α := .ofDist dist dist_self dist_comm dist_triangle
   uniformity_dist : 𝓤 α = ⨅ ε > 0, 𝓟 { p : α × α | dist p.1 p.2 < ε } := by intros; rfl
@@ -158,7 +159,6 @@ def PseudoMetricSpace.ofDistTopology {α : Type u} [TopologicalSpace α] (dist :
     dist_self := dist_self
     dist_comm := dist_comm
     dist_triangle := dist_triangle
-    edist_dist := fun x y => by exact ENNReal.coe_nnreal_eq _
     toUniformSpace :=
       (UniformSpace.ofDist dist dist_self dist_comm dist_triangle).replaceTopology <|
         TopologicalSpace.ext_iff.2 fun s ↦ (H s).trans <| forall₂_congr fun x _ ↦
@@ -1341,7 +1341,6 @@ instance Real.pseudoMetricSpace : PseudoMetricSpace ℝ where
   dist_self := by simp [abs_zero]
   dist_comm x y := abs_sub_comm _ _
   dist_triangle x y z := abs_sub_le _ _ _
-  edist_dist := fun x y => by exact ENNReal.coe_nnreal_eq _
 #align real.pseudo_metric_space Real.pseudoMetricSpace
 
 theorem Real.dist_eq (x y : ℝ) : dist x y = |x - y| := rfl

--- a/Mathlib/Topology/MetricSpace/Pseudo/Defs.lean
+++ b/Mathlib/Topology/MetricSpace/Pseudo/Defs.lean
@@ -115,7 +115,6 @@ class PseudoMetricSpace (α : Type u) extends Dist α : Type u where
   edist : α → α → ℝ≥0∞ := fun x y => ENNReal.ofNNReal ⟨dist x y, dist_nonneg' _ ‹_› ‹_› ‹_›⟩
   edist_dist : ∀ x y : α, edist x y = ENNReal.ofReal (dist x y) := by
     intros x y; exact ENNReal.coe_nnreal_eq _
-  -- Porting note (#11215): TODO: add := by _
   toUniformSpace : UniformSpace α := .ofDist dist dist_self dist_comm dist_triangle
   uniformity_dist : 𝓤 α = ⨅ ε > 0, 𝓟 { p : α × α | dist p.1 p.2 < ε } := by intros; rfl
   toBornology : Bornology α := Bornology.ofDist dist dist_comm dist_triangle


### PR DESCRIPTION
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
