### PR TITLE
[Merged by Bors] - feat: Scalar multiplication of an indicator function

### DIFF
--- a/Mathlib/Algebra/Module/Basic.lean
+++ b/Mathlib/Algebra/Module/Basic.lean
@@ -191,6 +191,16 @@ lemma indicator_smul_const (s : Set α) (r : α → R) (m : M) :
   funext <| indicator_smul_const_apply _ _ _
 
 end SMulWithZero
+
+section MulZeroOneClass
+
+variable [MulZeroOneClass R]
+
+lemma smul_indicator_one_apply (s : Set α) (r : R) (a : α) :
+    r • s.indicator (1 : α → R) a = s.indicator (fun _ ↦ r) a := by
+  simp_rw [← indicator_const_smul_apply, Pi.one_apply, smul_eq_mul, mul_one]
+
+end MulZeroOneClass
 end Set
 
 assert_not_exists Multiset


### PR DESCRIPTION
from GibbsMeasure


Co-authored-by: Yael Dillies <yael.dillies@gmail.com>

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
