### PR TITLE
[Merged by Bors] - feat(SpecialFunctions.Log.ENNRealLog): remove a coercion in log_pow

### DIFF
--- a/Mathlib/Analysis/SpecialFunctions/Log/ENNRealLog.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Log/ENNRealLog.lean
@@ -168,17 +168,17 @@ theorem log_mul_add {x y : ℝ≥0∞} : log (x * y) = log x + log y := by
       rw_mod_cast [log_pos_real' xy_real, log_pos_real' y_real, ENNReal.toReal_mul]
       exact Real.log_mul (Ne.symm (ne_of_lt x_real)) (Ne.symm (ne_of_lt y_real))
 
-theorem log_pow {x : ℝ≥0∞} {n : ℕ} : log (x ^ n) = (n : ℝ≥0∞) * log x := by
+theorem log_pow {x : ℝ≥0∞} {n : ℕ} : log (x ^ n) = n * log x := by
   cases' Nat.eq_zero_or_pos n with n_zero n_pos
   · simp [n_zero, pow_zero x]
   rcases ENNReal.trichotomy x with (rfl | rfl | x_real)
-  · rw [zero_pow (Ne.symm (ne_of_lt n_pos)), log_zero, EReal.mul_bot_of_pos]; norm_cast
-  · rw [ENNReal.top_pow n_pos, log_top, EReal.mul_top_of_pos]; norm_cast
+  · rw [zero_pow (Ne.symm (ne_of_lt n_pos)), log_zero, EReal.mul_bot_of_pos (Nat.cast_pos'.2 n_pos)]
+  · rw [ENNReal.top_pow n_pos, log_top, EReal.mul_top_of_pos (Nat.cast_pos'.2 n_pos)]
   · replace x_real := ENNReal.toReal_pos_iff.1 x_real
     have x_ne_zero := Ne.symm (LT.lt.ne x_real.1)
     have x_ne_top := LT.lt.ne x_real.2
-    simp only [log, pow_eq_zero_iff', x_ne_zero, ne_eq, false_and, ↓reduceIte, pow_eq_top_iff,
-      x_ne_top, toReal_pow, Real.log_pow, EReal.coe_mul]
+    simp only [log, pow_eq_zero_iff', x_ne_zero, false_and, ↓reduceIte, pow_eq_top_iff, x_ne_top,
+      toReal_pow, Real.log_pow, EReal.coe_mul]
     rfl
 
 theorem log_rpow {x : ℝ≥0∞} {y : ℝ} : log (x ^ y) = y * log x := by

--- a/Mathlib/Analysis/SpecialFunctions/Log/ENNRealLogExp.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Log/ENNRealLogExp.lean
@@ -54,7 +54,6 @@ namespace EReal
 
 lemma exp_nmul (x : EReal) (n : ℕ) : exp (n * x) = (exp x) ^ n := by
   simp_rw [← log_eq_iff, log_pow, log_exp]
-  norm_cast
 
 lemma exp_mul (x : EReal) (y : ℝ) : exp (x * y) = (exp x) ^ y := by
   rw [← log_eq_iff, log_rpow, log_exp, log_exp, mul_comm]


### PR DESCRIPTION
The previous version of the lemma stated that `log (x ^ n) = (n : ℝ≥0∞) * log x`. Changed to `log (x ^ n) = n * log x`, removing a coercion.

There are many different coercions from Nat, Real, etc. to EReal. I think statements should as much as possible use the "canonical" coercion, which from Nat to EReal is the AddMonoidWithOne coercion. Anything more complicated (here, going from Nat -> ENNReal -> EReal) gets quickly into coercion hell.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
