### PR TITLE
[Merged by Bors] - feat: `RCLike` versions of Hahn-Banach separation theorems

### DIFF
--- a/Mathlib/Analysis/NormedSpace/Extend.lean
+++ b/Mathlib/Analysis/NormedSpace/Extend.lean
@@ -35,11 +35,10 @@ open RCLike
 
 open ComplexConjugate
 
-variable {𝕜 : Type*} [RCLike 𝕜] {F : Type*} [SeminormedAddCommGroup F]
-
+variable {𝕜 : Type*} [RCLike 𝕜] {F : Type*}
 namespace LinearMap
 
-variable [Module ℝ F] [Module 𝕜 F] [IsScalarTower ℝ 𝕜 F]
+variable  [AddCommGroup F] [Module ℝ F] [Module 𝕜 F] [IsScalarTower ℝ 𝕜 F]
 
 /-- Extend `fr : F →ₗ[ℝ] ℝ` to `F →ₗ[𝕜] 𝕜` in a way that will also be continuous and have its norm
 bounded by `‖fr‖` if `fr` is continuous. -/
@@ -85,8 +84,8 @@ theorem extendTo𝕜'_apply_re (fr : F →ₗ[ℝ] ℝ) (x : F) : re (fr.extendT
   simp only [extendTo𝕜'_apply, map_sub, zero_mul, mul_zero, sub_zero,
     rclike_simps]
 
-theorem norm_extendTo𝕜'_apply_sq [NormedSpace 𝕜 F] (fr : F →ₗ[ℝ] ℝ) (x : F) :
-    ‖(fr.extendTo𝕜' x : 𝕜)‖ ^ 2 = fr (conj (fr.extendTo𝕜' x : 𝕜) • x) :=
+theorem norm_extendTo𝕜'_apply_sq [SeminormedAddCommGroup F] [NormedSpace 𝕜 F]
+    (fr : F →ₗ[ℝ] ℝ) (x : F) : ‖(fr.extendTo𝕜' x : 𝕜)‖ ^ 2 = fr (conj (fr.extendTo𝕜' x : 𝕜) • x) :=
   calc
     ‖(fr.extendTo𝕜' x : 𝕜)‖ ^ 2 = re (conj (fr.extendTo𝕜' x) * fr.extendTo𝕜' x : 𝕜) := by
       rw [RCLike.conj_mul, ← ofReal_pow, ofReal_re]
@@ -95,7 +94,7 @@ theorem norm_extendTo𝕜'_apply_sq [NormedSpace 𝕜 F] (fr : F →ₗ[ℝ] ℝ
 
 end LinearMap
 
-variable [NormedSpace 𝕜 F]
+variable [SeminormedAddCommGroup F] [NormedSpace 𝕜 F]
 namespace ContinuousLinearMap
 
 variable [NormedSpace ℝ F] [IsScalarTower ℝ 𝕜 F]

--- a/Mathlib/Analysis/NormedSpace/Extend.lean
+++ b/Mathlib/Analysis/NormedSpace/Extend.lean
@@ -84,7 +84,7 @@ theorem extendTo𝕜'_apply_re (fr : F →ₗ[ℝ] ℝ) (x : F) : re (fr.extendT
   simp only [extendTo𝕜'_apply, map_sub, zero_mul, mul_zero, sub_zero,
     rclike_simps]
 
-theorem norm_extendTo𝕜'_apply_sq [SeminormedAddCommGroup F] [NormedSpace 𝕜 F]
+theorem norm_extendTo𝕜'_apply_sq [SeminormedAddCommGroup F]
     (fr : F →ₗ[ℝ] ℝ) (x : F) : ‖(fr.extendTo𝕜' x : 𝕜)‖ ^ 2 = fr (conj (fr.extendTo𝕜' x : 𝕜) • x) :=
   calc
     ‖(fr.extendTo𝕜' x : 𝕜)‖ ^ 2 = re (conj (fr.extendTo𝕜' x) * fr.extendTo𝕜' x : 𝕜) := by

--- a/Mathlib/Analysis/NormedSpace/Extend.lean
+++ b/Mathlib/Analysis/NormedSpace/Extend.lean
@@ -38,7 +38,7 @@ open ComplexConjugate
 variable {𝕜 : Type*} [RCLike 𝕜] {F : Type*}
 namespace LinearMap
 
-variable  [AddCommGroup F] [Module ℝ F] [Module 𝕜 F] [IsScalarTower ℝ 𝕜 F]
+variable [AddCommGroup F] [Module ℝ F] [Module 𝕜 F] [IsScalarTower ℝ 𝕜 F]
 
 /-- Extend `fr : F →ₗ[ℝ] ℝ` to `F →ₗ[𝕜] 𝕜` in a way that will also be continuous and have its norm
 bounded by `‖fr‖` if `fr` is continuous. -/

--- a/Mathlib/Analysis/NormedSpace/Extend.lean
+++ b/Mathlib/Analysis/NormedSpace/Extend.lean
@@ -84,7 +84,7 @@ theorem extendTo𝕜'_apply_re (fr : F →ₗ[ℝ] ℝ) (x : F) : re (fr.extendT
   simp only [extendTo𝕜'_apply, map_sub, zero_mul, mul_zero, sub_zero,
     rclike_simps]
 
-theorem norm_extendTo𝕜'_apply_sq [SeminormedAddCommGroup F]
+theorem norm_extendTo𝕜'_apply_sq
     (fr : F →ₗ[ℝ] ℝ) (x : F) : ‖(fr.extendTo𝕜' x : 𝕜)‖ ^ 2 = fr (conj (fr.extendTo𝕜' x : 𝕜) • x) :=
   calc
     ‖(fr.extendTo𝕜' x : 𝕜)‖ ^ 2 = re (conj (fr.extendTo𝕜' x) * fr.extendTo𝕜' x : 𝕜) := by

--- a/Mathlib/Analysis/NormedSpace/Extend.lean
+++ b/Mathlib/Analysis/NormedSpace/Extend.lean
@@ -35,11 +35,11 @@ open RCLike
 
 open ComplexConjugate
 
-variable {𝕜 : Type*} [RCLike 𝕜] {F : Type*} [SeminormedAddCommGroup F] [NormedSpace 𝕜 F]
+variable {𝕜 : Type*} [RCLike 𝕜] {F : Type*} [SeminormedAddCommGroup F]
 
 namespace LinearMap
 
-variable [Module ℝ F] [IsScalarTower ℝ 𝕜 F]
+variable [Module ℝ F] [Module 𝕜 F] [IsScalarTower ℝ 𝕜 F]
 
 /-- Extend `fr : F →ₗ[ℝ] ℝ` to `F →ₗ[𝕜] 𝕜` in a way that will also be continuous and have its norm
 bounded by `‖fr‖` if `fr` is continuous. -/
@@ -85,7 +85,7 @@ theorem extendTo𝕜'_apply_re (fr : F →ₗ[ℝ] ℝ) (x : F) : re (fr.extendT
   simp only [extendTo𝕜'_apply, map_sub, zero_mul, mul_zero, sub_zero,
     rclike_simps]
 
-theorem norm_extendTo𝕜'_apply_sq (fr : F →ₗ[ℝ] ℝ) (x : F) :
+theorem norm_extendTo𝕜'_apply_sq [NormedSpace 𝕜 F] (fr : F →ₗ[ℝ] ℝ) (x : F) :
     ‖(fr.extendTo𝕜' x : 𝕜)‖ ^ 2 = fr (conj (fr.extendTo𝕜' x : 𝕜) • x) :=
   calc
     ‖(fr.extendTo𝕜' x : 𝕜)‖ ^ 2 = re (conj (fr.extendTo𝕜' x) * fr.extendTo𝕜' x : 𝕜) := by
@@ -95,6 +95,7 @@ theorem norm_extendTo𝕜'_apply_sq (fr : F →ₗ[ℝ] ℝ) (x : F) :
 
 end LinearMap
 
+variable [NormedSpace 𝕜 F]
 namespace ContinuousLinearMap
 
 variable [NormedSpace ℝ F] [IsScalarTower ℝ 𝕜 F]

--- a/Mathlib/Analysis/NormedSpace/Extend.lean
+++ b/Mathlib/Analysis/NormedSpace/Extend.lean
@@ -84,8 +84,8 @@ theorem extendTo𝕜'_apply_re (fr : F →ₗ[ℝ] ℝ) (x : F) : re (fr.extendT
   simp only [extendTo𝕜'_apply, map_sub, zero_mul, mul_zero, sub_zero,
     rclike_simps]
 
-theorem norm_extendTo𝕜'_apply_sq
-    (fr : F →ₗ[ℝ] ℝ) (x : F) : ‖(fr.extendTo𝕜' x : 𝕜)‖ ^ 2 = fr (conj (fr.extendTo𝕜' x : 𝕜) • x) :=
+theorem norm_extendTo𝕜'_apply_sq (fr : F →ₗ[ℝ] ℝ) (x : F) :
+    ‖(fr.extendTo𝕜' x : 𝕜)‖ ^ 2 = fr (conj (fr.extendTo𝕜' x : 𝕜) • x) :=
   calc
     ‖(fr.extendTo𝕜' x : 𝕜)‖ ^ 2 = re (conj (fr.extendTo𝕜' x) * fr.extendTo𝕜' x : 𝕜) := by
       rw [RCLike.conj_mul, ← ofReal_pow, ofReal_re]

--- a/Mathlib/Analysis/NormedSpace/HahnBanach/Separation.lean
+++ b/Mathlib/Analysis/NormedSpace/HahnBanach/Separation.lean
@@ -221,41 +221,41 @@ noncomputable def extendTo𝕜'ₗ : (E →L[ℝ] ℝ) →ₗ[ℝ] (E →L[𝕜]
 
 variable [ContinuousSMul ℝ E]
 
-theorem separate_convex_open_set_RCLike {s : Set E}
+theorem separate_convex_open_set {s : Set E}
     (hs₀ : (0 : E) ∈ s) (hs₁ : Convex ℝ s) (hs₂ : IsOpen s) {x₀ : E} (hx₀ : x₀ ∉ s) :
     ∃ f : E →L[𝕜] 𝕜, re (f x₀) = 1 ∧ ∀ x ∈ s, re (f x) < 1 := by
-  obtain ⟨g, hg⟩ := separate_convex_open_set hs₀ hs₁ hs₂ hx₀
+  obtain ⟨g, hg⟩ := _root_.separate_convex_open_set hs₀ hs₁ hs₂ hx₀
   use extendTo𝕜'ₗ g
   simp only [extendTo𝕜'ₗ_apply_toFun, map_sub, ofReal_re, mul_re, I_re, zero_mul, ofReal_im,
     mul_zero, sub_self, sub_zero]
   exact hg
 
-theorem geometric_hahn_banach_open_RCLike (hs₁ : Convex ℝ s) (hs₂ : IsOpen s) (ht : Convex ℝ t)
+theorem geometric_hahn_banach_open (hs₁ : Convex ℝ s) (hs₂ : IsOpen s) (ht : Convex ℝ t)
     (disj : Disjoint s t) : ∃ (f : E →L[𝕜] 𝕜) (u : ℝ), (∀ a ∈ s, re (f a) < u) ∧
     ∀ b ∈ t, u ≤ re (f b) := by
-  obtain ⟨f, u, h⟩ := geometric_hahn_banach_open hs₁ hs₂ ht disj
+  obtain ⟨f, u, h⟩ := _root_.geometric_hahn_banach_open hs₁ hs₂ ht disj
   use extendTo𝕜'ₗ f
   simp only [extendTo𝕜'ₗ_apply_toFun, map_sub, ofReal_re, mul_re, I_re, zero_mul, ofReal_im,
     mul_zero, sub_self, sub_zero]
   exact Exists.intro u h
 
-theorem geometric_hahn_banach_open_point_RCLike (hs₁ : Convex ℝ s) (hs₂ : IsOpen s) (disj : x ∉ s) :
+theorem geometric_hahn_banach_open_point (hs₁ : Convex ℝ s) (hs₂ : IsOpen s) (disj : x ∉ s) :
     ∃ f : E →L[𝕜] 𝕜, ∀ a ∈ s, re (f a) < re (f x) := by
-  obtain ⟨f, h⟩ := geometric_hahn_banach_open_point hs₁ hs₂ disj
+  obtain ⟨f, h⟩ := _root_.geometric_hahn_banach_open_point hs₁ hs₂ disj
   use extendTo𝕜'ₗ f
   simp only [extendTo𝕜'ₗ_apply_toFun, map_sub, ofReal_re, mul_re, I_re, zero_mul, ofReal_im,
     mul_zero, sub_self, sub_zero]
   exact fun a a_1 ↦ h a a_1
 
-theorem geometric_hahn_banach_point_open_RCLike (ht₁ : Convex ℝ t) (ht₂ : IsOpen t) (disj : x ∉ t) :
+theorem geometric_hahn_banach_point_open (ht₁ : Convex ℝ t) (ht₂ : IsOpen t) (disj : x ∉ t) :
     ∃ f : E →L[𝕜] 𝕜, ∀ b ∈ t, re (f x) < re (f b) :=
-  let ⟨f, hf⟩ := geometric_hahn_banach_open_point_RCLike ht₁ ht₂ disj
+  let ⟨f, hf⟩ := geometric_hahn_banach_open_point ht₁ ht₂ disj
   ⟨-f, by simpa⟩
 
-theorem geometric_hahn_banach_open_open_RCLike (hs₁ : Convex ℝ s) (hs₂ : IsOpen s)
+theorem geometric_hahn_banach_open_open (hs₁ : Convex ℝ s) (hs₂ : IsOpen s)
     (ht₁ : Convex ℝ t) (ht₃ : IsOpen t) (disj : Disjoint s t) :
     ∃ (f : E →L[𝕜] 𝕜) (u : ℝ), (∀ a ∈ s, re (f a) < u) ∧ ∀ b ∈ t, u < re (f b) := by
-  obtain ⟨f, u, h⟩ := geometric_hahn_banach_open_open hs₁ hs₂ ht₁ ht₃ disj
+  obtain ⟨f, u, h⟩ := _root_.geometric_hahn_banach_open_open hs₁ hs₂ ht₁ ht₃ disj
   use extendTo𝕜'ₗ f
   simp only [extendTo𝕜'ₗ_apply_toFun, map_sub, ofReal_re, mul_re, I_re, zero_mul, ofReal_im,
     mul_zero, sub_self, sub_zero]
@@ -263,10 +263,10 @@ theorem geometric_hahn_banach_open_open_RCLike (hs₁ : Convex ℝ s) (hs₂ : I
 
 variable [LocallyConvexSpace ℝ E]
 
-theorem geometric_hahn_banach_compact_closed_RCLike (hs₁ : Convex ℝ s) (hs₂ : IsCompact s)
+theorem geometric_hahn_banach_compact_closed (hs₁ : Convex ℝ s) (hs₂ : IsCompact s)
     (ht₁ : Convex ℝ t) (ht₂ : IsClosed t) (disj : Disjoint s t) :
     ∃ (f : E →L[𝕜] 𝕜) (u v : ℝ), (∀ a ∈ s, re (f a) < u) ∧ u < v ∧ ∀ b ∈ t, v < re (f b) := by
-  obtain ⟨g, u, v, h1⟩ := geometric_hahn_banach_compact_closed hs₁ hs₂ ht₁ ht₂ disj
+  obtain ⟨g, u, v, h1⟩ := _root_.geometric_hahn_banach_compact_closed hs₁ hs₂ ht₁ ht₂ disj
   use extendTo𝕜'ₗ g
   simp only [extendTo𝕜'ₗ_apply_toFun, map_sub, ofReal_re, mul_re, I_re, zero_mul, ofReal_im,
     mul_zero, sub_self, sub_zero, exists_and_left]
@@ -276,39 +276,39 @@ theorem geometric_hahn_banach_compact_closed_RCLike (hs₁ : Convex ℝ s) (hs�
   use v
   exact h1.2
 
-theorem geometric_hahn_banach_closed_compact_RCLike (hs₁ : Convex ℝ s) (hs₂ : IsClosed s)
+theorem geometric_hahn_banach_closed_compact (hs₁ : Convex ℝ s) (hs₂ : IsClosed s)
     (ht₁ : Convex ℝ t) (ht₂ : IsCompact t) (disj : Disjoint s t) :
     ∃ (f : E →L[𝕜] 𝕜) (u v : ℝ), (∀ a ∈ s, re (f a) < u) ∧ u < v ∧ ∀ b ∈ t, v < re (f b) :=
-  let ⟨f, s, t, hs, st, ht⟩ := geometric_hahn_banach_compact_closed_RCLike ht₁ ht₂ hs₁ hs₂ disj.symm
+  let ⟨f, s, t, hs, st, ht⟩ := geometric_hahn_banach_compact_closed ht₁ ht₂ hs₁ hs₂ disj.symm
   ⟨-f, -t, -s, by simpa using ht, by simpa using st, by simpa using hs⟩
 
-theorem geometric_hahn_banach_point_closed_RCLike (ht₁ : Convex ℝ t) (ht₂ : IsClosed t)
+theorem geometric_hahn_banach_point_closed (ht₁ : Convex ℝ t) (ht₂ : IsClosed t)
     (disj : x ∉ t) : ∃ (f : E →L[𝕜] 𝕜) (u : ℝ), re (f x) < u ∧ ∀ b ∈ t, u < re (f b) :=
   let ⟨f, _u, v, ha, hst, hb⟩ :=
-    geometric_hahn_banach_compact_closed_RCLike (convex_singleton x) isCompact_singleton ht₁ ht₂
+    geometric_hahn_banach_compact_closed (convex_singleton x) isCompact_singleton ht₁ ht₂
       (disjoint_singleton_left.2 disj)
   ⟨f, v, hst.trans' <| ha x <| mem_singleton _, hb⟩
 
-theorem geometric_hahn_banach_closed_point_RCLike (hs₁ : Convex ℝ s) (hs₂ : IsClosed s)
+theorem geometric_hahn_banach_closed_point (hs₁ : Convex ℝ s) (hs₂ : IsClosed s)
     (disj : x ∉ s) : ∃ (f : E →L[𝕜] 𝕜) (u : ℝ), (∀ a ∈ s, re (f a) < u) ∧ u < re (f x) :=
   let ⟨f, s, _t, ha, hst, hb⟩ :=
-    geometric_hahn_banach_closed_compact_RCLike hs₁ hs₂ (convex_singleton x) isCompact_singleton
+    geometric_hahn_banach_closed_compact hs₁ hs₂ (convex_singleton x) isCompact_singleton
       (disjoint_singleton_right.2 disj)
   ⟨f, s, ha, hst.trans <| hb x <| mem_singleton _⟩
 
-theorem geometric_hahn_banach_point_point_RCLike [T1Space E] (hxy : x ≠ y) :
+theorem geometric_hahn_banach_point_point [T1Space E] (hxy : x ≠ y) :
     ∃ f : E →L[𝕜] 𝕜, re (f x) < re (f y) := by
   obtain ⟨f, s, t, hs, st, ht⟩ :=
-    geometric_hahn_banach_compact_closed_RCLike (𝕜 := 𝕜) (convex_singleton x) isCompact_singleton
+    geometric_hahn_banach_compact_closed (𝕜 := 𝕜) (convex_singleton x) isCompact_singleton
       (convex_singleton y) isClosed_singleton (disjoint_singleton.2 hxy)
   exact ⟨f, by linarith [hs x rfl, ht y rfl]⟩
 
-theorem iInter_halfspaces_eq_RCLike (hs₁ : Convex ℝ s) (hs₂ : IsClosed s) :
+theorem iInter_halfspaces_eq (hs₁ : Convex ℝ s) (hs₂ : IsClosed s) :
     ⋂ l : E →L[𝕜] 𝕜, { x | ∃ y ∈ s, re (l x) ≤ re (l y) } = s := by
   rw [Set.iInter_setOf]
   refine Set.Subset.antisymm (fun x hx => ?_) fun x hx l => ⟨x, hx, le_rfl⟩
   by_contra h
-  obtain ⟨l, s, hlA, hl⟩ := geometric_hahn_banach_closed_point_RCLike (𝕜 := 𝕜) hs₁ hs₂ h
+  obtain ⟨l, s, hlA, hl⟩ := geometric_hahn_banach_closed_point (𝕜 := 𝕜) hs₁ hs₂ h
   obtain ⟨y, hy, hxy⟩ := hx l
   exact ((hxy.trans_lt (hlA y hy)).trans hl).false
 

--- a/Mathlib/Analysis/NormedSpace/HahnBanach/Separation.lean
+++ b/Mathlib/Analysis/NormedSpace/HahnBanach/Separation.lean
@@ -301,5 +301,22 @@ theorem geometric_hahn_banach_closed_point_RCLike (hs₁ : Convex ℝ s) (hs₂ 
       (disjoint_singleton_right.2 disj)
   ⟨f, s, ha, hst.trans <| hb x <| mem_singleton _⟩
 
+/-- See also `NormedSpace.eq_iff_forall_dual_eq`. -/
+theorem geometric_hahn_banach_point_point_RCLike [T1Space E] (hxy : x ≠ y) :
+    ∃ f : E →L[𝕜] 𝕜, re (f x) < re (f y) := by
+  obtain ⟨f, s, t, hs, st, ht⟩ :=
+    geometric_hahn_banach_compact_closed_RCLike (𝕜 := 𝕜) (convex_singleton x) isCompact_singleton
+      (convex_singleton y) isClosed_singleton (disjoint_singleton.2 hxy)
+  exact ⟨f, by linarith [hs x rfl, ht y rfl]⟩
+
+/-- A closed convex set is the intersection of the halfspaces containing it. -/
+theorem iInter_halfspaces_eq_RCLike (hs₁ : Convex ℝ s) (hs₂ : IsClosed s) :
+    ⋂ l : E →L[𝕜] 𝕜, { x | ∃ y ∈ s, re (l x) ≤ re (l y) } = s := by
+  rw [Set.iInter_setOf]
+  refine Set.Subset.antisymm (fun x hx => ?_) fun x hx l => ⟨x, hx, le_rfl⟩
+  by_contra h
+  obtain ⟨l, s, hlA, hl⟩ := geometric_hahn_banach_closed_point_RCLike (𝕜 := 𝕜) hs₁ hs₂ h
+  obtain ⟨y, hy, hxy⟩ := hx l
+  exact ((hxy.trans_lt (hlA y hy)).trans hl).not_le le_rfl
 
 end RCLike

--- a/Mathlib/Analysis/NormedSpace/HahnBanach/Separation.lean
+++ b/Mathlib/Analysis/NormedSpace/HahnBanach/Separation.lean
@@ -269,8 +269,7 @@ theorem geometric_hahn_banach_compact_closed (hs₁ : Convex ℝ s) (hs₂ : IsC
     ∃ (f : E →L[𝕜] 𝕜) (u v : ℝ), (∀ a ∈ s, re (f a) < u) ∧ u < v ∧ ∀ b ∈ t, v < re (f b) := by
   obtain ⟨g, u, v, h1⟩ := _root_.geometric_hahn_banach_compact_closed hs₁ hs₂ ht₁ ht₂ disj
   use extendTo𝕜'ₗ g
-  simp only [extendTo𝕜'ₗ_apply_toFun, map_sub, ofReal_re, mul_re, I_re, zero_mul, ofReal_im,
-    mul_zero, sub_self, sub_zero, exists_and_left]
+  simp only [re_extendTo𝕜'ₗ, exists_and_left]
   use u
   constructor
   exact h1.1

--- a/Mathlib/Analysis/NormedSpace/HahnBanach/Separation.lean
+++ b/Mathlib/Analysis/NormedSpace/HahnBanach/Separation.lean
@@ -210,34 +210,55 @@ open RCLike
 variable [RCLike 𝕜] [TopologicalSpace E] [AddCommGroup E] [TopologicalAddGroup E]
   [Module 𝕜 E] [Module ℝ E] [ContinuousSMul 𝕜 E] [IsScalarTower ℝ 𝕜 E]
 
-@[simp]
 noncomputable def LinTo𝕜' : (E →L[ℝ] ℝ) →ₗ[ℝ] (E →L[𝕜] 𝕜) :=
   letI to𝕜 (fr : (E →L[ℝ] ℝ)) : (E →L[𝕜] 𝕜) :=
     { toLinearMap := LinearMap.extendTo𝕜' fr
       cont := show Continuous fun x ↦ (fr x : 𝕜) - (I : 𝕜) * (fr ((I : 𝕜) • x) : 𝕜) by fun_prop }
   have h fr x : to𝕜 fr x = ((fr x : 𝕜) - (I : 𝕜) * (fr ((I : 𝕜) • x) : 𝕜)) := rfl
   { toFun := to𝕜
-    map_add' := by intros; ext; simp [h]; ring
+    map_add' := by intros; ext; simp [h] ; ring
     map_smul' := by intros; ext; simp [h, real_smul_eq_coe_mul]; ring }
 
-theorem separate_convex_open_set_RCLike [ContinuousSMul ℝ E] {s : Set E}
+@[simp]
+lemma extendTo𝕜'_apply (fr : E →L[ℝ] ℝ) (x : E) :
+    LinTo𝕜' fr x = ((fr x : 𝕜) - (I : 𝕜) * (fr ((I : 𝕜) • x) : 𝕜)) :=
+  rfl
+
+variable [ContinuousSMul ℝ E]
+
+theorem separate_convex_open_set_RCLike  {s : Set E}
     (hs₀ : (0 : E) ∈ s) (hs₁ : Convex ℝ s) (hs₂ : IsOpen s) {x₀ : E} (hx₀ : x₀ ∉ s) :
     ∃ f : E →L[𝕜] 𝕜, re (f x₀) = 1 ∧ ∀ x ∈ s, re (f x) < 1 := by
   obtain ⟨g, hg⟩ := separate_convex_open_set hs₀ hs₁ hs₂ hx₀
   use LinTo𝕜' g
-  simp only [LinTo𝕜', LinearMap.extendTo𝕜', ContinuousLinearMap.coe_coe, LinearMap.coe_mk,
-    AddHom.coe_mk, ContinuousLinearMap.coe_mk', map_sub, ofReal_re, mul_re, I_re, zero_mul,
-    ofReal_im, mul_zero, sub_self, sub_zero]
+  simp only [extendTo𝕜'_apply, map_sub, ofReal_re, mul_re, I_re, zero_mul, ofReal_im, mul_zero,
+    sub_self, sub_zero]
   exact hg
 
-theorem geometric_hahn_banach_compact_closed_RCLike [LocallyConvexSpace ℝ E] [ContinuousSMul ℝ E]
+theorem geometric_hahn_banach_open_RCLike (hs₁ : Convex ℝ s) (hs₂ : IsOpen s) (ht : Convex ℝ t)
+    (disj : Disjoint s t) : ∃ (f : E →L[𝕜] 𝕜) (u : ℝ), (∀ a ∈ s, re (f a) < u) ∧
+    ∀ b ∈ t, u ≤ re (f b) := by
+  obtain ⟨f, u, h⟩ := geometric_hahn_banach_open hs₁ hs₂ ht disj
+  use LinTo𝕜' f
+  simp only [extendTo𝕜'_apply, map_sub, ofReal_re, mul_re, I_re, zero_mul, ofReal_im, mul_zero,
+    sub_self, sub_zero]
+  exact Exists.intro u h
+
+theorem geometric_hahn_banach_open_point_RCLike (hs₁ : Convex ℝ s) (hs₂ : IsOpen s) (disj : x ∉ s) :
+    ∃ f : E →L[𝕜] 𝕜, ∀ a ∈ s, re (f a) < re (f x) := by
+  obtain ⟨f, h⟩ := geometric_hahn_banach_open_point hs₁ hs₂ disj
+  use LinTo𝕜' f
+  simp only [extendTo𝕜'_apply, map_sub, ofReal_re, mul_re, I_re, zero_mul, ofReal_im, mul_zero,
+    sub_self, sub_zero]
+  exact fun a a_1 ↦ h a a_1
+
+theorem geometric_hahn_banach_compact_closed_RCLike [LocallyConvexSpace ℝ E]
 (hs₁ : Convex ℝ s) (hs₂ : IsCompact s) (ht₁ : Convex ℝ t) (ht₂ : IsClosed t) (disj : Disjoint s t) :
     ∃ (f : E →L[𝕜] 𝕜) (u v : ℝ), (∀ a ∈ s, re (f a) < u) ∧ u < v ∧ ∀ b ∈ t, v < re (f b) := by
   obtain ⟨g, u, v, h1⟩ := geometric_hahn_banach_compact_closed hs₁ hs₂ ht₁ ht₂ disj
   use LinTo𝕜' g
-  simp only [LinTo𝕜', LinearMap.extendTo𝕜', ContinuousLinearMap.coe_coe, LinearMap.coe_mk,
-    AddHom.coe_mk, ContinuousLinearMap.coe_mk', map_sub, ofReal_re, mul_re, I_re, zero_mul,
-    ofReal_im, mul_zero, sub_self, sub_zero, exists_and_left]
+  simp only [extendTo𝕜'_apply, map_sub, ofReal_re, mul_re, I_re, zero_mul, ofReal_im, mul_zero,
+    sub_self, sub_zero, exists_and_left]
   use u
   constructor
   exact h1.1

--- a/Mathlib/Analysis/NormedSpace/HahnBanach/Separation.lean
+++ b/Mathlib/Analysis/NormedSpace/HahnBanach/Separation.lean
@@ -7,6 +7,7 @@ import Mathlib.Analysis.Convex.Cone.Extension
 import Mathlib.Analysis.Convex.Gauge
 import Mathlib.Topology.Algebra.Module.FiniteDimension
 import Mathlib.Topology.Algebra.Module.LocallyConvex
+import Mathlib.Analysis.RCLike.Basic
 
 /-!
 # Separation Hahn-Banach theorem
@@ -200,3 +201,64 @@ theorem iInter_halfspaces_eq (hs₁ : Convex ℝ s) (hs₂ : IsClosed s) :
   obtain ⟨l, s, hlA, hl⟩ := geometric_hahn_banach_closed_point hs₁ hs₂ h
   obtain ⟨y, hy, hxy⟩ := hx l
   exact ((hxy.trans_lt (hlA y hy)).trans hl).not_le le_rfl
+
+section RCLike
+
+open RCLike
+
+variable [RCLike 𝕜] [TopologicalSpace E] [AddCommGroup E] [TopologicalAddGroup E]
+  [Module 𝕜 E] [Module ℝ E] [ContinuousSMul 𝕜 E] [IsScalarTower ℝ 𝕜 E] {s t : Set E} {x y : E} (a : ℝ)
+
+/-
+This is interesting. We want a linear map from ℝ-linear functionals to 𝕜-linear functionals.
+How does one map an ℝ-linear functional to a 𝕜-linear functional?
+
+We want a "lift", here. But maybe not the lift tactic right away.
+
+We want this to have the property that the real functional below is essentially the real
+part of the functional above. Does this require knowing something about the structure of
+RCLike fields? I don't know. The original idea I had was to take φ and map it to ofReal ∘ φ.
+That would work as a function. Does this even make sense?
+
+If x, y are in E, then φ(x + y)= φ(x) + φ(y) by the linearity, and the addition is in 𝕜 on
+the right. What about smul? In this case, we have φ(m • x)= m * φ(x) because φ is linear.
+the goal is then to pass this through the ofReal...and I do NOT see how that is going to work.
+
+In fact, I don't believe it will.
+-/
+def RCLinearMapDual : (E →L[ℝ] ℝ) →ₗ[ℝ] (E →L[ℝ] 𝕜) where
+  toFun := fun
+    | .mk toLinearMap cont => {
+      toFun := fun x ↦ ofReal (toLinearMap x) - (I : 𝕜) * ofReal (toLinearMap ((I : 𝕜) • x))
+      map_add' := by
+        intro x y
+        simp only [map_add, smul_add, mul_add]
+        exact
+          add_sub_add_comm ((algebraMap ℝ 𝕜) (toLinearMap x)) ((algebraMap ℝ 𝕜) (toLinearMap y))
+            (I * (algebraMap ℝ 𝕜) (toLinearMap (I • x)))
+            (I * (algebraMap ℝ 𝕜) (toLinearMap (I • y)))
+      map_smul' := by
+        intro m x
+        simp only [LinearMapClass.map_smul, map_mul, RingHom.id_apply, smul_sub, smul_eq_mul,
+          real_smul_ofReal, sub_right_inj]
+        rw [smul_comm, LinearMapClass.map_smul]
+        sorry
+      cont := {
+        isOpen_preimage := by
+          intro s hs
+          sorry
+      }
+    }
+  map_add' := by
+    intro f g
+    simp only [LinearMap.add_apply, ContinuousLinearMap.coe_coe, map_add]
+    ext x
+    simp only [ContinuousLinearMap.coe_mk', LinearMap.coe_mk, AddHom.coe_mk,
+      ContinuousLinearMap.add_apply]
+    rw [mul_add]
+    exact
+      add_sub_add_comm ((algebraMap ℝ 𝕜) (f x)) ((algebraMap ℝ 𝕜) (g x))
+        (I * (algebraMap ℝ 𝕜) (f (I • x))) (I * (algebraMap ℝ 𝕜) (g (I • x)))
+  map_smul' := sorry
+
+end RCLike

--- a/Mathlib/Analysis/NormedSpace/HahnBanach/Separation.lean
+++ b/Mathlib/Analysis/NormedSpace/HahnBanach/Separation.lean
@@ -220,7 +220,7 @@ noncomputable def LinTo𝕜' : (E →L[ℝ] ℝ) →ₗ[ℝ] (E →L[𝕜] 𝕜)
     map_smul' := by intros; ext; simp [h, real_smul_eq_coe_mul]; ring }
 
 @[simp]
-lemma real_of_real_of_LinTo𝕜' (g : E →L[ℝ] ℝ) (x : E) :  re ((LinTo𝕜' g) x : 𝕜) = g x := by
+lemma real_of_LinTo𝕜' (g : E →L[ℝ] ℝ) (x : E) :  re ((LinTo𝕜' g) x : 𝕜) = g x := by
   have h g (x : E) : LinTo𝕜' g x = ((g x : 𝕜) - (I : 𝕜) * (g ((I : 𝕜) • x) : 𝕜)) := rfl
   simp only [h , map_sub, ofReal_re, mul_re, I_re, zero_mul, ofReal_im, mul_zero,
   sub_self, sub_zero]
@@ -231,18 +231,18 @@ theorem separate_convex_open_set_RCLike  {s : Set E}
     (hs₀ : (0 : E) ∈ s) (hs₁ : Convex ℝ s) (hs₂ : IsOpen s) {x₀ : E} (hx₀ : x₀ ∉ s) :
     ∃ f : E →L[𝕜] 𝕜, re (f x₀) = 1 ∧ ∀ x ∈ s, re (f x) < 1 := by
   obtain ⟨g, hg⟩ := separate_convex_open_set hs₀ hs₁ hs₂ hx₀; use LinTo𝕜' g
-  simp only [real_of_real_of_LinTo𝕜']; exact hg
+  simp only [real_of_LinTo𝕜']; exact hg
 
 theorem geometric_hahn_banach_open_RCLike (hs₁ : Convex ℝ s) (hs₂ : IsOpen s) (ht : Convex ℝ t)
     (disj : Disjoint s t) : ∃ (f : E →L[𝕜] 𝕜) (u : ℝ), (∀ a ∈ s, re (f a) < u) ∧
     ∀ b ∈ t, u ≤ re (f b) := by
   obtain ⟨f, u, h⟩ := geometric_hahn_banach_open hs₁ hs₂ ht disj; use LinTo𝕜' f
-  simp only [real_of_real_of_LinTo𝕜']; exact Exists.intro u h
+  simp only [real_of_LinTo𝕜']; exact Exists.intro u h
 
 theorem geometric_hahn_banach_open_point_RCLike (hs₁ : Convex ℝ s) (hs₂ : IsOpen s) (disj : x ∉ s) :
     ∃ f : E →L[𝕜] 𝕜, ∀ a ∈ s, re (f a) < re (f x) := by
   obtain ⟨f, h⟩ := geometric_hahn_banach_open_point hs₁ hs₂ disj; use LinTo𝕜' f
-  simp only [real_of_real_of_LinTo𝕜']; exact fun a a_1 ↦ h a a_1
+  simp only [real_of_LinTo𝕜']; exact fun a a_1 ↦ h a a_1
 
 theorem geometric_hahn_banach_point_open_RCLike (ht₁ : Convex ℝ t) (ht₂ : IsOpen t) (disj : x ∉ t) :
     ∃ f : E →L[𝕜] 𝕜, ∀ b ∈ t, re (f x) < re (f b) :=
@@ -253,7 +253,7 @@ theorem geometric_hahn_banach_open_open_RCLike (hs₁ : Convex ℝ s) (hs₂ : I
     (ht₁ : Convex ℝ t) (ht₃ : IsOpen t) (disj : Disjoint s t) :
     ∃ (f : E →L[𝕜] 𝕜) (u : ℝ), (∀ a ∈ s, re (f a) < u) ∧ ∀ b ∈ t, u < re (f b) := by
   obtain ⟨f, u, h⟩ := geometric_hahn_banach_open_open hs₁ hs₂ ht₁ ht₃ disj
-  use LinTo𝕜' f; simp only [real_of_real_of_LinTo𝕜']; exact Exists.intro u h
+  use LinTo𝕜' f; simp only [real_of_LinTo𝕜']; exact Exists.intro u h
 
 variable [LocallyConvexSpace ℝ E]
 
@@ -261,7 +261,7 @@ theorem geometric_hahn_banach_compact_closed_RCLike (hs₁ : Convex ℝ s) (hs�
     (ht₁ : Convex ℝ t) (ht₂ : IsClosed t) (disj : Disjoint s t) :
     ∃ (f : E →L[𝕜] 𝕜) (u v : ℝ), (∀ a ∈ s, re (f a) < u) ∧ u < v ∧ ∀ b ∈ t, v < re (f b) := by
   obtain ⟨g, u, v, h1⟩ := geometric_hahn_banach_compact_closed hs₁ hs₂ ht₁ ht₂ disj; use LinTo𝕜' g
-  simp only [real_of_real_of_LinTo𝕜', exists_and_left]; use u; constructor; exact h1.1; use v
+  simp only [real_of_LinTo𝕜', exists_and_left]; use u; constructor; exact h1.1; use v
   exact h1.2
 
 theorem geometric_hahn_banach_closed_compact_RCLike (hs₁ : Convex ℝ s) (hs₂ : IsClosed s)

--- a/Mathlib/Analysis/NormedSpace/HahnBanach/Separation.lean
+++ b/Mathlib/Analysis/NormedSpace/HahnBanach/Separation.lean
@@ -259,6 +259,15 @@ def RCLinearMapDual : (E →L[ℝ] ℝ) →ₗ[ℝ] (E →L[ℝ] 𝕜) where
     exact
       add_sub_add_comm ((algebraMap ℝ 𝕜) (f x)) ((algebraMap ℝ 𝕜) (g x))
         (I * (algebraMap ℝ 𝕜) (f (I • x))) (I * (algebraMap ℝ 𝕜) (g (I • x)))
-  map_smul' := sorry
+  map_smul' := by
+    intro m f
+    simp only [LinearMap.smul_apply, ContinuousLinearMap.coe_coe, smul_eq_mul, map_mul,
+      RingHom.id_apply]
+    ext x
+    simp only [ContinuousLinearMap.coe_mk', LinearMap.coe_mk, AddHom.coe_mk,
+      ContinuousLinearMap.coe_smul', Pi.smul_apply]
+    rw [smul_sub]
+    simp only [smul_eq_mul, real_smul_ofReal, sub_right_inj]
+    rw [← real_smul_eq_coe_mul, Algebra.mul_smul_comm]
 
 end RCLike

--- a/Mathlib/Analysis/NormedSpace/HahnBanach/Separation.lean
+++ b/Mathlib/Analysis/NormedSpace/HahnBanach/Separation.lean
@@ -284,7 +284,6 @@ theorem geometric_hahn_banach_closed_point_RCLike (hs₁ : Convex ℝ s) (hs₂ 
       (disjoint_singleton_right.2 disj)
   ⟨f, s, ha, hst.trans <| hb x <| mem_singleton _⟩
 
-/-- See also `NormedSpace.eq_iff_forall_dual_eq`. -/
 theorem geometric_hahn_banach_point_point_RCLike [T1Space E] (hxy : x ≠ y) :
     ∃ f : E →L[𝕜] 𝕜, re (f x) < re (f y) := by
   obtain ⟨f, s, t, hs, st, ht⟩ :=
@@ -292,7 +291,6 @@ theorem geometric_hahn_banach_point_point_RCLike [T1Space E] (hxy : x ≠ y) :
       (convex_singleton y) isClosed_singleton (disjoint_singleton.2 hxy)
   exact ⟨f, by linarith [hs x rfl, ht y rfl]⟩
 
-/-- A closed convex set is the intersection of the halfspaces containing it. -/
 theorem iInter_halfspaces_eq_RCLike (hs₁ : Convex ℝ s) (hs₂ : IsClosed s) :
     ⋂ l : E →L[𝕜] 𝕜, { x | ∃ y ∈ s, re (l x) ≤ re (l y) } = s := by
   rw [Set.iInter_setOf]

--- a/Mathlib/Analysis/NormedSpace/HahnBanach/Separation.lean
+++ b/Mathlib/Analysis/NormedSpace/HahnBanach/Separation.lean
@@ -216,7 +216,7 @@ noncomputable def LinTo𝕜' : (E →L[ℝ] ℝ) →ₗ[ℝ] (E →L[𝕜] 𝕜)
       cont := show Continuous fun x ↦ (fr x : 𝕜) - (I : 𝕜) * (fr ((I : 𝕜) • x) : 𝕜) by fun_prop }
   have h fr x : to𝕜 fr x = ((fr x : 𝕜) - (I : 𝕜) * (fr ((I : 𝕜) • x) : 𝕜)) := rfl
   { toFun := to𝕜
-    map_add' := by intros; ext; simp [h] ; ring
+    map_add' := by intros; ext; simp [h]; ring
     map_smul' := by intros; ext; simp [h, real_smul_eq_coe_mul]; ring }
 
 @[simp]

--- a/Mathlib/Analysis/NormedSpace/HahnBanach/Separation.lean
+++ b/Mathlib/Analysis/NormedSpace/HahnBanach/Separation.lean
@@ -254,11 +254,25 @@ noncomputable def extendTo𝕜' (fr : E →L[ℝ] ℝ) : E →L[𝕜] 𝕜 where
   cont := by
     change Continuous (fun x => (fr x : 𝕜) - (I : 𝕜) * fr ((I : 𝕜) • x)); fun_prop
 
-
-
-
-  --toFun := extendTo𝕜'' fr.1
-  --map_add' := LinearMap.map_add (extendTo𝕜'' ↑fr)
-  --map_smul' := LinearMap.CompatibleSMul.map_smul (extendTo𝕜'' ↑fr)
+noncomputable def LinTo𝕜' : (E →L[ℝ] ℝ) →ₗ[ℝ] (E →L[𝕜] 𝕜) where
+  toFun := extendTo𝕜'
+  map_add' := by
+    intro f g
+    ext v
+    simp only [ContinuousLinearMap.add_apply]
+    change (fun x => ((f + g) x : 𝕜) - (I : 𝕜) * (f + g) ((I : 𝕜) • x)) v =
+     ((fun x => (f x : 𝕜) - (I : 𝕜) * f ((I : 𝕜) • x)) +
+       (fun x => (g x : 𝕜) - (I : 𝕜) * g ((I : 𝕜) • x))) v
+    simp only [ContinuousLinearMap.add_apply, map_add, Pi.add_apply]
+    ring_nf
+  map_smul' := by
+    intro m f
+    simp only [RingHom.id_apply]
+    ext v
+    change (fun x => ((m • f) x : 𝕜) - (I : 𝕜) * (m • f) ((I : 𝕜) • x)) v =
+       m • ((fun x => (f x : 𝕜) - (I : 𝕜) * f ((I : 𝕜) • x)) v)
+    simp only [ContinuousLinearMap.coe_smul', Pi.smul_apply, smul_eq_mul, map_mul,
+       @real_smul_eq_coe_mul]
+    ring_nf
 
 end RCLike

--- a/Mathlib/Analysis/NormedSpace/HahnBanach/Separation.lean
+++ b/Mathlib/Analysis/NormedSpace/HahnBanach/Separation.lean
@@ -209,6 +209,7 @@ variable [RCLike 𝕜] [TopologicalSpace E] [AddCommGroup E] [TopologicalAddGrou
   [Module 𝕜 E] [Module ℝ E] [ContinuousSMul 𝕜 E] [IsScalarTower ℝ 𝕜 E]
 
 /--Real linear extension of continuous extension of `LinearMap.extendTo𝕜'` -/
+@[simps!]
 noncomputable def extendTo𝕜'ₗ : (E →L[ℝ] ℝ) →ₗ[ℝ] (E →L[𝕜] 𝕜) :=
   letI to𝕜 (fr : (E →L[ℝ] ℝ)) : (E →L[𝕜] 𝕜) :=
     { toLinearMap := LinearMap.extendTo𝕜' fr
@@ -218,12 +219,6 @@ noncomputable def extendTo𝕜'ₗ : (E →L[ℝ] ℝ) →ₗ[ℝ] (E →L[𝕜]
     map_add' := by intros; ext; simp [h]; ring
     map_smul' := by intros; ext; simp [h, real_smul_eq_coe_mul]; ring }
 
-@[simp]
-lemma re_extendTo𝕜'ₗ (g : E →L[ℝ] ℝ) (x : E) :  re ((extendTo𝕜'ₗ g) x : 𝕜) = g x := by
-  have h g (x : E) : extendTo𝕜'ₗ g x = ((g x : 𝕜) - (I : 𝕜) * (g ((I : 𝕜) • x) : 𝕜)) := rfl
-  simp only [h , map_sub, ofReal_re, mul_re, I_re, zero_mul, ofReal_im, mul_zero,
-    sub_self, sub_zero]
-
 variable [ContinuousSMul ℝ E]
 
 theorem separate_convex_open_set_RCLike {s : Set E}
@@ -231,7 +226,8 @@ theorem separate_convex_open_set_RCLike {s : Set E}
     ∃ f : E →L[𝕜] 𝕜, re (f x₀) = 1 ∧ ∀ x ∈ s, re (f x) < 1 := by
   obtain ⟨g, hg⟩ := separate_convex_open_set hs₀ hs₁ hs₂ hx₀
   use extendTo𝕜'ₗ g
-  simp only [re_extendTo𝕜'ₗ]
+  simp only [extendTo𝕜'ₗ_apply_toFun, map_sub, ofReal_re, mul_re, I_re, zero_mul, ofReal_im,
+    mul_zero, sub_self, sub_zero]
   exact hg
 
 theorem geometric_hahn_banach_open_RCLike (hs₁ : Convex ℝ s) (hs₂ : IsOpen s) (ht : Convex ℝ t)
@@ -239,14 +235,16 @@ theorem geometric_hahn_banach_open_RCLike (hs₁ : Convex ℝ s) (hs₂ : IsOpen
     ∀ b ∈ t, u ≤ re (f b) := by
   obtain ⟨f, u, h⟩ := geometric_hahn_banach_open hs₁ hs₂ ht disj
   use extendTo𝕜'ₗ f
-  simp only [re_extendTo𝕜'ₗ]
+  simp only [extendTo𝕜'ₗ_apply_toFun, map_sub, ofReal_re, mul_re, I_re, zero_mul, ofReal_im,
+    mul_zero, sub_self, sub_zero]
   exact Exists.intro u h
 
 theorem geometric_hahn_banach_open_point_RCLike (hs₁ : Convex ℝ s) (hs₂ : IsOpen s) (disj : x ∉ s) :
     ∃ f : E →L[𝕜] 𝕜, ∀ a ∈ s, re (f a) < re (f x) := by
   obtain ⟨f, h⟩ := geometric_hahn_banach_open_point hs₁ hs₂ disj
   use extendTo𝕜'ₗ f
-  simp only [re_extendTo𝕜'ₗ]
+  simp only [extendTo𝕜'ₗ_apply_toFun, map_sub, ofReal_re, mul_re, I_re, zero_mul, ofReal_im,
+    mul_zero, sub_self, sub_zero]
   exact fun a a_1 ↦ h a a_1
 
 theorem geometric_hahn_banach_point_open_RCLike (ht₁ : Convex ℝ t) (ht₂ : IsOpen t) (disj : x ∉ t) :
@@ -259,7 +257,8 @@ theorem geometric_hahn_banach_open_open_RCLike (hs₁ : Convex ℝ s) (hs₂ : I
     ∃ (f : E →L[𝕜] 𝕜) (u : ℝ), (∀ a ∈ s, re (f a) < u) ∧ ∀ b ∈ t, u < re (f b) := by
   obtain ⟨f, u, h⟩ := geometric_hahn_banach_open_open hs₁ hs₂ ht₁ ht₃ disj
   use extendTo𝕜'ₗ f
-  simp only [re_extendTo𝕜'ₗ]
+  simp only [extendTo𝕜'ₗ_apply_toFun, map_sub, ofReal_re, mul_re, I_re, zero_mul, ofReal_im,
+    mul_zero, sub_self, sub_zero]
   exact Exists.intro u h
 
 variable [LocallyConvexSpace ℝ E]
@@ -269,7 +268,8 @@ theorem geometric_hahn_banach_compact_closed_RCLike (hs₁ : Convex ℝ s) (hs�
     ∃ (f : E →L[𝕜] 𝕜) (u v : ℝ), (∀ a ∈ s, re (f a) < u) ∧ u < v ∧ ∀ b ∈ t, v < re (f b) := by
   obtain ⟨g, u, v, h1⟩ := geometric_hahn_banach_compact_closed hs₁ hs₂ ht₁ ht₂ disj
   use extendTo𝕜'ₗ g
-  simp only [re_extendTo𝕜'ₗ, exists_and_left]
+  simp only [extendTo𝕜'ₗ_apply_toFun, map_sub, ofReal_re, mul_re, I_re, zero_mul, ofReal_im,
+    mul_zero, sub_self, sub_zero, exists_and_left]
   use u
   constructor
   exact h1.1

--- a/Mathlib/Analysis/NormedSpace/HahnBanach/Separation.lean
+++ b/Mathlib/Analysis/NormedSpace/HahnBanach/Separation.lean
@@ -207,50 +207,13 @@ section RCLike
 
 open RCLike
 
-variable [RCLike 𝕜] [Module 𝕜 E] [Module ℝ E] [IsScalarTower ℝ 𝕜 E]
-
-/-- The old extendTo𝕜', but generalizing the normed space assumption on the domain. -/
-noncomputable def extendTo𝕜'' (fr : E →ₗ[ℝ] ℝ) : E →ₗ[𝕜] 𝕜 := by
-  let fc : E → 𝕜 := fun x => (fr x : 𝕜) - (I : 𝕜) * fr ((I : 𝕜) • x)
-  have add : ∀ x y : E, fc (x + y) = fc x + fc y := by
-    intro x y
-    simp only [fc, smul_add, LinearMap.map_add, ofReal_add]
-    rw [mul_add]
-    abel
-  have A : ∀ (c : ℝ) (x : E), (fr ((c : 𝕜) • x) : 𝕜) = (c : 𝕜) * (fr x : 𝕜) := by
-    intro c x
-    rw [← ofReal_mul]
-    congr 1
-    rw [RCLike.ofReal_alg, smul_assoc, fr.map_smul, Algebra.id.smul_eq_mul, one_smul]
-  have smul_ℝ : ∀ (c : ℝ) (x : E), fc ((c : 𝕜) • x) = (c : 𝕜) * fc x := by
-    intro c x
-    dsimp only [fc]
-    rw [A c x, smul_smul, mul_comm I (c : 𝕜), ← smul_smul, A, mul_sub]
-    ring
-  have smul_I : ∀ x : E, fc ((I : 𝕜) • x) = (I : 𝕜) * fc x := by
-    intro x
-    dsimp only [fc]
-    cases' @I_mul_I_ax 𝕜 _ with h h
-    · simp [h]
-    rw [mul_sub, ← mul_assoc, smul_smul, h]
-    simp only [neg_mul, LinearMap.map_neg, one_mul, one_smul, mul_neg, ofReal_neg, neg_smul,
-      sub_neg_eq_add, add_comm]
-  have smul_𝕜 : ∀ (c : 𝕜) (x : E), fc (c • x) = c • fc x := by
-    intro c x
-    rw [← re_add_im c, add_smul, add_smul, add, smul_ℝ, ← smul_smul, smul_ℝ, smul_I, ← mul_assoc]
-    rfl
-  exact
-    { toFun := fc
-      map_add' := add
-      map_smul' := smul_𝕜 }
-
-variable [TopologicalSpace E] [AddCommGroup E] [TopologicalAddGroup E]
+variable [RCLike 𝕜] [TopologicalSpace E] [AddCommGroup E] [TopologicalAddGroup E]
   [Module 𝕜 E] [Module ℝ E] [ContinuousSMul 𝕜 E] [IsScalarTower ℝ 𝕜 E]
 
 @[simp]
-noncomputable def LinTo𝕜'' : (E →L[ℝ] ℝ) →ₗ[ℝ] (E →L[𝕜] 𝕜) :=
+noncomputable def LinTo𝕜' : (E →L[ℝ] ℝ) →ₗ[ℝ] (E →L[𝕜] 𝕜) :=
   letI to𝕜 (fr : (E →L[ℝ] ℝ)) : (E →L[𝕜] 𝕜) :=
-    { toLinearMap := extendTo𝕜'' fr
+    { toLinearMap := LinearMap.extendTo𝕜' fr
       cont := show Continuous fun x ↦ (fr x : 𝕜) - (I : 𝕜) * (fr ((I : 𝕜) • x) : 𝕜) by fun_prop }
   have h fr x : to𝕜 fr x = ((fr x : 𝕜) - (I : 𝕜) * (fr ((I : 𝕜) • x) : 𝕜)) := rfl
   { toFun := to𝕜
@@ -261,20 +224,20 @@ theorem separate_convex_open_set_RCLike [ContinuousSMul ℝ E] {s : Set E}
     (hs₀ : (0 : E) ∈ s) (hs₁ : Convex ℝ s) (hs₂ : IsOpen s) {x₀ : E} (hx₀ : x₀ ∉ s) :
     ∃ f : E →L[𝕜] 𝕜, re (f x₀) = 1 ∧ ∀ x ∈ s, re (f x) < 1 := by
   obtain ⟨g, hg⟩ := separate_convex_open_set hs₀ hs₁ hs₂ hx₀
-  use LinTo𝕜'' g
-  simp only [LinTo𝕜'', extendTo𝕜'', ContinuousLinearMap.coe_coe, LinearMap.coe_mk, AddHom.coe_mk,
-    ContinuousLinearMap.coe_mk', map_sub, ofReal_re, mul_re, I_re, zero_mul, ofReal_im, mul_zero,
-    sub_self, sub_zero]
+  use LinTo𝕜' g
+  simp only [LinTo𝕜', LinearMap.extendTo𝕜', ContinuousLinearMap.coe_coe, LinearMap.coe_mk,
+    AddHom.coe_mk, ContinuousLinearMap.coe_mk', map_sub, ofReal_re, mul_re, I_re, zero_mul,
+    ofReal_im, mul_zero, sub_self, sub_zero]
   exact hg
 
 theorem geometric_hahn_banach_compact_closed_RCLike [LocallyConvexSpace ℝ E] [ContinuousSMul ℝ E]
 (hs₁ : Convex ℝ s) (hs₂ : IsCompact s) (ht₁ : Convex ℝ t) (ht₂ : IsClosed t) (disj : Disjoint s t) :
     ∃ (f : E →L[𝕜] 𝕜) (u v : ℝ), (∀ a ∈ s, re (f a) < u) ∧ u < v ∧ ∀ b ∈ t, v < re (f b) := by
   obtain ⟨g, u, v, h1⟩ := geometric_hahn_banach_compact_closed hs₁ hs₂ ht₁ ht₂ disj
-  use LinTo𝕜'' g
-  simp only [LinTo𝕜'', extendTo𝕜'', ContinuousLinearMap.coe_coe, LinearMap.coe_mk, AddHom.coe_mk,
-    ContinuousLinearMap.coe_mk', map_sub, ofReal_re, mul_re, I_re, zero_mul, ofReal_im, mul_zero,
-    sub_self, sub_zero, exists_and_left]
+  use LinTo𝕜' g
+  simp only [LinTo𝕜', LinearMap.extendTo𝕜', ContinuousLinearMap.coe_coe, LinearMap.coe_mk,
+    AddHom.coe_mk, ContinuousLinearMap.coe_mk', map_sub, ofReal_re, mul_re, I_re, zero_mul,
+    ofReal_im, mul_zero, sub_self, sub_zero, exists_and_left]
   use u
   constructor
   exact h1.1

--- a/Mathlib/Analysis/NormedSpace/HahnBanach/Separation.lean
+++ b/Mathlib/Analysis/NormedSpace/HahnBanach/Separation.lean
@@ -247,6 +247,7 @@ noncomputable def extendTo𝕜'' (fr : E →ₗ[ℝ] ℝ) : E →ₗ[𝕜] 𝕜 
 variable [TopologicalSpace E] [AddCommGroup E] [TopologicalAddGroup E]
   [Module 𝕜 E] [Module ℝ E] [ContinuousSMul 𝕜 E] [IsScalarTower ℝ 𝕜 E]
 
+@[simp]
 noncomputable def LinTo𝕜'' : (E →L[ℝ] ℝ) →ₗ[ℝ] (E →L[𝕜] 𝕜) :=
   letI to𝕜 (fr : (E →L[ℝ] ℝ)) : (E →L[𝕜] 𝕜) :=
     { toLinearMap := extendTo𝕜'' fr
@@ -256,18 +257,28 @@ noncomputable def LinTo𝕜'' : (E →L[ℝ] ℝ) →ₗ[ℝ] (E →L[𝕜] 𝕜
     map_add' := by intros; ext; simp [h]; ring
     map_smul' := by intros; ext; simp [h, real_smul_eq_coe_mul]; ring }
 
-theorem real_part_thing (g : E →L[ℝ] ℝ) : ∀ x,  re ((LinTo𝕜'' g) x : 𝕜) = g x := by
-  intro x
-  simp only [LinTo𝕜'', LinearMap.coe_mk, AddHom.coe_mk, ContinuousLinearMap.coe_mk', extendTo𝕜'',
-    ContinuousLinearMap.coe_coe, LinearMap.coe_mk, AddHom.coe_mk, map_sub, ofReal_re, mul_re, I_re,
-    zero_mul, ofReal_im, mul_zero, sub_self, sub_zero]
-
 theorem separate_convex_open_set_RCLike [ContinuousSMul ℝ E] {s : Set E}
     (hs₀ : (0 : E) ∈ s) (hs₁ : Convex ℝ s) (hs₂ : IsOpen s) {x₀ : E} (hx₀ : x₀ ∉ s) :
     ∃ f : E →L[𝕜] 𝕜, re (f x₀) = 1 ∧ ∀ x ∈ s, re (f x) < 1 := by
   obtain ⟨g, hg⟩ := separate_convex_open_set hs₀ hs₁ hs₂ hx₀
   use LinTo𝕜'' g
-  simp only [real_part_thing g]
+  simp only [LinTo𝕜'', extendTo𝕜'', ContinuousLinearMap.coe_coe, LinearMap.coe_mk, AddHom.coe_mk,
+    ContinuousLinearMap.coe_mk', map_sub, ofReal_re, mul_re, I_re, zero_mul, ofReal_im, mul_zero,
+    sub_self, sub_zero]
   exact hg
+
+theorem geometric_hahn_banach_compact_closed_RCLike [LocallyConvexSpace ℝ E] [ContinuousSMul ℝ E]
+(hs₁ : Convex ℝ s) (hs₂ : IsCompact s) (ht₁ : Convex ℝ t) (ht₂ : IsClosed t) (disj : Disjoint s t) :
+    ∃ (f : E →L[𝕜] 𝕜) (u v : ℝ), (∀ a ∈ s, re (f a) < u) ∧ u < v ∧ ∀ b ∈ t, v < re (f b) := by
+  obtain ⟨g, u, v, h1⟩ := geometric_hahn_banach_compact_closed hs₁ hs₂ ht₁ ht₂ disj
+  use LinTo𝕜'' g
+  simp only [LinTo𝕜'', extendTo𝕜'', ContinuousLinearMap.coe_coe, LinearMap.coe_mk, AddHom.coe_mk,
+    ContinuousLinearMap.coe_mk', map_sub, ofReal_re, mul_re, I_re, zero_mul, ofReal_im, mul_zero,
+    sub_self, sub_zero, exists_and_left]
+  use u
+  constructor
+  exact h1.1
+  use v
+  exact h1.2
 
 end RCLike

--- a/Mathlib/Analysis/NormedSpace/HahnBanach/Separation.lean
+++ b/Mathlib/Analysis/NormedSpace/HahnBanach/Separation.lean
@@ -265,8 +265,7 @@ theorem real_part_thing (g : E →L[ℝ] ℝ) : ∀ x,  re ((LinTo𝕜'' g) x : 
 theorem separate_convex_open_set_RCLike [ContinuousSMul ℝ E] {s : Set E}
     (hs₀ : (0 : E) ∈ s) (hs₁ : Convex ℝ s) (hs₂ : IsOpen s) {x₀ : E} (hx₀ : x₀ ∉ s) :
     ∃ f : E →L[𝕜] 𝕜, re (f x₀) = 1 ∧ ∀ x ∈ s, re (f x) < 1 := by
-  have h := separate_convex_open_set hs₀ hs₁ hs₂ hx₀
-  obtain ⟨g, hg⟩ := h
+  obtain ⟨g, hg⟩ := separate_convex_open_set hs₀ hs₁ hs₂ hx₀
   use LinTo𝕜'' g
   simp only [real_part_thing g]
   exact hg

--- a/Mathlib/Analysis/NormedSpace/HahnBanach/Separation.lean
+++ b/Mathlib/Analysis/NormedSpace/HahnBanach/Separation.lean
@@ -256,4 +256,19 @@ noncomputable def LinTo𝕜'' : (E →L[ℝ] ℝ) →ₗ[ℝ] (E →L[𝕜] 𝕜
     map_add' := by intros; ext; simp [h]; ring
     map_smul' := by intros; ext; simp [h, real_smul_eq_coe_mul]; ring }
 
+theorem real_part_thing (g : E →L[ℝ] ℝ) : ∀ x,  re ((LinTo𝕜'' g) x : 𝕜) = g x := by
+  intro x
+  simp only [LinTo𝕜'', LinearMap.coe_mk, AddHom.coe_mk, ContinuousLinearMap.coe_mk', extendTo𝕜'',
+    ContinuousLinearMap.coe_coe, LinearMap.coe_mk, AddHom.coe_mk, map_sub, ofReal_re, mul_re, I_re,
+    zero_mul, ofReal_im, mul_zero, sub_self, sub_zero]
+
+theorem separate_convex_open_set_RCLike [ContinuousSMul ℝ E] {s : Set E}
+    (hs₀ : (0 : E) ∈ s) (hs₁ : Convex ℝ s) (hs₂ : IsOpen s) {x₀ : E} (hx₀ : x₀ ∉ s) :
+    ∃ f : E →L[𝕜] 𝕜, re (f x₀) = 1 ∧ ∀ x ∈ s, re (f x) < 1 := by
+  have h := separate_convex_open_set hs₀ hs₁ hs₂ hx₀
+  obtain ⟨g, hg⟩ := h
+  use LinTo𝕜'' g
+  simp only [real_part_thing g]
+  exact hg
+
 end RCLike

--- a/Mathlib/Analysis/NormedSpace/HahnBanach/Separation.lean
+++ b/Mathlib/Analysis/NormedSpace/HahnBanach/Separation.lean
@@ -209,7 +209,6 @@ variable [RCLike 𝕜] [TopologicalSpace E] [AddCommGroup E] [TopologicalAddGrou
   [Module 𝕜 E] [Module ℝ E] [ContinuousSMul 𝕜 E] [IsScalarTower ℝ 𝕜 E]
 
 /--Real linear extension of continuous extension of `LinearMap.extendTo𝕜'` -/
-@[simps!]
 noncomputable def extendTo𝕜'ₗ : (E →L[ℝ] ℝ) →ₗ[ℝ] (E →L[𝕜] 𝕜) :=
   letI to𝕜 (fr : (E →L[ℝ] ℝ)) : (E →L[𝕜] 𝕜) :=
     { toLinearMap := LinearMap.extendTo𝕜' fr
@@ -219,6 +218,12 @@ noncomputable def extendTo𝕜'ₗ : (E →L[ℝ] ℝ) →ₗ[ℝ] (E →L[𝕜]
     map_add' := by intros; ext; simp [h]; ring
     map_smul' := by intros; ext; simp [h, real_smul_eq_coe_mul]; ring }
 
+@[simp]
+lemma re_extendTo𝕜'ₗ (g : E →L[ℝ] ℝ) (x : E) :  re ((extendTo𝕜'ₗ g) x : 𝕜) = g x := by
+  have h g (x : E) : extendTo𝕜'ₗ g x = ((g x : 𝕜) - (I : 𝕜) * (g ((I : 𝕜) • x) : 𝕜)) := rfl
+  simp only [h , map_sub, ofReal_re, mul_re, I_re, zero_mul, ofReal_im, mul_zero,
+    sub_self, sub_zero]
+
 variable [ContinuousSMul ℝ E]
 
 theorem separate_convex_open_set {s : Set E}
@@ -226,8 +231,7 @@ theorem separate_convex_open_set {s : Set E}
     ∃ f : E →L[𝕜] 𝕜, re (f x₀) = 1 ∧ ∀ x ∈ s, re (f x) < 1 := by
   obtain ⟨g, hg⟩ := _root_.separate_convex_open_set hs₀ hs₁ hs₂ hx₀
   use extendTo𝕜'ₗ g
-  simp only [extendTo𝕜'ₗ_apply_toFun, map_sub, ofReal_re, mul_re, I_re, zero_mul, ofReal_im,
-    mul_zero, sub_self, sub_zero]
+  simp only [re_extendTo𝕜'ₗ]
   exact hg
 
 theorem geometric_hahn_banach_open (hs₁ : Convex ℝ s) (hs₂ : IsOpen s) (ht : Convex ℝ t)
@@ -235,16 +239,14 @@ theorem geometric_hahn_banach_open (hs₁ : Convex ℝ s) (hs₂ : IsOpen s) (ht
     ∀ b ∈ t, u ≤ re (f b) := by
   obtain ⟨f, u, h⟩ := _root_.geometric_hahn_banach_open hs₁ hs₂ ht disj
   use extendTo𝕜'ₗ f
-  simp only [extendTo𝕜'ₗ_apply_toFun, map_sub, ofReal_re, mul_re, I_re, zero_mul, ofReal_im,
-    mul_zero, sub_self, sub_zero]
+  simp only [re_extendTo𝕜'ₗ]
   exact Exists.intro u h
 
 theorem geometric_hahn_banach_open_point (hs₁ : Convex ℝ s) (hs₂ : IsOpen s) (disj : x ∉ s) :
     ∃ f : E →L[𝕜] 𝕜, ∀ a ∈ s, re (f a) < re (f x) := by
   obtain ⟨f, h⟩ := _root_.geometric_hahn_banach_open_point hs₁ hs₂ disj
   use extendTo𝕜'ₗ f
-  simp only [extendTo𝕜'ₗ_apply_toFun, map_sub, ofReal_re, mul_re, I_re, zero_mul, ofReal_im,
-    mul_zero, sub_self, sub_zero]
+  simp only [re_extendTo𝕜'ₗ]
   exact fun a a_1 ↦ h a a_1
 
 theorem geometric_hahn_banach_point_open (ht₁ : Convex ℝ t) (ht₂ : IsOpen t) (disj : x ∉ t) :
@@ -257,8 +259,7 @@ theorem geometric_hahn_banach_open_open (hs₁ : Convex ℝ s) (hs₂ : IsOpen s
     ∃ (f : E →L[𝕜] 𝕜) (u : ℝ), (∀ a ∈ s, re (f a) < u) ∧ ∀ b ∈ t, u < re (f b) := by
   obtain ⟨f, u, h⟩ := _root_.geometric_hahn_banach_open_open hs₁ hs₂ ht₁ ht₃ disj
   use extendTo𝕜'ₗ f
-  simp only [extendTo𝕜'ₗ_apply_toFun, map_sub, ofReal_re, mul_re, I_re, zero_mul, ofReal_im,
-    mul_zero, sub_self, sub_zero]
+  simp only [re_extendTo𝕜'ₗ]
   exact Exists.intro u h
 
 variable [LocallyConvexSpace ℝ E]

--- a/Mathlib/Analysis/NormedSpace/HahnBanach/Separation.lean
+++ b/Mathlib/Analysis/NormedSpace/HahnBanach/Separation.lean
@@ -207,26 +207,10 @@ section RCLike
 open RCLike
 
 variable [RCLike 𝕜] [TopologicalSpace E] [AddCommGroup E] [TopologicalAddGroup E]
-  [Module 𝕜 E] [Module ℝ E] [ContinuousSMul 𝕜 E] [IsScalarTower ℝ 𝕜 E] {s t : Set E} {x y : E} (a : ℝ)
+  [Module 𝕜 E] [Module ℝ E] [ContinuousSMul 𝕜 E] [IsScalarTower ℝ 𝕜 E]
+  {s t : Set E} {x y : E} (a : ℝ)
 
-/-
-This is interesting. We want a linear map from ℝ-linear functionals to 𝕜-linear functionals.
-How does one map an ℝ-linear functional to a 𝕜-linear functional?
-
-We want a "lift", here. But maybe not the lift tactic right away.
-
-We want this to have the property that the real functional below is essentially the real
-part of the functional above. Does this require knowing something about the structure of
-RCLike fields? I don't know. The original idea I had was to take φ and map it to ofReal ∘ φ.
-That would work as a function. Does this even make sense?
-
-If x, y are in E, then φ(x + y)= φ(x) + φ(y) by the linearity, and the addition is in 𝕜 on
-the right. What about smul? In this case, we have φ(m • x)= m * φ(x) because φ is linear.
-the goal is then to pass this through the ofReal...and I do NOT see how that is going to work.
-
-In fact, I don't believe it will.
--/
-def RCLinearMapDual : (E →L[ℝ] ℝ) →ₗ[ℝ] (E →L[ℝ] 𝕜) where
+def RCLikeLinearMap : (E →L[ℝ] ℝ) →ₗ[ℝ] (E →L[ℝ] 𝕜) where
   toFun := fun
     | .mk toLinearMap cont => {
       toFun := fun x ↦ ofReal (toLinearMap x) - (I : 𝕜) * ofReal (toLinearMap ((I : 𝕜) • x))
@@ -244,11 +228,20 @@ def RCLinearMapDual : (E →L[ℝ] ℝ) →ₗ[ℝ] (E →L[ℝ] 𝕜) where
         rw [smul_comm, LinearMapClass.map_smul]
         simp only [smul_eq_mul, map_mul, real_smul_ofReal, real_smul_eq_coe_mul]
         exact Algebra.left_comm I m ((algebraMap ℝ 𝕜) (toLinearMap (I • x)))
-      cont := {
-        isOpen_preimage := by
-          intro s hs
-          sorry
-      }
+      cont := by
+        have : Continuous (HSMul.hSMul (α := 𝕜) (β := 𝕜) I) := continuous_const_smul I
+        simp_all only [AddHom.toFun_eq_coe, LinearMap.coe_toAddHom]
+        apply Continuous.sub
+        · apply Continuous.comp'
+          · apply continuous_algebraMap
+          · simp_all only
+        · apply Continuous.comp'
+          · exact this
+          · apply Continuous.comp'
+            · apply continuous_algebraMap
+            · apply Continuous.comp'
+              · simp_all only
+              · exact continuous_const_smul I
     }
   map_add' := by
     intro f g

--- a/Mathlib/Analysis/NormedSpace/HahnBanach/Separation.lean
+++ b/Mathlib/Analysis/NormedSpace/HahnBanach/Separation.lean
@@ -209,7 +209,7 @@ variable [RCLike 𝕜] [TopologicalSpace E] [AddCommGroup E] [TopologicalAddGrou
   [Module 𝕜 E] [Module ℝ E] [ContinuousSMul 𝕜 E] [IsScalarTower ℝ 𝕜 E]
 
 /--Real linear extension of continuous extension of `LinearMap.extendTo𝕜'` -/
-noncomputable def LinTo𝕜' : (E →L[ℝ] ℝ) →ₗ[ℝ] (E →L[𝕜] 𝕜) :=
+noncomputable def extendTo𝕜'ₗ : (E →L[ℝ] ℝ) →ₗ[ℝ] (E →L[𝕜] 𝕜) :=
   letI to𝕜 (fr : (E →L[ℝ] ℝ)) : (E →L[𝕜] 𝕜) :=
     { toLinearMap := LinearMap.extendTo𝕜' fr
       cont := show Continuous fun x ↦ (fr x : 𝕜) - (I : 𝕜) * (fr ((I : 𝕜) • x) : 𝕜) by fun_prop }
@@ -219,8 +219,8 @@ noncomputable def LinTo𝕜' : (E →L[ℝ] ℝ) →ₗ[ℝ] (E →L[𝕜] 𝕜)
     map_smul' := by intros; ext; simp [h, real_smul_eq_coe_mul]; ring }
 
 @[simp]
-lemma real_LinTo𝕜' (g : E →L[ℝ] ℝ) (x : E) :  re ((LinTo𝕜' g) x : 𝕜) = g x := by
-  have h g (x : E) : LinTo𝕜' g x = ((g x : 𝕜) - (I : 𝕜) * (g ((I : 𝕜) • x) : 𝕜)) := rfl
+lemma re_extendTo𝕜'ₗ (g : E →L[ℝ] ℝ) (x : E) :  re ((extendTo𝕜'ₗ g) x : 𝕜) = g x := by
+  have h g (x : E) : extendTo𝕜'ₗ g x = ((g x : 𝕜) - (I : 𝕜) * (g ((I : 𝕜) • x) : 𝕜)) := rfl
   simp only [h , map_sub, ofReal_re, mul_re, I_re, zero_mul, ofReal_im, mul_zero,
     sub_self, sub_zero]
 
@@ -230,23 +230,23 @@ theorem separate_convex_open_set_RCLike {s : Set E}
     (hs₀ : (0 : E) ∈ s) (hs₁ : Convex ℝ s) (hs₂ : IsOpen s) {x₀ : E} (hx₀ : x₀ ∉ s) :
     ∃ f : E →L[𝕜] 𝕜, re (f x₀) = 1 ∧ ∀ x ∈ s, re (f x) < 1 := by
   obtain ⟨g, hg⟩ := separate_convex_open_set hs₀ hs₁ hs₂ hx₀
-  use LinTo𝕜' g
-  simp only [real_LinTo𝕜']
+  use extendTo𝕜'ₗ g
+  simp only [re_extendTo𝕜'ₗ]
   exact hg
 
 theorem geometric_hahn_banach_open_RCLike (hs₁ : Convex ℝ s) (hs₂ : IsOpen s) (ht : Convex ℝ t)
     (disj : Disjoint s t) : ∃ (f : E →L[𝕜] 𝕜) (u : ℝ), (∀ a ∈ s, re (f a) < u) ∧
     ∀ b ∈ t, u ≤ re (f b) := by
   obtain ⟨f, u, h⟩ := geometric_hahn_banach_open hs₁ hs₂ ht disj
-  use LinTo𝕜' f
-  simp only [real_LinTo𝕜']
+  use extendTo𝕜'ₗ f
+  simp only [re_extendTo𝕜'ₗ]
   exact Exists.intro u h
 
 theorem geometric_hahn_banach_open_point_RCLike (hs₁ : Convex ℝ s) (hs₂ : IsOpen s) (disj : x ∉ s) :
     ∃ f : E →L[𝕜] 𝕜, ∀ a ∈ s, re (f a) < re (f x) := by
   obtain ⟨f, h⟩ := geometric_hahn_banach_open_point hs₁ hs₂ disj
-  use LinTo𝕜' f
-  simp only [real_LinTo𝕜']
+  use extendTo𝕜'ₗ f
+  simp only [re_extendTo𝕜'ₗ]
   exact fun a a_1 ↦ h a a_1
 
 theorem geometric_hahn_banach_point_open_RCLike (ht₁ : Convex ℝ t) (ht₂ : IsOpen t) (disj : x ∉ t) :
@@ -258,8 +258,8 @@ theorem geometric_hahn_banach_open_open_RCLike (hs₁ : Convex ℝ s) (hs₂ : I
     (ht₁ : Convex ℝ t) (ht₃ : IsOpen t) (disj : Disjoint s t) :
     ∃ (f : E →L[𝕜] 𝕜) (u : ℝ), (∀ a ∈ s, re (f a) < u) ∧ ∀ b ∈ t, u < re (f b) := by
   obtain ⟨f, u, h⟩ := geometric_hahn_banach_open_open hs₁ hs₂ ht₁ ht₃ disj
-  use LinTo𝕜' f
-  simp only [real_LinTo𝕜']
+  use extendTo𝕜'ₗ f
+  simp only [re_extendTo𝕜'ₗ]
   exact Exists.intro u h
 
 variable [LocallyConvexSpace ℝ E]
@@ -268,8 +268,8 @@ theorem geometric_hahn_banach_compact_closed_RCLike (hs₁ : Convex ℝ s) (hs�
     (ht₁ : Convex ℝ t) (ht₂ : IsClosed t) (disj : Disjoint s t) :
     ∃ (f : E →L[𝕜] 𝕜) (u v : ℝ), (∀ a ∈ s, re (f a) < u) ∧ u < v ∧ ∀ b ∈ t, v < re (f b) := by
   obtain ⟨g, u, v, h1⟩ := geometric_hahn_banach_compact_closed hs₁ hs₂ ht₁ ht₂ disj
-  use LinTo𝕜' g
-  simp only [real_LinTo𝕜', exists_and_left]
+  use extendTo𝕜'ₗ g
+  simp only [re_extendTo𝕜'ₗ, exists_and_left]
   use u
   constructor
   exact h1.1

--- a/Mathlib/Analysis/NormedSpace/HahnBanach/Separation.lean
+++ b/Mathlib/Analysis/NormedSpace/HahnBanach/Separation.lean
@@ -252,7 +252,23 @@ theorem geometric_hahn_banach_open_point_RCLike (hs₁ : Convex ℝ s) (hs₂ : 
     sub_self, sub_zero]
   exact fun a a_1 ↦ h a a_1
 
-theorem geometric_hahn_banach_compact_closed_RCLike [LocallyConvexSpace ℝ E]
+theorem geometric_hahn_banach_point_open_RCLike (ht₁ : Convex ℝ t) (ht₂ : IsOpen t) (disj : x ∉ t) :
+    ∃ f : E →L[𝕜] 𝕜, ∀ b ∈ t, re (f x) < re (f b) :=
+  let ⟨f, hf⟩ := geometric_hahn_banach_open_point_RCLike ht₁ ht₂ disj
+  ⟨-f, by simpa⟩
+
+theorem geometric_hahn_banach_open_open_RCLike (hs₁ : Convex ℝ s) (hs₂ : IsOpen s)
+    (ht₁ : Convex ℝ t) (ht₃ : IsOpen t) (disj : Disjoint s t) :
+    ∃ (f : E →L[𝕜] 𝕜) (u : ℝ), (∀ a ∈ s, re (f a) < u) ∧ ∀ b ∈ t, u < re (f b) := by
+  obtain ⟨f, u, h⟩ := geometric_hahn_banach_open_open hs₁ hs₂ ht₁ ht₃ disj
+  use LinTo𝕜' f
+  simp only [extendTo𝕜'_apply, map_sub, ofReal_re, mul_re, I_re, zero_mul, ofReal_im, mul_zero,
+    sub_self, sub_zero]
+  exact Exists.intro u h
+
+variable [LocallyConvexSpace ℝ E]
+
+theorem geometric_hahn_banach_compact_closed_RCLike
 (hs₁ : Convex ℝ s) (hs₂ : IsCompact s) (ht₁ : Convex ℝ t) (ht₂ : IsClosed t) (disj : Disjoint s t) :
     ∃ (f : E →L[𝕜] 𝕜) (u v : ℝ), (∀ a ∈ s, re (f a) < u) ∧ u < v ∧ ∀ b ∈ t, v < re (f b) := by
   obtain ⟨g, u, v, h1⟩ := geometric_hahn_banach_compact_closed hs₁ hs₂ ht₁ ht₂ disj
@@ -264,5 +280,26 @@ theorem geometric_hahn_banach_compact_closed_RCLike [LocallyConvexSpace ℝ E]
   exact h1.1
   use v
   exact h1.2
+
+theorem geometric_hahn_banach_closed_compact_RCLike (hs₁ : Convex ℝ s) (hs₂ : IsClosed s)
+    (ht₁ : Convex ℝ t) (ht₂ : IsCompact t) (disj : Disjoint s t) :
+    ∃ (f : E →L[𝕜] 𝕜) (u v : ℝ), (∀ a ∈ s, re (f a) < u) ∧ u < v ∧ ∀ b ∈ t, v < re (f b) :=
+  let ⟨f, s, t, hs, st, ht⟩ := geometric_hahn_banach_compact_closed_RCLike ht₁ ht₂ hs₁ hs₂ disj.symm
+  ⟨-f, -t, -s, by simpa using ht, by simpa using st, by simpa using hs⟩
+
+theorem geometric_hahn_banach_point_closed_RCLike (ht₁ : Convex ℝ t) (ht₂ : IsClosed t)
+    (disj : x ∉ t) : ∃ (f : E →L[𝕜] 𝕜) (u : ℝ), re (f x) < u ∧ ∀ b ∈ t, u < re (f b) :=
+  let ⟨f, _u, v, ha, hst, hb⟩ :=
+    geometric_hahn_banach_compact_closed_RCLike (convex_singleton x) isCompact_singleton ht₁ ht₂
+      (disjoint_singleton_left.2 disj)
+  ⟨f, v, hst.trans' <| ha x <| mem_singleton _, hb⟩
+
+theorem geometric_hahn_banach_closed_point_RCLike (hs₁ : Convex ℝ s) (hs₂ : IsClosed s)
+    (disj : x ∉ s) : ∃ (f : E →L[𝕜] 𝕜) (u : ℝ), (∀ a ∈ s, re (f a) < u) ∧ u < re (f x) :=
+  let ⟨f, s, _t, ha, hst, hb⟩ :=
+    geometric_hahn_banach_closed_compact_RCLike hs₁ hs₂ (convex_singleton x) isCompact_singleton
+      (disjoint_singleton_right.2 disj)
+  ⟨f, s, ha, hst.trans <| hb x <| mem_singleton _⟩
+
 
 end RCLike

--- a/Mathlib/Analysis/NormedSpace/HahnBanach/Separation.lean
+++ b/Mathlib/Analysis/NormedSpace/HahnBanach/Separation.lean
@@ -242,7 +242,8 @@ def RCLinearMapDual : (E →L[ℝ] ℝ) →ₗ[ℝ] (E →L[ℝ] 𝕜) where
         simp only [LinearMapClass.map_smul, map_mul, RingHom.id_apply, smul_sub, smul_eq_mul,
           real_smul_ofReal, sub_right_inj]
         rw [smul_comm, LinearMapClass.map_smul]
-        sorry
+        simp only [smul_eq_mul, map_mul, real_smul_ofReal, real_smul_eq_coe_mul]
+        exact Algebra.left_comm I m ((algebraMap ℝ 𝕜) (toLinearMap (I • x)))
       cont := {
         isOpen_preimage := by
           intro s hs

--- a/Mathlib/Analysis/NormedSpace/HahnBanach/Separation.lean
+++ b/Mathlib/Analysis/NormedSpace/HahnBanach/Separation.lean
@@ -257,8 +257,8 @@ theorem geometric_hahn_banach_open_open_RCLike (hs₁ : Convex ℝ s) (hs₂ : I
 
 variable [LocallyConvexSpace ℝ E]
 
-theorem geometric_hahn_banach_compact_closed_RCLike
-(hs₁ : Convex ℝ s) (hs₂ : IsCompact s) (ht₁ : Convex ℝ t) (ht₂ : IsClosed t) (disj : Disjoint s t) :
+theorem geometric_hahn_banach_compact_closed_RCLike (hs₁ : Convex ℝ s) (hs₂ : IsCompact s)
+    (ht₁ : Convex ℝ t) (ht₂ : IsClosed t) (disj : Disjoint s t) :
     ∃ (f : E →L[𝕜] 𝕜) (u v : ℝ), (∀ a ∈ s, re (f a) < u) ∧ u < v ∧ ∀ b ∈ t, v < re (f b) := by
   obtain ⟨g, u, v, h1⟩ := geometric_hahn_banach_compact_closed hs₁ hs₂ ht₁ ht₂ disj; use LinTo𝕜' g
   simp only [real_of_real_of_LinTo𝕜', exists_and_left]; use u; constructor; exact h1.1; use v

--- a/Mathlib/Analysis/NormedSpace/HahnBanach/Separation.lean
+++ b/Mathlib/Analysis/NormedSpace/HahnBanach/Separation.lean
@@ -203,9 +203,7 @@ theorem iInter_halfspaces_eq (hs₁ : Convex ℝ s) (hs₂ : IsClosed s) :
   obtain ⟨y, hy, hxy⟩ := hx l
   exact ((hxy.trans_lt (hlA y hy)).trans hl).not_le le_rfl
 
-section RCLike
-
-open RCLike
+namespace RCLike
 
 variable [RCLike 𝕜] [TopologicalSpace E] [AddCommGroup E] [TopologicalAddGroup E]
   [Module 𝕜 E] [Module ℝ E] [ContinuousSMul 𝕜 E] [IsScalarTower ℝ 𝕜 E]
@@ -221,29 +219,35 @@ noncomputable def LinTo𝕜' : (E →L[ℝ] ℝ) →ₗ[ℝ] (E →L[𝕜] 𝕜)
     map_smul' := by intros; ext; simp [h, real_smul_eq_coe_mul]; ring }
 
 @[simp]
-lemma real_of_LinTo𝕜' (g : E →L[ℝ] ℝ) (x : E) :  re ((LinTo𝕜' g) x : 𝕜) = g x := by
+lemma real_LinTo𝕜' (g : E →L[ℝ] ℝ) (x : E) :  re ((LinTo𝕜' g) x : 𝕜) = g x := by
   have h g (x : E) : LinTo𝕜' g x = ((g x : 𝕜) - (I : 𝕜) * (g ((I : 𝕜) • x) : 𝕜)) := rfl
   simp only [h , map_sub, ofReal_re, mul_re, I_re, zero_mul, ofReal_im, mul_zero,
-  sub_self, sub_zero]
+    sub_self, sub_zero]
 
 variable [ContinuousSMul ℝ E]
 
-theorem separate_convex_open_set_RCLike  {s : Set E}
+theorem separate_convex_open_set_RCLike {s : Set E}
     (hs₀ : (0 : E) ∈ s) (hs₁ : Convex ℝ s) (hs₂ : IsOpen s) {x₀ : E} (hx₀ : x₀ ∉ s) :
     ∃ f : E →L[𝕜] 𝕜, re (f x₀) = 1 ∧ ∀ x ∈ s, re (f x) < 1 := by
-  obtain ⟨g, hg⟩ := separate_convex_open_set hs₀ hs₁ hs₂ hx₀; use LinTo𝕜' g
-  simp only [real_of_LinTo𝕜']; exact hg
+  obtain ⟨g, hg⟩ := separate_convex_open_set hs₀ hs₁ hs₂ hx₀
+  use LinTo𝕜' g
+  simp only [real_LinTo𝕜']
+  exact hg
 
 theorem geometric_hahn_banach_open_RCLike (hs₁ : Convex ℝ s) (hs₂ : IsOpen s) (ht : Convex ℝ t)
     (disj : Disjoint s t) : ∃ (f : E →L[𝕜] 𝕜) (u : ℝ), (∀ a ∈ s, re (f a) < u) ∧
     ∀ b ∈ t, u ≤ re (f b) := by
-  obtain ⟨f, u, h⟩ := geometric_hahn_banach_open hs₁ hs₂ ht disj; use LinTo𝕜' f
-  simp only [real_of_LinTo𝕜']; exact Exists.intro u h
+  obtain ⟨f, u, h⟩ := geometric_hahn_banach_open hs₁ hs₂ ht disj
+  use LinTo𝕜' f
+  simp only [real_LinTo𝕜']
+  exact Exists.intro u h
 
 theorem geometric_hahn_banach_open_point_RCLike (hs₁ : Convex ℝ s) (hs₂ : IsOpen s) (disj : x ∉ s) :
     ∃ f : E →L[𝕜] 𝕜, ∀ a ∈ s, re (f a) < re (f x) := by
-  obtain ⟨f, h⟩ := geometric_hahn_banach_open_point hs₁ hs₂ disj; use LinTo𝕜' f
-  simp only [real_of_LinTo𝕜']; exact fun a a_1 ↦ h a a_1
+  obtain ⟨f, h⟩ := geometric_hahn_banach_open_point hs₁ hs₂ disj
+  use LinTo𝕜' f
+  simp only [real_LinTo𝕜']
+  exact fun a a_1 ↦ h a a_1
 
 theorem geometric_hahn_banach_point_open_RCLike (ht₁ : Convex ℝ t) (ht₂ : IsOpen t) (disj : x ∉ t) :
     ∃ f : E →L[𝕜] 𝕜, ∀ b ∈ t, re (f x) < re (f b) :=
@@ -254,15 +258,22 @@ theorem geometric_hahn_banach_open_open_RCLike (hs₁ : Convex ℝ s) (hs₂ : I
     (ht₁ : Convex ℝ t) (ht₃ : IsOpen t) (disj : Disjoint s t) :
     ∃ (f : E →L[𝕜] 𝕜) (u : ℝ), (∀ a ∈ s, re (f a) < u) ∧ ∀ b ∈ t, u < re (f b) := by
   obtain ⟨f, u, h⟩ := geometric_hahn_banach_open_open hs₁ hs₂ ht₁ ht₃ disj
-  use LinTo𝕜' f; simp only [real_of_LinTo𝕜']; exact Exists.intro u h
+  use LinTo𝕜' f
+  simp only [real_LinTo𝕜']
+  exact Exists.intro u h
 
 variable [LocallyConvexSpace ℝ E]
 
 theorem geometric_hahn_banach_compact_closed_RCLike (hs₁ : Convex ℝ s) (hs₂ : IsCompact s)
     (ht₁ : Convex ℝ t) (ht₂ : IsClosed t) (disj : Disjoint s t) :
     ∃ (f : E →L[𝕜] 𝕜) (u v : ℝ), (∀ a ∈ s, re (f a) < u) ∧ u < v ∧ ∀ b ∈ t, v < re (f b) := by
-  obtain ⟨g, u, v, h1⟩ := geometric_hahn_banach_compact_closed hs₁ hs₂ ht₁ ht₂ disj; use LinTo𝕜' g
-  simp only [real_of_LinTo𝕜', exists_and_left]; use u; constructor; exact h1.1; use v
+  obtain ⟨g, u, v, h1⟩ := geometric_hahn_banach_compact_closed hs₁ hs₂ ht₁ ht₂ disj
+  use LinTo𝕜' g
+  simp only [real_LinTo𝕜', exists_and_left]
+  use u
+  constructor
+  exact h1.1
+  use v
   exact h1.2
 
 theorem geometric_hahn_banach_closed_compact_RCLike (hs₁ : Convex ℝ s) (hs₂ : IsClosed s)
@@ -299,6 +310,6 @@ theorem iInter_halfspaces_eq_RCLike (hs₁ : Convex ℝ s) (hs₂ : IsClosed s) 
   by_contra h
   obtain ⟨l, s, hlA, hl⟩ := geometric_hahn_banach_closed_point_RCLike (𝕜 := 𝕜) hs₁ hs₂ h
   obtain ⟨y, hy, hxy⟩ := hx l
-  exact ((hxy.trans_lt (hlA y hy)).trans hl).not_le le_rfl
+  exact ((hxy.trans_lt (hlA y hy)).trans hl).false
 
 end RCLike

--- a/Mathlib/Analysis/NormedSpace/HahnBanach/Separation.lean
+++ b/Mathlib/Analysis/NormedSpace/HahnBanach/Separation.lean
@@ -258,7 +258,7 @@ theorem geometric_hahn_banach_open_open_RCLike (hs₁ : Convex ℝ s) (hs₂ : I
 variable [LocallyConvexSpace ℝ E]
 
 theorem geometric_hahn_banach_compact_closed_RCLike
-(hs₁ : Convex ℝ s) (hs₂ : IsCompact s) (ht₁ : Convex ℝ t) (ht₂ : IsClosed t) (disj : Disjoint s t) :
+    (hs₁ : Convex ℝ s) (hs₂ : IsCompact s) (ht₁ : Convex ℝ t) (ht₂ : IsClosed t) (disj : Disjoint s t) :
     ∃ (f : E →L[𝕜] 𝕜) (u v : ℝ), (∀ a ∈ s, re (f a) < u) ∧ u < v ∧ ∀ b ∈ t, v < re (f b) := by
   obtain ⟨g, u, v, h1⟩ := geometric_hahn_banach_compact_closed hs₁ hs₂ ht₁ ht₂ disj; use LinTo𝕜' g
   simp only [real_of_real_of_LinTo𝕜', exists_and_left]; use u; constructor; exact h1.1; use v

--- a/Mathlib/Analysis/NormedSpace/HahnBanach/Separation.lean
+++ b/Mathlib/Analysis/NormedSpace/HahnBanach/Separation.lean
@@ -247,32 +247,13 @@ noncomputable def extendTo𝕜'' (fr : E →ₗ[ℝ] ℝ) : E →ₗ[𝕜] 𝕜 
 variable [TopologicalSpace E] [AddCommGroup E] [TopologicalAddGroup E]
   [Module 𝕜 E] [Module ℝ E] [ContinuousSMul 𝕜 E] [IsScalarTower ℝ 𝕜 E]
 
-noncomputable def extendTo𝕜' (fr : E →L[ℝ] ℝ) : E →L[𝕜] 𝕜 where
-  toFun := extendTo𝕜'' fr.1
-  map_add' := fun x y ↦ LinearMap.map_add (extendTo𝕜'' ↑fr) x y
-  map_smul' := fun m x ↦ LinearMap.CompatibleSMul.map_smul (extendTo𝕜'' ↑fr) m x
-  cont := by
-    change Continuous (fun x => (fr x : 𝕜) - (I : 𝕜) * fr ((I : 𝕜) • x)); fun_prop
-
-noncomputable def LinTo𝕜' : (E →L[ℝ] ℝ) →ₗ[ℝ] (E →L[𝕜] 𝕜) where
-  toFun := extendTo𝕜'
-  map_add' := by
-    intro f g
-    ext v
-    simp only [ContinuousLinearMap.add_apply]
-    change (fun x => ((f + g) x : 𝕜) - (I : 𝕜) * (f + g) ((I : 𝕜) • x)) v =
-     ((fun x => (f x : 𝕜) - (I : 𝕜) * f ((I : 𝕜) • x)) +
-       (fun x => (g x : 𝕜) - (I : 𝕜) * g ((I : 𝕜) • x))) v
-    simp only [ContinuousLinearMap.add_apply, map_add, Pi.add_apply]
-    ring_nf
-  map_smul' := by
-    intro m f
-    simp only [RingHom.id_apply]
-    ext v
-    change (fun x => ((m • f) x : 𝕜) - (I : 𝕜) * (m • f) ((I : 𝕜) • x)) v =
-       m • ((fun x => (f x : 𝕜) - (I : 𝕜) * f ((I : 𝕜) • x)) v)
-    simp only [ContinuousLinearMap.coe_smul', Pi.smul_apply, smul_eq_mul, map_mul,
-       @real_smul_eq_coe_mul]
-    ring_nf
+noncomputable def LinTo𝕜'' : (E →L[ℝ] ℝ) →ₗ[ℝ] (E →L[𝕜] 𝕜) :=
+  letI to𝕜 (fr : (E →L[ℝ] ℝ)) : (E →L[𝕜] 𝕜) :=
+    { toLinearMap := extendTo𝕜'' fr
+      cont := show Continuous fun x ↦ (fr x : 𝕜) - (I : 𝕜) * (fr ((I : 𝕜) • x) : 𝕜) by fun_prop }
+  have h fr x : to𝕜 fr x = ((fr x : 𝕜) - (I : 𝕜) * (fr ((I : 𝕜) • x) : 𝕜)) := rfl
+  { toFun := to𝕜
+    map_add' := by intros; ext; simp [h]; ring
+    map_smul' := by intros; ext; simp [h, real_smul_eq_coe_mul]; ring }
 
 end RCLike

--- a/Mathlib/Analysis/NormedSpace/HahnBanach/Separation.lean
+++ b/Mathlib/Analysis/NormedSpace/HahnBanach/Separation.lean
@@ -210,6 +210,7 @@ open RCLike
 variable [RCLike 𝕜] [TopologicalSpace E] [AddCommGroup E] [TopologicalAddGroup E]
   [Module 𝕜 E] [Module ℝ E] [ContinuousSMul 𝕜 E] [IsScalarTower ℝ 𝕜 E]
 
+/--Real linear extension of continuous extension of `LinearMap.extendTo𝕜'` -/
 noncomputable def LinTo𝕜' : (E →L[ℝ] ℝ) →ₗ[ℝ] (E →L[𝕜] 𝕜) :=
   letI to𝕜 (fr : (E →L[ℝ] ℝ)) : (E →L[𝕜] 𝕜) :=
     { toLinearMap := LinearMap.extendTo𝕜' fr

--- a/Mathlib/Analysis/NormedSpace/HahnBanach/Separation.lean
+++ b/Mathlib/Analysis/NormedSpace/HahnBanach/Separation.lean
@@ -220,37 +220,29 @@ noncomputable def LinTo𝕜' : (E →L[ℝ] ℝ) →ₗ[ℝ] (E →L[𝕜] 𝕜)
     map_smul' := by intros; ext; simp [h, real_smul_eq_coe_mul]; ring }
 
 @[simp]
-lemma extendTo𝕜'_apply (fr : E →L[ℝ] ℝ) (x : E) :
-    LinTo𝕜' fr x = ((fr x : 𝕜) - (I : 𝕜) * (fr ((I : 𝕜) • x) : 𝕜)) :=
-  rfl
+lemma real_of_real_of_LinTo𝕜' (g : E →L[ℝ] ℝ) (x : E) :  re ((LinTo𝕜' g) x : 𝕜) = g x := by
+  have h g (x : E) : LinTo𝕜' g x = ((g x : 𝕜) - (I : 𝕜) * (g ((I : 𝕜) • x) : 𝕜)) := rfl
+  simp only [h , map_sub, ofReal_re, mul_re, I_re, zero_mul, ofReal_im, mul_zero,
+  sub_self, sub_zero]
 
 variable [ContinuousSMul ℝ E]
 
 theorem separate_convex_open_set_RCLike  {s : Set E}
     (hs₀ : (0 : E) ∈ s) (hs₁ : Convex ℝ s) (hs₂ : IsOpen s) {x₀ : E} (hx₀ : x₀ ∉ s) :
     ∃ f : E →L[𝕜] 𝕜, re (f x₀) = 1 ∧ ∀ x ∈ s, re (f x) < 1 := by
-  obtain ⟨g, hg⟩ := separate_convex_open_set hs₀ hs₁ hs₂ hx₀
-  use LinTo𝕜' g
-  simp only [extendTo𝕜'_apply, map_sub, ofReal_re, mul_re, I_re, zero_mul, ofReal_im, mul_zero,
-    sub_self, sub_zero]
-  exact hg
+  obtain ⟨g, hg⟩ := separate_convex_open_set hs₀ hs₁ hs₂ hx₀; use LinTo𝕜' g
+  simp only [real_of_real_of_LinTo𝕜']; exact hg
 
 theorem geometric_hahn_banach_open_RCLike (hs₁ : Convex ℝ s) (hs₂ : IsOpen s) (ht : Convex ℝ t)
     (disj : Disjoint s t) : ∃ (f : E →L[𝕜] 𝕜) (u : ℝ), (∀ a ∈ s, re (f a) < u) ∧
     ∀ b ∈ t, u ≤ re (f b) := by
-  obtain ⟨f, u, h⟩ := geometric_hahn_banach_open hs₁ hs₂ ht disj
-  use LinTo𝕜' f
-  simp only [extendTo𝕜'_apply, map_sub, ofReal_re, mul_re, I_re, zero_mul, ofReal_im, mul_zero,
-    sub_self, sub_zero]
-  exact Exists.intro u h
+  obtain ⟨f, u, h⟩ := geometric_hahn_banach_open hs₁ hs₂ ht disj; use LinTo𝕜' f
+  simp only [real_of_real_of_LinTo𝕜']; exact Exists.intro u h
 
 theorem geometric_hahn_banach_open_point_RCLike (hs₁ : Convex ℝ s) (hs₂ : IsOpen s) (disj : x ∉ s) :
     ∃ f : E →L[𝕜] 𝕜, ∀ a ∈ s, re (f a) < re (f x) := by
-  obtain ⟨f, h⟩ := geometric_hahn_banach_open_point hs₁ hs₂ disj
-  use LinTo𝕜' f
-  simp only [extendTo𝕜'_apply, map_sub, ofReal_re, mul_re, I_re, zero_mul, ofReal_im, mul_zero,
-    sub_self, sub_zero]
-  exact fun a a_1 ↦ h a a_1
+  obtain ⟨f, h⟩ := geometric_hahn_banach_open_point hs₁ hs₂ disj; use LinTo𝕜' f
+  simp only [real_of_real_of_LinTo𝕜']; exact fun a a_1 ↦ h a a_1
 
 theorem geometric_hahn_banach_point_open_RCLike (ht₁ : Convex ℝ t) (ht₂ : IsOpen t) (disj : x ∉ t) :
     ∃ f : E →L[𝕜] 𝕜, ∀ b ∈ t, re (f x) < re (f b) :=
@@ -261,24 +253,15 @@ theorem geometric_hahn_banach_open_open_RCLike (hs₁ : Convex ℝ s) (hs₂ : I
     (ht₁ : Convex ℝ t) (ht₃ : IsOpen t) (disj : Disjoint s t) :
     ∃ (f : E →L[𝕜] 𝕜) (u : ℝ), (∀ a ∈ s, re (f a) < u) ∧ ∀ b ∈ t, u < re (f b) := by
   obtain ⟨f, u, h⟩ := geometric_hahn_banach_open_open hs₁ hs₂ ht₁ ht₃ disj
-  use LinTo𝕜' f
-  simp only [extendTo𝕜'_apply, map_sub, ofReal_re, mul_re, I_re, zero_mul, ofReal_im, mul_zero,
-    sub_self, sub_zero]
-  exact Exists.intro u h
+  use LinTo𝕜' f; simp only [real_of_real_of_LinTo𝕜']; exact Exists.intro u h
 
 variable [LocallyConvexSpace ℝ E]
 
 theorem geometric_hahn_banach_compact_closed_RCLike
 (hs₁ : Convex ℝ s) (hs₂ : IsCompact s) (ht₁ : Convex ℝ t) (ht₂ : IsClosed t) (disj : Disjoint s t) :
     ∃ (f : E →L[𝕜] 𝕜) (u v : ℝ), (∀ a ∈ s, re (f a) < u) ∧ u < v ∧ ∀ b ∈ t, v < re (f b) := by
-  obtain ⟨g, u, v, h1⟩ := geometric_hahn_banach_compact_closed hs₁ hs₂ ht₁ ht₂ disj
-  use LinTo𝕜' g
-  simp only [extendTo𝕜'_apply, map_sub, ofReal_re, mul_re, I_re, zero_mul, ofReal_im, mul_zero,
-    sub_self, sub_zero, exists_and_left]
-  use u
-  constructor
-  exact h1.1
-  use v
+  obtain ⟨g, u, v, h1⟩ := geometric_hahn_banach_compact_closed hs₁ hs₂ ht₁ ht₂ disj; use LinTo𝕜' g
+  simp only [real_of_real_of_LinTo𝕜', exists_and_left]; use u; constructor; exact h1.1; use v
   exact h1.2
 
 theorem geometric_hahn_banach_closed_compact_RCLike (hs₁ : Convex ℝ s) (hs₂ : IsClosed s)

--- a/Mathlib/Analysis/NormedSpace/HahnBanach/Separation.lean
+++ b/Mathlib/Analysis/NormedSpace/HahnBanach/Separation.lean
@@ -270,11 +270,7 @@ theorem geometric_hahn_banach_compact_closed (hs₁ : Convex ℝ s) (hs₂ : IsC
   obtain ⟨g, u, v, h1⟩ := _root_.geometric_hahn_banach_compact_closed hs₁ hs₂ ht₁ ht₂ disj
   use extendTo𝕜'ₗ g
   simp only [re_extendTo𝕜'ₗ, exists_and_left]
-  use u
-  constructor
-  exact h1.1
-  use v
-  exact h1.2
+  exact ⟨u, h1.1, v, h1.2⟩
 
 theorem geometric_hahn_banach_closed_compact (hs₁ : Convex ℝ s) (hs₂ : IsClosed s)
     (ht₁ : Convex ℝ t) (ht₂ : IsCompact t) (disj : Disjoint s t) :


### PR DESCRIPTION
Generalized first definition in `Mathlib.Analysis.NormedSpace.Extend`, and used this to prove `RCLike` generalizations of Hahn-Banach separation theorems.

Co-authored-by: Jireh Loreaux <loreaujy@gmail.com>

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
