### PR TITLE
[Merged by Bors] - chore: remove `import Mathlib.Mathport.Rename`

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -3040,7 +3040,6 @@ import Mathlib.Logic.Unique
 import Mathlib.Logic.UnivLE
 import Mathlib.Mathport.Attributes
 import Mathlib.Mathport.Notation
-import Mathlib.Mathport.Rename
 import Mathlib.Mathport.Syntax
 import Mathlib.MeasureTheory.Category.MeasCat
 import Mathlib.MeasureTheory.Constructions.BorelSpace.Basic

--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -3040,6 +3040,7 @@ import Mathlib.Logic.Unique
 import Mathlib.Logic.UnivLE
 import Mathlib.Mathport.Attributes
 import Mathlib.Mathport.Notation
+import Mathlib.Mathport.Rename
 import Mathlib.Mathport.Syntax
 import Mathlib.MeasureTheory.Category.MeasCat
 import Mathlib.MeasureTheory.Constructions.BorelSpace.Basic

--- a/Mathlib/Algebra/Group/ZeroOne.lean
+++ b/Mathlib/Algebra/Group/ZeroOne.lean
@@ -4,7 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Gabriel Ebner, Mario Carneiro
 -/
 import Mathlib.Tactic.ToAdditive
-import Mathlib.Mathport.Rename
 
 /-!
 ## Classes for `Zero` and `One`

--- a/Mathlib/Algebra/HierarchyDesign.lean
+++ b/Mathlib/Algebra/HierarchyDesign.lean
@@ -4,7 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Scott Morrison, Eric Wieser
 -/
 import Batteries.Util.LibraryNote
-import Mathlib.Mathport.Rename
 
 /-!
 # Documentation of the algebraic hierarchy

--- a/Mathlib/Algebra/Quotient.lean
+++ b/Mathlib/Algebra/Quotient.lean
@@ -3,7 +3,6 @@ Copyright (c) 2021 Anne Baanen. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Anne Baanen
 -/
-import Mathlib.Mathport.Rename
 import Mathlib.Tactic.Common
 
 /-!

--- a/Mathlib/CategoryTheory/ConcreteCategory/Bundled.lean
+++ b/Mathlib/CategoryTheory/ConcreteCategory/Bundled.lean
@@ -4,7 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Scott Morrison, Johannes Hölzl, Reid Barton, Sean Leather
 -/
 import Batteries.Tactic.Lint.Misc
-import Mathlib.Mathport.Rename
 
 /-!
 # Bundled types

--- a/Mathlib/Control/Combinators.lean
+++ b/Mathlib/Control/Combinators.lean
@@ -3,7 +3,6 @@ Copyright (c) 2016 Microsoft Corporation. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Jeremy Avigad, Leonardo de Moura
 -/
-import Mathlib.Mathport.Rename
 
 /-!
 # Monad combinators, as in Haskell's Control.Monad.

--- a/Mathlib/Control/Lawful.lean
+++ b/Mathlib/Control/Lawful.lean
@@ -4,7 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Sebastian Ullrich
 -/
 
-import Mathlib.Mathport.Rename
 import Mathlib.Tactic.Basic
 
 /-!

--- a/Mathlib/Control/ULift.lean
+++ b/Mathlib/Control/ULift.lean
@@ -3,7 +3,6 @@ Copyright (c) 2018 Scott Morrison. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Scott Morrison, Jannis Limperg
 -/
-import Mathlib.Mathport.Rename
 
 /-!
 # Monadic instances for `ULift` and `PLift`

--- a/Mathlib/Data/Bracket.lean
+++ b/Mathlib/Data/Bracket.lean
@@ -3,7 +3,6 @@ Copyright (c) 2021 Patrick Lutz. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Patrick Lutz, Oliver Nash
 -/
-import Mathlib.Mathport.Rename
 import Mathlib.Tactic.TypeStar
 
 /-!

--- a/Mathlib/Data/DList/Defs.lean
+++ b/Mathlib/Data/DList/Defs.lean
@@ -4,7 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Leonardo de Moura
 -/
 import Batteries.Data.DList
-import Mathlib.Mathport.Rename
 import Mathlib.Tactic.Cases
 
 /-!

--- a/Mathlib/Data/Fin/Fin2.lean
+++ b/Mathlib/Data/Fin/Fin2.lean
@@ -4,7 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Mario Carneiro
 -/
 import Mathlib.Data.Nat.Notation
-import Mathlib.Mathport.Rename
 import Mathlib.Data.Fintype.Basic
 import Mathlib.Logic.Function.Basic
 

--- a/Mathlib/Data/HashMap.lean
+++ b/Mathlib/Data/HashMap.lean
@@ -9,7 +9,6 @@ The porting header is just here to mark that no further work on `data.hash_map` 
 -/
 import Batteries.Data.HashMap.Basic
 import Batteries.Data.RBMap.Basic
-import Mathlib.Mathport.Rename
 
 /-!
 # Additional API for `HashMap` and `RBSet`.

--- a/Mathlib/Data/Int/Align.lean
+++ b/Mathlib/Data/Int/Align.lean
@@ -3,7 +3,6 @@ Copyright (c) 2016 Jeremy Avigad. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Jeremy Avigad
 -/
-import Mathlib.Mathport.Rename
 
 /-!
 # Align statements for results about the integers

--- a/Mathlib/Data/List/TFAE.lean
+++ b/Mathlib/Data/List/TFAE.lean
@@ -6,7 +6,6 @@ Authors: Johan Commelin, Simon Hudon
 import Batteries.Data.List.Lemmas
 import Batteries.Tactic.Classical
 import Mathlib.Tactic.TypeStar
-import Mathlib.Mathport.Rename
 
 /-!
 # The Following Are Equivalent

--- a/Mathlib/Data/MLList/DepthFirst.lean
+++ b/Mathlib/Data/MLList/DepthFirst.lean
@@ -3,6 +3,7 @@ Copyright (c) 2023 Scott Morrison. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Scott Morrison
 -/
+import Lean.Data.HashSet
 import Batteries.Data.MLList.Basic
 import Mathlib.Control.Combinators
 

--- a/Mathlib/Data/Num/Basic.lean
+++ b/Mathlib/Data/Num/Basic.lean
@@ -4,7 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Leonardo de Moura, Mario Carneiro
 -/
 import Lean.Linter.Deprecated
-import Mathlib.Mathport.Rename
 import Mathlib.Data.Int.Notation
 import Mathlib.Algebra.Group.ZeroOne
 import Mathlib.Data.Nat.Bits

--- a/Mathlib/Data/Option/Defs.lean
+++ b/Mathlib/Data/Option/Defs.lean
@@ -3,7 +3,6 @@ Copyright (c) 2018 Mario Carneiro. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Mario Carneiro
 -/
-import Mathlib.Mathport.Rename
 import Mathlib.Tactic.Lemma
 import Mathlib.Tactic.TypeStar
 

--- a/Mathlib/Data/Rat/Init.lean
+++ b/Mathlib/Data/Rat/Init.lean
@@ -4,7 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johannes Hölzl, Mario Carneiro, Yaël Dillies
 -/
 import Mathlib.Data.Nat.Notation
-import Mathlib.Mathport.Rename
 import Mathlib.Tactic.Lemma
 import Mathlib.Tactic.ProjectionNotation
 import Mathlib.Tactic.TypeStar

--- a/Mathlib/Data/Rbmap/Basic.lean
+++ b/Mathlib/Data/Rbmap/Basic.lean
@@ -3,7 +3,6 @@ Copyright (c) 2017 Microsoft Corporation. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Leonardo de Moura
 -/
-import Mathlib.Mathport.Rename
 
 /-!
 # Porting note: essentially already ported to std4

--- a/Mathlib/Data/Rbmap/Default.lean
+++ b/Mathlib/Data/Rbmap/Default.lean
@@ -3,7 +3,6 @@ Copyright (c) 2017 Microsoft Corporation. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Leonardo de Moura
 -/
-import Mathlib.Mathport.Rename
 
 /-!
 # Porting note: essentially already ported to std4

--- a/Mathlib/Data/Rbtree/Basic.lean
+++ b/Mathlib/Data/Rbtree/Basic.lean
@@ -3,7 +3,6 @@ Copyright (c) 2017 Microsoft Corporation. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Leonardo de Moura
 -/
-import Mathlib.Mathport.Rename
 
 /-!
 # Porting note: essentially already ported to std4

--- a/Mathlib/Data/Rbtree/DefaultLt.lean
+++ b/Mathlib/Data/Rbtree/DefaultLt.lean
@@ -3,7 +3,6 @@ Copyright (c) 2017 Microsoft Corporation. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Leonardo de Moura
 -/
-import Mathlib.Mathport.Rename
 
 /-!
 # Porting note: essentially already ported to std4

--- a/Mathlib/Data/Rbtree/Find.lean
+++ b/Mathlib/Data/Rbtree/Find.lean
@@ -3,7 +3,6 @@ Copyright (c) 2017 Microsoft Corporation. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Leonardo de Moura
 -/
-import Mathlib.Mathport.Rename
 
 /-!
 # Porting note: essentially already ported to std4

--- a/Mathlib/Data/Rbtree/Insert.lean
+++ b/Mathlib/Data/Rbtree/Insert.lean
@@ -3,7 +3,6 @@ Copyright (c) 2017 Microsoft Corporation. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Leonardo de Moura
 -/
-import Mathlib.Mathport.Rename
 
 /-!
 # Porting note: essentially already ported to std4

--- a/Mathlib/Data/Rbtree/Main.lean
+++ b/Mathlib/Data/Rbtree/Main.lean
@@ -3,7 +3,6 @@ Copyright (c) 2017 Microsoft Corporation. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Leonardo de Moura
 -/
-import Mathlib.Mathport.Rename
 
 /-!
 # Porting note: essentially already ported to std4

--- a/Mathlib/Data/Rbtree/MinMax.lean
+++ b/Mathlib/Data/Rbtree/MinMax.lean
@@ -3,7 +3,6 @@ Copyright (c) 2017 Microsoft Corporation. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Leonardo de Moura
 -/
-import Mathlib.Mathport.Rename
 
 /-!
 # Porting note: essentially already ported to std4

--- a/Mathlib/Data/Stream/Defs.lean
+++ b/Mathlib/Data/Stream/Defs.lean
@@ -3,7 +3,6 @@ Copyright (c) 2015 Microsoft Corporation. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Leonardo de Moura
 -/
-import Mathlib.Mathport.Rename
 import Mathlib.Data.Nat.Notation
 
 /-!

--- a/Mathlib/Data/String/Defs.lean
+++ b/Mathlib/Data/String/Defs.lean
@@ -5,7 +5,6 @@ Authors: Simon Hudon, Keeley Hoek, Floris van Doorn, Chris Bailey
 -/
 import Batteries.Data.List.Basic
 import Batteries.Data.String.Basic
-import Mathlib.Mathport.Rename
 
 /-!
 # Definitions for `String`

--- a/Mathlib/Data/Tree/Basic.lean
+++ b/Mathlib/Data/Tree/Basic.lean
@@ -5,7 +5,6 @@ Authors: Mario Carneiro, Wojciech Nawrocki
 -/
 import Batteries.Data.RBMap.Basic
 import Mathlib.Data.Nat.Notation
-import Mathlib.Mathport.Rename
 import Mathlib.Tactic.TypeStar
 import Mathlib.Util.CompileInductive
 

--- a/Mathlib/Init/Classes/Order.lean
+++ b/Mathlib/Init/Classes/Order.lean
@@ -5,7 +5,6 @@ Authors: Johan Commelin
 -/
 
 import Batteries.Classes.Order
-import Mathlib.Mathport.Rename
 
 /-!
 # Note about `Mathlib/Init/`

--- a/Mathlib/Init/Classical.lean
+++ b/Mathlib/Init/Classical.lean
@@ -4,7 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Leonardo de Moura, Jeremy Avigad, Mario Carneiro
 -/
 import Mathlib.Tactic.IrreducibleDef
-import Mathlib.Mathport.Rename
 
 /-!
 # Note about `Mathlib/Init/`

--- a/Mathlib/Init/Core.lean
+++ b/Mathlib/Init/Core.lean
@@ -3,7 +3,6 @@ Copyright (c) 2014 Microsoft Corporation. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Leonardo de Moura, Mario Carneiro
 -/
-import Mathlib.Mathport.Rename
 import Mathlib.Tactic.Relation.Trans
 
 /-!

--- a/Mathlib/Init/Data/Int/DivMod.lean
+++ b/Mathlib/Init/Data/Int/DivMod.lean
@@ -4,7 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johan Commelin
 -/
 
-import Mathlib.Mathport.Rename
 
 /-!
 # Note about `Mathlib/Init/`

--- a/Mathlib/Init/Data/Int/Lemmas.lean
+++ b/Mathlib/Init/Data/Int/Lemmas.lean
@@ -3,7 +3,6 @@ Copyright (c) 2023 Johan Commelin. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johan Commelin
 -/
-import Mathlib.Mathport.Rename
 
 /-!
 # Note about `Mathlib/Init/`

--- a/Mathlib/Init/Data/List/Basic.lean
+++ b/Mathlib/Init/Data/List/Basic.lean
@@ -3,7 +3,6 @@ Copyright (c) 2016 Microsoft Corporation. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Leonardo de Moura
 -/
-import Mathlib.Mathport.Rename
 import Mathlib.Data.Nat.Notation
 import Batteries.Data.List.Basic
 

--- a/Mathlib/Init/Data/List/Instances.lean
+++ b/Mathlib/Init/Data/List/Instances.lean
@@ -3,7 +3,6 @@ Copyright (c) 2016 Microsoft Corporation. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Leonardo de Moura
 -/
-import Mathlib.Mathport.Rename
 
 /-!
 # Note about `Mathlib/Init/`

--- a/Mathlib/Init/Data/List/Lemmas.lean
+++ b/Mathlib/Init/Data/List/Lemmas.lean
@@ -4,7 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Parikshit Khanna, Jeremy Avigad, Leonardo de Moura, Floris van Doorn
 -/
 import Batteries.Data.List.Lemmas
-import Mathlib.Mathport.Rename
 import Mathlib.Tactic.Cases
 
 /-!

--- a/Mathlib/Init/Data/Nat/Basic.lean
+++ b/Mathlib/Init/Data/Nat/Basic.lean
@@ -3,7 +3,6 @@ Copyright (c) 2014 Microsoft Corporation. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Floris van Doorn, Leonardo de Moura
 -/
-import Mathlib.Mathport.Rename
 
 /-!
 # Note about `Mathlib/Init/`

--- a/Mathlib/Init/Data/Nat/Div.lean
+++ b/Mathlib/Init/Data/Nat/Div.lean
@@ -5,7 +5,6 @@ Authors: Johan Commelin
 -/
 
 import Init.Data.Nat.Div
-import Mathlib.Mathport.Rename
 
 /-!
 # Note about `Mathlib/Init/`

--- a/Mathlib/Init/Data/Nat/GCD.lean
+++ b/Mathlib/Init/Data/Nat/GCD.lean
@@ -7,7 +7,6 @@ Authors: Jeremy Avigad, Leonardo de Moura, Mario Carneiro
 
 import Batteries.Data.Nat.Gcd
 import Mathlib.Data.Nat.Notation
-import Mathlib.Mathport.Rename
 
 /-!
 # Note about `Mathlib/Init/`

--- a/Mathlib/Init/Data/Nat/Lemmas.lean
+++ b/Mathlib/Init/Data/Nat/Lemmas.lean
@@ -6,7 +6,6 @@ Authors: Leonardo de Moura, Jeremy Avigad
 import Batteries.Data.Nat.Lemmas
 import Batteries.WF
 import Mathlib.Util.AssertExists
-import Mathlib.Mathport.Rename
 import Mathlib.Data.Nat.Notation
 
 /-!

--- a/Mathlib/Init/Data/Option/Basic.lean
+++ b/Mathlib/Init/Data/Option/Basic.lean
@@ -4,7 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johan Commelin
 -/
 
-import Mathlib.Mathport.Rename
 
 /-!
 # Note about `Mathlib/Init/`

--- a/Mathlib/Init/Data/Option/Init/Lemmas.lean
+++ b/Mathlib/Init/Data/Option/Init/Lemmas.lean
@@ -4,7 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johan Commelin
 -/
 
-import Mathlib.Mathport.Rename
 
 /-!
 # Note about `Mathlib/Init/`

--- a/Mathlib/Init/Data/Option/Lemmas.lean
+++ b/Mathlib/Init/Data/Option/Lemmas.lean
@@ -5,7 +5,6 @@ Authors: Johan Commelin
 -/
 
 import Batteries.Data.Option.Lemmas
-import Mathlib.Mathport.Rename
 
 /-!
 # Note about `Mathlib/Init/`

--- a/Mathlib/Init/Data/Ordering/Basic.lean
+++ b/Mathlib/Init/Data/Ordering/Basic.lean
@@ -4,7 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Leonardo de Moura
 -/
 
-import Mathlib.Mathport.Rename
 
 /-!
 # Note about `Mathlib/Init/`

--- a/Mathlib/Init/Data/Quot.lean
+++ b/Mathlib/Init/Data/Quot.lean
@@ -3,7 +3,6 @@ Copyright (c) 2015 Microsoft Corporation. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Leonardo de Moura
 -/
-import Mathlib.Mathport.Rename
 
 /-!
 # Note about `Mathlib/Init/`

--- a/Mathlib/Init/Data/Rat/Basic.lean
+++ b/Mathlib/Init/Data/Rat/Basic.lean
@@ -5,7 +5,6 @@ Authors: Johan Commelin
 -/
 
 import Batteries.Data.Rat.Lemmas
-import Mathlib.Mathport.Rename
 
 /-!
 # Note about `Mathlib/Init/`

--- a/Mathlib/Init/Data/Sigma/Lex.lean
+++ b/Mathlib/Init/Data/Sigma/Lex.lean
@@ -3,7 +3,6 @@ Copyright (c) 2016 Microsoft Corporation. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Leonardo de Moura
 -/
-import Mathlib.Mathport.Rename
 
 /-!
 # Note about `Mathlib/Init/`

--- a/Mathlib/Init/Logic.lean
+++ b/Mathlib/Init/Logic.lean
@@ -5,7 +5,6 @@ Authors: Leonardo de Moura, Jeremy Avigad, Floris van Doorn
 -/
 import Mathlib.Tactic.Lemma
 import Mathlib.Mathport.Attributes
-import Mathlib.Mathport.Rename
 import Mathlib.Tactic.Relation.Trans
 import Mathlib.Tactic.ProjectionNotation
 import Batteries.Tactic.Alias

--- a/Mathlib/Init/Meta/WellFoundedTactics.lean
+++ b/Mathlib/Init/Meta/WellFoundedTactics.lean
@@ -3,7 +3,6 @@ Copyright (c) 2017 Microsoft Corporation. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Leonardo de Moura
 -/
-import Mathlib.Mathport.Rename
 
 /-!
 # Note about `Mathlib/Init/`

--- a/Mathlib/Init/Order/Defs.lean
+++ b/Mathlib/Init/Order/Defs.lean
@@ -3,7 +3,6 @@ Copyright (c) 2016 Microsoft Corporation. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Leonardo de Moura
 -/
-import Mathlib.Mathport.Rename
 import Mathlib.Init.Algebra.Classes
 import Mathlib.Init.Data.Ordering.Basic
 import Mathlib.Tactic.SplitIfs

--- a/Mathlib/Init/Quot.lean
+++ b/Mathlib/Init/Quot.lean
@@ -3,7 +3,6 @@ Copyright (c) 2023 Microsoft Corporation. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johan Commelin
 -/
-import Mathlib.Mathport.Rename
 
 /-!
 # Note about `Mathlib/Init/`

--- a/Mathlib/Init/Set.lean
+++ b/Mathlib/Init/Set.lean
@@ -5,7 +5,6 @@ Authors: Leonardo de Moura
 -/
 import Lean.Parser.Term
 import Batteries.Util.ExtendedBinder
-import Mathlib.Mathport.Rename
 
 /-!
 # Note about `Mathlib/Init/`

--- a/Mathlib/Lean/Json.lean
+++ b/Mathlib/Lean/Json.lean
@@ -4,6 +4,8 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Eric Wieser
 -/
 
+import Lean.Data.Json.FromToJson
+
 /-!
 # Json serialization typeclass for `PUnit` & `Fin n` & `Subtype p`
 -/

--- a/Mathlib/Lean/Json.lean
+++ b/Mathlib/Lean/Json.lean
@@ -3,7 +3,6 @@ Copyright (c) 2022 Eric Wieser. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Eric Wieser
 -/
-import Mathlib.Mathport.Rename
 
 /-!
 # Json serialization typeclass for `PUnit` & `Fin n` & `Subtype p`

--- a/Mathlib/Lean/Thunk.lean
+++ b/Mathlib/Lean/Thunk.lean
@@ -3,7 +3,6 @@ Copyright (c) 2018 Simon Hudon. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Simon Hudon
 -/
-import Mathlib.Mathport.Rename
 import Batteries.Data.Thunk
 
 /-!

--- a/Mathlib/Logic/Function/Defs.lean
+++ b/Mathlib/Logic/Function/Defs.lean
@@ -3,7 +3,6 @@ Copyright (c) 2014 Microsoft Corporation. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Leonardo de Moura, Jeremy Avigad, Haitao Zhang
 -/
-import Mathlib.Mathport.Rename
 import Mathlib.Tactic.AdaptationNote
 import Mathlib.Tactic.Attr.Register
 import Mathlib.Tactic.Basic

--- a/Mathlib/Logic/Function/OfArity.lean
+++ b/Mathlib/Logic/Function/OfArity.lean
@@ -4,7 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Mario Carneiro
 -/
 
-import Mathlib.Mathport.Rename
 import Mathlib.Logic.Function.FromTypes
 
 /-! # Function types of a given arity

--- a/Mathlib/Order/Notation.lean
+++ b/Mathlib/Order/Notation.lean
@@ -5,7 +5,6 @@ Authors: Johannes Hölzl, Yury Kudryashov, Yaël Dillies
 -/
 import Mathlib.Tactic.Basic
 import Mathlib.Tactic.Simps.NotationClass
-import Mathlib.Mathport.Rename
 
 /-!
 # Notation classes for lattice operations

--- a/Mathlib/RepresentationTheory/Rep.lean
+++ b/Mathlib/RepresentationTheory/Rep.lean
@@ -424,7 +424,6 @@ def MonoidalClosed.linearHomEquiv : (A ⊗ B ⟶ C) ≃ₗ[k] B ⟶ A ⟶[Rep k 
   { (ihom.adjunction A).homEquiv _ _ with
     map_add' := fun _ _ => rfl
     map_smul' := fun _ _ => rfl }
-  set_option linter.uppercaseLean3 false in
 
 /-- There is a `k`-linear isomorphism between the sets of representation morphisms`Hom(A ⊗ B, C)`
 and `Hom(A, Homₖ(B, C))`. -/

--- a/Mathlib/Tactic/CC/Datatypes.lean
+++ b/Mathlib/Tactic/CC/Datatypes.lean
@@ -8,7 +8,6 @@ import Lean.Meta.Tactic.Rfl
 import Batteries.Data.HashMap.Basic
 import Batteries.Data.RBMap.Basic
 import Mathlib.Lean.Meta.Basic
-import Mathlib.Mathport.Rename
 
 /-!
 # Datatypes for `cc`

--- a/Mathlib/Tactic/Common.lean
+++ b/Mathlib/Tactic/Common.lean
@@ -20,7 +20,6 @@ import ProofWidgets
 import Mathlib.Tactic.Linter.Lint
 
 -- Now import all tactics defined in Mathlib that do not require theory files.
-import Mathlib.Mathport.Rename
 import Mathlib.Tactic.ApplyCongr
 -- ApplyFun imports `Mathlib.Order.Monotone.Basic`
 -- import Mathlib.Tactic.ApplyFun

--- a/Mathlib/Tactic/Hint.lean
+++ b/Mathlib/Tactic/Hint.lean
@@ -7,7 +7,6 @@ import Lean.Meta.Tactic.TryThis
 import Batteries.Linter.UnreachableTactic
 import Batteries.Control.Nondet.Basic
 import Mathlib.Tactic.FailIfNoProgress
-import Mathlib.Mathport.Rename
 
 /-!
 # The `hint` tactic.

--- a/Mathlib/Tactic/Lift.lean
+++ b/Mathlib/Tactic/Lift.lean
@@ -4,7 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Floris van Doorn
 -/
 import Mathlib.Tactic.Basic
-import Mathlib.Mathport.Rename
 import Batteries.Lean.Expr
 import Batteries.Lean.Meta.UnusedNames
 

--- a/Mathlib/Tactic/ToLevel.lean
+++ b/Mathlib/Tactic/ToLevel.lean
@@ -3,7 +3,6 @@ Copyright (c) 2023 Kyle Miller. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Kyle Miller
 -/
-import Mathlib.Mathport.Rename
 import Mathlib.Tactic.PPWithUniv
 
 /-! # `ToLevel` class

--- a/test/HashCommandLinter.lean
+++ b/test/HashCommandLinter.lean
@@ -1,5 +1,4 @@
 import Lean.Elab.GuardMsgs
-import Mathlib.Mathport.Rename
 import Mathlib.Tactic.AdaptationNote
 import Mathlib.Tactic.Linter.HashCommandLinter
 

--- a/test/search/DepthFirst.lean
+++ b/test/search/DepthFirst.lean
@@ -1,3 +1,4 @@
+import Lean.Meta.Basic
 import Mathlib.Data.MLList.DepthFirst
 
 /--


### PR DESCRIPTION
We remove all `import Mathlib.Mathport.Rename`.

This is done using

```bash
find . -name "*.lean" -exec sed -i '/^import Mathlib.Mathport.Rename/d' {} +
```

plus two fixing by hand of files that were missing various imports.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
