### PR TITLE
[Merged by Bors] - chore: remove two mathport syntax stubs

### DIFF
--- a/Mathlib/Mathport/Syntax.lean
+++ b/Mathlib/Mathport/Syntax.lean
@@ -266,8 +266,6 @@ syntax generalizingClause := " generalizing" (ppSpace ident)+
 
 /- N -/ syntax (name := addTacticDoc) (docComment)? "add_tactic_doc " term : command
 
-/- M -/ syntax (name := addHintTactic) "add_hint_tactic " tactic : command
-
 /- S -/ syntax (name := listUnusedDecls) "#list_unused_decls" : command
 
 /- N -/ syntax (name := defReplacer) "def_replacer " ident Parser.Term.optType : command

--- a/Mathlib/Mathport/Syntax.lean
+++ b/Mathlib/Mathport/Syntax.lean
@@ -225,7 +225,6 @@ syntax generalizingClause := " generalizing" (ppSpace ident)+
 /- E -/ syntax (name := nthRwLHS) "nth_rw_lhs " num rwRuleSeq (location)? : tactic
 /- E -/ syntax (name := nthRwRHS) "nth_rw_rhs " num rwRuleSeq (location)? : tactic
 
-/- S -/ syntax (name := rwSearch) "rw_search" (config)? rwRuleSeq : tactic
 /- S -/ syntax (name := rwSearch?) "rw_search?" (config)? rwRuleSeq : tactic
 
 /- M -/ syntax (name := piInstanceDeriveField) "pi_instance_derive_field" : tactic

--- a/Mathlib/Mathport/Syntax.lean
+++ b/Mathlib/Mathport/Syntax.lean
@@ -225,8 +225,6 @@ syntax generalizingClause := " generalizing" (ppSpace ident)+
 /- E -/ syntax (name := nthRwLHS) "nth_rw_lhs " num rwRuleSeq (location)? : tactic
 /- E -/ syntax (name := nthRwRHS) "nth_rw_rhs " num rwRuleSeq (location)? : tactic
 
-/- S -/ syntax (name := rwSearch?) "rw_search?" (config)? rwRuleSeq : tactic
-
 /- M -/ syntax (name := piInstanceDeriveField) "pi_instance_derive_field" : tactic
 /- M -/ syntax (name := piInstance) "pi_instance" : tactic
 

--- a/scripts/nolints.json
+++ b/scripts/nolints.json
@@ -641,7 +641,6 @@
  ["docBlame", "Mathlib.Tactic.revertTargetDeps"],
  ["docBlame", "Mathlib.Tactic.rintro?"],
  ["docBlame", "Mathlib.Tactic.rsimp"],
- ["docBlame", "Mathlib.Tactic.rwSearch?"],
  ["docBlame", "Mathlib.Tactic.safe"],
  ["docBlame", "Mathlib.Tactic.sample"],
  ["docBlame", "Mathlib.Tactic.setArgsRest"],

--- a/scripts/nolints.json
+++ b/scripts/nolints.json
@@ -559,7 +559,6 @@
  ["docBlame", "Mathlib.ProjectionNotation.getPPCollapseStructureProjections"],
  ["docBlame", "Mathlib.Tactic.abstract"],
  ["docBlame", "Mathlib.Tactic.acMono"],
- ["docBlame", "Mathlib.Tactic.addHintTactic"],
  ["docBlame", "Mathlib.Tactic.addTacticDoc"],
  ["docBlame", "Mathlib.Tactic.applyField"],
  ["docBlame", "Mathlib.Tactic.applyNormed"],

--- a/scripts/nolints.json
+++ b/scripts/nolints.json
@@ -642,7 +642,6 @@
  ["docBlame", "Mathlib.Tactic.revertTargetDeps"],
  ["docBlame", "Mathlib.Tactic.rintro?"],
  ["docBlame", "Mathlib.Tactic.rsimp"],
- ["docBlame", "Mathlib.Tactic.rwSearch"],
  ["docBlame", "Mathlib.Tactic.rwSearch?"],
  ["docBlame", "Mathlib.Tactic.safe"],
  ["docBlame", "Mathlib.Tactic.sample"],


### PR DESCRIPTION
The `hint` and `rw_search` tactics have been implemented by now.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
