### PR TITLE
[Merged by Bors] - chore(Combinatorics): remove superfluous use of DecidableEq

### DIFF
--- a/Mathlib/Combinatorics/SimpleGraph/LapMatrix.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/LapMatrix.lean
@@ -120,6 +120,8 @@ theorem lapMatrix_toLin'_apply_eq_zero_iff_forall_reachable (x : V → ℝ) :
   rw [← (posSemidef_lapMatrix ℝ G).toLinearMap₂'_zero_iff, star_trivial,
       lapMatrix_toLinearMap₂'_apply'_eq_zero_iff_forall_reachable]
 
+section
+
 variable [DecidableEq G.ConnectedComponent]
 
 lemma mem_ker_toLin'_lapMatrix_of_connectedComponent {G : SimpleGraph V} [DecidableRel G.Adj]
@@ -179,9 +181,12 @@ noncomputable def lapMatrix_ker_basis :=
   Basis.mk (linearIndependent_lapMatrix_ker_basis_aux G)
     (top_le_span_range_lapMatrix_ker_basis_aux G)
 
+end
+
 /-- The number of connected components in `G` is the dimension of the nullspace its Laplacian. -/
 theorem card_ConnectedComponent_eq_rank_ker_lapMatrix : Fintype.card G.ConnectedComponent =
     FiniteDimensional.finrank ℝ (LinearMap.ker (Matrix.toLin' (G.lapMatrix ℝ))) := by
+  classical
   rw [FiniteDimensional.finrank_eq_card_basis (lapMatrix_ker_basis G)]
 
 end SimpleGraph

--- a/Mathlib/Combinatorics/SimpleGraph/Matching.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Matching.lean
@@ -192,9 +192,9 @@ namespace ConnectedComponent
 
 section Finite
 
-variable [Fintype V] [DecidableEq V] [DecidableRel G.Adj]
+variable [Fintype V] [DecidableRel G.Adj]
 
-lemma even_card_of_isPerfectMatching (c : ConnectedComponent G) (hM : M.IsPerfectMatching) :
+lemma even_card_of_isPerfectMatching [DecidableEq V] (c : ConnectedComponent G) (hM : M.IsPerfectMatching) :
     Even (Fintype.card c.supp) := by
   classical simpa using (hM.induce_connectedComponent_isMatching c).even_card
 
@@ -217,6 +217,7 @@ lemma odd_matches_node_outside {u : Set V} {c : ConnectedComponent (Subgraph.del
 
   apply Nat.odd_iff_not_even.mp codd
   haveI : Fintype ↑(Subgraph.induce M (Subtype.val '' supp c)).verts := Fintype.ofFinite _
+  classical
   have hMeven := Subgraph.IsMatching.even_card hMmatch
   haveI : Fintype (c.supp) := Fintype.ofFinite _
   simp only [Subgraph.induce_verts, Subgraph.verts_top, Set.toFinset_image,

--- a/Mathlib/Combinatorics/SimpleGraph/Matching.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Matching.lean
@@ -194,7 +194,8 @@ section Finite
 
 variable [Fintype V] [DecidableRel G.Adj]
 
-lemma even_card_of_isPerfectMatching [DecidableEq V] (c : ConnectedComponent G) (hM : M.IsPerfectMatching) :
+lemma even_card_of_isPerfectMatching [DecidableEq V]
+    (c : ConnectedComponent G) (hM : M.IsPerfectMatching) :
     Even (Fintype.card c.supp) := by
   classical simpa using (hM.induce_connectedComponent_isMatching c).even_card
 


### PR DESCRIPTION
Found by the linter in #10235.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
