### PR TITLE
[Merged by Bors] - feat(Topology/Instances): the only closed subfield of the field of real numbers is the real numbers itself

### DIFF
--- a/Mathlib/Topology/Instances/Real.lean
+++ b/Mathlib/Topology/Instances/Real.lean
@@ -130,15 +130,10 @@ theorem Real.totallyBounded_ball (x ε : ℝ) : TotallyBounded (ball x ε) := by
   rw [Real.ball_eq_Ioo]; apply totallyBounded_Ioo
 
 theorem Real.subfield_eq_of_closed {K : Subfield ℝ} (hc : IsClosed (K : Set ℝ)) : K = ⊤ := by
-  suffices Set.univ ⊆ (K : Set ℝ) by
-    exact eq_top_iff.2 fun _ _ => this (Set.mem_univ _)
-  suffices Set.univ ⊆ closure (Set.range ((↑) : ℚ → ℝ)) by
-    refine subset_trans this ?_
-    rw [← IsClosed.closure_eq hc]
-    apply closure_mono
-    rintro _ ⟨_, rfl⟩
-    simp only [SetLike.mem_coe, SubfieldClass.ratCast_mem]
-  rw [DenseRange.closure_range Rat.denseRange_cast]
+  rw [SetLike.ext'_iff, Subfield.coe_top, ← hc.closure_eq]
+  refine Rat.denseRange_cast.mono ?_ |>.closure_eq
+  rintro - ⟨_, rfl⟩
+  exact SubfieldClass.ratCast_mem K _
 
 section
 

--- a/Mathlib/Topology/Instances/Real.lean
+++ b/Mathlib/Topology/Instances/Real.lean
@@ -6,6 +6,7 @@ Authors: Johannes Hölzl, Mario Carneiro
 import Mathlib.Data.Real.Star
 import Mathlib.Algebra.Algebra.Basic
 import Mathlib.Algebra.Periodic
+import Mathlib.Topology.Algebra.Order.Archimedean
 import Mathlib.Topology.Algebra.Order.Field
 import Mathlib.Topology.Algebra.UniformMulAction
 import Mathlib.Topology.Algebra.Star
@@ -127,6 +128,17 @@ instance Real.instCompleteSpace : CompleteSpace ℝ := by
 
 theorem Real.totallyBounded_ball (x ε : ℝ) : TotallyBounded (ball x ε) := by
   rw [Real.ball_eq_Ioo]; apply totallyBounded_Ioo
+
+theorem Real.subfield_eq_of_closed {K : Subfield ℝ} (hc : IsClosed (K : Set ℝ)) : K = ⊤ := by
+  suffices Set.univ ⊆ (K : Set ℝ) by
+    exact eq_top_iff.2 fun _ _ => this (Set.mem_univ _)
+  suffices Set.univ ⊆ closure (Set.range ((↑) : ℚ → ℝ)) by
+    refine subset_trans this ?_
+    rw [← IsClosed.closure_eq hc]
+    apply closure_mono
+    rintro _ ⟨_, rfl⟩
+    simp only [SetLike.mem_coe, SubfieldClass.ratCast_mem]
+  rw [DenseRange.closure_range Rat.denseRange_cast]
 
 section
 


### PR DESCRIPTION
This PR contains the result that the only closed subfield of the field of real numbers is the field of real numbers itself.

Split off from the larger PR #13577.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
