### PR TITLE
[Merged by Bors] - refactor(Topology/Category): preparation for switching to new API for limits in CompHaus

### DIFF
--- a/Mathlib/Topology/Category/CompHausLike/EffectiveEpi.lean
+++ b/Mathlib/Topology/Category/CompHausLike/EffectiveEpi.lean
@@ -3,13 +3,18 @@ Copyright (c) 2024 Dagur Asgeirsson. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Adam Topaz, Dagur Asgeirsson
 -/
-import Mathlib.CategoryTheory.Sites.Coherent.Basic
+import Mathlib.CategoryTheory.Sites.Coherent.Comparison
 import Mathlib.Topology.Category.CompHausLike.Limits
 /-!
 
 # Effective epimorphisms in `CompHausLike`
 
 In any category of compact Hausdorff spaces, continuous surjections are effective epimorphisms.
+
+We deduce that if the converse holds and explicit pullbacks exist, then `CompHausLike P` is
+preregular.
+
+If furthermore explicit finite coproducts exist, then `CompHausLike P` is precoherent.
 -/
 
 universe u
@@ -54,5 +59,11 @@ theorem preregular [HasExplicitPullbacks P]
     intro y
     obtain ⟨z, hz⟩ := hs π hπ (f y)
     exact ⟨⟨(y, z), hz.symm⟩, rfl⟩
+
+theorem precoherent [HasExplicitPullbacks P] [HasExplicitFiniteCoproducts.{0} P]
+    (hs : ∀ ⦃X Y : CompHausLike P⦄ (f : X ⟶ Y), EffectiveEpi f → Function.Surjective f) :
+    Precoherent (CompHausLike P) := by
+  have : Preregular (CompHausLike P) := preregular hs
+  infer_instance
 
 end CompHausLike

--- a/Mathlib/Topology/Category/CompHausLike/Limits.lean
+++ b/Mathlib/Topology/Category/CompHausLike/Limits.lean
@@ -13,10 +13,25 @@ import Mathlib.Topology.Category.CompHausLike.Basic
 This file collects some constructions of explicit limits and colimits in `CompHausLike P`,
 which may be useful due to their definitional properties.
 
-So far, we have the following:
-- Explicit pullbacks, defined in the "usual" way as a subset of the product.
-- Explicit finite coproducts, defined as a disjoint union.
+## Main definitions
 
+* `HasExplicitFiniteCoproducts`: A typeclass describing the property that forming all finite
+  disjoint unions is stable under the property `P`.
+  - Given this property, we deduce that `CompHausLike P` has finite coproducts and the inclusion
+    functors to other `CompHausLike P'` and to `TopCat` preserve them.
+
+* `HasExplicitPullbacks`: A typeclass describing the property that forming all "explicit pullbacks"
+  is stable under the property `P`. Here, explicit pullbacks are defined as a subset of the product.
+  - Given this property, we deduce that `CompHausLike P` has pullbacks and the inclusion
+    functors to other `CompHausLike P'` and to `TopCat` preserve them.
+  - We also define a variant `HasExplicitPullbacksOfInclusions` which is says that explicit
+    pullbacks along inclusion maps into finite disjoint unions exist. `Stonean` has this property
+    but not the stronger one.
+
+## Main results
+
+* Given `[HasExplicitPullbacksOfInclusions P]` (which is implied by `[HasExplicitPullbacks P]`),
+  we provide an instance `FinitaryExtensive (CompHausLike P)`.
 -/
 
 namespace CompHausLike


### PR DESCRIPTION



---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
