### PR TITLE
[Merged by Bors] - chore: split conj into two files to streamline imports

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -1482,6 +1482,7 @@ import Mathlib.CategoryTheory.Groupoid.Subgroupoid
 import Mathlib.CategoryTheory.Groupoid.VertexGroup
 import Mathlib.CategoryTheory.GuitartExact.Basic
 import Mathlib.CategoryTheory.GuitartExact.VerticalComposition
+import Mathlib.CategoryTheory.HomCongr
 import Mathlib.CategoryTheory.Idempotents.Basic
 import Mathlib.CategoryTheory.Idempotents.Biproducts
 import Mathlib.CategoryTheory.Idempotents.FunctorCategories

--- a/Mathlib/CategoryTheory/Adjunction/Mates.lean
+++ b/Mathlib/CategoryTheory/Adjunction/Mates.lean
@@ -4,11 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Bhavik Mehta, Emily Riehl
 -/
 import Mathlib.CategoryTheory.Adjunction.Basic
-import Mathlib.CategoryTheory.Conj
-import Mathlib.CategoryTheory.Category.Basic
-import Mathlib.CategoryTheory.Functor.Basic
-import Mathlib.CategoryTheory.Functor.Category
-import Mathlib.CategoryTheory.Whiskering
+import Mathlib.CategoryTheory.HomCongr
 
 import Mathlib.Tactic.ApplyFun
 

--- a/Mathlib/CategoryTheory/Adjunction/Reflective.lean
+++ b/Mathlib/CategoryTheory/Adjunction/Reflective.lean
@@ -4,8 +4,8 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Bhavik Mehta
 -/
 import Mathlib.CategoryTheory.Adjunction.FullyFaithful
-import Mathlib.CategoryTheory.Conj
 import Mathlib.CategoryTheory.Functor.ReflectsIso
+import Mathlib.CategoryTheory.HomCongr
 
 /-!
 # Reflective functors

--- a/Mathlib/CategoryTheory/Adjunction/Restrict.lean
+++ b/Mathlib/CategoryTheory/Adjunction/Restrict.lean
@@ -3,8 +3,8 @@ Copyright (c) 2019 Scott Morrison. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Scott Morrison
 -/
-import Mathlib.CategoryTheory.Conj
 import Mathlib.CategoryTheory.Adjunction.Basic
+import Mathlib.CategoryTheory.HomCongr
 /-!
 
 # Restricting adjunctions

--- a/Mathlib/CategoryTheory/Closed/Zero.lean
+++ b/Mathlib/CategoryTheory/Closed/Zero.lean
@@ -5,7 +5,6 @@ Authors: Bhavik Mehta
 -/
 import Mathlib.CategoryTheory.Closed.Cartesian
 import Mathlib.CategoryTheory.PUnit
-import Mathlib.CategoryTheory.Conj
 import Mathlib.CategoryTheory.Limits.Shapes.ZeroObjects
 
 /-!

--- a/Mathlib/CategoryTheory/Conj.lean
+++ b/Mathlib/CategoryTheory/Conj.lean
@@ -5,6 +5,7 @@ Authors: Yury Kudryashov
 -/
 import Mathlib.Algebra.Group.Units.Equiv
 import Mathlib.CategoryTheory.Endomorphism
+import Mathlib.CategoryTheory.HomCongr
 
 /-!
 # Conjugate morphisms by isomorphisms
@@ -15,12 +16,11 @@ An isomorphism `α : X ≅ Y` defines
 - a group isomorphism `CategoryTheory.Iso.conjAut : Aut X ≃* Aut Y` by
   `α.conjAut f = α.symm ≪≫ f ≪≫ α`.
 
-For completeness, we also define
-`CategoryTheory.Iso.homCongr : (X ≅ X₁) → (Y ≅ Y₁) → (X ⟶ Y) ≃ (X₁ ⟶ Y₁)`,
-cf. `Equiv.arrowCongr`,
-and `CategoryTheory.Iso.isoCongr : (f : X₁ ≅ X₂) → (g : Y₁ ≅ Y₂) → (X₁ ≅ Y₁) ≃ (X₂ ≅ Y₂)`.
+using
+`CategoryTheory.Iso.homCongr : (X ≅ X₁) → (Y ≅ Y₁) → (X ⟶ Y) ≃ (X₁ ⟶ Y₁)`
+and `CategoryTheory.Iso.isoCongr : (f : X₁ ≅ X₂) → (g : Y₁ ≅ Y₂) → (X₁ ≅ Y₁) ≃ (X₂ ≅ Y₂)`
+which are defined in  `CategoryTheory.HomCongr`.
 -/
-
 
 universe v u
 
@@ -29,56 +29,6 @@ namespace CategoryTheory
 namespace Iso
 
 variable {C : Type u} [Category.{v} C]
-
-/-- If `X` is isomorphic to `X₁` and `Y` is isomorphic to `Y₁`, then
-there is a natural bijection between `X ⟶ Y` and `X₁ ⟶ Y₁`. See also `Equiv.arrowCongr`. -/
-def homCongr {X Y X₁ Y₁ : C} (α : X ≅ X₁) (β : Y ≅ Y₁) : (X ⟶ Y) ≃ (X₁ ⟶ Y₁) where
-  toFun f := α.inv ≫ f ≫ β.hom
-  invFun f := α.hom ≫ f ≫ β.inv
-  left_inv f :=
-    show α.hom ≫ (α.inv ≫ f ≫ β.hom) ≫ β.inv = f by
-      rw [Category.assoc, Category.assoc, β.hom_inv_id, α.hom_inv_id_assoc, Category.comp_id]
-  right_inv f :=
-    show α.inv ≫ (α.hom ≫ f ≫ β.inv) ≫ β.hom = f by
-      rw [Category.assoc, Category.assoc, β.inv_hom_id, α.inv_hom_id_assoc, Category.comp_id]
-
--- @[simp, nolint simpNF] Porting note (#10675): dsimp can not prove this
-@[simp]
-theorem homCongr_apply {X Y X₁ Y₁ : C} (α : X ≅ X₁) (β : Y ≅ Y₁) (f : X ⟶ Y) :
-    α.homCongr β f = α.inv ≫ f ≫ β.hom := by
-  rfl
-
-theorem homCongr_comp {X Y Z X₁ Y₁ Z₁ : C} (α : X ≅ X₁) (β : Y ≅ Y₁) (γ : Z ≅ Z₁) (f : X ⟶ Y)
-    (g : Y ⟶ Z) : α.homCongr γ (f ≫ g) = α.homCongr β f ≫ β.homCongr γ g := by simp
-
-/- Porting note (#10618): removed `@[simp]`; simp can prove this -/
-theorem homCongr_refl {X Y : C} (f : X ⟶ Y) : (Iso.refl X).homCongr (Iso.refl Y) f = f := by simp
-
-/- Porting note (#10618): removed `@[simp]`; simp can prove this -/
-theorem homCongr_trans {X₁ Y₁ X₂ Y₂ X₃ Y₃ : C} (α₁ : X₁ ≅ X₂) (β₁ : Y₁ ≅ Y₂) (α₂ : X₂ ≅ X₃)
-    (β₂ : Y₂ ≅ Y₃) (f : X₁ ⟶ Y₁) :
-    (α₁ ≪≫ α₂).homCongr (β₁ ≪≫ β₂) f = (α₁.homCongr β₁).trans (α₂.homCongr β₂) f := by simp
-
-@[simp]
-theorem homCongr_symm {X₁ Y₁ X₂ Y₂ : C} (α : X₁ ≅ X₂) (β : Y₁ ≅ Y₂) :
-    (α.homCongr β).symm = α.symm.homCongr β.symm :=
-  rfl
-
-/-- If `X` is isomorphic to `X₁` and `Y` is isomorphic to `Y₁`, then
-there is a bijection between `X ≅ Y` and `X₁ ≅ Y₁`. -/
-def isoCongr {X₁ Y₁ X₂ Y₂ : C} (f : X₁ ≅ X₂) (g : Y₁ ≅ Y₂) : (X₁ ≅ Y₁) ≃ (X₂ ≅ Y₂) where
-  toFun h := f.symm.trans <| h.trans <| g
-  invFun h := f.trans <| h.trans <| g.symm
-  left_inv := by aesop_cat
-  right_inv := by aesop_cat
-
-/-- If `X₁` is isomorphic to `X₂`, then there is a bijection between `X₁ ≅ Y` and `X₂ ≅ Y`. -/
-def isoCongrLeft {X₁ X₂ Y : C} (f : X₁ ≅ X₂) : (X₁ ≅ Y) ≃ (X₂ ≅ Y) :=
-  isoCongr f (Iso.refl _)
-
-/-- If `Y₁` is isomorphic to `Y₂`, then there is a bijection between `X ≅ Y₁` and `X ≅ Y₂`. -/
-def isoCongrRight {X Y₁ Y₂ : C} (g : Y₁ ≅ Y₂) : (X ≅ Y₁) ≃ (X ≅ Y₂) :=
-  isoCongr (Iso.refl _) g
 
 variable {X Y : C} (α : X ≅ Y)
 
@@ -157,9 +107,6 @@ namespace Functor
 universe v₁ u₁
 
 variable {C : Type u} [Category.{v} C] {D : Type u₁} [Category.{v₁} D] (F : C ⥤ D)
-
-theorem map_homCongr {X Y X₁ Y₁ : C} (α : X ≅ X₁) (β : Y ≅ Y₁) (f : X ⟶ Y) :
-    F.map (Iso.homCongr α β f) = Iso.homCongr (F.mapIso α) (F.mapIso β) (F.map f) := by simp
 
 theorem map_conj {X Y : C} (α : X ≅ Y) (f : End X) :
     F.map (α.conj f) = (F.mapIso α).conj (F.map f) :=

--- a/Mathlib/CategoryTheory/Conj.lean
+++ b/Mathlib/CategoryTheory/Conj.lean
@@ -14,8 +14,7 @@ An isomorphism `α : X ≅ Y` defines
 - a monoid isomorphism
   `CategoryTheory.Iso.conj : End X ≃* End Y` by `α.conj f = α.inv ≫ f ≫ α.hom`;
 - a group isomorphism `CategoryTheory.Iso.conjAut : Aut X ≃* Aut Y` by
-  `α.conjAut f = α.symm ≪≫ f ≪≫ α`.
-
+  `α.conjAut f = α.symm ≪≫ f ≪≫ α`
 using
 `CategoryTheory.Iso.homCongr : (X ≅ X₁) → (Y ≅ Y₁) → (X ⟶ Y) ≃ (X₁ ⟶ Y₁)`
 and `CategoryTheory.Iso.isoCongr : (f : X₁ ≅ X₂) → (g : Y₁ ≅ Y₂) → (X₁ ≅ Y₁) ≃ (X₂ ≅ Y₂)`

--- a/Mathlib/CategoryTheory/HomCongr.lean
+++ b/Mathlib/CategoryTheory/HomCongr.lean
@@ -1,0 +1,105 @@
+/-
+Copyright (c) 2019 Yury Kudryashov. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Yury Kudryashov
+-/
+import Mathlib.CategoryTheory.Iso
+
+/-!
+# Conjugate morphisms by isomorphisms
+
+We define
+`CategoryTheory.Iso.homCongr : (X ≅ X₁) → (Y ≅ Y₁) → (X ⟶ Y) ≃ (X₁ ⟶ Y₁)`,
+cf. `Equiv.arrowCongr`,
+and `CategoryTheory.Iso.isoCongr : (f : X₁ ≅ X₂) → (g : Y₁ ≅ Y₂) → (X₁ ≅ Y₁) ≃ (X₂ ≅ Y₂)`.
+
+As corollaries, an isomorphism `α : X ≅ Y` defines
+- a monoid isomorphism
+  `CategoryTheory.Iso.conj : End X ≃* End Y` by `α.conj f = α.inv ≫ f ≫ α.hom`;
+- a group isomorphism `CategoryTheory.Iso.conjAut : Aut X ≃* Aut Y` by
+  `α.conjAut f = α.symm ≪≫ f ≪≫ α`
+which can be found in  `CategoryTheory.Conj`.
+-/
+
+
+universe v u
+
+namespace CategoryTheory
+
+namespace Iso
+
+variable {C : Type u} [Category.{v} C]
+
+/-- If `X` is isomorphic to `X₁` and `Y` is isomorphic to `Y₁`, then
+there is a natural bijection between `X ⟶ Y` and `X₁ ⟶ Y₁`. See also `Equiv.arrowCongr`. -/
+def homCongr {X Y X₁ Y₁ : C} (α : X ≅ X₁) (β : Y ≅ Y₁) : (X ⟶ Y) ≃ (X₁ ⟶ Y₁) where
+  toFun f := α.inv ≫ f ≫ β.hom
+  invFun f := α.hom ≫ f ≫ β.inv
+  left_inv f :=
+    show α.hom ≫ (α.inv ≫ f ≫ β.hom) ≫ β.inv = f by
+      rw [Category.assoc, Category.assoc, β.hom_inv_id, α.hom_inv_id_assoc, Category.comp_id]
+  right_inv f :=
+    show α.inv ≫ (α.hom ≫ f ≫ β.inv) ≫ β.hom = f by
+      rw [Category.assoc, Category.assoc, β.inv_hom_id, α.inv_hom_id_assoc, Category.comp_id]
+
+-- @[simp, nolint simpNF] Porting note (#10675): dsimp can not prove this
+@[simp]
+theorem homCongr_apply {X Y X₁ Y₁ : C} (α : X ≅ X₁) (β : Y ≅ Y₁) (f : X ⟶ Y) :
+    α.homCongr β f = α.inv ≫ f ≫ β.hom := by
+  rfl
+
+theorem homCongr_comp {X Y Z X₁ Y₁ Z₁ : C} (α : X ≅ X₁) (β : Y ≅ Y₁) (γ : Z ≅ Z₁) (f : X ⟶ Y)
+    (g : Y ⟶ Z) : α.homCongr γ (f ≫ g) = α.homCongr β f ≫ β.homCongr γ g := by simp
+
+/- Porting note (#10618): removed `@[simp]`; simp can prove this -/
+theorem homCongr_refl {X Y : C} (f : X ⟶ Y) : (Iso.refl X).homCongr (Iso.refl Y) f = f := by simp
+
+/- Porting note (#10618): removed `@[simp]`; simp can prove this -/
+theorem homCongr_trans {X₁ Y₁ X₂ Y₂ X₃ Y₃ : C} (α₁ : X₁ ≅ X₂) (β₁ : Y₁ ≅ Y₂) (α₂ : X₂ ≅ X₃)
+    (β₂ : Y₂ ≅ Y₃) (f : X₁ ⟶ Y₁) :
+    (α₁ ≪≫ α₂).homCongr (β₁ ≪≫ β₂) f = (α₁.homCongr β₁).trans (α₂.homCongr β₂) f := by simp
+
+@[simp]
+theorem homCongr_symm {X₁ Y₁ X₂ Y₂ : C} (α : X₁ ≅ X₂) (β : Y₁ ≅ Y₂) :
+    (α.homCongr β).symm = α.symm.homCongr β.symm :=
+  rfl
+
+/-- If `X` is isomorphic to `X₁` and `Y` is isomorphic to `Y₁`, then
+there is a bijection between `X ≅ Y` and `X₁ ≅ Y₁`. -/
+def isoCongr {X₁ Y₁ X₂ Y₂ : C} (f : X₁ ≅ X₂) (g : Y₁ ≅ Y₂) : (X₁ ≅ Y₁) ≃ (X₂ ≅ Y₂) where
+  toFun h := f.symm.trans <| h.trans <| g
+  invFun h := f.trans <| h.trans <| g.symm
+  left_inv := by aesop_cat
+  right_inv := by aesop_cat
+
+@[simp]
+theorem isoCongr_hom {X₁ Y₁ X₂ Y₂ : C} (f : X₁ ≅ X₂) (g : Y₁ ≅ Y₂) (h : X₁ ≅ Y₁) :
+    ((f.isoCongr g) h).hom = (f.homCongr g) h.hom := rfl
+
+/-- If `X₁` is isomorphic to `X₂`, then there is a bijection between `X₁ ≅ Y` and `X₂ ≅ Y`. -/
+def isoCongrLeft {X₁ X₂ Y : C} (f : X₁ ≅ X₂) : (X₁ ≅ Y) ≃ (X₂ ≅ Y) :=
+  isoCongr f (Iso.refl _)
+
+/-- If `Y₁` is isomorphic to `Y₂`, then there is a bijection between `X ≅ Y₁` and `X ≅ Y₂`. -/
+def isoCongrRight {X Y₁ Y₂ : C} (g : Y₁ ≅ Y₂) : (X ≅ Y₁) ≃ (X ≅ Y₂) :=
+  isoCongr (Iso.refl _) g
+
+end Iso
+
+namespace Functor
+
+universe v₁ u₁
+
+variable {C : Type u} [Category.{v} C] {D : Type u₁} [Category.{v₁} D] (F : C ⥤ D)
+
+theorem map_homCongr {X Y X₁ Y₁ : C} (α : X ≅ X₁) (β : Y ≅ Y₁) (f : X ⟶ Y) :
+    F.map (Iso.homCongr α β f) = Iso.homCongr (F.mapIso α) (F.mapIso β) (F.map f) := by simp
+
+theorem map_isoCongr {X Y X₁ Y₁ : C} (α : X ≅ X₁) (β : Y ≅ Y₁) (f : X ≅ Y) :
+    F.mapIso (Iso.isoCongr α β f) = Iso.isoCongr (F.mapIso α) (F.mapIso β) (F.mapIso f) := by
+  ext
+  simp
+
+end Functor
+
+end CategoryTheory

--- a/Mathlib/CategoryTheory/HomCongr.lean
+++ b/Mathlib/CategoryTheory/HomCongr.lean
@@ -32,6 +32,7 @@ variable {C : Type u} [Category.{v} C]
 
 /-- If `X` is isomorphic to `X₁` and `Y` is isomorphic to `Y₁`, then
 there is a natural bijection between `X ⟶ Y` and `X₁ ⟶ Y₁`. See also `Equiv.arrowCongr`. -/
+@[simps]
 def homCongr {X Y X₁ Y₁ : C} (α : X ≅ X₁) (β : Y ≅ Y₁) : (X ⟶ Y) ≃ (X₁ ⟶ Y₁) where
   toFun f := α.inv ≫ f ≫ β.hom
   invFun f := α.hom ≫ f ≫ β.inv
@@ -41,12 +42,6 @@ def homCongr {X Y X₁ Y₁ : C} (α : X ≅ X₁) (β : Y ≅ Y₁) : (X ⟶ Y)
   right_inv f :=
     show α.inv ≫ (α.hom ≫ f ≫ β.inv) ≫ β.hom = f by
       rw [Category.assoc, Category.assoc, β.inv_hom_id, α.inv_hom_id_assoc, Category.comp_id]
-
--- @[simp, nolint simpNF] Porting note (#10675): dsimp can not prove this
-@[simp]
-theorem homCongr_apply {X Y X₁ Y₁ : C} (α : X ≅ X₁) (β : Y ≅ Y₁) (f : X ⟶ Y) :
-    α.homCongr β f = α.inv ≫ f ≫ β.hom := by
-  rfl
 
 theorem homCongr_comp {X Y Z X₁ Y₁ Z₁ : C} (α : X ≅ X₁) (β : Y ≅ Y₁) (γ : Z ≅ Z₁) (f : X ⟶ Y)
     (g : Y ⟶ Z) : α.homCongr γ (f ≫ g) = α.homCongr β f ≫ β.homCongr γ g := by simp
@@ -66,15 +61,12 @@ theorem homCongr_symm {X₁ Y₁ X₂ Y₂ : C} (α : X₁ ≅ X₂) (β : Y₁ 
 
 /-- If `X` is isomorphic to `X₁` and `Y` is isomorphic to `Y₁`, then
 there is a bijection between `X ≅ Y` and `X₁ ≅ Y₁`. -/
+@[simps]
 def isoCongr {X₁ Y₁ X₂ Y₂ : C} (f : X₁ ≅ X₂) (g : Y₁ ≅ Y₂) : (X₁ ≅ Y₁) ≃ (X₂ ≅ Y₂) where
   toFun h := f.symm.trans <| h.trans <| g
   invFun h := f.trans <| h.trans <| g.symm
   left_inv := by aesop_cat
   right_inv := by aesop_cat
-
-@[simp]
-theorem isoCongr_hom {X₁ Y₁ X₂ Y₂ : C} (f : X₁ ≅ X₂) (g : Y₁ ≅ Y₂) (h : X₁ ≅ Y₁) :
-    ((f.isoCongr g) h).hom = (f.homCongr g) h.hom := rfl
 
 /-- If `X₁` is isomorphic to `X₂`, then there is a bijection between `X₁ ≅ Y` and `X₂ ≅ Y`. -/
 def isoCongrLeft {X₁ X₂ Y : C} (f : X₁ ≅ X₂) : (X₁ ≅ Y) ≃ (X₂ ≅ Y) :=

--- a/Mathlib/CategoryTheory/Limits/IsConnected.lean
+++ b/Mathlib/CategoryTheory/Limits/IsConnected.lean
@@ -6,7 +6,7 @@ Authors: Paul Reichert
 import Mathlib.CategoryTheory.Limits.Types
 import Mathlib.CategoryTheory.IsConnected
 import Mathlib.CategoryTheory.Limits.Final
-import Mathlib.CategoryTheory.Conj
+import Mathlib.CategoryTheory.HomCongr
 
 /-!
 # Colimits of connected index categories

--- a/Mathlib/CategoryTheory/Localization/HomEquiv.lean
+++ b/Mathlib/CategoryTheory/Localization/HomEquiv.lean
@@ -5,7 +5,7 @@ Authors: Joël Riou
 -/
 
 import Mathlib.CategoryTheory.Localization.LocalizerMorphism
-import Mathlib.CategoryTheory.Conj
+import Mathlib.CategoryTheory.HomCongr
 
 /-!
 # Bijections between morphisms in two localized categories


### PR DESCRIPTION
This splits the file CategoryTheory.Conj into CategoryTheory.HomCongr and CategoryTheory.Conj. The point is that the latter requires much heavier imports than the former, while the former is all that is needed for CategoryTheory.Adjunction.Mates, which is used elsewhere.

While making those changes, I added one theorem to the HomCongr file:

* A theorem `map_isoCongr` which parallels the existing `map_homCongr`.

The proof is by `ext; simp` once the existing `isoCongr` is tagged with simps. 

In parallel, I've tagged the definition `homCongr` with simps and removed the theorem `homCongr_apply` which is automatically generated by simps.

---

This was done with help from @jcommelin who tells me I should apologize for polluting the PR!

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
