### PR TITLE
[Merged by Bors] - feat: add `tsub_eq_tsub_of_add_eq_add`

### DIFF
--- a/Mathlib/Algebra/Order/Sub/Defs.lean
+++ b/Mathlib/Algebra/Order/Sub/Defs.lean
@@ -309,6 +309,12 @@ theorem add_tsub_cancel_right (a b : α) : a + b - b = a :=
 theorem add_tsub_cancel_left (a b : α) : a + b - a = b :=
   Contravariant.AddLECancellable.add_tsub_cancel_left
 
+/-- A more general version of the reverse direction of `sub_eq_sub_iff_add_eq_add` -/
+theorem tsub_eq_tsub_of_add_eq_add (h : a + d = c + b) : a - b = c - d := by
+  calc a - b = a + d - d - b := by rw [add_tsub_cancel_right]
+           _ = c + b - b - d := by rw [h, tsub_right_comm]
+           _ = c - d := by rw [add_tsub_cancel_right]
+
 theorem lt_add_of_tsub_lt_left (h : a - b < c) : a < b + c :=
   Contravariant.AddLECancellable.lt_add_of_tsub_lt_left h
 


### PR DESCRIPTION
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
