### PR TITLE
[Merged by Bors] - feat: add `Pairwise.pairwiseDisjoint`

### DIFF
--- a/Mathlib/Data/Set/Pairwise/Basic.lean
+++ b/Mathlib/Data/Set/Pairwise/Basic.lean
@@ -293,6 +293,9 @@ lemma pairwiseDisjoint_range_iff {α β : Type*} {f : α → (Set β)} :
   · rintro h _ ⟨x, rfl⟩ _ ⟨y, rfl⟩ hxy
     exact (h x y).resolve_left hxy
 
+lemma _root_.Pairwise.pairwiseDisjoint (h : Pairwise (Disjoint on f)) (s : Set ι) :
+    s.PairwiseDisjoint f := h.set_pairwise s
+
 end PartialOrderBot
 
 section SemilatticeInfBot

--- a/Mathlib/Data/Set/Pairwise/Basic.lean
+++ b/Mathlib/Data/Set/Pairwise/Basic.lean
@@ -293,6 +293,7 @@ lemma pairwiseDisjoint_range_iff {α β : Type*} {f : α → (Set β)} :
   · rintro h _ ⟨x, rfl⟩ _ ⟨y, rfl⟩ hxy
     exact (h x y).resolve_left hxy
 
+/-- If the range of `f` is pairwise disjoint, then the image of any set `s` under `f` is as well. -/
 lemma _root_.Pairwise.pairwiseDisjoint (h : Pairwise (Disjoint on f)) (s : Set ι) :
     s.PairwiseDisjoint f := h.set_pairwise s
 


### PR DESCRIPTION
`Pairwise (Disjoint on f)` implies `s.PairwiseDisjoint f` for any set `s`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
