### PR TITLE
[Merged by Bors] - refactor (Algebra/Order/AddTorsor) : Add multiplicative versions of everything, use to_additive

### DIFF
--- a/Mathlib/Algebra/Order/AddTorsor.lean
+++ b/Mathlib/Algebra/Order/AddTorsor.lean
@@ -12,7 +12,8 @@ This file defines ordered scalar multiplication and vector addition, and proves 
 In the additive case, a motivating example is given by the additive action of `ℤ` on subsets of
 reals that are closed under integer translation.  The order compatibility allows for a treatment of
 the `R((z))`-module structure on `(z ^ s) V((z))` for an `R`-module `V`, using the formalism of Hahn
-series.
+series.  In the multiplicative case, a standard example is the action of non-negative rationals on
+an ordered field.
 
 ## Implementation notes
 
@@ -29,19 +30,21 @@ series.
 * IsOrderedCancelVAdd : inequalities are preserved and reflected by translation.
 
 ## Instances
+* OrderedCommMonoid.toIsOrderedSMul
 * OrderedAddCommMonoid.toIsOrderedVAdd
+* IsOrderedSMul.toCovariantClassLeft
 * IsOrderedVAdd.toCovariantClassLeft
+* IsOrderedCancelSMul.toCancelSMul
 * IsOrderedCancelVAdd.toCancelVAdd
+* OrderedCancelCommMonoid.toIsOrderedCancelSMul
 * OrderedCancelAddCommMonoid.toIsOrderedCancelVAdd
+* IsOrderedCancelSMul.toContravariantClassLeft
 * IsOrderedCancelVAdd.toContravariantClassLeft
 
 ## TODO
-* `OrderedAddTorsor `: An additive torsor over an additive commutative group with compatible order.
-* `Set.vAddAntidiagonal`
+* definitions and finiteness results for antidiagonals
 * (lex) prod instances
 * Pi instances
-* `vAddAntidiagonal.finite_of_isPWO`
-* `Finset.vAddAntidiagonal`
 
 -/
 

--- a/Mathlib/Algebra/Order/AddTorsor.lean
+++ b/Mathlib/Algebra/Order/AddTorsor.lean
@@ -7,27 +7,33 @@ import Mathlib.Algebra.Group.Action.Defs
 import Mathlib.Algebra.Order.Monoid.Defs
 
 /-!
-# Ordered AddTorsors
-This file defines ordered vector addition and proves some properties.  A motivating example is given
-by the additive action of `ℤ` on subsets of reals that are closed under integer translation.  The
-order compatibility allows for a treatment of the `R((z))`-module structure on `(z ^ s) V((z))` for
-an `R`-module `V`, using the formalism of Hahn series.
+# Ordered scalar multiplication and vector addition
+This file defines ordered scalar multiplication and vector addition, and proves some properties.
+In the additive case, a motivating example is given by the additive action of `ℤ` on subsets of
+reals that are closed under integer translation.  The order compatibility allows for a treatment of
+the `R((z))`-module structure on `(z ^ s) V((z))` for an `R`-module `V`, using the formalism of Hahn
+series.
 
 ## Implementation notes
 
-We write our conditions as `Prop`-valued mixins.
+* Beause these classes mix the algebra and order hierarchies, we write them as `Prop`-valued mixins.
+* Despite the file name, Ordered AddTorsors are not defined as a separate class.  To implement them,
+  combine `[AddTorsor G P]` with `[IsOrderedCancelVAdd G P]`
 
 ## Definitions
-* OrderedVAdd : inequalities are preserved by translation.
-* CancelVAdd : the vector addition version of cancellative addition
-* OrderedCancelVAdd : inequalities are preserved and reflected by translation.
+* IsOrderedSMul : inequalities are preserved by scalar multiplication.
+* IsOrderedVAdd : inequalities are preserved by translation.
+* IsCancelSMul : the scalar multiplication version of cancellative multiplication
+* IsCancelVAdd : the vector addition version of cancellative addition
+* IsOrderedCancelSMul : inequalities are preserved and reflected by scalar multiplication.
+* IsOrderedCancelVAdd : inequalities are preserved and reflected by translation.
 
 ## Instances
-* OrderedAddCommMonoid.toOrderedVAdd
-* OrderedVAdd.toCovariantClassLeft
-* OrderedCancelVAdd.toCancelVAdd
-* OrderedCancelAddCommMonoid.toOrderedCancelVAdd
-* OrderedCancelVAdd.toContravariantClassLeft
+* OrderedAddCommMonoid.toIsOrderedVAdd
+* IsOrderedVAdd.toCovariantClassLeft
+* IsOrderedCancelVAdd.toCancelVAdd
+* OrderedCancelAddCommMonoid.toIsOrderedCancelVAdd
+* IsOrderedCancelVAdd.toContravariantClassLeft
 
 ## TODO
 * `OrderedAddTorsor `: An additive torsor over an additive commutative group with compatible order.
@@ -44,65 +50,89 @@ open Function
 variable {G P : Type*}
 
 /-- An ordered vector addition is a bi-monotone vector addition. -/
-class OrderedVAdd (G P : Type*) [LE G] [LE P] [VAdd G P] : Prop where
+class IsOrderedVAdd (G P : Type*) [LE G] [LE P] [VAdd G P] : Prop where
   protected vadd_le_vadd_left : ∀ a b : P, a ≤ b → ∀ c : G, c +ᵥ a ≤ c +ᵥ b
   protected vadd_le_vadd_right : ∀ c d : G, c ≤ d → ∀ a : P, c +ᵥ a ≤ d +ᵥ a
 
-instance OrderedAddCommMonoid.toOrderedVAdd [OrderedAddCommMonoid G] : OrderedVAdd G G where
-  vadd_le_vadd_left _ _ := add_le_add_left
-  vadd_le_vadd_right _ _ h a := add_le_add_right h a
+/-- An ordered scalar multiplication is a bi-monotone scalar multiplication. -/
+@[to_additive]
+class IsOrderedSMul (G P : Type*) [LE G] [LE P] [SMul G P] : Prop where
+  protected smul_le_smul_left : ∀ a b : P, a ≤ b → ∀ c : G, c • a ≤ c • b
+  protected smul_le_smul_right : ∀ c d : G, c ≤ d → ∀ a : P, c • a ≤ d • a
 
-instance OrderedVAdd.toCovariantClassLeft [LE G] [LE P] [VAdd G P] [OrderedVAdd G P] :
-    CovariantClass G P (· +ᵥ ·) (· ≤ ·) where
-  elim := fun a _ _ bc ↦ OrderedVAdd.vadd_le_vadd_left _ _ bc a
+@[to_additive]
+instance [LE G] [LE P] [SMul G P] [IsOrderedSMul G P] : CovariantClass G P (· • ·) (· ≤ ·) where
+  elim := fun a _ _ bc ↦ IsOrderedSMul.smul_le_smul_left _ _ bc a
+
+@[to_additive]
+instance [OrderedCommMonoid G] : IsOrderedSMul G G where
+  smul_le_smul_left _ _ := mul_le_mul_left'
+  smul_le_smul_right _ _ := mul_le_mul_right'
 
 /-- A vector addition is cancellative if it is pointwise injective on the left and right. -/
-class CancelVAdd (G P : Type*) [LE G] [LE P] [VAdd G P] : Prop where
+class IsCancelVAdd (G P : Type*) [VAdd G P] : Prop where
   protected left_cancel : ∀ (a : G) (b c : P), a +ᵥ b = a +ᵥ c → b = c
   protected right_cancel : ∀ (a b : G) (c : P), a +ᵥ c = b +ᵥ c → a = b
 
+/-- A scalar multiplication is cancellative if it is pointwise injective on the left and right. -/
+@[to_additive]
+class IsCancelSMul (G P : Type*) [SMul G P] : Prop where
+  protected left_cancel : ∀ (a : G) (b c : P), a • b = a • c → b = c
+  protected right_cancel : ∀ (a b : G) (c : P), a • c = b • c → a = b
+
 /-- An ordered cancellative vector addition is an ordered vector addition that is cancellative. -/
-class OrderedCancelVAdd (G P : Type*) [LE G] [LE P] [VAdd G P] extends OrderedVAdd G P : Prop where
+class IsOrderedCancelVAdd (G P : Type*) [LE G] [LE P] [VAdd G P] extends
+    IsOrderedVAdd G P : Prop where
   protected le_of_vadd_le_vadd_left : ∀ (a : G) (b c : P), a +ᵥ b ≤ a +ᵥ c → b ≤ c
   protected le_of_vadd_le_vadd_right : ∀ (a b : G) (c : P), a +ᵥ c ≤ b +ᵥ c → a ≤ b
 
-instance OrderedCancelVAdd.toCancelVAdd [PartialOrder G] [PartialOrder P] [VAdd G P]
-    [OrderedCancelVAdd G P] : CancelVAdd G P where
-  left_cancel a b c h := (OrderedCancelVAdd.le_of_vadd_le_vadd_left a b c h.le).antisymm
-    (OrderedCancelVAdd.le_of_vadd_le_vadd_left a c b h.ge)
-  right_cancel a b c h := by
-    refine (OrderedCancelVAdd.le_of_vadd_le_vadd_right a b c h.le).antisymm ?_
-    exact (OrderedCancelVAdd.le_of_vadd_le_vadd_right b a c h.ge)
+/-- An ordered cancellative scalar multiplication is an ordered scalar multiplication that is
+  cancellative. -/
+@[to_additive]
+class IsOrderedCancelSMul (G P : Type*) [LE G] [LE P] [SMul G P] extends
+    IsOrderedSMul G P : Prop where
+  protected le_of_smul_le_smul_left : ∀ (a : G) (b c : P), a • b ≤ a • c → b ≤ c
+  protected le_of_smul_le_smul_right : ∀ (a b : G) (c : P), a • c ≤ b • c → a ≤ b
 
-instance OrderedCancelAddCommMonoid.toOrderedCancelVAdd [OrderedCancelAddCommMonoid G] :
-    OrderedCancelVAdd G G where
-  le_of_vadd_le_vadd_left _ _ _ := le_of_add_le_add_left
-  le_of_vadd_le_vadd_right _ _ _ := le_of_add_le_add_right
+@[to_additive]
+instance [PartialOrder G] [PartialOrder P] [SMul G P] [IsOrderedCancelSMul G P] :
+    IsCancelSMul G P where
+  left_cancel a b c h := (IsOrderedCancelSMul.le_of_smul_le_smul_left a b c h.le).antisymm
+    (IsOrderedCancelSMul.le_of_smul_le_smul_left a c b h.ge)
+  right_cancel a b c h := (IsOrderedCancelSMul.le_of_smul_le_smul_right a b c h.le).antisymm
+    (IsOrderedCancelSMul.le_of_smul_le_smul_right b a c h.ge)
 
-namespace VAdd
+@[to_additive]
+instance [OrderedCancelCommMonoid G] : IsOrderedCancelSMul G G where
+  le_of_smul_le_smul_left _ _ _ := le_of_mul_le_mul_left'
+  le_of_smul_le_smul_right _ _ _ := le_of_mul_le_mul_right'
 
-theorem vadd_lt_vadd_of_le_of_lt [LE G] [Preorder P] [VAdd G P] [OrderedCancelVAdd G P]
+namespace SMul
+
+@[to_additive]
+theorem smul_lt_smul_of_le_of_lt [LE G] [Preorder P] [SMul G P] [IsOrderedCancelSMul G P]
     {a b : G} {c d : P} (h₁ : a ≤ b) (h₂ : c < d) :
-    a +ᵥ c < b +ᵥ d := by
-  refine lt_of_le_of_lt (OrderedVAdd.vadd_le_vadd_right a b h₁ c) ?_
-  refine lt_of_le_not_le (OrderedVAdd.vadd_le_vadd_left c d (le_of_lt h₂) b) ?_
+  a • c < b • d := by
+  refine lt_of_le_of_lt (IsOrderedSMul.smul_le_smul_right a b h₁ c) ?_
+  refine lt_of_le_not_le (IsOrderedSMul.smul_le_smul_left c d (le_of_lt h₂) b) ?_
   by_contra hbdc
-  have h : d ≤ c := OrderedCancelVAdd.le_of_vadd_le_vadd_left b d c hbdc
+  have h : d ≤ c := IsOrderedCancelSMul.le_of_smul_le_smul_left b d c hbdc
   rw [@lt_iff_le_not_le] at h₂
   simp_all only [not_true_eq_false, and_false]
 
-theorem vadd_lt_vadd_of_lt_of_le [Preorder G] [Preorder P] [VAdd G P] [OrderedCancelVAdd G P]
-    {a b : G} {c d : P} (h₁ : a < b) (h₂ : c ≤ d) :
-    a +ᵥ c < b +ᵥ d := by
-  refine lt_of_le_of_lt (OrderedVAdd.vadd_le_vadd_left c d h₂ a) ?_
-  refine lt_of_le_not_le (OrderedVAdd.vadd_le_vadd_right a b (le_of_lt h₁) d) ?_
+@[to_additive]
+theorem smul_lt_smul_of_lt_of_le [Preorder G] [Preorder P] [SMul G P] [IsOrderedCancelSMul G P]
+    {a b : G} {c d : P} (h₁ : a < b) (h₂ : c ≤ d) : a • c < b • d := by
+  refine lt_of_le_of_lt (IsOrderedSMul.smul_le_smul_left c d h₂ a) ?_
+  refine lt_of_le_not_le (IsOrderedSMul.smul_le_smul_right a b (le_of_lt h₁) d) ?_
   by_contra hbad
-  have h : b ≤ a := OrderedCancelVAdd.le_of_vadd_le_vadd_right b a d hbad
+  have h : b ≤ a := IsOrderedCancelSMul.le_of_smul_le_smul_right b a d hbad
   rw [@lt_iff_le_not_le] at h₁
   simp_all only [not_true_eq_false, and_false]
 
-end VAdd
+end SMul
 
-instance (priority := 200) OrderedCancelVAdd.toContravariantClassLeLeft [LE G]
-    [LE P] [VAdd G P] [OrderedCancelVAdd G P] : ContravariantClass G P (· +ᵥ ·) (· ≤ ·) :=
-  ⟨OrderedCancelVAdd.le_of_vadd_le_vadd_left⟩
+@[to_additive]
+instance (priority := 200) [LE G] [LE P] [SMul G P] [IsOrderedCancelSMul G P] :
+    ContravariantClass G P (· • ·) (· ≤ ·) :=
+  ⟨IsOrderedCancelSMul.le_of_smul_le_smul_left⟩

--- a/Mathlib/Algebra/Order/AddTorsor.lean
+++ b/Mathlib/Algebra/Order/AddTorsor.lean
@@ -57,6 +57,8 @@ class IsOrderedVAdd (G P : Type*) [LE G] [LE P] [VAdd G P] : Prop where
   protected vadd_le_vadd_left : ∀ a b : P, a ≤ b → ∀ c : G, c +ᵥ a ≤ c +ᵥ b
   protected vadd_le_vadd_right : ∀ c d : G, c ≤ d → ∀ a : P, c +ᵥ a ≤ d +ᵥ a
 
+@[deprecated (since := "2024-07-15")] alias OrderedVAdd := IsOrderedVAdd
+
 /-- An ordered scalar multiplication is a bi-monotone scalar multiplication. -/
 @[to_additive]
 class IsOrderedSMul (G P : Type*) [LE G] [LE P] [SMul G P] : Prop where
@@ -77,6 +79,8 @@ class IsCancelVAdd (G P : Type*) [VAdd G P] : Prop where
   protected left_cancel : ∀ (a : G) (b c : P), a +ᵥ b = a +ᵥ c → b = c
   protected right_cancel : ∀ (a b : G) (c : P), a +ᵥ c = b +ᵥ c → a = b
 
+@[deprecated (since := "2024-07-15")] alias CancelVAdd := IsCancelVAdd
+
 /-- A scalar multiplication is cancellative if it is pointwise injective on the left and right. -/
 @[to_additive]
 class IsCancelSMul (G P : Type*) [SMul G P] : Prop where
@@ -88,6 +92,8 @@ class IsOrderedCancelVAdd (G P : Type*) [LE G] [LE P] [VAdd G P] extends
     IsOrderedVAdd G P : Prop where
   protected le_of_vadd_le_vadd_left : ∀ (a : G) (b c : P), a +ᵥ b ≤ a +ᵥ c → b ≤ c
   protected le_of_vadd_le_vadd_right : ∀ (a b : G) (c : P), a +ᵥ c ≤ b +ᵥ c → a ≤ b
+
+@[deprecated (since := "2024-07-15")] alias OrderedCancelVAdd := IsOrderedCancelVAdd
 
 /-- An ordered cancellative scalar multiplication is an ordered scalar multiplication that is
   cancellative. -/

--- a/Mathlib/Algebra/Order/AddTorsor.lean
+++ b/Mathlib/Algebra/Order/AddTorsor.lean
@@ -59,7 +59,9 @@ class IsOrderedVAdd (G P : Type*) [LE G] [LE P] [VAdd G P] : Prop where
 
 @[deprecated (since := "2024-07-15")] alias OrderedVAdd := IsOrderedVAdd
 
-/-- An ordered scalar multiplication is a bi-monotone scalar multiplication. -/
+/-- An ordered scalar multiplication is a bi-monotone scalar multiplication. Note that this is
+different from `OrderedSMul`, which uses strict inequality, requires `G` to be a semiring, and the
+defining conditions are restricted to positive elements of `G`. -/
 @[to_additive]
 class IsOrderedSMul (G P : Type*) [LE G] [LE P] [SMul G P] : Prop where
   protected smul_le_smul_left : ∀ a b : P, a ≤ b → ∀ c : G, c • a ≤ c • b

--- a/Mathlib/Algebra/Order/Module/OrderedSMul.lean
+++ b/Mathlib/Algebra/Order/Module/OrderedSMul.lean
@@ -43,7 +43,9 @@ ordered module, ordered scalar, ordered smul, ordered action, ordered vector spa
 -/
 
 /-- The ordered scalar product property is when an ordered additive commutative monoid
-with a partial order has a scalar multiplication which is compatible with the order.
+with a partial order has a scalar multiplication which is compatible with the order. Note that this
+is different from `IsOrderedSMul`, which uses `≤`, has no semiring assumption, and has no positivity
+constraint on the defining conditions.
 -/
 class OrderedSMul (R M : Type*) [OrderedSemiring R] [OrderedAddCommMonoid M] [SMulWithZero R M] :
   Prop where


### PR DESCRIPTION
This PR adds multiplicative versions of the existing Prop-valued mixin classes relating vector addition to order.  Also, we rename:

-  `OrderedVAdd` to `IsOrderedVAdd`
-  `CancelVAdd` to `IsCancelVAdd`
-  `OrderedCancelVAdd` to `IsOrderedCancelVAdd`

---


[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
