### PR TITLE
[Merged by Bors] - fix: `maintainer merge` messages only once

### DIFF
--- a/.github/workflows/maintainer_merge_review.yml
+++ b/.github/workflows/maintainer_merge_review.yml
@@ -2,6 +2,7 @@ name: Maintainer merge (review)
 
 on:
   pull_request_review:
+    # triggers on a review, whether or not it is accompanied by a comment
     types: [submitted]
 
 jobs:
@@ -28,7 +29,7 @@ jobs:
           type: 'stream'
           topic: 'maintainer merge'
           content: |
-            ${{ format('{0} requested a maintainer merge from review (action: {3}) on PR [#{1}]({2}):', github.event.review.user.login, github.event.pull_request.number, github.event.pull_request.html_url, github.event.action ) }}
+            ${{ format('{0} requested a maintainer merge from review on PR [#{1}]({2}):', github.event.review.user.login, github.event.pull_request.number, github.event.pull_request.html_url ) }}
 
             > ${{ github.event.pull_request.title }}
 

--- a/.github/workflows/maintainer_merge_review.yml
+++ b/.github/workflows/maintainer_merge_review.yml
@@ -28,7 +28,7 @@ jobs:
           type: 'stream'
           topic: 'maintainer merge'
           content: |
-            ${{ format('{0} requested a maintainer merge from review on PR [#{1}]({2}):', github.event.review.user.login, github.event.pull_request.number, github.event.pull_request.html_url ) }}
+            ${{ format('{0} requested a maintainer merge from review (submitted: ${{ pull_request_review.submitted }} or edited: ${{ pull_request_review.edited }}) on PR [#{1}]({2}):', github.event.review.user.login, github.event.pull_request.number, github.event.pull_request.html_url ) }}
 
             > ${{ github.event.pull_request.title }}
 

--- a/.github/workflows/maintainer_merge_review.yml
+++ b/.github/workflows/maintainer_merge_review.yml
@@ -2,7 +2,7 @@ name: Maintainer merge (review)
 
 on:
   pull_request_review:
-    types: [submitted, edited]
+    types: [submitted]
 
 jobs:
   ping_zulip:

--- a/.github/workflows/maintainer_merge_review.yml
+++ b/.github/workflows/maintainer_merge_review.yml
@@ -28,7 +28,7 @@ jobs:
           type: 'stream'
           topic: 'maintainer merge'
           content: |
-            ${{ format('{0} requested a maintainer merge from review (submitted: {3} or edited: {4}) on PR [#{1}]({2}):', github.event.review.user.login, github.event.pull_request.number, github.event.pull_request.html_url, pull_request_review.submitted, pull_request_review.edited ) }}
+            ${{ format('{0} requested a maintainer merge from review (action: {3}) on PR [#{1}]({2}):', github.event.review.user.login, github.event.pull_request.number, github.event.pull_request.html_url, github.event.action ) }}
 
             > ${{ github.event.pull_request.title }}
 

--- a/.github/workflows/maintainer_merge_review.yml
+++ b/.github/workflows/maintainer_merge_review.yml
@@ -28,7 +28,7 @@ jobs:
           type: 'stream'
           topic: 'maintainer merge'
           content: |
-            ${{ format('{0} requested a maintainer merge from review (submitted: ${{ pull_request_review.submitted }} or edited: ${{ pull_request_review.edited }}) on PR [#{1}]({2}):', github.event.review.user.login, github.event.pull_request.number, github.event.pull_request.html_url ) }}
+            ${{ format('{0} requested a maintainer merge from review (submitted: {3} or edited: {4}) on PR [#{1}]({2}):', github.event.review.user.login, github.event.pull_request.number, github.event.pull_request.html_url, pull_request_review.submitted, pull_request_review.edited ) }}
 
             > ${{ github.event.pull_request.title }}
 


### PR DESCRIPTION
Testing the doubled `maintainer merge` messages.

The conclusion seems to be that `edited` triggers the action also when a comment is submitted as part of a review.  The change proposed here likely means that editing a message to make it contain `maintainer merge` will not trigger a `maintainer merge` message, but will not double `maintainer merge` messages that are sent from a review that also adds comments.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
