### PR TITLE
[Merged by Bors] - feat: Lemmas specialised to `piFinset fun _ : Fin n ↦ s`

### DIFF
--- a/Mathlib/Data/Fintype/BigOperators.lean
+++ b/Mathlib/Data/Fintype/BigOperators.lean
@@ -113,7 +113,8 @@ namespace Fintype
     (piFinset s).card = ∏ i, (s i).card := by simp [piFinset, card_map]
 
 /-- This lemma is specifically designed to be used backwards, whence the specialisation to `Fin n`
-as the indexing type doesn't matter in practice. -/
+as the indexing type doesn't matter in practice. The more general forward direction lemma here is
+`Fintype.card_piFinset`. -/
 lemma card_piFinset_const {α : Type*} (s : Finset α) (n : ℕ) :
     (piFinset fun _ : Fin n ↦ s).card = s.card ^ n := by simp
 
@@ -121,7 +122,8 @@ lemma card_piFinset_const {α : Type*} (s : Finset α) (n : ℕ) :
   card_piFinset _
 
 /-- This lemma is specifically designed to be used backwards, whence the specialisation to `Fin n`
-as the indexing type doesn't matter in practice. -/
+as the indexing type doesn't matter in practice. The more general forward direction lemma here is
+`Fintype.card_pi`. -/
 lemma card_pi_const (α : Type*) [Fintype α] (n : ℕ) : card (Fin n → α) = card α ^ n :=
   card_piFinset_const _ _
 

--- a/Mathlib/Data/Fintype/BigOperators.lean
+++ b/Mathlib/Data/Fintype/BigOperators.lean
@@ -115,7 +115,7 @@ namespace Fintype
 /-- This lemma is specifically designed to be used backwards, whence the specialisation to `Fin n`
 as the indexing type doesn't matter in practice. -/
 lemma card_piFinset_const {α : Type*} (s : Finset α) (n : ℕ) :
-   (piFinset fun _ : Fin n ↦ s).card = s.card ^ n := by simp
+    (piFinset fun _ : Fin n ↦ s).card = s.card ^ n := by simp
 
 @[simp] lemma card_pi [DecidableEq ι] [∀ i, Fintype (α i)] : card (∀ i, α i) = ∏ i, card (α i) :=
   card_piFinset _

--- a/Mathlib/Data/Fintype/BigOperators.lean
+++ b/Mathlib/Data/Fintype/BigOperators.lean
@@ -112,8 +112,18 @@ namespace Fintype
 @[simp] lemma card_piFinset (s : ∀ i, Finset (α i)) :
     (piFinset s).card = ∏ i, (s i).card := by simp [piFinset, card_map]
 
+/-- This lemma is specifically designed to be used backwards, whence the specialisation to `Fin n`
+as the indexing type doesn't matter in practice. -/
+lemma card_piFinset_const {α : Type*} (s : Finset α) (n : ℕ) :
+   (piFinset fun _ : Fin n ↦ s).card = s.card ^ n := by simp
+
 @[simp] lemma card_pi [DecidableEq ι] [∀ i, Fintype (α i)] : card (∀ i, α i) = ∏ i, card (α i) :=
   card_piFinset _
+
+/-- This lemma is specifically designed to be used backwards, whence the specialisation to `Fin n`
+as the indexing type doesn't matter in practice. -/
+lemma card_pi_const (α : Type*) [Fintype α] (n : ℕ) : card (Fin n → α) = card α ^ n :=
+  card_piFinset_const _ _
 
 @[simp] nonrec lemma card_sigma [Fintype ι] [∀ i, Fintype (α i)] :
     card (Sigma α) = ∑ i, card (α i) := card_sigma _ _

--- a/Mathlib/Data/Fintype/Pi.lean
+++ b/Mathlib/Data/Fintype/Pi.lean
@@ -56,10 +56,8 @@ theorem piFinset_empty [Nonempty α] : piFinset (fun _ => ∅ : ∀ i, Finset (�
 lemma piFinset_nonempty : (piFinset s).Nonempty ↔ ∀ a, (s a).Nonempty := by
   simp [Finset.Nonempty, Classical.skolem]
 
-/-- This lemma is specifically designed to be used backwards, whence the specialisation to `Fin n`
-as the indexing type doesn't matter in practice. -/
-lemma _root_.Finset.Nonempty.piFinset_const {s : Finset α} (hs : s.Nonempty) {n : ℕ} :
-    (piFinset fun _ : Fin n ↦ s).Nonempty := piFinset_nonempty.2 fun _ ↦ hs
+lemma _root_.Finset.Nonempty.piFinset_const {s : Finset α} (hs : s.Nonempty) {ι : Type*} [Fintype ι]
+    [DecidableEq ι] : (piFinset fun _ : ι ↦ s).Nonempty := piFinset_nonempty.2 fun _ ↦ hs
 
 @[simp]
 lemma piFinset_of_isEmpty [IsEmpty α] (s : ∀ a, Finset (γ a)) : piFinset s = univ :=

--- a/Mathlib/Data/Fintype/Pi.lean
+++ b/Mathlib/Data/Fintype/Pi.lean
@@ -56,8 +56,8 @@ theorem piFinset_empty [Nonempty α] : piFinset (fun _ => ∅ : ∀ i, Finset (�
 lemma piFinset_nonempty : (piFinset s).Nonempty ↔ ∀ a, (s a).Nonempty := by
   simp [Finset.Nonempty, Classical.skolem]
 
-lemma _root_.Finset.Nonempty.piFinset_const {s : Finset α} (hs : s.Nonempty) {ι : Type*} [Fintype ι]
-    [DecidableEq ι] : (piFinset fun _ : ι ↦ s).Nonempty := piFinset_nonempty.2 fun _ ↦ hs
+lemma _root_.Finset.Nonempty.piFinset_const {ι : Type*} [Fintype ι] [DecidableEq ι] {s : Finset α}
+    (hs : s.Nonempty) : (piFinset fun _ : ι ↦ s).Nonempty := piFinset_nonempty.2 fun _ ↦ hs
 
 @[simp]
 lemma piFinset_of_isEmpty [IsEmpty α] (s : ∀ a, Finset (γ a)) : piFinset s = univ :=

--- a/Mathlib/Data/Fintype/Pi.lean
+++ b/Mathlib/Data/Fintype/Pi.lean
@@ -56,6 +56,11 @@ theorem piFinset_empty [Nonempty α] : piFinset (fun _ => ∅ : ∀ i, Finset (�
 lemma piFinset_nonempty : (piFinset s).Nonempty ↔ ∀ a, (s a).Nonempty := by
   simp [Finset.Nonempty, Classical.skolem]
 
+/-- This lemma is specifically designed to be used backwards, whence the specialisation to `Fin n`
+as the indexing type doesn't matter in practice. -/
+lemma _root_.Finset.Nonempty.piFinset_const {s : Finset α} (hs : s.Nonempty) {n : ℕ} :
+    (piFinset fun _ : Fin n ↦ s).Nonempty := piFinset_nonempty.2 fun _ ↦ hs
+
 @[simp]
 lemma piFinset_of_isEmpty [IsEmpty α] (s : ∀ a, Finset (γ a)) : piFinset s = univ :=
   eq_univ_of_forall fun _ ↦ by simp


### PR DESCRIPTION
Those lemmas are specifically useful for rewriting backwards when the indexing type doesn't matter (and also sometimes useful forwardly).

From LeanAPAP


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
