### PR TITLE
[Merged by Bors] - feat: extend the linter against broad imports

### DIFF
--- a/Mathlib/Tactic/Linter/Header.lean
+++ b/Mathlib/Tactic/Linter/Header.lean
@@ -217,7 +217,7 @@ def broadImportsCheck (imports : Array Syntax) (mainModule : Name) : Array (Synt
       s!"Mathlib.Tactic.Replace defines a deprecated form of the 'replace' tactic; \
       please do not use it in mathlib.")
     | `Mathlib.Tactic.Have =>
-      if mainModule != `Mathlib.Tactic.Replace then
+      if ![`Mathlib.Tactic, `Mathlib.Tactic.Replace].contains mainModule then
         output := output.push (i,
           s!"Mathlib.Tactic.Have defines a deprecated form of the 'have' tactic; \
           please do not use it in mathlib.")

--- a/Mathlib/Tactic/Linter/Header.lean
+++ b/Mathlib/Tactic/Linter/Header.lean
@@ -207,18 +207,31 @@ def copyrightHeaderChecks (copyright : String) : Array (Syntax × String) := Id.
 
 /-- Check the `Syntax` `imports` for broad imports: either `Mathlib.Tactic` or any import
 starting with `Lake`. -/
-def broadImportsCheck (imports : Array Syntax)  : Array (Syntax × String) := Id.run do
+def broadImportsCheck (imports : Array Syntax) (mainModule : Name) : Array (Syntax × String) := Id.run do
   let mut output := #[]
   for i in imports do
     match i.getId with
     | `Mathlib.Tactic =>
       output := output.push (i, s!"Files in mathlib cannot import the whole tactic folder.")
+    | `Mathlib.Tactic.Replace => output := output.push (i,
+      s!"Mathlib.Tactic.Replace defines a deprecated form of the 'replace' tactic; \
+      please do not use it in mathlib.")
+    | `Mathlib.Tactic.Have =>
+      if mainModule != `Mathlib.Tactic.Replace then
+        output := output.push (i,
+          s!"Mathlib.Tactic.Have defines a deprecated form of the 'have' tactic; \
+          please do not use it in mathlib.")
     | modName =>
       if modName.getRoot == `Lake then
       output := output.push (i,
         s!"In the past, importing 'Lake' in mathlib has led to dramatic slow-downs of the linter \
           (see e.g. mathlib4#13779). Please consider carefully if this import is useful and \
           make sure to benchmark it. If this is fine, feel free to allow this linter.")
+      else if (`Mathlib.Deprecated).isPrefixOf modName &&
+          !(`Mathlib.Deprecated).isPrefixOf mainModule then
+        -- We do not complain about files in the `Deprecated` directory importing one another.
+        output := output.push (i, s!"Files in the `Deprecated` directory are not supposed to be imported.")
+
   return output
 
 /--
@@ -277,7 +290,7 @@ def headerLinter : Linter where run := withSetOptionIn fun stx ↦ do
     parseUpToHere (stx.getTailPos?.getD default) "\nsection")
   let importIds := getImportIds upToStx
   -- Report on broad imports.
-  for (imp, msg) in broadImportsCheck importIds do
+  for (imp, msg) in broadImportsCheck importIds mainModule do
     Linter.logLint linter.style.header imp msg
   let afterImports := firstNonImport? upToStx
   if afterImports.isNone then return

--- a/Mathlib/Tactic/Linter/Header.lean
+++ b/Mathlib/Tactic/Linter/Header.lean
@@ -213,7 +213,8 @@ def broadImportsCheck (imports : Array Syntax) (mainModule : Name) : Array (Synt
     match i.getId with
     | `Mathlib.Tactic =>
       output := output.push (i, s!"Files in mathlib cannot import the whole tactic folder.")
-    | `Mathlib.Tactic.Replace => output := output.push (i,
+    | `Mathlib.Tactic.Replace =>
+      if mainModule != `Mathlib.Tactic then output := output.push (i,
       s!"Mathlib.Tactic.Replace defines a deprecated form of the 'replace' tactic; \
       please do not use it in mathlib.")
     | `Mathlib.Tactic.Have =>

--- a/test/Header.lean
+++ b/test/Header.lean
@@ -7,12 +7,20 @@ Authors: Damiano Testa
 import Mathlib.Tactic.Linter.Header
 import Lake
 import /- -/ Mathlib.Tactic -- the `TextBased` linter does not flag this `broadImport`
+import Mathlib.Tactic.Have
+import Mathlib.Deprecated.Subfield
 
 /--
 warning: In the past, importing 'Lake' in mathlib has led to dramatic slow-downs of the linter (see e.g. mathlib4#13779). Please consider carefully if this import is useful and make sure to benchmark it. If this is fine, feel free to allow this linter.
 note: this linter can be disabled with `set_option linter.style.header false`
 ---
 warning: Files in mathlib cannot import the whole tactic folder.
+note: this linter can be disabled with `set_option linter.style.header false`
+---
+warning: Mathlib.Tactic.Have defines a deprecated form of the 'have' tactic; please do not use it in mathlib.
+note: this linter can be disabled with `set_option linter.style.header false`
+---
+warning: Files in the `Deprecated` directory are not supposed to be imported.
 note: this linter can be disabled with `set_option linter.style.header false`
 ---
 warning: The module doc-string for a file should be the first command after the imports.


### PR DESCRIPTION
Also lint on importing `Tactic.{Have,Replace}` or any file in the `Deprecated` directory.
Both of these are not supposed to be imported; this linter enforces it.

---

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
