### PR TITLE
[Merged by Bors] - style: remove extraneous spaces around [ arguments

### DIFF
--- a/Mathlib/Algebra/MonoidAlgebra/Grading.lean
+++ b/Mathlib/Algebra/MonoidAlgebra/Grading.lean
@@ -119,7 +119,7 @@ def decomposeAux : R[M] →ₐ[R] ⨁ i : ι, gradeBy R f i :=
         dsimp only [toAdd_one, Eq.ndrec, Set.mem_setOf_eq, ne_eq, OneHom.toFun_eq_coe,
           OneHom.coe_mk, toAdd_mul]
         convert DirectSum.of_mul_of (A := (fun i : ι => gradeBy R f i)) _ _
-        repeat { rw [ AddMonoidHom.map_add] }
+        repeat { rw [AddMonoidHom.map_add] }
         simp only [SetLike.coe_gMul]
         exact Eq.trans (by rw [one_mul]) single_mul_single.symm }
 

--- a/Mathlib/Algebra/Order/Antidiag/Prod.lean
+++ b/Mathlib/Algebra/Order/Antidiag/Prod.lean
@@ -152,7 +152,7 @@ theorem filter_fst_eq_antidiagonal (n m : A) [DecidablePred (· = m)] [Decidable
   suffices a = m → (a + b = n ↔ m ≤ n ∧ b = n - m) by
     rw [mem_filter, mem_antidiagonal, apply_ite (fun n ↦ (a, b) ∈ n), mem_singleton,
       Prod.mk.inj_iff, ite_prop_iff_or]
-    simpa [ ← and_assoc, @and_right_comm _ (a = _), and_congr_left_iff]
+    simpa [← and_assoc, @and_right_comm _ (a = _), and_congr_left_iff]
   rintro rfl
   constructor
   · rintro rfl

--- a/Mathlib/Algebra/Order/Archimedean.lean
+++ b/Mathlib/Algebra/Order/Archimedean.lean
@@ -168,7 +168,7 @@ theorem exists_floor (x : α) : ∃ fl : ℤ, ∀ z : ℤ, z ≤ fl ↔ (z : α)
 end StrictOrderedRing
 
 section LinearOrderedSemiring
-variable [LinearOrderedSemiring α] [Archimedean α] [ ExistsAddOfLE α] {x y : α}
+variable [LinearOrderedSemiring α] [Archimedean α] [ExistsAddOfLE α] {x y : α}
 
 /-- Every x greater than or equal to 1 is between two successive
 natural-number powers of every y greater than one. -/

--- a/Mathlib/Analysis/SpecialFunctions/Integrals.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Integrals.lean
@@ -782,5 +782,5 @@ theorem integral_sqrt_one_sub_sq : ∫ x in (-1 : ℝ)..1, √(1 - x ^ 2 : ℝ) 
     _ = ∫ x in (-(π / 2))..(π / 2), cos x ^ 2 := by
           refine integral_congr_ae (MeasureTheory.ae_of_all _ fun _ h => ?_)
           rw [uIoc_of_le (neg_le_self (le_of_lt (half_pos Real.pi_pos))), Set.mem_Ioc] at h
-          rw [ ← Real.cos_eq_sqrt_one_sub_sin_sq (le_of_lt h.1) h.2, pow_two]
+          rw [← Real.cos_eq_sqrt_one_sub_sin_sq (le_of_lt h.1) h.2, pow_two]
     _ = π / 2 := by simp

--- a/Mathlib/Combinatorics/Additive/FreimanHom.lean
+++ b/Mathlib/Combinatorics/Additive/FreimanHom.lean
@@ -147,7 +147,7 @@ lemma isMulFreimanHom_two :
   bijOn := hg.bijOn.comp hf.bijOn
   map_prod_eq_map_prod s t hsA htA hs ht := by
     rw [← map_map, ← map_map]
-    rw[ hg.map_prod_eq_map_prod _ _ (by rwa [card_map]) (by rwa [card_map]),
+    rw [hg.map_prod_eq_map_prod _ _ (by rwa [card_map]) (by rwa [card_map]),
       hf.map_prod_eq_map_prod hsA htA hs ht]
     · simpa using fun a h ↦ hf.bijOn.mapsTo (hsA h)
     · simpa using fun a h ↦ hf.bijOn.mapsTo (htA h)

--- a/Mathlib/LinearAlgebra/Lagrange.lean
+++ b/Mathlib/LinearAlgebra/Lagrange.lean
@@ -267,7 +267,7 @@ theorem sum_basis (hvs : Set.InjOn v s) (hs : s.Nonempty) :
 theorem basisDivisor_add_symm {x y : F} (hxy : x ≠ y) :
     basisDivisor x y + basisDivisor y x = 1 := by
   classical
-  rw [ ← sum_basis Function.injective_id.injOn ⟨x, mem_insert_self _ {y}⟩,
+  rw [← sum_basis Function.injective_id.injOn ⟨x, mem_insert_self _ {y}⟩,
     sum_insert (not_mem_singleton.mpr hxy), sum_singleton, basis_pair_left hxy,
     basis_pair_right hxy, id, id]
 

--- a/Mathlib/NumberTheory/NumberField/Discriminant.lean
+++ b/Mathlib/NumberTheory/NumberField/Discriminant.lean
@@ -205,7 +205,7 @@ theorem abs_discr_gt_two (h : 1 < finrank ℚ K) : 2 < |discr K| := by
     rw [_root_.le_div_iff (by positivity), ← _root_.div_le_iff' (by positivity), one_mul]
     linarith [Real.pi_gt_three]
   have h₂ : (9 : ℝ) < π ^ 2 := by
-    rw [ ← Real.sqrt_lt (by positivity) (by positivity), show Real.sqrt (9 : ℝ) = 3 from
+    rw [← Real.sqrt_lt (by positivity) (by positivity), show Real.sqrt (9 : ℝ) = 3 from
     (Real.sqrt_eq_iff_sq_eq (by positivity) (by positivity)).mpr (by norm_num)]
     exact Real.pi_gt_three
   refine Int.cast_lt.mp <| lt_of_lt_of_le ?_ (abs_discr_ge h)

--- a/Mathlib/Topology/Order/LawsonTopology.lean
+++ b/Mathlib/Topology/Order/LawsonTopology.lean
@@ -224,7 +224,7 @@ lemma singleton_isClosed (a : α) : IsClosed ({a} : Set α) := by
     ← WithLawson.isClosed_preimage_ofLawson]
   apply IsClosed.inter
     (lawsonClosed_of_lowerClosed _ (IsLower.isClosed_upperClosure (finite_singleton a)))
-  rw [ lowerClosure_singleton, LowerSet.coe_Iic, ← WithLawson.isClosed_preimage_ofLawson]
+  rw [lowerClosure_singleton, LowerSet.coe_Iic, ← WithLawson.isClosed_preimage_ofLawson]
   apply lawsonClosed_of_scottClosed
   exact IsScott.isClosed_Iic
 

--- a/test/Monotonicity.lean
+++ b/test/Monotonicity.lean
@@ -280,7 +280,7 @@ example {x y z w : ℕ} : true := by
 -- : (m + x + n) * z + k ≤ z * (y + n + m) + k :=
 -- begin
 --   ac_mono* : m + x + n ≤ y + n + m,
---   transitivity; [ skip , apply h₁ ],
+--   transitivity; [skip , apply h₁],
 --   apply le_of_eq,
 --   ac_refl,
 -- end


### PR DESCRIPTION
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
