### PR TITLE
[Merged by Bors] - chore(RingTheory): fix `DecidableEq` and `Fintype` vs `Finite`

### DIFF
--- a/Mathlib/RingTheory/AdicCompletion/AsTensorProduct.lean
+++ b/Mathlib/RingTheory/AdicCompletion/AsTensorProduct.lean
@@ -89,7 +89,11 @@ section PiFintype
 In this section we show that `ofTensorProduct` is an isomorphism if `M = R^n`.
 -/
 
-variable (ι : Type*) [Fintype ι] [DecidableEq ι]
+variable (ι : Type*)
+
+section DecidableEq
+
+variable [Fintype ι] [DecidableEq ι]
 
 private lemma piEquivOfFintype_comp_ofTensorProduct_eq :
     piEquivOfFintype I (fun _ : ι ↦ R) ∘ₗ ofTensorProduct I (ι → R) =
@@ -134,10 +138,14 @@ def ofTensorProductEquivOfPiFintype :
     (ofTensorProduct_comp_ofTensorProductInvOfPiFintype I ι)
     (ofTensorProductInvOfPiFintype_comp_ofTensorProduct I ι)
 
+end DecidableEq
+
 /-- If `M = R^ι`, `ofTensorProduct` is bijective. -/
-lemma ofTensorProduct_bijective_of_pi_of_fintype :
-    Function.Bijective (ofTensorProduct I (ι → R)) :=
-  EquivLike.bijective (ofTensorProductEquivOfPiFintype I ι)
+lemma ofTensorProduct_bijective_of_pi_of_fintype [Finite ι] :
+    Function.Bijective (ofTensorProduct I (ι → R)) := by
+  classical
+  cases nonempty_fintype ι
+  exact EquivLike.bijective (ofTensorProductEquivOfPiFintype I ι)
 
 end PiFintype
 

--- a/Mathlib/RingTheory/Flat/EquationalCriterion.lean
+++ b/Mathlib/RingTheory/Flat/EquationalCriterion.lean
@@ -220,10 +220,11 @@ Let $M$ be a flat module. Let $R^\iota$ be a finite free module, let $f \in R^{\
 element, and let $x \colon R^{\iota} \to M$ be a homomorphism such that $x(f) = 0$. Then there
 exist a finite free module $R^\kappa$ and homomorphisms $a \colon R^{\iota} \to R^{\kappa}$ and
 $y \colon R^{\kappa} \to M$ such that $x = y \circ a$ and $a(f) = 0$. -/
-theorem exists_factorization_of_apply_eq_zero [Flat R M] {ι : Type u} [Fintype ι]
+theorem exists_factorization_of_apply_eq_zero [Flat R M] {ι : Type u} [_root_.Finite ι]
     {f : ι →₀ R} {x : (ι →₀ R) →ₗ[R] M} (h : x f = 0) :
     ∃ (κ : Type u) (_ : Fintype κ) (a : (ι →₀ R) →ₗ[R] (κ →₀ R)) (y : (κ →₀ R) →ₗ[R] M),
-      x = y ∘ₗ a ∧ a f = 0 := iff_forall_exists_factorization.mp ‹Flat R M› h
+      x = y ∘ₗ a ∧ a f = 0 :=
+  let ⟨_⟩ := nonempty_fintype ι; iff_forall_exists_factorization.mp ‹Flat R M› h
 
 /-- **Equational criterion for flatness**
 [Stacks 00HK](https://stacks.math.columbia.edu/tag/00HK), backward direction, alternate form.


### PR DESCRIPTION
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)