### PR TITLE
[Merged by Bors] - feat(Data.Real.ENatENNReal/EReal): add a few coe lemmas

### DIFF
--- a/Mathlib/Data/Real/ENatENNReal.lean
+++ b/Mathlib/Data/Real/ENatENNReal.lean
@@ -65,7 +65,7 @@ theorem toENNReal_ofNat (n : ℕ) [n.AtLeastTwo] :
 
 @[simp, norm_cast]
 theorem toENNReal_coe_eq_iff : (m : ℝ≥0∞) = (n : ℝ≥0∞) ↔ m = n :=
-  OrderEmbedding.eq_iff_eq ENat.toENNRealOrderEmbedding
+  toENNRealOrderEmbedding.eq_iff_eq
 
 @[simp, norm_cast]
 theorem toENNReal_le : (m : ℝ≥0∞) ≤ n ↔ m ≤ n :=

--- a/Mathlib/Data/Real/ENatENNReal.lean
+++ b/Mathlib/Data/Real/ENatENNReal.lean
@@ -64,6 +64,10 @@ theorem toENNReal_ofNat (n : ℕ) [n.AtLeastTwo] :
   rfl
 
 @[simp, norm_cast]
+theorem toENNReal_coe_eq_iff : (m : ℝ≥0∞) = n ↔ m = n :=
+  OrderEmbedding.eq_iff_eq ENat.toENNRealOrderEmbedding
+
+@[simp, norm_cast]
 theorem toENNReal_le : (m : ℝ≥0∞) ≤ n ↔ m ≤ n :=
   toENNRealOrderEmbedding.le_iff_le
 #align enat.coe_ennreal_le ENat.toENNReal_le
@@ -105,6 +109,10 @@ theorem toENNReal_one : ((1 : ℕ∞) : ℝ≥0∞) = 1 :=
 theorem toENNReal_mul (m n : ℕ∞) : ↑(m * n) = (m * n : ℝ≥0∞) :=
   map_mul toENNRealRingHom m n
 #align enat.coe_ennreal_mul ENat.toENNReal_mul
+
+@[simp]
+theorem toENNReal_pow (x : ℕ∞) (n : ℕ) : (x ^ n : ℕ∞) = (x : ℝ≥0∞) ^ n :=
+  RingHom.map_pow toENNRealRingHom x n
 
 @[simp]
 theorem toENNReal_min (m n : ℕ∞) : ↑(min m n) = (min m n : ℝ≥0∞) :=

--- a/Mathlib/Data/Real/ENatENNReal.lean
+++ b/Mathlib/Data/Real/ENatENNReal.lean
@@ -92,12 +92,12 @@ theorem toENNReal_zero : ((0 : ℕ∞) : ℝ≥0∞) = 0 :=
   map_zero toENNRealRingHom
 #align enat.coe_ennreal_zero ENat.toENNReal_zero
 
-@[simp]
+@[simp, norm_cast]
 theorem toENNReal_add (m n : ℕ∞) : ↑(m + n) = (m + n : ℝ≥0∞) :=
   map_add toENNRealRingHom m n
 #align enat.coe_ennreal_add ENat.toENNReal_add
 
-@[simp]
+@[simp, norm_cast]
 theorem toENNReal_one : ((1 : ℕ∞) : ℝ≥0∞) = 1 :=
   map_one toENNRealRingHom
 #align enat.coe_ennreal_one ENat.toENNReal_one
@@ -105,26 +105,26 @@ theorem toENNReal_one : ((1 : ℕ∞) : ℝ≥0∞) = 1 :=
 #noalign enat.coe_ennreal_bit0
 #noalign enat.coe_ennreal_bit1
 
-@[simp]
+@[simp, norm_cast]
 theorem toENNReal_mul (m n : ℕ∞) : ↑(m * n) = (m * n : ℝ≥0∞) :=
   map_mul toENNRealRingHom m n
 #align enat.coe_ennreal_mul ENat.toENNReal_mul
 
-@[simp]
+@[simp, norm_cast]
 theorem toENNReal_pow (x : ℕ∞) (n : ℕ) : (x ^ n : ℕ∞) = (x : ℝ≥0∞) ^ n :=
   RingHom.map_pow toENNRealRingHom x n
 
-@[simp]
+@[simp, norm_cast]
 theorem toENNReal_min (m n : ℕ∞) : ↑(min m n) = (min m n : ℝ≥0∞) :=
   toENNReal_mono.map_min
 #align enat.coe_ennreal_min ENat.toENNReal_min
 
-@[simp]
+@[simp, norm_cast]
 theorem toENNReal_max (m n : ℕ∞) : ↑(max m n) = (max m n : ℝ≥0∞) :=
   toENNReal_mono.map_max
 #align enat.coe_ennreal_max ENat.toENNReal_max
 
-@[simp]
+@[simp, norm_cast]
 theorem toENNReal_sub (m n : ℕ∞) : ↑(m - n) = (m - n : ℝ≥0∞) :=
   WithTop.map_sub Nat.cast_tsub Nat.cast_zero m n
 #align enat.coe_ennreal_sub ENat.toENNReal_sub

--- a/Mathlib/Data/Real/ENatENNReal.lean
+++ b/Mathlib/Data/Real/ENatENNReal.lean
@@ -64,7 +64,7 @@ theorem toENNReal_ofNat (n : ℕ) [n.AtLeastTwo] :
   rfl
 
 @[simp, norm_cast]
-theorem toENNReal_coe_eq_iff : (m : ℝ≥0∞) = n ↔ m = n :=
+theorem toENNReal_coe_eq_iff : (m : ℝ≥0∞) = (n : ℝ≥0∞) ↔ m = n :=
   OrderEmbedding.eq_iff_eq ENat.toENNRealOrderEmbedding
 
 @[simp, norm_cast]

--- a/Mathlib/Data/Real/EReal.lean
+++ b/Mathlib/Data/Real/EReal.lean
@@ -737,19 +737,19 @@ theorem natCast_ne_bot (n : ℕ) : (n : EReal) ≠ ⊥ := Ne.symm (ne_of_beq_fal
 theorem natCast_ne_top (n : ℕ) : (n : EReal) ≠ ⊤ := Ne.symm (ne_of_beq_false rfl)
 
 @[simp, norm_cast]
-theorem natCast_eq_natCast_iff {m n : ℕ} : (m : EReal) = (n : EReal) ↔ m = n := by
+theorem natCast_eq_iff {m n : ℕ} : (m : EReal) = (n : EReal) ↔ m = n := by
   rw [← coe_coe_eq_natCast n, ← coe_coe_eq_natCast m, EReal.coe_eq_coe_iff, Nat.cast_inj]
 
 @[simp, norm_cast]
-theorem natCast_ne_natCast_iff {m n : ℕ} : (m : EReal) ≠ (n : EReal) ↔ m ≠ n :=
-  not_iff_not.2 natCast_eq_natCast_iff
+theorem natCast_ne_iff {m n : ℕ} : (m : EReal) ≠ (n : EReal) ↔ m ≠ n :=
+  not_iff_not.2 natCast_eq_iff
 
 @[simp, norm_cast]
-theorem natCast_le_natCast_iff {m n : ℕ} : (m : EReal) ≤ (n : EReal) ↔ m ≤ n := by
+theorem natCast_le_iff {m n : ℕ} : (m : EReal) ≤ (n : EReal) ↔ m ≤ n := by
   rw [← coe_coe_eq_natCast n, ← coe_coe_eq_natCast m, EReal.coe_le_coe_iff, Nat.cast_le]
 
 @[simp, norm_cast]
-theorem natCast_lt_natCast_iff {m n : ℕ} : (m : EReal) < (n : EReal) ↔ m < n := by
+theorem natCast_lt_iff {m n : ℕ} : (m : EReal) < (n : EReal) ↔ m < n := by
   rw [← coe_coe_eq_natCast n, ← coe_coe_eq_natCast m, EReal.coe_lt_coe_iff, Nat.cast_lt]
 
 theorem natCast_mul (m n : ℕ) :

--- a/Mathlib/Data/Real/EReal.lean
+++ b/Mathlib/Data/Real/EReal.lean
@@ -740,7 +740,6 @@ theorem natCast_ne_top (n : ℕ) : (n : EReal) ≠ ⊤ := Ne.symm (ne_of_beq_fal
 theorem natCast_eq_iff {m n : ℕ} : (m : EReal) = (n : EReal) ↔ m = n := by
   rw [← coe_coe_eq_natCast n, ← coe_coe_eq_natCast m, EReal.coe_eq_coe_iff, Nat.cast_inj]
 
-@[simp, norm_cast]
 theorem natCast_ne_iff {m n : ℕ} : (m : EReal) ≠ (n : EReal) ↔ m ≠ n :=
   not_iff_not.2 natCast_eq_iff
 

--- a/Mathlib/Data/Real/EReal.lean
+++ b/Mathlib/Data/Real/EReal.lean
@@ -751,6 +751,7 @@ theorem natCast_le_iff {m n : ℕ} : (m : EReal) ≤ (n : EReal) ↔ m ≤ n := 
 theorem natCast_lt_iff {m n : ℕ} : (m : EReal) < (n : EReal) ↔ m < n := by
   rw [← coe_coe_eq_natCast n, ← coe_coe_eq_natCast m, EReal.coe_lt_coe_iff, Nat.cast_lt]
 
+@[simp, norm_cast]
 theorem natCast_mul (m n : ℕ) :
     (m * n : ℕ) = (m : EReal) * (n : EReal) := by
   rw [← coe_coe_eq_natCast, ← coe_coe_eq_natCast, ← coe_coe_eq_natCast, Nat.cast_mul, EReal.coe_mul]

--- a/Mathlib/Data/Real/EReal.lean
+++ b/Mathlib/Data/Real/EReal.lean
@@ -728,6 +728,34 @@ theorem coe_ennreal_nsmul (n : ℕ) (x : ℝ≥0∞) : (↑(n • x) : EReal) = 
 #noalign ereal.coe_ennreal_bit0
 #noalign ereal.coe_ennreal_bit1
 
+/-! ### nat coercion -/
+
+theorem coe_coe_eq_natCast (n : ℕ) : (n : ℝ) = (n : EReal) := rfl
+
+theorem natCast_ne_bot (n : ℕ) : (n : EReal) ≠ ⊥ := Ne.symm (ne_of_beq_false rfl)
+
+theorem natCast_ne_top (n : ℕ) : (n : EReal) ≠ ⊤ := Ne.symm (ne_of_beq_false rfl)
+
+@[simp, norm_cast]
+theorem natCast_eq_natCast_iff {m n : ℕ} : (m : EReal) = (n : EReal) ↔ m = n := by
+  rw [← coe_coe_eq_natCast n, ← coe_coe_eq_natCast m, EReal.coe_eq_coe_iff, Nat.cast_inj]
+
+@[simp, norm_cast]
+theorem natCast_ne_natCast_iff {m n : ℕ} : (m : EReal) ≠ (n : EReal) ↔ m ≠ n :=
+  not_iff_not.2 natCast_eq_natCast_iff
+
+@[simp, norm_cast]
+theorem natCast_le_natCast_iff {m n : ℕ} : (m : EReal) ≤ (n : EReal) ↔ m ≤ n := by
+  rw [← coe_coe_eq_natCast n, ← coe_coe_eq_natCast m, EReal.coe_le_coe_iff, Nat.cast_le]
+
+@[simp, norm_cast]
+theorem natCast_lt_natCast_iff {m n : ℕ} : (m : EReal) < (n : EReal) ↔ m < n := by
+  rw [← coe_coe_eq_natCast n, ← coe_coe_eq_natCast m, EReal.coe_lt_coe_iff, Nat.cast_lt]
+
+theorem natCast_mul (m n : ℕ) :
+    (m * n : ℕ) = (m : EReal) * (n : EReal) := by
+  rw [← coe_coe_eq_natCast, ← coe_coe_eq_natCast, ← coe_coe_eq_natCast, Nat.cast_mul, EReal.coe_mul]
+
 /-! ### Order -/
 
 theorem exists_rat_btwn_of_lt :
@@ -1619,6 +1647,12 @@ lemma inv_neg_of_neg_ne_bot {a : EReal} (h : a < 0) (h' : a ≠ ⊥) : a⁻¹ < 
 lemma div_eq_inv_mul (a b : EReal) : a / b = b⁻¹ * a := EReal.mul_comm a b⁻¹
 
 lemma coe_div (a b : ℝ) : (a / b : ℝ) = (a : EReal) / (b : EReal) := rfl
+
+theorem natCast_div_le (m n : ℕ) :
+    (m / n : ℕ) ≤ (m : EReal) / (n : EReal) := by
+  rw [← coe_coe_eq_natCast, ← coe_coe_eq_natCast, ← coe_coe_eq_natCast, ← coe_div,
+    EReal.coe_le_coe_iff]
+  exact Nat.cast_div_le
 
 @[simp]
 lemma div_bot {a : EReal} : a / ⊥ = 0 := inv_bot ▸ mul_zero a


### PR DESCRIPTION
Add a few lemmas about coercion:

- `toENNReal_coe_eq_iff`, `toENNReal_pow` in Data.Real.ENatENNReal
- 9 lemmas about `natCast` into `EReal ` in Data.Real.EReal

Allows a better handle on functions from ENat to ENNReal, as well as from Nat to EReal.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
