### PR TITLE
[Merged by Bors] - chore(test/CategoryTheory/Elementwise): use `MonCat`

### DIFF
--- a/test/CategoryTheory/Elementwise.lean
+++ b/test/CategoryTheory/Elementwise.lean
@@ -92,7 +92,7 @@ lemma bar''' {M N K : MonCat} {f : M ⟶ N} {g : N ⟶ K} {h : M ⟶ K} (w : f �
     g (f x) = h x := by apply foo_apply w
 
 example (M N K : MonCat) (f : M ⟶ N) (g : N ⟶ K) (h : M ⟶ K) (w : f ≫ g = h) (m : M) :
-    g (f m) = h m := by erw [elementwise_of% w]; rfl
+    g (f m) = h m := by erw [elementwise_of% w]; rfl -- Porting note: was `rw`, switched to `erw; rfl`
 
 example (M N K : MonCat) (f : M ⟶ N) (g : N ⟶ K) (h : M ⟶ K) (w : f ≫ g = h) (m : M) :
     g (f m) = h m := by

--- a/test/CategoryTheory/Elementwise.lean
+++ b/test/CategoryTheory/Elementwise.lean
@@ -1,12 +1,11 @@
 import Mathlib.Tactic.CategoryTheory.Elementwise
---import Mathlib.Algebra.Category.Mon.Basic
+import Mathlib.Algebra.Category.MonCat.Basic
 
 set_option autoImplicit true
 
 namespace ElementwiseTest
 open CategoryTheory
 
-set_option linter.existingAttributeWarning false in
 attribute [simp] Iso.hom_inv_id Iso.inv_hom_id IsIso.hom_inv_id IsIso.inv_hom_id
 
 attribute [local instance] ConcreteCategory.instFunLike ConcreteCategory.hasCoeToSort
@@ -82,22 +81,20 @@ example {C : Type u} [Category.{v} C] [ConcreteCategory.{w} C]
   rw [this]
 
 section Mon
--- TODO: switch to actual Mon when it is ported
-variable (Mon : Type _) [Category Mon] [ConcreteCategory Mon]
 
-lemma bar' {M N K : Mon} {f : M ⟶ N} {g : N ⟶ K} {h : M ⟶ K} (w : f ≫ g = h) (x : M) :
+lemma bar' {M N K : MonCat} {f : M ⟶ N} {g : N ⟶ K} {h : M ⟶ K} (w : f ≫ g = h) (x : M) :
     g (f x) = h x := by exact foo_apply w x
 
-lemma bar'' {M N K : Mon} {f : M ⟶ N} {g : N ⟶ K} {h : M ⟶ K} (w : f ≫ g = h) (x : M) :
+lemma bar'' {M N K : MonCat} {f : M ⟶ N} {g : N ⟶ K} {h : M ⟶ K} (w : f ≫ g = h) (x : M) :
     g (f x) = h x := by apply foo_apply w
 
-lemma bar''' {M N K : Mon} {f : M ⟶ N} {g : N ⟶ K} {h : M ⟶ K} (w : f ≫ g = h) (x : M) :
+lemma bar''' {M N K : MonCat} {f : M ⟶ N} {g : N ⟶ K} {h : M ⟶ K} (w : f ≫ g = h) (x : M) :
     g (f x) = h x := by apply foo_apply w
 
-example (M N K : Mon) (f : M ⟶ N) (g : N ⟶ K) (h : M ⟶ K) (w : f ≫ g = h) (m : M) :
-    g (f m) = h m := by rw [elementwise_of% w]
+example (M N K : MonCat) (f : M ⟶ N) (g : N ⟶ K) (h : M ⟶ K) (w : f ≫ g = h) (m : M) :
+    g (f m) = h m := by erw [elementwise_of% w]; rfl
 
-example (M N K : Mon) (f : M ⟶ N) (g : N ⟶ K) (h : M ⟶ K) (w : f ≫ g = h) (m : M) :
+example (M N K : MonCat) (f : M ⟶ N) (g : N ⟶ K) (h : M ⟶ K) (w : f ≫ g = h) (m : M) :
     g (f m) = h m := by
   -- Porting note: did not port `elementwise!` tactic
   replace w := elementwise_of% w


### PR DESCRIPTION
This addresses a TODO from the port.
One test only works with an erw and rfl; help from an expert fixing this is welcome. Remove one set_option which did not do anything.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
