### PR TITLE
Cat is monoidal with the cartesian product of categories

### DIFF
--- a/Mathlib/CategoryTheory/Monoidal/Cat.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Cat.lean
@@ -1,0 +1,35 @@
+import Mathlib.CategoryTheory.ChosenFiniteProducts
+
+namespace CategoryTheory.Cat
+
+open Limits
+
+/-- The chosen terminal object in `Cat` is terminal. -/
+def isTerminalPUnit : IsTerminal (Cat.of <| Discrete PUnit) where
+  lift s := Functor.star s.pt
+  fac s (j : Discrete PEmpty.{1}) := by dsimp; exact PEmpty.elim j.as
+  uniq s m _ :=  Functor.punit_ext' m (Functor.star s.pt)
+
+/-- The product cone in `Cat`. -/
+def prodCone (C D : Cat) : BinaryFan C D :=
+  .mk (P := .of (C × D)) (Prod.fst _ _) (Prod.snd _ _)
+
+def isLimitProdCone (X Y : Cat) : IsLimit (prodCone X Y) := BinaryFan.isLimitMk
+  (fun S => Functor.prod' S.fst S.snd)-- def prod' (F : A ⥤ B) (G : A ⥤ C) : A ⥤ B × C
+  (fun S => rfl)
+  (fun S => rfl)
+  (fun S m (h1 : m ≫ Prod.fst X Y = S.fst) (h2 : m ≫ Prod.snd X Y = S.snd) => by
+    fapply Functor.hext
+    · intro X
+      apply Prod.ext <;> simp [← h1, ← h2]
+    · intro X Y f
+      dsimp
+      rw [← h1, ← h2]
+      rfl)
+
+
+instance : ChosenFiniteProducts Cat where
+  product (X Y : Cat) :  LimitCone (pair X Y) := { isLimit := isLimitProdCone X Y }
+  terminal : LimitCone (Functor.empty Cat) := {isLimit := isTerminalPUnit }
+
+end CategoryTheory.Cat


### PR DESCRIPTION
feat(CategoryTheory/Monoidal): `Cat`, the category of categories, is monoidal with the cartesian product of categories

Co-authored-by : atopaz@fastmail.com
Co-authored-by : yael.dillies@gmail.com

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
