### PR TITLE
[Merged by Bors] - feat(FieldTheory/IntermediateField): add `Subfield.extendScalars`

### DIFF
--- a/Mathlib/FieldTheory/IntermediateField.lean
+++ b/Mathlib/FieldTheory/IntermediateField.lean
@@ -711,6 +711,8 @@ end ExtendScalars
 
 namespace IntermediateField
 
+variable {S}
+
 section Tower
 
 section Restrict

--- a/Mathlib/FieldTheory/IntermediateField.lean
+++ b/Mathlib/FieldTheory/IntermediateField.lean
@@ -636,7 +636,8 @@ theorem le_extendScalars_iff (E' : IntermediateField F L) :
 
 variable (F)
 
-/-- `Subfield.extendScalars` is an order isomorphism from
+/-- `Subfield.extendScalars.orderIso` bundles `Subfield.extendScalars`
+into an order isomorphism from
 `{ E : Subfield L // F ≤ E }` to `IntermediateField F L`. Its inverse is
 `IntermediateField.toSubfield`. -/
 @[simps]
@@ -688,7 +689,8 @@ theorem le_extendScalars_iff (E' : IntermediateField F L) :
 
 variable (F)
 
-/-- `IntermediateField.extendScalars` is an order isomorphism from
+/-- `IntermediateField.extendScalars.orderIso` bundles `IntermediateField.extendScalars`
+into an order isomorphism from
 `{ E : IntermediateField K L // F ≤ E }` to `IntermediateField F L`. Its inverse is
 `IntermediateField.restrictScalars`. -/
 @[simps]

--- a/Mathlib/FieldTheory/IntermediateField.lean
+++ b/Mathlib/FieldTheory/IntermediateField.lean
@@ -603,36 +603,35 @@ end RestrictScalars
 /-- This was formerly an instance called `lift2_alg`, but an instance above already provides it. -/
 example {F : IntermediateField K L} {E : IntermediateField F L} : Algebra K E := by infer_instance
 
+end Tower
+
+end IntermediateField
+
 section ExtendScalars
 
-section Subfield
-
-open Subfield
+namespace Subfield
 
 variable {F E E' : Subfield L} (h : F ≤ E) (h' : F ≤ E') {x : L}
 
 /-- If `F ≤ E` are two subfields of `L`, then `E` is also an intermediate field of
 `L / F`. It can be viewed as an inverse to `IntermediateField.toSubfield`. -/
-def _root_.Subfield.extendScalars : IntermediateField F L :=
-  E.toIntermediateField fun ⟨_, hf⟩ ↦ h hf
+def extendScalars : IntermediateField F L := E.toIntermediateField fun ⟨_, hf⟩ ↦ h hf
 
 @[simp]
-theorem _root_.Subfield.coe_extendScalars : (extendScalars h : Set L) = (E : Set L) := rfl
+theorem coe_extendScalars : (extendScalars h : Set L) = (E : Set L) := rfl
 
 @[simp]
-theorem _root_.Subfield.extendScalars_toSubfield : (extendScalars h).toSubfield = E :=
-  SetLike.coe_injective rfl
+theorem extendScalars_toSubfield : (extendScalars h).toSubfield = E := SetLike.coe_injective rfl
 
 @[simp]
-theorem _root_.Subfield.mem_extendScalars : x ∈ extendScalars h ↔ x ∈ E := Iff.rfl
+theorem mem_extendScalars : x ∈ extendScalars h ↔ x ∈ E := Iff.rfl
 
-theorem _root_.Subfield.extendScalars_le_extendScalars_iff :
-    extendScalars h ≤ extendScalars h' ↔ E ≤ E' := Iff.rfl
+theorem extendScalars_le_extendScalars_iff : extendScalars h ≤ extendScalars h' ↔ E ≤ E' := Iff.rfl
 
-theorem _root_.Subfield.extendScalars_le_iff (E' : IntermediateField F L) :
+theorem extendScalars_le_iff (E' : IntermediateField F L) :
     extendScalars h ≤ E' ↔ E ≤ E'.toSubfield := Iff.rfl
 
-theorem _root_.Subfield.le_extendScalars_iff (E' : IntermediateField F L) :
+theorem le_extendScalars_iff (E' : IntermediateField F L) :
     E' ≤ extendScalars h ↔ E'.toSubfield ≤ E := Iff.rfl
 
 variable (F)
@@ -640,7 +639,8 @@ variable (F)
 /-- `Subfield.extendScalars` is an order isomorphism from
 `{ E : Subfield L // F ≤ E }` to `IntermediateField F L`. Its inverse is
 `IntermediateField.toSubfield`. -/
-def _root_.Subfield.extendScalars.orderIso :
+@[simps]
+def extendScalars.orderIso :
     { E : Subfield L // F ≤ E } ≃o IntermediateField F L where
   toFun E := extendScalars E.2
   invFun E := ⟨E.toSubfield, fun x hx ↦ E.algebraMap_mem ⟨x, hx⟩⟩
@@ -650,11 +650,13 @@ def _root_.Subfield.extendScalars.orderIso :
     simp only [Equiv.coe_fn_mk]
     exact extendScalars_le_extendScalars_iff _ _
 
-theorem _root_.Subfield.extendScalars_injective :
+theorem extendScalars_injective :
     Function.Injective fun E : { E : Subfield L // F ≤ E } ↦ extendScalars E.2 :=
   (extendScalars.orderIso F).injective
 
 end Subfield
+
+namespace IntermediateField
 
 variable {F E E' : IntermediateField K L} (h : F ≤ E) (h' : F ≤ E') {x : L}
 
@@ -689,6 +691,7 @@ variable (F)
 /-- `IntermediateField.extendScalars` is an order isomorphism from
 `{ E : IntermediateField K L // F ≤ E }` to `IntermediateField F L`. Its inverse is
 `IntermediateField.restrictScalars`. -/
+@[simps]
 def extendScalars.orderIso : { E : IntermediateField K L // F ≤ E } ≃o IntermediateField F L where
   toFun E := extendScalars E.2
   invFun E := ⟨E.restrictScalars K, fun x hx ↦ E.algebraMap_mem ⟨x, hx⟩⟩
@@ -702,7 +705,13 @@ theorem extendScalars_injective :
     Function.Injective fun E : { E : IntermediateField K L // F ≤ E } ↦ extendScalars E.2 :=
   (extendScalars.orderIso F).injective
 
+end IntermediateField
+
 end ExtendScalars
+
+namespace IntermediateField
+
+section Tower
 
 section Restrict
 

--- a/Mathlib/FieldTheory/IntermediateField.lean
+++ b/Mathlib/FieldTheory/IntermediateField.lean
@@ -605,11 +605,63 @@ example {F : IntermediateField K L} {E : IntermediateField F L} : Algebra K E :=
 
 section ExtendScalars
 
+section Subfield
+
+open Subfield
+
+variable {F E E' : Subfield L} (h : F ≤ E) (h' : F ≤ E') {x : L}
+
+/-- If `F ≤ E` are two subfields of `L`, then `E` is also an intermediate field of
+`L / F`. It can be viewed as an inverse to `IntermediateField.toSubfield`. -/
+def _root_.Subfield.extendScalars : IntermediateField F L :=
+  E.toIntermediateField fun ⟨_, hf⟩ ↦ h hf
+
+@[simp]
+theorem _root_.Subfield.coe_extendScalars : (extendScalars h : Set L) = (E : Set L) := rfl
+
+@[simp]
+theorem _root_.Subfield.extendScalars_toSubfield : (extendScalars h).toSubfield = E :=
+  SetLike.coe_injective rfl
+
+@[simp]
+theorem _root_.Subfield.mem_extendScalars : x ∈ extendScalars h ↔ x ∈ E := Iff.rfl
+
+theorem _root_.Subfield.extendScalars_le_extendScalars_iff :
+    extendScalars h ≤ extendScalars h' ↔ E ≤ E' := Iff.rfl
+
+theorem _root_.Subfield.extendScalars_le_iff (E' : IntermediateField F L) :
+    extendScalars h ≤ E' ↔ E ≤ E'.toSubfield := Iff.rfl
+
+theorem _root_.Subfield.le_extendScalars_iff (E' : IntermediateField F L) :
+    E' ≤ extendScalars h ↔ E'.toSubfield ≤ E := Iff.rfl
+
+variable (F)
+
+/-- `Subfield.extendScalars` is an order isomorphism from
+`{ E : Subfield L // F ≤ E }` to `IntermediateField F L`. Its inverse is
+`IntermediateField.toSubfield`. -/
+def _root_.Subfield.extendScalars.orderIso :
+    { E : Subfield L // F ≤ E } ≃o IntermediateField F L where
+  toFun E := extendScalars E.2
+  invFun E := ⟨E.toSubfield, fun x hx ↦ E.algebraMap_mem ⟨x, hx⟩⟩
+  left_inv E := rfl
+  right_inv E := rfl
+  map_rel_iff' {E E'} := by
+    simp only [Equiv.coe_fn_mk]
+    exact extendScalars_le_extendScalars_iff _ _
+
+theorem _root_.Subfield.extendScalars_injective :
+    Function.Injective fun E : { E : Subfield L // F ≤ E } ↦ extendScalars E.2 :=
+  (extendScalars.orderIso F).injective
+
+end Subfield
+
 variable {F E E' : IntermediateField K L} (h : F ≤ E) (h' : F ≤ E') {x : L}
 
 /-- If `F ≤ E` are two intermediate fields of `L / K`, then `E` is also an intermediate field of
 `L / F`. It can be viewed as an inverse to `IntermediateField.restrictScalars`. -/
-def extendScalars : IntermediateField F L := E.toSubfield.toIntermediateField fun ⟨_, hf⟩ ↦ h hf
+def extendScalars : IntermediateField F L :=
+  Subfield.extendScalars (show F.toSubfield ≤ E.toSubfield from h)
 
 @[simp]
 theorem coe_extendScalars : (extendScalars h : Set L) = (E : Set L) := rfl


### PR DESCRIPTION
... which can be viewed as an inverse to `IntermediateField.toSubfield`.

This is similar to `IntermediateField.extendScalars`.

 
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
