### PR TITLE
[Merged by Bors] - feat(CstarAlgebra): define Hilbert C⋆-modules

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -1071,8 +1071,8 @@ import Mathlib.Analysis.CstarAlgebra.ContinuousFunctionalCalculus.Unital
 import Mathlib.Analysis.CstarAlgebra.ContinuousFunctionalCalculus.Unitary
 import Mathlib.Analysis.CstarAlgebra.Exponential
 import Mathlib.Analysis.CstarAlgebra.GelfandDuality
-import Mathlib.Analysis.CstarAlgebra.HilbertCstarModule
 import Mathlib.Analysis.CstarAlgebra.Matrix
+import Mathlib.Analysis.CstarAlgebra.Module
 import Mathlib.Analysis.CstarAlgebra.Multiplier
 import Mathlib.Analysis.CstarAlgebra.Spectrum
 import Mathlib.Analysis.CstarAlgebra.Unitization

--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -1071,6 +1071,7 @@ import Mathlib.Analysis.CstarAlgebra.ContinuousFunctionalCalculus.Unital
 import Mathlib.Analysis.CstarAlgebra.ContinuousFunctionalCalculus.Unitary
 import Mathlib.Analysis.CstarAlgebra.Exponential
 import Mathlib.Analysis.CstarAlgebra.GelfandDuality
+import Mathlib.Analysis.CstarAlgebra.HilbertCstarModule
 import Mathlib.Analysis.CstarAlgebra.Matrix
 import Mathlib.Analysis.CstarAlgebra.Multiplier
 import Mathlib.Analysis.CstarAlgebra.Spectrum

--- a/Mathlib/Analysis/CstarAlgebra/HilbertCstarModule.lean
+++ b/Mathlib/Analysis/CstarAlgebra/HilbertCstarModule.lean
@@ -253,33 +253,13 @@ lemma norm_eq_csSup [CompleteSpace A] (v : E) :
     ‖v‖ = sSup { ‖⟪w, v⟫_A‖ | (w : E) (_ : ‖w‖ ≤ 1) } := by
   let instNACG : NormedAddCommGroup E := NormedAddCommGroup.ofCore normedSpaceCore
   let instNS : NormedSpace ℂ E := .ofCore normedSpaceCore
-  apply Eq.symm
-  refine IsLUB.csSup_eq ⟨?mem_upperBounds, ?mem_lowerBounds⟩
-    ⟨0, ⟨0, by simp [HilbertCstarModule.inner_zero_left]⟩⟩
-  case mem_upperBounds =>
-    rw [mem_upperBounds]
-    intro x hx
-    obtain ⟨w, hw₁, hw₂⟩ := hx
-    rw [← hw₂]
+  refine Eq.symm <| IsGreatest.csSup_eq ⟨⟨‖v‖⁻¹ • v, ?_, ?_⟩, ?_⟩
+  · simpa only [norm_smul, norm_inv, norm_norm] using inv_mul_le_one_of_le le_rfl (by positivity)
+  · simp [norm_smul, HilbertCstarModule.inner_self_eq_norm_sq, pow_two, ← mul_assoc]
+  · rintro - ⟨w, hw, rfl⟩
     calc _ ≤ ‖w‖ * ‖v‖ := norm_inner_le E
       _ ≤ 1 * ‖v‖ := by gcongr
       _ = ‖v‖ := by simp
-  case mem_lowerBounds =>
-    rw [mem_lowerBounds]
-    intro x hx
-    rw [mem_upperBounds] at hx
-    have hmain : ‖v‖ ∈ { ‖⟪w, v⟫_A‖ | (w : E) (_ : ‖w‖ ≤ 1) } := by
-      refine ⟨‖v‖⁻¹ • v, ⟨?_, ?_⟩⟩
-      · simp [norm_smul]
-        by_cases hv : v = 0
-        · simp [hv]
-        · have hv' : ‖v‖ ≠ 0 := by
-            intro hv''
-            rw [HilbertCstarModule.norm_zero_iff] at hv''
-            exact hv hv''
-          rw [inv_mul_cancel hv']
-      · simp [norm_smul, HilbertCstarModule.inner_self_eq_norm_sq, pow_two, ← mul_assoc]
-    exact hx ‖v‖ hmain
 
 end norm
 

--- a/Mathlib/Analysis/CstarAlgebra/HilbertCstarModule.lean
+++ b/Mathlib/Analysis/CstarAlgebra/HilbertCstarModule.lean
@@ -1,0 +1,235 @@
+/-
+Copyright (c) 2024 Frédéric Dupuis. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Frédéric Dupuis
+-/
+
+import Mathlib.Analysis.InnerProductSpace.Basic
+import Mathlib.Analysis.CstarAlgebra.ContinuousFunctionalCalculus.Order
+
+/-!
+# Hilbert C⋆-modules
+
+FIXME
+
+## Main declarations
+
+## Implementation note
+
+FIXME
+-/
+
+open scoped ComplexOrder RightActions
+
+class HilbertCstarModule (A : outParam <| Type*) (E : Type*) [NonUnitalSemiring A] [StarRing A]
+    [Module ℂ A] [AddCommGroup E] [Module ℂ E] [PartialOrder A] [SMul Aᵐᵒᵖ E]
+    extends Inner A E where
+  inner_add_left x y z : inner (x + y) z = inner x z + inner y z
+  inner_self_nonneg x : 0 ≤ inner x x
+  inner_self x : inner x x = 0 ↔ x = 0
+  inner_op_smul_right (a : A) (x y : E) : inner x (y <• a) = inner x y * a
+  inner_smul_right_complex {z : ℂ} {x} {y} : inner x (z • y) = z • inner x y
+  star_inner x y : star (inner x y) = inner y x
+
+attribute [simp] HilbertCstarModule.inner_add_left HilbertCstarModule.star_inner
+  HilbertCstarModule.inner_op_smul_right HilbertCstarModule.inner_smul_right_complex
+
+namespace HilbertCstarModule
+
+section general
+
+variable {A E : Type*} [NonUnitalRing A] [StarRing A] [AddCommGroup E] [Module ℂ A]
+  [Module ℂ E] [PartialOrder A] [SMul Aᵐᵒᵖ E] [StarModule ℂ A] [HilbertCstarModule A E]
+
+local notation "⟪" x ", " y "⟫" => inner (𝕜 := A) x y
+
+@[simp]
+lemma inner_add_right {x y z : E} : ⟪x, y + z⟫ = ⟪x, y⟫ + ⟪x, z⟫ := by
+  rw [← star_star (r := ⟪x, y + z⟫)]
+  simp only [inner_add_left, star_add, star_inner]
+
+@[simp]
+lemma inner_op_smul_left {a : A} {x y : E} : ⟪x <• a, y⟫ = star a * ⟪x, y⟫ := by
+  rw [← star_inner]; simp
+
+@[simp]
+lemma inner_smul_left_complex {z : ℂ} {x y : E} : ⟪z • x, y⟫ = star z • ⟪x, y⟫ := by
+  rw [← star_inner]
+  simp
+
+@[simp]
+lemma inner_smul_left_real {z : ℝ} {x y : E} : ⟪z • x, y⟫ = z • ⟪x, y⟫ := by
+  have h₁ : z • x = (z : ℂ) • x := by simp
+  rw [h₁, ← star_inner, inner_smul_right_complex]
+  simp
+
+@[simp]
+lemma inner_smul_right_real {z : ℝ} {x y : E} : ⟪x, z • y⟫ = z • ⟪x, y⟫ := by
+  have h₁ : z • y = (z : ℂ) • y := by simp
+  rw [h₁, ← star_inner, inner_smul_left_complex]
+  simp
+
+def innerRightL (x : E) : E →ₗ[ℂ] A where
+  toFun y := ⟪x, y⟫
+  map_add' z y := by simp
+  map_smul' z y := by simp
+
+def innerLeftL (x : E) : E →ₗ⋆[ℂ] A where
+  toFun y := ⟪y, x⟫
+  map_add' z y := by simp
+  map_smul' z y := by simp
+
+lemma inner_eq_innerRightL (x y : E) : ⟪x, y⟫ = innerRightL x y := rfl
+
+lemma inner_eq_innerLeftL (x y : E) : ⟪x, y⟫ = innerLeftL y x := rfl
+
+@[simp] lemma inner_zero_right {x : E} : ⟪x, 0⟫ = 0 := by simp [inner_eq_innerRightL]
+@[simp] lemma inner_zero_left {x : E} : ⟪0, x⟫ = 0 := by simp [inner_eq_innerLeftL]
+@[simp] lemma inner_neg_right {x y : E} : ⟪x, -y⟫ = -⟪x, y⟫ := by simp [inner_eq_innerRightL]
+@[simp] lemma inner_neg_left {x y : E} : ⟪-x, y⟫ = -⟪x, y⟫ := by simp [inner_eq_innerLeftL]
+@[simp] lemma inner_sub_left {x y z : E} : ⟪x - y, z⟫ = ⟪x, z⟫ - ⟪y, z⟫ := by
+  simp [inner_eq_innerLeftL]
+@[simp] lemma inner_sub_right {x y z : E} : ⟪x, y - z⟫ = ⟪x, y⟫ - ⟪x, z⟫ := by
+  simp [inner_eq_innerRightL]
+
+lemma inner_sum_left {ι : Type*} [DecidableEq ι] {s : Finset ι} {x : ι → E} {y : E} :
+    ⟪∑ i ∈ s, x i, y⟫ = ∑ i ∈ s, ⟪x i, y⟫ := by
+  induction s using Finset.induction_on
+  case empty => simp
+  case insert a t a_notmem_t hbase =>
+    simp_rw [Finset.sum_insert a_notmem_t]
+    simp only [inner_add_left, hbase]
+
+lemma inner_sum_right {ι : Type*} [DecidableEq ι] {s : Finset ι} {x : E} {y : ι → E} :
+    ⟪x, ∑ i ∈ s, y i⟫ = ∑ i ∈ s, ⟪x, y i⟫ := by
+  induction s using Finset.induction_on
+  case empty => simp
+  case insert a t a_notmem_t hbase =>
+    simp_rw [Finset.sum_insert a_notmem_t]
+    simp only [inner_add_right, hbase]
+
+@[simp]
+lemma isSelfAdjoint_inner_self {x : E} : IsSelfAdjoint ⟪x, x⟫_A := star_inner _ _
+
+end general
+
+section normed
+
+variable {A E : Type*} [NonUnitalNormedRing A] [StarRing A] [CstarRing A] [PartialOrder A]
+  [CompleteSpace A] [StarOrderedRing A] [AddCommGroup E] [NormedSpace ℂ A]
+  [Module ℂ E] [SMul Aᵐᵒᵖ E]
+  [StarModule ℂ A] [hsm : HilbertCstarModule A E] [IsScalarTower ℂ A A] [SMulCommClass ℂ A A]
+
+local notation "⟪" x ", " y "⟫" => inner (𝕜 := A) x y
+
+variable (A) in
+noncomputable def norm : Norm E where
+  norm x := Real.sqrt ‖⟪x, x⟫‖
+
+attribute [local instance] norm
+
+lemma norm_def {x : E} : ‖x‖ = Real.sqrt ‖⟪x, x⟫‖ := rfl
+
+lemma inner_self_eq_norm_sq {x : E} : ‖⟪x, x⟫‖ = ‖x‖ ^ 2 := by simp [norm_def]
+
+@[simp] lemma norm_zero : ‖(0 : E)‖ = 0 := by simp [norm]
+
+@[simp]
+lemma norm_zero_iff (x : E) : ‖x‖ = 0 ↔ x = 0 :=
+  ⟨fun h => by simpa [norm, inner_self] using h, fun h => by simp [norm, h]⟩
+
+lemma norm_nonneg {x : E} : 0 ≤ ‖x‖ := by simp [norm]; positivity
+
+lemma norm_pos {x : E} (hx : x ≠ 0) : 0 < ‖x‖ := by
+  simp only [norm, Real.sqrt_pos, norm_pos_iff]
+  intro H
+  rw [inner_self] at H
+  exact hx H
+
+@[simp]
+lemma norm_neg {x : E} : ‖-x‖ = ‖x‖ := by simp [norm]
+
+lemma norm_sq_eq {x : E} : ‖x‖ ^ 2 = ‖⟪x, x⟫‖ := by simp [norm]
+
+lemma smul_nonneg_iff {a : A} {r : ℝ} (hr : 0 < r) : 0 ≤ a ↔ 0 ≤ r • a := by
+  refine ⟨smul_nonneg (le_of_lt hr), fun hra => ?_⟩
+  have : a = r⁻¹ • (r • a) := by
+    rw [smul_smul, inv_mul_cancel]
+    exact (MulAction.one_smul a).symm
+    exact Ne.symm (ne_of_lt hr)
+  rw [this]
+  refine smul_nonneg ?_ hra
+  positivity
+
+@[simp]
+protected lemma norm_smul {r : ℝ} {x : E} : ‖r • x‖ = ‖r‖ * ‖x‖ := by
+  rw [norm_def, norm_def]
+  simp only [inner_smul_left_real, inner_smul_right_real, _root_.norm_smul, ← mul_assoc]
+  rw [Real.sqrt_mul (by positivity)]
+  congr
+  exact Real.sqrt_mul_self (by positivity)
+
+lemma cauchy_schwarz₁ (x y : E) : ⟪y, x⟫ * ⟪x, y⟫ ≤ ‖x‖ ^ 2 • ⟪y, y⟫ := by
+  rcases eq_or_ne x 0 with h|h
+  · simp [h]
+  · have h₁ : ∀ (a : A),
+        (0 : A) ≤ ‖x‖ ^ 2 • (star a * a) - ‖x‖ ^ 2 • (⟪y, x⟫ * a)
+                  - ‖x‖ ^ 2 • (star a * ⟪x, y⟫) + ‖x‖ ^ 2 • (‖x‖ ^ 2 • ⟪y, y⟫) := fun a => by
+      calc (0 : A) ≤ ⟪x <• a - ‖x‖ ^ 2 • y, x <• a - ‖x‖ ^ 2 • y⟫_A := by
+                      exact inner_self_nonneg _
+            _ = star a * ⟪x, x⟫ * a - ‖x‖ ^ 2 • (⟪y, x⟫ * a)
+                  - ‖x‖ ^ 2 • (star a * ⟪x, y⟫) + ‖x‖ ^ 2 • (‖x‖ ^ 2 • ⟪y, y⟫) := by
+                      simp only [inner_sub_right, inner_op_smul_right, inner_sub_left,
+                        inner_op_smul_left, inner_smul_left_real, sub_mul, smul_mul_assoc,
+                        inner_smul_right_real, smul_sub]
+                      abel
+            _ ≤ ‖x‖ ^ 2 • (star a * a) - ‖x‖ ^ 2 • (⟪y, x⟫ * a)
+                  - ‖x‖ ^ 2 • (star a * ⟪x, y⟫) + ‖x‖ ^ 2 • (‖x‖ ^ 2 • ⟪y, y⟫) := by
+                      gcongr
+                      calc _ ≤ ‖⟪x, x⟫_A‖ • (star a * a) := CstarRing.conjugate_le_norm_smul
+                        _ = (Real.sqrt ‖⟪x, x⟫_A‖) ^ 2 • (star a * a) := by
+                                  congr
+                                  have : 0 ≤ ‖⟪x, x⟫_A‖ := by positivity
+                                  rw [Real.sq_sqrt this]
+                        _ = ‖x‖ ^ 2 • (star a * a) := rfl
+    specialize h₁ ⟪x, y⟫
+    simp only [star_inner, sub_self, zero_sub, le_neg_add_iff_add_le, add_zero] at h₁
+    rwa [smul_le_smul_iff_of_pos_left (pow_pos (norm_pos h) _)] at h₁
+
+lemma cauchy_schwarz₂ (x y : E) : ‖⟪x, y⟫‖ ≤ ‖x‖ * ‖y‖ := by
+  have := calc ‖⟪x, y⟫‖ ^ 2 = ‖⟪y, x⟫ * ⟪x, y⟫‖ := by
+                rw [← star_inner x y, CstarRing.norm_star_mul_self, pow_two]
+    _ ≤ ‖‖x‖^ 2 • ⟪y, y⟫‖ := by
+                refine CstarRing.norm_le_norm_of_nonneg_of_le ?_ (cauchy_schwarz₁ x y)
+                rw [← star_inner x y]
+                exact star_mul_self_nonneg ⟪x, y⟫_A
+    _ = ‖x‖ ^ 2 * ‖⟪y, y⟫‖ := by simp [_root_.norm_smul]
+    _ = ‖x‖ ^ 2 * ‖y‖ ^ 2 := by simp only [norm, _root_.norm_nonneg, Real.sq_sqrt]
+    _ = (‖x‖ * ‖y‖) ^ 2 := by simp only [mul_pow]
+  refine (pow_le_pow_iff_left (R := ℝ) (_root_.norm_nonneg ⟪x, y⟫_A) ?_ (by norm_num)).mp this
+  exact mul_nonneg norm_nonneg norm_nonneg
+
+lemma norm_triangle (x y : E) : ‖x + y‖ ≤ ‖x‖ + ‖y‖ := by
+  have h : ‖x + y‖ ^ 2 ≤ (‖x‖ + ‖y‖) ^ 2 := by
+    calc _ ≤ ‖⟪x, x⟫ + ⟪y, x⟫‖ + ‖⟪x, y⟫‖ + ‖⟪y, y⟫‖ := by
+          simp only [norm, inner_add_right, inner_add_left, ← add_assoc, _root_.norm_nonneg,
+            Real.sq_sqrt]
+          exact norm_add₃_le _ _ _
+      _ ≤ ‖⟪x, x⟫‖ + ‖⟪y, x⟫‖ + ‖⟪x, y⟫‖ + ‖⟪y, y⟫‖ := by gcongr; exact norm_add_le _ _
+      _ ≤ ‖⟪x, x⟫‖ + ‖y‖ * ‖x‖ + ‖x‖ * ‖y‖ + ‖⟪y, y⟫‖ := by
+          gcongr <;> exact cauchy_schwarz₂ _ _
+      _ = ‖x‖ ^ 2 + ‖y‖ * ‖x‖ + ‖x‖ * ‖y‖ + ‖y‖ ^ 2 := by
+          simp [norm]
+      _ = (‖x‖ + ‖y‖) ^ 2 := by simp only [add_pow_two, add_left_inj]; ring
+  refine (pow_le_pow_iff_left norm_nonneg ?_ (by norm_num)).mp h
+  exact add_nonneg norm_nonneg norm_nonneg
+
+lemma normedSpaceCore : NormedSpace.Core ℂ E where
+  norm_nonneg x := norm_nonneg
+  norm_eq_zero_iff x := norm_zero_iff x
+  norm_smul c x := by simp [norm, _root_.norm_smul, ← mul_assoc]
+  norm_triangle x y := norm_triangle x y
+
+end normed
+
+end HilbertCstarModule

--- a/Mathlib/Analysis/CstarAlgebra/HilbertCstarModule.lean
+++ b/Mathlib/Analysis/CstarAlgebra/HilbertCstarModule.lean
@@ -4,7 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Frédéric Dupuis
 -/
 
-import Mathlib.Analysis.InnerProductSpace.Basic
 import Mathlib.Analysis.CstarAlgebra.ContinuousFunctionalCalculus.Order
 
 /-!
@@ -21,17 +20,21 @@ FIXME
 
 open scoped ComplexOrder RightActions
 
+/-- A *Hilbert C⋆-module* is a complex linear space `E` endowed with a right `A`-module structure
+(where `A` is typically a C⋆-algebra) and an inner product `⟪x, y⟫_A` which satisfies the
+following properties. -/
 class HilbertCstarModule (A : outParam <| Type*) (E : Type*) [NonUnitalSemiring A] [StarRing A]
-    [Module ℂ A] [AddCommGroup E] [Module ℂ E] [PartialOrder A] [SMul Aᵐᵒᵖ E]
+    [Module ℂ A] [AddCommGroup E] [Module ℂ E] [PartialOrder A] [SMul Aᵐᵒᵖ E] [Norm A] [Norm E]
     extends Inner A E where
-  inner_add_left x y z : inner (x + y) z = inner x z + inner y z
-  inner_self_nonneg x : 0 ≤ inner x x
-  inner_self x : inner x x = 0 ↔ x = 0
-  inner_op_smul_right (a : A) (x y : E) : inner x (y <• a) = inner x y * a
+  inner_add_right {x} {y} {z} : inner x (y + z) = inner x y + inner x z
+  inner_self_nonneg {x} : 0 ≤ inner x x
+  inner_self {x} : inner x x = 0 ↔ x = 0
+  inner_op_smul_right {a : A} {x y : E} : inner x (y <• a) = inner x y * a
   inner_smul_right_complex {z : ℂ} {x} {y} : inner x (z • y) = z • inner x y
   star_inner x y : star (inner x y) = inner y x
+  norm_eq_sqrt_norm_inner_self x : ‖x‖ = √‖inner x x‖
 
-attribute [simp] HilbertCstarModule.inner_add_left HilbertCstarModule.star_inner
+attribute [simp] HilbertCstarModule.inner_add_right HilbertCstarModule.star_inner
   HilbertCstarModule.inner_op_smul_right HilbertCstarModule.inner_smul_right_complex
 
 namespace HilbertCstarModule
@@ -39,14 +42,15 @@ namespace HilbertCstarModule
 section general
 
 variable {A E : Type*} [NonUnitalRing A] [StarRing A] [AddCommGroup E] [Module ℂ A]
-  [Module ℂ E] [PartialOrder A] [SMul Aᵐᵒᵖ E] [StarModule ℂ A] [HilbertCstarModule A E]
+  [Module ℂ E] [PartialOrder A] [SMul Aᵐᵒᵖ E] [StarModule ℂ A] [Norm A] [Norm E]
+  [HilbertCstarModule A E]
 
 local notation "⟪" x ", " y "⟫" => inner (𝕜 := A) x y
 
 @[simp]
-lemma inner_add_right {x y z : E} : ⟪x, y + z⟫ = ⟪x, y⟫ + ⟪x, z⟫ := by
-  rw [← star_star (r := ⟪x, y + z⟫)]
-  simp only [inner_add_left, star_add, star_inner]
+lemma inner_add_left {x y z : E} : ⟪x + y, z⟫ = ⟪x, z⟫ + ⟪y, z⟫ := by
+  rw [← star_star (r := ⟪x + y, z⟫)]
+  simp only [inner_add_right, star_add, star_inner]
 
 @[simp]
 lemma inner_op_smul_left {a : A} {x y : E} : ⟪x <• a, y⟫ = star a * ⟪x, y⟫ := by
@@ -69,11 +73,13 @@ lemma inner_smul_right_real {z : ℝ} {x y : E} : ⟪x, z • y⟫ = z • ⟪x,
   rw [h₁, ← star_inner, inner_smul_left_complex]
   simp
 
+/-- The function `y ↦ ⟪x, y⟫` bundled as a linear map. -/
 def innerRightL (x : E) : E →ₗ[ℂ] A where
   toFun y := ⟪x, y⟫
   map_add' z y := by simp
   map_smul' z y := by simp
 
+/-- The function `y ↦ ⟪y, x⟫` bundled as a conjugate-linear map. -/
 def innerLeftL (x : E) : E →ₗ⋆[ℂ] A where
   toFun y := ⟪y, x⟫
   map_add' z y := by simp
@@ -87,19 +93,12 @@ lemma inner_eq_innerLeftL (x y : E) : ⟪x, y⟫ = innerLeftL y x := rfl
 @[simp] lemma inner_zero_left {x : E} : ⟪0, x⟫ = 0 := by simp [inner_eq_innerLeftL]
 @[simp] lemma inner_neg_right {x y : E} : ⟪x, -y⟫ = -⟪x, y⟫ := by simp [inner_eq_innerRightL]
 @[simp] lemma inner_neg_left {x y : E} : ⟪-x, y⟫ = -⟪x, y⟫ := by simp [inner_eq_innerLeftL]
-@[simp] lemma inner_sub_left {x y z : E} : ⟪x - y, z⟫ = ⟪x, z⟫ - ⟪y, z⟫ := by
-  simp [inner_eq_innerLeftL]
 @[simp] lemma inner_sub_right {x y z : E} : ⟪x, y - z⟫ = ⟪x, y⟫ - ⟪x, z⟫ := by
   simp [inner_eq_innerRightL]
+@[simp] lemma inner_sub_left {x y z : E} : ⟪x - y, z⟫ = ⟪x, z⟫ - ⟪y, z⟫ := by
+  simp [inner_eq_innerLeftL]
 
-lemma inner_sum_left {ι : Type*} [DecidableEq ι] {s : Finset ι} {x : ι → E} {y : E} :
-    ⟪∑ i ∈ s, x i, y⟫ = ∑ i ∈ s, ⟪x i, y⟫ := by
-  induction s using Finset.induction_on
-  case empty => simp
-  case insert a t a_notmem_t hbase =>
-    simp_rw [Finset.sum_insert a_notmem_t]
-    simp only [inner_add_left, hbase]
-
+@[simp]
 lemma inner_sum_right {ι : Type*} [DecidableEq ι] {s : Finset ι} {x : E} {y : ι → E} :
     ⟪x, ∑ i ∈ s, y i⟫ = ∑ i ∈ s, ⟪x, y i⟫ := by
   induction s using Finset.induction_on
@@ -107,6 +106,10 @@ lemma inner_sum_right {ι : Type*} [DecidableEq ι] {s : Finset ι} {x : E} {y :
   case insert a t a_notmem_t hbase =>
     simp_rw [Finset.sum_insert a_notmem_t]
     simp only [inner_add_right, hbase]
+
+@[simp]
+lemma inner_sum_left {ι : Type*} [DecidableEq ι] {s : Finset ι} {x : ι → E} {y : E} :
+    ⟪∑ i ∈ s, x i, y⟫ = ∑ i ∈ s, ⟪x i, y⟫ := by rw [← star_inner y]; simp
 
 @[simp]
 lemma isSelfAdjoint_inner_self {x : E} : IsSelfAdjoint ⟪x, x⟫_A := star_inner _ _
@@ -117,39 +120,41 @@ section normed
 
 variable {A E : Type*} [NonUnitalNormedRing A] [StarRing A] [CstarRing A] [PartialOrder A]
   [CompleteSpace A] [StarOrderedRing A] [AddCommGroup E] [NormedSpace ℂ A]
-  [Module ℂ E] [SMul Aᵐᵒᵖ E]
+  [Module ℂ E] [SMul Aᵐᵒᵖ E] [Norm E]
   [StarModule ℂ A] [hsm : HilbertCstarModule A E] [IsScalarTower ℂ A A] [SMulCommClass ℂ A A]
 
 local notation "⟪" x ", " y "⟫" => inner (𝕜 := A) x y
 
 variable (A) in
+/-- The norm associated with a Hilbert C⋆-module. It is not registered as a norm, since a type
+might already have a norm defined on it. -/
 noncomputable def norm : Norm E where
   norm x := Real.sqrt ‖⟪x, x⟫‖
 
-attribute [local instance] norm
+--attribute [local instance] norm
 
-lemma norm_def {x : E} : ‖x‖ = Real.sqrt ‖⟪x, x⟫‖ := rfl
+--lemma norm_eq_sqrt_norm_inner_self {x : E} : ‖x‖ = Real.sqrt ‖⟪x, x⟫‖ := rfl
 
-lemma inner_self_eq_norm_sq {x : E} : ‖⟪x, x⟫‖ = ‖x‖ ^ 2 := by simp [norm_def]
+lemma inner_self_eq_norm_sq {x : E} : ‖⟪x, x⟫‖ = ‖x‖ ^ 2 := by simp [norm_eq_sqrt_norm_inner_self]
 
-@[simp] lemma norm_zero : ‖(0 : E)‖ = 0 := by simp [norm]
+@[simp] lemma norm_zero : ‖(0 : E)‖ = 0 := by simp [norm_eq_sqrt_norm_inner_self]
 
 @[simp]
 lemma norm_zero_iff (x : E) : ‖x‖ = 0 ↔ x = 0 :=
-  ⟨fun h => by simpa [norm, inner_self] using h, fun h => by simp [norm, h]⟩
+  ⟨fun h => by simpa [norm_eq_sqrt_norm_inner_self, inner_self] using h, fun h => by simp [norm, h]⟩
 
-lemma norm_nonneg {x : E} : 0 ≤ ‖x‖ := by simp [norm]; positivity
+lemma norm_nonneg {x : E} : 0 ≤ ‖x‖ := by simp [norm_eq_sqrt_norm_inner_self]; positivity
 
 lemma norm_pos {x : E} (hx : x ≠ 0) : 0 < ‖x‖ := by
-  simp only [norm, Real.sqrt_pos, norm_pos_iff]
+  simp only [norm_eq_sqrt_norm_inner_self, Real.sqrt_pos, norm_pos_iff]
   intro H
   rw [inner_self] at H
   exact hx H
 
 @[simp]
-lemma norm_neg {x : E} : ‖-x‖ = ‖x‖ := by simp [norm]
+lemma norm_neg {x : E} : ‖-x‖ = ‖x‖ := by simp [norm_eq_sqrt_norm_inner_self]
 
-lemma norm_sq_eq {x : E} : ‖x‖ ^ 2 = ‖⟪x, x⟫‖ := by simp [norm]
+lemma norm_sq_eq {x : E} : ‖x‖ ^ 2 = ‖⟪x, x⟫‖ := by simp [norm_eq_sqrt_norm_inner_self]
 
 lemma smul_nonneg_iff {a : A} {r : ℝ} (hr : 0 < r) : 0 ≤ a ↔ 0 ≤ r • a := by
   refine ⟨smul_nonneg (le_of_lt hr), fun hra => ?_⟩
@@ -163,7 +168,7 @@ lemma smul_nonneg_iff {a : A} {r : ℝ} (hr : 0 < r) : 0 ≤ a ↔ 0 ≤ r • a
 
 @[simp]
 protected lemma norm_smul {r : ℝ} {x : E} : ‖r • x‖ = ‖r‖ * ‖x‖ := by
-  rw [norm_def, norm_def]
+  rw [norm_eq_sqrt_norm_inner_self, norm_eq_sqrt_norm_inner_self x]
   simp only [inner_smul_left_real, inner_smul_right_real, _root_.norm_smul, ← mul_assoc]
   rw [Real.sqrt_mul (by positivity)]
   congr
@@ -176,7 +181,7 @@ lemma cauchy_schwarz₁ (x y : E) : ⟪y, x⟫ * ⟪x, y⟫ ≤ ‖x‖ ^ 2 • 
         (0 : A) ≤ ‖x‖ ^ 2 • (star a * a) - ‖x‖ ^ 2 • (⟪y, x⟫ * a)
                   - ‖x‖ ^ 2 • (star a * ⟪x, y⟫) + ‖x‖ ^ 2 • (‖x‖ ^ 2 • ⟪y, y⟫) := fun a => by
       calc (0 : A) ≤ ⟪x <• a - ‖x‖ ^ 2 • y, x <• a - ‖x‖ ^ 2 • y⟫_A := by
-                      exact inner_self_nonneg _
+                      exact inner_self_nonneg
             _ = star a * ⟪x, x⟫ * a - ‖x‖ ^ 2 • (⟪y, x⟫ * a)
                   - ‖x‖ ^ 2 • (star a * ⟪x, y⟫) + ‖x‖ ^ 2 • (‖x‖ ^ 2 • ⟪y, y⟫) := by
                       simp only [inner_sub_right, inner_op_smul_right, inner_sub_left,
@@ -191,20 +196,21 @@ lemma cauchy_schwarz₁ (x y : E) : ⟪y, x⟫ * ⟪x, y⟫ ≤ ‖x‖ ^ 2 • 
                                   congr
                                   have : 0 ≤ ‖⟪x, x⟫_A‖ := by positivity
                                   rw [Real.sq_sqrt this]
-                        _ = ‖x‖ ^ 2 • (star a * a) := rfl
+                        _ = ‖x‖ ^ 2 • (star a * a) := by rw [← norm_eq_sqrt_norm_inner_self]
     specialize h₁ ⟪x, y⟫
     simp only [star_inner, sub_self, zero_sub, le_neg_add_iff_add_le, add_zero] at h₁
     rwa [smul_le_smul_iff_of_pos_left (pow_pos (norm_pos h) _)] at h₁
 
 lemma cauchy_schwarz₂ (x y : E) : ‖⟪x, y⟫‖ ≤ ‖x‖ * ‖y‖ := by
   have := calc ‖⟪x, y⟫‖ ^ 2 = ‖⟪y, x⟫ * ⟪x, y⟫‖ := by
-                rw [← star_inner x y, CstarRing.norm_star_mul_self, pow_two]
+                rw [← star_inner x, CstarRing.norm_star_mul_self, pow_two]
     _ ≤ ‖‖x‖^ 2 • ⟪y, y⟫‖ := by
                 refine CstarRing.norm_le_norm_of_nonneg_of_le ?_ (cauchy_schwarz₁ x y)
-                rw [← star_inner x y]
+                rw [← star_inner x]
                 exact star_mul_self_nonneg ⟪x, y⟫_A
     _ = ‖x‖ ^ 2 * ‖⟪y, y⟫‖ := by simp [_root_.norm_smul]
-    _ = ‖x‖ ^ 2 * ‖y‖ ^ 2 := by simp only [norm, _root_.norm_nonneg, Real.sq_sqrt]
+    _ = ‖x‖ ^ 2 * ‖y‖ ^ 2 := by
+                simp only [norm_eq_sqrt_norm_inner_self, _root_.norm_nonneg, Real.sq_sqrt]
     _ = (‖x‖ * ‖y‖) ^ 2 := by simp only [mul_pow]
   refine (pow_le_pow_iff_left (R := ℝ) (_root_.norm_nonneg ⟪x, y⟫_A) ?_ (by norm_num)).mp this
   exact mul_nonneg norm_nonneg norm_nonneg
@@ -212,22 +218,24 @@ lemma cauchy_schwarz₂ (x y : E) : ‖⟪x, y⟫‖ ≤ ‖x‖ * ‖y‖ := by
 lemma norm_triangle (x y : E) : ‖x + y‖ ≤ ‖x‖ + ‖y‖ := by
   have h : ‖x + y‖ ^ 2 ≤ (‖x‖ + ‖y‖) ^ 2 := by
     calc _ ≤ ‖⟪x, x⟫ + ⟪y, x⟫‖ + ‖⟪x, y⟫‖ + ‖⟪y, y⟫‖ := by
-          simp only [norm, inner_add_right, inner_add_left, ← add_assoc, _root_.norm_nonneg,
-            Real.sq_sqrt]
+          simp only [norm_eq_sqrt_norm_inner_self, inner_add_right, inner_add_left, ← add_assoc,
+            _root_.norm_nonneg, Real.sq_sqrt]
           exact norm_add₃_le _ _ _
       _ ≤ ‖⟪x, x⟫‖ + ‖⟪y, x⟫‖ + ‖⟪x, y⟫‖ + ‖⟪y, y⟫‖ := by gcongr; exact norm_add_le _ _
       _ ≤ ‖⟪x, x⟫‖ + ‖y‖ * ‖x‖ + ‖x‖ * ‖y‖ + ‖⟪y, y⟫‖ := by
           gcongr <;> exact cauchy_schwarz₂ _ _
       _ = ‖x‖ ^ 2 + ‖y‖ * ‖x‖ + ‖x‖ * ‖y‖ + ‖y‖ ^ 2 := by
-          simp [norm]
+          simp [norm_eq_sqrt_norm_inner_self]
       _ = (‖x‖ + ‖y‖) ^ 2 := by simp only [add_pow_two, add_left_inj]; ring
   refine (pow_le_pow_iff_left norm_nonneg ?_ (by norm_num)).mp h
   exact add_nonneg norm_nonneg norm_nonneg
 
+/-- This allows us to get `NormedAddCommGroup` and `NormedSpace` instances on `E` via
+`NormedAddCommGroup.ofCore` and `NormedSpace.ofCore`. -/
 lemma normedSpaceCore : NormedSpace.Core ℂ E where
   norm_nonneg x := norm_nonneg
   norm_eq_zero_iff x := norm_zero_iff x
-  norm_smul c x := by simp [norm, _root_.norm_smul, ← mul_assoc]
+  norm_smul c x := by simp [norm_eq_sqrt_norm_inner_self, _root_.norm_smul, ← mul_assoc]
   norm_triangle x y := norm_triangle x y
 
 end normed

--- a/Mathlib/Analysis/CstarAlgebra/HilbertCstarModule.lean
+++ b/Mathlib/Analysis/CstarAlgebra/HilbertCstarModule.lean
@@ -135,15 +135,14 @@ lemma inner_sum_left {ι : Type*} [DecidableEq ι] {s : Finset ι} {x : ι → E
     ⟪∑ i ∈ s, x i, y⟫ = ∑ i ∈ s, ⟪x i, y⟫ := by rw [← star_inner y]; simp
 
 @[simp]
-lemma isSelfAdjoint_inner_self {x : E} : IsSelfAdjoint ⟪x, x⟫_A := star_inner _ _
+lemma isSelfAdjoint_inner_self {x : E} : IsSelfAdjoint ⟪x, x⟫ := star_inner _ _
 
 end general
 
 section norm
 
 variable {A E : Type*} [NonUnitalNormedRing A] [StarRing A] [CstarRing A] [PartialOrder A]
-  [CompleteSpace A] [StarOrderedRing A] [AddCommGroup E] [NormedSpace ℂ A]
-  [Module ℂ E] [SMul Aᵐᵒᵖ E] [Norm E]
+  [StarOrderedRing A] [AddCommGroup E] [NormedSpace ℂ A] [Module ℂ E] [SMul Aᵐᵒᵖ E] [Norm E]
   [StarModule ℂ A] [HilbertCstarModule A E] [IsScalarTower ℂ A A] [SMulCommClass ℂ A A]
 
 local notation "⟪" x ", " y "⟫" => inner (𝕜 := A) x y
@@ -195,7 +194,7 @@ protected lemma norm_smul {r : ℝ} {x : E} : ‖r • x‖ = ‖r‖ * ‖x‖ 
   exact Real.sqrt_mul_self (by positivity)
 
 /-- A version of the Cauchy-Schwarz inequality for Hilbert C⋆-modules. -/
-lemma inner_mul_inner_swap_le {x y : E} : ⟪y, x⟫ * ⟪x, y⟫ ≤ ‖x‖ ^ 2 • ⟪y, y⟫ := by
+lemma inner_mul_inner_swap_le [CompleteSpace A] {x y : E} : ⟪y, x⟫ * ⟪x, y⟫ ≤ ‖x‖ ^ 2 • ⟪y, y⟫ := by
   rcases eq_or_ne x 0 with h|h
   · simp [h]
   · have h₁ : ∀ (a : A),
@@ -223,7 +222,7 @@ lemma inner_mul_inner_swap_le {x y : E} : ⟪y, x⟫ * ⟪x, y⟫ ≤ ‖x‖ ^ 
     rwa [smul_le_smul_iff_of_pos_left (pow_pos (HilbertCstarModule.norm_pos h) _)] at h₁
 
 /-- The Cauchy-Schwarz inequality for Hilbert C⋆-modules. -/
-lemma norm_inner_le {x y : E} : ‖⟪x, y⟫‖ ≤ ‖x‖ * ‖y‖ := by
+lemma norm_inner_le [CompleteSpace A] {x y : E} : ‖⟪x, y⟫‖ ≤ ‖x‖ * ‖y‖ := by
   have := calc ‖⟪x, y⟫‖ ^ 2 = ‖⟪y, x⟫ * ⟪x, y⟫‖ := by
                 rw [← star_inner x, CstarRing.norm_star_mul_self, pow_two]
     _ ≤ ‖‖x‖^ 2 • ⟪y, y⟫‖ := by
@@ -237,7 +236,7 @@ lemma norm_inner_le {x y : E} : ‖⟪x, y⟫‖ ≤ ‖x‖ * ‖y‖ := by
   refine (pow_le_pow_iff_left (R := ℝ) (norm_nonneg ⟪x, y⟫_A) ?_ (by norm_num)).mp this
   exact mul_nonneg HilbertCstarModule.norm_nonneg HilbertCstarModule.norm_nonneg
 
-protected lemma norm_triangle (x y : E) : ‖x + y‖ ≤ ‖x‖ + ‖y‖ := by
+protected lemma norm_triangle [CompleteSpace A] (x y : E) : ‖x + y‖ ≤ ‖x‖ + ‖y‖ := by
   have h : ‖x + y‖ ^ 2 ≤ (‖x‖ + ‖y‖) ^ 2 := by
     calc _ ≤ ‖⟪x, x⟫ + ⟪y, x⟫‖ + ‖⟪x, y⟫‖ + ‖⟪y, y⟫‖ := by
           simp only [norm_eq_sqrt_norm_inner_self, inner_add_right, inner_add_left, ← add_assoc,
@@ -253,7 +252,7 @@ protected lemma norm_triangle (x y : E) : ‖x + y‖ ≤ ‖x‖ + ‖y‖ := b
 
 /-- This allows us to get `NormedAddCommGroup` and `NormedSpace` instances on `E` via
 `NormedAddCommGroup.ofCore` and `NormedSpace.ofCore`. -/
-lemma normedSpaceCore : NormedSpace.Core ℂ E where
+lemma normedSpaceCore [CompleteSpace A] : NormedSpace.Core ℂ E where
   norm_nonneg x := HilbertCstarModule.norm_nonneg
   norm_eq_zero_iff x := norm_zero_iff x
   norm_smul c x := by simp [norm_eq_sqrt_norm_inner_self, norm_smul, ← mul_assoc]

--- a/Mathlib/Analysis/CstarAlgebra/HilbertCstarModule.lean
+++ b/Mathlib/Analysis/CstarAlgebra/HilbertCstarModule.lean
@@ -171,9 +171,6 @@ protected lemma norm_pos {x : E} (hx : x ≠ 0) : 0 < ‖x‖ := by
   rw [inner_self] at H
   exact hx H
 
-@[simp]
-protected lemma norm_neg {x : E} : ‖-x‖ = ‖x‖ := by simp [norm_eq_sqrt_norm_inner_self]
-
 lemma norm_sq_eq {x : E} : ‖x‖ ^ 2 = ‖⟪x, x⟫‖ := by simp [norm_eq_sqrt_norm_inner_self]
 
 protected lemma smul_nonneg_iff {a : A} {r : ℝ} (hr : 0 < r) : 0 ≤ a ↔ 0 ≤ r • a := by
@@ -185,14 +182,6 @@ protected lemma smul_nonneg_iff {a : A} {r : ℝ} (hr : 0 < r) : 0 ≤ a ↔ 0 �
   rw [this]
   refine smul_nonneg ?_ hra
   positivity
-
-@[simp]
-protected lemma norm_smul {r : ℝ} {x : E} : ‖r • x‖ = ‖r‖ * ‖x‖ := by
-  rw [norm_eq_sqrt_norm_inner_self, norm_eq_sqrt_norm_inner_self x]
-  simp only [inner_smul_left_real, inner_smul_right_real, norm_smul, ← mul_assoc]
-  rw [Real.sqrt_mul (by positivity)]
-  congr
-  exact Real.sqrt_mul_self (by positivity)
 
 /-- A version of the Cauchy-Schwarz inequality for Hilbert C⋆-modules. -/
 lemma inner_mul_inner_swap_le [CompleteSpace A] {x y : E} : ⟪y, x⟫ * ⟪x, y⟫ ≤ ‖x‖ ^ 2 • ⟪y, y⟫ := by
@@ -263,6 +252,7 @@ lemma normedSpaceCore [CompleteSpace A] : NormedSpace.Core ℂ E where
 lemma norm_eq_csSup [CompleteSpace A] (v : E) :
     ‖v‖ = sSup { ‖⟪w, v⟫_A‖ | (w : E) (_ : ‖w‖ ≤ 1) } := by
   let instNACG : NormedAddCommGroup E := NormedAddCommGroup.ofCore normedSpaceCore
+  let instNS : NormedSpace ℂ E := .ofCore normedSpaceCore
   apply Eq.symm
   refine IsLUB.csSup_eq ⟨?mem_upperBounds, ?mem_lowerBounds⟩
     ⟨0, ⟨0, by simp [HilbertCstarModule.inner_zero_left]⟩⟩
@@ -280,7 +270,7 @@ lemma norm_eq_csSup [CompleteSpace A] (v : E) :
     rw [mem_upperBounds] at hx
     have hmain : ‖v‖ ∈ { ‖⟪w, v⟫_A‖ | (w : E) (_ : ‖w‖ ≤ 1) } := by
       refine ⟨‖v‖⁻¹ • v, ⟨?_, ?_⟩⟩
-      · simp [HilbertCstarModule.norm_smul (x := v)]
+      · simp [norm_smul]
         by_cases hv : v = 0
         · simp [hv]
         · have hv' : ‖v‖ ≠ 0 := by

--- a/Mathlib/Analysis/CstarAlgebra/Module.lean
+++ b/Mathlib/Analysis/CstarAlgebra/Module.lean
@@ -107,16 +107,14 @@ def innerₛₗ : E →ₗ⋆[ℂ] E →ₗ[ℂ] A where
 
 lemma innerₛₗ_apply {x y : E} : innerₛₗ x y = ⟪x, y⟫ := rfl
 
-lemma inner_eq_innerₛₗ (x y : E) : ⟪x, y⟫ = innerₛₗ x y := rfl
-
-@[simp] lemma inner_zero_right {x : E} : ⟪x, 0⟫ = 0 := by simp [inner_eq_innerₛₗ]
-@[simp] lemma inner_zero_left {x : E} : ⟪0, x⟫ = 0 := by simp [inner_eq_innerₛₗ]
-@[simp] lemma inner_neg_right {x y : E} : ⟪x, -y⟫ = -⟪x, y⟫ := by simp [inner_eq_innerₛₗ]
-@[simp] lemma inner_neg_left {x y : E} : ⟪-x, y⟫ = -⟪x, y⟫ := by simp [inner_eq_innerₛₗ]
+@[simp] lemma inner_zero_right {x : E} : ⟪x, 0⟫ = 0 := by simp [← innerₛₗ_apply]
+@[simp] lemma inner_zero_left {x : E} : ⟪0, x⟫ = 0 := by simp [← innerₛₗ_apply]
+@[simp] lemma inner_neg_right {x y : E} : ⟪x, -y⟫ = -⟪x, y⟫ := by simp [← innerₛₗ_apply]
+@[simp] lemma inner_neg_left {x y : E} : ⟪-x, y⟫ = -⟪x, y⟫ := by simp [← innerₛₗ_apply]
 @[simp] lemma inner_sub_right {x y z : E} : ⟪x, y - z⟫ = ⟪x, y⟫ - ⟪x, z⟫ := by
-  simp [inner_eq_innerₛₗ]
+  simp [← innerₛₗ_apply]
 @[simp] lemma inner_sub_left {x y z : E} : ⟪x - y, z⟫ = ⟪x, z⟫ - ⟪y, z⟫ := by
-  simp [inner_eq_innerₛₗ]
+  simp [← innerₛₗ_apply]
 
 @[simp]
 lemma inner_sum_right {ι : Type*} [DecidableEq ι] {s : Finset ι} {x : E} {y : ι → E} :
@@ -262,11 +260,9 @@ noncomputable def innerSL : E →L⋆[ℂ] E →L[ℂ] A :=
 
 lemma innerSL_apply {x y : E} : innerSL x y = ⟪x, y⟫_A := rfl
 
-lemma inner_eq_innerSL (x y : E) : ⟪x, y⟫_A = innerSL x y := rfl
-
 @[continuity, fun_prop]
 lemma continuous_inner : Continuous (fun x : E × E => ⟪x.1, x.2⟫_A) := by
-  simp_rw [inner_eq_innerSL]
+  simp_rw [← innerSL_apply]
   fun_prop
 
 end NormedAddCommGroup

--- a/Mathlib/Analysis/CstarAlgebra/Module.lean
+++ b/Mathlib/Analysis/CstarAlgebra/Module.lean
@@ -154,7 +154,6 @@ lemma inner_self_eq_norm_sq {x : E} : ‖⟪x, x⟫‖ = ‖x‖ ^ 2 := by simp 
 
 protected lemma norm_zero : ‖(0 : E)‖ = 0 := by simp [norm_eq_sqrt_norm_inner_self]
 
-@[simp]
 lemma norm_zero_iff (x : E) : ‖x‖ = 0 ↔ x = 0 :=
   ⟨fun h => by simpa [norm_eq_sqrt_norm_inner_self, inner_self] using h,
     fun h => by simp [norm, h]; rw [CstarModule.norm_zero] ⟩

--- a/Mathlib/Analysis/CstarAlgebra/Module.lean
+++ b/Mathlib/Analysis/CstarAlgebra/Module.lean
@@ -16,19 +16,19 @@ vector space.
 
 ## Main declarations
 
-+ `HilbertCstarModule`: The class containing the Hilbert C⋆-module structure
-+ `HilbertCstarModule.normedSpaceCore`: The proof that a Hilbert C⋆-module is a normed vector
++ `CstarModule`: The class containing the Hilbert C⋆-module structure
++ `CstarModule.normedSpaceCore`: The proof that a Hilbert C⋆-module is a normed vector
   space. This can be used with `NormedAddCommGroup.ofCore` and `NormedSpace.ofCore` to create
   the relevant instances on a type of interest.
-+ `HilbertCstarModule.inner_mul_inner_swap_le`: The statement that
++ `CstarModule.inner_mul_inner_swap_le`: The statement that
   `⟪y, x⟫ * ⟪x, y⟫ ≤ ‖x‖ ^ 2 • ⟪y, y⟫`, which can be viewed as a version of the Cauchy-Schwarz
   inequality for Hilbert C⋆-modules.
-+ `HilbertCstarModule.norm_inner_le`, which states that `‖⟪x, y⟫‖ ≤ ‖x‖ * ‖y‖`, i.e. the
++ `CstarModule.norm_inner_le`, which states that `‖⟪x, y⟫‖ ≤ ‖x‖ * ‖y‖`, i.e. the
   Cauchy-Schwarz inequality.
 
 ## Implementation notes
 
-The class `HilbertCstarModule A E` requires `E` to already have a `Norm E` instance on it, but
+The class `CstarModule A E` requires `E` to already have a `Norm E` instance on it, but
 no other norm-related instances. We then include the fact that this norm agrees with the norm
 induced by the inner product among the axioms of the class. Furthermore, instead of registering
 `NormedAddCommGroup E` and `NormedSpace ℂ E` instances (which might already be present on the type,
@@ -47,7 +47,7 @@ open scoped ComplexOrder RightActions
 /-- A *Hilbert C⋆-module* is a complex module `E` endowed with a right `A`-module structure
 (where `A` is typically a C⋆-algebra) and an inner product `⟪x, y⟫_A` which satisfies the
 following properties. -/
-class HilbertCstarModule (A : outParam <| Type*) (E : Type*) [NonUnitalSemiring A] [StarRing A]
+class CstarModule (A : outParam <| Type*) (E : Type*) [NonUnitalSemiring A] [StarRing A]
     [Module ℂ A] [AddCommGroup E] [Module ℂ E] [PartialOrder A] [SMul Aᵐᵒᵖ E] [Norm A] [Norm E]
     extends Inner A E where
   inner_add_right {x} {y} {z} : inner x (y + z) = inner x y + inner x z
@@ -58,16 +58,16 @@ class HilbertCstarModule (A : outParam <| Type*) (E : Type*) [NonUnitalSemiring 
   star_inner x y : star (inner x y) = inner y x
   norm_eq_sqrt_norm_inner_self x : ‖x‖ = √‖inner x x‖
 
-attribute [simp] HilbertCstarModule.inner_add_right HilbertCstarModule.star_inner
-  HilbertCstarModule.inner_op_smul_right HilbertCstarModule.inner_smul_right_complex
+attribute [simp] CstarModule.inner_add_right CstarModule.star_inner
+  CstarModule.inner_op_smul_right CstarModule.inner_smul_right_complex
 
-namespace HilbertCstarModule
+namespace CstarModule
 
 section general
 
 variable {A E : Type*} [NonUnitalRing A] [StarRing A] [AddCommGroup E] [Module ℂ A]
   [Module ℂ E] [PartialOrder A] [SMul Aᵐᵒᵖ E] [StarModule ℂ A] [Norm A] [Norm E]
-  [HilbertCstarModule A E]
+  [CstarModule A E]
 
 local notation "⟪" x ", " y "⟫" => inner (𝕜 := A) x y
 
@@ -144,7 +144,7 @@ section norm
 
 variable {A E : Type*} [NonUnitalNormedRing A] [StarRing A] [CstarRing A] [PartialOrder A]
   [StarOrderedRing A] [AddCommGroup E] [NormedSpace ℂ A] [Module ℂ E] [SMul Aᵐᵒᵖ E] [Norm E]
-  [StarModule ℂ A] [HilbertCstarModule A E] [IsScalarTower ℂ A A] [SMulCommClass ℂ A A]
+  [StarModule ℂ A] [CstarModule A E] [IsScalarTower ℂ A A] [SMulCommClass ℂ A A]
 
 local notation "⟪" x ", " y "⟫" => inner (𝕜 := A) x y
 
@@ -209,7 +209,7 @@ lemma inner_mul_inner_swap_le [CompleteSpace A] {x y : E} : ⟪y, x⟫ * ⟪x, y
                         _ = ‖x‖ ^ 2 • (star a * a) := by rw [← norm_eq_sqrt_norm_inner_self]
     specialize h₁ ⟪x, y⟫
     simp only [star_inner, sub_self, zero_sub, le_neg_add_iff_add_le, add_zero] at h₁
-    rwa [smul_le_smul_iff_of_pos_left (pow_pos (HilbertCstarModule.norm_pos h) _)] at h₁
+    rwa [smul_le_smul_iff_of_pos_left (pow_pos (CstarModule.norm_pos h) _)] at h₁
 
 variable (E) in
 /-- The Cauchy-Schwarz inequality for Hilbert C⋆-modules. -/
@@ -225,7 +225,7 @@ lemma norm_inner_le [CompleteSpace A] {x y : E} : ‖⟪x, y⟫‖ ≤ ‖x‖ *
                 simp only [norm_eq_sqrt_norm_inner_self, norm_nonneg, Real.sq_sqrt]
     _ = (‖x‖ * ‖y‖) ^ 2 := by simp only [mul_pow]
   refine (pow_le_pow_iff_left (R := ℝ) (norm_nonneg ⟪x, y⟫_A) ?_ (by norm_num)).mp this
-  exact mul_nonneg HilbertCstarModule.norm_nonneg HilbertCstarModule.norm_nonneg
+  exact mul_nonneg CstarModule.norm_nonneg CstarModule.norm_nonneg
 
 protected lemma norm_triangle [CompleteSpace A] (x y : E) : ‖x + y‖ ≤ ‖x‖ + ‖y‖ := by
   have h : ‖x + y‖ ^ 2 ≤ (‖x‖ + ‖y‖) ^ 2 := by
@@ -238,16 +238,16 @@ protected lemma norm_triangle [CompleteSpace A] (x y : E) : ‖x + y‖ ≤ ‖x
       _ = ‖x‖ ^ 2 + ‖y‖ * ‖x‖ + ‖x‖ * ‖y‖ + ‖y‖ ^ 2 := by
           simp [norm_eq_sqrt_norm_inner_self]
       _ = (‖x‖ + ‖y‖) ^ 2 := by simp only [add_pow_two, add_left_inj]; ring
-  refine (pow_le_pow_iff_left HilbertCstarModule.norm_nonneg ?_ (by norm_num)).mp h
-  exact add_nonneg HilbertCstarModule.norm_nonneg HilbertCstarModule.norm_nonneg
+  refine (pow_le_pow_iff_left CstarModule.norm_nonneg ?_ (by norm_num)).mp h
+  exact add_nonneg CstarModule.norm_nonneg CstarModule.norm_nonneg
 
 /-- This allows us to get `NormedAddCommGroup` and `NormedSpace` instances on `E` via
 `NormedAddCommGroup.ofCore` and `NormedSpace.ofCore`. -/
 lemma normedSpaceCore [CompleteSpace A] : NormedSpace.Core ℂ E where
-  norm_nonneg x := HilbertCstarModule.norm_nonneg
+  norm_nonneg x := CstarModule.norm_nonneg
   norm_eq_zero_iff x := norm_zero_iff x
   norm_smul c x := by simp [norm_eq_sqrt_norm_inner_self, norm_smul, ← mul_assoc]
-  norm_triangle x y := HilbertCstarModule.norm_triangle x y
+  norm_triangle x y := CstarModule.norm_triangle x y
 
 lemma norm_eq_csSup [CompleteSpace A] (v : E) :
     ‖v‖ = sSup { ‖⟪w, v⟫_A‖ | (w : E) (_ : ‖w‖ ≤ 1) } := by
@@ -255,7 +255,7 @@ lemma norm_eq_csSup [CompleteSpace A] (v : E) :
   let instNS : NormedSpace ℂ E := .ofCore normedSpaceCore
   refine Eq.symm <| IsGreatest.csSup_eq ⟨⟨‖v‖⁻¹ • v, ?_, ?_⟩, ?_⟩
   · simpa only [norm_smul, norm_inv, norm_norm] using inv_mul_le_one_of_le le_rfl (by positivity)
-  · simp [norm_smul, HilbertCstarModule.inner_self_eq_norm_sq, pow_two, ← mul_assoc]
+  · simp [norm_smul, CstarModule.inner_self_eq_norm_sq, pow_two, ← mul_assoc]
   · rintro - ⟨w, hw, rfl⟩
     calc _ ≤ ‖w‖ * ‖v‖ := norm_inner_le E
       _ ≤ 1 * ‖v‖ := by gcongr
@@ -263,4 +263,4 @@ lemma norm_eq_csSup [CompleteSpace A] (v : E) :
 
 end norm
 
-end HilbertCstarModule
+end CstarModule

--- a/Mathlib/Analysis/CstarAlgebra/Module.lean
+++ b/Mathlib/Analysis/CstarAlgebra/Module.lean
@@ -173,7 +173,7 @@ protected lemma norm_pos {x : E} (hx : x ≠ 0) : 0 < ‖x‖ := by
 
 lemma norm_sq_eq {x : E} : ‖x‖ ^ 2 = ‖⟪x, x⟫‖ := by simp [norm_eq_sqrt_norm_inner_self]
 
-/-- A version of the Cauchy-Schwarz inequality for Hilbert C⋆-modules. -/
+/-- The C⋆-algebra-valued Cauchy-Schwarz inequality for Hilbert C⋆-modules. -/
 lemma inner_mul_inner_swap_le [CompleteSpace A] {x y : E} : ⟪y, x⟫ * ⟪x, y⟫ ≤ ‖x‖ ^ 2 • ⟪y, y⟫ := by
   rcases eq_or_ne x 0 with h|h
   · simp [h]

--- a/Mathlib/Analysis/CstarAlgebra/Module.lean
+++ b/Mathlib/Analysis/CstarAlgebra/Module.lean
@@ -97,30 +97,26 @@ lemma inner_smul_right_real {z : ℝ} {x y : E} : ⟪x, z • y⟫ = z • ⟪x,
   rw [h₁, ← star_inner, inner_smul_left_complex]
   simp
 
-/-- The function `y ↦ ⟪x, y⟫` bundled as a linear map. -/
-def innerRightL (x : E) : E →ₗ[ℂ] A where
-  toFun y := ⟪x, y⟫
-  map_add' z y := by simp
-  map_smul' z y := by simp
+/-- The function `⟨x, y⟩ ↦ ⟪x, y⟫` bundled as a sesquilinear map. -/
+def innerₛₗ : E →ₗ⋆[ℂ] E →ₗ[ℂ] A where
+  toFun x := { toFun := fun y => ⟪x, y⟫
+               map_add' := fun z y => by simp
+               map_smul' := fun z y => by simp }
+  map_add' z y := by ext; simp
+  map_smul' z y := by ext; simp
 
-/-- The function `y ↦ ⟪y, x⟫` bundled as a conjugate-linear map. -/
-def innerLeftL (x : E) : E →ₗ⋆[ℂ] A where
-  toFun y := ⟪y, x⟫
-  map_add' z y := by simp
-  map_smul' z y := by simp
+lemma innerₛₗ_apply {x y : E} : innerₛₗ x y = ⟪x, y⟫ := rfl
 
-lemma inner_eq_innerRightL (x y : E) : ⟪x, y⟫ = innerRightL x y := rfl
+lemma inner_eq_innerₛₗ (x y : E) : ⟪x, y⟫ = innerₛₗ x y := rfl
 
-lemma inner_eq_innerLeftL (x y : E) : ⟪x, y⟫ = innerLeftL y x := rfl
-
-@[simp] lemma inner_zero_right {x : E} : ⟪x, 0⟫ = 0 := by simp [inner_eq_innerRightL]
-@[simp] lemma inner_zero_left {x : E} : ⟪0, x⟫ = 0 := by simp [inner_eq_innerLeftL]
-@[simp] lemma inner_neg_right {x y : E} : ⟪x, -y⟫ = -⟪x, y⟫ := by simp [inner_eq_innerRightL]
-@[simp] lemma inner_neg_left {x y : E} : ⟪-x, y⟫ = -⟪x, y⟫ := by simp [inner_eq_innerLeftL]
+@[simp] lemma inner_zero_right {x : E} : ⟪x, 0⟫ = 0 := by simp [inner_eq_innerₛₗ]
+@[simp] lemma inner_zero_left {x : E} : ⟪0, x⟫ = 0 := by simp [inner_eq_innerₛₗ]
+@[simp] lemma inner_neg_right {x y : E} : ⟪x, -y⟫ = -⟪x, y⟫ := by simp [inner_eq_innerₛₗ]
+@[simp] lemma inner_neg_left {x y : E} : ⟪-x, y⟫ = -⟪x, y⟫ := by simp [inner_eq_innerₛₗ]
 @[simp] lemma inner_sub_right {x y z : E} : ⟪x, y - z⟫ = ⟪x, y⟫ - ⟪x, z⟫ := by
-  simp [inner_eq_innerRightL]
+  simp [inner_eq_innerₛₗ]
 @[simp] lemma inner_sub_left {x y z : E} : ⟪x - y, z⟫ = ⟪x, z⟫ - ⟪y, z⟫ := by
-  simp [inner_eq_innerLeftL]
+  simp [inner_eq_innerₛₗ]
 
 @[simp]
 lemma inner_sum_right {ι : Type*} [DecidableEq ι] {s : Finset ι} {x : E} {y : ι → E} :
@@ -156,12 +152,12 @@ noncomputable def norm : Norm E where
 
 lemma inner_self_eq_norm_sq {x : E} : ‖⟪x, x⟫‖ = ‖x‖ ^ 2 := by simp [norm_eq_sqrt_norm_inner_self]
 
-@[simp]
 protected lemma norm_zero : ‖(0 : E)‖ = 0 := by simp [norm_eq_sqrt_norm_inner_self]
 
 @[simp]
 lemma norm_zero_iff (x : E) : ‖x‖ = 0 ↔ x = 0 :=
-  ⟨fun h => by simpa [norm_eq_sqrt_norm_inner_self, inner_self] using h, fun h => by simp [norm, h]⟩
+  ⟨fun h => by simpa [norm_eq_sqrt_norm_inner_self, inner_self] using h,
+    fun h => by simp [norm, h]; rw [CstarModule.norm_zero] ⟩
 
 protected lemma norm_nonneg {x : E} : 0 ≤ ‖x‖ := by simp [norm_eq_sqrt_norm_inner_self]; positivity
 
@@ -176,7 +172,7 @@ lemma norm_sq_eq {x : E} : ‖x‖ ^ 2 = ‖⟪x, x⟫‖ := by simp [norm_eq_sq
 /-- The C⋆-algebra-valued Cauchy-Schwarz inequality for Hilbert C⋆-modules. -/
 lemma inner_mul_inner_swap_le [CompleteSpace A] {x y : E} : ⟪y, x⟫ * ⟪x, y⟫ ≤ ‖x‖ ^ 2 • ⟪y, y⟫ := by
   rcases eq_or_ne x 0 with h|h
-  · simp [h]
+  · simp [h, CstarModule.norm_zero (E := E)]
   · have h₁ : ∀ (a : A),
         (0 : A) ≤ ‖x‖ ^ 2 • (star a * a) - ‖x‖ ^ 2 • (⟪y, x⟫ * a)
                   - ‖x‖ ^ 2 • (star a * ⟪x, y⟫) + ‖x‖ ^ 2 • (‖x‖ ^ 2 • ⟪y, y⟫) := fun a => by
@@ -252,5 +248,28 @@ lemma norm_eq_csSup [CompleteSpace A] (v : E) :
       _ = ‖v‖ := by simp
 
 end norm
+
+section NormedAddCommGroup
+
+variable {A E : Type*} [NonUnitalNormedRing A] [StarRing A] [CstarRing A] [PartialOrder A]
+  [StarOrderedRing A] [NormedSpace ℂ A] [SMul Aᵐᵒᵖ E] [CompleteSpace A]
+  [NormedAddCommGroup E] [NormedSpace ℂ E] [StarModule ℂ A] [CstarModule A E] [IsScalarTower ℂ A A]
+  [SMulCommClass ℂ A A]
+
+/-- The function `⟨x, y⟩ ↦ ⟪x, y⟫` bundled as a continuous sesquilinear map. -/
+noncomputable def innerSL : E →L⋆[ℂ] E →L[ℂ] A :=
+  LinearMap.mkContinuous₂ (innerₛₗ : E →ₗ⋆[ℂ] E →ₗ[ℂ] A) 1 <| fun x y => by
+    simp [← inner_eq_innerₛₗ, norm_inner_le E]
+
+lemma innerSL_apply {x y : E} : innerSL x y = ⟪x, y⟫_A := rfl
+
+lemma inner_eq_innerSL (x y : E) : ⟪x, y⟫_A = innerSL x y := rfl
+
+@[continuity, fun_prop]
+lemma continuous_inner : Continuous (fun x : E × E => ⟪x.1, x.2⟫_A) := by
+  simp_rw [inner_eq_innerSL]
+  fun_prop
+
+end NormedAddCommGroup
 
 end CstarModule

--- a/Mathlib/Analysis/CstarAlgebra/Module.lean
+++ b/Mathlib/Analysis/CstarAlgebra/Module.lean
@@ -173,16 +173,6 @@ protected lemma norm_pos {x : E} (hx : x ≠ 0) : 0 < ‖x‖ := by
 
 lemma norm_sq_eq {x : E} : ‖x‖ ^ 2 = ‖⟪x, x⟫‖ := by simp [norm_eq_sqrt_norm_inner_self]
 
-protected lemma smul_nonneg_iff {a : A} {r : ℝ} (hr : 0 < r) : 0 ≤ a ↔ 0 ≤ r • a := by
-  refine ⟨smul_nonneg (le_of_lt hr), fun hra => ?_⟩
-  have : a = r⁻¹ • (r • a) := by
-    rw [smul_smul, inv_mul_cancel]
-    exact (MulAction.one_smul a).symm
-    exact Ne.symm (ne_of_lt hr)
-  rw [this]
-  refine smul_nonneg ?_ hra
-  positivity
-
 /-- A version of the Cauchy-Schwarz inequality for Hilbert C⋆-modules. -/
 lemma inner_mul_inner_swap_le [CompleteSpace A] {x y : E} : ⟪y, x⟫ * ⟪x, y⟫ ≤ ‖x‖ ^ 2 • ⟪y, y⟫ := by
   rcases eq_or_ne x 0 with h|h

--- a/Mathlib/Analysis/CstarAlgebra/Module.lean
+++ b/Mathlib/Analysis/CstarAlgebra/Module.lean
@@ -256,7 +256,7 @@ variable {A E : Type*} [NonUnitalNormedRing A] [StarRing A] [CstarRing A] [Parti
 /-- The function `⟨x, y⟩ ↦ ⟪x, y⟫` bundled as a continuous sesquilinear map. -/
 noncomputable def innerSL : E →L⋆[ℂ] E →L[ℂ] A :=
   LinearMap.mkContinuous₂ (innerₛₗ : E →ₗ⋆[ℂ] E →ₗ[ℂ] A) 1 <| fun x y => by
-    simp [← inner_eq_innerₛₗ, norm_inner_le E]
+    simp [innerₛₗ_apply, norm_inner_le E]
 
 lemma innerSL_apply {x y : E} : innerSL x y = ⟪x, y⟫_A := rfl
 


### PR DESCRIPTION
This PR defines [Hilbert C⋆-modules](https://en.wikipedia.org/wiki/Hilbert_C*-module). A Hilbert C⋆-module is a complex module `E` together with a right `A`-module structure, where `A` is a C⋆-algebra, and with an "inner product" that takes values in `A`. This inner product satisfies the Cauchy-Schwarz inequality, and induces a norm that makes `E` a normed vector space.

This is a stepping stone towards proving that matrices with entries in a C⋆-algebra are a C⋆-algebra, which is in turn needed to define completely positive maps.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
