### PR TITLE
[Merged by Bors] - chore: swap the direction of some ext_iff lemmas

### DIFF
--- a/Mathlib/Analysis/Complex/UpperHalfPlane/Basic.lean
+++ b/Mathlib/Analysis/Complex/UpperHalfPlane/Basic.lean
@@ -66,7 +66,8 @@ instance : Inhabited ℍ :=
 
 @[ext] theorem ext {a b : ℍ} (h : (a : ℂ) = b) : a = b := Subtype.eq h
 
-@[simp, norm_cast] theorem ext_iff {a b : ℍ} : (a : ℂ) = b ↔ a = b := Subtype.coe_inj
+protected theorem ext_iff {a b : ℍ} : a = b ↔ (a : ℂ) = b := Subtype.coe_inj.symm
+@[simp, norm_cast] theorem ext_iff' {a b : ℍ} : (a : ℂ) = b ↔ a = b := UpperHalfPlane.ext_iff.symm
 
 instance canLift : CanLift ℂ ℍ ((↑) : ℍ → ℂ) fun z => 0 < z.im :=
   Subtype.canLift fun (z : ℂ) => 0 < z.im
@@ -517,7 +518,7 @@ theorem modular_S_smul (z : ℍ) : ModularGroup.S • z = mk (-z : ℂ)⁻¹ z.i
 #align upper_half_plane.modular_S_smul UpperHalfPlane.modular_S_smul
 
 theorem modular_T_zpow_smul (z : ℍ) (n : ℤ) : ModularGroup.T ^ n • z = (n : ℝ) +ᵥ z := by
-  rw [← ext_iff, coe_vadd, add_comm, specialLinearGroup_apply, coe_mk]
+  rw [UpperHalfPlane.ext_iff, coe_vadd, add_comm, specialLinearGroup_apply, coe_mk]
   -- Porting note: added `coeToGL` and merged `rw` and `simp`
   simp [coeToGL, ModularGroup.coe_T_zpow,
     of_apply, cons_val_zero, algebraMap.coe_one, Complex.ofReal_one, one_mul, cons_val_one,

--- a/Mathlib/Analysis/NormedSpace/Star/Unitization.lean
+++ b/Mathlib/Analysis/NormedSpace/Star/Unitization.lean
@@ -57,7 +57,7 @@ variable (E)
 
 /-- A C⋆-algebra over a densely normed field is a regular normed algebra. -/
 instance CstarRing.instRegularNormedAlgebra : RegularNormedAlgebra 𝕜 E where
-  isometry_mul' := AddMonoidHomClass.isometry_of_norm (mul 𝕜 E) fun a => NNReal.eq_iff.mpr <|
+  isometry_mul' := AddMonoidHomClass.isometry_of_norm (mul 𝕜 E) fun a => NNReal.eq_iff.mp <|
     show ‖mul 𝕜 E a‖₊ = ‖a‖₊ by
     rw [← sSup_closed_unit_ball_eq_nnnorm]
     refine csSup_eq_of_forall_le_of_forall_lt_exists_gt ?_ ?_ fun r hr => ?_

--- a/Mathlib/Data/Finmap.lean
+++ b/Mathlib/Data/Finmap.lean
@@ -162,10 +162,13 @@ theorem ext : ∀ {s t : Finmap β}, s.entries = t.entries → s = t
   | ⟨l₁, h₁⟩, ⟨l₂, _⟩, H => by congr
 #align finmap.ext Finmap.ext
 
+protected theorem ext_iff {s t : Finmap β} : s = t ↔ s.entries = t.entries :=
+  ⟨congr_arg _, ext⟩
+
 @[simp]
-theorem ext_iff {s t : Finmap β} : s.entries = t.entries ↔ s = t :=
-  ⟨ext, congr_arg _⟩
-#align finmap.ext_iff Finmap.ext_iff
+theorem ext_iff' {s t : Finmap β} : s.entries = t.entries ↔ s = t :=
+  Finmap.ext_iff.symm
+#align finmap.ext_iff Finmap.ext_iff'
 
 /-! ### mem -/
 
@@ -253,7 +256,7 @@ section
 variable [DecidableEq α]
 
 instance decidableEq [∀ a, DecidableEq (β a)] : DecidableEq (Finmap β)
-  | _, _ => decidable_of_iff _ ext_iff
+  | _, _ => decidable_of_iff _ Finmap.ext_iff.symm
 #align finmap.has_decidable_eq Finmap.decidableEq
 
 /-! ### lookup -/

--- a/Mathlib/Data/NNReal/Basic.lean
+++ b/Mathlib/Data/NNReal/Basic.lean
@@ -98,12 +98,12 @@ instance canLift : CanLift ℝ ℝ≥0 toReal fun r => 0 ≤ r :=
   Subtype.eq
 #align nnreal.eq NNReal.eq
 
-protected theorem eq_iff {n m : ℝ≥0} : (n : ℝ) = (m : ℝ) ↔ n = m :=
-  Subtype.ext_iff.symm
+protected theorem eq_iff {n m : ℝ≥0} : n = m ↔ (n : ℝ) = (m : ℝ) :=
+  Subtype.ext_iff
 #align nnreal.eq_iff NNReal.eq_iff
 
 theorem ne_iff {x y : ℝ≥0} : (x : ℝ) ≠ (y : ℝ) ↔ x ≠ y :=
-  not_congr <| NNReal.eq_iff
+  NNReal.eq_iff.symm.not
 #align nnreal.ne_iff NNReal.ne_iff
 
 protected theorem «forall» {p : ℝ≥0 → Prop} :

--- a/Mathlib/GroupTheory/Congruence/Basic.lean
+++ b/Mathlib/GroupTheory/Congruence/Basic.lean
@@ -198,8 +198,8 @@ theorem toSetoid_inj {c d : Con M} (H : c.toSetoid = d.toSetoid) : c = d :=
 
 /-- Iff version of extensionality rule for congruence relations. -/
 @[to_additive "Iff version of extensionality rule for additive congruence relations."]
-theorem ext_iff {c d : Con M} : (∀ x y, c x y ↔ d x y) ↔ c = d :=
-  ⟨ext, fun h _ _ => h ▸ Iff.rfl⟩
+protected theorem ext_iff {c d : Con M} : c = d ↔ (∀ x y, c x y ↔ d x y) :=
+  ⟨fun h _ _ => h ▸ Iff.rfl, ext⟩
 #align con.ext_iff Con.ext_iff
 #align add_con.ext_iff AddCon.ext_iff
 
@@ -396,7 +396,7 @@ protected theorem liftOn_coe {β} (c : Con M) (f : M → β) (h : ∀ a b, c a b
 @[to_additive "Makes an additive isomorphism of quotients by two additive congruence relations,
 given that the relations are equal."]
 protected def congr {c d : Con M} (h : c = d) : c.Quotient ≃* d.Quotient :=
-  { Quotient.congr (Equiv.refl M) <| by apply ext_iff.2 h with
+  { Quotient.congr (Equiv.refl M) <| by apply Con.ext_iff.mp h with
     map_mul' := fun x y => by rcases x with ⟨⟩; rcases y with ⟨⟩; rfl }
 #align con.congr Con.congr
 #align add_con.congr AddCon.congr

--- a/Mathlib/LinearAlgebra/AffineSpace/AffineSubspace.lean
+++ b/Mathlib/LinearAlgebra/AffineSpace/AffineSubspace.lean
@@ -346,8 +346,8 @@ theorem ext {p q : AffineSubspace k P} (h : ∀ x, x ∈ p ↔ x ∈ q) : p = q 
 #align affine_subspace.ext AffineSubspace.ext
 
 -- Porting note: removed `simp`, proof is `simp only [SetLike.ext'_iff]`
-theorem ext_iff (s₁ s₂ : AffineSubspace k P) : (s₁ : Set P) = s₂ ↔ s₁ = s₂ :=
-  SetLike.ext'_iff.symm
+protected theorem ext_iff (s₁ s₂ : AffineSubspace k P) : s₁ = s₂ ↔ (s₁ : Set P) = s₂ :=
+  SetLike.ext'_iff
 #align affine_subspace.ext_iff AffineSubspace.ext_iff
 
 /-- Two affine subspaces with the same direction and nonempty intersection are equal. -/
@@ -773,7 +773,7 @@ theorem bot_coe : ((⊥ : AffineSubspace k P) : Set P) = ∅ :=
 
 theorem bot_ne_top : (⊥ : AffineSubspace k P) ≠ ⊤ := by
   intro contra
-  rw [← ext_iff, bot_coe, top_coe] at contra
+  rw [AffineSubspace.ext_iff, bot_coe, top_coe] at contra
   exact Set.empty_ne_univ contra
 #align affine_subspace.bot_ne_top AffineSubspace.bot_ne_top
 
@@ -870,7 +870,7 @@ theorem subsingleton_of_subsingleton_span_eq_top {s : Set P} (h₁ : s.Subsingle
     (h₂ : affineSpan k s = ⊤) : Subsingleton P := by
   obtain ⟨p, hp⟩ := AffineSubspace.nonempty_of_affineSpan_eq_top k V P h₂
   have : s = {p} := Subset.antisymm (fun q hq => h₁ hq hp) (by simp [hp])
-  rw [this, ← AffineSubspace.ext_iff, AffineSubspace.coe_affineSpan_singleton,
+  rw [this, AffineSubspace.ext_iff, AffineSubspace.coe_affineSpan_singleton,
     AffineSubspace.top_coe, eq_comm, ← subsingleton_iff_singleton (mem_univ _)] at h₂
   exact subsingleton_of_univ_subsingleton h₂
 #align affine_subspace.subsingleton_of_subsingleton_span_eq_top AffineSubspace.subsingleton_of_subsingleton_span_eq_top
@@ -1634,7 +1634,7 @@ namespace AffineMap
 
 @[simp]
 theorem map_top_of_surjective (hf : Function.Surjective f) : AffineSubspace.map f ⊤ = ⊤ := by
-  rw [← AffineSubspace.ext_iff]
+  rw [AffineSubspace.ext_iff]
   exact image_univ_of_surjective hf
 #align affine_map.map_top_of_surjective AffineMap.map_top_of_surjective
 
@@ -1714,7 +1714,7 @@ theorem comap_mono {f : P₁ →ᵃ[k] P₂} {s t : AffineSubspace k P₂} : s �
 
 @[simp]
 theorem comap_top {f : P₁ →ᵃ[k] P₂} : (⊤ : AffineSubspace k P₂).comap f = ⊤ := by
-  rw [← ext_iff]
+  rw [AffineSubspace.ext_iff]
   exact preimage_univ (f := f)
 #align affine_subspace.comap_top AffineSubspace.comap_top
 

--- a/Mathlib/MeasureTheory/Decomposition/Jordan.lean
+++ b/Mathlib/MeasureTheory/Decomposition/Jordan.lean
@@ -234,9 +234,9 @@ def toJordanDecomposition (s : SignedMeasure α) : JordanDecomposition α :=
     negPart_finite := inferInstance
     mutuallySingular := by
       refine ⟨iᶜ, hi.1.compl, ?_, ?_⟩
-      -- Porting note: added `← NNReal.eq_iff`
-      · rw [toMeasureOfZeroLE_apply _ _ hi.1 hi.1.compl]; simp [← NNReal.eq_iff]
-      · rw [toMeasureOfLEZero_apply _ _ hi.1.compl hi.1.compl.compl]; simp [← NNReal.eq_iff] }
+      -- Porting note: added `NNReal.eq_iff`
+      · rw [toMeasureOfZeroLE_apply _ _ hi.1 hi.1.compl]; simp [NNReal.eq_iff]
+      · rw [toMeasureOfLEZero_apply _ _ hi.1.compl hi.1.compl.compl]; simp [NNReal.eq_iff] }
 #align measure_theory.signed_measure.to_jordan_decomposition MeasureTheory.SignedMeasure.toJordanDecomposition
 
 theorem toJordanDecomposition_spec (s : SignedMeasure α) :
@@ -524,9 +524,9 @@ theorem absolutelyContinuous_ennreal_iff (s : SignedMeasure α) (μ : VectorMeas
     rw [totalVariation, Measure.add_apply, hpos, hneg, toMeasureOfZeroLE_apply _ _ _ hS₁,
       toMeasureOfLEZero_apply _ _ _ hS₁]
     rw [← VectorMeasure.AbsolutelyContinuous.ennrealToMeasure] at h
-    -- Porting note: added `← NNReal.eq_iff`
+    -- Porting note: added `NNReal.eq_iff`
     simp [h (measure_mono_null (i.inter_subset_right) hS₂),
-      h (measure_mono_null (iᶜ.inter_subset_right) hS₂), ← NNReal.eq_iff]
+      h (measure_mono_null (iᶜ.inter_subset_right) hS₂), NNReal.eq_iff]
   · refine VectorMeasure.AbsolutelyContinuous.mk fun S hS₁ hS₂ => ?_
     rw [← VectorMeasure.ennrealToMeasure_apply hS₁] at hS₂
     exact null_of_totalVariation_zero s (h hS₂)
@@ -556,13 +556,13 @@ theorem mutuallySingular_iff (s t : SignedMeasure α) :
     refine ⟨u, hmeas, ?_, ?_⟩
     · rw [totalVariation, Measure.add_apply, hipos, hineg, toMeasureOfZeroLE_apply _ _ _ hmeas,
         toMeasureOfLEZero_apply _ _ _ hmeas]
-      -- Porting note: added `← NNReal.eq_iff`
-      simp [hu₁ _ Set.inter_subset_right, ← NNReal.eq_iff]
+      -- Porting note: added `NNReal.eq_iff`
+      simp [hu₁ _ Set.inter_subset_right, NNReal.eq_iff]
     · rw [totalVariation, Measure.add_apply, hjpos, hjneg,
         toMeasureOfZeroLE_apply _ _ _ hmeas.compl,
         toMeasureOfLEZero_apply _ _ _ hmeas.compl]
-      -- Porting note: added `← NNReal.eq_iff`
-      simp [hu₂ _ Set.inter_subset_right, ← NNReal.eq_iff]
+      -- Porting note: added `NNReal.eq_iff`
+      simp [hu₂ _ Set.inter_subset_right, NNReal.eq_iff]
   · rintro ⟨u, hmeas, hu₁, hu₂⟩
     exact
       ⟨u, hmeas, fun t htu => null_of_totalVariation_zero _ (measure_mono_null htu hu₁),
@@ -577,8 +577,8 @@ theorem mutuallySingular_ennreal_iff (s : SignedMeasure α) (μ : VectorMeasure 
     refine ⟨u, hmeas, ?_, ?_⟩
     · rw [totalVariation, Measure.add_apply, hpos, hneg, toMeasureOfZeroLE_apply _ _ _ hmeas,
         toMeasureOfLEZero_apply _ _ _ hmeas]
-      -- Porting note: added `← NNReal.eq_iff`
-      simp [hu₁ _ Set.inter_subset_right, ← NNReal.eq_iff]
+      -- Porting note: added `NNReal.eq_iff`
+      simp [hu₁ _ Set.inter_subset_right, NNReal.eq_iff]
     · rw [VectorMeasure.ennrealToMeasure_apply hmeas.compl]
       exact hu₂ _ (Set.Subset.refl _)
   · rintro ⟨u, hmeas, hu₁, hu₂⟩

--- a/Mathlib/Topology/MetricSpace/Basic.lean
+++ b/Mathlib/Topology/MetricSpace/Basic.lean
@@ -94,18 +94,18 @@ theorem eq_of_forall_dist_le {x y : γ} (h : ∀ ε > 0, dist x y ≤ ε) : x = 
 
 /-- Deduce the equality of points from the vanishing of the nonnegative distance-/
 theorem eq_of_nndist_eq_zero {x y : γ} : nndist x y = 0 → x = y := by
-  simp only [← NNReal.eq_iff, ← dist_nndist, imp_self, NNReal.coe_zero, dist_eq_zero]
+  simp only [NNReal.eq_iff, ← dist_nndist, imp_self, NNReal.coe_zero, dist_eq_zero]
 #align eq_of_nndist_eq_zero eq_of_nndist_eq_zero
 
 /-- Characterize the equality of points as the vanishing of the nonnegative distance-/
 @[simp]
 theorem nndist_eq_zero {x y : γ} : nndist x y = 0 ↔ x = y := by
-  simp only [← NNReal.eq_iff, ← dist_nndist, imp_self, NNReal.coe_zero, dist_eq_zero]
+  simp only [NNReal.eq_iff, ← dist_nndist, imp_self, NNReal.coe_zero, dist_eq_zero]
 #align nndist_eq_zero nndist_eq_zero
 
 @[simp]
 theorem zero_eq_nndist {x y : γ} : 0 = nndist x y ↔ x = y := by
-  simp only [← NNReal.eq_iff, ← dist_nndist, imp_self, NNReal.coe_zero, zero_eq_dist]
+  simp only [NNReal.eq_iff, ← dist_nndist, imp_self, NNReal.coe_zero, zero_eq_dist]
 #align zero_eq_nndist zero_eq_nndist
 
 namespace Metric


### PR DESCRIPTION
In lean 4.11, the @[ext] attribute will generate `ext_iff` lemmas automatically, following the mathlib convention of putting the 'plain' equality on the left hand side. Some existing lemmas didn't follow this convention; this PR changes that.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
