### PR TITLE
[Merged by Bors] - chore(ModelTheory): Fix Model Theory docstrings

### DIFF
--- a/Mathlib/ModelTheory/Algebra/Field/Basic.lean
+++ b/Mathlib/ModelTheory/Algebra/Field/Basic.lean
@@ -21,8 +21,8 @@ This file defines the first order theory of fields as a theory over the language
 * `FirstOrder.Model.fieldOfModelField` : a model of the theory of fields on a type `K` that
   already has ring operations.
 * `FirstOrder.Model.compatibleRingOfModelField` : shows that the ring operations on `K` given
-by `fieldOfModelField` are compatible with the ring operations on `K` given by the
-`Language.ring.Structure` instance.
+  by `fieldOfModelField` are compatible with the ring operations on `K` given by the
+  `Language.ring.Structure` instance.
 
 -/
 

--- a/Mathlib/ModelTheory/Algebra/Field/Basic.lean
+++ b/Mathlib/ModelTheory/Algebra/Field/Basic.lean
@@ -11,19 +11,18 @@ import Mathlib.Algebra.Field.MinimalAxioms
 import Mathlib.Data.Nat.Cast.Order.Ring
 
 /-!
-
 # The First Order Theory of Fields
 
 This file defines the first order theory of fields as a theory over the language of rings.
 
 ## Main definitions
-* `FirstOrder.Language.Theory.field` : the theory of fields
-* `FirstOrder.Model.fieldOfModelField` : a model of the theory of fields on a type `K` that
+
+- `FirstOrder.Language.Theory.field` : the theory of fields
+- `FirstOrder.Model.fieldOfModelField` : a model of the theory of fields on a type `K` that
   already has ring operations.
-* `FirstOrder.Model.compatibleRingOfModelField` : shows that the ring operations on `K` given
+- `FirstOrder.Model.compatibleRingOfModelField` : shows that the ring operations on `K` given
   by `fieldOfModelField` are compatible with the ring operations on `K` given by the
   `Language.ring.Structure` instance.
-
 -/
 
 variable {K : Type*}

--- a/Mathlib/ModelTheory/Algebra/Field/CharP.lean
+++ b/Mathlib/ModelTheory/Algebra/Field/CharP.lean
@@ -10,16 +10,15 @@ import Mathlib.ModelTheory.Algebra.Ring.FreeCommRing
 import Mathlib.ModelTheory.Algebra.Field.Basic
 
 /-!
-
 # First order theory of fields
 
 This file defines the first order theory of fields of characteristic `p` as a theory over the
 language of rings
 
 ## Main definitions
-* `FirstOrder.Language.Theory.fieldOfChar` : the first order theory of fields of characteristic `p`
-  as a theory over the language of rings
 
+- `FirstOrder.Language.Theory.fieldOfChar` : the first order theory of fields of characteristic `p`
+  as a theory over the language of rings
 -/
 
 variable {p : ℕ} {K : Type*}

--- a/Mathlib/ModelTheory/Algebra/Ring/Basic.lean
+++ b/Mathlib/ModelTheory/Algebra/Ring/Basic.lean
@@ -9,7 +9,6 @@ import Mathlib.ModelTheory.Semantics
 import Mathlib.Algebra.Ring.Equiv
 
 /-!
-
 # First Order Language of Rings
 
 This file defines the first order language of rings, as well as defining instance of `Add`, `Mul`,
@@ -17,11 +16,11 @@ etc. on terms in the language.
 
 ## Main Definitions
 
-* `FirstOrder.Language.ring` : the language of rings, with function symbols `+`, `*`, `-`, `0`, `1`
-* `FirstOrder.Ring.CompatibleRing` : A class stating that a type is a `Language.ring.Structure`, and
+- `FirstOrder.Language.ring` : the language of rings, with function symbols `+`, `*`, `-`, `0`, `1`
+- `FirstOrder.Ring.CompatibleRing` : A class stating that a type is a `Language.ring.Structure`, and
   that this structure is the same as the structure given by the classes `Add`, `Mul`, etc. already
   on `R`.
-* `FirstOrder.Ring.compatibleRingOfRing` : Given a type `R` with instances for each of the `Ring`
+- `FirstOrder.Ring.compatibleRingOfRing` : Given a type `R` with instances for each of the `Ring`
   operations, make a `compatibleRing` instance.
 
 ## Implementation Notes
@@ -38,7 +37,6 @@ a `Language.ring.Structure K` instance and for example an instance of `Theory.fi
 you must add local instances with definitions like `ModelTheory.Field.fieldOfModelField K` and
 `FirstOrder.Ring.compatibleRingOfModelField K`.
 (in `Mathlib/ModelTheory/Algebra/Field/Basic.lean`), depending on the Theory.
-
 -/
 
 variable {α : Type*}

--- a/Mathlib/ModelTheory/Algebra/Ring/Basic.lean
+++ b/Mathlib/ModelTheory/Algebra/Ring/Basic.lean
@@ -19,10 +19,10 @@ etc. on terms in the language.
 
 * `FirstOrder.Language.ring` : the language of rings, with function symbols `+`, `*`, `-`, `0`, `1`
 * `FirstOrder.Ring.CompatibleRing` : A class stating that a type is a `Language.ring.Structure`, and
-that this structure is the same as the structure given by the classes `Add`, `Mul`, etc. already on
-`R`.
+  that this structure is the same as the structure given by the classes `Add`, `Mul`, etc. already
+  on `R`.
 * `FirstOrder.Ring.compatibleRingOfRing` : Given a type `R` with instances for each of the `Ring`
-operations, make a `compatibleRing` instance.
+  operations, make a `compatibleRing` instance.
 
 ## Implementation Notes
 

--- a/Mathlib/ModelTheory/Algebra/Ring/FreeCommRing.lean
+++ b/Mathlib/ModelTheory/Algebra/Ring/FreeCommRing.lean
@@ -8,7 +8,6 @@ import Mathlib.ModelTheory.Algebra.Ring.Basic
 import Mathlib.RingTheory.FreeCommRing
 
 /-!
-
 # Making a term in the language of rings from an element of the FreeCommRing
 
 This file defines the function `FirstOrder.Ring.termOfFreeCommRing` which constructs a
@@ -16,7 +15,6 @@ This file defines the function `FirstOrder.Ring.termOfFreeCommRing` which constr
 
 The theorem `FirstOrder.Ring.realize_termOfFreeCommRing` shows that the term constructed when
 realized in a ring `R` is equal to the lift of the element of `FreeCommRing α` to `R`.
-
 -/
 
 namespace FirstOrder

--- a/Mathlib/ModelTheory/Basic.lean
+++ b/Mathlib/ModelTheory/Basic.lean
@@ -8,33 +8,35 @@ import Mathlib.SetTheory.Cardinal.Basic
 
 /-!
 # Basics on First-Order Structures
+
 This file defines first-order languages and structures in the style of the
 [Flypitch project](https://flypitch.github.io/), as well as several important maps between
 structures.
 
 ## Main Definitions
-* A `FirstOrder.Language` defines a language as a pair of functions from the natural numbers to
+
+- A `FirstOrder.Language` defines a language as a pair of functions from the natural numbers to
   `Type l`. One sends `n` to the type of `n`-ary functions, and the other sends `n` to the type of
   `n`-ary relations.
-* A `FirstOrder.Language.Structure` interprets the symbols of a given `FirstOrder.Language` in the
+- A `FirstOrder.Language.Structure` interprets the symbols of a given `FirstOrder.Language` in the
   context of a given type.
-* A `FirstOrder.Language.Hom`, denoted `M →[L] N`, is a map from the `L`-structure `M` to the
+- A `FirstOrder.Language.Hom`, denoted `M →[L] N`, is a map from the `L`-structure `M` to the
   `L`-structure `N` that commutes with the interpretations of functions, and which preserves the
   interpretations of relations (although only in the forward direction).
-* A `FirstOrder.Language.Embedding`, denoted `M ↪[L] N`, is an embedding from the `L`-structure `M`
+- A `FirstOrder.Language.Embedding`, denoted `M ↪[L] N`, is an embedding from the `L`-structure `M`
   to the `L`-structure `N` that commutes with the interpretations of functions, and which preserves
   the interpretations of relations in both directions.
-* A `FirstOrder.Language.Equiv`, denoted `M ≃[L] N`, is an equivalence from the `L`-structure `M`
+- A `FirstOrder.Language.Equiv`, denoted `M ≃[L] N`, is an equivalence from the `L`-structure `M`
   to the `L`-structure `N` that commutes with the interpretations of functions, and which preserves
   the interpretations of relations in both directions.
 
 ## References
+
 For the Flypitch project:
 - [J. Han, F. van Doorn, *A formal proof of the independence of the continuum hypothesis*]
-[flypitch_cpp]
+  [flypitch_cpp]
 - [J. Han, F. van Doorn, *A formalization of forcing and the unprovability of
-the continuum hypothesis*][flypitch_itp]
-
+  the continuum hypothesis*][flypitch_itp]
 -/
 
 universe u v u' v' w w'

--- a/Mathlib/ModelTheory/Bundled.lean
+++ b/Mathlib/ModelTheory/Bundled.lean
@@ -8,15 +8,17 @@ import Mathlib.CategoryTheory.ConcreteCategory.Bundled
 
 /-!
 # Bundled First-Order Structures
+
 This file bundles types together with their first-order structure.
 
 ## Main Definitions
-* `FirstOrder.Language.Theory.ModelType` is the type of nonempty models of a particular theory.
-* `FirstOrder.Language.equivSetoid` is the isomorphism equivalence relation on bundled structures.
+
+- `FirstOrder.Language.Theory.ModelType` is the type of nonempty models of a particular theory.
+- `FirstOrder.Language.equivSetoid` is the isomorphism equivalence relation on bundled structures.
 
 ## TODO
-* Define category structures on bundled structures and models.
 
+- Define category structures on bundled structures and models.
 -/
 
 

--- a/Mathlib/ModelTheory/Complexity.lean
+++ b/Mathlib/ModelTheory/Complexity.lean
@@ -12,18 +12,18 @@ This file defines quantifier complexity of first-order formulas, and constructs 
 
 ## Main Definitions
 
-* `FirstOrder.Language.BoundedFormula.IsAtomic` defines atomic formulas - those which are
+- `FirstOrder.Language.BoundedFormula.IsAtomic` defines atomic formulas - those which are
   constructed only from terms and relations.
-* `FirstOrder.Language.BoundedFormula.IsQF` defines quantifier-free formulas - those which are
+- `FirstOrder.Language.BoundedFormula.IsQF` defines quantifier-free formulas - those which are
   constructed only from atomic formulas and boolean operations.
-* `FirstOrder.Language.BoundedFormula.IsPrenex` defines when a formula is in prenex normal form -
+- `FirstOrder.Language.BoundedFormula.IsPrenex` defines when a formula is in prenex normal form -
   when it consists of a series of quantifiers applied to a quantifier-free formula.
-* `FirstOrder.Language.BoundedFormula.toPrenex` constructs a prenex normal form of a given formula.
+- `FirstOrder.Language.BoundedFormula.toPrenex` constructs a prenex normal form of a given formula.
 
 
 ## Main Results
 
-* `FirstOrder.Language.BoundedFormula.realize_toPrenex` shows that the prenex normal form of a
+- `FirstOrder.Language.BoundedFormula.realize_toPrenex` shows that the prenex normal form of a
   formula has the same realization as the original formula.
 
 -/

--- a/Mathlib/ModelTheory/Complexity.lean
+++ b/Mathlib/ModelTheory/Complexity.lean
@@ -13,18 +13,18 @@ This file defines quantifier complexity of first-order formulas, and constructs 
 ## Main Definitions
 
 * `FirstOrder.Language.BoundedFormula.IsAtomic` defines atomic formulas - those which are
-constructed only from terms and relations.
+  constructed only from terms and relations.
 * `FirstOrder.Language.BoundedFormula.IsQF` defines quantifier-free formulas - those which are
-constructed only from atomic formulas and boolean operations.
+  constructed only from atomic formulas and boolean operations.
 * `FirstOrder.Language.BoundedFormula.IsPrenex` defines when a formula is in prenex normal form -
-when it consists of a series of quantifiers applied to a quantifier-free formula.
+  when it consists of a series of quantifiers applied to a quantifier-free formula.
 * `FirstOrder.Language.BoundedFormula.toPrenex` constructs a prenex normal form of a given formula.
 
 
 ## Main Results
 
 * `FirstOrder.Language.BoundedFormula.realize_toPrenex` shows that the prenex normal form of a
-formula has the same realization as the original formula.
+  formula has the same realization as the original formula.
 
 -/
 

--- a/Mathlib/ModelTheory/Definability.lean
+++ b/Mathlib/ModelTheory/Definability.lean
@@ -13,11 +13,11 @@ This file defines what it means for a set over a first-order structure to be def
 
 ## Main Definitions
 * `Set.Definable` is defined so that `A.Definable L s` indicates that the
-set `s` of a finite cartesian power of `M` is definable with parameters in `A`.
+  set `s` of a finite cartesian power of `M` is definable with parameters in `A`.
 * `Set.Definable₁` is defined so that `A.Definable₁ L s` indicates that
-`(s : Set M)` is definable with parameters in `A`.
+  `(s : Set M)` is definable with parameters in `A`.
 * `Set.Definable₂` is defined so that `A.Definable₂ L s` indicates that
-`(s : Set (M × M))` is definable with parameters in `A`.
+  `(s : Set (M × M))` is definable with parameters in `A`.
 * A `FirstOrder.Language.DefinableSet` is defined so that `L.DefinableSet A α` is the boolean
   algebra of subsets of `α → M` defined by formulas with parameters in `A`.
 

--- a/Mathlib/ModelTheory/Definability.lean
+++ b/Mathlib/ModelTheory/Definability.lean
@@ -9,21 +9,24 @@ import Mathlib.ModelTheory.Semantics
 
 /-!
 # Definable Sets
+
 This file defines what it means for a set over a first-order structure to be definable.
 
 ## Main Definitions
-* `Set.Definable` is defined so that `A.Definable L s` indicates that the
+
+- `Set.Definable` is defined so that `A.Definable L s` indicates that the
   set `s` of a finite cartesian power of `M` is definable with parameters in `A`.
-* `Set.Definable₁` is defined so that `A.Definable₁ L s` indicates that
+- `Set.Definable₁` is defined so that `A.Definable₁ L s` indicates that
   `(s : Set M)` is definable with parameters in `A`.
-* `Set.Definable₂` is defined so that `A.Definable₂ L s` indicates that
+- `Set.Definable₂` is defined so that `A.Definable₂ L s` indicates that
   `(s : Set (M × M))` is definable with parameters in `A`.
-* A `FirstOrder.Language.DefinableSet` is defined so that `L.DefinableSet A α` is the boolean
+- A `FirstOrder.Language.DefinableSet` is defined so that `L.DefinableSet A α` is the boolean
   algebra of subsets of `α → M` defined by formulas with parameters in `A`.
 
 ## Main Results
-* `L.DefinableSet A α` forms a `BooleanAlgebra`
-* `Set.Definable.image_comp` shows that definability is closed under projections in finite
+
+- `L.DefinableSet A α` forms a `BooleanAlgebra`
+- `Set.Definable.image_comp` shows that definability is closed under projections in finite
   dimensions.
 
 -/

--- a/Mathlib/ModelTheory/DirectLimit.lean
+++ b/Mathlib/ModelTheory/DirectLimit.lean
@@ -10,15 +10,17 @@ import Mathlib.ModelTheory.FinitelyGenerated
 
 /-!
 # Direct Limits of First-Order Structures
+
 This file constructs the direct limit of a directed system of first-order embeddings.
 
 ## Main Definitions
-* `FirstOrder.Language.DirectLimit G f` is the direct limit of the directed system `f` of
+
+- `FirstOrder.Language.DirectLimit G f` is the direct limit of the directed system `f` of
   first-order embeddings between the structures indexed by `G`.
-* `FirstOrder.Language.DirectLimit.lift` is the universal property of the direct limit: maps
+- `FirstOrder.Language.DirectLimit.lift` is the universal property of the direct limit: maps
   from the components to another module that respect the directed system structure give rise to
   a unique map out of the direct limit.
-* `FirstOrder.Language.DirectLimit.equiv_lift` is the equivalence between limits of
+- `FirstOrder.Language.DirectLimit.equiv_lift` is the equivalence between limits of
   isomorphic direct systems.
 -/
 

--- a/Mathlib/ModelTheory/ElementaryMaps.lean
+++ b/Mathlib/ModelTheory/ElementaryMaps.lean
@@ -15,11 +15,11 @@ import Mathlib.ModelTheory.Substructures
 * The `FirstOrder.Language.elementaryDiagram` of a structure is the set of all sentences with
   parameters that the structure satisfies.
 * `FirstOrder.Language.ElementaryEmbedding.ofModelsElementaryDiagram` is the canonical
-elementary embedding of any structure into a model of its elementary diagram.
+  elementary embedding of any structure into a model of its elementary diagram.
 
 ## Main Results
 * The Tarski-Vaught Test for embeddings: `FirstOrder.Language.Embedding.isElementary_of_exists`
-gives a simple criterion for an embedding to be elementary.
+  gives a simple criterion for an embedding to be elementary.
  -/
 
 

--- a/Mathlib/ModelTheory/ElementaryMaps.lean
+++ b/Mathlib/ModelTheory/ElementaryMaps.lean
@@ -10,15 +10,17 @@ import Mathlib.ModelTheory.Substructures
 # Elementary Maps Between First-Order Structures
 
 ## Main Definitions
-* A `FirstOrder.Language.ElementaryEmbedding` is an embedding that commutes with the
+
+- A `FirstOrder.Language.ElementaryEmbedding` is an embedding that commutes with the
   realizations of formulas.
-* The `FirstOrder.Language.elementaryDiagram` of a structure is the set of all sentences with
+- The `FirstOrder.Language.elementaryDiagram` of a structure is the set of all sentences with
   parameters that the structure satisfies.
-* `FirstOrder.Language.ElementaryEmbedding.ofModelsElementaryDiagram` is the canonical
+- `FirstOrder.Language.ElementaryEmbedding.ofModelsElementaryDiagram` is the canonical
   elementary embedding of any structure into a model of its elementary diagram.
 
 ## Main Results
-* The Tarski-Vaught Test for embeddings: `FirstOrder.Language.Embedding.isElementary_of_exists`
+
+- The Tarski-Vaught Test for embeddings: `FirstOrder.Language.Embedding.isElementary_of_exists`
   gives a simple criterion for an embedding to be elementary.
  -/
 

--- a/Mathlib/ModelTheory/ElementarySubstructures.lean
+++ b/Mathlib/ModelTheory/ElementarySubstructures.lean
@@ -9,11 +9,13 @@ import Mathlib.ModelTheory.ElementaryMaps
 # Elementary Substructures
 
 ## Main Definitions
-* A `FirstOrder.Language.ElementarySubstructure` is a substructure where the realization of each
+
+- A `FirstOrder.Language.ElementarySubstructure` is a substructure where the realization of each
   formula agrees with the realization in the larger model.
 
 ## Main Results
-* The Tarski-Vaught Test for substructures:
+
+- The Tarski-Vaught Test for substructures:
   `FirstOrder.Language.Substructure.isElementary_of_exists` gives a simple criterion for a
   substructure to be elementary.
  -/

--- a/Mathlib/ModelTheory/Encoding.lean
+++ b/Mathlib/ModelTheory/Encoding.lean
@@ -16,15 +16,15 @@ import Mathlib.SetTheory.Cardinal.Ordinal
 
 ## Main Results
 * `FirstOrder.Language.Term.card_le` shows that the number of terms in `L.Term α` is at most
-`max ℵ₀ # (α ⊕ Σ i, L.Functions i)`.
+  `max ℵ₀ # (α ⊕ Σ i, L.Functions i)`.
 * `FirstOrder.Language.BoundedFormula.card_le` shows that the number of bounded formulas in
-`Σ n, L.BoundedFormula α n` is at most
-`max ℵ₀ (Cardinal.lift.{max u v} #α + Cardinal.lift.{u'} L.card)`.
+  `Σ n, L.BoundedFormula α n` is at most
+  `max ℵ₀ (Cardinal.lift.{max u v} #α + Cardinal.lift.{u'} L.card)`.
 
 ## TODO
 * `Primcodable` instances for terms and formulas, based on the `encoding`s
 * Computability facts about term and formula operations, to set up a computability approach to
-incompleteness
+  incompleteness
 
 -/
 

--- a/Mathlib/ModelTheory/Encoding.lean
+++ b/Mathlib/ModelTheory/Encoding.lean
@@ -8,22 +8,26 @@ import Mathlib.Logic.Small.List
 import Mathlib.ModelTheory.Syntax
 import Mathlib.SetTheory.Cardinal.Ordinal
 
-/-! # Encodings and Cardinality of First-Order Syntax
+/-!
+# Encodings and Cardinality of First-Order Syntax
 
 ## Main Definitions
-* `FirstOrder.Language.Term.encoding` encodes terms as lists.
-* `FirstOrder.Language.BoundedFormula.encoding` encodes bounded formulas as lists.
+
+- `FirstOrder.Language.Term.encoding` encodes terms as lists.
+- `FirstOrder.Language.BoundedFormula.encoding` encodes bounded formulas as lists.
 
 ## Main Results
-* `FirstOrder.Language.Term.card_le` shows that the number of terms in `L.Term α` is at most
+
+- `FirstOrder.Language.Term.card_le` shows that the number of terms in `L.Term α` is at most
   `max ℵ₀ # (α ⊕ Σ i, L.Functions i)`.
-* `FirstOrder.Language.BoundedFormula.card_le` shows that the number of bounded formulas in
+- `FirstOrder.Language.BoundedFormula.card_le` shows that the number of bounded formulas in
   `Σ n, L.BoundedFormula α n` is at most
   `max ℵ₀ (Cardinal.lift.{max u v} #α + Cardinal.lift.{u'} L.card)`.
 
 ## TODO
-* `Primcodable` instances for terms and formulas, based on the `encoding`s
-* Computability facts about term and formula operations, to set up a computability approach to
+
+- `Primcodable` instances for terms and formulas, based on the `encoding`s
+- Computability facts about term and formula operations, to set up a computability approach to
   incompleteness
 
 -/

--- a/Mathlib/ModelTheory/FinitelyGenerated.lean
+++ b/Mathlib/ModelTheory/FinitelyGenerated.lean
@@ -7,17 +7,20 @@ import Mathlib.ModelTheory.Substructures
 
 /-!
 # Finitely Generated First-Order Structures
+
 This file defines what it means for a first-order (sub)structure to be finitely or countably
 generated, similarly to other finitely-generated objects in the algebra library.
 
 ## Main Definitions
-* `FirstOrder.Language.Substructure.FG` indicates that a substructure is finitely generated.
-* `FirstOrder.Language.Structure.FG` indicates that a structure is finitely generated.
-* `FirstOrder.Language.Substructure.CG` indicates that a substructure is countably generated.
-* `FirstOrder.Language.Structure.CG` indicates that a structure is countably generated.
+
+- `FirstOrder.Language.Substructure.FG` indicates that a substructure is finitely generated.
+- `FirstOrder.Language.Structure.FG` indicates that a structure is finitely generated.
+- `FirstOrder.Language.Substructure.CG` indicates that a substructure is countably generated.
+- `FirstOrder.Language.Structure.CG` indicates that a structure is countably generated.
 
 
 ## TODO
+
 Develop a more unified definition of finite generation using the theory of closure operators, or use
 this definition of finite generation to define the others.
 

--- a/Mathlib/ModelTheory/Fraisse.lean
+++ b/Mathlib/ModelTheory/Fraisse.lean
@@ -18,39 +18,44 @@ ultrahomogeneous structures. To each is associated a unique (up to nonunique iso
 Fraïssé limit - the countable ultrahomogeneous structure with that age.
 
 ## Main Definitions
-* `FirstOrder.Language.age` is the class of finitely-generated structures that embed into a
+
+- `FirstOrder.Language.age` is the class of finitely-generated structures that embed into a
   particular structure.
-* A class `K` is `FirstOrder.Language.Hereditary` when all finitely-generated
+- A class `K` is `FirstOrder.Language.Hereditary` when all finitely-generated
   structures that embed into structures in `K` are also in `K`.
-* A class `K` has `FirstOrder.Language.JointEmbedding` when for every `M`, `N` in
+- A class `K` has `FirstOrder.Language.JointEmbedding` when for every `M`, `N` in
   `K`, there is another structure in `K` into which both `M` and `N` embed.
-* A class `K` has `FirstOrder.Language.Amalgamation` when for any pair of embeddings
+- A class `K` has `FirstOrder.Language.Amalgamation` when for any pair of embeddings
   of a structure `M` in `K` into other structures in `K`, those two structures can be embedded into a
   fourth structure in `K` such that the resulting square of embeddings commutes.
-* `FirstOrder.Language.IsFraisse` indicates that a class is nonempty, isomorphism-invariant,
+- `FirstOrder.Language.IsFraisse` indicates that a class is nonempty, isomorphism-invariant,
   essentially countable, and satisfies the hereditary, joint embedding, and amalgamation properties.
-* `FirstOrder.Language.IsFraisseLimit` indicates that a structure is a Fraïssé limit for a given
+- `FirstOrder.Language.IsFraisseLimit` indicates that a structure is a Fraïssé limit for a given
   class.
 
 ## Main Results
-* We show that the age of any structure is isomorphism-invariant and satisfies the hereditary and
+
+- We show that the age of any structure is isomorphism-invariant and satisfies the hereditary and
   joint-embedding properties.
-* `FirstOrder.Language.age.countable_quotient` shows that the age of any countable structure is
+- `FirstOrder.Language.age.countable_quotient` shows that the age of any countable structure is
   essentially countable.
-* `FirstOrder.Language.exists_countable_is_age_of_iff` gives necessary and sufficient conditions
+- `FirstOrder.Language.exists_countable_is_age_of_iff` gives necessary and sufficient conditions
   for a class to be the age of a countable structure in a language with countably many functions.
 
 ## Implementation Notes
-* Classes of structures are formalized with `Set (Bundled L.Structure)`.
-* Some results pertain to countable limit structures, others to countably-generated limit
+
+- Classes of structures are formalized with `Set (Bundled L.Structure)`.
+- Some results pertain to countable limit structures, others to countably-generated limit
   structures. In the case of a language with countably many function symbols, these are equivalent.
 
 ## References
+
 - [W. Hodges, *A Shorter Model Theory*][Hodges97]
 - [K. Tent, M. Ziegler, *A Course in Model Theory*][Tent_Ziegler]
 
 ## TODO
-* Show existence and uniqueness of Fraïssé limits
+
+- Show existence and uniqueness of Fraïssé limits
 
 -/
 

--- a/Mathlib/ModelTheory/Fraisse.lean
+++ b/Mathlib/ModelTheory/Fraisse.lean
@@ -19,31 +19,31 @@ Fraïssé limit - the countable ultrahomogeneous structure with that age.
 
 ## Main Definitions
 * `FirstOrder.Language.age` is the class of finitely-generated structures that embed into a
-particular structure.
+  particular structure.
 * A class `K` is `FirstOrder.Language.Hereditary` when all finitely-generated
-structures that embed into structures in `K` are also in `K`.
+  structures that embed into structures in `K` are also in `K`.
 * A class `K` has `FirstOrder.Language.JointEmbedding` when for every `M`, `N` in
-`K`, there is another structure in `K` into which both `M` and `N` embed.
+  `K`, there is another structure in `K` into which both `M` and `N` embed.
 * A class `K` has `FirstOrder.Language.Amalgamation` when for any pair of embeddings
-of a structure `M` in `K` into other structures in `K`, those two structures can be embedded into a
-fourth structure in `K` such that the resulting square of embeddings commutes.
+  of a structure `M` in `K` into other structures in `K`, those two structures can be embedded into a
+  fourth structure in `K` such that the resulting square of embeddings commutes.
 * `FirstOrder.Language.IsFraisse` indicates that a class is nonempty, isomorphism-invariant,
-essentially countable, and satisfies the hereditary, joint embedding, and amalgamation properties.
+  essentially countable, and satisfies the hereditary, joint embedding, and amalgamation properties.
 * `FirstOrder.Language.IsFraisseLimit` indicates that a structure is a Fraïssé limit for a given
-class.
+  class.
 
 ## Main Results
 * We show that the age of any structure is isomorphism-invariant and satisfies the hereditary and
-joint-embedding properties.
+  joint-embedding properties.
 * `FirstOrder.Language.age.countable_quotient` shows that the age of any countable structure is
-essentially countable.
+  essentially countable.
 * `FirstOrder.Language.exists_countable_is_age_of_iff` gives necessary and sufficient conditions
-for a class to be the age of a countable structure in a language with countably many functions.
+  for a class to be the age of a countable structure in a language with countably many functions.
 
 ## Implementation Notes
 * Classes of structures are formalized with `Set (Bundled L.Structure)`.
 * Some results pertain to countable limit structures, others to countably-generated limit
-structures. In the case of a language with countably many function symbols, these are equivalent.
+  structures. In the case of a language with countably many function symbols, these are equivalent.
 
 ## References
 - [W. Hodges, *A Shorter Model Theory*][Hodges97]

--- a/Mathlib/ModelTheory/Fraisse.lean
+++ b/Mathlib/ModelTheory/Fraisse.lean
@@ -26,8 +26,8 @@ Fraïssé limit - the countable ultrahomogeneous structure with that age.
 - A class `K` has `FirstOrder.Language.JointEmbedding` when for every `M`, `N` in
   `K`, there is another structure in `K` into which both `M` and `N` embed.
 - A class `K` has `FirstOrder.Language.Amalgamation` when for any pair of embeddings
-  of a structure `M` in `K` into other structures in `K`, those two structures can be embedded into a
-  fourth structure in `K` such that the resulting square of embeddings commutes.
+  of a structure `M` in `K` into other structures in `K`, those two structures can be embedded into
+  a fourth structure in `K` such that the resulting square of embeddings commutes.
 - `FirstOrder.Language.IsFraisse` indicates that a class is nonempty, isomorphism-invariant,
   essentially countable, and satisfies the hereditary, joint embedding, and amalgamation properties.
 - `FirstOrder.Language.IsFraisseLimit` indicates that a structure is a Fraïssé limit for a given

--- a/Mathlib/ModelTheory/Graph.lean
+++ b/Mathlib/ModelTheory/Graph.lean
@@ -8,14 +8,16 @@ import Mathlib.Combinatorics.SimpleGraph.Basic
 
 /-!
 # First-Order Structures in Graph Theory
+
 This file defines first-order languages, structures, and theories in graph theory.
 
 ## Main Definitions
-* `FirstOrder.Language.graph` is the language consisting of a single relation representing
+
+- `FirstOrder.Language.graph` is the language consisting of a single relation representing
   adjacency.
-* `SimpleGraph.structure` is the first-order structure corresponding to a given simple graph.
-* `FirstOrder.Language.Theory.simpleGraph` is the theory of simple graphs.
-* `FirstOrder.Language.simpleGraphOfStructure` gives the simple graph corresponding to a model
+- `SimpleGraph.structure` is the first-order structure corresponding to a given simple graph.
+- `FirstOrder.Language.Theory.simpleGraph` is the theory of simple graphs.
+- `FirstOrder.Language.simpleGraphOfStructure` gives the simple graph corresponding to a model
   of the theory of simple graphs.
 -/
 

--- a/Mathlib/ModelTheory/Graph.lean
+++ b/Mathlib/ModelTheory/Graph.lean
@@ -12,11 +12,11 @@ This file defines first-order languages, structures, and theories in graph theor
 
 ## Main Definitions
 * `FirstOrder.Language.graph` is the language consisting of a single relation representing
-adjacency.
+  adjacency.
 * `SimpleGraph.structure` is the first-order structure corresponding to a given simple graph.
 * `FirstOrder.Language.Theory.simpleGraph` is the theory of simple graphs.
 * `FirstOrder.Language.simpleGraphOfStructure` gives the simple graph corresponding to a model
-of the theory of simple graphs.
+  of the theory of simple graphs.
 -/
 
 

--- a/Mathlib/ModelTheory/LanguageMap.lean
+++ b/Mathlib/ModelTheory/LanguageMap.lean
@@ -7,19 +7,22 @@ import Mathlib.ModelTheory.Basic
 
 /-!
 # Language Maps
+
 Maps between first-order languages in the style of the
 [Flypitch project](https://flypitch.github.io/), as well as several important maps between
 structures.
 
 ## Main Definitions
-* A `FirstOrder.Language.LHom`, denoted `L →ᴸ L'`, is a map between languages, sending the symbols
+
+- A `FirstOrder.Language.LHom`, denoted `L →ᴸ L'`, is a map between languages, sending the symbols
   of one to symbols of the same kind and arity in the other.
-* A `FirstOrder.Language.LEquiv`, denoted `L ≃ᴸ L'`, is an invertible language homomorphism.
-* `FirstOrder.Language.withConstants` is defined so that if `M` is an `L.Structure` and
+- A `FirstOrder.Language.LEquiv`, denoted `L ≃ᴸ L'`, is an invertible language homomorphism.
+- `FirstOrder.Language.withConstants` is defined so that if `M` is an `L.Structure` and
   `A : Set M`, `L.withConstants A`, denoted `L[[A]]`, is a language which adds constant symbols for
   elements of `A` to `L`.
 
 ## References
+
 For the Flypitch project:
 - [J. Han, F. van Doorn, *A formal proof of the independence of the continuum hypothesis*]
   [flypitch_cpp]

--- a/Mathlib/ModelTheory/LanguageMap.lean
+++ b/Mathlib/ModelTheory/LanguageMap.lean
@@ -22,9 +22,9 @@ structures.
 ## References
 For the Flypitch project:
 - [J. Han, F. van Doorn, *A formal proof of the independence of the continuum hypothesis*]
-[flypitch_cpp]
+  [flypitch_cpp]
 - [J. Han, F. van Doorn, *A formalization of forcing and the unprovability of
-the continuum hypothesis*][flypitch_itp]
+  the continuum hypothesis*][flypitch_itp]
 
 -/
 

--- a/Mathlib/ModelTheory/Order.lean
+++ b/Mathlib/ModelTheory/Order.lean
@@ -12,18 +12,18 @@ This file defines ordered first-order languages and structures, as well as their
 ## Main Definitions
 * `FirstOrder.Language.order` is the language consisting of a single relation representing `≤`.
 * `FirstOrder.Language.orderStructure` is the structure on an ordered type, assigning the symbol
-representing `≤` to the actual relation `≤`.
+  representing `≤` to the actual relation `≤`.
 * `FirstOrder.Language.IsOrdered` points out a specific symbol in a language as representing `≤`.
 * `FirstOrder.Language.OrderedStructure` indicates that the `≤` symbol in an ordered language
-is interpreted as the actual relation `≤` in a particular structure.
+  is interpreted as the actual relation `≤` in a particular structure.
 * `FirstOrder.Language.linearOrderTheory` and similar define the theories of preorders,
-partial orders, and linear orders.
+  partial orders, and linear orders.
 * `FirstOrder.Language.dlo` defines the theory of dense linear orders without endpoints, a
-particularly useful example in model theory.
+  particularly useful example in model theory.
 
 ## Main Results
 * `PartialOrder`s model the theory of partial orders, `LinearOrder`s model the theory of
-linear orders, and dense linear orders without endpoints model `Language.dlo`.
+  linear orders, and dense linear orders without endpoints model `Language.dlo`.
 
 -/
 

--- a/Mathlib/ModelTheory/Order.lean
+++ b/Mathlib/ModelTheory/Order.lean
@@ -7,24 +7,26 @@ import Mathlib.ModelTheory.Semantics
 
 /-!
 # Ordered First-Ordered Structures
+
 This file defines ordered first-order languages and structures, as well as their theories.
 
 ## Main Definitions
-* `FirstOrder.Language.order` is the language consisting of a single relation representing `≤`.
-* `FirstOrder.Language.orderStructure` is the structure on an ordered type, assigning the symbol
+
+- `FirstOrder.Language.order` is the language consisting of a single relation representing `≤`.
+- `FirstOrder.Language.orderStructure` is the structure on an ordered type, assigning the symbol
   representing `≤` to the actual relation `≤`.
-* `FirstOrder.Language.IsOrdered` points out a specific symbol in a language as representing `≤`.
-* `FirstOrder.Language.OrderedStructure` indicates that the `≤` symbol in an ordered language
+- `FirstOrder.Language.IsOrdered` points out a specific symbol in a language as representing `≤`.
+- `FirstOrder.Language.OrderedStructure` indicates that the `≤` symbol in an ordered language
   is interpreted as the actual relation `≤` in a particular structure.
-* `FirstOrder.Language.linearOrderTheory` and similar define the theories of preorders,
+- `FirstOrder.Language.linearOrderTheory` and similar define the theories of preorders,
   partial orders, and linear orders.
-* `FirstOrder.Language.dlo` defines the theory of dense linear orders without endpoints, a
+- `FirstOrder.Language.dlo` defines the theory of dense linear orders without endpoints, a
   particularly useful example in model theory.
 
 ## Main Results
-* `PartialOrder`s model the theory of partial orders, `LinearOrder`s model the theory of
-  linear orders, and dense linear orders without endpoints model `Language.dlo`.
 
+- `PartialOrder`s model the theory of partial orders, `LinearOrder`s model the theory of
+  linear orders, and dense linear orders without endpoints model `Language.dlo`.
 -/
 
 

--- a/Mathlib/ModelTheory/Quotients.lean
+++ b/Mathlib/ModelTheory/Quotients.lean
@@ -12,9 +12,9 @@ This file defines prestructures and quotients of first-order structures.
 
 ## Main Definitions
 * If `s` is a setoid (equivalence relation) on `M`, a `FirstOrder.Language.Prestructure s` is the
-data for a first-order structure on `M` that will still be a structure when modded out by `s`.
+  data for a first-order structure on `M` that will still be a structure when modded out by `s`.
 * The structure `FirstOrder.Language.quotientStructure s` is the resulting structure on
-`Quotient s`.
+  `Quotient s`.
 
 -/
 

--- a/Mathlib/ModelTheory/Quotients.lean
+++ b/Mathlib/ModelTheory/Quotients.lean
@@ -8,14 +8,15 @@ import Mathlib.ModelTheory.Semantics
 
 /-!
 # Quotients of First-Order Structures
+
 This file defines prestructures and quotients of first-order structures.
 
 ## Main Definitions
-* If `s` is a setoid (equivalence relation) on `M`, a `FirstOrder.Language.Prestructure s` is the
-  data for a first-order structure on `M` that will still be a structure when modded out by `s`.
-* The structure `FirstOrder.Language.quotientStructure s` is the resulting structure on
-  `Quotient s`.
 
+- If `s` is a setoid (equivalence relation) on `M`, a `FirstOrder.Language.Prestructure s` is the
+  data for a first-order structure on `M` that will still be a structure when modded out by `s`.
+- The structure `FirstOrder.Language.quotientStructure s` is the resulting structure on
+  `Quotient s`.
 -/
 
 

--- a/Mathlib/ModelTheory/Satisfiability.lean
+++ b/Mathlib/ModelTheory/Satisfiability.lean
@@ -9,34 +9,37 @@ import Mathlib.ModelTheory.Skolem
 
 /-!
 # First-Order Satisfiability
+
 This file deals with the satisfiability of first-order theories, as well as equivalence over them.
 
 ## Main Definitions
-* `FirstOrder.Language.Theory.IsSatisfiable`: `T.IsSatisfiable` indicates that `T` has a nonempty
+
+- `FirstOrder.Language.Theory.IsSatisfiable`: `T.IsSatisfiable` indicates that `T` has a nonempty
   model.
-* `FirstOrder.Language.Theory.IsFinitelySatisfiable`: `T.IsFinitelySatisfiable` indicates that
+- `FirstOrder.Language.Theory.IsFinitelySatisfiable`: `T.IsFinitelySatisfiable` indicates that
   every finite subset of `T` is satisfiable.
-* `FirstOrder.Language.Theory.IsComplete`: `T.IsComplete` indicates that `T` is satisfiable and
+- `FirstOrder.Language.Theory.IsComplete`: `T.IsComplete` indicates that `T` is satisfiable and
   models each sentence or its negation.
-* `FirstOrder.Language.Theory.SemanticallyEquivalent`: `T.SemanticallyEquivalent φ ψ` indicates
+- `FirstOrder.Language.Theory.SemanticallyEquivalent`: `T.SemanticallyEquivalent φ ψ` indicates
   that `φ` and `ψ` are equivalent formulas or sentences in models of `T`.
-* `Cardinal.Categorical`: A theory is `κ`-categorical if all models of size `κ` are isomorphic.
+- `Cardinal.Categorical`: A theory is `κ`-categorical if all models of size `κ` are isomorphic.
 
 ## Main Results
-* The Compactness Theorem, `FirstOrder.Language.Theory.isSatisfiable_iff_isFinitelySatisfiable`,
+
+- The Compactness Theorem, `FirstOrder.Language.Theory.isSatisfiable_iff_isFinitelySatisfiable`,
   shows that a theory is satisfiable iff it is finitely satisfiable.
-* `FirstOrder.Language.completeTheory.isComplete`: The complete theory of a structure is
+- `FirstOrder.Language.completeTheory.isComplete`: The complete theory of a structure is
   complete.
-* `FirstOrder.Language.Theory.exists_large_model_of_infinite_model` shows that any theory with an
+- `FirstOrder.Language.Theory.exists_large_model_of_infinite_model` shows that any theory with an
   infinite model has arbitrarily large models.
-* `FirstOrder.Language.Theory.exists_elementaryEmbedding_card_eq`: The Upward Löwenheim–Skolem
+- `FirstOrder.Language.Theory.exists_elementaryEmbedding_card_eq`: The Upward Löwenheim–Skolem
   Theorem: If `κ` is a cardinal greater than the cardinalities of `L` and an infinite `L`-structure
   `M`, then `M` has an elementary extension of cardinality `κ`.
 
 ## Implementation Details
-* Satisfiability of an `L.Theory` `T` is defined in the minimal universe containing all the symbols
-  of `L`. By Löwenheim-Skolem, this is equivalent to satisfiability in any universe.
 
+- Satisfiability of an `L.Theory` `T` is defined in the minimal universe containing all the symbols
+  of `L`. By Löwenheim-Skolem, this is equivalent to satisfiability in any universe.
 -/
 
 

--- a/Mathlib/ModelTheory/Satisfiability.lean
+++ b/Mathlib/ModelTheory/Satisfiability.lean
@@ -13,29 +13,29 @@ This file deals with the satisfiability of first-order theories, as well as equi
 
 ## Main Definitions
 * `FirstOrder.Language.Theory.IsSatisfiable`: `T.IsSatisfiable` indicates that `T` has a nonempty
-model.
+  model.
 * `FirstOrder.Language.Theory.IsFinitelySatisfiable`: `T.IsFinitelySatisfiable` indicates that
-every finite subset of `T` is satisfiable.
+  every finite subset of `T` is satisfiable.
 * `FirstOrder.Language.Theory.IsComplete`: `T.IsComplete` indicates that `T` is satisfiable and
-models each sentence or its negation.
+  models each sentence or its negation.
 * `FirstOrder.Language.Theory.SemanticallyEquivalent`: `T.SemanticallyEquivalent φ ψ` indicates
-that `φ` and `ψ` are equivalent formulas or sentences in models of `T`.
+  that `φ` and `ψ` are equivalent formulas or sentences in models of `T`.
 * `Cardinal.Categorical`: A theory is `κ`-categorical if all models of size `κ` are isomorphic.
 
 ## Main Results
 * The Compactness Theorem, `FirstOrder.Language.Theory.isSatisfiable_iff_isFinitelySatisfiable`,
-shows that a theory is satisfiable iff it is finitely satisfiable.
+  shows that a theory is satisfiable iff it is finitely satisfiable.
 * `FirstOrder.Language.completeTheory.isComplete`: The complete theory of a structure is
-complete.
+  complete.
 * `FirstOrder.Language.Theory.exists_large_model_of_infinite_model` shows that any theory with an
-infinite model has arbitrarily large models.
+  infinite model has arbitrarily large models.
 * `FirstOrder.Language.Theory.exists_elementaryEmbedding_card_eq`: The Upward Löwenheim–Skolem
-Theorem: If `κ` is a cardinal greater than the cardinalities of `L` and an infinite `L`-structure
-`M`, then `M` has an elementary extension of cardinality `κ`.
+  Theorem: If `κ` is a cardinal greater than the cardinalities of `L` and an infinite `L`-structure
+  `M`, then `M` has an elementary extension of cardinality `κ`.
 
 ## Implementation Details
 * Satisfiability of an `L.Theory` `T` is defined in the minimal universe containing all the symbols
-of `L`. By Löwenheim-Skolem, this is equivalent to satisfiability in any universe.
+  of `L`. By Löwenheim-Skolem, this is equivalent to satisfiability in any universe.
 
 -/
 

--- a/Mathlib/ModelTheory/Semantics.lean
+++ b/Mathlib/ModelTheory/Semantics.lean
@@ -9,40 +9,44 @@ import Mathlib.Data.List.ProdSigma
 
 /-!
 # Basics on First-Order Semantics
+
 This file defines the interpretations of first-order terms, formulas, sentences, and theories
 in a style inspired by the [Flypitch project](https://flypitch.github.io/).
 
 ## Main Definitions
-* `FirstOrder.Language.Term.realize` is defined so that `t.realize v` is the term `t` evaluated at
+
+- `FirstOrder.Language.Term.realize` is defined so that `t.realize v` is the term `t` evaluated at
   variables `v`.
-* `FirstOrder.Language.BoundedFormula.Realize` is defined so that `φ.Realize v xs` is the bounded
+- `FirstOrder.Language.BoundedFormula.Realize` is defined so that `φ.Realize v xs` is the bounded
   formula `φ` evaluated at tuples of variables `v` and `xs`.
-* `FirstOrder.Language.Formula.Realize` is defined so that `φ.Realize v` is the formula `φ`
+- `FirstOrder.Language.Formula.Realize` is defined so that `φ.Realize v` is the formula `φ`
   evaluated at variables `v`.
-* `FirstOrder.Language.Sentence.Realize` is defined so that `φ.Realize M` is the sentence `φ`
+- `FirstOrder.Language.Sentence.Realize` is defined so that `φ.Realize M` is the sentence `φ`
   evaluated in the structure `M`. Also denoted `M ⊨ φ`.
-* `FirstOrder.Language.Theory.Model` is defined so that `T.Model M` is true if and only if every
+- `FirstOrder.Language.Theory.Model` is defined so that `T.Model M` is true if and only if every
   sentence of `T` is realized in `M`. Also denoted `T ⊨ φ`.
 
 ## Main Results
-* Several results in this file show that syntactic constructions such as `relabel`, `castLE`,
+
+- Several results in this file show that syntactic constructions such as `relabel`, `castLE`,
   `liftAt`, `subst`, and the actions of language maps commute with realization of terms, formulas,
   sentences, and theories.
 
 ## Implementation Notes
-* Formulas use a modified version of de Bruijn variables. Specifically, a `L.BoundedFormula α n`
+
+- Formulas use a modified version of de Bruijn variables. Specifically, a `L.BoundedFormula α n`
   is a formula with some variables indexed by a type `α`, which cannot be quantified over, and some
   indexed by `Fin n`, which can. For any `φ : L.BoundedFormula α (n + 1)`, we define the formula
   `∀' φ : L.BoundedFormula α n` by universally quantifying over the variable indexed by
   `n : Fin (n + 1)`.
 
 ## References
+
 For the Flypitch project:
 - [J. Han, F. van Doorn, *A formal proof of the independence of the continuum hypothesis*]
   [flypitch_cpp]
 - [J. Han, F. van Doorn, *A formalization of forcing and the unprovability of
   the continuum hypothesis*][flypitch_itp]
-
 -/
 
 

--- a/Mathlib/ModelTheory/Semantics.lean
+++ b/Mathlib/ModelTheory/Semantics.lean
@@ -14,34 +14,34 @@ in a style inspired by the [Flypitch project](https://flypitch.github.io/).
 
 ## Main Definitions
 * `FirstOrder.Language.Term.realize` is defined so that `t.realize v` is the term `t` evaluated at
-variables `v`.
+  variables `v`.
 * `FirstOrder.Language.BoundedFormula.Realize` is defined so that `φ.Realize v xs` is the bounded
-formula `φ` evaluated at tuples of variables `v` and `xs`.
+  formula `φ` evaluated at tuples of variables `v` and `xs`.
 * `FirstOrder.Language.Formula.Realize` is defined so that `φ.Realize v` is the formula `φ`
-evaluated at variables `v`.
+  evaluated at variables `v`.
 * `FirstOrder.Language.Sentence.Realize` is defined so that `φ.Realize M` is the sentence `φ`
-evaluated in the structure `M`. Also denoted `M ⊨ φ`.
+  evaluated in the structure `M`. Also denoted `M ⊨ φ`.
 * `FirstOrder.Language.Theory.Model` is defined so that `T.Model M` is true if and only if every
-sentence of `T` is realized in `M`. Also denoted `T ⊨ φ`.
+  sentence of `T` is realized in `M`. Also denoted `T ⊨ φ`.
 
 ## Main Results
 * Several results in this file show that syntactic constructions such as `relabel`, `castLE`,
-`liftAt`, `subst`, and the actions of language maps commute with realization of terms, formulas,
-sentences, and theories.
+  `liftAt`, `subst`, and the actions of language maps commute with realization of terms, formulas,
+  sentences, and theories.
 
 ## Implementation Notes
 * Formulas use a modified version of de Bruijn variables. Specifically, a `L.BoundedFormula α n`
-is a formula with some variables indexed by a type `α`, which cannot be quantified over, and some
-indexed by `Fin n`, which can. For any `φ : L.BoundedFormula α (n + 1)`, we define the formula
-`∀' φ : L.BoundedFormula α n` by universally quantifying over the variable indexed by
-`n : Fin (n + 1)`.
+  is a formula with some variables indexed by a type `α`, which cannot be quantified over, and some
+  indexed by `Fin n`, which can. For any `φ : L.BoundedFormula α (n + 1)`, we define the formula
+  `∀' φ : L.BoundedFormula α n` by universally quantifying over the variable indexed by
+  `n : Fin (n + 1)`.
 
 ## References
 For the Flypitch project:
 - [J. Han, F. van Doorn, *A formal proof of the independence of the continuum hypothesis*]
-[flypitch_cpp]
+  [flypitch_cpp]
 - [J. Han, F. van Doorn, *A formalization of forcing and the unprovability of
-the continuum hypothesis*][flypitch_itp]
+  the continuum hypothesis*][flypitch_itp]
 
 -/
 

--- a/Mathlib/ModelTheory/Skolem.lean
+++ b/Mathlib/ModelTheory/Skolem.lean
@@ -9,17 +9,19 @@ import Mathlib.ModelTheory.ElementarySubstructures
 # Skolem Functions and Downward Löwenheim–Skolem
 
 ## Main Definitions
-* `FirstOrder.Language.skolem₁` is a language consisting of Skolem functions for another language.
+
+- `FirstOrder.Language.skolem₁` is a language consisting of Skolem functions for another language.
 
 ## Main Results
-* `FirstOrder.Language.exists_elementarySubstructure_card_eq` is the Downward Löwenheim–Skolem
+
+- `FirstOrder.Language.exists_elementarySubstructure_card_eq` is the Downward Löwenheim–Skolem
   theorem: If `s` is a set in an `L`-structure `M` and `κ` an infinite cardinal such that
   `max (#s, L.card) ≤ κ` and `κ ≤ # M`, then `M` has an elementary substructure containing `s` of
   cardinality `κ`.
 
 ## TODO
-* Use `skolem₁` recursively to construct an actual Skolemization of a language.
 
+- Use `skolem₁` recursively to construct an actual Skolemization of a language.
 -/
 
 

--- a/Mathlib/ModelTheory/Substructures.lean
+++ b/Mathlib/ModelTheory/Substructures.lean
@@ -14,19 +14,19 @@ substructures appearing in the algebra library.
 
 ## Main Definitions
 * A `FirstOrder.Language.Substructure` is defined so that `L.Substructure M` is the type of all
-substructures of the `L`-structure `M`.
+  substructures of the `L`-structure `M`.
 * `FirstOrder.Language.Substructure.closure` is defined so that if `s : Set M`, `closure L s` is
-the least substructure of `M` containing `s`.
+  the least substructure of `M` containing `s`.
 * `FirstOrder.Language.Substructure.comap` is defined so that `s.comap f` is the preimage of the
-substructure `s` under the homomorphism `f`, as a substructure.
+  substructure `s` under the homomorphism `f`, as a substructure.
 * `FirstOrder.Language.Substructure.map` is defined so that `s.map f` is the image of the
-substructure `s` under the homomorphism `f`, as a substructure.
+  substructure `s` under the homomorphism `f`, as a substructure.
 * `FirstOrder.Language.Hom.range` is defined so that `f.range` is the range of the
-homomorphism `f`, as a substructure.
+  homomorphism `f`, as a substructure.
 * `FirstOrder.Language.Hom.domRestrict` and `FirstOrder.Language.Hom.codRestrict` restrict
-the domain and codomain respectively of first-order homomorphisms to substructures.
+  the domain and codomain respectively of first-order homomorphisms to substructures.
 * `FirstOrder.Language.Embedding.domRestrict` and `FirstOrder.Language.Embedding.codRestrict`
-restrict the domain and codomain respectively of first-order embeddings to substructures.
+  restrict the domain and codomain respectively of first-order embeddings to substructures.
 * `FirstOrder.Language.Substructure.inclusion` is the inclusion embedding between substructures.
 
 ## Main Results

--- a/Mathlib/ModelTheory/Substructures.lean
+++ b/Mathlib/ModelTheory/Substructures.lean
@@ -9,29 +9,31 @@ import Mathlib.ModelTheory.Encoding
 
 /-!
 # First-Order Substructures
+
 This file defines substructures of first-order structures in a similar manner to the various
 substructures appearing in the algebra library.
 
 ## Main Definitions
-* A `FirstOrder.Language.Substructure` is defined so that `L.Substructure M` is the type of all
+
+- A `FirstOrder.Language.Substructure` is defined so that `L.Substructure M` is the type of all
   substructures of the `L`-structure `M`.
-* `FirstOrder.Language.Substructure.closure` is defined so that if `s : Set M`, `closure L s` is
+- `FirstOrder.Language.Substructure.closure` is defined so that if `s : Set M`, `closure L s` is
   the least substructure of `M` containing `s`.
-* `FirstOrder.Language.Substructure.comap` is defined so that `s.comap f` is the preimage of the
+- `FirstOrder.Language.Substructure.comap` is defined so that `s.comap f` is the preimage of the
   substructure `s` under the homomorphism `f`, as a substructure.
-* `FirstOrder.Language.Substructure.map` is defined so that `s.map f` is the image of the
+- `FirstOrder.Language.Substructure.map` is defined so that `s.map f` is the image of the
   substructure `s` under the homomorphism `f`, as a substructure.
-* `FirstOrder.Language.Hom.range` is defined so that `f.range` is the range of the
+- `FirstOrder.Language.Hom.range` is defined so that `f.range` is the range of the
   homomorphism `f`, as a substructure.
-* `FirstOrder.Language.Hom.domRestrict` and `FirstOrder.Language.Hom.codRestrict` restrict
+- `FirstOrder.Language.Hom.domRestrict` and `FirstOrder.Language.Hom.codRestrict` restrict
   the domain and codomain respectively of first-order homomorphisms to substructures.
-* `FirstOrder.Language.Embedding.domRestrict` and `FirstOrder.Language.Embedding.codRestrict`
+- `FirstOrder.Language.Embedding.domRestrict` and `FirstOrder.Language.Embedding.codRestrict`
   restrict the domain and codomain respectively of first-order embeddings to substructures.
-* `FirstOrder.Language.Substructure.inclusion` is the inclusion embedding between substructures.
+- `FirstOrder.Language.Substructure.inclusion` is the inclusion embedding between substructures.
 
 ## Main Results
-* `L.Substructure M` forms a `CompleteLattice`.
 
+- `L.Substructure M` forms a `CompleteLattice`.
 -/
 
 

--- a/Mathlib/ModelTheory/Syntax.lean
+++ b/Mathlib/ModelTheory/Syntax.lean
@@ -9,45 +9,48 @@ import Mathlib.ModelTheory.LanguageMap
 
 /-!
 # Basics on First-Order Syntax
+
 This file defines first-order terms, formulas, sentences, and theories in a style inspired by the
 [Flypitch project](https://flypitch.github.io/).
 
 ## Main Definitions
-* A `FirstOrder.Language.Term` is defined so that `L.Term α` is the type of `L`-terms with free
+
+- A `FirstOrder.Language.Term` is defined so that `L.Term α` is the type of `L`-terms with free
   variables indexed by `α`.
-* A `FirstOrder.Language.Formula` is defined so that `L.Formula α` is the type of `L`-formulas with
+- A `FirstOrder.Language.Formula` is defined so that `L.Formula α` is the type of `L`-formulas with
   free variables indexed by `α`.
-* A `FirstOrder.Language.Sentence` is a formula with no free variables.
-* A `FirstOrder.Language.Theory` is a set of sentences.
-* The variables of terms and formulas can be relabelled with `FirstOrder.Language.Term.relabel`,
+- A `FirstOrder.Language.Sentence` is a formula with no free variables.
+- A `FirstOrder.Language.Theory` is a set of sentences.
+- The variables of terms and formulas can be relabelled with `FirstOrder.Language.Term.relabel`,
   `FirstOrder.Language.BoundedFormula.relabel`, and `FirstOrder.Language.Formula.relabel`.
-* Given an operation on terms and an operation on relations,
+- Given an operation on terms and an operation on relations,
   `FirstOrder.Language.BoundedFormula.mapTermRel` gives an operation on formulas.
-* `FirstOrder.Language.BoundedFormula.castLE` adds more `Fin`-indexed variables.
-* `FirstOrder.Language.BoundedFormula.liftAt` raises the indexes of the `Fin`-indexed variables
+- `FirstOrder.Language.BoundedFormula.castLE` adds more `Fin`-indexed variables.
+- `FirstOrder.Language.BoundedFormula.liftAt` raises the indexes of the `Fin`-indexed variables
   above a particular index.
-* `FirstOrder.Language.Term.subst` and `FirstOrder.Language.BoundedFormula.subst` substitute
+- `FirstOrder.Language.Term.subst` and `FirstOrder.Language.BoundedFormula.subst` substitute
   variables with given terms.
-* Language maps can act on syntactic objects with functions such as
+- Language maps can act on syntactic objects with functions such as
   `FirstOrder.Language.LHom.onFormula`.
-* `FirstOrder.Language.Term.constantsVarsEquiv` and
+- `FirstOrder.Language.Term.constantsVarsEquiv` and
   `FirstOrder.Language.BoundedFormula.constantsVarsEquiv` switch terms and formulas between having
   constants in the language and having extra variables indexed by the same type.
 
 ## Implementation Notes
-* Formulas use a modified version of de Bruijn variables. Specifically, a `L.BoundedFormula α n`
+
+- Formulas use a modified version of de Bruijn variables. Specifically, a `L.BoundedFormula α n`
   is a formula with some variables indexed by a type `α`, which cannot be quantified over, and some
   indexed by `Fin n`, which can. For any `φ : L.BoundedFormula α (n + 1)`, we define the formula
   `∀' φ : L.BoundedFormula α n` by universally quantifying over the variable indexed by
   `n : Fin (n + 1)`.
 
 ## References
+
 For the Flypitch project:
 - [J. Han, F. van Doorn, *A formal proof of the independence of the continuum hypothesis*]
   [flypitch_cpp]
 - [J. Han, F. van Doorn, *A formalization of forcing and the unprovability of
   the continuum hypothesis*][flypitch_itp]
-
 -/
 
 

--- a/Mathlib/ModelTheory/Syntax.lean
+++ b/Mathlib/ModelTheory/Syntax.lean
@@ -20,33 +20,33 @@ This file defines first-order terms, formulas, sentences, and theories in a styl
 * A `FirstOrder.Language.Sentence` is a formula with no free variables.
 * A `FirstOrder.Language.Theory` is a set of sentences.
 * The variables of terms and formulas can be relabelled with `FirstOrder.Language.Term.relabel`,
-`FirstOrder.Language.BoundedFormula.relabel`, and `FirstOrder.Language.Formula.relabel`.
+  `FirstOrder.Language.BoundedFormula.relabel`, and `FirstOrder.Language.Formula.relabel`.
 * Given an operation on terms and an operation on relations,
   `FirstOrder.Language.BoundedFormula.mapTermRel` gives an operation on formulas.
 * `FirstOrder.Language.BoundedFormula.castLE` adds more `Fin`-indexed variables.
 * `FirstOrder.Language.BoundedFormula.liftAt` raises the indexes of the `Fin`-indexed variables
-above a particular index.
+  above a particular index.
 * `FirstOrder.Language.Term.subst` and `FirstOrder.Language.BoundedFormula.subst` substitute
-variables with given terms.
+  variables with given terms.
 * Language maps can act on syntactic objects with functions such as
-`FirstOrder.Language.LHom.onFormula`.
+  `FirstOrder.Language.LHom.onFormula`.
 * `FirstOrder.Language.Term.constantsVarsEquiv` and
-`FirstOrder.Language.BoundedFormula.constantsVarsEquiv` switch terms and formulas between having
-constants in the language and having extra variables indexed by the same type.
+  `FirstOrder.Language.BoundedFormula.constantsVarsEquiv` switch terms and formulas between having
+  constants in the language and having extra variables indexed by the same type.
 
 ## Implementation Notes
 * Formulas use a modified version of de Bruijn variables. Specifically, a `L.BoundedFormula α n`
-is a formula with some variables indexed by a type `α`, which cannot be quantified over, and some
-indexed by `Fin n`, which can. For any `φ : L.BoundedFormula α (n + 1)`, we define the formula
-`∀' φ : L.BoundedFormula α n` by universally quantifying over the variable indexed by
-`n : Fin (n + 1)`.
+  is a formula with some variables indexed by a type `α`, which cannot be quantified over, and some
+  indexed by `Fin n`, which can. For any `φ : L.BoundedFormula α (n + 1)`, we define the formula
+  `∀' φ : L.BoundedFormula α n` by universally quantifying over the variable indexed by
+  `n : Fin (n + 1)`.
 
 ## References
 For the Flypitch project:
 - [J. Han, F. van Doorn, *A formal proof of the independence of the continuum hypothesis*]
-[flypitch_cpp]
+  [flypitch_cpp]
 - [J. Han, F. van Doorn, *A formalization of forcing and the unprovability of
-the continuum hypothesis*][flypitch_itp]
+  the continuum hypothesis*][flypitch_itp]
 
 -/
 

--- a/Mathlib/ModelTheory/Types.lean
+++ b/Mathlib/ModelTheory/Types.lean
@@ -21,11 +21,11 @@ This file defines the space of complete types over a first-order theory.
 * `FirstOrder.Language.Theory.CompleteType.nonempty_iff`:
   The space `T.CompleteType α` is nonempty exactly when `T` is satisfiable.
 * `FirstOrder.Language.Theory.CompleteType.exists_modelType_is_realized_in`: Every type is realized
-in some model.
+  in some model.
 
 ## Implementation Notes
 * Complete types are implemented as maximal consistent theories in an expanded language.
-More frequently they are described as maximal consistent sets of formulas, but this is equivalent.
+  More frequently they are described as maximal consistent sets of formulas, but this is equivalent.
 
 ## TODO
 * Connect `T.CompleteType α` to sets of formulas `L.Formula α`.

--- a/Mathlib/ModelTheory/Types.lean
+++ b/Mathlib/ModelTheory/Types.lean
@@ -7,29 +7,33 @@ import Mathlib.ModelTheory.Satisfiability
 
 /-!
 # Type Spaces
+
 This file defines the space of complete types over a first-order theory.
 (Note that types in model theory are different from types in type theory.)
 
 ## Main Definitions
-* `FirstOrder.Language.Theory.CompleteType`:
+
+- `FirstOrder.Language.Theory.CompleteType`:
   `T.CompleteType α` consists of complete types over the theory `T` with variables `α`.
-* `FirstOrder.Language.Theory.typeOf` is the type of a given tuple.
-* `FirstOrder.Language.Theory.realizedTypes`: `T.realizedTypes M α` is the set of
+- `FirstOrder.Language.Theory.typeOf` is the type of a given tuple.
+- `FirstOrder.Language.Theory.realizedTypes`: `T.realizedTypes M α` is the set of
   types in `T.CompleteType α` that are realized in `M` - that is, the type of some tuple in `M`.
 
 ## Main Results
-* `FirstOrder.Language.Theory.CompleteType.nonempty_iff`:
+
+- `FirstOrder.Language.Theory.CompleteType.nonempty_iff`:
   The space `T.CompleteType α` is nonempty exactly when `T` is satisfiable.
-* `FirstOrder.Language.Theory.CompleteType.exists_modelType_is_realized_in`: Every type is realized
+- `FirstOrder.Language.Theory.CompleteType.exists_modelType_is_realized_in`: Every type is realized
   in some model.
 
 ## Implementation Notes
-* Complete types are implemented as maximal consistent theories in an expanded language.
+
+- Complete types are implemented as maximal consistent theories in an expanded language.
   More frequently they are described as maximal consistent sets of formulas, but this is equivalent.
 
 ## TODO
-* Connect `T.CompleteType α` to sets of formulas `L.Formula α`.
 
+- Connect `T.CompleteType α` to sets of formulas `L.Formula α`.
 -/
 
 

--- a/Mathlib/ModelTheory/Ultraproducts.lean
+++ b/Mathlib/ModelTheory/Ultraproducts.lean
@@ -7,19 +7,22 @@ import Mathlib.ModelTheory.Quotients
 import Mathlib.Order.Filter.Germ.Basic
 import Mathlib.Order.Filter.Ultrafilter
 
-/-! # Ultraproducts and Łoś's Theorem
+/-!
+# Ultraproducts and Łoś's Theorem
 
 ## Main Definitions
-* `FirstOrder.Language.Ultraproduct.Structure` is the ultraproduct structure on `Filter.Product`.
+
+- `FirstOrder.Language.Ultraproduct.Structure` is the ultraproduct structure on `Filter.Product`.
 
 ## Main Results
-* Łoś's Theorem: `FirstOrder.Language.Ultraproduct.sentence_realize`. An ultraproduct models a
+
+- Łoś's Theorem: `FirstOrder.Language.Ultraproduct.sentence_realize`. An ultraproduct models a
   sentence `φ` if and only if the set of structures in the product that model `φ` is in the
   ultrafilter.
 
 ## Tags
-ultraproduct, Los's theorem
 
+ultraproduct, Los's theorem
 -/
 
 universe u v

--- a/Mathlib/ModelTheory/Ultraproducts.lean
+++ b/Mathlib/ModelTheory/Ultraproducts.lean
@@ -14,8 +14,8 @@ import Mathlib.Order.Filter.Ultrafilter
 
 ## Main Results
 * Łoś's Theorem: `FirstOrder.Language.Ultraproduct.sentence_realize`. An ultraproduct models a
-sentence `φ` if and only if the set of structures in the product that model `φ` is in the
-ultrafilter.
+  sentence `φ` if and only if the set of structures in the product that model `φ` is in the
+  ultrafilter.
 
 ## Tags
 ultraproduct, Los's theorem


### PR DESCRIPTION
Updates the style on docstrings of files in the Model Theory folder to better match the current style guide.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
