### PR TITLE
[Merged by Bors] - chore: backports for leanprover/lean4#4814 (part 7)

### DIFF
--- a/Mathlib/Algebra/Module/LinearMap/Defs.lean
+++ b/Mathlib/Algebra/Module/LinearMap/Defs.lean
@@ -654,13 +654,13 @@ variable [Semiring R] [AddCommMonoid M] [AddCommMonoid M₂]
 variable [Module R M] [Module R M₂]
 
 /-- Convert an `IsLinearMap` predicate to a `LinearMap` -/
-def mk' (f : M → M₂) (H : IsLinearMap R f) : M →ₗ[R] M₂ where
+def mk' (f : M → M₂) (lin : IsLinearMap R f) : M →ₗ[R] M₂ where
   toFun := f
-  map_add' := H.1
-  map_smul' := H.2
+  map_add' := lin.1
+  map_smul' := lin.2
 
 @[simp]
-theorem mk'_apply {f : M → M₂} (H : IsLinearMap R f) (x : M) : mk' f H x = f x :=
+theorem mk'_apply {f : M → M₂} (lin : IsLinearMap R f) (x : M) : mk' f lin x = f x :=
   rfl
 
 theorem isLinearMap_smul {R M : Type*} [CommSemiring R] [AddCommMonoid M] [Module R M] (c : R) :
@@ -673,9 +673,7 @@ theorem isLinearMap_smul' {R M : Type*} [Semiring R] [AddCommMonoid M] [Module R
     IsLinearMap R fun c : R ↦ c • a :=
   IsLinearMap.mk (fun x y ↦ add_smul x y a) fun x y ↦ mul_smul x y a
 
-variable {f : M → M₂} (lin : IsLinearMap R f)
-
-theorem map_zero : f (0 : M) = (0 : M₂) :=
+theorem map_zero {f : M → M₂} (lin : IsLinearMap R f) : f (0 : M) = (0 : M₂) :=
   (lin.mk' f).map_zero
 
 end AddCommMonoid
@@ -688,12 +686,10 @@ variable [Module R M] [Module R M₂]
 theorem isLinearMap_neg : IsLinearMap R fun z : M ↦ -z :=
   IsLinearMap.mk neg_add fun x y ↦ (smul_neg x y).symm
 
-variable {f : M → M₂} (lin : IsLinearMap R f)
-
-theorem map_neg (x : M) : f (-x) = -f x :=
+theorem map_neg {f : M → M₂} (lin : IsLinearMap R f) (x : M) : f (-x) = -f x :=
   (lin.mk' f).map_neg x
 
-theorem map_sub (x y) : f (x - y) = f x - f y :=
+theorem map_sub {f : M → M₂} (lin : IsLinearMap R f) (x y : M) : f (x - y) = f x - f y :=
   (lin.mk' f).map_sub x y
 
 end AddCommGroup

--- a/Mathlib/Algebra/Order/Group/PosPart.lean
+++ b/Mathlib/Algebra/Order/Group/PosPart.lean
@@ -49,8 +49,9 @@ section Lattice
 variable [Lattice α]
 
 section Group
-variable [Group α] [CovariantClass α α (· * ·) (· ≤ ·)]
-  [CovariantClass α α (swap (· * ·)) (· ≤ ·)] {a : α}
+variable [Group α] {a : α}
+  -- [CovariantClass α α (· * ·) (· ≤ ·)]
+  -- [CovariantClass α α (swap (· * ·)) (· ≤ ·)] {a : α}
 
 /-- The *positive part* of an element `a` in a lattice ordered group is `a ⊔ 1`, denoted `a⁺ᵐ`. -/
 @[to_additive
@@ -70,9 +71,6 @@ def leOnePart (a : α) : α := a⁻¹ ⊔ 1
 
 @[to_additive] lemma oneLePart_mono : Monotone (oneLePart : α → α) :=
   fun _a _b hab ↦ sup_le_sup_right hab _
-
-@[to_additive] lemma leOnePart_anti : Antitone (leOnePart : α → α) :=
-  fun _a _b hab ↦ sup_le_sup_right (inv_le_inv_iff.2 hab) _
 
 @[to_additive (attr := simp)] lemma oneLePart_one : (1 : α)⁺ᵐ = 1 := sup_idem _
 
@@ -95,14 +93,9 @@ def leOnePart (a : α) : α := a⁻¹ ⊔ 1
 @[to_additive "See also `negPart_eq_neg`."]
 lemma leOnePart_eq_inv' : a⁻ᵐ = a⁻¹ ↔ 1 ≤ a⁻¹ := sup_eq_left
 
-@[to_additive (attr := simp)] lemma leOnePart_eq_inv : a⁻ᵐ = a⁻¹ ↔ a ≤ 1 := by simp [leOnePart]
-
 /-- See also `leOnePart_eq_one`. -/
 @[to_additive "See also `negPart_eq_zero`."]
 lemma leOnePart_eq_one' : a⁻ᵐ = 1 ↔ a⁻¹ ≤ 1 := sup_eq_right
-
-@[to_additive (attr := simp)]
-lemma leOnePart_eq_one : a⁻ᵐ = 1 ↔ 1 ≤ a := by simp [leOnePart_eq_one']
 
 @[to_additive] lemma oneLePart_le_one : a⁺ᵐ ≤ 1 ↔ a ≤ 1 := by simp [oneLePart]
 
@@ -115,13 +108,35 @@ lemma leOnePart_le_one' : a⁻ᵐ ≤ 1 ↔ a⁻¹ ≤ 1 := by simp [leOnePart]
 @[to_additive (attr := simp) posPart_pos] lemma one_lt_oneLePart (ha : 1 < a) : 1 < a⁺ᵐ := by
   rwa [oneLePart_eq_self.2 ha.le]
 
-@[to_additive (attr := simp) negPart_pos] lemma one_lt_ltOnePart (ha : a < 1) : 1 < a⁻ᵐ := by
-  rwa [leOnePart_eq_inv.2 ha.le, one_lt_inv']
-
 @[to_additive (attr := simp)] lemma oneLePart_inv (a : α) : a⁻¹⁺ᵐ = a⁻ᵐ := rfl
 
 @[to_additive (attr := simp)] lemma leOnePart_inv (a : α) : a⁻¹⁻ᵐ = a⁺ᵐ := by
   simp [oneLePart, leOnePart]
+
+section covariantmul
+variable [CovariantClass α α (· * ·) (· ≤ ·)]
+
+@[to_additive (attr := simp)] lemma leOnePart_eq_inv : a⁻ᵐ = a⁻¹ ↔ a ≤ 1 := by simp [leOnePart]
+
+@[to_additive (attr := simp)]
+lemma leOnePart_eq_one : a⁻ᵐ = 1 ↔ 1 ≤ a := by simp [leOnePart_eq_one']
+
+@[to_additive (attr := simp) negPart_pos] lemma one_lt_ltOnePart (ha : a < 1) : 1 < a⁻ᵐ := by
+  rwa [leOnePart_eq_inv.2 ha.le, one_lt_inv']
+
+-- Bourbaki A.VI.12 Prop 9 a)
+@[to_additive (attr := simp)] lemma oneLePart_div_leOnePart (a : α) : a⁺ᵐ / a⁻ᵐ = a := by
+  rw [div_eq_mul_inv, mul_inv_eq_iff_eq_mul, leOnePart, mul_sup, mul_one, mul_right_inv, sup_comm,
+    oneLePart]
+
+@[to_additive (attr := simp)] lemma leOnePart_div_oneLePart (a : α) : a⁻ᵐ / a⁺ᵐ = a⁻¹ := by
+  rw [← inv_div, oneLePart_div_leOnePart]
+
+section covariantmulop
+variable [CovariantClass α α (swap (· * ·)) (· ≤ ·)]
+
+@[to_additive] lemma leOnePart_anti : Antitone (leOnePart : α → α) :=
+  fun _a _b hab ↦ sup_le_sup_right (inv_le_inv_iff.2 hab) _
 
 @[to_additive]
 lemma leOnePart_eq_inv_inf_one (a : α) : a⁻ᵐ = (a ⊓ 1)⁻¹ := by
@@ -139,23 +154,19 @@ lemma leOnePart_eq_inv_inf_one (a : α) : a⁻ᵐ = (a ⊓ 1)⁻¹ := by
   exact sup_eq_left.2 <| one_le_mabs a
 
 -- Bourbaki A.VI.12 Prop 9 a)
-@[to_additive (attr := simp)] lemma oneLePart_div_leOnePart (a : α) : a⁺ᵐ / a⁻ᵐ = a := by
-  rw [div_eq_mul_inv, mul_inv_eq_iff_eq_mul, leOnePart, mul_sup, mul_one, mul_right_inv, sup_comm,
-    oneLePart]
-
-@[to_additive (attr := simp)] lemma leOnePart_div_oneLePart (a : α) : a⁻ᵐ / a⁺ᵐ = a⁻¹ := by
-  rw [← inv_div, oneLePart_div_leOnePart]
-
--- Bourbaki A.VI.12 Prop 9 a)
 -- a⁺ᵐ ⊓ a⁻ᵐ = 0 (`a⁺` and `a⁻` are co-prime, and, since they are positive, disjoint)
 @[to_additive] lemma oneLePart_inf_leOnePart_eq_one (a : α) : a⁺ᵐ ⊓ a⁻ᵐ = 1 := by
   rw [← mul_left_inj a⁻ᵐ⁻¹, inf_mul, one_mul, mul_right_inv, ← div_eq_mul_inv,
     oneLePart_div_leOnePart, leOnePart_eq_inv_inf_one, inv_inv]
 
+end covariantmulop
+
+end covariantmul
+
 end Group
 
 section CommGroup
-variable [Lattice α] [CommGroup α] [CovariantClass α α (· * ·) (· ≤ ·)]
+variable [CommGroup α] [CovariantClass α α (· * ·) (· ≤ ·)]
 
 -- Bourbaki A.VI.12 (with a and b swapped)
 @[to_additive] lemma sup_eq_mul_oneLePart_div (a b : α) : a ⊔ b = b * (a / b)⁺ᵐ := by
@@ -191,24 +202,28 @@ end CommGroup
 end Lattice
 
 section LinearOrder
-variable [LinearOrder α] [Group α] [CovariantClass α α (· * ·) (· ≤ ·)] {a : α}
+variable [LinearOrder α] [Group α] {a : α}
 
 @[to_additive] lemma oneLePart_eq_ite : a⁺ᵐ = if 1 ≤ a then a else 1 := by
   rw [oneLePart, ← maxDefault, ← sup_eq_maxDefault]; simp_rw [sup_comm]
 
-@[to_additive] lemma leOnePart_eq_ite : a⁻ᵐ = if a ≤ 1 then a⁻¹ else 1 := by
-  simp_rw [← one_le_inv']; rw [leOnePart, ← maxDefault, ← sup_eq_maxDefault]; simp_rw [sup_comm]
-
 @[to_additive (attr := simp) posPart_pos_iff] lemma one_lt_oneLePart_iff : 1 < a⁺ᵐ ↔ 1 < a :=
   lt_iff_lt_of_le_iff_le $ (one_le_oneLePart _).le_iff_eq.trans oneLePart_eq_one
-
-@[to_additive (attr := simp) negPart_pos_iff] lemma one_lt_ltOnePart_iff : 1 < a⁻ᵐ ↔ a < 1 :=
-  lt_iff_lt_of_le_iff_le $ (one_le_leOnePart _).le_iff_eq.trans leOnePart_eq_one
 
 @[to_additive posPart_eq_of_posPart_pos]
 lemma oneLePart_of_one_lt_oneLePart (ha : 1 < a⁺ᵐ) : a⁺ᵐ = a := by
   rw [oneLePart, right_lt_sup, not_le] at ha; exact oneLePart_eq_self.2 ha.le
 
+section covariantmul
+variable [CovariantClass α α (· * ·) (· ≤ ·)]
+
+@[to_additive] lemma leOnePart_eq_ite : a⁻ᵐ = if a ≤ 1 then a⁻¹ else 1 := by
+  simp_rw [← one_le_inv']; rw [leOnePart, ← maxDefault, ← sup_eq_maxDefault]; simp_rw [sup_comm]
+
+@[to_additive (attr := simp) negPart_pos_iff] lemma one_lt_ltOnePart_iff : 1 < a⁻ᵐ ↔ a < 1 :=
+  lt_iff_lt_of_le_iff_le $ (one_le_leOnePart _).le_iff_eq.trans leOnePart_eq_one
+
+end covariantmul
 end LinearOrder
 
 namespace Pi

--- a/Mathlib/Algebra/Order/Group/PosPart.lean
+++ b/Mathlib/Algebra/Order/Group/PosPart.lean
@@ -50,8 +50,6 @@ variable [Lattice α]
 
 section Group
 variable [Group α] {a : α}
-  -- [CovariantClass α α (· * ·) (· ≤ ·)]
-  -- [CovariantClass α α (swap (· * ·)) (· ≤ ·)] {a : α}
 
 /-- The *positive part* of an element `a` in a lattice ordered group is `a ⊔ 1`, denoted `a⁺ᵐ`. -/
 @[to_additive

--- a/Mathlib/Data/Set/Lattice.lean
+++ b/Mathlib/Data/Set/Lattice.lean
@@ -1246,7 +1246,7 @@ section
 
 open Function
 
-variable (s : Set β) {f : α → β} {U : ι → Set β} (hU : iUnion U = univ)
+variable {f : α → β} {U : ι → Set β} (hU : iUnion U = univ)
 
 theorem injective_iff_injective_of_iUnion_eq_univ :
     Injective f ↔ ∀ i, Injective ((U i).restrictPreimage f) := by

--- a/Mathlib/Order/Interval/Set/OrdConnectedComponent.lean
+++ b/Mathlib/Order/Interval/Set/OrdConnectedComponent.lean
@@ -175,7 +175,7 @@ theorem disjoint_ordT5Nhd : Disjoint (ordT5Nhd s t) (ordT5Nhd t s) := by
   clear hx₂
   rw [mem_ordConnectedComponent, subset_inter_iff] at ha hb
   wlog hab : a ≤ b with H
-  · exact H (x := x) b hbt hb a has ha (le_of_not_le hab)
+  · exact H b hbt hb a has ha (le_of_not_le hab)
   cases' ha with ha ha'
   cases' hb with hb hb'
   have hsub : [[a, b]] ⊆ (ordSeparatingSet s t).ordConnectedSectionᶜ := by

--- a/Mathlib/Order/Interval/Set/OrdConnectedComponent.lean
+++ b/Mathlib/Order/Interval/Set/OrdConnectedComponent.lean
@@ -167,6 +167,7 @@ def ordT5Nhd (s t : Set α) : Set α :=
   ⋃ x ∈ s, ordConnectedComponent (tᶜ ∩ (ordConnectedSection <| ordSeparatingSet s t)ᶜ) x
 
 theorem disjoint_ordT5Nhd : Disjoint (ordT5Nhd s t) (ordT5Nhd t s) := by
+  clear x y z
   rw [disjoint_iff_inf_le]
   rintro x ⟨hx₁, hx₂⟩
   rcases mem_iUnion₂.1 hx₁ with ⟨a, has, ha⟩

--- a/Mathlib/Order/Interval/Set/OrdConnectedComponent.lean
+++ b/Mathlib/Order/Interval/Set/OrdConnectedComponent.lean
@@ -175,7 +175,7 @@ theorem disjoint_ordT5Nhd : Disjoint (ordT5Nhd s t) (ordT5Nhd t s) := by
   clear hx₂
   rw [mem_ordConnectedComponent, subset_inter_iff] at ha hb
   wlog hab : a ≤ b with H
-  · exact H (x := x) (y := y) (z := z) b hbt hb a has ha (le_of_not_le hab)
+  · exact H (x := x) b hbt hb a has ha (le_of_not_le hab)
   cases' ha with ha ha'
   cases' hb with hb hb'
   have hsub : [[a, b]] ⊆ (ordSeparatingSet s t).ordConnectedSectionᶜ := by

--- a/Mathlib/SetTheory/ZFC/Basic.lean
+++ b/Mathlib/SetTheory/ZFC/Basic.lean
@@ -1507,22 +1507,23 @@ theorem map_fval {f : ZFSet.{u} → ZFSet.{u}} [H : PSet.Definable 1 f] {x y : Z
         subst e
         exact ⟨_, h, rfl⟩⟩
 
-variable (x : ZFSet.{u}) (h : ∅ ∉ x)
+variable (x : ZFSet.{u})
 
 /-- A choice function on the class of nonempty ZFC sets. -/
 noncomputable def choice : ZFSet :=
   @map (fun y => Classical.epsilon fun z => z ∈ y) (Classical.allDefinable _) x
 
-theorem choice_mem_aux (y : ZFSet.{u}) (yx : y ∈ x) :
+theorem choice_mem_aux (h : ∅ ∉ x) (y : ZFSet.{u}) (yx : y ∈ x) :
     (Classical.epsilon fun z : ZFSet.{u} => z ∈ y) ∈ y :=
   (@Classical.epsilon_spec _ fun z : ZFSet.{u} => z ∈ y) <|
     by_contradiction fun n => h <| by rwa [← (eq_empty y).2 fun z zx => n ⟨z, zx⟩]
 
-theorem choice_isFunc : IsFunc x (⋃₀ x) (choice x) :=
+theorem choice_isFunc (h : ∅ ∉ x) : IsFunc x (⋃₀ x) (choice x) :=
   (@map_isFunc _ (Classical.allDefinable _) _ _).2 fun y yx =>
     mem_sUnion.2 ⟨y, yx, choice_mem_aux x h y yx⟩
 
-theorem choice_mem (y : ZFSet.{u}) (yx : y ∈ x) : (choice x ′ y : Class.{u}) ∈ (y : Class.{u}) := by
+theorem choice_mem (h : ∅ ∉ x) (y : ZFSet.{u}) (yx : y ∈ x) :
+    (choice x ′ y : Class.{u}) ∈ (y : Class.{u}) := by
   delta choice
   rw [@map_fval _ (Classical.allDefinable _) x y yx, Class.coe_mem, Class.coe_apply]
   exact choice_mem_aux x h y yx


### PR DESCRIPTION
see https://github.com/leanprover-community/mathlib4/pull/15245

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
