### PR TITLE
[Merged by Bors] - feat(RingTheory/Radical): Radical of an element in a unique factorization normalization monoid

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -3843,6 +3843,7 @@ import Mathlib.RingTheory.PrincipalIdealDomain
 import Mathlib.RingTheory.QuotSMulTop
 import Mathlib.RingTheory.QuotientNilpotent
 import Mathlib.RingTheory.QuotientNoetherian
+import Mathlib.RingTheory.Radical
 import Mathlib.RingTheory.ReesAlgebra
 import Mathlib.RingTheory.Regular.IsSMulRegular
 import Mathlib.RingTheory.Regular.RegularSequence

--- a/Mathlib/RingTheory/Radical.lean
+++ b/Mathlib/RingTheory/Radical.lean
@@ -1,0 +1,98 @@
+/-
+Copyright (c) 2024 Jineon Back and Seewoo Lee. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Jineon Baek, Seewoo Lee
+-/
+import Mathlib.Algebra.Ring.Regular
+import Mathlib.RingTheory.UniqueFactorizationDomain
+
+/-!
+# Radical of an element of a unique factorization normalization monoid
+
+This file defines a radical `rad(a)` of an element `a` of a unique factorization normalization
+monoid, which is defined as a product of normalized prime factors of `a` without duplication.
+This is different from the radical of ideal.
+
+## Main declarations
+
+- `radical_associated_eq`: If `a` and `b` are associates, i.e. `a * u = b` for some unit `u`,
+  then `rad(a) = rad(b)`.
+- `radical_unit_hMul`: Multiplying unit does not change the radical.
+- `radical_dvd_self`: `rad(a)` divides `a`.
+- `radical_pow`: `rad(a ^ n) = rad(a)` for any `n ≥ 1`
+- `radical_prime`: Radical of a prime element is equal to its normalization
+
+## TODO
+
+- Make a comparison with `Ideal.radical`. Especially, for principal ideal, `rad((a)) = (rad(a))`,
+  where the first (resp. second) `rad` is radical of an ideal (resp. element).
+- Prove `rad(rad(a)) = rad(a)`.
+-/
+
+noncomputable section
+
+open scoped Classical
+
+open UniqueFactorizationMonoid
+
+variable {k : Type _} [Field k]
+variable {α : Type _} [CancelCommMonoidWithZero α] [NormalizationMonoid α]
+  [UniqueFactorizationMonoid α]
+
+/-- Prime factors of a polynomial `a` are monic factors of `a` without duplication. -/
+def primeFactors (a : α) : Finset α :=
+  (normalizedFactors a).toFinset
+
+/-- Radical of a polynomial `a` is a product of prime factors of `a`. -/
+def radical (a : α) : α :=
+  (primeFactors a).prod id
+
+theorem radical_zero_eq_one : radical (0 : α) = 1 := by
+  rw [radical, primeFactors, normalizedFactors_zero, Multiset.toFinset_zero, Finset.prod_empty]
+
+theorem radical_one_eq_one : radical (1 : α) = 1 := by
+  rw [radical, primeFactors, normalizedFactors_one, Multiset.toFinset_zero, Finset.prod_empty]
+
+theorem radical_associated_eq {a b : α} (h : Associated a b) : radical a = radical b :=
+  by
+  rcases iff_iff_and_or_not_and_not.mp h.eq_zero_iff with (⟨rfl, rfl⟩ | ⟨ha, hb⟩)
+  · rfl
+  · simp_rw [radical, primeFactors]
+    rw [(associated_iff_normalizedFactors_eq_normalizedFactors ha hb).mp h]
+
+theorem radical_unit_eq_one {a : α} (h : IsUnit a) : radical a = 1 :=
+  (radical_associated_eq (associated_one_iff_isUnit.mpr h)).trans radical_one_eq_one
+
+theorem radical_unit_hMul {u : αˣ} {a : α} : radical ((↑u : α) * a) = radical a :=
+  radical_associated_eq (associated_unit_mul_left _ _ u.isUnit)
+
+theorem primeFactors_pow (a : α) {n : ℕ} (hn : 0 < n) : primeFactors (a ^ n) = primeFactors a :=
+  by
+  simp_rw [primeFactors]
+  simp only [normalizedFactors_pow]
+  rw [Multiset.toFinset_nsmul]
+  exact ne_of_gt hn
+
+theorem radical_pow (a : α) {n : Nat} (hn : 0 < n) : radical (a ^ n) = radical a := by
+  simp_rw [radical, primeFactors_pow a hn]
+
+theorem radical_dvd_self (a : α) : radical a ∣ a :=
+  by
+  by_cases ha : a = 0
+  · rw [ha]
+    apply dvd_zero
+  · rw [radical, ← Finset.prod_val, ← (normalizedFactors_prod ha).dvd_iff_dvd_right]
+    apply Multiset.prod_dvd_prod_of_le
+    rw [primeFactors, Multiset.toFinset_val]
+    apply Multiset.dedup_le
+
+theorem radical_prime {a : α} (ha : Prime a) : radical a = normalize a :=
+  by
+  rw [radical, primeFactors]
+  rw [normalizedFactors_irreducible ha.irreducible]
+  simp only [Multiset.toFinset_singleton, id, Finset.prod_singleton]
+
+theorem radical_prime_pow {a : α} (ha : Prime a) {n : ℕ} (hn : 1 ≤ n) :
+    radical (a ^ n) = normalize a := by
+  rw [radical_pow a hn]
+  exact radical_prime ha

--- a/Mathlib/RingTheory/Radical.lean
+++ b/Mathlib/RingTheory/Radical.lean
@@ -52,8 +52,7 @@ theorem radical_zero_eq_one : radical (0 : α) = 1 := by
 theorem radical_one_eq_one : radical (1 : α) = 1 := by
   rw [radical, primeFactors, normalizedFactors_one, Multiset.toFinset_zero, Finset.prod_empty]
 
-theorem radical_associated_eq {a b : α} (h : Associated a b) : radical a = radical b :=
-  by
+theorem radical_associated_eq {a b : α} (h : Associated a b) : radical a = radical b := by
   rcases iff_iff_and_or_not_and_not.mp h.eq_zero_iff with (⟨rfl, rfl⟩ | ⟨ha, hb⟩)
   · rfl
   · simp_rw [radical, primeFactors]
@@ -65,8 +64,7 @@ theorem radical_unit_eq_one {a : α} (h : IsUnit a) : radical a = 1 :=
 theorem radical_unit_hMul {u : αˣ} {a : α} : radical ((↑u : α) * a) = radical a :=
   radical_associated_eq (associated_unit_mul_left _ _ u.isUnit)
 
-theorem primeFactors_pow (a : α) {n : ℕ} (hn : 0 < n) : primeFactors (a ^ n) = primeFactors a :=
-  by
+theorem primeFactors_pow (a : α) {n : ℕ} (hn : 0 < n) : primeFactors (a ^ n) = primeFactors a := by
   simp_rw [primeFactors]
   simp only [normalizedFactors_pow]
   rw [Multiset.toFinset_nsmul]
@@ -75,8 +73,7 @@ theorem primeFactors_pow (a : α) {n : ℕ} (hn : 0 < n) : primeFactors (a ^ n) 
 theorem radical_pow (a : α) {n : Nat} (hn : 0 < n) : radical (a ^ n) = radical a := by
   simp_rw [radical, primeFactors_pow a hn]
 
-theorem radical_dvd_self (a : α) : radical a ∣ a :=
-  by
+theorem radical_dvd_self (a : α) : radical a ∣ a := by
   by_cases ha : a = 0
   · rw [ha]
     apply dvd_zero
@@ -85,8 +82,7 @@ theorem radical_dvd_self (a : α) : radical a ∣ a :=
     rw [primeFactors, Multiset.toFinset_val]
     apply Multiset.dedup_le
 
-theorem radical_prime {a : α} (ha : Prime a) : radical a = normalize a :=
-  by
+theorem radical_prime {a : α} (ha : Prime a) : radical a = normalize a := by
   rw [radical, primeFactors]
   rw [normalizedFactors_irreducible ha.irreducible]
   simp only [Multiset.toFinset_singleton, id, Finset.prod_singleton]

--- a/Mathlib/RingTheory/Radical.lean
+++ b/Mathlib/RingTheory/Radical.lean
@@ -3,7 +3,6 @@ Copyright (c) 2024 Jineon Back and Seewoo Lee. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Jineon Baek, Seewoo Lee
 -/
-import Mathlib.Algebra.Ring.Regular
 import Mathlib.RingTheory.UniqueFactorizationDomain
 
 /-!

--- a/Mathlib/RingTheory/Radical.lean
+++ b/Mathlib/RingTheory/Radical.lean
@@ -29,6 +29,7 @@ This is different from the radical of an ideal.
 - Make a comparison with `Ideal.radical`. Especially, for principal ideal,
   `Ideal.radical (Ideal.span {a}) = Ideal.span {radical a}`.
 - Prove `radical (radical a) = radical a`.
+- Prove a comparison between `primeFactors` and `Nat.primeFactors`.
 -/
 
 noncomputable section

--- a/Mathlib/RingTheory/Radical.lean
+++ b/Mathlib/RingTheory/Radical.lean
@@ -37,7 +37,6 @@ open scoped Classical
 
 open UniqueFactorizationMonoid
 
-variable {k : Type*} [Field k]
 -- `CancelCommMonoidWithZero` is required by `UniqueFactorizationMonoid`
 variable {M : Type*} [CancelCommMonoidWithZero M] [NormalizationMonoid M]
   [UniqueFactorizationMonoid M]

--- a/Mathlib/RingTheory/Radical.lean
+++ b/Mathlib/RingTheory/Radical.lean
@@ -52,9 +52,11 @@ the prime factors of `a`.
 def radical (a : α) : α :=
   (primeFactors a).prod id
 
+@[simp]
 theorem radical_zero_eq : radical (0 : α) = 1 := by
   rw [radical, primeFactors, normalizedFactors_zero, Multiset.toFinset_zero, Finset.prod_empty]
 
+@[simp]
 theorem radical_one_eq : radical (1 : α) = 1 := by
   rw [radical, primeFactors, normalizedFactors_one, Multiset.toFinset_zero, Finset.prod_empty]
 

--- a/Mathlib/RingTheory/Radical.lean
+++ b/Mathlib/RingTheory/Radical.lean
@@ -8,14 +8,16 @@ import Mathlib.RingTheory.UniqueFactorizationDomain
 /-!
 # Radical of an element of a unique factorization normalization monoid
 
-This file defines a radical `rad(a)` of an element `a` of a unique factorization normalization
+This file defines a radical of an element `a` of a unique factorization normalization
 monoid, which is defined as a product of normalized prime factors of `a` without duplication.
-This is different from the radical of ideal.
+This is different from the radical of an ideal.
 
 ## Main declarations
 
+- `radical`: The radical of an element `a` in a unique factorization monoid is the product of
+  its prime factors.
 - `radical_associated_eq`: If `a` and `b` are associates, i.e. `a * u = b` for some unit `u`,
-  then `rad(a) = rad(b)`.
+  then `radical a = radical b`.
 - `radical_unit_hMul`: Multiplying unit does not change the radical.
 - `radical_dvd_self`: `rad(a)` divides `a`.
 - `radical_pow`: `rad(a ^ n) = rad(a)` for any `n ≥ 1`
@@ -23,9 +25,9 @@ This is different from the radical of ideal.
 
 ## TODO
 
-- Make a comparison with `Ideal.radical`. Especially, for principal ideal, `rad((a)) = (rad(a))`,
-  where the first (resp. second) `rad` is radical of an ideal (resp. element).
-- Prove `rad(rad(a)) = rad(a)`.
+- Make a comparison with `Ideal.radical`. Especially, for principal ideal,
+  `Ideal.radical (Ideal.span {a}) = Ideal.span {radical a}`.
+- Prove `radical (radical a) = radical a`.
 -/
 
 noncomputable section
@@ -35,14 +37,18 @@ open scoped Classical
 open UniqueFactorizationMonoid
 
 variable {k : Type _} [Field k]
+-- `CancelCommMonoidWithZero` is required by `UniqueFactorizationMonoid`
 variable {α : Type _} [CancelCommMonoidWithZero α] [NormalizationMonoid α]
   [UniqueFactorizationMonoid α]
 
-/-- Prime factors of a polynomial `a` are monic factors of `a` without duplication. -/
+/-- The finite set of prime factors of an element in a unique factorization monoid. -/
 def primeFactors (a : α) : Finset α :=
   (normalizedFactors a).toFinset
 
-/-- Radical of a polynomial `a` is a product of prime factors of `a`. -/
+/--
+Radical of an element `a` in a unique factorization monoid is the product of
+the prime factors of `a`.
+-/
 def radical (a : α) : α :=
   (primeFactors a).prod id
 

--- a/Mathlib/RingTheory/Radical.lean
+++ b/Mathlib/RingTheory/Radical.lean
@@ -16,11 +16,11 @@ This is different from the radical of an ideal.
 
 - `radical`: The radical of an element `a` in a unique factorization monoid is the product of
   its prime factors.
-- `radical_associated_eq`: If `a` and `b` are associates, i.e. `a * u = b` for some unit `u`,
+- `radical_eq_of_associated`: If `a` and `b` are associates, i.e. `a * u = b` for some unit `u`,
   then `radical a = radical b`.
 - `radical_unit_hMul`: Multiplying unit does not change the radical.
-- `radical_dvd_self`: `rad(a)` divides `a`.
-- `radical_pow`: `rad(a ^ n) = rad(a)` for any `n ≥ 1`
+- `radical_dvd_self`: `radical a` divides `a`.
+- `radical_pow`: `radical (a ^ n) = radical a` for any `n ≥ 1`
 - `radical_prime`: Radical of a prime element is equal to its normalization
 
 ## TODO
@@ -52,23 +52,23 @@ the prime factors of `a`.
 def radical (a : α) : α :=
   (primeFactors a).prod id
 
-theorem radical_zero_eq_one : radical (0 : α) = 1 := by
+theorem radical_zero_eq : radical (0 : α) = 1 := by
   rw [radical, primeFactors, normalizedFactors_zero, Multiset.toFinset_zero, Finset.prod_empty]
 
-theorem radical_one_eq_one : radical (1 : α) = 1 := by
+theorem radical_one_eq : radical (1 : α) = 1 := by
   rw [radical, primeFactors, normalizedFactors_one, Multiset.toFinset_zero, Finset.prod_empty]
 
-theorem radical_associated_eq {a b : α} (h : Associated a b) : radical a = radical b := by
+theorem radical_eq_of_associated {a b : α} (h : Associated a b) : radical a = radical b := by
   rcases iff_iff_and_or_not_and_not.mp h.eq_zero_iff with (⟨rfl, rfl⟩ | ⟨ha, hb⟩)
   · rfl
   · simp_rw [radical, primeFactors]
     rw [(associated_iff_normalizedFactors_eq_normalizedFactors ha hb).mp h]
 
 theorem radical_unit_eq_one {a : α} (h : IsUnit a) : radical a = 1 :=
-  (radical_associated_eq (associated_one_iff_isUnit.mpr h)).trans radical_one_eq_one
+  (radical_eq_of_associated (associated_one_iff_isUnit.mpr h)).trans radical_one_eq
 
 theorem radical_unit_hMul {u : αˣ} {a : α} : radical ((↑u : α) * a) = radical a :=
-  radical_associated_eq (associated_unit_mul_left _ _ u.isUnit)
+  radical_eq_of_associated (associated_unit_mul_left _ _ u.isUnit)
 
 theorem primeFactors_pow (a : α) {n : ℕ} (hn : 0 < n) : primeFactors (a ^ n) = primeFactors a := by
   simp_rw [primeFactors]

--- a/Mathlib/RingTheory/Radical.lean
+++ b/Mathlib/RingTheory/Radical.lean
@@ -18,10 +18,10 @@ This is different from the radical of an ideal.
   its prime factors.
 - `radical_eq_of_associated`: If `a` and `b` are associates, i.e. `a * u = b` for some unit `u`,
   then `radical a = radical b`.
-- `radical_unit_hMul`: Multiplying unit does not change the radical.
+- `radical_unit_mul`: Multiplying unit does not change the radical.
 - `radical_dvd_self`: `radical a` divides `a`.
 - `radical_pow`: `radical (a ^ n) = radical a` for any `n ≥ 1`
-- `radical_prime`: Radical of a prime element is equal to its normalization
+- `radical_of_prime`: Radical of a prime element is equal to its normalization
 
 ## TODO
 
@@ -69,8 +69,11 @@ theorem radical_eq_of_associated {a b : α} (h : Associated a b) : radical a = r
 theorem radical_unit_eq_one {a : α} (h : IsUnit a) : radical a = 1 :=
   (radical_eq_of_associated (associated_one_iff_isUnit.mpr h)).trans radical_one_eq
 
-theorem radical_unit_hMul {u : αˣ} {a : α} : radical ((↑u : α) * a) = radical a :=
+theorem radical_unit_mul {u : αˣ} {a : α} : radical ((↑u : α) * a) = radical a :=
   radical_eq_of_associated (associated_unit_mul_left _ _ u.isUnit)
+
+theorem radical_mul_unit {u : αˣ} {a : α} : radical (a * (↑u : α)) = radical a :=
+  radical_eq_of_associated (associated_mul_unit_left _ _ u.isUnit)
 
 theorem primeFactors_pow (a : α) {n : ℕ} (hn : 0 < n) : primeFactors (a ^ n) = primeFactors a := by
   simp_rw [primeFactors]
@@ -90,12 +93,12 @@ theorem radical_dvd_self (a : α) : radical a ∣ a := by
     rw [primeFactors, Multiset.toFinset_val]
     apply Multiset.dedup_le
 
-theorem radical_prime {a : α} (ha : Prime a) : radical a = normalize a := by
+theorem radical_of_prime {a : α} (ha : Prime a) : radical a = normalize a := by
   rw [radical, primeFactors]
   rw [normalizedFactors_irreducible ha.irreducible]
   simp only [Multiset.toFinset_singleton, id, Finset.prod_singleton]
 
-theorem radical_prime_pow {a : α} (ha : Prime a) {n : ℕ} (hn : 1 ≤ n) :
+theorem radical_pow_of_prime {a : α} (ha : Prime a) {n : ℕ} (hn : 0 < n) :
     radical (a ^ n) = normalize a := by
   rw [radical_pow a hn]
-  exact radical_prime ha
+  exact radical_of_prime ha

--- a/Mathlib/RingTheory/Radical.lean
+++ b/Mathlib/RingTheory/Radical.lean
@@ -22,6 +22,7 @@ This is different from the radical of an ideal.
 - `radical_dvd_self`: `radical a` divides `a`.
 - `radical_pow`: `radical (a ^ n) = radical a` for any `n ≥ 1`
 - `radical_of_prime`: Radical of a prime element is equal to its normalization
+- `radical_pow_of_prime`: Radical of a power of prime element is equal to its normalization
 
 ## TODO
 
@@ -36,9 +37,9 @@ open scoped Classical
 
 open UniqueFactorizationMonoid
 
-variable {k : Type _} [Field k]
+variable {k : Type*} [Field k]
 -- `CancelCommMonoidWithZero` is required by `UniqueFactorizationMonoid`
-variable {M : Type _} [CancelCommMonoidWithZero M] [NormalizationMonoid M]
+variable {M : Type*} [CancelCommMonoidWithZero M] [NormalizationMonoid M]
   [UniqueFactorizationMonoid M]
 
 /-- The finite set of prime factors of an element in a unique factorization monoid. -/

--- a/Mathlib/RingTheory/Radical.lean
+++ b/Mathlib/RingTheory/Radical.lean
@@ -38,53 +38,53 @@ open UniqueFactorizationMonoid
 
 variable {k : Type _} [Field k]
 -- `CancelCommMonoidWithZero` is required by `UniqueFactorizationMonoid`
-variable {α : Type _} [CancelCommMonoidWithZero α] [NormalizationMonoid α]
-  [UniqueFactorizationMonoid α]
+variable {M : Type _} [CancelCommMonoidWithZero M] [NormalizationMonoid M]
+  [UniqueFactorizationMonoid M]
 
 /-- The finite set of prime factors of an element in a unique factorization monoid. -/
-def primeFactors (a : α) : Finset α :=
+def primeFactors (a : M) : Finset M :=
   (normalizedFactors a).toFinset
 
 /--
 Radical of an element `a` in a unique factorization monoid is the product of
 the prime factors of `a`.
 -/
-def radical (a : α) : α :=
+def radical (a : M) : M :=
   (primeFactors a).prod id
 
 @[simp]
-theorem radical_zero_eq : radical (0 : α) = 1 := by
+theorem radical_zero_eq : radical (0 : M) = 1 := by
   rw [radical, primeFactors, normalizedFactors_zero, Multiset.toFinset_zero, Finset.prod_empty]
 
 @[simp]
-theorem radical_one_eq : radical (1 : α) = 1 := by
+theorem radical_one_eq : radical (1 : M) = 1 := by
   rw [radical, primeFactors, normalizedFactors_one, Multiset.toFinset_zero, Finset.prod_empty]
 
-theorem radical_eq_of_associated {a b : α} (h : Associated a b) : radical a = radical b := by
+theorem radical_eq_of_associated {a b : M} (h : Associated a b) : radical a = radical b := by
   rcases iff_iff_and_or_not_and_not.mp h.eq_zero_iff with (⟨rfl, rfl⟩ | ⟨ha, hb⟩)
   · rfl
   · simp_rw [radical, primeFactors]
     rw [(associated_iff_normalizedFactors_eq_normalizedFactors ha hb).mp h]
 
-theorem radical_unit_eq_one {a : α} (h : IsUnit a) : radical a = 1 :=
+theorem radical_unit_eq_one {a : M} (h : IsUnit a) : radical a = 1 :=
   (radical_eq_of_associated (associated_one_iff_isUnit.mpr h)).trans radical_one_eq
 
-theorem radical_unit_mul {u : αˣ} {a : α} : radical ((↑u : α) * a) = radical a :=
+theorem radical_unit_mul {u : Mˣ} {a : M} : radical ((↑u : M) * a) = radical a :=
   radical_eq_of_associated (associated_unit_mul_left _ _ u.isUnit)
 
-theorem radical_mul_unit {u : αˣ} {a : α} : radical (a * (↑u : α)) = radical a :=
+theorem radical_mul_unit {u : Mˣ} {a : M} : radical (a * (↑u : M)) = radical a :=
   radical_eq_of_associated (associated_mul_unit_left _ _ u.isUnit)
 
-theorem primeFactors_pow (a : α) {n : ℕ} (hn : 0 < n) : primeFactors (a ^ n) = primeFactors a := by
+theorem primeFactors_pow (a : M) {n : ℕ} (hn : 0 < n) : primeFactors (a ^ n) = primeFactors a := by
   simp_rw [primeFactors]
   simp only [normalizedFactors_pow]
   rw [Multiset.toFinset_nsmul]
   exact ne_of_gt hn
 
-theorem radical_pow (a : α) {n : Nat} (hn : 0 < n) : radical (a ^ n) = radical a := by
+theorem radical_pow (a : M) {n : Nat} (hn : 0 < n) : radical (a ^ n) = radical a := by
   simp_rw [radical, primeFactors_pow a hn]
 
-theorem radical_dvd_self (a : α) : radical a ∣ a := by
+theorem radical_dvd_self (a : M) : radical a ∣ a := by
   by_cases ha : a = 0
   · rw [ha]
     apply dvd_zero
@@ -93,12 +93,12 @@ theorem radical_dvd_self (a : α) : radical a ∣ a := by
     rw [primeFactors, Multiset.toFinset_val]
     apply Multiset.dedup_le
 
-theorem radical_of_prime {a : α} (ha : Prime a) : radical a = normalize a := by
+theorem radical_of_prime {a : M} (ha : Prime a) : radical a = normalize a := by
   rw [radical, primeFactors]
   rw [normalizedFactors_irreducible ha.irreducible]
   simp only [Multiset.toFinset_singleton, id, Finset.prod_singleton]
 
-theorem radical_pow_of_prime {a : α} (ha : Prime a) {n : ℕ} (hn : 0 < n) :
+theorem radical_pow_of_prime {a : M} (ha : Prime a) {n : ℕ} (hn : 0 < n) :
     radical (a ^ n) = normalize a := by
   rw [radical_pow a hn]
   exact radical_of_prime ha


### PR DESCRIPTION
For a unique factorization normalization monoid, define a radical of an element as a product of normalized prime factors (without duplication).

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

This is part of our project to port [Mason-Stothers Theorem](https://github.com/seewoo5/lean-poly-abc) in mathlib @jcpaik. You can find more theorems that will be added in future PRs [here](https://github.com/seewoo5/lean-poly-abc/blob/main/LeanPolyABC/Lib/Radical.lean).

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
