### PR TITLE
[Merged by Bors] - fix: allow markdown in declarations_diff

### DIFF
--- a/scripts/declarations_diff.sh
+++ b/scripts/declarations_diff.sh
@@ -165,6 +165,7 @@ printf $'<details>
 ./scripts/declarations_diff.sh long <optional_commit>
 ```
 </details>
+
 The doc-module for `script/declarations_diff.sh` contains some details about this script.'
 
  : <<ReferenceTest


### PR DESCRIPTION
This is mostly aesthetical: with the extra line break, the markdown parser kicks in, notices the backticks `` ` `` and interprets them as code.  Otherwise, it prints the literal backticks.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
