### PR TITLE
[Merged by Bors] - fix: parse header in `minImports` to improve reports

### DIFF
--- a/Mathlib/Tactic/Linter/MinImports.lean
+++ b/Mathlib/Tactic/Linter/MinImports.lean
@@ -72,10 +72,10 @@ def minImportsLinter : Linter where run := withSetOptionIn fun stx => do
       let currentlyUnneededImports := explicitImportsInFile.diff importsSoFar
       -- we read the current file, to do a custom parsing of the imports:
       -- this is a hack to obtain some `Syntax` information for the `import X` commands
-      let filePath ← getFileName
-      let fil ← IO.FS.readFile filePath
+      let fname ← getFileName
+      let contents ← IO.FS.readFile fname
       -- `impMods` is the syntax for the modules imported in the current file
-      let (impMods, _) ← Parser.parseHeader (Parser.mkInputContext fil filePath)
+      let (impMods, _) ← Parser.parseHeader (Parser.mkInputContext contents fname)
       for i in currentlyUnneededImports do
         match impMods.find? (·.getId == i) with
           | some impPos => logWarningAt impPos m!"unneeded import '{i}'"

--- a/Mathlib/Tactic/Linter/MinImports.lean
+++ b/Mathlib/Tactic/Linter/MinImports.lean
@@ -72,26 +72,21 @@ def minImportsLinter : Linter where run := withSetOptionIn fun stx => do
       let currentlyUnneededImports := explicitImportsInFile.diff importsSoFar
       -- we read the current file, to do a custom parsing of the imports:
       -- this is a hack to obtain some `Syntax` information for the `import X` commands
-      let fil ← IO.FS.readFile (← getFileName)
+      let filePath ← getFileName
+      let fil ← IO.FS.readFile filePath
+      -- `impMods` is the syntax for the modules imported in the current file
+      let (impMods, _) ← Parser.parseHeader (Parser.mkInputContext fil filePath)
       for i in currentlyUnneededImports do
-        -- looking for the position of 'import i', so we split at ' i' and
-        -- compute the length of the string until '...import| i'
-        match fil.splitOn (" " ++ i.toString) with
-          | a::_::_ =>
-            let al := a.length
-            -- create a syntax covering the range that should be occupied by import `i`
-            let impPos : Syntax := .ofRange ⟨⟨al + 1⟩, ⟨al + i.toString.length + 1⟩⟩
-            logWarningAt impPos m!"unneeded import '{i}'"
+        match impMods.find? (·.getId == i) with
+          | some impPos => logWarningAt impPos m!"unneeded import '{i}'"
           | _ => dbg_trace f!"'{i}' not found"  -- this should be unreachable
       -- if the linter found new imports that should be added (likely to *reduce* the dependencies)
       if !newImps.isEmpty then
         -- format the imports prepending `import ` to each module name
         let withImport := (newImps.toArray.qsort Name.lt).map (s!"import {·}")
-        -- create a syntax node supported, likely on the first imported module name
-        let firstImport : Syntax := match fil.splitOn "import " with
-          | a::_::_ => .ofRange ⟨⟨a.length⟩, ⟨a.length + "import".length⟩⟩
-          | _ => .ofRange ⟨⟨0⟩, ⟨19⟩⟩
-        logWarningAt firstImport m!"-- missing imports\n{"\n".intercalate withImport.toList}"
+        -- log a warning at the first `import`, if there is one.
+        logWarningAt ((impMods.find? (·.isOfKind `import)).getD default)
+          m!"-- missing imports\n{"\n".intercalate withImport.toList}"
     let id ← getId stx
     let newImports := getIrredundantImports (← getEnv) (← getAllImports stx id)
     let tot := (newImports.append importsSoFar)


### PR DESCRIPTION
When reporting the summary of import changes, the `minImports` linter was using a text-based heuristic to determine the imports.  Kyle explained how to get exact syntax information for the header and this PR uses that for error reporting.

Note that there is no change to the linter, other than in how the report is printed.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
