### PR TITLE
[Merged by Bors] - chore: robustifying for debug.byAsSorry (part 11)

### DIFF
--- a/Mathlib/Algebra/Category/Grp/Kernels.lean
+++ b/Mathlib/Algebra/Category/Grp/Kernels.lean
@@ -42,6 +42,6 @@ def cokernelIsColimit : IsColimit <| cokernelCocone f :=
     (fun s => lift _ _ <| (range_le_ker_iff _ _).mpr <| CokernelCofork.condition s)
     (fun _ => rfl)
     (fun _ _ h => have : Epi (cokernelCocone f).π := (epi_iff_surjective _).mpr <| mk'_surjective _
-      (cancel_epi _).mp <| by simpa only [parallelPair_obj_one] using h)
+      (cancel_epi (cokernelCocone f).π).mp <| by simpa only [parallelPair_obj_one] using h)
 
 end AddCommGrp

--- a/Mathlib/Algebra/Exact.lean
+++ b/Mathlib/Algebra/Exact.lean
@@ -111,7 +111,7 @@ variable {X₁ X₂ X₃ Y₁ Y₂ Y₃ : Type*} [AddCommMonoid X₁] [AddCommMo
   {f₁₂ : X₁ →+ X₂} {f₂₃ : X₂ →+ X₃} {g₁₂ : Y₁ →+ Y₂} {g₂₃ : Y₂ →+ Y₃}
 
 lemma of_ladder_addEquiv_of_exact (comm₁₂ : g₁₂.comp e₁ = AddMonoidHom.comp e₂ f₁₂)
-  (comm₂₃ : g₂₃.comp e₂ = AddMonoidHom.comp e₃ f₂₃) (H : Exact f₁₂ f₂₃) : Exact g₁₂ g₂₃ := by
+    (comm₂₃ : g₂₃.comp e₂ = AddMonoidHom.comp e₃ f₂₃) (H : Exact f₁₂ f₂₃) : Exact g₁₂ g₂₃ := by
   have h₁₂ := DFunLike.congr_fun comm₁₂
   have h₂₃ := DFunLike.congr_fun comm₂₃
   dsimp at h₁₂ h₂₃
@@ -126,7 +126,7 @@ lemma of_ladder_addEquiv_of_exact (comm₁₂ : g₁₂.comp e₁ = AddMonoidHom
     exact ⟨e₁ x₁, by rw [h₁₂]⟩
 
 lemma of_ladder_addEquiv_of_exact' (comm₁₂ : g₁₂.comp e₁ = AddMonoidHom.comp e₂ f₁₂)
-  (comm₂₃ : g₂₃.comp e₂ = AddMonoidHom.comp e₃ f₂₃) (H : Exact g₁₂ g₂₃) : Exact f₁₂ f₂₃ := by
+    (comm₂₃ : g₂₃.comp e₂ = AddMonoidHom.comp e₃ f₂₃) (H : Exact g₁₂ g₂₃) : Exact f₁₂ f₂₃ := by
   refine of_ladder_addEquiv_of_exact e₁.symm e₂.symm e₃.symm ?_ ?_ H
   · ext y₁
     obtain ⟨x₁, rfl⟩ := e₁.surjective y₁
@@ -138,7 +138,7 @@ lemma of_ladder_addEquiv_of_exact' (comm₁₂ : g₁₂.comp e₁ = AddMonoidHo
     simpa using DFunLike.congr_fun comm₂₃.symm x₂
 
 lemma iff_of_ladder_addEquiv (comm₁₂ : g₁₂.comp e₁ = AddMonoidHom.comp e₂ f₁₂)
-  (comm₂₃ : g₂₃.comp e₂ = AddMonoidHom.comp e₃ f₂₃) : Exact g₁₂ g₂₃ ↔ Exact f₁₂ f₂₃ := by
+    (comm₂₃ : g₂₃.comp e₂ = AddMonoidHom.comp e₃ f₂₃) : Exact g₁₂ g₂₃ ↔ Exact f₁₂ f₂₃ := by
   constructor
   · exact of_ladder_addEquiv_of_exact' e₁ e₂ e₃ comm₁₂ comm₂₃
   · exact of_ladder_addEquiv_of_exact e₁ e₂ e₃ comm₁₂ comm₂₃

--- a/Mathlib/Algebra/Exact.lean
+++ b/Mathlib/Algebra/Exact.lean
@@ -109,10 +109,9 @@ variable {X₁ X₂ X₃ Y₁ Y₂ Y₃ : Type*} [AddCommMonoid X₁] [AddCommMo
   [AddCommMonoid Y₁] [AddCommMonoid Y₂] [AddCommMonoid Y₃]
   (e₁ : X₁ ≃+ Y₁) (e₂ : X₂ ≃+ Y₂) (e₃ : X₃ ≃+ Y₃)
   {f₁₂ : X₁ →+ X₂} {f₂₃ : X₂ →+ X₃} {g₁₂ : Y₁ →+ Y₂} {g₂₃ : Y₂ →+ Y₃}
-  (comm₁₂ : g₁₂.comp e₁ = AddMonoidHom.comp e₂ f₁₂)
-  (comm₂₃ : g₂₃.comp e₂ = AddMonoidHom.comp e₃ f₂₃)
 
-lemma of_ladder_addEquiv_of_exact (H : Exact f₁₂ f₂₃) : Exact g₁₂ g₂₃ := by
+lemma of_ladder_addEquiv_of_exact (comm₁₂ : g₁₂.comp e₁ = AddMonoidHom.comp e₂ f₁₂)
+  (comm₂₃ : g₂₃.comp e₂ = AddMonoidHom.comp e₃ f₂₃) (H : Exact f₁₂ f₂₃) : Exact g₁₂ g₂₃ := by
   have h₁₂ := DFunLike.congr_fun comm₁₂
   have h₂₃ := DFunLike.congr_fun comm₂₃
   dsimp at h₁₂ h₂₃
@@ -126,7 +125,8 @@ lemma of_ladder_addEquiv_of_exact (H : Exact f₁₂ f₂₃) : Exact g₁₂ g�
     obtain ⟨x₁, rfl⟩ := (H x₂).1 (e₃.injective (by rw [← h₂₃, hx₂, map_zero]))
     exact ⟨e₁ x₁, by rw [h₁₂]⟩
 
-lemma of_ladder_addEquiv_of_exact' (H : Exact g₁₂ g₂₃) : Exact f₁₂ f₂₃ := by
+lemma of_ladder_addEquiv_of_exact' (comm₁₂ : g₁₂.comp e₁ = AddMonoidHom.comp e₂ f₁₂)
+  (comm₂₃ : g₂₃.comp e₂ = AddMonoidHom.comp e₃ f₂₃) (H : Exact g₁₂ g₂₃) : Exact f₁₂ f₂₃ := by
   refine of_ladder_addEquiv_of_exact e₁.symm e₂.symm e₃.symm ?_ ?_ H
   · ext y₁
     obtain ⟨x₁, rfl⟩ := e₁.surjective y₁
@@ -137,7 +137,8 @@ lemma of_ladder_addEquiv_of_exact' (H : Exact g₁₂ g₂₃) : Exact f₁₂ f
     apply e₃.injective
     simpa using DFunLike.congr_fun comm₂₃.symm x₂
 
-lemma iff_of_ladder_addEquiv : Exact g₁₂ g₂₃ ↔ Exact f₁₂ f₂₃ := by
+lemma iff_of_ladder_addEquiv (comm₁₂ : g₁₂.comp e₁ = AddMonoidHom.comp e₂ f₁₂)
+  (comm₂₃ : g₂₃.comp e₂ = AddMonoidHom.comp e₃ f₂₃) : Exact g₁₂ g₂₃ ↔ Exact f₁₂ f₂₃ := by
   constructor
   · exact of_ladder_addEquiv_of_exact' e₁ e₂ e₃ comm₁₂ comm₂₃
   · exact of_ladder_addEquiv_of_exact e₁ e₂ e₃ comm₁₂ comm₂₃

--- a/Mathlib/Algebra/Homology/ShortComplex/Exact.lean
+++ b/Mathlib/Algebra/Homology/ShortComplex/Exact.lean
@@ -703,37 +703,35 @@ variable [Balanced C]
 
 namespace Exact
 
-variable (hS : S.Exact)
-
-lemma isIso_f' (h : S.LeftHomologyData) [Mono S.f] :
+lemma isIso_f' (hS : S.Exact) (h : S.LeftHomologyData) [Mono S.f] :
     IsIso h.f' := by
   have := hS.epi_f' h
   have := mono_of_mono_fac h.f'_i
   exact isIso_of_mono_of_epi h.f'
 
-lemma isIso_toCycles [Mono S.f] [S.HasLeftHomology] :
+lemma isIso_toCycles (hS : S.Exact) [Mono S.f] [S.HasLeftHomology]:
     IsIso S.toCycles :=
   hS.isIso_f' _
 
-lemma isIso_g' (h : S.RightHomologyData) [Epi S.g] :
+lemma isIso_g' (hS : S.Exact) (h : S.RightHomologyData) [Epi S.g] :
     IsIso h.g' := by
   have := hS.mono_g' h
   have := epi_of_epi_fac h.p_g'
   exact isIso_of_mono_of_epi h.g'
 
-lemma isIso_fromOpcycles [Epi S.g] [S.HasRightHomology] :
+lemma isIso_fromOpcycles (hS : S.Exact) [Epi S.g] [S.HasRightHomology] :
     IsIso S.fromOpcycles :=
   hS.isIso_g' _
 
 /-- In a balanced category, if a short complex `S` is exact and `S.f` is a mono, then
 `S.X₁` is the kernel of `S.g`. -/
-noncomputable def fIsKernel [Mono S.f] : IsLimit (KernelFork.ofι S.f S.zero) := by
+noncomputable def fIsKernel (hS : S.Exact) [Mono S.f] : IsLimit (KernelFork.ofι S.f S.zero) := by
   have := hS.hasHomology
   have := hS.isIso_toCycles
   exact IsLimit.ofIsoLimit S.cyclesIsKernel
     (Fork.ext (asIso S.toCycles).symm (by simp))
 
-lemma map_of_mono_of_preservesKernel (F : C ⥤ D)
+lemma map_of_mono_of_preservesKernel (hS : S.Exact) (F : C ⥤ D)
     [F.PreservesZeroMorphisms] [(S.map F).HasHomology] (_ : Mono S.f)
     (_ : PreservesLimit (parallelPair S.g 0) F) :
     (S.map F).Exact :=
@@ -741,13 +739,14 @@ lemma map_of_mono_of_preservesKernel (F : C ⥤ D)
 
 /-- In a balanced category, if a short complex `S` is exact and `S.g` is an epi, then
 `S.X₃` is the cokernel of `S.g`. -/
-noncomputable def gIsCokernel [Epi S.g] : IsColimit (CokernelCofork.ofπ S.g S.zero) := by
+noncomputable def gIsCokernel (hS : S.Exact) [Epi S.g] :
+    IsColimit (CokernelCofork.ofπ S.g S.zero) := by
   have := hS.hasHomology
   have := hS.isIso_fromOpcycles
   exact IsColimit.ofIsoColimit S.opcyclesIsCokernel
     (Cofork.ext (asIso S.fromOpcycles) (by simp))
 
-lemma map_of_epi_of_preservesCokernel (F : C ⥤ D)
+lemma map_of_epi_of_preservesCokernel (hS : S.Exact) (F : C ⥤ D)
     [F.PreservesZeroMorphisms] [(S.map F).HasHomology] (_ : Epi S.g)
     (_ : PreservesColimit (parallelPair S.f 0) F) :
     (S.map F).Exact :=
@@ -755,29 +754,29 @@ lemma map_of_epi_of_preservesCokernel (F : C ⥤ D)
 
 /-- If a short complex `S` in a balanced category is exact and such that `S.f` is a mono,
 then a morphism `k : A ⟶ S.X₂` such that `k ≫ S.g = 0` lifts to a morphism `A ⟶ S.X₁`. -/
-noncomputable def lift {A : C} (k : A ⟶ S.X₂) (hk : k ≫ S.g = 0) [Mono S.f] :
+noncomputable def lift (hS : S.Exact) {A : C} (k : A ⟶ S.X₂) (hk : k ≫ S.g = 0) [Mono S.f] :
     A ⟶ S.X₁ := hS.fIsKernel.lift (KernelFork.ofι k hk)
 
 @[reassoc (attr := simp)]
-lemma lift_f {A : C} (k : A ⟶ S.X₂) (hk : k ≫ S.g = 0) [Mono S.f] :
+lemma lift_f (hS : S.Exact) {A : C} (k : A ⟶ S.X₂) (hk : k ≫ S.g = 0) [Mono S.f] :
     hS.lift k hk ≫ S.f = k :=
   Fork.IsLimit.lift_ι _
 
-lemma lift' {A : C} (k : A ⟶ S.X₂) (hk : k ≫ S.g = 0) [Mono S.f] :
+lemma lift' (hS : S.Exact) {A : C} (k : A ⟶ S.X₂) (hk : k ≫ S.g = 0) [Mono S.f] :
     ∃ (l : A ⟶ S.X₁), l ≫ S.f = k :=
   ⟨hS.lift k hk, by simp⟩
 
 /-- If a short complex `S` in a balanced category is exact and such that `S.g` is an epi,
 then a morphism `k : S.X₂ ⟶ A` such that `S.f ≫ k = 0` descends to a morphism `S.X₃ ⟶ A`. -/
-noncomputable def desc {A : C} (k : S.X₂ ⟶ A) (hk : S.f ≫ k = 0) [Epi S.g] :
+noncomputable def desc (hS : S.Exact) {A : C} (k : S.X₂ ⟶ A) (hk : S.f ≫ k = 0) [Epi S.g] :
     S.X₃ ⟶ A := hS.gIsCokernel.desc (CokernelCofork.ofπ k hk)
 
 @[reassoc (attr := simp)]
-lemma g_desc {A : C} (k : S.X₂ ⟶ A) (hk : S.f ≫ k = 0) [Epi S.g] :
+lemma g_desc (hS : S.Exact) {A : C} (k : S.X₂ ⟶ A) (hk : S.f ≫ k = 0) [Epi S.g] :
     S.g ≫ hS.desc k hk = k :=
   Cofork.IsColimit.π_desc (hS.gIsCokernel)
 
-lemma desc' {A : C} (k : S.X₂ ⟶ A) (hk : S.f ≫ k = 0) [Epi S.g] :
+lemma desc' (hS : S.Exact) {A : C} (k : S.X₂ ⟶ A) (hk : S.f ≫ k = 0) [Epi S.g] :
     ∃ (l : S.X₃ ⟶ A), S.g ≫ l = k :=
   ⟨hS.desc k hk, by simp⟩
 

--- a/Mathlib/Algebra/Polynomial/Inductions.lean
+++ b/Mathlib/Algebra/Polynomial/Inductions.lean
@@ -163,11 +163,12 @@ theorem degree_pos_induction_on {P : R[X] → Prop} (p : R[X]) (h0 : 0 < degree 
     (hC : ∀ {a}, a ≠ 0 → P (C a * X)) (hX : ∀ {p}, 0 < degree p → P p → P (p * X))
     (hadd : ∀ {p} {a}, 0 < degree p → P p → P (p + C a)) : P p :=
   recOnHorner p (fun h => by rw [degree_zero] at h; exact absurd h (by decide))
-    (fun p a _ _ ih h0 =>
-      have : 0 < degree p :=
-        lt_of_not_ge fun h =>
-          not_lt_of_ge degree_C_le <| by rwa [eq_C_of_degree_le_zero h, ← C_add] at h0
-      hadd this (ih this))
+    (fun p a heq0 _ ih h0 =>
+      (have : 0 < degree p :=
+        (lt_of_not_ge fun h =>
+          not_lt_of_ge (degree_C_le (a := a)) <|
+            by rwa [eq_C_of_degree_le_zero h, ← C_add,heq0,zero_add] at h0)
+      hadd this (ih this)))
     (fun p _ ih h0' =>
       if h0 : 0 < degree p then hX h0 (ih h0)
       else by

--- a/Mathlib/Algebra/Polynomial/Monic.lean
+++ b/Mathlib/Algebra/Polynomial/Monic.lean
@@ -293,36 +293,40 @@ section Injective
 
 open Function
 
-variable [Semiring S] {f : R →+* S} (hf : Injective f)
+variable [Semiring S] {f : R →+* S}
 
-theorem degree_map_eq_of_injective (p : R[X]) : degree (p.map f) = degree p :=
+theorem degree_map_eq_of_injective (hf : Injective f) (p : R[X]) : degree (p.map f) = degree p :=
   letI := Classical.decEq R
   if h : p = 0 then by simp [h]
   else
     degree_map_eq_of_leadingCoeff_ne_zero _
       (by rw [← f.map_zero]; exact mt hf.eq_iff.1 (mt leadingCoeff_eq_zero.1 h))
 
-theorem natDegree_map_eq_of_injective (p : R[X]) : natDegree (p.map f) = natDegree p :=
+theorem natDegree_map_eq_of_injective (hf : Injective f) (p : R[X]) :
+    natDegree (p.map f) = natDegree p :=
   natDegree_eq_of_degree_eq (degree_map_eq_of_injective hf p)
 
-theorem leadingCoeff_map' (p : R[X]) : leadingCoeff (p.map f) = f (leadingCoeff p) := by
+theorem leadingCoeff_map' (hf : Injective f) (p : R[X]) :
+    leadingCoeff (p.map f) = f (leadingCoeff p) := by
   unfold leadingCoeff
   rw [coeff_map, natDegree_map_eq_of_injective hf p]
 
-theorem nextCoeff_map (p : R[X]) : (p.map f).nextCoeff = f p.nextCoeff := by
+theorem nextCoeff_map (hf : Injective f) (p : R[X]) : (p.map f).nextCoeff = f p.nextCoeff := by
   unfold nextCoeff
   rw [natDegree_map_eq_of_injective hf]
   split_ifs <;> simp [*]
 
-theorem leadingCoeff_of_injective (p : R[X]) : leadingCoeff (p.map f) = f (leadingCoeff p) := by
+theorem leadingCoeff_of_injective (hf : Injective f) (p : R[X]) :
+    leadingCoeff (p.map f) = f (leadingCoeff p) := by
   delta leadingCoeff
   rw [coeff_map f, natDegree_map_eq_of_injective hf p]
 
-theorem monic_of_injective {p : R[X]} (hp : (p.map f).Monic) : p.Monic := by
+theorem monic_of_injective (hf : Injective f) {p : R[X]} (hp : (p.map f).Monic) : p.Monic := by
   apply hf
   rw [← leadingCoeff_of_injective hf, hp.leadingCoeff, f.map_one]
 
-theorem _root_.Function.Injective.monic_map_iff {p : R[X]} : p.Monic ↔ (p.map f).Monic :=
+theorem _root_.Function.Injective.monic_map_iff (hf : Injective f) {p : R[X]} :
+    p.Monic ↔ (p.map f).Monic :=
   ⟨Monic.map _, Polynomial.monic_of_injective hf⟩
 
 end Injective

--- a/Mathlib/Algebra/Star/RingQuot.lean
+++ b/Mathlib/Algebra/Star/RingQuot.lean
@@ -18,9 +18,10 @@ variable {R : Type u} [Semiring R] (r : R → R → Prop)
 
 section StarRing
 
-variable [StarRing R] (hr : ∀ a b, r a b → r (star a) (star b))
+variable [StarRing R]
 
-theorem Rel.star ⦃a b : R⦄ (h : Rel r a b) : Rel r (star a) (star b) := by
+theorem Rel.star (hr : ∀ a b, r a b → r (star a) (star b))
+    ⦃a b : R⦄ (h : Rel r a b) : Rel r (star a) (star b) := by
   induction h with
   | of h          => exact Rel.of (hr _ _ h)
   | add_left _ h  => rw [star_add, star_add]
@@ -30,7 +31,7 @@ theorem Rel.star ⦃a b : R⦄ (h : Rel r a b) : Rel r (star a) (star b) := by
   | mul_right _ h => rw [star_mul, star_mul]
                      exact Rel.mul_left h
 
-private irreducible_def star' : RingQuot r → RingQuot r
+private irreducible_def star' (hr : ∀ a b, r a b → r (star a) (star b)) : RingQuot r → RingQuot r
   | ⟨a⟩ => ⟨Quot.map (star : R → R) (Rel.star r hr) a⟩
 
 theorem star'_quot (hr : ∀ a b, r a b → r (star a) (star b)) {a} :

--- a/Mathlib/Data/Finsupp/WellFounded.lean
+++ b/Mathlib/Data/Finsupp/WellFounded.lean
@@ -27,23 +27,24 @@ variable {α N : Type*}
 
 namespace Finsupp
 
-variable [Zero N] {r : α → α → Prop} {s : N → N → Prop} (hbot : ∀ ⦃n⦄, ¬s n 0)
-  (hs : WellFounded s)
+variable [Zero N] {r : α → α → Prop} {s : N → N → Prop}
 
 /-- Transferred from `DFinsupp.Lex.acc`. See the top of that file for an explanation for the
   appearance of the relation `rᶜ ⊓ (≠)`. -/
-theorem Lex.acc (x : α →₀ N) (h : ∀ a ∈ x.support, Acc (rᶜ ⊓ (· ≠ ·)) a) :
+theorem Lex.acc (hbot : ∀ ⦃n⦄, ¬s n 0) (hs : WellFounded s) (x : α →₀ N)
+    (h : ∀ a ∈ x.support, Acc (rᶜ ⊓ (· ≠ ·)) a) :
     Acc (Finsupp.Lex r s) x := by
   rw [lex_eq_invImage_dfinsupp_lex]
   classical
     refine InvImage.accessible toDFinsupp (DFinsupp.Lex.acc (fun _ => hbot) (fun _ => hs) _ ?_)
     simpa only [toDFinsupp_support] using h
 
-theorem Lex.wellFounded (hr : WellFounded <| rᶜ ⊓ (· ≠ ·)) : WellFounded (Finsupp.Lex r s) :=
+theorem Lex.wellFounded (hbot : ∀ ⦃n⦄, ¬s n 0) (hs : WellFounded s)
+    (hr : WellFounded <| rᶜ ⊓ (· ≠ ·)) : WellFounded (Finsupp.Lex r s) :=
   ⟨fun x => Lex.acc hbot hs x fun a _ => hr.apply a⟩
 
-theorem Lex.wellFounded' [IsTrichotomous α r] (hr : WellFounded (Function.swap r)) :
-    WellFounded (Finsupp.Lex r s) :=
+theorem Lex.wellFounded' (hbot : ∀ ⦃n⦄, ¬s n 0) (hs : WellFounded s)
+    [IsTrichotomous α r] (hr : WellFounded (Function.swap r)) : WellFounded (Finsupp.Lex r s) :=
   (lex_eq_invImage_dfinsupp_lex r s).symm ▸
     InvImage.wf _ (DFinsupp.Lex.wellFounded' (fun _ => hbot) (fun _ => hs) hr)
 

--- a/Mathlib/GroupTheory/OrderOfElement.lean
+++ b/Mathlib/GroupTheory/OrderOfElement.lean
@@ -369,15 +369,17 @@ lemma IsOfFinOrder.finite_powers (ha : IsOfFinOrder a) : (powers a : Set G).Fini
 
 namespace Commute
 
-variable {x} (h : Commute x y)
+variable {x}
 
 @[to_additive]
-theorem orderOf_mul_dvd_lcm : orderOf (x * y) ∣ Nat.lcm (orderOf x) (orderOf y) := by
+theorem orderOf_mul_dvd_lcm (h : Commute x y) :
+    orderOf (x * y) ∣ Nat.lcm (orderOf x) (orderOf y) := by
   rw [orderOf, ← comp_mul_left]
   exact Function.Commute.minimalPeriod_of_comp_dvd_lcm h.function_commute_mul_left
 
 @[to_additive]
-theorem orderOf_dvd_lcm_mul : orderOf y ∣ Nat.lcm (orderOf x) (orderOf (x * y)) := by
+theorem orderOf_dvd_lcm_mul (h : Commute x y):
+    orderOf y ∣ Nat.lcm (orderOf x) (orderOf (x * y)) := by
   by_cases h0 : orderOf x = 0
   · rw [h0, lcm_zero_left]
     apply dvd_zero
@@ -389,18 +391,20 @@ theorem orderOf_dvd_lcm_mul : orderOf y ∣ Nat.lcm (orderOf x) (orderOf (x * y)
       (lcm_dvd_iff.2 ⟨(orderOf_pow_dvd _).trans (dvd_lcm_left _ _), dvd_lcm_right _ _⟩)
 
 @[to_additive addOrderOf_add_dvd_mul_addOrderOf]
-theorem orderOf_mul_dvd_mul_orderOf : orderOf (x * y) ∣ orderOf x * orderOf y :=
+theorem orderOf_mul_dvd_mul_orderOf (h : Commute x y):
+    orderOf (x * y) ∣ orderOf x * orderOf y :=
   dvd_trans h.orderOf_mul_dvd_lcm (lcm_dvd_mul _ _)
 
 @[to_additive addOrderOf_add_eq_mul_addOrderOf_of_coprime]
-theorem orderOf_mul_eq_mul_orderOf_of_coprime (hco : (orderOf x).Coprime (orderOf y)) :
-    orderOf (x * y) = orderOf x * orderOf y := by
+theorem orderOf_mul_eq_mul_orderOf_of_coprime (h : Commute x y)
+    (hco : (orderOf x).Coprime (orderOf y)) : orderOf (x * y) = orderOf x * orderOf y := by
   rw [orderOf, ← comp_mul_left]
   exact h.function_commute_mul_left.minimalPeriod_of_comp_eq_mul_of_coprime hco
 
 /-- Commuting elements of finite order are closed under multiplication. -/
 @[to_additive "Commuting elements of finite additive order are closed under addition."]
-theorem isOfFinOrder_mul (hx : IsOfFinOrder x) (hy : IsOfFinOrder y) : IsOfFinOrder (x * y) :=
+theorem isOfFinOrder_mul (h : Commute x y) (hx : IsOfFinOrder x) (hy : IsOfFinOrder y) :
+    IsOfFinOrder (x * y) :=
   orderOf_pos_iff.mp <|
     pos_of_dvd_of_pos h.orderOf_mul_dvd_mul_orderOf <| mul_pos hx.orderOf_pos hy.orderOf_pos
 
@@ -410,7 +414,7 @@ theorem isOfFinOrder_mul (hx : IsOfFinOrder x) (hy : IsOfFinOrder y) : IsOfFinOr
   "If each prime factor of
   `addOrderOf x` has higher multiplicity in `addOrderOf y`, and `x` commutes with `y`,
   then `x + y` has the same order as `y`."]
-theorem orderOf_mul_eq_right_of_forall_prime_mul_dvd (hy : IsOfFinOrder y)
+theorem orderOf_mul_eq_right_of_forall_prime_mul_dvd (h : Commute x y) (hy : IsOfFinOrder y)
     (hdvd : ∀ p : ℕ, p.Prime → p ∣ orderOf x → p * orderOf x ∣ orderOf y) :
     orderOf (x * y) = orderOf y := by
   have hoy := hy.orderOf_pos

--- a/Mathlib/RingTheory/Ideal/Maps.lean
+++ b/Mathlib/RingTheory/Ideal/Maps.lean
@@ -347,9 +347,8 @@ variable [FunLike F R S] [RingHomClass F R S] (f : F) {I : Ideal R}
 
 section Surjective
 
-variable (hf : Function.Surjective f)
-
-theorem comap_map_of_surjective (I : Ideal R) : comap f (map f I) = I ⊔ comap f ⊥ :=
+theorem comap_map_of_surjective (hf : Function.Surjective f) (I : Ideal R) :
+    comap f (map f I) = I ⊔ comap f ⊥ :=
   le_antisymm
     (fun r h =>
       let ⟨s, hsi, hfsr⟩ := mem_image_of_mem_map_of_surjective f hf h
@@ -359,7 +358,8 @@ theorem comap_map_of_surjective (I : Ideal R) : comap f (map f I) = I ⊔ comap 
     (sup_le (map_le_iff_le_comap.1 le_rfl) (comap_mono bot_le))
 
 /-- Correspondence theorem -/
-def relIsoOfSurjective : Ideal S ≃o { p : Ideal R // comap f ⊥ ≤ p } where
+def relIsoOfSurjective (hf : Function.Surjective f) :
+    Ideal S ≃o { p : Ideal R // comap f ⊥ ≤ p } where
   toFun J := ⟨comap f J, comap_mono bot_le⟩
   invFun I := map f I.1
   left_inv J := map_comap_of_surjective f hf J
@@ -372,11 +372,11 @@ def relIsoOfSurjective : Ideal S ≃o { p : Ideal R // comap f ⊥ ≤ p } where
       comap_mono⟩
 
 /-- The map on ideals induced by a surjective map preserves inclusion. -/
-def orderEmbeddingOfSurjective : Ideal S ↪o Ideal R :=
+def orderEmbeddingOfSurjective (hf : Function.Surjective f) : Ideal S ↪o Ideal R :=
   (relIsoOfSurjective f hf).toRelEmbedding.trans (Subtype.relEmbedding (fun x y => x ≤ y) _)
 
-theorem map_eq_top_or_isMaximal_of_surjective {I : Ideal R} (H : IsMaximal I) :
-    map f I = ⊤ ∨ IsMaximal (map f I) := by
+theorem map_eq_top_or_isMaximal_of_surjective (hf : Function.Surjective f) {I : Ideal R}
+    (H : IsMaximal I) : map f I = ⊤ ∨ IsMaximal (map f I) := by
   refine or_iff_not_imp_left.2 fun ne_top => ⟨⟨fun h => ne_top h, fun J hJ => ?_⟩⟩
   · refine
       (relIsoOfSurjective f hf).injective
@@ -384,7 +384,8 @@ theorem map_eq_top_or_isMaximal_of_surjective {I : Ideal R} (H : IsMaximal I) :
     · exact map_le_iff_le_comap.1 (le_of_lt hJ)
     · exact fun h => hJ.right (le_map_of_comap_le_of_surjective f hf (le_of_eq h.symm))
 
-theorem comap_isMaximal_of_surjective {K : Ideal S} [H : IsMaximal K] : IsMaximal (comap f K) := by
+theorem comap_isMaximal_of_surjective (hf : Function.Surjective f) {K : Ideal S} [H : IsMaximal K]:
+    IsMaximal (comap f K) := by
   refine ⟨⟨comap_ne_top _ H.1.1, fun J hJ => ?_⟩⟩
   suffices map f J = ⊤ by
     have := congr_arg (comap f) this
@@ -398,7 +399,8 @@ theorem comap_isMaximal_of_surjective {K : Ideal S} [H : IsMaximal K] : IsMaxima
   rw [comap_map_of_surjective _ hf, sup_eq_left]
   exact le_trans (comap_mono bot_le) (le_of_lt hJ)
 
-theorem comap_le_comap_iff_of_surjective (I J : Ideal S) : comap f I ≤ comap f J ↔ I ≤ J :=
+theorem comap_le_comap_iff_of_surjective (hf : Function.Surjective f) (I J : Ideal S) :
+    comap f I ≤ comap f J ↔ I ≤ J :=
   ⟨fun h => (map_comap_of_surjective f hf I).symm.le.trans (map_le_of_le_comap h), fun h =>
     le_comap_of_map_le ((map_comap_of_surjective f hf I).le.trans h)⟩
 

--- a/Mathlib/RingTheory/Localization/FractionRing.lean
+++ b/Mathlib/RingTheory/Localization/FractionRing.lean
@@ -125,7 +125,9 @@ noncomputable abbrev toField : Field K where
   mul_inv_cancel := IsFractionRing.mul_inv_cancel A
   inv_zero := show IsFractionRing.inv A (0 : K) = 0 by rw [IsFractionRing.inv]; exact dif_pos rfl
   nnqsmul := _
+  nnqsmul_def := fun q a => rfl
   qsmul := _
+  qsmul_def := fun a x => rfl
 
 lemma surjective_iff_isField [IsDomain R] : Function.Surjective (algebraMap R K) ↔ IsField R where
   mp h := (RingEquiv.ofBijective (algebraMap R K)
@@ -215,7 +217,7 @@ noncomputable def map {A B K L : Type*} [CommRing A] [CommRing B] [IsDomain B] [
 fields of fractions `K ≃+* L`. -/
 noncomputable def fieldEquivOfRingEquiv [Algebra B L] [IsFractionRing B L] (h : A ≃+* B) :
     K ≃+* L :=
-  ringEquivOfRingEquiv K L h
+  ringEquivOfRingEquiv (M := nonZeroDivisors A) K (T := nonZeroDivisors B) L h
     (by
       ext b
       show b ∈ h.toEquiv '' _ ↔ _


### PR DESCRIPTION
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
