### PR TITLE
[Merged by Bors] - chore(TensorProduct/RightExactness): move three lemmas to Algebra/Exact

### DIFF
--- a/Mathlib/Algebra/Exact.lean
+++ b/Mathlib/Algebra/Exact.lean
@@ -172,6 +172,21 @@ lemma exact_of_comp_of_mem_range
     (h1 : g ∘ₗ f = 0) (h2 : ∀ x, g x = 0 → x ∈ range f) : Exact f g :=
   exact_of_comp_eq_zero_of_ker_le_range h1 h2
 
+variable {R M N P : Type*} [CommRing R]
+  [AddCommGroup M] [AddCommGroup N] [AddCommGroup P] [Module R M] [Module R N] [Module R P]
+
+lemma exact_subtype_mkQ (Q : Submodule R N) :
+    Exact (Submodule.subtype Q) (Submodule.mkQ Q) := by
+  rw [exact_iff, Submodule.ker_mkQ, Submodule.range_subtype Q]
+
+lemma exact_map_mkQ_range (f : M →ₗ[R] N) :
+    Exact f (Submodule.mkQ (range f)) :=
+  exact_iff.mpr <| Submodule.ker_mkQ _
+
+lemma exact_subtype_ker_map (g : N →ₗ[R] P) :
+    Exact (Submodule.subtype (ker g)) g :=
+  exact_iff.mpr <| (Submodule.range_subtype _).symm
+
 end LinearMap
 
 variable (f g) in

--- a/Mathlib/LinearAlgebra/TensorProduct/RightExactness.lean
+++ b/Mathlib/LinearAlgebra/TensorProduct/RightExactness.lean
@@ -6,6 +6,7 @@ Authors: Antoine Chambert-Loir
 
 import Mathlib.Algebra.Exact
 import Mathlib.RingTheory.TensorProduct.Basic
+import Mathlib.Tactic.Common
 
 /-! # Right-exactness properties of tensor product
 
@@ -163,20 +164,7 @@ variable {R M N P : Type*} [CommRing R]
     [AddCommGroup M] [AddCommGroup N] [AddCommGroup P]
     [Module R M] [Module R N] [Module R P]
 
-open Function LinearMap
-
--- TODO: Move this and related lemmas to another file
-lemma LinearMap.exact_subtype_mkQ (Q : Submodule R N) :
-    Exact (Submodule.subtype Q) (Submodule.mkQ Q) := by
-  rw [exact_iff, Submodule.ker_mkQ, Submodule.range_subtype Q]
-
-lemma LinearMap.exact_map_mkQ_range (f : M →ₗ[R] N) :
-    Exact f (Submodule.mkQ (range f)) :=
-  exact_iff.mpr <| Submodule.ker_mkQ _
-
-lemma LinearMap.exact_subtype_ker_map (g : N →ₗ[R] P) :
-    Exact (Submodule.subtype (ker g)) g :=
-  exact_iff.mpr <| (Submodule.range_subtype _).symm
+open Function
 
 variable {f : M →ₗ[R] N} {g : N →ₗ[R] P}
     (Q : Type*) [AddCommGroup Q] [Module R Q]

--- a/Mathlib/LinearAlgebra/TensorProduct/RightExactness.lean
+++ b/Mathlib/LinearAlgebra/TensorProduct/RightExactness.lean
@@ -6,7 +6,6 @@ Authors: Antoine Chambert-Loir
 
 import Mathlib.Algebra.Exact
 import Mathlib.RingTheory.TensorProduct.Basic
-import Mathlib.Tactic.Common
 
 /-! # Right-exactness properties of tensor product
 


### PR DESCRIPTION
The location was suggested by #find_home. This addresses a porting TODO.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
