### PR TITLE
[Merged by Bors] - chore(Data/Matroid/Closure): fix typo

### DIFF
--- a/Mathlib/Data/Matroid/Closure.lean
+++ b/Mathlib/Data/Matroid/Closure.lean
@@ -38,6 +38,7 @@ All such choices come with tradeoffs. Provided that `M.closure X` has already be
 for `X ⊆ M.E`, the two best candidates for extending it to all `X` seem to be:
 
 (1) The function for which `M.closure X = M.closure (X ∩ M.E)` for all `X : Set α`
+
 (2) The function for which `M.closure X = M.closure (X ∩ M.E) ∪ X` for all `X : Set α`
 
 For both options, the function `closure` is monotone and idempotent with no assumptions on `X`.


### PR DESCRIPTION
We add a single newline character so that a two-item list in the docstring for matroid closure appears with the items on separate lines in docgen.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
