### PR TITLE
[Merged by Bors] - chore(ConcreteCategory/Bundled): remove outdated comment about Bundled.map

### DIFF
--- a/Mathlib/CategoryTheory/ConcreteCategory/Bundled.lean
+++ b/Mathlib/CategoryTheory/ConcreteCategory/Bundled.lean
@@ -52,7 +52,7 @@ theorem coe_mk (α) (str) : (@Bundled.mk c α str : Type u) = α :=
   rfl
 
 /-- Map over the bundled structure -/
-def map (f : ∀ {α}, c α → d α) (b : Bundled c) : Bundled d :=
+abbrev map (f : ∀ {α}, c α → d α) (b : Bundled c) : Bundled d :=
   ⟨b, f b.str⟩
 
 end Bundled

--- a/Mathlib/CategoryTheory/ConcreteCategory/Bundled.lean
+++ b/Mathlib/CategoryTheory/ConcreteCategory/Bundled.lean
@@ -51,18 +51,6 @@ instance coeSort : CoeSort (Bundled c) (Type u) :=
 theorem coe_mk (α) (str) : (@Bundled.mk c α str : Type u) = α :=
   rfl
 
-/-
-`Bundled.map` is reducible so that, if we define a category
-
-  def Ring : Type (u+1) := induced_category SemiRing (bundled.map @ring.to_semiring)
-
-instance search is able to "see" that a morphism R ⟶ S in Ring is really
-a (semi)ring homomorphism from R.α to S.α, and not merely from
-`(Bundled.map @Ring.toSemiring R).α` to `(Bundled.map @Ring.toSemiring S).α`.
-
-TODO: Once at least one use of this has been ported, check if this still needs to be reducible in
-Lean 4.
--/
 /-- Map over the bundled structure -/
 def map (f : ∀ {α}, c α → d α) (b : Bundled c) : Bundled d :=
   ⟨b, f b.str⟩


### PR DESCRIPTION
the definition is not reducible, so apparently this is fine.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
