### PR TITLE
[Merged by Bors] - chore(Data/Finsupp/Defs): remove superfluous DecidableEq

### DIFF
--- a/Mathlib/Data/Finsupp/Defs.lean
+++ b/Mathlib/Data/Finsupp/Defs.lean
@@ -502,8 +502,9 @@ theorem support_update_ne_zero [DecidableEq α] (h : b ≠ 0) :
   simp only [update, h, ite_false, mem_support_iff, ne_eq]
   congr!
 
-theorem support_update_subset [DecidableEq α] [DecidableEq M] :
+theorem support_update_subset [DecidableEq α] :
     support (f.update a b) ⊆ insert a f.support := by
+  classical
   rw [support_update]
   split_ifs
   · exact (erase_subset _ _).trans (subset_insert _ _)


### PR DESCRIPTION
Found by the linter in #10235.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
