### PR TITLE
[Merged by Bors] - feat(Nat/log): Nat.log 2 = Nat.log2 and linear bound on Nat.log

### DIFF
--- a/Mathlib/Data/Nat/Log.lean
+++ b/Mathlib/Data/Nat/Log.lean
@@ -197,6 +197,29 @@ theorem add_pred_div_lt {b n : ℕ} (hb : 1 < b) (hn : 2 ≤ n) : (n + b - 1) / 
     succ_pred_eq_of_pos (by omega)]
   exact Nat.add_le_mul hn hb
 
+lemma log2_eq_log_two {n : ℕ} : Nat.log2 n = Nat.log 2 n := by
+  induction n using Nat.strongRec
+  next n ih =>
+    unfold Nat.log2 Nat.log
+    by_cases h : n = 0
+    · simp [h]
+    · congr
+      simp
+      exact ih (n/2) (Nat.div_lt_self (Nat.pos_of_ne_zero h) (by simp))
+
+lemma log_two_le_self {n : ℕ} : Nat.log 2 n ≤ n := by
+  rw [← Nat.log2_eq_log_two]
+  exact log2_le_self n
+
+lemma log_le_self {b n : ℕ} : b.log n ≤ n := by
+  induction b with
+  | zero => simp
+  | succ m ih =>
+    by_cases h : 1 < m
+    · exact le_trans (Nat.log_anti_left h (by omega)) ih
+    · simp [Nat.le_one_iff_eq_zero_or_eq_one] at h
+      obtain rfl | rfl := h <;> simp [Nat.log_two_le_self]
+
 /-! ### Ceil logarithm -/
 
 

--- a/Mathlib/Data/Nat/Log.lean
+++ b/Mathlib/Data/Nat/Log.lean
@@ -204,7 +204,7 @@ lemma log2_eq_log_two {n : ℕ} : Nat.log2 n = Nat.log 2 n := by
     by_cases h : n = 0
     · simp [h]
     · congr
-      simp
+      simp only [ge_iff_le, lt_succ_self, and_true]
       exact ih (n/2) (Nat.div_lt_self (Nat.pos_of_ne_zero h) (by simp))
 
 lemma log_two_le_self {n : ℕ} : Nat.log 2 n ≤ n := by

--- a/Mathlib/Data/Nat/Log.lean
+++ b/Mathlib/Data/Nat/Log.lean
@@ -207,15 +207,11 @@ theorem add_pred_div_lt {b n : ℕ} (hb : 1 < b) (hn : 2 ≤ n) : (n + b - 1) / 
   exact Nat.add_le_mul hn hb
 
 lemma log2_eq_log_two {n : ℕ} : Nat.log2 n = Nat.log 2 n := by
-  induction n using Nat.strongRec with
-  | _ =>
-    rename_i n ih
-    unfold Nat.log2 Nat.log
-    by_cases h : n = 0
-    · simp [h]
-    · congr
-      simp only [ge_iff_le, lt_succ_self, and_true]
-      exact ih (n/2) (Nat.div_lt_self (Nat.pos_of_ne_zero h) (by simp))
+  rcases eq_or_ne n 0 with rfl | hn
+  · rw [log2_zero, log_zero_right]
+  apply eq_of_forall_le_iff
+  intro m
+  rw [Nat.le_log2 hn, ← Nat.pow_le_iff_le_log Nat.one_lt_two hn]
 
 
 /-! ### Ceil logarithm -/

--- a/Mathlib/Data/Nat/Log.lean
+++ b/Mathlib/Data/Nat/Log.lean
@@ -213,7 +213,6 @@ lemma log2_eq_log_two {n : ℕ} : Nat.log2 n = Nat.log 2 n := by
   intro m
   rw [Nat.le_log2 hn, ← Nat.pow_le_iff_le_log Nat.one_lt_two hn]
 
-
 /-! ### Ceil logarithm -/
 
 

--- a/Mathlib/Data/Nat/Log.lean
+++ b/Mathlib/Data/Nat/Log.lean
@@ -109,6 +109,15 @@ theorem log_lt_of_lt_pow {b x y : ℕ} (hy : y ≠ 0) : y < b ^ x → log b y < 
 theorem lt_pow_of_log_lt {b x y : ℕ} (hb : 1 < b) : log b y < x → y < b ^ x :=
   lt_imp_lt_of_le_imp_le (le_log_of_pow_le hb)
 
+lemma log_lt_self (b : ℕ) {x : ℕ} (hx : x ≠ 0) : log b x < x :=
+  match le_or_lt b 1 with
+  | .inl h => log_of_left_le_one h x ▸ Nat.pos_iff_ne_zero.2 hx
+  | .inr h => log_lt_of_lt_pow hx <| lt_pow_self h _
+
+lemma log_le_self (b x : ℕ) : log b x ≤ x :=
+  if hx : x = 0 then by simp [hx]
+  else (log_lt_self b hx).le
+
 theorem lt_pow_succ_log_self {b : ℕ} (hb : 1 < b) (x : ℕ) : x < b ^ (log b x).succ :=
   lt_pow_of_log_lt hb (lt_succ_self _)
 
@@ -198,8 +207,9 @@ theorem add_pred_div_lt {b n : ℕ} (hb : 1 < b) (hn : 2 ≤ n) : (n + b - 1) / 
   exact Nat.add_le_mul hn hb
 
 lemma log2_eq_log_two {n : ℕ} : Nat.log2 n = Nat.log 2 n := by
-  induction n using Nat.strongRec
-  next n ih =>
+  induction n using Nat.strongRec with
+  | _ =>
+    rename_i n ih
     unfold Nat.log2 Nat.log
     by_cases h : n = 0
     · simp [h]
@@ -207,18 +217,6 @@ lemma log2_eq_log_two {n : ℕ} : Nat.log2 n = Nat.log 2 n := by
       simp only [ge_iff_le, lt_succ_self, and_true]
       exact ih (n/2) (Nat.div_lt_self (Nat.pos_of_ne_zero h) (by simp))
 
-lemma log_two_le_self {n : ℕ} : Nat.log 2 n ≤ n := by
-  rw [← Nat.log2_eq_log_two]
-  exact log2_le_self n
-
-lemma log_le_self {b n : ℕ} : b.log n ≤ n := by
-  induction b with
-  | zero => simp
-  | succ m ih =>
-    by_cases h : 1 < m
-    · exact le_trans (Nat.log_anti_left h (by omega)) ih
-    · simp [Nat.le_one_iff_eq_zero_or_eq_one] at h
-      obtain rfl | rfl := h <;> simp [Nat.log_two_le_self]
 
 /-! ### Ceil logarithm -/
 


### PR DESCRIPTION
There is a `Nat.log2` function in Lean (Init/Data/Nat/Log2.lean), which corresponds to the floor log base 2 over Nat.
This PR proves this connection and uses it to show that `Nat.log b n ≤ n` as a simple upper bound on Nat.log.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
