### PR TITLE
[Merged by Bors] - doc: add a couple of module docstrings

### DIFF
--- a/Mathlib/Data/String/Lemmas.lean
+++ b/Mathlib/Data/String/Lemmas.lean
@@ -7,6 +7,10 @@ import Mathlib.Init.Data.Nat.Notation
 import Mathlib.Data.String.Defs
 import Mathlib.Tactic.Basic
 
+/-!
+# Miscellaneous lemmas about strings
+-/
+
 namespace String
 
 lemma congr_append : ∀ (a b : String), a ++ b = String.mk (a.data ++ b.data)

--- a/Mathlib/Lean/Exception.lean
+++ b/Mathlib/Lean/Exception.lean
@@ -5,6 +5,15 @@ Authors: E.W.Ayers
 -/
 import Lean.Exception
 
+/-!
+# Additional methods for working with `Exception`s
+
+This file contains two additional methods for working with `Exception`s
+* `successIfFail`, a generalisation of `fail_if_success` to arbitrary `MonadError`s
+* `isFailedToSynthesize`: check if an exception is of the "failed to synthesize" form
+
+-/
+
 set_option autoImplicit true
 
 open Lean

--- a/Mathlib/Lean/Expr/ReplaceRec.lean
+++ b/Mathlib/Lean/Expr/ReplaceRec.lean
@@ -7,12 +7,14 @@ Floris van Doorn, E.W.Ayers
 import Lean.Expr
 import Mathlib.Util.MemoFix
 
-namespace Lean.Expr
 /-!
 # ReplaceRec
 
 We define a more flexible version of `Expr.replace` where we can use recursive calls even when
-replacing a subexpression. We completely mimic the implementation of `Expr.replace`. -/
+replacing a subexpression. We completely mimic the implementation of `Expr.replace`.
+-/
+
+namespace Lean.Expr
 
 /-- A version of `Expr.replace` where the replacement function is available to the function `f?`.
 

--- a/Mathlib/Lean/LocalContext.lean
+++ b/Mathlib/Lean/LocalContext.lean
@@ -5,6 +5,10 @@ Authors: Scott Morrison
 -/
 import Lean.LocalContext
 
+/-!
+# Additional methods about `LocalContext`
+-/
+
 namespace Lean.LocalContext
 
 universe u v

--- a/Mathlib/Logic/Lemmas.lean
+++ b/Mathlib/Logic/Lemmas.lean
@@ -14,6 +14,7 @@ import Mathlib.Tactic.Tauto
 # More basic logic properties
 A few more logic lemmas. These are in their own file, rather than `Logic.Basic`, because it is
 convenient to be able to use the `tauto` or `split_ifs` tactics.
+
 ## Implementation notes
 We spell those lemmas out with `dite` and `ite` rather than the `if then else` notation because this
 would result in less delta-reduced statements.

--- a/Mathlib/Mathport/Attributes.lean
+++ b/Mathlib/Mathport/Attributes.lean
@@ -5,6 +5,12 @@ Authors: Mario Carneiro
 -/
 import Lean.Attributes
 
+/-!
+# Defines the "substitution" attribute for mathport
+
+This has to be defined in a separate file.
+-/
+
 namespace Lean.Attr
 
 initialize substAttr : TagAttribute ← registerTagAttribute `subst "substitution"

--- a/Mathlib/Mathport/Rename.lean
+++ b/Mathlib/Mathport/Rename.lean
@@ -6,6 +6,14 @@ Authors: Daniel Selsam
 import Lean.Elab.Command
 import Lean.Linter.Util
 
+/-!
+# Mathport infrastructure for tracking renaming Lean 3 to Lean 4 names
+
+This file defines mathport infrastructure for tracking renaming of Lean 3 declarations to
+their Lean 4 counterparts. This correspondence is declared in the ported file using the
+`#align` command (and its variants with `ₓ` and `#noalign`).
+-/
+
 namespace Mathlib.Prelude.Rename
 
 open Lean

--- a/scripts/style-exceptions.txt
+++ b/scripts/style-exceptions.txt
@@ -1,10 +1,4 @@
 Mathlib/Data/ByteArray.lean : line 7 : ERR_MOD : Module docstring missing, or too late
-Mathlib/Data/String/Lemmas.lean : line 10 : ERR_MOD : Module docstring missing, or too late
-Mathlib/Lean/Exception.lean : line 8 : ERR_MOD : Module docstring missing, or too late
-Mathlib/Lean/Expr/ReplaceRec.lean : line 10 : ERR_MOD : Module docstring missing, or too late
-Mathlib/Lean/LocalContext.lean : line 8 : ERR_MOD : Module docstring missing, or too late
-Mathlib/Mathport/Attributes.lean : line 8 : ERR_MOD : Module docstring missing, or too late
-Mathlib/Mathport/Rename.lean : line 9 : ERR_MOD : Module docstring missing, or too late
 Mathlib/Tactic/ApplyWith.lean : line 9 : ERR_MOD : Module docstring missing, or too late
 Mathlib/Tactic/Basic.lean : line 14 : ERR_MOD : Module docstring missing, or too late
 Mathlib/Tactic/ByContra.lean : line 8 : ERR_MOD : Module docstring missing, or too late


### PR DESCRIPTION
This covers about a third of the missing files in mathlib: the remaining files are `Data/ByteArray` or in the Tactic directory.

---

Close checking of these is very welcome: I'm not certain about `Mathlib/Attribute`, for instance.

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
