### PR TITLE
feat(Combinatorics/SimpleGraph/Subgraph): Definition of symmDiff and simp lemmas

### DIFF
--- a/Mathlib/Combinatorics/SimpleGraph/Subgraph.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Subgraph.lean
@@ -1169,14 +1169,17 @@ def symmDiff : Subgraph G := {
 lemma symmDiff_verts : (H.symmDiff H').verts = H.verts ∪ H'.verts := by rfl
 
 @[simp]
-lemma symmDiff_adj : (H.symmDiff H').Adj v w = ((¬H.Adj v w ∧ H'.Adj v w) ∨ (H.Adj v w ∧ ¬H'.Adj v w)) := rfl
+lemma symmDiff_adj : (H.symmDiff H').Adj v w = ((¬H.Adj v w ∧ H'.Adj v w) ∨
+    (H.Adj v w ∧ ¬H'.Adj v w)) := rfl
 
 lemma symmDiff_adj_comm : (H.symmDiff H').Adj v w = (H.symmDiff H').Adj v w := by
   simp only [symmDiff_adj, eq_iff_iff]
 
 @[simp]
-lemma symmDiff_singletonSubgraph_adj : (H.symmDiff (G.singletonSubgraph u)).Adj v w = H.Adj v w := by
-  simp [singletonSubgraph_adj, Pi.bot_apply, eq_iff_iff, Prop.bot_eq_false]
+lemma symmDiff_singletonSubgraph_adj : (H.symmDiff (G.singletonSubgraph u)).Adj v w
+    = H.Adj v w := by
+  simp only [symmDiff_adj, singletonSubgraph_adj, Pi.bot_apply, Prop.bot_eq_false, and_false,
+    not_false_eq_true, and_true, false_or]
 
 end SymmDiff
 

--- a/Mathlib/Combinatorics/SimpleGraph/Subgraph.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Subgraph.lean
@@ -1144,6 +1144,42 @@ theorem deleteVerts_inter_verts_set_right_eq :
 
 end DeleteVerts
 
+section SymmDiff
+
+variable {u v w : V} (H H': Subgraph G)
+
+/-- The symmetric difference of two subgraphs. An edge is in the resulting graph iff it is in
+exactly one of the operands. -/
+def symmDiff : Subgraph G := {
+  verts := H.verts ∪ H'.verts,
+  Adj := fun v w ↦ (¬ H.Adj v w ∧ H'.Adj v w) ∨ (H.Adj v w ∧ ¬ H'.Adj v w),
+  adj_sub := fun hvw ↦ by
+    cases hvw <;> next h1 => simp only [h1.1, h1.2, H'.adj_sub, H.adj_sub]
+  edge_vert := fun hvw ↦ by
+    cases hvw
+    next h1 => right; exact H'.support_subset_verts (H'.mem_support.mpr ⟨_, h1.2⟩)
+    next h2 => left; exact H.support_subset_verts (H.mem_support.mpr ⟨_, h2.1⟩)
+  symm := fun _ _ hvw ↦ by
+    cases hvw
+    next h1 => left; exact ⟨fun h ↦ h1.1 h.symm, h1.2.symm⟩
+    next h2 => right; exact ⟨h2.1.symm, fun h ↦ h2.2 h.symm⟩
+  }
+
+@[simp]
+lemma symmDiff_verts : (H.symmDiff H').verts = H.verts ∪ H'.verts := by rfl
+
+@[simp]
+lemma symmDiff_adj : (H.symmDiff H').Adj v w = ((¬H.Adj v w ∧ H'.Adj v w) ∨ (H.Adj v w ∧ ¬H'.Adj v w)) := rfl
+
+lemma symmDiff_adj_comm : (H.symmDiff H').Adj v w = (H.symmDiff H').Adj v w := by
+  simp only [symmDiff_adj, eq_iff_iff]
+
+@[simp]
+lemma symmDiff_singletonSubgraph_adj : (H.symmDiff (G.singletonSubgraph u)).Adj v w = H.Adj v w := by
+  simp [singletonSubgraph_adj, Pi.bot_apply, eq_iff_iff, Prop.bot_eq_false]
+
+end SymmDiff
+
 end Subgraph
 
 end SimpleGraph

--- a/Mathlib/Combinatorics/SimpleGraph/Subgraph.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Subgraph.lean
@@ -1172,10 +1172,9 @@ lemma symmDiff_verts : (H.symmDiff H').verts = H.verts ∪ H'.verts := by rfl
 lemma symmDiff_adj : (H.symmDiff H').Adj v w = ((¬H.Adj v w ∧ H'.Adj v w) ∨
     (H.Adj v w ∧ ¬H'.Adj v w)) := rfl
 
-lemma symmDiff_adj_comm : (H.symmDiff H').Adj v w = (H.symmDiff H').Adj v w := by
-  simp only [symmDiff_adj, eq_iff_iff]
+lemma symmDiff_adj_comm : (H.symmDiff H').Adj v w = (H'.symmDiff H).Adj v w := by
+  unfold symmDiff; simp only [eq_iff_iff]; tauto
 
-@[simp]
 lemma symmDiff_singletonSubgraph_adj : (H.symmDiff (G.singletonSubgraph u)).Adj v w
     = H.Adj v w := by
   simp only [symmDiff_adj, singletonSubgraph_adj, Pi.bot_apply, Prop.bot_eq_false, and_false,


### PR DESCRIPTION
Introduces the symmetrics difference on subgraphs. 
In preparation for Tutte's theorem. 


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
