### PR TITLE
[Merged by Bors] - feat: add `OrderedSMul ℝ A` instance for `StarOrderedRing A`

### DIFF
--- a/Mathlib/Analysis/RCLike/Basic.lean
+++ b/Mathlib/Analysis/RCLike/Basic.lean
@@ -813,6 +813,11 @@ lemma _root_.StarModule.instOrderedSMul {A : Type*} [NonUnitalRing A] [StarRing 
       StarModule.smul_lt_smul_of_pos hxy (RCLike.inv_pos_of_pos hc)
     simpa [smul_smul, inv_mul_cancel hc.ne'] using this
 
+instance {A : Type*} [NonUnitalRing A] [StarRing A] [PartialOrder A] [StarOrderedRing A]
+    [Module ℝ A] [StarModule ℝ A] [IsScalarTower ℝ A A] [SMulCommClass ℝ A A] :
+    OrderedSMul ℝ A :=
+  StarModule.instOrderedSMul
+
 scoped[ComplexOrder] attribute [instance] StarModule.instOrderedSMul
 
 end Order


### PR DESCRIPTION
This instance is already available in the scope `ComplexOrder`, but for `ℝ` that is unnecesary, so we make it a global instance.

This instance could be moved earlier (so that we don't make use of `RCLike`), but it's probably not that important to do so.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
