### PR TITLE
feat(CstarRing): show that `‖x‖` is the sup of `‖y * x‖` for `‖y‖ ≤ 1`

### DIFF
--- a/Mathlib/Analysis/Normed/Field/Basic.lean
+++ b/Mathlib/Analysis/Normed/Field/Basic.lean
@@ -239,6 +239,16 @@ theorem nnnorm_mul_le (a b : α) : ‖a * b‖₊ ≤ ‖a‖₊ * ‖b‖₊ :=
     Real.toNNReal_mono (norm_mul_le _ _)
 #align nnnorm_mul_le nnnorm_mul_le
 
+lemma norm_mul_le_norm_right {a : α} (ha : ‖a‖ ≤ 1) (b : α) : ‖a * b‖ ≤ ‖b‖ := calc
+  ‖a * b‖ ≤ ‖a‖ * ‖b‖ := norm_mul_le _ _
+  _ ≤ 1 * ‖b‖ := by gcongr
+  _ = ‖b‖ := one_mul _
+
+lemma norm_mul_le_norm_left {b : α} (hb : ‖b‖ ≤ 1) (a : α) : ‖a * b‖ ≤ ‖a‖ := calc
+  ‖a * b‖ ≤ ‖a‖ * ‖b‖ := norm_mul_le _ _
+  _ ≤ ‖a‖ * 1 := by gcongr
+  _ = ‖a‖ := mul_one _
+
 theorem one_le_norm_one (β) [NormedRing β] [Nontrivial β] : 1 ≤ ‖(1 : β)‖ :=
   (le_mul_iff_one_le_left <| norm_pos_iff.mpr (one_ne_zero : (1 : β) ≠ 0)).mp
     (by simpa only [mul_one] using norm_mul_le (1 : β) 1)

--- a/Mathlib/Analysis/NormedSpace/Star/Basic.lean
+++ b/Mathlib/Analysis/NormedSpace/Star/Basic.lean
@@ -162,8 +162,7 @@ theorem norm_eq_sSup_norm_mul [Module ℝ E] [IsScalarTower ℝ E E] [BoundedSMu
   have h₁' : ‖x'‖ ≤ 1 := by
     by_cases htriv : x = 0
     · simp [x', htriv]
-    · have : ‖x‖ ≠ 0 := by exact norm_ne_zero_iff.mpr htriv
-      simp [x', norm_smul, inv_mul_cancel this]
+    · simp [x', norm_smul, inv_mul_cancel (norm_ne_zero_iff.mpr htriv)]
   apply Eq.symm
   refine csSup_eq_of_forall_le_of_forall_lt_exists_gt ⟨‖x‖, x', ⟨h₁, h₁'⟩⟩ ?_ ?_
   · rintro c ⟨y, hy₁, hy₂⟩

--- a/Mathlib/Analysis/NormedSpace/Star/Basic.lean
+++ b/Mathlib/Analysis/NormedSpace/Star/Basic.lean
@@ -22,9 +22,13 @@ A C⋆-ring is a normed star group that is also a ring and that verifies the str
 condition `‖x⋆ * x‖ = ‖x‖^2` for all `x`.  If a C⋆-ring is also a star algebra, then it is a
 C⋆-algebra.
 
-To get a C⋆-algebra `E` over field `𝕜`, use
+To get a unital C⋆-algebra `E` over field `𝕜`, use
 `[NormedField 𝕜] [StarRing 𝕜] [NormedRing E] [StarRing E] [CstarRing E]
  [NormedAlgebra 𝕜 E] [StarModule 𝕜 E]`.
+
+For a non-unital C⋆-algebra, use
+`[NormedField 𝕜] [StarRing 𝕜] [NonUnitalNormedRing E] [StarRing E] [CstarRing E] [Module 𝕜 E]
+ [SMulCommClass 𝕜 E E] [IsScalarTower 𝕜 E E] [StarModule 𝕜 E]`.
 
 ## TODO
 
@@ -148,6 +152,27 @@ theorem mul_star_self_eq_zero_iff (x : E) : x * x⋆ = 0 ↔ x = 0 := by
 theorem mul_star_self_ne_zero_iff (x : E) : x * x⋆ ≠ 0 ↔ x ≠ 0 := by
   simp only [Ne, mul_star_self_eq_zero_iff]
 #align cstar_ring.mul_star_self_ne_zero_iff CstarRing.mul_star_self_ne_zero_iff
+
+theorem norm_eq_sSup_norm_mul [Module ℝ E] [SMulCommClass ℝ E E] [IsScalarTower ℝ E E]
+    [BoundedSMul ℝ E] (x : E) :
+    ‖x‖ = sSup { c | ∃ y, c = ‖y * x‖ ∧ ‖y‖ ≤ 1 } := by
+  let x' := ‖x⋆‖⁻¹ • x⋆
+  have h₁ : ‖x‖ = ‖x' * x‖ := by
+    simp [x', smul_mul_assoc, norm_smul, norm_inv, norm_norm, norm_star_mul_self,
+          ← mul_assoc, norm_star]
+  have h₁' : ‖x'‖ ≤ 1 := by
+    by_cases htriv : x = 0
+    · simp [x', htriv]
+    · have : ‖x‖ ≠ 0 := by exact norm_ne_zero_iff.mpr htriv
+      simp [x', norm_smul, inv_mul_cancel this]
+  apply Eq.symm
+  refine csSup_eq_of_forall_le_of_forall_lt_exists_gt ⟨‖x‖, x', ⟨h₁, h₁'⟩⟩ ?_ ?_
+  · rintro c ⟨y, hy₁, hy₂⟩
+    rw [hy₁]
+    calc _ ≤ ‖y‖ * ‖x‖ := norm_mul_le _ _
+      _ ≤ 1 * ‖x‖ := by gcongr
+      _ = ‖x‖ := by simp
+  · exact fun c hc => ⟨‖x‖, ⟨x', h₁, h₁'⟩, hc⟩
 
 end NonUnital
 

--- a/Mathlib/Analysis/NormedSpace/Star/Basic.lean
+++ b/Mathlib/Analysis/NormedSpace/Star/Basic.lean
@@ -153,8 +153,7 @@ theorem mul_star_self_ne_zero_iff (x : E) : x * x⋆ ≠ 0 ↔ x ≠ 0 := by
   simp only [Ne, mul_star_self_eq_zero_iff]
 #align cstar_ring.mul_star_self_ne_zero_iff CstarRing.mul_star_self_ne_zero_iff
 
-theorem norm_eq_sSup_norm_mul [Module ℝ E] [SMulCommClass ℝ E E] [IsScalarTower ℝ E E]
-    [BoundedSMul ℝ E] (x : E) :
+theorem norm_eq_sSup_norm_mul [Module ℝ E] [IsScalarTower ℝ E E] [BoundedSMul ℝ E] (x : E) :
     ‖x‖ = sSup { c | ∃ y, c = ‖y * x‖ ∧ ‖y‖ ≤ 1 } := by
   let x' := ‖x⋆‖⁻¹ • x⋆
   have h₁ : ‖x‖ = ‖x' * x‖ := by

--- a/Mathlib/Analysis/NormedSpace/Star/Basic.lean
+++ b/Mathlib/Analysis/NormedSpace/Star/Basic.lean
@@ -27,7 +27,7 @@ To get a unital C⋆-algebra `E` over field `𝕜`, use
  [NormedAlgebra 𝕜 E] [StarModule 𝕜 E]`.
 
 For a non-unital C⋆-algebra, use
-`[NormedField 𝕜] [StarRing 𝕜] [NonUnitalNormedRing E] [StarRing E] [CstarRing E] [Module 𝕜 E]
+`[NormedField 𝕜] [StarRing 𝕜] [NonUnitalNormedRing E] [StarRing E] [CstarRing E] [NormedSpace 𝕜 E]
  [SMulCommClass 𝕜 E E] [IsScalarTower 𝕜 E E] [StarModule 𝕜 E]`.
 
 ## TODO

--- a/Mathlib/Data/Set/Basic.lean
+++ b/Mathlib/Data/Set/Basic.lean
@@ -1348,6 +1348,12 @@ theorem default_coe_singleton (x : α) : (default : ({x} : Set α)) = ⟨x, rfl�
   rfl
 #align set.default_coe_singleton Set.default_coe_singleton
 
+lemma inter_singleton (s : Set α) (a : α) : s ∩ {a} = {a} ∨ s ∩ {a} = ∅ := by
+  simpa using Classical.em (a ∈ s)
+
+lemma singleton_inter (s : Set α) (a : α) : s ∩ {a} = {a} ∨ s ∩ {a} = ∅ := by
+  simpa using Classical.em (a ∈ s)
+
 /-! ### Lemmas about sets defined as `{x ∈ s | p x}`. -/
 
 


### PR DESCRIPTION
Also, add documentation about non-unital C*-algebras to the module docstring.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
