### PR TITLE
[Merged by Bors] - chore: remove unnecessary implicit arguments in MonoidWithZeroHom.coe_copy

### DIFF
--- a/Mathlib/Algebra/GroupWithZero/Hom.lean
+++ b/Mathlib/Algebra/GroupWithZero/Hom.lean
@@ -141,10 +141,10 @@ protected def copy (f : α →*₀ β) (f' : α → β) (h : f' = f) : α →* �
   { f.toZeroHom.copy f' h, f.toMonoidHom.copy f' h with }
 
 @[simp]
-lemma coe_copy {_ : MulZeroOneClass α} {_ : MulZeroOneClass β} (f : α →*₀ β) (f' : α → β) (h) :
+lemma coe_copy (f : α →*₀ β) (f' : α → β) (h) :
     (f.copy f' h) = f' := rfl
 
-lemma copy_eq {_ : MulZeroOneClass α} {_ : MulZeroOneClass β} (f : α →*₀ β) (f' : α → β) (h) :
+lemma copy_eq (f : α →*₀ β) (f' : α → β) (h) :
     f.copy f' h = f := DFunLike.ext' h
 
 protected lemma map_one (f : α →*₀ β) : f 1 = 1 := f.map_one'

--- a/Mathlib/Algebra/GroupWithZero/Hom.lean
+++ b/Mathlib/Algebra/GroupWithZero/Hom.lean
@@ -141,11 +141,9 @@ protected def copy (f : α →*₀ β) (f' : α → β) (h : f' = f) : α →* �
   { f.toZeroHom.copy f' h, f.toMonoidHom.copy f' h with }
 
 @[simp]
-lemma coe_copy (f : α →*₀ β) (f' : α → β) (h) :
-    (f.copy f' h) = f' := rfl
+lemma coe_copy (f : α →*₀ β) (f' : α → β) (h) : (f.copy f' h) = f' := rfl
 
-lemma copy_eq (f : α →*₀ β) (f' : α → β) (h) :
-    f.copy f' h = f := DFunLike.ext' h
+lemma copy_eq (f : α →*₀ β) (f' : α → β) (h) : f.copy f' h = f := DFunLike.ext' h
 
 protected lemma map_one (f : α →*₀ β) : f 1 = 1 := f.map_one'
 


### PR DESCRIPTION
It's perfectly fine for these to just be instance implicit arguments.