### PR TITLE
[Merged by Bors] - chore(Topology/LocallyClosed): use `X`/`Y` instead of `α`/`β`

### DIFF
--- a/Mathlib/Topology/LocallyClosed.lean
+++ b/Mathlib/Topology/LocallyClosed.lean
@@ -24,7 +24,7 @@ import Mathlib.Topology.LocalAtTarget
 
 -/
 
-variable {α β : Type*} [TopologicalSpace α] [TopologicalSpace β] {s t : Set α} {f : α → β}
+variable {X Y : Type*} [TopologicalSpace X] [TopologicalSpace Y] {s t : Set X} {f : X → Y}
 
 open scoped Topology Set.Notation
 
@@ -39,7 +39,7 @@ This is the largest set such that `s` is closed in, and `s` is locally closed if
 This is unnamed in the literature, and this name is due to the fact that `coborder s = (border sᶜ)ᶜ`
 where `border s = s \ interior s` is the border in the sense of Hausdorff.
 -/
-def coborder (s : Set α) : Set α :=
+def coborder (s : Set X) : Set X :=
   (closure s \ s)ᶜ
 
 lemma subset_coborder :
@@ -74,24 +74,24 @@ lemma coborder_eq_compl_frontier_iff :
 
 alias ⟨_, IsOpen.coborder_eq⟩ := coborder_eq_compl_frontier_iff
 
-lemma IsOpenMap.coborder_preimage_subset (hf : IsOpenMap f) (s : Set β) :
+lemma IsOpenMap.coborder_preimage_subset (hf : IsOpenMap f) (s : Set Y) :
     coborder (f ⁻¹' s) ⊆ f ⁻¹' (coborder s) := by
   rw [coborder, coborder, preimage_compl, preimage_diff, compl_subset_compl]
   apply diff_subset_diff_left
   exact hf.preimage_closure_subset_closure_preimage
 
-lemma Continuous.preimage_coborder_subset (hf : Continuous f) (s : Set β) :
+lemma Continuous.preimage_coborder_subset (hf : Continuous f) (s : Set Y) :
     f ⁻¹' (coborder s) ⊆ coborder (f ⁻¹' s) := by
   rw [coborder, coborder, preimage_compl, preimage_diff, compl_subset_compl]
   apply diff_subset_diff_left
   exact hf.closure_preimage_subset s
 
-lemma coborder_preimage (hf : IsOpenMap f) (hf' : Continuous f) (s : Set β) :
+lemma coborder_preimage (hf : IsOpenMap f) (hf' : Continuous f) (s : Set Y) :
     coborder (f ⁻¹' s) = f ⁻¹' (coborder s) :=
   (hf.coborder_preimage_subset s).antisymm (hf'.preimage_coborder_subset s)
 
 protected
-lemma OpenEmbedding.coborder_preimage (hf : OpenEmbedding f) (s : Set β) :
+lemma OpenEmbedding.coborder_preimage (hf : OpenEmbedding f) (s : Set Y) :
     coborder (f ⁻¹' s) = f ⁻¹' (coborder s) :=
   coborder_preimage hf.isOpenMap hf.continuous s
 
@@ -103,7 +103,7 @@ lemma isClosed_preimage_val_coborder :
 A set is locally closed if it is the intersection of some open set and some closed set.
 Also see `isLocallyClosed_tfae`.
 -/
-def IsLocallyClosed (s : Set α) : Prop := ∃ (U Z : Set α), IsOpen U ∧ IsClosed Z ∧ s = U ∩ Z
+def IsLocallyClosed (s : Set X) : Prop := ∃ (U Z : Set X), IsOpen U ∧ IsClosed Z ∧ s = U ∩ Z
 
 lemma IsOpen.isLocallyClosed (hs : IsOpen s) : IsLocallyClosed s :=
   ⟨_, _, hs, isClosed_univ, (inter_univ _).symm⟩
@@ -117,16 +117,16 @@ lemma IsLocallyClosed.inter (hs : IsLocallyClosed s) (ht : IsLocallyClosed t) :
   obtain ⟨U₂, Z₂, hU₂, hZ₂, rfl⟩ := ht
   refine ⟨_, _, hU₁.inter hU₂, hZ₁.inter hZ₂, inter_inter_inter_comm U₁ Z₁ U₂ Z₂⟩
 
-lemma IsLocallyClosed.preimage {s : Set β} (hs : IsLocallyClosed s)
-    {f : α → β} (hf : Continuous f) :
+lemma IsLocallyClosed.preimage {s : Set Y} (hs : IsLocallyClosed s)
+    {f : X → Y} (hf : Continuous f) :
     IsLocallyClosed (f ⁻¹' s) := by
   obtain ⟨U, Z, hU, hZ, rfl⟩ := hs
   exact ⟨_, _, hU.preimage hf, hZ.preimage hf, preimage_inter⟩
 
 nonrec
-lemma Inducing.isLocallyClosed_iff {s : Set α}
-    {f : α → β} (hf : Inducing f) :
-    IsLocallyClosed s ↔ ∃ s' : Set β, IsLocallyClosed s' ∧ f ⁻¹' s' = s := by
+lemma Inducing.isLocallyClosed_iff {s : Set X}
+    {f : X → Y} (hf : Inducing f) :
+    IsLocallyClosed s ↔ ∃ s' : Set Y, IsLocallyClosed s' ∧ f ⁻¹' s' = s := by
   simp_rw [IsLocallyClosed, hf.isOpen_iff, hf.isClosed_iff]
   constructor
   · rintro ⟨_, _, ⟨U, hU, rfl⟩, ⟨Z, hZ, rfl⟩, rfl⟩
@@ -134,14 +134,14 @@ lemma Inducing.isLocallyClosed_iff {s : Set α}
   · rintro ⟨_, ⟨U, Z, hU, hZ, rfl⟩, rfl⟩
     exact ⟨_, _, ⟨U, hU, rfl⟩, ⟨Z, hZ, rfl⟩, rfl⟩
 
-lemma Embedding.isLocallyClosed_iff {s : Set α}
-    {f : α → β} (hf : Embedding f) :
-    IsLocallyClosed s ↔ ∃ s' : Set β, IsLocallyClosed s' ∧ s' ∩ range f = f '' s := by
+lemma Embedding.isLocallyClosed_iff {s : Set X}
+    {f : X → Y} (hf : Embedding f) :
+    IsLocallyClosed s ↔ ∃ s' : Set Y, IsLocallyClosed s' ∧ s' ∩ range f = f '' s := by
   simp_rw [hf.toInducing.isLocallyClosed_iff,
     ← (image_injective.mpr hf.inj).eq_iff, image_preimage_eq_inter_range]
 
-lemma IsLocallyClosed.image {s : Set α} (hs : IsLocallyClosed s)
-    {f : α → β} (hf : Inducing f) (hf' : IsLocallyClosed (range f)) :
+lemma IsLocallyClosed.image {s : Set X} (hs : IsLocallyClosed s)
+    {f : X → Y} (hf : Inducing f) (hf' : IsLocallyClosed (range f)) :
     IsLocallyClosed (f '' s) := by
   obtain ⟨t, ht, rfl⟩ := hf.isLocallyClosed_iff.mp hs
   rw [image_preimage_eq_inter_range]
@@ -155,7 +155,7 @@ A set `s` is locally closed if one of the equivalent conditions below hold
 4. Every `x ∈ s` has some open neighborhood `U` such that `U ∩ closure s ⊆ s`.
 5. `s` is open in the closure of `s`.
 -/
-lemma isLocallyClosed_tfae (s : Set α) :
+lemma isLocallyClosed_tfae (s : Set X) :
     List.TFAE
     [ IsLocallyClosed s,
       IsOpen (coborder s),
@@ -205,9 +205,9 @@ lemma IsLocallyClosed.isOpen_preimage_val_closure (hs : IsLocallyClosed s) :
 
 open TopologicalSpace
 
-variable {ι : Type*} {U : ι → Opens β} (hU : iSup U = ⊤)
+variable {ι : Type*} {U : ι → Opens Y} (hU : iSup U = ⊤)
 
-theorem isLocallyClosed_iff_coe_preimage_of_iSup_eq_top (s : Set β) :
+theorem isLocallyClosed_iff_coe_preimage_of_iSup_eq_top (s : Set Y) :
     IsLocallyClosed s ↔ ∀ i, IsLocallyClosed ((↑) ⁻¹' s : Set (U i)) := by
   simp_rw [isLocallyClosed_iff_isOpen_coborder]
   rw [isOpen_iff_coe_preimage_of_iSup_eq_top hU]


### PR DESCRIPTION
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
