### PR TITLE
[Merged by Bors] - feat: add the `cdot` linter

### DIFF
--- a/Mathlib/Combinatorics/Colex.lean
+++ b/Mathlib/Combinatorics/Colex.lean
@@ -338,7 +338,7 @@ lemma lt_iff_max'_mem {s t : Colex α} :
   rw [lt_iff_le_and_ne, le_iff_max'_mem]; aesop
 
 lemma lt_iff_exists_filter_lt :
-    toColex s < toColex t ↔ ∃ w ∈ t \ s, s.filter (w < .) = t.filter (w < .) := by
+    toColex s < toColex t ↔ ∃ w ∈ t \ s, s.filter (w < ·) = t.filter (w < ·) := by
   simp only [lt_iff_exists_forall_lt, mem_sdiff, filter_inj, and_assoc]
   refine ⟨fun h ↦ ?_, ?_⟩
   · let u := (t \ s).filter fun w ↦ ∀ a ∈ s, a ∉ t → a < w

--- a/Mathlib/NumberTheory/LegendreSymbol/AddCharacter.lean
+++ b/Mathlib/NumberTheory/LegendreSymbol/AddCharacter.lean
@@ -70,7 +70,7 @@ theorem to_mulShift_inj_of_isPrimitive {ψ : AddChar R R'} (hψ : IsPrimitive ψ
   intro a b h
   apply_fun fun x => x * mulShift ψ (-b) at h
   simp only [mulShift_mul, mulShift_zero, add_right_neg, mulShift_apply] at h
-  simpa [← sub_eq_add_neg, sub_eq_zero] using (hψ . h)
+  simpa [← sub_eq_add_neg, sub_eq_zero] using (hψ · h)
 
 -- `AddCommGroup.equiv_direct_sum_zmod_of_fintype`
 -- gives the structure theorem for finite abelian groups.

--- a/Mathlib/Tactic/Linter/Lint.lean
+++ b/Mathlib/Tactic/Linter/Lint.lean
@@ -168,7 +168,7 @@ For instance, a "plain" dot `.` is allowed syntax, but is flagged by the linter.
 
 /--
 The `cdot` linter flags uses of the "cdot" `·` that are achieved by typing a character
-different form `·`.
+different from `·`.
 For instance, a "plain" dot `.` is allowed syntax, but is flagged by the linter. -/
 register_option linter.cdot : Bool := {
   defValue := true
@@ -186,16 +186,15 @@ def isCDot? : Syntax → Bool
 `findCDot stx` extracts from `stx` the syntax nodes of `kind` `Lean.Parser.Term.cdot` or `cdotTk`. -/
 partial
 def findCDot : Syntax → Array Syntax
-  | stx@(.node _ k args) =>
+  | stx@(.node _ kind args) =>
     let dargs := (args.map findCDot).flatten
-    match k with
-      | ``Lean.Parser.Term.cdot => dargs.push stx
-      | ``cdotTk => dargs.push stx
+    match kind with
+      | ``Lean.Parser.Term.cdot | ``cdotTk=> dargs.push stx
       | _ =>  dargs
   |_ => #[]
 
-/-- `unwanted_cdot stx` returns an array of syntax atoms corresponding to `cdot`s that are not
-written with the character `·`.
+/-- `unwanted_cdot stx` returns an array of syntax atoms within `stx`
+corresponding to `cdot`s that are not written with the character `·`.
 This is precisely what the `cdot` linter flags.
 -/
 def unwanted_cdot (stx : Syntax) : Array Syntax :=
@@ -213,8 +212,7 @@ def cdotLinter : Linter where run := withSetOptionIn fun stx => do
     if (← MonadState.get).messages.hasErrors then
       return
     for s in unwanted_cdot stx do
-      Linter.logLint linter.cdot s
-        m!"Please, use '·' (typed as `\\·`) instead of '{s}' as 'cdot'."
+      Linter.logLint linter.cdot s m!"Please, use '·' (typed as `\\·`) instead of '{s}' as 'cdot'."
 
 initialize addLinter cdotLinter
 

--- a/Mathlib/Tactic/Linter/Lint.lean
+++ b/Mathlib/Tactic/Linter/Lint.lean
@@ -162,7 +162,7 @@ end MissingEnd
 # The `cdot` linter
 
 The `cdot` linter is a syntax-linter that flags uses of the "cdot" `·` that are achieved
-by typing a character different form `·`.
+by typing a character different from `·`.
 For instance, a "plain" dot `.` is allowed syntax, but is flagged by the linter.
 -/
 

--- a/Mathlib/Tactic/Linter/Lint.lean
+++ b/Mathlib/Tactic/Linter/Lint.lean
@@ -183,23 +183,23 @@ def isCDot? : Syntax → Bool
   | _ => false
 
 /--
-`findDot stx` extracts from `stx` the syntax nodes of `kind` `Lean.Parser.Term.cdot` or `cdotTk`. -/
+`findCDot stx` extracts from `stx` the syntax nodes of `kind` `Lean.Parser.Term.cdot` or `cdotTk`. -/
 partial
-def findDot : Syntax → Array Syntax
+def findCDot : Syntax → Array Syntax
   | stx@(.node _ k args) =>
-    let dargs := (args.map findDot).flatten
+    let dargs := (args.map findCDot).flatten
     match k with
       | ``Lean.Parser.Term.cdot => dargs.push stx
       | ``cdotTk => dargs.push stx
       | _ =>  dargs
   |_ => #[]
 
-/-- `unwanted.cDot stx` returns an array of syntax atoms corresponding to `cdot`s that are not
+/-- `unwanted_cdot stx` returns an array of syntax atoms corresponding to `cdot`s that are not
 written with the character `·`.
 This is precisely what the `cdot` linter flags.
 -/
-def unwanted.cDot (stx : Syntax) : Array Syntax :=
-  (findDot stx).filter (!isCDot? ·)
+def unwanted_cdot (stx : Syntax) : Array Syntax :=
+  (findCDot stx).filter (!isCDot? ·)
 
 namespace CDotLinter
 
@@ -212,7 +212,7 @@ def cdotLinter : Linter where run := withSetOptionIn fun stx => do
       return
     if (← MonadState.get).messages.hasErrors then
       return
-    for s in unwanted.cDot stx do
+    for s in unwanted_cdot stx do
       Linter.logLint linter.cdot s
         m!"Please, use '·' (typed as `\\·`) instead of '{s}' as 'cdot'."
 

--- a/test/Lint.lean
+++ b/test/Lint.lean
@@ -57,3 +57,23 @@ set_option linter.dupNamespace true in
 export Nat (add)
 
 end add
+
+set_option linter.cdot false in
+/--
+warning: Please, use '·' (typed as `\·`) instead of '.' as 'cdot'.
+note: this linter can be disabled with `set_option linter.cdot false`
+---
+warning: Please, use '·' (typed as `\·`) instead of '.' as 'cdot'.
+note: this linter can be disabled with `set_option linter.cdot false`
+---
+warning: Please, use '·' (typed as `\·`) instead of '.' as 'cdot'.
+note: this linter can be disabled with `set_option linter.cdot false`
+-/
+#guard_msgs in
+set_option linter.cdot true in
+attribute [instance] Int.add in
+instance : Inhabited Nat where
+  default := by
+    . have := 0
+      · have : Nat → Nat → Nat := (· + .)
+        . exact 0

--- a/test/Lint.lean
+++ b/test/Lint.lean
@@ -77,3 +77,12 @@ instance : Inhabited Nat where
     . have := 0
       · have : Nat → Nat → Nat := (· + .)
         . exact 0
+
+set_option linter.cdot false in
+/--
+warning: Please, use '·' (typed as `\·`) instead of '.' as 'cdot'.
+note: this linter can be disabled with `set_option linter.cdot false`
+-/
+#guard_msgs in
+set_option linter.cdot true in
+example : Add Nat where add := (. + ·)


### PR DESCRIPTION
The `cdot` linter is a syntax linter that flags uses of the "cdot" `·` that are achieved by typing a character different from `·`.

For instance, a "plain" dot `.` is allowed syntax, but is flagged by the linter.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
