### PR TITLE
[Merged by Bors] - feat: Add LinearOrderedCommMonoidWithZero and lemmas for unitInterval

### DIFF
--- a/Mathlib/Topology/UnitInterval.lean
+++ b/Mathlib/Topology/UnitInterval.lean
@@ -142,7 +142,7 @@ theorem half_le_symm_iff (t : I) : 1 / 2 ≤ (σ t : ℝ) ↔ (t : ℝ) ≤ 1 / 
   rw [coe_symm_eq, le_sub_iff_add_le, add_comm, ← le_sub_iff_add_le, sub_half]
 
 @[simp]
-lemma eq_zero_iff_symm_eq_one {i : I} : σ i = 1 ↔ i = 0 := by
+lemma symm_eq_one_iff_eq_zero {i : I} : σ i = 1 ↔ i = 0 := by
   apply Iff.intro
   · intro h
     rw [← unitInterval.symm_zero] at h
@@ -151,7 +151,7 @@ lemma eq_zero_iff_symm_eq_one {i : I} : σ i = 1 ↔ i = 0 := by
     rw [h, symm_zero]
 
 @[simp]
-lemma eq_one_iff_symm_eq_zero {i : I} : σ i = 0 ↔ i = 1 := by
+lemma symm_eq_zero_iff_eq_one {i : I} : σ i = 0 ↔ i = 1 := by
   apply Iff.intro
   · intro h
     rw [← unitInterval.symm_one] at h
@@ -159,39 +159,39 @@ lemma eq_one_iff_symm_eq_zero {i : I} : σ i = 0 ↔ i = 1 := by
   · intro h
     rw [h, symm_one]
 
-theorem le_symm_if_le_symm {i j : I} (h : i ≤ σ j) : j ≤ σ i := by
+theorem le_symm_of_le_symm {i j : I} (h : i ≤ σ j) : j ≤ σ i := by
   rw [Subtype.mk_le_mk, coe_symm_eq] at h ⊢
   apply le_sub_left_of_add_le
   rw [add_comm]
   exact add_le_of_le_sub_left h
 
 theorem le_symm_iff_le_symm {i j : I} : i ≤ σ j ↔ j ≤ σ i :=
-  ⟨le_symm_if_le_symm, le_symm_if_le_symm⟩
+  ⟨le_symm_of_le_symm, le_symm_of_le_symm⟩
 
-theorem symm_le_if_symm_le {i j : I} (h : σ i ≤ j) : σ j ≤ i := by
+theorem symm_le_of_symm_le {i j : I} (h : σ i ≤ j) : σ j ≤ i := by
   rw [Subtype.mk_le_mk, coe_symm_eq] at h ⊢
   rw [sub_le_iff_le_add, add_comm, ← sub_le_iff_le_add]
   exact h
 
 theorem symm_le_iff_symm_le {i j : I} : σ i ≤ j ↔ σ j ≤ i :=
-  ⟨symm_le_if_symm_le, symm_le_if_symm_le⟩
+  ⟨symm_le_of_symm_le, symm_le_of_symm_le⟩
 
-theorem lt_symm_if_lt_symm {i j : I} (h : i < σ j) : j < σ i := by
+theorem lt_symm_of_lt_symm {i j : I} (h : i < σ j) : j < σ i := by
   rw [Subtype.mk_lt_mk, coe_symm_eq] at h ⊢
   apply lt_sub_left_of_add_lt
   rw [add_comm]
   exact add_lt_of_lt_sub_left h
 
 theorem lt_symm_iff_lt_symm {i j : I} : i < σ j ↔ j < σ i :=
-  ⟨lt_symm_if_lt_symm, lt_symm_if_lt_symm⟩
+  ⟨lt_symm_of_lt_symm, lt_symm_of_lt_symm⟩
 
-theorem symm_lt_if_symm_lt {i j : I} (h : σ i < j) : σ j < i := by
+theorem symm_lt_of_symm_lt {i j : I} (h : σ i < j) : σ j < i := by
   rw [Subtype.mk_lt_mk, coe_symm_eq] at h ⊢
   rw [sub_lt_iff_lt_add, add_comm, ← sub_lt_iff_lt_add]
   exact h
 
 theorem symm_lt_iff_symm_lt {i j : I} : σ i < j ↔ σ j < i :=
-  ⟨symm_lt_if_symm_lt, symm_lt_if_symm_lt⟩
+  ⟨symm_lt_of_symm_lt, symm_lt_of_symm_lt⟩
 
 instance : ConnectedSpace I :=
   Subtype.connectedSpace ⟨nonempty_Icc.mpr zero_le_one, isPreconnected_Icc⟩

--- a/Mathlib/Topology/UnitInterval.lean
+++ b/Mathlib/Topology/UnitInterval.lean
@@ -67,11 +67,19 @@ instance : BoundedOrder I := Set.Icc.boundedOrder zero_le_one
 
 lemma univ_eq_Icc : (univ : Set I) = Icc (0 : I) (1 : I) := Icc_bot_top.symm
 
+@[norm_cast]
 theorem coe_ne_zero {x : I} : (x : ℝ) ≠ 0 ↔ x ≠ 0 :=
   not_iff_not.mpr coe_eq_zero
 
+@[norm_cast]
 theorem coe_ne_one {x : I} : (x : ℝ) ≠ 1 ↔ x ≠ 1 :=
   not_iff_not.mpr coe_eq_one
+
+@[norm_cast]
+lemma coe_pos {x : I} : (0 : ℝ) < x ↔ 0 < x := Iff.rfl
+
+@[norm_cast]
+lemma coe_lt_one {x : I} : (x : ℝ) < 1 ↔ x < 1 := Iff.rfl
 
 instance : Nonempty I :=
   ⟨0⟩
@@ -133,6 +141,62 @@ theorem strictAnti_symm : StrictAnti σ := fun _ _ h ↦ sub_lt_sub_left (α := 
 theorem half_le_symm_iff (t : I) : 1 / 2 ≤ (σ t : ℝ) ↔ (t : ℝ) ≤ 1 / 2 := by
   rw [coe_symm_eq, le_sub_iff_add_le, add_comm, ← le_sub_iff_add_le, sub_half]
 
+@[simp]
+lemma eq_zero_iff_sym_eq_one (i : I) : σ i = 1 ↔ i = 0 := by
+  apply Iff.intro
+  · intro h
+    rw [← unitInterval.symm_zero] at h
+    exact symm_bijective.injective h
+  · intro h
+    rw [h, symm_zero]
+
+@[simp]
+lemma eq_one_iff_sym_eq_zero (i : I) : σ i = 0 ↔ i = 1 := by
+  apply Iff.intro
+  · intro h
+    rw [← unitInterval.symm_one] at h
+    exact symm_bijective.injective h
+  · intro h
+    rw [h, symm_one]
+
+theorem le_symm_if_le_symm (i j : I) : i ≤ σ j → j ≤ σ i := by
+  intro h
+  rw [Subtype.mk_le_mk, coe_symm_eq] at h ⊢
+  apply le_sub_left_of_add_le
+  rw [add_comm]
+  exact add_le_of_le_sub_left h
+
+theorem le_symm_iff_le_symm (i j : I) : i ≤ σ j ↔ j ≤ σ i :=
+  ⟨le_symm_if_le_symm i j, le_symm_if_le_symm j i⟩
+
+theorem symm_le_if_symm_le (i j : I) : σ i ≤ j → σ j ≤ i := by
+  intro h
+  rw [Subtype.mk_le_mk, coe_symm_eq] at h ⊢
+  rw [sub_le_iff_le_add, add_comm, ← sub_le_iff_le_add]
+  exact h
+
+theorem symm_le_iff_symm_le (i j : I) : σ i ≤ j ↔ σ j ≤ i :=
+  ⟨symm_le_if_symm_le i j, symm_le_if_symm_le j i⟩
+
+theorem lt_symm_if_lt_symm (i j : I) : i < σ j → j < σ i := by
+  intro h
+  rw [Subtype.mk_lt_mk, coe_symm_eq] at h ⊢
+  apply lt_sub_left_of_add_lt
+  rw [add_comm]
+  exact add_lt_of_lt_sub_left h
+
+theorem lt_symm_iff_lt_symm (i j : I) : i < σ j ↔ j < σ i :=
+  ⟨lt_symm_if_lt_symm i j, lt_symm_if_lt_symm j i⟩
+
+theorem symm_lt_if_symm_lt (i j : I) : σ i < j → σ j < i := by
+  intro h
+  rw [Subtype.mk_lt_mk, coe_symm_eq] at h ⊢
+  rw [sub_lt_iff_lt_add, add_comm, ← sub_lt_iff_lt_add]
+  exact h
+
+theorem symm_lt_iff_symm_lt (i j : I) : σ i < j ↔ σ j < i :=
+  ⟨symm_lt_if_symm_lt i j, symm_lt_if_symm_lt j i⟩
+
 instance : ConnectedSpace I :=
   Subtype.connectedSpace ⟨nonempty_Icc.mpr zero_le_one, isPreconnected_Icc⟩
 
@@ -160,6 +224,19 @@ theorem nonneg' {t : I} : 0 ≤ t :=
 theorem le_one' {t : I} : t ≤ 1 :=
   t.2.2
 
+@[simp]
+lemma ne_zero_iff_pos {x : I} : x ≠ 0 ↔ 0 < x := by
+  rw [← coe_ne_zero, ← coe_pos, lt_iff_le_and_ne, and_iff_right (nonneg x), ne_comm]
+
+@[simp]
+lemma ne_one_iff_lt {x : I} : x ≠ 1 ↔ x < 1 := by
+  rw [← coe_lt_one, ← coe_ne_one, lt_iff_le_and_ne, and_iff_right (le_one x)]
+
+lemma eq_one_of_le_mul {i j : I} (h_i : i ≠ 0) (h : i ≤ j * i) : j = 1 := by
+  contrapose! h
+  simp only [ne_eq, ne_one_iff_lt, ← coe_lt_one, ne_zero_iff_pos, ← coe_pos] at h h_i
+  exact Subtype.coe_lt_coe.mp <| by simpa using mul_lt_mul_of_pos_right h h_i
+
 instance : Nontrivial I := ⟨⟨1, 0, (one_ne_zero <| congrArg Subtype.val ·)⟩⟩
 
 theorem mul_pos_mem_iff {a t : ℝ} (ha : 0 < a) : a * t ∈ I ↔ t ∈ Set.Icc (0 : ℝ) (1 / a) := by
@@ -171,6 +248,25 @@ theorem mul_pos_mem_iff {a t : ℝ} (ha : 0 < a) : a * t ∈ I ↔ t ∈ Set.Icc
 
 theorem two_mul_sub_one_mem_iff {t : ℝ} : 2 * t - 1 ∈ I ↔ t ∈ Set.Icc (1 / 2 : ℝ) 1 := by
   constructor <;> rintro ⟨h₁, h₂⟩ <;> constructor <;> linarith
+
+instance : LinearOrderedCommMonoidWithZero I where
+  zero_mul i := zero_mul i
+  mul_zero i := mul_zero i
+  zero_le_one := nonneg'
+  mul_le_mul_left i j h_ij k := by
+    simp only [← Subtype.coe_le_coe, coe_mul]
+    apply mul_le_mul (by rfl) ?_ (nonneg i) (nonneg k)
+    simp [h_ij]
+  le_total := LinearOrder.le_total
+  decidableLE := LinearOrder.decidableLE
+  min_def := LinearOrder.min_def
+  max_def := LinearOrder.max_def
+  compare_eq_compareOfLessAndEq i j := by
+    simp [compare, compareOfLessAndEq]
+    split_ifs
+    all_goals try rfl
+    case pos h_ne h_eq => exact h_ne <| Subtype.coe_inj.mpr h_eq
+    case neg h_eq h_ne => exact h_ne <| Subtype.coe_inj.mp h_eq
 
 end unitInterval
 

--- a/Mathlib/Topology/UnitInterval.lean
+++ b/Mathlib/Topology/UnitInterval.lean
@@ -226,10 +226,11 @@ lemma pos_iff_ne_zero {x : I} : 0 < x ↔ x ≠ 0 := by
 lemma lt_one_iff_ne {x : I} : x < 1 ↔ x ≠ 1 := by
   rw [← coe_lt_one, ← coe_ne_one, lt_iff_le_and_ne, and_iff_right (le_one x)]
 
-lemma eq_one_of_le_mul {i j : I} (h_i : i ≠ 0) (h : i ≤ j * i) : j = 1 := by
+lemma one_or_zero_of_le_mul {i j : I} (h : i ≤ j * i) : i = 0 ∨ j = 1 := by
   contrapose! h
-  simp only [ne_eq, ← lt_one_iff_ne, ← coe_lt_one, ← pos_iff_ne_zero, ← coe_pos] at h h_i
-  exact Subtype.coe_lt_coe.mp <| by simpa using mul_lt_mul_of_pos_right h h_i
+  simp only [ne_eq, ← lt_one_iff_ne, ← coe_lt_one, ← pos_iff_ne_zero, ← coe_pos] at h
+  simp only [← Subtype.coe_lt_coe, coe_mul]
+  simpa using mul_lt_mul_of_pos_right h.right h.left
 
 instance : Nontrivial I := ⟨⟨1, 0, (one_ne_zero <| congrArg Subtype.val ·)⟩⟩
 

--- a/Mathlib/Topology/UnitInterval.lean
+++ b/Mathlib/Topology/UnitInterval.lean
@@ -142,7 +142,7 @@ theorem half_le_symm_iff (t : I) : 1 / 2 ≤ (σ t : ℝ) ↔ (t : ℝ) ≤ 1 / 
   rw [coe_symm_eq, le_sub_iff_add_le, add_comm, ← le_sub_iff_add_le, sub_half]
 
 @[simp]
-lemma eq_zero_iff_sym_eq_one (i : I) : σ i = 1 ↔ i = 0 := by
+lemma eq_zero_iff_symm_eq_one {i : I} : σ i = 1 ↔ i = 0 := by
   apply Iff.intro
   · intro h
     rw [← unitInterval.symm_zero] at h
@@ -151,7 +151,7 @@ lemma eq_zero_iff_sym_eq_one (i : I) : σ i = 1 ↔ i = 0 := by
     rw [h, symm_zero]
 
 @[simp]
-lemma eq_one_iff_sym_eq_zero (i : I) : σ i = 0 ↔ i = 1 := by
+lemma eq_one_iff_symm_eq_zero {i : I} : σ i = 0 ↔ i = 1 := by
   apply Iff.intro
   · intro h
     rw [← unitInterval.symm_one] at h
@@ -159,43 +159,39 @@ lemma eq_one_iff_sym_eq_zero (i : I) : σ i = 0 ↔ i = 1 := by
   · intro h
     rw [h, symm_one]
 
-theorem le_symm_if_le_symm (i j : I) : i ≤ σ j → j ≤ σ i := by
-  intro h
+theorem le_symm_if_le_symm {i j : I} (h : i ≤ σ j) : j ≤ σ i := by
   rw [Subtype.mk_le_mk, coe_symm_eq] at h ⊢
   apply le_sub_left_of_add_le
   rw [add_comm]
   exact add_le_of_le_sub_left h
 
-theorem le_symm_iff_le_symm (i j : I) : i ≤ σ j ↔ j ≤ σ i :=
-  ⟨le_symm_if_le_symm i j, le_symm_if_le_symm j i⟩
+theorem le_symm_iff_le_symm {i j : I} : i ≤ σ j ↔ j ≤ σ i :=
+  ⟨le_symm_if_le_symm, le_symm_if_le_symm⟩
 
-theorem symm_le_if_symm_le (i j : I) : σ i ≤ j → σ j ≤ i := by
-  intro h
+theorem symm_le_if_symm_le {i j : I} (h : σ i ≤ j) : σ j ≤ i := by
   rw [Subtype.mk_le_mk, coe_symm_eq] at h ⊢
   rw [sub_le_iff_le_add, add_comm, ← sub_le_iff_le_add]
   exact h
 
-theorem symm_le_iff_symm_le (i j : I) : σ i ≤ j ↔ σ j ≤ i :=
-  ⟨symm_le_if_symm_le i j, symm_le_if_symm_le j i⟩
+theorem symm_le_iff_symm_le {i j : I} : σ i ≤ j ↔ σ j ≤ i :=
+  ⟨symm_le_if_symm_le, symm_le_if_symm_le⟩
 
-theorem lt_symm_if_lt_symm (i j : I) : i < σ j → j < σ i := by
-  intro h
+theorem lt_symm_if_lt_symm {i j : I} (h : i < σ j) : j < σ i := by
   rw [Subtype.mk_lt_mk, coe_symm_eq] at h ⊢
   apply lt_sub_left_of_add_lt
   rw [add_comm]
   exact add_lt_of_lt_sub_left h
 
-theorem lt_symm_iff_lt_symm (i j : I) : i < σ j ↔ j < σ i :=
-  ⟨lt_symm_if_lt_symm i j, lt_symm_if_lt_symm j i⟩
+theorem lt_symm_iff_lt_symm {i j : I} : i < σ j ↔ j < σ i :=
+  ⟨lt_symm_if_lt_symm, lt_symm_if_lt_symm⟩
 
-theorem symm_lt_if_symm_lt (i j : I) : σ i < j → σ j < i := by
-  intro h
+theorem symm_lt_if_symm_lt {i j : I} (h : σ i < j) : σ j < i := by
   rw [Subtype.mk_lt_mk, coe_symm_eq] at h ⊢
   rw [sub_lt_iff_lt_add, add_comm, ← sub_lt_iff_lt_add]
   exact h
 
-theorem symm_lt_iff_symm_lt (i j : I) : σ i < j ↔ σ j < i :=
-  ⟨symm_lt_if_symm_lt i j, symm_lt_if_symm_lt j i⟩
+theorem symm_lt_iff_symm_lt {i j : I} : σ i < j ↔ σ j < i :=
+  ⟨symm_lt_if_symm_lt, symm_lt_if_symm_lt⟩
 
 instance : ConnectedSpace I :=
   Subtype.connectedSpace ⟨nonempty_Icc.mpr zero_le_one, isPreconnected_Icc⟩
@@ -224,17 +220,15 @@ theorem nonneg' {t : I} : 0 ≤ t :=
 theorem le_one' {t : I} : t ≤ 1 :=
   t.2.2
 
-@[simp]
-lemma ne_zero_iff_pos {x : I} : x ≠ 0 ↔ 0 < x := by
+lemma pos_iff_ne_zero {x : I} : 0 < x ↔ x ≠ 0 := by
   rw [← coe_ne_zero, ← coe_pos, lt_iff_le_and_ne, and_iff_right (nonneg x), ne_comm]
 
-@[simp]
-lemma ne_one_iff_lt {x : I} : x ≠ 1 ↔ x < 1 := by
+lemma lt_one_iff_ne {x : I} : x < 1 ↔ x ≠ 1 := by
   rw [← coe_lt_one, ← coe_ne_one, lt_iff_le_and_ne, and_iff_right (le_one x)]
 
 lemma eq_one_of_le_mul {i j : I} (h_i : i ≠ 0) (h : i ≤ j * i) : j = 1 := by
   contrapose! h
-  simp only [ne_eq, ne_one_iff_lt, ← coe_lt_one, ne_zero_iff_pos, ← coe_pos] at h h_i
+  simp only [ne_eq, ← lt_one_iff_ne, ← coe_lt_one, ← pos_iff_ne_zero, ← coe_pos] at h h_i
   exact Subtype.coe_lt_coe.mp <| by simpa using mul_lt_mul_of_pos_right h h_i
 
 instance : Nontrivial I := ⟨⟨1, 0, (one_ne_zero <| congrArg Subtype.val ·)⟩⟩
@@ -255,14 +249,14 @@ instance : LinearOrderedCommMonoidWithZero I where
   zero_le_one := nonneg'
   mul_le_mul_left i j h_ij k := by
     simp only [← Subtype.coe_le_coe, coe_mul]
-    apply mul_le_mul (by rfl) ?_ (nonneg i) (nonneg k)
+    apply mul_le_mul le_rfl ?_ (nonneg i) (nonneg k)
     simp [h_ij]
   le_total := LinearOrder.le_total
   decidableLE := LinearOrder.decidableLE
   min_def := LinearOrder.min_def
   max_def := LinearOrder.max_def
   compare_eq_compareOfLessAndEq i j := by
-    simp [compare, compareOfLessAndEq]
+    simp only [compare, compareOfLessAndEq, Subtype.coe_lt_coe]
     split_ifs
     all_goals try rfl
     case pos h_ne h_eq => exact h_ne <| Subtype.coe_inj.mpr h_eq

--- a/Mathlib/Topology/UnitInterval.lean
+++ b/Mathlib/Topology/UnitInterval.lean
@@ -226,7 +226,7 @@ lemma pos_iff_ne_zero {x : I} : 0 < x ↔ x ≠ 0 := by
 lemma lt_one_iff_ne {x : I} : x < 1 ↔ x ≠ 1 := by
   rw [← coe_lt_one, ← coe_ne_one, lt_iff_le_and_ne, and_iff_right (le_one x)]
 
-lemma one_or_zero_of_le_mul {i j : I} (h : i ≤ j * i) : i = 0 ∨ j = 1 := by
+lemma eq_one_or_eq_zero_of_le_mul {i j : I} (h : i ≤ j * i) : i = 0 ∨ j = 1 := by
   contrapose! h
   simp only [ne_eq, ← lt_one_iff_ne, ← coe_lt_one, ← pos_iff_ne_zero, ← coe_pos] at h
   simp only [← Subtype.coe_lt_coe, coe_mul]

--- a/Mathlib/Topology/UnitInterval.lean
+++ b/Mathlib/Topology/UnitInterval.lean
@@ -67,8 +67,8 @@ instance : BoundedOrder I := Set.Icc.boundedOrder zero_le_one
 
 lemma univ_eq_Icc : (univ : Set I) = Icc (0 : I) (1 : I) := Icc_bot_top.symm
 
-@[norm_cast] theorem coe_ne_zero {x : I} : (x : ℝ) ≠ 0 ↔ x ≠ 0 := not_iff_not.mpr coe_eq_zero
-@[norm_cast] theorem coe_ne_one {x : I} : (x : ℝ) ≠ 1 ↔ x ≠ 1 := not_iff_not.mpr coe_eq_one
+@[norm_cast] theorem coe_ne_zero {x : I} : (x : ℝ) ≠ 0 ↔ x ≠ 0 := coe_eq_zero.not
+@[norm_cast] theorem coe_ne_one {x : I} : (x : ℝ) ≠ 1 ↔ x ≠ 1 := coe_eq_one.not
 @[simp, norm_cast] theorem coe_pos {x : I} : (0 : ℝ) < x ↔ 0 < x := Iff.rfl
 @[simp, norm_cast] theorem coe_lt_one {x : I} : (x : ℝ) < 1 ↔ x < 1 := Iff.rfl
 
@@ -143,24 +143,24 @@ lemma symm_eq_zero {i : I} : σ i = 0 ↔ i = 1 := by
   rw [← symm_one, symm_inj]
 
 @[simp]
-theorem symm_le_symm_iff {i j : I} : σ i ≤ σ j ↔ j ≤ i := by
+theorem symm_le_symm {i j : I} : σ i ≤ σ j ↔ j ≤ i := by
   simp only [symm, Subtype.mk_le_mk, sub_le_sub_iff, add_le_add_iff_left, Subtype.coe_le_coe]
 
 theorem le_symm_comm {i j : I} : i ≤ σ j ↔ j ≤ σ i := by
-  rw [← symm_le_symm_iff, symm_symm]
+  rw [← symm_le_symm, symm_symm]
 
 theorem symm_le_comm {i j : I} : σ i ≤ j ↔ σ j ≤ i := by
-  rw [← symm_le_symm_iff, symm_symm]
+  rw [← symm_le_symm, symm_symm]
 
 @[simp]
-theorem symm_lt_symm_iff {i j : I} : σ i < σ j ↔ j < i := by
+theorem symm_lt_symm {i j : I} : σ i < σ j ↔ j < i := by
   simp only [symm, Subtype.mk_lt_mk, sub_lt_sub_iff_left, Subtype.coe_lt_coe]
 
 theorem lt_symm_comm {i j : I} : i < σ j ↔ j < σ i := by
-  rw [← symm_lt_symm_iff, symm_symm]
+  rw [← symm_lt_symm, symm_symm]
 
 theorem symm_lt_comm {i j : I} : σ i < j ↔ σ j < i := by
-  rw [← symm_lt_symm_iff, symm_symm]
+  rw [← symm_lt_symm, symm_symm]
 
 instance : ConnectedSpace I :=
   Subtype.connectedSpace ⟨nonempty_Icc.mpr zero_le_one, isPreconnected_Icc⟩
@@ -192,8 +192,7 @@ theorem le_one' {t : I} : t ≤ 1 :=
 lemma pos_iff_ne_zero {x : I} : 0 < x ↔ x ≠ 0 := by
   rw [← coe_ne_zero, ← coe_pos, lt_iff_le_and_ne, and_iff_right (nonneg x), ne_comm]
 
-lemma lt_one_iff_ne {x : I} : x < 1 ↔ x ≠ 1 := by
-  rw [← coe_lt_one, ← coe_ne_one, lt_iff_le_and_ne, and_iff_right (le_one x)]
+lemma lt_one_iff_ne {x : I} : x < 1 ↔ x ≠ 1 := lt_top_iff_ne_top
 
 lemma eq_one_or_eq_zero_of_le_mul {i j : I} (h : i ≤ j * i) : i = 0 ∨ j = 1 := by
   contrapose! h

--- a/Mathlib/Topology/UnitInterval.lean
+++ b/Mathlib/Topology/UnitInterval.lean
@@ -189,8 +189,7 @@ theorem nonneg' {t : I} : 0 ≤ t :=
 theorem le_one' {t : I} : t ≤ 1 :=
   t.2.2
 
-lemma pos_iff_ne_zero {x : I} : 0 < x ↔ x ≠ 0 := by
-  rw [← coe_ne_zero, ← coe_pos, lt_iff_le_and_ne, and_iff_right (nonneg x), ne_comm]
+lemma pos_iff_ne_zero {x : I} : 0 < x ↔ x ≠ 0 := bot_lt_iff_ne_bot
 
 lemma lt_one_iff_ne {x : I} : x < 1 ↔ x ≠ 1 := lt_top_iff_ne_top
 

--- a/Mathlib/Topology/UnitInterval.lean
+++ b/Mathlib/Topology/UnitInterval.lean
@@ -135,11 +135,11 @@ theorem half_le_symm_iff (t : I) : 1 / 2 ≤ (σ t : ℝ) ↔ (t : ℝ) ≤ 1 / 
   rw [coe_symm_eq, le_sub_iff_add_le, add_comm, ← le_sub_iff_add_le, sub_half]
 
 @[simp]
-lemma symm_eq_one_iff {i : I} : σ i = 1 ↔ i = 0 := by
+lemma symm_eq_one {i : I} : σ i = 1 ↔ i = 0 := by
   rw [← symm_zero, symm_inj]
 
 @[simp]
-lemma symm_eq_zero_iff {i : I} : σ i = 0 ↔ i = 1 := by
+lemma symm_eq_zero {i : I} : σ i = 0 ↔ i = 1 := by
   rw [← symm_one, symm_inj]
 
 @[simp]

--- a/Mathlib/Topology/UnitInterval.lean
+++ b/Mathlib/Topology/UnitInterval.lean
@@ -67,8 +67,8 @@ instance : BoundedOrder I := Set.Icc.boundedOrder zero_le_one
 
 lemma univ_eq_Icc : (univ : Set I) = Icc (0 : I) (1 : I) := Icc_bot_top.symm
 
-@[simp, norm_cast] theorem coe_ne_zero {x : I} : (x : ℝ) ≠ 0 ↔ x ≠ 0 := not_iff_not.mpr coe_eq_zero
-@[simp, norm_cast] theorem coe_ne_one {x : I} : (x : ℝ) ≠ 1 ↔ x ≠ 1 := not_iff_not.mpr coe_eq_one
+@[norm_cast] theorem coe_ne_zero {x : I} : (x : ℝ) ≠ 0 ↔ x ≠ 0 := not_iff_not.mpr coe_eq_zero
+@[norm_cast] theorem coe_ne_one {x : I} : (x : ℝ) ≠ 1 ↔ x ≠ 1 := not_iff_not.mpr coe_eq_one
 @[simp, norm_cast] theorem coe_pos {x : I} : (0 : ℝ) < x ↔ 0 < x := Iff.rfl
 @[simp, norm_cast] theorem coe_lt_one {x : I} : (x : ℝ) < 1 ↔ x < 1 := Iff.rfl
 

--- a/Mathlib/Topology/UnitInterval.lean
+++ b/Mathlib/Topology/UnitInterval.lean
@@ -67,17 +67,10 @@ instance : BoundedOrder I := Set.Icc.boundedOrder zero_le_one
 
 lemma univ_eq_Icc : (univ : Set I) = Icc (0 : I) (1 : I) := Icc_bot_top.symm
 
-@[simp, norm_cast]
-theorem coe_ne_zero {x : I} : (x : ℝ) ≠ 0 ↔ x ≠ 0 :=
-  not_iff_not.mpr coe_eq_zero
-
-@[simp, norm_cast]
-theorem coe_ne_one {x : I} : (x : ℝ) ≠ 1 ↔ x ≠ 1 :=
-  not_iff_not.mpr coe_eq_one
-
-@[simp, norm_cast] lemma coe_pos {x : I} : (0 : ℝ) < x ↔ 0 < x := Iff.rfl
-
-@[simp, norm_cast] lemma coe_lt_one {x : I} : (x : ℝ) < 1 ↔ x < 1 := Iff.rfl
+@[simp, norm_cast] theorem coe_ne_zero {x : I} : (x : ℝ) ≠ 0 ↔ x ≠ 0 := not_iff_not.mpr coe_eq_zero
+@[simp, norm_cast] theorem coe_ne_one {x : I} : (x : ℝ) ≠ 1 ↔ x ≠ 1 := not_iff_not.mpr coe_eq_one
+@[simp, norm_cast] theorem coe_pos {x : I} : (0 : ℝ) < x ↔ 0 < x := Iff.rfl
+@[simp, norm_cast] theorem coe_lt_one {x : I} : (x : ℝ) < 1 ↔ x < 1 := Iff.rfl
 
 instance : Nonempty I :=
   ⟨0⟩

--- a/Mathlib/Topology/UnitInterval.lean
+++ b/Mathlib/Topology/UnitInterval.lean
@@ -189,14 +189,14 @@ theorem nonneg' {t : I} : 0 ≤ t :=
 theorem le_one' {t : I} : t ≤ 1 :=
   t.2.2
 
-lemma pos_iff_ne_zero {x : I} : 0 < x ↔ x ≠ 0 := bot_lt_iff_ne_bot
+protected lemma pos_iff_ne_zero {x : I} : 0 < x ↔ x ≠ 0 := bot_lt_iff_ne_bot
 
-lemma lt_one_iff_ne {x : I} : x < 1 ↔ x ≠ 1 := lt_top_iff_ne_top
+protected lemma lt_one_iff_ne {x : I} : x < 1 ↔ x ≠ 1 := lt_top_iff_ne_top
 
 lemma eq_one_or_eq_zero_of_le_mul {i j : I} (h : i ≤ j * i) : i = 0 ∨ j = 1 := by
   contrapose! h
-  simp only [ne_eq, ← lt_one_iff_ne, ← coe_lt_one, ← pos_iff_ne_zero, ← coe_pos] at h
-  simp only [← Subtype.coe_lt_coe, coe_mul]
+  rw [← unitInterval.lt_one_iff_ne, ← coe_lt_one, ← unitInterval.pos_iff_ne_zero, ← coe_pos] at h
+  rw [← Subtype.coe_lt_coe, coe_mul]
   simpa using mul_lt_mul_of_pos_right h.right h.left
 
 instance : Nontrivial I := ⟨⟨1, 0, (one_ne_zero <| congrArg Subtype.val ·)⟩⟩

--- a/Mathlib/Topology/UnitInterval.lean
+++ b/Mathlib/Topology/UnitInterval.lean
@@ -67,19 +67,17 @@ instance : BoundedOrder I := Set.Icc.boundedOrder zero_le_one
 
 lemma univ_eq_Icc : (univ : Set I) = Icc (0 : I) (1 : I) := Icc_bot_top.symm
 
-@[norm_cast]
+@[simp, norm_cast]
 theorem coe_ne_zero {x : I} : (x : ℝ) ≠ 0 ↔ x ≠ 0 :=
   not_iff_not.mpr coe_eq_zero
 
-@[norm_cast]
+@[simp, norm_cast]
 theorem coe_ne_one {x : I} : (x : ℝ) ≠ 1 ↔ x ≠ 1 :=
   not_iff_not.mpr coe_eq_one
 
-@[norm_cast]
-lemma coe_pos {x : I} : (0 : ℝ) < x ↔ 0 < x := Iff.rfl
+@[simp, norm_cast] lemma coe_pos {x : I} : (0 : ℝ) < x ↔ 0 < x := Iff.rfl
 
-@[norm_cast]
-lemma coe_lt_one {x : I} : (x : ℝ) < 1 ↔ x < 1 := Iff.rfl
+@[simp, norm_cast] lemma coe_lt_one {x : I} : (x : ℝ) < 1 ↔ x < 1 := Iff.rfl
 
 instance : Nonempty I :=
   ⟨0⟩
@@ -138,60 +136,37 @@ theorem strictAnti_symm : StrictAnti σ := fun _ _ h ↦ sub_lt_sub_left (α := 
 @[deprecated (since := "2024-02-27")] alias involutive_symm := symm_involutive
 @[deprecated (since := "2024-02-27")] alias bijective_symm := symm_bijective
 
+@[simp]
+theorem symm_inj {i j : I} : σ i = σ j ↔ i = j := symm_bijective.injective.eq_iff
+
 theorem half_le_symm_iff (t : I) : 1 / 2 ≤ (σ t : ℝ) ↔ (t : ℝ) ≤ 1 / 2 := by
   rw [coe_symm_eq, le_sub_iff_add_le, add_comm, ← le_sub_iff_add_le, sub_half]
 
 @[simp]
-lemma symm_eq_one_iff_eq_zero {i : I} : σ i = 1 ↔ i = 0 := by
-  apply Iff.intro
-  · intro h
-    rw [← unitInterval.symm_zero] at h
-    exact symm_bijective.injective h
-  · intro h
-    rw [h, symm_zero]
+lemma symm_eq_one {i : I} : σ i = 1 ↔ i = 0 := by
+  rw [← symm_zero, symm_inj]
 
 @[simp]
-lemma symm_eq_zero_iff_eq_one {i : I} : σ i = 0 ↔ i = 1 := by
-  apply Iff.intro
-  · intro h
-    rw [← unitInterval.symm_one] at h
-    exact symm_bijective.injective h
-  · intro h
-    rw [h, symm_one]
+lemma symm_eq_zero {i : I} : σ i = 0 ↔ i = 1 := by
+  rw [← symm_one, symm_inj]
 
-theorem le_symm_of_le_symm {i j : I} (h : i ≤ σ j) : j ≤ σ i := by
-  rw [Subtype.mk_le_mk, coe_symm_eq] at h ⊢
-  apply le_sub_left_of_add_le
-  rw [add_comm]
-  exact add_le_of_le_sub_left h
+theorem symm_le_symm_iff {i j : I} : σ i ≤ σ j ↔ j ≤ i := by
+  simp only [symm, Subtype.mk_le_mk, sub_le_sub_iff, add_le_add_iff_left, Subtype.coe_le_coe]
 
-theorem le_symm_iff_le_symm {i j : I} : i ≤ σ j ↔ j ≤ σ i :=
-  ⟨le_symm_of_le_symm, le_symm_of_le_symm⟩
+theorem le_symm_comm {i j : I} : i ≤ σ j ↔ j ≤ σ i := by
+  rw [← symm_le_symm_iff, symm_symm]
 
-theorem symm_le_of_symm_le {i j : I} (h : σ i ≤ j) : σ j ≤ i := by
-  rw [Subtype.mk_le_mk, coe_symm_eq] at h ⊢
-  rw [sub_le_iff_le_add, add_comm, ← sub_le_iff_le_add]
-  exact h
+theorem symm_le_comm {i j : I} : σ i ≤ j ↔ σ j ≤ i := by
+  rw [← symm_le_symm_iff, symm_symm]
 
-theorem symm_le_iff_symm_le {i j : I} : σ i ≤ j ↔ σ j ≤ i :=
-  ⟨symm_le_of_symm_le, symm_le_of_symm_le⟩
+theorem symm_lt_symm_iff {i j : I} : σ i < σ j ↔ j < i := by
+  simp only [symm, Subtype.mk_lt_mk, sub_lt_sub_iff_left, Subtype.coe_lt_coe]
 
-theorem lt_symm_of_lt_symm {i j : I} (h : i < σ j) : j < σ i := by
-  rw [Subtype.mk_lt_mk, coe_symm_eq] at h ⊢
-  apply lt_sub_left_of_add_lt
-  rw [add_comm]
-  exact add_lt_of_lt_sub_left h
+theorem lt_symm_comm {i j : I} : i < σ j ↔ j < σ i := by
+  rw [← symm_lt_symm_iff, symm_symm]
 
-theorem lt_symm_iff_lt_symm {i j : I} : i < σ j ↔ j < σ i :=
-  ⟨lt_symm_of_lt_symm, lt_symm_of_lt_symm⟩
-
-theorem symm_lt_of_symm_lt {i j : I} (h : σ i < j) : σ j < i := by
-  rw [Subtype.mk_lt_mk, coe_symm_eq] at h ⊢
-  rw [sub_lt_iff_lt_add, add_comm, ← sub_lt_iff_lt_add]
-  exact h
-
-theorem symm_lt_iff_symm_lt {i j : I} : σ i < j ↔ σ j < i :=
-  ⟨symm_lt_of_symm_lt, symm_lt_of_symm_lt⟩
+theorem symm_lt_comm {i j : I} : σ i < j ↔ σ j < i := by
+  rw [← symm_lt_symm_iff, symm_symm]
 
 instance : ConnectedSpace I :=
   Subtype.connectedSpace ⟨nonempty_Icc.mpr zero_le_one, isPreconnected_Icc⟩

--- a/Mathlib/Topology/UnitInterval.lean
+++ b/Mathlib/Topology/UnitInterval.lean
@@ -85,7 +85,6 @@ instance : Nonempty I :=
 instance : Mul I :=
   ⟨fun x y => ⟨x * y, mul_mem x.2 y.2⟩⟩
 
--- todo: we could set up a `LinearOrderedCommMonoidWithZero I` instance
 theorem mul_le_left {x y : I} : x * y ≤ x :=
   Subtype.coe_le_coe.mp <| mul_le_of_le_one_right x.2.1 y.2.2
 
@@ -150,6 +149,7 @@ lemma symm_eq_one {i : I} : σ i = 1 ↔ i = 0 := by
 lemma symm_eq_zero {i : I} : σ i = 0 ↔ i = 1 := by
   rw [← symm_one, symm_inj]
 
+@[simp]
 theorem symm_le_symm_iff {i j : I} : σ i ≤ σ j ↔ j ≤ i := by
   simp only [symm, Subtype.mk_le_mk, sub_le_sub_iff, add_le_add_iff_left, Subtype.coe_le_coe]
 
@@ -159,6 +159,7 @@ theorem le_symm_comm {i j : I} : i ≤ σ j ↔ j ≤ σ i := by
 theorem symm_le_comm {i j : I} : σ i ≤ j ↔ σ j ≤ i := by
   rw [← symm_le_symm_iff, symm_symm]
 
+@[simp]
 theorem symm_lt_symm_iff {i j : I} : σ i < σ j ↔ j < i := by
   simp only [symm, Subtype.mk_lt_mk, sub_lt_sub_iff_left, Subtype.coe_lt_coe]
 

--- a/Mathlib/Topology/UnitInterval.lean
+++ b/Mathlib/Topology/UnitInterval.lean
@@ -191,11 +191,12 @@ theorem le_one' {t : I} : t ≤ 1 :=
 
 protected lemma pos_iff_ne_zero {x : I} : 0 < x ↔ x ≠ 0 := bot_lt_iff_ne_bot
 
-protected lemma lt_one_iff_ne {x : I} : x < 1 ↔ x ≠ 1 := lt_top_iff_ne_top
+protected lemma lt_one_iff_ne_one {x : I} : x < 1 ↔ x ≠ 1 := lt_top_iff_ne_top
 
 lemma eq_one_or_eq_zero_of_le_mul {i j : I} (h : i ≤ j * i) : i = 0 ∨ j = 1 := by
   contrapose! h
-  rw [← unitInterval.lt_one_iff_ne, ← coe_lt_one, ← unitInterval.pos_iff_ne_zero, ← coe_pos] at h
+  rw [← unitInterval.lt_one_iff_ne_one, ← coe_lt_one, ← unitInterval.pos_iff_ne_zero,
+    ← coe_pos] at h
   rw [← Subtype.coe_lt_coe, coe_mul]
   simpa using mul_lt_mul_of_pos_right h.right h.left
 

--- a/Mathlib/Topology/UnitInterval.lean
+++ b/Mathlib/Topology/UnitInterval.lean
@@ -135,11 +135,11 @@ theorem half_le_symm_iff (t : I) : 1 / 2 ≤ (σ t : ℝ) ↔ (t : ℝ) ≤ 1 / 
   rw [coe_symm_eq, le_sub_iff_add_le, add_comm, ← le_sub_iff_add_le, sub_half]
 
 @[simp]
-lemma symm_eq_one {i : I} : σ i = 1 ↔ i = 0 := by
+lemma symm_eq_one_iff {i : I} : σ i = 1 ↔ i = 0 := by
   rw [← symm_zero, symm_inj]
 
 @[simp]
-lemma symm_eq_zero {i : I} : σ i = 0 ↔ i = 1 := by
+lemma symm_eq_zero_iff {i : I} : σ i = 0 ↔ i = 1 := by
   rw [← symm_one, symm_inj]
 
 @[simp]

--- a/Mathlib/Topology/UnitInterval.lean
+++ b/Mathlib/Topology/UnitInterval.lean
@@ -220,16 +220,7 @@ instance : LinearOrderedCommMonoidWithZero I where
     simp only [← Subtype.coe_le_coe, coe_mul]
     apply mul_le_mul le_rfl ?_ (nonneg i) (nonneg k)
     simp [h_ij]
-  le_total := LinearOrder.le_total
-  decidableLE := LinearOrder.decidableLE
-  min_def := LinearOrder.min_def
-  max_def := LinearOrder.max_def
-  compare_eq_compareOfLessAndEq i j := by
-    simp only [compare, compareOfLessAndEq, Subtype.coe_lt_coe]
-    split_ifs
-    all_goals try rfl
-    case pos h_ne h_eq => exact h_ne <| Subtype.coe_inj.mpr h_eq
-    case neg h_eq h_ne => exact h_ne <| Subtype.coe_inj.mp h_eq
+  __ := inferInstanceAs (LinearOrder I)
 
 end unitInterval
 


### PR DESCRIPTION
Co-authored-by: Jireh Loreaux <loreaujy@gmail.com>

---
This PR adds various lemmas about the `unitInterval` that might be of interest. 

It would be nice to also have lemmas similar to [Mathlib/Algebra/Order/GroupWithZero/Unbundled](https://leanprover-community.github.io/mathlib4_docs/Mathlib/Algebra/Order/GroupWithZero/Unbundled.html), but instantiation `unitInterval` as `PosMulMono` and similar feels weird as unitInterval has no nonnegative values. Maybe there is a clever way to generalize these lemmas? Or we can provide a similar API for `OrderedCommMonoid`? Unfortunately, that would not help with strictness and reflection lemmas. All of these feel not fitting for this PR, however.

This [zulip thread](https://leanprover.zulipchat.com/#narrow/stream/217875-Is-there-code-for-X.3F/topic/eq.20one.20of.20le.20mul.20in.20the.20unit) is related.

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
