### PR TITLE
[Merged by Bors] - refactor(GroupTheory/Complement,SchurZassenhaus): Replace `Fintype.card` with `Nat.card`

### DIFF
--- a/Mathlib/GroupTheory/Complement.lean
+++ b/Mathlib/GroupTheory/Complement.lean
@@ -700,13 +700,13 @@ theorem IsComplement'.index_eq_card (h : IsComplement' H K) : K.index = Nat.card
   (card_left_transversal h).symm
 #align subgroup.is_complement'.index_eq_card Subgroup.IsComplement'.index_eq_card
 
-theorem IsComplement.card_mul [Fintype G] [Fintype S] [Fintype T] (h : IsComplement S T) :
-    Fintype.card S * Fintype.card T = Fintype.card G :=
-  (Fintype.card_prod _ _).symm.trans (Fintype.card_of_bijective h)
+theorem IsComplement.card_mul (h : IsComplement S T) :
+    Nat.card S * Nat.card T = Nat.card G :=
+  (Nat.card_prod _ _).symm.trans (Nat.card_eq_of_bijective _ h)
 #align subgroup.is_complement.card_mul Subgroup.IsComplement.card_mul
 
-theorem IsComplement'.card_mul [Fintype G] [Fintype H] [Fintype K] (h : IsComplement' H K) :
-    Fintype.card H * Fintype.card K = Fintype.card G :=
+theorem IsComplement'.card_mul (h : IsComplement' H K) :
+    Nat.card H * Nat.card K = Nat.card G :=
   IsComplement.card_mul h
 #align subgroup.is_complement'.card_mul Subgroup.IsComplement'.card_mul
 
@@ -717,21 +717,21 @@ theorem isComplement'_of_disjoint_and_mul_eq_univ (h1 : Disjoint H K)
   exact ⟨(⟨h, hh⟩, ⟨k, hk⟩), hg⟩
 #align subgroup.is_complement'_of_disjoint_and_mul_eq_univ Subgroup.isComplement'_of_disjoint_and_mul_eq_univ
 
-theorem isComplement'_of_card_mul_and_disjoint [Fintype G] [Fintype H] [Fintype K]
-    (h1 : Fintype.card H * Fintype.card K = Fintype.card G) (h2 : Disjoint H K) :
+theorem isComplement'_of_card_mul_and_disjoint [Finite G]
+    (h1 : Nat.card H * Nat.card K = Nat.card G) (h2 : Disjoint H K) :
     IsComplement' H K :=
-  (Fintype.bijective_iff_injective_and_card _).mpr
-    ⟨mul_injective_of_disjoint h2, (Fintype.card_prod H K).trans h1⟩
+  (Nat.bijective_iff_injective_and_card _).mpr
+    ⟨mul_injective_of_disjoint h2, (Nat.card_prod H K).trans h1⟩
 #align subgroup.is_complement'_of_card_mul_and_disjoint Subgroup.isComplement'_of_card_mul_and_disjoint
 
-theorem isComplement'_iff_card_mul_and_disjoint [Fintype G] [Fintype H] [Fintype K] :
-    IsComplement' H K ↔ Fintype.card H * Fintype.card K = Fintype.card G ∧ Disjoint H K :=
+theorem isComplement'_iff_card_mul_and_disjoint [Finite G] :
+    IsComplement' H K ↔ Nat.card H * Nat.card K = Nat.card G ∧ Disjoint H K :=
   ⟨fun h => ⟨h.card_mul, h.disjoint⟩, fun h => isComplement'_of_card_mul_and_disjoint h.1 h.2⟩
 #align subgroup.is_complement'_iff_card_mul_and_disjoint Subgroup.isComplement'_iff_card_mul_and_disjoint
 
-theorem isComplement'_of_coprime [Fintype G] [Fintype H] [Fintype K]
-    (h1 : Fintype.card H * Fintype.card K = Fintype.card G)
-    (h2 : Nat.Coprime (Fintype.card H) (Fintype.card K)) : IsComplement' H K :=
+theorem isComplement'_of_coprime [Finite G]
+    (h1 : Nat.card H * Nat.card K = Nat.card G)
+    (h2 : Nat.Coprime (Nat.card H) (Nat.card K)) : IsComplement' H K :=
   isComplement'_of_card_mul_and_disjoint h1 (disjoint_iff.mpr (inf_eq_bot_of_coprime h2))
 #align subgroup.is_complement'_of_coprime Subgroup.isComplement'_of_coprime
 

--- a/Mathlib/GroupTheory/Nilpotent.lean
+++ b/Mathlib/GroupTheory/Nilpotent.lean
@@ -870,7 +870,7 @@ theorem IsPGroup.isNilpotent [Finite G] {p : ℕ} [hp : Fact (Nat.Prime p)] (h :
       exact of_quotient_center_nilpotent hnq
 #align is_p_group.is_nilpotent IsPGroup.isNilpotent
 
-variable [Fintype G]
+variable [Finite G]
 
 /-- If a finite group is the direct product of its Sylow groups, it is nilpotent -/
 theorem isNilpotent_of_product_of_sylow_group

--- a/Mathlib/GroupTheory/OrderOfElement.lean
+++ b/Mathlib/GroupTheory/OrderOfElement.lean
@@ -1140,13 +1140,10 @@ lemma Nat.Coprime.pow_left_bijective (hn : (Nat.card G).Coprime n) : Bijective (
   (powCoprime hn).bijective
 
 @[to_additive add_inf_eq_bot_of_coprime]
-theorem inf_eq_bot_of_coprime {G : Type*} [Group G] {H K : Subgroup G} [Fintype H] [Fintype K]
-    (h : Nat.Coprime (Fintype.card H) (Fintype.card K)) : H ⊓ K = ⊥ := by
-  refine (H ⊓ K).eq_bot_iff_forall.mpr fun x hx => ?_
-  rw [← orderOf_eq_one_iff, ← Nat.dvd_one, ← h.gcd_eq_one, Nat.dvd_gcd_iff]
-  exact
-    ⟨(congr_arg (· ∣ Fintype.card H) (orderOf_coe ⟨x, hx.1⟩)).mpr orderOf_dvd_card,
-      (congr_arg (· ∣ Fintype.card K) (orderOf_coe ⟨x, hx.2⟩)).mpr orderOf_dvd_card⟩
+theorem inf_eq_bot_of_coprime {G : Type*} [Group G] {H K : Subgroup G}
+    (h : Nat.Coprime (Nat.card H) (Nat.card K)) : H ⊓ K = ⊥ :=
+  card_eq_one.mp (Nat.eq_one_of_dvd_coprimes h
+    (card_dvd_of_le inf_le_left) (card_dvd_of_le inf_le_right))
 #align inf_eq_bot_of_coprime inf_eq_bot_of_coprime
 #align add_inf_eq_bot_of_coprime add_inf_eq_bot_of_coprime
 

--- a/Mathlib/GroupTheory/SchurZassenhaus.lean
+++ b/Mathlib/GroupTheory/SchurZassenhaus.lean
@@ -140,11 +140,11 @@ The proof is by contradiction. We assume that `G` is a minimal counterexample to
 -/
 
 
-variable {G : Type u} [Group G] [Fintype G] {N : Subgroup G} [Normal N]
-  (h1 : Nat.Coprime (Fintype.card N) N.index)
-  (h2 : ∀ (G' : Type u) [Group G'] [Fintype G'],
-    Fintype.card G' < Fintype.card G → ∀ {N' : Subgroup G'} [N'.Normal],
-      Nat.Coprime (Fintype.card N') N'.index → ∃ H' : Subgroup G', IsComplement' N' H')
+variable {G : Type u} [Group G] [Finite G] {N : Subgroup G} [Normal N]
+  (h1 : Nat.Coprime (Nat.card N) N.index)
+  (h2 : ∀ (G' : Type u) [Group G'] [Finite G'],
+    Nat.card G' < Nat.card G → ∀ {N' : Subgroup G'} [N'.Normal],
+      Nat.Coprime (Nat.card N') N'.index → ∃ H' : Subgroup G', IsComplement' N' H')
   (h3 : ∀ H : Subgroup G, ¬IsComplement' N H)
 
 /-! We will arrive at a contradiction via the following steps:
@@ -166,7 +166,6 @@ private theorem step0 : N ≠ ⊥ := by
 
 /-- Do not use this lemma: It is made obsolete by `exists_right_complement'_of_coprime` -/
 private theorem step1 (K : Subgroup G) (hK : K ⊔ N = ⊤) : K = ⊤ := by
-  simp only [← Nat.card_eq_fintype_card] at h1 h2
   contrapose! h3
   have h4 : (N.comap K.subtype).index = N.index := by
     rw [← N.relindex_top_right, ← hK]
@@ -186,14 +185,12 @@ private theorem step1 (K : Subgroup G) (hK : K ⊔ N = ⊤) : K = ⊤ := by
     rw [hH, ← N.index_mul_card, mul_comm]
   have h8 : (Nat.card N).Coprime (Nat.card (H.map K.subtype)) := by
     rwa [hH]
-  simp only [Nat.card_eq_fintype_card] at h7 h8
   exact ⟨H.map K.subtype, isComplement'_of_coprime h7 h8⟩
 
 /-- Do not use this lemma: It is made obsolete by `exists_right_complement'_of_coprime` -/
 private theorem step2 (K : Subgroup G) [K.Normal] (hK : K ≤ N) : K = ⊥ ∨ K = N := by
   have : Function.Surjective (QuotientGroup.mk' K) := Quotient.surjective_Quotient_mk''
   have h4 := step1 h1 h2 h3
-  simp only [← Nat.card_eq_fintype_card] at h1 h2
   contrapose! h4
   have h5 : Nat.card (G ⧸ K) < Nat.card G := by
     rw [← index_eq_card, ← K.index_mul_card]
@@ -232,20 +229,18 @@ private theorem step3 (K : Subgroup N) [(K.map N.subtype).Normal] : K = ⊥ ∨ 
   rwa [inj.eq_iff, inj.eq_iff] at key
 
 /-- Do not use this lemma: It is made obsolete by `exists_right_complement'_of_coprime` -/
-private theorem step4 : (Fintype.card N).minFac.Prime := by
-  rw [← Nat.card_eq_fintype_card]
+private theorem step4 : (Nat.card N).minFac.Prime := by
   exact Nat.minFac_prime (N.one_lt_card_iff_ne_bot.mpr (step0 h1 h3)).ne'
 
 /-- Do not use this lemma: It is made obsolete by `exists_right_complement'_of_coprime` -/
-private theorem step5 {P : Sylow (Fintype.card N).minFac N} : P.1 ≠ ⊥ := by
-  haveI : Fact (Fintype.card N).minFac.Prime := ⟨step4 h1 h3⟩
+private theorem step5 {P : Sylow (Nat.card N).minFac N} : P.1 ≠ ⊥ := by
+  haveI : Fact (Nat.card N).minFac.Prime := ⟨step4 h1 h3⟩
   apply P.ne_bot_of_dvd_card
-  rw [← Nat.card_eq_fintype_card]
   exact (Nat.card N).minFac_dvd
 
 /-- Do not use this lemma: It is made obsolete by `exists_right_complement'_of_coprime` -/
-private theorem step6 : IsPGroup (Fintype.card N).minFac N := by
-  haveI : Fact (Fintype.card N).minFac.Prime := ⟨step4 h1 h3⟩
+private theorem step6 : IsPGroup (Nat.card N).minFac N := by
+  haveI : Fact (Nat.card N).minFac.Prime := ⟨step4 h1 h3⟩
   refine Sylow.nonempty.elim fun P => P.2.of_surjective P.1.subtype ?_
   rw [← MonoidHom.range_top_iff_surjective, subtype_range]
   haveI : (P.1.map N.subtype).Normal :=
@@ -255,7 +250,7 @@ private theorem step6 : IsPGroup (Fintype.card N).minFac N := by
 /-- Do not use this lemma: It is made obsolete by `exists_right_complement'_of_coprime` -/
 theorem step7 : IsCommutative N := by
   haveI := N.bot_or_nontrivial.resolve_left (step0 h1 h3)
-  haveI : Fact (Fintype.card N).minFac.Prime := ⟨step4 h1 h3⟩
+  haveI : Fact (Nat.card N).minFac.Prime := ⟨step4 h1 h3⟩
   exact
     ⟨⟨fun g h => ((eq_top_iff.mp ((step3 h1 h2 h3 (center N)).resolve_left
       (step6 h1 h2 h3).bot_lt_center.ne') (mem_top h)).comm g).symm⟩⟩
@@ -266,24 +261,15 @@ end SchurZassenhausInduction
 variable {n : ℕ} {G : Type u} [Group G]
 
 /-- Do not use this lemma: It is made obsolete by `exists_right_complement'_of_coprime` -/
-private theorem exists_right_complement'_of_coprime_aux' [Fintype G] (hG : Fintype.card G = n)
-    {N : Subgroup G} [N.Normal] (hN : Nat.Coprime (Fintype.card N) N.index) :
+private theorem exists_right_complement'_of_coprime_aux' [Finite G] (hG : Nat.card G = n)
+    {N : Subgroup G} [N.Normal] (hN : Nat.Coprime (Nat.card N) N.index) :
     ∃ H : Subgroup G, IsComplement' N H := by
   revert G
   apply Nat.strongInductionOn n
   rintro n ih G _ _ rfl N _ hN
   refine not_forall_not.mp fun h3 => ?_
   haveI := SchurZassenhausInduction.step7 hN (fun G' _ _ hG' => by apply ih _ hG'; rfl) h3
-  rw [← Nat.card_eq_fintype_card] at hN
   exact not_exists_of_forall_not h3 (exists_right_complement'_of_coprime_aux hN)
-
-/-- **Schur-Zassenhaus** for normal subgroups:
-  If `H : Subgroup G` is normal, and has order coprime to its index, then there exists a
-  subgroup `K` which is a (right) complement of `H`. -/
-theorem exists_right_complement'_of_coprime_of_fintype [Fintype G] {N : Subgroup G} [N.Normal]
-    (hN : Nat.Coprime (Fintype.card N) N.index) : ∃ H : Subgroup G, IsComplement' N H :=
-  exists_right_complement'_of_coprime_aux' rfl hN
-#align subgroup.exists_right_complement'_of_coprime_of_fintype Subgroup.exists_right_complement'_of_coprime_of_fintype
 
 /-- **Schur-Zassenhaus** for normal subgroups:
   If `H : Subgroup G` is normal, and has order coprime to its index, then there exists a
@@ -304,17 +290,8 @@ theorem exists_right_complement'_of_coprime {N : Subgroup G} [N.Normal]
     exact mul_ne_zero hN1 hN2
   haveI := (Cardinal.lt_aleph0_iff_fintype.mp
     (lt_of_not_ge (mt Cardinal.toNat_apply_of_aleph0_le hN3))).some
-  apply exists_right_complement'_of_coprime_of_fintype
-  rwa [← Nat.card_eq_fintype_card]
+  exact exists_right_complement'_of_coprime_aux' rfl hN
 #align subgroup.exists_right_complement'_of_coprime Subgroup.exists_right_complement'_of_coprime
-
-/-- **Schur-Zassenhaus** for normal subgroups:
-  If `H : Subgroup G` is normal, and has order coprime to its index, then there exists a
-  subgroup `K` which is a (left) complement of `H`. -/
-theorem exists_left_complement'_of_coprime_of_fintype [Fintype G] {N : Subgroup G} [N.Normal]
-    (hN : Nat.Coprime (Fintype.card N) N.index) : ∃ H : Subgroup G, IsComplement' H N :=
-  Exists.imp (fun _ => IsComplement'.symm) (exists_right_complement'_of_coprime_of_fintype hN)
-#align subgroup.exists_left_complement'_of_coprime_of_fintype Subgroup.exists_left_complement'_of_coprime_of_fintype
 
 /-- **Schur-Zassenhaus** for normal subgroups:
   If `H : Subgroup G` is normal, and has order coprime to its index, then there exists a

--- a/Mathlib/GroupTheory/SchurZassenhaus.lean
+++ b/Mathlib/GroupTheory/SchurZassenhaus.lean
@@ -229,8 +229,8 @@ private theorem step3 (K : Subgroup N) [(K.map N.subtype).Normal] : K = ⊥ ∨ 
   rwa [inj.eq_iff, inj.eq_iff] at key
 
 /-- Do not use this lemma: It is made obsolete by `exists_right_complement'_of_coprime` -/
-private theorem step4 : (Nat.card N).minFac.Prime := by
-  exact Nat.minFac_prime (N.one_lt_card_iff_ne_bot.mpr (step0 h1 h3)).ne'
+private theorem step4 : (Nat.card N).minFac.Prime :=
+  Nat.minFac_prime (N.one_lt_card_iff_ne_bot.mpr (step0 h1 h3)).ne'
 
 /-- Do not use this lemma: It is made obsolete by `exists_right_complement'_of_coprime` -/
 private theorem step5 {P : Sylow (Nat.card N).minFac N} : P.1 ≠ ⊥ := by

--- a/Mathlib/SetTheory/Cardinal/Finite.lean
+++ b/Mathlib/SetTheory/Cardinal/Finite.lean
@@ -94,20 +94,15 @@ theorem card_eq_of_bijective (f : α → β) (hf : Function.Bijective f) : Nat.c
   card_congr (Equiv.ofBijective f hf)
 #align nat.card_eq_of_bijective Nat.card_eq_of_bijective
 
-protected theorem bijective_iff_injective_and_card [Fintype β] (f : α → β) :
+protected theorem bijective_iff_injective_and_card [Finite β] (f : α → β) :
     Bijective f ↔ Injective f ∧ Nat.card α = Nat.card β := by
-  -- Note this proof is a bit convoluted because we don’t assume `Fintype α` but derive it
-  -- in both branches
-  constructor
-  · intro h
-    have : Fintype α := Fintype.ofInjective f h.1
-    rw [Fintype.bijective_iff_injective_and_card] at h
-    rwa [card_eq_fintype_card, card_eq_fintype_card]
-  · intro ⟨h, h'⟩
-    have : Fintype α := Fintype.ofInjective f h
-    rw [card_eq_fintype_card, card_eq_fintype_card] at h'
-    rw [Fintype.bijective_iff_injective_and_card]
-    exact ⟨h, h'⟩
+  rw [Bijective, and_congr_right_iff]
+  intro h
+  have := Fintype.ofFinite β
+  have := Fintype.ofInjective f h
+  revert h
+  rw [← and_congr_right_iff, ← Bijective,
+    card_eq_fintype_card, card_eq_fintype_card, Fintype.bijective_iff_injective_and_card]
 
 theorem _root_.Function.Injective.bijective_of_nat_card_le [Fintype β] {f : α → β}
     (inj : Injective f) (hc : Nat.card β ≤ Nat.card α) : Bijective f :=


### PR DESCRIPTION
We're in the home stretch!

This PR switches over `GroupTheory/Complement` and `GroupTheory/SchurZassenhaus` from `Fintype.card` to `Nat.card`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
