### PR TITLE
[Merged by Bors] - feat: Direct sum of additive characters

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -170,6 +170,7 @@ import Mathlib.Algebra.ContinuedFractions.TerminatedStable
 import Mathlib.Algebra.ContinuedFractions.Translations
 import Mathlib.Algebra.CubicDiscriminant
 import Mathlib.Algebra.DirectLimit
+import Mathlib.Algebra.DirectSum.AddChar
 import Mathlib.Algebra.DirectSum.Algebra
 import Mathlib.Algebra.DirectSum.Basic
 import Mathlib.Algebra.DirectSum.Decomposition

--- a/Mathlib/Algebra/DirectSum/AddChar.lean
+++ b/Mathlib/Algebra/DirectSum/AddChar.lean
@@ -1,0 +1,35 @@
+/-
+Copyright (c) 2024 Yaël Dillies. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Yaël Dillies
+-/
+import Mathlib.Algebra.DirectSum.Basic
+import Mathlib.Algebra.Group.AddChar
+
+/-!
+# Direct sum of additive characters
+
+This file defines the direct sum of additive characters.
+-/
+
+open Function
+open scoped DirectSum
+
+variable {ι R : Type*} {G : ι → Type*} [DecidableEq ι] [∀ i, AddCommGroup (G i)] [CommMonoid R]
+
+namespace AddChar
+section DirectSum
+
+/-- Direct sum of additive characters. -/
+@[simps!]
+def directSum (ψ : ∀ i, AddChar (G i) R) : AddChar (⨁ i, G i) R :=
+  toAddMonoidHomEquiv.symm <| DirectSum.toAddMonoid fun i ↦ toAddMonoidHomEquiv (ψ i)
+
+lemma directSum_injective :
+    Injective (directSum : (∀ i, AddChar (G i) R) → AddChar (⨁ i, G i) R) := by
+  refine toAddMonoidHomEquiv.symm.injective.comp $ DirectSum.toAddMonoid_injective.comp ?_
+  rintro ψ χ h
+  simpa [Function.funext_iff] using h
+
+end DirectSum
+end AddChar

--- a/Mathlib/Algebra/DirectSum/AddChar.lean
+++ b/Mathlib/Algebra/DirectSum/AddChar.lean
@@ -27,7 +27,7 @@ def directSum (ψ : ∀ i, AddChar (G i) R) : AddChar (⨁ i, G i) R :=
 
 lemma directSum_injective :
     Injective (directSum : (∀ i, AddChar (G i) R) → AddChar (⨁ i, G i) R) := by
-  refine toAddMonoidHomEquiv.symm.injective.comp $ DirectSum.toAddMonoid_injective.comp ?_
+  refine toAddMonoidHomEquiv.symm.injective.comp <| DirectSum.toAddMonoid_injective.comp ?_
   rintro ψ χ h
   simpa [funext_iff] using h
 

--- a/Mathlib/Algebra/DirectSum/AddChar.lean
+++ b/Mathlib/Algebra/DirectSum/AddChar.lean
@@ -29,7 +29,7 @@ lemma directSum_injective :
     Injective (directSum : (∀ i, AddChar (G i) R) → AddChar (⨁ i, G i) R) := by
   refine toAddMonoidHomEquiv.symm.injective.comp $ DirectSum.toAddMonoid_injective.comp ?_
   rintro ψ χ h
-  simpa [Function.funext_iff] using h
+  simpa [funext_iff] using h
 
 end DirectSum
 end AddChar


### PR DESCRIPTION
Define the direct sum of additive characters as an `AddChar (⨁ i, G i) R`.

From LeanAPAP

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
