### PR TITLE
[Merged by Bors] - chore: remove `#align`-oriented linters

### DIFF
--- a/Mathlib/Tactic/Linter/HashCommandLinter.lean
+++ b/Mathlib/Tactic/Linter/HashCommandLinter.lean
@@ -56,8 +56,7 @@ private partial def withSetOptionIn' (cmd : CommandElab) : CommandElab := fun st
     cmd stx
 
 /-- `allowed_commands` is the `HashSet` of `#`-commands that are allowed in 'Mathlib'. -/
-private abbrev allowed_commands : HashSet String :=
-  { "#align", "#align_import", "#noalign", "#adaptation_note" }
+private abbrev allowed_commands : HashSet String := { "#adaptation_note" }
 
 /-- Checks that no command beginning with `#` is present in 'Mathlib',
 except for the ones in `allowed_commands`.

--- a/Mathlib/Tactic/Linter/Lint.lean
+++ b/Mathlib/Tactic/Linter/Lint.lean
@@ -111,45 +111,6 @@ initialize addLinter dupNamespace
 end DupNamespaceLinter
 
 /-!
-#  `oneLineAlign` linter
-
-The `oneLineAlign` linter checks that `#align` statements span a single line,
-which is desirable as it allows them to be parsed by very simple parsers.
--/
-
-/--
-The `oneLineAlign` linter is set on by default.  Lean emits a warning on `#align` statements
-spanning more than one line.
--/
-register_option linter.oneLineAlign : Bool := {
-  defValue := true
-  descr := "enable the one-line align linter"
-}
-
-namespace OneLineAlignLinter
-
-open Lean
-
-/-- Gets the value of the `linter.oneLineAlign` option. -/
-def getLinterOneLineAlign (o : Options) : Bool := Linter.getLinterValue linter.oneLineAlign o
-
-@[inherit_doc linter.oneLineAlign]
-def oneLineAlign : Linter where run := withSetOptionIn fun stx => do
-  if getLinterOneLineAlign (← getOptions) then
-    if stx.isOfKind `Mathlib.Prelude.Rename.align then
-      if let some spos := stx.getRange? then
-        let fm ← getFileMap
-        let lines := (fm.toPosition spos.stop).line - (fm.toPosition spos.start).line + 1
-        if lines != 1 then
-          Linter.logLint linter.oneLineAlign stx
-            m!"This `#align` spans {lines} lines, instead of just one.\n\
-              Do not worry, the 100 character limit does not apply to `#align` statements!"
-
-initialize addLinter oneLineAlign
-
-end OneLineAlignLinter
-
-/-!
 # The "missing end" linter
 
 The "missing end" linter emits a warning on non-closed `section`s and `namespace`s.

--- a/test/HashCommandLinter.lean
+++ b/test/HashCommandLinter.lean
@@ -4,8 +4,6 @@ import Mathlib.Tactic.AdaptationNote
 import Mathlib.Tactic.Linter.HashCommandLinter
 
 section ignored_commands
-theorem fo₁ : True := .intro
--- `#align` is allowed by the linter
 
 -- `#guard_msgs in` without a doc-string triggers the linter, but with the `doc-string does not
 /--


### PR DESCRIPTION
Now that `#align`s have been removed, these linters and exceptions are obsolete.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
