### PR TITLE
[Merged by Bors] - feat (Topology.Order): Generalize `Monotone.tendsto_nhdsWithin_Iio`

### DIFF
--- a/Mathlib/Topology/Order/Monotone.lean
+++ b/Mathlib/Topology/Order/Monotone.lean
@@ -292,15 +292,8 @@ lemma MonotoneOn.tendsto_nhdsWithin_Iio {α β : Type*} [LinearOrder α] [Topolo
 lemma MonotoneOn.tendsto_nhdsWithin_Ioi {α β : Type*} [LinearOrder α] [TopologicalSpace α]
     [OrderTopology α] [ConditionallyCompleteLinearOrder β] [TopologicalSpace β] [OrderTopology β]
     {f : α → β} {x : α} (Mf : MonotoneOn f (Ioi x)) (h_bdd : BddBelow (f '' Ioi x)) :
-    Tendsto f (𝓝[>] x) (𝓝 (sInf (f '' Ioi x))) := by
-  rcases eq_empty_or_nonempty (Ioi x) with (h | h); · simp [h]
-  refine tendsto_order.2 ⟨fun l hl => ?_, fun m hm => ?_⟩
-  · refine mem_of_superset self_mem_nhdsWithin fun y hy => hl.trans_le ?_
-    exact csInf_le h_bdd (mem_image_of_mem _ hy)
-  · obtain ⟨z, xz, zm⟩ : ∃ a : α, x < a ∧ f a < m := by
-      simpa only [mem_image, exists_prop, exists_exists_and_eq_and] using
-        exists_lt_of_csInf_lt (h.image _) hm
-    exact mem_of_superset (Ioo_mem_nhdsWithin_Ioi' xz) fun y hy => (Mf hy.1 xz hy.2.le).trans_lt zm
+    Tendsto f (𝓝[>] x) (𝓝 (sInf (f '' Ioi x))) :=
+  MonotoneOn.tendsto_nhdsWithin_Iio (α := αᵒᵈ) (β := βᵒᵈ) Mf.dual h_bdd
 
 /-- A monotone map has a limit to the left of any point `x`, equal to `sSup (f '' (Iio x))`. -/
 theorem Monotone.tendsto_nhdsWithin_Iio {α β : Type*} [LinearOrder α] [TopologicalSpace α]

--- a/Mathlib/Topology/Order/Monotone.lean
+++ b/Mathlib/Topology/Order/Monotone.lean
@@ -307,4 +307,42 @@ theorem Monotone.tendsto_nhdsWithin_Ioi {α β : Type*} [LinearOrder α] [Topolo
     {f : α → β} (Mf : Monotone f) (x : α) : Tendsto f (𝓝[>] x) (𝓝 (sInf (f '' Ioi x))) :=
   Monotone.tendsto_nhdsWithin_Iio (α := αᵒᵈ) (β := βᵒᵈ) Mf.dual x
 
+lemma AntitoneOn.tendsto_nhdsWithin_Ioo_left {α β : Type*} [LinearOrder α] [TopologicalSpace α]
+    [OrderTopology α] [ConditionallyCompleteLinearOrder β] [TopologicalSpace β] [OrderTopology β]
+    {f : α → β} {x y : α} (h_nonempty : (Ioo y x).Nonempty) (Af : AntitoneOn f (Ioo y x))
+    (h_bdd : BddBelow (f '' Ioo y x)) :
+    Tendsto f (𝓝[<] x) (𝓝 (sInf (f '' Ioo y x))) :=
+  MonotoneOn.tendsto_nhdsWithin_Ioo_left h_nonempty Af.dual_right h_bdd
+
+lemma AntitoneOn.tendsto_nhdsWithin_Ioo_right {α β : Type*} [LinearOrder α] [TopologicalSpace α]
+    [OrderTopology α] [ConditionallyCompleteLinearOrder β] [TopologicalSpace β] [OrderTopology β]
+    {f : α → β} {x y : α} (h_nonempty : (Ioo x y).Nonempty) (Af : AntitoneOn f (Ioo x y))
+    (h_bdd : BddAbove (f '' Ioo x y)) :
+    Tendsto f (𝓝[>] x) (𝓝 (sSup (f '' Ioo x y))) :=
+  MonotoneOn.tendsto_nhdsWithin_Ioo_right h_nonempty Af.dual_right h_bdd
+
+lemma AntitoneOn.tendsto_nhdsWithin_Iio {α β : Type*} [LinearOrder α] [TopologicalSpace α]
+    [OrderTopology α] [ConditionallyCompleteLinearOrder β] [TopologicalSpace β] [OrderTopology β]
+    {f : α → β} {x : α} (Af : AntitoneOn f (Iio x)) (h_bdd : BddBelow (f '' Iio x)) :
+    Tendsto f (𝓝[<] x) (𝓝 (sInf (f '' Iio x))) :=
+  MonotoneOn.tendsto_nhdsWithin_Iio Af.dual_right h_bdd
+
+lemma AntitoneOn.tendsto_nhdsWithin_Ioi {α β : Type*} [LinearOrder α] [TopologicalSpace α]
+    [OrderTopology α] [ConditionallyCompleteLinearOrder β] [TopologicalSpace β] [OrderTopology β]
+    {f : α → β} {x : α} (Af : AntitoneOn f (Ioi x)) (h_bdd : BddAbove (f '' Ioi x)) :
+    Tendsto f (𝓝[>] x) (𝓝 (sSup (f '' Ioi x))) :=
+  MonotoneOn.tendsto_nhdsWithin_Ioi Af.dual_right h_bdd
+
+/-- An antitone map has a limit to the left of any point `x`, equal to `sInf (f '' (Iio x))`. -/
+theorem Antitone.tendsto_nhdsWithin_Iio {α β : Type*} [LinearOrder α] [TopologicalSpace α]
+    [OrderTopology α] [ConditionallyCompleteLinearOrder β] [TopologicalSpace β] [OrderTopology β]
+    {f : α → β} (Af : Antitone f) (x : α) : Tendsto f (𝓝[<] x) (𝓝 (sInf (f '' Iio x))) :=
+  Monotone.tendsto_nhdsWithin_Iio Af.dual_right x
+
+/-- An antitone map has a limit to the right of any point `x`, equal to `sSup (f '' (Ioi x))`. -/
+theorem Antitone.tendsto_nhdsWithin_Ioi {α β : Type*} [LinearOrder α] [TopologicalSpace α]
+    [OrderTopology α] [ConditionallyCompleteLinearOrder β] [TopologicalSpace β] [OrderTopology β]
+    {f : α → β} (Af : Antitone f) (x : α) : Tendsto f (𝓝[>] x) (𝓝 (sSup (f '' Ioi x))) :=
+  Monotone.tendsto_nhdsWithin_Ioi Af.dual_right x
+
 end ConditionallyCompleteLinearOrder

--- a/Mathlib/Topology/Order/Monotone.lean
+++ b/Mathlib/Topology/Order/Monotone.lean
@@ -246,18 +246,68 @@ theorem Antitone.map_ciInf_of_continuousAt {f : α → β} {g : γ → α} (Cf :
   Monotone.map_ciInf_of_continuousAt (show ContinuousAt (OrderDual.toDual ∘ f) (⨅ i, g i) from Cf)
     Af H
 
-/-- A monotone map has a limit to the left of any point `x`, equal to `sSup (f '' (Iio x))`. -/
-theorem Monotone.tendsto_nhdsWithin_Iio {α β : Type*} [LinearOrder α] [TopologicalSpace α]
+lemma MonotoneOn.tendsto_nhdsWithin_Ioo_left {α β : Type*} [LinearOrder α] [TopologicalSpace α]
     [OrderTopology α] [ConditionallyCompleteLinearOrder β] [TopologicalSpace β] [OrderTopology β]
-    {f : α → β} (Mf : Monotone f) (x : α) : Tendsto f (𝓝[<] x) (𝓝 (sSup (f '' Iio x))) := by
+    {f : α → β} {x y : α} (h_nonempty : (Ioo y x).Nonempty) (Mf : MonotoneOn f (Ioo y x))
+    (h_bdd : BddAbove (f '' Ioo y x)) :
+    Tendsto f (𝓝[<] x) (𝓝 (sSup (f '' Ioo y x))) := by
+  refine tendsto_order.2 ⟨fun l hl => ?_, fun m hm => ?_⟩
+  · obtain ⟨z, ⟨yz, zx⟩, lz⟩ : ∃ a : α, a ∈ Ioo y x ∧ l < f a := by
+      simpa only [mem_image, exists_prop, exists_exists_and_eq_and] using
+        exists_lt_of_lt_csSup (h_nonempty.image _) hl
+    refine mem_of_superset (Ioo_mem_nhdsWithin_Iio' zx) fun w hw => ?_
+    exact lz.trans_le <| Mf ⟨yz, zx⟩ ⟨yz.trans_le hw.1.le, hw.2⟩ hw.1.le
+  · rcases h_nonempty with ⟨_, hy, hx⟩
+    refine mem_of_superset (Ioo_mem_nhdsWithin_Iio' (hy.trans hx)) fun w hw => lt_of_le_of_lt ?_ hm
+    exact le_csSup h_bdd (mem_image_of_mem _ hw)
+
+lemma MonotoneOn.tendsto_nhdsWithin_Ioo_right {α β : Type*} [LinearOrder α] [TopologicalSpace α]
+    [OrderTopology α] [ConditionallyCompleteLinearOrder β] [TopologicalSpace β] [OrderTopology β]
+    {f : α → β} {x y : α} (h_nonempty : (Ioo x y).Nonempty) (Mf : MonotoneOn f (Ioo x y))
+    (h_bdd : BddBelow (f '' Ioo x y)) :
+    Tendsto f (𝓝[>] x) (𝓝 (sInf (f '' Ioo x y))) := by
+  refine tendsto_order.2 ⟨fun l hl => ?_, fun m hm => ?_⟩
+  · rcases h_nonempty with ⟨p, hy, hx⟩
+    refine mem_of_superset (Ioo_mem_nhdsWithin_Ioi' (hy.trans hx)) fun w hw => hl.trans_le ?_
+    exact csInf_le h_bdd (mem_image_of_mem _ hw)
+  · obtain ⟨z, ⟨xz, zy⟩, zm⟩ : ∃ a : α, a ∈ Ioo x y ∧ f a < m := by
+      simpa [mem_image, exists_prop, exists_exists_and_eq_and] using
+        exists_lt_of_csInf_lt (h_nonempty.image _) hm
+    refine mem_of_superset (Ioo_mem_nhdsWithin_Ioi' xz) fun w hw => ?_
+    exact (Mf ⟨hw.1, hw.2.trans zy⟩ ⟨xz, zy⟩ hw.2.le).trans_lt zm
+
+lemma MonotoneOn.tendsto_nhdsWithin_Iio {α β : Type*} [LinearOrder α] [TopologicalSpace α]
+    [OrderTopology α] [ConditionallyCompleteLinearOrder β] [TopologicalSpace β] [OrderTopology β]
+    {f : α → β} {x : α} (Mf : MonotoneOn f (Iio x)) (h_bdd : BddAbove (f '' Iio x)) :
+    Tendsto f (𝓝[<] x) (𝓝 (sSup (f '' Iio x))) := by
   rcases eq_empty_or_nonempty (Iio x) with (h | h); · simp [h]
   refine tendsto_order.2 ⟨fun l hl => ?_, fun m hm => ?_⟩
   · obtain ⟨z, zx, lz⟩ : ∃ a : α, a < x ∧ l < f a := by
       simpa only [mem_image, exists_prop, exists_exists_and_eq_and] using
         exists_lt_of_lt_csSup (h.image _) hl
-    exact mem_of_superset (Ioo_mem_nhdsWithin_Iio' zx) fun y hy => lz.trans_le (Mf hy.1.le)
-  · refine mem_of_superset self_mem_nhdsWithin fun _ hy => lt_of_le_of_lt ?_ hm
-    exact le_csSup (Mf.map_bddAbove bddAbove_Iio) (mem_image_of_mem _ hy)
+    exact mem_of_superset (Ioo_mem_nhdsWithin_Iio' zx) fun y hy => lz.trans_le (Mf zx hy.2 hy.1.le)
+  · refine mem_of_superset self_mem_nhdsWithin fun y hy => lt_of_le_of_lt ?_ hm
+    exact le_csSup h_bdd (mem_image_of_mem _ hy)
+
+lemma MonotoneOn.tendsto_nhdsWithin_Ioi {α β : Type*} [LinearOrder α] [TopologicalSpace α]
+    [OrderTopology α] [ConditionallyCompleteLinearOrder β] [TopologicalSpace β] [OrderTopology β]
+    {f : α → β} {x : α} (Mf : MonotoneOn f (Ioi x)) (h_bdd : BddBelow (f '' Ioi x)) :
+    Tendsto f (𝓝[>] x) (𝓝 (sInf (f '' Ioi x))) := by
+  rcases eq_empty_or_nonempty (Ioi x) with (h | h); · simp [h]
+  refine tendsto_order.2 ⟨fun l hl => ?_, fun m hm => ?_⟩
+  · refine mem_of_superset self_mem_nhdsWithin fun y hy => hl.trans_le ?_
+    exact csInf_le h_bdd (mem_image_of_mem _ hy)
+  · obtain ⟨z, xz, zm⟩ : ∃ a : α, x < a ∧ f a < m := by
+      simpa only [mem_image, exists_prop, exists_exists_and_eq_and] using
+        exists_lt_of_csInf_lt (h.image _) hm
+    exact mem_of_superset (Ioo_mem_nhdsWithin_Ioi' xz) fun y hy => (Mf hy.1 xz hy.2.le).trans_lt zm
+
+/-- A monotone map has a limit to the left of any point `x`, equal to `sSup (f '' (Iio x))`. -/
+theorem Monotone.tendsto_nhdsWithin_Iio {α β : Type*} [LinearOrder α] [TopologicalSpace α]
+    [OrderTopology α] [ConditionallyCompleteLinearOrder β] [TopologicalSpace β] [OrderTopology β]
+    {f : α → β} (Mf : Monotone f) (x : α) : Tendsto f (𝓝[<] x) (𝓝 (sSup (f '' Iio x))) :=
+  MonotoneOn.tendsto_nhdsWithin_Iio (Mf.monotoneOn _) (Mf.map_bddAbove bddAbove_Iio)
+
 
 /-- A monotone map has a limit to the right of any point `x`, equal to `sInf (f '' (Ioi x))`. -/
 theorem Monotone.tendsto_nhdsWithin_Ioi {α β : Type*} [LinearOrder α] [TopologicalSpace α]

--- a/Mathlib/Topology/Order/Monotone.lean
+++ b/Mathlib/Topology/Order/Monotone.lean
@@ -308,7 +308,6 @@ theorem Monotone.tendsto_nhdsWithin_Iio {α β : Type*} [LinearOrder α] [Topolo
     {f : α → β} (Mf : Monotone f) (x : α) : Tendsto f (𝓝[<] x) (𝓝 (sSup (f '' Iio x))) :=
   MonotoneOn.tendsto_nhdsWithin_Iio (Mf.monotoneOn _) (Mf.map_bddAbove bddAbove_Iio)
 
-
 /-- A monotone map has a limit to the right of any point `x`, equal to `sInf (f '' (Ioi x))`. -/
 theorem Monotone.tendsto_nhdsWithin_Ioi {α β : Type*} [LinearOrder α] [TopologicalSpace α]
     [OrderTopology α] [ConditionallyCompleteLinearOrder β] [TopologicalSpace β] [OrderTopology β]


### PR DESCRIPTION
`Monotone.tendsto_nhdsWithin_Iio` and `Monotone.tendsto_nhdsWithin_Ioi` assume monotonicity on the whole space, but it is sufficient for the function to be monotone on an interval.

- Add `MonotoneOn.tendsto_nhdsWithin_Ioo_left`,  `MonotoneOn.tendsto_nhdsWithin_Ioo_right`, `MonotoneOn.tendsto_nhdsWithin_Iio` and `MonotoneOn.tendsto_nhdsWithin_Ioi`.
- Simplify the proof of `Monotone.tendsto_nhdsWithin_Iio` using `MonotoneOn.tendsto_nhdsWithin_Iio`.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
