### PR TITLE
chore: backport removal of two bad `@[elab_as_elim]` attributes

### DIFF
--- a/Mathlib/MeasureTheory/Function/SimpleFuncDenseLp.lean
+++ b/Mathlib/MeasureTheory/Function/SimpleFuncDenseLp.lean
@@ -699,7 +699,6 @@ theorem toSimpleFunc_indicatorConst {s : Set α} (hs : MeasurableSet s) (hμs : 
 /-- To prove something for an arbitrary `Lp` simple function, with `0 < p < ∞`, it suffices to show
 that the property holds for (multiples of) characteristic functions of finite-measure measurable
 sets and is closed under addition (of functions with disjoint support). -/
-@[elab_as_elim]
 protected theorem induction (hp_pos : p ≠ 0) (hp_ne_top : p ≠ ∞) {P : Lp.simpleFunc E p μ → Prop}
     (h_ind :
       ∀ (c : E) {s : Set α} (hs : MeasurableSet s) (hμs : μ s < ∞),

--- a/Mathlib/RingTheory/ClassGroup.lean
+++ b/Mathlib/RingTheory/ClassGroup.lean
@@ -166,7 +166,6 @@ variable (K)
 /-- Induction principle for the class group: to show something holds for all `x : ClassGroup R`,
 we can choose a fraction field `K` and show it holds for the equivalence class of each
 `I : FractionalIdeal R⁰ K`. -/
-@[elab_as_elim]
 theorem ClassGroup.induction {P : ClassGroup R → Prop}
     (h : ∀ I : (FractionalIdeal R⁰ K)ˣ, P (ClassGroup.mk I)) (x : ClassGroup R) : P x :=
   QuotientGroup.induction_on x fun I => by


### PR DESCRIPTION
See [zulip](https://leanprover.zulipchat.com/#narrow/stream/428973-nightly-testing/topic/Mathlib.20status.20updates/near/452398632).

These will cause failures after nightly-2024-07-18.