### PR TITLE
feat: define n-manifolds and closed manifolds

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -2581,6 +2581,7 @@ import Mathlib.Geometry.Manifold.Algebra.Structures
 import Mathlib.Geometry.Manifold.AnalyticManifold
 import Mathlib.Geometry.Manifold.BumpFunction
 import Mathlib.Geometry.Manifold.ChartedSpace
+import Mathlib.Geometry.Manifold.ClosedNManifold
 import Mathlib.Geometry.Manifold.Complex
 import Mathlib.Geometry.Manifold.ConformalGroupoid
 import Mathlib.Geometry.Manifold.ContMDiff.Atlas

--- a/Mathlib/Geometry/Manifold/ChartedSpace.lean
+++ b/Mathlib/Geometry/Manifold/ChartedSpace.lean
@@ -576,6 +576,14 @@ lemma chart_mem_atlas (H : Type*) {M : Type*} [TopologicalSpace H] [TopologicalS
 
 section ChartedSpace
 
+/-- An empty type is a charted space over any topological space. -/
+def ChartedSpace.empty (H : Type*) [TopologicalSpace H]
+    (M : Type*) [TopologicalSpace M] [IsEmpty M] : ChartedSpace H M where
+  atlas := ∅
+  chartAt x := (IsEmpty.false x).elim
+  mem_chart_source x := (IsEmpty.false x).elim
+  chart_mem_atlas x := (IsEmpty.false x).elim
+
 /-- Any space is a `ChartedSpace` modelled over itself, by just using the identity chart. -/
 instance chartedSpaceSelf (H : Type*) [TopologicalSpace H] : ChartedSpace H H where
   atlas := {PartialHomeomorph.refl H}

--- a/Mathlib/Geometry/Manifold/ClosedNManifold.lean
+++ b/Mathlib/Geometry/Manifold/ClosedNManifold.lean
@@ -1,0 +1,119 @@
+/-
+Copyright (c) 2024 Michael Rothgang. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Michael Rothgang
+-/
+import Mathlib.Geometry.Manifold.Instances.Real
+import Mathlib.Geometry.Manifold.Instances.Sphere
+import Mathlib.Geometry.Manifold.InteriorBoundary
+
+/-!
+# Closed `n`-dimensional manifolds
+
+We define closed `n`-dimensional manifolds and show a few basic properties.
+
+## Main definitions
+TODO add parameters!
+* `ClosedManifold M I`: a topological manifold `M` is closed if it is compact and boundaryless
+* `NManifold n M I`: an n-manifold is a smooth `n`-dimensional manifold `M`.
+* `ClosedNManifold n M I`: a closed n-manifold `M` is both closed and an `n`-manifold
+
+## Main results
+* `ClosedManifold.prod`: the product of closed manifolds is closed
+* `NManifold.prod`: the product of an `n`-manifold and an `m`-manifold is an `n+m`-manifold
+* `ClosedNManifold.prod`: the product of a closed `n`-manifold and a closed `m`-manifold is a closed
+`n+m`-manifold
+* We prove a few basic examples
+  - the empty set is closed and an `n`-manifold, for every `n` (TODO insert!)
+  - Euclidean n-space is an n-manifold
+  - the standard n-sphere is a closed n-manifold
+  - the standard two-torus `S¹ × S¹` is a closed 2-manifold
+
+TODO: wait for the product results to be merged! investigate why the spheres fail!
+
+-/
+
+open scoped Manifold
+open Metric (sphere)
+open FiniteDimensional Set
+
+noncomputable section
+
+variable (n : ℕ) {𝕜 : Type*} [NontriviallyNormedField 𝕜]
+  -- declare a smooth manifold `M` over the pair `(E, H)`.
+  {E : Type*} [NormedAddCommGroup E] [NormedSpace 𝕜 E] {H : Type*} [TopologicalSpace H]
+  (M : Type*) [TopologicalSpace M] [ChartedSpace H M]
+  (I : ModelWithCorners 𝕜 E H) [SmoothManifoldWithCorners I M]
+
+/-- A topological manifold is called **closed** iff it is compact without boundary. -/
+structure ClosedManifold [CompactSpace M] [BoundarylessManifold I M]
+
+variable {E' : Type*} [NormedAddCommGroup E'] [NormedSpace 𝕜 E']
+  {H' : Type*} [TopologicalSpace H'] (N : Type*) [TopologicalSpace N] [ChartedSpace H' N]
+  (J : ModelWithCorners 𝕜 E' H') [SmoothManifoldWithCorners J N]
+
+-- instance ClosedManifold.prod [CompactSpace M] [BoundarylessManifold I M]
+--     [CompactSpace N] [BoundarylessManifold J N] :
+--   ClosedManifold (M × N) (I.prod J) where
+
+/-- An **n-manifold** is a smooth `n`-dimensional manifold. -/
+structure NManifold [NormedAddCommGroup E]  [NormedSpace 𝕜 E] [FiniteDimensional 𝕜 E]
+    {H : Type*} [TopologicalSpace H] (M : Type*) [TopologicalSpace M] [ChartedSpace H M]
+    (I : ModelWithCorners 𝕜 E H) [SmoothManifoldWithCorners I M] where
+  hdim : finrank 𝕜 E = n
+
+/-- The product of an `n`- and and an `m`-manifold is an `n+m`-manifold. -/
+instance NManifold.prod {m n : ℕ} [FiniteDimensional 𝕜 E] [FiniteDimensional 𝕜 E']
+    (s : NManifold m M I) (t : NManifold n N J) : NManifold (m + n) (M × N) (I.prod J) where
+  hdim := by rw [s.hdim.symm, t.hdim.symm]; apply finrank_prod
+
+structure ClosedNManifold [CompactSpace M] [BoundarylessManifold I M] [FiniteDimensional 𝕜 E]
+    extends NManifold n M I
+
+instance ClosedNManifold.ClosedManifold [CompactSpace M] [BoundarylessManifold I M] [FiniteDimensional 𝕜 E] :
+  ClosedManifold M I where
+
+variable {n}
+
+-- /-- The product of a closed `n`- and a closed closed `m`-manifold is a closed `n+m`-manifold. -/
+-- instance ClosedNManifold.prod {m n : ℕ} [FiniteDimensional 𝕜 E] [FiniteDimensional 𝕜 E']
+--     [CompactSpace M] [BoundarylessManifold I M] [CompactSpace N] [BoundarylessManifold J N]
+--     (s : ClosedNManifold m M I) (t : ClosedNManifold n N J) :
+--     ClosedNManifold (m + n) (M × N) (I.prod J) where
+--   -- TODO: can I inherit this from `NManifold.prod`?
+--   hdim := by rw [s.hdim.symm, t.hdim.symm]; apply finrank_prod
+
+section examples
+
+-- Let `E` be a finite-dimensional real normed space.
+variable {E : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E]
+
+-- TODO: move the empty manifold here, once its definition is in a separate file
+
+/- TODO: these two examples worked when ClosedManifold only demanded `I.Boundaryless`;
+-- diagnose and fix this!
+/-- The standard `n`-sphere is a closed manifold. -/
+example {n : ℕ} [FiniteDimensional ℝ E] [Fact (finrank ℝ E = n + 1)] :
+  ClosedManifold (sphere (0 : E) 1) (𝓡 n) where
+/-- The standard `2`-torus is a closed manifold. -/
+example [FiniteDimensional ℝ E] [Fact (finrank ℝ E = 1 + 1)] :
+    ClosedManifold ((sphere (0 : E) 1) × (sphere (0 : E) 1)) ((𝓡 2).prod (𝓡 2)) where
+-/
+
+-- The standard Euclidean space is an `n`-manifold. -/
+example {n : ℕ} {M : Type*} [TopologicalSpace M] [ChartedSpace (EuclideanSpace ℝ (Fin n)) M]
+    [SmoothManifoldWithCorners (𝓡 n) M] : NManifold n M (𝓡 n) where
+  hdim := finrank_euclideanSpace_fin
+
+variable {F : Type*} [NormedAddCommGroup F] [InnerProductSpace ℝ F] [FiniteDimensional ℝ F]
+
+/-- The standard `n`-sphere is a closed `n`-manifold. -/
+example {n : ℕ} [Fact (finrank ℝ F = n + 1)] : ClosedNManifold n (sphere (0 : F) 1) (𝓡 n) where
+  hdim := finrank_euclideanSpace_fin
+
+/-- The standard 2-torus is a closed two-manifold. -/
+example [Fact (finrank ℝ F = 1 + 1)] :
+    ClosedNManifold 2 ((sphere (0 : F) 1) × (sphere (0 : F) 1)) ((𝓡 1).prod (𝓡 1)) where
+  hdim := by rw [finrank_prod, finrank_euclideanSpace_fin]
+
+end examples

--- a/Mathlib/Geometry/Manifold/ClosedNManifold.lean
+++ b/Mathlib/Geometry/Manifold/ClosedNManifold.lean
@@ -13,7 +13,6 @@ import Mathlib.Geometry.Manifold.InteriorBoundary
 We define closed `n`-dimensional manifolds and show a few basic properties.
 
 ## Main definitions
-TODO add parameters!
 * `ClosedManifold M I`: a topological manifold `M` is closed if it is compact and boundaryless
 * `NManifold n M I`: an n-manifold is a smooth `n`-dimensional manifold `M`.
 * `ClosedNManifold n M I`: a closed n-manifold `M` is both closed and an `n`-manifold
@@ -29,8 +28,7 @@ TODO add parameters!
   - the standard n-sphere is a closed n-manifold
   - the standard two-torus `S¹ × S¹` is a closed 2-manifold
 
-TODO: wait for the product results to be merged! investigate why the spheres fail!
-
+TODO: investigate why the spheres fail!
 -/
 
 open scoped Manifold
@@ -52,9 +50,9 @@ variable {E' : Type*} [NormedAddCommGroup E'] [NormedSpace 𝕜 E']
   {H' : Type*} [TopologicalSpace H'] (N : Type*) [TopologicalSpace N] [ChartedSpace H' N]
   (J : ModelWithCorners 𝕜 E' H') [SmoothManifoldWithCorners J N]
 
--- instance ClosedManifold.prod [CompactSpace M] [BoundarylessManifold I M]
---     [CompactSpace N] [BoundarylessManifold J N] :
---   ClosedManifold (M × N) (I.prod J) where
+instance ClosedManifold.prod [CompactSpace M] [BoundarylessManifold I M]
+    [CompactSpace N] [BoundarylessManifold J N] :
+  ClosedManifold (M × N) (I.prod J) where
 
 /-- An **n-manifold** is a smooth `n`-dimensional manifold. -/
 structure NManifold [NormedAddCommGroup E]  [NormedSpace 𝕜 E] [FiniteDimensional 𝕜 E]
@@ -68,33 +66,41 @@ instance NManifold.prod {m n : ℕ} [FiniteDimensional 𝕜 E] [FiniteDimensiona
   hdim := by rw [s.hdim.symm, t.hdim.symm]; apply finrank_prod
 
 structure ClosedNManifold [CompactSpace M] [BoundarylessManifold I M] [FiniteDimensional 𝕜 E]
-    extends NManifold n M I
+  extends NManifold n M I
 
-instance ClosedNManifold.ClosedManifold [CompactSpace M] [BoundarylessManifold I M] [FiniteDimensional 𝕜 E] :
-  ClosedManifold M I where
+instance ClosedNManifold.ClosedManifold [CompactSpace M] [BoundarylessManifold I M]
+  [FiniteDimensional 𝕜 E] : ClosedManifold M I where
 
 variable {n}
 
--- /-- The product of a closed `n`- and a closed closed `m`-manifold is a closed `n+m`-manifold. -/
--- instance ClosedNManifold.prod {m n : ℕ} [FiniteDimensional 𝕜 E] [FiniteDimensional 𝕜 E']
---     [CompactSpace M] [BoundarylessManifold I M] [CompactSpace N] [BoundarylessManifold J N]
---     (s : ClosedNManifold m M I) (t : ClosedNManifold n N J) :
---     ClosedNManifold (m + n) (M × N) (I.prod J) where
---   -- TODO: can I inherit this from `NManifold.prod`?
---   hdim := by rw [s.hdim.symm, t.hdim.symm]; apply finrank_prod
+/-- The product of a closed `n`- and a closed closed `m`-manifold is a closed `n+m`-manifold. -/
+instance ClosedNManifold.prod {m n : ℕ} [FiniteDimensional 𝕜 E] [FiniteDimensional 𝕜 E']
+    [CompactSpace M] [BoundarylessManifold I M] [CompactSpace N] [BoundarylessManifold J N]
+    (s : ClosedNManifold m M I) (t : ClosedNManifold n N J) :
+    ClosedNManifold (m + n) (M × N) (I.prod J) where
+  -- TODO: can I inherit this from `NManifold.prod`?
+  hdim := by rw [s.hdim.symm, t.hdim.symm]; apply finrank_prod
 
 section examples
 
+/-- The empty manifold is closed. -/
+instance [IsEmpty M] : ClosedManifold M I where
+
+-- The empty manifold, modelled on an `n`-dimensional space, is a closed `n`-manifold.
+-- FIXME: is requiring the model space to be n-dimensional the right design decision?
+instance {n : ℕ} [FiniteDimensional 𝕜 E] (h : finrank 𝕜 E = n) [IsEmpty M] :
+    ClosedNManifold n M I where
+  hdim := h
+
 -- Let `E` be a finite-dimensional real normed space.
 variable {E : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E]
-
--- TODO: move the empty manifold here, once its definition is in a separate file
 
 /- TODO: these two examples worked when ClosedManifold only demanded `I.Boundaryless`;
 -- diagnose and fix this!
 /-- The standard `n`-sphere is a closed manifold. -/
 example {n : ℕ} [FiniteDimensional ℝ E] [Fact (finrank ℝ E = n + 1)] :
   ClosedManifold (sphere (0 : E) 1) (𝓡 n) where
+
 /-- The standard `2`-torus is a closed manifold. -/
 example [FiniteDimensional ℝ E] [Fact (finrank ℝ E = 1 + 1)] :
     ClosedManifold ((sphere (0 : E) 1) × (sphere (0 : E) 1)) ((𝓡 2).prod (𝓡 2)) where

--- a/Mathlib/Geometry/Manifold/InteriorBoundary.lean
+++ b/Mathlib/Geometry/Manifold/InteriorBoundary.lean
@@ -21,10 +21,12 @@ Define the interior and boundary of a manifold.
 - `ModelWithCorners.univ_eq_interior_union_boundary`: `M` is the union of its interior and boundary
 - `ModelWithCorners.interior_boundary_disjoint`: interior and boundary of `M` are disjoint
 - `BoundarylessManifold.isInteriorPoint`: if `M` is boundaryless, every point is an interior point
-
+- `ModelWithCorners.Boundaryless.{boundary_eq_empty, of_boundary_eq_empty}`:
+`M` is boundaryless if and only if its boundary is empty
 - `ModelWithCorners.interior_prod`: the interior of `M × N` is the product of the interiors
 of `M` and `N`.
 - `ModelWithCorners.boundary_prod`: the boundary of `M × N` is `∂M × N ∪ (M × ∂N)`.
+- `ModelWithCorners.BoundarylessManifold.prod`: if `M` and `N` are boundaryless, so is `M × N`
 
 ## Tags
 manifold, interior, boundary
@@ -123,36 +125,42 @@ instance : BoundarylessManifold I M where
     let r := ((chartAt H x).isOpen_extend_target I).interior_eq
     have : extChartAt I x = (chartAt H x).extend I := rfl
     rw [← this] at r
-    rw [ModelWithCorners.isInteriorPoint_iff, r]
+    rw [isInteriorPoint_iff, r]
     exact PartialEquiv.map_source _ (mem_extChartAt_source _ _)
 
 end Boundaryless
 
 section BoundarylessManifold
-variable [BoundarylessManifold I M]
 
 /-- The empty manifold is boundaryless. -/
 instance BoundarylessManifold.of_empty [IsEmpty M] : BoundarylessManifold I M where
   isInteriorPoint' x := (IsEmpty.false x).elim
 
-lemma _root_.BoundarylessManifold.isInteriorPoint {x : M} :
+lemma _root_.BoundarylessManifold.isInteriorPoint {x : M} [BoundarylessManifold I M] :
     IsInteriorPoint I x := BoundarylessManifold.isInteriorPoint' x
 
 /-- If `I` is boundaryless, `M` has full interior. -/
-lemma interior_eq_univ : I.interior M = univ :=
+lemma interior_eq_univ [BoundarylessManifold I M] : I.interior M = univ :=
   eq_univ_of_forall fun _ => BoundarylessManifold.isInteriorPoint I
 
 /-- Boundaryless manifolds have empty boundary. -/
-lemma Boundaryless.boundary_eq_empty : I.boundary M = ∅ := by
+lemma Boundaryless.boundary_eq_empty [BoundarylessManifold I M] : I.boundary M = ∅ := by
   rw [I.boundary_eq_complement_interior, I.interior_eq_univ, compl_empty_iff]
 
 instance [BoundarylessManifold I M] : IsEmpty (I.boundary M) :=
   isEmpty_coe_sort.mpr (Boundaryless.boundary_eq_empty I)
 
-end BoundarylessManifold
-end ModelWithCorners
+/-- Manifolds with empty boundary are boundaryless. -/
+lemma Boundaryless.of_boundary_eq_empty (h : I.boundary M = ∅) : BoundarylessManifold I M where
+  isInteriorPoint' x := by
+    show x ∈ I.interior M
+    rw [boundary_eq_complement_interior, compl_empty_iff] at h
+    rw [h]
+    trivial
 
--- Interior and boundary of the product of two manifolds.
+end BoundarylessManifold
+
+/-! Interior and boundary of the product of two manifolds. -/
 section prod
 
 variable {I}
@@ -162,43 +170,53 @@ variable {I}
   (J : ModelWithCorners 𝕜 E' H') [SmoothManifoldWithCorners J N] {x : M} {y : N}
 
 /-- The interior of `M × N` is the product of the interiors of `M` and `N`. -/
-lemma ModelWithCorners.interior_prod :
+lemma interior_prod :
     (I.prod J).interior (M × N) = (I.interior M) ×ˢ (J.interior N) := by
   ext p
   have aux : (interior (range ↑I)) ×ˢ (interior (range J)) = interior (range (I.prod J)) := by
     rw [← interior_prod_eq, ← Set.range_prod_map, modelWithCorners_prod_coe]
   constructor <;> intro hp
   · replace hp : (I.prod J).IsInteriorPoint p := hp
-    rw [ModelWithCorners.IsInteriorPoint, ← aux] at hp
+    rw [IsInteriorPoint, ← aux] at hp
     exact hp
   · obtain ⟨h₁, h₂⟩ := Set.mem_prod.mp hp
     rw [ModelWithCorners.interior] at h₁ h₂
     show (I.prod J).IsInteriorPoint p
-    rw [ModelWithCorners.IsInteriorPoint, ← aux]
+    rw [IsInteriorPoint, ← aux]
     apply mem_prod.mpr; constructor; exacts [h₁, h₂]
 
 /-- The boundary of `M × N` is `∂M × N ∪ (M × ∂N)`. -/
-lemma ModelWithCorners.boundary_prod :
+lemma boundary_prod :
     (I.prod J).boundary (M × N) = Set.prod univ (J.boundary N) ∪ Set.prod (I.boundary M) univ := by
   let h := calc (I.prod J).boundary (M × N)
     _ = ((I.prod J).interior (M × N))ᶜ := (I.prod J).boundary_eq_complement_interior
-    _ = ((I.interior M) ×ˢ (J.interior N))ᶜ := by rw [ModelWithCorners.interior_prod]
+    _ = ((I.interior M) ×ˢ (J.interior N))ᶜ := by rw [interior_prod]
     _ = (I.interior M)ᶜ ×ˢ univ ∪ univ ×ˢ (J.interior N)ᶜ := by rw [compl_prod_eq_union]
   rw [h, I.boundary_eq_complement_interior, J.boundary_eq_complement_interior, union_comm]
   rfl
 
 /-- If `M` is boundaryless, `∂(M×N) = M × ∂N`. -/
-lemma boundary_of_boundaryless_left [I.Boundaryless] :
+lemma boundary_of_boundaryless_left [BoundarylessManifold I M] :
     (I.prod J).boundary (M × N) = Set.prod (univ : Set M) (J.boundary N) := by
-  rw [ModelWithCorners.boundary_prod, ModelWithCorners.Boundaryless.boundary_eq_empty I]
+  rw [boundary_prod, Boundaryless.boundary_eq_empty I]
   have : Set.prod (∅ : Set M) (univ : Set N) = ∅ := Set.empty_prod
   rw [this, union_empty]
 
 /-- If `N` is boundaryless, `∂(M×N) = ∂M × N`. -/
-lemma boundary_of_boundaryless_right [J.Boundaryless] :
+lemma boundary_of_boundaryless_right [BoundarylessManifold J N] :
     (I.prod J).boundary (M × N) = Set.prod (I.boundary M) (univ : Set N) := by
-  rw [ModelWithCorners.boundary_prod, ModelWithCorners.Boundaryless.boundary_eq_empty J]
+  rw [boundary_prod, Boundaryless.boundary_eq_empty J]
   have : Set.prod (univ : Set M) (∅ : Set N) = ∅ := Set.prod_empty
   rw [this, empty_union]
 
+/-- The product of two boundaryless manifolds is boundaryless. -/
+instance BoundarylessManifold.prod [BoundarylessManifold I M] [BoundarylessManifold J N] :
+    BoundarylessManifold (I.prod J) (M × N) := by
+  apply Boundaryless.of_boundary_eq_empty
+  rw [boundary_of_boundaryless_left, Boundaryless.boundary_eq_empty]
+  have : Set.prod (univ : Set M) (∅ : Set N) = ∅ := Set.prod_empty
+  rw [this]
+
 end prod
+
+end ModelWithCorners

--- a/Mathlib/Geometry/Manifold/InteriorBoundary.lean
+++ b/Mathlib/Geometry/Manifold/InteriorBoundary.lean
@@ -131,6 +131,10 @@ end Boundaryless
 section BoundarylessManifold
 variable [BoundarylessManifold I M]
 
+/-- The empty manifold is boundaryless. -/
+instance BoundarylessManifold.of_empty [IsEmpty M] : BoundarylessManifold I M where
+  isInteriorPoint' x := (IsEmpty.false x).elim
+
 lemma _root_.BoundarylessManifold.isInteriorPoint {x : M} :
     IsInteriorPoint I x := BoundarylessManifold.isInteriorPoint' x
 
@@ -141,6 +145,9 @@ lemma interior_eq_univ : I.interior M = univ :=
 /-- Boundaryless manifolds have empty boundary. -/
 lemma Boundaryless.boundary_eq_empty : I.boundary M = ∅ := by
   rw [I.boundary_eq_complement_interior, I.interior_eq_univ, compl_empty_iff]
+
+instance [BoundarylessManifold I M] : IsEmpty (I.boundary M) :=
+  isEmpty_coe_sort.mpr (Boundaryless.boundary_eq_empty I)
 
 end BoundarylessManifold
 end ModelWithCorners

--- a/Mathlib/Geometry/Manifold/SmoothManifoldWithCorners.lean
+++ b/Mathlib/Geometry/Manifold/SmoothManifoldWithCorners.lean
@@ -660,6 +660,24 @@ theorem compatible_of_mem_maximalAtlas {e e' : PartialHomeomorph M H} (he : e �
     (he' : e' ∈ maximalAtlas I M) : e.symm.trans e' ∈ contDiffGroupoid ∞ I :=
   StructureGroupoid.compatible_of_mem_maximalAtlas he he'
 
+/-- The empty set is a smooth manifold w.r.t. any charted space and model. -/
+instance empty [IsEmpty M] : SmoothManifoldWithCorners I M := by
+  apply smoothManifoldWithCorners_of_contDiffOn
+  intro e e' _ _ x hx
+  set t := I.symm ⁻¹' (e.symm ≫ₕ e').source ∩ range I
+  -- Since `M` is empty, the condition about compatibility of transition maps is vacuous.
+  have : (e.symm ≫ₕ e').source = ∅ := calc (e.symm ≫ₕ e').source
+    _ = (e.symm.source) ∩ e.symm ⁻¹' e'.source := by rw [← PartialHomeomorph.trans_source]
+    _ = (e.symm.source) ∩ e.symm ⁻¹' ∅ := by rw [eq_empty_of_isEmpty (e'.source)]
+    _ = (e.symm.source) ∩ ∅ := by rw [preimage_empty]
+    _ = ∅ := inter_empty e.symm.source
+  have : t = ∅ := calc t
+    _ = I.symm ⁻¹' (e.symm ≫ₕ e').source ∩ range I := by
+      rw [← Subtype.preimage_val_eq_preimage_val_iff]
+    _ = ∅ ∩ range I := by rw [this, preimage_empty]
+    _ = ∅ := empty_inter (range I)
+  apply (this ▸ hx).elim
+
 /-- The product of two smooth manifolds with corners is naturally a smooth manifold with corners. -/
 instance prod {𝕜 : Type*} [NontriviallyNormedField 𝕜] {E : Type*} [NormedAddCommGroup E]
     [NormedSpace 𝕜 E] {E' : Type*} [NormedAddCommGroup E'] [NormedSpace 𝕜 E'] {H : Type*}


### PR DESCRIPTION
Define structures `NManifold` and `ClosedManifold` for n-dimensional resp. closed smooth manifolds (i.e., compact without boundary). These are useful in their own right, and needed to state the basic definitions in bordism theory.

To show these definitions are workable, we state some standard examples:
- Euclidean space is an n-manifold
- the n-sphere is a closed n-manifold
- the two-torus is a closed 2-manifold

Defining n-manifolds posed a design question, whether to have the n-dimensionality as a typeclass assumption or a proof-valued field. The former could avoid unnecessary boilerplate, say when the dimension is ambient and always fixed. However, encoding the dimension in a typeclass is inflexible for dimension-changing constructions. Three examples:
- The product of an n- and an m-manifold is an n+m-manifold: I would prefer that a 2+3 and a 4+1-manifold are the same as a 5-manifold; the typeclass system and addition don't mix well.
- Bordism theory requires such equalities: a cobordism between two 4-manifolds is a certain 5-manifold; the general definition would state this as a 4+1-manifold, which needs to be unified with 5.
- Surgery between manifolds involves k-handles, the product of a k- and an n-k-manifold (for all k): this uses quite extensively that n=k+(n-k) for all k.

For these reasons, I have decided for the latter option.

I am open to also defining a class IsNManifold and adding an instance SmoothNManifold -> IsNManifold.


---

- [ ] depends on: #14972
- [ ] depends on: #14974

Bikeshedding welcome: what is the best order of arguments for n-manifolds and closed n-manifolds?
Right now, I've chosen `NManifold n M I`, but could also be convinced that `NManifold M I n` or some other permutation is better.


<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
