### PR TITLE
[Merged by Bors] - feat: add `orthogonalComplement_eq_orthogonalComplement`

### DIFF
--- a/Mathlib/Analysis/InnerProductSpace/Projection.lean
+++ b/Mathlib/Analysis/InnerProductSpace/Projection.lean
@@ -845,6 +845,14 @@ theorem Submodule.isCompl_orthogonal_of_completeSpace [HasOrthogonalProjection K
   ⟨K.orthogonal_disjoint, codisjoint_iff.2 Submodule.sup_orthogonal_of_completeSpace⟩
 #align submodule.is_compl_orthogonal_of_complete_space Submodule.isCompl_orthogonal_of_completeSpace
 
+theorem eq_iff_orthogonalComplement_eq {L : Submodule 𝕜 E}[HasOrthogonalProjection K]
+    [HasOrthogonalProjection L] : K = L ↔ Kᗮ = Lᗮ := by
+   constructor
+   · exact fun a ↦ congrArg Submodule.orthogonal a
+   · intro H
+     rw [← (Submodule.orthogonal_orthogonal K), ← (Submodule.orthogonal_orthogonal) L]
+     exact congrArg Submodule.orthogonal H
+
 @[simp]
 theorem Submodule.orthogonal_eq_bot_iff [HasOrthogonalProjection K] : Kᗮ = ⊥ ↔ K = ⊤ := by
   refine ⟨?_, fun h => by rw [h, Submodule.top_orthogonal_eq_bot]⟩

--- a/Mathlib/Analysis/InnerProductSpace/Projection.lean
+++ b/Mathlib/Analysis/InnerProductSpace/Projection.lean
@@ -845,13 +845,11 @@ theorem Submodule.isCompl_orthogonal_of_completeSpace [HasOrthogonalProjection K
   ⟨K.orthogonal_disjoint, codisjoint_iff.2 Submodule.sup_orthogonal_of_completeSpace⟩
 #align submodule.is_compl_orthogonal_of_complete_space Submodule.isCompl_orthogonal_of_completeSpace
 
-theorem eq_iff_orthogonalComplement_eq {L : Submodule 𝕜 E}[HasOrthogonalProjection K]
-    [HasOrthogonalProjection L] : K = L ↔ Kᗮ = Lᗮ := by
-   constructor
-   · exact fun a ↦ congrArg Submodule.orthogonal a
-   · intro H
-     rw [← (Submodule.orthogonal_orthogonal K), ← (Submodule.orthogonal_orthogonal) L]
-     exact congrArg Submodule.orthogonal H
+@[simp]
+theorem orthogonalComplement_eq_orthogonalComplement {L : Submodule 𝕜 E} [HasOrthogonalProjection K]
+    [HasOrthogonalProjection L] : Kᗮ = Lᗮ ↔ K = L := by
+    exact ⟨fun h ↦ by simpa using congr(Submodule.orthogonal $(h)),
+    fun h ↦ congr(Submodule.orthogonal $(h))⟩
 
 @[simp]
 theorem Submodule.orthogonal_eq_bot_iff [HasOrthogonalProjection K] : Kᗮ = ⊥ ↔ K = ⊤ := by

--- a/Mathlib/Analysis/InnerProductSpace/Projection.lean
+++ b/Mathlib/Analysis/InnerProductSpace/Projection.lean
@@ -847,8 +847,8 @@ theorem Submodule.isCompl_orthogonal_of_completeSpace [HasOrthogonalProjection K
 
 @[simp]
 theorem orthogonalComplement_eq_orthogonalComplement {L : Submodule 𝕜 E} [HasOrthogonalProjection K]
-    [HasOrthogonalProjection L] : Kᗮ = Lᗮ ↔ K = L := by
-    exact ⟨fun h ↦ by simpa using congr(Submodule.orthogonal $(h)),
+    [HasOrthogonalProjection L] : Kᗮ = Lᗮ ↔ K = L :=
+  ⟨fun h ↦ by simpa using congr(Submodule.orthogonal $(h)),
     fun h ↦ congr(Submodule.orthogonal $(h))⟩
 
 @[simp]


### PR DESCRIPTION
Included a lemma that asserts that two vector submodules of a vector space in a `RClike field' are equal if and only if their orthogonal complements are equal 

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
