### PR TITLE
[Merged by Bors] - chore (Algebra.Order.Ring.Unbundled.Basic): inline typeclass assumptions 

### DIFF
--- a/Mathlib/Algebra/Order/Ring/Unbundled/Basic.lean
+++ b/Mathlib/Algebra/Order/Ring/Unbundled/Basic.lean
@@ -383,7 +383,7 @@ section StrictOrderedSemiring
 variable [Semiring α] [PartialOrder α] {a b c d : α}
 
 @[simp]
-theorem pow_pos [ZeroLEOneClass α] [NeZero 1] [PosMulStrictMono α]
+theorem pow_pos [ZeroLEOneClass α] [PosMulStrictMono α]
     (H : 0 < a) : ∀ n : ℕ, 0 < a ^ n
   | 0 => by
     nontriviality
@@ -578,7 +578,7 @@ lemma mul_add_mul_le_mul_add_mul' [ExistsAddOfLE α] [MulPosMono α]
 variable [ContravariantClass α α (· + ·) (· < ·)]
 
 /-- Binary strict **rearrangement inequality**. -/
-lemma mul_add_mul_lt_mul_add_mul [ExistsAddOfLE α] [PosMulMono α] [MulPosStrictMono α]
+lemma mul_add_mul_lt_mul_add_mul [ExistsAddOfLE α] [MulPosStrictMono α]
     [CovariantClass α α (· + ·) (· < ·)] [ContravariantClass α α (· + ·) (· < ·)]
     (hab : a < b) (hcd : c < d) : a * d + b * c < a * c + b * d := by
   obtain ⟨b, rfl⟩ := exists_add_of_le hab.le
@@ -692,7 +692,7 @@ theorem nonpos_of_mul_nonneg_right [MulPosStrictMono α]
 
 @[simp]
 theorem Units.inv_pos
-    [ZeroLEOneClass α] [NeZero (R := α) 1] [MulPosMono α] [PosMulStrictMono α]
+    [ZeroLEOneClass α] [NeZero (R := α) 1] [PosMulStrictMono α]
     {u : αˣ} : (0 : α) < ↑u⁻¹ ↔ (0 : α) < u :=
   have : ∀ {u : αˣ}, (0 : α) < u → (0 : α) < ↑u⁻¹ := @fun u h =>
     (mul_pos_iff_of_pos_left h).mp <| u.mul_inv.symm ▸ zero_lt_one

--- a/Mathlib/Algebra/Order/Ring/Unbundled/Basic.lean
+++ b/Mathlib/Algebra/Order/Ring/Unbundled/Basic.lean
@@ -586,7 +586,7 @@ lemma mul_add_mul_lt_mul_add_mul [ExistsAddOfLE α] [MulPosStrictMono α]
   exact add_lt_add_left (mul_lt_mul_of_pos_right hab <| (lt_add_iff_pos_right _).1 hcd) _
 
 /-- Binary **rearrangement inequality**. -/
-lemma mul_add_mul_lt_mul_add_mul' [ExistsAddOfLE α] [PosMulMono α] [MulPosStrictMono α]
+lemma mul_add_mul_lt_mul_add_mul' [ExistsAddOfLE α] [MulPosStrictMono α]
     [CovariantClass α α (· + ·) (· < ·)] [ContravariantClass α α (· + ·) (· < ·)]
     (hba : b < a) (hdc : d < c) : a * d + b * c < a * c + b * d := by
   rw [add_comm (a * d), add_comm (a * c)]

--- a/Mathlib/Algebra/Order/Ring/Unbundled/Basic.lean
+++ b/Mathlib/Algebra/Order/Ring/Unbundled/Basic.lean
@@ -135,12 +135,15 @@ theorem add_one_le_two_mul [LE α] [Semiring α] [CovariantClass α α (· + ·)
 
 section OrderedSemiring
 
-variable [Semiring α] [PartialOrder α] [MulPosMono α] [PosMulMono α] [ZeroLEOneClass α]
-  [CovariantClass α α (· + ·) (· ≤ ·)] [CovariantClass α α (· * ·) (· ≤ ·)]
-  {a b c d : α}
+-- variable [Semiring α] [PartialOrder α] [MulPosMono α] [PosMulMono α] [ZeroLEOneClass α]
+--   [CovariantClass α α (· + ·) (· ≤ ·)] [CovariantClass α α (· * ·) (· ≤ ·)]
+--   {a b c d : α}
+
+variable [Semiring α] [Preorder α] {a b c d : α}
 
 @[simp]
-theorem pow_nonneg (H : 0 ≤ a) : ∀ n : ℕ, 0 ≤ a ^ n
+theorem pow_nonneg [ZeroLEOneClass α] [PosMulMono α]
+    (H : 0 ≤ a) : ∀ n : ℕ, 0 ≤ a ^ n
   | 0 => by
     rw [pow_zero]
     exact zero_le_one
@@ -148,74 +151,95 @@ theorem pow_nonneg (H : 0 ≤ a) : ∀ n : ℕ, 0 ≤ a ^ n
     rw [pow_succ]
     exact mul_nonneg (pow_nonneg H _) H
 
-lemma pow_le_pow_of_le_one (ha₀ : 0 ≤ a) (ha₁ : a ≤ 1) : ∀ {m n : ℕ}, m ≤ n → a ^ n ≤ a ^ m
+lemma pow_le_pow_of_le_one [ZeroLEOneClass α] [PosMulMono α] [MulPosMono α]
+    (ha₀ : 0 ≤ a) (ha₁ : a ≤ 1) : ∀ {m n : ℕ}, m ≤ n → a ^ n ≤ a ^ m
   | _, _, Nat.le.refl => le_rfl
   | _, _, Nat.le.step h => by
     rw [pow_succ']
     exact (mul_le_of_le_one_left (pow_nonneg ha₀ _) ha₁).trans $ pow_le_pow_of_le_one ha₀ ha₁ h
 
-lemma pow_le_of_le_one (h₀ : 0 ≤ a) (h₁ : a ≤ 1) {n : ℕ} (hn : n ≠ 0) : a ^ n ≤ a :=
+lemma pow_le_of_le_one [ZeroLEOneClass α] [PosMulMono α] [MulPosMono α]
+    (h₀ : 0 ≤ a) (h₁ : a ≤ 1) {n : ℕ} (hn : n ≠ 0) : a ^ n ≤ a :=
   (pow_one a).subst (pow_le_pow_of_le_one h₀ h₁ (Nat.pos_of_ne_zero hn))
 
-lemma sq_le (h₀ : 0 ≤ a) (h₁ : a ≤ 1) : a ^ 2 ≤ a := pow_le_of_le_one h₀ h₁ two_ne_zero
+lemma sq_le [ZeroLEOneClass α] [PosMulMono α] [MulPosMono α]
+    (h₀ : 0 ≤ a) (h₁ : a ≤ 1) : a ^ 2 ≤ a :=
+  pow_le_of_le_one h₀ h₁ two_ne_zero
 
 -- Porting note: it's unfortunate we need to write `(@one_le_two α)` here.
-theorem add_le_mul_two_add (a2 : 2 ≤ a) (b0 : 0 ≤ b) : a + (2 + b) ≤ a * (2 + b) :=
+theorem add_le_mul_two_add [ZeroLEOneClass α] [MulPosMono α] [CovariantClass α α (· + ·) (· ≤ ·)]
+    (a2 : 2 ≤ a) (b0 : 0 ≤ b) : a + (2 + b) ≤ a * (2 + b) :=
   calc
     a + (2 + b) ≤ a + (a + a * b) :=
       add_le_add_left (add_le_add a2 <| le_mul_of_one_le_left b0 <| (@one_le_two α).trans a2) a
     _ ≤ a * (2 + b) := by rw [mul_add, mul_two, add_assoc]
 
-theorem one_le_mul_of_one_le_of_one_le (ha : 1 ≤ a) (hb : 1 ≤ b) : (1 : α) ≤ a * b :=
+theorem one_le_mul_of_one_le_of_one_le [ZeroLEOneClass α] [PosMulMono α]
+    (ha : 1 ≤ a) (hb : 1 ≤ b) : (1 : α) ≤ a * b :=
   Left.one_le_mul_of_le_of_le ha hb <| zero_le_one.trans ha
 
 section Monotone
 
 variable [Preorder β] {f g : β → α}
 
-theorem monotone_mul_left_of_nonneg (ha : 0 ≤ a) : Monotone fun x => a * x := fun _ _ h =>
+theorem monotone_mul_left_of_nonneg [PosMulMono α]
+    (ha : 0 ≤ a) : Monotone fun x => a * x := fun _ _ h =>
   mul_le_mul_of_nonneg_left h ha
 
-theorem monotone_mul_right_of_nonneg (ha : 0 ≤ a) : Monotone fun x => x * a := fun _ _ h =>
+theorem monotone_mul_right_of_nonneg [MulPosMono α]
+    (ha : 0 ≤ a) : Monotone fun x => x * a := fun _ _ h =>
   mul_le_mul_of_nonneg_right h ha
 
-theorem Monotone.mul_const (hf : Monotone f) (ha : 0 ≤ a) : Monotone fun x => f x * a :=
+theorem Monotone.mul_const [MulPosMono α]
+    (hf : Monotone f) (ha : 0 ≤ a) : Monotone fun x => f x * a :=
   (monotone_mul_right_of_nonneg ha).comp hf
 
-theorem Monotone.const_mul (hf : Monotone f) (ha : 0 ≤ a) : Monotone fun x => a * f x :=
+theorem Monotone.const_mul [PosMulMono α]
+    (hf : Monotone f) (ha : 0 ≤ a) : Monotone fun x => a * f x :=
   (monotone_mul_left_of_nonneg ha).comp hf
 
-theorem Antitone.mul_const (hf : Antitone f) (ha : 0 ≤ a) : Antitone fun x => f x * a :=
+theorem Antitone.mul_const [MulPosMono α]
+    (hf : Antitone f) (ha : 0 ≤ a) : Antitone fun x => f x * a :=
   (monotone_mul_right_of_nonneg ha).comp_antitone hf
 
-theorem Antitone.const_mul (hf : Antitone f) (ha : 0 ≤ a) : Antitone fun x => a * f x :=
+theorem Antitone.const_mul [PosMulMono α]
+    (hf : Antitone f) (ha : 0 ≤ a) : Antitone fun x => a * f x :=
   (monotone_mul_left_of_nonneg ha).comp_antitone hf
 
-theorem Monotone.mul (hf : Monotone f) (hg : Monotone g) (hf₀ : ∀ x, 0 ≤ f x) (hg₀ : ∀ x, 0 ≤ g x) :
-    Monotone (f * g) := fun _ _ h => mul_le_mul (hf h) (hg h) (hg₀ _) (hf₀ _)
+theorem Monotone.mul [PosMulMono α] [MulPosMono α]
+    (hf : Monotone f) (hg : Monotone g) (hf₀ : ∀ x, 0 ≤ f x) (hg₀ : ∀ x, 0 ≤ g x) :
+    Monotone (f * g) :=
+  fun _ _ h => mul_le_mul (hf h) (hg h) (hg₀ _) (hf₀ _)
 
 end Monotone
 
-theorem mul_le_one (ha : a ≤ 1) (hb' : 0 ≤ b) (hb : b ≤ 1) : a * b ≤ 1 :=
+theorem mul_le_one [ZeroLEOneClass α] [PosMulMono α] [MulPosMono α]
+    (ha : a ≤ 1) (hb' : 0 ≤ b) (hb : b ≤ 1) : a * b ≤ 1 :=
   one_mul (1 : α) ▸ mul_le_mul ha hb hb' zero_le_one
 
-theorem one_lt_mul_of_le_of_lt (ha : 1 ≤ a) (hb : 1 < b) : 1 < a * b :=
+theorem one_lt_mul_of_le_of_lt [ZeroLEOneClass α] [MulPosMono α]
+    (ha : 1 ≤ a) (hb : 1 < b) : 1 < a * b :=
   hb.trans_le <| le_mul_of_one_le_left (zero_le_one.trans hb.le) ha
 
-theorem one_lt_mul_of_lt_of_le (ha : 1 < a) (hb : 1 ≤ b) : 1 < a * b :=
+theorem one_lt_mul_of_lt_of_le [ZeroLEOneClass α] [PosMulMono α]
+    (ha : 1 < a) (hb : 1 ≤ b) : 1 < a * b :=
   ha.trans_le <| le_mul_of_one_le_right (zero_le_one.trans ha.le) hb
 
 alias one_lt_mul := one_lt_mul_of_le_of_lt
 
-theorem mul_lt_one_of_nonneg_of_lt_one_left (ha₀ : 0 ≤ a) (ha : a < 1) (hb : b ≤ 1) : a * b < 1 :=
+theorem mul_lt_one_of_nonneg_of_lt_one_left [PosMulMono α]
+    (ha₀ : 0 ≤ a) (ha : a < 1) (hb : b ≤ 1) : a * b < 1 :=
   (mul_le_of_le_one_right ha₀ hb).trans_lt ha
 
-theorem mul_lt_one_of_nonneg_of_lt_one_right (ha : a ≤ 1) (hb₀ : 0 ≤ b) (hb : b < 1) : a * b < 1 :=
+theorem mul_lt_one_of_nonneg_of_lt_one_right [MulPosMono α]
+    (ha : a ≤ 1) (hb₀ : 0 ≤ b) (hb : b < 1) : a * b < 1 :=
   (mul_le_of_le_one_left hb₀ ha).trans_lt hb
 
-variable [ExistsAddOfLE α] [ContravariantClass α α (swap (· + ·)) (· ≤ ·)]
+-- variable [ExistsAddOfLE α] [ContravariantClass α α (swap (· + ·)) (· ≤ ·)]
 
-theorem mul_le_mul_of_nonpos_left (h : b ≤ a) (hc : c ≤ 0) : c * a ≤ c * b := by
+theorem mul_le_mul_of_nonpos_left [ExistsAddOfLE α] [PosMulMono α]
+    [CovariantClass α α (swap (· + ·)) (· ≤ ·)] [ContravariantClass α α (swap (· + ·)) (· ≤ ·)]
+    (h : b ≤ a) (hc : c ≤ 0) : c * a ≤ c * b := by
   obtain ⟨d, hcd⟩ := exists_add_of_le hc
   refine le_of_add_le_add_right (a := d * b + d * a) ?_
   calc
@@ -223,7 +247,9 @@ theorem mul_le_mul_of_nonpos_left (h : b ≤ a) (hc : c ≤ 0) : c * a ≤ c * b
     _ ≤ d * a := mul_le_mul_of_nonneg_left h <| hcd.trans_le <| add_le_of_nonpos_left hc
     _ = _ := by rw [← add_assoc, ← add_mul, ← hcd, zero_mul, zero_add]
 
-theorem mul_le_mul_of_nonpos_right (h : b ≤ a) (hc : c ≤ 0) : a * c ≤ b * c := by
+theorem mul_le_mul_of_nonpos_right [ExistsAddOfLE α] [MulPosMono α]
+    [CovariantClass α α (swap (· + ·)) (· ≤ ·)] [ContravariantClass α α (swap (· + ·)) (· ≤ ·)]
+    (h : b ≤ a) (hc : c ≤ 0) : a * c ≤ b * c := by
   obtain ⟨d, hcd⟩ := exists_add_of_le hc
   refine le_of_add_le_add_right (a := b * d + a * d) ?_
   calc
@@ -231,87 +257,121 @@ theorem mul_le_mul_of_nonpos_right (h : b ≤ a) (hc : c ≤ 0) : a * c ≤ b * 
     _ ≤ a * d := mul_le_mul_of_nonneg_right h <| hcd.trans_le <| add_le_of_nonpos_left hc
     _ = _ := by rw [← add_assoc, ← mul_add, ← hcd, mul_zero, zero_add]
 
-theorem mul_nonneg_of_nonpos_of_nonpos (ha : a ≤ 0) (hb : b ≤ 0) : 0 ≤ a * b := by
+theorem mul_nonneg_of_nonpos_of_nonpos [ExistsAddOfLE α] [MulPosMono α]
+    [CovariantClass α α (swap (· + ·)) (· ≤ ·)] [ContravariantClass α α (swap (· + ·)) (· ≤ ·)]
+    (ha : a ≤ 0) (hb : b ≤ 0) : 0 ≤ a * b := by
   simpa only [zero_mul] using mul_le_mul_of_nonpos_right ha hb
 
-theorem mul_le_mul_of_nonneg_of_nonpos (hca : c ≤ a) (hbd : b ≤ d) (hc : 0 ≤ c) (hb : b ≤ 0) :
-    a * b ≤ c * d :=
+theorem mul_le_mul_of_nonneg_of_nonpos [ExistsAddOfLE α] [MulPosMono α] [PosMulMono α]
+    [CovariantClass α α (swap (· + ·)) (· ≤ ·)] [ContravariantClass α α (swap (· + ·)) (· ≤ ·)]
+    (hca : c ≤ a) (hbd : b ≤ d) (hc : 0 ≤ c) (hb : b ≤ 0) : a * b ≤ c * d :=
   (mul_le_mul_of_nonpos_right hca hb).trans <| mul_le_mul_of_nonneg_left hbd hc
 
-theorem mul_le_mul_of_nonneg_of_nonpos' (hca : c ≤ a) (hbd : b ≤ d) (ha : 0 ≤ a) (hd : d ≤ 0) :
-    a * b ≤ c * d :=
+theorem mul_le_mul_of_nonneg_of_nonpos' [ExistsAddOfLE α] [PosMulMono α] [MulPosMono α]
+    [CovariantClass α α (swap (· + ·)) (· ≤ ·)] [ContravariantClass α α (swap (· + ·)) (· ≤ ·)]
+    (hca : c ≤ a) (hbd : b ≤ d) (ha : 0 ≤ a) (hd : d ≤ 0) : a * b ≤ c * d :=
   (mul_le_mul_of_nonneg_left hbd ha).trans <| mul_le_mul_of_nonpos_right hca hd
 
-theorem mul_le_mul_of_nonpos_of_nonneg (hac : a ≤ c) (hdb : d ≤ b) (hc : c ≤ 0) (hb : 0 ≤ b) :
-    a * b ≤ c * d :=
+theorem mul_le_mul_of_nonpos_of_nonneg [ExistsAddOfLE α] [MulPosMono α] [PosMulMono α]
+    [CovariantClass α α (swap (· + ·)) (· ≤ ·)] [ContravariantClass α α (swap (· + ·)) (· ≤ ·)]
+    (hac : a ≤ c) (hdb : d ≤ b) (hc : c ≤ 0) (hb : 0 ≤ b) : a * b ≤ c * d :=
   (mul_le_mul_of_nonneg_right hac hb).trans <| mul_le_mul_of_nonpos_left hdb hc
 
-theorem mul_le_mul_of_nonpos_of_nonneg' (hca : c ≤ a) (hbd : b ≤ d) (ha : 0 ≤ a) (hd : d ≤ 0) :
-    a * b ≤ c * d :=
+theorem mul_le_mul_of_nonpos_of_nonneg' [ExistsAddOfLE α] [PosMulMono α] [MulPosMono α]
+    [CovariantClass α α (swap (· + ·)) (· ≤ ·)] [ContravariantClass α α (swap (· + ·)) (· ≤ ·)]
+    (hca : c ≤ a) (hbd : b ≤ d) (ha : 0 ≤ a) (hd : d ≤ 0) : a * b ≤ c * d :=
   (mul_le_mul_of_nonneg_left hbd ha).trans <| mul_le_mul_of_nonpos_right hca hd
 
-theorem mul_le_mul_of_nonpos_of_nonpos (hca : c ≤ a) (hdb : d ≤ b) (hc : c ≤ 0) (hb : b ≤ 0) :
-    a * b ≤ c * d :=
+theorem mul_le_mul_of_nonpos_of_nonpos [ExistsAddOfLE α] [MulPosMono α] [PosMulMono α]
+    [CovariantClass α α (swap (· + ·)) (· ≤ ·)] [ContravariantClass α α (swap (· + ·)) (· ≤ ·)]
+    (hca : c ≤ a) (hdb : d ≤ b) (hc : c ≤ 0) (hb : b ≤ 0) : a * b ≤ c * d :=
   (mul_le_mul_of_nonpos_right hca hb).trans <| mul_le_mul_of_nonpos_left hdb hc
 
-theorem mul_le_mul_of_nonpos_of_nonpos' (hca : c ≤ a) (hdb : d ≤ b) (ha : a ≤ 0) (hd : d ≤ 0) :
-    a * b ≤ c * d :=
+theorem mul_le_mul_of_nonpos_of_nonpos' [ExistsAddOfLE α] [PosMulMono α] [MulPosMono α]
+    [CovariantClass α α (swap (· + ·)) (· ≤ ·)] [ContravariantClass α α (swap (· + ·)) (· ≤ ·)]
+    (hca : c ≤ a) (hdb : d ≤ b) (ha : a ≤ 0) (hd : d ≤ 0) : a * b ≤ c * d :=
   (mul_le_mul_of_nonpos_left hdb ha).trans <| mul_le_mul_of_nonpos_right hca hd
 
 /-- Variant of `mul_le_of_le_one_left` for `b` non-positive instead of non-negative.  -/
-theorem le_mul_of_le_one_left (hb : b ≤ 0) (h : a ≤ 1) : b ≤ a * b := by
+theorem le_mul_of_le_one_left [ExistsAddOfLE α] [MulPosMono α]
+    [CovariantClass α α (swap (· + ·)) (· ≤ ·)] [ContravariantClass α α (swap (· + ·)) (· ≤ ·)]
+    (hb : b ≤ 0) (h : a ≤ 1) : b ≤ a * b := by
   simpa only [one_mul] using mul_le_mul_of_nonpos_right h hb
 
 /-- Variant of `le_mul_of_one_le_left` for `b` non-positive instead of non-negative. -/
-theorem mul_le_of_one_le_left (hb : b ≤ 0) (h : 1 ≤ a) : a * b ≤ b := by
+theorem mul_le_of_one_le_left [ExistsAddOfLE α] [MulPosMono α]
+    [CovariantClass α α (swap (· + ·)) (· ≤ ·)] [ContravariantClass α α (swap (· + ·)) (· ≤ ·)]
+    (hb : b ≤ 0) (h : 1 ≤ a) : a * b ≤ b := by
   simpa only [one_mul] using mul_le_mul_of_nonpos_right h hb
 
 /-- Variant of `mul_le_of_le_one_right` for `a` non-positive instead of non-negative. -/
-theorem le_mul_of_le_one_right (ha : a ≤ 0) (h : b ≤ 1) : a ≤ a * b := by
+theorem le_mul_of_le_one_right [ExistsAddOfLE α] [PosMulMono α]
+    [CovariantClass α α (swap (· + ·)) (· ≤ ·)] [ContravariantClass α α (swap (· + ·)) (· ≤ ·)]
+    (ha : a ≤ 0) (h : b ≤ 1) : a ≤ a * b := by
   simpa only [mul_one] using mul_le_mul_of_nonpos_left h ha
 
 /-- Variant of `le_mul_of_one_le_right` for `a` non-positive instead of non-negative. -/
-theorem mul_le_of_one_le_right (ha : a ≤ 0) (h : 1 ≤ b) : a * b ≤ a := by
+theorem mul_le_of_one_le_right [ExistsAddOfLE α] [PosMulMono α]
+    [CovariantClass α α (swap (· + ·)) (· ≤ ·)] [ContravariantClass α α (swap (· + ·)) (· ≤ ·)]
+    (ha : a ≤ 0) (h : 1 ≤ b) : a * b ≤ a := by
   simpa only [mul_one] using mul_le_mul_of_nonpos_left h ha
 
 section Monotone
 
 variable [Preorder β] {f g : β → α}
 
-theorem antitone_mul_left {a : α} (ha : a ≤ 0) : Antitone (a * ·) := fun _ _ b_le_c =>
+theorem antitone_mul_left [ExistsAddOfLE α] [PosMulMono α]
+    [CovariantClass α α (swap (· + ·)) (· ≤ ·)] [ContravariantClass α α (swap (· + ·)) (· ≤ ·)]
+    {a : α} (ha : a ≤ 0) : Antitone (a * ·) := fun _ _ b_le_c =>
   mul_le_mul_of_nonpos_left b_le_c ha
 
-theorem antitone_mul_right {a : α} (ha : a ≤ 0) : Antitone fun x => x * a := fun _ _ b_le_c =>
+theorem antitone_mul_right [ExistsAddOfLE α] [MulPosMono α]
+    [CovariantClass α α (swap (· + ·)) (· ≤ ·)] [ContravariantClass α α (swap (· + ·)) (· ≤ ·)]
+    {a : α} (ha : a ≤ 0) : Antitone fun x => x * a := fun _ _ b_le_c =>
   mul_le_mul_of_nonpos_right b_le_c ha
 
-theorem Monotone.const_mul_of_nonpos (hf : Monotone f) (ha : a ≤ 0) : Antitone fun x => a * f x :=
+theorem Monotone.const_mul_of_nonpos [ExistsAddOfLE α] [PosMulMono α]
+    [CovariantClass α α (swap (· + ·)) (· ≤ ·)] [ContravariantClass α α (swap (· + ·)) (· ≤ ·)]
+    (hf : Monotone f) (ha : a ≤ 0) : Antitone fun x => a * f x :=
   (antitone_mul_left ha).comp_monotone hf
 
-theorem Monotone.mul_const_of_nonpos (hf : Monotone f) (ha : a ≤ 0) : Antitone fun x => f x * a :=
+theorem Monotone.mul_const_of_nonpos [ExistsAddOfLE α] [MulPosMono α]
+    [CovariantClass α α (swap (· + ·)) (· ≤ ·)] [ContravariantClass α α (swap (· + ·)) (· ≤ ·)]
+    (hf : Monotone f) (ha : a ≤ 0) : Antitone fun x => f x * a :=
   (antitone_mul_right ha).comp_monotone hf
 
-theorem Antitone.const_mul_of_nonpos (hf : Antitone f) (ha : a ≤ 0) : Monotone fun x => a * f x :=
+theorem Antitone.const_mul_of_nonpos [ExistsAddOfLE α] [PosMulMono α]
+    [CovariantClass α α (swap (· + ·)) (· ≤ ·)] [ContravariantClass α α (swap (· + ·)) (· ≤ ·)]
+    (hf : Antitone f) (ha : a ≤ 0) : Monotone fun x => a * f x :=
   (antitone_mul_left ha).comp hf
 
-theorem Antitone.mul_const_of_nonpos (hf : Antitone f) (ha : a ≤ 0) : Monotone fun x => f x * a :=
+theorem Antitone.mul_const_of_nonpos [ExistsAddOfLE α] [MulPosMono α]
+    [CovariantClass α α (swap (· + ·)) (· ≤ ·)] [ContravariantClass α α (swap (· + ·)) (· ≤ ·)]
+    (hf : Antitone f) (ha : a ≤ 0) : Monotone fun x => f x * a :=
   (antitone_mul_right ha).comp hf
 
-theorem Antitone.mul_monotone (hf : Antitone f) (hg : Monotone g) (hf₀ : ∀ x, f x ≤ 0)
+theorem Antitone.mul_monotone [ExistsAddOfLE α] [PosMulMono α] [MulPosMono α]
+    [CovariantClass α α (swap (· + ·)) (· ≤ ·)] [ContravariantClass α α (swap (· + ·)) (· ≤ ·)]
+    (hf : Antitone f) (hg : Monotone g) (hf₀ : ∀ x, f x ≤ 0)
     (hg₀ : ∀ x, 0 ≤ g x) : Antitone (f * g) := fun _ _ h =>
   mul_le_mul_of_nonpos_of_nonneg (hf h) (hg h) (hf₀ _) (hg₀ _)
 
-theorem Monotone.mul_antitone (hf : Monotone f) (hg : Antitone g) (hf₀ : ∀ x, 0 ≤ f x)
+theorem Monotone.mul_antitone [ExistsAddOfLE α] [PosMulMono α] [MulPosMono α]
+    [CovariantClass α α (swap (· + ·)) (· ≤ ·)] [ContravariantClass α α (swap (· + ·)) (· ≤ ·)]
+    (hf : Monotone f) (hg : Antitone g) (hf₀ : ∀ x, 0 ≤ f x)
     (hg₀ : ∀ x, g x ≤ 0) : Antitone (f * g) := fun _ _ h =>
   mul_le_mul_of_nonneg_of_nonpos (hf h) (hg h) (hf₀ _) (hg₀ _)
 
-theorem Antitone.mul (hf : Antitone f) (hg : Antitone g) (hf₀ : ∀ x, f x ≤ 0) (hg₀ : ∀ x, g x ≤ 0) :
+theorem Antitone.mul [ExistsAddOfLE α] [PosMulMono α] [MulPosMono α]
+    [CovariantClass α α (swap (· + ·)) (· ≤ ·)] [ContravariantClass α α (swap (· + ·)) (· ≤ ·)]
+    (hf : Antitone f) (hg : Antitone g) (hf₀ : ∀ x, f x ≤ 0) (hg₀ : ∀ x, g x ≤ 0) :
     Monotone (f * g) := fun _ _ h => mul_le_mul_of_nonpos_of_nonpos (hf h) (hg h) (hf₀ _) (hg₀ _)
 
 end Monotone
 
-variable [ContravariantClass α α (· + ·) (· ≤ ·)]
-
-lemma le_iff_exists_nonneg_add (a b : α) : a ≤ b ↔ ∃ c ≥ 0, b = a + c := by
+lemma le_iff_exists_nonneg_add
+    [ExistsAddOfLE α] [ContravariantClass α α (· + ·) (· ≤ ·)] [CovariantClass α α (· + ·) (· ≤ ·)]
+    (a b : α) : a ≤ b ↔ ∃ c ≥ 0, b = a + c := by
   refine ⟨fun h ↦ ?_, ?_⟩
   · obtain ⟨c, rfl⟩ := exists_add_of_le h
     exact ⟨c, nonneg_of_le_add_right h, rfl⟩
@@ -324,11 +384,11 @@ section OrderedCommRing
 
 section StrictOrderedSemiring
 
-variable [Semiring α] [PartialOrder α] [ZeroLEOneClass α] [PosMulStrictMono α] [MulPosStrictMono α]
-  [CovariantClass α α (· + ·) (· < ·)] {a b c d : α}
+variable [Semiring α] [PartialOrder α] {a b c d : α}
 
 @[simp]
-theorem pow_pos (H : 0 < a) : ∀ n : ℕ, 0 < a ^ n
+theorem pow_pos [ZeroLEOneClass α] [NeZero 1] [PosMulStrictMono α]
+    (H : 0 < a) : ∀ n : ℕ, 0 < a ^ n
   | 0 => by
     nontriviality
     rw [pow_zero]
@@ -337,75 +397,91 @@ theorem pow_pos (H : 0 < a) : ∀ n : ℕ, 0 < a ^ n
     rw [pow_succ]
     exact mul_pos (pow_pos H _) H
 
-theorem mul_self_lt_mul_self (h1 : 0 ≤ a) (h2 : a < b) : a * a < b * b :=
+theorem mul_self_lt_mul_self [PosMulStrictMono α] [MulPosMono α]
+    (h1 : 0 ≤ a) (h2 : a < b) : a * a < b * b :=
   mul_lt_mul' h2.le h2 h1 <| h1.trans_lt h2
 
 -- In the next lemma, we used to write `Set.Ici 0` instead of `{x | 0 ≤ x}`.
 -- As this lemma is not used outside this file,
 -- and the import for `Set.Ici` is not otherwise needed until later,
 -- we choose not to use it here.
-theorem strictMonoOn_mul_self : StrictMonoOn (fun x : α => x * x) { x | 0 ≤ x } :=
+theorem strictMonoOn_mul_self [PosMulStrictMono α] [MulPosMono α] :
+    StrictMonoOn (fun x : α => x * x) { x | 0 ≤ x } :=
   fun _ hx _ _ hxy => mul_self_lt_mul_self hx hxy
 
 -- See Note [decidable namespace]
-protected theorem Decidable.mul_lt_mul'' [@DecidableRel α (· ≤ ·)] (h1 : a < c) (h2 : b < d)
+protected theorem Decidable.mul_lt_mul'' [PosMulMono α] [PosMulStrictMono α] [MulPosStrictMono α]
+    [@DecidableRel α (· ≤ ·)] (h1 : a < c) (h2 : b < d)
     (h3 : 0 ≤ a) (h4 : 0 ≤ b) : a * b < c * d :=
   h4.lt_or_eq_dec.elim (fun b0 => mul_lt_mul h1 h2.le b0 <| h3.trans h1.le) fun b0 => by
     rw [← b0, mul_zero]; exact mul_pos (h3.trans_lt h1) (h4.trans_lt h2)
 
-theorem lt_mul_left (hn : 0 < a) (hm : 1 < b) : a < b * a := by
+theorem lt_mul_left [MulPosStrictMono α]
+    (hn : 0 < a) (hm : 1 < b) : a < b * a := by
   convert mul_lt_mul_of_pos_right hm hn
   rw [one_mul]
 
-theorem lt_mul_right (hn : 0 < a) (hm : 1 < b) : a < a * b := by
+theorem lt_mul_right [PosMulStrictMono α]
+    (hn : 0 < a) (hm : 1 < b) : a < a * b := by
   convert mul_lt_mul_of_pos_left hm hn
   rw [mul_one]
 
-theorem lt_mul_self (hn : 1 < a) : a < a * a :=
+theorem lt_mul_self [ZeroLEOneClass α] [MulPosStrictMono α]
+    (hn : 1 < a) : a < a * a :=
   lt_mul_left (hn.trans_le' zero_le_one) hn
 
 section Monotone
 
 variable [Preorder β] {f g : β → α}
 
-theorem strictMono_mul_left_of_pos (ha : 0 < a) : StrictMono fun x => a * x := fun _ _ b_lt_c =>
+theorem strictMono_mul_left_of_pos [PosMulStrictMono α]
+    (ha : 0 < a) : StrictMono fun x => a * x := fun _ _ b_lt_c =>
   mul_lt_mul_of_pos_left b_lt_c ha
 
-theorem strictMono_mul_right_of_pos (ha : 0 < a) : StrictMono fun x => x * a := fun _ _ b_lt_c =>
+theorem strictMono_mul_right_of_pos [MulPosStrictMono α]
+    (ha : 0 < a) : StrictMono fun x => x * a := fun _ _ b_lt_c =>
   mul_lt_mul_of_pos_right b_lt_c ha
 
-theorem StrictMono.mul_const (hf : StrictMono f) (ha : 0 < a) : StrictMono fun x => f x * a :=
+theorem StrictMono.mul_const [MulPosStrictMono α]
+    (hf : StrictMono f) (ha : 0 < a) : StrictMono fun x => f x * a :=
   (strictMono_mul_right_of_pos ha).comp hf
 
-theorem StrictMono.const_mul (hf : StrictMono f) (ha : 0 < a) : StrictMono fun x => a * f x :=
+theorem StrictMono.const_mul [PosMulStrictMono α]
+    (hf : StrictMono f) (ha : 0 < a) : StrictMono fun x => a * f x :=
   (strictMono_mul_left_of_pos ha).comp hf
 
-theorem StrictAnti.mul_const (hf : StrictAnti f) (ha : 0 < a) : StrictAnti fun x => f x * a :=
+theorem StrictAnti.mul_const [MulPosStrictMono α]
+    (hf : StrictAnti f) (ha : 0 < a) : StrictAnti fun x => f x * a :=
   (strictMono_mul_right_of_pos ha).comp_strictAnti hf
 
-theorem StrictAnti.const_mul (hf : StrictAnti f) (ha : 0 < a) : StrictAnti fun x => a * f x :=
+theorem StrictAnti.const_mul [PosMulStrictMono α]
+    (hf : StrictAnti f) (ha : 0 < a) : StrictAnti fun x => a * f x :=
   (strictMono_mul_left_of_pos ha).comp_strictAnti hf
 
-theorem StrictMono.mul_monotone (hf : StrictMono f) (hg : Monotone g) (hf₀ : ∀ x, 0 ≤ f x)
+theorem StrictMono.mul_monotone [PosMulMono α] [MulPosStrictMono α]
+    (hf : StrictMono f) (hg : Monotone g) (hf₀ : ∀ x, 0 ≤ f x)
     (hg₀ : ∀ x, 0 < g x) : StrictMono (f * g) := fun _ _ h =>
   mul_lt_mul (hf h) (hg h.le) (hg₀ _) (hf₀ _)
 
-theorem Monotone.mul_strictMono (hf : Monotone f) (hg : StrictMono g) (hf₀ : ∀ x, 0 < f x)
+theorem Monotone.mul_strictMono [PosMulStrictMono α] [MulPosMono α]
+    (hf : Monotone f) (hg : StrictMono g) (hf₀ : ∀ x, 0 < f x)
     (hg₀ : ∀ x, 0 ≤ g x) : StrictMono (f * g) := fun _ _ h =>
   mul_lt_mul' (hf h.le) (hg h) (hg₀ _) (hf₀ _)
 
-theorem StrictMono.mul (hf : StrictMono f) (hg : StrictMono g) (hf₀ : ∀ x, 0 ≤ f x)
+theorem StrictMono.mul [PosMulStrictMono α] [MulPosStrictMono α]
+    (hf : StrictMono f) (hg : StrictMono g) (hf₀ : ∀ x, 0 ≤ f x)
     (hg₀ : ∀ x, 0 ≤ g x) : StrictMono (f * g) := fun _ _ h =>
   mul_lt_mul'' (hf h) (hg h) (hf₀ _) (hg₀ _)
 
 end Monotone
 
-theorem lt_two_mul_self [NeZero (R := α) 1] (ha : 0 < a) : a < 2 * a :=
+theorem lt_two_mul_self [ZeroLEOneClass α] [MulPosStrictMono α] [NeZero (R := α) 1]
+    [CovariantClass α α (· + ·) (· < ·)] (ha : 0 < a) : a < 2 * a :=
   lt_mul_of_one_lt_left ha one_lt_two
 
-variable [ExistsAddOfLE α] [ContravariantClass α α (swap (· + ·)) (· < ·)]
-
-theorem mul_lt_mul_of_neg_left (h : b < a) (hc : c < 0) : c * a < c * b := by
+theorem mul_lt_mul_of_neg_left [ExistsAddOfLE α] [PosMulStrictMono α]
+    [CovariantClass α α (swap (· + ·)) (· < ·)] [ContravariantClass α α (swap (· + ·)) (· < ·)]
+    (h : b < a) (hc : c < 0) : c * a < c * b := by
   obtain ⟨d, hcd⟩ := exists_add_of_le hc.le
   refine (add_lt_add_iff_right (d * b + d * a)).1 ?_
   calc
@@ -413,7 +489,9 @@ theorem mul_lt_mul_of_neg_left (h : b < a) (hc : c < 0) : c * a < c * b := by
     _ < d * a := mul_lt_mul_of_pos_left h <| hcd.trans_lt <| add_lt_of_neg_left _ hc
     _ = _ := by rw [← add_assoc, ← add_mul, ← hcd, zero_mul, zero_add]
 
-theorem mul_lt_mul_of_neg_right (h : b < a) (hc : c < 0) : a * c < b * c := by
+theorem mul_lt_mul_of_neg_right [ExistsAddOfLE α] [MulPosStrictMono α]
+    [CovariantClass α α (swap (· + ·)) (· < ·)] [ContravariantClass α α (swap (· + ·)) (· < ·)]
+    (h : b < a) (hc : c < 0) : a * c < b * c := by
   obtain ⟨d, hcd⟩ := exists_add_of_le hc.le
   refine (add_lt_add_iff_right (b * d + a * d)).1 ?_
   calc
@@ -421,77 +499,101 @@ theorem mul_lt_mul_of_neg_right (h : b < a) (hc : c < 0) : a * c < b * c := by
     _ < a * d := mul_lt_mul_of_pos_right h <| hcd.trans_lt <| add_lt_of_neg_left _ hc
     _ = _ := by rw [← add_assoc, ← mul_add, ← hcd, mul_zero, zero_add]
 
-theorem mul_pos_of_neg_of_neg {a b : α} (ha : a < 0) (hb : b < 0) : 0 < a * b := by
+theorem mul_pos_of_neg_of_neg [ExistsAddOfLE α] [MulPosStrictMono α]
+    [CovariantClass α α (swap (· + ·)) (· < ·)] [ContravariantClass α α (swap (· + ·)) (· < ·)]
+    {a b : α} (ha : a < 0) (hb : b < 0) : 0 < a * b := by
   simpa only [zero_mul] using mul_lt_mul_of_neg_right ha hb
 
 /-- Variant of `mul_lt_of_lt_one_left` for `b` negative instead of positive. -/
-theorem lt_mul_of_lt_one_left (hb : b < 0) (h : a < 1) : b < a * b := by
+theorem lt_mul_of_lt_one_left [ExistsAddOfLE α] [MulPosStrictMono α]
+    [CovariantClass α α (swap (· + ·)) (· < ·)] [ContravariantClass α α (swap (· + ·)) (· < ·)]
+    (hb : b < 0) (h : a < 1) : b < a * b := by
   simpa only [one_mul] using mul_lt_mul_of_neg_right h hb
 
 /-- Variant of `lt_mul_of_one_lt_left` for `b` negative instead of positive. -/
-theorem mul_lt_of_one_lt_left (hb : b < 0) (h : 1 < a) : a * b < b := by
+theorem mul_lt_of_one_lt_left [ExistsAddOfLE α] [MulPosStrictMono α]
+    [CovariantClass α α (swap (· + ·)) (· < ·)] [ContravariantClass α α (swap (· + ·)) (· < ·)]
+    (hb : b < 0) (h : 1 < a) : a * b < b := by
   simpa only [one_mul] using mul_lt_mul_of_neg_right h hb
 
 /-- Variant of `mul_lt_of_lt_one_right` for `a` negative instead of positive. -/
-theorem lt_mul_of_lt_one_right (ha : a < 0) (h : b < 1) : a < a * b := by
+theorem lt_mul_of_lt_one_right [ExistsAddOfLE α] [PosMulStrictMono α]
+    [CovariantClass α α (swap (· + ·)) (· < ·)] [ContravariantClass α α (swap (· + ·)) (· < ·)]
+    (ha : a < 0) (h : b < 1) : a < a * b := by
   simpa only [mul_one] using mul_lt_mul_of_neg_left h ha
 
 /-- Variant of `lt_mul_of_lt_one_right` for `a` negative instead of positive. -/
-theorem mul_lt_of_one_lt_right (ha : a < 0) (h : 1 < b) : a * b < a := by
+theorem mul_lt_of_one_lt_right [ExistsAddOfLE α] [PosMulStrictMono α]
+    [CovariantClass α α (swap (· + ·)) (· < ·)] [ContravariantClass α α (swap (· + ·)) (· < ·)]
+    (ha : a < 0) (h : 1 < b) : a * b < a := by
   simpa only [mul_one] using mul_lt_mul_of_neg_left h ha
 
 section Monotone
 
 variable [Preorder β] {f g : β → α}
 
-theorem strictAnti_mul_left {a : α} (ha : a < 0) : StrictAnti (a * ·) := fun _ _ b_lt_c =>
+theorem strictAnti_mul_left [ExistsAddOfLE α] [PosMulStrictMono α]
+    [CovariantClass α α (swap (· + ·)) (· < ·)] [ContravariantClass α α (swap (· + ·)) (· < ·)]
+    {a : α} (ha : a < 0) : StrictAnti (a * ·) := fun _ _ b_lt_c =>
   mul_lt_mul_of_neg_left b_lt_c ha
 
-theorem strictAnti_mul_right {a : α} (ha : a < 0) : StrictAnti fun x => x * a := fun _ _ b_lt_c =>
+theorem strictAnti_mul_right [ExistsAddOfLE α] [MulPosStrictMono α]
+    [CovariantClass α α (swap (· + ·)) (· < ·)] [ContravariantClass α α (swap (· + ·)) (· < ·)]
+    {a : α} (ha : a < 0) : StrictAnti fun x => x * a := fun _ _ b_lt_c =>
   mul_lt_mul_of_neg_right b_lt_c ha
 
-theorem StrictMono.const_mul_of_neg (hf : StrictMono f) (ha : a < 0) :
-    StrictAnti fun x => a * f x :=
+theorem StrictMono.const_mul_of_neg [ExistsAddOfLE α] [PosMulStrictMono α]
+    [CovariantClass α α (swap (· + ·)) (· < ·)] [ContravariantClass α α (swap (· + ·)) (· < ·)]
+    (hf : StrictMono f) (ha : a < 0) : StrictAnti fun x => a * f x :=
   (strictAnti_mul_left ha).comp_strictMono hf
 
-theorem StrictMono.mul_const_of_neg (hf : StrictMono f) (ha : a < 0) :
-    StrictAnti fun x => f x * a :=
+theorem StrictMono.mul_const_of_neg [ExistsAddOfLE α] [MulPosStrictMono α]
+    [CovariantClass α α (swap (· + ·)) (· < ·)] [ContravariantClass α α (swap (· + ·)) (· < ·)]
+    (hf : StrictMono f) (ha : a < 0) : StrictAnti fun x => f x * a :=
   (strictAnti_mul_right ha).comp_strictMono hf
 
-theorem StrictAnti.const_mul_of_neg (hf : StrictAnti f) (ha : a < 0) :
-    StrictMono fun x => a * f x :=
+theorem StrictAnti.const_mul_of_neg [ExistsAddOfLE α] [PosMulStrictMono α]
+    [CovariantClass α α (swap (· + ·)) (· < ·)] [ContravariantClass α α (swap (· + ·)) (· < ·)]
+    (hf : StrictAnti f) (ha : a < 0) : StrictMono fun x => a * f x :=
   (strictAnti_mul_left ha).comp hf
 
-theorem StrictAnti.mul_const_of_neg (hf : StrictAnti f) (ha : a < 0) :
-    StrictMono fun x => f x * a :=
+theorem StrictAnti.mul_const_of_neg [ExistsAddOfLE α] [MulPosStrictMono α]
+    [CovariantClass α α (swap (· + ·)) (· < ·)] [ContravariantClass α α (swap (· + ·)) (· < ·)]
+    (hf : StrictAnti f) (ha : a < 0) : StrictMono fun x => f x * a :=
   (strictAnti_mul_right ha).comp hf
 
 end Monotone
 
-variable [CovariantClass α α (· + ·) (· ≤ ·)] [ContravariantClass α α (· + ·) (· ≤ ·)]
-
 /-- Binary **rearrangement inequality**. -/
-lemma mul_add_mul_le_mul_add_mul (hab : a ≤ b) (hcd : c ≤ d) : a * d + b * c ≤ a * c + b * d := by
+lemma mul_add_mul_le_mul_add_mul [ExistsAddOfLE α] [MulPosMono α]
+    [CovariantClass α α (· + ·) (· ≤ ·)] [ContravariantClass α α (· + ·) (· ≤ ·)]
+    (hab : a ≤ b) (hcd : c ≤ d) : a * d + b * c ≤ a * c + b * d := by
   obtain ⟨b, rfl⟩ := exists_add_of_le hab
   obtain ⟨d, rfl⟩ := exists_add_of_le hcd
   rw [mul_add, add_right_comm, mul_add, ← add_assoc]
   exact add_le_add_left (mul_le_mul_of_nonneg_right hab <| (le_add_iff_nonneg_right _).1 hcd) _
 
 /-- Binary **rearrangement inequality**. -/
-lemma mul_add_mul_le_mul_add_mul' (hba : b ≤ a) (hdc : d ≤ c) : a * d + b * c ≤ a * c + b * d := by
+lemma mul_add_mul_le_mul_add_mul' [ExistsAddOfLE α] [MulPosMono α]
+    [CovariantClass α α (· + ·) (· ≤ ·)] [ContravariantClass α α (· + ·) (· ≤ ·)]
+    (hba : b ≤ a) (hdc : d ≤ c) : a * d + b * c ≤ a * c + b * d := by
   rw [add_comm (a * d), add_comm (a * c)]; exact mul_add_mul_le_mul_add_mul hba hdc
 
 variable [ContravariantClass α α (· + ·) (· < ·)]
 
 /-- Binary strict **rearrangement inequality**. -/
-lemma mul_add_mul_lt_mul_add_mul (hab : a < b) (hcd : c < d) : a * d + b * c < a * c + b * d := by
+lemma mul_add_mul_lt_mul_add_mul [ExistsAddOfLE α] [PosMulMono α] [MulPosStrictMono α]
+    [CovariantClass α α (· + ·) (· < ·)] [ContravariantClass α α (· + ·) (· < ·)]
+    (hab : a < b) (hcd : c < d) : a * d + b * c < a * c + b * d := by
   obtain ⟨b, rfl⟩ := exists_add_of_le hab.le
   obtain ⟨d, rfl⟩ := exists_add_of_le hcd.le
   rw [mul_add, add_right_comm, mul_add, ← add_assoc]
   exact add_lt_add_left (mul_lt_mul_of_pos_right hab <| (lt_add_iff_pos_right _).1 hcd) _
 
 /-- Binary **rearrangement inequality**. -/
-lemma mul_add_mul_lt_mul_add_mul' (hba : b < a) (hdc : d < c) : a * d + b * c < a * c + b * d := by
+lemma mul_add_mul_lt_mul_add_mul' [ExistsAddOfLE α] [PosMulMono α] [MulPosStrictMono α]
+    [CovariantClass α α (· + ·) (· < ·)] [ContravariantClass α α (· + ·) (· < ·)]
+    (hba : b < a) (hdc : d < c) : a * d + b * c < a * c + b * d := by
   rw [add_comm (a * d), add_comm (a * c)]
   exact mul_add_mul_lt_mul_add_mul hba hdc
 
@@ -499,10 +601,11 @@ end StrictOrderedSemiring
 
 section LinearOrderedSemiring
 
-variable [Semiring α] [LinearOrder α] [PosMulStrictMono α] [MulPosStrictMono α] {a b c d : α}
+variable [Semiring α] [LinearOrder α] {a b c d : α}
 
-theorem nonneg_and_nonneg_or_nonpos_and_nonpos_of_mul_nonneg (hab : 0 ≤ a * b) :
-    0 ≤ a ∧ 0 ≤ b ∨ a ≤ 0 ∧ b ≤ 0 := by
+theorem nonneg_and_nonneg_or_nonpos_and_nonpos_of_mul_nonneg
+    [MulPosStrictMono α] [PosMulStrictMono α]
+    (hab : 0 ≤ a * b) : 0 ≤ a ∧ 0 ≤ b ∨ a ≤ 0 ∧ b ≤ 0 := by
   refine Decidable.or_iff_not_and_not.2 ?_
   simp only [not_and, not_le]; intro ab nab; apply not_lt_of_le hab _
   rcases lt_trichotomy 0 a with (ha | rfl | ha)
@@ -510,34 +613,39 @@ theorem nonneg_and_nonneg_or_nonpos_and_nonpos_of_mul_nonneg (hab : 0 ≤ a * b)
   · exact ((ab le_rfl).asymm (nab le_rfl)).elim
   · exact mul_neg_of_neg_of_pos ha (nab ha.le)
 
-theorem nonneg_of_mul_nonneg_left (h : 0 ≤ a * b) (hb : 0 < b) : 0 ≤ a :=
+theorem nonneg_of_mul_nonneg_left [MulPosStrictMono α]
+    (h : 0 ≤ a * b) (hb : 0 < b) : 0 ≤ a :=
   le_of_not_gt fun ha => (mul_neg_of_neg_of_pos ha hb).not_le h
 
-theorem nonneg_of_mul_nonneg_right (h : 0 ≤ a * b) (ha : 0 < a) : 0 ≤ b :=
+theorem nonneg_of_mul_nonneg_right [PosMulStrictMono α]
+    (h : 0 ≤ a * b) (ha : 0 < a) : 0 ≤ b :=
   le_of_not_gt fun hb => (mul_neg_of_pos_of_neg ha hb).not_le h
 
-theorem nonpos_of_mul_nonpos_left (h : a * b ≤ 0) (hb : 0 < b) : a ≤ 0 :=
+theorem nonpos_of_mul_nonpos_left [PosMulStrictMono α]
+    (h : a * b ≤ 0) (hb : 0 < b) : a ≤ 0 :=
   le_of_not_gt fun ha : a > 0 => (mul_pos ha hb).not_le h
 
-theorem nonpos_of_mul_nonpos_right (h : a * b ≤ 0) (ha : 0 < a) : b ≤ 0 :=
+theorem nonpos_of_mul_nonpos_right [PosMulStrictMono α]
+    (h : a * b ≤ 0) (ha : 0 < a) : b ≤ 0 :=
   le_of_not_gt fun hb : b > 0 => (mul_pos ha hb).not_le h
 
 @[simp]
-theorem mul_nonneg_iff_of_pos_left (h : 0 < c) : 0 ≤ c * b ↔ 0 ≤ b := by
+theorem mul_nonneg_iff_of_pos_left [PosMulStrictMono α]
+    (h : 0 < c) : 0 ≤ c * b ↔ 0 ≤ b := by
   convert mul_le_mul_left h
   simp
 
 @[simp]
-theorem mul_nonneg_iff_of_pos_right (h : 0 < c) : 0 ≤ b * c ↔ 0 ≤ b := by
+theorem mul_nonneg_iff_of_pos_right [MulPosStrictMono α]
+    (h : 0 < c) : 0 ≤ b * c ↔ 0 ≤ b := by
   simpa using (mul_le_mul_right h : 0 * c ≤ b * c ↔ 0 ≤ b)
 
-variable [ZeroLEOneClass α] [CovariantClass α α (· + ·) (· ≤ ·)] [NeZero (R := α) 1]
-
--- Porting note: we used to not need the type annotation on `(0 : α)` at the start of the `calc`.
-theorem add_le_mul_of_left_le_right (a2 : 2 ≤ a) (ab : a ≤ b) : a + b ≤ a * b :=
+theorem add_le_mul_of_left_le_right [ZeroLEOneClass α] [NeZero (R := α) 1]
+    [MulPosStrictMono α] [CovariantClass α α (· + ·) (· ≤ ·)]
+    (a2 : 2 ≤ a) (ab : a ≤ b) : a + b ≤ a * b :=
   have : 0 < b :=
-    calc (0 : α)
-      _ < 2 := zero_lt_two
+    calc
+      0 < 2 := zero_lt_two
       _ ≤ a := a2
       _ ≤ b := ab
   calc
@@ -546,7 +654,9 @@ theorem add_le_mul_of_left_le_right (a2 : 2 ≤ a) (ab : a ≤ b) : a + b ≤ a 
     _ ≤ a * b := (mul_le_mul_right this).mpr a2
 
 -- Porting note: we used to not need the type annotation on `(0 : α)` at the start of the `calc`.
-theorem add_le_mul_of_right_le_left (b2 : 2 ≤ b) (ba : b ≤ a) : a + b ≤ a * b :=
+theorem add_le_mul_of_right_le_left [ZeroLEOneClass α] [NeZero (R := α) 1]
+    [CovariantClass α α (· + ·) (· ≤ ·)] [PosMulStrictMono α]
+    (b2 : 2 ≤ b) (ba : b ≤ a) : a + b ≤ a * b :=
   have : 0 < a :=
     calc (0 : α)
       _ < 2 := zero_lt_two
@@ -557,88 +667,116 @@ theorem add_le_mul_of_right_le_left (b2 : 2 ≤ b) (ba : b ≤ a) : a + b ≤ a 
     _ = a * 2 := (mul_two a).symm
     _ ≤ a * b := (mul_le_mul_left this).mpr b2
 
-theorem add_le_mul (a2 : 2 ≤ a) (b2 : 2 ≤ b) : a + b ≤ a * b :=
+theorem add_le_mul [ZeroLEOneClass α] [NeZero (R := α) 1]
+    [MulPosStrictMono α] [PosMulStrictMono α] [CovariantClass α α (· + ·) (· ≤ ·)]
+    (a2 : 2 ≤ a) (b2 : 2 ≤ b) : a + b ≤ a * b :=
   if hab : a ≤ b then add_le_mul_of_left_le_right a2 hab
   else add_le_mul_of_right_le_left b2 (le_of_not_le hab)
 
-theorem add_le_mul' (a2 : 2 ≤ a) (b2 : 2 ≤ b) : a + b ≤ b * a :=
+theorem add_le_mul' [ZeroLEOneClass α] [NeZero (R := α) 1]
+    [MulPosStrictMono α] [PosMulStrictMono α] [CovariantClass α α (· + ·) (· ≤ ·)]
+    (a2 : 2 ≤ a) (b2 : 2 ≤ b) : a + b ≤ b * a :=
   (le_of_eq (add_comm _ _)).trans (add_le_mul b2 a2)
 
-theorem mul_nonneg_iff_right_nonneg_of_pos (ha : 0 < a) : 0 ≤ a * b ↔ 0 ≤ b :=
+theorem mul_nonneg_iff_right_nonneg_of_pos [PosMulStrictMono α]
+    (ha : 0 < a) : 0 ≤ a * b ↔ 0 ≤ b :=
   ⟨fun h => nonneg_of_mul_nonneg_right h ha, mul_nonneg ha.le⟩
 
-theorem mul_nonneg_iff_left_nonneg_of_pos (hb : 0 < b) : 0 ≤ a * b ↔ 0 ≤ a :=
+theorem mul_nonneg_iff_left_nonneg_of_pos [PosMulStrictMono α] [MulPosStrictMono α]
+    (hb : 0 < b) : 0 ≤ a * b ↔ 0 ≤ a :=
   ⟨fun h => nonneg_of_mul_nonneg_left h hb, fun h => mul_nonneg h hb.le⟩
 
-theorem nonpos_of_mul_nonneg_left (h : 0 ≤ a * b) (hb : b < 0) : a ≤ 0 :=
+theorem nonpos_of_mul_nonneg_left [PosMulStrictMono α]
+    (h : 0 ≤ a * b) (hb : b < 0) : a ≤ 0 :=
   le_of_not_gt fun ha => absurd h (mul_neg_of_pos_of_neg ha hb).not_le
 
-theorem nonpos_of_mul_nonneg_right (h : 0 ≤ a * b) (ha : a < 0) : b ≤ 0 :=
+theorem nonpos_of_mul_nonneg_right [MulPosStrictMono α]
+    (h : 0 ≤ a * b) (ha : a < 0) : b ≤ 0 :=
   le_of_not_gt fun hb => absurd h (mul_neg_of_neg_of_pos ha hb).not_le
 
 @[simp]
-theorem Units.inv_pos {u : αˣ} : (0 : α) < ↑u⁻¹ ↔ (0 : α) < u :=
+theorem Units.inv_pos
+    [ZeroLEOneClass α] [NeZero (R := α) 1] [MulPosMono α] [PosMulStrictMono α]
+    {u : αˣ} : (0 : α) < ↑u⁻¹ ↔ (0 : α) < u :=
   have : ∀ {u : αˣ}, (0 : α) < u → (0 : α) < ↑u⁻¹ := @fun u h =>
     (mul_pos_iff_of_pos_left h).mp <| u.mul_inv.symm ▸ zero_lt_one
   ⟨this, this⟩
 
 @[simp]
-theorem Units.inv_neg {u : αˣ} : ↑u⁻¹ < (0 : α) ↔ ↑u < (0 : α) :=
+theorem Units.inv_neg
+    [ZeroLEOneClass α] [NeZero (R := α) 1] [MulPosMono α] [PosMulMono α]
+    {u : αˣ} : ↑u⁻¹ < (0 : α) ↔ ↑u < (0 : α) :=
   have : ∀ {u : αˣ}, ↑u < (0 : α) → ↑u⁻¹ < (0 : α) := @fun u h =>
     neg_of_mul_pos_right (u.mul_inv.symm ▸ zero_lt_one) h.le
   ⟨this, this⟩
 
-theorem cmp_mul_pos_left (ha : 0 < a) (b c : α) : cmp (a * b) (a * c) = cmp b c :=
+theorem cmp_mul_pos_left [PosMulStrictMono α]
+    (ha : 0 < a) (b c : α) : cmp (a * b) (a * c) = cmp b c :=
   (strictMono_mul_left_of_pos ha).cmp_map_eq b c
 
-theorem cmp_mul_pos_right (ha : 0 < a) (b c : α) : cmp (b * a) (c * a) = cmp b c :=
+theorem cmp_mul_pos_right [MulPosStrictMono α]
+    (ha : 0 < a) (b c : α) : cmp (b * a) (c * a) = cmp b c :=
   (strictMono_mul_right_of_pos ha).cmp_map_eq b c
 
-theorem mul_max_of_nonneg (b c : α) (ha : 0 ≤ a) : a * max b c = max (a * b) (a * c) :=
+theorem mul_max_of_nonneg [PosMulMono α]
+    (b c : α) (ha : 0 ≤ a) : a * max b c = max (a * b) (a * c) :=
   (monotone_mul_left_of_nonneg ha).map_max
 
-theorem mul_min_of_nonneg (b c : α) (ha : 0 ≤ a) : a * min b c = min (a * b) (a * c) :=
+theorem mul_min_of_nonneg [PosMulMono α]
+    (b c : α) (ha : 0 ≤ a) : a * min b c = min (a * b) (a * c) :=
   (monotone_mul_left_of_nonneg ha).map_min
 
-theorem max_mul_of_nonneg (a b : α) (hc : 0 ≤ c) : max a b * c = max (a * c) (b * c) :=
+theorem max_mul_of_nonneg [MulPosMono α]
+    (a b : α) (hc : 0 ≤ c) : max a b * c = max (a * c) (b * c) :=
   (monotone_mul_right_of_nonneg hc).map_max
 
-theorem min_mul_of_nonneg (a b : α) (hc : 0 ≤ c) : min a b * c = min (a * c) (b * c) :=
+theorem min_mul_of_nonneg [MulPosMono α]
+    (a b : α) (hc : 0 ≤ c) : min a b * c = min (a * c) (b * c) :=
   (monotone_mul_right_of_nonneg hc).map_min
 
-theorem le_of_mul_le_of_one_le {a b c : α} (h : a * c ≤ b) (hb : 0 ≤ b) (hc : 1 ≤ c) : a ≤ b :=
+theorem le_of_mul_le_of_one_le
+    [ZeroLEOneClass α] [NeZero (R := α) 1] [MulPosStrictMono α] [PosMulMono α]
+    {a b c : α} (h : a * c ≤ b) (hb : 0 ≤ b) (hc : 1 ≤ c) : a ≤ b :=
   le_of_mul_le_mul_right (h.trans <| le_mul_of_one_le_right hb hc) <| zero_lt_one.trans_le hc
 
-theorem nonneg_le_nonneg_of_sq_le_sq {a b : α} (hb : 0 ≤ b) (h : a * a ≤ b * b) : a ≤ b :=
+theorem nonneg_le_nonneg_of_sq_le_sq [PosMulStrictMono α] [MulPosMono α]
+    {a b : α} (hb : 0 ≤ b) (h : a * a ≤ b * b) : a ≤ b :=
   le_of_not_gt fun hab => (mul_self_lt_mul_self hb hab).not_le h
 
-theorem mul_self_le_mul_self_iff {a b : α} (h1 : 0 ≤ a) (h2 : 0 ≤ b) : a ≤ b ↔ a * a ≤ b * b :=
+theorem mul_self_le_mul_self_iff [PosMulStrictMono α] [MulPosMono α]
+    {a b : α} (h1 : 0 ≤ a) (h2 : 0 ≤ b) : a ≤ b ↔ a * a ≤ b * b :=
   ⟨mul_self_le_mul_self h1, nonneg_le_nonneg_of_sq_le_sq h2⟩
 
-theorem mul_self_lt_mul_self_iff {a b : α} (h1 : 0 ≤ a) (h2 : 0 ≤ b) : a < b ↔ a * a < b * b :=
+theorem mul_self_lt_mul_self_iff [PosMulStrictMono α] [MulPosMono α]
+    {a b : α} (h1 : 0 ≤ a) (h2 : 0 ≤ b) : a < b ↔ a * a < b * b :=
   ((@strictMonoOn_mul_self α _).lt_iff_lt h1 h2).symm
 
-theorem mul_self_inj {a b : α} (h1 : 0 ≤ a) (h2 : 0 ≤ b) : a * a = b * b ↔ a = b :=
+theorem mul_self_inj [PosMulStrictMono α] [MulPosMono α]
+    {a b : α} (h1 : 0 ≤ a) (h2 : 0 ≤ b) : a * a = b * b ↔ a = b :=
   (@strictMonoOn_mul_self α _).eq_iff_eq h1 h2
 
-lemma sign_cases_of_C_mul_pow_nonneg  (h : ∀ n, 0 ≤ a * b ^ n) : a = 0 ∨ 0 < a ∧ 0 ≤ b := by
+lemma sign_cases_of_C_mul_pow_nonneg [PosMulStrictMono α]
+    (h : ∀ n, 0 ≤ a * b ^ n) : a = 0 ∨ 0 < a ∧ 0 ≤ b := by
   have : 0 ≤ a := by simpa only [pow_zero, mul_one] using h 0
   refine this.eq_or_gt.imp_right fun ha ↦ ⟨ha, nonneg_of_mul_nonneg_right ?_ ha⟩
   simpa only [pow_one] using h 1
 
-variable [ExistsAddOfLE α] [CovariantClass α α (· + ·) (· < ·)]
-  [ContravariantClass α α (· + ·) (· ≤ ·)]
-
-theorem mul_pos_iff : 0 < a * b ↔ 0 < a ∧ 0 < b ∨ a < 0 ∧ b < 0 :=
+theorem mul_pos_iff [ExistsAddOfLE α] [PosMulStrictMono α] [MulPosStrictMono α]
+    [CovariantClass α α (· + ·) (· < ·)] [ContravariantClass α α (· + ·) (· < ·)] :
+    0 < a * b ↔ 0 < a ∧ 0 < b ∨ a < 0 ∧ b < 0 :=
   ⟨pos_and_pos_or_neg_and_neg_of_mul_pos, fun h =>
     h.elim (and_imp.2 mul_pos) (and_imp.2 mul_pos_of_neg_of_neg)⟩
 
-theorem mul_nonneg_iff : 0 ≤ a * b ↔ 0 ≤ a ∧ 0 ≤ b ∨ a ≤ 0 ∧ b ≤ 0 :=
+theorem mul_nonneg_iff [ExistsAddOfLE α] [MulPosStrictMono α] [PosMulStrictMono α]
+    [ContravariantClass α α (· + ·) (· ≤ ·)] [CovariantClass α α (· + ·) (· ≤ ·)]:
+    0 ≤ a * b ↔ 0 ≤ a ∧ 0 ≤ b ∨ a ≤ 0 ∧ b ≤ 0 :=
   ⟨nonneg_and_nonneg_or_nonpos_and_nonpos_of_mul_nonneg, fun h =>
     h.elim (and_imp.2 mul_nonneg) (and_imp.2 mul_nonneg_of_nonpos_of_nonpos)⟩
 
 /-- Out of three elements of a `LinearOrderedRing`, two must have the same sign. -/
-theorem mul_nonneg_of_three (a b c : α) : 0 ≤ a * b ∨ 0 ≤ b * c ∨ 0 ≤ c * a := by
+theorem mul_nonneg_of_three [ExistsAddOfLE α] [MulPosStrictMono α] [PosMulStrictMono α]
+    [CovariantClass α α (· + ·) (· ≤ ·)] [ContravariantClass α α (· + ·) (· ≤ ·)]
+    (a b c : α) : 0 ≤ a * b ∨ 0 ≤ b * c ∨ 0 ≤ c * a := by
   iterate 3 rw [mul_nonneg_iff]
   have or_a := le_total 0 a
   have or_b := le_total 0 b
@@ -662,7 +800,9 @@ theorem mul_nonneg_of_three (a b c : α) : 0 ≤ a * b ∨ 0 ≤ b * c ∨ 0 ≤
             Or.elim or_a (fun (_ : 0 ≤ a) => Or.inr (Or.inl (Or.inr ⟨h4, h0⟩)))
               (fun (h6 : a ≤ 0) => Or.inl (Or.inr ⟨h6, h4⟩))))
 
-lemma mul_nonneg_iff_pos_imp_nonneg : 0 ≤ a * b ↔ (0 < a → 0 ≤ b) ∧ (0 < b → 0 ≤ a) := by
+lemma mul_nonneg_iff_pos_imp_nonneg [ExistsAddOfLE α] [PosMulStrictMono α] [MulPosStrictMono α]
+    [CovariantClass α α (· + ·) (· ≤ ·)] [ContravariantClass α α (· + ·) (· ≤ ·)] :
+    0 ≤ a * b ↔ (0 < a → 0 ≤ b) ∧ (0 < b → 0 ≤ a) := by
   refine mul_nonneg_iff.trans ?_
   simp_rw [← not_le, ← or_iff_not_imp_left]
   have := le_total a 0
@@ -670,35 +810,53 @@ lemma mul_nonneg_iff_pos_imp_nonneg : 0 ≤ a * b ↔ (0 < a → 0 ≤ b) ∧ (0
   tauto
 
 @[simp]
-theorem mul_le_mul_left_of_neg {a b c : α} (h : c < 0) : c * a ≤ c * b ↔ b ≤ a :=
+theorem mul_le_mul_left_of_neg [ExistsAddOfLE α] [PosMulStrictMono α]
+    [CovariantClass α α (swap (· + ·)) (· ≤ ·)] [ContravariantClass α α (swap (· + ·)) (· ≤ ·)]
+    {a b c : α} (h : c < 0) : c * a ≤ c * b ↔ b ≤ a :=
   (strictAnti_mul_left h).le_iff_le
 
 @[simp]
-theorem mul_le_mul_right_of_neg {a b c : α} (h : c < 0) : a * c ≤ b * c ↔ b ≤ a :=
+theorem mul_le_mul_right_of_neg [ExistsAddOfLE α] [MulPosStrictMono α]
+    [CovariantClass α α (swap (· + ·)) (· ≤ ·)] [ContravariantClass α α (swap (· + ·)) (· ≤ ·)]
+    {a b c : α} (h : c < 0) : a * c ≤ b * c ↔ b ≤ a :=
   (strictAnti_mul_right h).le_iff_le
 
 @[simp]
-theorem mul_lt_mul_left_of_neg {a b c : α} (h : c < 0) : c * a < c * b ↔ b < a :=
+theorem mul_lt_mul_left_of_neg [ExistsAddOfLE α] [PosMulStrictMono α]
+    [CovariantClass α α (swap (· + ·)) (· < ·)] [ContravariantClass α α (swap (· + ·)) (· < ·)]
+    {a b c : α} (h : c < 0) : c * a < c * b ↔ b < a :=
   (strictAnti_mul_left h).lt_iff_lt
 
 @[simp]
-theorem mul_lt_mul_right_of_neg {a b c : α} (h : c < 0) : a * c < b * c ↔ b < a :=
+theorem mul_lt_mul_right_of_neg [ExistsAddOfLE α] [MulPosStrictMono α]
+    [CovariantClass α α (swap (· + ·)) (· < ·)] [ContravariantClass α α (swap (· + ·)) (· < ·)]
+    {a b c : α} (h : c < 0) : a * c < b * c ↔ b < a :=
   (strictAnti_mul_right h).lt_iff_lt
 
-theorem lt_of_mul_lt_mul_of_nonpos_left (h : c * a < c * b) (hc : c ≤ 0) : b < a :=
+theorem lt_of_mul_lt_mul_of_nonpos_left [ExistsAddOfLE α] [PosMulMono α]
+    [CovariantClass α α (swap (· + ·)) (· ≤ ·)] [ContravariantClass α α (swap (· + ·)) (· ≤ ·)]
+    (h : c * a < c * b) (hc : c ≤ 0) : b < a :=
   (antitone_mul_left hc).reflect_lt h
 
-theorem lt_of_mul_lt_mul_of_nonpos_right (h : a * c < b * c) (hc : c ≤ 0) : b < a :=
+theorem lt_of_mul_lt_mul_of_nonpos_right [ExistsAddOfLE α] [MulPosMono α]
+    [CovariantClass α α (swap (· + ·)) (· ≤ ·)] [ContravariantClass α α (swap (· + ·)) (· ≤ ·)]
+    (h : a * c < b * c) (hc : c ≤ 0) : b < a :=
   (antitone_mul_right hc).reflect_lt h
 
-theorem cmp_mul_neg_left {a : α} (ha : a < 0) (b c : α) : cmp (a * b) (a * c) = cmp c b :=
+theorem cmp_mul_neg_left [ExistsAddOfLE α] [PosMulStrictMono α]
+    [ContravariantClass α α (swap (· + ·)) (· < ·)] [CovariantClass α α (swap (· + ·)) (· < ·)]
+    {a : α} (ha : a < 0) (b c : α) : cmp (a * b) (a * c) = cmp c b :=
   (strictAnti_mul_left ha).cmp_map_eq b c
 
-theorem cmp_mul_neg_right {a : α} (ha : a < 0) (b c : α) : cmp (b * a) (c * a) = cmp c b :=
+theorem cmp_mul_neg_right [ExistsAddOfLE α] [MulPosStrictMono α]
+    [ContravariantClass α α (swap (· + ·)) (· < ·)] [CovariantClass α α (swap (· + ·)) (· < ·)]
+    {a : α} (ha : a < 0) (b c : α) : cmp (b * a) (c * a) = cmp c b :=
   (strictAnti_mul_right ha).cmp_map_eq b c
 
 @[simp]
-theorem mul_self_pos {a : α} : 0 < a * a ↔ a ≠ 0 := by
+theorem mul_self_pos [ExistsAddOfLE α] [PosMulStrictMono α] [MulPosStrictMono α]
+    [CovariantClass α α (· + ·) (· < ·)] [ContravariantClass α α (· + ·) (· < ·)]
+    {a : α} : 0 < a * a ↔ a ≠ 0 := by
   constructor
   · rintro h rfl
     rw [mul_zero] at h
@@ -707,27 +865,39 @@ theorem mul_self_pos {a : α} : 0 < a * a ↔ a ≠ 0 := by
     cases' h.lt_or_lt with h h
     exacts [mul_pos_of_neg_of_neg h h, mul_pos h h]
 
-theorem nonneg_of_mul_nonpos_left {a b : α} (h : a * b ≤ 0) (hb : b < 0) : 0 ≤ a :=
+theorem nonneg_of_mul_nonpos_left [ExistsAddOfLE α] [MulPosStrictMono α]
+    [CovariantClass α α (swap (· + ·)) (· ≤ ·)] [ContravariantClass α α (swap (· + ·)) (· ≤ ·)]
+    {a b : α} (h : a * b ≤ 0) (hb : b < 0) : 0 ≤ a :=
   le_of_not_gt fun ha => absurd h (mul_pos_of_neg_of_neg ha hb).not_le
 
-theorem nonneg_of_mul_nonpos_right {a b : α} (h : a * b ≤ 0) (ha : a < 0) : 0 ≤ b :=
+theorem nonneg_of_mul_nonpos_right [ExistsAddOfLE α] [MulPosStrictMono α]
+    [CovariantClass α α (swap (· + ·)) (· ≤ ·)] [ContravariantClass α α (swap (· + ·)) (· ≤ ·)]
+    {a b : α} (h : a * b ≤ 0) (ha : a < 0) : 0 ≤ b :=
   le_of_not_gt fun hb => absurd h (mul_pos_of_neg_of_neg ha hb).not_le
 
-theorem pos_of_mul_neg_left {a b : α} (h : a * b < 0) (hb : b ≤ 0) : 0 < a :=
+theorem pos_of_mul_neg_left [ExistsAddOfLE α] [MulPosMono α]
+    [CovariantClass α α (swap (· + ·)) (· ≤ ·)] [ContravariantClass α α (swap (· + ·)) (· ≤ ·)]
+    {a b : α} (h : a * b < 0) (hb : b ≤ 0) : 0 < a :=
   lt_of_not_ge fun ha => absurd h (mul_nonneg_of_nonpos_of_nonpos ha hb).not_lt
 
-theorem pos_of_mul_neg_right {a b : α} (h : a * b < 0) (ha : a ≤ 0) : 0 < b :=
+theorem pos_of_mul_neg_right [ExistsAddOfLE α] [MulPosMono α]
+    [CovariantClass α α (swap (· + ·)) (· ≤ ·)] [ContravariantClass α α (swap (· + ·)) (· ≤ ·)]
+    {a b : α} (h : a * b < 0) (ha : a ≤ 0) : 0 < b :=
   lt_of_not_ge fun hb => absurd h (mul_nonneg_of_nonpos_of_nonpos ha hb).not_lt
 
-theorem neg_iff_pos_of_mul_neg (hab : a * b < 0) : a < 0 ↔ 0 < b :=
+theorem neg_iff_pos_of_mul_neg [ExistsAddOfLE α] [PosMulMono α] [MulPosMono α]
+    [CovariantClass α α (swap (· + ·)) (· ≤ ·)] [ContravariantClass α α (swap (· + ·)) (· ≤ ·)]
+    (hab : a * b < 0) : a < 0 ↔ 0 < b :=
   ⟨pos_of_mul_neg_right hab ∘ le_of_lt, neg_of_mul_neg_left hab ∘ le_of_lt⟩
 
-theorem pos_iff_neg_of_mul_neg (hab : a * b < 0) : 0 < a ↔ b < 0 :=
+theorem pos_iff_neg_of_mul_neg [ExistsAddOfLE α] [PosMulMono α] [MulPosMono α]
+    [CovariantClass α α (swap (· + ·)) (· ≤ ·)] [ContravariantClass α α (swap (· + ·)) (· ≤ ·)]
+    (hab : a * b < 0) : 0 < a ↔ b < 0 :=
   ⟨neg_of_mul_neg_right hab ∘ le_of_lt, pos_of_mul_neg_left hab ∘ le_of_lt⟩
 
-variable [IsRightCancelAdd α] [NoZeroDivisors α]
-
-lemma sq_nonneg (a : α) : 0 ≤ a ^ 2 := by
+lemma sq_nonneg [IsRightCancelAdd α]
+    [ZeroLEOneClass α] [ExistsAddOfLE α] [PosMulMono α] [CovariantClass α α (· + ·) (· < ·)]
+    (a : α) : 0 ≤ a ^ 2 := by
   obtain ha | ha := le_total 0 a
   · exact pow_nonneg ha _
   obtain ⟨b, hab⟩ := exists_add_of_le ha
@@ -741,14 +911,22 @@ lemma sq_nonneg (a : α) : 0 ≤ a ^ 2 := by
 
 alias pow_two_nonneg := sq_nonneg
 
-lemma mul_self_nonneg (a : α) : 0 ≤ a * a := by simpa only [sq] using sq_nonneg a
+lemma mul_self_nonneg [IsRightCancelAdd α]
+    [ZeroLEOneClass α] [ExistsAddOfLE α] [PosMulMono α] [CovariantClass α α (· + ·) (· < ·)]
+    (a : α) : 0 ≤ a * a := by simpa only [sq] using sq_nonneg a
 
 /-- The sum of two squares is zero iff both elements are zero. -/
-lemma mul_self_add_mul_self_eq_zero : a * a + b * b = 0 ↔ a = 0 ∧ b = 0 := by
+lemma mul_self_add_mul_self_eq_zero [IsRightCancelAdd α] [NoZeroDivisors α]
+    [ZeroLEOneClass α] [ExistsAddOfLE α] [PosMulMono α]
+    [CovariantClass α α (· + ·) (· ≤ ·)] [CovariantClass α α (· + ·) (· < ·)] :
+    a * a + b * b = 0 ↔ a = 0 ∧ b = 0 := by
   rw [add_eq_zero_iff', mul_self_eq_zero (M₀ := α), mul_self_eq_zero (M₀ := α)] <;>
     apply mul_self_nonneg
 
-lemma eq_zero_of_mul_self_add_mul_self_eq_zero (h : a * a + b * b = 0) : a = 0 :=
+lemma eq_zero_of_mul_self_add_mul_self_eq_zero [IsRightCancelAdd α] [NoZeroDivisors α]
+    [ZeroLEOneClass α] [ExistsAddOfLE α] [PosMulMono α]
+    [CovariantClass α α (· + ·) (· ≤ ·)] [CovariantClass α α (· + ·) (· < ·)]
+    (h : a * a + b * b = 0) : a = 0 :=
   (mul_self_add_mul_self_eq_zero.mp h).left
 
 end LinearOrderedSemiring
@@ -765,12 +943,11 @@ lemma max_mul_mul_le_max_mul_max [PosMulMono α] [MulPosMono α] (b c : α) (ha 
     mul_le_mul (le_max_right a c) (le_max_right b d) hd (le_trans ha (le_max_left a c))
   max_le (by simpa [mul_comm, max_comm] using ba) (by simpa [mul_comm, max_comm] using cd)
 
-variable [ExistsAddOfLE α]
-
 /-- Binary **arithmetic mean-geometric mean inequality** (aka AM-GM inequality) for linearly ordered
 commutative semirings. -/
-lemma two_mul_le_add_sq [MulPosStrictMono α] [ContravariantClass α α (· + ·) (· ≤ ·)]
-    [CovariantClass α α (· + ·) (· ≤ ·)] (a b : α) : 2 * a * b ≤ a ^ 2 + b ^ 2 := by
+lemma two_mul_le_add_sq [ExistsAddOfLE α] [MulPosStrictMono α]
+    [ContravariantClass α α (· + ·) (· ≤ ·)] [CovariantClass α α (· + ·) (· ≤ ·)]
+    (a b : α) : 2 * a * b ≤ a ^ 2 + b ^ 2 := by
   simpa [fn_min_add_fn_max (fun x ↦ x * x), sq, two_mul, add_mul]
     using mul_add_mul_le_mul_add_mul (@min_le_max _ _ a b) (@min_le_max _ _ a b)
 
@@ -780,35 +957,49 @@ end LinearOrderedCommSemiring
 
 section LinearOrderedRing
 
-variable [Ring α] [LinearOrder α] [PosMulStrictMono α] [MulPosStrictMono α] [ExistsAddOfLE α]
-  [CovariantClass α α (· + ·) (· ≤ ·)] [CovariantClass α α (· + ·) (· < ·)] [ZeroLEOneClass α]
-  {a b c: α}
+variable [Ring α] [LinearOrder α] {a b : α}
 
 -- TODO: Can the following five lemmas be generalised to
 -- `[Semiring α] [LinearOrder α] [ExistsAddOfLE α] ..`?
 
-lemma mul_neg_iff : a * b < 0 ↔ 0 < a ∧ b < 0 ∨ a < 0 ∧ 0 < b := by
+lemma mul_neg_iff [PosMulStrictMono α] [MulPosStrictMono α]
+    [ContravariantClass α α (· + ·) (· < ·)] [CovariantClass α α (· + ·) (· < ·)] :
+    a * b < 0 ↔ 0 < a ∧ b < 0 ∨ a < 0 ∧ 0 < b := by
   rw [← neg_pos, neg_mul_eq_mul_neg, mul_pos_iff (α := α), neg_pos, neg_lt_zero]
 
-lemma mul_nonpos_iff : a * b ≤ 0 ↔ 0 ≤ a ∧ b ≤ 0 ∨ a ≤ 0 ∧ 0 ≤ b := by
+lemma mul_nonpos_iff [MulPosStrictMono α] [PosMulStrictMono α]
+    [ContravariantClass α α (· + ·) (· ≤ ·)] [CovariantClass α α (· + ·) (· ≤ ·)] :
+    a * b ≤ 0 ↔ 0 ≤ a ∧ b ≤ 0 ∨ a ≤ 0 ∧ 0 ≤ b := by
   rw [← neg_nonneg, neg_mul_eq_mul_neg, mul_nonneg_iff (α := α), neg_nonneg, neg_nonpos]
 
-lemma mul_nonneg_iff_neg_imp_nonpos : 0 ≤ a * b ↔ (a < 0 → b ≤ 0) ∧ (b < 0 → a ≤ 0) := by
+lemma mul_nonneg_iff_neg_imp_nonpos [PosMulStrictMono α] [MulPosStrictMono α]
+    [CovariantClass α α (· + ·) (· ≤ ·)] [ContravariantClass α α (· + ·) (· ≤ ·)] :
+    0 ≤ a * b ↔ (a < 0 → b ≤ 0) ∧ (b < 0 → a ≤ 0) := by
   rw [← neg_mul_neg, mul_nonneg_iff_pos_imp_nonneg (α := α)]; simp only [neg_pos, neg_nonneg]
 
-lemma mul_nonpos_iff_pos_imp_nonpos : a * b ≤ 0 ↔ (0 < a → b ≤ 0) ∧ (b < 0 → 0 ≤ a) := by
+lemma mul_nonpos_iff_pos_imp_nonpos [PosMulStrictMono α] [MulPosStrictMono α]
+    [CovariantClass α α (· + ·) (· ≤ ·)] [ContravariantClass α α (· + ·) (· ≤ ·)] :
+    a * b ≤ 0 ↔ (0 < a → b ≤ 0) ∧ (b < 0 → 0 ≤ a) := by
   rw [← neg_nonneg, ← mul_neg, mul_nonneg_iff_pos_imp_nonneg (α := α)]
   simp only [neg_pos, neg_nonneg]
 
-lemma mul_nonpos_iff_neg_imp_nonneg : a * b ≤ 0 ↔ (a < 0 → 0 ≤ b) ∧ (0 < b → a ≤ 0) := by
+lemma mul_nonpos_iff_neg_imp_nonneg [PosMulStrictMono α] [MulPosStrictMono α]
+    [CovariantClass α α (· + ·) (· ≤ ·)] [ContravariantClass α α (· + ·) (· ≤ ·)] :
+    a * b ≤ 0 ↔ (a < 0 → 0 ≤ b) ∧ (0 < b → a ≤ 0) := by
   rw [← neg_nonneg, ← neg_mul, mul_nonneg_iff_pos_imp_nonneg (α := α)]
   simp only [neg_pos, neg_nonneg]
 
-lemma neg_one_lt_zero [NeZero (R := α) 1] : -1 < (0 : α) := neg_lt_zero.2 zero_lt_one
+lemma neg_one_lt_zero
+    [ZeroLEOneClass α] [NeZero (R := α) 1] [CovariantClass α α (· + ·) (· < ·)] :
+    -1 < (0 : α) := neg_lt_zero.2 zero_lt_one
 
-lemma sub_one_lt (a : α) [NeZero (R := α) 1] : a - 1 < a := sub_lt_iff_lt_add.2 <| lt_add_one a
+lemma sub_one_lt [ZeroLEOneClass α] [NeZero (R := α) 1]
+    [CovariantClass α α (· + ·) (· < ·)]
+    (a : α) : a - 1 < a := sub_lt_iff_lt_add.2 <| lt_add_one a
 
-lemma mul_self_le_mul_self_of_le_of_neg_le (h₁ : a ≤ b) (h₂ : -a ≤ b) : a * a ≤ b * b :=
+lemma mul_self_le_mul_self_of_le_of_neg_le
+    [MulPosMono α] [PosMulMono α] [CovariantClass α α (· + ·) (· ≤ ·)]
+    (h₁ : a ≤ b) (h₂ : -a ≤ b) : a * a ≤ b * b :=
   (le_total 0 a).elim (mul_self_le_mul_self · h₁) fun h ↦
     (neg_mul_neg a a).symm.trans_le <|
       mul_le_mul h₂ h₂ (neg_nonneg.2 h) <| (neg_nonneg.2 h).trans h₂

--- a/Mathlib/Algebra/Order/Ring/Unbundled/Basic.lean
+++ b/Mathlib/Algebra/Order/Ring/Unbundled/Basic.lean
@@ -135,10 +135,6 @@ theorem add_one_le_two_mul [LE α] [Semiring α] [CovariantClass α α (· + ·)
 
 section OrderedSemiring
 
--- variable [Semiring α] [PartialOrder α] [MulPosMono α] [PosMulMono α] [ZeroLEOneClass α]
---   [CovariantClass α α (· + ·) (· ≤ ·)] [CovariantClass α α (· * ·) (· ≤ ·)]
---   {a b c d : α}
-
 variable [Semiring α] [Preorder α] {a b c d : α}
 
 @[simp]

--- a/Mathlib/Algebra/Order/Ring/Unbundled/Basic.lean
+++ b/Mathlib/Algebra/Order/Ring/Unbundled/Basic.lean
@@ -231,7 +231,6 @@ theorem mul_lt_one_of_nonneg_of_lt_one_right [MulPosMono α]
     (ha : a ≤ 1) (hb₀ : 0 ≤ b) (hb : b < 1) : a * b < 1 :=
   (mul_le_of_le_one_left hb₀ ha).trans_lt hb
 
--- variable [ExistsAddOfLE α] [ContravariantClass α α (swap (· + ·)) (· ≤ ·)]
 
 theorem mul_le_mul_of_nonpos_left [ExistsAddOfLE α] [PosMulMono α]
     [CovariantClass α α (swap (· + ·)) (· ≤ ·)] [ContravariantClass α α (swap (· + ·)) (· ≤ ·)]


### PR DESCRIPTION
We improve the generality of the results here by using inlined typeclass assumptions. It also makes this file comport better with the new variable inclusion mechanism. See [Zulip](https://leanprover.zulipchat.com/#narrow/stream/287929-mathlib4/topic/New.20variable.20inclusion.20mechanism).

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
