### PR TITLE
[Merged by Bors] - fix(Tactic/Simps): Prevent `simps` from viewing `field_1` as a prefix of `field`.

### DIFF
--- a/test/Simps.lean
+++ b/test/Simps.lean
@@ -1184,14 +1184,31 @@ class Artificial (n : Nat) where
 
 initialize_simps_projections Artificial
 
+
+namespace UnderScoreDigit
+
 /-!
-We do not consider `field` to be a prefix to `field_1`, as the latter is often
+We do not consider `field` to be a prefix of `field_1`, as the latter is often
 a different field with an auto-generated name.
 -/
 
 structure Foo where
   field : Nat
-  field_1 : Nat × Nat
+  field_9 : Nat × Nat
+  field_2 : Nat
 
-@[simps field field_1 field_1_fst]
-def myFoo : Foo := ⟨1, ⟨1, 1⟩⟩
+@[simps field field_2 field_9_fst]
+def myFoo : Foo := ⟨1, ⟨1, 1⟩, 1⟩
+
+structure Prod (X Y : Type _) extends Prod X Y
+
+structure Prod2 (X Y : Type _) extends Prod X Y
+
+initialize_simps_projections Prod2 (toProd → myName, toProd_1 → myOtherName)
+
+structure Prod3 (X Y : Type _) extends Prod X Y
+
+@[simps] def foo : Prod3 Nat Nat := { fst := 1, snd := 3 }
+@[simps toProd_1] def foo' : Prod3 Nat Nat := { fst := 1, snd := 3 }
+
+end UnderScoreDigit

--- a/test/Simps.lean
+++ b/test/Simps.lean
@@ -1183,3 +1183,15 @@ class Artificial (n : Nat) where
   one : Nat
 
 initialize_simps_projections Artificial
+
+/-!
+We do not consider `field` to be a prefix to `field_1`, as the latter is often
+a different field with an auto-generated name.
+-/
+
+structure Foo where
+  field : Nat
+  field_1 : Nat × Nat
+
+@[simps field field_1 field_1_fst]
+def myFoo : Foo := ⟨1, ⟨1, 1⟩⟩


### PR DESCRIPTION
Related zulip thread: https://leanprover.zulipchat.com/#narrow/stream/270676-lean4/topic/Custom.20name.20for.20projection.20in.20.60structure.20extends.60

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
