### PR TITLE
[Merged by Bors] - chore(CstarAlgebra/Module): drop `DecidableEq` assumptions

### DIFF
--- a/Mathlib/Analysis/CstarAlgebra/Module.lean
+++ b/Mathlib/Analysis/CstarAlgebra/Module.lean
@@ -117,17 +117,14 @@ lemma innerₛₗ_apply {x y : E} : innerₛₗ x y = ⟪x, y⟫ := rfl
   simp [← innerₛₗ_apply]
 
 @[simp]
-lemma inner_sum_right {ι : Type*} [DecidableEq ι] {s : Finset ι} {x : E} {y : ι → E} :
-    ⟪x, ∑ i ∈ s, y i⟫ = ∑ i ∈ s, ⟪x, y i⟫ := by
-  induction s using Finset.induction_on
-  case empty => simp
-  case insert a t a_notmem_t hbase =>
-    simp_rw [Finset.sum_insert a_notmem_t]
-    simp only [inner_add_right, hbase]
+lemma inner_sum_right {ι : Type*} {s : Finset ι} {x : E} {y : ι → E} :
+    ⟪x, ∑ i ∈ s, y i⟫ = ∑ i ∈ s, ⟪x, y i⟫ :=
+  map_sum (innerₛₗ x) ..
 
 @[simp]
-lemma inner_sum_left {ι : Type*} [DecidableEq ι] {s : Finset ι} {x : ι → E} {y : E} :
-    ⟪∑ i ∈ s, x i, y⟫ = ∑ i ∈ s, ⟪x i, y⟫ := by rw [← star_inner y]; simp
+lemma inner_sum_left {ι : Type*} {s : Finset ι} {x : ι → E} {y : E} :
+    ⟪∑ i ∈ s, x i, y⟫ = ∑ i ∈ s, ⟪x i, y⟫ :=
+  map_sum (innerₛₗ.flip y) ..
 
 @[simp]
 lemma isSelfAdjoint_inner_self {x : E} : IsSelfAdjoint ⟪x, x⟫ := star_inner _ _


### PR DESCRIPTION
Also reuse `map_sum` instead of proving by induction.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)