### PR TITLE
[Merged by Bors] - feat: The multinomial theorem in terms of `piAntidiag`

### DIFF
--- a/Mathlib/Algebra/BigOperators/Group/Finset.lean
+++ b/Mathlib/Algebra/BigOperators/Group/Finset.lean
@@ -2089,18 +2089,23 @@ theorem disjoint_finset_sum_right {β : Type*} {i : Finset β} {f : β → Multi
     {a : Multiset α} : Multiset.Disjoint a (i.sum f) ↔ ∀ b ∈ i, Multiset.Disjoint a (f b) := by
   simpa only [disjoint_comm] using disjoint_finset_sum_left
 
+@[simp]
+lemma mem_sum {s : Finset ι} {m : ι → Multiset α} : a ∈ ∑ i ∈ s, m i ↔ ∃ i ∈ s, a ∈ m i := by
+  induction' s using Finset.cons_induction <;> simp [*]
+
 variable [DecidableEq α]
 
-@[simp]
 theorem toFinset_sum_count_eq (s : Multiset α) : ∑ a in s.toFinset, s.count a = card s := by
   simpa using (Finset.sum_multiset_map_count s (fun _ => (1 : ℕ))).symm
 
-@[simp]
-theorem sum_count_eq [Fintype α] (s : Multiset α) : ∑ a, s.count a = Multiset.card s := by
+@[simp] lemma sum_count_eq_card {s : Finset α} {m : Multiset α} (hms : ∀ a ∈ m, a ∈ s) :
+    ∑ a ∈ s, m.count a = card m := by
   rw [← toFinset_sum_count_eq, ← Finset.sum_filter_ne_zero]
-  congr
-  ext
-  simp
+  congr with a
+  simpa using hms a
+
+@[deprecated sum_count_eq_card (since := "2024-07-21")]
+theorem sum_count_eq [Fintype α] (s : Multiset α) : ∑ a, s.count a = Multiset.card s := by simp
 
 theorem count_sum' {s : Finset β} {a : α} {f : β → Multiset α} :
     count a (∑ x ∈ s, f x) = ∑ x ∈ s, count a (f x) := by

--- a/Mathlib/Algebra/Order/Antidiag/Pi.lean
+++ b/Mathlib/Algebra/Order/Antidiag/Pi.lean
@@ -244,4 +244,19 @@ lemma map_nsmul_piAntidiag_univ [Fintype ι] (m : ℕ) {n : ℕ} (hn : n ≠ 0) 
   simpa using map_nsmul_piAntidiag (univ : Finset ι) m hn
 
 end Nat
+
+lemma map_sym_eq_piAntidiag [DecidableEq ι] (s : Finset ι) (n : ℕ) :
+    (s.sym n).map ⟨fun m a ↦ m.1.count a, Multiset.count_injective.comp Sym.coe_injective⟩ =
+      piAntidiag s n := by
+  ext f
+  simp only [Sym.val_eq_coe, mem_map, mem_sym_iff, Embedding.coeFn_mk, funext_iff, Sym.exists,
+    Sym.mem_mk, Sym.coe_mk, exists_and_left, exists_prop, mem_piAntidiag, ne_eq]
+  constructor
+  · rintro ⟨m, hm, rfl, hf⟩
+    simpa [← hf, Multiset.sum_count_eq_card hm]
+  · rintro ⟨rfl, hf⟩
+    refine ⟨∑ a ∈ s, f a • {a}, ?_, ?_⟩
+    · simp (config := { contextual := true })
+    · simpa [Multiset.count_sum', Multiset.count_singleton, not_imp_comm, eq_comm (a := 0)] using hf
+
 end Finset

--- a/Mathlib/Data/Multiset/Basic.lean
+++ b/Mathlib/Data/Multiset/Basic.lean
@@ -636,11 +636,16 @@ theorem mem_of_mem_nsmul {a : α} {s : Multiset α} {n : ℕ} (h : a ∈ n • s
     exact h.elim ih id
 
 @[simp]
-theorem mem_nsmul {a : α} {s : Multiset α} {n : ℕ} (h0 : n ≠ 0) : a ∈ n • s ↔ a ∈ s := by
-  refine ⟨mem_of_mem_nsmul, fun h => ?_⟩
-  obtain ⟨n, rfl⟩ := exists_eq_succ_of_ne_zero h0
+theorem mem_nsmul {a : α} {s : Multiset α} {n : ℕ} : a ∈ n • s ↔ n ≠ 0 ∧ a ∈ s := by
+  refine ⟨fun ha ↦ ⟨?_, mem_of_mem_nsmul ha⟩, fun h => ?_⟩
+  · rintro rfl
+    simp [zero_nsmul] at ha
+  obtain ⟨n, rfl⟩ := exists_eq_succ_of_ne_zero h.1
   rw [succ_nsmul, mem_add]
-  exact Or.inr h
+  exact Or.inr h.2
+
+lemma mem_nsmul_of_ne_zero {a : α} {s : Multiset α} {n : ℕ} (h0 : n ≠ 0) : a ∈ n • s ↔ a ∈ s := by
+  simp [*]
 
 theorem nsmul_cons {s : Multiset α} (n : ℕ) (a : α) :
     n • (a ::ₘ s) = n • ({a} : Multiset α) + n • s := by
@@ -2198,6 +2203,9 @@ theorem ext {s t : Multiset α} : s = t ↔ ∀ a, count a s = count a t :=
 @[ext]
 theorem ext' {s t : Multiset α} : (∀ a, count a s = count a t) → s = t :=
   ext.2
+
+lemma count_injective : Injective fun (s : Multiset α) a ↦ s.count a :=
+  fun _s _t hst ↦ ext' $ congr_fun hst
 
 @[simp]
 theorem coe_inter (s t : List α) : (s ∩ t : Multiset α) = (s.bagInter t : List α) := by ext; simp

--- a/Mathlib/Data/Nat/Choose/Multinomial.lean
+++ b/Mathlib/Data/Nat/Choose/Multinomial.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Kyle Miller, Pim Otte
 -/
 import Mathlib.Algebra.BigOperators.Fin
+import Mathlib.Algebra.Order.Antidiag.Pi
 import Mathlib.Data.Nat.Choose.Sum
 import Mathlib.Data.Nat.Factorial.BigOperators
 import Mathlib.Data.Fin.VecNotation
@@ -196,16 +197,58 @@ theorem multinomial_zero [DecidableEq α] : multinomial (0 : Multiset α) = 1 :=
 end Multiset
 
 namespace Finset
+open _root_.Nat
 
 /-! ### Multinomial theorem -/
 
-variable {α : Type*} [DecidableEq α] (s : Finset α) {R : Type*}
+variable {α R : Type*} [DecidableEq α]
 
-/-- The multinomial theorem
+section Semiring
+variable [Semiring R]
 
-  Proof is by induction on the number of summands.
--/
-theorem sum_pow_of_commute [Semiring R] (x : α → R)
+-- TODO: Can we prove one of the following two from the other one?
+/-- The **multinomial theorem**. -/
+lemma sum_pow_eq_sum_piAntidiag_of_commute (s : Finset α) (f : α → R)
+    (hc : (s : Set α).Pairwise fun i j ↦ Commute (f i) (f j)) (n : ℕ) :
+    (∑ i in s, f i) ^ n = ∑ k in piAntidiag s n, multinomial s k *
+      s.noncommProd (fun i ↦ f i ^ k i) (hc.mono' fun i j h ↦ h.pow_pow ..) := by
+  classical
+  induction' s using Finset.cons_induction with a s has ih generalizing n
+  · cases n <;> simp
+  rw [Finset.sum_cons, piAntidiag_cons, sum_disjiUnion]
+  simp only [sum_map, Function.Embedding.coeFn_mk, Pi.add_apply, multinomial_cons,
+    Pi.add_apply, eq_self_iff_true, if_true, Nat.cast_mul, noncommProd_cons, eq_self_iff_true,
+    if_true, sum_add_distrib, sum_ite_eq', has, if_false, add_zero,
+      addLeftEmbedding_eq_addRightEmbedding, addRightEmbedding_apply]
+  suffices ∀ p : ℕ × ℕ, p ∈ antidiagonal n →
+    ∑ g in piAntidiag s p.2, ((g a + p.1 + s.sum g).choose (g a + p.1) : R) *
+      multinomial s (g + fun i ↦ ite (i = a) p.1 0) *
+        (f a ^ (g a + p.1) * s.noncommProd (fun i ↦ f i ^ (g i + ite (i = a) p.1 0))
+          ((hc.mono (by simp)).mono' fun i j h ↦ h.pow_pow ..)) =
+      ∑ g in piAntidiag s p.2, n.choose p.1 * multinomial s g * (f a ^ p.1 *
+        s.noncommProd (fun i ↦ f i ^ g i) ((hc.mono (by simp)).mono' fun i j h ↦ h.pow_pow ..)) by
+    rw [sum_congr rfl this]
+    simp only [Nat.antidiagonal_eq_map, sum_map, Function.Embedding.coeFn_mk]
+    rw [(Commute.sum_right _ _ _ fun i hi ↦ hc (by simp) (by simp [hi])
+      (by simpa [eq_comm] using ne_of_mem_of_not_mem hi has)).add_pow]
+    simp only [ih (hc.mono (by simp)), sum_mul, mul_sum]
+    refine sum_congr rfl fun i _ ↦ sum_congr rfl fun g _ ↦ ?_
+    rw [← Nat.cast_comm, (Nat.commute_cast (f a ^ i) _).left_comm, mul_assoc]
+  refine fun p hp ↦ sum_congr rfl fun f hf ↦ ?_
+  rw [mem_piAntidiag] at hf
+  rw [not_imp_comm.1 (hf.2 _) has, zero_add, hf.1]
+  congr 2
+  · rw [mem_antidiagonal.1 hp]
+  · rw [multinomial_congr]
+    intro t ht
+    rw [Pi.add_apply, if_neg, add_zero]
+    exact ne_of_mem_of_not_mem ht has
+  refine noncommProd_congr rfl (fun t ht ↦ ?_) _
+  rw [if_neg, add_zero]
+  exact ne_of_mem_of_not_mem ht has
+
+/-- The **multinomial theorem**. -/
+theorem sum_pow_of_commute [Semiring R] (x : α → R) (s : Finset α)
     (hc : (s : Set α).Pairwise fun i j => Commute (x i) (x j)) :
     ∀ n,
       s.sum x ^ n =
@@ -243,13 +286,23 @@ theorem sum_pow_of_commute [Semiring R] (x : α → R)
     rw [Multiset.card_replicate, Nat.cast_mul, mul_assoc, Nat.cast_comm]
     congr 1; simp_rw [← mul_assoc, Nat.cast_comm]; rfl
 
+end Semiring
+
+section CommSemiring
+variable [CommSemiring R] {f : α → R} {s : Finset α}
+
+lemma sum_pow_eq_sum_piAntidiag (s : Finset α) (f : α → R) (n : ℕ) :
+    (∑ i in s, f i) ^ n = ∑ k in piAntidiag s n, multinomial s k * ∏ i in s, f i ^ k i := by
+  simp_rw [← noncommProd_eq_prod]
+  rw [← sum_pow_eq_sum_piAntidiag_of_commute _ _ fun _ _ _ _ _ ↦ Commute.all ..]
 
 theorem sum_pow [CommSemiring R] (x : α → R) (n : ℕ) :
     s.sum x ^ n = ∑ k ∈ s.sym n, k.val.multinomial * (k.val.map x).prod := by
   conv_rhs => rw [← sum_coe_sort]
-  convert sum_pow_of_commute s x (fun _ _ _ _ _ => mul_comm _ _) n
+  convert sum_pow_of_commute x s (fun _ _ _ _ _ ↦ Commute.all ..) n
   rw [Multiset.noncommProd_eq_prod]
 
+end CommSemiring
 end Finset
 
 namespace Sym

--- a/Mathlib/Data/Nat/Choose/Multinomial.lean
+++ b/Mathlib/Data/Nat/Choose/Multinomial.lean
@@ -219,7 +219,7 @@ lemma sum_pow_eq_sum_piAntidiag_of_commute (s : Finset α) (f : α → R)
   simp only [sum_map, Function.Embedding.coeFn_mk, Pi.add_apply, multinomial_cons,
     Pi.add_apply, eq_self_iff_true, if_true, Nat.cast_mul, noncommProd_cons, eq_self_iff_true,
     if_true, sum_add_distrib, sum_ite_eq', has, if_false, add_zero,
-      addLeftEmbedding_eq_addRightEmbedding, addRightEmbedding_apply]
+    addLeftEmbedding_eq_addRightEmbedding, addRightEmbedding_apply]
   suffices ∀ p : ℕ × ℕ, p ∈ antidiagonal n →
     ∑ g in piAntidiag s p.2, ((g a + p.1 + s.sum g).choose (g a + p.1) : R) *
       multinomial s (g + fun i ↦ ite (i = a) p.1 0) *

--- a/Mathlib/Data/Sym/Basic.lean
+++ b/Mathlib/Data/Sym/Basic.lean
@@ -147,9 +147,19 @@ instance : Membership α (Sym α n) :=
 instance decidableMem [DecidableEq α] (a : α) (s : Sym α n) : Decidable (a ∈ s) :=
   s.1.decidableMem _
 
+@[simp, norm_cast] lemma coe_mk (s : Multiset α) (h : Multiset.card s = n) : mk s h = s := rfl
+
 @[simp]
 theorem mem_mk (a : α) (s : Multiset α) (h : Multiset.card s = n) : a ∈ mk s h ↔ a ∈ s :=
   Iff.rfl
+
+lemma «forall» {p : Sym α n → Prop} :
+    (∀ s : Sym α n, p s) ↔ ∀ (s : Multiset α) (hs : Multiset.card s = n), p (Sym.mk s hs) := by
+  simp [Sym]
+
+lemma «exists» {p : Sym α n → Prop} :
+    (∃ s : Sym α n, p s) ↔ ∃ (s : Multiset α) (hs : Multiset.card s = n), p (Sym.mk s hs) := by
+  simp [Sym]
 
 @[simp]
 theorem not_mem_nil (a : α) : ¬ a ∈ (nil : Sym α 0) :=


### PR DESCRIPTION
Prove that `(∑ i in s, f i) ^ n = ∑ k in piAntidiag s n, multinomial s k * ∏ i in s, f i ^ k i`. We already have a version of this for `Finset.sym`, so I am also adding machinery to deduce one from the other. I however haven't managed to do that.

From LeanAPAP

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
