### PR TITLE
[Merged by Bors] - chore(Mathlib/Lean): remove use of autoImplicit

### DIFF
--- a/Mathlib/Lean/CoreM.lean
+++ b/Mathlib/Lean/CoreM.lean
@@ -9,14 +9,12 @@ import Mathlib.Tactic.ToExpr
 # Additional functions using `CoreM` state.
 -/
 
-set_option autoImplicit true
-
 open Lean Core
 
 /--
 Run a `CoreM α` in a fresh `Environment` with specified `modules : List Name` imported.
 -/
-def CoreM.withImportModules (modules : Array Name) (run : CoreM α)
+def CoreM.withImportModules {α : Type} (modules : Array Name) (run : CoreM α)
     (searchPath : Option SearchPath := none) (options : Options := {})
     (trustLevel : UInt32 := 0) (fileName := "") :
     IO α := unsafe do

--- a/Mathlib/Lean/Elab/Tactic/Basic.lean
+++ b/Mathlib/Lean/Elab/Tactic/Basic.lean
@@ -8,8 +8,6 @@ import Mathlib.Lean.Meta
 # Additions to `Lean.Elab.Tactic.Basic`
 -/
 
-set_option autoImplicit true
-
 open Lean Elab Tactic
 
 namespace Lean.Elab.Tactic
@@ -35,7 +33,7 @@ def doneWithScope (scope : MessageData) : TacticM Unit := do
 Like `focusAndDone` but takes a scope (e.g. tactic name) as an argument to
 produce more detailed error messages.
 -/
-def focusAndDoneWithScope (scope : MessageData) (tactic : TacticM α) : TacticM α :=
+def focusAndDoneWithScope {α : Type} (scope : MessageData) (tactic : TacticM α) : TacticM α :=
   focus do
     let a ← try tactic catch e =>
       if isAbortTacticException e then throw e

--- a/Mathlib/Lean/EnvExtension.lean
+++ b/Mathlib/Lean/EnvExtension.lean
@@ -9,8 +9,6 @@ import Lean.ScopedEnvExtension
 # Helper function for environment extensions and attributes.
 -/
 
-set_option autoImplicit true
-
 open Lean
 
-instance [Inhabited σ] : Inhabited (ScopedEnvExtension.State σ) := ⟨{state := default}⟩
+instance {σ : Type} [Inhabited σ] : Inhabited (ScopedEnvExtension.State σ) := ⟨{state := default}⟩

--- a/Mathlib/Lean/Exception.lean
+++ b/Mathlib/Lean/Exception.lean
@@ -14,14 +14,13 @@ This file contains two additional methods for working with `Exception`s
 
 -/
 
-set_option autoImplicit true
-
 open Lean
 
 /--
 A generalisation of `fail_if_success` to an arbitrary `MonadError`.
 -/
-def successIfFail [MonadError M] [Monad M] (m : M α) : M Exception := do
+def successIfFail {α : Type} {M : Type → Type} [MonadError M] [Monad M] (m : M α) :
+    M Exception := do
   match ← tryCatch (m *> pure none) (pure ∘ some) with
   | none => throwError "Expected an exception."
   | some ex => return ex

--- a/Mathlib/Lean/Expr/Basic.lean
+++ b/Mathlib/Lean/Expr/Basic.lean
@@ -18,8 +18,6 @@ This file defines basic operations on the types expr, name, declaration, level, 
 This file is mostly for non-tactics.
 -/
 
-set_option autoImplicit true
-
 namespace Lean
 
 namespace BinderInfo
@@ -340,7 +338,10 @@ def sides? (ty : Expr) : Option (Expr × Expr × Expr × Expr) :=
 
 end recognizers
 
-def modifyAppArgM [Functor M] [Pure M] (modifier : Expr → M Expr) : Expr → M Expr
+universe u
+
+def modifyAppArgM {M : Type → Type u} [Functor M] [Pure M]
+    (modifier : Expr → M Expr) : Expr → M Expr
   | app f a => mkApp f <$> modifier a
   | e => pure e
 
@@ -370,8 +371,8 @@ def getArg? (e : Expr) (i : Nat) (n := e.getAppNumArgs) : Option Expr :=
 
 /-- Given `f a₀ a₁ ... aₙ₋₁`, runs `modifier` on the `i`th argument.
 An argument `n` may be provided which says how many arguments we are expecting `e` to have. -/
-def modifyArgM [Monad M] (modifier : Expr → M Expr) (e : Expr) (i : Nat) (n := e.getAppNumArgs) :
-    M Expr := do
+def modifyArgM {M : Type → Type u} [Monad M] (modifier : Expr → M Expr)
+    (e : Expr) (i : Nat) (n := e.getAppNumArgs) : M Expr := do
   let some a := getArg? e i | return e
   let a ← modifier a
   return modifyArg (fun _ ↦ a) e i n

--- a/Mathlib/Lean/Message.lean
+++ b/Mathlib/Lean/Message.lean
@@ -9,8 +9,7 @@ import Lean.Message
 # Additional operations on MessageData and related types
 -/
 
-set_option autoImplicit true
+open Lean Std MessageData
 
-open Lean Std Format MessageData
-instance [ToMessageData α] [ToMessageData β] : ToMessageData (α × β) :=
+instance {α β : Type} [ToMessageData α] [ToMessageData β] : ToMessageData (α × β) :=
   ⟨fun x => paren <| toMessageData x.1 ++ ofFormat "," ++ Format.line ++ toMessageData x.2⟩

--- a/Mathlib/Lean/Meta.lean
+++ b/Mathlib/Lean/Meta.lean
@@ -10,8 +10,6 @@ import Lean.Meta.Tactic.Clear
 
 /-! ## Additional utilities in `Lean.MVarId` -/
 
-set_option autoImplicit true
-
 open Lean Meta
 
 namespace Lean.MVarId
@@ -65,6 +63,8 @@ namespace Lean.Elab.Tactic
 -- but that is taken in core by a function that lifts a `tac : MVarId → MetaM (Option MVarId)`.
 def liftMetaTactic' (tac : MVarId → MetaM MVarId) : TacticM Unit :=
   liftMetaTactic fun g => do pure [← tac g]
+
+variable {α : Type}
 
 @[inline] private def TacticM.runCore (x : TacticM α) (ctx : Context) (s : State) :
     TermElabM (α × State) :=

--- a/Mathlib/Lean/Meta/Basic.lean
+++ b/Mathlib/Lean/Meta/Basic.lean
@@ -12,12 +12,10 @@ import Lean.Meta.Basic
 Likely these already exist somewhere. Pointers welcome.
 -/
 
-set_option autoImplicit true
-
 /--
 Restore the metavariable context after execution.
 -/
-def Lean.Meta.preservingMCtx (x : MetaM α) : MetaM α := do
+def Lean.Meta.preservingMCtx {α : Type} (x : MetaM α) : MetaM α := do
   let mctx ← getMCtx
   try x finally setMCtx mctx
 

--- a/Mathlib/Lean/Meta/DiscrTree.lean
+++ b/Mathlib/Lean/Meta/DiscrTree.lean
@@ -9,8 +9,6 @@ import Lean.Meta.DiscrTree
 # Additions to `Lean.Meta.DiscrTree`
 -/
 
-set_option autoImplicit true
-
 namespace Lean.Meta.DiscrTree
 
 /--
@@ -24,8 +22,8 @@ Implementation: we reverse the results from `getMatch`,
 so that we return lemmas matching larger subexpressions first,
 and amongst those we return more specific lemmas first.
 -/
-partial def getSubexpressionMatches (d : DiscrTree α) (e : Expr) (config : WhnfCoreConfig) :
-    MetaM (Array α) := do
+partial def getSubexpressionMatches {α : Type}
+    (d : DiscrTree α) (e : Expr) (config : WhnfCoreConfig) : MetaM (Array α) := do
   match e with
   | .bvar _ => return #[]
   | .forallE _ _ _ _ => forallTelescope e (fun args body => do

--- a/Mathlib/Lean/Meta/Simp.lean
+++ b/Mathlib/Lean/Meta/Simp.lean
@@ -12,11 +12,9 @@ import Lean.Elab.Tactic.Simp
 [TODO] Needs documentation, cleanup, and possibly reunification of `mkSimpContext'` with core.
 -/
 
-set_option autoImplicit true
-
 open Lean Elab.Tactic
 
-def Lean.PHashSet.toList [BEq α] [Hashable α] (s : Lean.PHashSet α) : List α :=
+def Lean.PHashSet.toList.{u} {α : Type u} [BEq α] [Hashable α] (s : Lean.PHashSet α) : List α :=
   s.1.toList.map (·.1)
 
 namespace Lean

--- a/Mathlib/Lean/Thunk.lean
+++ b/Mathlib/Lean/Thunk.lean
@@ -10,8 +10,6 @@ import Batteries.Data.Thunk
 # Basic facts about `Thunk`.
 -/
 
-set_option autoImplicit true
-
 namespace Thunk
 
 #align thunk.mk Thunk.mk
@@ -19,7 +17,10 @@ namespace Thunk
 @[simp] theorem get_pure {α} (x : α) : (Thunk.pure x).get = x := rfl
 @[simp] theorem get_mk {α} (f : Unit → α) : (Thunk.mk f).get = f () := rfl
 
-instance {α : Type u} [DecidableEq α] : DecidableEq (Thunk α) := by
+universe u v
+variable {α : Type u} {β : Type v}
+
+instance [DecidableEq α] : DecidableEq (Thunk α) := by
   intro a b
   have : a = b ↔ a.get = b.get := ⟨by intro x; rw [x], by intro; ext; assumption⟩
   rw [this]
@@ -28,8 +29,8 @@ instance {α : Type u} [DecidableEq α] : DecidableEq (Thunk α) := by
 /-- The cartesian product of two thunks. -/
 def prod (a : Thunk α) (b : Thunk β) : Thunk (α × β) := Thunk.mk fun _ => (a.get, b.get)
 
-@[simp] theorem prod_get_fst : (prod a b).get.1 = a.get := rfl
-@[simp] theorem prod_get_snd : (prod a b).get.2 = b.get := rfl
+@[simp] theorem prod_get_fst {a : Thunk α} {b : Thunk β} : (prod a b).get.1 = a.get := rfl
+@[simp] theorem prod_get_snd {a : Thunk α} {b : Thunk β} : (prod a b).get.2 = b.get := rfl
 
 /-- The sum of two thunks. -/
 def add [Add α] (a b : Thunk α) : Thunk α := Thunk.mk fun _ => a.get + b.get


### PR DESCRIPTION
All eleven files in the Lean/ directory use autoImplicit, but only in a very minor way. Removing it seems easier than making this a permanent exception.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
