### PR TITLE
[Merged by Bors] - chore(Perm/List): `List.get` -> `getElem`

### DIFF
--- a/Mathlib/GroupTheory/Perm/Cycle/Basic.lean
+++ b/Mathlib/GroupTheory/Perm/Cycle/Basic.lean
@@ -867,10 +867,10 @@ theorem Nodup.isCycleOn_formPerm (h : l.Nodup) :
     l.formPerm.IsCycleOn { a | a ∈ l } := by
   refine ⟨l.formPerm.bijOn fun _ => List.formPerm_mem_iff_mem, fun a ha b hb => ?_⟩
   rw [Set.mem_setOf, ← List.indexOf_lt_length] at ha hb
-  rw [← List.indexOf_get ha, ← List.indexOf_get hb]
+  rw [← List.getElem_indexOf ha, ← List.getElem_indexOf hb]
   refine ⟨l.indexOf b - l.indexOf a, ?_⟩
   simp only [sub_eq_neg_add, zpow_add, zpow_neg, Equiv.Perm.inv_eq_iff_eq, zpow_natCast,
-    Equiv.Perm.coe_mul, List.formPerm_pow_apply_get _ h, Function.comp]
+    Equiv.Perm.coe_mul, List.formPerm_pow_apply_getElem _ h, Function.comp]
   rw [add_comm]
 
 end

--- a/Mathlib/GroupTheory/Perm/Cycle/Concrete.lean
+++ b/Mathlib/GroupTheory/Perm/Cycle/Concrete.lean
@@ -77,10 +77,9 @@ theorem isCycle_formPerm (hl : Nodup l) (hn : 2 ≤ l.length) : IsCycle (formPer
     · rwa [formPerm_apply_mem_ne_self_iff _ hl _ (mem_cons_self _ _)]
     · intro w hw
       have : w ∈ x::y::l := mem_of_formPerm_ne_self _ _ hw
-      obtain ⟨k, hk⟩ := get_of_mem this
+      obtain ⟨k, hk, rfl⟩ := getElem_of_mem this
       use k
-      rw [← hk]
-      simp only [zpow_natCast, formPerm_pow_apply_head _ _ hl k, Nat.mod_eq_of_lt k.isLt]
+      simp only [zpow_natCast, formPerm_pow_apply_head _ _ hl k, Nat.mod_eq_of_lt hk]
 
 theorem pairwise_sameCycle_formPerm (hl : Nodup l) (hn : 2 ≤ l.length) :
     Pairwise l.formPerm.SameCycle l :=
@@ -110,6 +109,7 @@ theorem cycleType_formPerm (hl : Nodup l) (hn : 2 ≤ l.length) :
   · simpa using isCycle_formPerm hl hn
   · simp
 
+set_option linter.deprecated false in
 theorem formPerm_apply_mem_eq_next (hl : Nodup l) (x : α) (hx : x ∈ l) :
     formPerm l x = next l x hx := by
   obtain ⟨k, rfl⟩ := get_of_mem hx

--- a/Mathlib/GroupTheory/Perm/List.lean
+++ b/Mathlib/GroupTheory/Perm/List.lean
@@ -136,18 +136,19 @@ theorem formPerm_apply_getLast (x : α) (xs : List α) :
 
 @[simp]
 theorem formPerm_apply_getElem_length (x : α) (xs : List α) :
-    formPerm (x :: xs) ((x :: xs)[xs.length]) = x := by
+    formPerm (x :: xs) (x :: xs)[xs.length] = x := by
   rw [getElem_cons_length _ _ _ rfl, formPerm_apply_getLast]
 
+@[deprecated formPerm_apply_getElem_length (since := "2024-08-03")]
 theorem formPerm_apply_get_length (x : α) (xs : List α) :
-    formPerm (x :: xs) ((x :: xs).get (Fin.mk xs.length (by simp))) = x := by
-  simp [formPerm_apply_getElem_length]
+    formPerm (x :: xs) ((x :: xs).get (Fin.mk xs.length (by simp))) = x :=
+  formPerm_apply_getElem_length ..
 
 set_option linter.deprecated false in
-@[simp, deprecated formPerm_apply_get_length (since := "2024-05-30")]
+@[deprecated formPerm_apply_getElem_length (since := "2024-05-30")]
 theorem formPerm_apply_nthLe_length (x : α) (xs : List α) :
-    formPerm (x :: xs) ((x :: xs).nthLe xs.length (by simp)) = x := by
-  apply formPerm_apply_get_length
+    formPerm (x :: xs) ((x :: xs).nthLe xs.length (by simp)) = x :=
+  formPerm_apply_getElem_length ..
 
 theorem formPerm_apply_head (x y : α) (xs : List α) (h : Nodup (x :: y :: xs)) :
     formPerm (x :: y :: xs) x = y := by simp [formPerm_apply_of_not_mem h.not_mem]
@@ -159,12 +160,13 @@ theorem formPerm_apply_getElem_zero (l : List α) (h : Nodup l) (hl : 1 < l.leng
   · simp at hl
   · rw [getElem_cons_zero, formPerm_apply_head _ _ _ h, getElem_cons_succ, getElem_cons_zero]
 
+@[deprecated formPerm_apply_getElem_zero (since := "2024-08-03")]
 theorem formPerm_apply_get_zero (l : List α) (h : Nodup l) (hl : 1 < l.length) :
-    formPerm l (l.get (Fin.mk 0 (by omega))) = l.get (Fin.mk 1 hl) := by
-  simp_all [formPerm_apply_getElem_zero]
+    formPerm l (l.get (Fin.mk 0 (by omega))) = l.get (Fin.mk 1 hl) :=
+  formPerm_apply_getElem_zero l h hl
 
 set_option linter.deprecated false in
-@[deprecated formPerm_apply_get_zero (since := "2024-05-30")]
+@[deprecated formPerm_apply_getElem_zero (since := "2024-05-30")]
 theorem formPerm_apply_nthLe_zero (l : List α) (h : Nodup l) (hl : 1 < l.length) :
     formPerm l (l.nthLe 0 (by omega)) = l.nthLe 1 hl := by
   apply formPerm_apply_get_zero _ h
@@ -176,7 +178,7 @@ theorem formPerm_eq_head_iff_eq_getLast (x y : α) :
   Iff.trans (by rw [formPerm_apply_getLast]) (formPerm (y :: l)).injective.eq_iff
 
 theorem formPerm_apply_lt_getElem (xs : List α) (h : Nodup xs) (n : ℕ) (hn : n + 1 < xs.length) :
-    formPerm xs (xs[n]'((Nat.lt_succ_self n).trans hn)) = xs[n + 1] := by
+    formPerm xs xs[n] = xs[n + 1] := by
   induction' n with n IH generalizing xs
   · simpa using formPerm_apply_getElem_zero _ h _
   · rcases xs with (_ | ⟨x, _ | ⟨y, l⟩⟩)
@@ -191,6 +193,7 @@ theorem formPerm_apply_lt_getElem (xs : List α) (h : Nodup xs) (n : ℕ) (hn : 
         rw [← hx, IH] at h
         simp [getElem_mem] at h
 
+@[deprecated formPerm_apply_lt_getElem (since := "2024-08-03")]
 theorem formPerm_apply_lt_get (xs : List α) (h : Nodup xs) (n : ℕ) (hn : n + 1 < xs.length) :
     formPerm xs (xs.get (Fin.mk n ((Nat.lt_succ_self n).trans hn))) =
       xs.get (Fin.mk (n + 1) hn) := by
@@ -202,7 +205,7 @@ theorem formPerm_apply_lt (xs : List α) (h : Nodup xs) (n : ℕ) (hn : n + 1 < 
     formPerm xs (xs.nthLe n ((Nat.lt_succ_self n).trans hn)) = xs.nthLe (n + 1) hn := by
   apply formPerm_apply_lt_get _ h
 
-theorem formPerm_apply_getElem (xs : List α) (w : Nodup xs) (i : Nat) (h : i < xs.length) :
+theorem formPerm_apply_getElem (xs : List α) (w : Nodup xs) (i : ℕ) (h : i < xs.length) :
     formPerm xs xs[i] =
       xs[(i + 1) % xs.length]'(Nat.mod_lt _ (i.zero_le.trans_lt h)) := by
   cases' xs with x xs
@@ -216,6 +219,7 @@ theorem formPerm_apply_getElem (xs : List α) (w : Nodup xs) (i : Nat) (h : i < 
       congr
       rw [Nat.mod_eq_of_lt]; simpa [Nat.succ_eq_add_one]
 
+@[deprecated formPerm_apply_getElem (since := "2024-08-03")]
 theorem formPerm_apply_get (xs : List α) (h : Nodup xs) (i : Fin xs.length) :
     formPerm xs (xs.get i) =
       xs.get ⟨((i.val + 1) % xs.length), (Nat.mod_lt _ (i.val.zero_le.trans_lt i.isLt))⟩ := by
@@ -234,8 +238,8 @@ theorem support_formPerm_of_nodup' (l : List α) (h : Nodup l) (h' : ∀ x : α,
   · exact support_formPerm_le' l
   · intro x hx
     simp only [Finset.mem_coe, mem_toFinset] at hx
-    obtain ⟨⟨n, hn⟩, rfl⟩ := get_of_mem hx
-    rw [Set.mem_setOf_eq, formPerm_apply_get _ h]
+    obtain ⟨n, hn, rfl⟩ := getElem_of_mem hx
+    rw [Set.mem_setOf_eq, formPerm_apply_getElem _ h]
     intro H
     rw [nodup_iff_injective_get, Function.Injective] at h
     specialize h H
@@ -255,8 +259,8 @@ theorem formPerm_rotate_one (l : List α) (h : Nodup l) : formPerm (l.rotate 1) 
   have h' : Nodup (l.rotate 1) := by simpa using h
   ext x
   by_cases hx : x ∈ l.rotate 1
-  · obtain ⟨⟨k, hk⟩, rfl⟩ := get_of_mem hx
-    rw [formPerm_apply_get _ h', get_rotate l, get_rotate l, formPerm_apply_get _ h]
+  · obtain ⟨k, hk, rfl⟩ := getElem_of_mem hx
+    rw [formPerm_apply_getElem _ h', getElem_rotate l, getElem_rotate l, formPerm_apply_getElem _ h]
     simp
   · rw [formPerm_apply_of_not_mem hx, formPerm_apply_of_not_mem]
     simpa using hx
@@ -287,7 +291,7 @@ theorem formPerm_reverse : ∀ l : List α, formPerm l.reverse = (formPerm l)⁻
   | a::b::l => by
     simp [formPerm_append_pair, swap_comm, ← formPerm_reverse (b::l)]
 
-theorem formPerm_pow_apply_getElem (l : List α) (w : Nodup l) (n : ℕ) (i : Nat) (h : i < l.length) :
+theorem formPerm_pow_apply_getElem (l : List α) (w : Nodup l) (n : ℕ) (i : ℕ) (h : i < l.length) :
     (formPerm l ^ n) l[i] =
       l[(i + n) % l.length]'(Nat.mod_lt _ (i.zero_le.trans_lt h)) := by
   induction' n with n hn
@@ -295,6 +299,7 @@ theorem formPerm_pow_apply_getElem (l : List α) (w : Nodup l) (n : ℕ) (i : Na
   · simp [pow_succ', mul_apply, hn, formPerm_apply_getElem _ w, Nat.succ_eq_add_one,
       ← Nat.add_assoc]
 
+@[deprecated formPerm_pow_apply_getElem (since := "2024-08-03")]
 theorem formPerm_pow_apply_get (l : List α) (h : Nodup l) (n : ℕ) (i : Fin l.length) :
     (formPerm l ^ n) (l.get i) =
       l.get ⟨((i.val + n) % l.length), (Nat.mod_lt _ (i.val.zero_le.trans_lt i.isLt))⟩ := by
@@ -309,8 +314,8 @@ theorem formPerm_pow_apply_nthLe (l : List α) (h : Nodup l) (n k : ℕ) (hk : k
 
 theorem formPerm_pow_apply_head (x : α) (l : List α) (h : Nodup (x :: l)) (n : ℕ) :
     (formPerm (x :: l) ^ n) x =
-      (x :: l).get ⟨(n % (x :: l).length), (Nat.mod_lt _ (Nat.zero_lt_succ _))⟩ := by
-  convert formPerm_pow_apply_get _ h n ⟨0, Nat.succ_pos _⟩
+      (x :: l)[(n % (x :: l).length)]'(Nat.mod_lt _ (Nat.zero_lt_succ _)) := by
+  convert formPerm_pow_apply_getElem _ h n 0 (Nat.succ_pos _)
   simp
 
 theorem formPerm_ext_iff {x y x' y' : α} {l l' : List α} (hd : Nodup (x :: y :: l))
@@ -333,27 +338,25 @@ theorem formPerm_ext_iff {x y x' y' : α} {l l' : List α} (hd : Nodup (x :: y :
       support_formPerm_of_nodup' _ hd' (by simp)]
     simp only [h]
   use n
-  apply List.ext_get
+  apply List.ext_getElem
   · rw [length_rotate, hl]
   · intro k hk hk'
-    rw [get_rotate]
+    rw [getElem_rotate]
     induction' k with k IH
     · refine Eq.trans ?_ hx'
       congr
       simpa using hn
-    · conv => congr <;> · arg 2; (congr; (simp only [Fin.val_mk]; rw [← Nat.mod_eq_of_lt hk']))
-      rw [← formPerm_apply_get _ hd' ⟨k, k.lt_succ_self.trans hk'⟩,
-        ← IH (k.lt_succ_self.trans hk), ← h, formPerm_apply_get _ hd]
-      congr 2
-      simp only [Fin.val_mk]
+    · conv => congr <;> · arg 2; (rw [← Nat.mod_eq_of_lt hk'])
+      rw [← formPerm_apply_getElem _ hd' k (k.lt_succ_self.trans hk'),
+        ← IH (k.lt_succ_self.trans hk), ← h, formPerm_apply_getElem _ hd]
+      congr 1
       rw [hl, Nat.mod_eq_of_lt hk', add_right_comm]
       apply Nat.add_mod
 
 theorem formPerm_apply_mem_eq_self_iff (hl : Nodup l) (x : α) (hx : x ∈ l) :
     formPerm l x = x ↔ length l ≤ 1 := by
-  obtain ⟨⟨k, hk⟩, rfl⟩ := get_of_mem hx
-  rw [formPerm_apply_get _ hl ⟨k, hk⟩, hl.get_inj_iff, Fin.mk.inj_iff]
-  simp only [Fin.val_mk]
+  obtain ⟨k, hk, rfl⟩ := getElem_of_mem hx
+  rw [formPerm_apply_getElem _ hl k hk, hl.getElem_inj_iff]
   cases hn : l.length
   · exact absurd k.zero_le (hk.trans_le hn.le).not_le
   · rw [hn] at hk


### PR DESCRIPTION
Deprecate `List.get` lemmas, use `getElem` versions in proofs.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
