### PR TITLE
[Merged by Bors] - fix: don't create new branches (and PRs) in update_dependencies.yml

### DIFF
--- a/.github/workflows/update_dependencies.yml
+++ b/.github/workflows/update_dependencies.yml
@@ -29,11 +29,9 @@ jobs:
       - name: Update dependencies
         run: lake update
 
-      - name: Generate branch name
-        id: generate_branch_name
+      - name: Generate PR title
         run: |
           timestamp=$(date -u +"%Y-%m-%d-%H-%M")
-          echo "branch_name=update-dependencies-$timestamp" >> "$GITHUB_ENV"
           echo "pr_title=chore: update Mathlib dependencies $(date -u +"%Y-%m-%d")" >> "$GITHUB_ENV"
 
       - name: Create Pull Request
@@ -41,7 +39,7 @@ jobs:
         with:
           token: "${{ secrets.NIGHTLY_TESTING }}"
           commit-message: "chore: update Mathlib dependencies ${{ env.timestamp }}"
-          branch: "${{ env.branch_name }}"
+          branch: "for-bot-use-only-update-dependencies"
           base: master
           title: "${{ env.pr_title }}"
           body: "This PR updates the Mathlib dependencies."

--- a/.github/workflows/update_dependencies.yml
+++ b/.github/workflows/update_dependencies.yml
@@ -31,7 +31,7 @@ jobs:
 
       - name: Generate PR title
         run: |
-          timestamp=$(date -u +"%Y-%m-%d-%H-%M")
+          echo "timestamp=$(date -u +"%Y-%m-%d-%H-%M")" >> "$GITHUB_ENV"
           echo "pr_title=chore: update Mathlib dependencies $(date -u +"%Y-%m-%d")" >> "$GITHUB_ENV"
 
       - name: Create Pull Request

--- a/.github/workflows/update_dependencies.yml
+++ b/.github/workflows/update_dependencies.yml
@@ -39,7 +39,8 @@ jobs:
         with:
           token: "${{ secrets.NIGHTLY_TESTING }}"
           commit-message: "chore: update Mathlib dependencies ${{ env.timestamp }}"
-          branch: "for-bot-use-only-update-dependencies"
+          # this branch is referenced in update_dependencies_zulip.yml
+          branch: "update-dependencies-bot-use-only"
           base: master
           title: "${{ env.pr_title }}"
           body: "This PR updates the Mathlib dependencies."


### PR DESCRIPTION
The bot has been [creating a bunch of PRs](https://github.com/leanprover-community/mathlib4/issues?q=is%3Aopen+label%3Aauto-merge-after-CI+chore%3A+update+Mathlib+dependencies). This is because the current workflow [adds a timestamp suffix to the branch name](https://github.com/leanprover-community/mathlib4/blob/0512d468dedbde988a3759fcb4118c07e1cd3185/.github/workflows/update_dependencies.yml), which is discouraged in the README of the [create-pull-request action that we're using](https://github.com/peter-evans/create-pull-request?tab=readme-ov-file#alternative-strategy---always-create-a-new-pull-request-branch) (precisely because it leads to the creation of lots of PRs).

After this PR, the bot will always use a branch named `update-dependencies-bot-use-only` and hence should only create a new PR if the previous one has been merged. Note that the action force-pushes to this branch, so it's possible that the bot can end up canceling the bors queue. If this turns out to be an issue, we could add a step which checks if the `ready-to-merge` label is present, but I've put this off for now.

Summary of [Zulip discussion](https://leanprover.zulipchat.com/#narrow/stream/345428-mathlib-reviewers/topic/.22update.20mathlib.20dependencies.22.20PRs) (link requires access to the mathlib reviewers channel on Zulip).

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
