### PR TITLE
[Merged by Bors] - chore: unify `add_halves` and `add_halves'`

### DIFF
--- a/Counterexamples/Pseudoelement.lean
+++ b/Counterexamples/Pseudoelement.lean
@@ -66,7 +66,7 @@ theorem fst_x_pseudo_eq_fst_y : PseudoEqual _ (app biprod.fst x) (app biprod.fst
 theorem snd_x_pseudo_eq_snd_y : PseudoEqual _ (app biprod.snd x) (app biprod.snd y) := by
   refine ⟨of ℤ ℚ, 𝟙 _, 2 • 𝟙 _, inferInstance, ?_, ?_⟩
   · refine (ModuleCat.epi_iff_surjective _).2 fun a => ⟨(show ℚ from a) / 2, ?_⟩
-    simpa only [two_smul] using add_halves' (show ℚ from a)
+    simpa only [two_smul] using add_halves (show ℚ from a)
   · dsimp [x, y]
     refine ConcreteCategory.hom_ext _ _ fun a => ?_
     simp_rw [biprod.lift_snd]; rfl

--- a/Mathlib/Algebra/CharZero/Lemmas.lean
+++ b/Mathlib/Algebra/CharZero/Lemmas.lean
@@ -130,17 +130,27 @@ end
 
 section
 
-variable {R : Type*} [DivisionRing R] [CharZero R]
+variable {R : Type*} [DivisionSemiring R] [NeZero (2 : R)]
 
-@[simp] lemma half_add_self (a : R) : (a + a) / 2 = a := by
+@[simp] lemma add_self_div_two (a : R) : (a + a) / 2 = a := by
   rw [← mul_two, mul_div_cancel_right₀ a two_ne_zero]
-#align half_add_self half_add_self
+#align add_self_div_two add_self_div_two
+#align half_add_self add_self_div_two
+@[deprecated (since := "2024-07-16")] alias half_add_self := add_self_div_two
+
 
 @[simp]
-theorem add_halves' (a : R) : a / 2 + a / 2 = a := by rw [← add_div, half_add_self]
-#align add_halves' add_halves'
+theorem add_halves (a : R) : a / 2 + a / 2 = a := by rw [← add_div, add_self_div_two]
+#align add_halves add_halves
+#align add_halves' add_halves
+@[deprecated (since := "2024-07-16")] alias add_havles' := add_halves
 
-theorem sub_half (a : R) : a - a / 2 = a / 2 := by rw [sub_eq_iff_eq_add, add_halves']
+end
+section
+
+variable {R : Type*} [DivisionRing R] [CharZero R]
+
+theorem sub_half (a : R) : a - a / 2 = a / 2 := by rw [sub_eq_iff_eq_add, add_halves]
 #align sub_half sub_half
 
 theorem half_sub (a : R) : a / 2 - a = -(a / 2) := by rw [← neg_sub, sub_half]

--- a/Mathlib/Algebra/CharZero/Lemmas.lean
+++ b/Mathlib/Algebra/CharZero/Lemmas.lean
@@ -143,7 +143,7 @@ variable {R : Type*} [DivisionSemiring R] [NeZero (2 : R)]
 theorem add_halves (a : R) : a / 2 + a / 2 = a := by rw [← add_div, add_self_div_two]
 #align add_halves add_halves
 #align add_halves' add_halves
-@[deprecated (since := "2024-07-16")] alias add_havles' := add_halves
+@[deprecated (since := "2024-07-16")] alias add_halves' := add_halves
 
 end
 section

--- a/Mathlib/Algebra/Order/Field/Basic.lean
+++ b/Mathlib/Algebra/Order/Field/Basic.lean
@@ -3,8 +3,7 @@ Copyright (c) 2014 Robert Lewis. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Robert Lewis, Leonardo de Moura, Mario Carneiro, Floris van Doorn
 -/
-import Mathlib.Algebra.Field.Basic
-import Mathlib.Algebra.GroupWithZero.Units.Equiv
+import Mathlib.Algebra.CharZero.Lemmas
 import Mathlib.Algebra.Order.Field.Defs
 import Mathlib.Algebra.Order.Ring.Abs
 import Mathlib.Order.Bounds.OrderIso
@@ -429,18 +428,6 @@ theorem one_le_one_div (h1 : 0 < a) (h2 : a ≤ 1) : 1 ≤ 1 / a := by
 ### Results about halving.
 The equalities also hold in semifields of characteristic `0`.
 -/
-
-
-/- TODO: Unify `add_halves` and `add_halves'` into a single lemma about
-`DivisionSemiring` + `CharZero` -/
-theorem add_halves (a : α) : a / 2 + a / 2 = a := by
-  rw [div_add_div_same, ← two_mul, mul_div_cancel_left₀ a two_ne_zero]
-#align add_halves add_halves
-
--- TODO: Generalize to `DivisionSemiring`
-theorem add_self_div_two (a : α) : (a + a) / 2 = a := by
-  rw [← mul_two, mul_div_cancel_right₀ a two_ne_zero]
-#align add_self_div_two add_self_div_two
 
 theorem half_pos (h : 0 < a) : 0 < a / 2 :=
   div_pos h zero_lt_two

--- a/Mathlib/Algebra/Order/Floor.lean
+++ b/Mathlib/Algebra/Order/Floor.lean
@@ -1587,7 +1587,7 @@ theorem round_eq (x : α) : round x = ⌊x + 1 / 2⌋ := by
 
 @[simp]
 theorem round_two_inv : round (2⁻¹ : α) = 1 := by
-  simp only [round_eq, ← one_div, add_halves', floor_one]
+  simp only [round_eq, ← one_div, add_halves, floor_one]
 #align round_two_inv round_two_inv
 
 @[simp]

--- a/Mathlib/Analysis/LocallyConvex/WithSeminorms.lean
+++ b/Mathlib/Analysis/LocallyConvex/WithSeminorms.lean
@@ -126,7 +126,7 @@ theorem basisSets_add (U) (hU : U ∈ p.basisSets) :
   use (s.sup p).ball 0 (r / 2)
   refine ⟨p.basisSets_mem s (div_pos hr zero_lt_two), ?_⟩
   refine Set.Subset.trans (ball_add_ball_subset (s.sup p) (r / 2) (r / 2) 0 0) ?_
-  rw [hU, add_zero, add_halves']
+  rw [hU, add_zero, add_halves]
 #align seminorm_family.basis_sets_add SeminormFamily.basisSets_add
 
 theorem basisSets_neg (U) (hU' : U ∈ p.basisSets) :

--- a/Mathlib/Analysis/SpecialFunctions/Trigonometric/Inverse.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Trigonometric/Inverse.lean
@@ -416,7 +416,7 @@ theorem arccos_of_one_le {x : ℝ} (hx : 1 ≤ x) : arccos x = 0 := by
 #align real.arccos_of_one_le Real.arccos_of_one_le
 
 theorem arccos_of_le_neg_one {x : ℝ} (hx : x ≤ -1) : arccos x = π := by
-  rw [arccos, arcsin_of_le_neg_one hx, sub_neg_eq_add, add_halves']
+  rw [arccos, arcsin_of_le_neg_one hx, sub_neg_eq_add, add_halves]
 #align real.arccos_of_le_neg_one Real.arccos_of_le_neg_one
 
 -- The junk values for `arccos` and `sqrt` make this true even outside `[-1, 1]`.

--- a/Mathlib/Combinatorics/SimpleGraph/LapMatrix.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/LapMatrix.lean
@@ -78,7 +78,7 @@ theorem lapMatrix_toLinearMap₂' [Field R] [CharZero R] (x : V → R) :
   simp_rw [toLinearMap₂'_apply', lapMatrix, sub_mulVec, dotProduct_sub, dotProduct_mulVec_degMatrix,
     dotProduct_mulVec_adjMatrix, ← sum_sub_distrib, degree_eq_sum_if_adj, sum_mul, ite_mul, one_mul,
     zero_mul, ← sum_sub_distrib, ite_sub_ite, sub_zero]
-  rw [← half_add_self (∑ x_1 : V, ∑ x_2 : V, _)]
+  rw [← add_self_div_two (∑ x_1 : V, ∑ x_2 : V, _)]
   conv_lhs => enter [1,2,2,i,2,j]; rw [if_congr (adj_comm G i j) rfl rfl]
   conv_lhs => enter [1,2]; rw [Finset.sum_comm]
   simp_rw [← sum_add_distrib, ite_add_ite]

--- a/Mathlib/Data/Complex/Exponential.lean
+++ b/Mathlib/Data/Complex/Exponential.lean
@@ -584,8 +584,8 @@ theorem cos_eq (z : ℂ) : cos z = cos z.re * cosh z.im - sin z.re * sinh z.im *
 theorem sin_sub_sin : sin x - sin y = 2 * sin ((x - y) / 2) * cos ((x + y) / 2) := by
   have s1 := sin_add ((x + y) / 2) ((x - y) / 2)
   have s2 := sin_sub ((x + y) / 2) ((x - y) / 2)
-  rw [div_add_div_same, add_sub, add_right_comm, add_sub_cancel_right, half_add_self] at s1
-  rw [div_sub_div_same, ← sub_add, add_sub_cancel_left, half_add_self] at s2
+  rw [div_add_div_same, add_sub, add_right_comm, add_sub_cancel_right, add_self_div_two] at s1
+  rw [div_sub_div_same, ← sub_add, add_sub_cancel_left, add_self_div_two] at s2
   rw [s1, s2]
   ring
 #align complex.sin_sub_sin Complex.sin_sub_sin
@@ -593,8 +593,8 @@ theorem sin_sub_sin : sin x - sin y = 2 * sin ((x - y) / 2) * cos ((x + y) / 2) 
 theorem cos_sub_cos : cos x - cos y = -2 * sin ((x + y) / 2) * sin ((x - y) / 2) := by
   have s1 := cos_add ((x + y) / 2) ((x - y) / 2)
   have s2 := cos_sub ((x + y) / 2) ((x - y) / 2)
-  rw [div_add_div_same, add_sub, add_right_comm, add_sub_cancel_right, half_add_self] at s1
-  rw [div_sub_div_same, ← sub_add, add_sub_cancel_left, half_add_self] at s2
+  rw [div_add_div_same, add_sub, add_right_comm, add_sub_cancel_right, add_self_div_two] at s1
+  rw [div_sub_div_same, ← sub_add, add_sub_cancel_left, add_self_div_two] at s2
   rw [s1, s2]
   ring
 #align complex.cos_sub_cos Complex.cos_sub_cos

--- a/Mathlib/Geometry/Euclidean/MongePoint.lean
+++ b/Mathlib/Geometry/Euclidean/MongePoint.lean
@@ -541,7 +541,7 @@ theorem dist_orthocenter_reflection_circumcenter (t : Triangle ℝ P) {i₁ i₂
     sum_singleton, h, ite_false, dist_self, mul_zero, mem_singleton, true_or, ite_true, sub_self,
     zero_mul, implies_true, sum_insert_of_eq_zero_if_not_mem, or_true, add_zero, div_one,
     sub_neg_eq_add, pointsWithCircumcenter_eq_circumcenter, dist_circumcenter_eq_circumradius,
-    sum_const_zero, dist_circumcenter_eq_circumradius', mul_one, neg_add_rev, half_add_self]
+    sum_const_zero, dist_circumcenter_eq_circumradius', mul_one, neg_add_rev, add_self_div_two]
   norm_num
 #align affine.triangle.dist_orthocenter_reflection_circumcenter Affine.Triangle.dist_orthocenter_reflection_circumcenter
 

--- a/Mathlib/NumberTheory/LSeries/HurwitzZetaOdd.lean
+++ b/Mathlib/NumberTheory/LSeries/HurwitzZetaOdd.lean
@@ -133,7 +133,7 @@ for the defining sum. -/
 
 lemma sinKernel_def (a x : ℝ) : ↑(sinKernel ↑a x) = jacobiTheta₂' a (I * x) / (-2 * π) := by
   rw [sinKernel, Function.Periodic.lift_coe, re_eq_add_conj, map_div₀, jacobiTheta₂'_conj]
-  simp_rw [map_mul, conj_I, conj_ofReal, map_neg, map_ofNat, neg_mul, neg_neg, half_add_self]
+  simp_rw [map_mul, conj_I, conj_ofReal, map_neg, map_ofNat, neg_mul, neg_neg, add_self_div_two]
 
 lemma sinKernel_undef (a : UnitAddCircle) {x : ℝ} (hx : x ≤ 0) : sinKernel a x = 0 := by
   induction' a using QuotientAddGroup.induction_on' with a'


### PR DESCRIPTION
by generalizing to `DivisionSemiring`


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
