### PR TITLE
[Merged by Bors] - chore: remove miscellaneous obsolete porting notes

### DIFF
--- a/Mathlib/CategoryTheory/Functor/Basic.lean
+++ b/Mathlib/CategoryTheory/Functor/Basic.lean
@@ -122,9 +122,6 @@ theorem map_dite (F : C ⥤ D) {X Y : C} {P : Prop} [Decidable P]
     F.map (if h : P then f h else g h) = if h : P then F.map (f h) else F.map (g h) := by
   aesop_cat
 
--- Porting note: `to_prefunctor_obj` and `to_prefunctor_map` are now tautologies,
--- so have not been ported.
-
 @[simp]
 theorem toPrefunctor_comp (F : C ⥤ D) (G : D ⥤ E) :
     F.toPrefunctor.comp G.toPrefunctor = (F ⋙ G).toPrefunctor := rfl

--- a/Mathlib/Data/Finsupp/Multiset.lean
+++ b/Mathlib/Data/Finsupp/Multiset.lean
@@ -10,10 +10,10 @@ import Mathlib.Data.Finsupp.Order
 # Equivalence between `Multiset` and `ℕ`-valued finitely supported functions
 
 This defines `Finsupp.toMultiset` the equivalence between `α →₀ ℕ` and `Multiset α`, along
-with `Multiset.toFinsupp` the reverse equivalence and `Finsupp.orderIsoMultiset` the equivalence
-promoted to an order isomorphism.
--/
+with `Multiset.toFinsupp` the reverse equivalence and `Finsupp.orderIsoMultiset` (the equivalence
+promoted to an order isomorphism).
 
+-/
 
 open Finset
 

--- a/Mathlib/Data/Finsupp/Order.lean
+++ b/Mathlib/Data/Finsupp/Order.lean
@@ -17,12 +17,6 @@ This file lifts order structures on `α` to `ι →₀ α`.
   functions.
 -/
 
--- Porting note: removed from module documentation because it moved to `Data.Finsupp.Multiset`
--- TODO: move to `Data.Finsupp.Multiset` when that is ported
--- * `Finsupp.orderIsoMultiset`: The order isomorphism between `ℕ`-valued finitely supported
---   functions and multisets.
-
-
 noncomputable section
 
 open Finset

--- a/Mathlib/Data/Int/Order/Lemmas.lean
+++ b/Mathlib/Data/Int/Order/Lemmas.lean
@@ -10,8 +10,7 @@ import Mathlib.Algebra.Order.Ring.Abs
 
 The distinction between this file and `Data.Int.Order.Basic` is not particularly clear.
 They are separated by now to minimize the porting requirements for tactics during the transition to
-mathlib4. Now that `Algebra.Order.Ring.Rat` has been ported, please feel free to reorganize these
-two files.
+mathlib4. Please feel free to reorganize these two files.
 -/
 
 open Function Nat

--- a/Mathlib/Data/Nat/Order/Lemmas.lean
+++ b/Mathlib/Data/Nat/Order/Lemmas.lean
@@ -11,11 +11,9 @@ import Mathlib.Data.Set.Basic
 # Further lemmas about the natural numbers
 
 The distinction between this file and `Mathlib.Algebra.Order.Ring.Nat` is not particularly clear.
-They are separated for now to minimize the porting requirements for tactics during the transition to
-mathlib4. After `Mathlib.Algebra.Order.Ring.Rat` has been ported,
-please feel free to reorganize these two files.
+They were separated for now to minimize the porting requirements for tactics
+during the transition to mathlib4. Please feel free to reorganize these two files.
 -/
-
 
 universe u v
 

--- a/Mathlib/RingTheory/Coprime/Basic.lean
+++ b/Mathlib/RingTheory/Coprime/Basic.lean
@@ -354,10 +354,7 @@ end CommRing
 theorem sq_add_sq_ne_zero {R : Type*} [LinearOrderedCommRing R] {a b : R} (h : IsCoprime a b) :
     a ^ 2 + b ^ 2 ≠ 0 := by
   intro h'
-  obtain ⟨ha, hb⟩ := (add_eq_zero_iff'
-  --Porting TODO: replace with sq_nonneg when that file is ported
-    (by rw [pow_two]; exact mul_self_nonneg _)
-    (by rw [pow_two]; exact mul_self_nonneg _)).mp h'
+  obtain ⟨ha, hb⟩ := (add_eq_zero_iff' (sq_nonneg _) (sq_nonneg _)).mp h'
   obtain rfl := pow_eq_zero ha
   obtain rfl := pow_eq_zero hb
   exact not_isCoprime_zero_zero h


### PR DESCRIPTION
---

Commits can be removed individually.
Found by auditing all occurrences of the word "ported".

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
