### PR TITLE
[Merged by Bors] - refactor(RingTheory/Trace/Basic): remove `Field` assumptions

### DIFF
--- a/Mathlib/RingTheory/Trace/Basic.lean
+++ b/Mathlib/RingTheory/Trace/Basic.lean
@@ -125,7 +125,7 @@ theorem trace_eq_trace_adjoin [FiniteDimensional K L] (x : L) :
   conv =>
     lhs
     rw [← IntermediateField.AdjoinSimple.algebraMap_gen K x]
-  rw [← trace_trace (L := K⟮x⟯), trace_algebraMap, LinearMap.map_smul_of_tower]
+  rw [← trace_trace (S := K⟮x⟯), trace_algebraMap, LinearMap.map_smul_of_tower]
 
 variable {K}
 

--- a/Mathlib/RingTheory/Trace/Defs.lean
+++ b/Mathlib/RingTheory/Trace/Defs.lean
@@ -122,7 +122,7 @@ theorem trace_comp_trace_of_basis [Algebra S T] [IsScalarTower R S T] {ι κ : T
   rw [LinearMap.comp_apply, LinearMap.restrictScalars_apply, trace_trace_of_basis b c]
 
 @[simp]
-theorem trace_trace  [Algebra S T] [IsScalarTower R S T]
+theorem trace_trace [Algebra S T] [IsScalarTower R S T]
     [Module.Free R S] [Module.Finite R S] [Module.Free S T] [Module.Finite S T] (x : T) :
     trace R S (trace S T x) = trace R T x :=
   trace_trace_of_basis (Module.Free.chooseBasis R S) (Module.Free.chooseBasis S T) x

--- a/Mathlib/RingTheory/Trace/Defs.lean
+++ b/Mathlib/RingTheory/Trace/Defs.lean
@@ -28,8 +28,8 @@ the roots of the minimal polynomial of `s` over `R`.
 ## Implementation notes
 
 Typically, the trace is defined specifically for finite field extensions.
-The definition is as general as possible and the assumption that we have
-fields or that the extension is finite is added to the lemmas as needed.
+The definition is as general as possible and the assumption that the extension is finite
+is added to the lemmas as needed.
 
 We only define the trace for left multiplication (`Algebra.leftMulMatrix`,
 i.e. `LinearMap.mulLeft`).
@@ -46,7 +46,6 @@ universe u v w z
 
 variable {R S T : Type*} [CommRing R] [CommRing S] [CommRing T]
 variable [Algebra R S] [Algebra R T]
-variable {K L : Type*} [Field K] [Field L] [Algebra K L]
 variable {ι κ : Type w} [Fintype ι]
 
 open FiniteDimensional
@@ -97,10 +96,11 @@ theorem trace_algebraMap_of_basis (x : R) : trace R S (algebraMap R S x) = Finty
 (If `L` is not finite-dimensional over `K`, then `trace` and `finrank` return `0`.)
 -/
 @[simp]
-theorem trace_algebraMap (x : K) : trace K L (algebraMap K L x) = finrank K L • x := by
-  by_cases H : ∃ s : Finset L, Nonempty (Basis s K L)
+theorem trace_algebraMap [StrongRankCondition R] [Module.Free R S] (x : R) :
+    trace R S (algebraMap R S x) = finrank R S • x := by
+  by_cases H : ∃ s : Finset S, Nonempty (Basis s R S)
   · rw [trace_algebraMap_of_basis H.choose_spec.some, finrank_eq_card_basis H.choose_spec.some]
-  · simp [trace_eq_zero_of_not_exists_basis K H, finrank_eq_zero_of_not_exists_basis_finset H]
+  · simp [trace_eq_zero_of_not_exists_basis R H, finrank_eq_zero_of_not_exists_basis_finset H]
 
 theorem trace_trace_of_basis [Algebra S T] [IsScalarTower R S T] {ι κ : Type*} [Finite ι]
     [Finite κ] (b : Basis ι R S) (c : Basis κ S T) (x : T) :
@@ -122,14 +122,16 @@ theorem trace_comp_trace_of_basis [Algebra S T] [IsScalarTower R S T] {ι κ : T
   rw [LinearMap.comp_apply, LinearMap.restrictScalars_apply, trace_trace_of_basis b c]
 
 @[simp]
-theorem trace_trace [Algebra K T] [Algebra L T] [IsScalarTower K L T] [FiniteDimensional K L]
-    [FiniteDimensional L T] (x : T) : trace K L (trace L T x) = trace K T x :=
-  trace_trace_of_basis (Basis.ofVectorSpace K L) (Basis.ofVectorSpace L T) x
+theorem trace_trace  [Algebra S T] [IsScalarTower R S T]
+    [Module.Free R S] [Module.Finite R S] [Module.Free S T] [Module.Finite S T] (x : T) :
+    trace R S (trace S T x) = trace R T x :=
+  trace_trace_of_basis (Module.Free.chooseBasis R S) (Module.Free.chooseBasis S T) x
 
 @[simp]
-theorem trace_comp_trace [Algebra K T] [Algebra L T] [IsScalarTower K L T] [FiniteDimensional K L]
-    [FiniteDimensional L T] : (trace K L).comp ((trace L T).restrictScalars K) = trace K T := by
-  ext; rw [LinearMap.comp_apply, LinearMap.restrictScalars_apply, trace_trace]
+theorem trace_comp_trace [Algebra S T] [IsScalarTower R S T]
+    [Module.Free R S] [Module.Finite R S] [Module.Free S T] [Module.Finite S T] :
+    (trace R S).comp ((trace S T).restrictScalars R) = trace R T :=
+  LinearMap.ext trace_trace
 
 @[simp]
 theorem trace_prod_apply [Module.Free R S] [Module.Free R T] [Module.Finite R S] [Module.Finite R T]


### PR DESCRIPTION
`[Module.Free R S] [Module.Finite R S]` replaces `[FiniteDimensional K L]`

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
