### PR TITLE
[Merged by Bors] - chore(Tactic): reduce use of Implicit, part 2

### DIFF
--- a/Mathlib/Tactic/Abel.lean
+++ b/Mathlib/Tactic/Abel.lean
@@ -19,8 +19,6 @@ assert_not_exists OrderedAddCommMonoid
 assert_not_exists TopologicalSpace
 assert_not_exists PseudoMetricSpace
 
-set_option autoImplicit true
-
 namespace Mathlib.Tactic.Abel
 open Lean Elab Meta Tactic Qq
 
@@ -400,9 +398,9 @@ elab_rules : tactic | `(tactic| abel1 $[!%$tk]?) => withMainContext do
 
 @[inherit_doc abel1] macro (name := abel1!) "abel1!" : tactic => `(tactic| abel1 !)
 
-theorem term_eq [AddCommMonoid α] (n : ℕ) (x a : α) : term n x a = n • x + a := rfl
+theorem term_eq {α : Type*} [AddCommMonoid α] (n : ℕ) (x a : α) : term n x a = n • x + a := rfl
 /-- A type synonym used by `abel` to represent `n • x + a` in an additive commutative group. -/
-theorem termg_eq [AddCommGroup α] (n : ℤ) (x a : α) : termg n x a = n • x + a := rfl
+theorem termg_eq {α : Type*} [AddCommGroup α] (n : ℤ) (x a : α) : termg n x a = n • x + a := rfl
 
 /-- True if this represents an atomic expression. -/
 def NormalExpr.isAtom : NormalExpr → Bool

--- a/Mathlib/Tactic/CongrExclamation.lean
+++ b/Mathlib/Tactic/CongrExclamation.lean
@@ -21,7 +21,7 @@ The `congr!` tactic is used by the `convert` and `convert_to` tactics.
 See the syntax docstring for more details.
 -/
 
-set_option autoImplicit true
+universe u v
 
 open Lean Meta Elab Tactic
 
@@ -499,13 +499,13 @@ def CongrMetaM.nextPattern : CongrMetaM (Option (TSyntax `rcasesPat)) := do
     else
       (none, s)
 
-private theorem heq_imp_of_eq_imp {p : HEq x y → Prop} (h : (he : x = y) → p (heq_of_eq he))
-    (he : HEq x y) : p he := by
+private theorem heq_imp_of_eq_imp {α : Sort*} {x y : α} {p : HEq x y → Prop}
+    (h : (he : x = y) → p (heq_of_eq he)) (he : HEq x y) : p he := by
   cases he
   exact h rfl
 
-private theorem eq_imp_of_iff_imp {p : x = y → Prop} (h : (he : x ↔ y) → p (propext he))
-    (he : x = y) : p he := by
+private theorem eq_imp_of_iff_imp {x y : Prop} {p : x = y → Prop}
+    (h : (he : x ↔ y) → p (propext he)) (he : x = y) : p he := by
   cases he
   exact h Iff.rfl
 

--- a/Mathlib/Tactic/Core.lean
+++ b/Mathlib/Tactic/Core.lean
@@ -9,13 +9,9 @@ import Mathlib.Lean.Expr.Basic
 import Batteries.Tactic.OpenPrivate
 
 /-!
-#
-
-Generally useful tactics.
+# Generally useful tactics.
 
 -/
-
-set_option autoImplicit true
 
 open Lean.Elab.Tactic
 
@@ -199,7 +195,8 @@ def allGoals (tac : TacticM Unit) : TacticM Unit := do
 def andThenOnSubgoals (tac1 : TacticM Unit) (tac2 : TacticM Unit) : TacticM Unit :=
   focus do tac1; allGoals tac2
 
-variable [Monad m] [MonadExcept Exception m]
+universe u
+variable {m : Type → Type u} [Monad m] [MonadExcept Exception m]
 
 /-- Repeats a tactic at most `n` times, stopping sooner if the
 tactic fails. Always succeeds. -/

--- a/Mathlib/Tactic/FunProp/ToBatteries.lean
+++ b/Mathlib/Tactic/FunProp/ToBatteries.lean
@@ -13,7 +13,6 @@ namespace Mathlib
 open Lean Meta
 
 namespace Meta.FunProp
-set_option autoImplicit true
 
 /-- Check if `a` can be obtained by removing elements from `b`. -/
 def isOrderedSubsetOf {α} [Inhabited α] [DecidableEq α] (a b : Array α) : Bool :=

--- a/Mathlib/Tactic/Linarith/Verification.lean
+++ b/Mathlib/Tactic/Linarith/Verification.lean
@@ -19,11 +19,11 @@ This file implements the reconstruction.
 The public facing declaration in this file is `proveFalseByLinarith`.
 -/
 
-set_option autoImplicit true
-
 open Lean Elab Tactic Meta
 
 namespace Qq
+
+variable {u : Level}
 
 /-- Typesafe conversion of `n : ℕ` to `Q($α)`. -/
 def ofNatQ (α : Q(Type $u)) (_ : Q(Semiring $α)) (n : ℕ) : Q($α) :=
@@ -46,7 +46,7 @@ open Qq
 /-! ### Auxiliary functions for assembling proofs -/
 
 /-- A typesafe version of `mulExpr`. -/
-def mulExpr' (n : ℕ) {α : Q(Type $u)} (inst : Q(Semiring $α)) (e : Q($α)) : Q($α) :=
+def mulExpr' {u : Level} (n : ℕ) {α : Q(Type $u)} (inst : Q(Semiring $α)) (e : Q($α)) : Q($α) :=
   if n = 1 then e else
     let n := ofNatQ α inst n
     q($n * $e)
@@ -61,7 +61,7 @@ def mulExpr (n : ℕ) (e : Expr) : MetaM Expr := do
   return mulExpr' n inst e
 
 /-- A type-safe analogue of `addExprs`. -/
-def addExprs' {α : Q(Type $u)} (_inst : Q(AddMonoid $α)) : List Q($α) → Q($α)
+def addExprs' {u : Level} {α : Q(Type $u)} (_inst : Q(AddMonoid $α)) : List Q($α) → Q($α)
   | []   => q(0)
   | h::t => go h t
     where

--- a/Mathlib/Tactic/Nontriviality/Core.lean
+++ b/Mathlib/Tactic/Nontriviality/Core.lean
@@ -9,7 +9,7 @@ import Mathlib.Tactic.Attr.Core
 
 /-! # The `nontriviality` tactic. -/
 
-set_option autoImplicit true
+universe u
 
 namespace Mathlib.Tactic.Nontriviality
 open Lean Elab Meta Tactic Qq
@@ -24,7 +24,8 @@ Tries to generate a `Nontrivial α` instance by performing case analysis on
 attempting to discharge the subsingleton branch using lemmas with `@[nontriviality]` attribute,
 including `Subsingleton.le` and `eq_iff_true_of_subsingleton`.
 -/
-def nontrivialityByElim (α : Q(Type u)) (g : MVarId) (simpArgs : Array Syntax) : MetaM MVarId := do
+def nontrivialityByElim {u : Level} (α : Q(Type u)) (g : MVarId) (simpArgs : Array Syntax) :
+    MetaM MVarId := do
   let p : Q(Prop) ← g.getType
   guard (← instantiateMVars (← inferType p)).isProp
   g.withContext do

--- a/Mathlib/Tactic/Propose.lean
+++ b/Mathlib/Tactic/Propose.lean
@@ -33,8 +33,6 @@ example (K L M : List α) (w : L.Disjoint M) (m : K ⊆ L) : True := by
 ```
 -/
 
-set_option autoImplicit true
-
 namespace Mathlib.Tactic.Propose
 
 open Lean Meta Batteries.Tactic Tactic.TryThis

--- a/Mathlib/Tactic/PushNeg.lean
+++ b/Mathlib/Tactic/PushNeg.lean
@@ -11,13 +11,11 @@ import Mathlib.Tactic.Conv
 import Mathlib.Init.Set
 import Lean.Elab.Tactic.Location
 
-set_option autoImplicit true
-
 namespace Mathlib.Tactic.PushNeg
 
 open Lean Meta Elab.Tactic Parser.Tactic
 
-variable (p q : Prop) (s : α → Prop)
+variable (p q : Prop) {α : Sort*} (s : α → Prop)
 
 theorem not_not_eq : (¬ ¬ p) = p := propext not_not
 theorem not_and_eq : (¬ (p ∧ q)) = (p → ¬ q) := propext not_and
@@ -30,21 +28,21 @@ theorem not_ne_eq (x y : α) : (¬ (x ≠ y)) = (x = y) := ne_eq x y ▸ not_not
 theorem not_iff : (¬ (p ↔ q)) = ((p ∧ ¬ q) ∨ (¬ p ∧ q)) := propext <|
   _root_.not_iff.trans <| iff_iff_and_or_not_and_not.trans <| by rw [not_not, or_comm]
 
-variable {β : Type u} [LinearOrder β]
+variable {β : Type*} [LinearOrder β]
 theorem not_le_eq (a b : β) : (¬ (a ≤ b)) = (b < a) := propext not_le
 theorem not_lt_eq (a b : β) : (¬ (a < b)) = (b ≤ a) := propext not_lt
 theorem not_ge_eq (a b : β) : (¬ (a ≥ b)) = (a < b) := propext not_le
 theorem not_gt_eq (a b : β) : (¬ (a > b)) = (a ≤ b) := propext not_lt
 
-theorem not_nonempty_eq (s : Set γ) : (¬ s.Nonempty) = (s = ∅) := by
-  have A : ∀ (x : γ), ¬(x ∈ (∅ : Set γ)) := fun x ↦ id
+theorem not_nonempty_eq (s : Set β) : (¬ s.Nonempty) = (s = ∅) := by
+  have A : ∀ (x : β), ¬(x ∈ (∅ : Set β)) := fun x ↦ id
   simp only [Set.Nonempty, not_exists, eq_iff_iff]
   exact ⟨fun h ↦ Set.ext (fun x ↦ by simp only [h x, false_iff, A]), fun h ↦ by rwa [h]⟩
 
-theorem ne_empty_eq_nonempty (s : Set γ) : (s ≠ ∅) = s.Nonempty := by
+theorem ne_empty_eq_nonempty (s : Set β) : (s ≠ ∅) = s.Nonempty := by
   rw [ne_eq, ← not_nonempty_eq s, not_not]
 
-theorem empty_ne_eq_nonempty (s : Set γ) : (∅ ≠ s) = s.Nonempty := by
+theorem empty_ne_eq_nonempty (s : Set β) : (∅ ≠ s) = s.Nonempty := by
   rw [ne_comm, ne_empty_eq_nonempty]
 
 /-- Make `push_neg` use `not_and_or` rather than the default `not_and`. -/

--- a/Mathlib/Tactic/Relation/Symm.lean
+++ b/Mathlib/Tactic/Relation/Symm.lean
@@ -9,8 +9,6 @@ import Lean.Meta.Tactic.Symm
 # `relSidesIfSymm?`
 -/
 
-set_option autoImplicit true
-
 open Lean Meta Symm
 
 namespace Mathlib.Tactic

--- a/Mathlib/Tactic/Relation/Trans.lean
+++ b/Mathlib/Tactic/Relation/Trans.lean
@@ -14,8 +14,6 @@ This implements the `trans` tactic, which can apply transitivity theorems with a
 variable argument.
 -/
 
-set_option autoImplicit true
-
 namespace Mathlib.Tactic
 open Lean Meta Elab
 
@@ -50,14 +48,16 @@ initialize registerBuiltinAttribute {
     transExt.add (decl, key) kind
 }
 
+universe u v in
 /-- Composition using the `Trans` class in the homogeneous case. -/
-def _root_.Trans.simple {a b c : α} [Trans r r r] : r a b → r b c → r a c := trans
+def _root_.Trans.simple {α : Sort u} {r : α → α → Sort v} {a b c : α} [Trans r r r] :
+    r a b → r b c → r a c := trans
 
+set_option autoImplicit true in -- TODO, handle better - use Sort*?
 /-- Composition using the `Trans` class in the general case. -/
 def _root_.Trans.het {a : α} {b : β} {c : γ}
     {r : α → β → Sort u} {s : β → γ → Sort v} {t : outParam (α → γ → Sort w)}
     [Trans r s t] : r a b → s b c → t a c := trans
-
 
 open Lean.Elab.Tactic
 

--- a/Mathlib/Tactic/SuccessIfFailWithMsg.lean
+++ b/Mathlib/Tactic/SuccessIfFailWithMsg.lean
@@ -14,8 +14,6 @@ It's mostly useful in tests, where we want to make sure that tactics fail in cer
 circumstances.
 -/
 
-set_option autoImplicit true
-
 open Lean Elab Meta Tactic Syntax
 
 namespace Mathlib.Tactic
@@ -28,7 +26,8 @@ syntax (name := successIfFailWithMsg) "success_if_fail_with_msg " term:max tacti
 
 /-- Evaluates `tacs` and succeeds only if `tacs` both fails and throws an error equal (as a string)
 to `msg`. -/
-def successIfFailWithMessage [Monad m] [MonadLiftT IO m] [MonadBacktrack s m] [MonadError m]
+def successIfFailWithMessage {s α : Type} {m : Type → Type}
+    [Monad m] [MonadLiftT IO m] [MonadBacktrack s m] [MonadError m]
     (msg : String) (tacs : m α) (ref : Option Syntax := none) : m Unit := do
   let s ← saveState
   let err ←

--- a/Mathlib/Tactic/SudoSetOption.lean
+++ b/Mathlib/Tactic/SudoSetOption.lean
@@ -11,11 +11,9 @@ import Lean.Elab.ElabRules
 Allows setting undeclared options.
 -/
 
-set_option autoImplicit true
-
 open Lean Elab
 
-private def setOption [Monad m] [MonadError m]
+private def setOption {m : Type → Type} [Monad m] [MonadError m]
     (name val : Syntax) (opts : Options) : m Options := do
   let val ← match val with
     | Syntax.ident _ _ `true _  => pure <| DataValue.ofBool true

--- a/Mathlib/Tactic/TermCongr.lean
+++ b/Mathlib/Tactic/TermCongr.lean
@@ -47,7 +47,7 @@ it eagerly wants to solve for instance arguments. The current version is able to
 expected LHS and RHS to fill in arguments before solving for instance arguments.
 -/
 
-set_option autoImplicit true
+universe u
 
 namespace Mathlib.Tactic.TermCongr
 open Lean Elab Meta
@@ -416,7 +416,7 @@ def CongrResult.mkDefault' (mvarCounterSaved : Nat) (lhs rhs : Expr) : MetaM Con
   CongrResult.mkDefault lhs rhs
 
 /-- Throw an internal error. -/
-def throwCongrEx (lhs rhs : Expr) (msg : MessageData) : MetaM α := do
+def throwCongrEx {α : Type} (lhs rhs : Expr) (msg : MessageData) : MetaM α := do
   throwError "congr(...) failed with left-hand side{indentD lhs}\n\
     and right-hand side {indentD rhs}\n{msg}"
 

--- a/Mathlib/Tactic/ToAdditive.lean
+++ b/Mathlib/Tactic/ToAdditive.lean
@@ -475,9 +475,6 @@ structure Config : Type where
   existing : Option Bool := none
   deriving Repr
 
---set_option autoImplicit true
---variable [Monad M] [MonadOptions M] [MonadEnv M]
-
 open Lean.Expr.FindImpl in
 /-- Implementation function for `additiveTest`.
   We cache previous applications of the function, using the same method that `Expr.find?` uses,

--- a/Mathlib/Tactic/ToAdditive.lean
+++ b/Mathlib/Tactic/ToAdditive.lean
@@ -233,8 +233,6 @@ that the new name differs from the original one.
 
 -/
 
-set_option autoImplicit true
-
 open Lean Meta Elab Command Std
 
 /-- The `to_additive_ignore_args` attribute. -/
@@ -477,7 +475,8 @@ structure Config : Type where
   existing : Option Bool := none
   deriving Repr
 
-variable [Monad M] [MonadOptions M] [MonadEnv M]
+--set_option autoImplicit true
+--variable [Monad M] [MonadOptions M] [MonadEnv M]
 
 open Lean.Expr.FindImpl in
 /-- Implementation function for `additiveTest`.
@@ -819,8 +818,8 @@ def copyInstanceAttribute (src tgt : Name) : CoreM Unit := do
     addInstance tgt attr_kind prio |>.run'
 
 /-- Warn the user when the multiplicative declaration has an attribute. -/
-def warnExt [Inhabited σ] (stx : Syntax) (ext : PersistentEnvExtension α β σ) (f : σ → Name → Bool)
-    (thisAttr attrName src tgt : Name) : CoreM Unit := do
+def warnExt {σ α β : Type} [Inhabited σ] (stx : Syntax) (ext : PersistentEnvExtension α β σ)
+    (f : σ → Name → Bool) (thisAttr attrName src tgt : Name) : CoreM Unit := do
   if f (ext.getState (← getEnv)) src then
     Linter.logLintIf linter.existingAttributeWarning stx <|
       m!"The source declaration {src} was given attribute {attrName} before calling @[{thisAttr}]. \
@@ -833,19 +832,19 @@ def warnExt [Inhabited σ] (stx : Syntax) (ext : PersistentEnvExtension α β σ
       else ""
 
 /-- Warn the user when the multiplicative declaration has a simple scoped attribute. -/
-def warnAttr [Inhabited β] (stx : Syntax) (attr : SimpleScopedEnvExtension α β)
+def warnAttr {α β : Type} [Inhabited β] (stx : Syntax) (attr : SimpleScopedEnvExtension α β)
     (f : β → Name → Bool) (thisAttr attrName src tgt : Name) : CoreM Unit :=
 warnExt stx attr.ext (f ·.stateStack.head!.state ·) thisAttr attrName src tgt
 
 /-- Warn the user when the multiplicative declaration has a parametric attribute. -/
-def warnParametricAttr (stx : Syntax) (attr : ParametricAttribute β)
+def warnParametricAttr {β : Type} (stx : Syntax) (attr : ParametricAttribute β)
     (thisAttr attrName src tgt : Name) : CoreM Unit :=
 warnExt stx attr.ext (·.contains ·) thisAttr attrName src tgt
 
 /-- `runAndAdditivize names desc t` runs `t` on all elements of `names`
 and adds translations between the generated lemmas (the output of `t`).
 `names` must be non-empty. -/
-def additivizeLemmas [Monad m] [MonadError m] [MonadLiftT CoreM m]
+def additivizeLemmas {m : Type → Type} [Monad m] [MonadError m] [MonadLiftT CoreM m]
     (names : Array Name) (desc : String) (t : Name → m (Array Name)) : m Unit := do
   let auxLemmas ← names.mapM t
   let nLemmas := auxLemmas[0]!.size

--- a/Mathlib/Tactic/ToLevel.lean
+++ b/Mathlib/Tactic/ToLevel.lean
@@ -16,8 +16,6 @@ override the ones from Lean 4 core.
 
 -/
 
-set_option autoImplicit true
-
 namespace Lean
 
 /-- A class to create `Level` expressions that denote particular universe levels in Lean.
@@ -35,6 +33,8 @@ attribute [pp_with_univ] toLevel
 
 instance : ToLevel.{0} where
   toLevel := .zero
+
+universe u v
 
 instance [ToLevel.{u}] : ToLevel.{u+1} where
   toLevel := .succ toLevel.{u}

--- a/Mathlib/Tactic/UnsetOption.lean
+++ b/Mathlib/Tactic/UnsetOption.lean
@@ -19,11 +19,9 @@ is cleaner not to write it explicitly, or for some options where the default
 behaviour is different from any user set value.
 -/
 
-set_option autoImplicit true
-
 namespace Lean.Elab
 
-variable [Monad m] [MonadOptions m] [MonadExceptOf Exception m] [MonadRef m]
+variable {m : Type → Type} [Monad m] [MonadOptions m] [MonadExceptOf Exception m] [MonadRef m]
 variable [AddErrorMessageContext m] [MonadLiftT (EIO Exception) m] [MonadInfoTree m]
 
 /-- unset the option specified by id -/


### PR DESCRIPTION
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
