### PR TITLE
[Merged by Bors] - chore: remove unused lemmas about bit0/1

### DIFF
--- a/Mathlib/Data/Int/Cast/Basic.lean
+++ b/Mathlib/Data/Int/Cast/Basic.lean
@@ -125,20 +125,8 @@ theorem cast_sub (m n) : ((m - n : ℤ) : R) = m - n := by
 #align int.cast_sub Int.cast_subₓ
 -- type had `HasLiftT`
 
-section deprecated
-set_option linter.deprecated false
-
-@[norm_cast, deprecated (since := "2022-11-22")]
-theorem cast_bit0 (n : ℤ) : ((bit0 n : ℤ) : R) = bit0 (n : R) :=
-  Int.cast_add _ _
-#align int.cast_bit0 Int.cast_bit0
-
-@[norm_cast, deprecated (since := "2022-11-22")]
-theorem cast_bit1 (n : ℤ) : ((bit1 n : ℤ) : R) = bit1 (n : R) := by
-  rw [bit1, Int.cast_add, Int.cast_one, cast_bit0]; rfl
-#align int.cast_bit1 Int.cast_bit1
-
-end deprecated
+#noalign int.cast_bit0
+#noalign int.cast_bit1
 
 theorem cast_two : ((2 : ℤ) : R) = 2 := cast_ofNat _
 #align int.cast_two Int.cast_two

--- a/Mathlib/Data/Matrix/Basic.lean
+++ b/Mathlib/Data/Matrix/Basic.lean
@@ -619,38 +619,10 @@ instance instAddCommGroupWithOne [AddCommGroupWithOne α] :
   __ := addCommGroup
   __ := instAddGroupWithOne
 
-section Numeral
-
-set_option linter.deprecated false
-
-@[deprecated (since := "2023-04-02"), simp]
-theorem bit0_apply [Add α] (M : Matrix m m α) (i : m) (j : m) : (bit0 M) i j = bit0 (M i j) :=
-  rfl
-#align matrix.bit0_apply Matrix.bit0_apply
-
-variable [AddZeroClass α] [One α]
-
-@[deprecated (since := "2023-04-02")]
-theorem bit1_apply (M : Matrix n n α) (i : n) (j : n) :
-    (bit1 M) i j = if i = j then bit1 (M i j) else bit0 (M i j) := by
-  dsimp [bit1]
-  by_cases h : i = j
-  · subst h
-    simp
-  · simp [h]
-#align matrix.bit1_apply Matrix.bit1_apply
-
-@[deprecated (since := "2023-04-02"), simp]
-theorem bit1_apply_eq (M : Matrix n n α) (i : n) : (bit1 M) i i = bit1 (M i i) := by
-  simp [bit1_apply]
-#align matrix.bit1_apply_eq Matrix.bit1_apply_eq
-
-@[deprecated (since := "2023-04-02"), simp]
-theorem bit1_apply_ne (M : Matrix n n α) {i j : n} (h : i ≠ j) : (bit1 M) i j = bit0 (M i j) := by
-  simp [bit1_apply, h]
-#align matrix.bit1_apply_ne Matrix.bit1_apply_ne
-
-end Numeral
+#noalign matrix.bit0_apply
+#noalign matrix.bit1_apply
+#noalign matrix.bit1_apply_eq
+#noalign matrix.bit1_apply_ne
 
 end Diagonal
 

--- a/Mathlib/Data/Rat/Cast/CharZero.lean
+++ b/Mathlib/Data/Rat/Cast/CharZero.lean
@@ -65,21 +65,8 @@ theorem cast_mul [CharZero α] (m n) : ((m * n : ℚ) : α) = m * n :=
   cast_mul_of_ne_zero (Nat.cast_ne_zero.2 <| ne_of_gt m.pos) (Nat.cast_ne_zero.2 <| ne_of_gt n.pos)
 #align rat.cast_mul Rat.cast_mul
 
-section
-
-set_option linter.deprecated false
-
-@[simp, norm_cast]
-theorem cast_bit0 [CharZero α] (n : ℚ) : ((bit0 n : ℚ) : α) = (bit0 n : α) :=
-  cast_add _ _
-#align rat.cast_bit0 Rat.cast_bit0
-
-@[simp, norm_cast]
-theorem cast_bit1 [CharZero α] (n : ℚ) : ((bit1 n : ℚ) : α) = (bit1 n : α) := by
-  rw [bit1, cast_add, cast_one, cast_bit0]; rfl
-#align rat.cast_bit1 Rat.cast_bit1
-
-end
+#noalign rat.cast_bit0
+#noalign rat.cast_bit1
 
 variable (α)
 variable [CharZero α]

--- a/Mathlib/RingTheory/MvPowerSeries/Basic.lean
+++ b/Mathlib/RingTheory/MvPowerSeries/Basic.lean
@@ -827,19 +827,8 @@ theorem coe_C (a : R) : ((C a : MvPolynomial σ R) : MvPowerSeries σ R) = MvPow
 set_option linter.uppercaseLean3 false in
 #align mv_polynomial.coe_C MvPolynomial.coe_C
 
-set_option linter.deprecated false in
-@[simp, norm_cast]
-theorem coe_bit0 :
-    ((bit0 φ : MvPolynomial σ R) : MvPowerSeries σ R) = bit0 (φ : MvPowerSeries σ R) :=
-  coe_add _ _
-#align mv_polynomial.coe_bit0 MvPolynomial.coe_bit0
-
-set_option linter.deprecated false in
-@[simp, norm_cast]
-theorem coe_bit1 :
-    ((bit1 φ : MvPolynomial σ R) : MvPowerSeries σ R) = bit1 (φ : MvPowerSeries σ R) := by
-  rw [bit1, bit1, coe_add, coe_one, coe_bit0]
-#align mv_polynomial.coe_bit1 MvPolynomial.coe_bit1
+#noalign mv_polynomial.coe_bit0
+#noalign mv_polynomial.coe_bit1
 
 @[simp, norm_cast]
 theorem coe_X (s : σ) : ((X s : MvPolynomial σ R) : MvPowerSeries σ R) = MvPowerSeries.X s :=

--- a/Mathlib/RingTheory/PowerSeries/Basic.lean
+++ b/Mathlib/RingTheory/PowerSeries/Basic.lean
@@ -893,18 +893,8 @@ theorem coe_C (a : R) : ((C a : R[X]) : PowerSeries R) = PowerSeries.C R a := by
 set_option linter.uppercaseLean3 false in
 #align polynomial.coe_C Polynomial.coe_C
 
-
-set_option linter.deprecated false in
-@[simp, norm_cast]
-theorem coe_bit0 : ((bit0 φ : R[X]) : PowerSeries R) = bit0 (φ : PowerSeries R) :=
-  coe_add φ φ
-#align polynomial.coe_bit0 Polynomial.coe_bit0
-
-set_option linter.deprecated false in
-@[simp, norm_cast]
-theorem coe_bit1 : ((bit1 φ : R[X]) : PowerSeries R) = bit1 (φ : PowerSeries R) := by
-  rw [bit1, bit1, coe_add, coe_one, coe_bit0]
-#align polynomial.coe_bit1 Polynomial.coe_bit1
+#noalign polynomial.coe_bit0
+#noalign polynomial.coe_bit1
 
 @[simp, norm_cast]
 theorem coe_X : ((X : R[X]) : PowerSeries R) = PowerSeries.X :=

--- a/Mathlib/SetTheory/Cardinal/Basic.lean
+++ b/Mathlib/SetTheory/Cardinal/Basic.lean
@@ -541,21 +541,8 @@ instance commSemiring : CommSemiring Cardinal.{u} where
   natCast_zero := rfl
   natCast_succ := Cardinal.cast_succ
 
-/-! Porting note (#11229): Deprecated section. Remove. -/
-section deprecated
-set_option linter.deprecated false
-
-@[deprecated (since := "2023-02-11")]
-theorem power_bit0 (a b : Cardinal) : a ^ bit0 b = a ^ b * a ^ b :=
-  power_add
-#align cardinal.power_bit0 Cardinal.power_bit0
-
-@[deprecated (since := "2023-02-11")]
-theorem power_bit1 (a b : Cardinal) : a ^ bit1 b = a ^ b * a ^ b * a := by
-  rw [bit1, ← power_bit0, power_add, power_one]
-#align cardinal.power_bit1 Cardinal.power_bit1
-
-end deprecated
+#noalign cardinal.power_bit0
+#noalign cardinal.power_bit1
 
 @[simp]
 theorem one_power {a : Cardinal} : (1 : Cardinal) ^ a = 1 :=
@@ -621,20 +608,8 @@ theorem lift_mul (a b : Cardinal.{u}) : lift.{v} (a * b) = lift.{v} a * lift.{v}
     mk_congr <| Equiv.ulift.trans (Equiv.prodCongr Equiv.ulift Equiv.ulift).symm
 #align cardinal.lift_mul Cardinal.lift_mul
 
-/-! Porting note (#11229): Deprecated section. Remove. -/
-section deprecated
-set_option linter.deprecated false
-
-@[simp, deprecated (since := "2023-02-11")]
-theorem lift_bit0 (a : Cardinal) : lift.{v} (bit0 a) = bit0 (lift.{v} a) :=
-  lift_add a a
-#align cardinal.lift_bit0 Cardinal.lift_bit0
-
-@[simp, deprecated (since := "2023-02-11")]
-theorem lift_bit1 (a : Cardinal) : lift.{v} (bit1 a) = bit1 (lift.{v} a) := by simp [bit1]
-#align cardinal.lift_bit1 Cardinal.lift_bit1
-
-end deprecated
+#noalign cardinal.lift_bit0
+#noalign cardinal.lift_bit1
 
 -- Porting note: Proof used to be simp, needed to remind simp that 1 + 1 = 2
 theorem lift_two : lift.{u, v} 2 = 2 := by simp [← one_add_one_eq_two]


### PR DESCRIPTION
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
