### PR TITLE
[Merged by Bors] - feat: the empty set is a smooth manifold

### DIFF
--- a/Mathlib/Geometry/Manifold/ChartedSpace.lean
+++ b/Mathlib/Geometry/Manifold/ChartedSpace.lean
@@ -576,6 +576,14 @@ lemma chart_mem_atlas (H : Type*) {M : Type*} [TopologicalSpace H] [TopologicalS
 
 section ChartedSpace
 
+/-- An empty type is a charted space over any topological space. -/
+def ChartedSpace.empty (H : Type*) [TopologicalSpace H]
+    (M : Type*) [TopologicalSpace M] [IsEmpty M] : ChartedSpace H M where
+  atlas := ∅
+  chartAt x := (IsEmpty.false x).elim
+  mem_chart_source x := (IsEmpty.false x).elim
+  chart_mem_atlas x := (IsEmpty.false x).elim
+
 /-- Any space is a `ChartedSpace` modelled over itself, by just using the identity chart. -/
 instance chartedSpaceSelf (H : Type*) [TopologicalSpace H] : ChartedSpace H H where
   atlas := {PartialHomeomorph.refl H}

--- a/Mathlib/Geometry/Manifold/InteriorBoundary.lean
+++ b/Mathlib/Geometry/Manifold/InteriorBoundary.lean
@@ -131,6 +131,10 @@ end Boundaryless
 section BoundarylessManifold
 variable [BoundarylessManifold I M]
 
+/-- The empty manifold is boundaryless. -/
+instance BoundarylessManifold.of_empty [IsEmpty M] : BoundarylessManifold I M where
+  isInteriorPoint' x := (IsEmpty.false x).elim
+
 lemma _root_.BoundarylessManifold.isInteriorPoint {x : M} :
     IsInteriorPoint I x := BoundarylessManifold.isInteriorPoint' x
 
@@ -141,6 +145,9 @@ lemma interior_eq_univ : I.interior M = univ :=
 /-- Boundaryless manifolds have empty boundary. -/
 lemma Boundaryless.boundary_eq_empty : I.boundary M = ∅ := by
   rw [I.boundary_eq_complement_interior, I.interior_eq_univ, compl_empty_iff]
+
+instance [BoundarylessManifold I M] : IsEmpty (I.boundary M) :=
+  isEmpty_coe_sort.mpr (Boundaryless.boundary_eq_empty I)
 
 end BoundarylessManifold
 end ModelWithCorners

--- a/Mathlib/Geometry/Manifold/SmoothManifoldWithCorners.lean
+++ b/Mathlib/Geometry/Manifold/SmoothManifoldWithCorners.lean
@@ -660,6 +660,24 @@ theorem compatible_of_mem_maximalAtlas {e e' : PartialHomeomorph M H} (he : e �
     (he' : e' ∈ maximalAtlas I M) : e.symm.trans e' ∈ contDiffGroupoid ∞ I :=
   StructureGroupoid.compatible_of_mem_maximalAtlas he he'
 
+/-- The empty set is a smooth manifold w.r.t. any charted space and model. -/
+instance empty [IsEmpty M] : SmoothManifoldWithCorners I M := by
+  apply smoothManifoldWithCorners_of_contDiffOn
+  intro e e' _ _ x hx
+  set t := I.symm ⁻¹' (e.symm ≫ₕ e').source ∩ range I
+  -- Since `M` is empty, the condition about compatibility of transition maps is vacuous.
+  have : (e.symm ≫ₕ e').source = ∅ := calc (e.symm ≫ₕ e').source
+    _ = (e.symm.source) ∩ e.symm ⁻¹' e'.source := by rw [← PartialHomeomorph.trans_source]
+    _ = (e.symm.source) ∩ e.symm ⁻¹' ∅ := by rw [eq_empty_of_isEmpty (e'.source)]
+    _ = (e.symm.source) ∩ ∅ := by rw [preimage_empty]
+    _ = ∅ := inter_empty e.symm.source
+  have : t = ∅ := calc t
+    _ = I.symm ⁻¹' (e.symm ≫ₕ e').source ∩ range I := by
+      rw [← Subtype.preimage_val_eq_preimage_val_iff]
+    _ = ∅ ∩ range I := by rw [this, preimage_empty]
+    _ = ∅ := empty_inter (range I)
+  apply (this ▸ hx).elim
+
 /-- The product of two smooth manifolds with corners is naturally a smooth manifold with corners. -/
 instance prod {𝕜 : Type*} [NontriviallyNormedField 𝕜] {E : Type*} [NormedAddCommGroup E]
     [NormedSpace 𝕜 E] {E' : Type*} [NormedAddCommGroup E'] [NormedSpace 𝕜 E'] {H : Type*}


### PR DESCRIPTION
- Prove that an empty type is a charted space
- An empty type is a smooth manifold over any pair (E, H)
- The empty manifold is boundaryless

Split out from my branch on bordism theory.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
