### PR TITLE
chore: remove or tweak outdated comments about 'when X is ported'

### DIFF
--- a/Mathlib/Analysis/Calculus/Deriv/AffineMap.lean
+++ b/Mathlib/Analysis/Calculus/Deriv/AffineMap.lean
@@ -15,8 +15,7 @@ from dimension 1 to a domain in higher dimension.
 
 ## TODO
 
-Add theorems about `deriv`s and `fderiv`s of `ContinuousAffineMap`s once they will be ported to
-Mathlib 4.
+Add theorems about `deriv`s and `fderiv`s of `ContinuousAffineMap`s.
 
 ## Keywords
 

--- a/Mathlib/Combinatorics/SimpleGraph/Regularity/Chunk.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Regularity/Chunk.lean
@@ -24,11 +24,6 @@ This entire file is internal to the proof of Szemerédi Regularity Lemma.
 * `SzemerediRegularity.edgeDensity_chunk_not_uniform`: `chunk` locally increases the edge density
   between non-uniform parts.
 
-## TODO
-
-Once ported to mathlib4, this file will be a great golfing ground for Heather's new tactic
-`gcongr`.
-
 ## References
 
 [Yaël Dillies, Bhavik Mehta, *Formalising Szemerédi’s Regularity Lemma in Lean*][srl_itp]

--- a/Mathlib/Combinatorics/SimpleGraph/Regularity/Increment.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Regularity/Increment.lean
@@ -23,11 +23,6 @@ This entire file is internal to the proof of Szemerédi Regularity Lemma.
 * `SzemerediRegularity.energy_increment`: The increment partition has energy greater than the
   original by a known (small) fixed amount.
 
-## TODO
-
-Once ported to mathlib4, this file will be a great golfing ground for Heather's new tactic
-`gcongr`.
-
 ## References
 
 [Yaël Dillies, Bhavik Mehta, *Formalising Szemerédi’s Regularity Lemma in Lean*][srl_itp]

--- a/Mathlib/Tactic/ApplyFun.lean
+++ b/Mathlib/Tactic/ApplyFun.lean
@@ -13,7 +13,7 @@ import Mathlib.Order.Hom.Basic
 Apply a function to an equality or inequality in either a local hypothesis or the goal.
 
 ## Porting notes
-When the `mono` tactic has been ported we can attempt to automatically discharge `Monotone f` goals.
+We can attempt to automatically discharge `Monotone f` goals using `mono`.
 -/
 
 namespace Mathlib.Tactic
@@ -52,8 +52,7 @@ def applyFunHyp (f : Term) (using? : Option Term) (h : FVarId) (g : MVarId) :
           | none => do
             let f ← elabTermForApply f
             let ng ← mkFreshExprMVar (← mkAppM ``Function.Injective #[f])
-            -- TODO attempt to solve this goal using `mono` when it has been ported,
-            -- via `synthesizeUsing`.
+            -- TODO attempt to solve this goal using `mono` via `synthesizeUsing`.
             pure (ng, [ng.mvarId!])
         pure (← mkAppM' (← mkAppM ``Function.Injective.ne #[injective_f]) #[d.toExpr], newGoals)
       | _ => throwError
@@ -66,8 +65,7 @@ def applyFunHyp (f : Term) (using? : Option Term) (h : FVarId) (g : MVarId) :
         | none => do
           let f ← elabTermForApply f
           let ng ← mkFreshExprMVar (← mkAppM ``StrictMono #[f])
-          -- TODO attempt to solve this goal using `mono` when it has been ported,
-          -- via `synthesizeUsing`.
+          -- TODO attempt to solve this goal using `mono`, via `synthesizeUsing`.
           pure (ng, [ng.mvarId!])
       pure (← mkAppM' strict_monotone_f #[d.toExpr], newGoals)
     | (``LE.le, _) =>
@@ -78,8 +76,7 @@ def applyFunHyp (f : Term) (using? : Option Term) (h : FVarId) (g : MVarId) :
         | none => do
           let f ← elabTermForApply f
           let ng ← mkFreshExprMVar (← mkAppM ``Monotone #[f])
-          -- TODO attempt to solve this goal using `mono` when it has been ported,
-          -- via `synthesizeUsing`.
+          -- TODO attempt to solve this goal using `mono`, via `synthesizeUsing`.
           pure (ng, [ng.mvarId!])
       pure (← mkAppM' monotone_f #[d.toExpr], newGoals)
     | _ => throwError

--- a/Mathlib/Topology/Algebra/Group/Basic.lean
+++ b/Mathlib/Topology/Algebra/Group/Basic.lean
@@ -401,7 +401,6 @@ continuous.
 When you declare an instance that does not already have a `UniformSpace` instance,
 you should also provide an instance of `UniformSpace` and `UniformGroup` using
 `TopologicalGroup.toUniformSpace` and `topologicalCommGroup_isUniform`. -/
--- Porting note: check that these ↑ names exist once they've been ported in the future.
 @[to_additive]
 class TopologicalGroup (G : Type*) [TopologicalSpace G] [Group G] extends ContinuousMul G,
   ContinuousInv G : Prop

--- a/test/CategoryTheory/Elementwise.lean
+++ b/test/CategoryTheory/Elementwise.lean
@@ -1,8 +1,6 @@
 import Mathlib.Tactic.CategoryTheory.Elementwise
 import Mathlib.Algebra.Category.MonCat.Basic
 
-set_option autoImplicit true
-
 namespace ElementwiseTest
 open CategoryTheory
 


### PR DESCRIPTION
- [x] depends on: #15219
- [x] depends on: #15221

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
