### PR TITLE
[Merged by Bors] - chore: update Batteries and deprecate LazyList

### DIFF
--- a/Mathlib/Data/LazyList/Basic.lean
+++ b/Mathlib/Data/LazyList/Basic.lean
@@ -66,7 +66,8 @@ instance : LawfulTraversable LazyList := by
         Function.comp, Thunk.pure, ofList]
     · apply ih
 
-@[deprecated (since := "2024-07-22"), simp] theorem bind_singleton {α} (x : LazyList α) : x.bind singleton = x := by
+@[deprecated (since := "2024-07-22"), simp]
+theorem bind_singleton {α} (x : LazyList α) : x.bind singleton = x := by
   induction x using LazyList.rec (motive_2 := fun xs => xs.get.bind singleton = xs.get) with
   | nil => simp [LazyList.bind]
   | cons h t ih =>

--- a/Mathlib/Data/LazyList/Basic.lean
+++ b/Mathlib/Data/LazyList/Basic.lean
@@ -11,11 +11,10 @@ import Mathlib.Lean.Thunk
 /-!
 ## Definitions on lazy lists
 
-This file contains various definitions and proofs on lazy lists.
-
-TODO: This file will soon be deprecated.
+This file is entirely deprecated, and contains various definitions and proofs on lazy lists.
 -/
 
+set_option linter.deprecated false
 
 universe u
 
@@ -24,6 +23,7 @@ namespace LazyList
 open Function
 
 /-- Isomorphism between strict and lazy lists. -/
+@[deprecated (since := "2024-07-22")]
 def listEquivLazyList (α : Type*) : List α ≃ LazyList α where
   toFun := LazyList.ofList
   invFun := LazyList.toList
@@ -38,10 +38,12 @@ def listEquivLazyList (α : Type*) : List α ≃ LazyList α where
     · simp [toList, ofList]
     · simpa [ofList, toList]
 
+@[deprecated (since := "2024-07-22")]
 instance : Traversable LazyList where
   map := @LazyList.traverse Id _
   traverse := @LazyList.traverse
 
+@[deprecated (since := "2024-07-22")]
 instance : LawfulTraversable LazyList := by
   apply Equiv.isLawfulTraversable' listEquivLazyList <;> intros <;> ext <;> rename_i f xs
   · induction' xs using LazyList.rec with _ _ _ _ ih
@@ -64,7 +66,7 @@ instance : LawfulTraversable LazyList := by
         Function.comp, Thunk.pure, ofList]
     · apply ih
 
-@[simp] theorem bind_singleton {α} (x : LazyList α) : x.bind singleton = x := by
+@[deprecated (since := "2024-07-22"), simp] theorem bind_singleton {α} (x : LazyList α) : x.bind singleton = x := by
   induction x using LazyList.rec (motive_2 := fun xs => xs.get.bind singleton = xs.get) with
   | nil => simp [LazyList.bind]
   | cons h t ih =>
@@ -73,6 +75,7 @@ instance : LawfulTraversable LazyList := by
     simp [ih]
   | mk f ih => simp_all
 
+@[deprecated (since := "2024-07-22")]
 instance : LawfulMonad LazyList := LawfulMonad.mk'
   (id_map := by
     intro α xs

--- a/Mathlib/Data/Seq/Seq.lean
+++ b/Mathlib/Data/Seq/Seq.lean
@@ -402,30 +402,42 @@ def ofStream (s : Stream' α) : Seq α :=
 instance coeStream : Coe (Stream' α) (Seq α) :=
   ⟨ofStream⟩
 
+section LazyList
+
+set_option linter.deprecated false
+
 /-- Embed a `LazyList α` as a sequence. Note that even though this
   is non-meta, it will produce infinite sequences if used with
   cyclic `LazyList`s created by meta constructions. -/
+@[deprecated (since := "2024-07-22")]
 def ofLazyList : LazyList α → Seq α :=
   corec fun l =>
     match l with
     | LazyList.nil => none
     | LazyList.cons a l' => some (a, l'.get)
 
+@[deprecated (since := "2024-07-22")]
 instance coeLazyList : Coe (LazyList α) (Seq α) :=
   ⟨ofLazyList⟩
 
 /-- Translate a sequence into a `LazyList`. Since `LazyList` and `List`
   are isomorphic as non-meta types, this function is necessarily meta. -/
+@[deprecated (since := "2024-07-22")]
 unsafe def toLazyList : Seq α → LazyList α
   | s =>
     match destruct s with
     | none => LazyList.nil
     | some (a, s') => LazyList.cons a (toLazyList s')
 
+end LazyList
+
 /-- Translate a sequence to a list. This function will run forever if
   run on an infinite sequence. -/
-unsafe def forceToList (s : Seq α) : List α :=
-  (toLazyList s).toList
+unsafe def forceToList : Seq α → List α
+  | s =>
+    match destruct s with
+    | none => []
+    | some (a, s') => a :: forceToList s'
 
 /-- The sequence of natural numbers some 0, some 1, ... -/
 def nats : Seq ℕ :=

--- a/Mathlib/Testing/SlimCheck/Functions.lean
+++ b/Mathlib/Testing/SlimCheck/Functions.lean
@@ -393,12 +393,12 @@ def Perm.slice [DecidableEq α] (n m : ℕ) :
 /-- A lazy list, in decreasing order, of sizes that should be
 sliced off a list of length `n`
 -/
-def sliceSizes : ℕ → LazyList ℕ+
+def sliceSizes : ℕ → List ℕ+
   | n =>
     if h : 0 < n then
       have : n / 2 < n := Nat.div_lt_self h (by decide : 1 < 2)
-      LazyList.cons ⟨_, h⟩ (sliceSizes <| n / 2)
-    else LazyList.nil
+      ⟨_, h⟩ :: (sliceSizes <| n / 2)
+    else []
 
 /-- Shrink a permutation of a list, slicing a segment in the middle.
 
@@ -410,7 +410,7 @@ protected def shrinkPerm {α : Type} [DecidableEq α] :
     (Σ' xs ys : List α, xs ~ ys ∧ ys.Nodup) → List (Σ' xs ys : List α, xs ~ ys ∧ ys.Nodup)
   | xs => do
     let k := xs.1.length
-    let n ← (sliceSizes k).toList
+    let n ← sliceSizes k
     let i ← List.finRange <| k / n
     pure <| Perm.slice (i * n) n xs
 

--- a/Mathlib/Testing/SlimCheck/Functions.lean
+++ b/Mathlib/Testing/SlimCheck/Functions.lean
@@ -390,7 +390,7 @@ def Perm.slice [DecidableEq α] (n m : ℕ) :
     have h₀ : xs' ~ ys.inter xs' := List.Perm.dropSlice_inter _ _ h h'
     ⟨xs', ys.inter xs', h₀, h'.inter _⟩
 
-/-- A lazy list, in decreasing order, of sizes that should be
+/-- A list, in decreasing order, of sizes that should be
 sliced off a list of length `n`
 -/
 def sliceSizes : ℕ → List ℕ+

--- a/Mathlib/Testing/SlimCheck/Functions.lean
+++ b/Mathlib/Testing/SlimCheck/Functions.lean
@@ -9,7 +9,6 @@ import Mathlib.Data.Finsupp.Defs
 import Mathlib.Data.Finsupp.ToDFinsupp
 import Mathlib.Testing.SlimCheck.Sampleable
 import Mathlib.Testing.SlimCheck.Testable
-import Batteries.Data.LazyList
 
 /-!
 ## `slim_check`: generators for functions

--- a/lake-manifest.json
+++ b/lake-manifest.json
@@ -5,7 +5,7 @@
    "type": "git",
    "subDir": null,
    "scope": "leanprover-community",
-   "rev": "ac82ca1064a77eb76d37ae2ab2d1cdeb942d57fe",
+   "rev": "d2b1546c5fc05a06426e3f6ee1cb020e71be5592",
    "name": "batteries",
    "manifestFile": "lake-manifest.json",
    "inputRev": "main",


### PR DESCRIPTION
`LazyList` was deprecated in Batteries (with an indication to use `MLList` instead). The uses in Mathlib were trivial, as they were immediately forced to a `List` anyway. This PR deprecates the code about `LazyList`, and replaces the lazy-but-not-really code with strict versions.