### PR TITLE
[Merged by Bors] - chore: Move `DistribMulAction` on `Opposite`, `Pi`, `Prod`, `Sum`, `Sigma`, `Units`

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -290,6 +290,9 @@ import Mathlib.Algebra.Group.ZeroOne
 import Mathlib.Algebra.GroupPower.IterateHom
 import Mathlib.Algebra.GroupWithZero.Action.Defs
 import Mathlib.Algebra.GroupWithZero.Action.Opposite
+import Mathlib.Algebra.GroupWithZero.Action.Pi
+import Mathlib.Algebra.GroupWithZero.Action.Prod
+import Mathlib.Algebra.GroupWithZero.Action.Units
 import Mathlib.Algebra.GroupWithZero.Basic
 import Mathlib.Algebra.GroupWithZero.Center
 import Mathlib.Algebra.GroupWithZero.Commute
@@ -2675,15 +2678,12 @@ import Mathlib.GroupTheory.GroupAction.FixingSubgroup
 import Mathlib.GroupTheory.GroupAction.Group
 import Mathlib.GroupTheory.GroupAction.Hom
 import Mathlib.GroupTheory.GroupAction.Period
-import Mathlib.GroupTheory.GroupAction.Pi
 import Mathlib.GroupTheory.GroupAction.Pointwise
-import Mathlib.GroupTheory.GroupAction.Prod
 import Mathlib.GroupTheory.GroupAction.Quotient
 import Mathlib.GroupTheory.GroupAction.Ring
 import Mathlib.GroupTheory.GroupAction.SubMulAction
 import Mathlib.GroupTheory.GroupAction.SubMulAction.Pointwise
 import Mathlib.GroupTheory.GroupAction.Support
-import Mathlib.GroupTheory.GroupAction.Units
 import Mathlib.GroupTheory.HNNExtension
 import Mathlib.GroupTheory.Index
 import Mathlib.GroupTheory.MonoidLocalization.Basic

--- a/Mathlib/Algebra/Algebra/NonUnitalHom.lean
+++ b/Mathlib/Algebra/Algebra/NonUnitalHom.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Oliver Nash
 -/
 import Mathlib.Algebra.Algebra.Hom
-import Mathlib.GroupTheory.GroupAction.Prod
+import Mathlib.Algebra.GroupWithZero.Action.Prod
 
 /-!
 # Morphisms of non-unital algebras

--- a/Mathlib/Algebra/GroupWithZero/Action/Pi.lean
+++ b/Mathlib/Algebra/GroupWithZero/Action/Pi.lean
@@ -4,21 +4,18 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Simon Hudon, Patrick Massot
 -/
 import Mathlib.Algebra.Group.Action.Pi
-import Mathlib.Algebra.GroupWithZero.Action.Defs
-import Mathlib.Algebra.GroupWithZero.Defs
-import Mathlib.Data.Set.Function
+import Mathlib.Algebra.GroupWithZero.Action.Basic
 
 /-!
-# Pi instances for multiplicative actions
+# Pi instances for multiplicative actions with zero
 
-This file defines instances for `MulAction` and related structures on `Pi` types.
+This file defines instances for `MulActionWithZero` and related structures on `Pi` types.
 
 ## See also
 
-* `GroupTheory.GroupAction.option`
-* `GroupTheory.GroupAction.prod`
-* `GroupTheory.GroupAction.sigma`
-* `GroupTheory.GroupAction.sum`
+* `Algebra.GroupWithZero.Action.Opposite`
+* `Algebra.GroupWithZero.Action.Prod`
+* `Algebra.GroupWithZero.Action.Units`
 -/
 
 

--- a/Mathlib/Algebra/GroupWithZero/Action/Pi.lean
+++ b/Mathlib/Algebra/GroupWithZero/Action/Pi.lean
@@ -4,7 +4,9 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Simon Hudon, Patrick Massot
 -/
 import Mathlib.Algebra.Group.Action.Pi
-import Mathlib.Algebra.GroupWithZero.Action.Basic
+import Mathlib.Algebra.GroupWithZero.Action.Defs
+import Mathlib.Algebra.GroupWithZero.Defs
+import Mathlib.Tactic.Common
 
 /-!
 # Pi instances for multiplicative actions with zero

--- a/Mathlib/Algebra/GroupWithZero/Action/Prod.lean
+++ b/Mathlib/Algebra/GroupWithZero/Action/Prod.lean
@@ -7,29 +7,20 @@ import Mathlib.Algebra.Group.Action.Prod
 import Mathlib.Algebra.GroupWithZero.Action.Defs
 
 /-!
-# Prod instances for additive and multiplicative actions
-This file defines instances for binary product of additive and multiplicative actions and provides
-scalar multiplication as a homomorphism from `α × β` to `β`.
-## Main declarations
-* `smulMulHom`/`smulMonoidHom`: Scalar multiplication bundled as a multiplicative/monoid
-  homomorphism.
+# Prod instances for multiplicative actions with zero
+
+This file defines instances for `MulActionWithZero` and related structures on `α × β`
+
 ## See also
-* `Mathlib.GroupTheory.GroupAction.Option`
-* `Mathlib.GroupTheory.GroupAction.Pi`
-* `Mathlib.GroupTheory.GroupAction.Sigma`
-* `Mathlib.GroupTheory.GroupAction.Sum`
 
-# Porting notes
-The `to_additive` attribute can be used to generate both the `smul` and `vadd` lemmas
-from the corresponding `pow` lemmas, as explained on zulip here:
-https://leanprover.zulipchat.com/#narrow/near/316087838
-
-This was not done as part of the port in order to stay as close as possible to the mathlib3 code.
+* `Algebra.GroupWithZero.Action.Opposite`
+* `Algebra.GroupWithZero.Action.Pi`
+* `Algebra.GroupWithZero.Action.Units`
 -/
 
 assert_not_exists MonoidWithZero
 
-variable {M N P E α β : Type*}
+variable {M N α β : Type*}
 
 namespace Prod
 

--- a/Mathlib/Algebra/GroupWithZero/Action/Units.lean
+++ b/Mathlib/Algebra/GroupWithZero/Action/Units.lean
@@ -5,28 +5,29 @@ Authors: Eric Wieser
 -/
 import Mathlib.Algebra.Group.Action.Units
 import Mathlib.Algebra.GroupWithZero.Action.Defs
-import Mathlib.Tactic.Common
 
-/-! # Group actions on and by `Mˣ`
+/-!
+# Multiplicative actions with zero on and by `Mˣ`
 
-This file provides the action of a unit on a type `α`, `SMul Mˣ α`, in the presence of
-`SMul M α`, with the obvious definition stated in `Units.smul_def`. This definition preserves
-`MulAction` and `DistribMulAction` structures too.
+This file provides the multiplicative actions with zero of a unit on a type `α`, `SMul Mˣ α`, in the
+presence of `SMulWithZero M α`, with the obvious definition stated in `Units.smul_def`.
 
-Additionally, a `MulAction G M` for some group `G` satisfying some additional properties admits a
-`MulAction G Mˣ` structure, again with the obvious definition stated in `Units.coe_smul`.
-These instances use a primed name.
+Additionally, a `MulDistribMulAction G M` for some group `G` satisfying some additional properties
+admits a `MulDistribMulAction G Mˣ` structure, again with the obvious definition stated in
+`Units.coe_smul`. This instance uses a primed name.
 
-The results are repeated for `AddUnits` and `VAdd` where relevant.
+## See also
+
+* `Algebra.GroupWithZero.Action.Opposite`
+* `Algebra.GroupWithZero.Action.Pi`
+* `Algebra.GroupWithZero.Action.Prod`
 -/
 
-
-variable {G H M N : Type*} {α : Type*}
+variable {G M α : Type*}
 
 namespace Units
 
 /-! ### Action of the units of `M` on a type `α` -/
-
 
 @[to_additive]
 instance [Monoid M] [SMul M α] : SMul Mˣ α where smul m a := (m : M) • a

--- a/Mathlib/Algebra/GroupWithZero/Units/Lemmas.lean
+++ b/Mathlib/Algebra/GroupWithZero/Units/Lemmas.lean
@@ -4,9 +4,9 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johan Commelin
 -/
 import Mathlib.Algebra.Group.Units.Hom
+import Mathlib.Algebra.GroupWithZero.Action.Units
 import Mathlib.Algebra.GroupWithZero.Commute
 import Mathlib.Algebra.GroupWithZero.Hom
-import Mathlib.GroupTheory.GroupAction.Units
 
 /-!
 # Further lemmas about units in a `MonoidWithZero` or a `GroupWithZero`.

--- a/Mathlib/Algebra/Module/Defs.lean
+++ b/Mathlib/Algebra/Module/Defs.lean
@@ -4,11 +4,11 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Nathaniel Thomas, Jeremy Avigad, Johannes Hölzl, Mario Carneiro
 -/
 import Mathlib.Algebra.Group.Hom.End
+import Mathlib.Algebra.GroupWithZero.Action.Units
 import Mathlib.Algebra.Ring.Invertible
 import Mathlib.Algebra.Ring.Opposite
 import Mathlib.Algebra.SMulWithZero
 import Mathlib.Data.Int.Cast.Lemmas
-import Mathlib.GroupTheory.GroupAction.Units
 
 /-!
 # Modules over a ring

--- a/Mathlib/Algebra/Module/Pi.lean
+++ b/Mathlib/Algebra/Module/Pi.lean
@@ -3,10 +3,10 @@ Copyright (c) 2018 Simon Hudon. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Simon Hudon, Patrick Massot
 -/
+import Mathlib.Algebra.GroupWithZero.Action.Pi
 import Mathlib.Algebra.Module.Defs
 import Mathlib.Algebra.Regular.SMul
 import Mathlib.Algebra.Ring.Pi
-import Mathlib.GroupTheory.GroupAction.Pi
 
 /-!
 # Pi instances for modules

--- a/Mathlib/Algebra/Module/Prod.lean
+++ b/Mathlib/Algebra/Module/Prod.lean
@@ -3,8 +3,8 @@ Copyright (c) 2018 Simon Hudon. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Simon Hudon, Patrick Massot, Eric Wieser
 -/
+import Mathlib.Algebra.GroupWithZero.Action.Prod
 import Mathlib.Algebra.Module.Defs
-import Mathlib.GroupTheory.GroupAction.Prod
 
 /-!
 # Prod instances for module and multiplicative actions

--- a/Mathlib/Algebra/Order/Floor/Div.lean
+++ b/Mathlib/Algebra/Order/Floor/Div.lean
@@ -3,10 +3,10 @@ Copyright (c) 2023 Yaël Dillies. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Yaël Dillies
 -/
+import Mathlib.Algebra.GroupWithZero.Action.Pi
 import Mathlib.Algebra.Order.Module.Defs
 import Mathlib.Algebra.Order.Pi
 import Mathlib.Data.Finsupp.Order
-import Mathlib.GroupTheory.GroupAction.Pi
 import Mathlib.Order.GaloisConnection
 
 /-!

--- a/Mathlib/Data/DFinsupp/Basic.lean
+++ b/Mathlib/Data/DFinsupp/Basic.lean
@@ -5,13 +5,13 @@ Authors: Johannes Hölzl, Kenny Lau
 -/
 import Mathlib.Algebra.BigOperators.GroupWithZero.Finset
 import Mathlib.Algebra.Group.Submonoid.Membership
+import Mathlib.Algebra.GroupWithZero.Action.Pi
+import Mathlib.Algebra.Module.LinearMap.Defs
 import Mathlib.Data.Finset.Preimage
 import Mathlib.Data.Fintype.Quotient
 import Mathlib.Data.Set.Finite
 import Mathlib.GroupTheory.GroupAction.BigOperators
-import Mathlib.GroupTheory.GroupAction.Pi
 import Mathlib.Order.ConditionallyCompleteLattice.Basic
-import Mathlib.Algebra.Module.LinearMap.Defs
 
 /-!
 # Dependent functions with finite support

--- a/Mathlib/Data/Int/AbsoluteValue.lean
+++ b/Mathlib/Data/Int/AbsoluteValue.lean
@@ -3,10 +3,10 @@ Copyright (c) 2021 Anne Baanen. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Anne Baanen
 -/
+import Mathlib.Algebra.GroupWithZero.Action.Units
 import Mathlib.Algebra.Module.Defs
 import Mathlib.Algebra.Order.AbsoluteValue
 import Mathlib.Data.Int.Cast.Lemmas
-import Mathlib.GroupTheory.GroupAction.Units
 
 /-!
 # Absolute values and the integers

--- a/Mathlib/GroupTheory/GroupAction/Group.lean
+++ b/Mathlib/GroupTheory/GroupAction/Group.lean
@@ -3,11 +3,11 @@ Copyright (c) 2018 Chris Hughes. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Chris Hughes
 -/
-import Mathlib.Algebra.Group.Aut
 import Mathlib.Algebra.Group.Action.Basic
+import Mathlib.Algebra.Group.Aut
 import Mathlib.Algebra.Group.Invertible.Basic
+import Mathlib.Algebra.GroupWithZero.Action.Units
 import Mathlib.Algebra.GroupWithZero.Units.Basic
-import Mathlib.GroupTheory.GroupAction.Units
 
 /-!
 # Group actions applied to various types of group

--- a/Mathlib/RingTheory/Coprime/Basic.lean
+++ b/Mathlib/RingTheory/Coprime/Basic.lean
@@ -3,10 +3,10 @@ Copyright (c) 2020 Kenny Lau. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Kenny Lau, Ken Lee, Chris Hughes
 -/
+import Mathlib.Algebra.GroupWithZero.Action.Units
 import Mathlib.Algebra.GroupWithZero.Divisibility
 import Mathlib.Algebra.Ring.Divisibility.Basic
 import Mathlib.Algebra.Ring.Hom.Defs
-import Mathlib.GroupTheory.GroupAction.Units
 import Mathlib.Logic.Basic
 import Mathlib.Tactic.Ring
 

--- a/test/instance_diamonds.lean
+++ b/test/instance_diamonds.lean
@@ -3,13 +3,13 @@ Copyright (c) 2021 Eric Wieser. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Eric Wieser
 -/
+import Mathlib.Algebra.GroupWithZero.Action.Prod
+import Mathlib.Algebra.GroupWithZero.Action.Units
 import Mathlib.Algebra.Module.Pi
 import Mathlib.Algebra.Polynomial.Basic
-import Mathlib.GroupTheory.GroupAction.Prod
-import Mathlib.GroupTheory.GroupAction.Units
 import Mathlib.Data.Complex.Module
-import Mathlib.RingTheory.Algebraic
 import Mathlib.Data.ZMod.Basic
+import Mathlib.RingTheory.Algebraic
 import Mathlib.RingTheory.TensorProduct.Basic
 
 /-! # Tests that instances do not form diamonds -/


### PR DESCRIPTION

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
