### PR TITLE
[Merged by Bors] - feat: Real.exists_natCast_add_one_le_pow_of_one_le

### DIFF
--- a/Mathlib/Data/Nat/Cast/Order/Ring.lean
+++ b/Mathlib/Data/Nat/Cast/Order/Ring.lean
@@ -93,4 +93,32 @@ theorem abs_ofNat [LinearOrderedRing α] (n : ℕ) [n.AtLeastTwo] :
     |(no_index (OfNat.ofNat n : α))| = OfNat.ofNat n :=
   abs_cast n
 
+lemma mul_le_pow {a : ℕ} (ha : a ≠ 1) (b : ℕ) :
+    a * b ≤ a ^ b := by
+  induction b generalizing a with
+  | zero => simp
+  | succ b hb =>
+    rw [mul_add_one, pow_succ]
+    rcases a with (_|_|a)
+    · simp
+    · simp at ha
+    · rw [mul_add_one, mul_add_one, add_comm (_ * a), add_assoc _ (_ * a)]
+      rcases b with (_|b)
+      · simp [add_assoc, add_comm]
+      refine add_le_add (hb (by simp)) ?_
+      rw [pow_succ']
+      refine (le_add_left ?_ ?_).trans' ?_
+      exact le_mul_of_one_le_right' (one_le_pow _ _ (by simp))
+
+lemma two_mul_sq_add_one_le_two_pow_two_mul (k : ℕ) : 2 * k ^ 2 + 1 ≤ 2 ^ (2 * k) := by
+  induction k with
+  | zero => simp
+  | succ k hk =>
+    rw [add_pow_two, one_pow, mul_one, add_assoc, mul_add, add_right_comm]
+    refine (add_le_add_right hk _).trans ?_
+    rw [mul_add 2 k, pow_add, mul_one, pow_two, ← mul_assoc, mul_two, mul_two, add_assoc]
+    gcongr
+    rw [← two_mul, ← pow_succ']
+    exact le_add_of_le_right (mul_le_pow (by simp) _)
+
 end Nat

--- a/Mathlib/Data/Real/Archimedean.lean
+++ b/Mathlib/Data/Real/Archimedean.lean
@@ -338,7 +338,7 @@ theorem iInter_Iic_rat : ⋂ r : ℚ, Iic (r : ℝ) = ∅ := by
 /-- Exponentiation is eventually larger than linear growth. -/
 lemma exists_natCast_add_one_lt_pow_of_one_lt {a : ℝ} (ha : 1 < a) :
     ∃ m : ℕ, (m + 1 : ℝ) < a ^ m := by
-  obtain ⟨k, posk, hk⟩ : ∃ (k : ℕ) (_ : 0 < k), a > 1 / k + 1 := by
+  obtain ⟨k, posk, hk⟩ : ∃ k : ℕ, 0 < k ∧ 1 / k + 1 < a := by
     contrapose! ha
     refine le_of_forall_lt_rat_imp_le ?_
     intro q hq

--- a/Mathlib/Data/Real/Archimedean.lean
+++ b/Mathlib/Data/Real/Archimedean.lean
@@ -336,13 +336,22 @@ theorem iInter_Iic_rat : ⋂ r : ℚ, Iic (r : ℝ) = ∅ := by
   exact iInter_Iic_eq_empty_iff.mpr not_bddBelow_coe
 
 /-- Exponentiation is eventually larger than linear growth. -/
-lemma exists_natCast_add_one_le_pow_of_one_le {a : ℝ} (ha : 1 ≤ a) :
-    ∃ m : ℕ, (m + 1 : ℝ) ≤ a ^ m := by
-  obtain ⟨k, hk⟩ : ∃ k : ℕ, a ≥ 1 / k + 1 := by
+lemma exists_natCast_add_one_lt_pow_of_one_lt {a : ℝ} (ha : 1 < a) :
+    ∃ m : ℕ, (m + 1 : ℝ) < a ^ m := by
+  obtain ⟨k, posk, hk⟩ : ∃ (k : ℕ) (_ : 0 < k), a > 1 / k + 1 := by
     contrapose! ha
-    simpa using (ha 0)
+    refine le_of_forall_lt_rat_imp_le ?_
+    intro q hq
+    refine (ha q.den (by positivity)).trans ?_
+    rw [← le_sub_iff_add_le, div_le_iff (by positivity), sub_mul, one_mul]
+    norm_cast at hq ⊢
+    rw [← q.num_div_den, one_lt_div (by positivity)] at hq
+    rw [q.mul_den_eq_num]
+    norm_cast at hq ⊢
+    rw [le_tsub_iff_left hq.le]
+    exact hq
   use 2 * k ^ 2
-  refine (pow_le_pow_left (by positivity) hk _).trans' ?_
+  refine (pow_lt_pow_left hk (by positivity) (by simp [posk.ne'])).trans_le' ?_
   rcases k.zero_le.eq_or_lt with rfl|kpos
   · simp
   rw [pow_two, mul_left_comm, pow_mul]

--- a/Mathlib/Data/Real/Archimedean.lean
+++ b/Mathlib/Data/Real/Archimedean.lean
@@ -335,4 +335,21 @@ theorem iUnion_Iic_rat : ⋃ r : ℚ, Iic (r : ℝ) = univ := by
 theorem iInter_Iic_rat : ⋂ r : ℚ, Iic (r : ℝ) = ∅ := by
   exact iInter_Iic_eq_empty_iff.mpr not_bddBelow_coe
 
+/-- Exponentiation is eventually larger than linear growth. -/
+lemma exists_natCast_add_one_le_pow_of_one_le {a : ℝ} (ha : 1 ≤ a) :
+    ∃ m : ℕ, (m + 1 : ℝ) ≤ a ^ m := by
+  obtain ⟨k, hk⟩ : ∃ k : ℕ, a ≥ 1 / k + 1 := by
+    contrapose! ha
+    simpa using (ha 0)
+  use 2 * k ^ 2
+  refine (pow_le_pow_left (by positivity) hk _).trans' ?_
+  rcases k.zero_le.eq_or_lt with rfl|kpos
+  · simp
+  rw [pow_two, mul_left_comm, pow_mul]
+  have := mul_add_one_le_add_one_pow (a := 1 / k) (by simp) k
+  rw [div_mul_cancel₀ _ (by simp [kpos.ne'])] at this
+  refine (pow_le_pow_left (by positivity) this _).trans' ?_
+  rw [mul_left_comm, ← pow_two]
+  exact_mod_cast Nat.two_mul_sq_add_one_le_two_pow_two_mul _
+
 end Real

--- a/Mathlib/Data/Real/Basic.lean
+++ b/Mathlib/Data/Real/Basic.lean
@@ -571,6 +571,19 @@ theorem mk_near_of_forall_near {f : CauSeq ℚ abs} {x : ℝ} {ε : ℝ}
       sub_le_comm.1 <|
         le_mk_of_forall_le <| H.imp fun _ h j ij => sub_le_comm.1 (abs_sub_le_iff.1 <| h j ij).2⟩
 
+lemma mul_add_one_le_add_one_pow {a : ℝ} (ha : 0 ≤ a) (b : ℕ) : a * b + 1 ≤ (a + 1) ^ b := by
+  rcases ha.eq_or_lt with rfl|ha'
+  · simp
+  clear ha
+  induction b generalizing a with
+  | zero => simp
+  | succ b hb =>
+    rw [Nat.cast_add_one, mul_add, mul_one, add_right_comm, pow_succ, mul_add, mul_one, add_comm]
+    gcongr
+    · rw [le_mul_iff_one_le_left ha']
+      exact (pow_le_pow_left zero_le_one (by simpa using ha'.le) b).trans' (by simp)
+    · exact hb ha'
+
 end Real
 
 /-- A function `f : R → ℝ≥0` is nonarchimedean if it satisfies the strong triangle inequality


### PR DESCRIPTION
Necessary for arguments in approaching a power from above


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
