### PR TITLE
[Merged by Bors] - fix: reformulate the message when there are too many files to display

### DIFF
--- a/scripts/import_trans_difference.sh
+++ b/scripts/import_trans_difference.sh
@@ -64,7 +64,7 @@ printf '\n\n<details><summary>Import changes for all files</summary>\n\n%s\n\n</
         reds[diff[fil]]=reds[diff[fil]]" `"fil"`"
       }
     }
-    if (200 <= con) { printf("Too many changes (%s)!\n", con) } else {
+    if (200 <= con) { printf("There are %s files with changed transitive imports: this is too many to display!\n", con) } else {
       for(x in reds) {
         if (nums[x] <= 2) { printf("|%s|%s|\n", reds[x], x) }
         else { printf("|<details><summary>%s files</summary>%s</details>|%s|\n", nums[x], reds[x], x) }


### PR DESCRIPTION
The new message should make it clear that the import changes are not displayed because they are too many, not that the PR should be rejected because of this!

Reported in #14471.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
