### PR TITLE
[Merged by Bors] - chore: remove unused lemmas about bit0/1

### DIFF
--- a/Mathlib/Algebra/Order/Ring/Int.lean
+++ b/Mathlib/Algebra/Order/Ring/Int.lean
@@ -75,34 +75,7 @@ lemma add_two_le_iff_lt_of_even_sub {m n : ℤ} (even : Even (n - m)) : m + 2 �
 
 end Int
 
-section bit0_bit1
-variable {R}
-set_option linter.deprecated false
-
--- The next four lemmas allow us to replace multiplication by a numeral with a `zsmul` expression.
-
-section NonUnitalNonAssocRing
-variable [NonUnitalNonAssocRing R] (n r : R)
-
-lemma bit0_mul : (2 • n) * r = (2 : ℤ) • (n * r) := by
-  rw [two_nsmul, add_mul, ← one_add_one_eq_two, add_zsmul, one_zsmul]
-#align bit0_mul bit0_mul
-
-lemma mul_bit0 : r * (2 • n) = (2 : ℤ) • (r * n) := by
-  rw [two_nsmul, mul_add, ← one_add_one_eq_two, add_zsmul, one_zsmul]
-#align mul_bit0 mul_bit0
-
-end NonUnitalNonAssocRing
-
-section NonAssocRing
-variable [NonAssocRing R] (n r : R)
-
-lemma bit1_mul : (2 • n + 1) * r = (2 : ℤ) • (n * r) + r := by rw [add_mul, bit0_mul, one_mul]
-#align bit1_mul bit1_mul
-
-lemma mul_bit1 {n r : R} : r * (2 • n + 1) = (2 : ℤ) • (r * n) + r := by
-  rw [mul_add, mul_bit0, mul_one]
-#align mul_bit1 mul_bit1
-
-end NonAssocRing
-end bit0_bit1
+#noalign bit0_mul
+#noalign mul_bit0
+#noalign bit1_mul
+#noalign mul_bit1

--- a/Mathlib/Algebra/Polynomial/Degree/Lemmas.lean
+++ b/Mathlib/Algebra/Polynomial/Degree/Lemmas.lean
@@ -255,16 +255,8 @@ theorem natDegree_sum_eq_of_disjoint (f : S → R[X]) (s : Finset S)
     simp [H x hx]
 #align polynomial.nat_degree_sum_eq_of_disjoint Polynomial.natDegree_sum_eq_of_disjoint
 
-set_option linter.deprecated false in
-theorem natDegree_bit0 (a : R[X]) : (2 * a).natDegree ≤ a.natDegree := by
-  rw [two_mul]
-  exact (natDegree_add_le _ _).trans (max_self _).le
-#align polynomial.nat_degree_bit0 Polynomial.natDegree_bit0
-
-set_option linter.deprecated false in
-theorem natDegree_bit1 (a : R[X]) : (2 * a + 1).natDegree ≤ a.natDegree :=
-  (natDegree_add_le _ _).trans (by simp [natDegree_bit0])
-#align polynomial.nat_degree_bit1 Polynomial.natDegree_bit1
+#noalign polynomial.nat_degree_bit0
+#noalign polynomial.nat_degree_bit1
 
 variable [Semiring S]
 

--- a/Mathlib/Algebra/Tropical/Basic.lean
+++ b/Mathlib/Algebra/Tropical/Basic.lean
@@ -346,8 +346,7 @@ theorem add_eq_right_iff {x y : Tropical R} : x + y = y ↔ y ≤ x := by
 theorem add_self (x : Tropical R) : x + x = x :=
   untrop_injective (min_eq_right le_rfl)
 #align tropical.add_self Tropical.add_self
-
-#noalign tropical.bit0
+#align tropical.bit0 Tropical.add_self
 
 theorem add_eq_iff {x y z : Tropical R} : x + y = z ↔ x = z ∧ x ≤ y ∨ y = z ∧ y ≤ x := by
   rw [trop_add_def, trop_eq_iff_eq_untrop]


### PR DESCRIPTION
Deletions:
- bit0_mul
- mul_bit0
- bit1_mul
- mul_bit1
- Polynomial.natDegree_bit0
- Polynomial.natDegree_bit1
- Polynomial.bit0_comp
- Polynomial.bit1_comp

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
