### PR TITLE
[Merged by Bors] - feat: The norm of a complex-valued `AddChar`

### DIFF
--- a/Mathlib/Algebra/Group/AddChar.lean
+++ b/Mathlib/Algebra/Group/AddChar.lean
@@ -317,6 +317,14 @@ lemma injective_iff {ψ : AddChar A M} : Injective ψ ↔ ∀ ⦃x⦄, ψ x = 1 
 
 end fromAddGrouptoDivisionCommMonoid
 
+section MonoidWithZero
+variable {A M₀ : Type*} [AddGroup A] [MonoidWithZero M₀] [Nontrivial M₀]
+
+@[simp] lemma coe_ne_zero (ψ : AddChar A M₀) : (ψ : A → M₀) ≠ 0 :=
+  ne_iff.2 ⟨0, fun h ↦ by simpa only [h, Pi.zero_apply, zero_ne_one] using map_zero_eq_one ψ⟩
+
+end MonoidWithZero
+
 /-!
 ## Additive characters of rings
 -/

--- a/Mathlib/Analysis/Normed/Field/Basic.lean
+++ b/Mathlib/Analysis/Normed/Field/Basic.lean
@@ -5,6 +5,7 @@ Authors: Patrick Massot, Johannes Hölzl
 -/
 import Mathlib.Algebra.Algebra.NonUnitalSubalgebra
 import Mathlib.Algebra.Algebra.Subalgebra.Basic
+import Mathlib.Algebra.Group.AddChar
 import Mathlib.Algebra.Order.Ring.Finset
 import Mathlib.Analysis.Normed.Group.Bounded
 import Mathlib.Analysis.Normed.Group.Constructions
@@ -847,6 +848,9 @@ protected lemma IsOfFinOrder.norm_eq_one (ha : IsOfFinOrder a) : ‖a‖ = 1 :=
 
 example [Monoid β] (φ : β →* α) {x : β} {k : ℕ+} (h : x ^ (k : ℕ) = 1) :
     ‖φ x‖ = 1 := (φ.isOfFinOrder <| isOfFinOrder_iff_pow_eq_one.2 ⟨_, k.2, h⟩).norm_eq_one
+
+@[simp] lemma AddChar.norm_apply {G : Type*} [AddLeftCancelMonoid G] [Finite G] (ψ : AddChar G α)
+    (x : G) : ‖ψ x‖ = 1 := (ψ.toMonoidHom.isOfFinOrder <| isOfFinOrder_of_finite _).norm_eq_one
 
 end NormedDivisionRing
 

--- a/Mathlib/Analysis/RCLike/Basic.lean
+++ b/Mathlib/Analysis/RCLike/Basic.lean
@@ -40,11 +40,11 @@ their counterparts in `Mathlib/Analysis/Complex/Basic.lean` (which causes linter
 A few lemmas requiring heavier imports are in `Mathlib/Data/RCLike/Lemmas.lean`.
 -/
 
+open scoped ComplexConjugate
+
 section
 
 local notation "𝓚" => algebraMap ℝ _
-
-open ComplexConjugate
 
 /--
 This typeclass captures properties shared by ℝ and ℂ, with an API that closely matches that of ℂ.
@@ -81,8 +81,6 @@ end
 variable {K E : Type*} [RCLike K]
 
 namespace RCLike
-
-open ComplexConjugate
 
 /-- Coercion from `ℝ` to an `RCLike` field. -/
 @[coe] abbrev ofReal : ℝ → K := Algebra.cast
@@ -824,8 +822,6 @@ scoped[ComplexOrder] attribute [instance] StarModule.instOrderedSMul
 
 end Order
 
-open ComplexConjugate
-
 section CleanupLemmas
 
 local notation "reR" => @RCLike.re ℝ _
@@ -1022,3 +1018,14 @@ noncomputable def realLinearIsometryEquiv (h : I = (0 : K)) : K ≃ₗᵢ[ℝ] �
 end CaseSpecific
 
 end RCLike
+
+namespace AddChar
+variable {G : Type*} [Finite G]
+
+lemma inv_apply_eq_conj [AddLeftCancelMonoid G] (ψ : AddChar G K) (x : G) : (ψ x)⁻¹ = conj (ψ x) :=
+  RCLike.inv_eq_conj <| norm_apply _ _
+
+lemma map_neg_eq_conj [AddCommGroup G] (ψ : AddChar G K) (x : G) : ψ (-x) = conj (ψ x) := by
+  rw [map_neg_eq_inv, inv_apply_eq_conj]
+
+end AddChar

--- a/Mathlib/Analysis/RCLike/Lemmas.lean
+++ b/Mathlib/Analysis/RCLike/Lemmas.lean
@@ -1,15 +1,53 @@
 /-
 Copyright (c) 2020 Frédéric Dupuis. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Frédéric Dupuis
+Authors: Frédéric Dupuis, Yaël Dillies
 -/
+import Mathlib.Algebra.Group.AddChar
 import Mathlib.Analysis.Normed.Module.FiniteDimension
 import Mathlib.Analysis.RCLike.Basic
 
 /-! # Further lemmas about `RCLike` -/
 
+open Function
+open scoped ComplexConjugate
 
-variable {K E : Type*} [RCLike K]
+variable {G K E : Type*}
+
+namespace AddChar
+section AddGroup
+variable [AddGroup G]
+
+section NormedField
+variable [Finite G] [NormedField K]
+
+@[simp] lemma norm_apply (ψ : AddChar G K) (x : G) : ‖ψ x‖ = 1 :=
+  (ψ.toMonoidHom.isOfFinOrder $ isOfFinOrder_of_finite _).norm_eq_one
+
+@[simp] lemma coe_ne_zero (ψ : AddChar G K) : (ψ : G → K) ≠ 0 :=
+  ne_iff.2 ⟨0, fun h ↦ by simpa only [h, Pi.zero_apply, zero_ne_one] using map_zero_eq_one ψ⟩
+
+end NormedField
+
+section RCLike
+variable [RCLike K]
+
+lemma inv_apply_eq_conj [Finite G] (ψ : AddChar G K) (x : G) : (ψ x)⁻¹ = conj (ψ x) :=
+  RCLike.inv_eq_conj $ norm_apply _ _
+
+end RCLike
+end AddGroup
+
+section AddCommGroup
+variable [AddCommGroup G] [RCLike K] {ψ₁ ψ₂ : AddChar G K}
+
+lemma map_neg_eq_conj [Finite G] (ψ : AddChar G K) (x : G) : ψ (-x) = conj (ψ x) := by
+  rw [map_neg_eq_inv, RCLike.inv_eq_conj $ norm_apply _ _]
+
+end AddCommGroup
+end AddChar
+
+variable [RCLike K]
 
 namespace Polynomial
 

--- a/Mathlib/Analysis/RCLike/Lemmas.lean
+++ b/Mathlib/Analysis/RCLike/Lemmas.lean
@@ -18,22 +18,19 @@ namespace AddChar
 section AddGroup
 variable [AddGroup G]
 
-section NormedField
-variable [Finite G] [NormedField K]
+section NormedDivisionRing
+variable [Finite G] [NormedDivisionRing K]
 
 @[simp] lemma norm_apply (ψ : AddChar G K) (x : G) : ‖ψ x‖ = 1 :=
-  (ψ.toMonoidHom.isOfFinOrder $ isOfFinOrder_of_finite _).norm_eq_one
+  (ψ.toMonoidHom.isOfFinOrder <| isOfFinOrder_of_finite _).norm_eq_one
 
-@[simp] lemma coe_ne_zero (ψ : AddChar G K) : (ψ : G → K) ≠ 0 :=
-  ne_iff.2 ⟨0, fun h ↦ by simpa only [h, Pi.zero_apply, zero_ne_one] using map_zero_eq_one ψ⟩
-
-end NormedField
+end NormedDivisionRing
 
 section RCLike
 variable [RCLike K]
 
 lemma inv_apply_eq_conj [Finite G] (ψ : AddChar G K) (x : G) : (ψ x)⁻¹ = conj (ψ x) :=
-  RCLike.inv_eq_conj $ norm_apply _ _
+  RCLike.inv_eq_conj <| norm_apply _ _
 
 end RCLike
 end AddGroup
@@ -42,7 +39,7 @@ section AddCommGroup
 variable [AddCommGroup G] [RCLike K] {ψ₁ ψ₂ : AddChar G K}
 
 lemma map_neg_eq_conj [Finite G] (ψ : AddChar G K) (x : G) : ψ (-x) = conj (ψ x) := by
-  rw [map_neg_eq_inv, RCLike.inv_eq_conj $ norm_apply _ _]
+  rw [map_neg_eq_inv, inv_apply_eq_conj]
 
 end AddCommGroup
 end AddChar

--- a/Mathlib/Analysis/RCLike/Lemmas.lean
+++ b/Mathlib/Analysis/RCLike/Lemmas.lean
@@ -1,19 +1,15 @@
 /-
 Copyright (c) 2020 Frédéric Dupuis. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Frédéric Dupuis, Yaël Dillies
+Authors: Frédéric Dupuis
 -/
 import Mathlib.Analysis.Normed.Module.FiniteDimension
 import Mathlib.Analysis.RCLike.Basic
 
 /-! # Further lemmas about `RCLike` -/
 
-open Function
-open scoped ComplexConjugate
 
-variable {G K E : Type*}
-
-variable [RCLike K]
+variable {K E : Type*} [RCLike K]
 
 namespace Polynomial
 

--- a/Mathlib/Analysis/RCLike/Lemmas.lean
+++ b/Mathlib/Analysis/RCLike/Lemmas.lean
@@ -3,7 +3,6 @@ Copyright (c) 2020 Frédéric Dupuis. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Frédéric Dupuis, Yaël Dillies
 -/
-import Mathlib.Algebra.Group.AddChar
 import Mathlib.Analysis.Normed.Module.FiniteDimension
 import Mathlib.Analysis.RCLike.Basic
 
@@ -13,36 +12,6 @@ open Function
 open scoped ComplexConjugate
 
 variable {G K E : Type*}
-
-namespace AddChar
-section AddGroup
-variable [AddGroup G]
-
-section NormedDivisionRing
-variable [Finite G] [NormedDivisionRing K]
-
-@[simp] lemma norm_apply (ψ : AddChar G K) (x : G) : ‖ψ x‖ = 1 :=
-  (ψ.toMonoidHom.isOfFinOrder <| isOfFinOrder_of_finite _).norm_eq_one
-
-end NormedDivisionRing
-
-section RCLike
-variable [RCLike K]
-
-lemma inv_apply_eq_conj [Finite G] (ψ : AddChar G K) (x : G) : (ψ x)⁻¹ = conj (ψ x) :=
-  RCLike.inv_eq_conj <| norm_apply _ _
-
-end RCLike
-end AddGroup
-
-section AddCommGroup
-variable [AddCommGroup G] [RCLike K] {ψ₁ ψ₂ : AddChar G K}
-
-lemma map_neg_eq_conj [Finite G] (ψ : AddChar G K) (x : G) : ψ (-x) = conj (ψ x) := by
-  rw [map_neg_eq_inv, inv_apply_eq_conj]
-
-end AddCommGroup
-end AddChar
 
 variable [RCLike K]
 


### PR DESCRIPTION
From LeanAPAP


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
