### PR TITLE
[Merged by Bors] - chore: generalize tower instances for Module.End

### DIFF
--- a/Mathlib/Algebra/Algebra/Equiv.lean
+++ b/Mathlib/Algebra/Algebra/Equiv.lean
@@ -668,11 +668,13 @@ protected theorem smul_def (f : A₁ ≃ₐ[R] A₁) (a : A₁) : f • a = f a 
 instance apply_faithfulSMul : FaithfulSMul (A₁ ≃ₐ[R] A₁) A₁ :=
   ⟨AlgEquiv.ext⟩
 
-instance apply_smulCommClass : SMulCommClass R (A₁ ≃ₐ[R] A₁) A₁ where
-  smul_comm r e a := (map_smul e r a).symm
+instance apply_smulCommClass {S} [SMul S R] [SMul S A₁] [IsScalarTower S R A₁] :
+    SMulCommClass S (A₁ ≃ₐ[R] A₁) A₁ where
+  smul_comm r e a := (e.toLinearEquiv.map_smul_of_tower r a).symm
 
-instance apply_smulCommClass' : SMulCommClass (A₁ ≃ₐ[R] A₁) R A₁ where
-  smul_comm e r a := map_smul e r a
+instance apply_smulCommClass' {S} [SMul S R] [SMul S A₁] [IsScalarTower S R A₁] :
+    SMulCommClass (A₁ ≃ₐ[R] A₁) S A₁ :=
+  SMulCommClass.symm _ _ _
 
 instance : MulDistribMulAction (A₁ ≃ₐ[R] A₁) A₁ˣ where
   smul := fun f => Units.map f

--- a/Mathlib/Algebra/Module/Equiv/Basic.lean
+++ b/Mathlib/Algebra/Module/Equiv/Basic.lean
@@ -124,11 +124,13 @@ protected theorem smul_def (f : M ≃ₗ[R] M) (a : M) : f • a = f a :=
 instance apply_faithfulSMul : FaithfulSMul (M ≃ₗ[R] M) M :=
   ⟨@fun _ _ => LinearEquiv.ext⟩
 
-instance apply_smulCommClass : SMulCommClass R (M ≃ₗ[R] M) M where
-  smul_comm r e m := (e.map_smul r m).symm
+instance apply_smulCommClass [SMul S R] [SMul S M] [IsScalarTower S R M] :
+    SMulCommClass S (M ≃ₗ[R] M) M where
+  smul_comm r e m := (e.map_smul_of_tower r m).symm
 
-instance apply_smulCommClass' : SMulCommClass (M ≃ₗ[R] M) R M where
-  smul_comm := LinearEquiv.map_smul
+instance apply_smulCommClass' [SMul S R] [SMul S M] [IsScalarTower S R M] :
+    SMulCommClass (M ≃ₗ[R] M) S M :=
+  SMulCommClass.symm _ _ _
 
 end Automorphisms
 

--- a/Mathlib/Algebra/Module/LinearMap/End.lean
+++ b/Mathlib/Algebra/Module/LinearMap/End.lean
@@ -204,14 +204,16 @@ protected theorem smul_def (f : Module.End R M) (a : M) : f • a = f a :=
 instance apply_faithfulSMul : FaithfulSMul (Module.End R M) M :=
   ⟨LinearMap.ext⟩
 
-instance apply_smulCommClass : SMulCommClass R (Module.End R M) M where
-  smul_comm r e m := (e.map_smul r m).symm
+instance apply_smulCommClass [SMul S R] [SMul S M] [IsScalarTower S R M] :
+    SMulCommClass S (Module.End R M) M where
+  smul_comm r e m := (e.map_smul_of_tower r m).symm
 
-instance apply_smulCommClass' : SMulCommClass (Module.End R M) R M where
-  smul_comm := LinearMap.map_smul
+instance apply_smulCommClass' [SMul S R] [SMul S M] [IsScalarTower S R M] :
+    SMulCommClass (Module.End R M) S M :=
+  SMulCommClass.symm _ _ _
 
-instance apply_isScalarTower {R M : Type*} [CommSemiring R] [AddCommMonoid M] [Module R M] :
-    IsScalarTower R (Module.End R M) M :=
+instance apply_isScalarTower [Monoid S] [DistribMulAction S M] [SMulCommClass R S M] :
+    IsScalarTower S (Module.End R M) M :=
   ⟨fun _ _ _ ↦ rfl⟩
 
 end Endomorphisms


### PR DESCRIPTION
This now matches the generality of `Module.End.instAlgebra`, meaning that the generality is available to `M/R/S` not just `A/R/S`.

[Context](https://leanprover.zulipchat.com/#narrow/stream/217875-Is-there-code-for-X.3F/topic/Quadratic.20forms.20with.20values.20in.20a.20larger.20ring/near/452999484) on Zulip.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
