### PR TITLE
[Merged by Bors] - chore(Tactic): reduce autoImplicit, part 4

### DIFF
--- a/Mathlib/Tactic/Linarith/Frontend.lean
+++ b/Mathlib/Tactic/Linarith/Frontend.lean
@@ -129,8 +129,6 @@ The components of `linarith` are spread between a number of files for the sake o
 linarith, nlinarith, lra, nra, Fourier-Motzkin, linear arithmetic, linear programming
 -/
 
-set_option autoImplicit true
-
 open Lean Elab Tactic Meta
 open Batteries
 
@@ -232,7 +230,7 @@ abbrev ExprMultiMap α := Array (Expr × List α)
 
 /-- Retrieves the list of values at a key, as well as the index of the key for later modification.
 (If the key is not in the map it returns `self.size` as the index.) -/
-def ExprMultiMap.find (self : ExprMultiMap α) (k : Expr) : MetaM (Nat × List α) := do
+def ExprMultiMap.find {α : Type} (self : ExprMultiMap α) (k : Expr) : MetaM (Nat × List α) := do
   for h : i in [:self.size] do
     let (k', vs) := self[i]'h.2
     if ← isDefEq k' k then
@@ -241,7 +239,8 @@ def ExprMultiMap.find (self : ExprMultiMap α) (k : Expr) : MetaM (Nat × List �
 
 /-- Insert a new value into the map at key `k`. This does a defeq check with all other keys
 in the map. -/
-def ExprMultiMap.insert (self : ExprMultiMap α) (k : Expr) (v : α) : MetaM (ExprMultiMap α) := do
+def ExprMultiMap.insert {α : Type} (self : ExprMultiMap α) (k : Expr) (v : α) :
+    MetaM (ExprMultiMap α) := do
   for h : i in [:self.size] do
     if ← isDefEq (self[i]'h.2).1 k then
       return self.modify i fun (k, vs) => (k, v::vs)

--- a/Mathlib/Tactic/Linarith/Lemmas.lean
+++ b/Mathlib/Tactic/Linarith/Lemmas.lean
@@ -18,10 +18,9 @@ Those in the `Linarith` namespace should stay here.
 Those outside the `Linarith` namespace may be deleted as they are ported to mathlib4.
 -/
 
-set_option autoImplicit true
-
 namespace Linarith
 
+universe u
 theorem lt_irrefl {α : Type u} [Preorder α] {a : α} : ¬a < a := _root_.lt_irrefl a
 
 theorem eq_of_eq_of_eq {α} [OrderedSemiring α] {a b : α} (ha : a = 0) (hb : b = 0) : a + b = 0 := by
@@ -78,8 +77,8 @@ section
 open Function
 -- These lemmas can be removed when their originals are ported.
 
-theorem lt_zero_of_zero_gt [Zero α] [LT α] {a : α} (h : 0 > a) : a < 0 := h
+theorem lt_zero_of_zero_gt {α : Type*} [Zero α] [LT α] {a : α} (h : 0 > a) : a < 0 := h
 
-theorem le_zero_of_zero_ge [Zero α] [LE α] {a : α} (h : 0 ≥ a) : a ≤ 0 := h
+theorem le_zero_of_zero_ge {α : Type*} [Zero α] [LE α] {a : α} (h : 0 ≥ a) : a ≤ 0 := h
 
 end

--- a/Mathlib/Tactic/Linarith/Parsing.lean
+++ b/Mathlib/Tactic/Linarith/Parsing.lean
@@ -27,8 +27,6 @@ This is ultimately converted into a `Linexp` in the obvious way.
 `linearFormsAndMaxVar` is the main entry point into this file. Everything else is contained.
 -/
 
-set_option autoImplicit true
-
 open Linarith.Ineq Batteries
 
 section
@@ -39,7 +37,8 @@ open Lean Elab Tactic Meta
 and returns the value associated with this key if it exists.
 Otherwise, it fails.
 -/
-def List.findDefeq (red : TransparencyMode) (m : List (Expr × v)) (e : Expr) : MetaM v := do
+def List.findDefeq {v : Type} (red : TransparencyMode) (m : List (Expr × v)) (e : Expr) :
+    MetaM v := do
   if let some (_, n) ← m.findM? fun ⟨e', _⟩ => withTransparency red (isDefEq e e') then
     return n
   else
@@ -51,7 +50,8 @@ We introduce a local instance allowing addition of `RBMap`s,
 removing any keys with value zero.
 We don't need to prove anything about this addition, as it is only used in meta code.
 -/
-local instance [Add β] [Zero β] [DecidableEq β] : Add (RBMap α β c) where
+local instance {α β : Type*} {c : α → α → Ordering} [Add β] [Zero β] [DecidableEq β] :
+    Add (RBMap α β c) where
   add := fun f g => (f.mergeWith (fun _ b b' => b + b') g).filter (fun _ b => b ≠ 0)
 
 namespace Linarith

--- a/Mathlib/Tactic/Linarith/Preprocessing.lean
+++ b/Mathlib/Tactic/Linarith/Preprocessing.lean
@@ -25,8 +25,6 @@ preprocessing steps by adding them to the `LinarithConfig` object. `Linarith.def
 is the main list, and generally none of these should be skipped unless you know what you're doing.
 -/
 
-set_option autoImplicit true
-
 namespace Linarith
 
 /-! ### Preprocessing -/
@@ -269,7 +267,8 @@ end compWithZero
 
 section cancelDenoms
 
-theorem without_one_mul [MulOneClass M] {a b : M} (h : 1 * a = b) : a = b := by rwa [one_mul] at h
+theorem without_one_mul {M : Type*} [MulOneClass M] {a b : M} (h : 1 * a = b) : a = b := by
+  rwa [one_mul] at h
 
 /--
 `normalizeDenominatorsLHS h lhs` assumes that `h` is a proof of `lhs R 0`.

--- a/Mathlib/Tactic/Positivity/Basic.lean
+++ b/Mathlib/Tactic/Positivity/Basic.lean
@@ -19,7 +19,7 @@ import Qq
 This file sets up the basic `positivity` extensions tagged with the `@[positivity]` attribute.
 -/
 
-set_option autoImplicit true
+variable {α : Type*}
 
 namespace Mathlib.Meta.Positivity
 open Lean Meta Qq Function
@@ -85,7 +85,7 @@ such that `positivity` successfully recognises both `a` and `b`. -/
   | _, _ => pure .none
 
 section LinearOrder
-variable [LinearOrder R] {a b c : R}
+variable {R : Type*} [LinearOrder R] {a b c : R}
 
 private lemma le_min_of_lt_of_le (ha : a < b) (hb : a ≤ c) : a ≤ min b c := le_min ha.le hb
 private lemma le_min_of_le_of_lt (ha : a ≤ b) (hb : a < c) : a ≤ min b c := le_min ha hb.le
@@ -256,7 +256,7 @@ private theorem pow_zero_pos [OrderedSemiring α] [Nontrivial α] (a : α) : 0 <
 
 /-- The `positivity` extension which identifies expressions of the form `a ^ (0:ℕ)`.
 This extension is run in addition to the general `a ^ b` extension (they are overlapping). -/
-@[positivity (_ : α) ^ (0:ℕ)]
+@[positivity _ ^ (0:ℕ)]
 def evalPowZeroNat : PositivityExt where eval {u α} _zα _pα e := do
   let .app (.app _ (a : Q($α))) _ ← withReducible (whnf e) | throwError "not ^"
   _ ← synthInstanceQ (q(OrderedSemiring $α) : Q(Type u))
@@ -265,7 +265,7 @@ def evalPowZeroNat : PositivityExt where eval {u α} _zα _pα e := do
 
 /-- The `positivity` extension which identifies expressions of the form `a ^ (b : ℕ)`,
 such that `positivity` successfully recognises both `a` and `b`. -/
-@[positivity (_ : α) ^ (_ : ℕ)]
+@[positivity _ ^ (_ : ℕ)]
 def evalPow : PositivityExt where eval {u α} zα pα e := do
   let .app (.app _ (a : Q($α))) (b : Q(ℕ)) ← withReducible (whnf e) | throwError "not ^"
   let result ← catchNone do
@@ -308,7 +308,7 @@ private theorem abs_pos_of_ne_zero {α : Type*} [AddGroup α] [LinearOrder α]
     [CovariantClass α α (·+·) (·≤·)] {a : α} : a ≠ 0 → 0 < |a| := abs_pos.mpr
 
 /-- The `positivity` extension which identifies expressions of the form `|a|`. -/
-@[positivity |(_ : α)|]
+@[positivity |_|]
 def evalAbs : PositivityExt where eval {u} (α : Q(Type u)) zα pα (e : Q($α)) := do
   let ~q(@abs _ (_) (_) $a) := e | throwError "not |·|"
   try

--- a/Mathlib/Tactic/Positivity/Core.lean
+++ b/Mathlib/Tactic/Positivity/Core.lean
@@ -19,19 +19,17 @@ The actual behavior is in `@[positivity]`-tagged definitions in `Tactic.Positivi
 and elsewhere.
 -/
 
-set_option autoImplicit true
-
 open Lean hiding Rat
 open Lean.Meta Qq Lean.Elab Term
 
 /-- Attribute for identifying `positivity` extensions. -/
 syntax (name := positivity) "positivity " term,+ : attr
 
-lemma ne_of_ne_of_eq' (hab : (a : α) ≠ c) (hbc : a = b) : b ≠ c := hbc ▸ hab
+lemma ne_of_ne_of_eq' {α : Sort*} {a c b : α} (hab : (a : α) ≠ c) (hbc : a = b) : b ≠ c := hbc ▸ hab
 
 namespace Mathlib.Meta.Positivity
 
-variable {α : Q(Type u)} (zα : Q(Zero $α)) (pα : Q(PartialOrder $α))
+variable {u : Level} {α : Q(Type u)} (zα : Q(Zero $α)) (pα : Q(PartialOrder $α))
 
 /-- The result of `positivity` running on an expression `e` of type `α`. -/
 inductive Strictness (e : Q($α)) where
@@ -42,7 +40,7 @@ inductive Strictness (e : Q($α)) where
   deriving Repr
 
 /-- Gives a generic description of the `positivity` result. -/
-def Strictness.toString : Strictness zα pα e → String
+def Strictness.toString {e : Q($α)} : Strictness zα pα e → String
   | positive _ => "positive"
   | nonnegative _ => "nonnegative"
   | nonzero _ => "nonzero"
@@ -119,28 +117,30 @@ initialize registerBuiltinAttribute {
     | _ => throwUnsupportedSyntax
 }
 
-lemma lt_of_le_of_ne' [PartialOrder A] :
+variable {A : Type*} {e : A}
+
+lemma lt_of_le_of_ne' {a b : A} [PartialOrder A] :
     (a : A) ≤ b → b ≠ a → a < b := fun h₁ h₂ => lt_of_le_of_ne h₁ h₂.symm
 
-lemma pos_of_isNat [StrictOrderedSemiring A]
+lemma pos_of_isNat {n : ℕ} [StrictOrderedSemiring A]
     (h : NormNum.IsNat e n) (w : Nat.ble 1 n = true) : 0 < (e : A) := by
   rw [NormNum.IsNat.to_eq h rfl]
   apply Nat.cast_pos.2
   simpa using w
 
-lemma nonneg_of_isNat [OrderedSemiring A]
+lemma nonneg_of_isNat {n : ℕ} [OrderedSemiring A]
     (h : NormNum.IsNat e n) : 0 ≤ (e : A) := by
   rw [NormNum.IsNat.to_eq h rfl]
   exact Nat.cast_nonneg n
 
-lemma nz_of_isNegNat [StrictOrderedRing A]
+lemma nz_of_isNegNat {n : ℕ} [StrictOrderedRing A]
     (h : NormNum.IsInt e (.negOfNat n)) (w : Nat.ble 1 n = true) : (e : A) ≠ 0 := by
   rw [NormNum.IsInt.neg_to_eq h rfl]
   simp only [ne_eq, neg_eq_zero]
   apply ne_of_gt
   simpa using w
 
-lemma pos_of_isRat [LinearOrderedRing A] :
+lemma pos_of_isRat {n : ℤ} {d : ℕ} [LinearOrderedRing A] :
     (NormNum.IsRat e n d) → (decide (0 < n)) → ((0 : A) < (e : A))
   | ⟨inv, eq⟩, h => by
     have pos_invOf_d : (0 < ⅟ (d : A)) := pos_invOf_of_invertible_cast d
@@ -148,11 +148,11 @@ lemma pos_of_isRat [LinearOrderedRing A] :
     rw [eq]
     exact mul_pos pos_n pos_invOf_d
 
-lemma nonneg_of_isRat [LinearOrderedRing A] :
+lemma nonneg_of_isRat {n : ℤ} {d : ℕ} [LinearOrderedRing A] :
     (NormNum.IsRat e n d) → (decide (n = 0)) → (0 ≤ (e : A))
   | ⟨inv, eq⟩, h => by rw [eq, of_decide_eq_true h]; simp
 
-lemma nz_of_isRat [LinearOrderedRing A] :
+lemma nz_of_isRat {n : ℤ} {d : ℕ} [LinearOrderedRing A] :
     (NormNum.IsRat e n d) → (decide (n < 0)) → ((e : A) ≠ 0)
   | ⟨inv, eq⟩, h => by
     have pos_invOf_d : (0 < ⅟ (d : A)) := pos_invOf_of_invertible_cast d
@@ -164,7 +164,7 @@ lemma nz_of_isRat [LinearOrderedRing A] :
 variable {zα pα} in
 /-- Converts a `MetaM Strictness` which can fail
 into one that never fails and returns `.none` instead. -/
-def catchNone (t : MetaM (Strictness zα pα e)) : MetaM (Strictness zα pα e) :=
+def catchNone {e : Q($α)} (t : MetaM (Strictness zα pα e)) : MetaM (Strictness zα pα e) :=
   try t catch e =>
     trace[Tactic.positivity.failure] "{e.toMessageData}"
     pure .none
@@ -172,7 +172,7 @@ def catchNone (t : MetaM (Strictness zα pα e)) : MetaM (Strictness zα pα e) 
 variable {zα pα} in
 /-- Converts a `MetaM Strictness` which can return `.none`
 into one which never returns `.none` but fails instead. -/
-def throwNone [Monad m] [Alternative m]
+def throwNone {m : Type → Type*} {e : Q($α)} [Monad m] [Alternative m]
     (t : m (Strictness zα pα e)) : m (Strictness zα pα e) := do
   match ← t with
   | .none => failure
@@ -296,7 +296,7 @@ variable {zα pα} in
 It assumes `t₁` has already been run for a result, and runs `t₂` and takes the best result.
 It will skip `t₂` if `t₁` is already a proof of `.positive`, and can also combine
 `.nonnegative` and `.nonzero` to produce a `.positive` result. -/
-def orElse (t₁ : Strictness zα pα e) (t₂ : MetaM (Strictness zα pα e)) :
+def orElse {e : Q($α)} (t₁ : Strictness zα pα e) (t₂ : MetaM (Strictness zα pα e)) :
     MetaM (Strictness zα pα e) := do
   match t₁ with
   | .none => catchNone t₂

--- a/Mathlib/Tactic/Relation/Trans.lean
+++ b/Mathlib/Tactic/Relation/Trans.lean
@@ -57,8 +57,8 @@ def _root_.Trans.simple {α : Sort u} {r : α → α → Sort v} {a b c : α} [T
 universe u v w in
 /-- Composition using the `Trans` class in the general case. -/
 def _root_.Trans.het {α β γ : Sort*} {a : α} {b : β} {c : γ}
-    {r : α → β → Sort u} {s : β → γ → Sort v} {t : outParam (α → γ → Sort w)}
-    [Trans r s t] : r a b → s b c → t a c := trans
+    {r : α → β → Sort u} {s : β → γ → Sort v} {t : outParam (α → γ → Sort w)} [Trans r s t] :
+    r a b → s b c → t a c := trans
 
 open Lean.Elab.Tactic
 

--- a/Mathlib/Tactic/Ring/RingNF.lean
+++ b/Mathlib/Tactic/Ring/RingNF.lean
@@ -18,16 +18,13 @@ such as `sin (x + y) + sin (y + x) = 2 * sin (x + y)`.
 
 -/
 
-set_option autoImplicit true
-
--- In this file we would like to be able to use multi-character auto-implicits.
-set_option relaxedAutoImplicit true
-
 namespace Mathlib.Tactic
 open Lean hiding Rat
 open Qq Meta
 
 namespace Ring
+
+variable {u : Level} {arg : Q(Type u)} {sα : Q(CommSemiring $arg)} {a : Q($arg)}
 
 /-- True if this represents an atomic expression. -/
 def ExBase.isAtom : ExBase sα a → Bool
@@ -111,7 +108,7 @@ def rewrite (parent : Expr) (root := true) : M Simp.Result :=
     let post := Simp.postDefault #[]
     (·.1) <$> Simp.main parent nctx.ctx (methods := { pre, post })
 
-variable [CommSemiring R]
+variable {R : Type*} [CommSemiring R] {n d : ℕ}
 
 theorem add_assoc_rev (a b c : R) : a + (b + c) = a + b + c := (add_assoc ..).symm
 theorem mul_assoc_rev (a b c : R) : a * (b * c) = a * b * c := (mul_assoc ..).symm
@@ -135,7 +132,7 @@ Runs a tactic in the `RingNF.M` monad, given initial data:
 * `x`: the tactic to run
 -/
 partial def M.run
-    (s : IO.Ref AtomM.State) (cfg : RingNF.Config) (x : M α) : MetaM α := do
+    {α : Type} (s : IO.Ref AtomM.State) (cfg : RingNF.Config) (x : M α) : MetaM α := do
   let ctx := {
     simpTheorems := #[← Elab.Tactic.simpOnlyBuiltins.foldlM (·.addConst ·) {}]
     congrTheorems := ← getSimpCongrTheorems

--- a/Mathlib/Tactic/ToExpr.lean
+++ b/Mathlib/Tactic/ToExpr.lean
@@ -16,21 +16,22 @@ that come from core Lean 4 that do not handle universe polymorphism.
 In addition, we provide some additional `ToExpr` instances for core definitions.
 -/
 
-set_option autoImplicit true
-
 section override
 namespace Lean
 
 attribute [-instance] Lean.instToExprOption
 
+set_option autoImplicit true in
 deriving instance ToExpr for Option
 
 attribute [-instance] Lean.instToExprList
 
+set_option autoImplicit true in
 deriving instance ToExpr for List
 
 attribute [-instance] Lean.instToExprArray
 
+universe u in
 instance {α : Type u} [ToExpr α] [ToLevel.{u}] : ToExpr (Array α) :=
   let type := toTypeExpr α
   { toExpr     := fun as => mkApp2 (mkConst ``List.toArray [toLevel.{u}]) type (toExpr as.toList)
@@ -38,6 +39,7 @@ instance {α : Type u} [ToExpr α] [ToLevel.{u}] : ToExpr (Array α) :=
 
 attribute [-instance] Lean.instToExprProd
 
+set_option autoImplicit true in
 deriving instance ToExpr for Prod
 
 deriving instance ToExpr for System.FilePath
@@ -50,8 +52,10 @@ open Lean
 
 deriving instance ToExpr for Int
 
+set_option autoImplicit true in
 deriving instance ToExpr for ULift
 
+universe u in
 /-- Hand-written instance since `PUnit` is a `Sort` rather than a `Type`. -/
 instance [ToLevel.{u}] : ToExpr PUnit.{u+1} where
   toExpr _ := mkConst ``PUnit.unit [toLevel.{u+1}]


### PR DESCRIPTION
After this, the only remaining uses are `Ring/Basic` (which is requires more work, hence shall get its own PR), `Sat/FromLRAT` and four single declarations in `ToExpr`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
