### PR TITLE
[Merged by Bors] - feat: generalize `Int.cast_nonneg` and related lemmas

### DIFF
--- a/Mathlib/Algebra/Order/Ring/Cast.lean
+++ b/Mathlib/Algebra/Order/Ring/Cast.lean
@@ -24,7 +24,7 @@ open Function Nat
 variable {R : Type*}
 
 namespace Int
-section OrderedRing
+section OrderedAddCommGroupWithOne
 
 variable [AddCommGroupWithOne R] [PartialOrder R] [CovariantClass R R (· + ·) (· ≤ ·)]
 variable [ZeroLEOneClass R] [NeZero (1 : R)]
@@ -58,7 +58,7 @@ lemma cast_strictMono : StrictMono (fun x : ℤ => (x : R)) :=
 
 @[simp] lemma cast_lt_zero : (n : R) < 0 ↔ n < 0 := by rw [← cast_zero, cast_lt]
 
-end OrderedRing
+end OrderedAddCommGroupWithOne
 
 section LinearOrderedRing
 variable [LinearOrderedRing R] {a b n : ℤ} {x : R}

--- a/Mathlib/Algebra/Order/Ring/Cast.lean
+++ b/Mathlib/Algebra/Order/Ring/Cast.lean
@@ -25,14 +25,16 @@ variable {R : Type*}
 
 namespace Int
 section OrderedRing
-variable [OrderedRing R]
+
+variable [AddCommGroupWithOne R] [PartialOrder R] [CovariantClass R R (· + ·) (· ≤ ·)]
+variable [ZeroLEOneClass R] [NeZero (1 : R)]
 
 lemma cast_mono : Monotone (Int.cast : ℤ → R) := by
   intro m n h
   rw [← sub_nonneg] at h
   lift n - m to ℕ using h with k hk
   rw [← sub_nonneg, ← cast_sub, ← hk, cast_natCast]
-  exact k.cast_nonneg
+  exact k.cast_nonneg'
 
 variable [Nontrivial R] {m n : ℤ}
 


### PR DESCRIPTION

---

If this benchmarks fine, I think it's a good change. See also [this comment](https://github.com/leanprover-community/mathlib4/pull/13974#discussion_r1680054076) on #13974

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
