### PR TITLE
[Merged by Bors] - chore: rename endOf linter to missingEnd

### DIFF
--- a/Mathlib/Tactic/Linter/Lint.lean
+++ b/Mathlib/Tactic/Linter/Lint.lean
@@ -150,29 +150,29 @@ initialize addLinter oneLineAlign
 end OneLineAlignLinter
 
 /-!
-# The "EndOf" linter
+# The "missing end" linter
 
-The "EndOf" linter emits a warning on non-closed `section`s and `namespace`s.
+The "missing end" linter emits a warning on non-closed `section`s and `namespace`s.
 It allows the "outermost" `noncomputable section` to be left open (whether or not it is named).
 -/
 
 open Lean Elab Command
 
-/-- The "EndOf" linter emits a warning on non-closed `section`s and `namespace`s.
+/-- The "missing end" linter emits a warning on non-closed `section`s and `namespace`s.
 It allows the "outermost" `noncomputable section` to be left open (whether or not it is named).
 -/
-register_option linter.endOf : Bool := {
+register_option linter.missingEnd : Bool := {
   defValue := true
-  descr := "enable the EndOf linter"
+  descr := "enable the missing end linter"
 }
 
-namespace EndOf
+namespace MissingEnd
 
-/-- Gets the value of the `linter.endOf` option. -/
-def getLinterHash (o : Options) : Bool := Linter.getLinterValue linter.endOf o
+/-- Gets the value of the `linter.missingEnd` option. -/
+def getLinterHash (o : Options) : Bool := Linter.getLinterValue linter.missingEnd o
 
-@[inherit_doc Mathlib.Linter.linter.endOf]
-def endOfLinter : Linter where run := withSetOptionIn fun stx ↦ do
+@[inherit_doc Mathlib.Linter.linter.missingEnd]
+def missingEndLinter : Linter where run := withSetOptionIn fun stx ↦ do
     -- Only run this linter at the end of a module.
     unless stx.isOfKind ``Lean.Parser.Command.eoi do return
     if getLinterHash (← getOptions) && !(← MonadState.get).messages.hasErrors then
@@ -187,11 +187,11 @@ def endOfLinter : Linter where run := withSetOptionIn fun stx ↦ do
       if !ends.isEmpty then
         let ending := (ends.map Prod.fst).foldl (init := "") fun a b ↦
           a ++ s!"\n\nend{if b == "" then "" else " "}{b}"
-        Linter.logLint linter.endOf stx
+        Linter.logLint linter.missingEnd stx
          m!"unclosed sections or namespaces; expected: '{ending}'"
 
-initialize addLinter endOfLinter
+initialize addLinter missingEndLinter
 
-end EndOf
+end MissingEnd
 
 end Mathlib.Linter


### PR DESCRIPTION
Per [zulip discussion](https://leanprover.zulipchat.com/#narrow/stream/287929-mathlib4/topic/linting.20for.20unclosed.20sections.3F/near/451359224).


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
