### PR TITLE
[Merged by Bors] - refactor(GroupTheory/PGroup,Sylow): Replace Fintype.card with Nat.card

### DIFF
--- a/Mathlib/GroupTheory/Nilpotent.lean
+++ b/Mathlib/GroupTheory/Nilpotent.lean
@@ -874,10 +874,10 @@ variable [Fintype G]
 
 /-- If a finite group is the direct product of its Sylow groups, it is nilpotent -/
 theorem isNilpotent_of_product_of_sylow_group
-    (e : (∀ p : (Fintype.card G).primeFactors, ∀ P : Sylow p G, (↑P : Subgroup G)) ≃* G) :
+    (e : (∀ p : (Nat.card G).primeFactors, ∀ P : Sylow p G, (↑P : Subgroup G)) ≃* G) :
     IsNilpotent G := by
   classical
-    let ps := (Fintype.card G).primeFactors
+    let ps := (Nat.card G).primeFactors
     have : ∀ (p : ps) (P : Sylow p G), IsNilpotent (↑P : Subgroup G) := by
       intro p P
       haveI : Fact (Nat.Prime ↑p) := Fact.mk <| Nat.prime_of_mem_primeFactors p.2
@@ -893,7 +893,7 @@ theorem isNilpotent_of_finite_tfae :
       [IsNilpotent G, NormalizerCondition G, ∀ H : Subgroup G, IsCoatom H → H.Normal,
         ∀ (p : ℕ) (_hp : Fact p.Prime) (P : Sylow p G), (↑P : Subgroup G).Normal,
         Nonempty
-          ((∀ p : (card G).primeFactors, ∀ P : Sylow p G, (↑P : Subgroup G)) ≃* G)] := by
+          ((∀ p : (Nat.card G).primeFactors, ∀ P : Sylow p G, (↑P : Subgroup G)) ≃* G)] := by
   tfae_have 1 → 2
   · exact @normalizerCondition_of_isNilpotent _ _
   tfae_have 2 → 3

--- a/Mathlib/GroupTheory/PGroup.lean
+++ b/Mathlib/GroupTheory/PGroup.lean
@@ -21,7 +21,6 @@ then the number of fixed points of the action is congruent mod `p` to the cardin
 It also contains proofs of some corollaries of this lemma about existence of fixed points.
 -/
 
-
 open Fintype MulAction
 
 variable (p : ℕ) (G : Type*) [Group G]
@@ -43,24 +42,24 @@ theorem iff_orderOf [hp : Fact p.Prime] : IsPGroup p G ↔ ∀ g : G, ∃ k : �
       Exists.imp fun k hk => by rw [← hk, pow_orderOf_eq_one]⟩
 #align is_p_group.iff_order_of IsPGroup.iff_orderOf
 
-theorem of_card [Fintype G] {n : ℕ} (hG : card G = p ^ n) : IsPGroup p G := fun g =>
-  ⟨n, by rw [← hG, pow_card_eq_one]⟩
+theorem of_card {n : ℕ} (hG : Nat.card G = p ^ n) : IsPGroup p G := fun g =>
+  ⟨n, by rw [← hG, pow_card_eq_one']⟩
 #align is_p_group.of_card IsPGroup.of_card
 
 theorem of_bot : IsPGroup p (⊥ : Subgroup G) :=
-  of_card (by rw [← Nat.card_eq_fintype_card, Subgroup.card_bot, pow_zero])
+  of_card (by rw [Subgroup.card_bot, pow_zero])
 #align is_p_group.of_bot IsPGroup.of_bot
 
-theorem iff_card [Fact p.Prime] [Fintype G] : IsPGroup p G ↔ ∃ n : ℕ, card G = p ^ n := by
-  have hG : card G ≠ 0 := card_ne_zero
+theorem iff_card [Fact p.Prime] [Finite G] : IsPGroup p G ↔ ∃ n : ℕ, Nat.card G = p ^ n := by
+  have hG : Nat.card G ≠ 0 := Nat.card_pos.ne'
   refine ⟨fun h => ?_, fun ⟨n, hn⟩ => of_card hn⟩
-  suffices ∀ q ∈ Nat.factors (card G), q = p by
-    use (card G).factors.length
+  suffices ∀ q ∈ Nat.factors (Nat.card G), q = p by
+    use (Nat.card G).factors.length
     rw [← List.prod_replicate, ← List.eq_replicate_of_mem this, Nat.prod_factors hG]
   intro q hq
   obtain ⟨hq1, hq2⟩ := (Nat.mem_factors hG).mp hq
   haveI : Fact q.Prime := ⟨hq1⟩
-  obtain ⟨g, hg⟩ := exists_prime_orderOf_dvd_card q hq2
+  obtain ⟨g, hg⟩ := exists_prime_orderOf_dvd_card' q hq2
   obtain ⟨k, hk⟩ := (iff_orderOf.mp h) g
   exact (hq1.pow_eq_iff.mp (hg.symm.trans hk).symm).1.symm
 #align is_p_group.iff_card IsPGroup.iff_card
@@ -132,9 +131,7 @@ noncomputable abbrev powEquiv' {n : ℕ} (hn : ¬p ∣ n) : G ≃ G :=
 #align is_p_group.pow_equiv' IsPGroup.powEquiv'
 
 theorem index (H : Subgroup G) [H.FiniteIndex] : ∃ n : ℕ, H.index = p ^ n := by
-  haveI := H.normalCore.fintypeQuotientOfFiniteIndex
   obtain ⟨n, hn⟩ := iff_card.mp (hG.to_quotient H.normalCore)
-  rw [← Nat.card_eq_fintype_card] at hn
   obtain ⟨k, _, hk2⟩ :=
     (Nat.dvd_prime_pow hp.out).mp
       ((congr_arg _ (H.normalCore.index_eq_card.trans hn)).mp
@@ -143,9 +140,9 @@ theorem index (H : Subgroup G) [H.FiniteIndex] : ∃ n : ℕ, H.index = p ^ n :=
 #align is_p_group.index IsPGroup.index
 
 theorem card_eq_or_dvd : Nat.card G = 1 ∨ p ∣ Nat.card G := by
-  cases fintypeOrInfinite G
+  cases finite_or_infinite G
   · obtain ⟨n, hn⟩ := iff_card.mp hG
-    rw [Nat.card_eq_fintype_card, hn]
+    rw [hn]
     cases' n with n n
     · exact Or.inl rfl
     · exact Or.inr ⟨p ^ n, by rw [pow_succ']⟩
@@ -153,34 +150,36 @@ theorem card_eq_or_dvd : Nat.card G = 1 ∨ p ∣ Nat.card G := by
     exact Or.inr ⟨0, rfl⟩
 #align is_p_group.card_eq_or_dvd IsPGroup.card_eq_or_dvd
 
-theorem nontrivial_iff_card [Fintype G] : Nontrivial G ↔ ∃ n > 0, card G = p ^ n :=
+theorem nontrivial_iff_card [Finite G] : Nontrivial G ↔ ∃ n > 0, Nat.card G = p ^ n :=
   ⟨fun hGnt =>
     let ⟨k, hk⟩ := iff_card.1 hG
     ⟨k,
       Nat.pos_of_ne_zero fun hk0 => by
-        rw [hk0, pow_zero] at hk; exact Fintype.one_lt_card.ne' hk,
+        rw [hk0, pow_zero] at hk; exact Finite.one_lt_card.ne' hk,
       hk⟩,
     fun ⟨k, hk0, hk⟩ =>
-    one_lt_card_iff_nontrivial.1 <|
+    Finite.one_lt_card_iff_nontrivial.1 <|
       hk.symm ▸ one_lt_pow (Fact.out (p := p.Prime)).one_lt (ne_of_gt hk0)⟩
 #align is_p_group.nontrivial_iff_card IsPGroup.nontrivial_iff_card
 
 variable {α : Type*} [MulAction G α]
 
-theorem card_orbit (a : α) [Fintype (orbit G a)] : ∃ n : ℕ, card (orbit G a) = p ^ n := by
+theorem card_orbit (a : α) [Finite (orbit G a)] : ∃ n : ℕ, Nat.card (orbit G a) = p ^ n := by
   let ϕ := orbitEquivQuotientStabilizer G a
-  haveI := Fintype.ofEquiv (orbit G a) ϕ
+  haveI := Finite.of_equiv (orbit G a) ϕ
   haveI := (stabilizer G a).finiteIndex_of_finite_quotient
-  rw [card_congr ϕ, ← Nat.card_eq_fintype_card, ← Subgroup.index_eq_card]
+  rw [Nat.card_congr ϕ]
   exact hG.index (stabilizer G a)
 #align is_p_group.card_orbit IsPGroup.card_orbit
 
-variable (α) [Fintype α]
+variable (α) [Finite α]
 
 /-- If `G` is a `p`-group acting on a finite set `α`, then the number of fixed points
   of the action is congruent mod `p` to the cardinality of `α` -/
-theorem card_modEq_card_fixedPoints [Fintype (fixedPoints G α)] :
-    card α ≡ card (fixedPoints G α) [MOD p] := by
+theorem card_modEq_card_fixedPoints : Nat.card α ≡ Nat.card (fixedPoints G α) [MOD p] := by
+  have := Fintype.ofFinite α
+  have := Fintype.ofFinite (fixedPoints G α)
+  rw [Nat.card_eq_fintype_card, Nat.card_eq_fintype_card]
   classical
     calc
       card α = card (Σy : Quotient (orbitRel G α), { x // Quotient.mk'' x = y }) :=
@@ -202,6 +201,7 @@ theorem card_modEq_card_fixedPoints [Fintype (fixedPoints G α)] :
           (fun b => Quotient.inductionOn' b fun b _ hb => ?_) fun a ha _ => by
           rw [key, mem_fixedPoints_iff_card_orbit_eq_one.mp a.2])
     obtain ⟨k, hk⟩ := hG.card_orbit b
+    rw [Nat.card_eq_fintype_card] at hk
     have : k = 0 :=
       Nat.le_zero.1
         (Nat.le_of_lt_succ
@@ -217,12 +217,12 @@ theorem card_modEq_card_fixedPoints [Fintype (fixedPoints G α)] :
 
 /-- If a p-group acts on `α` and the cardinality of `α` is not a multiple
   of `p` then the action has a fixed point. -/
-theorem nonempty_fixed_point_of_prime_not_dvd_card (hpα : ¬p ∣ card α) [Finite (fixedPoints G α)] :
+theorem nonempty_fixed_point_of_prime_not_dvd_card (hpα : ¬p ∣ Nat.card α) :
     (fixedPoints G α).Nonempty :=
+  have : Finite α := Nat.finite_of_card_ne_zero (fun h ↦ (h ▸ hpα) (dvd_zero p))
   @Set.nonempty_of_nonempty_subtype _ _
     (by
-      cases nonempty_fintype (fixedPoints G α)
-      rw [← card_pos_iff, pos_iff_ne_zero]
+      rw [← Finite.card_pos_iff, pos_iff_ne_zero]
       contrapose! hpα
       rw [← Nat.modEq_zero_iff_dvd, ← hpα]
       exact hG.card_modEq_card_fixedPoints α)
@@ -230,24 +230,23 @@ theorem nonempty_fixed_point_of_prime_not_dvd_card (hpα : ¬p ∣ card α) [Fin
 
 /-- If a p-group acts on `α` and the cardinality of `α` is a multiple
   of `p`, and the action has one fixed point, then it has another fixed point. -/
-theorem exists_fixed_point_of_prime_dvd_card_of_fixed_point (hpα : p ∣ card α) {a : α}
+theorem exists_fixed_point_of_prime_dvd_card_of_fixed_point (hpα : p ∣ Nat.card α) {a : α}
     (ha : a ∈ fixedPoints G α) : ∃ b, b ∈ fixedPoints G α ∧ a ≠ b := by
-  cases nonempty_fintype (fixedPoints G α)
-  have hpf : p ∣ card (fixedPoints G α) :=
+  have hpf : p ∣ Nat.card (fixedPoints G α) :=
     Nat.modEq_zero_iff_dvd.mp ((hG.card_modEq_card_fixedPoints α).symm.trans hpα.modEq_zero_nat)
-  have hα : 1 < card (fixedPoints G α) :=
-    (Fact.out (p := p.Prime)).one_lt.trans_le (Nat.le_of_dvd (card_pos_iff.2 ⟨⟨a, ha⟩⟩) hpf)
+  have hα : 1 < Nat.card (fixedPoints G α) :=
+    (Fact.out (p := p.Prime)).one_lt.trans_le (Nat.le_of_dvd (Finite.card_pos_iff.2 ⟨⟨a, ha⟩⟩) hpf)
+  rw [Finite.one_lt_card_iff_nontrivial] at hα
   exact
-    let ⟨⟨b, hb⟩, hba⟩ := exists_ne_of_one_lt_card hα ⟨a, ha⟩
+    let ⟨⟨b, hb⟩, hba⟩ := exists_ne (⟨a, ha⟩ : fixedPoints G α)
     ⟨b, hb, fun hab => hba (by simp_rw [hab])⟩
 #align is_p_group.exists_fixed_point_of_prime_dvd_card_of_fixed_point IsPGroup.exists_fixed_point_of_prime_dvd_card_of_fixed_point
 
 theorem center_nontrivial [Nontrivial G] [Finite G] : Nontrivial (Subgroup.center G) := by
   classical
-    cases nonempty_fintype G
     have := (hG.of_equiv ConjAct.toConjAct).exists_fixed_point_of_prime_dvd_card_of_fixed_point G
     rw [ConjAct.fixedPoints_eq_center] at this
-    have dvd : p ∣ card G := by
+    have dvd : p ∣ Nat.card G := by
       obtain ⟨n, hn0, hn⟩ := hG.nontrivial_iff_card.mp inferInstance
       exact hn.symm ▸ dvd_pow_self _ (ne_of_gt hn0)
     obtain ⟨g, hg⟩ := this dvd (Subgroup.center G).one_mem
@@ -337,9 +336,9 @@ theorem to_sup_of_normal_left' {H K : Subgroup G} (hH : IsPGroup p H) (hK : IsPG
 
 /-- finite p-groups with different p have coprime orders -/
 theorem coprime_card_of_ne {G₂ : Type*} [Group G₂] (p₁ p₂ : ℕ) [hp₁ : Fact p₁.Prime]
-    [hp₂ : Fact p₂.Prime] (hne : p₁ ≠ p₂) (H₁ : Subgroup G) (H₂ : Subgroup G₂) [Fintype H₁]
-    [Fintype H₂] (hH₁ : IsPGroup p₁ H₁) (hH₂ : IsPGroup p₂ H₂) :
-    Nat.Coprime (Fintype.card H₁) (Fintype.card H₂) := by
+    [hp₂ : Fact p₂.Prime] (hne : p₁ ≠ p₂) (H₁ : Subgroup G) (H₂ : Subgroup G₂) [Finite H₁]
+    [Finite H₂] (hH₁ : IsPGroup p₁ H₁) (hH₂ : IsPGroup p₂ H₂) :
+    Nat.Coprime (Nat.card H₁) (Nat.card H₂) := by
   obtain ⟨n₁, heq₁⟩ := iff_card.mp hH₁; rw [heq₁]; clear heq₁
   obtain ⟨n₂, heq₂⟩ := iff_card.mp hH₂; rw [heq₂]; clear heq₂
   exact Nat.coprime_pow_primes _ _ hp₁.elim hp₂.elim hne
@@ -361,13 +360,14 @@ theorem disjoint_of_ne (p₁ p₂ : ℕ) [hp₁ : Fact p₁.Prime] [hp₂ : Fact
 
 section P2comm
 
-variable [Fintype G] [Fact p.Prime] {n : ℕ} (hGpn : card G = p ^ n)
+variable [Fact p.Prime] {n : ℕ} (hGpn : Nat.card G = p ^ n)
 
 open Subgroup
 
 /-- The cardinality of the `center` of a `p`-group is `p ^ k` where `k` is positive. -/
-theorem card_center_eq_prime_pow (hn : 0 < n) [Fintype (center G)] :
-    ∃ k > 0, card (center G) = p ^ k := by
+theorem card_center_eq_prime_pow (hn : 0 < n) :
+    ∃ k > 0, Nat.card (center G) = p ^ k := by
+  have : Finite G := Nat.finite_of_card_ne_zero (hGpn ▸ pow_ne_zero n (NeZero.ne p))
   have hcG := to_subgroup (of_card hGpn) (center G)
   rcases iff_card.1 hcG with _
   haveI : Nontrivial G := (nontrivial_iff_card <| of_card hGpn).2 ⟨n, hn, hGpn⟩
@@ -375,34 +375,26 @@ theorem card_center_eq_prime_pow (hn : 0 < n) [Fintype (center G)] :
 #align is_p_group.card_center_eq_prime_pow IsPGroup.card_center_eq_prime_pow
 
 /-- The quotient by the center of a group of cardinality `p ^ 2` is cyclic. -/
-theorem cyclic_center_quotient_of_card_eq_prime_sq (hG : card G = p ^ 2) :
+theorem cyclic_center_quotient_of_card_eq_prime_sq (hG : Nat.card G = p ^ 2) :
     IsCyclic (G ⧸ center G) := by
-  classical
-    rcases card_center_eq_prime_pow hG zero_lt_two with ⟨k, hk0, hk⟩
-    rw [← Nat.card_eq_fintype_card] at hG hk
-    rw [card_eq_card_quotient_mul_card_subgroup (center G), mul_comm, hk] at hG
-    rw [Nat.card_eq_fintype_card] at hG
-    have hk2 := (Nat.pow_dvd_pow_iff_le_right (Fact.out (p := p.Prime)).one_lt).1 ⟨_, hG.symm⟩
-    interval_cases k
-    · rw [sq, pow_one, mul_right_inj' (Fact.out (p := p.Prime)).ne_zero] at hG
-      exact isCyclic_of_prime_card hG
-    · exact
-        @isCyclic_of_subsingleton _ _
-          ⟨Fintype.card_le_one_iff.1
-              (mul_right_injective₀ (pow_ne_zero 2 (NeZero.ne p))
-                  (hG.trans (mul_one (p ^ 2)).symm)).le⟩
+  apply isCyclic_of_card_dvd_prime (p := p)
+  rw [← mul_dvd_mul_iff_left (NeZero.ne p), ← sq, ← hG, ← (center G).card_mul_index]
+  apply mul_dvd_mul_right
+  rcases card_center_eq_prime_pow hG zero_lt_two with ⟨k, hk0, hk⟩
+  rw [hk]
+  exact dvd_pow_self p hk0.ne'
 #align is_p_group.cyclic_center_quotient_of_card_eq_prime_sq IsPGroup.cyclic_center_quotient_of_card_eq_prime_sq
 
 /-- A group of order `p ^ 2` is commutative. See also `IsPGroup.commutative_of_card_eq_prime_sq`
 for just the proof that `∀ a b, a * b = b * a` -/
-def commGroupOfCardEqPrimeSq (hG : card G = p ^ 2) : CommGroup G :=
+def commGroupOfCardEqPrimeSq (hG : Nat.card G = p ^ 2) : CommGroup G :=
   @commGroupOfCycleCenterQuotient _ _ _ _ (cyclic_center_quotient_of_card_eq_prime_sq hG) _
     (QuotientGroup.ker_mk' (center G)).le
 #align is_p_group.comm_group_of_card_eq_prime_sq IsPGroup.commGroupOfCardEqPrimeSq
 
 /-- A group of order `p ^ 2` is commutative. See also `IsPGroup.commGroupOfCardEqPrimeSq`
 for the `CommGroup` instance. -/
-theorem commutative_of_card_eq_prime_sq (hG : card G = p ^ 2) : ∀ a b : G, a * b = b * a :=
+theorem commutative_of_card_eq_prime_sq (hG : Nat.card G = p ^ 2) : ∀ a b : G, a * b = b * a :=
   (commGroupOfCardEqPrimeSq hG).mul_comm
 #align is_p_group.commutative_of_card_eq_prime_sq IsPGroup.commutative_of_card_eq_prime_sq
 

--- a/Mathlib/GroupTheory/Perm/Cycle/Type.lean
+++ b/Mathlib/GroupTheory/Perm/Cycle/Type.lean
@@ -470,6 +470,7 @@ theorem rotate_length : rotate v n = v :=
 
 end VectorsProdEqOne
 
+-- TODO: Make make the `Finite` version of this theorem the default
 /-- For every prime `p` dividing the order of a finite group `G` there exists an element of order
 `p` in `G`. This is known as Cauchy's theorem. -/
 theorem _root_.exists_prime_orderOf_dvd_card {G : Type*} [Group G] [Fintype G] (p : ℕ)
@@ -505,6 +506,7 @@ theorem _root_.exists_prime_orderOf_dvd_card {G : Type*} [Group G] [Fintype G] (
     simp only [v₀, Vector.replicate]
 #align exists_prime_order_of_dvd_card exists_prime_orderOf_dvd_card
 
+-- TODO: Make make the `Finite` version of this theorem the default
 /-- For every prime `p` dividing the order of a finite additive group `G` there exists an element of
 order `p` in `G`. This is the additive version of Cauchy's theorem. -/
 theorem _root_.exists_prime_addOrderOf_dvd_card {G : Type*} [AddGroup G] [Fintype G] (p : ℕ)
@@ -514,6 +516,7 @@ theorem _root_.exists_prime_addOrderOf_dvd_card {G : Type*} [AddGroup G] [Fintyp
 
 attribute [to_additive existing] exists_prime_orderOf_dvd_card
 
+-- TODO: Make make the `Finite` version of this theorem the default
 /-- For every prime `p` dividing the order of a finite group `G` there exists an element of order
 `p` in `G`. This is known as Cauchy's theorem. -/
 @[to_additive]

--- a/Mathlib/GroupTheory/Perm/Cycle/Type.lean
+++ b/Mathlib/GroupTheory/Perm/Cycle/Type.lean
@@ -514,6 +514,15 @@ theorem _root_.exists_prime_addOrderOf_dvd_card {G : Type*} [AddGroup G] [Fintyp
 
 attribute [to_additive existing] exists_prime_orderOf_dvd_card
 
+/-- For every prime `p` dividing the order of a finite group `G` there exists an element of order
+`p` in `G`. This is known as Cauchy's theorem. -/
+@[to_additive]
+theorem _root_.exists_prime_orderOf_dvd_card' {G : Type*} [Group G] [Finite G] (p : ℕ)
+    [hp : Fact p.Prime] (hdvd : p ∣ Nat.card G) : ∃ x : G, orderOf x = p := by
+  have := Fintype.ofFinite G
+  rw [Nat.card_eq_fintype_card] at hdvd
+  exact exists_prime_orderOf_dvd_card p hdvd
+
 end Cauchy
 
 theorem subgroup_eq_top_of_swap_mem [DecidableEq α] {H : Subgroup (Perm α)}

--- a/Mathlib/GroupTheory/SchurZassenhaus.lean
+++ b/Mathlib/GroupTheory/SchurZassenhaus.lean
@@ -237,9 +237,11 @@ private theorem step4 : (Fintype.card N).minFac.Prime := by
   exact Nat.minFac_prime (N.one_lt_card_iff_ne_bot.mpr (step0 h1 h3)).ne'
 
 /-- Do not use this lemma: It is made obsolete by `exists_right_complement'_of_coprime` -/
-private theorem step5 {P : Sylow (Fintype.card N).minFac N} : P.1 ≠ ⊥ :=
+private theorem step5 {P : Sylow (Fintype.card N).minFac N} : P.1 ≠ ⊥ := by
   haveI : Fact (Fintype.card N).minFac.Prime := ⟨step4 h1 h3⟩
-  P.ne_bot_of_dvd_card (Fintype.card N).minFac_dvd
+  apply P.ne_bot_of_dvd_card
+  rw [← Nat.card_eq_fintype_card]
+  exact (Nat.card N).minFac_dvd
 
 /-- Do not use this lemma: It is made obsolete by `exists_right_complement'_of_coprime` -/
 private theorem step6 : IsPGroup (Fintype.card N).minFac N := by

--- a/Mathlib/GroupTheory/SpecificGroups/Cyclic.lean
+++ b/Mathlib/GroupTheory/SpecificGroups/Cyclic.lean
@@ -175,6 +175,17 @@ theorem isCyclic_of_prime_card {α : Type u} [Group α] [Fintype α] {p : ℕ} [
 #align is_cyclic_of_prime_card isCyclic_of_prime_card
 #align is_add_cyclic_of_prime_card isAddCyclic_of_prime_card
 
+/-- A finite group of order dividing a prime is cyclic. -/
+@[to_additive "A finite group of order dividing a prime is cyclic."]
+theorem isCyclic_of_card_dvd_prime {α : Type u} [Group α] {p : ℕ} [hp : Fact p.Prime]
+    (h : Nat.card α ∣ p) : IsCyclic α := by
+  have : Finite α := Nat.finite_of_card_ne_zero (ne_zero_of_dvd_ne_zero hp.1.ne_zero h)
+  rcases (Nat.dvd_prime hp.out).mp h with h | h
+  · exact @isCyclic_of_subsingleton α _ (Nat.card_eq_one_iff_unique.mp h).1
+  · have : Fintype α := Fintype.ofFinite α
+    rw [Nat.card_eq_fintype_card] at h
+    exact isCyclic_of_prime_card h
+
 @[to_additive]
 theorem isCyclic_of_surjective {H G F : Type*} [Group H] [Group G] [hH : IsCyclic H]
     [FunLike F H G] [MonoidHomClass F H G] (f : F) (hf : Function.Surjective f) :

--- a/Mathlib/GroupTheory/Sylow.lean
+++ b/Mathlib/GroupTheory/Sylow.lean
@@ -43,7 +43,7 @@ The Sylow theorems are the following results for every finite group `G` and ever
 -/
 
 
-open Fintype MulAction Subgroup
+open MulAction Subgroup
 
 section InfiniteSylow
 
@@ -809,7 +809,7 @@ noncomputable def directProductOfNormal [Finite G]
     letI := unique_of_normal _ (hn (P p))
     apply MulEquiv.piUnique
   apply MulEquiv.ofBijective (Subgroup.noncommPiCoprod hcomm)
-  apply (bijective_iff_injective_and_card _).mpr
+  apply (Fintype.bijective_iff_injective_and_card _).mpr
   constructor
   · apply Subgroup.injective_noncommPiCoprod_of_independent
     apply independent_of_coprime_order hcomm

--- a/Mathlib/GroupTheory/Sylow.lean
+++ b/Mathlib/GroupTheory/Sylow.lean
@@ -186,29 +186,24 @@ theorem Sylow.exists_comap_subtype_eq {H : Subgroup G} (P : Sylow p H) :
 #align sylow.exists_comap_subtype_eq Sylow.exists_comap_subtype_eq
 
 /-- If the kernel of `f : H →* G` is a `p`-group,
-  then `Fintype (Sylow p G)` implies `Fintype (Sylow p H)`. -/
-noncomputable def Sylow.fintypeOfKerIsPGroup {H : Type*} [Group H] {f : H →* G}
-    (hf : IsPGroup p f.ker) [Fintype (Sylow p G)] : Fintype (Sylow p H) :=
+  then `Finite (Sylow p G)` implies `Finite (Sylow p H)`. -/
+theorem Sylow.finite_of_ker_is_pGroup {H : Type*} [Group H] {f : H →* G}
+    (hf : IsPGroup p f.ker) [Finite (Sylow p G)] : Finite (Sylow p H) :=
   let h_exists := fun P : Sylow p H => P.exists_comap_eq_of_ker_isPGroup hf
   let g : Sylow p H → Sylow p G := fun P => Classical.choose (h_exists P)
   have hg : ∀ P : Sylow p H, (g P).1.comap f = P := fun P => Classical.choose_spec (h_exists P)
-  Fintype.ofInjective g fun P Q h => Sylow.ext (by rw [← hg, h]; exact (h_exists Q).choose_spec)
-#align sylow.fintype_of_ker_is_p_group Sylow.fintypeOfKerIsPGroup
+  Finite.of_injective g fun P Q h => Sylow.ext (by rw [← hg, h]; exact (h_exists Q).choose_spec)
+#align sylow.fintype_of_ker_is_p_group Sylow.finite_of_ker_is_pGroup
 
-/-- If `f : H →* G` is injective, then `Fintype (Sylow p G)` implies `Fintype (Sylow p H)`. -/
-noncomputable def Sylow.fintypeOfInjective {H : Type*} [Group H] {f : H →* G}
-    (hf : Function.Injective f) [Fintype (Sylow p G)] : Fintype (Sylow p H) :=
-  Sylow.fintypeOfKerIsPGroup (IsPGroup.ker_isPGroup_of_injective hf)
-#align sylow.fintype_of_injective Sylow.fintypeOfInjective
-
-/-- If `H` is a subgroup of `G`, then `Fintype (Sylow p G)` implies `Fintype (Sylow p H)`. -/
-noncomputable instance (H : Subgroup G) [Fintype (Sylow p G)] : Fintype (Sylow p H) :=
-  Sylow.fintypeOfInjective H.subtype_injective
+/-- If `f : H →* G` is injective, then `Finite (Sylow p G)` implies `Finite (Sylow p H)`. -/
+theorem Sylow.finite_of_injective {H : Type*} [Group H] {f : H →* G}
+    (hf : Function.Injective f) [Finite (Sylow p G)] : Finite (Sylow p H) :=
+  Sylow.finite_of_ker_is_pGroup (IsPGroup.ker_isPGroup_of_injective hf)
+#align sylow.fintype_of_injective Sylow.finite_of_injective
 
 /-- If `H` is a subgroup of `G`, then `Finite (Sylow p G)` implies `Finite (Sylow p H)`. -/
-instance (H : Subgroup G) [Finite (Sylow p G)] : Finite (Sylow p H) := by
-  cases nonempty_fintype (Sylow p G)
-  infer_instance
+instance (H : Subgroup G) [Finite (Sylow p G)] : Finite (Sylow p H) :=
+  Sylow.finite_of_injective H.subtype_injective
 
 open Pointwise
 
@@ -295,7 +290,6 @@ theorem IsPGroup.sylow_mem_fixedPoints_iff {P : Subgroup G} (hP : IsPGroup p P) 
 instance [hp : Fact p.Prime] [Finite (Sylow p G)] : IsPretransitive G (Sylow p G) :=
   ⟨fun P Q => by
     classical
-      cases nonempty_fintype (Sylow p G)
       have H := fun {R : Sylow p G} {S : orbit G P} =>
         calc
           S ∈ fixedPoints R (orbit G P) ↔ S.1 ∈ fixedPoints R (Sylow p G) :=
@@ -309,11 +303,11 @@ instance [hp : Fact p.Prime] [Finite (Sylow p G)] : IsPretransitive G (Sylow p G
       apply Q.2.nonempty_fixed_point_of_prime_not_dvd_card
       refine fun h => hp.out.not_dvd_one (Nat.modEq_zero_iff_dvd.mp ?_)
       calc
-        1 = card (fixedPoints P (orbit G P)) := ?_
-        _ ≡ card (orbit G P) [MOD p] := (P.2.card_modEq_card_fixedPoints (orbit G P)).symm
+        1 = Nat.card (fixedPoints P (orbit G P)) := ?_
+        _ ≡ Nat.card (orbit G P) [MOD p] := (P.2.card_modEq_card_fixedPoints (orbit G P)).symm
         _ ≡ 0 [MOD p] := Nat.modEq_zero_iff_dvd.mpr h
-      rw [← Set.card_singleton (⟨P, mem_orbit_self P⟩ : orbit G P)]
-      refine card_congr' (congr_arg _ (Eq.symm ?_))
+      rw [← Nat.card_unique (α := ({⟨P, mem_orbit_self P⟩} : Set (orbit G P))), eq_comm]
+      congr
       rw [Set.eq_singleton_iff_unique_mem]
       exact ⟨H.mpr rfl, fun R h => Subtype.ext (Sylow.ext (H.mp h))⟩⟩
 
@@ -321,8 +315,8 @@ variable (p) (G)
 
 /-- A generalization of **Sylow's third theorem**.
   If the number of Sylow `p`-subgroups is finite, then it is congruent to `1` modulo `p`. -/
-theorem card_sylow_modEq_one [Fact p.Prime] [Fintype (Sylow p G)] :
-    card (Sylow p G) ≡ 1 [MOD p] := by
+theorem card_sylow_modEq_one [Fact p.Prime] [Finite (Sylow p G)] :
+    Nat.card (Sylow p G) ≡ 1 [MOD p] := by
   refine Sylow.nonempty.elim fun P : Sylow p G => ?_
   have : fixedPoints P.1 (Sylow p G) = {P} :=
     Set.ext fun Q : Sylow p G =>
@@ -330,15 +324,11 @@ theorem card_sylow_modEq_one [Fact p.Prime] [Fintype (Sylow p G)] :
         Q ∈ fixedPoints P (Sylow p G) ↔ P.1 ≤ Q := P.2.sylow_mem_fixedPoints_iff
         _ ↔ Q.1 = P.1 := ⟨P.3 Q.2, ge_of_eq⟩
         _ ↔ Q ∈ {P} := Sylow.ext_iff.symm.trans Set.mem_singleton_iff.symm
-
-  have fin : Fintype (fixedPoints P.1 (Sylow p G)) := by
-    rw [this]
-    infer_instance
-  have : card (fixedPoints P.1 (Sylow p G)) = 1 := by simp [this]
+  have : Nat.card (fixedPoints P.1 (Sylow p G)) = 1 := by simp [this]
   exact (P.2.card_modEq_card_fixedPoints (Sylow p G)).trans (by rw [this])
 #align card_sylow_modeq_one card_sylow_modEq_one
 
-theorem not_dvd_card_sylow [hp : Fact p.Prime] [Fintype (Sylow p G)] : ¬p ∣ card (Sylow p G) :=
+theorem not_dvd_card_sylow [hp : Fact p.Prime] [Finite (Sylow p G)] : ¬p ∣ Nat.card (Sylow p G) :=
   fun h =>
   hp.1.ne_one
     (Nat.dvd_one.mp
@@ -404,22 +394,22 @@ noncomputable def Sylow.equivQuotientNormalizer [Fact p.Prime] [Finite (Sylow p 
 
 #align sylow.equiv_quotient_normalizer Sylow.equivQuotientNormalizer
 
-noncomputable instance [Fact p.Prime] [Fintype (Sylow p G)] (P : Sylow p G) :
-    Fintype (G ⧸ (P : Subgroup G).normalizer) :=
-  ofEquiv (Sylow p G) P.equivQuotientNormalizer
+instance [Fact p.Prime] [Finite (Sylow p G)] (P : Sylow p G) :
+    Finite (G ⧸ (P : Subgroup G).normalizer) :=
+  Finite.of_equiv (Sylow p G) P.equivQuotientNormalizer
 
-theorem card_sylow_eq_card_quotient_normalizer [Fact p.Prime] [Fintype (Sylow p G)]
-    (P : Sylow p G) : card (Sylow p G) = card (G ⧸ (P : Subgroup G).normalizer) :=
-  card_congr P.equivQuotientNormalizer
+theorem card_sylow_eq_card_quotient_normalizer [Fact p.Prime] [Finite (Sylow p G)]
+    (P : Sylow p G) : Nat.card (Sylow p G) = Nat.card (G ⧸ (P : Subgroup G).normalizer) :=
+  Nat.card_congr P.equivQuotientNormalizer
 #align card_sylow_eq_card_quotient_normalizer card_sylow_eq_card_quotient_normalizer
 
-theorem card_sylow_eq_index_normalizer [Fact p.Prime] [Fintype (Sylow p G)] (P : Sylow p G) :
-    card (Sylow p G) = (P : Subgroup G).normalizer.index := by
-  rw [card_sylow_eq_card_quotient_normalizer, ← Nat.card_eq_fintype_card, index_eq_card]
+theorem card_sylow_eq_index_normalizer [Fact p.Prime] [Finite (Sylow p G)] (P : Sylow p G) :
+    Nat.card (Sylow p G) = (P : Subgroup G).normalizer.index :=
+  card_sylow_eq_card_quotient_normalizer P
 #align card_sylow_eq_index_normalizer card_sylow_eq_index_normalizer
 
-theorem card_sylow_dvd_index [Fact p.Prime] [Fintype (Sylow p G)] (P : Sylow p G) :
-    card (Sylow p G) ∣ (P : Subgroup G).index :=
+theorem card_sylow_dvd_index [Fact p.Prime] [Finite (Sylow p G)] (P : Sylow p G) :
+    Nat.card (Sylow p G) ∣ (P : Subgroup G).index :=
   ((congr_arg _ (card_sylow_eq_index_normalizer P)).mp dvd_rfl).trans
     (index_dvd_of_le le_normalizer)
 #align card_sylow_dvd_index card_sylow_dvd_index
@@ -427,10 +417,9 @@ theorem card_sylow_dvd_index [Fact p.Prime] [Fintype (Sylow p G)] (P : Sylow p G
 theorem not_dvd_index_sylow' [hp : Fact p.Prime] (P : Sylow p G) [(P : Subgroup G).Normal]
     [fP : FiniteIndex (P : Subgroup G)] : ¬p ∣ (P : Subgroup G).index := by
   intro h
-  letI : Fintype (G ⧸ (P : Subgroup G)) := (P : Subgroup G).fintypeQuotientOfFiniteIndex
-  rw [index_eq_card (P : Subgroup G), Nat.card_eq_fintype_card] at h
-  obtain ⟨x, hx⟩ := exists_prime_orderOf_dvd_card (G := G ⧸ (P : Subgroup G)) p h
-  have h := IsPGroup.of_card ((Fintype.card_zpowers.trans hx).trans (pow_one p).symm)
+  rw [index_eq_card (P : Subgroup G)] at h
+  obtain ⟨x, hx⟩ := exists_prime_orderOf_dvd_card' (G := G ⧸ (P : Subgroup G)) p h
+  have h := IsPGroup.of_card (((Nat.card_zpowers x).trans hx).trans (pow_one p).symm)
   let Q := (zpowers x).comap (QuotientGroup.mk' (P : Subgroup G))
   have hQ : IsPGroup p Q := by
     apply h.comap_of_ker_isPGroup
@@ -445,7 +434,6 @@ theorem not_dvd_index_sylow' [hp : Fact p.Prime] (P : Sylow p G) [(P : Subgroup 
 
 theorem not_dvd_index_sylow [hp : Fact p.Prime] [Finite (Sylow p G)] (P : Sylow p G)
     (hP : relindex ↑P (P : Subgroup G).normalizer ≠ 0) : ¬p ∣ (P : Subgroup G).index := by
-  cases nonempty_fintype (Sylow p G)
   rw [← relindex_mul_index le_normalizer, ← card_sylow_eq_index_normalizer]
   haveI : (P.subtype le_normalizer : Subgroup (P : Subgroup G).normalizer).Normal :=
     Subgroup.normal_in_normalizer
@@ -487,11 +475,9 @@ universe u v w
 
 variable {G : Type u} {α : Type v} {β : Type w} [Group G]
 
-attribute [local instance 10] Subtype.fintype setFintype Classical.propDecidable
-
-theorem QuotientGroup.card_preimage_mk [Fintype G] (s : Subgroup G) (t : Set (G ⧸ s)) :
-    Fintype.card (QuotientGroup.mk ⁻¹' t) = Fintype.card s * Fintype.card t := by
-  rw [← Fintype.card_prod, Fintype.card_congr (preimageMkEquivSubgroupProdSet _ _)]
+theorem QuotientGroup.card_preimage_mk (s : Subgroup G) (t : Set (G ⧸ s)) :
+    Nat.card (QuotientGroup.mk ⁻¹' t) = Nat.card s * Nat.card t := by
+  rw [← Nat.card_prod, Nat.card_congr (preimageMkEquivSubgroupProdSet _ _)]
 #align quotient_group.card_preimage_mk QuotientGroup.card_preimage_mk
 
 namespace Sylow
@@ -534,86 +520,81 @@ def fixedPointsMulLeftCosetsEquivQuotient (H : Subgroup G) [Finite (H : Set G)] 
 
 /-- If `H` is a `p`-subgroup of `G`, then the index of `H` inside its normalizer is congruent
   mod `p` to the index of `H`.  -/
-theorem card_quotient_normalizer_modEq_card_quotient [Fintype G] {p : ℕ} {n : ℕ} [hp : Fact p.Prime]
-    {H : Subgroup G} (hH : Fintype.card H = p ^ n) :
-    Fintype.card (normalizer H ⧸ Subgroup.comap ((normalizer H).subtype : normalizer H →* G) H) ≡
-      card (G ⧸ H) [MOD p] := by
-  rw [← Fintype.card_congr (fixedPointsMulLeftCosetsEquivQuotient H)]
+theorem card_quotient_normalizer_modEq_card_quotient [Finite G] {p : ℕ} {n : ℕ} [hp : Fact p.Prime]
+    {H : Subgroup G} (hH : Nat.card H = p ^ n) :
+    Nat.card (normalizer H ⧸ Subgroup.comap ((normalizer H).subtype : normalizer H →* G) H) ≡
+      Nat.card (G ⧸ H) [MOD p] := by
+  rw [← Nat.card_congr (fixedPointsMulLeftCosetsEquivQuotient H)]
   exact ((IsPGroup.of_card hH).card_modEq_card_fixedPoints _).symm
 #align sylow.card_quotient_normalizer_modeq_card_quotient Sylow.card_quotient_normalizer_modEq_card_quotient
 
 /-- If `H` is a subgroup of `G` of cardinality `p ^ n`, then the cardinality of the
   normalizer of `H` is congruent mod `p ^ (n + 1)` to the cardinality of `G`.  -/
-theorem card_normalizer_modEq_card [Fintype G] {p : ℕ} {n : ℕ} [hp : Fact p.Prime] {H : Subgroup G}
-    (hH : Fintype.card H = p ^ n) : card (normalizer H) ≡ card G [MOD p ^ (n + 1)] := by
+theorem card_normalizer_modEq_card [Finite G] {p : ℕ} {n : ℕ} [hp : Fact p.Prime] {H : Subgroup G}
+    (hH : Nat.card H = p ^ n) : Nat.card (normalizer H) ≡ Nat.card G [MOD p ^ (n + 1)] := by
   have : H.subgroupOf (normalizer H) ≃ H := (subgroupOfEquivOfLe le_normalizer).toEquiv
-  simp only [← Nat.card_eq_fintype_card] at hH ⊢
   rw [card_eq_card_quotient_mul_card_subgroup H,
     card_eq_card_quotient_mul_card_subgroup (H.subgroupOf (normalizer H)), Nat.card_congr this,
     hH, pow_succ']
-  simp only [Nat.card_eq_fintype_card] at hH ⊢
   exact (card_quotient_normalizer_modEq_card_quotient hH).mul_right' _
 #align sylow.card_normalizer_modeq_card Sylow.card_normalizer_modEq_card
 
 /-- If `H` is a `p`-subgroup but not a Sylow `p`-subgroup, then `p` divides the
   index of `H` inside its normalizer. -/
-theorem prime_dvd_card_quotient_normalizer [Fintype G] {p : ℕ} {n : ℕ} [hp : Fact p.Prime]
-    (hdvd : p ^ (n + 1) ∣ card G) {H : Subgroup G} (hH : Fintype.card H = p ^ n) :
-    p ∣ card (normalizer H ⧸ Subgroup.comap ((normalizer H).subtype : normalizer H →* G) H) :=
+theorem prime_dvd_card_quotient_normalizer [Finite G] {p : ℕ} {n : ℕ} [hp : Fact p.Prime]
+    (hdvd : p ^ (n + 1) ∣ Nat.card G) {H : Subgroup G} (hH : Nat.card H = p ^ n) :
+    p ∣ Nat.card (normalizer H ⧸ Subgroup.comap ((normalizer H).subtype : normalizer H →* G) H) :=
   let ⟨s, hs⟩ := exists_eq_mul_left_of_dvd hdvd
-  have hcard : card (G ⧸ H) = s * p :=
-    (mul_left_inj' (show card H ≠ 0 from Fintype.card_ne_zero)).1
+  have hcard : Nat.card (G ⧸ H) = s * p :=
+    (mul_left_inj' (show Nat.card H ≠ 0 from Nat.card_pos.ne')).1
       (by
-        simp only [← Nat.card_eq_fintype_card] at hs hH ⊢
         rw [← card_eq_card_quotient_mul_card_subgroup H, hH, hs, pow_succ', mul_assoc, mul_comm p])
   have hm :
     s * p % p =
-      card (normalizer H ⧸ Subgroup.comap ((normalizer H).subtype : normalizer H →* G) H) % p :=
+      Nat.card (normalizer H ⧸ Subgroup.comap ((normalizer H).subtype : normalizer H →* G) H) % p :=
     hcard ▸ (card_quotient_normalizer_modEq_card_quotient hH).symm
   Nat.dvd_of_mod_eq_zero (by rwa [Nat.mod_eq_zero_of_dvd (dvd_mul_left _ _), eq_comm] at hm)
 #align sylow.prime_dvd_card_quotient_normalizer Sylow.prime_dvd_card_quotient_normalizer
 
 /-- If `H` is a `p`-subgroup but not a Sylow `p`-subgroup of cardinality `p ^ n`,
   then `p ^ (n + 1)` divides the cardinality of the normalizer of `H`. -/
-theorem prime_pow_dvd_card_normalizer [Fintype G] {p : ℕ} {n : ℕ} [_hp : Fact p.Prime]
-    (hdvd : p ^ (n + 1) ∣ card G) {H : Subgroup G} (hH : Fintype.card H = p ^ n) :
-    p ^ (n + 1) ∣ card (normalizer H) :=
+theorem prime_pow_dvd_card_normalizer [Finite G] {p : ℕ} {n : ℕ} [_hp : Fact p.Prime]
+    (hdvd : p ^ (n + 1) ∣ Nat.card G) {H : Subgroup G} (hH : Nat.card H = p ^ n) :
+    p ^ (n + 1) ∣ Nat.card (normalizer H) :=
   Nat.modEq_zero_iff_dvd.1 ((card_normalizer_modEq_card hH).trans hdvd.modEq_zero_nat)
 #align sylow.prime_pow_dvd_card_normalizer Sylow.prime_pow_dvd_card_normalizer
 
 /-- If `H` is a subgroup of `G` of cardinality `p ^ n`,
   then `H` is contained in a subgroup of cardinality `p ^ (n + 1)`
   if `p ^ (n + 1)` divides the cardinality of `G` -/
-theorem exists_subgroup_card_pow_succ [Fintype G] {p : ℕ} {n : ℕ} [hp : Fact p.Prime]
-    (hdvd : p ^ (n + 1) ∣ card G) {H : Subgroup G} (hH : Fintype.card H = p ^ n) :
-    ∃ K : Subgroup G, Fintype.card K = p ^ (n + 1) ∧ H ≤ K :=
+theorem exists_subgroup_card_pow_succ [Finite G] {p : ℕ} {n : ℕ} [hp : Fact p.Prime]
+    (hdvd : p ^ (n + 1) ∣ Nat.card G) {H : Subgroup G} (hH : Nat.card H = p ^ n) :
+    ∃ K : Subgroup G, Nat.card K = p ^ (n + 1) ∧ H ≤ K :=
   let ⟨s, hs⟩ := exists_eq_mul_left_of_dvd hdvd
-  have hcard : card (G ⧸ H) = s * p :=
-    (mul_left_inj' (show card H ≠ 0 from Fintype.card_ne_zero)).1
+  have hcard : Nat.card (G ⧸ H) = s * p :=
+    (mul_left_inj' (show Nat.card H ≠ 0 from Nat.card_pos.ne')).1
       (by
-        simp only [← Nat.card_eq_fintype_card] at hs hH ⊢
         rw [← card_eq_card_quotient_mul_card_subgroup H, hH, hs, pow_succ', mul_assoc, mul_comm p])
-  have hm : s * p % p = card (normalizer H ⧸ H.subgroupOf H.normalizer) % p :=
-    Fintype.card_congr (fixedPointsMulLeftCosetsEquivQuotient H) ▸
+  have hm : s * p % p = Nat.card (normalizer H ⧸ H.subgroupOf H.normalizer) % p :=
+    Nat.card_congr (fixedPointsMulLeftCosetsEquivQuotient H) ▸
       hcard ▸ (IsPGroup.of_card hH).card_modEq_card_fixedPoints _
-  have hm' : p ∣ card (normalizer H ⧸ H.subgroupOf H.normalizer) :=
+  have hm' : p ∣ Nat.card (normalizer H ⧸ H.subgroupOf H.normalizer) :=
     Nat.dvd_of_mod_eq_zero (by rwa [Nat.mod_eq_zero_of_dvd (dvd_mul_left _ _), eq_comm] at hm)
-  let ⟨x, hx⟩ := @exists_prime_orderOf_dvd_card _ (QuotientGroup.Quotient.group _) _ _ hp hm'
+  let ⟨x, hx⟩ := @exists_prime_orderOf_dvd_card' _ (QuotientGroup.Quotient.group _) _ _ hp hm'
   have hequiv : H ≃ H.subgroupOf H.normalizer := (subgroupOfEquivOfLe le_normalizer).symm.toEquiv
   ⟨Subgroup.map (normalizer H).subtype
       (Subgroup.comap (mk' (H.subgroupOf H.normalizer)) (zpowers x)), by
-    show Fintype.card (Subgroup.map H.normalizer.subtype
+    show Nat.card (Subgroup.map H.normalizer.subtype
               (comap (mk' (H.subgroupOf H.normalizer)) (Subgroup.zpowers x))) = p ^ (n + 1)
-    suffices Fintype.card (Subtype.val ''
+    suffices Nat.card (Subtype.val ''
               (Subgroup.comap (mk' (H.subgroupOf H.normalizer)) (zpowers x) : Set H.normalizer)) =
         p ^ (n + 1)
       by convert this using 2
-    rw [Set.card_image_of_injective
-        (Subgroup.comap (mk' (H.subgroupOf H.normalizer)) (zpowers x) : Set H.normalizer)
-        Subtype.val_injective,
-      pow_succ, ← hH, Fintype.card_congr hequiv, ← hx, ← Fintype.card_zpowers, ←
-      Fintype.card_prod]
-    exact @Fintype.card_congr _ _ (_) (_)
+    rw [Nat.card_image_of_injective Subtype.val_injective
+        (Subgroup.comap (mk' (H.subgroupOf H.normalizer)) (zpowers x) : Set H.normalizer),
+      pow_succ, ← hH, Nat.card_congr hequiv, ← hx, ← Nat.card_zpowers, ←
+      Nat.card_prod]
+    exact Nat.card_congr
       (preimageMkEquivSubgroupProdSet (H.subgroupOf H.normalizer) (zpowers x)), by
     intro y hy
     simp only [exists_prop, Subgroup.coeSubtype, mk'_apply, Subgroup.mem_map, Subgroup.mem_comap]
@@ -626,9 +607,9 @@ theorem exists_subgroup_card_pow_succ [Fintype G] {p : ℕ} {n : ℕ} [hp : Fact
 /-- If `H` is a subgroup of `G` of cardinality `p ^ n`,
   then `H` is contained in a subgroup of cardinality `p ^ m`
   if `n ≤ m` and `p ^ m` divides the cardinality of `G` -/
-theorem exists_subgroup_card_pow_prime_le [Fintype G] (p : ℕ) :
-    ∀ {n m : ℕ} [_hp : Fact p.Prime] (_hdvd : p ^ m ∣ card G) (H : Subgroup G)
-      (_hH : card H = p ^ n) (_hnm : n ≤ m), ∃ K : Subgroup G, card K = p ^ m ∧ H ≤ K
+theorem exists_subgroup_card_pow_prime_le [Finite G] (p : ℕ) :
+    ∀ {n m : ℕ} [_hp : Fact p.Prime] (_hdvd : p ^ m ∣ Nat.card G) (H : Subgroup G)
+      (_hH : Nat.card H = p ^ n) (_hnm : n ≤ m), ∃ K : Subgroup G, Nat.card K = p ^ m ∧ H ≤ K
   | n, m => fun {hdvd H hH hnm} =>
     (lt_or_eq_of_le hnm).elim
       (fun hnm : n < m =>
@@ -638,7 +619,7 @@ theorem exists_subgroup_card_pow_prime_le [Fintype G] (p : ℕ) :
         let ⟨K, hK⟩ :=
           @exists_subgroup_card_pow_prime_le _ _ n (m - 1) _
             (Nat.pow_dvd_of_le_of_pow_dvd tsub_le_self hdvd) H hH hnm1
-        have hdvd' : p ^ (m - 1 + 1) ∣ card G := by rwa [tsub_add_cancel_of_le h0m.nat_succ_le]
+        have hdvd' : p ^ (m - 1 + 1) ∣ Nat.card G := by rwa [tsub_add_cancel_of_le h0m.nat_succ_le]
         let ⟨K', hK'⟩ := @exists_subgroup_card_pow_succ _ _ _ _ _ _ hdvd' K hK.1
         ⟨K', by rw [hK'.1, tsub_add_cancel_of_le h0m.nat_succ_le], le_trans hK.2 hK'.2⟩)
       fun hnm : n = m => ⟨H, by simp [hH, hnm]⟩
@@ -646,11 +627,10 @@ theorem exists_subgroup_card_pow_prime_le [Fintype G] (p : ℕ) :
 
 /-- A generalisation of **Sylow's first theorem**. If `p ^ n` divides
   the cardinality of `G`, then there is a subgroup of cardinality `p ^ n` -/
-theorem exists_subgroup_card_pow_prime [Fintype G] (p : ℕ) {n : ℕ} [Fact p.Prime]
-    (hdvd : p ^ n ∣ card G) : ∃ K : Subgroup G, Fintype.card K = p ^ n :=
+theorem exists_subgroup_card_pow_prime [Finite G] (p : ℕ) {n : ℕ} [Fact p.Prime]
+    (hdvd : p ^ n ∣ Nat.card G) : ∃ K : Subgroup G, Nat.card K = p ^ n :=
   let ⟨K, hK⟩ := exists_subgroup_card_pow_prime_le p hdvd ⊥
-    -- The @ is due to a Fintype ⊥ mismatch, but this will be fixed once we convert to Nat.card
-    (by rw [← @Nat.card_eq_fintype_card, card_bot, pow_zero]) n.zero_le
+    (by rw [card_bot, pow_zero]) n.zero_le
   ⟨K, hK.1⟩
 #align sylow.exists_subgroup_card_pow_prime Sylow.exists_subgroup_card_pow_prime
 
@@ -660,9 +640,7 @@ lemma exists_subgroup_card_pow_prime_of_le_card {n p : ℕ} (hp : p.Prime) (h : 
     (hn : p ^ n ≤ Nat.card G) : ∃ H : Subgroup G, Nat.card H = p ^ n := by
   have : Fact p.Prime := ⟨hp⟩
   have : Finite G := Nat.finite_of_card_ne_zero <| by linarith [Nat.one_le_pow n p hp.pos]
-  cases nonempty_fintype G
   obtain ⟨m, hm⟩ := h.exists_card_eq
-  simp_rw [Nat.card_eq_fintype_card] at hm hn ⊢
   refine exists_subgroup_card_pow_prime _ ?_
   rw [hm] at hn ⊢
   exact pow_dvd_pow _ <| (pow_le_pow_iff_right hp.one_lt).1 hn
@@ -687,61 +665,59 @@ lemma exists_subgroup_le_card_le {k p : ℕ} (hp : p.Prime) (h : IsPGroup p G) {
   refine ⟨H', H'H, ?_⟩
   simpa only [pow_succ', H'card] using And.intro hmk hkm
 
-theorem pow_dvd_card_of_pow_dvd_card [Fintype G] {p n : ℕ} [hp : Fact p.Prime] (P : Sylow p G)
-    (hdvd : p ^ n ∣ card G) : p ^ n ∣ card P := by
-  rw [← Nat.card_eq_fintype_card, ← index_mul_card P.1, Nat.card_eq_fintype_card] at hdvd
+theorem pow_dvd_card_of_pow_dvd_card [Finite G] {p n : ℕ} [hp : Fact p.Prime] (P : Sylow p G)
+    (hdvd : p ^ n ∣ Nat.card G) : p ^ n ∣ Nat.card P := by
+  rw [← index_mul_card P.1] at hdvd
   exact (hp.1.coprime_pow_of_not_dvd
     (not_dvd_index_sylow P index_ne_zero_of_finite)).symm.dvd_of_dvd_mul_left hdvd
 #align sylow.pow_dvd_card_of_pow_dvd_card Sylow.pow_dvd_card_of_pow_dvd_card
 
-theorem dvd_card_of_dvd_card [Fintype G] {p : ℕ} [Fact p.Prime] (P : Sylow p G)
-    (hdvd : p ∣ card G) : p ∣ card P := by
+theorem dvd_card_of_dvd_card [Finite G] {p : ℕ} [Fact p.Prime] (P : Sylow p G)
+    (hdvd : p ∣ Nat.card G) : p ∣ Nat.card P := by
   rw [← pow_one p] at hdvd
   have key := P.pow_dvd_card_of_pow_dvd_card hdvd
   rwa [pow_one] at key
 #align sylow.dvd_card_of_dvd_card Sylow.dvd_card_of_dvd_card
 
 /-- Sylow subgroups are Hall subgroups. -/
-theorem card_coprime_index [Fintype G] {p : ℕ} [hp : Fact p.Prime] (P : Sylow p G) :
-    (card P).Coprime (index (P : Subgroup G)) :=
+theorem card_coprime_index [Finite G] {p : ℕ} [hp : Fact p.Prime] (P : Sylow p G) :
+    (Nat.card P).Coprime (index (P : Subgroup G)) :=
   let ⟨_n, hn⟩ := IsPGroup.iff_card.mp P.2
   hn.symm ▸ (hp.1.coprime_pow_of_not_dvd (not_dvd_index_sylow P index_ne_zero_of_finite)).symm
 #align sylow.card_coprime_index Sylow.card_coprime_index
 
-theorem ne_bot_of_dvd_card [Fintype G] {p : ℕ} [hp : Fact p.Prime] (P : Sylow p G)
-    (hdvd : p ∣ card G) : (P : Subgroup G) ≠ ⊥ := by
+theorem ne_bot_of_dvd_card [Finite G] {p : ℕ} [hp : Fact p.Prime] (P : Sylow p G)
+    (hdvd : p ∣ Nat.card G) : (P : Subgroup G) ≠ ⊥ := by
   refine fun h => hp.out.not_dvd_one ?_
-  have key : p ∣ card (P : Subgroup G) := P.dvd_card_of_dvd_card hdvd
-  -- The @ is due to a Fintype ⊥ mismatch, but this will be fixed once we convert to Nat.card
-  rwa [h, ← @Nat.card_eq_fintype_card, card_bot] at key
+  have key : p ∣ Nat.card (P : Subgroup G) := P.dvd_card_of_dvd_card hdvd
+  rwa [h, card_bot] at key
 #align sylow.ne_bot_of_dvd_card Sylow.ne_bot_of_dvd_card
 
 /-- The cardinality of a Sylow subgroup is `p ^ n`
  where `n` is the multiplicity of `p` in the group order. -/
-theorem card_eq_multiplicity [Fintype G] {p : ℕ} [hp : Fact p.Prime] (P : Sylow p G) :
-    card P = p ^ Nat.factorization (card G) p := by
-  obtain ⟨n, heq : card P = _⟩ := IsPGroup.iff_card.mp P.isPGroup'
+theorem card_eq_multiplicity [Finite G] {p : ℕ} [hp : Fact p.Prime] (P : Sylow p G) :
+    Nat.card P = p ^ Nat.factorization (Nat.card G) p := by
+  obtain ⟨n, heq : Nat.card P = _⟩ := IsPGroup.iff_card.mp P.isPGroup'
   refine Nat.dvd_antisymm ?_ (P.pow_dvd_card_of_pow_dvd_card (Nat.ord_proj_dvd _ p))
-  rw [heq, ← hp.out.pow_dvd_iff_dvd_ord_proj (show card G ≠ 0 from card_ne_zero), ← heq]
-  simp only [← Nat.card_eq_fintype_card]
+  rw [heq, ← hp.out.pow_dvd_iff_dvd_ord_proj (show Nat.card G ≠ 0 from Nat.card_pos.ne'), ← heq]
   exact P.1.card_subgroup_dvd_card
 #align sylow.card_eq_multiplicity Sylow.card_eq_multiplicity
 
 /-- A subgroup with cardinality `p ^ n` is a Sylow subgroup
  where `n` is the multiplicity of `p` in the group order. -/
-def ofCard [Fintype G] {p : ℕ} [Fact p.Prime] (H : Subgroup G) [Fintype H]
-    (card_eq : card H = p ^ (card G).factorization p) : Sylow p G where
+def ofCard [Finite G] {p : ℕ} [Fact p.Prime] (H : Subgroup G)
+    (card_eq : Nat.card H = p ^ (Nat.card G).factorization p) : Sylow p G where
   toSubgroup := H
   isPGroup' := IsPGroup.of_card card_eq
   is_maximal' := by
     obtain ⟨P, hHP⟩ := (IsPGroup.of_card card_eq).exists_le_sylow
-    exact SetLike.ext'
-      (Set.eq_of_subset_of_card_le hHP (P.card_eq_multiplicity.trans card_eq.symm).le).symm ▸ P.3
+    exact SetLike.ext' (Set.Finite.eq_of_subset_of_card_le (inferInstanceAs (Finite P)) hHP
+      (P.card_eq_multiplicity.trans card_eq.symm).le).symm ▸ P.3
 #align sylow.of_card Sylow.ofCard
 
 @[simp, norm_cast]
-theorem coe_ofCard [Fintype G] {p : ℕ} [Fact p.Prime] (H : Subgroup G) [Fintype H]
-    (card_eq : card H = p ^ (card G).factorization p) : ↑(ofCard H card_eq) = H :=
+theorem coe_ofCard [Finite G] {p : ℕ} [Fact p.Prime] (H : Subgroup G)
+    (card_eq : Nat.card H = p ^ (Nat.card G).factorization p) : ↑(ofCard H card_eq) = H :=
   rfl
 #align sylow.coe_of_card Sylow.coe_ofCard
 
@@ -809,12 +785,14 @@ theorem normal_of_normalizerCondition (hnc : NormalizerCondition G) {p : ℕ} [F
 /-- If all its Sylow subgroups are normal, then a finite group is isomorphic to the direct product
 of these Sylow subgroups.
 -/
-noncomputable def directProductOfNormal [Fintype G]
+noncomputable def directProductOfNormal [Finite G]
     (hn : ∀ {p : ℕ} [Fact p.Prime] (P : Sylow p G), (↑P : Subgroup G).Normal) :
-    (∀ p : (card G).primeFactors, ∀ P : Sylow p G, (↑P : Subgroup G)) ≃* G := by
-  set ps := (Fintype.card G).primeFactors
+    (∀ p : (Nat.card G).primeFactors, ∀ P : Sylow p G, (↑P : Subgroup G)) ≃* G := by
+  have := Fintype.ofFinite G
+  set ps := (Nat.card G).primeFactors
   -- “The” Sylow subgroup for p
   let P : ∀ p, Sylow p G := default
+  have : ∀ p, Fintype (P p) := fun p ↦ Fintype.ofFinite (P p)
   have hcomm : Pairwise fun p₁ p₂ : ps => ∀ x y : G, x ∈ P p₁ → y ∈ P p₂ → Commute x y := by
     rintro ⟨p₁, hp₁⟩ ⟨p₂, hp₂⟩ hne
     haveI hp₁' := Fact.mk (Nat.prime_of_mem_primeFactors hp₁)
@@ -824,35 +802,33 @@ noncomputable def directProductOfNormal [Fintype G]
     apply IsPGroup.disjoint_of_ne p₁ p₂ hne' _ _ (P p₁).isPGroup' (P p₂).isPGroup'
   refine MulEquiv.trans (N := ∀ p : ps, P p) ?_ ?_
   -- There is only one Sylow subgroup for each p, so the inner product is trivial
-  · show (∀ p : ps, ∀ P : Sylow p G, P) ≃* ∀ p : ps, P p
-    -- here we need to help the elaborator with an explicit instantiation
+  · -- here we need to help the elaborator with an explicit instantiation
     apply @MulEquiv.piCongrRight ps (fun p => ∀ P : Sylow p G, P) (fun p => P p) _ _
     rintro ⟨p, hp⟩
     haveI hp' := Fact.mk (Nat.prime_of_mem_primeFactors hp)
     letI := unique_of_normal _ (hn (P p))
     apply MulEquiv.piUnique
-  show (∀ p : ps, P p) ≃* G
   apply MulEquiv.ofBijective (Subgroup.noncommPiCoprod hcomm)
   apply (bijective_iff_injective_and_card _).mpr
   constructor
-  · show Injective _
-    apply Subgroup.injective_noncommPiCoprod_of_independent
+  · apply Subgroup.injective_noncommPiCoprod_of_independent
     apply independent_of_coprime_order hcomm
     rintro ⟨p₁, hp₁⟩ ⟨p₂, hp₂⟩ hne
     haveI hp₁' := Fact.mk (Nat.prime_of_mem_primeFactors hp₁)
     haveI hp₂' := Fact.mk (Nat.prime_of_mem_primeFactors hp₂)
     have hne' : p₁ ≠ p₂ := by simpa using hne
+    simp only [← Nat.card_eq_fintype_card]
     apply IsPGroup.coprime_card_of_ne p₁ p₂ hne' _ _ (P p₁).isPGroup' (P p₂).isPGroup'
-  · show card (∀ p : ps, P p) = card G
+  · simp only [← Nat.card_eq_fintype_card]
     calc
-      card (∀ p : ps, P p) = ∏ p : ps, card (P p) := Fintype.card_pi
-      _ = ∏ p : ps, p.1 ^ (card G).factorization p.1 := by
+      Nat.card (∀ p : ps, P p) = ∏ p : ps, Nat.card (P p) := Nat.card_pi
+      _ = ∏ p : ps, p.1 ^ (Nat.card G).factorization p.1 := by
         congr 1 with ⟨p, hp⟩
         exact @card_eq_multiplicity _ _ _ p ⟨Nat.prime_of_mem_primeFactors hp⟩ (P p)
-      _ = ∏ p ∈ ps, p ^ (card G).factorization p :=
-        (Finset.prod_finset_coe (fun p => p ^ (card G).factorization p) _)
-      _ = (card G).factorization.prod (· ^ ·) := rfl
-      _ = card G := Nat.factorization_prod_pow_eq_self Fintype.card_ne_zero
+      _ = ∏ p ∈ ps, p ^ (Nat.card G).factorization p :=
+        (Finset.prod_finset_coe (fun p => p ^ (Nat.card G).factorization p) _)
+      _ = (Nat.card G).factorization.prod (· ^ ·) := rfl
+      _ = Nat.card G := Nat.factorization_prod_pow_eq_self Nat.card_pos.ne'
 #align sylow.direct_product_of_normal Sylow.directProductOfNormal
 
 end Sylow


### PR DESCRIPTION
A lot of the group theory library still needs to be switched over from Fintype.card to Nat.card. This PR switches over GroupTheory/PGroup.lean and GroupTheory/Sylow (there was enough dependence between the two that it was simplest to do them together).

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
