### PR TITLE
[Merged by Bors] - feat: generalize `spectrum.subset_subalgebra` to subalgebra classes

### DIFF
--- a/Mathlib/Algebra/Algebra/Spectrum.lean
+++ b/Mathlib/Algebra/Algebra/Spectrum.lean
@@ -263,14 +263,15 @@ local notation "σ" => spectrum R
 
 local notation "↑ₐ" => algebraMap R A
 
--- it would be nice to state this for `subalgebra_class`, but we don't have such a thing yet
-theorem subset_subalgebra {S : Subalgebra R A} (a : S) : spectrum R (a : A) ⊆ spectrum R a :=
-  compl_subset_compl.2 fun _ => IsUnit.map S.val
+theorem subset_subalgebra {S R A : Type*} [CommSemiring R] [Ring A] [Algebra R A]
+    [SetLike S A] [SubringClass S A] [SMulMemClass S R A] {s : S} (a : s) :
+    spectrum R (a : A) ⊆ spectrum R a :=
+  Set.compl_subset_compl.mpr fun _ ↦ IsUnit.map (SubalgebraClass.val s)
 
--- this is why it would be nice if `subset_subalgebra` was registered for `subalgebra_class`.
+@[deprecated subset_subalgebra (since := "2024-07-19")]
 theorem subset_starSubalgebra [StarRing R] [StarRing A] [StarModule R A] {S : StarSubalgebra R A}
     (a : S) : spectrum R (a : A) ⊆ spectrum R a :=
-  compl_subset_compl.2 fun _ => IsUnit.map S.subtype
+  subset_subalgebra a
 
 theorem singleton_add_eq (a : A) (r : R) : {r} + σ a = σ (↑ₐ r + a) :=
   ext fun x => by

--- a/Mathlib/Analysis/NormedSpace/Star/ContinuousFunctionalCalculus.lean
+++ b/Mathlib/Analysis/NormedSpace/Star/ContinuousFunctionalCalculus.lean
@@ -83,7 +83,7 @@ theorem spectrum_star_mul_self_of_isStarNormal :
   rcases subsingleton_or_nontrivial A with ⟨⟩
   · simp only [spectrum.of_subsingleton, Set.empty_subset]
   · set a' : elementalStarAlgebra ℂ a := ⟨a, self_mem ℂ a⟩
-    refine (spectrum.subset_starSubalgebra (star a' * a')).trans ?_
+    refine (spectrum.subset_subalgebra (star a' * a')).trans ?_
     rw [← spectrum.gelfandTransform_eq (star a' * a'), ContinuousMap.spectrum_eq_range]
     rintro - ⟨φ, rfl⟩
     rw [gelfandTransform_apply_apply ℂ _ (star a' * a') φ, map_mul φ, map_star φ]


### PR DESCRIPTION

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
