### PR TITLE
[Merged by Bors] - feat(Algebra/Group/SemiconjBy): relating SemiconjBy to orderOf

### DIFF
--- a/Mathlib/Algebra/Group/Semiconj/Basic.lean
+++ b/Mathlib/Algebra/Group/Semiconj/Basic.lean
@@ -63,5 +63,9 @@ variable [Group G] {a x y : G}
 #align semiconj_by.zpow_right SemiconjBy.zpow_right
 #align add_semiconj_by.zsmul_right AddSemiconjBy.zsmul_right
 
+variable (a) in
+@[to_additive] lemma eq_one_iff (h : SemiconjBy a x y): x = 1 ↔ y = 1 := by
+  rw [← conj_eq_one_iff (a := a) (b := x), h.eq, mul_inv_cancel_right]
+
 end Group
 end SemiconjBy

--- a/Mathlib/GroupTheory/OrderOfElement.lean
+++ b/Mathlib/GroupTheory/OrderOfElement.lean
@@ -1347,8 +1347,8 @@ lemma charP_of_prime_pow_injective (R) [Ring R] [Fintype R] (p n : ℕ) [hp : Fa
 
 namespace SemiconjBy
 
-variable [Group G] (a:G) {x y : G} (h:SemiconjBy a x y) in
-@[to_additive] lemma orderOf_eq : orderOf x = orderOf y := by
+@[to_additive]
+lemma orderOf_eq [Group G] (a : G) {x y : G} (h : SemiconjBy a x y) : orderOf x = orderOf y := by
   rw [orderOf_eq_orderOf_iff]
   intro n
   exact (h.pow_right n).eq_one_iff

--- a/Mathlib/GroupTheory/OrderOfElement.lean
+++ b/Mathlib/GroupTheory/OrderOfElement.lean
@@ -1344,3 +1344,13 @@ lemma charP_of_prime_pow_injective (R) [Ring R] [Fintype R] (p n : ℕ) [hp : Fa
   obtain rfl : i = n := hR i hi $ by rw [← Nat.cast_pow, CharP.cast_eq_zero]
   assumption
 #align char_p_of_prime_pow_injective charP_of_prime_pow_injective
+
+namespace SemiconjBy
+
+variable [Group G] (a:G) {x y : G} (h:SemiconjBy a x y) in
+@[to_additive] lemma orderOf_eq : orderOf x = orderOf y := by
+  rw [orderOf_eq_orderOf_iff]
+  intro n
+  exact (h.pow_right n).eq_one_iff
+
+end SemiconjBy


### PR DESCRIPTION
this PR adds `SemiconjBy.orderOf_eq`, proving that semiconjugates have the same order.
it also adds `SemiconjBy.eq_one_iff`, which is used to prove the previous statement.

relevant zulip thread:
https://leanprover.zulipchat.com/#narrow/stream/113489-new-members/topic/group.20problem

Co-authored-by: Ruben Van de Velde

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
