### PR TITLE
[Merged by Bors] - chore: normalise authors line in copyright header

### DIFF
--- a/test/MfldSetTac.lean
+++ b/test/MfldSetTac.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2022 Heather Macbeth. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Author: Heather Macbeth, Frédéric Dupuis
+Authors: Heather Macbeth, Frédéric Dupuis
 -/
 
 import Mathlib.Logic.Equiv.PartialEquiv

--- a/test/push_neg.lean
+++ b/test/push_neg.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2022 Alice Laroche. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Author: Alice Laroche, Frédéric Dupuis, Jireh Loreaux
+Authors: Alice Laroche, Frédéric Dupuis, Jireh Loreaux
 -/
 
 import Mathlib.Tactic.PushNeg


### PR DESCRIPTION
Two test files used 'Author', but had multiple authors. This is both absurd and violates the style guide.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
