### PR TITLE
[Merged by Bors] - chore: remove unused imports

### DIFF
--- a/Mathlib/Control/Traversable/Basic.lean
+++ b/Mathlib/Control/Traversable/Basic.lean
@@ -5,7 +5,6 @@ Authors: Simon Hudon
 -/
 import Mathlib.Data.Option.Defs
 import Mathlib.Control.Functor
-import Batteries.Data.List.Basic
 
 #align_import control.traversable.basic from "leanprover-community/mathlib"@"1fc36cc9c8264e6e81253f88be7fb2cb6c92d76a"
 

--- a/Mathlib/Data/List/Defs.lean
+++ b/Mathlib/Data/List/Defs.lean
@@ -8,7 +8,6 @@ import Mathlib.Control.Functor
 import Mathlib.Data.SProd
 import Mathlib.Util.CompileInductive
 import Batteries.Tactic.Lint.Basic
-import Batteries.Data.List.Lemmas
 
 #align_import data.list.defs from "leanprover-community/mathlib"@"d2d8742b0c21426362a9dacebc6005db895ca963"
 

--- a/Mathlib/Data/Nat/BitIndices.lean
+++ b/Mathlib/Data/Nat/BitIndices.lean
@@ -3,7 +3,6 @@ Copyright (c) 2024 Peter Nelson. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Peter Nelson
 -/
-import Batteries.Data.List.Pairwise
 import Mathlib.Data.List.Sort
 import Mathlib.Data.Nat.Bitwise
 import Mathlib.Algebra.BigOperators.Ring.List

--- a/Mathlib/Lean/Meta/Simp.lean
+++ b/Mathlib/Lean/Meta/Simp.lean
@@ -3,7 +3,6 @@ Copyright (c) 2022 Scott Morrison. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Scott Morrison, Gabriel Ebner, Floris van Doorn
 -/
-import Batteries.Tactic.OpenPrivate
 import Lean.Elab.Tactic.Simp
 
 /-!

--- a/Mathlib/Tactic/ApplyCongr.lean
+++ b/Mathlib/Tactic/ApplyCongr.lean
@@ -5,7 +5,6 @@ Authors: Lucas Allen, Scott Morrison
 -/
 
 import Mathlib.Tactic.Conv
-import Batteries.Tactic.OpenPrivate
 
 /-!
 ## Introduce the `apply_congr` conv mode tactic.

--- a/Mathlib/Tactic/FunProp/Core.lean
+++ b/Mathlib/Tactic/FunProp/Core.lean
@@ -4,8 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Tomas Skrivan
 -/
 import Lean
-import Batteries.Tactic.Exact
-
 import Mathlib.Tactic.FunProp.Theorems
 import Mathlib.Tactic.FunProp.ToBatteries
 import Mathlib.Tactic.FunProp.Types

--- a/Mathlib/Tactic/FunProp/FunctionData.lean
+++ b/Mathlib/Tactic/FunProp/FunctionData.lean
@@ -6,7 +6,6 @@ Authors: Tomas Skrivan
 import Lean
 import Qq
 
-import Batteries.Lean.Expr
 import Mathlib.Tactic.FunProp.Mor
 
 /-!

--- a/Mathlib/Tactic/NormNum/Core.lean
+++ b/Mathlib/Tactic/NormNum/Core.lean
@@ -3,7 +3,6 @@ Copyright (c) 2022 Mario Carneiro. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Mario Carneiro
 -/
-import Batteries.Lean.Meta.DiscrTree
 import Mathlib.Tactic.NormNum.Result
 import Mathlib.Util.Qq
 import Lean.Elab.Tactic.Location

--- a/Mathlib/Tactic/Widget/Calc.lean
+++ b/Mathlib/Tactic/Widget/Calc.lean
@@ -4,7 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Patrick Massot
 -/
 import Lean.Elab.Tactic.Calc
-import Batteries.CodeAction
 
 import Mathlib.Data.String.Defs
 import Mathlib.Tactic.Widget.SelectPanelUtils

--- a/Mathlib/Tactic/Widget/Conv.lean
+++ b/Mathlib/Tactic/Widget/Conv.lean
@@ -5,7 +5,6 @@ Authors: Robin Böhne, Wojciech Nawrocki, Patrick Massot
 -/
 import Mathlib.Tactic.Widget.SelectPanelUtils
 import Mathlib.Data.String.Defs
-import Batteries.Lean.Position
 import Batteries.Tactic.Lint
 
 /-! # Conv widget

--- a/Mathlib/Util/WhatsNew.lean
+++ b/Mathlib/Util/WhatsNew.lean
@@ -4,7 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Gabriel Ebner
 -/
 import Lean
-import Batteries.Tactic.OpenPrivate
 
 /-!
 Defines a command wrapper that prints the changes the command makes to the


### PR DESCRIPTION
These are all unused imports of files in Batteries, that are missed by `shake` because of `noshake`.