### PR TITLE
[Merged by Bors] - feat: the pullback of a completable topological field is a completable topological field

### DIFF
--- a/Mathlib/Topology/Algebra/UniformField.lean
+++ b/Mathlib/Topology/Algebra/UniformField.lean
@@ -195,8 +195,6 @@ instance (priority := 100) completableTopField_of_complete (L : Type*) [Field L]
         map (fun x => x⁻¹) F ≤ map (fun x => x⁻¹) (𝓝 x) := map_mono hx
         _ ≤ 𝓝 x⁻¹ := continuousAt_inv₀ hx'
 
-section Pullback
-
 variable {α β : Type*} [Field β] [b : UniformSpace β] [CompletableTopField β]
   [Field α]
 
@@ -213,5 +211,3 @@ theorem UniformInducing.completableTopField
   rw [Filter.map_comm h_comm]
   apply CompletableTopField.nice _ F_cau
   rw [← Filter.push_pull', ← map_zero f, ← hf.inducing.nhds_eq_comap, inf_F, Filter.map_bot]
-
-end Pullback

--- a/Mathlib/Topology/Algebra/UniformField.lean
+++ b/Mathlib/Topology/Algebra/UniformField.lean
@@ -214,13 +214,4 @@ theorem UniformInducing.completableTopField
   apply CompletableTopField.nice _ F_cau
   rw [← Filter.push_pull', ← map_zero f, ← hf.inducing.nhds_eq_comap, inf_F, Filter.map_bot]
 
-namespace UniformSpace
-
-instance comap_completableTopField (f : α →+* β)
-    [@T0Space α (UniformSpace.comap f b).toTopologicalSpace] :
-    @CompletableTopField _ _ (UniformSpace.comap f b) :=
-  letI := UniformSpace.comap f b; (uniformInducing_iff_uniformSpace.2 rfl).completableTopField
-
-end UniformSpace
-
 end Pullback

--- a/Mathlib/Topology/Algebra/UniformField.lean
+++ b/Mathlib/Topology/Algebra/UniformField.lean
@@ -194,3 +194,33 @@ instance (priority := 100) completableTopField_of_complete (L : Type*) [Field L]
       calc
         map (fun x => x⁻¹) F ≤ map (fun x => x⁻¹) (𝓝 x) := map_mono hx
         _ ≤ 𝓝 x⁻¹ := continuousAt_inv₀ hx'
+
+section Pullback
+
+variable {α β : Type*} [Field β] [b : UniformSpace β] [CompletableTopField β]
+  [Field α]
+
+/-- The pullback of a completable topological field along a uniform inducing
+ring homomorphism is a completable topological field. -/
+theorem UniformInducing.completableTopField
+    [UniformSpace α] [T0Space α]
+    {f : α →+* β} (hf : UniformInducing f) :
+    CompletableTopField α := by
+  refine CompletableTopField.mk (fun F F_cau inf_F => ?_)
+  rw [← UniformInducing.cauchy_map_iff hf] at F_cau ⊢
+  have h_comm : (f ∘ fun x => x⁻¹) = (fun x => x⁻¹) ∘ f := by
+    ext; simp only [Function.comp_apply, map_inv₀, Subfield.coe_inv]
+  rw [Filter.map_comm h_comm]
+  apply CompletableTopField.nice _ F_cau
+  rw [← Filter.push_pull', ← map_zero f, ← hf.inducing.nhds_eq_comap, inf_F, Filter.map_bot]
+
+namespace UniformSpace
+
+instance comap_completableTopField (f : α →+* β)
+    [@T0Space α (UniformSpace.comap f b).toTopologicalSpace] :
+    @CompletableTopField _ _ (UniformSpace.comap f b) :=
+  letI := UniformSpace.comap f b; (uniformInducing_iff_uniformSpace.2 rfl).completableTopField
+
+end UniformSpace
+
+end Pullback


### PR DESCRIPTION
This PR contains results showing that the pullback of a completable topological field under a uniform inducing ring homomorphism is a completable topological field.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

This has been split from the larger PR #13577.

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
