### PR TITLE
[Merged by Bors] - refactor: remove some dependence on `circle` in C⋆-algebras

### DIFF
--- a/Mathlib/Analysis/CstarAlgebra/ContinuousFunctionalCalculus/Instances.lean
+++ b/Mathlib/Analysis/CstarAlgebra/ContinuousFunctionalCalculus/Instances.lean
@@ -169,29 +169,6 @@ instance IsStarNormal.instNonUnitalContinuousFunctionalCalculus {A : Type*} [Non
     NonUnitalContinuousFunctionalCalculus ℂ (IsStarNormal : A → Prop) :=
   RCLike.nonUnitalContinuousFunctionalCalculus Unitization.isStarNormal_inr
 
-instance IsStarNormal.cfcₙ_map {R A : Type*} {p : A → Prop} [CommSemiring R] [StarRing R]
-    [MetricSpace R] [TopologicalSemiring R] [ContinuousStar R] [Nontrivial R] [TopologicalSpace A]
-    [NonUnitalRing A] [StarRing A] [Module R A] [IsScalarTower R A A] [SMulCommClass R A A]
-    [NonUnitalContinuousFunctionalCalculus R p] (a : A) (f : R → R) :
-    IsStarNormal (cfcₙ f a) where
-  star_comm_self := by
-    refine cfcₙ_cases (fun x ↦ Commute (star x) x) _ _ (Commute.zero_right _) fun _ _ _ ↦ ?_
-    simp only [Commute, SemiconjBy]
-    rw [← cfcₙ_apply f a, ← cfcₙ_star, ← cfcₙ_mul .., ← cfcₙ_mul ..]
-    congr! 2
-    exact mul_comm _ _
-
-instance IsStarNormal.cfc_map {R A : Type*} {p : A → Prop} [CommSemiring R] [StarRing R]
-    [MetricSpace R] [TopologicalSemiring R] [ContinuousStar R] [TopologicalSpace A] [Ring A]
-    [StarRing A] [Algebra R A] [ContinuousFunctionalCalculus R p] (a : A) (f : R → R) :
-    IsStarNormal (cfc f a) where
-  star_comm_self := by
-    rw [Commute, SemiconjBy]
-    by_cases h : ContinuousOn f (spectrum R a)
-    · rw [← cfc_star, ← cfc_mul .., ← cfc_mul ..]
-      congr! 2
-      exact mul_comm _ _
-    · simp [cfc_apply_of_not_continuousOn a h]
 end Normal
 
 /-!

--- a/Mathlib/Analysis/CstarAlgebra/ContinuousFunctionalCalculus/NonUnital.lean
+++ b/Mathlib/Analysis/CstarAlgebra/ContinuousFunctionalCalculus/NonUnital.lean
@@ -446,6 +446,14 @@ lemma CFC.quasispectrum_zero_eq : σₙ R (0 : A) = {0} := by
     simpa [CFC.quasispectrum_zero_eq]
   · exact cfcₙ_apply_of_not_map_zero _ hf0
 
+instance IsStarNormal.cfcₙ_map (f : R → R) (a : A) : IsStarNormal (cfcₙ f a) where
+  star_comm_self := by
+    refine cfcₙ_cases (fun x ↦ Commute (star x) x) _ _ (Commute.zero_right _) fun _ _ _ ↦ ?_
+    simp only [Commute, SemiconjBy]
+    rw [← cfcₙ_apply f a, ← cfcₙ_star, ← cfcₙ_mul .., ← cfcₙ_mul ..]
+    congr! 2
+    exact mul_comm _ _
+
 end CFCn
 
 end Main

--- a/Mathlib/Analysis/CstarAlgebra/ContinuousFunctionalCalculus/Unital.lean
+++ b/Mathlib/Analysis/CstarAlgebra/ContinuousFunctionalCalculus/Unital.lean
@@ -621,6 +621,15 @@ lemma cfc_algebraMap (r : R) (f : R → R) : cfc f (algebraMap R A r) = algebraM
 @[simp] lemma cfc_apply_one {f : R → R} : cfc f (1 : A) = algebraMap R A (f 1) := by
   simpa using cfc_algebraMap (A := A) 1 f
 
+instance IsStarNormal.cfc_map (f : R → R) (a : A) : IsStarNormal (cfc f a) where
+  star_comm_self := by
+    rw [Commute, SemiconjBy]
+    by_cases h : ContinuousOn f (spectrum R a)
+    · rw [← cfc_star, ← cfc_mul .., ← cfc_mul ..]
+      congr! 2
+      exact mul_comm _ _
+    · simp [cfc_apply_of_not_continuousOn a h]
+
 end CFC
 
 end Basic

--- a/Mathlib/Analysis/CstarAlgebra/ContinuousFunctionalCalculus/Unitary.lean
+++ b/Mathlib/Analysis/CstarAlgebra/ContinuousFunctionalCalculus/Unitary.lean
@@ -15,39 +15,69 @@ import Mathlib.Analysis.CstarAlgebra.ContinuousFunctionalCalculus.Unital
   star-normal and its spectrum lies on the unit circle.
 
 -/
+
+section prereq
+
+instance IsStarNormal.cfc_map {R A : Type*} {p : A → Prop} [CommSemiring R] [StarRing R]
+    [MetricSpace R] [TopologicalSemiring R] [ContinuousStar R] [TopologicalSpace A] [Ring A]
+    [StarRing A] [Algebra R A] [ContinuousFunctionalCalculus R p] (a : A) (f : R → R) :
+    IsStarNormal (cfc f a) where
+  star_comm_self := by
+    rw [Commute, SemiconjBy]
+    by_cases h : ContinuousOn f (spectrum R a)
+    · rw [← cfc_star, ← cfc_mul .., ← cfc_mul ..]
+      congr! 2
+      exact mul_comm _ _
+    · simp [cfc_apply_of_not_continuousOn a h]
+
+theorem sq_eq_one_iff_of_pos {R : Type*} [LinearOrderedRing R] {a : R} (ha : 0 ≤ a) :
+    a ^ 2 = 1 ↔ a = 1 := by
+  rw [sq_eq_one_iff, or_iff_left_iff_imp]
+  rintro rfl
+  norm_num at ha
+
+
+
+end prereq
+
+section Unitary
+
+variable {R A : Type*} {p : A → Prop}
+variable [CommRing R] [StarRing R] [MetricSpace R] [TopologicalRing R] [ContinuousStar R]
+variable [TopologicalSpace A] [Ring A] [StarRing A] [Algebra R A] [StarModule R A]
+variable [ContinuousFunctionalCalculus R p]
+
+lemma cfc_unitary_iff (f : R → R) (a : A) (ha : p a := by cfc_tac)
+    (hf : ContinuousOn f (spectrum R a) := by cfc_cont_tac) :
+    cfc f a ∈ unitary A ↔ ∀ x ∈ spectrum R a, star (f x) * f x = 1 := by
+  simp only [unitary, Submonoid.mem_mk, Subsemigroup.mem_mk, Set.mem_setOf_eq]
+  rw [← IsStarNormal.cfc_map (p := p) a f |>.star_comm_self |>.eq, and_self, ← cfc_one R a,
+    ← cfc_star, ← cfc_mul .., cfc_eq_cfc_iff_eqOn]
+  exact Iff.rfl
+
+end Unitary
+
 section Unitary
 
 variable {A : Type*} [TopologicalSpace A] [Ring A] [StarRing A] [Algebra ℂ A]
   [StarModule ℂ A] [ContinuousFunctionalCalculus ℂ (IsStarNormal : A → Prop)]
 
-lemma unitary_iff_isStarNormal_and_spectrum_subset_circle {u : A} :
-    u ∈ unitary A ↔ IsStarNormal u ∧ spectrum ℂ u ⊆ circle := by
-  refine ⟨fun hu ↦ ?_, ?_⟩
-  · have h_normal := isStarNormal_of_mem_unitary hu
-    refine ⟨h_normal, ?_⟩
-    have h := unitary.star_mul_self_of_mem hu
-    rw [← cfc_id ℂ u, ← cfc_star id u, ← cfc_mul .., ← cfc_one ℂ u] at h
-    have := eqOn_of_cfc_eq_cfc h
-    peel this with x hx _
-    rw [SetLike.mem_coe, mem_circle_iff_normSq]
-    simpa using congr($(this).re)
-  · rintro ⟨_, hu⟩
-    rw [unitary.mem_iff, ← cfc_id ℂ u, ← cfc_star, ← cfc_mul .., ← cfc_mul .., ← cfc_one ℂ u]
-    simp only [id_eq]
-    constructor
-    all_goals
-      apply cfc_congr (fun x hx ↦ ?_)
-      simp only [RCLike.star_def, mul_comm x]
-      apply hu at hx
-      rwa [SetLike.mem_coe, mem_circle_iff_normSq, ← Complex.ofReal_injective.eq_iff,
-        Complex.normSq_eq_conj_mul_self] at hx
+lemma unitary_iff_isStarNormal_and_spectrum_subset_sphere {u : A} :
+    u ∈ unitary A ↔ IsStarNormal u ∧ spectrum ℂ u ⊆ Metric.sphere 0 1 := by
+  rw [← and_iff_right_of_imp isStarNormal_of_mem_unitary]
+  refine and_congr_right fun hu ↦ ?_
+  nth_rw 1 [← cfc_id ℂ u]
+  rw [cfc_unitary_iff id u, Set.subset_def]
+  congr! with x -
+  simp only [id_eq, RCLike.star_def, mem_sphere_iff_norm, sub_zero, Complex.conj_mul']
+  exact_mod_cast sq_eq_one_iff_of_pos (norm_nonneg x)
 
-lemma mem_unitary_of_spectrum_subset_circle {u : A}
+lemma mem_unitary_of_spectrum_subset_sphere {u : A}
     [IsStarNormal u] (hu : spectrum ℂ u ⊆ circle) : u ∈ unitary A :=
-  unitary_iff_isStarNormal_and_spectrum_subset_circle.mpr ⟨‹_›, hu⟩
+  unitary_iff_isStarNormal_and_spectrum_subset_sphere.mpr ⟨‹_›, hu⟩
 
 lemma spectrum_subset_circle_of_mem_unitary {u : A} (hu : u ∈ unitary A) :
     spectrum ℂ u ⊆ circle :=
-  unitary_iff_isStarNormal_and_spectrum_subset_circle.mp hu |>.right
+  unitary_iff_isStarNormal_and_spectrum_subset_sphere.mp hu |>.right
 
 end Unitary

--- a/Mathlib/Analysis/CstarAlgebra/ContinuousFunctionalCalculus/Unitary.lean
+++ b/Mathlib/Analysis/CstarAlgebra/ContinuousFunctionalCalculus/Unitary.lean
@@ -11,41 +11,16 @@ import Mathlib.Analysis.CstarAlgebra.ContinuousFunctionalCalculus.Unital
 
 ## Main theorems
 
-* `unitary_iff_isStarNormal_and_spectrum_subset_circle`: An element is unitary if and only if it is
+* `unitary_iff_isStarNormal_and_spectrum_subset_unitary`: An element is unitary if and only if it is
   star-normal and its spectrum lies on the unit circle.
 
 -/
 
-section prereq
+section Generic
 
-instance IsStarNormal.cfc_map {R A : Type*} {p : A → Prop} [CommSemiring R] [StarRing R]
-    [MetricSpace R] [TopologicalSemiring R] [ContinuousStar R] [TopologicalSpace A] [Ring A]
-    [StarRing A] [Algebra R A] [ContinuousFunctionalCalculus R p] (a : A) (f : R → R) :
-    IsStarNormal (cfc f a) where
-  star_comm_self := by
-    rw [Commute, SemiconjBy]
-    by_cases h : ContinuousOn f (spectrum R a)
-    · rw [← cfc_star, ← cfc_mul .., ← cfc_mul ..]
-      congr! 2
-      exact mul_comm _ _
-    · simp [cfc_apply_of_not_continuousOn a h]
-
-theorem sq_eq_one_iff_of_pos {R : Type*} [LinearOrderedRing R] {a : R} (ha : 0 ≤ a) :
-    a ^ 2 = 1 ↔ a = 1 := by
-  rw [sq_eq_one_iff, or_iff_left_iff_imp]
-  rintro rfl
-  norm_num at ha
-
-
-
-end prereq
-
-section Unitary
-
-variable {R A : Type*} {p : A → Prop}
-variable [CommRing R] [StarRing R] [MetricSpace R] [TopologicalRing R] [ContinuousStar R]
-variable [TopologicalSpace A] [Ring A] [StarRing A] [Algebra R A] [StarModule R A]
-variable [ContinuousFunctionalCalculus R p]
+variable {R A : Type*} {p : A → Prop} [CommRing R] [StarRing R] [MetricSpace R]
+variable [TopologicalRing R] [ContinuousStar R] [TopologicalSpace A] [Ring A] [StarRing A]
+variable [Algebra R A] [StarModule R A] [ContinuousFunctionalCalculus R p]
 
 lemma cfc_unitary_iff (f : R → R) (a : A) (ha : p a := by cfc_tac)
     (hf : ContinuousOn f (spectrum R a) := by cfc_cont_tac) :
@@ -55,29 +30,27 @@ lemma cfc_unitary_iff (f : R → R) (a : A) (ha : p a := by cfc_tac)
     ← cfc_star, ← cfc_mul .., cfc_eq_cfc_iff_eqOn]
   exact Iff.rfl
 
-end Unitary
-
-section Unitary
+end Generic
+section Complex
 
 variable {A : Type*} [TopologicalSpace A] [Ring A] [StarRing A] [Algebra ℂ A]
   [StarModule ℂ A] [ContinuousFunctionalCalculus ℂ (IsStarNormal : A → Prop)]
 
-lemma unitary_iff_isStarNormal_and_spectrum_subset_sphere {u : A} :
-    u ∈ unitary A ↔ IsStarNormal u ∧ spectrum ℂ u ⊆ Metric.sphere 0 1 := by
+lemma unitary_iff_isStarNormal_and_spectrum_subset_unitary {u : A} :
+    u ∈ unitary A ↔ IsStarNormal u ∧ spectrum ℂ u ⊆ unitary ℂ := by
   rw [← and_iff_right_of_imp isStarNormal_of_mem_unitary]
   refine and_congr_right fun hu ↦ ?_
   nth_rw 1 [← cfc_id ℂ u]
   rw [cfc_unitary_iff id u, Set.subset_def]
   congr! with x -
-  simp only [id_eq, RCLike.star_def, mem_sphere_iff_norm, sub_zero, Complex.conj_mul']
-  exact_mod_cast sq_eq_one_iff_of_pos (norm_nonneg x)
+  simp [unitary.mem_iff_star_mul_self]
 
-lemma mem_unitary_of_spectrum_subset_sphere {u : A}
-    [IsStarNormal u] (hu : spectrum ℂ u ⊆ circle) : u ∈ unitary A :=
-  unitary_iff_isStarNormal_and_spectrum_subset_sphere.mpr ⟨‹_›, hu⟩
+lemma mem_unitary_of_spectrum_subset_unitary {u : A}
+    [IsStarNormal u] (hu : spectrum ℂ u ⊆ unitary ℂ) : u ∈ unitary A :=
+  unitary_iff_isStarNormal_and_spectrum_subset_unitary.mpr ⟨‹_›, hu⟩
 
-lemma spectrum_subset_circle_of_mem_unitary {u : A} (hu : u ∈ unitary A) :
-    spectrum ℂ u ⊆ circle :=
-  unitary_iff_isStarNormal_and_spectrum_subset_sphere.mp hu |>.right
+lemma spectrum_subset_unitary_of_mem_unitary {u : A} (hu : u ∈ unitary A) :
+    spectrum ℂ u ⊆ unitary ℂ :=
+  unitary_iff_isStarNormal_and_spectrum_subset_unitary.mp hu |>.right
 
-end Unitary
+end Complex

--- a/Mathlib/Analysis/CstarAlgebra/ContinuousFunctionalCalculus/Unitary.lean
+++ b/Mathlib/Analysis/CstarAlgebra/ContinuousFunctionalCalculus/Unitary.lean
@@ -3,9 +3,9 @@ Copyright (c) 2024 Jireh Loreaux. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Jireh Loreaux
 -/
-import Mathlib.Analysis.Complex.Circle
 import Mathlib.Tactic.Peel
 import Mathlib.Analysis.CstarAlgebra.ContinuousFunctionalCalculus.Unital
+import Mathlib.Analysis.Complex.Basic
 
 /-! # Conditions on unitary elements imposed by the continuous functional calculus
 

--- a/Mathlib/Analysis/CstarAlgebra/ContinuousFunctionalCalculus/Unitary.lean
+++ b/Mathlib/Analysis/CstarAlgebra/ContinuousFunctionalCalculus/Unitary.lean
@@ -26,7 +26,7 @@ lemma cfc_unitary_iff (f : R → R) (a : A) (ha : p a := by cfc_tac)
     (hf : ContinuousOn f (spectrum R a) := by cfc_cont_tac) :
     cfc f a ∈ unitary A ↔ ∀ x ∈ spectrum R a, star (f x) * f x = 1 := by
   simp only [unitary, Submonoid.mem_mk, Subsemigroup.mem_mk, Set.mem_setOf_eq]
-  rw [← IsStarNormal.cfc_map (p := p) a f |>.star_comm_self |>.eq, and_self, ← cfc_one R a,
+  rw [← IsStarNormal.cfc_map (p := p) f a |>.star_comm_self |>.eq, and_self, ← cfc_one R a,
     ← cfc_star, ← cfc_mul .., cfc_eq_cfc_iff_eqOn]
   exact Iff.rfl
 

--- a/Mathlib/Analysis/CstarAlgebra/ContinuousFunctionalCalculus/Unitary.lean
+++ b/Mathlib/Analysis/CstarAlgebra/ContinuousFunctionalCalculus/Unitary.lean
@@ -31,6 +31,7 @@ lemma cfc_unitary_iff (f : R → R) (a : A) (ha : p a := by cfc_tac)
   exact Iff.rfl
 
 end Generic
+
 section Complex
 
 variable {A : Type*} [TopologicalSpace A] [Ring A] [StarRing A] [Algebra ℂ A]


### PR DESCRIPTION

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
