### PR TITLE
[Merged by Bors] - chore: remove autoImplicit in five miscellaneous files

### DIFF
--- a/Mathlib/Order/Estimator.lean
+++ b/Mathlib/Order/Estimator.lean
@@ -32,7 +32,7 @@ An appropriate well-foundedness condition would then ensure that repeated improv
 the exact value.
 -/
 
-set_option autoImplicit true
+variable {α ε : Type*}
 
 /--
 Given `[EstimatorData a ε]`
@@ -69,9 +69,9 @@ section trivial
 variable [Preorder α]
 
 /-- A trivial estimator, containing the actual value. -/
-abbrev Estimator.trivial (a : α) : Type* := { b : α // b = a }
+abbrev Estimator.trivial.{u} {α : Type u} (a : α) : Type u := { b : α // b = a }
 
-instance : Bot (Estimator.trivial a) := ⟨⟨a, rfl⟩⟩
+instance {a : α} : Bot (Estimator.trivial a) := ⟨⟨a, rfl⟩⟩
 
 instance : WellFoundedGT Unit where
   wf := ⟨fun .unit => ⟨.unit, nofun⟩⟩
@@ -116,7 +116,6 @@ def Estimator.improveUntil (a : Thunk α) (p : α → Bool)
     [Estimator a ε] [WellFoundedGT (range (bound a : ε → α))] (e : ε) :
     Except (Option ε) ε :=
   Estimator.improveUntilAux a p e false
-
 
 attribute [local instance] WellFoundedGT.toWellFoundedRelation in
 /--
@@ -188,7 +187,7 @@ end add
 /-! Estimator for the first component of a pair. -/
 section fst
 
-variable [PartialOrder α] [PartialOrder β]
+variable {β : Type*} [PartialOrder α] [PartialOrder β]
 
 /--
 An estimator for `(a, b)` can be turned into an estimator for `a`,
@@ -203,7 +202,7 @@ structure Estimator.fst
 
 variable [∀ a : α, WellFoundedGT { x // x ≤ a }]
 
-instance [Estimator a ε] : WellFoundedGT (range (bound a : ε → α)) :=
+instance {a : Thunk α} [Estimator a ε] : WellFoundedGT (range (bound a : ε → α)) :=
   let f : range (bound a : ε → α) ↪o { x // x ≤ a.get } :=
     Subtype.orderEmbedding (by rintro _ ⟨e, rfl⟩; exact Estimator.bound_le e)
   f.wellFoundedGT
@@ -221,7 +220,7 @@ instance [DecidableRel ((· : α) < ·)] {a : Thunk α} {b : Thunk β}
 -- This isn't an instance as at the sole use case we need to provide
 -- the instance arguments by hand anyway.
 def Estimator.fstInst [DecidableRel ((· : α) < ·)] [∀ (p : α × β), WellFoundedGT { q // q ≤ p }]
-    (a : Thunk α) (b : Thunk β) {ε : Type*} (i : Estimator (a.prod b) ε) :
+    (a : Thunk α) (b : Thunk β) (i : Estimator (a.prod b) ε) :
     Estimator a (Estimator.fst (a.prod b) ε) where
   bound_le e := (Estimator.bound_le e.inner : bound (a.prod b) e.inner ≤ (a.get, b.get)).1
   improve_spec e := by

--- a/Mathlib/Tactic/Sat/FromLRAT.lean
+++ b/Mathlib/Tactic/Sat/FromLRAT.lean
@@ -190,7 +190,8 @@ structure Clause.reify (v : Valuation) (c : Clause) (p : Prop) : Prop where
   prop : ¬ v.satisfies c → p
 
 /-- Reification of a single clause formula. -/
-theorem Fmla.reify_one {c : Clause} {a : Prop} (h : Clause.reify v c a) : Fmla.reify v (Fmla.one c) a :=
+theorem Fmla.reify_one {c : Clause} {a : Prop} (h : Clause.reify v c a) :
+    Fmla.reify v (Fmla.one c) a :=
   ⟨fun H ↦ h.1 fun h ↦ H ⟨fun | _, List.Mem.head .. => h⟩⟩
 
 /-- Asserts that `¬⟦l⟧_v` implies `p`. -/

--- a/Mathlib/Tactic/Sat/FromLRAT.lean
+++ b/Mathlib/Tactic/Sat/FromLRAT.lean
@@ -39,8 +39,6 @@ foo : ∀ (a a_1 : Prop), (¬a ∧ ¬a_1 ∨ a ∧ ¬a_1) ∨ ¬a ∧ a_1 ∨ a 
   to load CNF / LRAT files from disk.
 -/
 
-set_option autoImplicit true
-
 open Lean hiding Literal HashMap
 open Batteries
 
@@ -120,7 +118,8 @@ def Fmla.proof (f : Fmla) (c : Clause) : Prop :=
   ∀ v : Valuation, v.satisfies_fmla f → v.satisfies c
 
 /-- If `f` subsumes `c` (i.e. `c ∈ f`), then `f.proof c`. -/
-theorem Fmla.proof_of_subsumes (H : Fmla.subsumes f (Fmla.one c)) : f.proof c :=
+theorem Fmla.proof_of_subsumes {f : Fmla} {c : Clause}
+    (H : Fmla.subsumes f (Fmla.one c)) : f.proof c :=
   fun _ h ↦ h.1 _ <| H.1 _ <| List.Mem.head ..
 
 /-- The core unit-propagation step.
@@ -153,7 +152,7 @@ def Valuation.mk : List Prop → Valuation
 
 /-- The fundamental relationship between `mk` and `implies`:
 `(mk ps).implies p ps 0` is equivalent to `p`. -/
-theorem Valuation.mk_implies {as ps} (as₁) : as = List.reverseAux as₁ ps →
+theorem Valuation.mk_implies {p} {as ps} (as₁) : as = List.reverseAux as₁ ps →
     (Valuation.mk as).implies p ps as₁.length → p := by
   induction ps generalizing as₁ with
   | nil => exact fun _ ↦ id
@@ -169,16 +168,18 @@ theorem Valuation.mk_implies {as ps} (as₁) : as = List.reverseAux as₁ ps →
 structure Fmla.reify (v : Valuation) (f : Fmla) (p : Prop) : Prop where
   prop : ¬ v.satisfies_fmla f → p
 
+variable {v : Valuation}
+
 /-- If `f` is unsatisfiable, and every `v` which agrees with `ps` implies `¬⟦f⟧_v → p`, then `p`.
 Equivalently, there exists a valuation `v` which agrees with `ps`,
 and every such valuation yields `¬⟦f⟧_v` because `f` is unsatisfiable. -/
-theorem Fmla.refute {ps} (f : Fmla) (hf : f.proof [])
+theorem Fmla.refute {p : Prop} {ps} (f : Fmla) (hf : f.proof [])
     (hv : ∀ v, Valuation.implies v (Fmla.reify v f p) ps 0) : p :=
   (Valuation.mk_implies [] rfl (hv _)).1 (hf _)
 
 /-- Negation turns AND into OR, so `¬⟦f₁ ∧ f₂⟧_v ≡ ¬⟦f₁⟧_v ∨ ¬⟦f₂⟧_v`. -/
-theorem Fmla.reify_or (h₁ : Fmla.reify v f₁ a) (h₂ : Fmla.reify v f₂ b) :
-    Fmla.reify v (f₁.and f₂) (a ∨ b) := by
+theorem Fmla.reify_or {f₁ : Fmla} {a : Prop} {f₂ : Fmla} {b : Prop}
+    (h₁ : Fmla.reify v f₁ a) (h₂ : Fmla.reify v f₂ b) : Fmla.reify v (f₁.and f₂) (a ∨ b) := by
   refine ⟨fun H ↦ by_contra fun hn ↦ H ⟨fun c h ↦ by_contra fun hn' ↦ ?_⟩⟩
   rcases List.mem_append.1 h with h | h
   · exact hn <| Or.inl <| h₁.1 fun Hc ↦ hn' <| Hc.1 _ h
@@ -189,7 +190,7 @@ structure Clause.reify (v : Valuation) (c : Clause) (p : Prop) : Prop where
   prop : ¬ v.satisfies c → p
 
 /-- Reification of a single clause formula. -/
-theorem Fmla.reify_one (h : Clause.reify v c a) : Fmla.reify v (Fmla.one c) a :=
+theorem Fmla.reify_one {c : Clause} {a : Prop} (h : Clause.reify v c a) : Fmla.reify v (Fmla.one c) a :=
   ⟨fun H ↦ h.1 fun h ↦ H ⟨fun | _, List.Mem.head .. => h⟩⟩
 
 /-- Asserts that `¬⟦l⟧_v` implies `p`. -/
@@ -197,7 +198,8 @@ structure Literal.reify (v : Valuation) (l : Literal) (p : Prop) : Prop where
   prop : v.neg l → p
 
 /-- Negation turns OR into AND, so `¬⟦l ∨ c⟧_v ≡ ¬⟦l⟧_v ∧ ¬⟦c⟧_v`. -/
-theorem Clause.reify_and (h₁ : Literal.reify v l a) (h₂ : Clause.reify v c b) :
+theorem Clause.reify_and {l : Literal} {a : Prop} {c : Clause} {b : Prop}
+    (h₁ : Literal.reify v l a) (h₂ : Clause.reify v c b) :
     Clause.reify v (Clause.cons l c) (a ∧ b) :=
   ⟨fun H ↦ ⟨h₁.1 (by_contra fun hn ↦ H hn.elim), h₂.1 fun h ↦ H fun _ ↦ h⟩⟩
 
@@ -205,14 +207,15 @@ theorem Clause.reify_and (h₁ : Literal.reify v l a) (h₂ : Clause.reify v c b
 theorem Clause.reify_zero : Clause.reify v Clause.nil True := ⟨fun _ ↦ trivial⟩
 
 /-- The reification of a singleton clause `¬⟦l⟧_v ≡ ¬⟦l⟧_v`. -/
-theorem Clause.reify_one (h₁ : Literal.reify v l a) : Clause.reify v (Clause.nil.cons l) a :=
+theorem Clause.reify_one {l : Literal} {a : Prop}
+    (h₁ : Literal.reify v l a) : Clause.reify v (Clause.nil.cons l) a :=
   ⟨fun H ↦ ((Clause.reify_and h₁ Clause.reify_zero).1 H).1⟩
 
 /-- The reification of a positive literal `¬⟦a⟧_v ≡ ¬a`. -/
-theorem Literal.reify_pos (h : v n ↔ a) : (Literal.pos n).reify v ¬a := ⟨mt h.2⟩
+theorem Literal.reify_pos {a : Prop} {n : ℕ} (h : v n ↔ a) : (Literal.pos n).reify v ¬a := ⟨mt h.2⟩
 
 /-- The reification of a negative literal `¬⟦¬a⟧_v ≡ a`. -/
-theorem Literal.reify_neg (h : v n ↔ a) : (Literal.neg n).reify v a := ⟨h.1⟩
+theorem Literal.reify_neg {a : Prop} {n : ℕ} (h : v n ↔ a) : (Literal.neg n).reify v a := ⟨h.1⟩
 
 end Sat
 

--- a/Mathlib/Testing/SlimCheck/Gen.lean
+++ b/Mathlib/Testing/SlimCheck/Gen.lean
@@ -27,7 +27,7 @@ random testing
 * https://hackage.haskell.org/package/QuickCheck
 -/
 
-set_option autoImplicit true
+universe u v
 
 namespace SlimCheck
 
@@ -66,7 +66,7 @@ def getSize : Gen Nat :=
   return (← read).down
 
 /-- Apply a function to the size parameter. -/
-def resize (f : Nat → Nat) (x : Gen α) : Gen α :=
+def resize {α : Type*} (f : Nat → Nat) (x : Gen α) : Gen α :=
   withReader (ULift.up ∘ f ∘ ULift.down) x
 
 variable {α : Type u}
@@ -113,7 +113,7 @@ def prodOf {α : Type u} {β : Type v} (x : Gen α) (y : Gen β) : Gen (α × β
 end Gen
 
 /-- Execute a `Gen` inside the `IO` monad using `size` as the example size-/
-def Gen.run (x : Gen α) (size : Nat) : BaseIO α :=
+def Gen.run {α : Type} (x : Gen α) (size : Nat) : BaseIO α :=
   letI : MonadLift Id BaseIO := ⟨fun f => pure <| Id.run f⟩
   IO.runRand (ReaderT.run x ⟨size⟩:)
 

--- a/Mathlib/Testing/SlimCheck/Sampleable.lean
+++ b/Mathlib/Testing/SlimCheck/Sampleable.lean
@@ -86,11 +86,12 @@ random testing
 
 -/
 
-set_option autoImplicit true
-
 namespace SlimCheck
 
 open Random Gen
+
+universe u v
+variable {α β : Type*}
 
 /-- Given an example `x : α`, `Shrinkable α` gives us a way to shrink it
 and suggest simpler examples. -/

--- a/Mathlib/Testing/SlimCheck/Testable.lean
+++ b/Mathlib/Testing/SlimCheck/Testable.lean
@@ -319,7 +319,8 @@ def addShrinks (n : Nat) : TestResult p → TestResult p
   | p => p
 
 universe u in
-instance {α : Type u} {m : Type u → Type*} [Pure m] : Inhabited (OptionT m α) := ⟨(pure none : m (Option α))⟩
+instance {α : Type u} {m : Type u → Type*} [Pure m] : Inhabited (OptionT m α) :=
+  ⟨(pure none : m (Option α))⟩
 
 variable {α : Sort*}
 

--- a/Mathlib/Testing/SlimCheck/Testable.lean
+++ b/Mathlib/Testing/SlimCheck/Testable.lean
@@ -79,8 +79,6 @@ random testing
 
 -/
 
-set_option autoImplicit true
-
 namespace SlimCheck
 
 /-- Result of trying to disprove `p`
@@ -143,6 +141,8 @@ class PrintableProp (p : Prop) where
   printProp : String
 
 export PrintableProp (printProp)
+
+variable {p q : Prop}
 
 instance (priority := low) : PrintableProp p where
   printProp := "⋯"
@@ -216,7 +216,7 @@ def addInfo (x : String) (h : q → p) (r : TestResult p)
     imp h r p
 
 /-- Add some formatting to the information recorded by `addInfo`. -/
-def addVarInfo [Repr γ] (var : String) (x : γ) (h : q → p) (r : TestResult p)
+def addVarInfo {γ : Type*} [Repr γ] (var : String) (x : γ) (h : q → p) (r : TestResult p)
     (p : PSum Unit (p → q) := PSum.inl ()) : TestResult q :=
   addInfo s!"{var} := {repr x}" h r p
 
@@ -244,7 +244,8 @@ open TestResult
 def runProp (p : Prop) [Testable p] : Configuration → Bool → Gen (TestResult p) := Testable.run
 
 /-- A `dbgTrace` with special formatting -/
-def slimTrace [Pure m] (s : String) : m PUnit := dbgTrace s!"[SlimCheck: {s}]" (fun _ ↦ pure ())
+def slimTrace {m : Type → Type*} [Pure m] (s : String) : m PUnit :=
+  dbgTrace s!"[SlimCheck: {s}]" (fun _ ↦ pure ())
 
 instance andTestable [Testable p] [Testable q] : Testable (p ∧ q) where
   run := fun cfg min ↦ do
@@ -317,7 +318,10 @@ def addShrinks (n : Nat) : TestResult p → TestResult p
   | TestResult.failure p xs m => TestResult.failure p xs (m + n)
   | p => p
 
-instance [Pure m] : Inhabited (OptionT m α) := ⟨(pure none : m (Option α))⟩
+universe u in
+instance {α : Type u} {m : Type u → Type*} [Pure m] : Inhabited (OptionT m α) := ⟨(pure none : m (Option α))⟩
+
+variable {α : Sort*}
 
 /-- Shrink a counter-example `x` by using `Shrinkable.shrink x`, picking the first
 candidate that falsifies a property and recursively shrinking that one.
@@ -383,7 +387,7 @@ where
   run := fun cfg min ↦
     imp (fun h (b : Bool) ↦ h b) <$> Testable.runProp (NamedBinder var <| ∀ b : Bool, β b) cfg min
 
-instance (priority := high) unusedVarTestable [Nonempty α] [Testable β] :
+instance (priority := high) unusedVarTestable {β : Prop} [Nonempty α] [Testable β] :
   Testable (NamedBinder var (α → β))
 where
   run := fun cfg min ↦ do
@@ -420,6 +424,8 @@ end Testable
 
 section PrintableProp
 
+variable {α : Type*} {x y : α}
+
 instance Eq.printableProp [Repr α] {x y : α} : PrintableProp (x = y) where
   printProp := s!"{repr x} = {repr y}"
 
@@ -431,6 +437,8 @@ instance LE.printableProp [Repr α] [LE α] {x y : α} : PrintableProp (x ≤ y)
 
 instance LT.printableProp [Repr α] [LT α] {x y : α} : PrintableProp (x < y) where
   printProp := s!"{repr x} < {repr y}"
+
+variable {x y : Prop}
 
 instance And.printableProp [PrintableProp x] [PrintableProp y] : PrintableProp (x ∧ y) where
   printProp := s!"{printProp x} ∧ {printProp y}"


### PR DESCRIPTION
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
