### PR TITLE
[Merged by Bors] - chore: reduce imports in 6 files under `GroupTheory`

### DIFF
--- a/Mathlib/GroupTheory/Abelianization.lean
+++ b/Mathlib/GroupTheory/Abelianization.lean
@@ -3,7 +3,6 @@ Copyright (c) 2018 Kenny Lau. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Kenny Lau, Michael Howes
 -/
-import Mathlib.Data.Finite.Card
 import Mathlib.GroupTheory.Commutator
 import Mathlib.GroupTheory.Finiteness
 

--- a/Mathlib/GroupTheory/Archimedean.lean
+++ b/Mathlib/GroupTheory/Archimedean.lean
@@ -5,7 +5,6 @@ Authors: Heather Macbeth, Patrick Massot
 -/
 import Mathlib.Algebra.Group.Subgroup.Order
 import Mathlib.Algebra.Order.Archimedean
-import Mathlib.Data.Set.Lattice
 
 /-!
 # Archimedean groups

--- a/Mathlib/GroupTheory/Commensurable.lean
+++ b/Mathlib/GroupTheory/Commensurable.lean
@@ -3,8 +3,6 @@ Copyright (c) 2021 Chris Birkbeck. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Chris Birkbeck
 -/
-import Mathlib.Algebra.Group.Subgroup.Pointwise
-import Mathlib.GroupTheory.GroupAction.ConjAct
 import Mathlib.GroupTheory.Index
 
 /-!

--- a/Mathlib/GroupTheory/Commutator.lean
+++ b/Mathlib/GroupTheory/Commutator.lean
@@ -3,9 +3,7 @@ Copyright (c) 2021 Jordan Brown, Thomas Browning, Patrick Lutz. All rights reser
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Jordan Brown, Thomas Browning, Patrick Lutz
 -/
-import Mathlib.Algebra.Group.Commutator
 import Mathlib.Algebra.Group.Subgroup.Finite
-import Mathlib.Data.Bracket
 import Mathlib.GroupTheory.Subgroup.Centralizer
 import Mathlib.Tactic.Group
 

--- a/Mathlib/GroupTheory/Nilpotent.lean
+++ b/Mathlib/GroupTheory/Nilpotent.lean
@@ -3,12 +3,8 @@ Copyright (c) 2021 Kevin Buzzard. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Kevin Buzzard, Ines Wright, Joachim Breitner
 -/
-import Mathlib.GroupTheory.QuotientGroup
 import Mathlib.GroupTheory.Solvable
-import Mathlib.GroupTheory.PGroup
 import Mathlib.GroupTheory.Sylow
-import Mathlib.Data.Nat.Factorization.Basic
-import Mathlib.Tactic.TFAE
 import Mathlib.Algebra.Group.Subgroup.Order
 
 /-!

--- a/Mathlib/GroupTheory/Sylow.lean
+++ b/Mathlib/GroupTheory/Sylow.lean
@@ -3,12 +3,9 @@ Copyright (c) 2018 Chris Hughes. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Chris Hughes, Thomas Browning
 -/
-import Mathlib.Data.Nat.Factorization.Basic
 import Mathlib.Data.SetLike.Fintype
-import Mathlib.GroupTheory.GroupAction.ConjAct
 import Mathlib.GroupTheory.PGroup
 import Mathlib.GroupTheory.NoncommPiCoprod
-import Mathlib.Data.Set.Lattice
 
 /-!
 # Sylow theorems


### PR DESCRIPTION
remove 13 imports in 6 files under `GroupTheory`, with help of #min_imports

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
