### PR TITLE
[Merged by Bors] - chore(Tactic/CategoryTheory/Coherence): import non-meta coherence theorem

### DIFF
--- a/Mathlib/CategoryTheory/Bicategory/Adjunction.lean
+++ b/Mathlib/CategoryTheory/Bicategory/Adjunction.lean
@@ -4,7 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Yuma Mizuno
 -/
 import Mathlib.Tactic.CategoryTheory.Coherence
-import Mathlib.CategoryTheory.Bicategory.Coherence
 
 /-!
 # Adjunctions in bicategories

--- a/Mathlib/CategoryTheory/Monoidal/Braided/Basic.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Braided/Basic.lean
@@ -3,7 +3,6 @@ Copyright (c) 2020 Scott Morrison. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Scott Morrison
 -/
-import Mathlib.CategoryTheory.Monoidal.Free.Coherence
 import Mathlib.CategoryTheory.Monoidal.Discrete
 import Mathlib.CategoryTheory.Monoidal.NaturalTransformation
 import Mathlib.CategoryTheory.Monoidal.Opposite

--- a/Mathlib/CategoryTheory/Monoidal/CoherenceLemmas.lean
+++ b/Mathlib/CategoryTheory/Monoidal/CoherenceLemmas.lean
@@ -4,7 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Michael Jendrusch, Scott Morrison, Bhavik Mehta, Jakob von Raumer
 -/
 import Mathlib.Tactic.CategoryTheory.Coherence
-import Mathlib.CategoryTheory.Monoidal.Free.Coherence
 
 /-!
 # Lemmas which are consequences of monoidal coherence

--- a/Mathlib/CategoryTheory/Monoidal/Opposite.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Opposite.lean
@@ -3,7 +3,6 @@ Copyright (c) 2020 Scott Morrison. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Scott Morrison
 -/
-import Mathlib.CategoryTheory.Monoidal.Free.Coherence
 import Mathlib.Tactic.CategoryTheory.Coherence
 
 /-!

--- a/Mathlib/CategoryTheory/Monoidal/Rigid/Basic.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Rigid/Basic.lean
@@ -3,7 +3,6 @@ Copyright (c) 2021 Jakob von Raumer. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Jakob von Raumer
 -/
-import Mathlib.CategoryTheory.Monoidal.Free.Coherence
 import Mathlib.Tactic.CategoryTheory.Coherence
 import Mathlib.CategoryTheory.Closed.Monoidal
 import Mathlib.Tactic.ApplyFun

--- a/Mathlib/Tactic/CategoryTheory/BicategoryCoherence.lean
+++ b/Mathlib/Tactic/CategoryTheory/BicategoryCoherence.lean
@@ -3,7 +3,7 @@ Copyright (c) 2022 Yuma Mizuno. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Yuma Mizuno
 -/
-import Mathlib.CategoryTheory.Bicategory.Free
+import Mathlib.CategoryTheory.Bicategory.Coherence
 import Mathlib.Tactic.CategoryTheory.BicategoricalComp
 
 /-!

--- a/Mathlib/Tactic/CategoryTheory/Coherence.lean
+++ b/Mathlib/Tactic/CategoryTheory/Coherence.lean
@@ -3,7 +3,7 @@ Copyright (c) 2022. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Scott Morrison, Yuma Mizuno, Oleksandr Manzyuk
 -/
-import Mathlib.CategoryTheory.Monoidal.Free.Basic
+import Mathlib.CategoryTheory.Monoidal.Free.Coherence
 import Mathlib.Lean.Meta
 import Mathlib.Tactic.CategoryTheory.BicategoryCoherence
 import Mathlib.Tactic.CategoryTheory.MonoidalComp
@@ -22,9 +22,6 @@ in a monoidal category which are built out of associators and unitors
 are equal.
 
 -/
-
--- Porting note: restore when ported
--- import Mathlib.CategoryTheory.Bicategory.CoherenceTactic
 
 universe v u
 

--- a/scripts/noshake.json
+++ b/scripts/noshake.json
@@ -271,9 +271,11 @@
   "Mathlib.Tactic.CategoryTheory.Reassoc":
   ["Mathlib.CategoryTheory.Functor.Basic"],
   "Mathlib.Tactic.CategoryTheory.Coherence":
-  ["Mathlib.Tactic.CategoryTheory.MonoidalComp"],
+  ["Mathlib.CategoryTheory.Monoidal.Free.Coherence",
+   "Mathlib.Tactic.CategoryTheory.MonoidalComp"],
   "Mathlib.Tactic.CategoryTheory.BicategoryCoherence":
-  ["Mathlib.Tactic.CategoryTheory.BicategoricalComp"],
+  ["Mathlib.CategoryTheory.Bicategory.Coherence",
+   "Mathlib.Tactic.CategoryTheory.BicategoricalComp"],
   "Mathlib.Tactic.CC.Addition":
   ["Mathlib.Logic.Basic", "Mathlib.Tactic.CC.Lemmas"],
   "Mathlib.Tactic.Basic": ["Mathlib.Tactic.Linter.OldObtain"],

--- a/test/CategoryTheory/Coherence.lean
+++ b/test/CategoryTheory/Coherence.lean
@@ -1,5 +1,3 @@
-import Mathlib.CategoryTheory.Monoidal.Free.Coherence
-import Mathlib.CategoryTheory.Bicategory.Coherence
 import Mathlib.Tactic.CategoryTheory.Coherence
 
 open CategoryTheory


### PR DESCRIPTION
The definition of the coherence tactic do not require the non-meta coherence theorem, but it implicitly assumes the theorem when running the meta program.

It would be confusing if the coherence tactic failed because you did import `Mathlib.Tactic.CategoryTheory.Coherence` but forgot to import `Mathlib.CategoryTheory.Monoidal.Free.Coherence`. This PR makes the first file import the second one (and similarly for the bicategory version).

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
