### PR TITLE
[Merged by Bors] - feat(CategoryTheory/Adjunction): `typeToCat` is left adjoint to `Cat.objects`

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -1339,7 +1339,6 @@ import Mathlib.CategoryTheory.Action
 import Mathlib.CategoryTheory.Adhesive
 import Mathlib.CategoryTheory.Adjunction.AdjointFunctorTheorems
 import Mathlib.CategoryTheory.Adjunction.Basic
-import Mathlib.CategoryTheory.Adjunction.Cat
 import Mathlib.CategoryTheory.Adjunction.Comma
 import Mathlib.CategoryTheory.Adjunction.Evaluation
 import Mathlib.CategoryTheory.Adjunction.FullyFaithful
@@ -1376,6 +1375,7 @@ import Mathlib.CategoryTheory.CatCommSq
 import Mathlib.CategoryTheory.Category.Basic
 import Mathlib.CategoryTheory.Category.Bipointed
 import Mathlib.CategoryTheory.Category.Cat
+import Mathlib.CategoryTheory.Category.Cat.Adjunction
 import Mathlib.CategoryTheory.Category.Cat.Limit
 import Mathlib.CategoryTheory.Category.Factorisation
 import Mathlib.CategoryTheory.Category.GaloisConnection

--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -1339,6 +1339,7 @@ import Mathlib.CategoryTheory.Action
 import Mathlib.CategoryTheory.Adhesive
 import Mathlib.CategoryTheory.Adjunction.AdjointFunctorTheorems
 import Mathlib.CategoryTheory.Adjunction.Basic
+import Mathlib.CategoryTheory.Adjunction.Cat
 import Mathlib.CategoryTheory.Adjunction.Comma
 import Mathlib.CategoryTheory.Adjunction.Evaluation
 import Mathlib.CategoryTheory.Adjunction.FullyFaithful

--- a/Mathlib/CategoryTheory/Adjunction/Cat.lean
+++ b/Mathlib/CategoryTheory/Adjunction/Cat.lean
@@ -15,6 +15,9 @@ The embedding `Type ⥤ Cat` has a right adjoint `Cat.objects` mapping
 each category to its set of objects.
 
 
+## Notes
+All this could be made with 2-functors
+
 ## TODO
 The embedding `Type ⥤ Cat` has a left adjoint `Cat.connectedComponents` mapping
 each category to its set of connected components.
@@ -46,17 +49,14 @@ private lemma linverse : Function.LeftInverse (xryTolxy X C) (lxyToxry X C) :=
         Discrete.functor_map_id (xryTolxy X C (lxyToxry X C fctr)) f
       _                                        = fctr.map f := (Discrete.functor_map_id fctr f).symm
 
-private lemma rightinverse : Function.RightInverse (xryTolxy X C) (lxyToxry X C) := fun _ ↦ by
-  fapply funext
-  intro x
-  rfl
+private lemma rightinverse : Function.RightInverse (xryTolxy X C) (lxyToxry X C) := fun _ ↦
+  funext (fun _ => rfl)
 
-private def homEquiv : ∀ X C, (typeToCat.obj X ⟶ C) ≃ (X ⟶ Cat.objects.obj C) := fun X C ↦ by
-    apply Equiv.mk
-      (lxyToxry X C)
-      (xryTolxy X C)
-      (linverse X C)
-      (rightinverse X C)
+private def homEquiv : (typeToCat.obj X ⟶ C) ≃ (X ⟶ Cat.objects.obj C) where
+      toFun:= lxyToxry X C
+      invFun:= (xryTolxy X C)
+      left_inv:=(linverse X C)
+      right_inv:= (rightinverse X C)
 
 private def counit_app : ∀ C,  (Cat.objects ⋙ typeToCat).obj C ⥤ C := fun C =>
     { obj := Discrete.as

--- a/Mathlib/CategoryTheory/Adjunction/Cat.lean
+++ b/Mathlib/CategoryTheory/Adjunction/Cat.lean
@@ -3,11 +3,8 @@ Copyright (c) 2024 Nicolas Rolland. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Nicolas Rolland
 -/
-import Mathlib.CategoryTheory.DiscreteCategory
-import Mathlib.CategoryTheory.Types
 import Mathlib.CategoryTheory.Category.Cat
 import Mathlib.CategoryTheory.Adjunction.Basic
-
 /-!
 # Adjunctions related to Cat, the category of categories
 
@@ -24,63 +21,33 @@ each category to its set of connected components.
 
 -/
 
-
-universe v u
-
+universe u
 namespace CategoryTheory
 
-section AdjDiscObj
-
-variable (X : Type u)
-variable (C : Cat)
-
-private def lxyToxry : (typeToCat.obj X ⟶ C) → (X ⟶ Cat.objects.obj C) := fun f x ↦ f.obj ⟨x⟩
-private def xryTolxy : (X ⟶ Cat.objects.obj C) → (typeToCat.obj X ⟶ C) := fun f ↦ Discrete.functor f
-
-private lemma linverse : Function.LeftInverse (xryTolxy X C) (lxyToxry X C) :=
-  fun (fctr : typeToCat.obj X ⥤ C) ↦ by
-  fapply Functor.hext
-  · intro x; rfl
-  · intro ⟨x⟩ ⟨y⟩ f
-    simp
-    obtain rfl := (Discrete.eq_of_hom f : x = y)
-    calc
-      (xryTolxy X C (lxyToxry X C fctr)).map f = 𝟙 (fctr.obj { as := x }) :=
-        Discrete.functor_map_id (xryTolxy X C (lxyToxry X C fctr)) f
-      _                                        = fctr.map f := (Discrete.functor_map_id fctr f).symm
-
-private lemma rightinverse : Function.RightInverse (xryTolxy X C) (lxyToxry X C) := fun _ ↦
-  funext (fun _ => rfl)
+variable (X : Type u) (C : Cat)
 
 private def homEquiv : (typeToCat.obj X ⟶ C) ≃ (X ⟶ Cat.objects.obj C) where
-      toFun:= lxyToxry X C
-      invFun:= (xryTolxy X C)
-      left_inv:=(linverse X C)
-      right_inv:= (rightinverse X C)
+      toFun f x := f.obj ⟨x⟩
+      invFun := Discrete.functor
+      left_inv F := Functor.ext (fun _ ↦ rfl)
+                                (fun⟨_⟩ ⟨_⟩ f => by
+                                        obtain rfl := Discrete.eq_of_hom f
+                                        simp)
+      right_inv := fun _ ↦ funext (fun _ => rfl)
 
-private def counit_app : ∀ C,  (Cat.objects ⋙ typeToCat).obj C ⥤ C := fun C =>
-    { obj := Discrete.as
-      map := eqToHom ∘ Discrete.eq_of_hom }
+private def typeToCatObjectsAdjCounitApp : (Cat.objects ⋙ typeToCat).obj C ⥤ C where
+     obj := Discrete.as
+     map := eqToHom ∘ Discrete.eq_of_hom
 
-
-/-- typeToCat : Type ⥤ Cat is left adjoint to Cat.objects : Cat ⥤ Type
--/
-def adjTypeToCatCatobjects : typeToCat ⊣ Cat.objects where
+/-- typeToCat : Type ⥤ Cat is left adjoint to Cat.objects : Cat ⥤ Type -/
+def typeToCatObjectsAdj : typeToCat ⊣ Cat.objects where
   homEquiv  := homEquiv
-  unit : 𝟭 (Type u) ⟶ typeToCat ⋙ Cat.objects := { app:= fun X  ↦ Discrete.mk }
-  counit : Cat.objects ⋙ typeToCat ⟶ 𝟭 Cat :=
-  {
-    app := counit_app
-    naturality := by intro C D (f : C ⥤ D)
-                     fapply Functor.hext
-                     · intro c
-                       rfl
-                     · intro ⟨_⟩ ⟨_⟩ f
-                       obtain rfl := Discrete.eq_of_hom f
-                       aesop_cat
-  }
-
-end AdjDiscObj
-
+  unit : 𝟭 (Type u) ⟶ typeToCat ⋙ Cat.objects := { app:= fun _  ↦ Discrete.mk }
+  counit : Cat.objects ⋙ typeToCat ⟶ 𝟭 Cat := {
+    app := typeToCatObjectsAdjCounitApp
+    naturality := fun _ _ _  ↦  Functor.hext (fun _ ↦ rfl)
+                                             (by intro ⟨_⟩ ⟨_⟩ f
+                                                 obtain rfl := Discrete.eq_of_hom f
+                                                 aesop_cat ) }
 
 end CategoryTheory

--- a/Mathlib/CategoryTheory/Adjunction/Cat.lean
+++ b/Mathlib/CategoryTheory/Adjunction/Cat.lean
@@ -28,11 +28,10 @@ variable (X : Type u) (C : Cat)
 private def homEquiv : (typeToCat.obj X ⟶ C) ≃ (X ⟶ Cat.objects.obj C) where
   toFun f x := f.obj ⟨x⟩
   invFun := Discrete.functor
-  left_inv F := Functor.ext (fun _ ↦ rfl)
-    (fun⟨_⟩ ⟨_⟩ f => by
-      obtain rfl := Discrete.eq_of_hom f
-      simp)
-  right_inv := fun _ ↦ funext (fun _ => rfl)
+  left_inv F := Functor.ext (fun _ ↦ rfl) (fun ⟨_⟩ ⟨_⟩ f => by
+    obtain rfl := Discrete.eq_of_hom f
+    simp)
+  right_inv _ := rfl
 
 private def typeToCatObjectsAdjCounitApp : (Cat.objects ⋙ typeToCat).obj C ⥤ C where
   obj := Discrete.as

--- a/Mathlib/CategoryTheory/Adjunction/Cat.lean
+++ b/Mathlib/CategoryTheory/Adjunction/Cat.lean
@@ -1,0 +1,86 @@
+/-
+Copyright (c) 2024 Nicolas Rolland. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Nicolas Rolland
+-/
+import Mathlib.CategoryTheory.DiscreteCategory
+import Mathlib.CategoryTheory.Types
+import Mathlib.CategoryTheory.Category.Cat
+import Mathlib.CategoryTheory.Adjunction.Basic
+
+/-!
+# Adjunctions related to Cat, the category of categories
+
+The embedding `Type ⥤ Cat` has a right adjoint `Cat.objects` mapping
+each category to its set of objects.
+
+
+## TODO
+The embedding `Type ⥤ Cat` has a left adjoint `Cat.connectedComponents` mapping
+each category to its set of connected components.
+
+-/
+
+
+universe v u
+
+namespace CategoryTheory
+
+section AdjDiscObj
+
+variable (X : Type u)
+variable (C : Cat)
+
+private def lxyToxry : (typeToCat.obj X ⟶ C) → (X ⟶ Cat.objects.obj C) := fun f x ↦ f.obj ⟨x⟩
+private def xryTolxy : (X ⟶ Cat.objects.obj C) → (typeToCat.obj X ⟶ C) := fun f ↦ Discrete.functor f
+
+private lemma linverse : Function.LeftInverse (xryTolxy X C) (lxyToxry X C) :=
+  fun (fctr : typeToCat.obj X ⥤ C) ↦ by
+  fapply Functor.hext
+  · intro x; rfl
+  · intro ⟨x⟩ ⟨y⟩ f
+    simp
+    obtain rfl := (Discrete.eq_of_hom f : x = y)
+    calc
+      (xryTolxy X C (lxyToxry X C fctr)).map f = 𝟙 (fctr.obj { as := x }) :=
+        Discrete.functor_map_id (xryTolxy X C (lxyToxry X C fctr)) f
+      _                                        = fctr.map f := (Discrete.functor_map_id fctr f).symm
+
+private lemma rightinverse : Function.RightInverse (xryTolxy X C) (lxyToxry X C) := fun _ ↦ by
+  fapply funext
+  intro x
+  rfl
+
+private def homEquiv : ∀ X C, (typeToCat.obj X ⟶ C) ≃ (X ⟶ Cat.objects.obj C) := fun X C ↦ by
+    apply Equiv.mk
+      (lxyToxry X C)
+      (xryTolxy X C)
+      (linverse X C)
+      (rightinverse X C)
+
+private def counit_app : ∀ C,  (Cat.objects ⋙ typeToCat).obj C ⥤ C := fun C =>
+    { obj := Discrete.as
+      map := eqToHom ∘ Discrete.eq_of_hom }
+
+
+/-- typeToCat : Type ⥤ Cat is left adjoint to Cat.objects : Cat ⥤ Type
+-/
+def adjTypeToCatCatobjects : typeToCat ⊣ Cat.objects where
+  homEquiv  := homEquiv
+  unit : 𝟭 (Type u) ⟶ typeToCat ⋙ Cat.objects := { app:= fun X  ↦ Discrete.mk }
+  counit : Cat.objects ⋙ typeToCat ⟶ 𝟭 Cat :=
+  {
+    app := counit_app
+    naturality := by intro C D (f : C ⥤ D)
+                     fapply Functor.hext
+                     · intro c
+                       rfl
+                     · intro ⟨_⟩ ⟨_⟩ f
+                       obtain rfl := Discrete.eq_of_hom f
+                       aesop_cat
+  }
+
+end AdjDiscObj
+
+
+end CategoryTheory

--- a/Mathlib/CategoryTheory/Adjunction/Cat.lean
+++ b/Mathlib/CategoryTheory/Adjunction/Cat.lean
@@ -45,8 +45,8 @@ def typeToCatObjectsAdj : typeToCat ⊣ Cat.objects where
   counit : Cat.objects ⋙ typeToCat ⟶ 𝟭 Cat := {
     app := typeToCatObjectsAdjCounitApp
     naturality := fun _ _ _  ↦  Functor.hext (fun _ ↦ rfl)
-                                             (by intro ⟨_⟩ ⟨_⟩ f
-                                                 obtain rfl := Discrete.eq_of_hom f
-                                                 aesop_cat ) }
+      (by intro ⟨_⟩ ⟨_⟩ f
+          obtain rfl := Discrete.eq_of_hom f
+          aesop_cat ) }
 
 end CategoryTheory

--- a/Mathlib/CategoryTheory/Adjunction/Cat.lean
+++ b/Mathlib/CategoryTheory/Adjunction/Cat.lean
@@ -18,7 +18,6 @@ All this could be made with 2-functors
 ## TODO
 The embedding `Type ⥤ Cat` has a left adjoint `Cat.connectedComponents` mapping
 each category to its set of connected components.
-
 -/
 
 universe u
@@ -27,17 +26,17 @@ namespace CategoryTheory
 variable (X : Type u) (C : Cat)
 
 private def homEquiv : (typeToCat.obj X ⟶ C) ≃ (X ⟶ Cat.objects.obj C) where
-      toFun f x := f.obj ⟨x⟩
-      invFun := Discrete.functor
-      left_inv F := Functor.ext (fun _ ↦ rfl)
-                                (fun⟨_⟩ ⟨_⟩ f => by
-                                        obtain rfl := Discrete.eq_of_hom f
-                                        simp)
-      right_inv := fun _ ↦ funext (fun _ => rfl)
+  toFun f x := f.obj ⟨x⟩
+  invFun := Discrete.functor
+  left_inv F := Functor.ext (fun _ ↦ rfl)
+                            (fun⟨_⟩ ⟨_⟩ f => by
+                                    obtain rfl := Discrete.eq_of_hom f
+                                    simp)
+  right_inv := fun _ ↦ funext (fun _ => rfl)
 
 private def typeToCatObjectsAdjCounitApp : (Cat.objects ⋙ typeToCat).obj C ⥤ C where
-     obj := Discrete.as
-     map := eqToHom ∘ Discrete.eq_of_hom
+  obj := Discrete.as
+  map := eqToHom ∘ Discrete.eq_of_hom
 
 /-- typeToCat : Type ⥤ Cat is left adjoint to Cat.objects : Cat ⥤ Type -/
 def typeToCatObjectsAdj : typeToCat ⊣ Cat.objects where

--- a/Mathlib/CategoryTheory/Adjunction/Cat.lean
+++ b/Mathlib/CategoryTheory/Adjunction/Cat.lean
@@ -40,8 +40,8 @@ private def typeToCatObjectsAdjCounitApp : (Cat.objects ⋙ typeToCat).obj C ⥤
 /-- typeToCat : Type ⥤ Cat is left adjoint to Cat.objects : Cat ⥤ Type -/
 def typeToCatObjectsAdj : typeToCat ⊣ Cat.objects where
   homEquiv  := homEquiv
-  unit : 𝟭 (Type u) ⟶ typeToCat ⋙ Cat.objects := { app:= fun _  ↦ Discrete.mk }
-  counit : Cat.objects ⋙ typeToCat ⟶ 𝟭 Cat := {
+  unit := { app:= fun _  ↦ Discrete.mk }
+  counit := {
     app := typeToCatObjectsAdjCounitApp
     naturality := fun _ _ _  ↦  Functor.hext (fun _ ↦ rfl)
       (by intro ⟨_⟩ ⟨_⟩ f

--- a/Mathlib/CategoryTheory/Adjunction/Cat.lean
+++ b/Mathlib/CategoryTheory/Adjunction/Cat.lean
@@ -29,9 +29,9 @@ private def homEquiv : (typeToCat.obj X ⟶ C) ≃ (X ⟶ Cat.objects.obj C) whe
   toFun f x := f.obj ⟨x⟩
   invFun := Discrete.functor
   left_inv F := Functor.ext (fun _ ↦ rfl)
-                            (fun⟨_⟩ ⟨_⟩ f => by
-                                    obtain rfl := Discrete.eq_of_hom f
-                                    simp)
+    (fun⟨_⟩ ⟨_⟩ f => by
+      obtain rfl := Discrete.eq_of_hom f
+      simp)
   right_inv := fun _ ↦ funext (fun _ => rfl)
 
 private def typeToCatObjectsAdjCounitApp : (Cat.objects ⋙ typeToCat).obj C ⥤ C where

--- a/Mathlib/CategoryTheory/Category/Cat/Adjunction.lean
+++ b/Mathlib/CategoryTheory/Category/Cat/Adjunction.lean
@@ -8,24 +8,27 @@ import Mathlib.CategoryTheory.Adjunction.Basic
 /-!
 # Adjunctions related to Cat, the category of categories
 
-The embedding `Type ⥤ Cat` has a right adjoint `Cat.objects` mapping
-each category to its set of objects.
+The embedding `typeToCat: Type ⥤ Cat`, mapping a type to the corresponding discrete category, is
+left adjoint to the functor `Cat.objects`, which maps a category to its set of objects.
+
 
 
 ## Notes
 All this could be made with 2-functors
 
 ## TODO
-The embedding `Type ⥤ Cat` has a left adjoint `Cat.connectedComponents` mapping
-each category to its set of connected components.
+
+Define the left adjoint `Cat.connectedComponents`, which map
+a category to its set of connected components.
+
 -/
 
 universe u
-namespace CategoryTheory
+namespace CategoryTheory.Cat
 
 variable (X : Type u) (C : Cat)
 
-private def homEquiv : (typeToCat.obj X ⟶ C) ≃ (X ⟶ Cat.objects.obj C) where
+private def typeToCatObjectsAdjHomEquiv : (typeToCat.obj X ⟶ C) ≃ (X ⟶ Cat.objects.obj C) where
   toFun f x := f.obj ⟨x⟩
   invFun := Discrete.functor
   left_inv F := Functor.ext (fun _ ↦ rfl) (fun ⟨_⟩ ⟨_⟩ f => by
@@ -37,9 +40,9 @@ private def typeToCatObjectsAdjCounitApp : (Cat.objects ⋙ typeToCat).obj C ⥤
   obj := Discrete.as
   map := eqToHom ∘ Discrete.eq_of_hom
 
-/-- typeToCat : Type ⥤ Cat is left adjoint to Cat.objects : Cat ⥤ Type -/
+/-- `typeToCat : Type ⥤ Cat` is left adjoint to `Cat.objects : Cat ⥤ Type` -/
 def typeToCatObjectsAdj : typeToCat ⊣ Cat.objects where
-  homEquiv  := homEquiv
+  homEquiv  := typeToCatObjectsAdjHomEquiv
   unit := { app:= fun _  ↦ Discrete.mk }
   counit := {
     app := typeToCatObjectsAdjCounitApp
@@ -48,4 +51,4 @@ def typeToCatObjectsAdj : typeToCat ⊣ Cat.objects where
           obtain rfl := Discrete.eq_of_hom f
           aesop_cat ) }
 
-end CategoryTheory
+end CategoryTheory.Cat


### PR DESCRIPTION
The embedding of `Type` into `Cat`, which views a set as a discrete category, is left adjoint to the functor `Cat.objects : Cat -> Set` mapping a category to its set of objects


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
