### PR TITLE
[Merged by Bors] - feat(Combinatorics/SimpleGraph): distance of vertices in a subgraph

### DIFF
--- a/Mathlib/Combinatorics/SimpleGraph/Metric.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Metric.lean
@@ -129,7 +129,7 @@ theorem edist_eq_one_iff_adj : G.edist u v = 1 ↔ G.Adj u v := by
   · exact le_antisymm (edist_le h.toWalk) (ENat.one_le_iff_pos.mpr <| edist_pos_of_ne h.ne)
 
 /-- Supergraphs have smaller or equal extended distances to their subgraphs. -/
-theorem edist_le_subgraph_edist {G' : SimpleGraph V} {u v : V} (h : G ≤ G') (hr : G.Reachable u v) :
+theorem edist_le_subgraph_edist {G' : SimpleGraph V} (h : G ≤ G') (hr : G.Reachable u v) :
     G'.edist u v ≤ G.edist u v := by
   obtain ⟨_, hw⟩ := hr.exists_walk_length_eq_edist
   rw [← hw, ← Walk.length_map (Hom.mapSpanningSubgraphs h)]
@@ -242,7 +242,7 @@ lemma Connected.exists_path_of_dist (hconn : G.Connected) (u v : V) :
   exact ⟨p, p.isPath_of_length_eq_dist h, h⟩
 
 /-- Supergraphs have smaller or equal distances to their subgraphs. -/
-theorem dist_le_subgraph_dist {G' : SimpleGraph V} {u v : V} (h : G ≤ G') (hr : G.Reachable u v) :
+theorem dist_le_subgraph_dist {G' : SimpleGraph V} (h : G ≤ G') (hr : G.Reachable u v) :
     G'.dist u v ≤ G.dist u v := by
   obtain ⟨_, hw⟩ := hr.exists_walk_length_eq_dist
   rw [← hw, ← Walk.length_map (Hom.mapSpanningSubgraphs h)]

--- a/Mathlib/Combinatorics/SimpleGraph/Metric.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Metric.lean
@@ -129,11 +129,13 @@ theorem edist_eq_one_iff_adj : G.edist u v = 1 ↔ G.Adj u v := by
   · exact le_antisymm (edist_le h.toWalk) (ENat.one_le_iff_pos.mpr <| edist_pos_of_ne h.ne)
 
 /-- Supergraphs have smaller or equal extended distances to their subgraphs. -/
-theorem edist_le_subgraph_edist {G' : SimpleGraph V} (h : G ≤ G') (hr : G.Reachable u v) :
+theorem edist_le_subgraph_edist {G' : SimpleGraph V} (h : G ≤ G') :
     G'.edist u v ≤ G.edist u v := by
-  obtain ⟨_, hw⟩ := hr.exists_walk_length_eq_edist
-  rw [← hw, ← Walk.length_map (Hom.mapSpanningSubgraphs h)]
-  apply edist_le
+  by_cases hr : G.Reachable u v
+  · obtain ⟨_, hw⟩ := hr.exists_walk_length_eq_edist
+    rw [← hw, ← Walk.length_map (Hom.mapSpanningSubgraphs h)]
+    apply edist_le
+  · exact edist_eq_top_of_not_reachable hr ▸ le_top
 
 end edist
 

--- a/Mathlib/Combinatorics/SimpleGraph/Metric.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Metric.lean
@@ -128,6 +128,13 @@ theorem edist_eq_one_iff_adj : G.edist u v = 1 ↔ G.Adj u v := by
     exact w.adj_of_length_eq_one <| Nat.cast_eq_one.mp <| h ▸ hw
   · exact le_antisymm (edist_le h.toWalk) (ENat.one_le_iff_pos.mpr <| edist_pos_of_ne h.ne)
 
+/-- Supergraphs have smaller or equal extended distances to their subgraphs. -/
+theorem dist_le_subgraph_edist {G' : SimpleGraph V} {u v : V} (h : G ≤ G') (hr : G.Reachable u v) :
+    G'.edist u v ≤ G.edist u v := by
+  obtain ⟨_, hw⟩ := exists_walk_of_edist_ne_top <| edist_ne_top_iff_reachable.mpr hr
+  rw [← hw, ← Walk.length_map (Hom.mapSpanningSubgraphs h)]
+  apply edist_le
+
 end edist
 
 section dist

--- a/Mathlib/Combinatorics/SimpleGraph/Metric.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Metric.lean
@@ -234,6 +234,13 @@ lemma Connected.exists_path_of_dist (hconn : G.Connected) (u v : V) :
   obtain ⟨p, h⟩ := hconn.exists_walk_length_eq_dist  u v
   exact ⟨p, p.isPath_of_length_eq_dist h, h⟩
 
+/-- Supergraphs have smaller or equal distances to their subgraphs. -/
+theorem dist_le_subgraph_dist {G' : SimpleGraph V} {u v : V} (h : G ≤ G') (hd : G.dist u v ≠ 0) :
+    G'.dist u v ≤ G.dist u v := by
+  obtain ⟨_, hw⟩ := exists_walk_of_dist_ne_zero hd
+  rw [← hw, ← Walk.length_map (Hom.mapSpanningSubgraphs h)]
+  apply dist_le
+
 end dist
 
 end SimpleGraph

--- a/Mathlib/Combinatorics/SimpleGraph/Metric.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Metric.lean
@@ -131,7 +131,7 @@ theorem edist_eq_one_iff_adj : G.edist u v = 1 ↔ G.Adj u v := by
 /-- Supergraphs have smaller or equal extended distances to their subgraphs. -/
 theorem edist_le_subgraph_edist {G' : SimpleGraph V} {u v : V} (h : G ≤ G') (hr : G.Reachable u v) :
     G'.edist u v ≤ G.edist u v := by
-  obtain ⟨_, hw⟩ := exists_walk_of_edist_ne_top <| edist_ne_top_iff_reachable.mpr hr
+  obtain ⟨_, hw⟩ := hr.exists_walk_length_eq_edist
   rw [← hw, ← Walk.length_map (Hom.mapSpanningSubgraphs h)]
   apply edist_le
 
@@ -242,9 +242,9 @@ lemma Connected.exists_path_of_dist (hconn : G.Connected) (u v : V) :
   exact ⟨p, p.isPath_of_length_eq_dist h, h⟩
 
 /-- Supergraphs have smaller or equal distances to their subgraphs. -/
-theorem dist_le_subgraph_dist {G' : SimpleGraph V} {u v : V} (h : G ≤ G') (hd : G.dist u v ≠ 0) :
+theorem dist_le_subgraph_dist {G' : SimpleGraph V} {u v : V} (h : G ≤ G') (hr : G.Reachable u v) :
     G'.dist u v ≤ G.dist u v := by
-  obtain ⟨_, hw⟩ := exists_walk_of_dist_ne_zero hd
+  obtain ⟨_, hw⟩ := hr.exists_walk_length_eq_dist
   rw [← hw, ← Walk.length_map (Hom.mapSpanningSubgraphs h)]
   apply dist_le
 

--- a/Mathlib/Combinatorics/SimpleGraph/Metric.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Metric.lean
@@ -129,7 +129,7 @@ theorem edist_eq_one_iff_adj : G.edist u v = 1 ↔ G.Adj u v := by
   · exact le_antisymm (edist_le h.toWalk) (ENat.one_le_iff_pos.mpr <| edist_pos_of_ne h.ne)
 
 /-- Supergraphs have smaller or equal extended distances to their subgraphs. -/
-theorem dist_le_subgraph_edist {G' : SimpleGraph V} {u v : V} (h : G ≤ G') (hr : G.Reachable u v) :
+theorem edist_le_subgraph_edist {G' : SimpleGraph V} {u v : V} (h : G ≤ G') (hr : G.Reachable u v) :
     G'.edist u v ≤ G.edist u v := by
   obtain ⟨_, hw⟩ := exists_walk_of_edist_ne_top <| edist_ne_top_iff_reachable.mpr hr
   rw [← hw, ← Walk.length_map (Hom.mapSpanningSubgraphs h)]


### PR DESCRIPTION
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
