### PR TITLE
[Merged by Bors] - fix(Data/Set/Sigma): address comments for #14961

### DIFF
--- a/Mathlib/Data/Set/Sigma.lean
+++ b/Mathlib/Data/Set/Sigma.lean
@@ -78,8 +78,8 @@ theorem univ_sigma_univ : (@univ ι).sigma (fun _ ↦ @univ (α i)) = univ := ex
 theorem sigma_univ : s.sigma (fun _ ↦ univ : ∀ i, Set (α i)) = Sigma.fst ⁻¹' s :=
   ext fun _ ↦ and_true_iff _
 
-@[simp] theorem univ_sigma_preimage (s : Set (Σ i, α i)) :
-    (@univ ι).sigma (fun i ↦ Sigma.mk i ⁻¹' s) = s :=
+@[simp] theorem univ_sigma_preimage_mk (s : Set (Σ i, α i)) :
+    (univ : Set ι).sigma (fun i ↦ Sigma.mk i ⁻¹' s) = s :=
   ext <| by simp
 
 @[simp]


### PR DESCRIPTION
I mistakenly approved the merge for #14961 before addressing the comments. This changes the content of the PR slightly to address them. 

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
