### PR TITLE
[Merged by Bors] - chore(UniformEmbedding): add `UniformInducing.uniformInducing_iff`

### DIFF
--- a/Mathlib/Topology/UniformSpace/UniformEmbedding.lean
+++ b/Mathlib/Topology/UniformSpace/UniformEmbedding.lean
@@ -107,6 +107,11 @@ theorem UniformInducing.uniformContinuous_iff {f : α → β} {g : β → γ} (h
   rw [← hg.comap_uniformity, ← map_le_iff_le_comap, Filter.map_map]; rfl
 #align uniform_inducing.uniform_continuous_iff UniformInducing.uniformContinuous_iff
 
+protected theorem UniformInducing.uniformInducing_iff {f : α → β} {g : β → γ}
+    (hg : UniformInducing g) : UniformInducing f ↔ UniformInducing (g ∘ f) := by
+  simp only [uniformInducing_iff, ← hg.comap_uniformity, comap_comap]
+  rfl
+
 theorem UniformInducing.uniformContinuousOn_iff {f : α → β} {g : β → γ} {S : Set α}
     (hg : UniformInducing g) :
     UniformContinuousOn f S ↔ UniformContinuousOn (g ∘ f) S := by

--- a/Mathlib/Topology/UniformSpace/UniformEmbedding.lean
+++ b/Mathlib/Topology/UniformSpace/UniformEmbedding.lean
@@ -107,8 +107,8 @@ theorem UniformInducing.uniformContinuous_iff {f : α → β} {g : β → γ} (h
   rw [← hg.comap_uniformity, ← map_le_iff_le_comap, Filter.map_map]; rfl
 #align uniform_inducing.uniform_continuous_iff UniformInducing.uniformContinuous_iff
 
-protected theorem UniformInducing.uniformInducing_iff {f : α → β} {g : β → γ}
-    (hg : UniformInducing g) : UniformInducing f ↔ UniformInducing (g ∘ f) := by
+protected theorem UniformInducing.uniformInducing_comp_iff {f : α → β} {g : β → γ}
+    (hg : UniformInducing g) : UniformInducing (g ∘ f) ↔ UniformInducing f := by
   simp only [uniformInducing_iff, ← hg.comap_uniformity, comap_comap]
   rfl
 


### PR DESCRIPTION
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
