### PR TITLE
[Merged by Bors] - chore: remove unnecessary imports

### DIFF
--- a/Mathlib/Condensed/Light/Module.lean
+++ b/Mathlib/Condensed/Light/Module.lean
@@ -11,7 +11,6 @@ import Mathlib.CategoryTheory.Sites.Abelian
 import Mathlib.CategoryTheory.Sites.Adjunction
 import Mathlib.CategoryTheory.Sites.Equivalence
 import Mathlib.Condensed.Light.Basic
-
 /-!
 
 # Light condensed `R`-modules

--- a/Mathlib/Condensed/Light/Module.lean
+++ b/Mathlib/Condensed/Light/Module.lean
@@ -10,8 +10,8 @@ import Mathlib.Algebra.Category.ModuleCat.FilteredColimits
 import Mathlib.CategoryTheory.Sites.Abelian
 import Mathlib.CategoryTheory.Sites.Adjunction
 import Mathlib.CategoryTheory.Sites.Equivalence
-import Mathlib.CategoryTheory.Sites.LeftExact
 import Mathlib.Condensed.Light.Basic
+
 /-!
 
 # Light condensed `R`-modules

--- a/Mathlib/NumberTheory/LSeries/RiemannZeta.lean
+++ b/Mathlib/NumberTheory/LSeries/RiemannZeta.lean
@@ -3,9 +3,7 @@ Copyright (c) 2023 David Loeffler. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: David Loeffler
 -/
-import Mathlib.Analysis.SpecialFunctions.Gamma.Beta
 import Mathlib.NumberTheory.LSeries.HurwitzZeta
-import Mathlib.Analysis.Complex.RemovableSingularity
 import Mathlib.Analysis.PSeriesComplex
 
 /-!

--- a/Mathlib/Probability/Distributions/Geometric.lean
+++ b/Mathlib/Probability/Distributions/Geometric.lean
@@ -4,7 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Josha Dekker
 -/
 
-import Mathlib.Topology.Filter
 import Mathlib.Probability.ProbabilityMassFunction.Basic
 import Mathlib.MeasureTheory.Function.StronglyMeasurable.Basic
 

--- a/Mathlib/Probability/Distributions/Geometric.lean
+++ b/Mathlib/Probability/Distributions/Geometric.lean
@@ -4,8 +4,9 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Josha Dekker
 -/
 
-import Mathlib.Probability.Notation
+import Mathlib.Topology.Filter
 import Mathlib.Probability.ProbabilityMassFunction.Basic
+import Mathlib.MeasureTheory.Function.StronglyMeasurable.Basic
 
 /-! # Geometric distributions over ℕ
 

--- a/Mathlib/Probability/Distributions/Poisson.lean
+++ b/Mathlib/Probability/Distributions/Poisson.lean
@@ -4,7 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Josha Dekker
 -/
 
-import Mathlib.Topology.Filter
 import Mathlib.Analysis.SpecialFunctions.Exponential
 import Mathlib.Probability.ProbabilityMassFunction.Basic
 import Mathlib.MeasureTheory.Function.StronglyMeasurable.Basic

--- a/Mathlib/Probability/Distributions/Poisson.lean
+++ b/Mathlib/Probability/Distributions/Poisson.lean
@@ -4,10 +4,10 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Josha Dekker
 -/
 
-import Mathlib.Analysis.NormedSpace.Exponential
+import Mathlib.Topology.Filter
 import Mathlib.Analysis.SpecialFunctions.Exponential
-import Mathlib.Probability.Notation
 import Mathlib.Probability.ProbabilityMassFunction.Basic
+import Mathlib.MeasureTheory.Function.StronglyMeasurable.Basic
 
 /-! # Poisson distributions over ℕ
 

--- a/Mathlib/RingTheory/FiniteType.lean
+++ b/Mathlib/RingTheory/FiniteType.lean
@@ -3,11 +3,7 @@ Copyright (c) 2020 Johan Commelin. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johan Commelin
 -/
-import Mathlib.Algebra.FreeAlgebra
-import Mathlib.GroupTheory.Finiteness
 import Mathlib.RingTheory.Adjoin.Tower
-import Mathlib.RingTheory.Finiteness
-import Mathlib.RingTheory.Noetherian
 
 /-!
 # Finiteness conditions in commutative algebra

--- a/Mathlib/Topology/Category/Stonean/EffectiveEpi.lean
+++ b/Mathlib/Topology/Category/Stonean/EffectiveEpi.lean
@@ -6,7 +6,6 @@ Authors: Dagur Asgeirsson, Boris Bolvig Kjær, Jon Eugster, Sina Hazratpour, Nim
 import Mathlib.CategoryTheory.Sites.Coherent.ReflectsPreregular
 import Mathlib.Topology.Category.CompHaus.EffectiveEpi
 import Mathlib.Topology.Category.Stonean.Limits
-import Mathlib.Topology.Category.CompHaus.EffectiveEpi
 
 /-!
 # Effective epimorphic families in `Stonean`


### PR DESCRIPTION
More import reductions to debug the linter at #14840.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
