### PR TITLE
fix(LinearAlgebra/Alternating/Basic): fix `MultilinearMap.alternatization`

### DIFF
--- a/Mathlib/Data/Nat/Factorial/SuperFactorial.lean
+++ b/Mathlib/Data/Nat/Factorial/SuperFactorial.lean
@@ -116,7 +116,7 @@ theorem superFactorial_dvd_vandermonde_det {n : ℕ} (v : Fin (n + 1) → ℤ) :
   let m := inf' univ ⟨0, mem_univ _⟩ v
   let w' := fun i ↦ (v i - m).toNat
   have hw' : ∀ i, (w' i : ℤ) = v i - m := fun i ↦ Int.toNat_sub_of_le (inf'_le _ (mem_univ _))
-  have h := Matrix.det_eval_matrixOfPolynomials_eq_det_vandermonde (fun i ↦ ↑(w' i))
+  have h := Matrix.det_eval_matrixOfPolynomials_eq_det_vandermonde (R := ℤ) (fun i ↦ ↑(w' i))
       (fun i => descPochhammer ℤ i)
       (fun i => descPochhammer_natDegree ℤ i)
       (fun i => monic_descPochhammer ℤ i)

--- a/Mathlib/LinearAlgebra/Alternating/Basic.lean
+++ b/Mathlib/LinearAlgebra/Alternating/Basic.lean
@@ -790,10 +790,8 @@ def alternatization : MultilinearMap R (fun _ : ι => M) N' →+ M [⋀^ι]→�
       AlternatingMap.coe_mk, coe_mk, AlternatingMap.zero_apply]
 
 theorem alternatization_def (m : MultilinearMap R (fun _ : ι => M) N') :
-    ⇑(alternatization m) = (∑ σ : Perm ι, Equiv.Perm.sign σ • m.domDomCongr σ : _) := by
-  unfold alternatization
-  ext
-  simp
+    ⇑(alternatization m) = (∑ σ : Perm ι, Equiv.Perm.sign σ • m.domDomCongr σ : _) :=
+  alternatization_map_eq_coe_aux _
 
 theorem alternatization_coe (m : MultilinearMap R (fun _ : ι => M) N') :
     ↑(alternatization m) = (∑ σ : Perm ι, Equiv.Perm.sign σ • m.domDomCongr σ : _) :=

--- a/Mathlib/LinearAlgebra/Alternating/Basic.lean
+++ b/Mathlib/LinearAlgebra/Alternating/Basic.lean
@@ -763,13 +763,12 @@ private lemma alternatization_map_eq_coe_aux (m : MultilinearMap R (fun _ : ι =
 
 private theorem alternization_map_eq_zero_of_eq_aux (m : MultilinearMap R (fun _ : ι => M) N')
     (v : ι → M) (i j : ι) (hv : v i = v j) (i_ne_j : i ≠ j) :
-    ∑ σ : Perm ι, Equiv.Perm.sign σ • m.domDomCongr σ v = 0 := by
-  exact
-    Finset.sum_involution (fun σ _ => swap i j * σ)
-      -- Porting note: `-Equiv.Perm.sign_swap'` is required.
-      (fun σ _ => by simp [Perm.sign_swap i_ne_j, apply_swap_eq_self hv, -Equiv.Perm.sign_swap'])
-      (fun σ _ _ => (not_congr swap_mul_eq_iff).mpr i_ne_j) (fun σ _ => Finset.mem_univ _)
-      fun σ _ => swap_mul_involutive i j σ
+    ∑ σ : Perm ι, Equiv.Perm.sign σ • m.domDomCongr σ v = 0 :=
+  Finset.sum_involution (fun σ _ => swap i j * σ)
+    -- Porting note: `-Equiv.Perm.sign_swap'` is required.
+    (fun σ _ => by simp [Perm.sign_swap i_ne_j, apply_swap_eq_self hv, -Equiv.Perm.sign_swap'])
+    (fun σ _ _ => (not_congr swap_mul_eq_iff).mpr i_ne_j) (fun σ _ => Finset.mem_univ _)
+    fun σ _ => swap_mul_involutive i j σ
 
 /-- Produce an `AlternatingMap` out of a `MultilinearMap`, by summing over all argument
 permutations. -/
@@ -791,11 +790,11 @@ def alternatization : MultilinearMap R (fun _ : ι => M) N' →+ M [⋀^ι]→�
 
 theorem alternatization_def (m : MultilinearMap R (fun _ : ι => M) N') :
     ⇑(alternatization m) = (∑ σ : Perm ι, Equiv.Perm.sign σ • m.domDomCongr σ : _) :=
-  alternatization_map_eq_coe_aux _
+  alternatization_map_eq_coe_aux m
 
 theorem alternatization_coe (m : MultilinearMap R (fun _ : ι => M) N') :
     ↑(alternatization m) = (∑ σ : Perm ι, Equiv.Perm.sign σ • m.domDomCongr σ : _) :=
-  coe_injective (alternatization_map_eq_coe_aux _)
+  coe_injective (alternatization_map_eq_coe_aux m)
 
 theorem alternatization_apply (m : MultilinearMap R (fun _ : ι => M) N') (v : ι → M) :
     alternatization m v = ∑ σ : Perm ι, Equiv.Perm.sign σ • m.domDomCongr σ v := by

--- a/Mathlib/LinearAlgebra/Alternating/Basic.lean
+++ b/Mathlib/LinearAlgebra/Alternating/Basic.lean
@@ -795,7 +795,7 @@ theorem alternatization_def (m : MultilinearMap R (fun _ : ι => M) N') :
 
 theorem alternatization_coe (m : MultilinearMap R (fun _ : ι => M) N') :
     ↑(alternatization m) = (∑ σ : Perm ι, Equiv.Perm.sign σ • m.domDomCongr σ : _) :=
-  coe_injective (by simp only [AlternatingMap.coe_multilinearMap, alternatization_def, coe_sum])
+  coe_injective (alternatization_map_eq_coe_aux _)
 
 theorem alternatization_apply (m : MultilinearMap R (fun _ : ι => M) N') (v : ι → M) :
     alternatization m v = ∑ σ : Perm ι, Equiv.Perm.sign σ • m.domDomCongr σ v := by

--- a/Mathlib/LinearAlgebra/Alternating/Basic.lean
+++ b/Mathlib/LinearAlgebra/Alternating/Basic.lean
@@ -763,8 +763,7 @@ private lemma alternatization_map_eq_coe_aux (m : MultilinearMap R (fun _ : ι =
 
 private theorem alternization_map_eq_zero_of_eq_aux (m : MultilinearMap R (fun _ : ι => M) N')
     (v : ι → M) (i j : ι) (hv : v i = v j) (i_ne_j : i ≠ j) :
-    (∑ σ : Perm ι, Equiv.Perm.sign σ • m.domDomCongr σ) v = 0 := by
-  rw [sum_apply]
+    ∑ σ : Perm ι, Equiv.Perm.sign σ • m.domDomCongr σ v = 0 := by
   exact
     Finset.sum_involution (fun σ _ => swap i j * σ)
       -- Porting note: `-Equiv.Perm.sign_swap'` is required.
@@ -779,9 +778,7 @@ def alternatization : MultilinearMap R (fun _ : ι => M) N' →+ M [⋀^ι]→�
     { toFun := fun x ↦ ∑ σ : Perm ι, Equiv.Perm.sign σ • m.domDomCongr σ x
       map_add' := by rw [alternatization_map_eq_coe_aux]; simp
       map_smul' := by rw [alternatization_map_eq_coe_aux]; simp
-      map_eq_zero_of_eq' := by
-        simp (config := {beta := false}) only [alternatization_map_eq_coe_aux]
-        apply alternization_map_eq_zero_of_eq_aux
+      map_eq_zero_of_eq' := alternization_map_eq_zero_of_eq_aux m
     }
   map_add' a b := by
     ext

--- a/Mathlib/LinearAlgebra/Alternating/Basic.lean
+++ b/Mathlib/LinearAlgebra/Alternating/Basic.lean
@@ -755,7 +755,7 @@ open Equiv
 
 variable [Fintype ι] [DecidableEq ι]
 
-private lemma eq_val (m : MultilinearMap R (fun _ : ι => M) N') :
+private lemma alternatization_map_eq_coe_aux (m : MultilinearMap R (fun _ : ι => M) N') :
     (fun x ↦ ∑ σ : Perm ι, Equiv.Perm.sign σ • m.domDomCongr σ x) =
       ⇑(∑ σ : Perm ι, Equiv.Perm.sign σ • m.domDomCongr σ) := by
   ext
@@ -777,11 +777,10 @@ permutations. -/
 def alternatization : MultilinearMap R (fun _ : ι => M) N' →+ M [⋀^ι]→ₗ[R] N' where
   toFun m :=
     { toFun := fun x ↦ ∑ σ : Perm ι, Equiv.Perm.sign σ • m.domDomCongr σ x
-      map_add' := by rw [eq_val]; simp
-      map_smul' := by rw [eq_val]; simp
+      map_add' := by rw [alternatization_map_eq_coe_aux]; simp
+      map_smul' := by rw [alternatization_map_eq_coe_aux]; simp
       map_eq_zero_of_eq' := by
-        dsimp (config := {beta := false}) only
-        rw [eq_val]
+        simp (config := {beta := false}) only [alternatization_map_eq_coe_aux]
         apply alternization_map_eq_zero_of_eq_aux
     }
   map_add' a b := by

--- a/Mathlib/LinearAlgebra/Alternating/Basic.lean
+++ b/Mathlib/LinearAlgebra/Alternating/Basic.lean
@@ -798,7 +798,7 @@ theorem alternatization_coe (m : MultilinearMap R (fun _ : ι => M) N') :
 
 theorem alternatization_apply (m : MultilinearMap R (fun _ : ι => M) N') (v : ι → M) :
     alternatization m v = ∑ σ : Perm ι, Equiv.Perm.sign σ • m.domDomCongr σ v := by
-  simp only [alternatization_def, smul_apply, sum_apply]
+  rfl
 
 end MultilinearMap
 

--- a/test/DetOne.lean
+++ b/test/DetOne.lean
@@ -1,6 +1,11 @@
 import Mathlib.LinearAlgebra.Determinant
 
-/-- see https://leanprover.zulipchat.com/#narrow/stream/287929-mathlib4/topic/kernel.20deep.20recursion.20detected -/
+/--
+Check that using Matrix.det_one for an explicit matrix doesn't cause a
+(kernel) deep recursion detected
+error, see
+https://leanprover.zulipchat.com/#narrow/stream/287929-mathlib4/topic/kernel.20deep.20recursion.20detected
+-/
 
 example : (1 : Matrix (Fin 8) (Fin 8) ℚ).det = 1 := by
   rw [Matrix.det_one]

--- a/test/DetOne.lean
+++ b/test/DetOne.lean
@@ -1,0 +1,20 @@
+import Mathlib.LinearAlgebra.Determinant
+
+/-- see https://leanprover.zulipchat.com/#narrow/stream/287929-mathlib4/topic/kernel.20deep.20recursion.20detected -/
+
+example : (1 : Matrix (Fin 8) (Fin 8) ℚ).det = 1 := by
+  rw [Matrix.det_one]
+
+example : (1 : Matrix (Fin 8) (Fin 8) ℚ).det = 1 := Matrix.det_one
+
+example : (1 : Matrix (Fin 8) (Fin 8) ℚ).det = 1 := by
+  have := Matrix.det_one (n := Fin 8) (R := ℚ)
+  exact this
+
+/--
+warning: declaration uses 'sorry'
+-/
+#guard_msgs in
+example : (1 : Matrix (Fin 8) (Fin 8) ℚ).det = 1 := by
+  unfold Matrix.det Matrix.detRowAlternating MultilinearMap.alternatization
+  sorry


### PR DESCRIPTION
See https://leanprover.zulipchat.com/#narrow/stream/287929-mathlib4/topic/kernel.20deep.20recursion.20detected.

Fix
```lean
import Mathlib.LinearAlgebra.Determinant

example : (1 : Matrix (Fin 8) (Fin 8) ℚ).det = 1 := by
  rw [Matrix.det_one]
```

causing a `(kernel) deep recursion detected` error.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
