### PR TITLE
[Merged by Bors] - refactor: improvements to lint_style

### DIFF
--- a/Mathlib/Tactic/Linter/TextBased.lean
+++ b/Mathlib/Tactic/Linter/TextBased.lean
@@ -353,14 +353,12 @@ def lintFile (path : FilePath) (sizeLimit : Option ℕ) (exceptions : Array Erro
   errors := errors.append (allOutput.flatten.filter (fun e ↦ !exceptions.contains e))
   return errors
 
-/-- Lint all files referenced in a given import-only file.
-Print formatted errors to standard output.
+/-- Lint a collection of modules for style violations.
+Print formatted errors for all unexpected style violations to standard output.
 Return the number of files which had new style errors.
 `style` specifies if the error should be formatted for humans to read, github problem matchers
 to consume or for the style exceptions file. -/
-def lintAllFiles (path : FilePath) (style : ErrorFormat) : IO UInt32 := do
-  -- Read all module names from the file at `path`.
-  let allModules ← IO.FS.lines path
+def lintModules (moduleNames : Array String) (style : ErrorFormat) : IO UInt32 := do
   -- Read the style exceptions file.
   -- We also have a `nolints` file with manual exceptions for the linter.
   let exceptions ← IO.FS.lines (mkFilePath ["scripts", "style-exceptions.txt"])
@@ -370,8 +368,7 @@ def lintAllFiles (path : FilePath) (style : ErrorFormat) : IO UInt32 := do
 
   let mut numberErrorFiles := 0
   let mut allUnexpectedErrors := #[]
-  for module in allModules do
-    let module := module.stripPrefix "import "
+  for module in moduleNames do
     -- Convert the module name to a file name, then lint that file.
     let path := (mkFilePath (module.split (· == '.'))).addExtension "lean"
     -- Find all size limits for this given file.

--- a/Mathlib/Tactic/Linter/TextBased.lean
+++ b/Mathlib/Tactic/Linter/TextBased.lean
@@ -113,9 +113,6 @@ structure ErrorContext where
   style exceptions: for example, we ignore the particular line length of a "line too long" error. -/
 def StyleError.normalise (err : StyleError) : StyleError := match err with
   -- NB: keep this in sync with `parse?_errorContext` below.
-  | StyleError.fileTooLong _ _ => StyleError.fileTooLong 0 0
-  -- We do *not* care about the *kind* of wrong copyright.
-  | StyleError.copyright _ => StyleError.copyright ""
   | StyleError.lineLength _ => StyleError.lineLength 0
   | _ => err
 
@@ -151,7 +148,7 @@ def outputMessage (errctx : ErrorContext) (style : ErrorFormat) : String :=
 def parse?_errorContext (line : String) : Option ErrorContext := Id.run do
   let parts := line.split (· == ' ')
   match parts with
-    | filename :: ":" :: "line" :: _line_number :: ":" :: error_code :: ":" :: error_message =>
+    | filename :: ":" :: "line" :: line_number :: ":" :: error_code :: ":" :: error_message =>
       -- Turn the filename into a path. In general, this is ambiguous if we don't know if we're
       -- dealing with e.g. Windows or POSIX paths. In our setting, this is fine, since no path
       -- component contains any path separator.
@@ -161,10 +158,10 @@ def parse?_errorContext (line : String) : Option ErrorContext := Id.run do
       let err : Option StyleError := match error_code with
         -- Use default values for parameters which are normalised.
         -- NB: keep this in sync with `normalise` above!
-        | "ERR_COP" => some (StyleError.copyright "")
         | "ERR_LIN" => some (StyleError.lineLength 0)
         | "ERR_AUT" => some (StyleError.authors)
         | "ERR_ADN" => some (StyleError.adaptationNote)
+        | "ERR_COP" => some (StyleError.copyright (some (" ".intercalate error_message)))
         | "ERR_IMP" =>
           -- XXX tweak exceptions messages to ease parsing?
           if (error_message.get! 0).containsSubstr "tactic" then
@@ -181,8 +178,9 @@ def parse?_errorContext (line : String) : Option ErrorContext := Id.run do
             | _ => none
           | _ => none
         | _ => none
-      -- Omit the line number, as we don't use it anyway.
-      err.map fun e ↦ (ErrorContext.mk e 0 path)
+      match String.toNat? line_number with
+      | some n => err.map fun e ↦ (ErrorContext.mk e n path)
+      | _ => none
     -- It would be nice to print an error on any line which doesn't match the above format,
     -- but is awkward to do so (this `def` is not in any IO monad). Hopefully, this is not necessary
     -- anyway as the style exceptions file is mostly automatically generated.

--- a/Mathlib/Tactic/Linter/TextBased.lean
+++ b/Mathlib/Tactic/Linter/TextBased.lean
@@ -128,7 +128,7 @@ instance : BEq ErrorContext where
 
 /-- Output the formatted error message, containing its context.
 `style` specifies if the error should be formatted for humans to read, github problem matchers
-to consume or for the style exceptions file. -/
+to consume, or for the style exceptions file. -/
 def outputMessage (errctx : ErrorContext) (style : ErrorFormat) : String :=
   let error_message := errctx.error.errorMessage style
   match style with
@@ -201,7 +201,7 @@ def parseStyleExceptions (lines : Array String) : Array ErrorContext := Id.run d
 
 /-- Print information about all errors encountered to standard output.
 `style` specifies if the error should be formatted for humans to read, github problem matchers
-to consume or for the style exceptions file. -/
+to consume, or for the style exceptions file. -/
 def formatErrors (errors : Array ErrorContext) (style : ErrorFormat) : IO Unit := do
   for e in errors do
     IO.println (outputMessage e style)

--- a/Mathlib/Tactic/Linter/TextBased.lean
+++ b/Mathlib/Tactic/Linter/TextBased.lean
@@ -115,7 +115,7 @@ def StyleError.normalise (err : StyleError) : StyleError := match err with
   -- NB: keep this in sync with `parse?_errorContext` below.
   | StyleError.fileTooLong _ _ => StyleError.fileTooLong 0 0
   -- We do *not* care about the *kind* of wrong copyright.
-  | StyleError.copyright _ => StyleError.copyright ""
+  | StyleError.copyright _ => StyleError.copyright none
   | StyleError.lineLength _ => StyleError.lineLength 0
   | _ => err
 
@@ -161,7 +161,7 @@ def parse?_errorContext (line : String) : Option ErrorContext := Id.run do
       let err : Option StyleError := match error_code with
         -- Use default values for parameters which are normalised.
         -- NB: keep this in sync with `normalise` above!
-        | "ERR_COP" => some (StyleError.copyright "")
+        | "ERR_COP" => some (StyleError.copyright none)
         | "ERR_LIN" => some (StyleError.lineLength 0)
         | "ERR_AUT" => some (StyleError.authors)
         | "ERR_ADN" => some (StyleError.adaptationNote)

--- a/Mathlib/Tactic/Linter/TextBased.lean
+++ b/Mathlib/Tactic/Linter/TextBased.lean
@@ -128,7 +128,8 @@ instance : BEq ErrorContext where
       && (ctx.error).normalise == (ctx'.error).normalise
 
 /-- Output the formatted error message, containing its context.
-`style` specifies if the error should be formatted for humans or for github output matchers -/
+`style` specifies if the error should be formatted for humans to read, github problem matchers
+to consume or for the style exceptions file. -/
 def outputMessage (errctx : ErrorContext) (style : ErrorFormat) : String :=
   let error_message := errctx.error.errorMessage style
   match style with
@@ -194,7 +195,8 @@ def parseStyleExceptions (lines : Array String) : Array ErrorContext := Id.run d
   Array.filterMap (parse?_errorContext ·) (lines.filter (fun line ↦ !line.startsWith "--"))
 
 /-- Print information about all errors encountered to standard output.
-`style` specifies if we print errors for humand or github consumption. -/
+`style` specifies if the error should be formatted for humans to read, github problem matchers
+to consume or for the style exceptions file. -/
 def formatErrors (errors : Array ErrorContext) (style : ErrorFormat) : IO Unit := do
   for e in errors do
     IO.println (outputMessage e style)
@@ -354,7 +356,8 @@ def lintFile (path : FilePath) (sizeLimit : Option ℕ) (exceptions : Array Erro
 /-- Lint all files referenced in a given import-only file.
 Print formatted errors to standard output.
 Return the number of files which had new style errors.
-`style` specifies if errors should be formatted for github or human consumption. -/
+`style` specifies if the error should be formatted for humans to read, github problem matchers
+to consume or for the style exceptions file. -/
 def lintAllFiles (path : FilePath) (style : ErrorFormat) : IO UInt32 := do
   -- Read all module names from the file at `path`.
   let allModules ← IO.FS.lines path

--- a/scripts/lint_style.lean
+++ b/scripts/lint_style.lean
@@ -22,10 +22,11 @@ def lintStyleCli (args : Cli.Parsed) : IO UInt32 := do
     | (true, _) => ErrorFormat.github
     | (false, true) => ErrorFormat.exceptionsFile
     | (false, false) => ErrorFormat.humanReadable
-  let mut numberErrorFiles : UInt32 := 0
+  -- Read all module names to lint.
+  let mut allModules := #[]
   for s in ["Archive.lean", "Counterexamples.lean", "Mathlib.lean"] do
-    let n ← lintAllFiles (System.mkFilePath [s]) errorStyle
-    numberErrorFiles := numberErrorFiles + n
+    allModules := allModules.append ((← IO.FS.lines s).map (·.stripPrefix "import "))
+  let numberErrorFiles ← lintModules allModules errorStyle
   -- Make sure to return an exit code of at most 125, so this return value can be used further
   -- in shell scripts.
   return min numberErrorFiles 125


### PR DESCRIPTION
To prepare for #14273; pulled out for easy of reviewing.
Commits can be reviewed individually.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
