### PR TITLE
[Merged by Bors] - feat(GroupTheory/Index): finite quotient lemmas

### DIFF
--- a/Mathlib/GroupTheory/Index.lean
+++ b/Mathlib/GroupTheory/Index.lean
@@ -380,6 +380,20 @@ noncomputable def fintypeOfIndexNeZero (hH : H.index ≠ 0) : Fintype (G ⧸ H) 
 theorem one_lt_index_of_ne_top [Finite (G ⧸ H)] (hH : H ≠ ⊤) : 1 < H.index :=
   Nat.one_lt_iff_ne_zero_and_ne_one.mpr ⟨index_ne_zero_of_finite, mt index_eq_one.mp hH⟩
 
+@[to_additive]
+lemma finite_quotient_of_finite_quotient_of_index_ne_zero {X : Type*} [MulAction G X]
+    [Finite <| MulAction.orbitRel.Quotient G X] (hi : H.index ≠ 0) :
+    Finite <| MulAction.orbitRel.Quotient H X := by
+  have := fintypeOfIndexNeZero hi
+  exact MulAction.finite_quotient_of_finite_quotient_of_finite_quotient
+
+@[to_additive]
+lemma finite_quotient_of_pretransitive_of_index_ne_zero {X : Type*} [MulAction G X]
+    [MulAction.IsPretransitive G X] (hi : H.index ≠ 0) :
+    Finite <| MulAction.orbitRel.Quotient H X := by
+  have := (MulAction.pretransitive_iff_subsingleton_quotient G X).1 inferInstance
+  exact finite_quotient_of_finite_quotient_of_index_ne_zero hi
+
 section FiniteIndex
 
 variable (H K)


### PR DESCRIPTION
Add some lemmas about finiteness of `MulAction.orbitRel.Quotient` for actions by a subgroup of finite index.

From AperiodicMonotilesLean.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
