### PR TITLE
[Merged by Bors] - chore: split off `Defs` and `Induction` from `Nat/Factorization/Basic`

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -2279,6 +2279,8 @@ import Mathlib.Data.Nat.Factorial.Cast
 import Mathlib.Data.Nat.Factorial.DoubleFactorial
 import Mathlib.Data.Nat.Factorial.SuperFactorial
 import Mathlib.Data.Nat.Factorization.Basic
+import Mathlib.Data.Nat.Factorization.Defs
+import Mathlib.Data.Nat.Factorization.Induction
 import Mathlib.Data.Nat.Factorization.PrimePow
 import Mathlib.Data.Nat.Factorization.Root
 import Mathlib.Data.Nat.Factors

--- a/Mathlib/Analysis/SpecialFunctions/Log/Basic.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Log/Basic.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Chris Hughes, Abhimanyu Pallavi Sudhir, Jean Lo, Calle Sönne
 -/
 import Mathlib.Analysis.SpecialFunctions.Exp
-import Mathlib.Data.Nat.Factorization.Basic
+import Mathlib.Data.Nat.Factorization.Defs
 import Mathlib.Analysis.NormedSpace.Real
 
 /-!

--- a/Mathlib/Data/Nat/Factorization/Basic.lean
+++ b/Mathlib/Data/Nat/Factorization/Basic.lean
@@ -6,133 +6,26 @@ Authors: Stuart Presnell
 import Mathlib.Data.Finsupp.Multiset
 import Mathlib.Data.Nat.GCD.BigOperators
 import Mathlib.Data.Nat.PrimeFin
+import Mathlib.Data.Nat.Factorization.Defs
 import Mathlib.NumberTheory.Padics.PadicVal
 import Mathlib.Order.Interval.Finset.Nat
 
 /-!
-# Prime factorizations
-
- `n.factorization` is the finitely supported function `ℕ →₀ ℕ`
- mapping each prime factor of `n` to its multiplicity in `n`.  For example, since 2000 = 2^4 * 5^3,
-  * `factorization 2000 2` is 4
-  * `factorization 2000 5` is 3
-  * `factorization 2000 k` is 0 for all other `k : ℕ`.
-
-## TODO
-
-* As discussed in this Zulip thread:
-https://leanprover.zulipchat.com/#narrow/stream/217875/topic/Multiplicity.20in.20the.20naturals
-We have lots of disparate ways of talking about the multiplicity of a prime
-in a natural number, including `factors.count`, `padicValNat`, `multiplicity`,
-and the material in `Data/PNat/Factors`.  Move some of this material to this file,
-prove results about the relationships between these definitions,
-and (where appropriate) choose a uniform canonical way of expressing these ideas.
-
-* Moreover, the results here should be generalised to an arbitrary unique factorization monoid
-with a normalization function, and then deduplicated.  The basics of this have been started in
-`RingTheory/UniqueFactorizationDomain`.
-
-* Extend the inductions to any `NormalizationMonoid` with unique factorization.
-
+# Basic lemmas on prime factorizations
 -/
-
--- Workaround for lean4#2038
-attribute [-instance] instBEqNat
 
 open Nat Finset List Finsupp
 
 namespace Nat
 variable {a b m n p : ℕ}
 
-/-- `n.factorization` is the finitely supported function `ℕ →₀ ℕ`
- mapping each prime factor of `n` to its multiplicity in `n`. -/
-def factorization (n : ℕ) : ℕ →₀ ℕ where
-  support := n.primeFactors
-  toFun p := if p.Prime then padicValNat p n else 0
-  mem_support_toFun := by simp [not_or]; aesop
-
-/-- The support of `n.factorization` is exactly `n.primeFactors`. -/
-@[simp] lemma support_factorization (n : ℕ) : (factorization n).support = n.primeFactors := rfl
-
-theorem factorization_def (n : ℕ) {p : ℕ} (pp : p.Prime) : n.factorization p = padicValNat p n := by
-  simpa [factorization] using absurd pp
-
-/-- We can write both `n.factorization p` and `n.factors.count p` to represent the power
-of `p` in the factorization of `n`: we declare the former to be the simp-normal form. -/
-@[simp]
-theorem primeFactorsList_count_eq {n p : ℕ} : n.primeFactorsList.count p = n.factorization p := by
-  rcases n.eq_zero_or_pos with (rfl | hn0)
-  · simp [factorization, count]
-  if pp : p.Prime then ?_ else
-    rw [count_eq_zero_of_not_mem (mt prime_of_mem_primeFactorsList pp)]
-    simp [factorization, pp]
-  simp only [factorization_def _ pp]
-  apply _root_.le_antisymm
-  · rw [le_padicValNat_iff_replicate_subperm_primeFactorsList pp hn0.ne']
-    exact List.le_count_iff_replicate_sublist.mp le_rfl |>.subperm
-  · rw [← Nat.lt_add_one_iff, lt_iff_not_ge, ge_iff_le,
-      le_padicValNat_iff_replicate_subperm_primeFactorsList pp hn0.ne']
-    intro h
-    have := h.count_le p
-    simp at this
-
-theorem factorization_eq_primeFactorsList_multiset (n : ℕ) :
-    n.factorization = Multiset.toFinsupp (n.primeFactorsList : Multiset ℕ) := by
-  ext p
-  simp
-
-@[deprecated (since := "2024-07-16")] alias factors_count_eq := primeFactorsList_count_eq
-@[deprecated (since := "2024-07-16")]
-alias factorization_eq_factors_multiset := factorization_eq_primeFactorsList_multiset
-
-theorem multiplicity_eq_factorization {n p : ℕ} (pp : p.Prime) (hn : n ≠ 0) :
-    multiplicity p n = n.factorization p := by
-  simp [factorization, pp, padicValNat_def' pp.ne_one hn.bot_lt]
-
 /-! ### Basic facts about factorization -/
-
-
-@[simp]
-theorem factorization_prod_pow_eq_self {n : ℕ} (hn : n ≠ 0) : n.factorization.prod (· ^ ·) = n := by
-  rw [factorization_eq_primeFactorsList_multiset n]
-  simp only [← prod_toMultiset, factorization, Multiset.prod_coe, Multiset.toFinsupp_toMultiset]
-  exact prod_primeFactorsList hn
-
-theorem eq_of_factorization_eq {a b : ℕ} (ha : a ≠ 0) (hb : b ≠ 0)
-    (h : ∀ p : ℕ, a.factorization p = b.factorization p) : a = b :=
-  eq_of_perm_primeFactorsList ha hb
-    (by simpa only [List.perm_iff_count, primeFactorsList_count_eq] using h)
-
-/-- Every nonzero natural number has a unique prime factorization -/
-theorem factorization_inj : Set.InjOn factorization { x : ℕ | x ≠ 0 } := fun a ha b hb h =>
-  eq_of_factorization_eq ha hb fun p => by simp [h]
-
-@[simp]
-theorem factorization_zero : factorization 0 = 0 := by ext; simp [factorization]
-
-@[simp]
-theorem factorization_one : factorization 1 = 0 := by ext; simp [factorization]
 
 /-! ## Lemmas characterising when `n.factorization p = 0` -/
 
 
-theorem factorization_eq_zero_iff (n p : ℕ) :
-    n.factorization p = 0 ↔ ¬p.Prime ∨ ¬p ∣ n ∨ n = 0 := by
-  simp_rw [← not_mem_support_iff, support_factorization, mem_primeFactors, not_and_or, not_ne_iff]
-
-@[simp]
-theorem factorization_eq_zero_of_non_prime (n : ℕ) {p : ℕ} (hp : ¬p.Prime) :
-    n.factorization p = 0 := by simp [factorization_eq_zero_iff, hp]
-
-theorem factorization_eq_zero_of_not_dvd {n p : ℕ} (h : ¬p ∣ n) : n.factorization p = 0 := by
-  simp [factorization_eq_zero_iff, h]
-
 theorem factorization_eq_zero_of_lt {n p : ℕ} (h : n < p) : n.factorization p = 0 :=
   Finsupp.not_mem_support_iff.mp (mt le_of_mem_primeFactors (not_le_of_lt h))
-
-@[simp]
-theorem factorization_zero_right (n : ℕ) : n.factorization 0 = 0 :=
-  factorization_eq_zero_of_non_prime _ not_prime_zero
 
 @[simp]
 theorem factorization_one_right (n : ℕ) : n.factorization 1 = 0 :=
@@ -140,15 +33,6 @@ theorem factorization_one_right (n : ℕ) : n.factorization 1 = 0 :=
 
 theorem dvd_of_factorization_pos {n p : ℕ} (hn : n.factorization p ≠ 0) : p ∣ n :=
   dvd_of_mem_primeFactorsList <| mem_primeFactors_iff_mem_primeFactorsList.1 <| mem_support_iff.2 hn
-
-theorem Prime.factorization_pos_of_dvd {n p : ℕ} (hp : p.Prime) (hn : n ≠ 0) (h : p ∣ n) :
-    0 < n.factorization p := by
-    rwa [← primeFactorsList_count_eq, count_pos_iff_mem, mem_primeFactorsList_iff_dvd hn hp]
-
-theorem factorization_eq_zero_of_remainder {p r : ℕ} (i : ℕ) (hr : ¬p ∣ r) :
-    (p * i + r).factorization p = 0 := by
-  apply factorization_eq_zero_of_not_dvd
-  rwa [← Nat.dvd_add_iff_right (Dvd.intro i rfl)]
 
 theorem factorization_eq_zero_iff_remainder {p r : ℕ} (i : ℕ) (pp : p.Prime) (hr0 : r ≠ 0) :
     ¬p ∣ r ↔ (p * i + r).factorization p = 0 := by
@@ -168,14 +52,6 @@ theorem factorization_eq_zero_iff' (n : ℕ) : n.factorization = 0 ↔ n = 0 ∨
 /-! ## Lemmas about factorizations of products and powers -/
 
 
-/-- For nonzero `a` and `b`, the power of `p` in `a * b` is the sum of the powers in `a` and `b` -/
-@[simp]
-theorem factorization_mul {a b : ℕ} (ha : a ≠ 0) (hb : b ≠ 0) :
-    (a * b).factorization = a.factorization + b.factorization := by
-  ext p
-  simp only [add_apply, ← primeFactorsList_count_eq,
-    perm_iff_count.mp (perm_primeFactorsList_mul ha hb) p, count_append]
-
 /-- A product over `n.factorization` can be written as a product over `n.primeFactors`; -/
 lemma prod_factorization_eq_prod_primeFactors {β : Type*} [CommMonoid β] (f : ℕ → ℕ → β) :
     n.factorization.prod f = ∏ p ∈ n.primeFactors, f p (n.factorization p) := rfl
@@ -184,45 +60,12 @@ lemma prod_factorization_eq_prod_primeFactors {β : Type*} [CommMonoid β] (f : 
 lemma prod_primeFactors_prod_factorization {β : Type*} [CommMonoid β] (f : ℕ → β) :
     ∏ p ∈ n.primeFactors, f p = n.factorization.prod (fun p _ ↦ f p) := rfl
 
-/-- For any `p : ℕ` and any function `g : α → ℕ` that's non-zero on `S : Finset α`,
-the power of `p` in `S.prod g` equals the sum over `x ∈ S` of the powers of `p` in `g x`.
-Generalises `factorization_mul`, which is the special case where `S.card = 2` and `g = id`. -/
-theorem factorization_prod {α : Type*} {S : Finset α} {g : α → ℕ} (hS : ∀ x ∈ S, g x ≠ 0) :
-    (S.prod g).factorization = S.sum fun x => (g x).factorization := by
-  classical
-    ext p
-    refine Finset.induction_on' S ?_ ?_
-    · simp
-    · intro x T hxS hTS hxT IH
-      have hT : T.prod g ≠ 0 := prod_ne_zero_iff.mpr fun x hx => hS x (hTS hx)
-      simp [prod_insert hxT, sum_insert hxT, ← IH, factorization_mul (hS x hxS) hT]
-
-/-- For any `p`, the power of `p` in `n^k` is `k` times the power in `n` -/
-@[simp]
-theorem factorization_pow (n k : ℕ) : factorization (n ^ k) = k • n.factorization := by
-  induction' k with k ih; · simp
-  rcases eq_or_ne n 0 with (rfl | hn)
-  · simp
-  rw [Nat.pow_succ, mul_comm, factorization_mul hn (pow_ne_zero _ hn), ih,
-    add_smul, one_smul, add_comm]
-
 /-! ## Lemmas about factorizations of primes and prime powers -/
 
-
-/-- The only prime factor of prime `p` is `p` itself, with multiplicity `1` -/
-@[simp]
-protected theorem Prime.factorization {p : ℕ} (hp : Prime p) : p.factorization = single p 1 := by
-  ext q
-  rw [← primeFactorsList_count_eq, primeFactorsList_prime hp, single_apply, count_singleton',
-    if_congr eq_comm] <;> rfl
 
 /-- The multiplicity of prime `p` in `p` is `1` -/
 @[simp]
 theorem Prime.factorization_self {p : ℕ} (hp : Prime p) : p.factorization p = 1 := by simp [hp]
-
-/-- For prime `p` the only prime factor of `p^k` is `p` with multiplicity `k` -/
-theorem Prime.factorization_pow {p k : ℕ} (hp : Prime p) : (p ^ k).factorization = single p k := by
-  simp [hp]
 
 /-- If the factorization of `n` contains just one number `p` then `n` is a power of `p` -/
 theorem eq_pow_of_factorization_eq_single {n p k : ℕ} (hn : n ≠ 0)
@@ -238,53 +81,14 @@ theorem Prime.eq_of_factorization_pos {p q : ℕ} (hp : Prime p) (h : p.factoriz
 /-! ### Equivalence between `ℕ+` and `ℕ →₀ ℕ` with support in the primes. -/
 
 
-/-- Any Finsupp `f : ℕ →₀ ℕ` whose support is in the primes is equal to the factorization of
-the product `∏ (a : ℕ) ∈ f.support, a ^ f a`. -/
-theorem prod_pow_factorization_eq_self {f : ℕ →₀ ℕ} (hf : ∀ p : ℕ, p ∈ f.support → Prime p) :
-    (f.prod (· ^ ·)).factorization = f := by
-  have h : ∀ x : ℕ, x ∈ f.support → x ^ f x ≠ 0 := fun p hp =>
-    pow_ne_zero _ (Prime.ne_zero (hf p hp))
-  simp only [Finsupp.prod, factorization_prod h]
-  conv =>
-    rhs
-    rw [(sum_single f).symm]
-  exact sum_congr rfl fun p hp => Prime.factorization_pow (hf p hp)
-
 theorem eq_factorization_iff {n : ℕ} {f : ℕ →₀ ℕ} (hn : n ≠ 0) (hf : ∀ p ∈ f.support, Prime p) :
     f = n.factorization ↔ f.prod (· ^ ·) = n :=
   ⟨fun h => by rw [h, factorization_prod_pow_eq_self hn], fun h => by
     rw [← h, prod_pow_factorization_eq_self hf]⟩
 
-/-- The equiv between `ℕ+` and `ℕ →₀ ℕ` with support in the primes. -/
-def factorizationEquiv : ℕ+ ≃ { f : ℕ →₀ ℕ | ∀ p ∈ f.support, Prime p } where
-  toFun := fun ⟨n, _⟩ => ⟨n.factorization, fun _ => prime_of_mem_primeFactors⟩
-  invFun := fun ⟨f, hf⟩ =>
-    ⟨f.prod _, prod_pow_pos_of_zero_not_mem_support fun H => not_prime_zero (hf 0 H)⟩
-  left_inv := fun ⟨_, hx⟩ => Subtype.ext <| factorization_prod_pow_eq_self hx.ne.symm
-  right_inv := fun ⟨_, hf⟩ => Subtype.ext <| prod_pow_factorization_eq_self hf
-
-theorem factorizationEquiv_apply (n : ℕ+) : (factorizationEquiv n).1 = n.1.factorization := by
-  cases n
-  rfl
-
 theorem factorizationEquiv_inv_apply {f : ℕ →₀ ℕ} (hf : ∀ p ∈ f.support, Prime p) :
     (factorizationEquiv.symm ⟨f, hf⟩).1 = f.prod (· ^ ·) :=
   rfl
-
-/-! ### Generalisation of the "even part" and "odd part" of a natural number
-
-We introduce the notations `ord_proj[p] n` for the largest power of the prime `p` that
-divides `n` and `ord_compl[p] n` for the complementary part. The `ord` naming comes from
-the $p$-adic order/valuation of a number, and `proj` and `compl` are for the projection and
-complementary projection. The term `n.factorization p` is the $p$-adic order itself.
-For example, `ord_proj[2] n` is the even part of `n` and `ord_compl[2] n` is the odd part. -/
-
-
--- Porting note: Lean 4 thinks we need `HPow` without this
-set_option quotPrecheck false in
-notation "ord_proj[" p "] " n:arg => p ^ Nat.factorization n p
-
-notation "ord_compl[" p "] " n:arg => n / ord_proj[p] n
 
 @[simp]
 theorem ord_proj_of_not_prime (n p : ℕ) (hp : ¬p.Prime) : ord_proj[p] n = 1 := by
@@ -293,14 +97,6 @@ theorem ord_proj_of_not_prime (n p : ℕ) (hp : ¬p.Prime) : ord_proj[p] n = 1 :
 @[simp]
 theorem ord_compl_of_not_prime (n p : ℕ) (hp : ¬p.Prime) : ord_compl[p] n = n := by
   simp [factorization_eq_zero_of_non_prime n hp]
-
-theorem ord_proj_dvd (n p : ℕ) : ord_proj[p] n ∣ n := by
-  if hp : p.Prime then ?_ else simp [hp]
-  rw [← primeFactorsList_count_eq]
-  apply dvd_of_primeFactorsList_subperm (pow_ne_zero _ hp.ne_zero)
-  rw [hp.primeFactorsList_pow, List.subperm_ext_iff]
-  intro q hq
-  simp [List.eq_of_mem_replicate hq]
 
 theorem ord_compl_dvd (n p : ℕ) : ord_compl[p] n ∣ n :=
   div_dvd_of_dvd (ord_proj_dvd n p)
@@ -350,30 +146,12 @@ theorem factorization_le_of_le_pow {n p b : ℕ} (hb : n ≤ p ^ b) : n.factoriz
   else
     simp [factorization_eq_zero_of_non_prime n pp]
 
-theorem factorization_le_iff_dvd {d n : ℕ} (hd : d ≠ 0) (hn : n ≠ 0) :
-    d.factorization ≤ n.factorization ↔ d ∣ n := by
-  constructor
-  · intro hdn
-    set K := n.factorization - d.factorization with hK
-    use K.prod (· ^ ·)
-    rw [← factorization_prod_pow_eq_self hn, ← factorization_prod_pow_eq_self hd,
-        ← Finsupp.prod_add_index' pow_zero pow_add, hK, add_tsub_cancel_of_le hdn]
-  · rintro ⟨c, rfl⟩
-    rw [factorization_mul hd (right_ne_zero_of_mul hn)]
-    simp
-
 theorem factorization_prime_le_iff_dvd {d n : ℕ} (hd : d ≠ 0) (hn : n ≠ 0) :
     (∀ p : ℕ, p.Prime → d.factorization p ≤ n.factorization p) ↔ d ∣ n := by
   rw [← factorization_le_iff_dvd hd hn]
   refine ⟨fun h p => (em p.Prime).elim (h p) fun hp => ?_, fun h p _ => h p⟩
   simp_rw [factorization_eq_zero_of_non_prime _ hp]
   rfl
-
-theorem pow_succ_factorization_not_dvd {n p : ℕ} (hn : n ≠ 0) (hp : p.Prime) :
-    ¬p ^ (n.factorization p + 1) ∣ n := by
-  intro h
-  rw [← factorization_le_iff_dvd (pow_pos hp.pos _).ne' hn] at h
-  simpa [hp.factorization] using h p
 
 theorem factorization_le_factorization_mul_left {a b : ℕ} (hb : b ≠ 0) :
     a.factorization ≤ (a * b).factorization := by
@@ -578,26 +356,6 @@ theorem factorization_lcm {a b : ℕ} (ha : a ≠ 0) (hb : b ≠ 0) :
   ext1
   exact (min_add_max _ _).symm
 
-/-- If `a = ∏ pᵢ ^ nᵢ` and `b = ∏ pᵢ ^ mᵢ`, then `factorizationLCMLeft = ∏ pᵢ ^ kᵢ`, where
-`kᵢ = nᵢ` if `mᵢ ≤ nᵢ` and `0` otherwise. Note that the product is over the divisors of `lcm a b`,
-so if one of `a` or `b` is `0` then the result is `1`. -/
-def factorizationLCMLeft (a b : ℕ) : ℕ :=
-  (Nat.lcm a b).factorization.prod fun p n ↦
-    if b.factorization p ≤ a.factorization p then p ^ n else 1
-
-/-- If `a = ∏ pᵢ ^ nᵢ` and `b = ∏ pᵢ ^ mᵢ`, then `factorizationLCMRight = ∏ pᵢ ^ kᵢ`, where
-`kᵢ = mᵢ` if `nᵢ < mᵢ` and `0` otherwise. Note that the product is over the divisors of `lcm a b`,
-so if one of `a` or `b` is `0` then the result is `1`.
-
-Note that `factorizationLCMRight a b` is *not* `factorizationLCMLeft b a`: the difference is
-that in `factorizationLCMLeft a b` there are the primes whose exponent in `a` is bigger or equal
-than the exponent in `b`, while in `factorizationLCMRight a b` there are the primes whose
-exponent in `b` is strictly bigger than in `a`. For example `factorizationLCMLeft 2 2 = 2`, but
-`factorizationLCMRight 2 2 = 1`. -/
-def factorizationLCMRight (a b : ℕ) :=
-  (Nat.lcm a b).factorization.prod fun p n ↦
-    if b.factorization p ≤ a.factorization p then 1 else p ^ n
-
 variable (a b)
 
 @[simp]
@@ -724,18 +482,6 @@ theorem Ico_filter_pow_dvd_eq {n p b : ℕ} (pp : p.Prime) (hn : n ≠ 0) (hb : 
 /-! ### Factorization and coprimes -/
 
 
-/-- For coprime `a` and `b`, the power of `p` in `a * b` is the sum of the powers in `a` and `b` -/
-theorem factorization_mul_apply_of_coprime {p a b : ℕ} (hab : Coprime a b) :
-    (a * b).factorization p = a.factorization p + b.factorization p := by
-  simp only [← primeFactorsList_count_eq,
-    perm_iff_count.mp (perm_primeFactorsList_mul_of_coprime hab), count_append]
-
-/-- For coprime `a` and `b`, the power of `p` in `a * b` is the sum of the powers in `a` and `b` -/
-theorem factorization_mul_of_coprime {a b : ℕ} (hab : Coprime a b) :
-    (a * b).factorization = a.factorization + b.factorization := by
-  ext q
-  rw [Finsupp.add_apply, factorization_mul_apply_of_coprime hab]
-
 /-- If `p` is a prime factor of `a` then the power of `p` in `a` is the same that in `a * b`,
 for any `b` coprime to `a`. -/
 theorem factorization_eq_of_coprime_left {p a b : ℕ} (hab : Coprime a b)
@@ -750,94 +496,6 @@ theorem factorization_eq_of_coprime_right {p a b : ℕ} (hab : Coprime a b)
     (hpb : p ∈ b.primeFactorsList) : (a * b).factorization p = b.factorization p := by
   rw [mul_comm]
   exact factorization_eq_of_coprime_left (coprime_comm.mp hab) hpb
-
-/-! ### Induction principles involving factorizations -/
-
-
-/-- Given `P 0, P 1` and a way to extend `P a` to `P (p ^ n * a)` for prime `p` not dividing `a`,
-we can define `P` for all natural numbers. -/
-@[elab_as_elim]
-def recOnPrimePow {P : ℕ → Sort*} (h0 : P 0) (h1 : P 1)
-    (h : ∀ a p n : ℕ, p.Prime → ¬p ∣ a → 0 < n → P a → P (p ^ n * a)) : ∀ a : ℕ, P a := fun a =>
-  Nat.strongRecOn a fun n =>
-    match n with
-    | 0 => fun _ => h0
-    | 1 => fun _ => h1
-    | k + 2 => fun hk => by
-      letI p := (k + 2).minFac
-      haveI hp : Prime p := minFac_prime (succ_succ_ne_one k)
-      letI t := (k + 2).factorization p
-      haveI hpt : p ^ t ∣ k + 2 := ord_proj_dvd _ _
-      haveI htp : 0 < t := hp.factorization_pos_of_dvd (k + 1).succ_ne_zero (k + 2).minFac_dvd
-      convert h ((k + 2) / p ^ t) p t hp _ htp (hk _ (Nat.div_lt_of_lt_mul _)) using 1
-      · rw [Nat.mul_div_cancel' hpt]
-      · rw [Nat.dvd_div_iff_mul_dvd hpt, ← Nat.pow_succ]
-        exact pow_succ_factorization_not_dvd (k + 1).succ_ne_zero hp
-      · simp [lt_mul_iff_one_lt_left Nat.succ_pos', one_lt_pow_iff htp.ne', hp.one_lt]
-
-/-- Given `P 0`, `P 1`, and `P (p ^ n)` for positive prime powers, and a way to extend `P a` and
-`P b` to `P (a * b)` when `a, b` are positive coprime, we can define `P` for all natural numbers. -/
-@[elab_as_elim]
-def recOnPosPrimePosCoprime {P : ℕ → Sort*} (hp : ∀ p n : ℕ, Prime p → 0 < n → P (p ^ n))
-    (h0 : P 0) (h1 : P 1) (h : ∀ a b, 1 < a → 1 < b → Coprime a b → P a → P b → P (a * b)) :
-    ∀ a, P a :=
-  recOnPrimePow h0 h1 <| by
-    intro a p n hp' hpa hn hPa
-    by_cases ha1 : a = 1
-    · rw [ha1, mul_one]
-      exact hp p n hp' hn
-    refine h (p ^ n) a (hp'.one_lt.trans_le (le_self_pow hn.ne' _)) ?_ ?_ (hp _ _ hp' hn) hPa
-    · contrapose! hpa
-      simp [lt_one_iff.1 (lt_of_le_of_ne hpa ha1)]
-    · simpa [hn, Prime.coprime_iff_not_dvd hp']
-
-/-- Given `P 0`, `P (p ^ n)` for all prime powers, and a way to extend `P a` and `P b` to
-`P (a * b)` when `a, b` are positive coprime, we can define `P` for all natural numbers. -/
-@[elab_as_elim]
-def recOnPrimeCoprime {P : ℕ → Sort*} (h0 : P 0) (hp : ∀ p n : ℕ, Prime p → P (p ^ n))
-    (h : ∀ a b, 1 < a → 1 < b → Coprime a b → P a → P b → P (a * b)) : ∀ a, P a :=
-  recOnPosPrimePosCoprime (fun p n h _ => hp p n h) h0 (hp 2 0 prime_two) h
-
-/-- Given `P 0`, `P 1`, `P p` for all primes, and a way to extend `P a` and `P b` to
-`P (a * b)`, we can define `P` for all natural numbers. -/
-@[elab_as_elim]
-def recOnMul {P : ℕ → Sort*} (h0 : P 0) (h1 : P 1) (hp : ∀ p, Prime p → P p)
-    (h : ∀ a b, P a → P b → P (a * b)) : ∀ a, P a :=
-  let rec
-    /-- The predicate holds on prime powers -/
-    hp'' (p n : ℕ) (hp' : Prime p) : P (p ^ n) :=
-    match n with
-    | 0 => h1
-    | n + 1 => h _ _ (hp'' p n hp') (hp p hp')
-  recOnPrimeCoprime h0 hp'' fun a b _ _ _ => h a b
-
-/-- For any multiplicative function `f` with `f 1 = 1` and any `n ≠ 0`,
-we can evaluate `f n` by evaluating `f` at `p ^ k` over the factorization of `n` -/
-theorem multiplicative_factorization {β : Type*} [CommMonoid β] (f : ℕ → β)
-    (h_mult : ∀ x y : ℕ, Coprime x y → f (x * y) = f x * f y) (hf : f 1 = 1) :
-    ∀ {n : ℕ}, n ≠ 0 → f n = n.factorization.prod fun p k => f (p ^ k) := by
-  apply Nat.recOnPosPrimePosCoprime
-  · rintro p k hp - -
-    -- Porting note: replaced `simp` with `rw`
-    rw [Prime.factorization_pow hp, Finsupp.prod_single_index _]
-    rwa [pow_zero]
-  · simp
-  · rintro -
-    rw [factorization_one, hf]
-    simp
-  · intro a b _ _ hab ha hb hab_pos
-    rw [h_mult a b hab, ha (left_ne_zero_of_mul hab_pos), hb (right_ne_zero_of_mul hab_pos),
-      factorization_mul_of_coprime hab, ← prod_add_index_of_disjoint]
-    exact hab.disjoint_primeFactors
-
-/-- For any multiplicative function `f` with `f 1 = 1` and `f 0 = 1`,
-we can evaluate `f n` by evaluating `f` at `p ^ k` over the factorization of `n` -/
-theorem multiplicative_factorization' {β : Type*} [CommMonoid β] (f : ℕ → β)
-    (h_mult : ∀ x y : ℕ, Coprime x y → f (x * y) = f x * f y) (hf0 : f 0 = 1) (hf1 : f 1 = 1) :
-    f n = n.factorization.prod fun p k => f (p ^ k) := by
-  obtain rfl | hn := eq_or_ne n 0
-  · simpa
-  · exact multiplicative_factorization _ h_mult hf1 hn
 
 /-- Two positive naturals are equal if their prime padic valuations are equal -/
 theorem eq_iff_prime_padicValNat_eq (a b : ℕ) (ha : a ≠ 0) (hb : b ≠ 0) :

--- a/Mathlib/Data/Nat/Factorization/Basic.lean
+++ b/Mathlib/Data/Nat/Factorization/Basic.lean
@@ -3,10 +3,8 @@ Copyright (c) 2021 Stuart Presnell. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Stuart Presnell
 -/
-import Mathlib.Data.Finsupp.Multiset
 import Mathlib.Data.Nat.PrimeFin
 import Mathlib.Data.Nat.Factorization.Defs
-import Mathlib.NumberTheory.Padics.PadicVal
 import Mathlib.Order.Interval.Finset.Nat
 
 /-!

--- a/Mathlib/Data/Nat/Factorization/Basic.lean
+++ b/Mathlib/Data/Nat/Factorization/Basic.lean
@@ -5,6 +5,7 @@ Authors: Stuart Presnell
 -/
 import Mathlib.Data.Nat.PrimeFin
 import Mathlib.Data.Nat.Factorization.Defs
+import Mathlib.Data.Nat.GCD.BigOperators
 import Mathlib.Order.Interval.Finset.Nat
 
 /-!

--- a/Mathlib/Data/Nat/Factorization/Basic.lean
+++ b/Mathlib/Data/Nat/Factorization/Basic.lean
@@ -4,7 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Stuart Presnell
 -/
 import Mathlib.Data.Finsupp.Multiset
-import Mathlib.Data.Nat.GCD.BigOperators
 import Mathlib.Data.Nat.PrimeFin
 import Mathlib.Data.Nat.Factorization.Defs
 import Mathlib.NumberTheory.Padics.PadicVal

--- a/Mathlib/Data/Nat/Factorization/Defs.lean
+++ b/Mathlib/Data/Nat/Factorization/Defs.lean
@@ -4,10 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Stuart Presnell
 -/
 import Mathlib.Data.Finsupp.Multiset
-import Mathlib.Data.Nat.GCD.BigOperators
-import Mathlib.Data.Nat.PrimeFin
 import Mathlib.NumberTheory.Padics.PadicVal
-import Mathlib.Order.Interval.Finset.Nat
 
 /-!
 # Prime factorizations

--- a/Mathlib/Data/Nat/Factorization/Defs.lean
+++ b/Mathlib/Data/Nat/Factorization/Defs.lean
@@ -1,0 +1,291 @@
+/-
+Copyright (c) 2021 Stuart Presnell. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Stuart Presnell
+-/
+import Mathlib.Data.Finsupp.Multiset
+import Mathlib.Data.Nat.GCD.BigOperators
+import Mathlib.Data.Nat.PrimeFin
+import Mathlib.NumberTheory.Padics.PadicVal
+import Mathlib.Order.Interval.Finset.Nat
+
+/-!
+# Prime factorizations
+
+ `n.factorization` is the finitely supported function `ℕ →₀ ℕ`
+ mapping each prime factor of `n` to its multiplicity in `n`.  For example, since 2000 = 2^4 * 5^3,
+  * `factorization 2000 2` is 4
+  * `factorization 2000 5` is 3
+  * `factorization 2000 k` is 0 for all other `k : ℕ`.
+
+## TODO
+
+* As discussed in this Zulip thread:
+https://leanprover.zulipchat.com/#narrow/stream/217875/topic/Multiplicity.20in.20the.20naturals
+We have lots of disparate ways of talking about the multiplicity of a prime
+in a natural number, including `factors.count`, `padicValNat`, `multiplicity`,
+and the material in `Data/PNat/Factors`.  Move some of this material to this file,
+prove results about the relationships between these definitions,
+and (where appropriate) choose a uniform canonical way of expressing these ideas.
+
+* Moreover, the results here should be generalised to an arbitrary unique factorization monoid
+with a normalization function, and then deduplicated.  The basics of this have been started in
+`RingTheory/UniqueFactorizationDomain`.
+
+* Extend the inductions to any `NormalizationMonoid` with unique factorization.
+
+-/
+
+-- Workaround for lean4#2038
+attribute [-instance] instBEqNat
+
+open Nat Finset List Finsupp
+
+namespace Nat
+variable {a b m n p : ℕ}
+
+/-- `n.factorization` is the finitely supported function `ℕ →₀ ℕ`
+ mapping each prime factor of `n` to its multiplicity in `n`. -/
+def factorization (n : ℕ) : ℕ →₀ ℕ where
+  support := n.primeFactors
+  toFun p := if p.Prime then padicValNat p n else 0
+  mem_support_toFun := by simp [not_or]; aesop
+
+/-- The support of `n.factorization` is exactly `n.primeFactors`. -/
+@[simp] lemma support_factorization (n : ℕ) : (factorization n).support = n.primeFactors := rfl
+
+theorem factorization_def (n : ℕ) {p : ℕ} (pp : p.Prime) : n.factorization p = padicValNat p n := by
+  simpa [factorization] using absurd pp
+
+/-- We can write both `n.factorization p` and `n.factors.count p` to represent the power
+of `p` in the factorization of `n`: we declare the former to be the simp-normal form. -/
+@[simp]
+theorem primeFactorsList_count_eq {n p : ℕ} : n.primeFactorsList.count p = n.factorization p := by
+  rcases n.eq_zero_or_pos with (rfl | hn0)
+  · simp [factorization, count]
+  if pp : p.Prime then ?_ else
+    rw [count_eq_zero_of_not_mem (mt prime_of_mem_primeFactorsList pp)]
+    simp [factorization, pp]
+  simp only [factorization_def _ pp]
+  apply _root_.le_antisymm
+  · rw [le_padicValNat_iff_replicate_subperm_primeFactorsList pp hn0.ne']
+    exact List.le_count_iff_replicate_sublist.mp le_rfl |>.subperm
+  · rw [← Nat.lt_add_one_iff, lt_iff_not_ge, ge_iff_le,
+      le_padicValNat_iff_replicate_subperm_primeFactorsList pp hn0.ne']
+    intro h
+    have := h.count_le p
+    simp at this
+
+theorem factorization_eq_primeFactorsList_multiset (n : ℕ) :
+    n.factorization = Multiset.toFinsupp (n.primeFactorsList : Multiset ℕ) := by
+  ext p
+  simp
+
+@[deprecated (since := "2024-07-16")] alias factors_count_eq := primeFactorsList_count_eq
+@[deprecated (since := "2024-07-16")]
+alias factorization_eq_factors_multiset := factorization_eq_primeFactorsList_multiset
+
+theorem Prime.factorization_pos_of_dvd {n p : ℕ} (hp : p.Prime) (hn : n ≠ 0) (h : p ∣ n) :
+    0 < n.factorization p := by
+    rwa [← primeFactorsList_count_eq, count_pos_iff_mem, mem_primeFactorsList_iff_dvd hn hp]
+
+theorem multiplicity_eq_factorization {n p : ℕ} (pp : p.Prime) (hn : n ≠ 0) :
+    multiplicity p n = n.factorization p := by
+  simp [factorization, pp, padicValNat_def' pp.ne_one hn.bot_lt]
+
+/-! ### Basic facts about factorization -/
+
+
+@[simp]
+theorem factorization_prod_pow_eq_self {n : ℕ} (hn : n ≠ 0) : n.factorization.prod (· ^ ·) = n := by
+  rw [factorization_eq_primeFactorsList_multiset n]
+  simp only [← prod_toMultiset, factorization, Multiset.prod_coe, Multiset.toFinsupp_toMultiset]
+  exact prod_primeFactorsList hn
+
+theorem eq_of_factorization_eq {a b : ℕ} (ha : a ≠ 0) (hb : b ≠ 0)
+    (h : ∀ p : ℕ, a.factorization p = b.factorization p) : a = b :=
+  eq_of_perm_primeFactorsList ha hb
+    (by simpa only [List.perm_iff_count, primeFactorsList_count_eq] using h)
+
+
+/-- Every nonzero natural number has a unique prime factorization -/
+theorem factorization_inj : Set.InjOn factorization { x : ℕ | x ≠ 0 } := fun a ha b hb h =>
+  eq_of_factorization_eq ha hb fun p => by simp [h]
+
+@[simp]
+theorem factorization_zero : factorization 0 = 0 := by ext; simp [factorization]
+
+@[simp]
+theorem factorization_one : factorization 1 = 0 := by ext; simp [factorization]
+
+/-! ## Lemmas characterising when `n.factorization p = 0` -/
+
+theorem factorization_eq_zero_iff (n p : ℕ) :
+    n.factorization p = 0 ↔ ¬p.Prime ∨ ¬p ∣ n ∨ n = 0 := by
+  simp_rw [← not_mem_support_iff, support_factorization, mem_primeFactors, not_and_or, not_ne_iff]
+
+@[simp]
+theorem factorization_eq_zero_of_non_prime (n : ℕ) {p : ℕ} (hp : ¬p.Prime) :
+    n.factorization p = 0 := by simp [factorization_eq_zero_iff, hp]
+
+@[simp]
+theorem factorization_zero_right (n : ℕ) : n.factorization 0 = 0 :=
+  factorization_eq_zero_of_non_prime _ not_prime_zero
+
+theorem factorization_eq_zero_of_not_dvd {n p : ℕ} (h : ¬p ∣ n) : n.factorization p = 0 := by
+  simp [factorization_eq_zero_iff, h]
+
+theorem factorization_eq_zero_of_remainder {p r : ℕ} (i : ℕ) (hr : ¬p ∣ r) :
+    (p * i + r).factorization p = 0 := by
+  apply factorization_eq_zero_of_not_dvd
+  rwa [← Nat.dvd_add_iff_right (Dvd.intro i rfl)]
+
+/-! ## Lemmas about factorizations of products and powers -/
+
+/-- For nonzero `a` and `b`, the power of `p` in `a * b` is the sum of the powers in `a` and `b` -/
+@[simp]
+theorem factorization_mul {a b : ℕ} (ha : a ≠ 0) (hb : b ≠ 0) :
+    (a * b).factorization = a.factorization + b.factorization := by
+  ext p
+  simp only [add_apply, ← primeFactorsList_count_eq,
+    perm_iff_count.mp (perm_primeFactorsList_mul ha hb) p, count_append]
+
+theorem factorization_le_iff_dvd {d n : ℕ} (hd : d ≠ 0) (hn : n ≠ 0) :
+    d.factorization ≤ n.factorization ↔ d ∣ n := by
+  constructor
+  · intro hdn
+    set K := n.factorization - d.factorization with hK
+    use K.prod (· ^ ·)
+    rw [← factorization_prod_pow_eq_self hn, ← factorization_prod_pow_eq_self hd,
+        ← Finsupp.prod_add_index' pow_zero pow_add, hK, add_tsub_cancel_of_le hdn]
+  · rintro ⟨c, rfl⟩
+    rw [factorization_mul hd (right_ne_zero_of_mul hn)]
+    simp
+
+/-- For any `p : ℕ` and any function `g : α → ℕ` that's non-zero on `S : Finset α`,
+the power of `p` in `S.prod g` equals the sum over `x ∈ S` of the powers of `p` in `g x`.
+Generalises `factorization_mul`, which is the special case where `S.card = 2` and `g = id`. -/
+theorem factorization_prod {α : Type*} {S : Finset α} {g : α → ℕ} (hS : ∀ x ∈ S, g x ≠ 0) :
+    (S.prod g).factorization = S.sum fun x => (g x).factorization := by
+  classical
+    ext p
+    refine Finset.induction_on' S ?_ ?_
+    · simp
+    · intro x T hxS hTS hxT IH
+      have hT : T.prod g ≠ 0 := prod_ne_zero_iff.mpr fun x hx => hS x (hTS hx)
+      simp [prod_insert hxT, sum_insert hxT, ← IH, factorization_mul (hS x hxS) hT]
+
+/-- For any `p`, the power of `p` in `n^k` is `k` times the power in `n` -/
+@[simp]
+theorem factorization_pow (n k : ℕ) : factorization (n ^ k) = k • n.factorization := by
+  induction' k with k ih; · simp
+  rcases eq_or_ne n 0 with (rfl | hn)
+  · simp
+  rw [Nat.pow_succ, mul_comm, factorization_mul hn (pow_ne_zero _ hn), ih,
+    add_smul, one_smul, add_comm]
+
+/-! ## Lemmas about factorizations of primes and prime powers -/
+
+
+/-- The only prime factor of prime `p` is `p` itself, with multiplicity `1` -/
+@[simp]
+protected theorem Prime.factorization {p : ℕ} (hp : Prime p) : p.factorization = single p 1 := by
+  ext q
+  rw [← primeFactorsList_count_eq, primeFactorsList_prime hp, single_apply, count_singleton',
+    if_congr eq_comm] <;> rfl
+
+/-- For prime `p` the only prime factor of `p^k` is `p` with multiplicity `k` -/
+theorem Prime.factorization_pow {p k : ℕ} (hp : Prime p) : (p ^ k).factorization = single p k := by
+  simp [hp]
+
+theorem pow_succ_factorization_not_dvd {n p : ℕ} (hn : n ≠ 0) (hp : p.Prime) :
+    ¬p ^ (n.factorization p + 1) ∣ n := by
+  intro h
+  rw [← factorization_le_iff_dvd (pow_pos hp.pos _).ne' hn] at h
+  simpa [hp.factorization] using h p
+
+/-! ### Equivalence between `ℕ+` and `ℕ →₀ ℕ` with support in the primes. -/
+
+
+/-- Any Finsupp `f : ℕ →₀ ℕ` whose support is in the primes is equal to the factorization of
+the product `∏ (a : ℕ) ∈ f.support, a ^ f a`. -/
+theorem prod_pow_factorization_eq_self {f : ℕ →₀ ℕ} (hf : ∀ p : ℕ, p ∈ f.support → Prime p) :
+    (f.prod (· ^ ·)).factorization = f := by
+  have h : ∀ x : ℕ, x ∈ f.support → x ^ f x ≠ 0 := fun p hp =>
+    pow_ne_zero _ (Prime.ne_zero (hf p hp))
+  simp only [Finsupp.prod, factorization_prod h]
+  conv =>
+    rhs
+    rw [(sum_single f).symm]
+  exact sum_congr rfl fun p hp => Prime.factorization_pow (hf p hp)
+
+/-- The equiv between `ℕ+` and `ℕ →₀ ℕ` with support in the primes. -/
+def factorizationEquiv : ℕ+ ≃ { f : ℕ →₀ ℕ | ∀ p ∈ f.support, Prime p } where
+  toFun := fun ⟨n, _⟩ => ⟨n.factorization, fun _ => prime_of_mem_primeFactors⟩
+  invFun := fun ⟨f, hf⟩ =>
+    ⟨f.prod _, prod_pow_pos_of_zero_not_mem_support fun H => not_prime_zero (hf 0 H)⟩
+  left_inv := fun ⟨_, hx⟩ => Subtype.ext <| factorization_prod_pow_eq_self hx.ne.symm
+  right_inv := fun ⟨_, hf⟩ => Subtype.ext <| prod_pow_factorization_eq_self hf
+
+/-! ### Factorization and coprimes -/
+
+
+/-- For coprime `a` and `b`, the power of `p` in `a * b` is the sum of the powers in `a` and `b` -/
+theorem factorization_mul_apply_of_coprime {p a b : ℕ} (hab : Coprime a b) :
+    (a * b).factorization p = a.factorization p + b.factorization p := by
+  simp only [← primeFactorsList_count_eq,
+    perm_iff_count.mp (perm_primeFactorsList_mul_of_coprime hab), count_append]
+
+/-- For coprime `a` and `b`, the power of `p` in `a * b` is the sum of the powers in `a` and `b` -/
+theorem factorization_mul_of_coprime {a b : ℕ} (hab : Coprime a b) :
+    (a * b).factorization = a.factorization + b.factorization := by
+  ext q
+  rw [Finsupp.add_apply, factorization_mul_apply_of_coprime hab]
+
+/-! ### Generalisation of the "even part" and "odd part" of a natural number
+
+We introduce the notations `ord_proj[p] n` for the largest power of the prime `p` that
+divides `n` and `ord_compl[p] n` for the complementary part. The `ord` naming comes from
+the $p$-adic order/valuation of a number, and `proj` and `compl` are for the projection and
+complementary projection. The term `n.factorization p` is the $p$-adic order itself.
+For example, `ord_proj[2] n` is the even part of `n` and `ord_compl[2] n` is the odd part. -/
+
+
+-- Porting note: Lean 4 thinks we need `HPow` without this
+set_option quotPrecheck false in
+notation "ord_proj[" p "] " n:arg => p ^ Nat.factorization n p
+
+notation "ord_compl[" p "] " n:arg => n / ord_proj[p] n
+
+theorem ord_proj_dvd (n p : ℕ) : ord_proj[p] n ∣ n := by
+  if hp : p.Prime then ?_ else simp [hp]
+  rw [← primeFactorsList_count_eq]
+  apply dvd_of_primeFactorsList_subperm (pow_ne_zero _ hp.ne_zero)
+  rw [hp.primeFactorsList_pow, List.subperm_ext_iff]
+  intro q hq
+  simp [List.eq_of_mem_replicate hq]
+
+/-! ### Factorization LCM definitions -/
+
+
+/-- If `a = ∏ pᵢ ^ nᵢ` and `b = ∏ pᵢ ^ mᵢ`, then `factorizationLCMLeft = ∏ pᵢ ^ kᵢ`, where
+`kᵢ = nᵢ` if `mᵢ ≤ nᵢ` and `0` otherwise. Note that the product is over the divisors of `lcm a b`,
+so if one of `a` or `b` is `0` then the result is `1`. -/
+def factorizationLCMLeft (a b : ℕ) : ℕ :=
+  (Nat.lcm a b).factorization.prod fun p n ↦
+    if b.factorization p ≤ a.factorization p then p ^ n else 1
+
+/-- If `a = ∏ pᵢ ^ nᵢ` and `b = ∏ pᵢ ^ mᵢ`, then `factorizationLCMRight = ∏ pᵢ ^ kᵢ`, where
+`kᵢ = mᵢ` if `nᵢ < mᵢ` and `0` otherwise. Note that the product is over the divisors of `lcm a b`,
+so if one of `a` or `b` is `0` then the result is `1`.
+
+Note that `factorizationLCMRight a b` is *not* `factorizationLCMLeft b a`: the difference is
+that in `factorizationLCMLeft a b` there are the primes whose exponent in `a` is bigger or equal
+than the exponent in `b`, while in `factorizationLCMRight a b` there are the primes whose
+exponent in `b` is strictly bigger than in `a`. For example `factorizationLCMLeft 2 2 = 2`, but
+`factorizationLCMRight 2 2 = 1`. -/
+def factorizationLCMRight (a b : ℕ) :=
+  (Nat.lcm a b).factorization.prod fun p n ↦
+    if b.factorization p ≤ a.factorization p then 1 else p ^ n
+
+end Nat

--- a/Mathlib/Data/Nat/Factorization/Induction.lean
+++ b/Mathlib/Data/Nat/Factorization/Induction.lean
@@ -1,0 +1,108 @@
+/-
+Copyright (c) 2021 Stuart Presnell. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Stuart Presnell
+-/
+import Mathlib.Data.Nat.Factorization.Defs
+
+/-!
+# Induction principles involving factorizations
+-/
+
+open Nat Finset List Finsupp
+
+namespace Nat
+variable {a b m n p : ℕ}
+
+/-! ## Definitions -/
+
+
+/-- Given `P 0, P 1` and a way to extend `P a` to `P (p ^ n * a)` for prime `p` not dividing `a`,
+we can define `P` for all natural numbers. -/
+@[elab_as_elim]
+def recOnPrimePow {P : ℕ → Sort*} (h0 : P 0) (h1 : P 1)
+    (h : ∀ a p n : ℕ, p.Prime → ¬p ∣ a → 0 < n → P a → P (p ^ n * a)) : ∀ a : ℕ, P a := fun a =>
+  Nat.strongRecOn a fun n =>
+    match n with
+    | 0 => fun _ => h0
+    | 1 => fun _ => h1
+    | k + 2 => fun hk => by
+      letI p := (k + 2).minFac
+      haveI hp : Prime p := minFac_prime (succ_succ_ne_one k)
+      letI t := (k + 2).factorization p
+      haveI hpt : p ^ t ∣ k + 2 := ord_proj_dvd _ _
+      haveI htp : 0 < t := hp.factorization_pos_of_dvd (k + 1).succ_ne_zero (k + 2).minFac_dvd
+      convert h ((k + 2) / p ^ t) p t hp _ htp (hk _ (Nat.div_lt_of_lt_mul _)) using 1
+      · rw [Nat.mul_div_cancel' hpt]
+      · rw [Nat.dvd_div_iff_mul_dvd hpt, ← Nat.pow_succ]
+        exact pow_succ_factorization_not_dvd (k + 1).succ_ne_zero hp
+      · simp [lt_mul_iff_one_lt_left Nat.succ_pos', one_lt_pow_iff htp.ne', hp.one_lt]
+
+/-- Given `P 0`, `P 1`, and `P (p ^ n)` for positive prime powers, and a way to extend `P a` and
+`P b` to `P (a * b)` when `a, b` are positive coprime, we can define `P` for all natural numbers. -/
+@[elab_as_elim]
+def recOnPosPrimePosCoprime {P : ℕ → Sort*} (hp : ∀ p n : ℕ, Prime p → 0 < n → P (p ^ n))
+    (h0 : P 0) (h1 : P 1) (h : ∀ a b, 1 < a → 1 < b → Coprime a b → P a → P b → P (a * b)) :
+    ∀ a, P a :=
+  recOnPrimePow h0 h1 <| by
+    intro a p n hp' hpa hn hPa
+    by_cases ha1 : a = 1
+    · rw [ha1, mul_one]
+      exact hp p n hp' hn
+    refine h (p ^ n) a (hp'.one_lt.trans_le (le_self_pow hn.ne' _)) ?_ ?_ (hp _ _ hp' hn) hPa
+    · contrapose! hpa
+      simp [lt_one_iff.1 (lt_of_le_of_ne hpa ha1)]
+    · simpa [hn, Prime.coprime_iff_not_dvd hp']
+
+/-- Given `P 0`, `P (p ^ n)` for all prime powers, and a way to extend `P a` and `P b` to
+`P (a * b)` when `a, b` are positive coprime, we can define `P` for all natural numbers. -/
+@[elab_as_elim]
+def recOnPrimeCoprime {P : ℕ → Sort*} (h0 : P 0) (hp : ∀ p n : ℕ, Prime p → P (p ^ n))
+    (h : ∀ a b, 1 < a → 1 < b → Coprime a b → P a → P b → P (a * b)) : ∀ a, P a :=
+  recOnPosPrimePosCoprime (fun p n h _ => hp p n h) h0 (hp 2 0 prime_two) h
+
+/-- Given `P 0`, `P 1`, `P p` for all primes, and a way to extend `P a` and `P b` to
+`P (a * b)`, we can define `P` for all natural numbers. -/
+@[elab_as_elim]
+def recOnMul {P : ℕ → Sort*} (h0 : P 0) (h1 : P 1) (hp : ∀ p, Prime p → P p)
+    (h : ∀ a b, P a → P b → P (a * b)) : ∀ a, P a :=
+  let rec
+    /-- The predicate holds on prime powers -/
+    hp'' (p n : ℕ) (hp' : Prime p) : P (p ^ n) :=
+    match n with
+    | 0 => h1
+    | n + 1 => h _ _ (hp'' p n hp') (hp p hp')
+  recOnPrimeCoprime h0 hp'' fun a b _ _ _ => h a b
+
+/-! ## Lemmas on multiplicative functions -/
+
+
+/-- For any multiplicative function `f` with `f 1 = 1` and any `n ≠ 0`,
+we can evaluate `f n` by evaluating `f` at `p ^ k` over the factorization of `n` -/
+theorem multiplicative_factorization {β : Type*} [CommMonoid β] (f : ℕ → β)
+    (h_mult : ∀ x y : ℕ, Coprime x y → f (x * y) = f x * f y) (hf : f 1 = 1) :
+    ∀ {n : ℕ}, n ≠ 0 → f n = n.factorization.prod fun p k => f (p ^ k) := by
+  apply Nat.recOnPosPrimePosCoprime
+  · rintro p k hp - -
+    -- Porting note: replaced `simp` with `rw`
+    rw [Prime.factorization_pow hp, Finsupp.prod_single_index _]
+    rwa [pow_zero]
+  · simp
+  · rintro -
+    rw [factorization_one, hf]
+    simp
+  · intro a b _ _ hab ha hb hab_pos
+    rw [h_mult a b hab, ha (left_ne_zero_of_mul hab_pos), hb (right_ne_zero_of_mul hab_pos),
+      factorization_mul_of_coprime hab, ← prod_add_index_of_disjoint]
+    exact hab.disjoint_primeFactors
+
+/-- For any multiplicative function `f` with `f 1 = 1` and `f 0 = 1`,
+we can evaluate `f n` by evaluating `f` at `p ^ k` over the factorization of `n` -/
+theorem multiplicative_factorization' {β : Type*} [CommMonoid β] (f : ℕ → β)
+    (h_mult : ∀ x y : ℕ, Coprime x y → f (x * y) = f x * f y) (hf0 : f 0 = 1) (hf1 : f 1 = 1) :
+    f n = n.factorization.prod fun p k => f (p ^ k) := by
+  obtain rfl | hn := eq_or_ne n 0
+  · simpa
+  · exact multiplicative_factorization _ h_mult hf1 hn
+
+end Nat

--- a/Mathlib/Data/Nat/Factorization/Root.lean
+++ b/Mathlib/Data/Nat/Factorization/Root.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Yaël Dillies
 -/
 import Mathlib.Algebra.Order.Floor.Div
-import Mathlib.Data.Nat.Factorization.Basic
+import Mathlib.Data.Nat.Factorization.Defs
 
 /-!
 # Roots of natural numbers, rounded up and down

--- a/Mathlib/Data/Nat/Totient.lean
+++ b/Mathlib/Data/Nat/Totient.lean
@@ -5,6 +5,7 @@ Authors: Chris Hughes
 -/
 import Mathlib.Algebra.CharP.Two
 import Mathlib.Data.Nat.Factorization.Basic
+import Mathlib.Data.Nat.Factorization.Induction
 import Mathlib.Data.Nat.Periodic
 import Mathlib.Data.ZMod.Basic
 

--- a/Mathlib/NumberTheory/ArithmeticFunction.lean
+++ b/Mathlib/NumberTheory/ArithmeticFunction.lean
@@ -8,7 +8,7 @@ import Mathlib.Algebra.Module.BigOperators
 import Mathlib.NumberTheory.Divisors
 import Mathlib.Data.Nat.Squarefree
 import Mathlib.Data.Nat.GCD.BigOperators
-import Mathlib.Data.Nat.Factorization.Basic
+import Mathlib.Data.Nat.Factorization.Induction
 import Mathlib.Tactic.ArithMult
 
 /-!

--- a/Mathlib/NumberTheory/SmoothNumbers.lean
+++ b/Mathlib/NumberTheory/SmoothNumbers.lean
@@ -3,7 +3,7 @@ Copyright (c) 2023 Michael Stoll. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Michael Stoll, Ralf Stephan
 -/
-import Mathlib.Data.Nat.Factorization.Basic
+import Mathlib.Data.Nat.Factorization.Defs
 import Mathlib.Data.Nat.Squarefree
 
 /-!


### PR DESCRIPTION
`Nat/Factorization/Basic` has 900 lines and 5 imports. This PR reduces size and number of imported files in several downstream files by importing the minimal newly created `Nat/Factorization/Defs` or `Nat/Factorization/Induction`

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
