### PR TITLE
feat (Analysis/NormedSpace/Equidecomposability): Definition of Equidecomposability

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -1062,6 +1062,7 @@ import Mathlib.Analysis.Convolution
 import Mathlib.Analysis.Distribution.AEEqOfIntegralContDiff
 import Mathlib.Analysis.Distribution.FourierSchwartz
 import Mathlib.Analysis.Distribution.SchwartzSpace
+import Mathlib.Analysis.Equidecomposability
 import Mathlib.Analysis.Fourier.AddCircle
 import Mathlib.Analysis.Fourier.FourierTransform
 import Mathlib.Analysis.Fourier.FourierTransformDeriv

--- a/Mathlib/Analysis/Equidecomposability.lean
+++ b/Mathlib/Analysis/Equidecomposability.lean
@@ -1,7 +1,9 @@
 import Mathlib.Analysis.NormedSpace.AffineIsometry
 import Mathlib.Order.Partition.Finpartition
 
-
+/-
+Definition of Equidecomposability
+-/
 open Function
 
 variable (𝕜 : Type*) {V: Type*}(P: Type*)

--- a/Mathlib/Analysis/Equidecomposability.lean
+++ b/Mathlib/Analysis/Equidecomposability.lean
@@ -1,3 +1,9 @@
+/-
+Copyright (c) 2024 Chiara Cimino. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Chiara Cimino, Christian Krause, Victoria Schleis
+-/
+
 import Mathlib.Analysis.NormedSpace.AffineIsometry
 import Mathlib.Order.Partition.Finpartition
 

--- a/Mathlib/Analysis/Equidecomposability.lean
+++ b/Mathlib/Analysis/Equidecomposability.lean
@@ -1,7 +1,7 @@
 import Mathlib.Analysis.NormedSpace.AffineIsometry
 import Mathlib.Order.Partition.Finpartition
 
-/-
+/-!
 Definition of Equidecomposability
 -/
 open Function
@@ -10,7 +10,7 @@ variable (𝕜 : Type*) {V: Type*}(P: Type*)
   [NormedField 𝕜]
   [SeminormedAddCommGroup V] [NormedSpace 𝕜 V] [PseudoMetricSpace P] [NormedAddTorsor V P]
 
-/-
+/--
 Two subsets B₁ B₂ of a pseudometric space P are equidecomposable if B₁ and B₂ can be divided into
 finitely many affinely isometric parts.
 -/

--- a/Mathlib/Analysis/Equidecomposability.lean
+++ b/Mathlib/Analysis/Equidecomposability.lean
@@ -1,0 +1,20 @@
+import Mathlib.Analysis.NormedSpace.AffineIsometry
+import Mathlib.Order.Partition.Finpartition
+
+
+open Function
+
+variable (𝕜 : Type*) {V: Type*}(P: Type*)
+  [NormedField 𝕜]
+  [SeminormedAddCommGroup V] [NormedSpace 𝕜 V] [PseudoMetricSpace P] [NormedAddTorsor V P]
+
+/-
+Two subsets B₁ B₂ of a pseudometric space P are equidecomposable if B₁ and B₂ can be divided into
+finitely many affinely isometric parts.
+-/
+def equidecomposable (B₁ B₂ : Set P) : Prop :=
+  ∃ (P_B₁ : Finpartition B₁), ∃ (P_B₂ : Finpartition B₂), ∃ (f : P_B₁.parts → P_B₂.parts),
+    P_B₂.parts.val.sizeOf = P_B₁.parts.val.sizeOf ∧
+  Bijective f ∧ (∀ p_b₁ : P_B₁.parts, ∃ (a : AffineIsometry 𝕜 P P),
+    ∀ x ∈ p_b₁.val, ∃ y ∈ (f p_b₁).val, a.toFun x = y ∧
+    ∀ y ∈ (f p_b₁).val, ∃ x ∈ p_b₁.val, a.toFun x = y)


### PR DESCRIPTION
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
