### PR TITLE
[Merged by Bors] - feat(CategoryTheory/Limits): identification of the point of any limit pullback cone in Type

### DIFF
--- a/Mathlib/CategoryTheory/Limits/Shapes/Types.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/Types.lean
@@ -670,12 +670,6 @@ open CategoryTheory.Limits.WalkingCospan
 variable {W X Y Z : Type u}
 variable (f : X ⟶ Z) (g : Y ⟶ Z)
 
---/-- The pullback cone given by the instance `HasPullbacks (Type u)` is isomorphic to the
---explicit pullback cone given by `pullbackLimitCone`.
----/
---noncomputable def pullbackConeIsoPullback : limit.cone (cospan f g) ≅ pullbackCone f g :=
---  (limit.isLimit _).uniqueUpToIso (pullbackLimitCone f g).isLimit
-
 /-- The pullback given by the instance `HasPullbacks (Type u)` is isomorphic to the
 explicit pullback object given by `PullbackObj`.
 -/

--- a/Mathlib/CategoryTheory/Limits/Shapes/Types.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/Types.lean
@@ -663,7 +663,7 @@ end Pullback
 
 namespace Types
 
-namespace Pullback
+section Pullback
 
 open CategoryTheory.Limits.WalkingCospan
 

--- a/Mathlib/CategoryTheory/Limits/Shapes/Types.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/Types.lean
@@ -574,12 +574,6 @@ end Cofork
 
 section Pullback
 
-open CategoryTheory.Limits.WalkingPair
-
-open CategoryTheory.Limits.WalkingCospan
-
-open CategoryTheory.Limits.WalkingCospan.Hom
-
 -- #synth HasPullbacks.{u} (Type u)
 instance : HasPullbacks.{u} (Type u) :=
   -- FIXME does not work via `inferInstance` despite `#synth HasPullbacks.{u} (Type u)` succeeding.
@@ -590,7 +584,7 @@ instance : HasPullbacks.{u} (Type u) :=
 instance : HasPushouts.{u} (Type u) :=
   hasPushouts_of_hasWidePushouts.{u} (Type u)
 
-variable {W X Y Z : Type u}
+variable {X Y Z : Type u}
 variable (f : X ⟶ Z) (g : Y ⟶ Z)
 
 -- porting note (#5171): removed @[nolint has_nonempty_instance]
@@ -623,47 +617,98 @@ def pullbackLimitCone (f : X ⟶ Z) (g : Y ⟶ Z) : Limits.LimitCone (cospan f g
         Subtype.ext <|
           Prod.ext (congr_fun (w WalkingCospan.left) x) (congr_fun (w WalkingCospan.right) x)
 
-/-- The pullback cone given by the instance `HasPullbacks (Type u)` is isomorphic to the
-explicit pullback cone given by `pullbackLimitCone`.
--/
-noncomputable def pullbackConeIsoPullback : limit.cone (cospan f g) ≅ pullbackCone f g :=
-  (limit.isLimit _).uniqueUpToIso (pullbackLimitCone f g).isLimit
+end Pullback
+
+end Types
+
+section Pullback
+
+variable {X Y S : Type v} {f : X ⟶ S} {g : Y ⟶ S} {c : PullbackCone f g}
+  (hc : IsLimit c)
+
+namespace PullbackCone.IsLimit
+
+/-- A limit pullback cone in the category of types identifies to the explicit pullback. -/
+noncomputable def equivPullbackObj : c.pt ≃ Types.PullbackObj f g :=
+  (IsLimit.conePointUniqueUpToIso hc (Types.pullbackLimitCone f g).isLimit).toEquiv
+
+@[simp]
+lemma equivPullbackObj_apply_fst (x : c.pt) : (equivPullbackObj hc x).1.1 = c.fst x :=
+  congr_fun (IsLimit.conePointUniqueUpToIso_hom_comp hc
+    (Types.pullbackLimitCone f g).isLimit .left) x
+
+@[simp]
+lemma equivPullbackObj_apply_snd (x : c.pt) : (equivPullbackObj hc x).1.2 = c.snd x :=
+  congr_fun (IsLimit.conePointUniqueUpToIso_hom_comp hc
+    (Types.pullbackLimitCone f g).isLimit .right) x
+
+@[simp]
+lemma equivPullbackObj_symm_apply_fst (x : Types.PullbackObj f g) :
+    c.fst ((equivPullbackObj hc).symm x) = x.1.1 := by
+  obtain ⟨x, rfl⟩ := (equivPullbackObj hc).surjective x
+  simp
+
+@[simp]
+lemma equivPullbackObj_symm_apply_snd (x : Types.PullbackObj f g) :
+    c.snd ((equivPullbackObj hc).symm x) = x.1.2 := by
+  obtain ⟨x, rfl⟩ := (equivPullbackObj hc).surjective x
+  simp
+
+lemma type_ext {x y : c.pt} (h₁ : c.fst x = c.fst y) (h₂ : c.snd x = c.snd y) : x = y :=
+  (equivPullbackObj hc).injective (by ext <;> assumption)
+
+end PullbackCone.IsLimit
+
+end Pullback
+
+namespace Types
+
+namespace Pullback
+
+open CategoryTheory.Limits.WalkingCospan
+
+variable {W X Y Z : Type u}
+variable (f : X ⟶ Z) (g : Y ⟶ Z)
+
+--/-- The pullback cone given by the instance `HasPullbacks (Type u)` is isomorphic to the
+--explicit pullback cone given by `pullbackLimitCone`.
+---/
+--noncomputable def pullbackConeIsoPullback : limit.cone (cospan f g) ≅ pullbackCone f g :=
+--  (limit.isLimit _).uniqueUpToIso (pullbackLimitCone f g).isLimit
 
 /-- The pullback given by the instance `HasPullbacks (Type u)` is isomorphic to the
 explicit pullback object given by `PullbackObj`.
 -/
 noncomputable def pullbackIsoPullback : pullback f g ≅ PullbackObj f g :=
-  (Cones.forget _).mapIso <| pullbackConeIsoPullback f g
+  (PullbackCone.IsLimit.equivPullbackObj (pullbackIsPullback f g)).toIso
 
 @[simp]
 theorem pullbackIsoPullback_hom_fst (p : pullback f g) :
     ((pullbackIsoPullback f g).hom p : X × Y).fst = (pullback.fst f g) p :=
-  congr_fun ((pullbackConeIsoPullback f g).hom.w left) p
+  PullbackCone.IsLimit.equivPullbackObj_apply_fst (pullbackIsPullback f g) p
 
 @[simp]
 theorem pullbackIsoPullback_hom_snd (p : pullback f g) :
     ((pullbackIsoPullback f g).hom p : X × Y).snd = (pullback.snd f g) p :=
-  congr_fun ((pullbackConeIsoPullback f g).hom.w right) p
-
-@[simp]
-theorem pullbackIsoPullback_inv_fst :
-    (pullbackIsoPullback f g).inv ≫ pullback.fst _ _ = fun p => (p.1 : X × Y).fst :=
-  (pullbackConeIsoPullback f g).inv.w left
+  PullbackCone.IsLimit.equivPullbackObj_apply_snd (pullbackIsPullback f g) p
 
 @[simp]
 theorem pullbackIsoPullback_inv_fst_apply (x : (Types.pullbackCone f g).pt) :
-    (pullback.fst f g) ((pullbackIsoPullback f g).inv x) = (fun p => (p.1 : X × Y).fst) x := by
-  rw [elementwise_of% pullbackIsoPullback_inv_fst]
-
-@[simp]
-theorem pullbackIsoPullback_inv_snd :
-    (pullbackIsoPullback f g).inv ≫ pullback.snd _ _ = fun p => (p.1 : X × Y).snd :=
-  (pullbackConeIsoPullback f g).inv.w right
+    (pullback.fst f g) ((pullbackIsoPullback f g).inv x) = (fun p => (p.1 : X × Y).fst) x :=
+  PullbackCone.IsLimit.equivPullbackObj_symm_apply_fst (pullbackIsPullback f g) x
 
 @[simp]
 theorem pullbackIsoPullback_inv_snd_apply (x : (Types.pullbackCone f g).pt) :
-    (pullback.snd f g) ((pullbackIsoPullback f g).inv x) = (fun p => (p.1 : X × Y).snd) x := by
-  rw [elementwise_of% pullbackIsoPullback_inv_snd]
+    (pullback.snd f g) ((pullbackIsoPullback f g).inv x) = (fun p => (p.1 : X × Y).snd) x :=
+  PullbackCone.IsLimit.equivPullbackObj_symm_apply_snd (pullbackIsPullback f g) x
+
+@[simp]
+theorem pullbackIsoPullback_inv_fst :
+    (pullbackIsoPullback f g).inv ≫ pullback.fst _ _ = fun p => (p.1 : X × Y).fst := by aesop
+
+@[simp]
+theorem pullbackIsoPullback_inv_snd :
+    (pullbackIsoPullback f g).inv ≫ pullback.snd _ _ = fun p => (p.1 : X × Y).snd := by aesop
 
 end Pullback
 


### PR DESCRIPTION
The pullback of two maps in `Type` was already described explicitly. We generalize the API to any limit pullback cone.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
