### PR TITLE
[Merged by Bors] - feat: Create a partition from an element of Sym

### DIFF
--- a/Mathlib/Combinatorics/Enumerative/Partition.lean
+++ b/Mathlib/Combinatorics/Enumerative/Partition.lean
@@ -110,7 +110,7 @@ def ofSym {n : ℕ} {σ : Type*} (s : Sym σ n) [DecidableEq σ] : n.Partition w
 
 variable {n : ℕ} {σ τ : Type*} [DecidableEq σ] [DecidableEq τ]
 
-lemma ofSym_map (e : σ ≃ τ) (s : Sym σ n) :
+@[simp] lemma ofSym_map (e : σ ≃ τ) (s : Sym σ n) :
     ofSym (s.map e) = ofSym s := by
   simp only [ofSym, Sym.val_eq_coe, Sym.coe_map, toFinset_val, mk.injEq]
   rw [Multiset.dedup_map_of_injective e.injective]

--- a/Mathlib/Combinatorics/Enumerative/Partition.lean
+++ b/Mathlib/Combinatorics/Enumerative/Partition.lean
@@ -120,7 +120,7 @@ variable {n : ℕ} {σ τ : Type*} [DecidableEq σ] [DecidableEq τ]
 
 /-- An equivalence between `σ` and `τ` induces an equivalence between the subtypes of `Sym σ n` and
 `Sym τ n` corresponding to a given partition. -/
-def ofSym_shape_equiv (μ : Partition n) (e : σ ≃ τ) :
+def ofSymShapeEquiv (μ : Partition n) (e : σ ≃ τ) :
     {x : Sym σ n // ofSym x = μ} ≃ {x : Sym τ n // ofSym x = μ} where
   toFun := fun x => ⟨Sym.equivCongr e x, by simp [ofSym_map, x.2]⟩
   invFun := fun x => ⟨Sym.equivCongr e.symm x, by simp [ofSym_map, x.2]⟩

--- a/Mathlib/Combinatorics/Enumerative/Partition.lean
+++ b/Mathlib/Combinatorics/Enumerative/Partition.lean
@@ -154,18 +154,6 @@ instance UniquePartitionOne : Unique (Partition 1) where
 lemma ofSym_one (s : Sym σ 1) : ofSym s = indiscrete 1 := by
   ext; simp
 
-/-- The equivalence between `σ` and `1`-tuples of elements of σ -/
-def ofSym_equiv_indiscrete (σ : Type*) [DecidableEq σ] : σ ≃
-    { a : Sym σ 1 // ofSym a = indiscrete 1 } where
-  toFun := fun a => ⟨Sym.oneEquiv a, by ext; simp⟩
-  invFun := fun a => Sym.oneEquiv.symm a.1
-  left_inv := by intro a; simp only [Sym.oneEquiv_apply]; rfl
-  right_inv := by intro a; simp only [Equiv.apply_symm_apply, Subtype.coe_eta]
-
-@[simp]
-lemma ofSym_equiv_indiscrete_apply (i : σ) :
-    ((ofSym_equiv_indiscrete σ) i : Multiset σ) = {i} := rfl
-
 /-- The number of times a positive integer `i` appears in the partition `ofSums n l hl` is the same
 as the number of times it appears in the multiset `l`.
 (For `i = 0`, `Partition.non_zero` combined with `Multiset.count_eq_zero_of_not_mem` gives that

--- a/Mathlib/Combinatorics/Enumerative/Partition.lean
+++ b/Mathlib/Combinatorics/Enumerative/Partition.lean
@@ -151,7 +151,7 @@ instance UniquePartitionZero : Unique (Partition 0) where
 instance UniquePartitionOne : Unique (Partition 1) where
   uniq _ := Partition.ext _ _ <| by simp
 
-lemma ofSym_one (s : Sym σ 1) : ofSym s = indiscrete 1 := by
+@[simp] lemma ofSym_one (s : Sym σ 1) : ofSym s = indiscrete 1 := by
   ext; simp
 
 /-- The number of times a positive integer `i` appears in the partition `ofSums n l hl` is the same

--- a/Mathlib/Data/Sym/Basic.lean
+++ b/Mathlib/Data/Sym/Basic.lean
@@ -534,6 +534,19 @@ theorem mem_append_iff {s' : Sym α m} : a ∈ s.append s' ↔ a ∈ s ∨ a ∈
   Multiset.mem_add
 #align sym.mem_append_iff Sym.mem_append_iff
 
+/-- Defines an equivalence between `α` and `Sym α 1`. -/
+@[simps apply]
+def oneEquiv : α ≃ Sym α 1 where
+  toFun a := ⟨{a}, by simp⟩
+  invFun s := (Equiv.subtypeQuotientEquivQuotientSubtype
+      (·.length = 1) _ (fun l ↦ Iff.rfl) (fun l l' ↦ by rfl) s).liftOn
+    (fun l ↦ l.1.head <| List.length_pos.mp <| by simp)
+    fun ⟨_, _⟩ ⟨_, h⟩ ↦ fun perm ↦ by
+      obtain ⟨a, rfl⟩ := List.length_eq_one.mp h
+      exact List.eq_of_mem_singleton (perm.mem_iff.mp <| List.head_mem _)
+  left_inv a := by rfl
+  right_inv := by rintro ⟨⟨l⟩, h⟩; obtain ⟨a, rfl⟩ := List.length_eq_one.mp h; rfl
+
 /-- Fill a term `m : Sym α (n - i)` with `i` copies of `a` to obtain a term of `Sym α n`.
 This is a convenience wrapper for `m.append (replicate i a)` that adjusts the term using
 `Sym.cast`. -/

--- a/Mathlib/Data/Sym/Basic.lean
+++ b/Mathlib/Data/Sym/Basic.lean
@@ -534,7 +534,7 @@ theorem mem_append_iff {s' : Sym α m} : a ∈ s.append s' ↔ a ∈ s ∨ a ∈
   Multiset.mem_add
 #align sym.mem_append_iff Sym.mem_append_iff
 
-/-- Defines an equivalence between `α` and `Sym α 1`. -/
+/-- `a ↦ {a}` as an equivalence between `α` and `Sym α 1`. -/
 @[simps apply]
 def oneEquiv : α ≃ Sym α 1 where
   toFun a := ⟨{a}, by simp⟩


### PR DESCRIPTION
An element of Sym induces a partition given by the multiplicities of its elements.

Co-authored-by: Nirvana Coppola [nirvanac93@gmail.com](mailto:nirvanac93@gmail.com)

---

See https://github.com/leanprover-community/mathlib4/pull/12572.

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
