### PR TITLE
[Merged by Bors] - feat(MeasureTheory): adding setLintegral_compl and setIntegral_compl theorems.

### DIFF
--- a/Mathlib/MeasureTheory/Integral/Lebesgue.lean
+++ b/Mathlib/MeasureTheory/Integral/Lebesgue.lean
@@ -1442,6 +1442,11 @@ theorem lintegral_add_compl (f : α → ℝ≥0∞) {A : Set α} (hA : Measurabl
   rw [← lintegral_add_measure, Measure.restrict_add_restrict_compl hA]
 #align measure_theory.lintegral_add_compl MeasureTheory.lintegral_add_compl
 
+theorem setLintegral_compl {f : α → ℝ≥0∞} {s : Set α} (hsm : MeasurableSet s)
+    (hfs : ∫⁻ x in s, f x ∂μ ≠ ∞) :
+    ∫⁻ x in sᶜ, f x ∂μ = ∫⁻ x, f x ∂μ - ∫⁻ x in s, f x ∂μ := by
+  rw [← lintegral_add_compl (μ := μ) f hsm, ENNReal.add_sub_cancel_left hfs]
+
 theorem setLIntegral_iUnion_of_directed {ι : Type*} [Countable ι]
     (f : α → ℝ≥0∞) {s : ι → Set α} (hd : Directed (· ⊆ ·) s) :
     ∫⁻ x in ⋃ i, s i, f x ∂μ = ⨆ i, ∫⁻ x in s i, f x ∂μ := by
@@ -1595,6 +1600,51 @@ theorem setLIntegral_subtype {s : Set α} (hs : MeasurableSet s) (t : Set s) (f 
     ∫⁻ x in t, f x ∂(μ.comap (↑)) = ∫⁻ x in (↑) '' t, f x ∂μ := by
   rw [(MeasurableEmbedding.subtype_coe hs).restrict_comap, lintegral_subtype_comap hs,
     restrict_restrict hs, inter_eq_right.2 (Subtype.coe_image_subset _ _)]
+
+section UnifTight
+
+/-- If `f : α → ℝ≥0∞` has finite integral, then there exists a measurable set `s` of finite measure
+such that the integral of `f` over `sᶜ` is less than a given positive number.
+
+Also used to prove an `Lᵖ`-norm version in `MeasureTheory.Memℒp.exists_snorm_indicator_compl_le`. -/
+theorem exists_setLintegral_compl_lt {f : α → ℝ≥0∞} (hf : ∫⁻ a, f a ∂μ ≠ ∞)
+    {ε : ℝ≥0∞} (hε : ε ≠ 0) :
+    ∃ s : Set α, MeasurableSet s ∧ μ s < ∞ ∧ ∫⁻ a in sᶜ, f a ∂μ < ε := by
+  by_cases hf₀ : ∫⁻ a, f a ∂μ = 0
+  · exact ⟨∅, .empty, by simp, by simpa [hf₀, pos_iff_ne_zero]⟩
+  obtain ⟨g, hgf, hg_meas, hgsupp, hgε⟩ :
+      ∃ g ≤ f, Measurable g ∧ μ (support g) < ∞ ∧ ∫⁻ a, f a ∂μ - ε < ∫⁻ a, g a ∂μ := by
+    obtain ⟨g, hgf, hgε⟩ : ∃ (g : α →ₛ ℝ≥0∞) (_ : g ≤ f), ∫⁻ a, f a ∂μ - ε < g.lintegral μ := by
+      simpa only [← lt_iSup_iff, ← lintegral_def] using ENNReal.sub_lt_self hf hf₀ hε
+    refine ⟨g, hgf, g.measurable, ?_, by rwa [g.lintegral_eq_lintegral]⟩
+    exact SimpleFunc.FinMeasSupp.of_lintegral_ne_top <| ne_top_of_le_ne_top hf <|
+      g.lintegral_eq_lintegral μ ▸ lintegral_mono hgf
+  refine ⟨_, measurableSet_support hg_meas, hgsupp, ?_⟩
+  calc
+    ∫⁻ a in (support g)ᶜ, f a ∂μ
+      = ∫⁻ a in (support g)ᶜ, f a - g a ∂μ := setLIntegral_congr_fun
+      (measurableSet_support hg_meas).compl <| ae_of_all _ <| by intro; simp_all
+    _ ≤ ∫⁻ a, f a - g a ∂μ := setLIntegral_le_lintegral _ _
+    _ = ∫⁻ a, f a ∂μ - ∫⁻ a, g a ∂μ :=
+      lintegral_sub hg_meas (ne_top_of_le_ne_top hf <| lintegral_mono hgf) (ae_of_all _ hgf)
+    _ < ε := ENNReal.sub_lt_of_lt_add (lintegral_mono hgf) <|
+      ENNReal.lt_add_of_sub_lt_left (.inl hf) hgε
+
+/-- For any function `f : α → ℝ≥0∞`, there exists a measurable function `g ≤ f` with the same
+integral over any measurable set. -/
+theorem exists_measurable_le_setLintegral_eq_of_integrable {f : α → ℝ≥0∞} (hf : ∫⁻ a, f a ∂μ ≠ ∞) :
+    ∃ (g : α → ℝ≥0∞), Measurable g ∧ g ≤ f ∧ ∀ s : Set α, MeasurableSet s →
+      ∫⁻ a in s, f a ∂μ = ∫⁻ a in s, g a ∂μ := by
+  obtain ⟨g, hmg, hgf, hifg⟩ := exists_measurable_le_lintegral_eq (μ := μ) f
+  use g, hmg, hgf
+  refine fun s hms ↦ le_antisymm ?_ (lintegral_mono hgf)
+  rw [← compl_compl s, setLintegral_compl hms.compl, setLintegral_compl hms.compl, hifg]
+  · gcongr; apply hgf
+  · rw [hifg] at hf
+    exact ne_top_of_le_ne_top hf (setLIntegral_le_lintegral _ _)
+  · exact ne_top_of_le_ne_top hf (setLIntegral_le_lintegral _ _)
+
+end UnifTight
 
 @[deprecated (since := "2024-06-29")]
 alias set_lintegral_subtype := setLIntegral_subtype

--- a/Mathlib/MeasureTheory/Integral/Lebesgue.lean
+++ b/Mathlib/MeasureTheory/Integral/Lebesgue.lean
@@ -1601,51 +1601,6 @@ theorem setLIntegral_subtype {s : Set α} (hs : MeasurableSet s) (t : Set s) (f 
   rw [(MeasurableEmbedding.subtype_coe hs).restrict_comap, lintegral_subtype_comap hs,
     restrict_restrict hs, inter_eq_right.2 (Subtype.coe_image_subset _ _)]
 
-section UnifTight
-
-/-- If `f : α → ℝ≥0∞` has finite integral, then there exists a measurable set `s` of finite measure
-such that the integral of `f` over `sᶜ` is less than a given positive number.
-
-Also used to prove an `Lᵖ`-norm version in `MeasureTheory.Memℒp.exists_snorm_indicator_compl_le`. -/
-theorem exists_setLintegral_compl_lt {f : α → ℝ≥0∞} (hf : ∫⁻ a, f a ∂μ ≠ ∞)
-    {ε : ℝ≥0∞} (hε : ε ≠ 0) :
-    ∃ s : Set α, MeasurableSet s ∧ μ s < ∞ ∧ ∫⁻ a in sᶜ, f a ∂μ < ε := by
-  by_cases hf₀ : ∫⁻ a, f a ∂μ = 0
-  · exact ⟨∅, .empty, by simp, by simpa [hf₀, pos_iff_ne_zero]⟩
-  obtain ⟨g, hgf, hg_meas, hgsupp, hgε⟩ :
-      ∃ g ≤ f, Measurable g ∧ μ (support g) < ∞ ∧ ∫⁻ a, f a ∂μ - ε < ∫⁻ a, g a ∂μ := by
-    obtain ⟨g, hgf, hgε⟩ : ∃ (g : α →ₛ ℝ≥0∞) (_ : g ≤ f), ∫⁻ a, f a ∂μ - ε < g.lintegral μ := by
-      simpa only [← lt_iSup_iff, ← lintegral_def] using ENNReal.sub_lt_self hf hf₀ hε
-    refine ⟨g, hgf, g.measurable, ?_, by rwa [g.lintegral_eq_lintegral]⟩
-    exact SimpleFunc.FinMeasSupp.of_lintegral_ne_top <| ne_top_of_le_ne_top hf <|
-      g.lintegral_eq_lintegral μ ▸ lintegral_mono hgf
-  refine ⟨_, measurableSet_support hg_meas, hgsupp, ?_⟩
-  calc
-    ∫⁻ a in (support g)ᶜ, f a ∂μ
-      = ∫⁻ a in (support g)ᶜ, f a - g a ∂μ := setLIntegral_congr_fun
-      (measurableSet_support hg_meas).compl <| ae_of_all _ <| by intro; simp_all
-    _ ≤ ∫⁻ a, f a - g a ∂μ := setLIntegral_le_lintegral _ _
-    _ = ∫⁻ a, f a ∂μ - ∫⁻ a, g a ∂μ :=
-      lintegral_sub hg_meas (ne_top_of_le_ne_top hf <| lintegral_mono hgf) (ae_of_all _ hgf)
-    _ < ε := ENNReal.sub_lt_of_lt_add (lintegral_mono hgf) <|
-      ENNReal.lt_add_of_sub_lt_left (.inl hf) hgε
-
-/-- For any function `f : α → ℝ≥0∞`, there exists a measurable function `g ≤ f` with the same
-integral over any measurable set. -/
-theorem exists_measurable_le_setLintegral_eq_of_integrable {f : α → ℝ≥0∞} (hf : ∫⁻ a, f a ∂μ ≠ ∞) :
-    ∃ (g : α → ℝ≥0∞), Measurable g ∧ g ≤ f ∧ ∀ s : Set α, MeasurableSet s →
-      ∫⁻ a in s, f a ∂μ = ∫⁻ a in s, g a ∂μ := by
-  obtain ⟨g, hmg, hgf, hifg⟩ := exists_measurable_le_lintegral_eq (μ := μ) f
-  use g, hmg, hgf
-  refine fun s hms ↦ le_antisymm ?_ (lintegral_mono hgf)
-  rw [← compl_compl s, setLintegral_compl hms.compl, setLintegral_compl hms.compl, hifg]
-  · gcongr; apply hgf
-  · rw [hifg] at hf
-    exact ne_top_of_le_ne_top hf (setLIntegral_le_lintegral _ _)
-  · exact ne_top_of_le_ne_top hf (setLIntegral_le_lintegral _ _)
-
-end UnifTight
-
 @[deprecated (since := "2024-06-29")]
 alias set_lintegral_subtype := setLIntegral_subtype
 

--- a/Mathlib/MeasureTheory/Integral/SetIntegral.lean
+++ b/Mathlib/MeasureTheory/Integral/SetIntegral.lean
@@ -178,6 +178,10 @@ theorem integral_add_compl (hs : MeasurableSet s) (hfi : Integrable f μ) :
   integral_add_compl₀ hs.nullMeasurableSet hfi
 #align measure_theory.integral_add_compl MeasureTheory.integral_add_compl
 
+theorem setIntegral_compl (hs : MeasurableSet s) (hfi : Integrable f μ) :
+    ∫ x in sᶜ, f x ∂μ = ∫ x, f x ∂μ - ∫ x in s, f x ∂μ := by
+  rw [← integral_add_compl (μ := μ) hs hfi, add_sub_cancel_left]
+
 /-- For a function `f` and a measurable set `s`, the integral of `indicator s f`
 over the whole space is equal to `∫ x in s, f x ∂μ` defined as `∫ x, f x ∂(μ.restrict s)`. -/
 theorem integral_indicator (hs : MeasurableSet s) :

--- a/Mathlib/Probability/Martingale/Convergence.lean
+++ b/Mathlib/Probability/Martingale/Convergence.lean
@@ -401,10 +401,9 @@ theorem Integrable.tendsto_ae_condexp (hg : Integrable g μ)
   · rintro t ⟨n, ht⟩ -
     exact this n _ ht
   · rintro t htmeas ht -
-    have hgeq := @integral_add_compl _ _ (⨆ n, ℱ n) _ _ _ _ _ htmeas (hg.trim hle hgmeas)
-    have hheq := @integral_add_compl _ _ (⨆ n, ℱ n) _ _ _ _ _ htmeas
+    have hgeq := @setIntegral_compl _ _ (⨆ n, ℱ n) _ _ _ _ _ htmeas (hg.trim hle hgmeas)
+    have hheq := @setIntegral_compl _ _ (⨆ n, ℱ n) _ _ _ _ _ htmeas
       (hlimint.trim hle stronglyMeasurable_limitProcess)
-    rw [add_comm, ← eq_sub_iff_add_eq] at hgeq hheq
     rw [setIntegral_trim hle hgmeas htmeas.compl,
       setIntegral_trim hle stronglyMeasurable_limitProcess htmeas.compl, hgeq, hheq, ←
       setIntegral_trim hle hgmeas htmeas, ←


### PR DESCRIPTION
Adding setLintegral_compl and setIntegral_compl theorems for convenience. setIntegral_compl is used immediately to simplify a few lines in Martingale.Convergence.lean.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
