### PR TITLE
[Merged by Bors] - refactor(Probability): Make kernels a type

### DIFF
--- a/Mathlib/Probability/Independence/Basic.lean
+++ b/Mathlib/Probability/Independence/Basic.lean
@@ -48,7 +48,7 @@ as for a family, but without the starting `i`, for example `IndepFun` is the ver
 for two functions.
 
 The definition of independence for `iIndepSets` uses finite sets (`Finset`). See
-`ProbabilityTheory.kernel.iIndepSets`. An alternative and equivalent way of defining independence
+`ProbabilityTheory.Kernel.iIndepSets`. An alternative and equivalent way of defining independence
 would have been to use countable sets.
 
 Most of the definitions and lemmas in this file list all variables instead of using the `variable`
@@ -80,13 +80,13 @@ for any finite set of indices `s = {i_1, ..., i_n}`, for any sets
 It will be used for families of pi_systems. -/
 def iIndepSets {_mΩ : MeasurableSpace Ω}
     (π : ι → Set (Set Ω)) (μ : Measure Ω := by volume_tac) : Prop :=
-  kernel.iIndepSets π (kernel.const Unit μ) (Measure.dirac () : Measure Unit)
+  Kernel.iIndepSets π (Kernel.const Unit μ) (Measure.dirac () : Measure Unit)
 
 /-- Two sets of sets `s₁, s₂` are independent with respect to a measure `μ` if for any sets
 `t₁ ∈ p₁, t₂ ∈ s₂`, then `μ (t₁ ∩ t₂) = μ (t₁) * μ (t₂)` -/
 def IndepSets {_mΩ : MeasurableSpace Ω}
     (s1 s2 : Set (Set Ω)) (μ : Measure Ω := by volume_tac) : Prop :=
-  kernel.IndepSets s1 s2 (kernel.const Unit μ) (Measure.dirac () : Measure Unit)
+  Kernel.IndepSets s1 s2 (Kernel.const Unit μ) (Measure.dirac () : Measure Unit)
 
 /-- A family of measurable space structures (i.e. of σ-algebras) is independent with respect to a
 measure `μ` (typically defined on a finer σ-algebra) if the family of sets of measurable sets they
@@ -95,24 +95,24 @@ for any finite set of indices `s = {i_1, ..., i_n}`, for any sets
 `f i_1 ∈ m i_1, ..., f i_n ∈ m i_n`, then `μ (⋂ i in s, f i) = ∏ i ∈ s, μ (f i)`. -/
 def iIndep (m : ι → MeasurableSpace Ω) {_mΩ : MeasurableSpace Ω} (μ : Measure Ω := by volume_tac) :
     Prop :=
-  kernel.iIndep m (kernel.const Unit μ) (Measure.dirac () : Measure Unit)
+  Kernel.iIndep m (Kernel.const Unit μ) (Measure.dirac () : Measure Unit)
 
 /-- Two measurable space structures (or σ-algebras) `m₁, m₂` are independent with respect to a
 measure `μ` (defined on a third σ-algebra) if for any sets `t₁ ∈ m₁, t₂ ∈ m₂`,
 `μ (t₁ ∩ t₂) = μ (t₁) * μ (t₂)` -/
 def Indep (m₁ m₂ : MeasurableSpace Ω)
     {_mΩ : MeasurableSpace Ω} (μ : Measure Ω := by volume_tac) : Prop :=
-  kernel.Indep m₁ m₂ (kernel.const Unit μ) (Measure.dirac () : Measure Unit)
+  Kernel.Indep m₁ m₂ (Kernel.const Unit μ) (Measure.dirac () : Measure Unit)
 
 /-- A family of sets is independent if the family of measurable space structures they generate is
 independent. For a set `s`, the generated measurable space has measurable sets `∅, s, sᶜ, univ`. -/
 def iIndepSet {_mΩ : MeasurableSpace Ω} (s : ι → Set Ω) (μ : Measure Ω := by volume_tac) : Prop :=
-  kernel.iIndepSet s (kernel.const Unit μ) (Measure.dirac () : Measure Unit)
+  Kernel.iIndepSet s (Kernel.const Unit μ) (Measure.dirac () : Measure Unit)
 
 /-- Two sets are independent if the two measurable space structures they generate are independent.
 For a set `s`, the generated measurable space structure has measurable sets `∅, s, sᶜ, univ`. -/
 def IndepSet {_mΩ : MeasurableSpace Ω} (s t : Set Ω) (μ : Measure Ω := by volume_tac) : Prop :=
-  kernel.IndepSet s t (kernel.const Unit μ) (Measure.dirac () : Measure Unit)
+  Kernel.IndepSet s t (Kernel.const Unit μ) (Measure.dirac () : Measure Unit)
 
 /-- A family of functions defined on the same space `Ω` and taking values in possibly different
 spaces, each with a measurable space structure, is independent if the family of measurable space
@@ -120,14 +120,14 @@ structures they generate on `Ω` is independent. For a function `g` with codomai
 space structure `m`, the generated measurable space structure is `MeasurableSpace.comap g m`. -/
 def iIndepFun {_mΩ : MeasurableSpace Ω} {β : ι → Type*} (m : ∀ x : ι, MeasurableSpace (β x))
     (f : ∀ x : ι, Ω → β x) (μ : Measure Ω := by volume_tac) : Prop :=
-  kernel.iIndepFun m f (kernel.const Unit μ) (Measure.dirac () : Measure Unit)
+  Kernel.iIndepFun m f (Kernel.const Unit μ) (Measure.dirac () : Measure Unit)
 
 /-- Two functions are independent if the two measurable space structures they generate are
 independent. For a function `f` with codomain having measurable space structure `m`, the generated
 measurable space structure is `MeasurableSpace.comap f m`. -/
 def IndepFun {β γ} {_mΩ : MeasurableSpace Ω} [MeasurableSpace β] [MeasurableSpace γ]
     (f : Ω → β) (g : Ω → γ) (μ : Measure Ω := by volume_tac) : Prop :=
-  kernel.IndepFun f g (kernel.const Unit μ) (Measure.dirac () : Measure Unit)
+  Kernel.IndepFun f g (Kernel.const Unit μ) (Measure.dirac () : Measure Unit)
 
 end Definitions
 
@@ -138,7 +138,7 @@ variable {π : ι → Set (Set Ω)} {m : ι → MeasurableSpace Ω} {_ : Measura
 lemma iIndepSets_iff (π : ι → Set (Set Ω)) (μ : Measure Ω) :
     iIndepSets π μ ↔ ∀ (s : Finset ι) {f : ι → Set Ω} (_H : ∀ i, i ∈ s → f i ∈ π i),
       μ (⋂ i ∈ s, f i) = ∏ i ∈ s, μ (f i) := by
-  simp only [iIndepSets, kernel.iIndepSets, ae_dirac_eq, Filter.eventually_pure, kernel.const_apply]
+  simp only [iIndepSets, Kernel.iIndepSets, ae_dirac_eq, Filter.eventually_pure, Kernel.const_apply]
 
 lemma iIndepSets.meas_biInter (h : iIndepSets π μ) (s : Finset ι) {f : ι → Set Ω}
     (hf : ∀ i, i ∈ s → f i ∈ π i) : μ (⋂ i ∈ s, f i) = ∏ i ∈ s, μ (f i) :=
@@ -149,11 +149,11 @@ lemma iIndepSets.meas_iInter [Fintype ι] (h : iIndepSets π μ) (hs : ∀ i, s 
 
 lemma IndepSets_iff (s1 s2 : Set (Set Ω)) (μ : Measure Ω) :
     IndepSets s1 s2 μ ↔ ∀ t1 t2 : Set Ω, t1 ∈ s1 → t2 ∈ s2 → (μ (t1 ∩ t2) = μ t1 * μ t2) := by
-  simp only [IndepSets, kernel.IndepSets, ae_dirac_eq, Filter.eventually_pure, kernel.const_apply]
+  simp only [IndepSets, Kernel.IndepSets, ae_dirac_eq, Filter.eventually_pure, Kernel.const_apply]
 
 lemma iIndep_iff_iIndepSets (m : ι → MeasurableSpace Ω) {_mΩ : MeasurableSpace Ω} (μ : Measure Ω) :
     iIndep m μ ↔ iIndepSets (fun x ↦ {s | MeasurableSet[m x] s}) μ := by
-  simp only [iIndep, iIndepSets, kernel.iIndep]
+  simp only [iIndep, iIndepSets, Kernel.iIndep]
 
 lemma iIndep.iIndepSets' {m : ι → MeasurableSpace Ω}
     {_ : MeasurableSpace Ω} {μ : Measure Ω} (hμ : iIndep m μ) :
@@ -172,7 +172,7 @@ lemma iIndep.meas_iInter [Fintype ι] (hμ : iIndep m μ) (hs : ∀ i, Measurabl
 
 lemma Indep_iff_IndepSets (m₁ m₂ : MeasurableSpace Ω) {_mΩ : MeasurableSpace Ω} (μ : Measure Ω) :
     Indep m₁ m₂ μ ↔ IndepSets {s | MeasurableSet[m₁] s} {s | MeasurableSet[m₂] s} μ := by
-  simp only [Indep, IndepSets, kernel.Indep]
+  simp only [Indep, IndepSets, Kernel.Indep]
 
 lemma Indep_iff (m₁ m₂ : MeasurableSpace Ω) {_mΩ : MeasurableSpace Ω} (μ : Measure Ω) :
     Indep m₁ m₂ μ
@@ -181,7 +181,7 @@ lemma Indep_iff (m₁ m₂ : MeasurableSpace Ω) {_mΩ : MeasurableSpace Ω} (μ
 
 lemma iIndepSet_iff_iIndep (s : ι → Set Ω) (μ : Measure Ω) :
     iIndepSet s μ ↔ iIndep (fun i ↦ generateFrom {s i}) μ := by
-  simp only [iIndepSet, iIndep, kernel.iIndepSet]
+  simp only [iIndepSet, iIndep, Kernel.iIndepSet]
 
 lemma iIndepSet_iff (s : ι → Set Ω) (μ : Measure Ω) :
     iIndepSet s μ ↔ ∀ (s' : Finset ι) {f : ι → Set Ω}
@@ -191,7 +191,7 @@ lemma iIndepSet_iff (s : ι → Set Ω) (μ : Measure Ω) :
 
 lemma IndepSet_iff_Indep (s t : Set Ω) (μ : Measure Ω) :
     IndepSet s t μ ↔ Indep (generateFrom {s}) (generateFrom {t}) μ := by
-  simp only [IndepSet, Indep, kernel.IndepSet]
+  simp only [IndepSet, Indep, Kernel.IndepSet]
 
 lemma IndepSet_iff (s t : Set Ω) (μ : Measure Ω) :
     IndepSet s t μ ↔ ∀ t1 t2, MeasurableSet[generateFrom {s}] t1
@@ -201,7 +201,7 @@ lemma IndepSet_iff (s t : Set Ω) (μ : Measure Ω) :
 lemma iIndepFun_iff_iIndep {β : ι → Type*}
     (m : ∀ x : ι, MeasurableSpace (β x)) (f : ∀ x : ι, Ω → β x) (μ : Measure Ω) :
     iIndepFun m f μ ↔ iIndep (fun x ↦ (m x).comap (f x)) μ := by
-  simp only [iIndepFun, iIndep, kernel.iIndepFun]
+  simp only [iIndepFun, iIndep, Kernel.iIndepFun]
 
 protected lemma iIndepFun.iIndep {m : ∀ i, MeasurableSpace (κ i)} {f : ∀ x : ι, Ω → κ x}
     (hf : iIndepFun m f μ) :
@@ -225,7 +225,7 @@ lemma iIndepFun.meas_iInter [Fintype ι] {m : ∀ i, MeasurableSpace (κ i)} {f 
 lemma IndepFun_iff_Indep [mβ : MeasurableSpace β]
     [mγ : MeasurableSpace γ] (f : Ω → β) (g : Ω → γ) (μ : Measure Ω) :
     IndepFun f g μ ↔ Indep (MeasurableSpace.comap f mβ) (MeasurableSpace.comap g mγ) μ := by
-  simp only [IndepFun, Indep, kernel.IndepFun]
+  simp only [IndepFun, Indep, Kernel.IndepFun]
 
 lemma IndepFun_iff {β γ} [mβ : MeasurableSpace β] [mγ : MeasurableSpace γ]
     (f : Ω → β) (g : Ω → γ) (μ : Measure Ω) :
@@ -248,77 +248,77 @@ variable {m₁ m₂ m₃ : MeasurableSpace Ω} (m' : MeasurableSpace Ω)
 
 @[symm]
 theorem IndepSets.symm {s₁ s₂ : Set (Set Ω)} (h : IndepSets s₁ s₂ μ) : IndepSets s₂ s₁ μ :=
-  kernel.IndepSets.symm h
+  Kernel.IndepSets.symm h
 
 @[symm]
 theorem Indep.symm (h : Indep m₁ m₂ μ) : Indep m₂ m₁ μ := IndepSets.symm h
 
 theorem indep_bot_right [IsProbabilityMeasure μ] : Indep m' ⊥ μ :=
-  kernel.indep_bot_right m'
+  Kernel.indep_bot_right m'
 
 theorem indep_bot_left [IsProbabilityMeasure μ] : Indep ⊥ m' μ := (indep_bot_right m').symm
 
 theorem indepSet_empty_right [IsProbabilityMeasure μ] (s : Set Ω) : IndepSet s ∅ μ :=
-  kernel.indepSet_empty_right s
+  Kernel.indepSet_empty_right s
 
 theorem indepSet_empty_left [IsProbabilityMeasure μ] (s : Set Ω) : IndepSet ∅ s μ :=
-  kernel.indepSet_empty_left s
+  Kernel.indepSet_empty_left s
 
 theorem indepSets_of_indepSets_of_le_left {s₁ s₂ s₃ : Set (Set Ω)}
     (h_indep : IndepSets s₁ s₂ μ) (h31 : s₃ ⊆ s₁) :
     IndepSets s₃ s₂ μ :=
-  kernel.indepSets_of_indepSets_of_le_left h_indep h31
+  Kernel.indepSets_of_indepSets_of_le_left h_indep h31
 
 theorem indepSets_of_indepSets_of_le_right {s₁ s₂ s₃ : Set (Set Ω)}
     (h_indep : IndepSets s₁ s₂ μ) (h32 : s₃ ⊆ s₂) :
     IndepSets s₁ s₃ μ :=
-  kernel.indepSets_of_indepSets_of_le_right h_indep h32
+  Kernel.indepSets_of_indepSets_of_le_right h_indep h32
 
 theorem indep_of_indep_of_le_left (h_indep : Indep m₁ m₂ μ) (h31 : m₃ ≤ m₁) :
     Indep m₃ m₂ μ :=
-  kernel.indep_of_indep_of_le_left h_indep h31
+  Kernel.indep_of_indep_of_le_left h_indep h31
 
 theorem indep_of_indep_of_le_right (h_indep : Indep m₁ m₂ μ) (h32 : m₃ ≤ m₂) :
     Indep m₁ m₃ μ :=
-  kernel.indep_of_indep_of_le_right h_indep h32
+  Kernel.indep_of_indep_of_le_right h_indep h32
 
 theorem IndepSets.union {s₁ s₂ s' : Set (Set Ω)} (h₁ : IndepSets s₁ s' μ) (h₂ : IndepSets s₂ s' μ) :
     IndepSets (s₁ ∪ s₂) s' μ :=
-  kernel.IndepSets.union h₁ h₂
+  Kernel.IndepSets.union h₁ h₂
 
 @[simp]
 theorem IndepSets.union_iff {s₁ s₂ s' : Set (Set Ω)} :
     IndepSets (s₁ ∪ s₂) s' μ ↔ IndepSets s₁ s' μ ∧ IndepSets s₂ s' μ :=
-  kernel.IndepSets.union_iff
+  Kernel.IndepSets.union_iff
 
 theorem IndepSets.iUnion {s : ι → Set (Set Ω)} {s' : Set (Set Ω)}
     (hyp : ∀ n, IndepSets (s n) s' μ) :
     IndepSets (⋃ n, s n) s' μ :=
-  kernel.IndepSets.iUnion hyp
+  Kernel.IndepSets.iUnion hyp
 
 theorem IndepSets.bUnion {s : ι → Set (Set Ω)} {s' : Set (Set Ω)}
     {u : Set ι} (hyp : ∀ n ∈ u, IndepSets (s n) s' μ) :
     IndepSets (⋃ n ∈ u, s n) s' μ :=
-  kernel.IndepSets.bUnion hyp
+  Kernel.IndepSets.bUnion hyp
 
 theorem IndepSets.inter {s₁ s' : Set (Set Ω)} (s₂ : Set (Set Ω)) (h₁ : IndepSets s₁ s' μ) :
     IndepSets (s₁ ∩ s₂) s' μ :=
-  kernel.IndepSets.inter s₂ h₁
+  Kernel.IndepSets.inter s₂ h₁
 
 theorem IndepSets.iInter {s : ι → Set (Set Ω)} {s' : Set (Set Ω)}
     (h : ∃ n, IndepSets (s n) s' μ) :
     IndepSets (⋂ n, s n) s' μ :=
-  kernel.IndepSets.iInter h
+  Kernel.IndepSets.iInter h
 
 theorem IndepSets.bInter {s : ι → Set (Set Ω)} {s' : Set (Set Ω)}
     {u : Set ι} (h : ∃ n ∈ u, IndepSets (s n) s' μ) :
     IndepSets (⋂ n ∈ u, s n) s' μ :=
-  kernel.IndepSets.bInter h
+  Kernel.IndepSets.bInter h
 
 theorem indepSets_singleton_iff {s t : Set Ω} :
     IndepSets {s} {t} μ ↔ μ (s ∩ t) = μ s * μ t := by
-  simp only [IndepSets, kernel.indepSets_singleton_iff, ae_dirac_eq, Filter.eventually_pure,
-    kernel.const_apply]
+  simp only [IndepSets, Kernel.indepSets_singleton_iff, ae_dirac_eq, Filter.eventually_pure,
+    Kernel.const_apply]
 
 end Indep
 
@@ -331,17 +331,17 @@ variable {m : ι → MeasurableSpace Ω}  {_mΩ : MeasurableSpace Ω} {μ : Meas
 
 theorem iIndepSets.indepSets {s : ι → Set (Set Ω)}
     (h_indep : iIndepSets s μ) {i j : ι} (hij : i ≠ j) : IndepSets (s i) (s j) μ :=
-  kernel.iIndepSets.indepSets h_indep hij
+  Kernel.iIndepSets.indepSets h_indep hij
 
 theorem iIndep.indep
     (h_indep : iIndep m μ) {i j : ι} (hij : i ≠ j) : Indep (m i) (m j) μ :=
-  kernel.iIndep.indep h_indep hij
+  Kernel.iIndep.indep h_indep hij
 
 theorem iIndepFun.indepFun {β : ι → Type*}
     {m : ∀ x, MeasurableSpace (β x)} {f : ∀ i, Ω → β i} (hf_Indep : iIndepFun m f μ) {i j : ι}
     (hij : i ≠ j) :
     IndepFun (f i) (f j) μ :=
-  kernel.iIndepFun.indepFun hf_Indep hij
+  Kernel.iIndepFun.indepFun hf_Indep hij
 
 end FromIndepToIndep
 
@@ -361,12 +361,12 @@ variable {m : ι → MeasurableSpace Ω} {_mΩ : MeasurableSpace Ω} {μ : Measu
 theorem iIndep.iIndepSets
     {s : ι → Set (Set Ω)} (hms : ∀ n, m n = generateFrom (s n)) (h_indep : iIndep m μ) :
     iIndepSets s μ :=
-  kernel.iIndep.iIndepSets hms h_indep
+  Kernel.iIndep.iIndepSets hms h_indep
 
 theorem Indep.indepSets {s1 s2 : Set (Set Ω)}
     (h_indep : Indep (generateFrom s1) (generateFrom s2) μ) :
     IndepSets s1 s2 μ :=
-  kernel.Indep.indepSets h_indep
+  Kernel.Indep.indepSets h_indep
 
 end FromMeasurableSpacesToSetsOfSets
 
@@ -381,71 +381,71 @@ theorem IndepSets.indep [IsProbabilityMeasure μ]
     (hp2 : IsPiSystem p2) (hpm1 : m1 = generateFrom p1) (hpm2 : m2 = generateFrom p2)
     (hyp : IndepSets p1 p2 μ) :
     Indep m1 m2 μ :=
-  kernel.IndepSets.indep h1 h2 hp1 hp2 hpm1 hpm2 hyp
+  Kernel.IndepSets.indep h1 h2 hp1 hp2 hpm1 hpm2 hyp
 
 theorem IndepSets.indep' [IsProbabilityMeasure μ]
     {p1 p2 : Set (Set Ω)} (hp1m : ∀ s ∈ p1, MeasurableSet s) (hp2m : ∀ s ∈ p2, MeasurableSet s)
     (hp1 : IsPiSystem p1) (hp2 : IsPiSystem p2) (hyp : IndepSets p1 p2 μ) :
     Indep (generateFrom p1) (generateFrom p2) μ :=
-  kernel.IndepSets.indep' hp1m hp2m hp1 hp2 hyp
+  Kernel.IndepSets.indep' hp1m hp2m hp1 hp2 hyp
 
 theorem indepSets_piiUnionInter_of_disjoint [IsProbabilityMeasure μ] {s : ι → Set (Set Ω)}
     {S T : Set ι} (h_indep : iIndepSets s μ) (hST : Disjoint S T) :
     IndepSets (piiUnionInter s S) (piiUnionInter s T) μ :=
-  kernel.indepSets_piiUnionInter_of_disjoint h_indep hST
+  Kernel.indepSets_piiUnionInter_of_disjoint h_indep hST
 
 theorem iIndepSet.indep_generateFrom_of_disjoint [IsProbabilityMeasure μ] {s : ι → Set Ω}
     (hsm : ∀ n, MeasurableSet (s n)) (hs : iIndepSet s μ) (S T : Set ι) (hST : Disjoint S T) :
     Indep (generateFrom { t | ∃ n ∈ S, s n = t }) (generateFrom { t | ∃ k ∈ T, s k = t }) μ :=
-  kernel.iIndepSet.indep_generateFrom_of_disjoint hsm hs S T hST
+  Kernel.iIndepSet.indep_generateFrom_of_disjoint hsm hs S T hST
 
 theorem indep_iSup_of_disjoint [IsProbabilityMeasure μ]
     (h_le : ∀ i, m i ≤ _mΩ) (h_indep : iIndep m μ) {S T : Set ι} (hST : Disjoint S T) :
     Indep (⨆ i ∈ S, m i) (⨆ i ∈ T, m i) μ :=
-  kernel.indep_iSup_of_disjoint h_le h_indep hST
+  Kernel.indep_iSup_of_disjoint h_le h_indep hST
 
 theorem indep_iSup_of_directed_le
     [IsProbabilityMeasure μ] (h_indep : ∀ i, Indep (m i) m1 μ)
     (h_le : ∀ i, m i ≤ _mΩ) (h_le' : m1 ≤ _mΩ) (hm : Directed (· ≤ ·) m) :
     Indep (⨆ i, m i) m1 μ :=
-  kernel.indep_iSup_of_directed_le h_indep h_le h_le' hm
+  Kernel.indep_iSup_of_directed_le h_indep h_le h_le' hm
 
 theorem iIndepSet.indep_generateFrom_lt [Preorder ι] [IsProbabilityMeasure μ] {s : ι → Set Ω}
     (hsm : ∀ n, MeasurableSet (s n)) (hs : iIndepSet s μ) (i : ι) :
     Indep (generateFrom {s i}) (generateFrom { t | ∃ j < i, s j = t }) μ :=
-  kernel.iIndepSet.indep_generateFrom_lt hsm hs i
+  Kernel.iIndepSet.indep_generateFrom_lt hsm hs i
 
 theorem iIndepSet.indep_generateFrom_le [LinearOrder ι] [IsProbabilityMeasure μ] {s : ι → Set Ω}
     (hsm : ∀ n, MeasurableSet (s n)) (hs : iIndepSet s μ) (i : ι) {k : ι} (hk : i < k) :
     Indep (generateFrom {s k}) (generateFrom { t | ∃ j ≤ i, s j = t }) μ :=
-  kernel.iIndepSet.indep_generateFrom_le hsm hs i hk
+  Kernel.iIndepSet.indep_generateFrom_le hsm hs i hk
 
 theorem iIndepSet.indep_generateFrom_le_nat [IsProbabilityMeasure μ] {s : ℕ → Set Ω}
     (hsm : ∀ n, MeasurableSet (s n)) (hs : iIndepSet s μ) (n : ℕ) :
     Indep (generateFrom {s (n + 1)}) (generateFrom { t | ∃ k ≤ n, s k = t }) μ :=
-  kernel.iIndepSet.indep_generateFrom_le_nat hsm hs n
+  Kernel.iIndepSet.indep_generateFrom_le_nat hsm hs n
 
 theorem indep_iSup_of_monotone [SemilatticeSup ι] [IsProbabilityMeasure μ]
     (h_indep : ∀ i, Indep (m i) m1 μ) (h_le : ∀ i, m i ≤ _mΩ) (h_le' : m1 ≤ _mΩ) (hm : Monotone m) :
     Indep (⨆ i, m i) m1 μ :=
-  kernel.indep_iSup_of_monotone h_indep h_le h_le' hm
+  Kernel.indep_iSup_of_monotone h_indep h_le h_le' hm
 
 theorem indep_iSup_of_antitone [SemilatticeInf ι] [IsProbabilityMeasure μ]
     (h_indep : ∀ i, Indep (m i) m1 μ) (h_le : ∀ i, m i ≤ _mΩ) (h_le' : m1 ≤ _mΩ) (hm : Antitone m) :
     Indep (⨆ i, m i) m1 μ :=
-  kernel.indep_iSup_of_antitone h_indep h_le h_le' hm
+  Kernel.indep_iSup_of_antitone h_indep h_le h_le' hm
 
 theorem iIndepSets.piiUnionInter_of_not_mem {π : ι → Set (Set Ω)} {a : ι} {S : Finset ι}
     (hp_ind : iIndepSets π μ) (haS : a ∉ S) :
     IndepSets (piiUnionInter π S) (π a) μ :=
-  kernel.iIndepSets.piiUnionInter_of_not_mem hp_ind haS
+  Kernel.iIndepSets.piiUnionInter_of_not_mem hp_ind haS
 
 /-- The measurable space structures generated by independent pi-systems are independent. -/
 theorem iIndepSets.iIndep [IsProbabilityMeasure μ]
     (h_le : ∀ i, m i ≤ _mΩ) (π : ι → Set (Set Ω)) (h_pi : ∀ n, IsPiSystem (π n))
     (h_generate : ∀ i, m i = generateFrom (π i)) (h_ind : iIndepSets π μ) :
     iIndep m μ :=
-  kernel.iIndepSets.iIndep m h_le π h_pi h_generate h_ind
+  Kernel.iIndepSets.iIndep m h_le π h_pi h_generate h_ind
 
 end FromPiSystemsToMeasurableSpaces
 
@@ -464,7 +464,7 @@ variable {m₁ m₂ _mΩ : MeasurableSpace Ω} {μ : Measure Ω} {s t : Set Ω} 
 theorem indepSet_iff_indepSets_singleton (hs_meas : MeasurableSet s)
     (ht_meas : MeasurableSet t) (μ : Measure Ω := by volume_tac)
     [IsProbabilityMeasure μ] : IndepSet s t μ ↔ IndepSets {s} {t} μ :=
-  kernel.indepSet_iff_indepSets_singleton hs_meas ht_meas _ _
+  Kernel.indepSet_iff_indepSets_singleton hs_meas ht_meas _ _
 
 theorem indepSet_iff_measure_inter_eq_mul (hs_meas : MeasurableSet s)
     (ht_meas : MeasurableSet t) (μ : Measure Ω := by volume_tac)
@@ -476,43 +476,43 @@ theorem IndepSets.indepSet_of_mem (hs : s ∈ S) (ht : t ∈ T)
     (μ : Measure Ω := by volume_tac) [IsProbabilityMeasure μ]
     (h_indep : IndepSets S T μ) :
     IndepSet s t μ :=
-  kernel.IndepSets.indepSet_of_mem _ _ hs ht hs_meas ht_meas _ _ h_indep
+  Kernel.IndepSets.indepSet_of_mem _ _ hs ht hs_meas ht_meas _ _ h_indep
 
 theorem Indep.indepSet_of_measurableSet
     (h_indep : Indep m₁ m₂ μ) {s t : Set Ω} (hs : MeasurableSet[m₁] s) (ht : MeasurableSet[m₂] t) :
     IndepSet s t μ :=
-  kernel.Indep.indepSet_of_measurableSet h_indep hs ht
+  Kernel.Indep.indepSet_of_measurableSet h_indep hs ht
 
 theorem indep_iff_forall_indepSet (μ : Measure Ω) :
     Indep m₁ m₂ μ ↔ ∀ s t, MeasurableSet[m₁] s → MeasurableSet[m₂] t → IndepSet s t μ :=
-  kernel.indep_iff_forall_indepSet m₁ m₂ _ _
+  Kernel.indep_iff_forall_indepSet m₁ m₂ _ _
 
 theorem iIndep_comap_mem_iff {f : ι → Set Ω} :
     iIndep (fun i => MeasurableSpace.comap (· ∈ f i) ⊤) μ ↔ iIndepSet f μ :=
-  kernel.iIndep_comap_mem_iff
+  Kernel.iIndep_comap_mem_iff
 
 alias ⟨_, iIndepSet.iIndep_comap_mem⟩ := iIndep_comap_mem_iff
 
 theorem iIndepSets_singleton_iff {s : ι → Set Ω} :
     iIndepSets (fun i ↦ {s i}) μ ↔ ∀ t, μ (⋂ i ∈ t, s i) = ∏ i ∈ t, μ (s i) := by
-  simp_rw [iIndepSets, kernel.iIndepSets_singleton_iff, ae_dirac_eq, Filter.eventually_pure,
-    kernel.const_apply]
+  simp_rw [iIndepSets, Kernel.iIndepSets_singleton_iff, ae_dirac_eq, Filter.eventually_pure,
+    Kernel.const_apply]
 
 variable [IsProbabilityMeasure μ]
 
 theorem iIndepSet_iff_iIndepSets_singleton {f : ι → Set Ω} (hf : ∀ i, MeasurableSet (f i)) :
     iIndepSet f μ ↔ iIndepSets (fun i ↦ {f i}) μ :=
-  kernel.iIndepSet_iff_iIndepSets_singleton hf
+  Kernel.iIndepSet_iff_iIndepSets_singleton hf
 
 theorem iIndepSet_iff_meas_biInter {f : ι → Set Ω} (hf : ∀ i, MeasurableSet (f i)) :
     iIndepSet f μ ↔ ∀ s, μ (⋂ i ∈ s, f i) = ∏ i ∈ s, μ (f i) := by
-  simp_rw [iIndepSet, kernel.iIndepSet_iff_meas_biInter hf, ae_dirac_eq, Filter.eventually_pure,
-    kernel.const_apply]
+  simp_rw [iIndepSet, Kernel.iIndepSet_iff_meas_biInter hf, ae_dirac_eq, Filter.eventually_pure,
+    Kernel.const_apply]
 
 theorem iIndepSets.iIndepSet_of_mem {π : ι → Set (Set Ω)} {f : ι → Set Ω}
     (hfπ : ∀ i, f i ∈ π i) (hf : ∀ i, MeasurableSet (f i))
     (hπ : iIndepSets π μ) : iIndepSet f μ :=
-  kernel.iIndepSets.iIndepSet_of_mem hfπ hf hπ
+  Kernel.iIndepSets.iIndepSet_of_mem hfπ hf hπ
 
 end IndepSet
 
@@ -530,23 +530,23 @@ theorem indepFun_iff_measure_inter_preimage_eq_mul {mβ : MeasurableSpace β}
     IndepFun f g μ ↔
       ∀ s t, MeasurableSet s → MeasurableSet t
         → μ (f ⁻¹' s ∩ g ⁻¹' t) = μ (f ⁻¹' s) * μ (g ⁻¹' t) := by
-  simp only [IndepFun, kernel.indepFun_iff_measure_inter_preimage_eq_mul, ae_dirac_eq,
-    Filter.eventually_pure, kernel.const_apply]
+  simp only [IndepFun, Kernel.indepFun_iff_measure_inter_preimage_eq_mul, ae_dirac_eq,
+    Filter.eventually_pure, Kernel.const_apply]
 
 theorem iIndepFun_iff_measure_inter_preimage_eq_mul {ι : Type*} {β : ι → Type*}
     (m : ∀ x, MeasurableSpace (β x)) (f : ∀ i, Ω → β i) :
     iIndepFun m f μ ↔
       ∀ (S : Finset ι) {sets : ∀ i : ι, Set (β i)} (_H : ∀ i, i ∈ S → MeasurableSet[m i] (sets i)),
         μ (⋂ i ∈ S, f i ⁻¹' sets i) = ∏ i ∈ S, μ (f i ⁻¹' sets i) := by
-  simp only [iIndepFun, kernel.iIndepFun_iff_measure_inter_preimage_eq_mul, ae_dirac_eq,
-    Filter.eventually_pure, kernel.const_apply]
+  simp only [iIndepFun, Kernel.iIndepFun_iff_measure_inter_preimage_eq_mul, ae_dirac_eq,
+    Filter.eventually_pure, Kernel.const_apply]
 
 theorem indepFun_iff_indepSet_preimage {mβ : MeasurableSpace β} {mβ' : MeasurableSpace β'}
     [IsProbabilityMeasure μ] (hf : Measurable f) (hg : Measurable g) :
     IndepFun f g μ ↔
       ∀ s t, MeasurableSet s → MeasurableSet t → IndepSet (f ⁻¹' s) (g ⁻¹' t) μ := by
-  simp only [IndepFun, IndepSet, kernel.indepFun_iff_indepSet_preimage hf hg, ae_dirac_eq,
-    Filter.eventually_pure, kernel.const_apply]
+  simp only [IndepFun, IndepSet, Kernel.indepFun_iff_indepSet_preimage hf hg, ae_dirac_eq,
+    Filter.eventually_pure, Kernel.const_apply]
 
 theorem indepFun_iff_map_prod_eq_prod_map_map {mβ : MeasurableSpace β} {mβ' : MeasurableSpace β'}
     [IsFiniteMeasure μ] (hf : AEMeasurable f μ) (hg : AEMeasurable g μ) :
@@ -570,15 +570,15 @@ nonrec theorem IndepFun.symm {_ : MeasurableSpace β} {_ : MeasurableSpace β'}
 theorem IndepFun.ae_eq {mβ : MeasurableSpace β} {mβ' : MeasurableSpace β'}
     {f' : Ω → β} {g' : Ω → β'} (hfg : IndepFun f g μ)
     (hf : f =ᵐ[μ] f') (hg : g =ᵐ[μ] g') : IndepFun f' g' μ := by
-  refine kernel.IndepFun.ae_eq hfg ?_ ?_ <;>
-    simp only [ae_dirac_eq, Filter.eventually_pure, kernel.const_apply]
+  refine Kernel.IndepFun.ae_eq hfg ?_ ?_ <;>
+    simp only [ae_dirac_eq, Filter.eventually_pure, Kernel.const_apply]
   exacts [hf, hg]
 
 theorem IndepFun.comp {_mβ : MeasurableSpace β} {_mβ' : MeasurableSpace β'}
     {_mγ : MeasurableSpace γ} {_mγ' : MeasurableSpace γ'} {φ : β → γ} {ψ : β' → γ'}
     (hfg : IndepFun f g μ) (hφ : Measurable φ) (hψ : Measurable ψ) :
     IndepFun (φ ∘ f) (ψ ∘ g) μ :=
-  kernel.IndepFun.comp hfg hφ hψ
+  Kernel.IndepFun.comp hfg hφ hψ
 
 theorem IndepFun.neg_right {_mβ : MeasurableSpace β} {_mβ' : MeasurableSpace β'} [Neg β']
     [MeasurableNeg β'] (hfg : IndepFun f g μ) :
@@ -593,7 +593,7 @@ variable {β : ι → Type*} {m : ∀ i, MeasurableSpace (β i)} {f : ∀ i, Ω 
 
 @[nontriviality]
 lemma iIndepFun.of_subsingleton [IsProbabilityMeasure μ] [Subsingleton ι] : iIndepFun m f μ :=
-  kernel.iIndepFun.of_subsingleton
+  Kernel.iIndepFun.of_subsingleton
 
 lemma iIndepFun.isProbabilityMeasure (h : iIndepFun m f μ) : IsProbabilityMeasure μ :=
   ⟨by simpa using h.meas_biInter (S := ∅) (s := fun _ ↦ univ)⟩
@@ -605,13 +605,13 @@ lemma iIndepFun.indepFun_finset (S T : Finset ι) (hST : Disjoint S T) (hf_Indep
     (hf_meas : ∀ i, Measurable (f i)) :
     IndepFun (fun a (i : S) ↦ f i a) (fun a (i : T) ↦ f i a) μ :=
   have := hf_Indep.isProbabilityMeasure
-  kernel.iIndepFun.indepFun_finset S T hST hf_Indep hf_meas
+  Kernel.iIndepFun.indepFun_finset S T hST hf_Indep hf_meas
 
 lemma iIndepFun.indepFun_prod_mk (hf_Indep : iIndepFun m f μ) (hf_meas : ∀ i, Measurable (f i))
     (i j k : ι) (hik : i ≠ k) (hjk : j ≠ k) :
     IndepFun (fun a => (f i a, f j a)) (f k) μ :=
   have := hf_Indep.isProbabilityMeasure
-  kernel.iIndepFun.indepFun_prod_mk hf_Indep hf_meas i j k hik hjk
+  Kernel.iIndepFun.indepFun_prod_mk hf_Indep hf_meas i j k hik hjk
 
 open Finset in
 lemma iIndepFun.indepFun_prod_mk_prod_mk (h_indep : iIndepFun m f μ) (hf : ∀ i, Measurable (f i))
@@ -633,14 +633,14 @@ lemma iIndepFun.indepFun_mul_left (hf_indep : iIndepFun (fun _ ↦ m) f μ)
     (hf_meas : ∀ i, Measurable (f i)) (i j k : ι) (hik : i ≠ k) (hjk : j ≠ k) :
     IndepFun (f i * f j) (f k) μ :=
   have := hf_indep.isProbabilityMeasure
-  kernel.iIndepFun.indepFun_mul_left hf_indep hf_meas i j k hik hjk
+  Kernel.iIndepFun.indepFun_mul_left hf_indep hf_meas i j k hik hjk
 
 @[to_additive]
 lemma iIndepFun.indepFun_mul_right (hf_indep : iIndepFun (fun _ ↦ m) f μ)
     (hf_meas : ∀ i, Measurable (f i)) (i j k : ι) (hij : i ≠ j) (hik : i ≠ k) :
     IndepFun (f i) (f j * f k) μ :=
   have := hf_indep.isProbabilityMeasure
-  kernel.iIndepFun.indepFun_mul_right hf_indep hf_meas i j k hij hik
+  Kernel.iIndepFun.indepFun_mul_right hf_indep hf_meas i j k hij hik
 
 @[to_additive]
 lemma iIndepFun.indepFun_mul_mul (hf_indep : iIndepFun (fun _ ↦ m) f μ)
@@ -648,7 +648,7 @@ lemma iIndepFun.indepFun_mul_mul (hf_indep : iIndepFun (fun _ ↦ m) f μ)
     (i j k l : ι) (hik : i ≠ k) (hil : i ≠ l) (hjk : j ≠ k) (hjl : j ≠ l) :
     IndepFun (f i * f j) (f k * f l) μ :=
   have := hf_indep.isProbabilityMeasure
-  kernel.iIndepFun.indepFun_mul_mul hf_indep hf_meas i j k l hik hil hjk hjl
+  Kernel.iIndepFun.indepFun_mul_mul hf_indep hf_meas i j k l hik hil hjk hjl
 
 end Mul
 
@@ -660,14 +660,14 @@ lemma iIndepFun.indepFun_div_left (hf_indep : iIndepFun (fun _ ↦ m) f μ)
     (hf_meas : ∀ i, Measurable (f i)) (i j k : ι) (hik : i ≠ k) (hjk : j ≠ k) :
     IndepFun (f i / f j) (f k) μ :=
   have := hf_indep.isProbabilityMeasure
-  kernel.iIndepFun.indepFun_div_left hf_indep hf_meas i j k hik hjk
+  Kernel.iIndepFun.indepFun_div_left hf_indep hf_meas i j k hik hjk
 
 @[to_additive]
 lemma iIndepFun.indepFun_div_right (hf_indep : iIndepFun (fun _ ↦ m) f μ)
     (hf_meas : ∀ i, Measurable (f i)) (i j k : ι) (hij : i ≠ j) (hik : i ≠ k) :
     IndepFun (f i) (f j / f k) μ :=
   have := hf_indep.isProbabilityMeasure
-  kernel.iIndepFun.indepFun_div_right hf_indep hf_meas i j k hij hik
+  Kernel.iIndepFun.indepFun_div_right hf_indep hf_meas i j k hij hik
 
 @[to_additive]
 lemma iIndepFun.indepFun_div_div (hf_indep : iIndepFun (fun _ ↦ m) f μ)
@@ -675,7 +675,7 @@ lemma iIndepFun.indepFun_div_div (hf_indep : iIndepFun (fun _ ↦ m) f μ)
     (i j k l : ι) (hik : i ≠ k) (hil : i ≠ l) (hjk : j ≠ k) (hjl : j ≠ l) :
     IndepFun (f i / f j) (f k / f l) μ :=
   have := hf_indep.isProbabilityMeasure
-  kernel.iIndepFun.indepFun_div_div hf_indep hf_meas i j k l hik hil hjk hjl
+  Kernel.iIndepFun.indepFun_div_div hf_indep hf_meas i j k l hik hil hjk hjl
 
 end Div
 
@@ -687,20 +687,20 @@ lemma iIndepFun.indepFun_finset_prod_of_not_mem (hf_Indep : iIndepFun (fun _ ↦
     (hf_meas : ∀ i, Measurable (f i)) {s : Finset ι} {i : ι} (hi : i ∉ s) :
     IndepFun (∏ j ∈ s, f j) (f i) μ :=
   have := hf_Indep.isProbabilityMeasure
-  kernel.iIndepFun.indepFun_finset_prod_of_not_mem hf_Indep hf_meas hi
+  Kernel.iIndepFun.indepFun_finset_prod_of_not_mem hf_Indep hf_meas hi
 
 @[to_additive]
 lemma iIndepFun.indepFun_prod_range_succ {f : ℕ → Ω → β} (hf_Indep : iIndepFun (fun _ ↦ m) f μ)
     (hf_meas : ∀ i, Measurable (f i)) (n : ℕ) : IndepFun (∏ j ∈ Finset.range n, f j) (f n) μ :=
   have := hf_Indep.isProbabilityMeasure
-  kernel.iIndepFun.indepFun_prod_range_succ hf_Indep hf_meas n
+  Kernel.iIndepFun.indepFun_prod_range_succ hf_Indep hf_meas n
 
 end CommMonoid
 
 theorem iIndepSet.iIndepFun_indicator [Zero β] [One β] {m : MeasurableSpace β} {s : ι → Set Ω}
     (hs : iIndepSet s μ) :
     iIndepFun (fun _n => m) (fun n => (s n).indicator fun _ω => 1) μ :=
-  kernel.iIndepSet.iIndepFun_indicator hs
+  Kernel.iIndepSet.iIndepFun_indicator hs
 
 end IndepFun
 

--- a/Mathlib/Probability/Independence/Conditional.lean
+++ b/Mathlib/Probability/Independence/Conditional.lean
@@ -73,14 +73,14 @@ See `ProbabilityTheory.iCondIndepSets_iff`.
 It will be used for families of pi_systems. -/
 def iCondIndepSets (π : ι → Set (Set Ω)) (μ : Measure Ω := by volume_tac) [IsFiniteMeasure μ] :
     Prop :=
-  kernel.iIndepSets π (condexpKernel μ m') (μ.trim hm')
+  Kernel.iIndepSets π (condexpKernel μ m') (μ.trim hm')
 
 /-- Two sets of sets `s₁, s₂` are conditionally independent given `m'` with respect to a measure
 `μ` if for any sets `t₁ ∈ s₁, t₂ ∈ s₂`, then `μ⟦t₁ ∩ t₂ | m'⟧ =ᵐ[μ] μ⟦t₁ | m'⟧ * μ⟦t₂ | m'⟧`.
 See `ProbabilityTheory.condIndepSets_iff`. -/
 def CondIndepSets (s1 s2 : Set (Set Ω)) (μ : Measure Ω := by volume_tac) [IsFiniteMeasure μ] :
     Prop :=
-  kernel.IndepSets s1 s2 (condexpKernel μ m') (μ.trim hm')
+  Kernel.IndepSets s1 s2 (condexpKernel μ m') (μ.trim hm')
 
 /-- A family of measurable space structures (i.e. of σ-algebras) is conditionally independent given
 `m'` with respect to a measure `μ` (typically defined on a finer σ-algebra) if the family of sets of
@@ -91,7 +91,7 @@ any sets `f i_1 ∈ m i_1, ..., f i_n ∈ m i_n`, then
 See `ProbabilityTheory.iCondIndep_iff`. -/
 def iCondIndep (m : ι → MeasurableSpace Ω)
     (μ : @Measure Ω mΩ := by volume_tac) [IsFiniteMeasure μ] : Prop :=
-  kernel.iIndep m (condexpKernel (mΩ := mΩ) μ m') (μ.trim hm')
+  Kernel.iIndep m (condexpKernel (mΩ := mΩ) μ m') (μ.trim hm')
 
 end
 
@@ -102,7 +102,7 @@ See `ProbabilityTheory.condIndep_iff`. -/
 def CondIndep (m' m₁ m₂ : MeasurableSpace Ω)
     {mΩ : MeasurableSpace Ω} [StandardBorelSpace Ω] [Nonempty Ω]
     (hm' : m' ≤ mΩ) (μ : Measure Ω := by volume_tac) [IsFiniteMeasure μ] : Prop :=
-  kernel.Indep m₁ m₂ (condexpKernel μ m') (μ.trim hm')
+  Kernel.Indep m₁ m₂ (condexpKernel μ m') (μ.trim hm')
 
 section
 
@@ -114,14 +114,14 @@ generate is conditionally independent. For a set `s`, the generated measurable s
 sets `∅, s, sᶜ, univ`.
 See `ProbabilityTheory.iCondIndepSet_iff`. -/
 def iCondIndepSet (s : ι → Set Ω) (μ : Measure Ω := by volume_tac) [IsFiniteMeasure μ] : Prop :=
-  kernel.iIndepSet s (condexpKernel μ m') (μ.trim hm')
+  Kernel.iIndepSet s (condexpKernel μ m') (μ.trim hm')
 
 /-- Two sets are conditionally independent if the two measurable space structures they generate are
 conditionally independent. For a set `s`, the generated measurable space structure has measurable
 sets `∅, s, sᶜ, univ`.
 See `ProbabilityTheory.condIndepSet_iff`. -/
 def CondIndepSet (s t : Set Ω) (μ : Measure Ω := by volume_tac) [IsFiniteMeasure μ] : Prop :=
-  kernel.IndepSet s t (condexpKernel μ m') (μ.trim hm')
+  Kernel.IndepSet s t (condexpKernel μ m') (μ.trim hm')
 
 /-- A family of functions defined on the same space `Ω` and taking values in possibly different
 spaces, each with a measurable space structure, is conditionally independent if the family of
@@ -131,7 +131,7 @@ with codomain having measurable space structure `m`, the generated measurable sp
 See `ProbabilityTheory.iCondIndepFun_iff`. -/
 def iCondIndepFun {β : ι → Type*} (m : ∀ x : ι, MeasurableSpace (β x))
     (f : ∀ x : ι, Ω → β x) (μ : Measure Ω := by volume_tac) [IsFiniteMeasure μ] : Prop :=
-  kernel.iIndepFun m f (condexpKernel μ m') (μ.trim hm')
+  Kernel.iIndepFun m f (condexpKernel μ m') (μ.trim hm')
 
 /-- Two functions are conditionally independent if the two measurable space structures they generate
 are conditionally independent. For a function `f` with codomain having measurable space structure
@@ -139,7 +139,7 @@ are conditionally independent. For a function `f` with codomain having measurabl
 See `ProbabilityTheory.condIndepFun_iff`. -/
 def CondIndepFun {β γ : Type*} [MeasurableSpace β] [MeasurableSpace γ]
     (f : Ω → β) (g : Ω → γ) (μ : Measure Ω := by volume_tac) [IsFiniteMeasure μ] : Prop :=
-  kernel.IndepFun f g (condexpKernel μ m') (μ.trim hm')
+  Kernel.IndepFun f g (condexpKernel μ m') (μ.trim hm')
 
 end
 
@@ -155,7 +155,7 @@ lemma iCondIndepSets_iff (π : ι → Set (Set Ω)) (hπ : ∀ i s (_hs : s ∈ 
     (μ : Measure Ω) [IsFiniteMeasure μ] :
     iCondIndepSets m' hm' π μ ↔ ∀ (s : Finset ι) {f : ι → Set Ω} (_H : ∀ i, i ∈ s → f i ∈ π i),
       μ⟦⋂ i ∈ s, f i | m'⟧ =ᵐ[μ] ∏ i ∈ s, (μ⟦f i | m'⟧) := by
-  simp only [iCondIndepSets, kernel.iIndepSets]
+  simp only [iCondIndepSets, Kernel.iIndepSets]
   have h_eq' : ∀ (s : Finset ι) (f : ι → Set Ω) (_H : ∀ i, i ∈ s → f i ∈ π i) i (_hi : i ∈ s),
       (fun ω ↦ ENNReal.toReal (condexpKernel μ m' ω (f i))) =ᵐ[μ] μ⟦f i | m'⟧ :=
     fun s f H i hi ↦ condexpKernel_ae_eq_condexp hm' (hπ i (f i) (H i hi))
@@ -194,7 +194,7 @@ lemma condIndepSets_iff (s1 s2 : Set (Set Ω)) (hs1 : ∀ s ∈ s1, MeasurableSe
     (hs2 : ∀ s ∈ s2, MeasurableSet s) (μ : Measure Ω) [IsFiniteMeasure μ] :
     CondIndepSets m' hm' s1 s2 μ ↔ ∀ (t1 t2 : Set Ω) (_ : t1 ∈ s1) (_ : t2 ∈ s2),
       (μ⟦t1 ∩ t2 | m'⟧) =ᵐ[μ] (μ⟦t1 | m'⟧) * (μ⟦t2 | m'⟧) := by
-  simp only [CondIndepSets, kernel.IndepSets]
+  simp only [CondIndepSets, Kernel.IndepSets]
   have hs1_eq : ∀ s ∈ s1, (fun ω ↦ ENNReal.toReal (condexpKernel μ m' ω s)) =ᵐ[μ] μ⟦s | m'⟧ :=
     fun s hs ↦ condexpKernel_ae_eq_condexp hm' (hs1 s hs)
   have hs2_eq : ∀ s ∈ s2, (fun ω ↦ ENNReal.toReal (condexpKernel μ m' ω s)) =ᵐ[μ] μ⟦s | m'⟧ :=
@@ -251,7 +251,7 @@ theorem condIndepSets_singleton_iff {μ : Measure Ω} [IsFiniteMeasure μ]
 lemma iCondIndep_iff_iCondIndepSets (m : ι → MeasurableSpace Ω)
     (μ : @Measure Ω mΩ) [IsFiniteMeasure μ] :
     iCondIndep m' hm' m μ ↔ iCondIndepSets m' hm' (fun x ↦ {s | MeasurableSet[m x] s}) μ := by
-  simp only [iCondIndep, iCondIndepSets, kernel.iIndep]
+  simp only [iCondIndep, iCondIndepSets, Kernel.iIndep]
 
 lemma iCondIndep_iff (m : ι → MeasurableSpace Ω) (hm : ∀ i, m i ≤ mΩ)
     (μ : @Measure Ω mΩ) [IsFiniteMeasure μ] :
@@ -270,7 +270,7 @@ lemma condIndep_iff_condIndepSets (m' m₁ m₂ : MeasurableSpace Ω) {mΩ : Mea
     [StandardBorelSpace Ω] [Nonempty Ω] (hm' : m' ≤ mΩ) (μ : Measure Ω ) [IsFiniteMeasure μ] :
     CondIndep m' m₁ m₂ hm' μ
       ↔ CondIndepSets m' hm' {s | MeasurableSet[m₁] s} {s | MeasurableSet[m₂] s} μ := by
-  simp only [CondIndep, CondIndepSets, kernel.Indep]
+  simp only [CondIndep, CondIndepSets, Kernel.Indep]
 
 lemma condIndep_iff (m' m₁ m₂ : MeasurableSpace Ω)
     {mΩ : MeasurableSpace Ω} [StandardBorelSpace Ω] [Nonempty Ω]
@@ -290,12 +290,12 @@ variable (m' : MeasurableSpace Ω) {mΩ : MeasurableSpace Ω} [StandardBorelSpac
 
 lemma iCondIndepSet_iff_iCondIndep (s : ι → Set Ω) (μ : Measure Ω) [IsFiniteMeasure μ] :
     iCondIndepSet m' hm' s μ ↔ iCondIndep m' hm' (fun i ↦ generateFrom {s i}) μ := by
-  simp only [iCondIndepSet, iCondIndep, kernel.iIndepSet]
+  simp only [iCondIndepSet, iCondIndep, Kernel.iIndepSet]
 
 theorem iCondIndepSet_iff_iCondIndepSets_singleton (s : ι → Set Ω) (hs : ∀ i, MeasurableSet (s i))
     (μ : Measure Ω) [IsFiniteMeasure μ] :
     iCondIndepSet m' hm' s μ ↔ iCondIndepSets m' hm' (fun i ↦ {s i}) μ :=
-  kernel.iIndepSet_iff_iIndepSets_singleton hs
+  Kernel.iIndepSet_iff_iIndepSets_singleton hs
 
 lemma iCondIndepSet_iff (s : ι → Set Ω) (hs : ∀ i, MeasurableSet (s i))
     (μ : Measure Ω) [IsFiniteMeasure μ] :
@@ -305,12 +305,12 @@ lemma iCondIndepSet_iff (s : ι → Set Ω) (hs : ∀ i, MeasurableSet (s i))
 
 lemma condIndepSet_iff_condIndep (s t : Set Ω) (μ : Measure Ω) [IsFiniteMeasure μ] :
     CondIndepSet m' hm' s t μ ↔ CondIndep m' (generateFrom {s}) (generateFrom {t}) hm' μ := by
-  simp only [CondIndepSet, CondIndep, kernel.IndepSet]
+  simp only [CondIndepSet, CondIndep, Kernel.IndepSet]
 
 theorem condIndepSet_iff_condIndepSets_singleton {s t : Set Ω} (hs_meas : MeasurableSet s)
     (ht_meas : MeasurableSet t) (μ : Measure Ω) [IsFiniteMeasure μ] :
     CondIndepSet m' hm' s t μ ↔ CondIndepSets m' hm' {s} {t} μ :=
-  kernel.indepSet_iff_indepSets_singleton hs_meas ht_meas _ _
+  Kernel.indepSet_iff_indepSets_singleton hs_meas ht_meas _ _
 
 lemma condIndepSet_iff (s t : Set Ω) (hs : MeasurableSet s) (ht : MeasurableSet t)
     (μ : Measure Ω) [IsFiniteMeasure μ] :
@@ -322,7 +322,7 @@ lemma iCondIndepFun_iff_iCondIndep {β : ι → Type*}
     (μ : Measure Ω) [IsFiniteMeasure μ] :
     iCondIndepFun m' hm' m f μ
       ↔ iCondIndep m' hm' (fun x ↦ MeasurableSpace.comap (f x) (m x)) μ := by
-  simp only [iCondIndepFun, iCondIndep, kernel.iIndepFun]
+  simp only [iCondIndepFun, iCondIndep, Kernel.iIndepFun]
 
 lemma iCondIndepFun_iff {β : ι → Type*}
     (m : ∀ x : ι, MeasurableSpace (β x)) (f : ∀ x : ι, Ω → β x) (hf : ∀ i, Measurable (f i))
@@ -338,7 +338,7 @@ lemma condIndepFun_iff_condIndep {β γ : Type*} [mβ : MeasurableSpace β]
     [mγ : MeasurableSpace γ] (f : Ω → β) (g : Ω → γ) (μ : Measure Ω) [IsFiniteMeasure μ] :
     CondIndepFun m' hm' f g μ
       ↔ CondIndep m' (MeasurableSpace.comap f mβ) (MeasurableSpace.comap g mγ) hm' μ := by
-  simp only [CondIndepFun, CondIndep, kernel.IndepFun]
+  simp only [CondIndepFun, CondIndep, Kernel.IndepFun]
 
 lemma condIndepFun_iff {β γ : Type*} [mβ : MeasurableSpace β] [mγ : MeasurableSpace γ]
     (f : Ω → β) (g : Ω → γ) (hf : Measurable f) (hg : Measurable g)
@@ -358,53 +358,53 @@ variable {m' : MeasurableSpace Ω} {mΩ : MeasurableSpace Ω} [StandardBorelSpac
 @[symm]
 theorem CondIndepSets.symm {s₁ s₂ : Set (Set Ω)}
     (h : CondIndepSets m' hm' s₁ s₂ μ) : CondIndepSets m' hm' s₂ s₁ μ :=
-  kernel.IndepSets.symm h
+  Kernel.IndepSets.symm h
 
 theorem condIndepSets_of_condIndepSets_of_le_left {s₁ s₂ s₃ : Set (Set Ω)}
     (h_indep : CondIndepSets m' hm' s₁ s₂ μ) (h31 : s₃ ⊆ s₁) :
     CondIndepSets m' hm' s₃ s₂ μ :=
-  kernel.indepSets_of_indepSets_of_le_left h_indep h31
+  Kernel.indepSets_of_indepSets_of_le_left h_indep h31
 
 theorem condIndepSets_of_condIndepSets_of_le_right {s₁ s₂ s₃ : Set (Set Ω)}
     (h_indep : CondIndepSets m' hm' s₁ s₂ μ) (h32 : s₃ ⊆ s₂) :
     CondIndepSets m' hm' s₁ s₃ μ :=
-  kernel.indepSets_of_indepSets_of_le_right h_indep h32
+  Kernel.indepSets_of_indepSets_of_le_right h_indep h32
 
 theorem CondIndepSets.union {s₁ s₂ s' : Set (Set Ω)}
     (h₁ : CondIndepSets m' hm' s₁ s' μ) (h₂ : CondIndepSets m' hm' s₂ s' μ) :
     CondIndepSets m' hm' (s₁ ∪ s₂) s' μ :=
-  kernel.IndepSets.union h₁ h₂
+  Kernel.IndepSets.union h₁ h₂
 
 @[simp]
 theorem CondIndepSets.union_iff {s₁ s₂ s' : Set (Set Ω)}  :
     CondIndepSets m' hm' (s₁ ∪ s₂) s' μ
       ↔ CondIndepSets m' hm' s₁ s' μ ∧ CondIndepSets m' hm' s₂ s' μ :=
-  kernel.IndepSets.union_iff
+  Kernel.IndepSets.union_iff
 
 theorem CondIndepSets.iUnion {s : ι → Set (Set Ω)} {s' : Set (Set Ω)}
     (hyp : ∀ n, CondIndepSets m' hm' (s n) s' μ) :
     CondIndepSets m' hm' (⋃ n, s n) s' μ :=
-  kernel.IndepSets.iUnion hyp
+  Kernel.IndepSets.iUnion hyp
 
 theorem CondIndepSets.bUnion {s : ι → Set (Set Ω)} {s' : Set (Set Ω)}
     {u : Set ι} (hyp : ∀ n ∈ u, CondIndepSets m' hm' (s n) s' μ) :
     CondIndepSets m' hm' (⋃ n ∈ u, s n) s' μ :=
-  kernel.IndepSets.bUnion hyp
+  Kernel.IndepSets.bUnion hyp
 
 theorem CondIndepSets.inter {s₁ s' : Set (Set Ω)} (s₂ : Set (Set Ω))
     (h₁ : CondIndepSets m' hm' s₁ s' μ) :
     CondIndepSets m' hm' (s₁ ∩ s₂) s' μ :=
-  kernel.IndepSets.inter s₂ h₁
+  Kernel.IndepSets.inter s₂ h₁
 
 theorem CondIndepSets.iInter {s : ι → Set (Set Ω)} {s' : Set (Set Ω)}
     (h : ∃ n, CondIndepSets m' hm' (s n) s' μ) :
     CondIndepSets m' hm' (⋂ n, s n) s' μ :=
-  kernel.IndepSets.iInter h
+  Kernel.IndepSets.iInter h
 
 theorem CondIndepSets.bInter {s : ι → Set (Set Ω)} {s' : Set (Set Ω)}
     {u : Set ι} (h : ∃ n ∈ u, CondIndepSets m' hm' (s n) s' μ) :
     CondIndepSets m' hm' (⋂ n ∈ u, s n) s' μ :=
-  kernel.IndepSets.bInter h
+  Kernel.IndepSets.bInter h
 
 end CondIndepSets
 
@@ -414,10 +414,10 @@ variable {m' : MeasurableSpace Ω} {mΩ : MeasurableSpace Ω} [StandardBorelSpac
   {hm' : m' ≤ mΩ} {μ : Measure Ω} [IsFiniteMeasure μ]
 
 theorem condIndepSet_empty_right (s : Set Ω) : CondIndepSet m' hm' s ∅ μ :=
-  kernel.indepSet_empty_right s
+  Kernel.indepSet_empty_right s
 
 theorem condIndepSet_empty_left (s : Set Ω) : CondIndepSet m' hm' ∅ s μ :=
-  kernel.indepSet_empty_left s
+  Kernel.indepSet_empty_left s
 
 end CondIndepSet
 
@@ -434,27 +434,27 @@ theorem condIndep_bot_right (m₁ : MeasurableSpace Ω) {m' : MeasurableSpace Ω
     {mΩ : MeasurableSpace Ω} [StandardBorelSpace Ω] [Nonempty Ω]
     {hm' : m' ≤ mΩ} {μ : Measure Ω} [IsFiniteMeasure μ] :
     CondIndep m' m₁ ⊥ hm' μ :=
-  kernel.indep_bot_right m₁
+  Kernel.indep_bot_right m₁
 
 theorem condIndep_bot_left (m₁ : MeasurableSpace Ω) {m' : MeasurableSpace Ω}
     {mΩ : MeasurableSpace Ω} [StandardBorelSpace Ω] [Nonempty Ω]
     {hm' : m' ≤ mΩ} {μ : Measure Ω} [IsFiniteMeasure μ] :
     CondIndep m' ⊥ m₁ hm' μ :=
-  (kernel.indep_bot_right m₁).symm
+  (Kernel.indep_bot_right m₁).symm
 
 theorem condIndep_of_condIndep_of_le_left {m' m₁ m₂ m₃ : MeasurableSpace Ω}
     {mΩ : MeasurableSpace Ω} [StandardBorelSpace Ω] [Nonempty Ω]
     {hm' : m' ≤ mΩ} {μ : Measure Ω} [IsFiniteMeasure μ]
     (h_indep : CondIndep m' m₁ m₂ hm' μ) (h31 : m₃ ≤ m₁) :
     CondIndep m' m₃ m₂ hm' μ :=
-  kernel.indep_of_indep_of_le_left h_indep h31
+  Kernel.indep_of_indep_of_le_left h_indep h31
 
 theorem condIndep_of_condIndep_of_le_right {m' m₁ m₂ m₃ : MeasurableSpace Ω}
     {mΩ : MeasurableSpace Ω} [StandardBorelSpace Ω] [Nonempty Ω]
     {hm' : m' ≤ mΩ} {μ : Measure Ω} [IsFiniteMeasure μ]
     (h_indep : CondIndep m' m₁ m₂ hm' μ) (h32 : m₃ ≤ m₂) :
     CondIndep m' m₁ m₃ hm' μ :=
-  kernel.indep_of_indep_of_le_right h_indep h32
+  Kernel.indep_of_indep_of_le_right h_indep h32
 
 end CondIndep
 
@@ -470,18 +470,18 @@ variable {m' : MeasurableSpace Ω}
 theorem iCondIndepSets.condIndepSets {s : ι → Set (Set Ω)}
     (h_indep : iCondIndepSets m' hm' s μ) {i j : ι} (hij : i ≠ j) :
     CondIndepSets m' hm' (s i) (s j) μ :=
-  kernel.iIndepSets.indepSets h_indep hij
+  Kernel.iIndepSets.indepSets h_indep hij
 
 theorem iCondIndep.condIndep {m : ι → MeasurableSpace Ω}
     (h_indep : iCondIndep m' hm' m μ) {i j : ι} (hij : i ≠ j) :
       CondIndep m' (m i) (m j) hm' μ :=
-  kernel.iIndep.indep h_indep hij
+  Kernel.iIndep.indep h_indep hij
 
 theorem iCondIndepFun.condIndepFun {β : ι → Type*}
     {m : ∀ x, MeasurableSpace (β x)} {f : ∀ i, Ω → β i}
     (hf_Indep : iCondIndepFun m' hm' m f μ) {i j : ι} (hij : i ≠ j) :
     CondIndepFun m' hm' (f i) (f j) μ :=
-  kernel.iIndepFun.indepFun hf_Indep hij
+  Kernel.iIndepFun.indepFun hf_Indep hij
 
 end FromiCondIndepToCondIndep
 
@@ -506,12 +506,12 @@ theorem iCondIndep.iCondIndepSets {m : ι → MeasurableSpace Ω}
     {s : ι → Set (Set Ω)} (hms : ∀ n, m n = generateFrom (s n))
     (h_indep : iCondIndep m' hm' m μ) :
     iCondIndepSets m' hm' s μ :=
-  kernel.iIndep.iIndepSets hms h_indep
+  Kernel.iIndep.iIndepSets hms h_indep
 
 theorem CondIndep.condIndepSets {s1 s2 : Set (Set Ω)}
     (h_indep : CondIndep m' (generateFrom s1) (generateFrom s2) hm' μ) :
     CondIndepSets m' hm' s1 s2 μ :=
-  kernel.Indep.indepSets h_indep
+  Kernel.Indep.indepSets h_indep
 
 end FromMeasurableSpacesToSetsOfSets
 
@@ -529,68 +529,68 @@ theorem CondIndepSets.condIndep
     (hpm1 : m₁ = generateFrom p1) (hpm2 : m₂ = generateFrom p2)
     (hyp : CondIndepSets m' hm' p1 p2 μ) :
     CondIndep m' m₁ m₂ hm' μ :=
-  kernel.IndepSets.indep h1 h2 hp1 hp2 hpm1 hpm2 hyp
+  Kernel.IndepSets.indep h1 h2 hp1 hp2 hpm1 hpm2 hyp
 
 theorem CondIndepSets.condIndep'
     {p1 p2 : Set (Set Ω)} (hp1m : ∀ s ∈ p1, MeasurableSet s) (hp2m : ∀ s ∈ p2, MeasurableSet s)
     (hp1 : IsPiSystem p1) (hp2 : IsPiSystem p2) (hyp : CondIndepSets m' hm' p1 p2 μ) :
     CondIndep m' (generateFrom p1) (generateFrom p2) hm' μ :=
-  kernel.IndepSets.indep' hp1m hp2m hp1 hp2 hyp
+  Kernel.IndepSets.indep' hp1m hp2m hp1 hp2 hyp
 
 theorem condIndepSets_piiUnionInter_of_disjoint {s : ι → Set (Set Ω)}
     {S T : Set ι} (h_indep : iCondIndepSets m' hm' s μ) (hST : Disjoint S T) :
     CondIndepSets m' hm' (piiUnionInter s S) (piiUnionInter s T) μ :=
-  kernel.indepSets_piiUnionInter_of_disjoint h_indep hST
+  Kernel.indepSets_piiUnionInter_of_disjoint h_indep hST
 
 theorem iCondIndepSet.condIndep_generateFrom_of_disjoint {s : ι → Set Ω}
     (hsm : ∀ n, MeasurableSet (s n)) (hs : iCondIndepSet m' hm' s μ) (S T : Set ι)
     (hST : Disjoint S T) :
     CondIndep m' (generateFrom { t | ∃ n ∈ S, s n = t })
       (generateFrom { t | ∃ k ∈ T, s k = t }) hm' μ :=
-  kernel.iIndepSet.indep_generateFrom_of_disjoint hsm hs S T hST
+  Kernel.iIndepSet.indep_generateFrom_of_disjoint hsm hs S T hST
 
 theorem condIndep_iSup_of_disjoint {m : ι → MeasurableSpace Ω}
     (h_le : ∀ i, m i ≤ mΩ) (h_indep : iCondIndep m' hm' m μ) {S T : Set ι} (hST : Disjoint S T) :
     CondIndep m' (⨆ i ∈ S, m i) (⨆ i ∈ T, m i) hm' μ :=
-  kernel.indep_iSup_of_disjoint h_le h_indep hST
+  Kernel.indep_iSup_of_disjoint h_le h_indep hST
 
 theorem condIndep_iSup_of_directed_le {m : ι → MeasurableSpace Ω}
     (h_indep : ∀ i, CondIndep m' (m i) m₁ hm' μ)
     (h_le : ∀ i, m i ≤ mΩ) (h_le' : m₁ ≤ mΩ) (hm : Directed (· ≤ ·) m) :
     CondIndep m' (⨆ i, m i) m₁ hm' μ :=
-  kernel.indep_iSup_of_directed_le h_indep h_le h_le' hm
+  Kernel.indep_iSup_of_directed_le h_indep h_le h_le' hm
 
 theorem iCondIndepSet.condIndep_generateFrom_lt [Preorder ι] {s : ι → Set Ω}
     (hsm : ∀ n, MeasurableSet (s n)) (hs : iCondIndepSet m' hm' s μ) (i : ι) :
     CondIndep m' (generateFrom {s i}) (generateFrom { t | ∃ j < i, s j = t }) hm' μ :=
-  kernel.iIndepSet.indep_generateFrom_lt hsm hs i
+  Kernel.iIndepSet.indep_generateFrom_lt hsm hs i
 
 theorem iCondIndepSet.condIndep_generateFrom_le [LinearOrder ι] {s : ι → Set Ω}
     (hsm : ∀ n, MeasurableSet (s n)) (hs : iCondIndepSet m' hm' s μ) (i : ι) {k : ι} (hk : i < k) :
     CondIndep m' (generateFrom {s k}) (generateFrom { t | ∃ j ≤ i, s j = t }) hm' μ :=
-  kernel.iIndepSet.indep_generateFrom_le hsm hs i hk
+  Kernel.iIndepSet.indep_generateFrom_le hsm hs i hk
 
 theorem iCondIndepSet.condIndep_generateFrom_le_nat {s : ℕ → Set Ω}
     (hsm : ∀ n, MeasurableSet (s n)) (hs : iCondIndepSet m' hm' s μ) (n : ℕ) :
     CondIndep m' (generateFrom {s (n + 1)}) (generateFrom { t | ∃ k ≤ n, s k = t }) hm' μ :=
-  kernel.iIndepSet.indep_generateFrom_le_nat hsm hs n
+  Kernel.iIndepSet.indep_generateFrom_le_nat hsm hs n
 
 theorem condIndep_iSup_of_monotone [SemilatticeSup ι] {m : ι → MeasurableSpace Ω}
     (h_indep : ∀ i, CondIndep m' (m i) m₁ hm' μ) (h_le : ∀ i, m i ≤ mΩ) (h_le' : m₁ ≤ mΩ)
     (hm : Monotone m) :
     CondIndep m' (⨆ i, m i) m₁ hm' μ :=
-  kernel.indep_iSup_of_monotone h_indep h_le h_le' hm
+  Kernel.indep_iSup_of_monotone h_indep h_le h_le' hm
 
 theorem condIndep_iSup_of_antitone [SemilatticeInf ι] {m : ι → MeasurableSpace Ω}
     (h_indep : ∀ i, CondIndep m' (m i) m₁ hm' μ) (h_le : ∀ i, m i ≤ mΩ) (h_le' : m₁ ≤ mΩ)
     (hm : Antitone m) :
     CondIndep m' (⨆ i, m i) m₁ hm' μ :=
-  kernel.indep_iSup_of_antitone h_indep h_le h_le' hm
+  Kernel.indep_iSup_of_antitone h_indep h_le h_le' hm
 
 theorem iCondIndepSets.piiUnionInter_of_not_mem {π : ι → Set (Set Ω)} {a : ι} {S : Finset ι}
     (hp_ind : iCondIndepSets m' hm' π μ) (haS : a ∉ S) :
     CondIndepSets m' hm' (piiUnionInter π S) (π a) μ :=
-  kernel.iIndepSets.piiUnionInter_of_not_mem hp_ind haS
+  Kernel.iIndepSets.piiUnionInter_of_not_mem hp_ind haS
 
 /-- The σ-algebras generated by conditionally independent pi-systems are conditionally independent.
 -/
@@ -598,7 +598,7 @@ theorem iCondIndepSets.iCondIndep (m : ι → MeasurableSpace Ω)
     (h_le : ∀ i, m i ≤ mΩ) (π : ι → Set (Set Ω)) (h_pi : ∀ n, IsPiSystem (π n))
     (h_generate : ∀ i, m i = generateFrom (π i)) (h_ind : iCondIndepSets m' hm' π μ) :
     iCondIndep m' hm' m μ :=
-  kernel.iIndepSets.iIndep m h_le π h_pi h_generate h_ind
+  Kernel.iIndepSets.iIndep m h_le π h_pi h_generate h_ind
 
 end FromPiSystemsToMeasurableSpaces
 
@@ -616,18 +616,18 @@ theorem CondIndepSets.condIndepSet_of_mem (hs : s ∈ S) (ht : t ∈ T)
     (hs_meas : MeasurableSet s) (ht_meas : MeasurableSet t) (μ : Measure Ω) [IsFiniteMeasure μ]
     (h_indep : CondIndepSets m' hm' S T μ) :
     CondIndepSet m' hm' s t μ :=
-  kernel.IndepSets.indepSet_of_mem _ _ hs ht hs_meas ht_meas _ _ h_indep
+  Kernel.IndepSets.indepSet_of_mem _ _ hs ht hs_meas ht_meas _ _ h_indep
 
 theorem CondIndep.condIndepSet_of_measurableSet {μ : Measure Ω} [IsFiniteMeasure μ]
     (h_indep : CondIndep m' m₁ m₂ hm' μ) {s t : Set Ω} (hs : MeasurableSet[m₁] s)
     (ht : MeasurableSet[m₂] t) :
     CondIndepSet m' hm' s t μ :=
-  kernel.Indep.indepSet_of_measurableSet h_indep hs ht
+  Kernel.Indep.indepSet_of_measurableSet h_indep hs ht
 
 theorem condIndep_iff_forall_condIndepSet (μ : Measure Ω) [IsFiniteMeasure μ] :
     CondIndep m' m₁ m₂ hm' μ ↔ ∀ s t, MeasurableSet[m₁] s → MeasurableSet[m₂] t
       → CondIndepSet m' hm' s t μ :=
-  kernel.indep_iff_forall_indepSet m₁ m₂ _ _
+  Kernel.indep_iff_forall_indepSet m₁ m₂ _ _
 
 end CondIndepSet
 
@@ -679,7 +679,7 @@ theorem condIndepFun_iff_condIndepSet_preimage {mβ : MeasurableSpace β} {mβ' 
     (hf : Measurable f) (hg : Measurable g) :
     CondIndepFun m' hm' f g μ ↔
       ∀ s t, MeasurableSet s → MeasurableSet t → CondIndepSet m' hm' (f ⁻¹' s) (g ⁻¹' t) μ := by
-  simp only [CondIndepFun, CondIndepSet, kernel.indepFun_iff_indepSet_preimage hf hg]
+  simp only [CondIndepFun, CondIndepSet, Kernel.indepFun_iff_indepSet_preimage hf hg]
 
 @[symm]
 nonrec theorem CondIndepFun.symm {_ : MeasurableSpace β} {f g : Ω → β}
@@ -691,7 +691,7 @@ theorem CondIndepFun.comp {γ γ' : Type*} {_mβ : MeasurableSpace β} {_mβ' : 
     {_mγ : MeasurableSpace γ} {_mγ' : MeasurableSpace γ'} {φ : β → γ} {ψ : β' → γ'}
     (hfg : CondIndepFun m' hm' f g μ) (hφ : Measurable φ) (hψ : Measurable ψ) :
     CondIndepFun m' hm' (φ ∘ f) (ψ ∘ g) μ :=
-  kernel.IndepFun.comp hfg hφ hψ
+  Kernel.IndepFun.comp hfg hφ hψ
 
 theorem CondIndepFun.neg_right {_mβ : MeasurableSpace β} {_mβ' : MeasurableSpace β'} [Neg β']
     [MeasurableNeg β'] (hfg : CondIndepFun m' hm' f g μ)  :
@@ -706,7 +706,7 @@ variable {β : ι → Type*} {m : ∀ i, MeasurableSpace (β i)} {f : ∀ i, Ω 
 
 @[nontriviality]
 lemma iCondIndepFun.of_subsingleton [Subsingleton ι] : iCondIndepFun m' hm' m f μ :=
-  kernel.iIndepFun.of_subsingleton
+  Kernel.iIndepFun.of_subsingleton
 
 /-- If `f` is a family of mutually conditionally independent random variables
 (`iCondIndepFun m' hm' m f μ`) and `S, T` are two disjoint finite index sets, then the tuple formed
@@ -715,13 +715,13 @@ theorem iCondIndepFun.condIndepFun_finset {β : ι → Type*}
     {m : ∀ i, MeasurableSpace (β i)} {f : ∀ i, Ω → β i} (S T : Finset ι) (hST : Disjoint S T)
     (hf_Indep : iCondIndepFun m' hm' m f μ) (hf_meas : ∀ i, Measurable (f i)) :
     CondIndepFun m' hm' (fun a (i : S) => f i a) (fun a (i : T) => f i a) μ :=
-  kernel.iIndepFun.indepFun_finset S T hST hf_Indep hf_meas
+  Kernel.iIndepFun.indepFun_finset S T hST hf_Indep hf_meas
 
 theorem iCondIndepFun.condIndepFun_prod_mk {β : ι → Type*}
     {m : ∀ i, MeasurableSpace (β i)} {f : ∀ i, Ω → β i} (hf_Indep : iCondIndepFun m' hm' m f μ)
     (hf_meas : ∀ i, Measurable (f i)) (i j k : ι) (hik : i ≠ k) (hjk : j ≠ k) :
     CondIndepFun m' hm' (fun a => (f i a, f j a)) (f k) μ :=
-  kernel.iIndepFun.indepFun_prod_mk hf_Indep hf_meas i j k hik hjk
+  Kernel.iIndepFun.indepFun_prod_mk hf_Indep hf_meas i j k hik hjk
 
 open Finset in
 lemma iCondIndepFun.condIndepFun_prod_mk_prod_mk (h_indep : iCondIndepFun m' hm' m f μ)
@@ -743,20 +743,20 @@ variable {β : Type*} {m : MeasurableSpace β} [Mul β] [MeasurableMul₂ β] {f
 lemma iCondIndepFun.indepFun_mul_left (hf_indep : iCondIndepFun m' hm' (fun _ ↦ m) f μ)
     (hf_meas : ∀ i, Measurable (f i)) (i j k : ι) (hik : i ≠ k) (hjk : j ≠ k) :
     CondIndepFun m' hm' (f i * f j) (f k) μ :=
-  kernel.iIndepFun.indepFun_mul_left hf_indep hf_meas i j k hik hjk
+  Kernel.iIndepFun.indepFun_mul_left hf_indep hf_meas i j k hik hjk
 
 @[to_additive]
 lemma iCondIndepFun.indepFun_mul_right (hf_indep : iCondIndepFun m' hm' (fun _ ↦ m) f μ)
     (hf_meas : ∀ i, Measurable (f i)) (i j k : ι) (hij : i ≠ j) (hik : i ≠ k) :
     CondIndepFun m' hm' (f i) (f j * f k) μ :=
-  kernel.iIndepFun.indepFun_mul_right hf_indep hf_meas i j k hij hik
+  Kernel.iIndepFun.indepFun_mul_right hf_indep hf_meas i j k hij hik
 
 @[to_additive]
 lemma iCondIndepFun.indepFun_mul_mul (hf_indep : iCondIndepFun m' hm' (fun _ ↦ m) f μ)
     (hf_meas : ∀ i, Measurable (f i))
     (i j k l : ι) (hik : i ≠ k) (hil : i ≠ l) (hjk : j ≠ k) (hjl : j ≠ l) :
     CondIndepFun m' hm' (f i * f j) (f k * f l) μ :=
-  kernel.iIndepFun.indepFun_mul_mul hf_indep hf_meas i j k l hik hil hjk hjl
+  Kernel.iIndepFun.indepFun_mul_mul hf_indep hf_meas i j k l hik hil hjk hjl
 
 end Mul
 
@@ -767,20 +767,20 @@ variable {β : Type*} {m : MeasurableSpace β} [Div β] [MeasurableDiv₂ β] {f
 lemma iCondIndepFun.indepFun_div_left (hf_indep : iCondIndepFun m' hm' (fun _ ↦ m) f μ)
     (hf_meas : ∀ i, Measurable (f i)) (i j k : ι) (hik : i ≠ k) (hjk : j ≠ k) :
     CondIndepFun m' hm' (f i / f j) (f k) μ :=
-  kernel.iIndepFun.indepFun_div_left hf_indep hf_meas i j k hik hjk
+  Kernel.iIndepFun.indepFun_div_left hf_indep hf_meas i j k hik hjk
 
 @[to_additive]
 lemma iCondIndepFun.indepFun_div_right (hf_indep : iCondIndepFun m' hm' (fun _ ↦ m) f μ)
     (hf_meas : ∀ i, Measurable (f i)) (i j k : ι) (hij : i ≠ j) (hik : i ≠ k) :
     CondIndepFun m' hm' (f i) (f j / f k) μ :=
-  kernel.iIndepFun.indepFun_div_right hf_indep hf_meas i j k hij hik
+  Kernel.iIndepFun.indepFun_div_right hf_indep hf_meas i j k hij hik
 
 @[to_additive]
 lemma iCondIndepFun.indepFun_div_div (hf_indep : iCondIndepFun m' hm' (fun _ ↦ m) f μ)
     (hf_meas : ∀ i, Measurable (f i))
     (i j k l : ι) (hik : i ≠ k) (hil : i ≠ l) (hjk : j ≠ k) (hjl : j ≠ l) :
     CondIndepFun m' hm' (f i / f j) (f k / f l) μ :=
-  kernel.iIndepFun.indepFun_div_div hf_indep hf_meas i j k l hik hil hjk hjl
+  Kernel.iIndepFun.indepFun_div_div hf_indep hf_meas i j k l hik hil hjk hjl
 
 end Div
 
@@ -792,20 +792,20 @@ theorem iCondIndepFun.condIndepFun_finset_prod_of_not_mem
     (hf_Indep : iCondIndepFun m' hm' (fun _ => m) f μ) (hf_meas : ∀ i, Measurable (f i))
     {s : Finset ι} {i : ι} (hi : i ∉ s) :
     CondIndepFun m' hm' (∏ j ∈ s, f j) (f i) μ :=
-  kernel.iIndepFun.indepFun_finset_prod_of_not_mem hf_Indep hf_meas hi
+  Kernel.iIndepFun.indepFun_finset_prod_of_not_mem hf_Indep hf_meas hi
 
 @[to_additive]
 theorem iCondIndepFun.condIndepFun_prod_range_succ {f : ℕ → Ω → β}
     (hf_Indep : iCondIndepFun m' hm' (fun _ => m) f μ) (hf_meas : ∀ i, Measurable (f i)) (n : ℕ) :
     CondIndepFun m' hm' (∏ j ∈ Finset.range n, f j) (f n) μ :=
-  kernel.iIndepFun.indepFun_prod_range_succ hf_Indep hf_meas n
+  Kernel.iIndepFun.indepFun_prod_range_succ hf_Indep hf_meas n
 
 end CommMonoid
 
 theorem iCondIndepSet.iCondIndepFun_indicator [Zero β] [One β] {m : MeasurableSpace β}
     {s : ι → Set Ω} (hs : iCondIndepSet m' hm' s μ) :
     iCondIndepFun m' hm' (fun _n => m) (fun n => (s n).indicator fun _ω => 1) μ :=
-  kernel.iIndepSet.iIndepFun_indicator hs
+  Kernel.iIndepSet.iIndepFun_indicator hs
 
 end CondIndepFun
 

--- a/Mathlib/Probability/Independence/Kernel.lean
+++ b/Mathlib/Probability/Independence/Kernel.lean
@@ -10,13 +10,13 @@ import Mathlib.Probability.Kernel.Basic
 # Independence with respect to a kernel and a measure
 
 A family of sets of sets `π : ι → Set (Set Ω)` is independent with respect to a kernel
-`κ : kernel α Ω` and a measure `μ` on `α` if for any finite set of indices `s = {i_1, ..., i_n}`,
+`κ : Kernel α Ω` and a measure `μ` on `α` if for any finite set of indices `s = {i_1, ..., i_n}`,
 for any sets `f i_1 ∈ π i_1, ..., f i_n ∈ π i_n`, then for `μ`-almost every `a : α`,
 `κ a (⋂ i in s, f i) = ∏ i ∈ s, κ a (f i)`.
 
 This notion of independence is a generalization of both independence and conditional independence.
 For conditional independence, `κ` is the conditional kernel `ProbabilityTheory.condexpKernel` and
-`μ` is the ambiant measure. For (non-conditional) independence, `κ = kernel.const Unit μ` and the
+`μ` is the ambiant measure. For (non-conditional) independence, `κ = Kernel.const Unit μ` and the
 measure is the Dirac measure on `Unit`.
 
 The main purpose of this file is to prove only once the properties that hold for both conditional
@@ -24,30 +24,30 @@ and non-conditional independence.
 
 ## Main definitions
 
-* `ProbabilityTheory.kernel.iIndepSets`: independence of a family of sets of sets.
-  Variant for two sets of sets: `ProbabilityTheory.kernel.IndepSets`.
-* `ProbabilityTheory.kernel.iIndep`: independence of a family of σ-algebras. Variant for two
+* `ProbabilityTheory.Kernel.iIndepSets`: independence of a family of sets of sets.
+  Variant for two sets of sets: `ProbabilityTheory.Kernel.IndepSets`.
+* `ProbabilityTheory.Kernel.iIndep`: independence of a family of σ-algebras. Variant for two
   σ-algebras: `Indep`.
-* `ProbabilityTheory.kernel.iIndepSet`: independence of a family of sets. Variant for two sets:
-  `ProbabilityTheory.kernel.IndepSet`.
-* `ProbabilityTheory.kernel.iIndepFun`: independence of a family of functions (random variables).
-  Variant for two functions: `ProbabilityTheory.kernel.IndepFun`.
+* `ProbabilityTheory.Kernel.iIndepSet`: independence of a family of sets. Variant for two sets:
+  `ProbabilityTheory.Kernel.IndepSet`.
+* `ProbabilityTheory.Kernel.iIndepFun`: independence of a family of functions (random variables).
+  Variant for two functions: `ProbabilityTheory.Kernel.IndepFun`.
 
 See the file `Mathlib/Probability/Kernel/Basic.lean` for a more detailed discussion of these
 definitions in the particular case of the usual independence notion.
 
 ## Main statements
 
-* `ProbabilityTheory.kernel.iIndepSets.iIndep`: if π-systems are independent as sets of sets,
+* `ProbabilityTheory.Kernel.iIndepSets.iIndep`: if π-systems are independent as sets of sets,
   then the measurable space structures they generate are independent.
-* `ProbabilityTheory.kernel.IndepSets.Indep`: variant with two π-systems.
+* `ProbabilityTheory.Kernel.IndepSets.Indep`: variant with two π-systems.
 -/
 
 open MeasureTheory MeasurableSpace
 
 open scoped MeasureTheory ENNReal
 
-namespace ProbabilityTheory.kernel
+namespace ProbabilityTheory.Kernel
 
 variable {α Ω ι : Type*}
 
@@ -60,38 +60,38 @@ a measure `μ` if for any finite set of indices `s = {i_1, ..., i_n}`, for any s
 `f i_1 ∈ π i_1, ..., f i_n ∈ π i_n`, then `∀ᵐ a ∂μ, κ a (⋂ i in s, f i) = ∏ i ∈ s, κ a (f i)`.
 It will be used for families of pi_systems. -/
 def iIndepSets {_mΩ : MeasurableSpace Ω}
-    (π : ι → Set (Set Ω)) (κ : kernel α Ω) (μ : Measure α := by volume_tac) : Prop :=
+    (π : ι → Set (Set Ω)) (κ : Kernel α Ω) (μ : Measure α := by volume_tac) : Prop :=
   ∀ (s : Finset ι) {f : ι → Set Ω} (_H : ∀ i, i ∈ s → f i ∈ π i),
   ∀ᵐ a ∂μ, κ a (⋂ i ∈ s, f i) = ∏ i ∈ s, κ a (f i)
 
 /-- Two sets of sets `s₁, s₂` are independent with respect to a kernel `κ` and a measure `μ` if for
 any sets `t₁ ∈ s₁, t₂ ∈ s₂`, then `∀ᵐ a ∂μ, κ a (t₁ ∩ t₂) = κ a (t₁) * κ a (t₂)` -/
 def IndepSets {_mΩ : MeasurableSpace Ω}
-    (s1 s2 : Set (Set Ω)) (κ : kernel α Ω) (μ : Measure α := by volume_tac) : Prop :=
+    (s1 s2 : Set (Set Ω)) (κ : Kernel α Ω) (μ : Measure α := by volume_tac) : Prop :=
   ∀ t1 t2 : Set Ω, t1 ∈ s1 → t2 ∈ s2 → (∀ᵐ a ∂μ, κ a (t1 ∩ t2) = κ a t1 * κ a t2)
 
 /-- A family of measurable space structures (i.e. of σ-algebras) is independent with respect to a
 kernel `κ` and a measure `μ` if the family of sets of measurable sets they define is independent. -/
-def iIndep (m : ι → MeasurableSpace Ω) {_mΩ : MeasurableSpace Ω} (κ : kernel α Ω)
+def iIndep (m : ι → MeasurableSpace Ω) {_mΩ : MeasurableSpace Ω} (κ : Kernel α Ω)
     (μ : Measure α := by volume_tac) : Prop :=
   iIndepSets (fun x ↦ {s | MeasurableSet[m x] s}) κ μ
 
 /-- Two measurable space structures (or σ-algebras) `m₁, m₂` are independent with respect to a
 kernel `κ` and a measure `μ` if for any sets `t₁ ∈ m₁, t₂ ∈ m₂`,
 `∀ᵐ a ∂μ, κ a (t₁ ∩ t₂) = κ a (t₁) * κ a (t₂)` -/
-def Indep (m₁ m₂ : MeasurableSpace Ω) {_mΩ : MeasurableSpace Ω} (κ : kernel α Ω)
+def Indep (m₁ m₂ : MeasurableSpace Ω) {_mΩ : MeasurableSpace Ω} (κ : Kernel α Ω)
     (μ : Measure α := by volume_tac) : Prop :=
   IndepSets {s | MeasurableSet[m₁] s} {s | MeasurableSet[m₂] s} κ μ
 
 /-- A family of sets is independent if the family of measurable space structures they generate is
 independent. For a set `s`, the generated measurable space has measurable sets `∅, s, sᶜ, univ`. -/
-def iIndepSet {_mΩ : MeasurableSpace Ω} (s : ι → Set Ω) (κ : kernel α Ω)
+def iIndepSet {_mΩ : MeasurableSpace Ω} (s : ι → Set Ω) (κ : Kernel α Ω)
     (μ : Measure α := by volume_tac) : Prop :=
   iIndep (fun i ↦ generateFrom {s i}) κ μ
 
 /-- Two sets are independent if the two measurable space structures they generate are independent.
 For a set `s`, the generated measurable space structure has measurable sets `∅, s, sᶜ, univ`. -/
-def IndepSet {_mΩ : MeasurableSpace Ω} (s t : Set Ω) (κ : kernel α Ω)
+def IndepSet {_mΩ : MeasurableSpace Ω} (s t : Set Ω) (κ : Kernel α Ω)
     (μ : Measure α := by volume_tac) : Prop :=
   Indep (generateFrom {s}) (generateFrom {t}) κ μ
 
@@ -100,7 +100,7 @@ spaces, each with a measurable space structure, is independent if the family of 
 structures they generate on `Ω` is independent. For a function `g` with codomain having measurable
 space structure `m`, the generated measurable space structure is `MeasurableSpace.comap g m`. -/
 def iIndepFun {_mΩ : MeasurableSpace Ω} {β : ι → Type*} (m : ∀ x : ι, MeasurableSpace (β x))
-    (f : ∀ x : ι, Ω → β x) (κ : kernel α Ω)
+    (f : ∀ x : ι, Ω → β x) (κ : Kernel α Ω)
     (μ : Measure α := by volume_tac) : Prop :=
   iIndep (fun x ↦ MeasurableSpace.comap (f x) (m x)) κ μ
 
@@ -108,7 +108,7 @@ def iIndepFun {_mΩ : MeasurableSpace Ω} {β : ι → Type*} (m : ∀ x : ι, M
 independent. For a function `f` with codomain having measurable space structure `m`, the generated
 measurable space structure is `MeasurableSpace.comap f m`. -/
 def IndepFun {β γ} {_mΩ : MeasurableSpace Ω} [mβ : MeasurableSpace β] [mγ : MeasurableSpace γ]
-    (f : Ω → β) (g : Ω → γ) (κ : kernel α Ω)
+    (f : Ω → β) (g : Ω → γ) (κ : Kernel α Ω)
     (μ : Measure α := by volume_tac) : Prop :=
   Indep (MeasurableSpace.comap f mβ) (MeasurableSpace.comap g mγ) κ μ
 
@@ -118,7 +118,7 @@ section ByDefinition
 
 variable {β : ι → Type*} {mβ : ∀ i, MeasurableSpace (β i)}
   {_mα : MeasurableSpace α} {m : ι → MeasurableSpace Ω} {_mΩ : MeasurableSpace Ω}
-  {κ : kernel α Ω} {μ : Measure α}
+  {κ : Kernel α Ω} {μ : Measure α}
   {π : ι → Set (Set Ω)} {s : ι → Set Ω} {S : Finset ι} {f : ∀ x : ι, Ω → β x}
 
 lemma iIndepSets.meas_biInter (h : iIndepSets π κ μ) (s : Finset ι)
@@ -163,7 +163,7 @@ section Indep
 variable {_mα : MeasurableSpace α}
 
 @[symm]
-theorem IndepSets.symm {_mΩ : MeasurableSpace Ω} {κ : kernel α Ω} {μ : Measure α}
+theorem IndepSets.symm {_mΩ : MeasurableSpace Ω} {κ : Kernel α Ω} {μ : Measure α}
     {s₁ s₂ : Set (Set Ω)} (h : IndepSets s₁ s₂ κ μ) :
     IndepSets s₂ s₁ κ μ := by
   intros t1 t2 ht1 ht2
@@ -171,13 +171,13 @@ theorem IndepSets.symm {_mΩ : MeasurableSpace Ω} {κ : kernel α Ω} {μ : Mea
   rwa [Set.inter_comm, mul_comm]
 
 @[symm]
-theorem Indep.symm {m₁ m₂ : MeasurableSpace Ω} {_mΩ : MeasurableSpace Ω} {κ : kernel α Ω}
+theorem Indep.symm {m₁ m₂ : MeasurableSpace Ω} {_mΩ : MeasurableSpace Ω} {κ : Kernel α Ω}
     {μ : Measure α} (h : Indep m₁ m₂ κ μ) :
     Indep m₂ m₁ κ μ :=
   IndepSets.symm h
 
 theorem indep_bot_right (m' : MeasurableSpace Ω) {_mΩ : MeasurableSpace Ω}
-    {κ : kernel α Ω} {μ : Measure α} [IsMarkovKernel κ] :
+    {κ : Kernel α Ω} {μ : Measure α} [IsMarkovKernel κ] :
     Indep m' ⊥ κ μ := by
   intros s t _ ht
   rw [Set.mem_setOf_eq, MeasurableSpace.measurableSet_bot_iff] at ht
@@ -187,42 +187,42 @@ theorem indep_bot_right (m' : MeasurableSpace Ω) {_mΩ : MeasurableSpace Ω}
   · rw [ht, Set.inter_univ, measure_univ, mul_one]
 
 theorem indep_bot_left (m' : MeasurableSpace Ω) {_mΩ : MeasurableSpace Ω}
-    {κ : kernel α Ω} {μ : Measure α} [IsMarkovKernel κ] :
+    {κ : Kernel α Ω} {μ : Measure α} [IsMarkovKernel κ] :
     Indep ⊥ m' κ μ := (indep_bot_right m').symm
 
 theorem indepSet_empty_right {_mΩ : MeasurableSpace Ω}
-    {κ : kernel α Ω} {μ : Measure α} [IsMarkovKernel κ] (s : Set Ω) :
+    {κ : Kernel α Ω} {μ : Measure α} [IsMarkovKernel κ] (s : Set Ω) :
     IndepSet s ∅ κ μ := by
   simp only [IndepSet, generateFrom_singleton_empty]
   exact indep_bot_right _
 
-theorem indepSet_empty_left {_mΩ : MeasurableSpace Ω} {κ : kernel α Ω}
+theorem indepSet_empty_left {_mΩ : MeasurableSpace Ω} {κ : Kernel α Ω}
     {μ : Measure α} [IsMarkovKernel κ] (s : Set Ω) :
     IndepSet ∅ s κ μ :=
   (indepSet_empty_right s).symm
 
 theorem indepSets_of_indepSets_of_le_left {s₁ s₂ s₃ : Set (Set Ω)} {_mΩ : MeasurableSpace Ω}
-    {κ : kernel α Ω} {μ : Measure α} (h_indep : IndepSets s₁ s₂ κ μ) (h31 : s₃ ⊆ s₁) :
+    {κ : Kernel α Ω} {μ : Measure α} (h_indep : IndepSets s₁ s₂ κ μ) (h31 : s₃ ⊆ s₁) :
     IndepSets s₃ s₂ κ μ :=
   fun t1 t2 ht1 ht2 => h_indep t1 t2 (Set.mem_of_subset_of_mem h31 ht1) ht2
 
 theorem indepSets_of_indepSets_of_le_right {s₁ s₂ s₃ : Set (Set Ω)} {_mΩ : MeasurableSpace Ω}
-    {κ : kernel α Ω} {μ : Measure α} (h_indep : IndepSets s₁ s₂ κ μ) (h32 : s₃ ⊆ s₂) :
+    {κ : Kernel α Ω} {μ : Measure α} (h_indep : IndepSets s₁ s₂ κ μ) (h32 : s₃ ⊆ s₂) :
     IndepSets s₁ s₃ κ μ :=
   fun t1 t2 ht1 ht2 => h_indep t1 t2 ht1 (Set.mem_of_subset_of_mem h32 ht2)
 
 theorem indep_of_indep_of_le_left {m₁ m₂ m₃ : MeasurableSpace Ω} {_mΩ : MeasurableSpace Ω}
-    {κ : kernel α Ω} {μ : Measure α} (h_indep : Indep m₁ m₂ κ μ) (h31 : m₃ ≤ m₁) :
+    {κ : Kernel α Ω} {μ : Measure α} (h_indep : Indep m₁ m₂ κ μ) (h31 : m₃ ≤ m₁) :
     Indep m₃ m₂ κ μ :=
   fun t1 t2 ht1 ht2 => h_indep t1 t2 (h31 _ ht1) ht2
 
 theorem indep_of_indep_of_le_right {m₁ m₂ m₃ : MeasurableSpace Ω} {_mΩ : MeasurableSpace Ω}
-    {κ : kernel α Ω} {μ : Measure α} (h_indep : Indep m₁ m₂ κ μ) (h32 : m₃ ≤ m₂) :
+    {κ : Kernel α Ω} {μ : Measure α} (h_indep : Indep m₁ m₂ κ μ) (h32 : m₃ ≤ m₂) :
     Indep m₁ m₃ κ μ :=
   fun t1 t2 ht1 ht2 => h_indep t1 t2 ht1 (h32 _ ht2)
 
 theorem IndepSets.union {s₁ s₂ s' : Set (Set Ω)} {_mΩ : MeasurableSpace Ω}
-    {κ : kernel α Ω} {μ : Measure α}
+    {κ : Kernel α Ω} {μ : Measure α}
     (h₁ : IndepSets s₁ s' κ μ) (h₂ : IndepSets s₂ s' κ μ) :
     IndepSets (s₁ ∪ s₂) s' κ μ := by
   intro t1 t2 ht1 ht2
@@ -232,7 +232,7 @@ theorem IndepSets.union {s₁ s₂ s' : Set (Set Ω)} {_mΩ : MeasurableSpace Ω
 
 @[simp]
 theorem IndepSets.union_iff {s₁ s₂ s' : Set (Set Ω)} {_mΩ : MeasurableSpace Ω}
-    {κ : kernel α Ω} {μ : Measure α} :
+    {κ : Kernel α Ω} {μ : Measure α} :
     IndepSets (s₁ ∪ s₂) s' κ μ ↔ IndepSets s₁ s' κ μ ∧ IndepSets s₂ s' κ μ :=
   ⟨fun h =>
     ⟨indepSets_of_indepSets_of_le_left h Set.subset_union_left,
@@ -240,7 +240,7 @@ theorem IndepSets.union_iff {s₁ s₂ s' : Set (Set Ω)} {_mΩ : MeasurableSpac
     fun h => IndepSets.union h.left h.right⟩
 
 theorem IndepSets.iUnion {s : ι → Set (Set Ω)} {s' : Set (Set Ω)} {_mΩ : MeasurableSpace Ω}
-    {κ : kernel α Ω} {μ : Measure α} (hyp : ∀ n, IndepSets (s n) s' κ μ) :
+    {κ : Kernel α Ω} {μ : Measure α} (hyp : ∀ n, IndepSets (s n) s' κ μ) :
     IndepSets (⋃ n, s n) s' κ μ := by
   intro t1 t2 ht1 ht2
   rw [Set.mem_iUnion] at ht1
@@ -248,7 +248,7 @@ theorem IndepSets.iUnion {s : ι → Set (Set Ω)} {s' : Set (Set Ω)} {_mΩ : M
   exact hyp n t1 t2 ht1 ht2
 
 theorem IndepSets.bUnion {s : ι → Set (Set Ω)} {s' : Set (Set Ω)} {_mΩ : MeasurableSpace Ω}
-    {κ : kernel α Ω} {μ : Measure α} {u : Set ι} (hyp : ∀ n ∈ u, IndepSets (s n) s' κ μ) :
+    {κ : Kernel α Ω} {μ : Measure α} {u : Set ι} (hyp : ∀ n ∈ u, IndepSets (s n) s' κ μ) :
     IndepSets (⋃ n ∈ u, s n) s' κ μ := by
   intro t1 t2 ht1 ht2
   simp_rw [Set.mem_iUnion] at ht1
@@ -256,29 +256,29 @@ theorem IndepSets.bUnion {s : ι → Set (Set Ω)} {s' : Set (Set Ω)} {_mΩ : M
   exact hyp n hpn t1 t2 ht1 ht2
 
 theorem IndepSets.inter {s₁ s' : Set (Set Ω)} (s₂ : Set (Set Ω)) {_mΩ : MeasurableSpace Ω}
-    {κ : kernel α Ω} {μ : Measure α} (h₁ : IndepSets s₁ s' κ μ) :
+    {κ : Kernel α Ω} {μ : Measure α} (h₁ : IndepSets s₁ s' κ μ) :
     IndepSets (s₁ ∩ s₂) s' κ μ :=
   fun t1 t2 ht1 ht2 => h₁ t1 t2 ((Set.mem_inter_iff _ _ _).mp ht1).left ht2
 
 theorem IndepSets.iInter {s : ι → Set (Set Ω)} {s' : Set (Set Ω)} {_mΩ : MeasurableSpace Ω}
-    {κ : kernel α Ω} {μ : Measure α} (h : ∃ n, IndepSets (s n) s' κ μ) :
+    {κ : Kernel α Ω} {μ : Measure α} (h : ∃ n, IndepSets (s n) s' κ μ) :
     IndepSets (⋂ n, s n) s' κ μ := by
   intro t1 t2 ht1 ht2; cases' h with n h; exact h t1 t2 (Set.mem_iInter.mp ht1 n) ht2
 
 theorem IndepSets.bInter {s : ι → Set (Set Ω)} {s' : Set (Set Ω)} {_mΩ : MeasurableSpace Ω}
-    {κ : kernel α Ω} {μ : Measure α} {u : Set ι} (h : ∃ n ∈ u, IndepSets (s n) s' κ μ) :
+    {κ : Kernel α Ω} {μ : Measure α} {u : Set ι} (h : ∃ n ∈ u, IndepSets (s n) s' κ μ) :
     IndepSets (⋂ n ∈ u, s n) s' κ μ := by
   intro t1 t2 ht1 ht2
   rcases h with ⟨n, hn, h⟩
   exact h t1 t2 (Set.biInter_subset_of_mem hn ht1) ht2
 
 theorem iIndep_comap_mem_iff {f : ι → Set Ω} {_mΩ : MeasurableSpace Ω}
-    {κ : kernel α Ω} {μ : Measure α} :
+    {κ : Kernel α Ω} {μ : Measure α} :
     iIndep (fun i => MeasurableSpace.comap (· ∈ f i) ⊤) κ μ ↔ iIndepSet f κ μ := by
   simp_rw [← generateFrom_singleton, iIndepSet]
 
 theorem iIndepSets_singleton_iff {s : ι → Set Ω} {_mΩ : MeasurableSpace Ω}
-    {κ : kernel α Ω} {μ : Measure α} :
+    {κ : Kernel α Ω} {μ : Measure α} :
     iIndepSets (fun i ↦ {s i}) κ μ ↔
       ∀ S : Finset ι, ∀ᵐ a ∂μ, κ a (⋂ i ∈ S, s i) = ∏ i ∈ S, κ a (s i) := by
   refine ⟨fun h S ↦ h S (fun i _ ↦ rfl), fun h S f hf ↦ ?_⟩
@@ -287,7 +287,7 @@ theorem iIndepSets_singleton_iff {s : ι → Set Ω} {_mΩ : MeasurableSpace Ω}
   rwa [Finset.prod_congr rfl this, Set.iInter₂_congr hf]
 
 theorem indepSets_singleton_iff {s t : Set Ω} {_mΩ : MeasurableSpace Ω}
-    {κ : kernel α Ω} {μ : Measure α} :
+    {κ : Kernel α Ω} {μ : Measure α} :
     IndepSets {s} {t} κ μ ↔ ∀ᵐ a ∂μ, κ a (s ∩ t) = κ a s * κ a t :=
   ⟨fun h ↦ h s t rfl rfl,
    fun h s1 t1 hs1 ht1 ↦ by rwa [Set.mem_singleton_iff.mp hs1, Set.mem_singleton_iff.mp ht1]⟩
@@ -302,7 +302,7 @@ section FromiIndepToIndep
 variable {_mα : MeasurableSpace α}
 
 theorem iIndepSets.indepSets {s : ι → Set (Set Ω)} {_mΩ : MeasurableSpace Ω}
-    {κ : kernel α Ω} {μ : Measure α} (h_indep : iIndepSets s κ μ) {i j : ι} (hij : i ≠ j) :
+    {κ : Kernel α Ω} {μ : Measure α} (h_indep : iIndepSets s κ μ) {i j : ι} (hij : i ≠ j) :
     IndepSets (s i) (s j) κ μ := by
   classical
   intro t₁ t₂ ht₁ ht₂
@@ -327,12 +327,12 @@ theorem iIndepSets.indepSets {s : ι → Set (Set Ω)} {_mΩ : MeasurableSpace �
   rw [← h_inter, ← h_prod, h_indep']
 
 theorem iIndep.indep {m : ι → MeasurableSpace Ω} {_mΩ : MeasurableSpace Ω}
-    {κ : kernel α Ω} {μ : Measure α}
+    {κ : Kernel α Ω} {μ : Measure α}
     (h_indep : iIndep m κ μ) {i j : ι} (hij : i ≠ j) : Indep (m i) (m j) κ μ :=
   iIndepSets.indepSets h_indep hij
 
 theorem iIndepFun.indepFun {_mΩ : MeasurableSpace Ω}
-    {κ : kernel α Ω} {μ : Measure α} {β : ι → Type*}
+    {κ : Kernel α Ω} {μ : Measure α} {β : ι → Type*}
     {m : ∀ x, MeasurableSpace (β x)} {f : ∀ i, Ω → β i} (hf_Indep : iIndepFun m f κ μ) {i j : ι}
     (hij : i ≠ j) : IndepFun (f i) (f j) κ μ :=
   hf_Indep.indep hij
@@ -353,7 +353,7 @@ section FromMeasurableSpacesToSetsOfSets
 variable {_mα : MeasurableSpace α}
 
 theorem iIndep.iIndepSets {_mΩ : MeasurableSpace Ω}
-    {κ : kernel α Ω} {μ : Measure α} {m : ι → MeasurableSpace Ω}
+    {κ : Kernel α Ω} {μ : Measure α} {m : ι → MeasurableSpace Ω}
     {s : ι → Set (Set Ω)} (hms : ∀ n, m n = generateFrom (s n)) (h_indep : iIndep m κ μ) :
     iIndepSets s κ μ :=
   fun S f hfs =>
@@ -361,7 +361,7 @@ theorem iIndep.iIndepSets {_mΩ : MeasurableSpace Ω}
     ((hms x).symm ▸ measurableSet_generateFrom (hfs x hxS) : MeasurableSet[m x] (f x))
 
 theorem Indep.indepSets {_mΩ : MeasurableSpace Ω}
-    {κ : kernel α Ω} {μ : Measure α} {s1 s2 : Set (Set Ω)}
+    {κ : Kernel α Ω} {μ : Measure α} {s1 s2 : Set (Set Ω)}
     (h_indep : Indep (generateFrom s1) (generateFrom s2) κ μ) :
     IndepSets s1 s2 κ μ :=
   fun t1 t2 ht1 ht2 =>
@@ -376,7 +376,7 @@ section FromPiSystemsToMeasurableSpaces
 variable {_mα : MeasurableSpace α}
 
 theorem IndepSets.indep_aux {m₂ m : MeasurableSpace Ω}
-    {κ : kernel α Ω} {μ : Measure α} [IsMarkovKernel κ] {p1 p2 : Set (Set Ω)} (h2 : m₂ ≤ m)
+    {κ : Kernel α Ω} {μ : Measure α} [IsMarkovKernel κ] {p1 p2 : Set (Set Ω)} (h2 : m₂ ≤ m)
     (hp2 : IsPiSystem p2) (hpm2 : m₂ = generateFrom p2) (hyp : IndepSets p1 p2 κ μ) {t1 t2 : Set Ω}
     (ht1 : t1 ∈ p1) (ht1m : MeasurableSet[m] t1) (ht2m : MeasurableSet[m₂] t2) :
     ∀ᵐ a ∂μ, κ a (t1 ∩ t2) = κ a t1 * κ a t2 := by
@@ -407,7 +407,7 @@ theorem IndepSets.indep_aux {m₂ m : MeasurableSpace Ω}
     · exact fun i ↦ ht1m.inter (h2 _ (hf_meas i))
 
 /-- The measurable space structures generated by independent pi-systems are independent. -/
-theorem IndepSets.indep {m1 m2 m : MeasurableSpace Ω} {κ : kernel α Ω} {μ : Measure α}
+theorem IndepSets.indep {m1 m2 m : MeasurableSpace Ω} {κ : Kernel α Ω} {μ : Measure α}
     [IsMarkovKernel κ] {p1 p2 : Set (Set Ω)} (h1 : m1 ≤ m) (h2 : m2 ≤ m) (hp1 : IsPiSystem p1)
     (hp2 : IsPiSystem p2) (hpm1 : m1 = generateFrom p1) (hpm2 : m2 = generateFrom p2)
     (hyp : IndepSets p1 p2 κ μ) :
@@ -446,13 +446,13 @@ theorem IndepSets.indep {m1 m2 m : MeasurableSpace Ω} {κ : kernel α Ω} {μ :
     · exact fun i ↦ (h2 _ ht2).inter (h1 _ (hf_meas i))
 
 theorem IndepSets.indep' {_mΩ : MeasurableSpace Ω}
-    {κ : kernel α Ω} {μ : Measure α} [IsMarkovKernel κ]
+    {κ : Kernel α Ω} {μ : Measure α} [IsMarkovKernel κ]
     {p1 p2 : Set (Set Ω)} (hp1m : ∀ s ∈ p1, MeasurableSet s) (hp2m : ∀ s ∈ p2, MeasurableSet s)
     (hp1 : IsPiSystem p1) (hp2 : IsPiSystem p2) (hyp : IndepSets p1 p2 κ μ) :
     Indep (generateFrom p1) (generateFrom p2) κ μ :=
   hyp.indep (generateFrom_le hp1m) (generateFrom_le hp2m) hp1 hp2 rfl rfl
 
-variable {_mΩ : MeasurableSpace Ω} {κ : kernel α Ω} {μ : Measure α}
+variable {_mΩ : MeasurableSpace Ω} {κ : Kernel α Ω} {μ : Measure α}
 
 theorem indepSets_piiUnionInter_of_disjoint [IsMarkovKernel κ] {s : ι → Set (Set Ω)}
     {S T : Set ι} (h_indep : iIndepSets s κ μ) (hST : Disjoint S T) :
@@ -519,7 +519,7 @@ theorem indep_iSup_of_disjoint [IsMarkovKernel κ] {m : ι → MeasurableSpace �
   · classical exact indepSets_piiUnionInter_of_disjoint h_indep hST
 
 theorem indep_iSup_of_directed_le {Ω} {m : ι → MeasurableSpace Ω} {m' m0 : MeasurableSpace Ω}
-    {κ : kernel α Ω} {μ : Measure α} [IsMarkovKernel κ] (h_indep : ∀ i, Indep (m i) m' κ μ)
+    {κ : Kernel α Ω} {μ : Measure α} [IsMarkovKernel κ] (h_indep : ∀ i, Indep (m i) m' κ μ)
     (h_le : ∀ i, m i ≤ m0) (h_le' : m' ≤ m0) (hm : Directed (· ≤ ·) m) :
     Indep (⨆ i, m i) m' κ μ := by
   let p : ι → Set (Set Ω) := fun n => { t | MeasurableSet[m n] t }
@@ -561,14 +561,14 @@ theorem iIndepSet.indep_generateFrom_le_nat [IsMarkovKernel κ] {s : ℕ → Set
   iIndepSet.indep_generateFrom_le hsm hs _ n.lt_succ_self
 
 theorem indep_iSup_of_monotone [SemilatticeSup ι] {Ω} {m : ι → MeasurableSpace Ω}
-    {m' m0 : MeasurableSpace Ω} {κ : kernel α Ω} {μ : Measure α} [IsMarkovKernel κ]
+    {m' m0 : MeasurableSpace Ω} {κ : Kernel α Ω} {μ : Measure α} [IsMarkovKernel κ]
     (h_indep : ∀ i, Indep (m i) m' κ μ) (h_le : ∀ i, m i ≤ m0) (h_le' : m' ≤ m0)
     (hm : Monotone m) :
     Indep (⨆ i, m i) m' κ μ :=
   indep_iSup_of_directed_le h_indep h_le h_le' (Monotone.directed_le hm)
 
 theorem indep_iSup_of_antitone [SemilatticeInf ι] {Ω} {m : ι → MeasurableSpace Ω}
-    {m' m0 : MeasurableSpace Ω} {κ : kernel α Ω} {μ : Measure α} [IsMarkovKernel κ]
+    {m' m0 : MeasurableSpace Ω} {κ : Kernel α Ω} {μ : Measure α} [IsMarkovKernel κ]
     (h_indep : ∀ i, Indep (m i) m' κ μ) (h_le : ∀ i, m i ≤ m0) (h_le' : m' ≤ m0)
     (hm : Antitone m) :
     Indep (⨆ i, m i) m' κ μ :=
@@ -656,7 +656,7 @@ We prove the following equivalences on `IndepSet`, for measurable sets `s, t`.
 
 variable {_mα : MeasurableSpace α}
 
-theorem iIndepSet_iff_iIndepSets_singleton {_mΩ : MeasurableSpace Ω} {κ : kernel α Ω}
+theorem iIndepSet_iff_iIndepSets_singleton {_mΩ : MeasurableSpace Ω} {κ : Kernel α Ω}
     [IsMarkovKernel κ] {μ : Measure α} {f : ι → Set Ω}
     (hf : ∀ i, MeasurableSet (f i)) :
     iIndepSet f κ μ ↔ iIndepSets (fun i ↦ {f i}) κ μ :=
@@ -664,12 +664,12 @@ theorem iIndepSet_iff_iIndepSets_singleton {_mΩ : MeasurableSpace Ω} {κ : ker
     iIndepSets.iIndep _ (fun i ↦ generateFrom_le <| by rintro t (rfl : t = _); exact hf _) _
       (fun _ ↦ IsPiSystem.singleton _) fun _ ↦ rfl⟩
 
-theorem iIndepSet_iff_meas_biInter {_mΩ : MeasurableSpace Ω} {κ : kernel α Ω}
+theorem iIndepSet_iff_meas_biInter {_mΩ : MeasurableSpace Ω} {κ : Kernel α Ω}
     [IsMarkovKernel κ] {μ : Measure α} {f : ι → Set Ω} (hf : ∀ i, MeasurableSet (f i)) :
     iIndepSet f κ μ ↔ ∀ s, ∀ᵐ a ∂μ, κ a (⋂ i ∈ s, f i) = ∏ i ∈ s, κ a (f i) :=
   (iIndepSet_iff_iIndepSets_singleton hf).trans iIndepSets_singleton_iff
 
-theorem iIndepSets.iIndepSet_of_mem {_mΩ : MeasurableSpace Ω} {κ : kernel α Ω}
+theorem iIndepSets.iIndepSet_of_mem {_mΩ : MeasurableSpace Ω} {κ : Kernel α Ω}
     [IsMarkovKernel κ] {μ : Measure α} {π : ι → Set (Set Ω)} {f : ι → Set Ω}
     (hfπ : ∀ i, f i ∈ π i) (hf : ∀ i, MeasurableSet (f i))
     (hπ : iIndepSets π κ μ) :
@@ -679,7 +679,7 @@ theorem iIndepSets.iIndepSet_of_mem {_mΩ : MeasurableSpace Ω} {κ : kernel α 
 variable {s t : Set Ω} (S T : Set (Set Ω))
 
 theorem indepSet_iff_indepSets_singleton {m0 : MeasurableSpace Ω} (hs_meas : MeasurableSet s)
-    (ht_meas : MeasurableSet t) (κ : kernel α Ω) (μ : Measure α)
+    (ht_meas : MeasurableSet t) (κ : Kernel α Ω) (μ : Measure α)
     [IsMarkovKernel κ] :
     IndepSet s t κ μ ↔ IndepSets {s} {t} κ μ :=
   ⟨Indep.indepSets, fun h =>
@@ -689,19 +689,19 @@ theorem indepSet_iff_indepSets_singleton {m0 : MeasurableSpace Ω} (hs_meas : Me
       (IsPiSystem.singleton s) (IsPiSystem.singleton t) rfl rfl h⟩
 
 theorem indepSet_iff_measure_inter_eq_mul {_m0 : MeasurableSpace Ω} (hs_meas : MeasurableSet s)
-    (ht_meas : MeasurableSet t) (κ : kernel α Ω) (μ : Measure α)
+    (ht_meas : MeasurableSet t) (κ : Kernel α Ω) (μ : Measure α)
     [IsMarkovKernel κ] :
     IndepSet s t κ μ ↔ ∀ᵐ a ∂μ, κ a (s ∩ t) = κ a s * κ a t :=
   (indepSet_iff_indepSets_singleton hs_meas ht_meas κ μ).trans indepSets_singleton_iff
 
 theorem IndepSets.indepSet_of_mem {_m0 : MeasurableSpace Ω} (hs : s ∈ S) (ht : t ∈ T)
     (hs_meas : MeasurableSet s) (ht_meas : MeasurableSet t)
-    (κ : kernel α Ω) (μ : Measure α) [IsMarkovKernel κ]
+    (κ : Kernel α Ω) (μ : Measure α) [IsMarkovKernel κ]
     (h_indep : IndepSets S T κ μ) :
     IndepSet s t κ μ :=
   (indepSet_iff_measure_inter_eq_mul hs_meas ht_meas κ μ).mpr (h_indep s t hs ht)
 
-theorem Indep.indepSet_of_measurableSet {m₁ m₂ m0 : MeasurableSpace Ω} {κ : kernel α Ω}
+theorem Indep.indepSet_of_measurableSet {m₁ m₂ m0 : MeasurableSpace Ω} {κ : Kernel α Ω}
     {μ : Measure α}
     (h_indep : Indep m₁ m₂ κ μ) {s t : Set Ω} (hs : MeasurableSet[m₁] s)
     (ht : MeasurableSet[m₂] t) :
@@ -719,7 +719,7 @@ theorem Indep.indepSet_of_measurableSet {m₁ m₂ m0 : MeasurableSpace Ω} {κ 
     · exact fun f hf => MeasurableSet.iUnion hf
 
 theorem indep_iff_forall_indepSet (m₁ m₂ : MeasurableSpace Ω) {_m0 : MeasurableSpace Ω}
-    (κ : kernel α Ω) (μ : Measure α) :
+    (κ : Kernel α Ω) (μ : Measure α) :
     Indep m₁ m₂ κ μ ↔ ∀ s t, MeasurableSet[m₁] s → MeasurableSet[m₂] t → IndepSet s t κ μ :=
   ⟨fun h => fun _s _t hs ht => h.indepSet_of_measurableSet hs ht, fun h s t hs ht =>
     h s t hs ht s t (measurableSet_generateFrom (Set.mem_singleton s))
@@ -735,7 +735,7 @@ section IndepFun
 
 
 variable {β β' γ γ' : Type*} {_mα : MeasurableSpace α} {_mΩ : MeasurableSpace Ω}
-  {κ : kernel α Ω} {μ : Measure α} {f : Ω → β} {g : Ω → β'}
+  {κ : Kernel α Ω} {μ : Measure α} {f : Ω → β} {g : Ω → β'}
 
 theorem indepFun_iff_measure_inter_preimage_eq_mul {mβ : MeasurableSpace β}
     {mβ' : MeasurableSpace β'} :
@@ -1072,4 +1072,4 @@ theorem iIndepSet.iIndepFun_indicator [Zero β] [One β] {m : MeasurableSpace β
 
 end IndepFun
 
-end ProbabilityTheory.kernel
+end ProbabilityTheory.Kernel

--- a/Mathlib/Probability/Independence/ZeroOne.lean
+++ b/Mathlib/Probability/Independence/ZeroOne.lean
@@ -26,10 +26,10 @@ open scoped MeasureTheory ENNReal
 namespace ProbabilityTheory
 
 variable {α Ω ι : Type*} {_mα : MeasurableSpace α} {s : ι → MeasurableSpace Ω}
-  {m m0 : MeasurableSpace Ω} {κ : kernel α Ω} {μα : Measure α} {μ : Measure Ω}
+  {m m0 : MeasurableSpace Ω} {κ : Kernel α Ω} {μα : Measure α} {μ : Measure Ω}
 
-theorem kernel.measure_eq_zero_or_one_or_top_of_indepSet_self {t : Set Ω}
-    (h_indep : kernel.IndepSet t t κ μα) :
+theorem Kernel.measure_eq_zero_or_one_or_top_of_indepSet_self {t : Set Ω}
+    (h_indep : Kernel.IndepSet t t κ μα) :
     ∀ᵐ a ∂μα, κ a t = 0 ∨ κ a t = 1 ∨ κ a t = ∞ := by
   specialize h_indep t t (measurableSet_generateFrom (Set.mem_singleton t))
     (measurableSet_generateFrom (Set.mem_singleton t))
@@ -44,9 +44,9 @@ theorem kernel.measure_eq_zero_or_one_or_top_of_indepSet_self {t : Set Ω}
 theorem measure_eq_zero_or_one_or_top_of_indepSet_self {t : Set Ω}
     (h_indep : IndepSet t t μ) : μ t = 0 ∨ μ t = 1 ∨ μ t = ∞ := by
   simpa only [ae_dirac_eq, Filter.eventually_pure]
-    using kernel.measure_eq_zero_or_one_or_top_of_indepSet_self h_indep
+    using Kernel.measure_eq_zero_or_one_or_top_of_indepSet_self h_indep
 
-theorem kernel.measure_eq_zero_or_one_of_indepSet_self [∀ a, IsFiniteMeasure (κ a)] {t : Set Ω}
+theorem Kernel.measure_eq_zero_or_one_of_indepSet_self [∀ a, IsFiniteMeasure (κ a)] {t : Set Ω}
     (h_indep : IndepSet t t κ μα) :
     ∀ᵐ a ∂μα, κ a t = 0 ∨ κ a t = 1 := by
   filter_upwards [measure_eq_zero_or_one_or_top_of_indepSet_self h_indep] with a h_0_1_top
@@ -55,14 +55,16 @@ theorem kernel.measure_eq_zero_or_one_of_indepSet_self [∀ a, IsFiniteMeasure (
 theorem measure_eq_zero_or_one_of_indepSet_self [IsFiniteMeasure μ] {t : Set Ω}
     (h_indep : IndepSet t t μ) : μ t = 0 ∨ μ t = 1 := by
   simpa only [ae_dirac_eq, Filter.eventually_pure]
-    using kernel.measure_eq_zero_or_one_of_indepSet_self h_indep
+    using Kernel.measure_eq_zero_or_one_of_indepSet_self h_indep
 
 theorem condexp_eq_zero_or_one_of_condIndepSet_self
     [StandardBorelSpace Ω] [Nonempty Ω]
     (hm : m ≤ m0) [hμ : IsFiniteMeasure μ] {t : Set Ω} (ht : MeasurableSet t)
     (h_indep : CondIndepSet m hm t t μ) :
     ∀ᵐ ω ∂μ, (μ⟦t | m⟧) ω = 0 ∨ (μ⟦t | m⟧) ω = 1 := by
-  have h := ae_of_ae_trim hm (kernel.measure_eq_zero_or_one_of_indepSet_self h_indep)
+  -- TODO: Why is not inferred?
+  have (a) : IsFiniteMeasure (condexpKernel μ m a) := inferInstance
+  have h := ae_of_ae_trim hm (Kernel.measure_eq_zero_or_one_of_indepSet_self h_indep)
   filter_upwards [condexpKernel_ae_eq_condexp hm ht, h] with ω hω_eq hω
   rw [← hω_eq, ENNReal.toReal_eq_zero_iff, ENNReal.toReal_eq_one_iff]
   cases hω with
@@ -73,19 +75,19 @@ variable [IsMarkovKernel κ] [IsProbabilityMeasure μ]
 
 open Filter
 
-theorem kernel.indep_biSup_compl (h_le : ∀ n, s n ≤ m0) (h_indep : iIndep s κ μα) (t : Set ι) :
+theorem Kernel.indep_biSup_compl (h_le : ∀ n, s n ≤ m0) (h_indep : iIndep s κ μα) (t : Set ι) :
     Indep (⨆ n ∈ t, s n) (⨆ n ∈ tᶜ, s n) κ μα :=
   indep_iSup_of_disjoint h_le h_indep disjoint_compl_right
 
 theorem indep_biSup_compl (h_le : ∀ n, s n ≤ m0) (h_indep : iIndep s μ) (t : Set ι) :
     Indep (⨆ n ∈ t, s n) (⨆ n ∈ tᶜ, s n) μ :=
-  kernel.indep_biSup_compl h_le h_indep t
+  Kernel.indep_biSup_compl h_le h_indep t
 
 theorem condIndep_biSup_compl [StandardBorelSpace Ω] [Nonempty Ω]
     (hm : m ≤ m0) [IsFiniteMeasure μ]
     (h_le : ∀ n, s n ≤ m0) (h_indep : iCondIndep m hm s μ) (t : Set ι) :
     CondIndep m (⨆ n ∈ t, s n) (⨆ n ∈ tᶜ, s n) hm μ :=
-  kernel.indep_biSup_compl h_le h_indep t
+  Kernel.indep_biSup_compl h_le h_indep t
 
 section Abstract
 
@@ -101,7 +103,7 @@ For the example of `f = atTop`, we can take
 `p = bddAbove` and `ns : ι → Set ι := fun i => Set.Iic i`.
 -/
 
-theorem kernel.indep_biSup_limsup (h_le : ∀ n, s n ≤ m0) (h_indep : iIndep s κ μα)
+theorem Kernel.indep_biSup_limsup (h_le : ∀ n, s n ≤ m0) (h_indep : iIndep s κ μα)
     (hf : ∀ t, p t → tᶜ ∈ f) {t : Set ι} (ht : p t) :
     Indep (⨆ n ∈ t, s n) (limsup s f) κ μα := by
   refine indep_of_indep_of_le_right (indep_biSup_compl h_le h_indep t) ?_
@@ -112,16 +114,16 @@ theorem kernel.indep_biSup_limsup (h_le : ∀ n, s n ≤ m0) (h_indep : iIndep s
 theorem indep_biSup_limsup (h_le : ∀ n, s n ≤ m0) (h_indep : iIndep s μ) (hf : ∀ t, p t → tᶜ ∈ f)
     {t : Set ι} (ht : p t) :
     Indep (⨆ n ∈ t, s n) (limsup s f) μ :=
-  kernel.indep_biSup_limsup h_le h_indep hf ht
+  Kernel.indep_biSup_limsup h_le h_indep hf ht
 
 theorem condIndep_biSup_limsup [StandardBorelSpace Ω] [Nonempty Ω]
     (hm : m ≤ m0) [IsFiniteMeasure μ]
     (h_le : ∀ n, s n ≤ m0) (h_indep : iCondIndep m hm s μ) (hf : ∀ t, p t → tᶜ ∈ f)
     {t : Set ι} (ht : p t) :
     CondIndep m (⨆ n ∈ t, s n) (limsup s f) hm μ :=
-  kernel.indep_biSup_limsup h_le h_indep hf ht
+  Kernel.indep_biSup_limsup h_le h_indep hf ht
 
-theorem kernel.indep_iSup_directed_limsup (h_le : ∀ n, s n ≤ m0) (h_indep : iIndep s κ μα)
+theorem Kernel.indep_iSup_directed_limsup (h_le : ∀ n, s n ≤ m0) (h_indep : iIndep s κ μα)
     (hf : ∀ t, p t → tᶜ ∈ f) (hns : Directed (· ≤ ·) ns) (hnsp : ∀ a, p (ns a)) :
     Indep (⨆ a, ⨆ n ∈ ns a, s n) (limsup s f) κ μα := by
   apply indep_iSup_of_directed_le
@@ -137,16 +139,16 @@ theorem kernel.indep_iSup_directed_limsup (h_le : ∀ n, s n ≤ m0) (h_indep : 
 theorem indep_iSup_directed_limsup (h_le : ∀ n, s n ≤ m0) (h_indep : iIndep s μ)
     (hf : ∀ t, p t → tᶜ ∈ f) (hns : Directed (· ≤ ·) ns) (hnsp : ∀ a, p (ns a)) :
     Indep (⨆ a, ⨆ n ∈ ns a, s n) (limsup s f) μ :=
-  kernel.indep_iSup_directed_limsup h_le h_indep hf hns hnsp
+  Kernel.indep_iSup_directed_limsup h_le h_indep hf hns hnsp
 
 theorem condIndep_iSup_directed_limsup [StandardBorelSpace Ω]
     [Nonempty Ω] (hm : m ≤ m0) [IsFiniteMeasure μ]
     (h_le : ∀ n, s n ≤ m0) (h_indep : iCondIndep m hm s μ)
     (hf : ∀ t, p t → tᶜ ∈ f) (hns : Directed (· ≤ ·) ns) (hnsp : ∀ a, p (ns a)) :
     CondIndep m (⨆ a, ⨆ n ∈ ns a, s n) (limsup s f) hm μ :=
-  kernel.indep_iSup_directed_limsup h_le h_indep hf hns hnsp
+  Kernel.indep_iSup_directed_limsup h_le h_indep hf hns hnsp
 
-theorem kernel.indep_iSup_limsup (h_le : ∀ n, s n ≤ m0) (h_indep : iIndep s κ μα)
+theorem Kernel.indep_iSup_limsup (h_le : ∀ n, s n ≤ m0) (h_indep : iIndep s κ μα)
     (hf : ∀ t, p t → tᶜ ∈ f)
     (hns : Directed (· ≤ ·) ns) (hnsp : ∀ a, p (ns a)) (hns_univ : ∀ n, ∃ a, n ∈ ns a) :
     Indep (⨆ n, s n) (limsup s f) κ μα := by
@@ -162,16 +164,16 @@ theorem kernel.indep_iSup_limsup (h_le : ∀ n, s n ≤ m0) (h_indep : iIndep s 
 theorem indep_iSup_limsup (h_le : ∀ n, s n ≤ m0) (h_indep : iIndep s μ) (hf : ∀ t, p t → tᶜ ∈ f)
     (hns : Directed (· ≤ ·) ns) (hnsp : ∀ a, p (ns a)) (hns_univ : ∀ n, ∃ a, n ∈ ns a) :
     Indep (⨆ n, s n) (limsup s f) μ :=
-  kernel.indep_iSup_limsup h_le h_indep hf hns hnsp hns_univ
+  Kernel.indep_iSup_limsup h_le h_indep hf hns hnsp hns_univ
 
 theorem condIndep_iSup_limsup [StandardBorelSpace Ω] [Nonempty Ω]
     (hm : m ≤ m0) [IsFiniteMeasure μ]
     (h_le : ∀ n, s n ≤ m0) (h_indep : iCondIndep m hm s μ) (hf : ∀ t, p t → tᶜ ∈ f)
     (hns : Directed (· ≤ ·) ns) (hnsp : ∀ a, p (ns a)) (hns_univ : ∀ n, ∃ a, n ∈ ns a) :
     CondIndep m (⨆ n, s n) (limsup s f) hm μ :=
-  kernel.indep_iSup_limsup h_le h_indep hf hns hnsp hns_univ
+  Kernel.indep_iSup_limsup h_le h_indep hf hns hnsp hns_univ
 
-theorem kernel.indep_limsup_self (h_le : ∀ n, s n ≤ m0) (h_indep : iIndep s κ μα)
+theorem Kernel.indep_limsup_self (h_le : ∀ n, s n ≤ m0) (h_indep : iIndep s κ μα)
     (hf : ∀ t, p t → tᶜ ∈ f)
     (hns : Directed (· ≤ ·) ns) (hnsp : ∀ a, p (ns a)) (hns_univ : ∀ n, ∃ a, n ∈ ns a) :
     Indep (limsup s f) (limsup s f) κ μα :=
@@ -180,16 +182,16 @@ theorem kernel.indep_limsup_self (h_le : ∀ n, s n ≤ m0) (h_indep : iIndep s 
 theorem indep_limsup_self (h_le : ∀ n, s n ≤ m0) (h_indep : iIndep s μ) (hf : ∀ t, p t → tᶜ ∈ f)
     (hns : Directed (· ≤ ·) ns) (hnsp : ∀ a, p (ns a)) (hns_univ : ∀ n, ∃ a, n ∈ ns a) :
     Indep (limsup s f) (limsup s f) μ :=
-  kernel.indep_limsup_self h_le h_indep hf hns hnsp hns_univ
+  Kernel.indep_limsup_self h_le h_indep hf hns hnsp hns_univ
 
 theorem condIndep_limsup_self [StandardBorelSpace Ω] [Nonempty Ω]
     (hm : m ≤ m0) [IsFiniteMeasure μ]
     (h_le : ∀ n, s n ≤ m0) (h_indep : iCondIndep m hm s μ) (hf : ∀ t, p t → tᶜ ∈ f)
     (hns : Directed (· ≤ ·) ns) (hnsp : ∀ a, p (ns a)) (hns_univ : ∀ n, ∃ a, n ∈ ns a) :
     CondIndep m (limsup s f) (limsup s f) hm μ :=
-  kernel.indep_limsup_self h_le h_indep hf hns hnsp hns_univ
+  Kernel.indep_limsup_self h_le h_indep hf hns hnsp hns_univ
 
-theorem kernel.measure_zero_or_one_of_measurableSet_limsup (h_le : ∀ n, s n ≤ m0)
+theorem Kernel.measure_zero_or_one_of_measurableSet_limsup (h_le : ∀ n, s n ≤ m0)
     (h_indep : iIndep s κ μα)
     (hf : ∀ t, p t → tᶜ ∈ f) (hns : Directed (· ≤ ·) ns) (hnsp : ∀ a, p (ns a))
     (hns_univ : ∀ n, ∃ a, n ∈ ns a) {t : Set Ω} (ht_tail : MeasurableSet[limsup s f] t) :
@@ -203,7 +205,7 @@ theorem measure_zero_or_one_of_measurableSet_limsup (h_le : ∀ n, s n ≤ m0) (
     (hns_univ : ∀ n, ∃ a, n ∈ ns a) {t : Set Ω} (ht_tail : MeasurableSet[limsup s f] t) :
     μ t = 0 ∨ μ t = 1 := by
   simpa only [ae_dirac_eq, Filter.eventually_pure]
-    using kernel.measure_zero_or_one_of_measurableSet_limsup h_le h_indep hf hns hnsp hns_univ
+    using Kernel.measure_zero_or_one_of_measurableSet_limsup h_le h_indep hf hns hnsp hns_univ
       ht_tail
 
 theorem condexp_zero_or_one_of_measurableSet_limsup [StandardBorelSpace Ω] [Nonempty Ω]
@@ -213,7 +215,7 @@ theorem condexp_zero_or_one_of_measurableSet_limsup [StandardBorelSpace Ω] [Non
     (hns_univ : ∀ n, ∃ a, n ∈ ns a) {t : Set Ω} (ht_tail : MeasurableSet[limsup s f] t) :
     ∀ᵐ ω ∂μ, (μ⟦t | m⟧) ω = 0 ∨ (μ⟦t | m⟧) ω = 1 := by
   have h := ae_of_ae_trim hm
-    (kernel.measure_zero_or_one_of_measurableSet_limsup h_le h_indep hf hns hnsp hns_univ ht_tail)
+    (Kernel.measure_zero_or_one_of_measurableSet_limsup h_le h_indep hf hns hnsp hns_univ ht_tail)
   have ht : MeasurableSet t := limsup_le_iSup.trans (iSup_le h_le) t ht_tail
   filter_upwards [condexpKernel_ae_eq_condexp hm ht, h] with ω hω_eq hω
   rw [← hω_eq, ENNReal.toReal_eq_zero_iff, ENNReal.toReal_eq_one_iff]
@@ -227,7 +229,7 @@ section AtTop
 
 variable [SemilatticeSup ι] [NoMaxOrder ι] [Nonempty ι]
 
-theorem kernel.indep_limsup_atTop_self (h_le : ∀ n, s n ≤ m0) (h_indep : iIndep s κ μα) :
+theorem Kernel.indep_limsup_atTop_self (h_le : ∀ n, s n ≤ m0) (h_indep : iIndep s κ μα) :
     Indep (limsup s atTop) (limsup s atTop) κ μα := by
   let ns : ι → Set ι := Set.Iic
   have hnsp : ∀ i, BddAbove (ns i) := fun i => bddAbove_Iic
@@ -243,15 +245,15 @@ theorem kernel.indep_limsup_atTop_self (h_le : ∀ n, s n ≤ m0) (h_indep : iIn
 
 theorem indep_limsup_atTop_self (h_le : ∀ n, s n ≤ m0) (h_indep : iIndep s μ) :
     Indep (limsup s atTop) (limsup s atTop) μ :=
-  kernel.indep_limsup_atTop_self h_le h_indep
+  Kernel.indep_limsup_atTop_self h_le h_indep
 
 theorem condIndep_limsup_atTop_self [StandardBorelSpace Ω] [Nonempty Ω]
     (hm : m ≤ m0) [IsFiniteMeasure μ]
     (h_le : ∀ n, s n ≤ m0) (h_indep : iCondIndep m hm s μ) :
     CondIndep m (limsup s atTop) (limsup s atTop) hm μ :=
-  kernel.indep_limsup_atTop_self h_le h_indep
+  Kernel.indep_limsup_atTop_self h_le h_indep
 
-theorem kernel.measure_zero_or_one_of_measurableSet_limsup_atTop (h_le : ∀ n, s n ≤ m0)
+theorem Kernel.measure_zero_or_one_of_measurableSet_limsup_atTop (h_le : ∀ n, s n ≤ m0)
     (h_indep : iIndep s κ μα) {t : Set Ω} (ht_tail : MeasurableSet[limsup s atTop] t) :
     ∀ᵐ a ∂μα, κ a t = 0 ∨ κ a t = 1 :=
   measure_eq_zero_or_one_of_indepSet_self
@@ -264,7 +266,7 @@ theorem measure_zero_or_one_of_measurableSet_limsup_atTop (h_le : ∀ n, s n ≤
     (h_indep : iIndep s μ) {t : Set Ω} (ht_tail : MeasurableSet[limsup s atTop] t) :
     μ t = 0 ∨ μ t = 1 := by
   simpa only [ae_dirac_eq, Filter.eventually_pure]
-    using kernel.measure_zero_or_one_of_measurableSet_limsup_atTop h_le h_indep ht_tail
+    using Kernel.measure_zero_or_one_of_measurableSet_limsup_atTop h_le h_indep ht_tail
 
 theorem condexp_zero_or_one_of_measurableSet_limsup_atTop [StandardBorelSpace Ω] [Nonempty Ω]
     (hm : m ≤ m0) [IsFiniteMeasure μ] (h_le : ∀ n, s n ≤ m0)
@@ -279,7 +281,7 @@ section AtBot
 
 variable [SemilatticeInf ι] [NoMinOrder ι] [Nonempty ι]
 
-theorem kernel.indep_limsup_atBot_self (h_le : ∀ n, s n ≤ m0) (h_indep : iIndep s κ μα) :
+theorem Kernel.indep_limsup_atBot_self (h_le : ∀ n, s n ≤ m0) (h_indep : iIndep s κ μα) :
     Indep (limsup s atBot) (limsup s atBot) κ μα := by
   let ns : ι → Set ι := Set.Ici
   have hnsp : ∀ i, BddBelow (ns i) := fun i => bddBelow_Ici
@@ -295,17 +297,17 @@ theorem kernel.indep_limsup_atBot_self (h_le : ∀ n, s n ≤ m0) (h_indep : iIn
 
 theorem indep_limsup_atBot_self (h_le : ∀ n, s n ≤ m0) (h_indep : iIndep s μ) :
     Indep (limsup s atBot) (limsup s atBot) μ :=
-  kernel.indep_limsup_atBot_self h_le h_indep
+  Kernel.indep_limsup_atBot_self h_le h_indep
 
 theorem condIndep_limsup_atBot_self [StandardBorelSpace Ω] [Nonempty Ω]
     (hm : m ≤ m0) [IsFiniteMeasure μ]
     (h_le : ∀ n, s n ≤ m0) (h_indep : iCondIndep m hm s μ) :
     CondIndep m (limsup s atBot) (limsup s atBot) hm μ :=
-  kernel.indep_limsup_atBot_self h_le h_indep
+  Kernel.indep_limsup_atBot_self h_le h_indep
 
 /-- **Kolmogorov's 0-1 law**, kernel version: any event in the tail σ-algebra of an independent
 sequence of sub-σ-algebras has probability 0 or 1 almost surely. -/
-theorem kernel.measure_zero_or_one_of_measurableSet_limsup_atBot (h_le : ∀ n, s n ≤ m0)
+theorem Kernel.measure_zero_or_one_of_measurableSet_limsup_atBot (h_le : ∀ n, s n ≤ m0)
     (h_indep : iIndep s κ μα) {t : Set Ω} (ht_tail : MeasurableSet[limsup s atBot] t) :
     ∀ᵐ a ∂μα, κ a t = 0 ∨ κ a t = 1 :=
   measure_eq_zero_or_one_of_indepSet_self
@@ -317,7 +319,7 @@ theorem measure_zero_or_one_of_measurableSet_limsup_atBot (h_le : ∀ n, s n ≤
     (h_indep : iIndep s μ) {t : Set Ω} (ht_tail : MeasurableSet[limsup s atBot] t) :
     μ t = 0 ∨ μ t = 1 := by
   simpa only [ae_dirac_eq, Filter.eventually_pure]
-    using kernel.measure_zero_or_one_of_measurableSet_limsup_atBot h_le h_indep ht_tail
+    using Kernel.measure_zero_or_one_of_measurableSet_limsup_atBot h_le h_indep ht_tail
 
 /-- **Kolmogorov's 0-1 law**, conditional version: any event in the tail σ-algebra of a
 conditinoally independent sequence of sub-σ-algebras has conditional probability 0 or 1. -/

--- a/Mathlib/Probability/Kernel/Basic.lean
+++ b/Mathlib/Probability/Kernel/Basic.lean
@@ -17,7 +17,7 @@ measurable sets `s` of `β`, `a ↦ κ a s` is measurable.
 ## Main definitions
 
 Classes of kernels:
-* `ProbabilityTheory.kernel α β`: kernels from `α` to `β`, defined as the `AddSubmonoid` of the
+* `ProbabilityTheory.Kernel α β`: kernels from `α` to `β`, defined as the `AddSubmonoid` of the
   measurable functions in `α → Measure β`.
 * `ProbabilityTheory.IsMarkovKernel κ`: a kernel from `α` to `β` is said to be a Markov kernel
   if for all `a : α`, `k a` is a probability measure.
@@ -30,16 +30,16 @@ Classes of kernels:
   sum of finite kernels.
 
 Particular kernels:
-* `ProbabilityTheory.kernel.deterministic (f : α → β) (hf : Measurable f)`:
+* `ProbabilityTheory.Kernel.deterministic (f : α → β) (hf : Measurable f)`:
   kernel `a ↦ Measure.dirac (f a)`.
-* `ProbabilityTheory.kernel.const α (μβ : measure β)`: constant kernel `a ↦ μβ`.
-* `ProbabilityTheory.kernel.restrict κ (hs : MeasurableSet s)`: kernel for which the image of
+* `ProbabilityTheory.Kernel.const α (μβ : measure β)`: constant kernel `a ↦ μβ`.
+* `ProbabilityTheory.Kernel.restrict κ (hs : MeasurableSet s)`: kernel for which the image of
   `a : α` is `(κ a).restrict s`.
-  Integral: `∫⁻ b, f b ∂(kernel.restrict κ hs a) = ∫⁻ b in s, f b ∂(κ a)`
+  Integral: `∫⁻ b, f b ∂(κ.restrict hs a) = ∫⁻ b in s, f b ∂(κ a)`
 
 ## Main statements
 
-* `ProbabilityTheory.kernel.ext_fun`: if `∫⁻ b, f b ∂(κ a) = ∫⁻ b, f b ∂(η a)` for all measurable
+* `ProbabilityTheory.Kernel.ext_fun`: if `∫⁻ b, f b ∂(κ a) = ∫⁻ b, f b ∂(η a)` for all measurable
   functions `f` and all `a`, then the two kernels `κ` and `η` are equal.
 
 -/
@@ -55,199 +55,203 @@ namespace ProbabilityTheory
 `κ : α → Measure β`. The measurable space structure on `MeasureTheory.Measure β` is given by
 `MeasureTheory.Measure.instMeasurableSpace`. A map `κ : α → MeasureTheory.Measure β` is measurable
 iff `∀ s : Set β, MeasurableSet s → Measurable (fun a ↦ κ a s)`. -/
-noncomputable def kernel (α β : Type*) [MeasurableSpace α] [MeasurableSpace β] :
-    AddSubmonoid (α → Measure β) where
-  carrier := Measurable
-  zero_mem' := measurable_zero
-  add_mem' hf hg := Measurable.add hf hg
-
--- Porting note: using `FunLike` instead of `CoeFun` to use `DFunLike.coe`
-instance {α β : Type*} [MeasurableSpace α] [MeasurableSpace β] :
-    FunLike (kernel α β) α (Measure β) where
-  coe := Subtype.val
-  coe_injective' := Subtype.val_injective
-
-instance kernel.instCovariantAddLE {α β : Type*} [MeasurableSpace α] [MeasurableSpace β] :
-    CovariantClass (kernel α β) (kernel α β) (· + ·) (· ≤ ·) :=
-  ⟨fun _ _ _ hμ a ↦ add_le_add_left (hμ a) _⟩
-
-noncomputable
-instance kernel.instOrderBot {α β : Type*} [MeasurableSpace α] [MeasurableSpace β] :
-    OrderBot (kernel α β) where
-  bot := 0
-  bot_le κ a := by simp only [ZeroMemClass.coe_zero, Pi.zero_apply, Measure.zero_le]
+structure Kernel (α β : Type*) [MeasurableSpace α] [MeasurableSpace β] where
+  toFun : α → Measure β
+  /-- DO NOT USE. Use `Kernel.measurable` instead. -/
+  measurable' : Measurable toFun
 
 variable {α β ι : Type*} {mα : MeasurableSpace α} {mβ : MeasurableSpace β}
 
-namespace kernel
+namespace Kernel
 
-@[simp]
-theorem coeFn_zero : ⇑(0 : kernel α β) = 0 :=
-  rfl
+instance instFunLike : FunLike (Kernel α β) α (Measure β) where
+  coe := toFun
+  coe_injective' f g h := by cases f; cases g; congr
 
-@[simp]
-theorem coeFn_add (κ η : kernel α β) : ⇑(κ + η) = κ + η :=
-  rfl
+lemma measurable (κ : Kernel α β) : Measurable κ := κ.measurable'
+
+instance instZero : Zero (Kernel α β) where zero := ⟨0, measurable_zero⟩
+noncomputable instance instAdd : Add (Kernel α β) where add κ η := ⟨κ + η, κ.2.add η.2⟩
+noncomputable instance instSMulNat : SMul ℕ (Kernel α β) where
+  smul n κ := ⟨n • κ, (measurable_const (a := n)).smul κ.2⟩
+
+@[simp, norm_cast] lemma coe_zero : ⇑(0 : Kernel α β) = 0 := rfl
+@[simp, norm_cast] lemma coe_add (κ η : Kernel α β) : ⇑(κ + η) = κ + η := rfl
+@[simp, norm_cast] lemma coe_nsmul (n : ℕ) (κ : Kernel α β) : ⇑(n • κ) = n • κ := rfl
+
+@[simp] lemma zero_apply (a : α) : (0 : Kernel α β) a = 0 := rfl
+@[simp] lemma add_apply (κ η : Kernel α β) (a : α) : (κ + η) a = κ a + η a := rfl
+@[simp] lemma nsmul_apply (n : ℕ) (κ : Kernel α β) (a : α) : (n • κ) a = n • κ a := rfl
+
+noncomputable instance instAddCommMonoid : AddCommMonoid (Kernel α β) :=
+  DFunLike.coe_injective.addCommMonoid _ coe_zero coe_add (by intros; rfl)
+
+instance instPartialOrder : PartialOrder (Kernel α β) := .lift _ DFunLike.coe_injective
+
+instance instCovariantAddLE {α β : Type*} [MeasurableSpace α] [MeasurableSpace β] :
+    CovariantClass (Kernel α β) (Kernel α β) (· + ·) (· ≤ ·) :=
+  ⟨fun _ _ _ hμ a ↦ add_le_add_left (hμ a) _⟩
+
+noncomputable
+instance instOrderBot {α β : Type*} [MeasurableSpace α] [MeasurableSpace β] :
+    OrderBot (Kernel α β) where
+  bot := 0
+  bot_le κ a := by simp only [coe_zero, Pi.zero_apply, Measure.zero_le]
 
 /-- Coercion to a function as an additive monoid homomorphism. -/
 def coeAddHom (α β : Type*) [MeasurableSpace α] [MeasurableSpace β] :
-    kernel α β →+ α → Measure β :=
-  AddSubmonoid.subtype _
+    Kernel α β →+ α → Measure β where
+  toFun := (⇑)
+  map_zero' := coe_zero
+  map_add' := coe_add
 
 @[simp]
-theorem zero_apply (a : α) : (0 : kernel α β) a = 0 :=
-  rfl
-
-@[simp]
-theorem coe_finset_sum (I : Finset ι) (κ : ι → kernel α β) : ⇑(∑ i ∈ I, κ i) = ∑ i ∈ I, ⇑(κ i) :=
+theorem coe_finset_sum (I : Finset ι) (κ : ι → Kernel α β) : ⇑(∑ i ∈ I, κ i) = ∑ i ∈ I, ⇑(κ i) :=
   map_sum (coeAddHom α β) _ _
 
-theorem finset_sum_apply (I : Finset ι) (κ : ι → kernel α β) (a : α) :
+theorem finset_sum_apply (I : Finset ι) (κ : ι → Kernel α β) (a : α) :
     (∑ i ∈ I, κ i) a = ∑ i ∈ I, κ i a := by rw [coe_finset_sum, Finset.sum_apply]
 
-theorem finset_sum_apply' (I : Finset ι) (κ : ι → kernel α β) (a : α) (s : Set β) :
+theorem finset_sum_apply' (I : Finset ι) (κ : ι → Kernel α β) (a : α) (s : Set β) :
     (∑ i ∈ I, κ i) a s = ∑ i ∈ I, κ i a s := by rw [finset_sum_apply, Measure.finset_sum_apply]
 
-end kernel
+end Kernel
 
 /-- A kernel is a Markov kernel if every measure in its image is a probability measure. -/
-class IsMarkovKernel (κ : kernel α β) : Prop where
+class IsMarkovKernel (κ : Kernel α β) : Prop where
   isProbabilityMeasure : ∀ a, IsProbabilityMeasure (κ a)
 
 /-- A kernel is finite if every measure in its image is finite, with a uniform bound. -/
-class IsFiniteKernel (κ : kernel α β) : Prop where
+class IsFiniteKernel (κ : Kernel α β) : Prop where
   exists_univ_le : ∃ C : ℝ≥0∞, C < ∞ ∧ ∀ a, κ a Set.univ ≤ C
 
 /-- A constant `C : ℝ≥0∞` such that `C < ∞` (`ProbabilityTheory.IsFiniteKernel.bound_lt_top κ`) and
-for all `a : α` and `s : Set β`, `κ a s ≤ C` (`ProbabilityTheory.kernel.measure_le_bound κ a s`).
+for all `a : α` and `s : Set β`, `κ a s ≤ C` (`ProbabilityTheory.Kernel.measure_le_bound κ a s`).
 
 Porting note (#11215): TODO: does it make sense to
 -- make `ProbabilityTheory.IsFiniteKernel.bound` the least possible bound?
 -- Should it be an `NNReal` number? -/
-noncomputable def IsFiniteKernel.bound (κ : kernel α β) [h : IsFiniteKernel κ] : ℝ≥0∞ :=
+noncomputable def IsFiniteKernel.bound (κ : Kernel α β) [h : IsFiniteKernel κ] : ℝ≥0∞ :=
   h.exists_univ_le.choose
 
-theorem IsFiniteKernel.bound_lt_top (κ : kernel α β) [h : IsFiniteKernel κ] :
+theorem IsFiniteKernel.bound_lt_top (κ : Kernel α β) [h : IsFiniteKernel κ] :
     IsFiniteKernel.bound κ < ∞ :=
   h.exists_univ_le.choose_spec.1
 
-theorem IsFiniteKernel.bound_ne_top (κ : kernel α β) [IsFiniteKernel κ] :
+theorem IsFiniteKernel.bound_ne_top (κ : Kernel α β) [IsFiniteKernel κ] :
     IsFiniteKernel.bound κ ≠ ∞ :=
   (IsFiniteKernel.bound_lt_top κ).ne
 
-theorem kernel.measure_le_bound (κ : kernel α β) [h : IsFiniteKernel κ] (a : α) (s : Set β) :
+theorem Kernel.measure_le_bound (κ : Kernel α β) [h : IsFiniteKernel κ] (a : α) (s : Set β) :
     κ a s ≤ IsFiniteKernel.bound κ :=
   (measure_mono (Set.subset_univ s)).trans (h.exists_univ_le.choose_spec.2 a)
 
 instance isFiniteKernel_zero (α β : Type*) {mα : MeasurableSpace α} {mβ : MeasurableSpace β} :
-    IsFiniteKernel (0 : kernel α β) :=
+    IsFiniteKernel (0 : Kernel α β) :=
   ⟨⟨0, ENNReal.coe_lt_top, fun _ => by
-      simp only [kernel.zero_apply, Measure.coe_zero, Pi.zero_apply, le_zero_iff]⟩⟩
+      simp only [Kernel.zero_apply, Measure.coe_zero, Pi.zero_apply, le_zero_iff]⟩⟩
 
-instance IsFiniteKernel.add (κ η : kernel α β) [IsFiniteKernel κ] [IsFiniteKernel η] :
+instance IsFiniteKernel.add (κ η : Kernel α β) [IsFiniteKernel κ] [IsFiniteKernel η] :
     IsFiniteKernel (κ + η) := by
   refine ⟨⟨IsFiniteKernel.bound κ + IsFiniteKernel.bound η,
     ENNReal.add_lt_top.mpr ⟨IsFiniteKernel.bound_lt_top κ, IsFiniteKernel.bound_lt_top η⟩,
     fun a => ?_⟩⟩
-  exact add_le_add (kernel.measure_le_bound _ _ _) (kernel.measure_le_bound _ _ _)
+  exact add_le_add (Kernel.measure_le_bound _ _ _) (Kernel.measure_le_bound _ _ _)
 
-lemma isFiniteKernel_of_le {κ ν : kernel α β} [hν : IsFiniteKernel ν] (hκν : κ ≤ ν) :
+lemma isFiniteKernel_of_le {κ ν : Kernel α β} [hν : IsFiniteKernel ν] (hκν : κ ≤ ν) :
     IsFiniteKernel κ := by
-  refine ⟨hν.bound, hν.bound_lt_top, fun a ↦ (hκν _ _).trans (kernel.measure_le_bound ν a Set.univ)⟩
+  refine ⟨hν.bound, hν.bound_lt_top, fun a ↦ (hκν _ _).trans (Kernel.measure_le_bound ν a Set.univ)⟩
 
-variable {κ : kernel α β}
+variable {κ : Kernel α β}
 
 instance IsMarkovKernel.is_probability_measure' [IsMarkovKernel κ] (a : α) :
     IsProbabilityMeasure (κ a) :=
   IsMarkovKernel.isProbabilityMeasure a
 
 instance IsFiniteKernel.isFiniteMeasure [IsFiniteKernel κ] (a : α) : IsFiniteMeasure (κ a) :=
-  ⟨(kernel.measure_le_bound κ a Set.univ).trans_lt (IsFiniteKernel.bound_lt_top κ)⟩
+  ⟨(Kernel.measure_le_bound κ a Set.univ).trans_lt (IsFiniteKernel.bound_lt_top κ)⟩
 
 instance (priority := 100) IsMarkovKernel.isFiniteKernel [IsMarkovKernel κ] :
     IsFiniteKernel κ :=
   ⟨⟨1, ENNReal.one_lt_top, fun _ => prob_le_one⟩⟩
 
-namespace kernel
+namespace Kernel
 
 @[ext]
-theorem ext {η : kernel α β} (h : ∀ a, κ a = η a) : κ = η := DFunLike.ext _ _ h
+theorem ext {η : Kernel α β} (h : ∀ a, κ a = η a) : κ = η := DFunLike.ext _ _ h
 
-theorem ext_iff {η : kernel α β} : κ = η ↔ ∀ a, κ a = η a := DFunLike.ext_iff
+theorem ext_iff {η : Kernel α β} : κ = η ↔ ∀ a, κ a = η a := DFunLike.ext_iff
 
-theorem ext_iff' {η : kernel α β} :
+theorem ext_iff' {η : Kernel α β} :
     κ = η ↔ ∀ a s, MeasurableSet s → κ a s = η a s := by
   simp_rw [ext_iff, Measure.ext_iff]
 
-theorem ext_fun {η : kernel α β} (h : ∀ a f, Measurable f → ∫⁻ b, f b ∂κ a = ∫⁻ b, f b ∂η a) :
+theorem ext_fun {η : Kernel α β} (h : ∀ a f, Measurable f → ∫⁻ b, f b ∂κ a = ∫⁻ b, f b ∂η a) :
     κ = η := by
   ext a s hs
   specialize h a (s.indicator fun _ => 1) (Measurable.indicator measurable_const hs)
   simp_rw [lintegral_indicator_const hs, one_mul] at h
   rw [h]
 
-theorem ext_fun_iff {η : kernel α β} :
+theorem ext_fun_iff {η : Kernel α β} :
     κ = η ↔ ∀ a f, Measurable f → ∫⁻ b, f b ∂κ a = ∫⁻ b, f b ∂η a :=
   ⟨fun h a f _ => by rw [h], ext_fun⟩
 
-protected theorem measurable (κ : kernel α β) : Measurable κ :=
-  κ.prop
-
-protected theorem measurable_coe (κ : kernel α β) {s : Set β} (hs : MeasurableSet s) :
+protected theorem measurable_coe (κ : Kernel α β) {s : Set β} (hs : MeasurableSet s) :
     Measurable fun a => κ a s :=
-  (Measure.measurable_coe hs).comp (kernel.measurable κ)
+  (Measure.measurable_coe hs).comp κ.measurable
 
 lemma IsFiniteKernel.integrable (μ : Measure α) [IsFiniteMeasure μ]
-    (κ : kernel α β) [IsFiniteKernel κ] {s : Set β} (hs : MeasurableSet s) :
+    (κ : Kernel α β) [IsFiniteKernel κ] {s : Set β} (hs : MeasurableSet s) :
     Integrable (fun x => (κ x s).toReal) μ := by
   refine Integrable.mono' (integrable_const (IsFiniteKernel.bound κ).toReal)
-    ((kernel.measurable_coe κ hs).ennreal_toReal.aestronglyMeasurable)
+    ((κ.measurable_coe  hs).ennreal_toReal.aestronglyMeasurable)
     (ae_of_all μ fun x => ?_)
   rw [Real.norm_eq_abs, abs_of_nonneg ENNReal.toReal_nonneg,
     ENNReal.toReal_le_toReal (measure_ne_top _ _) (IsFiniteKernel.bound_ne_top _)]
-  exact kernel.measure_le_bound _ _ _
+  exact Kernel.measure_le_bound _ _ _
 
 lemma IsMarkovKernel.integrable (μ : Measure α) [IsFiniteMeasure μ]
-    (κ : kernel α β) [IsMarkovKernel κ] {s : Set β} (hs : MeasurableSet s) :
+    (κ : Kernel α β) [IsMarkovKernel κ] {s : Set β} (hs : MeasurableSet s) :
     Integrable (fun x => (κ x s).toReal) μ :=
   IsFiniteKernel.integrable μ κ hs
 
 section Sum
 
 /-- Sum of an indexed family of kernels. -/
-protected noncomputable def sum [Countable ι] (κ : ι → kernel α β) : kernel α β where
-  val a := Measure.sum fun n => κ n a
-  property := by
+protected noncomputable def sum [Countable ι] (κ : ι → Kernel α β) : Kernel α β where
+  toFun a := Measure.sum fun n => κ n a
+  measurable' := by
     refine Measure.measurable_of_measurable_coe _ fun s hs => ?_
     simp_rw [Measure.sum_apply _ hs]
-    exact Measurable.ennreal_tsum fun n => kernel.measurable_coe (κ n) hs
+    exact Measurable.ennreal_tsum fun n => Kernel.measurable_coe (κ n) hs
 
-theorem sum_apply [Countable ι] (κ : ι → kernel α β) (a : α) :
-    kernel.sum κ a = Measure.sum fun n => κ n a :=
+theorem sum_apply [Countable ι] (κ : ι → Kernel α β) (a : α) :
+    Kernel.sum κ a = Measure.sum fun n => κ n a :=
   rfl
 
-theorem sum_apply' [Countable ι] (κ : ι → kernel α β) (a : α) {s : Set β} (hs : MeasurableSet s) :
-    kernel.sum κ a s = ∑' n, κ n a s := by rw [sum_apply κ a, Measure.sum_apply _ hs]
+theorem sum_apply' [Countable ι] (κ : ι → Kernel α β) (a : α) {s : Set β} (hs : MeasurableSet s) :
+    Kernel.sum κ a s = ∑' n, κ n a s := by rw [sum_apply κ a, Measure.sum_apply _ hs]
 
 @[simp]
-theorem sum_zero [Countable ι] : (kernel.sum fun _ : ι => (0 : kernel α β)) = 0 := by
+theorem sum_zero [Countable ι] : (Kernel.sum fun _ : ι => (0 : Kernel α β)) = 0 := by
   ext a s hs
   rw [sum_apply' _ a hs]
   simp only [zero_apply, Measure.coe_zero, Pi.zero_apply, tsum_zero]
 
-theorem sum_comm [Countable ι] (κ : ι → ι → kernel α β) :
-    (kernel.sum fun n => kernel.sum (κ n)) = kernel.sum fun m => kernel.sum fun n => κ n m := by
+theorem sum_comm [Countable ι] (κ : ι → ι → Kernel α β) :
+    (Kernel.sum fun n => Kernel.sum (κ n)) = Kernel.sum fun m => Kernel.sum fun n => κ n m := by
   ext a s; simp_rw [sum_apply]; rw [Measure.sum_comm]
 
 @[simp]
-theorem sum_fintype [Fintype ι] (κ : ι → kernel α β) : kernel.sum κ = ∑ i, κ i := by
+theorem sum_fintype [Fintype ι] (κ : ι → Kernel α β) : Kernel.sum κ = ∑ i, κ i := by
   ext a s hs
   simp only [sum_apply' κ a hs, finset_sum_apply' _ κ a s, tsum_fintype]
 
-theorem sum_add [Countable ι] (κ η : ι → kernel α β) :
-    (kernel.sum fun n => κ n + η n) = kernel.sum κ + kernel.sum η := by
+theorem sum_add [Countable ι] (κ η : ι → Kernel α β) :
+    (Kernel.sum fun n => κ n + η n) = Kernel.sum κ + Kernel.sum η := by
   ext a s hs
-  simp only [coeFn_add, Pi.add_apply, sum_apply, Measure.sum_apply _ hs, Pi.add_apply,
+  simp only [coe_add, Pi.add_apply, sum_apply, Measure.sum_apply _ hs, Pi.add_apply,
     Measure.coe_add, tsum_add ENNReal.summable ENNReal.summable]
 
 end Sum
@@ -255,8 +259,8 @@ end Sum
 section SFinite
 
 /-- A kernel is s-finite if it can be written as the sum of countably many finite kernels. -/
-class _root_.ProbabilityTheory.IsSFiniteKernel (κ : kernel α β) : Prop where
-  tsum_finite : ∃ κs : ℕ → kernel α β, (∀ n, IsFiniteKernel (κs n)) ∧ κ = kernel.sum κs
+class _root_.ProbabilityTheory.IsSFiniteKernel (κ : Kernel α β) : Prop where
+  tsum_finite : ∃ κs : ℕ → Kernel α β, (∀ n, IsFiniteKernel (κs n)) ∧ κ = Kernel.sum κs
 
 instance (priority := 100) IsFiniteKernel.isSFiniteKernel [h : IsFiniteKernel κ] :
     IsSFiniteKernel κ :=
@@ -265,35 +269,35 @@ instance (priority := 100) IsFiniteKernel.isSFiniteKernel [h : IsFiniteKernel κ
       · exact h
       · infer_instance, by
       ext a s hs
-      rw [kernel.sum_apply' _ _ hs]
+      rw [Kernel.sum_apply' _ _ hs]
       have : (fun i => ((ite (i = 0) κ 0) a) s) = fun i => ite (i = 0) (κ a s) 0 := by
         ext1 i; split_ifs <;> rfl
       rw [this, tsum_ite_eq]⟩⟩
 
-/-- A sequence of finite kernels such that `κ = ProbabilityTheory.kernel.sum (seq κ)`. See
-`ProbabilityTheory.kernel.isFiniteKernel_seq` and `ProbabilityTheory.kernel.kernel_sum_seq`. -/
-noncomputable def seq (κ : kernel α β) [h : IsSFiniteKernel κ] : ℕ → kernel α β :=
+/-- A sequence of finite kernels such that `κ = ProbabilityTheory.Kernel.sum (seq κ)`. See
+`ProbabilityTheory.Kernel.isFiniteKernel_seq` and `ProbabilityTheory.Kernel.kernel_sum_seq`. -/
+noncomputable def seq (κ : Kernel α β) [h : IsSFiniteKernel κ] : ℕ → Kernel α β :=
   h.tsum_finite.choose
 
-theorem kernel_sum_seq (κ : kernel α β) [h : IsSFiniteKernel κ] : kernel.sum (seq κ) = κ :=
+theorem kernel_sum_seq (κ : Kernel α β) [h : IsSFiniteKernel κ] : Kernel.sum (seq κ) = κ :=
   h.tsum_finite.choose_spec.2.symm
 
-theorem measure_sum_seq (κ : kernel α β) [h : IsSFiniteKernel κ] (a : α) :
-    (Measure.sum fun n => seq κ n a) = κ a := by rw [← kernel.sum_apply, kernel_sum_seq κ]
+theorem measure_sum_seq (κ : Kernel α β) [h : IsSFiniteKernel κ] (a : α) :
+    (Measure.sum fun n => seq κ n a) = κ a := by rw [← Kernel.sum_apply, kernel_sum_seq κ]
 
-instance isFiniteKernel_seq (κ : kernel α β) [h : IsSFiniteKernel κ] (n : ℕ) :
-    IsFiniteKernel (kernel.seq κ n) :=
+instance isFiniteKernel_seq (κ : Kernel α β) [h : IsSFiniteKernel κ] (n : ℕ) :
+    IsFiniteKernel (Kernel.seq κ n) :=
   h.tsum_finite.choose_spec.1 n
 
 instance IsSFiniteKernel.sFinite [IsSFiniteKernel κ] (a : α) : SFinite (κ a) :=
   ⟨⟨fun n ↦ seq κ n a, inferInstance, (measure_sum_seq κ a).symm⟩⟩
 
-instance IsSFiniteKernel.add (κ η : kernel α β) [IsSFiniteKernel κ] [IsSFiniteKernel η] :
+instance IsSFiniteKernel.add (κ η : Kernel α β) [IsSFiniteKernel κ] [IsSFiniteKernel η] :
     IsSFiniteKernel (κ + η) := by
   refine ⟨⟨fun n => seq κ n + seq η n, fun n => inferInstance, ?_⟩⟩
   rw [sum_add, kernel_sum_seq κ, kernel_sum_seq η]
 
-theorem IsSFiniteKernel.finset_sum {κs : ι → kernel α β} (I : Finset ι)
+theorem IsSFiniteKernel.finset_sum {κs : ι → Kernel α β} (I : Finset ι)
     (h : ∀ i ∈ I, IsSFiniteKernel (κs i)) : IsSFiniteKernel (∑ i ∈ I, κs i) := by
   classical
   induction' I using Finset.induction with i I hi_nmem_I h_ind h
@@ -304,21 +308,21 @@ theorem IsSFiniteKernel.finset_sum {κs : ι → kernel α β} (I : Finset ι)
       h_ind fun i hiI => h i (Finset.mem_insert_of_mem hiI)
     exact IsSFiniteKernel.add _ _
 
-theorem isSFiniteKernel_sum_of_denumerable [Denumerable ι] {κs : ι → kernel α β}
-    (hκs : ∀ n, IsSFiniteKernel (κs n)) : IsSFiniteKernel (kernel.sum κs) := by
+theorem isSFiniteKernel_sum_of_denumerable [Denumerable ι] {κs : ι → Kernel α β}
+    (hκs : ∀ n, IsSFiniteKernel (κs n)) : IsSFiniteKernel (Kernel.sum κs) := by
   let e : ℕ ≃ ι × ℕ := (Denumerable.eqv (ι × ℕ)).symm
   refine ⟨⟨fun n => seq (κs (e n).1) (e n).2, inferInstance, ?_⟩⟩
-  have hκ_eq : kernel.sum κs = kernel.sum fun n => kernel.sum (seq (κs n)) := by
+  have hκ_eq : Kernel.sum κs = Kernel.sum fun n => Kernel.sum (seq (κs n)) := by
     simp_rw [kernel_sum_seq]
   ext a s hs
   rw [hκ_eq]
-  simp_rw [kernel.sum_apply' _ _ hs]
+  simp_rw [Kernel.sum_apply' _ _ hs]
   change (∑' i, ∑' m, seq (κs i) m a s) = ∑' n, (fun im : ι × ℕ => seq (κs im.fst) im.snd a s) (e n)
   rw [e.tsum_eq (fun im : ι × ℕ => seq (κs im.fst) im.snd a s),
     tsum_prod' ENNReal.summable fun _ => ENNReal.summable]
 
-theorem isSFiniteKernel_sum [Countable ι] {κs : ι → kernel α β}
-    (hκs : ∀ n, IsSFiniteKernel (κs n)) : IsSFiniteKernel (kernel.sum κs) := by
+theorem isSFiniteKernel_sum [Countable ι] {κs : ι → Kernel α β}
+    (hκs : ∀ n, IsSFiniteKernel (κs n)) : IsSFiniteKernel (Kernel.sum κs) := by
   cases fintypeOrInfinite ι
   · rw [sum_fintype]
     exact IsSFiniteKernel.finset_sum Finset.univ fun i _ => hκs i
@@ -329,10 +333,10 @@ end SFinite
 
 section Deterministic
 
-/-- Kernel which to `a` associates the dirac measure at `f a`. This is a Markov kernel. -/
-noncomputable def deterministic (f : α → β) (hf : Measurable f) : kernel α β where
-  val a := Measure.dirac (f a)
-  property := by
+/-- Kernel which to `a` associates the dirac measure at `f a`. This is a Markov Kernel. -/
+noncomputable def deterministic (f : α → β) (hf : Measurable f) : Kernel α β where
+  toFun a := Measure.dirac (f a)
+  measurable' := by
     refine Measure.measurable_of_measurable_coe _ fun s hs => ?_
     simp_rw [Measure.dirac_apply' _ hs]
     exact measurable_one.indicator (hf hs)
@@ -352,18 +356,18 @@ instance isMarkovKernel_deterministic {f : α → β} (hf : Measurable f) :
   ⟨fun a => by rw [deterministic_apply hf]; infer_instance⟩
 
 theorem lintegral_deterministic' {f : β → ℝ≥0∞} {g : α → β} {a : α} (hg : Measurable g)
-    (hf : Measurable f) : ∫⁻ x, f x ∂kernel.deterministic g hg a = f (g a) := by
-  rw [kernel.deterministic_apply, lintegral_dirac' _ hf]
+    (hf : Measurable f) : ∫⁻ x, f x ∂deterministic g hg a = f (g a) := by
+  rw [deterministic_apply, lintegral_dirac' _ hf]
 
 @[simp]
 theorem lintegral_deterministic {f : β → ℝ≥0∞} {g : α → β} {a : α} (hg : Measurable g)
-    [MeasurableSingletonClass β] : ∫⁻ x, f x ∂kernel.deterministic g hg a = f (g a) := by
-  rw [kernel.deterministic_apply, lintegral_dirac (g a) f]
+    [MeasurableSingletonClass β] : ∫⁻ x, f x ∂deterministic g hg a = f (g a) := by
+  rw [deterministic_apply, lintegral_dirac (g a) f]
 
 theorem setLIntegral_deterministic' {f : β → ℝ≥0∞} {g : α → β} {a : α} (hg : Measurable g)
     (hf : Measurable f) {s : Set β} (hs : MeasurableSet s) [Decidable (g a ∈ s)] :
-    ∫⁻ x in s, f x ∂kernel.deterministic g hg a = if g a ∈ s then f (g a) else 0 := by
-  rw [kernel.deterministic_apply, setLIntegral_dirac' hf hs]
+    ∫⁻ x in s, f x ∂deterministic g hg a = if g a ∈ s then f (g a) else 0 := by
+  rw [deterministic_apply, setLIntegral_dirac' hf hs]
 
 @[deprecated (since := "2024-06-29")]
 alias set_lintegral_deterministic' := setLIntegral_deterministic'
@@ -371,28 +375,28 @@ alias set_lintegral_deterministic' := setLIntegral_deterministic'
 @[simp]
 theorem setLIntegral_deterministic {f : β → ℝ≥0∞} {g : α → β} {a : α} (hg : Measurable g)
     [MeasurableSingletonClass β] (s : Set β) [Decidable (g a ∈ s)] :
-    ∫⁻ x in s, f x ∂kernel.deterministic g hg a = if g a ∈ s then f (g a) else 0 := by
-  rw [kernel.deterministic_apply, setLIntegral_dirac f s]
+    ∫⁻ x in s, f x ∂deterministic g hg a = if g a ∈ s then f (g a) else 0 := by
+  rw [deterministic_apply, setLIntegral_dirac f s]
 
 @[deprecated (since := "2024-06-29")]
 alias set_lintegral_deterministic := setLIntegral_deterministic
 
 theorem integral_deterministic' {E : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E]
     [CompleteSpace E] {f : β → E} {g : α → β} {a : α} (hg : Measurable g)
-    (hf : StronglyMeasurable f) : ∫ x, f x ∂kernel.deterministic g hg a = f (g a) := by
-  rw [kernel.deterministic_apply, integral_dirac' _ _ hf]
+    (hf : StronglyMeasurable f) : ∫ x, f x ∂deterministic g hg a = f (g a) := by
+  rw [deterministic_apply, integral_dirac' _ _ hf]
 
 @[simp]
 theorem integral_deterministic {E : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E]
     [CompleteSpace E] {f : β → E} {g : α → β} {a : α} (hg : Measurable g)
-    [MeasurableSingletonClass β] : ∫ x, f x ∂kernel.deterministic g hg a = f (g a) := by
-  rw [kernel.deterministic_apply, integral_dirac _ (g a)]
+    [MeasurableSingletonClass β] : ∫ x, f x ∂deterministic g hg a = f (g a) := by
+  rw [deterministic_apply, integral_dirac _ (g a)]
 
 theorem setIntegral_deterministic' {E : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E]
     [CompleteSpace E] {f : β → E} {g : α → β} {a : α} (hg : Measurable g)
     (hf : StronglyMeasurable f) {s : Set β} (hs : MeasurableSet s) [Decidable (g a ∈ s)] :
-    ∫ x in s, f x ∂kernel.deterministic g hg a = if g a ∈ s then f (g a) else 0 := by
-  rw [kernel.deterministic_apply, setIntegral_dirac' hf _ hs]
+    ∫ x in s, f x ∂deterministic g hg a = if g a ∈ s then f (g a) else 0 := by
+  rw [deterministic_apply, setIntegral_dirac' hf _ hs]
 
 @[deprecated (since := "2024-04-17")]
 alias set_integral_deterministic' := setIntegral_deterministic'
@@ -401,8 +405,8 @@ alias set_integral_deterministic' := setIntegral_deterministic'
 theorem setIntegral_deterministic {E : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E]
     [CompleteSpace E] {f : β → E} {g : α → β} {a : α} (hg : Measurable g)
     [MeasurableSingletonClass β] (s : Set β) [Decidable (g a ∈ s)] :
-    ∫ x in s, f x ∂kernel.deterministic g hg a = if g a ∈ s then f (g a) else 0 := by
-  rw [kernel.deterministic_apply, setIntegral_dirac f _ s]
+    ∫ x in s, f x ∂deterministic g hg a = if g a ∈ s then f (g a) else 0 := by
+  rw [deterministic_apply, setIntegral_dirac f _ s]
 
 @[deprecated (since := "2024-04-17")]
 alias set_integral_deterministic := setIntegral_deterministic
@@ -413,25 +417,25 @@ section Const
 
 /-- Constant kernel, which always returns the same measure. -/
 def const (α : Type*) {β : Type*} [MeasurableSpace α] {_ : MeasurableSpace β} (μβ : Measure β) :
-    kernel α β where
-  val _ := μβ
-  property := measurable_const
+    Kernel α β where
+  toFun _ := μβ
+  measurable' := measurable_const
 
 @[simp]
 theorem const_apply (μβ : Measure β) (a : α) : const α μβ a = μβ :=
   rfl
 
 @[simp]
-lemma const_zero : kernel.const α (0 : Measure β) = 0 := by
-  ext x s _; simp [kernel.const_apply]
+lemma const_zero : const α (0 : Measure β) = 0 := by
+  ext x s _; simp [const_apply]
 
 lemma const_add (β : Type*) [MeasurableSpace β] (μ ν : Measure α) :
     const β (μ + ν) = const β μ + const β ν := by ext; simp
 
 lemma sum_const [Countable ι] (μ : ι → Measure β) :
-    kernel.sum (fun n ↦ const α (μ n)) = const α (Measure.sum μ) := by
+    Kernel.sum (fun n ↦ const α (μ n)) = const α (Measure.sum μ) := by
   ext x s hs
-  rw [const_apply, Measure.sum_apply _ hs, kernel.sum_apply' _ _ hs]
+  rw [const_apply, Measure.sum_apply _ hs, Kernel.sum_apply' _ _ hs]
   simp only [const_apply]
 
 instance isFiniteKernel_const {μβ : Measure β} [IsFiniteMeasure μβ] :
@@ -448,24 +452,24 @@ instance isMarkovKernel_const {μβ : Measure β} [hμβ : IsProbabilityMeasure 
 
 @[simp]
 theorem lintegral_const {f : β → ℝ≥0∞} {μ : Measure β} {a : α} :
-    ∫⁻ x, f x ∂kernel.const α μ a = ∫⁻ x, f x ∂μ := by rw [kernel.const_apply]
+    ∫⁻ x, f x ∂const α μ a = ∫⁻ x, f x ∂μ := by rw [const_apply]
 
 @[simp]
 theorem setLIntegral_const {f : β → ℝ≥0∞} {μ : Measure β} {a : α} {s : Set β} :
-    ∫⁻ x in s, f x ∂kernel.const α μ a = ∫⁻ x in s, f x ∂μ := by rw [kernel.const_apply]
+    ∫⁻ x in s, f x ∂const α μ a = ∫⁻ x in s, f x ∂μ := by rw [const_apply]
 
 @[deprecated (since := "2024-06-29")]
 alias set_lintegral_const := setLIntegral_const
 
 @[simp]
 theorem integral_const {E : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E]
-    {f : β → E} {μ : Measure β} {a : α} : ∫ x, f x ∂kernel.const α μ a = ∫ x, f x ∂μ := by
-  rw [kernel.const_apply]
+    {f : β → E} {μ : Measure β} {a : α} : ∫ x, f x ∂const α μ a = ∫ x, f x ∂μ := by
+  rw [const_apply]
 
 @[simp]
 theorem setIntegral_const {E : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E]
     {f : β → E} {μ : Measure β} {a : α} {s : Set β} :
-    ∫ x in s, f x ∂kernel.const α μ a = ∫ x in s, f x ∂μ := by rw [kernel.const_apply]
+    ∫ x in s, f x ∂const α μ a = ∫ x in s, f x ∂μ := by rw [const_apply]
 
 @[deprecated (since := "2024-04-17")]
 alias set_integral_const := setIntegral_const
@@ -473,44 +477,44 @@ alias set_integral_const := setIntegral_const
 end Const
 
 /-- In a countable space with measurable singletons, every function `α → MeasureTheory.Measure β`
-defines a kernel. -/
+defines a Kernel. -/
 def ofFunOfCountable [MeasurableSpace α] {_ : MeasurableSpace β} [Countable α]
-    [MeasurableSingletonClass α] (f : α → Measure β) : kernel α β where
-  val := f
-  property := measurable_of_countable f
+    [MeasurableSingletonClass α] (f : α → Measure β) : Kernel α β where
+  toFun := f
+  measurable' := measurable_of_countable f
 
 section Restrict
 
 variable {s t : Set β}
 
 /-- Kernel given by the restriction of the measures in the image of a kernel to a set. -/
-protected noncomputable def restrict (κ : kernel α β) (hs : MeasurableSet s) : kernel α β where
-  val a := (κ a).restrict s
-  property := by
+protected noncomputable def restrict (κ : Kernel α β) (hs : MeasurableSet s) : Kernel α β where
+  toFun a := (κ a).restrict s
+  measurable' := by
     refine Measure.measurable_of_measurable_coe _ fun t ht => ?_
     simp_rw [Measure.restrict_apply ht]
-    exact kernel.measurable_coe κ (ht.inter hs)
+    exact Kernel.measurable_coe κ (ht.inter hs)
 
-theorem restrict_apply (κ : kernel α β) (hs : MeasurableSet s) (a : α) :
-    kernel.restrict κ hs a = (κ a).restrict s :=
+theorem restrict_apply (κ : Kernel α β) (hs : MeasurableSet s) (a : α) :
+    κ.restrict hs a = (κ a).restrict s :=
   rfl
 
-theorem restrict_apply' (κ : kernel α β) (hs : MeasurableSet s) (a : α) (ht : MeasurableSet t) :
-    kernel.restrict κ hs a t = (κ a) (t ∩ s) := by
+theorem restrict_apply' (κ : Kernel α β) (hs : MeasurableSet s) (a : α) (ht : MeasurableSet t) :
+    κ.restrict hs a t = (κ a) (t ∩ s) := by
   rw [restrict_apply κ hs a, Measure.restrict_apply ht]
 
 @[simp]
-theorem restrict_univ : kernel.restrict κ MeasurableSet.univ = κ := by
+theorem restrict_univ : κ.restrict MeasurableSet.univ = κ := by
   ext1 a
-  rw [kernel.restrict_apply, Measure.restrict_univ]
+  rw [Kernel.restrict_apply, Measure.restrict_univ]
 
 @[simp]
-theorem lintegral_restrict (κ : kernel α β) (hs : MeasurableSet s) (a : α) (f : β → ℝ≥0∞) :
-    ∫⁻ b, f b ∂kernel.restrict κ hs a = ∫⁻ b in s, f b ∂κ a := by rw [restrict_apply]
+theorem lintegral_restrict (κ : Kernel α β) (hs : MeasurableSet s) (a : α) (f : β → ℝ≥0∞) :
+    ∫⁻ b, f b ∂κ.restrict hs a = ∫⁻ b in s, f b ∂κ a := by rw [restrict_apply]
 
 @[simp]
-theorem setLIntegral_restrict (κ : kernel α β) (hs : MeasurableSet s) (a : α) (f : β → ℝ≥0∞)
-    (t : Set β) : ∫⁻ b in t, f b ∂kernel.restrict κ hs a = ∫⁻ b in t ∩ s, f b ∂κ a := by
+theorem setLIntegral_restrict (κ : Kernel α β) (hs : MeasurableSet s) (a : α) (f : β → ℝ≥0∞)
+    (t : Set β) : ∫⁻ b in t, f b ∂κ.restrict hs a = ∫⁻ b in t ∩ s, f b ∂κ a := by
   rw [restrict_apply, Measure.restrict_restrict' hs]
 
 @[deprecated (since := "2024-06-29")]
@@ -519,21 +523,21 @@ alias set_lintegral_restrict := setLIntegral_restrict
 @[simp]
 theorem setIntegral_restrict {E : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E]
     {f : β → E} {a : α} (hs : MeasurableSet s) (t : Set β) :
-    ∫ x in t, f x ∂kernel.restrict κ hs a = ∫ x in t ∩ s, f x ∂κ a := by
+    ∫ x in t, f x ∂κ.restrict hs a = ∫ x in t ∩ s, f x ∂κ a := by
   rw [restrict_apply, Measure.restrict_restrict' hs]
 
 @[deprecated (since := "2024-04-17")]
 alias set_integral_restrict := setIntegral_restrict
 
-instance IsFiniteKernel.restrict (κ : kernel α β) [IsFiniteKernel κ] (hs : MeasurableSet s) :
-    IsFiniteKernel (kernel.restrict κ hs) := by
+instance IsFiniteKernel.restrict (κ : Kernel α β) [IsFiniteKernel κ] (hs : MeasurableSet s) :
+    IsFiniteKernel (κ.restrict hs) := by
   refine ⟨⟨IsFiniteKernel.bound κ, IsFiniteKernel.bound_lt_top κ, fun a => ?_⟩⟩
   rw [restrict_apply' κ hs a MeasurableSet.univ]
   exact measure_le_bound κ a _
 
-instance IsSFiniteKernel.restrict (κ : kernel α β) [IsSFiniteKernel κ] (hs : MeasurableSet s) :
-    IsSFiniteKernel (kernel.restrict κ hs) := by
-  refine ⟨⟨fun n => kernel.restrict (seq κ n) hs, inferInstance, ?_⟩⟩
+instance IsSFiniteKernel.restrict (κ : Kernel α β) [IsSFiniteKernel κ] (hs : MeasurableSet s) :
+    IsSFiniteKernel (κ.restrict hs) := by
+  refine ⟨⟨fun n => Kernel.restrict (seq κ n) hs, inferInstance, ?_⟩⟩
   ext1 a
   simp_rw [sum_apply, restrict_apply, ← Measure.restrict_sum _ hs, ← sum_apply, kernel_sum_seq]
 
@@ -544,45 +548,45 @@ section ComapRight
 variable {γ : Type*} {mγ : MeasurableSpace γ} {f : γ → β}
 
 /-- Kernel with value `(κ a).comap f`, for a measurable embedding `f`. That is, for a measurable set
-`t : Set β`, `ProbabilityTheory.kernel.comapRight κ hf a t = κ a (f '' t)`. -/
-noncomputable def comapRight (κ : kernel α β) (hf : MeasurableEmbedding f) : kernel α γ where
-  val a := (κ a).comap f
-  property := by
+`t : Set β`, `ProbabilityTheory.Kernel.comapRight κ hf a t = κ a (f '' t)`. -/
+noncomputable def comapRight (κ : Kernel α β) (hf : MeasurableEmbedding f) : Kernel α γ where
+  toFun a := (κ a).comap f
+  measurable' := by
     refine Measure.measurable_measure.mpr fun t ht => ?_
     have : (fun a => Measure.comap f (κ a) t) = fun a => κ a (f '' t) := by
       ext1 a
       rw [Measure.comap_apply _ hf.injective _ _ ht]
       exact fun s' hs' ↦ hf.measurableSet_image.mpr hs'
     rw [this]
-    exact kernel.measurable_coe _ (hf.measurableSet_image.mpr ht)
+    exact Kernel.measurable_coe _ (hf.measurableSet_image.mpr ht)
 
-theorem comapRight_apply (κ : kernel α β) (hf : MeasurableEmbedding f) (a : α) :
+theorem comapRight_apply (κ : Kernel α β) (hf : MeasurableEmbedding f) (a : α) :
     comapRight κ hf a = Measure.comap f (κ a) :=
   rfl
 
-theorem comapRight_apply' (κ : kernel α β) (hf : MeasurableEmbedding f) (a : α) {t : Set γ}
+theorem comapRight_apply' (κ : Kernel α β) (hf : MeasurableEmbedding f) (a : α) {t : Set γ}
     (ht : MeasurableSet t) : comapRight κ hf a t = κ a (f '' t) := by
   rw [comapRight_apply,
     Measure.comap_apply _ hf.injective (fun s => hf.measurableSet_image.mpr) _ ht]
 
 @[simp]
-lemma comapRight_id (κ : kernel α β) : comapRight κ MeasurableEmbedding.id = κ := by
+lemma comapRight_id (κ : Kernel α β) : comapRight κ MeasurableEmbedding.id = κ := by
   ext _ _ hs; rw [comapRight_apply' _ _ _ hs]; simp
 
-theorem IsMarkovKernel.comapRight (κ : kernel α β) (hf : MeasurableEmbedding f)
+theorem IsMarkovKernel.comapRight (κ : Kernel α β) (hf : MeasurableEmbedding f)
     (hκ : ∀ a, κ a (Set.range f) = 1) : IsMarkovKernel (comapRight κ hf) := by
   refine ⟨fun a => ⟨?_⟩⟩
   rw [comapRight_apply' κ hf a MeasurableSet.univ]
   simp only [Set.image_univ, Subtype.range_coe_subtype, Set.setOf_mem_eq]
   exact hκ a
 
-instance IsFiniteKernel.comapRight (κ : kernel α β) [IsFiniteKernel κ]
+instance IsFiniteKernel.comapRight (κ : Kernel α β) [IsFiniteKernel κ]
     (hf : MeasurableEmbedding f) : IsFiniteKernel (comapRight κ hf) := by
   refine ⟨⟨IsFiniteKernel.bound κ, IsFiniteKernel.bound_lt_top κ, fun a => ?_⟩⟩
   rw [comapRight_apply' κ hf a .univ]
   exact measure_le_bound κ a _
 
-protected instance IsSFiniteKernel.comapRight (κ : kernel α β) [IsSFiniteKernel κ]
+protected instance IsSFiniteKernel.comapRight (κ : Kernel α β) [IsSFiniteKernel κ]
     (hf : MeasurableEmbedding f) : IsSFiniteKernel (comapRight κ hf) := by
   refine ⟨⟨fun n => comapRight (seq κ n) hf, inferInstance, ?_⟩⟩
   ext1 a
@@ -602,13 +606,13 @@ end ComapRight
 
 section Piecewise
 
-variable {η : kernel α β} {s : Set α} {hs : MeasurableSet s} [DecidablePred (· ∈ s)]
+variable {η : Kernel α β} {s : Set α} {hs : MeasurableSet s} [DecidablePred (· ∈ s)]
 
-/-- `ProbabilityTheory.kernel.piecewise hs κ η` is the kernel equal to `κ` on the measurable set `s`
+/-- `ProbabilityTheory.Kernel.piecewise hs κ η` is the kernel equal to `κ` on the measurable set `s`
 and to `η` on its complement. -/
-def piecewise (hs : MeasurableSet s) (κ η : kernel α β) : kernel α β where
-  val a := if a ∈ s then κ a else η a
-  property := Measurable.piecewise hs (kernel.measurable _) (kernel.measurable _)
+def piecewise (hs : MeasurableSet s) (κ η : Kernel α β) : Kernel α β where
+  toFun a := if a ∈ s then κ a else η a
+  measurable' := κ.measurable.piecewise hs η.measurable
 
 theorem piecewise_apply (a : α) : piecewise hs κ η a = if a ∈ s then κ a else η a :=
   rfl
@@ -633,7 +637,7 @@ protected instance IsSFiniteKernel.piecewise [IsSFiniteKernel κ] [IsSFiniteKern
     IsSFiniteKernel (piecewise hs κ η) := by
   refine ⟨⟨fun n => piecewise hs (seq κ n) (seq η n), inferInstance, ?_⟩⟩
   ext1 a
-  simp_rw [sum_apply, kernel.piecewise_apply]
+  simp_rw [sum_apply, Kernel.piecewise_apply]
   split_ifs <;> exact (measure_sum_seq _ a).symm
 
 theorem lintegral_piecewise (a : α) (g : β → ℝ≥0∞) :
@@ -663,7 +667,5 @@ theorem setIntegral_piecewise {E : Type*} [NormedAddCommGroup E] [NormedSpace �
 alias set_integral_piecewise := setIntegral_piecewise
 
 end Piecewise
-
-end kernel
-
+end Kernel
 end ProbabilityTheory

--- a/Mathlib/Probability/Kernel/Basic.lean
+++ b/Mathlib/Probability/Kernel/Basic.lean
@@ -340,7 +340,7 @@ end SFinite
 
 section Deterministic
 
-/-- Kernel which to `a` associates the dirac measure at `f a`. This is a Markov Kernel. -/
+/-- Kernel which to `a` associates the dirac measure at `f a`. This is a Markov kernel. -/
 noncomputable def deterministic (f : α → β) (hf : Measurable f) : Kernel α β where
   toFun a := Measure.dirac (f a)
   measurable' := by
@@ -484,7 +484,7 @@ alias set_integral_const := setIntegral_const
 end Const
 
 /-- In a countable space with measurable singletons, every function `α → MeasureTheory.Measure β`
-defines a Kernel. -/
+defines a kernel. -/
 def ofFunOfCountable [MeasurableSpace α] {_ : MeasurableSpace β} [Countable α]
     [MeasurableSingletonClass α] (f : α → Measure β) : Kernel α β where
   toFun := f

--- a/Mathlib/Probability/Kernel/Basic.lean
+++ b/Mathlib/Probability/Kernel/Basic.lean
@@ -60,6 +60,8 @@ structure Kernel (α β : Type*) [MeasurableSpace α] [MeasurableSpace β] where
   /-- DO NOT USE. Use `Kernel.measurable` instead. -/
   measurable' : Measurable toFun
 
+@[deprecated (since := "2024-07-22")] alias kernel := Kernel
+
 variable {α β ι : Type*} {mα : MeasurableSpace α} {mβ : MeasurableSpace β}
 
 namespace Kernel

--- a/Mathlib/Probability/Kernel/Basic.lean
+++ b/Mathlib/Probability/Kernel/Basic.lean
@@ -17,8 +17,7 @@ measurable sets `s` of `β`, `a ↦ κ a s` is measurable.
 ## Main definitions
 
 Classes of kernels:
-* `ProbabilityTheory.Kernel α β`: kernels from `α` to `β`, defined as the `AddSubmonoid` of the
-  measurable functions in `α → Measure β`.
+* `ProbabilityTheory.Kernel α β`: kernels from `α` to `β`.
 * `ProbabilityTheory.IsMarkovKernel κ`: a kernel from `α` to `β` is said to be a Markov kernel
   if for all `a : α`, `k a` is a probability measure.
 * `ProbabilityTheory.IsFiniteKernel κ`: a kernel from `α` to `β` is said to be finite if there
@@ -56,8 +55,14 @@ namespace ProbabilityTheory
 `MeasureTheory.Measure.instMeasurableSpace`. A map `κ : α → MeasureTheory.Measure β` is measurable
 iff `∀ s : Set β, MeasurableSet s → Measurable (fun a ↦ κ a s)`. -/
 structure Kernel (α β : Type*) [MeasurableSpace α] [MeasurableSpace β] where
+  /-- The underlying function of a kernel.
+
+  Do not use this function directly. Instead use the coercion coming from the `DFunLike` 
+  instance. -/
   toFun : α → Measure β
-  /-- DO NOT USE. Use `Kernel.measurable` instead. -/
+  /-- A kernel is a measurable map.
+
+  Do not use this lemma directly. Use `Kernel.measurable` instead. -/
   measurable' : Measurable toFun
 
 @[deprecated (since := "2024-07-22")] alias kernel := Kernel

--- a/Mathlib/Probability/Kernel/Basic.lean
+++ b/Mathlib/Probability/Kernel/Basic.lean
@@ -57,7 +57,7 @@ iff `∀ s : Set β, MeasurableSet s → Measurable (fun a ↦ κ a s)`. -/
 structure Kernel (α β : Type*) [MeasurableSpace α] [MeasurableSpace β] where
   /-- The underlying function of a kernel.
 
-  Do not use this function directly. Instead use the coercion coming from the `DFunLike` 
+  Do not use this function directly. Instead use the coercion coming from the `DFunLike`
   instance. -/
   toFun : α → Measure β
   /-- A kernel is a measurable map.

--- a/Mathlib/Probability/Kernel/Composition.lean
+++ b/Mathlib/Probability/Kernel/Composition.lean
@@ -588,7 +588,7 @@ variable {γ δ : Type*} {mγ : MeasurableSpace γ} {mδ : MeasurableSpace δ} {
 /-- The pushforward of a kernel along a measurable function.
 We include measurability in the assumptions instead of using junk values
 to make sure that typeclass inference can infer that the `map` of a Markov kernel
-is again a Markov Kernel. -/
+is again a Markov kernel. -/
 noncomputable def map (κ : Kernel α β) (f : β → γ) (hf : Measurable f) : Kernel α γ where
   toFun a := (κ a).map f
   measurable' := (Measure.measurable_map _ hf).comp (Kernel.measurable κ)
@@ -643,7 +643,7 @@ lemma map_const (μ : Measure α) {f : α → β} (hf : Measurable f) :
 /-- Pullback of a kernel, such that for each set s `comap κ g hg c s = κ (g c) s`.
 We include measurability in the assumptions instead of using junk values
 to make sure that typeclass inference can infer that the `comap` of a Markov kernel
-is again a Markov Kernel. -/
+is again a Markov kernel. -/
 def comap (κ : Kernel α β) (g : γ → α) (hg : Measurable g) : Kernel γ β where
   toFun a := κ (g a)
   measurable' := κ.measurable.comp hg

--- a/Mathlib/Probability/Kernel/Composition.lean
+++ b/Mathlib/Probability/Kernel/Composition.lean
@@ -9,16 +9,16 @@ import Mathlib.Probability.Kernel.MeasurableIntegral
 # Product and composition of kernels
 
 We define
-* the composition-product `κ ⊗ₖ η` of two s-finite kernels `κ : kernel α β` and
-  `η : kernel (α × β) γ`, a kernel from `α` to `β × γ`.
+* the composition-product `κ ⊗ₖ η` of two s-finite kernels `κ : Kernel α β` and
+  `η : Kernel (α × β) γ`, a kernel from `α` to `β × γ`.
 * the map and comap of a kernel along a measurable function.
-* the composition `η ∘ₖ κ` of kernels `κ : kernel α β` and `η : kernel β γ`, kernel from `α` to
+* the composition `η ∘ₖ κ` of kernels `κ : Kernel α β` and `η : Kernel β γ`, kernel from `α` to
   `γ`.
-* the product `κ ×ₖ η` of s-finite kernels `κ : kernel α β` and `η : kernel α γ`,
+* the product `κ ×ₖ η` of s-finite kernels `κ : Kernel α β` and `η : Kernel α γ`,
   a kernel from `α` to `β × γ`.
 
 A note on names:
-The composition-product `kernel α β → kernel (α × β) γ → kernel α (β × γ)` is named composition in
+The composition-product `Kernel α β → Kernel (α × β) γ → Kernel α (β × γ)` is named composition in
 [kallenberg2021] and product on the wikipedia article on transition kernels.
 Most papers studying categories of kernels call composition the map we call composition. We adopt
 that convention because it fits better with the use of the name `comp` elsewhere in mathlib.
@@ -26,17 +26,17 @@ that convention because it fits better with the use of the name `comp` elsewhere
 ## Main definitions
 
 Kernels built from other kernels:
-* `compProd (κ : kernel α β) (η : kernel (α × β) γ) : kernel α (β × γ)`: composition-product of 2
+* `compProd (κ : Kernel α β) (η : Kernel (α × β) γ) : Kernel α (β × γ)`: composition-product of 2
   s-finite kernels. We define a notation `κ ⊗ₖ η = compProd κ η`.
   `∫⁻ bc, f bc ∂((κ ⊗ₖ η) a) = ∫⁻ b, ∫⁻ c, f (b, c) ∂(η (a, b)) ∂(κ a)`
-* `map (κ : kernel α β) (f : β → γ) (hf : Measurable f) : kernel α γ`
+* `map (κ : Kernel α β) (f : β → γ) (hf : Measurable f) : Kernel α γ`
   `∫⁻ c, g c ∂(map κ f hf a) = ∫⁻ b, g (f b) ∂(κ a)`
-* `comap (κ : kernel α β) (f : γ → α) (hf : Measurable f) : kernel γ β`
+* `comap (κ : Kernel α β) (f : γ → α) (hf : Measurable f) : Kernel γ β`
   `∫⁻ b, g b ∂(comap κ f hf c) = ∫⁻ b, g b ∂(κ (f c))`
-* `comp (η : kernel β γ) (κ : kernel α β) : kernel α γ`: composition of 2 kernels.
+* `comp (η : Kernel β γ) (κ : Kernel α β) : Kernel α γ`: composition of 2 kernels.
   We define a notation `η ∘ₖ κ = comp η κ`.
   `∫⁻ c, g c ∂((η ∘ₖ κ) a) = ∫⁻ b, ∫⁻ c, g c ∂(η b) ∂(κ a)`
-* `prod (κ : kernel α β) (η : kernel α γ) : kernel α (β × γ)`: product of 2 s-finite kernels.
+* `prod (κ : Kernel α β) (η : Kernel α γ) : Kernel α (β × γ)`: product of 2 s-finite kernels.
   `∫⁻ bc, f bc ∂((κ ×ₖ η) a) = ∫⁻ b, ∫⁻ c, f (b, c) ∂(η a) ∂(κ a)`
 
 ## Main statements
@@ -50,9 +50,9 @@ Kernels built from other kernels:
 
 ## Notations
 
-* `κ ⊗ₖ η = ProbabilityTheory.kernel.compProd κ η`
-* `η ∘ₖ κ = ProbabilityTheory.kernel.comp η κ`
-* `κ ×ₖ η = ProbabilityTheory.kernel.prod κ η`
+* `κ ⊗ₖ η = ProbabilityTheory.Kernel.compProd κ η`
+* `η ∘ₖ κ = ProbabilityTheory.Kernel.comp η κ`
+* `κ ×ₖ η = ProbabilityTheory.Kernel.prod κ η`
 
 -/
 
@@ -63,7 +63,7 @@ open scoped ENNReal
 
 namespace ProbabilityTheory
 
-namespace kernel
+namespace Kernel
 
 variable {α β ι : Type*} {mα : MeasurableSpace α} {mβ : MeasurableSpace β}
 
@@ -73,7 +73,7 @@ section CompositionProduct
 ### Composition-Product of kernels
 
 We define a kernel composition-product
-`compProd : kernel α β → kernel (α × β) γ → kernel α (β × γ)`.
+`compProd : Kernel α β → Kernel (α × β) γ → Kernel α (β × γ)`.
 -/
 
 
@@ -81,18 +81,18 @@ variable {γ : Type*} {mγ : MeasurableSpace γ} {s : Set (β × γ)}
 
 /-- Auxiliary function for the definition of the composition-product of two kernels.
 For all `a : α`, `compProdFun κ η a` is a countably additive function with value zero on the empty
-set, and the composition-product of kernels is defined in `kernel.compProd` through
+set, and the composition-product of kernels is defined in `Kernel.compProd` through
 `Measure.ofMeasurable`. -/
-noncomputable def compProdFun (κ : kernel α β) (η : kernel (α × β) γ) (a : α) (s : Set (β × γ)) :
+noncomputable def compProdFun (κ : Kernel α β) (η : Kernel (α × β) γ) (a : α) (s : Set (β × γ)) :
     ℝ≥0∞ :=
   ∫⁻ b, η (a, b) {c | (b, c) ∈ s} ∂κ a
 
-theorem compProdFun_empty (κ : kernel α β) (η : kernel (α × β) γ) (a : α) :
+theorem compProdFun_empty (κ : Kernel α β) (η : Kernel (α × β) γ) (a : α) :
     compProdFun κ η a ∅ = 0 := by
   simp only [compProdFun, Set.mem_empty_iff_false, Set.setOf_false, measure_empty,
     MeasureTheory.lintegral_const, zero_mul]
 
-theorem compProdFun_iUnion (κ : kernel α β) (η : kernel (α × β) γ) [IsSFiniteKernel η] (a : α)
+theorem compProdFun_iUnion (κ : Kernel α β) (η : Kernel (α × β) γ) [IsSFiniteKernel η] (a : α)
     (f : ℕ → Set (β × γ)) (hf_meas : ∀ i, MeasurableSet (f i))
     (hf_disj : Pairwise (Disjoint on f)) :
     compProdFun κ η a (⋃ i, f i) = ∑' i, compProdFun κ η a (f i) := by
@@ -123,7 +123,7 @@ theorem compProdFun_iUnion (κ : kernel α β) (η : kernel (α × β) γ) [IsSF
       measurable_fst.snd.prod_mk measurable_snd (hf_meas i)
     exact ((measurable_kernel_prod_mk_left hm).comp measurable_prod_mk_left).aemeasurable
 
-theorem compProdFun_tsum_right (κ : kernel α β) (η : kernel (α × β) γ) [IsSFiniteKernel η] (a : α)
+theorem compProdFun_tsum_right (κ : Kernel α β) (η : Kernel (α × β) γ) [IsSFiniteKernel η] (a : α)
     (hs : MeasurableSet s) : compProdFun κ η a s = ∑' n, compProdFun κ (seq η n) a s := by
   simp_rw [compProdFun, (measure_sum_seq η _).symm]
   have :
@@ -137,17 +137,17 @@ theorem compProdFun_tsum_right (κ : kernel α β) (η : kernel (α × β) γ) [
   exact fun n => ((measurable_kernel_prod_mk_left (κ := (seq η n))
     ((measurable_fst.snd.prod_mk measurable_snd) hs)).comp measurable_prod_mk_left).aemeasurable
 
-theorem compProdFun_tsum_left (κ : kernel α β) (η : kernel (α × β) γ) [IsSFiniteKernel κ] (a : α)
+theorem compProdFun_tsum_left (κ : Kernel α β) (η : Kernel (α × β) γ) [IsSFiniteKernel κ] (a : α)
     (s : Set (β × γ)) : compProdFun κ η a s = ∑' n, compProdFun (seq κ n) η a s := by
   simp_rw [compProdFun, (measure_sum_seq κ _).symm, lintegral_sum_measure]
 
-theorem compProdFun_eq_tsum (κ : kernel α β) [IsSFiniteKernel κ] (η : kernel (α × β) γ)
+theorem compProdFun_eq_tsum (κ : Kernel α β) [IsSFiniteKernel κ] (η : Kernel (α × β) γ)
     [IsSFiniteKernel η] (a : α) (hs : MeasurableSet s) :
     compProdFun κ η a s = ∑' (n) (m), compProdFun (seq κ n) (seq η m) a s := by
   simp_rw [compProdFun_tsum_left κ η a s, compProdFun_tsum_right _ η a hs]
 
 /-- Auxiliary lemma for `measurable_compProdFun`. -/
-theorem measurable_compProdFun_of_finite (κ : kernel α β) [IsFiniteKernel κ] (η : kernel (α × β) γ)
+theorem measurable_compProdFun_of_finite (κ : Kernel α β) [IsFiniteKernel κ] (η : Kernel (α × β) γ)
     [IsFiniteKernel η] (hs : MeasurableSet s) : Measurable fun a => compProdFun κ η a s := by
   simp only [compProdFun]
   have h_meas : Measurable (Function.uncurry fun a b => η (a, b) {c : γ | (b, c) ∈ s}) := by
@@ -160,7 +160,7 @@ theorem measurable_compProdFun_of_finite (κ : kernel α β) [IsFiniteKernel κ]
     exact measurable_kernel_prod_mk_left (measurable_fst.snd.prod_mk measurable_snd hs)
   exact h_meas.lintegral_kernel_prod_right
 
-theorem measurable_compProdFun (κ : kernel α β) [IsSFiniteKernel κ] (η : kernel (α × β) γ)
+theorem measurable_compProdFun (κ : Kernel α β) [IsSFiniteKernel κ] (η : Kernel (α × β) γ)
     [IsSFiniteKernel η] (hs : MeasurableSet s) : Measurable fun a => compProdFun κ η a s := by
   simp_rw [compProdFun_tsum_right κ η _ hs]
   refine Measurable.ennreal_tsum fun n => ?_
@@ -179,14 +179,14 @@ open scoped Classical
 
 /-- Composition-Product of kernels. For s-finite kernels, it satisfies
 `∫⁻ bc, f bc ∂(compProd κ η a) = ∫⁻ b, ∫⁻ c, f (b, c) ∂(η (a, b)) ∂(κ a)`
-(see `ProbabilityTheory.kernel.lintegral_compProd`).
+(see `ProbabilityTheory.Kernel.lintegral_compProd`).
 If either of the kernels is not s-finite, `compProd` is given the junk value 0. -/
-noncomputable def compProd (κ : kernel α β) (η : kernel (α × β) γ) : kernel α (β × γ) :=
+noncomputable def compProd (κ : Kernel α β) (η : Kernel (α × β) γ) : Kernel α (β × γ) :=
 if h : IsSFiniteKernel κ ∧ IsSFiniteKernel η then
-{ val := fun a ↦
+{ toFun := fun a ↦
     Measure.ofMeasurable (fun s _ => compProdFun κ η a s) (compProdFun_empty κ η a)
       (@compProdFun_iUnion _ _ _ _ _ _ κ η h.2 a)
-  property := by
+  measurable' := by
     have : IsSFiniteKernel κ := h.1
     have : IsSFiniteKernel η := h.2
     refine Measure.measurable_of_measurable_coe _ fun s hs => ?_
@@ -200,9 +200,9 @@ if h : IsSFiniteKernel κ ∧ IsSFiniteKernel η then
     exact measurable_compProdFun κ η hs }
 else 0
 
-scoped[ProbabilityTheory] infixl:100 " ⊗ₖ " => ProbabilityTheory.kernel.compProd
+scoped[ProbabilityTheory] infixl:100 " ⊗ₖ " => ProbabilityTheory.Kernel.compProd
 
-theorem compProd_apply_eq_compProdFun (κ : kernel α β) [IsSFiniteKernel κ] (η : kernel (α × β) γ)
+theorem compProd_apply_eq_compProdFun (κ : Kernel α β) [IsSFiniteKernel κ] (η : Kernel (α × β) γ)
     [IsSFiniteKernel η] (a : α) (hs : MeasurableSet s) :
     (κ ⊗ₖ η) a s = compProdFun κ η a s := by
   rw [compProd, dif_pos]
@@ -215,24 +215,24 @@ theorem compProd_apply_eq_compProdFun (κ : kernel α β) [IsSFiniteKernel κ] (
   rw [Measure.ofMeasurable_apply _ hs]
   rfl
 
-theorem compProd_of_not_isSFiniteKernel_left (κ : kernel α β) (η : kernel (α × β) γ)
+theorem compProd_of_not_isSFiniteKernel_left (κ : Kernel α β) (η : Kernel (α × β) γ)
     (h : ¬ IsSFiniteKernel κ) :
     κ ⊗ₖ η = 0 := by
   rw [compProd, dif_neg]
   simp [h]
 
-theorem compProd_of_not_isSFiniteKernel_right (κ : kernel α β) (η : kernel (α × β) γ)
+theorem compProd_of_not_isSFiniteKernel_right (κ : Kernel α β) (η : Kernel (α × β) γ)
     (h : ¬ IsSFiniteKernel η) :
     κ ⊗ₖ η = 0 := by
   rw [compProd, dif_neg]
   simp [h]
 
-theorem compProd_apply (κ : kernel α β) [IsSFiniteKernel κ] (η : kernel (α × β) γ)
+theorem compProd_apply (κ : Kernel α β) [IsSFiniteKernel κ] (η : Kernel (α × β) γ)
     [IsSFiniteKernel η] (a : α) (hs : MeasurableSet s) :
     (κ ⊗ₖ η) a s = ∫⁻ b, η (a, b) {c | (b, c) ∈ s} ∂κ a :=
   compProd_apply_eq_compProdFun κ η a hs
 
-theorem le_compProd_apply (κ : kernel α β) [IsSFiniteKernel κ] (η : kernel (α × β) γ)
+theorem le_compProd_apply (κ : Kernel α β) [IsSFiniteKernel κ] (η : Kernel (α × β) γ)
     [IsSFiniteKernel η] (a : α) (s : Set (β × γ)) :
     ∫⁻ b, η (a, b) {c | (b, c) ∈ s} ∂κ a ≤ (κ ⊗ₖ η) a s :=
   calc
@@ -240,33 +240,33 @@ theorem le_compProd_apply (κ : kernel α β) [IsSFiniteKernel κ] (η : kernel 
         ∫⁻ b, η (a, b) {c | (b, c) ∈ toMeasurable ((κ ⊗ₖ η) a) s} ∂κ a :=
       lintegral_mono fun _ => measure_mono fun _ h_mem => subset_toMeasurable _ _ h_mem
     _ = (κ ⊗ₖ η) a (toMeasurable ((κ ⊗ₖ η) a) s) :=
-      (kernel.compProd_apply_eq_compProdFun κ η a (measurableSet_toMeasurable _ _)).symm
+      (Kernel.compProd_apply_eq_compProdFun κ η a (measurableSet_toMeasurable _ _)).symm
     _ = (κ ⊗ₖ η) a s := measure_toMeasurable s
 
 @[simp]
-lemma compProd_zero_left (κ : kernel (α × β) γ) :
-    (0 : kernel α β) ⊗ₖ κ = 0 := by
+lemma compProd_zero_left (κ : Kernel (α × β) γ) :
+    (0 : Kernel α β) ⊗ₖ κ = 0 := by
   by_cases h : IsSFiniteKernel κ
   · ext a s hs
-    rw [kernel.compProd_apply _ _ _ hs]
+    rw [Kernel.compProd_apply _ _ _ hs]
     simp
-  · rw [kernel.compProd_of_not_isSFiniteKernel_right _ _ h]
+  · rw [Kernel.compProd_of_not_isSFiniteKernel_right _ _ h]
 
 @[simp]
-lemma compProd_zero_right (κ : kernel α β) (γ : Type*) [MeasurableSpace γ] :
-    κ ⊗ₖ (0 : kernel (α × β) γ) = 0 := by
+lemma compProd_zero_right (κ : Kernel α β) (γ : Type*) [MeasurableSpace γ] :
+    κ ⊗ₖ (0 : Kernel (α × β) γ) = 0 := by
   by_cases h : IsSFiniteKernel κ
   · ext a s hs
-    rw [kernel.compProd_apply _ _ _ hs]
+    rw [Kernel.compProd_apply _ _ _ hs]
     simp
-  · rw [kernel.compProd_of_not_isSFiniteKernel_left _ _ h]
+  · rw [Kernel.compProd_of_not_isSFiniteKernel_left _ _ h]
 
 section Ae
 
 /-! ### `ae` filter of the composition-product -/
 
 
-variable {κ : kernel α β} [IsSFiniteKernel κ] {η : kernel (α × β) γ} [IsSFiniteKernel η] {a : α}
+variable {κ : Kernel α β} [IsSFiniteKernel κ] {η : Kernel (α × β) γ} [IsSFiniteKernel η] {a : α}
 
 theorem ae_kernel_lt_top (a : α) (h2s : (κ ⊗ₖ η) a s ≠ ∞) :
     ∀ᵐ b ∂κ a, η (a, b) (Prod.mk b ⁻¹' s) < ∞ := by
@@ -276,16 +276,16 @@ theorem ae_kernel_lt_top (a : α) (h2s : (κ ⊗ₖ η) a s ≠ ∞) :
   have ht : MeasurableSet t := measurableSet_toMeasurable _ _
   have h2t : (κ ⊗ₖ η) a t ≠ ∞ := by rwa [measure_toMeasurable]
   have ht_lt_top : ∀ᵐ b ∂κ a, η (a, b) (Prod.mk b ⁻¹' t) < ∞ := by
-    rw [kernel.compProd_apply _ _ _ ht] at h2t
-    exact ae_lt_top (kernel.measurable_kernel_prod_mk_left' ht a) h2t
+    rw [Kernel.compProd_apply _ _ _ ht] at h2t
+    exact ae_lt_top (Kernel.measurable_kernel_prod_mk_left' ht a) h2t
   filter_upwards [ht_lt_top] with b hb
   exact (this b).trans_lt hb
 
 theorem compProd_null (a : α) (hs : MeasurableSet s) :
     (κ ⊗ₖ η) a s = 0 ↔ (fun b => η (a, b) (Prod.mk b ⁻¹' s)) =ᵐ[κ a] 0 := by
-  rw [kernel.compProd_apply _ _ _ hs, lintegral_eq_zero_iff]
+  rw [Kernel.compProd_apply _ _ _ hs, lintegral_eq_zero_iff]
   · rfl
-  · exact kernel.measurable_kernel_prod_mk_left' hs a
+  · exact Kernel.measurable_kernel_prod_mk_left' hs a
 
 theorem ae_null_of_compProd_null (h : (κ ⊗ₖ η) a s = 0) :
     (fun b => η (a, b) (Prod.mk b ⁻¹' s)) =ᵐ[κ a] 0 := by
@@ -317,14 +317,14 @@ end Ae
 
 section Restrict
 
-variable {κ : kernel α β} [IsSFiniteKernel κ] {η : kernel (α × β) γ} [IsSFiniteKernel η] {a : α}
+variable {κ : Kernel α β} [IsSFiniteKernel κ] {η : Kernel (α × β) γ} [IsSFiniteKernel η] {a : α}
 
 theorem compProd_restrict {s : Set β} {t : Set γ} (hs : MeasurableSet s) (ht : MeasurableSet t) :
-    kernel.restrict κ hs ⊗ₖ kernel.restrict η ht = kernel.restrict (κ ⊗ₖ η) (hs.prod ht) := by
+    Kernel.restrict κ hs ⊗ₖ Kernel.restrict η ht = Kernel.restrict (κ ⊗ₖ η) (hs.prod ht) := by
   ext a u hu
   rw [compProd_apply _ _ _ hu, restrict_apply' _ _ _ hu,
     compProd_apply _ _ _ (hu.inter (hs.prod ht))]
-  simp only [kernel.restrict_apply, Measure.restrict_apply' ht, Set.mem_inter_iff,
+  simp only [Kernel.restrict_apply, Measure.restrict_apply' ht, Set.mem_inter_iff,
     Set.prod_mk_mem_set_prod_eq]
   have :
     ∀ b,
@@ -341,14 +341,14 @@ theorem compProd_restrict {s : Set β} {t : Set γ} (hs : MeasurableSet s) (ht :
   rw [lintegral_indicator _ hs]
 
 theorem compProd_restrict_left {s : Set β} (hs : MeasurableSet s) :
-    kernel.restrict κ hs ⊗ₖ η = kernel.restrict (κ ⊗ₖ η) (hs.prod MeasurableSet.univ) := by
+    Kernel.restrict κ hs ⊗ₖ η = Kernel.restrict (κ ⊗ₖ η) (hs.prod MeasurableSet.univ) := by
   rw [← compProd_restrict]
-  · congr; exact kernel.restrict_univ.symm
+  · congr; exact Kernel.restrict_univ.symm
 
 theorem compProd_restrict_right {t : Set γ} (ht : MeasurableSet t) :
-    κ ⊗ₖ kernel.restrict η ht = kernel.restrict (κ ⊗ₖ η) (MeasurableSet.univ.prod ht) := by
+    κ ⊗ₖ Kernel.restrict η ht = Kernel.restrict (κ ⊗ₖ η) (MeasurableSet.univ.prod ht) := by
   rw [← compProd_restrict]
-  · congr; exact kernel.restrict_univ.symm
+  · congr; exact Kernel.restrict_univ.symm
 
 end Restrict
 
@@ -358,7 +358,7 @@ section Lintegral
 
 
 /-- Lebesgue integral against the composition-product of two kernels. -/
-theorem lintegral_compProd' (κ : kernel α β) [IsSFiniteKernel κ] (η : kernel (α × β) γ)
+theorem lintegral_compProd' (κ : Kernel α β) [IsSFiniteKernel κ] (η : Kernel (α × β) γ)
     [IsSFiniteKernel η] (a : α) {f : β → γ → ℝ≥0∞} (hf : Measurable (Function.uncurry f)) :
     ∫⁻ bc, f bc.1 bc.2 ∂(κ ⊗ₖ η) a = ∫⁻ b, ∫⁻ c, f b c ∂η (a, b) ∂κ a := by
   let F : ℕ → SimpleFunc (β × γ) ℝ≥0∞ := SimpleFunc.eapprox (Function.uncurry f)
@@ -421,7 +421,7 @@ theorem lintegral_compProd' (κ : kernel α β) [IsSFiniteKernel κ] (η : kerne
     exact (SimpleFunc.measurable _).comp measurable_prod_mk_left
 
 /-- Lebesgue integral against the composition-product of two kernels. -/
-theorem lintegral_compProd (κ : kernel α β) [IsSFiniteKernel κ] (η : kernel (α × β) γ)
+theorem lintegral_compProd (κ : Kernel α β) [IsSFiniteKernel κ] (η : Kernel (α × β) γ)
     [IsSFiniteKernel η] (a : α) {f : β × γ → ℝ≥0∞} (hf : Measurable f) :
     ∫⁻ bc, f bc ∂(κ ⊗ₖ η) a = ∫⁻ b, ∫⁻ c, f (b, c) ∂η (a, b) ∂κ a := by
   let g := Function.curry f
@@ -431,7 +431,7 @@ theorem lintegral_compProd (κ : kernel α β) [IsSFiniteKernel κ] (η : kernel
   · simp_rw [g, Function.uncurry_curry]; exact hf
 
 /-- Lebesgue integral against the composition-product of two kernels. -/
-theorem lintegral_compProd₀ (κ : kernel α β) [IsSFiniteKernel κ] (η : kernel (α × β) γ)
+theorem lintegral_compProd₀ (κ : Kernel α β) [IsSFiniteKernel κ] (η : Kernel (α × β) γ)
     [IsSFiniteKernel η] (a : α) {f : β × γ → ℝ≥0∞} (hf : AEMeasurable f ((κ ⊗ₖ η) a)) :
     ∫⁻ z, f z ∂(κ ⊗ₖ η) a = ∫⁻ x, ∫⁻ y, f (x, y) ∂η (a, x) ∂κ a := by
   have A : ∫⁻ z, f z ∂(κ ⊗ₖ η) a = ∫⁻ z, hf.mk f z ∂(κ ⊗ₖ η) a := lintegral_congr_ae hf.ae_eq_mk
@@ -441,18 +441,18 @@ theorem lintegral_compProd₀ (κ : kernel α β) [IsSFiniteKernel κ] (η : ker
   rw [A, B, lintegral_compProd]
   exact hf.measurable_mk
 
-theorem setLIntegral_compProd (κ : kernel α β) [IsSFiniteKernel κ] (η : kernel (α × β) γ)
+theorem setLIntegral_compProd (κ : Kernel α β) [IsSFiniteKernel κ] (η : Kernel (α × β) γ)
     [IsSFiniteKernel η] (a : α) {f : β × γ → ℝ≥0∞} (hf : Measurable f) {s : Set β} {t : Set γ}
     (hs : MeasurableSet s) (ht : MeasurableSet t) :
     ∫⁻ z in s ×ˢ t, f z ∂(κ ⊗ₖ η) a = ∫⁻ x in s, ∫⁻ y in t, f (x, y) ∂η (a, x) ∂κ a := by
-  simp_rw [← kernel.restrict_apply (κ ⊗ₖ η) (hs.prod ht), ← compProd_restrict hs ht,
-    lintegral_compProd _ _ _ hf, kernel.restrict_apply]
+  simp_rw [← Kernel.restrict_apply (κ ⊗ₖ η) (hs.prod ht), ← compProd_restrict hs ht,
+    lintegral_compProd _ _ _ hf, Kernel.restrict_apply]
 
 @[deprecated (since := "2024-06-29")]
 alias set_lintegral_compProd := setLIntegral_compProd
 
-theorem setLIntegral_compProd_univ_right (κ : kernel α β) [IsSFiniteKernel κ]
-    (η : kernel (α × β) γ) [IsSFiniteKernel η] (a : α) {f : β × γ → ℝ≥0∞} (hf : Measurable f)
+theorem setLIntegral_compProd_univ_right (κ : Kernel α β) [IsSFiniteKernel κ]
+    (η : Kernel (α × β) γ) [IsSFiniteKernel η] (a : α) {f : β × γ → ℝ≥0∞} (hf : Measurable f)
     {s : Set β} (hs : MeasurableSet s) :
     ∫⁻ z in s ×ˢ Set.univ, f z ∂(κ ⊗ₖ η) a = ∫⁻ x in s, ∫⁻ y, f (x, y) ∂η (a, x) ∂κ a := by
   simp_rw [setLIntegral_compProd κ η a hf hs MeasurableSet.univ, Measure.restrict_univ]
@@ -460,7 +460,7 @@ theorem setLIntegral_compProd_univ_right (κ : kernel α β) [IsSFiniteKernel κ
 @[deprecated (since := "2024-06-29")]
 alias set_lintegral_compProd_univ_right := setLIntegral_compProd_univ_right
 
-theorem setLIntegral_compProd_univ_left (κ : kernel α β) [IsSFiniteKernel κ] (η : kernel (α × β) γ)
+theorem setLIntegral_compProd_univ_left (κ : Kernel α β) [IsSFiniteKernel κ] (η : Kernel (α × β) γ)
     [IsSFiniteKernel η] (a : α) {f : β × γ → ℝ≥0∞} (hf : Measurable f) {t : Set γ}
     (ht : MeasurableSet t) :
     ∫⁻ z in Set.univ ×ˢ t, f z ∂(κ ⊗ₖ η) a = ∫⁻ x, ∫⁻ y in t, f (x, y) ∂η (a, x) ∂κ a := by
@@ -471,44 +471,44 @@ alias set_lintegral_compProd_univ_left := setLIntegral_compProd_univ_left
 
 end Lintegral
 
-theorem compProd_eq_tsum_compProd (κ : kernel α β) [IsSFiniteKernel κ] (η : kernel (α × β) γ)
+theorem compProd_eq_tsum_compProd (κ : Kernel α β) [IsSFiniteKernel κ] (η : Kernel (α × β) γ)
     [IsSFiniteKernel η] (a : α) (hs : MeasurableSet s) :
     (κ ⊗ₖ η) a s = ∑' (n : ℕ) (m : ℕ), (seq κ n ⊗ₖ seq η m) a s := by
   simp_rw [compProd_apply_eq_compProdFun _ _ _ hs]; exact compProdFun_eq_tsum κ η a hs
 
-theorem compProd_eq_sum_compProd (κ : kernel α β) [IsSFiniteKernel κ] (η : kernel (α × β) γ)
-    [IsSFiniteKernel η] : κ ⊗ₖ η = kernel.sum fun n => kernel.sum fun m => seq κ n ⊗ₖ seq η m := by
-  ext a s hs; simp_rw [kernel.sum_apply' _ a hs]; rw [compProd_eq_tsum_compProd κ η a hs]
+theorem compProd_eq_sum_compProd (κ : Kernel α β) [IsSFiniteKernel κ] (η : Kernel (α × β) γ)
+    [IsSFiniteKernel η] : κ ⊗ₖ η = Kernel.sum fun n => Kernel.sum fun m => seq κ n ⊗ₖ seq η m := by
+  ext a s hs; simp_rw [Kernel.sum_apply' _ a hs]; rw [compProd_eq_tsum_compProd κ η a hs]
 
-theorem compProd_eq_sum_compProd_left (κ : kernel α β) [IsSFiniteKernel κ] (η : kernel (α × β) γ) :
-    κ ⊗ₖ η = kernel.sum fun n => seq κ n ⊗ₖ η := by
+theorem compProd_eq_sum_compProd_left (κ : Kernel α β) [IsSFiniteKernel κ] (η : Kernel (α × β) γ) :
+    κ ⊗ₖ η = Kernel.sum fun n => seq κ n ⊗ₖ η := by
   by_cases h : IsSFiniteKernel η
   swap
   · simp_rw [compProd_of_not_isSFiniteKernel_right _ _ h]
     simp
   rw [compProd_eq_sum_compProd]
   congr with n a s hs
-  simp_rw [kernel.sum_apply' _ _ hs, compProd_apply_eq_compProdFun _ _ _ hs,
+  simp_rw [Kernel.sum_apply' _ _ hs, compProd_apply_eq_compProdFun _ _ _ hs,
     compProdFun_tsum_right _ η a hs]
 
-theorem compProd_eq_sum_compProd_right (κ : kernel α β) (η : kernel (α × β) γ)
-    [IsSFiniteKernel η] : κ ⊗ₖ η = kernel.sum fun n => κ ⊗ₖ seq η n := by
+theorem compProd_eq_sum_compProd_right (κ : Kernel α β) (η : Kernel (α × β) γ)
+    [IsSFiniteKernel η] : κ ⊗ₖ η = Kernel.sum fun n => κ ⊗ₖ seq η n := by
   by_cases hκ : IsSFiniteKernel κ
   swap
   · simp_rw [compProd_of_not_isSFiniteKernel_left _ _ hκ]
     simp
   rw [compProd_eq_sum_compProd]
   simp_rw [compProd_eq_sum_compProd_left κ _]
-  rw [kernel.sum_comm]
+  rw [Kernel.sum_comm]
 
-instance IsMarkovKernel.compProd (κ : kernel α β) [IsMarkovKernel κ] (η : kernel (α × β) γ)
+instance IsMarkovKernel.compProd (κ : Kernel α β) [IsMarkovKernel κ] (η : Kernel (α × β) γ)
     [IsMarkovKernel η] : IsMarkovKernel (κ ⊗ₖ η) :=
   ⟨fun a =>
     ⟨by
       rw [compProd_apply κ η a MeasurableSet.univ]
       simp only [Set.mem_univ, Set.setOf_true, measure_univ, lintegral_one]⟩⟩
 
-theorem compProd_apply_univ_le (κ : kernel α β) (η : kernel (α × β) γ) [IsFiniteKernel η] (a : α) :
+theorem compProd_apply_univ_le (κ : Kernel α β) (η : Kernel (α × β) γ) [IsFiniteKernel η] (a : α) :
     (κ ⊗ₖ η) a Set.univ ≤ κ a Set.univ * IsFiniteKernel.bound η := by
   by_cases hκ : IsSFiniteKernel κ
   swap
@@ -523,7 +523,7 @@ theorem compProd_apply_univ_le (κ : kernel α β) (η : kernel (α × β) γ) [
     _ = Cη * κ a Set.univ := MeasureTheory.lintegral_const Cη
     _ = κ a Set.univ * Cη := mul_comm _ _
 
-instance IsFiniteKernel.compProd (κ : kernel α β) [IsFiniteKernel κ] (η : kernel (α × β) γ)
+instance IsFiniteKernel.compProd (κ : Kernel α β) [IsFiniteKernel κ] (η : Kernel (α × β) γ)
     [IsFiniteKernel η] : IsFiniteKernel (κ ⊗ₖ η) :=
   ⟨⟨IsFiniteKernel.bound κ * IsFiniteKernel.bound η,
       ENNReal.mul_lt_top (IsFiniteKernel.bound_ne_top κ) (IsFiniteKernel.bound_ne_top η), fun a =>
@@ -532,7 +532,7 @@ instance IsFiniteKernel.compProd (κ : kernel α β) [IsFiniteKernel κ] (η : k
         _ ≤ IsFiniteKernel.bound κ * IsFiniteKernel.bound η :=
           mul_le_mul (measure_le_bound κ a Set.univ) le_rfl (zero_le _) (zero_le _)⟩⟩
 
-instance IsSFiniteKernel.compProd (κ : kernel α β) (η : kernel (α × β) γ) :
+instance IsSFiniteKernel.compProd (κ : Kernel α β) (η : Kernel (α × β) γ) :
     IsSFiniteKernel (κ ⊗ₖ η) := by
   by_cases h : IsSFiniteKernel κ
   swap
@@ -543,22 +543,22 @@ instance IsSFiniteKernel.compProd (κ : kernel α β) (η : kernel (α × β) γ
   · rw [compProd_of_not_isSFiniteKernel_right _ _ h]
     infer_instance
   rw [compProd_eq_sum_compProd]
-  exact kernel.isSFiniteKernel_sum fun n => kernel.isSFiniteKernel_sum inferInstance
+  exact Kernel.isSFiniteKernel_sum fun n => Kernel.isSFiniteKernel_sum inferInstance
 
-lemma compProd_add_left (μ κ : kernel α β) (η : kernel (α × β) γ)
+lemma compProd_add_left (μ κ : Kernel α β) (η : Kernel (α × β) γ)
     [IsSFiniteKernel μ] [IsSFiniteKernel κ] [IsSFiniteKernel η] :
     (μ + κ) ⊗ₖ η = μ ⊗ₖ η + κ ⊗ₖ η := by ext _ _ hs; simp [compProd_apply _ _ _ hs]
 
-lemma compProd_add_right (μ : kernel α β) (κ η : kernel (α × β) γ)
+lemma compProd_add_right (μ : Kernel α β) (κ η : Kernel (α × β) γ)
     [IsSFiniteKernel μ] [IsSFiniteKernel κ] [IsSFiniteKernel η] :
     μ ⊗ₖ (κ + η) = μ ⊗ₖ κ + μ ⊗ₖ η := by
   ext a s hs
-  simp only [compProd_apply _ _ _ hs, coeFn_add, Pi.add_apply, Measure.coe_add]
+  simp only [compProd_apply _ _ _ hs, coe_add, Pi.add_apply, Measure.coe_add]
   rw [lintegral_add_left]
   exact measurable_kernel_prod_mk_left' hs a
 
 lemma comapRight_compProd_id_prod {δ : Type*} {mδ : MeasurableSpace δ}
-    (κ : kernel α β) [IsSFiniteKernel κ] (η : kernel (α × β) γ) [IsSFiniteKernel η]
+    (κ : Kernel α β) [IsSFiniteKernel κ] (η : Kernel (α × β) γ) [IsSFiniteKernel η]
     {f : δ → γ} (hf : MeasurableEmbedding f) :
     comapRight (κ ⊗ₖ η) (MeasurableEmbedding.id.prod_mk hf) = κ ⊗ₖ (comapRight η hf) := by
   ext a t ht
@@ -588,51 +588,51 @@ variable {γ δ : Type*} {mγ : MeasurableSpace γ} {mδ : MeasurableSpace δ} {
 /-- The pushforward of a kernel along a measurable function.
 We include measurability in the assumptions instead of using junk values
 to make sure that typeclass inference can infer that the `map` of a Markov kernel
-is again a Markov kernel. -/
-noncomputable def map (κ : kernel α β) (f : β → γ) (hf : Measurable f) : kernel α γ where
-  val a := (κ a).map f
-  property := (Measure.measurable_map _ hf).comp (kernel.measurable κ)
+is again a Markov Kernel. -/
+noncomputable def map (κ : Kernel α β) (f : β → γ) (hf : Measurable f) : Kernel α γ where
+  toFun a := (κ a).map f
+  measurable' := (Measure.measurable_map _ hf).comp (Kernel.measurable κ)
 
-theorem map_apply (κ : kernel α β) (hf : Measurable f) (a : α) : map κ f hf a = (κ a).map f :=
+theorem map_apply (κ : Kernel α β) (hf : Measurable f) (a : α) : map κ f hf a = (κ a).map f :=
   rfl
 
-theorem map_apply' (κ : kernel α β) (hf : Measurable f) (a : α) {s : Set γ} (hs : MeasurableSet s) :
+theorem map_apply' (κ : Kernel α β) (hf : Measurable f) (a : α) {s : Set γ} (hs : MeasurableSet s) :
     map κ f hf a s = κ a (f ⁻¹' s) := by rw [map_apply, Measure.map_apply hf hs]
 
 @[simp]
-lemma map_zero (hf : Measurable f) : kernel.map (0 : kernel α β) f hf = 0 := by
-  ext; rw [kernel.map_apply]; simp
+lemma map_zero (hf : Measurable f) : Kernel.map (0 : Kernel α β) f hf = 0 := by
+  ext; rw [Kernel.map_apply]; simp
 
 @[simp]
-lemma map_id (κ : kernel α β) : map κ id measurable_id = κ := by ext a; rw [map_apply]; simp
+lemma map_id (κ : Kernel α β) : map κ id measurable_id = κ := by ext a; rw [map_apply]; simp
 
 @[simp]
-lemma map_id' (κ : kernel α β) : map κ (fun a ↦ a) measurable_id = κ := map_id κ
+lemma map_id' (κ : Kernel α β) : map κ (fun a ↦ a) measurable_id = κ := map_id κ
 
-nonrec theorem lintegral_map (κ : kernel α β) (hf : Measurable f) (a : α) {g' : γ → ℝ≥0∞}
+nonrec theorem lintegral_map (κ : Kernel α β) (hf : Measurable f) (a : α) {g' : γ → ℝ≥0∞}
     (hg : Measurable g') : ∫⁻ b, g' b ∂map κ f hf a = ∫⁻ a, g' (f a) ∂κ a := by
   rw [map_apply _ hf, lintegral_map hg hf]
 
-theorem sum_map_seq (κ : kernel α β) [IsSFiniteKernel κ] (hf : Measurable f) :
-    (kernel.sum fun n => map (seq κ n) f hf) = map κ f hf := by
+theorem sum_map_seq (κ : Kernel α β) [IsSFiniteKernel κ] (hf : Measurable f) :
+    (Kernel.sum fun n => map (seq κ n) f hf) = map κ f hf := by
   ext a s hs
-  rw [kernel.sum_apply, map_apply' κ hf a hs, Measure.sum_apply _ hs, ← measure_sum_seq κ,
+  rw [Kernel.sum_apply, map_apply' κ hf a hs, Measure.sum_apply _ hs, ← measure_sum_seq κ,
     Measure.sum_apply _ (hf hs)]
   simp_rw [map_apply' _ hf _ hs]
 
-instance IsMarkovKernel.map (κ : kernel α β) [IsMarkovKernel κ] (hf : Measurable f) :
+instance IsMarkovKernel.map (κ : Kernel α β) [IsMarkovKernel κ] (hf : Measurable f) :
     IsMarkovKernel (map κ f hf) :=
   ⟨fun a => ⟨by rw [map_apply' κ hf a MeasurableSet.univ, Set.preimage_univ, measure_univ]⟩⟩
 
-instance IsFiniteKernel.map (κ : kernel α β) [IsFiniteKernel κ] (hf : Measurable f) :
+instance IsFiniteKernel.map (κ : Kernel α β) [IsFiniteKernel κ] (hf : Measurable f) :
     IsFiniteKernel (map κ f hf) := by
   refine ⟨⟨IsFiniteKernel.bound κ, IsFiniteKernel.bound_lt_top κ, fun a => ?_⟩⟩
   rw [map_apply' κ hf a MeasurableSet.univ]
   exact measure_le_bound κ a _
 
-instance IsSFiniteKernel.map (κ : kernel α β) [IsSFiniteKernel κ] (hf : Measurable f) :
+instance IsSFiniteKernel.map (κ : Kernel α β) [IsSFiniteKernel κ] (hf : Measurable f) :
     IsSFiniteKernel (map κ f hf) :=
-  ⟨⟨fun n => kernel.map (seq κ n) f hf, inferInstance, (sum_map_seq κ hf).symm⟩⟩
+  ⟨⟨fun n => Kernel.map (seq κ n) f hf, inferInstance, (sum_map_seq κ hf).symm⟩⟩
 
 @[simp]
 lemma map_const (μ : Measure α) {f : α → β} (hf : Measurable f) :
@@ -643,54 +643,54 @@ lemma map_const (μ : Measure α) {f : α → β} (hf : Measurable f) :
 /-- Pullback of a kernel, such that for each set s `comap κ g hg c s = κ (g c) s`.
 We include measurability in the assumptions instead of using junk values
 to make sure that typeclass inference can infer that the `comap` of a Markov kernel
-is again a Markov kernel. -/
-def comap (κ : kernel α β) (g : γ → α) (hg : Measurable g) : kernel γ β where
-  val a := κ (g a)
-  property := (kernel.measurable κ).comp hg
+is again a Markov Kernel. -/
+def comap (κ : Kernel α β) (g : γ → α) (hg : Measurable g) : Kernel γ β where
+  toFun a := κ (g a)
+  measurable' := κ.measurable.comp hg
 
-theorem comap_apply (κ : kernel α β) (hg : Measurable g) (c : γ) : comap κ g hg c = κ (g c) :=
+theorem comap_apply (κ : Kernel α β) (hg : Measurable g) (c : γ) : comap κ g hg c = κ (g c) :=
   rfl
 
-theorem comap_apply' (κ : kernel α β) (hg : Measurable g) (c : γ) (s : Set β) :
+theorem comap_apply' (κ : Kernel α β) (hg : Measurable g) (c : γ) (s : Set β) :
     comap κ g hg c s = κ (g c) s :=
   rfl
 
 @[simp]
-lemma comap_zero (hg : Measurable g) : kernel.comap (0 : kernel α β) g hg = 0 := by
-  ext; rw [kernel.comap_apply]; simp
+lemma comap_zero (hg : Measurable g) : Kernel.comap (0 : Kernel α β) g hg = 0 := by
+  ext; rw [Kernel.comap_apply]; simp
 
 @[simp]
-lemma comap_id (κ : kernel α β) : comap κ id measurable_id = κ := by ext a; rw [comap_apply]; simp
+lemma comap_id (κ : Kernel α β) : comap κ id measurable_id = κ := by ext a; rw [comap_apply]; simp
 
 @[simp]
-lemma comap_id' (κ : kernel α β) : comap κ (fun a ↦ a) measurable_id = κ := comap_id κ
+lemma comap_id' (κ : Kernel α β) : comap κ (fun a ↦ a) measurable_id = κ := comap_id κ
 
-theorem lintegral_comap (κ : kernel α β) (hg : Measurable g) (c : γ) (g' : β → ℝ≥0∞) :
+theorem lintegral_comap (κ : Kernel α β) (hg : Measurable g) (c : γ) (g' : β → ℝ≥0∞) :
     ∫⁻ b, g' b ∂comap κ g hg c = ∫⁻ b, g' b ∂κ (g c) :=
   rfl
 
-theorem sum_comap_seq (κ : kernel α β) [IsSFiniteKernel κ] (hg : Measurable g) :
-    (kernel.sum fun n => comap (seq κ n) g hg) = comap κ g hg := by
+theorem sum_comap_seq (κ : Kernel α β) [IsSFiniteKernel κ] (hg : Measurable g) :
+    (Kernel.sum fun n => comap (seq κ n) g hg) = comap κ g hg := by
   ext a s hs
-  rw [kernel.sum_apply, comap_apply' κ hg a s, Measure.sum_apply _ hs, ← measure_sum_seq κ,
+  rw [Kernel.sum_apply, comap_apply' κ hg a s, Measure.sum_apply _ hs, ← measure_sum_seq κ,
     Measure.sum_apply _ hs]
   simp_rw [comap_apply' _ hg _ s]
 
-instance IsMarkovKernel.comap (κ : kernel α β) [IsMarkovKernel κ] (hg : Measurable g) :
+instance IsMarkovKernel.comap (κ : Kernel α β) [IsMarkovKernel κ] (hg : Measurable g) :
     IsMarkovKernel (comap κ g hg) :=
   ⟨fun a => ⟨by rw [comap_apply' κ hg a Set.univ, measure_univ]⟩⟩
 
-instance IsFiniteKernel.comap (κ : kernel α β) [IsFiniteKernel κ] (hg : Measurable g) :
+instance IsFiniteKernel.comap (κ : Kernel α β) [IsFiniteKernel κ] (hg : Measurable g) :
     IsFiniteKernel (comap κ g hg) := by
   refine ⟨⟨IsFiniteKernel.bound κ, IsFiniteKernel.bound_lt_top κ, fun a => ?_⟩⟩
   rw [comap_apply' κ hg a Set.univ]
   exact measure_le_bound κ _ _
 
-instance IsSFiniteKernel.comap (κ : kernel α β) [IsSFiniteKernel κ] (hg : Measurable g) :
+instance IsSFiniteKernel.comap (κ : Kernel α β) [IsSFiniteKernel κ] (hg : Measurable g) :
     IsSFiniteKernel (comap κ g hg) :=
-  ⟨⟨fun n => kernel.comap (seq κ n) g hg, inferInstance, (sum_comap_seq κ hg).symm⟩⟩
+  ⟨⟨fun n => Kernel.comap (seq κ n) g hg, inferInstance, (sum_comap_seq κ hg).symm⟩⟩
 
-lemma comap_map_comm (κ : kernel β γ) {f : α → β} {g : γ → δ}
+lemma comap_map_comm (κ : Kernel β γ) {f : α → β} {g : γ → δ}
     (hf : Measurable f) (hg : Measurable g) :
     comap (map κ g hg) f hf = map (comap κ f hf) g hg := by
   ext x s _
@@ -704,165 +704,165 @@ section FstSnd
 
 variable {δ : Type*} {mδ : MeasurableSpace δ}
 
-/-- Define a `kernel (γ × α) β` from a `kernel α β` by taking the comap of the projection. -/
-def prodMkLeft (γ : Type*) [MeasurableSpace γ] (κ : kernel α β) : kernel (γ × α) β :=
+/-- Define a `Kernel (γ × α) β` from a `Kernel α β` by taking the comap of the projection. -/
+def prodMkLeft (γ : Type*) [MeasurableSpace γ] (κ : Kernel α β) : Kernel (γ × α) β :=
   comap κ Prod.snd measurable_snd
 
-/-- Define a `kernel (α × γ) β` from a `kernel α β` by taking the comap of the projection. -/
-def prodMkRight (γ : Type*) [MeasurableSpace γ] (κ : kernel α β) : kernel (α × γ) β :=
+/-- Define a `Kernel (α × γ) β` from a `Kernel α β` by taking the comap of the projection. -/
+def prodMkRight (γ : Type*) [MeasurableSpace γ] (κ : Kernel α β) : Kernel (α × γ) β :=
   comap κ Prod.fst measurable_fst
 
 variable {γ : Type*} {mγ : MeasurableSpace γ} {f : β → γ} {g : γ → α}
 
 @[simp]
-theorem prodMkLeft_apply (κ : kernel α β) (ca : γ × α) : prodMkLeft γ κ ca = κ ca.snd :=
+theorem prodMkLeft_apply (κ : Kernel α β) (ca : γ × α) : prodMkLeft γ κ ca = κ ca.snd :=
   rfl
 
 @[simp]
-theorem prodMkRight_apply (κ : kernel α β) (ca : α × γ) : prodMkRight γ κ ca = κ ca.fst := rfl
+theorem prodMkRight_apply (κ : Kernel α β) (ca : α × γ) : prodMkRight γ κ ca = κ ca.fst := rfl
 
-theorem prodMkLeft_apply' (κ : kernel α β) (ca : γ × α) (s : Set β) :
+theorem prodMkLeft_apply' (κ : Kernel α β) (ca : γ × α) (s : Set β) :
     prodMkLeft γ κ ca s = κ ca.snd s :=
   rfl
 
-theorem prodMkRight_apply' (κ : kernel α β) (ca : α × γ) (s : Set β) :
+theorem prodMkRight_apply' (κ : Kernel α β) (ca : α × γ) (s : Set β) :
     prodMkRight γ κ ca s = κ ca.fst s := rfl
 
 @[simp]
-lemma prodMkLeft_zero : kernel.prodMkLeft α (0 : kernel β γ) = 0 := by
+lemma prodMkLeft_zero : Kernel.prodMkLeft α (0 : Kernel β γ) = 0 := by
   ext x s _; simp
 
 @[simp]
-lemma prodMkRight_zero : kernel.prodMkRight α (0 : kernel β γ) = 0 := by
+lemma prodMkRight_zero : Kernel.prodMkRight α (0 : Kernel β γ) = 0 := by
   ext x s _; simp
 
 @[simp]
-lemma prodMkLeft_add (κ η : kernel α β) :
+lemma prodMkLeft_add (κ η : Kernel α β) :
     prodMkLeft γ (κ + η) = prodMkLeft γ κ + prodMkLeft γ η := by ext; simp
 
 @[simp]
-lemma prodMkRight_add (κ η : kernel α β) :
+lemma prodMkRight_add (κ η : Kernel α β) :
     prodMkRight γ (κ + η) = prodMkRight γ κ + prodMkRight γ η := by ext; simp
 
-theorem lintegral_prodMkLeft (κ : kernel α β) (ca : γ × α) (g : β → ℝ≥0∞) :
+theorem lintegral_prodMkLeft (κ : Kernel α β) (ca : γ × α) (g : β → ℝ≥0∞) :
     ∫⁻ b, g b ∂prodMkLeft γ κ ca = ∫⁻ b, g b ∂κ ca.snd := rfl
 
-theorem lintegral_prodMkRight (κ : kernel α β) (ca : α × γ) (g : β → ℝ≥0∞) :
+theorem lintegral_prodMkRight (κ : Kernel α β) (ca : α × γ) (g : β → ℝ≥0∞) :
     ∫⁻ b, g b ∂prodMkRight γ κ ca = ∫⁻ b, g b ∂κ ca.fst := rfl
 
-instance IsMarkovKernel.prodMkLeft (κ : kernel α β) [IsMarkovKernel κ] :
-    IsMarkovKernel (prodMkLeft γ κ) := by rw [kernel.prodMkLeft]; infer_instance
+instance IsMarkovKernel.prodMkLeft (κ : Kernel α β) [IsMarkovKernel κ] :
+    IsMarkovKernel (prodMkLeft γ κ) := by rw [Kernel.prodMkLeft]; infer_instance
 
-instance IsMarkovKernel.prodMkRight (κ : kernel α β) [IsMarkovKernel κ] :
-    IsMarkovKernel (prodMkRight γ κ) := by rw [kernel.prodMkRight]; infer_instance
+instance IsMarkovKernel.prodMkRight (κ : Kernel α β) [IsMarkovKernel κ] :
+    IsMarkovKernel (prodMkRight γ κ) := by rw [Kernel.prodMkRight]; infer_instance
 
-instance IsFiniteKernel.prodMkLeft (κ : kernel α β) [IsFiniteKernel κ] :
-    IsFiniteKernel (prodMkLeft γ κ) := by rw [kernel.prodMkLeft]; infer_instance
+instance IsFiniteKernel.prodMkLeft (κ : Kernel α β) [IsFiniteKernel κ] :
+    IsFiniteKernel (prodMkLeft γ κ) := by rw [Kernel.prodMkLeft]; infer_instance
 
-instance IsFiniteKernel.prodMkRight (κ : kernel α β) [IsFiniteKernel κ] :
-    IsFiniteKernel (prodMkRight γ κ) := by rw [kernel.prodMkRight]; infer_instance
+instance IsFiniteKernel.prodMkRight (κ : Kernel α β) [IsFiniteKernel κ] :
+    IsFiniteKernel (prodMkRight γ κ) := by rw [Kernel.prodMkRight]; infer_instance
 
-instance IsSFiniteKernel.prodMkLeft (κ : kernel α β) [IsSFiniteKernel κ] :
-    IsSFiniteKernel (prodMkLeft γ κ) := by rw [kernel.prodMkLeft]; infer_instance
+instance IsSFiniteKernel.prodMkLeft (κ : Kernel α β) [IsSFiniteKernel κ] :
+    IsSFiniteKernel (prodMkLeft γ κ) := by rw [Kernel.prodMkLeft]; infer_instance
 
-instance IsSFiniteKernel.prodMkRight (κ : kernel α β) [IsSFiniteKernel κ] :
-    IsSFiniteKernel (prodMkRight γ κ) := by rw [kernel.prodMkRight]; infer_instance
+instance IsSFiniteKernel.prodMkRight (κ : Kernel α β) [IsSFiniteKernel κ] :
+    IsSFiniteKernel (prodMkRight γ κ) := by rw [Kernel.prodMkRight]; infer_instance
 
-lemma map_prodMkLeft (γ : Type*) [MeasurableSpace γ] (κ : kernel α β)
+lemma map_prodMkLeft (γ : Type*) [MeasurableSpace γ] (κ : Kernel α β)
     {f : β → δ} (hf : Measurable f) :
     map (prodMkLeft γ κ) f hf = prodMkLeft γ (map κ f hf) := rfl
 
-lemma map_prodMkRight (κ : kernel α β) (γ : Type*) [MeasurableSpace γ]
+lemma map_prodMkRight (κ : Kernel α β) (γ : Type*) [MeasurableSpace γ]
     {f : β → δ} (hf : Measurable f) :
     map (prodMkRight γ κ) f hf = prodMkRight γ (map κ f hf) := rfl
 
-/-- Define a `kernel (β × α) γ` from a `kernel (α × β) γ` by taking the comap of `Prod.swap`. -/
-def swapLeft (κ : kernel (α × β) γ) : kernel (β × α) γ :=
+/-- Define a `Kernel (β × α) γ` from a `Kernel (α × β) γ` by taking the comap of `Prod.swap`. -/
+def swapLeft (κ : Kernel (α × β) γ) : Kernel (β × α) γ :=
   comap κ Prod.swap measurable_swap
 
 @[simp]
-theorem swapLeft_apply (κ : kernel (α × β) γ) (a : β × α) : swapLeft κ a = κ a.swap := rfl
+theorem swapLeft_apply (κ : Kernel (α × β) γ) (a : β × α) : swapLeft κ a = κ a.swap := rfl
 
-theorem swapLeft_apply' (κ : kernel (α × β) γ) (a : β × α) (s : Set γ) :
+theorem swapLeft_apply' (κ : Kernel (α × β) γ) (a : β × α) (s : Set γ) :
     swapLeft κ a s = κ a.swap s := rfl
 
-theorem lintegral_swapLeft (κ : kernel (α × β) γ) (a : β × α) (g : γ → ℝ≥0∞) :
+theorem lintegral_swapLeft (κ : Kernel (α × β) γ) (a : β × α) (g : γ → ℝ≥0∞) :
     ∫⁻ c, g c ∂swapLeft κ a = ∫⁻ c, g c ∂κ a.swap := by
   rw [swapLeft_apply]
 
-instance IsMarkovKernel.swapLeft (κ : kernel (α × β) γ) [IsMarkovKernel κ] :
-    IsMarkovKernel (swapLeft κ) := by rw [kernel.swapLeft]; infer_instance
+instance IsMarkovKernel.swapLeft (κ : Kernel (α × β) γ) [IsMarkovKernel κ] :
+    IsMarkovKernel (swapLeft κ) := by rw [Kernel.swapLeft]; infer_instance
 
-instance IsFiniteKernel.swapLeft (κ : kernel (α × β) γ) [IsFiniteKernel κ] :
-    IsFiniteKernel (swapLeft κ) := by rw [kernel.swapLeft]; infer_instance
+instance IsFiniteKernel.swapLeft (κ : Kernel (α × β) γ) [IsFiniteKernel κ] :
+    IsFiniteKernel (swapLeft κ) := by rw [Kernel.swapLeft]; infer_instance
 
-instance IsSFiniteKernel.swapLeft (κ : kernel (α × β) γ) [IsSFiniteKernel κ] :
-    IsSFiniteKernel (swapLeft κ) := by rw [kernel.swapLeft]; infer_instance
+instance IsSFiniteKernel.swapLeft (κ : Kernel (α × β) γ) [IsSFiniteKernel κ] :
+    IsSFiniteKernel (swapLeft κ) := by rw [Kernel.swapLeft]; infer_instance
 
-@[simp] lemma swapLeft_prodMkLeft (κ : kernel α β) (γ : Type*) [MeasurableSpace γ] :
+@[simp] lemma swapLeft_prodMkLeft (κ : Kernel α β) (γ : Type*) [MeasurableSpace γ] :
     swapLeft (prodMkLeft γ κ) = prodMkRight γ κ := rfl
 
-@[simp] lemma swapLeft_prodMkRight (κ : kernel α β) (γ : Type*) [MeasurableSpace γ] :
+@[simp] lemma swapLeft_prodMkRight (κ : Kernel α β) (γ : Type*) [MeasurableSpace γ] :
     swapLeft (prodMkRight γ κ) = prodMkLeft γ κ := rfl
 
-/-- Define a `kernel α (γ × β)` from a `kernel α (β × γ)` by taking the map of `Prod.swap`. -/
-noncomputable def swapRight (κ : kernel α (β × γ)) : kernel α (γ × β) :=
+/-- Define a `Kernel α (γ × β)` from a `Kernel α (β × γ)` by taking the map of `Prod.swap`. -/
+noncomputable def swapRight (κ : Kernel α (β × γ)) : Kernel α (γ × β) :=
   map κ Prod.swap measurable_swap
 
-theorem swapRight_apply (κ : kernel α (β × γ)) (a : α) : swapRight κ a = (κ a).map Prod.swap :=
+theorem swapRight_apply (κ : Kernel α (β × γ)) (a : α) : swapRight κ a = (κ a).map Prod.swap :=
   rfl
 
-theorem swapRight_apply' (κ : kernel α (β × γ)) (a : α) {s : Set (γ × β)} (hs : MeasurableSet s) :
+theorem swapRight_apply' (κ : Kernel α (β × γ)) (a : α) {s : Set (γ × β)} (hs : MeasurableSet s) :
     swapRight κ a s = κ a {p | p.swap ∈ s} := by
   rw [swapRight_apply, Measure.map_apply measurable_swap hs]; rfl
 
-theorem lintegral_swapRight (κ : kernel α (β × γ)) (a : α) {g : γ × β → ℝ≥0∞} (hg : Measurable g) :
+theorem lintegral_swapRight (κ : Kernel α (β × γ)) (a : α) {g : γ × β → ℝ≥0∞} (hg : Measurable g) :
     ∫⁻ c, g c ∂swapRight κ a = ∫⁻ bc : β × γ, g bc.swap ∂κ a := by
   rw [swapRight, lintegral_map _ measurable_swap a hg]
 
-instance IsMarkovKernel.swapRight (κ : kernel α (β × γ)) [IsMarkovKernel κ] :
-    IsMarkovKernel (swapRight κ) := by rw [kernel.swapRight]; infer_instance
+instance IsMarkovKernel.swapRight (κ : Kernel α (β × γ)) [IsMarkovKernel κ] :
+    IsMarkovKernel (swapRight κ) := by rw [Kernel.swapRight]; infer_instance
 
-instance IsFiniteKernel.swapRight (κ : kernel α (β × γ)) [IsFiniteKernel κ] :
-    IsFiniteKernel (swapRight κ) := by rw [kernel.swapRight]; infer_instance
+instance IsFiniteKernel.swapRight (κ : Kernel α (β × γ)) [IsFiniteKernel κ] :
+    IsFiniteKernel (swapRight κ) := by rw [Kernel.swapRight]; infer_instance
 
-instance IsSFiniteKernel.swapRight (κ : kernel α (β × γ)) [IsSFiniteKernel κ] :
-    IsSFiniteKernel (swapRight κ) := by rw [kernel.swapRight]; infer_instance
+instance IsSFiniteKernel.swapRight (κ : Kernel α (β × γ)) [IsSFiniteKernel κ] :
+    IsSFiniteKernel (swapRight κ) := by rw [Kernel.swapRight]; infer_instance
 
-/-- Define a `kernel α β` from a `kernel α (β × γ)` by taking the map of the first projection. -/
-noncomputable def fst (κ : kernel α (β × γ)) : kernel α β :=
+/-- Define a `Kernel α β` from a `Kernel α (β × γ)` by taking the map of the first projection. -/
+noncomputable def fst (κ : Kernel α (β × γ)) : Kernel α β :=
   map κ Prod.fst measurable_fst
 
-theorem fst_apply (κ : kernel α (β × γ)) (a : α) : fst κ a = (κ a).map Prod.fst :=
+theorem fst_apply (κ : Kernel α (β × γ)) (a : α) : fst κ a = (κ a).map Prod.fst :=
   rfl
 
-theorem fst_apply' (κ : kernel α (β × γ)) (a : α) {s : Set β} (hs : MeasurableSet s) :
+theorem fst_apply' (κ : Kernel α (β × γ)) (a : α) {s : Set β} (hs : MeasurableSet s) :
     fst κ a s = κ a {p | p.1 ∈ s} := by rw [fst_apply, Measure.map_apply measurable_fst hs]; rfl
 
 @[simp]
-lemma fst_zero : fst (0 : kernel α (β × γ)) = 0 := by simp [fst]
+lemma fst_zero : fst (0 : Kernel α (β × γ)) = 0 := by simp [fst]
 
-theorem lintegral_fst (κ : kernel α (β × γ)) (a : α) {g : β → ℝ≥0∞} (hg : Measurable g) :
+theorem lintegral_fst (κ : Kernel α (β × γ)) (a : α) {g : β → ℝ≥0∞} (hg : Measurable g) :
     ∫⁻ c, g c ∂fst κ a = ∫⁻ bc : β × γ, g bc.fst ∂κ a := by
   rw [fst, lintegral_map _ measurable_fst a hg]
 
-instance IsMarkovKernel.fst (κ : kernel α (β × γ)) [IsMarkovKernel κ] : IsMarkovKernel (fst κ) := by
-  rw [kernel.fst]; infer_instance
+instance IsMarkovKernel.fst (κ : Kernel α (β × γ)) [IsMarkovKernel κ] : IsMarkovKernel (fst κ) := by
+  rw [Kernel.fst]; infer_instance
 
-instance IsFiniteKernel.fst (κ : kernel α (β × γ)) [IsFiniteKernel κ] : IsFiniteKernel (fst κ) := by
-  rw [kernel.fst]; infer_instance
+instance IsFiniteKernel.fst (κ : Kernel α (β × γ)) [IsFiniteKernel κ] : IsFiniteKernel (fst κ) := by
+  rw [Kernel.fst]; infer_instance
 
-instance IsSFiniteKernel.fst (κ : kernel α (β × γ)) [IsSFiniteKernel κ] :
-    IsSFiniteKernel (fst κ) := by rw [kernel.fst]; infer_instance
+instance IsSFiniteKernel.fst (κ : Kernel α (β × γ)) [IsSFiniteKernel κ] :
+    IsSFiniteKernel (fst κ) := by rw [Kernel.fst]; infer_instance
 
-instance (priority := 100) isFiniteKernel_of_isFiniteKernel_fst {κ : kernel α (β × γ)}
+instance (priority := 100) isFiniteKernel_of_isFiniteKernel_fst {κ : Kernel α (β × γ)}
     [h : IsFiniteKernel (fst κ)] :
     IsFiniteKernel κ := by
   refine ⟨h.bound, h.bound_lt_top, fun a ↦ le_trans ?_ (measure_le_bound (fst κ) a Set.univ)⟩
   rw [fst_apply' _ _ MeasurableSet.univ]
   simp
 
-lemma fst_map_prod (κ : kernel α β) {f : β → γ} {g : β → δ}
+lemma fst_map_prod (κ : Kernel α β) {f : β → γ} {g : β → δ}
     (hf : Measurable f) (hg : Measurable g) :
     fst (map κ (fun x ↦ (f x, g x)) (hf.prod_mk hg)) = map κ f hf := by
   ext x s hs
@@ -870,13 +870,13 @@ lemma fst_map_prod (κ : kernel α β) {f : β → γ} {g : β → δ}
   · rfl
   · exact measurable_fst hs
 
-lemma fst_map_id_prod (κ : kernel α β) {γ : Type*} {mγ : MeasurableSpace γ}
+lemma fst_map_id_prod (κ : Kernel α β) {γ : Type*} {mγ : MeasurableSpace γ}
     {f : β → γ} (hf : Measurable f) :
     fst (map κ (fun a ↦ (a, f a)) (measurable_id.prod_mk hf)) = κ := by
-  rw [fst_map_prod _ measurable_id' hf, kernel.map_id']
+  rw [fst_map_prod _ measurable_id' hf, Kernel.map_id']
 
 @[simp]
-lemma fst_compProd (κ : kernel α β) (η : kernel (α × β) γ) [IsSFiniteKernel κ] [IsMarkovKernel η] :
+lemma fst_compProd (κ : Kernel α β) (η : Kernel (α × β) γ) [IsSFiniteKernel κ] [IsMarkovKernel η] :
     fst (κ ⊗ₖ η) = κ := by
   ext x s hs
   rw [fst_apply' _ _ hs, compProd_apply]
@@ -889,46 +889,46 @@ lemma fst_compProd (κ : kernel α β) (η : kernel (α × β) γ) [IsSFiniteKer
   simp_rw [this]
   rw [lintegral_indicator_const hs, one_mul]
 
-lemma fst_prodMkLeft (δ : Type*) [MeasurableSpace δ] (κ : kernel α (β × γ)) :
+lemma fst_prodMkLeft (δ : Type*) [MeasurableSpace δ] (κ : Kernel α (β × γ)) :
     fst (prodMkLeft δ κ) = prodMkLeft δ (fst κ) := rfl
 
-lemma fst_prodMkRight (κ : kernel α (β × γ)) (δ : Type*) [MeasurableSpace δ] :
+lemma fst_prodMkRight (κ : Kernel α (β × γ)) (δ : Type*) [MeasurableSpace δ] :
     fst (prodMkRight δ κ) = prodMkRight δ (fst κ) := rfl
 
-/-- Define a `kernel α γ` from a `kernel α (β × γ)` by taking the map of the second projection. -/
-noncomputable def snd (κ : kernel α (β × γ)) : kernel α γ :=
+/-- Define a `Kernel α γ` from a `Kernel α (β × γ)` by taking the map of the second projection. -/
+noncomputable def snd (κ : Kernel α (β × γ)) : Kernel α γ :=
   map κ Prod.snd measurable_snd
 
-theorem snd_apply (κ : kernel α (β × γ)) (a : α) : snd κ a = (κ a).map Prod.snd :=
+theorem snd_apply (κ : Kernel α (β × γ)) (a : α) : snd κ a = (κ a).map Prod.snd :=
   rfl
 
-theorem snd_apply' (κ : kernel α (β × γ)) (a : α) {s : Set γ} (hs : MeasurableSet s) :
+theorem snd_apply' (κ : Kernel α (β × γ)) (a : α) {s : Set γ} (hs : MeasurableSet s) :
     snd κ a s = κ a {p | p.2 ∈ s} := by rw [snd_apply, Measure.map_apply measurable_snd hs]; rfl
 
 @[simp]
-lemma snd_zero : snd (0 : kernel α (β × γ)) = 0 := by simp [snd]
+lemma snd_zero : snd (0 : Kernel α (β × γ)) = 0 := by simp [snd]
 
-theorem lintegral_snd (κ : kernel α (β × γ)) (a : α) {g : γ → ℝ≥0∞} (hg : Measurable g) :
+theorem lintegral_snd (κ : Kernel α (β × γ)) (a : α) {g : γ → ℝ≥0∞} (hg : Measurable g) :
     ∫⁻ c, g c ∂snd κ a = ∫⁻ bc : β × γ, g bc.snd ∂κ a := by
   rw [snd, lintegral_map _ measurable_snd a hg]
 
-instance IsMarkovKernel.snd (κ : kernel α (β × γ)) [IsMarkovKernel κ] : IsMarkovKernel (snd κ) := by
-  rw [kernel.snd]; infer_instance
+instance IsMarkovKernel.snd (κ : Kernel α (β × γ)) [IsMarkovKernel κ] : IsMarkovKernel (snd κ) := by
+  rw [Kernel.snd]; infer_instance
 
-instance IsFiniteKernel.snd (κ : kernel α (β × γ)) [IsFiniteKernel κ] : IsFiniteKernel (snd κ) := by
-  rw [kernel.snd]; infer_instance
+instance IsFiniteKernel.snd (κ : Kernel α (β × γ)) [IsFiniteKernel κ] : IsFiniteKernel (snd κ) := by
+  rw [Kernel.snd]; infer_instance
 
-instance IsSFiniteKernel.snd (κ : kernel α (β × γ)) [IsSFiniteKernel κ] :
-    IsSFiniteKernel (snd κ) := by rw [kernel.snd]; infer_instance
+instance IsSFiniteKernel.snd (κ : Kernel α (β × γ)) [IsSFiniteKernel κ] :
+    IsSFiniteKernel (snd κ) := by rw [Kernel.snd]; infer_instance
 
-instance (priority := 100) isFiniteKernel_of_isFiniteKernel_snd {κ : kernel α (β × γ)}
+instance (priority := 100) isFiniteKernel_of_isFiniteKernel_snd {κ : Kernel α (β × γ)}
     [h : IsFiniteKernel (snd κ)] :
     IsFiniteKernel κ := by
   refine ⟨h.bound, h.bound_lt_top, fun a ↦ le_trans ?_ (measure_le_bound (snd κ) a Set.univ)⟩
   rw [snd_apply' _ _ MeasurableSet.univ]
   simp
 
-lemma snd_map_prod (κ : kernel α β) {f : β → γ} {g : β → δ}
+lemma snd_map_prod (κ : Kernel α β) {f : β → γ} {g : β → δ}
     (hf : Measurable f) (hg : Measurable g) :
     snd (map κ (fun x ↦ (f x, g x)) (hf.prod_mk hg)) = map κ g hg := by
   ext x s hs
@@ -936,26 +936,26 @@ lemma snd_map_prod (κ : kernel α β) {f : β → γ} {g : β → δ}
   · rfl
   · exact measurable_snd hs
 
-lemma snd_map_prod_id (κ : kernel α β) {γ : Type*} {mγ : MeasurableSpace γ}
+lemma snd_map_prod_id (κ : Kernel α β) {γ : Type*} {mγ : MeasurableSpace γ}
     {f : β → γ} (hf : Measurable f) :
     snd (map κ (fun a ↦ (f a, a)) (hf.prod_mk measurable_id)) = κ := by
-  rw [snd_map_prod _ hf measurable_id', kernel.map_id']
+  rw [snd_map_prod _ hf measurable_id', Kernel.map_id']
 
-lemma snd_prodMkLeft (δ : Type*) [MeasurableSpace δ] (κ : kernel α (β × γ)) :
+lemma snd_prodMkLeft (δ : Type*) [MeasurableSpace δ] (κ : Kernel α (β × γ)) :
     snd (prodMkLeft δ κ) = prodMkLeft δ (snd κ) := rfl
 
-lemma snd_prodMkRight (κ : kernel α (β × γ)) (δ : Type*) [MeasurableSpace δ] :
+lemma snd_prodMkRight (κ : Kernel α (β × γ)) (δ : Type*) [MeasurableSpace δ] :
     snd (prodMkRight δ κ) = prodMkRight δ (snd κ) := rfl
 
 @[simp]
-lemma fst_swapRight (κ : kernel α (β × γ)) : fst (swapRight κ) = snd κ := by
+lemma fst_swapRight (κ : Kernel α (β × γ)) : fst (swapRight κ) = snd κ := by
   ext a s hs
   rw [fst_apply' _ _ hs, swapRight_apply', snd_apply' _ _ hs]
   · rfl
   · exact measurable_fst hs
 
 @[simp]
-lemma snd_swapRight (κ : kernel α (β × γ)) : snd (swapRight κ) = fst κ := by
+lemma snd_swapRight (κ : Kernel α (β × γ)) : snd (swapRight κ) = fst κ := by
   ext a s hs
   rw [snd_apply' _ _ hs, swapRight_apply', fst_apply' _ _ hs]
   · rfl
@@ -971,20 +971,20 @@ section Comp
 variable {γ : Type*} {mγ : MeasurableSpace γ} {f : β → γ} {g : γ → α}
 
 /-- Composition of two kernels. -/
-noncomputable def comp (η : kernel β γ) (κ : kernel α β) : kernel α γ where
-  val a := (κ a).bind η
-  property := (Measure.measurable_bind' (kernel.measurable _)).comp (kernel.measurable _)
+noncomputable def comp (η : Kernel β γ) (κ : Kernel α β) : Kernel α γ where
+  toFun a := (κ a).bind η
+  measurable' := (Measure.measurable_bind' η.measurable).comp κ.measurable
 
-scoped[ProbabilityTheory] infixl:100 " ∘ₖ " => ProbabilityTheory.kernel.comp
+scoped[ProbabilityTheory] infixl:100 " ∘ₖ " => ProbabilityTheory.Kernel.comp
 
-theorem comp_apply (η : kernel β γ) (κ : kernel α β) (a : α) : (η ∘ₖ κ) a = (κ a).bind η :=
+theorem comp_apply (η : Kernel β γ) (κ : Kernel α β) (a : α) : (η ∘ₖ κ) a = (κ a).bind η :=
   rfl
 
-theorem comp_apply' (η : kernel β γ) (κ : kernel α β) (a : α) {s : Set γ} (hs : MeasurableSet s) :
+theorem comp_apply' (η : Kernel β γ) (κ : Kernel α β) (a : α) {s : Set γ} (hs : MeasurableSet s) :
     (η ∘ₖ κ) a s = ∫⁻ b, η b s ∂κ a := by
-  rw [comp_apply, Measure.bind_apply hs (kernel.measurable _)]
+  rw [comp_apply, Measure.bind_apply hs (Kernel.measurable _)]
 
-theorem comp_eq_snd_compProd (η : kernel β γ) [IsSFiniteKernel η] (κ : kernel α β)
+theorem comp_eq_snd_compProd (η : Kernel β γ) [IsSFiniteKernel η] (κ : Kernel α β)
     [IsSFiniteKernel κ] : η ∘ₖ κ = snd (κ ⊗ₖ prodMkLeft α η) := by
   ext a s hs
   rw [comp_apply' _ _ _ hs, snd_apply' _ _ hs, compProd_apply]
@@ -992,36 +992,36 @@ theorem comp_eq_snd_compProd (η : kernel β γ) [IsSFiniteKernel η] (κ : kern
   · exact measurable_snd hs
   simp only [Set.mem_setOf_eq, Set.setOf_mem_eq, prodMkLeft_apply' _ _ s]
 
-theorem lintegral_comp (η : kernel β γ) (κ : kernel α β) (a : α) {g : γ → ℝ≥0∞}
+theorem lintegral_comp (η : Kernel β γ) (κ : Kernel α β) (a : α) {g : γ → ℝ≥0∞}
     (hg : Measurable g) : ∫⁻ c, g c ∂(η ∘ₖ κ) a = ∫⁻ b, ∫⁻ c, g c ∂η b ∂κ a := by
-  rw [comp_apply, Measure.lintegral_bind (kernel.measurable _) hg]
+  rw [comp_apply, Measure.lintegral_bind (Kernel.measurable _) hg]
 
-instance IsMarkovKernel.comp (η : kernel β γ) [IsMarkovKernel η] (κ : kernel α β)
+instance IsMarkovKernel.comp (η : Kernel β γ) [IsMarkovKernel η] (κ : Kernel α β)
     [IsMarkovKernel κ] : IsMarkovKernel (η ∘ₖ κ) := by rw [comp_eq_snd_compProd]; infer_instance
 
-instance IsFiniteKernel.comp (η : kernel β γ) [IsFiniteKernel η] (κ : kernel α β)
+instance IsFiniteKernel.comp (η : Kernel β γ) [IsFiniteKernel η] (κ : Kernel α β)
     [IsFiniteKernel κ] : IsFiniteKernel (η ∘ₖ κ) := by rw [comp_eq_snd_compProd]; infer_instance
 
-instance IsSFiniteKernel.comp (η : kernel β γ) [IsSFiniteKernel η] (κ : kernel α β)
+instance IsSFiniteKernel.comp (η : Kernel β γ) [IsSFiniteKernel η] (κ : Kernel α β)
     [IsSFiniteKernel κ] : IsSFiniteKernel (η ∘ₖ κ) := by rw [comp_eq_snd_compProd]; infer_instance
 
 /-- Composition of kernels is associative. -/
-theorem comp_assoc {δ : Type*} {mδ : MeasurableSpace δ} (ξ : kernel γ δ) [IsSFiniteKernel ξ]
-    (η : kernel β γ) (κ : kernel α β) : ξ ∘ₖ η ∘ₖ κ = ξ ∘ₖ (η ∘ₖ κ) := by
+theorem comp_assoc {δ : Type*} {mδ : MeasurableSpace δ} (ξ : Kernel γ δ) [IsSFiniteKernel ξ]
+    (η : Kernel β γ) (κ : Kernel α β) : ξ ∘ₖ η ∘ₖ κ = ξ ∘ₖ (η ∘ₖ κ) := by
   refine ext_fun fun a f hf => ?_
   simp_rw [lintegral_comp _ _ _ hf, lintegral_comp _ _ _ hf.lintegral_kernel]
 
-theorem deterministic_comp_eq_map (hf : Measurable f) (κ : kernel α β) :
+theorem deterministic_comp_eq_map (hf : Measurable f) (κ : Kernel α β) :
     deterministic f hf ∘ₖ κ = map κ f hf := by
   ext a s hs
   simp_rw [map_apply' _ _ _ hs, comp_apply' _ _ _ hs, deterministic_apply' hf _ hs,
     lintegral_indicator_const_comp hf hs, one_mul]
 
-theorem comp_deterministic_eq_comap (κ : kernel α β) (hg : Measurable g) :
+theorem comp_deterministic_eq_comap (κ : Kernel α β) (hg : Measurable g) :
     κ ∘ₖ deterministic g hg = comap κ g hg := by
   ext a s hs
   simp_rw [comap_apply' _ _ _ s, comp_apply' _ _ _ hs, deterministic_apply hg a,
-    lintegral_dirac' _ (kernel.measurable_coe κ hs)]
+    lintegral_dirac' _ (Kernel.measurable_coe κ hs)]
 
 end Comp
 
@@ -1033,17 +1033,17 @@ section Prod
 variable {γ : Type*} {mγ : MeasurableSpace γ}
 
 /-- Product of two kernels. This is meaningful only when the kernels are s-finite. -/
-noncomputable def prod (κ : kernel α β) (η : kernel α γ) : kernel α (β × γ) :=
+noncomputable def prod (κ : Kernel α β) (η : Kernel α γ) : Kernel α (β × γ) :=
   κ ⊗ₖ swapLeft (prodMkLeft β η)
 
-scoped[ProbabilityTheory] infixl:100 " ×ₖ " => ProbabilityTheory.kernel.prod
+scoped[ProbabilityTheory] infixl:100 " ×ₖ " => ProbabilityTheory.Kernel.prod
 
-theorem prod_apply' (κ : kernel α β) [IsSFiniteKernel κ] (η : kernel α γ) [IsSFiniteKernel η]
+theorem prod_apply' (κ : Kernel α β) [IsSFiniteKernel κ] (η : Kernel α γ) [IsSFiniteKernel η]
     (a : α) {s : Set (β × γ)} (hs : MeasurableSet s) :
     (κ ×ₖ η) a s = ∫⁻ b : β, (η a) {c : γ | (b, c) ∈ s} ∂κ a := by
   simp_rw [prod, compProd_apply _ _ _ hs, swapLeft_apply _ _, prodMkLeft_apply, Prod.swap_prod_mk]
 
-lemma prod_apply (κ : kernel α β) [IsSFiniteKernel κ] (η : kernel α γ) [IsSFiniteKernel η]
+lemma prod_apply (κ : Kernel α β) [IsSFiniteKernel κ] (η : Kernel α γ) [IsSFiniteKernel η]
     (a : α) :
     (κ ×ₖ η) a = (κ a).prod (η a) := by
   ext s hs
@@ -1055,30 +1055,28 @@ lemma prod_const (μ : Measure β) [SFinite μ] (ν : Measure γ) [SFinite ν] :
   ext x
   rw [const_apply, prod_apply, const_apply, const_apply]
 
-theorem lintegral_prod (κ : kernel α β) [IsSFiniteKernel κ] (η : kernel α γ) [IsSFiniteKernel η]
+theorem lintegral_prod (κ : Kernel α β) [IsSFiniteKernel κ] (η : Kernel α γ) [IsSFiniteKernel η]
     (a : α) {g : β × γ → ℝ≥0∞} (hg : Measurable g) :
     ∫⁻ c, g c ∂(κ ×ₖ η) a = ∫⁻ b, ∫⁻ c, g (b, c) ∂η a ∂κ a := by
   simp_rw [prod, lintegral_compProd _ _ _ hg, swapLeft_apply, prodMkLeft_apply, Prod.swap_prod_mk]
 
-instance IsMarkovKernel.prod (κ : kernel α β) [IsMarkovKernel κ] (η : kernel α γ)
-    [IsMarkovKernel η] : IsMarkovKernel (κ ×ₖ η) := by rw [kernel.prod]; infer_instance
+instance IsMarkovKernel.prod (κ : Kernel α β) [IsMarkovKernel κ] (η : Kernel α γ)
+    [IsMarkovKernel η] : IsMarkovKernel (κ ×ₖ η) := by rw [Kernel.prod]; infer_instance
 
-instance IsFiniteKernel.prod (κ : kernel α β) [IsFiniteKernel κ] (η : kernel α γ)
-    [IsFiniteKernel η] : IsFiniteKernel (κ ×ₖ η) := by rw [kernel.prod]; infer_instance
+instance IsFiniteKernel.prod (κ : Kernel α β) [IsFiniteKernel κ] (η : Kernel α γ)
+    [IsFiniteKernel η] : IsFiniteKernel (κ ×ₖ η) := by rw [Kernel.prod]; infer_instance
 
-instance IsSFiniteKernel.prod (κ : kernel α β) (η : kernel α γ) :
-    IsSFiniteKernel (κ ×ₖ η) := by rw [kernel.prod]; infer_instance
+instance IsSFiniteKernel.prod (κ : Kernel α β) (η : Kernel α γ) :
+    IsSFiniteKernel (κ ×ₖ η) := by rw [Kernel.prod]; infer_instance
 
-@[simp] lemma fst_prod (κ : kernel α β) [IsSFiniteKernel κ] (η : kernel α γ) [IsMarkovKernel η] :
+@[simp] lemma fst_prod (κ : Kernel α β) [IsSFiniteKernel κ] (η : Kernel α γ) [IsMarkovKernel η] :
     fst (κ ×ₖ η) = κ := by
   rw [prod]; simp
 
-@[simp] lemma snd_prod (κ : kernel α β) [IsMarkovKernel κ] (η : kernel α γ) [IsSFiniteKernel η] :
+@[simp] lemma snd_prod (κ : Kernel α β) [IsMarkovKernel κ] (η : Kernel α γ) [IsSFiniteKernel η] :
     snd (κ ×ₖ η) = η := by
   ext x; simp [snd_apply, prod_apply]
 
 end Prod
-
-end kernel
-
+end Kernel
 end ProbabilityTheory

--- a/Mathlib/Probability/Kernel/CondDistrib.lean
+++ b/Mathlib/Probability/Kernel/CondDistrib.lean
@@ -216,7 +216,7 @@ theorem condDistrib_ae_eq_condexp (hX : Measurable X) (hY : Measurable Y) (hs : 
     exact @Measurable.ennreal_toReal _ (mβ.comap X) _ (measurable_condDistrib hs)
 
 /-- The conditional expectation of a function `f` of the product `(X, Y)` is almost everywhere equal
-to the integral of `y ↦ f(X, y)` against the `condDistrib` Kernel. -/
+to the integral of `y ↦ f(X, y)` against the `condDistrib` kernel. -/
 theorem condexp_prod_ae_eq_integral_condDistrib' [NormedSpace ℝ F] [CompleteSpace F]
     (hX : Measurable X) (hY : AEMeasurable Y μ)
     (hf_int : Integrable f (μ.map fun a => (X a, Y a))) :
@@ -240,7 +240,7 @@ theorem condexp_prod_ae_eq_integral_condDistrib' [NormedSpace ℝ F] [CompleteSp
   · exact aestronglyMeasurable'_integral_condDistrib hX.aemeasurable hY hf_int.1
 
 /-- The conditional expectation of a function `f` of the product `(X, Y)` is almost everywhere equal
-to the integral of `y ↦ f(X, y)` against the `condDistrib` Kernel. -/
+to the integral of `y ↦ f(X, y)` against the `condDistrib` kernel. -/
 theorem condexp_prod_ae_eq_integral_condDistrib₀ [NormedSpace ℝ F] [CompleteSpace F]
     (hX : Measurable X) (hY : AEMeasurable Y μ)
     (hf : AEStronglyMeasurable f (μ.map fun a => (X a, Y a)))
@@ -251,7 +251,7 @@ theorem condexp_prod_ae_eq_integral_condDistrib₀ [NormedSpace ℝ F] [Complete
   condexp_prod_ae_eq_integral_condDistrib' hX hY hf_int'
 
 /-- The conditional expectation of a function `f` of the product `(X, Y)` is almost everywhere equal
-to the integral of `y ↦ f(X, y)` against the `condDistrib` Kernel. -/
+to the integral of `y ↦ f(X, y)` against the `condDistrib` kernel. -/
 theorem condexp_prod_ae_eq_integral_condDistrib [NormedSpace ℝ F] [CompleteSpace F]
     (hX : Measurable X) (hY : AEMeasurable Y μ) (hf : StronglyMeasurable f)
     (hf_int : Integrable (fun a => f (X a, Y a)) μ) :

--- a/Mathlib/Probability/Kernel/CondDistrib.lean
+++ b/Mathlib/Probability/Kernel/CondDistrib.lean
@@ -10,7 +10,7 @@ import Mathlib.Probability.Notation
 # Regular conditional probability distribution
 
 We define the regular conditional probability distribution of `Y : α → Ω` given `X : α → β`, where
-`Ω` is a standard Borel space. This is a `kernel β Ω` such that for almost all `a`, `condDistrib`
+`Ω` is a standard Borel space. This is a `Kernel β Ω` such that for almost all `a`, `condDistrib`
 evaluated at `X a` and a measurable set `s` is equal to the conditional expectation
 `μ⟦Y ⁻¹' s | mβ.comap X⟧` evaluated at `a`.
 
@@ -58,7 +58,7 @@ the conditional expectation `μ⟦Y ⁻¹' s | mβ.comap X⟧ a`. It also satisf
 `μ[(fun a => f (X a, Y a)) | mβ.comap X] =ᵐ[μ] fun a => ∫ y, f (X a, y) ∂(condDistrib Y X μ (X a))`
 for all integrable functions `f`. -/
 noncomputable irreducible_def condDistrib {_ : MeasurableSpace α} [MeasurableSpace β] (Y : α → Ω)
-    (X : α → β) (μ : Measure α) [IsFiniteMeasure μ] : kernel β Ω :=
+    (X : α → β) (μ : Measure α) [IsFiniteMeasure μ] : Kernel β Ω :=
   (μ.map fun a => (X a, Y a)).condKernel
 
 instance [MeasurableSpace β] : IsMarkovKernel (condDistrib Y X μ) := by
@@ -79,7 +79,7 @@ section Measurability
 
 theorem measurable_condDistrib (hs : MeasurableSet s) :
     Measurable[mβ.comap X] fun a => condDistrib Y X μ (X a) s :=
-  (kernel.measurable_coe _ hs).comp (Measurable.of_comap_le le_rfl)
+  (Kernel.measurable_coe _ hs).comp (Measurable.of_comap_le le_rfl)
 
 theorem _root_.MeasureTheory.AEStronglyMeasurable.ae_integrable_condDistrib_map_iff
     (hY : AEMeasurable Y μ) (hf : AEStronglyMeasurable f (μ.map fun a => (X a, Y a))) :
@@ -110,7 +110,7 @@ end Measurability
 /-- `condDistrib` is a.e. uniquely defined as the kernel satisfying the defining property of
 `condKernel`. -/
 theorem condDistrib_ae_eq_of_measure_eq_compProd (hX : Measurable X) (hY : Measurable Y)
-    (κ : kernel β Ω) [IsFiniteKernel κ] (hκ : μ.map (fun x => (X x, Y x)) = μ.map X ⊗ₘ κ) :
+    (κ : Kernel β Ω) [IsFiniteKernel κ] (hκ : μ.map (fun x => (X x, Y x)) = μ.map X ⊗ₘ κ) :
     ∀ᵐ x ∂μ.map X, κ x = condDistrib Y X μ x := by
   have heq : μ.map X = (μ.map (fun x ↦ (X x, Y x))).fst := by
     ext s hs
@@ -126,7 +126,7 @@ section Integrability
 theorem integrable_toReal_condDistrib (hX : AEMeasurable X μ) (hs : MeasurableSet s) :
     Integrable (fun a => (condDistrib Y X μ (X a) s).toReal) μ := by
   refine integrable_toReal_of_lintegral_ne_top ?_ ?_
-  · exact Measurable.comp_aemeasurable (kernel.measurable_coe _ hs) hX
+  · exact Measurable.comp_aemeasurable (Kernel.measurable_coe _ hs) hX
   · refine ne_of_lt ?_
     calc
       ∫⁻ a, condDistrib Y X μ (X a) s ∂μ ≤ ∫⁻ _, 1 ∂μ := lintegral_mono fun a => prob_le_one
@@ -184,7 +184,7 @@ theorem setLIntegral_preimage_condDistrib (hX : Measurable X) (hY : AEMeasurable
   -- Porting note: need to massage the LHS integrand into the form accepted by `lintegral_comp`
   -- (`rw` does not see that the two forms are defeq)
   conv_lhs => arg 2; change (fun a => ((condDistrib Y X μ) a) s) ∘ X
-  rw [lintegral_comp (kernel.measurable_coe _ hs) hX, condDistrib, ← Measure.restrict_map hX ht, ←
+  rw [lintegral_comp (Kernel.measurable_coe _ hs) hX, condDistrib, ← Measure.restrict_map hX ht, ←
     Measure.fst_map_prod_mk₀ hY, Measure.setLIntegral_condKernel_eq_measure_prod ht hs,
     Measure.map_apply_of_aemeasurable (hX.aemeasurable.prod_mk hY) (ht.prod hs), mk_preimage_prod]
 
@@ -216,7 +216,7 @@ theorem condDistrib_ae_eq_condexp (hX : Measurable X) (hY : Measurable Y) (hs : 
     exact @Measurable.ennreal_toReal _ (mβ.comap X) _ (measurable_condDistrib hs)
 
 /-- The conditional expectation of a function `f` of the product `(X, Y)` is almost everywhere equal
-to the integral of `y ↦ f(X, y)` against the `condDistrib` kernel. -/
+to the integral of `y ↦ f(X, y)` against the `condDistrib` Kernel. -/
 theorem condexp_prod_ae_eq_integral_condDistrib' [NormedSpace ℝ F] [CompleteSpace F]
     (hX : Measurable X) (hY : AEMeasurable Y μ)
     (hf_int : Integrable f (μ.map fun a => (X a, Y a))) :
@@ -240,7 +240,7 @@ theorem condexp_prod_ae_eq_integral_condDistrib' [NormedSpace ℝ F] [CompleteSp
   · exact aestronglyMeasurable'_integral_condDistrib hX.aemeasurable hY hf_int.1
 
 /-- The conditional expectation of a function `f` of the product `(X, Y)` is almost everywhere equal
-to the integral of `y ↦ f(X, y)` against the `condDistrib` kernel. -/
+to the integral of `y ↦ f(X, y)` against the `condDistrib` Kernel. -/
 theorem condexp_prod_ae_eq_integral_condDistrib₀ [NormedSpace ℝ F] [CompleteSpace F]
     (hX : Measurable X) (hY : AEMeasurable Y μ)
     (hf : AEStronglyMeasurable f (μ.map fun a => (X a, Y a)))
@@ -251,7 +251,7 @@ theorem condexp_prod_ae_eq_integral_condDistrib₀ [NormedSpace ℝ F] [Complete
   condexp_prod_ae_eq_integral_condDistrib' hX hY hf_int'
 
 /-- The conditional expectation of a function `f` of the product `(X, Y)` is almost everywhere equal
-to the integral of `y ↦ f(X, y)` against the `condDistrib` kernel. -/
+to the integral of `y ↦ f(X, y)` against the `condDistrib` Kernel. -/
 theorem condexp_prod_ae_eq_integral_condDistrib [NormedSpace ℝ F] [CompleteSpace F]
     (hX : Measurable X) (hY : AEMeasurable Y μ) (hf : StronglyMeasurable f)
     (hf_int : Integrable (fun a => f (X a, Y a)) μ) :

--- a/Mathlib/Probability/Kernel/Condexp.lean
+++ b/Mathlib/Probability/Kernel/Condexp.lean
@@ -63,15 +63,15 @@ variable {Ω F : Type*} {m : MeasurableSpace Ω} [mΩ : MeasurableSpace Ω]
 It is defined as the conditional distribution of the identity given the identity, where the second
 identity is understood as a map from `Ω` with the σ-algebra `mΩ` to `Ω` with σ-algebra `m ⊓ mΩ`.
 We use `m ⊓ mΩ` instead of `m` to ensure that it is a sub-σ-algebra of `mΩ`. We then use
-`kernel.comap` to get a kernel from `m` to `mΩ` instead of from `m ⊓ mΩ` to `mΩ`. -/
+`Kernel.comap` to get a kernel from `m` to `mΩ` instead of from `m ⊓ mΩ` to `mΩ`. -/
 noncomputable irreducible_def condexpKernel (μ : Measure Ω) [IsFiniteMeasure μ]
-    (m : MeasurableSpace Ω) : @kernel Ω Ω m mΩ :=
-  kernel.comap (@condDistrib Ω Ω Ω mΩ _ _ mΩ (m ⊓ mΩ) id id μ _) id
+    (m : MeasurableSpace Ω) : @Kernel Ω Ω m mΩ :=
+  Kernel.comap (@condDistrib Ω Ω Ω mΩ _ _ mΩ (m ⊓ mΩ) id id μ _) id
     (measurable_id'' (inf_le_left : m ⊓ mΩ ≤ m))
 
 lemma condexpKernel_apply_eq_condDistrib {ω : Ω} :
     condexpKernel μ m ω = @condDistrib Ω Ω Ω mΩ _ _ mΩ (m ⊓ mΩ) id id μ _ (id ω) := by
-  simp_rw [condexpKernel, kernel.comap_apply]
+  simp_rw [condexpKernel, Kernel.comap_apply]
 
 instance : IsMarkovKernel (condexpKernel μ m) := by simp only [condexpKernel]; infer_instance
 

--- a/Mathlib/Probability/Kernel/Disintegration/Basic.lean
+++ b/Mathlib/Probability/Kernel/Disintegration/Basic.lean
@@ -11,30 +11,30 @@ import Mathlib.Probability.Kernel.Disintegration.CdfToKernel
 /-!
 # Disintegration of kernels and measures
 
-Let `κ : kernel α (β × Ω)` be a finite kernel, where `Ω` is a standard Borel space. Then if `α` is
+Let `κ : Kernel α (β × Ω)` be a finite kernel, where `Ω` is a standard Borel space. Then if `α` is
 countable or `β` has a countably generated σ-algebra (for example if it is standard Borel), then
-there exists a `kernel (α × β) Ω` called conditional kernel and denoted by `condKernel κ` such that
+there exists a `Kernel (α × β) Ω` called conditional kernel and denoted by `condKernel κ` such that
 `κ = fst κ ⊗ₖ condKernel κ`.
 We also define a conditional kernel for a measure `ρ : Measure (β × Ω)`, where `Ω` is a standard
-Borel space. This is a `kernel β Ω` denoted by `ρ.condKernel` such that `ρ = ρ.fst ⊗ₘ ρ.condKernel`.
+Borel space. This is a `Kernel β Ω` denoted by `ρ.condKernel` such that `ρ = ρ.fst ⊗ₘ ρ.condKernel`.
 
 In order to obtain a disintegration for any standard Borel space `Ω`, we use that these spaces embed
 measurably into `ℝ`: it then suffices to define a suitable kernel for `Ω = ℝ`.
 
-For `κ : kernel α (β × ℝ)`, the construction of the conditional kernel proceeds as follows:
+For `κ : Kernel α (β × ℝ)`, the construction of the conditional kernel proceeds as follows:
 * Build a measurable function `f : (α × β) → ℚ → ℝ` such that for all measurable sets
-  `s` and all `q : ℚ`, `∫ x in s, f (a, x) q ∂(kernel.fst κ a) = (κ a (s ×ˢ Iic (q : ℝ))).toReal`.
+  `s` and all `q : ℚ`, `∫ x in s, f (a, x) q ∂(Kernel.fst κ a) = (κ a (s ×ˢ Iic (q : ℝ))).toReal`.
   We restrict to `ℚ` here to be able to prove the measurability.
 * Extend that function to `(α × β) → StieltjesFunction`. See the file `MeasurableStieltjes.lean`.
 * Finally obtain from the measurable Stieltjes function a measure on `ℝ` for each element of `α × β`
-  in a measurable way: we have obtained a `kernel (α × β) ℝ`.
+  in a measurable way: we have obtained a `Kernel (α × β) ℝ`.
   See the file `CdfToKernel.lean` for that step.
 
 The first step (building the measurable function on `ℚ`) is done differently depending on whether
 `α` is countable or not.
 * If `α` is countable, we can provide for each `a : α` a function `f : β → ℚ → ℝ` and proceed as
-  above to obtain a `kernel β ℝ`. Since `α` is countable, measurability is not an issue and we can
-  put those together into a `kernel (α × β) ℝ`. The construction of that `f` is done in
+  above to obtain a `Kernel β ℝ`. Since `α` is countable, measurability is not an issue and we can
+  put those together into a `Kernel (α × β) ℝ`. The construction of that `f` is done in
   the `CondCdf.lean` file.
 * If `α` is not countable, we can't proceed separately for each `a : α` and have to build a function
   `f : α × β → ℚ → ℝ` which is measurable on the product. We are able to do so if `β` has a
@@ -51,12 +51,12 @@ The conditional kernel is unique (almost everywhere w.r.t. `fst κ`): this is pr
 
 ## Main definitions
 
-* `ProbabilityTheory.kernel.condKernel κ : kernel (α × β) Ω`: conditional kernel described above.
-* `MeasureTheory.Measure.condKernel ρ : kernel β Ω`: conditional kernel of a measure.
+* `ProbabilityTheory.Kernel.condKernel κ : Kernel (α × β) Ω`: conditional kernel described above.
+* `MeasureTheory.Measure.condKernel ρ : Kernel β Ω`: conditional kernel of a measure.
 
 ## Main statements
 
-* `ProbabilityTheory.kernel.compProd_fst_condKernel`: `fst κ ⊗ₖ condKernel κ = κ`
+* `ProbabilityTheory.Kernel.compProd_fst_condKernel`: `fst κ ⊗ₖ condKernel κ = κ`
 * `MeasureTheory.Measure.compProd_fst_condKernel`: `ρ.fst ⊗ₘ ρ.condKernel = ρ`
 -/
 
@@ -64,7 +64,7 @@ open MeasureTheory Set Filter MeasurableSpace
 
 open scoped ENNReal MeasureTheory Topology ProbabilityTheory
 
-namespace ProbabilityTheory.kernel
+namespace ProbabilityTheory.Kernel
 
 variable {α β γ Ω : Type*} {mα : MeasurableSpace α} {mβ : MeasurableSpace β}
   {mγ : MeasurableSpace γ} [MeasurableSpace.CountablyGenerated γ]
@@ -74,7 +74,7 @@ section Real
 
 /-! ### Disintegration of kernels from `α` to `γ × ℝ` for countably generated `γ` -/
 
-lemma isRatCondKernelCDFAux_density_Iic (κ : kernel α (γ × ℝ)) [IsFiniteKernel κ] :
+lemma isRatCondKernelCDFAux_density_Iic (κ : Kernel α (γ × ℝ)) [IsFiniteKernel κ] :
     IsRatCondKernelCDFAux (fun (p : α × γ) q ↦ density κ (fst κ) p.1 p.2 (Iic q)) κ (fst κ) where
   measurable := measurable_pi_iff.mpr fun _ ↦ measurable_density κ (fst κ) measurableSet_Iic
   mono' a q r hqr :=
@@ -111,49 +111,49 @@ lemma isRatCondKernelCDFAux_density_Iic (κ : kernel α (γ × ℝ)) [IsFiniteKe
 
 /-- Taking the kernel density of intervals `Iic q` for `q : ℚ` gives a function with the property
 `isRatCondKernelCDF`. -/
-lemma isRatCondKernelCDF_density_Iic (κ : kernel α (γ × ℝ)) [IsFiniteKernel κ] :
+lemma isRatCondKernelCDF_density_Iic (κ : Kernel α (γ × ℝ)) [IsFiniteKernel κ] :
     IsRatCondKernelCDF (fun (p : α × γ) q ↦ density κ (fst κ) p.1 p.2 (Iic q)) κ (fst κ) :=
   (isRatCondKernelCDFAux_density_Iic κ).isRatCondKernelCDF
 
-/-- The conditional kernel CDF of a kernel `κ : kernel α (γ × ℝ)`, where `γ` is countably generated.
+/-- The conditional kernel CDF of a kernel `κ : Kernel α (γ × ℝ)`, where `γ` is countably generated.
 -/
 noncomputable
-def condKernelCDF (κ : kernel α (γ × ℝ)) [IsFiniteKernel κ] : α × γ → StieltjesFunction :=
+def condKernelCDF (κ : Kernel α (γ × ℝ)) [IsFiniteKernel κ] : α × γ → StieltjesFunction :=
   stieltjesOfMeasurableRat (fun (p : α × γ) q ↦ density κ (fst κ) p.1 p.2 (Iic q))
     (isRatCondKernelCDF_density_Iic κ).measurable
 
-lemma isCondKernelCDF_condKernelCDF (κ : kernel α (γ × ℝ)) [IsFiniteKernel κ] :
+lemma isCondKernelCDF_condKernelCDF (κ : Kernel α (γ × ℝ)) [IsFiniteKernel κ] :
     IsCondKernelCDF (condKernelCDF κ) κ (fst κ) :=
   isCondKernelCDF_stieltjesOfMeasurableRat (isRatCondKernelCDF_density_Iic κ)
 
-/-- Auxiliary definition for `ProbabilityTheory.kernel.condKernel`.
-A conditional kernel for `κ : kernel α (γ × ℝ)` where `γ` is countably generated. -/
+/-- Auxiliary definition for `ProbabilityTheory.Kernel.condKernel`.
+A conditional kernel for `κ : Kernel α (γ × ℝ)` where `γ` is countably generated. -/
 noncomputable
-def condKernelReal (κ : kernel α (γ × ℝ)) [IsFiniteKernel κ] : kernel (α × γ) ℝ :=
+def condKernelReal (κ : Kernel α (γ × ℝ)) [IsFiniteKernel κ] : Kernel (α × γ) ℝ :=
   (isCondKernelCDF_condKernelCDF κ).toKernel
 
-instance instIsMarkovKernelCondKernelReal (κ : kernel α (γ × ℝ)) [IsFiniteKernel κ] :
+instance instIsMarkovKernelCondKernelReal (κ : Kernel α (γ × ℝ)) [IsFiniteKernel κ] :
     IsMarkovKernel (condKernelReal κ) := by
   rw [condKernelReal]
   infer_instance
 
-lemma compProd_fst_condKernelReal (κ : kernel α (γ × ℝ)) [IsFiniteKernel κ] :
+lemma compProd_fst_condKernelReal (κ : Kernel α (γ × ℝ)) [IsFiniteKernel κ] :
     fst κ ⊗ₖ condKernelReal κ = κ := by
   rw [condKernelReal, compProd_toKernel]
 
 /-- Auxiliary definition for `MeasureTheory.Measure.condKernel` and
-`ProbabilityTheory.kernel.condKernel`.
-A conditional kernel for `κ : kernel Unit (α × ℝ)`. -/
+`ProbabilityTheory.Kernel.condKernel`.
+A conditional kernel for `κ : Kernel Unit (α × ℝ)`. -/
 noncomputable
-def condKernelUnitReal (κ : kernel Unit (α × ℝ)) [IsFiniteKernel κ] : kernel (Unit × α) ℝ :=
+def condKernelUnitReal (κ : Kernel Unit (α × ℝ)) [IsFiniteKernel κ] : Kernel (Unit × α) ℝ :=
   (isCondKernelCDF_condCDF (κ ())).toKernel
 
-instance instIsMarkovKernelCondKernelUnitReal (κ : kernel Unit (α × ℝ)) [IsFiniteKernel κ] :
+instance instIsMarkovKernelCondKernelUnitReal (κ : Kernel Unit (α × ℝ)) [IsFiniteKernel κ] :
     IsMarkovKernel (condKernelUnitReal κ) := by
   rw [condKernelUnitReal]
   infer_instance
 
-lemma compProd_fst_condKernelUnitReal (κ : kernel Unit (α × ℝ)) [IsFiniteKernel κ] :
+lemma compProd_fst_condKernelUnitReal (κ : Kernel Unit (α × ℝ)) [IsFiniteKernel κ] :
     fst κ ⊗ₖ condKernelUnitReal κ = κ := by
   rw [condKernelUnitReal, compProd_toKernel]
   ext a
@@ -169,27 +169,27 @@ Since every standard Borel space embeds measurably into `ℝ`, we can generalize
 property on `ℝ` to all these spaces. -/
 
 open Classical in
-/-- Auxiliary definition for `ProbabilityTheory.kernel.condKernel`.
-A Borel space `Ω` embeds measurably into `ℝ` (with embedding `e`), hence we can get a `kernel α Ω`
-from a `kernel α ℝ` by taking the comap by `e`.
-Here we take the comap of a modification of `η : kernel α ℝ`, useful when `η a` is a probability
+/-- Auxiliary definition for `ProbabilityTheory.Kernel.condKernel`.
+A Borel space `Ω` embeds measurably into `ℝ` (with embedding `e`), hence we can get a `Kernel α Ω`
+from a `Kernel α ℝ` by taking the comap by `e`.
+Here we take the comap of a modification of `η : Kernel α ℝ`, useful when `η a` is a probability
 measure with all its mass on `range e` almost everywhere with respect to some measure and we want to
-ensure that the comap is a Markov kernel.
+ensure that the comap is a Markov Kernel.
 We thus take the comap by `e` of a kernel defined piecewise: `η` when
 `η a (range (embeddingReal Ω))ᶜ = 0`, and an arbitrary deterministic kernel otherwise. -/
 noncomputable
 def borelMarkovFromReal (Ω : Type*) [Nonempty Ω] [MeasurableSpace Ω] [StandardBorelSpace Ω]
-    (η : kernel α ℝ) :
-    kernel α Ω :=
+    (η : Kernel α ℝ) :
+    Kernel α Ω :=
   have he := measurableEmbedding_embeddingReal Ω
   let x₀ := (range_nonempty (embeddingReal Ω)).choose
   comapRight
-    (piecewise ((kernel.measurable_coe η he.measurableSet_range.compl) (measurableSet_singleton 0) :
+    (piecewise ((Kernel.measurable_coe η he.measurableSet_range.compl) (measurableSet_singleton 0) :
         MeasurableSet {a | η a (range (embeddingReal Ω))ᶜ = 0})
       η (deterministic (fun _ ↦ x₀) measurable_const)) he
 
 lemma borelMarkovFromReal_apply (Ω : Type*) [Nonempty Ω] [MeasurableSpace Ω] [StandardBorelSpace Ω]
-    (η : kernel α ℝ) (a : α) :
+    (η : Kernel α ℝ) (a : α) :
     borelMarkovFromReal Ω η a
       = if η a (range (embeddingReal Ω))ᶜ = 0 then (η a).comap (embeddingReal Ω)
         else (Measure.dirac (range_nonempty (embeddingReal Ω)).choose).comap (embeddingReal Ω) := by
@@ -199,7 +199,7 @@ lemma borelMarkovFromReal_apply (Ω : Type*) [Nonempty Ω] [MeasurableSpace Ω] 
   split_ifs <;> rfl
 
 lemma borelMarkovFromReal_apply' (Ω : Type*) [Nonempty Ω] [MeasurableSpace Ω] [StandardBorelSpace Ω]
-    (η : kernel α ℝ) (a : α) {s : Set Ω} (hs : MeasurableSet s) :
+    (η : Kernel α ℝ) (a : α) {s : Set Ω} (hs : MeasurableSet s) :
     borelMarkovFromReal Ω η a s
       = if η a (range (embeddingReal Ω))ᶜ = 0 then η a (embeddingReal Ω '' s)
         else (embeddingReal Ω '' s).indicator 1 (range_nonempty (embeddingReal Ω)).choose := by
@@ -209,18 +209,18 @@ lemma borelMarkovFromReal_apply' (Ω : Type*) [Nonempty Ω] [MeasurableSpace Ω]
   · rw [Measure.comap_apply _ he.injective he.measurableSet_image' _ hs]
   · rw [Measure.comap_apply _ he.injective he.measurableSet_image' _ hs, Measure.dirac_apply]
 
-/-- When `η` is an s-finite kernel, `borelMarkovFromReal Ω η` is an s-finite kernel. -/
-instance instIsSFiniteKernelBorelMarkovFromReal (η : kernel α ℝ) [IsSFiniteKernel η] :
+/-- When `η` is an s-finite kernel, `borelMarkovFromReal Ω η` is an s-finite Kernel. -/
+instance instIsSFiniteKernelBorelMarkovFromReal (η : Kernel α ℝ) [IsSFiniteKernel η] :
     IsSFiniteKernel (borelMarkovFromReal Ω η) :=
   IsSFiniteKernel.comapRight _ (measurableEmbedding_embeddingReal Ω)
 
-/-- When `η` is a finite kernel, `borelMarkovFromReal Ω η` is a finite kernel. -/
-instance instIsFiniteKernelBorelMarkovFromReal (η : kernel α ℝ) [IsFiniteKernel η] :
+/-- When `η` is a finite kernel, `borelMarkovFromReal Ω η` is a finite Kernel. -/
+instance instIsFiniteKernelBorelMarkovFromReal (η : Kernel α ℝ) [IsFiniteKernel η] :
     IsFiniteKernel (borelMarkovFromReal Ω η) :=
   IsFiniteKernel.comapRight _ (measurableEmbedding_embeddingReal Ω)
 
-/-- When `η` is a Markov kernel, `borelMarkovFromReal Ω η` is a Markov kernel. -/
-instance instIsMarkovKernelBorelMarkovFromReal (η : kernel α ℝ) [IsMarkovKernel η] :
+/-- When `η` is a Markov kernel, `borelMarkovFromReal Ω η` is a Markov Kernel. -/
+instance instIsMarkovKernelBorelMarkovFromReal (η : Kernel α ℝ) [IsMarkovKernel η] :
     IsMarkovKernel (borelMarkovFromReal Ω η) := by
   refine IsMarkovKernel.comapRight _ (measurableEmbedding_embeddingReal Ω) (fun a ↦ ?_)
   classical
@@ -234,7 +234,7 @@ instance instIsMarkovKernelBorelMarkovFromReal (η : kernel α ℝ) [IsMarkovKer
 hypothesis `hη` is `fst κ' ⊗ₖ η = κ'`. The conclusion of the lemma is
 `fst κ ⊗ₖ borelMarkovFromReal Ω η = comapRight (fst κ' ⊗ₖ η) _`. -/
 lemma compProd_fst_borelMarkovFromReal_eq_comapRight_compProd
-    (κ : kernel α (β × Ω)) [IsSFiniteKernel κ] (η : kernel (α × β) ℝ) [IsSFiniteKernel η]
+    (κ : Kernel α (β × Ω)) [IsSFiniteKernel κ] (η : Kernel (α × β) ℝ) [IsSFiniteKernel η]
     (hη : (fst (map κ (Prod.map (id : β → β) (embeddingReal Ω))
         (measurable_id.prod_map (measurableEmbedding_embeddingReal Ω).measurable))) ⊗ₖ η
       = map κ (Prod.map (id : β → β) (embeddingReal Ω))
@@ -285,8 +285,8 @@ lemma compProd_fst_borelMarkovFromReal_eq_comapRight_compProd
 /-- For `κ' := map κ (Prod.map (id : β → β) e) (measurable_id.prod_map he.measurable)`, the
 hypothesis `hη` is `fst κ' ⊗ₖ η = κ'`. With that hypothesis,
 `fst κ ⊗ₖ borelMarkovFromReal κ η = κ`.-/
-lemma compProd_fst_borelMarkovFromReal (κ : kernel α (β × Ω)) [IsSFiniteKernel κ]
-    (η : kernel (α × β) ℝ) [IsSFiniteKernel η]
+lemma compProd_fst_borelMarkovFromReal (κ : Kernel α (β × Ω)) [IsSFiniteKernel κ]
+    (η : Kernel (α × β) ℝ) [IsSFiniteKernel η]
     (hη : (fst (map κ (Prod.map (id : β → β) (embeddingReal Ω))
         (measurable_id.prod_map (measurableEmbedding_embeddingReal Ω).measurable))) ⊗ₖ η
       = map κ (Prod.map (id : β → β) (embeddingReal Ω))
@@ -309,24 +309,24 @@ end BorelSnd
 
 section CountablyGenerated
 
-open ProbabilityTheory.kernel
+open ProbabilityTheory.Kernel
 
-/-- Auxiliary definition for `ProbabilityTheory.kernel.condKernel`.
-A conditional kernel for `κ : kernel α (γ × Ω)` where `γ` is countably generated and `Ω` is
+/-- Auxiliary definition for `ProbabilityTheory.Kernel.condKernel`.
+A conditional kernel for `κ : Kernel α (γ × Ω)` where `γ` is countably generated and `Ω` is
 standard Borel. -/
 noncomputable
-def condKernelBorel (κ : kernel α (γ × Ω)) [IsFiniteKernel κ] : kernel (α × γ) Ω :=
+def condKernelBorel (κ : Kernel α (γ × Ω)) [IsFiniteKernel κ] : Kernel (α × γ) Ω :=
   let e := embeddingReal Ω
   let he := measurableEmbedding_embeddingReal Ω
   let κ' := map κ (Prod.map (id : γ → γ) e) (measurable_id.prod_map he.measurable)
   borelMarkovFromReal Ω (condKernelReal κ')
 
-instance instIsMarkovKernelCondKernelBorel (κ : kernel α (γ × Ω)) [IsFiniteKernel κ] :
+instance instIsMarkovKernelCondKernelBorel (κ : Kernel α (γ × Ω)) [IsFiniteKernel κ] :
     IsMarkovKernel (condKernelBorel κ) := by
   rw [condKernelBorel]
   infer_instance
 
-lemma compProd_fst_condKernelBorel (κ : kernel α (γ × Ω)) [IsFiniteKernel κ] :
+lemma compProd_fst_condKernelBorel (κ : Kernel α (γ × Ω)) [IsFiniteKernel κ] :
     fst κ ⊗ₖ condKernelBorel κ = κ := by
   rw [condKernelBorel, compProd_fst_borelMarkovFromReal _ _ (compProd_fst_condKernelReal _)]
 
@@ -335,21 +335,21 @@ end CountablyGenerated
 section Unit
 
 /-- Auxiliary definition for `MeasureTheory.Measure.condKernel` and
-`ProbabilityTheory.kernel.condKernel`.
-A conditional kernel for `κ : kernel Unit (α × Ω)` where `Ω` is standard Borel. -/
+`ProbabilityTheory.Kernel.condKernel`.
+A conditional kernel for `κ : Kernel Unit (α × Ω)` where `Ω` is standard Borel. -/
 noncomputable
-def condKernelUnitBorel (κ : kernel Unit (α × Ω)) [IsFiniteKernel κ] : kernel (Unit × α) Ω :=
+def condKernelUnitBorel (κ : Kernel Unit (α × Ω)) [IsFiniteKernel κ] : Kernel (Unit × α) Ω :=
   let e := embeddingReal Ω
   let he := measurableEmbedding_embeddingReal Ω
   let κ' := map κ (Prod.map (id : α → α) e) (measurable_id.prod_map he.measurable)
   borelMarkovFromReal Ω (condKernelUnitReal κ')
 
-instance instIsMarkovKernelCondKernelUnitBorel (κ : kernel Unit (α × Ω)) [IsFiniteKernel κ] :
+instance instIsMarkovKernelCondKernelUnitBorel (κ : Kernel Unit (α × Ω)) [IsFiniteKernel κ] :
     IsMarkovKernel (condKernelUnitBorel κ) := by
   rw [condKernelUnitBorel]
   infer_instance
 
-lemma compProd_fst_condKernelUnitBorel (κ : kernel Unit (α × Ω)) [IsFiniteKernel κ] :
+lemma compProd_fst_condKernelUnitBorel (κ : Kernel Unit (α × Ω)) [IsFiniteKernel κ] :
     fst κ ⊗ₖ condKernelUnitBorel κ = κ := by
   rw [condKernelUnitBorel,
     compProd_fst_borelMarkovFromReal _ _ (compProd_fst_condKernelUnitReal _)]
@@ -364,7 +364,7 @@ variable {ρ : Measure (α × Ω)} [IsFiniteMeasure ρ]
 `ρ = ρ.fst ⊗ₘ ρ.condKernel` (see `MeasureTheory.Measure.compProd_fst_condKernel`). -/
 noncomputable
 irreducible_def _root_.MeasureTheory.Measure.condKernel (ρ : Measure (α × Ω)) [IsFiniteMeasure ρ] :
-    kernel α Ω :=
+    Kernel α Ω :=
   comap (condKernelUnitBorel (const Unit ρ)) (fun a ↦ ((), a)) measurable_prod_mk_left
 
 lemma _root_.MeasureTheory.Measure.condKernel_apply (ρ : Measure (α × Ω)) [IsFiniteMeasure ρ]
@@ -433,30 +433,30 @@ section Countable
 
 variable [Countable α]
 
-/-- Auxiliary definition for `ProbabilityTheory.kernel.condKernel`.
-A conditional kernel for `κ : kernel α (β × Ω)` where `α` is countable and `Ω` is standard Borel. -/
+/-- Auxiliary definition for `ProbabilityTheory.Kernel.condKernel`.
+A conditional kernel for `κ : Kernel α (β × Ω)` where `α` is countable and `Ω` is standard Borel. -/
 noncomputable
-def condKernelCountable (κ : kernel α (β × Ω)) [IsFiniteKernel κ] : kernel (α × β) Ω where
-  val p := (κ p.1).condKernel p.2
-  property := by
+def condKernelCountable (κ : Kernel α (β × Ω)) [IsFiniteKernel κ] : Kernel (α × β) Ω where
+  toFun p := (κ p.1).condKernel p.2
+  measurable' := by
     change Measurable ((fun q : β × α ↦ (κ q.2).condKernel q.1) ∘ Prod.swap)
     refine (measurable_from_prod_countable' (fun a ↦ ?_) ?_).comp measurable_swap
-    · exact kernel.measurable (κ a).condKernel
+    · exact (κ a).condKernel.measurable
     · intro y y' x hy'
       have : κ y' = κ y := by
         ext s hs
         exact mem_of_mem_measurableAtom hy'
-          (kernel.measurable_coe κ hs (measurableSet_singleton (κ y s))) rfl
+          (Kernel.measurable_coe κ hs (measurableSet_singleton (κ y s))) rfl
       simp [this]
 
-lemma condKernelCountable_apply (κ : kernel α (β × Ω)) [IsFiniteKernel κ] (p : α × β) :
+lemma condKernelCountable_apply (κ : Kernel α (β × Ω)) [IsFiniteKernel κ] (p : α × β) :
     condKernelCountable κ p = (κ p.1).condKernel p.2 := rfl
 
-instance instIsMarkovKernelCondKernelCountable (κ : kernel α (β × Ω)) [IsFiniteKernel κ] :
+instance instIsMarkovKernelCondKernelCountable (κ : Kernel α (β × Ω)) [IsFiniteKernel κ] :
     IsMarkovKernel (condKernelCountable κ) :=
   ⟨fun p ↦ (Measure.instIsMarkovKernelCondKernel (κ p.1)).isProbabilityMeasure p.2⟩
 
-lemma compProd_fst_condKernelCountable (κ : kernel α (β × Ω)) [IsFiniteKernel κ] :
+lemma compProd_fst_condKernelCountable (κ : Kernel α (β × Ω)) [IsFiniteKernel κ] :
     fst κ ⊗ₖ condKernelCountable κ = κ := by
   ext a s hs
   have h := (κ a).compProd_fst_condKernel
@@ -470,20 +470,20 @@ section CountableOrCountablyGenerated
 
 open Classical in
 
-/-- Conditional kernel of a kernel `κ : kernel α (β × Ω)`: a Markov kernel such that
+/-- Conditional kernel of a kernel `κ : Kernel α (β × Ω)`: a Markov kernel such that
 `fst κ ⊗ₖ condKernel κ = κ` (see `MeasureTheory.Measure.compProd_fst_condKernel`).
 It exists whenever `Ω` is standard Borel and either `α` is countable
 or `β` is countably generated. -/
 noncomputable
 irreducible_def condKernel [h : CountableOrCountablyGenerated α β]
-    (κ : kernel α (β × Ω)) [IsFiniteKernel κ] :
-    kernel (α × β) Ω :=
+    (κ : Kernel α (β × Ω)) [IsFiniteKernel κ] :
+    Kernel (α × β) Ω :=
   if hα : Countable α then condKernelCountable κ
   else letI := h.countableOrCountablyGenerated.resolve_left hα; condKernelBorel κ
 
-/-- `condKernel κ` is a Markov kernel. -/
+/-- `condKernel κ` is a Markov Kernel. -/
 instance instIsMarkovKernelCondKernel [CountableOrCountablyGenerated α β]
-    (κ : kernel α (β × Ω)) [IsFiniteKernel κ] :
+    (κ : Kernel α (β × Ω)) [IsFiniteKernel κ] :
     IsMarkovKernel (condKernel κ) := by
   rw [condKernel_def]
   split_ifs <;> infer_instance
@@ -491,7 +491,7 @@ instance instIsMarkovKernelCondKernel [CountableOrCountablyGenerated α β]
 /-- **Disintegration** of finite kernels.
 The composition-product of `fst κ` and `condKernel κ` is equal to `κ`. -/
 lemma compProd_fst_condKernel [hαβ : CountableOrCountablyGenerated α β]
-    (κ : kernel α (β × Ω)) [IsFiniteKernel κ] :
+    (κ : Kernel α (β × Ω)) [IsFiniteKernel κ] :
     fst κ ⊗ₖ condKernel κ = κ := by
   rw [condKernel_def]
   split_ifs with h
@@ -501,4 +501,4 @@ lemma compProd_fst_condKernel [hαβ : CountableOrCountablyGenerated α β]
 
 end CountableOrCountablyGenerated
 
-end ProbabilityTheory.kernel
+end ProbabilityTheory.Kernel

--- a/Mathlib/Probability/Kernel/Disintegration/Basic.lean
+++ b/Mathlib/Probability/Kernel/Disintegration/Basic.lean
@@ -174,7 +174,7 @@ A Borel space `Ω` embeds measurably into `ℝ` (with embedding `e`), hence we c
 from a `Kernel α ℝ` by taking the comap by `e`.
 Here we take the comap of a modification of `η : Kernel α ℝ`, useful when `η a` is a probability
 measure with all its mass on `range e` almost everywhere with respect to some measure and we want to
-ensure that the comap is a Markov Kernel.
+ensure that the comap is a Markov kernel.
 We thus take the comap by `e` of a kernel defined piecewise: `η` when
 `η a (range (embeddingReal Ω))ᶜ = 0`, and an arbitrary deterministic kernel otherwise. -/
 noncomputable

--- a/Mathlib/Probability/Kernel/Disintegration/Basic.lean
+++ b/Mathlib/Probability/Kernel/Disintegration/Basic.lean
@@ -209,17 +209,17 @@ lemma borelMarkovFromReal_apply' (Ω : Type*) [Nonempty Ω] [MeasurableSpace Ω]
   · rw [Measure.comap_apply _ he.injective he.measurableSet_image' _ hs]
   · rw [Measure.comap_apply _ he.injective he.measurableSet_image' _ hs, Measure.dirac_apply]
 
-/-- When `η` is an s-finite kernel, `borelMarkovFromReal Ω η` is an s-finite Kernel. -/
+/-- When `η` is an s-finite kernel, `borelMarkovFromReal Ω η` is an s-finite kernel. -/
 instance instIsSFiniteKernelBorelMarkovFromReal (η : Kernel α ℝ) [IsSFiniteKernel η] :
     IsSFiniteKernel (borelMarkovFromReal Ω η) :=
   IsSFiniteKernel.comapRight _ (measurableEmbedding_embeddingReal Ω)
 
-/-- When `η` is a finite kernel, `borelMarkovFromReal Ω η` is a finite Kernel. -/
+/-- When `η` is a finite kernel, `borelMarkovFromReal Ω η` is a finite kernel. -/
 instance instIsFiniteKernelBorelMarkovFromReal (η : Kernel α ℝ) [IsFiniteKernel η] :
     IsFiniteKernel (borelMarkovFromReal Ω η) :=
   IsFiniteKernel.comapRight _ (measurableEmbedding_embeddingReal Ω)
 
-/-- When `η` is a Markov kernel, `borelMarkovFromReal Ω η` is a Markov Kernel. -/
+/-- When `η` is a Markov kernel, `borelMarkovFromReal Ω η` is a Markov kernel. -/
 instance instIsMarkovKernelBorelMarkovFromReal (η : Kernel α ℝ) [IsMarkovKernel η] :
     IsMarkovKernel (borelMarkovFromReal Ω η) := by
   refine IsMarkovKernel.comapRight _ (measurableEmbedding_embeddingReal Ω) (fun a ↦ ?_)
@@ -481,7 +481,7 @@ irreducible_def condKernel [h : CountableOrCountablyGenerated α β]
   if hα : Countable α then condKernelCountable κ
   else letI := h.countableOrCountablyGenerated.resolve_left hα; condKernelBorel κ
 
-/-- `condKernel κ` is a Markov Kernel. -/
+/-- `condKernel κ` is a Markov kernel. -/
 instance instIsMarkovKernelCondKernel [CountableOrCountablyGenerated α β]
     (κ : Kernel α (β × Ω)) [IsFiniteKernel κ] :
     IsMarkovKernel (condKernel κ) := by

--- a/Mathlib/Probability/Kernel/Disintegration/CdfToKernel.lean
+++ b/Mathlib/Probability/Kernel/Disintegration/CdfToKernel.lean
@@ -10,18 +10,18 @@ import Mathlib.Probability.Kernel.Disintegration.MeasurableStieltjes
 /-!
 # Building a Markov kernel from a conditional cumulative distribution function
 
-Let `κ : kernel α (β × ℝ)` and `ν : kernel α β` be two finite kernels.
+Let `κ : Kernel α (β × ℝ)` and `ν : Kernel α β` be two finite kernels.
 A function `f : α × β → StieltjesFunction` is called a conditional kernel CDF of `κ` with respect
 to `ν` if it is measurable, tends to to 0 at -∞ and to 1 at +∞ for all `p : α × β`,
 `fun b ↦ f (a, b) x` is `(ν a)`-integrable for all `a : α` and `x : ℝ` and for all measurable
 sets `s : Set β`, `∫ b in s, f (a, b) x ∂(ν a) = (κ a (s ×ˢ Iic x)).toReal`.
 
-From such a function with property `hf : IsCondKernelCDF f κ ν`, we can build a `kernel (α × β) ℝ`
+From such a function with property `hf : IsCondKernelCDF f κ ν`, we can build a `Kernel (α × β) ℝ`
 denoted by `hf.toKernel f` such that `κ = ν ⊗ₖ hf.toKernel f`.
 
 ## Main definitions
 
-Let `κ : kernel α (β × ℝ)` and `ν : kernel α β`.
+Let `κ : Kernel α (β × ℝ)` and `ν : Kernel α β`.
 
 * `ProbabilityTheory.IsCondKernelCDF`: a function `f : α × β → StieltjesFunction` is called
   a conditional kernel CDF of `κ` with respect to `ν` if it is measurable, tends to to 0 at -∞ and
@@ -29,7 +29,7 @@ Let `κ : kernel α (β × ℝ)` and `ν : kernel α β`.
   `x : ℝ` and for all measurable sets `s : Set β`,
   `∫ b in s, f (a, b) x ∂(ν a) = (κ a (s ×ˢ Iic x)).toReal`.
 * `ProbabilityTheory.IsCondKernelCDF.toKernel`: from a function `f : α × β → StieltjesFunction`
-  with the property `hf : IsCondKernelCDF f κ ν`, build a `kernel (α × β) ℝ` such that
+  with the property `hf : IsCondKernelCDF f κ ν`, build a `Kernel (α × β) ℝ` such that
   `κ = ν ⊗ₖ hf.toKernel f`.
 * `ProbabilityTheory.IsRatCondKernelCDF`: a function `f : α × β → ℚ → ℝ` is called a rational
   conditional kernel CDF of `κ` with respect to `ν` if is measurable and satisfies the same
@@ -52,7 +52,7 @@ open scoped NNReal ENNReal MeasureTheory Topology ProbabilityTheory
 namespace ProbabilityTheory
 
 variable {α β : Type*} {mα : MeasurableSpace α} {mβ : MeasurableSpace β}
-  {κ : kernel α (β × ℝ)} {ν : kernel α β}
+  {κ : Kernel α (β × ℝ)} {ν : Kernel α β}
 
 section stieltjesOfMeasurableRat
 
@@ -63,7 +63,7 @@ to `ν` if is measurable, if `fun b ↦ f (a, b) x` is `(ν a)`-integrable for a
 and for all measurable sets `s : Set β`, `∫ b in s, f (a, b) x ∂(ν a) = (κ a (s ×ˢ Iic x)).toReal`.
 Also the `ℚ → ℝ` function `f (a, b)` should satisfy the properties of a Sieltjes function for
 `(ν a)`-almost all `b : β`. -/
-structure IsRatCondKernelCDF (f : α × β → ℚ → ℝ) (κ : kernel α (β × ℝ)) (ν : kernel α β) : Prop :=
+structure IsRatCondKernelCDF (f : α × β → ℚ → ℝ) (κ : Kernel α (β × ℝ)) (ν : Kernel α β) : Prop :=
   measurable : Measurable f
   isRatStieltjesPoint_ae (a : α) : ∀ᵐ b ∂(ν a), IsRatStieltjesPoint f (a, b)
   integrable (a : α) (q : ℚ) : Integrable (fun b ↦ f (a, b) q) (ν a)
@@ -233,7 +233,7 @@ variable {f : α × β → ℚ → ℝ}
 /-- This property implies `IsRatCondKernelCDF`. The measurability, integrability and integral
 conditions are the same, but the limit properties of `IsRatCondKernelCDF` are replaced by
 limits of integrals. -/
-structure IsRatCondKernelCDFAux (f : α × β → ℚ → ℝ) (κ : kernel α (β × ℝ)) (ν : kernel α β) :
+structure IsRatCondKernelCDFAux (f : α × β → ℚ → ℝ) (κ : Kernel α (β × ℝ)) (ν : Kernel α β) :
     Prop :=
   measurable : Measurable f
   mono' (a : α) {q r : ℚ} (_hqr : q ≤ r) : ∀ᵐ c ∂(ν a), f (a, c) q ≤ f (a, c) r
@@ -423,7 +423,7 @@ variable {f : α × β → StieltjesFunction}
 respect to `ν` if it is measurable, tends to to 0 at -∞ and to 1 at +∞ for all `p : α × β`,
 `fun b ↦ f (a, b) x` is `(ν a)`-integrable for all `a : α` and `x : ℝ` and for all
 measurable sets `s : Set β`, `∫ b in s, f (a, b) x ∂(ν a) = (κ a (s ×ˢ Iic x)).toReal`. -/
-structure IsCondKernelCDF (f : α × β → StieltjesFunction) (κ : kernel α (β × ℝ)) (ν : kernel α β) :
+structure IsCondKernelCDF (f : α × β → StieltjesFunction) (κ : Kernel α (β × ℝ)) (ν : Kernel α β) :
     Prop :=
   measurable (x : ℝ) : Measurable fun p ↦ f p x
   integrable (a : α) (x : ℝ) : Integrable (fun b ↦ f (a, b) x) (ν a)
@@ -473,7 +473,7 @@ end IsCondKernelCDF
 section ToKernel
 
 variable {_ : MeasurableSpace β} {f : α × β → StieltjesFunction}
-  {κ : kernel α (β × ℝ)} {ν : kernel α β}
+  {κ : Kernel α (β × ℝ)} {ν : Kernel α β}
 
 /-- A measurable function `α → StieltjesFunction` with limits 0 at -∞ and 1 at +∞ gives a measurable
 function `α → Measure ℝ` by taking `StieltjesFunction.measure` at each point. -/
@@ -507,9 +507,9 @@ lemma StieltjesFunction.measurable_measure {f : α → StieltjesFunction}
 Markov kernel from `α × β` to `ℝ`, by taking for each `p : α × β` the measure defined by `f p`. -/
 noncomputable
 def IsCondKernelCDF.toKernel (f : α × β → StieltjesFunction) (hf : IsCondKernelCDF f κ ν) :
-    kernel (α × β) ℝ where
-  val p := (f p).measure
-  property := StieltjesFunction.measurable_measure hf.measurable
+    Kernel (α × β) ℝ where
+  toFun p := (f p).measure
+  measurable' := StieltjesFunction.measurable_measure hf.measurable
     hf.tendsto_atBot_zero hf.tendsto_atTop_one
 
 lemma IsCondKernelCDF.toKernel_apply {hf : IsCondKernelCDF f κ ν} (p : α × β) :
@@ -554,7 +554,7 @@ lemma setLIntegral_toKernel_univ [IsFiniteKernel κ] (hf : IsCondKernelCDF f κ 
   rw [lintegral_iSup_directed]
   · simp_rw [setLIntegral_toKernel_Iic hf _ _ hs]
   · refine fun q ↦ Measurable.aemeasurable ?_
-    exact (kernel.measurable_coe _ measurableSet_Iic).comp measurable_prod_mk_left
+    exact (Kernel.measurable_coe _ measurableSet_Iic).comp measurable_prod_mk_left
   · refine Monotone.directed_le fun i j hij t ↦ measure_mono (Iic_subset_Iic.mpr ?_)
     exact mod_cast hij
 
@@ -582,7 +582,7 @@ lemma setLIntegral_toKernel_prod [IsFiniteKernel κ] (hf : IsCondKernelCDF f κ 
     _ = ∫⁻ b in s, hf.toKernel f (a, b) univ ∂(ν a)
           - ∫⁻ b in s, hf.toKernel f (a, b) t ∂(ν a) := by
         rw [lintegral_sub]
-        · exact (kernel.measurable_coe (hf.toKernel f) ht).comp measurable_prod_mk_left
+        · exact (Kernel.measurable_coe (hf.toKernel f) ht).comp measurable_prod_mk_left
         · rw [ht_lintegral]
           exact measure_ne_top _ _
         · exact eventually_of_forall fun a ↦ measure_mono (subset_univ _)
@@ -603,7 +603,7 @@ lemma setLIntegral_toKernel_prod [IsFiniteKernel κ] (hf : IsCondKernelCDF f κ 
       exact Or.inr (hf_disj hij)
     · exact fun i ↦ MeasurableSet.prod hs (hf_meas i)
     · exact fun i ↦
-        ((kernel.measurable_coe _ (hf_meas i)).comp measurable_prod_mk_left).aemeasurable.restrict
+        ((Kernel.measurable_coe _ (hf_meas i)).comp measurable_prod_mk_left).aemeasurable.restrict
 
 @[deprecated (since := "2024-06-29")]
 alias set_lintegral_toKernel_prod := setLIntegral_toKernel_prod
@@ -652,7 +652,7 @@ lemma lintegral_toKernel_mem [IsFiniteKernel κ] (hf : IsCondKernelCDF f κ ν)
               ≤ᵐ[ν a] fun x ↦ hf.toKernel f (a, x) univ :=
           eventually_of_forall fun _ ↦ measure_mono (subset_univ _)
         rw [lintegral_sub _ _ h_le]
-        · exact kernel.measurable_kernel_prod_mk_left' ht a
+        · exact Kernel.measurable_kernel_prod_mk_left' ht a
         refine ((lintegral_mono_ae h_le).trans_lt ?_).ne
         rw [lintegral_toKernel_univ hf]
         exact measure_lt_top _ univ
@@ -676,14 +676,14 @@ lemma lintegral_toKernel_mem [IsFiniteKernel κ] (hf : IsCondKernelCDF f κ ν)
           congr with x : 1
           rw [measure_iUnion (h_disj x) fun i ↦ measurable_prod_mk_left (hf_meas i)]
     _ = ∑' i, ∫⁻ b, hf.toKernel f (a, b) {y | (b, y) ∈ f' i} ∂(ν a) :=
-          lintegral_tsum fun i ↦ (kernel.measurable_kernel_prod_mk_left' (hf_meas i) a).aemeasurable
+          lintegral_tsum fun i ↦ (Kernel.measurable_kernel_prod_mk_left' (hf_meas i) a).aemeasurable
     _ = ∑' i, κ a (f' i) := by simp_rw [hf_eq]
     _ = κ a (iUnion f') := (measure_iUnion hf_disj hf_meas).symm
 
 lemma compProd_toKernel [IsFiniteKernel κ] [IsSFiniteKernel ν] (hf : IsCondKernelCDF f κ ν) :
     ν ⊗ₖ hf.toKernel f = κ := by
   ext a s hs
-  rw [kernel.compProd_apply _ _ _ hs, lintegral_toKernel_mem hf a hs]
+  rw [Kernel.compProd_apply _ _ _ hs, lintegral_toKernel_mem hf a hs]
 
 end
 

--- a/Mathlib/Probability/Kernel/Disintegration/CondCdf.lean
+++ b/Mathlib/Probability/Kernel/Disintegration/CondCdf.lean
@@ -211,7 +211,7 @@ lemma integrable_preCDF (ρ : Measure (α × ℝ)) [IsFiniteMeasure ρ] (x : ℚ
 
 lemma isRatCondKernelCDFAux_preCDF (ρ : Measure (α × ℝ)) [IsFiniteMeasure ρ] :
     IsRatCondKernelCDFAux (fun p r ↦ (preCDF ρ r p.2).toReal)
-      (kernel.const Unit ρ) (kernel.const Unit ρ.fst) where
+      (Kernel.const Unit ρ) (Kernel.const Unit ρ.fst) where
   measurable := measurable_preCDF'.comp measurable_snd
   mono' a r r' hrr' := by
     filter_upwards [monotone_preCDF ρ, preCDF_le_one ρ] with a h1 h2
@@ -220,30 +220,30 @@ lemma isRatCondKernelCDFAux_preCDF (ρ : Measure (α × ℝ)) [IsFiniteMeasure �
     exact h1 hrr'
   nonneg' _ q := by simp
   le_one' a q := by
-    simp only [kernel.const_apply, forall_const]
+    simp only [Kernel.const_apply, forall_const]
     filter_upwards [preCDF_le_one ρ] with a ha
     refine ENNReal.toReal_le_of_le_ofReal zero_le_one ?_
     simp [ha]
   tendsto_integral_of_antitone a s _ hs_tendsto := by
-    simp_rw [kernel.const_apply, integral_preCDF_fst ρ]
+    simp_rw [Kernel.const_apply, integral_preCDF_fst ρ]
     have h := ρ.tendsto_IicSnd_atBot MeasurableSet.univ
     rw [← ENNReal.zero_toReal]
     have h0 : Tendsto ENNReal.toReal (𝓝 0) (𝓝 0) :=
       ENNReal.continuousAt_toReal ENNReal.zero_ne_top
     exact h0.comp (h.comp hs_tendsto)
   tendsto_integral_of_monotone a s _ hs_tendsto := by
-    simp_rw [kernel.const_apply, integral_preCDF_fst ρ]
+    simp_rw [Kernel.const_apply, integral_preCDF_fst ρ]
     have h := ρ.tendsto_IicSnd_atTop MeasurableSet.univ
     have h0 : Tendsto ENNReal.toReal (𝓝 (ρ.fst univ)) (𝓝 (ρ.fst univ).toReal) :=
       ENNReal.continuousAt_toReal (measure_ne_top _ _)
     exact h0.comp (h.comp hs_tendsto)
   integrable _ q := integrable_preCDF ρ q
-  setIntegral a s hs q := by rw [kernel.const_apply, kernel.const_apply,
+  setIntegral a s hs q := by rw [Kernel.const_apply, Kernel.const_apply,
     setIntegral_preCDF_fst _ _ hs, Measure.IicSnd_apply _ _ hs]
 
 lemma isRatCondKernelCDF_preCDF (ρ : Measure (α × ℝ)) [IsFiniteMeasure ρ] :
     IsRatCondKernelCDF (fun p r ↦ (preCDF ρ r p.2).toReal)
-      (kernel.const Unit ρ) (kernel.const Unit ρ.fst) :=
+      (Kernel.const Unit ρ) (Kernel.const Unit ρ.fst) :=
   (isRatCondKernelCDFAux_preCDF ρ).isRatCondKernelCDF
 
 /-! ### Conditional cdf -/
@@ -259,8 +259,8 @@ lemma condCDF_eq_stieltjesOfMeasurableRat_unit_prod (ρ : Measure (α × ℝ)) (
   rw [condCDF, ← stieltjesOfMeasurableRat_unit_prod]
 
 lemma isCondKernelCDF_condCDF (ρ : Measure (α × ℝ)) [IsFiniteMeasure ρ] :
-    IsCondKernelCDF (fun p : Unit × α ↦ condCDF ρ p.2) (kernel.const Unit ρ)
-      (kernel.const Unit ρ.fst) := by
+    IsCondKernelCDF (fun p : Unit × α ↦ condCDF ρ p.2) (Kernel.const Unit ρ)
+      (Kernel.const Unit ρ.fst) := by
   simp_rw [condCDF_eq_stieltjesOfMeasurableRat_unit_prod ρ]
   exact isCondKernelCDF_stieltjesOfMeasurableRat (isRatCondKernelCDF_preCDF ρ)
 

--- a/Mathlib/Probability/Kernel/Disintegration/Density.lean
+++ b/Mathlib/Probability/Kernel/Disintegration/Density.lean
@@ -10,40 +10,40 @@ import Mathlib.Probability.Process.PartitionFiltration
 /-!
 # Kernel density
 
-Let `κ : kernel α (γ × β)` and `ν : kernel α γ` be two finite kernels with `kernel.fst κ ≤ ν`,
+Let `κ : Kernel α (γ × β)` and `ν : Kernel α γ` be two finite kernels with `Kernel.fst κ ≤ ν`,
 where `γ` has a countably generated σ-algebra (true in particular for standard Borel spaces).
 We build a function `density κ ν : α → γ → Set β → ℝ` jointly measurable in the first two arguments
 such that for all `a : α` and all measurable sets `s : Set β` and `A : Set γ`,
 `∫ x in A, density κ ν a x s ∂(ν a) = (κ a (A ×ˢ s)).toReal`.
 
 There are two main applications of this construction (still TODO, in other files).
-* Disintegration of kernels: for `κ : kernel α (γ × β)`, we want to build a kernel
-  `η : kernel (α × γ) β` such that `κ = fst κ ⊗ₖ η`. For `β = ℝ`, we can use the density of `κ`
+* Disintegration of kernels: for `κ : Kernel α (γ × β)`, we want to build a kernel
+  `η : Kernel (α × γ) β` such that `κ = fst κ ⊗ₖ η`. For `β = ℝ`, we can use the density of `κ`
   with respect to `fst κ` for intervals to build a kernel cumulative distribution function for `η`.
   The construction can then be extended to `β` standard Borel.
-* Radon-Nikodym theorem for kernels: for `κ ν : kernel α γ`, we can use the density to build a
+* Radon-Nikodym theorem for kernels: for `κ ν : Kernel α γ`, we can use the density to build a
   Radon-Nikodym derivative of `κ` with respect to `ν`. We don't need `β` here but we can apply the
   density construction to `β = Unit`. The derivative construction will use `density` but will not
   be exactly equal to it because we will want to remove the `fst κ ≤ ν` assumption.
 
 ## Main definitions
 
-* `ProbabilityTheory.kernel.density`: for `κ : kernel α (γ × β)` and `ν : kernel α γ` two finite
-  kernels, `kernel.density κ ν` is a function `α → γ → Set β → ℝ`.
+* `ProbabilityTheory.Kernel.density`: for `κ : Kernel α (γ × β)` and `ν : Kernel α γ` two finite
+  kernels, `Kernel.density κ ν` is a function `α → γ → Set β → ℝ`.
 
 ## Main statements
 
-* `ProbabilityTheory.kernel.setIntegral_density`: for all measurable sets `A : Set γ` and
-  `s : Set β`, `∫ x in A, kernel.density κ ν a x s ∂(ν a) = (κ a (A ×ˢ s)).toReal`.
-* `ProbabilityTheory.kernel.measurable_density`: the function
-  `p : α × γ ↦ kernel.density κ ν p.1 p.2 s` is measurable.
+* `ProbabilityTheory.Kernel.setIntegral_density`: for all measurable sets `A : Set γ` and
+  `s : Set β`, `∫ x in A, Kernel.density κ ν a x s ∂(ν a) = (κ a (A ×ˢ s)).toReal`.
+* `ProbabilityTheory.Kernel.measurable_density`: the function
+  `p : α × γ ↦ Kernel.density κ ν p.1 p.2 s` is measurable.
 
 ## Construction of the density
 
 If we were interested only in a fixed `a : α`, then we could use the Radon-Nikodym derivative to
 build the density function `density κ ν`, as follows.
 ```
-def density' (κ : kernel α (γ × β)) (ν : kernel a γ) (a : α) (x : γ) (s : Set β) : ℝ :=
+def density' (κ : Kernel α (γ × β)) (ν : kernel a γ) (a : α) (x : γ) (s : Set β) : ℝ :=
   (((κ a).restrict (univ ×ˢ s)).fst.rnDeriv (ν a) x).toReal
 ```
 However, we can't turn those functions for each `a` into a measurable function of the pair `(a, x)`.
@@ -79,27 +79,27 @@ open MeasureTheory Set Filter MeasurableSpace
 
 open scoped NNReal ENNReal MeasureTheory Topology ProbabilityTheory
 
-namespace ProbabilityTheory.kernel
+namespace ProbabilityTheory.Kernel
 
 variable {α β γ : Type*} {mα : MeasurableSpace α} {mβ : MeasurableSpace β} {mγ : MeasurableSpace γ}
-    [CountablyGenerated γ] {κ : kernel α (γ × β)} {ν : kernel α γ}
+    [CountablyGenerated γ] {κ : Kernel α (γ × β)} {ν : Kernel α γ}
 
 section DensityProcess
 
 /-- An `ℕ`-indexed martingale that is a density for `κ` with respect to `ν` on the sets in
-`countablePartition γ n`. Used to define its limit `ProbabilityTheory.kernel.density`, which is
+`countablePartition γ n`. Used to define its limit `ProbabilityTheory.Kernel.density`, which is
 a density for those kernels for all measurable sets. -/
 noncomputable
-def densityProcess (κ : kernel α (γ × β)) (ν : kernel α γ) (n : ℕ) (a : α) (x : γ) (s : Set β) :
+def densityProcess (κ : Kernel α (γ × β)) (ν : Kernel α γ) (n : ℕ) (a : α) (x : γ) (s : Set β) :
     ℝ :=
   (κ a (countablePartitionSet n x ×ˢ s) / ν a (countablePartitionSet n x)).toReal
 
-lemma densityProcess_def (κ : kernel α (γ × β)) (ν : kernel α γ) (n : ℕ) (a : α) (s : Set β) :
+lemma densityProcess_def (κ : Kernel α (γ × β)) (ν : Kernel α γ) (n : ℕ) (a : α) (s : Set β) :
     (fun t ↦ densityProcess κ ν n a t s)
       = fun t ↦ (κ a (countablePartitionSet n t ×ˢ s) / ν a (countablePartitionSet n t)).toReal :=
   rfl
 
-lemma measurable_densityProcess_countableFiltration_aux (κ : kernel α (γ × β)) (ν : kernel α γ)
+lemma measurable_densityProcess_countableFiltration_aux (κ : Kernel α (γ × β)) (ν : Kernel α γ)
     (n : ℕ) {s : Set β} (hs : MeasurableSet s) :
     Measurable[mα.prod (countableFiltration γ n)] (fun (p : α × γ) ↦
       κ p.1 (countablePartitionSet n p.2 ×ˢ s) / ν p.1 (countablePartitionSet n p.2)) := by
@@ -110,54 +110,54 @@ lemma measurable_densityProcess_countableFiltration_aux (κ : kernel α (γ × �
       (fun p : α × countablePartition γ n ↦ κ p.1 (↑p.2 ×ˢ s) / ν p.1 p.2) := by
     refine Measurable.div ?_ ?_
     · refine measurable_from_prod_countable (fun t ↦ ?_)
-      exact kernel.measurable_coe _ ((measurableSet_countablePartition _ t.prop).prod hs)
+      exact Kernel.measurable_coe _ ((measurableSet_countablePartition _ t.prop).prod hs)
     · refine measurable_from_prod_countable ?_
       rintro ⟨t, ht⟩
-      exact kernel.measurable_coe _ (measurableSet_countablePartition _ ht)
+      exact Kernel.measurable_coe _ (measurableSet_countablePartition _ ht)
   refine h1.comp (measurable_fst.prod_mk ?_)
   change @Measurable (α × γ) (countablePartition γ n) (mα.prod (countableFiltration γ n)) ⊤
     ((fun c ↦ ⟨countablePartitionSet n c, countablePartitionSet_mem n c⟩) ∘ (fun p : α × γ ↦ p.2))
   exact (measurable_countablePartitionSet_subtype n ⊤).comp measurable_snd
 
-lemma measurable_densityProcess_aux (κ : kernel α (γ × β)) (ν : kernel α γ) (n : ℕ)
+lemma measurable_densityProcess_aux (κ : Kernel α (γ × β)) (ν : Kernel α γ) (n : ℕ)
     {s : Set β} (hs : MeasurableSet s) :
     Measurable (fun (p : α × γ) ↦
       κ p.1 (countablePartitionSet n p.2 ×ˢ s) / ν p.1 (countablePartitionSet n p.2)) := by
   refine Measurable.mono (measurable_densityProcess_countableFiltration_aux κ ν n hs) ?_ le_rfl
   exact sup_le_sup le_rfl (comap_mono ((countableFiltration γ).le _))
 
-lemma measurable_densityProcess (κ : kernel α (γ × β)) (ν : kernel α γ) (n : ℕ)
+lemma measurable_densityProcess (κ : Kernel α (γ × β)) (ν : Kernel α γ) (n : ℕ)
     {s : Set β} (hs : MeasurableSet s) :
     Measurable (fun (p : α × γ) ↦ densityProcess κ ν n p.1 p.2 s) :=
   (measurable_densityProcess_aux κ ν n hs).ennreal_toReal
 
-lemma measurable_densityProcess_left (κ : kernel α (γ × β)) (ν : kernel α γ) (n : ℕ)
+lemma measurable_densityProcess_left (κ : Kernel α (γ × β)) (ν : Kernel α γ) (n : ℕ)
     (x : γ) {s : Set β} (hs : MeasurableSet s) :
     Measurable (fun a ↦ densityProcess κ ν n a x s) :=
   (measurable_densityProcess κ ν n hs).comp (measurable_id.prod_mk measurable_const)
 
-lemma measurable_densityProcess_right (κ : kernel α (γ × β)) (ν : kernel α γ) (n : ℕ)
+lemma measurable_densityProcess_right (κ : Kernel α (γ × β)) (ν : Kernel α γ) (n : ℕ)
     {s : Set β} (a : α) (hs : MeasurableSet s) :
     Measurable (fun x ↦ densityProcess κ ν n a x s) :=
   (measurable_densityProcess κ ν n hs).comp (measurable_const.prod_mk measurable_id)
 
-lemma measurable_countableFiltration_densityProcess (κ : kernel α (γ × β)) (ν : kernel α γ) (n : ℕ)
+lemma measurable_countableFiltration_densityProcess (κ : Kernel α (γ × β)) (ν : Kernel α γ) (n : ℕ)
     (a : α) {s : Set β} (hs : MeasurableSet s) :
     Measurable[countableFiltration γ n] (fun x ↦ densityProcess κ ν n a x s) := by
   refine @Measurable.ennreal_toReal _ (countableFiltration γ n) _ ?_
   exact (measurable_densityProcess_countableFiltration_aux κ ν n hs).comp measurable_prod_mk_left
 
-lemma stronglyMeasurable_countableFiltration_densityProcess (κ : kernel α (γ × β)) (ν : kernel α γ)
+lemma stronglyMeasurable_countableFiltration_densityProcess (κ : Kernel α (γ × β)) (ν : Kernel α γ)
     (n : ℕ) (a : α) {s : Set β} (hs : MeasurableSet s) :
     StronglyMeasurable[countableFiltration γ n] (fun x ↦ densityProcess κ ν n a x s) :=
   (measurable_countableFiltration_densityProcess κ ν n a hs).stronglyMeasurable
 
-lemma adapted_densityProcess (κ : kernel α (γ × β)) (ν : kernel α γ) (a : α)
+lemma adapted_densityProcess (κ : Kernel α (γ × β)) (ν : Kernel α γ) (a : α)
     {s : Set β} (hs : MeasurableSet s) :
     Adapted (countableFiltration γ) (fun n x ↦ densityProcess κ ν n a x s) :=
   fun n ↦ stronglyMeasurable_countableFiltration_densityProcess κ ν n a hs
 
-lemma densityProcess_nonneg (κ : kernel α (γ × β)) (ν : kernel α γ) (n : ℕ)
+lemma densityProcess_nonneg (κ : Kernel α (γ × β)) (ν : Kernel α γ) (n : ℕ)
     (a : α) (x : γ) (s : Set β) :
     0 ≤ densityProcess κ ν n a x s :=
   ENNReal.toReal_nonneg
@@ -319,7 +319,7 @@ lemma densityProcess_mono_set (hκν : fst κ ≤ ν) (n : ℕ) (a : α) (x : γ
   rw [ENNReal.toReal_le_toReal (h_ne_top s) (h_ne_top s')]
   gcongr
 
-lemma densityProcess_mono_kernel_left {κ' : kernel α (γ × β)} (hκκ' : κ ≤ κ')
+lemma densityProcess_mono_kernel_left {κ' : Kernel α (γ × β)} (hκκ' : κ ≤ κ')
     (hκ'ν : fst κ' ≤ ν) (n : ℕ) (a : α) (x : γ) (s : Set β) :
     densityProcess κ ν n a x s ≤ densityProcess κ' ν n a x s := by
   unfold densityProcess
@@ -339,7 +339,7 @@ lemma densityProcess_mono_kernel_left {κ' : kernel α (γ × β)} (hκκ' : κ 
     simp only [ne_eq, h0, and_false, false_or, not_and, not_not]
     exact fun h_top ↦ eq_top_mono h_le h_top
 
-lemma densityProcess_antitone_kernel_right {ν' : kernel α γ}
+lemma densityProcess_antitone_kernel_right {ν' : Kernel α γ}
     (hνν' : ν ≤ ν') (hκν : fst κ ≤ ν) (n : ℕ) (a : α) (x : γ) (s : Set β) :
     densityProcess κ ν' n a x s ≤ densityProcess κ ν n a x s := by
   unfold densityProcess
@@ -359,11 +359,11 @@ lemma densityProcess_antitone_kernel_right {ν' : kernel α γ}
     exact fun h_top ↦ eq_top_mono h_le h_top
 
 @[simp]
-lemma densityProcess_empty (κ : kernel α (γ × β)) (ν : kernel α γ) (n : ℕ) (a : α) (x : γ) :
+lemma densityProcess_empty (κ : Kernel α (γ × β)) (ν : Kernel α γ) (n : ℕ) (a : α) (x : γ) :
     densityProcess κ ν n a x ∅ = 0 := by
   simp [densityProcess]
 
-lemma tendsto_densityProcess_atTop_empty_of_antitone (κ : kernel α (γ × β)) (ν : kernel α γ)
+lemma tendsto_densityProcess_atTop_empty_of_antitone (κ : Kernel α (γ × β)) (ν : Kernel α γ)
     [IsFiniteKernel κ] (n : ℕ) (a : α) (x : γ)
     (seq : ℕ → Set β) (hseq : Antitone seq) (hseq_iInter : ⋂ i, seq i = ∅)
     (hseq_meas : ∀ m, MeasurableSet (seq m)) :
@@ -389,7 +389,7 @@ lemma tendsto_densityProcess_atTop_empty_of_antitone (κ : kernel α (γ × β))
     · exact ⟨0, measure_ne_top _ _⟩
   · exact .inr h0
 
-lemma tendsto_densityProcess_atTop_of_antitone (κ : kernel α (γ × β)) (ν : kernel α γ)
+lemma tendsto_densityProcess_atTop_of_antitone (κ : Kernel α (γ × β)) (ν : Kernel α γ)
     [IsFiniteKernel κ] (n : ℕ) (a : α) (x : γ)
     (seq : ℕ → Set β) (hseq : Antitone seq) (hseq_iInter : ⋂ i, seq i = ∅)
     (hseq_meas : ∀ m, MeasurableSet (seq m)) :
@@ -453,7 +453,7 @@ section Density
 is measurable on `α × γ` for all measurable sets `s : Set β` and satisfies that
 `∫ x in A, density κ ν a x s ∂(ν a) = (κ a (A ×ˢ s)).toReal` for all measurable `A : Set γ`. -/
 noncomputable
-def density (κ : kernel α (γ × β)) (ν : kernel α γ) (a : α) (x : γ) (s : Set β) : ℝ :=
+def density (κ : Kernel α (γ × β)) (ν : Kernel α γ) (a : α) (x : γ) (s : Set β) : ℝ :=
   limsup (fun n ↦ densityProcess κ ν n a x s) atTop
 
 lemma density_ae_eq_limitProcess (hκν : fst κ ≤ ν) [IsFiniteKernel ν]
@@ -470,18 +470,18 @@ lemma tendsto_m_density (hκν : fst κ ≤ ν) (a : α) [IsFiniteKernel ν]
   filter_upwards [tendsto_densityProcess_limitProcess hκν a hs, density_ae_eq_limitProcess hκν a hs]
     with t h1 h2 using h2 ▸ h1
 
-lemma measurable_density (κ : kernel α (γ × β)) (ν : kernel α γ)
+lemma measurable_density (κ : Kernel α (γ × β)) (ν : Kernel α γ)
     {s : Set β} (hs : MeasurableSet s) :
     Measurable (fun (p : α × γ) ↦ density κ ν p.1 p.2 s) :=
   measurable_limsup (fun n ↦ measurable_densityProcess κ ν n hs)
 
-lemma measurable_density_left (κ : kernel α (γ × β)) (ν : kernel α γ) (x : γ)
+lemma measurable_density_left (κ : Kernel α (γ × β)) (ν : Kernel α γ) (x : γ)
     {s : Set β} (hs : MeasurableSet s) :
     Measurable (fun a ↦ density κ ν a x s) := by
   change Measurable ((fun (p : α × γ) ↦ density κ ν p.1 p.2 s) ∘ (fun a ↦ (a, x)))
   exact (measurable_density κ ν hs).comp measurable_prod_mk_right
 
-lemma measurable_density_right (κ : kernel α (γ × β)) (ν : kernel α γ)
+lemma measurable_density_right (κ : Kernel α (γ × β)) (ν : Kernel α γ)
     {s : Set β} (hs : MeasurableSet s) (a : α) :
     Measurable (fun x ↦ density κ ν a x s) := by
   change Measurable ((fun (p : α × γ) ↦ density κ ν p.1 p.2 s) ∘ (fun x ↦ (a, x)))
@@ -705,7 +705,7 @@ lemma densityProcess_fst_univ [IsFiniteKernel κ] (n : ℕ) (a : α) (x : γ) :
     · rwa [fst_apply' _ _ (measurableSet_countablePartitionSet _ _)] at h
     · exact measure_ne_top _ _
 
-lemma densityProcess_fst_univ_ae (κ : kernel α (γ × β)) [IsFiniteKernel κ] (n : ℕ) (a : α) :
+lemma densityProcess_fst_univ_ae (κ : Kernel α (γ × β)) [IsFiniteKernel κ] (n : ℕ) (a : α) :
     ∀ᵐ x ∂(fst κ a), densityProcess κ (fst κ) n a x univ = 1 := by
   rw [ae_iff]
   have : {x | ¬ densityProcess κ (fst κ) n a x univ = 1}
@@ -733,7 +733,7 @@ lemma densityProcess_fst_univ_ae (κ : kernel α (γ × β)) [IsFiniteKernel κ]
     · simp [h, measurableSet_countablePartition n hs]
     · simp [h]
 
-lemma tendsto_densityProcess_fst_atTop_univ_of_monotone (κ : kernel α (γ × β)) (n : ℕ) (a : α)
+lemma tendsto_densityProcess_fst_atTop_univ_of_monotone (κ : Kernel α (γ × β)) (n : ℕ) (a : α)
     (x : γ) (seq : ℕ → Set β) (hseq : Monotone seq) (hseq_iUnion : ⋃ i, seq i = univ) :
     Tendsto (fun m ↦ densityProcess κ (fst κ) n a x (seq m)) atTop
       (𝓝 (densityProcess κ (fst κ) n a x univ)) := by
@@ -772,14 +772,14 @@ lemma tendsto_densityProcess_fst_atTop_univ_of_monotone (κ : kernel α (γ × �
     rw [← prod_iUnion, hseq_iUnion]
   · exact Or.inr h0
 
-lemma tendsto_densityProcess_fst_atTop_ae_of_monotone (κ : kernel α (γ × β)) [IsFiniteKernel κ]
+lemma tendsto_densityProcess_fst_atTop_ae_of_monotone (κ : Kernel α (γ × β)) [IsFiniteKernel κ]
     (n : ℕ) (a : α) (seq : ℕ → Set β) (hseq : Monotone seq) (hseq_iUnion : ⋃ i, seq i = univ) :
     ∀ᵐ x ∂(fst κ a), Tendsto (fun m ↦ densityProcess κ (fst κ) n a x (seq m)) atTop (𝓝 1) := by
   filter_upwards [densityProcess_fst_univ_ae κ n a] with x hx
   rw [← hx]
   exact tendsto_densityProcess_fst_atTop_univ_of_monotone κ n a x seq hseq hseq_iUnion
 
-lemma density_fst_univ (κ : kernel α (γ × β)) [IsFiniteKernel κ] (a : α) :
+lemma density_fst_univ (κ : Kernel α (γ × β)) [IsFiniteKernel κ] (a : α) :
     ∀ᵐ x ∂(fst κ a), density κ (fst κ) a x univ = 1 := by
   have h := fun n ↦ densityProcess_fst_univ_ae κ n a
   rw [← ae_all_iff] at h
@@ -802,7 +802,7 @@ lemma tendsto_density_fst_atTop_ae_of_monotone [IsFiniteKernel κ]
 end UnivFst
 
 end Density
-
-end kernel
+  
+end Kernel
 
 end ProbabilityTheory

--- a/Mathlib/Probability/Kernel/Disintegration/Density.lean
+++ b/Mathlib/Probability/Kernel/Disintegration/Density.lean
@@ -802,7 +802,7 @@ lemma tendsto_density_fst_atTop_ae_of_monotone [IsFiniteKernel κ]
 end UnivFst
 
 end Density
-  
+
 end Kernel
 
 end ProbabilityTheory

--- a/Mathlib/Probability/Kernel/Disintegration/Integral.lean
+++ b/Mathlib/Probability/Kernel/Disintegration/Integral.lean
@@ -8,12 +8,12 @@ import Mathlib.Probability.Kernel.Disintegration.Basic
 /-!
 # Lebesgue and Bochner integrals of conditional kernels
 
-Integrals of `ProbabilityTheory.kernel.condKernel` and `MeasureTheory.Measure.condKernel`.
+Integrals of `ProbabilityTheory.Kernel.condKernel` and `MeasureTheory.Measure.condKernel`.
 
 ## Main statements
 
 * `ProbabilityTheory.setIntegral_condKernel`: the integral
-  `∫ b in s, ∫ ω in t, f (b, ω) ∂(kernel.condKernel κ (a, b)) ∂(kernel.fst κ a)` is equal to
+  `∫ b in s, ∫ ω in t, f (b, ω) ∂(Kernel.condKernel κ (a, b)) ∂(Kernel.fst κ a)` is equal to
   `∫ x in s ×ˢ t, f x ∂(κ a)`.
 * `MeasureTheory.Measure.setIntegral_condKernel`:
   `∫ b in s, ∫ ω in t, f (b, ω) ∂(ρ.condKernel b) ∂ρ.fst = ∫ x in s ×ˢ t, f x ∂ρ`
@@ -33,23 +33,23 @@ variable {α β Ω : Type*} {mα : MeasurableSpace α} {mβ : MeasurableSpace β
 
 section Lintegral
 
-variable [CountableOrCountablyGenerated α β] {κ : kernel α (β × Ω)} [IsFiniteKernel κ]
+variable [CountableOrCountablyGenerated α β] {κ : Kernel α (β × Ω)} [IsFiniteKernel κ]
   {f : β × Ω → ℝ≥0∞}
 
 lemma lintegral_condKernel_mem (a : α) {s : Set (β × Ω)} (hs : MeasurableSet s) :
-    ∫⁻ x, kernel.condKernel κ (a, x) {y | (x, y) ∈ s} ∂(kernel.fst κ a) = κ a s := by
-  conv_rhs => rw [← kernel.compProd_fst_condKernel κ]
-  simp_rw [kernel.compProd_apply _ _ _ hs]
+    ∫⁻ x, Kernel.condKernel κ (a, x) {y | (x, y) ∈ s} ∂(Kernel.fst κ a) = κ a s := by
+  conv_rhs => rw [← Kernel.compProd_fst_condKernel κ]
+  simp_rw [Kernel.compProd_apply _ _ _ hs]
 
 lemma setLIntegral_condKernel_eq_measure_prod (a : α) {s : Set β} (hs : MeasurableSet s)
     {t : Set Ω} (ht : MeasurableSet t) :
-    ∫⁻ b in s, kernel.condKernel κ (a, b) t ∂(kernel.fst κ a) = κ a (s ×ˢ t) := by
-  have : κ a (s ×ˢ t) = (kernel.fst κ ⊗ₖ kernel.condKernel κ) a (s ×ˢ t) := by
-    congr; exact (kernel.compProd_fst_condKernel κ).symm
-  rw [this, kernel.compProd_apply _ _ _ (hs.prod ht)]
+    ∫⁻ b in s, Kernel.condKernel κ (a, b) t ∂(Kernel.fst κ a) = κ a (s ×ˢ t) := by
+  have : κ a (s ×ˢ t) = (Kernel.fst κ ⊗ₖ Kernel.condKernel κ) a (s ×ˢ t) := by
+    congr; exact (Kernel.compProd_fst_condKernel κ).symm
+  rw [this, Kernel.compProd_apply _ _ _ (hs.prod ht)]
   classical
-  have : ∀ b, kernel.condKernel κ (a, b) {c | (b, c) ∈ s ×ˢ t}
-      = s.indicator (fun b ↦ kernel.condKernel κ (a, b) t) b := by
+  have : ∀ b, Kernel.condKernel κ (a, b) {c | (b, c) ∈ s ×ˢ t}
+      = s.indicator (fun b ↦ Kernel.condKernel κ (a, b) t) b := by
     intro b
     by_cases hb : b ∈ s <;> simp [hb]
   simp_rw [this]
@@ -59,23 +59,23 @@ lemma setLIntegral_condKernel_eq_measure_prod (a : α) {s : Set β} (hs : Measur
 alias set_lintegral_condKernel_eq_measure_prod := setLIntegral_condKernel_eq_measure_prod
 
 lemma lintegral_condKernel (hf : Measurable f) (a : α) :
-    ∫⁻ b, ∫⁻ ω, f (b, ω) ∂(kernel.condKernel κ (a, b)) ∂(kernel.fst κ a) = ∫⁻ x, f x ∂(κ a) := by
-  conv_rhs => rw [← kernel.compProd_fst_condKernel κ]
-  rw [kernel.lintegral_compProd _ _ _ hf]
+    ∫⁻ b, ∫⁻ ω, f (b, ω) ∂(Kernel.condKernel κ (a, b)) ∂(Kernel.fst κ a) = ∫⁻ x, f x ∂(κ a) := by
+  conv_rhs => rw [← Kernel.compProd_fst_condKernel κ]
+  rw [Kernel.lintegral_compProd _ _ _ hf]
 
 lemma setLIntegral_condKernel (hf : Measurable f) (a : α) {s : Set β}
     (hs : MeasurableSet s) {t : Set Ω} (ht : MeasurableSet t) :
-    ∫⁻ b in s, ∫⁻ ω in t, f (b, ω) ∂(kernel.condKernel κ (a, b)) ∂(kernel.fst κ a)
+    ∫⁻ b in s, ∫⁻ ω in t, f (b, ω) ∂(Kernel.condKernel κ (a, b)) ∂(Kernel.fst κ a)
       = ∫⁻ x in s ×ˢ t, f x ∂(κ a) := by
-  conv_rhs => rw [← kernel.compProd_fst_condKernel κ]
-  rw [kernel.setLIntegral_compProd _ _ _ hf hs ht]
+  conv_rhs => rw [← Kernel.compProd_fst_condKernel κ]
+  rw [Kernel.setLIntegral_compProd _ _ _ hf hs ht]
 
 @[deprecated (since := "2024-06-29")]
 alias set_lintegral_condKernel := setLIntegral_condKernel
 
 lemma setLIntegral_condKernel_univ_right (hf : Measurable f) (a : α) {s : Set β}
     (hs : MeasurableSet s) :
-    ∫⁻ b in s, ∫⁻ ω, f (b, ω) ∂(kernel.condKernel κ (a, b)) ∂(kernel.fst κ a)
+    ∫⁻ b in s, ∫⁻ ω, f (b, ω) ∂(Kernel.condKernel κ (a, b)) ∂(Kernel.fst κ a)
       = ∫⁻ x in s ×ˢ Set.univ, f x ∂(κ a) := by
   rw [← setLIntegral_condKernel hf a hs MeasurableSet.univ]; simp_rw [Measure.restrict_univ]
 
@@ -84,7 +84,7 @@ alias set_lintegral_condKernel_univ_right := setLIntegral_condKernel_univ_right
 
 lemma setLIntegral_condKernel_univ_left (hf : Measurable f) (a : α) {t : Set Ω}
     (ht : MeasurableSet t) :
-    ∫⁻ b, ∫⁻ ω in t, f (b, ω) ∂(kernel.condKernel κ (a, b)) ∂(kernel.fst κ a)
+    ∫⁻ b, ∫⁻ ω in t, f (b, ω) ∂(Kernel.condKernel κ (a, b)) ∂(Kernel.fst κ a)
       = ∫⁻ x in Set.univ ×ˢ t, f x ∂(κ a) := by
   rw [← setLIntegral_condKernel hf a MeasurableSet.univ ht]; simp_rw [Measure.restrict_univ]
 
@@ -95,28 +95,28 @@ end Lintegral
 
 section Integral
 
-variable [CountableOrCountablyGenerated α β] {κ : kernel α (β × Ω)} [IsFiniteKernel κ]
+variable [CountableOrCountablyGenerated α β] {κ : Kernel α (β × Ω)} [IsFiniteKernel κ]
   {E : Type*} {f : β × Ω → E} [NormedAddCommGroup E] [NormedSpace ℝ E]
 
 lemma _root_.MeasureTheory.AEStronglyMeasurable.integral_kernel_condKernel (a : α)
     (hf : AEStronglyMeasurable f (κ a)) :
-    AEStronglyMeasurable (fun x ↦ ∫ y, f (x, y) ∂(kernel.condKernel κ (a, x)))
-      (kernel.fst κ a) := by
-  rw [← kernel.compProd_fst_condKernel κ] at hf
+    AEStronglyMeasurable (fun x ↦ ∫ y, f (x, y) ∂(Kernel.condKernel κ (a, x)))
+      (Kernel.fst κ a) := by
+  rw [← Kernel.compProd_fst_condKernel κ] at hf
   exact AEStronglyMeasurable.integral_kernel_compProd hf
 
 lemma integral_condKernel (a : α) (hf : Integrable f (κ a)) :
-    ∫ b, ∫ ω, f (b, ω) ∂(kernel.condKernel κ (a, b)) ∂(kernel.fst κ a) = ∫ x, f x ∂(κ a) := by
-  conv_rhs => rw [← kernel.compProd_fst_condKernel κ]
-  rw [← kernel.compProd_fst_condKernel κ] at hf
+    ∫ b, ∫ ω, f (b, ω) ∂(Kernel.condKernel κ (a, b)) ∂(Kernel.fst κ a) = ∫ x, f x ∂(κ a) := by
+  conv_rhs => rw [← Kernel.compProd_fst_condKernel κ]
+  rw [← Kernel.compProd_fst_condKernel κ] at hf
   rw [integral_compProd hf]
 
 lemma setIntegral_condKernel (a : α) {s : Set β} (hs : MeasurableSet s)
     {t : Set Ω} (ht : MeasurableSet t) (hf : IntegrableOn f (s ×ˢ t) (κ a)) :
-    ∫ b in s, ∫ ω in t, f (b, ω) ∂(kernel.condKernel κ (a, b)) ∂(kernel.fst κ a)
+    ∫ b in s, ∫ ω in t, f (b, ω) ∂(Kernel.condKernel κ (a, b)) ∂(Kernel.fst κ a)
       = ∫ x in s ×ˢ t, f x ∂(κ a) := by
-  conv_rhs => rw [← kernel.compProd_fst_condKernel κ]
-  rw [← kernel.compProd_fst_condKernel κ] at hf
+  conv_rhs => rw [← Kernel.compProd_fst_condKernel κ]
+  rw [← Kernel.compProd_fst_condKernel κ] at hf
   rw [setIntegral_compProd hs ht hf]
 
 @[deprecated (since := "2024-04-17")]
@@ -124,7 +124,7 @@ alias set_integral_condKernel := setIntegral_condKernel
 
 lemma setIntegral_condKernel_univ_right (a : α) {s : Set β} (hs : MeasurableSet s)
     (hf : IntegrableOn f (s ×ˢ Set.univ) (κ a)) :
-    ∫ b in s, ∫ ω, f (b, ω) ∂(kernel.condKernel κ (a, b)) ∂(kernel.fst κ a)
+    ∫ b in s, ∫ ω, f (b, ω) ∂(Kernel.condKernel κ (a, b)) ∂(Kernel.fst κ a)
       = ∫ x in s ×ˢ Set.univ, f x ∂(κ a) := by
   rw [← setIntegral_condKernel a hs MeasurableSet.univ hf]; simp_rw [Measure.restrict_univ]
 
@@ -133,7 +133,7 @@ alias set_integral_condKernel_univ_right := setIntegral_condKernel_univ_right
 
 lemma setIntegral_condKernel_univ_left (a : α) {t : Set Ω} (ht : MeasurableSet t)
     (hf : IntegrableOn f (Set.univ ×ˢ t) (κ a)) :
-    ∫ b, ∫ ω in t, f (b, ω) ∂(kernel.condKernel κ (a, b)) ∂(kernel.fst κ a)
+    ∫ b, ∫ ω in t, f (b, ω) ∂(Kernel.condKernel κ (a, b)) ∂(Kernel.fst κ a)
       = ∫ x in Set.univ ×ˢ t, f x ∂(κ a) := by
   rw [← setIntegral_condKernel a MeasurableSet.univ ht hf]; simp_rw [Measure.restrict_univ]
 

--- a/Mathlib/Probability/Kernel/Disintegration/Unique.lean
+++ b/Mathlib/Probability/Kernel/Disintegration/Unique.lean
@@ -77,7 +77,7 @@ lemma eq_condKernel_of_measure_eq_compProd_real {ρ : Measure (α × ℝ)} [IsFi
     exact tsum_congr heq
 
 /-- A finite kernel which satisfies the disintegration property is almost everywhere equal to the
-disintegration Kernel. -/
+disintegration kernel. -/
 theorem eq_condKernel_of_measure_eq_compProd (κ : Kernel α Ω) [IsFiniteKernel κ]
     (hκ : ρ = ρ.fst ⊗ₘ κ) :
     ∀ᵐ x ∂ρ.fst, κ x = ρ.condKernel x := by
@@ -164,7 +164,7 @@ section Kernel
 The conditional kernel is unique almost everywhere. -/
 
 /-- A finite kernel which satisfies the disintegration property is almost everywhere equal to the
-disintegration Kernel. -/
+disintegration kernel. -/
 theorem eq_condKernel_of_kernel_eq_compProd [CountableOrCountablyGenerated α β]
     {ρ : Kernel α (β × Ω)} [IsFiniteKernel ρ] {κ : Kernel (α × β) Ω} [IsFiniteKernel κ]
     (hκ : Kernel.fst ρ ⊗ₖ κ = ρ) (a : α) :

--- a/Mathlib/Probability/Kernel/Disintegration/Unique.lean
+++ b/Mathlib/Probability/Kernel/Disintegration/Unique.lean
@@ -8,16 +8,16 @@ import Mathlib.Probability.Kernel.Disintegration.Integral
 /-!
 # Uniqueness of the conditional kernel
 
-We prove that the conditional kernels `ProbabilityTheory.kernel.condKernel` and
+We prove that the conditional kernels `ProbabilityTheory.Kernel.condKernel` and
 `MeasureTheory.Measure.condKernel` are almost everywhere unique.
 
 ## Main statements
 
 * `ProbabilityTheory.eq_condKernel_of_kernel_eq_compProd`: a.e. uniqueness of
-  `ProbabilityTheory.kernel.condKernel`
+  `ProbabilityTheory.Kernel.condKernel`
 * `ProbabilityTheory.eq_condKernel_of_measure_eq_compProd`: a.e. uniqueness of
   `MeasureTheory.Measure.condKernel`
-* `ProbabilityTheory.kernel.condKernel_apply_eq_condKernel`: the kernel `condKernel` is almost
+* `ProbabilityTheory.Kernel.condKernel_apply_eq_condKernel`: the kernel `condKernel` is almost
   everywhere equal to the measure `condKernel`.
 -/
 
@@ -44,11 +44,11 @@ everywhere equal to the disintegration kernel of `ρ` when evaluated on a measur
 This theorem in the case of finite kernels is weaker than `eq_condKernel_of_measure_eq_compProd`
 which asserts that the kernels are equal almost everywhere and not just on a given measurable
 set. -/
-theorem eq_condKernel_of_measure_eq_compProd' (κ : kernel α Ω) [IsSFiniteKernel κ]
+theorem eq_condKernel_of_measure_eq_compProd' (κ : Kernel α Ω) [IsSFiniteKernel κ]
     (hκ : ρ = ρ.fst ⊗ₘ κ) {s : Set Ω} (hs : MeasurableSet s) :
     ∀ᵐ x ∂ρ.fst, κ x s = ρ.condKernel x s := by
   refine ae_eq_of_forall_setLIntegral_eq_of_sigmaFinite
-    (kernel.measurable_coe κ hs) (kernel.measurable_coe ρ.condKernel hs) (fun t ht _ ↦ ?_)
+    (Kernel.measurable_coe κ hs) (Kernel.measurable_coe ρ.condKernel hs) (fun t ht _ ↦ ?_)
   conv_rhs => rw [Measure.setLIntegral_condKernel_eq_measure_prod ht hs, hκ]
   simp only [Measure.compProd_apply (ht.prod hs), Set.mem_prod, ← lintegral_indicator _ ht]
   congr with x
@@ -58,7 +58,7 @@ theorem eq_condKernel_of_measure_eq_compProd' (κ : kernel α Ω) [IsSFiniteKern
 /-- Auxiliary lemma for `eq_condKernel_of_measure_eq_compProd`.
 Uniqueness of the disintegration kernel on ℝ. -/
 lemma eq_condKernel_of_measure_eq_compProd_real {ρ : Measure (α × ℝ)} [IsFiniteMeasure ρ]
-    (κ : kernel α ℝ) [IsFiniteKernel κ] (hκ : ρ = ρ.fst ⊗ₘ κ) :
+    (κ : Kernel α ℝ) [IsFiniteKernel κ] (hκ : ρ = ρ.fst ⊗ₘ κ) :
     ∀ᵐ x ∂ρ.fst, κ x = ρ.condKernel x := by
   have huniv : ∀ᵐ x ∂ρ.fst, κ x Set.univ = ρ.condKernel x Set.univ :=
     eq_condKernel_of_measure_eq_compProd' κ hκ MeasurableSet.univ
@@ -77,8 +77,8 @@ lemma eq_condKernel_of_measure_eq_compProd_real {ρ : Measure (α × ℝ)} [IsFi
     exact tsum_congr heq
 
 /-- A finite kernel which satisfies the disintegration property is almost everywhere equal to the
-disintegration kernel. -/
-theorem eq_condKernel_of_measure_eq_compProd (κ : kernel α Ω) [IsFiniteKernel κ]
+disintegration Kernel. -/
+theorem eq_condKernel_of_measure_eq_compProd (κ : Kernel α Ω) [IsFiniteKernel κ]
     (hκ : ρ = ρ.fst ⊗ₘ κ) :
     ∀ᵐ x ∂ρ.fst, κ x = ρ.condKernel x := by
   -- The idea is to transport the question to `ℝ` from `Ω` using `embeddingReal`
@@ -88,91 +88,89 @@ theorem eq_condKernel_of_measure_eq_compProd (κ : kernel α Ω) [IsFiniteKernel
   set ρ' : Measure (α × ℝ) := ρ.map (Prod.map id f) with hρ'def
   have hρ' : ρ'.fst = ρ.fst := by
     ext s hs
-    have : Measurable fun x : α × Ω ↦ Prod.map id f x :=
-      Measurable.prod measurable_fst <| hf.measurable.comp measurable_snd
-    rw [hρ'def, Measure.fst_apply hs, Measure.fst_apply hs,
-      Measure.map_apply this (measurable_fst hs)]
-    simp [preimage_preimage]
-  have hρ'' : ∀ᵐ x ∂ρ.fst, kernel.map κ f hf.measurable x = ρ'.condKernel x := by
+    rw [hρ'def, Measure.fst_apply, Measure.fst_apply, Measure.map_apply]
+    exacts [rfl, Measurable.prod measurable_fst <| hf.measurable.comp measurable_snd,
+      measurable_fst hs, hs, hs]
+  have hρ'' : ∀ᵐ x ∂ρ.fst, Kernel.map κ f hf.measurable x = ρ'.condKernel x := by
     rw [← hρ']
-    refine eq_condKernel_of_measure_eq_compProd_real (kernel.map κ f hf.measurable) ?_
+    refine eq_condKernel_of_measure_eq_compProd_real (Kernel.map κ f hf.measurable) ?_
     ext s hs
     conv_lhs => rw [hρ'def, hκ]
     rw [Measure.map_apply (measurable_id.prod_map hf.measurable) hs, hρ',
       Measure.compProd_apply hs, Measure.compProd_apply (measurable_id.prod_map hf.measurable hs)]
     congr with a
-    rw [kernel.map_apply' _ _ _ (measurable_prod_mk_left hs)]
-    simp [preimage_preimage]
+    rw [Kernel.map_apply']
+    exacts [rfl, measurable_prod_mk_left hs]
   suffices ∀ᵐ x ∂ρ.fst, ∀ s, MeasurableSet s → ρ'.condKernel x s = ρ.condKernel x (f ⁻¹' s) by
     filter_upwards [hρ'', this] with x hx h
-    rw [kernel.map_apply] at hx
+    rw [Kernel.map_apply] at hx
     ext s hs
     rw [← Set.preimage_image_eq s hf.injective,
       ← Measure.map_apply hf.measurable <| hf.measurableSet_image.2 hs, hx,
       h _ <| hf.measurableSet_image.2 hs]
-  suffices ρ.map (Prod.map id f) = (ρ.fst ⊗ₘ (kernel.map ρ.condKernel f hf.measurable)) by
+  suffices ρ.map (Prod.map id f) = (ρ.fst ⊗ₘ (Kernel.map ρ.condKernel f hf.measurable)) by
     rw [← hρ'] at this
     have heq := eq_condKernel_of_measure_eq_compProd_real _ this
     rw [hρ'] at heq
     filter_upwards [heq] with x hx s hs
-    rw [← hx, kernel.map_apply, Measure.map_apply hf.measurable hs]
+    rw [← hx, Kernel.map_apply, Measure.map_apply hf.measurable hs]
   ext s hs
   conv_lhs => rw [← ρ.compProd_fst_condKernel]
   rw [Measure.compProd_apply hs, Measure.map_apply (measurable_id.prod_map hf.measurable) hs,
     Measure.compProd_apply]
   · congr with a
-    rw [kernel.map_apply' _ _ _ (measurable_prod_mk_left hs)]
-    simp [preimage_preimage]
+    rw [Kernel.map_apply']
+    exacts [rfl, measurable_prod_mk_left hs]
   · exact measurable_id.prod_map hf.measurable hs
 
 end Measure
 
 section KernelAndMeasure
 
-lemma kernel.apply_eq_measure_condKernel_of_compProd_eq
-    {ρ : kernel α (β × Ω)} [IsFiniteKernel ρ] {κ : kernel (α × β) Ω} [IsFiniteKernel κ]
-    (hκ : kernel.fst ρ ⊗ₖ κ = ρ) (a : α) :
-    (fun b ↦ κ (a, b)) =ᵐ[kernel.fst ρ a] (ρ a).condKernel := by
-  have : ρ a = (ρ a).fst ⊗ₘ kernel.comap κ (fun b ↦ (a, b)) measurable_prod_mk_left := by
+lemma Kernel.apply_eq_measure_condKernel_of_compProd_eq
+    {ρ : Kernel α (β × Ω)} [IsFiniteKernel ρ] {κ : Kernel (α × β) Ω} [IsFiniteKernel κ]
+    (hκ : Kernel.fst ρ ⊗ₖ κ = ρ) (a : α) :
+    (fun b ↦ κ (a, b)) =ᵐ[Kernel.fst ρ a] (ρ a).condKernel := by
+  have : ρ a = (ρ a).fst ⊗ₘ Kernel.comap κ (fun b ↦ (a, b)) measurable_prod_mk_left := by
     ext s hs
     conv_lhs => rw [← hκ]
-    rw [Measure.compProd_apply hs, kernel.compProd_apply _ _ _ hs]
+    rw [Measure.compProd_apply hs, Kernel.compProd_apply _ _ _ hs]
     rfl
   have h := eq_condKernel_of_measure_eq_compProd _ this
-  rw [kernel.fst_apply]
+  rw [Kernel.fst_apply]
   filter_upwards [h] with b hb
-  rw [← hb, kernel.comap_apply]
+  rw [← hb, Kernel.comap_apply]
 
-/-- For `fst κ a`-almost all `b`, the conditional kernel `kernel.condKernel κ` applied to `(a, b)`
+/-- For `fst κ a`-almost all `b`, the conditional kernel `Kernel.condKernel κ` applied to `(a, b)`
 is equal to the conditional kernel of the measure `κ a` applied to `b`. -/
-lemma kernel.condKernel_apply_eq_condKernel [CountableOrCountablyGenerated α β]
-    (κ : kernel α (β × Ω)) [IsFiniteKernel κ] (a : α) :
-    (fun b ↦ kernel.condKernel κ (a, b)) =ᵐ[kernel.fst κ a] (κ a).condKernel :=
-  kernel.apply_eq_measure_condKernel_of_compProd_eq (compProd_fst_condKernel κ) a
+lemma Kernel.condKernel_apply_eq_condKernel [CountableOrCountablyGenerated α β]
+    (κ : Kernel α (β × Ω)) [IsFiniteKernel κ] (a : α) :
+    (fun b ↦ Kernel.condKernel κ (a, b)) =ᵐ[Kernel.fst κ a] (κ a).condKernel :=
+  Kernel.apply_eq_measure_condKernel_of_compProd_eq (compProd_fst_condKernel κ) a
 
 lemma condKernel_const [CountableOrCountablyGenerated α β] (ρ : Measure (β × Ω)) [IsFiniteMeasure ρ]
     (a : α) :
-    (fun b ↦ kernel.condKernel (kernel.const α ρ) (a, b)) =ᵐ[ρ.fst] ρ.condKernel := by
-  have h := kernel.condKernel_apply_eq_condKernel (kernel.const α ρ) a
-  simp_rw [kernel.fst_apply, kernel.const_apply] at h
+    (fun b ↦ Kernel.condKernel (Kernel.const α ρ) (a, b)) =ᵐ[ρ.fst] ρ.condKernel := by
+  have h := Kernel.condKernel_apply_eq_condKernel (Kernel.const α ρ) a
+  simp_rw [Kernel.fst_apply, Kernel.const_apply] at h
   filter_upwards [h] with b hb using hb
 
 end KernelAndMeasure
 
 section Kernel
 
-/-! ### Uniqueness of `kernel.condKernel`
+/-! ### Uniqueness of `Kernel.condKernel`
 
 The conditional kernel is unique almost everywhere. -/
 
 /-- A finite kernel which satisfies the disintegration property is almost everywhere equal to the
-disintegration kernel. -/
+disintegration Kernel. -/
 theorem eq_condKernel_of_kernel_eq_compProd [CountableOrCountablyGenerated α β]
-    {ρ : kernel α (β × Ω)} [IsFiniteKernel ρ] {κ : kernel (α × β) Ω} [IsFiniteKernel κ]
-    (hκ : kernel.fst ρ ⊗ₖ κ = ρ) (a : α) :
-    ∀ᵐ x ∂(kernel.fst ρ a), κ (a, x) = kernel.condKernel ρ (a, x) := by
-  filter_upwards [kernel.condKernel_apply_eq_condKernel ρ a,
-    kernel.apply_eq_measure_condKernel_of_compProd_eq hκ a] with a h1 h2
+    {ρ : Kernel α (β × Ω)} [IsFiniteKernel ρ] {κ : Kernel (α × β) Ω} [IsFiniteKernel κ]
+    (hκ : Kernel.fst ρ ⊗ₖ κ = ρ) (a : α) :
+    ∀ᵐ x ∂(Kernel.fst ρ a), κ (a, x) = Kernel.condKernel ρ (a, x) := by
+  filter_upwards [Kernel.condKernel_apply_eq_condKernel ρ a,
+    Kernel.apply_eq_measure_condKernel_of_compProd_eq hκ a] with a h1 h2
   rw [h1, h2]
 
 end Kernel

--- a/Mathlib/Probability/Kernel/IntegralCompProd.lean
+++ b/Mathlib/Probability/Kernel/IntegralCompProd.lean
@@ -11,7 +11,7 @@ import Mathlib.MeasureTheory.Integral.SetIntegral
 
 We prove properties of the composition-product of two kernels. If `κ` is an s-finite kernel from
 `α` to `β` and `η` is an s-finite kernel from `α × β` to `γ`, we can form their composition-product
-`κ ⊗ₖ η : kernel α (β × γ)`. We proved in `ProbabilityTheory.kernel.lintegral_compProd` that it
+`κ ⊗ₖ η : Kernel α (β × γ)`. We proved in `ProbabilityTheory.Kernel.lintegral_compProd` that it
 verifies `∫⁻ bc, f bc ∂((κ ⊗ₖ η) a) = ∫⁻ b, ∫⁻ c, f (b, c) ∂(η (a, b)) ∂(κ a)`. In this file, we
 prove the same equality for the Bochner integral.
 
@@ -33,13 +33,12 @@ kernels.
 
 noncomputable section
 
-open scoped Topology ENNReal MeasureTheory ProbabilityTheory
-
-open Set Function Real ENNReal MeasureTheory Filter ProbabilityTheory ProbabilityTheory.kernel
+open Set Function Real ENNReal MeasureTheory Filter ProbabilityTheory ProbabilityTheory.Kernel
+open scoped Topology ENNReal MeasureTheory
 
 variable {α β γ E : Type*} {mα : MeasurableSpace α} {mβ : MeasurableSpace β}
-  {mγ : MeasurableSpace γ} [NormedAddCommGroup E] {κ : kernel α β} [IsSFiniteKernel κ]
-  {η : kernel (α × β) γ} [IsSFiniteKernel η] {a : α}
+  {mγ : MeasurableSpace γ} [NormedAddCommGroup E] {κ : Kernel α β} [IsSFiniteKernel κ]
+  {η : Kernel (α × β) γ} [IsSFiniteKernel η] {a : α}
 
 namespace ProbabilityTheory
 
@@ -84,7 +83,7 @@ theorem hasFiniteIntegral_compProd_iff ⦃f : β × γ → E⦄ (h1f : StronglyM
       (∀ᵐ x ∂κ a, HasFiniteIntegral (fun y => f (x, y)) (η (a, x))) ∧
         HasFiniteIntegral (fun x => ∫ y, ‖f (x, y)‖ ∂η (a, x)) (κ a) := by
   simp only [HasFiniteIntegral]
-  rw [kernel.lintegral_compProd _ _ _ h1f.ennnorm]
+  rw [Kernel.lintegral_compProd _ _ _ h1f.ennnorm]
   have : ∀ x, ∀ᵐ y ∂η (a, x), 0 ≤ ‖f (x, y)‖ := fun x => eventually_of_forall fun y => norm_nonneg _
   simp_rw [integral_eq_lintegral_of_nonneg_ae (this _)
       (h1f.norm.comp_measurable measurable_prod_mk_left).aestronglyMeasurable,
@@ -143,7 +142,7 @@ theorem _root_.MeasureTheory.Integrable.integral_compProd [NormedSpace ℝ E]
 variable [NormedSpace ℝ E] {E' : Type*} [NormedAddCommGroup E']
   [CompleteSpace E'] [NormedSpace ℝ E']
 
-theorem kernel.integral_fn_integral_add ⦃f g : β × γ → E⦄ (F : E → E')
+theorem Kernel.integral_fn_integral_add ⦃f g : β × γ → E⦄ (F : E → E')
     (hf : Integrable f ((κ ⊗ₖ η) a)) (hg : Integrable g ((κ ⊗ₖ η) a)) :
     ∫ x, F (∫ y, f (x, y) + g (x, y) ∂η (a, x)) ∂κ a =
       ∫ x, F (∫ y, f (x, y) ∂η (a, x) + ∫ y, g (x, y) ∂η (a, x)) ∂κ a := by
@@ -151,7 +150,7 @@ theorem kernel.integral_fn_integral_add ⦃f g : β × γ → E⦄ (F : E → E'
   filter_upwards [hf.compProd_mk_left_ae, hg.compProd_mk_left_ae] with _ h2f h2g
   simp [integral_add h2f h2g]
 
-theorem kernel.integral_fn_integral_sub ⦃f g : β × γ → E⦄ (F : E → E')
+theorem Kernel.integral_fn_integral_sub ⦃f g : β × γ → E⦄ (F : E → E')
     (hf : Integrable f ((κ ⊗ₖ η) a)) (hg : Integrable g ((κ ⊗ₖ η) a)) :
     ∫ x, F (∫ y, f (x, y) - g (x, y) ∂η (a, x)) ∂κ a =
       ∫ x, F (∫ y, f (x, y) ∂η (a, x) - ∫ y, g (x, y) ∂η (a, x)) ∂κ a := by
@@ -159,7 +158,7 @@ theorem kernel.integral_fn_integral_sub ⦃f g : β × γ → E⦄ (F : E → E'
   filter_upwards [hf.compProd_mk_left_ae, hg.compProd_mk_left_ae] with _ h2f h2g
   simp [integral_sub h2f h2g]
 
-theorem kernel.lintegral_fn_integral_sub ⦃f g : β × γ → E⦄ (F : E → ℝ≥0∞)
+theorem Kernel.lintegral_fn_integral_sub ⦃f g : β × γ → E⦄ (F : E → ℝ≥0∞)
     (hf : Integrable f ((κ ⊗ₖ η) a)) (hg : Integrable g ((κ ⊗ₖ η) a)) :
     ∫⁻ x, F (∫ y, f (x, y) - g (x, y) ∂η (a, x)) ∂κ a =
       ∫⁻ x, F (∫ y, f (x, y) ∂η (a, x) - ∫ y, g (x, y) ∂η (a, x)) ∂κ a := by
@@ -167,34 +166,34 @@ theorem kernel.lintegral_fn_integral_sub ⦃f g : β × γ → E⦄ (F : E → �
   filter_upwards [hf.compProd_mk_left_ae, hg.compProd_mk_left_ae] with _ h2f h2g
   simp [integral_sub h2f h2g]
 
-theorem kernel.integral_integral_add ⦃f g : β × γ → E⦄ (hf : Integrable f ((κ ⊗ₖ η) a))
+theorem Kernel.integral_integral_add ⦃f g : β × γ → E⦄ (hf : Integrable f ((κ ⊗ₖ η) a))
     (hg : Integrable g ((κ ⊗ₖ η) a)) :
     ∫ x, ∫ y, f (x, y) + g (x, y) ∂η (a, x) ∂κ a =
       ∫ x, ∫ y, f (x, y) ∂η (a, x) ∂κ a + ∫ x, ∫ y, g (x, y) ∂η (a, x) ∂κ a :=
-  (kernel.integral_fn_integral_add id hf hg).trans <|
+  (Kernel.integral_fn_integral_add id hf hg).trans <|
     integral_add hf.integral_compProd hg.integral_compProd
 
-theorem kernel.integral_integral_add' ⦃f g : β × γ → E⦄ (hf : Integrable f ((κ ⊗ₖ η) a))
+theorem Kernel.integral_integral_add' ⦃f g : β × γ → E⦄ (hf : Integrable f ((κ ⊗ₖ η) a))
     (hg : Integrable g ((κ ⊗ₖ η) a)) :
     ∫ x, ∫ y, (f + g) (x, y) ∂η (a, x) ∂κ a =
       ∫ x, ∫ y, f (x, y) ∂η (a, x) ∂κ a + ∫ x, ∫ y, g (x, y) ∂η (a, x) ∂κ a :=
-  kernel.integral_integral_add hf hg
+  Kernel.integral_integral_add hf hg
 
-theorem kernel.integral_integral_sub ⦃f g : β × γ → E⦄ (hf : Integrable f ((κ ⊗ₖ η) a))
+theorem Kernel.integral_integral_sub ⦃f g : β × γ → E⦄ (hf : Integrable f ((κ ⊗ₖ η) a))
     (hg : Integrable g ((κ ⊗ₖ η) a)) :
     ∫ x, ∫ y, f (x, y) - g (x, y) ∂η (a, x) ∂κ a =
       ∫ x, ∫ y, f (x, y) ∂η (a, x) ∂κ a - ∫ x, ∫ y, g (x, y) ∂η (a, x) ∂κ a :=
-  (kernel.integral_fn_integral_sub id hf hg).trans <|
+  (Kernel.integral_fn_integral_sub id hf hg).trans <|
     integral_sub hf.integral_compProd hg.integral_compProd
 
-theorem kernel.integral_integral_sub' ⦃f g : β × γ → E⦄ (hf : Integrable f ((κ ⊗ₖ η) a))
+theorem Kernel.integral_integral_sub' ⦃f g : β × γ → E⦄ (hf : Integrable f ((κ ⊗ₖ η) a))
     (hg : Integrable g ((κ ⊗ₖ η) a)) :
     ∫ x, ∫ y, (f - g) (x, y) ∂η (a, x) ∂κ a =
       ∫ x, ∫ y, f (x, y) ∂η (a, x) ∂κ a - ∫ x, ∫ y, g (x, y) ∂η (a, x) ∂κ a :=
-  kernel.integral_integral_sub hf hg
+  Kernel.integral_integral_sub hf hg
 
 -- Porting note: couldn't get the `→₁[]` syntax to work
-theorem kernel.continuous_integral_integral :
+theorem Kernel.continuous_integral_integral :
     -- Continuous fun f : α × β →₁[(κ ⊗ₖ η) a] E => ∫ x, ∫ y, f (x, y) ∂η (a, x) ∂κ a := by
     Continuous fun f : (MeasureTheory.Lp (α := β × γ) E 1 (((κ ⊗ₖ η) a) : Measure (β × γ))) =>
         ∫ x, ∫ y, f (x, y) ∂η (a, x) ∂κ a := by
@@ -203,7 +202,7 @@ theorem kernel.continuous_integral_integral :
     tendsto_integral_of_L1 _ (L1.integrable_coeFn g).integral_compProd
       (eventually_of_forall fun h => (L1.integrable_coeFn h).integral_compProd) ?_
   simp_rw [←
-    kernel.lintegral_fn_integral_sub (fun x => (‖x‖₊ : ℝ≥0∞)) (L1.integrable_coeFn _)
+    Kernel.lintegral_fn_integral_sub (fun x => (‖x‖₊ : ℝ≥0∞)) (L1.integrable_coeFn _)
       (L1.integrable_coeFn g)]
   apply tendsto_of_tendsto_of_tendsto_of_le_of_le tendsto_const_nhds _ (fun i => zero_le _) _
   · exact fun i => ∫⁻ x, ∫⁻ y, ‖i (x, y) - g (x, y)‖₊ ∂η (a, x) ∂κ a
@@ -215,7 +214,7 @@ theorem kernel.continuous_integral_integral :
   have : ∀ i : (MeasureTheory.Lp (α := β × γ) E 1 (((κ ⊗ₖ η) a) : Measure (β × γ))),
       Measurable fun z => (‖i z - g z‖₊ : ℝ≥0∞) := fun i =>
     ((Lp.stronglyMeasurable i).sub (Lp.stronglyMeasurable g)).ennnorm
-  simp_rw [← kernel.lintegral_compProd _ _ _ (this _), ← L1.ofReal_norm_sub_eq_lintegral, ←
+  simp_rw [← Kernel.lintegral_compProd _ _ _ (this _), ← L1.ofReal_norm_sub_eq_lintegral, ←
     ofReal_zero]
   refine (continuous_ofReal.tendsto 0).comp ?_
   rw [← tendsto_iff_norm_sub_tendsto_zero]
@@ -234,13 +233,13 @@ theorem integral_compProd :
     congr 1
     rw [integral_toReal]
     rotate_left
-    · exact (kernel.measurable_kernel_prod_mk_left' hs _).aemeasurable
+    · exact (Kernel.measurable_kernel_prod_mk_left' hs _).aemeasurable
     · exact ae_kernel_lt_top a h2s.ne
-    rw [kernel.compProd_apply _ _ _ hs]
+    rw [Kernel.compProd_apply _ _ _ hs]
     rfl
   · intro f g _ i_f i_g hf hg
-    simp_rw [integral_add' i_f i_g, kernel.integral_integral_add' i_f i_g, hf, hg]
-  · exact isClosed_eq continuous_integral kernel.continuous_integral_integral
+    simp_rw [integral_add' i_f i_g, Kernel.integral_integral_add' i_f i_g, hf, hg]
+  · exact isClosed_eq continuous_integral Kernel.continuous_integral_integral
   · intro f g hfg _ hf
     convert hf using 1
     · exact integral_congr_ae hfg.symm
@@ -252,9 +251,9 @@ theorem setIntegral_compProd {f : β × γ → E} {s : Set β} {t : Set γ} (hs 
     (ht : MeasurableSet t) (hf : IntegrableOn f (s ×ˢ t) ((κ ⊗ₖ η) a)) :
     ∫ z in s ×ˢ t, f z ∂(κ ⊗ₖ η) a = ∫ x in s, ∫ y in t, f (x, y) ∂η (a, x) ∂κ a := by
   -- Porting note: `compProd_restrict` needed some explicit argumnts
-  rw [← kernel.restrict_apply (κ ⊗ₖ η) (hs.prod ht), ← compProd_restrict hs ht, integral_compProd]
-  · simp_rw [kernel.restrict_apply]
-  · rw [compProd_restrict, kernel.restrict_apply]; exact hf
+  rw [← Kernel.restrict_apply (κ ⊗ₖ η) (hs.prod ht), ← compProd_restrict hs ht, integral_compProd]
+  · simp_rw [Kernel.restrict_apply]
+  · rw [compProd_restrict, Kernel.restrict_apply]; exact hf
 
 @[deprecated (since := "2024-04-17")]
 alias set_integral_compProd := setIntegral_compProd

--- a/Mathlib/Probability/Kernel/Invariance.lean
+++ b/Mathlib/Probability/Kernel/Invariance.lean
@@ -13,12 +13,12 @@ kernel `μ.bind κ` is the same measure.
 
 ## Main definitions
 
-* `ProbabilityTheory.kernel.Invariant`: invariance of a given measure with respect to a kernel.
+* `ProbabilityTheory.Kernel.Invariant`: invariance of a given measure with respect to a Kernel.
 
 ## Useful lemmas
 
-* `ProbabilityTheory.kernel.const_bind_eq_comp_const`, and
-  `ProbabilityTheory.kernel.comp_const_apply_eq_bind` established the relationship between
+* `ProbabilityTheory.Kernel.const_bind_eq_comp_const`, and
+  `ProbabilityTheory.Kernel.comp_const_apply_eq_bind` established the relationship between
   the push-forward measure and the composition of kernels.
 
 -/
@@ -32,30 +32,30 @@ namespace ProbabilityTheory
 
 variable {α β γ : Type*} {mα : MeasurableSpace α} {mβ : MeasurableSpace β} {mγ : MeasurableSpace γ}
 
-namespace kernel
+namespace Kernel
 
 /-! ### Push-forward of measures along a kernel -/
 
 
 @[simp]
-theorem bind_add (μ ν : Measure α) (κ : kernel α β) : (μ + ν).bind κ = μ.bind κ + ν.bind κ := by
+theorem bind_add (μ ν : Measure α) (κ : Kernel α β) : (μ + ν).bind κ = μ.bind κ + ν.bind κ := by
   ext1 s hs
-  rw [Measure.bind_apply hs (kernel.measurable _), lintegral_add_measure, Measure.coe_add,
-    Pi.add_apply, Measure.bind_apply hs (kernel.measurable _),
-    Measure.bind_apply hs (kernel.measurable _)]
+  rw [Measure.bind_apply hs (Kernel.measurable _), lintegral_add_measure, Measure.coe_add,
+    Pi.add_apply, Measure.bind_apply hs (Kernel.measurable _),
+    Measure.bind_apply hs (Kernel.measurable _)]
 
 @[simp]
-theorem bind_smul (κ : kernel α β) (μ : Measure α) (r : ℝ≥0∞) : (r • μ).bind κ = r • μ.bind κ := by
+theorem bind_smul (κ : Kernel α β) (μ : Measure α) (r : ℝ≥0∞) : (r • μ).bind κ = r • μ.bind κ := by
   ext1 s hs
-  rw [Measure.bind_apply hs (kernel.measurable _), lintegral_smul_measure, Measure.coe_smul,
-    Pi.smul_apply, Measure.bind_apply hs (kernel.measurable _), smul_eq_mul]
+  rw [Measure.bind_apply hs (Kernel.measurable _), lintegral_smul_measure, Measure.coe_smul,
+    Pi.smul_apply, Measure.bind_apply hs (Kernel.measurable _), smul_eq_mul]
 
-theorem const_bind_eq_comp_const (κ : kernel α β) (μ : Measure α) :
+theorem const_bind_eq_comp_const (κ : Kernel α β) (μ : Measure α) :
     const α (μ.bind κ) = κ ∘ₖ const α μ := by
   ext a s hs
-  simp_rw [comp_apply' _ _ _ hs, const_apply, Measure.bind_apply hs (kernel.measurable _)]
+  simp_rw [comp_apply' _ _ _ hs, const_apply, Measure.bind_apply hs (Kernel.measurable _)]
 
-theorem comp_const_apply_eq_bind (κ : kernel α β) (μ : Measure α) (a : α) :
+theorem comp_const_apply_eq_bind (κ : Kernel α β) (μ : Measure α) (a : α) :
     (κ ∘ₖ const α μ) a = μ.bind κ := by
   rw [← const_apply (μ.bind κ) a, const_bind_eq_comp_const κ μ]
 
@@ -64,10 +64,10 @@ theorem comp_const_apply_eq_bind (κ : kernel α β) (μ : Measure α) (a : α) 
 
 /-- A measure `μ` is invariant with respect to the kernel `κ` if the push-forward measure of `μ`
 along `κ` equals `μ`. -/
-def Invariant (κ : kernel α α) (μ : Measure α) : Prop :=
+def Invariant (κ : Kernel α α) (μ : Measure α) : Prop :=
   μ.bind κ = μ
 
-variable {κ η : kernel α α} {μ : Measure α}
+variable {κ η : Kernel α α} {μ : Measure α}
 
 theorem Invariant.def (hκ : Invariant κ μ) : μ.bind κ = μ :=
   hκ
@@ -82,6 +82,6 @@ theorem Invariant.comp [IsSFiniteKernel κ] (hκ : Invariant κ μ) (hη : Invar
   · simp_rw [Invariant, ← comp_const_apply_eq_bind (κ ∘ₖ η) μ hα.some, comp_assoc, hη.comp_const,
       hκ.comp_const, const_apply]
 
-end kernel
+end Kernel
 
 end ProbabilityTheory

--- a/Mathlib/Probability/Kernel/Invariance.lean
+++ b/Mathlib/Probability/Kernel/Invariance.lean
@@ -13,7 +13,7 @@ kernel `μ.bind κ` is the same measure.
 
 ## Main definitions
 
-* `ProbabilityTheory.Kernel.Invariant`: invariance of a given measure with respect to a Kernel.
+* `ProbabilityTheory.Kernel.Invariant`: invariance of a given measure with respect to a kernel.
 
 ## Useful lemmas
 

--- a/Mathlib/Probability/Kernel/MeasurableIntegral.lean
+++ b/Mathlib/Probability/Kernel/MeasurableIntegral.lean
@@ -16,10 +16,10 @@ is strongly measurable.
 ## Main statements
 
 * `Measurable.lintegral_kernel_prod_right`: the function `a ↦ ∫⁻ b, f a b ∂(κ a)` is measurable,
-  for an s-finite kernel `κ : kernel α β` and a function `f : α → β → ℝ≥0∞` such that `uncurry f`
+  for an s-finite kernel `κ : Kernel α β` and a function `f : α → β → ℝ≥0∞` such that `uncurry f`
   is measurable.
 * `MeasureTheory.StronglyMeasurable.integral_kernel_prod_right`: the function
-  `a ↦ ∫ b, f a b ∂(κ a)` is measurable, for an s-finite kernel `κ : kernel α β` and a function
+  `a ↦ ∫ b, f a b ∂(κ a)` is measurable, for an s-finite kernel `κ : Kernel α β` and a function
   `f : α → β → E` such that `uncurry f` is measurable.
 
 -/
@@ -30,11 +30,11 @@ open MeasureTheory ProbabilityTheory Function Set Filter
 open scoped MeasureTheory ENNReal Topology
 
 variable {α β γ : Type*} {mα : MeasurableSpace α} {mβ : MeasurableSpace β} {mγ : MeasurableSpace γ}
-  {κ : kernel α β} {η : kernel (α × β) γ} {a : α}
+  {κ : Kernel α β} {η : Kernel (α × β) γ} {a : α}
 
 namespace ProbabilityTheory
 
-namespace kernel
+namespace Kernel
 
 /-- This is an auxiliary lemma for `measurable_kernel_prod_mk_left`. -/
 theorem measurable_kernel_prod_mk_left_of_finite {t : Set (α × β)} (ht : MeasurableSet t)
@@ -58,7 +58,7 @@ theorem measurable_kernel_prod_mk_left_of_finite {t : Set (α × β)} (ht : Meas
       split_ifs
       exacts [rfl, measure_empty]
     rw [h_eq_ite]
-    exact Measurable.ite ht₁ (kernel.measurable_coe κ ht₂) measurable_const
+    exact Measurable.ite ht₁ (Kernel.measurable_coe κ ht₂) measurable_const
   · -- we assume that the result is true for `t` and we prove it for `tᶜ`
     intro t' ht' h_meas
     have h_eq_sdiff : ∀ a, Prod.mk a ⁻¹' t'ᶜ = Set.univ \ Prod.mk a ⁻¹' t' := by
@@ -74,7 +74,7 @@ theorem measurable_kernel_prod_mk_left_of_finite {t : Set (α × β)} (ht : Meas
       · exact (@measurable_prod_mk_left α β _ _ a) ht'
       · exact measure_ne_top _ _
     rw [this]
-    exact Measurable.sub (kernel.measurable_coe κ MeasurableSet.univ) h_meas
+    exact Measurable.sub (Kernel.measurable_coe κ MeasurableSet.univ) h_meas
   · -- we assume that the result is true for a family of disjoint sets and prove it for their union
     intro f h_disj hf_meas hf
     have h_Union :
@@ -98,10 +98,10 @@ theorem measurable_kernel_prod_mk_left_of_finite {t : Set (α × β)} (ht : Meas
 
 theorem measurable_kernel_prod_mk_left [IsSFiniteKernel κ] {t : Set (α × β)}
     (ht : MeasurableSet t) : Measurable fun a => κ a (Prod.mk a ⁻¹' t) := by
-  rw [← kernel.kernel_sum_seq κ]
-  have : ∀ a, kernel.sum (kernel.seq κ) a (Prod.mk a ⁻¹' t) =
-      ∑' n, kernel.seq κ n a (Prod.mk a ⁻¹' t) := fun a =>
-    kernel.sum_apply' _ _ (measurable_prod_mk_left ht)
+  rw [← Kernel.kernel_sum_seq κ]
+  have : ∀ a, Kernel.sum (Kernel.seq κ) a (Prod.mk a ⁻¹' t) =
+      ∑' n, Kernel.seq κ n a (Prod.mk a ⁻¹' t) := fun a =>
+    Kernel.sum_apply' _ _ (measurable_prod_mk_left ht)
   simp_rw [this]
   refine Measurable.ennreal_tsum fun n => ?_
   exact measurable_kernel_prod_mk_left_of_finite ht inferInstance
@@ -118,16 +118,16 @@ theorem measurable_kernel_prod_mk_right [IsSFiniteKernel κ] {s : Set (β × α)
     (hs : MeasurableSet s) : Measurable fun y => κ y ((fun x => (x, y)) ⁻¹' s) :=
   measurable_kernel_prod_mk_left (measurableSet_swap_iff.mpr hs)
 
-end kernel
+end Kernel
 
-open ProbabilityTheory.kernel
+open ProbabilityTheory.Kernel
 
 section Lintegral
 
 variable [IsSFiniteKernel κ] [IsSFiniteKernel η]
 
 /-- Auxiliary lemma for `Measurable.lintegral_kernel_prod_right`. -/
-theorem kernel.measurable_lintegral_indicator_const {t : Set (α × β)} (ht : MeasurableSet t)
+theorem Kernel.measurable_lintegral_indicator_const {t : Set (α × β)} (ht : MeasurableSet t)
     (c : ℝ≥0∞) : Measurable fun a => ∫⁻ b, t.indicator (Function.const (α × β) c) (a, b) ∂κ a := by
   -- Porting note: was originally by
   -- `simp_rw [lintegral_indicator_const_comp measurable_prod_mk_left ht _]`
@@ -159,7 +159,7 @@ theorem _root_.Measurable.lintegral_kernel_prod_right {f : α → β → ℝ≥0
   · intro c t ht
     simp only [SimpleFunc.const_zero, SimpleFunc.coe_piecewise, SimpleFunc.coe_const,
       SimpleFunc.coe_zero, Set.piecewise_eq_indicator]
-    exact kernel.measurable_lintegral_indicator_const (κ := κ) ht c
+    exact Kernel.measurable_lintegral_indicator_const (κ := κ) ht c
   · intro g₁ g₂ _ hm₁ hm₂
     simp only [SimpleFunc.coe_add, Pi.add_apply]
     have h_add :
@@ -241,7 +241,7 @@ theorem measurableSet_kernel_integrable ⦃f : α → β → E⦄ (hf : Strongly
 
 end ProbabilityTheory
 
-open ProbabilityTheory ProbabilityTheory.kernel
+open ProbabilityTheory.Kernel
 
 namespace MeasureTheory
 
@@ -270,7 +270,7 @@ theorem StronglyMeasurable.integral_kernel_prod_right ⦃f : α → β → E⦄
     refine Finset.stronglyMeasurable_sum _ fun x _ => ?_
     refine (Measurable.ennreal_toReal ?_).stronglyMeasurable.smul_const _
     simp only [s', SimpleFunc.coe_comp, preimage_comp]
-    apply kernel.measurable_kernel_prod_mk_left
+    apply Kernel.measurable_kernel_prod_mk_left
     exact (s n).measurableSet_fiber x
   have h2f' : Tendsto f' atTop (𝓝 fun x : α => ∫ y : β, f x y ∂κ x) := by
     rw [tendsto_pi_nhds]; intro x

--- a/Mathlib/Probability/Kernel/MeasureCompProd.lean
+++ b/Mathlib/Probability/Kernel/MeasureCompProd.lean
@@ -8,15 +8,15 @@ import Mathlib.Probability.Kernel.IntegralCompProd
 /-!
 # Composition-Product of a measure and a kernel
 
-This operation, denoted by `⊗ₘ`, takes `μ : Measure α` and `κ : kernel α β` and creates
+This operation, denoted by `⊗ₘ`, takes `μ : Measure α` and `κ : Kernel α β` and creates
 `μ ⊗ₘ κ : Measure (α × β)`. The integral of a function against `μ ⊗ₘ κ` is
 `∫⁻ x, f x ∂(μ ⊗ₘ κ) = ∫⁻ a, ∫⁻ b, f (a, b) ∂(κ a) ∂μ`.
 
-`μ ⊗ₘ κ` is defined as `((kernel.const Unit μ) ⊗ₖ (kernel.prodMkLeft Unit κ)) ()`.
+`μ ⊗ₘ κ` is defined as `((Kernel.const Unit μ) ⊗ₖ (Kernel.prodMkLeft Unit κ)) ()`.
 
 ## Main definitions
 
-* `Measure.compProd`: from `μ : Measure α` and `κ : kernel α β`, get a `Measure (α × β)`.
+* `Measure.compProd`: from `μ : Measure α` and `κ : Kernel α β`, get a `Measure (α × β)`.
 
 ## Notations
 
@@ -30,22 +30,22 @@ open ProbabilityTheory
 namespace MeasureTheory.Measure
 
 variable {α β : Type*} {mα : MeasurableSpace α} {mβ : MeasurableSpace β}
-  {μ : Measure α} {κ η : kernel α β}
+  {μ : Measure α} {κ η : Kernel α β}
 
-/-- The composition-product of a measure and a kernel. -/
+/-- The composition-product of a measure and a Kernel. -/
 noncomputable
-def compProd (μ : Measure α) (κ : kernel α β) : Measure (α × β) :=
-  (kernel.const Unit μ ⊗ₖ kernel.prodMkLeft Unit κ) ()
+def compProd (μ : Measure α) (κ : Kernel α β) : Measure (α × β) :=
+  (Kernel.const Unit μ ⊗ₖ Kernel.prodMkLeft Unit κ) ()
 
 @[inherit_doc]
 scoped[ProbabilityTheory] infixl:100 " ⊗ₘ " => MeasureTheory.Measure.compProd
 
-@[simp] lemma compProd_zero_left (κ : kernel α β) : (0 : Measure α) ⊗ₘ κ = 0 := by simp [compProd]
-@[simp] lemma compProd_zero_right (μ : Measure α) : μ ⊗ₘ (0 : kernel α β) = 0 := by simp [compProd]
+@[simp] lemma compProd_zero_left (κ : Kernel α β) : (0 : Measure α) ⊗ₘ κ = 0 := by simp [compProd]
+@[simp] lemma compProd_zero_right (μ : Measure α) : μ ⊗ₘ (0 : Kernel α β) = 0 := by simp [compProd]
 
 lemma compProd_apply [SFinite μ] [IsSFiniteKernel κ] {s : Set (α × β)} (hs : MeasurableSet s) :
     (μ ⊗ₘ κ) s = ∫⁻ a, κ a (Prod.mk a ⁻¹' s) ∂μ := by
-  simp_rw [compProd, kernel.compProd_apply _ _ _ hs, kernel.const_apply, kernel.prodMkLeft_apply']
+  simp_rw [compProd, Kernel.compProd_apply _ _ _ hs, Kernel.const_apply, Kernel.prodMkLeft_apply']
   rfl
 
 lemma compProd_apply_prod [SFinite μ] [IsSFiniteKernel κ]
@@ -67,41 +67,41 @@ lemma compProd_congr [SFinite μ] [IsSFiniteKernel κ] [IsSFiniteKernel η]
 lemma ae_compProd_of_ae_ae [SFinite μ] [IsSFiniteKernel κ] {p : α × β → Prop}
     (hp : MeasurableSet {x | p x}) (h : ∀ᵐ a ∂μ, ∀ᵐ b ∂(κ a), p (a, b)) :
     ∀ᵐ x ∂(μ ⊗ₘ κ), p x :=
-  kernel.ae_compProd_of_ae_ae hp h
+  Kernel.ae_compProd_of_ae_ae hp h
 
 lemma ae_ae_of_ae_compProd [SFinite μ] [IsSFiniteKernel κ] {p : α × β → Prop}
     (h : ∀ᵐ x ∂(μ ⊗ₘ κ), p x) :
     ∀ᵐ a ∂μ, ∀ᵐ b ∂κ a, p (a, b) := by
-  convert kernel.ae_ae_of_ae_compProd h -- Much faster with `convert`
+  convert Kernel.ae_ae_of_ae_compProd h -- Much faster with `convert`
 
 lemma ae_compProd_iff [SFinite μ] [IsSFiniteKernel κ] {p : α × β → Prop}
     (hp : MeasurableSet {x | p x}) :
     (∀ᵐ x ∂(μ ⊗ₘ κ), p x) ↔ ∀ᵐ a ∂μ, ∀ᵐ b ∂(κ a), p (a, b) :=
-  kernel.ae_compProd_iff hp
+  Kernel.ae_compProd_iff hp
 
-lemma compProd_add_left (μ ν : Measure α) [SFinite μ] [SFinite ν] (κ : kernel α β)
+lemma compProd_add_left (μ ν : Measure α) [SFinite μ] [SFinite ν] (κ : Kernel α β)
     [IsSFiniteKernel κ] :
     (μ + ν) ⊗ₘ κ = μ ⊗ₘ κ + ν ⊗ₘ κ := by
-  rw [Measure.compProd, kernel.const_add, kernel.compProd_add_left]; rfl
+  rw [Measure.compProd, Kernel.const_add, Kernel.compProd_add_left]; rfl
 
-lemma compProd_add_right (μ : Measure α) [SFinite μ] (κ η : kernel α β)
+lemma compProd_add_right (μ : Measure α) [SFinite μ] (κ η : Kernel α β)
     [IsSFiniteKernel κ] [IsSFiniteKernel η] :
     μ ⊗ₘ (κ + η) = μ ⊗ₘ κ + μ ⊗ₘ η := by
-  rw [Measure.compProd, kernel.prodMkLeft_add, kernel.compProd_add_right]; rfl
+  rw [Measure.compProd, Kernel.prodMkLeft_add, Kernel.compProd_add_right]; rfl
 
 section Integral
 
 lemma lintegral_compProd [SFinite μ] [IsSFiniteKernel κ]
     {f : α × β → ℝ≥0∞} (hf : Measurable f) :
     ∫⁻ x, f x ∂(μ ⊗ₘ κ) = ∫⁻ a, ∫⁻ b, f (a, b) ∂(κ a) ∂μ := by
-  rw [compProd, kernel.lintegral_compProd _ _ _ hf]
+  rw [compProd, Kernel.lintegral_compProd _ _ _ hf]
   simp
 
 lemma setLIntegral_compProd [SFinite μ] [IsSFiniteKernel κ]
     {f : α × β → ℝ≥0∞} (hf : Measurable f)
     {s : Set α} (hs : MeasurableSet s) {t : Set β} (ht : MeasurableSet t) :
     ∫⁻ x in s ×ˢ t, f x ∂(μ ⊗ₘ κ) = ∫⁻ a in s, ∫⁻ b in t, f (a, b) ∂(κ a) ∂μ := by
-  rw [compProd, kernel.setLIntegral_compProd _ _ _ hf hs ht]
+  rw [compProd, Kernel.setLIntegral_compProd _ _ _ hf hs ht]
   simp
 
 @[deprecated (since := "2024-06-29")]
@@ -140,17 +140,17 @@ lemma dirac_compProd_apply [MeasurableSingletonClass α] {a : α} [IsSFiniteKern
     (Measure.dirac a ⊗ₘ κ) s = κ a (Prod.mk a ⁻¹' s) := by
   rw [compProd_apply hs, lintegral_dirac]
 
-lemma dirac_unit_compProd (κ : kernel Unit β) [IsSFiniteKernel κ] :
+lemma dirac_unit_compProd (κ : Kernel Unit β) [IsSFiniteKernel κ] :
     Measure.dirac () ⊗ₘ κ = (κ ()).map (Prod.mk ()) := by
   ext s hs; rw [dirac_compProd_apply hs, Measure.map_apply measurable_prod_mk_left hs]
 
 lemma dirac_unit_compProd_const (μ : Measure β) [IsFiniteMeasure μ] :
-    Measure.dirac () ⊗ₘ kernel.const Unit μ = μ.map (Prod.mk ()) := by
-  rw [dirac_unit_compProd, kernel.const_apply]
+    Measure.dirac () ⊗ₘ Kernel.const Unit μ = μ.map (Prod.mk ()) := by
+  rw [dirac_unit_compProd, Kernel.const_apply]
 
 @[simp]
 lemma snd_dirac_unit_compProd_const (μ : Measure β) [IsFiniteMeasure μ] :
-    snd (Measure.dirac () ⊗ₘ kernel.const Unit μ) = μ := by
+    snd (Measure.dirac () ⊗ₘ Kernel.const Unit μ) = μ := by
   rw [dirac_unit_compProd_const, snd, map_map measurable_snd measurable_prod_mk_left]
   simp
 

--- a/Mathlib/Probability/Kernel/MeasureCompProd.lean
+++ b/Mathlib/Probability/Kernel/MeasureCompProd.lean
@@ -32,7 +32,7 @@ namespace MeasureTheory.Measure
 variable {α β : Type*} {mα : MeasurableSpace α} {mβ : MeasurableSpace β}
   {μ : Measure α} {κ η : Kernel α β}
 
-/-- The composition-product of a measure and a Kernel. -/
+/-- The composition-product of a measure and a kernel. -/
 noncomputable
 def compProd (μ : Measure α) (κ : Kernel α β) : Measure (α × β) :=
   (Kernel.const Unit μ ⊗ₖ Kernel.prodMkLeft Unit κ) ()

--- a/Mathlib/Probability/Kernel/RadonNikodym.lean
+++ b/Mathlib/Probability/Kernel/RadonNikodym.lean
@@ -10,18 +10,18 @@ import Mathlib.Probability.Kernel.WithDensity
 # Radon-Nikodym derivative and Lebesgue decomposition for kernels
 
 Let `α` and `γ` be two measurable space, where either `α` is countable or `γ` is
-countably generated. Let `κ, η : kernel α γ` be finite kernels.
-Then there exists a function `kernel.rnDeriv κ η : α → γ → ℝ≥0∞` jointly measurable on `α × γ`
-and a kernel `kernel.singularPart κ η : kernel α γ` such that
-* `κ = kernel.withDensity η (kernel.rnDeriv κ η) + kernel.singularPart κ η`,
-* for all `a : α`, `kernel.singularPart κ η a ⟂ₘ η a`,
-* for all `a : α`, `kernel.singularPart κ η a = 0 ↔ κ a ≪ η a`,
-* for all `a : α`, `kernel.withDensity η (kernel.rnDeriv κ η) a = 0 ↔ κ a ⟂ₘ η a`.
+countably generated. Let `κ, η : Kernel α γ` be finite kernels.
+Then there exists a function `Kernel.rnDeriv κ η : α → γ → ℝ≥0∞` jointly measurable on `α × γ`
+and a kernel `Kernel.singularPart κ η : Kernel α γ` such that
+* `κ = Kernel.withDensity η (Kernel.rnDeriv κ η) + Kernel.singularPart κ η`,
+* for all `a : α`, `Kernel.singularPart κ η a ⟂ₘ η a`,
+* for all `a : α`, `Kernel.singularPart κ η a = 0 ↔ κ a ≪ η a`,
+* for all `a : α`, `Kernel.withDensity η (Kernel.rnDeriv κ η) a = 0 ↔ κ a ⟂ₘ η a`.
 
 Furthermore, the sets `{a | κ a ≪ η a}` and `{a | κ a ⟂ₘ η a}` are measurable.
 
-When `γ` is countably generated, the construction of the derivative starts from `kernel.density`:
-for two finite kernels `κ' : kernel α (γ × β)` and `η' : kernel α γ` with `fst κ' ≤ η'`,
+When `γ` is countably generated, the construction of the derivative starts from `Kernel.density`:
+for two finite kernels `κ' : Kernel α (γ × β)` and `η' : Kernel α γ` with `fst κ' ≤ η'`,
 the function `density κ' η' : α → γ → Set β → ℝ` is jointly measurable in the first two arguments
 and satisfies that for all `a : α` and all measurable sets `s : Set β` and `A : Set γ`,
 `∫ x in A, density κ' η' a x s ∂(η' a) = (κ' a (A ×ˢ s)).toReal`.
@@ -38,23 +38,23 @@ The countably generated measurable space assumption is not needed to have a deco
 measures, but the additional difficulty with kernels is to obtain joint measurability of the
 derivative. This is why we can't simply define `rnDeriv κ η` by `a ↦ (κ a).rnDeriv (ν a)`
 everywhere unless `α` is countable (although `rnDeriv κ η` has that value almost everywhere).
-See the construction of `kernel.density` for details on how the countably generated hypothesis
+See the construction of `Kernel.density` for details on how the countably generated hypothesis
 is used.
 
 ## Main definitions
 
-* `ProbabilityTheory.kernel.rnDeriv`: a function `α → γ → ℝ≥0∞` jointly measurable on `α × γ`
-* `ProbabilityTheory.kernel.singularPart`: a `kernel α γ`
+* `ProbabilityTheory.Kernel.rnDeriv`: a function `α → γ → ℝ≥0∞` jointly measurable on `α × γ`
+* `ProbabilityTheory.Kernel.singularPart`: a `Kernel α γ`
 
 ## Main statements
 
-* `ProbabilityTheory.kernel.mutuallySingular_singularPart`: for all `a : α`,
-  `kernel.singularPart κ η a ⟂ₘ η a`
-* `ProbabilityTheory.kernel.rnDeriv_add_singularPart`:
-  `kernel.withDensity η (kernel.rnDeriv κ η) + kernel.singularPart κ η = κ`
-* `ProbabilityTheory.kernel.measurableSet_absolutelyContinuous` : the set `{a | κ a ≪ η a}`
+* `ProbabilityTheory.Kernel.mutuallySingular_singularPart`: for all `a : α`,
+  `Kernel.singularPart κ η a ⟂ₘ η a`
+* `ProbabilityTheory.Kernel.rnDeriv_add_singularPart`:
+  `Kernel.withDensity η (Kernel.rnDeriv κ η) + Kernel.singularPart κ η = κ`
+* `ProbabilityTheory.Kernel.measurableSet_absolutelyContinuous` : the set `{a | κ a ≪ η a}`
   is Measurable
-* `ProbabilityTheory.kernel.measurableSet_mutuallySingular` : the set `{a | κ a ⟂ₘ η a}`
+* `ProbabilityTheory.Kernel.measurableSet_mutuallySingular` : the set `{a | κ a ⟂ₘ η a}`
   is Measurable
 
 ## References
@@ -73,19 +73,19 @@ open MeasureTheory Set Filter
 
 open scoped NNReal ENNReal MeasureTheory Topology ProbabilityTheory
 
-namespace ProbabilityTheory.kernel
+namespace ProbabilityTheory.Kernel
 
-variable {α γ : Type*} {mα : MeasurableSpace α} {mγ : MeasurableSpace γ} {κ η : kernel α γ}
+variable {α γ : Type*} {mα : MeasurableSpace α} {mγ : MeasurableSpace γ} {κ η : Kernel α γ}
   [hαγ : MeasurableSpace.CountableOrCountablyGenerated α γ]
 
 open Classical in
-/-- Auxiliary function used to define `ProbabilityTheory.kernel.rnDeriv` and
-`ProbabilityTheory.kernel.singularPart`.
+/-- Auxiliary function used to define `ProbabilityTheory.Kernel.rnDeriv` and
+`ProbabilityTheory.Kernel.singularPart`.
 
 This has the properties we want for a Radon-Nikodym derivative only if `κ ≪ ν`. The definition of
 `rnDeriv κ η` will be built from `rnDerivAux κ (κ + η)`. -/
 noncomputable
-def rnDerivAux (κ η : kernel α γ) (a : α) (x : γ) : ℝ :=
+def rnDerivAux (κ η : Kernel α γ) (a : α) (x : γ) : ℝ :=
   if hα : Countable α then ((κ a).rnDeriv (η a) x).toReal
   else haveI := hαγ.countableOrCountablyGenerated.resolve_left hα
     density (map κ (fun a ↦ (a, ()))
@@ -109,8 +109,8 @@ lemma rnDerivAux_le_one [IsFiniteKernel η] (hκη : κ ≤ η) {a : α} :
   · have := hαγ.countableOrCountablyGenerated.resolve_left hα
     exact density_le_one ((fst_map_id_prod _ measurable_const).trans_le hκη) _ _ _
 
-lemma measurable_rnDerivAux (κ η : kernel α γ) :
-    Measurable (fun p : α × γ ↦ kernel.rnDerivAux κ η p.1 p.2) := by
+lemma measurable_rnDerivAux (κ η : Kernel α γ) :
+    Measurable (fun p : α × γ ↦ Kernel.rnDerivAux κ η p.1 p.2) := by
   simp_rw [rnDerivAux]
   split_ifs with hα
   · refine Measurable.ennreal_toReal ?_
@@ -118,20 +118,20 @@ lemma measurable_rnDerivAux (κ η : kernel α γ) :
     refine (measurable_from_prod_countable' (fun a ↦ ?_) ?_).comp measurable_swap
     · exact Measure.measurable_rnDeriv (κ a) (η a)
     · intro a a' c ha'_mem_a
-      have h_eq : ∀ κ : kernel α γ, κ a' = κ a := fun κ ↦ by
+      have h_eq : ∀ κ : Kernel α γ, κ a' = κ a := fun κ ↦ by
         ext s hs
         exact mem_of_mem_measurableAtom ha'_mem_a
-          (kernel.measurable_coe κ hs (measurableSet_singleton (κ a s))) rfl
+          (Kernel.measurable_coe κ hs (measurableSet_singleton (κ a s))) rfl
       rw [h_eq κ, h_eq η]
   · have := hαγ.countableOrCountablyGenerated.resolve_left hα
     exact measurable_density _ η MeasurableSet.univ
 
-lemma measurable_rnDerivAux_right (κ η : kernel α γ) (a : α) :
+lemma measurable_rnDerivAux_right (κ η : Kernel α γ) (a : α) :
     Measurable (fun x : γ ↦ rnDerivAux κ η a x) := by
   change Measurable ((fun p : α × γ ↦ rnDerivAux κ η p.1 p.2) ∘ (fun x ↦ (a, x)))
   exact (measurable_rnDerivAux _ _).comp measurable_prod_mk_left
 
-lemma setLIntegral_rnDerivAux (κ η : kernel α γ) [IsFiniteKernel κ] [IsFiniteKernel η]
+lemma setLIntegral_rnDerivAux (κ η : Kernel α γ) [IsFiniteKernel κ] [IsFiniteKernel η]
     (a : α) {s : Set γ} (hs : MeasurableSet s) :
     ∫⁻ x in s, ENNReal.ofReal (rnDerivAux κ (κ + η) a x) ∂(κ + η) a = κ a s := by
   have h_le : κ ≤ κ + η := le_add_of_nonneg_right bot_le
@@ -151,17 +151,17 @@ lemma setLIntegral_rnDerivAux (κ η : kernel α γ) [IsFiniteKernel κ] [IsFini
 @[deprecated (since := "2024-06-29")]
 alias set_lintegral_rnDerivAux := setLIntegral_rnDerivAux
 
-lemma withDensity_rnDerivAux (κ η : kernel α γ) [IsFiniteKernel κ] [IsFiniteKernel η] :
+lemma withDensity_rnDerivAux (κ η : Kernel α γ) [IsFiniteKernel κ] [IsFiniteKernel η] :
     withDensity (κ + η) (fun a x ↦ Real.toNNReal (rnDerivAux κ (κ + η) a x)) = κ := by
   ext a s hs
-  rw [kernel.withDensity_apply']
+  rw [Kernel.withDensity_apply']
   swap
   · exact (measurable_rnDerivAux _ _).ennreal_ofReal
   have : ∀ b, (Real.toNNReal b : ℝ≥0∞) = ENNReal.ofReal b := fun _ ↦ rfl
   simp_rw [this]
   exact setLIntegral_rnDerivAux κ η a hs
 
-lemma withDensity_one_sub_rnDerivAux (κ η : kernel α γ) [IsFiniteKernel κ] [IsFiniteKernel η] :
+lemma withDensity_one_sub_rnDerivAux (κ η : Kernel α γ) [IsFiniteKernel κ] [IsFiniteKernel η] :
     withDensity (κ + η) (fun a x ↦ Real.toNNReal (1 - rnDerivAux κ (κ + η) a x)) = η := by
   have h_le : κ ≤ κ + η := le_add_of_nonneg_right bot_le
   suffices withDensity (κ + η) (fun a x ↦ Real.toNNReal (1 - rnDerivAux κ (κ + η) a x))
@@ -173,7 +173,7 @@ lemma withDensity_one_sub_rnDerivAux (κ η : kernel α γ) [IsFiniteKernel κ] 
         = κ a s + η a s := by
       rw [this]
       simp
-    simp only [coeFn_add, Pi.add_apply, Measure.coe_add] at h
+    simp only [coe_add, Pi.add_apply, Measure.coe_add] at h
     rwa [withDensity_rnDerivAux, add_comm, ENNReal.add_right_inj (measure_ne_top _ _)] at h
   have : ∀ b, (Real.toNNReal b : ℝ≥0∞) = ENNReal.ofReal b := fun _ ↦ rfl
   simp_rw [this, ENNReal.ofReal_sub _ (rnDerivAux_nonneg h_le), ENNReal.ofReal_one]
@@ -188,33 +188,33 @@ lemma withDensity_one_sub_rnDerivAux (κ η : kernel α γ) [IsFiniteKernel κ] 
 
 /-- A set of points in `α × γ` related to the absolute continuity / mutual singularity of
 `κ` and `η`. -/
-def mutuallySingularSet (κ η : kernel α γ) : Set (α × γ) := {p | 1 ≤ rnDerivAux κ (κ + η) p.1 p.2}
+def mutuallySingularSet (κ η : Kernel α γ) : Set (α × γ) := {p | 1 ≤ rnDerivAux κ (κ + η) p.1 p.2}
 
 /-- A set of points in `α × γ` related to the absolute continuity / mutual singularity of
 `κ` and `η`. That is,
 * `withDensity η (rnDeriv κ η) a (mutuallySingularSetSlice κ η a) = 0`,
 * `singularPart κ η a (mutuallySingularSetSlice κ η a)ᶜ = 0`.
  -/
-def mutuallySingularSetSlice (κ η : kernel α γ) (a : α) : Set γ :=
+def mutuallySingularSetSlice (κ η : Kernel α γ) (a : α) : Set γ :=
   {x | 1 ≤ rnDerivAux κ (κ + η) a x}
 
-lemma mem_mutuallySingularSetSlice (κ η : kernel α γ) (a : α) (x : γ) :
+lemma mem_mutuallySingularSetSlice (κ η : Kernel α γ) (a : α) (x : γ) :
     x ∈ mutuallySingularSetSlice κ η a ↔ 1 ≤ rnDerivAux κ (κ + η) a x := by
   rw [mutuallySingularSetSlice]; rfl
 
-lemma not_mem_mutuallySingularSetSlice (κ η : kernel α γ) (a : α) (x : γ) :
+lemma not_mem_mutuallySingularSetSlice (κ η : Kernel α γ) (a : α) (x : γ) :
     x ∉ mutuallySingularSetSlice κ η a ↔ rnDerivAux κ (κ + η) a x < 1 := by
   simp [mutuallySingularSetSlice]
 
-lemma measurableSet_mutuallySingularSet (κ η : kernel α γ) :
+lemma measurableSet_mutuallySingularSet (κ η : Kernel α γ) :
     MeasurableSet (mutuallySingularSet κ η) :=
   measurable_rnDerivAux κ (κ + η) measurableSet_Ici
 
-lemma measurableSet_mutuallySingularSetSlice (κ η : kernel α γ) (a : α) :
+lemma measurableSet_mutuallySingularSetSlice (κ η : Kernel α γ) (a : α) :
     MeasurableSet (mutuallySingularSetSlice κ η a) :=
   measurable_prod_mk_left (measurableSet_mutuallySingularSet κ η)
 
-lemma measure_mutuallySingularSetSlice (κ η : kernel α γ) [IsFiniteKernel κ] [IsFiniteKernel η]
+lemma measure_mutuallySingularSetSlice (κ η : Kernel α γ) [IsFiniteKernel κ] [IsFiniteKernel η]
     (a : α) :
     η a (mutuallySingularSetSlice κ η a) = 0 := by
   have h_coe : ∀ b, (Real.toNNReal b : ℝ≥0∞) = ENNReal.ofReal b := fun _ ↦ rfl
@@ -222,7 +222,7 @@ lemma measure_mutuallySingularSetSlice (κ η : kernel α γ) [IsFiniteKernel κ
       (1 - rnDerivAux κ (κ + η) a x)) a {x | 1 ≤ rnDerivAux κ (κ + η) a x} = 0 by
     rwa [withDensity_one_sub_rnDerivAux κ η] at this
   simp_rw [h_coe]
-  rw [kernel.withDensity_apply', lintegral_eq_zero_iff, EventuallyEq, ae_restrict_iff]
+  rw [Kernel.withDensity_apply', lintegral_eq_zero_iff, EventuallyEq, ae_restrict_iff]
   rotate_left
   · exact (measurable_const.sub
       ((measurable_rnDerivAux _ _).comp measurable_prod_mk_left)).ennreal_ofReal
@@ -236,49 +236,49 @@ lemma measure_mutuallySingularSetSlice (κ η : kernel α γ) [IsFiniteKernel κ
 
 /-- Radon-Nikodym derivative of the kernel `κ` with respect to the kernel `η`. -/
 noncomputable
-irreducible_def rnDeriv (κ η : kernel α γ) (a : α) (x : γ) : ℝ≥0∞ :=
+irreducible_def rnDeriv (κ η : Kernel α γ) (a : α) (x : γ) : ℝ≥0∞ :=
   ENNReal.ofReal (rnDerivAux κ (κ + η) a x) / ENNReal.ofReal (1 - rnDerivAux κ (κ + η) a x)
 
-lemma rnDeriv_def' (κ η : kernel α γ) :
+lemma rnDeriv_def' (κ η : Kernel α γ) :
     rnDeriv κ η = fun a x ↦ ENNReal.ofReal (rnDerivAux κ (κ + η) a x)
       / ENNReal.ofReal (1 - rnDerivAux κ (κ + η) a x) := by ext; rw [rnDeriv_def]
 
-lemma measurable_rnDeriv (κ η : kernel α γ) :
+lemma measurable_rnDeriv (κ η : Kernel α γ) :
     Measurable (fun p : α × γ ↦ rnDeriv κ η p.1 p.2) := by
   simp_rw [rnDeriv_def]
   exact (measurable_rnDerivAux κ _).ennreal_ofReal.div
     (measurable_const.sub (measurable_rnDerivAux κ _)).ennreal_ofReal
 
-lemma measurable_rnDeriv_right (κ η : kernel α γ) (a : α) :
+lemma measurable_rnDeriv_right (κ η : Kernel α γ) (a : α) :
     Measurable (fun x : γ ↦ rnDeriv κ η a x) := by
   change Measurable ((fun p : α × γ ↦ rnDeriv κ η p.1 p.2) ∘ (fun x ↦ (a, x)))
   exact (measurable_rnDeriv _ _).comp measurable_prod_mk_left
 
-lemma rnDeriv_eq_top_iff (κ η : kernel α γ) (a : α) (x : γ) :
+lemma rnDeriv_eq_top_iff (κ η : Kernel α γ) (a : α) (x : γ) :
     rnDeriv κ η a x = ∞ ↔ (a, x) ∈ mutuallySingularSet κ η := by
   simp only [rnDeriv, ENNReal.div_eq_top, ne_eq, ENNReal.ofReal_eq_zero, not_le,
     tsub_le_iff_right, zero_add, ENNReal.ofReal_ne_top, not_false_eq_true, and_true, or_false,
     mutuallySingularSet, mem_setOf_eq, and_iff_right_iff_imp]
   exact fun h ↦ zero_lt_one.trans_le h
 
-lemma rnDeriv_eq_top_iff' (κ η : kernel α γ) (a : α) (x : γ) :
+lemma rnDeriv_eq_top_iff' (κ η : Kernel α γ) (a : α) (x : γ) :
     rnDeriv κ η a x = ∞ ↔ x ∈ mutuallySingularSetSlice κ η a := by
   rw [rnDeriv_eq_top_iff, mutuallySingularSet, mutuallySingularSetSlice, mem_setOf, mem_setOf]
 
 /-- Singular part of the kernel `κ` with respect to the kernel `η`. -/
 noncomputable
-irreducible_def singularPart (κ η : kernel α γ) [IsSFiniteKernel κ] [IsSFiniteKernel η] :
-    kernel α γ :=
+irreducible_def singularPart (κ η : Kernel α γ) [IsSFiniteKernel κ] [IsSFiniteKernel η] :
+    Kernel α γ :=
   withDensity (κ + η) (fun a x ↦ Real.toNNReal (rnDerivAux κ (κ + η) a x)
     - Real.toNNReal (1 - rnDerivAux κ (κ + η) a x) * rnDeriv κ η a x)
 
-lemma measurable_singularPart_fun (κ η : kernel α γ) :
+lemma measurable_singularPart_fun (κ η : Kernel α γ) :
     Measurable (fun p : α × γ ↦ Real.toNNReal (rnDerivAux κ (κ + η) p.1 p.2)
       - Real.toNNReal (1 - rnDerivAux κ (κ + η) p.1 p.2) * rnDeriv κ η p.1 p.2) :=
   (measurable_rnDerivAux _ _).ennreal_ofReal.sub
     ((measurable_const.sub (measurable_rnDerivAux _ _)).ennreal_ofReal.mul (measurable_rnDeriv _ _))
 
-lemma measurable_singularPart_fun_right (κ η : kernel α γ) (a : α) :
+lemma measurable_singularPart_fun_right (κ η : Kernel α γ) (a : α) :
     Measurable (fun x : γ ↦ Real.toNNReal (rnDerivAux κ (κ + η) a x)
       - Real.toNNReal (1 - rnDerivAux κ (κ + η) a x) * rnDeriv κ η a x) := by
   change Measurable ((Function.uncurry fun a b ↦
@@ -286,11 +286,11 @@ lemma measurable_singularPart_fun_right (κ η : kernel α γ) (a : α) :
     - ENNReal.ofReal (1 - rnDerivAux κ (κ + η) a b) * rnDeriv κ η a b) ∘ (fun b ↦ (a, b)))
   exact (measurable_singularPart_fun κ η).comp measurable_prod_mk_left
 
-lemma singularPart_compl_mutuallySingularSetSlice (κ η : kernel α γ) [IsSFiniteKernel κ]
+lemma singularPart_compl_mutuallySingularSetSlice (κ η : Kernel α γ) [IsSFiniteKernel κ]
     [IsSFiniteKernel η] (a : α) :
     singularPart κ η a (mutuallySingularSetSlice κ η a)ᶜ = 0 := by
   have h_coe : ∀ b, (Real.toNNReal b : ℝ≥0∞) = ENNReal.ofReal b := fun _ ↦ rfl
-  rw [singularPart, kernel.withDensity_apply', lintegral_eq_zero_iff, EventuallyEq,
+  rw [singularPart, Kernel.withDensity_apply', lintegral_eq_zero_iff, EventuallyEq,
     ae_restrict_iff]
   all_goals simp_rw [h_coe]
   rotate_left
@@ -317,7 +317,7 @@ lemma singularPart_of_subset_mutuallySingularSetSlice [IsFiniteKernel κ]
     (hs : s ⊆ mutuallySingularSetSlice κ η a) :
     singularPart κ η a s = κ a s := by
   have hs' : ∀ x ∈ s, 1 ≤ rnDerivAux κ (κ + η) a x := fun _ hx ↦ hs hx
-  rw [singularPart, kernel.withDensity_apply']
+  rw [singularPart, Kernel.withDensity_apply']
   swap; · exact measurable_singularPart_fun κ η
   calc
     ∫⁻ x in s, ↑(Real.toNNReal (rnDerivAux κ (κ + η) a x)) -
@@ -334,10 +334,10 @@ lemma singularPart_of_subset_mutuallySingularSetSlice [IsFiniteKernel κ]
         suffices η a s = 0 by simp [this]
         exact measure_mono_null hs (measure_mutuallySingularSetSlice κ η a)
 
-lemma withDensity_rnDeriv_mutuallySingularSetSlice (κ η : kernel α γ) [IsFiniteKernel κ]
+lemma withDensity_rnDeriv_mutuallySingularSetSlice (κ η : Kernel α γ) [IsFiniteKernel κ]
     [IsFiniteKernel η] (a : α) :
     withDensity η (rnDeriv κ η) a (mutuallySingularSetSlice κ η a) = 0 := by
-  rw [kernel.withDensity_apply']
+  rw [Kernel.withDensity_apply']
   · exact setLIntegral_measure_zero _ _ (measure_mutuallySingularSetSlice κ η a)
   · exact measurable_rnDeriv κ η
 
@@ -358,7 +358,7 @@ lemma withDensity_rnDeriv_of_subset_compl_mutuallySingularSetSlice
     rw [rnDeriv_def']
     congr
     exact (withDensity_one_sub_rnDerivAux κ η).symm
-  rw [this, ← withDensity_mul, kernel.withDensity_apply']
+  rw [this, ← withDensity_mul, Kernel.withDensity_apply']
   rotate_left
   · exact ((measurable_const.sub (measurable_rnDerivAux _ _)).ennreal_ofReal.mul
     (measurable_rnDeriv _ _))
@@ -383,7 +383,7 @@ lemma withDensity_rnDeriv_of_subset_compl_mutuallySingularSetSlice
   _ = κ a s := setLIntegral_rnDerivAux κ η a hsm
 
 /-- The singular part of `κ` with respect to `η` is mutually singular with `η`. -/
-lemma mutuallySingular_singularPart (κ η : kernel α γ) [IsFiniteKernel κ] [IsFiniteKernel η]
+lemma mutuallySingular_singularPart (κ η : Kernel α γ) [IsFiniteKernel κ] [IsFiniteKernel η]
     (a : α) :
     singularPart κ η a ⟂ₘ η a := by
   symm
@@ -393,11 +393,11 @@ lemma mutuallySingular_singularPart (κ η : kernel α γ) [IsFiniteKernel κ] [
 /-- Lebesgue decomposition of a finite kernel `κ` with respect to another one `η`.
 `κ` is the sum of an abolutely continuous part `withDensity η (rnDeriv κ η)` and a singular part
 `singularPart κ η`. -/
-lemma rnDeriv_add_singularPart (κ η : kernel α γ) [IsFiniteKernel κ] [IsFiniteKernel η] :
+lemma rnDeriv_add_singularPart (κ η : Kernel α γ) [IsFiniteKernel κ] [IsFiniteKernel η] :
     withDensity η (rnDeriv κ η) + singularPart κ η = κ := by
   ext a s hs
   rw [← inter_union_diff s (mutuallySingularSetSlice κ η a)]
-  simp only [coeFn_add, Pi.add_apply, Measure.coe_add]
+  simp only [coe_add, Pi.add_apply, Measure.coe_add]
   have hm := measurableSet_mutuallySingularSetSlice κ η a
   simp only [measure_union (Disjoint.mono inter_subset_right subset_rfl disjoint_sdiff_right)
     (hs.diff hm)]
@@ -407,7 +407,7 @@ lemma rnDeriv_add_singularPart (κ η : kernel α γ) [IsFiniteKernel κ] [IsFin
     zero_add, withDensity_rnDeriv_of_subset_compl_mutuallySingularSetSlice (hs.diff hm)
       (diff_subset_iff.mpr (by simp)), add_comm]
 
-lemma singularPart_eq_zero_iff_apply_eq_zero (κ η : kernel α γ) [IsFiniteKernel κ]
+lemma singularPart_eq_zero_iff_apply_eq_zero (κ η : Kernel α γ) [IsFiniteKernel κ]
     [IsFiniteKernel η] (a : α) :
     singularPart κ η a = 0 ↔ singularPart κ η a (mutuallySingularSetSlice κ η a) = 0 := by
   rw [← Measure.measure_univ_eq_zero]
@@ -415,7 +415,7 @@ lemma singularPart_eq_zero_iff_apply_eq_zero (κ η : kernel α γ) [IsFiniteKer
   rw [this, measure_union disjoint_compl_right (measurableSet_mutuallySingularSetSlice κ η a).compl,
     singularPart_compl_mutuallySingularSetSlice, add_zero]
 
-lemma withDensity_rnDeriv_eq_zero_iff_apply_eq_zero (κ η : kernel α γ) [IsFiniteKernel κ]
+lemma withDensity_rnDeriv_eq_zero_iff_apply_eq_zero (κ η : Kernel α γ) [IsFiniteKernel κ]
     [IsFiniteKernel η] (a : α) :
     withDensity η (rnDeriv κ η) a = 0
       ↔ withDensity η (rnDeriv κ η) a (mutuallySingularSetSlice κ η a)ᶜ = 0 := by
@@ -424,10 +424,10 @@ lemma withDensity_rnDeriv_eq_zero_iff_apply_eq_zero (κ η : kernel α γ) [IsFi
   rw [this, measure_union disjoint_compl_right (measurableSet_mutuallySingularSetSlice κ η a).compl,
     withDensity_rnDeriv_mutuallySingularSetSlice, zero_add]
 
-lemma singularPart_eq_zero_iff_absolutelyContinuous (κ η : kernel α γ)
+lemma singularPart_eq_zero_iff_absolutelyContinuous (κ η : Kernel α γ)
     [IsFiniteKernel κ] [IsFiniteKernel η] (a : α) :
     singularPart κ η a = 0 ↔ κ a ≪ η a := by
-  conv_rhs => rw [← rnDeriv_add_singularPart κ η, coeFn_add, Pi.add_apply]
+  conv_rhs => rw [← rnDeriv_add_singularPart κ η, coe_add, Pi.add_apply]
   refine ⟨fun h ↦ ?_, fun h ↦ ?_⟩
   · rw [h, add_zero]
     exact withDensity_absolutelyContinuous _ _
@@ -435,10 +435,10 @@ lemma singularPart_eq_zero_iff_absolutelyContinuous (κ η : kernel α γ)
   exact Measure.eq_zero_of_absolutelyContinuous_of_mutuallySingular h.2
     (mutuallySingular_singularPart _ _ _)
 
-lemma withDensity_rnDeriv_eq_zero_iff_mutuallySingular (κ η : kernel α γ)
+lemma withDensity_rnDeriv_eq_zero_iff_mutuallySingular (κ η : Kernel α γ)
     [IsFiniteKernel κ] [IsFiniteKernel η] (a : α) :
     withDensity η (rnDeriv κ η) a = 0 ↔ κ a ⟂ₘ η a := by
-  conv_rhs => rw [← rnDeriv_add_singularPart κ η, coeFn_add, Pi.add_apply]
+  conv_rhs => rw [← rnDeriv_add_singularPart κ η, coe_add, Pi.add_apply]
   refine ⟨fun h ↦ ?_, fun h ↦ ?_⟩
   · rw [h, zero_add]
     exact mutuallySingular_singularPart _ _ _
@@ -447,33 +447,33 @@ lemma withDensity_rnDeriv_eq_zero_iff_mutuallySingular (κ η : kernel α γ)
   exact h.1.mono_ac Measure.AbsolutelyContinuous.rfl
     (withDensity_absolutelyContinuous (κ := η) (rnDeriv κ η) a)
 
-lemma singularPart_eq_zero_iff_measure_eq_zero (κ η : kernel α γ)
+lemma singularPart_eq_zero_iff_measure_eq_zero (κ η : Kernel α γ)
     [IsFiniteKernel κ] [IsFiniteKernel η] (a : α) :
     singularPart κ η a = 0 ↔ κ a (mutuallySingularSetSlice κ η a) = 0 := by
   have h_eq_add := rnDeriv_add_singularPart κ η
   simp_rw [ext_iff, Measure.ext_iff] at h_eq_add
   specialize h_eq_add a (mutuallySingularSetSlice κ η a)
     (measurableSet_mutuallySingularSetSlice κ η a)
-  simp only [coeFn_add, Pi.add_apply, Measure.coe_add,
+  simp only [coe_add, Pi.add_apply, Measure.coe_add,
     withDensity_rnDeriv_mutuallySingularSetSlice κ η, zero_add] at h_eq_add
   rw [← h_eq_add]
   exact singularPart_eq_zero_iff_apply_eq_zero κ η a
 
-lemma withDensity_rnDeriv_eq_zero_iff_measure_eq_zero (κ η : kernel α γ)
+lemma withDensity_rnDeriv_eq_zero_iff_measure_eq_zero (κ η : Kernel α γ)
     [IsFiniteKernel κ] [IsFiniteKernel η] (a : α) :
     withDensity η (rnDeriv κ η) a = 0 ↔ κ a (mutuallySingularSetSlice κ η a)ᶜ = 0 := by
   have h_eq_add := rnDeriv_add_singularPart κ η
   simp_rw [ext_iff, Measure.ext_iff] at h_eq_add
   specialize h_eq_add a (mutuallySingularSetSlice κ η a)ᶜ
     (measurableSet_mutuallySingularSetSlice κ η a).compl
-  simp only [coeFn_add, Pi.add_apply, Measure.coe_add,
+  simp only [coe_add, Pi.add_apply, Measure.coe_add,
     singularPart_compl_mutuallySingularSetSlice κ η, add_zero] at h_eq_add
   rw [← h_eq_add]
   exact withDensity_rnDeriv_eq_zero_iff_apply_eq_zero κ η a
 
 /-- The set of points `a : α` such that `κ a ≪ η a` is measurable. -/
 @[measurability]
-lemma measurableSet_absolutelyContinuous (κ η : kernel α γ) [IsFiniteKernel κ] [IsFiniteKernel η] :
+lemma measurableSet_absolutelyContinuous (κ η : Kernel α γ) [IsFiniteKernel κ] [IsFiniteKernel η] :
     MeasurableSet {a | κ a ≪ η a} := by
   simp_rw [← singularPart_eq_zero_iff_absolutelyContinuous,
     singularPart_eq_zero_iff_measure_eq_zero]
@@ -482,11 +482,11 @@ lemma measurableSet_absolutelyContinuous (κ η : kernel α γ) [IsFiniteKernel 
 
 /-- The set of points `a : α` such that `κ a ⟂ₘ η a` is measurable. -/
 @[measurability]
-lemma measurableSet_mutuallySingular (κ η : kernel α γ) [IsFiniteKernel κ] [IsFiniteKernel η] :
+lemma measurableSet_mutuallySingular (κ η : Kernel α γ) [IsFiniteKernel κ] [IsFiniteKernel η] :
     MeasurableSet {a | κ a ⟂ₘ η a} := by
   simp_rw [← withDensity_rnDeriv_eq_zero_iff_mutuallySingular,
     withDensity_rnDeriv_eq_zero_iff_measure_eq_zero]
   exact measurable_kernel_prod_mk_left (measurableSet_mutuallySingularSet κ η).compl
     (measurableSet_singleton 0)
 
-end ProbabilityTheory.kernel
+end ProbabilityTheory.Kernel

--- a/Mathlib/Probability/Kernel/WithDensity.lean
+++ b/Mathlib/Probability/Kernel/WithDensity.lean
@@ -11,7 +11,7 @@ import Mathlib.MeasureTheory.Integral.SetIntegral
 
 For an s-finite kernel `κ : Kernel α β` and a function `f : α → β → ℝ≥0∞` which is finite
 everywhere, we define `withDensity κ f` as the kernel `a ↦ (κ a).withDensity (f a)`. This is
-an s-finite Kernel.
+an s-finite kernel.
 
 ## Main definitions
 

--- a/Mathlib/Probability/Kernel/WithDensity.lean
+++ b/Mathlib/Probability/Kernel/WithDensity.lean
@@ -9,21 +9,21 @@ import Mathlib.MeasureTheory.Integral.SetIntegral
 /-!
 # With Density
 
-For an s-finite kernel `κ : kernel α β` and a function `f : α → β → ℝ≥0∞` which is finite
+For an s-finite kernel `κ : Kernel α β` and a function `f : α → β → ℝ≥0∞` which is finite
 everywhere, we define `withDensity κ f` as the kernel `a ↦ (κ a).withDensity (f a)`. This is
-an s-finite kernel.
+an s-finite Kernel.
 
 ## Main definitions
 
-* `ProbabilityTheory.kernel.withDensity κ (f : α → β → ℝ≥0∞)`:
+* `ProbabilityTheory.Kernel.withDensity κ (f : α → β → ℝ≥0∞)`:
   kernel `a ↦ (κ a).withDensity (f a)`. It is defined if `κ` is s-finite. If `f` is finite
-  everywhere, then this is also an s-finite kernel. The class of s-finite kernels is the smallest
+  everywhere, then this is also an s-finite Kernel. The class of s-finite kernels is the smallest
   class of kernels that contains finite kernels and which is stable by `withDensity`.
   Integral: `∫⁻ b, g b ∂(withDensity κ f a) = ∫⁻ b, f a b * g b ∂(κ a)`
 
 ## Main statements
 
-* `ProbabilityTheory.kernel.lintegral_withDensity`:
+* `ProbabilityTheory.Kernel.lintegral_withDensity`:
   `∫⁻ b, g b ∂(withDensity κ f a) = ∫⁻ b, f a b * g b ∂(κ a)`
 
 -/
@@ -33,76 +33,76 @@ open MeasureTheory ProbabilityTheory
 
 open scoped MeasureTheory ENNReal NNReal
 
-namespace ProbabilityTheory.kernel
+namespace ProbabilityTheory.Kernel
 
 variable {α β ι : Type*} {mα : MeasurableSpace α} {mβ : MeasurableSpace β}
-variable {κ : kernel α β} {f : α → β → ℝ≥0∞}
+variable {κ : Kernel α β} {f : α → β → ℝ≥0∞}
 
 /-- Kernel with image `(κ a).withDensity (f a)` if `Function.uncurry f` is measurable, and
 with image 0 otherwise. If `Function.uncurry f` is measurable, it satisfies
 `∫⁻ b, g b ∂(withDensity κ f hf a) = ∫⁻ b, f a b * g b ∂(κ a)`. -/
-noncomputable def withDensity (κ : kernel α β) [IsSFiniteKernel κ] (f : α → β → ℝ≥0∞) :
-    kernel α β :=
+noncomputable def withDensity (κ : Kernel α β) [IsSFiniteKernel κ] (f : α → β → ℝ≥0∞) :
+    Kernel α β :=
   @dite _ (Measurable (Function.uncurry f)) (Classical.dec _) (fun hf =>
     (⟨fun a => (κ a).withDensity (f a),
       by
         refine Measure.measurable_of_measurable_coe _ fun s hs => ?_
         simp_rw [withDensity_apply _ hs]
-        exact hf.setLIntegral_kernel_prod_right hs⟩ : kernel α β)) fun _ => 0
+        exact hf.setLIntegral_kernel_prod_right hs⟩ : Kernel α β)) fun _ => 0
 
-theorem withDensity_of_not_measurable (κ : kernel α β) [IsSFiniteKernel κ]
+theorem withDensity_of_not_measurable (κ : Kernel α β) [IsSFiniteKernel κ]
     (hf : ¬Measurable (Function.uncurry f)) : withDensity κ f = 0 := by classical exact dif_neg hf
 
-protected theorem withDensity_apply (κ : kernel α β) [IsSFiniteKernel κ]
+protected theorem withDensity_apply (κ : Kernel α β) [IsSFiniteKernel κ]
     (hf : Measurable (Function.uncurry f)) (a : α) :
     withDensity κ f a = (κ a).withDensity (f a) := by
   classical
   rw [withDensity, dif_pos hf]
   rfl
 
-protected theorem withDensity_apply' (κ : kernel α β) [IsSFiniteKernel κ]
+protected theorem withDensity_apply' (κ : Kernel α β) [IsSFiniteKernel κ]
     (hf : Measurable (Function.uncurry f)) (a : α) (s : Set β) :
     withDensity κ f a s = ∫⁻ b in s, f a b ∂κ a := by
-  rw [kernel.withDensity_apply κ hf, withDensity_apply' _ s]
+  rw [Kernel.withDensity_apply κ hf, withDensity_apply' _ s]
 
-nonrec lemma withDensity_congr_ae (κ : kernel α β) [IsSFiniteKernel κ] {f g : α → β → ℝ≥0∞}
+nonrec lemma withDensity_congr_ae (κ : Kernel α β) [IsSFiniteKernel κ] {f g : α → β → ℝ≥0∞}
     (hf : Measurable (Function.uncurry f)) (hg : Measurable (Function.uncurry g))
     (hfg : ∀ a, f a =ᵐ[κ a] g a) :
     withDensity κ f = withDensity κ g := by
   ext a
-  rw [kernel.withDensity_apply _ hf,kernel.withDensity_apply _ hg, withDensity_congr_ae (hfg a)]
+  rw [Kernel.withDensity_apply _ hf,Kernel.withDensity_apply _ hg, withDensity_congr_ae (hfg a)]
 
 nonrec lemma withDensity_absolutelyContinuous [IsSFiniteKernel κ]
     (f : α → β → ℝ≥0∞) (a : α) :
-    kernel.withDensity κ f a ≪ κ a := by
+    Kernel.withDensity κ f a ≪ κ a := by
   by_cases hf : Measurable (Function.uncurry f)
-  · rw [kernel.withDensity_apply _ hf]
+  · rw [Kernel.withDensity_apply _ hf]
     exact withDensity_absolutelyContinuous _ _
   · rw [withDensity_of_not_measurable _ hf]
     simp [Measure.AbsolutelyContinuous.zero]
 
 @[simp]
-lemma withDensity_one (κ : kernel α β) [IsSFiniteKernel κ] :
-    kernel.withDensity κ 1 = κ := by
-  ext; rw [kernel.withDensity_apply _ measurable_const]; simp
+lemma withDensity_one (κ : Kernel α β) [IsSFiniteKernel κ] :
+    Kernel.withDensity κ 1 = κ := by
+  ext; rw [Kernel.withDensity_apply _ measurable_const]; simp
 
 @[simp]
-lemma withDensity_one' (κ : kernel α β) [IsSFiniteKernel κ] :
-    kernel.withDensity κ (fun _ _ ↦ 1) = κ := kernel.withDensity_one _
+lemma withDensity_one' (κ : Kernel α β) [IsSFiniteKernel κ] :
+    Kernel.withDensity κ (fun _ _ ↦ 1) = κ := Kernel.withDensity_one _
 
 @[simp]
-lemma withDensity_zero (κ : kernel α β) [IsSFiniteKernel κ] :
-    kernel.withDensity κ 0 = 0 := by
-  ext; rw [kernel.withDensity_apply _ measurable_const]; simp
+lemma withDensity_zero (κ : Kernel α β) [IsSFiniteKernel κ] :
+    Kernel.withDensity κ 0 = 0 := by
+  ext; rw [Kernel.withDensity_apply _ measurable_const]; simp
 
 @[simp]
-lemma withDensity_zero' (κ : kernel α β) [IsSFiniteKernel κ] :
-    kernel.withDensity κ (fun _ _ ↦ 0) = 0 := kernel.withDensity_zero _
+lemma withDensity_zero' (κ : Kernel α β) [IsSFiniteKernel κ] :
+    Kernel.withDensity κ (fun _ _ ↦ 0) = 0 := Kernel.withDensity_zero _
 
-theorem lintegral_withDensity (κ : kernel α β) [IsSFiniteKernel κ]
+theorem lintegral_withDensity (κ : Kernel α β) [IsSFiniteKernel κ]
     (hf : Measurable (Function.uncurry f)) (a : α) {g : β → ℝ≥0∞} (hg : Measurable g) :
     ∫⁻ b, g b ∂withDensity κ f a = ∫⁻ b, f a b * g b ∂κ a := by
-  rw [kernel.withDensity_apply _ hf,
+  rw [Kernel.withDensity_apply _ hf,
     lintegral_withDensity_eq_lintegral_mul _ (Measurable.of_uncurry_left hf) hg]
   simp_rw [Pi.mul_apply]
 
@@ -110,26 +110,26 @@ theorem integral_withDensity {E : Type*} [NormedAddCommGroup E] [NormedSpace ℝ
     {f : β → E} [IsSFiniteKernel κ] {a : α} {g : α → β → ℝ≥0}
     (hg : Measurable (Function.uncurry g)) :
     ∫ b, f b ∂withDensity κ (fun a b => g a b) a = ∫ b, g a b • f b ∂κ a := by
-  rw [kernel.withDensity_apply, integral_withDensity_eq_integral_smul]
+  rw [Kernel.withDensity_apply, integral_withDensity_eq_integral_smul]
   · exact Measurable.of_uncurry_left hg
   · exact measurable_coe_nnreal_ennreal.comp hg
 
-theorem withDensity_add_left (κ η : kernel α β) [IsSFiniteKernel κ] [IsSFiniteKernel η]
+theorem withDensity_add_left (κ η : Kernel α β) [IsSFiniteKernel κ] [IsSFiniteKernel η]
     (f : α → β → ℝ≥0∞) : withDensity (κ + η) f = withDensity κ f + withDensity η f := by
   by_cases hf : Measurable (Function.uncurry f)
   · ext a s
-    simp only [kernel.withDensity_apply _ hf, coeFn_add, Pi.add_apply, withDensity_add_measure,
+    simp only [Kernel.withDensity_apply _ hf, coe_add, Pi.add_apply, withDensity_add_measure,
       Measure.add_apply]
   · simp_rw [withDensity_of_not_measurable _ hf]
     rw [zero_add]
 
-theorem withDensity_kernel_sum [Countable ι] (κ : ι → kernel α β) (hκ : ∀ i, IsSFiniteKernel (κ i))
+theorem withDensity_kernel_sum [Countable ι] (κ : ι → Kernel α β) (hκ : ∀ i, IsSFiniteKernel (κ i))
     (f : α → β → ℝ≥0∞) :
-    @withDensity _ _ _ _ (kernel.sum κ) (isSFiniteKernel_sum hκ) f =
-      kernel.sum fun i => withDensity (κ i) f := by
+    @withDensity _ _ _ _ (Kernel.sum κ) (isSFiniteKernel_sum hκ) f =
+      Kernel.sum fun i => withDensity (κ i) f := by
   by_cases hf : Measurable (Function.uncurry f)
   · ext1 a
-    simp_rw [sum_apply, kernel.withDensity_apply _ hf, sum_apply,
+    simp_rw [sum_apply, Kernel.withDensity_apply _ hf, sum_apply,
       withDensity_sum (fun n => κ n a) (f a)]
   · simp_rw [withDensity_of_not_measurable _ hf]
     exact sum_zero.symm
@@ -138,8 +138,8 @@ lemma withDensity_add_right [IsSFiniteKernel κ] {f g : α → β → ℝ≥0∞
     (hf : Measurable (Function.uncurry f)) (hg : Measurable (Function.uncurry g)) :
     withDensity κ (f + g) = withDensity κ f + withDensity κ g := by
   ext a
-  rw [coeFn_add, Pi.add_apply, kernel.withDensity_apply _ hf, kernel.withDensity_apply _ hg,
-    kernel.withDensity_apply, Pi.add_apply, MeasureTheory.withDensity_add_right]
+  rw [coe_add, Pi.add_apply, Kernel.withDensity_apply _ hf, Kernel.withDensity_apply _ hg,
+    Kernel.withDensity_apply, Pi.add_apply, MeasureTheory.withDensity_add_right]
   · exact hg.comp measurable_prod_mk_left
   · exact hf.add hg
 
@@ -153,13 +153,13 @@ lemma withDensity_sub_add_cancel [IsSFiniteKernel κ] {f g : α → β → ℝ�
   filter_upwards [hfg a] with x hx
   rwa [Pi.add_apply, Pi.add_apply, tsub_add_cancel_iff_le]
 
-theorem withDensity_tsum [Countable ι] (κ : kernel α β) [IsSFiniteKernel κ] {f : ι → α → β → ℝ≥0∞}
+theorem withDensity_tsum [Countable ι] (κ : Kernel α β) [IsSFiniteKernel κ] {f : ι → α → β → ℝ≥0∞}
     (hf : ∀ i, Measurable (Function.uncurry (f i))) :
-    withDensity κ (∑' n, f n) = kernel.sum fun n => withDensity κ (f n) := by
+    withDensity κ (∑' n, f n) = Kernel.sum fun n => withDensity κ (f n) := by
   have h_sum_a : ∀ a, Summable fun n => f n a := fun a => Pi.summable.mpr fun b => ENNReal.summable
   have h_sum : Summable fun n => f n := Pi.summable.mpr h_sum_a
   ext a s hs
-  rw [sum_apply' _ a hs, kernel.withDensity_apply' κ _ a s]
+  rw [sum_apply' _ a hs, Kernel.withDensity_apply' κ _ a s]
   swap
   · have : Function.uncurry (∑' n, f n) = ∑' n, Function.uncurry (f n) := by
       ext1 p
@@ -173,16 +173,16 @@ theorem withDensity_tsum [Countable ι] (κ : kernel α β) [IsSFiniteKernel κ]
     rw [tsum_apply h_sum, tsum_apply (h_sum_a a)]
   rw [this, lintegral_tsum fun n => (Measurable.of_uncurry_left (hf n)).aemeasurable]
   congr with n
-  rw [kernel.withDensity_apply' _ (hf n) a s]
+  rw [Kernel.withDensity_apply' _ (hf n) a s]
 
 /-- If a kernel `κ` is finite and a function `f : α → β → ℝ≥0∞` is bounded, then `withDensity κ f`
 is finite. -/
-theorem isFiniteKernel_withDensity_of_bounded (κ : kernel α β) [IsFiniteKernel κ] {B : ℝ≥0∞}
+theorem isFiniteKernel_withDensity_of_bounded (κ : Kernel α β) [IsFiniteKernel κ] {B : ℝ≥0∞}
     (hB_top : B ≠ ∞) (hf_B : ∀ a b, f a b ≤ B) : IsFiniteKernel (withDensity κ f) := by
   by_cases hf : Measurable (Function.uncurry f)
   · exact ⟨⟨B * IsFiniteKernel.bound κ, ENNReal.mul_lt_top hB_top (IsFiniteKernel.bound_ne_top κ),
       fun a => by
-        rw [kernel.withDensity_apply' κ hf a Set.univ]
+        rw [Kernel.withDensity_apply' κ hf a Set.univ]
         calc
           ∫⁻ b in Set.univ, f a b ∂κ a ≤ ∫⁻ _ in Set.univ, B ∂κ a := lintegral_mono (hf_B a)
           _ = B * κ a Set.univ := by
@@ -193,7 +193,7 @@ theorem isFiniteKernel_withDensity_of_bounded (κ : kernel α β) [IsFiniteKerne
 
 /-- Auxiliary lemma for `IsSFiniteKernel.withDensity`.
 If a kernel `κ` is finite, then `withDensity κ f` is s-finite. -/
-theorem isSFiniteKernel_withDensity_of_isFiniteKernel (κ : kernel α β) [IsFiniteKernel κ]
+theorem isSFiniteKernel_withDensity_of_isFiniteKernel (κ : Kernel α β) [IsFiniteKernel κ]
     (hf_ne_top : ∀ a b, f a b ≠ ∞) : IsSFiniteKernel (withDensity κ f) := by
   -- We already have that for `f` bounded from above and a `κ` a finite kernel,
   -- `withDensity κ f` is finite. We write any function as a countable sum of bounded
@@ -253,9 +253,9 @@ theorem isSFiniteKernel_withDensity_of_isFiniteKernel (κ : kernel α β) [IsFin
 
 /-- For an s-finite kernel `κ` and a function `f : α → β → ℝ≥0∞` which is everywhere finite,
 `withDensity κ f` is s-finite. -/
-nonrec theorem IsSFiniteKernel.withDensity (κ : kernel α β) [IsSFiniteKernel κ]
+nonrec theorem IsSFiniteKernel.withDensity (κ : Kernel α β) [IsSFiniteKernel κ]
     (hf_ne_top : ∀ a b, f a b ≠ ∞) : IsSFiniteKernel (withDensity κ f) := by
-  have h_eq_sum : withDensity κ f = kernel.sum fun i => withDensity (seq κ i) f := by
+  have h_eq_sum : withDensity κ f = Kernel.sum fun i => withDensity (seq κ i) f := by
     rw [← withDensity_kernel_sum _ _]
     congr
     exact (kernel_sum_seq κ).symm
@@ -264,7 +264,7 @@ nonrec theorem IsSFiniteKernel.withDensity (κ : kernel α β) [IsSFiniteKernel 
     isSFiniteKernel_withDensity_of_isFiniteKernel (seq κ n) hf_ne_top
 
 /-- For an s-finite kernel `κ` and a function `f : α → β → ℝ≥0`, `withDensity κ f` is s-finite. -/
-instance (κ : kernel α β) [IsSFiniteKernel κ] (f : α → β → ℝ≥0) :
+instance (κ : Kernel α β) [IsSFiniteKernel κ] (f : α → β → ℝ≥0) :
     IsSFiniteKernel (withDensity κ fun a b => f a b) :=
   IsSFiniteKernel.withDensity κ fun _ _ => ENNReal.coe_ne_top
 
@@ -273,15 +273,15 @@ nonrec lemma withDensity_mul [IsSFiniteKernel κ] {f : α → β → ℝ≥0} {g
     withDensity κ (fun a x ↦ f a x * g a x)
       = withDensity (withDensity κ fun a x ↦ f a x) g := by
   ext a : 1
-  rw [kernel.withDensity_apply]
+  rw [Kernel.withDensity_apply]
   swap; · exact (measurable_coe_nnreal_ennreal.comp hf).mul hg
   change (Measure.withDensity (κ a) ((fun x ↦ (f a x : ℝ≥0∞)) * (fun x ↦ (g a x : ℝ≥0∞)))) =
       (withDensity (withDensity κ fun a x ↦ f a x) g) a
   rw [withDensity_mul]
-  · rw [kernel.withDensity_apply _ hg, kernel.withDensity_apply]
+  · rw [Kernel.withDensity_apply _ hg, Kernel.withDensity_apply]
     exact measurable_coe_nnreal_ennreal.comp hf
   · rw [measurable_coe_nnreal_ennreal_iff]
     exact hf.comp measurable_prod_mk_left
   · exact hg.comp measurable_prod_mk_left
 
-end ProbabilityTheory.kernel
+end ProbabilityTheory.Kernel

--- a/Mathlib/Probability/Kernel/WithDensity.lean
+++ b/Mathlib/Probability/Kernel/WithDensity.lean
@@ -17,7 +17,7 @@ an s-finite Kernel.
 
 * `ProbabilityTheory.Kernel.withDensity κ (f : α → β → ℝ≥0∞)`:
   kernel `a ↦ (κ a).withDensity (f a)`. It is defined if `κ` is s-finite. If `f` is finite
-  everywhere, then this is also an s-finite Kernel. The class of s-finite kernels is the smallest
+  everywhere, then this is also an s-finite kernel. The class of s-finite kernels is the smallest
   class of kernels that contains finite kernels and which is stable by `withDensity`.
   Integral: `∫⁻ b, g b ∂(withDensity κ f a) = ∫⁻ b, f a b * g b ∂(κ a)`
 


### PR DESCRIPTION
Turn `kernel : AddSubmonoid (α → MeasureTheory.Measure β)` into `Kernel : Type _`. This is similar to #12386 but here to gain access to dot notation rather than for performance reasons.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->
A later PR will rename the predicates like `IsMarkovKernel`, `IsFiniteKernel`... to use dot notation.

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
