### PR TITLE
[Merged by Bors] - chore: remove some obsolete porting notes mentioning noncomputable

### DIFF
--- a/Mathlib/Analysis/CstarAlgebra/Multiplier.lean
+++ b/Mathlib/Analysis/CstarAlgebra/Multiplier.lean
@@ -447,7 +447,7 @@ maps `Lₐ Rₐ : A →L[𝕜] A` given by left- and right-multiplication by `a`
 Warning: if `A = 𝕜`, then this is a coercion which is not definitionally equal to the
 `algebraMap 𝕜 𝓜(𝕜, 𝕜)` coercion, but these are propositionally equal. See
 `DoubleCentralizer.coe_eq_algebraMap` below. -/
--- Porting note: added `noncomputable` because an IR check failed?
+-- Porting note: added `noncomputable`; IR check does not recognise `ContinuousLinearMap.mul`
 @[coe]
 protected noncomputable def coe (a : A) : 𝓜(𝕜, A) :=
   { fst := ContinuousLinearMap.mul 𝕜 A a

--- a/Mathlib/Analysis/Quaternion.lean
+++ b/Mathlib/Analysis/Quaternion.lean
@@ -86,7 +86,6 @@ noncomputable instance : NormedDivisionRing ℍ where
     simp only [norm_eq_sqrt_real_inner, inner_self, normSq.map_mul]
     exact Real.sqrt_mul normSq_nonneg _
 
--- Porting note: added `noncomputable`
 noncomputable instance : NormedAlgebra ℝ ℍ where
   norm_smul_le := norm_smul_le
   toAlgebra := Quaternion.algebra

--- a/Mathlib/CategoryTheory/Monoidal/Types/Coyoneda.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Types/Coyoneda.lean
@@ -25,14 +25,7 @@ open Opposite
 
 open MonoidalCategory
 
--- Porting note: made it noncomputable.
--- `failed to compile definition, consider marking it as 'noncomputable' because it`
--- `depends on 'CategoryTheory.typesMonoidal', and it does not have executable code`
--- I don't know if that is a problem, might need to change it back in the future, but
--- if so it might be better to fix then instead of at the moment of porting.
-
 /-- `(𝟙_ C ⟶ -)` is a lax monoidal functor to `Type`. -/
-noncomputable
 def coyonedaTensorUnit (C : Type u) [Category.{v} C] [MonoidalCategory C] :
     LaxMonoidalFunctor C (Type v) := .ofTensorHom
     (F := coyoneda.obj (op (𝟙_ C)))

--- a/Mathlib/Computability/PartrecCode.lean
+++ b/Mathlib/Computability/PartrecCode.lean
@@ -79,7 +79,6 @@ inductive Code : Type
   | prec : Code → Code → Code
   | rfind' : Code → Code
 
--- Porting note: `Nat.Partrec.Code.recOn` is noncomputable in Lean4, so we make it computable.
 compile_inductive% Code
 
 end Nat.Partrec

--- a/Mathlib/Computability/TMToPartrec.lean
+++ b/Mathlib/Computability/TMToPartrec.lean
@@ -867,7 +867,6 @@ inductive Λ'
   | pred (q₁ q₂ : Λ')
   | ret (k : Cont')
 
--- Porting note: `Turing.PartrecToTM2.Λ'.rec` is noncomputable in Lean4, so we make it computable.
 compile_inductive% Code
 compile_inductive% Cont'
 compile_inductive% K'

--- a/Mathlib/Data/Analysis/Topology.lean
+++ b/Mathlib/Data/Analysis/Topology.lean
@@ -153,10 +153,8 @@ theorem ext [T : TopologicalSpace α] {σ : Type*} {F : Ctop α σ} (H₁ : ∀ 
 
 variable [TopologicalSpace α]
 
--- Porting note: add non-computable : because
--- > ... it depends on `Inter.inter`, and it does not have executable code.
 /-- The topological space realizer made of the open sets. -/
-protected noncomputable def id : Realizer α :=
+protected def id : Realizer α :=
   ⟨{ x : Set α // IsOpen x },
     { f := Subtype.val
       top := fun _ ↦ ⟨univ, isOpen_univ⟩

--- a/Mathlib/MeasureTheory/Measure/Haar/Basic.lean
+++ b/Mathlib/MeasureTheory/Measure/Haar/Basic.lean
@@ -83,10 +83,6 @@ variable {G : Type*} [Group G]
 
 namespace haar
 
--- Porting note: Even in `noncomputable section`, a definition with `to_additive` require
---               `noncomputable` to generate an additive definition.
---               Please refer to leanprover/lean4#2077.
-
 /-- The index or Haar covering number or ratio of `K` w.r.t. `V`, denoted `(K : V)`:
   it is the smallest number of (left) translates of `V` that is necessary to cover `K`.
   It is defined to be 0 if no finite number of translates cover `K`. -/
@@ -341,11 +337,6 @@ theorem nonempty_iInter_clPrehaar (K₀ : PositiveCompacts G) :
 ### Lemmas about `chaar`
 -/
 
-
--- Porting note: Even in `noncomputable section`, a definition with `to_additive` require
---               `noncomputable` to generate an additive definition.
---               Please refer to leanprover/lean4#2077.
-
 /-- This is the "limit" of `prehaar K₀ U K` as `U` becomes a smaller and smaller open
   neighborhood of `(1 : G)`. More precisely, it is defined to be an arbitrary element
   in the intersection of all the sets `clPrehaar K₀ V` in `haarProduct K₀`.
@@ -463,10 +454,6 @@ theorem is_left_invariant_chaar {K₀ : PositiveCompacts G} (g : G) (K : Compact
     apply is_left_invariant_prehaar; rw [h2U.interior_eq]; exact ⟨1, h3U⟩
   · apply continuous_iff_isClosed.mp this; exact isClosed_singleton
 
--- Porting note: Even in `noncomputable section`, a definition with `to_additive` require
---               `noncomputable` to generate an additive definition.
---               Please refer to leanprover/lean4#2077.
-
 /-- The function `chaar` interpreted in `ℝ≥0`, as a content -/
 @[to_additive "additive version of `MeasureTheory.Measure.haar.haarContent`"]
 noncomputable def haarContent (K₀ : PositiveCompacts G) : Content G where
@@ -518,12 +505,7 @@ open haar
 ### The Haar measure
 -/
 
-
 variable [TopologicalSpace G] [TopologicalGroup G] [MeasurableSpace G] [BorelSpace G]
-
--- Porting note: Even in `noncomputable section`, a definition with `to_additive` require
---               `noncomputable` to generate an additive definition.
---               Please refer to leanprover/lean4#2077.
 
 /-- The Haar measure on the locally compact group `G`, scaled so that `haarMeasure K₀ K₀ = 1`. -/
 @[to_additive


### PR DESCRIPTION
- Two porting notes are obsolete: the `noncomputable` modifier could simply be removed.
- A few others don't seem actionable.
- leanprover/lean4#2077 is fixed now: no point referencing this issue any more
(The `noncomputable` needs to stay, as the definition relies on other noncomputable items.)

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
