### PR TITLE
[Merged by Bors] - feat(IntermediateValue): add `IsFixedPt` corollaries

### DIFF
--- a/Mathlib/Dynamics/FixedPoints/Basic.lean
+++ b/Mathlib/Dynamics/FixedPoints/Basic.lean
@@ -33,10 +33,6 @@ namespace Function
 
 open Function (Commute)
 
-/-- A point `x` is a fixed point of `f : α → α` if `f x = x`. -/
-def IsFixedPt (f : α → α) (x : α) :=
-  f x = x
-
 /-- Every point is a fixed point of `id`. -/
 theorem isFixedPt_id (x : α) : IsFixedPt id x :=
   (rfl : _)

--- a/Mathlib/Logic/Function/Defs.lean
+++ b/Mathlib/Logic/Function/Defs.lean
@@ -202,4 +202,7 @@ protected theorem LeftInverse.id {g : β → α} {f : α → β} (h : LeftInvers
 protected theorem RightInverse.id {g : β → α} {f : α → β} (h : RightInverse g f) : f ∘ g = id :=
   funext h
 
+/-- A point `x` is a fixed point of `f : α → α` if `f x = x`. -/
+def IsFixedPt (f : α → α) (x : α) := f x = x
+
 end Function

--- a/Mathlib/Topology/Order/IntermediateValue.lean
+++ b/Mathlib/Topology/Order/IntermediateValue.lean
@@ -43,8 +43,7 @@ intermediate value theorem, connected space, connected set
 
 
 open Filter OrderDual TopologicalSpace Function Set
-
-open Topology Filter
+open scoped Topology Filter Interval
 
 universe u v w
 
@@ -56,7 +55,6 @@ and `g` are two functions continuous on a preconnected set `s`, `f a ≤ g a` at
 `g b ≤ f b` at some `b ∈ s`, then `f c = g c` at some `c ∈ s`. We prove several versions of this
 statement, including the classical IVT that corresponds to a constant function `g`.
 -/
-
 
 section
 
@@ -375,12 +373,12 @@ theorem isPreconnected_Icc : IsPreconnected (Icc a b) :=
         rw [union_comm s t] at hab
         exact isPreconnected_Icc_aux y x t s h ht hs hab hy hx)
 
-theorem isPreconnected_uIcc : IsPreconnected (uIcc a b) :=
+theorem isPreconnected_uIcc : IsPreconnected ([[a, b]]) :=
   isPreconnected_Icc
 
 theorem Set.OrdConnected.isPreconnected {s : Set α} (h : s.OrdConnected) : IsPreconnected s :=
   isPreconnected_of_forall_pair fun x hx y hy =>
-    ⟨uIcc x y, h.uIcc_subset hx hy, left_mem_uIcc, right_mem_uIcc, isPreconnected_uIcc⟩
+    ⟨[[x, y]], h.uIcc_subset hx hy, left_mem_uIcc, right_mem_uIcc, isPreconnected_uIcc⟩
 
 theorem isPreconnected_iff_ordConnected {s : Set α} : IsPreconnected s ↔ OrdConnected s :=
   ⟨IsPreconnected.ordConnected, Set.OrdConnected.isPreconnected⟩
@@ -486,9 +484,31 @@ theorem intermediate_value_Icc' {a b : α} (hab : a ≤ b) {f : α → δ}
   isPreconnected_Icc.intermediate_value (right_mem_Icc.2 hab) (left_mem_Icc.2 hab) hf
 
 /-- **Intermediate Value Theorem** for continuous functions on closed intervals, unordered case. -/
-theorem intermediate_value_uIcc {a b : α} {f : α → δ} (hf : ContinuousOn f (uIcc a b)) :
-    uIcc (f a) (f b) ⊆ f '' uIcc a b := by
+theorem intermediate_value_uIcc {a b : α} {f : α → δ} (hf : ContinuousOn f [[a, b]]) :
+    [[f a, f b]] ⊆ f '' uIcc a b := by
   cases le_total (f a) (f b) <;> simp [*, isPreconnected_uIcc.intermediate_value]
+
+/-- If `f : α → α` is continuous on `[[a, b]]`, `a ≤ f a`, and `f b ≤ b`,
+then `f` has a fixed point on `[[a, b]]`. -/
+theorem exists_mem_uIcc_isFixedPt {a b : α} {f : α → α} (hf : ContinuousOn f (uIcc a b))
+    (ha : a ≤ f a) (hb : f b ≤ b) : ∃ c ∈ [[a, b]], IsFixedPt f c :=
+  isPreconnected_uIcc.intermediate_value₂ right_mem_uIcc left_mem_uIcc hf continuousOn_id hb ha
+
+/-- If `f : α → α` is continuous on `[a, b]`, `a ≤ b`, `a ≤ f a`, and `f b ≤ b`,
+then `f` has a fixed point on `[a, b]`.
+
+In particular, if `[a, b]` is forward-invariant under `f`,
+then `f` has a fixed point on `[a, b]`, see `exists_mem_Icc_isFixedPt_of_mapsTo`. -/
+theorem exists_mem_Icc_isFixedPt {a b : α} {f : α → α} (hf : ContinuousOn f (Icc a b))
+    (hle : a ≤ b) (ha : a ≤ f a) (hb : f b ≤ b) : ∃ c ∈ Icc a b, IsFixedPt f c :=
+  isPreconnected_Icc.intermediate_value₂
+    (right_mem_Icc.2 hle) (left_mem_Icc.2 hle) hf continuousOn_id hb ha
+
+/-- If a closed interval is forward-invariant under a continuous map `f : α → α`,
+then this map has a fixed point on this interval. -/
+theorem exists_mem_Icc_isFixedPt_of_mapsTo {a b : α} {f : α → α} (hf : ContinuousOn f (Icc a b))
+    (hle : a ≤ b) (hmaps : MapsTo f (Icc a b) (Icc a b)) : ∃ c ∈ Icc a b, IsFixedPt f c :=
+  exists_mem_Icc_isFixedPt hf hle (hmaps <| left_mem_Icc.2 hle).1 (hmaps <| right_mem_Icc.2 hle).2
 
 theorem intermediate_value_Ico {a b : α} (hab : a ≤ b) {f : α → δ} (hf : ContinuousOn f (Icc a b)) :
     Ico (f a) (f b) ⊆ f '' Ico a b :=


### PR DESCRIPTION
Motivated by https://github.com/b-mehta/sharkovsky

Also move the definition of `Function.IsFixedPt` to `Logic/Function/Defs`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)