### PR TITLE
feat(Dynamics.Flow): add a notion of invariance under a map

### DIFF
--- a/Mathlib/Dynamics/Flow.lean
+++ b/Mathlib/Dynamics/Flow.lean
@@ -49,12 +49,8 @@ theorem isInvariant_iff_image {ϕ : τ → α → α} {s : Set α} :
   simp_rw [IsInvariant, mapsTo']
 #align is_invariant_iff_image isInvariant_iff_image
 
-theorem isInvariant_apply {ϕ : τ → α → α} {s : Set α} (h : IsInvariant ϕ s) (t : τ) {x : α}
-    (hx : x ∈ s) :
-    ϕ t x ∈ s := by
-  apply isInvariant_iff_image.1 h t
-  rw [mem_image]
-  use x, hx
+theorem isInvariant_mem {ϕ : τ → α → α} {s : Set α} (h : IsInvariant ϕ s) (t : τ) {x : α}
+    (hx : x ∈ s) : ϕ t x ∈ s := isInvariant_iff_image.1 h t (mem_image_of_mem (ϕ t) hx)
 
 /-- A set `s ⊆ α` is forward-invariant under `ϕ : τ → α → α` if
     `ϕ t s ⊆ s` for all `t ≥ 0`. -/
@@ -80,22 +76,13 @@ theorem isFwInvariant_iff_isInvariant [CanonicallyOrderedAddCommMonoid τ] {ϕ :
   ⟨IsFwInvariant.isInvariant, IsInvariant.isFwInvariant⟩
 #align is_fw_invariant_iff_is_invariant isFwInvariant_iff_isInvariant
 
-/-- Actions of `ℕ` are defined by a single map. This definition is  -/
-def IsMapInvariant (T : α → α) (s : Set α) : Prop :=
-  MapsTo T s s
-
 /-- For actions of `ℕ`, it suffices to check the first iterate. -/
-theorem isMapInvariant_iff_isInvariant {T : α → α} {s : Set α} :
-    IsMapInvariant T s ↔ IsInvariant (fun n : ℕ ↦ T^[n]) s := by
-  refine Iff.intro (fun h n ↦ Set.MapsTo.iterate h n) (fun h ↦ ?_)
+theorem mapsTo_self_iff_isInvariant_nat {T : α → α} {s : Set α} :
+    MapsTo T s s ↔ IsInvariant (fun n : ℕ ↦ T^[n]) s := by
+  refine Iff.intro (fun h n ↦ MapsTo.iterate h n) (fun h ↦ ?_)
   specialize h 1
   simp only [iterate_one] at h
   exact h
-
-theorem isMapInvariant_apply {T : α → α} {s : Set α} (h : IsMapInvariant T s) (n : ℕ) {x : α}
-    (hx : x ∈ s) :
-    T^[n] x ∈ s :=
-  isInvariant_apply (isMapInvariant_iff_isInvariant.1 h) n hx
 
 end Invariant
 

--- a/Mathlib/Dynamics/Flow.lean
+++ b/Mathlib/Dynamics/Flow.lean
@@ -44,11 +44,17 @@ def IsInvariant (ϕ : τ → α → α) (s : Set α) : Prop :=
   ∀ t, MapsTo (ϕ t) s s
 #align is_invariant IsInvariant
 
-variable (ϕ : τ → α → α) (s : Set α)
-
-theorem isInvariant_iff_image : IsInvariant ϕ s ↔ ∀ t, ϕ t '' s ⊆ s := by
+theorem isInvariant_iff_image {ϕ : τ → α → α} {s : Set α} :
+    IsInvariant ϕ s ↔ ∀ t, ϕ t '' s ⊆ s := by
   simp_rw [IsInvariant, mapsTo']
 #align is_invariant_iff_image isInvariant_iff_image
+
+theorem isInvariant_apply {ϕ : τ → α → α} {s : Set α} (h : IsInvariant ϕ s) (t : τ) {x : α}
+    (hx : x ∈ s) :
+    ϕ t x ∈ s := by
+  apply isInvariant_iff_image.1 h t
+  rw [mem_image]
+  use x, hx
 
 /-- A set `s ⊆ α` is forward-invariant under `ϕ : τ → α → α` if
     `ϕ t s ⊆ s` for all `t ≥ 0`. -/
@@ -73,6 +79,23 @@ theorem isFwInvariant_iff_isInvariant [CanonicallyOrderedAddCommMonoid τ] {ϕ :
     IsFwInvariant ϕ s ↔ IsInvariant ϕ s :=
   ⟨IsFwInvariant.isInvariant, IsInvariant.isFwInvariant⟩
 #align is_fw_invariant_iff_is_invariant isFwInvariant_iff_isInvariant
+
+/-- Actions of `ℕ` are defined by a single map. This definition is  -/
+def IsMapInvariant (T : α → α) (s : Set α) : Prop :=
+  MapsTo T s s
+
+/-- For actions of `ℕ`, it suffices to check the first iterate. -/
+theorem isMapInvariant_iff_isInvariant {T : α → α} {s : Set α} :
+    IsMapInvariant T s ↔ IsInvariant (fun n : ℕ ↦ T^[n]) s := by
+  refine Iff.intro (fun h n ↦ Set.MapsTo.iterate h n) (fun h ↦ ?_)
+  specialize h 1
+  simp only [iterate_one] at h
+  exact h
+
+theorem isMapInvariant_apply {T : α → α} {s : Set α} (h : IsMapInvariant T s) (n : ℕ) {x : α}
+    (hx : x ∈ s) :
+    T^[n] x ∈ s :=
+  isInvariant_apply (isMapInvariant_iff_isInvariant.1 h) n hx
 
 end Invariant
 
@@ -156,7 +179,7 @@ variable {τ : Type*} [AddCommGroup τ] [TopologicalSpace τ] [TopologicalAddGro
   {α : Type*} [TopologicalSpace α] (ϕ : Flow τ α)
 
 theorem isInvariant_iff_image_eq (s : Set α) : IsInvariant ϕ s ↔ ∀ t, ϕ t '' s = s :=
-  (isInvariant_iff_image _ _).trans
+  isInvariant_iff_image.trans
     (Iff.intro
       (fun h t => Subset.antisymm (h t) fun _ hx => ⟨_, h (-t) ⟨_, hx, rfl⟩, by simp [← map_add]⟩)
       fun h t => by rw [h t])

--- a/Mathlib/Dynamics/OmegaLimit.lean
+++ b/Mathlib/Dynamics/OmegaLimit.lean
@@ -373,7 +373,7 @@ theorem omegaLimit_omegaLimit (hf : ∀ t, Tendsto (t + ·) f f) : ω f ϕ (ω f
   have l₁ : (ω f ϕ s ∩ o).Nonempty :=
     ht₂.mono
       (inter_subset_inter_left _
-        ((isInvariant_iff_image _ _).mp (isInvariant_omegaLimit _ _ _ hf) _))
+        (isInvariant_iff_image.1 (isInvariant_omegaLimit _ _ _ hf) _))
   have l₂ : (closure (image2 ϕ u s) ∩ o).Nonempty :=
     l₁.mono fun b hb ↦ ⟨omegaLimit_subset_closure_fw_image _ _ _ hu hb.1, hb.2⟩
   have l₃ : (o ∩ image2 ϕ u s).Nonempty := by


### PR DESCRIPTION
The file had a notion of invariance under a family of maps or a monoid action.

Actions of Nat are determined by a single action. ~We give a simpler version `IsMapInvariant` of invariance in this case, and prove its equivalence with the more general one.~ This is the new lemma `mapsTo_self_iff_isinvariant_nat`

I did some additional cleaning (made some variables implicit and added a `mem` lemma for easier use).

~Note: The current state of Dynamics.Flow is not very convincing, as it is half about invariance and half about flows. It should probably be split in two files (and the section about invariance expanded). In the meantime, this PR is a quick fix for another project.~

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
