### PR TITLE
[Merged by Bors] - feat: add lemma relating Set.encard to tsum over ennreal 

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -4230,6 +4230,7 @@ import Mathlib.Topology.Algebra.GroupWithZero
 import Mathlib.Topology.Algebra.InfiniteSum.Basic
 import Mathlib.Topology.Algebra.InfiniteSum.Constructions
 import Mathlib.Topology.Algebra.InfiniteSum.Defs
+import Mathlib.Topology.Algebra.InfiniteSum.ENNReal
 import Mathlib.Topology.Algebra.InfiniteSum.Group
 import Mathlib.Topology.Algebra.InfiniteSum.GroupCompletion
 import Mathlib.Topology.Algebra.InfiniteSum.Module

--- a/Mathlib/Data/Set/Card.lean
+++ b/Mathlib/Data/Set/Card.lean
@@ -133,6 +133,8 @@ theorem Finite.exists_encard_eq_coe (h : s.Finite) : ∃ (n : ℕ), s.encard = n
 @[simp] theorem encard_eq_top_iff : s.encard = ⊤ ↔ s.Infinite := by
   rw [← not_iff_not, ← Ne, ← lt_top_iff_ne_top, encard_lt_top_iff, not_infinite]
 
+alias ⟨_, encard_eq_top⟩ := encard_eq_top_iff
+
 theorem encard_ne_top_iff : s.encard ≠ ⊤ ↔ s.Finite := by
   simp
 

--- a/Mathlib/Topology/Algebra/InfiniteSum/ENNReal.lean
+++ b/Mathlib/Topology/Algebra/InfiniteSum/ENNReal.lean
@@ -15,7 +15,8 @@ This file provides lemmas relating sums of constants to the cardinality of the d
 ## TODO
 
 + Once we have a topology on `ENat`, provide an `ENat` valued version
-+ Once we replace `PartENat` entirely with `ENat` (and get a `ENat.card` to replace `PartENat.card`), provide versions which sum over the whole type.
++ Once we replace `PartENat` entirely with `ENat` (and replace `PartENat.card` with a `ENat.card`),
+  provide versions which sum over the whole type.
 -/
 
 open Set Function
@@ -32,9 +33,10 @@ lemma tsum_set_one_eq : ∑' (_ : s), (1 : ℝ≥0∞) = s.encard := by
   · have : Infinite s := infinite_coe_iff.mpr hinf
     rw [tsum_const_eq_top_of_ne_zero one_ne_zero, encard_eq_top hinf, ENat.toENNReal_top]
 
-lemma tsum_const_eq' {α : Type*} (s : Set α) (c : ℝ≥0∞) :
+@[simp]
+lemma tsum_set_const_eq' (c : ℝ≥0∞) :
     ∑' (_:s), (c : ℝ≥0∞) = s.encard * c := by
   nth_rw 1 [← one_mul c]
-  rw [ENNReal.tsum_mul_right,tsum_one_eq']
+  rw [ENNReal.tsum_mul_right,tsum_set_one_eq]
 
 end ENNReal

--- a/Mathlib/Topology/Algebra/InfiniteSum/ENNReal.lean
+++ b/Mathlib/Topology/Algebra/InfiniteSum/ENNReal.lean
@@ -12,46 +12,25 @@ import Mathlib.Topology.Instances.ENNReal
 
 This file provides lemmas relating sums of constants to the cardinality of the domain of these sums.
 
+## TODO
+
++ Once we have a topology on `ENat`, provide an `ENat` valued version
++ Once we replace `PartENat` entirely with `ENat` (and get a `ENat.card` to replace `PartENat.card`), provide versions which sum over the whole type.
 -/
 
 open Set Function
 
+variable {α : Type*} (s : Set α)
+
 namespace ENNReal
 
-lemma tsum_one_eq' {α : Type*} (s : Set α) : ∑' (_:s), (1 : ℝ≥0∞) = s.encard := by
-  if hfin : s.Finite then
-    have hfin' : Finite s := by exact hfin
-    rw [tsum_def]
-    simp only [ENNReal.summable, ↓reduceDIte]
-    have hsup: support (fun (_ : s) ↦ (1 : ℝ≥0∞)) = Set.univ := by
-      ext i
-      simp only [mem_support, ne_eq, one_ne_zero, not_false_eq_true, mem_univ]
-    have hsupfin: (Set.univ : Set s).Finite := by exact finite_univ
-    rw [← hsup] at hsupfin
-    rw [if_pos hsupfin]
-    rw [hfin.encard_eq_coe_toFinset_card]
-    simp only [ENat.toENNReal_coe]
-    rw [Finset.card_eq_sum_ones]
-    rw [finsum_eq_sum (fun (_ : s) ↦ (1 :ℝ≥0∞)) hsupfin]
-    simp only [Finset.sum_const, nsmul_eq_mul, mul_one, smul_eq_mul, Nat.cast_inj]
-    apply Finset.card_bij (fun a _ => a.val)
-    · intro a
-      simp only [Finite.mem_toFinset, mem_support, ne_eq, one_ne_zero, not_false_eq_true,
-        Subtype.coe_prop, imp_self]
-    · intro a _ a' _ heq
-      ext
-      exact heq
-    · intro a ha
-      use ⟨a,by
-        simp only [Finite.mem_toFinset] at ha
-        exact ha⟩
-      simp only [Finite.mem_toFinset, mem_support, ne_eq, one_ne_zero, not_false_eq_true,
-        exists_const]
-  else
-  have : Infinite s := by exact infinite_coe_iff.mpr hfin
-  rw [tsum_const_eq_top_of_ne_zero (by norm_num)]
-  rw [Set.encard_eq_top_iff.mpr hfin]
-  simp only [ENat.toENNReal_top]
+@[simp]
+lemma tsum_set_one_eq : ∑' (_ : s), (1 : ℝ≥0∞) = s.encard := by
+  obtain (hfin | hinf) := Set.finite_or_infinite s
+  · lift s to Finset α using hfin
+    simp [tsum_fintype]
+  · have : Infinite s := infinite_coe_iff.mpr hinf
+    rw [tsum_const_eq_top_of_ne_zero one_ne_zero, encard_eq_top hinf, ENat.toENNReal_top]
 
 lemma tsum_const_eq' {α : Type*} (s : Set α) (c : ℝ≥0∞) :
     ∑' (_:s), (c : ℝ≥0∞) = s.encard * c := by

--- a/Mathlib/Topology/Algebra/InfiniteSum/ENNReal.lean
+++ b/Mathlib/Topology/Algebra/InfiniteSum/ENNReal.lean
@@ -34,8 +34,7 @@ lemma tsum_set_one_eq : ∑' (_ : s), (1 : ℝ≥0∞) = s.encard := by
     rw [tsum_const_eq_top_of_ne_zero one_ne_zero, encard_eq_top hinf, ENat.toENNReal_top]
 
 @[simp]
-lemma tsum_set_const_eq' (c : ℝ≥0∞) :
-    ∑' (_:s), (c : ℝ≥0∞) = s.encard * c := by
+lemma tsum_set_const_eq (c : ℝ≥0∞) : ∑' (_:s), (c : ℝ≥0∞) = s.encard * c := by
   nth_rw 1 [← one_mul c]
   rw [ENNReal.tsum_mul_right,tsum_set_one_eq]
 

--- a/Mathlib/Topology/Algebra/InfiniteSum/ENNReal.lean
+++ b/Mathlib/Topology/Algebra/InfiniteSum/ENNReal.lean
@@ -7,7 +7,15 @@ import Mathlib.Data.Real.ENatENNReal
 import Mathlib.Data.Set.Card
 import Mathlib.Topology.Instances.ENNReal
 
+/-!
+# Infinite sums of ENNReal and Set.encard
+
+This file provides lemmas relating sums of constants to the cardinality of the domain of these sums.
+
+-/
+
 open Set Function
+
 namespace ENNReal
 
 lemma tsum_one_eq' {α : Type*} (s : Set α) : ∑' (_:s), (1 : ℝ≥0∞) = s.encard := by

--- a/Mathlib/Topology/Algebra/InfiniteSum/ENNReal.lean
+++ b/Mathlib/Topology/Algebra/InfiniteSum/ENNReal.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2024 Edward van de Meent. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Author: Edward van de Meent.
+Author: Edward van de Meent
 -/
 import Mathlib.Data.Real.ENatENNReal
 import Mathlib.Data.Set.Card

--- a/Mathlib/Topology/Algebra/InfiniteSum/ENNReal.lean
+++ b/Mathlib/Topology/Algebra/InfiniteSum/ENNReal.lean
@@ -1,0 +1,48 @@
+import Mathlib.Data.Real.ENatENNReal
+import Mathlib.Data.Set.Card
+import Mathlib.Topology.Instances.ENNReal
+
+open Set Function
+namespace ENNReal
+
+lemma tsum_one_eq' {α : Type*} (s : Set α) : ∑' (_:s), (1 : ℝ≥0∞) = s.encard := by
+  if hfin : s.Finite then
+    have hfin' : Finite s := by exact hfin
+    rw [tsum_def]
+    simp only [ENNReal.summable, ↓reduceDIte]
+    have hsup: support (fun (_ : s) ↦ (1 : ℝ≥0∞)) = Set.univ := by
+      ext i
+      simp only [mem_support, ne_eq, one_ne_zero, not_false_eq_true, mem_univ]
+    have hsupfin: (Set.univ : Set s).Finite := by exact finite_univ
+    rw [← hsup] at hsupfin
+    rw [if_pos hsupfin]
+    rw [hfin.encard_eq_coe_toFinset_card]
+    simp only [ENat.toENNReal_coe]
+    rw [Finset.card_eq_sum_ones]
+    rw [finsum_eq_sum (fun (_ : s) ↦ (1 :ℝ≥0∞)) hsupfin]
+    simp only [Finset.sum_const, nsmul_eq_mul, mul_one, smul_eq_mul, Nat.cast_inj]
+    apply Finset.card_bij (fun a _ => a.val)
+    · intro a
+      simp only [Finite.mem_toFinset, mem_support, ne_eq, one_ne_zero, not_false_eq_true,
+        Subtype.coe_prop, imp_self]
+    · intro a _ a' _ heq
+      ext
+      exact heq
+    · intro a ha
+      use ⟨a,by
+        simp only [Finite.mem_toFinset] at ha
+        exact ha⟩
+      simp only [Finite.mem_toFinset, mem_support, ne_eq, one_ne_zero, not_false_eq_true,
+        exists_const]
+  else
+  have : Infinite s := by exact infinite_coe_iff.mpr hfin
+  rw [tsum_const_eq_top_of_ne_zero (by norm_num)]
+  rw [Set.encard_eq_top_iff.mpr hfin]
+  simp only [ENat.toENNReal_top]
+
+lemma tsum_const_eq' {α : Type*} (s : Set α) (c : ℝ≥0∞) :
+    ∑' (_:s), (c : ℝ≥0∞) = s.encard * c := by
+  nth_rw 1 [← one_mul c]
+  rw [ENNReal.tsum_mul_right,tsum_one_eq']
+
+end ENNReal

--- a/Mathlib/Topology/Algebra/InfiniteSum/ENNReal.lean
+++ b/Mathlib/Topology/Algebra/InfiniteSum/ENNReal.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2024 Edward van de Meent. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Author: Edward van de Meent
+Authors: Edward van de Meent
 -/
 import Mathlib.Data.Real.ENatENNReal
 import Mathlib.Data.Set.Card

--- a/Mathlib/Topology/Algebra/InfiniteSum/ENNReal.lean
+++ b/Mathlib/Topology/Algebra/InfiniteSum/ENNReal.lean
@@ -1,3 +1,8 @@
+/-
+Copyright (c) 2024 Edward van de Meent. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Author: Edward van de Meent.
+-/
 import Mathlib.Data.Real.ENatENNReal
 import Mathlib.Data.Set.Card
 import Mathlib.Topology.Instances.ENNReal


### PR DESCRIPTION
two lemmas: `s.tsum (1:ENNReal) = s.encard` and `s.tsum c = s.encard * c`, where `c:ENNReal` and `s : Set α`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
