### PR TITLE
[Merged by Bors] - chore: fix some non-flexible simps

### DIFF
--- a/Mathlib/Algebra/Category/Ring/Constructions.lean
+++ b/Mathlib/Algebra/Category/Ring/Constructions.lean
@@ -111,7 +111,7 @@ section Terminal
 def punitIsTerminal : IsTerminal (CommRingCat.of.{u} PUnit) := by
   refine IsTerminal.ofUnique (h := fun X => ⟨⟨⟨⟨1, rfl⟩, fun _ _ => rfl⟩, ?_, ?_⟩, ?_⟩)
   · rfl
-  · intros; simp; ext
+  · intros; simp only [coe_of, Pi.one_apply, self_eq_add_right]; ext
   · intros f; ext; rfl
 
 instance commRingCat_hasStrictTerminalObjects : HasStrictTerminalObjects CommRingCat.{u} := by

--- a/Mathlib/Algebra/FreeAlgebra.lean
+++ b/Mathlib/Algebra/FreeAlgebra.lean
@@ -234,7 +234,7 @@ instance : Semiring (FreeAlgebra R X) where
   __ := instDistrib R X
   natCast n := Quot.mk _ (n : R)
   natCast_zero := by simp; rfl
-  natCast_succ n := by simp; exact Quot.sound Rel.add_scalar
+  natCast_succ n := by simpa using Quot.sound Rel.add_scalar
 
 instance : Inhabited (FreeAlgebra R X) :=
   ⟨0⟩

--- a/Mathlib/Analysis/Calculus/ContDiff/Basic.lean
+++ b/Mathlib/Analysis/Calculus/ContDiff/Basic.lean
@@ -1572,8 +1572,7 @@ theorem contDiffAt_ring_inverse [CompleteSpace R] (x : Rˣ) :
   induction' n using ENat.nat_induction with n IH Itop
   · intro m hm
     refine ⟨{ y : R | IsUnit y }, ?_, ?_⟩
-    · simp [nhdsWithin_univ]
-      exact x.nhds
+    · simpa [nhdsWithin_univ] using x.nhds
     · use ftaylorSeriesWithin 𝕜 inverse univ
       rw [le_antisymm hm bot_le, hasFTaylorSeriesUpToOn_zero_iff]
       constructor

--- a/Mathlib/Analysis/Calculus/Deriv/Slope.lean
+++ b/Mathlib/Analysis/Calculus/Deriv/Slope.lean
@@ -95,8 +95,7 @@ theorem range_derivWithin_subset_closure_span_image
     range (derivWithin f s) ⊆ closure (Submodule.span 𝕜 (f '' t)) := by
   rintro - ⟨x, rfl⟩
   rcases eq_or_neBot (𝓝[s \ {x}] x) with H|H
-  · simp [derivWithin, fderivWithin, H]
-    exact subset_closure (zero_mem _)
+  · simpa [derivWithin, fderivWithin, H] using subset_closure (zero_mem _)
   by_cases H' : DifferentiableWithinAt 𝕜 f s x; swap
   · rw [derivWithin_zero_of_not_differentiableWithinAt H']
     exact subset_closure (zero_mem _)

--- a/Mathlib/Analysis/Calculus/ParametricIntegral.lean
+++ b/Mathlib/Analysis/Calculus/ParametricIntegral.lean
@@ -273,8 +273,7 @@ theorem hasDerivAt_integral_of_dominated_loc_of_lip {F' : α → E} (ε_pos : 0 
       hF'_int
   refine ⟨hF'_int, ?_⟩
   by_cases hE : CompleteSpace E; swap
-  · simp [integral, hE]
-    exact hasDerivAt_const x₀ 0
+  · simpa [integral, hE] using hasDerivAt_const x₀ 0
   simp_rw [hasDerivAt_iff_hasFDerivAt] at h_diff ⊢
   simpa only [(· ∘ ·), ContinuousLinearMap.integral_comp_comm _ hF'_int] using key
 

--- a/Mathlib/Analysis/Distribution/SchwartzSpace.lean
+++ b/Mathlib/Analysis/Distribution/SchwartzSpace.lean
@@ -604,8 +604,7 @@ def _root_.MeasureTheory.Measure.integrablePower (μ : Measure D) : ℕ :=
 lemma integrable_pow_neg_integrablePower
     (μ : Measure D) [h : μ.HasTemperateGrowth] :
     Integrable (fun x ↦ (1 + ‖x‖) ^ (- (μ.integrablePower : ℝ))) μ := by
-  simp [Measure.integrablePower, h]
-  exact h.exists_integrable.choose_spec
+  simpa [Measure.integrablePower, h] using h.exists_integrable.choose_spec
 
 instance _root_.MeasureTheory.Measure.IsFiniteMeasure.instHasTemperateGrowth {μ : Measure D}
     [h : IsFiniteMeasure μ] : μ.HasTemperateGrowth := ⟨⟨0, by simp⟩⟩

--- a/Mathlib/Analysis/FunctionalSpaces/SobolevInequality.lean
+++ b/Mathlib/Analysis/FunctionalSpaces/SobolevInequality.lean
@@ -477,8 +477,8 @@ theorem snorm_le_snorm_fderiv_of_eq_inner  {u : E → F'}
   have h2p : (p : ℝ) < n := by
     have : 0 < p⁻¹ - (n : ℝ)⁻¹ :=
       NNReal.coe_lt_coe.mpr (pos_iff_ne_zero.mpr (inv_ne_zero hp'0)) |>.trans_eq hp'
-    simp [sub_pos] at this
-    rwa [inv_lt_inv _ (zero_lt_one.trans_le (NNReal.coe_le_coe.mpr hp))] at this
+    rwa [NNReal.coe_inv, sub_pos,
+      inv_lt_inv _ (zero_lt_one.trans_le (NNReal.coe_le_coe.mpr hp))] at this
     exact_mod_cast hn
   have h0n : 2 ≤ n := Nat.succ_le_of_lt <| Nat.one_lt_cast.mp <| hp.trans_lt h2p
   have hn : NNReal.IsConjExponent n n' := .conjExponent (by norm_cast)

--- a/Mathlib/Analysis/InnerProductSpace/NormPow.lean
+++ b/Mathlib/Analysis/InnerProductSpace/NormPow.lean
@@ -29,7 +29,7 @@ variable {F : Type*} [NormedAddCommGroup F] [NormedSpace ℝ F]
 theorem hasFDerivAt_norm_rpow (x : E) {p : ℝ} (hp : 1 < p) :
     HasFDerivAt (fun x : E ↦ ‖x‖ ^ p) ((p * ‖x‖ ^ (p - 2)) • innerSL ℝ x) x := by
   by_cases hx : x = 0
-  · simp [hx]
+  · simp only [hx, norm_zero, map_zero, smul_zero]
     have h2p : 0 < p - 1 := sub_pos.mpr hp
     rw [HasFDerivAt, hasFDerivAtFilter_iff_isLittleO]
     calc (fun x : E ↦ ‖x‖ ^ p - ‖(0 : E)‖ ^ p - 0)

--- a/Mathlib/Analysis/InnerProductSpace/PiL2.lean
+++ b/Mathlib/Analysis/InnerProductSpace/PiL2.lean
@@ -649,7 +649,8 @@ def Complex.isometryOfOrthonormal (v : OrthonormalBasis (Fin 2) ℝ F) : ℂ ≃
 @[simp]
 theorem Complex.map_isometryOfOrthonormal (v : OrthonormalBasis (Fin 2) ℝ F) (f : F ≃ₗᵢ[ℝ] F') :
     Complex.isometryOfOrthonormal (v.map f) = (Complex.isometryOfOrthonormal v).trans f := by
-  simp [Complex.isometryOfOrthonormal, LinearIsometryEquiv.trans_assoc, OrthonormalBasis.map]
+  simp only [isometryOfOrthonormal, OrthonormalBasis.map, LinearIsometryEquiv.symm_trans,
+    LinearIsometryEquiv.symm_symm]
   -- Porting note: `LinearIsometryEquiv.trans_assoc` doesn't trigger in the `simp` above
   rw [LinearIsometryEquiv.trans_assoc]
 

--- a/Mathlib/Analysis/Matrix.lean
+++ b/Mathlib/Analysis/Matrix.lean
@@ -403,7 +403,7 @@ private theorem norm_unitOf (a : α) : ‖unitOf a‖₊ = 1 := by
 
 set_option tactic.skipAssignedInstances false in
 private theorem mul_unitOf (a : α) : a * unitOf a = algebraMap _ _ (‖a‖₊ : ℝ)  := by
-  simp [unitOf]
+  simp only [unitOf, coe_nnnorm]
   split_ifs with h
   · simp [h]
   · rw [mul_smul_comm, mul_inv_cancel h, Algebra.algebraMap_eq_smul_one]

--- a/Mathlib/Analysis/Normed/Field/Basic.lean
+++ b/Mathlib/Analysis/Normed/Field/Basic.lean
@@ -196,7 +196,7 @@ instance Prod.normOneClass [SeminormedAddCommGroup α] [One α] [NormOneClass α
 instance Pi.normOneClass {ι : Type*} {α : ι → Type*} [Nonempty ι] [Fintype ι]
     [∀ i, SeminormedAddCommGroup (α i)] [∀ i, One (α i)] [∀ i, NormOneClass (α i)] :
     NormOneClass (∀ i, α i) :=
-  ⟨by simp [Pi.norm_def]; exact Finset.sup_const Finset.univ_nonempty 1⟩
+  ⟨by simpa [Pi.norm_def] using Finset.sup_const Finset.univ_nonempty 1⟩
 
 instance MulOpposite.normOneClass [SeminormedAddCommGroup α] [One α] [NormOneClass α] :
     NormOneClass αᵐᵒᵖ :=

--- a/Mathlib/Analysis/NormedSpace/WeakOperatorTopology.lean
+++ b/Mathlib/Analysis/NormedSpace/WeakOperatorTopology.lean
@@ -218,7 +218,7 @@ all `x` and `y`.  -/
 def seminorm (x : E) (y : F⋆) : Seminorm 𝕜 (E →WOT[𝕜] F) where
   toFun A := ‖y (A x)‖
   map_zero' := by simp
-  add_le' A B := by simp; exact norm_add_le _ _
+  add_le' A B := by simpa using norm_add_le _ _
   neg' A := by simp
   smul' r A := by simp
 
@@ -231,7 +231,7 @@ def seminormFamily : SeminormFamily 𝕜 (E →WOT[𝕜] F) (E × F⋆) :=
 lemma hasBasis_seminorms : (𝓝 (0 : E →WOT[𝕜] F)).HasBasis (seminormFamily 𝕜 E F).basisSets id := by
   let p := seminormFamily 𝕜 E F
   rw [nhds_induced, nhds_pi]
-  simp [map_zero, zero_apply]
+  simp only [map_zero, Pi.zero_apply]
   have h := Filter.hasBasis_pi (fun _ : (E × F⋆) ↦ Metric.nhds_basis_ball (x := 0)) |>.comap
     (inducingFn 𝕜 E F)
   refine h.to_hasBasis' ?_ ?_

--- a/Mathlib/CategoryTheory/Preadditive/HomOrthogonal.lean
+++ b/Mathlib/CategoryTheory/Preadditive/HomOrthogonal.lean
@@ -130,7 +130,7 @@ theorem matrixDecomposition_id (o : HomOrthogonal s) {α : Type} [Finite α] {f 
   split_ifs with h
   · cases h
     simp
-  · simp at h
+  · simp only [Subtype.mk.injEq] at h
     -- Porting note: used to be `convert comp_zero`, but that does not work anymore
     have : biproduct.ι (fun a ↦ s (f a)) a ≫ biproduct.π (fun b ↦ s (f b)) b = 0 := by
       simpa using biproduct.ι_π_ne _ (Ne.symm h)

--- a/Mathlib/CategoryTheory/Sites/Coherent/LocallySurjective.lean
+++ b/Mathlib/CategoryTheory/Sites/Coherent/LocallySurjective.lean
@@ -96,8 +96,7 @@ lemma extensiveTopology.presheafIsLocallySurjective_iff [FinitaryPreExtensive C]
     obtain ⟨x, hx⟩ := h X y
     convert (extensiveTopology C).top_mem' X
     rw [← Sieve.id_mem_iff_eq_top]
-    simp [Presheaf.imageSieve]
-    exact ⟨x, hx⟩
+    simpa [Presheaf.imageSieve] using ⟨x, hx⟩
 
 lemma extensiveTopology.isLocallySurjective_iff [FinitaryExtensive C]
     {F G : Sheaf (extensiveTopology C) D} (f : F ⟶ G)

--- a/Mathlib/Data/List/Perm.lean
+++ b/Mathlib/Data/List/Perm.lean
@@ -156,8 +156,8 @@ theorem Perm.foldr_eq {f : α → β → β} {l₁ l₂ : List α} (lcomm : Left
   intro b
   induction p using Perm.recOnSwap' generalizing b with
   | nil => rfl
-  | cons _ _ r  => simp; rw [r b]
-  | swap' _ _ _ r => simp; rw [lcomm, r b]
+  | cons _ _ r  => simp [r b]
+  | swap' _ _ _ r => simp only [foldr_cons]; rw [lcomm, r b]
   | trans _ _ r₁ r₂ => exact Eq.trans (r₁ b) (r₂ b)
 
 section
@@ -291,7 +291,9 @@ theorem Perm.bind_left (l : List α) {f g : α → List β} (h : ∀ a ∈ l, f 
 
 theorem bind_append_perm (l : List α) (f g : α → List β) :
     l.bind f ++ l.bind g ~ l.bind fun x => f x ++ g x := by
-  induction' l with a l IH <;> simp
+  induction' l with a l IH
+  · simp
+  simp only [bind_cons, append_assoc]
   refine (Perm.trans ?_ (IH.append_left _)).append_left _
   rw [← append_assoc, ← append_assoc]
   exact perm_append_comm.append_right _
@@ -318,18 +320,13 @@ theorem perm_lookmap (f : α → Option α) {l₁ l₂ : List α}
     lookmap f l₁ ~ lookmap f l₂ := by
   induction' p with a l₁ l₂ p IH a b l l₁ l₂ l₃ p₁ _ IH₁ IH₂; · simp
   · cases h : f a
-    · simp [h]
-      exact IH (pairwise_cons.1 H).2
+    · simpa [h] using IH (pairwise_cons.1 H).2
     · simp [lookmap_cons_some _ _ h, p]
   · cases' h₁ : f a with c <;> cases' h₂ : f b with d
-    · simp [h₁, h₂]
-      apply swap
-    · simp [h₁, lookmap_cons_some _ _ h₂]
-      apply swap
-    · simp [lookmap_cons_some _ _ h₁, h₂]
-      apply swap
-    · simp [lookmap_cons_some _ _ h₁, lookmap_cons_some _ _ h₂]
-      rcases (pairwise_cons.1 H).1 _ (mem_cons.2 (Or.inl rfl)) _ h₂ _ h₁ with ⟨rfl, rfl⟩
+    · simpa [h₁, h₂] using swap _ _ _
+    · simpa [h₁, lookmap_cons_some _ _ h₂] using swap _ _ _
+    · simpa [lookmap_cons_some _ _ h₁, h₂] using swap _ _ _
+    · rcases (pairwise_cons.1 H).1 _ (mem_cons.2 (Or.inl rfl)) _ h₂ _ h₁ with ⟨rfl, rfl⟩
       exact Perm.refl _
   · refine (IH₁ H).trans (IH₂ ((p₁.pairwise_iff ?_).1 H))
     intro x y h c hc d hd

--- a/Mathlib/Data/Nat/Pairing.lean
+++ b/Mathlib/Data/Nat/Pairing.lean
@@ -79,9 +79,9 @@ theorem pair_eq_pair {a b c d : ℕ} : pair a b = pair c d ↔ a = c ∧ b = d :
 theorem unpair_lt {n : ℕ} (n1 : 1 ≤ n) : (unpair n).1 < n := by
   let s := sqrt n
   simp only [unpair, Nat.sub_le_iff_le_add]
-  by_cases h : n - s * s < s <;> simp [h]
+  by_cases h : n - s * s < s <;> simp only [h, ↓reduceIte]
   · exact lt_of_lt_of_le h (sqrt_le_self _)
-  · simp at h
+  · simp only [not_lt] at h
     have s0 : 0 < s := sqrt_pos.2 n1
     exact lt_of_le_of_lt h (Nat.sub_lt n1 (Nat.mul_pos s0 s0))
 
@@ -117,10 +117,10 @@ theorem pair_lt_pair_left {a₁ a₂} (b) (h : a₁ < a₂) : pair a₁ b < pair
     · apply Nat.add_lt_add_right; assumption
 
 theorem pair_lt_pair_right (a) {b₁ b₂} (h : b₁ < b₂) : pair a b₁ < pair a b₂ := by
-  by_cases h₁ : a < b₁ <;> simp [pair, h₁, Nat.add_assoc]
-  · simp [pair, lt_trans h₁ h, h]
-    exact mul_self_lt_mul_self h
-  · by_cases h₂ : a < b₂ <;> simp [pair, h₂, h]
+  by_cases h₁ : a < b₁
+  · simpa [pair, h₁, Nat.add_assoc, lt_trans h₁ h, h] using mul_self_lt_mul_self h
+  · simp only [pair, h₁, ↓reduceIte, Nat.add_assoc]
+    by_cases h₂ : a < b₂ <;> simp [pair, h₂, h]
     simp? at h₁ says simp only [not_lt] at h₁
     rw [Nat.add_comm, Nat.add_comm _ a, Nat.add_assoc, Nat.add_lt_add_iff_left]
     rwa [Nat.add_comm, ← sqrt_lt, sqrt_add_eq]

--- a/Mathlib/Data/Real/Cardinality.lean
+++ b/Mathlib/Data/Real/Cardinality.lean
@@ -66,8 +66,9 @@ theorem cantorFunctionAux_false (h : f n = false) : cantorFunctionAux c f n = 0 
   simp [cantorFunctionAux, h]
 
 theorem cantorFunctionAux_nonneg (h : 0 ≤ c) : 0 ≤ cantorFunctionAux c f n := by
-  cases h' : f n <;> simp [h']
-  apply pow_nonneg h
+  cases h' : f n
+  · simp [h']
+  · simpa [h'] using pow_nonneg h _
 
 theorem cantorFunctionAux_eq (h : f n = g n) :
     cantorFunctionAux c f n = cantorFunctionAux c g n := by simp [cantorFunctionAux, h]

--- a/Mathlib/Geometry/Manifold/Instances/Sphere.lean
+++ b/Mathlib/Geometry/Manifold/Instances/Sphere.lean
@@ -226,8 +226,8 @@ theorem stereo_left_inv (hv : ‖v‖ = 1) {x : sphere (0 : E) 1} (hx : (x : E) 
     ring!
   convert
     congr_arg₂ Add.add (congr_arg (fun t => t • (y : E)) h₁) (congr_arg (fun t => t • v) h₂) using 1
-  · simp [a, inner_add_right, inner_smul_right, hvy, real_inner_self_eq_norm_mul_norm, hv, mul_smul,
-      mul_pow, Real.norm_eq_abs, sq_abs, norm_smul]
+  · simp only [innerSL_apply, norm_smul, norm_div, RCLike.norm_ofNat, Real.norm_eq_abs,
+      AddSubgroupClass.coe_norm, mul_pow, div_pow, sq_abs, SetLike.val_smul, mul_smul, a]
     -- Porting note: used to be simp only [split, add_comm] but get maxRec errors
     rw [split, add_comm]
     ac_rfl

--- a/Mathlib/GroupTheory/Coset.lean
+++ b/Mathlib/GroupTheory/Coset.lean
@@ -178,7 +178,7 @@ theorem orbit_subgroup_one_eq_self : MulAction.orbit s (1 : α) = s :=
 
 @[to_additive eq_addCosets_of_normal]
 theorem eq_cosets_of_normal (N : s.Normal) (g : α) : g • (s : Set α) = op g • s :=
-  Set.ext fun a => by simp [mem_leftCoset_iff, mem_rightCoset_iff]; rw [N.mem_comm_iff]
+  Set.ext fun a => by simp [mem_leftCoset_iff, mem_rightCoset_iff, N.mem_comm_iff]
 
 @[to_additive normal_of_eq_addCosets]
 theorem normal_of_eq_cosets (h : ∀ g : α, g • (s : Set α) = op g • s) : s.Normal :=

--- a/Mathlib/MeasureTheory/Function/LpSeminorm/TriangleInequality.lean
+++ b/Mathlib/MeasureTheory/Function/LpSeminorm/TriangleInequality.lean
@@ -91,8 +91,7 @@ theorem snorm_add_le' {f g : α → E} (hf : AEStronglyMeasurable f μ) (hg : AE
     · have : p ∈ Set.Ioo (0 : ℝ≥0∞) 1 := ⟨hp.bot_lt, h'p⟩
       simp only [LpAddConst, if_pos this]
     · simpa using ENNReal.toReal_mono ENNReal.one_ne_top h'p.le
-  · simp [LpAddConst_of_one_le h'p]
-    exact snorm_add_le hf hg h'p
+  · simpa [LpAddConst_of_one_le h'p] using snorm_add_le hf hg h'p
 
 variable (μ E)
 

--- a/Mathlib/MeasureTheory/Function/LpSpace.lean
+++ b/Mathlib/MeasureTheory/Function/LpSpace.lean
@@ -888,7 +888,7 @@ theorem Memℒp.norm_rpow_div {f : α → E} (hf : Memℒp f p μ) (q : ℝ≥0�
   by_cases q_top : q = ∞
   · simp [q_top]
   by_cases q_zero : q = 0
-  · simp [q_zero]
+  · simp only [q_zero, ENNReal.zero_toReal, Real.rpow_zero]
     by_cases p_zero : p = 0
     · simp [p_zero]
     rw [ENNReal.div_zero p_zero]

--- a/Mathlib/MeasureTheory/Function/SimpleFuncDenseLp.lean
+++ b/Mathlib/MeasureTheory/Function/SimpleFuncDenseLp.lean
@@ -81,7 +81,7 @@ theorem norm_approxOn_zero_le [OpensMeasurableSpace E] {f : β → E} (hf : Meas
     (h₀ : (0 : E) ∈ s) [SeparableSpace s] (x : β) (n : ℕ) :
     ‖approxOn f hf s 0 h₀ n x‖ ≤ ‖f x‖ + ‖f x‖ := by
   have := edist_approxOn_y0_le hf h₀ x n
-  simp [edist_comm (0 : E), edist_eq_coe_nnnorm] at this
+  simp only [edist_comm (0 : E), edist_eq_coe_nnnorm] at this
   exact mod_cast this
 
 theorem tendsto_approxOn_Lp_snorm [OpensMeasurableSpace E] {f : β → E} (hf : Measurable f)

--- a/Mathlib/MeasureTheory/Function/UnifTight.lean
+++ b/Mathlib/MeasureTheory/Function/UnifTight.lean
@@ -65,7 +65,7 @@ theorem unifTight_iff_ennreal {_ : MeasurableSpace α} (f : ι → α → β) (p
       μ s ≠ ∞ ∧ ∀ i, snorm (sᶜ.indicator (f i)) p μ ≤ ε := by
   simp only [ENNReal.forall_ennreal, ENNReal.coe_pos]
   refine (and_iff_left ?_).symm
-  simp [-ne_eq, zero_lt_top, le_top]
+  simp only [zero_lt_top, le_top, implies_true, and_true, true_implies]
   use ∅; simpa only [measure_empty] using zero_ne_top
 
 theorem unifTight_iff_real {_ : MeasurableSpace α} (f : ι → α → β) (p : ℝ≥0∞) (μ : Measure α) :

--- a/Mathlib/MeasureTheory/Integral/Marginal.lean
+++ b/Mathlib/MeasureTheory/Integral/Marginal.lean
@@ -90,10 +90,8 @@ theorem _root_.Measurable.lmarginal (hf : Measurable f) : Measurable (∫⋯∫�
   refine hf.comp ?_
   rw [measurable_pi_iff]; intro i
   by_cases hi : i ∈ s
-  · simp [hi, updateFinset]
-    exact measurable_pi_iff.1 measurable_snd _
-  · simp [hi, updateFinset]
-    exact measurable_pi_iff.1 measurable_fst _
+  · simpa [hi, updateFinset] using measurable_pi_iff.1 measurable_snd _
+  · simpa [hi, updateFinset] using measurable_pi_iff.1 measurable_fst _
 
 @[simp] theorem lmarginal_empty (f : (∀ i, π i) → ℝ≥0∞) : ∫⋯∫⁻_∅, f ∂μ = f := by
   ext1 x

--- a/Mathlib/MeasureTheory/Integral/MeanInequalities.lean
+++ b/Mathlib/MeasureTheory/Integral/MeanInequalities.lean
@@ -195,7 +195,7 @@ theorem lintegral_prod_norm_pow_le {α ι : Type*} [MeasurableSpace α] {μ : Me
     simp at hp
   | @insert i₀ s hi₀ ih =>
     rcases eq_or_ne (p i₀) 1 with h2i₀|h2i₀
-    · simp [hi₀]
+    · simp only [hi₀, not_false_eq_true, prod_insert]
       have h2p : ∀ i ∈ s, p i = 0 := by
         simpa [hi₀, h2i₀, sum_eq_zero_iff_of_nonneg (fun i hi ↦ h2p i <| mem_insert_of_mem hi)]
           using hp

--- a/Mathlib/MeasureTheory/OuterMeasure/Induced.lean
+++ b/Mathlib/MeasureTheory/OuterMeasure/Induced.lean
@@ -349,7 +349,7 @@ theorem trim_zero : (0 : OuterMeasure α).trim = 0 :=
 
 theorem trim_sum_ge {ι} (m : ι → OuterMeasure α) : (sum fun i => (m i).trim) ≤ (sum m).trim :=
   fun s => by
-  simp [trim_eq_iInf]
+  simp only [sum_apply, trim_eq_iInf, le_iInf_iff]
   exact fun t st ht =>
     ENNReal.tsum_le_tsum fun i => iInf_le_of_le t <| iInf_le_of_le st <| iInf_le _ ht
 

--- a/Mathlib/MeasureTheory/OuterMeasure/Operations.lean
+++ b/Mathlib/MeasureTheory/OuterMeasure/Operations.lean
@@ -73,7 +73,7 @@ variable {R' : Type*} [SMul R' ℝ≥0∞] [IsScalarTower R' ℝ≥0∞ ℝ≥0�
 instance instSMul : SMul R (OuterMeasure α) :=
   ⟨fun c m =>
     { measureOf := fun s => c • m s
-      empty := by simp; rw [← smul_one_mul c]; simp
+      empty := by simp only [measure_empty]; rw [← smul_one_mul c]; simp
       mono := fun {s t} h => by
         simp only
         rw [← smul_one_mul c, ← smul_one_mul c (m t)]

--- a/Mathlib/MeasureTheory/SetAlgebra.lean
+++ b/Mathlib/MeasureTheory/SetAlgebra.lean
@@ -218,8 +218,8 @@ theorem countable_generateSetAlgebra (h : 𝒜.Countable) :
   have count_ℬ : ℬ.Countable := by
     apply h.union
     have : compl '' 𝒜 = {s | sᶜ ∈ 𝒜} := by
-      ext s; simp
-      exact ⟨fun ⟨x, x_mem, hx⟩ ↦ by simp [← hx, x_mem], fun hs ↦ ⟨sᶜ, hs, by simp⟩⟩
+      ext s
+      simpa using ⟨fun ⟨x, x_mem, hx⟩ ↦ by simp [← hx, x_mem], fun hs ↦ ⟨sᶜ, hs, by simp⟩⟩
     exact this ▸ h.image compl
   let f : Set (Set (Set α)) → Set α := fun A ↦ ⋃ a ∈ A, ⋂ t ∈ a, t
   let 𝒞 := {a | a.Finite ∧ a ⊆ ℬ}

--- a/Mathlib/NumberTheory/Dioph.lean
+++ b/Mathlib/NumberTheory/Dioph.lean
@@ -234,7 +234,7 @@ theorem sumsq_eq_zero (x) : ∀ l, sumsq l x = 0 ↔ l.Forall fun a : Poly α =>
                 have t := add_le_add_left (sumsq_nonneg x ps) (p x * p x)
                 rwa [add_zero] at t)
               (mul_self_nonneg _)
-        ⟨this, by simp [this] at h; exact h⟩,
+        ⟨this, by simpa [this] using h⟩,
       fun ⟨h1, h2⟩ => by rw [add_apply, mul_apply, h1, h2]; rfl⟩
 
 end
@@ -242,9 +242,9 @@ end
 /-- Map the index set of variables, replacing `x_i` with `x_(f i)`. -/
 def map {α β} (f : α → β) (g : Poly α) : Poly β :=
   ⟨fun v => g <| v ∘ f, Poly.induction (C := fun g => IsPoly (fun v => g (v ∘ f)))
-    (fun i => by simp; apply IsPoly.proj) (fun n => by simp; apply IsPoly.const)
-    (fun f g pf pg => by simp; apply IsPoly.sub pf pg)
-    (fun f g pf pg => by simp; apply IsPoly.mul pf pg) _⟩
+    (fun i => by simpa using IsPoly.proj _) (fun n => by simpa using IsPoly.const _)
+    (fun f g pf pg => by simpa using IsPoly.sub pf pg)
+    (fun f g pf pg => by simpa using IsPoly.mul pf pg) _⟩
 
 @[simp]
 theorem map_apply {α β} (f : α → β) (g : Poly α) (v) : map f g v = g (v ∘ f) := rfl

--- a/Mathlib/NumberTheory/NumberField/CanonicalEmbedding/ConvexBody.lean
+++ b/Mathlib/NumberTheory/NumberField/CanonicalEmbedding/ConvexBody.lean
@@ -186,9 +186,8 @@ theorem convexBodyLT'_mem {x : K} :
 
 theorem convexBodyLT'_neg_mem (x : E K) (hx : x ∈ convexBodyLT' K f w₀) :
     -x ∈ convexBodyLT' K f w₀ := by
-  simp [Set.mem_prod, Prod.fst_neg, Set.mem_pi, Set.mem_univ, Pi.neg_apply,
-    mem_ball_zero_iff, norm_neg, Real.norm_eq_abs, forall_true_left, Subtype.forall,
-    Prod.snd_neg, Complex.norm_eq_abs] at hx ⊢
+  simp only [Set.mem_prod, Set.mem_pi, Set.mem_univ, mem_ball, dist_zero_right, Real.norm_eq_abs,
+    true_implies, Subtype.forall, Prod.fst_neg, Pi.neg_apply, norm_neg, Prod.snd_neg] at hx ⊢
   convert hx using 3
   split_ifs <;> simp
 

--- a/Mathlib/NumberTheory/Padics/PadicNumbers.lean
+++ b/Mathlib/NumberTheory/Padics/PadicNumbers.lean
@@ -280,7 +280,7 @@ theorem ne_zero_iff_nequiv_zero (f : PadicSeq p) : mk f ≠ 0 ↔ ¬f ≈ 0 :=
 
 theorem norm_const (q : ℚ) : norm (const (padicNorm p) q) = padicNorm p q :=
   if hq : q = 0 then by
-    have : const (padicNorm p) q ≈ 0 := by simp [hq]; apply Setoid.refl (const (padicNorm p) 0)
+    have : const (padicNorm p) q ≈ 0 := by simpa [hq] using Setoid.refl (const (padicNorm p) 0)
     subst hq; simp [norm, this]
   else by
     have : ¬const (padicNorm p) q ≈ 0 := not_equiv_zero_const_of_nonzero hq

--- a/Mathlib/NumberTheory/PellMatiyasevic.lean
+++ b/Mathlib/NumberTheory/PellMatiyasevic.lean
@@ -401,7 +401,7 @@ theorem y_dvd_iff (m n) : yn a1 m ∣ yn a1 n ↔ m ∣ n :=
 theorem xy_modEq_yn (n) :
     ∀ k, xn a1 (n * k) ≡ xn a1 n ^ k [MOD yn a1 n ^ 2] ∧ yn a1 (n * k) ≡
         k * xn a1 n ^ (k - 1) * yn a1 n [MOD yn a1 n ^ 3]
-  | 0 => by constructor <;> simp <;> exact Nat.ModEq.refl _
+  | 0 => by constructor <;> simpa using Nat.ModEq.refl _
   | k + 1 => by
     let ⟨hx, hy⟩ := xy_modEq_yn n k
     have L : xn a1 (n * k) * xn a1 n + d a1 * yn a1 (n * k) * yn a1 n ≡
@@ -745,7 +745,7 @@ end
 theorem xy_modEq_of_modEq {a b c} (a1 : 1 < a) (b1 : 1 < b) (h : a ≡ b [MOD c]) :
     ∀ n, xn a1 n ≡ xn b1 n [MOD c] ∧ yn a1 n ≡ yn b1 n [MOD c]
   | 0 => by constructor <;> rfl
-  | 1 => by simp; exact ⟨h, ModEq.refl 1⟩
+  | 1 => by simpa using ⟨h, ModEq.refl 1⟩
   | n + 2 =>
     ⟨(xy_modEq_of_modEq a1 b1 h n).left.add_right_cancel <| by
         rw [xn_succ_succ a1, xn_succ_succ b1]
@@ -787,7 +787,7 @@ theorem matiyasevic {a k x y} :
       have vp : 0 < v := strictMono_y a1 (lt_trans zero_lt_one m1)
       have b1 : 1 < b :=
         have : xn a1 1 < u := strictMono_x a1 m1
-        have : a < u := by simp at this; exact this
+        have : a < u := by simpa using this
         lt_of_lt_of_le a1 <| by
           delta ModEq at ba; rw [Nat.mod_eq_of_lt this] at ba; rw [← ba]
           apply Nat.mod_le

--- a/Mathlib/Order/Filter/Cocardinal.lean
+++ b/Mathlib/Order/Filter/Cocardinal.lean
@@ -95,8 +95,7 @@ theorem _root_.Finset.eventually_cocardinal_nmem (s : Finset α) :
   eventually_cocardinal_nmem_of_card_lt <| lt_of_lt_of_le (finset_card_lt_aleph0 s) (hreg.aleph0_le)
 
 theorem eventually_cocardinal_ne (x : α) : ∀ᶠ a in cocardinal α hreg, a ≠ x := by
-  simp [Set.finite_singleton x]
-  exact hreg.nat_lt 1
+  simpa [Set.finite_singleton x] using hreg.nat_lt 1
 
 /-- The filter defined by all sets that have countable complements. -/
 abbrev cocountable : Filter α := cocardinal α Cardinal.isRegular_aleph_one

--- a/Mathlib/Order/Filter/Partial.lean
+++ b/Mathlib/Order/Filter/Partial.lean
@@ -104,7 +104,8 @@ theorem rcomap_sets (r : Rel α β) (f : Filter β) :
 theorem rcomap_rcomap (r : Rel α β) (s : Rel β γ) (l : Filter γ) :
     rcomap r (rcomap s l) = rcomap (r.comp s) l :=
   filter_eq <| by
-    ext t; simp [rcomap_sets, Rel.image, Rel.core_comp]; constructor
+    ext t; simp only [rcomap_sets, Rel.image, Filter.mem_sets, Set.mem_setOf_eq, Rel.core_comp]
+    constructor
     · rintro ⟨u, ⟨v, vsets, hv⟩, h⟩
       exact ⟨v, vsets, Set.Subset.trans (Rel.core_mono _ hv) h⟩
     rintro ⟨t, tsets, ht⟩

--- a/Mathlib/Order/Filter/Partial.lean
+++ b/Mathlib/Order/Filter/Partial.lean
@@ -119,9 +119,9 @@ theorem rtendsto_iff_le_rcomap (r : Rel α β) (l₁ : Filter α) (l₂ : Filter
     RTendsto r l₁ l₂ ↔ l₁ ≤ l₂.rcomap r := by
   rw [rtendsto_def]
   simp_rw [← l₂.mem_sets]
-  simp [Filter.le_def, rcomap, Rel.mem_image]; constructor
-  · exact fun h s t tl₂ => mem_of_superset (h t tl₂)
-  · exact fun h t tl₂ => h _ t tl₂ Set.Subset.rfl
+  constructor
+  · simpa [Filter.le_def, rcomap, Rel.mem_image] using fun h s t tl₂ => mem_of_superset (h t tl₂)
+  · simpa [Filter.le_def, rcomap, Rel.mem_image] using fun h t tl₂ => h _ t tl₂ Set.Subset.rfl
 
 -- Interestingly, there does not seem to be a way to express this relation using a forward map.
 -- Given a filter `f` on `α`, we want a filter `f'` on `β` such that `r.preimage s ∈ f` if
@@ -168,9 +168,9 @@ def RTendsto' (r : Rel α β) (l₁ : Filter α) (l₂ : Filter β) :=
 
 theorem rtendsto'_def (r : Rel α β) (l₁ : Filter α) (l₂ : Filter β) :
     RTendsto' r l₁ l₂ ↔ ∀ s ∈ l₂, r.preimage s ∈ l₁ := by
-  unfold RTendsto' rcomap'; simp [le_def, Rel.mem_image]; constructor
-  · exact fun h s hs => h _ _ hs Set.Subset.rfl
-  · exact fun h s t ht => mem_of_superset (h t ht)
+  unfold RTendsto' rcomap'; constructor
+  · simpa [le_def, Rel.mem_image] using fun h s hs => h _ _ hs Set.Subset.rfl
+  · simpa [le_def, Rel.mem_image] using fun h s t ht => mem_of_superset (h t ht)
 
 theorem tendsto_iff_rtendsto (l₁ : Filter α) (l₂ : Filter β) (f : α → β) :
     Tendsto f l₁ l₂ ↔ RTendsto (Function.graph f) l₁ l₂ := by

--- a/Mathlib/Order/OmegaCompletePartialOrder.lean
+++ b/Mathlib/Order/OmegaCompletePartialOrder.lean
@@ -122,7 +122,7 @@ theorem map_comp : (c.map f).map g = c.map (g.comp f) :=
 
 @[mono]
 theorem map_le_map {g : α →o β} (h : f ≤ g) : c.map f ≤ c.map g :=
-  fun i => by simp [mem_map_iff]; exists i; apply h
+  fun i => by simp only [map_coe, Function.comp_apply]; exists i; apply h
 
 /-- `OmegaCompletePartialOrder.Chain.zip` pairs up the elements of two chains
 that have the same index. -/

--- a/Mathlib/RingTheory/Generators.lean
+++ b/Mathlib/RingTheory/Generators.lean
@@ -392,13 +392,11 @@ instance Cotangent.module : Module S P.Cotangent where
   smul_add := fun r x y ↦ ext (smul_add (P.σ r) x.val y.val)
   add_smul := fun r s x ↦ by
     have := smul_eq_zero_of_mem (P.σ (r + s) - (P.σ r + P.σ s) : P.Ring) (by simp ) x
-    simp only [sub_smul, add_smul, sub_eq_zero] at this
-    exact this
+    simpa only [sub_smul, add_smul, sub_eq_zero]
   zero_smul := fun x ↦ smul_eq_zero_of_mem (P.σ 0 : P.Ring) (by simp) x
   one_smul := fun x ↦ by
     have := smul_eq_zero_of_mem (P.σ 1 - 1 : P.Ring) (by simp) x
-    simp [sub_eq_zero, sub_smul] at this
-    exact this
+    simpa [sub_eq_zero, sub_smul]
   mul_smul := fun r s x ↦ by
     have := smul_eq_zero_of_mem (P.σ (r * s) - (P.σ r * P.σ s) : P.Ring) (by simp) x
     simpa only [sub_smul, mul_smul, sub_eq_zero] using this

--- a/Mathlib/RingTheory/TensorProduct/MvPolynomial.lean
+++ b/Mathlib/RingTheory/TensorProduct/MvPolynomial.lean
@@ -203,8 +203,7 @@ noncomputable def algebraTensorAlgEquiv :
 @[simp]
 lemma algebraTensorAlgEquiv_tmul (a : A) (p : MvPolynomial σ R) :
     algebraTensorAlgEquiv R A (a ⊗ₜ p) = a • MvPolynomial.map (algebraMap R A) p := by
-  simp [algebraTensorAlgEquiv]
-  rw [Algebra.smul_def]
+  simp [algebraTensorAlgEquiv, Algebra.smul_def]
   rfl
 
 @[simp]

--- a/Mathlib/SetTheory/Ordinal/Notation.lean
+++ b/Mathlib/SetTheory/Ordinal/Notation.lean
@@ -406,15 +406,15 @@ theorem add_nfBelow {b} : ∀ {o₁ o₂}, NFBelow o₁ b → NFBelow o₂ b →
   | 0, _, _, h₂ => h₂
   | oadd e n a, o, h₁, h₂ => by
     have h' := add_nfBelow (h₁.snd.mono <| le_of_lt h₁.lt) h₂
-    simp [oadd_add]; revert h'; cases' a + o with e' n' a' <;> intro h'
+    simp only [oadd_add]; revert h'; cases' a + o with e' n' a' <;> intro h'
     · exact NFBelow.oadd h₁.fst NFBelow.zero h₁.lt
     have : ((e.cmp e').Compares e e') := @cmp_compares _ _ h₁.fst h'.fst
-    cases h : cmp e e' <;> dsimp [addAux] <;> simp [h]
+    cases h : cmp e e' <;> dsimp [addAux] <;> simp only [h]
     · exact h'
-    · simp [h] at this
+    · simp only [h] at this
       subst e'
       exact NFBelow.oadd h'.fst h'.snd h'.lt
-    · simp [h] at this
+    · simp only [h] at this
       exact NFBelow.oadd h₁.fst (NF.below_of_lt this ⟨⟨_, h'⟩⟩) h₁.lt
 
 instance add_nf (o₁ o₂) : ∀ [NF o₁] [NF o₂], NF (o₁ + o₂)
@@ -452,12 +452,13 @@ theorem sub_nfBelow : ∀ {o₁ o₂ b}, NFBelow o₁ b → NF o₂ → NFBelow 
     have h' := sub_nfBelow h₁.snd h₂.snd
     simp only [HSub.hSub, Sub.sub, sub] at h' ⊢
     have := @cmp_compares _ _ h₁.fst h₂.fst
-    cases h : cmp e₁ e₂ <;> simp [sub]
+    cases h : cmp e₁ e₂
     · apply NFBelow.zero
-    · simp only [h, Ordering.compares_eq] at this
+    · rw [Nat.sub_eq]
+      simp only [h, Ordering.compares_eq] at this
       subst e₂
-      cases (n₁ : ℕ) - n₂ <;> simp [sub]
-      · by_cases en : n₁ = n₂ <;> simp [en]
+      cases (n₁ : ℕ) - n₂
+      · by_cases en : n₁ = n₂ <;> simp only [en, ↓reduceIte]
         · exact h'.mono (le_of_lt h₁.lt)
         · exact NFBelow.zero
       · exact NFBelow.oadd h₁.fst h₁.snd h₁.lt
@@ -528,7 +529,7 @@ theorem oadd_mul_nfBelow {e₁ n₁ a₁ b₁} (h₁ : NFBelow (oadd e₁ n₁ a
   | 0, b₂, _ => NFBelow.zero
   | oadd e₂ n₂ a₂, b₂, h₂ => by
     have IH := oadd_mul_nfBelow h₁ h₂.snd
-    by_cases e0 : e₂ = 0 <;> simp [e0, oadd_mul]
+    by_cases e0 : e₂ = 0 <;> simp only [e0, oadd_mul, ↓reduceIte]
     · apply NFBelow.oadd h₁.fst h₁.snd
       simpa using (add_lt_add_iff_left (repr e₁)).2 (lt_of_le_of_lt (Ordinal.zero_le _) h₂.lt)
     · haveI := h₁.fst
@@ -555,11 +556,13 @@ theorem repr_mul : ∀ (o₁ o₂) [NF o₁] [NF o₂], repr (o₁ * o₂) = rep
     have ao : repr a₁ + ω ^ repr e₁ * (n₁ : ℕ) = ω ^ repr e₁ * (n₁ : ℕ) := by
       apply add_absorp h₁.snd'.repr_lt
       simpa using (Ordinal.mul_le_mul_iff_left <| opow_pos _ omega_pos).2 (natCast_le.2 n₁.2)
-    by_cases e0 : e₂ = 0 <;> simp [e0, mul]
-    · cases' Nat.exists_eq_succ_of_ne_zero n₂.ne_zero with x xe
+    by_cases e0 : e₂ = 0
+    · simp [e0, mul]
+      cases' Nat.exists_eq_succ_of_ne_zero n₂.ne_zero with x xe
       simp only [xe, h₂.zero_of_zero e0, repr, add_zero]
       rw [natCast_succ x, add_mul_succ _ ao, mul_assoc]
-    · haveI := h₁.fst
+    · simp only [repr]
+      haveI := h₁.fst
       haveI := h₂.fst
       simp only [Mul.mul, mul, e0, ite_false, repr.eq_2, repr_add, opow_add, IH, repr, mul_add]
       rw [← mul_assoc]
@@ -727,7 +730,7 @@ theorem split_add_lt {o e n a m} [NF o] (h : split o = (oadd e n a, m)) :
 @[simp]
 theorem mulNat_eq_mul (n o) : mulNat o n = o * ofNat n := by cases o <;> cases n <;> rfl
 
-instance nf_mulNat (o) [NF o] (n) : NF (mulNat o n) := by simp; exact ONote.mul_nf o (ofNat n)
+instance nf_mulNat (o) [NF o] (n) : NF (mulNat o n) := by simpa using ONote.mul_nf o (ofNat n)
 
 instance nf_opowAux (e a0 a) [NF e] [NF a0] [NF a] : ∀ k m, NF (opowAux e a0 a k m) := by
   intro k m
@@ -827,7 +830,7 @@ theorem repr_opow_aux₂ {a0 a'} [N0 : NF a0] [Na' : NF a'] (m : ℕ) (d : ω �
   have ω00 : 0 < ω0 ^ (k : Ordinal) := opow_pos _ (opow_pos _ omega_pos)
   have Rl : R < ω ^ (repr a0 * succ ↑k) := by
     by_cases k0 : k = 0
-    · simp [R, k0]
+    · simp only [k0, Nat.cast_zero, succ_zero, mul_one, R]
       refine lt_of_lt_of_le ?_ (opow_le_opow_right omega_pos (one_le_iff_ne_zero.2 e0))
       cases' m with m <;> simp [opowAux, omega_pos]
       rw [← add_one_eq_succ, ← Nat.cast_succ]

--- a/Mathlib/Topology/Category/Profinite/Nobeling.lean
+++ b/Mathlib/Topology/Category/Profinite/Nobeling.lean
@@ -819,8 +819,8 @@ instance (α : Type*) [TopologicalSpace α] : NoZeroSMulDivisors ℤ (LocallyCon
   intro hc
   ext x
   apply mul_right_injective₀ hc
-  simp [LocallyConstant.ext_iff] at h ⊢
-  exact h x
+  simp [LocallyConstant.ext_iff] at h
+  simpa [LocallyConstant.ext_iff] using h x
 
 theorem GoodProducts.linearIndependentSingleton :
     LinearIndependent ℤ (eval ({fun _ ↦ false} : Set (I → Bool))) := by

--- a/Mathlib/Topology/MetricSpace/Closeds.lean
+++ b/Mathlib/Topology/MetricSpace/Closeds.lean
@@ -201,7 +201,7 @@ instance Closeds.compactSpace [CompactSpace α] : CompactSpace (Closeds α) :=
       · intro x hx
         have : x ∈ ⋃ y ∈ s, ball y δ := hs (by simp)
         rcases mem_iUnion₂.1 this with ⟨y, ys, dy⟩
-        have : edist y x < δ := by simp at dy; rwa [edist_comm] at dy
+        have : edist y x < δ := by simpa [edist_comm]
         exact ⟨y, ⟨ys, ⟨x, hx, this⟩⟩, le_of_lt dy⟩
       · rintro x ⟨_, ⟨y, yu, hy⟩⟩
         exact ⟨y, yu, le_of_lt hy⟩
@@ -342,7 +342,7 @@ instance NonemptyCompacts.secondCountableTopology [SecondCountableTopology α] :
       have tc : ∀ x ∈ t, ∃ y ∈ c, edist x y ≤ δ := by
         intro x hx
         rcases tb x hx with ⟨y, yv, Dxy⟩
-        have : y ∈ c := by simp [c, -mem_image]; exact ⟨yv, ⟨x, hx, Dxy⟩⟩
+        have : y ∈ c := by simpa [c, -mem_image] using ⟨yv, ⟨x, hx, Dxy⟩⟩
         exact ⟨y, this, le_of_lt Dxy⟩
       -- points in `c` are well approximated by points in `t`
       have ct : ∀ y ∈ c, ∃ x ∈ t, edist y x ≤ δ := by

--- a/Mathlib/Topology/MetricSpace/PiNat.lean
+++ b/Mathlib/Topology/MetricSpace/PiNat.lean
@@ -388,8 +388,7 @@ protected def metricSpaceOfDiscreteUniformity {E : ℕ → Type*} [∀ n, Unifor
     eq_of_dist_eq_zero := PiNat.eq_of_dist_eq_zero _ _
     toUniformSpace := Pi.uniformSpace _
     uniformity_dist := by
-      simp [Pi.uniformity, comap_iInf, gt_iff_lt, preimage_setOf_eq, comap_principal,
-        PseudoMetricSpace.uniformity_dist, h, idRel]
+      simp only [Pi.uniformity, h, idRel, comap_principal, preimage_setOf_eq]
       apply le_antisymm
       · simp only [le_iInf_iff, le_principal_iff]
         intro ε εpos

--- a/Mathlib/Topology/Semicontinuous.lean
+++ b/Mathlib/Topology/Semicontinuous.lean
@@ -437,16 +437,12 @@ theorem LowerSemicontinuousWithinAt.add' {f g : α → γ} (hf : LowerSemicontin
       filter_upwards [hf z₁ z₁lt, hg z₂ z₂lt] with z h₁z h₂z
       have A1 : min (f z) (f x) ∈ u := by
         by_cases H : f z ≤ f x
-        · simp [H]
-          exact h₁ ⟨h₁z, H⟩
-        · simp [le_of_not_le H]
-          exact h₁ ⟨z₁lt, le_rfl⟩
+        · simpa [H] using h₁ ⟨h₁z, H⟩
+        · simpa [le_of_not_le H]
       have A2 : min (g z) (g x) ∈ v := by
         by_cases H : g z ≤ g x
-        · simp [H]
-          exact h₂ ⟨h₂z, H⟩
-        · simp [le_of_not_le H]
-          exact h₂ ⟨z₂lt, le_rfl⟩
+        · simpa [H] using h₂ ⟨h₂z, H⟩
+        · simpa [le_of_not_le H]
       have : (min (f z) (f x), min (g z) (g x)) ∈ u ×ˢ v := ⟨A1, A2⟩
       calc
         y < min (f z) (f x) + min (g z) (g x) := h this
@@ -456,10 +452,8 @@ theorem LowerSemicontinuousWithinAt.add' {f g : α → γ} (hf : LowerSemicontin
       filter_upwards [hf z₁ z₁lt] with z h₁z
       have A1 : min (f z) (f x) ∈ u := by
         by_cases H : f z ≤ f x
-        · simp [H]
-          exact h₁ ⟨h₁z, H⟩
-        · simp [le_of_not_le H]
-          exact h₁ ⟨z₁lt, le_rfl⟩
+        · simpa [H] using h₁ ⟨h₁z, H⟩
+        · simpa [le_of_not_le H]
       have : (min (f z) (f x), g x) ∈ u ×ˢ v := ⟨A1, xv⟩
       calc
         y < min (f z) (f x) + g x := h this
@@ -472,10 +466,8 @@ theorem LowerSemicontinuousWithinAt.add' {f g : α → γ} (hf : LowerSemicontin
       filter_upwards [hg z₂ z₂lt] with z h₂z
       have A2 : min (g z) (g x) ∈ v := by
         by_cases H : g z ≤ g x
-        · simp [H]
-          exact h₂ ⟨h₂z, H⟩
-        · simp [le_of_not_le H]
-          exact h₂ ⟨z₂lt, le_rfl⟩
+        · simpa [H] using h₂ ⟨h₂z, H⟩
+        · simpa [le_of_not_le H] using h₂ ⟨z₂lt, le_rfl⟩
       have : (f x, min (g z) (g x)) ∈ u ×ˢ v := ⟨xu, A2⟩
       calc
         y < f x + min (g z) (g x) := h this

--- a/Mathlib/Topology/UniformSpace/Completion.lean
+++ b/Mathlib/Topology/UniformSpace/Completion.lean
@@ -90,7 +90,7 @@ private theorem symm_gen : map Prod.swap ((𝓤 α).lift' gen) ≤ (𝓤 α).lif
         (monotone_setOf fun p => @Filter.monotone_mem _ (p.2.val ×ˢ p.1.val)))
       (by
         have h := fun p : CauchyFilter α × CauchyFilter α => @Filter.prod_comm _ _ p.2.val p.1.val
-        simp [f, Function.comp, h, mem_map']
+        simp only [Function.comp, h, mem_map, f]
         exact le_rfl)
   exact h₁.trans_le h₂
 
@@ -210,7 +210,7 @@ instance : CompleteSpace (CauchyFilter α) :=
         have : t' ⊆ { y : α | (f', pureCauchy y) ∈ gen t } := fun x hx =>
           (f ×ˢ pure x).sets_of_superset (prod_mem_prod ht' hx) h
         f.sets_of_superset ht' <| Subset.trans this (preimage_mono ht₂)
-    ⟨f', by simp [nhds_eq_uniformity]; assumption⟩
+    ⟨f', by simpa [nhds_eq_uniformity]⟩
 
 end
 


### PR DESCRIPTION
Found by the "flexible tactics" linter in #11821: all simp`s changed are non-terminal in the sense of the linter.
Yet, all of the fixes seem like neutral or improvements to me.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
