### PR TITLE
[Merged by Bors] - feat(AlgebraicGeometry/Pullbacks): Fibred product of affine schemes.

### DIFF
--- a/Mathlib/Algebra/Category/Ring/Constructions.lean
+++ b/Mathlib/Algebra/Category/Ring/Constructions.lean
@@ -34,16 +34,16 @@ namespace CommRingCat
 
 section Pushout
 
-variable {R A B : CommRingCat.{u}} (f : R ⟶ A) (g : R ⟶ B)
+variable (R A B : Type u) [CommRing R] [CommRing A] [CommRing B]
+variable [Algebra R A] [Algebra R B]
 
 /-- The explicit cocone with tensor products as the fibered product in `CommRingCat`. -/
-def pushoutCocone : Limits.PushoutCocone f g := by
-  letI := RingHom.toAlgebra f
-  letI := RingHom.toAlgebra g
+def pushoutCocone : Limits.PushoutCocone
+    (CommRingCat.ofHom (algebraMap R A)) (CommRingCat.ofHom (algebraMap R B)) := by
   fapply Limits.PushoutCocone.mk
-  · show CommRingCat; exact CommRingCat.of (A ⊗[R] B)
-  · show A ⟶ _; exact Algebra.TensorProduct.includeLeftRingHom
-  · show B ⟶ _; exact Algebra.TensorProduct.includeRight.toRingHom
+  · exact CommRingCat.of (A ⊗[R] B)
+  · exact Algebra.TensorProduct.includeLeftRingHom (A := A)
+  · exact Algebra.TensorProduct.includeRight.toRingHom (A := B)
   · ext r
     trans algebraMap R (A ⊗[R] B) r
     · exact Algebra.TensorProduct.includeLeft.commutes (R := R) r
@@ -53,75 +53,51 @@ set_option linter.uppercaseLean3 false in
 
 @[simp]
 theorem pushoutCocone_inl :
-    (pushoutCocone f g).inl = by
-      letI := f.toAlgebra
-      letI := g.toAlgebra
-      exact Algebra.TensorProduct.includeLeftRingHom :=
+    (pushoutCocone R A B).inl = Algebra.TensorProduct.includeLeftRingHom (A := A) :=
   rfl
 set_option linter.uppercaseLean3 false in
 #align CommRing.pushout_cocone_inl CommRingCat.pushoutCocone_inl
 
 @[simp]
 theorem pushoutCocone_inr :
-    (pushoutCocone f g).inr = by
-      letI := f.toAlgebra
-      letI := g.toAlgebra
-      exact Algebra.TensorProduct.includeRight.toRingHom :=
+    (pushoutCocone R A B).inr = Algebra.TensorProduct.includeRight.toRingHom (A := B) :=
   rfl
 set_option linter.uppercaseLean3 false in
 #align CommRing.pushout_cocone_inr CommRingCat.pushoutCocone_inr
 
 @[simp]
 theorem pushoutCocone_pt :
-    (pushoutCocone f g).pt = by
-      letI := f.toAlgebra
-      letI := g.toAlgebra
-      exact CommRingCat.of (A ⊗[R] B) :=
+    (pushoutCocone R A B).pt = CommRingCat.of (A ⊗[R] B) :=
   rfl
 set_option linter.uppercaseLean3 false in
 #align CommRing.pushout_cocone_X CommRingCat.pushoutCocone_pt
 
 /-- Verify that the `pushout_cocone` is indeed the colimit. -/
-def pushoutCoconeIsColimit : Limits.IsColimit (pushoutCocone f g) :=
+def pushoutCoconeIsColimit : Limits.IsColimit (pushoutCocone R A B) :=
   Limits.PushoutCocone.isColimitAux' _ fun s => by
-    letI := RingHom.toAlgebra f
-    letI := RingHom.toAlgebra g
-    letI := RingHom.toAlgebra (f ≫ s.inl)
+    letI := RingHom.toAlgebra (s.inl.comp (algebraMap R A))
     let f' : A →ₐ[R] s.pt :=
       { s.inl with
         commutes' := fun r => rfl }
     let g' : B →ₐ[R] s.pt :=
       { s.inr with
-        commutes' := fun r => by
-          change (g ≫ s.inr) r = (f ≫ s.inl) r
-          congr 1
-          exact
-            (s.ι.naturality Limits.WalkingSpan.Hom.snd).trans
-              (s.ι.naturality Limits.WalkingSpan.Hom.fst).symm }
-    -- Porting note: Lean has forget why `A ⊗[R] B` makes sense
-    letI : Algebra R A := f.toAlgebra
-    letI : Algebra R B := g.toAlgebra
-    letI : Algebra R (pushoutCocone f g).pt := show Algebra R (A ⊗[R] B) by infer_instance
+        commutes' := DFunLike.congr_fun ((s.ι.naturality Limits.WalkingSpan.Hom.snd).trans
+              (s.ι.naturality Limits.WalkingSpan.Hom.fst).symm) }
+    letI : Algebra R (pushoutCocone R A B).pt := show Algebra R (A ⊗[R] B) by infer_instance
     -- The factor map is a ⊗ b ↦ f(a) * g(b).
     use AlgHom.toRingHom (Algebra.TensorProduct.productMap f' g')
     simp only [pushoutCocone_inl, pushoutCocone_inr]
     constructor
     · ext x
-      -- Porting note: Lean can't see through `forget` functor
-      letI : Semiring ((forget CommRingCat).obj A) := A.str.toSemiring
-      letI : Algebra R ((forget CommRingCat).obj A) := show Algebra R A by infer_instance
-      exact Algebra.TensorProduct.productMap_left_apply _ _ x
+      exact Algebra.TensorProduct.productMap_left_apply (A := A) _ _ x
     constructor
     · ext x
-      -- Porting note: Lean can't see through `forget` functor
-      letI : Semiring ((forget CommRingCat).obj B) := B.str.toSemiring
-      letI : Algebra R ((forget CommRingCat).obj B) := show Algebra R B by infer_instance
-      exact Algebra.TensorProduct.productMap_right_apply _ _ x
+      exact Algebra.TensorProduct.productMap_right_apply (B := B) _ _ x
     intro h eq1 eq2
     let h' : A ⊗[R] B →ₐ[R] s.pt :=
       { h with
         commutes' := fun r => by
-          change h (f r ⊗ₜ[R] 1) = s.inl (f r)
+          change h (algebraMap R A r ⊗ₜ[R] 1) = s.inl (algebraMap R A r)
           rw [← eq1]
           simp only [pushoutCocone_pt, coe_of, AlgHom.toRingHom_eq_coe]
           rfl }

--- a/Mathlib/AlgebraicGeometry/Pullbacks.lean
+++ b/Mathlib/AlgebraicGeometry/Pullbacks.lean
@@ -620,4 +620,43 @@ instance Scheme.pullback_map_isOpenImmersion {X Y S X' Y' S' : Scheme}
   rw [pullback_map_eq_pullbackFstFstIso_inv]
   infer_instance
 
+section Spec
+
+variable (R S T : Type u) [CommRing R] [CommRing S] [CommRing T] [Algebra R S] [Algebra R T]
+
+open TensorProduct Algebra.TensorProduct CommRingCat
+
+/-- The isomorphism between the fiber product of two affine schemes `Spec B` and `Spec C`
+over an affine scheme `Spec A` and the `Spec` of the tensor product `B ⊗[A] C`.-/
+noncomputable
+def pullbackSpecIso :
+    pullback (Spec.map (CommRingCat.ofHom (algebraMap R S)))
+      (Spec.map (CommRingCat.ofHom (algebraMap R T))) ≅ Spec (.of <| S ⊗[R] T) :=
+  letI H := IsLimit.equivIsoLimit (PullbackCone.eta _)
+    (PushoutCocone.isColimitEquivIsLimitOp _ (CommRingCat.pushoutCoconeIsColimit R S T))
+  limit.isoLimitCone ⟨_, isLimitPullbackConeMapOfIsLimit Scheme.Spec _ H⟩
+
+@[reassoc (attr := simp)]
+lemma pullbackSpecIso_inv_fst :
+    (pullbackSpecIso R S T).inv ≫ pullback.fst _ _ = Spec.map (ofHom includeLeftRingHom) :=
+  limit.isoLimitCone_inv_π _ _
+
+@[reassoc (attr := simp)]
+lemma pullbackSpecIso_inv_snd :
+    (pullbackSpecIso R S T).inv ≫ pullback.snd _ _ = Spec.map (ofHom includeRight.toRingHom) :=
+  limit.isoLimitCone_inv_π _ _
+
+@[reassoc (attr := simp)]
+lemma pullbackSpecIso_hom_fst :
+    (pullbackSpecIso R S T).hom ≫ Spec.map (ofHom includeLeftRingHom) = pullback.fst _ _ := by
+  rw [← pullbackSpecIso_inv_fst, Iso.hom_inv_id_assoc]
+
+@[reassoc (attr := simp)]
+lemma pullbackSpecIso_hom_snd :
+    (pullbackSpecIso R S T).hom ≫ Spec.map (ofHom includeRight.toRingHom) = pullback.snd _ _ := by
+  rw [← pullbackSpecIso_inv_snd, Iso.hom_inv_id_assoc]
+
+end Spec
+
+
 end AlgebraicGeometry

--- a/Mathlib/AlgebraicGeometry/Pullbacks.lean
+++ b/Mathlib/AlgebraicGeometry/Pullbacks.lean
@@ -624,7 +624,7 @@ section Spec
 
 variable (R S T : Type u) [CommRing R] [CommRing S] [CommRing T] [Algebra R S] [Algebra R T]
 
-open TensorProduct Algebra.TensorProduct CommRingCat
+open TensorProduct Algebra.TensorProduct CommRingCat RingHomClass
 
 /-- The isomorphism between the fiber product of two affine schemes `Spec B` and `Spec C`
 over an affine scheme `Spec A` and the `Spec` of the tensor product `B ⊗[A] C`.-/
@@ -643,7 +643,7 @@ lemma pullbackSpecIso_inv_fst :
 
 @[reassoc (attr := simp)]
 lemma pullbackSpecIso_inv_snd :
-    (pullbackSpecIso R S T).inv ≫ pullback.snd _ _ = Spec.map (ofHom includeRight.toRingHom) :=
+    (pullbackSpecIso R S T).inv ≫ pullback.snd _ _ = Spec.map (ofHom (toRingHom includeRight)) :=
   limit.isoLimitCone_inv_π _ _
 
 @[reassoc (attr := simp)]
@@ -653,7 +653,7 @@ lemma pullbackSpecIso_hom_fst :
 
 @[reassoc (attr := simp)]
 lemma pullbackSpecIso_hom_snd :
-    (pullbackSpecIso R S T).hom ≫ Spec.map (ofHom includeRight.toRingHom) = pullback.snd _ _ := by
+    (pullbackSpecIso R S T).hom ≫ Spec.map (ofHom (toRingHom includeRight)) = pullback.snd _ _ := by
   rw [← pullbackSpecIso_inv_snd, Iso.hom_inv_id_assoc]
 
 end Spec

--- a/Mathlib/AlgebraicGeometry/Pullbacks.lean
+++ b/Mathlib/AlgebraicGeometry/Pullbacks.lean
@@ -626,8 +626,8 @@ variable (R S T : Type u) [CommRing R] [CommRing S] [CommRing T] [Algebra R S] [
 
 open TensorProduct Algebra.TensorProduct CommRingCat RingHomClass
 
-/-- The isomorphism between the fiber product of two affine schemes `Spec B` and `Spec C`
-over an affine scheme `Spec A` and the `Spec` of the tensor product `B ⊗[A] C`.-/
+/-- The isomorphism between the fiber product of two schemes `Spec S` and `Spec T`
+over a scheme `Spec R` and the `Spec` of the tensor product `S ⊗[R] T`.-/
 noncomputable
 def pullbackSpecIso :
     pullback (Spec.map (CommRingCat.ofHom (algebraMap R S)))
@@ -635,22 +635,42 @@ def pullbackSpecIso :
   letI H := IsLimit.equivIsoLimit (PullbackCone.eta _)
     (PushoutCocone.isColimitEquivIsLimitOp _ (CommRingCat.pushoutCoconeIsColimit R S T))
   limit.isoLimitCone ⟨_, isLimitPullbackConeMapOfIsLimit Scheme.Spec _ H⟩
-
+/--
+The composition of the inverse of the isomorphism `pullbackSepcIso R S T` (from the pullback of
+`Spec S ⟶ Spec R` and `Spec T ⟶ Spec R` to `Spec (S ⊗[R] T)`) with the first projection is
+the morphism `Spec (S ⊗[R] T) ⟶ Spec S` obtained by applying `Spec.map` to the ring morphism
+`s ↦ s ⊗ₜ[R] 1`.
+-/
 @[reassoc (attr := simp)]
 lemma pullbackSpecIso_inv_fst :
     (pullbackSpecIso R S T).inv ≫ pullback.fst _ _ = Spec.map (ofHom includeLeftRingHom) :=
   limit.isoLimitCone_inv_π _ _
-
+/--
+The composition of the inverse of the isomorphism `pullbackSepcIso R S T` (from the pullback of
+`Spec S ⟶ Spec R` and `Spec T ⟶ Spec R` to `Spec (S ⊗[R] T)`) with the second projection is
+the morphism `Spec (S ⊗[R] T) ⟶ Spec T` obtained by applying `Spec.map` to the ring morphism
+`t ↦ 1 ⊗ₜ[R] t`.
+-/
 @[reassoc (attr := simp)]
 lemma pullbackSpecIso_inv_snd :
     (pullbackSpecIso R S T).inv ≫ pullback.snd _ _ = Spec.map (ofHom (toRingHom includeRight)) :=
   limit.isoLimitCone_inv_π _ _
-
+/--
+The composition of the isomorphism `pullbackSepcIso R S T` (from the pullback of
+`Spec S ⟶ Spec R` and `Spec T ⟶ Spec R` to `Spec (S ⊗[R] T)`) with the morphism
+`Spec (S ⊗[R] T) ⟶ Spec S` obtained by applying `Spec.map` to the ring morphism `s ↦ s ⊗ₜ[R] 1`
+is the first projection.
+-/
 @[reassoc (attr := simp)]
 lemma pullbackSpecIso_hom_fst :
     (pullbackSpecIso R S T).hom ≫ Spec.map (ofHom includeLeftRingHom) = pullback.fst _ _ := by
   rw [← pullbackSpecIso_inv_fst, Iso.hom_inv_id_assoc]
-
+/--
+The composition of the isomorphism `pullbackSepcIso R S T` (from the pullback of
+`Spec S ⟶ Spec R` and `Spec T ⟶ Spec R` to `Spec (S ⊗[R] T)`) with the morphism
+`Spec (S ⊗[R] T) ⟶ Spec T` obtained by applying `Spec.map` to the ring morphism `t ↦ 1 ⊗ₜ[R] t`
+is the second projection.
+-/
 @[reassoc (attr := simp)]
 lemma pullbackSpecIso_hom_snd :
     (pullbackSpecIso R S T).hom ≫ Spec.map (ofHom (toRingHom includeRight)) = pullback.snd _ _ := by

--- a/Mathlib/RingTheory/RingHomProperties.lean
+++ b/Mathlib/RingTheory/RingHomProperties.lean
@@ -168,13 +168,11 @@ attribute [local instance] Algebra.TensorProduct.rightAlgebra
 theorem StableUnderBaseChange.pushout_inl (hP : RingHom.StableUnderBaseChange @P)
     (hP' : RingHom.RespectsIso @P) {R S T : CommRingCat} (f : R ⟶ S) (g : R ⟶ T) (H : P g) :
     P (pushout.inl _ _ : S ⟶ pushout f g) := by
-  rw [←
-    show _ = pushout.inl _ _ from
-      colimit.isoColimitCocone_ι_inv ⟨_, CommRingCat.pushoutCoconeIsColimit f g⟩
-        WalkingSpan.left,
-    hP'.cancel_right_isIso]
   letI := f.toAlgebra
   letI := g.toAlgebra
+  rw [← show _ = pushout.inl f g from
+      colimit.isoColimitCocone_ι_inv ⟨_, CommRingCat.pushoutCoconeIsColimit R S T⟩ WalkingSpan.left,
+    hP'.cancel_right_isIso]
   dsimp only [CommRingCat.pushoutCocone_inl, PushoutCocone.ι_app_left]
   apply hP R T S (TensorProduct R S T)
   exact H


### PR DESCRIPTION
This contribution was created as part of the AIM workshop "Formalizing algebraic geometry" in June 2024.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
