### PR TITLE
[Merged by Bors] - chore: use double backticks for explicit names, if possible

### DIFF
--- a/Mathlib/Lean/Meta/DiscrTree.lean
+++ b/Mathlib/Lean/Meta/DiscrTree.lean
@@ -44,6 +44,6 @@ Check if a `keys : Array DiscTree.Key` is "specific",
 i.e. something other than `[*]` or `[=, *, *, *]`.
 -/
 def keysSpecific (keys : Array DiscrTree.Key) : Bool :=
-  keys != #[Key.star] && keys != #[Key.const `Eq 3, Key.star, Key.star, Key.star]
+  keys != #[Key.star] && keys != #[Key.const ``Eq 3, Key.star, Key.star, Key.star]
 
 end Lean.Meta.DiscrTree

--- a/Mathlib/Tactic/Abel.lean
+++ b/Mathlib/Tactic/Abel.lean
@@ -340,7 +340,7 @@ partial def eval (e : Expr) : M (NormalExpr × Expr) := do
     let (e₁, p₁) ← eval e
     let (e₂, p₂) ← evalNeg e₁
     return (e₂, ← iapp `Mathlib.Tactic.Abel.subst_into_neg #[e, e₁, e₂, p₁, p₂])
-  | (`AddMonoid.nsmul, #[_, _, e₁, e₂]) => do
+  | (``AddMonoid.nsmul, #[_, _, e₁, e₂]) => do
     let n ← if (← read).isGroup then mkAppM ``Int.ofNat #[e₁] else pure e₁
     let (e', p) ← eval <| ← iapp ``smul #[n, e₂]
     return (e', ← iapp ``unfold_smul #[e₁, e₂, e', p])

--- a/Mathlib/Tactic/DeriveFintype.lean
+++ b/Mathlib/Tactic/DeriveFintype.lean
@@ -188,7 +188,7 @@ def mkFintypeInstanceHandler (declNames : Array Name) : CommandElabM Bool := do
     mkFintype declName
 
 initialize
-  registerDerivingHandler `Fintype mkFintypeInstanceHandler
+  registerDerivingHandler ``Fintype mkFintypeInstanceHandler
   registerTraceClass `Elab.Deriving.fintype
 
 end Mathlib.Deriving.Fintype

--- a/Mathlib/Tactic/DeriveToExpr.lean
+++ b/Mathlib/Tactic/DeriveToExpr.lean
@@ -223,7 +223,7 @@ def mkToExprInstanceHandler (declNames : Array Name) : CommandElabM Bool := do
     return false
 
 initialize
-  registerDerivingHandler `Lean.ToExpr mkToExprInstanceHandler
+  registerDerivingHandler ``Lean.ToExpr mkToExprInstanceHandler
   registerTraceClass `Elab.Deriving.toExpr
 
 end Mathlib.Deriving.ToExpr

--- a/Mathlib/Tactic/Widget/CongrM.lean
+++ b/Mathlib/Tactic/Widget/CongrM.lean
@@ -23,7 +23,7 @@ open Lean Meta Server ProofWidgets
 def makeCongrMString (pos : Array Lean.SubExpr.GoalsLocation) (goalType : Expr)
     (_ : SelectInsertParams) : MetaM (String × String × Option (String.Pos × String.Pos)) := do
   let subexprPos := getGoalLocations pos
-  unless goalType.isAppOf `Eq || goalType.isAppOf `Iff do
+  unless goalType.isAppOf ``Eq || goalType.isAppOf ``Iff do
     throwError "The goal must be an equality or iff."
   let mut goalTypeWithMetaVars := goalType
   for pos in subexprPos do

--- a/Mathlib/Tactic/Widget/GCongr.lean
+++ b/Mathlib/Tactic/Widget/GCongr.lean
@@ -19,7 +19,7 @@ open Lean Meta Server ProofWidgets
 def makeGCongrString (pos : Array Lean.SubExpr.GoalsLocation) (goalType : Expr)
     (_ : SelectInsertParams) : MetaM (String × String × Option (String.Pos × String.Pos)) := do
 let subexprPos := getGoalLocations pos
-unless goalType.isAppOf ``LE.le || goalType.isAppOf ``LT.lt || goalType.isAppOf ``Int.ModEq do
+unless goalType.isAppOf ``LE.le || goalType.isAppOf ``LT.lt || goalType.isAppOf `Int.ModEq do
   panic! "The goal must be a ≤ or < or ≡."
 let mut goalTypeWithMetaVars := goalType
 for pos in subexprPos do

--- a/Mathlib/Tactic/Widget/GCongr.lean
+++ b/Mathlib/Tactic/Widget/GCongr.lean
@@ -3,7 +3,6 @@ Copyright (c) 2023 Patrick Massot. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Patrick Massot
 -/
-import Mathlib.Algebra.ModEq
 import Mathlib.Tactic.Widget.SelectPanelUtils
 import Mathlib.Tactic.GCongr
 
@@ -26,7 +25,7 @@ let mut goalTypeWithMetaVars := goalType
 for pos in subexprPos do
   goalTypeWithMetaVars ← insertMetaVar goalTypeWithMetaVars pos
 
-let side := if goalType.isAppOf ``Int.ModEq then
+let side := if goalType.isAppOf `Int.ModEq then
               if subexprPos[0]!.toArray[0]! = 0 then 1 else 2
             else
               if subexprPos[0]!.toArray[0]! = 0 then 2 else 3

--- a/Mathlib/Tactic/Widget/GCongr.lean
+++ b/Mathlib/Tactic/Widget/GCongr.lean
@@ -3,6 +3,7 @@ Copyright (c) 2023 Patrick Massot. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Patrick Massot
 -/
+import Mathlib.Algebra.ModEq
 import Mathlib.Tactic.Widget.SelectPanelUtils
 import Mathlib.Tactic.GCongr
 
@@ -19,13 +20,13 @@ open Lean Meta Server ProofWidgets
 def makeGCongrString (pos : Array Lean.SubExpr.GoalsLocation) (goalType : Expr)
     (_ : SelectInsertParams) : MetaM (String × String × Option (String.Pos × String.Pos)) := do
 let subexprPos := getGoalLocations pos
-unless goalType.isAppOf `LE.le || goalType.isAppOf `LT.lt || goalType.isAppOf `Int.ModEq do
+unless goalType.isAppOf ``LE.le || goalType.isAppOf ``LT.lt || goalType.isAppOf ``Int.ModEq do
   panic! "The goal must be a ≤ or < or ≡."
 let mut goalTypeWithMetaVars := goalType
 for pos in subexprPos do
   goalTypeWithMetaVars ← insertMetaVar goalTypeWithMetaVars pos
 
-let side := if goalType.isAppOf `Int.ModEq then
+let side := if goalType.isAppOf ``Int.ModEq then
               if subexprPos[0]!.toArray[0]! = 0 then 1 else 2
             else
               if subexprPos[0]!.toArray[0]! = 0 then 2 else 3

--- a/Mathlib/Tactic/Widget/SelectInsertParamsClass.lean
+++ b/Mathlib/Tactic/Widget/SelectInsertParamsClass.lean
@@ -43,5 +43,5 @@ def mkSelectInsertParamsInstanceHandler (declNames : Array Name) : CommandElabM 
   else
     return false
 
-initialize registerDerivingHandler `SelectInsertParamsClass mkSelectInsertParamsInstanceHandler
+initialize registerDerivingHandler ``SelectInsertParamsClass mkSelectInsertParamsInstanceHandler
 end Lean.Elab

--- a/scripts/noshake.json
+++ b/scripts/noshake.json
@@ -203,7 +203,6 @@
   ["Mathlib.Topology.Algebra.UniformRing"],
   "Mathlib.Tactic.Widget.SelectPanelUtils":
   ["ProofWidgets.Component.OfRpcMethod"],
-  "Mathlib.Tactic.Widget.GCongr": ["Mathlib.Algebra.ModEq"],
   "Mathlib.Tactic.Widget.CommDiag": ["Mathlib.CategoryTheory.Category.Basic"],
   "Mathlib.Tactic.Use": ["Batteries.Logic"],
   "Mathlib.Tactic.TermCongr": ["Mathlib.Logic.Basic"],

--- a/scripts/noshake.json
+++ b/scripts/noshake.json
@@ -203,6 +203,7 @@
   ["Mathlib.Topology.Algebra.UniformRing"],
   "Mathlib.Tactic.Widget.SelectPanelUtils":
   ["ProofWidgets.Component.OfRpcMethod"],
+  "Mathlib.Tactic.Widget.GCongr": ["Mathlib.Algebra.ModEq"],
   "Mathlib.Tactic.Widget.CommDiag": ["Mathlib.CategoryTheory.Category.Basic"],
   "Mathlib.Tactic.Use": ["Batteries.Logic"],
   "Mathlib.Tactic.TermCongr": ["Mathlib.Logic.Basic"],


### PR DESCRIPTION
This PR is very likely not exhaustive: the next step to finding these more exhaustively would be to write an intelligent linter.
(I found these using a simple text-based linter, which has still too many false positive).

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
