### PR TITLE
[Merged by Bors] - refactor(AlgebraicGeometry): Introduce `HasRingHomProperty`.

### DIFF
--- a/Mathlib/AlgebraicGeometry/Morphisms/Basic.lean
+++ b/Mathlib/AlgebraicGeometry/Morphisms/Basic.lean
@@ -582,6 +582,16 @@ theorem stableUnderBaseChange (hP' : Q.StableUnderBaseChange) :
       rw [← pullbackSymmetry_hom_comp_snd, Q.cancel_left_of_respectsIso]
       apply of_isPullback (.of_hasPullback _ _) H)
 
+lemma isLocalAtSource
+    (H : ∀ {X Y : Scheme.{u}} (f : X ⟶ Y) [IsAffine Y] (𝒰 : Scheme.OpenCover.{u} X),
+        Q f ↔ ∀ i, Q (𝒰.map i ≫ f)) : IsLocalAtSource P where
+  iff_of_openCover' {X Y} f 𝒰 := by
+    simp_rw [IsLocalAtTarget.iff_of_iSup_eq_top _ (iSup_affineOpens_eq_top Y)]
+    rw [forall_comm]
+    refine forall_congr' fun U ↦ ?_
+    simp_rw [HasAffineProperty.iff_of_isAffine, morphismRestrict_comp]
+    exact @H _ _ (f ∣_ U.1) U.2 (𝒰.restrict (f ⁻¹ᵁ U.1))
+
 end HasAffineProperty
 
 end targetAffineLocally

--- a/Mathlib/AlgebraicGeometry/Morphisms/Constructors.lean
+++ b/Mathlib/AlgebraicGeometry/Morphisms/Constructors.lean
@@ -60,7 +60,6 @@ instance AffineTargetMorphismProperty.diagonal_respectsIso (P : AffineTargetMorp
     rw [pullback.mapDesc_comp, P.cancel_right_of_respectsIso]
     apply H
 
-attribute [-ext] Scheme.Hom.ext in
 theorem HasAffineProperty.diagonal_of_openCover (P) {Q} [HasAffineProperty P Q]
     {X Y : Scheme.{u}} (f : X ⟶ Y) (𝒰 : Scheme.OpenCover.{u} Y) [∀ i, IsAffine (𝒰.obj i)]
     (𝒰' : ∀ i, Scheme.OpenCover.{u} (pullback f (𝒰.map i))) [∀ i j, IsAffine ((𝒰' i).obj j)]
@@ -78,7 +77,7 @@ theorem HasAffineProperty.diagonal_of_openCover (P) {Q} [HasAffineProperty P Q]
     ((pullbackDiagonalMapIso _ _ ((𝒰' i).map j) ((𝒰' i).map k)).inv ≫
       pullback.map _ _ _ _ (𝟙 _) (𝟙 _) (𝟙 _) _ _) (pullback.snd _ _)).mp _ using 1
   · simp
-  · ext <;> simp
+  · ext1 <;> simp
   · simp only [Category.assoc, limit.lift_π, PullbackCone.mk_pt, PullbackCone.mk_π_app,
       Functor.const_obj_obj, cospan_one, cospan_left, cospan_right, Category.comp_id]
     convert h𝒰' i j k

--- a/Mathlib/AlgebraicGeometry/Morphisms/Constructors.lean
+++ b/Mathlib/AlgebraicGeometry/Morphisms/Constructors.lean
@@ -60,6 +60,7 @@ instance AffineTargetMorphismProperty.diagonal_respectsIso (P : AffineTargetMorp
     rw [pullback.mapDesc_comp, P.cancel_right_of_respectsIso]
     apply H
 
+attribute [-ext] Scheme.Hom.ext in
 theorem HasAffineProperty.diagonal_of_openCover (P) {Q} [HasAffineProperty P Q]
     {X Y : Scheme.{u}} (f : X ⟶ Y) (𝒰 : Scheme.OpenCover.{u} Y) [∀ i, IsAffine (𝒰.obj i)]
     (𝒰' : ∀ i, Scheme.OpenCover.{u} (pullback f (𝒰.map i))) [∀ i j, IsAffine ((𝒰' i).obj j)]

--- a/Mathlib/AlgebraicGeometry/Morphisms/Constructors.lean
+++ b/Mathlib/AlgebraicGeometry/Morphisms/Constructors.lean
@@ -81,7 +81,7 @@ theorem HasAffineProperty.diagonal_of_openCover (P) {Q} [HasAffineProperty P Q]
   · simp only [Category.assoc, limit.lift_π, PullbackCone.mk_pt, PullbackCone.mk_π_app,
       Functor.const_obj_obj, cospan_one, cospan_left, cospan_right, Category.comp_id]
     convert h𝒰' i j k
-    ext <;> simp [Scheme.OpenCover.pullbackHom]
+    ext1 <;> simp [Scheme.OpenCover.pullbackHom]
 
 theorem HasAffineProperty.diagonal_of_openCover_diagonal
     (P) {Q} [HasAffineProperty P Q]

--- a/Mathlib/AlgebraicGeometry/Morphisms/FiniteType.lean
+++ b/Mathlib/AlgebraicGeometry/Morphisms/FiniteType.lean
@@ -14,7 +14,7 @@ A morphism of schemes `f : X ⟶ Y` is locally of finite type if for each affine
 
 A morphism of schemes is of finite type if it is both locally of finite type and quasi-compact.
 
-We show that these properties are local, and are stable under compositions.
+We show that these properties are local, and are stable under compositions and base change.
 
 -/
 
@@ -37,45 +37,43 @@ class LocallyOfFiniteType (f : X ⟶ Y) : Prop where
   finiteType_of_affine_subset :
     ∀ (U : Y.affineOpens) (V : X.affineOpens) (e : V.1 ≤ f ⁻¹ᵁ U.1), (f.appLE U V e).FiniteType
 
-theorem locallyOfFiniteType_eq : @LocallyOfFiniteType = affineLocally @RingHom.FiniteType := by
-  ext X Y f
-  rw [locallyOfFiniteType_iff, affineLocally_iff_affineOpens_le]
-  exact RingHom.finiteType_respectsIso
+instance : HasRingHomProperty @LocallyOfFiniteType RingHom.FiniteType where
+  isLocal_ringHomProperty := RingHom.finiteType_is_local
+  eq_affineLocally' := by
+    ext X Y f
+    rw [locallyOfFiniteType_iff, affineLocally_iff_affineOpens_le]
 
 instance (priority := 900) locallyOfFiniteType_of_isOpenImmersion [IsOpenImmersion f] :
     LocallyOfFiniteType f :=
-  locallyOfFiniteType_eq.symm ▸ RingHom.finiteType_is_local.affineLocally_of_isOpenImmersion f
-
-instance locallyOfFiniteType_isStableUnderComposition :
-    MorphismProperty.IsStableUnderComposition @LocallyOfFiniteType :=
-  locallyOfFiniteType_eq.symm ▸ RingHom.finiteType_is_local.affineLocally_isStableUnderComposition
+  HasRingHomProperty.of_isOpenImmersion
 
 instance locallyOfFiniteType_comp {X Y Z : Scheme} (f : X ⟶ Y) (g : Y ⟶ Z)
     [hf : LocallyOfFiniteType f] [hg : LocallyOfFiniteType g] : LocallyOfFiniteType (f ≫ g) :=
   MorphismProperty.comp_mem _ f g hf hg
 
 theorem locallyOfFiniteType_of_comp {X Y Z : Scheme} (f : X ⟶ Y) (g : Y ⟶ Z)
-    [hf : LocallyOfFiniteType (f ≫ g)] : LocallyOfFiniteType f := by
-  revert hf
-  rw [locallyOfFiniteType_eq]
-  apply RingHom.finiteType_is_local.affineLocally_of_comp
-  introv H
-  exact RingHom.FiniteType.of_comp_finiteType H
+    [LocallyOfFiniteType (f ≫ g)] : LocallyOfFiniteType f :=
+  HasRingHomProperty.of_comp (fun f g ↦ RingHom.FiniteType.of_comp_finiteType) ‹_›
 
-theorem LocallyOfFiniteType.affine_openCover_iff {X Y : Scheme.{u}} (f : X ⟶ Y)
-    (𝒰 : Scheme.OpenCover.{u} Y) [∀ i, IsAffine (𝒰.obj i)]
-    (𝒰' : ∀ i, Scheme.OpenCover.{u} ((𝒰.pullbackCover f).obj i)) [∀ i j, IsAffine ((𝒰' i).obj j)] :
-    LocallyOfFiniteType f ↔
-    ∀ i j, (Scheme.Γ.map ((𝒰' i).map j ≫ pullback.snd _ _).op).FiniteType :=
-  locallyOfFiniteType_eq.symm ▸ RingHom.finiteType_is_local.affine_openCover_iff f 𝒰 𝒰'
-
-theorem LocallyOfFiniteType.source_openCover_iff {X Y : Scheme.{u}} (f : X ⟶ Y)
-    (𝒰 : Scheme.OpenCover.{u} X) : LocallyOfFiniteType f ↔ ∀ i, LocallyOfFiniteType (𝒰.map i ≫ f) :=
-  locallyOfFiniteType_eq.symm ▸ RingHom.finiteType_is_local.source_openCover_iff f 𝒰
-
-instance locallyOfFiniteType_isLocalAtTarget : IsLocalAtTarget @LocallyOfFiniteType := by
-  have := RingHom.finiteType_is_local.hasAffinePropertyAffineLocally
-  rw [← locallyOfFiniteType_eq] at this
-  infer_instance
+open scoped TensorProduct in
+lemma locallyOfFiniteType_stableUnderBaseChange :
+    MorphismProperty.StableUnderBaseChange @LocallyOfFiniteType := by
+  apply HasRingHomProperty.stableUnderBaseChange
+  apply RingHom.StableUnderBaseChange.mk _ RingHom.finiteType_is_local.respectsIso
+  intros R S T _ _ _ _ _ H
+  have H : Algebra.FiniteType R T := by
+    delta RingHom.FiniteType at H; convert H; exact Algebra.algebra_ext _ _ fun _ ↦ rfl
+  suffices Algebra.FiniteType S (S ⊗[R] T) by
+    delta RingHom.FiniteType; convert this; exact Algebra.algebra_ext _ _ fun _ ↦ rfl
+  obtain ⟨ι, _, f, hf⟩ := Algebra.FiniteType.iff_quotient_mvPolynomial'.mp H
+  let g := (Algebra.TensorProduct.productLeftAlgHom
+    (Algebra.TensorProduct.includeLeft : S →ₐ[S] S ⊗[R] T)
+    (Algebra.TensorProduct.includeRight.comp f))
+  have hg : Function.Surjective g := by
+    show Function.Surjective (g.toLinearMap.restrictScalars R)
+    convert f.toLinearMap.lTensor_surjective S hf using 2
+    ext; simp [g]
+  exact ((Algebra.FiniteType.mvPolynomial _ _).equiv
+    (MvPolynomial.algebraTensorAlgEquiv R (σ := ι) S).symm).of_surjective _ hg
 
 end AlgebraicGeometry

--- a/Mathlib/AlgebraicGeometry/Morphisms/FiniteType.lean
+++ b/Mathlib/AlgebraicGeometry/Morphisms/FiniteType.lean
@@ -57,23 +57,7 @@ theorem locallyOfFiniteType_of_comp {X Y Z : Scheme} (f : X ⟶ Y) (g : Y ⟶ Z)
 
 open scoped TensorProduct in
 lemma locallyOfFiniteType_stableUnderBaseChange :
-    MorphismProperty.StableUnderBaseChange @LocallyOfFiniteType := by
-  apply HasRingHomProperty.stableUnderBaseChange
-  apply RingHom.StableUnderBaseChange.mk _ RingHom.finiteType_is_local.respectsIso
-  intros R S T _ _ _ _ _ H
-  have H : Algebra.FiniteType R T := by
-    delta RingHom.FiniteType at H; convert H; exact Algebra.algebra_ext _ _ fun _ ↦ rfl
-  suffices Algebra.FiniteType S (S ⊗[R] T) by
-    delta RingHom.FiniteType; convert this; exact Algebra.algebra_ext _ _ fun _ ↦ rfl
-  obtain ⟨ι, _, f, hf⟩ := Algebra.FiniteType.iff_quotient_mvPolynomial'.mp H
-  let g := (Algebra.TensorProduct.productLeftAlgHom
-    (Algebra.TensorProduct.includeLeft : S →ₐ[S] S ⊗[R] T)
-    (Algebra.TensorProduct.includeRight.comp f))
-  have hg : Function.Surjective g := by
-    show Function.Surjective (g.toLinearMap.restrictScalars R)
-    convert f.toLinearMap.lTensor_surjective S hf using 2
-    ext; simp [g]
-  exact ((Algebra.FiniteType.mvPolynomial _ _).equiv
-    (MvPolynomial.algebraTensorAlgEquiv R (σ := ι) S).symm).of_surjective _ hg
+    MorphismProperty.StableUnderBaseChange @LocallyOfFiniteType :=
+  HasRingHomProperty.stableUnderBaseChange RingHom.finiteType_stableUnderBaseChange
 
 end AlgebraicGeometry

--- a/Mathlib/AlgebraicGeometry/Morphisms/RingHomProperties.lean
+++ b/Mathlib/AlgebraicGeometry/Morphisms/RingHomProperties.lean
@@ -27,8 +27,31 @@ the target. (TODO)
 
 For the latter `P` should be local on the target (`RingHom.PropertyIsLocal P`), and
 `affineLocally P` will be local on both the source and the target.
+We also provide the following interface:
 
-Further more, these properties are stable under compositions (resp. base change) if `P` is. (TODO)
+## `HasRingHomProperty`
+
+`HasRingHomProperty P Q` is a type class asserting that `P` is local at the target and the source,
+and for `f : Spec B ⟶ Spec A`, it is equivalent to the ring hom property `Q`.
+
+For `HasRingHomProperty P Q` and `f : X ⟶ Y`, we provide these API lemmas:
+- `AlgebraicGeometry.HasAffineProperty.iff_appLE`:
+    `P f` if and only if `Q (f.appLE U V _)` for all affine `U : Opens Y` and `V : Opens X`.
+- `AlgebraicGeometry.HasAffineProperty.iff_of_openCover`:
+    If `Y` is affine, `P f ↔ ∀ i, Q ((𝒰.map i ≫ f).app ⊤)` for an affine open cover `𝒰` of `X`.
+- `AlgebraicGeometry.HasAffineProperty.iff_of_isAffine`:
+    If `X` and `Y` are affine, then `P f ↔ Q (f.app ⊤)`.
+- `AlgebraicGeometry.HasAffineProperty.Spec_iff`:
+    `P (Spec.map φ) ↔ Q φ`
+- `AlgebraicGeometry.HasAffineProperty.iff_of_iSup_eq_top`:
+    If `Y` is affine, `P f ↔ ∀ i, Q (f.appLE ⊤ (U i) _)` for a family `U` of affine opens of `X`.
+- `AlgebraicGeometry.HasAffineProperty.of_isOpenImmersion`:
+    If `f` is an open immersion then `P f`.
+- `AlgebraicGeometry.HasAffineProperty.stableUnderBaseChange`:
+    If `Q` is stable under base change, then so is `P`.
+
+We also provide the instances `P.IsMultiplicative`, `P.IsStableUnderComposition`,
+`IsLocalAtTarget P`, `IsLocalAtSource P`.
 
 -/
 
@@ -38,81 +61,25 @@ universe u
 
 open CategoryTheory Opposite TopologicalSpace CategoryTheory.Limits AlgebraicGeometry
 
-variable (P : ∀ {R S : Type u} [CommRing R] [CommRing S], (R →+* S) → Prop)
-
 namespace RingHom
 
-variable {P}
-theorem RespectsIso.basicOpen_iff (hP : RespectsIso @P) {X Y : Scheme.{u}} [IsAffine X] [IsAffine Y]
-    (f : X ⟶ Y) (r : Y.presheaf.obj (Opposite.op ⊤)) :
-    P (Scheme.Γ.map (f ∣_ Y.basicOpen r).op) ↔
-    P (@IsLocalization.Away.map (Y.presheaf.obj (Opposite.op ⊤)) _
-      (Y.presheaf.obj (Opposite.op <| Y.basicOpen r)) _ _ (X.presheaf.obj (Opposite.op ⊤)) _
-      (X.presheaf.obj (Opposite.op <| X.basicOpen (Scheme.Γ.map f.op r))) _ _
-      (Scheme.Γ.map f.op) r _ <| @isLocalization_away_of_isAffine X _ (Scheme.Γ.map f.op r)) := by
-  rw [Γ_map_morphismRestrict, hP.cancel_left_isIso, hP.cancel_right_isIso,
-    ← hP.cancel_right_isIso (f.val.c.app (Opposite.op (Y.basicOpen r)))
-      (X.presheaf.map (eqToHom (Scheme.preimage_basicOpen f r).symm).op), ← eq_iff_iff]
-  congr
-  delta IsLocalization.Away.map
-  refine IsLocalization.ringHom_ext (Submonoid.powers r) ?_
-  generalize_proofs
-  haveI i1 := @isLocalization_away_of_isAffine X _ (Scheme.Γ.map f.op r)
-  -- Porting note: needs to be very explicit here
-  convert
-    (@IsLocalization.map_comp (hy := ‹_ ≤ _›) (Y.presheaf.obj <| Opposite.op (Scheme.basicOpen Y r))
-    _ _ (isLocalization_away_of_isAffine _) _ _ _ i1).symm using 1
-  change Y.presheaf.map _ ≫ _ = _ ≫ X.presheaf.map _
-  rw [f.val.c.naturality_assoc]
-  dsimp
-  simp only [← X.presheaf.map_comp]
-  congr 1
+variable (P : ∀ {R S : Type u} [CommRing R] [CommRing S], (R →+* S) → Prop)
 
-theorem RespectsIso.basicOpen_iff_localization (hP : RespectsIso @P) {X Y : Scheme.{u}} [IsAffine X]
-    [IsAffine Y] (f : X ⟶ Y) (r : Y.presheaf.obj (Opposite.op ⊤)) :
-    P (Scheme.Γ.map (f ∣_ Y.basicOpen r).op) ↔ P (Localization.awayMap (Scheme.Γ.map f.op) r) := by
-  refine (hP.basicOpen_iff _ _).trans ?_
-  -- Porting note: was a one line term mode proof, but this `dsimp` is vital so the term mode
-  -- one liner is not possible
-  dsimp
-  rw [← hP.is_localization_away_iff]
-
-@[deprecated (since := "2024-03-02")] alias
-RespectsIso.ofRestrict_morphismRestrict_iff_of_isAffine := RespectsIso.basicOpen_iff_localization
-
-theorem RespectsIso.ofRestrict_morphismRestrict_iff (hP : RingHom.RespectsIso @P) {X Y : Scheme.{u}}
-    [IsAffine Y] (f : X ⟶ Y) (r : Y.presheaf.obj (Opposite.op ⊤)) (U : Opens X.carrier)
-    (hU : IsAffineOpen U) {V : Opens _}
-    (e : V = (Scheme.ιOpens <| f ⁻¹ᵁ Y.basicOpen r) ⁻¹ᵁ U) :
-    P (Scheme.Γ.map (Scheme.ιOpens V ≫ f ∣_ Y.basicOpen r).op) ↔
-    P (Localization.awayMap (Scheme.Γ.map (Scheme.ιOpens U ≫ f).op) r) := by
-  subst e
-  refine (hP.cancel_right_isIso _
-    (Scheme.Γ.mapIso (Scheme.restrictRestrictComm _ _ _).op).inv).symm.trans ?_
-  haveI : IsAffine _ := hU
-  rw [← hP.basicOpen_iff_localization, iff_iff_eq]
-  congr 1
-  simp only [Functor.mapIso_inv, Iso.op_inv, ← Functor.map_comp, ← op_comp, morphismRestrict_comp]
-  rw [← Category.assoc]
-  congr 3
-  rw [← cancel_mono (Scheme.ιOpens _), Category.assoc, Scheme.restrictRestrictComm,
-    IsOpenImmersion.isoOfRangeEq_inv_fac, morphismRestrict_ι]
-
-theorem StableUnderBaseChange.Γ_pullback_fst (hP : StableUnderBaseChange @P) (hP' : RespectsIso @P)
+theorem StableUnderBaseChange.pullback_fst_app_top
+    (hP : StableUnderBaseChange P) (hP' : RespectsIso P)
     {X Y S : Scheme} [IsAffine X] [IsAffine Y] [IsAffine S] (f : X ⟶ S) (g : Y ⟶ S)
-    (H : P (Scheme.Γ.map g.op)) : P (Scheme.Γ.map (pullback.fst f g).op) := by
+    (H : P (g.app ⊤)) : P ((pullback.fst f g).app ⊤) := by
   -- Porting note (#11224): change `rw` to `erw`
   erw [← PreservesPullback.iso_inv_fst AffineScheme.forgetToScheme (AffineScheme.ofHom f)
       (AffineScheme.ofHom g)]
-  rw [op_comp, Functor.map_comp, hP'.cancel_right_isIso, AffineScheme.forgetToScheme_map]
+  rw [Scheme.comp_app, hP'.cancel_right_isIso, AffineScheme.forgetToScheme_map]
   have :=
     _root_.congr_arg Quiver.Hom.unop
       (PreservesPullback.iso_hom_fst AffineScheme.Γ.rightOp (AffineScheme.ofHom f)
         (AffineScheme.ofHom g))
-  simp only [Quiver.Hom.unop_op, Functor.rightOp_map, unop_comp] at this
-  delta AffineScheme.Γ at this
-  simp only [Quiver.Hom.unop_op, Functor.comp_map, AffineScheme.forgetToScheme_map,
-    Functor.op_map] at this
+  simp only [AffineScheme.Γ, Functor.rightOp_obj, Functor.comp_obj, Functor.op_obj, unop_comp,
+    AffineScheme.forgetToScheme_obj, Scheme.Γ_obj, Functor.rightOp_map, Functor.comp_map,
+    Functor.op_map, Quiver.Hom.unop_op, AffineScheme.forgetToScheme_map, Scheme.Γ_map] at this
   rw [← this, hP'.cancel_right_isIso, ← pushoutIsoUnopPullback_inl_hom, hP'.cancel_right_isIso]
   exact hP.pushout_inl _ hP' _ _ H
 
@@ -120,422 +87,257 @@ end RingHom
 
 namespace AlgebraicGeometry
 
+section affineLocally
+
+variable (P : ∀ {R S : Type u} [CommRing R] [CommRing S], (R →+* S) → Prop)
+
 /-- For `P` a property of ring homomorphisms, `sourceAffineLocally P` holds for `f : X ⟶ Y`
 whenever `P` holds for the restriction of `f` on every affine open subset of `X`. -/
 def sourceAffineLocally : AffineTargetMorphismProperty := fun X _ f _ =>
-  ∀ U : X.affineOpens, P (Scheme.Γ.map (X.ofRestrict U.1.openEmbedding ≫ f).op)
+  ∀ U : X.affineOpens, P (f.appLE ⊤ U le_top)
 
 /-- For `P` a property of ring homomorphisms, `affineLocally P` holds for `f : X ⟶ Y` if for each
 affine open `U = Spec A ⊆ Y` and `V = Spec B ⊆ f ⁻¹' U`, the ring hom `A ⟶ B` satisfies `P`.
 Also see `affineLocally_iff_affineOpens_le`. -/
 abbrev affineLocally : MorphismProperty Scheme.{u} :=
-  targetAffineLocally (sourceAffineLocally @P)
+  targetAffineLocally (sourceAffineLocally P)
 
-variable {P}
-
-theorem sourceAffineLocally_respectsIso (h₁ : RingHom.RespectsIso @P) :
-    (sourceAffineLocally @P).toProperty.RespectsIso := by
+theorem sourceAffineLocally_respectsIso (h₁ : RingHom.RespectsIso P) :
+    (sourceAffineLocally P).toProperty.RespectsIso := by
   apply AffineTargetMorphismProperty.respectsIso_mk
   · introv H U
-    rw [← h₁.cancel_right_isIso _ (Scheme.Γ.map (Scheme.restrictMapIso e.inv U.1).hom.op), ←
-      Functor.map_comp, ← op_comp]
-    convert H ⟨_, U.prop.preimage_of_isIso e.inv⟩ using 3
-    rw [IsOpenImmersion.isoOfRangeEq_hom_fac_assoc, Category.assoc,
-      e.inv_hom_id_assoc]
+    have : IsIso (e.hom.appLE (e.hom ''ᵁ U) U.1 (e.hom.preimage_image_eq _).ge) :=
+      inferInstanceAs (IsIso (e.hom.app _ ≫
+        X.presheaf.map (eqToHom (e.hom.preimage_image_eq _).symm).op))
+    rw [← Scheme.appLE_comp_appLE _ _ ⊤ (e.hom ''ᵁ U) U.1 le_top (e.hom.preimage_image_eq _).ge,
+      h₁.cancel_right_isIso]
+    exact H ⟨_, U.prop.image_of_isOpenImmersion e.hom⟩
   · introv H U
-    rw [← Category.assoc, op_comp, Functor.map_comp, h₁.cancel_left_isIso]
+    rw [Scheme.comp_appLE, h₁.cancel_left_isIso]
     exact H U
 
-theorem affineLocally_respectsIso (h : RingHom.RespectsIso @P) : (affineLocally @P).RespectsIso := by
-  have := sourceAffineLocally_respectsIso h
-  delta affineLocally
-  infer_instance
+theorem affineLocally_respectsIso (h : RingHom.RespectsIso P) : (affineLocally P).RespectsIso :=
+  letI := sourceAffineLocally_respectsIso P h
+  inferInstance
 
-theorem affineLocally_iff_affineOpens_le
-    (hP : RingHom.RespectsIso @P) {X Y : Scheme.{u}} (f : X ⟶ Y) :
-    affineLocally.{u} (@P) f ↔
-    ∀ (U : Y.affineOpens) (V : X.affineOpens) (e : V.1 ≤ (Opens.map f.1.base).obj U.1),
-      P (f.appLE _ _ e) := by
-  apply forall_congr'
-  intro U
-  delta sourceAffineLocally
-  simp_rw [op_comp, Scheme.Γ.map_comp, Γ_map_morphismRestrict, Category.assoc, Scheme.Γ_map_op,
-    hP.cancel_left_isIso (Y.presheaf.map (eqToHom _).op)]
+open Scheme in
+theorem sourceAffineLocally_morphismRestrict {X Y : Scheme.{u}} (f : X ⟶ Y)
+    (U : Opens Y) (hU : IsAffineOpen U) :
+    @sourceAffineLocally P _ _ (f ∣_ U) hU ↔
+      ∀ (V : X.affineOpens) (e : V.1 ≤ f ⁻¹ᵁ U), P (f.appLE U V e) := by
+  dsimp only [sourceAffineLocally]
+  simp only [morphismRestrict_appLE]
+  rw [(affineOpensRestrict (f ⁻¹ᵁ U)).forall_congr_left, Subtype.forall]
+  refine forall₂_congr fun V h ↦ ?_
+  have := (affineOpensRestrict (f ⁻¹ᵁ U)).apply_symm_apply ⟨V, h⟩
+  exact f.appLE_congr _ (ιOpens_image_top _) congr($(this).1.1) _
+
+theorem affineLocally_iff_affineOpens_le {X Y : Scheme.{u}} (f : X ⟶ Y) :
+    affineLocally.{u} P f ↔
+      ∀ (U : Y.affineOpens) (V : X.affineOpens) (e : V.1 ≤ f ⁻¹ᵁ U.1), P (f.appLE U V e) :=
+  forall_congr' fun U ↦ sourceAffineLocally_morphismRestrict P f U U.2
+
+theorem sourceAffineLocally_isLocal (h₁ : RingHom.RespectsIso P)
+    (h₂ : RingHom.LocalizationPreserves P) (h₃ : RingHom.OfLocalizationSpan P) :
+    (sourceAffineLocally P).IsLocal := by
   constructor
-  · intro H V e
-    let U' := (Opens.map f.val.base).obj U.1
-    have e'' : (Scheme.Hom.opensFunctor (X.ofRestrict U'.openEmbedding)).obj
-        (X.ofRestrict U'.openEmbedding⁻¹ᵁ V) = V := by
-      ext1; refine Set.image_preimage_eq_inter_range.trans (Set.inter_eq_left.mpr ?_)
-      erw [Subtype.range_val]
-      exact e
-    have h : X.ofRestrict U'.openEmbedding ⁻¹ᵁ ↑V ∈ Scheme.affineOpens (X.restrict _) := by
-      apply (X.ofRestrict U'.openEmbedding).isAffineOpen_iff_of_isOpenImmersion.mp
-      -- Porting note: was convert V.2
-      rw [e'']
-      convert V.2
-    have := H ⟨(Opens.map (X.ofRestrict U'.openEmbedding).1.base).obj V.1, h⟩
-    rw [← hP.cancel_right_isIso _ (X.presheaf.map (eqToHom _)), Scheme.Hom.appLE,
-      Category.assoc, ← X.presheaf.map_comp]
-    · convert this using 1
-      congr 1
-      rw [X.presheaf.map_comp]
-      · simp only [Scheme.ofRestrict_val_c_app, Scheme.restrict_presheaf_map, ← X.presheaf.map_comp]
-        congr 1
-    · dsimp only [Functor.op, unop_op]
-      rw [Opens.openEmbedding_obj_top]
-      congr 1
-      exact e''.symm
-  · intro H V
-    specialize H ⟨_, V.2.image_of_isOpenImmersion (X.ofRestrict _)⟩ (Subtype.coe_image_subset _ _)
-    rw [← hP.cancel_right_isIso _ (X.presheaf.map (eqToHom _)), Category.assoc]
-    · convert H
-      simp only [Scheme.ofRestrict_val_c_app, Scheme.restrict_presheaf_map, ← X.presheaf.map_comp]
-      congr 1
-    · dsimp only [Functor.op, unop_op]; rw [Opens.openEmbedding_obj_top]
-
--- The `IsLocalization` is not necessary, but Lean errors if it is omitted.
-@[nolint unusedHavesSuffices]
-theorem scheme_restrict_basicOpen_of_localizationPreserves (h₁ : RingHom.RespectsIso @P)
-    (h₂ : RingHom.LocalizationPreserves @P) {X Y : Scheme.{u}} [IsAffine Y] (f : X ⟶ Y)
-    (r : Y.presheaf.obj (op ⊤)) (H : sourceAffineLocally (@P) f)
-    (U : (X.restrict ((Opens.map f.1.base).obj <| Y.basicOpen r).openEmbedding).affineOpens) :
-    P (Scheme.Γ.map ((X.restrict ((Opens.map f.1.base).obj <|
-      Y.basicOpen r).openEmbedding).ofRestrict U.1.openEmbedding ≫ f ∣_ Y.basicOpen r).op) := by
-  specialize H ⟨_, U.2.image_of_isOpenImmersion (X.ofRestrict _)⟩
-  letI i1 : Algebra (Y.presheaf.obj <| Opposite.op ⊤) (Localization.Away r) :=
-    OreLocalization.instAlgebra
-  haveI : IsLocalization.Away r (Localization.Away r) := inferInstance
-  exact (h₁.ofRestrict_morphismRestrict_iff f r
-    ((Scheme.Hom.opensFunctor
-      (X.ofRestrict ((Opens.map f.1.base).obj <| Y.basicOpen r).openEmbedding)).obj U.1)
-    (IsAffineOpen.image_of_isOpenImmersion U.2
-      (X.ofRestrict ((Opens.map f.1.base).obj <| Y.basicOpen r).openEmbedding))
-    (Opens.ext (Set.preimage_image_eq _ Subtype.coe_injective).symm)).mpr (h₂.away r H)
-
-theorem sourceAffineLocally_isLocal (h₁ : RingHom.RespectsIso @P)
-    (h₂ : RingHom.LocalizationPreserves @P) (h₃ : RingHom.OfLocalizationSpan @P) :
-    (sourceAffineLocally @P).IsLocal := by
-  constructor
-  · exact sourceAffineLocally_respectsIso h₁
-  · introv H U
-    apply scheme_restrict_basicOpen_of_localizationPreserves h₁ h₂; assumption
+  · exact sourceAffineLocally_respectsIso P h₁
+  · intro X Y _ f r H
+    rw [sourceAffineLocally_morphismRestrict]
+    intro U hU
+    have : X.basicOpen (f.appLE ⊤ U (by simp) r) = U := by
+      simp only [Scheme.Hom.appLE, Opens.map_top, CommRingCat.coe_comp_of, RingHom.coe_comp,
+        Function.comp_apply]
+      rw [Scheme.basicOpen_res]
+      simpa using hU
+    rw [← f.appLE_congr _ rfl this P,
+      IsAffineOpen.appLE_eq_away_map f (isAffineOpen_top Y) U.2 _ r]
+    apply (config := { allowSynthFailures := true }) h₂.away
+    exact H U
   · introv hs hs' U
     apply h₃ _ _ hs
     intro r
-    have := hs' r ⟨(Opens.map (X.ofRestrict _).1.base).obj U.1, ?_⟩
-    · rwa [h₁.ofRestrict_morphismRestrict_iff] at this
-      · exact U.2
-      · rfl
-    · suffices ∀ (V) (_ : V = (Opens.map f.val.base).obj (Y.basicOpen r.val)),
-          IsAffineOpen ((Opens.map (X.ofRestrict V.openEmbedding).1.base).obj U.1) by
-        exact this _ rfl
-      intro V hV
-      rw [Scheme.preimage_basicOpen] at hV
-      subst hV
-      exact U.2.ιOpens_basicOpen_preimage (Scheme.Γ.map f.op r.1)
+    simp_rw [sourceAffineLocally_morphismRestrict] at hs'
+    have := hs' r ⟨X.basicOpen (f.appLE ⊤ U le_top r.1), U.2.basicOpen (f.appLE ⊤ U le_top r.1)⟩
+      (by simpa [Scheme.Hom.appLE] using Scheme.basicOpen_restrict _ _ _)
+    rwa [IsAffineOpen.appLE_eq_away_map f (isAffineOpen_top Y) U.2,
+      ← h₁.is_localization_away_iff] at this
 
-variable (hP : RingHom.PropertyIsLocal @P)
+end affineLocally
 
-theorem sourceAffineLocally_of_source_open_cover_aux (h₁ : RingHom.RespectsIso @P)
-    (h₃ : RingHom.OfLocalizationSpanTarget @P) {X Y : Scheme.{u}} (f : X ⟶ Y) (U : X.affineOpens)
-    (s : Set (X.presheaf.obj (op U.1))) (hs : Ideal.span s = ⊤)
-    (hs' : ∀ r : s, P (Scheme.Γ.map (Scheme.ιOpens (X.basicOpen r.1) ≫ f).op)) :
-    P (Scheme.Γ.map (Scheme.ιOpens U ≫ f).op) := by
-  apply_fun Ideal.map (X.presheaf.map (eqToHom U.1.openEmbedding_obj_top).op) at hs
-  rw [Ideal.map_span, Ideal.map_top] at hs
-  apply h₃.ofIsLocalization h₁ _ _ hs
-  rintro ⟨s, r, hr, hs⟩
-  refine ⟨_, _, _, @AlgebraicGeometry.Γ_restrict_isLocalization (X ∣_ᵤ U.1) U.2 s, ?_⟩
-  rw [RingHom.algebraMap_toAlgebra, ← CommRingCat.comp_eq_ring_hom_comp, ← Functor.map_comp,
-    ← op_comp, ← h₁.cancel_right_isIso _ (Scheme.Γ.mapIso (Scheme.restrictRestrict _ _ _).op).inv]
-  subst hs
-  rw [← h₁.cancel_right_isIso _
-    (Scheme.Γ.mapIso (Scheme.restrictIsoOfEq _ (Scheme.map_basicOpen_map _ _ _)).op).inv]
-  simp only [Functor.mapIso_inv, Iso.op_inv, ← Functor.map_comp, ← op_comp,
-    Scheme.restrictRestrict_inv_restrict_restrict_assoc, Scheme.restrictIsoOfEq,
-    IsOpenImmersion.isoOfRangeEq_inv_fac_assoc]
-  exact hs' ⟨r, hr⟩
+/--
+`HasRingHomProperty P Q` is a type class asserting that `P` is local at the target and the source,
+and for `f : Spec B ⟶ Spec A`, it is equivalent to the ring hom property `Q`.
+To make the proofs easier, we state it instead as
+1. `Q` is local (See `RingHom.PropertyIsLocal`)
+2. `P f` if and only if `Q` holds for every `Γ(Y, U) ⟶ Γ(X, V)` for all affine `U`, `V`.
+-/
+class HasRingHomProperty (P : MorphismProperty Scheme.{u})
+    (Q : outParam (∀ {R S : Type u} [CommRing R] [CommRing S], (R →+* S) → Prop)) : Prop where
+  isLocal_ringHomProperty : RingHom.PropertyIsLocal Q
+  eq_affineLocally' : P = affineLocally Q
 
-theorem isOpenImmersionCat_comp_of_sourceAffineLocally (h₁ : RingHom.RespectsIso @P)
-    {X Y Z : Scheme.{u}} [IsAffine X] [IsAffine Z] (f : X ⟶ Y) [IsOpenImmersion f] (g : Y ⟶ Z)
-    (h₂ : sourceAffineLocally (@P) g) : P (Scheme.Γ.map (f ≫ g).op) := by
-  rw [← h₁.cancel_right_isIso _
-    (Scheme.Γ.map (IsOpenImmersion.isoOfRangeEq (Y.ofRestrict _) f _).hom.op),
-    ← Functor.map_comp, ← op_comp]
-  · convert h₂ ⟨_, isAffineOpen_opensRange f⟩ using 3
-    · rw [IsOpenImmersion.isoOfRangeEq_hom_fac_assoc]
-      exact Subtype.range_coe
+namespace HasRingHomProperty
 
-end AlgebraicGeometry
+variable (P : MorphismProperty Scheme.{u}) {Q} [HasRingHomProperty P Q]
+variable {X Y Z : Scheme.{u}} (f : X ⟶ Y) (g : Y ⟶ Z)
 
-open AlgebraicGeometry
+lemma eq_affineLocally : P = affineLocally Q := eq_affineLocally'
 
-namespace RingHom.PropertyIsLocal
+instance : HasAffineProperty P (sourceAffineLocally Q) where
+  isLocal_affineProperty := sourceAffineLocally_isLocal _
+    (HasRingHomProperty.isLocal_ringHomProperty P).respectsIso
+    (HasRingHomProperty.isLocal_ringHomProperty P).LocalizationPreserves
+    (HasRingHomProperty.isLocal_ringHomProperty P).ofLocalizationSpan
+  eq_targetAffineLocally' := eq_affineLocally P
 
-variable {P} (hP : RingHom.PropertyIsLocal @P)
+theorem appLE (H : P f) (U : Y.affineOpens) (V : X.affineOpens) (e) : Q (f.appLE U V e) := by
+  rw [eq_affineLocally P, affineLocally_iff_affineOpens_le] at H
+  exact H _ _ _
 
-theorem sourceAffineLocally_of_source_openCover {X Y : Scheme.{u}} (f : X ⟶ Y) [IsAffine Y]
-    (𝒰 : X.OpenCover) [∀ i, IsAffine (𝒰.obj i)] (H : ∀ i, P (Scheme.Γ.map (𝒰.map i ≫ f).op)) :
-    sourceAffineLocally (@P) f := by
-  let S i := (⟨⟨Set.range (𝒰.map i).1.base, (𝒰.IsOpen i).base_open.isOpen_range⟩,
-    isAffineOpen_opensRange (𝒰.map i)⟩ : X.affineOpens)
+theorem app_top (H : P f) [IsAffine X] [IsAffine Y] : Q (f.app ⊤) := by
+  rw [Scheme.Hom.app_eq_appLE]
+  exact appLE P f H ⟨_, isAffineOpen_top _⟩ ⟨_, isAffineOpen_top _⟩ _
+
+theorem comp_of_isOpenImmersion [IsOpenImmersion f] (H : P g) :
+    P (f ≫ g) := by
+  rw [eq_affineLocally P, affineLocally_iff_affineOpens_le] at H ⊢
+  intro U V e
+  have : IsIso (f.appLE (f ''ᵁ V) V.1 (f.preimage_image_eq _).ge) :=
+    inferInstanceAs (IsIso (f.app _ ≫
+      X.presheaf.map (eqToHom (f.preimage_image_eq _).symm).op))
+  rw [← Scheme.appLE_comp_appLE _ _ _ (f ''ᵁ V) V.1
+    (Set.image_subset_iff.mpr e) (f.preimage_image_eq _).ge,
+    (isLocal_ringHomProperty P).respectsIso.cancel_right_isIso]
+  exact H _ ⟨_, V.2.image_of_isOpenImmersion _⟩ _
+
+variable {P f}
+
+lemma iff_appLE : P f ↔ ∀ (U : Y.affineOpens) (V : X.affineOpens) (e), Q (f.appLE U V e) := by
+  rw [eq_affineLocally P, affineLocally_iff_affineOpens_le]
+
+theorem of_openCover [IsAffine Y]
+    (𝒰 : X.OpenCover) [∀ i, IsAffine (𝒰.obj i)] (H : ∀ i, Q ((𝒰.map i ≫ f).app ⊤)) :
+    P f := by
+  rw [HasAffineProperty.iff_of_isAffine (P := P)]
   intro U
-  -- Porting note: here is what we are eliminating into Lean
-  apply of_affine_open_cover
-    (P := fun V => P (Scheme.Γ.map (X.ofRestrict (Opens.openEmbedding V.val) ≫ f).op)) S
-    𝒰.iSup_opensRange
-  · intro U r H
-    -- Porting note: failing on instance synthesis for an (unspecified) meta variable
-    -- made φ explicit and forced to use dsimp in the proof
-    convert hP.StableUnderComposition
-      (S := Scheme.Γ.obj (Opposite.op (X.restrict <| Opens.openEmbedding U.val)))
-      (T := Scheme.Γ.obj (Opposite.op (X.restrict <| Opens.openEmbedding (X.basicOpen r))))
-      ?_ ?_ H ?_ using 1
-    swap
-    · refine X.presheaf.map
-          (@homOfLE _ _ ((IsOpenMap.functor _).obj _) ((IsOpenMap.functor _).obj _) ?_).op
-      dsimp
-      rw [Opens.openEmbedding_obj_top, Opens.openEmbedding_obj_top]
-      exact X.basicOpen_le _
-    · rw [op_comp, op_comp, Functor.map_comp, Functor.map_comp]
-      refine (Eq.trans ?_ (Category.assoc (obj := CommRingCat) _ _ _).symm : _)
-      congr 1
-      dsimp
-      refine Eq.trans ?_ (X.presheaf.map_comp _ _)
-      change X.presheaf.map _ = _
-      congr!
-    -- Porting note: need to pass Algebra through explicitly
-    convert @HoldsForLocalizationAway _ hP _
-      (Scheme.Γ.obj (Opposite.op (X.restrict (X.basicOpen r).openEmbedding))) _ _ ?_
-      (X.presheaf.map (eqToHom U.1.openEmbedding_obj_top).op r) ?_
-    · exact RingHom.algebraMap_toAlgebra
-        (R := Scheme.Γ.obj <| Opposite.op <| X.restrict (U.1.openEmbedding))
-        (S :=
-          Scheme.Γ.obj (Opposite.op <| X.restrict (X.affineBasicOpen r).1.openEmbedding)) _|>.symm
-    · dsimp [Scheme.Γ]
-      have := U.2
-      rw [← U.1.openEmbedding_obj_top] at this
-      -- Porting note: the second argument of `IsLocalization.Away` is a type, and we want
-      -- to generate an equality, so using `typeEqs := true` to force allowing type equalities.
-      convert (config := {typeEqs := true, transparency := .default})
-          this.isLocalization_basicOpen _ using 5
-      all_goals rw [Opens.openEmbedding_obj_top]; exact (Scheme.basicOpen_res_eq _ _ _).symm
-  · introv hs hs'
-    exact sourceAffineLocally_of_source_open_cover_aux hP.respectsIso hP.2 _ _ _ hs hs'
-  · rintro i
+  let S i : X.affineOpens := ⟨_, isAffineOpen_opensRange (𝒰.map i)⟩
+  induction U using of_affine_open_cover S 𝒰.iSup_opensRange with
+  | basicOpen U r H =>
+    simp_rw [Scheme.affineBasicOpen_coe,
+      ← f.appLE_map (U := ⊤) le_top (homOfLE (X.basicOpen_le r)).op]
+    apply (isLocal_ringHomProperty P).StableUnderComposition _ _ H
+    have := U.2.isLocalization_basicOpen r
+    apply (isLocal_ringHomProperty P).HoldsForLocalizationAway _ r
+  | openCover U s hs H =>
+    apply (isLocal_ringHomProperty P).OfLocalizationSpanTarget.ofIsLocalization
+      (isLocal_ringHomProperty P).respectsIso _ _ hs
+    rintro r
+    refine ⟨_, _, _, IsAffineOpen.isLocalization_basicOpen U.2 r, ?_⟩
+    rw [RingHom.algebraMap_toAlgebra, ← CommRingCat.comp_eq_ring_hom_comp, Scheme.Hom.appLE_map]
+    exact H r
+  | hU i =>
     specialize H i
-    rw [← hP.respectsIso.cancel_right_isIso _
-        (Scheme.Γ.map
-          (IsOpenImmersion.isoOfRangeEq (𝒰.map i) (X.ofRestrict (S i).1.openEmbedding)
-                Subtype.range_coe.symm).inv.op)] at H
-    rwa [← Scheme.Γ.map_comp, ← op_comp, IsOpenImmersion.isoOfRangeEq_inv_fac_assoc] at H
+    rw [← (isLocal_ringHomProperty P).respectsIso.cancel_right_isIso _
+      ((IsOpenImmersion.isoOfRangeEq (𝒰.map i) (Scheme.ιOpens (S i).1)
+      Subtype.range_coe.symm).inv.app _), ← Scheme.comp_app,
+      IsOpenImmersion.isoOfRangeEq_inv_fac_assoc, Scheme.comp_app,
+      Scheme.ofRestrict_app, Scheme.Hom.app_eq_appLE, Scheme.Hom.appLE_map] at H
+    exact (f.appLE_congr _ rfl (by simp) Q).mp H
 
-theorem affine_openCover_TFAE {X Y : Scheme.{u}} [IsAffine Y] (f : X ⟶ Y) :
-    List.TFAE
-      [sourceAffineLocally (@P) f,
-        ∃ (𝒰 : Scheme.OpenCover.{u} X) (_ : ∀ i, IsAffine (𝒰.obj i)),
-          ∀ i : 𝒰.J, P (Scheme.Γ.map (𝒰.map i ≫ f).op),
-        ∀ (𝒰 : Scheme.OpenCover.{u} X) [∀ i, IsAffine (𝒰.obj i)] (i : 𝒰.J),
-          P (Scheme.Γ.map (𝒰.map i ≫ f).op),
-        ∀ {U : Scheme} (g : U ⟶ X) [IsAffine U] [IsOpenImmersion g],
-          P (Scheme.Γ.map (g ≫ f).op)] := by
-  tfae_have 1 → 4
-  · intro H U g _ hg
-    specialize H ⟨⟨_, hg.base_open.isOpen_range⟩, isAffineOpen_opensRange g⟩
-    rw [← hP.respectsIso.cancel_right_isIso _ (Scheme.Γ.map (IsOpenImmersion.isoOfRangeEq g
-      (X.ofRestrict (Opens.openEmbedding ⟨_, hg.base_open.isOpen_range⟩))
-      Subtype.range_coe.symm).hom.op),
-      ← Scheme.Γ.map_comp, ← op_comp, IsOpenImmersion.isoOfRangeEq_hom_fac_assoc] at H
-    exact H
-  tfae_have 4 → 3
-  · intro H 𝒰 _ i; apply H
-  tfae_have 3 → 2
-  · intro H; exact ⟨X.affineCover, inferInstance, H _⟩
-  tfae_have 2 → 1
-  · rintro ⟨𝒰, _, h𝒰⟩
-    exact sourceAffineLocally_of_source_openCover hP f 𝒰 h𝒰
-  tfae_finish
+theorem iff_of_openCover [IsAffine Y] (𝒰 : X.OpenCover) [∀ i, IsAffine (𝒰.obj i)] :
+    P f ↔ ∀ i, Q ((𝒰.map i ≫ f).app ⊤) :=
+  ⟨fun H i ↦ app_top P _ (comp_of_isOpenImmersion P (𝒰.map i) f H), of_openCover 𝒰⟩
 
-theorem openCover_TFAE {X Y : Scheme.{u}} [IsAffine Y] (f : X ⟶ Y) :
-    List.TFAE
-      [sourceAffineLocally (@P) f,
-        ∃ 𝒰 : Scheme.OpenCover.{u} X, ∀ i : 𝒰.J, sourceAffineLocally (@P) (𝒰.map i ≫ f),
-        ∀ (𝒰 : Scheme.OpenCover.{u} X) (i : 𝒰.J), sourceAffineLocally (@P) (𝒰.map i ≫ f),
-        ∀ {U : Scheme} (g : U ⟶ X) [IsOpenImmersion g], sourceAffineLocally (@P) (g ≫ f)] := by
-  tfae_have 1 → 4
-  · intro H U g hg V
-    -- Porting note: this has metavariable if I put it directly into rw
-    have := (hP.affine_openCover_TFAE f).out 0 3
-    rw [this] at H
-    haveI : IsAffine _ := V.2
-    rw [← Category.assoc]
-    -- Porting note: Lean could find this previously
-    have : IsOpenImmersion <| (Scheme.ofRestrict U (Opens.openEmbedding V.val)) ≫ g :=
-      LocallyRingedSpace.IsOpenImmersion.comp _ _
-    apply H
-  tfae_have 4 → 3
-  · intro H 𝒰 _ i; apply H
-  tfae_have 3 → 2
-  · intro H; exact ⟨X.affineCover, H _⟩
-  tfae_have 2 → 1
-  · rintro ⟨𝒰, h𝒰⟩
-    -- Porting note: this has metavariable if I put it directly into rw
-    have := (hP.affine_openCover_TFAE f).out 0 1
-    rw [this]
-    refine ⟨𝒰.bind fun _ => Scheme.affineCover _, ?_, ?_⟩
-    · intro i; dsimp; infer_instance
-    · intro i
-      specialize h𝒰 i.1
-      -- Porting note: this has metavariable if I put it directly into rw
-      have := (hP.affine_openCover_TFAE (𝒰.map i.fst ≫ f)).out 0 3
-      rw [this] at h𝒰
-      -- Porting note: this was discharged after the apply previously
-      have : IsAffine (Scheme.OpenCover.obj
-        (Scheme.OpenCover.bind 𝒰 fun x ↦ Scheme.affineCover (Scheme.OpenCover.obj 𝒰 x)) i) := by
-          dsimp; infer_instance
-      apply @h𝒰 _ (show _ from _)
-  tfae_finish
+theorem iff_of_isAffine [IsAffine X] [IsAffine Y] :
+    P f ↔ Q (f.app ⊤) := by
+  rw [iff_of_openCover (P := P) (Scheme.openCoverOfIsIso.{u} (𝟙 _))]
+  simp
 
-theorem sourceAffineLocally_comp_of_isOpenImmersion {X Y Z : Scheme.{u}} [IsAffine Z] (f : X ⟶ Y)
-    (g : Y ⟶ Z) [IsOpenImmersion f] (H : sourceAffineLocally (@P) g) :
-    sourceAffineLocally (@P) (f ≫ g) := by
-      -- Porting note: more tfae mis-behavior
-      have := (hP.openCover_TFAE g).out 0 3
-      apply this.mp H
+theorem Spec_iff {R S : CommRingCat.{u}} {φ : R ⟶ S} :
+    P (Spec.map φ) ↔ Q φ := by
+  have H := (isLocal_ringHomProperty P).respectsIso
+  rw [iff_of_isAffine (P := P), ← H.cancel_right_isIso _ (Scheme.ΓSpecIso _).hom,
+    Scheme.ΓSpecIso_naturality, H.cancel_left_isIso]
 
-theorem source_affine_openCover_iff {X Y : Scheme.{u}} (f : X ⟶ Y) [IsAffine Y]
-    (𝒰 : Scheme.OpenCover.{u} X) [∀ i, IsAffine (𝒰.obj i)] :
-    sourceAffineLocally (@P) f ↔ ∀ i, P (Scheme.Γ.map (𝒰.map i ≫ f).op) := by
-  -- Porting note: seems like TFAE is misbehaving; this used to be pure term proof but
-  -- had strange failures where the output of TFAE turned into a metavariable when used despite
-  -- being correctly displayed in the infoview
-  refine ⟨fun H => ?_, fun H => ?_⟩
-  · have h := (hP.affine_openCover_TFAE f).out 0 2
-    apply h.mp
-    exact H
-  · have h := (hP.affine_openCover_TFAE f).out 1 0
-    apply h.mp
-    use 𝒰
+theorem of_iSup_eq_top [IsAffine Y] {ι : Type*}
+    (U : ι → X.affineOpens) (hU : ⨆ i, (U i : Opens X) = ⊤)
+    (H : ∀ i, Q (f.appLE ⊤ (U i).1 le_top)) :
+    P f := by
+  have (i) : IsAffine ((X.openCoverOfSuprEqTop _ hU).obj i) := (U i).2
+  refine of_openCover (X.openCoverOfSuprEqTop _ hU) fun i ↦ ?_
+  simpa [Scheme.Hom.app_eq_appLE] using (f.appLE_congr _ rfl (by simp) Q).mp (H i)
 
-theorem isLocal_sourceAffineLocally : (sourceAffineLocally @P).IsLocal :=
-  sourceAffineLocally_isLocal hP.respectsIso hP.LocalizationPreserves
-    (@RingHom.PropertyIsLocal.ofLocalizationSpan _ hP)
+theorem iff_of_iSup_eq_top [IsAffine Y] {ι : Type*}
+    (U : ι → X.affineOpens) (hU : ⨆ i, (U i : Opens X) = ⊤) :
+    P f ↔ ∀ i, Q (f.appLE ⊤ (U i).1 le_top) :=
+  ⟨fun H _ ↦ appLE P f H ⟨_, isAffineOpen_top _⟩ _ le_top, of_iSup_eq_top U hU⟩
 
-theorem hasAffinePropertyAffineLocally :
-    HasAffineProperty (affineLocally @P) (sourceAffineLocally @P) where
-  isLocal_affineProperty := hP.isLocal_sourceAffineLocally
-  eq_targetAffineLocally' := rfl
+lemma HasAffineProperty.isLocalAtSource (P) {Q} [HasAffineProperty P Q]
+    (H : ∀ {X Y : Scheme.{u}} (f : X ⟶ Y) [IsAffine Y] (𝒰 : Scheme.OpenCover.{u} X),
+        Q f ↔ ∀ i, Q (𝒰.map i ≫ f)) : IsLocalAtSource P where
+  iff_of_openCover' {X Y} f 𝒰 := by
+    simp_rw [IsLocalAtTarget.iff_of_iSup_eq_top _ (iSup_affineOpens_eq_top Y)]
+    rw [forall_comm]
+    refine forall_congr' fun U ↦ ?_
+    simp_rw [HasAffineProperty.iff_of_isAffine, morphismRestrict_comp]
+    exact @H _ _ (f ∣_ U.1) U.2 (𝒰.restrict (f ⁻¹ᵁ U.1))
 
-theorem affine_openCover_iff {X Y : Scheme.{u}} (f : X ⟶ Y) (𝒰 : Scheme.OpenCover.{u} Y)
-    [∀ i, IsAffine (𝒰.obj i)] (𝒰' : ∀ i, Scheme.OpenCover.{u} ((𝒰.pullbackCover f).obj i))
-    [∀ i j, IsAffine ((𝒰' i).obj j)] :
-    affineLocally (@P) f ↔ ∀ i j, P (Scheme.Γ.map ((𝒰' i).map j ≫ pullback.snd _ _).op) :=
-  letI := hP.hasAffinePropertyAffineLocally
-  (HasAffineProperty.iff_of_openCover 𝒰).trans
-    (forall_congr' fun i => hP.source_affine_openCover_iff _ (𝒰' i))
+instance : IsLocalAtSource P := by
+  apply HasAffineProperty.isLocalAtSource
+  intros X Y f _ 𝒰
+  simp_rw [← HasAffineProperty.iff_of_isAffine (P := P),
+    iff_of_openCover 𝒰.affineRefinement.openCover,
+    fun i ↦ iff_of_openCover (P := P) (f := 𝒰.map i ≫ f) (𝒰.obj i).affineCover]
+  simp [Scheme.OpenCover.affineRefinement]
 
-theorem source_openCover_iff {X Y : Scheme.{u}} (f : X ⟶ Y) (𝒰 : Scheme.OpenCover.{u} X) :
-    affineLocally (@P) f ↔ ∀ i, affineLocally (@P) (𝒰.map i ≫ f) := by
-  constructor
-  · intro H i U
-    rw [morphismRestrict_comp]
-    apply hP.sourceAffineLocally_comp_of_isOpenImmersion
-    apply H
-  · intro H U
-    haveI : IsAffine _ := U.2
-    apply ((hP.openCover_TFAE (f ∣_ U.1)).out 1 0).mp
-    use 𝒰.pullbackCover (X.ofRestrict _)
-    intro i
-    specialize H i U
-    rw [morphismRestrict_comp] at H
-    delta morphismRestrict at H
-    have := sourceAffineLocally_respectsIso hP.respectsIso
-    rw [Category.assoc, (sourceAffineLocally P).cancel_left_of_respectsIso,
-      ← (sourceAffineLocally P).cancel_left_of_respectsIso (pullbackSymmetry _ _).hom,
-      pullbackSymmetry_hom_comp_snd_assoc] at H
-    exact H
+instance : P.ContainsIdentities where
+  id_mem X := by
+    rw [IsLocalAtTarget.iff_of_iSup_eq_top (P := P) _ (iSup_affineOpens_eq_top _)]
+    intro U
+    rw [morphismRestrict_id, iff_of_isAffine (P := P), Scheme.id_app]
+    have := IsLocalization.at_units (.powers (1 : Γ(X ∣_ᵤ 𝟙 X ⁻¹ᵁ U, ⊤))) (by simp)
+    exact (isLocal_ringHomProperty P).HoldsForLocalizationAway Γ(X ∣_ᵤ 𝟙 X ⁻¹ᵁ U, ⊤) 1
 
-theorem affineLocally_of_isOpenImmersion (hP : RingHom.PropertyIsLocal @P) {X Y : Scheme.{u}}
-    (f : X ⟶ Y) [hf : IsOpenImmersion f] : affineLocally (@P) f := by
-  intro U
-  haveI H : IsAffine _ := U.2
-  rw [← Category.comp_id (f ∣_ U)]
-  apply hP.sourceAffineLocally_comp_of_isOpenImmersion
-  -- Porting note: need to excuse Lean from synthesizing an instance
-  rw [@source_affine_openCover_iff _ hP _ _ _ _ (Scheme.openCoverOfIsIso (𝟙 _)) (_)]
-  · intro i
-    let esto := Scheme.Γ.obj (Opposite.op (Y.restrict <| Opens.openEmbedding U.val))
-    let eso := Scheme.Γ.obj (Opposite.op ((Scheme.openCoverOfIsIso
-      (𝟙 (Y.restrict <| Opens.openEmbedding U.val))).obj i))
-    have := hP.HoldsForLocalizationAway
-    convert @this esto eso _ _ ?_ 1 ?_
-    · exact (RingHom.algebraMap_toAlgebra (Scheme.Γ.map _)).symm
-    · exact
-        @IsLocalization.away_of_isUnit_of_bijective _ _ _ _ (_) _ isUnit_one Function.bijective_id
-  · intro; exact H
-
-theorem affineLocally_of_comp
-    (H : ∀ {R S T : Type u} [CommRing R] [CommRing S] [CommRing T],
-      ∀ (f : R →+* S) (g : S →+* T), P (g.comp f) → P g)
-    {X Y Z : Scheme.{u}} {f : X ⟶ Y} {g : Y ⟶ Z} (h : affineLocally (@P) (f ≫ g)) :
-    affineLocally (@P) f := by
-  let 𝒰 : ∀ i, ((Z.affineCover.pullbackCover (f ≫ g)).obj i).OpenCover := by
-    intro i
-    refine Scheme.OpenCover.bind ?_ fun i => Scheme.affineCover _
-    apply Scheme.OpenCover.pushforwardIso _
-      (pullbackRightPullbackFstIso g (Z.affineCover.map i) f).hom
-    apply Scheme.Pullback.openCoverOfRight
-    exact (pullback g (Z.affineCover.map i)).affineCover
-  have h𝒰 : ∀ i j, IsAffine ((𝒰 i).obj j) := by dsimp [𝒰]; infer_instance
-  let 𝒰' := (Z.affineCover.pullbackCover g).bind fun i => Scheme.affineCover _
-  have h𝒰' : ∀ i, IsAffine (𝒰'.obj i) := by dsimp [𝒰']; infer_instance
-  rw [hP.affine_openCover_iff f 𝒰' fun i => Scheme.affineCover _]
-  rw [hP.affine_openCover_iff (f ≫ g) Z.affineCover 𝒰] at h
-  rintro ⟨i, j⟩ k
-  dsimp at i j k
-  specialize h i ⟨j, k⟩
-  dsimp only [𝒰, 𝒰', Scheme.OpenCover.bind_map, Scheme.OpenCover.pushforwardIso_obj,
-    Scheme.Pullback.openCoverOfRight_obj, Scheme.OpenCover.pushforwardIso_map,
-    Scheme.Pullback.openCoverOfRight_map, Scheme.OpenCover.bind_obj,
-    Scheme.OpenCover.pullbackCover_obj, Scheme.OpenCover.pullbackCover_map] at h ⊢
-  rw [Category.assoc, Category.assoc, pullbackRightPullbackFstIso_hom_snd,
-    pullback.lift_snd_assoc, Category.assoc, ← Category.assoc, op_comp, Functor.map_comp] at h
-  exact H _ _ h
-
-theorem affineLocally_isStableUnderComposition : (affineLocally @P).IsStableUnderComposition where
-  comp_mem {X Y S} f g hf hg := by
-    let 𝒰 : ∀ i, ((S.affineCover.pullbackCover (f ≫ g)).obj i).OpenCover := by
+instance : P.IsStableUnderComposition where
+  comp_mem {X Y Z} f g hf hg := by
+    wlog hZ : IsAffine Z generalizing X Y Z
+    · rw [IsLocalAtTarget.iff_of_iSup_eq_top (P := P) _ (iSup_affineOpens_eq_top _)]
+      intro U
+      rw [morphismRestrict_comp]
+      exact this _ _ (IsLocalAtTarget.restrict hf _) (IsLocalAtTarget.restrict hg _) U.2
+    wlog hY : IsAffine Y generalizing X Y
+    · rw [IsLocalAtSource.iff_of_openCover (P := P) (Y.affineCover.pullbackCover f)]
       intro i
-      refine Scheme.OpenCover.bind ?_ fun i => Scheme.affineCover _
-      apply Scheme.OpenCover.pushforwardIso _
-        (pullbackRightPullbackFstIso g (S.affineCover.map i) f).hom
-      apply Scheme.Pullback.openCoverOfRight
-      exact (pullback g (S.affineCover.map i)).affineCover
-    -- Porting note: used to be - rw [hP.affine_openCover_iff (f ≫ g) S.affineCover _] - but
-    -- metavariables cause problems in the instance search
-    apply (@affine_openCover_iff _ hP _ _ (f ≫ g) S.affineCover _ ?_ ?_).mpr
-    rotate_left
-    · exact 𝒰
-    · intro i j; dsimp [𝒰] at *; infer_instance
-    · rintro i ⟨j, k⟩
-      dsimp at i j k
-      dsimp only [𝒰, Scheme.OpenCover.bind_map, Scheme.OpenCover.pushforwardIso_obj,
-        Scheme.Pullback.openCoverOfRight_obj, Scheme.OpenCover.pushforwardIso_map,
-        Scheme.Pullback.openCoverOfRight_map, Scheme.OpenCover.bind_obj]
-      rw [Category.assoc, Category.assoc, pullbackRightPullbackFstIso_hom_snd,
-        pullback.lift_snd_assoc, Category.assoc, ← Category.assoc, op_comp, Functor.map_comp]
-      apply hP.StableUnderComposition
-      · -- Porting note: used to be exact _|>. hg i j but that can't find an instance
-        apply hP.affine_openCover_iff _ _ _|>.mp
-        exact hg
-      · letI := hP.hasAffinePropertyAffineLocally
-        replace hf := HasAffineProperty.of_isPullback (.of_hasPullback _
-          ((pullback g (S.affineCover.map i)).affineCover.map j ≫ pullback.fst _ _)) hf
-        -- Porting note: again strange behavior of TFAE
-        have := (hP.affine_openCover_TFAE
-          (pullback.snd f ((pullback g (S.affineCover.map i)).affineCover.map j ≫
-            pullback.fst _ _))).out 0 3
-        apply this.mp hf
+      rw [← Scheme.OpenCover.pullbackHom_map_assoc]
+      exact this _ _ (IsLocalAtTarget.of_isPullback (.of_hasPullback _ _) hf)
+        (comp_of_isOpenImmersion _ _ _ hg) inferInstance
+    wlog hX : IsAffine X generalizing X
+    · rw [IsLocalAtSource.iff_of_openCover (P := P) X.affineCover]
+      intro i
+      rw [← Category.assoc]
+      exact this _ (comp_of_isOpenImmersion _ _ _ hf) inferInstance
+    rw [iff_of_isAffine (P := P)] at hf hg ⊢
+    exact (isLocal_ringHomProperty P).StableUnderComposition _ _ hg hf
 
-end RingHom.PropertyIsLocal
+instance : P.IsMultiplicative where
+
+lemma of_isOpenImmersion [IsOpenImmersion f] : P f := IsLocalAtSource.of_isOpenImmersion f
+
+lemma stableUnderBaseChange (hP : RingHom.StableUnderBaseChange Q) : P.StableUnderBaseChange := by
+  apply HasAffineProperty.stableUnderBaseChange
+  letI := HasAffineProperty.isLocal_affineProperty P
+  apply AffineTargetMorphismProperty.StableUnderBaseChange.mk
+  intros X Y S _ _ f g H
+  rw [← HasAffineProperty.iff_of_isAffine (P := P)] at H ⊢
+  wlog hX : IsAffine Y generalizing Y
+  · rw [IsLocalAtSource.iff_of_openCover (P := P)
+      (Scheme.Pullback.openCoverOfRight Y.affineCover f g)]
+    intro i
+    simp only [Scheme.Pullback.openCoverOfRight_obj, Scheme.Pullback.openCoverOfRight_map,
+      limit.lift_π, PullbackCone.mk_pt, PullbackCone.mk_π_app, Category.comp_id]
+    apply this _ (comp_of_isOpenImmersion _ _ _ H) inferInstance
+  rw [iff_of_isAffine (P := P)] at H ⊢
+  exact hP.pullback_fst_app_top _ (isLocal_ringHomProperty P).respectsIso _ _ H
+
+end HasRingHomProperty

--- a/Mathlib/AlgebraicGeometry/Morphisms/RingHomProperties.lean
+++ b/Mathlib/AlgebraicGeometry/Morphisms/RingHomProperties.lean
@@ -32,10 +32,10 @@ We also provide the following interface:
 ## `HasRingHomProperty`
 
 `HasRingHomProperty P Q` is a type class asserting that `P` is local at the target and the source,
-and for `f : Spec B ⟶ Spec A`, it is equivalent to the ring hom property `Q`.
+and for `f : Spec B ⟶ Spec A`, it is equivalent to the ring hom property `Q` on `Γ(f)`.
 
 For `HasRingHomProperty P Q` and `f : X ⟶ Y`, we provide these API lemmas:
-- `AlgebraicGeometry.HasAffineProperty.iff_appLE`:
+- `AlgebraicGeometry.HasRingHomProperty.iff_appLE`:
     `P f` if and only if `Q (f.appLE U V _)` for all affine `U : Opens Y` and `V : Opens X`.
 - `AlgebraicGeometry.HasAffineProperty.iff_of_openCover`:
     If `Y` is affine, `P f ↔ ∀ i, Q ((𝒰.map i ≫ f).app ⊤)` for an affine open cover `𝒰` of `X`.
@@ -171,6 +171,7 @@ and for `f : Spec B ⟶ Spec A`, it is equivalent to the ring hom property `Q`.
 To make the proofs easier, we state it instead as
 1. `Q` is local (See `RingHom.PropertyIsLocal`)
 2. `P f` if and only if `Q` holds for every `Γ(Y, U) ⟶ Γ(X, V)` for all affine `U`, `V`.
+See `HasRingHomProperty.iff_appLE`.
 -/
 class HasRingHomProperty (P : MorphismProperty Scheme.{u})
     (Q : outParam (∀ {R S : Type u} [CommRing R] [CommRing S], (R →+* S) → Prop)) : Prop where
@@ -186,9 +187,9 @@ lemma eq_affineLocally : P = affineLocally Q := eq_affineLocally'
 
 instance : HasAffineProperty P (sourceAffineLocally Q) where
   isLocal_affineProperty := sourceAffineLocally_isLocal _
-    (HasRingHomProperty.isLocal_ringHomProperty P).respectsIso
-    (HasRingHomProperty.isLocal_ringHomProperty P).LocalizationPreserves
-    (HasRingHomProperty.isLocal_ringHomProperty P).ofLocalizationSpan
+    (isLocal_ringHomProperty P).respectsIso
+    (isLocal_ringHomProperty P).LocalizationPreserves
+    (isLocal_ringHomProperty P).ofLocalizationSpan
   eq_targetAffineLocally' := eq_affineLocally P
 
 theorem appLE (H : P f) (U : Y.affineOpens) (V : X.affineOpens) (e) : Q (f.appLE U V e) := by

--- a/Mathlib/AlgebraicGeometry/Morphisms/RingHomProperties.lean
+++ b/Mathlib/AlgebraicGeometry/Morphisms/RingHomProperties.lean
@@ -185,7 +185,8 @@ variable {X Y Z : Scheme.{u}} (f : X ⟶ Y) (g : Y ⟶ Z)
 
 lemma eq_affineLocally : P = affineLocally Q := eq_affineLocally'
 
-instance : HasAffineProperty P (sourceAffineLocally Q) where
+@[local instance]
+lemma HasAffineProperty : HasAffineProperty P (sourceAffineLocally Q) where
   isLocal_affineProperty := sourceAffineLocally_isLocal _
     (isLocal_ringHomProperty P).respectsIso
     (isLocal_ringHomProperty P).LocalizationPreserves

--- a/Mathlib/AlgebraicGeometry/Morphisms/RingHomProperties.lean
+++ b/Mathlib/AlgebraicGeometry/Morphisms/RingHomProperties.lean
@@ -37,7 +37,7 @@ and for `f : Spec B ⟶ Spec A`, it is equivalent to the ring hom property `Q`.
 For `HasRingHomProperty P Q` and `f : X ⟶ Y`, we provide these API lemmas:
 - `AlgebraicGeometry.HasAffineProperty.iff_appLE`:
     `P f` if and only if `Q (f.appLE U V _)` for all affine `U : Opens Y` and `V : Opens X`.
-- `AlgebraicGeometry.HasAffineProperty.iff_of_openCover`:
+- `AlgebraicGeometry.HasAffineProperty.iff_of_source_openCover`:
     If `Y` is affine, `P f ↔ ∀ i, Q ((𝒰.map i ≫ f).app ⊤)` for an affine open cover `𝒰` of `X`.
 - `AlgebraicGeometry.HasAffineProperty.iff_of_isAffine`:
     If `X` and `Y` are affine, then `P f ↔ Q (f.app ⊤)`.
@@ -216,7 +216,7 @@ variable {P f}
 lemma iff_appLE : P f ↔ ∀ (U : Y.affineOpens) (V : X.affineOpens) (e), Q (f.appLE U V e) := by
   rw [eq_affineLocally P, affineLocally_iff_affineOpens_le]
 
-theorem of_openCover [IsAffine Y]
+theorem of_source_openCover [IsAffine Y]
     (𝒰 : X.OpenCover) [∀ i, IsAffine (𝒰.obj i)] (H : ∀ i, Q ((𝒰.map i ≫ f).app ⊤)) :
     P f := by
   rw [HasAffineProperty.iff_of_isAffine (P := P)]
@@ -245,13 +245,13 @@ theorem of_openCover [IsAffine Y]
       Scheme.ofRestrict_app, Scheme.Hom.app_eq_appLE, Scheme.Hom.appLE_map] at H
     exact (f.appLE_congr _ rfl (by simp) Q).mp H
 
-theorem iff_of_openCover [IsAffine Y] (𝒰 : X.OpenCover) [∀ i, IsAffine (𝒰.obj i)] :
+theorem iff_of_source_openCover [IsAffine Y] (𝒰 : X.OpenCover) [∀ i, IsAffine (𝒰.obj i)] :
     P f ↔ ∀ i, Q ((𝒰.map i ≫ f).app ⊤) :=
-  ⟨fun H i ↦ app_top P _ (comp_of_isOpenImmersion P (𝒰.map i) f H), of_openCover 𝒰⟩
+  ⟨fun H i ↦ app_top P _ (comp_of_isOpenImmersion P (𝒰.map i) f H), of_source_openCover 𝒰⟩
 
 theorem iff_of_isAffine [IsAffine X] [IsAffine Y] :
     P f ↔ Q (f.app ⊤) := by
-  rw [iff_of_openCover (P := P) (Scheme.openCoverOfIsIso.{u} (𝟙 _))]
+  rw [iff_of_source_openCover (P := P) (Scheme.openCoverOfIsIso.{u} (𝟙 _))]
   simp
 
 theorem Spec_iff {R S : CommRingCat.{u}} {φ : R ⟶ S} :
@@ -265,7 +265,7 @@ theorem of_iSup_eq_top [IsAffine Y] {ι : Type*}
     (H : ∀ i, Q (f.appLE ⊤ (U i).1 le_top)) :
     P f := by
   have (i) : IsAffine ((X.openCoverOfSuprEqTop _ hU).obj i) := (U i).2
-  refine of_openCover (X.openCoverOfSuprEqTop _ hU) fun i ↦ ?_
+  refine of_source_openCover (X.openCoverOfSuprEqTop _ hU) fun i ↦ ?_
   simpa [Scheme.Hom.app_eq_appLE] using (f.appLE_congr _ rfl (by simp) Q).mp (H i)
 
 theorem iff_of_iSup_eq_top [IsAffine Y] {ι : Type*}
@@ -273,22 +273,12 @@ theorem iff_of_iSup_eq_top [IsAffine Y] {ι : Type*}
     P f ↔ ∀ i, Q (f.appLE ⊤ (U i).1 le_top) :=
   ⟨fun H _ ↦ appLE P f H ⟨_, isAffineOpen_top _⟩ _ le_top, of_iSup_eq_top U hU⟩
 
-lemma HasAffineProperty.isLocalAtSource (P) {Q} [HasAffineProperty P Q]
-    (H : ∀ {X Y : Scheme.{u}} (f : X ⟶ Y) [IsAffine Y] (𝒰 : Scheme.OpenCover.{u} X),
-        Q f ↔ ∀ i, Q (𝒰.map i ≫ f)) : IsLocalAtSource P where
-  iff_of_openCover' {X Y} f 𝒰 := by
-    simp_rw [IsLocalAtTarget.iff_of_iSup_eq_top _ (iSup_affineOpens_eq_top Y)]
-    rw [forall_comm]
-    refine forall_congr' fun U ↦ ?_
-    simp_rw [HasAffineProperty.iff_of_isAffine, morphismRestrict_comp]
-    exact @H _ _ (f ∣_ U.1) U.2 (𝒰.restrict (f ⁻¹ᵁ U.1))
-
 instance : IsLocalAtSource P := by
   apply HasAffineProperty.isLocalAtSource
   intros X Y f _ 𝒰
   simp_rw [← HasAffineProperty.iff_of_isAffine (P := P),
-    iff_of_openCover 𝒰.affineRefinement.openCover,
-    fun i ↦ iff_of_openCover (P := P) (f := 𝒰.map i ≫ f) (𝒰.obj i).affineCover]
+    iff_of_source_openCover 𝒰.affineRefinement.openCover,
+    fun i ↦ iff_of_source_openCover (P := P) (f := 𝒰.map i ≫ f) (𝒰.obj i).affineCover]
   simp [Scheme.OpenCover.affineRefinement]
 
 instance : P.ContainsIdentities where
@@ -296,8 +286,8 @@ instance : P.ContainsIdentities where
     rw [IsLocalAtTarget.iff_of_iSup_eq_top (P := P) _ (iSup_affineOpens_eq_top _)]
     intro U
     rw [morphismRestrict_id, iff_of_isAffine (P := P), Scheme.id_app]
-    have := IsLocalization.at_units (.powers (1 : Γ(X ∣_ᵤ 𝟙 X ⁻¹ᵁ U, ⊤))) (by simp)
-    exact (isLocal_ringHomProperty P).HoldsForLocalizationAway Γ(X ∣_ᵤ 𝟙 X ⁻¹ᵁ U, ⊤) 1
+    exact (isLocal_ringHomProperty P).HoldsForLocalizationAway.of_bijective _ _
+      Function.bijective_id
 
 instance : P.IsStableUnderComposition where
   comp_mem {X Y Z} f g hf hg := by

--- a/Mathlib/AlgebraicGeometry/Morphisms/RingHomProperties.lean
+++ b/Mathlib/AlgebraicGeometry/Morphisms/RingHomProperties.lean
@@ -341,3 +341,5 @@ lemma stableUnderBaseChange (hP : RingHom.StableUnderBaseChange Q) : P.StableUnd
   exact hP.pullback_fst_app_top _ (isLocal_ringHomProperty P).respectsIso _ _ H
 
 end HasRingHomProperty
+
+end AlgebraicGeometry

--- a/Mathlib/AlgebraicGeometry/Morphisms/RingHomProperties.lean
+++ b/Mathlib/AlgebraicGeometry/Morphisms/RingHomProperties.lean
@@ -320,6 +320,32 @@ instance : P.IsStableUnderComposition where
     rw [iff_of_isAffine (P := P)] at hf hg ⊢
     exact (isLocal_ringHomProperty P).StableUnderComposition _ _ hg hf
 
+theorem of_comp
+    (H : ∀ {R S T : Type u} [CommRing R] [CommRing S] [CommRing T],
+      ∀ (f : R →+* S) (g : S →+* T), Q (g.comp f) → Q g)
+    {X Y Z : Scheme.{u}} {f : X ⟶ Y} {g : Y ⟶ Z} (h : P (f ≫ g)) : P f := by
+  wlog hZ : IsAffine Z generalizing X Y Z
+  · rw [IsLocalAtTarget.iff_of_iSup_eq_top (P := P) _
+      (g.preimage_iSup_eq_top (iSup_affineOpens_eq_top Z))]
+    intro U
+    have H := IsLocalAtTarget.restrict h U.1
+    rw [morphismRestrict_comp] at H
+    exact this H inferInstance
+  wlog hY : IsAffine Y generalizing X Y
+  · rw [IsLocalAtTarget.iff_of_iSup_eq_top (P := P) _ (iSup_affineOpens_eq_top Y)]
+    intro U
+    have H := comp_of_isOpenImmersion P (Scheme.ιOpens (f ⁻¹ᵁ U.1)) (f ≫ g) h
+    rw [← morphismRestrict_ι_assoc] at H
+    exact this H inferInstance
+  wlog hY : IsAffine X generalizing X
+  · rw [IsLocalAtSource.iff_of_iSup_eq_top (P := P) _ (iSup_affineOpens_eq_top X)]
+    intro U
+    have H := comp_of_isOpenImmersion P (Scheme.ιOpens U.1) (f ≫ g) h
+    rw [← Category.assoc] at H
+    exact this H inferInstance
+  rw [iff_of_isAffine (P := P)] at h ⊢
+  exact H _ _ h
+
 instance : P.IsMultiplicative where
 
 lemma of_isOpenImmersion [IsOpenImmersion f] : P f := IsLocalAtSource.of_isOpenImmersion f

--- a/Mathlib/AlgebraicGeometry/Morphisms/RingHomProperties.lean
+++ b/Mathlib/AlgebraicGeometry/Morphisms/RingHomProperties.lean
@@ -37,17 +37,17 @@ and for `f : Spec B ⟶ Spec A`, it is equivalent to the ring hom property `Q` o
 For `HasRingHomProperty P Q` and `f : X ⟶ Y`, we provide these API lemmas:
 - `AlgebraicGeometry.HasRingHomProperty.iff_appLE`:
     `P f` if and only if `Q (f.appLE U V _)` for all affine `U : Opens Y` and `V : Opens X`.
-- `AlgebraicGeometry.HasAffineProperty.iff_of_source_openCover`:
+- `AlgebraicGeometry.HasRingHomProperty.iff_of_source_openCover`:
     If `Y` is affine, `P f ↔ ∀ i, Q ((𝒰.map i ≫ f).app ⊤)` for an affine open cover `𝒰` of `X`.
-- `AlgebraicGeometry.HasAffineProperty.iff_of_isAffine`:
+- `AlgebraicGeometry.HasRingHomProperty.iff_of_isAffine`:
     If `X` and `Y` are affine, then `P f ↔ Q (f.app ⊤)`.
-- `AlgebraicGeometry.HasAffineProperty.Spec_iff`:
+- `AlgebraicGeometry.HasRingHomProperty.Spec_iff`:
     `P (Spec.map φ) ↔ Q φ`
-- `AlgebraicGeometry.HasAffineProperty.iff_of_iSup_eq_top`:
+- `AlgebraicGeometry.HasRingHomProperty.iff_of_iSup_eq_top`:
     If `Y` is affine, `P f ↔ ∀ i, Q (f.appLE ⊤ (U i) _)` for a family `U` of affine opens of `X`.
-- `AlgebraicGeometry.HasAffineProperty.of_isOpenImmersion`:
+- `AlgebraicGeometry.HasRingHomProperty.of_isOpenImmersion`:
     If `f` is an open immersion then `P f`.
-- `AlgebraicGeometry.HasAffineProperty.stableUnderBaseChange`:
+- `AlgebraicGeometry.HasRingHomProperty.stableUnderBaseChange`:
     If `Q` is stable under base change, then so is `P`.
 
 We also provide the instances `P.IsMultiplicative`, `P.IsStableUnderComposition`,

--- a/Mathlib/AlgebraicGeometry/Restrict.lean
+++ b/Mathlib/AlgebraicGeometry/Restrict.lean
@@ -469,7 +469,8 @@ end MorphismRestrict
 /-- The restriction of an open cover to an open subset. -/
 @[simps! J obj map]
 noncomputable
-def Scheme.OpenCover.restrict {X : Scheme} (𝒰 : X.OpenCover) (U : Opens X) : (X ∣_ᵤ U).OpenCover := by
+def Scheme.OpenCover.restrict {X : Scheme.{u}} (𝒰 : X.OpenCover) (U : Opens X) :
+    (X ∣_ᵤ U).OpenCover := by
   refine copy (𝒰.pullbackCover (ιOpens U)) 𝒰.J _ (𝒰.map · ∣_ U) (Equiv.refl _)
     (fun i ↦ IsOpenImmersion.isoOfRangeEq (ιOpens _) (pullback.snd _ _) ?_) ?_
   · erw [IsOpenImmersion.range_pullback_snd_of_left (ιOpens U) (𝒰.map i)]

--- a/Mathlib/AlgebraicGeometry/Restrict.lean
+++ b/Mathlib/AlgebraicGeometry/Restrict.lean
@@ -288,6 +288,10 @@ theorem isPullback_morphismRestrict {X Y : Scheme.{u}} (f : X ⟶ Y) (U : Opens 
   -- Porting note: changed `rw` to `erw`
   erw [pullbackRestrictIsoRestrict_inv_fst]; rw [Category.comp_id]
 
+@[simp]
+lemma morphismRestrict_id {X : Scheme.{u}} (U : Opens X) : 𝟙 X ∣_ U = 𝟙 _ := by
+  rw [← cancel_mono (Scheme.ιOpens U), morphismRestrict_ι, Category.comp_id, Category.id_comp]
+
 theorem morphismRestrict_comp {X Y Z : Scheme.{u}} (f : X ⟶ Y) (g : Y ⟶ Z) (U : Opens Z) :
     (f ≫ g) ∣_ U = f ∣_ g ⁻¹ᵁ U ≫ g ∣_ U := by
   delta morphismRestrict
@@ -364,16 +368,6 @@ theorem Γ_map_morphismRestrict {X Y : Scheme.{u}} (f : X ⟶ Y) (U : Opens Y) :
         f.app U ≫ X.presheaf.map (eqToHom (f ⁻¹ᵁ U).openEmbedding_obj_top).op := by
   rw [Scheme.Γ_map_op, morphismRestrict_app f U ⊤, f.naturality_assoc, ← X.presheaf.map_comp]
   rfl
-
-@[simp]
-lemma morphismRestrict_id {X : Scheme.{u}} (U : Opens X) : 𝟙 X ∣_ U = 𝟙 _ := by
-  ext1
-  · ext; erw [morphismRestrict_val_base (𝟙 X) U]; rfl
-  · simp only [Scheme.restrict_presheaf_obj, Scheme.id_val_base, Opens.carrier_eq_coe,
-      TopCat.coe_id, id_eq, eq_mpr_eq_cast, morphismRestrict_app', Scheme.Hom.appLE, Scheme.id_app,
-      Category.id_comp, eqToHom_op, Scheme.restrict_presheaf_map, ← Functor.map_comp]
-    rw [← X.presheaf.map_id]
-    rfl
 
 /-- Restricting a morphism onto the image of an open immersion is isomorphic to the base change
 along the immersion. -/

--- a/Mathlib/AlgebraicGeometry/Restrict.lean
+++ b/Mathlib/AlgebraicGeometry/Restrict.lean
@@ -3,7 +3,7 @@ Copyright (c) 2021 Andrew Yang. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Andrew Yang
 -/
-import Mathlib.AlgebraicGeometry.OpenImmersion
+import Mathlib.AlgebraicGeometry.Cover.Open
 
 /-!
 # Restriction of Schemes and Morphisms
@@ -365,6 +365,16 @@ theorem Γ_map_morphismRestrict {X Y : Scheme.{u}} (f : X ⟶ Y) (U : Opens Y) :
   rw [Scheme.Γ_map_op, morphismRestrict_app f U ⊤, f.naturality_assoc, ← X.presheaf.map_comp]
   rfl
 
+@[simp]
+lemma morphismRestrict_id {X : Scheme.{u}} (U : Opens X) : 𝟙 X ∣_ U = 𝟙 _ := by
+  ext1
+  · ext; erw [morphismRestrict_val_base (𝟙 X) U]; rfl
+  · simp only [Scheme.restrict_presheaf_obj, Scheme.id_val_base, Opens.carrier_eq_coe,
+      TopCat.coe_id, id_eq, eq_mpr_eq_cast, morphismRestrict_app', Scheme.Hom.appLE, Scheme.id_app,
+      Category.id_comp, eqToHom_op, Scheme.restrict_presheaf_map, ← Functor.map_comp]
+    rw [← X.presheaf.map_id]
+    rfl
+
 /-- Restricting a morphism onto the image of an open immersion is isomorphic to the base change
 along the immersion. -/
 def morphismRestrictOpensRange
@@ -455,5 +465,20 @@ instance {X Y : Scheme.{u}} (f : X ⟶ Y) (U : Opens Y) [IsOpenImmersion f] :
   exact PresheafedSpace.IsOpenImmersion.comp _ _
 
 end MorphismRestrict
+
+/-- The restriction of an open cover to an open subset. -/
+@[simps! J obj map]
+noncomputable
+def Scheme.OpenCover.restrict {X : Scheme} (𝒰 : X.OpenCover) (U : Opens X) : (X ∣_ᵤ U).OpenCover := by
+  refine copy (𝒰.pullbackCover (ιOpens U)) 𝒰.J _ (𝒰.map · ∣_ U) (Equiv.refl _)
+    (fun i ↦ IsOpenImmersion.isoOfRangeEq (ιOpens _) (pullback.snd _ _) ?_) ?_
+  · erw [IsOpenImmersion.range_pullback_snd_of_left (ιOpens U) (𝒰.map i)]
+    rw [opensRange_ιOpens]
+    exact Subtype.range_val
+  · intro i
+    rw [← cancel_mono (ιOpens U)]
+    simp only [morphismRestrict_ι, pullbackCover_J, Equiv.refl_apply, pullbackCover_obj,
+      pullbackCover_map, Category.assoc, pullback.condition]
+    erw [IsOpenImmersion.isoOfRangeEq_hom_fac_assoc]
 
 end AlgebraicGeometry

--- a/Mathlib/AlgebraicGeometry/Scheme.lean
+++ b/Mathlib/AlgebraicGeometry/Scheme.lean
@@ -149,6 +149,12 @@ protected lemma ext {f g : X ⟶ Y} (h_base : f.1.base = g.1.base)
   LocallyRingedSpace.Hom.ext _ _ <| SheafedSpace.ext _ _ h_base
     (TopCat.Presheaf.ext fun U ↦ by simpa using h_app U)
 
+lemma preimage_iSup {ι} (U : ι → Opens Y) : f ⁻¹ᵁ iSup U = ⨆ i, f ⁻¹ᵁ U i :=
+  Opens.ext (by simp)
+
+lemma preimage_iSup_eq_top {ι} {U : ι → Opens Y} (hU : iSup U = ⊤) :
+    ⨆ i, f ⁻¹ᵁ U i = ⊤ := (f.preimage_iSup U).symm.trans (by rw [hU]; rfl)
+
 end Hom
 
 /-- The forgetful functor from `Scheme` to `LocallyRingedSpace`. -/

--- a/Mathlib/AlgebraicGeometry/Scheme.lean
+++ b/Mathlib/AlgebraicGeometry/Scheme.lean
@@ -153,7 +153,7 @@ lemma preimage_iSup {ι} (U : ι → Opens Y) : f ⁻¹ᵁ iSup U = ⨆ i, f ⁻
   Opens.ext (by simp)
 
 lemma preimage_iSup_eq_top {ι} {U : ι → Opens Y} (hU : iSup U = ⊤) :
-    ⨆ i, f ⁻¹ᵁ U i = ⊤ := (f.preimage_iSup U).symm.trans (by rw [hU]; rfl)
+    ⨆ i, f ⁻¹ᵁ U i = ⊤ := f.preimage_iSup U ▸ hU ▸ rfl
 
 end Hom
 

--- a/Mathlib/AlgebraicGeometry/Scheme.lean
+++ b/Mathlib/AlgebraicGeometry/Scheme.lean
@@ -142,6 +142,13 @@ lemma appLE_congr (e : V ≤ f ⁻¹ᵁ U) (e₁ : U = U') (e₂ : V = V')
 noncomputable def homeomorph [IsIso f] : X ≃ₜ Y :=
   TopCat.homeoOfIso (asIso <| f.val.base)
 
+@[ext]
+protected lemma ext {f g : X ⟶ Y} (h_base : f.1.base = g.1.base)
+    (h_app : ∀ U, f.app U ≫ X.presheaf.map
+      (eqToHom congr((Opens.map $h_base.symm).obj U)).op = g.app U) : f = g :=
+  LocallyRingedSpace.Hom.ext _ _ <| SheafedSpace.ext _ _ h_base
+    (TopCat.Presheaf.ext fun U ↦ by simpa using h_app U)
+
 end Hom
 
 /-- The forgetful functor from `Scheme` to `LocallyRingedSpace`. -/

--- a/Mathlib/RingTheory/LocalProperties.lean
+++ b/Mathlib/RingTheory/LocalProperties.lean
@@ -162,6 +162,15 @@ theorem RingHom.ofLocalizationSpanTarget_iff_finite :
     obtain ⟨s', h₁, h₂⟩ := (Ideal.span_eq_top_iff_finite s).mp hs
     exact h s' h₂ fun x => hs' ⟨_, h₁ x.prop⟩
 
+theorem RingHom.HoldsForLocalizationAway.of_bijective
+    (H : RingHom.HoldsForLocalizationAway P) (hf : Function.Bijective f) :
+    P f := by
+  letI := f.toAlgebra
+  have := IsLocalization.at_units (.powers (1 : R)) (by simp)
+  have := IsLocalization.isLocalization_of_algEquiv (.powers (1 : R))
+    (AlgEquiv.ofBijective (Algebra.ofId R S) hf)
+  exact H _ 1
+
 variable {P f R' S'}
 
 theorem RingHom.PropertyIsLocal.respectsIso (hP : RingHom.PropertyIsLocal @P) :


### PR DESCRIPTION
`HasRingHomProperty P Q` is a type class asserting that `P` is local at the target and the source,
and for `f : Spec B ⟶ Spec A`, it is equivalent to the ring hom property `Q` on `Γ(f)`.
This replace the previous API `affineLocally` that is both slow and hard to use.

This is then used to refactor `LocallyOfFiniteType` and to deduplicate code.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
