### PR TITLE
[Merged by Bors] - docs: fix references.bib

### DIFF
--- a/docs/references.bib
+++ b/docs/references.bib
@@ -144,7 +144,8 @@
   author        = {Jeremy Avigad and Leonardo de Moura and Soonho Kong},
   title         = {{T}heorem {P}roving in {L}ean},
   year          = {2017},
-  howpublished  = {\url{https://leanprover.github.io/theorem_proving_in_lean/}}
+  howpublished  = {},
+  url           = {https://leanprover.github.io/theorem_proving_in_lean/}
 }
 
 @Book{            axler2015,
@@ -1376,8 +1377,8 @@
   pages         = {58--78},
   publisher     = {Springer},
   year          = {2020},
-  url           = {https://doi.org/10.1007/978-3-030-51054-1\_4},
-  doi           = {10.1007/978-3-030-51054-1\_4},
+  url           = {https://doi.org/10.1007/978-3-030-51054-1_4},
+  doi           = {10.1007/978-3-030-51054-1_4},
   timestamp     = {Mon, 06 Jul 2020 09:05:32 +0200},
   biburl        = {https://dblp.org/rec/conf/cade/FurerLST20.bib},
   bibsource     = {dblp computer science bibliography, https://dblp.org}
@@ -2148,7 +2149,7 @@
 
 @Article{         kleiman1979,
   author        = {Kleiman, Steven Lawrence},
-  title         = {Misconceptions about {$K\_X$}},
+  title         = {Misconceptions about {$K_X$}},
   journal       = {Enseign. Math. (2)},
   volume        = {25},
   year          = {1979},


### PR DESCRIPTION
This PR removes `\url` and `\_` commands in `references.bib`. The existence of them breaks https://github.com/leanprover/doc-gen4/pull/209.

- The first is `howpublished = {\url{...}}`. I think it's better to use the standard `url` field. Meanwhile `howpublished` field is preserved since some bibtex parser complains about missing that field.
- There are some `\_` in `url` and `doi` fields. I think it's better to replace them with `_`; there are already some `_` in `url` and `doi` fields of other bibitems.
- There is `$K\_X$`, but which, after checking the original article, should be `$K_X$`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
