### PR TITLE
[Merged by Bors] - feat: Convex functions are continuous

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -1097,6 +1097,7 @@ import Mathlib.Analysis.Convex.Cone.Extension
 import Mathlib.Analysis.Convex.Cone.InnerDual
 import Mathlib.Analysis.Convex.Cone.Pointed
 import Mathlib.Analysis.Convex.Cone.Proper
+import Mathlib.Analysis.Convex.Continuous
 import Mathlib.Analysis.Convex.Contractible
 import Mathlib.Analysis.Convex.Deriv
 import Mathlib.Analysis.Convex.EGauge

--- a/Mathlib/Analysis/Convex/Continuous.lean
+++ b/Mathlib/Analysis/Convex/Continuous.lean
@@ -207,6 +207,7 @@ protected lemma ConvexOn.locallyLipschitz (hf : ConvexOn ℝ univ f) : LocallyLi
 protected lemma ConcaveOn.locallyLipschitz (hf : ConcaveOn ℝ univ f) : LocallyLipschitz f := by
   simpa using hf.locallyLipschitzOn_interior
 
+-- Commented out since `intrinsicInterior` is not imported (but should be once these are proved)
 -- proof_wanted ConvexOn.locallyLipschitzOn_intrinsicInterior (hf : ConvexOn ℝ C f) :
 --     ContinuousOn f (intrinsicInterior ℝ C)
 

--- a/Mathlib/Analysis/Convex/Continuous.lean
+++ b/Mathlib/Analysis/Convex/Continuous.lean
@@ -16,14 +16,11 @@ open FiniteDimensional Metric Set List Bornology
 open scoped Topology
 
 variable {E : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E]
-  {C : Set E} {f : E → ℝ} {x₀ : E} {ε r : ℝ}
+  {C : Set E} {f : E → ℝ} {x₀ : E} {ε r r' M : ℝ}
 
-lemma ConvexOn.exists_lipschitzOnWith_of_isBounded (hf : ConvexOn ℝ (ball x₀ r) f) (hε : 0 < ε)
-    (hf' : IsBounded (f '' ball x₀ r)) : ∃ K, LipschitzOnWith K f (ball x₀ (r - ε)) := by
-  rw [isBounded_iff_subset_ball 0] at hf'
-  simp only [Set.subset_def, mem_image, mem_ball, dist_zero_right, Real.norm_eq_abs,
-    forall_exists_index, and_imp, forall_apply_eq_imp_iff₂] at hf'
-  obtain ⟨M, hM⟩ := hf'
+lemma ConvexOn.lipschitzOnWith_of_abs_le (hf : ConvexOn ℝ (ball x₀ r) f) (hε : 0 < ε)
+    (hM : ∀ a, dist a x₀ < r → |f a| ≤ M) :
+    LipschitzOnWith (2 * M / ε).toNNReal f (ball x₀ (r - ε)) := by
   set K := 2 * M / ε with hK
   have oneside {x y : E} (hx : x ∈ ball x₀ (r - ε)) (hy : y ∈ ball x₀ (r - ε)) :
       f x - f y ≤ K * ‖x - y‖ := by
@@ -59,16 +56,30 @@ lemma ConvexOn.exists_lipschitzOnWith_of_isBounded (hf : ConvexOn ℝ (ball x₀
       _ ≤ _ := by
         rw [sub_eq_add_neg (f _), two_mul]
         gcongr
-        · exact (le_abs_self _).trans <| (hM _ hz).le
-        · exact (neg_le_abs _).trans <| (hM _ hx').le
-  refine ⟨K.toNNReal, .of_dist_le' fun x hx y hy ↦ ?_⟩
+        · exact (le_abs_self _).trans <| hM _ hz
+        · exact (neg_le_abs _).trans <| hM _ hx'
+  refine .of_dist_le' fun x hx y hy ↦ ?_
   simp_rw [dist_eq_norm_sub, Real.norm_eq_abs, abs_sub_le_iff]
   exact ⟨oneside hx hy, norm_sub_rev x _ ▸ oneside hy hx⟩
 
-lemma ConcaveOn.exists_lipschitzOnWith_of_isBounded (hf : ConcaveOn ℝ (ball x₀ r) f) (hε : 0 < ε)
-    (hf' : IsBounded (f '' ball x₀ r)) : ∃ K, LipschitzOnWith K f (ball x₀ (r - ε)) := by
+lemma ConcaveOn.lipschitzOnWith_of_abs_le (hf : ConcaveOn ℝ (ball x₀ r) f) (hε : 0 < ε)
+    (hM : ∀ a, dist a x₀ < r → |f a| ≤ M) :
+    LipschitzOnWith (2 * M / ε).toNNReal f (ball x₀ (r - ε)) := by
+  simpa using hf.neg.lipschitzOnWith_of_abs_le hε <| by simpa using hM
+
+lemma ConvexOn.exists_lipschitzOnWith_of_isBounded (hf : ConvexOn ℝ (ball x₀ r) f) (hr : r' < r)
+    (hf' : IsBounded (f '' ball x₀ r)) : ∃ K, LipschitzOnWith K f (ball x₀ r') := by
+  rw [isBounded_iff_subset_ball 0] at hf'
+  simp only [Set.subset_def, mem_image, mem_ball, dist_zero_right, Real.norm_eq_abs,
+    forall_exists_index, and_imp, forall_apply_eq_imp_iff₂] at hf'
+  obtain ⟨M, hM⟩ := hf'
+  rw [← sub_sub_cancel r r']
+  exact ⟨_, hf.lipschitzOnWith_of_abs_le (sub_pos.2 hr) fun a ha ↦ (hM a ha).le⟩
+
+lemma ConcaveOn.exists_lipschitzOnWith_of_isBounded (hf : ConcaveOn ℝ (ball x₀ r) f) (hr : r' < r)
+    (hf' : IsBounded (f '' ball x₀ r)) : ∃ K, LipschitzOnWith K f (ball x₀ r') := by
   replace hf' : IsBounded ((-f) '' ball x₀ r) := by convert hf'.neg; ext; simp [neg_eq_iff_eq_neg]
-  simpa using hf.neg.exists_lipschitzOnWith_of_isBounded hε hf'
+  simpa using hf.neg.exists_lipschitzOnWith_of_isBounded hr hf'
 
 lemma ConvexOn.isBoundedUnder_abs (hf : ConvexOn ℝ C f) {x₀ : E} (hC : C ∈ 𝓝 x₀) :
     (𝓝 x₀).IsBoundedUnder (· ≤ ·) |f| ↔ (𝓝 x₀).IsBoundedUnder (· ≤ ·) f := by
@@ -141,7 +152,7 @@ lemma ConvexOn.continuousOn_tfae (hC : IsOpen C) (hC' : C.Nonempty) (hf : Convex
     obtain ⟨ε, hε, hεD⟩ := Metric.mem_nhds_iff.1 <| Filter.inter_mem (hC.mem_nhds hx) hr
     simp only [preimage_setOf_eq, Pi.abs_apply, subset_inter_iff, hC.nhdsWithin_eq hx] at hεD ⊢
     obtain ⟨K, hK⟩ := exists_lipschitzOnWith_of_isBounded (hf.subset hεD.1 (convex_ball ..))
-      (half_pos hε) <| isBounded_iff_forall_norm_le.2 ⟨r, by simpa using hεD.2⟩
+      (half_lt_self hε) <| isBounded_iff_forall_norm_le.2 ⟨r, by simpa using hεD.2⟩
     exact ⟨K, _, ball_mem_nhds _ (by simpa), hK⟩
   tfae_finish
 

--- a/Mathlib/Analysis/Convex/Continuous.lean
+++ b/Mathlib/Analysis/Convex/Continuous.lean
@@ -1,0 +1,220 @@
+/-
+Copyright (c) 2023 Yaël Dillies, Zichen Wang. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Yaël Dillies, Zichen Wang
+-/
+import Mathlib.Analysis.Convex.Normed
+
+/-!
+# Convex functions are continuous
+
+This file proves that a convex function from a finite dimensional real normed space to `ℝ` is
+continuous.
+-/
+
+open FiniteDimensional Metric Set List Bornology
+open scoped Topology
+
+variable {E : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E]
+  {C : Set E} {f : E → ℝ} {x₀ : E} {ε r : ℝ}
+
+lemma ConvexOn.exists_lipschitzOnWith_of_isBounded (hf : ConvexOn ℝ (ball x₀ r) f) (hε : 0 < ε)
+    (hf' : IsBounded (f '' ball x₀ r)) : ∃ K, LipschitzOnWith K f (ball x₀ (r - ε)) := by
+  rw [isBounded_iff_subset_ball 0] at hf'
+  simp only [Set.subset_def, mem_image, mem_ball, dist_zero_right, Real.norm_eq_abs,
+    forall_exists_index, and_imp, forall_apply_eq_imp_iff₂] at hf'
+  obtain ⟨M, hM⟩ := hf'
+  set K := 2 * M / ε with hK
+  have oneside {x y : E} (hx : x ∈ ball x₀ (r - ε)) (hy : y ∈ ball x₀ (r - ε)) :
+      f x - f y ≤ K * ‖x - y‖ := by
+    obtain rfl | hxy := eq_or_ne x y
+    · simp
+    have hx₀r : ball x₀ (r - ε) ⊆ ball x₀ r := ball_subset_ball <| by linarith
+    have hx' : x ∈ ball x₀ r := hx₀r hx
+    have hy' : y ∈ ball x₀ r := hx₀r hy
+    let z := x + (ε / ‖x - y‖) • (x - y)
+    replace hxy : 0 < ‖x - y‖ := by rwa [norm_sub_pos_iff]
+    have hz : z ∈ ball x₀ r := mem_ball_iff_norm.2 <| by
+      calc
+        _ = ‖(x - x₀) + (ε / ‖x - y‖) • (x - y)‖ := by simp only [z, add_sub_right_comm]
+        _ ≤ ‖x - x₀‖ + ‖(ε / ‖x - y‖) • (x - y)‖ := norm_add_le ..
+        _ < r - ε + ε :=
+          add_lt_add_of_lt_of_le (mem_ball_iff_norm.1 hx) <| by
+            simp [norm_smul, abs_of_nonneg, hε.le, hxy.ne']
+        _ = r := by simp
+    let a := ε / (ε + ‖x - y‖)
+    let b := ‖x - y‖ / (ε + ‖x - y‖)
+    have hab : a + b = 1 := by field_simp [a, b]
+    have hxyz : x = a • y + b • z := by
+      calc
+        x = a • x + b • x := by rw [Convex.combo_self hab]
+        _ = a • y + b • z := by simp [z, a, b, smul_smul, hxy.ne', smul_sub]; abel
+    rw [hK, mul_comm, ← mul_div_assoc, le_div_iff₀' hε]
+    calc
+      ε * (f x - f y) ≤ ‖x - y‖ * (f z - f x) := by
+        rw [mul_sub, mul_sub, sub_le_sub_iff, ← add_mul]
+        have h := hf.2 hy' hz (by positivity) (by positivity) hab
+        field_simp [← hxyz, a, b, ← mul_div_right_comm] at h
+        rwa [← le_div_iff₀' (by positivity), add_comm (_ * _)]
+      _ ≤ _ := by
+        rw [sub_eq_add_neg (f _), two_mul]
+        gcongr
+        · exact (le_abs_self _).trans <| (hM _ hz).le
+        · exact (neg_le_abs _).trans <| (hM _ hx').le
+  refine ⟨K.toNNReal, .of_dist_le' fun x hx y hy ↦ ?_⟩
+  simp_rw [dist_eq_norm_sub, Real.norm_eq_abs, abs_sub_le_iff]
+  exact ⟨oneside hx hy, norm_sub_rev x _ ▸ oneside hy hx⟩
+
+lemma ConcaveOn.exists_lipschitzOnWith_of_isBounded (hf : ConcaveOn ℝ (ball x₀ r) f) (hε : 0 < ε)
+    (hf' : IsBounded (f '' ball x₀ r)) : ∃ K, LipschitzOnWith K f (ball x₀ (r - ε)) := by
+  replace hf' : IsBounded ((-f) '' ball x₀ r) := by convert hf'.neg; ext; simp [neg_eq_iff_eq_neg]
+  simpa using hf.neg.exists_lipschitzOnWith_of_isBounded hε hf'
+
+lemma ConvexOn.isBoundedUnder_abs (hf : ConvexOn ℝ C f) {x₀ : E} (hC : C ∈ 𝓝 x₀) :
+    (𝓝 x₀).IsBoundedUnder (· ≤ ·) |f| ↔ (𝓝 x₀).IsBoundedUnder (· ≤ ·) f := by
+  refine ⟨fun h ↦ h.mono_le <| .of_forall fun x ↦ le_abs_self _, ?_⟩
+  rintro ⟨r, hr⟩
+  refine ⟨|r| + 2 * |f x₀|, ?_⟩
+  have : (𝓝 x₀).Tendsto (fun y => 2 • x₀ - y) (𝓝 x₀) :=
+    tendsto_nhds_nhds.2 (⟨·, ·, by simp [two_nsmul, dist_comm]⟩)
+  simp only [Filter.eventually_map, Pi.abs_apply, abs_le'] at hr ⊢
+  filter_upwards [this.eventually_mem hC, hC, hr, this.eventually hr] with y hx hx' hfr hfr'
+  refine ⟨hfr.trans <| (le_abs_self _).trans <| by simp, ?_⟩
+  rw [← sub_le_iff_le_add, neg_sub_comm, sub_le_iff_le_add', ← abs_two, ← abs_mul]
+  calc
+    -|2 * f x₀| ≤ 2 * f x₀ := neg_abs_le _
+    _ ≤ f y + f (2 • x₀ - y) := by
+      have := hf.2 hx' hx (by positivity) (by positivity) (add_halves _)
+      simp only [one_div, ← Nat.cast_smul_eq_nsmul ℝ, Nat.cast_ofNat, smul_sub, ne_eq,
+        OfNat.ofNat_ne_zero, not_false_eq_true, inv_smul_smul₀, add_sub_cancel, smul_eq_mul] at this
+      cancel_denoms at this
+      rwa [← Nat.cast_two, Nat.cast_smul_eq_nsmul] at this
+    _ ≤ f y + |r| := by gcongr; exact hfr'.trans (le_abs_self _)
+
+lemma ConcaveOn.isBoundedUnder_abs (hf : ConcaveOn ℝ C f) {x₀ : E} (hC : C ∈ 𝓝 x₀) :
+    (𝓝 x₀).IsBoundedUnder (· ≤ ·) |f| ↔ (𝓝 x₀).IsBoundedUnder (· ≥ ·) f := by
+  simpa [Pi.neg_def, Pi.abs_def] using hf.neg.isBoundedUnder_abs hC
+
+lemma ConvexOn.continuousOn_tfae (hC : IsOpen C) (hC' : C.Nonempty) (hf : ConvexOn ℝ C f) : TFAE [
+    LocallyLipschitzOn C f,
+    ContinuousOn f C,
+    ∃ x₀ ∈ C, ContinuousAt f x₀,
+    ∃ x₀ ∈ C, (𝓝 x₀).IsBoundedUnder (· ≤ ·) f,
+    ∀ ⦃x₀⦄, x₀ ∈ C → (𝓝 x₀).IsBoundedUnder (· ≤ ·) f,
+    ∀ ⦃x₀⦄, x₀ ∈ C → (𝓝 x₀).IsBoundedUnder (· ≤ ·) |f|] := by
+  tfae_have 1 → 2
+  · exact LocallyLipschitzOn.continuousOn
+  tfae_have 2 → 3
+  · obtain ⟨x₀, hx₀⟩ := hC'
+    exact fun h ↦ ⟨x₀, hx₀, h.continuousAt <| hC.mem_nhds hx₀⟩
+  tfae_have 3 → 4
+  · rintro ⟨x₀, hx₀, h⟩
+    exact ⟨x₀, hx₀, f x₀ + 1, by simpa using h.eventually (eventually_le_nhds (by simp))⟩
+  tfae_have 4 → 5
+  · rintro ⟨x₀, hx₀, r, hr⟩ x hx
+    have : ∀ᶠ δ in 𝓝 (0 : ℝ), (1 - δ)⁻¹ • x - (δ / (1 - δ)) • x₀ ∈ C := by
+      have h : ContinuousAt (fun δ : ℝ ↦ (1 - δ)⁻¹ • x - (δ / (1 - δ)) • x₀) 0 := by
+        fun_prop (disch := norm_num)
+      exact h (by simpa using hC.mem_nhds hx)
+    obtain ⟨δ, hδ₀, hy, hδ₁⟩ := (this.and <| eventually_lt_nhds zero_lt_one).exists_gt
+    set y := (1 - δ)⁻¹ • x - (δ / (1 - δ)) • x₀
+    refine ⟨max r (f y), ?_⟩
+    simp only [Filter.eventually_map, Pi.abs_apply] at hr ⊢
+    obtain ⟨ε, hε, hr⟩ := Metric.eventually_nhds_iff.1 <| hr.and (hC.eventually_mem hx₀)
+    refine Metric.eventually_nhds_iff.2 ⟨ε * δ, by positivity, fun z hz ↦ ?_⟩
+    have hx₀' : δ⁻¹ • (x - y) + y = x₀ := MulAction.injective₀ (sub_ne_zero.2 hδ₁.ne') <| by
+      simp [y, smul_sub, smul_smul, hδ₀.ne', div_eq_mul_inv, sub_ne_zero.2 hδ₁.ne', mul_left_comm,
+        sub_mul, sub_smul]
+    let w := δ⁻¹ • (z - y) + y
+    have hwyz : δ • w + (1 - δ) • y = z := by simp [w, hδ₀.ne', sub_smul]
+    have hw : dist w x₀ < ε := by
+      simpa [w, ← hx₀', dist_smul₀, abs_of_nonneg, hδ₀.le, inv_mul_lt_iff', hδ₀]
+    calc
+      f z ≤ max (f w) (f y) :=
+        hf.le_max_of_mem_segment (hr hw).2 hy ⟨_, _, hδ₀.le, sub_nonneg.2 hδ₁.le, by simp, hwyz⟩
+      _ ≤ max r (f y) := by gcongr; exact (hr hw).1
+  tfae_have 6 ↔ 5
+  · exact forall₂_congr fun x₀ hx₀ ↦ hf.isBoundedUnder_abs (hC.mem_nhds hx₀)
+  tfae_have 6 → 1
+  · rintro h x hx
+    obtain ⟨r, hr⟩ := h hx
+    obtain ⟨ε, hε, hεD⟩ := Metric.mem_nhds_iff.1 <| Filter.inter_mem (hC.mem_nhds hx) hr
+    simp only [preimage_setOf_eq, Pi.abs_apply, subset_inter_iff, hC.nhdsWithin_eq hx] at hεD ⊢
+    obtain ⟨K, hK⟩ := exists_lipschitzOnWith_of_isBounded (hf.subset hεD.1 (convex_ball ..))
+      (half_pos hε) <| isBounded_iff_forall_norm_le.2 ⟨r, by simpa using hεD.2⟩
+    exact ⟨K, _, ball_mem_nhds _ (by simpa), hK⟩
+  tfae_finish
+
+lemma ConcaveOn.continuousOn_tfae (hC : IsOpen C) (hC' : C.Nonempty) (hf : ConcaveOn ℝ C f) : TFAE [
+    LocallyLipschitzOn C f,
+    ContinuousOn f C,
+    ∃ x₀ ∈ C, ContinuousAt f x₀,
+    ∃ x₀ ∈ C, (𝓝 x₀).IsBoundedUnder (· ≥ ·) f,
+    ∀ ⦃x₀⦄, x₀ ∈ C → (𝓝 x₀).IsBoundedUnder (· ≥ ·) f,
+    ∀ ⦃x₀⦄, x₀ ∈ C → (𝓝 x₀).IsBoundedUnder (· ≤ ·) |f|] := by
+  have := hf.neg.continuousOn_tfae hC hC'
+  simp at this
+  convert this using 8 <;> exact (Equiv.neg ℝ).exists_congr (by simp)
+
+lemma ConvexOn.locallyLipschitzOn_iff_continuousOn (hC : IsOpen C) (hf : ConvexOn ℝ C f) :
+    LocallyLipschitzOn C f ↔ ContinuousOn f C := by
+  obtain rfl | hC' := C.eq_empty_or_nonempty
+  · simp
+  · exact (hf.continuousOn_tfae hC hC').out 0 1
+
+lemma ConcaveOn.locallyLipschitzOn_iff_continuousOn (hC : IsOpen C) (hf : ConcaveOn ℝ C f) :
+    LocallyLipschitzOn C f ↔ ContinuousOn f C := by
+  simpa using hf.neg.locallyLipschitzOn_iff_continuousOn hC
+
+variable [FiniteDimensional ℝ E]
+
+protected lemma ConvexOn.locallyLipschitzOn (hC : IsOpen C) (hf : ConvexOn ℝ C f) :
+    LocallyLipschitzOn C f := by
+  obtain rfl | ⟨x₀, hx₀⟩ := C.eq_empty_or_nonempty
+  · simp
+  · obtain ⟨b, hx₀b, hbC⟩ := exists_mem_interior_convexHull_affineBasis (hC.mem_nhds hx₀)
+    refine ((hf.continuousOn_tfae hC ⟨x₀, hx₀⟩).out 3 0).mp ?_
+    refine ⟨x₀, hx₀, BddAbove.isBoundedUnder (IsOpen.mem_nhds isOpen_interior hx₀b) ?_⟩
+    exact (hf.bddAbove_convexHull ((subset_convexHull ..).trans hbC)
+      ((finite_range _).image _).bddAbove).mono (by gcongr; exact interior_subset)
+
+protected lemma ConcaveOn.locallyLipschitzOn (hC : IsOpen C) (hf : ConcaveOn ℝ C f) :
+    LocallyLipschitzOn C f := by simpa using hf.neg.locallyLipschitzOn hC
+
+protected lemma ConvexOn.continuousOn (hC : IsOpen C) (hf : ConvexOn ℝ C f) :
+    ContinuousOn f C := (hf.locallyLipschitzOn hC).continuousOn
+
+protected lemma ConcaveOn.continuousOn (hC : IsOpen C) (hf : ConcaveOn ℝ C f) :
+    ContinuousOn f C := (hf.locallyLipschitzOn hC).continuousOn
+
+lemma ConvexOn.locallyLipschitzOn_interior (hf : ConvexOn ℝ C f) :
+    LocallyLipschitzOn (interior C) f :=
+  (hf.subset interior_subset hf.1.interior).locallyLipschitzOn isOpen_interior
+
+lemma ConcaveOn.locallyLipschitzOn_interior (hf : ConcaveOn ℝ C f) :
+    LocallyLipschitzOn (interior C) f :=
+  (hf.subset interior_subset hf.1.interior).locallyLipschitzOn isOpen_interior
+
+lemma ConvexOn.continuousOn_interior (hf : ConvexOn ℝ C f) : ContinuousOn f (interior C) :=
+  hf.locallyLipschitzOn_interior.continuousOn
+
+lemma ConcaveOn.continuousOn_interior (hf : ConcaveOn ℝ C f) : ContinuousOn f (interior C) :=
+  hf.locallyLipschitzOn_interior.continuousOn
+
+protected lemma ConvexOn.locallyLipschitz (hf : ConvexOn ℝ univ f) : LocallyLipschitz f := by
+  simpa using hf.locallyLipschitzOn_interior
+
+protected lemma ConcaveOn.locallyLipschitz (hf : ConcaveOn ℝ univ f) : LocallyLipschitz f := by
+  simpa using hf.locallyLipschitzOn_interior
+
+-- proof_wanted ConvexOn.locallyLipschitzOn_intrinsicInterior (hf : ConvexOn ℝ C f) :
+--     ContinuousOn f (intrinsicInterior ℝ C)
+
+-- proof_wanted ConcaveOn.locallyLipschitzOn_intrinsicInterior (hf : ConcaveOn ℝ C f) :
+--     ContinuousOn f (intrinsicInterior ℝ C)
+
+-- proof_wanted ConvexOn.continuousOn_intrinsicInterior (hf : ConvexOn ℝ C f) :
+--     ContinuousOn f (intrinsicInterior ℝ C)
+
+-- proof_wanted ConcaveOn.continuousOn_intrinsicInterior (hf : ConcaveOn ℝ C f) :
+--     ContinuousOn f (intrinsicInterior ℝ C)

--- a/Mathlib/Analysis/Convex/Intrinsic.lean
+++ b/Mathlib/Analysis/Convex/Intrinsic.lean
@@ -96,24 +96,6 @@ theorem intrinsicFrontier_subset_intrinsicClosure : intrinsicFrontier 𝕜 s ⊆
 theorem subset_intrinsicClosure : s ⊆ intrinsicClosure 𝕜 s :=
   fun x hx => ⟨⟨x, subset_affineSpan _ _ hx⟩, subset_closure hx, rfl⟩
 
-lemma intrinsicInterior_eq_interior_of_span (hs : affineSpan 𝕜 s = ⊤) :
-    intrinsicInterior 𝕜 s = interior s := by
-  set f : affineSpan 𝕜 s ≃ₜ P := .trans (.setCongr (congr_arg SetLike.coe hs)) (.Set.univ _)
-  change f '' interior (f ⁻¹' s) = interior s
-  rw [f.image_interior, f.image_preimage]
-
-lemma intrinsicFrontier_eq_frontier_of_span (hs : affineSpan 𝕜 s = ⊤) :
-    intrinsicFrontier 𝕜 s = frontier s := by
-  set f : affineSpan 𝕜 s ≃ₜ P := .trans (.setCongr (congr_arg SetLike.coe hs)) (.Set.univ _)
-  change f '' frontier (f ⁻¹' s) = frontier s
-  rw [f.image_frontier, f.image_preimage]
-
-lemma intrinsicClosure_eq_closure_of_span (hs : affineSpan 𝕜 s = ⊤) :
-    intrinsicClosure 𝕜 s = closure s := by
-  set f : affineSpan 𝕜 s ≃ₜ P := .trans (.setCongr (congr_arg SetLike.coe hs)) (.Set.univ _)
-  change f '' closure (f ⁻¹' s) = closure s
-  rw [f.image_closure, f.image_preimage]
-
 @[simp]
 theorem intrinsicInterior_empty : intrinsicInterior 𝕜 (∅ : Set P) = ∅ := by simp [intrinsicInterior]
 
@@ -122,15 +104,6 @@ theorem intrinsicFrontier_empty : intrinsicFrontier 𝕜 (∅ : Set P) = ∅ := 
 
 @[simp]
 theorem intrinsicClosure_empty : intrinsicClosure 𝕜 (∅ : Set P) = ∅ := by simp [intrinsicClosure]
-
-@[simp] lemma intrinsicInterior_univ : intrinsicInterior 𝕜 (univ : Set P) = univ := by
-  simp [intrinsicInterior]
-
-@[simp] lemma intrinsicFrontier_univ : intrinsicFrontier 𝕜 (univ : Set P) = ∅ := by
-  simp [intrinsicFrontier]
-
-@[simp] lemma intrinsicClosure_univ : intrinsicClosure 𝕜 (univ : Set P) = univ := by
-  simp [intrinsicClosure]
 
 @[simp]
 theorem intrinsicClosure_nonempty : (intrinsicClosure 𝕜 s).Nonempty ↔ s.Nonempty :=

--- a/Mathlib/Topology/ContinuousOn.lean
+++ b/Mathlib/Topology/ContinuousOn.lean
@@ -609,7 +609,7 @@ theorem continuous_of_cover_nhds {ι : Sort*} {f : α → β} {s : ι → Set α
     rw [ContinuousAt, ← nhdsWithin_eq_nhds.2 hi]
     exact hf _ _ (mem_of_mem_nhds hi)
 
-theorem continuousOn_empty (f : α → β) : ContinuousOn f ∅ := fun _ => False.elim
+@[simp] theorem continuousOn_empty (f : α → β) : ContinuousOn f ∅ := fun _ => False.elim
 
 @[simp]
 theorem continuousOn_singleton (f : α → β) (a : α) : ContinuousOn f {a} :=

--- a/docs/undergrad.yaml
+++ b/docs/undergrad.yaml
@@ -356,7 +356,9 @@ Single Variable Real Analysis:
     Weierstrass trigonometric approximation theorem: 'span_fourier_closure_eq_top'
   Convexity:
     convex functions of a real variable: 'ConvexOn'
-    continuity and differentiability of convex functions: 'https://en.wikipedia.org/wiki/Convex_function#Functions_of_one_variable'
+    continuity and differentiability of convex functions:
+      continuity: 'ConvexOn.continuousOn'
+      differentiability: 'https://en.wikipedia.org/wiki/Convex_function#Functions_of_one_variable'
     characterizations of convexity: 'convexOn_of_deriv2_nonneg'
     convexity inequalities: 'analysis/mean_inequalities.html'
 


### PR DESCRIPTION
Prove that convex functions from an open set in a finite dimensional real normed space are locally Lipschitz on that set.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->
- [x] depends on: #14660
- [x] depends on: #16111
- [x] depends on: #16115
- [x] depends on: #16117
- [x] depends on: #16118

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
