### PR TITLE
[Merged by Bors] - chore(Logic/Equiv/Fin): Tidy tuple equivalences

### DIFF
--- a/Archive/Wiedijk100Theorems/CubingACube.lean
+++ b/Archive/Wiedijk100Theorems/CubingACube.lean
@@ -181,7 +181,7 @@ theorem shiftUp_bottom_subset_bottoms (hc : (cs i).xm ≠ 1) :
     (cs i).shiftUp.bottom ⊆ ⋃ i : ι, (cs i).bottom := by
   intro p hp; cases' hp with hp0 hps; rw [tail_shiftUp] at hps
   have : p ∈ (unitCube : Cube (n + 1)).toSet := by
-    simp only [toSet, forall_fin_succ, hp0, side_unitCube, mem_setOf_eq, mem_Ico, head_shiftUp]
+    simp only [toSet, forall_iff_succ, hp0, side_unitCube, mem_setOf_eq, mem_Ico, head_shiftUp]
     refine ⟨⟨?_, ?_⟩, ?_⟩
     · rw [← zero_add (0 : ℝ)]; apply add_le_add
       · apply zero_le_b h
@@ -225,7 +225,7 @@ theorem valley_unitCube [Nontrivial ι] (h : Correct cs) : Valley cs unitCube :=
     intro h0 hv
     have : v ∈ (unitCube : Cube (n + 1)).toSet := by
       dsimp only [toSet, unitCube, mem_setOf_eq]
-      rw [forall_fin_succ, h0]; constructor
+      rw [forall_iff_succ, h0]; constructor
       · norm_num [side, unitCube]
       · exact hv
     rw [← h.2, mem_iUnion] at this; rcases this with ⟨i, hi⟩
@@ -408,14 +408,14 @@ theorem mi_not_onBoundary (j : Fin n) : ¬OnBoundary (mi_mem_bcubes : mi h v ∈
   have i'_i'' : i' ≠ i'' := by
     rintro ⟨⟩
     have : (cs i).b ∈ (cs i').toSet := by
-      simp only [toSet, forall_fin_succ, hi.1, bottom_mem_side h2i', true_and_iff, mem_setOf_eq]
+      simp only [toSet, forall_iff_succ, hi.1, bottom_mem_side h2i', true_and_iff, mem_setOf_eq]
       intro j₂; by_cases hj₂ : j₂ = j
       · simpa [p', side_tail, hj'.symm, hj₂] using hi''.2 j
       · simpa [p, hj₂] using hi'.2 j₂
     apply not_disjoint_iff.mpr ⟨(cs i).b, (cs i).b_mem_toSet, this⟩ (h.1 i_i')
   have i_i'' : i ≠ i'' := by intro h; induction h; simpa [p', hx'.2] using hi''.2 j'
   apply Not.elim _ (h.1 i'_i'')
-  simp_rw [onFun, comp, toSet_disjoint, not_exists, not_disjoint_iff, forall_fin_succ]
+  simp_rw [onFun, comp, toSet_disjoint, not_exists, not_disjoint_iff, forall_iff_succ]
   refine ⟨⟨c.b 0, bottom_mem_side h2i', bottom_mem_side h2i''⟩, ?_⟩
   intro j₂
   by_cases hj₂ : j₂ = j
@@ -480,9 +480,9 @@ theorem valley_mi : Valley cs (cs (mi h v)).shiftUp := by
     have h3i'' : (cs i).w < (cs i'').w := by
       apply mi_strict_minimal _ h2i''; rintro rfl; apply h2p3; convert hi''.2
     let p' := @cons n (fun _ => ℝ) (cs i).xm p3
-    have hp' : p' ∈ (cs i').toSet := by simpa [p', toSet, forall_fin_succ, hi'.symm] using h1p3
+    have hp' : p' ∈ (cs i').toSet := by simpa [p', toSet, forall_iff_succ, hi'.symm] using h1p3
     have h2p' : p' ∈ (cs i'').toSet := by
-      simp only [p', toSet, forall_fin_succ, cons_succ, cons_zero, mem_setOf_eq]
+      simp only [p', toSet, forall_iff_succ, cons_succ, cons_zero, mem_setOf_eq]
       refine ⟨?_, by simpa [toSet] using hi''.2⟩
       have : (cs i).b 0 = (cs i'').b 0 := by rw [hi.1, h2i''.1]
       simp [side, hw', xm, this, h3i'']

--- a/Mathlib/Algebra/MvPolynomial/Equiv.lean
+++ b/Mathlib/Algebra/MvPolynomial/Equiv.lean
@@ -377,7 +377,7 @@ theorem eval_eq_eval_mv_eval' (s : Fin n → R) (y : R) (f : MvPolynomial (Fin (
       (Polynomial.aeval y).comp (φ.comp (finSuccEquiv R n).toAlgHom) f
   congr 2
   apply MvPolynomial.algHom_ext
-  rw [Fin.forall_fin_succ]
+  rw [Fin.forall_iff_succ]
   simp only [φ, aeval_X, Fin.cons_zero, AlgEquiv.toAlgHom_eq_coe, AlgHom.coe_comp,
     Polynomial.coe_aeval_eq_eval, Polynomial.map_C, AlgHom.coe_mk, RingHom.toFun_eq_coe,
     Polynomial.coe_mapRingHom, comp_apply, finSuccEquiv_apply, eval₂Hom_X',

--- a/Mathlib/CategoryTheory/Monoidal/Types/Basic.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Types/Basic.lean
@@ -101,6 +101,6 @@ of a type to the image of that type, tensored with the image of the nth cartesia
 noncomputable def MonoidalFunctor.mapPi {C : Type*} [Category C] [MonoidalCategory C]
     (F : MonoidalFunctor (Type _) C) (n : ℕ) (β : Type*) :
     F.obj (Fin (n + 1) → β) ≅ F.obj β ⊗ F.obj (Fin n → β) :=
-  Functor.mapIso _ (Equiv.piFinSucc n β).toIso ≪≫ (asIso (F.μ β (Fin n → β))).symm
+  Functor.mapIso _ (Fin.consEquiv _).symm.toIso ≪≫ (asIso (F.μ β (Fin n → β))).symm
 
 end CategoryTheory

--- a/Mathlib/Data/Countable/Basic.lean
+++ b/Mathlib/Data/Countable/Basic.lean
@@ -123,7 +123,7 @@ instance [Finite α] [∀ a, Countable (π a)] : Countable (∀ a, π a) := by
     induction' n with n ihn
     · change Countable (Fin 0 → ℕ); infer_instance
     · haveI := ihn
-      exact Countable.of_equiv (ℕ × (Fin n → ℕ)) (Equiv.piFinSucc _ _).symm
+      exact Countable.of_equiv (ℕ × (Fin n → ℕ)) (Fin.consEquiv fun _ ↦ ℕ)
   rcases Finite.exists_equiv_fin α with ⟨n, ⟨e⟩⟩
   have f := fun a => (nonempty_embedding_nat (π a)).some
   exact ((Embedding.piCongrRight f).trans (Equiv.piCongrLeft' _ e).toEmbedding).countable

--- a/Mathlib/Data/Fin/Tuple/Basic.lean
+++ b/Mathlib/Data/Fin/Tuple/Basic.lean
@@ -272,7 +272,7 @@ theorem comp_tail {α : Type*} {β : Type*} (g : α → β) (q : Fin n.succ → 
 
 theorem le_cons [∀ i, Preorder (α i)] {x : α 0} {q : ∀ i, α i} {p : ∀ i : Fin n, α i.succ} :
     q ≤ cons x p ↔ q 0 ≤ x ∧ tail q ≤ p :=
-  forall_iff_succ.trans <| and_congr Iff.rfl <| forall_congr' fun j ↦ by simp [tail]
+  forall_fin_succ.trans <| and_congr Iff.rfl <| forall_congr' fun j ↦ by simp [tail]
 
 theorem cons_le [∀ i, Preorder (α i)] {x : α 0} {q : ∀ i, α i} {p : ∀ i : Fin n, α i.succ} :
     cons x p ≤ q ↔ x ≤ q 0 ∧ p ≤ tail q :=
@@ -280,7 +280,7 @@ theorem cons_le [∀ i, Preorder (α i)] {x : α 0} {q : ∀ i, α i} {p : ∀ i
 
 theorem cons_le_cons [∀ i, Preorder (α i)] {x₀ y₀ : α 0} {x y : ∀ i : Fin n, α i.succ} :
     cons x₀ x ≤ cons y₀ y ↔ x₀ ≤ y₀ ∧ x ≤ y :=
-  forall_iff_succ.trans <| and_congr_right' <| by simp only [cons_succ, Pi.le_def]
+  forall_fin_succ.trans <| and_congr_right' <| by simp only [cons_succ, Pi.le_def]
 
 theorem range_fin_succ {α} (f : Fin (n + 1) → α) :
     Set.range f = insert (f 0) (Set.range (Fin.tail f)) :=

--- a/Mathlib/Data/Fin/Tuple/Basic.lean
+++ b/Mathlib/Data/Fin/Tuple/Basic.lean
@@ -724,18 +724,11 @@ def succAboveCases {α : Fin (n + 1) → Sort u} (i : Fin (n + 1)) (x : α i)
     else @Eq.recOn _ _ (fun x _ ↦ α x) _ (succAbove_pred_of_lt _ _ <|
     (Fin.lt_or_lt_of_ne hj).resolve_left hlt) (p _)
 
-/-- This is a duplicate of `Fin.forall_fin_succ` in Core. We should upstream the name change. -/
-lemma forall_iff_succ {P : Fin (n + 1) → Prop} : (∀ i, P i) ↔ P 0 ∧ ∀ i, P (succ i) :=
-  ⟨fun h ↦ ⟨h _, fun _ ↦ h _⟩, fun h ↦ cases h.1 h.2⟩
+-- This is a duplicate of `Fin.exists_fin_succ` in Core. We should upstream the name change.
+alias forall_iff_succ := forall_fin_succ
 
-/-- This is a duplicate of `Fin.exists_fin_succ` in Core. We should upstream the name change. -/
-lemma exists_iff_succ {P : Fin (n + 1) → Prop} : (∃ i, P i) ↔ P 0 ∨ ∃ i, P (succ i) where
-  mp := by
-    rintro ⟨i, hi⟩
-    induction' i using cases
-    · exact .inl hi
-    · exact .inr ⟨_, hi⟩
-  mpr := by rintro (h | ⟨i, hi⟩) <;> exact ⟨_, ‹_›⟩
+-- This is a duplicate of `Fin.exists_fin_succ` in Core. We should upstream the name change.
+alias exists_iff_succ := exists_fin_succ
 
 lemma forall_iff_castSucc {P : Fin (n + 1) → Prop} :
     (∀ i, P i) ↔ P (last n) ∧ ∀ i, P (castSucc i) :=

--- a/Mathlib/Data/Fin/Tuple/Finset.lean
+++ b/Mathlib/Data/Fin/Tuple/Finset.lean
@@ -17,11 +17,11 @@ variable {n : ℕ} {α : Fin (n + 1) → Type*}
 
 lemma mem_piFinset_succ {x : ∀ i, α i} {s : ∀ i, Finset (α i)} :
     x ∈ piFinset s ↔ x 0 ∈ s 0 ∧ tail x ∈ piFinset (tail s) := by
-  simp only [mem_piFinset, forall_fin_succ, tail]
+  simp only [mem_piFinset, forall_iff_succ, tail]
 
 lemma mem_piFinset_succ' {x : ∀ i, α i} {s : ∀ i, Finset (α i)} :
     x ∈ piFinset s ↔ init x ∈ piFinset (init s) ∧ x (last n) ∈ s (last n) := by
-  simp only [mem_piFinset, forall_fin_succ', init]
+  simp only [mem_piFinset, forall_iff_succ', init]
 
 lemma cons_mem_piFinset_cons {x₀ : α 0} {x : ∀ i : Fin n, α i.succ}
     {s₀ : Finset (α 0)} {s : ∀ i : Fin n, Finset (α i.succ)} :

--- a/Mathlib/Data/Fin/Tuple/Finset.lean
+++ b/Mathlib/Data/Fin/Tuple/Finset.lean
@@ -20,8 +20,8 @@ lemma mem_piFinset_succ {x : ∀ i, α i} {s : ∀ i, Finset (α i)} :
   simp only [mem_piFinset, forall_iff_succ, tail]
 
 lemma mem_piFinset_succ' {x : ∀ i, α i} {s : ∀ i, Finset (α i)} :
-    x ∈ piFinset s ↔ init x ∈ piFinset (init s) ∧ x (last n) ∈ s (last n) := by
-  simp only [mem_piFinset, forall_iff_succ', init]
+    x ∈ piFinset s ↔ x (last n) ∈ s (last n) ∧ init x ∈ piFinset (init s) := by
+  simp only [mem_piFinset, forall_iff_castSucc, init]
 
 lemma cons_mem_piFinset_cons {x₀ : α 0} {x : ∀ i : Fin n, α i.succ}
     {s₀ : Finset (α 0)} {s : ∀ i : Fin n, Finset (α i.succ)} :
@@ -30,7 +30,7 @@ lemma cons_mem_piFinset_cons {x₀ : α 0} {x : ∀ i : Fin n, α i.succ}
 
 lemma snoc_mem_piFinset_snoc {x : ∀ i : Fin n, α i.castSucc} {xₙ : α (.last n)}
     {s : ∀ i : Fin n, Finset (α i.castSucc)} {sₙ : Finset (α <| .last n)} :
-    snoc x xₙ ∈ piFinset (snoc s sₙ) ↔ x ∈ piFinset s ∧ xₙ ∈ sₙ := by
+    snoc x xₙ ∈ piFinset (snoc s sₙ) ↔ xₙ ∈ sₙ ∧ x ∈ piFinset s := by
   simp_rw [mem_piFinset_succ', init_snoc, snoc_last]
 
 end Fin

--- a/Mathlib/Data/Fin/VecNotation.lean
+++ b/Mathlib/Data/Fin/VecNotation.lean
@@ -171,7 +171,7 @@ theorem range_cons_cons_empty (x y : α) (u : Fin 0 → α) :
 
 @[simp]
 theorem vecCons_const (a : α) : (vecCons a fun _ : Fin n => a) = fun _ => a :=
-  funext <| Fin.forall_fin_succ.2 ⟨rfl, cons_val_succ _ _⟩
+  funext <| Fin.forall_iff_succ.2 ⟨rfl, cons_val_succ _ _⟩
 
 theorem vec_single_eq_const (a : α) : ![a] = fun _ => a :=
   let _ : Unique (Fin 1) := inferInstance

--- a/Mathlib/Logic/Equiv/Fin.lean
+++ b/Mathlib/Logic/Equiv/Fin.lean
@@ -37,6 +37,59 @@ def finTwoEquiv : Fin 2 ≃ Bool where
   left_inv := Fin.forall_fin_two.2 <| by simp
   right_inv := Bool.forall_bool.2 <| by simp
 
+/-!
+### Tuples
+
+This section defines a bunch of equivalences between `n + 1`-tuples and products of `n`-tuples with
+an entry.
+-/
+
+namespace Fin
+
+/-- Equivalence between tuples of length `n + 1` and pairs of an element and a tuple of length `n`
+given by separating out the first element of the tuple.
+
+This is `Fin.cons` as an `Equiv`. -/
+@[simps]
+def consEquiv (α : Fin (n + 1) → Type*) : α 0 × (∀ i, α (succ i)) ≃ ∀ i, α i where
+  toFun f := cons f.1 f.2
+  invFun f := (f 0, tail f)
+  left_inv f := by simp
+  right_inv f := by simp
+
+/-- Equivalence between tuples of length `n + 1` and pairs of an element and a tuple of length `n`
+given by separating out the last element of the tuple.
+
+This is `Fin.snoc` as an `Equiv`. -/
+@[simps]
+def snocEquiv (α : Fin (n + 1) → Type*) : α (last n) × (∀ i, α (castSucc i)) ≃ ∀ i, α i where
+  toFun f i := Fin.snoc f.2 f.1 _
+  invFun f := ⟨f _, Fin.init f⟩
+  left_inv f := by simp
+  right_inv f := by simp
+
+/-- Equivalence between tuples of length `n + 1` and pairs of an element and a tuple of length `n`
+given by separating out the `p`-th element of the tuple.
+
+This is `Fin.insertNth` as an `Equiv`. -/
+@[simps]
+def insertNthEquiv (α : Fin (n + 1) → Type u) (p : Fin (n + 1)) :
+    α p × (∀ i, α (p.succAbove i)) ≃ ∀ i, α i where
+  toFun f := insertNth p f.1 f.2
+  invFun f := (f p, removeNth p f)
+  left_inv f := by ext <;> simp
+  right_inv f := by simp
+
+@[simp] lemma insertNthEquiv_zero (α : Fin (n + 1) → Type*) : insertNthEquiv α 0 = consEquiv α :=
+  Equiv.symm_bijective.injective $ by ext <;> rfl
+
+/-- Note this lemma can only be written about non-dependent tuples as `insertNth (last n) = snoc` is
+not a definitional equality. -/
+@[simp] lemma insertNthEquiv_last (n : ℕ) (α : Type*) :
+    insertNthEquiv (fun _ ↦ α) (last n) = snocEquiv (fun _ ↦ α) := by ext; simp
+
+end Fin
+
 /-- `Π i : Fin 2, α i` is equivalent to `α 0 × α 1`. See also `finTwoArrowEquiv` for a
 non-dependent version and `prodEquivPiFinTwo` for a version with inputs `α β : Type u`. -/
 @[simps (config := .asFn)]
@@ -45,6 +98,12 @@ def piFinTwoEquiv (α : Fin 2 → Type u) : (∀ i, α i) ≃ α 0 × α 1 where
   invFun p := Fin.cons p.1 <| Fin.cons p.2 finZeroElim
   left_inv _ := funext <| Fin.forall_fin_two.2 ⟨rfl, rfl⟩
   right_inv := fun _ => rfl
+
+/-!
+### Miscellaneous
+
+This is currently not very sorted. PRs welcome!
+-/
 
 theorem Fin.preimage_apply_01_prod {α : Fin 2 → Type u} (s : Set (α 0)) (t : Set (α 1)) :
     (fun f : ∀ i, α i => (f 0, f 1)) ⁻¹' s ×ˢ t =
@@ -202,7 +261,7 @@ theorem finSuccEquivLast_symm_some (i : Fin n) :
   finSuccEquiv'_symm_none _
 
 /-- Equivalence between `Π j : Fin (n + 1), α j` and `α i × Π j : Fin n, α (Fin.succAbove i j)`. -/
-@[simps (config := .asFn)]
+@[simps (config := .asFn), deprecated Fin.insertNthEquiv (since := "2024-07-12")]
 def Equiv.piFinSuccAbove (α : Fin (n + 1) → Type u) (i : Fin (n + 1)) :
     (∀ j, α j) ≃ α i × ∀ j, α (i.succAbove j) where
   toFun f := (f i, i.removeNth f)
@@ -211,9 +270,9 @@ def Equiv.piFinSuccAbove (α : Fin (n + 1) → Type u) (i : Fin (n + 1)) :
   right_inv f := by simp
 
 /-- Equivalence between `Fin (n + 1) → β` and `β × (Fin n → β)`. -/
-@[simps! (config := .asFn)]
+@[simps! (config := .asFn), deprecated Fin.consEquiv (since := "2024-07-12")]
 def Equiv.piFinSucc (n : ℕ) (β : Type u) : (Fin (n + 1) → β) ≃ β × (Fin n → β) :=
-  Equiv.piFinSuccAbove (fun _ => β) 0
+  (Fin.insertNthEquiv (fun _ => β) 0).symm
 
 /-- An embedding `e : Fin (n+1) ↪ ι` corresponds to an embedding `f : Fin n ↪ ι` (corresponding
 the last `n` coordinates of `e`) together with a value not taken by `f` (corresponding to `e 0`). -/
@@ -236,9 +295,9 @@ def Equiv.embeddingFinSucc (n : ℕ) (ι : Type*) :
 
 /-- Equivalence between `Fin (n + 1) → β` and `β × (Fin n → β)` which separates out the last
 element of the tuple. -/
-@[simps! (config := .asFn)]
+@[simps! (config := .asFn), deprecated Fin.snocEquiv (since := "2024-07-12")]
 def Equiv.piFinCastSucc (n : ℕ) (β : Type u) : (Fin (n + 1) → β) ≃ β × (Fin n → β) :=
-  Equiv.piFinSuccAbove (fun _ => β) (.last _)
+  (Fin.insertNthEquiv (fun _ => β) (.last _)).symm
 
 /-- Equivalence between `Fin m ⊕ Fin n` and `Fin (m + n)` -/
 def finSumFinEquiv : Fin m ⊕ Fin n ≃ Fin (m + n) where

--- a/Mathlib/Logic/Equiv/Fin.lean
+++ b/Mathlib/Logic/Equiv/Fin.lean
@@ -81,7 +81,7 @@ def insertNthEquiv (α : Fin (n + 1) → Type u) (p : Fin (n + 1)) :
   right_inv f := by simp
 
 @[simp] lemma insertNthEquiv_zero (α : Fin (n + 1) → Type*) : insertNthEquiv α 0 = consEquiv α :=
-  Equiv.symm_bijective.injective $ by ext <;> rfl
+  Equiv.symm_bijective.injective <| by ext <;> rfl
 
 /-- Note this lemma can only be written about non-dependent tuples as `insertNth (last n) = snoc` is
 not a definitional equality. -/

--- a/Mathlib/MeasureTheory/Integral/Pi.lean
+++ b/Mathlib/MeasureTheory/Integral/Pi.lean
@@ -33,7 +33,8 @@ theorem Integrable.fin_nat_prod {n : ℕ} {E : Fin n → Type*}
   | succ n n_ih =>
       have := ((measurePreserving_piFinSuccAbove (fun i => (volume : Measure (E i))) 0).symm)
       rw [volume_pi, ← this.integrable_comp_emb (MeasurableEquiv.measurableEmbedding _)]
-      simp_rw [MeasurableEquiv.piFinSuccAbove_symm_apply, Fin.prod_univ_succ, Fin.insertNth_zero]
+      simp_rw [MeasurableEquiv.piFinSuccAbove_symm_apply, Fin.insertNthEquiv,
+        Fin.prod_univ_succ, Fin.insertNth_zero]
       simp only [Fin.zero_succAbove, cast_eq, Function.comp_def, Fin.cons_zero, Fin.cons_succ]
       have : Integrable (fun (x : (j : Fin n) → E (Fin.succ j)) ↦ ∏ j, f (Fin.succ j) (x j)) :=
         n_ih (fun i ↦ hf _)
@@ -75,9 +76,9 @@ theorem integral_fin_nat_prod_eq_prod {n : ℕ} {E : Fin n → Type*}
             f 0 x.1 * ∏ i : Fin n, f (Fin.succ i) (x.2 i) := by
           rw [volume_pi, ← ((measurePreserving_piFinSuccAbove
             (fun i => (volume : Measure (E i))) 0).symm).integral_comp']
-          simp_rw [MeasurableEquiv.piFinSuccAbove_symm_apply,
-            Fin.prod_univ_succ, Fin.insertNth_zero, Fin.cons_succ, volume_eq_prod, volume_pi,
-            Fin.zero_succAbove, cast_eq, Fin.cons_zero]
+          simp_rw [MeasurableEquiv.piFinSuccAbove_symm_apply, Fin.insertNthEquiv,
+            Fin.prod_univ_succ, Fin.insertNth_zero, Equiv.coe_fn_mk, Fin.cons_succ, volume_eq_prod,
+            volume_pi, Fin.zero_succAbove, cast_eq, Fin.cons_zero]
         _ = (∫ x, f 0 x) * ∏ i : Fin n, ∫ (x : E (Fin.succ i)), f (Fin.succ i) x := by
           rw [← n_ih, ← integral_prod_mul, volume_eq_prod]
         _ = ∏ i, ∫ x, f i x := by rw [Fin.prod_univ_succ]

--- a/Mathlib/MeasureTheory/Integral/TorusIntegral.lean
+++ b/Mathlib/MeasureTheory/Integral/TorusIntegral.lean
@@ -217,7 +217,7 @@ theorem torusIntegral_succAbove
   have hem : MeasurePreserving e :=
     (volume_preserving_piFinSuccAbove (fun _ : Fin (n + 1) => ℝ) i).symm _
   have heπ : (e ⁻¹' Icc 0 fun _ => 2 * π) = Icc 0 (2 * π) ×ˢ Icc (0 : ℝⁿ) fun _ => 2 * π :=
-    ((OrderIso.piFinSuccAboveIso (fun _ => ℝ) i).symm.preimage_Icc _ _).trans (Icc_prod_eq _ _)
+    ((Fin.insertNthOrderIso (fun _ => ℝ) i).preimage_Icc _ _).trans (Icc_prod_eq _ _)
   rw [torusIntegral, ← hem.map_eq, setIntegral_map_equiv, heπ, Measure.volume_eq_prod,
     setIntegral_prod, circleIntegral_def_Icc]
   · refine setIntegral_congr measurableSet_Icc fun θ _ => ?_
@@ -225,7 +225,7 @@ theorem torusIntegral_succAbove
       deriv_circleMap, i.prod_univ_succAbove _, smul_smul, torusMap, circleMap_zero]
     refine setIntegral_congr measurableSet_Icc fun Θ _ => ?_
     simp only [MeasurableEquiv.piFinSuccAbove_symm_apply, i.insertNth_apply_same,
-      i.insertNth_apply_succAbove, (· ∘ ·)]
+      i.insertNth_apply_succAbove, (· ∘ ·), Fin.insertNthEquiv, Equiv.coe_fn_mk]
     congr 2
     simp only [funext_iff, i.forall_iff_succAbove, circleMap, Fin.insertNth_apply_same,
       eq_self_iff_true, Fin.insertNth_apply_succAbove, imp_true_iff, and_self_iff]

--- a/Mathlib/MeasureTheory/MeasurableSpace/Embedding.lean
+++ b/Mathlib/MeasureTheory/MeasurableSpace/Embedding.lean
@@ -488,17 +488,17 @@ def finTwoArrow : (Fin 2 → α) ≃ᵐ α × α :=
   piFinTwo fun _ => α
 
 /-- Measurable equivalence between `Π j : Fin (n + 1), α j` and
-`α i × Π j : Fin n, α (Fin.succAbove i j)`. -/
+`α i × Π j : Fin n, α (Fin.succAbove i j)`.
+
+Measurable version of `Fin.insertNthEquiv`. -/
 @[simps! (config := .asFn)]
 def piFinSuccAbove {n : ℕ} (α : Fin (n + 1) → Type*) [∀ i, MeasurableSpace (α i)]
     (i : Fin (n + 1)) : (∀ j, α j) ≃ᵐ α i × ∀ j, α (i.succAbove j) where
-  toEquiv := .piFinSuccAbove α i
+  toEquiv := (Fin.insertNthEquiv α i).symm
   measurable_toFun := (measurable_pi_apply i).prod_mk <| measurable_pi_iff.2 fun j =>
     measurable_pi_apply _
   measurable_invFun := measurable_pi_iff.2 <| i.forall_iff_succAbove.2
-    ⟨by simp only [piFinSuccAbove_symm_apply, Fin.insertNth_apply_same, measurable_fst],
-      fun j => by simpa only [piFinSuccAbove_symm_apply, Fin.insertNth_apply_succAbove]
-        using (measurable_pi_apply _).comp measurable_snd⟩
+    ⟨by simp [measurable_fst], fun j => by simpa using (measurable_pi_apply _).comp measurable_snd⟩
 
 variable (π)
 

--- a/Mathlib/MeasureTheory/Measure/Count.lean
+++ b/Mathlib/MeasureTheory/Measure/Count.lean
@@ -156,7 +156,7 @@ theorem count_injective_image [MeasurableSingletonClass α] [MeasurableSingleton
   rw [count_apply_infinite hs]
   rw [← finite_image_iff hf.injOn] at hs
   rw [count_apply_infinite hs]
-  
+
 instance count.isFiniteMeasure [Finite α] :
     IsFiniteMeasure (Measure.count : Measure α) :=
   ⟨by

--- a/Mathlib/MeasureTheory/Measure/Count.lean
+++ b/Mathlib/MeasureTheory/Measure/Count.lean
@@ -156,7 +156,7 @@ theorem count_injective_image [MeasurableSingletonClass α] [MeasurableSingleton
   rw [count_apply_infinite hs]
   rw [← finite_image_iff hf.injOn] at hs
   rw [count_apply_infinite hs]
-
+  
 instance count.isFiniteMeasure [Finite α] :
     IsFiniteMeasure (Measure.count : Measure α) :=
   ⟨by

--- a/Mathlib/MeasureTheory/OuterMeasure/Induced.lean
+++ b/Mathlib/MeasureTheory/OuterMeasure/Induced.lean
@@ -409,7 +409,7 @@ and `m₃ s`. -/
 theorem trim_binop {m₁ m₂ m₃ : OuterMeasure α} {op : ℝ≥0∞ → ℝ≥0∞ → ℝ≥0∞}
     (h : ∀ s, m₁ s = op (m₂ s) (m₃ s)) (s : Set α) : m₁.trim s = op (m₂.trim s) (m₃.trim s) := by
   rcases exists_measurable_superset_forall_eq_trim ![m₁, m₂, m₃] s with ⟨t, _hst, _ht, htm⟩
-  simp only [Fin.forall_fin_succ, Matrix.cons_val_zero, Matrix.cons_val_succ] at htm
+  simp only [Fin.forall_iff_succ, Matrix.cons_val_zero, Matrix.cons_val_succ] at htm
   rw [← htm.1, ← htm.2.1, ← htm.2.2.1, h]
 
 /-- If `m₁ s = op (m₂ s)` for all `s`, then the same is true for `m₁.trim` and `m₂.trim`. -/

--- a/Mathlib/Order/Fin/Tuple.lean
+++ b/Mathlib/Order/Fin/Tuple.lean
@@ -25,7 +25,7 @@ lemma pi_lex_lt_cons_cons {x₀ y₀ : α 0} {x y : ∀ i : Fin n, α i.succ}
     (s : ∀ {i : Fin n.succ}, α i → α i → Prop) :
     Pi.Lex (· < ·) (@s) (Fin.cons x₀ x) (Fin.cons y₀ y) ↔
       s x₀ y₀ ∨ x₀ = y₀ ∧ Pi.Lex (· < ·) (@fun i : Fin n ↦ @s i.succ) x y := by
-  simp_rw [Pi.Lex, Fin.exists_fin_succ, Fin.cons_succ, Fin.cons_zero, Fin.forall_fin_succ]
+  simp_rw [Pi.Lex, Fin.exists_fin_succ, Fin.cons_succ, Fin.cons_zero, Fin.forall_iff_succ]
   simp [and_assoc, exists_and_left]
 
 variable [∀ i, Preorder (α i)]
@@ -54,7 +54,7 @@ variable {α : Type*}
 
 lemma liftFun_vecCons {n : ℕ} (r : α → α → Prop) [IsTrans α r] {f : Fin (n + 1) → α} {a : α} :
     ((· < ·) ⇒ r) (vecCons a f) (vecCons a f) ↔ r a (f 0) ∧ ((· < ·) ⇒ r) f f := by
-  simp only [liftFun_iff_succ r, forall_fin_succ, cons_val_succ, cons_val_zero, ← succ_castSucc,
+  simp only [liftFun_iff_succ r, forall_iff_succ, cons_val_succ, cons_val_zero, ← succ_castSucc,
     castSucc_zero]
 
 variable [Preorder α] {n : ℕ} {f : Fin (n + 1) → α} {a : α}
@@ -112,11 +112,54 @@ def OrderIso.piFinTwoIso (α : Fin 2 → Type*) [∀ i, Preorder (α i)] : (∀ 
 def OrderIso.finTwoArrowIso (α : Type*) [Preorder α] : (Fin 2 → α) ≃o α × α :=
   { OrderIso.piFinTwoIso fun _ => α with toEquiv := finTwoArrowEquiv α }
 
+namespace Fin
+
+/-- Order isomorphism between tuples of length `n + 1` and pairs of an element and a tuple of length
+`n` given by separating out the first element of the tuple.
+
+This is `Fin.cons` as an `OrderIso`. -/
+@[simps!, simps toEquiv]
+def consOrderIso (α : Fin (n + 1) → Type*) [∀ i, LE (α i)] :
+    α 0 × (∀ i, α (succ i)) ≃o ∀ i, α i where
+  toEquiv := consEquiv α
+  map_rel_iff' := forall_iff_succ
+
+/-- Order isomorphism between tuples of length `n + 1` and pairs of an element and a tuple of length
+`n` given by separating out the last element of the tuple.
+
+This is `Fin.snoc` as an `OrderIso`. -/
+@[simps!, simps toEquiv]
+def snocOrderIso (α : Fin (n + 1) → Type*) [∀ i, LE (α i)] :
+    α (last n) × (∀ i, α (castSucc i)) ≃o ∀ i, α i where
+  toEquiv := snocEquiv α
+  map_rel_iff' := by simp [Pi.le_def, Prod.le_def, forall_iff_castSucc]
+
+/-- Order isomorphism between tuples of length `n + 1` and pairs of an element and a tuple of length
+`n` given by separating out the `p`-th element of the tuple.
+
+This is `Fin.insertNth` as an `OrderIso`. -/
+@[simps!, simps toEquiv]
+def insertNthOrderIso (α : Fin (n + 1) → Type*) [∀ i, LE (α i)] (p : Fin (n + 1)) :
+    α p × (∀ i, α (p.succAbove i)) ≃o ∀ i, α i where
+  toEquiv := insertNthEquiv α p
+  map_rel_iff' := by simp [Pi.le_def, Prod.le_def, p.forall_iff_succAbove]
+
+@[simp] lemma insertNthOrderIso_zero (α : Fin (n + 1) → Type*) [∀ i, LE (α i)] :
+    insertNthOrderIso α 0 = consOrderIso α := by ext; simp [insertNthOrderIso]
+
+/-- Note this lemma can only be written about non-dependent tuples as `insertNth (last n) = snoc` is
+not a definitional equality. -/
+@[simp] lemma insertNthOrderIso_last (n : ℕ) (α : Type*) [LE α] :
+    insertNthOrderIso (fun _ ↦ α) (last n) = snocOrderIso (fun _ ↦ α) := by ext; simp
+
+end Fin
+
 /-- Order isomorphism between `Π j : Fin (n + 1), α j` and
 `α i × Π j : Fin n, α (Fin.succAbove i j)`. -/
+@[deprecated Fin.insertNthOrderIso (since := "2024-07-12")]
 def OrderIso.piFinSuccAboveIso (α : Fin (n + 1) → Type*) [∀ i, LE (α i)]
     (i : Fin (n + 1)) : (∀ j, α j) ≃o α i × ∀ j, α (i.succAbove j) where
-  toEquiv := Equiv.piFinSuccAbove α i
+  toEquiv := (Fin.insertNthEquiv α i).symm
   map_rel_iff' := Iff.symm i.forall_iff_succAbove
 
 /-- `Fin.succAbove` as an order isomorphism between `Fin n` and `{x : Fin (n + 1) // x ≠ p}`. -/

--- a/Mathlib/RepresentationTheory/Action/Monoidal.lean
+++ b/Mathlib/RepresentationTheory/Action/Monoidal.lean
@@ -308,7 +308,7 @@ each factor. -/
 @[simps!]
 noncomputable def diagonalSucc (G : Type u) [Monoid G] (n : ℕ) :
     diagonal G (n + 1) ≅ leftRegular G ⊗ diagonal G n :=
-  mkIso (Equiv.piFinSuccAbove _ 0).toIso fun _ => rfl
+  mkIso (Fin.consEquiv _).symm.toIso fun _ => rfl
 
 end Action
 

--- a/Mathlib/RepresentationTheory/GroupCohomology/LowDegree.lean
+++ b/Mathlib/RepresentationTheory/GroupCohomology/LowDegree.lean
@@ -82,7 +82,7 @@ def twoCochainsLequiv : (inhomogeneousCochains A).X 2 ≃ₗ[k] G × G → A :=
 /-- The 3rd object in the complex of inhomogeneous cochains of `A : Rep k G` is isomorphic
 to `Fun(G³, A)` as a `k`-module. -/
 def threeCochainsLequiv : (inhomogeneousCochains A).X 3 ≃ₗ[k] G × G × G → A :=
-  LinearEquiv.funCongrLeft k A <| ((Equiv.piFinSucc 2 G).trans
+  LinearEquiv.funCongrLeft k A <| ((Fin.consEquiv _).symm.trans
     ((Equiv.refl G).prodCongr (piFinTwoEquiv fun _ => G))).symm
 
 end Cochains

--- a/Mathlib/RepresentationTheory/GroupCohomology/Resolution.lean
+++ b/Mathlib/RepresentationTheory/GroupCohomology/Resolution.lean
@@ -102,7 +102,7 @@ def actionDiagonalSucc (G : Type u) [Group G] :
       tensorIso (Iso.refl _) (actionDiagonalSucc G n) ≪≫
         leftRegularTensorIso _ _ ≪≫
           tensorIso (Iso.refl _)
-            (mkIso (Equiv.piFinSuccAbove (fun _ => G) 0).symm.toIso fun _ => rfl)
+            (mkIso (Fin.insertNthEquiv (fun _ => G) 0).toIso fun _ => rfl)
 
 theorem actionDiagonalSucc_hom_apply {G : Type u} [Group G] {n : ℕ} (f : Fin (n + 1) → G) :
     (actionDiagonalSucc G n).hom.hom f = (f 0, fun i => (f (Fin.castSucc i))⁻¹ * f i.succ) := by
@@ -143,7 +143,7 @@ theorem actionDiagonalSucc_inv_apply {G : Type u} [Group G] {n : ℕ} (g : G) (f
       simpa only [Fin.cons_succ, Pi.smul_apply, smul_eq_mul, Fin.partialProd_succ', mul_assoc] -/
     funext x
     dsimp [actionDiagonalSucc]
-    erw [hn, Equiv.piFinSuccAbove_symm_apply]
+    erw [hn, Fin.consEquiv_apply]
     refine Fin.cases ?_ (fun i => ?_) x
     · simp only [Fin.insertNth_zero, Fin.cons_zero, Fin.partialProd_zero, mul_one]
     · simp only [Fin.cons_succ, Pi.smul_apply, smul_eq_mul, Fin.partialProd_succ', ← mul_assoc]

--- a/Mathlib/RingTheory/Regular/RegularSequence.lean
+++ b/Mathlib/RingTheory/Regular/RegularSequence.lean
@@ -232,7 +232,7 @@ lemma isWeaklyRegular_cons_iff (r : R) (rs : List R) :
       IsSMulRegular M r ∧ IsWeaklyRegular (QuotSMulTop r M) rs :=
   have := Eq.trans (congrArg (· • ⊤) Ideal.ofList_nil) (bot_smul ⊤)
   let e i := quotOfListConsSMulTopEquivQuotSMulTopInner M r (rs.take i)
-  Iff.trans (isWeaklyRegular_iff_Fin _ _) <| Iff.trans Fin.forall_fin_succ <|
+  Iff.trans (isWeaklyRegular_iff_Fin _ _) <| Iff.trans Fin.forall_iff_succ <|
     and_congr ((quotEquivOfEqBot _ this).isSMulRegular_congr r) <|
       Iff.trans (forall_congr' fun i => (e i).isSMulRegular_congr (rs.get i))
         (isWeaklyRegular_iff_Fin _ _).symm


### PR DESCRIPTION
The names here were all over the place and there were missing versions. Harmonise the names and add the missing versions.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->
Before I fix downstream uses, I would like to know whether people think my names are good or not. I see two minor issues with them:
* ~~What I am naming `fooEquiv` is the `Equiv` such that `fooEquiv.invFun = foo`, not `fooEquiv.toFun = foo`.~~ Fixed by turning the equivs around
* The rest of the library contains things like `MeasurableEquiv.finFoo` rather than `Fin.fooMeasurableEquiv`.

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
