### PR TITLE
[Merged by Bors] - chore: Generalise `Pi.exists_forall_pos_add_lt` to monoids

### DIFF
--- a/Mathlib/Algebra/Order/Field/Pi.lean
+++ b/Mathlib/Algebra/Order/Field/Pi.lean
@@ -1,9 +1,8 @@
 /-
-Copyright (c) 2014 Robert Lewis. All rights reserved.
+Copyright (c) 2023 Yaël Dillies. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Yaël Dillies
 -/
-import Mathlib.Algebra.Order.Field.Basic
 import Mathlib.Data.Finset.Lattice
 import Mathlib.Data.Fintype.Card
 
@@ -13,17 +12,17 @@ import Mathlib.Data.Fintype.Card
 We split this from `Algebra.Order.Field.Basic` to avoid importing the finiteness hierarchy there.
 -/
 
-
-variable {α ι : Type*} [LinearOrderedSemifield α]
+variable {α ι : Type*} [LinearOrderedCancelAddCommMonoid α] [Nontrivial α] [DenselyOrdered α]
 
 theorem Pi.exists_forall_pos_add_lt [ExistsAddOfLE α] [Finite ι] {x y : ι → α}
     (h : ∀ i, x i < y i) : ∃ ε, 0 < ε ∧ ∀ i, x i + ε < y i := by
   cases nonempty_fintype ι
   cases isEmpty_or_nonempty ι
-  · exact ⟨1, zero_lt_one, isEmptyElim⟩
+  · obtain ⟨a, ha⟩ := exists_ne (0 : α)
+    obtain ha | ha := ha.lt_or_lt <;> obtain ⟨b, hb, -⟩ := exists_pos_add_of_lt' ha <;>
+      exact ⟨b, hb, isEmptyElim⟩
   choose ε hε hxε using fun i => exists_pos_add_of_lt' (h i)
   obtain rfl : x + ε = y := funext hxε
   have hε : 0 < Finset.univ.inf' Finset.univ_nonempty ε := (Finset.lt_inf'_iff _).2 fun i _ => hε _
-  exact
-    ⟨_, half_pos hε, fun i =>
-      add_lt_add_left ((half_lt_self hε).trans_le <| Finset.inf'_le _ <| Finset.mem_univ _) _⟩
+  obtain ⟨δ, hδ, hδε⟩ := exists_between hε
+  exact ⟨δ, hδ, fun i ↦ add_lt_add_left (hδε.trans_le <| Finset.inf'_le _ <| Finset.mem_univ _) _⟩


### PR DESCRIPTION
... as spotted by Yury.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
