### PR TITLE
[Merged by Bors] - feat(RingTheory/Derivation/Basic): add lemmas about the derivation of a fraction

### DIFF
--- a/Mathlib/RingTheory/Derivation/Basic.lean
+++ b/Mathlib/RingTheory/Derivation/Basic.lean
@@ -439,6 +439,19 @@ theorem leibniz_inv {K : Type*} [Field K] [Module K M] [Algebra R K] (D : Deriva
   · exact D.leibniz_of_mul_eq_one (inv_mul_cancel ha)
 #align derivation.leibniz_inv Derivation.leibniz_inv
 
+theorem leibniz_div {K : Type*} [Field K] [Module K M] [Algebra R K]
+    (D : Derivation R K M) (a b : K) : D (a / b) = b⁻¹ ^ 2 • (b • D a - a • D b) := by
+  simp only [div_eq_mul_inv, leibniz, leibniz_inv, inv_pow, neg_smul, smul_neg, smul_smul, add_comm,
+    sub_eq_add_neg, smul_add]
+  rw [← inv_mul_mul_self b⁻¹, inv_inv]
+  ring_nf
+
+theorem leibniz_div_const {K : Type*} [Field K] [Module K M] [Algebra R K]
+    (D : Derivation R K M) (a b : K) (h : D b = 0) : D (a / b) = b⁻¹ • D a := by
+  simp only [leibniz_div, inv_pow, h, smul_zero, sub_zero, smul_smul]
+  rw [← mul_self_mul_inv b⁻¹, inv_inv]
+  ring_nf
+
 instance : Neg (Derivation R A M) :=
   ⟨fun D =>
     mk' (-D) fun a b => by

--- a/Mathlib/RingTheory/Derivation/Basic.lean
+++ b/Mathlib/RingTheory/Derivation/Basic.lean
@@ -464,10 +464,8 @@ lemma leibniz_zpow {K : Type*} [Field K] [Module K M] [Algebra R K]
     rw [← zpow_natCast]
     congr
     omega
-  · rw [h]
-    rw [zpow_neg, zpow_natCast]
-    rw [leibniz_inv, leibniz_pow, inv_pow, ← pow_mul, ← zpow_natCast, ← zpow_natCast]
-    simp only [nsmul_eq_smul_cast K, zsmul_eq_smul_cast K, smul_smul]
+  · rw [h, zpow_neg, zpow_natCast, leibniz_inv, leibniz_pow, inv_pow, ← pow_mul, ← zpow_natCast,
+      ← zpow_natCast, nsmul_eq_smul_cast K, zsmul_eq_smul_cast K, smul_smul, smul_smul, smul_smul]
     trans (-n.natAbs * (a ^ ((n.natAbs - 1 : ℕ) : ℤ) / (a ^ ((n.natAbs * 2 : ℕ) : ℤ)))) • D a
     · ring_nf
     rw [← zpow_sub₀ ha]

--- a/Mathlib/RingTheory/Derivation/Basic.lean
+++ b/Mathlib/RingTheory/Derivation/Basic.lean
@@ -452,6 +452,29 @@ theorem leibniz_div_const {K : Type*} [Field K] [Module K M] [Algebra R K]
   rw [← mul_self_mul_inv b⁻¹, inv_inv]
   ring_nf
 
+lemma leibniz_zpow {K : Type*} [Field K] [Module K M] [Algebra R K]
+    (D : Derivation R K M) (a : K) (n : ℤ) : D (a ^ n) = n • a ^ (n - 1) • D a := by
+  by_cases hn : n = 0
+  · simp [hn]
+  by_cases ha : a = 0
+  · simp [ha, zero_zpow n hn]
+  rcases Int.natAbs_eq n with h | h
+  · rw [h]
+    simp only [zpow_natCast, leibniz_pow, natCast_zsmul]
+    rw [← zpow_natCast]
+    congr
+    omega
+  · rw [h]
+    rw [zpow_neg, zpow_natCast]
+    rw [leibniz_inv, leibniz_pow, inv_pow, ← pow_mul, ← zpow_natCast, ← zpow_natCast]
+    simp only [nsmul_eq_smul_cast K, zsmul_eq_smul_cast K, smul_smul]
+    trans (-n.natAbs * (a ^ ((n.natAbs - 1 : ℕ) : ℤ) / (a ^ ((n.natAbs * 2 : ℕ) : ℤ)))) • D a
+    · ring_nf
+    rw [← zpow_sub₀ ha]
+    congr 3
+    · norm_cast
+    omega
+
 instance : Neg (Derivation R A M) :=
   ⟨fun D =>
     mk' (-D) fun a b => by

--- a/Mathlib/RingTheory/Derivation/Basic.lean
+++ b/Mathlib/RingTheory/Derivation/Basic.lean
@@ -432,28 +432,28 @@ theorem leibniz_invOf [Invertible a] : D (⅟ a) = -⅟ a ^ 2 • D a :=
   D.leibniz_of_mul_eq_one <| invOf_mul_self a
 #align derivation.leibniz_inv_of Derivation.leibniz_invOf
 
-theorem leibniz_inv {K : Type*} [Field K] [Module K M] [Algebra R K] (D : Derivation R K M)
-    (a : K) : D a⁻¹ = -a⁻¹ ^ 2 • D a := by
+section Field
+
+variable {K : Type*} [Field K] [Module K M] [Algebra R K] (D : Derivation R K M)
+
+theorem leibniz_inv (a : K) : D a⁻¹ = -a⁻¹ ^ 2 • D a := by
   rcases eq_or_ne a 0 with (rfl | ha)
   · simp
   · exact D.leibniz_of_mul_eq_one (inv_mul_cancel ha)
 #align derivation.leibniz_inv Derivation.leibniz_inv
 
-theorem leibniz_div {K : Type*} [Field K] [Module K M] [Algebra R K]
-    (D : Derivation R K M) (a b : K) : D (a / b) = b⁻¹ ^ 2 • (b • D a - a • D b) := by
+theorem leibniz_div (a b : K) : D (a / b) = b⁻¹ ^ 2 • (b • D a - a • D b) := by
   simp only [div_eq_mul_inv, leibniz, leibniz_inv, inv_pow, neg_smul, smul_neg, smul_smul, add_comm,
     sub_eq_add_neg, smul_add]
   rw [← inv_mul_mul_self b⁻¹, inv_inv]
   ring_nf
 
-theorem leibniz_div_const {K : Type*} [Field K] [Module K M] [Algebra R K]
-    (D : Derivation R K M) (a b : K) (h : D b = 0) : D (a / b) = b⁻¹ • D a := by
+theorem leibniz_div_const (a b : K) (h : D b = 0) : D (a / b) = b⁻¹ • D a := by
   simp only [leibniz_div, inv_pow, h, smul_zero, sub_zero, smul_smul]
   rw [← mul_self_mul_inv b⁻¹, inv_inv]
   ring_nf
 
-lemma leibniz_zpow {K : Type*} [Field K] [Module K M] [Algebra R K]
-    (D : Derivation R K M) (a : K) (n : ℤ) : D (a ^ n) = n • a ^ (n - 1) • D a := by
+lemma leibniz_zpow (a : K) (n : ℤ) : D (a ^ n) = n • a ^ (n - 1) • D a := by
   by_cases hn : n = 0
   · simp [hn]
   by_cases ha : a = 0
@@ -472,6 +472,8 @@ lemma leibniz_zpow {K : Type*} [Field K] [Module K M] [Algebra R K]
     congr 3
     · norm_cast
     omega
+
+end Field
 
 instance : Neg (Derivation R A M) :=
   ⟨fun D =>


### PR DESCRIPTION
Add lemmas about the derivation of a fraction in a field.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
