### PR TITLE
[Merged by Bors] - docs: fix bibitem of `Proofs from THE BOOK`

### DIFF
--- a/docs/references.bib
+++ b/docs/references.bib
@@ -44,12 +44,16 @@
   doi           = {10.23638/LMCS-15(1:20)2019}
 }
 
-@Article{         aigner1999proofs,
-  author        = {Aigner, Martin and Ziegler, G{\"u}nter M},
-  title         = {Proofs from THE BOOK},
-  journal       = {Berlin. Germany},
-  year          = {1999},
-  publisher     = {Springer}
+@Book{            aigner1999proofs,
+  author        = {Aigner, Martin and Ziegler, G{\"u}nter M.},
+  title         = {Proofs from {THE} {BOOK}},
+  isbn          = {3-540-63698-6},
+  year          = {1998},
+  publisher     = {Berlin: Springer},
+  language      = {English},
+  keywords      = {00A05,11-01,05-01,52-01,26-01},
+  zbmath        = {1188564},
+  zbl           = {0905.00001}
 }
 
 @Misc{            aignerhorev2012infinite,


### PR DESCRIPTION
It was erroneously marked as `Article`, but it in in fact a book. The bibitem is corrected from the corresponding zbMath entry.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
