### PR TITLE
[Merged by Bors] - feat(RingTheory/Flat/Basic): if a subalgebra is flat, then it's also flat as a submodule

### DIFF
--- a/Mathlib/RingTheory/Flat/Basic.lean
+++ b/Mathlib/RingTheory/Flat/Basic.lean
@@ -74,6 +74,10 @@ the canonical map `I ⊗ M →ₗ M` is injective. -/
 
 namespace Flat
 
+variable {R} in
+instance instSubalgebraToSubmodule {S : Type v} [Ring S] [Algebra R S]
+    (A : Subalgebra R S) [Flat R A] : Flat R (Subalgebra.toSubmodule A) := ‹Flat R A›
+
 instance self (R : Type u) [CommRing R] : Flat R R :=
   ⟨by
     intro I _


### PR DESCRIPTION
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

This is suggested in https://github.com/leanprover-community/mathlib4/pull/15346#discussion_r1698051003.

I don't know if it is `easy` since it adds an instance, which may have performance impact on the whole mathlib.

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
