### PR TITLE
[Merged by Bors] - chore(AEEqOfIntegral): weaken TC assumptions in 2 lemmas

### DIFF
--- a/Mathlib/MeasureTheory/Function/AEEqOfIntegral.lean
+++ b/Mathlib/MeasureTheory/Function/AEEqOfIntegral.lean
@@ -667,38 +667,40 @@ alias ae_eq_zero_of_forall_set_integral_isClosed_eq_zero :=
 /-- If an integrable function has zero integral on all compact sets in a sigma-compact space, then
 it is zero almost everwhere. -/
 lemma ae_eq_zero_of_forall_setIntegral_isCompact_eq_zero
-    [SigmaCompactSpace β] [T2Space β] {μ : Measure β} {f : β → E} (hf : Integrable f μ)
+    [SigmaCompactSpace β] [R1Space β] {μ : Measure β} {f : β → E} (hf : Integrable f μ)
     (h'f : ∀ (s : Set β), IsCompact s → ∫ x in s, f x ∂μ = 0) :
     f =ᵐ[μ] 0 := by
   apply ae_eq_zero_of_forall_setIntegral_isClosed_eq_zero hf (fun s hs ↦ ?_)
-  let t : ℕ → Set β := fun n ↦ compactCovering β n ∩ s
+  let t : ℕ → Set β := fun n ↦ closure (compactCovering β n) ∩ s
   suffices H : Tendsto (fun n ↦ ∫ x in t n, f x ∂μ) atTop (𝓝 (∫ x in s, f x ∂μ)) by
     have A : ∀ n, ∫ x in t n, f x ∂μ = 0 :=
-      fun n ↦ h'f _ (IsCompact.inter_right (isCompact_compactCovering β n) hs)
+      fun n ↦ h'f _ ((isCompact_compactCovering β n).closure.inter_right hs)
     simp_rw [A, tendsto_const_nhds_iff] at H
     exact H.symm
-  have B : s = ⋃ n, t n := by rw [← Set.iUnion_inter, iUnion_compactCovering, Set.univ_inter]
+  have B : s = ⋃ n, t n := by
+    rw [← Set.iUnion_inter, iUnion_closure_compactCovering, Set.univ_inter]
   rw [B]
   apply tendsto_setIntegral_of_monotone
   · intros n
-    exact ((isCompact_compactCovering β n).inter_right hs).isClosed.measurableSet
+    exact (isClosed_closure.inter hs).measurableSet
   · intros m n hmn
-    exact Set.inter_subset_inter_left _ (compactCovering_subset β hmn)
+    simp only [t, Set.le_iff_subset]
+    gcongr
   · exact hf.integrableOn
 
 /-- If a locally integrable function has zero integral on all compact sets in a sigma-compact space,
 then it is zero almost everwhere. -/
 lemma ae_eq_zero_of_forall_setIntegral_isCompact_eq_zero'
-    [SigmaCompactSpace β] [T2Space β] {μ : Measure β} {f : β → E} (hf : LocallyIntegrable f μ)
+    [SigmaCompactSpace β] [R1Space β] {μ : Measure β} {f : β → E} (hf : LocallyIntegrable f μ)
     (h'f : ∀ (s : Set β), IsCompact s → ∫ x in s, f x ∂μ = 0) :
     f =ᵐ[μ] 0 := by
-  rw [← Measure.restrict_univ (μ := μ), ← iUnion_compactCovering]
+  rw [← μ.restrict_univ, ← iUnion_closure_compactCovering]
   apply (ae_restrict_iUnion_iff _ _).2 (fun n ↦ ?_)
   apply ae_eq_zero_of_forall_setIntegral_isCompact_eq_zero
-  · exact hf.integrableOn_isCompact (isCompact_compactCovering β n)
+  · exact hf.integrableOn_isCompact (isCompact_compactCovering β n).closure
   · intro s hs
-    rw [Measure.restrict_restrict hs.measurableSet]
-    exact h'f _ (hs.inter (isCompact_compactCovering β n))
+    rw [Measure.restrict_restrict' measurableSet_closure]
+    exact h'f _ (hs.inter_right isClosed_closure)
 
 end AeEqOfForallSetIntegralEq
 

--- a/Mathlib/Topology/Compactness/SigmaCompact.lean
+++ b/Mathlib/Topology/Compactness/SigmaCompact.lean
@@ -207,7 +207,10 @@ theorem iUnion_compactCovering : ⋃ n, compactCovering X n = univ := by
   exact (Classical.choose_spec SigmaCompactSpace.exists_compact_covering).2
 #align Union_compact_covering iUnion_compactCovering
 
-@[mono]
+theorem iUnion_closure_compactCovering : ⋃ n, closure (compactCovering X n) = univ :=
+  eq_top_mono (iUnion_mono fun _ ↦ subset_closure) (iUnion_compactCovering X)
+
+@[mono, gcongr]
 theorem compactCovering_subset ⦃m n : ℕ⦄ (h : m ≤ n) : compactCovering X m ⊆ compactCovering X n :=
   monotone_accumulate h
 #align compact_covering_subset compactCovering_subset


### PR DESCRIPTION
.. from `T2Space` to `R1Space`


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
