### PR TITLE
[Merged by Bors] - feat(CategoryTheory/Limits): a pullback cone is limit iff it is so after the application of coyoneda.obj

### DIFF
--- a/Mathlib/CategoryTheory/Limits/Preserves/Shapes/Pullbacks.lean
+++ b/Mathlib/CategoryTheory/Limits/Preserves/Shapes/Pullbacks.lean
@@ -5,6 +5,8 @@ Authors: Bhavik Mehta, Andrew Yang
 -/
 import Mathlib.CategoryTheory.Limits.Shapes.Pullback.HasPullback
 import Mathlib.CategoryTheory.Limits.Preserves.Basic
+import Mathlib.CategoryTheory.Limits.Opposites
+import Mathlib.CategoryTheory.Limits.Yoneda
 
 /-!
 # Preserving pullbacks
@@ -37,6 +39,30 @@ section Pullback
 
 variable {C : Type u₁} [Category.{v₁} C]
 variable {D : Type u₂} [Category.{v₂} D]
+
+namespace PullbackCone
+
+variable {X Y Z : C} {f : X ⟶ Z} {g : Y ⟶ Z} (c : PullbackCone f g) (G : C ⥤ D)
+
+/-- The image of a pullback cone by a functor. -/
+abbrev map : PullbackCone (G.map f) (G.map g) :=
+  PullbackCone.mk (G.map c.fst) (G.map c.snd)
+    (by simpa using G.congr_map c.condition)
+
+/-- The map (as a cone) of a pullback cone is limit iff
+the map (as a pullback cone) is limit. -/
+def isLimitMapConeEquiv :
+    IsLimit (mapCone G c) ≃ IsLimit (c.map G) :=
+  (IsLimit.postcomposeHomEquiv (diagramIsoCospan.{v₂} _) _).symm.trans <|
+    IsLimit.equivIsoLimit <| by
+      refine PullbackCone.ext (Iso.refl _) ?_ ?_
+      · dsimp only [fst]
+        simp
+      · dsimp only [snd]
+        simp
+
+end PullbackCone
+
 variable (G : C ⥤ D)
 variable {W X Y Z : C} {f : X ⟶ Z} {g : Y ⟶ Z} {h : W ⟶ X} {k : W ⟶ Y} (comm : h ≫ f = k ≫ g)
 
@@ -47,23 +73,21 @@ def isLimitMapConePullbackConeEquiv :
       IsLimit
         (PullbackCone.mk (G.map h) (G.map k) (by simp only [← G.map_comp, comm]) :
           PullbackCone (G.map f) (G.map g)) :=
-  (IsLimit.postcomposeHomEquiv (diagramIsoCospan.{v₂} _) _).symm.trans <|
-    IsLimit.equivIsoLimit <|
-      Cones.ext (Iso.refl _) <| by
-        rintro (_ | _ | _) <;> dsimp <;> simp only [comp_id, id_comp, G.map_comp]
+  (PullbackCone.mk _ _ comm).isLimitMapConeEquiv G
 
 /-- The property of preserving pullbacks expressed in terms of binary fans. -/
 def isLimitPullbackConeMapOfIsLimit [PreservesLimit (cospan f g) G]
     (l : IsLimit (PullbackCone.mk h k comm)) :
     have : G.map h ≫ G.map f = G.map k ≫ G.map g := by rw [← G.map_comp, ← G.map_comp,comm]
     IsLimit (PullbackCone.mk (G.map h) (G.map k) this) :=
-  isLimitMapConePullbackConeEquiv G comm (PreservesLimit.preserves l)
+  (PullbackCone.isLimitMapConeEquiv _ G).1 (PreservesLimit.preserves l)
 
 /-- The property of reflecting pullbacks expressed in terms of binary fans. -/
 def isLimitOfIsLimitPullbackConeMap [ReflectsLimit (cospan f g) G]
     (l : IsLimit (PullbackCone.mk (G.map h) (G.map k) (show G.map h ≫ G.map f = G.map k ≫ G.map g
     from by simp only [← G.map_comp,comm]))) : IsLimit (PullbackCone.mk h k comm) :=
-  ReflectsLimit.reflects ((isLimitMapConePullbackConeEquiv G comm).symm l)
+  ReflectsLimit.reflects
+    ((PullbackCone.isLimitMapConeEquiv (PullbackCone.mk _ _ comm) G).2 l)
 
 variable (f g) [PreservesLimit (cospan f g) G]
 
@@ -126,12 +150,42 @@ theorem PreservesPullback.iso_inv_snd :
     (PreservesPullback.iso G f g).inv ≫ G.map (pullback.snd f g) = pullback.snd _ _ := by
   simp [PreservesPullback.iso, Iso.inv_comp_eq]
 
+/-- A pullback cone in `C` is limit iff if it is so after the application
+of `coyoneda.obj X` for all `X : Cᵒᵖ`. -/
+def PullbackCone.isLimitCoyonedaEquiv (c : PullbackCone f g) :
+    IsLimit c ≃ ∀ (X : Cᵒᵖ), IsLimit (c.map (coyoneda.obj X)) :=
+  (Cone.isLimitCoyonedaEquiv c).trans
+    (Equiv.piCongrRight (fun X ↦ c.isLimitMapConeEquiv (coyoneda.obj X)))
+
 end Pullback
 
 section Pushout
 
 variable {C : Type u₁} [Category.{v₁} C]
 variable {D : Type u₂} [Category.{v₂} D]
+
+namespace PushoutCocone
+
+variable {W X Y : C} {f : W ⟶ X} {g : W ⟶ Y} (c : PushoutCocone f g) (G : C ⥤ D)
+
+/-- The image of a pullback cone by a functor. -/
+abbrev map : PushoutCocone (G.map f) (G.map g) :=
+  PushoutCocone.mk (G.map c.inl) (G.map c.inr) (by simpa using G.congr_map c.condition)
+
+/-- The map (as a cocone) of a pushout cocone is colimit iff
+the map (as a pushout cocone) is limit. -/
+def isColimitMapCoconeEquiv :
+    IsColimit (mapCocone G c) ≃ IsColimit (c.map G) :=
+  (IsColimit.precomposeHomEquiv (diagramIsoSpan.{v₂} _).symm _).symm.trans <|
+    IsColimit.equivIsoColimit <| by
+      refine PushoutCocone.ext (Iso.refl _) ?_ ?_
+      · dsimp only [inl]
+        simp
+      · dsimp only [inr]
+        simp
+
+end PushoutCocone
+
 variable (G : C ⥤ D)
 variable {W X Y Z : C} {h : X ⟶ Z} {k : Y ⟶ Z} {f : W ⟶ X} {g : W ⟶ Y} (comm : f ≫ h = g ≫ k)
 
@@ -271,6 +325,19 @@ variable [PreservesColimit (span f g) G]
 instance : IsIso (pushoutComparison G f g) := by
   rw [← PreservesPushout.iso_hom]
   infer_instance
+
+/-- A pushout cocone in `C` is colimit iff it becomes limit
+after the application of `yoneda.obj X` for all `X : C`. -/
+def PushoutCocone.isColimitYonedaEquiv (c : PushoutCocone f g) :
+    IsColimit c ≃ ∀ (X : C), IsLimit (c.op.map (yoneda.obj X)) :=
+  (Limits.Cocone.isColimitYonedaEquiv c).trans
+    (Equiv.piCongrRight (fun X ↦
+      (IsLimit.whiskerEquivalenceEquiv walkingSpanOpEquiv.symm).trans
+        ((IsLimit.postcomposeHomEquiv
+          (isoWhiskerRight (cospanOp f g).symm (yoneda.obj X)) _).symm.trans
+            (Equiv.trans (IsLimit.equivIsoLimit
+              (by exact Cones.ext (Iso.refl _) (by rintro (_|_|_) <;> simp)))
+                (c.op.isLimitMapConeEquiv (yoneda.obj X))))))
 
 end Pushout
 

--- a/Mathlib/CategoryTheory/Limits/Yoneda.lean
+++ b/Mathlib/CategoryTheory/Limits/Yoneda.lean
@@ -107,6 +107,15 @@ def yonedaJointlyReflectsLimits (F : J ⥤ Cᵒᵖ) (c : Cone F)
     dsimp [Types.isLimitEquivSections, Types.sectionOfCone]
     rw [eq, Category.comp_id, ← hm, unop_comp])
 
+/-- A cocone is colimit iff it becomes limit after the
+application of `yoneda.obj X` for all `X : C`. -/
+noncomputable def Limits.Cocone.isColimitYonedaEquiv {F : J ⥤ C} (c : Cocone F) :
+    IsColimit c ≃ ∀ (X : C), IsLimit ((yoneda.obj X).mapCone c.op) where
+  toFun h X := isLimitOfPreserves _ h.op
+  invFun h := IsLimit.unop (yonedaJointlyReflectsLimits _ _ h)
+  left_inv _ := Subsingleton.elim _ _
+  right_inv _ := by ext; apply Subsingleton.elim
+
 /-- The cone of `F` corresponding to an element in `(F ⋙ coyoneda.obj X).sections`. -/
 @[simps]
 def Limits.coneOfSectionCompCoyoneda (F : J ⥤ C) (X : Cᵒᵖ)
@@ -139,6 +148,14 @@ def coyonedaJointlyReflectsLimits (F : J ⥤ C) (c : Cone F)
     have eq := congr_fun ((hc (op s.pt)).fac ((coyoneda.obj (op s.pt)).mapCone s) j) (𝟙 _)
     dsimp at eq
     rw [eq, Category.id_comp, ← hm]
+
+/-- A cone is limit iff it is so after the application of `coyoneda.obj X` for all `X : Cᵒᵖ`. -/
+noncomputable def Limits.Cone.isLimitCoyonedaEquiv {F : J ⥤ C} (c : Cone F) :
+    IsLimit c ≃ ∀ (X : Cᵒᵖ), IsLimit ((coyoneda.obj X).mapCone c) where
+  toFun h X := isLimitOfPreserves _ h
+  invFun h := coyonedaJointlyReflectsLimits _ _ h
+  left_inv _ := Subsingleton.elim _ _
+  right_inv _ := by ext; apply Subsingleton.elim
 
 end
 


### PR DESCRIPTION


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
