### PR TITLE
[Merged by Bors] - chore: Move group lemmas out of `GroupTheory.GroupAction.Group`

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -204,6 +204,7 @@ import Mathlib.Algebra.GCDMonoid.Nat
 import Mathlib.Algebra.GeomSum
 import Mathlib.Algebra.GradedMonoid
 import Mathlib.Algebra.GradedMulAction
+import Mathlib.Algebra.Group.Action.Basic
 import Mathlib.Algebra.Group.Action.Defs
 import Mathlib.Algebra.Group.Action.Opposite
 import Mathlib.Algebra.Group.Action.Option

--- a/Mathlib/Algebra/Group/Action/Basic.lean
+++ b/Mathlib/Algebra/Group/Action/Basic.lean
@@ -1,0 +1,181 @@
+/-
+Copyright (c) 2018 Chris Hughes. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Chris Hughes
+-/
+import Mathlib.Algebra.Group.Action.Units
+import Mathlib.Algebra.Group.Invertible.Basic
+import Mathlib.GroupTheory.Perm.Basic
+
+#align_import group_theory.group_action.group from "leanprover-community/mathlib"@"3b52265189f3fb43aa631edffce5d060fafaf82f"
+
+/-!
+# More lemmas about group actions
+
+This file contains lemmas about group actions that require more imports than
+`Algebra.Group.Action.Defs` offers.
+-/
+
+assert_not_exists MonoidWithZero
+
+variable {α β γ : Type*}
+
+section MulAction
+
+section Group
+
+variable [Group α] [MulAction α β]
+
+/-- Given an action of a group `α` on `β`, each `g : α` defines a permutation of `β`. -/
+@[to_additive (attr := simps)]
+def MulAction.toPerm (a : α) : Equiv.Perm β :=
+  ⟨fun x => a • x, fun x => a⁻¹ • x, inv_smul_smul a, smul_inv_smul a⟩
+#align mul_action.to_perm MulAction.toPerm
+#align add_action.to_perm AddAction.toPerm
+#align add_action.to_perm_apply AddAction.toPerm_apply
+#align mul_action.to_perm_apply MulAction.toPerm_apply
+#align add_action.to_perm_symm_apply AddAction.toPerm_symm_apply
+#align mul_action.to_perm_symm_apply MulAction.toPerm_symm_apply
+
+/-- Given an action of an additive group `α` on `β`, each `g : α` defines a permutation of `β`. -/
+add_decl_doc AddAction.toPerm
+
+/-- `MulAction.toPerm` is injective on faithful actions. -/
+@[to_additive "`AddAction.toPerm` is injective on faithful actions."]
+lemma MulAction.toPerm_injective [FaithfulSMul α β] :
+    Function.Injective (MulAction.toPerm : α → Equiv.Perm β) :=
+  (show Function.Injective (Equiv.toFun ∘ MulAction.toPerm) from smul_left_injective').of_comp
+#align mul_action.to_perm_injective MulAction.toPerm_injective
+#align add_action.to_perm_injective AddAction.toPerm_injective
+
+variable (α) (β)
+
+/-- Given an action of a group `α` on a set `β`, each `g : α` defines a permutation of `β`. -/
+@[simps]
+def MulAction.toPermHom : α →* Equiv.Perm β where
+  toFun := MulAction.toPerm
+  map_one' := Equiv.ext <| one_smul α
+  map_mul' u₁ u₂ := Equiv.ext <| mul_smul (u₁ : α) u₂
+#align mul_action.to_perm_hom MulAction.toPermHom
+#align mul_action.to_perm_hom_apply MulAction.toPermHom_apply
+
+/-- Given an action of an additive group `α` on a set `β`, each `g : α` defines a permutation of
+`β`. -/
+@[simps!]
+def AddAction.toPermHom (α : Type*) [AddGroup α] [AddAction α β] :
+    α →+ Additive (Equiv.Perm β) :=
+  MonoidHom.toAdditive'' <| MulAction.toPermHom (Multiplicative α) β
+#align add_action.to_perm_hom AddAction.toPermHom
+
+/-- The tautological action by `Equiv.Perm α` on `α`.
+
+This generalizes `Function.End.applyMulAction`. -/
+instance Equiv.Perm.applyMulAction (α : Type*) : MulAction (Equiv.Perm α) α where
+  smul f a := f a
+  one_smul _ := rfl
+  mul_smul _ _ _ := rfl
+#align equiv.perm.apply_mul_action Equiv.Perm.applyMulAction
+
+@[simp]
+protected lemma Equiv.Perm.smul_def {α : Type*} (f : Equiv.Perm α) (a : α) : f • a = f a :=
+  rfl
+#align equiv.perm.smul_def Equiv.Perm.smul_def
+
+/-- `Equiv.Perm.applyMulAction` is faithful. -/
+instance Equiv.Perm.applyFaithfulSMul (α : Type*) : FaithfulSMul (Equiv.Perm α) α :=
+  ⟨Equiv.ext⟩
+#align equiv.perm.apply_has_faithful_smul Equiv.Perm.applyFaithfulSMul
+
+variable {α} {β}
+
+@[to_additive]
+protected lemma MulAction.bijective (g : α) : Function.Bijective (g • · : β → β) :=
+  (MulAction.toPerm g).bijective
+#align mul_action.bijective MulAction.bijective
+#align add_action.bijective AddAction.bijective
+
+@[to_additive]
+protected lemma MulAction.injective (g : α) : Function.Injective (g • · : β → β) :=
+  (MulAction.bijective g).injective
+#align mul_action.injective MulAction.injective
+#align add_action.injective AddAction.injective
+
+@[to_additive]
+protected lemma MulAction.surjective (g : α) : Function.Surjective (g • · : β → β) :=
+  (MulAction.bijective g).surjective
+#align mul_action.surjective MulAction.surjective
+#align add_action.surjective AddAction.surjective
+
+@[to_additive]
+lemma smul_left_cancel (g : α) {x y : β} (h : g • x = g • y) : x = y := MulAction.injective g h
+#align smul_left_cancel smul_left_cancel
+#align vadd_left_cancel vadd_left_cancel
+
+@[to_additive (attr := simp)]
+lemma smul_left_cancel_iff (g : α) {x y : β} : g • x = g • y ↔ x = y :=
+  (MulAction.injective g).eq_iff
+#align smul_left_cancel_iff smul_left_cancel_iff
+#align vadd_left_cancel_iff vadd_left_cancel_iff
+
+@[to_additive]
+lemma smul_eq_iff_eq_inv_smul (g : α) {x y : β} : g • x = y ↔ x = g⁻¹ • y :=
+  (MulAction.toPerm g).apply_eq_iff_eq_symm_apply
+#align smul_eq_iff_eq_inv_smul smul_eq_iff_eq_inv_smul
+#align vadd_eq_iff_eq_neg_vadd vadd_eq_iff_eq_neg_vadd
+
+end Group
+
+section Monoid
+variable [Monoid α] [MulAction α β] (c : α) (x y : β) [Invertible c]
+
+@[simp] lemma invOf_smul_smul : ⅟c • c • x = x := inv_smul_smul (unitOfInvertible c) _
+@[simp] lemma smul_invOf_smul : c • (⅟ c • x) = x := smul_inv_smul (unitOfInvertible c) _
+
+variable {c x y}
+
+lemma invOf_smul_eq_iff : ⅟c • x = y ↔ x = c • y := inv_smul_eq_iff (g := unitOfInvertible c)
+
+lemma smul_eq_iff_eq_invOf_smul : c • x = y ↔ x = ⅟c • y :=
+  smul_eq_iff_eq_inv_smul (g := unitOfInvertible c)
+
+end Monoid
+end MulAction
+
+section Arrow
+
+/-- If `G` acts on `A`, then it acts also on `A → B`, by `(g • F) a = F (g⁻¹ • a)`. -/
+@[to_additive (attr := simps) arrowAddAction
+      "If `G` acts on `A`, then it acts also on `A → B`, by `(g +ᵥ F) a = F (g⁻¹ +ᵥ a)`"]
+def arrowAction {G A B : Type*} [DivisionMonoid G] [MulAction G A] : MulAction G (A → B) where
+  smul g F a := F (g⁻¹ • a)
+  one_smul f := by
+    show (fun x => f ((1 : G)⁻¹ • x)) = f
+    simp only [inv_one, one_smul]
+  mul_smul x y f := by
+    show (fun a => f ((x*y)⁻¹ • a)) = (fun a => f (y⁻¹ • x⁻¹ • a))
+    simp only [mul_smul, mul_inv_rev]
+#align arrow_action arrowAction
+#align arrow_add_action arrowAddAction
+
+end Arrow
+
+namespace IsUnit
+variable [Monoid α] [MulAction α β]
+
+@[to_additive]
+lemma smul_left_cancel {a : α} (ha : IsUnit a) {x y : β} : a • x = a • y ↔ x = y :=
+  let ⟨u, hu⟩ := ha
+  hu ▸ smul_left_cancel_iff u
+#align is_unit.smul_left_cancel IsUnit.smul_left_cancel
+#align is_add_unit.vadd_left_cancel IsAddUnit.vadd_left_cancel
+
+end IsUnit
+
+section SMul
+variable [Group α] [Monoid β] [MulAction α β] [SMulCommClass α β β] [IsScalarTower α β β]
+
+@[simp] lemma isUnit_smul_iff (g : α) (m : β) : IsUnit (g • m) ↔ IsUnit m :=
+  ⟨fun h => inv_smul_smul g m ▸ h.smul g⁻¹, IsUnit.smul g⟩
+#align is_unit_smul_iff isUnit_smul_iff
+
+end SMul

--- a/Mathlib/GroupTheory/GroupAction/Embedding.lean
+++ b/Mathlib/GroupTheory/GroupAction/Embedding.lean
@@ -3,8 +3,8 @@ Copyright (c) 2022 Eric Wieser. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Eric Wieser
 -/
+import Mathlib.Algebra.Group.Action.Basic
 import Mathlib.Algebra.Group.Action.Pi
-import Mathlib.GroupTheory.GroupAction.Group
 
 #align_import group_theory.group_action.embedding from "leanprover-community/mathlib"@"a437a2499163d85d670479f69f625f461cc5fef9"
 

--- a/Mathlib/GroupTheory/GroupAction/Group.lean
+++ b/Mathlib/GroupTheory/GroupAction/Group.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Chris Hughes
 -/
 import Mathlib.Algebra.Group.Aut
+import Mathlib.Algebra.Group.Action.Basic
 import Mathlib.Algebra.Group.Invertible.Basic
 import Mathlib.Algebra.GroupWithZero.Units.Basic
 import Mathlib.GroupTheory.GroupAction.Units
@@ -22,130 +23,6 @@ universe u v w
 variable {α : Type u} {β : Type v} {γ : Type w}
 
 section MulAction
-section Group
-
-variable [Group α] [MulAction α β]
-
-/-- Given an action of a group `α` on `β`, each `g : α` defines a permutation of `β`. -/
-@[to_additive (attr := simps)]
-def MulAction.toPerm (a : α) : Equiv.Perm β :=
-  ⟨fun x => a • x, fun x => a⁻¹ • x, inv_smul_smul a, smul_inv_smul a⟩
-#align mul_action.to_perm MulAction.toPerm
-#align add_action.to_perm AddAction.toPerm
-#align add_action.to_perm_apply AddAction.toPerm_apply
-#align mul_action.to_perm_apply MulAction.toPerm_apply
-#align add_action.to_perm_symm_apply AddAction.toPerm_symm_apply
-#align mul_action.to_perm_symm_apply MulAction.toPerm_symm_apply
-
-/-- Given an action of an additive group `α` on `β`, each `g : α` defines a permutation of `β`. -/
-add_decl_doc AddAction.toPerm
-
-/-- `MulAction.toPerm` is injective on faithful actions. -/
-@[to_additive "`AddAction.toPerm` is injective on faithful actions."]
-theorem MulAction.toPerm_injective [FaithfulSMul α β] :
-    Function.Injective (MulAction.toPerm : α → Equiv.Perm β) :=
-  (show Function.Injective (Equiv.toFun ∘ MulAction.toPerm) from smul_left_injective').of_comp
-#align mul_action.to_perm_injective MulAction.toPerm_injective
-#align add_action.to_perm_injective AddAction.toPerm_injective
-
-variable (α) (β)
-
-/-- Given an action of a group `α` on a set `β`, each `g : α` defines a permutation of `β`. -/
-@[simps]
-def MulAction.toPermHom : α →* Equiv.Perm β where
-  toFun := MulAction.toPerm
-  map_one' := Equiv.ext <| one_smul α
-  map_mul' u₁ u₂ := Equiv.ext <| mul_smul (u₁ : α) u₂
-#align mul_action.to_perm_hom MulAction.toPermHom
-#align mul_action.to_perm_hom_apply MulAction.toPermHom_apply
-
-/-- Given an action of an additive group `α` on a set `β`, each `g : α` defines a permutation of
-`β`. -/
-@[simps!]
-def AddAction.toPermHom (α : Type*) [AddGroup α] [AddAction α β] :
-    α →+ Additive (Equiv.Perm β) :=
-  MonoidHom.toAdditive'' <| MulAction.toPermHom (Multiplicative α) β
-#align add_action.to_perm_hom AddAction.toPermHom
-
-/-- The tautological action by `Equiv.Perm α` on `α`.
-
-This generalizes `Function.End.applyMulAction`. -/
-instance Equiv.Perm.applyMulAction (α : Type*) : MulAction (Equiv.Perm α) α where
-  smul f a := f a
-  one_smul _ := rfl
-  mul_smul _ _ _ := rfl
-#align equiv.perm.apply_mul_action Equiv.Perm.applyMulAction
-
-@[simp]
-protected theorem Equiv.Perm.smul_def {α : Type*} (f : Equiv.Perm α) (a : α) : f • a = f a :=
-  rfl
-#align equiv.perm.smul_def Equiv.Perm.smul_def
-
-/-- `Equiv.Perm.applyMulAction` is faithful. -/
-instance Equiv.Perm.applyFaithfulSMul (α : Type*) : FaithfulSMul (Equiv.Perm α) α :=
-  ⟨Equiv.ext⟩
-#align equiv.perm.apply_has_faithful_smul Equiv.Perm.applyFaithfulSMul
-
-variable {α} {β}
-
-@[to_additive]
-protected theorem MulAction.bijective (g : α) : Function.Bijective (g • · : β → β) :=
-  (MulAction.toPerm g).bijective
-#align mul_action.bijective MulAction.bijective
-#align add_action.bijective AddAction.bijective
-
-@[to_additive]
-protected theorem MulAction.injective (g : α) : Function.Injective (g • · : β → β) :=
-  (MulAction.bijective g).injective
-#align mul_action.injective MulAction.injective
-#align add_action.injective AddAction.injective
-
-@[to_additive]
-protected theorem MulAction.surjective (g : α) : Function.Surjective (g • · : β → β) :=
-  (MulAction.bijective g).surjective
-#align mul_action.surjective MulAction.surjective
-#align add_action.surjective AddAction.surjective
-
-@[to_additive]
-theorem smul_left_cancel (g : α) {x y : β} (h : g • x = g • y) : x = y :=
-  MulAction.injective g h
-#align smul_left_cancel smul_left_cancel
-#align vadd_left_cancel vadd_left_cancel
-
-@[to_additive (attr := simp)]
-theorem smul_left_cancel_iff (g : α) {x y : β} : g • x = g • y ↔ x = y :=
-  (MulAction.injective g).eq_iff
-#align smul_left_cancel_iff smul_left_cancel_iff
-#align vadd_left_cancel_iff vadd_left_cancel_iff
-
-@[to_additive]
-theorem smul_eq_iff_eq_inv_smul (g : α) {x y : β} : g • x = y ↔ x = g⁻¹ • y :=
-  (MulAction.toPerm g).apply_eq_iff_eq_symm_apply
-#align smul_eq_iff_eq_inv_smul smul_eq_iff_eq_inv_smul
-#align vadd_eq_iff_eq_neg_vadd vadd_eq_iff_eq_neg_vadd
-
-end Group
-
-section Monoid
-
-variable [Monoid α] [MulAction α β]
-variable (c : α) (x y : β) [Invertible c]
-
-@[simp]
-theorem invOf_smul_smul : ⅟c • c • x = x := inv_smul_smul (unitOfInvertible c) _
-
-@[simp]
-theorem smul_invOf_smul : c • (⅟ c • x) = x := smul_inv_smul (unitOfInvertible c) _
-
-variable {c x y}
-
-theorem invOf_smul_eq_iff : ⅟c • x = y ↔ x = c • y :=
-  inv_smul_eq_iff (g := unitOfInvertible c)
-
-theorem smul_eq_iff_eq_invOf_smul : c • x = y ↔ x = ⅟c • y :=
-  smul_eq_iff_eq_inv_smul (g := unitOfInvertible c)
-
-end Monoid
 
 /-- `Monoid.toMulAction` is faithful on nontrivial cancellative monoids with zero. -/
 instance CancelMonoidWithZero.faithfulSMul [CancelMonoidWithZero α] [Nontrivial α] :
@@ -298,22 +175,6 @@ end MulDistribMulAction
 
 section Arrow
 
-/-- If `G` acts on `A`, then it acts also on `A → B`, by `(g • F) a = F (g⁻¹ • a)`. -/
-@[to_additive (attr := simps) arrowAddAction
-      "If `G` acts on `A`, then it acts also on `A → B`, by `(g +ᵥ F) a = F (g⁻¹ +ᵥ a)`"]
-def arrowAction {G A B : Type*} [DivisionMonoid G] [MulAction G A] : MulAction G (A → B) where
-  smul g F a := F (g⁻¹ • a)
-  one_smul := by
-    intro f
-    show (fun x => f ((1 : G)⁻¹ • x)) = f
-    simp only [inv_one, one_smul]
-  mul_smul := by
-    intros x y f
-    show (fun a => f ((x*y)⁻¹ • a)) = (fun a => f (y⁻¹ • x⁻¹ • a))
-    simp only [mul_smul, mul_inv_rev]
-#align arrow_action arrowAction
-#align arrow_add_action arrowAddAction
-
 attribute [local instance] arrowAction
 
 /-- When `B` is a monoid, `ArrowAction` is additionally a `MulDistribMulAction`. -/
@@ -338,19 +199,6 @@ end Arrow
 
 namespace IsUnit
 
-section MulAction
-
-variable [Monoid α] [MulAction α β]
-
-@[to_additive]
-theorem smul_left_cancel {a : α} (ha : IsUnit a) {x y : β} : a • x = a • y ↔ x = y :=
-  let ⟨u, hu⟩ := ha
-  hu ▸ smul_left_cancel_iff u
-#align is_unit.smul_left_cancel IsUnit.smul_left_cancel
-#align is_add_unit.vadd_left_cancel IsAddUnit.vadd_left_cancel
-
-end MulAction
-
 section DistribMulAction
 
 variable [Monoid α] [AddMonoid β] [DistribMulAction α β]
@@ -367,12 +215,6 @@ end IsUnit
 section SMul
 
 variable [Group α] [Monoid β]
-
-@[simp]
-theorem isUnit_smul_iff [MulAction α β] [SMulCommClass α β β] [IsScalarTower α β β] (g : α)
-    (m : β) : IsUnit (g • m) ↔ IsUnit m :=
-  ⟨fun h => inv_smul_smul g m ▸ h.smul g⁻¹, IsUnit.smul g⟩
-#align is_unit_smul_iff isUnit_smul_iff
 
 theorem IsUnit.smul_sub_iff_sub_inv_smul [AddGroup β] [DistribMulAction α β] [IsScalarTower α β β]
     [SMulCommClass α β β] (r : α) (a : β) : IsUnit (r • (1 : β) - a) ↔ IsUnit (1 - r⁻¹ • a) := by

--- a/Mathlib/GroupTheory/Perm/Subgroup.lean
+++ b/Mathlib/GroupTheory/Perm/Subgroup.lean
@@ -3,9 +3,9 @@ Copyright (c) 2020 Eric Wieser. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Eric Wieser
 -/
+import Mathlib.Algebra.Group.Action.Basic
 import Mathlib.Algebra.Group.Subgroup.Finite
 import Mathlib.Data.Fintype.Perm
-import Mathlib.GroupTheory.GroupAction.Group
 import Mathlib.GroupTheory.Perm.Basic
 
 #align_import group_theory.perm.subgroup from "leanprover-community/mathlib"@"4c19a16e4b705bf135cf9a80ac18fcc99c438514"


### PR DESCRIPTION
The rest of the file is now purely about `GroupWithZero` and alike, and will be moved under `Algebra.GroupWithZero.Action` in a future PR.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
