### PR TITLE
[Merged by Bors] - style: fix some double spaces

### DIFF
--- a/Mathlib/Algebra/Algebra/NonUnitalHom.lean
+++ b/Mathlib/Algebra/Algebra/NonUnitalHom.lean
@@ -167,7 +167,7 @@ variable [NonUnitalNonAssocSemiring C] [DistribMulAction T C]
 -- instance : CoeFun (A →ₙₐ[R] B) fun _ => A → B :=
 --   ⟨toFun⟩
 
-instance  : DFunLike (A →ₛₙₐ[φ] B) A fun _ => B where
+instance : DFunLike (A →ₛₙₐ[φ] B) A fun _ => B where
   coe f := f.toFun
   coe_injective' := by rintro ⟨⟨⟨f, _⟩, _⟩, _⟩ ⟨⟨⟨g, _⟩, _⟩, _⟩ h; congr
 

--- a/Mathlib/Algebra/Algebra/Operations.lean
+++ b/Mathlib/Algebra/Algebra/Operations.lean
@@ -27,7 +27,7 @@ An interface for multiplication and division of sub-R-modules of an R-algebra A 
 
 Let `R` be a commutative ring (or semiring) and let `A` be an `R`-algebra.
 
-* `1 : Submodule R A`       : the R-submodule R of the R-algebra A
+* `1 : Submodule R A`   : the R-submodule R of the R-algebra A
 * `Mul (Submodule R A)` : multiplication of two sub-R-modules M and N of A is defined to be
                               the smallest submodule containing all the products `m * n`.
 * `Div (Submodule R A)` : `I / J` is defined to be the submodule consisting of all `a : A` such

--- a/Mathlib/Algebra/Homology/HomologicalComplex.lean
+++ b/Mathlib/Algebra/Homology/HomologicalComplex.lean
@@ -1061,7 +1061,7 @@ then a function which takes a differential,
 and returns the next object, its differential, and the fact it composes appropriately to zero.
 -/
 def mk' (X₀ X₁ : V) (d : X₀ ⟶ X₁)
-    -- (succ' : ∀  : ΣX₀ X₁ : V, X₀ ⟶ X₁, Σ' (X₂ : V) (d : t.2.1 ⟶ X₂), t.2.2 ≫ d = 0) :
+    -- (succ' : ∀ : ΣX₀ X₁ : V, X₀ ⟶ X₁, Σ' (X₂ : V) (d : t.2.1 ⟶ X₂), t.2.2 ≫ d = 0) :
     (succ' : ∀ {X₀ X₁ : V} (f : X₀ ⟶ X₁), Σ' (X₂ : V) (d : X₁ ⟶ X₂), f ≫ d = 0) :
     CochainComplex V ℕ :=
   mk _ _ _ _ _ (succ' d).2.2 (fun S => succ' S.g)

--- a/Mathlib/Algebra/Homology/ShortComplex/SnakeLemma.lean
+++ b/Mathlib/Algebra/Homology/ShortComplex/SnakeLemma.lean
@@ -78,7 +78,7 @@ structure SnakeInput where
   h₀ : IsLimit (KernelFork.ofι _ w₀₂)
   /-- `L₃` is the cokernel of `v₁₂ : L₁ ⟶ L₂`. -/
   h₃ : IsColimit (CokernelCofork.ofπ _ w₁₃)
-  L₁_exact  : L₁.Exact
+  L₁_exact : L₁.Exact
   epi_L₁_g : Epi L₁.g
   L₂_exact : L₂.Exact
   mono_L₂_f : Mono L₂.f

--- a/Mathlib/Algebra/Module/LocalizedModule.lean
+++ b/Mathlib/Algebra/Module/LocalizedModule.lean
@@ -17,15 +17,15 @@ localize `M` by `S`. This gives us a `Localization S`-module.
 
 ## Main definitions
 
-* `LocalizedModule.r` : the equivalence relation defining this localization, namely
+* `LocalizedModule.r`: the equivalence relation defining this localization, namely
   `(m, s) ≈ (m', s')` if and only if there is some `u : S` such that `u • s' • m = u • s • m'`.
-* `LocalizedModule M S` : the localized module by `S`.
-* `LocalizedModule.mk`  : the canonical map sending `(m, s) : M × S ↦ m/s : LocalizedModule M S`
-* `LocalizedModule.liftOn` : any well defined function `f : M × S → α` respecting `r` descents to
+* `LocalizedModule M S`: the localized module by `S`.
+* `LocalizedModule.mk`: the canonical map sending `(m, s) : M × S ↦ m/s : LocalizedModule M S`
+* `LocalizedModule.liftOn`: any well defined function `f : M × S → α` respecting `r` descents to
   a function `LocalizedModule M S → α`
-* `LocalizedModule.liftOn₂` : any well defined function `f : M × S → M × S → α` respecting `r`
+* `LocalizedModule.liftOn₂`: any well defined function `f : M × S → M × S → α` respecting `r`
   descents to a function `LocalizedModule M S → LocalizedModule M S`
-* `LocalizedModule.mk_add_mk` : in the localized module
+* `LocalizedModule.mk_add_mk`: in the localized module
   `mk m s + mk m' s' = mk (s' • m + s • m') (s * s')`
 * `LocalizedModule.mk_smul_mk` : in the localized module, for any `r : R`, `s t : S`, `m : M`,
   we have `mk r s • mk m t = mk (r • m) (s * t)` where `mk r s : Localization S` is localized ring

--- a/Mathlib/Analysis/NormedSpace/PiTensorProduct/InjectiveSeminorm.lean
+++ b/Mathlib/Analysis/NormedSpace/PiTensorProduct/InjectiveSeminorm.lean
@@ -264,7 +264,7 @@ linear equivalence between `ContinuousMultilinearMap 𝕜 E F` and `(⨂[𝕜] i
 (induced by `PiTensorProduct.lift`). Here we give the upgrade of this equivalence to
 an isometric linear equivalence; in particular, it is a continuous linear equivalence.
 -/
-noncomputable def liftIsometry  : ContinuousMultilinearMap 𝕜 E F ≃ₗᵢ[𝕜] (⨂[𝕜] i, E i) →L[𝕜] F :=
+noncomputable def liftIsometry : ContinuousMultilinearMap 𝕜 E F ≃ₗᵢ[𝕜] (⨂[𝕜] i, E i) →L[𝕜] F :=
   { liftEquiv 𝕜 E F with
     norm_map' := by
       intro f

--- a/Mathlib/CategoryTheory/Limits/Shapes/Countable.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/Countable.lean
@@ -86,7 +86,7 @@ noncomputable def sequentialFunctor_obj : ℕ → J := fun
   | .succ n => (IsCofilteredOrEmpty.cone_objs ((exists_surjective_nat _).choose n)
       (sequentialFunctor_obj n)).choose
 
-theorem sequentialFunctor_map  : Antitone (sequentialFunctor_obj J) :=
+theorem sequentialFunctor_map : Antitone (sequentialFunctor_obj J) :=
   antitone_nat_of_succ_le fun n ↦
     leOfHom (IsCofilteredOrEmpty.cone_objs ((exists_surjective_nat _).choose n)
       (sequentialFunctor_obj J n)).choose_spec.choose_spec.choose

--- a/Mathlib/Combinatorics/SetFamily/FourFunctions.lean
+++ b/Mathlib/Combinatorics/SetFamily/FourFunctions.lean
@@ -109,7 +109,7 @@ lemma collapse_eq (ha : a ∉ s) (𝒜 : Finset (Finset α)) (f : Finset α → 
   rw [collapse, filter_collapse_eq ha]
   split_ifs <;> simp [(ne_of_mem_of_not_mem' (mem_insert_self a s) ha).symm, *]
 
-lemma collapse_of_mem (ha : a ∉ s) (ht : t ∈ 𝒜) (hu  : u ∈ 𝒜) (hts : t = s)
+lemma collapse_of_mem (ha : a ∉ s) (ht : t ∈ 𝒜) (hu : u ∈ 𝒜) (hts : t = s)
     (hus : u = insert a s) : collapse 𝒜 a f s = f t + f u := by
   subst hts; subst hus; simp_rw [collapse_eq ha, if_pos ht, if_pos hu]
 

--- a/Mathlib/Computability/Encoding.lean
+++ b/Mathlib/Computability/Encoding.lean
@@ -19,10 +19,10 @@ It also contains several examples:
 
 ## Examples
 
-- `finEncodingNatBool`   : a binary encoding of ℕ in a simple alphabet.
+- `finEncodingNatBool`  : a binary encoding of ℕ in a simple alphabet.
 - `finEncodingNatΓ'`    : a binary encoding of ℕ in the alphabet used for TM's.
 - `unaryFinEncodingNat` : a unary encoding of ℕ
-- `finEncodingBoolBool`  : an encoding of bool.
+- `finEncodingBoolBool` : an encoding of bool.
 -/
 
 

--- a/Mathlib/Data/Nat/SuccPred.lean
+++ b/Mathlib/Data/Nat/SuccPred.lean
@@ -22,7 +22,7 @@ namespace Nat
 variable {m n : ℕ}
 
 -- so that Lean reads `Nat.succ` through `succ_order.succ`
-@[instance] abbrev instSuccOrder  : SuccOrder ℕ :=
+@[instance] abbrev instSuccOrder : SuccOrder ℕ :=
   SuccOrder.ofSuccLeIff succ Nat.succ_le
 
 -- so that Lean reads `Nat.pred` through `pred_order.pred`

--- a/Mathlib/GroupTheory/PushoutI.lean
+++ b/Mathlib/GroupTheory/PushoutI.lean
@@ -166,7 +166,7 @@ theorem ofCoprodI_of (i : ι) (g : G i) :
 
 theorem induction_on {motive : PushoutI φ → Prop}
     (x : PushoutI φ)
-    (of  : ∀ (i : ι) (g : G i), motive (of i g))
+    (of : ∀ (i : ι) (g : G i), motive (of i g))
     (base : ∀ h, motive (base φ h))
     (mul : ∀ x y, motive x → motive y → motive (x * y)) : motive x := by
   delta PushoutI PushoutI.of PushoutI.base at *

--- a/Mathlib/MeasureTheory/Integral/Bochner.lean
+++ b/Mathlib/MeasureTheory/Integral/Bochner.lean
@@ -124,7 +124,7 @@ Use `isClosed_property` or `DenseRange.induction_on` for this argument.
 
 ## Notations
 
-* `α →ₛ E`  : simple functions (defined in `MeasureTheory/Integration`)
+* `α →ₛ E` : simple functions (defined in `MeasureTheory/Integration`)
 * `α →₁[μ] E` : functions in L1 space, i.e., equivalence classes of integrable functions (defined in
                 `MeasureTheory/LpSpace`)
 * `α →₁ₛ[μ] E` : simple functions in L1 space, i.e., equivalence classes of integrable simple

--- a/Mathlib/RingTheory/FreeCommRing.lean
+++ b/Mathlib/RingTheory/FreeCommRing.lean
@@ -19,9 +19,9 @@ in `α`
 
 ## Main definitions
 
-* `FreeCommRing α`     : the free commutative ring on a type α
+* `FreeCommRing α`   : the free commutative ring on a type α
 * `lift (f : α → R)` : the ring hom `FreeCommRing α →+* R` induced by functoriality from `f`.
-* `map (f : α → β)`      : the ring hom `FreeCommRing α →*+ FreeCommRing β` induced by
+* `map (f : α → β)`  : the ring hom `FreeCommRing α →*+ FreeCommRing β` induced by
                            functoriality from f.
 
 ## Main results

--- a/Mathlib/RingTheory/Polynomial/Eisenstein/IsIntegral.lean
+++ b/Mathlib/RingTheory/Polynomial/Eisenstein/IsIntegral.lean
@@ -89,7 +89,7 @@ theorem cyclotomic_prime_pow_comp_X_add_one_isEisensteinAt [hp : Fact p.Prime] (
       exact (cyclotomic_comp_X_add_one_isEisensteinAt p).mem hi
     · intro i hi
       rw [Ideal.submodule_span_eq, Ideal.mem_span_singleton, ← ZMod.intCast_zmod_eq_zero_iff_dvd,
-        show ↑(_  : ℤ) = Int.castRingHom (ZMod p) _ by rfl, ← coeff_map, map_comp, map_cyclotomic,
+        show ↑(_ : ℤ) = Int.castRingHom (ZMod p) _ by rfl, ← coeff_map, map_comp, map_cyclotomic,
         Polynomial.map_add, map_X, Polynomial.map_one, pow_add, pow_one,
         cyclotomic_mul_prime_dvd_eq_pow, pow_comp, ← ZMod.expand_card, coeff_expand hp.out.pos]
       · simp only [ite_eq_right_iff]
@@ -101,7 +101,7 @@ theorem cyclotomic_prime_pow_comp_X_add_one_isEisensteinAt [hp : Fact p.Prime] (
         rw [hk, mul_comm, Nat.mul_div_cancel _ hp.out.pos]
         replace hn := hn (lt_of_mul_lt_mul_left' hi)
         rw [Ideal.submodule_span_eq, Ideal.mem_span_singleton, ← ZMod.intCast_zmod_eq_zero_iff_dvd,
-           show ↑(_  : ℤ) = Int.castRingHom (ZMod p) _ by rfl, ← coeff_map] at hn
+           show ↑(_ : ℤ) = Int.castRingHom (ZMod p) _ by rfl, ← coeff_map] at hn
         simpa [map_comp] using hn
       · exact ⟨p ^ n, by rw [pow_succ']⟩
   · rw [coeff_zero_eq_eval_zero, eval_comp, cyclotomic_prime_pow_eq_geom_sum hp.out, eval_add,

--- a/Mathlib/SetTheory/Ordinal/FixedPointApproximants.lean
+++ b/Mathlib/SetTheory/Ordinal/FixedPointApproximants.lean
@@ -259,7 +259,7 @@ theorem gfpApprox_ord_eq_gfp : gfpApprox f ⊤ (ord <| succ #α) = gfp f :=
   lfpApprox_ord_eq_lfp (OrderHom.dual f)
 
 /-- Some ordinal approximation of the greatest fixed point is the greatest fixed point. -/
-theorem gfp_mem_range_gfpApprox  : gfp f ∈ Set.range (gfpApprox f ⊤) :=
+theorem gfp_mem_range_gfpApprox : gfp f ∈ Set.range (gfpApprox f ⊤) :=
   lfp_mem_range_lfpApprox (OrderHom.dual f)
 
 end OrdinalApprox

--- a/Mathlib/Tactic/FunProp/Theorems.lean
+++ b/Mathlib/Tactic/FunProp/Theorems.lean
@@ -180,7 +180,7 @@ structure FunctionTheorem where
   /-- function name -/
   funOrigin   : Origin
   /-- array of argument indices about which this theorem is about -/
-  mainArgs  : Array Nat
+  mainArgs    : Array Nat
   /-- total number of arguments applied to the function  -/
   appliedArgs : Nat
   /-- priority  -/

--- a/Mathlib/Tactic/FunProp/Types.lean
+++ b/Mathlib/Tactic/FunProp/Types.lean
@@ -91,7 +91,7 @@ deriving Inhabited
 structure State where
   /-- Simp's cache is used as the `funProp` tactic is designed to be used inside of simp and utilize
   its cache -/
-  cache        : Simp.Cache := {}
+  cache : Simp.Cache := {}
   /-- Count the number of steps and stop when maxSteps is reached. -/
   numSteps := 0
   /-- Log progress and failures messages that should be displayed to the user at the end. -/

--- a/Mathlib/Tactic/Linarith/Frontend.lean
+++ b/Mathlib/Tactic/Linarith/Frontend.lean
@@ -382,7 +382,7 @@ goals over arbitrary types that instantiate `LinearOrderedCommRing`.
 An example:
 ```lean
 example (x y z : ℚ) (h1 : 2*x < 3*y) (h2 : -4*x + 2*z < 0)
-        (h3 : 12*y - 4* z < 0)  : False := by
+        (h3 : 12*y - 4* z < 0) : False := by
   linarith
 ```
 

--- a/Mathlib/Tactic/NormNum/Core.lean
+++ b/Mathlib/Tactic/NormNum/Core.lean
@@ -56,9 +56,9 @@ abbrev Entry := Array (Array DiscrTree.Key) × Name
 /-- The state of the `norm_num` extension environment -/
 structure NormNums where
   /-- The tree of `norm_num` extensions. -/
-  tree   : DiscrTree NormNumExt := {}
+  tree : DiscrTree NormNumExt := {}
   /-- Erased `norm_num`s. -/
-  erased  : PHashSet Name := {}
+  erased : PHashSet Name := {}
   deriving Inhabited
 
 /-- Configuration for `DiscrTree`. -/

--- a/Mathlib/Topology/Category/Stonean/Limits.lean
+++ b/Mathlib/Topology/Category/Stonean/Limits.lean
@@ -248,7 +248,7 @@ lemma pullback.hom_ext {X Y Z W : Stonean} (f : X ⟶ Z) {i : Y ⟶ Z} (hi : Ope
   exact hfst
 
 /-- The explicit pullback cone is a limit cone. -/
-def pullback.isLimit  : IsLimit (pullback.cone f hi) :=
+def pullback.isLimit : IsLimit (pullback.cone f hi) :=
   Limits.PullbackCone.isLimitAux _
     (fun s => pullback.lift f hi s.fst s.snd s.condition)
     (fun _ => pullback.lift_fst _ _ _ _ _)


### PR DESCRIPTION
All remaining occurrences of `  : ` are about manually aligning things. This PR also found a few instances where this alignment was broken, and either removes the double spaces or restores the alignment.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
