### PR TITLE
[Merged by Bors] - feat(Data/Set/Sigma): univ sigma preimage eq self

### DIFF
--- a/Mathlib/Data/Set/Sigma.lean
+++ b/Mathlib/Data/Set/Sigma.lean
@@ -44,7 +44,7 @@ theorem image_sigmaMk_preimage_sigmaMap {β : ι' → Type*} {f : ι → ι'} (h
   rcases hxy with ⟨rfl, hxy⟩; rw [heq_iff_eq] at hxy; subst y
   exact ⟨x, hys, rfl⟩
 
-@[simp] theorem iUnion_preimage_image_sigmaMk_eq  {f : (i : ι) → Set (α i)} :
+@[simp] theorem iUnion_preimage_image_sigmaMk_eq {f : (i : ι) → Set (α i)} :
     ⋃ i, Sigma.mk j ⁻¹' (Sigma.mk i '' (f i)) = f j := by
   aesop
 

--- a/Mathlib/Data/Set/Sigma.lean
+++ b/Mathlib/Data/Set/Sigma.lean
@@ -44,10 +44,6 @@ theorem image_sigmaMk_preimage_sigmaMap {β : ι' → Type*} {f : ι → ι'} (h
   rcases hxy with ⟨rfl, hxy⟩; rw [heq_iff_eq] at hxy; subst y
   exact ⟨x, hys, rfl⟩
 
-@[simp] theorem iUnion_preimage_image_sigmaMk_eq {f : (i : ι) → Set (α i)} :
-    ⋃ i, Sigma.mk j ⁻¹' (Sigma.mk i '' (f i)) = f j := by
-  aesop
-
 /-- Indexed sum of sets. `s.sigma t` is the set of dependent pairs `⟨i, a⟩` such that `i ∈ s` and
 `a ∈ t i`. -/
 protected def sigma (s : Set ι) (t : ∀ i, Set (α i)) : Set (Σ i, α i) := {x | x.1 ∈ s ∧ x.2 ∈ t x.1}
@@ -81,6 +77,10 @@ theorem univ_sigma_univ : (@univ ι).sigma (fun _ ↦ @univ (α i)) = univ := ex
 @[simp]
 theorem sigma_univ : s.sigma (fun _ ↦ univ : ∀ i, Set (α i)) = Sigma.fst ⁻¹' s :=
   ext fun _ ↦ and_true_iff _
+
+@[simp] theorem univ_sigma_preimage (s : Set (Σ i, α i)) :
+    (@univ ι).sigma (fun i ↦ Sigma.mk i ⁻¹' s) = s :=
+  ext <| by simp
 
 @[simp]
 theorem singleton_sigma : ({i} : Set ι).sigma t = Sigma.mk i '' t i :=

--- a/Mathlib/Data/Set/Sigma.lean
+++ b/Mathlib/Data/Set/Sigma.lean
@@ -44,6 +44,10 @@ theorem image_sigmaMk_preimage_sigmaMap {β : ι' → Type*} {f : ι → ι'} (h
   rcases hxy with ⟨rfl, hxy⟩; rw [heq_iff_eq] at hxy; subst y
   exact ⟨x, hys, rfl⟩
 
+@[simp] theorem iUnion_preimage_image_sigmaMk_eq  {f : (i : ι) → Set (α i)} :
+    ⋃ i, Sigma.mk j ⁻¹' (Sigma.mk i '' (f i)) = f j := by
+  aesop
+
 /-- Indexed sum of sets. `s.sigma t` is the set of dependent pairs `⟨i, a⟩` such that `i ∈ s` and
 `a ∈ t i`. -/
 protected def sigma (s : Set ι) (t : ∀ i, Set (α i)) : Set (Σ i, α i) := {x | x.1 ∈ s ∧ x.2 ∈ t x.1}


### PR DESCRIPTION
This PR adds a single simp lemma stating that for  `α : ι → Type*` and `(s : Set (Σ i, α i))`, we have `univ.sigma (fun i ↦ Sigma.mk i ⁻¹' s) = s`. 

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
