### PR TITLE
[Merged by Bors] - chore: Move more lemmas to `Algebra.Group.Action.Defs`

### DIFF
--- a/Mathlib/Algebra/Group/Action/Defs.lean
+++ b/Mathlib/Algebra/Group/Action/Defs.lean
@@ -52,7 +52,7 @@ assert_not_exists MonoidWithZero
 
 open Function (Injective Surjective)
 
-variable {M N G A B α β γ δ : Type*}
+variable {M N G H A B α β γ δ : Type*}
 
 /-! ### Faithful actions -/
 
@@ -552,6 +552,54 @@ lemma smul_pow (r : M) (x : N) : ∀ n, (r • x) ^ n = r ^ n • x ^ n
 #align smul_pow smul_pow
 
 end Monoid
+
+section Group
+variable [Group G] [MulAction G α] {g : G} {a b : α}
+
+@[to_additive (attr := simp)]
+lemma inv_smul_smul (g : G) (a : α) : g⁻¹ • g • a = a := by rw [smul_smul, mul_left_inv, one_smul]
+#align inv_smul_smul inv_smul_smul
+#align neg_vadd_vadd neg_vadd_vadd
+
+@[to_additive (attr := simp)]
+lemma smul_inv_smul (g : G) (a : α) : g • g⁻¹ • a = a := by rw [smul_smul, mul_right_inv, one_smul]
+#align smul_inv_smul smul_inv_smul
+#align vadd_neg_vadd vadd_neg_vadd
+
+@[to_additive] lemma inv_smul_eq_iff : g⁻¹ • a = b ↔ a = g • b :=
+  ⟨fun h ↦ by rw [← h, smul_inv_smul], fun h ↦ by rw [h, inv_smul_smul]⟩
+#align inv_smul_eq_iff inv_smul_eq_iff
+#align neg_vadd_eq_iff neg_vadd_eq_iff
+
+@[to_additive] lemma eq_inv_smul_iff : a = g⁻¹ • b ↔ g • a = b :=
+  ⟨fun h ↦ by rw [h, smul_inv_smul], fun h ↦ by rw [← h, inv_smul_smul]⟩
+#align eq_inv_smul_iff eq_inv_smul_iff
+#align eq_neg_vadd_iff eq_neg_vadd_iff
+
+section Mul
+variable [Mul H] [MulAction G H] [SMulCommClass G H H] [IsScalarTower G H H] {g : G} {a b : H}
+
+@[simp] lemma Commute.smul_right_iff : Commute a (g • b) ↔ Commute a b :=
+  ⟨fun h ↦ inv_smul_smul g b ▸ h.smul_right g⁻¹, fun h ↦ h.smul_right g⟩
+#align commute.smul_right_iff Commute.smul_right_iff
+
+@[simp] lemma Commute.smul_left_iff : Commute (g • a) b ↔ Commute a b := by
+  rw [Commute.symm_iff, Commute.smul_right_iff, Commute.symm_iff]
+#align commute.smul_left_iff Commute.smul_left_iff
+
+end Mul
+
+variable [Group H] [MulAction G H] [SMulCommClass G H H] [IsScalarTower G H H]
+
+lemma smul_inv (g : G) (a : H) : (g • a)⁻¹ = g⁻¹ • a⁻¹ :=
+  inv_eq_of_mul_eq_one_right $ by rw [smul_mul_smul, mul_right_inv, mul_right_inv, one_smul]
+#align smul_inv smul_inv
+
+lemma smul_zpow (g : G) (a : H) (n : ℤ) : (g • a) ^ n = g ^ n • a ^ n := by
+  cases n <;> simp [smul_pow, smul_inv]
+#align smul_zpow smul_zpow
+
+end Group
 end
 
 lemma SMulCommClass.of_commMonoid

--- a/Mathlib/Dynamics/PeriodicPts.lean
+++ b/Mathlib/Dynamics/PeriodicPts.lean
@@ -9,7 +9,6 @@ import Mathlib.Data.List.Cycle
 import Mathlib.Data.Nat.Prime.Basic
 import Mathlib.Data.PNat.Basic
 import Mathlib.Dynamics.FixedPoints.Basic
-import Mathlib.GroupTheory.GroupAction.Group
 
 #align_import dynamics.periodic_pts from "leanprover-community/mathlib"@"d07245fd37786daa997af4f1a73a49fa3b748408"
 

--- a/Mathlib/GroupTheory/GroupAction/Group.lean
+++ b/Mathlib/GroupTheory/GroupAction/Group.lean
@@ -26,17 +26,6 @@ section Group
 
 variable [Group α] [MulAction α β]
 
-@[to_additive (attr := simp)]
-theorem inv_smul_smul (c : α) (x : β) : c⁻¹ • c • x = x := by rw [smul_smul, mul_left_inv, one_smul]
-#align inv_smul_smul inv_smul_smul
-#align neg_vadd_vadd neg_vadd_vadd
-
-@[to_additive (attr := simp)]
-theorem smul_inv_smul (c : α) (x : β) : c • c⁻¹ • x = x := by
-  rw [smul_smul, mul_right_inv, one_smul]
-#align smul_inv_smul smul_inv_smul
-#align vadd_neg_vadd vadd_neg_vadd
-
 /-- Given an action of a group `α` on `β`, each `g : α` defines a permutation of `β`. -/
 @[to_additive (attr := simps)]
 def MulAction.toPerm (a : α) : Equiv.Perm β :=
@@ -100,41 +89,6 @@ instance Equiv.Perm.applyFaithfulSMul (α : Type*) : FaithfulSMul (Equiv.Perm α
 variable {α} {β}
 
 @[to_additive]
-theorem inv_smul_eq_iff {a : α} {x y : β} : a⁻¹ • x = y ↔ x = a • y :=
-  (MulAction.toPerm a).symm_apply_eq
-#align inv_smul_eq_iff inv_smul_eq_iff
-#align neg_vadd_eq_iff neg_vadd_eq_iff
-
-@[to_additive]
-theorem eq_inv_smul_iff {a : α} {x y : β} : x = a⁻¹ • y ↔ a • x = y :=
-  (MulAction.toPerm a).eq_symm_apply
-#align eq_inv_smul_iff eq_inv_smul_iff
-#align eq_neg_vadd_iff eq_neg_vadd_iff
-
-theorem smul_inv [Group β] [SMulCommClass α β β] [IsScalarTower α β β] (c : α) (x : β) :
-    (c • x)⁻¹ = c⁻¹ • x⁻¹ := by
-  rw [inv_eq_iff_mul_eq_one, smul_mul_smul, mul_right_inv, mul_right_inv, one_smul]
-#align smul_inv smul_inv
-
-theorem smul_zpow [Group β] [SMulCommClass α β β] [IsScalarTower α β β] (c : α) (x : β) (p : ℤ) :
-    (c • x) ^ p = c ^ p • x ^ p := by
-  cases p <;>
-  simp [smul_pow, smul_inv]
-#align smul_zpow smul_zpow
-
-@[simp]
-theorem Commute.smul_right_iff [Mul β] [SMulCommClass α β β] [IsScalarTower α β β] {a b : β}
-    (r : α) : Commute a (r • b) ↔ Commute a b :=
-  ⟨fun h => inv_smul_smul r b ▸ h.smul_right r⁻¹, fun h => h.smul_right r⟩
-#align commute.smul_right_iff Commute.smul_right_iff
-
-@[simp]
-theorem Commute.smul_left_iff [Mul β] [SMulCommClass α β β] [IsScalarTower α β β] {a b : β}
-    (r : α) : Commute (r • a) b ↔ Commute a b := by
-  rw [Commute.symm_iff, Commute.smul_right_iff, Commute.symm_iff]
-#align commute.smul_left_iff Commute.smul_left_iff
-
-@[to_additive]
 protected theorem MulAction.bijective (g : α) : Function.Bijective (g • · : β → β) :=
   (MulAction.toPerm g).bijective
 #align mul_action.bijective MulAction.bijective
@@ -186,7 +140,7 @@ theorem smul_invOf_smul : c • (⅟ c • x) = x := smul_inv_smul (unitOfInvert
 variable {c x y}
 
 theorem invOf_smul_eq_iff : ⅟c • x = y ↔ x = c • y :=
-  inv_smul_eq_iff (a := unitOfInvertible c)
+  inv_smul_eq_iff (g := unitOfInvertible c)
 
 theorem smul_eq_iff_eq_invOf_smul : c • x = y ↔ x = ⅟c • y :=
   smul_eq_iff_eq_inv_smul (g := unitOfInvertible c)
@@ -224,13 +178,13 @@ theorem eq_inv_smul_iff₀ {a : α} (ha : a ≠ 0) {x y : β} : x = a⁻¹ • y
 @[simp]
 theorem Commute.smul_right_iff₀ [Mul β] [SMulCommClass α β β] [IsScalarTower α β β] {a b : β}
     {c : α} (hc : c ≠ 0) : Commute a (c • b) ↔ Commute a b :=
-  Commute.smul_right_iff (Units.mk0 c hc)
+  Commute.smul_right_iff (g := Units.mk0 c hc)
 #align commute.smul_right_iff₀ Commute.smul_right_iff₀
 
 @[simp]
 theorem Commute.smul_left_iff₀ [Mul β] [SMulCommClass α β β] [IsScalarTower α β β] {a b : β} {c : α}
     (hc : c ≠ 0) : Commute (c • a) b ↔ Commute a b :=
-  Commute.smul_left_iff (Units.mk0 c hc)
+  Commute.smul_left_iff (g := Units.mk0 c hc)
 #align commute.smul_left_iff₀ Commute.smul_left_iff₀
 
 /-- Right scalar multiplication as an order isomorphism. -/


### PR DESCRIPTION
Those will be needed in a future file `Algebra.GroupWithZero.Action.Defs`


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
