### PR TITLE
[Merged by Bors] - feat(GroupTheory/GroupAction): Add theorem for `smul` of `toConjAct`

### DIFF
--- a/Mathlib/GroupTheory/GroupAction/ConjAct.lean
+++ b/Mathlib/GroupTheory/GroupAction/ConjAct.lean
@@ -149,6 +149,9 @@ theorem smul_def (g : ConjAct G) (h : G) : g • h = ofConjAct g * h * (ofConjAc
   rfl
 #align conj_act.smul_def ConjAct.smul_def
 
+theorem toConjAct_smul (g h : G) : toConjAct g • h = g * h * g⁻¹ :=
+  rfl
+
 end DivInvMonoid
 
 section Units


### PR DESCRIPTION
Add the theorem `toConjAct_smul` as discussed in #13930.

This shows that `toConjAct g • h` is equal to `g * h * g⁻¹`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
