### PR TITLE
[Merged by Bors] - feat(CategoryTheory): Cat-valued functors induced by passing to Over/Under categories

### DIFF
--- a/Mathlib/CategoryTheory/Comma/Over.lean
+++ b/Mathlib/CategoryTheory/Comma/Over.lean
@@ -182,20 +182,82 @@ theorem map_obj_hom : ((map f).obj U).hom = U.hom ≫ f :=
 theorem map_map_left : ((map f).map g).left = g.left :=
   rfl
 #align category_theory.over.map_map_left CategoryTheory.Over.map_map_left
+end
 
-variable (Y)
+section coherences
+/--
+This section proves various equalities between functors that
+demonstrate, for instance, that over categories assemble into a
+functor `mapFunctor : T ⥤ Cat`.
+
+These equalities between functors are then converted to natural
+isomorphisms using `eqToIso`. Such natural isomorphisms could be
+obtained directly using `Iso.refl` but this method will have
+better computational properties, when used, for instance, in
+developing the theory of Beck-Chevalley transformations.
+-/
 
 /-- Mapping by the identity morphism is just the identity functor. -/
-def mapId : map (𝟙 Y) ≅ 𝟭 _ :=
-  NatIso.ofComponents fun X => isoMk (Iso.refl _)
+theorem mapId_eq (Y : T) : map (𝟙 Y) = 𝟭 _ := by
+  fapply Functor.ext
+  · intro x
+    dsimp [Over, Over.map, Comma.mapRight]
+    simp only [Category.comp_id]
+    exact rfl
+  · intros x y u
+    dsimp [Over, Over.map, Comma.mapRight]
+    simp
+
+/-- The natural isomorphism arising from `mapForget_eq`. -/
+def mapId (Y : T) : map (𝟙 Y) ≅ 𝟭 _ := eqToIso (mapId_eq Y)
+--  NatIso.ofComponents fun X => isoMk (Iso.refl _)
 #align category_theory.over.map_id CategoryTheory.Over.mapId
 
+/-- Mapping by `f` and then forgetting is the same as forgetting. -/
+theorem mapForget_eq {X Y : T} (f : X ⟶ Y) :
+    (map f) ⋙ (forget Y) = (forget X) := by
+  fapply Functor.ext
+  · dsimp [Over, Over.map]; intro x; exact rfl
+  · intros x y u; simp
+
+/-- The natural isomorphism arising from `mapForget_eq`. -/
+def mapForget {X Y : T} (f : X ⟶ Y) :
+    (map f) ⋙ (forget Y) ≅ (forget X) := eqToIso (mapForget_eq f)
+
+@[simp]
+theorem eqToHom_left {X : T} {U V : Over X} (e : U = V) :
+    (eqToHom e).left = eqToHom (e ▸ rfl : U.left = V.left) := by
+  subst e; rfl
+
 /-- Mapping by the composite morphism `f ≫ g` is the same as mapping by `f` then by `g`. -/
-def mapComp {Y Z : T} (f : X ⟶ Y) (g : Y ⟶ Z) : map (f ≫ g) ≅ map f ⋙ map g :=
-  NatIso.ofComponents fun X => isoMk (Iso.refl _)
+theorem mapComp_eq {X Y Z : T} (f : X ⟶ Y) (g : Y ⟶ Z) :
+    (map f) ⋙ (map g) = map (f ≫ g) := by
+  fapply Functor.ext
+  · simp [Over.map, Comma.mapRight]
+  · intro U V k
+    ext
+    simp
+
+/-- The natural isomorphism arising from `mapComp_eq`. -/
+def mapComp {X Y Z : T} (f : X ⟶ Y) (g : Y ⟶ Z) :
+    (map f) ⋙ (map g) ≅ map (f ≫ g) := eqToIso (mapComp_eq f g)
+--  NatIso.ofComponents fun X => isoMk (Iso.refl _)
 #align category_theory.over.map_comp CategoryTheory.Over.mapComp
 
-end
+end coherences
+
+-- set_option diagnostics true
+-- def mapFunctor.obj : T → Cat.{(max u₁ v₁) + 1} :=  by
+--   intro X
+--   have := Over X
+--   refine Cat.of ?C
+--   · exact Over X
+
+-- def mapFunctor : T ⥤ Cat where
+--   obj := Over
+--   map := map
+--   map_id := mapId_eq
+--   map_comp := mapComp_eq
 
 instance forget_reflects_iso : (forget X).ReflectsIsomorphisms where
   reflects {Y Z} f t := by
@@ -463,18 +525,60 @@ theorem map_obj_hom : ((map f).obj U).hom = f ≫ U.hom :=
 theorem map_map_right : ((map f).map g).right = g.right :=
   rfl
 #align category_theory.under.map_map_right CategoryTheory.Under.map_map_right
+end
+
+
+section coherences
+/--
+This section proves various equalities between functors that
+demonstrate, for instance, that under categories assemble into a
+functor `mapFunctor : Tᵒᵖ ⥤ Cat`.
+-/
 
 /-- Mapping by the identity morphism is just the identity functor. -/
-def mapId : map (𝟙 Y) ≅ 𝟭 _ :=
-  NatIso.ofComponents fun X => isoMk (Iso.refl _)
+theorem mapId_eq (Y : T) : map (𝟙 Y) = 𝟭 _ := by
+  fapply Functor.ext
+  · intro x
+    dsimp [Under, Under.map, Comma.mapLeft]
+    simp only [Category.id_comp]
+    exact rfl
+  · intros x y u
+    dsimp [Under, Under.map, Comma.mapLeft]
+    simp
+
+/-- Mapping by the identity morphism is just the identity functor. -/
+def mapId (Y : T) : map (𝟙 Y) ≅ 𝟭 _ := eqToIso (mapId_eq Y)
 #align category_theory.under.map_id CategoryTheory.Under.mapId
 
+/-- Mapping by `f` and then forgetting is the same as forgetting. -/
+theorem mapForget_eq {X Y : T} (f : X ⟶ Y) :
+    (map f) ⋙ (forget X) = (forget Y) := by
+  fapply Functor.ext
+  · dsimp [Under, Under.map]; intro x; exact rfl
+  · intros x y u; simp
+
+/-- The natural isomorphism arising from `mapForget_eq`. -/
+def mapForget {X Y : T} (f : X ⟶ Y) :
+    (map f) ⋙ (forget X) ≅ (forget Y) := eqToIso (mapForget_eq f)
+
+@[simp]
+theorem eqToHom_right {X : T} {U V : Under X} (e : U = V) :
+    (eqToHom e).right = eqToHom (e ▸ rfl : U.right = V.right) := by
+  subst e; rfl
+
 /-- Mapping by the composite morphism `f ≫ g` is the same as mapping by `f` then by `g`. -/
-def mapComp {Y Z : T} (f : X ⟶ Y) (g : Y ⟶ Z) : map (f ≫ g) ≅ map g ⋙ map f :=
-  NatIso.ofComponents fun X => isoMk (Iso.refl _)
+theorem mapComp_eq {X Y Z : T} (f : X ⟶ Y) (g : Y ⟶ Z) :
+    (map g) ⋙ (map f) = map (f ≫ g) := by
+  fapply Functor.ext
+  · simp [Under.map, Comma.mapLeft]
+  · intro U V k
+    ext
+    simp
+
+/-- The natural isomorphism arising from `mapComp_eq`. -/def mapComp {Y Z : T} (f : X ⟶ Y) (g : Y ⟶ Z) : map g ⋙ map f ≅ map (f ≫ g) := eqToIso (mapComp_eq f g)
 #align category_theory.under.map_comp CategoryTheory.Under.mapComp
 
-end
+end coherences
 
 instance forget_reflects_iso : (forget X).ReflectsIsomorphisms where
   reflects {Y Z} f t := by

--- a/Mathlib/CategoryTheory/Comma/Over.lean
+++ b/Mathlib/CategoryTheory/Comma/Over.lean
@@ -185,7 +185,7 @@ theorem map_map_left : ((map f).map g).left = g.left :=
 end
 
 section coherences
-/--
+/-!
 This section proves various equalities between functors that
 demonstrate, for instance, that over categories assemble into a
 functor `mapFunctor : T ⥤ Cat`.
@@ -231,7 +231,7 @@ theorem eqToHom_left {X : T} {U V : Over X} (e : U = V) :
 
 /-- Mapping by the composite morphism `f ≫ g` is the same as mapping by `f` then by `g`. -/
 theorem mapComp_eq {X Y Z : T} (f : X ⟶ Y) (g : Y ⟶ Z) :
-    (map f) ⋙ (map g) = map (f ≫ g) := by
+    map (f ≫ g) = (map f) ⋙ (map g) := by
   fapply Functor.ext
   · simp [Over.map, Comma.mapRight]
   · intro U V k
@@ -240,24 +240,17 @@ theorem mapComp_eq {X Y Z : T} (f : X ⟶ Y) (g : Y ⟶ Z) :
 
 /-- The natural isomorphism arising from `mapComp_eq`. -/
 def mapComp {X Y Z : T} (f : X ⟶ Y) (g : Y ⟶ Z) :
-    (map f) ⋙ (map g) ≅ map (f ≫ g) := eqToIso (mapComp_eq f g)
---  NatIso.ofComponents fun X => isoMk (Iso.refl _)
+    map (f ≫ g) ≅ (map f) ⋙ (map g) := eqToIso (mapComp_eq f g)
 #align category_theory.over.map_comp CategoryTheory.Over.mapComp
 
+/-- The functor defined by the over categories.-/
+def mapFunctor : T ⥤ Cat where
+  obj X := Cat.of (Over X)
+  map := map
+  map_id := mapId_eq
+  map_comp := mapComp_eq
+
 end coherences
-
--- set_option diagnostics true
--- def mapFunctor.obj : T → Cat.{(max u₁ v₁) + 1} :=  by
---   intro X
---   have := Over X
---   refine Cat.of ?C
---   · exact Over X
-
--- def mapFunctor : T ⥤ Cat where
---   obj := Over
---   map := map
---   map_id := mapId_eq
---   map_comp := mapComp_eq
 
 instance forget_reflects_iso : (forget X).ReflectsIsomorphisms where
   reflects {Y Z} f t := by
@@ -527,9 +520,8 @@ theorem map_map_right : ((map f).map g).right = g.right :=
 #align category_theory.under.map_map_right CategoryTheory.Under.map_map_right
 end
 
-
 section coherences
-/--
+/-!
 This section proves various equalities between functors that
 demonstrate, for instance, that under categories assemble into a
 functor `mapFunctor : Tᵒᵖ ⥤ Cat`.
@@ -568,15 +560,24 @@ theorem eqToHom_right {X : T} {U V : Under X} (e : U = V) :
 
 /-- Mapping by the composite morphism `f ≫ g` is the same as mapping by `f` then by `g`. -/
 theorem mapComp_eq {X Y Z : T} (f : X ⟶ Y) (g : Y ⟶ Z) :
-    (map g) ⋙ (map f) = map (f ≫ g) := by
+    map (f ≫ g) = (map g) ⋙ (map f) := by
   fapply Functor.ext
   · simp [Under.map, Comma.mapLeft]
   · intro U V k
     ext
     simp
 
-/-- The natural isomorphism arising from `mapComp_eq`. -/def mapComp {Y Z : T} (f : X ⟶ Y) (g : Y ⟶ Z) : map g ⋙ map f ≅ map (f ≫ g) := eqToIso (mapComp_eq f g)
+/-- The natural isomorphism arising from `mapComp_eq`. -/
+def mapComp {Y Z : T} (f : X ⟶ Y) (g : Y ⟶ Z) : map (f ≫ g) ≅ map g ⋙ map f :=
+  eqToIso (mapComp_eq f g)
 #align category_theory.under.map_comp CategoryTheory.Under.mapComp
+
+/-- The functor defined by the under categories.-/
+def mapFunctor : Tᵒᵖ ⥤ Cat where
+  obj X := Cat.of (Under X.unop)
+  map f := map f.unop
+  map_id X := mapId_eq X.unop
+  map_comp f g := mapComp_eq (g.unop) (f.unop)
 
 end coherences
 

--- a/Mathlib/CategoryTheory/Comma/Over.lean
+++ b/Mathlib/CategoryTheory/Comma/Over.lean
@@ -243,6 +243,7 @@ def mapComp {X Y Z : T} (f : X ⟶ Y) (g : Y ⟶ Z) :
     map (f ≫ g) ≅ (map f) ⋙ (map g) := eqToIso (mapComp_eq f g)
 #align category_theory.over.map_comp CategoryTheory.Over.mapComp
 
+variable (T) in
 /-- The functor defined by the over categories.-/
 @[simps] def mapFunctor : T ⥤ Cat where
   obj X := Cat.of (Over X)
@@ -572,8 +573,9 @@ def mapComp {Y Z : T} (f : X ⟶ Y) (g : Y ⟶ Z) : map (f ≫ g) ≅ map g ⋙ 
   eqToIso (mapComp_eq f g)
 #align category_theory.under.map_comp CategoryTheory.Under.mapComp
 
+variable (T) in
 /-- The functor defined by the under categories.-/
-def mapFunctor : Tᵒᵖ ⥤ Cat where
+@[simps] def mapFunctor : Tᵒᵖ  ⥤ Cat where
   obj X := Cat.of (Under X.unop)
   map f := map f.unop
   map_id X := mapId_eq X.unop

--- a/Mathlib/CategoryTheory/Comma/Over.lean
+++ b/Mathlib/CategoryTheory/Comma/Over.lean
@@ -244,7 +244,7 @@ def mapComp {X Y Z : T} (f : X ⟶ Y) (g : Y ⟶ Z) :
 #align category_theory.over.map_comp CategoryTheory.Over.mapComp
 
 /-- The functor defined by the over categories.-/
-def mapFunctor : T ⥤ Cat where
+@[simps] def mapFunctor : T ⥤ Cat where
   obj X := Cat.of (Over X)
   map := map
   map_id := mapId_eq


### PR DESCRIPTION
This PR redefines but does not rename the natural isomorphisms `mapId` and `mapComp` for the composition functors associated to over or under categories. Originally these were defined using `isoRefl`. Now instead these are defined using `eqToIso` applied to equalities between the appropriate functors, which are also added here. These equalities are also used to define functors `T ⥤ Cat` and `Tᵒᵖ ⥤ Cat` sending an object `X` to `Over X` and `Under X` respectively.

---

The advantage of defining the natural isomorphisms this way is that the data is easier to use (read: easier to get rid of) in the context of the Beck-Chevalley isomorphisms using for instance coherences involving Mates. In particular, in a future PR, I plan to redefine the corresponding isomorphisms to the pullback functors as `conjugateEquiv` of the natural isomorphisms here. The reason this is not done now is those definitions are currently in the process of being moved by #14519. I thought it best to keep the two PRs independent, but if there is a better practice please let me know.

Finally, should anything here be tagged with "simp"? I still don't get how that works.

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
