### PR TITLE
[Merged by Bors] - Feat(RingTheory/Flat): add localization of flat module is flat

### DIFF
--- a/Mathlib/RingTheory/Flat/Stability.lean
+++ b/Mathlib/RingTheory/Flat/Stability.lean
@@ -156,7 +156,7 @@ variable {R : Type u} {M Mp : Type*} (Rp : Type v)
 
 instance localizedModule [Module.Flat R M] (S : Submonoid R) : Module.Flat (Localization S)
     (LocalizedModule S M) := by
-  fapply Module.Flat.isBaseChange (R:=R) (M:=M) (S:=Localization S)
+  fapply Module.Flat.isBaseChange (R := R) (M := M) (S := Localization S)
   exact LocalizedModule.mkLinearMap S M
   rw [← isLocalizedModule_iff_isBaseChange S]
   exact localizedModuleIsLocalizedModule S

--- a/Mathlib/RingTheory/Flat/Stability.lean
+++ b/Mathlib/RingTheory/Flat/Stability.lean
@@ -150,7 +150,7 @@ end BaseChange
 
 section Localization
 
-variable (R : Type u) (S : Type v) (M Mp: Type w) (Rp : Type v)
+variable {R : Type u} {M Mp : Type*} (Rp : Type v)
   [CommRing R] [AddCommGroup M] [Module R M]  [CommRing Rp] [Module R M] [Algebra R Rp]
   [AddCommGroup Mp] [Module R Mp] [Module Rp Mp] [IsScalarTower R Rp Mp] (f : M →ₗ[R] Mp)
 

--- a/Mathlib/RingTheory/Flat/Stability.lean
+++ b/Mathlib/RingTheory/Flat/Stability.lean
@@ -154,7 +154,7 @@ variable (R : Type u) (S : Type v) (M Mp: Type w) (Rp : Type v)
   [CommRing R] [AddCommGroup M] [Module R M]  [CommRing Rp] [Module R M] [Algebra R Rp]
   [AddCommGroup Mp] [Module R Mp] [Module Rp Mp] [IsScalarTower R Rp Mp] (f : M →ₗ[R] Mp)
 
-theorem isLocalizedModule_ofFlat [Module.Flat R M] (S : Submonoid R) : Module.Flat (Localization S)
+instance localizedModule [Module.Flat R M] (S : Submonoid R) : Module.Flat (Localization S)
     (LocalizedModule S M) := by
   fapply Module.Flat.isBaseChange (R:=R) (M:=M) (S:=Localization S)
   exact LocalizedModule.mkLinearMap S M

--- a/Mathlib/RingTheory/Flat/Stability.lean
+++ b/Mathlib/RingTheory/Flat/Stability.lean
@@ -21,7 +21,8 @@ We show that flatness is stable under composition and base change.
 * `Module.Flat.baseChange`: if `M` is a flat `R`-module and `S` is any `R`-algebra,
                             then `S ⊗[R] M` is `S`-flat.
 * `Module.Flat.of_isLocalizedModule`: if `M` is a flat `R`-module and `S` is a submonoid of `R`
-                                          then the localization of `M` at `S` is flat.
+                                          then the localization of `M` at `S` is flat as a module
+                                          for the localzation of `R` at `S`.
 -/
 
 universe u v w t
@@ -151,7 +152,7 @@ end BaseChange
 section Localization
 
 variable {R : Type u} {M Mp : Type*} (Rp : Type v)
-  [CommRing R] [AddCommGroup M] [Module R M] [CommRing Rp] [Module R M] [Algebra R Rp]
+  [CommRing R] [AddCommGroup M] [Module R M] [CommRing Rp] [Algebra R Rp]
   [AddCommGroup Mp] [Module R Mp] [Module Rp Mp] [IsScalarTower R Rp Mp] (f : M →ₗ[R] Mp)
 
 instance localizedModule [Module.Flat R M] (S : Submonoid R) : Module.Flat (Localization S)
@@ -163,7 +164,7 @@ instance localizedModule [Module.Flat R M] (S : Submonoid R) : Module.Flat (Loca
 
 theorem of_isLocalizedModule [Module.Flat R M] (S : Submonoid R) [IsLocalization S Rp]
     (f : M →ₗ[R] Mp) [h : IsLocalizedModule S f] : Module.Flat Rp Mp := by
-  fapply Module.Flat.isBaseChange (R:=R) (M:=M) (S:=Rp) (N:=Mp)
+  fapply Module.Flat.isBaseChange (R := R) (M := M) (S := Rp) (N := Mp)
   exact (isLocalizedModule_iff_isBaseChange S Rp f).mp h
 
 end Localization

--- a/Mathlib/RingTheory/Flat/Stability.lean
+++ b/Mathlib/RingTheory/Flat/Stability.lean
@@ -6,6 +6,7 @@ Authors: Christian Merten
 import Mathlib.RingTheory.Flat.Basic
 import Mathlib.RingTheory.IsTensorProduct
 import Mathlib.LinearAlgebra.TensorProduct.Tower
+import Mathlib.RingTheory.Localization.BaseChange
 
 /-!
 # Flatness is stable under composition and base change
@@ -144,5 +145,20 @@ theorem isBaseChange [Module.Flat R M] (N : Type t) [AddCommGroup N] [Module R N
   of_linearEquiv S (S ⊗[R] M) N (IsBaseChange.equiv h).symm
 
 end BaseChange
+
+section Localization
+
+variable (R : Type u) (S : Type v) (M : Type w)
+  [CommRing R] [CommRing S] [Algebra R S]
+  [AddCommGroup M] [Module R M]
+
+theorem isLocalizedModule_ofFlat [Module.Flat R M] (S : Submonoid R) : Module.Flat (Localization S)
+ (LocalizedModule S M) := by
+  fapply Module.Flat.isBaseChange (R:=R) (M:=M) (S:=Localization S)
+  exact LocalizedModule.mkLinearMap S M
+  rw [← isLocalizedModule_iff_isBaseChange S]
+  exact localizedModuleIsLocalizedModule S
+
+end Localization
 
 end Module.Flat

--- a/Mathlib/RingTheory/Flat/Stability.lean
+++ b/Mathlib/RingTheory/Flat/Stability.lean
@@ -161,7 +161,7 @@ instance localizedModule [Module.Flat R M] (S : Submonoid R) : Module.Flat (Loca
   rw [← isLocalizedModule_iff_isBaseChange S]
   exact localizedModuleIsLocalizedModule S
 
-theorem IsLocalizedModule_ofFlat [Module.Flat R M] (S : Submonoid R) [IsLocalization S Rp]
+theorem of_isLocalizedModule [Module.Flat R M] (S : Submonoid R) [IsLocalization S Rp]
     (f : M →ₗ[R] Mp) (h: IsLocalizedModule S f): Module.Flat Rp Mp := by
   fapply Module.Flat.isBaseChange (R:=R) (M:=M) (S:=Rp) (N:=Mp)
   exact (isLocalizedModule_iff_isBaseChange S Rp f).mp h

--- a/Mathlib/RingTheory/Flat/Stability.lean
+++ b/Mathlib/RingTheory/Flat/Stability.lean
@@ -151,7 +151,7 @@ end BaseChange
 section Localization
 
 variable {R : Type u} {M Mp : Type*} (Rp : Type v)
-  [CommRing R] [AddCommGroup M] [Module R M]  [CommRing Rp] [Module R M] [Algebra R Rp]
+  [CommRing R] [AddCommGroup M] [Module R M] [CommRing Rp] [Module R M] [Algebra R Rp]
   [AddCommGroup Mp] [Module R Mp] [Module Rp Mp] [IsScalarTower R Rp Mp] (f : M →ₗ[R] Mp)
 
 instance localizedModule [Module.Flat R M] (S : Submonoid R) : Module.Flat (Localization S)

--- a/Mathlib/RingTheory/Flat/Stability.lean
+++ b/Mathlib/RingTheory/Flat/Stability.lean
@@ -20,7 +20,7 @@ We show that flatness is stable under composition and base change.
                       then `M` is a flat `R`-module
 * `Module.Flat.baseChange`: if `M` is a flat `R`-module and `S` is any `R`-algebra,
                             then `S ⊗[R] M` is `S`-flat.
-* `Module.Flat.isLocalizedModule_ofFlat`: if `M` is a flat `R`-module and `S` is a submonoid of `R`
+* `Module.Flat.of_isLocalizedModule`: if `M` is a flat `R`-module and `S` is a submonoid of `R`
                                           then the localization of `M` at `S` is flat.
 -/
 

--- a/Mathlib/RingTheory/Flat/Stability.lean
+++ b/Mathlib/RingTheory/Flat/Stability.lean
@@ -154,7 +154,7 @@ variable (R : Type u) (S : Type v) (M : Type w)
   [AddCommGroup M] [Module R M]
 
 theorem isLocalizedModule_ofFlat [Module.Flat R M] (S : Submonoid R) : Module.Flat (Localization S)
- (LocalizedModule S M) := by
+  (LocalizedModule S M) := by
   fapply Module.Flat.isBaseChange (R:=R) (M:=M) (S:=Localization S)
   exact LocalizedModule.mkLinearMap S M
   rw [← isLocalizedModule_iff_isBaseChange S]

--- a/Mathlib/RingTheory/Flat/Stability.lean
+++ b/Mathlib/RingTheory/Flat/Stability.lean
@@ -154,7 +154,7 @@ variable (R : Type u) (S : Type v) (M : Type w)
   [AddCommGroup M] [Module R M]
 
 theorem isLocalizedModule_ofFlat [Module.Flat R M] (S : Submonoid R) : Module.Flat (Localization S)
-  (LocalizedModule S M) := by
+    (LocalizedModule S M) := by
   fapply Module.Flat.isBaseChange (R:=R) (M:=M) (S:=Localization S)
   exact LocalizedModule.mkLinearMap S M
   rw [← isLocalizedModule_iff_isBaseChange S]

--- a/Mathlib/RingTheory/Flat/Stability.lean
+++ b/Mathlib/RingTheory/Flat/Stability.lean
@@ -162,7 +162,7 @@ instance localizedModule [Module.Flat R M] (S : Submonoid R) : Module.Flat (Loca
   exact localizedModuleIsLocalizedModule S
 
 theorem of_isLocalizedModule [Module.Flat R M] (S : Submonoid R) [IsLocalization S Rp]
-    (f : M →ₗ[R] Mp) (h: IsLocalizedModule S f): Module.Flat Rp Mp := by
+    (f : M →ₗ[R] Mp) [h : IsLocalizedModule S f] : Module.Flat Rp Mp := by
   fapply Module.Flat.isBaseChange (R:=R) (M:=M) (S:=Rp) (N:=Mp)
   exact (isLocalizedModule_iff_isBaseChange S Rp f).mp h
 

--- a/Mathlib/RingTheory/Flat/Stability.lean
+++ b/Mathlib/RingTheory/Flat/Stability.lean
@@ -19,7 +19,8 @@ We show that flatness is stable under composition and base change.
                       then `M` is a flat `R`-module
 * `Module.Flat.baseChange`: if `M` is a flat `R`-module and `S` is any `R`-algebra,
                             then `S ⊗[R] M` is `S`-flat.
-
+* `Module.Flat.isLocalizedModule_ofFlat`: if `M` is a flat `R`-module and `S` is a submonoid of `R`
+                                          then the localization of `M` at `S` is flat.
 -/
 
 universe u v w t

--- a/Mathlib/RingTheory/Flat/Stability.lean
+++ b/Mathlib/RingTheory/Flat/Stability.lean
@@ -7,6 +7,7 @@ import Mathlib.RingTheory.Flat.Basic
 import Mathlib.RingTheory.IsTensorProduct
 import Mathlib.LinearAlgebra.TensorProduct.Tower
 import Mathlib.RingTheory.Localization.BaseChange
+import Mathlib.Algebra.Module.LocalizedModule
 
 /-!
 # Flatness is stable under composition and base change
@@ -149,9 +150,9 @@ end BaseChange
 
 section Localization
 
-variable (R : Type u) (S : Type v) (M : Type w)
-  [CommRing R] [CommRing S] [Algebra R S]
-  [AddCommGroup M] [Module R M]
+variable (R : Type u) (S : Type v) (M Mp: Type w) (Rp : Type v)
+  [CommRing R] [AddCommGroup M] [Module R M]  [CommRing Rp] [Module R M] [Algebra R Rp]
+  [AddCommGroup Mp] [Module R Mp] [Module Rp Mp] [IsScalarTower R Rp Mp] (f : M →ₗ[R] Mp)
 
 theorem isLocalizedModule_ofFlat [Module.Flat R M] (S : Submonoid R) : Module.Flat (Localization S)
     (LocalizedModule S M) := by
@@ -159,6 +160,11 @@ theorem isLocalizedModule_ofFlat [Module.Flat R M] (S : Submonoid R) : Module.Fl
   exact LocalizedModule.mkLinearMap S M
   rw [← isLocalizedModule_iff_isBaseChange S]
   exact localizedModuleIsLocalizedModule S
+
+theorem IsLocalizedModule_ofFlat [Module.Flat R M] (S : Submonoid R) [IsLocalization S Rp]
+    (f : M →ₗ[R] Mp) (h: IsLocalizedModule S f): Module.Flat Rp Mp := by
+  fapply Module.Flat.isBaseChange (R:=R) (M:=M) (S:=Rp) (N:=Mp)
+  exact (isLocalizedModule_iff_isBaseChange S Rp f).mp h
 
 end Localization
 


### PR DESCRIPTION
add that localization of a flat module is flat.

Co-authored-by: Florent Schaffhauser and Andrew Yang

This contribution was created as part of the AIM workshop "Formalizing algebraic geometry" in
June 2024.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
