### PR TITLE
[Merged by Bors] - docs: add info about `#min_imports in`

### DIFF
--- a/Mathlib/Tactic/MinImports.lean
+++ b/Mathlib/Tactic/MinImports.lean
@@ -36,11 +36,17 @@ inductive Rel (α : Type) : α × α → α × α → Prop
 
 ## Todo
 
+*Examples*
 When parsing an `example`, `#min_imports in` retrieves all the information that it can from the
 `Syntax` of the `example`, but, since the `example` is not added to the environment, it fails
 to retrieve any `Expr` information about the proof term.
 It would be desirable to make `#min_imports in example ...` inspect the resulting proof and
 report imports, but this feature is missing for the moment.
+
+*Using `InfoTrees`*
+It may be more efficient (not necessarily in terms of speed, but of simplicity of code),
+to inspect the `InfoTrees` for each command and retrieve information from there.
+I have not looked into this yet.
 -/
 
 open Lean Elab Command

--- a/Mathlib/Tactic/MinImports.lean
+++ b/Mathlib/Tactic/MinImports.lean
@@ -13,6 +13,34 @@ If `stx` is a command, then it also elaborates `stx` and, in case it is a declar
 it also finds the imports implied by the declaration.
 
 Unlike the related `#find_home`, this command takes into account notation and tactic information.
+
+## Limitations
+
+Parsing of `attribute`s is hard and the command makes minimal effort to support them.
+Here is an example where the command fails to notice a dependency:
+```lean
+import Mathlib.Data.Sym.Sym2.Init -- the actual minimal import
+import Aesop.Frontend.Attribute   -- the import that `#min_imports in` suggests
+
+import Mathlib.Tactic.MinImports
+
+-- import Aesop.Frontend.Attribute
+#min_imports in
+@[aesop (rule_sets := [Sym2]) [safe [constructors, cases], norm]]
+inductive Rel (α : Type) : α × α → α × α → Prop
+  | refl (x y : α) : Rel _ (x, y) (x, y)
+  | swap (x y : α) : Rel _ (x, y) (y, x)
+
+-- `import Mathlib.Data.Sym.Sym2.Init` is not detected by `#min_imports in`.
+```
+
+## Todo
+
+When parsing an `example`, `#min_imports in` retrieves all the information that it can from the
+`Syntax` of the `example`, but, since the `example` is not added to the environment, it fails
+to retrieve any `Expr` information about the proof term.
+It would be desirable to make `#min_imports in example ...` inspect the resulting proof and
+report imports, but this feature is missing for the moment.
 -/
 
 open Lean Elab Command


### PR DESCRIPTION
Just adding some known limitations and future plans for `#min_imports in`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
