### PR TITLE
feat: checkAsSorry linter

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -4088,6 +4088,7 @@ import Mathlib.Tactic.Linarith.Preprocessing
 import Mathlib.Tactic.Linarith.Verification
 import Mathlib.Tactic.LinearCombination
 import Mathlib.Tactic.Linter
+import Mathlib.Tactic.Linter.CheckAsSorry
 import Mathlib.Tactic.Linter.GlobalAttributeIn
 import Mathlib.Tactic.Linter.HashCommandLinter
 import Mathlib.Tactic.Linter.Lint

--- a/Mathlib/Tactic.lean
+++ b/Mathlib/Tactic.lean
@@ -116,6 +116,7 @@ import Mathlib.Tactic.Linarith.Preprocessing
 import Mathlib.Tactic.Linarith.Verification
 import Mathlib.Tactic.LinearCombination
 import Mathlib.Tactic.Linter
+import Mathlib.Tactic.Linter.CheckAsSorry
 import Mathlib.Tactic.Linter.GlobalAttributeIn
 import Mathlib.Tactic.Linter.HashCommandLinter
 import Mathlib.Tactic.Linter.Lint

--- a/Mathlib/Tactic/Linter/CheckAsSorry.lean
+++ b/Mathlib/Tactic/Linter/CheckAsSorry.lean
@@ -49,7 +49,10 @@ def checkAsSorryLinter : Linter where run := withSetOptionIn fun stx ↦ do
       if let some (newCmd, id) ← toExample stx then
         let declName ← resolveGlobalConstNoOverload id
         let refType := (((← getEnv).find? declName).getD default).type
-        withScope (fun _ => { sc with currNamespace := ns }) do
+        let newScope := { sc with
+          currNamespace := ns
+          openDecls := (.simple sc.currNamespace [])::sc.openDecls }
+        withScope (fun _ => newScope) do
           let s ← modifyGet fun st => (st, { st with messages := {} })
           elabCommand newCmd
           let _ ← modifyGet fun st => (s, { st with messages := s.messages })

--- a/Mathlib/Tactic/Linter/CheckAsSorry.lean
+++ b/Mathlib/Tactic/Linter/CheckAsSorry.lean
@@ -1,0 +1,84 @@
+import Lean.Linter.Util
+import Lean.Elab.Command
+import Mathlib.Tactic.Lemma
+
+/-!
+#  The "checkAsSorry" linter
+
+The "checkAsSorry" linter emits a warning when replacing the proof of a `theorem` or `lemma` by
+`sorry` yields a declaration whose type is not equal to the original declaration.
+-/
+
+open Lean Elab Command
+
+namespace Mathlib.Linter
+
+/-- The "checkAsSorry" linter emits a warning when there are multiple active goals. -/
+register_option linter.checkAsSorry : Bool := {
+  defValue := true
+  descr := "enable the checkAsSorry linter"
+}
+
+def toExample {m : Type → Type} [Monad m] [MonadRef m] [MonadQuotation m] :
+    Syntax → m (Option (Syntax × Syntax))
+  | `($dm:declModifiers theorem $did:declId $ds* : $t := $_t:term) => do
+    return some (← `($dm:declModifiers theorem $did $ds* : $t := sorry), did.raw[0])
+  | `($dm:declModifiers lemma $did:declId $ds* : $t := $_t:term) => do
+    return some (← `($dm:declModifiers lemma $did $ds* : $t := sorry), did.raw[0])
+--  | `($dm:declModifiers example $ds:optDeclSig $dv:declVal) => do
+--    return some (← `($dm:declModifiers example $ds $dv:declVal), mkIdent `example)
+  | _ => return none
+
+namespace CheckAsSorry
+#check Parser.Command.declaration
+/-- Gets the value of the `linter.checkAsSorry` option. -/
+def getLinterHash (o : Options) : Bool := Linter.getLinterValue linter.checkAsSorry o
+
+@[inherit_doc Mathlib.Linter.linter.checkAsSorry]
+def checkAsSorryLinter : Linter where run := withSetOptionIn fun stx ↦ do
+    unless getLinterHash (← getOptions) do
+      return
+    if (← MonadState.get).messages.hasErrors then
+      return
+    if let some stx := stx.find? ([`lemma, ``Lean.Parser.Command.declaration].contains ·.getKind) then
+      --dbg_trace "found declaration"
+      let nm ← liftCoreM do mkFreshUserName `asSorry
+      let sc ← getScope
+      let ns := sc.currNamespace ++ nm
+      if let some (newCmd, id) ← toExample stx then
+        let declName ← resolveGlobalConstNoOverload id
+        let refType := (((← getEnv).find? declName).getD default).type
+        withScope (fun _ => { sc with currNamespace := ns }) do
+          let s ← modifyGet fun st => (st, { st with messages := {} })
+          --elabCommandTopLevel newCmd
+          elabCommand newCmd
+          let _ ← modifyGet fun st => (s, { st with messages := s.messages })
+
+
+
+          match (← getEnv).find? (ns ++ id.getId) with
+            | none => logWarningAt id "could not find the 'asSorried' declaration"
+            | some decl =>
+              if refType == decl.type then
+                return --logInfoAt id m!"'{declName}' works"
+              else
+                let defEq? := ← liftCoreM do
+                  let (a, _b) ← Meta.MetaM.run do Meta.isDefEq refType decl.type
+                  return a
+                if defEq? then
+                  Linter.logLint linter.checkAsSorry id
+                    m!"'{declName}' is not equal but is defeq to its 'asSorry'ed version.\n\
+                        actual type:      '{refType}'\n\
+                        'asSorry'ed type: '{decl.type}'"
+                else
+                  logErrorAt stx ""
+                  Linter.logLint linter.checkAsSorry id
+                    m!"'{declName}' is not defeq to its 'asSorry'ed version\n\
+                        actual type:      '{refType}'\n\
+                        'asSorry'ed type: '{decl.type}'"
+
+initialize addLinter checkAsSorryLinter
+
+end CheckAsSorry
+
+end Mathlib.Linter

--- a/test/CheckAsSorry.lean
+++ b/test/CheckAsSorry.lean
@@ -1,0 +1,34 @@
+import Mathlib.Tactic.Linter.CheckAsSorry
+
+set_option linter.checkAsSorry false
+
+namespace X
+
+/--
+error: ⏎
+---
+warning: 'X.heq0' is not defeq to its 'asSorry'ed version
+actual type:      '∀ {a b : Nat}, a = b → a = b'
+'asSorry'ed type: '∀ {α : Sort u_1} {a b : α}, a = b'
+note: this linter can be disabled with `set_option linter.checkAsSorry false`
+-/
+#guard_msgs in
+set_option linter.checkAsSorry true in
+variable {a b : Nat} (h : a = b) in
+lemma heq0 : a = b := by exact h
+
+/-- warning: declaration uses 'sorry' -/
+#guard_msgs in
+set_option linter.checkAsSorry true in
+/-- doc-string -/
+nonrec
+theorem heq1 {a b : Nat} (h : a = b) : a = b := sorry --by exact h
+
+#guard_msgs in
+set_option linter.checkAsSorry true in
+lemma heq2 {a b : Nat} (h : a = b) : a = b := by exact h
+
+/-- warning: declaration uses 'sorry' -/
+#guard_msgs in
+set_option linter.checkAsSorry true in
+lemma heq3 {a b : Nat} (h : a = b) : a = b := sorry


### PR DESCRIPTION
A very preliminary version of the `checkAsSorry` linter.
It flags declarations whose type is not equal to the 'asSorry'ed one.

[Zulip discussion](https://leanprover.zulipchat.com/#narrow/stream/287929-mathlib4/topic/Running.20Mathlib.20under.20.60set_option.20debug.2EbyAsSorry.60)

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
