### PR TITLE
[Merged by Bors] - fix: put `Nat.primeCounting` in a narrower scope

### DIFF
--- a/Mathlib/NumberTheory/PrimeCounting.lean
+++ b/Mathlib/NumberTheory/PrimeCounting.lean
@@ -27,8 +27,8 @@ are not prime, and so only at most `φ(k)/k` fraction of the numbers from `k` to
 
 ## Notation
 
-We use the standard notation `π` to represent the prime counting function (and `π'` to represent
-the reindexed version).
+Wtih `open scoped Nat.Prime`, we use the standard notation `π` to represent the prime counting
+function (and `π'` to represent the reindexed version).
 
 -/
 
@@ -39,17 +39,22 @@ open Finset
 
 /-- A variant of the traditional prime counting function which gives the number of primes
 *strictly* less than the input. More convenient for avoiding off-by-one errors.
--/
+
+With `open scoped Nat.Prime`, this has notation `π'`. -/
 def primeCounting' : ℕ → ℕ :=
   Nat.count Prime
 
-/-- The prime counting function: Returns the number of primes less than or equal to the input. -/
+/-- The prime counting function: Returns the number of primes less than or equal to the input.
+
+With `open scoped Nat.Prime`, this has notation `π`. -/
 def primeCounting (n : ℕ) : ℕ :=
   primeCounting' (n + 1)
 
-@[inherit_doc] scoped notation "π" => Nat.primeCounting
+@[inherit_doc] scoped[Nat.Prime] notation "π" => Nat.primeCounting
 
-@[inherit_doc] scoped notation "π'" => Nat.primeCounting'
+@[inherit_doc] scoped[Nat.Prime] notation "π'" => Nat.primeCounting'
+
+open scoped Nat.Prime
 
 theorem monotone_primeCounting' : Monotone primeCounting' :=
   count_monotone Prime


### PR DESCRIPTION
Without this, it is not possible to mix `!` notation for factorial and `π` notation for `Real.pi`.

More precisely; while the following works in `Mathlib/Analysis/SpecialFunctions/Stirling.lean`
```lean
lemma factorial_isEquivalent_stirling :
    (fun n ↦ n ! : ℕ → ℝ) ~[atTop] fun n ↦ Real.sqrt (2 * n * π) * (n / exp 1) ^ n := by
```
it produces an error about ambiguous syntax in a standalone file with `import Mathlib`:
```lean
import Mathlib

open scoped Real Nat Asymptotics
open Real

lemma factorial_isEquivalent_stirling :
    (fun n ↦ n ! : ℕ → ℝ) ~[atTop] fun n ↦ Real.sqrt (2 * n * π) * (n / exp 1) ^ n := by
```

Follows on from #13473

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
