### PR TITLE
[Merged by Bors] - chore(NumberTheory): drop some `DecidableEq` assumptions

### DIFF
--- a/Mathlib/NumberTheory/MulChar/Lemmas.lean
+++ b/Mathlib/NumberTheory/MulChar/Lemmas.lean
@@ -44,16 +44,17 @@ instance instStarMul [StarRing R'] : StarMul (MulChar R R') where
 lemma star_apply [StarRing R'] (χ : MulChar R R') (a : R) : (star χ) a = star (χ a) :=
   rfl
 
-variable [Fintype R] [DecidableEq R]
-
 /-- The values of a multiplicative character on `R` are `n`th roots of unity, where `n = #Rˣ`. -/
-lemma apply_mem_rootsOfUnity (a : Rˣ) {χ : MulChar R R'} :
+lemma apply_mem_rootsOfUnity [Fintype Rˣ] (a : Rˣ) {χ : MulChar R R'} :
     equivToUnitHom χ a ∈ rootsOfUnity ⟨Fintype.card Rˣ, Fintype.card_pos⟩ R' := by
   rw [mem_rootsOfUnity, ← map_pow, ← (equivToUnitHom χ).map_one, PNat.mk_coe, pow_card_eq_one]
+
+variable [Finite Rˣ]
 
 open Complex in
 /-- The conjugate of a multiplicative character with values in `ℂ` is its inverse. -/
 lemma star_eq_inv (χ : MulChar R ℂ) : star χ = χ⁻¹ := by
+  cases nonempty_fintype Rˣ
   ext1 a
   simp only [inv_apply_eq_inv']
   exact (inv_eq_conj <| norm_eq_one_of_mem_rootsOfUnity <| χ.apply_mem_rootsOfUnity a).symm
@@ -120,7 +121,9 @@ section FiniteField
 ### Multiplicative characters on finite fields
 -/
 
-variable (F : Type*) [Field F] [Fintype F] [DecidableEq F]
+section Fintype
+
+variable (F : Type*) [Field F] [Fintype F]
 variable {R : Type*} [CommRing R]
 
 /-- There is a character of order `n` on `F` if `#F ≡ 1 mod n` and the target contains
@@ -128,6 +131,7 @@ a primitive `n`th root of unity. -/
 lemma exists_mulChar_orderOf {n : ℕ} (h : n ∣ Fintype.card F - 1) {ζ : R}
     (hζ : IsPrimitiveRoot ζ n) :
     ∃ χ : MulChar F R, orderOf χ = n := by
+  classical
   have hn₀ : 0 < n := by
     refine Nat.pos_of_ne_zero fun hn ↦ ?_
     simp only [hn, zero_dvd_iff, Nat.sub_eq_zero_iff_le] at h
@@ -150,16 +154,21 @@ lemma exists_mulChar_orderOf {n : ℕ} (h : n ∣ Fintype.card F - 1) {ζ : R}
 
 /-- If there is a multiplicative character of order `n` on `F`, then `#F ≡ 1 mod n`. -/
 lemma orderOf_dvd_card_sub_one (χ : MulChar F R) : orderOf χ ∣ Fintype.card F - 1 := by
+  classical
   rw [← Fintype.card_units]
   exact orderOf_dvd_of_pow_eq_one χ.pow_card_eq_one
 
 /-- There is always a character on `F` of order `#F-1` with values in a ring that has
 a primitive `(#F-1)`th root of unity. -/
-lemma exists_mulChar_orderOf_eq_card_units {ζ : R} (hζ : IsPrimitiveRoot ζ (Monoid.orderUnits F)) :
+lemma exists_mulChar_orderOf_eq_card_units [DecidableEq F]
+    {ζ : R} (hζ : IsPrimitiveRoot ζ (Monoid.orderUnits F)) :
     ∃ χ : MulChar F R, orderOf χ = Fintype.card Fˣ :=
   exists_mulChar_orderOf F (by rw [Fintype.card_units]) hζ
 
-variable {F}
+end Fintype
+
+variable {F : Type*} [Field F] [Finite F]
+variable {R : Type*} [CommRing R]
 
 /- The non-zero values of a multiplicative character of order `n` are `n`th roots of unity. -/
 lemma apply_mem_rootsOfUnity_orderOf (χ : MulChar F R) {a : F} (ha : a ≠ 0) :

--- a/Mathlib/NumberTheory/NumberField/House.lean
+++ b/Mathlib/NumberTheory/NumberField/House.lean
@@ -111,7 +111,7 @@ private theorem supOfBasis_nonneg : 0 ≤ supOfBasis K := by
   simp only [supOfBasis, le_sup'_iff, mem_univ, and_self,
     exists_const, house_nonneg]
 
-variable {α : Type*} {β : Type*} [Fintype α] [Fintype β] [DecidableEq β] [DecidableEq α]
+variable {α : Type*} {β : Type*} [Fintype α] [Fintype β]
 
 variable (a : Matrix α β (𝓞 K))
 
@@ -287,6 +287,7 @@ private theorem house_le_bound : ∀ l, house (ξ K x l).1 ≤ (c₁ K) *
 theorem exists_ne_zero_int_vec_house_le :
     ∃ (ξ : β → 𝓞 K), ξ ≠ 0 ∧ a *ᵥ ξ = 0 ∧
     ∀ l, house (ξ l).1 ≤ c₁ K * ((c₁ K * q * A) ^ ((p : ℝ) / (q - p))) := by
+  classical
   let h := finrank ℚ K
   have hphqh : p * h < q * h := mul_lt_mul_of_pos_right hpq finrank_pos
   have h0ph : 0 < p * h := by rw [mul_pos_iff]; constructor; exact ⟨h0p, finrank_pos⟩

--- a/Mathlib/NumberTheory/SiegelsLemma.lean
+++ b/Mathlib/NumberTheory/SiegelsLemma.lean
@@ -38,7 +38,7 @@ open Matrix Finset
 
 namespace Int.Matrix
 
-variable {α β : Type*} [Fintype α] [Fintype β] [DecidableEq β] [DecidableEq α]
+variable {α β : Type*} [Fintype α] [Fintype β]
   (A : Matrix α β ℤ) (v : β → ℤ) (hn : Fintype.card α < Fintype.card β) (hm : 0 < Fintype.card α)
 
 -- Some definitions and relative properties
@@ -57,6 +57,8 @@ local notation3 "N" => fun i : α => ∑ j : β, B * (- negPart (A i j))
 local notation3 "S" => Finset.Icc N P
 
 section preparation
+
+variable [DecidableEq α] [DecidableEq β]
 
 /- In order to apply Pigeonhole we need:
 # Step 1: ∀ v ∈  T, A *ᵥ v ∈  S
@@ -173,6 +175,7 @@ end preparation
 
 theorem exists_ne_zero_int_vec_norm_le : ∃ t : β → ℤ, t ≠ 0 ∧
     A *ᵥ t = 0 ∧ ‖t‖ ≤ (n * max 1 ‖A‖) ^ ((m : ℝ) / (n - m)) := by
+  classical
   -- Pigeonhole
   rcases Finset.exists_ne_map_eq_of_card_lt_of_maps_to
     (card_S_lt_card_T A hn hm) (image_T_subset_S A)


### PR DESCRIPTION
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)