### PR TITLE
[Merged by Bors] - refactor: Extract predicate for conditional kernels 

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -3597,6 +3597,7 @@ import Mathlib.Probability.Kernel.Basic
 import Mathlib.Probability.Kernel.Composition
 import Mathlib.Probability.Kernel.CondDistrib
 import Mathlib.Probability.Kernel.Condexp
+import Mathlib.Probability.Kernel.Disintegration.Basic
 import Mathlib.Probability.Kernel.Disintegration.CdfToKernel
 import Mathlib.Probability.Kernel.Disintegration.CondCdf
 import Mathlib.Probability.Kernel.Disintegration.Density

--- a/Mathlib/Probability/Kernel/Basic.lean
+++ b/Mathlib/Probability/Kernel/Basic.lean
@@ -208,6 +208,12 @@ protected theorem measurable_coe (κ : Kernel α β) {s : Set β} (hs : Measurab
     Measurable fun a => κ a s :=
   (Measure.measurable_coe hs).comp κ.measurable
 
+lemma apply_congr_of_mem_measurableAtom (κ : Kernel α β) {y' y : α} (hy' : y' ∈ measurableAtom y) :
+  κ y' = κ y := by
+  ext s hs
+  exact mem_of_mem_measurableAtom hy'
+    (κ.measurable_coe hs (measurableSet_singleton (κ y s))) rfl
+
 lemma IsFiniteKernel.integrable (μ : Measure α) [IsFiniteMeasure μ]
     (κ : Kernel α β) [IsFiniteKernel κ] {s : Set β} (hs : MeasurableSet s) :
     Integrable (fun x => (κ x s).toReal) μ := by

--- a/Mathlib/Probability/Kernel/Basic.lean
+++ b/Mathlib/Probability/Kernel/Basic.lean
@@ -302,7 +302,8 @@ instance isFiniteKernel_seq (κ : Kernel α β) [h : IsSFiniteKernel κ] (n : �
     IsFiniteKernel (Kernel.seq κ n) :=
   h.tsum_finite.choose_spec.1 n
 
-instance IsSFiniteKernel.sFinite [IsSFiniteKernel κ] (a : α) : SFinite (κ a) :=
+instance _root_.ProbabilityTheory.IsSFiniteKernel.sFinite [IsSFiniteKernel κ] (a : α) :
+    SFinite (κ a) :=
   ⟨⟨fun n ↦ seq κ n a, inferInstance, (measure_sum_seq κ a).symm⟩⟩
 
 instance IsSFiniteKernel.add (κ η : Kernel α β) [IsSFiniteKernel κ] [IsSFiniteKernel η] :
@@ -451,17 +452,21 @@ lemma sum_const [Countable ι] (μ : ι → Measure β) :
   rw [const_apply, Measure.sum_apply _ hs, Kernel.sum_apply' _ _ hs]
   simp only [const_apply]
 
-instance isFiniteKernel_const {μβ : Measure β} [IsFiniteMeasure μβ] :
+instance const.instIsFiniteKernel {μβ : Measure β} [IsFiniteMeasure μβ] :
     IsFiniteKernel (const α μβ) :=
   ⟨⟨μβ Set.univ, measure_lt_top _ _, fun _ => le_rfl⟩⟩
 
-instance isSFiniteKernel_const {μβ : Measure β} [SFinite μβ] :
+instance const.instIsSFiniteKernel {μβ : Measure β} [SFinite μβ] :
     IsSFiniteKernel (const α μβ) :=
   ⟨fun n ↦ const α (sFiniteSeq μβ n), fun n ↦ inferInstance, by rw [sum_const, sum_sFiniteSeq]⟩
 
-instance isMarkovKernel_const {μβ : Measure β} [hμβ : IsProbabilityMeasure μβ] :
+instance const.instIsMarkovKernel {μβ : Measure β} [hμβ : IsProbabilityMeasure μβ] :
     IsMarkovKernel (const α μβ) :=
   ⟨fun _ => hμβ⟩
+
+lemma isSFiniteKernel_const [Nonempty α] {μβ : Measure β} :
+    IsSFiniteKernel (const α μβ) ↔ SFinite μβ :=
+  ⟨fun h ↦ h.sFinite (Classical.arbitrary α), fun _ ↦ inferInstance⟩
 
 @[simp]
 theorem lintegral_const {f : β → ℝ≥0∞} {μ : Measure β} {a : α} :

--- a/Mathlib/Probability/Kernel/Composition.lean
+++ b/Mathlib/Probability/Kernel/Composition.lean
@@ -766,6 +766,18 @@ instance IsSFiniteKernel.prodMkLeft (κ : Kernel α β) [IsSFiniteKernel κ] :
 instance IsSFiniteKernel.prodMkRight (κ : Kernel α β) [IsSFiniteKernel κ] :
     IsSFiniteKernel (prodMkRight γ κ) := by rw [Kernel.prodMkRight]; infer_instance
 
+lemma isSFiniteKernel_prodMkLeft_unit {κ : Kernel α β} :
+    IsSFiniteKernel (prodMkLeft Unit κ) ↔ IsSFiniteKernel κ := by
+  refine ⟨fun _ ↦ ?_, fun _ ↦ inferInstance⟩
+  change IsSFiniteKernel ((prodMkLeft Unit κ).comap (fun a ↦ ((), a)) (by fun_prop))
+  infer_instance
+
+lemma isSFiniteKernel_prodMkRight_unit {κ : Kernel α β} :
+    IsSFiniteKernel (prodMkRight Unit κ) ↔ IsSFiniteKernel κ := by
+  refine ⟨fun _ ↦ ?_, fun _ ↦ inferInstance⟩
+  change IsSFiniteKernel ((prodMkRight Unit κ).comap (fun a ↦ (a, ())) (by fun_prop))
+  infer_instance
+
 lemma map_prodMkLeft (γ : Type*) [MeasurableSpace γ] (κ : Kernel α β)
     {f : β → δ} (hf : Measurable f) :
     map (prodMkLeft γ κ) f hf = prodMkLeft γ (map κ f hf) := rfl

--- a/Mathlib/Probability/Kernel/Disintegration/Basic.lean
+++ b/Mathlib/Probability/Kernel/Disintegration/Basic.lean
@@ -97,7 +97,7 @@ lemma IsCondKernel.isMarkovKernel_iff_isSFiniteKernel [MeasurableSingletonClass 
 end MeasureTheory.Measure
 
 /-!
-### Disintegration of measures
+### Disintegration of kernels
 
 This section provides a predicate for a kernel to disintegrate a kernel, and proves that such a
 disintegrating kernel exists for a countable space if we have disintegrating.
@@ -108,8 +108,8 @@ variable (κ : Kernel α (β × Ω)) [IsFiniteKernel κ] (κCond : Kernel (α ×
 
 /-! #### Predicate for a kernel to disintegrate a kernel -/
 
-/-- A kernel `ρCond` is a conditional kernel for a measure `ρ` if it disintegrates it in the sense
-that `ρ.fst ⊗ₘ ρCond = ρ`. -/
+/-- A kernel `κCond` is a conditional kernel for a kernel `κ` if it disintegrates it in the sense
+that `κ.fst ⊗ₖ κCond = κ`. -/
 class IsCondKernel : Prop where
   disintegrate' : κ.fst ⊗ₖ κCond = κ
 

--- a/Mathlib/Probability/Kernel/Disintegration/Basic.lean
+++ b/Mathlib/Probability/Kernel/Disintegration/Basic.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2024 Yaël Dillies, Kin Yau James Wong. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Yaël Dillies, Kin Yau James Wong
+Authors: Yaël Dillies, Kin Yau James Wong, Rémy Degenne
 -/
 import Mathlib.Probability.Kernel.MeasureCompProd
 
@@ -24,13 +24,13 @@ A kernel `ρ : Kernel α (β × Ω)` is disintegrated by a kernel `κCond : Kern
 * `ProbabilityTheory.Kernel.IsCondKernel κ κCond`: Predicate for the kernel `κ Cond` to disintegrate
   the kernel `κ`.
 
-Further, if `κ` is a semifinite kernel from a countable `α` such that each measure `κ a` is
+Further, if `κ` is an s-finite kernel from a countable `α` such that each measure `κ a` is
 disintegrated by some kernel, then `κ` itself is disintegrated by a kernel, namely
 `ProbabilityTheory.Kernel.condKernelCountable`.
 
 ## See also
 
-`Mathlib.Probability.Kernel.Disintegration.Basic` for a **construction** of disintegrating kernels.
+`Mathlib.Probability.Kernel.Disintegration.StandardBorel` for a **construction** of disintegrating kernels.
 -/
 
 open MeasureTheory Set Filter MeasurableSpace ProbabilityTheory

--- a/Mathlib/Probability/Kernel/Disintegration/Basic.lean
+++ b/Mathlib/Probability/Kernel/Disintegration/Basic.lean
@@ -30,7 +30,8 @@ disintegrated by some kernel, then `κ` itself is disintegrated by a kernel, nam
 
 ## See also
 
-`Mathlib.Probability.Kernel.Disintegration.StandardBorel` for a **construction** of disintegrating kernels.
+`Mathlib.Probability.Kernel.Disintegration.StandardBorel` for a **construction** of disintegrating
+kernels.
 -/
 
 open MeasureTheory Set Filter MeasurableSpace ProbabilityTheory

--- a/Mathlib/Probability/Kernel/Disintegration/Basic.lean
+++ b/Mathlib/Probability/Kernel/Disintegration/Basic.lean
@@ -4,9 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Yaël Dillies, Kin Yau James Wong
 -/
 import Mathlib.Probability.Kernel.MeasureCompProd
-import Mathlib.Probability.Kernel.Disintegration.CondCdf
-import Mathlib.Probability.Kernel.Disintegration.Density
-import Mathlib.Probability.Kernel.Disintegration.CdfToKernel
 
 /-!
 # Disintegration of measures and kernels

--- a/Mathlib/Probability/Kernel/Disintegration/Basic.lean
+++ b/Mathlib/Probability/Kernel/Disintegration/Basic.lean
@@ -99,8 +99,10 @@ end MeasureTheory.Measure
 /-!
 ### Disintegration of kernels
 
-This section provides a predicate for a kernel to disintegrate a kernel, and proves that such a
-disintegrating kernel exists for a countable space if we have disintegrating.
+This section provides a predicate for a kernel to disintegrate a kernel. It also proves that if `κ`
+is an s-finite kernel from a countable `α` such that each measure `κ a` is disintegrated by some
+kernel, then `κ` itself is disintegrated by a kernel, namely
+`ProbabilityTheory.Kernel.condKernelCountable`..
 -/
 
 namespace ProbabilityTheory.Kernel

--- a/Mathlib/Probability/Kernel/Disintegration/Basic.lean
+++ b/Mathlib/Probability/Kernel/Disintegration/Basic.lean
@@ -1,0 +1,158 @@
+/-
+Copyright (c) 2024 Yaël Dillies, Kin Yau James Wong. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Yaël Dillies, Kin Yau James Wong
+-/
+import Mathlib.Probability.Kernel.MeasureCompProd
+import Mathlib.Probability.Kernel.Disintegration.CondCdf
+import Mathlib.Probability.Kernel.Disintegration.Density
+import Mathlib.Probability.Kernel.Disintegration.CdfToKernel
+
+/-!
+# Disintegration of measures and kernels
+
+This file defines predicates for a kernel to "disintegrate" a measure or a kernel. This kernel is
+also called the "conditional kernel" of the measure or kernel.
+
+A measure `ρ : Measure (α × Ω)` is disintegrated by a kernel `ρCond : Kernel α Ω` if
+`ρ.fst ⊗ₘ ρCond = ρ`.
+
+A kernel `ρ : Kernel α (β × Ω)` is disintegrated by a kernel `κCond : Kernel (α × β) Ω` if
+`κ.fst ⊗ₖ κCond = κ`.
+
+## Main definitions
+
+* `MeasureTheory.Measure.IsCondKernel ρ ρCond`: Predicate for the kernel `ρCond` to disintegrate the
+  measure `ρ`.
+* `ProbabilityTheory.Kernel.IsCondKernel κ κCond`: Predicate for the kernel `κ Cond` to disintegrate
+  the kernel `κ`.
+
+Further, if `κ` is a semifinite kernel from a countable `α` such that each measure `κ a` is
+disintegrated by some kernel, then `κ` itself is disintegrated by a kernel, namely
+`ProbabilityTheory.Kernel.condKernelCountable`.
+
+## See also
+
+`Mathlib.Probability.Kernel.Disintegration.Basic` for a **construction** of disintegrating kernels.
+-/
+
+open MeasureTheory Set Filter MeasurableSpace ProbabilityTheory
+open scoped ENNReal MeasureTheory Topology
+
+variable {α β Ω : Type*} {mα : MeasurableSpace α} {mβ : MeasurableSpace β} [MeasurableSpace Ω]
+
+/-!
+### Disintegration of measures
+
+This section provides a predicate for a kernel to disintegrate a measure.
+-/
+
+namespace MeasureTheory.Measure
+variable (ρ : Measure (α × Ω)) [IsFiniteMeasure ρ] (ρCond : Kernel α Ω)
+
+/-- A kernel `ρCond` is a conditional kernel for a measure `ρ` if it disintegrates it in the sense
+that `ρ.fst ⊗ₘ ρCond = ρ`. -/
+class IsCondKernel : Prop where
+  disintegrate' : ρ.fst ⊗ₘ ρCond = ρ
+
+variable [ρ.IsCondKernel ρCond]
+
+lemma disintegrate : ρ.fst ⊗ₘ ρCond = ρ := IsCondKernel.disintegrate'
+
+/-- Auxiliary lemma for `IsCondKernel.apply_of_ne_zero`. -/
+private lemma IsCondKernel.apply_of_ne_zero_of_measurableSet [MeasurableSingletonClass α]
+    [IsSFiniteKernel ρCond] {x : α} (hx : ρ.fst {x} ≠ 0) {s : Set Ω} (hs : MeasurableSet s) :
+    ρCond x s = (ρ.fst {x})⁻¹ * ρ ({x} ×ˢ s) := by
+  nth_rewrite 2 [← ρ.disintegrate ρCond]
+  rw [Measure.compProd_apply (measurableSet_prod.mpr (Or.inl ⟨measurableSet_singleton x, hs⟩))]
+  classical
+  have (a) : ρCond a (Prod.mk a ⁻¹' {x} ×ˢ s) = ({x} : Set α).indicator (ρCond · s) a := by
+    obtain rfl | hax := eq_or_ne a x
+    · simp only [singleton_prod, mem_singleton_iff, indicator_of_mem]
+      congr with y
+      simp
+    · simp only [singleton_prod, mem_singleton_iff, hax, not_false_eq_true, indicator_of_not_mem]
+      have : Prod.mk a ⁻¹' (Prod.mk x '' s) = ∅ := by ext y; simp [Ne.symm hax]
+      simp only [this, measure_empty]
+  simp_rw [this]
+  rw [MeasureTheory.lintegral_indicator _ (measurableSet_singleton x)]
+  simp only [Measure.restrict_singleton, lintegral_smul_measure, lintegral_dirac]
+  rw [← mul_assoc, ENNReal.inv_mul_cancel hx (measure_ne_top _ _), one_mul]
+
+/-- If the singleton `{x}` has non-zero mass for `ρ.fst`, then for all `s : Set Ω`,
+`ρCond x s = (ρ.fst {x})⁻¹ * ρ ({x} ×ˢ s)` . -/
+lemma IsCondKernel.apply_of_ne_zero [MeasurableSingletonClass α] [IsSFiniteKernel ρCond] {x : α}
+    (hx : ρ.fst {x} ≠ 0) (s : Set Ω) : ρCond x s = (ρ.fst {x})⁻¹ * ρ ({x} ×ˢ s) := by
+  have : ρCond x s = ((ρ.fst {x})⁻¹ • ρ).comap (fun (y : Ω) ↦ (x, y)) s := by
+    congr 2 with s hs
+    simp [IsCondKernel.apply_of_ne_zero_of_measurableSet _ _ hx hs,
+      (measurableEmbedding_prod_mk_left x).comap_apply]
+  simp [this, (measurableEmbedding_prod_mk_left x).comap_apply, hx]
+
+-- TODO: Can we generalise away from `MeasurableSingletonClass`, using eg `measurableAtom a` instead
+-- of `{a}`?
+lemma IsCondKernel.isMarkovKernel_iff_isSFiniteKernel [MeasurableSingletonClass α]
+    (hρ : ∀ a, ρ.fst {a} ≠ 0) : IsMarkovKernel ρCond ↔ IsSFiniteKernel ρCond := by
+  refine ⟨fun _ ↦ inferInstance, fun _ ↦ ⟨fun a ↦ ⟨?_⟩⟩⟩
+  rw [IsCondKernel.apply_of_ne_zero _ _ (hρ _), prod_univ, ← Measure.fst_apply
+    (measurableSet_singleton _), ENNReal.inv_mul_cancel (hρ _) (measure_ne_top _ _)]
+
+end MeasureTheory.Measure
+
+/-!
+### Disintegration of measures
+
+This section provides a predicate for a kernel to disintegrate a kernel, and proves that such a
+disintegrating kernel exists for a countable space if we have disintegrating.
+-/
+
+namespace ProbabilityTheory.Kernel
+variable (κ : Kernel α (β × Ω)) [IsFiniteKernel κ] (κCond : Kernel (α × β) Ω)
+
+/-! #### Predicate for a kernel to disintegrate a kernel -/
+
+/-- A kernel `ρCond` is a conditional kernel for a measure `ρ` if it disintegrates it in the sense
+that `ρ.fst ⊗ₘ ρCond = ρ`. -/
+class IsCondKernel : Prop where
+  disintegrate' : κ.fst ⊗ₖ κCond = κ
+
+variable [κ.IsCondKernel κCond]
+
+lemma disintegrate : κ.fst ⊗ₖ κCond = κ := IsCondKernel.disintegrate'
+
+/-! #### Existence of a disintegrating kernel in a countable space -/
+
+section Countable
+variable [Countable α] (κCond : α → Kernel β Ω)
+  (h_atom : ∀ x y, x ∈ measurableAtom y → κCond x = κCond y)
+
+/-- Auxiliary definition for `ProbabilityTheory.Kernel.condKernel`.
+
+A conditional kernel for `κ : Kernel α (β × Ω)` where `α` is countable and `Ω` is a measurable
+space. -/
+noncomputable def condKernelCountable : Kernel (α × β) Ω where
+  toFun p := κCond p.1 p.2
+  measurable' := by
+    change Measurable ((fun q : β × α ↦ (κCond q.2) q.1) ∘ Prod.swap)
+    refine (measurable_from_prod_countable' (fun a ↦ (κCond a).measurable) ?_).comp measurable_swap
+    · intro x y hx hy
+      simpa using DFunLike.congr (h_atom _ _ hy) rfl
+
+lemma condKernelCountable_apply (p : α × β) : condKernelCountable κCond h_atom p = κCond p.1 p.2 :=
+  rfl
+
+instance condKernelCountable.instIsMarkovKernel [∀ a, IsMarkovKernel (κCond a)] :
+    IsMarkovKernel (condKernelCountable κCond h_atom) where
+  isProbabilityMeasure p := (‹∀ a, IsMarkovKernel (κCond a)› p.1).isProbabilityMeasure p.2
+
+instance condKernelCountable.instIsCondKernel [∀ a, IsMarkovKernel (κCond a)]
+    (κ : Kernel α (β × Ω)) [IsSFiniteKernel κ] [∀ a, (κ a).IsCondKernel (κCond a)] :
+    κ.IsCondKernel (condKernelCountable κCond h_atom) := by
+  constructor
+  ext a s hs
+  conv_rhs => rw [← (κ a).disintegrate (κCond a)]
+  simp_rw [compProd_apply _ _ _ hs, condKernelCountable_apply, Measure.compProd_apply hs]
+  congr
+
+end Countable
+end ProbabilityTheory.Kernel

--- a/Mathlib/Probability/Kernel/Disintegration/Integral.lean
+++ b/Mathlib/Probability/Kernel/Disintegration/Integral.lean
@@ -38,14 +38,14 @@ variable [CountableOrCountablyGenerated α β] {κ : Kernel α (β × Ω)} [IsFi
 
 lemma lintegral_condKernel_mem (a : α) {s : Set (β × Ω)} (hs : MeasurableSet s) :
     ∫⁻ x, Kernel.condKernel κ (a, x) {y | (x, y) ∈ s} ∂(Kernel.fst κ a) = κ a s := by
-  conv_rhs => rw [← Kernel.compProd_fst_condKernel κ]
+  conv_rhs => rw [← κ.disintegrate κ.condKernel]
   simp_rw [Kernel.compProd_apply _ _ _ hs]
 
 lemma setLIntegral_condKernel_eq_measure_prod (a : α) {s : Set β} (hs : MeasurableSet s)
     {t : Set Ω} (ht : MeasurableSet t) :
     ∫⁻ b in s, Kernel.condKernel κ (a, b) t ∂(Kernel.fst κ a) = κ a (s ×ˢ t) := by
   have : κ a (s ×ˢ t) = (Kernel.fst κ ⊗ₖ Kernel.condKernel κ) a (s ×ˢ t) := by
-    congr; exact (Kernel.compProd_fst_condKernel κ).symm
+    congr; exact (κ.disintegrate _).symm
   rw [this, Kernel.compProd_apply _ _ _ (hs.prod ht)]
   classical
   have : ∀ b, Kernel.condKernel κ (a, b) {c | (b, c) ∈ s ×ˢ t}
@@ -60,14 +60,14 @@ alias set_lintegral_condKernel_eq_measure_prod := setLIntegral_condKernel_eq_mea
 
 lemma lintegral_condKernel (hf : Measurable f) (a : α) :
     ∫⁻ b, ∫⁻ ω, f (b, ω) ∂(Kernel.condKernel κ (a, b)) ∂(Kernel.fst κ a) = ∫⁻ x, f x ∂(κ a) := by
-  conv_rhs => rw [← Kernel.compProd_fst_condKernel κ]
+  conv_rhs => rw [← κ.disintegrate κ.condKernel]
   rw [Kernel.lintegral_compProd _ _ _ hf]
 
 lemma setLIntegral_condKernel (hf : Measurable f) (a : α) {s : Set β}
     (hs : MeasurableSet s) {t : Set Ω} (ht : MeasurableSet t) :
     ∫⁻ b in s, ∫⁻ ω in t, f (b, ω) ∂(Kernel.condKernel κ (a, b)) ∂(Kernel.fst κ a)
       = ∫⁻ x in s ×ˢ t, f x ∂(κ a) := by
-  conv_rhs => rw [← Kernel.compProd_fst_condKernel κ]
+  conv_rhs => rw [← κ.disintegrate κ.condKernel]
   rw [Kernel.setLIntegral_compProd _ _ _ hf hs ht]
 
 @[deprecated (since := "2024-06-29")]
@@ -102,21 +102,21 @@ lemma _root_.MeasureTheory.AEStronglyMeasurable.integral_kernel_condKernel (a : 
     (hf : AEStronglyMeasurable f (κ a)) :
     AEStronglyMeasurable (fun x ↦ ∫ y, f (x, y) ∂(Kernel.condKernel κ (a, x)))
       (Kernel.fst κ a) := by
-  rw [← Kernel.compProd_fst_condKernel κ] at hf
+  rw [← κ.disintegrate κ.condKernel] at hf
   exact AEStronglyMeasurable.integral_kernel_compProd hf
 
 lemma integral_condKernel (a : α) (hf : Integrable f (κ a)) :
     ∫ b, ∫ ω, f (b, ω) ∂(Kernel.condKernel κ (a, b)) ∂(Kernel.fst κ a) = ∫ x, f x ∂(κ a) := by
-  conv_rhs => rw [← Kernel.compProd_fst_condKernel κ]
-  rw [← Kernel.compProd_fst_condKernel κ] at hf
+  conv_rhs => rw [← κ.disintegrate κ.condKernel]
+  rw [← κ.disintegrate κ.condKernel] at hf
   rw [integral_compProd hf]
 
 lemma setIntegral_condKernel (a : α) {s : Set β} (hs : MeasurableSet s)
     {t : Set Ω} (ht : MeasurableSet t) (hf : IntegrableOn f (s ×ˢ t) (κ a)) :
     ∫ b in s, ∫ ω in t, f (b, ω) ∂(Kernel.condKernel κ (a, b)) ∂(Kernel.fst κ a)
       = ∫ x in s ×ˢ t, f x ∂(κ a) := by
-  conv_rhs => rw [← Kernel.compProd_fst_condKernel κ]
-  rw [← Kernel.compProd_fst_condKernel κ] at hf
+  conv_rhs => rw [← κ.disintegrate κ.condKernel]
+  rw [← κ.disintegrate κ.condKernel] at hf
   rw [setIntegral_compProd hs ht hf]
 
 @[deprecated (since := "2024-04-17")]

--- a/Mathlib/Probability/Kernel/Disintegration/Integral.lean
+++ b/Mathlib/Probability/Kernel/Disintegration/Integral.lean
@@ -156,7 +156,7 @@ variable [CountableOrCountablyGenerated α β] {ρ : Measure (β × Ω)} [IsFini
 
 lemma lintegral_condKernel_mem {s : Set (β × Ω)} (hs : MeasurableSet s) :
     ∫⁻ x, ρ.condKernel x {y | (x, y) ∈ s} ∂ρ.fst = ρ s := by
-  conv_rhs => rw [← compProd_fst_condKernel ρ]
+  conv_rhs => rw [← ρ.disintegrate ρ.condKernel]
   simp_rw [compProd_apply hs]
   rfl
 
@@ -164,7 +164,7 @@ lemma setLIntegral_condKernel_eq_measure_prod {s : Set β} (hs : MeasurableSet s
     (ht : MeasurableSet t) :
     ∫⁻ b in s, ρ.condKernel b t ∂ρ.fst = ρ (s ×ˢ t) := by
   have : ρ (s ×ˢ t) = (ρ.fst ⊗ₘ ρ.condKernel) (s ×ˢ t) := by
-    congr; exact (compProd_fst_condKernel ρ).symm
+    congr; exact (ρ.disintegrate _).symm
   rw [this, compProd_apply (hs.prod ht)]
   classical
   have : ∀ b, ρ.condKernel b (Prod.mk b ⁻¹' s ×ˢ t)
@@ -179,14 +179,14 @@ alias set_lintegral_condKernel_eq_measure_prod := setLIntegral_condKernel_eq_mea
 
 lemma lintegral_condKernel (hf : Measurable f) :
     ∫⁻ b, ∫⁻ ω, f (b, ω) ∂(ρ.condKernel b) ∂ρ.fst = ∫⁻ x, f x ∂ρ := by
-  conv_rhs => rw [← compProd_fst_condKernel ρ]
+  conv_rhs => rw [← ρ.disintegrate ρ.condKernel]
   rw [lintegral_compProd hf]
 
 lemma setLIntegral_condKernel (hf : Measurable f) {s : Set β}
     (hs : MeasurableSet s) {t : Set Ω} (ht : MeasurableSet t) :
     ∫⁻ b in s, ∫⁻ ω in t, f (b, ω) ∂(ρ.condKernel b) ∂ρ.fst
       = ∫⁻ x in s ×ˢ t, f x ∂ρ := by
-  conv_rhs => rw [← compProd_fst_condKernel ρ]
+  conv_rhs => rw [← ρ.disintegrate ρ.condKernel]
   rw [setLIntegral_compProd  hf hs ht]
 
 @[deprecated (since := "2024-06-29")]
@@ -220,20 +220,20 @@ variable {ρ : Measure (β × Ω)} [IsFiniteMeasure ρ]
 lemma _root_.MeasureTheory.AEStronglyMeasurable.integral_condKernel
     (hf : AEStronglyMeasurable f ρ) :
     AEStronglyMeasurable (fun x ↦ ∫ y, f (x, y) ∂ρ.condKernel x) ρ.fst := by
-  rw [← ρ.compProd_fst_condKernel] at hf
+  rw [← ρ.disintegrate ρ.condKernel] at hf
   exact AEStronglyMeasurable.integral_kernel_compProd hf
 
 lemma integral_condKernel (hf : Integrable f ρ) :
     ∫ b, ∫ ω, f (b, ω) ∂(ρ.condKernel b) ∂ρ.fst = ∫ x, f x ∂ρ := by
-  conv_rhs => rw [← compProd_fst_condKernel ρ]
-  rw [← compProd_fst_condKernel ρ] at hf
+  conv_rhs => rw [← ρ.disintegrate ρ.condKernel]
+  rw [← ρ.disintegrate ρ.condKernel] at hf
   rw [integral_compProd hf]
 
 lemma setIntegral_condKernel {s : Set β} (hs : MeasurableSet s)
     {t : Set Ω} (ht : MeasurableSet t) (hf : IntegrableOn f (s ×ˢ t) ρ) :
     ∫ b in s, ∫ ω in t, f (b, ω) ∂(ρ.condKernel b) ∂ρ.fst = ∫ x in s ×ˢ t, f x ∂ρ := by
-  conv_rhs => rw [← compProd_fst_condKernel ρ]
-  rw [← compProd_fst_condKernel ρ] at hf
+  conv_rhs => rw [← ρ.disintegrate ρ.condKernel]
+  rw [← ρ.disintegrate ρ.condKernel] at hf
   rw [setIntegral_compProd hs ht hf]
 
 @[deprecated (since := "2024-04-17")]
@@ -275,8 +275,8 @@ theorem AEStronglyMeasurable.ae_integrable_condKernel_iff {f : α × Ω → F}
     (hf : AEStronglyMeasurable f ρ) :
     (∀ᵐ a ∂ρ.fst, Integrable (fun ω ↦ f (a, ω)) (ρ.condKernel a)) ∧
       Integrable (fun a ↦ ∫ ω, ‖f (a, ω)‖ ∂ρ.condKernel a) ρ.fst ↔ Integrable f ρ := by
-  rw [← ρ.compProd_fst_condKernel] at hf
-  conv_rhs => rw [← ρ.compProd_fst_condKernel]
+  rw [← ρ.disintegrate ρ.condKernel] at hf
+  conv_rhs => rw [← ρ.disintegrate ρ.condKernel]
   rw [Measure.integrable_compProd_iff hf]
 
 theorem Integrable.condKernel_ae {f : α × Ω → F} (hf_int : Integrable f ρ) :

--- a/Mathlib/Probability/Kernel/Disintegration/StandardBorel.lean
+++ b/Mathlib/Probability/Kernel/Disintegration/StandardBorel.lean
@@ -4,12 +4,13 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Rémy Degenne
 -/
 import Mathlib.Probability.Kernel.MeasureCompProd
+import Mathlib.Probability.Kernel.Disintegration.Basic
 import Mathlib.Probability.Kernel.Disintegration.CondCdf
 import Mathlib.Probability.Kernel.Disintegration.Density
 import Mathlib.Probability.Kernel.Disintegration.CdfToKernel
 
 /-!
-# Disintegration of kernels and measures
+# Existence of disintegration of measures and kernels for standard Borel spaces
 
 Let `κ : Kernel α (β × Ω)` be a finite kernel, where `Ω` is a standard Borel space. Then if `α` is
 countable or `β` has a countably generated σ-algebra (for example if it is standard Borel), then
@@ -372,6 +373,18 @@ lemma _root_.MeasureTheory.Measure.condKernel_apply (ρ : Measure (α × Ω)) [I
     ρ.condKernel a = condKernelUnitBorel (const Unit ρ) ((), a) := by
   rw [Measure.condKernel]; rfl
 
+instance _root_.MeasureTheory.Measure.condKernel.instIsCondKernel (ρ : Measure (α × Ω))
+    [IsFiniteMeasure ρ] : ρ.IsCondKernel ρ.condKernel where
+  disintegrate' := by
+    have h1 : const Unit (Measure.fst ρ) = fst (const Unit ρ) := by
+      ext
+      simp only [fst_apply, Measure.fst, const_apply]
+    have h2 : prodMkLeft Unit (Measure.condKernel ρ) = condKernelUnitBorel (const Unit ρ) := by
+      ext
+      simp only [prodMkLeft_apply, Measure.condKernel_apply]
+    rw [Measure.compProd, h1, h2, compProd_fst_condKernelUnitBorel]
+    simp
+
 instance _root_.MeasureTheory.Measure.instIsMarkovKernelCondKernel
     (ρ : Measure (α × Ω)) [IsFiniteMeasure ρ] : IsMarkovKernel ρ.condKernel := by
   rw [Measure.condKernel]
@@ -380,52 +393,25 @@ instance _root_.MeasureTheory.Measure.instIsMarkovKernelCondKernel
 /-- **Disintegration** of finite product measures on `α × Ω`, where `Ω` is standard Borel. Such a
 measure can be written as the composition-product of `ρ.fst` (marginal measure over `α`) and
 a Markov kernel from `α` to `Ω`. We call that Markov kernel `ρ.condKernel`. -/
+@[deprecated Measure.disintegrate (since := "2024-07-24")]
 lemma _root_.MeasureTheory.Measure.compProd_fst_condKernel
     (ρ : Measure (α × Ω)) [IsFiniteMeasure ρ] :
-    ρ.fst ⊗ₘ ρ.condKernel = ρ := by
-  have h1 : const Unit (Measure.fst ρ) = fst (const Unit ρ) := by
-    ext
-    simp only [fst_apply, Measure.fst, const_apply]
-  have h2 : prodMkLeft Unit (Measure.condKernel ρ) = condKernelUnitBorel (const Unit ρ) := by
-    ext
-    simp only [prodMkLeft_apply, Measure.condKernel_apply]
-  rw [Measure.compProd, h1, h2, compProd_fst_condKernelUnitBorel]
-  simp
+    ρ.fst ⊗ₘ ρ.condKernel = ρ := ρ.disintegrate ρ.condKernel
 
+set_option linter.unusedVariables false in
 /-- Auxiliary lemma for `condKernel_apply_of_ne_zero`. -/
+@[deprecated Measure.IsCondKernel.apply_of_ne_zero (since := "2024-07-24")]
 lemma _root_.MeasureTheory.Measure.condKernel_apply_of_ne_zero_of_measurableSet
     [MeasurableSingletonClass α] {x : α} (hx : ρ.fst {x} ≠ 0) {s : Set Ω} (hs : MeasurableSet s) :
-    ρ.condKernel x s = (ρ.fst {x})⁻¹ * ρ ({x} ×ˢ s) := by
-  nth_rewrite 3 [← ρ.compProd_fst_condKernel]
-  rw [Measure.compProd_apply (measurableSet_prod.mpr (Or.inl ⟨measurableSet_singleton x, hs⟩))]
-  classical
-  have : ∀ a, ρ.condKernel a (Prod.mk a ⁻¹' {x} ×ˢ s)
-      = ({x} : Set α).indicator (fun a ↦ ρ.condKernel a s) a := by
-    intro a
-    by_cases hax : a = x
-    · simp only [hax, singleton_prod, mem_singleton_iff, indicator_of_mem]
-      congr with y
-      simp
-    · simp only [singleton_prod, mem_singleton_iff, hax, not_false_eq_true, indicator_of_not_mem]
-      have : Prod.mk a ⁻¹' (Prod.mk x '' s) = ∅ := by
-        ext y
-        simp [Ne.symm hax]
-      simp only [this, measure_empty]
-  simp_rw [this]
-  rw [MeasureTheory.lintegral_indicator _ (measurableSet_singleton x)]
-  simp only [Measure.restrict_singleton, lintegral_smul_measure, lintegral_dirac]
-  rw [← mul_assoc, ENNReal.inv_mul_cancel hx (measure_ne_top ρ.fst _), one_mul]
+    ρ.condKernel x s = (ρ.fst {x})⁻¹ * ρ ({x} ×ˢ s) :=
+  Measure.IsCondKernel.apply_of_ne_zero _ _ hx _
 
 /-- If the singleton `{x}` has non-zero mass for `ρ.fst`, then for all `s : Set Ω`,
 `ρ.condKernel x s = (ρ.fst {x})⁻¹ * ρ ({x} ×ˢ s)` . -/
 lemma _root_.MeasureTheory.Measure.condKernel_apply_of_ne_zero [MeasurableSingletonClass α]
     {x : α} (hx : ρ.fst {x} ≠ 0) (s : Set Ω) :
-    ρ.condKernel x s = (ρ.fst {x})⁻¹ * ρ ({x} ×ˢ s) := by
-  have : ρ.condKernel x s = ((ρ.fst {x})⁻¹ • ρ).comap (fun (y : Ω) ↦ (x, y)) s := by
-    congr 2 with s hs
-    simp [Measure.condKernel_apply_of_ne_zero_of_measurableSet hx hs,
-      (measurableEmbedding_prod_mk_left x).comap_apply]
-  simp [this, (measurableEmbedding_prod_mk_left x).comap_apply, hx]
+    ρ.condKernel x s = (ρ.fst {x})⁻¹ * ρ ({x} ×ˢ s) :=
+  Measure.IsCondKernel.apply_of_ne_zero _ _ hx _
 
 end Measure
 
@@ -433,36 +419,10 @@ section Countable
 
 variable [Countable α]
 
-/-- Auxiliary definition for `ProbabilityTheory.Kernel.condKernel`.
-A conditional kernel for `κ : Kernel α (β × Ω)` where `α` is countable and `Ω` is standard Borel. -/
-noncomputable
-def condKernelCountable (κ : Kernel α (β × Ω)) [IsFiniteKernel κ] : Kernel (α × β) Ω where
-  toFun p := (κ p.1).condKernel p.2
-  measurable' := by
-    change Measurable ((fun q : β × α ↦ (κ q.2).condKernel q.1) ∘ Prod.swap)
-    refine (measurable_from_prod_countable' (fun a ↦ ?_) ?_).comp measurable_swap
-    · exact (κ a).condKernel.measurable
-    · intro y y' x hy'
-      have : κ y' = κ y := by
-        ext s hs
-        exact mem_of_mem_measurableAtom hy'
-          (Kernel.measurable_coe κ hs (measurableSet_singleton (κ y s))) rfl
-      simp [this]
-
-lemma condKernelCountable_apply (κ : Kernel α (β × Ω)) [IsFiniteKernel κ] (p : α × β) :
-    condKernelCountable κ p = (κ p.1).condKernel p.2 := rfl
-
-instance instIsMarkovKernelCondKernelCountable (κ : Kernel α (β × Ω)) [IsFiniteKernel κ] :
-    IsMarkovKernel (condKernelCountable κ) :=
-  ⟨fun p ↦ (Measure.instIsMarkovKernelCondKernel (κ p.1)).isProbabilityMeasure p.2⟩
-
+@[deprecated disintegrate (since := "2024-07-24")]
 lemma compProd_fst_condKernelCountable (κ : Kernel α (β × Ω)) [IsFiniteKernel κ] :
-    fst κ ⊗ₖ condKernelCountable κ = κ := by
-  ext a s hs
-  have h := (κ a).compProd_fst_condKernel
-  conv_rhs => rw [← h]
-  simp_rw [compProd_apply _ _ _ hs, condKernelCountable_apply, Measure.compProd_apply hs]
-  congr
+    fst κ ⊗ₖ condKernelCountable (fun a ↦ (κ a).condKernel)
+      (fun x y h ↦ by simp [apply_congr_of_mem_measurableAtom _ h]) = κ := disintegrate _ _
 
 end Countable
 
@@ -478,7 +438,9 @@ noncomputable
 irreducible_def condKernel [h : CountableOrCountablyGenerated α β]
     (κ : Kernel α (β × Ω)) [IsFiniteKernel κ] :
     Kernel (α × β) Ω :=
-  if hα : Countable α then condKernelCountable κ
+  if hα : Countable α then
+    condKernelCountable (fun a ↦ (κ a).condKernel)
+      fun x y h ↦ by simp [apply_congr_of_mem_measurableAtom _ h]
   else letI := h.countableOrCountablyGenerated.resolve_left hα; condKernelBorel κ
 
 /-- `condKernel κ` is a Markov kernel. -/
@@ -495,7 +457,7 @@ lemma compProd_fst_condKernel [hαβ : CountableOrCountablyGenerated α β]
     fst κ ⊗ₖ condKernel κ = κ := by
   rw [condKernel_def]
   split_ifs with h
-  · exact compProd_fst_condKernelCountable κ
+  · exact κ.disintegrate _
   · have := hαβ.countableOrCountablyGenerated.resolve_left h
     exact compProd_fst_condKernelBorel κ
 

--- a/Mathlib/Probability/Kernel/Disintegration/StandardBorel.lean
+++ b/Mathlib/Probability/Kernel/Disintegration/StandardBorel.lean
@@ -458,12 +458,7 @@ instance instIsMarkovKernelCondKernel : IsMarkovKernel (condKernel κ) := by
   split_ifs <;> infer_instance
 
 instance condKernel.instIsCondKernel : κ.IsCondKernel κ.condKernel where
-  disintegrate := by
-    rw [condKernel_def]
-    split_ifs with hα
-    · exact κ.disintegrate _
-    · have := h.countableOrCountablyGenerated.resolve_left hα
-      exact disintegrate _ _
+  disintegrate := by rw [condKernel_def]; split_ifs with hα <;> exact disintegrate _ _
 
 /-- **Disintegration** of finite kernels.
 The composition-product of `fst κ` and `condKernel κ` is equal to `κ`. -/

--- a/Mathlib/Probability/Kernel/Disintegration/StandardBorel.lean
+++ b/Mathlib/Probability/Kernel/Disintegration/StandardBorel.lean
@@ -400,7 +400,7 @@ lemma _root_.MeasureTheory.Measure.compProd_fst_condKernel
 
 set_option linter.unusedVariables false in
 /-- Auxiliary lemma for `condKernel_apply_of_ne_zero`. -/
-@[deprecated Measure.IsCondKernel.apply_of_ne_zero (since := "2024-07-24")]
+@[deprecated Measure.IsCondKernel.apply_of_ne_zero (since := "2024-07-24"), nolint unusedArguments]
 lemma _root_.MeasureTheory.Measure.condKernel_apply_of_ne_zero_of_measurableSet
     [MeasurableSingletonClass α] {x : α} (hx : ρ.fst {x} ≠ 0) {s : Set Ω} (hs : MeasurableSet s) :
     ρ.condKernel x s = (ρ.fst {x})⁻¹ * ρ ({x} ×ˢ s) :=

--- a/Mathlib/Probability/Kernel/Disintegration/Unique.lean
+++ b/Mathlib/Probability/Kernel/Disintegration/Unique.lean
@@ -146,7 +146,7 @@ is equal to the conditional kernel of the measure `κ a` applied to `b`. -/
 lemma Kernel.condKernel_apply_eq_condKernel [CountableOrCountablyGenerated α β]
     (κ : Kernel α (β × Ω)) [IsFiniteKernel κ] (a : α) :
     (fun b ↦ Kernel.condKernel κ (a, b)) =ᵐ[Kernel.fst κ a] (κ a).condKernel :=
-  Kernel.apply_eq_measure_condKernel_of_compProd_eq (compProd_fst_condKernel κ) a
+  Kernel.apply_eq_measure_condKernel_of_compProd_eq (κ.disintegrate _) a
 
 lemma condKernel_const [CountableOrCountablyGenerated α β] (ρ : Measure (β × Ω)) [IsFiniteMeasure ρ]
     (a : α) :

--- a/Mathlib/Probability/Kernel/Disintegration/Unique.lean
+++ b/Mathlib/Probability/Kernel/Disintegration/Unique.lean
@@ -115,7 +115,7 @@ theorem eq_condKernel_of_measure_eq_compProd (κ : Kernel α Ω) [IsFiniteKernel
     filter_upwards [heq] with x hx s hs
     rw [← hx, Kernel.map_apply, Measure.map_apply hf.measurable hs]
   ext s hs
-  conv_lhs => rw [← ρ.compProd_fst_condKernel]
+  conv_lhs => rw [← ρ.disintegrate ρ.condKernel]
   rw [Measure.compProd_apply hs, Measure.map_apply (measurable_id.prod_map hf.measurable) hs,
     Measure.compProd_apply]
   · congr with a

--- a/Mathlib/Probability/Kernel/MeasureCompProd.lean
+++ b/Mathlib/Probability/Kernel/MeasureCompProd.lean
@@ -40,6 +40,16 @@ def compProd (μ : Measure α) (κ : Kernel α β) : Measure (α × β) :=
 @[inherit_doc]
 scoped[ProbabilityTheory] infixl:100 " ⊗ₘ " => MeasureTheory.Measure.compProd
 
+lemma compProd_of_not_sfinite (μ : Measure α) (κ : Kernel α β) (h : ¬ SFinite μ) :
+    μ ⊗ₘ κ = 0 := by
+  rw [compProd, Kernel.compProd_of_not_isSFiniteKernel_left, Kernel.zero_apply]
+  rwa [Kernel.isSFiniteKernel_const]
+
+lemma compProd_of_not_isSFiniteKernel (μ : Measure α) (κ : Kernel α β) (h : ¬ IsSFiniteKernel κ) :
+    μ ⊗ₘ κ = 0 := by
+  rw [compProd, Kernel.compProd_of_not_isSFiniteKernel_right, Kernel.zero_apply]
+  rwa [Kernel.isSFiniteKernel_prodMkLeft_unit]
+
 @[simp] lemma compProd_zero_left (κ : Kernel α β) : (0 : Measure α) ⊗ₘ κ = 0 := by simp [compProd]
 @[simp] lemma compProd_zero_right (μ : Measure α) : μ ⊗ₘ (0 : Kernel α β) = 0 := by simp [compProd]
 


### PR DESCRIPTION
Sometimes conditional kernels exist "by chance" and the existing `Measure.condKernel` and `Kernel.condKernel` definitions fail to capture this. This PR extracts the disintegration property of conditional kernels into two Prop-valued typeclasses `Measure.IsCondKernel` and `Kernel.IsCondKernel`.

[Zulip](https://leanprover.zulipchat.com/#narrow/stream/287929-mathlib4/topic/github.20permission/near/453644387)

Co-authored-by: Kin Yau James Wong <kyjwong0501@gmail.com>

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <kyjwong0501@gmail.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->
- [x] depends on: #15103

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
