### PR TITLE
[Merged by Bors] - chore (test/Lint): remove `#align` test

### DIFF
--- a/test/Lint.lean
+++ b/test/Lint.lean
@@ -57,14 +57,3 @@ set_option linter.dupNamespace true in
 export Nat (add)
 
 end add
-
-theorem toAlign : True := .intro
-
-/--
-warning: This `#align` spans 2 lines, instead of just one.
-Do not worry, the 100 character limit does not apply to `#align` statements!
-note: this linter can be disabled with `set_option linter.oneLineAlign false`
--/
-#guard_msgs in
-#align to_align
-  toAlign


### PR DESCRIPTION
This breaks testing for #14887 but can't be automated with `sed` so we remove it manually.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
