### PR TITLE
[Merged by Bors] - chore: Address todo in `Data/Matrix/Rank.lean`

### DIFF
--- a/Mathlib/Data/Matrix/Rank.lean
+++ b/Mathlib/Data/Matrix/Rank.lean
@@ -7,6 +7,7 @@ import Mathlib.LinearAlgebra.Determinant
 import Mathlib.LinearAlgebra.FiniteDimensional
 import Mathlib.LinearAlgebra.Matrix.Diagonal
 import Mathlib.LinearAlgebra.Matrix.DotProduct
+import Mathlib.LinearAlgebra.Matrix.Dual
 
 /-!
 # Rank of matrices
@@ -17,12 +18,6 @@ This definition does not depend on the choice of basis, see `Matrix.rank_eq_finr
 ## Main declarations
 
 * `Matrix.rank`: the rank of a matrix
-
-## TODO
-
-* Do a better job of generalizing over `ℚ`, `ℝ`, and `ℂ` in `Matrix.rank_transpose` and
-  `Matrix.rank_conjTranspose`. See
-  [this Zulip thread](https://leanprover.zulipchat.com/#narrow/stream/116395-maths/topic/row.20rank.20equals.20column.20rank/near/350462992).
 
 -/
 
@@ -252,29 +247,22 @@ theorem rank_transpose_mul_self (A : Matrix m n R) : (Aᵀ * A).rank = A.rank :=
 
 end LinearOrderedField
 
-section Field
-
-variable [Fintype m] [Field R]
-
-/-- TODO: prove this in greater generality. -/
 @[simp]
-theorem rank_transpose (A : Matrix m n R) : Aᵀ.rank = A.rank := by
+theorem rank_transpose [Field R] [Fintype m] (A : Matrix m n R) : Aᵀ.rank = A.rank := by
   classical
-  rw [M.transpose.rank_eq_finrank_range_toLin (Pi.basisFun K n).dualBasis (Pi.basisFun K m).dualBasis,
-      Matrix.toLin_transpose, ← LinearMap.dualMap_def,
-      LinearMap.finrank_range_dualMap_eq_finrank_range, Matrix.toLin_eq_toLin',
-      Matrix.toLin'_apply', Matrix.rank]
+  rw [Aᵀ.rank_eq_finrank_range_toLin (Pi.basisFun R n).dualBasis (Pi.basisFun R m).dualBasis,
+      toLin_transpose, ← LinearMap.dualMap_def, LinearMap.finrank_range_dualMap_eq_finrank_range,
+      toLin_eq_toLin', toLin'_apply', rank]
 
 @[simp]
-theorem rank_self_mul_transpose (A : Matrix m n R) : (A * Aᵀ).rank = A.rank := by
+theorem rank_self_mul_transpose [LinearOrderedField R] [Fintype m] (A : Matrix m n R) :
+    (A * Aᵀ).rank = A.rank := by
   simpa only [rank_transpose, transpose_transpose] using rank_transpose_mul_self Aᵀ
 
 /-- The rank of a matrix is the rank of the space spanned by its rows. -/
-theorem rank_eq_finrank_span_row [Finite m] (A : Matrix m n R) :
+theorem rank_eq_finrank_span_row [Field R] [Finite m] (A : Matrix m n R) :
     A.rank = finrank R (Submodule.span R (Set.range A)) := by
   cases nonempty_fintype m
   rw [← rank_transpose, rank_eq_finrank_span_cols, transpose_transpose]
-
-end Field
 
 end Matrix

--- a/Mathlib/Data/Matrix/Rank.lean
+++ b/Mathlib/Data/Matrix/Rank.lean
@@ -250,24 +250,31 @@ theorem rank_transpose_mul_self (A : Matrix m n R) : (Aᵀ * A).rank = A.rank :=
   · rw [ker_mulVecLin_transpose_mul_self]
   · simp only [LinearMap.finrank_range_add_finrank_ker]
 
+end LinearOrderedField
+
+section Field
+
+variable [Fintype m] [Field R]
+
 /-- TODO: prove this in greater generality. -/
 @[simp]
-theorem rank_transpose (A : Matrix m n R) : Aᵀ.rank = A.rank :=
-  le_antisymm ((rank_transpose_mul_self _).symm.trans_le <| rank_mul_le_left _ _)
-    ((rank_transpose_mul_self _).symm.trans_le <| rank_mul_le_left _ _)
+theorem rank_transpose (A : Matrix m n R) : Aᵀ.rank = A.rank := by
+  classical
+  rw [M.transpose.rank_eq_finrank_range_toLin (Pi.basisFun K n).dualBasis (Pi.basisFun K m).dualBasis,
+      Matrix.toLin_transpose, ← LinearMap.dualMap_def,
+      LinearMap.finrank_range_dualMap_eq_finrank_range, Matrix.toLin_eq_toLin',
+      Matrix.toLin'_apply', Matrix.rank]
 
 @[simp]
 theorem rank_self_mul_transpose (A : Matrix m n R) : (A * Aᵀ).rank = A.rank := by
   simpa only [rank_transpose, transpose_transpose] using rank_transpose_mul_self Aᵀ
 
-end LinearOrderedField
-
-/-- The rank of a matrix is the rank of the space spanned by its rows.
-
-TODO: prove this in a generality that works for `ℂ` too, not just `ℚ` and `ℝ`. -/
-theorem rank_eq_finrank_span_row [LinearOrderedField R] [Finite m] (A : Matrix m n R) :
+/-- The rank of a matrix is the rank of the space spanned by its rows. -/
+theorem rank_eq_finrank_span_row [Finite m] (A : Matrix m n R) :
     A.rank = finrank R (Submodule.span R (Set.range A)) := by
   cases nonempty_fintype m
   rw [← rank_transpose, rank_eq_finrank_span_cols, transpose_transpose]
+
+end Field
 
 end Matrix


### PR DESCRIPTION
This PR addresses a todo in `Data/Matrix/Rank.lean`, generalizing from `LinearOrderedField` to `Field` as suggested by this old Zulip thread: https://leanprover.zulipchat.com/#narrow/stream/116395-maths/topic/row.20rank.20equals.20column.20rank/near/350462992

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
