### PR TITLE
[Merged by Bors] - chore(Probability/Kernel): `initialize_simps_projections`

### DIFF
--- a/Mathlib/Probability/Kernel/Basic.lean
+++ b/Mathlib/Probability/Kernel/Basic.lean
@@ -73,8 +73,6 @@ scoped notation "Kernel[" mα "]" α:arg β:arg => @Kernel α β mα _
 /-- Notation for `Kernel` with respect to a non-standard σ-algebra in the domain and codomain. -/
 scoped notation "Kernel[" mα ", " mβ "]" α:arg β:arg => @Kernel α β mα mβ
 
-initialize_simps_projections Kernel (toFun → apply)
-
 variable {α β ι : Type*} {mα : MeasurableSpace α} {mβ : MeasurableSpace β}
 
 namespace Kernel
@@ -84,6 +82,9 @@ instance instFunLike : FunLike (Kernel α β) α (Measure β) where
   coe_injective' f g h := by cases f; cases g; congr
 
 lemma measurable (κ : Kernel α β) : Measurable κ := κ.measurable'
+@[simp, norm_cast] lemma coe_mk (f : α → Measure β) (hf) : mk f hf = f := rfl
+
+initialize_simps_projections Kernel (toFun → apply)
 
 instance instZero : Zero (Kernel α β) where zero := ⟨0, measurable_zero⟩
 noncomputable instance instAdd : Add (Kernel α β) where add κ η := ⟨κ + η, κ.2.add η.2⟩


### PR DESCRIPTION
Move `initialize_simps_projections` few lines down so that `simps` uses `FunLike.coe` instead of `CoeFn.coeFn`. Add `Kernel.coe_mk`.

Co-authored-by: Yaël Dillies <yael.dillies@gmail.com>

---

fixes placement of `initialize_simps_projections` in previous PR #15316

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
