### PR TITLE
[Merged by Bors] - feat(Algebra/Module/LinearMap/Defs): add `restrictScalars` as a `LinearMap`

### DIFF
--- a/Mathlib/Algebra/Module/LinearMap/Defs.lean
+++ b/Mathlib/Algebra/Module/LinearMap/Defs.lean
@@ -1068,6 +1068,7 @@ theorem restrictScalars_smul (c : R₁) (f : M →ₗ[S] N) :
 variable (S M N R R₁)
 
 /-- `LinearMap.restrictScalars` as a `LinearMap`. -/
+@[simps apply]
 def restrictScalarsₗ : (M →ₗ[S] N) →ₗ[R₁] M →ₗ[R] N where
   toFun := restrictScalars R
   map_add' := restrictScalars_add

--- a/Mathlib/Algebra/Module/LinearMap/Defs.lean
+++ b/Mathlib/Algebra/Module/LinearMap/Defs.lean
@@ -1058,9 +1058,7 @@ theorem restrictScalars_add (f g : M →ₗ[S] N) :
 theorem restrictScalars_neg (f : M →ₗ[S] N) : (-f).restrictScalars R = -f.restrictScalars R :=
   rfl
 
-variable {R₁ : Type*}
-variable [Semiring R₁] [Module R₁ N] [SMulCommClass S R₁ N]
-  [SMulCommClass R R₁ N]
+variable {R₁ : Type*} [Semiring R₁] [Module R₁ N] [SMulCommClass S R₁ N] [SMulCommClass R R₁ N]
 
 @[simp]
 theorem restrictScalars_smul (c : R₁) (f : M →ₗ[S] N) :

--- a/Mathlib/Algebra/Module/LinearMap/Defs.lean
+++ b/Mathlib/Algebra/Module/LinearMap/Defs.lean
@@ -1038,4 +1038,43 @@ end Module
 
 end Actions
 
+section RestrictScalarsAsLinearMap
+
+variable {R S M N : Type*} [Semiring R] [Semiring S] [AddCommGroup M] [AddCommGroup N] [Module R M]
+   [Module R N] [Module S M] [Module S N]
+  [LinearMap.CompatibleSMul M N R S]
+
+variable (R S M N) in
+@[simp]
+lemma restrictScalars_zero : (0 : M →ₗ[S] N).restrictScalars R = 0 :=
+  rfl
+
+@[simp]
+theorem restrictScalars_add (f g : M →ₗ[S] N) :
+    (f + g).restrictScalars R = f.restrictScalars R + g.restrictScalars R :=
+  rfl
+
+@[simp]
+theorem restrictScalars_neg (f : M →ₗ[S] N) : (-f).restrictScalars R = -f.restrictScalars R :=
+  rfl
+
+variable {R₁ : Type*}
+variable [Semiring R₁] [Module R₁ N] [SMulCommClass S R₁ N]
+  [SMulCommClass R R₁ N]
+
+@[simp]
+theorem restrictScalars_smul (c : R₁) (f : M →ₗ[S] N) :
+    (c • f).restrictScalars R = c • f.restrictScalars R :=
+  rfl
+
+variable (S M N R R₁)
+
+/-- `LinearMap.restrictScalars` as a `LinearMap`. -/
+def restrictScalarsₗ : (M →ₗ[S] N) →ₗ[R₁] M →ₗ[R] N where
+  toFun := restrictScalars R
+  map_add' := restrictScalars_add
+  map_smul' := restrictScalars_smul
+
+end RestrictScalarsAsLinearMap
+
 end LinearMap


### PR DESCRIPTION
add some missing lemmas on `RestrictScalars` as a `Linear Map`.

This contribution was created as part of the AIM workshop "Formalizing algebraic geometry" in
June 2024.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
