### PR TITLE
[Merged by Bors] - feat(Analysis/Analytic/Basic): add missing `AnalyticOn.neg` lemma

### DIFF
--- a/Mathlib/Analysis/Analytic/Basic.lean
+++ b/Mathlib/Analysis/Analytic/Basic.lean
@@ -617,6 +617,10 @@ theorem AnalyticOn.add {s : Set E} (hf : AnalyticOn 𝕜 f s) (hg : AnalyticOn �
   fun z hz => (hf z hz).add (hg z hz)
 #align analytic_on.add AnalyticOn.add
 
+theorem AnalyticOn.neg {s : Set E} (hf : AnalyticOn 𝕜 f s) :
+    AnalyticOn 𝕜 (- f) s :=
+  fun z hz => (hf z hz).neg
+
 theorem AnalyticOn.sub {s : Set E} (hf : AnalyticOn 𝕜 f s) (hg : AnalyticOn 𝕜 g s) :
     AnalyticOn 𝕜 (f - g) s :=
   fun z hz => (hf z hz).sub (hg z hz)

--- a/Mathlib/Analysis/Analytic/Basic.lean
+++ b/Mathlib/Analysis/Analytic/Basic.lean
@@ -617,8 +617,8 @@ theorem AnalyticOn.add {s : Set E} (hf : AnalyticOn 𝕜 f s) (hg : AnalyticOn �
   fun z hz => (hf z hz).add (hg z hz)
 #align analytic_on.add AnalyticOn.add
 
-theorem AnalyticOn.neg {s : Set E} (hf : AnalyticOn 𝕜 f s) :
-    AnalyticOn 𝕜 (-f) s := fun z hz ↦ (hf z hz).neg
+theorem AnalyticOn.neg {s : Set E} (hf : AnalyticOn 𝕜 f s) : AnalyticOn 𝕜 (-f) s :=
+  fun z hz ↦ (hf z hz).neg
 
 theorem AnalyticOn.sub {s : Set E} (hf : AnalyticOn 𝕜 f s) (hg : AnalyticOn 𝕜 g s) :
     AnalyticOn 𝕜 (f - g) s :=

--- a/Mathlib/Analysis/Analytic/Basic.lean
+++ b/Mathlib/Analysis/Analytic/Basic.lean
@@ -618,8 +618,7 @@ theorem AnalyticOn.add {s : Set E} (hf : AnalyticOn 𝕜 f s) (hg : AnalyticOn �
 #align analytic_on.add AnalyticOn.add
 
 theorem AnalyticOn.neg {s : Set E} (hf : AnalyticOn 𝕜 f s) :
-    AnalyticOn 𝕜 (-f) s :=
-  fun z hz => (hf z hz).neg
+    AnalyticOn 𝕜 (-f) s := fun z hz ↦ (hf z hz).neg
 
 theorem AnalyticOn.sub {s : Set E} (hf : AnalyticOn 𝕜 f s) (hg : AnalyticOn 𝕜 g s) :
     AnalyticOn 𝕜 (f - g) s :=

--- a/Mathlib/Analysis/Analytic/Basic.lean
+++ b/Mathlib/Analysis/Analytic/Basic.lean
@@ -618,7 +618,7 @@ theorem AnalyticOn.add {s : Set E} (hf : AnalyticOn 𝕜 f s) (hg : AnalyticOn �
 #align analytic_on.add AnalyticOn.add
 
 theorem AnalyticOn.neg {s : Set E} (hf : AnalyticOn 𝕜 f s) :
-    AnalyticOn 𝕜 (- f) s :=
+    AnalyticOn 𝕜 (-f) s :=
   fun z hz => (hf z hz).neg
 
 theorem AnalyticOn.sub {s : Set E} (hf : AnalyticOn 𝕜 f s) (hg : AnalyticOn 𝕜 g s) :


### PR DESCRIPTION
Add missing `AnalyticOn.neg` lemma.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
