### PR TITLE
[Merged by Bors] - chore: Move `DistribMulAction` on `Submonoid` instance

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -269,6 +269,7 @@ import Mathlib.Algebra.Group.Subgroup.Order
 import Mathlib.Algebra.Group.Subgroup.Pointwise
 import Mathlib.Algebra.Group.Subgroup.ZPowers
 import Mathlib.Algebra.Group.Submonoid.Basic
+import Mathlib.Algebra.Group.Submonoid.DistribMulAction
 import Mathlib.Algebra.Group.Submonoid.Membership
 import Mathlib.Algebra.Group.Submonoid.MulOpposite
 import Mathlib.Algebra.Group.Submonoid.Operations

--- a/Mathlib/Algebra/Group/Subgroup/Actions.lean
+++ b/Mathlib/Algebra/Group/Subgroup/Actions.lean
@@ -3,6 +3,7 @@ Copyright (c) 2021 Eric Wieser. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Eric Wieser
 -/
+import Mathlib.Algebra.Group.Submonoid.DistribMulAction
 import Mathlib.GroupTheory.Subgroup.Center
 
 /-!

--- a/Mathlib/Algebra/Group/Submonoid/DistribMulAction.lean
+++ b/Mathlib/Algebra/Group/Submonoid/DistribMulAction.lean
@@ -1,0 +1,26 @@
+/-
+Copyright (c) 2022 Yaël Dillies. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Yaël Dillies
+-/
+import Mathlib.Algebra.Group.Submonoid.Operations
+import Mathlib.Algebra.GroupWithZero.Action.Defs
+
+/-!
+# Distributive actions by submonoids
+-/
+
+namespace Submonoid
+variable {M α : Type*} [Monoid M]
+
+/-- The action by a submonoid is the action by the underlying monoid. -/
+instance distribMulAction [AddMonoid α] [DistribMulAction M α] (S : Submonoid M) :
+    DistribMulAction S α :=
+  DistribMulAction.compHom _ S.subtype
+
+/-- The action by a submonoid is the action by the underlying monoid. -/
+instance mulDistribMulAction [Monoid α] [MulDistribMulAction M α] (S : Submonoid M) :
+    MulDistribMulAction S α :=
+  MulDistribMulAction.compHom _ S.subtype
+
+end Submonoid

--- a/Mathlib/Algebra/Group/Submonoid/Operations.lean
+++ b/Mathlib/Algebra/Group/Submonoid/Operations.lean
@@ -4,10 +4,10 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johannes Hölzl, Kenny Lau, Johan Commelin, Mario Carneiro, Kevin Buzzard,
 Amelia Livingston, Yury Kudryashov
 -/
+import Mathlib.Algebra.Group.Action.Defs
+import Mathlib.Algebra.Group.Nat
 import Mathlib.Algebra.Group.Submonoid.Basic
 import Mathlib.Algebra.Group.Subsemigroup.Operations
-import Mathlib.Algebra.Group.Nat
-import Mathlib.Algebra.GroupWithZero.Action.Defs
 
 /-!
 # Operations on `Submonoid`s
@@ -1143,16 +1143,6 @@ variable [Monoid M']
       "The additive action by an `AddSubmonoid` is the action by the underlying `AddMonoid`. "]
 instance mulAction [MulAction M' α] (S : Submonoid M') : MulAction S α :=
   MulAction.compHom _ S.subtype
-
-/-- The action by a submonoid is the action by the underlying monoid. -/
-instance distribMulAction [AddMonoid α] [DistribMulAction M' α] (S : Submonoid M') :
-    DistribMulAction S α :=
-  DistribMulAction.compHom _ S.subtype
-
-/-- The action by a submonoid is the action by the underlying monoid. -/
-instance mulDistribMulAction [Monoid α] [MulDistribMulAction M' α] (S : Submonoid M') :
-    MulDistribMulAction S α :=
-  MulDistribMulAction.compHom _ S.subtype
 
 example {S : Submonoid M'} : IsScalarTower S M' M' := by infer_instance
 

--- a/Mathlib/Algebra/Ring/Action/Subobjects.lean
+++ b/Mathlib/Algebra/Ring/Action/Subobjects.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Eric Wieser
 -/
 import Mathlib.Algebra.Group.Subgroup.Basic
+import Mathlib.Algebra.Group.Submonoid.DistribMulAction
 import Mathlib.Algebra.Ring.Action.Basic
 
 /-!

--- a/Mathlib/GroupTheory/Congruence/Basic.lean
+++ b/Mathlib/GroupTheory/Congruence/Basic.lean
@@ -5,6 +5,7 @@ Authors: Amelia Livingston
 -/
 import Mathlib.Algebra.Group.Equiv.Basic
 import Mathlib.Algebra.Group.Submonoid.Operations
+import Mathlib.Algebra.GroupWithZero.Action.Defs
 import Mathlib.Data.Setoid.Basic
 
 /-!

--- a/Mathlib/RingTheory/OreLocalization/Basic.lean
+++ b/Mathlib/RingTheory/OreLocalization/Basic.lean
@@ -3,8 +3,8 @@ Copyright (c) 2022 Jakob von Raumer. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Jakob von Raumer, Kevin Klinge, Andrew Yang
 -/
+import Mathlib.Algebra.Group.Submonoid.DistribMulAction
 import Mathlib.RingTheory.OreLocalization.OreSet
-import Mathlib.Algebra.Group.Submonoid.Operations
 
 /-!
 


### PR DESCRIPTION
Move the instances that cannot be additivised from `Algebra.Group.Submonoid.Operations` to a new file `Algebra.Group.Submonoid.DistribMulAction`.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
