### PR TITLE
feat(Data/Nat/PartENat): add lemmas for PartENat

### DIFF
--- a/Mathlib/Data/Nat/PartENat.lean
+++ b/Mathlib/Data/Nat/PartENat.lean
@@ -227,18 +227,11 @@ nonrec theorem get_eq_iff_eq_some {a : PartENat} {ha : a.Dom} {b : ℕ} : a.get 
   get_eq_iff_eq_some
 #align part_enat.get_eq_iff_eq_some PartENat.get_eq_iff_eq_some
 
+@[simp]
 theorem get_eq_iff_eq_coe {a : PartENat} {ha : a.Dom} {b : ℕ} : a.get ha = b ↔ a = b := by
   rw [get_eq_iff_eq_some]
   rfl
 #align part_enat.get_eq_iff_eq_coe PartENat.get_eq_iff_eq_coe
-
-@[simp]
-lemma get_eq_zero_iff_eq_zero {a : PartENat} {ha : a.Dom} :
-    a.get ha = 0 ↔ a = 0 := get_eq_iff_eq_coe
-
-@[simp]
-lemma get_eq_one_iff_eq_one {a : PartENat} {ha : a.Dom} :
-    a.get ha = 1 ↔ a = 1 := get_eq_iff_eq_coe
 
 theorem dom_of_le_of_dom {x y : PartENat} : x ≤ y → y.Dom → x.Dom := fun ⟨h, _⟩ => h
 #align part_enat.dom_of_le_of_dom PartENat.dom_of_le_of_dom
@@ -915,7 +908,7 @@ noncomputable instance : CompleteLinearOrder PartENat :=
     linearOrder, LinearOrder.toBiheytingAlgebra with }
 
 /--
-The additive homorophism from PartENat to WithTop ℤ. This is needed for the definition of
+The additive homomorophism from PartENat to WithTop ℤ. This is needed for the definition of
 p-adic valuations in fraction rings over UFDs.
 -/
 noncomputable def toWithTopInt : PartENat →+ WithTop ℤ :=

--- a/Mathlib/Data/Nat/PartENat.lean
+++ b/Mathlib/Data/Nat/PartENat.lean
@@ -227,7 +227,6 @@ nonrec theorem get_eq_iff_eq_some {a : PartENat} {ha : a.Dom} {b : ℕ} : a.get 
   get_eq_iff_eq_some
 #align part_enat.get_eq_iff_eq_some PartENat.get_eq_iff_eq_some
 
-@[simp]
 theorem get_eq_iff_eq_coe {a : PartENat} {ha : a.Dom} {b : ℕ} : a.get ha = b ↔ a = b := by
   rw [get_eq_iff_eq_some]
   rfl

--- a/Mathlib/Data/Nat/PartENat.lean
+++ b/Mathlib/Data/Nat/PartENat.lean
@@ -929,9 +929,7 @@ lemma toWithTopInt_injective : Function.Injective PartENat.toWithTopInt := by
   apply (fun (x : And _ _) ↦  Part.ext' x.1 x.2)
   split at h <;> split at h <;> simp_all
 
-@[simp]
-lemma toWithTopInt_zero : PartENat.toWithTopInt 0 = 0 := by
-  simp [toWithTopInt_def]
+lemma toWithTopInt_zero : PartENat.toWithTopInt 0 = 0 := by simp
 
 @[simp]
 lemma toWithTopInt_eq_zero_iff (x : PartENat) : PartENat.toWithTopInt x = 0 ↔ x = 0 where

--- a/Mathlib/Data/Nat/PartENat.lean
+++ b/Mathlib/Data/Nat/PartENat.lean
@@ -194,6 +194,8 @@ theorem coe_add_get {x : ℕ} {y : PartENat} (h : ((x : PartENat) + y).Dom) :
   rfl
 #align part_enat.coe_add_get PartENat.coe_add_get
 
+theorem dom_add (x y : PartENat) : (x + y).Dom ↔ x.Dom ∧ y.Dom := Iff.rfl
+
 @[simp]
 theorem get_add {x y : PartENat} (h : (x + y).Dom) : get (x + y) h = x.get h.1 + y.get h.2 :=
   rfl


### PR DESCRIPTION
Add some missing lemmas for `PartENat`, as well as the additive homomorphism from it to `WithTop Int`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
