### PR TITLE
[Merged by Bors] - feat: prove Fermat's Last Theorem for `n=3`

### DIFF
--- a/Mathlib/NumberTheory/FLT/Three.lean
+++ b/Mathlib/NumberTheory/FLT/Three.lean
@@ -401,10 +401,6 @@ lemma lambda_sq_not_dvd_a_add_eta_sq_mul_b : ¬ λ ^ 2 ∣ (S.a + η ^ 2 * S.b) 
   rw [hk]
   ring
 
-lemma eta_add_one_mul_neg_eta_eq_one : ((η : 𝓞 K) + 1) * (-η) = 1 :=
-  calc ((η : 𝓞 K) + 1) * -η = -(η ^ 2 + η + 1) + 1 := by ring
-  _ = 1 := by rw [eta_sq]; ring
-
 attribute [local instance] IsCyclotomicExtension.Rat.three_pid
 attribute [local instance] UniqueFactorizationMonoid.toGCDMonoid
 

--- a/Mathlib/NumberTheory/FLT/Three.lean
+++ b/Mathlib/NumberTheory/FLT/Three.lean
@@ -669,7 +669,7 @@ private lemma u₄_sq : S.u₄ ^ 2 = 1 := by
 /-- Given `S : Solution`, we have that
 `S.Y ^ 3 + (S.u₄ * S.Z) ^ 3 = S.u₅ * (λ ^ (S.multiplicity - 1) * S.X) ^ 3`. -/
 private lemma formula3 :
-    S.Y ^ 3 + (S.u₄ * S.Z) ^ 3 = S.u₅ * (λ ^ (S.multiplicity - 1) * S.X) ^ 3 := by
+    S.Y ^ 3 + (S.u₄ * S.Z) ^ 3 = S.u₅ * (λ ^ (S.multiplicity - 1) * S.X) ^ 3 :=
   calc S.Y^3+(S.u₄*S.Z)^3=S.Y^3+S.u₄^2*S.u₄*S.Z^3 := by ring
   _ = S.Y^3+S.u₄*S.Z^3 := by simp [← Units.val_pow_eq_pow_val, S.u₄_sq]
   _ = S.u₅*(λ^(S.multiplicity-1)*S.X)^3 := S.formula2

--- a/Mathlib/NumberTheory/FLT/Three.lean
+++ b/Mathlib/NumberTheory/FLT/Three.lean
@@ -33,7 +33,8 @@ The strategy is the following:
   We then prove that, given `S' : Solution'`, there is `S : Solution` such that the multiplicity of
   `λ = ζ₃ - 1` in `c` is the same in `S'` and `S` (see `exists_Solution_of_Solution'`).
   In particular it is enough to prove that no `Solution` exists. The key point is a descent argument
-  on the multiplicity of `λ` in `c`: starting with `S : Solution` we can find `S₁ : Solution` with multiplicity strictly smaller (see `exists_Solution_multiplicity_lt`) and this finishes the proof.
+  on the multiplicity of `λ` in `c`: starting with `S : Solution` we can find `S₁ : Solution` with
+  multiplicity strictly smaller (see `exists_Solution_multiplicity_lt`) and this finishes the proof.
   To construct `S₁` we go through a `Solution'` and then back to a `Solution`. More importantly, we
   cannot control the unit `u`, and this is the reason why we need to consider the generalized
   equation `a ^ 3 + b ^ 3 = u * c ^ 3`. The construction is completely explicit, but it depends

--- a/Mathlib/NumberTheory/FLT/Three.lean
+++ b/Mathlib/NumberTheory/FLT/Three.lean
@@ -14,15 +14,15 @@ import Mathlib.Algebra.Ring.Divisibility.Lemmas
 The goal of this file is to prove Fermat Last theorem in the case `n = 3`.
 
 ## Main results
-* `fermatLastTheoremThree_case1`: the first case of Fermat Last Theorem when `n = 3`:
-  if `a b c : ℤ` are such that `¬ 3 ∣ a * b * c`, then `a ^ 3 + b ^ 3 ≠ c ^ 3`.
 * `fermatLastTheoremThree`: Fermat's Last Theorem for `n = 3`: if `a b c : ℕ` are all non-zero then
   `a ^ 3 + b ^ 3 ≠ c ^ 3`.
 
 ## Implementation details
-We follow the proof in <https://webusers.imj-prg.fr/~marc.hindry/Cours-arith.pdf>, page 43. The
+We follow the proof in <https://webusers.imj-prg.fr/~marc.hindry/Cours-arith.pdf>, page 43.
+
 The strategy is the following:
-* Case 1 is completely elementary and is proved using congruences modulo `9`.
+* The so called "Case 1", when `3 ∣ a * b * c` is completely elementary and is proved using
+  congruences modulo `9`.
 * To prove case 2, we consider the generalized equation `a ^ 3 + b ^ 3 = u * c ^ 3`, where `a`, `b`,
   and `c` are in the cyclotomic ring `ℤ[ζ₃]` (where `ζ₃` is a primitive cube root of unity) and `u`
   is a unit of `ℤ[ζ₃]`. `FermatLastTheoremForThree_of_FermatLastTheoremThreeGen` (whose proof is
@@ -40,6 +40,11 @@ The strategy is the following:
   equation `a ^ 3 + b ^ 3 = u * c ^ 3`. The construction is completely explicit, but it depends
   crucially on `IsCyclotomicExtension.Rat.Three.eq_one_or_neg_one_of_unit_of_congruent`, a special
   case of Kummer's lemma.
+* Note that we don't prove Case 1 for the generalized equation (in particular we don't prove that
+  the generalized equation has no nontrivial solutions). This is because the proof, even if
+  elementary on paper, would be quite annoying to formalize: indeed it involves a lot of explicit
+  computations in `ℤ[ζ₃] / (λ)`: this ring is isomorphic to `ℤ / 9ℤ`, but of course, even if we
+  construct such an isomorphism, tactics like `decide` would not work.
 
 -/
 

--- a/Mathlib/NumberTheory/FLT/Three.lean
+++ b/Mathlib/NumberTheory/FLT/Three.lean
@@ -109,7 +109,7 @@ private lemma fermatLastTheoremThree_of_dvd_a_of_gcd_eq_one_of_case2 {a b c : �
   have h3b : 3 ∣ b := by
     refine three_dvd_b_of_dvd_a_of_gcd_eq_one_of_case2 ha ?_ h3a HF H
     simp only [← Hgcd, gcd_insert, gcd_singleton, id_eq, ← Int.abs_eq_normalize, abs_neg]
-  rcases hx with (hx | hx | hx)
+  rcases hx with hx | hx | hx
   · exact hx ▸ h3a
   · exact hx ▸ h3b
   · simpa [hx] using dvd_c_of_prime_of_dvd_a_of_dvd_b_of_FLT Int.prime_three h3a h3b HF
@@ -130,7 +130,7 @@ theorem fermatLastTheoremThree_of_three_dvd_only_c
   · exact fermatLastTheoremThree_case_1 h1 hF
   rw [(prime_three).dvd_mul, (prime_three).dvd_mul] at h1
   rw [← sub_eq_zero, sub_eq_add_neg, ← (show Odd 3 by decide).neg_pow] at hF
-  rcases h1 with ((h3a | h3b) | h3c)
+  rcases h1 with (h3a | h3b) | h3c
   · refine fermatLastTheoremThree_of_dvd_a_of_gcd_eq_one_of_case2 ha h3a ?_ H hF
     simp only [← Hgcd, Insert.comm, gcd_insert, gcd_singleton, id_eq, ← abs_eq_normalize, abs_neg]
   · rw [add_comm (a ^ 3)] at hF
@@ -234,9 +234,9 @@ lemma a_cube_b_cube_congr_one_or_neg_one :
     λ ^ 4 ∣ S'.a ^ 3 - 1 ∧ λ ^ 4 ∣ S'.b ^ 3 + 1 ∨ λ ^ 4 ∣ S'.a ^ 3 + 1 ∧ λ ^ 4 ∣ S'.b ^ 3 - 1 := by
   obtain ⟨z, hz⟩ := S'.hcdvd
   rcases lambda_pow_four_dvd_cube_sub_one_or_add_one_of_lambda_not_dvd hζ S'.ha with
-    (⟨x, hx⟩ | ⟨x, hx⟩) <;>
+    ⟨x, hx⟩ | ⟨x, hx⟩ <;>
   rcases lambda_pow_four_dvd_cube_sub_one_or_add_one_of_lambda_not_dvd hζ S'.hb with
-    (⟨y, hy⟩ | ⟨y, hy⟩)
+    ⟨y, hy⟩ | ⟨y, hy⟩
   · exfalso
     replace hζ : IsPrimitiveRoot ζ ((3 : ℕ+) ^ 1) := by rwa [pow_one]
     refine hζ.toInteger_sub_one_not_dvd_two (by decide) ⟨S'.u * λ ^ 2 * z ^ 3 - λ ^ 3 * (x + y), ?_⟩
@@ -259,7 +259,7 @@ lemma a_cube_b_cube_congr_one_or_neg_one :
 /-- Given `S' : Solution'`, we have that `λ ^ 4` divides `S'.c ^ 3`. -/
 lemma lambda_pow_four_dvd_c_cube : λ ^ 4 ∣ S'.c ^ 3 := by
   rcases a_cube_b_cube_congr_one_or_neg_one S' with
-    (⟨⟨x, hx⟩, ⟨y, hy⟩⟩ | ⟨⟨x, hx⟩, ⟨y, hy⟩⟩) <;>
+    ⟨⟨x, hx⟩, ⟨y, hy⟩⟩ | ⟨⟨x, hx⟩, ⟨y, hy⟩⟩ <;>
   · refine ⟨S'.u⁻¹ * (x + y), ?_⟩
     symm
     calc _ = S'.u⁻¹ * (λ ^ 4 * x + λ ^ 4 * y) := by ring
@@ -339,7 +339,7 @@ result below). -/
 lemma ex_cube_add_cube_eq_and_isCoprime_and_not_dvd_and_dvd :
     ∃ (a' b' : 𝓞 K), a' ^ 3 + b' ^ 3 = S'.u * S'.c ^ 3 ∧ IsCoprime a' b' ∧ ¬ λ ∣ a' ∧
       ¬ λ ∣ b' ∧ λ ^ 2 ∣ a' + b' := by
-  rcases lambda_sq_dvd_or_dvd_or_dvd S' with (h | h | h)
+  rcases lambda_sq_dvd_or_dvd_or_dvd S' with h | h | h
   · exact ⟨S'.a, S'.b, S'.H, S'.coprime, S'.ha, S'.hb, h⟩
   · refine ⟨S'.a, η * S'.b, ?_, ?_, S'.ha, fun ⟨x, hx⟩ ↦ S'.hb ⟨η ^ 2 * x, ?_⟩, h⟩
     · simp [mul_pow, ← val_pow_eq_pow_val, hζ.toInteger_cube_eq_one, val_one, one_mul, S'.H]

--- a/Mathlib/NumberTheory/FLT/Three.lean
+++ b/Mathlib/NumberTheory/FLT/Three.lean
@@ -705,7 +705,7 @@ lemma Solution'_descent_multiplicity_lt :
 /-- Given any `S : Solution`, there is another `S₁ : Solution` such that
   `S₁.multiplicity < S.multiplicity` -/
 theorem exists_Solution_multiplicity_lt :
-    ∃ (S₁ : Solution hζ), S₁.multiplicity < S.multiplicity := by
+    ∃ S₁ : Solution hζ, S₁.multiplicity < S.multiplicity := by
   obtain ⟨S', hS'⟩ := exists_Solution_of_Solution' (Solution'_descent S)
   exact ⟨S', hS' ▸ Solution'_descent_multiplicity_lt S⟩
 

--- a/Mathlib/NumberTheory/FLT/Three.lean
+++ b/Mathlib/NumberTheory/FLT/Three.lean
@@ -16,9 +16,8 @@ The goal of this file is to prove Fermat Last theorem in the case `n = 3`.
 ## Main results
 * `fermatLastTheoremThree_case1`: the first case of Fermat Last Theorem when `n = 3`:
   if `a b c : ℤ` are such that `¬ 3 ∣ a * b * c`, then `a ^ 3 + b ^ 3 ≠ c ^ 3`.
-
-## TODO
-Prove case 2.
+* `fermatLastTheoremThree`: Fermat's Last Theorem for `n = 3`: if `a b c : ℕ` are all non-zero then
+  `a ^ 3 + b ^ 3 ≠ c ^ 3`.
 
 ## Implementation details
 We follow the proof in <https://webusers.imj-prg.fr/~marc.hindry/Cours-arith.pdf>, page 43. The
@@ -34,10 +33,13 @@ The strategy is the following:
   `S' : Solution'`, there is `S : Solution` such that the multiplicity of `λ = ζ₃ - 1` in `c` is
   the same in `S'` and `S` (see `exists_Solution_of_Solution'`). In particular it is enough to prove
   that no `Solution` exists. The key point is a descent argument on the multiplicity of `λ` in `c`:
-  starting with `S : Solution` we can find `S₁ : Solution` with multiplicity strictly smaller and
-  this finishes the proof. To construct `S₁` we go through a `Solution'` and then back to a
-  `Solution`. More importantly, we cannot control the unit `u`, and this is the reason why we need
-  to consider the generalized equation `a ^ 3 + b ^ 3 = u * c ^ 3`.
+  starting with `S : Solution` we can find `S₁ : Solution` with multiplicity strictly smaller (see
+  `exists_Solution_multiplicity_lt`) and this finishes the proof.
+  To construct `S₁` we go through a `Solution'` and then back to a `Solution`. More importantly, we
+  cannot control the unit `u`, and this is the reason why we need to consider the generalized
+  equation `a ^ 3 + b ^ 3 = u * c ^ 3`. The construction is completely explicit, but it depends
+  crucially on `IsCyclotomicExtension.Rat.Three.eq_one_or_neg_one_of_unit_of_congruent`, a special
+  case of Kummer's lemma.
 
 -/
 
@@ -144,6 +146,8 @@ variable {ζ : K} (hζ : IsPrimitiveRoot ζ (3 : ℕ+))
 
 local notation3 "η" => (IsPrimitiveRoot.isUnit (hζ.toInteger_isPrimitiveRoot) (by decide)).unit
 local notation3 "λ" => hζ.toInteger - 1
+
+suppress_compilation
 
 /-- `FermatLastTheoremForThreeGen` is the statement that `a ^ 3 + b ^ 3 = u * c ^ 3` has no
 nontrivial solutions in `𝓞 K` for all `u : (𝓞 K)ˣ` such that `¬ λ ∣ a`, `¬ λ ∣ b` and `λ ∣ c`.
@@ -289,14 +293,11 @@ lemma Solution.two_le_multiplicity : 2 ≤ S.multiplicity :=
 /-- Given `S' : Solution'`, the key factorization of `S'.a ^ 3 + S'.b ^ 3`. -/
 lemma a_cube_add_b_cube_eq_mul :
     S'.a ^ 3 + S'.b ^ 3 = (S'.a + S'.b) * (S'.a + η * S'.b) * (S'.a + η ^ 2 * S'.b) := by
-  have := hζ.isRoot_cyclotomic (by decide)
-  simp only [PNat.val_ofNat, Polynomial.cyclotomic_three, Polynomial.IsRoot.def,
-    Polynomial.eval_add, Polynomial.eval_pow, Polynomial.eval_X, Polynomial.eval_one] at this
   symm
   calc _ = S'.a^3+S'.a^2*S'.b*(η^2+η+1)+S'.a*S'.b^2*(η^2+η+η^3)+η^3*S'.b^3 := by ring
   _ = S'.a^3+S'.a^2*S'.b*(η^2+η+1)+S'.a*S'.b^2*(η^2+η+1)+S'.b^3 := by
     simp [hζ.toInteger_cube_eq_one]
-  _ = S'.a ^ 3 + S'.b ^ 3 := by ext; simp [this]
+  _ = S'.a ^ 3 + S'.b ^ 3 := by rw [eta_sq]; ring
 
 open PartENat in
 /-- Given `S' : Solution'`, we have that `λ ^ 2` divides one amongst `S'.a + S'.b`,
@@ -446,12 +447,12 @@ lemma associated_of_dvd_a_add_eta_mul_b_of_dvd_a_add_eta_sq_mul_b {p : 𝓞 K} (
   _ = λ := by rw [eta_sq, coe_eta]; ring
 
 /-- Given `S : Solution`, we let `S.y` be any element such that `S.a + η * S.b = λ * S.y` -/
-private noncomputable def y := (lambda_dvd_a_add_eta_mul_b S).choose
+private def y := (lambda_dvd_a_add_eta_mul_b S).choose
 private lemma y_spec : S.a + η * S.b = λ * S.y :=
   (lambda_dvd_a_add_eta_mul_b S).choose_spec
 
 /-- Given `S : Solution`, we let `S.z` be any element such that `S.a + η ^ 2 * S.b = λ * S.z` -/
-private noncomputable def z := (lambda_dvd_a_add_eta_sq_mul_b S).choose
+private def z := (lambda_dvd_a_add_eta_sq_mul_b S).choose
 private lemma z_spec : S.a + η ^ 2 * S.b = λ * S.z :=
   (lambda_dvd_a_add_eta_sq_mul_b S).choose_spec
 
@@ -480,12 +481,12 @@ lemma lambda_pow_dvd_a_add_b : λ ^ (3 * S.multiplicity - 2) ∣ S.a + S.b := by
 
 /-- Given `S : Solution`, we let `S.x` be any element such that
 `S.a + S.b = λ ^ (3*S.multiplicity-2) * S.x` -/
-private noncomputable def x := (lambda_pow_dvd_a_add_b S).choose
+private def x := (lambda_pow_dvd_a_add_b S).choose
 private lemma x_spec : S.a + S.b = λ ^ (3 * S.multiplicity - 2) * S.x :=
   (lambda_pow_dvd_a_add_b S).choose_spec
 
 /-- Given `S : Solution`, we let `S.w` be any element such that `S.c = λ ^ S.multiplicity * S.w` -/
-private noncomputable def w :=
+private def w :=
   (multiplicity.pow_multiplicity_dvd S.toSolution'.multiplicity_lambda_c_finite).choose
 
 private lemma w_spec : S.c = λ ^ S.multiplicity * S.w :=
@@ -565,24 +566,154 @@ private lemma exists_cube_associated :
 
 /-- Given `S : Solution`, we let `S.u₁` and `S.X` be any elements such that
 `S.X ^ 3 * S.u₁ = S.x` -/
-private noncomputable def X := (exists_cube_associated S).1.choose
-private noncomputable def u₁ := (exists_cube_associated S).1.choose_spec.choose
+private def X := (exists_cube_associated S).1.choose
+private def u₁ := (exists_cube_associated S).1.choose_spec.choose
 private lemma X_u₁_spec : S.X ^ 3 * S.u₁ = S.x :=
   (exists_cube_associated S).1.choose_spec.choose_spec
 
 /-- Given `S : Solution`, we let `S.u₂` and `S.Y` be any elements such that
 `S.Y ^ 3 * S.u₂ = S.y` -/
-private noncomputable def Y := (exists_cube_associated S).2.1.choose
-private noncomputable def u₂ := (exists_cube_associated S).2.1.choose_spec.choose
+private def Y := (exists_cube_associated S).2.1.choose
+private def u₂ := (exists_cube_associated S).2.1.choose_spec.choose
 private lemma Y_u₂_spec : S.Y ^ 3 * S.u₂ = S.y :=
   (exists_cube_associated S).2.1.choose_spec.choose_spec
 
 /-- Given `S : Solution`, we let `S.u₃` and `S.Z` be any elements such that
 `S.Z ^ 3 * S.u₃ = S.z` -/
-private noncomputable def Z := (exists_cube_associated S).2.2.choose
-private noncomputable def u₃ :=(exists_cube_associated S).2.2.choose_spec.choose
+private def Z := (exists_cube_associated S).2.2.choose
+private def u₃ :=(exists_cube_associated S).2.2.choose_spec.choose
 private lemma Z_u₃_spec : S.Z ^ 3 * S.u₃ = S.z :=
   (exists_cube_associated S).2.2.choose_spec.choose_spec
+
+private lemma X_ne_zero : S.X ≠ 0 :=
+  fun h ↦ lambda_not_dvd_x S <| by simp [← X_u₁_spec, h]
+
+private lemma lambda_not_dvd_X : ¬ λ ∣ S.X :=
+  fun h ↦ lambda_not_dvd_x S <| X_u₁_spec S ▸ dvd_mul_of_dvd_left (dvd_pow h (by decide)) _
+
+private lemma lambda_not_dvd_Y : ¬ λ ∣ S.Y :=
+  fun h ↦ lambda_not_dvd_y S <| Y_u₂_spec S ▸ dvd_mul_of_dvd_left (dvd_pow h (by decide)) _
+
+private lemma lambda_not_dvd_Z : ¬ λ ∣ S.Z :=
+  fun h ↦ lambda_not_dvd_z S <| Z_u₃_spec S ▸ dvd_mul_of_dvd_left (dvd_pow h (by decide)) _
+
+private lemma isCoprime_Y_Z : IsCoprime S.Y S.Z := by
+  rw [← IsCoprime.pow_iff (m := 3) (n := 3) (by decide) (by decide),
+    ← isCoprime_mul_unit_right_left S.u₂.isUnit, ← isCoprime_mul_unit_right_right S.u₃.isUnit,
+    Y_u₂_spec, Z_u₃_spec]
+  exact isCoprime_y_z S
+
+private lemma formula1 : S.X^3*S.u₁*λ^(3*S.multiplicity-2)+S.Y^3*S.u₂*λ*η+S.Z^3*S.u₃*λ*η^2 = 0 := by
+  rw [X_u₁_spec, Y_u₂_spec, Z_u₃_spec, mul_comm S.x, ← x_spec, mul_comm S.y, ← y_spec, mul_comm S.z,
+    ← z_spec, eta_sq]
+  calc _ = S.a+S.b+η^2*S.b-S.a+η^2*S.b+2*η*S.b+S.b := by ring
+  _ = 0 := by rw [eta_sq]; ring
+
+private def u₄ := η * S.u₃ * S.u₂⁻¹
+private lemma u₄_def : S.u₄ = η * S.u₃ * S.u₂⁻¹ := rfl
+private def u₅ := -η ^ 2 * S.u₁ * S.u₂⁻¹
+private lemma u₅_def : S.u₅ = -η ^ 2 * S.u₁ * S.u₂⁻¹ := rfl
+
+lemma formula2 : S.Y ^ 3 + S.u₄ * S.Z ^ 3 = S.u₅ * (λ ^ (S.multiplicity - 1) * S.X) ^ 3 := by
+  rw [u₅_def, neg_mul, neg_mul, Units.val_neg, neg_mul, eq_neg_iff_add_eq_zero, add_assoc,
+    add_comm (S.u₄ * S.Z ^ 3), ← add_assoc, add_comm (S.Y ^ 3)]
+  apply mul_right_cancel₀ hζ.zeta_sub_one_prime'.ne_zero
+  apply mul_right_cancel₀ S.u₂.isUnit.ne_zero
+  apply mul_right_cancel₀ (Units.isUnit η).ne_zero
+  simp only [zero_mul, add_mul]
+  rw [← formula1 S]
+  have : (S.multiplicity-1)*3+1 = 3*S.multiplicity-2 := by have := S.two_le_multiplicity; omega
+  congrm ?_ + ?_ + ?_
+  · calc _ = S.X^3 *(S.u₂*S.u₂⁻¹)*(η^3*S.u₁)*(λ^((S.multiplicity-1)*3)*λ):= by push_cast; ring
+    _ = S.X^3*S.u₁*λ^(3*S.multiplicity-2) := by simp [hζ.toInteger_cube_eq_one, ← pow_succ, this]
+  · ring
+  · field_simp [u₄_def]
+    ring
+
+private lemma lambda_sq_div_u₅_mul : λ ^ 2 ∣ S.u₅ * (λ ^ (S.multiplicity - 1) * S.X) ^ 3 := by
+  use λ^(3*S.multiplicity-5)*S.u₅*(S.X^3)
+  have : 3*(S.multiplicity-1) = 2+(3*S.multiplicity-5) := by have := S.two_le_multiplicity; omega
+  calc _ = λ^(3*(S.multiplicity-1))*S.u₅*S.X^3 := by ring
+  _ = λ^2*λ^(3*S.multiplicity-5)*S.u₅*S.X^3 := by rw [this, pow_add]
+  _ = λ^2*(λ^(3*S.multiplicity-5)*S.u₅*S.X^3) := by ring
+
+variable [DecidableEq (𝓞 K)]
+
+private lemma u₄_eq_one_or_neg_one : S.u₄ = 1 ∨ S.u₄ = -1 := by
+  have : λ^2 ∣ λ^4  := ⟨λ^2, by ring⟩
+  have h := S.lambda_sq_div_u₅_mul
+  apply IsCyclotomicExtension.Rat.Three.eq_one_or_neg_one_of_unit_of_congruent hζ
+  rcases h with ⟨kX, hkX⟩
+  rcases lambda_pow_four_dvd_cube_sub_one_or_add_one_of_lambda_not_dvd hζ S.lambda_not_dvd_Y with
+    HY | HY <;> rcases lambda_pow_four_dvd_cube_sub_one_or_add_one_of_lambda_not_dvd
+      hζ S.lambda_not_dvd_Z with HZ | HZ <;> replace HY := this.trans HY <;> replace HZ :=
+      this.trans HZ <;> rcases HY with ⟨kY, hkY⟩ <;> rcases HZ with ⟨kZ, hkZ⟩
+  · refine ⟨-1, kX-kY-S.u₄*kZ, ?_⟩
+    rw [show λ^2*(kX-kY-S.u₄*kZ)=λ^2*kX-λ^2*kY-S.u₄*(λ^2*kZ) by ring, ← hkX, ← hkY, ← hkZ,
+      ← S.formula2]
+    ring
+  · refine ⟨1, -kX+kY+S.u₄*kZ, ?_⟩
+    rw [show λ^2*(-kX+kY+S.u₄*kZ)=-(λ^2*kX-λ^2*kY-S.u₄*(λ^2*kZ)) by ring, ← hkX, ← hkY, ← hkZ,
+      ← S.formula2]
+    ring
+  · refine ⟨1, kX-kY-S.u₄*kZ, ?_⟩
+    rw [show λ^2*(kX-kY-S.u₄*kZ)=λ^2*kX-λ^2*kY-S.u₄*(λ^2*kZ) by ring, ← hkX, ← hkY, ← hkZ,
+      ← S.formula2]
+    ring
+  · refine ⟨-1, -kX+kY+S.u₄*kZ, ?_⟩
+    rw [show λ^2*(-kX+kY+S.u₄*kZ)=-(λ^2*kX-λ^2*kY-S.u₄*(λ^2*kZ)) by ring, ← hkX, ← hkY, ← hkZ,
+      ← S.formula2]
+    ring
+
+private lemma u₄_sq : S.u₄ ^ 2 = 1 := by
+  rcases S.u₄_eq_one_or_neg_one with h | h <;> simp [h]
+
+/-- Given `S : Solution`, we have that
+`S.Y ^ 3 + (S.u₄ * S.Z) ^ 3 = S.u₅ * (λ ^ (S.multiplicity - 1) * S.X) ^ 3`. -/
+private lemma formula3 :
+    S.Y ^ 3 + (S.u₄ * S.Z) ^ 3 = S.u₅ * (λ ^ (S.multiplicity - 1) * S.X) ^ 3 := by
+  calc S.Y^3+(S.u₄*S.Z)^3=S.Y^3+S.u₄^2*S.u₄*S.Z^3 := by ring
+  _ = S.Y^3+S.u₄*S.Z^3 := by simp [← Units.val_pow_eq_pow_val, S.u₄_sq]
+  _ = S.u₅*(λ^(S.multiplicity-1)*S.X)^3 := S.formula2
+
+/-- Given `S : Solution`, we construct `S₁ : Solution'`, with smaller multiplicity of `λ` in
+  `c` (see ``). -/
+def Solution'_descent : Solution' hζ where
+  a := S.Y
+  b := S.u₄ * S.Z
+  c := λ ^ (S.multiplicity - 1) * S.X
+  u := S.u₅
+  ha := S.lambda_not_dvd_Y
+  hb := fun h ↦ S.lambda_not_dvd_Z <| Units.dvd_mul_left.1 h
+  hc := fun h ↦ S.X_ne_zero <| by simpa [hζ.zeta_sub_one_prime'.ne_zero] using h
+  coprime := (isCoprime_mul_unit_left_right S.u₄.isUnit _ _).2 S.isCoprime_Y_Z
+  hcdvd := by
+    refine dvd_mul_of_dvd_left (dvd_pow_self _ (fun h ↦ ?_)) _
+    rw [Nat.sub_eq_iff_eq_add (le_trans (by norm_num) S.two_le_multiplicity), zero_add] at h
+    simpa [h] using S.two_le_multiplicity
+  H := formula3 S
+
+/-- We have that `S.Solution'_descent.multiplicity = S.multiplicity - 1`. -/
+lemma Solution'_descent_multiplicity : S.Solution'_descent.multiplicity = S.multiplicity - 1 := by
+  refine (multiplicity.unique' (by simp [Solution'_descent]) (fun h ↦ S.lambda_not_dvd_X ?_)).symm
+  obtain ⟨k, hk : λ^(S.multiplicity-1)*S.X=λ^(S.multiplicity-1+1)*k⟩ := h
+  rw [pow_succ, mul_assoc] at hk
+  simp only [mul_eq_mul_left_iff, pow_eq_zero_iff', hζ.zeta_sub_one_prime'.ne_zero, ne_eq,
+    false_and, or_false] at hk
+  simp [hk]
+
+/-- We have that `S.Solution'_descent.multiplicity < S.multiplicity`. -/
+lemma Solution'_descent_multiplicity_lt :
+    (Solution'_descent S).multiplicity < S.multiplicity := by
+  rw [Solution'_descent_multiplicity S, Nat.sub_one]
+  exact Nat.pred_lt <| by have := S.two_le_multiplicity; omega
+
+/-- Given any `S : Solution`, there is another `S₁ : Solution` such that
+  `S₁.multiplicity < S.multiplicity` -/
+theorem exists_Solution_multiplicity_lt :
+    ∃ (S₁ : Solution hζ), S₁.multiplicity < S.multiplicity := by
+  obtain ⟨S', hS'⟩ := exists_Solution_of_Solution' (Solution'_descent S)
+  exact ⟨S', hS' ▸ Solution'_descent_multiplicity_lt S⟩
 
 end Solution
 
@@ -591,3 +722,28 @@ end FermatLastTheoremForThreeGen
 end eisenstein
 
 end case2
+
+/-- Fermat's Last Theorem for `n = 3`: if `a b c : ℕ` are all non-zero then
+`a ^ 3 + b ^ 3 ≠ c ^ 3`. -/
+theorem fermatLastTheoremThree : FermatLastTheoremFor 3 := by
+  classical
+  let K := CyclotomicField 3 ℚ
+  let hζ := IsCyclotomicExtension.zeta_spec 3 ℚ K
+  have : NumberField K := IsCyclotomicExtension.numberField {3} ℚ _
+  apply FermatLastTheoremForThree_of_FermatLastTheoremThreeGen hζ
+  intro a b c u hc ha hb hcdvd coprime H
+  let S' : FermatLastTheoremForThreeGen.Solution' hζ :=
+  { a := a
+    b := b
+    c := c
+    u := u
+    ha := ha
+    hb := hb
+    hc := hc
+    coprime := coprime
+    hcdvd := hcdvd
+    H := H }
+  obtain ⟨S, -⟩ := FermatLastTheoremForThreeGen.exists_Solution_of_Solution' S'
+  obtain ⟨Smin, hSmin⟩ := S.exists_minimal
+  obtain ⟨Sfin, hSfin⟩ := Smin.exists_Solution_multiplicity_lt
+  linarith [hSmin Sfin]

--- a/Mathlib/NumberTheory/FLT/Three.lean
+++ b/Mathlib/NumberTheory/FLT/Three.lean
@@ -11,7 +11,7 @@ import Mathlib.Algebra.Ring.Divisibility.Lemmas
 
 /-!
 # Fermat Last Theorem in the case `n = 3`
-The goal of this file is to prove Fermat Last Theorem in the case `n = 3`.
+The goal of this file is to prove Fermat's Last Theorem in the case `n = 3`.
 
 ## Main results
 * `fermatLastTheoremThree`: Fermat's Last Theorem for `n = 3`: if `a b c : ℕ` are all non-zero then

--- a/Mathlib/NumberTheory/FLT/Three.lean
+++ b/Mathlib/NumberTheory/FLT/Three.lean
@@ -11,7 +11,7 @@ import Mathlib.Algebra.Ring.Divisibility.Lemmas
 
 /-!
 # Fermat Last Theorem in the case `n = 3`
-The goal of this file is to prove Fermat Last theorem in the case `n = 3`.
+The goal of this file is to prove Fermat Last Theorem in the case `n = 3`.
 
 ## Main results
 * `fermatLastTheoremThree`: Fermat's Last Theorem for `n = 3`: if `a b c : ℕ` are all non-zero then

--- a/Mathlib/NumberTheory/FLT/Three.lean
+++ b/Mathlib/NumberTheory/FLT/Three.lean
@@ -600,8 +600,10 @@ private lemma formula1 : S.X^3*S.u₁*λ^(3*S.multiplicity-2)+S.Y^3*S.u₂*λ*η
   calc _ = S.a+S.b+η^2*S.b-S.a+η^2*S.b+2*η*S.b+S.b := by ring
   _ = 0 := by rw [eta_sq]; ring
 
+/-- Let `u₄ := η * S.u₃ * S.u₂⁻¹` -/
 private noncomputable def u₄ := η * S.u₃ * S.u₂⁻¹
 private lemma u₄_def : S.u₄ = η * S.u₃ * S.u₂⁻¹ := rfl
+/-- Let `u₅ := -η ^ 2 * S.u₁ * S.u₂⁻¹` -/
 private noncomputable def u₅ := -η ^ 2 * S.u₁ * S.u₂⁻¹
 private lemma u₅_def : S.u₅ = -η ^ 2 * S.u₁ * S.u₂⁻¹ := rfl
 

--- a/Mathlib/NumberTheory/FLT/Three.lean
+++ b/Mathlib/NumberTheory/FLT/Three.lean
@@ -607,7 +607,8 @@ private lemma u₄_def : S.u₄ = η * S.u₃ * S.u₂⁻¹ := rfl
 private noncomputable def u₅ := -η ^ 2 * S.u₁ * S.u₂⁻¹
 private lemma u₅_def : S.u₅ = -η ^ 2 * S.u₁ * S.u₂⁻¹ := rfl
 
-private lemma formula2 : S.Y ^ 3 + S.u₄ * S.Z ^ 3 = S.u₅ * (λ ^ (S.multiplicity - 1) * S.X) ^ 3 := by
+private lemma formula2 :
+    S.Y ^ 3 + S.u₄ * S.Z ^ 3 = S.u₅ * (λ ^ (S.multiplicity - 1) * S.X) ^ 3 := by
   rw [u₅_def, neg_mul, neg_mul, Units.val_neg, neg_mul, eq_neg_iff_add_eq_zero, add_assoc,
     add_comm (S.u₄ * S.Z ^ 3), ← add_assoc, add_comm (S.Y ^ 3)]
   apply mul_right_cancel₀ hζ.zeta_sub_one_prime'.ne_zero

--- a/Mathlib/NumberTheory/FLT/Three.lean
+++ b/Mathlib/NumberTheory/FLT/Three.lean
@@ -611,18 +611,20 @@ private lemma u₄_def : S.u₄ = η * S.u₃ * S.u₂⁻¹ := rfl
 private noncomputable def u₅ := -η ^ 2 * S.u₁ * S.u₂⁻¹
 private lemma u₅_def : S.u₅ = -η ^ 2 * S.u₁ * S.u₂⁻¹ := rfl
 
+example (a b : 𝓞 K) (ha : a ≠ 0) (hb : b ≠ 0) : a * b ≠ 0 := by
+  exact mul_ne_zero ha hb
+
 private lemma formula2 :
     S.Y ^ 3 + S.u₄ * S.Z ^ 3 = S.u₅ * (λ ^ (S.multiplicity - 1) * S.X) ^ 3 := by
   rw [u₅_def, neg_mul, neg_mul, Units.val_neg, neg_mul, eq_neg_iff_add_eq_zero, add_assoc,
     add_comm (S.u₄ * S.Z ^ 3), ← add_assoc, add_comm (S.Y ^ 3)]
-  apply mul_right_cancel₀ hζ.zeta_sub_one_prime'.ne_zero
-  apply mul_right_cancel₀ S.u₂.isUnit.ne_zero
-  apply mul_right_cancel₀ (Units.isUnit η).ne_zero
+  apply mul_right_cancel₀ <| mul_ne_zero
+    (mul_ne_zero hζ.zeta_sub_one_prime'.ne_zero S.u₂.isUnit.ne_zero) (Units.isUnit η).ne_zero
   simp only [zero_mul, add_mul]
   rw [← formula1 S]
-  have : (S.multiplicity-1)*3+1 = 3*S.multiplicity-2 := by have := S.two_le_multiplicity; omega
   congrm ?_ + ?_ + ?_
-  · calc _ = S.X^3 *(S.u₂*S.u₂⁻¹)*(η^3*S.u₁)*(λ^((S.multiplicity-1)*3)*λ):= by push_cast; ring
+  · have : (S.multiplicity-1)*3+1 = 3*S.multiplicity-2 := by have := S.two_le_multiplicity; omega
+    calc _ = S.X^3 *(S.u₂*S.u₂⁻¹)*(η^3*S.u₁)*(λ^((S.multiplicity-1)*3)*λ):= by push_cast; ring
     _ = S.X^3*S.u₁*λ^(3*S.multiplicity-2) := by simp [hζ.toInteger_cube_eq_one, ← pow_succ, this]
   · ring
   · field_simp [u₄_def]
@@ -641,26 +643,22 @@ private lemma u₄_eq_one_or_neg_one : S.u₄ = 1 ∨ S.u₄ = -1 := by
   have : λ^2 ∣ λ^4  := ⟨λ^2, by ring⟩
   have h := S.lambda_sq_div_u₅_mul
   apply IsCyclotomicExtension.Rat.Three.eq_one_or_neg_one_of_unit_of_congruent hζ
-  rcases h with ⟨kX, hkX⟩
+  rcases h with ⟨X, hX⟩
   rcases lambda_pow_four_dvd_cube_sub_one_or_add_one_of_lambda_not_dvd hζ S.lambda_not_dvd_Y with
     HY | HY <;> rcases lambda_pow_four_dvd_cube_sub_one_or_add_one_of_lambda_not_dvd
       hζ S.lambda_not_dvd_Z with HZ | HZ <;> replace HY := this.trans HY <;> replace HZ :=
-      this.trans HZ <;> rcases HY with ⟨kY, hkY⟩ <;> rcases HZ with ⟨kZ, hkZ⟩
-  · refine ⟨-1, kX-kY-S.u₄*kZ, ?_⟩
-    rw [show λ^2*(kX-kY-S.u₄*kZ)=λ^2*kX-λ^2*kY-S.u₄*(λ^2*kZ) by ring, ← hkX, ← hkY, ← hkZ,
-      ← S.formula2]
+      this.trans HZ <;> rcases HY with ⟨Y, hY⟩ <;> rcases HZ with ⟨Z, hZ⟩
+  · refine ⟨-1, X-Y-S.u₄*Z, ?_⟩
+    rw [show λ^2*(X-Y-S.u₄*Z)=λ^2*X-λ^2*Y-S.u₄*(λ^2*Z) by ring, ← hX, ← hY, ← hZ, ← formula2]
     ring
-  · refine ⟨1, -kX+kY+S.u₄*kZ, ?_⟩
-    rw [show λ^2*(-kX+kY+S.u₄*kZ)=-(λ^2*kX-λ^2*kY-S.u₄*(λ^2*kZ)) by ring, ← hkX, ← hkY, ← hkZ,
-      ← S.formula2]
+  · refine ⟨1, -X+Y+S.u₄*Z, ?_⟩
+    rw [show λ^2*(-X+Y+S.u₄*Z)=-(λ^2*X-λ^2*Y-S.u₄*(λ^2*Z)) by ring, ← hX, ← hY, ← hZ, ← formula2]
     ring
-  · refine ⟨1, kX-kY-S.u₄*kZ, ?_⟩
-    rw [show λ^2*(kX-kY-S.u₄*kZ)=λ^2*kX-λ^2*kY-S.u₄*(λ^2*kZ) by ring, ← hkX, ← hkY, ← hkZ,
-      ← S.formula2]
+  · refine ⟨1, X-Y-S.u₄*Z, ?_⟩
+    rw [show λ^2*(X-Y-S.u₄*Z)=λ^2*X-λ^2*Y-S.u₄*(λ^2*Z) by ring, ← hX, ← hY, ← hZ, ← formula2]
     ring
-  · refine ⟨-1, -kX+kY+S.u₄*kZ, ?_⟩
-    rw [show λ^2*(-kX+kY+S.u₄*kZ)=-(λ^2*kX-λ^2*kY-S.u₄*(λ^2*kZ)) by ring, ← hkX, ← hkY, ← hkZ,
-      ← S.formula2]
+  · refine ⟨-1, -X+Y+S.u₄*Z, ?_⟩
+    rw [show λ^2*(-X+Y+S.u₄*Z)=-(λ^2*X-λ^2*Y-S.u₄*(λ^2*Z)) by ring, ← hX, ← hY, ← hZ, ← formula2]
     ring
 
 private lemma u₄_sq : S.u₄ ^ 2 = 1 := by

--- a/Mathlib/NumberTheory/FLT/Three.lean
+++ b/Mathlib/NumberTheory/FLT/Three.lean
@@ -147,8 +147,6 @@ variable {ζ : K} (hζ : IsPrimitiveRoot ζ (3 : ℕ+))
 local notation3 "η" => (IsPrimitiveRoot.isUnit (hζ.toInteger_isPrimitiveRoot) (by decide)).unit
 local notation3 "λ" => hζ.toInteger - 1
 
-suppress_compilation
-
 /-- `FermatLastTheoremForThreeGen` is the statement that `a ^ 3 + b ^ 3 = u * c ^ 3` has no
 nontrivial solutions in `𝓞 K` for all `u : (𝓞 K)ˣ` such that `¬ λ ∣ a`, `¬ λ ∣ b` and `λ ∣ c`.
 The reason to consider `FermatLastTheoremForThreeGen` is to make a descent argument working. -/
@@ -443,12 +441,12 @@ lemma associated_of_dvd_a_add_eta_mul_b_of_dvd_a_add_eta_sq_mul_b {p : 𝓞 K} (
   _ = λ := by rw [eta_sq, coe_eta]; ring
 
 /-- Given `S : Solution`, we let `S.y` be any element such that `S.a + η * S.b = λ * S.y` -/
-private def y := (lambda_dvd_a_add_eta_mul_b S).choose
+private noncomputable def y := (lambda_dvd_a_add_eta_mul_b S).choose
 private lemma y_spec : S.a + η * S.b = λ * S.y :=
   (lambda_dvd_a_add_eta_mul_b S).choose_spec
 
 /-- Given `S : Solution`, we let `S.z` be any element such that `S.a + η ^ 2 * S.b = λ * S.z` -/
-private def z := (lambda_dvd_a_add_eta_sq_mul_b S).choose
+private noncomputable def z := (lambda_dvd_a_add_eta_sq_mul_b S).choose
 private lemma z_spec : S.a + η ^ 2 * S.b = λ * S.z :=
   (lambda_dvd_a_add_eta_sq_mul_b S).choose_spec
 
@@ -463,7 +461,7 @@ private lemma lambda_not_dvd_z : ¬ λ ∣ S.z := fun h ↦ by
   exact lambda_sq_not_dvd_a_add_eta_sq_mul_b _ h
 
 /-- We have that `λ ^ (3*S.multiplicity-2)` divides `S.a + S.b`. -/
-lemma lambda_pow_dvd_a_add_b : λ ^ (3 * S.multiplicity - 2) ∣ S.a + S.b := by
+private lemma lambda_pow_dvd_a_add_b : λ ^ (3 * S.multiplicity - 2) ∣ S.a + S.b := by
   have h : λ ^ S.multiplicity ∣ S.c := multiplicity.pow_multiplicity_dvd _
   replace h : (λ ^ multiplicity S) ^ 3 ∣ S.u * S.c ^ 3 := by simp [h]
   rw [← S.H, a_cube_add_b_cube_eq_mul, ← pow_mul, mul_comm, y_spec, z_spec] at h
@@ -477,19 +475,18 @@ lemma lambda_pow_dvd_a_add_b : λ ^ (3 * S.multiplicity - 2) ∣ S.a + S.b := by
 
 /-- Given `S : Solution`, we let `S.x` be any element such that
 `S.a + S.b = λ ^ (3*S.multiplicity-2) * S.x` -/
-private def x := (lambda_pow_dvd_a_add_b S).choose
+private noncomputable def x := (lambda_pow_dvd_a_add_b S).choose
 private lemma x_spec : S.a + S.b = λ ^ (3 * S.multiplicity - 2) * S.x :=
   (lambda_pow_dvd_a_add_b S).choose_spec
 
 /-- Given `S : Solution`, we let `S.w` be any element such that `S.c = λ ^ S.multiplicity * S.w` -/
-private def w :=
+private noncomputable def w :=
   (multiplicity.pow_multiplicity_dvd S.toSolution'.multiplicity_lambda_c_finite).choose
 
 private lemma w_spec : S.c = λ ^ S.multiplicity * S.w :=
   (multiplicity.pow_multiplicity_dvd S.toSolution'.multiplicity_lambda_c_finite).choose_spec
 
-private lemma lambda_not_dvd_w : ¬ λ ∣ S.w := by
-  intro h
+private lemma lambda_not_dvd_w : ¬ λ ∣ S.w := fun h ↦ by
   replace h := mul_dvd_mul_left (λ ^ S.multiplicity) h
   rw [← w_spec] at h
   have hh := multiplicity.is_greatest' S.toSolution'.multiplicity_lambda_c_finite
@@ -562,22 +559,22 @@ private lemma exists_cube_associated :
 
 /-- Given `S : Solution`, we let `S.u₁` and `S.X` be any elements such that
 `S.X ^ 3 * S.u₁ = S.x` -/
-private def X := (exists_cube_associated S).1.choose
-private def u₁ := (exists_cube_associated S).1.choose_spec.choose
+private noncomputable def X := (exists_cube_associated S).1.choose
+private noncomputable def u₁ := (exists_cube_associated S).1.choose_spec.choose
 private lemma X_u₁_spec : S.X ^ 3 * S.u₁ = S.x :=
   (exists_cube_associated S).1.choose_spec.choose_spec
 
 /-- Given `S : Solution`, we let `S.u₂` and `S.Y` be any elements such that
 `S.Y ^ 3 * S.u₂ = S.y` -/
-private def Y := (exists_cube_associated S).2.1.choose
-private def u₂ := (exists_cube_associated S).2.1.choose_spec.choose
+private noncomputable def Y := (exists_cube_associated S).2.1.choose
+private noncomputable def u₂ := (exists_cube_associated S).2.1.choose_spec.choose
 private lemma Y_u₂_spec : S.Y ^ 3 * S.u₂ = S.y :=
   (exists_cube_associated S).2.1.choose_spec.choose_spec
 
 /-- Given `S : Solution`, we let `S.u₃` and `S.Z` be any elements such that
 `S.Z ^ 3 * S.u₃ = S.z` -/
-private def Z := (exists_cube_associated S).2.2.choose
-private def u₃ :=(exists_cube_associated S).2.2.choose_spec.choose
+private noncomputable def Z := (exists_cube_associated S).2.2.choose
+private noncomputable def u₃ :=(exists_cube_associated S).2.2.choose_spec.choose
 private lemma Z_u₃_spec : S.Z ^ 3 * S.u₃ = S.z :=
   (exists_cube_associated S).2.2.choose_spec.choose_spec
 
@@ -605,12 +602,12 @@ private lemma formula1 : S.X^3*S.u₁*λ^(3*S.multiplicity-2)+S.Y^3*S.u₂*λ*η
   calc _ = S.a+S.b+η^2*S.b-S.a+η^2*S.b+2*η*S.b+S.b := by ring
   _ = 0 := by rw [eta_sq]; ring
 
-private def u₄ := η * S.u₃ * S.u₂⁻¹
+private noncomputable def u₄ := η * S.u₃ * S.u₂⁻¹
 private lemma u₄_def : S.u₄ = η * S.u₃ * S.u₂⁻¹ := rfl
-private def u₅ := -η ^ 2 * S.u₁ * S.u₂⁻¹
+private noncomputable def u₅ := -η ^ 2 * S.u₁ * S.u₂⁻¹
 private lemma u₅_def : S.u₅ = -η ^ 2 * S.u₁ * S.u₂⁻¹ := rfl
 
-lemma formula2 : S.Y ^ 3 + S.u₄ * S.Z ^ 3 = S.u₅ * (λ ^ (S.multiplicity - 1) * S.X) ^ 3 := by
+private lemma formula2 : S.Y ^ 3 + S.u₄ * S.Z ^ 3 = S.u₅ * (λ ^ (S.multiplicity - 1) * S.X) ^ 3 := by
   rw [u₅_def, neg_mul, neg_mul, Units.val_neg, neg_mul, eq_neg_iff_add_eq_zero, add_assoc,
     add_comm (S.u₄ * S.Z ^ 3), ← add_assoc, add_comm (S.Y ^ 3)]
   apply mul_right_cancel₀ hζ.zeta_sub_one_prime'.ne_zero
@@ -674,7 +671,7 @@ private lemma formula3 :
 
 /-- Given `S : Solution`, we construct `S₁ : Solution'`, with smaller multiplicity of `λ` in
   `c` (see ``). -/
-def Solution'_descent : Solution' hζ where
+noncomputable def Solution'_descent : Solution' hζ where
   a := S.Y
   b := S.u₄ * S.Z
   c := λ ^ (S.multiplicity - 1) * S.X

--- a/Mathlib/NumberTheory/FLT/Three.lean
+++ b/Mathlib/NumberTheory/FLT/Three.lean
@@ -487,12 +487,10 @@ private lemma w_spec : S.c = λ ^ S.multiplicity * S.w :=
   (multiplicity.pow_multiplicity_dvd S.toSolution'.multiplicity_lambda_c_finite).choose_spec
 
 private lemma lambda_not_dvd_w : ¬ λ ∣ S.w := fun h ↦ by
-  replace h := mul_dvd_mul_left (λ ^ S.multiplicity) h
-  rw [← w_spec] at h
-  have hh := multiplicity.is_greatest' S.toSolution'.multiplicity_lambda_c_finite
-    (lt_add_one S.multiplicity)
-  rw [pow_succ', mul_comm] at hh
-  exact hh h
+  refine multiplicity.is_greatest' S.toSolution'.multiplicity_lambda_c_finite
+    (lt_add_one S.multiplicity) ?_
+  rw [pow_succ', mul_comm]
+  exact S.w_spec ▸ (mul_dvd_mul_left (λ ^ S.multiplicity) h)
 
 private lemma lambda_not_dvd_x : ¬ λ ∣ S.x := fun h ↦ by
   replace h := mul_dvd_mul_left (λ ^ (3 * S.multiplicity - 2)) h

--- a/Mathlib/NumberTheory/FLT/Three.lean
+++ b/Mathlib/NumberTheory/FLT/Three.lean
@@ -28,13 +28,12 @@ The strategy is the following:
   is a unit of `ℤ[ζ₃]`. `FermatLastTheoremForThree_of_FermatLastTheoremThreeGen` (whose proof is
   rather elementary on paper) says that to prove Fermat's last theorem for exponent `3`, it is
   enough to prove that this equation has no solutions such that `c ≠ 0`, `¬ λ ∣ a`, `¬ λ ∣ b`,
-  `λ ∣ c` and `IsCoprime a b`. We call such a tuple a `Solution'`. A `Solution` is the same as a
-  `Solution'` with the additional assumption that `λ ^ 2 ∣ a + b`. We then prove that, given
-  `S' : Solution'`, there is `S : Solution` such that the multiplicity of `λ = ζ₃ - 1` in `c` is
-  the same in `S'` and `S` (see `exists_Solution_of_Solution'`). In particular it is enough to prove
-  that no `Solution` exists. The key point is a descent argument on the multiplicity of `λ` in `c`:
-  starting with `S : Solution` we can find `S₁ : Solution` with multiplicity strictly smaller (see
-  `exists_Solution_multiplicity_lt`) and this finishes the proof.
+  `λ ∣ c` and `IsCoprime a b` (where we set `λ := ζ₃ - 1`). We call such a tuple a `Solution'`.
+  A `Solution` is the same as a `Solution'` with the additional assumption that `λ ^ 2 ∣ a + b`.
+  We then prove that, given `S' : Solution'`, there is `S : Solution` such that the multiplicity of
+  `λ = ζ₃ - 1` in `c` is the same in `S'` and `S` (see `exists_Solution_of_Solution'`).
+  In particular it is enough to prove that no `Solution` exists. The key point is a descent argument
+  on the multiplicity of `λ` in `c`: starting with `S : Solution` we can find `S₁ : Solution` with multiplicity strictly smaller (see `exists_Solution_multiplicity_lt`) and this finishes the proof.
   To construct `S₁` we go through a `Solution'` and then back to a `Solution`. More importantly, we
   cannot control the unit `u`, and this is the reason why we need to consider the generalized
   equation `a ^ 3 + b ^ 3 = u * c ^ 3`. The construction is completely explicit, but it depends
@@ -676,7 +675,7 @@ private lemma formula3 :
   _ = S.u₅*(λ^(S.multiplicity-1)*S.X)^3 := S.formula2
 
 /-- Given `S : Solution`, we construct `S₁ : Solution'`, with smaller multiplicity of `λ` in
-  `c` (see ``). -/
+  `c` (see `Solution'_descent_multiplicity_lt` below.). -/
 noncomputable def Solution'_descent : Solution' hζ where
   a := S.Y
   b := S.u₄ * S.Z


### PR DESCRIPTION
We add `fermatLastTheoremThree`: Fermat's Last Theorem for `n=3`.

From the flt3 project at LFTCM2024.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
