### PR TITLE
[Merged by Bors] - docs(Data/Finset/Basic): fix docstring referring to other files

### DIFF
--- a/Mathlib/Data/Finset/Basic.lean
+++ b/Mathlib/Data/Finset/Basic.lean
@@ -31,16 +31,16 @@ Finsets give a basic foundation for defining finite sums and products over types
   2. `∏ i ∈ (s : Finset α), f i`.
 
 Lean refers to these operations as big operators.
-More information can be found in `Mathlib.Algebra.BigOperators.Group.Finset`.
+More information can be found in `Mathlib/Algebra/BigOperators/Group/Finset.lean`.
 
 Finsets are directly used to define fintypes in Lean.
 A `Fintype α` instance for a type `α` consists of a universal `Finset α` containing every term of
-`α`, called `univ`. See `Mathlib.Data.Fintype.Basic`.
+`α`, called `univ`. See `Mathlib/Data/Fintype/Basic.lean`.
 There is also `univ'`, the noncomputable partner to `univ`,
 which is defined to be `α` as a finset if `α` is finite,
-and the empty finset otherwise. See `Mathlib.Data.Fintype.Basic`.
+and the empty finset otherwise. See `Mathlib/Data/Fintype/Basic.lean`.
 
-`Finset.card`, the size of a finset is defined in `Mathlib.Data.Finset.Card`.
+`Finset.card`, the size of a finset is defined in `Mathlib/Data/Finset/Card.lean`.
 This is then used to define `Fintype.card`, the size of a type.
 
 ## Main declarations
@@ -78,7 +78,7 @@ This is then used to define `Fintype.card`, the size of a type.
 
 There is a natural lattice structure on the subsets of a set.
 In Lean, we use lattice notation to talk about things involving unions and intersections. See
-`Mathlib.Order.Lattice`. For the lattice structure on finsets, `⊥` is called `bot` with `⊥ = ∅` and
+`Mathlib/Order/Lattice.lean`. For the lattice structure on finsets, `⊥` is called `bot` with `⊥ = ∅` and
 `⊤` is called `top` with `⊤ = univ`.
 
 * `Finset.instHasSubsetFinset`: Lots of API about lattices, otherwise behaves as one would expect.
@@ -97,7 +97,7 @@ In Lean, we use lattice notation to talk about things involving unions and inter
 * `Finset.erase`: For any `a : α`, `erase s a` returns `s` with the element `a` removed.
 * `Finset.instSDiffFinset`: Defines the set difference `s \ t` for finsets `s` and `t`.
 * `Finset.product`: Given finsets of `α` and `β`, defines finsets of `α × β`.
-  For arbitrary dependent products, see `Mathlib.Data.Finset.Pi`.
+  For arbitrary dependent products, see `Mathlib/Data/Finset/Pi.lean`.
 
 ### Predicates on finsets
 
@@ -107,7 +107,7 @@ In Lean, we use lattice notation to talk about things involving unions and inter
 
 ### Equivalences between finsets
 
-* The `Mathlib.Data.Equiv` files describe a general type of equivalence, so look in there for any
+* The `Mathlib/Data/Equiv.lean` files describe a general type of equivalence, so look in there for any
   lemmas. There is some API for rewriting sums and products from `s` to `t` given that `s ≃ t`.
   TODO: examples
 

--- a/Mathlib/Data/Finset/Basic.lean
+++ b/Mathlib/Data/Finset/Basic.lean
@@ -78,8 +78,8 @@ This is then used to define `Fintype.card`, the size of a type.
 
 There is a natural lattice structure on the subsets of a set.
 In Lean, we use lattice notation to talk about things involving unions and intersections. See
-`Mathlib/Order/Lattice.lean`. For the lattice structure on finsets, `⊥` is called `bot` with `⊥ = ∅` and
-`⊤` is called `top` with `⊤ = univ`.
+`Mathlib/Order/Lattice.lean`. For the lattice structure on finsets, `⊥` is called `bot` with
+`⊥ = ∅` and `⊤` is called `top` with `⊤ = univ`.
 
 * `Finset.instHasSubsetFinset`: Lots of API about lattices, otherwise behaves as one would expect.
 * `Finset.instUnionFinset`: Defines `s ∪ t` (or `s ⊔ t`) as the union of `s` and `t`.
@@ -107,8 +107,8 @@ In Lean, we use lattice notation to talk about things involving unions and inter
 
 ### Equivalences between finsets
 
-* The `Mathlib/Data/Equiv.lean` files describe a general type of equivalence, so look in there for any
-  lemmas. There is some API for rewriting sums and products from `s` to `t` given that `s ≃ t`.
+* The `Mathlib/Data/Equiv.lean` files describe a general type of equivalence, so look in there for
+  any lemmas. There is some API for rewriting sums and products from `s` to `t` given that `s ≃ t`.
   TODO: examples
 
 ## Tags


### PR DESCRIPTION
This PR fixes docstring referring to other files. Originally they were `Mathlib.XXX.XXX`, but according to doc-gen4, to make them work correctly, they should be `Mathlib/XXX/XXX.lean`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
