### PR TITLE
[Merged by Bors] - chore(SetTheory/Lists): remove porting notes

### DIFF
--- a/Mathlib/SetTheory/Lists.lean
+++ b/Mathlib/SetTheory/Lists.lean
@@ -83,9 +83,8 @@ def toList : ∀ {b}, Lists' α b → List (Lists α)
   | _, cons' a l => ⟨_, a⟩ :: l.toList
 #align lists'.to_list Lists'.toList
 
--- Porting note (#10618): removed @[simp]
--- simp can prove this: by simp only [@Lists'.toList, @Sigma.eta]
-theorem toList_cons (a : Lists α) (l) : toList (cons a l) = a :: l.toList := by simp
+@[simp]
+theorem toList_cons (a : Lists α) (l) : toList (cons a l) = a :: l.toList := rfl
 #align lists'.to_list_cons Lists'.toList_cons
 
 /-- Converts a `List` of ZFA lists to a proper ZFA prelist. -/
@@ -109,14 +108,8 @@ theorem of_toList : ∀ l : Lists' α true, ofList (toList l) = l :=
   fun b h l => by
     induction l with
     | atom => cases h
-    -- Porting note: case nil was not covered.
     | nil => simp
-    | cons' b a _ IH =>
-      -- Porting note: Previous code was:
-      -- change l' with cons' a l
-      --
-      -- This can be removed.
-      simpa [cons] using IH rfl
+    | cons' b a _ IH => simpa [cons] using IH rfl
 #align lists'.of_to_list Lists'.of_toList
 
 end Lists'
@@ -316,15 +309,12 @@ theorem Equiv.trans : ∀ {l₁ l₂ l₃ : Lists α}, l₁ ~ l₂ → l₂ ~ l�
   · intro a l₂ l₃ h₁ h₂
     rwa [← equiv_atom.1 h₁] at h₂
   · intro l₁ IH l₂ l₃ h₁ h₂
-    -- Porting note: Two 'have's are for saving the state.
-    have h₁' := h₁
-    have h₂' := h₂
-    cases' h₁ with _ _ l₂
+    cases' id h₁ with _ _ l₂
     · exact h₂
-    cases' h₂ with _ _ l₃
-    · exact h₁'
-    cases' Equiv.antisymm_iff.1 h₁' with hl₁ hr₁
-    cases' Equiv.antisymm_iff.1 h₂' with hl₂ hr₂
+    cases' id h₂ with _ _ l₃
+    · exact h₁
+    cases' Equiv.antisymm_iff.1 h₁ with hl₁ hr₁
+    cases' Equiv.antisymm_iff.1 h₂ with hl₂ hr₂
     apply Equiv.antisymm_iff.2; constructor <;> apply Lists'.subset_def.2
     · intro a₁ m₁
       rcases Lists'.mem_of_subset' hl₁ m₁ with ⟨a₂, m₂, e₁₂⟩
@@ -335,17 +325,8 @@ theorem Equiv.trans : ∀ {l₁ l₂ l₃ : Lists α}, l₁ ~ l₂ → l₂ ~ l�
       rcases Lists'.mem_of_subset' hr₁ m₂ with ⟨a₁, m₁, e₂₁⟩
       exact ⟨a₁, m₁, (IH _ m₁ e₂₁.symm e₃₂.symm).symm⟩
   · rintro _ ⟨⟩
-  · intro a l IH₁ IH
-    -- Porting note: Previous code was:
-    -- simpa [IH₁] using IH
-    --
-    -- Assumption fails.
-    simp only [Lists'.toList, Sigma.eta, List.find?, List.mem_cons, forall_eq_or_imp]
-    constructor
-    · intros l₂ l₃ h₁ h₂
-      exact IH₁ h₁ h₂
-    · intros a h₁ l₂ l₃ h₂ h₃
-      exact IH _ h₁ h₂ h₃
+  · intro a l IH₁ IH₂
+    simpa using ⟨IH₁, IH₂⟩ 
 #align lists.equiv.trans Lists.Equiv.trans
 
 instance instSetoidLists : Setoid (Lists α) :=

--- a/Mathlib/SetTheory/Lists.lean
+++ b/Mathlib/SetTheory/Lists.lean
@@ -326,7 +326,7 @@ theorem Equiv.trans : ∀ {l₁ l₂ l₃ : Lists α}, l₁ ~ l₂ → l₂ ~ l�
       exact ⟨a₁, m₁, (IH _ m₁ e₂₁.symm e₃₂.symm).symm⟩
   · rintro _ ⟨⟩
   · intro a l IH₁ IH₂
-    simpa using ⟨IH₁, IH₂⟩ 
+    simpa using ⟨IH₁, IH₂⟩
 #align lists.equiv.trans Lists.Equiv.trans
 
 instance instSetoidLists : Setoid (Lists α) :=


### PR DESCRIPTION
One porting note in this file remains.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
