### PR TITLE
feat(RelSeries): replaceLast

### DIFF
--- a/Mathlib/Order/RelSeries.lean
+++ b/Mathlib/Order/RelSeries.lean
@@ -219,6 +219,12 @@ lemma head_mem (x : RelSeries r) : x.head ∈ x := ⟨_, rfl⟩
 
 lemma last_mem (x : RelSeries r) : x.last ∈ x := ⟨_, rfl⟩
 
+@[simp]
+lemma head_singleton {r : Rel α α} (x : α) : (singleton r x).head = x := by simp [singleton, head]
+
+@[simp]
+lemma last_singleton {r : Rel α α} (x : α) : (singleton r x).last = x := by simp [singleton, last]
+
 end
 
 variable {r s}

--- a/Mathlib/Order/RelSeries.lean
+++ b/Mathlib/Order/RelSeries.lean
@@ -657,6 +657,31 @@ noncomputable def comap (p : LTSeries β) (f : α → β)
   LTSeries α := mk p.length (fun i ↦ (surjective (p i)).choose)
     (fun i j h ↦ comap (by simpa only [(surjective _).choose_spec] using p.strictMono h))
 
+/--
+Replaces the last element in a series with a (non-strictly) larger element.
+Essentially `p.eraseLast.snoc x`, but also works when `p` is a singleton.
+-/
+def replaceLast [Preorder α] (p : LTSeries α) (x : α) (h : p.last ≤ x) :
+    LTSeries α :=
+  if hlen : p.length = 0
+  then RelSeries.singleton _ x
+  else p.eraseLast.snoc x (by
+    apply lt_of_lt_of_le
+    · apply p.step ⟨p.length - 1, by omega⟩
+    · convert h
+      simp only [Fin.succ_mk, Nat.succ_eq_add_one, RelSeries.last, Fin.last]
+      congr; omega)
+
+@[simp]
+lemma last_replaceLast [Preorder α] (p : LTSeries α) (x : α) (h : p.last ≤ x) :
+    (p.replaceLast x h).last = x := by
+  unfold replaceLast; split <;> simp
+
+@[simp]
+lemma length_replaceLast [Preorder α] (p : LTSeries α) (x : α) (h : p.last ≤ x) :
+    (p.replaceLast x h).length = p.length := by
+  unfold replaceLast; split <;> (simp;omega)
+
 end LTSeries
 
 end LTSeries


### PR DESCRIPTION
Replaces the last element in a series with a (non-strictly) larger element.
Essentially `p.eraseLast.snoc x`, but also works when `p` is a singleton.

From the Carleson project.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]

-->

- [ ] depends on: #15384

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
