### PR TITLE
[Merged by Bors] - feat(Tactic/NthRewrite): Allow multiple occurrences

### DIFF
--- a/Mathlib/Tactic/NthRewrite.lean
+++ b/Mathlib/Tactic/NthRewrite.lean
@@ -17,19 +17,19 @@ namespace Mathlib.Tactic
 
 open Lean Elab Tactic Meta Parser.Tactic
 
-/-- `nth_rewrite` is a variant of `rewrite` that only changes the `n`ᵗʰ _occurrence_ of the
-expression to be rewritten. `nth_rewrite n [eq₁, eq₂,..., eqₘ]` will rewrite the `n`ᵗʰ _occurrence_
-of each of the `m` equalities `eqᵢ`in that order. Occurrences are counted beginning with `1` in
-order of precedence.
+/-- `nth_rewrite` is a variant of `rewrite` that only changes the `n₁, ..., nₖ`ᵗʰ _occurrence_ of
+the expression to be rewritten. `nth_rewrite n₁ ... nₖ [eq₁, eq₂,..., eqₘ]` will rewrite the
+`n₁, ..., nₖ`ᵗʰ _occurrence_ of each of the `m` equalities `eqᵢ`in that order. Occurrences are
+counted beginning with `1` in order of precedence.
 
 For example,
 ```lean
 example (h : a = 1) : a + a + a + a + a = 5 := by
-  nth_rewrite 2 [h]
+  nth_rewrite 2 3 [h]
 /-
 a: ℕ
 h: a = 1
-⊢ a + 1 + a + a + a = 5
+⊢ a + 1 + 1 + a + a = 5
 -/
 ```
 Notice that the second occurrence of `a` from the left has been rewritten by `nth_rewrite`.
@@ -67,16 +67,16 @@ h: a = a + b
 This new instance of `a` also turns out to be the third _occurrence_ of `a`.  Therefore,
 the next `nth_rewrite` with `h` rewrites this `a`.
 -/
-syntax (name := nthRewriteSeq) "nth_rewrite" (config)? ppSpace num rwRuleSeq (location)? : tactic
+syntax (name := nthRewriteSeq) "nth_rewrite" (config)? ppSpace num+ rwRuleSeq (location)? : tactic
 
 @[inherit_doc nthRewriteSeq, tactic nthRewriteSeq] def evalNthRewriteSeq : Tactic := fun stx => do
   match stx with
-  | `(tactic| nth_rewrite $[$_cfg]? $n $_rules $[$_loc]?) =>
+  | `(tactic| nth_rewrite $[$_cfg]? $[$n]* $_rules:rwRuleSeq $[$_loc]?) =>
     -- [TODO] `stx` should not be used directly, but the corresponding functions do not yet exist
     -- in Lean 4 core
     let cfg ← elabRewriteConfig stx[1]
     let loc := expandOptLocation stx[4]
-    let occ := Occurrences.pos [n.getNat]
+    let occ := Occurrences.pos (n.map TSyntax.getNat).toList
     let cfg := { cfg with occs := occ }
     withRWRulesSeq stx[0] stx[3] fun symm term => do
       withLocation loc
@@ -86,18 +86,18 @@ syntax (name := nthRewriteSeq) "nth_rewrite" (config)? ppSpace num rwRuleSeq (lo
   | _ => throwUnsupportedSyntax
 
 /--
-`nth_rw` is a variant of `rw` that only changes the `n`ᵗʰ _occurrence_ of the expression to be
-rewritten. Like `rw`, and unlike `nth_rewrite`, it will try to close the goal by trying `rfl`
-afterwards. `nth_rw n [eq₁, eq₂,..., eqₘ]` will rewrite the `n`ᵗʰ _occurrence_ of each of the
-`m` equalities `eqᵢ`in that order. Occurrences are counted beginning with `1` in
+`nth_rw` is a variant of `rw` that only changes the `n₁, ..., nₖ`ᵗʰ _occurrence_ of the expression
+to be rewritten. Like `rw`, and unlike `nth_rewrite`, it will try to close the goal by trying `rfl`
+afterwards. `nth_rw n₁ ... nₖ [eq₁, eq₂,..., eqₘ]` will rewrite the `n₁, ..., nₖ`ᵗʰ _occurrence_ of
+each of the `m` equalities `eqᵢ`in that order. Occurrences are counted beginning with `1` in
 order of precedence. For example,
 ```lean
 example (h : a = 1) : a + a + a + a + a = 5 := by
-  nth_rw 2 [h]
+  nth_rw 2 3 [h]
 /-
 a: ℕ
 h: a = 1
-⊢ a + 1 + a + a + a = 5
+⊢ a + 1 + 1 + a + a = 5
 -/
 ```
 Notice that the second occurrence of `a` from the left has been rewritten by `nth_rewrite`.
@@ -137,11 +137,11 @@ the next `nth_rw` with `h` rewrites this `a`.
 
 Further, `nth_rw` will close the remaining goal with `rfl` if possible.
 -/
-macro (name := nthRwSeq) "nth_rw" c:(config)? ppSpace n:num s:rwRuleSeq l:(location)? : tactic =>
+macro (name := nthRwSeq) "nth_rw" c:(config)? ppSpace n:num+ s:rwRuleSeq l:(location)? : tactic =>
   -- Note: This is a direct copy of `nth_rw` from core.
   match s with
   | `(rwRuleSeq| [$rs,*]%$rbrak) =>
     -- We show the `rfl` state on `]`
-    `(tactic| (nth_rewrite $(c)? $n [$rs,*] $(l)?; with_annotate_state $rbrak
+    `(tactic| (nth_rewrite $(c)? $[$n]* [$rs,*] $(l)?; with_annotate_state $rbrak
       (try (with_reducible rfl))))
   | _ => Macro.throwUnsupported

--- a/test/NthRewrite.lean
+++ b/test/NthRewrite.lean
@@ -103,3 +103,6 @@ example (x y : ℕ) (h₁ : x = y) (h₂ : x = x + x) : x + x = x := by
   nth_rewrite 1 [← h₁] at h₂
   nth_rewrite 3 [h₂]
   rfl
+
+example (x y : ℕ) (h : x = y) : x + x + x = x + y + y := by
+  nth_rw 2 3 [h]


### PR DESCRIPTION
Allow `nth_rewrite` and `nth_rw` tactic to use multiple occurrences, such as `nth_rw 2 3 [p]`.