### PR TITLE
[Merged by Bors] - feat(MeasureTheory/../Action): drop measurability assumptions

### DIFF
--- a/Mathlib/MeasureTheory/Group/Action.lean
+++ b/Mathlib/MeasureTheory/Group/Action.lean
@@ -101,15 +101,26 @@ end AE_smul
 section AE
 
 variable {m : MeasurableSpace α} [MeasurableSpace G] [Group G] [MulAction G α]
-  {μ : Measure α} [SMulInvariantMeasure G α μ]
-
-@[to_additive]
-theorem measure_smul_null {s} (h : μ s = 0) (c : G) : μ (c • s) = 0 := by
-  simpa only [preimage_smul_inv] using measure_preimage_smul_null h c⁻¹
+  (μ : Measure α) [SMulInvariantMeasure G α μ]
 
 @[to_additive (attr := simp)]
-theorem measure_smul_eq_zero_iff {s} (c : G) : μ (c • s) = 0 ↔ μ s = 0 :=
-  ⟨fun h ↦ by simpa using measure_smul_null h c⁻¹, fun h ↦ measure_smul_null h c⟩
+theorem measure_preimage_smul (c : G) (s : Set α) : μ ((c • ·) ⁻¹' s) = μ s :=
+  (measure_preimage_smul_le μ c s).antisymm <| by
+    simpa [preimage_preimage] using measure_preimage_smul_le μ c⁻¹ ((c • ·) ⁻¹' s)
+
+@[to_additive (attr := simp)]
+theorem measure_smul (c : G) (s : Set α) : μ (c • s) = μ s := by
+  simpa only [preimage_smul_inv] using measure_preimage_smul μ c⁻¹ s
+
+variable {μ}
+
+@[to_additive]
+theorem measure_smul_eq_zero_iff {s} (c : G) : μ (c • s) = 0 ↔ μ s = 0 := by
+  rw [measure_smul]
+
+@[to_additive]
+theorem measure_smul_null {s} (h : μ s = 0) (c : G) : μ (c • s) = 0 :=
+  (measure_smul_eq_zero_iff _).2 h
 
 @[to_additive (attr := simp)]
 theorem smul_mem_ae (c : G) {s : Set α} : c • s ∈ ae μ ↔ s ∈ ae μ := by
@@ -127,17 +138,6 @@ theorem smul_set_ae_le (c : G) {s t : Set α} : c • s ≤ᵐ[μ] c • t ↔ s
 @[to_additive (attr := simp)]
 theorem smul_set_ae_eq (c : G) {s t : Set α} : c • s =ᵐ[μ] c • t ↔ s =ᵐ[μ] t := by
   simp only [Filter.eventuallyLE_antisymm_iff, smul_set_ae_le]
-
-variable (μ)
-
-@[to_additive (attr := simp)]
-theorem measure_preimage_smul (c : G) (s : Set α) : μ ((c • ·) ⁻¹' s) = μ s :=
-  (measure_preimage_smul_le μ c s).antisymm <| by
-    simpa [preimage_preimage] using measure_preimage_smul_le μ c⁻¹ ((c • ·) ⁻¹' s)
-
-@[to_additive (attr := simp)]
-theorem measure_smul (c : G) (s : Set α) : μ (c • s) = μ s := by
-  simpa only [preimage_smul_inv] using measure_preimage_smul μ c⁻¹ s
 
 end AE
 

--- a/Mathlib/MeasureTheory/Group/Action.lean
+++ b/Mathlib/MeasureTheory/Group/Action.lean
@@ -67,6 +67,37 @@ instance smul_nnreal [SMulInvariantMeasure M α μ] (c : ℝ≥0) : SMulInvarian
 
 end SMulInvariantMeasure
 
+section AE_smul
+
+variable {m : MeasurableSpace α} [MeasurableSpace G] [SMul G α]
+  (μ : Measure α) [SMulInvariantMeasure G α μ] {s : Set α}
+
+/-- See also `measure_preimage_smul_of_nullMeasurableSet` and `measure_preimage_smul`. -/
+@[to_additive "See also `measure_preimage_smul_of_nullMeasurableSet` and `measure_preimage_smul`."]
+theorem measure_preimage_smul_le (c : G) (s : Set α) : μ ((c • ·) ⁻¹' s) ≤ μ s :=
+  (outerMeasure_le_iff (m := .map (c • ·) μ.1)).2
+    (fun _s hs ↦ (SMulInvariantMeasure.measure_preimage_smul _ hs).le) _
+
+/-- See also `smul_ae`. -/
+@[to_additive "See also `vadd_ae`."]
+theorem tendsto_smul_ae (c : G) : Filter.Tendsto (c • ·) (ae μ) (ae μ) := fun _s hs ↦
+  eq_bot_mono (measure_preimage_smul_le μ c _) hs
+
+variable {μ}
+
+@[to_additive]
+theorem measure_preimage_smul_null (h : μ s = 0) (c : G) : μ ((c • ·) ⁻¹' s) = 0 :=
+  eq_bot_mono (measure_preimage_smul_le μ c _) h
+
+@[to_additive]
+theorem measure_preimage_smul_of_nullMeasurableSet (hs : NullMeasurableSet s μ) (c : G) :
+    μ ((c • ·) ⁻¹' s) = μ s := by
+  rw [← measure_toMeasurable s,
+    ← SMulInvariantMeasure.measure_preimage_smul c (measurableSet_toMeasurable μ s)]
+  exact measure_congr (tendsto_smul_ae μ c hs.toMeasurable_ae_eq) |>.symm
+
+end AE_smul
+
 section AE
 
 variable {m : MeasurableSpace α} [MeasurableSpace G] [Group G] [MulAction G α]
@@ -74,9 +105,7 @@ variable {m : MeasurableSpace α} [MeasurableSpace G] [Group G] [MulAction G α]
 
 @[to_additive]
 theorem measure_smul_null {s} (h : μ s = 0) (c : G) : μ (c • s) = 0 := by
-  rcases exists_measurable_superset_of_null h with ⟨t, hst, htm, ht⟩
-  rw [← SMulInvariantMeasure.measure_preimage_smul c⁻¹ htm, preimage_smul_inv] at ht
-  exact measure_mono_null (image_mono hst) ht
+  simpa only [preimage_smul_inv] using measure_preimage_smul_null h c⁻¹
 
 @[to_additive (attr := simp)]
 theorem measure_smul_eq_zero_iff {s} (c : G) : μ (c • s) = 0 ↔ μ s = 0 :=
@@ -98,6 +127,17 @@ theorem smul_set_ae_le (c : G) {s t : Set α} : c • s ≤ᵐ[μ] c • t ↔ s
 @[to_additive (attr := simp)]
 theorem smul_set_ae_eq (c : G) {s t : Set α} : c • s =ᵐ[μ] c • t ↔ s =ᵐ[μ] t := by
   simp only [Filter.eventuallyLE_antisymm_iff, smul_set_ae_le]
+
+variable (μ)
+
+@[to_additive (attr := simp)]
+theorem measure_preimage_smul (c : G) (s : Set α) : μ ((c • ·) ⁻¹' s) = μ s :=
+  (measure_preimage_smul_le μ c s).antisymm <| by
+    simpa [preimage_preimage] using measure_preimage_smul_le μ c⁻¹ ((c • ·) ⁻¹' s)
+
+@[to_additive (attr := simp)]
+theorem measure_smul (c : G) (s : Set α) : μ (c • s) = μ s := by
+  simpa only [preimage_smul_inv] using measure_preimage_smul μ c⁻¹ s
 
 end AE
 
@@ -218,14 +258,6 @@ add_decl_doc vaddInvariantMeasure_tfae
 
 variable {G}
 variable [SMulInvariantMeasure G α μ]
-
-@[to_additive (attr := simp)]
-theorem measure_preimage_smul (s : Set α) : μ ((c • ·) ⁻¹' s) = μ s :=
-  ((smulInvariantMeasure_tfae G μ).out 0 3 rfl rfl).mp ‹_› c s
-
-@[to_additive (attr := simp)]
-theorem measure_smul (s : Set α) : μ (c • s) = μ s :=
-  ((smulInvariantMeasure_tfae G μ).out 0 4 rfl rfl).mp ‹_› c s
 
 variable {μ}
 

--- a/Mathlib/MeasureTheory/Group/FundamentalDomain.lean
+++ b/Mathlib/MeasureTheory/Group/FundamentalDomain.lean
@@ -134,9 +134,8 @@ theorem iUnion_smul_ae_eq (h : IsFundamentalDomain G s μ) : ⋃ g : G, g • s 
     mem_iUnion.2 ⟨g⁻¹, _, hg, inv_smul_smul _ _⟩
 
 @[to_additive]
-theorem measure_ne_zero [MeasurableSpace G] [Countable G] [MeasurableSMul G α]
-    [SMulInvariantMeasure G α μ] (hμ : μ ≠ 0) (h : IsFundamentalDomain G s μ) :
-    μ s ≠ 0 := by
+theorem measure_ne_zero [Countable G] [SMulInvariantMeasure G α μ]
+    (hμ : μ ≠ 0) (h : IsFundamentalDomain G s μ) : μ s ≠ 0 := by
   have hc := measure_univ_pos.mpr hμ
   contrapose! hc
   rw [← measure_congr h.iUnion_smul_ae_eq]

--- a/Mathlib/MeasureTheory/Measure/Haar/Quotient.lean
+++ b/Mathlib/MeasureTheory/Measure/Haar/Quotient.lean
@@ -131,7 +131,7 @@ lemma MeasureTheory.QuotientMeasureEqMeasurePreimage.mulInvariantMeasure_quotien
   map_mul_left_eq_self x := by
     ext A hA
     obtain ⟨x₁, h⟩ := @Quotient.exists_rep _ (QuotientGroup.leftRel Γ) x
-    convert measure_preimage_smul x₁ μ A using 1
+    convert measure_preimage_smul μ x₁ A using 1
     · rw [← h, Measure.map_apply (measurable_const_mul _) hA]
       simp [← MulAction.Quotient.coe_smul_out', ← Quotient.mk''_eq_mk]
     exact smulInvariantMeasure_quotient ν


### PR DESCRIPTION
Also reorder arguments of `measure_preimage_smul` and `measure_smul`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)