### PR TITLE
[Merged by Bors] - chore(Topology): remove some uses of open Classical

### DIFF
--- a/Mathlib/Topology/Algebra/Algebra.lean
+++ b/Mathlib/Topology/Algebra/Algebra.lean
@@ -27,10 +27,7 @@ TODO: add continuous algebra isomorphisms.
 
 -/
 
-open scoped Classical
-open Set TopologicalSpace Algebra BigOperators
-
-open scoped Classical
+open Set TopologicalSpace Algebra
 
 universe u v w
 

--- a/Mathlib/Topology/Algebra/Group/Basic.lean
+++ b/Mathlib/Topology/Algebra/Group/Basic.lean
@@ -31,8 +31,6 @@ groups.
 topological space, group, topological group
 -/
 
-
-open scoped Classical
 open Set Filter TopologicalSpace Function Topology Pointwise MulOpposite
 
 universe u v w x

--- a/Mathlib/Topology/Algebra/Group/Compact.lean
+++ b/Mathlib/Topology/Algebra/Group/Compact.lean
@@ -15,13 +15,6 @@ imports developing either positive compacts or the compact open topology.
 
 -/
 
-
-open scoped Classical
-open Set Filter TopologicalSpace Function
-
-open scoped Classical
-open Topology Filter Pointwise
-
 universe u v w x
 
 variable {α : Type u} {β : Type v} {G : Type w} {H : Type x}

--- a/Mathlib/Topology/Algebra/StarSubalgebra.lean
+++ b/Mathlib/Topology/Algebra/StarSubalgebra.lean
@@ -22,12 +22,6 @@ The topological closure of a star subalgebra is still a star subalgebra,
 which as a star algebra is a topological star algebra.
 -/
 
-
-open scoped Classical
-open Set TopologicalSpace
-
-open scoped Classical
-
 namespace StarSubalgebra
 
 section TopologicalStarAlgebra

--- a/Mathlib/Topology/Algebra/UniformField.lean
+++ b/Mathlib/Topology/Algebra/UniformField.lean
@@ -31,10 +31,8 @@ type class and the main results are the instances `UniformSpace.Completion.Field
 `UniformSpace.Completion.TopologicalDivisionRing`.
 -/
 
-
 noncomputable section
 
-open scoped Classical
 open uniformity Topology
 
 open Set UniformSpace UniformSpace.Completion Filter
@@ -88,6 +86,7 @@ theorem continuous_hatInv [CompletableTopField K] {x : hat K} (h : x ≠ 0) :
     erw [denseInducing_coe.nhds_eq_comap (0 : K), ← Filter.comap_inf, eq_bot]
     exact comap_bot
 
+open Classical in
 /-
 The value of `hat_inv` at zero is not really specified, although it's probably zero.
 Here we explicitly enforce the `inv_zero` axiom.

--- a/Mathlib/Topology/Algebra/UniformGroup.lean
+++ b/Mathlib/Topology/Algebra/UniformGroup.lean
@@ -34,10 +34,8 @@ group naturally induces a uniform structure.
   the quotient of a Banach space by a subspace is complete.
 -/
 
-
 noncomputable section
 
-open scoped Classical
 open Uniformity Topology Filter Pointwise
 
 section UniformGroup

--- a/Mathlib/Topology/Algebra/UniformRing.lean
+++ b/Mathlib/Topology/Algebra/UniformRing.lean
@@ -33,12 +33,6 @@ the main constructions deal with continuous ring morphisms.
 TODO: Generalise the results here from the concrete `Completion` to any `AbstractCompletion`.
 -/
 
-
-open scoped Classical
-open Set Filter TopologicalSpace AddCommGroup
-
-open scoped Classical
-
 noncomputable section
 
 universe u

--- a/Mathlib/Topology/Clopen.lean
+++ b/Mathlib/Topology/Clopen.lean
@@ -12,7 +12,7 @@ import Mathlib.Data.Set.BoolIndicator
 A clopen set is a set that is both closed and open.
 -/
 
-open Set Filter Topology TopologicalSpace Classical
+open Set Filter Topology TopologicalSpace
 
 universe u v
 

--- a/Mathlib/Topology/Compactness/Compact.lean
+++ b/Mathlib/Topology/Compactness/Compact.lean
@@ -26,7 +26,7 @@ We define the following properties for sets in a topological space:
   is compact.
 -/
 
-open Set Filter Topology TopologicalSpace Classical Function
+open Set Filter Topology TopologicalSpace Function
 
 universe u v
 
@@ -184,9 +184,10 @@ lemma IsCompact.elim_nhds_subcover_nhdsSet' (hs : IsCompact s) (U : ∀ x ∈ s,
   exact mem_interior_iff_mem_nhds.1 hy
 
 lemma IsCompact.elim_nhds_subcover_nhdsSet (hs : IsCompact s) {U : X → Set X}
-    (hU : ∀ x ∈ s, U x ∈ 𝓝 x) : ∃ t : Finset X, (∀ x ∈ t, x ∈ s) ∧ (⋃ x ∈ t, U x) ∈ 𝓝ˢ s :=
+    (hU : ∀ x ∈ s, U x ∈ 𝓝 x) : ∃ t : Finset X, (∀ x ∈ t, x ∈ s) ∧ (⋃ x ∈ t, U x) ∈ 𝓝ˢ s := by
   let ⟨t, ht⟩ := hs.elim_nhds_subcover_nhdsSet' (fun x _ => U x) hU
-  ⟨t.image (↑), fun x hx =>
+  classical
+  exact ⟨t.image (↑), fun x hx =>
     let ⟨y, _, hyx⟩ := Finset.mem_image.1 hx
     hyx ▸ y.2,
     by rwa [Finset.set_biUnion_finset_image]⟩
@@ -516,6 +517,7 @@ lemma eq_finite_iUnion_of_isTopologicalBasis_of_isCompact_open (b : ι → Set X
   subst this
   obtain ⟨t, ht⟩ :=
     hUc.elim_finite_subcover (b ∘ f') (fun i => hb.isOpen (Set.mem_range_self _)) (by rw [e])
+  classical
   refine ⟨t.image f', Set.toFinite _, le_antisymm ?_ ?_⟩
   · refine Set.Subset.trans ht ?_
     simp only [Set.iUnion_subset_iff]

--- a/Mathlib/Topology/Compactness/LocallyCompact.lean
+++ b/Mathlib/Topology/Compactness/LocallyCompact.lean
@@ -12,7 +12,8 @@ We define the following classes of topological spaces:
 * `LocallyCompactSpace`: for every point `x`, every open neighborhood of `x` contains a compact
   neighborhood of `x`. The definition is formulated in terms of the neighborhood filter.
 -/
-open Set Filter Topology TopologicalSpace Classical
+
+open Set Filter Topology TopologicalSpace
 
 variable {X : Type*} {Y : Type*} {ι : Type*}
 variable [TopologicalSpace X] [TopologicalSpace Y] {s t : Set X}
@@ -101,7 +102,8 @@ instance Pi.locallyCompactSpace [∀ i, CompactSpace (X i)] : LocallyCompactSpac
     refine ⟨s.pi n'', ?_, subset_trans (fun _ => ?_) hsub, ?_⟩
     · exact (set_pi_mem_nhds_iff hs _).mpr fun i _ => hn'' i
     · exact forall₂_imp fun i _ hi' => hsub' i hi'
-    · rw [← Set.univ_pi_ite]
+    · classical
+      rw [← Set.univ_pi_ite]
       refine isCompact_univ_pi fun i => ?_
       by_cases h : i ∈ s
       · rw [if_pos h]

--- a/Mathlib/Topology/Compactness/SigmaCompact.lean
+++ b/Mathlib/Topology/Compactness/SigmaCompact.lean
@@ -13,7 +13,8 @@ import Mathlib.Topology.Compactness.LocallyCompact
   of a countable collection of compact subspaces.
 
 -/
-open Set Filter Topology TopologicalSpace Classical
+
+open Set Filter Topology TopologicalSpace
 
 universe u v
 
@@ -367,15 +368,18 @@ theorem exists_superset_of_isCompact {s : Set X} (hs : IsCompact s) : ∃ n, s �
     exact mem_iUnion.2 ⟨k + 1, K.subset_interior_succ _ hk⟩
   · exact Monotone.directed_le fun _ _ h ↦ interior_mono <| K.subset h
 
+open Classical in
 /-- The minimal `n` such that `x ∈ K n`. -/
 protected noncomputable def find (x : X) : ℕ :=
   Nat.find (K.exists_mem x)
 
-theorem mem_find (x : X) : x ∈ K (K.find x) :=
-  Nat.find_spec (K.exists_mem x)
+theorem mem_find (x : X) : x ∈ K (K.find x) := by
+  classical
+  exact Nat.find_spec (K.exists_mem x)
 
-theorem mem_iff_find_le {x : X} {n : ℕ} : x ∈ K n ↔ K.find x ≤ n :=
-  ⟨fun h => Nat.find_min' (K.exists_mem x) h, fun h => K.subset h <| K.mem_find x⟩
+theorem mem_iff_find_le {x : X} {n : ℕ} : x ∈ K n ↔ K.find x ≤ n := by
+  classical
+  exact ⟨fun h => Nat.find_min' (K.exists_mem x) h, fun h => K.subset h <| K.mem_find x⟩
 
 /-- Prepend the empty set to a compact exhaustion `K n`. -/
 def shiftr : CompactExhaustion X where
@@ -385,8 +389,9 @@ def shiftr : CompactExhaustion X where
   iUnion_eq' := iUnion_eq_univ_iff.2 fun x => ⟨K.find x + 1, K.mem_find x⟩
 
 @[simp]
-theorem find_shiftr (x : X) : K.shiftr.find x = K.find x + 1 :=
-  Nat.find_comp_succ _ _ (not_mem_empty _)
+theorem find_shiftr (x : X) : K.shiftr.find x = K.find x + 1 := by
+  classical
+  exact Nat.find_comp_succ _ _ (not_mem_empty _)
 
 theorem mem_diff_shiftr_find (x : X) : x ∈ K.shiftr (K.find x + 1) \ K.shiftr (K.find x) :=
   ⟨K.mem_find _,

--- a/Mathlib/Topology/Connected/Basic.lean
+++ b/Mathlib/Topology/Connected/Basic.lean
@@ -34,9 +34,7 @@ and in particular
 https://ncatlab.org/nlab/show/too+simple+to+be+simple#relationship_to_biased_definitions.
 -/
 
-
 open Set Function Topology TopologicalSpace Relation
-open scoped Classical
 
 universe u v
 
@@ -425,6 +423,7 @@ theorem IsConnected.prod [TopologicalSpace β] {s : Set α} {t : Set β} (hs : I
 theorem isPreconnected_univ_pi [∀ i, TopologicalSpace (π i)] {s : ∀ i, Set (π i)}
     (hs : ∀ i, IsPreconnected (s i)) : IsPreconnected (pi univ s) := by
   rintro u v uo vo hsuv ⟨f, hfs, hfu⟩ ⟨g, hgs, hgv⟩
+  classical
   rcases exists_finset_piecewise_mem_of_mem_nhds (uo.mem_nhds hfu) g with ⟨I, hI⟩
   induction' I using Finset.induction_on with i I _ ihI
   · refine ⟨g, hgs, ⟨?_, hgv⟩⟩
@@ -457,6 +456,7 @@ that contains this point. -/
 def connectedComponent (x : α) : Set α :=
   ⋃₀ { s : Set α | IsPreconnected s ∧ x ∈ s }
 
+open Classical in
 /-- Given a set `F` in a topological space `α` and a point `x : α`, the connected
 component of `x` in `F` is the connected component of `x` in the subtype `F` seen as
 a set in `α`. This definition does not make sense if `x` is not in `F` so we return the

--- a/Mathlib/Topology/Connected/Clopen.lean
+++ b/Mathlib/Topology/Connected/Clopen.lean
@@ -21,7 +21,6 @@ to clopen sets.
 -/
 
 open Set Function Topology TopologicalSpace Relation
-open scoped Classical
 
 universe u v
 
@@ -267,6 +266,7 @@ theorem isConnected_iff_sUnion_disjoint_open {s : Set α} :
       ∀ U : Finset (Set α), (∀ u v : Set α, u ∈ U → v ∈ U → (s ∩ (u ∩ v)).Nonempty → u = v) →
         (∀ u ∈ U, IsOpen u) → (s ⊆ ⋃₀ ↑U) → ∃ u ∈ U, s ⊆ u := by
   rw [IsConnected, isPreconnected_iff_subset_of_disjoint]
+  classical
   refine ⟨fun ⟨hne, h⟩ U hU hUo hsU => ?_, fun h => ⟨?_, fun u v hu hv hs hsuv => ?_⟩⟩
   · induction U using Finset.induction_on with
     | empty => exact absurd (by simpa using hsU) hne.not_subset_empty

--- a/Mathlib/Topology/Constructions.lean
+++ b/Mathlib/Topology/Constructions.lean
@@ -30,10 +30,8 @@ product, sum, disjoint union, subspace, quotient space
 
 -/
 
-
 noncomputable section
 
-open scoped Classical
 open Topology TopologicalSpace Set Filter Function
 
 universe u v
@@ -1273,6 +1271,7 @@ theorem isOpen_pi_iff {s : Set (∀ a, π a)} :
     · exact Subset.trans
         (pi_mono fun i hi => (eval_image_pi_subset hi).trans (h1 i).choose_spec.1) h2
   · rintro ⟨I, t, ⟨h1, h2⟩⟩
+    classical
     refine ⟨I, fun a => ite (a ∈ I) (t a) univ, fun i => ?_, ?_⟩
     · by_cases hi : i ∈ I
       · use t i
@@ -1339,7 +1338,8 @@ theorem pi_generateFrom_eq {π : ι → Type*} {g : ∀ a, Set (Set (π a))} :
     rintro _ ⟨s, i, hi, rfl⟩
     letI := fun a => generateFrom (g a)
     exact isOpen_set_pi i.finite_toSet (fun a ha => GenerateOpen.basic _ (hi a ha))
-  · refine le_iInf fun i => coinduced_le_iff_le_induced.1 <| le_generateFrom fun s hs => ?_
+  · classical
+    refine le_iInf fun i => coinduced_le_iff_le_induced.1 <| le_generateFrom fun s hs => ?_
     refine GenerateOpen.basic _ ⟨update (fun i => univ) i s, {i}, ?_⟩
     simp [hs]
 
@@ -1365,6 +1365,7 @@ theorem pi_generateFrom_eq_finite {π : ι → Type*} {g : ∀ a, Set (Set (π a
     refine isOpen_iff_forall_mem_open.2 fun f hf => ?_
     choose c hcg hfc using fun a => sUnion_eq_univ_iff.1 (hg a) (f a)
     refine ⟨pi i t ∩ pi ((↑i)ᶜ : Set ι) c, inter_subset_left, ?_, ⟨hf, fun a _ => hfc a⟩⟩
+    classical
     rw [← univ_pi_piecewise]
     refine GenerateOpen.basic _ ⟨_, fun a => ?_, rfl⟩
     by_cases a ∈ i <;> simp [*]

--- a/Mathlib/Topology/ExtremallyDisconnected.lean
+++ b/Mathlib/Topology/ExtremallyDisconnected.lean
@@ -30,7 +30,6 @@ compact Hausdorff spaces.
 
 noncomputable section
 
-open scoped Classical
 open Function Set
 
 universe u

--- a/Mathlib/Topology/FiberBundle/Trivialization.lean
+++ b/Mathlib/Topology/FiberBundle/Trivialization.lean
@@ -48,8 +48,7 @@ type of linear trivializations is not even particularly well-behaved.
 -/
 
 open TopologicalSpace Filter Set Bundle Function
-
-open scoped Topology Classical Bundle
+open scoped Topology
 
 variable {ι : Type*} {B : Type*} {F : Type*} {E : B → Type*}
 variable (F) {Z : Type*} [TopologicalSpace B] [TopologicalSpace F] {proj : Z → B}
@@ -216,6 +215,7 @@ section Zero
 
 variable [∀ x, Zero (E x)]
 
+open Classical in
 /-- A fiberwise inverse to `e`. This is the function `F → E b` that induces a local inverse
 `B × F → TotalSpace F E` of `e` on `e.baseSet`. It is defined to be `0` outside `e.baseSet`. -/
 protected noncomputable def symm (e : Pretrivialization F (π F E)) (b : B) (y : F) : E b :=
@@ -666,6 +666,7 @@ theorem frontier_preimage (e : Trivialization F proj) (s : Set B) :
   rw [← (e.isImage_preimage_prod s).frontier.preimage_eq, frontier_prod_univ_eq,
     (e.isImage_preimage_prod _).preimage_eq, e.source_eq, preimage_inter]
 
+open Classical in
 /-- Given two bundle trivializations `e`, `e'` of `proj : Z → B` and a set `s : Set B` such that
 the base sets of `e` and `e'` intersect `frontier s` on the same set and `e p = e' p` whenever
 `proj p ∈ e.baseSet ∩ frontier s`, `e.piecewise e' s Hs Heq` is the bundle trivialization over
@@ -713,6 +714,7 @@ noncomputable def piecewiseLe [LinearOrder B] [OrderTopology B] (e e' : Triviali
     · simp [e.coe_fst', e'.coe_fst', *]
     · simp [coordChange_apply_snd, *]
 
+open Classical in
 /-- Given two bundle trivializations `e`, `e'` over disjoint sets, `e.disjoint_union e' H` is the
 bundle trivialization over the union of the base sets that agrees with `e` and `e'` over their
 base sets. -/

--- a/Mathlib/Topology/Instances/ENNReal.lean
+++ b/Mathlib/Topology/Instances/ENNReal.lean
@@ -17,7 +17,7 @@ import Mathlib.Topology.Order.T5
 noncomputable section
 
 open Set Filter Metric Function
-open scoped Classical Topology ENNReal NNReal Filter
+open scoped Topology ENNReal NNReal
 
 variable {α : Type*} {β : Type*} {γ : Type*}
 
@@ -348,6 +348,7 @@ protected theorem Tendsto.mul_const {f : Filter α} {m : α → ℝ≥0∞} {a b
 theorem tendsto_finset_prod_of_ne_top {ι : Type*} {f : ι → α → ℝ≥0∞} {x : Filter α} {a : ι → ℝ≥0∞}
     (s : Finset ι) (h : ∀ i ∈ s, Tendsto (f i) x (𝓝 (a i))) (h' : ∀ i ∈ s, a i ≠ ∞) :
     Tendsto (fun b => ∏ c ∈ s, f c b) x (𝓝 (∏ c ∈ s, a c)) := by
+  classical
   induction' s using Finset.induction with a s has IH
   · simp [tendsto_const_nhds]
   simp only [Finset.prod_insert has]
@@ -920,6 +921,7 @@ theorem tsum_union_le (f : α → ℝ≥0∞) (s t : Set α) :
   calc ∑' x : ↑(s ∪ t), f x = ∑' x : ⋃ b, cond b s t, f x := tsum_congr_set_coe _ union_eq_iUnion
   _ ≤ _ := by simpa using tsum_iUnion_le f (cond · s t)
 
+open Classical in
 theorem tsum_eq_add_tsum_ite {f : β → ℝ≥0∞} (b : β) :
     ∑' x, f x = f b + ∑' x, ite (x = b) 0 (f x) :=
   tsum_eq_add_tsum_ite' b ENNReal.summable
@@ -1064,6 +1066,7 @@ theorem summable_sigma {β : α → Type*} {f : (Σ x, β x) → ℝ≥0} :
 
 theorem indicator_summable {f : α → ℝ≥0} (hf : Summable f) (s : Set α) :
     Summable (s.indicator f) := by
+  classical
   refine NNReal.summable_of_le (fun a => le_trans (le_of_eq (s.indicator_apply f a)) ?_) hf
   split_ifs
   · exact le_refl (f a)
@@ -1109,6 +1112,7 @@ theorem tsum_pos {g : α → ℝ≥0} (hg : Summable g) (i : α) (hi : 0 < g i) 
   rw [← tsum_zero]
   exact tsum_lt_tsum (fun a => zero_le _) hi hg
 
+open Classical in
 theorem tsum_eq_add_tsum_ite {f : α → ℝ≥0} (hf : Summable f) (i : α) :
     ∑' x, f x = f i + ∑' x, ite (x = i) 0 (f x) := by
   refine tsum_eq_add_tsum_ite' i (NNReal.summable_of_le (fun i' => ?_) hf)

--- a/Mathlib/Topology/Irreducible.lean
+++ b/Mathlib/Topology/Irreducible.lean
@@ -27,7 +27,7 @@ https://ncatlab.org/nlab/show/too+simple+to+be+simple#relationship_to_biased_def
 
 -/
 
-open Set Classical
+open Set
 
 variable {X : Type*} {Y : Type*} [TopologicalSpace X] [TopologicalSpace Y] {s t : Set X}
 
@@ -220,6 +220,7 @@ theorem isIrreducible_iff_sInter :
     IsIrreducible s ↔
       ∀ (U : Finset (Set X)), (∀ u ∈ U, IsOpen u) → (∀ u ∈ U, (s ∩ u).Nonempty) →
         (s ∩ ⋂₀ ↑U).Nonempty := by
+  classical
   refine ⟨fun h U hu hU => ?_, fun h => ⟨?_, ?_⟩⟩
   · induction U using Finset.induction_on with
     | empty => simpa using h.nonempty
@@ -271,6 +272,7 @@ theorem IsPreirreducible.subset_irreducible {S U : Set X} (ht : IsPreirreducible
   replace ht : IsIrreducible t := ⟨⟨z, h₂ (h₁ hz)⟩, ht⟩
   refine ⟨⟨z, h₁ hz⟩, ?_⟩
   rintro u v hu hv ⟨x, hx, hx'⟩ ⟨y, hy, hy'⟩
+  classical
   obtain ⟨x, -, hx'⟩ : Set.Nonempty (t ∩ ⋂₀ ↑({U, u, v} : Finset (Set X))) := by
     refine isIrreducible_iff_sInter.mp ht {U, u, v} ?_ ?_
     · simp [*]

--- a/Mathlib/Topology/MetricSpace/GromovHausdorff.lean
+++ b/Mathlib/Topology/MetricSpace/GromovHausdorff.lean
@@ -41,19 +41,15 @@ i.e., it is complete and second countable. We also prove the Gromov compactness 
 
 noncomputable section
 
-open scoped Classical Topology ENNReal Cardinal
+open scoped Topology ENNReal Cardinal
+open Set Function TopologicalSpace Filter Metric Quotient Bornology
+open BoundedContinuousFunction Nat Int kuratowskiEmbedding
 
+open Sum (inl inr)
 
 local notation "ℓ_infty_ℝ" => lp (fun n : ℕ => ℝ) ∞
 
 universe u v w
-
-open scoped Classical
-open Set Function TopologicalSpace Filter Metric Quotient Bornology
-
-open BoundedContinuousFunction Nat Int kuratowskiEmbedding
-
-open Sum (inl inr)
 
 attribute [local instance] metricSpaceSum
 

--- a/Mathlib/Topology/MetricSpace/GromovHausdorffRealized.lean
+++ b/Mathlib/Topology/MetricSpace/GromovHausdorffRealized.lean
@@ -32,16 +32,9 @@ space structure on `X ⊕ Y`. The corresponding metric quotient is `OptimalGHCou
 
 noncomputable section
 
-open scoped Classical
-open Topology NNReal
-
 universe u v w
 
-open scoped Classical
-open Set Function TopologicalSpace Filter Metric Quotient
-
-open BoundedContinuousFunction
-
+open Topology NNReal Set Function TopologicalSpace Filter Metric Quotient BoundedContinuousFunction
 open Sum (inl inr)
 
 attribute [local instance] metricSpaceSum

--- a/Mathlib/Topology/PartitionOfUnity.lean
+++ b/Mathlib/Topology/PartitionOfUnity.lean
@@ -73,13 +73,9 @@ We use `WellOrderingRel j i` instead of `j < i` in the definition of
 partition of unity, bump function, Urysohn's lemma, normal space, paracompact space
 -/
 
-
 universe u v
 
-open Function Set Filter
-
-open scoped Classical
-open Topology
+open Function Set Filter Topology
 
 noncomputable section
 
@@ -333,6 +329,7 @@ theorem nonneg (i : ι) (x : X) : 0 ≤ f i x :=
 theorem le_one (i : ι) (x : X) : f i x ≤ 1 :=
   f.le_one' i x
 
+open Classical in
 /-- A `BumpCovering` that consists of a single function, uniformly equal to one, defined as an
 example for `Inhabited` instance. -/
 protected def single (i : ι) (s : Set X) : BumpCovering ι X s where
@@ -347,8 +344,10 @@ protected def single (i : ι) (s : Set X) : BumpCovering ι X s where
   le_one' := update_le_iff.2 ⟨le_rfl, fun _ _ _ => zero_le_one⟩
   eventuallyEq_one' x _ := ⟨i, by rw [Pi.single_eq_same, ContinuousMap.coe_one]⟩
 
+open Classical in
 @[simp]
-theorem coe_single (i : ι) (s : Set X) : ⇑(BumpCovering.single i s) = Pi.single i 1 := rfl
+theorem coe_single (i : ι) (s : Set X) : ⇑(BumpCovering.single i s) = Pi.single i 1 := by
+  rfl
 
 instance [Inhabited ι] : Inhabited (BumpCovering ι X s) :=
   ⟨BumpCovering.single default s⟩
@@ -453,6 +452,7 @@ theorem toPOUFun_zero_of_zero {i : ι} {x : X} (h : f i x = 0) : f.toPOUFun i x 
 theorem support_toPOUFun_subset (i : ι) : support (f.toPOUFun i) ⊆ support (f i) :=
   fun _ => mt <| f.toPOUFun_zero_of_zero
 
+open Classical in
 theorem toPOUFun_eq_mul_prod (i : ι) (x : X) (t : Finset ι)
     (ht : ∀ j, WellOrderingRel j i → f j x ≠ 0 → j ∈ t) :
     f.toPOUFun i x = f i x * ∏ j ∈ t.filter fun j => WellOrderingRel j i, (1 - f j x) := by
@@ -470,6 +470,7 @@ theorem sum_toPOUFun_eq (x : X) : ∑ᶠ i, f.toPOUFun i x = 1 - ∏ᶠ i, (1 - 
   have B : (mulSupport fun i => 1 - f i x) ⊆ s := by
     rw [hs, mulSupport_one_sub]
     exact fun i => id
+  classical
   letI : LinearOrder ι := linearOrderOfSTO WellOrderingRel
   rw [finsum_eq_sum_of_support_subset _ A, finprod_eq_prod_of_mulSupport_subset _ B,
     Finset.prod_one_sub_ordered, sub_sub_cancel]
@@ -477,6 +478,7 @@ theorem sum_toPOUFun_eq (x : X) : ∑ᶠ i, f.toPOUFun i x = 1 - ∏ᶠ i, (1 - 
   convert f.toPOUFun_eq_mul_prod _ _ _ fun j _ hj => _
   rwa [Finite.mem_toFinset]
 
+open Classical in
 theorem exists_finset_toPOUFun_eventuallyEq (i : ι) (x : X) : ∃ t : Finset ι,
     f.toPOUFun i =ᶠ[𝓝 x] f i * ∏ j ∈ t.filter fun j => WellOrderingRel j i, (1 - f j) := by
   rcases f.locallyFinite x with ⟨U, hU, hf⟩
@@ -519,11 +521,13 @@ def toPartitionOfUnity : PartitionOfUnity ι X s where
 theorem toPartitionOfUnity_apply (i : ι) (x : X) :
     f.toPartitionOfUnity i x = f i x * ∏ᶠ (j) (_ : WellOrderingRel j i), (1 - f j x) := rfl
 
+open Classical in
 theorem toPartitionOfUnity_eq_mul_prod (i : ι) (x : X) (t : Finset ι)
     (ht : ∀ j, WellOrderingRel j i → f j x ≠ 0 → j ∈ t) :
     f.toPartitionOfUnity i x = f i x * ∏ j ∈ t.filter fun j => WellOrderingRel j i, (1 - f j x) :=
   f.toPOUFun_eq_mul_prod i x t ht
 
+open Classical in
 theorem exists_finset_toPartitionOfUnity_eventuallyEq (i : ι) (x : X) : ∃ t : Finset ι,
     f.toPartitionOfUnity i =ᶠ[𝓝 x] f i * ∏ j ∈ t.filter fun j => WellOrderingRel j i, (1 - f j) :=
   f.exists_finset_toPOUFun_eventuallyEq i x

--- a/Mathlib/Topology/Separation.lean
+++ b/Mathlib/Topology/Separation.lean
@@ -124,10 +124,7 @@ If the space is also Lindelöf:
 
 -/
 
-
-
 open Function Set Filter Topology TopologicalSpace
-open scoped Classical
 
 universe u v
 
@@ -807,6 +804,7 @@ theorem Dense.diff_singleton [T1Space X] {s : Set X} (hs : Dense s) (x : X) [NeB
 obtains a dense set. -/
 theorem Dense.diff_finset [T1Space X] [∀ x : X, NeBot (𝓝[≠] x)] {s : Set X} (hs : Dense s)
     (t : Finset X) : Dense (s \ t) := by
+  classical
   induction t using Finset.induction_on with
   | empty => simpa using hs
   | insert _ ih =>
@@ -1138,6 +1136,7 @@ theorem IsCompact.binary_compact_cover {K U V : Set X}
 theorem IsCompact.finite_compact_cover {s : Set X} (hs : IsCompact s) {ι : Type*}
     (t : Finset ι) (U : ι → Set X) (hU : ∀ i ∈ t, IsOpen (U i)) (hsC : s ⊆ ⋃ i ∈ t, U i) :
     ∃ K : ι → Set X, (∀ i, IsCompact (K i)) ∧ (∀ i, K i ⊆ U i) ∧ s = ⋃ i ∈ t, K i := by
+  classical
   induction' t using Finset.induction with x t hx ih generalizing U s
   · refine ⟨fun _ => ∅, fun _ => isCompact_empty, fun i => empty_subset _, ?_⟩
     simpa only [subset_empty_iff, Finset.not_mem_empty, iUnion_false, iUnion_empty] using hsC

--- a/Mathlib/Topology/ShrinkingLemma.lean
+++ b/Mathlib/Topology/ShrinkingLemma.lean
@@ -26,10 +26,7 @@ We prove two versions of the lemma:
 normal space, shrinking lemma
 -/
 
-
 open Set Function
-
-open scoped Classical
 
 noncomputable section
 
@@ -70,9 +67,11 @@ variable {u : ι → Set X} {s : Set X}
 
 instance : CoeFun (PartialRefinement u s) fun _ => ι → Set X := ⟨toFun⟩
 
-protected theorem subset (v : PartialRefinement u s) (i : ι) : v i ⊆ u i :=
-  if h : i ∈ v.carrier then subset_closure.trans (v.closure_subset h) else (v.apply_eq h).le
+protected theorem subset (v : PartialRefinement u s) (i : ι) : v i ⊆ u i := by
+  classical
+  exact if h : i ∈ v.carrier then subset_closure.trans (v.closure_subset h) else (v.apply_eq h).le
 
+open Classical in
 instance : PartialOrder (PartialRefinement u s) where
   le v₁ v₂ := v₁.carrier ⊆ v₂.carrier ∧ ∀ i ∈ v₁.carrier, v₁ i = v₂ i
   le_refl v := ⟨Subset.refl _, fun _ _ => rfl⟩
@@ -98,6 +97,7 @@ their carriers. -/
 def chainSupCarrier (c : Set (PartialRefinement u s)) : Set ι :=
   ⋃ v ∈ c, carrier v
 
+open Classical in
 /-- Choice of an element of a nonempty chain of partial refinements. If `i` belongs to one of
 `carrier v`, `v ∈ c`, then `find c ne i` is one of these partial refinements. -/
 def find (c : Set (PartialRefinement u s)) (ne : c.Nonempty) (i : ι) : PartialRefinement u s :=
@@ -164,6 +164,7 @@ theorem exists_gt (v : PartialRefinement u s) (hs : IsClosed s) (i : ι) (hi : i
   have C : IsClosed (s ∩ ⋂ (j) (_ : j ≠ i), (v j)ᶜ) :=
     IsClosed.inter hs (isClosed_biInter fun _ _ => isClosed_compl_iff.2 <| v.isOpen _)
   rcases normal_exists_closure_subset C (v.isOpen i) I with ⟨vi, ovi, hvi, cvi⟩
+  classical
   refine ⟨⟨update v i vi, insert i v.carrier, ?_, ?_, ?_, ?_⟩, ?_, ?_⟩
   · intro j
     rcases eq_or_ne j i with (rfl| hne) <;> simp [*, v.isOpen]

--- a/Mathlib/Topology/UniformSpace/Cauchy.lean
+++ b/Mathlib/Topology/UniformSpace/Cauchy.lean
@@ -11,14 +11,9 @@ import Mathlib.Topology.UniformSpace.Basic
 # Theory of Cauchy filters in uniform spaces. Complete uniform spaces. Totally bounded subsets.
 -/
 
-
 universe u v
 
-open scoped Classical
-open Filter TopologicalSpace Set UniformSpace Function
-
-open scoped Classical
-open Uniformity Topology Filter
+open Filter Function TopologicalSpace Topology Set UniformSpace Uniformity
 
 variable {α : Type u} {β : Type v} [uniformSpace : UniformSpace α]
 

--- a/Mathlib/Topology/UniformSpace/UniformConvergenceTopology.lean
+++ b/Mathlib/Topology/UniformSpace/UniformConvergenceTopology.lean
@@ -131,10 +131,9 @@ connection API to do most of the work.
 uniform convergence
 -/
 
-
 noncomputable section
 
-open scoped Classical Topology Uniformity
+open scoped Topology Uniformity
 open Set Filter
 
 section TypeAlias

--- a/Mathlib/Topology/UnitInterval.lean
+++ b/Mathlib/Topology/UnitInterval.lean
@@ -19,10 +19,7 @@ We provide basic instances, as well as a custom tactic for discharging
 
 noncomputable section
 
-open scoped Classical
-open Topology Filter
-
-open Set Int Set.Icc
+open Topology Filter Set Int Set.Icc
 
 /-! ### The unit interval -/
 


### PR DESCRIPTION
---

Again, comments with a different preference on how to fix these are welcome.

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
