### PR TITLE
[Merged by Bors] - chore: fix Lean 3 names in comments, related to presheaves

### DIFF
--- a/Mathlib/CategoryTheory/Category/Pairwise.lean
+++ b/Mathlib/CategoryTheory/Category/Pairwise.lean
@@ -17,7 +17,7 @@ whose only non-identity morphisms are
 
 We use this later in describing (one formulation of) the sheaf condition.
 
-Given any function `U : ι → α`, where `α` is some complete lattice (e.g. `(opens X)ᵒᵖ`),
+Given any function `U : ι → α`, where `α` is some complete lattice (e.g. `(Opens X)ᵒᵖ`),
 we produce a functor `Pairwise ι ⥤ α` in the obvious way,
 and show that `iSup U` provides a colimit cocone over this functor.
 -/

--- a/Mathlib/CategoryTheory/Functor/Flat.lean
+++ b/Mathlib/CategoryTheory/Functor/Flat.lean
@@ -109,7 +109,7 @@ variable (F : C ⥤ D) [RepresentablyFlat F] {c : Cone K} (hc : IsLimit c) (s : 
 
 /-- (Implementation).
 Given a limit cone `c : cone K` and a cone `s : cone (K ⋙ F)` with `F` representably flat,
-`s` can factor through `F.map_cone c`.
+`s` can factor through `F.mapCone c`.
 -/
 noncomputable def lift : s.pt ⟶ F.obj c.pt :=
   let s' := IsCofiltered.cone (s.toStructuredArrow ⋙ StructuredArrow.pre _ K F)

--- a/Mathlib/Topology/Sheaves/Forget.lean
+++ b/Mathlib/Topology/Sheaves/Forget.lean
@@ -11,7 +11,7 @@ import Mathlib.Topology.Sheaves.Sheaf
 
 If `G : C ⥤ D` is a functor which reflects isomorphisms and preserves limits
 (we assume all limits exist in `C`),
-then checking the sheaf condition for a presheaf `F : presheaf C X`
+then checking the sheaf condition for a presheaf `F : Presheaf C X`
 is equivalent to checking the sheaf condition for `F ⋙ G`.
 
 The important special case is when
@@ -34,7 +34,7 @@ namespace TopCat.Presheaf
 
 /-- If `G : C ⥤ D` is a functor which reflects isomorphisms and preserves limits
 (we assume all limits exist in `C`),
-then checking the sheaf condition for a presheaf `F : presheaf C X`
+then checking the sheaf condition for a presheaf `F : Presheaf C X`
 is equivalent to checking the sheaf condition for `F ⋙ G`.
 
 The important special case is when

--- a/Mathlib/Topology/Sheaves/SheafCondition/EqualizerProducts.lean
+++ b/Mathlib/Topology/Sheaves/SheafCondition/EqualizerProducts.lean
@@ -142,7 +142,7 @@ def diagram.isoOfIso (α : F ≅ G) : diagram F U ≅ diagram.{v'} G U :=
           NatTrans.naturality, limMap_π_assoc]
       · simp)
 
-/-- If `F G : presheaf C X` are isomorphic presheaves,
+/-- If `F G : Presheaf C X` are isomorphic presheaves,
 then the `fork F U`, the canonical cone of the sheaf condition diagram for `F`,
 is isomorphic to `fork F G` postcomposed with the corresponding isomorphism between
 sheaf condition diagrams.
@@ -162,7 +162,7 @@ def fork.isoOfIso (α : F ≅ G) :
 
 end SheafConditionEqualizerProducts
 
-/-- The sheaf condition for a `F : presheaf C X` requires that the morphism
+/-- The sheaf condition for a `F : Presheaf C X` requires that the morphism
 `F.obj U ⟶ ∏ᶜ F.obj (U i)` (where `U` is some open set which is the union of the `U i`)
 is the equalizer of the two morphisms
 `∏ᶜ F.obj (U i) ⟶ ∏ᶜ F.obj (U i) ⊓ (U j)`.

--- a/Mathlib/Topology/Sheaves/SheafCondition/PairwiseIntersections.lean
+++ b/Mathlib/Topology/Sheaves/SheafCondition/PairwiseIntersections.lean
@@ -21,15 +21,15 @@ a category with objects corresponding to
 * intersections of pairs of open sets, `pair i j`,
 with morphisms from `pair i j` to both `single i` and `single j`.
 
-Any open cover `U : ι → opens X` provides a functor `diagram U : overlap ι ⥤ (opens X)ᵒᵖ`.
+Any open cover `U : ι → Opens X` provides a functor `diagram U : overlap ι ⥤ (Opens X)ᵒᵖ`.
 
-There is a canonical cone over this functor, `cone U`, whose cone point is `supr U`,
+There is a canonical cone over this functor, `cone U`, whose cone point is `isup U`,
 and in fact this is a limit cone.
 
-A presheaf `F : presheaf C X` is a sheaf precisely if it preserves this limit.
+A presheaf `F : Presheaf C X` is a sheaf precisely if it preserves this limit.
 We express this in two equivalent ways, as
-* `is_limit (F.map_cone (cone U))`, or
-* `preserves_limit (diagram U) F`
+* `isLimit (F.mapCone (cone U))`, or
+* `preservesLimit (diagram U) F`
 
 We show that this sheaf condition is equivalent to the `OpensLeCover` sheaf condition, and
 thereby also equivalent to the default sheaf condition.
@@ -52,8 +52,8 @@ section
 (which we prove equivalent to the usual one below as
 `isSheaf_iff_isSheafPairwiseIntersections`).
 
-A presheaf is a sheaf if `F` sends the cone `(pairwise.cocone U).op` to a limit cone.
-(Recall `Pairwise.cocone U` has cone point `supr U`, mapping down to the `U i` and the `U i ⊓ U j`.)
+A presheaf is a sheaf if `F` sends the cone `(Pairwise.cocone U).op` to a limit cone.
+(Recall `Pairwise.cocone U` has cone point `iSup U`, mapping down to the `U i` and the `U i ⊓ U j`.)
 -/
 def IsSheafPairwiseIntersections (F : Presheaf C X) : Prop :=
   ∀ ⦃ι : Type w⦄ (U : ι → Opens X), Nonempty (IsLimit (F.mapCone (Pairwise.cocone U).op))
@@ -64,7 +64,7 @@ def IsSheafPairwiseIntersections (F : Presheaf C X) : Prop :=
 
 A presheaf is a sheaf if `F` preserves the limit of `Pairwise.diagram U`.
 (Recall `Pairwise.diagram U` is the diagram consisting of the pairwise intersections
-`U i ⊓ U j` mapping into the open sets `U i`. This diagram has limit `supr U`.)
+`U i ⊓ U j` mapping into the open sets `U i`. This diagram has limit `iSup U`.)
 -/
 def IsSheafPreservesLimitPairwiseIntersections (F : Presheaf C X) : Prop :=
   ∀ ⦃ι : Type w⦄ (U : ι → Opens X), Nonempty (PreservesLimit (Pairwise.diagram U).op F)
@@ -78,7 +78,7 @@ variable {ι : Type w} (U : ι → Opens X)
 open CategoryTheory.Pairwise
 
 /-- Implementation detail:
-the object level of `pairwise_to_opens_le_cover : pairwise ι ⥤ opens_le_cover U`
+the object level of `pairwiseToOpensLeCover : Pairwise ι ⥤ OpensLeCover U`
 -/
 @[simp]
 def pairwiseToOpensLeCoverObj : Pairwise ι → OpensLeCover U
@@ -88,7 +88,7 @@ def pairwiseToOpensLeCoverObj : Pairwise ι → OpensLeCover U
 open CategoryTheory.Pairwise.Hom
 
 /-- Implementation detail:
-the morphism level of `pairwise_to_opens_le_cover : pairwise ι ⥤ opens_le_cover U`
+the morphism level of `pairwiseToOpensLeCover : Pairwise ι ⥤ OpensLeCover U`
 -/
 def pairwiseToOpensLeCoverMap :
     ∀ {V W : Pairwise ι}, (V ⟶ W) → (pairwiseToOpensLeCoverObj U V ⟶ pairwiseToOpensLeCoverObj U W)
@@ -108,7 +108,7 @@ def pairwiseToOpensLeCover : Pairwise ι ⥤ OpensLeCover U where
 instance (V : OpensLeCover U) : Nonempty (StructuredArrow V (pairwiseToOpensLeCover U)) :=
   ⟨@StructuredArrow.mk _ _ _ _ _ (single V.index) _ V.homToIndex⟩
 
--- This is a case bash: for each pair of types of objects in `pairwise ι`,
+-- This is a case bash: for each pair of types of objects in `Pairwise ι`,
 -- we have to explicitly construct a zigzag.
 /-- The diagram consisting of the `U i` and `U i ⊓ U j` is cofinal in the diagram
 of all opens contained in some `U i`.
@@ -202,7 +202,7 @@ instance : Functor.Final (pairwiseToOpensLeCover U) :=
                         right := left i' j' }⟩)
                   List.Chain.nil)))⟩
 
-/-- The diagram in `opens X` indexed by pairwise intersections from `U` is isomorphic
+/-- The diagram in `Opens X` indexed by pairwise intersections from `U` is isomorphic
 (in fact, equal) to the diagram factored through `OpensLeCover U`.
 -/
 def pairwiseDiagramIso :
@@ -211,7 +211,7 @@ def pairwiseDiagramIso :
   inv := { app := by rintro (i | ⟨i, j⟩) <;> exact 𝟙 _ }
 
 /--
-The cocone `Pairwise.cocone U` with cocone point `supr U` over `Pairwise.diagram U` is isomorphic
+The cocone `Pairwise.cocone U` with cocone point `iSup U` over `Pairwise.diagram U` is isomorphic
 to the cocone `opensLeCoverCocone U` (with the same cocone point)
 after appropriate whiskering and postcomposition.
 -/
@@ -228,7 +228,7 @@ open SheafCondition
 variable (F : Presheaf C X)
 
 /-- The sheaf condition
-in terms of a limit diagram over all `{ V : opens X // ∃ i, V ≤ U i }`
+in terms of a limit diagram over all `{ V : Opens X // ∃ i, V ≤ U i }`
 is equivalent to the reformulation
 in terms of a limit diagram over `U i` and `U i ⊓ U j`.
 -/

--- a/Mathlib/Topology/Sheaves/SheafCondition/UniqueGluing.lean
+++ b/Mathlib/Topology/Sheaves/SheafCondition/UniqueGluing.lean
@@ -17,12 +17,12 @@ functor `C ⥤ Type` preserves limits and reflects isomorphisms. The usual categ
 structures, such as `MonCat`, `AddCommGrp`, `RingCat`, `CommRingCat` etc. are all examples of
 this kind of category.
 
-A presheaf `F : presheaf C X` satisfies the sheaf condition if and only if, for every
+A presheaf `F : Presheaf C X` satisfies the sheaf condition if and only if, for every
 compatible family of sections `sf : Π i : ι, F.obj (op (U i))`, there exists a unique gluing
-`s : F.obj (op (supr U))`.
+`s : F.obj (op (iSup U))`.
 
 Here, the family `sf` is called compatible, if for all `i j : ι`, the restrictions of `sf i`
-and `sf j` to `U i ⊓ U j` agree. A section `s : F.obj (op (supr U))` is a gluing for the
+and `sf j` to `U i ⊓ U j` agree. A section `s : F.obj (op (iSup U))` is a gluing for the
 family `sf`, if `s` restricts to `sf i` on `U i` for all `i : ι`
 
 We show that the sheaf condition in terms of unique gluings is equivalent to the definition
@@ -65,9 +65,9 @@ def IsGluing (sf : ∀ i : ι, F.obj (op (U i))) (s : F.obj (op (iSup U))) : Pro
   ∀ i : ι, F.map (Opens.leSupr U i).op s = sf i
 
 /--
-The sheaf condition in terms of unique gluings. A presheaf `F : presheaf C X` satisfies this sheaf
+The sheaf condition in terms of unique gluings. A presheaf `F : Presheaf C X` satisfies this sheaf
 condition if and only if, for every compatible family of sections `sf : Π i : ι, F.obj (op (U i))`,
-there exists a unique gluing `s : F.obj (op (supr U))`.
+there exists a unique gluing `s : F.obj (op (iSup U))`.
 
 We prove this to be equivalent to the usual one below in
 `TopCat.Presheaf.isSheaf_iff_isSheafUniqueGluing`


### PR DESCRIPTION
Rename
- presheaf -> Presheaf
- opens -> Opens
- supr -> iSup
- pairwise -> pairwise
- and a few more

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
