### PR TITLE
[Merged by Bors] - feat(Data.List): Add `List.nodup_permutations_iff`

### DIFF
--- a/Mathlib/Data/List/Perm.lean
+++ b/Mathlib/Data/List/Perm.lean
@@ -634,7 +634,8 @@ lemma permutations_take_two (x y : α) (s : List α) :
     (x :: y :: s).permutations.take 2 = [x :: y :: s, y :: x :: s] := by
   induction s <;> simp only [take, permutationsAux, permutationsAux.rec, permutationsAux2, id_eq]
 
-theorem nodup_permutations_iff (s : List α) : Nodup s.permutations ↔ Nodup s := by
+@[simp]
+theorem nodup_permutations_iff {s : List α} : Nodup s.permutations ↔ Nodup s := by
   refine ⟨?_, nodup_permutations s⟩
   contrapose
   rw [← exists_duplicate_iff_not_nodup]

--- a/Mathlib/Data/List/Perm.lean
+++ b/Mathlib/Data/List/Perm.lean
@@ -630,7 +630,7 @@ theorem nodup_permutations (s : List α) (hs : Nodup s) : Nodup s.permutations :
         rw [← hx, nthLe_insertNth_of_lt _ _ _ _ ht (ht.trans_le hn)]
         exact nthLe_mem _ _ _
 
-lemma permutations_first_two (x y : α) (s : List α) :
+lemma permutations_take_two (x y : α) (s : List α) :
     (x :: y :: s).permutations.take 2 = [x :: y :: s, y :: x :: s] := by
   induction s <;> simp only [take, permutationsAux, permutationsAux.rec, permutationsAux2, id_eq]
 
@@ -641,11 +641,9 @@ theorem nodup_permutations_iff (s : List α) : Nodup s.permutations ↔ Nodup s 
   intro ⟨x, hs⟩
   rw [duplicate_iff_sublist] at hs
   obtain ⟨l, ht⟩ := List.Sublist.exists_perm_append hs
-  rw [List.Perm.nodup_iff (List.Perm.permutations ht)]
-  rw [← exists_duplicate_iff_not_nodup]
+  rw [List.Perm.nodup_iff (List.Perm.permutations ht), ← exists_duplicate_iff_not_nodup]
   use x :: x :: l
-  rw [List.duplicate_iff_sublist]
-  rw [← permutations_first_two]
+  rw [List.duplicate_iff_sublist, ← permutations_take_two]
   exact take_sublist 2 _
 
 -- TODO: `count s s.permutations = (zipWith count s s.tails).prod`

--- a/Mathlib/Data/List/Perm.lean
+++ b/Mathlib/Data/List/Perm.lean
@@ -5,6 +5,7 @@ Authors: Leonardo de Moura, Jeremy Avigad, Mario Carneiro
 -/
 import Mathlib.Data.List.Count
 import Mathlib.Data.List.Dedup
+import Mathlib.Data.List.Duplicate
 import Mathlib.Data.List.InsertNth
 import Mathlib.Data.List.Lattice
 import Mathlib.Data.List.Permutation
@@ -629,7 +630,24 @@ theorem nodup_permutations (s : List α) (hs : Nodup s) : Nodup s.permutations :
         rw [← hx, nthLe_insertNth_of_lt _ _ _ _ ht (ht.trans_le hn)]
         exact nthLe_mem _ _ _
 
--- TODO: `nodup s.permutations ↔ nodup s`
+lemma permutations_first_two (x y : α) (s : List α) :
+    (x :: y :: s).permutations.take 2 = [x :: y :: s, y :: x :: s] := by
+  induction s <;> simp only [take, permutationsAux, permutationsAux.rec, permutationsAux2, id_eq]
+
+theorem nodup_permutations_iff (s : List α) : Nodup s.permutations ↔ Nodup s := by
+  refine ⟨?_, nodup_permutations s⟩
+  contrapose
+  rw [← exists_duplicate_iff_not_nodup]
+  intro ⟨x, hs⟩
+  rw [duplicate_iff_sublist] at hs
+  obtain ⟨l, ht⟩ := List.Sublist.exists_perm_append hs
+  rw [List.Perm.nodup_iff (List.Perm.permutations ht)]
+  rw [← exists_duplicate_iff_not_nodup]
+  use x :: x :: l
+  rw [List.duplicate_iff_sublist]
+  rw [← permutations_first_two]
+  exact take_sublist 2 _
+
 -- TODO: `count s s.permutations = (zipWith count s s.tails).prod`
 end Permutations
 


### PR DESCRIPTION
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
