### PR TITLE
feat (MeasureTheory.Decomposition.Lebesgue): `measure_sub_singularPart` and `measure_sub_rnDeriv`

### DIFF
--- a/Mathlib/MeasureTheory/Decomposition/Lebesgue.lean
+++ b/Mathlib/MeasureTheory/Decomposition/Lebesgue.lean
@@ -108,9 +108,15 @@ theorem haveLebesgueDecomposition_add (μ ν : Measure α) [HaveLebesgueDecompos
     μ = μ.singularPart ν + ν.withDensity (μ.rnDeriv ν) :=
   (haveLebesgueDecomposition_spec μ ν).2.2
 
+/-- For the versions of this lemma where `ν.withDensity (μ.rnDeriv ν)` or `μ.singularPart ν` are
+isolated, see `MeasureTheory.Measure.measure_sub_singularPart` and
+`MeasureTheory.Measure.measure_sub_rnDeriv`. -/
 lemma singularPart_add_rnDeriv (μ ν : Measure α) [HaveLebesgueDecomposition μ ν] :
     μ.singularPart ν + ν.withDensity (μ.rnDeriv ν) = μ := (haveLebesgueDecomposition_add μ ν).symm
 
+/-- For the versions of this lemma where `μ.singularPart ν` or `ν.withDensity (μ.rnDeriv ν)` are
+isolated, see `MeasureTheory.Measure.measure_sub_singularPart` and
+`MeasureTheory.Measure.measure_sub_rnDeriv`. -/
 lemma rnDeriv_add_singularPart (μ ν : Measure α) [HaveLebesgueDecomposition μ ν] :
     ν.withDensity (μ.rnDeriv ν) + μ.singularPart ν = μ := by rw [add_comm, singularPart_add_rnDeriv]
 
@@ -463,6 +469,17 @@ lemma singularPart_restrict (μ ν : Measure α) [HaveLebesgueDecomposition μ �
   · ext t
     rw [withDensity_indicator hs, ← restrict_withDensity hs, ← Measure.restrict_add,
       ← μ.haveLebesgueDecomposition_add ν]
+
+lemma measure_sub_singularPart (μ ν : Measure α) [HaveLebesgueDecomposition μ ν]
+    [IsFiniteMeasure μ] :
+    μ - μ.singularPart ν = ν.withDensity (μ.rnDeriv ν) := by
+  nth_rw 1 [← rnDeriv_add_singularPart μ ν]
+  exact add_sub_cancel
+
+lemma measure_sub_rnDeriv (μ ν : Measure α) [HaveLebesgueDecomposition μ ν] [IsFiniteMeasure μ] :
+    μ - ν.withDensity (μ.rnDeriv ν) = μ.singularPart ν := by
+  nth_rw 1 [← singularPart_add_rnDeriv μ ν]
+  exact add_sub_cancel
 
 /-- Given measures `μ` and `ν`, if `s` is a measure mutually singular to `ν` and `f` is a
 measurable function such that `μ = s + fν`, then `f = μ.rnDeriv ν`.


### PR DESCRIPTION
Add `measure_sub_singularPart` and `measure_sub_rnDeriv`, they are the versions of `singularPart_add_rnDeriv` where the absolutely continuous part or the mutually singular part are isolated in the equality.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
