### PR TITLE
[Merged by Bors] - chore(CategoryTheory/DiscreteCategory): remove discrete_fun_ma_eq_id, mv …

### DIFF
--- a/Mathlib/CategoryTheory/DiscreteCategory.lean
+++ b/Mathlib/CategoryTheory/DiscreteCategory.lean
@@ -183,9 +183,17 @@ theorem functor_obj {I : Type u₁} (F : I → C) (i : I) :
   rfl
 #align category_theory.discrete.functor_obj CategoryTheory.Discrete.functor_obj
 
+@[simp]
 theorem functor_map {I : Type u₁} (F : I → C) {i : Discrete I} (f : i ⟶ i) :
     (Discrete.functor F).map f = 𝟙 (F i.as) := by aesop_cat
 #align category_theory.discrete.functor_map CategoryTheory.Discrete.functor_map
+#align category_theory.free_monoidal_category.discrete_functor_map_eq_id CategoryTheory.Discrete.functor_map
+
+@[simp]
+theorem functor_obj_eq_as {I : Type u₁} (F : I → C) (X : Discrete I) :
+    (Discrete.functor F).obj X = F X.as :=
+  rfl
+#align category_theory.free_monoidal_category.discrete_functor_obj_eq_as CategoryTheory.Discrete.functor_obj_eq_as
 
 /-- The discrete functor induced by a composition of maps can be written as a
 composition of two discrete functors.

--- a/Mathlib/CategoryTheory/GradedObject.lean
+++ b/Mathlib/CategoryTheory/GradedObject.lean
@@ -292,7 +292,7 @@ instance : (total β C).Faithful where
     ext i
     replace w := Sigma.ι (fun i : β => X i) i ≫= w
     erw [colimit.ι_map, colimit.ι_map] at w
-    simp? at * says simp only [Discrete.functor_obj, Discrete.natTrans_app] at *
+    simp? at * says simp only [Discrete.functor_obj_eq_as, Discrete.natTrans_app] at *
     exact Mono.right_cancellation _ _ w
 
 end GradedObject

--- a/Mathlib/CategoryTheory/Monoidal/Free/Coherence.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Free/Coherence.lean
@@ -4,7 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Markus Himmel
 -/
 import Mathlib.CategoryTheory.Monoidal.Free.Basic
-import Mathlib.CategoryTheory.Groupoid
 import Mathlib.CategoryTheory.DiscreteCategory
 
 #align_import category_theory.monoidal.free.coherence from "leanprover-community/mathlib"@"f187f1074fa1857c94589cc653c786cadc4c35ff"

--- a/Mathlib/CategoryTheory/Monoidal/Free/Coherence.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Free/Coherence.lean
@@ -247,22 +247,6 @@ def normalizeIsoAux (X : F C) : (tensorFunc C).obj X ≅ (normalize' C).obj X :=
       simp)
 #align category_theory.free_monoidal_category.normalize_iso_aux CategoryTheory.FreeMonoidalCategory.normalizeIsoAux
 
-section
-
-variable {D : Type u} [Category.{u} D] {I : Type u} (f : I → D) (X : Discrete I)
-
--- TODO: move to discrete_category.lean, decide whether this should be a global simp lemma
-@[simp]
-theorem discrete_functor_obj_eq_as : (Discrete.functor f).obj X = f X.as :=
-  rfl
-#align category_theory.free_monoidal_category.discrete_functor_obj_eq_as CategoryTheory.FreeMonoidalCategory.discrete_functor_obj_eq_as
-
--- TODO: move to discrete_category.lean, decide whether this should be a global simp lemma
-@[simp 1100]
-theorem discrete_functor_map_eq_id (g : X ⟶ X) : (Discrete.functor f).map g = 𝟙 _ := rfl
-#align category_theory.free_monoidal_category.discrete_functor_map_eq_id CategoryTheory.FreeMonoidalCategory.discrete_functor_map_eq_id
-
-end
 
 section
 


### PR DESCRIPTION
…discrete_functor_obj_eq_as

Seems like `CategoryTheory.FreeMonoidalCategory.discrete_functor_map_eq_id` is an exact duplicate of `CategoryTheory.Discrete.functor_map`, except it was a simp lemma.
