### PR TITLE
[Merged by Bors] - feat)List/MinMax): getD_maximum?_eq_unbot'_maximum

### DIFF
--- a/Mathlib/Data/List/MinMax.lean
+++ b/Mathlib/Data/List/MinMax.lean
@@ -41,11 +41,7 @@ def argAux (a : Option α) (b : α) : Option α :=
 theorem foldl_argAux_eq_none : l.foldl (argAux r) o = none ↔ l = [] ∧ o = none :=
   List.reverseRecOn l (by simp) fun tl hd => by
     simp only [foldl_append, foldl_cons, argAux, foldl_nil, append_eq_nil, and_false, false_and,
-      iff_false]
-    cases foldl (argAux r) o tl
-    · simp
-    · simp only [false_iff, not_and]
-      split_ifs <;> simp
+      iff_false]; cases foldl (argAux r) o tl <;> simp; try split_ifs <;> simp
 #align list.foldl_arg_aux_eq_none List.foldl_argAux_eq_none
 
 private theorem foldl_argAux_mem (l) : ∀ a m : α, m ∈ foldl (argAux r) (some a) l → m ∈ a :: l :=
@@ -394,7 +390,7 @@ theorem maximum_le_of_forall_le {b : WithBot α} (h : ∀ a ∈ l, a ≤ b) : l.
   induction l with
   | nil => simp
   | cons a l ih =>
-    simp only [maximum_cons, max_le_iff, WithBot.coe_le_coe]
+    simp only [maximum_cons, ge_iff_le, max_le_iff, WithBot.coe_le_coe]
     exact ⟨h a (by simp), ih fun a w => h a (mem_cons.mpr (Or.inr w))⟩
 
 theorem le_minimum_of_forall_le {b : WithTop α} (h : ∀ a ∈ l, b ≤ a) : b ≤ l.minimum :=
@@ -486,6 +482,26 @@ theorem getElem_le_maximum_of_length_pos {i : ℕ} (w : i < l.length) (h := (Nat
 theorem minimum_of_length_pos_le_getElem {i : ℕ} (w : i < l.length) (h := (Nat.zero_lt_of_lt w)) :
     l.minimum_of_length_pos h ≤ l[i] :=
   getElem_le_maximum_of_length_pos (α := αᵒᵈ) w
+
+lemma getD_maximum?_eq_unbot'_maximum (l : List α) (d : α) :
+    l.maximum?.getD d = l.maximum.unbot' d := by
+  cases hy : l.maximum with
+  | bot => simp [List.maximum_eq_bot.mp hy]
+  | coe y =>
+    rw [List.maximum_eq_coe_iff] at hy
+    simp only [WithBot.unbot'_coe]
+    cases hz : l.maximum? with
+    | none => simp [List.maximum?_eq_none_iff.mp hz] at hy
+    | some z =>
+      have : Antisymm (α := α) (· ≤ ·) := ⟨_root_.le_antisymm⟩
+      rw [List.maximum?_eq_some_iff] at hz
+      · rw [Option.getD_some]
+        exact _root_.le_antisymm (hy.right _ hz.left) (hz.right _ hy.left)
+      all_goals simp [le_total]
+
+lemma getD_minimum?_eq_untop'_minimum (l : List α) (d : α) :
+    l.minimum?.getD d = l.minimum.untop' d :=
+  getD_maximum?_eq_unbot'_maximum (α := αᵒᵈ) _ _
 
 end LinearOrder
 

--- a/Mathlib/Data/List/MinMax.lean
+++ b/Mathlib/Data/List/MinMax.lean
@@ -41,7 +41,11 @@ def argAux (a : Option α) (b : α) : Option α :=
 theorem foldl_argAux_eq_none : l.foldl (argAux r) o = none ↔ l = [] ∧ o = none :=
   List.reverseRecOn l (by simp) fun tl hd => by
     simp only [foldl_append, foldl_cons, argAux, foldl_nil, append_eq_nil, and_false, false_and,
-      iff_false]; cases foldl (argAux r) o tl <;> simp; try split_ifs <;> simp
+      iff_false]
+    cases foldl (argAux r) o tl
+    · simp
+    · simp only [false_iff, not_and]
+      split_ifs <;> simp
 #align list.foldl_arg_aux_eq_none List.foldl_argAux_eq_none
 
 private theorem foldl_argAux_mem (l) : ∀ a m : α, m ∈ foldl (argAux r) (some a) l → m ∈ a :: l :=
@@ -390,7 +394,7 @@ theorem maximum_le_of_forall_le {b : WithBot α} (h : ∀ a ∈ l, a ≤ b) : l.
   induction l with
   | nil => simp
   | cons a l ih =>
-    simp only [maximum_cons, ge_iff_le, max_le_iff, WithBot.coe_le_coe]
+    simp only [maximum_cons, max_le_iff, WithBot.coe_le_coe]
     exact ⟨h a (by simp), ih fun a w => h a (mem_cons.mpr (Or.inr w))⟩
 
 theorem le_minimum_of_forall_le {b : WithTop α} (h : ∀ a ∈ l, b ≤ a) : b ≤ l.minimum :=


### PR DESCRIPTION
And also for minimum
This links the two definitions


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
