### PR TITLE
[Merged by Bors] - feat: add simp lemmas for explicit matrix traces

### DIFF
--- a/Mathlib/LinearAlgebra/Matrix/Trace.lean
+++ b/Mathlib/LinearAlgebra/Matrix/Trace.lean
@@ -5,6 +5,7 @@ Authors: Johannes Hölzl, Patrick Massot, Casper Putz, Anne Baanen
 -/
 import Mathlib.Data.Matrix.Block
 import Mathlib.Data.Matrix.RowCol
+import Mathlib.Data.Matrix.Notation
 
 /-!
 # Trace of a matrix
@@ -178,13 +179,10 @@ section Fin
 
 variable [AddCommMonoid R]
 
-/-! ### Special cases for `Fin n`
-
-While `simp [Fin.sum_univ_succ]` can prove these, we include them for convenience and consistency
-with `Matrix.det_fin_two` etc.
+/-! ### Special cases for `Fin n` for low values of `n`
 -/
 
-
+@[simp]
 theorem trace_fin_zero (A : Matrix (Fin 0) (Fin 0) R) : trace A = 0 :=
   rfl
 
@@ -197,6 +195,19 @@ theorem trace_fin_two (A : Matrix (Fin 2) (Fin 2) R) : trace A = A 0 0 + A 1 1 :
 theorem trace_fin_three (A : Matrix (Fin 3) (Fin 3) R) : trace A = A 0 0 + A 1 1 + A 2 2 := by
   rw [← add_zero (A 2 2), add_assoc]
   rfl
+
+@[simp]
+theorem trace_fin_one_of (a : R) : trace !![a] = a :=
+  trace_fin_one _
+
+@[simp]
+theorem trace_fin_two_of (a b c d : R) : trace !![a, b; c, d] = a + d :=
+  trace_fin_two _
+
+@[simp]
+theorem trace_fin_three_of (a b c d e f g h i : R) :
+    trace !![a, b, c; d, e, f; g, h, i] = a + e + i :=
+  trace_fin_three _
 
 end Fin
 


### PR DESCRIPTION

---

This came while writing a linear algebra chapter, starting with extremely elementary examples where the difference between
```lean
#norm_num !![(1 : ℝ), 2; 3, 4].det
```
and
```lean
#norm_num !![(1 : ℝ), 2; 3, 4].trace
```
is currently very disappointing.

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
