### PR TITLE
[Merged by Bors] - feat(Analysis/Complex/ReImTopology): Uniform continuity of re im

### DIFF
--- a/Mathlib/Analysis/Complex/Basic.lean
+++ b/Mathlib/Analysis/Complex/Basic.lean
@@ -241,7 +241,7 @@ def reCLM : ℂ →L[ℝ] ℝ :=
 theorem continuous_re : Continuous re :=
   reCLM.continuous
 
-lemma UniformlyContinous_re : UniformContinuous re :=
+lemma uniformlyContinous_re : UniformContinuous re :=
   reCLM.uniformContinuous
 
 @[simp]
@@ -260,7 +260,7 @@ def imCLM : ℂ →L[ℝ] ℝ :=
 theorem continuous_im : Continuous im :=
   imCLM.continuous
 
-lemma UniformlyContinous_im : UniformContinuous im :=
+lemma uniformlyContinous_im : UniformContinuous im :=
   imCLM.uniformContinuous
 
 @[simp]

--- a/Mathlib/Analysis/Complex/Basic.lean
+++ b/Mathlib/Analysis/Complex/Basic.lean
@@ -241,11 +241,8 @@ def reCLM : ℂ →L[ℝ] ℝ :=
 theorem continuous_re : Continuous re :=
   reCLM.continuous
 
-lemma UniformlyContinous_re : UniformContinuous re := by
-  rw [Metric.uniformContinuous_iff]
-  intro ε hε
-  refine ⟨ε, hε, fun hxy => ?_⟩
-  apply lt_of_le_of_lt (Complex.abs_re_le_abs _) hxy
+lemma UniformlyContinous_re : UniformContinuous re :=
+  reCLM.uniformContinuous
 
 @[simp]
 theorem reCLM_coe : (reCLM : ℂ →ₗ[ℝ] ℝ) = reLm :=
@@ -263,11 +260,8 @@ def imCLM : ℂ →L[ℝ] ℝ :=
 theorem continuous_im : Continuous im :=
   imCLM.continuous
 
-lemma UniformlyContinous_im : UniformContinuous im := by
-  rw [Metric.uniformContinuous_iff]
-  intro ε hε
-  refine ⟨ε, hε, fun hxy => ?_⟩
-  apply lt_of_le_of_lt (Complex.abs_im_le_abs _) hxy
+lemma UniformlyContinous_im : UniformContinuous im :=
+  imCLM.uniformContinuous
 
 @[simp]
 theorem imCLM_coe : (imCLM : ℂ →ₗ[ℝ] ℝ) = imLm :=

--- a/Mathlib/Analysis/Complex/Basic.lean
+++ b/Mathlib/Analysis/Complex/Basic.lean
@@ -241,7 +241,7 @@ def reCLM : ℂ →L[ℝ] ℝ :=
 theorem continuous_re : Continuous re :=
   reCLM.continuous
 
-lemma UniformlyContinous_re : UniformContinuous (fun x : ℂ => x.re) := by
+lemma UniformlyContinous_re : UniformContinuous re := by
   rw [Metric.uniformContinuous_iff]
   intro ε hε
   refine ⟨ε, hε, fun hxy =>  ?_⟩
@@ -263,7 +263,7 @@ def imCLM : ℂ →L[ℝ] ℝ :=
 theorem continuous_im : Continuous im :=
   imCLM.continuous
 
-lemma UniformlyContinous_im : UniformContinuous (fun x : ℂ => x.im) := by
+lemma UniformlyContinous_im : UniformContinuous im := by
   rw [Metric.uniformContinuous_iff]
   intro ε hε
   refine ⟨ε, hε, fun hxy =>  ?_⟩

--- a/Mathlib/Analysis/Complex/Basic.lean
+++ b/Mathlib/Analysis/Complex/Basic.lean
@@ -241,6 +241,12 @@ def reCLM : ℂ →L[ℝ] ℝ :=
 theorem continuous_re : Continuous re :=
   reCLM.continuous
 
+lemma UniformlyContinous_re : UniformContinuous (fun x : ℂ => x.re) := by
+  rw [Metric.uniformContinuous_iff]
+  intro ε hε
+  refine ⟨ε, hε, fun hxy =>  ?_⟩
+  apply lt_of_le_of_lt (Complex.abs_re_le_abs _) hxy
+
 @[simp]
 theorem reCLM_coe : (reCLM : ℂ →ₗ[ℝ] ℝ) = reLm :=
   rfl
@@ -256,6 +262,12 @@ def imCLM : ℂ →L[ℝ] ℝ :=
 @[continuity, fun_prop]
 theorem continuous_im : Continuous im :=
   imCLM.continuous
+
+lemma UniformlyContinous_im : UniformContinuous (fun x : ℂ => x.im) := by
+  rw [Metric.uniformContinuous_iff]
+  intro ε hε
+  refine ⟨ε, hε, fun hxy =>  ?_⟩
+  apply lt_of_le_of_lt (Complex.abs_im_le_abs _) hxy
 
 @[simp]
 theorem imCLM_coe : (imCLM : ℂ →ₗ[ℝ] ℝ) = imLm :=

--- a/Mathlib/Analysis/Complex/Basic.lean
+++ b/Mathlib/Analysis/Complex/Basic.lean
@@ -244,7 +244,7 @@ theorem continuous_re : Continuous re :=
 lemma UniformlyContinous_re : UniformContinuous re := by
   rw [Metric.uniformContinuous_iff]
   intro ε hε
-  refine ⟨ε, hε, fun hxy =>  ?_⟩
+  refine ⟨ε, hε, fun hxy => ?_⟩
   apply lt_of_le_of_lt (Complex.abs_re_le_abs _) hxy
 
 @[simp]
@@ -266,7 +266,7 @@ theorem continuous_im : Continuous im :=
 lemma UniformlyContinous_im : UniformContinuous im := by
   rw [Metric.uniformContinuous_iff]
   intro ε hε
-  refine ⟨ε, hε, fun hxy =>  ?_⟩
+  refine ⟨ε, hε, fun hxy => ?_⟩
   apply lt_of_le_of_lt (Complex.abs_im_le_abs _) hxy
 
 @[simp]

--- a/Mathlib/Analysis/Complex/ReImTopology.lean
+++ b/Mathlib/Analysis/Complex/ReImTopology.lean
@@ -183,21 +183,21 @@ variable {α ι : Type*}
 protected lemma TendstoUniformlyOn.re {f : ι → α → ℂ} {p : Filter ι} {g : α → ℂ} {K : Set α}
     (hf : TendstoUniformlyOn f g p K) :
     TendstoUniformlyOn (fun n x => (f n x).re) (fun y => (g y).re) p K := by
-  apply UniformContinuous.comp_tendstoUniformlyOn UniformlyContinous_re hf
+  apply UniformContinuous.comp_tendstoUniformlyOn uniformlyContinous_re hf
 
 protected lemma TendstoUniformly.re {f : ι → α → ℂ} {p : Filter ι} {g : α → ℂ}
     (hf : TendstoUniformly f g p) :
     TendstoUniformly (fun n x => (f n x).re) (fun y => (g y).re) p := by
-  apply UniformContinuous.comp_tendstoUniformly UniformlyContinous_re hf
+  apply UniformContinuous.comp_tendstoUniformly uniformlyContinous_re hf
 
 protected lemma TendstoUniformlyOn.im {f : ι → α → ℂ} {p : Filter ι} {g : α → ℂ} {K : Set α}
     (hf : TendstoUniformlyOn f g p K) :
     TendstoUniformlyOn (fun n x => (f n x).im) (fun y => (g y).im) p K := by
-  apply UniformContinuous.comp_tendstoUniformlyOn UniformlyContinous_im hf
+  apply UniformContinuous.comp_tendstoUniformlyOn uniformlyContinous_im hf
 
 protected lemma TendstoUniformly.im {f : ι → α → ℂ} {p : Filter ι} {g : α → ℂ}
     (hf : TendstoUniformly f g p) :
     TendstoUniformly (fun n x => (f n x).im) (fun y => (g y).im) p := by
-  apply UniformContinuous.comp_tendstoUniformly UniformlyContinous_im hf
+  apply UniformContinuous.comp_tendstoUniformly uniformlyContinous_im hf
 
 end continuity

--- a/Mathlib/Analysis/Complex/ReImTopology.lean
+++ b/Mathlib/Analysis/Complex/ReImTopology.lean
@@ -181,23 +181,23 @@ section continuity
 variable {α ι : Type*}
 
 protected lemma TendstoUniformlyOn.re {f : ι → α → ℂ} {p : Filter ι} {g : α → ℂ} {K : Set α}
-    (hf : TendstoUniformlyOn f g p K) : TendstoUniformlyOn (fun n x => (f n x).re)
-      (fun y => (g y).re) p K := by
+    (hf : TendstoUniformlyOn f g p K) :
+    TendstoUniformlyOn (fun n x => (f n x).re) (fun y => (g y).re) p K := by
   apply UniformContinuous.comp_tendstoUniformlyOn UniformlyContinous_re hf
 
 protected lemma TendstoUniformly.re {f : ι → α → ℂ} {p : Filter ι} {g : α → ℂ}
-    (hf : TendstoUniformly f g p) : TendstoUniformly (fun n x => (f n x).re)
-      (fun y => (g y).re) p := by
+    (hf : TendstoUniformly f g p) :
+    TendstoUniformly (fun n x => (f n x).re) (fun y => (g y).re) p := by
   apply UniformContinuous.comp_tendstoUniformly UniformlyContinous_re hf
 
-protected lemma TendstoUniformlyOn.im (f : ι → α → ℂ) {p : Filter ι} {g : α → ℂ} {K : Set α}
-    (hf : TendstoUniformlyOn f g p K) : TendstoUniformlyOn (fun n x => (f n x).im)
-      (fun y => (g y).im) p K := by
+protected lemma TendstoUniformlyOn.im {f : ι → α → ℂ} {p : Filter ι} {g : α → ℂ} {K : Set α}
+    (hf : TendstoUniformlyOn f g p K) :
+    TendstoUniformlyOn (fun n x => (f n x).im) (fun y => (g y).im) p K := by
   apply UniformContinuous.comp_tendstoUniformlyOn UniformlyContinous_im hf
 
-protected lemma TendstoUniformly.im (f : ι → α → ℂ) {p : Filter ι} {g : α → ℂ}
-    (hf : TendstoUniformly f g p) : TendstoUniformly (fun n x => (f n x).im)
-      (fun y => (g y).im) p := by
+protected lemma TendstoUniformly.im {f : ι → α → ℂ} {p : Filter ι} {g : α → ℂ}
+    (hf : TendstoUniformly f g p) :
+    TendstoUniformly (fun n x => (f n x).im) (fun y => (g y).im) p := by
   apply UniformContinuous.comp_tendstoUniformly UniformlyContinous_im hf
 
 end continuity

--- a/Mathlib/Analysis/Complex/ReImTopology.lean
+++ b/Mathlib/Analysis/Complex/ReImTopology.lean
@@ -180,14 +180,24 @@ section continuity
 
 variable {α ι : Type*}
 
-lemma TendstoUniformlyOn_re_part (f : ι → α → ℂ) {p : Filter ι} (g : α → ℂ) (K : Set α)
+protected lemma TendstoUniformlyOn.re {f : ι → α → ℂ} {p : Filter ι} {g : α → ℂ} {K : Set α}
     (hf : TendstoUniformlyOn f g p K) : TendstoUniformlyOn (fun n x => (f n x).re)
       (fun y => (g y).re) p K := by
   apply UniformContinuous.comp_tendstoUniformlyOn UniformlyContinous_re hf
 
-lemma TendstoUniformlyOn_im_part (f : ι → α → ℂ) {p : Filter ι} (g : α → ℂ) (K : Set α)
+protected lemma TendstoUniformly.re {f : ι → α → ℂ} {p : Filter ι} {g : α → ℂ}
+    (hf : TendstoUniformly f g p) : TendstoUniformly (fun n x => (f n x).re)
+      (fun y => (g y).re) p := by
+  apply UniformContinuous.comp_tendstoUniformly UniformlyContinous_re hf
+
+protected lemma TendstoUniformlyOn.im (f : ι → α → ℂ) {p : Filter ι} {g : α → ℂ} {K : Set α}
     (hf : TendstoUniformlyOn f g p K) : TendstoUniformlyOn (fun n x => (f n x).im)
       (fun y => (g y).im) p K := by
   apply UniformContinuous.comp_tendstoUniformlyOn UniformlyContinous_im hf
+
+protected lemma TendstoUniformly.im (f : ι → α → ℂ) {p : Filter ι} {g : α → ℂ}
+    (hf : TendstoUniformly f g p) : TendstoUniformly (fun n x => (f n x).im)
+      (fun y => (g y).im) p := by
+  apply UniformContinuous.comp_tendstoUniformly UniformlyContinous_im hf
 
 end continuity

--- a/Mathlib/Analysis/Complex/ReImTopology.lean
+++ b/Mathlib/Analysis/Complex/ReImTopology.lean
@@ -180,18 +180,6 @@ section continuity
 
 variable {α ι : Type*}
 
-lemma UniformlyContinous_re : UniformContinuous (fun x : ℂ => x.re) := by
-  rw [Metric.uniformContinuous_iff]
-  intro ε hε
-  refine ⟨ε, hε, fun hxy =>  ?_⟩
-  apply lt_of_le_of_lt (Complex.abs_re_le_abs _) hxy
-
-lemma UniformlyContinous_im : UniformContinuous (fun x : ℂ => x.im) := by
-  rw [Metric.uniformContinuous_iff]
-  intro ε hε
-  refine ⟨ε, hε, fun hxy =>  ?_⟩
-  apply lt_of_le_of_lt (Complex.abs_im_le_abs _) hxy
-
 lemma TendstoUniformlyOn_re_part (f : ι → α → ℂ) {p : Filter ι} (g : α → ℂ) (K : Set α)
     (hf : TendstoUniformlyOn f g p K) : TendstoUniformlyOn (fun n x => (f n x).re)
       (fun y => (g y).re) p K := by

--- a/Mathlib/Analysis/Complex/ReImTopology.lean
+++ b/Mathlib/Analysis/Complex/ReImTopology.lean
@@ -192,12 +192,12 @@ lemma UniformlyContinous_im : UniformContinuous (fun x : ℂ => x.im) := by
   refine ⟨ε, hε, fun hxy =>  ?_⟩
   apply lt_of_le_of_lt (Complex.abs_im_le_abs _) hxy
 
-lemma TendstoUniformly_re_part (f : ι → α → ℂ) {p : Filter ι} (g : α → ℂ) (K : Set α)
+lemma TendstoUniformlyOn_re_part (f : ι → α → ℂ) {p : Filter ι} (g : α → ℂ) (K : Set α)
     (hf : TendstoUniformlyOn f g p K) : TendstoUniformlyOn (fun n x => (f n x).re)
       (fun y => (g y).re) p K := by
   apply UniformContinuous.comp_tendstoUniformlyOn UniformlyContinous_re hf
 
-lemma TendstoUniformly_im_part (f : ι → α → ℂ) {p : Filter ι} (g : α → ℂ) (K : Set α)
+lemma TendstoUniformlyOn_im_part (f : ι → α → ℂ) {p : Filter ι} (g : α → ℂ) (K : Set α)
     (hf : TendstoUniformlyOn f g p K) : TendstoUniformlyOn (fun n x => (f n x).im)
       (fun y => (g y).im) p K := by
   apply UniformContinuous.comp_tendstoUniformlyOn UniformlyContinous_im hf

--- a/Mathlib/Analysis/Complex/ReImTopology.lean
+++ b/Mathlib/Analysis/Complex/ReImTopology.lean
@@ -175,3 +175,31 @@ theorem IsClosed.reProdIm (hs : IsClosed s) (ht : IsClosed t) : IsClosed (s ×�
 
 theorem Bornology.IsBounded.reProdIm (hs : IsBounded s) (ht : IsBounded t) : IsBounded (s ×ℂ t) :=
   antilipschitz_equivRealProd.isBounded_preimage (hs.prod ht)
+
+section continuity
+
+variable {α ι : Type*}
+
+lemma UniformlyContinous_re : UniformContinuous (fun x : ℂ => x.re) := by
+  rw [Metric.uniformContinuous_iff]
+  intro ε hε
+  refine ⟨ε, hε, fun hxy =>  ?_⟩
+  apply lt_of_le_of_lt (Complex.abs_re_le_abs _) hxy
+
+lemma UniformlyContinous_im : UniformContinuous (fun x : ℂ => x.im) := by
+  rw [Metric.uniformContinuous_iff]
+  intro ε hε
+  refine ⟨ε, hε, fun hxy =>  ?_⟩
+  apply lt_of_le_of_lt (Complex.abs_im_le_abs _) hxy
+
+lemma TendstoUniformly_re_part (f : ι → α → ℂ) {p : Filter ι} (g : α → ℂ) (K : Set α)
+    (hf : TendstoUniformlyOn f g p K) : TendstoUniformlyOn (fun n x => (f n x).re)
+      (fun y => (g y).re) p K := by
+  apply UniformContinuous.comp_tendstoUniformlyOn UniformlyContinous_re hf
+
+lemma TendstoUniformly_im_part (f : ι → α → ℂ) {p : Filter ι} (g : α → ℂ) (K : Set α)
+    (hf : TendstoUniformlyOn f g p K) : TendstoUniformlyOn (fun n x => (f n x).im)
+      (fun y => (g y).im) p K := by
+  apply UniformContinuous.comp_tendstoUniformlyOn UniformlyContinous_im hf
+
+end continuity


### PR DESCRIPTION
We show that re and im are uniformly continuous and then use this to show that re/im parts of a uniform limit converge uniformly.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
