### PR TITLE
Feat(Mathlib/Algebra/Group/Prod): add noncomm coproduct property

### DIFF
--- a/Mathlib/Algebra/Group/Prod.lean
+++ b/Mathlib/Algebra/Group/Prod.lean
@@ -558,6 +558,62 @@ theorem comp_coprod {Q : Type*} [CommMonoid Q] (h : P →* Q) (f : M →* P) (g 
 
 end Coprod
 
+section NonCommCoprod
+
+variable [Monoid P] {f : M →* P} {g : N →* P} (comm : ∀ m n, Commute (f m) (g n))
+
+/-- Noncommutative coproduct of two commuting `MonoidHom`s with the same codomain:
+  `noncommCoprod comm (p : M × N) = f p.1 * g p.2`.
+  (Commutative case; for the general case, see `MonoidHom.noncommCoprod`.)-/
+@[to_additive
+    "Noncommutative Coproduct of two commuting `AddMonoidHom`s with the same codomain:
+    `noncommCoprod comm (p : M × N) = f p.1 + g p.2`.
+    (Commutative case; for the general case, see `AddHom.noncommCoprod`.)"]
+def noncommCoprod : M × N →* P where
+  toFun := f.comp (fst M N) * g.comp (snd M N)
+  map_one' := by simp
+  map_mul' x y := by
+    simp only [coe_comp, coe_fst, coe_snd, Pi.mul_apply, Function.comp_apply,
+      Prod.fst_mul, map_mul, Prod.snd_mul]
+    rw [← mul_assoc, mul_assoc _ (f y.1), comm]
+    simp only [mul_assoc]
+
+@[to_additive (attr := simp)]
+theorem noncommCoprod_apply (p : M × N) : noncommCoprod comm p = f p.1 * g p.2 :=
+  rfl
+
+@[to_additive (attr := simp)]
+theorem noncommCoprod_comp_inl : (noncommCoprod comm).comp (inl M N) = f :=
+  ext fun x => by simp
+
+@[to_additive (attr := simp)]
+theorem noncommCoprod_comp_inr : (noncommCoprod comm).comp (inr M N) = g :=
+  ext fun x => by simp
+
+@[to_additive (attr := simp)]
+theorem noncommCoprod_unique (φ : M × N →* P)
+    (comm := fun m n ↦ by
+      simp [commute_iff_eq, ← map_mul, Prod.mk_mul_mk, mul_one, one_mul]):
+    noncommCoprod comm (f := φ.comp (inl M N)) (g := φ.comp (inr M N)) = φ :=
+  ext fun x => by simp [← map_mul]
+
+@[to_additive (attr := simp)]
+theorem noncommCoprod_inl_inr {M N : Type*} [Monoid M] [Monoid N] :
+    noncommCoprod (f := inl M N) (g:= inr M N) (commute_inl_inr) = id (M × N) := by
+  apply noncommCoprod_unique (id <| M × N)
+
+@[to_additive]
+theorem comp_noncommCoprod {Q : Type*} [Monoid Q] (h : P →* Q)
+    (f : M →* P) (g : N →* P) (comm : ∀ m n, Commute (f m) (g n))
+    (comm' : ∀ m n, Commute (h.comp f m) (h.comp g n) := fun m n ↦ by
+      simp only [coe_comp, Function.comp_apply]
+      rw [commute_iff_eq, ← map_mul, comm, map_mul]) :
+    h.comp (noncommCoprod comm) =
+      noncommCoprod (f := h.comp f) (g := h.comp g) comm' :=
+  ext fun x => by simp
+
+end NonCommCoprod
+
 end MonoidHom
 
 namespace MulEquiv


### PR DESCRIPTION
We add the noncomm analogues of `MonoidHom.coprod`

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
