### PR TITLE
[Merged by Bors] - chore: enable the setOption, longLine, missingEnd linters globally

### DIFF
--- a/Mathlib/Tactic/Linter/Lint.lean
+++ b/Mathlib/Tactic/Linter/Lint.lean
@@ -131,9 +131,6 @@ namespace MissingEnd
 def missingEndLinter : Linter where run := withSetOptionIn fun stx ↦ do
     -- Only run this linter at the end of a module.
     unless stx.isOfKind ``Lean.Parser.Command.eoi do return
-    -- TODO: once mathlib's Lean version includes leanprover/lean4#4741, make this configurable
-    unless #[`Mathlib, `test, `Archive, `Counterexamples].contains (← getMainModule).getRoot do
-      return
     if Linter.getLinterValue linter.missingEnd (← getOptions) &&
         !(← MonadState.get).messages.hasErrors then
       let sc ← getScopes
@@ -227,9 +224,6 @@ def longLineLinter : Linter where run := withSetOptionIn fun stx ↦ do
     unless Linter.getLinterValue linter.longLine (← getOptions) do
       return
     if (← MonadState.get).messages.hasErrors then
-      return
-    -- TODO: once mathlib's Lean version includes leanprover/lean4#4741, make this configurable
-    unless #[`Mathlib, `test, `Archive, `Counterexamples].contains (← getMainModule).getRoot do
       return
     -- The linter ignores the `#guard_msgs` command, in particular its doc-string.
     -- The linter still lints the message guarded by `#guard_msgs`.

--- a/Mathlib/Tactic/Linter/Style.lean
+++ b/Mathlib/Tactic/Linter/Style.lean
@@ -56,9 +56,6 @@ def setOptionLinter : Linter where run := withSetOptionIn fun stx => do
       return
     if (← MonadState.get).messages.hasErrors then
       return
-    -- TODO: once mathlib's Lean version includes leanprover/lean4#4741, make this configurable
-    unless #[`Mathlib, `test, `Archive, `Counterexamples].contains (← getMainModule).getRoot do
-      return
     if let some head := stx.find? is_set_option then
       if let some name := parse_set_option head then
         let forbidden := [`debug, `pp, `profiler, `trace]


### PR DESCRIPTION
With Lean 4.11.0-rc1, downstream projects can disable these linters by setting (e.g.) linter.setOption false in their `lakefile.lean`.

------

Not tested on downstream projects yet: help doing so is welcome.

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

- [x] depends on: #15616

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
