### PR TITLE
[Merged by Bors] -  chore(Tactic/NormNum): remove autoImplicit

### DIFF
--- a/Mathlib/Tactic/NormNum/Basic.lean
+++ b/Mathlib/Tactic/NormNum/Basic.lean
@@ -23,7 +23,7 @@ This file adds `norm_num` plugins for
 See other files in this directory for many more plugins.
 -/
 
-set_option autoImplicit true
+universe u
 
 namespace Mathlib
 open Lean hiding Rat mkRat
@@ -53,7 +53,7 @@ theorem isNat_one (α) [AddMonoidWithOne α] : IsNat (One.one : α) (nat_lit 1) 
   match e with
   | ~q(One.one) => return .isNat sα (mkRawNatLit 1) q(isNat_one $α)
 
-theorem isNat_ofNat (α : Type u_1) [AddMonoidWithOne α] {a : α} {n : ℕ}
+theorem isNat_ofNat (α : Type u) [AddMonoidWithOne α] {a : α} {n : ℕ}
     (h : n = a) : IsNat a n := ⟨h.symm⟩
 
 /-- The `norm_num` extension which identifies an expression `OfNat.ofNat n`, returning `n`. -/
@@ -432,12 +432,12 @@ such that `norm_num` successfully recognises both `a` and `b`. -/
       return .isNat mα c q(isNat_mul (f := $f) (.refl $f) $pa $pb (.refl $c))
   core
 
-theorem isRat_div [DivisionRing α] : {a b : α} → {cn : ℤ} → {cd : ℕ} → IsRat (a * b⁻¹) cn cd →
-    IsRat (a / b) cn cd
+theorem isRat_div {α : Type u} [DivisionRing α] : {a b : α} → {cn : ℤ} → {cd : ℕ} →
+    IsRat (a * b⁻¹) cn cd → IsRat (a / b) cn cd
   | _, _, _, _, h => by simpa [div_eq_mul_inv] using h
 
 /-- Helper function to synthesize a typed `DivisionRing α` expression. -/
-def inferDivisionRing (α : Q(Type u)) : MetaM Q(DivisionRing $α) :=
+def inferDivisionRing {u : Level} (α : Q(Type u)) : MetaM Q(DivisionRing $α) :=
   return ← synthInstanceQ (q(DivisionRing $α) : Q(Type u)) <|> throwError "not a division ring"
 
 /-- The `norm_num` extension which identifies expressions of the form `a / b`,
@@ -474,6 +474,8 @@ such that `norm_num` successfully recognises `a`. -/
 
 /-! # (In)equalities -/
 
+variable {α : Type u}
+
 theorem isNat_eq_true [AddMonoidWithOne α] : {a b : α} → {c : ℕ} →
     IsNat a c → IsNat b c → a = b
   | _, _, _, ⟨rfl⟩, ⟨rfl⟩ => rfl
@@ -489,9 +491,9 @@ theorem isRat_eq_true [Ring α] : {a b : α} → {n : ℤ} → {d : ℕ} →
   | _, _, _, _, ⟨_, rfl⟩, ⟨_, rfl⟩ => by congr; apply Subsingleton.elim
 
 theorem eq_of_true {a b : Prop} (ha : a) (hb : b) : a = b := propext (iff_of_true ha hb)
-theorem ne_of_false_of_true (ha : ¬a) (hb : b) : a ≠ b := mt (· ▸ hb) ha
-theorem ne_of_true_of_false (ha : a) (hb : ¬b) : a ≠ b := mt (· ▸ ha) hb
-theorem eq_of_false (ha : ¬a) (hb : ¬b) : a = b := propext (iff_of_false ha hb)
+theorem ne_of_false_of_true {a b : Prop} (ha : ¬a) (hb : b) : a ≠ b := mt (· ▸ hb) ha
+theorem ne_of_true_of_false {a b : Prop} (ha : a) (hb : ¬b) : a ≠ b := mt (· ▸ ha) hb
+theorem eq_of_false {a b : Prop} (ha : ¬a) (hb : ¬b) : a = b := propext (iff_of_false ha hb)
 
 /-! # Nat operations -/
 

--- a/Mathlib/Tactic/NormNum/BigOperators.lean
+++ b/Mathlib/Tactic/NormNum/BigOperators.lean
@@ -38,13 +38,13 @@ In particular, we can't use the plugin on sums containing variables.
    normalization?)
 -/
 
-set_option autoImplicit true
-
 namespace Mathlib.Meta
 
 open Lean hiding Rat mkRat
 open Meta
 open Qq
+
+variable {u v : Level}
 
 /-- This represents the result of trying to determine whether the given expression `n : Q(ℕ)`
 is either `zero` or `succ`. -/
@@ -109,7 +109,7 @@ set_option linter.unusedVariables false in
 
 Fails if we cannot determine which of the alternatives apply to the expression.
 -/
-partial def List.proveNilOrCons {α : Q(Type u)} (s : Q(List $α)) :
+partial def List.proveNilOrCons {u : Level} {α : Q(Type u)} (s : Q(List $α)) :
     MetaM (List.ProveNilOrConsResult s) :=
   s.withApp fun e a =>
   match (e, e.constName, a) with

--- a/Mathlib/Tactic/NormNum/Core.lean
+++ b/Mathlib/Tactic/NormNum/Core.lean
@@ -156,7 +156,8 @@ def NormNums.eraseCore (d : NormNums) (declName : Name) : NormNums :=
   Check that it does in fact have the `norm_num` attribute by making sure it names a `NormNumExt`
   found somewhere in the state's tree, and is not erased.
 -/
-def NormNums.erase {m : Type → Type} [Monad m] [MonadError m] (d : NormNums) (declName : Name) : m NormNums := do
+def NormNums.erase {m : Type → Type} [Monad m] [MonadError m] (d : NormNums) (declName : Name) :
+    m NormNums := do
   unless d.tree.values.any (·.name == declName) && ! d.erased.contains declName
   do
     throwError "'{declName}' does not have [norm_num] attribute"

--- a/Mathlib/Tactic/NormNum/Core.lean
+++ b/Mathlib/Tactic/NormNum/Core.lean
@@ -17,9 +17,6 @@ The actual behavior is in `@[norm_num]`-tagged definitions in `Tactic.NormNum.Ba
 and elsewhere.
 -/
 
-
-set_option autoImplicit true
-
 open Lean hiding Rat mkRat
 open Lean.Meta Qq Lean.Elab Term
 
@@ -40,9 +37,11 @@ structure NormNumExt where
   /-- The extension should be run in the `post` phase when used as simp plugin. -/
   post := true
   /-- Attempts to prove an expression is equal to some explicit number of the relevant type. -/
-  eval {α : Q(Type u)} (e : Q($α)) : MetaM (Result e)
+  eval {u : Level} {α : Q(Type u)} (e : Q($α)) : MetaM (Result e)
   /-- The name of the `norm_num` extension. -/
   name : Name := by exact decl_name%
+
+variable {u : Level}
 
 /-- Read a `norm_num` extension from a declaration of the right type. -/
 def mkNormNumExt (n : Name) : ImportM NormNumExt := do
@@ -157,7 +156,7 @@ def NormNums.eraseCore (d : NormNums) (declName : Name) : NormNums :=
   Check that it does in fact have the `norm_num` attribute by making sure it names a `NormNumExt`
   found somewhere in the state's tree, and is not erased.
 -/
-def NormNums.erase [Monad m] [MonadError m] (d : NormNums) (declName : Name) : m NormNums := do
+def NormNums.erase {m : Type → Type} [Monad m] [MonadError m] (d : NormNums) (declName : Name) : m NormNums := do
   unless d.tree.values.any (·.name == declName) && ! d.erased.contains declName
   do
     throwError "'{declName}' does not have [norm_num] attribute"

--- a/Mathlib/Tactic/NormNum/DivMod.lean
+++ b/Mathlib/Tactic/NormNum/DivMod.lean
@@ -13,8 +13,6 @@ This file adds support for the `%`, `/`, and `∣` (divisibility) operators on `
 to the `norm_num` tactic.
 -/
 
-set_option autoImplicit true
-
 namespace Mathlib
 open Lean hiding Rat mkRat
 open Meta
@@ -34,7 +32,7 @@ lemma isInt_ediv {a b q m a' : ℤ} {b' r : ℕ}
   rw [Int.add_mul_ediv_right _ _ (Int.ofNat_ne_zero.2 ((Nat.zero_le ..).trans_lt h₂).ne')]
   rw [Int.ediv_eq_zero_of_lt, zero_add] <;> [simp; simpa using h₂]⟩
 
-lemma isInt_ediv_neg {a b q : ℤ} (h : IsInt (a / -b) q) (hq : -q = q') : IsInt (a / b) q' :=
+lemma isInt_ediv_neg {a b q q' : ℤ} (h : IsInt (a / -b) q) (hq : -q = q') : IsInt (a / b) q' :=
   ⟨by rw [Int.cast_id, ← hq, ← @Int.cast_id q, ← h.out, ← Int.ediv_neg, Int.neg_neg]⟩
 
 lemma isNat_neg_of_isNegNat {a : ℤ} {b : ℕ} (h : IsInt a (.negOfNat b)) : IsNat (-a) b :=

--- a/Mathlib/Tactic/NormNum/Eq.lean
+++ b/Mathlib/Tactic/NormNum/Eq.lean
@@ -9,7 +9,7 @@ import Mathlib.Tactic.NormNum.Inv
 # `norm_num` extension for equalities
 -/
 
-set_option autoImplicit true
+variable {α : Type*}
 
 open Lean Meta Qq
 

--- a/Mathlib/Tactic/NormNum/Ineq.lean
+++ b/Mathlib/Tactic/NormNum/Ineq.lean
@@ -13,11 +13,11 @@ import Mathlib.Algebra.Order.Ring.Cast
 # `norm_num` extensions for inequalities.
 -/
 
-set_option autoImplicit true
-
 open Lean Meta Qq
 
 namespace Mathlib.Meta.NormNum
+
+variable {u : Level}
 
 /-- Helper function to synthesize a typed `OrderedSemiring α` expression. -/
 def inferOrderedSemiring (α : Q(Type u)) : MetaM Q(OrderedSemiring $α) :=
@@ -32,6 +32,8 @@ def inferOrderedRing (α : Q(Type u)) : MetaM Q(OrderedRing $α) :=
 def inferLinearOrderedField (α : Q(Type u)) : MetaM Q(LinearOrderedField $α) :=
   return ← synthInstanceQ (q(LinearOrderedField $α) : Q(Type u)) <|>
     throwError "not a linear ordered field"
+
+variable {α : Type*}
 
 theorem isNat_le_true [OrderedSemiring α] : {a b : α} → {a' b' : ℕ} →
     IsNat a a' → IsNat b b' → Nat.ble a' b' = true → a ≤ b

--- a/Mathlib/Tactic/NormNum/Inv.lean
+++ b/Mathlib/Tactic/NormNum/Inv.lean
@@ -11,7 +11,7 @@ import Mathlib.Algebra.Field.Basic
 # `norm_num` plugins for `Rat.cast` and `⁻¹`.
 -/
 
-set_option autoImplicit true
+variable {u : Lean.Level}
 
 namespace Mathlib.Meta.NormNum
 
@@ -70,15 +70,15 @@ def evalMkRat : NormNumExt where eval {u α} (e : Q(ℚ)) : MetaM (Result e) := 
   let ⟨q, n, d, p⟩ ← rab.toRat' q(Rat.instDivisionRing)
   return .isRat' _ q n d q(isRat_mkRat $pa $pb $p)
 
-theorem isNat_ratCast [DivisionRing R] : {q : ℚ} → {n : ℕ} →
+theorem isNat_ratCast {R : Type*} [DivisionRing R] : {q : ℚ} → {n : ℕ} →
     IsNat q n → IsNat (q : R) n
   | _, _, ⟨rfl⟩ => ⟨by simp⟩
 
-theorem isInt_ratCast [DivisionRing R] : {q : ℚ} → {n : ℤ} →
+theorem isInt_ratCast {R : Type*} [DivisionRing R] : {q : ℚ} → {n : ℤ} →
     IsInt q n → IsInt (q : R) n
   | _, _, ⟨rfl⟩ => ⟨by simp⟩
 
-theorem isRat_ratCast [DivisionRing R] [CharZero R] : {q : ℚ} → {n : ℤ} → {d : ℕ} →
+theorem isRat_ratCast {R : Type*} [DivisionRing R] [CharZero R] : {q : ℚ} → {n : ℤ} → {d : ℕ} →
     IsRat q n d → IsRat (q : R) n d
   | _, _, _, ⟨⟨qi,_,_⟩, rfl⟩ => ⟨⟨qi, by norm_cast, by norm_cast⟩, by simp only []; norm_cast⟩
 

--- a/Mathlib/Tactic/NormNum/OfScientific.lean
+++ b/Mathlib/Tactic/NormNum/OfScientific.lean
@@ -10,14 +10,14 @@ import Mathlib.Data.Rat.Cast.Lemmas
 ## `norm_num` plugin for scientific notation.
 -/
 
-set_option autoImplicit true
-
 namespace Mathlib
 open Lean hiding Rat mkRat
 open Meta
 
 namespace Meta.NormNum
 open Qq
+
+variable {α : Type*}
 
 -- see note [norm_num lemma function equality]
 theorem isRat_ofScientific_of_true [DivisionRing α] :

--- a/Mathlib/Tactic/NormNum/Pow.lean
+++ b/Mathlib/Tactic/NormNum/Pow.lean
@@ -161,10 +161,9 @@ theorem isRat_pow {α} [Ring α] {f : α → ℕ → α} {a : α} {an cn : ℤ} 
   rw [← Nat.cast_pow] at this
   use this; simp [invOf_pow, Commute.mul_pow]
 
-set_option autoImplicit true in
 /-- The `norm_num` extension which identifies expressions of the form `a ^ b`,
 such that `norm_num` successfully recognises both `a` and `b`, with `b : ℕ`. -/
-@[norm_num (_ : α) ^ (_ : ℕ)]
+@[norm_num _ ^ (_ : ℕ)]
 def evalPow : NormNumExt where eval {u α} e := do
   let .app (.app (f : Q($α → ℕ → $α)) (a : Q($α))) (b : Q(ℕ)) ← whnfR e | failure
   let ⟨nb, pb⟩ ← deriveNat b q(instAddMonoidWithOneNat)
@@ -237,10 +236,9 @@ h.check
 ```
 blocks below were not necessary: we just did it once outside the `match rb with` block.
 -/
-set_option autoImplicit true in
 /-- The `norm_num` extension which identifies expressions of the form `a ^ b`,
 such that `norm_num` successfully recognises both `a` and `b`, with `b : ℤ`. -/
-@[norm_num (_ : α) ^ (_ : ℤ)]
+@[norm_num _ ^ (_ : ℤ)]
 def evalZPow : NormNumExt where eval {u α} e := do
   let .app (.app (f : Q($α → ℤ → $α)) (a : Q($α))) (b : Q(ℤ)) ← whnfR e | failure
   let _c ← synthInstanceQ q(DivisionSemiring $α)

--- a/Mathlib/Tactic/NormNum/Pow.lean
+++ b/Mathlib/Tactic/NormNum/Pow.lean
@@ -10,14 +10,14 @@ import Mathlib.Tactic.NormNum.Basic
 ## `norm_num` plugin for `^`.
 -/
 
-set_option autoImplicit true
-
 namespace Mathlib
 open Lean hiding Rat mkRat
 open Meta
 
 namespace Meta.NormNum
 open Qq
+
+variable {a b c : ℕ}
 
 theorem natPow_zero : Nat.pow a (nat_lit 0) = nat_lit 1 := rfl
 theorem natPow_one : Nat.pow a (nat_lit 1) = a := Nat.pow_one _
@@ -37,8 +37,9 @@ theorem IsNatPowT.run
 
 /-- This is the key to making the proof proceed as a balanced tree of applications instead of
 a linear sequence. It is just modus ponens after unwrapping the definitions. -/
-theorem IsNatPowT.trans (h1 : IsNatPowT p a b c) (h2 : IsNatPowT (Nat.pow a b = c) a b' c') :
-    IsNatPowT p a b' c' := ⟨h2.run' ∘ h1.run'⟩
+theorem IsNatPowT.trans {p : Prop} {b' c' : ℕ} (h1 : IsNatPowT p a b c)
+    (h2 : IsNatPowT (Nat.pow a b = c) a b' c') : IsNatPowT p a b' c' :=
+  ⟨h2.run' ∘ h1.run'⟩
 
 theorem IsNatPowT.bit0 : IsNatPowT (Nat.pow a b = c) a (nat_lit 2 * b) (Nat.mul c c) :=
   ⟨fun h1 => by simp [two_mul, pow_add, ← h1]⟩
@@ -102,14 +103,14 @@ where
 theorem intPow_ofNat (h1 : Nat.pow a b = c) :
     Int.pow (Int.ofNat a) b = Int.ofNat c := by simp [← h1]
 
-theorem intPow_negOfNat_bit0 (h1 : Nat.pow a b' = c')
+theorem intPow_negOfNat_bit0 {b' c' : ℕ} (h1 : Nat.pow a b' = c')
     (hb : nat_lit 2 * b' = b) (hc : c' * c' = c) :
     Int.pow (Int.negOfNat a) b = Int.ofNat c := by
   rw [← hb, Int.negOfNat_eq, Int.pow_eq, pow_mul, neg_pow_two, ← pow_mul, two_mul, pow_add, ← hc,
     ← h1]
   simp
 
-theorem intPow_negOfNat_bit1 (h1 : Nat.pow a b' = c')
+theorem intPow_negOfNat_bit1 {b' c' : ℕ} (h1 : Nat.pow a b' = c')
     (hb : nat_lit 2 * b' + nat_lit 1 = b) (hc : c' * (c' * a) = c) :
     Int.pow (Int.negOfNat a) b = Int.negOfNat c := by
   rw [← hb, Int.negOfNat_eq, Int.negOfNat_eq, Int.pow_eq, pow_succ, pow_mul, neg_pow_two, ← pow_mul,
@@ -160,6 +161,7 @@ theorem isRat_pow {α} [Ring α] {f : α → ℕ → α} {a : α} {an cn : ℤ} 
   rw [← Nat.cast_pow] at this
   use this; simp [invOf_pow, Commute.mul_pow]
 
+set_option autoImplicit true in
 /-- The `norm_num` extension which identifies expressions of the form `a ^ b`,
 such that `norm_num` successfully recognises both `a` and `b`, with `b : ℕ`. -/
 @[norm_num (_ : α) ^ (_ : ℕ)]
@@ -235,6 +237,7 @@ h.check
 ```
 blocks below were not necessary: we just did it once outside the `match rb with` block.
 -/
+set_option autoImplicit true in
 /-- The `norm_num` extension which identifies expressions of the form `a ^ b`,
 such that `norm_num` successfully recognises both `a` and `b`, with `b : ℤ`. -/
 @[norm_num (_ : α) ^ (_ : ℤ)]

--- a/Mathlib/Tactic/NormNum/Result.lean
+++ b/Mathlib/Tactic/NormNum/Result.lean
@@ -218,7 +218,8 @@ theorem IsRat.to_isInt {α} [Ring α] : ∀ {a : α} {n}, IsRat a n (nat_lit 1) 
 theorem IsInt.to_isRat {α} [Ring α] : ∀ {a : α} {n}, IsInt a n → IsRat a n (nat_lit 1)
   | _, _, ⟨rfl⟩ => ⟨⟨1, by simp, by simp⟩, by simp⟩
 
-theorem IsRat.to_raw_eq {n : ℤ} {d : ℕ} [DivisionRing α] : ∀ {a}, IsRat (a : α) n d → a = Rat.rawCast n d
+theorem IsRat.to_raw_eq {n : ℤ} {d : ℕ} [DivisionRing α] :
+    ∀ {a}, IsRat (a : α) n d → a = Rat.rawCast n d
   | _, ⟨inv, rfl⟩ => by simp [div_eq_mul_inv]
 
 theorem IsRat.neg_to_eq {α} [DivisionRing α] {n d} :

--- a/Mathlib/Tactic/NormNum/Result.lean
+++ b/Mathlib/Tactic/NormNum/Result.lean
@@ -23,8 +23,8 @@ or is either `true` or `false`.
 
 -/
 
-
-set_option autoImplicit true
+universe u
+variable {α : Type u}
 
 open Lean hiding Rat mkRat
 open Lean.Meta Qq Lean.Elab Term
@@ -36,19 +36,19 @@ namespace Meta.NormNum
 def instAddMonoidWithOneNat : AddMonoidWithOne ℕ := inferInstance
 
 /-- A shortcut (non)instance for `AddMonoidWithOne α` from `Ring α` to shrink generated proofs. -/
-def instAddMonoidWithOne [Ring α] : AddMonoidWithOne α := inferInstance
+def instAddMonoidWithOne {α : Type u} [Ring α] : AddMonoidWithOne α := inferInstance
 
 /-- Helper function to synthesize a typed `AddMonoidWithOne α` expression. -/
-def inferAddMonoidWithOne (α : Q(Type u)) : MetaM Q(AddMonoidWithOne $α) :=
+def inferAddMonoidWithOne {u : Level} (α : Q(Type u)) : MetaM Q(AddMonoidWithOne $α) :=
   return ← synthInstanceQ (q(AddMonoidWithOne $α) : Q(Type u)) <|>
     throwError "not an AddMonoidWithOne"
 
 /-- Helper function to synthesize a typed `Semiring α` expression. -/
-def inferSemiring (α : Q(Type u)) : MetaM Q(Semiring $α) :=
+def inferSemiring {u : Level} (α : Q(Type u)) : MetaM Q(Semiring $α) :=
   return ← synthInstanceQ (q(Semiring $α) : Q(Type u)) <|> throwError "not a semiring"
 
 /-- Helper function to synthesize a typed `Ring α` expression. -/
-def inferRing (α : Q(Type u)) : MetaM Q(Ring $α) :=
+def inferRing {u : Level} (α : Q(Type u)) : MetaM Q(Ring $α) :=
   return ← synthInstanceQ (q(Ring $α) : Q(Type u)) <|> throwError "not a ring"
 
 /--
@@ -96,7 +96,7 @@ This function is performance-critical, as many higher level tactics have to cons
 So rather than using typeclass search we hardcode the (relatively small) set of solutions
 to the typeclass problem.
 -/
-def mkOfNat (α : Q(Type u)) (_sα : Q(AddMonoidWithOne $α)) (lit : Q(ℕ)) :
+def mkOfNat {u : Level} (α : Q(Type u)) (_sα : Q(AddMonoidWithOne $α)) (lit : Q(ℕ)) :
     MetaM ((a' : Q($α)) × Q($lit = $a')) := do
   if α.isConstOf ``Nat then
     let a' : Q(ℕ) := q(OfNat.ofNat $lit : ℕ)
@@ -120,7 +120,7 @@ def mkOfNat (α : Q(Type u)) (_sα : Q(AddMonoidWithOne $α)) (lit : Q(ℕ)) :
       pure ⟨a', (q(Eq.refl $a') : Expr)⟩
 
 /-- Assert that an element of a semiring is equal to the coercion of some natural number. -/
-structure IsNat [AddMonoidWithOne α] (a : α) (n : ℕ) : Prop where
+structure IsNat {α : Type u} [AddMonoidWithOne α] (a : α) (n : ℕ) : Prop where
   /-- The element is equal to the coercion of the natural number. -/
   out : a = n
 
@@ -131,12 +131,12 @@ A "raw nat cast" is an expression of the form `(Nat.rawCast lit : α)` where `li
 natural number literal. These expressions are used by tactics like `ring` to decrease the number
 of typeclass arguments required in each use of a number literal at type `α`.
 -/
-@[simp] def _root_.Nat.rawCast [AddMonoidWithOne α] (n : ℕ) : α := n
+@[simp] def _root_.Nat.rawCast {α : Type u} [AddMonoidWithOne α] (n : ℕ) : α := n
 
-theorem IsNat.to_eq [AddMonoidWithOne α] {n} : {a a' : α} → IsNat a n → n = a' → a = a'
+theorem IsNat.to_eq {α : Type u} [AddMonoidWithOne α] {n} : {a a' : α} → IsNat a n → n = a' → a = a'
   | _, _, ⟨rfl⟩, rfl => rfl
 
-theorem IsNat.to_raw_eq [AddMonoidWithOne α] : IsNat (a : α) n → a = n.rawCast
+theorem IsNat.to_raw_eq {a : α} {n : ℕ} [AddMonoidWithOne α] : IsNat (a : α) n → a = n.rawCast
   | ⟨e⟩ => e
 
 theorem IsNat.of_raw (α) [AddMonoidWithOne α] (n : ℕ) : IsNat (n.rawCast : α) n := ⟨rfl⟩
@@ -168,7 +168,7 @@ theorem IsInt.to_isNat {α} [Ring α] : ∀ {a : α} {n}, IsInt a (.ofNat n) →
 theorem IsNat.to_isInt {α} [Ring α] : ∀ {a : α} {n}, IsNat a n → IsInt a (.ofNat n)
   | _, _, ⟨rfl⟩ => ⟨by simp⟩
 
-theorem IsInt.to_raw_eq [Ring α] : IsInt (a : α) n → a = n.rawCast
+theorem IsInt.to_raw_eq {a : α} {n : ℤ} [Ring α] : IsInt (a : α) n → a = n.rawCast
   | ⟨e⟩ => e
 
 theorem IsInt.of_raw (α) [Ring α] (n : ℤ) : IsInt (n.rawCast : α) n := ⟨rfl⟩
@@ -218,7 +218,7 @@ theorem IsRat.to_isInt {α} [Ring α] : ∀ {a : α} {n}, IsRat a n (nat_lit 1) 
 theorem IsInt.to_isRat {α} [Ring α] : ∀ {a : α} {n}, IsInt a n → IsRat a n (nat_lit 1)
   | _, _, ⟨rfl⟩ => ⟨⟨1, by simp, by simp⟩, by simp⟩
 
-theorem IsRat.to_raw_eq [DivisionRing α] : ∀ {a}, IsRat (a : α) n d → a = Rat.rawCast n d
+theorem IsRat.to_raw_eq {n : ℤ} {d : ℕ} [DivisionRing α] : ∀ {a}, IsRat (a : α) n d → a = Rat.rawCast n d
   | _, ⟨inv, rfl⟩ => by simp [div_eq_mul_inv]
 
 theorem IsRat.neg_to_eq {α} [DivisionRing α] {n d} :
@@ -250,13 +250,15 @@ inductive Result' where
   | isRat (inst : Expr) (q : Rat) (n d proof : Expr)
   deriving Inhabited
 
+variable {u : Level}
+
 section
 set_option linter.unusedVariables false
 
 /-- The result of `norm_num` running on an expression `x` of type `α`. -/
 @[nolint unusedArguments] def Result {α : Q(Type u)} (x : Q($α)) := Result'
 
-instance : Inhabited (Result x) := inferInstanceAs (Inhabited Result')
+instance {α : Q(Type u)} {x : Q(«$α»)} : Inhabited (Result x) := inferInstanceAs (Inhabited Result')
 
 /-- The result is `proof : x`, where `x` is a (true) proposition. -/
 @[match_pattern, inline] def Result.isTrue {x : Q(Prop)} :
@@ -308,7 +310,7 @@ def Result.isRat' {α : Q(Type u)} {x : Q($α)} (inst : Q(DivisionRing $α) := b
   else
     .isRat inst q n d proof
 
-instance : ToMessageData (Result x) where
+instance {α : Q(Type u)} {x : Q(«$α»)} : ToMessageData (Result x) where
   toMessageData
   | .isBool true proof => m!"isTrue ({proof})"
   | .isBool false proof => m!"isFalse ({proof})"
@@ -317,7 +319,7 @@ instance : ToMessageData (Result x) where
   | .isRat _ q _ _ proof => m!"isRat {q} ({proof})"
 
 /-- Returns the rational number that is the result of `norm_num` evaluation. -/
-def Result.toRat : Result e → Option Rat
+def Result.toRat {α : Q(Type u)} {e : Q(«$α»)} : Result e → Option Rat
   | .isBool .. => none
   | .isNat _ lit _ => some lit.natLit!
   | .isNegNat _ lit _ => some (-lit.natLit!)
@@ -325,7 +327,7 @@ def Result.toRat : Result e → Option Rat
 
 /-- Returns the rational number that is the result of `norm_num` evaluation, along with a proof
 that the denominator is nonzero in the `isRat` case. -/
-def Result.toRatNZ : Result e → Option (Rat × Option Expr)
+def Result.toRatNZ {α : Q(Type u)} {e : Q(«$α»)} : Result e → Option (Rat × Option Expr)
   | .isBool .. => none
   | .isNat _ lit _ => some (lit.natLit!, none)
   | .isNegNat _ lit _ => some (-lit.natLit!, none)

--- a/Mathlib/Util/Qq.lean
+++ b/Mathlib/Util/Qq.lean
@@ -25,6 +25,6 @@ def inferTypeQ' (e : Expr) : MetaM ((u : Level) × (α : Q(Type $u)) × Q($α)) 
   let some v := (← instantiateLevelMVars u).dec | throwError "not a Type{indentExpr e}"
   pure ⟨v, α, e⟩
 
-theorem QuotedDefEq.rfl {u : Level} {α : Q(Sort u)} {a : Q(«$α»)} : @QuotedDefEq u α a a := ⟨⟩
+theorem QuotedDefEq.rfl {u : Level} {α : Q(Sort u)} {a : Q($α)} : @QuotedDefEq u α a a := ⟨⟩
 
 end Qq


### PR DESCRIPTION
This is exhaustive

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)

~~except for two `norm_num` attributes in `Pow`. Help with those is welcome!~~
