### PR TITLE
[Merged by Bors] - feat(CategoryTheory): all morphisms are mono and epi when Quiver.IsThin holds

### DIFF
--- a/Mathlib/CategoryTheory/Category/Basic.lean
+++ b/Mathlib/CategoryTheory/Category/Basic.lean
@@ -313,7 +313,7 @@ theorem epi_of_epi_fac {X Y Z : C} {f : X ⟶ Y} {g : Y ⟶ Z} {h : X ⟶ Z} [Ep
 
 section
 
-variable [Quiver.IsThin C] {X Y : C} (f : X ⟶ Y)
+variable [Quiver.IsThin C] (f : X ⟶ Y)
 
 instance : Mono f where
   right_cancellation _ _ _ := Subsingleton.elim _ _

--- a/Mathlib/CategoryTheory/Category/Basic.lean
+++ b/Mathlib/CategoryTheory/Category/Basic.lean
@@ -311,6 +311,18 @@ theorem epi_of_epi_fac {X Y Z : C} {f : X ⟶ Y} {g : Y ⟶ Z} {h : X ⟶ Z} [Ep
     (w : f ≫ g = h) : Epi g := by
   subst h; exact epi_of_epi f g
 
+section
+
+variable [Quiver.IsThin C] {X Y : C} (f : X ⟶ Y)
+
+instance : Mono f where
+  right_cancellation _ _ _ := Subsingleton.elim _ _
+
+instance : Epi f where
+  left_cancellation _ _ _ := Subsingleton.elim _ _
+
+end
+
 end
 
 section

--- a/Mathlib/CategoryTheory/Category/Preorder.lean
+++ b/Mathlib/CategoryTheory/Category/Preorder.lean
@@ -52,6 +52,12 @@ instance (priority := 100) smallCategory (α : Type u) [Preorder α] : SmallCate
 instance subsingleton_hom {α : Type u} [Preorder α] (U V : α) :
   Subsingleton (U ⟶ V) := ⟨fun _ _ => ULift.ext _ _ (Subsingleton.elim _ _ )⟩
 
+instance {α : Type u} [Preorder α] {U V : α} (f : U ⟶ V) : Mono f where
+  right_cancellation _ _ _ := Subsingleton.elim _ _
+
+instance {α : Type u} [Preorder α] {U V : α} (f : U ⟶ V) : Epi f where
+  left_cancellation _ _ _ := Subsingleton.elim _ _
+
 end Preorder
 
 namespace CategoryTheory

--- a/Mathlib/CategoryTheory/Category/Preorder.lean
+++ b/Mathlib/CategoryTheory/Category/Preorder.lean
@@ -52,12 +52,6 @@ instance (priority := 100) smallCategory (α : Type u) [Preorder α] : SmallCate
 instance subsingleton_hom {α : Type u} [Preorder α] (U V : α) :
   Subsingleton (U ⟶ V) := ⟨fun _ _ => ULift.ext _ _ (Subsingleton.elim _ _ )⟩
 
-instance {α : Type u} [Preorder α] {U V : α} (f : U ⟶ V) : Mono f where
-  right_cancellation _ _ _ := Subsingleton.elim _ _
-
-instance {α : Type u} [Preorder α] {U V : α} (f : U ⟶ V) : Epi f where
-  left_cancellation _ _ _ := Subsingleton.elim _ _
-
 end Preorder
 
 namespace CategoryTheory


### PR DESCRIPTION
In particular, in preorders, all morphisms are mono and epi.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
