### PR TITLE
[Merged by Bors] - feat(Algebra/Ring): add `RingEquiv` versions of splitting and product equivalences

### DIFF
--- a/Mathlib/Algebra/Ring/Equiv.lean
+++ b/Mathlib/Algebra/Ring/Equiv.lean
@@ -481,7 +481,7 @@ def piEquivPiSubtypeProd {ι : Type*} (p : ι → Prop) [DecidablePred p] (Y : �
 
 /-- Product of ring equivalences. This is `Equiv.prodCongr` as a `RingEquiv`. -/
 @[simps!]
-def prodMap {R R' S S' : Type*} [NonUnitalNonAssocSemiring R] [NonUnitalNonAssocSemiring R']
+def prodCongr {R R' S S' : Type*} [NonUnitalNonAssocSemiring R] [NonUnitalNonAssocSemiring R']
     [NonUnitalNonAssocSemiring S] [NonUnitalNonAssocSemiring S']
     (f : R ≃+* R') (g : S ≃+* S') :
     R × S ≃+* R' × S' where
@@ -494,9 +494,9 @@ def prodMap {R R' S S' : Type*} [NonUnitalNonAssocSemiring R] [NonUnitalNonAssoc
       Prod.map, Prod.fst_add, map_add, Prod.snd_add, Prod.mk_add_mk]
 
 @[simp]
-theorem coe_prodMap {R R' S S' : Type*} [NonUnitalNonAssocSemiring R] [NonUnitalNonAssocSemiring R']
+theorem coe_prodCongr {R R' S S' : Type*} [NonUnitalNonAssocSemiring R] [NonUnitalNonAssocSemiring R']
     [NonUnitalNonAssocSemiring S] [NonUnitalNonAssocSemiring S'] (f : R ≃+* R') (g : S ≃+* S') :
-    ⇑(RingEquiv.prodMap f g) = Prod.map f g :=
+    ⇑(RingEquiv.prodCongr f g) = Prod.map f g :=
   rfl
 
 end NonUnitalSemiring

--- a/Mathlib/Algebra/Ring/Equiv.lean
+++ b/Mathlib/Algebra/Ring/Equiv.lean
@@ -494,8 +494,9 @@ def prodCongr {R R' S S' : Type*} [NonUnitalNonAssocSemiring R] [NonUnitalNonAss
       Prod.map, Prod.fst_add, map_add, Prod.snd_add, Prod.mk_add_mk]
 
 @[simp]
-theorem coe_prodCongr {R R' S S' : Type*} [NonUnitalNonAssocSemiring R] [NonUnitalNonAssocSemiring R']
-    [NonUnitalNonAssocSemiring S] [NonUnitalNonAssocSemiring S'] (f : R ≃+* R') (g : S ≃+* S') :
+theorem coe_prodCongr {R R' S S' : Type*} [NonUnitalNonAssocSemiring R]
+    [NonUnitalNonAssocSemiring R'] [NonUnitalNonAssocSemiring S] [NonUnitalNonAssocSemiring S']
+    (f : R ≃+* R') (g : S ≃+* S') :
     ⇑(RingEquiv.prodCongr f g) = Prod.map f g :=
   rfl
 

--- a/Mathlib/Algebra/Ring/Equiv.lean
+++ b/Mathlib/Algebra/Ring/Equiv.lean
@@ -3,6 +3,7 @@ Copyright (c) 2018 Johannes Hölzl. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johannes Hölzl, Callum Sutton, Yury Kudryashov
 -/
+import Mathlib.Algebra.Group.Prod
 import Mathlib.Algebra.Group.Opposite
 import Mathlib.Algebra.Group.Units.Equiv
 import Mathlib.Algebra.GroupWithZero.InjSurj
@@ -441,6 +442,61 @@ theorem piCongrRight_trans {ι : Type*} {R S T : ι → Type*}
     [∀ i, NonUnitalNonAssocSemiring (R i)] [∀ i, NonUnitalNonAssocSemiring (S i)]
     [∀ i, NonUnitalNonAssocSemiring (T i)] (e : ∀ i, R i ≃+* S i) (f : ∀ i, S i ≃+* T i) :
     (piCongrRight e).trans (piCongrRight f) = piCongrRight fun i => (e i).trans (f i) :=
+  rfl
+
+/-- Transport dependent functions through an equivalence of the base space.
+
+This is `Equiv.piCongrLeft'` as a `RingEquiv`. -/
+@[simps!]
+def piCongrLeft' {ι ι' : Type*} (R : ι → Type*) (e : ι ≃ ι')
+    [∀ i, NonUnitalNonAssocSemiring (R i)] :
+    ((i : ι) → R i) ≃+* ((i : ι') → R (e.symm i)) where
+  toEquiv := Equiv.piCongrLeft' R e
+  map_mul' _ _ := rfl
+  map_add' _ _ := rfl
+
+@[simp]
+theorem piCongrLeft'_symm {R : Type*} [NonUnitalNonAssocSemiring R] (e : α ≃ β) :
+    (RingEquiv.piCongrLeft' (fun _ => R) e).symm = RingEquiv.piCongrLeft' _ e.symm := by
+  simp only [piCongrLeft', RingEquiv.symm, MulEquiv.symm, Equiv.piCongrLeft'_symm]
+
+/-- Transport dependent functions through an equivalence of the base space.
+
+This is `Equiv.piCongrLeft` as a `RingEquiv`. -/
+@[simps!]
+def piCongrLeft {ι ι' : Type*} (S : ι' → Type*) (e : ι ≃ ι')
+    [∀ i, NonUnitalNonAssocSemiring (S i)] :
+    ((i : ι) → S (e i)) ≃+* ((i : ι') → S i) :=
+  (RingEquiv.piCongrLeft' S e.symm).symm
+
+/-- Splits the indices of ring `∀ (i : ι), Y i` along the predicate `p`. This is
+`Equiv.piEquivPiSubtypeProd` as a `RingEquiv`. -/
+@[simps!]
+def piEquivPiSubtypeProd {ι : Type*} (p : ι → Prop) [DecidablePred p] (Y : ι → Type*)
+    [∀ i, NonUnitalNonAssocSemiring (Y i)] :
+    ((i : ι) → Y i) ≃+* ((i : { x : ι // p x }) → Y i) × ((i : { x : ι // ¬p x }) → Y i) where
+  toEquiv := Equiv.piEquivPiSubtypeProd p Y
+  map_mul' _ _ := rfl
+  map_add' _ _ := rfl
+
+/-- Product of ring equivalences. This is `Equiv.prodCongr` as a `RingEquiv`. -/
+@[simps!]
+def prodMap {R R' S S' : Type*} [NonUnitalNonAssocSemiring R] [NonUnitalNonAssocSemiring R']
+    [NonUnitalNonAssocSemiring S] [NonUnitalNonAssocSemiring S']
+    (f : R ≃+* R') (g : S ≃+* S') :
+    R × S ≃+* R' × S' where
+  toEquiv := Equiv.prodCongr f g
+  map_mul' _ _ := by
+    simp only [Equiv.toFun_as_coe, Equiv.prodCongr_apply, EquivLike.coe_coe,
+      Prod.map, Prod.fst_mul, map_mul, Prod.snd_mul, Prod.mk_mul_mk]
+  map_add' _ _ := by
+    simp only [Equiv.toFun_as_coe, Equiv.prodCongr_apply, EquivLike.coe_coe,
+      Prod.map, Prod.fst_add, map_add, Prod.snd_add, Prod.mk_add_mk]
+
+@[simp]
+theorem coe_prodMap {R R' S S' : Type*} [NonUnitalNonAssocSemiring R] [NonUnitalNonAssocSemiring R']
+    [NonUnitalNonAssocSemiring S] [NonUnitalNonAssocSemiring S'] (f : R ≃+* R') (g : S ≃+* S') :
+    ⇑(RingEquiv.prodMap f g) = Prod.map f g :=
   rfl
 
 end NonUnitalSemiring


### PR DESCRIPTION
Add `RingEquiv` versions of `Equiv.piCongrLeft`, `Equiv.piEquivPiSubtypeProd`, and `Equiv.prodCongr`.

This has been split from the larger PR #13577.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
