### PR TITLE
chore(Algebra.Basic): scope and rename universal `Nat`-algebra and `Int`-algebra instances

### DIFF
--- a/Archive/Wiedijk100Theorems/AbelRuffini.lean
+++ b/Archive/Wiedijk100Theorems/AbelRuffini.lean
@@ -31,7 +31,7 @@ namespace AbelRuffini
 
 open Function Polynomial Polynomial.Gal Ideal
 
-open scoped Polynomial
+open scoped Int Polynomial
 
 attribute [local instance] splits_ℚ_ℂ
 

--- a/Counterexamples/Pseudoelement.lean
+++ b/Counterexamples/Pseudoelement.lean
@@ -28,8 +28,9 @@ given by `t ↦ (t, 2 * t)` and `y : ℚ ⟶ ℚ ⊞ ℚ` given by `t ↦ (t, t)
 * [F. Borceux, *Handbook of Categorical Algebra 2*][borceux-vol2]
 -/
 
-
 open CategoryTheory.Abelian CategoryTheory CategoryTheory.Limits ModuleCat LinearMap
+
+open scoped Int
 
 namespace Counterexample
 

--- a/Mathlib/Algebra/Algebra/Basic.lean
+++ b/Mathlib/Algebra/Algebra/Basic.lean
@@ -226,7 +226,7 @@ variable {R : Type*} [Semiring R]
 -- `ℕ`-algebras. This is only an issue since `Algebra.id` and `algebraNat` are not yet defeq.
 -- TODO: fix this by adding an `ofNat` field to semirings.
 /-- Semiring ⥤ ℕ-Alg -/
-instance (priority := 99) algebraNat : Algebra ℕ R where
+protected scoped instance (priority := 99) Nat.instAlgebraOfSemiring : Algebra ℕ R where
   commutes' := Nat.cast_commute
   smul_def' _ _ := nsmul_eq_mul _ _
   toRingHom := Nat.castRingHom R
@@ -244,11 +244,12 @@ variable (R : Type*) [Ring R]
 -- `ℤ`-algebras. This is only an issue since `Algebra.id ℤ` and `algebraInt ℤ` are not yet defeq.
 -- TODO: fix this by adding an `ofInt` field to rings.
 /-- Ring ⥤ ℤ-Alg -/
-instance (priority := 99) algebraInt : Algebra ℤ R where
+protected scoped instance (priority := 99) Int.instAlgebraOfRing : Algebra ℤ R where
   commutes' := Int.cast_commute
   smul_def' _ _ := zsmul_eq_mul _ _
   toRingHom := Int.castRingHom R
 
+open Int in
 /-- A special case of `eq_intCast'` that happens to be true definitionally -/
 @[simp]
 theorem algebraMap_int_eq : algebraMap ℤ R = Int.castRingHom R :=
@@ -294,11 +295,13 @@ theorem iff_algebraMap_injective [CommRing R] [Ring A] [IsDomain A] [Algebra R A
   ⟨@NoZeroSMulDivisors.algebraMap_injective R A _ _ _ _, NoZeroSMulDivisors.of_algebraMap_injective⟩
 
 -- see note [lower instance priority]
+open Nat in
 instance (priority := 100) CharZero.noZeroSMulDivisors_nat [Semiring R] [NoZeroDivisors R]
     [CharZero R] : NoZeroSMulDivisors ℕ R :=
   NoZeroSMulDivisors.of_algebraMap_injective <| (algebraMap ℕ R).injective_nat
 
 -- see note [lower instance priority]
+open Int in
 instance (priority := 100) CharZero.noZeroSMulDivisors_int [Ring R] [NoZeroDivisors R]
     [CharZero R] : NoZeroSMulDivisors ℤ R :=
   NoZeroSMulDivisors.of_algebraMap_injective <| (algebraMap ℤ R).injective_int
@@ -330,6 +333,7 @@ theorem algebra_compatible_smul (r : R) (m : M) : r • m = (algebraMap R A) r �
 theorem algebraMap_smul (r : R) (m : M) : (algebraMap R A) r • m = r • m :=
   (algebra_compatible_smul A r m).symm
 
+open Int in
 theorem intCast_smul {k V : Type*} [CommRing k] [AddCommGroup V] [Module k V] (r : ℤ) (x : V) :
     (r : k) • x = r • x :=
   algebraMap_smul k r x

--- a/Mathlib/Algebra/Algebra/Basic.lean
+++ b/Mathlib/Algebra/Algebra/Basic.lean
@@ -249,7 +249,7 @@ protected scoped instance (priority := 99) Int.instAlgebraOfRing : Algebra ℤ R
   smul_def' _ _ := zsmul_eq_mul _ _
   toRingHom := Int.castRingHom R
 
-open Int in
+open scoped Int in
 /-- A special case of `eq_intCast'` that happens to be true definitionally -/
 @[simp]
 theorem algebraMap_int_eq : algebraMap ℤ R = Int.castRingHom R :=
@@ -295,13 +295,13 @@ theorem iff_algebraMap_injective [CommRing R] [Ring A] [IsDomain A] [Algebra R A
   ⟨@NoZeroSMulDivisors.algebraMap_injective R A _ _ _ _, NoZeroSMulDivisors.of_algebraMap_injective⟩
 
 -- see note [lower instance priority]
-open Nat in
+open scoped Nat in
 instance (priority := 100) CharZero.noZeroSMulDivisors_nat [Semiring R] [NoZeroDivisors R]
     [CharZero R] : NoZeroSMulDivisors ℕ R :=
   NoZeroSMulDivisors.of_algebraMap_injective <| (algebraMap ℕ R).injective_nat
 
 -- see note [lower instance priority]
-open Int in
+open scoped Int in
 instance (priority := 100) CharZero.noZeroSMulDivisors_int [Ring R] [NoZeroDivisors R]
     [CharZero R] : NoZeroSMulDivisors ℤ R :=
   NoZeroSMulDivisors.of_algebraMap_injective <| (algebraMap ℤ R).injective_int
@@ -333,7 +333,7 @@ theorem algebra_compatible_smul (r : R) (m : M) : r • m = (algebraMap R A) r �
 theorem algebraMap_smul (r : R) (m : M) : (algebraMap R A) r • m = r • m :=
   (algebra_compatible_smul A r m).symm
 
-open Int in
+open scoped Int in
 theorem intCast_smul {k V : Type*} [CommRing k] [AddCommGroup V] [Module k V] (r : ℤ) (x : V) :
     (r : k) • x = r • x :=
   algebraMap_smul k r x

--- a/Mathlib/Algebra/Algebra/Hom.lean
+++ b/Mathlib/Algebra/Algebra/Hom.lean
@@ -420,6 +420,7 @@ namespace RingHom
 
 variable {R S : Type*}
 
+open Nat in
 /-- Reinterpret a `RingHom` as an `ℕ`-algebra homomorphism. -/
 def toNatAlgHom [Semiring R] [Semiring S] (f : R →+* S) : R →ₐ[ℕ] S :=
   { f with

--- a/Mathlib/Algebra/Algebra/Hom.lean
+++ b/Mathlib/Algebra/Algebra/Hom.lean
@@ -420,7 +420,7 @@ namespace RingHom
 
 variable {R S : Type*}
 
-open Nat in
+open scoped Nat in
 /-- Reinterpret a `RingHom` as an `ℕ`-algebra homomorphism. -/
 def toNatAlgHom [Semiring R] [Semiring S] (f : R →+* S) : R →ₐ[ℕ] S :=
   { f with

--- a/Mathlib/Algebra/Algebra/Subalgebra/Basic.lean
+++ b/Mathlib/Algebra/Algebra/Subalgebra/Basic.lean
@@ -1105,6 +1105,7 @@ section Nat
 
 variable {R : Type*} [Semiring R]
 
+open Nat in
 /-- A subsemiring is an `ℕ`-subalgebra. -/
 def subalgebraOfSubsemiring (S : Subsemiring R) : Subalgebra ℕ R :=
   { S with algebraMap_mem' := fun i => natCast_mem S i }
@@ -1120,6 +1121,7 @@ section Int
 
 variable {R : Type*} [Ring R]
 
+open Int in
 /-- A subring is a `ℤ`-subalgebra. -/
 def subalgebraOfSubring (S : Subring R) : Subalgebra ℤ R :=
   { S with

--- a/Mathlib/Algebra/Algebra/Subalgebra/Basic.lean
+++ b/Mathlib/Algebra/Algebra/Subalgebra/Basic.lean
@@ -1105,7 +1105,7 @@ section Nat
 
 variable {R : Type*} [Semiring R]
 
-open Nat in
+open scoped Nat in
 /-- A subsemiring is an `ℕ`-subalgebra. -/
 def subalgebraOfSubsemiring (S : Subsemiring R) : Subalgebra ℕ R :=
   { S with algebraMap_mem' := fun i => natCast_mem S i }
@@ -1121,7 +1121,7 @@ section Int
 
 variable {R : Type*} [Ring R]
 
-open Int in
+open scoped Int in
 /-- A subring is a `ℤ`-subalgebra. -/
 def subalgebraOfSubring (S : Subring R) : Subalgebra ℤ R :=
   { S with

--- a/Mathlib/Algebra/Algebra/Subalgebra/Unitization.lean
+++ b/Mathlib/Algebra/Algebra/Subalgebra/Unitization.lean
@@ -229,6 +229,7 @@ namespace NonUnitalSubsemiring
 
 variable {R S : Type*} [Semiring R] [SetLike S R] [hSR : NonUnitalSubsemiringClass S R] (s : S)
 
+open Nat in
 /-- The natural `ℕ`-algebra homomorphism from the unitization of a non-unital subsemiring to
 its `Subsemiring.closure`. -/
 def unitization : Unitization ℕ s →ₐ[ℕ] R :=
@@ -238,6 +239,7 @@ def unitization : Unitization ℕ s →ₐ[ℕ] R :=
 theorem unitization_apply (x : Unitization ℕ s) : unitization s x = x.fst + x.snd :=
   rfl
 
+open Nat in
 theorem unitization_range :
     (unitization s).range = subalgebraOfSubsemiring (Subsemiring.closure s) := by
   have := AddSubmonoidClass.nsmulMemClass (S := S)
@@ -276,6 +278,7 @@ namespace NonUnitalSubring
 
 variable {R S : Type*} [Ring R] [SetLike S R] [hSR : NonUnitalSubringClass S R] (s : S)
 
+open Int in
 /-- The natural `ℤ`-algebra homomorphism from the unitization of a non-unital subring to
 its `Subring.closure`. -/
 def unitization : Unitization ℤ s →ₐ[ℤ] R :=
@@ -285,6 +288,7 @@ def unitization : Unitization ℤ s →ₐ[ℤ] R :=
 theorem unitization_apply (x : Unitization ℤ s) : unitization s x = x.fst + x.snd :=
   rfl
 
+open Int in
 theorem unitization_range :
     (unitization s).range = subalgebraOfSubring (Subring.closure s) := by
   have := AddSubgroupClass.zsmulMemClass (S := S)

--- a/Mathlib/Algebra/Algebra/Subalgebra/Unitization.lean
+++ b/Mathlib/Algebra/Algebra/Subalgebra/Unitization.lean
@@ -229,7 +229,7 @@ namespace NonUnitalSubsemiring
 
 variable {R S : Type*} [Semiring R] [SetLike S R] [hSR : NonUnitalSubsemiringClass S R] (s : S)
 
-open Nat in
+open scoped Nat in
 /-- The natural `ℕ`-algebra homomorphism from the unitization of a non-unital subsemiring to
 its `Subsemiring.closure`. -/
 def unitization : Unitization ℕ s →ₐ[ℕ] R :=
@@ -239,7 +239,7 @@ def unitization : Unitization ℕ s →ₐ[ℕ] R :=
 theorem unitization_apply (x : Unitization ℕ s) : unitization s x = x.fst + x.snd :=
   rfl
 
-open Nat in
+open scoped Nat in
 theorem unitization_range :
     (unitization s).range = subalgebraOfSubsemiring (Subsemiring.closure s) := by
   have := AddSubmonoidClass.nsmulMemClass (S := S)
@@ -278,7 +278,7 @@ namespace NonUnitalSubring
 
 variable {R S : Type*} [Ring R] [SetLike S R] [hSR : NonUnitalSubringClass S R] (s : S)
 
-open Int in
+open scoped Int in
 /-- The natural `ℤ`-algebra homomorphism from the unitization of a non-unital subring to
 its `Subring.closure`. -/
 def unitization : Unitization ℤ s →ₐ[ℤ] R :=
@@ -288,7 +288,7 @@ def unitization : Unitization ℤ s →ₐ[ℤ] R :=
 theorem unitization_apply (x : Unitization ℤ s) : unitization s x = x.fst + x.snd :=
   rfl
 
-open Int in
+open scoped Int in
 theorem unitization_range :
     (unitization s).range = subalgebraOfSubring (Subring.closure s) := by
   have := AddSubgroupClass.zsmulMemClass (S := S)

--- a/Mathlib/Algebra/Category/ModuleCat/Injective.lean
+++ b/Mathlib/Algebra/Category/ModuleCat/Injective.lean
@@ -28,6 +28,7 @@ variable (R : Type u) [Ring R]
 instance : EnoughInjectives (ModuleCat.{v} ℤ) :=
   EnoughInjectives.of_equivalence (forget₂ (ModuleCat ℤ) AddCommGrp)
 
+open Int in
 lemma ModuleCat.enoughInjectives : EnoughInjectives (ModuleCat.{max v u} R) :=
   EnoughInjectives.of_adjunction (ModuleCat.restrictCoextendScalarsAdj.{max v u} (algebraMap ℤ R))
 

--- a/Mathlib/Algebra/Category/ModuleCat/Injective.lean
+++ b/Mathlib/Algebra/Category/ModuleCat/Injective.lean
@@ -28,7 +28,7 @@ variable (R : Type u) [Ring R]
 instance : EnoughInjectives (ModuleCat.{v} ℤ) :=
   EnoughInjectives.of_equivalence (forget₂ (ModuleCat ℤ) AddCommGrp)
 
-open Int in
+open scoped Int in
 lemma ModuleCat.enoughInjectives : EnoughInjectives (ModuleCat.{max v u} R) :=
   EnoughInjectives.of_adjunction (ModuleCat.restrictCoextendScalarsAdj.{max v u} (algebraMap ℤ R))
 

--- a/Mathlib/Algebra/FreeAlgebra.lean
+++ b/Mathlib/Algebra/FreeAlgebra.lean
@@ -201,7 +201,7 @@ instance instDistrib : Distrib (FreeAlgebra R X) where
     rintro ⟨⟩ ⟨⟩ ⟨⟩
     exact Quot.sound Rel.right_distrib
 
-open Nat in
+open scoped Nat in
 instance instAddCommMonoid : AddCommMonoid (FreeAlgebra R X) where
   add_assoc := by
     rintro ⟨⟩ ⟨⟩ ⟨⟩
@@ -253,7 +253,7 @@ instance instAlgebra {A} [CommSemiring A] [Algebra R A] : Algebra R (FreeAlgebra
     exact Quot.sound Rel.central_scalar
   smul_def' _ _ := rfl
 
-open Nat in
+open scoped Nat in
 -- verify there is no diamond at `default` transparency but we will need
 -- `reducible_and_instances` which currently fails #10906
 variable (S : Type) [CommSemiring S] in
@@ -276,7 +276,7 @@ instance {R S A} [CommSemiring R] [CommSemiring S] [CommSemiring A] [Algebra R A
 instance {S : Type*} [CommRing S] : Ring (FreeAlgebra S X) :=
   Algebra.semiringToRing S
 
-open Int in
+open scoped Int in
 -- verify there is no diamond but we will need
 -- `reducible_and_instances` which currently fails #10906
 variable (S : Type) [CommRing S] in

--- a/Mathlib/Algebra/FreeAlgebra.lean
+++ b/Mathlib/Algebra/FreeAlgebra.lean
@@ -201,6 +201,7 @@ instance instDistrib : Distrib (FreeAlgebra R X) where
     rintro ⟨⟩ ⟨⟩ ⟨⟩
     exact Quot.sound Rel.right_distrib
 
+open Nat in
 instance instAddCommMonoid : AddCommMonoid (FreeAlgebra R X) where
   add_assoc := by
     rintro ⟨⟩ ⟨⟩ ⟨⟩
@@ -252,10 +253,11 @@ instance instAlgebra {A} [CommSemiring A] [Algebra R A] : Algebra R (FreeAlgebra
     exact Quot.sound Rel.central_scalar
   smul_def' _ _ := rfl
 
+open Nat in
 -- verify there is no diamond at `default` transparency but we will need
 -- `reducible_and_instances` which currently fails #10906
 variable (S : Type) [CommSemiring S] in
-example : (algebraNat : Algebra ℕ (FreeAlgebra S X)) = instAlgebra _ _ := rfl
+example : (Nat.instAlgebraOfSemiring : Algebra ℕ (FreeAlgebra S X)) = instAlgebra _ _ := rfl
 
 instance {R S A} [CommSemiring R] [CommSemiring S] [CommSemiring A]
     [SMul R S] [Algebra R A] [Algebra S A] [IsScalarTower R S A] :
@@ -274,10 +276,11 @@ instance {R S A} [CommSemiring R] [CommSemiring S] [CommSemiring A] [Algebra R A
 instance {S : Type*} [CommRing S] : Ring (FreeAlgebra S X) :=
   Algebra.semiringToRing S
 
+open Int in
 -- verify there is no diamond but we will need
 -- `reducible_and_instances` which currently fails #10906
 variable (S : Type) [CommRing S] in
-example : (algebraInt _ : Algebra ℤ (FreeAlgebra S X)) = instAlgebra _ _ := rfl
+example : (Int.instAlgebraOfRing _ : Algebra ℤ (FreeAlgebra S X)) = instAlgebra _ _ := rfl
 
 variable {X}
 

--- a/Mathlib/Algebra/Module/Bimodule.lean
+++ b/Mathlib/Algebra/Module/Bimodule.lean
@@ -118,17 +118,17 @@ end Algebra
 
 section Ring
 
+open scoped Nat Int
+
 variable (R S M : Type*) [Ring R] [Ring S]
 variable [AddCommGroup M] [Module R M] [Module S M] [SMulCommClass R S M]
 
-open Nat Int in
 /-- A `Submodule` over `R ⊗[ℕ] S` is naturally also a `Submodule` over the canonically-isomorphic
 ring `R ⊗[ℤ] S`. -/
 @[simps!]
 def toSubbimoduleInt (p : Submodule (R ⊗[ℕ] S) M) : Submodule (R ⊗[ℤ] S) M :=
   baseChange ℤ p
 
-open Nat Int in
 /-- A `Submodule` over `R ⊗[ℤ] S` is naturally also a `Submodule` over the canonically-isomorphic
 ring `R ⊗[ℕ] S`. -/
 @[simps!]

--- a/Mathlib/Algebra/Module/Bimodule.lean
+++ b/Mathlib/Algebra/Module/Bimodule.lean
@@ -121,12 +121,14 @@ section Ring
 variable (R S M : Type*) [Ring R] [Ring S]
 variable [AddCommGroup M] [Module R M] [Module S M] [SMulCommClass R S M]
 
+open Nat Int in
 /-- A `Submodule` over `R ⊗[ℕ] S` is naturally also a `Submodule` over the canonically-isomorphic
 ring `R ⊗[ℤ] S`. -/
 @[simps!]
 def toSubbimoduleInt (p : Submodule (R ⊗[ℕ] S) M) : Submodule (R ⊗[ℤ] S) M :=
   baseChange ℤ p
 
+open Nat Int in
 /-- A `Submodule` over `R ⊗[ℤ] S` is naturally also a `Submodule` over the canonically-isomorphic
 ring `R ⊗[ℕ] S`. -/
 @[simps!]

--- a/Mathlib/Algebra/Module/Zlattice/Basic.lean
+++ b/Mathlib/Algebra/Module/Zlattice/Basic.lean
@@ -82,6 +82,8 @@ variable [FloorRing K]
 
 section Fintype
 
+open Int
+
 variable [Fintype ι]
 
 /-- The map that sends a vector of `E` to the element of the ℤ-lattice spanned by `b` obtained
@@ -261,6 +263,7 @@ end NormedLatticeField
 
 section Real
 
+open Int in
 theorem discreteTopology_pi_basisFun [Finite ι] :
     DiscreteTopology (span ℤ (Set.range (Pi.basisFun ℝ ι))) := by
   cases nonempty_fintype ι
@@ -280,6 +283,7 @@ theorem fundamentalDomain_subset_parallelepiped [Fintype ι] :
   rw [fundamentalDomain, parallelepiped_basis_eq, Set.setOf_subset_setOf]
   exact fun _ h i ↦ Set.Ico_subset_Icc_self (h i)
 
+open Int in
 instance [Finite ι] : DiscreteTopology (span ℤ (Set.range b)) := by
   have h : Set.MapsTo b.equivFun (span ℤ (Set.range b)) (span ℤ (Set.range (Pi.basisFun ℝ ι))) := by
     intro _ hx
@@ -467,6 +471,7 @@ instance instModuleFree_of_discrete_addSubgroup {E : Type*} [NormedAddCommGroup 
     exact noZeroSMulDivisors _
   infer_instance
 
+open Int in
 theorem Zlattice.rank [hs : IsZlattice K L] : finrank ℤ L = finrank K E := by
   classical
   have : Module.Finite ℤ L := module_finite K L
@@ -569,6 +574,7 @@ def Basis.ofZlatticeBasis :
 theorem Basis.ofZlatticeBasis_apply (i : ι) :
     b.ofZlatticeBasis K L i =  b i := by simp [Basis.ofZlatticeBasis]
 
+open Int in
 @[simp]
 theorem Basis.ofZlatticeBasis_repr_apply (x : L) (i : ι) :
     (b.ofZlatticeBasis K L).repr x i = b.repr x i := by

--- a/Mathlib/Algebra/Module/Zlattice/Basic.lean
+++ b/Mathlib/Algebra/Module/Zlattice/Basic.lean
@@ -82,7 +82,7 @@ variable [FloorRing K]
 
 section Fintype
 
-open Int
+open scoped Int
 
 variable [Fintype ι]
 
@@ -263,7 +263,7 @@ end NormedLatticeField
 
 section Real
 
-open Int in
+open scoped Int in
 theorem discreteTopology_pi_basisFun [Finite ι] :
     DiscreteTopology (span ℤ (Set.range (Pi.basisFun ℝ ι))) := by
   cases nonempty_fintype ι
@@ -283,7 +283,7 @@ theorem fundamentalDomain_subset_parallelepiped [Fintype ι] :
   rw [fundamentalDomain, parallelepiped_basis_eq, Set.setOf_subset_setOf]
   exact fun _ h i ↦ Set.Ico_subset_Icc_self (h i)
 
-open Int in
+open scoped Int in
 instance [Finite ι] : DiscreteTopology (span ℤ (Set.range b)) := by
   have h : Set.MapsTo b.equivFun (span ℤ (Set.range b)) (span ℤ (Set.range (Pi.basisFun ℝ ι))) := by
     intro _ hx
@@ -471,7 +471,7 @@ instance instModuleFree_of_discrete_addSubgroup {E : Type*} [NormedAddCommGroup 
     exact noZeroSMulDivisors _
   infer_instance
 
-open Int in
+open scoped Int in
 theorem Zlattice.rank [hs : IsZlattice K L] : finrank ℤ L = finrank K E := by
   classical
   have : Module.Finite ℤ L := module_finite K L
@@ -574,7 +574,7 @@ def Basis.ofZlatticeBasis :
 theorem Basis.ofZlatticeBasis_apply (i : ι) :
     b.ofZlatticeBasis K L i =  b i := by simp [Basis.ofZlatticeBasis]
 
-open Int in
+open scoped Int in
 @[simp]
 theorem Basis.ofZlatticeBasis_repr_apply (x : L) (i : ι) :
     (b.ofZlatticeBasis K L).repr x i = b.repr x i := by

--- a/Mathlib/Algebra/MvPolynomial/Counit.lean
+++ b/Mathlib/Algebra/MvPolynomial/Counit.lean
@@ -25,7 +25,7 @@ obtained by `X a ↦ a`.
 
 namespace MvPolynomial
 
-open Function
+open Function Nat Int
 
 variable (A B R : Type*) [CommSemiring A] [CommSemiring B] [CommRing R] [Algebra A B]
 

--- a/Mathlib/Algebra/MvPolynomial/Counit.lean
+++ b/Mathlib/Algebra/MvPolynomial/Counit.lean
@@ -25,7 +25,9 @@ obtained by `X a ↦ a`.
 
 namespace MvPolynomial
 
-open Function Nat Int
+open Function
+
+open scoped Nat Int
 
 variable (A B R : Type*) [CommSemiring A] [CommSemiring B] [CommRing R] [Algebra A B]
 

--- a/Mathlib/Algebra/MvPolynomial/Supported.lean
+++ b/Mathlib/Algebra/MvPolynomial/Supported.lean
@@ -111,6 +111,7 @@ theorem supported_strictMono [Nontrivial R] :
     StrictMono (supported R : Set σ → Subalgebra R (MvPolynomial σ R)) :=
   strictMono_of_le_iff_le fun _ _ ↦ supported_le_supported_iff.symm
 
+open Int in
 theorem exists_restrict_to_vars (R : Type*) [CommRing R] {F : MvPolynomial σ ℤ}
     (hF : ↑F.vars ⊆ s) : ∃ f : (s → R) → R, ∀ x : σ → R, f (x ∘ (↑) : s → R) = aeval x F := by
   rw [← mem_supported, supported_eq_range_rename, AlgHom.mem_range] at hF

--- a/Mathlib/Algebra/Polynomial/AlgebraMap.lean
+++ b/Mathlib/Algebra/Polynomial/AlgebraMap.lean
@@ -124,6 +124,7 @@ theorem eval₂_algebraMap_X {R A : Type*} [CommSemiring R] [Semiring A] [Algebr
   simp only [map_sum, map_mul, map_pow, eq_intCast, map_intCast]
   simp [Polynomial.C_eq_algebraMap]
 
+open Int in
 -- these used to be about `algebraMap ℤ R`, but now the simp-normal form is `Int.castRingHom R`.
 @[simp]
 theorem ringHom_eval₂_intCastRingHom {R S : Type*} [Ring R] [Ring S] (p : ℤ[X]) (f : R →+* S)
@@ -133,6 +134,7 @@ theorem ringHom_eval₂_intCastRingHom {R S : Type*} [Ring R] [Ring S] (p : ℤ[
 @[deprecated (since := "2024-05-27")]
 alias ringHom_eval₂_cast_int_ringHom := ringHom_eval₂_intCastRingHom
 
+open Int in
 @[simp]
 theorem eval₂_intCastRingHom_X {R : Type*} [Ring R] (p : ℤ[X]) (f : ℤ[X] →+* R) :
     eval₂ (Int.castRingHom R) (f X) p = f p :=

--- a/Mathlib/Algebra/Polynomial/AlgebraMap.lean
+++ b/Mathlib/Algebra/Polynomial/AlgebraMap.lean
@@ -124,7 +124,7 @@ theorem eval₂_algebraMap_X {R A : Type*} [CommSemiring R] [Semiring A] [Algebr
   simp only [map_sum, map_mul, map_pow, eq_intCast, map_intCast]
   simp [Polynomial.C_eq_algebraMap]
 
-open Int in
+open scoped Int in
 -- these used to be about `algebraMap ℤ R`, but now the simp-normal form is `Int.castRingHom R`.
 @[simp]
 theorem ringHom_eval₂_intCastRingHom {R S : Type*} [Ring R] [Ring S] (p : ℤ[X]) (f : R →+* S)
@@ -134,7 +134,7 @@ theorem ringHom_eval₂_intCastRingHom {R S : Type*} [Ring R] [Ring S] (p : ℤ[
 @[deprecated (since := "2024-05-27")]
 alias ringHom_eval₂_cast_int_ringHom := ringHom_eval₂_intCastRingHom
 
-open Int in
+open scoped Int in
 @[simp]
 theorem eval₂_intCastRingHom_X {R : Type*} [Ring R] (p : ℤ[X]) (f : ℤ[X] →+* R) :
     eval₂ (Int.castRingHom R) (f X) p = f p :=

--- a/Mathlib/Algebra/Polynomial/DenomsClearable.lean
+++ b/Mathlib/Algebra/Polynomial/DenomsClearable.lean
@@ -73,7 +73,7 @@ end DenomsClearable
 
 open RingHom
 
-open Int in
+open scoped Int in
 /-- Evaluating a polynomial with integer coefficients at a rational number and clearing
 denominators, yields a number greater than or equal to one.  The target can be any
 `LinearOrderedField K`.

--- a/Mathlib/Algebra/Polynomial/DenomsClearable.lean
+++ b/Mathlib/Algebra/Polynomial/DenomsClearable.lean
@@ -73,6 +73,7 @@ end DenomsClearable
 
 open RingHom
 
+open Int in
 /-- Evaluating a polynomial with integer coefficients at a rational number and clearing
 denominators, yields a number greater than or equal to one.  The target can be any
 `LinearOrderedField K`.

--- a/Mathlib/Algebra/Polynomial/UnitTrinomial.lean
+++ b/Mathlib/Algebra/Polynomial/UnitTrinomial.lean
@@ -320,7 +320,7 @@ theorem irreducible_of_isCoprime (hp : p.IsUnitTrinomial) (h : IsCoprime p p.mir
     Irreducible p :=
   irreducible_of_coprime hp fun _ => h.isUnit_of_dvd'
 
-open Int in
+open scoped Int in
 /-- A unit trinomial is irreducible if it has no complex roots in common with its mirror -/
 theorem irreducible_of_coprime' (hp : IsUnitTrinomial p)
     (h : ∀ z : ℂ, ¬(aeval z p = 0 ∧ aeval z (mirror p) = 0)) : Irreducible p := by

--- a/Mathlib/Algebra/Polynomial/UnitTrinomial.lean
+++ b/Mathlib/Algebra/Polynomial/UnitTrinomial.lean
@@ -320,6 +320,7 @@ theorem irreducible_of_isCoprime (hp : p.IsUnitTrinomial) (h : IsCoprime p p.mir
     Irreducible p :=
   irreducible_of_coprime hp fun _ => h.isUnit_of_dvd'
 
+open Int in
 /-- A unit trinomial is irreducible if it has no complex roots in common with its mirror -/
 theorem irreducible_of_coprime' (hp : IsUnitTrinomial p)
     (h : ∀ z : ℂ, ¬(aeval z p = 0 ∧ aeval z (mirror p) = 0)) : Irreducible p := by

--- a/Mathlib/Algebra/RingQuot.lean
+++ b/Mathlib/Algebra/RingQuot.lean
@@ -261,6 +261,7 @@ instance instSMulCommClass [CommSemiring T] [Algebra S R] [Algebra T R] [SMulCom
     SMulCommClass S T (RingQuot r) :=
   ⟨fun s t ⟨a⟩ => Quot.inductionOn a fun a' => by simp only [RingQuot.smul_quot, smul_comm]⟩
 
+open Nat in
 instance instAddCommMonoid (r : R → R → Prop) : AddCommMonoid (RingQuot r) where
   add := (· + ·)
   zero := 0
@@ -334,6 +335,7 @@ instance instSemiring (r : R → R → Prop) : Semiring (RingQuot r) where
 private def intCast {R : Type uR} [Ring R] (r : R → R → Prop) (z : ℤ) : RingQuot r :=
   ⟨Quot.mk _ z⟩
 
+open Int in
 instance instRing {R : Type uR} [Ring R] (r : R → R → Prop) : Ring (RingQuot r) :=
   { RingQuot.instSemiring r with
     neg := Neg.neg

--- a/Mathlib/Algebra/RingQuot.lean
+++ b/Mathlib/Algebra/RingQuot.lean
@@ -261,7 +261,7 @@ instance instSMulCommClass [CommSemiring T] [Algebra S R] [Algebra T R] [SMulCom
     SMulCommClass S T (RingQuot r) :=
   ⟨fun s t ⟨a⟩ => Quot.inductionOn a fun a' => by simp only [RingQuot.smul_quot, smul_comm]⟩
 
-open Nat in
+open scoped Nat in
 instance instAddCommMonoid (r : R → R → Prop) : AddCommMonoid (RingQuot r) where
   add := (· + ·)
   zero := 0
@@ -335,7 +335,7 @@ instance instSemiring (r : R → R → Prop) : Semiring (RingQuot r) where
 private def intCast {R : Type uR} [Ring R] (r : R → R → Prop) (z : ℤ) : RingQuot r :=
   ⟨Quot.mk _ z⟩
 
-open Int in
+open scoped Int in
 instance instRing {R : Type uR} [Ring R] (r : R → R → Prop) : Ring (RingQuot r) :=
   { RingQuot.instSemiring r with
     neg := Neg.neg

--- a/Mathlib/Analysis/Complex/UpperHalfPlane/Basic.lean
+++ b/Mathlib/Analysis/Complex/UpperHalfPlane/Basic.lean
@@ -26,7 +26,7 @@ We define the notation `ℍ` for the upper half plane available in the locale
 
 noncomputable section
 
-open Matrix Matrix.SpecialLinearGroup
+open Int Matrix Matrix.SpecialLinearGroup
 
 open scoped Classical MatrixGroups
 

--- a/Mathlib/Analysis/Complex/UpperHalfPlane/Basic.lean
+++ b/Mathlib/Analysis/Complex/UpperHalfPlane/Basic.lean
@@ -26,9 +26,9 @@ We define the notation `ℍ` for the upper half plane available in the locale
 
 noncomputable section
 
-open Int Matrix Matrix.SpecialLinearGroup
+open Matrix Matrix.SpecialLinearGroup
 
-open scoped Classical MatrixGroups
+open scoped Classical Int MatrixGroups
 
 /- Disable these instances as they are not the simp-normal form, and having them disabled ensures
 we state lemmas in this file without spurious `coe_fn` terms. -/

--- a/Mathlib/Analysis/Complex/UpperHalfPlane/Metric.lean
+++ b/Mathlib/Analysis/Complex/UpperHalfPlane/Metric.lean
@@ -318,6 +318,7 @@ theorem isometry_pos_mul (a : { x : ℝ // 0 < x }) : Isometry (a • · : ℍ �
     Real.norm_eq_abs, mul_left_comm]
   exact mul_div_mul_left _ _ (mt _root_.abs_eq_zero.1 a.2.ne')
 
+open Int in
 /-- `SL(2, ℝ)` acts on the upper half plane as an isometry. -/
 instance : IsometricSMul SL(2, ℝ) ℍ :=
   ⟨fun g => by
@@ -327,7 +328,7 @@ instance : IsometricSMul SL(2, ℝ) ℍ :=
         have h₂ : Complex.abs (y₁ * y₂) ≠ 0 := by simp [y₁.ne_zero, y₂.ne_zero]
         simp only [dist_eq, modular_S_smul, inv_neg, neg_div, div_mul_div_comm, coe_mk, mk_im,
           div_one, Complex.inv_im, Complex.neg_im, coe_im, neg_neg, Complex.normSq_neg,
-          mul_eq_mul_left_iff, Real.arsinh_inj, one_ne_zero, or_false_iff,
+          Int.mul_eq_mul_left_iff, Real.arsinh_inj, one_ne_zero, or_false_iff,
           dist_neg_neg, mul_neg, neg_mul, dist_inv_inv₀ y₁.ne_zero y₂.ne_zero, ←
           AbsoluteValue.map_mul, ← Complex.normSq_mul, Real.sqrt_div h₁, ← Complex.abs_apply,
           mul_div (2 : ℝ), div_div_div_comm, div_self h₂, Complex.norm_eq_abs]

--- a/Mathlib/Analysis/Complex/UpperHalfPlane/Metric.lean
+++ b/Mathlib/Analysis/Complex/UpperHalfPlane/Metric.lean
@@ -318,7 +318,7 @@ theorem isometry_pos_mul (a : { x : ℝ // 0 < x }) : Isometry (a • · : ℍ �
     Real.norm_eq_abs, mul_left_comm]
   exact mul_div_mul_left _ _ (mt _root_.abs_eq_zero.1 a.2.ne')
 
-open Int in
+open scoped Int in
 /-- `SL(2, ℝ)` acts on the upper half plane as an isometry. -/
 instance : IsometricSMul SL(2, ℝ) ℍ :=
   ⟨fun g => by

--- a/Mathlib/Analysis/Complex/UpperHalfPlane/Topology.lean
+++ b/Mathlib/Analysis/Complex/UpperHalfPlane/Topology.lean
@@ -99,7 +99,7 @@ lemma subset_verticalStrip_of_isCompact {K : Set ℍ} (hK : IsCompact K) :
   obtain ⟨v, _, hv⟩ := hK.exists_isMinOn hne continuous_im.continuousOn
   exact ⟨|re u|, im v, v.im_pos, fun k hk ↦ ⟨isMaxOn_iff.mp hu _ hk, isMinOn_iff.mp hv _ hk⟩⟩
 
-open Int in
+open scoped Int in
 theorem ModularGroup_T_zpow_mem_verticalStrip (z : ℍ) {N : ℕ} (hn : 0 < N) :
     ∃ n : ℤ, ModularGroup.T ^ (N * n) • z ∈ verticalStrip N z.im := by
   let n := Int.floor (z.re/N)

--- a/Mathlib/Analysis/Complex/UpperHalfPlane/Topology.lean
+++ b/Mathlib/Analysis/Complex/UpperHalfPlane/Topology.lean
@@ -99,6 +99,7 @@ lemma subset_verticalStrip_of_isCompact {K : Set ℍ} (hK : IsCompact K) :
   obtain ⟨v, _, hv⟩ := hK.exists_isMinOn hne continuous_im.continuousOn
   exact ⟨|re u|, im v, v.im_pos, fun k hk ↦ ⟨isMaxOn_iff.mp hu _ hk, isMinOn_iff.mp hv _ hk⟩⟩
 
+open Int in
 theorem ModularGroup_T_zpow_mem_verticalStrip (z : ℍ) {N : ℕ} (hn : 0 < N) :
     ∃ n : ℤ, ModularGroup.T ^ (N * n) • z ∈ verticalStrip N z.im := by
   let n := Int.floor (z.re/N)

--- a/Mathlib/Data/Matrix/Kronecker.lean
+++ b/Mathlib/Data/Matrix/Kronecker.lean
@@ -342,6 +342,7 @@ theorem one_kronecker [MulZeroOneClass α] [DecidableEq l] (B : Matrix m n α) :
   (diagonal_kronecker _ _).trans <|
     congr_arg _ <| congr_arg _ <| funext fun _ => Matrix.ext fun _ _ => one_mul _
 
+open Nat in
 theorem mul_kronecker_mul [Fintype m] [Fintype m'] [CommSemiring α] (A : Matrix l m α)
     (B : Matrix m n α) (A' : Matrix l' m' α) (B' : Matrix m' n' α) :
     (A * B) ⊗ₖ (A' * B') = A ⊗ₖ A' * B ⊗ₖ B' :=
@@ -358,10 +359,12 @@ theorem kronecker_assoc' [Semigroup α] (A : Matrix l m α) (B : Matrix n p α) 
     A ⊗ₖ (B ⊗ₖ C) :=
   kroneckerMap_assoc₁ _ _ _ _ A B C mul_assoc
 
+open Nat in
 theorem trace_kronecker [Fintype m] [Fintype n] [Semiring α] (A : Matrix m m α) (B : Matrix n n α) :
     trace (A ⊗ₖ B) = trace A * trace B :=
   trace_kroneckerMapBilinear (Algebra.lmul ℕ α).toLinearMap _ _
 
+open Nat in
 theorem det_kronecker [Fintype m] [Fintype n] [DecidableEq m] [DecidableEq n] [CommRing R]
     (A : Matrix m m R) (B : Matrix n n R) :
     det (A ⊗ₖ B) = det A ^ Fintype.card n * det B ^ Fintype.card m := by

--- a/Mathlib/Data/Matrix/Kronecker.lean
+++ b/Mathlib/Data/Matrix/Kronecker.lean
@@ -342,7 +342,7 @@ theorem one_kronecker [MulZeroOneClass α] [DecidableEq l] (B : Matrix m n α) :
   (diagonal_kronecker _ _).trans <|
     congr_arg _ <| congr_arg _ <| funext fun _ => Matrix.ext fun _ _ => one_mul _
 
-open Nat in
+open scoped Nat in
 theorem mul_kronecker_mul [Fintype m] [Fintype m'] [CommSemiring α] (A : Matrix l m α)
     (B : Matrix m n α) (A' : Matrix l' m' α) (B' : Matrix m' n' α) :
     (A * B) ⊗ₖ (A' * B') = A ⊗ₖ A' * B ⊗ₖ B' :=
@@ -359,12 +359,12 @@ theorem kronecker_assoc' [Semigroup α] (A : Matrix l m α) (B : Matrix n p α) 
     A ⊗ₖ (B ⊗ₖ C) :=
   kroneckerMap_assoc₁ _ _ _ _ A B C mul_assoc
 
-open Nat in
+open scoped Nat in
 theorem trace_kronecker [Fintype m] [Fintype n] [Semiring α] (A : Matrix m m α) (B : Matrix n n α) :
     trace (A ⊗ₖ B) = trace A * trace B :=
   trace_kroneckerMapBilinear (Algebra.lmul ℕ α).toLinearMap _ _
 
-open Nat in
+open scoped Nat in
 theorem det_kronecker [Fintype m] [Fintype n] [DecidableEq m] [DecidableEq n] [CommRing R]
     (A : Matrix m m R) (B : Matrix n n R) :
     det (A ⊗ₖ B) = det A ^ Fintype.card n * det B ^ Fintype.card m := by

--- a/Mathlib/Data/Real/Irrational.lean
+++ b/Mathlib/Data/Real/Irrational.lean
@@ -457,6 +457,7 @@ open Polynomial
 
 variable (x : ℝ) (p : ℤ[X])
 
+open Int in
 theorem one_lt_natDegree_of_irrational_root (hx : Irrational x) (p_nonzero : p ≠ 0)
     (x_is_root : aeval x p = 0) : 1 < p.natDegree := by
   by_contra rid

--- a/Mathlib/Data/Real/Irrational.lean
+++ b/Mathlib/Data/Real/Irrational.lean
@@ -438,7 +438,7 @@ theorem of_pow : ∀ n : ℕ, Irrational (x ^ n) → Irrational x
     rw [pow_succ] at h
     exact h.mul_cases.elim (of_pow n) id
 
-open Int in
+open scoped Int in
 theorem of_zpow : ∀ m : ℤ, Irrational (x ^ m) → Irrational x
   | (n : ℕ) => fun h => by
     rw [zpow_natCast] at h

--- a/Mathlib/FieldTheory/IsAlgClosed/Classification.lean
+++ b/Mathlib/FieldTheory/IsAlgClosed/Classification.lean
@@ -155,6 +155,7 @@ end Cardinal
 
 variable {K L : Type} [Field K] [Field L] [IsAlgClosed K] [IsAlgClosed L]
 
+open Int in
 /-- Two uncountable algebraically closed fields of characteristic zero are isomorphic
 if they have the same cardinality. -/
 theorem ringEquivOfCardinalEqOfCharZero [CharZero K] [CharZero L] (hK : ℵ₀ < #K)

--- a/Mathlib/FieldTheory/IsAlgClosed/Classification.lean
+++ b/Mathlib/FieldTheory/IsAlgClosed/Classification.lean
@@ -155,7 +155,7 @@ end Cardinal
 
 variable {K L : Type} [Field K] [Field L] [IsAlgClosed K] [IsAlgClosed L]
 
-open Int in
+open scoped Int in
 /-- Two uncountable algebraically closed fields of characteristic zero are isomorphic
 if they have the same cardinality. -/
 theorem ringEquivOfCardinalEqOfCharZero [CharZero K] [CharZero L] (hK : ℵ₀ < #K)

--- a/Mathlib/LinearAlgebra/CliffordAlgebra/Basic.lean
+++ b/Mathlib/LinearAlgebra/CliffordAlgebra/Basic.lean
@@ -78,11 +78,14 @@ instance (priority := 900) instAlgebra' {R A M} [CommSemiring R] [AddCommGroup M
     Algebra R (CliffordAlgebra Q) :=
   RingQuot.instAlgebra _
 
+open Nat in
 -- verify there are no diamonds
 -- but doesn't work at `reducible_and_instances` #10906
-example : (algebraNat : Algebra ℕ (CliffordAlgebra Q)) = instAlgebra' _ := rfl
+example : (Nat.instAlgebraOfSemiring : Algebra ℕ (CliffordAlgebra Q)) = instAlgebra' _ := rfl
+
+open Int in
 -- but doesn't work at `reducible_and_instances` #10906
-example : (algebraInt _ : Algebra ℤ (CliffordAlgebra Q)) = instAlgebra' _ := rfl
+example : (Int.instAlgebraOfRing _ : Algebra ℤ (CliffordAlgebra Q)) = instAlgebra' _ := rfl
 
 -- shortcut instance, as the other instance is slow
 instance instAlgebra : Algebra R (CliffordAlgebra Q) := instAlgebra' _

--- a/Mathlib/LinearAlgebra/CliffordAlgebra/Basic.lean
+++ b/Mathlib/LinearAlgebra/CliffordAlgebra/Basic.lean
@@ -78,12 +78,12 @@ instance (priority := 900) instAlgebra' {R A M} [CommSemiring R] [AddCommGroup M
     Algebra R (CliffordAlgebra Q) :=
   RingQuot.instAlgebra _
 
-open Nat in
+open scoped Nat in
 -- verify there are no diamonds
 -- but doesn't work at `reducible_and_instances` #10906
 example : (Nat.instAlgebraOfSemiring : Algebra ℕ (CliffordAlgebra Q)) = instAlgebra' _ := rfl
 
-open Int in
+open scoped Int in
 -- but doesn't work at `reducible_and_instances` #10906
 example : (Int.instAlgebraOfRing _ : Algebra ℤ (CliffordAlgebra Q)) = instAlgebra' _ := rfl
 

--- a/Mathlib/LinearAlgebra/FreeModule/IdealQuotient.lean
+++ b/Mathlib/LinearAlgebra/FreeModule/IdealQuotient.lean
@@ -75,7 +75,7 @@ noncomputable def quotientEquivPiSpan (I : Ideal S) (b : Basis ι R S) (hI : I �
       Submodule.quotientPi (show _ → Submodule R R from fun i => span ({a i} : Set R))
     exact this
 
-open Int in
+open scoped Int in
 /-- Ideal quotients over a free finite extension of `ℤ` are isomorphic to a direct product of
 `ZMod`. -/
 noncomputable def quotientEquivPiZMod (I : Ideal S) (b : Basis ι ℤ S) (hI : I ≠ ⊥) :
@@ -86,7 +86,7 @@ noncomputable def quotientEquivPiZMod (I : Ideal S) (b : Basis ι ℤ S) (hI : I
     AddEquiv.piCongrRight fun i => ↑(Int.quotientSpanEquivZMod (a i))
   (↑(e : (S ⧸ I) ≃ₗ[ℤ] _) : S ⧸ I ≃+ _).trans e'
 
-open Int in
+open scoped Int in
 /-- A nonzero ideal over a free finite extension of `ℤ` has a finite quotient.
 
 Can't be an instance because of the side condition `I ≠ ⊥`, and more importantly,

--- a/Mathlib/LinearAlgebra/FreeModule/IdealQuotient.lean
+++ b/Mathlib/LinearAlgebra/FreeModule/IdealQuotient.lean
@@ -75,6 +75,7 @@ noncomputable def quotientEquivPiSpan (I : Ideal S) (b : Basis ι R S) (hI : I �
       Submodule.quotientPi (show _ → Submodule R R from fun i => span ({a i} : Set R))
     exact this
 
+open Int in
 /-- Ideal quotients over a free finite extension of `ℤ` are isomorphic to a direct product of
 `ZMod`. -/
 noncomputable def quotientEquivPiZMod (I : Ideal S) (b : Basis ι ℤ S) (hI : I ≠ ⊥) :
@@ -85,6 +86,7 @@ noncomputable def quotientEquivPiZMod (I : Ideal S) (b : Basis ι ℤ S) (hI : I
     AddEquiv.piCongrRight fun i => ↑(Int.quotientSpanEquivZMod (a i))
   (↑(e : (S ⧸ I) ≃ₗ[ℤ] _) : S ⧸ I ≃+ _).trans e'
 
+open Int in
 /-- A nonzero ideal over a free finite extension of `ℤ` has a finite quotient.
 
 Can't be an instance because of the side condition `I ≠ ⊥`, and more importantly,

--- a/Mathlib/LinearAlgebra/FreeProduct/Basic.lean
+++ b/Mathlib/LinearAlgebra/FreeProduct/Basic.lean
@@ -85,7 +85,7 @@ def algEquiv_quot_algEquiv
       fun x y h ↦ by apply RingQuot.mkAlgHom_rel; simpa⟩))
     (by ext b; simp) (by ext a; simp)
 
-open Nat in
+open scoped Nat in
 /--If two (semi)rings are equivalent and their quotients by a relation `rel` are defined,
 then their quotients are also equivalent.
 

--- a/Mathlib/LinearAlgebra/FreeProduct/Basic.lean
+++ b/Mathlib/LinearAlgebra/FreeProduct/Basic.lean
@@ -85,6 +85,7 @@ def algEquiv_quot_algEquiv
       fun x y h ↦ by apply RingQuot.mkAlgHom_rel; simpa⟩))
     (by ext b; simp) (by ext a; simp)
 
+open Nat in
 /--If two (semi)rings are equivalent and their quotients by a relation `rel` are defined,
 then their quotients are also equivalent.
 

--- a/Mathlib/LinearAlgebra/Matrix/Adjugate.lean
+++ b/Mathlib/LinearAlgebra/Matrix/Adjugate.lean
@@ -332,7 +332,7 @@ theorem _root_.AlgHom.map_adjugate {R A B : Type*} [CommSemiring R] [CommRing A]
     f.mapMatrix M.adjugate = Matrix.adjugate (f.mapMatrix M) :=
   f.toRingHom.map_adjugate _
 
-open Int in
+open scoped Int in
 theorem det_adjugate (A : Matrix n n α) : (adjugate A).det = A.det ^ (Fintype.card n - 1) := by
   -- get rid of the `- 1`
   rcases (Fintype.card n).eq_zero_or_pos with h_card | h_card
@@ -482,7 +482,7 @@ theorem det_smul_adjugate_adjugate (A : Matrix n n α) :
   rwa [← Matrix.mul_assoc, mul_adjugate, Matrix.mul_smul, Matrix.mul_one, Matrix.smul_mul,
     Matrix.one_mul] at this
 
-open Int in
+open scoped Int in
 /-- Note that this is not true for `Fintype.card n = 1` since `1 - 2 = 0` and not `-1`. -/
 theorem adjugate_adjugate (A : Matrix n n α) (h : Fintype.card n ≠ 1) :
     adjugate (adjugate A) = det A ^ (Fintype.card n - 2) • A := by

--- a/Mathlib/LinearAlgebra/Matrix/Adjugate.lean
+++ b/Mathlib/LinearAlgebra/Matrix/Adjugate.lean
@@ -332,6 +332,7 @@ theorem _root_.AlgHom.map_adjugate {R A B : Type*} [CommSemiring R] [CommRing A]
     f.mapMatrix M.adjugate = Matrix.adjugate (f.mapMatrix M) :=
   f.toRingHom.map_adjugate _
 
+open Int in
 theorem det_adjugate (A : Matrix n n α) : (adjugate A).det = A.det ^ (Fintype.card n - 1) := by
   -- get rid of the `- 1`
   rcases (Fintype.card n).eq_zero_or_pos with h_card | h_card
@@ -481,6 +482,7 @@ theorem det_smul_adjugate_adjugate (A : Matrix n n α) :
   rwa [← Matrix.mul_assoc, mul_adjugate, Matrix.mul_smul, Matrix.mul_one, Matrix.smul_mul,
     Matrix.one_mul] at this
 
+open Int in
 /-- Note that this is not true for `Fintype.card n = 1` since `1 - 2 = 0` and not `-1`. -/
 theorem adjugate_adjugate (A : Matrix n n α) (h : Fintype.card n ≠ 1) :
     adjugate (adjugate A) = det A ^ (Fintype.card n - 2) • A := by

--- a/Mathlib/LinearAlgebra/QuadraticForm/Basic.lean
+++ b/Mathlib/LinearAlgebra/QuadraticForm/Basic.lean
@@ -877,13 +877,13 @@ theorem associated_rightInverse :
     Function.RightInverse (associatedHom S) (BilinMap.toQuadraticMap : _ → QuadraticMap R M R) :=
   fun Q => toQuadraticMap_associated S Q
 
-open Int in
+open scoped Int in
 /-- `associated'` is the `ℤ`-linear map that sends a quadratic form on a module `M` over `R` to its
 associated symmetric bilinear form. -/
 abbrev associated' : QuadraticMap R M R →ₗ[ℤ] BilinMap R M R :=
   associatedHom ℤ
 
-open Nat in
+open scoped Nat in
 /-- Symmetric bilinear forms can be lifted to quadratic forms -/
 instance canLift :
     CanLift (BilinMap R M R) (QuadraticForm R M) (associatedHom ℕ) LinearMap.IsSymm where
@@ -1022,7 +1022,7 @@ section Ring
 
 variable [CommRing R] [AddCommGroup M] [Module R M]
 
-open Int in
+open scoped Int in
 /-- The associated bilinear form of an anisotropic quadratic form is nondegenerate. -/
 theorem separatingLeft_of_anisotropic [Invertible (2 : R)] (Q : QuadraticMap R M R)
     (hB : Q.Anisotropic) :
@@ -1175,7 +1175,7 @@ end Semiring
 
 variable [CommRing R] [AddCommGroup M] [Module R M]
 
-open Nat in
+open scoped Nat in
 /-- There exists a non-null vector with respect to any symmetric, nonzero bilinear form `B`
 on a module `M` over a ring `R` with invertible `2`, i.e. there exists some
 `x : M` such that `B x x ≠ 0`. -/

--- a/Mathlib/LinearAlgebra/QuadraticForm/Basic.lean
+++ b/Mathlib/LinearAlgebra/QuadraticForm/Basic.lean
@@ -877,11 +877,13 @@ theorem associated_rightInverse :
     Function.RightInverse (associatedHom S) (BilinMap.toQuadraticMap : _ → QuadraticMap R M R) :=
   fun Q => toQuadraticMap_associated S Q
 
+open Int in
 /-- `associated'` is the `ℤ`-linear map that sends a quadratic form on a module `M` over `R` to its
 associated symmetric bilinear form. -/
 abbrev associated' : QuadraticMap R M R →ₗ[ℤ] BilinMap R M R :=
   associatedHom ℤ
 
+open Nat in
 /-- Symmetric bilinear forms can be lifted to quadratic forms -/
 instance canLift :
     CanLift (BilinMap R M R) (QuadraticForm R M) (associatedHom ℕ) LinearMap.IsSymm where
@@ -1020,6 +1022,7 @@ section Ring
 
 variable [CommRing R] [AddCommGroup M] [Module R M]
 
+open Int in
 /-- The associated bilinear form of an anisotropic quadratic form is nondegenerate. -/
 theorem separatingLeft_of_anisotropic [Invertible (2 : R)] (Q : QuadraticMap R M R)
     (hB : Q.Anisotropic) :
@@ -1172,6 +1175,7 @@ end Semiring
 
 variable [CommRing R] [AddCommGroup M] [Module R M]
 
+open Nat in
 /-- There exists a non-null vector with respect to any symmetric, nonzero bilinear form `B`
 on a module `M` over a ring `R` with invertible `2`, i.e. there exists some
 `x : M` such that `B x x ≠ 0`. -/

--- a/Mathlib/LinearAlgebra/TensorAlgebra/Basic.lean
+++ b/Mathlib/LinearAlgebra/TensorAlgebra/Basic.lean
@@ -71,9 +71,10 @@ instance instAlgebra {R A M} [CommSemiring R] [AddCommMonoid M] [CommSemiring A]
     Algebra R (TensorAlgebra A M) :=
   RingQuot.instAlgebra _
 
+open Nat in
 -- verify there is no diamond
 -- but doesn't work at `reducible_and_instances` #10906
-example : (algebraNat : Algebra ℕ (TensorAlgebra R M)) = instAlgebra := rfl
+example : (Nat.instAlgebraOfSemiring : Algebra ℕ (TensorAlgebra R M)) = instAlgebra := rfl
 
 instance {R S A M} [CommSemiring R] [CommSemiring S] [AddCommMonoid M] [CommSemiring A]
     [Algebra R A] [Algebra S A] [Module R M] [Module S M] [Module A M]
@@ -92,10 +93,11 @@ namespace TensorAlgebra
 instance {S : Type*} [CommRing S] [Module S M] : Ring (TensorAlgebra S M) :=
   RingQuot.instRing (Rel S M)
 
+open Int in
 -- verify there is no diamond
 -- but doesn't work at `reducible_and_instances` #10906
 variable (S M : Type) [CommRing S] [AddCommGroup M] [Module S M] in
-example : (algebraInt _ : Algebra ℤ (TensorAlgebra S M)) = instAlgebra := rfl
+example : (Int.instAlgebraOfRing _ : Algebra ℤ (TensorAlgebra S M)) = instAlgebra := rfl
 
 variable {M}
 

--- a/Mathlib/LinearAlgebra/TensorAlgebra/Basic.lean
+++ b/Mathlib/LinearAlgebra/TensorAlgebra/Basic.lean
@@ -71,7 +71,7 @@ instance instAlgebra {R A M} [CommSemiring R] [AddCommMonoid M] [CommSemiring A]
     Algebra R (TensorAlgebra A M) :=
   RingQuot.instAlgebra _
 
-open Nat in
+open scoped Nat in
 -- verify there is no diamond
 -- but doesn't work at `reducible_and_instances` #10906
 example : (Nat.instAlgebraOfSemiring : Algebra ℕ (TensorAlgebra R M)) = instAlgebra := rfl
@@ -93,7 +93,7 @@ namespace TensorAlgebra
 instance {S : Type*} [CommRing S] [Module S M] : Ring (TensorAlgebra S M) :=
   RingQuot.instRing (Rel S M)
 
-open Int in
+open scoped Int in
 -- verify there is no diamond
 -- but doesn't work at `reducible_and_instances` #10906
 variable (S M : Type) [CommRing S] [AddCommGroup M] [Module S M] in

--- a/Mathlib/NumberTheory/ClassNumber/AdmissibleCardPowDegree.lean
+++ b/Mathlib/NumberTheory/ClassNumber/AdmissibleCardPowDegree.lean
@@ -96,7 +96,7 @@ theorem exists_approx_polynomial_aux [Ring Fq] {d : ℕ} {m : ℕ} (hm : Fintype
 
 variable [Field Fq]
 
-open Int in
+open scoped Int in
 /-- If `A` is a family of enough low-degree polynomials over a finite field,
 there is a pair of elements in `A` (with different indices but not necessarily
 distinct), such that the difference of their remainders is close together. -/
@@ -167,7 +167,7 @@ theorem cardPowDegree_anti_archimedean {x y z : Fq[X]} {a : ℤ} (hxy : cardPowD
   convert degree_add_le (x - y) (y - z) using 2
   exact (sub_add_sub_cancel _ _ _).symm
 
-open Int in
+open scoped Int in
 /-- A slightly stronger version of `exists_partition` on which we perform induction on `n`:
 for all `ε > 0`, we can partition the remainders of any family of polynomials `A`
 into equivalence classes, where the equivalence(!) relation is "closer than `ε`". -/

--- a/Mathlib/NumberTheory/ClassNumber/AdmissibleCardPowDegree.lean
+++ b/Mathlib/NumberTheory/ClassNumber/AdmissibleCardPowDegree.lean
@@ -96,6 +96,7 @@ theorem exists_approx_polynomial_aux [Ring Fq] {d : ℕ} {m : ℕ} (hm : Fintype
 
 variable [Field Fq]
 
+open Int in
 /-- If `A` is a family of enough low-degree polynomials over a finite field,
 there is a pair of elements in `A` (with different indices but not necessarily
 distinct), such that the difference of their remainders is close together. -/
@@ -166,6 +167,7 @@ theorem cardPowDegree_anti_archimedean {x y z : Fq[X]} {a : ℤ} (hxy : cardPowD
   convert degree_add_le (x - y) (y - z) using 2
   exact (sub_add_sub_cancel _ _ _).symm
 
+open Int in
 /-- A slightly stronger version of `exists_partition` on which we perform induction on `n`:
 for all `ε > 0`, we can partition the remainders of any family of polynomials `A`
 into equivalence classes, where the equivalence(!) relation is "closer than `ε`". -/

--- a/Mathlib/NumberTheory/ClassNumber/Finite.lean
+++ b/Mathlib/NumberTheory/ClassNumber/Finite.lean
@@ -181,6 +181,7 @@ open Real
 
 attribute [-instance] Real.decidableEq
 
+open Int in
 /-- We can approximate `a / b : L` with `q / r`, where `r` has finitely many options for `L`. -/
 theorem exists_mem_finsetApprox (a : S) {b} (hb : b ≠ (0 : R)) :
     ∃ q : S,

--- a/Mathlib/NumberTheory/ClassNumber/Finite.lean
+++ b/Mathlib/NumberTheory/ClassNumber/Finite.lean
@@ -181,7 +181,7 @@ open Real
 
 attribute [-instance] Real.decidableEq
 
-open Int in
+open scoped Int in
 /-- We can approximate `a / b : L` with `q / r`, where `r` has finitely many options for `L`. -/
 theorem exists_mem_finsetApprox (a : S) {b} (hb : b ≠ (0 : R)) :
     ∃ q : S,

--- a/Mathlib/NumberTheory/Cyclotomic/Basic.lean
+++ b/Mathlib/NumberTheory/Cyclotomic/Basic.lean
@@ -531,8 +531,9 @@ section CyclotomicRing
 instance CyclotomicField.algebraBase : Algebra A (CyclotomicField n K) :=
   SplittingField.algebra' (cyclotomic n K)
 
+open Int in
 /-- Ensure there are no diamonds when `A = ℤ` but there are `reducible_and_instances` #10906 -/
-example : algebraInt (CyclotomicField n ℚ) = CyclotomicField.algebraBase _ _ _ := rfl
+example : Int.instAlgebraOfRing (CyclotomicField n ℚ) = CyclotomicField.algebraBase _ _ _ := rfl
 
 instance CyclotomicField.algebra' {R : Type*} [CommRing R] [Algebra R K] :
     Algebra R (CyclotomicField n K) :=
@@ -574,9 +575,10 @@ instance : Inhabited (CyclotomicRing n A K) := by
 instance algebraBase : Algebra A (CyclotomicRing n A K) :=
   (adjoin A _).algebra
 
+open Int in
 -- Ensure that there is no diamonds with ℤ.
 -- but there is at `reducible_and_instances` #10906
-example {n : ℕ+} : CyclotomicRing.algebraBase n ℤ ℚ = algebraInt _ := rfl
+example {n : ℕ+} : CyclotomicRing.algebraBase n ℤ ℚ = Int.instAlgebraOfRing _ := rfl
 
 instance : NoZeroSMulDivisors A (CyclotomicRing n A K) :=
   (adjoin A _).noZeroSMulDivisors_bot

--- a/Mathlib/NumberTheory/Cyclotomic/Basic.lean
+++ b/Mathlib/NumberTheory/Cyclotomic/Basic.lean
@@ -531,7 +531,7 @@ section CyclotomicRing
 instance CyclotomicField.algebraBase : Algebra A (CyclotomicField n K) :=
   SplittingField.algebra' (cyclotomic n K)
 
-open Int in
+open scoped Int in
 /-- Ensure there are no diamonds when `A = ℤ` but there are `reducible_and_instances` #10906 -/
 example : Int.instAlgebraOfRing (CyclotomicField n ℚ) = CyclotomicField.algebraBase _ _ _ := rfl
 
@@ -575,7 +575,7 @@ instance : Inhabited (CyclotomicRing n A K) := by
 instance algebraBase : Algebra A (CyclotomicRing n A K) :=
   (adjoin A _).algebra
 
-open Int in
+open scoped Int in
 -- Ensure that there is no diamonds with ℤ.
 -- but there is at `reducible_and_instances` #10906
 example {n : ℕ+} : CyclotomicRing.algebraBase n ℤ ℚ = Int.instAlgebraOfRing _ := rfl

--- a/Mathlib/NumberTheory/Cyclotomic/Discriminant.lean
+++ b/Mathlib/NumberTheory/Cyclotomic/Discriminant.lean
@@ -23,7 +23,7 @@ universe u v
 
 open Algebra Polynomial Nat IsPrimitiveRoot PowerBasis
 
-open scoped Polynomial Cyclotomic
+open scoped Int Polynomial Cyclotomic
 
 namespace IsPrimitiveRoot
 

--- a/Mathlib/NumberTheory/Cyclotomic/Rat.lean
+++ b/Mathlib/NumberTheory/Cyclotomic/Rat.lean
@@ -26,7 +26,7 @@ universe u
 
 open Algebra IsCyclotomicExtension Polynomial NumberField
 
-open scoped Cyclotomic Nat
+open scoped Cyclotomic Int Nat
 
 variable {p : ℕ+} {k : ℕ} {K : Type u} [Field K] [CharZero K] {ζ : K} [hp : Fact (p : ℕ).Prime]
 

--- a/Mathlib/NumberTheory/FLT/Three.lean
+++ b/Mathlib/NumberTheory/FLT/Three.lean
@@ -159,6 +159,7 @@ def FermatLastTheoremForThreeGen : Prop :=
   ∀ a b c : 𝓞 K, ∀ u : (𝓞 K)ˣ, c ≠ 0 → ¬ λ ∣ a → ¬ λ ∣ b  → λ ∣ c → IsCoprime a b →
     a ^ 3 + b ^ 3 ≠ u * c ^ 3
 
+open scoped Int in
 /-- To prove `FermatLastTheoremFor 3`, it is enough to prove `FermatLastTheoremForThreeGen`. -/
 lemma FermatLastTheoremForThree_of_FermatLastTheoremThreeGen :
     FermatLastTheoremForThreeGen hζ → FermatLastTheoremFor 3 := by

--- a/Mathlib/NumberTheory/LegendreSymbol/QuadraticChar/GaussSum.lean
+++ b/Mathlib/NumberTheory/LegendreSymbol/QuadraticChar/GaussSum.lean
@@ -67,6 +67,7 @@ theorem FiniteField.isSquare_neg_two_iff :
       quadraticChar_neg_two hF, χ₈'_nat_eq_if_mod_eight]
     omega
 
+open Int in
 /-- The relation between the values of the quadratic character of one field `F` at the
 cardinality of another field `F'` and of the quadratic character of `F'` at the cardinality
 of `F`. -/

--- a/Mathlib/NumberTheory/LegendreSymbol/QuadraticChar/GaussSum.lean
+++ b/Mathlib/NumberTheory/LegendreSymbol/QuadraticChar/GaussSum.lean
@@ -67,7 +67,7 @@ theorem FiniteField.isSquare_neg_two_iff :
       quadraticChar_neg_two hF, χ₈'_nat_eq_if_mod_eight]
     omega
 
-open Int in
+open scoped Int in
 /-- The relation between the values of the quadratic character of one field `F` at the
 cardinality of another field `F'` and of the quadratic character of `F'` at the cardinality
 of `F`. -/

--- a/Mathlib/NumberTheory/Liouville/Basic.lean
+++ b/Mathlib/NumberTheory/Liouville/Basic.lean
@@ -115,7 +115,7 @@ theorem exists_one_le_pow_mul_dist {Z N R : Type*} [PseudoMetricSpace R] {d : N 
     refine mul_le_mul_of_nonneg_left ((B this).trans ?_) (zero_le_one.trans (d0 a))
     exact mul_le_mul_of_nonneg_left (le_max_right _ M) dist_nonneg
 
-open Int in
+open scoped Int in
 theorem exists_pos_real_of_irrational_root {α : ℝ} (ha : Irrational α) {f : ℤ[X]} (f0 : f ≠ 0)
     (fa : eval α (map (algebraMap ℤ ℝ) f) = 0) :
     ∃ A : ℝ, 0 < A ∧ ∀ a : ℤ, ∀ b : ℕ,
@@ -168,7 +168,7 @@ theorem exists_pos_real_of_irrational_root {α : ℝ} (ha : Irrational α) {f : 
     refine ⟨hq, Finset.mem_coe.mp (Multiset.mem_toFinset.mpr ?_)⟩
     exact (mem_roots fR0).mpr (IsRoot.def.mpr hy)
 
-open Int in
+open scoped Int in
 /-- **Liouville's Theorem** -/
 protected theorem transcendental {x : ℝ} (lx : Liouville x) : Transcendental ℤ x := by
   -- Proceed by contradiction: if `x` is algebraic, then `x` is the root (`ef0`) of a

--- a/Mathlib/NumberTheory/Liouville/Basic.lean
+++ b/Mathlib/NumberTheory/Liouville/Basic.lean
@@ -115,6 +115,7 @@ theorem exists_one_le_pow_mul_dist {Z N R : Type*} [PseudoMetricSpace R] {d : N 
     refine mul_le_mul_of_nonneg_left ((B this).trans ?_) (zero_le_one.trans (d0 a))
     exact mul_le_mul_of_nonneg_left (le_max_right _ M) dist_nonneg
 
+open Int in
 theorem exists_pos_real_of_irrational_root {α : ℝ} (ha : Irrational α) {f : ℤ[X]} (f0 : f ≠ 0)
     (fa : eval α (map (algebraMap ℤ ℝ) f) = 0) :
     ∃ A : ℝ, 0 < A ∧ ∀ a : ℤ, ∀ b : ℕ,
@@ -167,6 +168,7 @@ theorem exists_pos_real_of_irrational_root {α : ℝ} (ha : Irrational α) {f : 
     refine ⟨hq, Finset.mem_coe.mp (Multiset.mem_toFinset.mpr ?_)⟩
     exact (mem_roots fR0).mpr (IsRoot.def.mpr hy)
 
+open Int in
 /-- **Liouville's Theorem** -/
 protected theorem transcendental {x : ℝ} (lx : Liouville x) : Transcendental ℤ x := by
   -- Proceed by contradiction: if `x` is algebraic, then `x` is the root (`ef0`) of a

--- a/Mathlib/NumberTheory/Liouville/LiouvilleNumber.lean
+++ b/Mathlib/NumberTheory/Liouville/LiouvilleNumber.lean
@@ -191,6 +191,7 @@ theorem liouville_liouvilleNumber {m : ℕ} (hm : 2 ≤ m) : Liouville (liouvill
   have hpos := remainder_pos m1 n
   simpa [abs_of_pos hpos, hpos.ne'] using @remainder_lt n m (by assumption_mod_cast)
 
+open Int in
 theorem transcendental_liouvilleNumber {m : ℕ} (hm : 2 ≤ m) :
     Transcendental ℤ (liouvilleNumber m) :=
   (liouville_liouvilleNumber hm).transcendental

--- a/Mathlib/NumberTheory/Liouville/LiouvilleNumber.lean
+++ b/Mathlib/NumberTheory/Liouville/LiouvilleNumber.lean
@@ -191,7 +191,7 @@ theorem liouville_liouvilleNumber {m : ℕ} (hm : 2 ≤ m) : Liouville (liouvill
   have hpos := remainder_pos m1 n
   simpa [abs_of_pos hpos, hpos.ne'] using @remainder_lt n m (by assumption_mod_cast)
 
-open Int in
+open scoped Int in
 theorem transcendental_liouvilleNumber {m : ℕ} (hm : 2 ≤ m) :
     Transcendental ℤ (liouvilleNumber m) :=
   (liouville_liouvilleNumber hm).transcendental

--- a/Mathlib/NumberTheory/Modular.lean
+++ b/Mathlib/NumberTheory/Modular.lean
@@ -227,6 +227,8 @@ theorem tendsto_lcRow0 {cd : Fin 2 → ℤ} (hcd : IsCoprime (cd 0) (cd 1)) :
     ring
   · rfl
 
+open Int
+
 /-- This replaces `(g•z).re = a/c + *` in the standard theory with the following novel identity:
   `g • z = (a c + b d) / (c^2 + d^2) + (d z - c) / ((c^2 + d^2) (c z + d))`
   which does not need to be decomposed depending on whether `c = 0`. -/
@@ -269,6 +271,7 @@ end TendstoLemmas
 
 section FundamentalDomain
 
+open Int
 
 attribute [local simp] UpperHalfPlane.coe_smul re_smul
 

--- a/Mathlib/NumberTheory/Modular.lean
+++ b/Mathlib/NumberTheory/Modular.lean
@@ -227,7 +227,7 @@ theorem tendsto_lcRow0 {cd : Fin 2 → ℤ} (hcd : IsCoprime (cd 0) (cd 1)) :
     ring
   · rfl
 
-open Int
+open scoped Int
 
 /-- This replaces `(g•z).re = a/c + *` in the standard theory with the following novel identity:
   `g • z = (a c + b d) / (c^2 + d^2) + (d z - c) / ((c^2 + d^2) (c z + d))`
@@ -271,7 +271,7 @@ end TendstoLemmas
 
 section FundamentalDomain
 
-open Int
+open scoped Int
 
 attribute [local simp] UpperHalfPlane.coe_smul re_smul
 

--- a/Mathlib/NumberTheory/ModularForms/EisensteinSeries/Defs.lean
+++ b/Mathlib/NumberTheory/ModularForms/EisensteinSeries/Defs.lean
@@ -88,6 +88,7 @@ section eisSummand
 /-- The function on `(Fin 2 → ℤ)` whose sum defines an Eisenstein series. -/
 def eisSummand (k : ℤ) (v : Fin 2 → ℤ) (z : ℍ) : ℂ := (v 0 * z.1 + v 1) ^ (-k)
 
+open Int in
 /-- How the `eisSummand` function changes under the Moebius action. -/
 theorem eisSummand_SL2_apply (k : ℤ) (i : (Fin 2 → ℤ)) (A : SL(2, ℤ)) (z : ℍ) :
     eisSummand k i (A • z) = (z.denom A) ^ k * eisSummand k (i ᵥ* A) z := by

--- a/Mathlib/NumberTheory/ModularForms/EisensteinSeries/Defs.lean
+++ b/Mathlib/NumberTheory/ModularForms/EisensteinSeries/Defs.lean
@@ -88,7 +88,7 @@ section eisSummand
 /-- The function on `(Fin 2 → ℤ)` whose sum defines an Eisenstein series. -/
 def eisSummand (k : ℤ) (v : Fin 2 → ℤ) (z : ℍ) : ℂ := (v 0 * z.1 + v 1) ^ (-k)
 
-open Int in
+open scoped Int in
 /-- How the `eisSummand` function changes under the Moebius action. -/
 theorem eisSummand_SL2_apply (k : ℤ) (i : (Fin 2 → ℤ)) (A : SL(2, ℤ)) (z : ℍ) :
     eisSummand k i (A • z) = (z.denom A) ^ k * eisSummand k (i ᵥ* A) z := by

--- a/Mathlib/NumberTheory/ModularForms/Identities.lean
+++ b/Mathlib/NumberTheory/ModularForms/Identities.lean
@@ -31,7 +31,7 @@ theorem vAdd_width_periodic (N : ℕ) (k n : ℤ) (f : SlashInvariantForm (Gamma
     empty_val', cons_val_fin_one, cons_val_one, head_fin_const, Int.cast_zero, zero_mul, head_cons,
     Int.cast_one, zero_add, one_zpow, one_mul]
 
-open Int in
+open scoped Int in
 theorem T_zpow_width_invariant (N : ℕ) (k n : ℤ) (f : SlashInvariantForm (Gamma N) k) (z : ℍ) :
     f (((ModularGroup.T ^ (N * n))) • z) = f z := by
   rw [modular_T_zpow_smul z (N * n)]

--- a/Mathlib/NumberTheory/ModularForms/Identities.lean
+++ b/Mathlib/NumberTheory/ModularForms/Identities.lean
@@ -31,6 +31,7 @@ theorem vAdd_width_periodic (N : ℕ) (k n : ℤ) (f : SlashInvariantForm (Gamma
     empty_val', cons_val_fin_one, cons_val_one, head_fin_const, Int.cast_zero, zero_mul, head_cons,
     Int.cast_one, zero_add, one_zpow, one_mul]
 
+open Int in
 theorem T_zpow_width_invariant (N : ℕ) (k n : ℤ) (f : SlashInvariantForm (Gamma N) k) (z : ℍ) :
     f (((ModularGroup.T ^ (N * n))) • z) = f z := by
   rw [modular_T_zpow_smul z (N * n)]

--- a/Mathlib/NumberTheory/ModularForms/JacobiTheta/OneVariable.lean
+++ b/Mathlib/NumberTheory/ModularForms/JacobiTheta/OneVariable.lean
@@ -30,12 +30,14 @@ lemma jacobiTheta_eq_jacobiTheta₂ (τ : ℂ) : jacobiTheta τ = jacobiTheta₂
 theorem jacobiTheta_two_add (τ : ℂ) : jacobiTheta (2 + τ) = jacobiTheta τ := by
   simp_rw [jacobiTheta_eq_jacobiTheta₂, add_comm, jacobiTheta₂_add_right]
 
+open Int in
 theorem jacobiTheta_T_sq_smul (τ : ℍ) : jacobiTheta (ModularGroup.T ^ 2 • τ :) = jacobiTheta τ := by
   suffices (ModularGroup.T ^ 2 • τ :) = (2 : ℂ) + ↑τ by simp_rw [this, jacobiTheta_two_add]
   have : ModularGroup.T ^ (2 : ℕ) = ModularGroup.T ^ (2 : ℤ) := rfl
   simp_rw [this, UpperHalfPlane.modular_T_zpow_smul, UpperHalfPlane.coe_vadd]
   norm_cast
 
+open Int in
 theorem jacobiTheta_S_smul (τ : ℍ) :
     jacobiTheta ↑(ModularGroup.S • τ) = (-I * τ) ^ (1 / 2 : ℂ) * jacobiTheta τ := by
   have h0 : (τ : ℂ) ≠ 0 := ne_of_apply_ne im (zero_im.symm ▸ ne_of_gt τ.2)

--- a/Mathlib/NumberTheory/ModularForms/JacobiTheta/OneVariable.lean
+++ b/Mathlib/NumberTheory/ModularForms/JacobiTheta/OneVariable.lean
@@ -30,14 +30,14 @@ lemma jacobiTheta_eq_jacobiTheta₂ (τ : ℂ) : jacobiTheta τ = jacobiTheta₂
 theorem jacobiTheta_two_add (τ : ℂ) : jacobiTheta (2 + τ) = jacobiTheta τ := by
   simp_rw [jacobiTheta_eq_jacobiTheta₂, add_comm, jacobiTheta₂_add_right]
 
-open Int in
+open scoped Int in
 theorem jacobiTheta_T_sq_smul (τ : ℍ) : jacobiTheta (ModularGroup.T ^ 2 • τ :) = jacobiTheta τ := by
   suffices (ModularGroup.T ^ 2 • τ :) = (2 : ℂ) + ↑τ by simp_rw [this, jacobiTheta_two_add]
   have : ModularGroup.T ^ (2 : ℕ) = ModularGroup.T ^ (2 : ℤ) := rfl
   simp_rw [this, UpperHalfPlane.modular_T_zpow_smul, UpperHalfPlane.coe_vadd]
   norm_cast
 
-open Int in
+open scoped Int in
 theorem jacobiTheta_S_smul (τ : ℍ) :
     jacobiTheta ↑(ModularGroup.S • τ) = (-I * τ) ^ (1 / 2 : ℂ) * jacobiTheta τ := by
   have h0 : (τ : ℂ) ≠ 0 := ne_of_apply_ne im (zero_im.symm ▸ ne_of_gt τ.2)

--- a/Mathlib/NumberTheory/ModularForms/SlashActions.lean
+++ b/Mathlib/NumberTheory/ModularForms/SlashActions.lean
@@ -179,6 +179,7 @@ theorem is_invariant_const (A : SL(2, ℤ)) (x : ℂ) :
 theorem is_invariant_one (A : SL(2, ℤ)) : (1 : ℍ → ℂ) ∣[(0 : ℤ)] A = (1 : ℍ → ℂ) :=
   is_invariant_const _ _
 
+open Int in
 /-- A function `f : ℍ → ℂ` is slash-invariant, of weight `k ∈ ℤ` and level `Γ`,
   if for every matrix `γ ∈ Γ` we have `f(γ • z)= (c*z+d)^k f(z)` where `γ= ![![a, b], ![c, d]]`,
   and it acts on `ℍ` via Möbius transformations. -/

--- a/Mathlib/NumberTheory/ModularForms/SlashActions.lean
+++ b/Mathlib/NumberTheory/ModularForms/SlashActions.lean
@@ -179,7 +179,7 @@ theorem is_invariant_const (A : SL(2, ℤ)) (x : ℂ) :
 theorem is_invariant_one (A : SL(2, ℤ)) : (1 : ℍ → ℂ) ∣[(0 : ℤ)] A = (1 : ℍ → ℂ) :=
   is_invariant_const _ _
 
-open Int in
+open scoped Int in
 /-- A function `f : ℍ → ℂ` is slash-invariant, of weight `k ∈ ℤ` and level `Γ`,
   if for every matrix `γ ∈ Γ` we have `f(γ • z)= (c*z+d)^k f(z)` where `γ= ![![a, b], ![c, d]]`,
   and it acts on `ℍ` via Möbius transformations. -/

--- a/Mathlib/NumberTheory/ModularForms/SlashInvariantForms.lean
+++ b/Mathlib/NumberTheory/ModularForms/SlashInvariantForms.lean
@@ -88,6 +88,7 @@ theorem slash_action_eqn [SlashInvariantFormClass F Γ k] (f : F) (γ : Γ) :
     ↑f ∣[k] γ = ⇑f :=
   SlashInvariantFormClass.slash_action_eq f γ
 
+open Int in
 theorem slash_action_eqn' (k : ℤ) (Γ : Subgroup SL(2, ℤ)) [SlashInvariantFormClass F Γ k] (f : F)
     (γ : Γ) (z : ℍ) : f (γ • z) = ((↑ₘ[ℤ] γ 1 0 : ℂ) * z + (↑ₘ[ℤ] γ 1 1 : ℂ)) ^ k * f z := by
   rw [← ModularForm.slash_action_eq'_iff, slash_action_eqn]

--- a/Mathlib/NumberTheory/ModularForms/SlashInvariantForms.lean
+++ b/Mathlib/NumberTheory/ModularForms/SlashInvariantForms.lean
@@ -88,7 +88,7 @@ theorem slash_action_eqn [SlashInvariantFormClass F Γ k] (f : F) (γ : Γ) :
     ↑f ∣[k] γ = ⇑f :=
   SlashInvariantFormClass.slash_action_eq f γ
 
-open Int in
+open scoped Int in
 theorem slash_action_eqn' (k : ℤ) (Γ : Subgroup SL(2, ℤ)) [SlashInvariantFormClass F Γ k] (f : F)
     (γ : Γ) (z : ℍ) : f (γ • z) = ((↑ₘ[ℤ] γ 1 0 : ℂ) * z + (↑ₘ[ℤ] γ 1 1 : ℂ)) ^ k * f z := by
   rw [← ModularForm.slash_action_eq'_iff, slash_action_eqn]

--- a/Mathlib/NumberTheory/MulChar/Lemmas.lean
+++ b/Mathlib/NumberTheory/MulChar/Lemmas.lean
@@ -195,7 +195,7 @@ lemma exists_apply_eq_pow {χ : MulChar F R} {n : ℕ} (hn : n ≠ 0) (hχ : χ 
   obtain ⟨k, hk₁, hk₂⟩ := hμ.eq_pow_of_pow_eq_one hζ' hn'
   exact ⟨k, hk₁, (hζ₂ ▸ hk₂).symm⟩
 
-open Int in
+open scoped Int in
 /-- The values of a multiplicative character `χ` such that `χ^n = 1` are contained in `ℤ[μ]` when
 `μ` is a primitive `n`th root of unity. -/
 lemma apply_mem_algebraAdjoin_of_pow_eq_one {χ : MulChar F R} {n : ℕ} (hn : n ≠ 0) (hχ : χ ^ n = 1)
@@ -208,7 +208,7 @@ lemma apply_mem_algebraAdjoin_of_pow_eq_one {χ : MulChar F R} {n : ℕ} (hn : n
     obtain ⟨k, _, hk⟩ := IsPrimitiveRoot.eq_pow_of_pow_eq_one hμ hζ₁ (Nat.pos_of_ne_zero hn)
     exact hζ₂ ▸ hk ▸ Subalgebra.pow_mem _ (Algebra.self_mem_adjoin_singleton ℤ μ) k
 
-open Int in
+open scoped Int in
 /-- The values of a multiplicative character of order `n` are contained in `ℤ[μ]` when
 `μ` is a primitive `n`th root of unity. -/
 lemma apply_mem_algebraAdjoin {χ : MulChar F R} {μ : R} (hμ : IsPrimitiveRoot μ (orderOf χ))

--- a/Mathlib/NumberTheory/MulChar/Lemmas.lean
+++ b/Mathlib/NumberTheory/MulChar/Lemmas.lean
@@ -195,6 +195,7 @@ lemma exists_apply_eq_pow {χ : MulChar F R} {n : ℕ} (hn : n ≠ 0) (hχ : χ 
   obtain ⟨k, hk₁, hk₂⟩ := hμ.eq_pow_of_pow_eq_one hζ' hn'
   exact ⟨k, hk₁, (hζ₂ ▸ hk₂).symm⟩
 
+open Int in
 /-- The values of a multiplicative character `χ` such that `χ^n = 1` are contained in `ℤ[μ]` when
 `μ` is a primitive `n`th root of unity. -/
 lemma apply_mem_algebraAdjoin_of_pow_eq_one {χ : MulChar F R} {n : ℕ} (hn : n ≠ 0) (hχ : χ ^ n = 1)
@@ -207,6 +208,7 @@ lemma apply_mem_algebraAdjoin_of_pow_eq_one {χ : MulChar F R} {n : ℕ} (hn : n
     obtain ⟨k, _, hk⟩ := IsPrimitiveRoot.eq_pow_of_pow_eq_one hμ hζ₁ (Nat.pos_of_ne_zero hn)
     exact hζ₂ ▸ hk ▸ Subalgebra.pow_mem _ (Algebra.self_mem_adjoin_singleton ℤ μ) k
 
+open Int in
 /-- The values of a multiplicative character of order `n` are contained in `ℤ[μ]` when
 `μ` is a primitive `n`th root of unity. -/
 lemma apply_mem_algebraAdjoin {χ : MulChar F R} {μ : R} (hμ : IsPrimitiveRoot μ (orderOf χ))

--- a/Mathlib/NumberTheory/NumberField/Basic.lean
+++ b/Mathlib/NumberTheory/NumberField/Basic.lean
@@ -39,7 +39,7 @@ class NumberField (K : Type*) [Field K] : Prop where
 
 open Function Module
 
-open scoped Classical nonZeroDivisors
+open scoped Int Classical nonZeroDivisors
 
 /-- `ℤ` with its usual ring structure is not a field. -/
 theorem Int.not_isField : ¬IsField ℤ := fun h =>

--- a/Mathlib/NumberTheory/NumberField/CanonicalEmbedding/Basic.lean
+++ b/Mathlib/NumberTheory/NumberField/CanonicalEmbedding/Basic.lean
@@ -139,7 +139,7 @@ theorem latticeBasis_apply [NumberField K] (i : Free.ChooseBasisIndex ℤ (𝓞 
   simp only [latticeBasis, integralBasis_apply, coe_basisOfLinearIndependentOfCardEqFinrank,
     Function.comp_apply, Equiv.apply_symm_apply]
 
-open Int in
+open scoped Int in
 theorem mem_span_latticeBasis [NumberField K] (x : (K →+* ℂ) → ℂ) :
     x ∈ Submodule.span ℤ (Set.range (latticeBasis K)) ↔
       x ∈ ((canonicalEmbedding K).comp (algebraMap (𝓞 K) K)).range := by
@@ -572,7 +572,7 @@ theorem latticeBasis_apply (i : ChooseBasisIndex ℤ (𝓞 K)) :
   simp only [latticeBasis, coe_basisOfLinearIndependentOfCardEqFinrank, Function.comp_apply,
     canonicalEmbedding.latticeBasis_apply, integralBasis_apply, commMap_canonical_eq_mixed]
 
-open Int in
+open scoped Int in
 theorem mem_span_latticeBasis (x : (E K)) :
     x ∈ Submodule.span ℤ (Set.range (latticeBasis K)) ↔
       x ∈ ((mixedEmbedding K).comp (algebraMap (𝓞 K) K)).range := by
@@ -652,7 +652,7 @@ theorem fractionalIdealLatticeBasis_apply (i : ChooseBasisIndex ℤ I) :
   simp only [fractionalIdealLatticeBasis, Basis.coe_reindex, Basis.coe_mk, Function.comp_apply,
     Equiv.apply_symm_apply]
 
-open Int in
+open scoped Int in
 theorem mem_span_fractionalIdealLatticeBasis (x : (E K)) :
     x ∈ Submodule.span ℤ (Set.range (fractionalIdealLatticeBasis K I)) ↔
       x ∈ mixedEmbedding K '' I := by

--- a/Mathlib/NumberTheory/NumberField/CanonicalEmbedding/Basic.lean
+++ b/Mathlib/NumberTheory/NumberField/CanonicalEmbedding/Basic.lean
@@ -139,6 +139,7 @@ theorem latticeBasis_apply [NumberField K] (i : Free.ChooseBasisIndex ℤ (𝓞 
   simp only [latticeBasis, integralBasis_apply, coe_basisOfLinearIndependentOfCardEqFinrank,
     Function.comp_apply, Equiv.apply_symm_apply]
 
+open Int in
 theorem mem_span_latticeBasis [NumberField K] (x : (K →+* ℂ) → ℂ) :
     x ∈ Submodule.span ℤ (Set.range (latticeBasis K)) ↔
       x ∈ ((canonicalEmbedding K).comp (algebraMap (𝓞 K) K)).range := by
@@ -571,6 +572,7 @@ theorem latticeBasis_apply (i : ChooseBasisIndex ℤ (𝓞 K)) :
   simp only [latticeBasis, coe_basisOfLinearIndependentOfCardEqFinrank, Function.comp_apply,
     canonicalEmbedding.latticeBasis_apply, integralBasis_apply, commMap_canonical_eq_mixed]
 
+open Int in
 theorem mem_span_latticeBasis (x : (E K)) :
     x ∈ Submodule.span ℤ (Set.range (latticeBasis K)) ↔
       x ∈ ((mixedEmbedding K).comp (algebraMap (𝓞 K) K)).range := by
@@ -650,6 +652,7 @@ theorem fractionalIdealLatticeBasis_apply (i : ChooseBasisIndex ℤ I) :
   simp only [fractionalIdealLatticeBasis, Basis.coe_reindex, Basis.coe_mk, Function.comp_apply,
     Equiv.apply_symm_apply]
 
+open Int in
 theorem mem_span_fractionalIdealLatticeBasis (x : (E K)) :
     x ∈ Submodule.span ℤ (Set.range (fractionalIdealLatticeBasis K I)) ↔
       x ∈ mixedEmbedding K '' I := by

--- a/Mathlib/NumberTheory/NumberField/ClassNumber.lean
+++ b/Mathlib/NumberTheory/NumberField/ClassNumber.lean
@@ -26,6 +26,7 @@ variable (K : Type*) [Field K] [NumberField K]
 
 namespace RingOfIntegers
 
+open scoped Int in
 noncomputable instance instFintypeClassGroup : Fintype (ClassGroup (𝓞 K)) :=
   ClassGroup.fintypeOfAdmissibleOfFinite ℚ K AbsoluteValue.absIsAdmissible
 

--- a/Mathlib/NumberTheory/NumberField/Discriminant.lean
+++ b/Mathlib/NumberTheory/NumberField/Discriminant.lean
@@ -33,7 +33,7 @@ namespace NumberField
 
 open FiniteDimensional NumberField NumberField.InfinitePlace Matrix
 
-open scoped Classical Real nonZeroDivisors
+open scoped Int Classical Real nonZeroDivisors
 
 variable (K : Type*) [Field K] [NumberField K]
 
@@ -438,6 +438,8 @@ namespace Rat
 
 open NumberField
 
+open scoped Int
+
 /-- The absolute discriminant of the number field `ℚ` is 1. -/
 @[simp]
 theorem numberField_discr : discr ℚ = 1 := by
@@ -460,6 +462,7 @@ end Rat
 
 variable {ι ι'} (K) [Field K] [DecidableEq ι] [DecidableEq ι'] [Fintype ι] [Fintype ι']
 
+open scoped Int in
 /-- If `b` and `b'` are `ℚ`-bases of a number field `K` such that
 `∀ i j, IsIntegral ℤ (b.toMatrix b' i j)` and `∀ i j, IsIntegral ℤ (b'.toMatrix b i j)` then
 `discr ℚ b = discr ℚ b'`. -/

--- a/Mathlib/NumberTheory/NumberField/Embeddings.lean
+++ b/Mathlib/NumberTheory/NumberField/Embeddings.lean
@@ -96,7 +96,7 @@ theorem coeff_bdd_of_norm_le {B : ℝ} {x : K} (h : ∀ φ : K →+* A, ‖φ x�
 
 variable (K A)
 
-open Int in
+open scoped Int in
 /-- Let `B` be a real number. The set of algebraic integers in `K` whose conjugates are all
 smaller in norm than `B` is finite. -/
 theorem finite_of_norm_le (B : ℝ) : {x : K | IsIntegral ℤ x ∧ ∀ φ : K →+* A, ‖φ x‖ ≤ B}.Finite := by
@@ -111,7 +111,7 @@ theorem finite_of_norm_le (B : ℝ) : {x : K | IsIntegral ℤ x ∧ ∀ φ : K �
   refine (Eq.trans_le ?_ <| coeff_bdd_of_norm_le hx.2 i).trans (Nat.le_ceil _)
   rw [h_map_ℚ_minpoly, coeff_map, eq_intCast, Int.norm_cast_rat, Int.norm_eq_abs, Int.cast_abs]
 
-open Int in
+open scoped Int in
 /-- An algebraic integer whose conjugates are all of norm one is a root of unity. -/
 theorem pow_eq_one_of_norm_eq_one {x : K} (hxi : IsIntegral ℤ x) (hx : ∀ φ : K →+* A, ‖φ x‖ = 1) :
     ∃ (n : ℕ) (_ : 0 < n), x ^ n = 1 := by
@@ -498,7 +498,7 @@ theorem prod_eq_abs_norm (x : K) :
     simp_rw [Finset.prod_congr rfl (this _), Finset.prod_const, card_filter_mk_eq]
   · rw [eq_ratCast, Rat.cast_abs, ← Complex.abs_ofReal, Complex.ofReal_ratCast]
 
-open Int in
+open scoped Int in
 theorem one_le_of_lt_one {w : InfinitePlace K} {a : (𝓞 K)} (ha : a ≠ 0)
     (h : ∀ ⦃z⦄, z ≠ w → z a < 1) : 1 ≤ w a := by
   suffices (1 : ℝ) ≤ |Algebra.norm ℚ (a : K)| by

--- a/Mathlib/NumberTheory/NumberField/Embeddings.lean
+++ b/Mathlib/NumberTheory/NumberField/Embeddings.lean
@@ -96,6 +96,7 @@ theorem coeff_bdd_of_norm_le {B : ℝ} {x : K} (h : ∀ φ : K →+* A, ‖φ x�
 
 variable (K A)
 
+open Int in
 /-- Let `B` be a real number. The set of algebraic integers in `K` whose conjugates are all
 smaller in norm than `B` is finite. -/
 theorem finite_of_norm_le (B : ℝ) : {x : K | IsIntegral ℤ x ∧ ∀ φ : K →+* A, ‖φ x‖ ≤ B}.Finite := by
@@ -110,6 +111,7 @@ theorem finite_of_norm_le (B : ℝ) : {x : K | IsIntegral ℤ x ∧ ∀ φ : K �
   refine (Eq.trans_le ?_ <| coeff_bdd_of_norm_le hx.2 i).trans (Nat.le_ceil _)
   rw [h_map_ℚ_minpoly, coeff_map, eq_intCast, Int.norm_cast_rat, Int.norm_eq_abs, Int.cast_abs]
 
+open Int in
 /-- An algebraic integer whose conjugates are all of norm one is a root of unity. -/
 theorem pow_eq_one_of_norm_eq_one {x : K} (hxi : IsIntegral ℤ x) (hx : ∀ φ : K →+* A, ‖φ x‖ = 1) :
     ∃ (n : ℕ) (_ : 0 < n), x ^ n = 1 := by
@@ -496,6 +498,7 @@ theorem prod_eq_abs_norm (x : K) :
     simp_rw [Finset.prod_congr rfl (this _), Finset.prod_const, card_filter_mk_eq]
   · rw [eq_ratCast, Rat.cast_abs, ← Complex.abs_ofReal, Complex.ofReal_ratCast]
 
+open Int in
 theorem one_le_of_lt_one {w : InfinitePlace K} {a : (𝓞 K)} (ha : a ≠ 0)
     (h : ∀ ⦃z⦄, z ≠ w → z a < 1) : 1 ≤ w a := by
   suffices (1 : ℝ) ≤ |Algebra.norm ℚ (a : K)| by

--- a/Mathlib/NumberTheory/NumberField/FractionalIdeal.lean
+++ b/Mathlib/NumberTheory/NumberField/FractionalIdeal.lean
@@ -26,7 +26,7 @@ variable (K : Type*) [Field K] [NumberField K]
 
 namespace NumberField
 
-open scoped nonZeroDivisors
+open scoped Int nonZeroDivisors
 
 section Basis
 

--- a/Mathlib/NumberTheory/NumberField/Norm.lean
+++ b/Mathlib/NumberTheory/NumberField/Norm.lean
@@ -26,7 +26,7 @@ open Finset NumberField Algebra FiniteDimensional
 
 section Rat
 
-open Int
+open scoped Int
 
 variable {K : Type*} [Field K] [NumberField K] (x : 𝓞 K)
 
@@ -42,7 +42,7 @@ namespace RingOfIntegers
 
 variable {L : Type*} (K : Type*) [Field K] [Field L] [Algebra K L] [FiniteDimensional K L]
 
-open Int in
+open scoped Int in
 /-- `Algebra.norm` as a morphism betwen the rings of integers. -/
 noncomputable def norm [Algebra.IsSeparable K L] : 𝓞 L →* 𝓞 K :=
   RingOfIntegers.restrict_monoidHom
@@ -66,7 +66,7 @@ theorem norm_algebraMap [Algebra.IsSeparable K L] (x : 𝓞 K) :
     RingOfIntegers.algebraMap_norm_algebraMap, Algebra.norm_algebraMap,
     RingOfIntegers.coe_eq_algebraMap, map_pow]
 
-open Int in
+open scoped Int in
 theorem isUnit_norm_of_isGalois [IsGalois K L] {x : 𝓞 L} : IsUnit (norm K x) ↔ IsUnit x := by
   classical
   refine ⟨fun hx => ?_, IsUnit.map _⟩
@@ -82,7 +82,7 @@ theorem isUnit_norm_of_isGalois [IsGalois K L] {x : 𝓞 L} : IsUnit (norm K x) 
       RingOfIntegers.map_mk]
   · rw [prod_sdiff <| subset_univ _, ← norm_eq_prod_automorphisms, coe_algebraMap_norm]
 
-open Int in
+open scoped Int in
 /-- If `L/K` is a finite Galois extension of fields, then, for all `(x : 𝓞 L)` we have that
 `x ∣ algebraMap (𝓞 K) (𝓞 L) (norm K x)`. -/
 theorem dvd_norm [IsGalois K L] (x : 𝓞 L) : x ∣ algebraMap (𝓞 K) (𝓞 L) (norm K x) := by

--- a/Mathlib/NumberTheory/NumberField/Norm.lean
+++ b/Mathlib/NumberTheory/NumberField/Norm.lean
@@ -26,6 +26,8 @@ open Finset NumberField Algebra FiniteDimensional
 
 section Rat
 
+open Int
+
 variable {K : Type*} [Field K] [NumberField K] (x : 𝓞 K)
 
 theorem Algebra.coe_norm_int : (Algebra.norm ℤ x : ℚ) = Algebra.norm ℚ (x : K) :=
@@ -40,6 +42,7 @@ namespace RingOfIntegers
 
 variable {L : Type*} (K : Type*) [Field K] [Field L] [Algebra K L] [FiniteDimensional K L]
 
+open Int in
 /-- `Algebra.norm` as a morphism betwen the rings of integers. -/
 noncomputable def norm [Algebra.IsSeparable K L] : 𝓞 L →* 𝓞 K :=
   RingOfIntegers.restrict_monoidHom
@@ -63,6 +66,7 @@ theorem norm_algebraMap [Algebra.IsSeparable K L] (x : 𝓞 K) :
     RingOfIntegers.algebraMap_norm_algebraMap, Algebra.norm_algebraMap,
     RingOfIntegers.coe_eq_algebraMap, map_pow]
 
+open Int in
 theorem isUnit_norm_of_isGalois [IsGalois K L] {x : 𝓞 L} : IsUnit (norm K x) ↔ IsUnit x := by
   classical
   refine ⟨fun hx => ?_, IsUnit.map _⟩
@@ -78,6 +82,7 @@ theorem isUnit_norm_of_isGalois [IsGalois K L] {x : 𝓞 L} : IsUnit (norm K x) 
       RingOfIntegers.map_mk]
   · rw [prod_sdiff <| subset_univ _, ← norm_eq_prod_automorphisms, coe_algebraMap_norm]
 
+open Int in
 /-- If `L/K` is a finite Galois extension of fields, then, for all `(x : 𝓞 L)` we have that
 `x ∣ algebraMap (𝓞 K) (𝓞 L) (norm K x)`. -/
 theorem dvd_norm [IsGalois K L] (x : 𝓞 L) : x ∣ algebraMap (𝓞 K) (𝓞 L) (norm K x) := by

--- a/Mathlib/NumberTheory/NumberField/Units/DirichletTheorem.lean
+++ b/Mathlib/NumberTheory/NumberField/Units/DirichletTheorem.lean
@@ -155,6 +155,7 @@ noncomputable def _root_.NumberField.Units.unitLattice :
     AddSubgroup ({w : InfinitePlace K // w ≠ w₀} → ℝ) :=
   AddSubgroup.map (logEmbedding K) ⊤
 
+open scoped Int in
 theorem unitLattice_inter_ball_finite (r : ℝ) :
     ((unitLattice K : Set ({ w : InfinitePlace K // w ≠ w₀} → ℝ)) ∩
       Metric.closedBall 0 r).Finite := by
@@ -239,6 +240,7 @@ def seq : ℕ → { x : 𝓞 K // x ≠ 0 }
 theorem seq_ne_zero (n : ℕ) : algebraMap (𝓞 K) K (seq K w₁ hB n) ≠ 0 :=
   RingOfIntegers.coe_ne_zero_iff.mpr (seq K w₁ hB n).prop
 
+open scoped Int in
 /-- The terms of the sequence have nonzero norm. -/
 theorem seq_norm_ne_zero (n : ℕ) : Algebra.norm ℤ (seq K w₁ hB n : 𝓞 K) ≠ 0 :=
   Algebra.norm_ne_zero_iff.mpr (Subtype.coe_ne_coe.1 (seq_ne_zero K w₁ hB n))
@@ -259,6 +261,7 @@ theorem seq_decreasing {n m : ℕ} (h : n < m) (w : InfinitePlace K) (hw : w ≠
           refine lt_trans ?_ (m_ih hr)
           exact (seq_next K w₁ hB (seq K w₁ hB m).prop).choose_spec.2.1 w hw
 
+open scoped Int in
 /-- The terms of the sequence have norm bounded by `B`. -/
 theorem seq_norm_le (n : ℕ) :
     Int.natAbs (Algebra.norm ℤ (seq K w₁ hB n : 𝓞 K)) ≤ B := by

--- a/Mathlib/RepresentationTheory/Maschke.lean
+++ b/Mathlib/RepresentationTheory/Maschke.lean
@@ -164,6 +164,7 @@ theorem exists_isCompl (p : Submodule (MonoidAlgebra k G) V) :
 instance complementedLattice : ComplementedLattice (Submodule (MonoidAlgebra k G) V) :=
   ⟨exists_isCompl⟩
 
+open Nat in
 instance [AddGroup G] : IsSemisimpleRing (AddMonoidAlgebra k G) :=
   letI : Invertible (Fintype.card (Multiplicative G) : k) := by
     rwa [Fintype.card_congr Multiplicative.toAdd]

--- a/Mathlib/RepresentationTheory/Maschke.lean
+++ b/Mathlib/RepresentationTheory/Maschke.lean
@@ -164,7 +164,7 @@ theorem exists_isCompl (p : Submodule (MonoidAlgebra k G) V) :
 instance complementedLattice : ComplementedLattice (Submodule (MonoidAlgebra k G) V) :=
   ⟨exists_isCompl⟩
 
-open Nat in
+open scoped Nat in
 instance [AddGroup G] : IsSemisimpleRing (AddMonoidAlgebra k G) :=
   letI : Invertible (Fintype.card (Multiplicative G) : k) := by
     rwa [Fintype.card_congr Multiplicative.toAdd]

--- a/Mathlib/RingTheory/Adjoin/Basic.lean
+++ b/Mathlib/RingTheory/Adjoin/Basic.lean
@@ -439,6 +439,8 @@ end AlgHom
 
 section NatInt
 
+open Nat Int
+
 theorem Algebra.adjoin_nat {R : Type*} [Semiring R] (s : Set R) :
     adjoin ℕ s = subalgebraOfSubsemiring (Subsemiring.closure s) :=
   le_antisymm (adjoin_le Subsemiring.subset_closure)

--- a/Mathlib/RingTheory/Adjoin/Basic.lean
+++ b/Mathlib/RingTheory/Adjoin/Basic.lean
@@ -439,7 +439,7 @@ end AlgHom
 
 section NatInt
 
-open Nat Int
+open scoped Nat Int
 
 theorem Algebra.adjoin_nat {R : Type*} [Semiring R] (s : Set R) :
     adjoin ℕ s = subalgebraOfSubsemiring (Subsemiring.closure s) :=

--- a/Mathlib/RingTheory/Adjoin/FG.lean
+++ b/Mathlib/RingTheory/Adjoin/FG.lean
@@ -189,6 +189,7 @@ theorem isNoetherianRing_of_fg {S : Subalgebra R A} (HS : S.FG) [IsNoetherianRin
   let ⟨t, ht⟩ := HS
   ht ▸ (Algebra.adjoin_eq_range R (↑t : Set A)).symm ▸ AlgHom.isNoetherianRing_range _
 
+open Int in
 theorem is_noetherian_subring_closure (s : Set R) (hs : s.Finite) :
     IsNoetherianRing (Subring.closure s) :=
   show IsNoetherianRing (subalgebraOfSubring (Subring.closure s)) from

--- a/Mathlib/RingTheory/Adjoin/FG.lean
+++ b/Mathlib/RingTheory/Adjoin/FG.lean
@@ -189,7 +189,7 @@ theorem isNoetherianRing_of_fg {S : Subalgebra R A} (HS : S.FG) [IsNoetherianRin
   let ⟨t, ht⟩ := HS
   ht ▸ (Algebra.adjoin_eq_range R (↑t : Set A)).symm ▸ AlgHom.isNoetherianRing_range _
 
-open Int in
+open scoped Int in
 theorem is_noetherian_subring_closure (s : Set R) (hs : s.Finite) :
     IsNoetherianRing (Subring.closure s) :=
   show IsNoetherianRing (subalgebraOfSubring (Subring.closure s)) from

--- a/Mathlib/RingTheory/AlgebraTower.lean
+++ b/Mathlib/RingTheory/AlgebraTower.lean
@@ -47,7 +47,7 @@ def Invertible.algebraTower (r : R) [Invertible (algebraMap R S r)] :
   Invertible.copy (Invertible.map (algebraMap S A) (algebraMap R S r)) (algebraMap R A r)
     (IsScalarTower.algebraMap_apply R S A r)
 
-open Nat in
+open scoped Nat in
 /-- A natural number that is invertible when coerced to `R` is also invertible
 when coerced to any `R`-algebra. -/
 def invertibleAlgebraCoeNat (n : ℕ) [inv : Invertible (n : R)] : Invertible (n : A) :=

--- a/Mathlib/RingTheory/AlgebraTower.lean
+++ b/Mathlib/RingTheory/AlgebraTower.lean
@@ -47,6 +47,7 @@ def Invertible.algebraTower (r : R) [Invertible (algebraMap R S r)] :
   Invertible.copy (Invertible.map (algebraMap S A) (algebraMap R S r)) (algebraMap R A r)
     (IsScalarTower.algebraMap_apply R S A r)
 
+open Nat in
 /-- A natural number that is invertible when coerced to `R` is also invertible
 when coerced to any `R`-algebra. -/
 def invertibleAlgebraCoeNat (n : ℕ) [inv : Invertible (n : R)] : Invertible (n : A) :=

--- a/Mathlib/RingTheory/Discriminant.lean
+++ b/Mathlib/RingTheory/Discriminant.lean
@@ -300,6 +300,8 @@ end Field
 
 section Int
 
+open Int
+
 /-- Two (finite) ℤ-bases have the same discriminant. -/
 theorem discr_eq_discr [Fintype ι] (b : Basis ι ℤ A) (b' : Basis ι ℤ A) :
     Algebra.discr ℤ b = Algebra.discr ℤ b' := by

--- a/Mathlib/RingTheory/Discriminant.lean
+++ b/Mathlib/RingTheory/Discriminant.lean
@@ -300,7 +300,7 @@ end Field
 
 section Int
 
-open Int
+open scoped Int
 
 /-- Two (finite) ℤ-bases have the same discriminant. -/
 theorem discr_eq_discr [Fintype ι] (b : Basis ι ℤ A) (b' : Basis ι ℤ A) :

--- a/Mathlib/RingTheory/FractionalIdeal/Norm.lean
+++ b/Mathlib/RingTheory/FractionalIdeal/Norm.lean
@@ -28,7 +28,7 @@ ideal of `R` and `I.den` an element of `R⁰` such that `I.den • I = I.num`.
 
 namespace FractionalIdeal
 
-open scoped Pointwise nonZeroDivisors
+open scoped Int Pointwise nonZeroDivisors
 
 variable {R : Type*} [CommRing R] [IsDedekindDomain R] [Module.Free ℤ R] [Module.Finite ℤ R]
 variable {K : Type*} [CommRing K] [Algebra R K] [IsFractionRing R K]

--- a/Mathlib/RingTheory/Ideal/Norm.lean
+++ b/Mathlib/RingTheory/Ideal/Norm.lean
@@ -230,6 +230,7 @@ theorem absNorm_ne_zero_iff (I : Ideal S) : Ideal.absNorm I ≠ 0 ↔ Finite (S 
   ⟨fun h => Nat.finite_of_card_ne_zero h, fun h =>
     (@AddSubgroup.finiteIndex_of_finite_quotient _ _ _ h).finiteIndex⟩
 
+open Int in
 /-- Let `e : S ≃ I` be an additive isomorphism (therefore a `ℤ`-linear equiv).
 Then an alternative way to compute the norm of `I` is given by taking the determinant of `e`.
 See `natAbs_det_basis_change` for a more familiar formulation of this result. -/
@@ -306,6 +307,7 @@ theorem natAbs_det_basis_change {ι : Type*} [Fintype ι] [DecidableEq ι] (b : 
       rw [Basis.det_comp_basis]
     _ = _ := natAbs_det_equiv I e
 
+open Int in
 @[simp]
 theorem absNorm_span_singleton (r : S) :
     absNorm (span ({r} : Set S)) = (Algebra.norm ℤ r).natAbs := by
@@ -323,20 +325,23 @@ theorem absNorm_span_singleton (r : S) :
 theorem absNorm_dvd_absNorm_of_le {I J : Ideal S} (h : J ≤ I) : Ideal.absNorm I ∣ Ideal.absNorm J :=
   map_dvd absNorm (dvd_iff_le.mpr h)
 
+open Int in
 theorem absNorm_dvd_norm_of_mem {I : Ideal S} {x : S} (h : x ∈ I) :
     ↑(Ideal.absNorm I) ∣ Algebra.norm ℤ x := by
   rw [← Int.dvd_natAbs, ← absNorm_span_singleton x, Int.natCast_dvd_natCast]
   exact absNorm_dvd_absNorm_of_le ((span_singleton_le_iff_mem _).mpr h)
 
+open Int in
 @[simp]
 theorem absNorm_span_insert (r : S) (s : Set S) :
-    absNorm (span (insert r s)) ∣ gcd (absNorm (span s)) (Algebra.norm ℤ r).natAbs :=
+    absNorm (span (insert r s)) ∣ GCDMonoid.gcd (absNorm (span s)) (Algebra.norm ℤ r).natAbs :=
   (dvd_gcd_iff _ _ _).mpr
     ⟨absNorm_dvd_absNorm_of_le (span_mono (Set.subset_insert _ _)),
       _root_.trans
         (absNorm_dvd_absNorm_of_le (span_mono (Set.singleton_subset_iff.mpr (Set.mem_insert _ _))))
         (by rw [absNorm_span_singleton])⟩
 
+open Int in
 theorem absNorm_eq_zero_iff {I : Ideal S} : Ideal.absNorm I = 0 ↔ I = ⊥ := by
   constructor
   · intro hI
@@ -378,6 +383,7 @@ theorem absNorm_mem (I : Ideal S) : ↑(Ideal.absNorm I) ∈ I := by
 theorem span_singleton_absNorm_le (I : Ideal S) : Ideal.span {(Ideal.absNorm I : S)} ≤ I := by
   simp only [Ideal.span_le, Set.singleton_subset_iff, SetLike.mem_coe, Ideal.absNorm_mem I]
 
+open Int in
 theorem span_singleton_absNorm {I : Ideal S} (hI : (Ideal.absNorm I).Prime) :
     Ideal.span (singleton (Ideal.absNorm I : ℤ)) = I.comap (algebraMap ℤ S) := by
   have : Ideal.IsPrime (Ideal.span (singleton (Ideal.absNorm I : ℤ))) := by
@@ -406,6 +412,7 @@ theorem finite_setOf_absNorm_eq [CharZero S] {n : ℕ} (hn : 0 < n) :
       comap_map_mk (span_singleton_absNorm_le J), ← hJ.symm]
     congr
 
+open Int in
 theorem norm_dvd_iff {x : S} (hx : Prime (Algebra.norm ℤ x)) {y : ℤ} :
     Algebra.norm ℤ x ∣ y ↔ x ∣ y := by
   rw [← Ideal.mem_span_singleton (y := x), ← eq_intCast (algebraMap ℤ S), ← Ideal.mem_comap,

--- a/Mathlib/RingTheory/Ideal/Norm.lean
+++ b/Mathlib/RingTheory/Ideal/Norm.lean
@@ -230,7 +230,7 @@ theorem absNorm_ne_zero_iff (I : Ideal S) : Ideal.absNorm I ≠ 0 ↔ Finite (S 
   ⟨fun h => Nat.finite_of_card_ne_zero h, fun h =>
     (@AddSubgroup.finiteIndex_of_finite_quotient _ _ _ h).finiteIndex⟩
 
-open Int in
+open scoped Int in
 /-- Let `e : S ≃ I` be an additive isomorphism (therefore a `ℤ`-linear equiv).
 Then an alternative way to compute the norm of `I` is given by taking the determinant of `e`.
 See `natAbs_det_basis_change` for a more familiar formulation of this result. -/
@@ -307,7 +307,7 @@ theorem natAbs_det_basis_change {ι : Type*} [Fintype ι] [DecidableEq ι] (b : 
       rw [Basis.det_comp_basis]
     _ = _ := natAbs_det_equiv I e
 
-open Int in
+open scoped Int in
 @[simp]
 theorem absNorm_span_singleton (r : S) :
     absNorm (span ({r} : Set S)) = (Algebra.norm ℤ r).natAbs := by
@@ -325,13 +325,13 @@ theorem absNorm_span_singleton (r : S) :
 theorem absNorm_dvd_absNorm_of_le {I J : Ideal S} (h : J ≤ I) : Ideal.absNorm I ∣ Ideal.absNorm J :=
   map_dvd absNorm (dvd_iff_le.mpr h)
 
-open Int in
+open scoped Int in
 theorem absNorm_dvd_norm_of_mem {I : Ideal S} {x : S} (h : x ∈ I) :
     ↑(Ideal.absNorm I) ∣ Algebra.norm ℤ x := by
   rw [← Int.dvd_natAbs, ← absNorm_span_singleton x, Int.natCast_dvd_natCast]
   exact absNorm_dvd_absNorm_of_le ((span_singleton_le_iff_mem _).mpr h)
 
-open Int in
+open scoped Int in
 @[simp]
 theorem absNorm_span_insert (r : S) (s : Set S) :
     absNorm (span (insert r s)) ∣ GCDMonoid.gcd (absNorm (span s)) (Algebra.norm ℤ r).natAbs :=
@@ -341,7 +341,7 @@ theorem absNorm_span_insert (r : S) (s : Set S) :
         (absNorm_dvd_absNorm_of_le (span_mono (Set.singleton_subset_iff.mpr (Set.mem_insert _ _))))
         (by rw [absNorm_span_singleton])⟩
 
-open Int in
+open scoped Int in
 theorem absNorm_eq_zero_iff {I : Ideal S} : Ideal.absNorm I = 0 ↔ I = ⊥ := by
   constructor
   · intro hI
@@ -383,7 +383,7 @@ theorem absNorm_mem (I : Ideal S) : ↑(Ideal.absNorm I) ∈ I := by
 theorem span_singleton_absNorm_le (I : Ideal S) : Ideal.span {(Ideal.absNorm I : S)} ≤ I := by
   simp only [Ideal.span_le, Set.singleton_subset_iff, SetLike.mem_coe, Ideal.absNorm_mem I]
 
-open Int in
+open scoped Int in
 theorem span_singleton_absNorm {I : Ideal S} (hI : (Ideal.absNorm I).Prime) :
     Ideal.span (singleton (Ideal.absNorm I : ℤ)) = I.comap (algebraMap ℤ S) := by
   have : Ideal.IsPrime (Ideal.span (singleton (Ideal.absNorm I : ℤ))) := by
@@ -412,7 +412,7 @@ theorem finite_setOf_absNorm_eq [CharZero S] {n : ℕ} (hn : 0 < n) :
       comap_map_mk (span_singleton_absNorm_le J), ← hJ.symm]
     congr
 
-open Int in
+open scoped Int in
 theorem norm_dvd_iff {x : S} (hx : Prime (Algebra.norm ℤ x)) {y : ℤ} :
     Algebra.norm ℤ x ∣ y ↔ x ∣ y := by
   rw [← Ideal.mem_span_singleton (y := x), ← eq_intCast (algebraMap ℤ S), ← Ideal.mem_comap,

--- a/Mathlib/RingTheory/IntegralClosure/IsIntegralClosure/Basic.lean
+++ b/Mathlib/RingTheory/IntegralClosure/IsIntegralClosure/Basic.lean
@@ -54,6 +54,7 @@ theorem IsIntegral.tower_top [Algebra A B] [IsScalarTower R A B] {x : B}
   let ⟨p, hp, hpx⟩ := hx
   ⟨p.map <| algebraMap R A, hp.map _, by rw [← aeval_def, aeval_map_algebraMap, aeval_def, hpx]⟩
 
+open Int in
 theorem map_isIntegral_int {B C F : Type*} [Ring B] [Ring C] {b : B}
     [FunLike F B C] [RingHomClass F B C] (f : F)
     (hb : IsIntegral ℤ b) : IsIntegral ℤ (f b) :=
@@ -284,9 +285,11 @@ theorem IsIntegral.pow {x : B} (h : IsIntegral R x) (n : ℕ) : IsIntegral R (x 
   .of_mem_of_fg _ h.fg_adjoin_singleton _ <|
     Subalgebra.pow_mem _ (by exact Algebra.subset_adjoin rfl) _
 
+open Nat in
 theorem IsIntegral.nsmul {x : B} (h : IsIntegral R x) (n : ℕ) : IsIntegral R (n • x) :=
   h.smul n
 
+open Int in
 theorem IsIntegral.zsmul {x : B} (h : IsIntegral R x) (n : ℤ) : IsIntegral R (n • x) :=
   h.smul n
 

--- a/Mathlib/RingTheory/IntegralClosure/IsIntegralClosure/Basic.lean
+++ b/Mathlib/RingTheory/IntegralClosure/IsIntegralClosure/Basic.lean
@@ -54,7 +54,7 @@ theorem IsIntegral.tower_top [Algebra A B] [IsScalarTower R A B] {x : B}
   let ⟨p, hp, hpx⟩ := hx
   ⟨p.map <| algebraMap R A, hp.map _, by rw [← aeval_def, aeval_map_algebraMap, aeval_def, hpx]⟩
 
-open Int in
+open scoped Int in
 theorem map_isIntegral_int {B C F : Type*} [Ring B] [Ring C] {b : B}
     [FunLike F B C] [RingHomClass F B C] (f : F)
     (hb : IsIntegral ℤ b) : IsIntegral ℤ (f b) :=
@@ -285,11 +285,11 @@ theorem IsIntegral.pow {x : B} (h : IsIntegral R x) (n : ℕ) : IsIntegral R (x 
   .of_mem_of_fg _ h.fg_adjoin_singleton _ <|
     Subalgebra.pow_mem _ (by exact Algebra.subset_adjoin rfl) _
 
-open Nat in
+open scoped Nat in
 theorem IsIntegral.nsmul {x : B} (h : IsIntegral R x) (n : ℕ) : IsIntegral R (n • x) :=
   h.smul n
 
-open Int in
+open scoped Int in
 theorem IsIntegral.zsmul {x : B} (h : IsIntegral R x) (n : ℤ) : IsIntegral R (n • x) :=
   h.smul n
 

--- a/Mathlib/RingTheory/Localization/Basic.lean
+++ b/Mathlib/RingTheory/Localization/Basic.lean
@@ -884,6 +884,7 @@ theorem mk_algebraMap {A : Type*} [CommSemiring A] [Algebra A R] (m : A) :
     mk (algebraMap A R m) 1 = algebraMap A (Localization M) m := by
   rw [mk_eq_mk', mk'_eq_iff_eq_mul, Submonoid.coe_one, map_one, mul_one]; rfl
 
+open Nat in
 theorem mk_natCast (m : ℕ) : (mk m 1 : Localization M) = m := by
   simpa using mk_algebraMap (R := R) (A := ℕ) _
 
@@ -948,6 +949,7 @@ theorem sub_mk (a c) (b d) : (mk a b : Localization M) - mk c d =
     mk ((d : R) * a - b * c) (b * d) := by
   rw [sub_eq_add_neg, neg_mk, add_mk, add_comm, mul_neg, ← sub_eq_add_neg]
 
+open Int in
 theorem mk_intCast (m : ℤ) : (mk m 1 : Localization M) = m := by
   simpa using mk_algebraMap (R := R) (A := ℤ) _
 

--- a/Mathlib/RingTheory/Localization/Basic.lean
+++ b/Mathlib/RingTheory/Localization/Basic.lean
@@ -884,7 +884,7 @@ theorem mk_algebraMap {A : Type*} [CommSemiring A] [Algebra A R] (m : A) :
     mk (algebraMap A R m) 1 = algebraMap A (Localization M) m := by
   rw [mk_eq_mk', mk'_eq_iff_eq_mul, Submonoid.coe_one, map_one, mul_one]; rfl
 
-open Nat in
+open scoped Nat in
 theorem mk_natCast (m : ℕ) : (mk m 1 : Localization M) = m := by
   simpa using mk_algebraMap (R := R) (A := ℕ) _
 
@@ -949,7 +949,7 @@ theorem sub_mk (a c) (b d) : (mk a b : Localization M) - mk c d =
     mk ((d : R) * a - b * c) (b * d) := by
   rw [sub_eq_add_neg, neg_mk, add_mk, add_comm, mul_neg, ← sub_eq_add_neg]
 
-open Int in
+open scoped Int in
 theorem mk_intCast (m : ℤ) : (mk m 1 : Localization M) = m := by
   simpa using mk_algebraMap (R := R) (A := ℤ) _
 

--- a/Mathlib/RingTheory/Localization/FractionRing.lean
+++ b/Mathlib/RingTheory/Localization/FractionRing.lean
@@ -43,6 +43,7 @@ abbrev IsFractionRing [CommRing K] [Algebra R K] :=
 instance {R : Type*} [Field R] : IsFractionRing R R :=
   IsLocalization.at_units _ (fun _ ↦ isUnit_of_mem_nonZeroDivisors)
 
+open Int in
 /-- The cast from `Int` to `Rat` as a `FractionRing`. -/
 instance Rat.isFractionRing : IsFractionRing ℤ ℚ where
   map_units' := by

--- a/Mathlib/RingTheory/Localization/FractionRing.lean
+++ b/Mathlib/RingTheory/Localization/FractionRing.lean
@@ -43,7 +43,7 @@ abbrev IsFractionRing [CommRing K] [Algebra R K] :=
 instance {R : Type*} [Field R] : IsFractionRing R R :=
   IsLocalization.at_units _ (fun _ ↦ isUnit_of_mem_nonZeroDivisors)
 
-open Int in
+open scoped Int in
 /-- The cast from `Int` to `Rat` as a `FractionRing`. -/
 instance Rat.isFractionRing : IsFractionRing ℤ ℚ where
   map_units' := by

--- a/Mathlib/RingTheory/Polynomial/Cyclotomic/Eval.lean
+++ b/Mathlib/RingTheory/Polynomial/Cyclotomic/Eval.lean
@@ -287,7 +287,7 @@ theorem cyclotomic_eval_le_add_one_pow_totient {q : ℝ} (hq' : 1 < q) :
   | 2 => by simp
   | n + 3 => (cyclotomic_eval_lt_add_one_pow_totient le_add_self hq').le
 
-open Int in
+open scoped Int in
 theorem sub_one_pow_totient_lt_natAbs_cyclotomic_eval {n : ℕ} {q : ℕ} (hn' : 1 < n) (hq : q ≠ 1) :
     (q - 1) ^ totient n < ((cyclotomic n ℤ).eval ↑q).natAbs := by
   rcases hq.lt_or_lt.imp_left Nat.lt_one_iff.mp with (rfl | hq')

--- a/Mathlib/RingTheory/Polynomial/Cyclotomic/Eval.lean
+++ b/Mathlib/RingTheory/Polynomial/Cyclotomic/Eval.lean
@@ -287,6 +287,7 @@ theorem cyclotomic_eval_le_add_one_pow_totient {q : ℝ} (hq' : 1 < q) :
   | 2 => by simp
   | n + 3 => (cyclotomic_eval_lt_add_one_pow_totient le_add_self hq').le
 
+open Int in
 theorem sub_one_pow_totient_lt_natAbs_cyclotomic_eval {n : ℕ} {q : ℕ} (hn' : 1 < n) (hq : q ≠ 1) :
     (q - 1) ^ totient n < ((cyclotomic n ℤ).eval ↑q).natAbs := by
   rcases hq.lt_or_lt.imp_left Nat.lt_one_iff.mp with (rfl | hq')

--- a/Mathlib/RingTheory/Polynomial/Cyclotomic/Expand.lean
+++ b/Mathlib/RingTheory/Polynomial/Cyclotomic/Expand.lean
@@ -69,7 +69,7 @@ theorem cyclotomic_expand_eq_cyclotomic_mul {p n : ℕ} (hp : Nat.Prime p) (hdiv
       Nat.totient_mul ((Nat.Prime.coprime_iff_not_dvd hp).2 hdiv), Nat.totient_prime hp,
       mul_comm (p - 1), ← Nat.mul_succ, Nat.sub_one, Nat.succ_pred_eq_of_pos hp.pos]
 
-open Int in
+open scoped Int in
 /-- If `p` is a prime such that `p ∣ n`, then
 `expand R p (cyclotomic n R) = cyclotomic (p * n) R`. -/
 @[simp]

--- a/Mathlib/RingTheory/Polynomial/Cyclotomic/Expand.lean
+++ b/Mathlib/RingTheory/Polynomial/Cyclotomic/Expand.lean
@@ -69,6 +69,7 @@ theorem cyclotomic_expand_eq_cyclotomic_mul {p n : ℕ} (hp : Nat.Prime p) (hdiv
       Nat.totient_mul ((Nat.Prime.coprime_iff_not_dvd hp).2 hdiv), Nat.totient_prime hp,
       mul_comm (p - 1), ← Nat.mul_succ, Nat.sub_one, Nat.succ_pred_eq_of_pos hp.pos]
 
+open Int in
 /-- If `p` is a prime such that `p ∣ n`, then
 `expand R p (cyclotomic n R) = cyclotomic (p * n) R`. -/
 @[simp]

--- a/Mathlib/RingTheory/Polynomial/Cyclotomic/Roots.lean
+++ b/Mathlib/RingTheory/Polynomial/Cyclotomic/Roots.lean
@@ -150,6 +150,7 @@ theorem cyclotomic_injective [CharZero R] : Function.Injective fun n => cyclotom
     replace hprim := hprim.eq_orderOf
     rwa [← IsPrimitiveRoot.eq_orderOf hroot] at hprim
 
+open Int in
 /-- The minimal polynomial of a primitive `n`-th root of unity `μ` divides `cyclotomic n ℤ`. -/
 theorem _root_.IsPrimitiveRoot.minpoly_dvd_cyclotomic {n : ℕ} {K : Type*} [Field K] {μ : K}
     (h : IsPrimitiveRoot μ n) (hpos : 0 < n) [CharZero K] : minpoly ℤ μ ∣ cyclotomic n ℤ := by
@@ -167,6 +168,7 @@ theorem _root_.IsPrimitiveRoot.minpoly_eq_cyclotomic_of_irreducible {K : Type*} 
   refine minpoly.eq_of_irreducible_of_monic h ?_ (cyclotomic.monic n K)
   rwa [aeval_def, eval₂_eq_eval_map, map_cyclotomic, ← IsRoot.def, isRoot_cyclotomic_iff]
 
+open Int in
 /-- `cyclotomic n ℤ` is the minimal polynomial of a primitive `n`-th root of unity `μ`. -/
 theorem cyclotomic_eq_minpoly {n : ℕ} {K : Type*} [Field K] {μ : K} (h : IsPrimitiveRoot μ n)
     (hpos : 0 < n) [CharZero K] : cyclotomic n ℤ = minpoly ℤ μ := by
@@ -174,18 +176,21 @@ theorem cyclotomic_eq_minpoly {n : ℕ} {K : Type*} [Field K] {μ : K} (h : IsPr
     (cyclotomic.monic n ℤ) (h.minpoly_dvd_cyclotomic hpos) ?_
   simpa [natDegree_cyclotomic n ℤ] using totient_le_degree_minpoly h
 
+open Int in
 /-- `cyclotomic n ℚ` is the minimal polynomial of a primitive `n`-th root of unity `μ`. -/
 theorem cyclotomic_eq_minpoly_rat {n : ℕ} {K : Type*} [Field K] {μ : K} (h : IsPrimitiveRoot μ n)
     (hpos : 0 < n) [CharZero K] : cyclotomic n ℚ = minpoly ℚ μ := by
   rw [← map_cyclotomic_int, cyclotomic_eq_minpoly h hpos]
   exact (minpoly.isIntegrallyClosed_eq_field_fractions' _ (IsPrimitiveRoot.isIntegral h hpos)).symm
 
+open Int in
 /-- `cyclotomic n ℤ` is irreducible. -/
 theorem cyclotomic.irreducible {n : ℕ} (hpos : 0 < n) : Irreducible (cyclotomic n ℤ) := by
   rw [cyclotomic_eq_minpoly (isPrimitiveRoot_exp n hpos.ne') hpos]
   apply minpoly.irreducible
   exact (isPrimitiveRoot_exp n hpos.ne').isIntegral hpos
 
+open Int in
 /-- `cyclotomic n ℚ` is irreducible. -/
 theorem cyclotomic.irreducible_rat {n : ℕ} (hpos : 0 < n) : Irreducible (cyclotomic n ℚ) := by
   rw [← map_cyclotomic_int]

--- a/Mathlib/RingTheory/Polynomial/Cyclotomic/Roots.lean
+++ b/Mathlib/RingTheory/Polynomial/Cyclotomic/Roots.lean
@@ -150,7 +150,7 @@ theorem cyclotomic_injective [CharZero R] : Function.Injective fun n => cyclotom
     replace hprim := hprim.eq_orderOf
     rwa [← IsPrimitiveRoot.eq_orderOf hroot] at hprim
 
-open Int in
+open scoped Int in
 /-- The minimal polynomial of a primitive `n`-th root of unity `μ` divides `cyclotomic n ℤ`. -/
 theorem _root_.IsPrimitiveRoot.minpoly_dvd_cyclotomic {n : ℕ} {K : Type*} [Field K] {μ : K}
     (h : IsPrimitiveRoot μ n) (hpos : 0 < n) [CharZero K] : minpoly ℤ μ ∣ cyclotomic n ℤ := by
@@ -168,7 +168,7 @@ theorem _root_.IsPrimitiveRoot.minpoly_eq_cyclotomic_of_irreducible {K : Type*} 
   refine minpoly.eq_of_irreducible_of_monic h ?_ (cyclotomic.monic n K)
   rwa [aeval_def, eval₂_eq_eval_map, map_cyclotomic, ← IsRoot.def, isRoot_cyclotomic_iff]
 
-open Int in
+open scoped Int in
 /-- `cyclotomic n ℤ` is the minimal polynomial of a primitive `n`-th root of unity `μ`. -/
 theorem cyclotomic_eq_minpoly {n : ℕ} {K : Type*} [Field K] {μ : K} (h : IsPrimitiveRoot μ n)
     (hpos : 0 < n) [CharZero K] : cyclotomic n ℤ = minpoly ℤ μ := by
@@ -176,21 +176,21 @@ theorem cyclotomic_eq_minpoly {n : ℕ} {K : Type*} [Field K] {μ : K} (h : IsPr
     (cyclotomic.monic n ℤ) (h.minpoly_dvd_cyclotomic hpos) ?_
   simpa [natDegree_cyclotomic n ℤ] using totient_le_degree_minpoly h
 
-open Int in
+open scoped Int in
 /-- `cyclotomic n ℚ` is the minimal polynomial of a primitive `n`-th root of unity `μ`. -/
 theorem cyclotomic_eq_minpoly_rat {n : ℕ} {K : Type*} [Field K] {μ : K} (h : IsPrimitiveRoot μ n)
     (hpos : 0 < n) [CharZero K] : cyclotomic n ℚ = minpoly ℚ μ := by
   rw [← map_cyclotomic_int, cyclotomic_eq_minpoly h hpos]
   exact (minpoly.isIntegrallyClosed_eq_field_fractions' _ (IsPrimitiveRoot.isIntegral h hpos)).symm
 
-open Int in
+open scoped Int in
 /-- `cyclotomic n ℤ` is irreducible. -/
 theorem cyclotomic.irreducible {n : ℕ} (hpos : 0 < n) : Irreducible (cyclotomic n ℤ) := by
   rw [cyclotomic_eq_minpoly (isPrimitiveRoot_exp n hpos.ne') hpos]
   apply minpoly.irreducible
   exact (isPrimitiveRoot_exp n hpos.ne').isIntegral hpos
 
-open Int in
+open scoped Int in
 /-- `cyclotomic n ℚ` is irreducible. -/
 theorem cyclotomic.irreducible_rat {n : ℕ} (hpos : 0 < n) : Irreducible (cyclotomic n ℚ) := by
   rw [← map_cyclotomic_int]

--- a/Mathlib/RingTheory/Polynomial/GaussLemma.lean
+++ b/Mathlib/RingTheory/Polynomial/GaussLemma.lean
@@ -307,12 +307,14 @@ end NormalizedGCDMonoid
 
 end FractionMap
 
+open Int in
 /-- **Gauss's Lemma** for `ℤ` states that a primitive integer polynomial is irreducible iff it is
   irreducible over `ℚ`. -/
 theorem IsPrimitive.Int.irreducible_iff_irreducible_map_cast {p : ℤ[X]} (hp : p.IsPrimitive) :
     Irreducible p ↔ Irreducible (p.map (Int.castRingHom ℚ)) :=
   hp.irreducible_iff_irreducible_map_fraction_map
 
+open Int in
 theorem IsPrimitive.Int.dvd_iff_map_cast_dvd_map_cast (p q : ℤ[X]) (hp : p.IsPrimitive)
     (hq : q.IsPrimitive) : p ∣ q ↔ p.map (Int.castRingHom ℚ) ∣ q.map (Int.castRingHom ℚ) :=
   hp.dvd_iff_fraction_map_dvd_fraction_map ℚ hq

--- a/Mathlib/RingTheory/Polynomial/GaussLemma.lean
+++ b/Mathlib/RingTheory/Polynomial/GaussLemma.lean
@@ -307,14 +307,14 @@ end NormalizedGCDMonoid
 
 end FractionMap
 
-open Int in
+open scoped Int in
 /-- **Gauss's Lemma** for `ℤ` states that a primitive integer polynomial is irreducible iff it is
   irreducible over `ℚ`. -/
 theorem IsPrimitive.Int.irreducible_iff_irreducible_map_cast {p : ℤ[X]} (hp : p.IsPrimitive) :
     Irreducible p ↔ Irreducible (p.map (Int.castRingHom ℚ)) :=
   hp.irreducible_iff_irreducible_map_fraction_map
 
-open Int in
+open scoped Int in
 theorem IsPrimitive.Int.dvd_iff_map_cast_dvd_map_cast (p q : ℤ[X]) (hp : p.IsPrimitive)
     (hq : q.IsPrimitive) : p ∣ q ↔ p.map (Int.castRingHom ℚ) ∣ q.map (Int.castRingHom ℚ) :=
   hp.dvd_iff_fraction_map_dvd_fraction_map ℚ hq

--- a/Mathlib/RingTheory/Polynomial/Hermite/Gaussian.lean
+++ b/Mathlib/RingTheory/Polynomial/Hermite/Gaussian.lean
@@ -30,7 +30,7 @@ polynomial factor occurring in the `n`th derivative of a gaussian.
 
 noncomputable section
 
-open Int Polynomial
+open scoped Int
 
 namespace Polynomial
 

--- a/Mathlib/RingTheory/Polynomial/Hermite/Gaussian.lean
+++ b/Mathlib/RingTheory/Polynomial/Hermite/Gaussian.lean
@@ -30,7 +30,7 @@ polynomial factor occurring in the `n`th derivative of a gaussian.
 
 noncomputable section
 
-open Polynomial
+open Int Polynomial
 
 namespace Polynomial
 

--- a/Mathlib/RingTheory/Polynomial/Pochhammer.lean
+++ b/Mathlib/RingTheory/Polynomial/Pochhammer.lean
@@ -93,7 +93,7 @@ theorem ascPochhammer_eval_comp {R : Type*} [CommSemiring R] (n : ℕ) (p : R[X]
 
 end
 
-open Nat in
+open scoped Nat in
 @[simp, norm_cast]
 theorem ascPochhammer_eval_cast (n k : ℕ) :
     (((ascPochhammer ℕ n).eval k : ℕ) : S) = ((ascPochhammer S n).eval k : S) := by
@@ -111,7 +111,7 @@ theorem ascPochhammer_zero_eval_zero : (ascPochhammer S 0).eval 0 = 1 := by simp
 theorem ascPochhammer_ne_zero_eval_zero {n : ℕ} (h : n ≠ 0) : (ascPochhammer S n).eval 0 = 0 := by
   simp [ascPochhammer_eval_zero, h]
 
-open Nat in
+open scoped Nat in
 theorem ascPochhammer_succ_right (n : ℕ) :
     ascPochhammer S (n + 1) = ascPochhammer S n * (X + (n : S[X])) := by
   suffices h : ascPochhammer ℕ (n + 1) = ascPochhammer ℕ n * (X + (n : ℕ[X])) by
@@ -188,7 +188,7 @@ end StrictOrderedSemiring
 
 section Factorial
 
-open Nat
+open scoped Nat
 
 variable (S : Type*) [Semiring S] (r n : ℕ)
 
@@ -259,7 +259,7 @@ theorem descPochhammer_map (f : R →+* T) (n : ℕ) :
   · simp [ih, descPochhammer_succ_left, map_comp]
 end
 
-open Int in
+open scoped Int in
 @[simp, norm_cast]
 theorem descPochhammer_eval_cast (n : ℕ) (k : ℤ) :
     (((descPochhammer ℤ n).eval k : ℤ) : R) = ((descPochhammer R n).eval k : R) := by
@@ -278,7 +278,7 @@ theorem descPochhammer_zero_eval_zero : (descPochhammer R 0).eval 0 = 1 := by si
 theorem descPochhammer_ne_zero_eval_zero {n : ℕ} (h : n ≠ 0) : (descPochhammer R n).eval 0 = 0 := by
   simp [descPochhammer_eval_zero, h]
 
-open Int in
+open scoped Int in
 theorem descPochhammer_succ_right (n : ℕ) :
     descPochhammer R (n + 1) = descPochhammer R n * (X - (n : R[X])) := by
   suffices h : descPochhammer ℤ (n + 1) = descPochhammer ℤ n * (X - (n : ℤ[X])) by
@@ -327,7 +327,7 @@ theorem descPochhammer_eq_ascPochhammer (n : ℕ) :
     rw [Nat.cast_succ, sub_add, add_sub_cancel_right, descPochhammer_succ_right,
       ascPochhammer_succ_left, ih, X_mul, mul_X_comp, comp_assoc, add_comp, X_comp, one_comp]
 
-open Nat in
+open scoped Nat in
 theorem descPochhammer_eval_eq_ascPochhammer (r : R) (n : ℕ) :
     (descPochhammer R n).eval r = (ascPochhammer R n).eval (r - n + 1) := by
   induction n with

--- a/Mathlib/RingTheory/Polynomial/Pochhammer.lean
+++ b/Mathlib/RingTheory/Polynomial/Pochhammer.lean
@@ -93,6 +93,7 @@ theorem ascPochhammer_eval_comp {R : Type*} [CommSemiring R] (n : ℕ) (p : R[X]
 
 end
 
+open Nat in
 @[simp, norm_cast]
 theorem ascPochhammer_eval_cast (n k : ℕ) :
     (((ascPochhammer ℕ n).eval k : ℕ) : S) = ((ascPochhammer S n).eval k : S) := by
@@ -110,6 +111,7 @@ theorem ascPochhammer_zero_eval_zero : (ascPochhammer S 0).eval 0 = 1 := by simp
 theorem ascPochhammer_ne_zero_eval_zero {n : ℕ} (h : n ≠ 0) : (ascPochhammer S n).eval 0 = 0 := by
   simp [ascPochhammer_eval_zero, h]
 
+open Nat in
 theorem ascPochhammer_succ_right (n : ℕ) :
     ascPochhammer S (n + 1) = ascPochhammer S n * (X + (n : S[X])) := by
   suffices h : ascPochhammer ℕ (n + 1) = ascPochhammer ℕ n * (X + (n : ℕ[X])) by
@@ -257,6 +259,7 @@ theorem descPochhammer_map (f : R →+* T) (n : ℕ) :
   · simp [ih, descPochhammer_succ_left, map_comp]
 end
 
+open Int in
 @[simp, norm_cast]
 theorem descPochhammer_eval_cast (n : ℕ) (k : ℤ) :
     (((descPochhammer ℤ n).eval k : ℤ) : R) = ((descPochhammer R n).eval k : R) := by
@@ -275,6 +278,7 @@ theorem descPochhammer_zero_eval_zero : (descPochhammer R 0).eval 0 = 1 := by si
 theorem descPochhammer_ne_zero_eval_zero {n : ℕ} (h : n ≠ 0) : (descPochhammer R n).eval 0 = 0 := by
   simp [descPochhammer_eval_zero, h]
 
+open Int in
 theorem descPochhammer_succ_right (n : ℕ) :
     descPochhammer R (n + 1) = descPochhammer R n * (X - (n : R[X])) := by
   suffices h : descPochhammer ℤ (n + 1) = descPochhammer ℤ n * (X - (n : ℤ[X])) by
@@ -323,6 +327,7 @@ theorem descPochhammer_eq_ascPochhammer (n : ℕ) :
     rw [Nat.cast_succ, sub_add, add_sub_cancel_right, descPochhammer_succ_right,
       ascPochhammer_succ_left, ih, X_mul, mul_X_comp, comp_assoc, add_comp, X_comp, one_comp]
 
+open Nat in
 theorem descPochhammer_eval_eq_ascPochhammer (r : R) (n : ℕ) :
     (descPochhammer R n).eval r = (ascPochhammer R n).eval (r - n + 1) := by
   induction n with

--- a/Mathlib/RingTheory/RootsOfUnity/Lemmas.lean
+++ b/Mathlib/RingTheory/RootsOfUnity/Lemmas.lean
@@ -43,7 +43,7 @@ lemma prod_pow_sub_one_eq_order {n : ℕ} {μ : R} (hμ : IsPrimitiveRoot μ (n 
   have : (-1 : R) ^ n = ∏ k ∈ range n, -1 := by rw [prod_const, card_range]
   simp only [this, ← prod_mul_distrib, neg_one_mul, neg_sub, ← prod_one_sub_pow_eq_order hμ]
 
-open Algebra in
+open Int Algebra in
 /-- If `μ` is a primitive `n`th root of unity in `R` and `k < n`, then `n` is divisible
 by `(μ-1)^k` in `ℤ[μ] ⊆ R`. -/
 lemma self_sub_one_pow_dvd_order {k n : ℕ} (hn : k < n) {μ : R} (hμ : IsPrimitiveRoot μ n) :

--- a/Mathlib/RingTheory/RootsOfUnity/Minpoly.lean
+++ b/Mathlib/RingTheory/RootsOfUnity/Minpoly.lean
@@ -29,6 +29,8 @@ namespace IsPrimitiveRoot
 
 section CommRing
 
+open Int
+
 variable {n : ℕ} {K : Type*} [CommRing K] {μ : K} (h : IsPrimitiveRoot μ n)
 
 /-- `μ` is integral over `ℤ`. -/

--- a/Mathlib/RingTheory/RootsOfUnity/Minpoly.lean
+++ b/Mathlib/RingTheory/RootsOfUnity/Minpoly.lean
@@ -29,7 +29,7 @@ namespace IsPrimitiveRoot
 
 section CommRing
 
-open Int
+open scoped Int
 
 variable {n : ℕ} {K : Type*} [CommRing K] {μ : K} (h : IsPrimitiveRoot μ n)
 

--- a/Mathlib/RingTheory/TensorProduct/Basic.lean
+++ b/Mathlib/RingTheory/TensorProduct/Basic.lean
@@ -399,7 +399,8 @@ instance leftAlgebra [SMulCommClass R S A] : Algebra S (A ⊗[R] B) :=
       rw [algebraMap_eq_smul_one, ← smul_tmul', smul_mul_assoc, ← one_def, one_mul]
     toRingHom := TensorProduct.includeLeftRingHom.comp (algebraMap S A) }
 
-example : (algebraNat : Algebra ℕ (ℕ ⊗[ℕ] B)) = leftAlgebra := rfl
+open Nat in
+example : (Nat.instAlgebraOfSemiring : Algebra ℕ (ℕ ⊗[ℕ] B)) = leftAlgebra := rfl
 
 -- This is for the `undergrad.yaml` list.
 /-- The tensor product of two `R`-algebras is an `R`-algebra. -/
@@ -559,8 +560,10 @@ theorem intCast_def' (z : ℤ) : (z : A ⊗[R] B) = (1 : A) ⊗ₜ (z : B) := by
 -- verify there are no diamonds
 example : (instRing : Ring (A ⊗[R] B)).toAddCommGroup = addCommGroup := by
   with_reducible_and_instances rfl
+
+open Int in
 -- fails at `with_reducible_and_instances rfl` #10906
-example : (algebraInt _ : Algebra ℤ (ℤ ⊗[ℤ] B)) = leftAlgebra := rfl
+example : (Int.instAlgebraOfRing _ : Algebra ℤ (ℤ ⊗[ℤ] B)) = leftAlgebra := rfl
 
 end Ring
 
@@ -589,11 +592,13 @@ end RightAlgebra
 
 end CommRing
 
+open Int in
 /-- Verify that typeclass search finds the ring structure on `A ⊗[ℤ] B`
 when `A` and `B` are merely rings, by treating both as `ℤ`-algebras.
 -/
 example [Ring A] [Ring B] : Ring (A ⊗[ℤ] B) := by infer_instance
 
+open Int in
 /-- Verify that typeclass search finds the comm_ring structure on `A ⊗[ℤ] B`
 when `A` and `B` are merely comm_rings, by treating both as `ℤ`-algebras.
 -/

--- a/Mathlib/RingTheory/TensorProduct/Basic.lean
+++ b/Mathlib/RingTheory/TensorProduct/Basic.lean
@@ -399,7 +399,7 @@ instance leftAlgebra [SMulCommClass R S A] : Algebra S (A ⊗[R] B) :=
       rw [algebraMap_eq_smul_one, ← smul_tmul', smul_mul_assoc, ← one_def, one_mul]
     toRingHom := TensorProduct.includeLeftRingHom.comp (algebraMap S A) }
 
-open Nat in
+open scoped Nat in
 example : (Nat.instAlgebraOfSemiring : Algebra ℕ (ℕ ⊗[ℕ] B)) = leftAlgebra := rfl
 
 -- This is for the `undergrad.yaml` list.
@@ -561,7 +561,7 @@ theorem intCast_def' (z : ℤ) : (z : A ⊗[R] B) = (1 : A) ⊗ₜ (z : B) := by
 example : (instRing : Ring (A ⊗[R] B)).toAddCommGroup = addCommGroup := by
   with_reducible_and_instances rfl
 
-open Int in
+open scoped Int in
 -- fails at `with_reducible_and_instances rfl` #10906
 example : (Int.instAlgebraOfRing _ : Algebra ℤ (ℤ ⊗[ℤ] B)) = leftAlgebra := rfl
 
@@ -592,13 +592,13 @@ end RightAlgebra
 
 end CommRing
 
-open Int in
+open scoped Int in
 /-- Verify that typeclass search finds the ring structure on `A ⊗[ℤ] B`
 when `A` and `B` are merely rings, by treating both as `ℤ`-algebras.
 -/
 example [Ring A] [Ring B] : Ring (A ⊗[ℤ] B) := by infer_instance
 
-open Int in
+open scoped Int in
 /-- Verify that typeclass search finds the comm_ring structure on `A ⊗[ℤ] B`
 when `A` and `B` are merely comm_rings, by treating both as `ℤ`-algebras.
 -/

--- a/Mathlib/RingTheory/Trace/Basic.lean
+++ b/Mathlib/RingTheory/Trace/Basic.lean
@@ -129,6 +129,7 @@ theorem trace_eq_trace_adjoin [FiniteDimensional K L] (x : L) :
 
 variable {K}
 
+open Nat in
 theorem trace_eq_sum_roots [FiniteDimensional K L] {x : L}
     (hF : (minpoly K x).Splits (algebraMap K F)) :
     algebraMap K F (Algebra.trace K L x) =
@@ -242,6 +243,7 @@ theorem sum_embeddings_eq_finrank_mul [FiniteDimensional K F] [Algebra.IsSeparab
       simp only [algHomEquivSigma, Equiv.coe_fn_mk, AlgHom.restrictDomain, AlgHom.comp_apply,
         IsScalarTower.coe_toAlgHom']
 
+open Nat in
 theorem trace_eq_sum_embeddings [FiniteDimensional K L] [Algebra.IsSeparable K L] {x : L} :
     algebraMap K E (Algebra.trace K L x) = ∑ σ : L →ₐ[K] E, σ x := by
   have hx := Algebra.IsSeparable.isIntegral K x

--- a/Mathlib/RingTheory/Trace/Basic.lean
+++ b/Mathlib/RingTheory/Trace/Basic.lean
@@ -129,7 +129,7 @@ theorem trace_eq_trace_adjoin [FiniteDimensional K L] (x : L) :
 
 variable {K}
 
-open Nat in
+open scoped Nat in
 theorem trace_eq_sum_roots [FiniteDimensional K L] {x : L}
     (hF : (minpoly K x).Splits (algebraMap K F)) :
     algebraMap K F (Algebra.trace K L x) =
@@ -243,7 +243,7 @@ theorem sum_embeddings_eq_finrank_mul [FiniteDimensional K F] [Algebra.IsSeparab
       simp only [algHomEquivSigma, Equiv.coe_fn_mk, AlgHom.restrictDomain, AlgHom.comp_apply,
         IsScalarTower.coe_toAlgHom']
 
-open Nat in
+open scoped Nat in
 theorem trace_eq_sum_embeddings [FiniteDimensional K L] [Algebra.IsSeparable K L] {x : L} :
     algebraMap K E (Algebra.trace K L x) = ∑ σ : L →ₐ[K] E, σ x := by
   have hx := Algebra.IsSeparable.isIntegral K x

--- a/Mathlib/RingTheory/WittVector/Basic.lean
+++ b/Mathlib/RingTheory/WittVector/Basic.lean
@@ -132,6 +132,8 @@ end WittVector
 
 namespace WittVector
 
+open Int
+
 /-- Evaluates the `n`th Witt polynomial on the first `n` coefficients of `x`,
 producing a value in `R`.
 This function will be bundled as the ring homomorphism `WittVector.ghostMap`

--- a/Mathlib/RingTheory/WittVector/Basic.lean
+++ b/Mathlib/RingTheory/WittVector/Basic.lean
@@ -132,7 +132,7 @@ end WittVector
 
 namespace WittVector
 
-open Int
+open scoped Int
 
 /-- Evaluates the `n`th Witt polynomial on the first `n` coefficients of `x`,
 producing a value in `R`.

--- a/Mathlib/RingTheory/WittVector/Defs.lean
+++ b/Mathlib/RingTheory/WittVector/Defs.lean
@@ -138,7 +138,7 @@ def wittPow (n : ℕ) : ℕ → MvPolynomial (Fin 1 × ℕ) ℤ :=
 
 variable {p}
 
-open Int
+open scoped Int
 
 /-- An auxiliary definition used in `WittVector.eval`.
 Evaluates a polynomial whose variables come from the disjoint union of `k` copies of `ℕ`,
@@ -290,7 +290,7 @@ end WittStructureSimplifications
 
 section Coeff
 
-open Int
+open scoped Int
 
 variable (R)
 

--- a/Mathlib/RingTheory/WittVector/Defs.lean
+++ b/Mathlib/RingTheory/WittVector/Defs.lean
@@ -138,6 +138,7 @@ def wittPow (n : ℕ) : ℕ → MvPolynomial (Fin 1 × ℕ) ℤ :=
 
 variable {p}
 
+open Int
 
 /-- An auxiliary definition used in `WittVector.eval`.
 Evaluates a polynomial whose variables come from the disjoint union of `k` copies of `ℕ`,
@@ -288,6 +289,8 @@ theorem constantCoeff_wittZSMul (z : ℤ) (n : ℕ) : constantCoeff (wittZSMul p
 end WittStructureSimplifications
 
 section Coeff
+
+open Int
 
 variable (R)
 

--- a/Mathlib/RingTheory/WittVector/Frobenius.lean
+++ b/Mathlib/RingTheory/WittVector/Frobenius.lean
@@ -197,6 +197,8 @@ theorem bind₁_frobeniusPoly_wittPolynomial (n : ℕ) :
 
 variable {p}
 
+open Int
+
 /-- `frobeniusFun` is the function underlying the ring endomorphism
 `frobenius : 𝕎 R →+* frobenius 𝕎 R`. -/
 def frobeniusFun (x : 𝕎 R) : 𝕎 R :=

--- a/Mathlib/RingTheory/WittVector/Frobenius.lean
+++ b/Mathlib/RingTheory/WittVector/Frobenius.lean
@@ -197,7 +197,7 @@ theorem bind₁_frobeniusPoly_wittPolynomial (n : ℕ) :
 
 variable {p}
 
-open Int
+open scoped Int
 
 /-- `frobeniusFun` is the function underlying the ring endomorphism
 `frobenius : 𝕎 R →+* frobenius 𝕎 R`. -/

--- a/Mathlib/RingTheory/WittVector/InitTail.lean
+++ b/Mathlib/RingTheory/WittVector/InitTail.lean
@@ -65,6 +65,7 @@ variable (P : ℕ → Prop)
 def selectPoly (n : ℕ) : MvPolynomial ℕ ℤ :=
   if P n then X n else 0
 
+open Int in
 theorem coeff_select (x : 𝕎 R) (n : ℕ) :
     (select P x).coeff n = aeval x.coeff (selectPoly P n) := by
   dsimp [select, selectPoly]
@@ -79,6 +80,7 @@ instance select_isPoly {P : ℕ → Prop} : IsPoly p fun _ _ x => select P x := 
   funext i
   apply coeff_select
 
+open Int in
 theorem select_add_select_not : ∀ x : 𝕎 R, select P x + select (fun i => ¬P i) x = x := by
   -- Porting note: TC search was insufficient to find this instance, even though all required
   -- instances exist. See zulip: [https://leanprover.zulipchat.com/#narrow/stream/287929-mathlib4/topic/WittVector.20saga/near/370073526]

--- a/Mathlib/RingTheory/WittVector/InitTail.lean
+++ b/Mathlib/RingTheory/WittVector/InitTail.lean
@@ -65,7 +65,7 @@ variable (P : ℕ → Prop)
 def selectPoly (n : ℕ) : MvPolynomial ℕ ℤ :=
   if P n then X n else 0
 
-open Int in
+open scoped Int in
 theorem coeff_select (x : 𝕎 R) (n : ℕ) :
     (select P x).coeff n = aeval x.coeff (selectPoly P n) := by
   dsimp [select, selectPoly]
@@ -80,7 +80,7 @@ instance select_isPoly {P : ℕ → Prop} : IsPoly p fun _ _ x => select P x := 
   funext i
   apply coeff_select
 
-open Int in
+open scoped Int in
 theorem select_add_select_not : ∀ x : 𝕎 R, select P x + select (fun i => ¬P i) x = x := by
   -- Porting note: TC search was insufficient to find this instance, even though all required
   -- instances exist. See zulip: [https://leanprover.zulipchat.com/#narrow/stream/287929-mathlib4/topic/WittVector.20saga/near/370073526]

--- a/Mathlib/RingTheory/WittVector/IsPoly.lean
+++ b/Mathlib/RingTheory/WittVector/IsPoly.lean
@@ -129,6 +129,8 @@ theorem poly_eq_of_wittPolynomial_bind_eq [Fact p.Prime] (f g : ℕ → MvPolyno
   simpa only [Function.comp, map_bind₁, map_wittPolynomial, ← bind₁_bind₁,
     bind₁_wittPolynomial_xInTermsOfW, bind₁_X_right] using h
 
+open Int
+
 -- Ideally, we would generalise this to n-ary functions
 -- But we don't have a good theory of n-ary compositions in mathlib
 /--

--- a/Mathlib/RingTheory/WittVector/IsPoly.lean
+++ b/Mathlib/RingTheory/WittVector/IsPoly.lean
@@ -129,7 +129,7 @@ theorem poly_eq_of_wittPolynomial_bind_eq [Fact p.Prime] (f g : ℕ → MvPolyno
   simpa only [Function.comp, map_bind₁, map_wittPolynomial, ← bind₁_bind₁,
     bind₁_wittPolynomial_xInTermsOfW, bind₁_X_right] using h
 
-open Int
+open scoped Int
 
 -- Ideally, we would generalise this to n-ary functions
 -- But we don't have a good theory of n-ary compositions in mathlib

--- a/Mathlib/RingTheory/WittVector/MulP.lean
+++ b/Mathlib/RingTheory/WittVector/MulP.lean
@@ -44,7 +44,7 @@ noncomputable def wittMulN : ℕ → ℕ → MvPolynomial ℕ ℤ
 
 variable {p}
 
-open Int in
+open scoped Int in
 theorem mulN_coeff (n : ℕ) (x : 𝕎 R) (k : ℕ) :
     (x * n).coeff k = aeval x.coeff (wittMulN p n k) := by
   induction' n with n ih generalizing k

--- a/Mathlib/RingTheory/WittVector/MulP.lean
+++ b/Mathlib/RingTheory/WittVector/MulP.lean
@@ -44,6 +44,7 @@ noncomputable def wittMulN : ℕ → ℕ → MvPolynomial ℕ ℤ
 
 variable {p}
 
+open Int in
 theorem mulN_coeff (n : ℕ) (x : 𝕎 R) (k : ℕ) :
     (x * n).coeff k = aeval x.coeff (wittMulN p n k) := by
   induction' n with n ih generalizing k

--- a/Mathlib/RingTheory/WittVector/StructurePolynomial.lean
+++ b/Mathlib/RingTheory/WittVector/StructurePolynomial.lean
@@ -318,7 +318,7 @@ theorem wittStructureInt_existsUnique (Φ : MvPolynomial idx ℤ) :
         bind₁ φ (wittPolynomial p ℤ n) = bind₁ (fun i : idx => rename (Prod.mk i) (W_ ℤ n)) Φ :=
   ⟨wittStructureInt p Φ, wittStructureInt_prop _ _, eq_wittStructureInt _ _⟩
 
-open Int in
+open scoped Int in
 theorem witt_structure_prop (Φ : MvPolynomial idx ℤ) (n) :
     aeval (fun i => map (Int.castRingHom R) (wittStructureInt p Φ i)) (wittPolynomial p ℤ n) =
       aeval (fun i => rename (Prod.mk i) (W n)) Φ := by

--- a/Mathlib/RingTheory/WittVector/StructurePolynomial.lean
+++ b/Mathlib/RingTheory/WittVector/StructurePolynomial.lean
@@ -318,6 +318,7 @@ theorem wittStructureInt_existsUnique (Φ : MvPolynomial idx ℤ) :
         bind₁ φ (wittPolynomial p ℤ n) = bind₁ (fun i : idx => rename (Prod.mk i) (W_ ℤ n)) Φ :=
   ⟨wittStructureInt p Φ, wittStructureInt_prop _ _, eq_wittStructureInt _ _⟩
 
+open Int in
 theorem witt_structure_prop (Φ : MvPolynomial idx ℤ) (n) :
     aeval (fun i => map (Int.castRingHom R) (wittStructureInt p Φ i)) (wittPolynomial p ℤ n) =
       aeval (fun i => rename (Prod.mk i) (W n)) Φ := by

--- a/Mathlib/RingTheory/WittVector/Verschiebung.lean
+++ b/Mathlib/RingTheory/WittVector/Verschiebung.lean
@@ -73,6 +73,7 @@ def verschiebungPoly (n : ℕ) : MvPolynomial ℕ ℤ :=
 theorem verschiebungPoly_zero : verschiebungPoly 0 = 0 :=
   rfl
 
+open Int in
 theorem aeval_verschiebung_poly' (x : 𝕎 R) (n : ℕ) :
     aeval x.coeff (verschiebungPoly n) = (verschiebungFun x).coeff n := by
   cases' n with n
@@ -149,6 +150,7 @@ theorem verschiebung_coeff_add_one (x : 𝕎 R) (n : ℕ) :
 theorem verschiebung_coeff_succ (x : 𝕎 R) (n : ℕ) : (verschiebung x).coeff n.succ = x.coeff n :=
   rfl
 
+open Int in
 theorem aeval_verschiebungPoly (x : 𝕎 R) (n : ℕ) :
     aeval x.coeff (verschiebungPoly n) = (verschiebung x).coeff n :=
   aeval_verschiebung_poly' x n

--- a/Mathlib/RingTheory/WittVector/Verschiebung.lean
+++ b/Mathlib/RingTheory/WittVector/Verschiebung.lean
@@ -73,7 +73,7 @@ def verschiebungPoly (n : ℕ) : MvPolynomial ℕ ℤ :=
 theorem verschiebungPoly_zero : verschiebungPoly 0 = 0 :=
   rfl
 
-open Int in
+open scoped Int in
 theorem aeval_verschiebung_poly' (x : 𝕎 R) (n : ℕ) :
     aeval x.coeff (verschiebungPoly n) = (verschiebungFun x).coeff n := by
   cases' n with n
@@ -150,7 +150,7 @@ theorem verschiebung_coeff_add_one (x : 𝕎 R) (n : ℕ) :
 theorem verschiebung_coeff_succ (x : 𝕎 R) (n : ℕ) : (verschiebung x).coeff n.succ = x.coeff n :=
   rfl
 
-open Int in
+open scoped Int in
 theorem aeval_verschiebungPoly (x : 𝕎 R) (n : ℕ) :
     aeval x.coeff (verschiebungPoly n) = (verschiebung x).coeff n :=
   aeval_verschiebung_poly' x n


### PR DESCRIPTION
We rename `algebraNat` to `Nat.instAlgebraOfSemiring` and `algebraInt` to `Int.instAlgebraOfRing` to be consistent with existing naming conventions. We also scope them to avoid typeclass search tripping over them unnecessarily.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

Moves:
- algebraNat -> Nat.instAlgebraOfSemiring
- algebraInt -> Int.instAlgebraOfRing

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
