### PR TITLE
[Merged by Bors] - feat(AlgebraicGeometry): the 1-hypercover attached to a GlueData

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -761,6 +761,7 @@ import Mathlib.AlgebraicGeometry.EllipticCurve.Weierstrass
 import Mathlib.AlgebraicGeometry.FunctionField
 import Mathlib.AlgebraicGeometry.GammaSpecAdjunction
 import Mathlib.AlgebraicGeometry.Gluing
+import Mathlib.AlgebraicGeometry.GluingOneHypercover
 import Mathlib.AlgebraicGeometry.Limits
 import Mathlib.AlgebraicGeometry.Modules.Presheaf
 import Mathlib.AlgebraicGeometry.Modules.Sheaf

--- a/Mathlib/AlgebraicGeometry/GluingOneHypercover.lean
+++ b/Mathlib/AlgebraicGeometry/GluingOneHypercover.lean
@@ -1,0 +1,70 @@
+/-
+Copyright (c) 2024 Joël Riou. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Calle Sönne, Joël Riou, Ravi Vakil
+-/
+import Mathlib.AlgebraicGeometry.Gluing
+import Mathlib.CategoryTheory.Sites.OneHypercover
+import Mathlib.AlgebraicGeometry.Sites.BigZariski
+
+/-!
+# Gluing Hypercovers
+
+In this file ...
+
+-/
+universe v u
+
+open CategoryTheory Opposite Limits
+
+namespace AlgebraicGeometry.Scheme.GlueData
+
+variable (D : Scheme.GlueData.{u})
+
+/-- TODO -/
+@[simps]
+noncomputable def oneHypercover : Scheme.zariskiTopology.OneHypercover D.glued where
+  I₀ := D.J
+  X := D.U
+  f := D.ι
+  I₁ _ _ := PUnit
+  Y i₁ i₂ _ := D.V (i₁, i₂)
+  p₁ i₁ i₂ _ := D.f i₁ i₂
+  p₂ i₁ i₂ j := D.t i₁ i₂ ≫ D.f i₂ i₁
+  w i₁ i₂ _ := by simp only [Category.assoc, Scheme.GlueData.glue_condition]
+  mem₀ := by
+    refine zariskiTopology.superset_covering ?_ (zariskiTopology_openCover D.openCover)
+    rw [Sieve.sets_iff_generate] -- the name of this lemma should be changed!
+    rintro W _ ⟨i⟩
+    exact ⟨_, 𝟙 _, _, ⟨i⟩, by simp; rfl⟩
+  mem₁ i₁ i₂ W p₁ p₂ fac := by
+    dsimp at p₁ p₂ fac ⊢
+    refine zariskiTopology.superset_covering ?_ (zariskiTopology.top_mem _)
+    intro T g _
+    dsimp
+    have ⟨φ, h₁, h₂⟩ := PullbackCone.IsLimit.lift' (D.vPullbackConeIsLimit i₁ i₂)
+      (g ≫ p₁) (g ≫ p₂) (by simpa using g ≫= fac)
+    exact ⟨⟨⟩, φ, h₁.symm, h₂.symm⟩
+
+variable {F : Sheaf Scheme.zariskiTopology (Type v)}
+
+section
+
+variable (s : ∀ (j : D.J), F.val.obj (op (D.U j)))
+  (h : ∀ (i j : D.J), F.val.map (D.f i j).op (s i) =
+    F.val.map ((D.f j i).op ≫ (D.t i j).op) (s j))
+
+/-- TODO -/
+noncomputable def sheafValGluedMk : F.val.obj (op D.glued) :=
+  Multifork.IsLimit.sectionsEquiv (D.oneHypercover.isLimitMultifork F)
+    { val := s
+      property := fun _ ↦ h _ _ }
+
+@[simp]
+lemma sheafValGluedMk_val (j : D.J) : F.val.map (D.ι j).op (D.sheafValGluedMk s h) = s j :=
+  Multifork.IsLimit.sectionsEquiv_apply_val (D.oneHypercover.isLimitMultifork F) _ _
+
+end
+
+
+end AlgebraicGeometry.Scheme.GlueData

--- a/Mathlib/AlgebraicGeometry/GluingOneHypercover.lean
+++ b/Mathlib/AlgebraicGeometry/GluingOneHypercover.lean
@@ -15,6 +15,11 @@ In this file, given `D : Scheme.GlueData`, we construct a 1-hypercover
 We use this 1-hypercover in order to define a constructor `D.sheafValGluedMk`
 for sections over `D.glued` of a sheaf of types over the big Zariski site.
 
+## Notes
+
+This contribution was created as part of the AIM workshop
+"Formalizing algebraic geometry" in June 2024.
+
 -/
 
 universe v u

--- a/Mathlib/AlgebraicGeometry/GluingOneHypercover.lean
+++ b/Mathlib/AlgebraicGeometry/GluingOneHypercover.lean
@@ -8,11 +8,15 @@ import Mathlib.CategoryTheory.Sites.OneHypercover
 import Mathlib.AlgebraicGeometry.Sites.BigZariski
 
 /-!
-# Gluing Hypercovers
+# The 1-hypercover of a glue data
 
-In this file ...
+In this file, given `D : Scheme.GlueData`, we construct a 1-hypercover
+`D.openHypercover` of the scheme `D.glued` in the big Zariski site.
+We use this 1-hypercover in order to define a constructor `D.sheafValGluedMk`
+for sections over `D.glued` of a sheaf of types over the big Zariski site.
 
 -/
+
 universe v u
 
 open CategoryTheory Opposite Limits
@@ -21,7 +25,10 @@ namespace AlgebraicGeometry.Scheme.GlueData
 
 variable (D : Scheme.GlueData.{u})
 
-/-- TODO -/
+/-- The 1-hypercover of `D.glued` in the big Zariski site that is given by the
+open cover `D.U` from the glue data `D`.
+The "covering of the intersection of two such open subsets" is the trivial
+covering provided by the `D.V`. -/
 @[simps]
 noncomputable def oneHypercover : Scheme.zariskiTopology.OneHypercover D.glued where
   I₀ := D.J
@@ -34,27 +41,23 @@ noncomputable def oneHypercover : Scheme.zariskiTopology.OneHypercover D.glued w
   w i₁ i₂ _ := by simp only [Category.assoc, Scheme.GlueData.glue_condition]
   mem₀ := by
     refine zariskiTopology.superset_covering ?_ (zariskiTopology_openCover D.openCover)
-    rw [Sieve.sets_iff_generate] -- the name of this lemma should be changed!
+    rw [Sieve.generate_le_iff]
     rintro W _ ⟨i⟩
     exact ⟨_, 𝟙 _, _, ⟨i⟩, by simp; rfl⟩
   mem₁ i₁ i₂ W p₁ p₂ fac := by
-    dsimp at p₁ p₂ fac ⊢
-    refine zariskiTopology.superset_covering ?_ (zariskiTopology.top_mem _)
-    intro T g _
-    dsimp
+    refine zariskiTopology.superset_covering (fun T g _ ↦ ?_) (zariskiTopology.top_mem _)
     have ⟨φ, h₁, h₂⟩ := PullbackCone.IsLimit.lift' (D.vPullbackConeIsLimit i₁ i₂)
       (g ≫ p₁) (g ≫ p₂) (by simpa using g ≫= fac)
     exact ⟨⟨⟩, φ, h₁.symm, h₂.symm⟩
 
-variable {F : Sheaf Scheme.zariskiTopology (Type v)}
-
 section
 
-variable (s : ∀ (j : D.J), F.val.obj (op (D.U j)))
+variable {F : Sheaf Scheme.zariskiTopology (Type v)}
+  (s : ∀ (j : D.J), F.val.obj (op (D.U j)))
   (h : ∀ (i j : D.J), F.val.map (D.f i j).op (s i) =
     F.val.map ((D.f j i).op ≫ (D.t i j).op) (s j))
 
-/-- TODO -/
+/-- Constructor for sections over `D.glued` of a sheaf of types on the big Zariski site. -/
 noncomputable def sheafValGluedMk : F.val.obj (op D.glued) :=
   Multifork.IsLimit.sectionsEquiv (D.oneHypercover.isLimitMultifork F)
     { val := s
@@ -65,6 +68,5 @@ lemma sheafValGluedMk_val (j : D.J) : F.val.map (D.ι j).op (D.sheafValGluedMk s
   Multifork.IsLimit.sectionsEquiv_apply_val (D.oneHypercover.isLimitMultifork F) _ _
 
 end
-
 
 end AlgebraicGeometry.Scheme.GlueData

--- a/Mathlib/AlgebraicGeometry/GluingOneHypercover.lean
+++ b/Mathlib/AlgebraicGeometry/GluingOneHypercover.lean
@@ -4,8 +4,8 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Calle Sönne, Joël Riou, Ravi Vakil
 -/
 import Mathlib.AlgebraicGeometry.Gluing
-import Mathlib.CategoryTheory.Sites.OneHypercover
 import Mathlib.AlgebraicGeometry.Sites.BigZariski
+import Mathlib.CategoryTheory.Sites.OneHypercover
 
 /-!
 # The 1-hypercover of a glue data
@@ -28,7 +28,7 @@ variable (D : Scheme.GlueData.{u})
 /-- The 1-hypercover of `D.glued` in the big Zariski site that is given by the
 open cover `D.U` from the glue data `D`.
 The "covering of the intersection of two such open subsets" is the trivial
-covering provided by the `D.V`. -/
+covering given by `D.V`. -/
 @[simps]
 noncomputable def oneHypercover : Scheme.zariskiTopology.OneHypercover D.glued where
   I₀ := D.J

--- a/Mathlib/CategoryTheory/Sites/Coherent/RegularTopology.lean
+++ b/Mathlib/CategoryTheory/Sites/Coherent/RegularTopology.lean
@@ -31,7 +31,7 @@ theorem mem_sieves_of_hasEffectiveEpi (S : Sieve X) :
     (∃ (Y : C) (π : Y ⟶ X), EffectiveEpi π ∧ S.arrows π) → (S ∈ (regularTopology C).sieves X) := by
   rintro ⟨Y, π, h⟩
   have h_le : Sieve.generate (Presieve.ofArrows (fun () ↦ Y) (fun _ ↦ π)) ≤ S := by
-    rw [Sieve.sets_iff_generate (Presieve.ofArrows _ _) S]
+    rw [Sieve.generate_le_iff (Presieve.ofArrows _ _) S]
     apply Presieve.le_of_factorsThru_sieve (Presieve.ofArrows _ _) S _
     intro W g f
     refine ⟨W, 𝟙 W, ?_⟩

--- a/Mathlib/CategoryTheory/Sites/Coverage.lean
+++ b/Mathlib/CategoryTheory/Sites/Coverage.lean
@@ -310,7 +310,7 @@ Grothendieck topology.
 -/
 theorem mem_toGrothendieck_sieves_of_superset (K : Coverage C) {X : C} {S : Sieve X}
     {R : Presieve X} (h : R ≤ S) (hR : R ∈ K.covering X) : S ∈ (K.toGrothendieck C).sieves X :=
-  K.saturate_of_superset ((Sieve.sets_iff_generate _ _).mpr h) (Coverage.Saturate.of X _ hR)
+  K.saturate_of_superset ((Sieve.generate_le_iff _ _).mpr h) (Coverage.Saturate.of X _ hR)
 
 end Coverage
 

--- a/Mathlib/CategoryTheory/Sites/Pretopology.lean
+++ b/Mathlib/CategoryTheory/Sites/Pretopology.lean
@@ -113,7 +113,7 @@ def toGrothendieck (K : Pretopology C) : GrothendieckTopology C where
   pullback_stable' X Y S g := by
     rintro ⟨R, hR, RS⟩
     refine ⟨_, K.pullbacks g _ hR, ?_⟩
-    rw [← Sieve.sets_iff_generate, Sieve.pullbackArrows_comm]
+    rw [← Sieve.generate_le_iff, Sieve.pullbackArrows_comm]
     apply Sieve.pullback_monotone
     rwa [Sieve.giGenerate.gc]
   transitive' := by

--- a/Mathlib/CategoryTheory/Sites/SheafOfTypes.lean
+++ b/Mathlib/CategoryTheory/Sites/SheafOfTypes.lean
@@ -111,7 +111,7 @@ theorem isSheaf_pretopology [HasPullbacks C] (K : Pretopology C) :
   · rintro PK X S ⟨R, hR, RS⟩
     have gRS : ⇑(generate R) ≤ S := by
       apply giGenerate.gc.monotone_u
-      rwa [sets_iff_generate]
+      rwa [generate_le_iff]
     apply isSheafFor_subsieve P gRS _
     intro Y f
     rw [← pullbackArrows_comm, ← isSheafFor_iff_generate]

--- a/Mathlib/CategoryTheory/Sites/Sieves.lean
+++ b/Mathlib/CategoryTheory/Sites/Sieves.lean
@@ -417,15 +417,17 @@ def bind (S : Presieve X) (R : ∀ ⦃Y⦄ ⦃f : Y ⟶ X⦄, S f → Sieve Y) :
 
 open Order Lattice
 
-theorem sets_iff_generate (R : Presieve X) (S : Sieve X) : generate R ≤ S ↔ R ≤ S :=
+theorem generate_le_iff (R : Presieve X) (S : Sieve X) : generate R ≤ S ↔ R ≤ S :=
   ⟨fun H Y g hg => H _ ⟨_, 𝟙 _, _, hg, id_comp _⟩, fun ss Y f => by
     rintro ⟨Z, f, g, hg, rfl⟩
     exact S.downward_closed (ss Z hg) f⟩
-#align category_theory.sieve.sets_iff_generate CategoryTheory.Sieve.sets_iff_generate
+#align category_theory.sieve.sets_iff_generate CategoryTheory.Sieve.generate_le_iff
+
+@[deprecated (since := "2024-07-13")] alias sets_iff_generate := generate_le_iff
 
 /-- Show that there is a galois insertion (generate, set_over). -/
 def giGenerate : GaloisInsertion (generate : Presieve X → Sieve X) arrows where
-  gc := sets_iff_generate
+  gc := generate_le_iff
   choice 𝒢 _ := generate 𝒢
   choice_eq _ _ := rfl
   le_l_u _ _ _ hf := ⟨_, 𝟙 _, _, hf, id_comp _⟩


### PR DESCRIPTION
Given `D : Scheme.GlueData`, we define the 1-hypercover of the scheme `D.glued` on the big Zariski site and use it in order to define a constructor for sections over `D.glued` of a sheaf of types over the big Zariski site. (Incidentally, the lemma `Sieve.sets_iff_generate` is renamed `Sieve.generate_le_iff`.)

This contribution was created as part of the AIM workshop "Formalizing algebraic geometry" in June 2024.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
