### PR TITLE
[Merged by Bors] - chore: robustifying for debug.byAsSorry

### DIFF
--- a/Mathlib/Algebra/Divisibility/Basic.lean
+++ b/Mathlib/Algebra/Divisibility/Basic.lean
@@ -157,7 +157,7 @@ section CommSemigroup
 variable [CommSemigroup α] {a b c : α}
 
 theorem Dvd.intro_left (c : α) (h : c * a = b) : a ∣ b :=
-  Dvd.intro _ (by rw [mul_comm] at h; apply h)
+  Dvd.intro c (by rw [mul_comm] at h; apply h)
 
 alias dvd_of_mul_left_eq := Dvd.intro_left
 

--- a/Mathlib/Algebra/Divisibility/Units.lean
+++ b/Mathlib/Algebra/Divisibility/Units.lean
@@ -98,7 +98,7 @@ variable [CommMonoid α] {a b u : α}
 /-- In a commutative monoid, an element `a` divides an element `b` iff `a` divides all left
     associates of `b`. -/
 @[simp]
-theorem dvd_mul_left(hu : IsUnit u)  : a ∣ u * b ↔ a ∣ b := by
+theorem dvd_mul_left (hu : IsUnit u) : a ∣ u * b ↔ a ∣ b := by
   rcases hu with ⟨u, rfl⟩
   apply Units.dvd_mul_left
 

--- a/Mathlib/Algebra/Divisibility/Units.lean
+++ b/Mathlib/Algebra/Divisibility/Units.lean
@@ -67,44 +67,45 @@ namespace IsUnit
 
 section Monoid
 
-variable [Monoid α] {a b u : α} (hu : IsUnit u)
+variable [Monoid α] {a b u : α}
 
 /-- Units of a monoid divide any element of the monoid. -/
 @[simp]
-theorem dvd : u ∣ a := by
+theorem dvd (hu : IsUnit u) : u ∣ a := by
   rcases hu with ⟨u, rfl⟩
   apply Units.coe_dvd
 
 @[simp]
-theorem dvd_mul_right : a ∣ b * u ↔ a ∣ b := by
+theorem dvd_mul_right (hu : IsUnit u) : a ∣ b * u ↔ a ∣ b := by
   rcases hu with ⟨u, rfl⟩
   apply Units.dvd_mul_right
 
 /-- In a monoid, an element a divides an element b iff all associates of `a` divide `b`. -/
 @[simp]
-theorem mul_right_dvd : a * u ∣ b ↔ a ∣ b := by
+theorem mul_right_dvd (hu : IsUnit u) : a * u ∣ b ↔ a ∣ b := by
   rcases hu with ⟨u, rfl⟩
   apply Units.mul_right_dvd
 
-theorem isPrimal : IsPrimal u := fun _ _ _ ↦ ⟨u, 1, hu.dvd, one_dvd _, (mul_one u).symm⟩
+theorem isPrimal (hu : IsUnit u) : IsPrimal u :=
+  fun _ _ _ ↦ ⟨u, 1, hu.dvd, one_dvd _, (mul_one u).symm⟩
 
 end Monoid
 
 section CommMonoid
 
-variable [CommMonoid α] {a b u : α} (hu : IsUnit u)
+variable [CommMonoid α] {a b u : α}
 
 /-- In a commutative monoid, an element `a` divides an element `b` iff `a` divides all left
     associates of `b`. -/
 @[simp]
-theorem dvd_mul_left : a ∣ u * b ↔ a ∣ b := by
+theorem dvd_mul_left(hu : IsUnit u)  : a ∣ u * b ↔ a ∣ b := by
   rcases hu with ⟨u, rfl⟩
   apply Units.dvd_mul_left
 
 /-- In a commutative monoid, an element `a` divides an element `b` iff all
   left associates of `a` divide `b`. -/
 @[simp]
-theorem mul_left_dvd : u * a ∣ b ↔ a ∣ b := by
+theorem mul_left_dvd (hu : IsUnit u) : u * a ∣ b ↔ a ∣ b := by
   rcases hu with ⟨u, rfl⟩
   apply Units.mul_left_dvd
 

--- a/Mathlib/Algebra/Field/IsField.lean
+++ b/Mathlib/Algebra/Field/IsField.lean
@@ -63,10 +63,13 @@ noncomputable def IsField.toSemifield {R : Type u} [Semiring R] (h : IsField R) 
   inv_zero := dif_pos rfl
   mul_inv_cancel a ha := by convert Classical.choose_spec (h.mul_inv_cancel ha); exact dif_neg ha
   nnqsmul := _
+  nnqsmul_def q a := rfl
 
 /-- Transferring from `IsField` to `Field`. -/
 noncomputable def IsField.toField {R : Type u} [Ring R] (h : IsField R) : Field R :=
-  { ‹Ring R›, IsField.toSemifield h with qsmul := _ }
+  { ‹Ring R›, IsField.toSemifield h with
+    qsmul := _
+    qsmul_def := fun q a => rfl }
 
 /-- For each field, and for each nonzero element of said field, there is a unique inverse.
 Since `IsField` doesn't remember the data of an `inv` function and as such,

--- a/Mathlib/Algebra/Field/MinimalAxioms.lean
+++ b/Mathlib/Algebra/Field/MinimalAxioms.lean
@@ -42,4 +42,6 @@ abbrev Field.ofMinimalAxioms (K : Type u)
     mul_inv_cancel := mul_inv_cancel
     inv_zero := inv_zero
     nnqsmul := _
-    qsmul := _ }
+    nnqsmul_def := fun q a => rfl
+    qsmul := _
+    qsmul_def := fun q a => rfl }

--- a/Mathlib/Algebra/GroupWithZero/InjSurj.lean
+++ b/Mathlib/Algebra/GroupWithZero/InjSurj.lean
@@ -50,7 +50,7 @@ variable [Mul M₀] [Zero M₀] [Mul M₀'] [Zero M₀']
 
 /-- Pull back a `NoZeroDivisors` instance along an injective function. -/
 protected theorem Function.Injective.noZeroDivisors [NoZeroDivisors M₀'] : NoZeroDivisors M₀ :=
-  { eq_zero_or_eq_zero_of_mul_eq_zero := @fun a b H =>
+  { eq_zero_or_eq_zero_of_mul_eq_zero := fun {a b} H ↦
       have : f a * f b = 0 := by rw [← mul, H, zero]
       (eq_zero_or_eq_zero_of_mul_eq_zero this).imp
         (fun H => hf <| by rwa [zero]) fun H => hf <| by rwa [zero] }

--- a/Mathlib/Algebra/GroupWithZero/InjSurj.lean
+++ b/Mathlib/Algebra/GroupWithZero/InjSurj.lean
@@ -50,8 +50,8 @@ variable [Mul M₀] [Zero M₀] [Mul M₀'] [Zero M₀']
 
 /-- Pull back a `NoZeroDivisors` instance along an injective function. -/
 protected theorem Function.Injective.noZeroDivisors [NoZeroDivisors M₀'] : NoZeroDivisors M₀ :=
-  { eq_zero_or_eq_zero_of_mul_eq_zero := fun H =>
-      have : f _ * f _ = 0 := by rw [← mul, H, zero]
+  { eq_zero_or_eq_zero_of_mul_eq_zero := @fun a b H =>
+      have : f a * f b = 0 := by rw [← mul, H, zero]
       (eq_zero_or_eq_zero_of_mul_eq_zero this).imp
         (fun H => hf <| by rwa [zero]) fun H => hf <| by rwa [zero] }
 

--- a/Mathlib/Algebra/Order/Monoid/Unbundled/Basic.lean
+++ b/Mathlib/Algebra/Order/Monoid/Unbundled/Basic.lean
@@ -359,24 +359,24 @@ theorem mul_le_of_le_one_left' [CovariantClass α α (swap (· * ·)) (· ≤ ·
 @[to_additive]
 theorem one_le_of_le_mul_right [ContravariantClass α α (· * ·) (· ≤ ·)] {a b : α} (h : a ≤ a * b) :
     1 ≤ b :=
-  le_of_mul_le_mul_left' <| by simpa only [mul_one]
+  le_of_mul_le_mul_left' (a := a) <| by simpa only [mul_one]
 
 @[to_additive]
 theorem le_one_of_mul_le_right [ContravariantClass α α (· * ·) (· ≤ ·)] {a b : α} (h : a * b ≤ a) :
     b ≤ 1 :=
-  le_of_mul_le_mul_left' <| by simpa only [mul_one]
+  le_of_mul_le_mul_left' (a := a) <| by simpa only [mul_one]
 
 @[to_additive]
 theorem one_le_of_le_mul_left [ContravariantClass α α (swap (· * ·)) (· ≤ ·)] {a b : α}
     (h : b ≤ a * b) :
     1 ≤ a :=
-  le_of_mul_le_mul_right' <| by simpa only [one_mul]
+  le_of_mul_le_mul_right' (a := b) <| by simpa only [one_mul]
 
 @[to_additive]
 theorem le_one_of_mul_le_left [ContravariantClass α α (swap (· * ·)) (· ≤ ·)] {a b : α}
     (h : a * b ≤ b) :
     a ≤ 1 :=
-  le_of_mul_le_mul_right' <| by simpa only [one_mul]
+  le_of_mul_le_mul_right' (a := b) <| by simpa only [one_mul]
 
 @[to_additive (attr := simp) le_add_iff_nonneg_right]
 theorem le_mul_iff_one_le_right' [CovariantClass α α (· * ·) (· ≤ ·)]
@@ -441,24 +441,24 @@ theorem mul_lt_of_lt_one_left' [CovariantClass α α (swap (· * ·)) (· < ·)]
 @[to_additive]
 theorem one_lt_of_lt_mul_right [ContravariantClass α α (· * ·) (· < ·)] {a b : α} (h : a < a * b) :
     1 < b :=
-  lt_of_mul_lt_mul_left' <| by simpa only [mul_one]
+  lt_of_mul_lt_mul_left' (a := a) <| by simpa only [mul_one]
 
 @[to_additive]
 theorem lt_one_of_mul_lt_right [ContravariantClass α α (· * ·) (· < ·)] {a b : α} (h : a * b < a) :
     b < 1 :=
-  lt_of_mul_lt_mul_left' <| by simpa only [mul_one]
+  lt_of_mul_lt_mul_left' (a := a) <| by simpa only [mul_one]
 
 @[to_additive]
 theorem one_lt_of_lt_mul_left [ContravariantClass α α (swap (· * ·)) (· < ·)] {a b : α}
     (h : b < a * b) :
     1 < a :=
-  lt_of_mul_lt_mul_right' <| by simpa only [one_mul]
+  lt_of_mul_lt_mul_right' (a := b) <| by simpa only [one_mul]
 
 @[to_additive]
 theorem lt_one_of_mul_lt_left [ContravariantClass α α (swap (· * ·)) (· < ·)] {a b : α}
     (h : a * b < b) :
     a < 1 :=
-  lt_of_mul_lt_mul_right' <| by simpa only [one_mul]
+  lt_of_mul_lt_mul_right' (a := b) <| by simpa only [one_mul]
 
 @[to_additive (attr := simp) lt_add_iff_pos_right]
 theorem lt_mul_iff_one_lt_right' [CovariantClass α α (· * ·) (· < ·)]

--- a/Mathlib/Combinatorics/Quiver/Path.lean
+++ b/Mathlib/Combinatorics/Quiver/Path.lean
@@ -116,7 +116,8 @@ theorem comp_inj {p₁ p₂ : Path a b} {q₁ q₂ : Path b c} (hq : q₁.length
 
 theorem comp_inj' {p₁ p₂ : Path a b} {q₁ q₂ : Path b c} (h : p₁.length = p₂.length) :
     p₁.comp q₁ = p₂.comp q₂ ↔ p₁ = p₂ ∧ q₁ = q₂ :=
-  ⟨fun h_eq => (comp_inj <| Nat.add_left_cancel <| by simpa [h] using congr_arg length h_eq).1 h_eq,
+  ⟨fun h_eq => (comp_inj <| Nat.add_left_cancel (n := p₂.length) <|
+    by simpa [h] using congr_arg length h_eq).1 h_eq,
    by rintro ⟨rfl, rfl⟩; rfl⟩
 
 theorem comp_injective_left (q : Path b c) : Injective fun p : Path a b => p.comp q :=

--- a/Mathlib/Control/Applicative.lean
+++ b/Mathlib/Control/Applicative.lean
@@ -95,21 +95,21 @@ theorem pure_seq_eq_map (f : α → β) (x : Comp F G α) : pure f <*> x = f <$>
 instance instLawfulApplicativeComp : LawfulApplicative (Comp F G) where
   seqLeft_eq := by intros; rfl
   seqRight_eq := by intros; rfl
-  pure_seq := @Comp.pure_seq_eq_map F G _ _ _ _
-  map_pure := @Comp.map_pure F G _ _ _ _
-  seq_pure := @Comp.seq_pure F G _ _ _ _
-  seq_assoc := @Comp.seq_assoc F G _ _ _ _
+  pure_seq := Comp.pure_seq_eq_map
+  map_pure := Comp.map_pure
+  seq_pure := Comp.seq_pure
+  seq_assoc := Comp.seq_assoc
 
 -- Porting note: mathport wasn't aware of the new implicit parameter omission in these `fun` binders
 
 theorem applicative_id_comp {F} [AF : Applicative F] [LawfulApplicative F] :
     @instApplicativeComp Id F _ _ = AF :=
-  @Applicative.ext F _ _ (@instLawfulApplicativeComp Id F _ _ _ _) _
+  @Applicative.ext F _ _ (instLawfulApplicativeComp (F := Id)) _
     (fun _ => rfl) (fun _ _ => rfl)
 
 theorem applicative_comp_id {F} [AF : Applicative F] [LawfulApplicative F] :
     @Comp.instApplicativeComp F Id _ _ = AF :=
-  @Applicative.ext F _ _ (@Comp.instLawfulApplicativeComp F Id _ _ _ _) _
+  @Applicative.ext F _ _ (instLawfulApplicativeComp (G := Id)) _
     (fun _ => rfl) (fun f x => show id <$> f <*> x = f <*> x by rw [id_map])
 
 open CommApplicative

--- a/Mathlib/Control/Functor.lean
+++ b/Mathlib/Control/Functor.lean
@@ -186,17 +186,17 @@ protected theorem comp_map (g' : α → β) (h : β → γ) :
 
 instance lawfulFunctor : LawfulFunctor (Comp F G) where
   map_const := rfl
-  id_map := @Comp.id_map F G _ _ _ _
-  comp_map := @Comp.comp_map F G _ _ _ _
+  id_map := Comp.id_map
+  comp_map := Comp.comp_map
 
 -- Porting note: had to use switch to `Id` from `id` because this has the `Functor` instance.
 theorem functor_comp_id {F} [AF : Functor F] [LawfulFunctor F] :
     @Comp.functor F Id _ _ = AF :=
-  @Functor.ext F _ AF (@Comp.lawfulFunctor F Id _ _ _ _) _ fun _ _ _ _ => rfl
+  @Functor.ext F _ AF (Comp.lawfulFunctor (G := Id)) _ fun _ _ _ _ => rfl
 
 -- Porting note: had to use switch to `Id` from `id` because this has the `Functor` instance.
 theorem functor_id_comp {F} [AF : Functor F] [LawfulFunctor F] : @Comp.functor Id F _ _ = AF :=
-  @Functor.ext F _ AF (@Comp.lawfulFunctor Id F _ _ _ _) _ fun _ _ _ _ => rfl
+  @Functor.ext F _ AF (Comp.lawfulFunctor (F := Id)) _ fun _ _ _ _ => rfl
 
 end Comp
 

--- a/Mathlib/Data/List/Basic.lean
+++ b/Mathlib/Data/List/Basic.lean
@@ -1537,6 +1537,7 @@ theorem scanr_cons (f : α → β → β) (b : β) (a : α) (l : List α) :
   | cons hd tl ih => simp only [foldr, ih]
 
 section FoldlEqFoldr
+
 -- foldl and foldr coincide when f is commutative and associative
 variable {f : α → α → α}
 

--- a/Mathlib/Data/List/Basic.lean
+++ b/Mathlib/Data/List/Basic.lean
@@ -1537,25 +1537,28 @@ theorem scanr_cons (f : α → β → β) (b : β) (a : α) (l : List α) :
   | cons hd tl ih => simp only [foldr, ih]
 
 section FoldlEqFoldr
-
 -- foldl and foldr coincide when f is commutative and associative
-variable {f : α → α → α} (hcomm : Commutative f) (hassoc : Associative f)
+variable {f : α → α → α}
 
-theorem foldl1_eq_foldr1 : ∀ a b l, foldl f a (l ++ [b]) = foldr f b (a :: l)
+theorem foldl1_eq_foldr1 (hassoc : Associative f) :
+    ∀ a b l, foldl f a (l ++ [b]) = foldr f b (a :: l)
   | a, b, nil => rfl
   | a, b, c :: l => by
-    simp only [cons_append, foldl_cons, foldr_cons, foldl1_eq_foldr1 _ _ l]; rw [hassoc]
+    simp only [cons_append, foldl_cons, foldr_cons, foldl1_eq_foldr1 hassoc _ _ l]; rw [hassoc]
 
-theorem foldl_eq_of_comm_of_assoc : ∀ a b l, foldl f a (b :: l) = f b (foldl f a l)
+theorem foldl_eq_of_comm_of_assoc (hcomm : Commutative f) (hassoc : Associative f) :
+    ∀ a b l, foldl f a (b :: l) = f b (foldl f a l)
   | a, b, nil => hcomm a b
   | a, b, c :: l => by
     simp only [foldl_cons]
-    rw [← foldl_eq_of_comm_of_assoc .., right_comm _ hcomm hassoc]; rfl
+    rw [← foldl_eq_of_comm_of_assoc hcomm hassoc .., right_comm _ hcomm hassoc]; rfl
 
-theorem foldl_eq_foldr : ∀ a l, foldl f a l = foldr f a l
+theorem foldl_eq_foldr (hcomm : Commutative f) (hassoc : Associative f) :
+    ∀ a l, foldl f a l = foldr f a l
   | a, nil => rfl
   | a, b :: l => by
-    simp only [foldr_cons, foldl_eq_of_comm_of_assoc hcomm hassoc]; rw [foldl_eq_foldr a l]
+    simp only [foldr_cons, foldl_eq_of_comm_of_assoc hcomm hassoc]
+    rw [foldl_eq_foldr hcomm hassoc a l]
 
 end FoldlEqFoldr
 

--- a/Mathlib/Data/List/Basic.lean
+++ b/Mathlib/Data/List/Basic.lean
@@ -959,7 +959,8 @@ theorem ext_nthLe {l₁ l₂ : List α} (hl : length l₁ = length l₂)
   ext_get hl h
 
 @[simp]
-theorem getElem_indexOf [DecidableEq α] {a : α} : ∀ {l : List α} (h), l[indexOf a l] = a
+theorem getElem_indexOf [DecidableEq α] {a : α} : ∀ {l : List α} (h : indexOf a l < l.length),
+    l[indexOf a l] = a
   | b :: l, h => by
     by_cases h' : b = a <;>
     simp [h', if_pos, if_false, getElem_indexOf]

--- a/Mathlib/Data/List/EditDistance/Defs.lean
+++ b/Mathlib/Data/List/EditDistance/Defs.lean
@@ -116,8 +116,8 @@ theorem impl_cons (w' : 0 < List.length ds) :
 
 -- Note this lemma has two unspecified proofs: `h` appears on the left-hand-side
 -- and should be found by matching, but `w'` will become an extra goal when rewriting.
-theorem impl_cons_fst_zero (h) (w' : 0 < List.length ds) :
-    (impl C (x :: xs) y ⟨d :: ds, w⟩).1[0] =
+theorem impl_cons_fst_zero (h : 0 < (impl C (x :: xs) y ⟨d :: ds, w⟩).val.length)
+    (w' : 0 < List.length ds) : (impl C (x :: xs) y ⟨d :: ds, w⟩).1[0] =
       let ⟨r, w⟩ := impl C xs y ⟨ds, w'⟩
       min (C.delete x + r[0]) (min (C.insert y + d) (C.substitute x y + ds[0])) :=
   match ds, w' with | _ :: _, _ => rfl
@@ -245,7 +245,7 @@ theorem suffixLevenshtein_cons₁_fst (x : α) (xs ys) :
   simp [suffixLevenshtein_cons₁]
 
 theorem suffixLevenshtein_cons_cons_fst_get_zero
-    (x : α) (xs y ys) (w) :
+    (x : α) (xs y ys) (w : 0 < (suffixLevenshtein C (x :: xs) (y :: ys)).val.length) :
     (suffixLevenshtein C (x :: xs) (y :: ys)).1[0] =
       let ⟨dx, _⟩ := suffixLevenshtein C xs (y :: ys)
       let ⟨dy, _⟩ := suffixLevenshtein C (x :: xs) ys

--- a/Mathlib/Data/List/OfFn.lean
+++ b/Mathlib/Data/List/OfFn.lean
@@ -41,7 +41,7 @@ theorem length_ofFn_go {n} (f : Fin n → α) (i j h) : length (ofFn.go f i j h)
 theorem length_ofFn {n} (f : Fin n → α) : length (ofFn f) = n := by
   simp [ofFn, length_ofFn_go]
 
-theorem getElem_ofFn_go {n} (f : Fin n → α) (i j h) (k) (hk) :
+theorem getElem_ofFn_go {n} (f : Fin n → α) (i j h) (k) (hk : k < (ofFn.go f i j h).length) :
     (ofFn.go f i j h)[k] = f ⟨j + k, by simp at hk; omega⟩ := by
   let i+1 := i
   cases k <;> simp [ofFn.go, getElem_ofFn_go (i := i)]

--- a/Mathlib/Data/List/Zip.lean
+++ b/Mathlib/Data/List/Zip.lean
@@ -264,7 +264,7 @@ theorem nthLe_zipWith {f : α → β → γ} {l : List α} {l' : List β} {i : �
 theorem getElem_zip {l : List α} {l' : List β} {i : Nat} {h : i < (zip l l').length} :
     (zip l l')[i] =
       (l[i]'(lt_length_left_of_zip h), l'[i]'(lt_length_right_of_zip h)) :=
-  getElem_zipWith
+  getElem_zipWith (h := h)
 
 @[deprecated getElem_zip (since := "2024-06-12")]
 theorem get_zip {l : List α} {l' : List β} {i : Fin (zip l l').length} :

--- a/Mathlib/Data/Nat/Defs.lean
+++ b/Mathlib/Data/Nat/Defs.lean
@@ -352,7 +352,7 @@ lemma one_lt_mul_iff : 1 < m * n ↔ 0 < m ∧ 0 < n ∧ (1 < m ∨ 1 < n) := by
 lemma eq_one_of_mul_eq_one_right (H : m * n = 1) : m = 1 := eq_one_of_dvd_one ⟨n, H.symm⟩
 
 lemma eq_one_of_mul_eq_one_left (H : m * n = 1) : n = 1 :=
-  eq_one_of_mul_eq_one_right (n := n) (by rwa [Nat.mul_comm])
+  eq_one_of_mul_eq_one_right (n := m) (by rwa [Nat.mul_comm])
 
 @[simp] protected lemma lt_mul_iff_one_lt_left (hb : 0 < b) : b < a * b ↔ 1 < a := by
   simpa using Nat.mul_lt_mul_right (b := 1) hb

--- a/Mathlib/Data/Nat/Defs.lean
+++ b/Mathlib/Data/Nat/Defs.lean
@@ -352,7 +352,7 @@ lemma one_lt_mul_iff : 1 < m * n ↔ 0 < m ∧ 0 < n ∧ (1 < m ∨ 1 < n) := by
 lemma eq_one_of_mul_eq_one_right (H : m * n = 1) : m = 1 := eq_one_of_dvd_one ⟨n, H.symm⟩
 
 lemma eq_one_of_mul_eq_one_left (H : m * n = 1) : n = 1 :=
-  eq_one_of_mul_eq_one_right (by rwa [Nat.mul_comm])
+  eq_one_of_mul_eq_one_right (n := n) (by rwa [Nat.mul_comm])
 
 @[simp] protected lemma lt_mul_iff_one_lt_left (hb : 0 < b) : b < a * b ↔ 1 < a := by
   simpa using Nat.mul_lt_mul_right (b := 1) hb

--- a/Mathlib/GroupTheory/NoncommCoprod.lean
+++ b/Mathlib/GroupTheory/NoncommCoprod.lean
@@ -33,7 +33,7 @@ assert_not_exists MonoidWithZero
 namespace MulHom
 
 variable {M N P : Type*} [Mul M] [Mul N] [Semigroup P]
-  (f : M →ₙ* P) (g : N →ₙ* P) (comm : ∀ m n, Commute (f m) (g n))
+  (f : M →ₙ* P) (g : N →ₙ* P)
 
 /-- Coproduct of two `MulHom`s with the same codomain with `Commute` assumption:
   `f.noncommCoprod g _ (p : M × N) = f p.1 * g p.2`.
@@ -42,12 +42,13 @@ variable {M N P : Type*} [Mul M] [Mul N] [Semigroup P]
     "Coproduct of two `AddHom`s with the same codomain with `AddCommute` assumption:
     `f.noncommCoprod g _ (p : M × N) = f p.1 + g p.2`.
     (For the commutative case, use `AddHom.coprod`)"]
-def noncommCoprod : M × N →ₙ* P where
+def noncommCoprod (comm : ∀ m n, Commute (f m) (g n)) : M × N →ₙ* P where
   toFun mn := f mn.fst * g mn.snd
   map_mul' mn mn' := by simpa using (comm _ _).mul_mul_mul_comm _ _
 
 @[to_additive]
-theorem comp_noncommCoprod {Q : Type*} [Semigroup Q] (h : P →ₙ* Q) :
+theorem comp_noncommCoprod {Q : Type*} [Semigroup Q] (h : P →ₙ* Q)
+    (comm : ∀ m n, Commute (f m) (g n)) :
     h.comp (f.noncommCoprod g comm) =
       (h.comp f).noncommCoprod (h.comp g) (fun m n ↦ (comm m n).map h) :=
   ext fun _ => map_mul h _ _

--- a/Mathlib/Order/BooleanAlgebra.lean
+++ b/Mathlib/Order/BooleanAlgebra.lean
@@ -274,7 +274,7 @@ theorem sdiff_sup : y \ (x ⊔ z) = y \ x ⊓ y \ z :=
                       inf_inf_sdiff, inf_bot_eq])
 
 theorem sdiff_eq_sdiff_iff_inf_eq_inf : y \ x = y \ z ↔ y ⊓ x = y ⊓ z :=
-  ⟨fun h => eq_of_inf_eq_sup_eq (by rw [inf_inf_sdiff, h, inf_inf_sdiff])
+  ⟨fun h => eq_of_inf_eq_sup_eq (a := y \ x) (by rw [inf_inf_sdiff, h, inf_inf_sdiff])
     (by rw [sup_inf_sdiff, h, sup_inf_sdiff]),
     fun h => by rw [← sdiff_inf_self_right, ← sdiff_inf_self_right z y, inf_comm, h, inf_comm]⟩
 
@@ -770,7 +770,7 @@ end lift
 
 instance PUnit.instBooleanAlgebra : BooleanAlgebra PUnit where
   __ := PUnit.instBiheytingAlgebra
-  le_sup_inf := _
+  le_sup_inf := by simp
   inf_compl_le_bot _ := trivial
   top_le_sup_compl _ := trivial
 

--- a/Mathlib/Order/Bounds/Basic.lean
+++ b/Mathlib/Order/Bounds/Basic.lean
@@ -974,7 +974,7 @@ theorem mem_lowerBounds_image (Has : a ∈ lowerBounds s) (Hat : a ∈ t) :
 theorem mem_lowerBounds_image_self : a ∈ lowerBounds t → a ∈ t → f a ∈ lowerBounds (f '' t) :=
   Hf.mem_lowerBounds_image subset_rfl
 
-theorem image_upperBounds_subset_upperBounds_image (Hst : s ⊆ t) :
+theorem image_upperBounds_subset_upperBounds_image (Hf : MonotoneOn f t) (Hst : s ⊆ t) :
     f '' (upperBounds s ∩ t) ⊆ upperBounds (f '' s) := by
   rintro _ ⟨a, ha, rfl⟩
   exact Hf.mem_upperBounds_image Hst ha.1 ha.2
@@ -1056,7 +1056,8 @@ theorem mem_upperBounds_image (Ha : a ∈ upperBounds s) : f a ∈ upperBounds (
 theorem mem_lowerBounds_image (Ha : a ∈ lowerBounds s) : f a ∈ lowerBounds (f '' s) :=
   forall_mem_image.2 fun _ H => Hf (Ha H)
 
-theorem image_upperBounds_subset_upperBounds_image : f '' upperBounds s ⊆ upperBounds (f '' s) := by
+theorem image_upperBounds_subset_upperBounds_image (Hf : Monotone f) :
+    f '' upperBounds s ⊆ upperBounds (f '' s) := by
   rintro _ ⟨a, ha, rfl⟩
   exact Hf.mem_upperBounds_image ha
 

--- a/Mathlib/Order/GaloisConnection.lean
+++ b/Mathlib/Order/GaloisConnection.lean
@@ -98,10 +98,12 @@ theorem monotone_u : Monotone u := fun a _ H => gc.le_u ((gc.l_u_le a).trans H)
 theorem monotone_l : Monotone l :=
   gc.dual.monotone_u.dual
 
-theorem upperBounds_l_image (s : Set α) : upperBounds (l '' s) = u ⁻¹' upperBounds s :=
+theorem upperBounds_l_image (gc : GaloisConnection l u) (s : Set α) :
+    upperBounds (l '' s) = u ⁻¹' upperBounds s :=
   Set.ext fun b => by simp [upperBounds, gc _ _]
 
-theorem lowerBounds_u_image (s : Set β) : lowerBounds (u '' s) = l ⁻¹' lowerBounds s :=
+theorem lowerBounds_u_image (gc : GaloisConnection l u) (s : Set β) :
+    lowerBounds (u '' s) = l ⁻¹' lowerBounds s :=
   gc.dual.upperBounds_l_image s
 
 theorem bddAbove_l_image {s : Set α} : BddAbove (l '' s) ↔ BddAbove s :=
@@ -159,7 +161,7 @@ theorem u_unique {l' : α → β} {u' : β → α} (gc' : GaloisConnection l' u'
 theorem exists_eq_u (a : α) : (∃ b : β, a = u b) ↔ a = u (l a) :=
   ⟨fun ⟨_, hS⟩ => hS.symm ▸ (gc.u_l_u_eq_u _).symm, fun HI => ⟨_, HI⟩⟩
 
-theorem u_eq {z : α} {y : β} : u y = z ↔ ∀ x, x ≤ z ↔ l x ≤ y := by
+theorem u_eq (gc : GaloisConnection l u) {z : α} {y : β} : u y = z ↔ ∀ x, x ≤ z ↔ l x ≤ y := by
   constructor
   · rintro rfl x
     exact (gc x y).symm
@@ -230,16 +232,19 @@ end SemilatticeInf
 
 section CompleteLattice
 
-variable [CompleteLattice α] [CompleteLattice β] {l : α → β} {u : β → α} (gc : GaloisConnection l u)
+variable [CompleteLattice α] [CompleteLattice β] {l : α → β} {u : β → α}
 
-theorem l_iSup {f : ι → α} : l (iSup f) = ⨆ i, l (f i) :=
+theorem l_iSup (gc : GaloisConnection l u) {f : ι → α} : l (iSup f) = ⨆ i, l (f i) :=
   Eq.symm <|
     IsLUB.iSup_eq <|
       show IsLUB (range (l ∘ f)) (l (iSup f)) by
         rw [range_comp, ← sSup_range]; exact gc.isLUB_l_image (isLUB_sSup _)
 
-theorem l_iSup₂ {f : ∀ i, κ i → α} : l (⨆ (i) (j), f i j) = ⨆ (i) (j), l (f i j) := by
+theorem l_iSup₂ (gc : GaloisConnection l u) {f : ∀ i, κ i → α} :
+    l (⨆ (i) (j), f i j) = ⨆ (i) (j), l (f i j) := by
   simp_rw [gc.l_iSup]
+
+variable (gc : GaloisConnection l u)
 
 theorem u_iInf {f : ι → β} : u (iInf f) = ⨅ i, u (f i) :=
   gc.dual.l_iSup
@@ -247,7 +252,8 @@ theorem u_iInf {f : ι → β} : u (iInf f) = ⨅ i, u (f i) :=
 theorem u_iInf₂ {f : ∀ i, κ i → β} : u (⨅ (i) (j), f i j) = ⨅ (i) (j), u (f i j) :=
   gc.dual.l_iSup₂
 
-theorem l_sSup {s : Set α} : l (sSup s) = ⨆ a ∈ s, l a := by simp only [sSup_eq_iSup, gc.l_iSup]
+theorem l_sSup (gc : GaloisConnection l u) {s : Set α} : l (sSup s) = ⨆ a ∈ s, l a := by
+  simp only [sSup_eq_iSup, gc.l_iSup]
 
 theorem u_sInf {s : Set β} : u (sInf s) = ⨅ a ∈ s, u a :=
   gc.dual.l_sSup

--- a/Mathlib/Order/RelIso/Basic.lean
+++ b/Mathlib/Order/RelIso/Basic.lean
@@ -426,8 +426,9 @@ def ofMonotone [IsTrichotomous α r] [IsAsymm β s] (f : α → β) (H : ∀ a b
     r ↪r s := by
   haveI := @IsAsymm.isIrrefl β s _
   refine ⟨⟨f, fun a b e => ?_⟩, @fun a b => ⟨fun h => ?_, H _ _⟩⟩
-  · refine ((@trichotomous _ r _ a b).resolve_left ?_).resolve_right ?_ <;>
-      exact fun h => @irrefl _ s _ _ (by simpa [e] using H _ _ h)
+  · refine ((@trichotomous _ r _ a b).resolve_left ?_).resolve_right ?_
+    · exact fun h => irrefl (r := s) (f a) (by simpa [e] using H _ _ h)
+    · exact fun h => irrefl (r := s) (f b) (by simpa [e] using H _ _ h)
   · refine (@trichotomous _ r _ a b).resolve_right (Or.rec (fun e => ?_) fun h' => ?_)
     · subst e
       exact irrefl _ h


### PR DESCRIPTION
These are some minor changes, which are think are positive or neutral in any case, that help Mathlib compile under `set_option debug.byAsSorry true` (an option that [arrived](https://github.com/leanprover/lean4/pull/4576) in v4.10 that turns all `by` blocks into sorries --- Mathlib is very much broken, although perhaps less than one might expect).

