### PR TITLE
[Merged by Bors] - feat(Analysis/SpecialFunctions/Complex/Log): Exponential tsum is tprod

### DIFF
--- a/Mathlib/Analysis/SpecialFunctions/Complex/Log.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Complex/Log.lean
@@ -251,7 +251,7 @@ variable {α ι: Type*}
 open Real
 
 lemma Real.HasSum_rexp_HasProd  (f : ι → α → ℝ) (hfn : ∀ x n, 0 < f n x)
-    (hf : ∀ x : α, HasSum (fun n => log ((f n x))) (∑' i, log (f i x))) (a : α) :
+    (hf : ∀ x : α, HasSum (fun n => log (f n x)) (∑' i, log (f i x))) (a : α) :
        HasProd (fun b ↦ f b a) ((rexp ∘ fun a ↦ ∑' (n : ι), log (f n a)) a) := by
   apply ((hf a).rexp).congr
   intro _
@@ -262,14 +262,14 @@ lemma Real.HasSum_rexp_HasProd  (f : ι → α → ℝ) (hfn : ∀ x n, 0 < f n 
 product.-/
 lemma Real.rexp_tsum_eq_tprod (f : ι → α → ℝ) (hfn : ∀ x n, 0 < f n x)
     (hf : ∀ x : α, Summable fun n => log ((f n x))) :
-      (rexp ∘ (fun a : α => (∑' n : ι, log ((f n a))))) =
+      (rexp ∘ (fun a : α => (∑' n : ι, log (f n a)))) =
         (fun a : α => ∏' n : ι, ((f n a))) := by
   ext a
   apply (HasProd.tprod_eq ?_).symm
   apply Real.HasSum_rexp_HasProd f hfn fun a => (hf a).hasSum
 
 lemma Real.summable_cexp_multipliable (f : ι → α → ℝ) (hfn : ∀ x n, 0 < f n x)
-    (hf : ∀ x : α, Summable fun n => log ((f n x))) (a : α):
+    (hf : ∀ x : α, Summable fun n => log (f n x)) (a : α):
       Multipliable fun b ↦ f b a := by
   have := (Real.HasSum_rexp_HasProd f hfn fun a => (hf a).hasSum) a
   use ((rexp ∘ fun a ↦ ∑' (n : ι), log (f n a)) a)
@@ -277,7 +277,7 @@ lemma Real.summable_cexp_multipliable (f : ι → α → ℝ) (hfn : ∀ x n, 0 
 open Complex
 
 lemma Complex.HasSum_cexp_HasProd (f : ι → α → ℂ) (hfn : ∀ x n, f n x ≠ 0)
-    (hf : ∀ x : α, HasSum (fun n => log ((f n x))) (∑' i, log (f i x))) (a : α) :
+    (hf : ∀ x : α, HasSum (fun n => log (f n x)) (∑' i, log (f i x))) (a : α) :
        HasProd (fun b ↦ f b a) ((cexp ∘ fun a ↦ ∑' (n : ι), log (f n a)) a) := by
   apply ((hf a).cexp).congr
   intro _
@@ -285,7 +285,7 @@ lemma Complex.HasSum_cexp_HasProd (f : ι → α → ℂ) (hfn : ∀ x n, f n x 
   exact funext fun x ↦ exp_log (hfn a x)
 
 lemma Complex.summable_cexp_multipliable (f : ι → α → ℂ) (hfn : ∀ x n, f n x ≠ 0)
-    (hf : ∀ x : α, Summable fun n => log ((f n x))) (a : α):
+    (hf : ∀ x : α, Summable fun n => log (f n x)) (a : α):
       Multipliable fun b ↦ f b a := by
   have := (Complex.HasSum_cexp_HasProd f hfn fun a => (hf a).hasSum) a
   use ((cexp ∘ fun a ↦ ∑' (n : ι), log (f n a)) a)
@@ -293,8 +293,8 @@ lemma Complex.summable_cexp_multipliable (f : ι → α → ℂ) (hfn : ∀ x n,
 /--The exponential of a infinite sum of comples logs (which converges absolutely) is an infinite
 product.-/
 lemma Complex.cexp_tsum_eq_tprod (f : ι → α → ℂ) (hfn : ∀ x n, f n x ≠ 0)
-    (hf : ∀ x : α, Summable fun n => log ((f n x))) :
-      (cexp ∘ (fun a : α => (∑' n : ι, log ((f n a))))) =
+    (hf : ∀ x : α, Summable fun n => log (f n x)) :
+      (cexp ∘ (fun a : α => (∑' n : ι, log (f n a)))) =
         (fun a : α => ∏' n : ι, ((f n a))) := by
   ext a
   apply (HasProd.tprod_eq ?_).symm

--- a/Mathlib/Analysis/SpecialFunctions/Complex/Log.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Complex/Log.lean
@@ -252,52 +252,60 @@ open Real
 
 lemma Real.HasSum_rexp_HasProd  (f : ι → α → ℝ) (hfn : ∀ x n, 0 < f n x)
     (hf : ∀ x : α, HasSum (fun n => log (f n x)) (∑' i, log (f i x))) (a : α) :
-       HasProd (fun b ↦ f b a) ((rexp ∘ fun a ↦ ∑' (n : ι), log (f n a)) a) := by
-  apply ((hf a).rexp).congr
-  intro _
-  congr
-  exact funext fun x ↦ exp_log (hfn a x)
+       HasProd (fun b ↦ f b a) (∏' n : ι, (f n a)) := by
+  have : HasProd (fun b ↦ f b a) ((rexp ∘ fun a ↦ ∑' (n : ι), log (f n a)) a) := by
+    apply ((hf a).rexp).congr
+    intro _
+    congr
+    exact funext fun x ↦ exp_log (hfn a x)
+  rwa [HasProd.tprod_eq this]
+
 
 /--The exponential of a infinite sum of real logs (which converges absolutely) is an infinite
 product.-/
 lemma Real.rexp_tsum_eq_tprod (f : ι → α → ℝ) (hfn : ∀ x n, 0 < f n x)
     (hf : ∀ x : α, Summable fun n => log ((f n x))) :
-      (rexp ∘ (fun a : α => (∑' n : ι, log (f n a)))) =
-        (fun a : α => ∏' n : ι, ((f n a))) := by
+      (rexp ∘ (fun a : α => (∑' n : ι, log (f n a)))) = (fun a : α => ∏' n : ι, (f n a)) := by
   ext a
   apply (HasProd.tprod_eq ?_).symm
-  apply Real.HasSum_rexp_HasProd f hfn fun a => (hf a).hasSum
+  apply ((hf a).hasSum.rexp).congr
+  intro _
+  congr
+  exact funext fun x ↦ exp_log (hfn a x)
 
 lemma Real.summable_cexp_multipliable (f : ι → α → ℝ) (hfn : ∀ x n, 0 < f n x)
-    (hf : ∀ x : α, Summable fun n => log (f n x)) (a : α):
-      Multipliable fun b ↦ f b a := by
+    (hf : ∀ x : α, Summable fun n => log (f n x)) (a : α): Multipliable fun b ↦ f b a := by
   have := (Real.HasSum_rexp_HasProd f hfn fun a => (hf a).hasSum) a
-  use ((rexp ∘ fun a ↦ ∑' (n : ι), log (f n a)) a)
+  use (∏' n : ι, (f n a))
 
 open Complex
 
 lemma Complex.HasSum_cexp_HasProd (f : ι → α → ℂ) (hfn : ∀ x n, f n x ≠ 0)
     (hf : ∀ x : α, HasSum (fun n => log (f n x)) (∑' i, log (f i x))) (a : α) :
-       HasProd (fun b ↦ f b a) ((cexp ∘ fun a ↦ ∑' (n : ι), log (f n a)) a) := by
-  apply ((hf a).cexp).congr
-  intro _
-  congr
-  exact funext fun x ↦ exp_log (hfn a x)
+       HasProd (fun b ↦ f b a) (∏' n : ι, (f n a)) := by
+  have : HasProd (fun b ↦ f b a) ((cexp ∘ fun a ↦ ∑' (n : ι), log (f n a)) a) := by
+    apply ((hf a).cexp).congr
+    intro _
+    congr
+    exact funext fun x ↦ exp_log (hfn a x)
+  rwa [HasProd.tprod_eq this]
 
 lemma Complex.summable_cexp_multipliable (f : ι → α → ℂ) (hfn : ∀ x n, f n x ≠ 0)
     (hf : ∀ x : α, Summable fun n => log (f n x)) (a : α):
       Multipliable fun b ↦ f b a := by
   have := (Complex.HasSum_cexp_HasProd f hfn fun a => (hf a).hasSum) a
-  use ((cexp ∘ fun a ↦ ∑' (n : ι), log (f n a)) a)
+  use (∏' n : ι, (f n a))
 
 /--The exponential of a infinite sum of comples logs (which converges absolutely) is an infinite
 product.-/
 lemma Complex.cexp_tsum_eq_tprod (f : ι → α → ℂ) (hfn : ∀ x n, f n x ≠ 0)
     (hf : ∀ x : α, Summable fun n => log (f n x)) :
-      (cexp ∘ (fun a : α => (∑' n : ι, log (f n a)))) =
-        (fun a : α => ∏' n : ι, ((f n a))) := by
+      (cexp ∘ (fun a : α => (∑' n : ι, log (f n a)))) = (fun a : α => ∏' n : ι, ((f n a))) := by
   ext a
   apply (HasProd.tprod_eq ?_).symm
-  apply Complex.HasSum_cexp_HasProd f hfn fun a => (hf a).hasSum
+  apply ((hf a).hasSum.cexp).congr
+  intro _
+  congr
+  exact funext fun x ↦ exp_log (hfn a x)
 
 end tsum_tprod

--- a/Mathlib/Analysis/SpecialFunctions/Complex/Log.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Complex/Log.lean
@@ -258,19 +258,25 @@ lemma Real.HasSum_rexp_HasProd  (f : ι → α → ℝ) (hfn : ∀ x n, 0 < f n 
   congr
   exact funext fun x ↦ exp_log (hfn a x)
 
-/--The exponential of a infinite sum  of real logs (which converges absolutely) is an infinite
+/--The exponential of a infinite sum of real logs (which converges absolutely) is an infinite
 product.-/
-lemma Real.rexp_tsum_eq_tprod  (f : ι → α → ℝ) (hfn : ∀ x n, 0 < f n x)
-    (hf : ∀ x : α,  Summable fun n => log ((f n x))) :
+lemma Real.rexp_tsum_eq_tprod (f : ι → α → ℝ) (hfn : ∀ x n, 0 < f n x)
+    (hf : ∀ x : α, Summable fun n => log ((f n x))) :
       (rexp ∘ (fun a : α => (∑' n : ι, log ((f n a))))) =
         (fun a : α => ∏' n : ι, ((f n a))) := by
   ext a
   apply (HasProd.tprod_eq ?_).symm
   apply Real.HasSum_rexp_HasProd f hfn fun a => (hf a).hasSum
 
+lemma Real.summable_cexp_multipliable (f : ι → α → ℝ) (hfn : ∀ x n, 0 < f n x)
+    (hf : ∀ x : α, Summable fun n => log ((f n x))) (a : α):
+      Multipliable fun b ↦ f b a := by
+  have := (Real.HasSum_rexp_HasProd f hfn fun a => (hf a).hasSum) a
+  use ((rexp ∘ fun a ↦ ∑' (n : ι), log (f n a)) a)
+
 open Complex
 
-lemma Complex.HasSum_cexp_HasProd  (f : ι → α → ℂ) (hfn : ∀ x n, f n x ≠ 0)
+lemma Complex.HasSum_cexp_HasProd (f : ι → α → ℂ) (hfn : ∀ x n, f n x ≠ 0)
     (hf : ∀ x : α, HasSum (fun n => log ((f n x))) (∑' i, log (f i x))) (a : α) :
        HasProd (fun b ↦ f b a) ((cexp ∘ fun a ↦ ∑' (n : ι), log (f n a)) a) := by
   apply ((hf a).cexp).congr
@@ -278,10 +284,16 @@ lemma Complex.HasSum_cexp_HasProd  (f : ι → α → ℂ) (hfn : ∀ x n, f n x
   congr
   exact funext fun x ↦ exp_log (hfn a x)
 
-/--The exponential of a infinite sum  of comples logs (which converges absolutely) is an infinite
+lemma Complex.summable_cexp_multipliable (f : ι → α → ℂ) (hfn : ∀ x n, f n x ≠ 0)
+    (hf : ∀ x : α, Summable fun n => log ((f n x))) (a : α):
+      Multipliable fun b ↦ f b a := by
+  have := (Complex.HasSum_cexp_HasProd f hfn fun a => (hf a).hasSum) a
+  use ((cexp ∘ fun a ↦ ∑' (n : ι), log (f n a)) a)
+
+/--The exponential of a infinite sum of comples logs (which converges absolutely) is an infinite
 product.-/
-lemma Complex.cexp_tsum_eq_tprod  (f : ι → α → ℂ) (hfn : ∀ x n, f n x ≠ 0)
-    (hf : ∀ x : α,  Summable fun n => log ((f n x)))  :
+lemma Complex.cexp_tsum_eq_tprod (f : ι → α → ℂ) (hfn : ∀ x n, f n x ≠ 0)
+    (hf : ∀ x : α, Summable fun n => log ((f n x))) :
       (cexp ∘ (fun a : α => (∑' n : ι, log ((f n a))))) =
         (fun a : α => ∏' n : ι, ((f n a))) := by
   ext a

--- a/Mathlib/Analysis/SpecialFunctions/Complex/Log.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Complex/Log.lean
@@ -251,9 +251,9 @@ variable {α ι: Type*}
 open Real
 
 lemma Real.HasSum_rexp_HasProd  (f : ι → α → ℝ) (hfn : ∀ x n, 0 < f n x)
-    (hf : ∀ x : α,  Summable fun n => log ((f n x))) (a : α) :
+    (hf : ∀ x : α, HasSum (fun n => log ((f n x))) (∑' i, log (f i x))) (a : α) :
        HasProd (fun b ↦ f b a) ((rexp ∘ fun a ↦ ∑' (n : ι), log (f n a)) a) := by
-  apply ((hf a).hasSum.rexp).congr
+  apply ((hf a).rexp).congr
   intro _
   congr
   exact funext fun x ↦ exp_log (hfn a x)
@@ -266,14 +266,14 @@ lemma Real.rexp_tsum_eq_tprod  (f : ι → α → ℝ) (hfn : ∀ x n, 0 < f n x
         (fun a : α => ∏' n : ι, ((f n a))) := by
   ext a
   apply (HasProd.tprod_eq ?_).symm
-  apply Real.HasSum_rexp_HasProd f hfn hf a
+  apply Real.HasSum_rexp_HasProd f hfn fun a => (hf a).hasSum
 
 open Complex
 
-lemma Complex.Summable_cexp_HasProd  (f : ι → α → ℂ) (hfn : ∀ x n, f n x ≠ 0)
-    (hf : ∀ x : α,  Summable fun n => log ((f n x))) (a : α) :
+lemma Complex.HasSum_cexp_HasProd  (f : ι → α → ℂ) (hfn : ∀ x n, f n x ≠ 0)
+    (hf : ∀ x : α, HasSum (fun n => log ((f n x))) (∑' i, log (f i x))) (a : α) :
        HasProd (fun b ↦ f b a) ((cexp ∘ fun a ↦ ∑' (n : ι), log (f n a)) a) := by
-  apply ((hf a).hasSum.cexp).congr
+  apply ((hf a).cexp).congr
   intro _
   congr
   exact funext fun x ↦ exp_log (hfn a x)
@@ -286,7 +286,7 @@ lemma Complex.cexp_tsum_eq_tprod  (f : ι → α → ℂ) (hfn : ∀ x n, f n x 
         (fun a : α => ∏' n : ι, ((f n a))) := by
   ext a
   apply (HasProd.tprod_eq ?_).symm
-  apply Complex.Summable_cexp_HasProd f hfn hf a
+  apply Complex.HasSum_cexp_HasProd f hfn fun a => (hf a).hasSum
 
 
 

--- a/Mathlib/Analysis/SpecialFunctions/Complex/Log.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Complex/Log.lean
@@ -300,6 +300,4 @@ lemma Complex.cexp_tsum_eq_tprod (f : ι → α → ℂ) (hfn : ∀ x n, f n x �
   apply (HasProd.tprod_eq ?_).symm
   apply Complex.HasSum_cexp_HasProd f hfn fun a => (hf a).hasSum
 
-
-
 end tsum_tprod

--- a/Mathlib/Analysis/SpecialFunctions/Complex/Log.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Complex/Log.lean
@@ -246,12 +246,38 @@ end LogDeriv
 
 section tsum_tprod
 
-variable {α  ι: Type*}
+variable {α ι: Type*}
+
+
+lemma Real.HasSum_rexp_HasProd  (f : ι → α → ℝ) (hfn : ∀ x n, 0 < f n x)
+    (hf : ∀ x : α,  Summable fun n => log ((f n x))) :
+      (exp ∘ (fun a : α => (∑' n : ι, log ((f n a))))) =
+        (fun a : α => ∏' n : ι, ((f n a))) := by
+  ext a
+  apply (HasProd.tprod_eq ?_).symm
+  apply ((hf a).hasSum.rexp).congr
+  intro _
+  congr
+  exact funext fun x ↦ Real.exp_log (hfn a x)
+
+/--The exponential of a infinite sum  of real logs (which converges absolutely) is an infinite
+product.-/
+lemma Real.rexp_tsum_eq_tprod  (f : ι → α → ℝ) (hfn : ∀ x n, 0 < f n x)
+    (hf : ∀ x : α,  Summable fun n => log ((f n x))) :
+      (exp ∘ (fun a : α => (∑' n : ι, log ((f n a))))) =
+        (fun a : α => ∏' n : ι, ((f n a))) := by
+  ext a
+  apply (HasProd.tprod_eq ?_).symm
+  apply ((hf a).hasSum.rexp).congr
+  intro _
+  congr
+  exact funext fun x ↦ Real.exp_log (hfn a x)
 
 open Complex in
 
-/--The exponential of a infinite sum  of logs (which converges absolutely) is an infinite product.-/
-lemma cexp_tsum_eq_tprod  (f : ι → α → ℂ) (hfn : ∀ x n, f n x ≠ 0)
+/--The exponential of a infinite sum  of comples logs (which converges absolutely) is an infinite
+product.-/
+lemma Complex.cexp_tsum_eq_tprod  (f : ι → α → ℂ) (hfn : ∀ x n, f n x ≠ 0)
     (hf : ∀ x : α,  Summable fun n => log ((f n x))) :
       (cexp ∘ (fun a : α => (∑' n : ι, log ((f n a))))) =
         (fun a : α => ∏' n : ι, ((f n a))) := by
@@ -261,5 +287,7 @@ lemma cexp_tsum_eq_tprod  (f : ι → α → ℂ) (hfn : ∀ x n, f n x ≠ 0)
   intro _
   congr
   exact funext fun x ↦ exp_log (hfn a x)
+
+
 
 end tsum_tprod

--- a/Mathlib/Analysis/SpecialFunctions/Complex/Log.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Complex/Log.lean
@@ -248,45 +248,45 @@ section tsum_tprod
 
 variable {α ι: Type*}
 
+open Real
 
 lemma Real.HasSum_rexp_HasProd  (f : ι → α → ℝ) (hfn : ∀ x n, 0 < f n x)
-    (hf : ∀ x : α,  Summable fun n => log ((f n x))) :
-      (exp ∘ (fun a : α => (∑' n : ι, log ((f n a))))) =
-        (fun a : α => ∏' n : ι, ((f n a))) := by
-  ext a
-  apply (HasProd.tprod_eq ?_).symm
+    (hf : ∀ x : α,  Summable fun n => log ((f n x))) (a : α) :
+       HasProd (fun b ↦ f b a) ((rexp ∘ fun a ↦ ∑' (n : ι), log (f n a)) a) := by
   apply ((hf a).hasSum.rexp).congr
   intro _
   congr
-  exact funext fun x ↦ Real.exp_log (hfn a x)
+  exact funext fun x ↦ exp_log (hfn a x)
 
 /--The exponential of a infinite sum  of real logs (which converges absolutely) is an infinite
 product.-/
 lemma Real.rexp_tsum_eq_tprod  (f : ι → α → ℝ) (hfn : ∀ x n, 0 < f n x)
     (hf : ∀ x : α,  Summable fun n => log ((f n x))) :
-      (exp ∘ (fun a : α => (∑' n : ι, log ((f n a))))) =
+      (rexp ∘ (fun a : α => (∑' n : ι, log ((f n a))))) =
         (fun a : α => ∏' n : ι, ((f n a))) := by
   ext a
   apply (HasProd.tprod_eq ?_).symm
-  apply ((hf a).hasSum.rexp).congr
-  intro _
-  congr
-  exact funext fun x ↦ Real.exp_log (hfn a x)
+  apply Real.HasSum_rexp_HasProd f hfn hf a
 
-open Complex in
+open Complex
 
-/--The exponential of a infinite sum  of comples logs (which converges absolutely) is an infinite
-product.-/
-lemma Complex.cexp_tsum_eq_tprod  (f : ι → α → ℂ) (hfn : ∀ x n, f n x ≠ 0)
-    (hf : ∀ x : α,  Summable fun n => log ((f n x))) :
-      (cexp ∘ (fun a : α => (∑' n : ι, log ((f n a))))) =
-        (fun a : α => ∏' n : ι, ((f n a))) := by
-  ext a
-  apply (HasProd.tprod_eq ?_).symm
+lemma Complex.Summable_cexp_HasProd  (f : ι → α → ℂ) (hfn : ∀ x n, f n x ≠ 0)
+    (hf : ∀ x : α,  Summable fun n => log ((f n x))) (a : α) :
+       HasProd (fun b ↦ f b a) ((cexp ∘ fun a ↦ ∑' (n : ι), log (f n a)) a) := by
   apply ((hf a).hasSum.cexp).congr
   intro _
   congr
   exact funext fun x ↦ exp_log (hfn a x)
+
+/--The exponential of a infinite sum  of comples logs (which converges absolutely) is an infinite
+product.-/
+lemma Complex.cexp_tsum_eq_tprod  (f : ι → α → ℂ) (hfn : ∀ x n, f n x ≠ 0)
+    (hf : ∀ x : α,  Summable fun n => log ((f n x)))  :
+      (cexp ∘ (fun a : α => (∑' n : ι, log ((f n a))))) =
+        (fun a : α => ∏' n : ι, ((f n a))) := by
+  ext a
+  apply (HasProd.tprod_eq ?_).symm
+  apply Complex.Summable_cexp_HasProd f hfn hf a
 
 
 

--- a/Mathlib/Analysis/SpecialFunctions/Complex/Log.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Complex/Log.lean
@@ -251,10 +251,10 @@ variable {α  ι: Type*}
 open Complex in
 
 /--The exponential of a infinite sum  of logs (which converges absolutely) is an infinite product.-/
-lemma cexp_tsum_eq_tprod  (f : ι → α → ℂ) (hfn : ∀ x n, 1 + f n x ≠ 0)
-  (hf : ∀ x : α,  Summable fun n => log (1 + (f n x))) :
-    (cexp ∘ (fun a : α => (∑' n : ι, log (1 + (f n a))))) =
-      (fun a : α => ∏' n : ι, (1 + (f n a))) := by
+lemma cexp_tsum_eq_tprod  (f : ι → α → ℂ) (hfn : ∀ x n, f n x ≠ 0)
+  (hf : ∀ x : α,  Summable fun n => log ((f n x))) :
+    (cexp ∘ (fun a : α => (∑' n : ι, log ((f n a))))) =
+      (fun a : α => ∏' n : ι, ((f n a))) := by
   ext a
   apply (HasProd.tprod_eq ?_).symm
   apply ((hf a).hasSum.cexp).congr

--- a/Mathlib/Analysis/SpecialFunctions/Complex/Log.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Complex/Log.lean
@@ -243,3 +243,23 @@ theorem _root_.Continuous.clog {f : α → ℂ} (h₁ : Continuous f)
   continuous_iff_continuousAt.2 fun x => h₁.continuousAt.clog (h₂ x)
 
 end LogDeriv
+
+section tsum_tprod
+
+variable {α  ι: Type*}
+
+open Complex in
+
+/--The exponential of a infinite sum  of logs (which converges absolutely) is an infinite product.-/
+lemma cexp_tsum_eq_tprod  (f : ι → α → ℂ) (hfn : ∀ x n, 1 + f n x ≠ 0)
+  (hf : ∀ x : α,  Summable fun n => log (1 + (f n x))) :
+    (cexp ∘ (fun a : α => (∑' n : ι, log (1 + (f n a))))) =
+      (fun a : α => ∏' n : ι, (1 + (f n a))) := by
+  ext a
+  apply (HasProd.tprod_eq ?_).symm
+  apply ((hf a).hasSum.cexp).congr
+  intro _
+  congr
+  exact funext fun x ↦ exp_log (hfn a x)
+
+end tsum_tprod

--- a/Mathlib/Analysis/SpecialFunctions/Complex/Log.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Complex/Log.lean
@@ -252,9 +252,9 @@ open Complex in
 
 /--The exponential of a infinite sum  of logs (which converges absolutely) is an infinite product.-/
 lemma cexp_tsum_eq_tprod  (f : ι → α → ℂ) (hfn : ∀ x n, f n x ≠ 0)
-  (hf : ∀ x : α,  Summable fun n => log ((f n x))) :
-    (cexp ∘ (fun a : α => (∑' n : ι, log ((f n a))))) =
-      (fun a : α => ∏' n : ι, ((f n a))) := by
+    (hf : ∀ x : α,  Summable fun n => log ((f n x))) :
+      (cexp ∘ (fun a : α => (∑' n : ι, log ((f n a))))) =
+        (fun a : α => ∏' n : ι, ((f n a))) := by
   ext a
   apply (HasProd.tprod_eq ?_).symm
   apply ((hf a).hasSum.cexp).congr


### PR DESCRIPTION
Taking cexp of an infinite sum of logs gives a tprod.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
