### PR TITLE
[Merged by Bors] - chore(Geometry/Manifold): split variable statements

### DIFF
--- a/Mathlib/Analysis/NormedSpace/OperatorNorm/Prod.lean
+++ b/Mathlib/Analysis/NormedSpace/OperatorNorm/Prod.lean
@@ -71,8 +71,8 @@ end OpNorm
 
 section Prod
 
-variable (M₁ M₂ M₃ M₄ : Type*) (𝕜)
-variable
+variable (𝕜)
+variable (M₁ M₂ M₃ M₄ : Type*)
   [SeminormedAddCommGroup M₁] [NormedSpace 𝕜 M₁]
   [SeminormedAddCommGroup M₂] [NormedSpace 𝕜 M₂]
   [SeminormedAddCommGroup M₃] [NormedSpace 𝕜 M₃]

--- a/Mathlib/Geometry/Manifold/BumpFunction.lean
+++ b/Mathlib/Geometry/Manifold/BumpFunction.lean
@@ -31,7 +31,7 @@ manifold, smooth bump function
 universe uE uF uH uM
 
 variable {E : Type uE} [NormedAddCommGroup E] [NormedSpace ℝ E] [FiniteDimensional ℝ E]
-  {H : Type uH} [TopologicalSpace H] (I : ModelWithCorners ℝ E H) {M : Type uM} [TopologicalSpace M]
+  {H : Type uH} [TopologicalSpace H] {I : ModelWithCorners ℝ E H} {M : Type uM} [TopologicalSpace M]
   [ChartedSpace H M] [SmoothManifoldWithCorners I M]
 
 open Function Filter FiniteDimensional Set Metric
@@ -46,6 +46,7 @@ noncomputable section
 In this section we define a structure for a bundled smooth bump function and prove its properties.
 -/
 
+variable (I) in
 /-- Given a smooth manifold modelled on a finite dimensional space `E`,
 `f : SmoothBumpFunction I M` is a smooth function on `M` such that in the extended chart `e` at
 `f.c`:
@@ -63,7 +64,7 @@ structure SmoothBumpFunction (c : M) extends ContDiffBump (extChartAt I c c) whe
 
 namespace SmoothBumpFunction
 
-variable {c : M} (f : SmoothBumpFunction I c) {x : M} {I}
+variable {c : M} (f : SmoothBumpFunction I c) {x : M}
 
 /-- The function defined by `f : SmoothBumpFunction c`. Use automatic coercion to function
 instead. -/
@@ -243,8 +244,9 @@ protected theorem hasCompactSupport : HasCompactSupport f :=
   f.isCompact_symm_image_closedBall.of_isClosed_subset isClosed_closure
     f.tsupport_subset_symm_image_closedBall
 
-variable (I c)
+variable (I)
 
+variable (c) in
 /-- The closures of supports of smooth bump functions centered at `c` form a basis of `𝓝 c`.
 In other words, each of these closures is a neighborhood of `c` and each neighborhood of `c`
 includes `tsupport f` for some `f : SmoothBumpFunction I c`. -/
@@ -257,8 +259,6 @@ theorem nhds_basis_tsupport :
     exact nhdsWithin_range_basis.map _
   exact this.to_hasBasis' (fun f _ => ⟨f, trivial, f.tsupport_subset_symm_image_closedBall⟩)
     fun f _ => f.tsupport_mem_nhds
-
-variable {c}
 
 /-- Given `s ∈ 𝓝 c`, the supports of smooth bump functions `f : SmoothBumpFunction I c` such that
 `tsupport f ⊆ s` form a basis of `𝓝 c`.  In other words, each of these supports is a

--- a/Mathlib/Geometry/Manifold/ChartedSpace.lean
+++ b/Mathlib/Geometry/Manifold/ChartedSpace.lean
@@ -968,15 +968,14 @@ theorem StructureGroupoid.trans_restricted {e e' : PartialHomeomorph M H} {G : S
 
 section MaximalAtlas
 
-variable (M) (G : StructureGroupoid H)
+variable (G : StructureGroupoid H)
 
+variable (M) in
 /-- Given a charted space admitting a structure groupoid, the maximal atlas associated to this
 structure groupoid is the set of all charts that are compatible with the atlas, i.e., such
 that changing coordinates with an atlas member gives an element of the groupoid. -/
 def StructureGroupoid.maximalAtlas : Set (PartialHomeomorph M H) :=
   { e | ∀ e' ∈ atlas H M, e.symm ≫ₕ e' ∈ G ∧ e'.symm ≫ₕ e ∈ G }
-
-variable {M}
 
 /-- The elements of the atlas belong to the maximal atlas for any structure groupoid. -/
 theorem StructureGroupoid.subset_maximalAtlas [HasGroupoid M G] : atlas H M ⊆ G.maximalAtlas M :=

--- a/Mathlib/Geometry/Manifold/ContMDiff/Basic.lean
+++ b/Mathlib/Geometry/Manifold/ContMDiff/Basic.lean
@@ -354,7 +354,7 @@ end Inclusion
 section
 
 variable (I)
-  [Nonempty M] {e : M → H} (h : OpenEmbedding e)
+variable [Nonempty M] {e : M → H} (h : OpenEmbedding e)
   [Nonempty M'] {e' : M' → H'} (h' : OpenEmbedding e')
   {n : WithTop ℕ}
 

--- a/Mathlib/Geometry/Manifold/PartitionOfUnity.lean
+++ b/Mathlib/Geometry/Manifold/PartitionOfUnity.lean
@@ -278,7 +278,8 @@ type if for each `i` the closure of the support of `f i` is a subset of `U i`. -
 def IsSubordinate (f : SmoothPartitionOfUnity ι I M s) (U : ι → Set M) :=
   ∀ i, tsupport (f i) ⊆ U i
 
-variable {f} {U : ι → Set M}
+variable {f}
+variable {U : ι → Set M}
 
 @[simp]
 theorem isSubordinate_toPartitionOfUnity :

--- a/Mathlib/Geometry/Manifold/VectorBundle/Basic.lean
+++ b/Mathlib/Geometry/Manifold/VectorBundle/Basic.lean
@@ -403,8 +403,9 @@ protected theorem Smooth.coordChange (hf : Smooth IM IB f)
     Smooth IM 𝓘(𝕜, F) (fun y ↦ e.coordChange e' (f y) (g y)) := fun x ↦
   (hf x).coordChange (hg x) (he x) (he' x)
 
-variable (IB e e')
+variable (e e')
 
+variable (IB) in
 theorem Trivialization.contMDiffOn_symm_trans :
     ContMDiffOn (IB.prod 𝓘(𝕜, F)) (IB.prod 𝓘(𝕜, F)) n
       (e.toPartialHomeomorph.symm ≫ₕ e'.toPartialHomeomorph) (e.target ∩ e'.target) := by
@@ -420,7 +421,7 @@ theorem Trivialization.contMDiffOn_symm_trans :
     simp_all only [Trivialization.mem_target, mfld_simps]
   exact (e'.coe_fst' this).trans (e.proj_symm_apply hb.1)
 
-variable {IB e e'}
+variable {e e'}
 
 theorem ContMDiffWithinAt.change_section_trivialization {f : M → TotalSpace F E}
     (hp : ContMDiffWithinAt IM IB n (π F E ∘ f) s x)
@@ -551,8 +552,8 @@ end
 
 namespace VectorBundleCore
 
-variable {ι : Type*} {F}
-variable (Z : VectorBundleCore 𝕜 B F ι)
+variable {F}
+variable {ι : Type*} (Z : VectorBundleCore 𝕜 B F ι)
 
 /-- Mixin for a `VectorBundleCore` stating smoothness (of transition functions). -/
 class IsSmooth (IB : ModelWithCorners 𝕜 EB HB) : Prop where

--- a/Mathlib/Geometry/Manifold/VectorBundle/Tangent.lean
+++ b/Mathlib/Geometry/Manifold/VectorBundle/Tangent.lean
@@ -196,7 +196,8 @@ does not pick wrong instances. In this section, we record the right instances fo
 them, noting in particular that the tangent bundle is a smooth manifold. -/
 section
 
-variable {M} (x : M)
+variable {M}
+variable (x : M)
 
 instance : Module 𝕜 (TangentSpace I x) := inferInstanceAs (Module 𝕜 E)
 
@@ -408,7 +409,8 @@ theorem tangentBundleModelSpaceHomeomorph_coe_symm :
 
 section inTangentCoordinates
 
-variable (I') {M H} {N : Type*}
+variable (I') {M H}
+variable {N : Type*}
 
 /-- The map `in_coordinates` for the tangent bundle is trivial on the model spaces -/
 theorem inCoordinates_tangent_bundle_core_model_space (x₀ x : H) (y₀ y : H') (ϕ : E →L[𝕜] E') :

--- a/Mathlib/Topology/FiberBundle/Basic.lean
+++ b/Mathlib/Topology/FiberBundle/Basic.lean
@@ -171,7 +171,8 @@ open TopologicalSpace Filter Set Bundle Topology
 
 section FiberBundle
 
-variable (F) [TopologicalSpace B] [TopologicalSpace F] (E : B → Type*)
+variable (F)
+variable [TopologicalSpace B] [TopologicalSpace F] (E : B → Type*)
   [TopologicalSpace (TotalSpace F E)] [∀ b, TopologicalSpace (E b)]
 
 /-- A (topological) fiber bundle with fiber `F` over a base `B` is a space projecting on `B`
@@ -207,7 +208,8 @@ end FiberBundle
 export FiberBundle (totalSpaceMk_inducing trivializationAtlas trivializationAt
   mem_baseSet_trivializationAt trivialization_mem_atlas)
 
-variable {F E}
+variable {F}
+variable {E}
 
 /-- Given a type `E` equipped with a fiber bundle structure, this is a `Prop` typeclass
 for trivializations of `E`, expressing that a trivialization is in the designated atlas for the
@@ -297,7 +299,8 @@ theorem continuousAt_totalSpace (f : X → TotalSpace F E) {x₀ : X} :
 
 end FiberBundle
 
-variable (F E)
+variable (F)
+variable (E)
 
 /-- If `E` is a fiber bundle over a conditionally complete linear order,
 then it is trivial over any closed interval. -/
@@ -700,7 +703,8 @@ end FiberBundleCore
 
 /-! ### Prebundle construction for constructing fiber bundles -/
 
-variable (F) (E : B → Type*) [TopologicalSpace B] [TopologicalSpace F]
+variable (F)
+variable (E : B → Type*) [TopologicalSpace B] [TopologicalSpace F]
   [∀ x, TopologicalSpace (E x)]
 
 /-- This structure permits to define a fiber bundle when trivializations are given as local

--- a/Mathlib/Topology/FiberBundle/Trivialization.lean
+++ b/Mathlib/Topology/FiberBundle/Trivialization.lean
@@ -51,8 +51,8 @@ open TopologicalSpace Filter Set Bundle Function
 
 open scoped Topology Classical Bundle
 
-variable {ι : Type*} {B : Type*} {F : Type*} {E : B → Type*}
-variable (F) {Z : Type*} [TopologicalSpace B] [TopologicalSpace F] {proj : Z → B}
+variable {ι : Type*} {B : Type*} (F : Type*) {E : B → Type*}
+variable {Z : Type*} [TopologicalSpace B] [TopologicalSpace F] {proj : Z → B}
 
 /-- This structure contains the information left for a local trivialization (which is implemented
 below as `Trivialization F proj`) if the total space has not been given a topology, but we


### PR DESCRIPTION
Make sure to perform binder annotation updates and declaring new variables in separate variable commands.
This is currently recommended because of leanprover/lean4#2789: mixing these can yield confusing errors.

Found by a linter in #15400.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
