### PR TITLE
[Merged by Bors] - feat(Polynomial/AlgebraMap): add `mapAlgHom`

### DIFF
--- a/Mathlib/Algebra/Polynomial/AlgebraMap.lean
+++ b/Mathlib/Algebra/Polynomial/AlgebraMap.lean
@@ -195,6 +195,7 @@ theorem mapAlgHom_comp (C : Type z) [Semiring C] [Algebra R C] (f : B →ₐ[R] 
   simp [AlgHom.comp_algebraMap, map_map]
   congr
 
+/-- If `A` and `B` are isomorphic as `R`-algebras, then so are their polynomial rings -/
 def mapAlgEquiv (f : A ≃ₐ[R] B) : Polynomial A ≃ₐ[R] Polynomial B :=
   AlgEquiv.ofAlgHom (mapAlgHom f.toAlgHom) (mapAlgHom f.symm.toAlgHom) (by simp) (by simp)
 

--- a/Mathlib/Algebra/Polynomial/AlgebraMap.lean
+++ b/Mathlib/Algebra/Polynomial/AlgebraMap.lean
@@ -199,7 +199,7 @@ def mapAlgEquiv (f : A ≃ₐ[R] B) : Polynomial A ≃ₐ[R] Polynomial B :=
   AlgEquiv.ofAlgHom (mapAlgHom f.toAlgHom) (mapAlgHom f.symm.toAlgHom) (by simp) (by simp)
 
 theorem mapAlgHom_eq_eval₂AlgHom'_CAlgHom (f : A →ₐ[R] B) : mapAlgHom f = eval₂AlgHom'
-    (CAlgHom.comp f) X (by intro a ; simp ; exact (commute_X (C (f a))).symm) := by
+    (CAlgHom.comp f) X (fun a => (commute_X (C (f a))).symm) := by
   apply AlgHom.ext ; intro x ; congr
 
 end Map

--- a/Mathlib/Algebra/Polynomial/AlgebraMap.lean
+++ b/Mathlib/Algebra/Polynomial/AlgebraMap.lean
@@ -200,7 +200,9 @@ def mapAlgEquiv (f : A ≃ₐ[R] B) : Polynomial A ≃ₐ[R] Polynomial B :=
 
 theorem mapAlgHom_eq_eval₂AlgHom'_CAlgHom (f : A →ₐ[R] B) : mapAlgHom f = eval₂AlgHom'
     (CAlgHom.comp f) X (fun a => (commute_X (C (f a))).symm) := by
-  apply AlgHom.ext ; intro x ; congr
+  apply AlgHom.ext
+  intro x
+  congr
 
 end Map
 

--- a/Mathlib/Algebra/Polynomial/AlgebraMap.lean
+++ b/Mathlib/Algebra/Polynomial/AlgebraMap.lean
@@ -195,14 +195,35 @@ theorem mapAlgHom_comp (C : Type z) [Semiring C] [Algebra R C] (f : B →ₐ[R] 
   simp [AlgHom.comp_algebraMap, map_map]
   congr
 
-/-- If `A` and `B` are isomorphic as `R`-algebras, then so are their polynomial rings -/
-def mapAlgEquiv (f : A ≃ₐ[R] B) : Polynomial A ≃ₐ[R] Polynomial B :=
-  AlgEquiv.ofAlgHom (mapAlgHom f.toAlgHom) (mapAlgHom f.symm.toAlgHom) (by simp) (by simp)
-
 theorem mapAlgHom_eq_eval₂AlgHom'_CAlgHom (f : A →ₐ[R] B) : mapAlgHom f = eval₂AlgHom'
     (CAlgHom.comp f) X (fun a => (commute_X (C (f a))).symm) := by
   apply AlgHom.ext
   intro x
+  congr
+
+/-- If `A` and `B` are isomorphic as `R`-algebras, then so are their polynomial rings -/
+def mapAlgEquiv (f : A ≃ₐ[R] B) : Polynomial A ≃ₐ[R] Polynomial B :=
+  AlgEquiv.ofAlgHom (mapAlgHom f.toAlgHom) (mapAlgHom f.symm.toAlgHom) (by simp) (by simp)
+
+@[simp]
+theorem coe_mapAlgEquiv (f : A ≃ₐ[R] B) : ⇑(mapAlgEquiv f) = map f :=
+  rfl
+
+@[simp]
+theorem mapAlgEquiv_id : mapAlgEquiv (@AlgEquiv.refl R A _ _ _) = AlgEquiv.refl :=
+  AlgEquiv.ext fun _x => map_id
+
+@[simp]
+theorem mapAlgEquiv_coe_ringHom (f : A ≃ₐ[R] B) :
+    ↑(mapAlgEquiv f : _ ≃ₐ[R] Polynomial B) = (mapRingHom ↑f : Polynomial A →+* Polynomial B) :=
+  rfl
+
+@[simp]
+theorem mapAlgEquiv_comp (C : Type z) [Semiring C] [Algebra R C] (f : A ≃ₐ[R] B) (g : B ≃ₐ[R] C) :
+    (mapAlgEquiv f).trans (mapAlgEquiv g) = mapAlgEquiv (f.trans g) := by
+  apply AlgEquiv.ext
+  intro x
+  simp [AlgEquiv.trans_apply, map_map]
   congr
 
 end Map

--- a/Mathlib/Algebra/Polynomial/AlgebraMap.lean
+++ b/Mathlib/Algebra/Polynomial/AlgebraMap.lean
@@ -157,14 +157,6 @@ set_option linter.uppercaseLean3 false in
 @[deprecated (since := "2024-04-17")]
 alias eval₂_int_castRingHom_X := eval₂_intCastRingHom_X
 
-end CommSemiring
-
-section aeval
-
-variable [CommSemiring R] [Semiring A] [CommSemiring A'] [Semiring B]
-variable [Algebra R A] [Algebra R A'] [Algebra R B]
-variable {p q : R[X]} (x : A)
-
 /-- `Polynomial.eval₂` as an `AlgHom` for noncommutative algebras.
 
 This is `Polynomial.eval₂RingHom'` for `AlgHom`s. -/
@@ -172,6 +164,53 @@ This is `Polynomial.eval₂RingHom'` for `AlgHom`s. -/
 def eval₂AlgHom' (f : A →ₐ[R] B) (b : B) (hf : ∀ a, Commute (f a) b) : A[X] →ₐ[R] B where
   toRingHom := eval₂RingHom' f b hf
   commutes' _ := (eval₂_C _ _).trans (f.commutes _)
+
+section Map
+
+/-- `Polynomial.map` as an `AlgHom` for noncommutative algebras.
+
+  This is the algebra version of `Polynomial.mapRingHom`. -/
+def mapAlgHom (f : A →ₐ[R] B) : Polynomial A →ₐ[R] Polynomial B where
+  toRingHom := mapRingHom f.toRingHom
+  commutes' := by simp
+
+@[simp]
+theorem coe_mapAlgHom (f : A →ₐ[R] B) : ⇑(mapAlgHom f) = map f :=
+  rfl
+
+@[simp]
+theorem mapAlgHom_id : mapAlgHom (AlgHom.id R A) = AlgHom.id R (Polynomial A) :=
+  AlgHom.ext fun _x => map_id
+
+@[simp]
+theorem mapAlgHom_coe_ringHom (f : A →ₐ[R] B) :
+    ↑(mapAlgHom f : _ →ₐ[R] Polynomial B) = (mapRingHom ↑f : Polynomial A →+* Polynomial B) :=
+  rfl
+
+@[simp]
+theorem mapAlgHom_comp (C : Type z) [Semiring C] [Algebra R C] (f : B →ₐ[R] C) (g : A →ₐ[R] B) :
+    (mapAlgHom f).comp (mapAlgHom g) = mapAlgHom (f.comp g) := by
+  apply AlgHom.ext
+  intro x
+  simp [AlgHom.comp_algebraMap, map_map]
+  congr
+
+def mapAlgEquiv (f : A ≃ₐ[R] B) : Polynomial A ≃ₐ[R] Polynomial B :=
+  AlgEquiv.ofAlgHom (mapAlgHom f.toAlgHom) (mapAlgHom f.symm.toAlgHom) (by simp) (by simp)
+
+theorem mapAlgHom_eq_eval₂AlgHom'_CAlgHom (f : A →ₐ[R] B) : mapAlgHom f = eval₂AlgHom'
+    (CAlgHom.comp f) X (by intro a ; simp ; exact (commute_X (C (f a))).symm) := by
+  apply AlgHom.ext ; intro x ; congr
+
+end Map
+
+end CommSemiring
+
+section aeval
+
+variable [CommSemiring R] [Semiring A] [CommSemiring A'] [Semiring B]
+variable [Algebra R A] [Algebra R A'] [Algebra R B]
+variable {p q : R[X]} (x : A)
 
 /-- Given a valuation `x` of the variable in an `R`-algebra `A`, `aeval R A x` is
 the unique `R`-algebra homomorphism from `R[X]` to `A` sending `X` to `x`.


### PR DESCRIPTION
Add `Polynomial.mapAlgHom` as an algebra homomorphism between two polynomial rings, extending `Polynomial.mapRingHom`. Provide supporting theorems for `mapAlgHom`.

Moved `Polynomial.eval₂AlgHom'` to earlier in `AlgebraMap.lean` , so that I can provide a theorem linking `mapAlgHom` and `eval₂AlgHom'`, without having to put `mapAlgHom` stuff after `aeval`.

---

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
