### PR TITLE
[Merged by Bors] - chore: adaptations for the multi-goal linter

### DIFF
--- a/Mathlib/Algebra/Star/Order.lean
+++ b/Mathlib/Algebra/Star/Order.lean
@@ -315,8 +315,8 @@ lemma NonUnitalStarRingHom.map_le_map_of_map_star (f : R →⋆ₙ+* S) {x y : R
   rw [StarOrderedRing.le_iff] at hxy ⊢
   obtain ⟨p, hp, rfl⟩ := hxy
   refine ⟨f p, ?_, map_add f _ _⟩
-  induction hp using AddSubmonoid.closure_induction'
   have hf : ∀ r, f (star r) = star (f r) := map_star _
+  induction hp using AddSubmonoid.closure_induction'
   all_goals aesop
 
 instance (priority := 100) StarRingHomClass.instOrderHomClass [FunLike F R S]

--- a/Mathlib/AlgebraicGeometry/Cover/Open.lean
+++ b/Mathlib/AlgebraicGeometry/Cover/Open.lean
@@ -460,8 +460,7 @@ lemma isNilpotent_of_isNilpotent_cover {X : Scheme.{u}} {U : Opens X} (s : Γ(X,
   have hfnleN (i : 𝒰.J) : fn i ≤ N := Finset.le_sup (Finset.mem_univ i)
   use N
   apply zero_of_zero_cover
-  intro i
-  simp only [map_pow]
+  on_goal 1 => intro i; simp only [map_pow]
   exact pow_eq_zero_of_le (hfnleN i) (hfn i)
 
 section deprecated

--- a/Mathlib/AlgebraicGeometry/Cover/Open.lean
+++ b/Mathlib/AlgebraicGeometry/Cover/Open.lean
@@ -461,6 +461,7 @@ lemma isNilpotent_of_isNilpotent_cover {X : Scheme.{u}} {U : Opens X} (s : Γ(X,
   use N
   apply zero_of_zero_cover
   on_goal 1 => intro i; simp only [map_pow]
+  -- This closes both remaining goals at once.
   exact pow_eq_zero_of_le (hfnleN i) (hfn i)
 
 section deprecated

--- a/Mathlib/AlgebraicGeometry/EllipticCurve/DivisionPolynomial/Degree.lean
+++ b/Mathlib/AlgebraicGeometry/EllipticCurve/DivisionPolynomial/Degree.lean
@@ -153,7 +153,8 @@ private def expDegree (n : ℕ) : ℕ :=
 private lemma expDegree_cast {n : ℕ} (hn : n ≠ 0) :
     2 * (expDegree n : ℤ) = n ^ 2 - if Even n then 4 else 1 := by
   rcases n.even_or_odd' with ⟨n, rfl | rfl⟩
-  · rcases n with _ | n; contradiction
+  · rcases n with _ | n
+    · contradiction
     push_cast [expDegree, show (2 * (n + 1)) ^ 2 = 2 * (2 * n * (n + 2)) + 4 by ring1, even_two_mul,
       Nat.add_sub_cancel, Nat.mul_div_cancel_left _ two_pos]
     ring1
@@ -321,7 +322,8 @@ private lemma natDegree_coeff_ΨSq_ofNat (n : ℕ) :
     (W.ΨSq n).natDegree ≤ n ^ 2 - 1 ∧ (W.ΨSq n).coeff (n ^ 2 - 1) = (n ^ 2 : ℤ) := by
   let dp {m n p} : _ → (p ^ n : R[X]).natDegree ≤ n * m := natDegree_pow_le_of_le n
   let h {n} := W.natDegree_coeff_preΨ' n
-  rcases n with _ | n; simp
+  rcases n with _ | n
+  · simp
   have hd : (n + 1) ^ 2 - 1 = 2 * expDegree (n + 1) + if Even (n + 1) then 3 else 0 := by
     push_cast [← @Nat.cast_inj ℤ, add_sq, expDegree_cast (by omega : n + 1 ≠ 0)]
     split_ifs <;> ring1
@@ -334,7 +336,7 @@ private lemma natDegree_coeff_ΨSq_ofNat (n : ℕ) :
     split_ifs <;> simp only [apply_ite natDegree, natDegree_one.le, W.natDegree_Ψ₂Sq_le]
   · erw [coeff_mul_of_natDegree_le (dp h.1), coeff_pow_of_natDegree_le h.1, h.2, apply_ite₂ coeff,
       coeff_Ψ₂Sq, coeff_one_zero, hc]
-    norm_cast
+    · norm_cast
     split_ifs <;> simp only [apply_ite natDegree, natDegree_one.le, W.natDegree_Ψ₂Sq_le]
 
 lemma natDegree_ΨSq_le (n : ℤ) : (W.ΨSq n).natDegree ≤ n.natAbs ^ 2 - 1 := by
@@ -386,7 +388,9 @@ private lemma natDegree_coeff_Φ_ofNat (n : ℕ) :
   let dp {m n p} : _ → (p ^ n : R[X]).natDegree ≤ n * m := natDegree_pow_le_of_le n
   let cm {m n p q} : _ → _ → (p * q : R[X]).coeff (m + n) = _ := coeff_mul_of_natDegree_le
   let h {n} := W.natDegree_coeff_preΨ' n
-  rcases n with _ | _ | n; simp; simp [natDegree_X_le]
+  rcases n with _ | _ | n
+  · simp
+  · simp [natDegree_X_le]
   have hd : (n + 1 + 1) ^ 2 = 1 + 2 * expDegree (n + 2) + if Even (n + 1) then 0 else 3 := by
     push_cast [← @Nat.cast_inj ℤ, expDegree_cast (by omega : n + 2 ≠ 0), Nat.even_add_one, ite_not]
     split_ifs <;> ring1

--- a/Mathlib/AlgebraicGeometry/Noetherian.lean
+++ b/Mathlib/AlgebraicGeometry/Noetherian.lean
@@ -136,7 +136,7 @@ theorem isLocallyNoetherian_iff_of_affine_openCover (𝒰 : Scheme.OpenCover.{v,
   · intro hCNoeth
     let fS i : X.affineOpens := ⟨Scheme.Hom.opensRange (𝒰.map i), isAffineOpen_opensRange _⟩
     apply isLocallyNoetherian_of_affine_cover (S := fS)
-    rw [← Scheme.OpenCover.iSup_opensRange 𝒰]
+    · rw [← Scheme.OpenCover.iSup_opensRange 𝒰]
     intro i
     apply isNoetherianRing_of_ringEquiv (R := Γ(𝒰.obj i, ⊤))
     apply CategoryTheory.Iso.commRingCatIsoToRingEquiv

--- a/Mathlib/Analysis/BoxIntegral/Basic.lean
+++ b/Mathlib/Analysis/BoxIntegral/Basic.lean
@@ -690,7 +690,8 @@ theorem integrable_of_bounded_and_ae_continuousWithinAt [CompleteSpace E] {I : B
       simpa only [edist_le_ofReal (le_of_lt ε₁0), dist_eq_norm, hJ.1] using ineq.trans (hr x hx)
     refine (norm_sum_le _ _).trans <| (sum_le_sum this).trans ?_
     rw [← sum_mul]
-    trans μ.toBoxAdditive I * ε₁; swap; linarith
+    trans μ.toBoxAdditive I * ε₁; swap
+    · linarith
     simp_rw [mul_le_mul_right ε₁0, μ.toBoxAdditive_apply]
     refine le_trans ?_ <| toReal_mono (lt_top_iff_ne_top.1 μI) <| μ.mono <| un (B \ B') sdiff_subset
     rw [← toReal_sum (fun J hJ ↦ μJ_ne_top J (mem_sdiff.1 hJ).1), ← Finset.tsum_subtype]

--- a/Mathlib/Analysis/FunctionalSpaces/SobolevInequality.lean
+++ b/Mathlib/Analysis/FunctionalSpaces/SobolevInequality.lean
@@ -328,7 +328,8 @@ theorem lintegral_pow_le_pow_lintegral_fderiv_aux
         · exact hu.comp (by convert contDiff_update 1 x i)
         · exact h2u.comp_closedEmbedding (closedEmbedding_update x i)
     _ ≤ ∫⁻ xᵢ, (‖fderiv ℝ u (update x i xᵢ)‖₊ : ℝ≥0∞) := ?_
-  gcongr with y; swap; exact Measure.restrict_le_self
+  gcongr with y; swap
+  · exact Measure.restrict_le_self
   -- bound the derivative which appears
   calc ‖deriv (u ∘ update x i) y‖₊ = ‖fderiv ℝ u (update x i y) (deriv (update x i) y)‖₊ := by
         rw [fderiv.comp_deriv _ (hu.differentiable le_rfl).differentiableAt

--- a/Mathlib/CategoryTheory/FiberedCategory/HomLift.lean
+++ b/Mathlib/CategoryTheory/FiberedCategory/HomLift.lean
@@ -113,6 +113,7 @@ lemma of_commSq {R S : 𝒮} {a b : 𝒳} (f : R ⟶ S) (φ : a ⟶ b) (ha : p.o
 instance comp {R S T : 𝒮} {a b c : 𝒳} (f : R ⟶ S) (g : S ⟶ T) (φ : a ⟶ b)
     (ψ : b ⟶ c) [p.IsHomLift f φ] [p.IsHomLift g ψ] : p.IsHomLift (f ≫ g) (φ ≫ ψ) := by
   apply of_commSq
+  -- This line transforms the first goal in suitable form; the last line closes all three goals.
   on_goal 1 => rw [p.map_comp]
   apply CommSq.horiz_comp (commSq p f φ) (commSq p g ψ)
 

--- a/Mathlib/CategoryTheory/FiberedCategory/HomLift.lean
+++ b/Mathlib/CategoryTheory/FiberedCategory/HomLift.lean
@@ -113,7 +113,7 @@ lemma of_commSq {R S : 𝒮} {a b : 𝒳} (f : R ⟶ S) (φ : a ⟶ b) (ha : p.o
 instance comp {R S T : 𝒮} {a b c : 𝒳} (f : R ⟶ S) (g : S ⟶ T) (φ : a ⟶ b)
     (ψ : b ⟶ c) [p.IsHomLift f φ] [p.IsHomLift g ψ] : p.IsHomLift (f ≫ g) (φ ≫ ψ) := by
   apply of_commSq
-  rw [p.map_comp]
+  on_goal 1 => rw [p.map_comp]
   apply CommSq.horiz_comp (commSq p f φ) (commSq p g ψ)
 
 /-- If `φ : a ⟶ b` and `ψ : b ⟶ c` lift `𝟙 R`, then so does `φ ≫ ψ` -/

--- a/Mathlib/Combinatorics/Additive/Corner/Roth.lean
+++ b/Mathlib/Combinatorics/Additive/Corner/Roth.lean
@@ -87,13 +87,14 @@ theorem corners_theorem (ε : ℝ) (hε : 0 < ε) (hG : cornersTheoremBound ε �
     positivity
   have := noAccidental hA
   rw [Nat.floor_lt' (by positivity), inv_pos_lt_iff_one_lt_mul'] at hG
+  swap
+  · have : ε / 9 ≤ 1 := by linarith
+    positivity
   refine hG.not_le (le_of_mul_le_mul_right ?_ (by positivity : (0 : ℝ) < card G ^ 2))
   classical
   have h₁ := (farFromTriangleFree_graph hAε).le_card_cliqueFinset
   rw [card_triangles, card_triangleIndices] at h₁
   convert h₁.trans (Nat.cast_le.2 $ card_le_univ _) using 1 <;> simp <;> ring
-  · have : ε / 9 ≤ 1 := by linarith
-    positivity
 
 /-- The **corners theorem** for `ℕ`.
 

--- a/Mathlib/Combinatorics/Additive/PluenneckeRuzsa.lean
+++ b/Mathlib/Combinatorics/Additive/PluenneckeRuzsa.lean
@@ -42,11 +42,11 @@ theorem ruzsa_triangle_inequality_div_div_div (A B C : Finset α) :
   refine card_mul_le_card_mul (fun b ac ↦ ac.1 * ac.2 = b) (fun x hx ↦ ?_)
     fun x _ ↦ card_le_one_iff.2 fun hu hv ↦
       ((mem_bipartiteBelow _).1 hu).2.symm.trans ?_
-  obtain ⟨a, ha, c, hc, rfl⟩ := mem_div.1 hx
-  refine card_le_card_of_injOn (fun b ↦ (a / b, b / c)) (fun b hb ↦ ?_) fun b₁ _ b₂ _ h ↦ ?_
-  · rw [mem_bipartiteAbove]
-    exact ⟨mk_mem_product (div_mem_div ha hb) (div_mem_div hb hc), div_mul_div_cancel' _ _ _⟩
-  · exact div_right_injective (Prod.ext_iff.1 h).1
+  · obtain ⟨a, ha, c, hc, rfl⟩ := mem_div.1 hx
+    refine card_le_card_of_injOn (fun b ↦ (a / b, b / c)) (fun b hb ↦ ?_) fun b₁ _ b₂ _ h ↦ ?_
+    · rw [mem_bipartiteAbove]
+      exact ⟨mk_mem_product (div_mem_div ha hb) (div_mem_div hb hc), div_mul_div_cancel' _ _ _⟩
+    · exact div_right_injective (Prod.ext_iff.1 h).1
   · exact ((mem_bipartiteBelow _).1 hv).2
 
 /-- **Ruzsa's triangle inequality**. Div-mul-mul version. -/

--- a/Mathlib/Data/Nat/BitIndices.lean
+++ b/Mathlib/Data/Nat/BitIndices.lean
@@ -56,14 +56,16 @@ theorem bitIndices_bit_false (n : ℕ) :
   rw [← bitIndices_bit_false, bit_false]
 
 @[simp] theorem bitIndices_sorted {n : ℕ} : n.bitIndices.Sorted (· < ·) := by
-  induction' n using binaryRec with b n hs; simp
+  induction' n using binaryRec with b n hs
+  · simp
   suffices List.Pairwise (fun a b ↦ a < b) n.bitIndices by
     cases b <;> simpa [List.Sorted, bit_false, bit_true, List.pairwise_map]
   exact List.Pairwise.imp (by simp) hs
 
 @[simp] theorem bitIndices_two_pow_mul (k n : ℕ) :
     bitIndices (2^k * n) = (bitIndices n).map (· + k) := by
-  induction' k with k ih; simp
+  induction' k with k ih
+  · simp
   rw [add_comm, pow_add, pow_one, mul_assoc, bitIndices_two_mul, ih, List.map_map, comp_add_right]
   simp [add_comm (a := 1)]
 
@@ -71,7 +73,8 @@ theorem bitIndices_bit_false (n : ℕ) :
   rw [← mul_one (a := 2^k), bitIndices_two_pow_mul]; simp
 
 @[simp] theorem twoPowSum_bitIndices (n : ℕ) : (n.bitIndices.map (fun i ↦ 2 ^ i)).sum = n := by
-  induction' n using binaryRec with b n hs; rfl
+  induction' n using binaryRec with b n hs
+  · rfl
   have hrw : (fun i ↦ 2^i) ∘ (fun x ↦ x+1) = fun i ↦ 2 * 2 ^ i := by
     ext i; simp [pow_add, mul_comm]
   cases b
@@ -82,7 +85,8 @@ theorem bitIndices_bit_false (n : ℕ) :
 See `Finset.equivBitIndices` for this bijection. -/
 theorem bitIndices_twoPowsum {L : List ℕ} (hL : List.Sorted (· < ·) L) :
     (L.map (fun i ↦ 2^i)).sum.bitIndices = L := by
-  cases' L with a L; rfl
+  cases' L with a L
+  · rfl
   obtain ⟨haL, hL⟩ := sorted_cons.1 hL
   simp_rw [Nat.lt_iff_add_one_le] at haL
   have h' : ∃ (L₀ : List ℕ), L₀.Sorted (· < ·) ∧ L = L₀.map (· + a + 1) := by

--- a/Mathlib/FieldTheory/RatFunc/Basic.lean
+++ b/Mathlib/FieldTheory/RatFunc/Basic.lean
@@ -209,8 +209,8 @@ variable [Monoid R] [DistribMulAction R K[X]]
 variable [IsScalarTower R K[X] K[X]]
 
 theorem mk_smul (c : R) (p q : K[X]) : RatFunc.mk (c • p) q = c • RatFunc.mk p q := by
-  by_cases hq : q = 0
   letI : SMulZeroClass R (FractionRing K[X]) := inferInstance
+  by_cases hq : q = 0
   · rw [hq, mk_zero, mk_zero, ← ofFractionRing_smul, smul_zero]
   · rw [mk_eq_localization_mk _ hq, mk_eq_localization_mk _ hq, ← Localization.smul_mk, ←
       ofFractionRing_smul]

--- a/Mathlib/GroupTheory/GroupAction/Basic.lean
+++ b/Mathlib/GroupTheory/GroupAction/Basic.lean
@@ -752,7 +752,7 @@ theorem mem_stabilizer_of_finite_iff_smul_le (s : Set α) (hs : s.Finite) (g : G
   haveI : Fintype (g • s : Set α) := Fintype.ofFinite _
   rw [mem_stabilizer_iff]
   constructor
-  exact Eq.subset
+  · exact Eq.subset
   · rw [← Set.toFinset_inj, ← Set.toFinset_subset_toFinset]
     intro h
     apply Finset.eq_of_subset_of_card_le h

--- a/Mathlib/LinearAlgebra/Matrix/GeneralLinearGroup/Card.lean
+++ b/Mathlib/LinearAlgebra/Matrix/GeneralLinearGroup/Card.lean
@@ -72,10 +72,10 @@ noncomputable def equiv_GL_linearindependent (hn : 0 < n) :
     rw [Set.finrank, ← rank_eq_finrank_span_cols, rank_unit]⟩
   invFun M := GeneralLinearGroup.mk'' (transpose (M.1)) <| by
     have : Nonempty (Fin n) := Fin.pos_iff_nonempty.1 hn
-    rw [← Basis.coePiBasisFun.toMatrix_eq_transpose,
-      ← coe_basisOfLinearIndependentOfCardEqFinrank M.2]
     let b := basisOfLinearIndependentOfCardEqFinrank M.2 (by simp)
     have := (Pi.basisFun 𝔽 (Fin n)).invertibleToMatrix b
+    rw [← Basis.coePiBasisFun.toMatrix_eq_transpose,
+      ← coe_basisOfLinearIndependentOfCardEqFinrank M.2]
     exact isUnit_det_of_invertible _
   left_inv := fun x ↦ Units.ext (ext fun i j ↦ rfl)
   right_inv := by exact congrFun rfl

--- a/Mathlib/MeasureTheory/Constructions/Pi.lean
+++ b/Mathlib/MeasureTheory/Constructions/Pi.lean
@@ -891,7 +891,7 @@ theorem measurePreserving_pi {β : ι → Type*} [∀ i, MeasurableSpace (β i)]
     haveI : ∀ i, SigmaFinite (μ i) := fun i ↦ (hf i).sigmaFinite
     refine (Measure.pi_eq fun s hs ↦ ?_).symm
     rw [Measure.map_apply, Set.preimage_pi, Measure.pi_pi]
-    simp_rw [← MeasurePreserving.measure_preimage (hf _) (hs _)]
+    · simp_rw [← MeasurePreserving.measure_preimage (hf _) (hs _)]
     · exact measurable_pi_iff.mpr <| fun i ↦ (hf i).measurable.comp (measurable_pi_apply i)
     · exact MeasurableSet.univ_pi hs
 

--- a/Mathlib/MeasureTheory/Function/ConditionalExpectation/Real.lean
+++ b/Mathlib/MeasureTheory/Function/ConditionalExpectation/Real.lean
@@ -155,7 +155,7 @@ theorem ae_bdd_condexp_of_ae_bdd {R : ℝ≥0} {f : α → ℝ} (hbdd : ∀ᵐ x
   suffices (μ {x | ↑R < |(μ[f|m]) x|}).toReal * ↑R < (μ {x | ↑R < |(μ[f|m]) x|}).toReal * ↑R by
     exact this.ne rfl
   refine lt_of_lt_of_le (setIntegral_gt_gt R.coe_nonneg ?_ h.ne.symm) ?_
-  exact integrable_condexp.abs.integrableOn
+  · exact integrable_condexp.abs.integrableOn
   refine (setIntegral_abs_condexp_le ?_ _).trans ?_
   · simp_rw [← Real.norm_eq_abs]
     exact @measurableSet_lt _ _ _ _ _ m _ _ _ _ _ measurable_const

--- a/Mathlib/MeasureTheory/Function/Intersectivity.lean
+++ b/Mathlib/MeasureTheory/Function/Intersectivity.lean
@@ -93,20 +93,20 @@ lemma bergelson' {s : ℕ → Set α} (hs : ∀ n, MeasurableSet (s n)) (hr₀ :
       _ ≤ ⨍⁻ x, limsup (f · x) atTop ∂μ := limsup_lintegral_le 1 hf (ae_of_all _ $ hf₁ ·) (by simp)
       _ ≤ limsup (f · x) atTop := hx
   -- This exactly means that the `s n` containing `x` have all their finite intersection non-null.
-  refine ⟨{n | x ∈ s n}, fun hxs ↦ ?_, fun u hux hu ↦ ?_⟩
-  -- This next block proves that a set of strictly positive natural density is infinite, mixed with
-  -- the fact that `{n | x ∈ s n}` has strictly positive natural density.
-  -- TODO: Separate it out to a lemma once we have a natural density API.
-  · refine ENNReal.div_ne_zero.2 ⟨hr₀, measure_ne_top _ _⟩ $ eq_bot_mono hx $ Tendsto.limsup_eq $
-      tendsto_of_tendsto_of_tendsto_of_le_of_le tendsto_const_nhds
-      (h := fun n ↦ (n.succ : ℝ≥0∞)⁻¹ * hxs.toFinset.card) ?_ bot_le fun n ↦ mul_le_mul_left' ?_ _
-    · simpa using ENNReal.Tendsto.mul_const (ENNReal.tendsto_inv_nat_nhds_zero.comp $
-        tendsto_add_atTop_nat 1) (.inr $ ENNReal.natCast_ne_top _)
-    · classical
-      simpa only [Finset.sum_apply, indicator_apply, Pi.one_apply, Finset.sum_boole, Nat.cast_le]
-        using Finset.card_le_card fun m hm ↦ hxs.mem_toFinset.2 (Finset.mem_filter.1 hm).2
-  · simp_rw [← hu.mem_toFinset]
-    exact hN₁ _ ⟨x, mem_iInter₂.2 fun n hn ↦ hux $ hu.mem_toFinset.1 hn, hxN⟩
+  · refine ⟨{n | x ∈ s n}, fun hxs ↦ ?_, fun u hux hu ↦ ?_⟩
+    -- This next block proves that a set of strictly positive natural density is infinite, mixed with
+    -- the fact that `{n | x ∈ s n}` has strictly positive natural density.
+    -- TODO: Separate it out to a lemma once we have a natural density API.
+    · refine ENNReal.div_ne_zero.2 ⟨hr₀, measure_ne_top _ _⟩ $ eq_bot_mono hx $ Tendsto.limsup_eq $
+        tendsto_of_tendsto_of_tendsto_of_le_of_le tendsto_const_nhds
+        (h := fun n ↦ (n.succ : ℝ≥0∞)⁻¹ * hxs.toFinset.card) ?_ bot_le fun n ↦ mul_le_mul_left' ?_ _
+      · simpa using ENNReal.Tendsto.mul_const (ENNReal.tendsto_inv_nat_nhds_zero.comp $
+          tendsto_add_atTop_nat 1) (.inr $ ENNReal.natCast_ne_top _)
+      · classical
+        simpa only [Finset.sum_apply, indicator_apply, Pi.one_apply, Finset.sum_boole, Nat.cast_le]
+          using Finset.card_le_card fun m hm ↦ hxs.mem_toFinset.2 (Finset.mem_filter.1 hm).2
+    · simp_rw [← hu.mem_toFinset]
+      exact hN₁ _ ⟨x, mem_iInter₂.2 fun n hn ↦ hux $ hu.mem_toFinset.1 hn, hxN⟩
   · refine eventually_of_forall fun n ↦ ?_
     obtain rfl | _ := eq_zero_or_neZero μ
     · simp

--- a/Mathlib/MeasureTheory/Measure/WithDensity.lean
+++ b/Mathlib/MeasureTheory/Measure/WithDensity.lean
@@ -580,8 +580,8 @@ protected instance SigmaFinite.withDensity [SigmaFinite μ] (f : α → ℝ≥0)
     · exact ⟨n, forall_mem_image.2 fun x hx ↦ hx.2⟩
   · rw [iUnion_eq_univ_iff]
     refine fun x ↦ ⟨max (spanningSetsIndex μ x) ⌈f x⌉₊, ?_, ?_⟩
-    exact mem_spanningSets_of_index_le _ _ (le_max_left ..)
-    simp [Nat.le_ceil]
+    · exact mem_spanningSets_of_index_le _ _ (le_max_left ..)
+    · simp [Nat.le_ceil]
 
 lemma SigmaFinite.withDensity_of_ne_top [SigmaFinite μ] {f : α → ℝ≥0∞}
     (hf_ne_top : ∀ᵐ x ∂μ, f x ≠ ∞) : SigmaFinite (μ.withDensity f) := by

--- a/Mathlib/MeasureTheory/Order/UpperLower.lean
+++ b/Mathlib/MeasureTheory/Order/UpperLower.lean
@@ -67,16 +67,16 @@ private lemma aux₀
     (frequently_of_forall fun _ ↦ lt_irrefl $ ENNReal.ofReal $ 4⁻¹ ^ Fintype.card ι)
     ((Filter.Tendsto.eventually_lt (H.comp hε₀) tendsto_const_nhds ?_).mono fun n ↦
       lt_of_le_of_lt ?_)
-  swap
-  calc
-    ENNReal.ofReal (4⁻¹ ^ Fintype.card ι)
-      = volume (closedBall (f (ε n) (hε' n)) (ε n / 4)) / volume (closedBall x (ε n)) := ?_
-    _ ≤ volume (closure s ∩ closedBall x (ε n)) / volume (closedBall x (ε n)) := by
-      gcongr; exact subset_inter ((hf₁ _ $ hε' n).trans interior_subset_closure) $ hf₀ _ $ hε' n
-  dsimp
-  have := hε' n
-  rw [Real.volume_pi_closedBall, Real.volume_pi_closedBall, ← ENNReal.ofReal_div_of_pos, ← div_pow,
-    mul_div_mul_left _ _ (two_ne_zero' ℝ), div_right_comm, div_self, one_div]
+  on_goal 2 =>
+    calc
+      ENNReal.ofReal (4⁻¹ ^ Fintype.card ι)
+        = volume (closedBall (f (ε n) (hε' n)) (ε n / 4)) / volume (closedBall x (ε n)) := ?_
+      _ ≤ volume (closure s ∩ closedBall x (ε n)) / volume (closedBall x (ε n)) := by
+        gcongr; exact subset_inter ((hf₁ _ $ hε' n).trans interior_subset_closure) $ hf₀ _ $ hε' n
+    dsimp
+    have := hε' n
+    rw [Real.volume_pi_closedBall, Real.volume_pi_closedBall, ← ENNReal.ofReal_div_of_pos, ← div_pow,
+      mul_div_mul_left _ _ (two_ne_zero' ℝ), div_right_comm, div_self, one_div]
   all_goals positivity
 
 /-- If we can fit a small ball inside a set `sᶜ` intersected with any neighborhood of `x`, then the
@@ -97,23 +97,23 @@ private lemma aux₁
       ((Filter.Tendsto.eventually_lt tendsto_const_nhds (H.comp hε₀) $
             ENNReal.sub_lt_self ENNReal.one_ne_top one_ne_zero ?_).mono
         fun n ↦ lt_of_le_of_lt' ?_)
-  swap
-  calc
-    volume (closure s ∩ closedBall x (ε n)) / volume (closedBall x (ε n))
-      ≤ volume (closedBall x (ε n) \ closedBall (f (ε n) $ hε' n) (ε n / 4)) /
-        volume (closedBall x (ε n)) := by
-      gcongr
-      rw [diff_eq_compl_inter]
-      refine inter_subset_inter_left _ ?_
-      rw [subset_compl_comm, ← interior_compl]
-      exact hf₁ _ _
-    _ = 1 - ENNReal.ofReal (4⁻¹ ^ Fintype.card ι) := ?_
-  dsimp only
-  have := hε' n
-  rw [measure_diff (hf₀ _ _) _ ((Real.volume_pi_closedBall _ _).trans_ne ENNReal.ofReal_ne_top),
-    Real.volume_pi_closedBall, Real.volume_pi_closedBall, ENNReal.sub_div fun _ _ ↦ _,
-    ENNReal.div_self _ ENNReal.ofReal_ne_top, ← ENNReal.ofReal_div_of_pos, ← div_pow,
-    mul_div_mul_left _ _ (two_ne_zero' ℝ), div_right_comm, div_self, one_div]
+  on_goal 2 =>
+    calc
+      volume (closure s ∩ closedBall x (ε n)) / volume (closedBall x (ε n))
+        ≤ volume (closedBall x (ε n) \ closedBall (f (ε n) $ hε' n) (ε n / 4)) /
+          volume (closedBall x (ε n)) := by
+        gcongr
+        rw [diff_eq_compl_inter]
+        refine inter_subset_inter_left _ ?_
+        rw [subset_compl_comm, ← interior_compl]
+        exact hf₁ _ _
+      _ = 1 - ENNReal.ofReal (4⁻¹ ^ Fintype.card ι) := ?_
+    dsimp only
+    have := hε' n
+    rw [measure_diff (hf₀ _ _) _ ((Real.volume_pi_closedBall _ _).trans_ne ENNReal.ofReal_ne_top),
+      Real.volume_pi_closedBall, Real.volume_pi_closedBall, ENNReal.sub_div fun _ _ ↦ _,
+      ENNReal.div_self _ ENNReal.ofReal_ne_top, ← ENNReal.ofReal_div_of_pos, ← div_pow,
+      mul_div_mul_left _ _ (two_ne_zero' ℝ), div_right_comm, div_self, one_div]
   all_goals try positivity
   · simp_all
   · measurability

--- a/Mathlib/NumberTheory/Harmonic/GammaDeriv.lean
+++ b/Mathlib/NumberTheory/Harmonic/GammaDeriv.lean
@@ -130,7 +130,7 @@ lemma hasDerivAt_Gamma_one_half : HasDerivAt Gamma (-√π * (γ + 2 * log 2)) (
     change deriv (Gamma ∘ fun s ↦ 2 * s) _ = _
     rw [deriv.comp, deriv_const_mul, mul_one_div, div_self two_ne_zero, deriv_id''] <;>
     dsimp only
-    rw [mul_one, mul_comm, hasDerivAt_Gamma_one.deriv, mul_neg, neg_mul]
+    · rw [mul_one, mul_comm, hasDerivAt_Gamma_one.deriv, mul_neg, neg_mul]
     · fun_prop
     · apply h_diff; norm_num -- s = 1
     · fun_prop

--- a/Mathlib/NumberTheory/Harmonic/GammaDeriv.lean
+++ b/Mathlib/NumberTheory/Harmonic/GammaDeriv.lean
@@ -128,7 +128,7 @@ lemma hasDerivAt_Gamma_one_half : HasDerivAt Gamma (-√π * (γ + 2 * log 2)) (
   _ = √π * (-2 * γ + deriv (fun s : ℝ ↦ 2 ^ (1 - 2 * s)) (1 / 2) + γ) := by
     congr 3
     change deriv (Gamma ∘ fun s ↦ 2 * s) _ = _
-    rw [deriv.comp, deriv_const_mul, mul_one_div, div_self two_ne_zero, deriv_id'']
+    rw [deriv.comp, deriv_const_mul, mul_one_div, div_self two_ne_zero, deriv_id''] <;>
     dsimp only
     rw [mul_one, mul_comm, hasDerivAt_Gamma_one.deriv, mul_neg, neg_mul]
     · fun_prop

--- a/Mathlib/NumberTheory/LSeries/HurwitzZetaValues.lean
+++ b/Mathlib/NumberTheory/LSeries/HurwitzZetaValues.lean
@@ -50,19 +50,19 @@ theorem cosZeta_two_mul_nat (hk : k ≠ 0) (hx : x ∈ Icc 0 1) :
     cosZeta x (2 * k) = (-1) ^ (k + 1) * (2 * π) ^ (2 * k) / 2 / (2 * k)! *
       ((Polynomial.bernoulli (2 * k)).map (algebraMap ℚ ℂ)).eval (x : ℂ) := by
   rw [← (hasSum_nat_cosZeta x (?_ : 1 < re (2 * k))).tsum_eq]
-  refine Eq.trans ?_ <| (congr_arg ofReal' (hasSum_one_div_nat_pow_mul_cos hk hx).tsum_eq).trans ?_
-  · rw [ofReal_tsum]
-    refine tsum_congr fun n ↦ ?_
-    rw [mul_comm (1 / _), mul_one_div, ofReal_div, mul_assoc (2 * π), mul_comm x n, ← mul_assoc,
-      ← Nat.cast_ofNat (R := ℂ), ← Nat.cast_mul, cpow_natCast, ofReal_pow, ofReal_natCast]
-  · simp only [ofReal_mul, ofReal_div, ofReal_pow, ofReal_natCast, ofReal_ofNat,
-      ofReal_neg, ofReal_one]
-    congr 1
-    have : (Polynomial.bernoulli (2 * k)).map (algebraMap ℚ ℂ) = _ :=
-      (Polynomial.map_map (algebraMap ℚ ℝ) ofReal _).symm
-    rw [this, ← ofReal_eq_coe, ← ofReal_eq_coe]
-    apply Polynomial.map_aeval_eq_aeval_map
-    simp only [Algebra.id.map_eq_id, RingHomCompTriple.comp_eq]
+  · refine Eq.trans ?_ <| (congr_arg ofReal' (hasSum_one_div_nat_pow_mul_cos hk hx).tsum_eq).trans ?_
+    · rw [ofReal_tsum]
+      refine tsum_congr fun n ↦ ?_
+      rw [mul_comm (1 / _), mul_one_div, ofReal_div, mul_assoc (2 * π), mul_comm x n, ← mul_assoc,
+        ← Nat.cast_ofNat (R := ℂ), ← Nat.cast_mul, cpow_natCast, ofReal_pow, ofReal_natCast]
+    · simp only [ofReal_mul, ofReal_div, ofReal_pow, ofReal_natCast, ofReal_ofNat,
+        ofReal_neg, ofReal_one]
+      congr 1
+      have : (Polynomial.bernoulli (2 * k)).map (algebraMap ℚ ℂ) = _ :=
+        (Polynomial.map_map (algebraMap ℚ ℝ) ofReal _).symm
+      rw [this, ← ofReal_eq_coe, ← ofReal_eq_coe]
+      apply Polynomial.map_aeval_eq_aeval_map
+      simp only [Algebra.id.map_eq_id, RingHomCompTriple.comp_eq]
   · rw [← Nat.cast_ofNat, ← Nat.cast_one, ← Nat.cast_mul, natCast_re, Nat.cast_lt]
     omega
 
@@ -77,21 +77,21 @@ theorem sinZeta_two_mul_nat_add_one (hk : k ≠ 0) (hx : x ∈ Icc 0 1) :
     sinZeta x (2 * k + 1) = (-1) ^ (k + 1) * (2 * π) ^ (2 * k + 1) / 2 / (2 * k + 1)! *
       ((Polynomial.bernoulli (2 * k + 1)).map (algebraMap ℚ ℂ)).eval (x : ℂ) := by
   rw [← (hasSum_nat_sinZeta x (?_ : 1 < re (2 * k + 1))).tsum_eq]
-  refine Eq.trans ?_ <| (congr_arg ofReal' (hasSum_one_div_nat_pow_mul_sin hk hx).tsum_eq).trans ?_
-  · rw [ofReal_tsum]
-    refine tsum_congr fun n ↦ ?_
-    rw [mul_comm (1 / _), mul_one_div, ofReal_div, mul_assoc (2 * π), mul_comm x n, ← mul_assoc]
-    congr 1
-    rw [← Nat.cast_ofNat, ← Nat.cast_mul, ← Nat.cast_add_one, cpow_natCast, ofReal_pow,
-      ofReal_natCast]
-  · simp only [ofReal_mul, ofReal_div, ofReal_pow, ofReal_natCast, ofReal_ofNat,
-      ofReal_neg, ofReal_one]
-    congr 1
-    have : (Polynomial.bernoulli (2 * k + 1)).map (algebraMap ℚ ℂ) = _ :=
-      (Polynomial.map_map (algebraMap ℚ ℝ) ofReal _).symm
-    rw [this, ← ofReal_eq_coe, ← ofReal_eq_coe]
-    apply Polynomial.map_aeval_eq_aeval_map
-    simp only [Algebra.id.map_eq_id, RingHomCompTriple.comp_eq]
+  · refine Eq.trans ?_ <| (congr_arg ofReal' (hasSum_one_div_nat_pow_mul_sin hk hx).tsum_eq).trans ?_
+    · rw [ofReal_tsum]
+      refine tsum_congr fun n ↦ ?_
+      rw [mul_comm (1 / _), mul_one_div, ofReal_div, mul_assoc (2 * π), mul_comm x n, ← mul_assoc]
+      congr 1
+      rw [← Nat.cast_ofNat, ← Nat.cast_mul, ← Nat.cast_add_one, cpow_natCast, ofReal_pow,
+        ofReal_natCast]
+    · simp only [ofReal_mul, ofReal_div, ofReal_pow, ofReal_natCast, ofReal_ofNat,
+        ofReal_neg, ofReal_one]
+      congr 1
+      have : (Polynomial.bernoulli (2 * k + 1)).map (algebraMap ℚ ℂ) = _ :=
+        (Polynomial.map_map (algebraMap ℚ ℝ) ofReal _).symm
+      rw [this, ← ofReal_eq_coe, ← ofReal_eq_coe]
+      apply Polynomial.map_aeval_eq_aeval_map
+      simp only [Algebra.id.map_eq_id, RingHomCompTriple.comp_eq]
   · rw [← Nat.cast_ofNat, ← Nat.cast_one, ← Nat.cast_mul, ← Nat.cast_add_one, natCast_re,
       Nat.cast_lt, lt_add_iff_pos_left]
     exact mul_pos two_pos (Nat.pos_of_ne_zero hk)

--- a/Mathlib/NumberTheory/NumberField/Units/Regulator.lean
+++ b/Mathlib/NumberTheory/NumberField/Units/Regulator.lean
@@ -84,14 +84,14 @@ theorem abs_det_eq_abs_det (u : Fin (rank K) → (𝓞 K)ˣ)
   rw [← h_col]
   have h := congr_arg abs <| Matrix.submatrix_succAbove_det_eq_negOnePow_submatrix_succAbove_det'
     (Matrix.of fun i w ↦ (mult (f w) : ℝ) * ((f w) (u i)).log) ?_ 0 (f.symm w₂)
-  rw [← Matrix.det_reindex_self e₁, ← Matrix.det_reindex_self g]
-  · rw [Units.smul_def, abs_zsmul, Int.abs_negOnePow, one_smul] at h
-    convert h
-    · ext; simp only [ne_eq, Matrix.reindex_apply, Matrix.submatrix_apply, Matrix.of_apply,
-        Equiv.apply_symm_apply, Equiv.trans_apply, Fin.succAbove_zero, id_eq, finSuccEquiv_succ,
-        Equiv.optionSubtype_symm_apply_apply_coe, f]
-    · ext; simp only [ne_eq, Equiv.coe_trans, Matrix.reindex_apply, Matrix.submatrix_apply,
-        Function.comp_apply, Equiv.apply_symm_apply, id_eq, Matrix.of_apply]; rfl
+  · rw [← Matrix.det_reindex_self e₁, ← Matrix.det_reindex_self g]
+    · rw [Units.smul_def, abs_zsmul, Int.abs_negOnePow, one_smul] at h
+      convert h
+      · ext; simp only [ne_eq, Matrix.reindex_apply, Matrix.submatrix_apply, Matrix.of_apply,
+          Equiv.apply_symm_apply, Equiv.trans_apply, Fin.succAbove_zero, id_eq, finSuccEquiv_succ,
+          Equiv.optionSubtype_symm_apply_apply_coe, f]
+      · ext; simp only [ne_eq, Equiv.coe_trans, Matrix.reindex_apply, Matrix.submatrix_apply,
+          Function.comp_apply, Equiv.apply_symm_apply, id_eq, Matrix.of_apply]; rfl
   · intro _
     simp_rw [Matrix.of_apply, ← Real.log_pow]
     rw [← Real.log_prod, Equiv.prod_comp f (fun w ↦ (w (u _) ^ (mult w))), prod_eq_abs_norm,

--- a/Mathlib/RingTheory/Binomial.lean
+++ b/Mathlib/RingTheory/Binomial.lean
@@ -307,14 +307,14 @@ theorem smeval_ascPochhammer_nat_cast [NatPowAssoc R] (n k : ℕ) :
 
 theorem multichoose_neg_self (n : ℕ) : multichoose (-n : ℤ) n = (-1)^n := by
   apply nsmul_right_injective _ (Nat.factorial_ne_zero _)
-  simp only
+  on_goal 1 => simp only
   rw [factorial_nsmul_multichoose_eq_ascPochhammer, smeval_ascPochhammer_self_neg, nsmul_eq_mul,
     Nat.cast_comm]
 
 @[simp]
 theorem multichoose_neg_succ (n : ℕ) : multichoose (-n : ℤ) (n + 1) = 0 := by
   apply nsmul_right_injective _ (Nat.factorial_ne_zero _)
-  simp only
+  on_goal 1 => simp only
   rw [factorial_nsmul_multichoose_eq_ascPochhammer, smeval_ascPochhammer_succ_neg, smul_zero]
 
 theorem multichoose_neg_add (n k : ℕ) : multichoose (-n : ℤ) (n + k + 1) = 0 := by

--- a/Mathlib/RingTheory/Binomial.lean
+++ b/Mathlib/RingTheory/Binomial.lean
@@ -308,6 +308,7 @@ theorem smeval_ascPochhammer_nat_cast [NatPowAssoc R] (n k : ℕ) :
 theorem multichoose_neg_self (n : ℕ) : multichoose (-n : ℤ) n = (-1)^n := by
   apply nsmul_right_injective _ (Nat.factorial_ne_zero _)
   on_goal 1 => simp only
+  -- This closes both remaining goals at once.
   rw [factorial_nsmul_multichoose_eq_ascPochhammer, smeval_ascPochhammer_self_neg, nsmul_eq_mul,
     Nat.cast_comm]
 
@@ -315,6 +316,7 @@ theorem multichoose_neg_self (n : ℕ) : multichoose (-n : ℤ) n = (-1)^n := by
 theorem multichoose_neg_succ (n : ℕ) : multichoose (-n : ℤ) (n + 1) = 0 := by
   apply nsmul_right_injective _ (Nat.factorial_ne_zero _)
   on_goal 1 => simp only
+  -- This closes both remaining goals at once.
   rw [factorial_nsmul_multichoose_eq_ascPochhammer, smeval_ascPochhammer_succ_neg, smul_zero]
 
 theorem multichoose_neg_add (n k : ℕ) : multichoose (-n : ℤ) (n + k + 1) = 0 := by

--- a/Mathlib/RingTheory/Binomial.lean
+++ b/Mathlib/RingTheory/Binomial.lean
@@ -407,12 +407,12 @@ theorem choose_zero_ite (R) [NonAssocRing R] [Pow R ℕ] [NatPowAssoc R] [Binomi
   rw [eq_ite_iff]
   by_cases hk: k = 0
   constructor
-  rw [hk, choose_zero_right, ← Prod.mk.inj_iff]
-  right
-  constructor
-  exact hk
-  rw [← @Nat.le_zero, Nat.not_le] at hk
-  rw [choose_zero_pos R hk]
+  · rw [hk, choose_zero_right, ← Prod.mk.inj_iff]
+  · right
+    constructor
+    · exact hk
+    · rw [← @Nat.le_zero, Nat.not_le] at hk
+      rw [choose_zero_pos R hk]
 
 @[simp]
 theorem choose_one_right' (r : R) : choose r 1 = r ^ 1 := by

--- a/Mathlib/RingTheory/DedekindDomain/Ideal.lean
+++ b/Mathlib/RingTheory/DedekindDomain/Ideal.lean
@@ -1437,7 +1437,7 @@ theorem count_span_normalizedFactors_eq {r X : R} (hr : r ≠ 0) (hX : Prime X) 
   rw [multiplicity_eq_count_normalizedFactors (Prime.irreducible hX) hr,
     multiplicity_eq_count_normalizedFactors (Prime.irreducible ?_), normalize_apply,
     normUnit_eq_one, Units.val_one, one_eq_top, mul_top, Nat.cast_inj] at this
-  simp only [normalize_apply, this]
+  · simp only [normalize_apply, this]
   · simp only [Submodule.zero_eq_bot, ne_eq, span_singleton_eq_bot, hr, not_false_eq_true]
   · simpa only [prime_span_singleton_iff]
 

--- a/Mathlib/RingTheory/HahnSeries/Multiplication.lean
+++ b/Mathlib/RingTheory/HahnSeries/Multiplication.lean
@@ -433,7 +433,8 @@ theorem orderTop_add_orderTop_le_orderTop_mul {Γ} [LinearOrderedCancelAddCommMo
     x.orderTop + y.orderTop ≤ (x * y).orderTop := by
   by_cases hx : x = 0; · simp [hx]
   by_cases hy : y = 0; · simp [hy]
-  by_cases hxy : x * y = 0; simp [hxy]
+  by_cases hxy : x * y = 0
+  · simp [hxy]
   rw [orderTop_of_ne hx, orderTop_of_ne hy, orderTop_of_ne hxy, ← WithTop.coe_add,
     WithTop.coe_le_coe, ← Set.IsWF.min_add]
   exact Set.IsWF.min_le_min_of_subset support_mul_subset_add_support

--- a/Mathlib/RingTheory/Kaehler/Basic.lean
+++ b/Mathlib/RingTheory/Kaehler/Basic.lean
@@ -718,11 +718,11 @@ lemma KaehlerDifferential.ker_map_of_surjective (h : Function.Surjective (algebr
     LinearMap.ker (map R R A B) =
       (LinearMap.ker finsupp_map).map (Finsupp.total A _ A (D R A)) := by
   rw [ker_map, ← kerTotal_map' R A B h, Submodule.comap_map_eq, Submodule.map_sup,
-    Submodule.map_sup, ← kerTotal_eq, ← Submodule.comap_bot, Submodule.map_comap_eq_of_surjective,
+    Submodule.map_sup, ← kerTotal_eq, ← Submodule.comap_bot,
+    Submodule.map_comap_eq_of_surjective (total_surjective _ _),
     bot_sup_eq, Submodule.map_span, ← Set.range_comp]
   convert bot_sup_eq _
   rw [Submodule.span_eq_bot]; simp
-  exact total_surjective _ _
 
 open IsScalarTower (toAlgHom)
 

--- a/Mathlib/RingTheory/LaurentSeries.lean
+++ b/Mathlib/RingTheory/LaurentSeries.lean
@@ -544,36 +544,36 @@ theorem valuation_le_iff_coeff_lt_eq_zero {D : ℤ} {f : LaurentSeries K} :
     rw [← f.single_order_mul_powerSeriesPart, hs, map_mul, valuation_single_zpow, neg_neg, mul_comm,
       ← le_mul_inv_iff₀, ofAdd_neg, WithZero.coe_inv, ← mul_inv, ← WithZero.coe_mul, ← ofAdd_add,
       ← WithZero.coe_inv, ← ofAdd_neg]
-    by_cases hDs : D + s ≤ 0
-    · apply le_trans ((PowerSeries.idealX K).valuation_le_one F)
-      rwa [← WithZero.coe_one, ← ofAdd_zero, WithZero.coe_le_coe, Multiplicative.ofAdd_le,
-        Left.nonneg_neg_iff]
-    · obtain ⟨d, hd⟩ := Int.eq_ofNat_of_zero_le (le_of_lt <| not_le.mp hDs)
-      rw [hd]
-      apply (intValuation_le_iff_coeff_lt_eq_zero K F).mpr
-      intro n hn
-      rw [powerSeriesPart_coeff f n, hs]
-      apply h_val_f
-      linarith
-    simp only [ne_eq, WithZero.coe_ne_zero, not_false_iff]
+    · by_cases hDs : D + s ≤ 0
+      · apply le_trans ((PowerSeries.idealX K).valuation_le_one F)
+        rwa [← WithZero.coe_one, ← ofAdd_zero, WithZero.coe_le_coe, Multiplicative.ofAdd_le,
+          Left.nonneg_neg_iff]
+      · obtain ⟨d, hd⟩ := Int.eq_ofNat_of_zero_le (le_of_lt <| not_le.mp hDs)
+        rw [hd]
+        apply (intValuation_le_iff_coeff_lt_eq_zero K F).mpr
+        intro n hn
+        rw [powerSeriesPart_coeff f n, hs]
+        apply h_val_f
+        linarith
+    · simp only [ne_eq, WithZero.coe_ne_zero, not_false_iff]
   · obtain ⟨s, hs⟩ := Int.exists_eq_neg_ofNat
       <| neg_nonpos_of_nonneg <| le_of_lt <| not_le.mp ord_nonpos
     rw [neg_inj] at hs
     rw [← f.single_order_mul_powerSeriesPart, hs, map_mul, valuation_single_zpow, mul_comm,
       ← le_mul_inv_iff₀, ofAdd_neg, WithZero.coe_inv, ← mul_inv, ← WithZero.coe_mul, ← ofAdd_add,
       ← WithZero.coe_inv, ← ofAdd_neg, neg_add, neg_neg]
-    by_cases hDs : D - s ≤ 0
-    · apply le_trans ((PowerSeries.idealX K).valuation_le_one F)
-      rw [← WithZero.coe_one, ← ofAdd_zero, WithZero.coe_le_coe, Multiplicative.ofAdd_le]
-      linarith
-    · obtain ⟨d, hd⟩ := Int.eq_ofNat_of_zero_le (le_of_lt <| not_le.mp hDs)
-      rw [← neg_neg (-D + ↑s), ← sub_eq_neg_add, neg_sub, hd]
-      apply (intValuation_le_iff_coeff_lt_eq_zero K F).mpr
-      intro n hn
-      rw [powerSeriesPart_coeff f n, hs]
-      apply h_val_f (s + n)
-      linarith
-    simp only [ne_eq, WithZero.coe_ne_zero, not_false_iff]
+    · by_cases hDs : D - s ≤ 0
+      · apply le_trans ((PowerSeries.idealX K).valuation_le_one F)
+        rw [← WithZero.coe_one, ← ofAdd_zero, WithZero.coe_le_coe, Multiplicative.ofAdd_le]
+        linarith
+      · obtain ⟨d, hd⟩ := Int.eq_ofNat_of_zero_le (le_of_lt <| not_le.mp hDs)
+        rw [← neg_neg (-D + ↑s), ← sub_eq_neg_add, neg_sub, hd]
+        apply (intValuation_le_iff_coeff_lt_eq_zero K F).mpr
+        intro n hn
+        rw [powerSeriesPart_coeff f n, hs]
+        apply h_val_f (s + n)
+        linarith
+    · simp only [ne_eq, WithZero.coe_ne_zero, not_false_iff]
 
 /- Two Laurent series whose difference has small valuation have the same coefficients for
 small enough indices. -/

--- a/Mathlib/RingTheory/LaurentSeries.lean
+++ b/Mathlib/RingTheory/LaurentSeries.lean
@@ -429,7 +429,7 @@ theorem intValuation_eq_of_coe (P : K[X]) :
   rw [count_associates_factors_eq (Ideal.span {P}) (Ideal.span {Polynomial.X}) (span_ne_zero).1
     (Ideal.span_singleton_prime Polynomial.X_ne_zero|>.mpr prime_X) (span_ne_zero).2,
     count_associates_factors_eq (Ideal.span {↑(P : K⟦X⟧)}) (idealX K).asIdeal]
-  convert (normalized_count_X_eq_of_coe hP).symm
+  on_goal 1 => convert (normalized_count_X_eq_of_coe hP).symm
   exacts [count_span_normalizedFactors_eq_of_normUnit hP Polynomial.normUnit_X prime_X,
     count_span_normalizedFactors_eq_of_normUnit (coe_ne_zero hP) normUnit_X X_prime,
     span_ne_zero'.1, (idealX K).isPrime, span_ne_zero'.2]
@@ -591,18 +591,17 @@ theorem val_le_one_iff_eq_coe (f : LaurentSeries K) : Valued.v f ≤ (1 : ℤₘ
     ∃ F : PowerSeries K, F = f := by
   rw [← WithZero.coe_one, ← ofAdd_zero, ← neg_zero, valuation_le_iff_coeff_lt_eq_zero]
   refine ⟨fun h => ⟨PowerSeries.mk fun n => f.coeff n, ?_⟩, ?_⟩
-  ext (_ | n)
+  on_goal 1 => ext (_ | n)
   · simp only [Int.ofNat_eq_coe, coeff_coe_powerSeries, coeff_mk]
-  simp only [h (Int.negSucc n) (Int.negSucc_lt_zero n)]
-  swap
-  rintro ⟨F, rfl⟩ _ _
+  on_goal 1 => simp only [h (Int.negSucc n) (Int.negSucc_lt_zero n)]
+  on_goal 2 => rintro ⟨F, rfl⟩ _ _
   all_goals
     apply HahnSeries.embDomain_notin_range
     simp only [Nat.coe_castAddMonoidHom, RelEmbedding.coe_mk, Function.Embedding.coeFn_mk,
       Set.mem_range, not_exists, Int.negSucc_lt_zero,]
     intro
-  linarith
-  simp only [not_false_eq_true]
+  · simp only [not_false_eq_true]
+  · linarith
 
 end LaurentSeries
 

--- a/Mathlib/RingTheory/Polynomial/Wronskian.lean
+++ b/Mathlib/RingTheory/Polynomial/Wronskian.lean
@@ -87,16 +87,16 @@ theorem degree_wronskian_lt_add {a b : R[X]} (ha : a ≠ 0) (hb : b ≠ 0) :
       constructor
       case left =>
         apply lt_of_le_of_lt
-        exact degree_mul_le a (derivative b)
-        rw [← Polynomial.degree_ne_bot] at ha
-        rw [WithBot.add_lt_add_iff_left ha]
-        exact Polynomial.degree_derivative_lt hb
+        · exact degree_mul_le a (derivative b)
+        · rw [← Polynomial.degree_ne_bot] at ha
+          rw [WithBot.add_lt_add_iff_left ha]
+          exact Polynomial.degree_derivative_lt hb
       case right =>
         apply lt_of_le_of_lt
-        exact degree_mul_le (derivative a) b
-        rw [← Polynomial.degree_ne_bot] at hb
-        rw [WithBot.add_lt_add_iff_right hb]
-        exact Polynomial.degree_derivative_lt ha
+        · exact degree_mul_le (derivative a) b
+        · rw [← Polynomial.degree_ne_bot] at hb
+          rw [WithBot.add_lt_add_iff_right hb]
+          exact Polynomial.degree_derivative_lt ha
 
 /--
 `natDegree` version of the above theorem.

--- a/Mathlib/RingTheory/PowerSeries/Basic.lean
+++ b/Mathlib/RingTheory/PowerSeries/Basic.lean
@@ -590,9 +590,9 @@ lemma coeff_one_pow (n : ℕ) (φ : R⟦X⟧) (hC : constantCoeff R φ = 1) :
       have h₁ (m : ℕ) : φ ^ (m + 1) = φ ^ m * φ := by exact rfl
       have h₂ : Finset.antidiagonal 1 = {(0, 1), (1, 0)} := by exact rfl
       rw [h₁, coeff_mul, h₂, Finset.sum_insert, Finset.sum_singleton]
-      simp only [coeff_zero_eq_constantCoeff, map_pow, Nat.cast_add, Nat.cast_one,
-        ih, hC, one_pow, one_mul, mul_one, ← one_add_mul, add_comm]
-      decide
+      · simp only [coeff_zero_eq_constantCoeff, map_pow, Nat.cast_add, Nat.cast_one,
+          ih, hC, one_pow, one_mul, mul_one, ← one_add_mul, add_comm]
+      · decide
 
 end CommSemiring
 

--- a/Mathlib/RingTheory/Valuation/Basic.lean
+++ b/Mathlib/RingTheory/Valuation/Basic.lean
@@ -759,8 +759,8 @@ theorem map_add_of_distinct_val (h : v x ≠ v y) : v (x + y) = @Min.min Γ₀ _
 theorem map_add_eq_of_lt_left {x y : R} (h : v x < v y) :
     v (x + y) = v x := by
   rw [map_add_of_distinct_val]
-  simp [le_of_lt, h]
-  simp [ne_of_lt, h]
+  · simp [le_of_lt, h]
+  · simp [ne_of_lt, h]
 
 theorem map_add_eq_of_lt_right {x y : R} (hx : v y < v x) :
     v (x + y) = v y := add_comm y x ▸ map_add_eq_of_lt_left v hx

--- a/Mathlib/SetTheory/Game/Basic.lean
+++ b/Mathlib/SetTheory/Game/Basic.lean
@@ -782,7 +782,7 @@ lemma mulOption_neg_neg {x} (y) {i j} :
     mulOption x y i j = mulOption x (-(-y)) i (toLeftMovesNeg <| toRightMovesNeg j) := by
   dsimp only [mulOption]
   congr 2
-  rw [neg_neg]
+  · rw [neg_neg]
   iterate 2 rw [moveLeft_neg, moveRight_neg, neg_neg]
 
 /-- The left options of `x * y` agree with that of `y * x` up to equivalence. -/
@@ -806,7 +806,7 @@ lemma leftMoves_mul_iff {x y : PGame} (P : Game → Prop) :
     convert h (Sum.inr (i, j)) using 1
   on_goal 2 =>
     rintro (⟨i, j⟩ | ⟨i, j⟩)
-    exact h.1 i j
+    · exact h.1 i j
     convert h.2 i j using 1
   all_goals
     dsimp only [mk_mul_moveLeft_inr, quot_sub, quot_add, neg_def, mulOption, moveLeft_mk]
@@ -824,11 +824,11 @@ lemma rightMoves_mul_iff {x y : PGame} (P : Game → Prop) :
   constructor <;> intro h
   on_goal 1 =>
     constructor <;> intros i j
-    convert h (Sum.inl (i, j))
+    on_goal 1 => convert h (Sum.inl (i, j))
   on_goal 2 => convert h (Sum.inr (i, j))
   on_goal 3 =>
     rintro (⟨i, j⟩ | ⟨i, j⟩)
-    convert h.1 i j using 1
+    on_goal 1 => convert h.1 i j using 1
     on_goal 2 => convert h.2 i j using 1
   all_goals
     dsimp [mulOption]

--- a/Mathlib/Topology/Category/TopCat/Limits/Pullbacks.lean
+++ b/Mathlib/Topology/Category/TopCat/Limits/Pullbacks.lean
@@ -212,8 +212,8 @@ theorem range_pullback_map {W X Y Z S T : TopCat} (f₁ : W ⟶ S) (f₂ : X ⟶
   apply Concrete.limit_ext
   rintro (_ | _ | _) <;>
   erw [← comp_apply, ← comp_apply] -- now `erw` after #13170
-  simp only [Category.assoc, limit.lift_π, PullbackCone.mk_π_app_one]
-  · simp only [cospan_one, pullbackIsoProdSubtype_inv_fst_assoc, comp_apply]
+  · simp only [Category.assoc, limit.lift_π, PullbackCone.mk_π_app_one]
+    simp only [cospan_one, pullbackIsoProdSubtype_inv_fst_assoc, comp_apply]
     erw [pullbackFst_apply, hx₁]
     rw [← limit.w _ WalkingCospan.Hom.inl, cospan_map_inl, comp_apply (g := g₁)]
     rfl -- `rfl` was not needed before #13170

--- a/Mathlib/Topology/Instances/EReal.lean
+++ b/Mathlib/Topology/Instances/EReal.lean
@@ -220,6 +220,7 @@ lemma limsup_add_le_of_le (ha : limsup u f < a) (hb : limsup v f ≤ b) :
   by_cases hb' : b = ⊤
   · convert le_top
     on_goal 1 => rw [hb']
+    -- This closes both remaining goals at once.
     exact add_top_of_ne_bot ha.ne_bot
   exact (limsup_add_le_add_limsup (hb ▸ Or.inr hb') (Or.inl ha.ne_top)).trans
     (add_le_add ha.le hb.le)

--- a/Mathlib/Topology/Instances/EReal.lean
+++ b/Mathlib/Topology/Instances/EReal.lean
@@ -219,7 +219,7 @@ lemma limsup_add_le_of_le (ha : limsup u f < a) (hb : limsup v f ≤ b) :
   · exact limsup_add_le_of_lt ha hb
   by_cases hb' : b = ⊤
   · convert le_top
-    rw [hb']
+    on_goal 1 => rw [hb']
     exact add_top_of_ne_bot ha.ne_bot
   exact (limsup_add_le_add_limsup (hb ▸ Or.inr hb') (Or.inl ha.ne_top)).trans
     (add_le_add ha.le hb.le)


### PR DESCRIPTION
---

I really don't care which colour we paint this bikeshed in - if you prefer fixing this in a different style, I'm all ears!

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
