### PR TITLE
[Merged by Bors] - doc: fix module documentation for `AntivaryOn`

### DIFF
--- a/Mathlib/Order/Monotone/Monovary.lean
+++ b/Mathlib/Order/Monotone/Monovary.lean
@@ -23,7 +23,7 @@ This condition comes up in the rearrangement inequality. See `Algebra.Order.Rear
 * `Monovary f g`: `f` monovaries with `g`. If `g i < g j`, then `f i ≤ f j`.
 * `Antivary f g`: `f` antivaries with `g`. If `g i < g j`, then `f j ≤ f i`.
 * `MonovaryOn f g s`: `f` monovaries with `g` on `s`.
-* `MonovaryOn f g s`: `f` antivaries with `g` on `s`.
+* `AntivaryOn f g s`: `f` antivaries with `g` on `s`.
 -/
 
 


### PR DESCRIPTION
Fix `MonovaryOn f g s`: `f` antivaries with `g` on `s`. to `AntivaryOn f g s`: `f` monovaries with `g` on `s`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
