### PR TITLE
[Merged by Bors] - docs: add module docs for `declarations_diff`

### DIFF
--- a/scripts/declarations_diff.sh
+++ b/scripts/declarations_diff.sh
@@ -33,7 +33,7 @@ with namespacing, e.g. you could see it with `++-- map_zero`.
 
 The script uses some heuristics to guide this process.
 * It assumes that the keyword (as above) appear on the same line as the corresponding
-  declaration id -- a line break between `theorem` and `riemannHypothesis` fools the script.
+  declaration id --- a line break between `theorem` and `riemannHypothesis` fools the script.
 * It deals with declaration modifiers (such as `noncomputable`, `nonrec`, `protected`) and
   attributes.
 * It is "aware" of "nameless" `instance`s and, rather than looking for a declaration id,

--- a/scripts/declarations_diff.sh
+++ b/scripts/declarations_diff.sh
@@ -18,6 +18,8 @@ and tries to find exact matches between a removed line and an added line
 Exact matches are removed.
 Among the remaining unmatched lines, the script tries to extract the declaration ids and tries to
 find exact matches among those.
+No effort is made to keep track of namespaces: if the declaration is `theorem abc ...`, then
+`abc` is extracted, even if this happens inside `namespace xyz`.
 If a declaration id is added once and removed once, then they are again considered paired and are
 not shown.
 
@@ -30,8 +32,8 @@ This means that the declaration `thmName` was added 3 times and removed twice: t
 with namespacing, e.g. you could see it with `++-- map_zero`.
 
 The script uses some heuristics to guide this process.
-* It assumes that the keyword above appear on the same line as the corresponding declaration id --
-  a line break between `theorem` and `riemannHypothesis` fools the script.
+* It assumes that the keyword (as above) appear on the same line as the corresponding
+  declaration id -- a line break between `theorem` and `riemannHypothesis` fools the script.
 * It deals with declaration modifiers (such as `noncomputable`, `nonrec`, `protected`) and
   attributes.
 * It is "aware" of "nameless" `instance`s and, rather than looking for a declaration id,

--- a/scripts/declarations_diff.sh
+++ b/scripts/declarations_diff.sh
@@ -162,7 +162,7 @@ printf $'<details>
 ## more verbose report:
 ./scripts/declarations_diff.sh long <optional_commit>
 ```
-The doc-module for `script/declarations_diff.sh` contain some details about this script.
+The doc-module for `script/declarations_diff.sh` contains some details about this script.
 </details>'
  : <<ReferenceTest
 theorem oh hello

--- a/scripts/declarations_diff.sh
+++ b/scripts/declarations_diff.sh
@@ -162,8 +162,9 @@ printf $'<details>
 ## more verbose report:
 ./scripts/declarations_diff.sh long <optional_commit>
 ```
-The doc-module for `script/declarations_diff.sh` contains some details about this script.
-</details>'
+</details>
+The doc-module for `script/declarations_diff.sh` contains some details about this script.'
+
  : <<ReferenceTest
 theorem oh hello
 inductive triggers the count even if it is not lean code

--- a/scripts/declarations_diff.sh
+++ b/scripts/declarations_diff.sh
@@ -20,8 +20,8 @@ Among the remaining unmatched lines, the script tries to extract the declaration
 find exact matches among those.
 No effort is made to keep track of namespaces: if the declaration is `theorem abc ...`, then
 `abc` is extracted, even if this happens inside `namespace xyz`.
-If a declaration id is added once and removed once, then they are again considered paired and are
-not shown.
+If a declaration id is added exactly once *and* removed exactly once,
+then they are again considered paired and are not shown.
 
 If a declaration id is either only added or removed or it is added or removed more than once, then
 the script will return a count such as
@@ -32,7 +32,7 @@ This means that a declaration `thmName` was added 3 times and removed twice: thi
 with namespacing, e.g. you could see it with `++-- map_zero`.
 
 The script uses some heuristics to guide this process.
-* It assumes that the keyword (as above) appear on the same line as the corresponding
+* It assumes that each keyword (as above) appears on the same line as the corresponding
   declaration id -- a line break between `theorem` and `riemannHypothesis` fools the script.
 * It deals with declaration modifiers (such as `noncomputable`, `nonrec`, `protected`) and
   attributes.

--- a/scripts/declarations_diff.sh
+++ b/scripts/declarations_diff.sh
@@ -7,7 +7,7 @@
 The `declarations_diff` script is a text-based script that attempts to find which declarations
 have been removed and which declarations have been added in the current PR with respect to `master`.
 
-In essence, it looks at the output of `git diff origin/master...HEAD`, it extracts the lines that
+In essence, it looks at the output of `git diff origin/master...HEAD`, extracts the lines that
 contain one of the keywords
 
 `theorem` `lemma` `inductive` `structure` `def` `class` `instance` `alias`
@@ -26,7 +26,7 @@ the script will return a count such as
 
 ++--+ thmName
 
-This means that the declaration `thmName` was added 3 times and removed twice: this can happen
+This means that a declaration `thmName` was added 3 times and removed twice: this can happen
 with namespacing, e.g. you could see it with `++-- map_zero`.
 
 The script uses some heuristics to guide this process.

--- a/scripts/declarations_diff.sh
+++ b/scripts/declarations_diff.sh
@@ -1,5 +1,44 @@
 #!/usr/bin/env bash
 
+ : <<'BASH_DOC_MODULE'
+
+#  The `declarations_diff` script
+
+The `declarations_diff` script is a text-based script that attempts to find which declarations
+have been removed and which declarations have been added in the current PR with respect to `master`.
+
+In essence, it looks at the output of `git diff origin/master...HEAD`, it extracts the lines that
+contain one of the keywords
+
+`theorem` `lemma` `inductive` `structure` `def` `class` `instance` `alias`
+
+and tries to find exact matches between a removed line and an added line
+(e.g. when moving a declaration from one file to another or restructuring within the same file).
+
+Exact matches are removed.
+Among the remaining unmatched lines, the script tries to extract the declaration ids and tries to
+find exact matches among those.
+If a declaration id is added once and removed once, then they are again considered paired and are
+not shown.
+
+If a declaration id is either only added or removed or it is added or removed more than once, then
+the script will return a count such as
+
+++--+ thmName
+
+This means that the declaration `thmName` was added 3 times and removed twice: this can happen
+with namespacing, e.g. you could see it with `++-- map_zero`.
+
+The script uses some heuristics to guide this process.
+* It assumes that the keyword above appear on the same line as the corresponding declaration id --
+  a line break between `theorem` and `riemannHypothesis` fools the script.
+* It deals with declaration modifiers (such as `noncomputable`, `nonrec`, `protected`) and
+  attributes.
+* It is "aware" of "nameless" `instance`s and, rather than looking for a declaration id,
+  in this case records the whole line `instance ...`.
+
+BASH_DOC_MODULE
+
 ## we narrow the diff to lines beginning with `theorem`, `lemma` and a few other commands
 begs="(theorem|lemma|inductive|structure|def|class|instance|alias)"
 
@@ -123,6 +162,7 @@ printf $'<details>
 ## more verbose report:
 ./scripts/declarations_diff.sh long <optional_commit>
 ```
+The doc-module for `script/declarations_diff.sh` contain some details about this script.
 </details>'
  : <<ReferenceTest
 theorem oh hello


### PR DESCRIPTION
This PR adds documentation to the `declarations_diff` script.

Consequence of #15149.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
