### PR TITLE
feat: the category of pointed objects of a concrete category

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -1383,6 +1383,7 @@ import Mathlib.CategoryTheory.ConcreteCategory.Bundled
 import Mathlib.CategoryTheory.ConcreteCategory.BundledHom
 import Mathlib.CategoryTheory.ConcreteCategory.Elementwise
 import Mathlib.CategoryTheory.ConcreteCategory.EpiMono
+import Mathlib.CategoryTheory.ConcreteCategory.Pointed
 import Mathlib.CategoryTheory.ConcreteCategory.ReflectsIso
 import Mathlib.CategoryTheory.ConcreteCategory.UnbundledHom
 import Mathlib.CategoryTheory.Conj

--- a/Mathlib/CategoryTheory/ConcreteCategory/Pointed.lean
+++ b/Mathlib/CategoryTheory/ConcreteCategory/Pointed.lean
@@ -62,10 +62,9 @@ namespace Pointed
 lemma ext {A B : Pointed C} (h₁ : A.obj = B.obj)
     (h₂ : (forget C).map (eqToHom h₁) A.pt = B.pt) :
     A = B := by
-  obtain ⟨X, x⟩ := A
-  obtain ⟨Y, y⟩ := B
+  cases A
+  cases B
   cases h₁
-  congr 1
   aesop
 
 /-- The type of morphisms between pointed objects. A morphism of pointed objects is a morphism

--- a/Mathlib/CategoryTheory/ConcreteCategory/Pointed.lean
+++ b/Mathlib/CategoryTheory/ConcreteCategory/Pointed.lean
@@ -124,14 +124,14 @@ instance : (forget (Pointed C)).Faithful := by
 def toCategoryOfElement :
     Pointed C ⥤ (forget C).Elements where
   obj X := ⟨X.obj, X.pt⟩
-  map {X Y} f := ⟨f.obj, f.pt⟩
+  map f := ⟨f.obj, f.pt⟩
 
 /-- The reverse direction of the equivalence `Pointed C ≌ (forget C).Elements`. -/
 @[simps map]
 def fromCategoryOfElements :
     (forget C).Elements ⥤ Pointed C where
   obj X := ⟨X.1, X.2⟩
-  map {X Y} f := ⟨f.1, f.2⟩
+  map f := ⟨f.1, f.2⟩
 
 /-- The equivalence between `Pointed C` and the category of elements of the forgetful
 functor of `C`. -/

--- a/Mathlib/CategoryTheory/ConcreteCategory/Pointed.lean
+++ b/Mathlib/CategoryTheory/ConcreteCategory/Pointed.lean
@@ -60,7 +60,7 @@ namespace Pointed
 
 @[ext]
 lemma ext {A B : Pointed C} (h₁ : A.obj = B.obj)
-    (h₂ : ConcreteCategory.forget.map (eqToHom h₁) A.pt = B.pt) :
+    (h₂ : (forget C).map (eqToHom h₁) A.pt = B.pt) :
     A = B := by
   obtain ⟨X, x⟩ := A
   obtain ⟨Y, y⟩ := B

--- a/Mathlib/CategoryTheory/ConcreteCategory/Pointed.lean
+++ b/Mathlib/CategoryTheory/ConcreteCategory/Pointed.lean
@@ -68,11 +68,11 @@ lemma ext {A B : Pointed C} (h₁ : A.obj = B.obj)
   aesop
 
 /-- The type of morphisms between pointed objects. A morphism of pointed objects is a morphism
-in the original category between the objects which preserve the basepoints. -/
+in the original category between the objects which preserves the basepoints. -/
 structure Hom (A B : Pointed C) where
   /-- the object morphism -/
   obj : A.obj ⟶ B.obj
-  /-- compatibility with the basedpoint -/
+  /-- compatibility with the basepoint -/
   pt : obj A.pt = B.pt := by aesop_cat
 
 /-- The category structure on the category of pointed objects. -/

--- a/Mathlib/CategoryTheory/ConcreteCategory/Pointed.lean
+++ b/Mathlib/CategoryTheory/ConcreteCategory/Pointed.lean
@@ -1,0 +1,171 @@
+/-
+Copyright (c) 2024 Sina Hazratpour. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Sina Hazratpour
+-/
+import Mathlib.CategoryTheory.Elements
+import Mathlib.CategoryTheory.ConcreteCategory.Basic
+
+/-!
+# The category of pointed objects of a concrete category
+
+This file defines the category of pointed objects of a concrete category. In a concrete category
+`C`, a pointed object is an object `X` together with a distinguished element of the underlying type
+of `X`, often called the basepoint.
+
+## Main definitions
+
+* `Pointed C` is the type of pointed objects in a concrete category `C`. We equip this type
+  with a category structure where the morphisms are the morphisms of the original category that
+  preserve the basepoint.
+
+### Implementation notes
+
+This construction is equivalent to a special case of the category of elements construction and
+also to a particular comma construction. This files provides a more convenient API for directly
+working with the category of pointed objects. We prove the equivalences in
+`CategoryTheory.ConcreteCategory.Pointed.elementsEquivalence` and
+`CategoryTheory.ConcreteCategory.structuredArrowEquivalence`.
+-/
+
+namespace CategoryTheory
+
+universe w v u
+
+variable {C : Type u} [Category.{v} C] [ConcreteCategory.{w,v,u} C]
+
+namespace ConcreteCategory
+
+attribute [local instance] ConcreteCategory.hasCoeToSort
+attribute [local instance] ConcreteCategory.instFunLike
+
+variable (C) in
+
+/-- The pointed objects of a category `C`. A pointed object in `C` is an object `X : C`
+together with a distinguished element `x` of the underlying type of `X`, often called
+the basepoint.
+ -/
+class Pointed where
+  /-- the underlying object -/
+  obj : C
+  /-- the basepoint -/
+  pt : obj
+
+namespace Pointed
+
+@[ext]
+lemma ext {A B : Pointed C} (h₁ : A.obj = B.obj)
+    (h₂ : ConcreteCategory.forget.map (eqToHom h₁) A.pt = B.pt) :
+    A = B := by
+  obtain ⟨X, x⟩ := A
+  obtain ⟨Y, y⟩ := B
+  cases h₁
+  congr 1
+  aesop
+
+/-- The type of morphisms between pointed objects. A morphism of pointed objects is a morphism
+in the original category between the objects which preserve the basepoints. -/
+structure Hom (A B : Pointed C) where
+  /-- the object morphism -/
+  obj : A.obj ⟶ B.obj
+  /-- compatibility with the basedpoint -/
+  pt : obj A.pt = B.pt := by aesop_cat
+
+/-- The category structure on the category of pointed objects. -/
+@[simps!]
+instance category : Category (Pointed C) where
+  Hom := Pointed.Hom
+  id A := ⟨𝟙 A.obj, by aesop_cat⟩
+  comp {X Y Z} f g := ⟨f.obj ≫ g.obj, by
+    simp [f.pt, g.pt]⟩
+
+/-- Constructor for morphisms of the category pointed objects. -/
+@[simps!]
+def homMk (A B : Pointed C) (f : A.obj ⟶ B.obj) (hf : f A.pt = B.pt) :
+    A ⟶ B :=
+  ⟨f, hf⟩
+
+@[ext]
+theorem Hom.ext {A B : Pointed C} (f g : A ⟶ B) (w : f.obj = g.obj) : f = g := by
+  cases f
+  cases g
+  cases w
+  rfl
+
+@[simp]
+theorem comp_obj {A B C : Pointed C} {f : A ⟶ B} {g : B ⟶ C} :
+  (f ≫ g).obj = f.obj ≫ g.obj := rfl
+
+@[simp]
+theorem id_obj {A : Pointed C} : (𝟙 A : A ⟶ A).obj = 𝟙 A.obj := rfl
+
+@[simp]
+theorem id_pt {A B : Pointed C} (f : A ⟶ B) : f.obj A.pt = B.pt := f.pt
+
+instance concreteCategory : ConcreteCategory (Pointed C) where
+  forget :=
+    { obj := fun A ↦ A.obj
+      map := fun f ↦ f.obj }
+  forget_faithful := by
+    refine ⟨@fun X Y ↦ ?_⟩
+    dsimp
+    fapply Function.Injective.comp
+    · apply forget_faithful.map_injective
+    · apply Hom.ext
+
+instance : (forget (Pointed C)).Faithful := by
+  exact forget_faithful
+
+@[simps obj]
+def toCategoryOfElement :
+    Pointed C ⥤ (forget C).Elements where
+  obj X := ⟨X.obj, X.pt⟩
+  map {X Y} f := ⟨f.obj, f.pt⟩
+
+@[simps map]
+def fromCategoryOfElements :
+    (forget C).Elements ⥤ Pointed C where
+  obj X := ⟨X.1, X.2⟩
+  map {X Y} f := ⟨f.1, f.2⟩
+
+/-- The equivalence between `Pointed C` and the category of elements of the forgetful
+functor of `C`. -/
+@[simps! functor_obj functor_map inverse_obj inverse_map unitIso_hom
+  unitIso_inv counitIso_hom counitIso_inv]
+def elementsEquivalence : Pointed C ≌ (forget C).Elements :=
+  Equivalence.mk (toCategoryOfElement) (fromCategoryOfElements)
+    (NatIso.ofComponents fun X => eqToIso (by aesop_cat))
+    (NatIso.ofComponents fun X => eqToIso (by aesop_cat))
+
+/-- The equivalence between `Pointed C` and the comma category `(*, ConcreteCategory.forget)`. -/
+@[simps! functor_obj functor_map inverse_obj inverse_map unitIso_hom
+  unitIso_inv counitIso_hom counitIso_inv]
+def structuredArrowEquivalence :
+    Pointed C ≌ StructuredArrow PUnit (forget C) :=
+  (elementsEquivalence).trans (CategoryOfElements.structuredArrowEquivalence _)
+
+variable {D : Type u} [Category.{v} D] [ConcreteCategory.{w,v,u} D]
+
+/-- For a map of concrete categories, `Pointed.map` takes the pointed objects of `C` to
+the pointed objects of `D`. -/
+@[simps!]
+def map [HasForget₂ C D] (A : Pointed C) : Pointed D where
+  obj := (forget₂ C D).obj A.obj
+  pt := by
+    rw [← Functor.comp_obj, HasForget₂.forget_comp]
+    exact A.pt
+
+/-- A map of concrete categories induces a functor between the correponding category of pointed
+objects. -/
+@[simps!]
+def functor [HasForget₂ C D] : Pointed C ⥤ Pointed D :=
+  toCategoryOfElement ⋙
+    CategoryOfElements.map (eqToHom HasForget₂.forget_comp.symm) ⋙
+      CategoryOfElements.pullback (ConcreteCategory.forget (C:= D)) (forget₂ C D) ⋙
+        fromCategoryOfElements
+
+end Pointed
+
+end ConcreteCategory
+
+end CategoryTheory

--- a/Mathlib/CategoryTheory/ConcreteCategory/Pointed.lean
+++ b/Mathlib/CategoryTheory/ConcreteCategory/Pointed.lean
@@ -19,6 +19,12 @@ of `X`, often called the basepoint.
   with a category structure where the morphisms are the morphisms of the original category that
   preserve the basepoint.
 
+* `Pointed.map`, for a map of concrete categories, takes the pointed objects of `C` to
+  the pointed objects of `D`.
+
+* `Pointed.functor` gives, for a map of concrete categories, a functor between the correponding
+  categories of pointed objects.
+
 ### Implementation notes
 
 This construction is equivalent to a special case of the category of elements construction and

--- a/Mathlib/CategoryTheory/ConcreteCategory/Pointed.lean
+++ b/Mathlib/CategoryTheory/ConcreteCategory/Pointed.lean
@@ -103,7 +103,7 @@ theorem comp_obj {A B C : Pointed C} {f : A ⟶ B} {g : B ⟶ C} : (f ≫ g).obj
 theorem id_obj {A : Pointed C} : (𝟙 A : A ⟶ A).obj = 𝟙 A.obj := rfl
 
 @[simp]
-theorem id_pt {A B : Pointed C} (f : A ⟶ B) : f.obj A.pt = B.pt := f.pt
+theorem hom_pt {A B : Pointed C} (f : A ⟶ B) : f.obj A.pt = B.pt := f.pt
 
 instance concreteCategory : ConcreteCategory (Pointed C) where
   forget :=

--- a/Mathlib/CategoryTheory/ConcreteCategory/Pointed.lean
+++ b/Mathlib/CategoryTheory/ConcreteCategory/Pointed.lean
@@ -49,8 +49,7 @@ variable (C) in
 
 /-- The pointed objects of a category `C`. A pointed object in `C` is an object `X : C`
 together with a distinguished element `x` of the underlying type of `X`, often called
-the basepoint.
- -/
+the basepoint. -/
 class Pointed where
   /-- the underlying object -/
   obj : C
@@ -121,12 +120,14 @@ instance concreteCategory : ConcreteCategory (Pointed C) where
 instance : (forget (Pointed C)).Faithful := by
   exact forget_faithful
 
+/-- The forward direction of the equivalence `Pointed C ≌ (forget C).Elements`. -/
 @[simps obj]
 def toCategoryOfElement :
     Pointed C ⥤ (forget C).Elements where
   obj X := ⟨X.obj, X.pt⟩
   map {X Y} f := ⟨f.obj, f.pt⟩
 
+/-- The reverse direction of the equivalence `Pointed C ≌ (forget C).Elements`. -/
 @[simps map]
 def fromCategoryOfElements :
     (forget C).Elements ⥤ Pointed C where

--- a/Mathlib/CategoryTheory/ConcreteCategory/Pointed.lean
+++ b/Mathlib/CategoryTheory/ConcreteCategory/Pointed.lean
@@ -47,8 +47,8 @@ attribute [local instance] ConcreteCategory.instFunLike
 
 variable (C) in
 
-/-- The pointed objects of a category `C`. A pointed object in `C` is an object `X : C`
-together with a distinguished element `x` of the underlying type of `X`, often called
+/-- The pointed objects of a category `C`. A pointed object in `C` is an object `obj : C`
+together with a distinguished element `pt` of the underlying type of `obj`, often called
 the basepoint. -/
 class Pointed where
   /-- the underlying object -/

--- a/Mathlib/CategoryTheory/ConcreteCategory/Pointed.lean
+++ b/Mathlib/CategoryTheory/ConcreteCategory/Pointed.lean
@@ -116,8 +116,6 @@ instance concreteCategory : ConcreteCategory (Pointed C) where
     · apply forget_faithful.map_injective
     · apply Hom.ext
 
-instance : (forget (Pointed C)).Faithful := by
-  exact forget_faithful
 
 /-- The forward direction of the equivalence `Pointed C ≌ (forget C).Elements`. -/
 @[simps obj]

--- a/Mathlib/CategoryTheory/ConcreteCategory/Pointed.lean
+++ b/Mathlib/CategoryTheory/ConcreteCategory/Pointed.lean
@@ -83,7 +83,7 @@ instance category : Category (Pointed C) where
   comp {X Y Z} f g := ⟨f.obj ≫ g.obj, by
     simp [f.pt, g.pt]⟩
 
-/-- Constructor for morphisms of the category pointed objects. -/
+/-- Constructor for morphisms in the category pointed objects. -/
 @[simps!]
 def homMk (A B : Pointed C) (f : A.obj ⟶ B.obj) (hf : f A.pt = B.pt) :
     A ⟶ B :=

--- a/Mathlib/CategoryTheory/ConcreteCategory/Pointed.lean
+++ b/Mathlib/CategoryTheory/ConcreteCategory/Pointed.lean
@@ -99,8 +99,7 @@ theorem Hom.ext {A B : Pointed C} (f g : A ⟶ B) (w : f.obj = g.obj) : f = g :=
   rfl
 
 @[simp]
-theorem comp_obj {A B C : Pointed C} {f : A ⟶ B} {g : B ⟶ C} :
-  (f ≫ g).obj = f.obj ≫ g.obj := rfl
+theorem comp_obj {A B C : Pointed C} {f : A ⟶ B} {g : B ⟶ C} : (f ≫ g).obj = f.obj ≫ g.obj := rfl
 
 @[simp]
 theorem id_obj {A : Pointed C} : (𝟙 A : A ⟶ A).obj = 𝟙 A.obj := rfl

--- a/Mathlib/CategoryTheory/Elements.lean
+++ b/Mathlib/CategoryTheory/Elements.lean
@@ -136,7 +136,7 @@ def map {F₁ F₂ : C ⥤ Type w} (α : F₁ ⟶ F₂) : F₁.Elements ⥤ F₂
 theorem map_π {F₁ F₂ : C ⥤ Type w} (α : F₁ ⟶ F₂) : map α ⋙ π F₂ = π F₁ :=
   rfl
 
-variable {D : Type u} [Category.{v} D] in
+variable {D : Type*} [Category D] in
 
 /-- The canonical functor between the category of elements of the base-change of `F : D ⥤ Type w`
 along a functor `G : C ⥤ D` and the category of elements of `F`.-/

--- a/Mathlib/CategoryTheory/Elements.lean
+++ b/Mathlib/CategoryTheory/Elements.lean
@@ -138,6 +138,8 @@ theorem map_π {F₁ F₂ : C ⥤ Type w} (α : F₁ ⟶ F₂) : map α ⋙ π F
 
 variable {D : Type u} [Category.{v} D] in
 
+/-- The canonical functor between the category of elements of the base-change of `F : D ⥤ Type w`
+along a functor `G : C ⥤ D` and the category of elements of `F`.-/
 @[simps obj map]
 def pullback (F : D ⥤ Type w) (G : C ⥤ D) :
     (G ⋙ F).Elements ⥤ F.Elements where

--- a/Mathlib/CategoryTheory/Elements.lean
+++ b/Mathlib/CategoryTheory/Elements.lean
@@ -136,6 +136,14 @@ def map {F₁ F₂ : C ⥤ Type w} (α : F₁ ⟶ F₂) : F₁.Elements ⥤ F₂
 theorem map_π {F₁ F₂ : C ⥤ Type w} (α : F₁ ⟶ F₂) : map α ⋙ π F₂ = π F₁ :=
   rfl
 
+variable {D : Type u} [Category.{v} D] in
+
+@[simps obj map]
+def pullback (F : D ⥤ Type w) (G : C ⥤ D) :
+    (G ⋙ F).Elements ⥤ F.Elements where
+  obj X := ⟨G.obj X.1, X.2⟩
+  map {X Y} f := ⟨G.map f.1, f.2⟩
+
 /-- The forward direction of the equivalence `F.Elements ≅ (*, F)`. -/
 def toStructuredArrow : F.Elements ⥤ StructuredArrow PUnit F where
   obj X := StructuredArrow.mk fun _ => X.2


### PR DESCRIPTION
This file defines the category of pointed objects of a concrete category. After this we will have the categories of pointed groups, pointed abelian groups, pointed groupoids, etc. 

To define `Pointed.functor`, we need to add the following "pullback" construction to the category of elements. 
```
@[simps obj map]
def pullback (F : D ⥤ Type w) (G : C ⥤ D) :
    (G ⋙ F).Elements ⥤ F.Elements where
  obj X := ⟨G.obj X.1, X.2⟩
  map {X Y} f := ⟨G.map f.1, f.2⟩
```
This is called pullback since the display map of `G ⋙ F` (i.e. `π (G ⋙ F)`) is a pullback of the display map of `F`. 

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
