### PR TITLE
[Merged by Bors] - feat (RingTheory/Binomial): Chu-Vandermonde identity

### DIFF
--- a/Mathlib/Algebra/Polynomial/Smeval.lean
+++ b/Mathlib/Algebra/Polynomial/Smeval.lean
@@ -5,8 +5,6 @@ Authors: Scott Carnahan
 -/
 import Mathlib.Algebra.Group.NatPowAssoc
 import Mathlib.Algebra.Polynomial.AlgebraMap
-import Mathlib.Algebra.Polynomial.Induction
-import Mathlib.Algebra.Polynomial.Eval
 
 /-!
 # Scalar-multiple polynomial evaluation
@@ -291,6 +289,43 @@ theorem smeval_comp : (p.comp q).smeval x  = p.smeval (q.smeval x) := by
     simp [smeval_monomial, smeval_C_mul, smeval_pow]
 
 end NatPowAssoc
+
+section Commute
+
+variable (R : Type*) [Semiring R] (p q : R[X]) {S : Type*} [Semiring S]
+  [Module R S] [IsScalarTower R S S] [SMulCommClass R S S] {x y : S}
+
+theorem smeval_commute_left (hc : Commute x y) : Commute (p.smeval x) y := by
+  induction p using Polynomial.induction_on' with
+  | h_add r s hr hs => exact (smeval_add R r s x) ▸ Commute.add_left hr hs
+  | h_monomial n a =>
+    simp only [smeval_monomial]
+    refine Commute.smul_left ?_ a
+    induction n with
+    | zero => simp only [npow_zero, Commute.one_left]
+    | succ n ih =>
+      refine (commute_iff_eq (x ^ (n + 1)) y).mpr ?_
+      rw [commute_iff_eq (x ^ n) y] at ih
+      rw [pow_succ, ← mul_assoc, ← ih]
+      exact Commute.right_comm hc (x ^ n)
+
+theorem smeval_commute (hc : Commute x y) : Commute (p.smeval x) (q.smeval y) := by
+  induction p using Polynomial.induction_on' with
+  | h_add r s hr hs => exact (smeval_add R r s x) ▸ Commute.add_left hr hs
+  | h_monomial n a =>
+    simp only [smeval_monomial]
+    refine Commute.smul_left ?_ a
+    induction n with
+    | zero => simp only [npow_zero, Commute.one_left]
+    | succ n ih =>
+      refine (commute_iff_eq (x ^ (n + 1)) (q.smeval y)).mpr ?_
+      rw [commute_iff_eq (x ^ n) (q.smeval y)] at ih
+      have hxq : x * q.smeval y = q.smeval y * x := by
+        refine (commute_iff_eq x (q.smeval y)).mp ?_
+        exact Commute.symm (smeval_commute_left R q (Commute.symm hc))
+      rw [pow_succ, ← mul_assoc, ← ih, mul_assoc, hxq, mul_assoc]
+
+end Commute
 
 section Algebra
 

--- a/Mathlib/RingTheory/Binomial.lean
+++ b/Mathlib/RingTheory/Binomial.lean
@@ -344,6 +344,8 @@ open Polynomial
 
 variable {R : Type*}
 
+section
+
 /-- The binomial coefficient `choose r n` generalizes the natural number `choose` function,
   interpreted in terms of choosing without replacement. -/
 def choose [AddCommGroupWithOne R] [Pow R ℕ] [BinomialRing R] (r : R) (n : ℕ) : R :=
@@ -449,6 +451,54 @@ theorem choose_add_smul_choose [NatPowAssoc R] (r : R) (n k : ℕ) :
     (Nat.choose (n + k) k) • choose (r + k) (n + k) = choose (r + k) k * choose r n := by
   rw [choose_smul_choose (r + k) (n + k) k (Nat.le_add_left k n), Nat.add_sub_cancel,
     add_sub_cancel_right]
+
+end
+
+/-- Pochhammer version of Chu-Vandermonde identity -/
+theorem descPochhammer_smeval_add [Ring R] {r s : R} (k : ℕ) (h: Commute r s) :
+    (descPochhammer ℤ k).smeval (r + s) = ∑ ij ∈ Finset.HasAntidiagonal.antidiagonal k,
+    Nat.choose k ij.1 * ((descPochhammer ℤ ij.1).smeval r * (descPochhammer ℤ ij.2).smeval s) := by
+  induction k with
+  | zero => simp [descPochhammer_zero, Finset.Nat.antidiagonal_zero, Finset.sum_singleton]
+  | succ k ih =>
+    rw [descPochhammer_succ_right, mul_comm, smeval_mul, Finset.sum_antidiagonal_choose_succ_mul
+      fun i j => ((descPochhammer ℤ i).smeval r * (descPochhammer ℤ j).smeval s),
+      ← Finset.sum_add_distrib, smeval_sub, smeval_X, smeval_natCast, pow_zero, pow_one, ih,
+      Finset.mul_sum]
+    refine Finset.sum_congr rfl ?_
+    intro ij hij -- try to move descPochhammers to right, gather multipliers.
+    have hdx : (descPochhammer ℤ ij.1).smeval r * (X - (ij.2 : ℤ[X])).smeval s =
+        (X - (ij.2 : ℤ[X])).smeval s * (descPochhammer ℤ ij.1).smeval r := by
+      refine (commute_iff_eq ((descPochhammer ℤ ij.1).smeval r)
+        ((X - (ij.2 : ℤ[X])).smeval s)).mp ?_
+      exact smeval_commute ℤ (descPochhammer ℤ ij.1) (X - (ij.2 : ℤ[X])) h
+    rw [descPochhammer_succ_right, mul_comm, smeval_mul, descPochhammer_succ_right, mul_comm,
+      smeval_mul, ← mul_assoc ((descPochhammer ℤ ij.1).smeval r), hdx]
+    simp only [mul_assoc _ ((descPochhammer ℤ ij.1).smeval r) _,
+      ← mul_assoc _ _ (((descPochhammer ℤ ij.1).smeval r) * _)]
+    have hl : (r + s - k • 1) * (k.choose ij.1) = (k.choose ij.1) * (X - (ij.2 : ℤ[X])).smeval s +
+        ↑(k.choose ij.2) * (X - (ij.1 : ℤ[X])).smeval r := by
+      simp only [smeval_sub, smeval_X, pow_one, smeval_natCast, pow_zero, ← mul_sub]
+      rw [← Nat.choose_symm_of_eq_add (List.Nat.mem_antidiagonal.mp hij).symm,
+        (List.Nat.mem_antidiagonal.mp hij).symm, ← mul_add, Nat.cast_comm, add_smul]
+      abel_nf
+    rw [hl, ← add_mul]
+
+/-- The Chu-Vandermonde identity for binomial rings -/
+theorem add_choose_eq [Ring R] [BinomialRing R] {r s : R} (k : ℕ) (h : Commute r s) :
+    choose (r + s) k =
+      ∑ ij ∈ Finset.HasAntidiagonal.antidiagonal k, choose r ij.1 * choose s ij.2 := by
+  refine nsmul_right_injective (Nat.factorial k) (Nat.factorial_ne_zero k) ?_
+  simp only
+  rw [← descPochhammer_eq_factorial_smul_choose, Finset.smul_sum, descPochhammer_smeval_add _ h]
+  refine Finset.sum_congr rfl ?_
+  intro x hx
+  rw [← Nat.choose_mul_factorial_mul_factorial (Finset.antidiagonal.fst_le hx),
+    tsub_eq_of_eq_add_rev (List.Nat.mem_antidiagonal.mp hx).symm, mul_assoc, nsmul_eq_mul,
+    Nat.cast_mul, Nat.cast_mul, ← mul_assoc _ (x.1.factorial : R), mul_assoc _ (x.2.factorial : R),
+    ← mul_assoc (x.2.factorial : R), Nat.cast_commute x.2.factorial,
+    mul_assoc _ (x.2.factorial : R), ← nsmul_eq_mul x.2.factorial]
+  simp [mul_assoc, descPochhammer_eq_factorial_smul_choose]
 
 end Ring
 

--- a/Mathlib/RingTheory/Binomial.lean
+++ b/Mathlib/RingTheory/Binomial.lean
@@ -26,13 +26,26 @@ integers is injective, and demand that the evaluation of the ascending Pochhamme
 because for `r` a natural number, it is the number of multisets of cardinality `k` taken from a type
 of cardinality `n`.
 
+## Definitions
+
+* `BinomialRing`: a mixin class specifying a suitable `multichoose` function.
+* `Ring.multichoose`: the quotient of an ascending Pochhammer evaluation by a factorial.
+* `Ring.choose`: the quotient of a descending Pochhammer evaluation by a factorial.
+
+## Results
+
+* Basic results with choose and multichoose, e.g., `choose_zero_right`
+* Relations between choose and multichoose, negated input.
+* Fundamental recursion: `choose_succ_succ`
+* Chu-Vandermonde identity: `add_choose_eq`
+* Pochhammer API
+
 ## References
 
 * [J. Elliott, *Binomial rings, integer-valued polynomials, and λ-rings*][elliott2006binomial]
 
 ## TODO
 
-* Generalized versions of basic identities of Nat.choose.
 Further results in Elliot's paper:
 * A CommRing is binomial if and only if it admits a λ-ring structure with trivial Adams operations.
 * The free commutative binomial ring on a set `X` is the ring of integer-valued polynomials in the
@@ -454,18 +467,19 @@ theorem choose_add_smul_choose [NatPowAssoc R] (r : R) (n k : ℕ) :
 
 end
 
+open Finset
+
 /-- Pochhammer version of Chu-Vandermonde identity -/
 theorem descPochhammer_smeval_add [Ring R] {r s : R} (k : ℕ) (h: Commute r s) :
-    (descPochhammer ℤ k).smeval (r + s) = ∑ ij ∈ Finset.HasAntidiagonal.antidiagonal k,
+    (descPochhammer ℤ k).smeval (r + s) = ∑ ij ∈ antidiagonal k,
     Nat.choose k ij.1 * ((descPochhammer ℤ ij.1).smeval r * (descPochhammer ℤ ij.2).smeval s) := by
   induction k with
-  | zero => simp [descPochhammer_zero, Finset.Nat.antidiagonal_zero, Finset.sum_singleton]
+  | zero => simp
   | succ k ih =>
-    rw [descPochhammer_succ_right, mul_comm, smeval_mul, Finset.sum_antidiagonal_choose_succ_mul
+    rw [descPochhammer_succ_right, mul_comm, smeval_mul, sum_antidiagonal_choose_succ_mul
       fun i j => ((descPochhammer ℤ i).smeval r * (descPochhammer ℤ j).smeval s),
-      ← Finset.sum_add_distrib, smeval_sub, smeval_X, smeval_natCast, pow_zero, pow_one, ih,
-      Finset.mul_sum]
-    refine Finset.sum_congr rfl ?_
+      ← sum_add_distrib, smeval_sub, smeval_X, smeval_natCast, pow_zero, pow_one, ih, mul_sum]
+    refine sum_congr rfl ?_
     intro ij hij -- try to move descPochhammers to right, gather multipliers.
     have hdx : (descPochhammer ℤ ij.1).smeval r * (X - (ij.2 : ℤ[X])).smeval s =
         (X - (ij.2 : ℤ[X])).smeval s * (descPochhammer ℤ ij.1).smeval r := by
@@ -487,13 +501,13 @@ theorem descPochhammer_smeval_add [Ring R] {r s : R} (k : ℕ) (h: Commute r s) 
 /-- The Chu-Vandermonde identity for binomial rings -/
 theorem add_choose_eq [Ring R] [BinomialRing R] {r s : R} (k : ℕ) (h : Commute r s) :
     choose (r + s) k =
-      ∑ ij ∈ Finset.HasAntidiagonal.antidiagonal k, choose r ij.1 * choose s ij.2 := by
+      ∑ ij ∈ antidiagonal k, choose r ij.1 * choose s ij.2 := by
   refine nsmul_right_injective (Nat.factorial k) (Nat.factorial_ne_zero k) ?_
   simp only
-  rw [← descPochhammer_eq_factorial_smul_choose, Finset.smul_sum, descPochhammer_smeval_add _ h]
-  refine Finset.sum_congr rfl ?_
+  rw [← descPochhammer_eq_factorial_smul_choose, smul_sum, descPochhammer_smeval_add _ h]
+  refine sum_congr rfl ?_
   intro x hx
-  rw [← Nat.choose_mul_factorial_mul_factorial (Finset.antidiagonal.fst_le hx),
+  rw [← Nat.choose_mul_factorial_mul_factorial (antidiagonal.fst_le hx),
     tsub_eq_of_eq_add_rev (List.Nat.mem_antidiagonal.mp hx).symm, mul_assoc, nsmul_eq_mul,
     Nat.cast_mul, Nat.cast_mul, ← mul_assoc _ (x.1.factorial : R), mul_assoc _ (x.2.factorial : R),
     ← mul_assoc (x.2.factorial : R), Nat.cast_commute x.2.factorial,


### PR DESCRIPTION
A general version of Chu-Vandermonde: If `r` and `s` are commuting elements of a binomial ring, then `choose (r + s) k` equals the sum over `ij in antidiagonal k` of `choose r ij.1 * choose s ij.2`.

---

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
