### PR TITLE
chore: fix theorem naming referencing `Units.oneSub`

### DIFF
--- a/Mathlib/Analysis/NormedSpace/Spectrum.lean
+++ b/Mathlib/Analysis/NormedSpace/Spectrum.lean
@@ -245,7 +245,7 @@ theorem eventually_isUnit_resolvent (a : A) : ∀ᶠ z in cobounded 𝕜, IsUnit
 theorem resolvent_isBigO_inv (a : A) : resolvent a =O[cobounded 𝕜] Inv.inv :=
   have h : (fun z ↦ resolvent (z⁻¹ • a) (1 : 𝕜)) =O[cobounded 𝕜] (fun _ ↦ (1 : ℝ)) := by
     simpa [Function.comp_def, resolvent] using
-      (NormedRing.inverse_one_sub_norm (R := A)).comp_tendsto
+      (NormedRing.inverse_oneSub_norm (R := A)).comp_tendsto
         (by simpa using (tendsto_inv₀_cobounded (α := 𝕜)).smul_const a)
   calc
     resolvent a =ᶠ[cobounded 𝕜] fun z ↦ z⁻¹ • resolvent (z⁻¹ • a) (1 : 𝕜) := by
@@ -298,7 +298,7 @@ theorem hasFPowerSeriesOnBall_inverse_one_sub_smul [CompleteSpace A] (a : A) :
           rwa [← coe_nnnorm, ← Real.lt_toNNReal_iff_coe_lt, Real.toNNReal_one, nnnorm_smul,
             ← NNReal.lt_inv_iff_mul_lt h]
       simpa [← smul_pow, (NormedRing.summable_geometric_of_norm_lt_one _ norm_lt).hasSum_iff] using
-        (NormedRing.inverse_one_sub _ norm_lt).symm }
+        (NormedRing.inverse_oneSub _ norm_lt).symm }
 
 variable {𝕜}
 

--- a/Mathlib/Analysis/NormedSpace/Units.lean
+++ b/Mathlib/Analysis/NormedSpace/Units.lean
@@ -98,7 +98,7 @@ open scoped Classical
 
 open Asymptotics Filter Metric Finset Ring
 
-theorem inverse_one_sub (t : R) (h : ‖t‖ < 1) : inverse (1 - t) = ↑(Units.oneSub t h)⁻¹ := by
+theorem inverse_oneSub (t : R) (h : ‖t‖ < 1) : inverse (1 - t) = ↑(Units.oneSub t h)⁻¹ := by
   rw [← inverse_unit (Units.oneSub t h), Units.val_oneSub]
 
 /-- The formula `Ring.inverse (x + t) = Ring.inverse (1 + x⁻¹ * t) * x⁻¹` holds for `t` sufficiently
@@ -112,17 +112,17 @@ theorem inverse_add (x : Rˣ) :
   rw [← x.val_add t ht, inverse_unit, Units.add, Units.copy_eq, mul_inv_rev, Units.val_mul,
     ← inverse_unit, Units.val_oneSub, sub_neg_eq_add]
 
-theorem inverse_one_sub_nth_order' (n : ℕ) {t : R} (ht : ‖t‖ < 1) :
+theorem inverse_oneSub_nth_order' (n : ℕ) {t : R} (ht : ‖t‖ < 1) :
     inverse ((1 : R) - t) = (∑ i ∈ range n, t ^ i) + t ^ n * inverse (1 - t) :=
   have := NormedRing.summable_geometric_of_norm_lt_one t ht
-  calc inverse (1 - t) = ∑' i : ℕ, t ^ i := inverse_one_sub t ht
+  calc inverse (1 - t) = ∑' i : ℕ, t ^ i := inverse_oneSub t ht
     _ = ∑ i ∈ range n, t ^ i + ∑' i : ℕ, t ^ (i + n) := (sum_add_tsum_nat_add _ this).symm
     _ = (∑ i ∈ range n, t ^ i) + t ^ n * inverse (1 - t) := by
-      simp only [inverse_one_sub t ht, add_comm _ n, pow_add, this.tsum_mul_left]; rfl
+      simp only [inverse_oneSub t ht, add_comm _ n, pow_add, this.tsum_mul_left]; rfl
 
-theorem inverse_one_sub_nth_order (n : ℕ) :
+theorem inverse_oneSub_nth_order (n : ℕ) :
     ∀ᶠ t in 𝓝 0, inverse ((1 : R) - t) = (∑ i ∈ range n, t ^ i) + t ^ n * inverse (1 - t) :=
-  Metric.eventually_nhds_iff.2 ⟨1, one_pos, fun t ht ↦ inverse_one_sub_nth_order' n <| by
+  Metric.eventually_nhds_iff.2 ⟨1, one_pos, fun t ht ↦ inverse_oneSub_nth_order' n <| by
     rwa [← dist_zero_right]⟩
 
 
@@ -135,19 +135,20 @@ theorem inverse_add_nth_order (x : Rˣ) (n : ℕ) :
       (∑ i ∈ range n, (-↑x⁻¹ * t) ^ i) * ↑x⁻¹ + (-↑x⁻¹ * t) ^ n * inverse (x + t) := by
   have hzero : Tendsto (-(↑x⁻¹ : R) * ·) (𝓝 0) (𝓝 0) :=
     (mulLeft_continuous _).tendsto' _ _ <| mul_zero _
-  filter_upwards [inverse_add x, hzero.eventually (inverse_one_sub_nth_order n)] with t ht ht'
+  filter_upwards [inverse_add x, hzero.eventually (inverse_oneSub_nth_order n)] with t ht ht'
   rw [neg_mul, sub_neg_eq_add] at ht'
   conv_lhs => rw [ht, ht', add_mul, ← neg_mul, mul_assoc]
   rw [ht]
 
-theorem inverse_one_sub_norm : (fun t : R => inverse (1 - t)) =O[𝓝 0] (fun _t => 1 : R → ℝ) := by
+theorem inverse_oneSub_norm : (fun t : R => inverse (1 - t)) =O[𝓝 0] (fun _t => 1 : R → ℝ) := by
+
   simp only [IsBigO, IsBigOWith, Metric.eventually_nhds_iff]
   refine ⟨‖(1 : R)‖ + 1, (2 : ℝ)⁻¹, by norm_num, fun t ht ↦ ?_⟩
   rw [dist_zero_right] at ht
   have ht' : ‖t‖ < 1 := by
     have : (2 : ℝ)⁻¹ < 1 := by cancel_denoms
     linarith
-  simp only [inverse_one_sub t ht', norm_one, mul_one, Set.mem_setOf_eq]
+  simp only [inverse_oneSub t ht', norm_one, mul_one, Set.mem_setOf_eq]
   change ‖∑' n : ℕ, t ^ n‖ ≤ _
   have := NormedRing.tsum_geometric_of_norm_lt_one t ht'
   have : (1 - ‖t‖)⁻¹ ≤ 2 := by
@@ -163,7 +164,7 @@ theorem inverse_add_norm (x : Rˣ) : (fun t : R => inverse (↑x + t)) =O[𝓝 0
   simp only [← sub_neg_eq_add, ← neg_mul]
   have hzero : Tendsto (-(↑x⁻¹ : R) * ·) (𝓝 0) (𝓝 0) :=
     (mulLeft_continuous _).tendsto' _ _ <| mul_zero _
-  exact (inverse_one_sub_norm.comp_tendsto hzero).mul (isBigO_const_const _ one_ne_zero _)
+  exact (inverse_oneSub_norm.comp_tendsto hzero).mul (isBigO_const_const _ one_ne_zero _)
 
 /-- The function
 `fun t ↦ Ring.inverse (x + t) - (∑ i ∈ Finset.range n, (- x⁻¹ * t) ^ i) * x⁻¹`

--- a/Mathlib/Analysis/NormedSpace/Units.lean
+++ b/Mathlib/Analysis/NormedSpace/Units.lean
@@ -101,6 +101,8 @@ open Asymptotics Filter Metric Finset Ring
 theorem inverse_oneSub (t : R) (h : ‖t‖ < 1) : inverse (1 - t) = ↑(Units.oneSub t h)⁻¹ := by
   rw [← inverse_unit (Units.oneSub t h), Units.val_oneSub]
 
+@[deprecated (since := "2024-07-25")] alias inverse_one_sub := inverse_oneSub
+
 /-- The formula `Ring.inverse (x + t) = Ring.inverse (1 + x⁻¹ * t) * x⁻¹` holds for `t` sufficiently
 small. -/
 theorem inverse_add (x : Rˣ) :
@@ -120,11 +122,14 @@ theorem inverse_oneSub_nth_order' (n : ℕ) {t : R} (ht : ‖t‖ < 1) :
     _ = (∑ i ∈ range n, t ^ i) + t ^ n * inverse (1 - t) := by
       simp only [inverse_oneSub t ht, add_comm _ n, pow_add, this.tsum_mul_left]; rfl
 
+@[deprecated (since := "2024-07-25")] alias inverse_one_sub_nth_order' := inverse_oneSub_nth_order'
+
 theorem inverse_oneSub_nth_order (n : ℕ) :
     ∀ᶠ t in 𝓝 0, inverse ((1 : R) - t) = (∑ i ∈ range n, t ^ i) + t ^ n * inverse (1 - t) :=
   Metric.eventually_nhds_iff.2 ⟨1, one_pos, fun t ht ↦ inverse_oneSub_nth_order' n <| by
     rwa [← dist_zero_right]⟩
 
+@[deprecated (since := "2024-07-25")] alias inverse_one_sub_nth_order := inverse_oneSub_nth_order
 
 /-- The formula
 `Ring.inverse (x + t) =
@@ -156,6 +161,8 @@ theorem inverse_oneSub_norm : (fun t : R => inverse (1 - t)) =O[𝓝 0] (fun _t 
     have : (2 : ℝ)⁻¹ + (2 : ℝ)⁻¹ = 1 := by ring
     linarith
   linarith
+
+@[deprecated (since := "2024-07-25")] alias inverse_one_sub_norm := inverse_oneSub_norm
 
 /-- The function `fun t ↦ inverse (x + t)` is O(1) as `t → 0`. -/
 theorem inverse_add_norm (x : Rˣ) : (fun t : R => inverse (↑x + t)) =O[𝓝 0] fun _t => (1 : ℝ) := by

--- a/Mathlib/Analysis/NormedSpace/Units.lean
+++ b/Mathlib/Analysis/NormedSpace/Units.lean
@@ -141,7 +141,6 @@ theorem inverse_add_nth_order (x : Rˣ) (n : ℕ) :
   rw [ht]
 
 theorem inverse_oneSub_norm : (fun t : R => inverse (1 - t)) =O[𝓝 0] (fun _t => 1 : R → ℝ) := by
-
   simp only [IsBigO, IsBigOWith, Metric.eventually_nhds_iff]
   refine ⟨‖(1 : R)‖ + 1, (2 : ℝ)⁻¹, by norm_num, fun t ht ↦ ?_⟩
   rw [dist_zero_right] at ht


### PR DESCRIPTION

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
