### PR TITLE
[Merged by Bors] - chore: (RingTheory/HahnSeries) : Move valuation material to new file

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -3693,6 +3693,7 @@ import Mathlib.RingTheory.HahnSeries.Basic
 import Mathlib.RingTheory.HahnSeries.Multiplication
 import Mathlib.RingTheory.HahnSeries.PowerSeries
 import Mathlib.RingTheory.HahnSeries.Summable
+import Mathlib.RingTheory.HahnSeries.Valuation
 import Mathlib.RingTheory.Henselian
 import Mathlib.RingTheory.HopfAlgebra
 import Mathlib.RingTheory.Ideal.AssociatedPrime

--- a/Mathlib/RingTheory/HahnSeries/Summable.lean
+++ b/Mathlib/RingTheory/HahnSeries/Summable.lean
@@ -10,19 +10,18 @@ import Mathlib.RingTheory.HahnSeries.Multiplication
 
 /-!
 # Summable families of Hahn Series
-If `Γ` is ordered and `R` has zero, then `HahnSeries Γ R` consists of formal series over `Γ` with
-coefficients in `R`, whose supports are partially well-ordered. With further structure on `R` and
-`Γ`, we can add further structure on `HahnSeries Γ R`.  We introduce a notion of summability for
-possibly infinite families of series.
+We introduce a notion of formal summability for families of Hahn series, and define a formal sum
+function. This theory is applied to characterize invertible Hahn series whose coefficients are in a
+commutative domain.
 
 ## Main Definitions
-  * A `HahnSeries.SummableFamily` is a family of Hahn series such that the union of their supports
-  is partially well-ordered and only finitely many are nonzero at any given coefficient.
+  * A `HahnSeries.SummableFamily` is a family of Hahn series such that the union of the supports
+  is partially well-ordered and only finitely many are nonzero at any given coefficient. Note that
+  this is different from `Summable` in the valuation topology, because there are topologically
+  summable families that do not satisfy the axioms of `HahnSeries.SummableFamily`, and formally
+  summable families whose sums do not converge topologically.
   * The formal sum, `HahnSeries.SummableFamily.hsum` can be bundled as a `LinearMap` via
-  `HahnSeries.SummableFamily.lsum`. Note that this is different from `Summable` in the valuation
-  topology, because there are topologically summable families that do not satisfy the axioms of
-  `HahnSeries.SummableFamily`, and formally summable families whose sums do not converge
-  topologically.
+  `HahnSeries.SummableFamily.lsum`.
 
 ## Main results
   * If `R` is a commutative domain, and `Γ` is a linearly ordered additive commutative group, then
@@ -72,7 +71,7 @@ variable (Γ) (R) [PartialOrder Γ] [AddCommMonoid R]
 /-- A family of Hahn series whose formal coefficient-wise sum is a Hahn series.  For each
 coefficient of the sum to be well-defined, we require that only finitely many series are nonzero at
 any given coefficient.  For the formal sum to be a Hahn series, we require that the union of the
-supports of the constituent series is well-founded. -/
+supports of the constituent series is partially well-ordered. -/
 structure SummableFamily (α : Type*) where
   /-- A parametrized family of Hahn series. -/
   toFun : α → HahnSeries Γ R

--- a/Mathlib/RingTheory/HahnSeries/Valuation.lean
+++ b/Mathlib/RingTheory/HahnSeries/Valuation.lean
@@ -18,7 +18,7 @@ admits an additive valuation given by `orderTop`.
     ordered.
 
 ## TODO
-  * Multiplicative versions?
+  * Multiplicative valuations
   * Add any API for Laurent series valuations that do not depend on `Γ = ℤ`.
 
 ## References

--- a/Mathlib/RingTheory/HahnSeries/Valuation.lean
+++ b/Mathlib/RingTheory/HahnSeries/Valuation.lean
@@ -1,0 +1,71 @@
+/-
+Copyright (c) 2021 Aaron Anderson. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Aaron Anderson
+-/
+import Mathlib.RingTheory.HahnSeries.Multiplication
+import Mathlib.RingTheory.Valuation.Basic
+
+#align_import ring_theory.hahn_series from "leanprover-community/mathlib"@"a484a7d0eade4e1268f4fb402859b6686037f965"
+
+/-!
+# Valuations on Hahn Series rings
+If `Γ` is a `LinearOrderedCancelAddCommMonoid` and `R` is a domain, then the domain `HahnSeries Γ R`
+admits an additive valuation given by `orderTop`.
+
+## Main Definitions
+  * `HahnSeries.addVal Γ R` defines an `AddValuation` on `HahnSeries Γ R` when `Γ` is linearly
+    ordered.
+
+## TODO
+  * Multiplicative versions?
+  * Add any API for Laurent series valuations that do not depend on `Γ = ℤ`.
+
+## References
+- [J. van der Hoeven, *Operators on Generalized Power Series*][van_der_hoeven]
+-/
+
+set_option linter.uppercaseLean3 false
+
+noncomputable section
+
+variable {Γ R : Type*}
+
+namespace HahnSeries
+
+section Valuation
+
+variable (Γ R) [LinearOrderedCancelAddCommMonoid Γ] [Ring R] [IsDomain R]
+
+/-- The additive valuation on `HahnSeries Γ R`, returning the smallest index at which
+  a Hahn Series has a nonzero coefficient, or `⊤` for the 0 series.  -/
+def addVal : AddValuation (HahnSeries Γ R) (WithTop Γ) :=
+  AddValuation.of orderTop orderTop_zero (orderTop_one) (fun x y => min_orderTop_le_orderTop_add)
+  fun x y => by
+    by_cases hx : x = 0; · simp [hx]
+    by_cases hy : y = 0; · simp [hy]
+    rw [← order_eq_orderTop_of_ne hx, ← order_eq_orderTop_of_ne hy,
+      ← order_eq_orderTop_of_ne (mul_ne_zero hx hy), ← WithTop.coe_add, WithTop.coe_eq_coe,
+      order_mul hx hy]
+#align hahn_series.add_val HahnSeries.addVal
+
+variable {Γ} {R}
+
+theorem addVal_apply {x : HahnSeries Γ R} :
+    addVal Γ R x = x.orderTop :=
+  AddValuation.of_apply _
+#align hahn_series.add_val_apply HahnSeries.addVal_apply
+
+@[simp]
+theorem addVal_apply_of_ne {x : HahnSeries Γ R} (hx : x ≠ 0) : addVal Γ R x = x.order :=
+  addVal_apply.trans (order_eq_orderTop_of_ne hx).symm
+#align hahn_series.add_val_apply_of_ne HahnSeries.addVal_apply_of_ne
+
+theorem addVal_le_of_coeff_ne_zero {x : HahnSeries Γ R} {g : Γ} (h : x.coeff g ≠ 0) :
+    addVal Γ R x ≤ g :=
+  orderTop_le_of_coeff_ne_zero h
+#align hahn_series.add_val_le_of_coeff_ne_zero HahnSeries.addVal_le_of_coeff_ne_zero
+
+end Valuation
+
+end HahnSeries


### PR DESCRIPTION
Valuation-theoretic material is moved to a separate file.  Also, minor docstrings adjustments.

---

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
