### PR TITLE
[Merged by Bors] - chore(Finset): Rename `noncommProd_map` to `map_noncommProd`

### DIFF
--- a/Mathlib/Data/Finset/NoncommProd.lean
+++ b/Mathlib/Data/Finset/NoncommProd.lean
@@ -162,17 +162,21 @@ lemma noncommProd_induction (s : Multiset α) (comm)
 variable [FunLike F α β]
 
 @[to_additive]
-protected theorem noncommProd_map_aux [MonoidHomClass F α β] (s : Multiset α)
+protected theorem map_noncommProd_aux [MonoidHomClass F α β] (s : Multiset α)
     (comm : { x | x ∈ s }.Pairwise Commute) (f : F) : { x | x ∈ s.map f }.Pairwise Commute := by
   simp only [Multiset.mem_map]
   rintro _ ⟨x, hx, rfl⟩ _ ⟨y, hy, rfl⟩ _
   exact (comm.of_refl hx hy).map f
 
 @[to_additive]
-theorem noncommProd_map [MonoidHomClass F α β] (s : Multiset α) (comm) (f : F) :
-    f (s.noncommProd comm) = (s.map f).noncommProd (Multiset.noncommProd_map_aux s comm f) := by
+theorem map_noncommProd [MonoidHomClass F α β] (s : Multiset α) (comm) (f : F) :
+    f (s.noncommProd comm) = (s.map f).noncommProd (Multiset.map_noncommProd_aux s comm f) := by
   induction s using Quotient.inductionOn
   simpa using map_list_prod f _
+
+@[deprecated (since := "2024-07-23")] alias noncommProd_map := map_noncommProd
+@[deprecated (since := "2024-07-23")]
+protected alias noncommProd_map_aux := Multiset.map_noncommProd_aux
 
 @[to_additive noncommSum_eq_card_nsmul]
 theorem noncommProd_eq_pow_card (s : Multiset α) (comm) (m : α) (h : ∀ x ∈ s, x = m) :
@@ -308,10 +312,12 @@ theorem noncommProd_singleton (a : α) (f : α → β) :
 variable [FunLike F β γ]
 
 @[to_additive]
-theorem noncommProd_map [MonoidHomClass F β γ] (s : Finset α) (f : α → β) (comm) (g : F) :
+theorem map_noncommProd [MonoidHomClass F β γ] (s : Finset α) (f : α → β) (comm) (g : F) :
     g (s.noncommProd f comm) =
       s.noncommProd (fun i => g (f i)) fun x hx y hy _ => (comm.of_refl hx hy).map g := by
-  simp [noncommProd, Multiset.noncommProd_map]
+  simp [noncommProd, Multiset.map_noncommProd]
+
+@[deprecated (since := "2024-07-23")] alias noncommProd_map := map_noncommProd
 
 @[to_additive noncommSum_eq_card_nsmul]
 theorem noncommProd_eq_pow_card (s : Finset α) (f : α → β) (comm) (m : β) (h : ∀ x ∈ s, f x = m) :
@@ -402,7 +408,7 @@ theorem noncommProd_mul_single [Fintype ι] [DecidableEq ι] (x : ∀ i, M i) :
     (univ.noncommProd (fun i => Pi.mulSingle i (x i)) fun i _ j _ _ =>
         Pi.mulSingle_apply_commute x i j) = x := by
   ext i
-  apply (univ.noncommProd_map (fun i ↦ MonoidHom.mulSingle M i (x i)) ?a
+  apply (univ.map_noncommProd (fun i ↦ MonoidHom.mulSingle M i (x i)) ?a
     (Pi.evalMonoidHom M i)).trans
   case a =>
     intro i _ j _ _
@@ -426,7 +432,7 @@ theorem _root_.MonoidHom.pi_ext [Finite ι] [DecidableEq ι] {f g : (∀ i, M i)
     (h : ∀ i x, f (Pi.mulSingle i x) = g (Pi.mulSingle i x)) : f = g := by
   cases nonempty_fintype ι
   ext x
-  rw [← noncommProd_mul_single x, univ.noncommProd_map, univ.noncommProd_map]
+  rw [← noncommProd_mul_single x, univ.map_noncommProd, univ.map_noncommProd]
   congr 1 with i; exact h i (x i)
 
 end FinitePi

--- a/Mathlib/Data/Finset/NoncommProd.lean
+++ b/Mathlib/Data/Finset/NoncommProd.lean
@@ -175,8 +175,11 @@ theorem map_noncommProd [MonoidHomClass F α β] (s : Multiset α) (comm) (f : F
   simpa using map_list_prod f _
 
 @[deprecated (since := "2024-07-23")] alias noncommProd_map := map_noncommProd
+@[deprecated (since := "2024-07-23")] alias noncommSum_map := map_noncommSum
 @[deprecated (since := "2024-07-23")]
 protected alias noncommProd_map_aux := Multiset.map_noncommProd_aux
+@[deprecated (since := "2024-07-23")]
+protected alias noncommSum_map_aux := Multiset.map_noncommSum_aux
 
 @[to_additive noncommSum_eq_card_nsmul]
 theorem noncommProd_eq_pow_card (s : Multiset α) (comm) (m : α) (h : ∀ x ∈ s, x = m) :
@@ -318,6 +321,7 @@ theorem map_noncommProd [MonoidHomClass F β γ] (s : Finset α) (f : α → β)
   simp [noncommProd, Multiset.map_noncommProd]
 
 @[deprecated (since := "2024-07-23")] alias noncommProd_map := map_noncommProd
+@[deprecated (since := "2024-07-23")] alias noncommSum_map := map_noncommSum
 
 @[to_additive noncommSum_eq_card_nsmul]
 theorem noncommProd_eq_pow_card (s : Finset α) (f : α → β) (comm) (m : β) (h : ∀ x ∈ s, f x = m) :

--- a/Mathlib/RingTheory/PiTensorProduct.lean
+++ b/Mathlib/RingTheory/PiTensorProduct.lean
@@ -208,7 +208,7 @@ def liftAlgHom {S : Type*} [Semiring S] [Algebra R S]
 @[simp] lemma tprod_noncommProd {κ : Type*} (s : Finset κ) (x : κ → Π i, A i) (hx) :
     tprod R (s.noncommProd x hx) = s.noncommProd (fun k => tprod R (x k))
       (hx.imp fun _ _ => Commute.tprod) :=
-  Finset.noncommProd_map s x _ (tprodMonoidHom R)
+  Finset.map_noncommProd s x _ (tprodMonoidHom R)
 
 /-- To show two algebra morphisms from finite tensor products are equal, it suffices to show that
 they agree on elements of the form $1 ⊗ ⋯ ⊗ a ⊗ 1 ⊗ ⋯$. -/


### PR DESCRIPTION
This matches the naming of `map_multiset_prod`

Moves:
- Multiset.noncommProd_map_aux -> Multiset.map_noncommProd_aux
- Multiset.noncommSum_map_aux -> Multiset.map_noncommSum_aux
- Multiset.noncommProd_map -> Multiset.map_noncommProd
- Multiset.noncommSum_map -> Multiset.map_noncommSum
- Finset.noncommProd_map -> Finset.map_noncommProd
- Finset.noncommSum_map -> Finset.map_noncommSum

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
