### PR TITLE
feat: linter for bare `open (scoped) Classical`

### DIFF
--- a/Mathlib/AlgebraicTopology/TopologicalSimplex.lean
+++ b/Mathlib/AlgebraicTopology/TopologicalSimplex.lean
@@ -73,6 +73,7 @@ def toTop : SimplexCategory ⥤ TopCat where
     ext f
     apply toTopObj.ext
     funext i
+    classical
     change (Finset.univ.filter (· = i)).sum _ = _
     simp [Finset.sum_filter, CategoryTheory.id_apply]
   map_comp := fun f g => by
@@ -82,6 +83,7 @@ def toTop : SimplexCategory ⥤ TopCat where
     funext i
     dsimp
     simp only [comp_apply, TopCat.coe_of_of, ContinuousMap.coe_mk, coe_toTopMap]
+    classical
     rw [← Finset.sum_biUnion]
     · apply Finset.sum_congr
       · exact Finset.ext (fun j => ⟨fun hj => by simpa using hj, fun hj => by simpa using hj⟩)

--- a/Mathlib/Analysis/BoxIntegral/Basic.lean
+++ b/Mathlib/Analysis/BoxIntegral/Basic.lean
@@ -260,6 +260,7 @@ theorem Integrable.of_neg (hf : Integrable I l (-f) vol) : Integrable I l f vol 
 theorem integrable_neg : Integrable I l (-f) vol ↔ Integrable I l f vol :=
   ⟨fun h => h.of_neg, fun h => h.neg⟩
 
+open Classical in
 @[simp]
 theorem integral_neg : integral I l (-f) vol = -integral I l f vol := by
   classical

--- a/Mathlib/Tactic/Linter/Lint.lean
+++ b/Mathlib/Tactic/Linter/Lint.lean
@@ -290,12 +290,11 @@ def openClassicalLinter : Linter where run := withSetOptionIn fun stx ↦ do
     | `(command|open $openDecl) =>
       let inner := openDecl.raw.getArgs
       let names := s!"{inner.get! 0}"
-      -- remove [ and ]. TODO: also remove `... want a better parser!
-      let names := (names.stripPrefix "[").stripSuffix "]"
-      dbg_trace names
-      let names := names.split (· == ' ')
-    -- todo: turn into each part into a `Name, and return these
-      some ((openDecl.raw.getArgs).map (fun s ↦ s.getId))
+      -- remove [ and ], and a leading "`" of each name.
+      -- TODO: find a cleaner parser! was `inner.map (fun s ↦ s.getId)` doesn't quite work...
+      let names := ((names.stripPrefix "[").stripSuffix "]").split (· == ' ')
+      let names := (names.map (·.stripPrefix "`")).map String.toName
+      some names.toArray
     | _ => none
     if let some names := names then
       -- We need to handle `open foo (bar)` commands also: ignore all anonymous names.

--- a/Mathlib/Tactic/Linter/Lint.lean
+++ b/Mathlib/Tactic/Linter/Lint.lean
@@ -282,7 +282,7 @@ def openClassicalLinter : Linter where run := withSetOptionIn fun stx ↦ do
     -- TODO: once mathlib's Lean version includes leanprover/lean4#4741, make this configurable
     unless #[`Mathlib, `test, `Archive, `Counterexamples].contains (← getMainModule).getRoot do
       return
-    -- If this is an open command, extract the list of opened namespaces.
+    -- If `stx` describes an `open` command, extract the list of opened namespaces.
     let names : Option (Array Name) := match stx with
     | `(command|open $name hiding $_) => some #[name.getId]
     | `(command|open $name renaming $_) => some #[name.getId]
@@ -300,8 +300,11 @@ def openClassicalLinter : Linter where run := withSetOptionIn fun stx ↦ do
       -- We need to handle `open foo (bar)` commands also: ignore all anonymous names.
       let names := names.filter fun n ↦ !(n matches .anonymous)
       if names.contains `Classical then
-        -- TODO: add useful error message!
-        Linter.logLint linter.openClassical stx "foo"
+        Linter.logLint linter.openClassical stx "\
+        please avoid 'open (scoped) Classical' statements: this can hide theorem statements\n\
+        which would be better stated with explicit decidability statements.\n\
+        Instead, use `open Classical in` for definitions or instances, the `classical` tactic \
+        for proofs.\nFor theorem statements, either add missing decidability assumptions or use `open Classical in`."
 
 initialize addLinter openClassicalLinter
 

--- a/Mathlib/Tactic/Linter/Lint.lean
+++ b/Mathlib/Tactic/Linter/Lint.lean
@@ -274,30 +274,30 @@ namespace OpenClassical
 def getLinterHash (o : Options) : Bool := Linter.getLinterValue linter.openClassical o
 
 /-- If `stx` is syntax describing an `open` command, `extractOpenNames stx`
-returns syntax for the opened names as well as an array of all names opened
-(omitting renamed or hidden items). -/
-def extractOpenNames : Syntax → Option (Syntax × (Array Name))
+returns an array of for the opened names with their corresponding syntax
+(omitting any renamed or hidden items). -/
+def extractOpenNames : Syntax → Option (Array (Syntax × Name))
   | `(command|open $openHiding:openHiding) =>
     -- The first argument is the identifier we care about.
     let arg := openHiding.raw[0]
-    some (arg, #[arg.getId])
+    some #[(arg, arg.getId)]
   | `(command|open $openRenaming:openRenaming) =>
     -- The first argument is the identifier we care about.
     let arg := openRenaming.raw[0]
-    some (arg, #[arg.getId])
+    some #[(arg, arg.getId)]
   | `(command|open $openOnly:openOnly) =>
     -- The first argument is the identifier we care about.
-    some (openOnly.raw, #[openOnly.raw[0].getId])
+    some #[(openOnly.raw[0], openOnly.raw[0].getId)]
   | `(command|open $openDecl:openSimple) =>
     -- The first and only argument of `openDecl` is an array containing all the names we
     -- are interested in.
-    let namesSyntax := (openDecl.raw.getArgs).get! 0
-    some (namesSyntax, (namesSyntax.getArgs).map (·.getId))
+    let namesSyntax := ((openDecl.raw.getArgs).get! 0).getArgs
+    some (namesSyntax.map (fun arg ↦ (arg, arg.getId)))
   | `(command|open $openScoped:openScoped) =>
     -- The first argument of `openScoped` is "scoped",
     -- the second one is an array containing all the names we are interested in.
-    let namesSyntax := openScoped.raw[1]
-    some (namesSyntax, (namesSyntax.getArgs).map (·.getId))
+    let namesSyntax := (openScoped.raw[1]).getArgs
+    some (namesSyntax.map fun arg ↦ (arg, arg.getId))
   | _ => none
 
 @[inherit_doc Mathlib.Linter.linter.openClassical]
@@ -310,8 +310,8 @@ def openClassicalLinter : Linter where run := withSetOptionIn fun stx ↦ do
     unless #[`Mathlib, `test, `Archive, `Counterexamples].contains (← getMainModule).getRoot do
       return
     -- If `stx` describes an `open` command, extract the list of opened namespaces.
-    if let some (stxN, names) := extractOpenNames stx then
-      if names.contains `Classical then
+    if let some namesSyntaxes := extractOpenNames stx then
+      if let some (stxN, _name) := namesSyntaxes.find? (fun (_, name) ↦ name == `Classical) then
         Linter.logLint linter.openClassical stxN "\
         please avoid 'open (scoped) Classical' statements: this can hide theorem statements\n\
         which would be better stated with explicit decidability statements.\n\

--- a/Mathlib/Tactic/Linter/Lint.lean
+++ b/Mathlib/Tactic/Linter/Lint.lean
@@ -275,7 +275,7 @@ def getLinterHash (o : Options) : Bool := Linter.getLinterValue linter.openClass
 
 /-- If `stx` is syntax describing an `open` command, `extractOpenNames stx`
 returns syntax for the opened names as well as an array of all names opened
-(discarding renamed or hidden items). -/
+(omitting renamed or hidden items). -/
 def extractOpenNames : Syntax → Option (Syntax × (Array Name))
   | `(command|open $openHiding:openHiding) =>
     -- The first argument is the identifier we care about.
@@ -316,7 +316,8 @@ def openClassicalLinter : Linter where run := withSetOptionIn fun stx ↦ do
         please avoid 'open (scoped) Classical' statements: this can hide theorem statements\n\
         which would be better stated with explicit decidability statements.\n\
         Instead, use `open Classical in` for definitions or instances, the `classical` tactic \
-        for proofs.\nFor theorem statements, either add missing decidability assumptions or use `open Classical in`."
+        for proofs.\nFor theorem statements, \
+        either add missing decidability assumptions or use `open Classical in`."
 
 initialize addLinter openClassicalLinter
 

--- a/Mathlib/Tactic/Linter/Lint.lean
+++ b/Mathlib/Tactic/Linter/Lint.lean
@@ -274,8 +274,8 @@ namespace OpenClassical
 def getLinterHash (o : Options) : Bool := Linter.getLinterValue linter.openClassical o
 
 /-- If `stx` is syntax describing an `open` command, `extractOpenNames stx`
-returns an array of for the opened names with their corresponding syntax
-(omitting any renamed or hidden items). -/
+returns an array of the syntax corresponding to the opened names,
+omitting any renamed or hidden items. -/
 def extractOpenNames : Syntax → Array Syntax
   | `(command|open $arg hiding $_*)    => #[arg]
   | `(command|open $arg renaming $_,*) => #[arg]

--- a/Mathlib/Tactic/Linter/Lint.lean
+++ b/Mathlib/Tactic/Linter/Lint.lean
@@ -260,8 +260,8 @@ end LongLine
 /-! # The "openClassical" linter -/
 
 /-- The "openClassical" linter emits a warning on `open Classical` statements which are not
-scoped to a single declaration. This can hide that some theorem statements would be better stated
-with explicit decidability statements.
+scoped to a single declaration. A non-scoped `open Classical` can hide that some theorem statements
+would be better stated with explicit decidability statements.
 -/
 register_option linter.openClassical : Bool := {
   defValue := true
@@ -276,30 +276,29 @@ def getLinterHash (o : Options) : Bool := Linter.getLinterValue linter.openClass
 /-- If `stx` is syntax describing an `open` command, `extractOpenNames stx`
 returns syntax for the opened names as well as an array of all names opened
 (discarding renamed or hidden items). -/
-def extractOpenNames : Syntax → Option (Syntax × (Array Name)) := fun stx ↦ do
-  match stx with
-    | `(command|open $openHiding:openHiding) =>
-      -- The first argument is the identifier we care about.
-      let arg := (openHiding.raw.getArgs).get! 0
-      some (arg, #[arg.getId])
-    | `(command|open $openRenaming:openRenaming) =>
-      -- The first argument is the identifier we care about.
-      let arg := (openRenaming.raw.getArgs).get! 0
-      some (arg, #[arg.getId])
-    | `(command|open $openOnly:openOnly) =>
-      -- The first argument is the identifier we care about.
-      some (openOnly.raw, #[(openOnly.raw.getArgs.get! 0).getId])
-    | `(command|open $openDecl:openSimple) =>
-      -- The first and only argument of `openDecl` is an array containing all the names we
-      -- are interested in.
-      let namesSyntax := (openDecl.raw.getArgs).get! 0
-      some (namesSyntax, (namesSyntax.getArgs).map fun a ↦ a.getId)
-    | `(command|open $openScoped:openScoped) =>
-      -- The first argument of `openScoped` is "scoped",
-      -- the second one is an array containing all the names we are interested in.
-      let namesSyntax := (openScoped.raw.getArgs).get! 1
-      some (namesSyntax, (namesSyntax.getArgs).map fun a ↦ a.getId)
-    | _ => none
+def extractOpenNames : Syntax → Option (Syntax × (Array Name))
+  | `(command|open $openHiding:openHiding) =>
+    -- The first argument is the identifier we care about.
+    let arg := openHiding.raw[0]
+    some (arg, #[arg.getId])
+  | `(command|open $openRenaming:openRenaming) =>
+    -- The first argument is the identifier we care about.
+    let arg := openRenaming.raw[0]
+    some (arg, #[arg.getId])
+  | `(command|open $openOnly:openOnly) =>
+    -- The first argument is the identifier we care about.
+    some (openOnly.raw, #[openOnly.raw[0].getId])
+  | `(command|open $openDecl:openSimple) =>
+    -- The first and only argument of `openDecl` is an array containing all the names we
+    -- are interested in.
+    let namesSyntax := (openDecl.raw.getArgs).get! 0
+    some (namesSyntax, (namesSyntax.getArgs).map (·.getId))
+  | `(command|open $openScoped:openScoped) =>
+    -- The first argument of `openScoped` is "scoped",
+    -- the second one is an array containing all the names we are interested in.
+    let namesSyntax := openScoped.raw[1]
+    some (namesSyntax, (namesSyntax.getArgs).map (·.getId))
+  | _ => none
 
 @[inherit_doc Mathlib.Linter.linter.openClassical]
 def openClassicalLinter : Linter where run := withSetOptionIn fun stx ↦ do

--- a/test/Lint.lean
+++ b/test/Lint.lean
@@ -181,25 +181,6 @@ note: this linter can be disabled with `set_option linter.openClassical false`
 open Classical (choose)
 
 -- `open scoped Classical` is also linted
-/--
-warning: please avoid 'open (scoped) Classical' statements: this can hide theorem statements
-which would be better stated with explicit decidability statements.
-Instead, use `open Classical in` for definitions or instances, the `classical` tactic for proofs.
-For theorem statements, either add missing decidability assumptions or use `open Classical in`.
-note: this linter can be disabled with `set_option linter.openClassical false`
--/
-#guard_msgs in
-open scoped Classical
-
-/--
-warning: please avoid 'open (scoped) Classical' statements: this can hide theorem statements
-which would be better stated with explicit decidability statements.
-Instead, use `open Classical in` for definitions or instances, the `classical` tactic for proofs.
-For theorem statements, either add missing decidability assumptions or use `open Classical in`.
-note: this linter can be disabled with `set_option linter.openClassical false`
--/
-#guard_msgs in
-open scoped Classical
 
 /--
 warning: please avoid 'open (scoped) Classical' statements: this can hide theorem statements

--- a/test/Lint.lean
+++ b/test/Lint.lean
@@ -157,6 +157,16 @@ For theorem statements, either add missing decidability assumptions or use `open
 note: this linter can be disabled with `set_option linter.openClassical false`
 -/
 #guard_msgs in
+open Classical hiding choose axiomOfChoice
+
+/--
+warning: please avoid 'open (scoped) Classical' statements: this can hide theorem statements
+which would be better stated with explicit decidability statements.
+Instead, use `open Classical in` for definitions or instances, the `classical` tactic for proofs.
+For theorem statements, either add missing decidability assumptions or use `open Classical in`.
+note: this linter can be disabled with `set_option linter.openClassical false`
+-/
+#guard_msgs in
 open Classical renaming choose -> foo, byCases -> bar
 
 -- Only opening specific items.

--- a/test/Lint.lean
+++ b/test/Lint.lean
@@ -117,8 +117,19 @@ info: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20,
 #guard_msgs in
 #eval List.range 27
 
--- TODO: need to wrangle these...
+/- Tests for the openClassical linter -/
+
+/--
+warning: foo
+note: this linter can be disabled with `set_option linter.openClassical false`
+-/
+#guard_msgs in
 open Classical
+/--
+warning: foo
+note: this linter can be disabled with `set_option linter.openClassical false`
+-/
+#guard_msgs in
 open Nat Classical Nat
 
 /--

--- a/test/Lint.lean
+++ b/test/Lint.lean
@@ -116,3 +116,34 @@ info: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20,
 -/
 #guard_msgs in
 #eval List.range 27
+
+-- TODO: need to wrangle these...
+open Classical
+open Nat Classical Nat
+
+/--
+warning: foo
+note: this linter can be disabled with `set_option linter.openClassical false`
+-/
+#guard_msgs in
+open Classical hiding choose
+
+/--
+warning: foo
+note: this linter can be disabled with `set_option linter.openClassical false`
+-/
+#guard_msgs in
+open Classical renaming choose -> foo, byCases -> bar
+
+-- Only opening specific items.
+/--
+warning: foo
+note: this linter can be disabled with `set_option linter.openClassical false`
+-/
+#guard_msgs in
+open Classical (choose)
+
+-- `open ... in` is *not* linted.
+#guard_msgs in
+open Classical (choose) in
+def foo : Nat := 1

--- a/test/Lint.lean
+++ b/test/Lint.lean
@@ -117,30 +117,43 @@ info: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20,
 #guard_msgs in
 #eval List.range 27
 
-/- Tests for the openClassical linter -/
+/- Tests for the `openClassical` linter -/
 
 /--
-warning: foo
+warning: please avoid 'open (scoped) Classical' statements: this can hide theorem statements
+which would be better stated with explicit decidability statements.
+Instead, use `open Classical in` for definitions or instances, the `classical` tactic for proofs.
+For theorem statements, either add missing decidability assumptions or use `open Classical in`.
 note: this linter can be disabled with `set_option linter.openClassical false`
 -/
 #guard_msgs in
 open Classical
+
 /--
-warning: foo
+warning: please avoid 'open (scoped) Classical' statements: this can hide theorem statements
+which would be better stated with explicit decidability statements.
+Instead, use `open Classical in` for definitions or instances, the `classical` tactic for proofs.
+For theorem statements, either add missing decidability assumptions or use `open Classical in`.
 note: this linter can be disabled with `set_option linter.openClassical false`
 -/
 #guard_msgs in
 open Nat Classical Nat
 
 /--
-warning: foo
+warning: please avoid 'open (scoped) Classical' statements: this can hide theorem statements
+which would be better stated with explicit decidability statements.
+Instead, use `open Classical in` for definitions or instances, the `classical` tactic for proofs.
+For theorem statements, either add missing decidability assumptions or use `open Classical in`.
 note: this linter can be disabled with `set_option linter.openClassical false`
 -/
 #guard_msgs in
 open Classical hiding choose
 
 /--
-warning: foo
+warning: please avoid 'open (scoped) Classical' statements: this can hide theorem statements
+which would be better stated with explicit decidability statements.
+Instead, use `open Classical in` for definitions or instances, the `classical` tactic for proofs.
+For theorem statements, either add missing decidability assumptions or use `open Classical in`.
 note: this linter can be disabled with `set_option linter.openClassical false`
 -/
 #guard_msgs in
@@ -148,11 +161,20 @@ open Classical renaming choose -> foo, byCases -> bar
 
 -- Only opening specific items.
 /--
-warning: foo
+warning: please avoid 'open (scoped) Classical' statements: this can hide theorem statements
+which would be better stated with explicit decidability statements.
+Instead, use `open Classical in` for definitions or instances, the `classical` tactic for proofs.
+For theorem statements, either add missing decidability assumptions or use `open Classical in`.
 note: this linter can be disabled with `set_option linter.openClassical false`
 -/
 #guard_msgs in
 open Classical (choose)
+
+-- TODO: `open scoped Classical` is also linted
+open scoped Classical
+open scoped Classical
+open scoped Classical
+open scoped Int Classical Nat
 
 -- `open ... in` is *not* linted.
 #guard_msgs in

--- a/test/Lint.lean
+++ b/test/Lint.lean
@@ -170,10 +170,45 @@ note: this linter can be disabled with `set_option linter.openClassical false`
 #guard_msgs in
 open Classical (choose)
 
--- TODO: `open scoped Classical` is also linted
+-- `open scoped Classical` is also linted
+/--
+warning: please avoid 'open (scoped) Classical' statements: this can hide theorem statements
+which would be better stated with explicit decidability statements.
+Instead, use `open Classical in` for definitions or instances, the `classical` tactic for proofs.
+For theorem statements, either add missing decidability assumptions or use `open Classical in`.
+note: this linter can be disabled with `set_option linter.openClassical false`
+-/
+#guard_msgs in
 open scoped Classical
+
+/--
+warning: please avoid 'open (scoped) Classical' statements: this can hide theorem statements
+which would be better stated with explicit decidability statements.
+Instead, use `open Classical in` for definitions or instances, the `classical` tactic for proofs.
+For theorem statements, either add missing decidability assumptions or use `open Classical in`.
+note: this linter can be disabled with `set_option linter.openClassical false`
+-/
+#guard_msgs in
 open scoped Classical
+
+/--
+warning: please avoid 'open (scoped) Classical' statements: this can hide theorem statements
+which would be better stated with explicit decidability statements.
+Instead, use `open Classical in` for definitions or instances, the `classical` tactic for proofs.
+For theorem statements, either add missing decidability assumptions or use `open Classical in`.
+note: this linter can be disabled with `set_option linter.openClassical false`
+-/
+#guard_msgs in
 open scoped Classical
+
+/--
+warning: please avoid 'open (scoped) Classical' statements: this can hide theorem statements
+which would be better stated with explicit decidability statements.
+Instead, use `open Classical in` for definitions or instances, the `classical` tactic for proofs.
+For theorem statements, either add missing decidability assumptions or use `open Classical in`.
+note: this linter can be disabled with `set_option linter.openClassical false`
+-/
+#guard_msgs in
 open scoped Int Classical Nat
 
 -- `open ... in` is *not* linted.

--- a/test/Lint.lean
+++ b/test/Lint.lean
@@ -118,6 +118,7 @@ info: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20,
 #eval List.range 27
 
 /- Tests for the `openClassical` linter -/
+section openClassical
 
 /--
 warning: please avoid 'open (scoped) Classical' statements: this can hide theorem statements
@@ -212,3 +213,5 @@ open scoped Int Classical Nat Classical
 #guard_msgs in
 open Classical (choose) in
 def foo : Nat := 1
+
+end openClassical

--- a/test/Lint.lean
+++ b/test/Lint.lean
@@ -198,9 +198,15 @@ which would be better stated with explicit decidability statements.
 Instead, use `open Classical in` for definitions or instances, the `classical` tactic for proofs.
 For theorem statements, either add missing decidability assumptions or use `open Classical in`.
 note: this linter can be disabled with `set_option linter.openClassical false`
+---
+warning: please avoid 'open (scoped) Classical' statements: this can hide theorem statements
+which would be better stated with explicit decidability statements.
+Instead, use `open Classical in` for definitions or instances, the `classical` tactic for proofs.
+For theorem statements, either add missing decidability assumptions or use `open Classical in`.
+note: this linter can be disabled with `set_option linter.openClassical false`
 -/
 #guard_msgs in
-open scoped Int Classical Nat
+open scoped Int Classical Nat Classical
 
 -- `open ... in` is *not* linted.
 #guard_msgs in


### PR DESCRIPTION
Inspired by #15371: `open (scoped) Classical in` is allowed.

---

Does not pass CI yet, as part 3 (and future parts 4 and perhaps 5) still need to land.
- [x] depends on: #15413
- [x] depends on: #15417
- [ ] depends on: #15480
- [x] depends on: #15481
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
