### PR TITLE
[Merged by Bors] - chore(GroupTheory/Coset): deprecate some lemma

### DIFF
--- a/Mathlib/Algebra/Order/ToIntervalMod.lean
+++ b/Mathlib/Algebra/Order/ToIntervalMod.lean
@@ -665,11 +665,11 @@ end Zero
 @[simps symm_apply]
 def QuotientAddGroup.equivIcoMod (a : α) : α ⧸ AddSubgroup.zmultiples p ≃ Set.Ico a (a + p) where
   toFun b :=
-    ⟨(toIcoMod_periodic hp a).lift b, QuotientAddGroup.induction_on' b <| toIcoMod_mem_Ico hp a⟩
+    ⟨(toIcoMod_periodic hp a).lift b, QuotientAddGroup.induction_on b <| toIcoMod_mem_Ico hp a⟩
   invFun := (↑)
   right_inv b := Subtype.ext <| (toIcoMod_eq_self hp).mpr b.prop
   left_inv b := by
-    induction b using QuotientAddGroup.induction_on'
+    induction b using QuotientAddGroup.induction_on
     dsimp
     rw [QuotientAddGroup.eq_iff_sub_mem, toIcoMod_sub_self]
     apply AddSubgroup.zsmul_mem_zmultiples
@@ -688,11 +688,11 @@ theorem QuotientAddGroup.equivIcoMod_zero (a : α) :
 @[simps symm_apply]
 def QuotientAddGroup.equivIocMod (a : α) : α ⧸ AddSubgroup.zmultiples p ≃ Set.Ioc a (a + p) where
   toFun b :=
-    ⟨(toIocMod_periodic hp a).lift b, QuotientAddGroup.induction_on' b <| toIocMod_mem_Ioc hp a⟩
+    ⟨(toIocMod_periodic hp a).lift b, QuotientAddGroup.induction_on b <| toIocMod_mem_Ioc hp a⟩
   invFun := (↑)
   right_inv b := Subtype.ext <| (toIocMod_eq_self hp).mpr b.prop
   left_inv b := by
-    induction b using QuotientAddGroup.induction_on'
+    induction b using QuotientAddGroup.induction_on
     dsimp
     rw [QuotientAddGroup.eq_iff_sub_mem, toIocMod_sub_self]
     apply AddSubgroup.zsmul_mem_zmultiples
@@ -805,36 +805,36 @@ theorem btw_coe_iff {x₁ x₂ x₃ : α} :
 instance circularPreorder : CircularPreorder (α ⧸ AddSubgroup.zmultiples p) where
   btw_refl x := show _ ≤ _ by simp [sub_self, hp'.out.le]
   btw_cyclic_left {x₁ x₂ x₃} h := by
-    induction x₁ using QuotientAddGroup.induction_on'
-    induction x₂ using QuotientAddGroup.induction_on'
-    induction x₃ using QuotientAddGroup.induction_on'
+    induction x₁ using QuotientAddGroup.induction_on
+    induction x₂ using QuotientAddGroup.induction_on
+    induction x₃ using QuotientAddGroup.induction_on
     simp_rw [btw_coe_iff] at h ⊢
     apply toIxxMod_cyclic_left _ h
   sbtw := _
   sbtw_iff_btw_not_btw := Iff.rfl
   sbtw_trans_left {x₁ x₂ x₃ x₄} (h₁₂₃ : _ ∧ _) (h₂₃₄ : _ ∧ _) :=
     show _ ∧ _ by
-      induction x₁ using QuotientAddGroup.induction_on'
-      induction x₂ using QuotientAddGroup.induction_on'
-      induction x₃ using QuotientAddGroup.induction_on'
-      induction x₄ using QuotientAddGroup.induction_on'
+      induction x₁ using QuotientAddGroup.induction_on
+      induction x₂ using QuotientAddGroup.induction_on
+      induction x₃ using QuotientAddGroup.induction_on
+      induction x₄ using QuotientAddGroup.induction_on
       simp_rw [btw_coe_iff] at h₁₂₃ h₂₃₄ ⊢
       apply toIxxMod_trans _ h₁₂₃ h₂₃₄
 
 instance circularOrder : CircularOrder (α ⧸ AddSubgroup.zmultiples p) :=
   { QuotientAddGroup.circularPreorder with
     btw_antisymm := fun {x₁ x₂ x₃} h₁₂₃ h₃₂₁ => by
-      induction x₁ using QuotientAddGroup.induction_on'
-      induction x₂ using QuotientAddGroup.induction_on'
-      induction x₃ using QuotientAddGroup.induction_on'
+      induction x₁ using QuotientAddGroup.induction_on
+      induction x₂ using QuotientAddGroup.induction_on
+      induction x₃ using QuotientAddGroup.induction_on
       rw [btw_cyclic] at h₃₂₁
       simp_rw [btw_coe_iff] at h₁₂₃ h₃₂₁
       simp_rw [← modEq_iff_eq_mod_zmultiples]
       exact toIxxMod_antisymm _ h₁₂₃ h₃₂₁
     btw_total := fun x₁ x₂ x₃ => by
-      induction x₁ using QuotientAddGroup.induction_on'
-      induction x₂ using QuotientAddGroup.induction_on'
-      induction x₃ using QuotientAddGroup.induction_on'
+      induction x₁ using QuotientAddGroup.induction_on
+      induction x₂ using QuotientAddGroup.induction_on
+      induction x₃ using QuotientAddGroup.induction_on
       simp_rw [btw_coe_iff]
       apply toIxxMod_total }
 

--- a/Mathlib/Algebra/Pointwise/Stabilizer.lean
+++ b/Mathlib/Algebra/Pointwise/Stabilizer.lean
@@ -170,7 +170,7 @@ local notation " q " => ((↑) : G → Q)
 @[to_additive]
 lemma stabilizer_image_coe_quotient : stabilizer Q (q '' s) = ⊥ := by
   ext a
-  induction' a using QuotientGroup.induction_on' with a
+  induction' a using QuotientGroup.induction_on with a
   simp only [mem_stabilizer_iff, Subgroup.mem_bot, QuotientGroup.eq_one_iff]
   have : q a • q '' s = q '' (a • s) :=
     (image_smul_distrib (QuotientGroup.mk' <| stabilizer G s) _ _).symm

--- a/Mathlib/Analysis/Fourier/AddCircle.lean
+++ b/Mathlib/Analysis/Fourier/AddCircle.lean
@@ -123,7 +123,7 @@ theorem fourier_coe_apply' {n : ℤ} {x : ℝ} :
 
 -- @[simp] -- Porting note: simp normal form is `fourier_zero'`
 theorem fourier_zero {x : AddCircle T} : fourier 0 x = 1 := by
-  induction x using QuotientAddGroup.induction_on'
+  induction x using QuotientAddGroup.induction_on
   simp only [fourier_coe_apply]
   norm_num
 
@@ -142,7 +142,7 @@ theorem fourier_one {x : AddCircle T} : fourier 1 x = toCircle x := by rw [fouri
 
 -- @[simp] -- Porting note: simp normal form is `fourier_neg'`
 theorem fourier_neg {n : ℤ} {x : AddCircle T} : fourier (-n) x = conj (fourier n x) := by
-  induction x using QuotientAddGroup.induction_on'
+  induction x using QuotientAddGroup.induction_on
   simp_rw [fourier_apply, toCircle]
   rw [← QuotientAddGroup.mk_zsmul, ← QuotientAddGroup.mk_zsmul]
   simp_rw [Function.Periodic.lift_coe, ← coe_inv_circle_eq_conj, ← expMapCircle_neg,

--- a/Mathlib/Analysis/SpecialFunctions/Complex/Circle.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Complex/Circle.lean
@@ -150,8 +150,8 @@ theorem toCircle_apply_mk (x : ℝ) : @toCircle T x = expMapCircle (2 * π / T *
 
 theorem toCircle_add (x : AddCircle T) (y : AddCircle T) :
     @toCircle T (x + y) = toCircle x * toCircle y := by
-  induction x using QuotientAddGroup.induction_on'
-  induction y using QuotientAddGroup.induction_on'
+  induction x using QuotientAddGroup.induction_on
+  induction y using QuotientAddGroup.induction_on
   simp_rw [← coe_add, toCircle_apply_mk, mul_add, expMapCircle_add]
 
 lemma toCircle_zero : toCircle (0 : AddCircle T) = 1 := by
@@ -162,8 +162,8 @@ theorem continuous_toCircle : Continuous (@toCircle T) :=
 
 theorem injective_toCircle (hT : T ≠ 0) : Function.Injective (@toCircle T) := by
   intro a b h
-  induction a using QuotientAddGroup.induction_on'
-  induction b using QuotientAddGroup.induction_on'
+  induction a using QuotientAddGroup.induction_on
+  induction b using QuotientAddGroup.induction_on
   simp_rw [toCircle_apply_mk] at h
   obtain ⟨m, hm⟩ := expMapCircle_eq_expMapCircle.mp h.symm
   rw [QuotientAddGroup.eq]; simp_rw [AddSubgroup.mem_zmultiples_iff, zsmul_eq_mul]
@@ -194,7 +194,7 @@ noncomputable def homeomorphCircle (hT : T ≠ 0) : AddCircle T ≃ₜ circle :=
 
 theorem homeomorphCircle_apply (hT : T ≠ 0) (x : AddCircle T) :
     homeomorphCircle hT x = toCircle x := by
-  induction' x using QuotientAddGroup.induction_on' with x
+  induction' x using QuotientAddGroup.induction_on with x
   rw [homeomorphCircle, Homeomorph.trans_apply,
     homeomorphAddCircle_apply_mk, homeomorphCircle'_apply_mk, toCircle_apply_mk]
   ring_nf

--- a/Mathlib/Data/ZMod/Quotient.lean
+++ b/Mathlib/Data/ZMod/Quotient.lean
@@ -92,11 +92,11 @@ noncomputable def zmultiplesQuotientStabilizerEquiv :
               exact isPeriodicPt_minimalPeriod (a +ᵥ ·) b))
           ⟨by
             rw [← ker_eq_bot_iff, eq_bot_iff]
-            refine fun q => induction_on' q fun n hn => ?_
+            refine fun q => induction_on q fun n hn => ?_
             rw [mem_bot, eq_zero_iff, Int.mem_zmultiples_iff, ←
               zsmul_vadd_eq_iff_minimalPeriod_dvd]
             exact (eq_zero_iff _).mp hn, fun q =>
-            induction_on' q fun ⟨_, n, rfl⟩ => ⟨n, rfl⟩⟩).symm.trans
+            induction_on q fun ⟨_, n, rfl⟩ => ⟨n, rfl⟩⟩).symm.trans
     (Int.quotientZMultiplesNatEquivZMod (minimalPeriod (a +ᵥ ·) b))
 
 theorem zmultiplesQuotientStabilizerEquiv_symm_apply (n : ZMod (minimalPeriod (a +ᵥ ·) b)) :

--- a/Mathlib/GroupTheory/Commensurable.lean
+++ b/Mathlib/GroupTheory/Commensurable.lean
@@ -56,7 +56,7 @@ def quotConjEquiv (H K : Subgroup G) (g : ConjAct G) :
     K ⧸ H.subgroupOf K ≃ (g • K).1 ⧸ (g • H).subgroupOf (g • K) :=
   Quotient.congr (K.equivSMul g).toEquiv fun a b => by
     dsimp
-    rw [← Quotient.eq'', ← Quotient.eq'', QuotientGroup.eq', QuotientGroup.eq',
+    rw [← Quotient.eq'', ← Quotient.eq'', QuotientGroup.eq, QuotientGroup.eq,
       Subgroup.mem_subgroupOf, Subgroup.mem_subgroupOf, ← MulEquiv.map_inv, ← MulEquiv.map_mul,
       Subgroup.equivSMul_apply_coe]
     exact Subgroup.smul_mem_pointwise_smul_iff.symm

--- a/Mathlib/GroupTheory/Complement.lean
+++ b/Mathlib/GroupTheory/Complement.lean
@@ -201,7 +201,7 @@ theorem mem_leftTransversals_iff_existsUnique_quotient_mk''_eq :
     S ∈ leftTransversals (H : Set G) ↔
       ∀ q : Quotient (QuotientGroup.leftRel H), ∃! s : S, Quotient.mk'' s.1 = q := by
   simp_rw [mem_leftTransversals_iff_existsUnique_inv_mul_mem, SetLike.mem_coe, ←
-    QuotientGroup.eq']
+    QuotientGroup.eq]
   exact ⟨fun h q => Quotient.inductionOn' q h, fun h g => h (Quotient.mk'' g)⟩
 
 @[to_additive]

--- a/Mathlib/GroupTheory/Coset.lean
+++ b/Mathlib/GroupTheory/Coset.lean
@@ -408,13 +408,13 @@ variable (s)
   stated in terms of an arbitrary `h : s`, rather than the specific `h = g⁻¹ * (mk g).out'`. -/
 @[to_additive QuotientAddGroup.mk_out'_eq_mul]
 theorem mk_out'_eq_mul (g : α) : ∃ h : s, (mk g : α ⧸ s).out' = g * h :=
-  ⟨⟨g⁻¹ * (mk g).out', eq'.mp (mk g).out_eq'.symm⟩, by rw [mul_inv_cancel_left]⟩
+  ⟨⟨g⁻¹ * (mk g).out', QuotientGroup.eq.mp (mk g).out_eq'.symm⟩, by rw [mul_inv_cancel_left]⟩
 
 variable {s} {a b : α}
 
 @[to_additive (attr := simp)]
 theorem mk_mul_of_mem (a : α) (hb : b ∈ s) : (mk (a * b) : α ⧸ s) = mk a := by
-  rwa [eq', mul_inv_rev, inv_mul_cancel_right, s.inv_mem_iff]
+  rwa [QuotientGroup.eq, mul_inv_rev, inv_mul_cancel_right, s.inv_mem_iff]
 
 @[to_additive]
 theorem eq_class_eq_leftCoset (s : Subgroup α) (g : α) :

--- a/Mathlib/GroupTheory/Coset.lean
+++ b/Mathlib/GroupTheory/Coset.lean
@@ -353,7 +353,7 @@ instance fintype [Fintype α] (s : Subgroup α) [DecidableRel (leftRel s).r] : F
 
 /-- The canonical map from a group `α` to the quotient `α ⧸ s`. -/
 @[to_additive (attr := coe) "The canonical map from an `AddGroup` `α` to the quotient `α ⧸ s`."]
-abbrev mk (a : α) : α ⧸ s :=
+def mk (a : α) : α ⧸ s :=
   Quotient.mk'' a
 
 @[to_additive]
@@ -367,13 +367,17 @@ lemma range_mk : range (QuotientGroup.mk (s := s)) = univ := range_iff_surjectiv
 theorem induction_on {C : α ⧸ s → Prop} (x : α ⧸ s) (H : ∀ z, C (QuotientGroup.mk z)) : C x :=
   Quotient.inductionOn' x H
 
+@[to_additive (attr := elab_as_elim)]
+theorem induction_on₂ {α β : Type*} [Group α] [Group β] {s : Subgroup α} {t : Subgroup β}
+    {C : α ⧸ s → β ⧸ t → Prop} (x : α ⧸ s) (y : β ⧸ t)
+    (H : ∀ z₁ z₂, C (QuotientGroup.mk z₁) (QuotientGroup.mk z₂)) : C x y :=
+  Quotient.inductionOn₂' x y H
+
 @[to_additive]
 instance : Coe α (α ⧸ s) :=
   ⟨mk⟩
 
-@[to_additive (attr := elab_as_elim)]
-theorem induction_on' {C : α ⧸ s → Prop} (x : α ⧸ s) (H : ∀ z : α, C z) : C x :=
-  Quotient.inductionOn' x H
+@[to_additive (attr := deprecated (since := "2024-08-04"))] alias induction_on' := induction_on
 
 @[to_additive (attr := simp)]
 theorem quotient_liftOn_mk {β} (f : α → β) (h) (x : α) : Quotient.liftOn' (x : α ⧸ s) f h = f x :=
@@ -397,13 +401,27 @@ protected theorem eq {a b : α} : (a : α ⧸ s) = b ↔ a⁻¹ * b ∈ s :=
     _ ↔ @Setoid.r _ (leftRel s) a b := Quotient.eq''
     _ ↔ _ := by rw [leftRel_apply]
 
-@[to_additive]
-theorem eq' {a b : α} : (mk a : α ⧸ s) = mk b ↔ a⁻¹ * b ∈ s :=
-  QuotientGroup.eq
+@[to_additive (attr := deprecated (since := "2024-08-04"))] alias eq' := QuotientGroup.eq
 
-@[to_additive] -- Porting note (#10618): `simp` can prove this.
+@[to_additive (attr := simp)]
 theorem out_eq' (a : α ⧸ s) : mk a.out' = a :=
   Quotient.out_eq' a
+
+/-- The canonical map from the quotient `α ⧸ s` to the quotient `β ⧸ t`. -/
+@[to_additive "The canonical map from an `AddGroup` `α` to the quotient `α ⧸ s`."]
+protected def map' {α β : Type*} [Group α] [Group β] {s : Subgroup α} {t : Subgroup β} (f : α →* β)
+    (h : s ≤ t.comap f) : α ⧸ s → β ⧸ t :=
+  Quotient.map' f (by
+    intro a b
+    simp_rw [leftRel_eq]
+    intro hs
+    simpa using h hs)
+
+@[to_additive (attr := simp)]
+theorem map'_mk {α β : Type*} [Group α] [Group β] {s : Subgroup α} {t : Subgroup β} (f : α →* β)
+    (h : s ≤ Subgroup.comap f t) (x : α) :
+    QuotientGroup.map' f h (x : α ⧸ s) = f x :=
+  rfl
 
 variable (s)
 
@@ -412,13 +430,13 @@ variable (s)
   stated in terms of an arbitrary `h : s`, rather than the specific `h = g⁻¹ * (mk g).out'`. -/
 @[to_additive QuotientAddGroup.mk_out'_eq_mul]
 theorem mk_out'_eq_mul (g : α) : ∃ h : s, (mk g : α ⧸ s).out' = g * h :=
-  ⟨⟨g⁻¹ * (mk g).out', eq'.mp (mk g).out_eq'.symm⟩, by rw [mul_inv_cancel_left]⟩
+  ⟨⟨g⁻¹ * (mk g).out', QuotientGroup.eq.mp (mk g).out_eq'.symm⟩, by rw [mul_inv_cancel_left]⟩
 
 variable {s} {a b : α}
 
 @[to_additive (attr := simp)]
 theorem mk_mul_of_mem (a : α) (hb : b ∈ s) : (mk (a * b) : α ⧸ s) = mk a := by
-  rwa [eq', mul_inv_rev, inv_mul_cancel_right, s.inv_mem_iff]
+  rwa [QuotientGroup.eq, mul_inv_rev, inv_mul_cancel_right, s.inv_mem_iff]
 
 @[to_additive]
 theorem eq_class_eq_leftCoset (s : Subgroup α) (g : α) :
@@ -484,25 +502,25 @@ variable {t : Subgroup α}
 /-- If two subgroups `M` and `N` of `G` are equal, their quotients are in bijection. -/
 @[to_additive "If two subgroups `M` and `N` of `G` are equal, their quotients are in bijection."]
 def quotientEquivOfEq (h : s = t) : α ⧸ s ≃ α ⧸ t where
-  toFun := Quotient.map' id fun _a _b h' => h ▸ h'
-  invFun := Quotient.map' id fun _a _b h' => h.symm ▸ h'
-  left_inv q := induction_on' q fun _g => rfl
-  right_inv q := induction_on' q fun _g => rfl
+  toFun := QuotientGroup.map' (.id _) h.le
+  invFun := QuotientGroup.map' (.id _) h.symm.le
+  left_inv q := induction_on q fun _g => rfl
+  right_inv q := induction_on q fun _g => rfl
 
 theorem quotientEquivOfEq_mk (h : s = t) (a : α) :
     quotientEquivOfEq h (QuotientGroup.mk a) = QuotientGroup.mk a :=
   rfl
 
 /-- If `H ≤ K`, then `G/H ≃ G/K × K/H` constructively, using the provided right inverse
-of the quotient map `G → G/K`. The classical version is `Subgroup.quotientEquivProdOfLE`. -/
-@[to_additive (attr := simps)
+of the quotient map `G/K → G`. The classical version is `Subgroup.quotientEquivProdOfLE`. -/
+@[to_additive (attr := simps) AddSubgroup.quotientEquivProdOfLE'
   "If `H ≤ K`, then `G/H ≃ G/K × K/H` constructively, using the provided right inverse
-  of the quotient map `G → G/K`. The classical version is `AddSubgroup.quotientEquivSumOfLE`."]
+  of the quotient map `G/K → G`. The classical version is `AddSubgroup.quotientEquivSumOfLE`."]
 def quotientEquivProdOfLE' (h_le : s ≤ t) (f : α ⧸ t → α)
     (hf : Function.RightInverse f QuotientGroup.mk) : α ⧸ s ≃ (α ⧸ t) × t ⧸ s.subgroupOf t where
   toFun a :=
-    ⟨a.map' id fun b c h => leftRel_apply.mpr (h_le (leftRel_apply.mp h)),
-      a.map' (fun g : α => ⟨(f (Quotient.mk'' g))⁻¹ * g, leftRel_apply.mp (Quotient.exact' (hf g))⟩)
+    ⟨QuotientGroup.map' (.id _) h_le a,
+      a.map' (fun g : α => ⟨(f g)⁻¹ * g, leftRel_apply.mp (Quotient.exact' (hf g))⟩)
         fun b c h => by
         rw [leftRel_apply]
         change ((f b)⁻¹ * b)⁻¹ * ((f c)⁻¹ * c) ∈ s
@@ -516,19 +534,20 @@ def quotientEquivProdOfLE' (h_le : s ≤ t) (f : α ⧸ t → α)
       rwa [mul_inv_rev, mul_assoc, inv_mul_cancel_left]
   left_inv := by
     refine Quotient.ind' fun a => ?_
-    simp_rw [Quotient.map'_mk'', id, mul_inv_cancel_left]
+    simp [QuotientGroup.map', QuotientGroup.mk, Quotient.map'_mk'', mul_inv_cancel_left]
   right_inv := by
     refine Prod.rec ?_
     refine Quotient.ind' fun a => ?_
     refine Quotient.ind' fun b => ?_
     have key : Quotient.mk'' (f (Quotient.mk'' a) * b) = Quotient.mk'' a :=
       (QuotientGroup.mk_mul_of_mem (f a) b.2).trans (hf a)
-    simp_rw [Quotient.map'_mk'', id, key, inv_mul_cancel_left]
+    simp [QuotientGroup.map', QuotientGroup.mk, Quotient.map'_mk'', key, inv_mul_cancel_left]
 
 /-- If `H ≤ K`, then `G/H ≃ G/K × K/H` nonconstructively.
 The constructive version is `quotientEquivProdOfLE'`. -/
-@[to_additive (attr := simps!) "If `H ≤ K`, then `G/H ≃ G/K × K/H` nonconstructively. The
- constructive version is `quotientEquivProdOfLE'`."]
+@[to_additive (attr := simps!) AddSubgroup.quotientEquivProdOfLE
+"If `H ≤ K`, then `G/H ≃ G/K × K/H` nonconstructively. The
+constructive version is `quotientEquivProdOfLE'`."]
 noncomputable def quotientEquivProdOfLE (h_le : s ≤ t) : α ⧸ s ≃ (α ⧸ t) × t ⧸ s.subgroupOf t :=
   quotientEquivProdOfLE' h_le Quotient.out' Quotient.out_eq'
 
@@ -538,13 +557,12 @@ noncomputable def quotientEquivProdOfLE (h_le : s ≤ t) : α ⧸ s ≃ (α ⧸ 
 def quotientSubgroupOfEmbeddingOfLE (H : Subgroup α) (h : s ≤ t) :
     s ⧸ H.subgroupOf s ↪ t ⧸ H.subgroupOf t where
   toFun :=
-    Quotient.map' (inclusion h) fun a b => by
-      simp_rw [leftRel_eq]
-      exact id
-  inj' :=
-    Quotient.ind₂' <| by
+    QuotientGroup.map' (inclusion h) fun a b => by
+      simpa only [comap_inclusion_subgroupOf]
+  inj' a b :=
+    QuotientGroup.induction_on₂ a b <| by
       intro a b h
-      simpa only [Quotient.map'_mk'', eq'] using h
+      simpa only [map'_mk, QuotientGroup.eq] using h
 
 -- Porting note: I had to add the type ascription to the right-hand side or else Lean times out.
 @[to_additive (attr := simp)]
@@ -571,9 +589,7 @@ theorem quotientSubgroupOfMapOfLE_apply_mk (H : Subgroup α) (h : s ≤ t) (g : 
 /-- If `s ≤ t`, then there is a map `α ⧸ s → α ⧸ t`. -/
 @[to_additive "If `s ≤ t`, then there is a map `α ⧸ s → α ⧸ t`."]
 def quotientMapOfLE (h : s ≤ t) : α ⧸ s → α ⧸ t :=
-  Quotient.map' id fun a b => by
-    simp_rw [leftRel_eq]
-    apply h
+  QuotientGroup.map' (.id _) fun _ => (h ·)
 
 @[to_additive (attr := simp)]
 theorem quotientMapOfLE_apply_mk (h : s ≤ t) (g : α) :
@@ -586,10 +602,10 @@ theorem quotientMapOfLE_apply_mk (h : s ≤ t) (g : α) :
 def quotientiInfSubgroupOfEmbedding {ι : Type*} (f : ι → Subgroup α) (H : Subgroup α) :
     H ⧸ (⨅ i, f i).subgroupOf H ↪ ∀ i, H ⧸ (f i).subgroupOf H where
   toFun q i := quotientSubgroupOfMapOfLE H (iInf_le f i) q
-  inj' :=
-    Quotient.ind₂' <| by
-      simp_rw [funext_iff, quotientSubgroupOfMapOfLE_apply_mk, eq', mem_subgroupOf, mem_iInf,
-        imp_self, forall_const]
+  inj' a b :=
+    QuotientGroup.induction_on₂ a b <| by
+      simp_rw [funext_iff, quotientSubgroupOfMapOfLE_apply_mk, QuotientGroup.eq, mem_subgroupOf,
+        mem_iInf, imp_self, forall_const]
 
 -- Porting note: I had to add the type ascription to the right-hand side or else Lean times out.
 @[to_additive (attr := simp)]
@@ -603,9 +619,10 @@ theorem quotientiInfSubgroupOfEmbedding_apply_mk {ι : Type*} (f : ι → Subgro
 @[to_additive (attr := simps) "The natural embedding `α ⧸ (⨅ i, f i) ↪ Π i, α ⧸ f i`."]
 def quotientiInfEmbedding {ι : Type*} (f : ι → Subgroup α) : (α ⧸ ⨅ i, f i) ↪ ∀ i, α ⧸ f i where
   toFun q i := quotientMapOfLE (iInf_le f i) q
-  inj' :=
-    Quotient.ind₂' <| by
-      simp_rw [funext_iff, quotientMapOfLE_apply_mk, eq', mem_iInf, imp_self, forall_const]
+  inj' a b :=
+    QuotientGroup.induction_on₂ a b <| by
+      simp_rw [funext_iff, quotientMapOfLE_apply_mk, QuotientGroup.eq, mem_iInf, imp_self,
+        forall_const]
 
 @[to_additive (attr := simp)]
 theorem quotientiInfEmbedding_apply_mk {ι : Type*} (f : ι → Subgroup α) (g : α) (i : ι) :

--- a/Mathlib/GroupTheory/Coset.lean
+++ b/Mathlib/GroupTheory/Coset.lean
@@ -353,7 +353,7 @@ instance fintype [Fintype α] (s : Subgroup α) [DecidableRel (leftRel s).r] : F
 
 /-- The canonical map from a group `α` to the quotient `α ⧸ s`. -/
 @[to_additive (attr := coe) "The canonical map from an `AddGroup` `α` to the quotient `α ⧸ s`."]
-def mk (a : α) : α ⧸ s :=
+abbrev mk (a : α) : α ⧸ s :=
   Quotient.mk'' a
 
 @[to_additive]
@@ -366,12 +366,6 @@ lemma range_mk : range (QuotientGroup.mk (s := s)) = univ := range_iff_surjectiv
 @[to_additive (attr := elab_as_elim)]
 theorem induction_on {C : α ⧸ s → Prop} (x : α ⧸ s) (H : ∀ z, C (QuotientGroup.mk z)) : C x :=
   Quotient.inductionOn' x H
-
-@[to_additive (attr := elab_as_elim)]
-theorem induction_on₂ {α β : Type*} [Group α] [Group β] {s : Subgroup α} {t : Subgroup β}
-    {C : α ⧸ s → β ⧸ t → Prop} (x : α ⧸ s) (y : β ⧸ t)
-    (H : ∀ z₁ z₂, C (QuotientGroup.mk z₁) (QuotientGroup.mk z₂)) : C x y :=
-  Quotient.inductionOn₂' x y H
 
 @[to_additive]
 instance : Coe α (α ⧸ s) :=
@@ -403,25 +397,9 @@ protected theorem eq {a b : α} : (a : α ⧸ s) = b ↔ a⁻¹ * b ∈ s :=
 
 @[to_additive (attr := deprecated (since := "2024-08-04"))] alias eq' := QuotientGroup.eq
 
-@[to_additive (attr := simp)]
+@[to_additive] -- Porting note (#10618): `simp` can prove this.
 theorem out_eq' (a : α ⧸ s) : mk a.out' = a :=
   Quotient.out_eq' a
-
-/-- The canonical map from the quotient `α ⧸ s` to the quotient `β ⧸ t`. -/
-@[to_additive "The canonical map from an `AddGroup` `α` to the quotient `α ⧸ s`."]
-protected def map' {α β : Type*} [Group α] [Group β] {s : Subgroup α} {t : Subgroup β} (f : α →* β)
-    (h : s ≤ t.comap f) : α ⧸ s → β ⧸ t :=
-  Quotient.map' f (by
-    intro a b
-    simp_rw [leftRel_eq]
-    intro hs
-    simpa using h hs)
-
-@[to_additive (attr := simp)]
-theorem map'_mk {α β : Type*} [Group α] [Group β] {s : Subgroup α} {t : Subgroup β} (f : α →* β)
-    (h : s ≤ Subgroup.comap f t) (x : α) :
-    QuotientGroup.map' f h (x : α ⧸ s) = f x :=
-  rfl
 
 variable (s)
 
@@ -430,13 +408,13 @@ variable (s)
   stated in terms of an arbitrary `h : s`, rather than the specific `h = g⁻¹ * (mk g).out'`. -/
 @[to_additive QuotientAddGroup.mk_out'_eq_mul]
 theorem mk_out'_eq_mul (g : α) : ∃ h : s, (mk g : α ⧸ s).out' = g * h :=
-  ⟨⟨g⁻¹ * (mk g).out', QuotientGroup.eq.mp (mk g).out_eq'.symm⟩, by rw [mul_inv_cancel_left]⟩
+  ⟨⟨g⁻¹ * (mk g).out', eq'.mp (mk g).out_eq'.symm⟩, by rw [mul_inv_cancel_left]⟩
 
 variable {s} {a b : α}
 
 @[to_additive (attr := simp)]
 theorem mk_mul_of_mem (a : α) (hb : b ∈ s) : (mk (a * b) : α ⧸ s) = mk a := by
-  rwa [QuotientGroup.eq, mul_inv_rev, inv_mul_cancel_right, s.inv_mem_iff]
+  rwa [eq', mul_inv_rev, inv_mul_cancel_right, s.inv_mem_iff]
 
 @[to_additive]
 theorem eq_class_eq_leftCoset (s : Subgroup α) (g : α) :
@@ -502,8 +480,8 @@ variable {t : Subgroup α}
 /-- If two subgroups `M` and `N` of `G` are equal, their quotients are in bijection. -/
 @[to_additive "If two subgroups `M` and `N` of `G` are equal, their quotients are in bijection."]
 def quotientEquivOfEq (h : s = t) : α ⧸ s ≃ α ⧸ t where
-  toFun := QuotientGroup.map' (.id _) h.le
-  invFun := QuotientGroup.map' (.id _) h.symm.le
+  toFun := Quotient.map' id fun _a _b h' => h ▸ h'
+  invFun := Quotient.map' id fun _a _b h' => h.symm ▸ h'
   left_inv q := induction_on q fun _g => rfl
   right_inv q := induction_on q fun _g => rfl
 
@@ -512,15 +490,15 @@ theorem quotientEquivOfEq_mk (h : s = t) (a : α) :
   rfl
 
 /-- If `H ≤ K`, then `G/H ≃ G/K × K/H` constructively, using the provided right inverse
-of the quotient map `G/K → G`. The classical version is `Subgroup.quotientEquivProdOfLE`. -/
-@[to_additive (attr := simps) AddSubgroup.quotientEquivProdOfLE'
+of the quotient map `G → G/K`. The classical version is `Subgroup.quotientEquivProdOfLE`. -/
+@[to_additive (attr := simps)
   "If `H ≤ K`, then `G/H ≃ G/K × K/H` constructively, using the provided right inverse
-  of the quotient map `G/K → G`. The classical version is `AddSubgroup.quotientEquivSumOfLE`."]
+  of the quotient map `G → G/K`. The classical version is `AddSubgroup.quotientEquivSumOfLE`."]
 def quotientEquivProdOfLE' (h_le : s ≤ t) (f : α ⧸ t → α)
     (hf : Function.RightInverse f QuotientGroup.mk) : α ⧸ s ≃ (α ⧸ t) × t ⧸ s.subgroupOf t where
   toFun a :=
-    ⟨QuotientGroup.map' (.id _) h_le a,
-      a.map' (fun g : α => ⟨(f g)⁻¹ * g, leftRel_apply.mp (Quotient.exact' (hf g))⟩)
+    ⟨a.map' id fun b c h => leftRel_apply.mpr (h_le (leftRel_apply.mp h)),
+      a.map' (fun g : α => ⟨(f (Quotient.mk'' g))⁻¹ * g, leftRel_apply.mp (Quotient.exact' (hf g))⟩)
         fun b c h => by
         rw [leftRel_apply]
         change ((f b)⁻¹ * b)⁻¹ * ((f c)⁻¹ * c) ∈ s
@@ -534,20 +512,19 @@ def quotientEquivProdOfLE' (h_le : s ≤ t) (f : α ⧸ t → α)
       rwa [mul_inv_rev, mul_assoc, inv_mul_cancel_left]
   left_inv := by
     refine Quotient.ind' fun a => ?_
-    simp [QuotientGroup.map', QuotientGroup.mk, Quotient.map'_mk'', mul_inv_cancel_left]
+    simp_rw [Quotient.map'_mk'', id, mul_inv_cancel_left]
   right_inv := by
     refine Prod.rec ?_
     refine Quotient.ind' fun a => ?_
     refine Quotient.ind' fun b => ?_
     have key : Quotient.mk'' (f (Quotient.mk'' a) * b) = Quotient.mk'' a :=
       (QuotientGroup.mk_mul_of_mem (f a) b.2).trans (hf a)
-    simp [QuotientGroup.map', QuotientGroup.mk, Quotient.map'_mk'', key, inv_mul_cancel_left]
+    simp_rw [Quotient.map'_mk'', id, key, inv_mul_cancel_left]
 
 /-- If `H ≤ K`, then `G/H ≃ G/K × K/H` nonconstructively.
 The constructive version is `quotientEquivProdOfLE'`. -/
-@[to_additive (attr := simps!) AddSubgroup.quotientEquivProdOfLE
-"If `H ≤ K`, then `G/H ≃ G/K × K/H` nonconstructively. The
-constructive version is `quotientEquivProdOfLE'`."]
+@[to_additive (attr := simps!) "If `H ≤ K`, then `G/H ≃ G/K × K/H` nonconstructively. The
+ constructive version is `quotientEquivProdOfLE'`."]
 noncomputable def quotientEquivProdOfLE (h_le : s ≤ t) : α ⧸ s ≃ (α ⧸ t) × t ⧸ s.subgroupOf t :=
   quotientEquivProdOfLE' h_le Quotient.out' Quotient.out_eq'
 
@@ -557,12 +534,13 @@ noncomputable def quotientEquivProdOfLE (h_le : s ≤ t) : α ⧸ s ≃ (α ⧸ 
 def quotientSubgroupOfEmbeddingOfLE (H : Subgroup α) (h : s ≤ t) :
     s ⧸ H.subgroupOf s ↪ t ⧸ H.subgroupOf t where
   toFun :=
-    QuotientGroup.map' (inclusion h) fun a b => by
-      simpa only [comap_inclusion_subgroupOf]
-  inj' a b :=
-    QuotientGroup.induction_on₂ a b <| by
+    Quotient.map' (inclusion h) fun a b => by
+      simp_rw [leftRel_eq]
+      exact id
+  inj' :=
+    Quotient.ind₂' <| by
       intro a b h
-      simpa only [map'_mk, QuotientGroup.eq] using h
+      simpa only [Quotient.map'_mk'', QuotientGroup.eq] using h
 
 -- Porting note: I had to add the type ascription to the right-hand side or else Lean times out.
 @[to_additive (attr := simp)]
@@ -589,7 +567,9 @@ theorem quotientSubgroupOfMapOfLE_apply_mk (H : Subgroup α) (h : s ≤ t) (g : 
 /-- If `s ≤ t`, then there is a map `α ⧸ s → α ⧸ t`. -/
 @[to_additive "If `s ≤ t`, then there is a map `α ⧸ s → α ⧸ t`."]
 def quotientMapOfLE (h : s ≤ t) : α ⧸ s → α ⧸ t :=
-  QuotientGroup.map' (.id _) fun _ => (h ·)
+  Quotient.map' id fun a b => by
+    simp_rw [leftRel_eq]
+    apply h
 
 @[to_additive (attr := simp)]
 theorem quotientMapOfLE_apply_mk (h : s ≤ t) (g : α) :
@@ -602,8 +582,8 @@ theorem quotientMapOfLE_apply_mk (h : s ≤ t) (g : α) :
 def quotientiInfSubgroupOfEmbedding {ι : Type*} (f : ι → Subgroup α) (H : Subgroup α) :
     H ⧸ (⨅ i, f i).subgroupOf H ↪ ∀ i, H ⧸ (f i).subgroupOf H where
   toFun q i := quotientSubgroupOfMapOfLE H (iInf_le f i) q
-  inj' a b :=
-    QuotientGroup.induction_on₂ a b <| by
+  inj' :=
+    Quotient.ind₂' <| by
       simp_rw [funext_iff, quotientSubgroupOfMapOfLE_apply_mk, QuotientGroup.eq, mem_subgroupOf,
         mem_iInf, imp_self, forall_const]
 
@@ -619,8 +599,8 @@ theorem quotientiInfSubgroupOfEmbedding_apply_mk {ι : Type*} (f : ι → Subgro
 @[to_additive (attr := simps) "The natural embedding `α ⧸ (⨅ i, f i) ↪ Π i, α ⧸ f i`."]
 def quotientiInfEmbedding {ι : Type*} (f : ι → Subgroup α) : (α ⧸ ⨅ i, f i) ↪ ∀ i, α ⧸ f i where
   toFun q i := quotientMapOfLE (iInf_le f i) q
-  inj' a b :=
-    QuotientGroup.induction_on₂ a b <| by
+  inj' :=
+    Quotient.ind₂' <| by
       simp_rw [funext_iff, quotientMapOfLE_apply_mk, QuotientGroup.eq, mem_iInf, imp_self,
         forall_const]
 

--- a/Mathlib/GroupTheory/GroupAction/Quotient.lean
+++ b/Mathlib/GroupTheory/GroupAction/Quotient.lean
@@ -99,7 +99,7 @@ theorem Quotient.coe_smul_out' [QuotientAction β H] (b : β) (q : α ⧸ H) : �
 
 theorem _root_.QuotientGroup.out'_conj_pow_minimalPeriod_mem (a : α) (q : α ⧸ H) :
     q.out'⁻¹ * a ^ Function.minimalPeriod (a • ·) q * q.out' ∈ H := by
-  rw [mul_assoc, ← QuotientGroup.eq', QuotientGroup.out_eq', ← smul_eq_mul, Quotient.mk_smul_out',
+  rw [mul_assoc, ← QuotientGroup.eq, QuotientGroup.out_eq', ← smul_eq_mul, Quotient.mk_smul_out',
     eq_comm, pow_smul_eq_iff_minimalPeriod_dvd]
 
 end QuotientAction

--- a/Mathlib/GroupTheory/QuotientGroup.lean
+++ b/Mathlib/GroupTheory/QuotientGroup.lean
@@ -83,7 +83,7 @@ theorem mk'_surjective : Surjective <| mk' N :=
 
 @[to_additive]
 theorem mk'_eq_mk' {x y : G} : mk' N x = mk' N y ↔ ∃ z ∈ N, x * z = y :=
-  QuotientGroup.eq'.trans <| by
+  QuotientGroup.eq.trans <| by
     simp only [← _root_.eq_inv_mul_iff_mul_eq, exists_prop, exists_eq_right]
 
 open scoped Pointwise in
@@ -217,7 +217,7 @@ theorem map_mk' (M : Subgroup H) [M.Normal] (f : G →* H) (h : N ≤ M.comap f)
 @[to_additive]
 theorem map_id_apply (h : N ≤ Subgroup.comap (MonoidHom.id _) N := (Subgroup.comap_id N).le) (x) :
     map N N (MonoidHom.id _) h x = x :=
-  induction_on' x fun _x => rfl
+  induction_on x fun _x => rfl
 
 @[to_additive (attr := simp)]
 theorem map_id (h : N ≤ Subgroup.comap (MonoidHom.id _) N := (Subgroup.comap_id N).le) :
@@ -230,7 +230,7 @@ theorem map_map {I : Type*} [Group I] (M : Subgroup H) (O : Subgroup I) [M.Norma
     (hgf : N ≤ Subgroup.comap (g.comp f) O :=
       hf.trans ((Subgroup.comap_mono hg).trans_eq (Subgroup.comap_comap _ _ _)))
     (x : G ⧸ N) : map M O g hg (map N M f hf x) = map N O (g.comp f) hgf x := by
-  refine induction_on' x fun x => ?_
+  refine induction_on x fun x => ?_
   simp only [map_mk, MonoidHom.comp_apply]
 
 @[to_additive (attr := simp)]

--- a/Mathlib/GroupTheory/Torsion.lean
+++ b/Mathlib/GroupTheory/Torsion.lean
@@ -372,7 +372,7 @@ variable (G) [CommGroup G]
       "Quotienting a group by its additive torsion subgroup yields an additive torsion free group."]
 theorem IsTorsionFree.quotient_torsion : IsTorsionFree <| G ⧸ torsion G := fun g hne hfin =>
   hne <| by
-    induction' g using QuotientGroup.induction_on' with g
+    induction' g using QuotientGroup.induction_on with g
     obtain ⟨m, mpos, hm⟩ := hfin.exists_pow_eq_one
     obtain ⟨n, npos, hn⟩ := ((QuotientGroup.eq_one_iff _).mp hm).exists_pow_eq_one
     exact

--- a/Mathlib/LinearAlgebra/Alternating/DomCoprod.lean
+++ b/Mathlib/LinearAlgebra/Alternating/DomCoprod.lean
@@ -229,7 +229,7 @@ theorem MultilinearMap.domCoprod_alternization [DecidableEq ιa] [DecidableEq ι
       (QuotientGroup.leftRelDecidable (MonoidHom.range (Perm.sumCongrHom ιa ιb)))
       (Quotient.mk (QuotientGroup.leftRel (MonoidHom.range (Perm.sumCongrHom ιa ιb))) a)
       (Quotient.mk'' σ)) _ (s := Finset.univ)
-    fun x _ => QuotientGroup.eq' (s := MonoidHom.range (Perm.sumCongrHom ιa ιb)) (a := x) (b := σ)]
+    fun x _ => QuotientGroup.eq (s := MonoidHom.range (Perm.sumCongrHom ιa ιb)) (a := x) (b := σ)]
   -- eliminate a multiplication
   rw [← Finset.map_univ_equiv (Equiv.mulLeft σ), Finset.filter_map, Finset.sum_map]
   simp_rw [Equiv.coe_toEmbedding, Equiv.coe_mulLeft, (· ∘ ·), mul_inv_rev, inv_mul_cancel_right,

--- a/Mathlib/NumberTheory/LSeries/HurwitzZetaEven.lean
+++ b/Mathlib/NumberTheory/LSeries/HurwitzZetaEven.lean
@@ -81,7 +81,7 @@ lemma evenKernel_def (a x : ℝ) :
 /-- For `x ≤ 0` the defining sum diverges, so the kernel is 0. -/
 lemma evenKernel_undef (a : UnitAddCircle) {x : ℝ} (hx : x ≤ 0) : evenKernel a x = 0 := by
   have : (I * ↑x).im ≤ 0 := by rwa [I_mul_im, ofReal_re]
-  induction' a using QuotientAddGroup.induction_on' with a'
+  induction' a using QuotientAddGroup.induction_on with a'
   rw [← ofReal_inj, evenKernel_def, jacobiTheta₂_undef _ this, mul_zero, ofReal_zero]
 
 /-- Cosine Hurwitz zeta kernel. See `cosKernel_def` for the defining formula, and
@@ -96,7 +96,7 @@ lemma cosKernel_def (a x : ℝ) : ↑(cosKernel ↑a x) = jacobiTheta₂ a (I * 
     conj_I, neg_mul, neg_neg, ← mul_two, mul_div_cancel_right₀ _ (two_ne_zero' ℂ)]
 
 lemma cosKernel_undef (a : UnitAddCircle) {x : ℝ} (hx : x ≤ 0) : cosKernel a x = 0 := by
-  induction' a using QuotientAddGroup.induction_on' with a'
+  induction' a using QuotientAddGroup.induction_on with a'
   rw [← ofReal_inj, cosKernel_def, jacobiTheta₂_undef _ (by rwa [I_mul_im, ofReal_re]), ofReal_zero]
 
 /-- For `a = 0`, both kernels agree. -/
@@ -106,17 +106,17 @@ lemma evenKernel_eq_cosKernel_of_zero : evenKernel 0 = cosKernel 0 := by
     zero_mul, Complex.exp_zero, one_mul, cosKernel_def]
 
 lemma evenKernel_neg (a : UnitAddCircle) (x : ℝ) : evenKernel (-a) x = evenKernel a x := by
-  induction' a using QuotientAddGroup.induction_on' with a'
+  induction' a using QuotientAddGroup.induction_on with a'
   simp only [← QuotientAddGroup.mk_neg, ← ofReal_inj, evenKernel_def, ofReal_neg, neg_sq, neg_mul,
     jacobiTheta₂_neg_left]
 
 lemma cosKernel_neg (a : UnitAddCircle) (x : ℝ) : cosKernel (-a) x = cosKernel a x := by
-  induction' a using QuotientAddGroup.induction_on' with a'
+  induction' a using QuotientAddGroup.induction_on with a'
   simp only [← QuotientAddGroup.mk_neg, ← ofReal_inj, cosKernel_def, ofReal_neg,
     jacobiTheta₂_neg_left]
 
 lemma continuousOn_evenKernel (a : UnitAddCircle) : ContinuousOn (evenKernel a) (Ioi 0) := by
-  induction' a using QuotientAddGroup.induction_on' with a'
+  induction' a using QuotientAddGroup.induction_on with a'
   apply continuous_re.comp_continuousOn (f := fun x ↦ (evenKernel a' x : ℂ))
   simp only [evenKernel_def a']
   refine ContinuousAt.continuousOn (fun x hx ↦ ((Continuous.continuousAt ?_).mul ?_))
@@ -126,7 +126,7 @@ lemma continuousOn_evenKernel (a : UnitAddCircle) : ContinuousOn (evenKernel a) 
     · rwa [mul_im, I_re, I_im, zero_mul, one_mul, zero_add, ofReal_re]
 
 lemma continuousOn_cosKernel (a : UnitAddCircle) : ContinuousOn (cosKernel a) (Ioi 0) := by
-  induction' a using QuotientAddGroup.induction_on' with a'
+  induction' a using QuotientAddGroup.induction_on with a'
   apply continuous_re.comp_continuousOn (f := fun x ↦ (cosKernel a' x : ℂ))
   simp only [cosKernel_def]
   refine ContinuousAt.continuousOn (fun x hx ↦ ?_)
@@ -138,7 +138,7 @@ lemma evenKernel_functional_equation (a : UnitAddCircle) (x : ℝ) :
   rcases le_or_lt x 0 with hx | hx
   · rw [evenKernel_undef _ hx, cosKernel_undef, mul_zero]
     exact div_nonpos_of_nonneg_of_nonpos zero_le_one hx
-  induction' a using QuotientAddGroup.induction_on' with a
+  induction' a using QuotientAddGroup.induction_on with a
   rw [← ofReal_inj, ofReal_mul, evenKernel_def, cosKernel_def, jacobiTheta₂_functional_equation]
   have h1 : I * ↑(1 / x) = -1 / (I * x) := by
     push_cast

--- a/Mathlib/NumberTheory/LSeries/HurwitzZetaOdd.lean
+++ b/Mathlib/NumberTheory/LSeries/HurwitzZetaOdd.lean
@@ -119,7 +119,7 @@ lemma oddKernel_def' (a x : ℝ) : ↑(oddKernel ↑a x) = cexp (-π * a ^ 2 * x
     (by ring : ↑π * I * ↑a ^ 2 * (I * ↑x) = I ^ 2 * ↑π * ↑a ^ 2 * x), I_sq, neg_one_mul]
 
 lemma oddKernel_undef (a : UnitAddCircle) {x : ℝ} (hx : x ≤ 0) : oddKernel a x = 0 := by
-  induction' a using QuotientAddGroup.induction_on' with a'
+  induction' a using QuotientAddGroup.induction_on with a'
   rw [← ofReal_eq_zero, oddKernel_def', jacobiTheta₂_undef, jacobiTheta₂'_undef, zero_div, zero_add,
     mul_zero, mul_zero] <;>
   rwa [I_mul_im, ofReal_re]
@@ -136,12 +136,12 @@ lemma sinKernel_def (a x : ℝ) : ↑(sinKernel ↑a x) = jacobiTheta₂' a (I *
   simp_rw [map_mul, conj_I, conj_ofReal, map_neg, map_ofNat, neg_mul, neg_neg, add_self_div_two]
 
 lemma sinKernel_undef (a : UnitAddCircle) {x : ℝ} (hx : x ≤ 0) : sinKernel a x = 0 := by
-  induction' a using QuotientAddGroup.induction_on' with a'
+  induction' a using QuotientAddGroup.induction_on with a'
   rw [← ofReal_eq_zero, sinKernel_def, jacobiTheta₂'_undef _ (by rwa [I_mul_im, ofReal_re]),
     zero_div]
 
 lemma oddKernel_neg (a : UnitAddCircle) (x : ℝ) : oddKernel (-a) x = -oddKernel a x := by
-  induction' a using QuotientAddGroup.induction_on' with a'
+  induction' a using QuotientAddGroup.induction_on with a'
   rw [← ofReal_inj, ← QuotientAddGroup.mk_neg, oddKernel_def, ofReal_neg, ofReal_neg, oddKernel_def,
     jacobiTheta₂''_neg_left]
 
@@ -150,7 +150,7 @@ lemma oddKernel_zero (x : ℝ) : oddKernel 0 x = 0 := by
 
 lemma sinKernel_neg (a : UnitAddCircle) (x : ℝ) :
     sinKernel (-a) x = -sinKernel a x := by
-  induction' a using QuotientAddGroup.induction_on' with a'
+  induction' a using QuotientAddGroup.induction_on with a'
   rw [← ofReal_inj, ← QuotientAddGroup.mk_neg, ofReal_neg, sinKernel_def, sinKernel_def, ofReal_neg,
     jacobiTheta₂'_neg_left, neg_div]
 
@@ -159,7 +159,7 @@ lemma sinKernel_zero (x : ℝ) : sinKernel 0 x = 0 := by
 
 /-- The odd kernel is continuous on `Ioi 0`. -/
 lemma continuousOn_oddKernel (a : UnitAddCircle) : ContinuousOn (oddKernel a) (Ioi 0) := by
-  induction' a using QuotientAddGroup.induction_on' with a
+  induction' a using QuotientAddGroup.induction_on with a
   suffices ContinuousOn (fun x ↦ (oddKernel a x : ℂ)) (Ioi 0) from
     (continuous_re.comp_continuousOn this).congr fun a _ ↦ (ofReal_re _).symm
   simp_rw [oddKernel_def' a]
@@ -173,7 +173,7 @@ lemma continuousOn_oddKernel (a : UnitAddCircle) : ContinuousOn (oddKernel a) (I
         (by rwa [I_mul_im, ofReal_re])).comp (f := fun u : ℝ ↦ (a * I * u, I * u)) hf.continuousAt
 
 lemma continuousOn_sinKernel (a : UnitAddCircle) : ContinuousOn (sinKernel a) (Ioi 0) := by
-  induction' a using QuotientAddGroup.induction_on' with a
+  induction' a using QuotientAddGroup.induction_on with a
   suffices ContinuousOn (fun x ↦ (sinKernel a x : ℂ)) (Ioi 0) from
     (continuous_re.comp_continuousOn this).congr fun a _ ↦ (ofReal_re _).symm
   simp_rw [sinKernel_def]
@@ -186,7 +186,7 @@ lemma oddKernel_functional_equation (a : UnitAddCircle) (x : ℝ) :
   -- first reduce to `0 < x`
   rcases le_or_lt x 0 with hx | hx
   · rw [oddKernel_undef _ hx, sinKernel_undef _ (one_div_nonpos.mpr hx), mul_zero]
-  induction' a using QuotientAddGroup.induction_on' with a
+  induction' a using QuotientAddGroup.induction_on with a
   have h1 : -1 / (I * ↑(1 / x)) = I * x := by rw [one_div, ofReal_inv, mul_comm, ← div_div,
     div_inv_eq_mul, div_eq_mul_inv, inv_I, mul_neg, neg_one_mul, neg_mul, neg_neg, mul_comm]
   have h2 : (-I * (I * ↑(1 / x))) = 1 / x := by

--- a/Mathlib/Topology/Instances/AddCircle.lean
+++ b/Mathlib/Topology/Instances/AddCircle.lean
@@ -238,12 +238,12 @@ theorem continuous_equivIoc_symm : Continuous (equivIoc p a).symm :=
 variable {x : AddCircle p} (hx : x ≠ a)
 
 theorem continuousAt_equivIco : ContinuousAt (equivIco p a) x := by
-  induction x using QuotientAddGroup.induction_on'
+  induction x using QuotientAddGroup.induction_on
   rw [ContinuousAt, Filter.Tendsto, QuotientAddGroup.nhds_eq, Filter.map_map]
   exact (continuousAt_toIcoMod hp.out a hx).codRestrict _
 
 theorem continuousAt_equivIoc : ContinuousAt (equivIoc p a) x := by
-  induction x using QuotientAddGroup.induction_on'
+  induction x using QuotientAddGroup.induction_on
   rw [ContinuousAt, Filter.Tendsto, QuotientAddGroup.nhds_eq, Filter.map_map]
   exact (continuousAt_toIocMod hp.out a hx).codRestrict _
 
@@ -409,7 +409,7 @@ theorem addOrderOf_coe_rat {q : ℚ} : addOrderOf (↑(↑q * p) : AddCircle p) 
 
 theorem addOrderOf_eq_pos_iff {u : AddCircle p} {n : ℕ} (h : 0 < n) :
     addOrderOf u = n ↔ ∃ m < n, m.gcd n = 1 ∧ ↑(↑m / ↑n * p) = u := by
-  refine ⟨QuotientAddGroup.induction_on' u fun k hk => ?_, ?_⟩
+  refine ⟨QuotientAddGroup.induction_on u fun k hk => ?_, ?_⟩
   · rintro ⟨m, _, h₁, rfl⟩
     exact addOrderOf_div_of_gcd_eq_one h h₁
   have h0 := addOrderOf_nsmul_eq_zero (k : AddCircle p)


### PR DESCRIPTION
They were different in mathlib3 because of coercions.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
