### PR TITLE
[Merged by Bors] - feat(ENat): not_lt_zero, coe_lt_top

### DIFF
--- a/Mathlib/Data/ENat/Basic.lean
+++ b/Mathlib/Data/ENat/Basic.lean
@@ -248,6 +248,14 @@ theorem le_of_lt_add_one (h : m < n + 1) : m ≤ n :=
 theorem le_coe_iff {n : ℕ∞} {k : ℕ} : n ≤ ↑k ↔ ∃ (n₀ : ℕ), n = n₀ ∧ n₀ ≤ k :=
   WithTop.le_coe_iff
 
+@[simp]
+lemma not_lt_zero (n : ℕ∞) : ¬ n < 0 := by
+  cases n <;> simp
+
+@[simp]
+lemma coe_lt_top (n : ℕ) : (n : ℕ∞) < ⊤ :=
+  WithTop.coe_lt_top n
+
 @[elab_as_elim]
 theorem nat_induction {P : ℕ∞ → Prop} (a : ℕ∞) (h0 : P 0) (hsuc : ∀ n : ℕ, P n → P n.succ)
     (htop : (∀ n : ℕ, P n) → P ⊤) : P a := by


### PR DESCRIPTION
from the Carleson project
