### PR TITLE
[Merged by Bors] - feat(Analysis/SpecialFunctions/Exp): cexp is uniformlyContinuousOn

### DIFF
--- a/Mathlib/Analysis/SpecialFunctions/Exp.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Exp.lean
@@ -117,7 +117,7 @@ theorem ContinuousOn.cexp (h : ContinuousOn f s) : ContinuousOn (fun y => exp (f
 theorem Continuous.cexp (h : Continuous f) : Continuous fun y => exp (f y) :=
   continuous_iff_continuousAt.2 fun _ => h.continuousAt.cexp
 
-/--The complex exponential function is uniformly continuous on left half planes. -/
+/-- The complex exponential function is uniformly continuous on left half planes. -/
 lemma UniformlyContinuousOn.cexp (a : ℝ) : UniformContinuousOn exp {x : ℂ | x.re ≤ a} := by
   have : Continuous (cexp - 1) := Continuous.sub (Continuous.cexp continuous_id') continuous_one
   rw [Metric.uniformContinuousOn_iff, Metric.continuous_iff'] at *

--- a/Mathlib/Analysis/SpecialFunctions/Exp.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Exp.lean
@@ -117,6 +117,37 @@ theorem ContinuousOn.cexp (h : ContinuousOn f s) : ContinuousOn (fun y => exp (f
 theorem Continuous.cexp (h : Continuous f) : Continuous fun y => exp (f y) :=
   continuous_iff_continuousAt.2 fun _ => h.continuousAt.cexp
 
+/--The complex exponential function is uniformly continuous on left half planes. -/
+lemma UniformlyContinuosOn_cexp (a : ℝ) : UniformContinuousOn cexp {x : ℂ | x.re ≤ a} := by
+  have : Continuous (cexp - 1) := Continuous.sub (Continuous.cexp continuous_id') continuous_one
+  rw [Metric.uniformContinuousOn_iff, Metric.continuous_iff'] at *
+  intro ε hε
+  simp only [gt_iff_lt, Pi.sub_apply, Pi.one_apply, dist_sub_eq_dist_add_right,
+    sub_add_cancel] at this
+  have ha : 0 < ε / (2 * Real.exp a) := by positivity
+  have H := this 0 (ε / (2 * Real.exp a)) ha
+  rw [Metric.eventually_nhds_iff] at H
+  obtain ⟨δ, hδ⟩ := H
+  refine ⟨δ, hδ.1, ?_⟩
+  intros x _ y hy hxy
+  have h3 := hδ.2 (y := x - y) (by simpa only [dist_zero_right, norm_eq_abs] using hxy)
+  rw [dist_eq_norm, exp_zero] at *
+  have : cexp x - cexp y = cexp y * (cexp (x - y) - 1) := by
+      rw [@mul_sub_one, ← exp_add]
+      ring_nf
+  rw [this, mul_comm]
+  have hya : ‖cexp y‖ ≤ Real.exp a := by
+    simp only [norm_eq_abs, abs_exp, Real.exp_le_exp]
+    exact hy
+  simp only [gt_iff_lt, dist_zero_right, norm_eq_abs, Set.mem_setOf_eq, norm_mul,
+    Complex.abs_exp] at *
+  apply lt_of_le_of_lt (mul_le_mul h3.le hya (Real.exp_nonneg y.re) (le_of_lt ha))
+  have hrr : ε / (2 * a.exp) * a.exp = ε / 2 := by
+    nth_rw 2 [mul_comm]
+    field_simp [mul_assoc]
+  rw [hrr]
+  exact div_two_lt_of_pos hε
+
 end ComplexContinuousExpComp
 
 namespace Real

--- a/Mathlib/Analysis/SpecialFunctions/Exp.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Exp.lean
@@ -118,7 +118,7 @@ theorem Continuous.cexp (h : Continuous f) : Continuous fun y => exp (f y) :=
   continuous_iff_continuousAt.2 fun _ => h.continuousAt.cexp
 
 /--The complex exponential function is uniformly continuous on left half planes. -/
-lemma UniformlyContinuosOn_cexp (a : ℝ) : UniformContinuousOn cexp {x : ℂ | x.re ≤ a} := by
+lemma UniformlyContinuosOn_cexp (a : ℝ) : UniformContinuousOn exp {x : ℂ | x.re ≤ a} := by
   have : Continuous (cexp - 1) := Continuous.sub (Continuous.cexp continuous_id') continuous_one
   rw [Metric.uniformContinuousOn_iff, Metric.continuous_iff'] at *
   intro ε hε

--- a/Mathlib/Analysis/SpecialFunctions/Exp.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Exp.lean
@@ -118,7 +118,7 @@ theorem Continuous.cexp (h : Continuous f) : Continuous fun y => exp (f y) :=
   continuous_iff_continuousAt.2 fun _ => h.continuousAt.cexp
 
 /--The complex exponential function is uniformly continuous on left half planes. -/
-lemma UniformlyContinuosOn_cexp (a : ℝ) : UniformContinuousOn exp {x : ℂ | x.re ≤ a} := by
+lemma UniformlyContinuousOn.cexp (a : ℝ) : UniformContinuousOn exp {x : ℂ | x.re ≤ a} := by
   have : Continuous (cexp - 1) := Continuous.sub (Continuous.cexp continuous_id') continuous_one
   rw [Metric.uniformContinuousOn_iff, Metric.continuous_iff'] at *
   intro ε hε
@@ -133,7 +133,7 @@ lemma UniformlyContinuosOn_cexp (a : ℝ) : UniformContinuousOn exp {x : ℂ | x
   have h3 := hδ.2 (y := x - y) (by simpa only [dist_zero_right, norm_eq_abs] using hxy)
   rw [dist_eq_norm, exp_zero] at *
   have : cexp x - cexp y = cexp y * (cexp (x - y) - 1) := by
-      rw [@mul_sub_one, ← exp_add]
+      rw [mul_sub_one, ← exp_add]
       ring_nf
   rw [this, mul_comm]
   have hya : ‖cexp y‖ ≤ Real.exp a := by


### PR DESCRIPTION
We show that the complex exponential is uniformly continuous on left half planes.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
