### PR TITLE
[Merged by Bors] - chore: backports for leanprover/lean4#4814 (part 14)

### DIFF
--- a/Mathlib/Algebra/MonoidAlgebra/Degree.lean
+++ b/Mathlib/Algebra/MonoidAlgebra/Degree.lean
@@ -204,7 +204,7 @@ variable [Semiring R] [Ring R']
 
 section SupDegree
 
-variable [AddZeroClass A] [SemilatticeSup B] [Add B] [OrderBot B] (D : A → B)
+variable [SemilatticeSup B] [OrderBot B] (D : A → B)
 
 /-- Let `R` be a semiring, let `A` be an `AddZeroClass`, let `B` be an `OrderBot`,
 and let `D : A → B` be a "degree" function.
@@ -243,7 +243,12 @@ theorem supDegree_single (a : A) (r : R) :
     (single a r).supDegree D = if r = 0 then ⊥ else D a := by
   split_ifs with hr <;> simp [supDegree_single_ne_zero, hr]
 
-variable {p q : R[A]}
+theorem apply_eq_zero_of_not_le_supDegree {p : R[A]} {a : A} (hlt : ¬ D a ≤ p.supDegree D) :
+    p a = 0 := by
+  contrapose! hlt
+  exact Finset.le_sup (Finsupp.mem_support_iff.2 hlt)
+
+variable [AddZeroClass A] {p q : R[A]}
 
 @[simp]
 theorem supDegree_zero : (0 : R[A]).supDegree D = ⊥ := by simp [supDegree]
@@ -253,11 +258,7 @@ theorem ne_zero_of_supDegree_ne_bot : p.supDegree D ≠ ⊥ → p ≠ 0 := mt (f
 theorem ne_zero_of_not_supDegree_le {b : B} (h : ¬ p.supDegree D ≤ b) : p ≠ 0 :=
   ne_zero_of_supDegree_ne_bot (fun he => h <| he ▸ bot_le)
 
-theorem apply_eq_zero_of_not_le_supDegree {a : A} (hlt : ¬ D a ≤ p.supDegree D) : p a = 0 := by
-  contrapose! hlt
-  exact Finset.le_sup (Finsupp.mem_support_iff.2 hlt)
-
-variable (hadd : ∀ a1 a2, D (a1 + a2) = D a1 + D a2)
+variable [Add B] (hadd : ∀ a1 a2, D (a1 + a2) = D a1 + D a2)
 
 theorem supDegree_mul_le [CovariantClass B B (· + ·) (· ≤ ·)]
     [CovariantClass B B (Function.swap (· + ·)) (· ≤ ·)] :

--- a/Mathlib/Algebra/Star/Subalgebra.lean
+++ b/Mathlib/Algebra/Star/Subalgebra.lean
@@ -653,7 +653,8 @@ variable {F R A B : Type*} [CommSemiring R] [StarRing R]
 variable [Semiring A] [Algebra R A] [StarRing A]
 variable [Semiring B] [Algebra R B] [StarRing B]
 
-section variable [StarModule R A]
+section
+variable [StarModule R A]
 
 theorem ext_adjoin {s : Set A} [FunLike F (adjoin R s) B]
     [AlgHomClass F R (adjoin R s) B] [StarAlgHomClass F R (adjoin R s) B] {f g : F}

--- a/Mathlib/Algebra/Star/Subalgebra.lean
+++ b/Mathlib/Algebra/Star/Subalgebra.lean
@@ -650,30 +650,10 @@ namespace StarAlgHom
 open StarSubalgebra StarAlgebra
 
 variable {F R A B : Type*} [CommSemiring R] [StarRing R]
-variable [Semiring A] [Algebra R A] [StarRing A] [StarModule R A]
-variable [Semiring B] [Algebra R B] [StarRing B] [StarModule R B]
-variable [FunLike F A B] [AlgHomClass F R A B] [StarAlgHomClass F R A B] (f g : F)
+variable [Semiring A] [Algebra R A] [StarRing A]
+variable [Semiring B] [Algebra R B] [StarRing B]
 
-/-- The equalizer of two star `R`-algebra homomorphisms. -/
-def equalizer : StarSubalgebra R A :=
-  { toSubalgebra := AlgHom.equalizer (f : A →ₐ[R] B) g
-    star_mem' := @fun a (ha : f a = g a) => by simpa only [← map_star] using congrArg star ha }
--- Porting note: much like `StarSubalgebra.copy` the old proof was broken and hard to fix
-
-@[simp]
-theorem mem_equalizer (x : A) : x ∈ StarAlgHom.equalizer f g ↔ f x = g x :=
-  Iff.rfl
-
-theorem adjoin_le_equalizer {s : Set A} (h : s.EqOn f g) : adjoin R s ≤ StarAlgHom.equalizer f g :=
-  adjoin_le h
-
-theorem ext_of_adjoin_eq_top {s : Set A} (h : adjoin R s = ⊤) ⦃f g : F⦄ (hs : s.EqOn f g) : f = g :=
-  DFunLike.ext f g fun _x => StarAlgHom.adjoin_le_equalizer f g hs <| h.symm ▸ trivial
-
-theorem map_adjoin (f : A →⋆ₐ[R] B) (s : Set A) :
-    map f (adjoin R s) = adjoin R (f '' s) :=
-  GaloisConnection.l_comm_of_u_comm Set.image_preimage (gc_map_comap f) StarAlgebra.gc
-    StarAlgebra.gc fun _ => rfl
+section variable [StarModule R A]
 
 theorem ext_adjoin {s : Set A} [FunLike F (adjoin R s) B]
     [AlgHomClass F R (adjoin R s) B] [StarAlgHomClass F R (adjoin R s) B] {f g : F}
@@ -696,6 +676,32 @@ theorem ext_adjoin_singleton {a : A} [FunLike F (adjoin R ({a} : Set A)) B]
           Subtype.ext <| Set.mem_singleton_iff.mp hx).symm ▸
       h
 
+variable [FunLike F A B] [AlgHomClass F R A B] [StarAlgHomClass F R A B] (f g : F)
+
+/-- The equalizer of two star `R`-algebra homomorphisms. -/
+def equalizer : StarSubalgebra R A :=
+  { toSubalgebra := AlgHom.equalizer (f : A →ₐ[R] B) g
+    star_mem' := @fun a (ha : f a = g a) => by simpa only [← map_star] using congrArg star ha }
+-- Porting note: much like `StarSubalgebra.copy` the old proof was broken and hard to fix
+
+@[simp]
+theorem mem_equalizer (x : A) : x ∈ StarAlgHom.equalizer f g ↔ f x = g x :=
+  Iff.rfl
+
+theorem adjoin_le_equalizer {s : Set A} (h : s.EqOn f g) : adjoin R s ≤ StarAlgHom.equalizer f g :=
+  adjoin_le h
+
+theorem ext_of_adjoin_eq_top {s : Set A} (h : adjoin R s = ⊤) ⦃f g : F⦄ (hs : s.EqOn f g) : f = g :=
+  DFunLike.ext f g fun _x => StarAlgHom.adjoin_le_equalizer f g hs <| h.symm ▸ trivial
+
+
+variable [StarModule R B]
+
+theorem map_adjoin (f : A →⋆ₐ[R] B) (s : Set A) :
+    map f (adjoin R s) = adjoin R (f '' s) :=
+  GaloisConnection.l_comm_of_u_comm Set.image_preimage (gc_map_comap f) StarAlgebra.gc
+    StarAlgebra.gc fun _ => rfl
+
 /-- Range of a `StarAlgHom` as a star subalgebra. -/
 protected def range
     (φ : A →⋆ₐ[R] B) : StarSubalgebra R B where
@@ -706,6 +712,9 @@ theorem range_eq_map_top (φ : A →⋆ₐ[R] B) : φ.range = (⊤ : StarSubalge
   StarSubalgebra.ext fun x =>
     ⟨by rintro ⟨a, ha⟩; exact ⟨a, by simp, ha⟩, by rintro ⟨a, -, ha⟩; exact ⟨a, ha⟩⟩
 
+end
+
+variable [StarModule R B]
 /-- Restriction of the codomain of a `StarAlgHom` to a star subalgebra containing the range. -/
 protected def codRestrict (f : A →⋆ₐ[R] B) (S : StarSubalgebra R B) (hf : ∀ x, f x ∈ S) :
     A →⋆ₐ[R] S where

--- a/Mathlib/LinearAlgebra/Dimension/Basic.lean
+++ b/Mathlib/LinearAlgebra/Dimension/Basic.lean
@@ -66,10 +66,9 @@ lemma nonempty_linearIndependent_set : Nonempty {s : Set M // LinearIndependent 
 
 end
 
-variable [Ring R] [Ring R'] [AddCommGroup M] [AddCommGroup M'] [AddCommGroup M₁]
-variable [Module R M] [Module R M'] [Module R M₁] [Module R' M'] [Module R' M₁]
 
 namespace LinearIndependent
+variable [Ring R] [AddCommGroup M] [Module R M]
 
 variable [Nontrivial R]
 
@@ -106,6 +105,10 @@ alias cardinal_le_rank_of_linearIndependent' := LinearIndependent.cardinal_le_ra
 section SurjectiveInjective
 
 section Module
+variable [Ring R] [AddCommGroup M] [Module R M] [Ring R']
+
+section
+variable [AddCommGroup M'] [Module R' M']
 
 /-- If `M / R` and `M' / R'` are modules, `i : R' → R` is a map which sends non-zero elements to
 non-zero elements, `j : M →+ M'` is an injective group homomorphism, such that the scalar
@@ -144,6 +147,10 @@ theorem lift_rank_eq_of_equiv_equiv (i : ZeroHom R R') (j : M ≃+ M')
   (lift_rank_le_of_surjective_injective i j hi.2 j.injective hc).antisymm <|
     lift_rank_le_of_injective_injective i j.symm (fun _ _ ↦ hi.1 <| by rwa [i.map_zero])
       j.symm.injective fun _ _ ↦ j.symm_apply_eq.2 <| by erw [hc, j.apply_symm_apply]
+end
+
+section
+variable [AddCommGroup M₁] [Module R' M₁]
 
 /-- The same-universe version of `lift_rank_le_of_injective_injective`. -/
 theorem rank_le_of_injective_injective (i : R' → R) (j : M →+ M₁)
@@ -165,6 +172,7 @@ theorem rank_eq_of_equiv_equiv (i : ZeroHom R R') (j : M ≃+ M₁)
     Module.rank R M = Module.rank R' M₁ := by
   simpa only [lift_id] using lift_rank_eq_of_equiv_equiv i j hi hc
 
+end
 end Module
 
 namespace Algebra
@@ -208,7 +216,7 @@ theorem lift_rank_eq_of_equiv_equiv (i : R ≃+* R') (j : S ≃+* S')
   simp only [RingEquiv.toRingHom_eq_coe, RingHom.coe_comp, RingHom.coe_coe, comp_apply] at this
   simp only [smul_def, RingEquiv.coe_toAddEquiv, map_mul, ZeroHom.coe_coe, this]
 
-variable {S' : Type v} [CommRing R'] [Ring S'] [Algebra R' S']
+variable {S' : Type v} [Ring S'] [Algebra R' S']
 
 /-- The same-universe version of `Algebra.lift_rank_le_of_injective_injective`. -/
 theorem rank_le_of_injective_injective
@@ -233,6 +241,11 @@ theorem rank_eq_of_equiv_equiv (i : R ≃+* R') (j : S ≃+* S')
 end Algebra
 
 end SurjectiveInjective
+
+variable [Ring R] [AddCommGroup M] [Module R M]
+  [Ring R']
+  [AddCommGroup M'] [AddCommGroup M₁]
+  [Module R M'] [Module R M₁] [Module R' M'] [Module R' M₁]
 
 section
 

--- a/Mathlib/LinearAlgebra/Matrix/ToLin.lean
+++ b/Mathlib/LinearAlgebra/Matrix/ToLin.lean
@@ -82,10 +82,10 @@ def Matrix.vecMulLinear [Fintype m] (M : Matrix m n R) : (m → R) →ₗ[R] n �
 theorem Matrix.coe_vecMulLinear [Fintype m] (M : Matrix m n R) :
     (M.vecMulLinear : _ → _) = M.vecMul := rfl
 
-variable [Fintype m] [DecidableEq m]
+variable [Fintype m]
 
 @[simp]
-theorem Matrix.vecMul_stdBasis (M : Matrix m n R) (i j) :
+theorem Matrix.vecMul_stdBasis [DecidableEq m] (M : Matrix m n R) (i j) :
     (LinearMap.stdBasis R (fun _ ↦ R) i 1 ᵥ* M) j = M i j := by
   have : (∑ i', (if i = i' then 1 else 0) * M i' j) = M i j := by
     simp_rw [boole_mul, Finset.sum_ite_eq, Finset.mem_univ, if_true]
@@ -118,6 +118,9 @@ theorem Matrix.vecMul_injective_iff {R : Type*} [CommRing R] {M : Matrix m n R} 
     ext j
     simp [vecMul, dotProduct]
 
+section
+variable [DecidableEq m]
+
 /-- Linear maps `(m → R) →ₗ[R] (n → R)` are linearly equivalent over `Rᵐᵒᵖ` to `Matrix m n R`,
 by having matrices act by right multiplication.
  -/
@@ -140,7 +143,7 @@ def LinearMap.toMatrixRight' : ((m → R) →ₗ[R] n → R) ≃ₗ[Rᵐᵒᵖ] 
 
 /-- A `Matrix m n R` is linearly equivalent over `Rᵐᵒᵖ` to a linear map `(m → R) →ₗ[R] (n → R)`,
 by having matrices act by right multiplication. -/
-abbrev Matrix.toLinearMapRight' : Matrix m n R ≃ₗ[Rᵐᵒᵖ] (m → R) →ₗ[R] n → R :=
+abbrev Matrix.toLinearMapRight' [DecidableEq m] : Matrix m n R ≃ₗ[Rᵐᵒᵖ] (m → R) →ₗ[R] n → R :=
   LinearEquiv.symm LinearMap.toMatrixRight'
 
 @[simp]
@@ -180,6 +183,7 @@ def Matrix.toLinearEquivRight'OfInv [Fintype n] [DecidableEq n] {M : Matrix m n 
       dsimp only -- Porting note: needed due to non-flat structures
       rw [← Matrix.toLinearMapRight'_mul_apply, hMM', Matrix.toLinearMapRight'_one, id_apply] }
 
+end
 end ToMatrixRight
 
 /-!
@@ -777,7 +781,7 @@ theorem toMatrix_distrib_mul_action_toLinearMap (x : R) :
     Basis.repr_self, Finsupp.smul_single_one, Finsupp.single_eq_pi_single, Matrix.diagonal_apply,
     Pi.single_apply]
 
-lemma LinearMap.toMatrix_prodMap [DecidableEq n] [DecidableEq m] [DecidableEq (n ⊕ m)]
+lemma LinearMap.toMatrix_prodMap [DecidableEq m] [DecidableEq (n ⊕ m)]
     (φ₁ : Module.End R M₁) (φ₂ : Module.End R M₂) :
     toMatrix (v₁.prod v₂) (v₁.prod v₂) (φ₁.prodMap φ₂) =
       Matrix.fromBlocks (toMatrix v₁ v₁ φ₁) 0 0 (toMatrix v₂ v₂ φ₂) := by

--- a/Mathlib/Topology/Compactness/SigmaCompact.lean
+++ b/Mathlib/Topology/Compactness/SigmaCompact.lean
@@ -183,6 +183,7 @@ instance (priority := 100) sigmaCompactSpace_of_locally_compact_second_countable
   refine SigmaCompactSpace.of_countable _ (hsc.image K) (forall_mem_image.2 fun x _ => hKc x) ?_
   rwa [sUnion_image]
 
+section
 -- Porting note: doesn't work on the same line
 variable (X)
 variable [SigmaCompactSpace X]
@@ -299,7 +300,7 @@ theorem countable_cover_nhds_of_sigma_compact {f : X → Set X} (hf : ∀ x, f x
   rcases countable_cover_nhdsWithin_of_sigma_compact isClosed_univ fun x _ => hf x with
     ⟨s, -, hsc, hsU⟩
   exact ⟨s, hsc, univ_subset_iff.1 hsU⟩
-
+end
 
 
 
@@ -407,7 +408,7 @@ noncomputable def choice (X : Type*) [TopologicalSpace X] [WeaklyLocallyCompactS
   · refine univ_subset_iff.1 (iUnion_compactCovering X ▸ ?_)
     exact iUnion_mono' fun n => ⟨n + 1, subset_union_right⟩
 
-noncomputable instance [LocallyCompactSpace X] :
+noncomputable instance [SigmaCompactSpace X] [LocallyCompactSpace X] :
     Inhabited (CompactExhaustion X) :=
   ⟨CompactExhaustion.choice X⟩
 


### PR DESCRIPTION
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
