### PR TITLE
[Merged by Bors] - chore: normalize number of newlines before module docstring

### DIFF
--- a/Mathlib/Algebra/Algebra/Rat.lean
+++ b/Mathlib/Algebra/Algebra/Rat.lean
@@ -6,7 +6,6 @@ Authors: Kenny Lau, Yury Kudryashov
 import Mathlib.Data.Rat.Cast.CharZero
 import Mathlib.Algebra.Algebra.Defs
 
-
 /-!
 # Further basic results about `Algebra`'s over `ℚ`.
 
@@ -48,5 +47,3 @@ instance algebra_rat_subsingleton {α} [Semiring α] : Subsingleton (Algebra ℚ
   ⟨fun x y => Algebra.algebra_ext x y <| RingHom.congr_fun <| Subsingleton.elim _ _⟩
 
 end Rat
-
-

--- a/Mathlib/Algebra/Category/Grp/Adjunctions.lean
+++ b/Mathlib/Algebra/Category/Grp/Adjunctions.lean
@@ -6,7 +6,6 @@ Authors: Scott Morrison, Johannes Hölzl
 import Mathlib.Algebra.Category.Grp.Basic
 import Mathlib.GroupTheory.FreeAbelianGroup
 
-
 /-!
 # Adjunctions regarding the category of (abelian) groups
 

--- a/Mathlib/Algebra/Homology/LocalCohomology.lean
+++ b/Mathlib/Algebra/Homology/LocalCohomology.lean
@@ -11,7 +11,6 @@ import Mathlib.RingTheory.Finiteness
 import Mathlib.CategoryTheory.Limits.Final
 import Mathlib.RingTheory.Noetherian
 
-
 /-!
 # Local cohomology.
 

--- a/Mathlib/Algebra/Polynomial/Degree/Definitions.lean
+++ b/Mathlib/Algebra/Polynomial/Degree/Definitions.lean
@@ -11,7 +11,6 @@ import Mathlib.Data.Nat.WithBot
 import Mathlib.Data.Nat.Cast.WithTop
 import Mathlib.Data.Nat.SuccPred
 
-
 /-!
 # Theory of univariate polynomials
 

--- a/Mathlib/Analysis/Calculus/ContDiff/FiniteDimension.lean
+++ b/Mathlib/Analysis/Calculus/ContDiff/FiniteDimension.lean
@@ -6,8 +6,6 @@ Authors: Sébastien Gouëzel, Floris van Doorn
 import Mathlib.Analysis.Calculus.ContDiff.Basic
 import Mathlib.Analysis.NormedSpace.FiniteDimension
 
-
-
 /-!
 # Higher differentiability in finite dimensions.
 

--- a/Mathlib/Analysis/Convex/Cone/Extension.lean
+++ b/Mathlib/Analysis/Convex/Cone/Extension.lean
@@ -7,8 +7,6 @@ import Mathlib.Analysis.Convex.Cone.Basic
 import Mathlib.Data.Real.Archimedean
 import Mathlib.LinearAlgebra.LinearPMap
 
-
-
 /-!
 # Extension theorems
 

--- a/Mathlib/Analysis/NormedSpace/BoundedLinearMaps.lean
+++ b/Mathlib/Analysis/NormedSpace/BoundedLinearMaps.lean
@@ -8,8 +8,6 @@ import Mathlib.Analysis.NormedSpace.Units
 import Mathlib.Analysis.NormedSpace.OperatorNorm.Completeness
 import Mathlib.Analysis.NormedSpace.OperatorNorm.Mul
 
-
-
 /-!
 # Bounded linear maps
 

--- a/Mathlib/Analysis/SpecialFunctions/Pow/Real.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Pow/Real.lean
@@ -7,7 +7,6 @@ Authors: Chris Hughes, Abhimanyu Pallavi Sudhir, Jean Lo, Calle Sönne, Sébasti
 import Mathlib.Analysis.SpecialFunctions.Pow.Complex
 import Qq
 
-
 /-! # Power function on `ℝ`
 
 We construct the power functions `x ^ y`, where `x` and `y` are real numbers.

--- a/Mathlib/Analysis/SumOverResidueClass.lean
+++ b/Mathlib/Analysis/SumOverResidueClass.lean
@@ -7,7 +7,6 @@ import Mathlib.Data.ZMod.Basic
 import Mathlib.Topology.Instances.ENNReal
 import Mathlib.Analysis.Normed.Field.Basic
 
-
 /-!
 # Sums over residue classes
 

--- a/Mathlib/CategoryTheory/Limits/Types.lean
+++ b/Mathlib/CategoryTheory/Limits/Types.lean
@@ -7,8 +7,6 @@ import Mathlib.Data.TypeMax
 import Mathlib.Logic.UnivLE
 import Mathlib.CategoryTheory.Limits.Shapes.Images
 
-
-
 /-!
 # Limits in the category of types.
 

--- a/Mathlib/CategoryTheory/Subterminal.lean
+++ b/Mathlib/CategoryTheory/Subterminal.lean
@@ -7,7 +7,6 @@ import Mathlib.CategoryTheory.Limits.Shapes.BinaryProducts
 import Mathlib.CategoryTheory.Limits.Shapes.Terminal
 import Mathlib.CategoryTheory.Subobject.MonoOver
 
-
 /-!
 # Subterminal objects
 

--- a/Mathlib/Combinatorics/Enumerative/Composition.lean
+++ b/Mathlib/Combinatorics/Enumerative/Composition.lean
@@ -8,8 +8,6 @@ import Mathlib.Algebra.Order.BigOperators.Group.Finset
 import Mathlib.Data.Finset.Sort
 import Mathlib.Data.Set.Subsingleton
 
-
-
 /-!
 # Compositions
 

--- a/Mathlib/Data/DList/Basic.lean
+++ b/Mathlib/Data/DList/Basic.lean
@@ -6,7 +6,6 @@ Authors: Simon Hudon
 import Mathlib.Data.DList.Defs
 import Mathlib.Tactic.TypeStar
 
-
 /-!
 # Difference list
 

--- a/Mathlib/Data/Finset/Pointwise/Interval.lean
+++ b/Mathlib/Data/Finset/Pointwise/Interval.lean
@@ -6,7 +6,6 @@ Authors: Eric Wieser
 import Mathlib.Data.Finset.Pointwise
 import Mathlib.Data.Set.Pointwise.Interval
 
-
 /-! # Pointwise operations on intervals
 
 This should be kept in sync with `Mathlib/Data/Set/Pointwise/Interval.lean`.

--- a/Mathlib/Data/Finsupp/Weight.lean
+++ b/Mathlib/Data/Finsupp/Weight.lean
@@ -10,7 +10,6 @@ import Mathlib.Algebra.Order.Ring.Defs
 import Mathlib.Algebra.Order.Monoid.Canonical.Defs
 import Mathlib.LinearAlgebra.Finsupp
 
-
 /-! # weights of Finsupp functions
 
 The theory of multivariate polynomials and power series is built

--- a/Mathlib/Data/Matroid/Init.lean
+++ b/Mathlib/Data/Matroid/Init.lean
@@ -5,7 +5,6 @@ Authors: Peter Nelson
 -/
 import Aesop
 
-
 /-!
 # Matroid Rule Set
 

--- a/Mathlib/Data/Rat/Cast/CharZero.lean
+++ b/Mathlib/Data/Rat/Cast/CharZero.lean
@@ -6,7 +6,6 @@ Authors: Johannes Hölzl, Mario Carneiro
 import Mathlib.Algebra.GroupWithZero.Units.Lemmas
 import Mathlib.Data.Rat.Cast.Defs
 
-
 /-!
 # Casts of rational numbers into characteristic zero fields (or division rings).
 -/

--- a/Mathlib/Data/Rat/Cast/Defs.lean
+++ b/Mathlib/Data/Rat/Cast/Defs.lean
@@ -10,7 +10,6 @@ import Mathlib.Algebra.Order.Field.Rat
 import Mathlib.Data.Int.Cast.Lemmas
 import Mathlib.Data.Rat.Lemmas
 
-
 /-!
 # Casts for Rational Numbers
 

--- a/Mathlib/Data/Rat/Cast/Lemmas.lean
+++ b/Mathlib/Data/Rat/Cast/Lemmas.lean
@@ -6,7 +6,6 @@ Authors: Johannes Hölzl, Mario Carneiro
 import Mathlib.Data.Rat.Cast.Defs
 import Mathlib.Algebra.Field.Basic
 
-
 /-!
 # Some exiled lemmas about casting
 

--- a/Mathlib/Data/Vector/Defs.lean
+++ b/Mathlib/Data/Vector/Defs.lean
@@ -6,8 +6,6 @@ Authors: Leonardo de Moura
 import Mathlib.Init.Data.List.Lemmas
 import Mathlib.Tactic.Common
 
-
-
 /-!
 The type `Vector` represents lists with fixed length.
 -/

--- a/Mathlib/Data/Vector/MapLemmas.lean
+++ b/Mathlib/Data/Vector/MapLemmas.lean
@@ -6,7 +6,6 @@ Authors: Alex Keizer
 import Mathlib.Data.Vector.Basic
 import Mathlib.Data.Vector.Snoc
 
-
 /-!
   This file establishes a set of normalization lemmas for `map`/`mapAccumr` operations on vectors
 -/

--- a/Mathlib/GroupTheory/Perm/DomMulAct.lean
+++ b/Mathlib/GroupTheory/Perm/DomMulAct.lean
@@ -11,7 +11,6 @@ import Mathlib.Data.Fintype.Basic
 import Mathlib.Data.Fintype.Perm
 import Mathlib.SetTheory.Cardinal.Finite
 
-
 /-!  Subgroup of `Equiv.Perm α` preserving a function
 
 Let `α` and `ι` by types and let `f : α → ι`

--- a/Mathlib/LinearAlgebra/Dimension/Finite.lean
+++ b/Mathlib/LinearAlgebra/Dimension/Finite.lean
@@ -8,8 +8,6 @@ import Mathlib.SetTheory.Cardinal.Cofinality
 import Mathlib.LinearAlgebra.FreeModule.Finite.Basic
 import Mathlib.LinearAlgebra.Dimension.StrongRankCondition
 
-
-
 /-!
 # Conditions for rank to be finite
 

--- a/Mathlib/MeasureTheory/Order/Group/Lattice.lean
+++ b/Mathlib/MeasureTheory/Order/Group/Lattice.lean
@@ -7,7 +7,6 @@ import Mathlib.Algebra.Order.Group.PosPart
 import Mathlib.MeasureTheory.Group.Arithmetic
 import Mathlib.MeasureTheory.Order.Lattice
 
-
 /-!
 # Measurability results on groups with a lattice structure.
 

--- a/Mathlib/NumberTheory/Harmonic/ZetaAsymp.lean
+++ b/Mathlib/NumberTheory/Harmonic/ZetaAsymp.lean
@@ -6,7 +6,6 @@ Authors: David Loeffler
 import Mathlib.NumberTheory.LSeries.RiemannZeta
 import Mathlib.NumberTheory.Harmonic.GammaDeriv
 
-
 /-!
 # Asymptotics of `ζ s` as `s → 1`
 

--- a/Mathlib/Order/Basic.lean
+++ b/Mathlib/Order/Basic.lean
@@ -14,8 +14,6 @@ import Mathlib.Order.Notation
 import Batteries.Data.Sum.Lemmas
 import Batteries.Tactic.Classical
 
-
-
 /-!
 # Basic definitions about `≤` and `<`
 

--- a/Mathlib/Order/PrimeSeparator.lean
+++ b/Mathlib/Order/PrimeSeparator.lean
@@ -7,7 +7,6 @@ Authors: Sam van Gool
 import Mathlib.Order.PrimeIdeal
 import Mathlib.Order.Zorn
 
-
 /-!
 # Separating prime filters and ideals
 

--- a/Mathlib/RingTheory/Ideal/Pointwise.lean
+++ b/Mathlib/RingTheory/Ideal/Pointwise.lean
@@ -5,7 +5,6 @@ Authors: Eric Wieser
 -/
 import Mathlib.RingTheory.Ideal.Maps
 
-
 /-! # Pointwise instances on `Ideal`s
 
 This file provides the action `Ideal.pointwiseMulAction` which morally matches the action of

--- a/Mathlib/RingTheory/PowerSeries/Trunc.lean
+++ b/Mathlib/RingTheory/PowerSeries/Trunc.lean
@@ -7,7 +7,6 @@ import Mathlib.Algebra.Polynomial.Coeff
 import Mathlib.Algebra.Polynomial.Degree.Lemmas
 import Mathlib.RingTheory.PowerSeries.Basic
 
-
 /-!
 
 # Formal power series in one variable - Truncation

--- a/Mathlib/SetTheory/Ordinal/FixedPointApproximants.lean
+++ b/Mathlib/SetTheory/Ordinal/FixedPointApproximants.lean
@@ -5,7 +5,6 @@ Authors: Ira Fesefeldt
 -/
 import Mathlib.SetTheory.Ordinal.Arithmetic
 
-
 /-!
 # Ordinal Approximants for the Fixed points on complete lattices
 

--- a/Mathlib/Tactic/FunProp/Mor.lean
+++ b/Mathlib/Tactic/FunProp/Mor.lean
@@ -7,7 +7,6 @@ import Lean
 import Mathlib.Data.FunLike.Basic
 import Mathlib.Tactic.FunProp.ToBatteries
 
-
 /-!
 ## `funProp` Meta programming functions like in Lean.Expr.* but for working with bundled morphisms.
 

--- a/Mathlib/Tactic/Widget/CongrM.lean
+++ b/Mathlib/Tactic/Widget/CongrM.lean
@@ -7,7 +7,6 @@ Authors: Patrick Massot
 import Mathlib.Tactic.Widget.SelectPanelUtils
 import Mathlib.Tactic.CongrM
 
-
 /-! # CongrM widget
 
 This file defines a `congrm?` tactic that displays a widget panel allowing to generate

--- a/Mathlib/Util/FormatTable.lean
+++ b/Mathlib/Util/FormatTable.lean
@@ -5,7 +5,6 @@ Authors: Bolton Bailey
 -/
 import Mathlib.Data.String.Defs
 
-
 /-!
 # Format Table
 

--- a/Mathlib/Util/GetAllModules.lean
+++ b/Mathlib/Util/GetAllModules.lean
@@ -6,7 +6,6 @@ Authors: Mario Carneiro, Kim Morrison, Damiano Testa
 
 import Lean.Util.Path
 
-
 /-!
 # Utility functions for finding all `.lean` files or modules in a project.
 


### PR DESCRIPTION
This helps avoid some spurious diffs on `nightly-testing` and `bump` branches as we clean up from removing `#align`.