### PR TITLE
[Merged by Bors] - refactor: Make `circle` a type `Circle`

### DIFF
--- a/Mathlib/Analysis/Complex/Circle.lean
+++ b/Mathlib/Analysis/Complex/Circle.lean
@@ -38,105 +38,142 @@ open Complex Metric
 
 open ComplexConjugate
 
-/-- The unit circle in `ℂ`, here given the structure of a submonoid of `ℂ`. -/
+/-- The unit circle in `ℂ`, here given the structure of a submonoid of `ℂ`.
+
+Please use `Circle` when referring to the circle as a type. -/
+@[deprecated (since := "2024-07-24")]
 def circle : Submonoid ℂ :=
   Submonoid.unitSphere ℂ
 
-@[simp]
+set_option linter.deprecated false in
+@[deprecated (since := "2024-07-24")]
 theorem mem_circle_iff_abs {z : ℂ} : z ∈ circle ↔ abs z = 1 :=
   mem_sphere_zero_iff_norm
 
-theorem circle_def : ↑circle = { z : ℂ | abs z = 1 } :=
-  Set.ext fun _ => mem_circle_iff_abs
+set_option linter.deprecated false in
+@[deprecated (since := "2024-07-24")]
+theorem mem_circle_iff_normSq {z : ℂ} : z ∈ circle ↔ normSq z = 1 := by
+  simp [Complex.abs, mem_circle_iff_abs]
 
-@[simp]
-theorem abs_coe_circle (z : circle) : abs z = 1 :=
-  mem_circle_iff_abs.mp z.2
+/-- The unit circle in `ℂ`. -/
+def Circle : Type := Submonoid.unitSphere ℂ
+deriving TopologicalSpace
 
-theorem mem_circle_iff_normSq {z : ℂ} : z ∈ circle ↔ normSq z = 1 := by simp [Complex.abs]
+namespace Circle
 
-@[simp]
-theorem normSq_eq_of_mem_circle (z : circle) : normSq z = 1 := by simp [normSq_eq_abs]
+instance instCoeOut : CoeOut Circle ℂ := subtypeCoe
 
-theorem ne_zero_of_mem_circle (z : circle) : (z : ℂ) ≠ 0 :=
-  ne_zero_of_mem_unit_sphere z
+instance instCommGroup : CommGroup Circle := Metric.sphere.commGroup
+instance instMetricSpace : MetricSpace Circle := Subtype.metricSpace
 
-instance commGroup : CommGroup circle :=
-  Metric.sphere.commGroup
+@[simp] lemma abs_coe (z : Circle) : abs z = 1 := mem_sphere_zero_iff_norm.1 z.2
+@[simp] lemma normSq_coe (z : Circle) : normSq z = 1 := by simp [normSq_eq_abs]
+@[simp] lemma coe_ne_zero (z : Circle) : (z : ℂ) ≠ 0 := ne_zero_of_mem_unit_sphere z
+@[simp, norm_cast] lemma coe_one : ↑(1 : Circle) = (1 : ℂ) := rfl
+@[simp, norm_cast] lemma coe_mul (z w : Circle) : ↑(z * w) = (z : ℂ) * w := rfl
+@[simp, norm_cast] lemma coe_inv (z : Circle) : ↑z⁻¹ = (z : ℂ)⁻¹ := rfl
+lemma coe_inv_eq_conj (z : Circle) : ↑z⁻¹ = conj (z : ℂ) := by
+  rw [coe_inv, inv_def, normSq_coe, inv_one, ofReal_one, mul_one]
 
-@[simp]
-theorem coe_inv_circle (z : circle) : ↑z⁻¹ = (z : ℂ)⁻¹ :=
-  rfl
+@[simp, norm_cast] lemma coe_div (z w : Circle) : ↑(z / w) = (z : ℂ) / w := rfl
 
-theorem coe_inv_circle_eq_conj (z : circle) : ↑z⁻¹ = conj (z : ℂ) := by
-  rw [coe_inv_circle, inv_def, normSq_eq_of_mem_circle, inv_one, ofReal_one, mul_one]
+/-- The coercion `Circle → ℂ` as a monoid homomorphism. -/
+@[simps]
+def coeHom : Circle →* ℂ where
+  toFun := (↑)
+  map_one' := coe_one
+  map_mul' := coe_mul
 
-@[simp]
-theorem coe_div_circle (z w : circle) : ↑(z / w) = (z : ℂ) / w :=
-  circle.subtype.map_div z w
+@[deprecated (since := "2024-07-24")] alias _root_.abs_coe_circle := abs_coe
+@[deprecated (since := "2024-07-24")] alias _root_.normSq_eq_of_mem_circle := normSq_coe
+@[deprecated (since := "2024-07-24")] alias _root_.ne_zero_of_mem_circle := coe_ne_zero
+@[deprecated (since := "2024-07-24")] alias _root_.coe_inv_circle := coe_inv
+@[deprecated (since := "2024-07-24")] alias _root_.coe_inv_circle_eq_conj := coe_inv_eq_conj
+@[deprecated (since := "2024-07-24")] alias _root_.coe_div_circle := coe_div
 
 /-- The elements of the circle embed into the units. -/
-def circle.toUnits : circle →* Units ℂ :=
-  unitSphereToUnits ℂ
+def toUnits : Circle →* Units ℂ := unitSphereToUnits ℂ
 
--- written manually because `@[simps]` was slow and generated the wrong lemma
-@[simp]
-theorem circle.toUnits_apply (z : circle) :
-    circle.toUnits z = Units.mk0 ↑z (ne_zero_of_mem_circle z) :=
-  rfl
+-- written manually because `@[simps]` generated the wrong lemma
+@[simp] lemma toUnits_apply (z : Circle) : toUnits z = Units.mk0 ↑z z.coe_ne_zero := rfl
 
-instance : CompactSpace circle :=
-  Metric.sphere.compactSpace _ _
-
-instance : TopologicalGroup circle :=
-  Metric.sphere.topologicalGroup
-
-instance : UniformGroup circle := by
-  convert topologicalGroup_is_uniform_of_compactSpace circle
+instance : CompactSpace Circle := Metric.sphere.compactSpace _ _
+instance : TopologicalGroup Circle := Metric.sphere.topologicalGroup
+instance instUniformSpace : UniformSpace Circle := instUniformSpaceSubtype
+instance : UniformGroup Circle := by
+  convert topologicalGroup_is_uniform_of_compactSpace Circle
   exact unique_uniformity_of_compact rfl rfl
 
 /-- If `z` is a nonzero complex number, then `conj z / z` belongs to the unit circle. -/
 @[simps]
-def circle.ofConjDivSelf (z : ℂ) (hz : z ≠ 0) : circle :=
-  ⟨conj z / z,
-    mem_circle_iff_abs.2 <| by rw [map_div₀, abs_conj, div_self]; exact Complex.abs.ne_zero hz⟩
+def ofConjDivSelf (z : ℂ) (hz : z ≠ 0) : Circle where
+  val := conj z / z
+  property := mem_sphere_zero_iff_norm.2 <| by
+    rw [norm_div, RCLike.norm_conj, div_self]; exact Complex.abs.ne_zero hz
 
 /-- The map `fun t => exp (t * I)` from `ℝ` to the unit circle in `ℂ`. -/
-def expMapCircle : C(ℝ, circle) where
-  toFun t := ⟨exp (t * I), by simp [exp_mul_I, abs_cos_add_sin_mul_I]⟩
+def exp : C(ℝ, Circle) where
+  toFun t := ⟨(t * I).exp, by simp [Submonoid.unitSphere, exp_mul_I, abs_cos_add_sin_mul_I]⟩
+  continuous_toFun := Continuous.subtype_mk (by fun_prop)
+    (by simp [Submonoid.unitSphere, exp_mul_I, abs_cos_add_sin_mul_I])
 
 @[simp]
-theorem expMapCircle_apply (t : ℝ) : ↑(expMapCircle t) = Complex.exp (t * Complex.I) :=
-  rfl
+theorem exp_apply (t : ℝ) : ↑(exp t) = Complex.exp (t * Complex.I) := rfl
 
 @[simp]
-theorem expMapCircle_zero : expMapCircle 0 = 1 :=
+theorem exp_zero : exp 0 = 1 :=
+  Subtype.ext <| by rw [exp_apply, ofReal_zero, zero_mul, Complex.exp_zero, coe_one]
+
+@[simp]
+theorem exp_add (x y : ℝ) : exp (x + y) = exp x * exp y :=
   Subtype.ext <| by
-    rw [expMapCircle_apply, ofReal_zero, zero_mul, exp_zero, Submonoid.coe_one]
-
-@[simp]
-theorem expMapCircle_add (x y : ℝ) : expMapCircle (x + y) = expMapCircle x * expMapCircle y :=
-  Subtype.ext <| by
-    simp only [expMapCircle_apply, Submonoid.coe_mul, ofReal_add, add_mul, Complex.exp_add]
+    simp only [exp_apply, Submonoid.coe_mul, ofReal_add, add_mul, Complex.exp_add, coe_mul]
 
 /-- The map `fun t => exp (t * I)` from `ℝ` to the unit circle in `ℂ`,
 considered as a homomorphism of groups. -/
 @[simps]
-def expMapCircleHom : ℝ →+ Additive circle where
-  toFun := Additive.ofMul ∘ expMapCircle
-  map_zero' := expMapCircle_zero
-  map_add' := expMapCircle_add
+def expHom : ℝ →+ Additive Circle where
+  toFun := Additive.ofMul ∘ exp
+  map_zero' := exp_zero
+  map_add' := exp_add
+
+@[simp] lemma exp_sub (x y : ℝ) : exp (x - y) = exp x / exp y := expHom.map_sub x y
+@[simp] lemma exp_neg (x : ℝ) : exp (-x) = (exp x)⁻¹ := expHom.map_neg x
+
+variable {α β M : Type*}
+
+instance instSMul [SMul ℂ α] : SMul Circle α := Submonoid.smul _
+
+instance instSMulCommClass_left [SMul ℂ β] [SMul α β] [SMulCommClass ℂ α β] :
+    SMulCommClass Circle α β := Submonoid.smulCommClass_left _
+
+instance instSMulCommClass_right [SMul ℂ β] [SMul α β] [SMulCommClass α ℂ β] :
+    SMulCommClass α Circle β := Submonoid.smulCommClass_right _
+
+instance instIsScalarTower [SMul ℂ α] [SMul ℂ β] [SMul α β] [IsScalarTower ℂ α β] :
+    IsScalarTower Circle α β := Submonoid.isScalarTower _
+
+instance instMulAction [MulAction ℂ α] : MulAction Circle α := Submonoid.mulAction _
+
+instance instDistribMulAction [AddMonoid M] [DistribMulAction ℂ M] :
+    DistribMulAction Circle M := Submonoid.distribMulAction _
+
+lemma smul_def [SMul ℂ α] (z : Circle) (a : α) : z • a = (z : ℂ) • a := rfl
+
+instance instContinuousSMul [TopologicalSpace α] [MulAction ℂ α] [ContinuousSMul ℂ α] :
+    ContinuousSMul Circle α := Submonoid.continuousSMul
 
 @[simp]
-theorem expMapCircle_sub (x y : ℝ) : expMapCircle (x - y) = expMapCircle x / expMapCircle y :=
-  expMapCircleHom.map_sub x y
-
-@[simp]
-theorem expMapCircle_neg (x : ℝ) : expMapCircle (-x) = (expMapCircle x)⁻¹ :=
-  expMapCircleHom.map_neg x
-
-@[simp]
-lemma norm_circle_smul {E : Type*} [SeminormedAddCommGroup E] [NormedSpace ℂ E]
-    (u : circle) (v : E) :
+protected lemma norm_smul {E : Type*} [SeminormedAddCommGroup E] [NormedSpace ℂ E]
+    (u : Circle) (v : E) :
     ‖u • v‖ = ‖v‖ := by
   rw [Submonoid.smul_def, norm_smul, norm_eq_of_mem_sphere, one_mul]
+
+@[deprecated (since := "2024-07-24")] noncomputable alias _root_.expMapCircle := exp
+@[deprecated (since := "2024-07-24")] noncomputable alias _root_.expMapCircle_apply := exp_apply
+@[deprecated (since := "2024-07-24")] noncomputable alias _root_.expMapCircle_zero := exp_zero
+@[deprecated (since := "2024-07-24")] noncomputable alias _root_.expMapCircle_sub := exp_sub
+@[deprecated (since := "2024-07-24")] noncomputable alias _root_.norm_circle_smul :=
+  Circle.norm_smul
+
+end Circle

--- a/Mathlib/Analysis/Complex/Isometry.lean
+++ b/Mathlib/Analysis/Complex/Isometry.lean
@@ -36,27 +36,27 @@ local notation "|" x "|" => Complex.abs x
 
 /-- An element of the unit circle defines a `LinearIsometryEquiv` from `ℂ` to itself, by
 rotation. -/
-def rotation : circle →* ℂ ≃ₗᵢ[ℝ] ℂ where
+def rotation : Circle →* ℂ ≃ₗᵢ[ℝ] ℂ where
   toFun a :=
     { DistribMulAction.toLinearEquiv ℝ ℂ a with
-      norm_map' := fun x => show |a * x| = |x| by rw [map_mul, abs_coe_circle, one_mul] }
-  map_one' := LinearIsometryEquiv.ext <| one_smul circle
+      norm_map' := fun x => show |a * x| = |x| by rw [map_mul, Circle.abs_coe, one_mul] }
+  map_one' := LinearIsometryEquiv.ext <| by simp
   map_mul' a b := LinearIsometryEquiv.ext <| mul_smul a b
 
 @[simp]
-theorem rotation_apply (a : circle) (z : ℂ) : rotation a z = a * z :=
+theorem rotation_apply (a : Circle) (z : ℂ) : rotation a z = a * z :=
   rfl
 
 @[simp]
-theorem rotation_symm (a : circle) : (rotation a).symm = rotation a⁻¹ :=
+theorem rotation_symm (a : Circle) : (rotation a).symm = rotation a⁻¹ :=
   LinearIsometryEquiv.ext fun _ => rfl
 
 @[simp]
-theorem rotation_trans (a b : circle) : (rotation a).trans (rotation b) = rotation (b * a) := by
+theorem rotation_trans (a b : Circle) : (rotation a).trans (rotation b) = rotation (b * a) := by
   ext1
   simp
 
-theorem rotation_ne_conjLIE (a : circle) : rotation a ≠ conjLIE := by
+theorem rotation_ne_conjLIE (a : Circle) : rotation a ≠ conjLIE := by
   intro h
   have h1 : rotation a 1 = conj 1 := LinearIsometryEquiv.congr_fun h 1
   have hI : rotation a I = conj I := LinearIsometryEquiv.congr_fun h I
@@ -67,11 +67,11 @@ theorem rotation_ne_conjLIE (a : circle) : rotation a ≠ conjLIE := by
 /-- Takes an element of `ℂ ≃ₗᵢ[ℝ] ℂ` and checks if it is a rotation, returns an element of the
 unit circle. -/
 @[simps]
-def rotationOf (e : ℂ ≃ₗᵢ[ℝ] ℂ) : circle :=
-  ⟨e 1 / Complex.abs (e 1), by simp⟩
+def rotationOf (e : ℂ ≃ₗᵢ[ℝ] ℂ) : Circle :=
+  ⟨e 1 / Complex.abs (e 1), by simp [Submonoid.unitSphere, ← Complex.norm_eq_abs]⟩
 
 @[simp]
-theorem rotationOf_rotation (a : circle) : rotationOf (rotation a) = a :=
+theorem rotationOf_rotation (a : Circle) : rotationOf (rotation a) = a :=
   Subtype.ext <| by simp
 
 theorem rotation_injective : Function.Injective rotation :=
@@ -125,8 +125,8 @@ theorem linear_isometry_complex_aux {f : ℂ ≃ₗᵢ[ℝ] ℂ} (h : f 1 = 1) :
       fin_cases i <;> simp [h, h']
 
 theorem linear_isometry_complex (f : ℂ ≃ₗᵢ[ℝ] ℂ) :
-    ∃ a : circle, f = rotation a ∨ f = conjLIE.trans (rotation a) := by
-  let a : circle := ⟨f 1, by rw [mem_circle_iff_abs, ← Complex.norm_eq_abs, f.norm_map, norm_one]⟩
+    ∃ a : Circle, f = rotation a ∨ f = conjLIE.trans (rotation a) := by
+  let a : Circle := ⟨f 1, by simp [Submonoid.unitSphere, ← Complex.norm_eq_abs, f.norm_map]⟩
   use a
   have : (f.trans (rotation a).symm) 1 = 1 := by simpa using rotation_apply a⁻¹ (f 1)
   refine (linear_isometry_complex_aux this).imp (fun h₁ => ?_) fun h₂ => ?_
@@ -135,7 +135,7 @@ theorem linear_isometry_complex (f : ℂ ≃ₗᵢ[ℝ] ℂ) :
 
 /-- The matrix representation of `rotation a` is equal to the conformal matrix
 `!![re a, -im a; im a, re a]`. -/
-theorem toMatrix_rotation (a : circle) :
+theorem toMatrix_rotation (a : Circle) :
     LinearMap.toMatrix basisOneI basisOneI (rotation a).toLinearEquiv =
       Matrix.planeConformalMatrix (re a) (im a) (by simp [pow_two, ← normSq_apply]) := by
   ext i j
@@ -147,11 +147,11 @@ theorem toMatrix_rotation (a : circle) :
 
 /-- The determinant of `rotation` (as a linear map) is equal to `1`. -/
 @[simp]
-theorem det_rotation (a : circle) : LinearMap.det ((rotation a).toLinearEquiv : ℂ →ₗ[ℝ] ℂ) = 1 := by
+theorem det_rotation (a : Circle) : LinearMap.det ((rotation a).toLinearEquiv : ℂ →ₗ[ℝ] ℂ) = 1 := by
   rw [← LinearMap.det_toMatrix basisOneI, toMatrix_rotation, Matrix.det_fin_two]
   simp [← normSq_apply]
 
 /-- The determinant of `rotation` (as a linear equiv) is equal to `1`. -/
 @[simp]
-theorem linearEquiv_det_rotation (a : circle) : LinearEquiv.det (rotation a).toLinearEquiv = 1 := by
+theorem linearEquiv_det_rotation (a : Circle) : LinearEquiv.det (rotation a).toLinearEquiv = 1 := by
   rw [← Units.eq_iff, LinearEquiv.coe_det, det_rotation, Units.val_one]

--- a/Mathlib/Analysis/Complex/UnitDisc/Basic.lean
+++ b/Mathlib/Analysis/Complex/UnitDisc/Basic.lean
@@ -97,23 +97,23 @@ theorem coe_eq_zero {z : 𝔻} : (z : ℂ) = 0 ↔ z = 0 :=
 instance : Inhabited 𝔻 :=
   ⟨0⟩
 
-instance circleAction : MulAction circle 𝔻 :=
+instance circleAction : MulAction Circle 𝔻 :=
   mulActionSphereBall
 
-instance isScalarTower_circle_circle : IsScalarTower circle circle 𝔻 :=
+instance isScalarTower_circle_circle : IsScalarTower Circle Circle 𝔻 :=
   isScalarTower_sphere_sphere_ball
 
-instance isScalarTower_circle : IsScalarTower circle 𝔻 𝔻 :=
+instance isScalarTower_circle : IsScalarTower Circle 𝔻 𝔻 :=
   isScalarTower_sphere_ball_ball
 
-instance instSMulCommClass_circle : SMulCommClass circle 𝔻 𝔻 :=
+instance instSMulCommClass_circle : SMulCommClass Circle 𝔻 𝔻 :=
   instSMulCommClass_sphere_ball_ball
 
-instance instSMulCommClass_circle' : SMulCommClass 𝔻 circle 𝔻 :=
+instance instSMulCommClass_circle' : SMulCommClass 𝔻 Circle 𝔻 :=
   SMulCommClass.symm _ _ _
 
 @[simp, norm_cast]
-theorem coe_smul_circle (z : circle) (w : 𝔻) : ↑(z • w) = (z * w : ℂ) :=
+theorem coe_smul_circle (z : Circle) (w : 𝔻) : ↑(z • w) = (z * w : ℂ) :=
   rfl
 
 instance closedBallAction : MulAction (closedBall (0 : ℂ) 1) 𝔻 :=
@@ -132,10 +132,10 @@ instance instSMulCommClass_closedBall : SMulCommClass (closedBall (0 : ℂ) 1) �
 instance instSMulCommClass_closedBall' : SMulCommClass 𝔻 (closedBall (0 : ℂ) 1) 𝔻 :=
   SMulCommClass.symm _ _ _
 
-instance instSMulCommClass_circle_closedBall : SMulCommClass circle (closedBall (0 : ℂ) 1) 𝔻 :=
+instance instSMulCommClass_circle_closedBall : SMulCommClass Circle (closedBall (0 : ℂ) 1) 𝔻 :=
   instSMulCommClass_sphere_closedBall_ball
 
-instance instSMulCommClass_closedBall_circle : SMulCommClass (closedBall (0 : ℂ) 1) circle 𝔻 :=
+instance instSMulCommClass_closedBall_circle : SMulCommClass (closedBall (0 : ℂ) 1) Circle 𝔻 :=
   SMulCommClass.symm _ _ _
 
 @[simp, norm_cast]

--- a/Mathlib/Analysis/Fourier/AddCircle.lean
+++ b/Mathlib/Analysis/Fourier/AddCircle.lean
@@ -111,7 +111,7 @@ theorem fourier_apply {n : ℤ} {x : AddCircle T} : fourier n x = toCircle (n �
 theorem fourier_coe_apply {n : ℤ} {x : ℝ} :
     fourier n (x : AddCircle T) = Complex.exp (2 * π * Complex.I * n * x / T) := by
   rw [fourier_apply, ← QuotientAddGroup.mk_zsmul, toCircle, Function.Periodic.lift_coe,
-    expMapCircle_apply, Complex.ofReal_mul, Complex.ofReal_div, Complex.ofReal_mul, zsmul_eq_mul,
+    Circle.exp_apply, Complex.ofReal_mul, Complex.ofReal_div, Complex.ofReal_mul, zsmul_eq_mul,
     Complex.ofReal_mul, Complex.ofReal_intCast]
   norm_num
   congr 1; ring
@@ -145,7 +145,7 @@ theorem fourier_neg {n : ℤ} {x : AddCircle T} : fourier (-n) x = conj (fourier
   induction x using QuotientAddGroup.induction_on
   simp_rw [fourier_apply, toCircle]
   rw [← QuotientAddGroup.mk_zsmul, ← QuotientAddGroup.mk_zsmul]
-  simp_rw [Function.Periodic.lift_coe, ← coe_inv_circle_eq_conj, ← expMapCircle_neg,
+  simp_rw [Function.Periodic.lift_coe, ← Circle.coe_inv_eq_conj, ← Circle.exp_neg,
     neg_smul, mul_neg]
 
 @[simp]
@@ -154,7 +154,7 @@ theorem fourier_neg' {n : ℤ} {x : AddCircle T} : @toCircle T (-(n • x)) = co
 
 -- @[simp] -- Porting note: simp normal form is `fourier_add'`
 theorem fourier_add {m n : ℤ} {x : AddCircle T} : fourier (m+n) x = fourier m x * fourier n x := by
-  simp_rw [fourier_apply, add_zsmul, toCircle_add, coe_mul_unitSphere]
+  simp_rw [fourier_apply, add_zsmul, toCircle_add, Circle.coe_mul]
 
 @[simp]
 theorem fourier_add' {m n : ℤ} {x : AddCircle T} :
@@ -163,7 +163,7 @@ theorem fourier_add' {m n : ℤ} {x : AddCircle T} :
 
 theorem fourier_norm [Fact (0 < T)] (n : ℤ) : ‖@fourier T n‖ = 1 := by
   rw [ContinuousMap.norm_eq_iSup_norm]
-  have : ∀ x : AddCircle T, ‖fourier n x‖ = 1 := fun x => abs_coe_circle _
+  have : ∀ x : AddCircle T, ‖fourier n x‖ = 1 := fun x => Circle.abs_coe _
   simp_rw [this]
   exact @ciSup_const _ _ _ Zero.instNonempty _
 
@@ -173,7 +173,7 @@ theorem fourier_add_half_inv_index {n : ℤ} (hn : n ≠ 0) (hT : 0 < T) (x : Ad
   rw [fourier_apply, zsmul_add, ← QuotientAddGroup.mk_zsmul, toCircle_add, coe_mul_unitSphere]
   have : (n : ℂ) ≠ 0 := by simpa using hn
   have : (@toCircle T (n • (T / 2 / n) : ℝ) : ℂ) = -1 := by
-    rw [zsmul_eq_mul, toCircle, Function.Periodic.lift_coe, expMapCircle_apply]
+    rw [zsmul_eq_mul, toCircle, Function.Periodic.lift_coe, Circle.exp_apply]
     replace hT := Complex.ofReal_ne_zero.mpr hT.ne'
     convert Complex.exp_pi_mul_I using 3
     field_simp; ring

--- a/Mathlib/Analysis/Fourier/FourierTransform.lean
+++ b/Mathlib/Analysis/Fourier/FourierTransform.lean
@@ -21,7 +21,7 @@ We set up the Fourier transform for complex-valued functions on finite-dimension
 In namespace `VectorFourier`, we define the Fourier integral in the following context:
 * `𝕜` is a commutative ring.
 * `V` and `W` are `𝕜`-modules.
-* `e` is a unitary additive character of `𝕜`, i.e. an `AddChar 𝕜 circle`.
+* `e` is a unitary additive character of `𝕜`, i.e. an `AddChar 𝕜 Circle`.
 * `μ` is a measure on `V`.
 * `L` is a `𝕜`-bilinear form `V × W → 𝕜`.
 * `E` is a complete normed `ℂ`-vector space.
@@ -55,7 +55,7 @@ Fourier transform of an integrable function is continuous (under mild assumption
 
 noncomputable section
 
-local notation "𝕊" => circle
+local notation "𝕊" => Circle
 
 open MeasureTheory Filter
 
@@ -93,7 +93,7 @@ theorem norm_fourierIntegral_le_integral_norm (e : AddChar 𝕜 𝕊) (μ : Meas
     (L : V →ₗ[𝕜] W →ₗ[𝕜] 𝕜) (f : V → E) (w : W) :
     ‖fourierIntegral e μ L f w‖ ≤ ∫ v : V, ‖f v‖ ∂μ := by
   refine (norm_integral_le_integral_norm _).trans (le_of_eq ?_)
-  simp_rw [norm_circle_smul]
+  simp_rw [Circle.norm_smul]
 
 /-- The Fourier integral converts right-translation into scalar multiplication by a phase factor. -/
 theorem fourierIntegral_comp_add_right [MeasurableAdd V] (e : AddChar 𝕜 𝕊) (μ : Measure V)
@@ -101,11 +101,11 @@ theorem fourierIntegral_comp_add_right [MeasurableAdd V] (e : AddChar 𝕜 𝕊)
     fourierIntegral e μ L (f ∘ fun v ↦ v + v₀) =
       fun w ↦ e (L v₀ w) • fourierIntegral e μ L f w := by
   ext1 w
-  dsimp only [fourierIntegral, Function.comp_apply, Submonoid.smul_def]
+  dsimp only [fourierIntegral, Function.comp_apply, Circle.smul_def]
   conv in L _ => rw [← add_sub_cancel_right v v₀]
   rw [integral_add_right_eq_self fun v : V ↦ (e (-L (v - v₀) w) : ℂ) • f v, ← integral_smul]
   congr 1 with v
-  rw [← smul_assoc, smul_eq_mul, ← Submonoid.coe_mul, ← e.map_add_eq_mul, ← LinearMap.neg_apply,
+  rw [← smul_assoc, smul_eq_mul, ← Circle.coe_mul, ← e.map_add_eq_mul, ← LinearMap.neg_apply,
     ← sub_eq_add_neg, ← LinearMap.sub_apply, LinearMap.map_sub, neg_sub]
 
 end Defs
@@ -131,7 +131,7 @@ theorem fourierIntegral_convergent_iff (he : Continuous e)
       Integrable (fun v : V ↦ e (-L v x) • g v) μ := by
     have c : Continuous fun v ↦ e (-L v x) :=
       he.comp (hL.comp (continuous_prod_mk.mpr ⟨continuous_id, continuous_const⟩)).neg
-    simp_rw [← integrable_norm_iff (c.aestronglyMeasurable.smul hg.1), norm_circle_smul]
+    simp_rw [← integrable_norm_iff (c.aestronglyMeasurable.smul hg.1), Circle.norm_smul]
     exact hg.norm
   -- then use it for both directions
   refine ⟨fun hf ↦ ?_, fun hf ↦ aux hf w⟩
@@ -159,7 +159,7 @@ theorem fourierIntegral_continuous [FirstCountableTopology W] (he : Continuous e
     Continuous (fourierIntegral e μ L f) := by
   apply continuous_of_dominated
   · exact fun w ↦ ((fourierIntegral_convergent_iff he hL w).2 hf).1
-  · exact fun w ↦ ae_of_all _ fun v ↦ le_of_eq (norm_circle_smul _ _)
+  · exact fun w ↦ ae_of_all _ fun v ↦ le_of_eq (Circle.norm_smul _ _)
   · exact hf.norm
   · refine ae_of_all _ fun v ↦ (he.comp ?_).smul continuous_const
     exact (hL.comp (continuous_prod_mk.mpr ⟨continuous_const, continuous_id⟩)).neg
@@ -206,7 +206,7 @@ theorem integral_bilin_fourierIntegral_eq_flip
       apply B.comp_aestronglyMeasurable A' -- `exact` works, but `apply` is 10x faster!
     · filter_upwards with ⟨ξ, x⟩
       rw [Function.uncurry_apply_pair, Submonoid.smul_def, (M.flip (g ξ)).map_smul,
-        ← Submonoid.smul_def, norm_circle_smul, ContinuousLinearMap.flip_apply,
+        ← Submonoid.smul_def, Circle.norm_smul, ContinuousLinearMap.flip_apply,
         norm_mul, norm_norm M, norm_mul, norm_norm, norm_norm, mul_comm (‖g _‖), ← mul_assoc]
       exact M.le_opNorm₂ (f x) (g ξ)
   _ = ∫ x, (∫ ξ, M (f x) (e (-L.flip ξ x) • g ξ) ∂ν) ∂μ := by
@@ -307,9 +307,9 @@ namespace Real
 
 /-- The standard additive character of `ℝ`, given by `fun x ↦ exp (2 * π * x * I)`. -/
 def fourierChar : AddChar ℝ 𝕊 where
-  toFun z := expMapCircle (2 * π * z)
-  map_zero_eq_one' := by simp only; rw [mul_zero, expMapCircle_zero]
-  map_add_eq_mul' x y := by simp only; rw [mul_add, expMapCircle_add]
+  toFun z := .exp (2 * π * z)
+  map_zero_eq_one' := by simp only; rw [mul_zero, Circle.exp_zero]
+  map_add_eq_mul' x y := by simp only; rw [mul_add, Circle.exp_add]
 
 @[inherit_doc] scoped[FourierTransform] notation "𝐞" => Real.fourierChar
 
@@ -319,8 +319,7 @@ theorem fourierChar_apply (x : ℝ) : 𝐞 x = Complex.exp (↑(2 * π * x) * Co
   rfl
 
 @[continuity]
-theorem continuous_fourierChar : Continuous 𝐞 :=
-  (map_continuous expMapCircle).comp (continuous_mul_left _)
+theorem continuous_fourierChar : Continuous 𝐞 := Circle.exp.continuous.comp (continuous_mul_left _)
 
 variable {E : Type*} [NormedAddCommGroup E] [NormedSpace ℂ E]
 
@@ -329,7 +328,7 @@ theorem vector_fourierIntegral_eq_integral_exp_smul {V : Type*} [AddCommGroup V]
     (μ : Measure V) (f : V → E) (w : W) :
     VectorFourier.fourierIntegral fourierChar μ L f w =
       ∫ v : V, Complex.exp (↑(-2 * π * L v w) * Complex.I) • f v ∂μ := by
-  simp_rw [VectorFourier.fourierIntegral, Submonoid.smul_def, Real.fourierChar_apply, mul_neg,
+  simp_rw [VectorFourier.fourierIntegral, Circle.smul_def, Real.fourierChar_apply, mul_neg,
     neg_mul]
 
 /-- The Fourier integral is well defined iff the function is integrable. Version with a general
@@ -397,7 +396,7 @@ lemma fourierIntegral_eq (f : V → E) (w : V) :
 
 lemma fourierIntegral_eq' (f : V → E) (w : V) :
     𝓕 f w = ∫ v, Complex.exp ((↑(-2 * π * ⟪v, w⟫) * Complex.I)) • f v := by
-  simp_rw [fourierIntegral_eq, Submonoid.smul_def, Real.fourierChar_apply, mul_neg, neg_mul]
+  simp_rw [fourierIntegral_eq, Circle.smul_def, Real.fourierChar_apply, mul_neg, neg_mul]
 
 lemma fourierIntegralInv_eq (f : V → E) (w : V) :
     𝓕⁻ f w = ∫ v, 𝐞 ⟪v, w⟫ • f v := by
@@ -405,7 +404,7 @@ lemma fourierIntegralInv_eq (f : V → E) (w : V) :
 
 lemma fourierIntegralInv_eq' (f : V → E) (w : V) :
     𝓕⁻ f w = ∫ v, Complex.exp ((↑(2 * π * ⟪v, w⟫) * Complex.I)) • f v := by
-  simp_rw [fourierIntegralInv_eq, Submonoid.smul_def, Real.fourierChar_apply]
+  simp_rw [fourierIntegralInv_eq, Circle.smul_def, Real.fourierChar_apply]
 
 lemma fourierIntegral_comp_linearIsometry (A : W ≃ₗᵢ[ℝ] V) (f : V → E) (w : W) :
     𝓕 (f ∘ A) w = (𝓕 f) (A w) := by
@@ -440,7 +439,7 @@ theorem fourierIntegral_real_eq (f : ℝ → E) (w : ℝ) :
 
 theorem fourierIntegral_real_eq_integral_exp_smul (f : ℝ → E) (w : ℝ) :
     𝓕 f w = ∫ v : ℝ, Complex.exp (↑(-2 * π * v * w) * Complex.I) • f v := by
-  simp_rw [fourierIntegral_real_eq, Submonoid.smul_def, Real.fourierChar_apply, mul_neg, neg_mul,
+  simp_rw [fourierIntegral_real_eq, Circle.smul_def, Real.fourierChar_apply, mul_neg, neg_mul,
     mul_assoc]
 
 @[deprecated (since := "2024-02-21")]

--- a/Mathlib/Analysis/Fourier/FourierTransformDeriv.lean
+++ b/Mathlib/Analysis/Fourier/FourierTransformDeriv.lean
@@ -225,7 +225,7 @@ theorem hasFDerivAt_fourierIntegral
     exact (L.continuous₂.comp (Continuous.Prod.mk_left w)).neg
   have h4 : (∀ᵐ v ∂μ, ∀ (w' : W), w' ∈ Metric.ball w 1 → ‖F' w' v‖ ≤ B v) := by
     filter_upwards with v w' _
-    rw [norm_circle_smul _ (fourierSMulRight L f v)]
+    rw [Circle.norm_smul _ (fourierSMulRight L f v)]
     exact norm_fourierSMulRight_le L f v
   have h5 : Integrable B μ := by simpa only [← mul_assoc] using hf'.const_mul (2 * π * ‖L‖)
   have h6 : ∀ᵐ v ∂μ, ∀ w', w' ∈ Metric.ball w 1 → HasFDerivAt (fun x ↦ F x v) (F' w' v) w' :=

--- a/Mathlib/Analysis/Fourier/PoissonSummation.lean
+++ b/Mathlib/Analysis/Fourier/PoissonSummation.lean
@@ -58,7 +58,7 @@ theorem Real.fourierCoeff_tsum_comp_add {f : C(ℝ, ℂ)}
   -- block, but I think it's more legible this way. We start with preliminaries about the integrand.
   let e : C(ℝ, ℂ) := (fourier (-m)).comp ⟨((↑) : ℝ → UnitAddCircle), continuous_quotient_mk'⟩
   have neK : ∀ (K : Compacts ℝ) (g : C(ℝ, ℂ)), ‖(e * g).restrict K‖ = ‖g.restrict K‖ := by
-    have (x : ℝ) : ‖e x‖ = 1 := abs_coe_circle (AddCircle.toCircle (-m • x))
+    have (x : ℝ) : ‖e x‖ = 1 := (AddCircle.toCircle (-m • x)).abs_coe
     intro K g
     simp_rw [norm_eq_iSup_norm, restrict_apply, mul_apply, norm_mul, this, one_mul]
   have eadd : ∀ (n : ℤ), e.comp (ContinuousMap.addRight n) = e := by

--- a/Mathlib/Analysis/Fourier/RiemannLebesgueLemma.lean
+++ b/Mathlib/Analysis/Fourier/RiemannLebesgueLemma.lean
@@ -69,7 +69,7 @@ theorem fourierIntegral_half_period_translate {w : V} (hw : w ≠ 0) :
     (fun v : V => 𝐞 (-⟪v, w⟫) • f (v + i w)) =
       fun v : V => (fun x : V => -(𝐞 (-⟪x, w⟫) • f x)) (v + i w) := by
     ext1 v
-    simp_rw [inner_add_left, hiw, Submonoid.smul_def, Real.fourierChar_apply, neg_add, mul_add,
+    simp_rw [inner_add_left, hiw, Circle.smul_def, Real.fourierChar_apply, neg_add, mul_add,
       ofReal_add, add_mul, exp_add]
     have : 2 * π * -(1 / 2) = -π := by field_simp; ring
     rw [this, ofReal_neg, neg_mul, exp_neg, exp_pi_mul_I, inv_neg, inv_one, mul_neg_one, neg_smul,
@@ -142,7 +142,7 @@ theorem tendsto_integral_exp_inner_smul_cocompact_of_continuous_compact_support 
       (hf1.integrable_of_hasCompactSupport hf2),
     norm_smul, this, inv_mul_eq_div, div_lt_iff' two_pos]
   refine lt_of_le_of_lt (norm_integral_le_integral_norm _) ?_
-  simp_rw [norm_circle_smul]
+  simp_rw [Circle.norm_smul]
   --* Show integral can be taken over A only.
   have int_A : ∫ v : V, ‖f v - f (v + i w)‖ = ∫ v in A, ‖f v - f (v + i w)‖ := by
     refine (setIntegral_eq_integral_of_forall_compl_eq_zero fun v hv => ?_).symm

--- a/Mathlib/Analysis/Normed/Field/UnitBall.lean
+++ b/Mathlib/Analysis/Normed/Field/UnitBall.lean
@@ -95,6 +95,7 @@ theorem coe_pow_unitClosedBall [SeminormedRing 𝕜] [NormOneClass 𝕜] (x : cl
   rfl
 
 /-- Unit sphere in a normed division ring as a bundled `Submonoid`. -/
+@[simps]
 def Submonoid.unitSphere (𝕜 : Type*) [NormedDivisionRing 𝕜] : Submonoid 𝕜 where
   carrier := sphere (0 : 𝕜) 1
   mul_mem' hx hy := by

--- a/Mathlib/Analysis/SpecialFunctions/Complex/Circle.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Complex/Circle.lean
@@ -19,114 +19,114 @@ open Complex Function Set
 
 open Real
 
-namespace circle
+namespace Circle
 
-theorem injective_arg : Injective fun z : circle => arg z := fun z w h =>
-  Subtype.ext <| ext_abs_arg ((abs_coe_circle z).trans (abs_coe_circle w).symm) h
+theorem injective_arg : Injective fun z : Circle => arg z := fun z w h =>
+  Subtype.ext <| ext_abs_arg (z.abs_coe.trans w.abs_coe.symm) h
 
 @[simp]
-theorem arg_eq_arg {z w : circle} : arg z = arg w ↔ z = w :=
+theorem arg_eq_arg {z w : Circle} : arg z = arg w ↔ z = w :=
   injective_arg.eq_iff
 
-end circle
-
-theorem arg_expMapCircle {x : ℝ} (h₁ : -π < x) (h₂ : x ≤ π) : arg (expMapCircle x) = x := by
-  rw [expMapCircle_apply, exp_mul_I, arg_cos_add_sin_mul_I ⟨h₁, h₂⟩]
+theorem arg_exp {x : ℝ} (h₁ : -π < x) (h₂ : x ≤ π) : arg (exp x) = x := by
+  rw [exp_apply, exp_mul_I, arg_cos_add_sin_mul_I ⟨h₁, h₂⟩]
 
 @[simp]
-theorem expMapCircle_arg (z : circle) : expMapCircle (arg z) = z :=
-  circle.injective_arg <| arg_expMapCircle (neg_pi_lt_arg _) (arg_le_pi _)
+theorem exp_arg (z : Circle) : exp (arg z) = z :=
+  injective_arg <| arg_exp (neg_pi_lt_arg _) (arg_le_pi _)
 
-namespace circle
+@[deprecated (since := "2024-07-25")] alias _root_.arg_expMapCircle := arg_exp
+@[deprecated (since := "2024-07-25")] alias _root_.expMapCircle_arg := exp_arg
 
 /-- `Complex.arg ∘ (↑)` and `expMapCircle` define a partial equivalence between `circle` and `ℝ`
 with `source = Set.univ` and `target = Set.Ioc (-π) π`. -/
 @[simps (config := .asFn)]
-noncomputable def argPartialEquiv : PartialEquiv circle ℝ where
+noncomputable def argPartialEquiv : PartialEquiv Circle ℝ where
   toFun := arg ∘ (↑)
-  invFun := expMapCircle
+  invFun := exp
   source := univ
   target := Ioc (-π) π
   map_source' _ _ := ⟨neg_pi_lt_arg _, arg_le_pi _⟩
   map_target' := mapsTo_univ _ _
-  left_inv' z _ := expMapCircle_arg z
-  right_inv' _ hx := arg_expMapCircle hx.1 hx.2
+  left_inv' z _ := exp_arg z
+  right_inv' _ hx := arg_exp hx.1 hx.2
 
 /-- `Complex.arg` and `expMapCircle` define an equivalence between `circle` and `(-π, π]`. -/
 @[simps (config := .asFn)]
-noncomputable def argEquiv : circle ≃ Ioc (-π) π where
+noncomputable def argEquiv : Circle ≃ Ioc (-π) π where
   toFun z := ⟨arg z, neg_pi_lt_arg _, arg_le_pi _⟩
-  invFun := expMapCircle ∘ (↑)
+  invFun := exp ∘ (↑)
   left_inv _ := argPartialEquiv.left_inv trivial
   right_inv x := Subtype.ext <| argPartialEquiv.right_inv x.2
 
-end circle
+lemma leftInverse_exp_arg : LeftInverse exp (arg ∘ (↑)) := exp_arg
+lemma invOn_arg_exp : InvOn (arg ∘ (↑)) exp (Ioc (-π) π) univ := argPartialEquiv.symm.invOn
+lemma surjOn_exp_neg_pi_pi : SurjOn exp (Ioc (-π) π) univ := argPartialEquiv.symm.surjOn
 
-theorem leftInverse_expMapCircle_arg : LeftInverse expMapCircle (arg ∘ (↑)) :=
-  expMapCircle_arg
-
-theorem invOn_arg_expMapCircle : InvOn (arg ∘ (↑)) expMapCircle (Ioc (-π) π) univ :=
-  circle.argPartialEquiv.symm.invOn
-
-theorem surjOn_expMapCircle_neg_pi_pi : SurjOn expMapCircle (Ioc (-π) π) univ :=
-  circle.argPartialEquiv.symm.surjOn
-
-theorem expMapCircle_eq_expMapCircle {x y : ℝ} :
-    expMapCircle x = expMapCircle y ↔ ∃ m : ℤ, x = y + m * (2 * π) := by
-  rw [Subtype.ext_iff, expMapCircle_apply, expMapCircle_apply, exp_eq_exp_iff_exists_int]
+lemma exp_eq_exp {x y : ℝ} : exp x = exp y ↔ ∃ m : ℤ, x = y + m * (2 * π) := by
+  rw [Subtype.ext_iff, exp_apply, exp_apply, exp_eq_exp_iff_exists_int]
   refine exists_congr fun n => ?_
   rw [← mul_assoc, ← add_mul, mul_left_inj' I_ne_zero]
   norm_cast
 
-theorem periodic_expMapCircle : Periodic expMapCircle (2 * π) := fun z =>
-  expMapCircle_eq_expMapCircle.2 ⟨1, by rw [Int.cast_one, one_mul]⟩
+lemma periodic_exp : Periodic exp (2 * π) := fun z ↦ exp_eq_exp.2 ⟨1, by rw [Int.cast_one, one_mul]⟩
 
-@[simp]
-theorem expMapCircle_two_pi : expMapCircle (2 * π) = 1 :=
-  periodic_expMapCircle.eq.trans expMapCircle_zero
+@[simp] lemma exp_two_pi : exp (2 * π) = 1 := periodic_exp.eq.trans exp_zero
 
-theorem expMapCircle_sub_two_pi (x : ℝ) : expMapCircle (x - 2 * π) = expMapCircle x :=
-  periodic_expMapCircle.sub_eq x
+lemma exp_sub_two_pi (x : ℝ) : exp (x - 2 * π) = exp x := periodic_exp.sub_eq x
+lemma exp_add_two_pi (x : ℝ) : exp (x + 2 * π) = exp x := periodic_exp x
 
-theorem expMapCircle_add_two_pi (x : ℝ) : expMapCircle (x + 2 * π) = expMapCircle x :=
-  periodic_expMapCircle x
+@[deprecated (since := "2024-07-25")]
+alias _root_.leftInverse_expMapCircle_arg := leftInverse_exp_arg
 
-/-- `expMapCircle`, applied to a `Real.Angle`. -/
-noncomputable def Real.Angle.expMapCircle (θ : Real.Angle) : circle :=
-  periodic_expMapCircle.lift θ
+@[deprecated (since := "2024-07-25")]
+alias _root_.surjOn_expMapCircle_neg_pi_pi := surjOn_exp_neg_pi_pi
 
-@[simp]
-theorem Real.Angle.expMapCircle_coe (x : ℝ) : Real.Angle.expMapCircle x = _root_.expMapCircle x :=
-  rfl
+@[deprecated (since := "2024-07-25")] alias _root_.invOn_arg_expMapCircle := invOn_arg_exp
+@[deprecated (since := "2024-07-25")] alias _root_.expMapCircle_eq_expMapCircle := exp_eq_exp
+@[deprecated (since := "2024-07-25")] alias _root_.periodic_expMapCircle := periodic_exp
+@[deprecated (since := "2024-07-25")] alias _root_.expMapCircle_two_pi := exp_two_pi
+@[deprecated (since := "2024-07-25")] alias _root_.expMapCircle_sub_two_pi := exp_sub_two_pi
+@[deprecated (since := "2024-07-25")] alias _root_.expMapCircle_add_two_pi := exp_add_two_pi
 
-theorem Real.Angle.coe_expMapCircle (θ : Real.Angle) :
-    (θ.expMapCircle : ℂ) = θ.cos + θ.sin * I := by
+end Circle
+
+namespace Real.Angle
+
+/-- `Circle.exp`, applied to a `Real.Angle`. -/
+noncomputable def toCircle (θ : Angle) : Circle := Circle.periodic_exp.lift θ
+
+@[simp] lemma toCircle_coe (x : ℝ) : toCircle x = .exp x := rfl
+
+lemma coe_toCircle (θ : Angle) : (θ.toCircle : ℂ) = θ.cos + θ.sin * I := by
   induction θ using Real.Angle.induction_on
   simp [exp_mul_I]
 
-@[simp]
-theorem Real.Angle.expMapCircle_zero : Real.Angle.expMapCircle 0 = 1 := by
-  rw [← Real.Angle.coe_zero, Real.Angle.expMapCircle_coe, _root_.expMapCircle_zero]
+@[simp] lemma toCircle_zero : toCircle 0 = 1 := by rw [← coe_zero, toCircle_coe, Circle.exp_zero]
 
-@[simp]
-theorem Real.Angle.expMapCircle_neg (θ : Real.Angle) :
-    Real.Angle.expMapCircle (-θ) = (Real.Angle.expMapCircle θ)⁻¹ := by
+@[simp] lemma toCircle_neg (θ : Angle) : toCircle (-θ) = (toCircle θ)⁻¹ := by
   induction θ using Real.Angle.induction_on
-  simp_rw [← Real.Angle.coe_neg, Real.Angle.expMapCircle_coe, _root_.expMapCircle_neg]
+  simp_rw [← coe_neg, toCircle_coe, Circle.exp_neg]
 
-@[simp]
-theorem Real.Angle.expMapCircle_add (θ₁ θ₂ : Real.Angle) : Real.Angle.expMapCircle (θ₁ + θ₂) =
-    Real.Angle.expMapCircle θ₁ * Real.Angle.expMapCircle θ₂ := by
+@[simp] lemma toCircle_add (θ₁ θ₂ : Angle) : toCircle (θ₁ + θ₂) = toCircle θ₁ * toCircle θ₂ := by
   induction θ₁ using Real.Angle.induction_on
   induction θ₂ using Real.Angle.induction_on
-  exact _root_.expMapCircle_add _ _
+  exact Circle.exp_add _ _
 
-@[simp]
-theorem Real.Angle.arg_expMapCircle (θ : Real.Angle) :
-    (arg (Real.Angle.expMapCircle θ) : Real.Angle) = θ := by
+@[simp] lemma arg_toCircle (θ : Real.Angle) : (arg θ.toCircle : Angle) = θ := by
   induction θ using Real.Angle.induction_on
-  rw [Real.Angle.expMapCircle_coe, expMapCircle_apply, exp_mul_I, ← ofReal_cos, ← ofReal_sin, ←
+  rw [toCircle_coe, Circle.exp_apply, exp_mul_I, ← ofReal_cos, ← ofReal_sin, ←
     Real.Angle.cos_coe, ← Real.Angle.sin_coe, arg_cos_add_sin_mul_I_coe_angle]
+
+@[deprecated (since := "2024-07-25")] alias expMapCircle := toCircle
+@[deprecated (since := "2024-07-25")] alias expMapCircle_coe := toCircle_coe
+@[deprecated (since := "2024-07-25")] alias coe_expMapCircle := coe_toCircle
+@[deprecated (since := "2024-07-25")] alias expMapCircle_zero := toCircle_zero
+@[deprecated (since := "2024-07-25")] alias expMapCircle_neg := toCircle_neg
+@[deprecated (since := "2024-07-25")] alias expMapCircle_add := toCircle_add
+@[deprecated (since := "2024-07-25")] alias arg_expMapCircle := arg_toCircle
+
+end Real.Angle
 
 namespace AddCircle
 
@@ -134,62 +134,60 @@ variable {T : ℝ}
 
 /-! ### Map from `AddCircle` to `Circle` -/
 
-theorem scaled_exp_map_periodic : Function.Periodic (fun x => expMapCircle (2 * π / T * x)) T := by
+theorem scaled_exp_map_periodic : Function.Periodic (fun x => Circle.exp (2 * π / T * x)) T := by
   -- The case T = 0 is not interesting, but it is true, so we prove it to save hypotheses
   rcases eq_or_ne T 0 with (rfl | hT)
   · intro x; simp
-  · intro x; simp_rw [mul_add]; rw [div_mul_cancel₀ _ hT, periodic_expMapCircle]
+  · intro x; simp_rw [mul_add]; rw [div_mul_cancel₀ _ hT, Circle.periodic_exp]
 
 /-- The canonical map `fun x => exp (2 π i x / T)` from `ℝ / ℤ • T` to the unit circle in `ℂ`.
 If `T = 0` we understand this as the constant function 1. -/
-noncomputable def toCircle : AddCircle T → circle :=
+noncomputable def toCircle : AddCircle T → Circle :=
   (@scaled_exp_map_periodic T).lift
 
-theorem toCircle_apply_mk (x : ℝ) : @toCircle T x = expMapCircle (2 * π / T * x) :=
+theorem toCircle_apply_mk (x : ℝ) : @toCircle T x = Circle.exp (2 * π / T * x) :=
   rfl
 
 theorem toCircle_add (x : AddCircle T) (y : AddCircle T) :
     @toCircle T (x + y) = toCircle x * toCircle y := by
   induction x using QuotientAddGroup.induction_on
   induction y using QuotientAddGroup.induction_on
-  simp_rw [← coe_add, toCircle_apply_mk, mul_add, expMapCircle_add]
+  simp_rw [← coe_add, toCircle_apply_mk, mul_add, Circle.exp_add]
 
 lemma toCircle_zero : toCircle (0 : AddCircle T) = 1 := by
-  rw [← QuotientAddGroup.mk_zero, toCircle_apply_mk, mul_zero, expMapCircle_zero]
+  rw [← QuotientAddGroup.mk_zero, toCircle_apply_mk, mul_zero, Circle.exp_zero]
 
 theorem continuous_toCircle : Continuous (@toCircle T) :=
-  continuous_coinduced_dom.mpr (expMapCircle.continuous.comp <| continuous_const.mul continuous_id')
+  continuous_coinduced_dom.mpr (Circle.exp.continuous.comp <| continuous_const.mul continuous_id')
 
 theorem injective_toCircle (hT : T ≠ 0) : Function.Injective (@toCircle T) := by
   intro a b h
   induction a using QuotientAddGroup.induction_on
   induction b using QuotientAddGroup.induction_on
   simp_rw [toCircle_apply_mk] at h
-  obtain ⟨m, hm⟩ := expMapCircle_eq_expMapCircle.mp h.symm
+  obtain ⟨m, hm⟩ := Circle.exp_eq_exp.mp h.symm
   rw [QuotientAddGroup.eq]; simp_rw [AddSubgroup.mem_zmultiples_iff, zsmul_eq_mul]
   use m
   field_simp at hm
   rw [← mul_right_inj' Real.two_pi_pos.ne']
   linarith
 
-/-- The homeomorphism between `AddCircle (2 * π)` and `circle`. -/
-@[simps] noncomputable def homeomorphCircle' : AddCircle (2 * π) ≃ₜ circle where
-  toFun := Angle.expMapCircle
+/-- The homeomorphism between `AddCircle (2 * π)` and `Circle`. -/
+@[simps] noncomputable def homeomorphCircle' : AddCircle (2 * π) ≃ₜ Circle where
+  toFun := Angle.toCircle
   invFun := fun x ↦ arg x
-  left_inv := Angle.arg_expMapCircle
-  right_inv := expMapCircle_arg
-  continuous_toFun := continuous_coinduced_dom.mpr expMapCircle.continuous
+  left_inv := Angle.arg_toCircle
+  right_inv := Circle.exp_arg
+  continuous_toFun := continuous_coinduced_dom.mpr Circle.exp.continuous
   continuous_invFun := by
     rw [continuous_iff_continuousAt]
     intro x
-    apply (continuousAt_arg_coe_angle (ne_zero_of_mem_circle x)).comp
-      continuousAt_subtype_val
+    exact (continuousAt_arg_coe_angle x.coe_ne_zero).comp continuousAt_subtype_val
 
-theorem homeomorphCircle'_apply_mk (x : ℝ) : homeomorphCircle' x = expMapCircle x :=
-  rfl
+theorem homeomorphCircle'_apply_mk (x : ℝ) : homeomorphCircle' x = Circle.exp x := rfl
 
-/-- The homeomorphism between `AddCircle` and `circle`. -/
-noncomputable def homeomorphCircle (hT : T ≠ 0) : AddCircle T ≃ₜ circle :=
+/-- The homeomorphism between `AddCircle` and `Circle`. -/
+noncomputable def homeomorphCircle (hT : T ≠ 0) : AddCircle T ≃ₜ Circle :=
   (homeomorphAddCircle T (2 * π) hT (by positivity)).trans homeomorphCircle'
 
 theorem homeomorphCircle_apply (hT : T ≠ 0) (x : AddCircle T) :
@@ -203,7 +201,10 @@ end AddCircle
 
 open AddCircle
 
--- todo: upgrade this to `IsCoveringMap expMapCircle`.
-lemma isLocalHomeomorph_expMapCircle : IsLocalHomeomorph expMapCircle := by
+-- todo: upgrade this to `IsCoveringMap Circle.exp`.
+lemma isLocalHomeomorph_circleExp : IsLocalHomeomorph Circle.exp := by
   have : Fact (0 < 2 * π) := ⟨by positivity⟩
   exact homeomorphCircle'.isLocalHomeomorph.comp (isLocalHomeomorph_coe (2 * π))
+
+@[deprecated (since := "2024-07-25")]
+alias isLocalHomeomorph_expMapCircle := isLocalHomeomorph_circleExp

--- a/Mathlib/Analysis/SpecialFunctions/Complex/CircleAddChar.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Complex/CircleAddChar.lean
@@ -22,7 +22,7 @@ open Complex Function
 open scoped Real
 
 /-- The canonical map from the additive to the multiplicative circle, as an `AddChar`. -/
-noncomputable def AddCircle.toCircle_addChar {T : ℝ} : AddChar (AddCircle T) circle where
+noncomputable def AddCircle.toCircle_addChar {T : ℝ} : AddChar (AddCircle T) Circle where
   toFun := toCircle
   map_zero_eq_one' := toCircle_zero
   map_add_eq_mul' := toCircle_add
@@ -31,17 +31,26 @@ open AddCircle
 
 namespace ZMod
 
+/-!
+### Additive characters valued in the complex circle
+-/
+
+open scoped Real
+
 variable {N : ℕ} [NeZero N]
 
 /-- The additive character from `ZMod N` to the unit circle in `ℂ`, sending `j mod N` to
 `exp (2 * π * I * j / N)`. -/
-noncomputable def toCircle : AddChar (ZMod N) circle :=
-  toCircle_addChar.compAddMonoidHom toAddCircle
+noncomputable def toCircle : AddChar (ZMod N) Circle where
+  toFun := fun j ↦ (toAddCircle j).toCircle
+  map_add_eq_mul' a b := by simp_rw [map_add, AddCircle.toCircle_add]
+  map_zero_eq_one' := by simp_rw [map_zero, AddCircle.toCircle, ← QuotientAddGroup.mk_zero,
+    Function.Periodic.lift_coe, mul_zero, Circle.exp_zero]
 
 lemma toCircle_intCast (j : ℤ) :
     toCircle (j : ZMod N) = exp (2 * π * I * j / N) := by
-  rw [toCircle, AddChar.compAddMonoidHom_apply, toCircle_addChar, AddChar.coe_mk,
-    AddCircle.toCircle, toAddCircle_intCast, Function.Periodic.lift_coe, expMapCircle_apply]
+  rw [toCircle, AddChar.coe_mk, AddCircle.toCircle, toAddCircle_intCast,
+    Function.Periodic.lift_coe, Circle.exp_apply]
   push_cast
   ring_nf
 
@@ -57,16 +66,14 @@ lemma toCircle_apply (j : ZMod N) :
     toCircle j = exp (2 * π * I * j.val / N) := by
   rw [← toCircle_natCast, natCast_zmod_val]
 
-lemma injective_toCircle : Injective (toCircle : ZMod N → circle) :=
+lemma injective_toCircle : Injective (toCircle : ZMod N → Circle) :=
   (AddCircle.injective_toCircle one_ne_zero).comp (toAddCircle_injective N)
 
 /-- The additive character from `ZMod N` to `ℂ`, sending `j mod N` to `exp (2 * π * I * j / N)`. -/
-noncomputable def stdAddChar : AddChar (ZMod N) ℂ := circle.subtype.compAddChar toCircle
+noncomputable def stdAddChar : AddChar (ZMod N) ℂ := Circle.coeHom.compAddChar toCircle
 
 lemma stdAddChar_coe (j : ℤ) :
-    stdAddChar (j : ZMod N) = exp (2 * π * I * j / N) := by
-  simp only [stdAddChar, MonoidHom.coe_compAddChar, Function.comp_apply,
-    Submonoid.coe_subtype, toCircle_intCast]
+    stdAddChar (j : ZMod N) = exp (2 * π * I * j / N) := by simp [stdAddChar, toCircle_intCast]
 
 lemma stdAddChar_apply (j : ZMod N) : stdAddChar j = ↑(toCircle j) := rfl
 

--- a/Mathlib/Analysis/SpecialFunctions/Complex/CircleAddChar.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Complex/CircleAddChar.lean
@@ -41,16 +41,13 @@ variable {N : ℕ} [NeZero N]
 
 /-- The additive character from `ZMod N` to the unit circle in `ℂ`, sending `j mod N` to
 `exp (2 * π * I * j / N)`. -/
-noncomputable def toCircle : AddChar (ZMod N) Circle where
-  toFun := fun j ↦ (toAddCircle j).toCircle
-  map_add_eq_mul' a b := by simp_rw [map_add, AddCircle.toCircle_add]
-  map_zero_eq_one' := by simp_rw [map_zero, AddCircle.toCircle, ← QuotientAddGroup.mk_zero,
-    Function.Periodic.lift_coe, mul_zero, Circle.exp_zero]
+noncomputable def toCircle : AddChar (ZMod N) Circle :=
+  toCircle_addChar.compAddMonoidHom toAddCircle
 
 lemma toCircle_intCast (j : ℤ) :
     toCircle (j : ZMod N) = exp (2 * π * I * j / N) := by
-  rw [toCircle, AddChar.coe_mk, AddCircle.toCircle, toAddCircle_intCast,
-    Function.Periodic.lift_coe, Circle.exp_apply]
+  rw [toCircle, AddChar.compAddMonoidHom_apply, toCircle_addChar, AddChar.coe_mk,
+    AddCircle.toCircle, toAddCircle_intCast, Function.Periodic.lift_coe, Circle.exp_apply]
   push_cast
   ring_nf
 

--- a/Mathlib/Geometry/Euclidean/Angle/Oriented/Rotation.lean
+++ b/Mathlib/Geometry/Euclidean/Angle/Oriented/Rotation.lean
@@ -161,13 +161,13 @@ theorem rotation_trans (θ₁ θ₂ : Real.Angle) :
 /-- Rotating the first of two vectors by `θ` scales their Kahler form by `cos θ - sin θ * I`. -/
 @[simp]
 theorem kahler_rotation_left (x y : V) (θ : Real.Angle) :
-    o.kahler (o.rotation θ x) y = conj (θ.expMapCircle : ℂ) * o.kahler x y := by
+    o.kahler (o.rotation θ x) y = conj (θ.toCircle : ℂ) * o.kahler x y := by
   -- Porting note: this needed the `Complex.conj_ofReal` instead of `RCLike.conj_ofReal`;
   -- I believe this is because the respective coercions are no longer defeq, and
-  -- `Real.Angle.coe_expMapCircle` uses the `Complex` version.
+  -- `Real.Angle.coe_toCircle` uses the `Complex` version.
   simp only [o.rotation_apply, map_add, map_mul, LinearMap.map_smulₛₗ, RingHom.id_apply,
     LinearMap.add_apply, LinearMap.smul_apply, real_smul, kahler_rightAngleRotation_left,
-    Real.Angle.coe_expMapCircle, Complex.conj_ofReal, conj_I]
+    Real.Angle.coe_toCircle, Complex.conj_ofReal, conj_I]
   ring
 
 /-- Negating a rotation is equivalent to rotation by π plus the angle. -/
@@ -187,15 +187,15 @@ theorem neg_rotation_pi_div_two (x : V) : -o.rotation (π / 2 : ℝ) x = o.rotat
 /-- Rotating the first of two vectors by `θ` scales their Kahler form by `cos (-θ) + sin (-θ) * I`.
 -/
 theorem kahler_rotation_left' (x y : V) (θ : Real.Angle) :
-    o.kahler (o.rotation θ x) y = (-θ).expMapCircle * o.kahler x y := by
-  simp only [Real.Angle.expMapCircle_neg, coe_inv_circle_eq_conj, kahler_rotation_left]
+    o.kahler (o.rotation θ x) y = (-θ).toCircle * o.kahler x y := by
+  simp only [Real.Angle.toCircle_neg, Circle.coe_inv_eq_conj, kahler_rotation_left]
 
 /-- Rotating the second of two vectors by `θ` scales their Kahler form by `cos θ + sin θ * I`. -/
 @[simp]
 theorem kahler_rotation_right (x y : V) (θ : Real.Angle) :
-    o.kahler x (o.rotation θ y) = θ.expMapCircle * o.kahler x y := by
+    o.kahler x (o.rotation θ y) = θ.toCircle * o.kahler x y := by
   simp only [o.rotation_apply, map_add, LinearMap.map_smulₛₗ, RingHom.id_apply, real_smul,
-    kahler_rightAngleRotation_right, Real.Angle.coe_expMapCircle]
+    kahler_rightAngleRotation_right, Real.Angle.coe_toCircle]
   ring
 
 /-- Rotating the first vector by `θ` subtracts `θ` from the angle between two vectors. -/
@@ -203,9 +203,9 @@ theorem kahler_rotation_right (x y : V) (θ : Real.Angle) :
 theorem oangle_rotation_left {x y : V} (hx : x ≠ 0) (hy : y ≠ 0) (θ : Real.Angle) :
     o.oangle (o.rotation θ x) y = o.oangle x y - θ := by
   simp only [oangle, o.kahler_rotation_left']
-  rw [Complex.arg_mul_coe_angle, Real.Angle.arg_expMapCircle]
+  rw [Complex.arg_mul_coe_angle, Real.Angle.arg_toCircle]
   · abel
-  · exact ne_zero_of_mem_circle _
+  · exact Circle.coe_ne_zero _
   · exact o.kahler_ne_zero hx hy
 
 /-- Rotating the second vector by `θ` adds `θ` to the angle between two vectors. -/
@@ -213,9 +213,9 @@ theorem oangle_rotation_left {x y : V} (hx : x ≠ 0) (hy : y ≠ 0) (θ : Real.
 theorem oangle_rotation_right {x y : V} (hx : x ≠ 0) (hy : y ≠ 0) (θ : Real.Angle) :
     o.oangle x (o.rotation θ y) = o.oangle x y + θ := by
   simp only [oangle, o.kahler_rotation_right]
-  rw [Complex.arg_mul_coe_angle, Real.Angle.arg_expMapCircle]
+  rw [Complex.arg_mul_coe_angle, Real.Angle.arg_toCircle]
   · abel
-  · exact ne_zero_of_mem_circle _
+  · exact Circle.coe_ne_zero _
   · exact o.kahler_ne_zero hx hy
 
 /-- The rotation of a vector by `θ` has an angle of `-θ` from that vector. -/
@@ -360,15 +360,15 @@ theorem rotation_map (θ : Real.Angle) (f : V ≃ₗᵢ[ℝ] V') (x : V') :
 
 @[simp]
 protected theorem _root_.Complex.rotation (θ : Real.Angle) (z : ℂ) :
-    Complex.orientation.rotation θ z = θ.expMapCircle * z := by
-  simp only [rotation_apply, Complex.rightAngleRotation, Real.Angle.coe_expMapCircle, real_smul]
+    Complex.orientation.rotation θ z = θ.toCircle * z := by
+  simp only [rotation_apply, Complex.rightAngleRotation, Real.Angle.coe_toCircle, real_smul]
   ring
 
 /-- Rotation in an oriented real inner product space of dimension 2 can be evaluated in terms of a
 complex-number representation of the space. -/
 theorem rotation_map_complex (θ : Real.Angle) (f : V ≃ₗᵢ[ℝ] ℂ)
     (hf : Orientation.map (Fin 2) f.toLinearEquiv o = Complex.orientation) (x : V) :
-    f (o.rotation θ x) = θ.expMapCircle * f x := by
+    f (o.rotation θ x) = θ.toCircle * f x := by
   rw [← Complex.rotation, ← hf, o.rotation_map, LinearIsometryEquiv.symm_apply_apply]
 
 /-- Negating the orientation negates the angle in `rotation`. -/

--- a/Mathlib/Geometry/Manifold/Instances/Sphere.lean
+++ b/Mathlib/Geometry/Manifold/Instances/Sphere.lean
@@ -37,13 +37,13 @@ We prove two lemmas about smooth maps:
 
 As an application we prove `contMdiffNegSphere`, that the antipodal map is smooth.
 
-Finally, we equip the `circle` (defined in `Analysis.Complex.Circle` to be the sphere in `ℂ`
+Finally, we equip the `Circle` (defined in `Analysis.Complex.Circle` to be the sphere in `ℂ`
 centred at `0` of radius `1`) with the following structure:
 * a charted space with model space `EuclideanSpace ℝ (Fin 1)` (inherited from `Metric.Sphere`)
 * a Lie group with model with corners `𝓡 1`
 
-We furthermore show that `expMapCircle` (defined in `Analysis.Complex.Circle` to be the natural
-map `fun t ↦ exp (t * I)` from `ℝ` to `circle`) is smooth.
+We furthermore show that `Circle.exp` (defined in `Analysis.Complex.Circle` to be the natural
+map `fun t ↦ exp (t * I)` from `ℝ` to `Circle`) is smooth.
 
 
 ## Implementation notes
@@ -538,7 +538,7 @@ theorem mfderiv_coe_sphere_injective {n : ℕ} [Fact (finrank ℝ E = n + 1)] (v
 
 end SmoothManifold
 
-section circle
+section Circle
 
 open Complex
 
@@ -550,17 +550,17 @@ attribute [local instance] finrank_real_complex_fact'
 
 /-- The unit circle in `ℂ` is a charted space modelled on `EuclideanSpace ℝ (Fin 1)`.  This
 follows by definition from the corresponding result for `Metric.Sphere`. -/
-instance : ChartedSpace (EuclideanSpace ℝ (Fin 1)) circle :=
+instance : ChartedSpace (EuclideanSpace ℝ (Fin 1)) Circle :=
   EuclideanSpace.instChartedSpaceSphere
 
-instance : SmoothManifoldWithCorners (𝓡 1) circle :=
+instance : SmoothManifoldWithCorners (𝓡 1) Circle :=
   EuclideanSpace.instSmoothManifoldWithCornersSphere (E := ℂ)
 
 /-- The unit circle in `ℂ` is a Lie group. -/
-instance : LieGroup (𝓡 1) circle where
+instance : LieGroup (𝓡 1) Circle where
   smooth_mul := by
     apply ContMDiff.codRestrict_sphere
-    let c : circle → ℂ := (↑)
+    let c : Circle → ℂ := (↑)
     have h₂ : ContMDiff (𝓘(ℝ, ℂ).prod 𝓘(ℝ, ℂ)) 𝓘(ℝ, ℂ) ∞ fun z : ℂ × ℂ => z.fst * z.snd := by
       rw [contMDiff_iff]
       exact ⟨continuous_mul, fun x y => contDiff_mul.contDiffOn⟩
@@ -571,11 +571,13 @@ instance : LieGroup (𝓡 1) circle where
     exact contMDiff_coe_sphere
   smooth_inv := by
     apply ContMDiff.codRestrict_sphere
-    simp only [← coe_inv_circle, coe_inv_circle_eq_conj]
+    simp only [← Circle.coe_inv, Circle.coe_inv_eq_conj]
     exact Complex.conjCLE.contDiff.contMDiff.comp contMDiff_coe_sphere
 
 /-- The map `fun t ↦ exp (t * I)` from `ℝ` to the unit circle in `ℂ` is smooth. -/
-theorem contMDiff_expMapCircle : ContMDiff 𝓘(ℝ, ℝ) (𝓡 1) ∞ expMapCircle :=
+theorem contMDiff_circleExp : ContMDiff 𝓘(ℝ, ℝ) (𝓡 1) ∞ Circle.exp :=
   (contDiff_exp.comp (contDiff_id.smul contDiff_const)).contMDiff.codRestrict_sphere _
 
-end circle
+@[deprecated (since := "2024-07-25")] alias contMDiff_expMapCircle := contMDiff_circleExp
+
+end Circle

--- a/Mathlib/Topology/Algebra/PontryaginDual.lean
+++ b/Mathlib/Topology/Algebra/PontryaginDual.lean
@@ -10,14 +10,14 @@ import Mathlib.Topology.Algebra.ContinuousMonoidHom
 # Pontryagin dual
 
 This file defines the Pontryagin dual of a topological group. The Pontryagin dual of a topological
-group `A` is the topological group of continuous homomorphisms `A →* circle` with the compact-open
-topology. For example, `ℤ` and `circle` are Pontryagin duals of each other. This is an example of
+group `A` is the topological group of continuous homomorphisms `A →* Circle` with the compact-open
+topology. For example, `ℤ` and `Circle` are Pontryagin duals of each other. This is an example of
 Pontryagin duality, which states that a locally compact abelian topological group is canonically
 isomorphic to its double dual.
 
 ## Main definitions
 
-* `PontryaginDual A`: The group of continuous homomorphisms `A →* circle`.
+* `PontryaginDual A`: The group of continuous homomorphisms `A →* Circle`.
 -/
 
 open Pointwise Function
@@ -26,49 +26,49 @@ variable (A B C D E G : Type*) [Monoid A] [Monoid B] [Monoid C] [Monoid D] [Comm
   [TopologicalSpace A] [TopologicalSpace B] [TopologicalSpace C] [TopologicalSpace D]
   [TopologicalSpace E] [TopologicalSpace G] [TopologicalGroup E] [TopologicalGroup G]
 
-/-- The Pontryagin dual of `A` is the group of continuous homomorphism `A → circle`. -/
+/-- The Pontryagin dual of `A` is the group of continuous homomorphism `A → Circle`. -/
 def PontryaginDual :=
-  ContinuousMonoidHom A circle
+  ContinuousMonoidHom A Circle
 
 -- Porting note: `deriving` doesn't derive these instances
 instance : TopologicalSpace (PontryaginDual A) :=
-  (inferInstance : TopologicalSpace (ContinuousMonoidHom A circle))
+  (inferInstance : TopologicalSpace (ContinuousMonoidHom A Circle))
 
 instance : T2Space (PontryaginDual A) :=
-  (inferInstance : T2Space (ContinuousMonoidHom A circle))
+  (inferInstance : T2Space (ContinuousMonoidHom A Circle))
 
 -- Porting note: instance is now noncomputable
 noncomputable instance : CommGroup (PontryaginDual A) :=
-  (inferInstance : CommGroup (ContinuousMonoidHom A circle))
+  (inferInstance : CommGroup (ContinuousMonoidHom A Circle))
 
 instance : TopologicalGroup (PontryaginDual A) :=
-  (inferInstance : TopologicalGroup (ContinuousMonoidHom A circle))
+  (inferInstance : TopologicalGroup (ContinuousMonoidHom A Circle))
 
 -- Porting note: instance is now noncomputable
 noncomputable instance : Inhabited (PontryaginDual A) :=
-  (inferInstance : Inhabited (ContinuousMonoidHom A circle))
+  (inferInstance : Inhabited (ContinuousMonoidHom A Circle))
 
 instance [LocallyCompactSpace G] : LocallyCompactSpace (PontryaginDual G) := by
-  let Vn : ℕ → Set circle :=
-    fun n ↦ expMapCircle '' { x | |x| < Real.pi / 2 ^ (n + 1)}
+  let Vn : ℕ → Set Circle :=
+    fun n ↦ Circle.exp '' { x | |x| < Real.pi / 2 ^ (n + 1)}
   have hVn : ∀ n x, x ∈ Vn n ↔ |Complex.arg x| < Real.pi / 2 ^ (n + 1) := by
-    refine fun n x ↦ ⟨?_, fun hx ↦ ⟨Complex.arg x, hx, expMapCircle_arg x⟩⟩
+    refine fun n x ↦ ⟨?_, fun hx ↦ ⟨Complex.arg x, hx, Circle.exp_arg x⟩⟩
     rintro ⟨t, ht : |t| < _, rfl⟩
     have ht' := ht.trans_le (div_le_self Real.pi_nonneg (one_le_pow_of_one_le one_le_two (n + 1)))
-    rwa [arg_expMapCircle (neg_lt_of_abs_lt ht') (lt_of_abs_lt ht').le]
+    rwa [Circle.arg_exp (neg_lt_of_abs_lt ht') (lt_of_abs_lt ht').le]
   refine ContinuousMonoidHom.locallyCompactSpace_of_hasBasis Vn ?_ ?_
   · intro n x h1 h2
     rw [hVn] at h1 h2 ⊢
-    rwa [Submonoid.coe_mul, Complex.arg_mul (ne_zero_of_mem_circle x) (ne_zero_of_mem_circle x),
+    rwa [Circle.coe_mul, Complex.arg_mul x.coe_ne_zero x.coe_ne_zero,
       ← two_mul, abs_mul, abs_two, ← lt_div_iff' two_pos, div_div, ← pow_succ] at h2
     apply Set.Ioo_subset_Ioc_self
     rw [← two_mul, Set.mem_Ioo, ← abs_lt, abs_mul, abs_two, ← lt_div_iff' two_pos]
     exact h1.trans_le
       (div_le_div_of_nonneg_left Real.pi_nonneg two_pos (le_self_pow one_le_two n.succ_ne_zero))
-  · rw [← expMapCircle_zero, ← isLocalHomeomorph_expMapCircle.map_nhds_eq 0]
+  · rw [← Circle.exp_zero, ← isLocalHomeomorph_circleExp.map_nhds_eq 0]
     refine ((nhds_basis_zero_abs_sub_lt ℝ).to_hasBasis
         (fun x hx ↦ ⟨Nat.ceil (Real.pi / x), trivial, fun t ht ↦ ?_⟩)
-          fun k _ ↦ ⟨Real.pi / 2 ^ (k + 1), by positivity, le_rfl⟩).map expMapCircle
+          fun k _ ↦ ⟨Real.pi / 2 ^ (k + 1), by positivity, le_rfl⟩).map Circle.exp
     rw [Set.mem_setOf_eq] at ht ⊢
     refine lt_of_lt_of_le ht ?_
     rw [div_le_iff' (pow_pos two_pos _), ← div_le_iff hx]
@@ -81,16 +81,16 @@ namespace PontryaginDual
 
 open ContinuousMonoidHom
 
-instance : FunLike (PontryaginDual A) A circle :=
+instance : FunLike (PontryaginDual A) A Circle :=
   ContinuousMonoidHom.funLike
 
-noncomputable instance : ContinuousMonoidHomClass (PontryaginDual A) A circle :=
+noncomputable instance : ContinuousMonoidHomClass (PontryaginDual A) A Circle :=
   ContinuousMonoidHom.ContinuousMonoidHomClass
 
 /-- `PontryaginDual` is a contravariant functor. -/
 noncomputable def map (f : ContinuousMonoidHom A B) :
     ContinuousMonoidHom (PontryaginDual B) (PontryaginDual A) :=
-  f.compLeft circle
+  f.compLeft Circle
 
 @[simp]
 theorem map_apply (f : ContinuousMonoidHom A B) (x : PontryaginDual B) (y : A) :

--- a/test/TCSynth.lean
+++ b/test/TCSynth.lean
@@ -54,7 +54,7 @@ section
 
 open Real in
 set_option synthInstance.maxHeartbeats 10000 in
-example : expMapCircle (2 * π) = 1 := by simp
+example : Circle.exp (2 * π) = 1 := by simp
 
 end
 


### PR DESCRIPTION
See https://github.com/leanprover-community/mathlib4/wiki/Tradeoffs-of-concrete-types-defined-as-subobjects for context

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
