### PR TITLE
[Merged by Bors] - feat: interior and boundary of a product manifold

### DIFF
--- a/Mathlib/Geometry/Manifold/InteriorBoundary.lean
+++ b/Mathlib/Geometry/Manifold/InteriorBoundary.lean
@@ -18,9 +18,13 @@ Define the interior and boundary of a manifold.
 - **boundary I M** is the **boundary** of `M`, the set of its boundary points.
 
 ## Main results
-- `univ_eq_interior_union_boundary`: `M` is the union of its interior and boundary
-- `interior_boundary_disjoint`: interior and boundary of `M` are disjoint
-- if `M` is boundaryless, every point is an interior point
+- `ModelWithCorners.univ_eq_interior_union_boundary`: `M` is the union of its interior and boundary
+- `ModelWithCorners.interior_boundary_disjoint`: interior and boundary of `M` are disjoint
+- `BoundarylessManifold.isInteriorPoint`: if `M` is boundaryless, every point is an interior point
+
+- `ModelWithCorners.interior_prod`: the interior of `M × N` is the product of the interiors
+of `M` and `N`.
+- `ModelWithCorners.boundary_prod`: the boundary of `M × N` is `∂M × N ∪ (M × ∂N)`.
 
 ## Tags
 manifold, interior, boundary
@@ -140,3 +144,54 @@ lemma Boundaryless.boundary_eq_empty : I.boundary M = ∅ := by
 
 end BoundarylessManifold
 end ModelWithCorners
+
+-- Interior and boundary of the product of two manifolds.
+section prod
+
+variable {I}
+  {E' : Type*} [NormedAddCommGroup E'] [NormedSpace 𝕜 E']
+  {H' : Type*} [TopologicalSpace H']
+  {N : Type*} [TopologicalSpace N] [ChartedSpace H' N]
+  (J : ModelWithCorners 𝕜 E' H') [SmoothManifoldWithCorners J N] {x : M} {y : N}
+
+/-- The interior of `M × N` is the product of the interiors of `M` and `N`. -/
+lemma ModelWithCorners.interior_prod :
+    (I.prod J).interior (M × N) = (I.interior M) ×ˢ (J.interior N) := by
+  ext p
+  have aux : (interior (range ↑I)) ×ˢ (interior (range J)) = interior (range (I.prod J)) := by
+    rw [← interior_prod_eq, ← Set.range_prod_map, modelWithCorners_prod_coe]
+  constructor <;> intro hp
+  · replace hp : (I.prod J).IsInteriorPoint p := hp
+    rw [ModelWithCorners.IsInteriorPoint, ← aux] at hp
+    exact hp
+  · obtain ⟨h₁, h₂⟩ := Set.mem_prod.mp hp
+    rw [ModelWithCorners.interior] at h₁ h₂
+    show (I.prod J).IsInteriorPoint p
+    rw [ModelWithCorners.IsInteriorPoint, ← aux]
+    apply mem_prod.mpr; constructor; exacts [h₁, h₂]
+
+/-- The boundary of `M × N` is `∂M × N ∪ (M × ∂N)`. -/
+lemma ModelWithCorners.boundary_prod :
+    (I.prod J).boundary (M × N) = Set.prod univ (J.boundary N) ∪ Set.prod (I.boundary M) univ := by
+  let h := calc (I.prod J).boundary (M × N)
+    _ = ((I.prod J).interior (M × N))ᶜ := (I.prod J).boundary_eq_complement_interior
+    _ = ((I.interior M) ×ˢ (J.interior N))ᶜ := by rw [ModelWithCorners.interior_prod]
+    _ = (I.interior M)ᶜ ×ˢ univ ∪ univ ×ˢ (J.interior N)ᶜ := by rw [compl_prod_eq_union]
+  rw [h, I.boundary_eq_complement_interior, J.boundary_eq_complement_interior, union_comm]
+  rfl
+
+/-- If `M` is boundaryless, `∂(M×N) = M × ∂N`. -/
+lemma boundary_of_boundaryless_left [I.Boundaryless] :
+    (I.prod J).boundary (M × N) = Set.prod (univ : Set M) (J.boundary N) := by
+  rw [ModelWithCorners.boundary_prod, ModelWithCorners.Boundaryless.boundary_eq_empty I]
+  have : Set.prod (∅ : Set M) (univ : Set N) = ∅ := Set.empty_prod
+  rw [this, union_empty]
+
+/-- If `N` is boundaryless, `∂(M×N) = ∂M × N`. -/
+lemma boundary_of_boundaryless_right [J.Boundaryless] :
+    (I.prod J).boundary (M × N) = Set.prod (I.boundary M) (univ : Set N) := by
+  rw [ModelWithCorners.boundary_prod, ModelWithCorners.Boundaryless.boundary_eq_empty J]
+  have : Set.prod (univ : Set M) (∅ : Set N) = ∅ := Set.prod_empty
+  rw [this, empty_union]
+
+end prod


### PR DESCRIPTION
I intend to use these results for formalising the beginnings of bordism theory.

---

[This branch](https://github.com/leanprover-community/mathlib4/compare/master...MR-bordism-theory) has the first steps.

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
