### PR TITLE
[Merged by Bors] - chore: address `elab_as_elim` workarounds

### DIFF
--- a/Mathlib/AlgebraicGeometry/Morphisms/QuasiSeparated.lean
+++ b/Mathlib/AlgebraicGeometry/Morphisms/QuasiSeparated.lean
@@ -57,16 +57,14 @@ theorem quasiSeparatedSpace_iff_affine (X : Scheme) :
         IsCompact (U ⊓ V).1
       by intro U V hU hU' hV hV'; exact this ⟨U, hU⟩ hU' ⟨V, hV⟩ hV'
     intro U hU V hV
-    -- Porting note: it complains "unable to find motive", but telling Lean that motive is
-    -- underscore is actually sufficient, weird
-    apply compact_open_induction_on (P := _) V hV
+    refine compact_open_induction_on V hV ?_ ?_
     · simp
     · intro S _ V hV
       change IsCompact (U.1 ∩ (S.1 ∪ V.1))
       rw [Set.inter_union_distrib_left]
       apply hV.union
       clear hV
-      apply compact_open_induction_on (P := _) U hU
+      refine compact_open_induction_on U hU ?_ ?_
       · simp
       · intro S _ W hW
         change IsCompact ((S.1 ∪ W.1) ∩ V.1)
@@ -244,9 +242,7 @@ theorem exists_eq_pow_mul_of_isCompact_of_isQuasiSeparated (X : Scheme.{u}) (U :
     ∃ (n : ℕ) (y : Γ(X, U)), y |_ X.basicOpen f = (f |_ X.basicOpen f) ^ n * x := by
   delta TopCat.Presheaf.restrictOpen TopCat.Presheaf.restrict
   revert hU' f x
-  -- Porting note: complains `expected type is not available`, but tell Lean that it is underscore
-  -- is sufficient
-  apply compact_open_induction_on (P := _) U hU
+  refine compact_open_induction_on U hU ?_ ?_
   · intro _ f x
     use 0, f
     refine @Subsingleton.elim _

--- a/Mathlib/Data/QPF/Univariate/Basic.lean
+++ b/Mathlib/Data/QPF/Univariate/Basic.lean
@@ -242,9 +242,7 @@ def Fix.dest : Fix F → F (Fix F) :=
 theorem Fix.rec_eq {α : Type _} (g : F α → α) (x : F (Fix F)) :
     Fix.rec g (Fix.mk x) = g (Fix.rec g <$> x) := by
   have : recF g ∘ fixToW = Fix.rec g := by
-    apply funext
-    apply Quotient.ind
-    intro x
+    ext ⟨x⟩
     apply recF_eq_of_Wequiv
     rw [fixToW]
     apply Wrepr_equiv
@@ -270,8 +268,7 @@ theorem Fix.ind_aux (a : q.P.A) (f : q.P.B a → q.P.W) :
 theorem Fix.ind_rec {α : Type u} (g₁ g₂ : Fix F → α)
     (h : ∀ x : F (Fix F), g₁ <$> x = g₂ <$> x → g₁ (Fix.mk x) = g₂ (Fix.mk x)) :
     ∀ x, g₁ x = g₂ x := by
-  apply Quot.ind
-  intro x
+  rintro ⟨x⟩
   induction' x with a f ih
   change g₁ ⟦⟨a, f⟩⟧ = g₂ ⟦⟨a, f⟩⟧
   rw [← Fix.ind_aux a f]; apply h
@@ -303,8 +300,7 @@ theorem Fix.dest_mk (x : F (Fix F)) : Fix.dest (Fix.mk x) = x := by
   apply Fix.mk_dest
 
 theorem Fix.ind (p : Fix F → Prop) (h : ∀ x : F (Fix F), Liftp p x → p (Fix.mk x)) : ∀ x, p x := by
-  apply Quot.ind
-  intro x
+  rintro ⟨x⟩
   induction' x with a f ih
   change p ⟦⟨a, f⟩⟧
   rw [← Fix.ind_aux a f]
@@ -374,17 +370,10 @@ theorem Cofix.dest_corec {α : Type u} (g : α → F α) (x : α) :
   dsimp
   rw [corecF_eq, abs_map, abs_repr, ← comp_map]; rfl
 
--- Porting note: Needed to add `(motive := _)` to get `Quot.inductionOn` to work
 private theorem Cofix.bisim_aux (r : Cofix F → Cofix F → Prop) (h' : ∀ x, r x x)
     (h : ∀ x y, r x y → Quot.mk r <$> Cofix.dest x = Quot.mk r <$> Cofix.dest y) :
     ∀ x y, r x y → x = y := by
-  intro x
-  apply Quot.inductionOn (motive := _) x
-  clear x
-  intro x y
-  apply Quot.inductionOn (motive := _) y
-  clear y
-  intro y rxy
+  rintro ⟨x⟩ ⟨y⟩ rxy
   apply Quot.sound
   let r' x y := r (Quot.mk _ x) (Quot.mk _ y)
   have : IsPrecongr r' := by
@@ -400,11 +389,9 @@ private theorem Cofix.bisim_aux (r : Cofix F → Cofix F → Prop) (h' : ∀ x, 
       rw [Quot.sound cuv]
       apply h'
     let f : Quot r → Quot r' :=
-      Quot.lift (Quot.lift (Quot.mk r') h₁)
-        (by
-          intro c; apply Quot.inductionOn (motive := _) c; clear c
-          intro c d; apply Quot.inductionOn (motive := _) d; clear d
-          intro d rcd; apply Quot.sound; apply rcd)
+      Quot.lift (Quot.lift (Quot.mk r') h₁) <| by
+        rintro ⟨c⟩ ⟨d⟩ rcd
+        exact Quot.sound rcd
     have : f ∘ Quot.mk r ∘ Quot.mk Mcongr = Quot.mk r' := rfl
     rw [← this, ← PFunctor.map_map _ _ f, ← PFunctor.map_map _ _ (Quot.mk r), abs_map, abs_map,
       abs_map, h₀]

--- a/Mathlib/Probability/Kernel/Composition.lean
+++ b/Mathlib/Probability/Kernel/Composition.lean
@@ -392,9 +392,7 @@ theorem lintegral_compProd' (κ : Kernel α β) [IsSFiniteKernel κ] (η : Kerne
   · exact fun i j hij b => lintegral_mono fun c => h_mono hij _
   congr
   ext1 n
-  -- Porting note: Added `(P := _)`
-  refine SimpleFunc.induction (P := fun f => (∫⁻ (a : β × γ), f a ∂(κ ⊗ₖ η) a =
-      ∫⁻ (a_1 : β), ∫⁻ (c : γ), f (a_1, c) ∂η (a, a_1) ∂κ a)) ?_ ?_ (F n)
+  refine SimpleFunc.induction ?_ ?_ (F n)
   · intro c s hs
     classical -- Porting note: Added `classical` for `Set.piecewise_eq_indicator`
     simp (config := { unfoldPartialApp := true }) only [SimpleFunc.const_zero,

--- a/Mathlib/RingTheory/Flat/EquationalCriterion.lean
+++ b/Mathlib/RingTheory/Flat/EquationalCriterion.lean
@@ -263,7 +263,7 @@ theorem exists_factorization_of_comp_eq_zero_of_free [Flat R M] {K N : Type u}
   have (K' : Submodule R K) (hK' : K'.FG) : ∃ (κ : Type u) (_ : Fintype κ) (a : N →ₗ[R] (κ →₀ R))
       (y : (κ →₀ R) →ₗ[R] M), x = y ∘ₗ a ∧ K' ≤ LinearMap.ker (a ∘ₗ f) := by
     revert N
-    apply Submodule.fg_induction (P := _) (N := K') (hN := hK')
+    apply Submodule.fg_induction (N := K') (hN := hK')
     · intro k N _ _ _ _ f x hfx
       have : x (f k) = 0 := by simpa using LinearMap.congr_fun hfx k
       simpa using exists_factorization_of_apply_eq_zero_of_free this

--- a/Mathlib/Topology/Homotopy/Product.lean
+++ b/Mathlib/Topology/Homotopy/Product.lean
@@ -131,10 +131,8 @@ theorem pi_lift (γ : ∀ i, Path (as i) (bs i)) :
   This is `Path.trans_pi_eq_pi_trans` descended to path homotopy classes. -/
 theorem comp_pi_eq_pi_comp (γ₀ : ∀ i, Path.Homotopic.Quotient (as i) (bs i))
     (γ₁ : ∀ i, Path.Homotopic.Quotient (bs i) (cs i)) : pi γ₀ ⬝ pi γ₁ = pi fun i => γ₀ i ⬝ γ₁ i := by
-  apply Quotient.induction_on_pi (p := _) γ₁
-  intro a
-  apply Quotient.induction_on_pi (p := _) γ₀
-  intros
+  induction γ₁ using Quotient.induction_on_pi with | _ a =>
+  induction γ₀ using Quotient.induction_on_pi
   simp only [pi_lift]
   rw [← Path.Homotopic.comp_lift, Path.trans_pi_eq_pi_trans, ← pi_lift]
   rfl
@@ -147,16 +145,14 @@ abbrev proj (i : ι) (p : Path.Homotopic.Quotient as bs) : Path.Homotopic.Quotie
 @[simp]
 theorem proj_pi (i : ι) (paths : ∀ i, Path.Homotopic.Quotient (as i) (bs i)) :
     proj i (pi paths) = paths i := by
-  apply Quotient.induction_on_pi (p := _) paths
-  intro; unfold proj
-  rw [pi_lift, ← Path.Homotopic.map_lift]
+  induction paths using Quotient.induction_on_pi
+  rw [proj, pi_lift, ← Path.Homotopic.map_lift]
   congr
 
 @[simp]
 theorem pi_proj (p : Path.Homotopic.Quotient as bs) : (pi fun i => proj i p) = p := by
-  apply Quotient.inductionOn (motive := _) p
-  intro; unfold proj
-  simp_rw [← Path.Homotopic.map_lift]
+  induction p using Quotient.inductionOn
+  simp_rw [proj, ← Path.Homotopic.map_lift]
   erw [pi_lift]
   congr
 
@@ -189,10 +185,8 @@ variable (r₁ : Path.Homotopic.Quotient a₂ a₃) (r₂ : Path.Homotopic.Quoti
 /-- Products commute with path composition.
     This is `trans_prod_eq_prod_trans` descended to the quotient. -/
 theorem comp_prod_eq_prod_comp : prod q₁ q₂ ⬝ prod r₁ r₂ = prod (q₁ ⬝ r₁) (q₂ ⬝ r₂) := by
-  apply Quotient.inductionOn₂ (motive := _) q₁ q₂
-  intro a b
-  apply Quotient.inductionOn₂ (motive := _) r₁ r₂
-  intros
+  induction q₁, q₂ using Quotient.inductionOn₂
+  induction r₁, r₂ using Quotient.inductionOn₂
   simp only [prod_lift, ← Path.Homotopic.comp_lift, Path.trans_prod_eq_prod_trans]
 
 variable {c₁ c₂ : α × β}
@@ -208,27 +202,21 @@ abbrev projRight (p : Path.Homotopic.Quotient c₁ c₂) : Path.Homotopic.Quotie
 /-- Lemmas showing projection is the inverse of product. -/
 @[simp]
 theorem projLeft_prod : projLeft (prod q₁ q₂) = q₁ := by
-  apply Quotient.inductionOn₂ (motive := _) q₁ q₂
-  intro p₁ p₂
-  unfold projLeft
-  rw [prod_lift, ← Path.Homotopic.map_lift]
+  induction q₁, q₂ using Quotient.inductionOn₂
+  rw [projLeft, prod_lift, ← Path.Homotopic.map_lift]
   congr
 
 @[simp]
 theorem projRight_prod : projRight (prod q₁ q₂) = q₂ := by
-  apply Quotient.inductionOn₂ (motive := _) q₁ q₂
-  intro p₁ p₂
-  unfold projRight
-  rw [prod_lift, ← Path.Homotopic.map_lift]
+  induction q₁, q₂ using Quotient.inductionOn₂
+  rw [projRight, prod_lift, ← Path.Homotopic.map_lift]
   congr
 
 @[simp]
 theorem prod_projLeft_projRight (p : Path.Homotopic.Quotient (a₁, b₁) (a₂, b₂)) :
     prod (projLeft p) (projRight p) = p := by
-  apply Quotient.inductionOn (motive := _) p
-  intro p'
-  unfold projLeft; unfold projRight
-  simp only [← Path.Homotopic.map_lift, prod_lift]
+  induction p using Quotient.inductionOn
+  simp only [projLeft, projRight, ← Path.Homotopic.map_lift, prod_lift]
   congr
 
 end Prod


### PR DESCRIPTION
There were a number of places that eliminator elaboration was suppressed using the `(motive := _)` trick to be used in conjuction with `apply`, but it's generally clearer to use `induction`, `refine`, or, sometimes, `rintro` (for `Quot`).


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
