### PR TITLE
[Merged by Bors] - chore: robustifying for debug.byAsSorry (part 2)

### DIFF
--- a/Mathlib/Algebra/Group/Subsemigroup/Operations.lean
+++ b/Mathlib/Algebra/Group/Subsemigroup/Operations.lean
@@ -301,12 +301,14 @@ theorem map_id (S : Subsemigroup M) : S.map (MulHom.id M) = S :=
 
 section GaloisCoinsertion
 
-variable {ι : Type*} {f : M →ₙ* N} (hf : Function.Injective f)
+variable {ι : Type*} {f : M →ₙ* N}
 
 /-- `map f` and `comap f` form a `GaloisCoinsertion` when `f` is injective. -/
 @[to_additive " `map f` and `comap f` form a `GaloisCoinsertion` when `f` is injective. "]
-def gciMapComap : GaloisCoinsertion (map f) (comap f) :=
+def gciMapComap (hf : Function.Injective f) : GaloisCoinsertion (map f) (comap f) :=
   (gc_map_comap f).toGaloisCoinsertion fun S x => by simp [mem_comap, mem_map, hf.eq_iff]
+
+variable (hf : Function.Injective f)
 
 @[to_additive]
 theorem comap_map_eq_of_injective (S : Subsemigroup M) : (S.map f).comap f = S :=

--- a/Mathlib/Algebra/Order/GroupWithZero/Canonical.lean
+++ b/Mathlib/Algebra/Order/GroupWithZero/Canonical.lean
@@ -120,10 +120,10 @@ theorem mul_inv_le_of_le_mul (hab : a ≤ b * c) : a * c⁻¹ ≤ b := by
   · exact le_of_le_mul_right h (by simpa [h] using hab)
 
 theorem inv_le_one₀ (ha : a ≠ 0) : a⁻¹ ≤ 1 ↔ 1 ≤ a :=
-  @inv_le_one' _ _ _ _ <| Units.mk0 a ha
+  inv_le_one' (a := Units.mk0 a ha)
 
 theorem one_le_inv₀ (ha : a ≠ 0) : 1 ≤ a⁻¹ ↔ a ≤ 1 :=
-  @one_le_inv' _ _ _ _ <| Units.mk0 a ha
+  one_le_inv' (a := Units.mk0 a ha)
 
 theorem le_mul_inv_iff₀ (hc : c ≠ 0) : a ≤ b * c⁻¹ ↔ a * c ≤ b :=
   ⟨fun h ↦ inv_inv c ▸ mul_inv_le_of_le_mul h, le_mul_inv_of_mul_le hc⟩
@@ -168,10 +168,10 @@ theorem mul_lt_right₀ (c : α) (h : a < b) (hc : c ≠ 0) : a * c < b * c := b
   exact le_of_le_mul_right hc h
 
 theorem inv_lt_one₀ (ha : a ≠ 0) : a⁻¹ < 1 ↔ 1 < a :=
-  @inv_lt_one' _ _ _ _ <| Units.mk0 a ha
+  inv_lt_one' (a := Units.mk0 a ha)
 
 theorem one_lt_inv₀ (ha : a ≠ 0) : 1 < a⁻¹ ↔ a < 1 :=
-  @one_lt_inv' _ _ _ _ <| Units.mk0 a ha
+  one_lt_inv' (a := Units.mk0 a ha)
 
 theorem inv_lt_inv₀ (ha : a ≠ 0) (hb : b ≠ 0) : a⁻¹ < b⁻¹ ↔ b < a :=
   show (Units.mk0 a ha)⁻¹ < (Units.mk0 b hb)⁻¹ ↔ Units.mk0 b hb < Units.mk0 a ha from

--- a/Mathlib/Algebra/Order/Monoid/Unbundled/Pow.lean
+++ b/Mathlib/Algebra/Order/Monoid/Unbundled/Pow.lean
@@ -45,7 +45,7 @@ theorem one_le_pow_of_one_le' {a : M} (H : 1 ≤ a) : ∀ n : ℕ, 1 ≤ a ^ n
 
 @[to_additive nsmul_nonpos]
 theorem pow_le_one' {a : M} (H : a ≤ 1) (n : ℕ) : a ^ n ≤ 1 :=
-  @one_le_pow_of_one_le' Mᵒᵈ _ _ _ _ H n
+  one_le_pow_of_one_le' (M := Mᵒᵈ) H n
 
 @[to_additive (attr := gcongr) nsmul_le_nsmul_left]
 theorem pow_le_pow_right' {a : M} {n m : ℕ} (ha : 1 ≤ a) (h : n ≤ m) : a ^ n ≤ a ^ m :=
@@ -69,7 +69,7 @@ theorem one_lt_pow' {a : M} (ha : 1 < a) {k : ℕ} (hk : k ≠ 0) : 1 < a ^ k :=
 
 @[to_additive nsmul_neg]
 theorem pow_lt_one' {a : M} (ha : a < 1) {k : ℕ} (hk : k ≠ 0) : a ^ k < 1 :=
-  @one_lt_pow' Mᵒᵈ _ _ _ _ ha k hk
+  one_lt_pow' (M := Mᵒᵈ) ha hk
 
 @[to_additive (attr := gcongr) nsmul_lt_nsmul_left]
 theorem pow_lt_pow_right' [CovariantClass M M (· * ·) (· < ·)] {a : M} {n m : ℕ} (ha : 1 < a)
@@ -192,7 +192,7 @@ theorem one_le_pow_iff {x : M} {n : ℕ} (hn : n ≠ 0) : 1 ≤ x ^ n ↔ 1 ≤ 
 
 @[to_additive]
 theorem pow_le_one_iff {x : M} {n : ℕ} (hn : n ≠ 0) : x ^ n ≤ 1 ↔ x ≤ 1 :=
-  @one_le_pow_iff Mᵒᵈ _ _ _ _ _ hn
+  one_le_pow_iff (M := Mᵒᵈ) hn
 
 @[to_additive nsmul_pos_iff]
 theorem one_lt_pow_iff {x : M} {n : ℕ} (hn : n ≠ 0) : 1 < x ^ n ↔ 1 < x :=

--- a/Mathlib/Algebra/Regular/Basic.lean
+++ b/Mathlib/Algebra/Regular/Basic.lean
@@ -122,7 +122,7 @@ element, then `b` is left-regular. -/
 @[to_additive "If an element `b` becomes add-left-regular after adding to it on the left
 an add-left-regular element, then `b` is add-left-regular."]
 theorem IsLeftRegular.of_mul (ab : IsLeftRegular (a * b)) : IsLeftRegular b :=
-  Function.Injective.of_comp (by rwa [comp_mul_left a b])
+  Function.Injective.of_comp (f := (a * ·)) (by rwa [comp_mul_left a b])
 
 /-- An element is left-regular if and only if multiplying it on the left by a left-regular element
 is left-regular. -/
@@ -284,12 +284,12 @@ variable [Monoid R] {a b : R}
 /-- An element admitting a left inverse is left-regular. -/
 @[to_additive "An element admitting a left additive opposite is add-left-regular."]
 theorem isLeftRegular_of_mul_eq_one (h : b * a = 1) : IsLeftRegular a :=
-  @IsLeftRegular.of_mul R _ _ _ (by rw [h]; exact isRegular_one.left)
+  IsLeftRegular.of_mul (a := b) (by rw [h]; exact isRegular_one.left)
 
 /-- An element admitting a right inverse is right-regular. -/
 @[to_additive "An element admitting a right additive opposite is add-right-regular."]
 theorem isRightRegular_of_mul_eq_one (h : a * b = 1) : IsRightRegular a :=
-  IsRightRegular.of_mul (by rw [h]; exact isRegular_one.right)
+  IsRightRegular.of_mul (a := b) (by rw [h]; exact isRegular_one.right)
 
 /-- If `R` is a monoid, an element in `Rˣ` is regular. -/
 @[to_additive "If `R` is an additive monoid, an element in `add_units R` is add-regular."]

--- a/Mathlib/CategoryTheory/Adjunction/Basic.lean
+++ b/Mathlib/CategoryTheory/Adjunction/Basic.lean
@@ -460,7 +460,6 @@ section ConstructLeft
 -- constructed from this data.
 variable {F_obj : C → D}
 variable (e : ∀ X Y, (F_obj X ⟶ Y) ≃ (X ⟶ G.obj Y))
-variable (he : ∀ X Y Y' g h, e X Y' (h ≫ g) = e X Y h ≫ G.map g)
 
 private theorem he' {X Y Y'} (f g) : (e X Y').symm (f ≫ G.map g) = (e X Y).symm f ≫ g := by
   rw [Equiv.symm_apply_eq, he]; simp
@@ -470,7 +469,7 @@ a bijection `e` between `F_obj X ⟶ Y` and `X ⟶ G.obj Y` satisfying a natural
 `he : ∀ X Y Y' g h, e X Y' (h ≫ g) = e X Y h ≫ G.map g`.
 Dual to `rightAdjointOfEquiv`. -/
 @[simps!]
-def leftAdjointOfEquiv : C ⥤ D where
+def leftAdjointOfEquiv (he : ∀ X Y Y' g h, e X Y' (h ≫ g) = e X Y h ≫ G.map g) : C ⥤ D where
   obj := F_obj
   map {X} {X'} f := (e X (F_obj X')).symm (f ≫ e X' (F_obj X') (𝟙 _))
   map_comp := fun f f' => by
@@ -479,6 +478,8 @@ def leftAdjointOfEquiv : C ⥤ D where
       rhs
       rw [assoc, ← he, id_comp, Equiv.apply_symm_apply]
     simp
+
+variable (he : ∀ X Y Y' g h, e X Y' (h ≫ g) = e X Y h ≫ G.map g)
 
 /-- Show that the functor given by `leftAdjointOfEquiv` is indeed left adjoint to `G`. Dual
 to `adjunctionOfRightEquiv`. -/
@@ -502,7 +503,6 @@ section ConstructRight
 -- Construction of a right adjoint, analogous to the above.
 variable {G_obj : D → C}
 variable (e : ∀ X Y, (F.obj X ⟶ Y) ≃ (X ⟶ G_obj Y))
-variable (he : ∀ X' X Y f g, e X' Y (F.map f ≫ g) = f ≫ e X Y g)
 
 private theorem he'' {X' X Y} (f g) : F.map f ≫ (e X Y).symm g = (e X' Y).symm (f ≫ g) := by
   rw [Equiv.eq_symm_apply, he]; simp
@@ -512,7 +512,7 @@ a bijection `e` between `F.obj X ⟶ Y` and `X ⟶ G_obj Y` satisfying a natural
 `he : ∀ X Y Y' g h, e X' Y (F.map f ≫ g) = f ≫ e X Y g`.
 Dual to `leftAdjointOfEquiv`. -/
 @[simps!]
-def rightAdjointOfEquiv : D ⥤ C where
+def rightAdjointOfEquiv (he : ∀ X' X Y f g, e X' Y (F.map f ≫ g) = f ≫ e X Y g) : D ⥤ C where
   obj := G_obj
   map {Y} {Y'} g := (e (G_obj Y) Y') ((e (G_obj Y) Y).symm (𝟙 _) ≫ g)
   map_comp := fun {Y} {Y'} {Y''} g g' => by
@@ -521,6 +521,8 @@ def rightAdjointOfEquiv : D ⥤ C where
       rhs
       rw [← assoc, he'' e he, comp_id, Equiv.symm_apply_apply]
     simp
+
+variable (he : ∀ X' X Y f g, e X' Y (F.map f ≫ g) = f ≫ e X Y g)
 
 /-- Show that the functor given by `rightAdjointOfEquiv` is indeed right adjoint to `F`. Dual
 to `adjunctionOfEquivRight`. -/

--- a/Mathlib/CategoryTheory/Adjunction/Basic.lean
+++ b/Mathlib/CategoryTheory/Adjunction/Basic.lean
@@ -461,9 +461,6 @@ section ConstructLeft
 variable {F_obj : C → D}
 variable (e : ∀ X Y, (F_obj X ⟶ Y) ≃ (X ⟶ G.obj Y))
 
-private theorem he' {X Y Y'} (f g) : (e X Y').symm (f ≫ G.map g) = (e X Y).symm f ≫ g := by
-  rw [Equiv.symm_apply_eq, he]; simp
-
 /-- Construct a left adjoint functor to `G`, given the functor's value on objects `F_obj` and
 a bijection `e` between `F_obj X ⟶ Y` and `X ⟶ G.obj Y` satisfying a naturality law
 `he : ∀ X Y Y' g h, e X Y' (h ≫ g) = e X Y h ≫ G.map g`.
@@ -488,7 +485,9 @@ def adjunctionOfEquivLeft : leftAdjointOfEquiv e he ⊣ G :=
   mkOfHomEquiv
     { homEquiv := e
       homEquiv_naturality_left_symm := fun {X'} {X} {Y} f g => by
-        have := @he' C _ D _ G F_obj e he
+        have {X : C} {Y Y' : D} (f : X ⟶ G.obj Y) (g : Y ⟶ Y') :
+            (e X Y').symm (f ≫ G.map g) = (e X Y).symm f ≫ g := by
+          rw [Equiv.symm_apply_eq, he]; simp
         erw [← this, ← Equiv.apply_eq_iff_eq (e X' Y)]
         simp only [leftAdjointOfEquiv_obj, Equiv.apply_symm_apply, assoc]
         congr
@@ -504,7 +503,8 @@ section ConstructRight
 variable {G_obj : D → C}
 variable (e : ∀ X Y, (F.obj X ⟶ Y) ≃ (X ⟶ G_obj Y))
 
-private theorem he'' {X' X Y} (f g) : F.map f ≫ (e X Y).symm g = (e X' Y).symm (f ≫ g) := by
+private theorem he'' (he : ∀ X' X Y f g, e X' Y (F.map f ≫ g) = f ≫ e X Y g)
+    {X' X Y} (f g) : F.map f ≫ (e X Y).symm g = (e X' Y).symm (f ≫ g) := by
   rw [Equiv.eq_symm_apply, he]; simp
 
 /-- Construct a right adjoint functor to `F`, given the functor's value on objects `G_obj` and
@@ -522,12 +522,11 @@ def rightAdjointOfEquiv (he : ∀ X' X Y f g, e X' Y (F.map f ≫ g) = f ≫ e X
       rw [← assoc, he'' e he, comp_id, Equiv.symm_apply_apply]
     simp
 
-variable (he : ∀ X' X Y f g, e X' Y (F.map f ≫ g) = f ≫ e X Y g)
-
 /-- Show that the functor given by `rightAdjointOfEquiv` is indeed right adjoint to `F`. Dual
 to `adjunctionOfEquivRight`. -/
 @[simps!]
-def adjunctionOfEquivRight : F ⊣ (rightAdjointOfEquiv e he) :=
+def adjunctionOfEquivRight (he : ∀ X' X Y f g, e X' Y (F.map f ≫ g) = f ≫ e X Y g) :
+    F ⊣ (rightAdjointOfEquiv e he) :=
   mkOfHomEquiv
     { homEquiv := e
       homEquiv_naturality_left_symm := by

--- a/Mathlib/CategoryTheory/Bicategory/Basic.lean
+++ b/Mathlib/CategoryTheory/Bicategory/Basic.lean
@@ -430,7 +430,7 @@ category of functors `(b ⟶ c) ⥤ (a ⟶ c)`. -/
 @[simps]
 def precomposing (a b c : B) : (a ⟶ b) ⥤ (b ⟶ c) ⥤ (a ⟶ c) where
   obj f := precomp c f
-  map η := ⟨(η ▷ ·), _⟩
+  map η := { app := (η ▷ ·) }
 
 /-- Postcomposition of a 1-morphism as a functor. -/
 @[simps]
@@ -443,7 +443,7 @@ category of functors `(a ⟶ b) ⥤ (a ⟶ c)`. -/
 @[simps]
 def postcomposing (a b c : B) : (b ⟶ c) ⥤ (a ⟶ b) ⥤ (a ⟶ c) where
   obj f := postcomp a f
-  map η := ⟨(· ◁ η), _⟩
+  map η := { app := (· ◁ η) }
 
 /-- Left component of the associator as a natural isomorphism. -/
 @[simps!]

--- a/Mathlib/CategoryTheory/Endomorphism.lean
+++ b/Mathlib/CategoryTheory/Endomorphism.lean
@@ -150,8 +150,8 @@ def toEnd (X : C) : Aut X →* End X := (Units.coeHom (End X)).comp (Aut.unitsEn
 
 /-- Isomorphisms induce isomorphisms of the automorphism group -/
 def autMulEquivOfIso {X Y : C} (h : X ≅ Y) : Aut X ≃* Aut Y where
-  toFun x := ⟨h.inv ≫ x.hom ≫ h.hom, h.inv ≫ x.inv ≫ h.hom, _, _⟩
-  invFun y := ⟨h.hom ≫ y.hom ≫ h.inv, h.hom ≫ y.inv ≫ h.inv, _, _⟩
+  toFun x := { hom := h.inv ≫ x.hom ≫ h.hom, inv := h.inv ≫ x.inv ≫ h.hom }
+  invFun y := { hom := h.hom ≫ y.hom ≫ h.inv, inv := h.hom ≫ y.inv ≫ h.inv }
   left_inv _ := by aesop_cat
   right_inv _ := by aesop_cat
   map_mul' := by simp [Aut_mul_def]

--- a/Mathlib/CategoryTheory/Quotient.lean
+++ b/Mathlib/CategoryTheory/Quotient.lean
@@ -141,10 +141,9 @@ theorem functor_map_eq_iff [h : Congruence r] {X Y : C} (f f' : X ⟶ Y) :
   simpa only [compClosure_eq_self r] using h.equivalence
 
 variable {D : Type _} [Category D] (F : C ⥤ D)
-  (H : ∀ (x y : C) (f₁ f₂ : x ⟶ y), r f₁ f₂ → F.map f₁ = F.map f₂)
 
 /-- The induced functor on the quotient category. -/
-def lift : Quotient r ⥤ D where
+def lift (H : ∀ (x y : C) (f₁ f₂ : x ⟶ y), r f₁ f₂ → F.map f₁ = F.map f₂) : Quotient r ⥤ D where
   obj a := F.obj a.as
   map := @fun a b hf ↦
     Quot.liftOn hf (fun f ↦ F.map f)
@@ -155,6 +154,8 @@ def lift : Quotient r ⥤ D where
   map_comp := by
     rintro a b c ⟨f⟩ ⟨g⟩
     exact F.map_comp f g
+
+variable (H : ∀ (x y : C) (f₁ f₂ : x ⟶ y), r f₁ f₂ → F.map f₁ = F.map f₂)
 
 theorem lift_spec : functor r ⋙ lift r F H = F := by
   apply Functor.ext; rotate_left

--- a/Mathlib/Data/List/EditDistance/Defs.lean
+++ b/Mathlib/Data/List/EditDistance/Defs.lean
@@ -246,7 +246,7 @@ theorem suffixLevenshtein_cons₁_fst (x : α) (xs ys) :
 
 theorem suffixLevenshtein_cons_cons_fst_get_zero
     (x : α) (xs y ys) (w : 0 < (suffixLevenshtein C (x :: xs) (y :: ys)).val.length) :
-    (suffixLevenshtein C (x :: xs) (y :: ys)).1[0] =
+    (suffixLevenshtein C (x :: xs) (y :: ys)).1[0]'w =
       let ⟨dx, _⟩ := suffixLevenshtein C xs (y :: ys)
       let ⟨dy, _⟩ := suffixLevenshtein C (x :: xs) ys
       let ⟨dxy, _⟩ := suffixLevenshtein C xs ys
@@ -296,4 +296,4 @@ theorem levenshtein_cons_cons
       min (C.delete x + levenshtein C xs (y :: ys))
         (min (C.insert y + levenshtein C (x :: xs) ys)
           (C.substitute x y + levenshtein C xs ys)) :=
-  suffixLevenshtein_cons_cons_fst_get_zero _ _ _ _ _
+  suffixLevenshtein_cons_cons_fst_get_zero ..

--- a/Mathlib/Data/Multiset/Basic.lean
+++ b/Mathlib/Data/Multiset/Basic.lean
@@ -1141,7 +1141,7 @@ theorem map_const (s : Multiset α) (b : β) : map (const α b) s = replicate (c
 
 theorem eq_of_mem_map_const {b₁ b₂ : β} {l : List α} (h : b₁ ∈ map (Function.const α b₂) l) :
     b₁ = b₂ :=
-  eq_of_mem_replicate <| by rwa [map_const] at h
+  eq_of_mem_replicate (n := card (l : Multiset α)) <| by rwa [map_const] at h
 
 @[simp]
 theorem map_le_map {f : α → β} {s t : Multiset α} (h : s ≤ t) : map f s ≤ map f t :=
@@ -1650,7 +1650,8 @@ theorem sub_add_inter (s t : Multiset α) : s - t + s ∩ t = s := by
   · rw [cons_inter_of_neg _ h, sub_cons, erase_of_not_mem h, IH]
 
 theorem sub_inter (s t : Multiset α) : s - s ∩ t = s - t :=
-  add_right_cancel <| by rw [sub_add_inter s t, tsub_add_cancel_of_le (inter_le_left s t)]
+  add_right_cancel (b := s ∩ t) <| by
+    rw [sub_add_inter s t, tsub_add_cancel_of_le (inter_le_left s t)]
 
 end
 

--- a/Mathlib/Order/Bounds/Basic.lean
+++ b/Mathlib/Order/Bounds/Basic.lean
@@ -1144,12 +1144,14 @@ theorem image2_lowerBounds_lowerBounds_subset :
   image2_subset_iff.2 fun _ ha _ hb ↦ mem_lowerBounds_image2 h₀ h₁ ha hb
 
 /-- See also `Monotone.map_bddAbove`. -/
-protected theorem BddAbove.image2 : BddAbove s → BddAbove t → BddAbove (image2 f s t) := by
+protected theorem BddAbove.image2 (h₀ : ∀ b, Monotone (swap f b)) (h₁ : ∀ a, Monotone (f a)) :
+    BddAbove s → BddAbove t → BddAbove (image2 f s t) := by
   rintro ⟨a, ha⟩ ⟨b, hb⟩
   exact ⟨f a b, mem_upperBounds_image2 h₀ h₁ ha hb⟩
 
 /-- See also `Monotone.map_bddBelow`. -/
-protected theorem BddBelow.image2 : BddBelow s → BddBelow t → BddBelow (image2 f s t) := by
+protected theorem BddBelow.image2 (h₀ : ∀ b, Monotone (swap f b)) (h₁ : ∀ a, Monotone (f a)) :
+    BddBelow s → BddBelow t → BddBelow (image2 f s t) := by
   rintro ⟨a, ha⟩ ⟨b, hb⟩
   exact ⟨f a b, mem_lowerBounds_image2 h₀ h₁ ha hb⟩
 

--- a/Mathlib/Order/Interval/Set/Pi.lean
+++ b/Mathlib/Order/Interval/Set/Pi.lean
@@ -58,7 +58,7 @@ theorem pi_univ_Ioi_subset : (pi univ fun i ↦ Ioi (x i)) ⊆ Ioi x := fun z hz
     (Nonempty.elim ‹Nonempty ι›) fun i ↦ not_lt_of_le (h i) (hz i trivial)⟩
 
 theorem pi_univ_Iio_subset : (pi univ fun i ↦ Iio (x i)) ⊆ Iio x :=
-  @pi_univ_Ioi_subset ι (fun i ↦ (α i)ᵒᵈ) _ x _
+  pi_univ_Ioi_subset (α := fun i ↦ (α i)ᵒᵈ) x
 
 theorem pi_univ_Ioo_subset : (pi univ fun i ↦ Ioo (x i) (y i)) ⊆ Ioo x y := fun _ hx ↦
   ⟨(pi_univ_Ioi_subset _) fun i hi ↦ (hx i hi).1, (pi_univ_Iio_subset _) fun i hi ↦ (hx i hi).2⟩

--- a/Mathlib/Order/Minimal.lean
+++ b/Mathlib/Order/Minimal.lean
@@ -86,9 +86,9 @@ theorem mem_maximals_setOf_iff {P : α → Prop} :
     x ∈ maximals r (setOf P) ↔ P x ∧ ∀ ⦃y⦄, P y → r x y → x = y :=
   mem_maximals_iff
 
-theorem mem_minimals_iff : x ∈ minimals r s ↔ x ∈ s ∧ ∀ ⦃y⦄, y ∈ s → r y x → x = y := by
-  haveI := IsAntisymm.swap r
-  exact mem_maximals_iff
+theorem mem_minimals_iff : x ∈ minimals r s ↔ x ∈ s ∧ ∀ ⦃y⦄, y ∈ s → r y x → x = y :=
+  have := IsAntisymm.swap r
+  mem_maximals_iff
 
 theorem mem_minimals_setOf_iff {P : α → Prop} :
     x ∈ minimals r (setOf P) ↔ P x ∧ ∀ ⦃y⦄, P y → r y x → x = y :=
@@ -118,7 +118,9 @@ theorem minimals_eq_minimals_of_subset_of_forall [IsTrans α r] (hts : t ⊆ s)
 
 theorem maximals_eq_maximals_of_subset_of_forall [IsTrans α r] (hts : t ⊆ s)
     (h : ∀ x ∈ s, ∃ y ∈ t, r x y) : maximals r s = maximals r t :=
-  @minimals_eq_minimals_of_subset_of_forall _ _ _ _ (IsAntisymm.swap r) (IsTrans.swap r) hts h
+  have := IsTrans.swap r
+  have := IsAntisymm.swap r
+  minimals_eq_minimals_of_subset_of_forall hts h
 
 variable (r s)
 
@@ -126,7 +128,7 @@ theorem maximals_antichain : IsAntichain r (maximals r s) := fun _a ha _b hb hab
   hab <| eq_of_mem_maximals ha hb.1 h
 
 theorem minimals_antichain : IsAntichain r (minimals r s) :=
-  haveI := IsAntisymm.swap r
+  have := IsAntisymm.swap r
   (maximals_antichain _ _).swap
 
 end IsAntisymm
@@ -280,6 +282,8 @@ section Image
 variable {f : α → β} {r : α → α → Prop} {s : β → β → Prop}
 
 section
+set_option debug.byAsSorry false
+
 variable {x : Set α} (hf : ∀ ⦃a a'⦄, a ∈ x → a' ∈ x → (r a a' ↔ s (f a) (f a'))) {a : α}
 
 theorem map_mem_minimals (ha : a ∈ minimals r x) : f a ∈ minimals s (f '' x) :=

--- a/Mathlib/Order/Minimal.lean
+++ b/Mathlib/Order/Minimal.lean
@@ -282,7 +282,6 @@ section Image
 variable {f : α → β} {r : α → α → Prop} {s : β → β → Prop}
 
 section
-set_option debug.byAsSorry false
 
 variable {x : Set α} (hf : ∀ ⦃a a'⦄, a ∈ x → a' ∈ x → (r a a' ↔ s (f a) (f a'))) {a : α}
 

--- a/Mathlib/Order/ModularLattice.lean
+++ b/Mathlib/Order/ModularLattice.lean
@@ -216,7 +216,7 @@ theorem sup_lt_sup_of_lt_of_inf_le_inf (hxy : x < y) (hinf : y ⊓ z ≤ x ⊓ z
     ne_of_lt hxy <| eq_of_le_of_inf_le_of_sup_le (le_of_lt hxy) hinf (le_of_eq hsup.symm)
 
 theorem inf_lt_inf_of_lt_of_sup_le_sup (hxy : x < y) (hinf : y ⊔ z ≤ x ⊔ z) : x ⊓ z < y ⊓ z :=
-  @sup_lt_sup_of_lt_of_inf_le_inf αᵒᵈ _ _ _ _ _ hxy hinf
+  sup_lt_sup_of_lt_of_inf_le_inf (α := αᵒᵈ) hxy hinf
 
 /-- A generalization of the theorem that if `N` is a submodule of `M` and
   `N` and `M / N` are both Artinian, then `M` is Artinian. -/
@@ -243,7 +243,8 @@ theorem wellFounded_gt_exact_sequence {β γ : Type*} [Preorder β] [PartialOrde
     (f₁ : β → α) (f₂ : α → β) (g₁ : γ → α) (g₂ : α → γ) (gci : GaloisCoinsertion f₁ f₂)
     (gi : GaloisInsertion g₂ g₁) (hf : ∀ a, f₁ (f₂ a) = a ⊓ K) (hg : ∀ a, g₁ (g₂ a) = a ⊔ K) :
     WellFounded ((· > ·) : α → α → Prop) :=
-  @wellFounded_lt_exact_sequence αᵒᵈ _ _ γᵒᵈ βᵒᵈ _ _ h₂ h₁ K g₁ g₂ f₁ f₂ gi.dual gci.dual hg hf
+  wellFounded_lt_exact_sequence (α := αᵒᵈ) (β := γᵒᵈ) (γ := βᵒᵈ)
+    h₂ h₁ K g₁ g₂ f₁ f₂ gi.dual gci.dual hg hf
 
 /-- The diamond isomorphism between the intervals `[a ⊓ b, a]` and `[b, a ⊔ b]` -/
 @[simps]


### PR DESCRIPTION
Followup to #14993.

Hopefully these are all independently positive or neutral.

These help get Mathlib compiling under `set_option debug.byAsSorry true`.