### PR TITLE
[Merged by Bors] - feat: missing Nat.card lemmas

### DIFF
--- a/Mathlib/SetTheory/Cardinal/Finite.lean
+++ b/Mathlib/SetTheory/Cardinal/Finite.lean
@@ -94,6 +94,21 @@ theorem card_eq_of_bijective (f : α → β) (hf : Function.Bijective f) : Nat.c
   card_congr (Equiv.ofBijective f hf)
 #align nat.card_eq_of_bijective Nat.card_eq_of_bijective
 
+protected theorem bijective_iff_injective_and_card [Fintype β] (f : α → β) :
+    Bijective f ↔ Injective f ∧ Nat.card α = Nat.card β := by
+  -- Note this proof is a bit convoluted because we don’t assume `Fintype α` but derive it
+  -- in both branches
+  constructor
+  · intro h
+    have : Fintype α := Fintype.ofInjective f h.1
+    rw [Fintype.bijective_iff_injective_and_card] at h
+    rwa [card_eq_fintype_card, card_eq_fintype_card]
+  · intro ⟨h, h'⟩
+    have : Fintype α := Fintype.ofInjective f h
+    rw [card_eq_fintype_card, card_eq_fintype_card] at h'
+    rw [Fintype.bijective_iff_injective_and_card]
+    exact ⟨h, h'⟩
+
 theorem card_eq_of_equiv_fin {α : Type*} {n : ℕ} (f : α ≃ Fin n) : Nat.card α = n := by
   simpa only [card_eq_fintype_card, Fintype.card_fin] using card_congr f
 #align nat.card_eq_of_equiv_fin Nat.card_eq_of_equiv_fin
@@ -154,6 +169,10 @@ theorem card_unique [Unique α] : Nat.card α = 1 :=
 theorem card_eq_one_iff_unique : Nat.card α = 1 ↔ Subsingleton α ∧ Nonempty α :=
   Cardinal.toNat_eq_one_iff_unique
 #align nat.card_eq_one_iff_unique Nat.card_eq_one_iff_unique
+
+theorem card_eq_one_iff_exists : Nat.card α = 1 ↔ ∃ x : α, ∀ y : α, y = x := by
+  rw [card_eq_one_iff_unique]
+  exact ⟨fun  ⟨s, ⟨a⟩⟩ ↦ ⟨a, fun x ↦ s.elim x a⟩, fun ⟨x, h⟩ ↦ ⟨subsingleton_of_forall_eq x h, ⟨x⟩⟩⟩
 
 theorem card_eq_two_iff : Nat.card α = 2 ↔ ∃ x y : α, x ≠ y ∧ {x, y} = @Set.univ α :=
   toNat_eq_ofNat.trans mk_eq_two_iff

--- a/Mathlib/SetTheory/Cardinal/Finite.lean
+++ b/Mathlib/SetTheory/Cardinal/Finite.lean
@@ -109,6 +109,11 @@ protected theorem bijective_iff_injective_and_card [Fintype β] (f : α → β) 
     rw [Fintype.bijective_iff_injective_and_card]
     exact ⟨h, h'⟩
 
+theorem _root_.Function.Injective.bijective_of_nat_card_le [Fintype β] {f : α → β}
+    (inj : Injective f) (hc : Nat.card β ≤ Nat.card α) : Bijective f :=
+  (Nat.bijective_iff_injective_and_card f).mpr
+    ⟨inj, hc.antisymm (card_le_card_of_injective f inj) |>.symm⟩
+
 theorem card_eq_of_equiv_fin {α : Type*} {n : ℕ} (f : α ≃ Fin n) : Nat.card α = n := by
   simpa only [card_eq_fintype_card, Fintype.card_fin] using card_congr f
 #align nat.card_eq_of_equiv_fin Nat.card_eq_of_equiv_fin


### PR DESCRIPTION
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
