### PR TITLE
[Merged by Bors] - feat: Translation of affine bases

### DIFF
--- a/Mathlib/Data/Set/Pointwise/SMul.lean
+++ b/Mathlib/Data/Set/Pointwise/SMul.lean
@@ -3,6 +3,7 @@ Copyright (c) 2019 Johan Commelin. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johan Commelin, Floris van Doorn
 -/
+import Mathlib.Algebra.Group.Pi.Basic
 import Mathlib.Algebra.Module.Defs
 import Mathlib.Data.Set.Pairwise.Basic
 import Mathlib.Data.Set.Pointwise.Basic
@@ -451,11 +452,17 @@ theorem range_smul_range {ι κ : Type*} [SMul α β] (b : ι → α) (c : κ �
 #align set.range_vadd_range Set.range_vadd_range
 
 @[to_additive]
-theorem smul_set_range [SMul α β] {ι : Sort*} {f : ι → β} :
+theorem smul_set_range [SMul α β] {ι : Sort*} (a : α) (f : ι → β) :
     a • range f = range fun i ↦ a • f i :=
   (range_comp _ _).symm
 #align set.smul_set_range Set.smul_set_range
 #align set.vadd_set_range Set.vadd_set_range
+
+@[to_additive] lemma range_smul [SMul α β] {ι : Sort*} (a : α) (f : ι → β) :
+    range (fun i ↦ a • f i) = a • range f := (smul_set_range ..).symm
+
+@[to_additive] lemma range_mul [Mul α] {ι : Sort*} (a : α) (f : ι → α) :
+    range (fun i ↦ a * f i) = a • range f := range_smul a f
 
 @[to_additive]
 instance smulCommClass_set [SMul α γ] [SMul β γ] [SMulCommClass α β γ] :

--- a/Mathlib/LinearAlgebra/AffineSpace/Basis.lean
+++ b/Mathlib/LinearAlgebra/AffineSpace/Basis.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Oliver Nash
 -/
 import Mathlib.LinearAlgebra.AffineSpace.Independent
+import Mathlib.LinearAlgebra.AffineSpace.Pointwise
 import Mathlib.LinearAlgebra.Basis
 
 #align_import linear_algebra.affine_space.basis from "leanprover-community/mathlib"@"2de9c37fa71dde2f1c6feff19876dd6a7b1519f0"
@@ -279,6 +280,18 @@ noncomputable def coords : P →ᵃ[k] ι → k where
 theorem coords_apply (q : P) (i : ι) : b.coords q i = b.coord i q :=
   rfl
 #align affine_basis.coords_apply AffineBasis.coords_apply
+
+instance instVAdd : VAdd V (AffineBasis ι k P) where
+  vadd x b :=
+    { toFun := x +ᵥ ⇑b,
+      ind' := b.ind'.vadd,
+      tot' := by rw [Pi.vadd_def, ← vadd_set_range, ← AffineSubspace.pointwise_vadd_span, b.tot,
+        AffineSubspace.pointwise_vadd_top] }
+
+@[simp, norm_cast] lemma coe_vadd (v : V) (b : AffineBasis ι k P) : ⇑(v +ᵥ b) = v +ᵥ ⇑b := rfl
+
+instance instAddAction : AddAction V (AffineBasis ι k P) :=
+  DFunLike.coe_injective.addAction _ coe_vadd
 
 end Ring
 

--- a/Mathlib/LinearAlgebra/AffineSpace/Basis.lean
+++ b/Mathlib/LinearAlgebra/AffineSpace/Basis.lean
@@ -290,6 +290,10 @@ instance instVAdd : VAdd V (AffineBasis ι k P) where
 
 @[simp, norm_cast] lemma coe_vadd (v : V) (b : AffineBasis ι k P) : ⇑(v +ᵥ b) = v +ᵥ ⇑b := rfl
 
+@[simp] lemma basisOf_vadd (v : V) (b : AffineBasis ι k P) : (v +ᵥ b).basisOf = b.basisOf := by
+  ext
+  simp
+
 instance instAddAction : AddAction V (AffineBasis ι k P) :=
   DFunLike.coe_injective.addAction _ coe_vadd
 

--- a/Mathlib/LinearAlgebra/AffineSpace/Basis.lean
+++ b/Mathlib/LinearAlgebra/AffineSpace/Basis.lean
@@ -298,7 +298,7 @@ instance instAddAction : AddAction V (AffineBasis ι k P) :=
   DFunLike.coe_injective.addAction _ coe_vadd
 
 @[simp] lemma coord_vadd (v : V) (b : AffineBasis ι k P) :
-  (v +ᵥ b).coord i = (b.coord i).comp (AffineEquiv.constVAdd k P v).symm := by
+    (v +ᵥ b).coord i = (b.coord i).comp (AffineEquiv.constVAdd k P v).symm := by
   ext p
   simp only [coord, ne_eq, basisOf_vadd, coe_vadd, Pi.vadd_apply, Basis.coe_sumCoords,
     AffineMap.coe_mk, AffineEquiv.constVAdd_symm, AffineMap.coe_comp, AffineEquiv.coe_toAffineMap,

--- a/Mathlib/LinearAlgebra/AffineSpace/Basis.lean
+++ b/Mathlib/LinearAlgebra/AffineSpace/Basis.lean
@@ -297,6 +297,15 @@ instance instVAdd : VAdd V (AffineBasis ι k P) where
 instance instAddAction : AddAction V (AffineBasis ι k P) :=
   DFunLike.coe_injective.addAction _ coe_vadd
 
+@[simp] lemma coord_vadd (v : V) (b : AffineBasis ι k P) :
+  (v +ᵥ b).coord i = (b.coord i).comp (AffineEquiv.constVAdd k P v).symm := by
+  ext p
+  simp only [coord, ne_eq, basisOf_vadd, coe_vadd, Pi.vadd_apply, Basis.coe_sumCoords,
+    AffineMap.coe_mk, AffineEquiv.constVAdd_symm, AffineMap.coe_comp, AffineEquiv.coe_toAffineMap,
+    Function.comp_apply, AffineEquiv.constVAdd_apply, sub_right_inj]
+  congr! 1
+  rw [vadd_vsub_assoc, neg_add_eq_sub, vsub_vadd_eq_vsub_sub]
+
 end Ring
 
 section DivisionRing

--- a/Mathlib/LinearAlgebra/AffineSpace/Combination.lean
+++ b/Mathlib/LinearAlgebra/AffineSpace/Combination.lean
@@ -81,6 +81,10 @@ theorem weightedVSubOfPoint_apply_const (w : ι → k) (p : P) (b : P) :
   rw [weightedVSubOfPoint_apply, sum_smul]
 #align finset.weighted_vsub_of_point_apply_const Finset.weightedVSubOfPoint_apply_const
 
+@[simp] lemma weightedVSubOfPoint_vadd (s : Finset ι) (w : ι → k) (p : ι → P) (b : P) (v : V) :
+    s.weightedVSubOfPoint (v +ᵥ p) b w = s.weightedVSubOfPoint p (-v +ᵥ b) w := by
+  simp [weightedVSubOfPoint, vadd_vsub_assoc, vsub_vadd_eq_vsub_sub, add_comm]
+
 /-- `weightedVSubOfPoint` gives equal results for two families of weights and two families of
 points that are equal on `s`. -/
 theorem weightedVSubOfPoint_congr {w₁ w₂ : ι → k} (hw : ∀ i ∈ s, w₁ i = w₂ i) {p₁ p₂ : ι → P}
@@ -278,6 +282,11 @@ theorem weightedVSub_apply_const (w : ι → k) (p : P) (h : ∑ i ∈ s, w i = 
 theorem weightedVSub_empty (w : ι → k) (p : ι → P) : (∅ : Finset ι).weightedVSub p w = (0 : V) := by
   simp [weightedVSub_apply]
 #align finset.weighted_vsub_empty Finset.weightedVSub_empty
+
+lemma weightedVSub_vadd {s : Finset ι} {w : ι → k} (h : ∑ i ∈ s, w i = 0) (p : ι → P) (v : V) :
+    s.weightedVSub (v +ᵥ p) w = s.weightedVSub p w := by
+  rw [weightedVSub, weightedVSubOfPoint_vadd,
+    weightedVSub_eq_weightedVSubOfPoint_of_sum_eq_zero _ _ _ h]
 
 /-- `weightedVSub` gives equal results for two families of weights and two families of points
 that are equal on `s`. -/

--- a/Mathlib/LinearAlgebra/AffineSpace/Combination.lean
+++ b/Mathlib/LinearAlgebra/AffineSpace/Combination.lean
@@ -81,9 +81,9 @@ theorem weightedVSubOfPoint_apply_const (w : ι → k) (p : P) (b : P) :
   rw [weightedVSubOfPoint_apply, sum_smul]
 #align finset.weighted_vsub_of_point_apply_const Finset.weightedVSubOfPoint_apply_const
 
-@[simp] lemma weightedVSubOfPoint_vadd (s : Finset ι) (w : ι → k) (p : ι → P) (b : P) (v : V) :
+lemma weightedVSubOfPoint_vadd (s : Finset ι) (w : ι → k) (p : ι → P) (b : P) (v : V) :
     s.weightedVSubOfPoint (v +ᵥ p) b w = s.weightedVSubOfPoint p (-v +ᵥ b) w := by
-  simp [weightedVSubOfPoint, vadd_vsub_assoc, vsub_vadd_eq_vsub_sub, add_comm]
+  simp [vadd_vsub_assoc, vsub_vadd_eq_vsub_sub, add_comm]
 
 /-- `weightedVSubOfPoint` gives equal results for two families of weights and two families of
 points that are equal on `s`. -/

--- a/Mathlib/LinearAlgebra/AffineSpace/Independent.lean
+++ b/Mathlib/LinearAlgebra/AffineSpace/Independent.lean
@@ -81,6 +81,12 @@ theorem affineIndependent_iff_of_fintype [Fintype ι] (p : ι → P) :
     simpa [hi] using h
 #align affine_independent_iff_of_fintype affineIndependent_iff_of_fintype
 
+@[simp] lemma affineIndependent_vadd {p : ι → P} {v : V} :
+    AffineIndependent k (v +ᵥ p) ↔ AffineIndependent k p := by
+  simp (config := { contextual := true }) [AffineIndependent, weightedVSub_vadd]
+
+protected alias ⟨AffineIndependent.of_vadd, AffineIndependent.vadd⟩ := affineIndependent_vadd
+
 /-- A family is affinely independent if and only if the differences
 from a base point in that family are linearly independent. -/
 theorem affineIndependent_iff_linearIndependent_vsub (p : ι → P) (i1 : ι) :

--- a/Mathlib/LinearAlgebra/AffineSpace/Pointwise.lean
+++ b/Mathlib/LinearAlgebra/AffineSpace/Pointwise.lean
@@ -19,13 +19,13 @@ open Affine Pointwise
 
 open Set
 
-namespace AffineSubspace
-
 variable {k : Type*} [Ring k]
 variable {V P V₁ P₁ V₂ P₂ : Type*}
 variable [AddCommGroup V] [Module k V] [AffineSpace V P]
 variable [AddCommGroup V₁] [Module k V₁] [AddTorsor V₁ P₁]
 variable [AddCommGroup V₂] [Module k V₂] [AddTorsor V₂ P₂]
+
+namespace AffineSubspace
 
 /-- The additive action on an affine subspace corresponding to applying the action to every element.
 
@@ -56,9 +56,12 @@ theorem vadd_mem_pointwise_vadd_iff {v : V} {s : AffineSubspace k P} {p : P} :
   vadd_mem_vadd_set_iff
 #align affine_subspace.vadd_mem_pointwise_vadd_iff AffineSubspace.vadd_mem_pointwise_vadd_iff
 
-theorem pointwise_vadd_bot (v : V) : v +ᵥ (⊥ : AffineSubspace k P) = ⊥ := by
+@[simp] theorem pointwise_vadd_bot (v : V) : v +ᵥ (⊥ : AffineSubspace k P) = ⊥ := by
   ext; simp [pointwise_vadd_eq_map, map_bot]
 #align affine_subspace.pointwise_vadd_bot AffineSubspace.pointwise_vadd_bot
+
+@[simp] lemma pointwise_vadd_top (v : V) : v +ᵥ (⊤ : AffineSubspace k P) = ⊤ := by
+  ext; simp [pointwise_vadd_eq_map, map_top, vadd_eq_iff_eq_neg_vadd]
 
 theorem pointwise_vadd_direction (v : V) (s : AffineSubspace k P) :
     (v +ᵥ s).direction = s.direction := by


### PR DESCRIPTION
Provide the additive action of a module `V` over the `k`-affine bases of a `V`-torsor `P`.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

This could be generalised to `AddAction V (AffineBasis ι k P)` where `P` is a `W`-torsor, but I'm a bit lazy to sort out exactly what the conditions are and what API we are missing. 

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
