### PR TITLE
chore(Data/Vector): reduce autoImplicit

### DIFF
--- a/Mathlib/Data/Vector/Basic.lean
+++ b/Mathlib/Data/Vector/Basic.lean
@@ -785,10 +785,10 @@ theorem replicate_succ (val : α) :
 section Append
 variable (ys : Vector α m)
 
-@[simp] lemma get_append_cons_zero : get (append (x ::ᵥ xs) ys) ⟨0, by omega⟩ = x := rfl
+@[simp] lemma get_append_cons_zero {x : α} : get (append (x ::ᵥ xs) ys) ⟨0, by omega⟩ = x := rfl
 
 @[simp]
-theorem get_append_cons_succ {i : Fin (n + m)} {h} :
+theorem get_append_cons_succ {x : α} {i : Fin (n + m)} {h} :
     get (append (x ::ᵥ xs) ys) ⟨i+1, h⟩ = get (append xs ys) i :=
   rfl
 
@@ -798,10 +798,11 @@ theorem append_nil : append xs nil = xs := by
 
 end Append
 
-variable (ys : Vector β n)
+set_option autoImplicit false
+variable {α β γ : Type*}
 
 @[simp]
-theorem get_map₂ (v₁ : Vector α n) (v₂ : Vector β n) (f : α → β → γ) (i : Fin n) :
+theorem get_map₂ (ys : Vector β n) (v₁ : Vector α n) (v₂ : Vector β n) (f : α → β → γ) (i : Fin n) :
     get (map₂ f v₁ v₂) i = f (get v₁ i) (get v₂ i) := by
   clear * - v₁ v₂
   induction v₁, v₂ using inductionOn₂ with
@@ -813,16 +814,18 @@ theorem get_map₂ (v₁ : Vector α n) (v₂ : Vector β n) (f : α → β → 
     · simp only [get_zero, head_cons]
     · simp only [get_cons_succ, ih]
 
+set_option autoImplicit true in
 @[simp]
-theorem mapAccumr_cons :
+theorem mapAccumr_cons {n : ℕ} (xs : Vector α n) :
     mapAccumr f (x ::ᵥ xs) s
     = let r := mapAccumr f xs s
       let q := f x r.1
       (q.1, q.2 ::ᵥ r.2) :=
   rfl
 
+set_option autoImplicit true in
 @[simp]
-theorem mapAccumr₂_cons :
+theorem mapAccumr₂_cons (ys) :
     mapAccumr₂ f (x ::ᵥ xs) (y ::ᵥ ys) s
     = let r := mapAccumr₂ f xs ys s
       let q := f x y r.1

--- a/Mathlib/Data/Vector/Basic.lean
+++ b/Mathlib/Data/Vector/Basic.lean
@@ -19,9 +19,6 @@ import Mathlib.Control.Traversable.Basic
 This file introduces the infix notation `::ᵥ` for `Vector.cons`.
 -/
 
-set_option autoImplicit true
-
-
 universe u
 
 variable {n : ℕ}
@@ -132,11 +129,11 @@ theorem get_map {β : Type*} (v : Vector α n) (f : α → β) (i : Fin n) :
 #align vector.nth_map Vector.get_map
 
 @[simp]
-theorem map₂_nil (f : α → β → γ) : Vector.map₂ f nil nil = nil :=
+theorem map₂_nil {α β γ : Type*} (f : α → β → γ) : Vector.map₂ f nil nil = nil :=
   rfl
 
 @[simp]
-theorem map₂_cons (hd₁ : α) (tl₁ : Vector α n) (hd₂ : β) (tl₂ : Vector β n) (f : α → β → γ) :
+theorem map₂_cons {α β γ : Type*} (hd₁ : α) (tl₁ : Vector α n) (hd₂ : β) (tl₂ : Vector β n) (f : α → β → γ) :
     Vector.map₂ f (hd₁ ::ᵥ tl₁) (hd₂ ::ᵥ tl₂) = f hd₁ hd₂ ::ᵥ (Vector.map₂ f tl₁ tl₂) :=
   rfl
 
@@ -518,15 +515,15 @@ def inductionOn₃ {C : ∀ {n}, Vector α n → Vector β n → Vector γ n →
 #align vector.induction_on₃ Vector.inductionOn₃
 
 /-- Define `motive v` by case-analysis on `v : Vector α n`. -/
-def casesOn {motive : ∀ {n}, Vector α n → Sort*} (v : Vector α m)
+def casesOn {m : ℕ} {motive : ∀ {n}, Vector α n → Sort*} (v : Vector α m)
     (nil : motive nil)
     (cons : ∀ {n}, (hd : α) → (tl : Vector α n) → motive (Vector.cons hd tl)) :
     motive v :=
   inductionOn (C := motive) v nil @fun _ hd tl _ => cons hd tl
 
 /-- Define `motive v₁ v₂` by case-analysis on `v₁ : Vector α n` and `v₂ : Vector β n`. -/
-def casesOn₂  {motive : ∀{n}, Vector α n → Vector β n → Sort*} (v₁ : Vector α m) (v₂ : Vector β m)
-    (nil : motive nil nil)
+def casesOn₂ {m : ℕ} {motive : ∀{n}, Vector α n → Vector β n → Sort*}
+    (v₁ : Vector α m) (v₂ : Vector β m) (nil : motive nil nil)
     (cons : ∀{n}, (x : α) → (y : β) → (xs : Vector α n) → (ys : Vector β n)
       → motive (x ::ᵥ xs) (y ::ᵥ ys)) :
     motive v₁ v₂ :=
@@ -534,7 +531,7 @@ def casesOn₂  {motive : ∀{n}, Vector α n → Vector β n → Sort*} (v₁ :
 
 /-- Define `motive v₁ v₂ v₃` by case-analysis on `v₁ : Vector α n`, `v₂ : Vector β n`, and
     `v₃ : Vector γ n`. -/
-def casesOn₃  {motive : ∀{n}, Vector α n → Vector β n → Vector γ n → Sort*} (v₁ : Vector α m)
+def casesOn₃ {m : ℕ} {motive : ∀{n}, Vector α n → Vector β n → Vector γ n → Sort*} (v₁ : Vector α m)
     (v₂ : Vector β m) (v₃ : Vector γ m) (nil : motive nil nil nil)
     (cons : ∀{n}, (x : α) → (y : β) → (z : γ) → (xs : Vector α n) → (ys : Vector β n)
       → (zs : Vector γ n) → motive (x ::ᵥ xs) (y ::ᵥ ys) (z ::ᵥ zs)) :
@@ -775,34 +772,33 @@ instance : LawfulTraversable.{u} (flip Vector n) where
 
 section Simp
 
-variable (xs : Vector α n)
-
 @[simp]
-theorem replicate_succ (val : α) :
+theorem replicate_succ {α : Type*} {n : ℕ} (val : α) :
     replicate (n+1) val = val ::ᵥ (replicate n val) :=
   rfl
 
 section Append
-variable (ys : Vector α m)
 
-@[simp] lemma get_append_cons_zero {x : α} : get (append (x ::ᵥ xs) ys) ⟨0, by omega⟩ = x := rfl
+variable {α : Type*} {m n : ℕ} {x : α}
+
+@[simp] lemma get_append_cons_zero (xs : Vector α n) (ys : Vector α m) :
+    get (append (x ::ᵥ xs) ys) ⟨0, by omega⟩ = x :=
+  rfl
 
 @[simp]
-theorem get_append_cons_succ {x : α} {i : Fin (n + m)} {h} :
+theorem get_append_cons_succ (xs : Vector α n) (ys : Vector α m) {i : Fin (n + m)} {h} :
     get (append (x ::ᵥ xs) ys) ⟨i+1, h⟩ = get (append xs ys) i :=
   rfl
 
 @[simp]
-theorem append_nil : append xs nil = xs := by
+theorem append_nil (xs : Vector α n) : append xs nil = xs := by
   cases xs; simp [append]
 
 end Append
 
-set_option autoImplicit false
-variable {α β γ : Type*}
-
+variable {α β γ : Type*} in
 @[simp]
-theorem get_map₂ (ys : Vector β n) (v₁ : Vector α n) (v₂ : Vector β n) (f : α → β → γ) (i : Fin n) :
+theorem get_map₂ (v₁ : Vector α n) (v₂ : Vector β n) (f : α → β → γ) (i : Fin n) :
     get (map₂ f v₁ v₂) i = f (get v₁ i) (get v₂ i) := by
   clear * - v₁ v₂
   induction v₁, v₂ using inductionOn₂ with
@@ -816,7 +812,7 @@ theorem get_map₂ (ys : Vector β n) (v₁ : Vector α n) (v₂ : Vector β n) 
 
 set_option autoImplicit true in
 @[simp]
-theorem mapAccumr_cons {n : ℕ} (xs : Vector α n) :
+theorem mapAccumr_cons  {n : ℕ} (xs : Vector α n) :
     mapAccumr f (x ::ᵥ xs) s
     = let r := mapAccumr f xs s
       let q := f x r.1
@@ -825,7 +821,7 @@ theorem mapAccumr_cons {n : ℕ} (xs : Vector α n) :
 
 set_option autoImplicit true in
 @[simp]
-theorem mapAccumr₂_cons (ys) :
+theorem mapAccumr₂_cons (xs : Vector α n) (ys) :
     mapAccumr₂ f (x ::ᵥ xs) (y ::ᵥ ys) s
     = let r := mapAccumr₂ f xs ys s
       let q := f x y r.1

--- a/Mathlib/Data/Vector/Basic.lean
+++ b/Mathlib/Data/Vector/Basic.lean
@@ -812,7 +812,7 @@ theorem get_map₂ (v₁ : Vector α n) (v₂ : Vector β n) (f : α → β → 
 
 set_option autoImplicit true in
 @[simp]
-theorem mapAccumr_cons  {n : ℕ} (xs : Vector α n) :
+theorem mapAccumr_cons {n : ℕ} (xs : Vector α n) :
     mapAccumr f (x ::ᵥ xs) s
     = let r := mapAccumr f xs s
       let q := f x r.1
@@ -821,7 +821,7 @@ theorem mapAccumr_cons  {n : ℕ} (xs : Vector α n) :
 
 set_option autoImplicit true in
 @[simp]
-theorem mapAccumr₂_cons (xs : Vector α n) (ys) :
+theorem mapAccumr₂_cons {n: ℕ} (xs : Vector α n) (ys) :
     mapAccumr₂ f (x ::ᵥ xs) (y ::ᵥ ys) s
     = let r := mapAccumr₂ f xs ys s
       let q := f x y r.1

--- a/Mathlib/Data/Vector/MapLemmas.lean
+++ b/Mathlib/Data/Vector/MapLemmas.lean
@@ -11,8 +11,6 @@ import Mathlib.Data.Vector.Snoc
   This file establishes a set of normalization lemmas for `map`/`mapAccumr` operations on vectors
 -/
 
-set_option autoImplicit true
-
 namespace Vector
 
 /-!
@@ -21,10 +19,12 @@ namespace Vector
 section Fold
 
 section Unary
+
+variable {α : Type*} {n : ℕ} {β : Type*} {σ₁ : Type} {γ : Type*} {σ₂ : Type}
 variable (xs : Vector α n) (f₁ : β → σ₁ → σ₁ × γ) (f₂ : α → σ₂ → σ₂ × β)
 
 @[simp]
-theorem mapAccumr_mapAccumr :
+theorem mapAccumr_mapAccumr {s₁ : σ₁} {s₂ : σ₂} :
     mapAccumr f₁ (mapAccumr f₂ xs s₂).snd s₁
     = let m := (mapAccumr (fun x s =>
         let r₂ := f₂ x s.snd
@@ -35,12 +35,12 @@ theorem mapAccumr_mapAccumr :
   induction xs using Vector.revInductionOn generalizing s₁ s₂ <;> simp_all
 
 @[simp]
-theorem mapAccumr_map (f₂ : α → β) :
+theorem mapAccumr_map {s : σ₁} (f₂ : α → β) :
     (mapAccumr f₁ (map f₂ xs) s) = (mapAccumr (fun x s => f₁ (f₂ x) s) xs s) := by
   induction xs using Vector.revInductionOn generalizing s <;> simp_all
 
 @[simp]
-theorem map_mapAccumr (f₁ : β → γ) :
+theorem map_mapAccumr {s : σ₂} (f₁ : β → γ) :
     (map f₁ (mapAccumr f₂ xs s).snd) = (mapAccumr (fun x s =>
         let r := (f₂ x s); (r.fst, f₁ r.snd)
       ) xs s).snd := by
@@ -54,10 +54,12 @@ theorem map_map (f₁ : β → γ) (f₂ : α → β) :
 end Unary
 
 section Binary
-variable (xs : Vector α n) (ys : Vector β n)
+
+variable {α : Type} {n : ℕ} {β : Type} (xs : Vector α n) (ys : Vector β n)
 
 @[simp]
-theorem mapAccumr₂_mapAccumr_left (f₁ : γ → β → σ₁ → σ₁ × ζ) (f₂ : α → σ₂ → σ₂ × γ) :
+theorem mapAccumr₂_mapAccumr_left {γ σ₁ ζ σ₂ : Type} {s₂ : σ₂} {s₁ : σ₁}
+    (f₁ : γ → β → σ₁ → σ₁ × ζ) (f₂ : α → σ₂ → σ₂ × γ) :
     (mapAccumr₂ f₁ (mapAccumr f₂ xs s₂).snd ys s₁)
     = let m := (mapAccumr₂ (fun x y s =>
           let r₂ := f₂ x s.snd
@@ -67,13 +69,15 @@ theorem mapAccumr₂_mapAccumr_left (f₁ : γ → β → σ₁ → σ₁ × ζ)
       (m.fst.fst, m.snd) := by
   induction xs, ys using Vector.revInductionOn₂ generalizing s₁ s₂ <;> simp_all
 
+variable {σ₁ σ₂ : Type} {s₁ : σ₁} {s₂ : σ₂}
+
 @[simp]
-theorem map₂_map_left (f₁ : γ → β → ζ) (f₂ : α → γ) :
+theorem map₂_map_left {γ ζ : Type*} (f₁ : γ → β → ζ) (f₂ : α → γ) :
     map₂ f₁ (map f₂ xs) ys = map₂ (fun x y => f₁ (f₂ x) y) xs ys := by
   induction xs, ys using Vector.revInductionOn₂ <;> simp_all
 
 @[simp]
-theorem mapAccumr₂_mapAccumr_right (f₁ : α → γ → σ₁ → σ₁ × ζ) (f₂ : β → σ₂ → σ₂ × γ) :
+theorem mapAccumr₂_mapAccumr_right {γ ζ : Type} (f₁ : α → γ → σ₁ → σ₁ × ζ) (f₂ : β → σ₂ → σ₂ × γ) :
     (mapAccumr₂ f₁ xs (mapAccumr f₂ ys s₂).snd s₁)
     = let m := (mapAccumr₂ (fun x y s =>
           let r₂ := f₂ y s.snd
@@ -84,12 +88,12 @@ theorem mapAccumr₂_mapAccumr_right (f₁ : α → γ → σ₁ → σ₁ × ζ
   induction xs, ys using Vector.revInductionOn₂ generalizing s₁ s₂ <;> simp_all
 
 @[simp]
-theorem map₂_map_right (f₁ : α → γ → ζ) (f₂ : β → γ) :
+theorem map₂_map_right {γ ζ : Type*} (f₁ : α → γ → ζ) (f₂ : β → γ) :
     map₂ f₁ xs (map f₂ ys) = map₂ (fun x y => f₁ x (f₂ y)) xs ys := by
   induction xs, ys using Vector.revInductionOn₂ <;> simp_all
 
 @[simp]
-theorem mapAccumr_mapAccumr₂ (f₁ : γ → σ₁ → σ₁ × ζ) (f₂ : α → β → σ₂ → σ₂ × γ) :
+theorem mapAccumr_mapAccumr₂ {γ ζ : Type} (f₁ : γ → σ₁ → σ₁ × ζ) (f₂ : α → β → σ₂ → σ₂ × γ) :
     (mapAccumr f₁ (mapAccumr₂ f₂ xs ys s₂).snd s₁)
     = let m := mapAccumr₂ (fun x y s =>
           let r₂ := f₂ x y s.snd
@@ -100,12 +104,13 @@ theorem mapAccumr_mapAccumr₂ (f₁ : γ → σ₁ → σ₁ × ζ) (f₂ : α 
   induction xs, ys using Vector.revInductionOn₂ generalizing s₁ s₂ <;> simp_all
 
 @[simp]
-theorem map_map₂ (f₁ : γ → ζ) (f₂ : α → β → γ) :
+theorem map_map₂ {γ ζ : Type*} (f₁ : γ → ζ) (f₂ : α → β → γ) :
     map f₁ (map₂ f₂ xs ys) = map₂ (fun x y => f₁ <| f₂ x y) xs ys := by
   induction xs, ys using Vector.revInductionOn₂ <;> simp_all
 
 @[simp]
-theorem mapAccumr₂_mapAccumr₂_left_left (f₁ : γ → α → σ₁ → σ₁ × φ) (f₂ : α → β → σ₂ → σ₂ × γ) :
+theorem mapAccumr₂_mapAccumr₂_left_left {φ γ : Type}
+    (f₁ : γ → α → σ₁ → σ₁ × φ) (f₂ : α → β → σ₂ → σ₂ × γ) :
     (mapAccumr₂ f₁ (mapAccumr₂ f₂ xs ys s₂).snd xs s₁)
     = let m := mapAccumr₂ (fun x y (s₁, s₂) =>
                 let r₂ := f₂ x y s₂
@@ -117,7 +122,7 @@ theorem mapAccumr₂_mapAccumr₂_left_left (f₁ : γ → α → σ₁ → σ�
   induction xs, ys using Vector.revInductionOn₂ generalizing s₁ s₂ <;> simp_all
 
 @[simp]
-theorem mapAccumr₂_mapAccumr₂_left_right
+theorem mapAccumr₂_mapAccumr₂_left_right {φ γ : Type}
     (f₁ : γ → β → σ₁ → σ₁ × φ) (f₂ : α → β → σ₂ → σ₂ × γ) :
     (mapAccumr₂ f₁ (mapAccumr₂ f₂ xs ys s₂).snd ys s₁)
     = let m := mapAccumr₂ (fun x y (s₁, s₂) =>
@@ -130,7 +135,8 @@ theorem mapAccumr₂_mapAccumr₂_left_right
   induction xs, ys using Vector.revInductionOn₂ generalizing s₁ s₂ <;> simp_all
 
 @[simp]
-theorem mapAccumr₂_mapAccumr₂_right_left (f₁ : α → γ → σ₁ → σ₁ × φ) (f₂ : α → β → σ₂ → σ₂ × γ) :
+theorem mapAccumr₂_mapAccumr₂_right_left {φ γ : Type}
+    (f₁ : α → γ → σ₁ → σ₁ × φ) (f₂ : α → β → σ₂ → σ₂ × γ) :
     (mapAccumr₂ f₁ xs (mapAccumr₂ f₂ xs ys s₂).snd s₁)
     = let m := mapAccumr₂ (fun x y (s₁, s₂) =>
                 let r₂ := f₂ x y s₂
@@ -142,7 +148,8 @@ theorem mapAccumr₂_mapAccumr₂_right_left (f₁ : α → γ → σ₁ → σ�
   induction xs, ys using Vector.revInductionOn₂ generalizing s₁ s₂ <;> simp_all
 
 @[simp]
-theorem mapAccumr₂_mapAccumr₂_right_right (f₁ : β → γ → σ₁ → σ₁ × φ) (f₂ : α → β → σ₂ → σ₂ × γ) :
+theorem mapAccumr₂_mapAccumr₂_right_right {φ γ : Type}
+    (f₁ : β → γ → σ₁ → σ₁ × φ) (f₂ : α → β → σ₂ → σ₂ × γ) :
     (mapAccumr₂ f₁ ys (mapAccumr₂ f₂ xs ys s₂).snd s₁)
     = let m := mapAccumr₂ (fun x y (s₁, s₂) =>
                 let r₂ := f₂ x y s₂
@@ -168,9 +175,10 @@ input values.
 -/
 
 section Bisim
-variable {xs : Vector α n}
 
-theorem mapAccumr_bisim {f₁ : α → σ₁ → σ₁ × β} {f₂ : α → σ₂ → σ₂ × β} {s₁ : σ₁} {s₂ : σ₂}
+variable {α β : Type*} {n : ℕ} {xs : Vector α n} {σ₁ σ₂ : Type} {s₁ : σ₁} {s₂ : σ₂}
+
+theorem mapAccumr_bisim {f₁ : α → σ₁ → σ₁ × β} {f₂ : α → σ₂ → σ₂ × β}
     (R : σ₁ → σ₂ → Prop) (h₀ : R s₁ s₂)
     (hR : ∀ {s q} a, R s q → R (f₁ a s).1 (f₂ a q).1 ∧ (f₁ a s).2 = (f₂ a q).2) :
     R (mapAccumr f₁ xs s₁).fst (mapAccumr f₂ xs s₂).fst
@@ -182,15 +190,15 @@ theorem mapAccumr_bisim {f₁ : α → σ₁ → σ₁ × β} {f₂ : α → σ�
     simp only [mapAccumr_snoc, ih hR, true_and]
     congr 1
 
-theorem mapAccumr_bisim_tail {f₁ : α → σ₁ → σ₁ × β} {f₂ : α → σ₂ → σ₂ × β} {s₁ : σ₁} {s₂ : σ₂}
+theorem mapAccumr_bisim_tail {f₁ : α → σ₁ → σ₁ × β} {f₂ : α → σ₂ → σ₂ × β}
     (h : ∃ R : σ₁ → σ₂ → Prop, R s₁ s₂ ∧
       ∀ {s q} a, R s q → R (f₁ a s).1 (f₂ a q).1 ∧ (f₁ a s).2 = (f₂ a q).2) :
     (mapAccumr f₁ xs s₁).snd = (mapAccumr f₂ xs s₂).snd := by
   rcases h with ⟨R, h₀, hR⟩
   exact (mapAccumr_bisim R h₀ hR).2
 
-theorem mapAccumr₂_bisim {ys : Vector β n} {f₁ : α → β → σ₁ → σ₁ × γ}
-    {f₂ : α → β → σ₂ → σ₂ × γ} {s₁ : σ₁} {s₂ : σ₂}
+theorem mapAccumr₂_bisim {α β γ : Type} {n : ℕ} {xs : Vector α n} {ys : Vector β n}
+    {f₁ : α → β → σ₁ → σ₁ × γ} {f₂ : α → β → σ₂ → σ₂ × γ}
     (R : σ₁ → σ₂ → Prop) (h₀ : R s₁ s₂)
     (hR :  ∀ {s q} a b, R s q → R (f₁ a b s).1 (f₂ a b q).1 ∧ (f₁ a b s).2 = (f₂ a b q).2) :
     R (mapAccumr₂ f₁ xs ys s₁).1 (mapAccumr₂ f₂ xs ys s₂).1
@@ -202,8 +210,8 @@ theorem mapAccumr₂_bisim {ys : Vector β n} {f₁ : α → β → σ₁ → σ
     simp only [mapAccumr₂_snoc, ih hR, true_and]
     congr 1
 
-theorem mapAccumr₂_bisim_tail {ys : Vector β n} {f₁ : α → β → σ₁ → σ₁ × γ}
-    {f₂ : α → β → σ₂ → σ₂ × γ} {s₁ : σ₁} {s₂ : σ₂}
+theorem mapAccumr₂_bisim_tail {α β γ : Type} {xs : Vector α n} {ys : Vector β n}
+    {f₁ : α → β → σ₁ → σ₁ × γ} {f₂ : α → β → σ₂ → σ₂ × γ}
     (h : ∃ R : σ₁ → σ₂ → Prop, R s₁ s₂ ∧
       ∀ {s q} a b, R s q → R (f₁ a b s).1 (f₂ a b q).1 ∧ (f₁ a b s).2 = (f₂ a b q).2) :
     (mapAccumr₂ f₁ xs ys s₁).2 = (mapAccumr₂ f₂ xs ys s₂).2 := by
@@ -219,6 +227,8 @@ The following section are collection of rewrites to simplify, or even get rid, r
 accumulation state
 -/
 section RedundantState
+
+set_option autoImplicit true
 variable {xs : Vector α n} {ys : Vector β n}
 
 protected theorem map_eq_mapAccumr :
@@ -231,7 +241,8 @@ protected theorem map_eq_mapAccumr :
   for all states in this set, then the state is not actually needed.
   Hence, then we can rewrite `mapAccumr` into just `map`
 -/
-theorem mapAccumr_eq_map {f : α → σ → σ × β} {s₀ : σ} (S : Set σ) (h₀ : s₀ ∈ S)
+theorem mapAccumr_eq_map {α : Type*} {n : ℕ} {xs : Vector α n} {β : Type*} {σ : Type}
+    {f : α → σ → σ × β} {s₀ : σ} (S : Set σ) (h₀ : s₀ ∈ S)
     (closure : ∀ a s, s ∈ S → (f a s).1 ∈ S)
     (out : ∀ a s s', s ∈ S → s' ∈ S → (f a s).2 = (f a s').2) :
     (mapAccumr f xs s₀).snd = map (f · s₀ |>.snd) xs := by
@@ -249,7 +260,8 @@ protected theorem map₂_eq_mapAccumr₂ :
   for all states in this set, then the state is not actually needed.
   Hence, then we can rewrite `mapAccumr₂` into just `map₂`
 -/
-theorem mapAccumr₂_eq_map₂ {f : α → β → σ → σ × γ} {s₀ : σ} (S : Set σ) (h₀ : s₀ ∈ S)
+theorem mapAccumr₂_eq_map₂ {α β γ σ : Type} {n : ℕ} {xs : Vector α n} {ys : Vector β n}
+    {f : α → β → σ → σ × γ} {s₀ : σ} (S : Set σ) (h₀ : s₀ ∈ S)
     (closure : ∀ a b s, s ∈ S → (f a b s).1 ∈ S)
     (out : ∀ a b s s', s ∈ S → s' ∈ S → (f a b s).2 = (f a b s').2) :
     (mapAccumr₂ f xs ys s₀).snd = map₂ (f · · s₀ |>.snd) xs ys := by
@@ -332,7 +344,8 @@ end RedundantState
 ## Unused input optimizations
 -/
 section UnusedInput
-variable {xs : Vector α n} {ys : Vector β n}
+
+variable {α β γ σ : Type} {n : ℕ} {xs : Vector α n} {ys : Vector β n} {s : σ}
 
 /--
   If `f` returns the same output and next state for every value of it's first argument, then
@@ -364,7 +377,8 @@ end UnusedInput
 ## Commutativity
 -/
 section Comm
-variable (xs ys : Vector α n)
+
+variable {α β γ σ : Type} {n : ℕ} (xs ys : Vector α n) {s : σ}
 
 theorem map₂_comm (f : α → α → β) (comm : ∀ a₁ a₂, f a₁ a₂ = f a₂ a₁) :
     map₂ f xs ys = map₂ f ys xs := by
@@ -380,7 +394,8 @@ end Comm
 ## Argument Flipping
 -/
 section Flip
-variable (xs : Vector α n) (ys : Vector β n)
+
+variable {α β γ σ : Type} {n : ℕ} (xs : Vector α n) (ys : Vector β n) {s : σ}
 
 theorem map₂_flip (f : α → β → γ) :
     map₂ f xs ys = map₂ (flip f) ys xs := by

--- a/Mathlib/Data/Vector/Snoc.lean
+++ b/Mathlib/Data/Vector/Snoc.lean
@@ -16,19 +16,18 @@ import Mathlib.Data.Vector.Basic
   `snoc xs x` for its inductive case. Effectively doing induction from right-to-left
 -/
 
-set_option autoImplicit true
-
 namespace Vector
 
 /-- Append a single element to the end of a vector -/
-def snoc : Vector α n → α → Vector α (n+1) :=
+def snoc {α : Type*} {n : ℕ} : Vector α n → α → Vector α (n+1) :=
   fun xs x => append xs (x ::ᵥ Vector.nil)
 
 /-!
 ## Simplification lemmas
 -/
 section Simp
-  variable (xs : Vector α n)
+
+variable {α : Type*} {n : ℕ} {x y : α} (xs : Vector α n)
 
 @[simp]
 theorem snoc_cons : (x ::ᵥ xs).snoc y = x ::ᵥ (xs.snoc y) :=
@@ -67,6 +66,8 @@ end Simp
 ## Reverse induction principle
 -/
 section Induction
+
+variable {α β : Type*}
 
 /-- Define `C v` by *reverse* induction on `v : Vector α n`.
     That is, break the vector down starting from the right-most element, using `snoc`
@@ -120,7 +121,9 @@ end Induction
 
 section Simp
 
-variable (xs : Vector α n)
+set_option autoImplicit true
+
+variable {n : ℕ} (xs : Vector α n)
 
 @[simp]
 theorem map_snoc : map f (xs.snoc x) = (map f xs).snoc (f x) := by


### PR DESCRIPTION
These files are more tricky: for instance, in MapLemmas, \alpha alternates between being in `Type` and `Type*`, making it harder to pull out a unified `variables` declaration.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
