### PR TITLE
feat(Computability.Timed): Split lemmas for Merge Sort's complexity

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -1957,6 +1957,7 @@ import Mathlib.Computability.PartrecCode
 import Mathlib.Computability.Primrec
 import Mathlib.Computability.Reduce
 import Mathlib.Computability.RegularExpressions
+import Mathlib.Computability.Timed.InsertionSort
 import Mathlib.Computability.TMComputable
 import Mathlib.Computability.TMToPartrec
 import Mathlib.Computability.TuringMachine

--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -1958,6 +1958,7 @@ import Mathlib.Computability.Primrec
 import Mathlib.Computability.Reduce
 import Mathlib.Computability.RegularExpressions
 import Mathlib.Computability.Timed.InsertionSort
+import Mathlib.Computability.Timed.Split
 import Mathlib.Computability.TMComputable
 import Mathlib.Computability.TMToPartrec
 import Mathlib.Computability.TuringMachine

--- a/Mathlib/Computability/Timed/InsertionSort.lean
+++ b/Mathlib/Computability/Timed/InsertionSort.lean
@@ -1,0 +1,103 @@
+/-
+Copyright (c) 2024 Tomaz Mascarenhas. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Tomaz Mascarenhas
+-/
+import Mathlib.Data.List.Sort
+import Mathlib.Tactic.Linarith
+/-!
+# Timed Insertion Sort
+  This file defines a new version of Insertion Sort that, besides sorting the input list, counts the
+  number of comparisons made through the execution of the algorithm. Also, it presents proofs of
+  its time complexity and its equivalence to the one defined in Data/List/Sort.lean
+ ## Main Definition
+  - Timed.insertion_sort : list α → (list α × ℕ)
+## Main Results
+  - Timed.insertion_sort_complexity :
+      ∀ l : list α, (Timed.insertionSort r l).snd ≤ l.length * l.length
+  - Timed.insertion_sort_equivalence :
+      ∀ l : list α, (Timed.insertionSort r l).fst = List.insertionSort r l
+-/
+
+namespace Timed
+
+universe u
+
+variable {α : Type u} (r : α → α → Prop) [DecidableRel r]
+local infixl:50 " ≼ " => r
+
+@[simp] def orderedInsert (a : α) : List α → (List α × Nat)
+  | []      => ([a], 0)
+  | b :: l => if a ≼ b then (a :: b :: l, 1)
+              else let (l', n) := orderedInsert a l
+                   (b :: l', n + 1)
+
+@[simp] def insertionSort : List α → (List α × Nat)
+  | [] => ([], 0)
+  | (h :: t) => let (l', n)  := insertionSort t
+                let (l'', m) := orderedInsert r h l'
+                (l'', n + m)
+
+theorem orderedInsert_complexity (a : α) :
+    ∀ l : List α, (orderedInsert r a l).snd ≤ l.length
+  | []     => by simp
+  | b :: l' => by
+    simp
+    split_ifs with h
+    · simp
+    · simp [orderedInsert_complexity a l']
+
+theorem orderedInsert_equivalence (a : α) : ∀ l : List α,
+    (orderedInsert r a l).fst = List.orderedInsert r a l
+  | [] => by simp
+  | b :: l' => by
+    simp
+    split_ifs with h
+    · rfl
+    · simp [orderedInsert_equivalence a l']
+
+theorem orderedInsert_increases_length (a : α) : ∀ l : List α,
+    (orderedInsert r a l).fst.length = l.length + 1
+  | [] => by simp
+  | b :: l' => by
+    simp
+    split_ifs with h
+    · rfl
+    · simp [orderedInsert_increases_length a l']
+
+theorem insertionSort_preserves_length : ∀ l : List α,
+    (insertionSort r l).fst.length = l.length := fun l =>
+  match l with
+  | [] => by simp
+  | a :: l' => by
+    simp
+    rw [orderedInsert_increases_length r a (insertionSort r l').fst]
+    simp [insertionSort_preserves_length l']
+
+theorem insertionSort_complexity :
+    ∀ l : List α, (insertionSort r l).snd ≤ l.length * l.length
+  | [] => by simp
+  | a :: l' => by
+    have same_lengths := insertionSort_preserves_length r l'
+    have mid :
+      (insertionSort r l').snd + (orderedInsert r a (insertionSort r l').fst).snd ≤
+      l'.length * l'.length + (orderedInsert r a (insertionSort r l').fst).snd :=
+        add_le_add (insertionSort_complexity l') le_rfl
+    have mid₂ :
+      l'.length * l'.length + (orderedInsert r a (insertionSort r l').fst).snd ≤
+      l'.length * l'.length + l'.length := by
+        apply add_le_add le_rfl
+        have orderedInsert_compl :=
+          orderedInsert_complexity r a (insertionSort r l').fst
+        rw [same_lengths] at orderedInsert_compl
+        exact orderedInsert_compl
+    simp
+    linarith
+
+theorem insertionSort_equivalence : ∀ l : List α,
+    (insertionSort r l).fst = List.insertionSort r l
+  | [] => by simp
+  | _ :: l' => by
+    simp [orderedInsert_equivalence, insertionSort_equivalence l']
+
+end Timed

--- a/Mathlib/Computability/Timed/InsertionSort.lean
+++ b/Mathlib/Computability/Timed/InsertionSort.lean
@@ -42,7 +42,7 @@ theorem orderedInsert_complexity (a : α) :
     ∀ l : List α, (orderedInsert r a l).snd ≤ l.length
   | []     => by simp
   | b :: l' => by
-    simp
+    simp only [orderedInsert, List.length_cons]
     split_ifs with h
     · simp
     · simp [orderedInsert_complexity a l']
@@ -51,7 +51,7 @@ theorem orderedInsert_equivalence (a : α) : ∀ l : List α,
     (orderedInsert r a l).fst = List.orderedInsert r a l
   | [] => by simp
   | b :: l' => by
-    simp
+    simp only [orderedInsert, List.orderedInsert]
     split_ifs with h
     · rfl
     · simp [orderedInsert_equivalence a l']
@@ -60,7 +60,7 @@ theorem orderedInsert_increases_length (a : α) : ∀ l : List α,
     (orderedInsert r a l).fst.length = l.length + 1
   | [] => by simp
   | b :: l' => by
-    simp
+    simp only [orderedInsert, List.length_cons]
     split_ifs with h
     · rfl
     · simp [orderedInsert_increases_length a l']
@@ -70,7 +70,7 @@ theorem insertionSort_preserves_length : ∀ l : List α,
   match l with
   | [] => by simp
   | a :: l' => by
-    simp
+    simp only [insertionSort, List.length_cons]
     rw [orderedInsert_increases_length r a (insertionSort r l').fst]
     simp [insertionSort_preserves_length l']
 
@@ -79,11 +79,11 @@ theorem insertionSort_complexity :
   | [] => by simp
   | a :: l' => by
     have same_lengths := insertionSort_preserves_length r l'
-    have mid :
+    have :
       (insertionSort r l').snd + (orderedInsert r a (insertionSort r l').fst).snd ≤
       l'.length * l'.length + (orderedInsert r a (insertionSort r l').fst).snd :=
         add_le_add (insertionSort_complexity l') le_rfl
-    have mid₂ :
+    have :
       l'.length * l'.length + (orderedInsert r a (insertionSort r l').fst).snd ≤
       l'.length * l'.length + l'.length := by
         apply add_le_add le_rfl
@@ -91,7 +91,7 @@ theorem insertionSort_complexity :
           orderedInsert_complexity r a (insertionSort r l').fst
         rw [same_lengths] at orderedInsert_compl
         exact orderedInsert_compl
-    simp
+    simp only [insertionSort, List.length_cons, ge_iff_le]
     linarith
 
 theorem insertionSort_equivalence : ∀ l : List α,

--- a/Mathlib/Computability/Timed/Split.lean
+++ b/Mathlib/Computability/Timed/Split.lean
@@ -1,0 +1,92 @@
+/-
+Copyright (c) 2024 Tomaz Mascarenhas. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Tomaz Mascarenhas
+-/
+import Mathlib.Data.List.Sort
+import Mathlib.Data.Nat.Log
+import Mathlib.Tactic.Linarith
+/-!
+# Timed Split
+  This file defines some new lemmas related to the `List.split` function that are necessary
+  for proving the complexity of `List.mergeSort`.
+## Main Results
+  - Timed.split_halves_length :
+      ∀ l l₁ l₂ : list α, Timed.split l = (l₁, l₂) →
+        l₁.length ≤ (l.length + 1) / 2 ∧ l₂.length ≤ l.length / 2
+  - Timed.split_lengths :
+      ∀ l l₁ l₂ : list α, Timed.split l = (l₁, l₂) →
+        l₁.length + l₂.length = l.length
+-/
+
+namespace Timed
+
+universe u
+
+variable {α : Type u}
+
+lemma div_two (b a : ℕ) : 2 * a ≤ b → a ≤ b / 2 :=
+  by simp_rw [Nat.le_div_iff_mul_le zero_lt_two, mul_comm, imp_self]
+
+lemma split_halves_length_aux : ∀ {l l₁ l₂ : List α},
+  List.split l = (l₁, l₂) →
+    2 * List.length l₁ ≤ List.length l + 1 ∧ 2 * List.length l₂ ≤ List.length l
+  | []       => by
+    intros h
+    unfold List.split at h
+    simp at h
+    have ⟨h₁, h₂⟩ := h
+    rw [← h₁, ← h₂]
+    simp
+  | (a :: t) => by
+    intros h'
+    cases e: List.split t with
+    | mk t₁ t₂ =>
+      have split_id : List.split (a :: t) = (a :: t₂, t₁) := by
+        unfold List.split
+        rw [e]
+      rw [split_id] at h'
+      injection h' with h₁ h₂
+      have ⟨ih₁, ih₂⟩ := split_halves_length_aux e
+      apply And.intro
+      · rw [← h₁]
+        simp
+        linarith
+      · rw [← h₂]
+        simp [ih₁]
+
+theorem split_halves_length : ∀ {l l₁ l₂ : List α},
+  List.split l = (l₁, l₂) →
+    List.length l₁ ≤ (List.length l + 1) / 2 ∧
+    List.length l₂ ≤ (List.length l) / 2 := by
+  intros l l₁ l₂ h
+  have ⟨pf₁, pf₂⟩ := split_halves_length_aux h
+  exact ⟨div_two (l.length + 1) l₁.length pf₁, div_two l.length l₂.length pf₂⟩
+
+theorem split_lengths : ∀ (l l₁ l₂ : List α),
+    List.split l = (l₁, l₂) → l₁.length + l₂.length = l.length
+  | []  => by
+    intros l₁ l₂
+    simp
+    intros h₁ h₂
+    rw [← h₁, ← h₂]
+    simp
+  | [_] => by
+    intros l₁ l₂
+    simp
+    intros h₁ h₂
+    rw [← h₁, ← h₂]
+    simp
+  | (_ :: _ :: t) => by
+    intros l₁ l₂ h
+    cases e : List.split t with
+    | mk l₁' l₂' =>
+      simp at h
+      rw [e] at h
+      have ih := split_lengths t l₁' l₂' e
+      have ⟨h₁, h₂⟩ := h
+      rw [← h₁, ← h₂]
+      simp
+      linarith
+
+end Timed

--- a/Mathlib/Computability/Timed/Split.lean
+++ b/Mathlib/Computability/Timed/Split.lean
@@ -34,7 +34,7 @@ lemma split_halves_length_aux : ∀ {l l₁ l₂ : List α},
   | []       => by
     intros h
     unfold List.split at h
-    simp at h
+    simp only [Prod.mk.injEq] at h
     have ⟨h₁, h₂⟩ := h
     rw [← h₁, ← h₂]
     simp
@@ -50,7 +50,7 @@ lemma split_halves_length_aux : ∀ {l l₁ l₂ : List α},
       have ⟨ih₁, ih₂⟩ := split_halves_length_aux e
       apply And.intro
       · rw [← h₁]
-        simp
+        simp only [List.length_cons]
         linarith
       · rw [← h₂]
         simp [ih₁]
@@ -67,13 +67,14 @@ theorem split_lengths : ∀ (l l₁ l₂ : List α),
     List.split l = (l₁, l₂) → l₁.length + l₂.length = l.length
   | []  => by
     intros l₁ l₂
-    simp
+    simp only
+      [List.split, Prod.mk.injEq, List.length_nil, add_eq_zero, List.length_eq_zero, and_imp]
     intros h₁ h₂
     rw [← h₁, ← h₂]
     simp
   | [_] => by
     intros l₁ l₂
-    simp
+    simp only [List.split, Prod.mk.injEq, List.length_singleton, and_imp]
     intros h₁ h₂
     rw [← h₁, ← h₂]
     simp
@@ -81,12 +82,12 @@ theorem split_lengths : ∀ (l l₁ l₂ : List α),
     intros l₁ l₂ h
     cases e : List.split t with
     | mk l₁' l₂' =>
-      simp at h
+      simp only [List.split, Prod.mk.injEq] at h
       rw [e] at h
       have ih := split_lengths t l₁' l₂' e
       have ⟨h₁, h₂⟩ := h
       rw [← h₁, ← h₂]
-      simp
+      simp only [List.length_cons]
       linarith
 
 end Timed


### PR DESCRIPTION
This PR adds some lemmas about `List.split` defined in `Data/List/Sort` that are necessary for formalizing the runtime complexity of merge and merge sort.

References:
- Previous PR on mathlib3: https://github.com/leanprover-community/mathlib3/pull/14494/
- First discussion on Zulip: https://leanprover.zulipchat.com/#narrow/stream/113488-general/topic/BSc.20Final.20Project/near/220647062
- Second disussion on Zulip: https://leanprover.zulipchat.com/#narrow/stream/113488-general/topic/Formalization.20of.20Runtime.20Complexity.20of.20Sorting.20Algorithms/near/284184450
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

- [ ] depends on: #18627 

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
