### PR TITLE
[Merged by Bors] - fix: add check for existing filepath

### DIFF
--- a/Mathlib/Tactic/Linter/Lint.lean
+++ b/Mathlib/Tactic/Linter/Lint.lean
@@ -245,6 +245,7 @@ def longLineLinter : Linter where run := withSetOptionIn fun stx ↦ do
     let stx := ← do
       if stx.isOfKind ``Lean.Parser.Command.eoi then
         let fname ← getFileName
+        if !(← System.FilePath.pathExists fname) then return default
         let contents ← IO.FS.readFile fname
         -- `impMods` is the syntax for the modules imported in the current file
         let (impMods, _) ← Parser.parseHeader (Parser.mkInputContext contents fname)


### PR DESCRIPTION
This should fix a problem with the online lean server

[Reported on Zulip](https://leanprover.zulipchat.com/#narrow/stream/113488-general/topic/reading.20the.20.22visible.22.20file.2C.20rather.20than.20the.20saved.20one/near/454337536)

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
