### PR TITLE
[Merged by Bors] - doc(Tactic): add remaining missing module docstrings

### DIFF
--- a/Mathlib/Tactic/ApplyWith.lean
+++ b/Mathlib/Tactic/ApplyWith.lean
@@ -6,12 +6,18 @@ Authors: Mario Carneiro
 import Lean.Elab.Eval
 import Lean.Elab.Tactic.ElabTerm
 
+/-!
+# The `applyWith` tactic
+The `applyWith` tactic is like `apply`, but allows passing a custom configuration to the underlying
+`apply` operation.
+-/
+
 namespace Mathlib.Tactic
 open Lean Meta Elab Tactic Term
 
 /--
 `apply (config := cfg) e` is like `apply e` but allows you to provide a configuration
-`cfg : ApplyConfig` to pass to the underlying apply operation.
+`cfg : ApplyConfig` to pass to the underlying `apply` operation.
 -/
 elab (name := applyWith) "apply" " (" &"config" " := " cfg:term ") " e:term : tactic => do
   let cfg ← unsafe evalTerm ApplyConfig (mkConst ``ApplyConfig) cfg

--- a/Mathlib/Tactic/Basic.lean
+++ b/Mathlib/Tactic/Basic.lean
@@ -11,6 +11,18 @@ import Mathlib.Tactic.Lemma
 import Mathlib.Tactic.TypeStar
 import Mathlib.Tactic.Linter.OldObtain
 
+/-!
+# Basic tactics and utilities for tactic writing
+
+This file defines some basic utilities for tactic writing, and also
+- the `introv` tactic, which allows the user to automatically introduce the variables of a theorem
+and explicitly name the non-dependent hypotheses,
+- an `assumption` macro, calling the `assumption` tactic on all goals
+- the tactics `match_target`, `clear_aux_decl` (clearing all auxiliary declarations from the
+context) and `clear_value` (which clear the bodies of given definitions, changing them into regular
+hypotheses).
+-/
+
 namespace Mathlib.Tactic
 open Lean Parser.Tactic Elab Command Elab.Tactic Meta
 

--- a/Mathlib/Tactic/Basic.lean
+++ b/Mathlib/Tactic/Basic.lean
@@ -19,8 +19,8 @@ This file defines some basic utilities for tactic writing, and also
 and explicitly name the non-dependent hypotheses,
 - an `assumption` macro, calling the `assumption` tactic on all goals
 - the tactics `match_target`, `clear_aux_decl` (clearing all auxiliary declarations from the
-context) and `clear_value` (which clear the bodies of given definitions, changing them into regular
-hypotheses).
+context) and `clear_value` (which clears the bodies of given local definitions,
+changing them into regular hypotheses).
 -/
 
 namespace Mathlib.Tactic

--- a/Mathlib/Tactic/ByContra.lean
+++ b/Mathlib/Tactic/ByContra.lean
@@ -5,6 +5,11 @@ Authors: Kevin Buzzard
 -/
 import Mathlib.Tactic.PushNeg
 
+/-!
+# The `by_contra` tactic
+
+The `by_contra!` tactic is a variant of the `by_contra` tactic, for proofs of contradiction.
+-/
 open Lean Lean.Parser Parser.Tactic Elab Command Elab.Tactic Meta
 
 /--

--- a/Mathlib/Tactic/ByContra.lean
+++ b/Mathlib/Tactic/ByContra.lean
@@ -10,6 +10,7 @@ import Mathlib.Tactic.PushNeg
 
 The `by_contra!` tactic is a variant of the `by_contra` tactic, for proofs of contradiction.
 -/
+
 open Lean Lean.Parser Parser.Tactic Elab Command Elab.Tactic Meta
 
 /--

--- a/Mathlib/Tactic/ClearExcept.lean
+++ b/Mathlib/Tactic/ClearExcept.lean
@@ -5,6 +5,13 @@ Authors: Joshua Clune
 -/
 import Lean.Elab.Tactic.ElabTerm
 
+/-!
+# The `clear*` tactic
+
+This file provides a variant of the `clear` tactic, which clears all hypothesis it can
+besides a provided list.
+-/
+
 open Lean.Meta
 
 namespace Lean.Elab.Tactic

--- a/Mathlib/Tactic/ClearExcept.lean
+++ b/Mathlib/Tactic/ClearExcept.lean
@@ -8,7 +8,7 @@ import Lean.Elab.Tactic.ElabTerm
 /-!
 # The `clear*` tactic
 
-This file provides a variant of the `clear` tactic, which clears all hypothesis it can
+This file provides a variant of the `clear` tactic, which clears all hypotheses it can
 besides a provided list.
 -/
 

--- a/Mathlib/Tactic/Coe.lean
+++ b/Mathlib/Tactic/Coe.lean
@@ -16,6 +16,7 @@ Defines notation for coercions.
 3. `↥ t` is a coercion to a type.
 6. `(↥)` is equivalent to the eta-reduction of `(↥ ·)`
 -/
+
 open Lean Meta
 
 namespace Lean.Elab.Term.CoeImpl

--- a/Mathlib/Tactic/Coe.lean
+++ b/Mathlib/Tactic/Coe.lean
@@ -5,10 +5,10 @@ Authors: Gabriel Ebner
 -/
 import Lean.Elab.ElabRules
 
-open Lean Elab Term Meta
-
 /-!
-Defines notations for coercions.
+# Additional coercion notation
+
+Defines notation for coercions.
 1. `↑ t` is defined in core.
 2. `(↑)` is equivalent to the eta-reduction of `(↑ ·)`
 3. `⇑ t` is a coercion to a function type.
@@ -16,6 +16,7 @@ Defines notations for coercions.
 3. `↥ t` is a coercion to a type.
 6. `(↥)` is equivalent to the eta-reduction of `(↥ ·)`
 -/
+open Lean Meta
 
 namespace Lean.Elab.Term.CoeImpl
 

--- a/Mathlib/Tactic/Constructor.lean
+++ b/Mathlib/Tactic/Constructor.lean
@@ -6,7 +6,16 @@ Authors: Scott Morrison, Newell Jensen
 import Lean.Elab.SyntheticMVars
 import Lean.Meta.Tactic.Constructor
 
-open Lean Meta Elab Tactic
+/-!
+# The `fconstructor` and `econstructor` tactics
+
+The `fconstructor` and `econstructor` tactics are variants of the `constructor` tactic in Lean core,
+except that
+- `fconstructor` does not reorder goals
+- `econstructor` adds only non-dependent premises as new goals.
+
+-/
+open Lean Elab Tactic
 
 /--
 `fconstructor` is like `constructor`

--- a/Mathlib/Tactic/Constructor.lean
+++ b/Mathlib/Tactic/Constructor.lean
@@ -13,8 +13,8 @@ The `fconstructor` and `econstructor` tactics are variants of the `constructor` 
 except that
 - `fconstructor` does not reorder goals
 - `econstructor` adds only non-dependent premises as new goals.
-
 -/
+
 open Lean Elab Tactic
 
 /--

--- a/Mathlib/Tactic/ExistsI.lean
+++ b/Mathlib/Tactic/ExistsI.lean
@@ -4,6 +4,12 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Arthur Paulino, Gabriel Ebner, Moritz Doll
 -/
 
+/-!
+# The `existsi` tactic
+This file defines the `existsi` tactic: its purpose is to instantiate existential quantifiers.
+Internally, it applies the `refine` tactic.
+-/
+
 namespace Mathlib.Tactic
 
 /--
@@ -22,6 +28,5 @@ example : ∃ x : Nat, ∃ y : Nat, x = y := by
   rfl
 ```
 -/
-
 macro "existsi " es:term,+ : tactic =>
   `(tactic| refine ⟨$es,*, ?_⟩)

--- a/Mathlib/Tactic/PushNeg.lean
+++ b/Mathlib/Tactic/PushNeg.lean
@@ -11,6 +11,13 @@ import Mathlib.Tactic.Conv
 import Mathlib.Init.Set
 import Lean.Elab.Tactic.Location
 
+/-!
+# The `push_neg` tactic
+
+The `push_neg` tactic pushes negations inside expressions: it can be applied to goals as well
+as local hypotheses and also works as a `conv` tactic.
+-/
+
 namespace Mathlib.Tactic.PushNeg
 
 open Lean Meta Elab.Tactic Parser.Tactic

--- a/Mathlib/Tactic/Recover.lean
+++ b/Mathlib/Tactic/Recover.lean
@@ -5,10 +5,19 @@ Authors: Gabriel Ebner, Siddhartha Gadgil, Jannis Limperg
 -/
 import Lean
 
-open Lean (HashSet)
-open Lean Meta Elab Tactic
+/-!
+# The `recover` tactic modifier
+
+This defines the `recover` tactic modifier, which can be used to debug cases where goals
+are not closed correctly. `recover tacs` for a tactic (or tactic sequence) `tacs`
+applies the tactics and then adds goals
+that are not closed, starting from the original goal.
+-/
 
 namespace Mathlib.Tactic
+
+open Lean (HashSet)
+open Lean Meta Elab Tactic
 
 /--
 Get all metavariables which `mvarId` depends on. These are the metavariables
@@ -45,8 +54,8 @@ partial def getUnassignedGoalMVarDependencies (mvarId : MVarId) :
           go pendingMVarId
 
 /-- Modifier `recover` for a tactic (sequence) to debug cases where goals are closed incorrectly.
-The tactic `recover tacs` for a tactic (sequence) tacs applies the tactics and then adds goals
-that are not closed starting from the original -/
+The tactic `recover tacs` for a tactic (sequence) `tacs` applies the tactics and then adds goals
+that are not closed, starting from the original goal. -/
 elab "recover " tacs:tacticSeq : tactic => do
   let originalGoals ← getGoals
   evalTactic tacs

--- a/Mathlib/Tactic/Rename.lean
+++ b/Mathlib/Tactic/Rename.lean
@@ -5,6 +5,11 @@ Authors: Gabriel Ebner
 -/
 import Lean
 
+/-!
+# The `rename'` tactic
+The `rename'` tactic renames one or several hypotheses. This file contains its definition.
+-/
+
 namespace Mathlib.Tactic
 
 open Lean Elab.Tactic Meta

--- a/Mathlib/Tactic/Rename.lean
+++ b/Mathlib/Tactic/Rename.lean
@@ -7,7 +7,7 @@ import Lean
 
 /-!
 # The `rename'` tactic
-The `rename'` tactic renames one or several hypotheses. This file contains its definition.
+The `rename'` tactic renames one or several hypotheses.
 -/
 
 namespace Mathlib.Tactic

--- a/Mathlib/Tactic/RenameBVar.lean
+++ b/Mathlib/Tactic/RenameBVar.lean
@@ -8,9 +8,15 @@ import Lean
 import Mathlib.Util.Tactic
 import Mathlib.Lean.Expr.Basic
 
+/-!
+# The `rename_bvar` tactic
+
+This file defines the `rename_bvar` tactic, for renaming bound variables.
+-/
+
 namespace Mathlib.Tactic
 
-open Lean Meta Parser Elab Tactic
+open Lean Parser Elab Tactic
 
 /-- Renames a bound variable in a hypothesis. -/
 def renameBVarHyp (mvarId : MVarId) (fvarId : FVarId) (old new : Name) :

--- a/Mathlib/Tactic/Set.lean
+++ b/Mathlib/Tactic/Set.lean
@@ -5,6 +5,17 @@ Authors: Ian Benway
 -/
 import Lean
 
+/-!
+# The `set` tactic
+
+This file defines the `set` tactic and its variant `set!`.
+
+`set a := t with h` is a variant of `let a := t`. It adds the hypothesis `h : a = t` to
+the local context and replaces `t` with `a` everywhere it can.
+`set a := t with ← h` will add `h : t = a` instead.
+`set! a := t with h` does not do any replacing.
+-/
+
 namespace Mathlib.Tactic
 open Lean Elab Elab.Tactic Meta
 

--- a/Mathlib/Tactic/SimpRw.lean
+++ b/Mathlib/Tactic/SimpRw.lean
@@ -11,7 +11,7 @@ import Lean
 
 This file defines the `simp_rw` tactic: it functions as a mix of `simp` and `rw`.
 Like `rw`, it applies each rewrite rule in the given order, but like `simp` it repeatedly applies
-these rules and also under binders like `∀ x, ...`, `∃ x, ...` and `fun x ↦...`.
+these rules and also under binders like `∀ x, ...`, `∃ x, ...` and `fun x ↦ ...`.
 -/
 namespace Mathlib.Tactic
 

--- a/Mathlib/Tactic/SimpRw.lean
+++ b/Mathlib/Tactic/SimpRw.lean
@@ -6,6 +6,13 @@ Authors: Anne Baanen, Mario Carneiro, Alex J. Best
 
 import Lean
 
+/-!
+# The `simp_rw` tactic
+
+This file defines the `simp_rw` tactic: it functions as a mix of `simp` and `rw`.
+Like `rw`, it applies each rewrite rule in the given order, but like `simp` it repeatedly applies
+these rules and also under binders like `∀ x, ...`, `∃ x, ...` and `fun x ↦...`.
+-/
 namespace Mathlib.Tactic
 
 open Lean Parser.Tactic Elab.Tactic

--- a/Mathlib/Tactic/Substs.lean
+++ b/Mathlib/Tactic/Substs.lean
@@ -8,9 +8,9 @@ import Lean
 /-!
 # The `substs` macro
 
-This file defines a `substs` macro, which applies the `subst` tactic to a list of hypothesis,
-in left to right order.
+The `substs` macro applies the `subst` tactic to a list of hypothesis, in left to right order.
 -/
+
 namespace Mathlib.Tactic.Substs
 
 

--- a/Mathlib/Tactic/Substs.lean
+++ b/Mathlib/Tactic/Substs.lean
@@ -5,9 +5,14 @@ Authors: Evan Lohn, Mario Carneiro
 -/
 import Lean
 
+/-!
+# The `substs` macro
+
+This file defines a `substs` macro, which applies the `subst` tactic to a list of hypothesis,
+in left to right order.
+-/
 namespace Mathlib.Tactic.Substs
-open Lean Meta Elab
-open Tactic
+
 
 /--
 Applies the `subst` tactic to all given hypotheses from left to right.

--- a/Mathlib/Tactic/TypeCheck.lean
+++ b/Mathlib/Tactic/TypeCheck.lean
@@ -5,6 +5,11 @@ Authors: Jireh Loreaux
 -/
 import Lean.Elab.Tactic.Basic
 
+/-!
+# The `type_check` tactic
+Define the `type_check` tactic: it type checks a given expression, and traces its type.
+-/
+
 open Lean Meta
 
 /-- Type check the given expression, and trace its type. -/

--- a/scripts/style-exceptions.txt
+++ b/scripts/style-exceptions.txt
@@ -1,12 +1,4 @@
 Mathlib/Data/ByteArray.lean : line 7 : ERR_MOD : Module docstring missing, or too late
-Mathlib/Tactic/ApplyWith.lean : line 9 : ERR_MOD : Module docstring missing, or too late
-Mathlib/Tactic/Basic.lean : line 14 : ERR_MOD : Module docstring missing, or too late
-Mathlib/Tactic/ByContra.lean : line 8 : ERR_MOD : Module docstring missing, or too late
-Mathlib/Tactic/ClearExcept.lean : line 8 : ERR_MOD : Module docstring missing, or too late
-Mathlib/Tactic/Coe.lean : line 8 : ERR_MOD : Module docstring missing, or too late
-Mathlib/Tactic/Constructor.lean : line 9 : ERR_MOD : Module docstring missing, or too late
-Mathlib/Tactic/ExistsI.lean : line 7 : ERR_MOD : Module docstring missing, or too late
-Mathlib/Tactic/Rename.lean : line 8 : ERR_MOD : Module docstring missing, or too late
 Mathlib/Algebra/BigOperators/Group/Finset.lean : line 1 : ERR_NUM_LIN : 2800 file contains 2616 lines, try to split it up
 Mathlib/Algebra/Group/Subgroup/Basic.lean : line 1 : ERR_NUM_LIN : 3900 file contains 3705 lines, try to split it up
 Mathlib/Algebra/Group/Submonoid/Operations.lean : line 1 : ERR_NUM_LIN : 1700 file contains 1527 lines, try to split it up

--- a/scripts/style-exceptions.txt
+++ b/scripts/style-exceptions.txt
@@ -6,14 +6,7 @@ Mathlib/Tactic/ClearExcept.lean : line 8 : ERR_MOD : Module docstring missing, o
 Mathlib/Tactic/Coe.lean : line 8 : ERR_MOD : Module docstring missing, or too late
 Mathlib/Tactic/Constructor.lean : line 9 : ERR_MOD : Module docstring missing, or too late
 Mathlib/Tactic/ExistsI.lean : line 7 : ERR_MOD : Module docstring missing, or too late
-Mathlib/Tactic/PushNeg.lean : line 14 : ERR_MOD : Module docstring missing, or too late
-Mathlib/Tactic/Recover.lean : line 8 : ERR_MOD : Module docstring missing, or too late
 Mathlib/Tactic/Rename.lean : line 8 : ERR_MOD : Module docstring missing, or too late
-Mathlib/Tactic/RenameBVar.lean : line 11 : ERR_MOD : Module docstring missing, or too late
-Mathlib/Tactic/Set.lean : line 8 : ERR_MOD : Module docstring missing, or too late
-Mathlib/Tactic/SimpRw.lean : line 9 : ERR_MOD : Module docstring missing, or too late
-Mathlib/Tactic/Substs.lean : line 8 : ERR_MOD : Module docstring missing, or too late
-Mathlib/Tactic/TypeCheck.lean : line 8 : ERR_MOD : Module docstring missing, or too late
 Mathlib/Algebra/BigOperators/Group/Finset.lean : line 1 : ERR_NUM_LIN : 2800 file contains 2616 lines, try to split it up
 Mathlib/Algebra/Group/Subgroup/Basic.lean : line 1 : ERR_NUM_LIN : 3900 file contains 3705 lines, try to split it up
 Mathlib/Algebra/Group/Submonoid/Operations.lean : line 1 : ERR_NUM_LIN : 1700 file contains 1527 lines, try to split it up

--- a/test/TypeCheck.lean
+++ b/test/TypeCheck.lean
@@ -1,4 +1,5 @@
 import Mathlib.Tactic.TypeCheck
+
 /-- A term where `inferType` returns `Prop`, but which does not type check. -/
 elab "wrong" : term =>
   return Lean.mkApp2 (.const ``id [.zero]) (.sort .zero) (.app (.sort .zero) (.sort .zero))


### PR DESCRIPTION
This fixes all `missing module docstring` exceptions except for `Data/ByteArray`.
While in the area, remove some superfluous open statements or make minor formatting fixes.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
