### PR TITLE
[Merged by Bors] - feat(Topology/DiscreteSubset): prove lemmas about the codiscrete filter, and define codiscreteWithin

### DIFF
--- a/Mathlib/Topology/DiscreteSubset.lean
+++ b/Mathlib/Topology/DiscreteSubset.lean
@@ -104,4 +104,41 @@ def Filter.codiscrete (X : Type*) [TopologicalSpace X] : Filter X where
     simp_rw [← isClosed_compl_iff, isClosed_and_discrete_iff] at hU hV ⊢
     exact fun x ↦ compl_inter U V ▸ sup_principal ▸ disjoint_sup_right.mpr ⟨hU x, hV x⟩
 
+lemma mem_codiscrete {S : Set X} :
+    S ∈ codiscrete X ↔ IsOpen S ∧ DiscreteTopology ↑Sᶜ := Iff.rfl
+
+lemma mem_codiscrete' {S : Set X} :
+    S ∈ codiscrete X ↔ ∀ x, Disjoint (𝓝[≠] x) (𝓟 Sᶜ) := by
+  rw [mem_codiscrete, ← isClosed_compl_iff, isClosed_and_discrete_iff]
+
+lemma mem_codiscrete_subtype {S : Set X} {U : Set S} :
+    U ∈ codiscrete S ↔ ∀ x ∈ S, ¬AccPt x (𝓟 (Subtype.val '' Uᶜ)) := by
+  simp only [mem_codiscrete', disjoint_principal_right, compl_compl, Subtype.forall, AccPt,
+    not_neBot, inf_principal_eq_bot]
+  congr! with x hx
+  constructor
+  · intro h
+    rw [nhdsWithin_subtype] at h
+    simp only [mem_comap] at h
+    obtain ⟨t, ht1, ht2⟩ := h
+    simp [mem_nhdsWithin] at ht1 ⊢
+    obtain ⟨u, hu1, hu2, hu3⟩ := ht1
+    use u, hu1, hu2
+    intro v hv
+    simp only [mem_compl_iff, mem_image, Subtype.exists, exists_and_right, exists_eq_right,
+      not_exists, not_not]
+    intro hv2
+    apply ht2
+    simp only [mem_preimage]
+    apply hu3
+    simpa [hv2]
+  · intro h
+    have : Tendsto Subtype.val (𝓝[≠] ⟨x, hx⟩) (𝓝[≠] x) :=
+      tendsto_nhdsWithin_of_tendsto_nhds_of_eventually_within _
+      continuous_subtype_val.continuousWithinAt <| eventually_mem_nhdsWithin.mono (by simp)
+    rw [tendsto_def] at this
+    convert this _ h
+    ext
+    simp
+
 end codiscrete_filter

--- a/Mathlib/Topology/DiscreteSubset.lean
+++ b/Mathlib/Topology/DiscreteSubset.lean
@@ -117,7 +117,7 @@ lemma mem_codiscreteWithin_accPt {S T : Set X} :
   simp only [mem_codiscreteWithin, disjoint_iff, AccPt, not_neBot]
 
 /-- In any topological space, we form a filter from the supremum of all punctured neighborhoods. -/
-def Filter.codiscrete (X : Type*) [TopologicalSpace X] : Filter X := codiscreteWithin Set.univ
+abbrev Filter.codiscrete (X : Type*) [TopologicalSpace X] : Filter X := codiscreteWithin Set.univ
 
 lemma mem_codiscrete {S : Set X} :
     S ∈ codiscrete X ↔ ∀ x, Disjoint (𝓝[≠] x) (𝓟 Sᶜ) := by

--- a/Mathlib/Topology/DiscreteSubset.lean
+++ b/Mathlib/Topology/DiscreteSubset.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2023 Oliver Nash. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Oliver Nash, Bhavik Mehta
+Authors: Oliver Nash, Bhavik Mehta, Daniel Weber
 -/
 import Mathlib.Topology.Constructions
 import Mathlib.Topology.Separation
@@ -32,6 +32,7 @@ see `IsClosed.tendsto_coe_cofinite_iff`.
 
 In a topological space the sets which are open with discrete complement form a filter. We
 formalise this as `Filter.codiscrete`. This is also the supremum of all punctured neighborhoods.
+We also define `Filter.codiscreteWithin`, which is a filter of codiscrete functions on a subset.
 
 -/
 
@@ -117,7 +118,7 @@ lemma mem_codiscreteWithin_accPt {S T : Set X} :
   simp only [mem_codiscreteWithin, disjoint_iff, AccPt, not_neBot]
 
 /-- In any topological space, we form a filter from the supremum of all punctured neighborhoods. -/
-abbrev Filter.codiscrete (X : Type*) [TopologicalSpace X] : Filter X := codiscreteWithin Set.univ
+def Filter.codiscrete (X : Type*) [TopologicalSpace X] : Filter X := codiscreteWithin Set.univ
 
 lemma mem_codiscrete {S : Set X} :
     S ∈ codiscrete X ↔ ∀ x, Disjoint (𝓝[≠] x) (𝓟 Sᶜ) := by
@@ -133,7 +134,7 @@ lemma mem_codiscrete' {S : Set X} :
 
 lemma mem_codiscrete_subtype_iff_mem_codiscreteWithin {S : Set X} {U : Set S} :
     U ∈ codiscrete S ↔ Subtype.val '' U ∈ codiscreteWithin S := by
-  simp only [mem_codiscrete, disjoint_principal_right, compl_compl, Subtype.forall,
+  simp [mem_codiscrete, disjoint_principal_right, compl_compl, Subtype.forall,
     mem_codiscreteWithin]
   congr! with x hx
   constructor

--- a/Mathlib/Topology/DiscreteSubset.lean
+++ b/Mathlib/Topology/DiscreteSubset.lean
@@ -126,7 +126,6 @@ lemma mem_codiscrete' {S : Set X} :
   rw [mem_codiscrete, ← isClosed_compl_iff, isClosed_and_discrete_iff]
 
 lemma mem_codiscrete_subtype_iff_mem_codiscreteWithin {S : Set X} {U : Set S} :
-    U ∈ codiscrete S ↔ Subtype.val '' U ∈ codiscreteWithin S := by
     U ∈ codiscrete S ↔ (↑) '' U ∈ codiscreteWithin S := by
   simp [mem_codiscrete, disjoint_principal_right, compl_compl, Subtype.forall,
     mem_codiscreteWithin]

--- a/Mathlib/Topology/DiscreteSubset.lean
+++ b/Mathlib/Topology/DiscreteSubset.lean
@@ -30,9 +30,9 @@ see `IsClosed.tendsto_coe_cofinite_iff`.
 
 ## Co-discrete open sets
 
-In a topological space the sets which are open with discrete complement form a filter. We
-formalise this as `Filter.codiscrete`. This is also the supremum of all punctured neighborhoods.
-We also define `Filter.codiscreteWithin`, which is a filter of codiscrete functions on a subset.
+We define the filter `Filter.codiscreteWithin S`, which is the supremum of all `𝓝[S \ {x}] x`.
+This is the filter of all open codiscrete sets within S. We also define `Filter.codiscrete` as
+`Filter.codiscreteWithin univ`, which is the filter of all open codiscrete sets in the space.
 
 -/
 

--- a/Mathlib/Topology/DiscreteSubset.lean
+++ b/Mathlib/Topology/DiscreteSubset.lean
@@ -92,32 +92,25 @@ theorem isClosed_and_discrete_iff {S : Set X} :
   · refine ⟨fun hx ↦ ?_, fun _ ↦ H⟩
     simpa [disjoint_iff, nhdsWithin, inf_assoc, hx] using H
 
-/-- We can create a filter of sets with no accumulation points inside a subset. -/
+/-- The filter of sets with no accumulation points inside a set `S : Set X`, implemented
+as the supremum over all punctured neighborhoods within `S`.  -/
 def Filter.codiscreteWithin (S : Set X) : Filter X := ⨆ x ∈ S, 𝓝[S \ {x}] x
 
 lemma mem_codiscreteWithin {S T : Set X} :
     S ∈ codiscreteWithin T ↔ ∀ x ∈ T, Disjoint (𝓝[≠] x) (𝓟 (T \ S)) := by
-  simp only [codiscreteWithin, mem_iSup, mem_nhdsWithin, disjoint_principal_right]
-  congr! 6 with x - u
-  constructor
-  · intro h _ _
-    simp only [mem_compl_iff, mem_diff, not_and, not_not]
-    intro _
-    apply h
-    simp_all
-  · intro h x hx
-    simp_all only [mem_inter_iff, mem_diff, mem_singleton_iff]
-    suffices x ∈ (T \ S)ᶜ by
-      simp only [mem_compl_iff, mem_diff, not_and, not_not] at this
-      exact this hx.2.1
-    apply h
-    simp_all
+  simp only [codiscreteWithin, mem_iSup, mem_nhdsWithin, disjoint_principal_right, subset_def,
+    mem_diff, mem_inter_iff, mem_compl_iff]
+  congr! 7 with x - u y
+  tauto
 
 lemma mem_codiscreteWithin_accPt {S T : Set X} :
     S ∈ codiscreteWithin T ↔ ∀ x ∈ T, ¬AccPt x (𝓟 (T \ S)) := by
   simp only [mem_codiscreteWithin, disjoint_iff, AccPt, not_neBot]
 
-/-- In any topological space, we form a filter from the supremum of all punctured neighborhoods. -/
+/-- In any topological space, the open sets with with discrete complement form a filter,
+defined as the supremum of all punctured neighborhoods.
+
+See `Filter.mem_codiscrete'` for the equivalence. -/
 def Filter.codiscrete (X : Type*) [TopologicalSpace X] : Filter X := codiscreteWithin Set.univ
 
 lemma mem_codiscrete {S : Set X} :
@@ -134,33 +127,19 @@ lemma mem_codiscrete' {S : Set X} :
 
 lemma mem_codiscrete_subtype_iff_mem_codiscreteWithin {S : Set X} {U : Set S} :
     U ∈ codiscrete S ↔ Subtype.val '' U ∈ codiscreteWithin S := by
+    U ∈ codiscrete S ↔ (↑) '' U ∈ codiscreteWithin S := by
   simp [mem_codiscrete, disjoint_principal_right, compl_compl, Subtype.forall,
     mem_codiscreteWithin]
   congr! with x hx
   constructor
-  · intro h
-    rw [nhdsWithin_subtype] at h
-    simp only [mem_comap] at h
-    obtain ⟨t, ht1, ht2⟩ := h
-    simp [mem_nhdsWithin] at ht1 ⊢
+  · rw [nhdsWithin_subtype, mem_comap]
+    rintro ⟨t, ht1, ht2⟩
+    rw [mem_nhdsWithin] at ht1 ⊢
     obtain ⟨u, hu1, hu2, hu3⟩ := ht1
-    use u, hu1, hu2
-    intro v hv
-    simp only [mem_compl_iff, mem_diff, mem_image, Subtype.exists, exists_and_right,
-      exists_eq_right, not_exists, not_and, not_forall, not_not]
-    intro hv2
-    use hv2
-    apply ht2
-    simp only [mem_preimage]
-    apply hu3
-    simpa [hv2]
-  · intro h
-    have : Tendsto Subtype.val (𝓝[≠] ⟨x, hx⟩) (𝓝[≠] x) :=
-      tendsto_nhdsWithin_of_tendsto_nhds_of_eventually_within _
+    refine ⟨u, hu1, hu2, fun v hv ↦ ?_⟩
+    simpa using fun hv2 ↦ ⟨hv2, ht2 <| hu3 <| by simpa [hv2]⟩
+  · suffices Tendsto (↑) (𝓝[≠] (⟨x, hx⟩ : S)) (𝓝[≠] x) by convert tendsto_def.mp this _; ext; simp
+    exact tendsto_nhdsWithin_of_tendsto_nhds_of_eventually_within _
       continuous_subtype_val.continuousWithinAt <| eventually_mem_nhdsWithin.mono (by simp)
-    rw [tendsto_def] at this
-    convert this _ h
-    ext
-    simp
 
 end codiscrete_filter


### PR DESCRIPTION
Prove lemmas about the codiscrete filter.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
