### PR TITLE
[Merged by Bors] - chore: backports for leanprover/lean4#4814 (part 25)

### DIFF
--- a/Mathlib/Algebra/Lie/Submodule.lean
+++ b/Mathlib/Algebra/Lie/Submodule.lean
@@ -36,8 +36,8 @@ universe u v w w₁ w₂
 section LieSubmodule
 
 variable (R : Type u) (L : Type v) (M : Type w)
-variable [CommRing R] [LieRing L] [LieAlgebra R L] [AddCommGroup M] [Module R M]
-variable [LieRingModule L M] [LieModule R L M]
+variable [CommRing R] [LieRing L] [AddCommGroup M] [Module R M]
+variable [LieRingModule L M]
 
 /-- A Lie submodule of a Lie module is a submodule that is closed under the Lie bracket.
 This is a sufficient condition for the subset itself to form a Lie module. -/
@@ -169,10 +169,6 @@ instance {S : Type*} [Semiring S] [SMul S R] [SMul Sᵐᵒᵖ R] [Module S M] [M
     [IsScalarTower S R M] [IsScalarTower Sᵐᵒᵖ R M] [IsCentralScalar S M] : IsCentralScalar S N :=
   N.toSubmodule.isCentralScalar
 
-instance instLieModule : LieModule R L N where
-  lie_smul := by intro t x y; apply SetCoe.ext; apply lie_smul
-  smul_lie := by intro t x y; apply SetCoe.ext; apply smul_lie
-
 @[simp, norm_cast]
 theorem coe_zero : ((0 : N) : M) = (0 : M) :=
   rfl
@@ -197,12 +193,19 @@ theorem coe_smul (t : R) (m : N) : (↑(t • m) : M) = t • (m : M) :=
 theorem coe_bracket (x : L) (m : N) : (↑⁅x, m⁆ : M) = ⁅x, ↑m⁆ :=
   rfl
 
+variable [LieAlgebra R L] [LieModule R L M]
+
+instance instLieModule : LieModule R L N where
+  lie_smul := by intro t x y; apply SetCoe.ext; apply lie_smul
+  smul_lie := by intro t x y; apply SetCoe.ext; apply smul_lie
+
 instance [Subsingleton M] : Unique (LieSubmodule R L M) :=
   ⟨⟨0⟩, fun _ ↦ (coe_toSubmodule_eq_iff _ _).mp (Subsingleton.elim _ _)⟩
 
 end LieSubmodule
 
 section LieIdeal
+variable [LieAlgebra R L] [LieModule R L M]
 
 /-- An ideal of a Lie algebra is a Lie submodule of the Lie algebra as a Lie module over itself. -/
 abbrev LieIdeal :=
@@ -265,6 +268,7 @@ theorem Submodule.exists_lieSubmodule_coe_eq_iff (p : Submodule R M) :
 namespace LieSubalgebra
 
 variable {L}
+variable [LieAlgebra R L]
 variable (K : LieSubalgebra R L)
 
 /-- Given a Lie subalgebra `K ⊆ L`, if we view `L` as a `K`-module by restriction, it contains
@@ -301,9 +305,9 @@ end LieSubmodule
 namespace LieSubmodule
 
 variable {R : Type u} {L : Type v} {M : Type w}
-variable [CommRing R] [LieRing L] [LieAlgebra R L] [AddCommGroup M] [Module R M]
-variable [LieRingModule L M] [LieModule R L M]
-variable (N N' : LieSubmodule R L M) (I J : LieIdeal R L)
+variable [CommRing R] [LieRing L] [AddCommGroup M] [Module R M]
+variable [LieRingModule L M]
+variable (N N' : LieSubmodule R L M)
 
 section LatticeStructure
 
@@ -741,9 +745,9 @@ end LieSubmodule
 section LieSubmoduleMapAndComap
 
 variable {R : Type u} {L : Type v} {L' : Type w₂} {M : Type w} {M' : Type w₁}
-variable [CommRing R] [LieRing L] [LieAlgebra R L] [LieRing L'] [LieAlgebra R L']
-variable [AddCommGroup M] [Module R M] [LieRingModule L M] [LieModule R L M]
-variable [AddCommGroup M'] [Module R M'] [LieRingModule L M'] [LieModule R L M']
+variable [CommRing R] [LieRing L] [LieRing L'] [LieAlgebra R L']
+variable [AddCommGroup M] [Module R M] [LieRingModule L M]
+variable [AddCommGroup M'] [Module R M'] [LieRingModule L M']
 
 namespace LieSubmodule
 
@@ -884,6 +888,7 @@ Submodules. -/
 end LieSubmodule
 
 namespace LieIdeal
+variable [LieAlgebra R L] [LieModule R L M] [LieModule R L M']
 
 variable (f : L →ₗ⁅R⁆ L') (I I₂ : LieIdeal R L) (J : LieIdeal R L')
 
@@ -988,7 +993,7 @@ instance subsingleton_of_bot : Subsingleton (LieIdeal R (⊥ : LieIdeal R L)) :=
 end LieIdeal
 
 namespace LieHom
-
+variable [LieAlgebra R L] [LieModule R L M] [LieModule R L M']
 variable (f : L →ₗ⁅R⁆ L') (I : LieIdeal R L) (J : LieIdeal R L')
 
 /-- The kernel of a morphism of Lie algebras, as an ideal in the domain. -/
@@ -1090,7 +1095,7 @@ theorem isIdealMorphism_of_surjective (h : Function.Surjective f) : f.IsIdealMor
 end LieHom
 
 namespace LieIdeal
-
+variable [LieAlgebra R L] [LieModule R L M] [LieModule R L M']
 variable {f : L →ₗ⁅R⁆ L'} {I : LieIdeal R L} {J : LieIdeal R L'}
 
 @[simp]
@@ -1223,9 +1228,9 @@ end LieSubmoduleMapAndComap
 namespace LieModuleHom
 
 variable {R : Type u} {L : Type v} {M : Type w} {N : Type w₁}
-variable [CommRing R] [LieRing L] [LieAlgebra R L]
-variable [AddCommGroup M] [Module R M] [LieRingModule L M] [LieModule R L M]
-variable [AddCommGroup N] [Module R N] [LieRingModule L N] [LieModule R L N]
+variable [CommRing R] [LieRing L]
+variable [AddCommGroup M] [Module R M] [LieRingModule L M]
+variable [AddCommGroup N] [Module R N] [LieRingModule L N]
 variable (f : M →ₗ⁅R,L⁆ N)
 
 /-- The kernel of a morphism of Lie algebras, as an ideal in the domain. -/
@@ -1299,8 +1304,8 @@ end LieModuleHom
 namespace LieSubmodule
 
 variable {R : Type u} {L : Type v} {M : Type w}
-variable [CommRing R] [LieRing L] [LieAlgebra R L]
-variable [AddCommGroup M] [Module R M] [LieRingModule L M] [LieModule R L M]
+variable [CommRing R] [LieRing L]
+variable [AddCommGroup M] [Module R M] [LieRingModule L M]
 variable (N : LieSubmodule R L M)
 
 @[simp]
@@ -1339,8 +1344,30 @@ end LieSubmodule
 
 section TopEquiv
 
-variable {R : Type u} {L : Type v}
-variable [CommRing R] [LieRing L] [LieAlgebra R L]
+variable (R : Type u) (L : Type v)
+variable [CommRing R] [LieRing L]
+
+variable (M : Type*) [AddCommGroup M] [Module R M] [LieRingModule L M]
+
+/-- The natural equivalence between the 'top' Lie submodule and the enclosing Lie module. -/
+def LieModuleEquiv.ofTop : (⊤ : LieSubmodule R L M) ≃ₗ⁅R,L⁆ M :=
+  { LinearEquiv.ofTop ⊤ rfl with
+    map_lie' := rfl }
+
+variable {R L}
+
+-- This lemma has always been bad, but leanprover/lean4#2644 made `simp` start noticing
+@[simp, nolint simpNF] lemma LieModuleEquiv.ofTop_apply (x : (⊤ : LieSubmodule R L M)) :
+    LieModuleEquiv.ofTop R L M x = x :=
+  rfl
+
+@[simp] lemma LieModuleEquiv.range_coe {M' : Type*}
+    [AddCommGroup M'] [Module R M'] [LieRingModule L M'] (e : M ≃ₗ⁅R,L⁆ M') :
+    LieModuleHom.range (e : M →ₗ⁅R,L⁆ M') = ⊤ := by
+  rw [LieModuleHom.range_eq_top]
+  exact e.surjective
+
+variable [LieAlgebra R L] [LieModule R L M]
 
 /-- The natural equivalence between the 'top' Lie subalgebra and the enclosing Lie algebra.
 
@@ -1365,24 +1392,5 @@ def LieIdeal.topEquiv : (⊤ : LieIdeal R L) ≃ₗ⁅R⁆ L :=
 @[simp, nolint simpNF]
 theorem LieIdeal.topEquiv_apply (x : (⊤ : LieIdeal R L)) : LieIdeal.topEquiv x = x :=
   rfl
-
-variable (R L)
-variable (M : Type*) [AddCommGroup M] [Module R M] [LieRingModule L M] [LieModule R L M]
-
-/-- The natural equivalence between the 'top' Lie submodule and the enclosing Lie module. -/
-def LieModuleEquiv.ofTop : (⊤ : LieSubmodule R L M) ≃ₗ⁅R,L⁆ M :=
-  { LinearEquiv.ofTop ⊤ rfl with
-    map_lie' := rfl }
-
--- This lemma has always been bad, but leanprover/lean4#2644 made `simp` start noticing
-@[simp, nolint simpNF] lemma LieModuleEquiv.ofTop_apply (x : (⊤ : LieSubmodule R L M)) :
-    LieModuleEquiv.ofTop R L M x = x :=
-  rfl
-
-@[simp] lemma LieModuleEquiv.range_coe {M' : Type*}
-    [AddCommGroup M'] [Module R M'] [LieRingModule L M'] (e : M ≃ₗ⁅R,L⁆ M') :
-    LieModuleHom.range (e : M →ₗ⁅R,L⁆ M') = ⊤ := by
-  rw [LieModuleHom.range_eq_top]
-  exact e.surjective
 
 end TopEquiv

--- a/Mathlib/AlgebraicGeometry/EllipticCurve/Jacobian.lean
+++ b/Mathlib/AlgebraicGeometry/EllipticCurve/Jacobian.lean
@@ -112,7 +112,7 @@ local macro "pderiv_simp" : tactic =>
     pderiv_X_of_ne (by decide : z ≠ x), pderiv_X_of_ne (by decide : x ≠ z),
     pderiv_X_of_ne (by decide : z ≠ y), pderiv_X_of_ne (by decide : y ≠ z)])
 
-variable {R : Type u} [CommRing R] {W' : Jacobian R} {F : Type v} [Field F] {W : Jacobian F}
+variable {R : Type u} {W' : Jacobian R} {F : Type v} [Field F] {W : Jacobian F}
 
 section Jacobian
 
@@ -126,6 +126,8 @@ lemma fin3_def_ext (X Y Z : R) : ![X, Y, Z] x = X ∧ ![X, Y, Z] y = Y ∧ ![X, 
 
 lemma comp_fin3 {S} (f : R → S) (X Y Z : R) : f ∘ ![X, Y, Z] = ![f X, f Y, f Z] :=
   (FinVec.map_eq _ _).symm
+
+variable [CommRing R]
 
 /-- The scalar multiplication on a point representative. -/
 scoped instance instSMulPoint : SMul R <| Fin 3 → R :=
@@ -223,6 +225,8 @@ lemma Y_eq_iff {P Q : Fin 3 → F} (hPz : P z ≠ 0) (hQz : Q z ≠ 0) :
   (div_eq_div_iff (pow_ne_zero 3 hPz) (pow_ne_zero 3 hQz)).symm
 
 end Jacobian
+
+variable [CommRing R]
 
 section Equation
 

--- a/Mathlib/Analysis/InnerProductSpace/Orientation.lean
+++ b/Mathlib/Analysis/InnerProductSpace/Orientation.lean
@@ -44,7 +44,7 @@ open scoped RealInnerProductSpace
 
 namespace OrthonormalBasis
 
-variable {ι : Type*} [Fintype ι] [DecidableEq ι] [ne : Nonempty ι] (e f : OrthonormalBasis ι ℝ E)
+variable {ι : Type*} [Fintype ι] [DecidableEq ι] (e f : OrthonormalBasis ι ℝ E)
   (x : Orientation ℝ E ι)
 
 /-- The change-of-basis matrix between two orthonormal bases with the same orientation has
@@ -89,6 +89,8 @@ theorem det_eq_neg_det_of_opposite_orientation (h : e.toBasis.orientation ≠ f.
   -- Porting note: added `neg_one_smul` with explicit type
   simp [e.det_to_matrix_orthonormalBasis_of_opposite_orientation f h,
     neg_one_smul ℝ (M := E [⋀^ι]→ₗ[ℝ] ℝ)]
+
+variable [Nonempty ι]
 
 section AdjustToOrientation
 

--- a/Mathlib/Analysis/Normed/Algebra/TrivSqZeroExt.lean
+++ b/Mathlib/Analysis/Normed/Algebra/TrivSqZeroExt.lean
@@ -192,9 +192,8 @@ noncomputable section Seminormed
 
 section Ring
 variable [SeminormedCommRing S] [SeminormedRing R] [SeminormedAddCommGroup M]
-variable [Algebra S R] [Module S M] [Module R M] [Module Rᵐᵒᵖ M]
-variable [BoundedSMul S R] [BoundedSMul S M] [BoundedSMul R M] [BoundedSMul Rᵐᵒᵖ M]
-variable [SMulCommClass R Rᵐᵒᵖ M] [IsScalarTower S R M] [IsScalarTower S Rᵐᵒᵖ M]
+variable [Algebra S R] [Module S M]
+variable [BoundedSMul S R] [BoundedSMul S M]
 
 instance instL1SeminormedAddCommGroup : SeminormedAddCommGroup (tsze R M) :=
   inferInstanceAs <| SeminormedAddCommGroup (WithLp 1 <| R × M)
@@ -216,6 +215,9 @@ theorem nnnorm_def (x : tsze R M) : ‖x‖₊ = ‖fst x‖₊ + ‖snd x‖₊
 
 @[simp] theorem nnnorm_inl (r : R) : ‖(inl r : tsze R M)‖₊ = ‖r‖₊ := by simp [nnnorm_def]
 @[simp] theorem nnnorm_inr (m : M) : ‖(inr m : tsze R M)‖₊ = ‖m‖₊ := by simp [nnnorm_def]
+
+variable [Module R M] [BoundedSMul R M] [Module Rᵐᵒᵖ M] [BoundedSMul Rᵐᵒᵖ M]
+  [SMulCommClass R Rᵐᵒᵖ M]
 
 instance instL1SeminormedRing : SeminormedRing (tsze R M) where
   norm_mul

--- a/Mathlib/Analysis/Normed/Algebra/UnitizationL1.lean
+++ b/Mathlib/Analysis/Normed/Algebra/UnitizationL1.lean
@@ -24,7 +24,7 @@ non-unital Banach algebra is compact, which can be established by passing to the
 -/
 
 variable (𝕜 A : Type*) [NormedField 𝕜] [NonUnitalNormedRing A]
-variable [NormedSpace 𝕜 A] [IsScalarTower 𝕜 A A] [SMulCommClass 𝕜 A A]
+variable [NormedSpace 𝕜 A]
 
 namespace WithLp
 
@@ -78,6 +78,8 @@ lemma unitization_isometry_inr :
   AddMonoidHomClass.isometry_of_norm
     ((WithLp.linearEquiv 1 𝕜 (Unitization 𝕜 A)).symm.comp <| Unitization.inrHom 𝕜 A)
     unitization_norm_inr
+
+variable [IsScalarTower 𝕜 A A] [SMulCommClass 𝕜 A A]
 
 instance instUnitizationRing : Ring (WithLp 1 (Unitization 𝕜 A)) :=
   inferInstanceAs (Ring (Unitization 𝕜 A))

--- a/Mathlib/Analysis/Normed/Lp/PiLp.lean
+++ b/Mathlib/Analysis/Normed/Lp/PiLp.lean
@@ -92,7 +92,7 @@ section
 for Pi types will not trigger. -/
 variable {𝕜 p α}
 variable [SeminormedRing 𝕜] [∀ i, SeminormedAddCommGroup (β i)]
-variable [∀ i, Module 𝕜 (β i)] [∀ i, BoundedSMul 𝕜 (β i)] (c : 𝕜)
+variable [∀ i, Module 𝕜 (β i)] (c : 𝕜)
 variable (x y : PiLp p β) (i : ι)
 
 #adaptation_note
@@ -744,7 +744,7 @@ variable {ι : Type*} {κ : ι → Type*} (p : ℝ≥0∞) [Fact (1 ≤ p)]
 
 variable (𝕜) in
 /-- `LinearEquiv.piCurry` for `PiLp`, as an isometry. -/
-def _root_.LinearIsometryEquiv.piLpCurry  :
+def _root_.LinearIsometryEquiv.piLpCurry :
     PiLp p (fun i : Sigma _ => α i.1 i.2) ≃ₗᵢ[𝕜] PiLp p (fun i => PiLp p (α i)) where
   toLinearEquiv :=
     WithLp.linearEquiv _ _ _

--- a/Mathlib/Analysis/NormedSpace/DualNumber.lean
+++ b/Mathlib/Analysis/NormedSpace/DualNumber.lean
@@ -25,7 +25,7 @@ open TrivSqZeroExt
 
 variable (𝕜 : Type*) {R : Type*}
 variable [Field 𝕜] [CharZero 𝕜] [CommRing R] [Algebra 𝕜 R]
-variable [UniformSpace R] [TopologicalRing R] [CompleteSpace R] [T2Space R]
+variable [UniformSpace R] [TopologicalRing R] [T2Space R]
 
 @[simp]
 theorem exp_eps : exp 𝕜 (eps : DualNumber R) = 1 + eps :=

--- a/Mathlib/Combinatorics/Additive/Corner/Roth.lean
+++ b/Mathlib/Combinatorics/Additive/Corner/Roth.lean
@@ -23,7 +23,7 @@ open Finset SimpleGraph TripartiteFromTriangles
 open Function hiding graph
 open Fintype (card)
 
-variable {G : Type*} [AddCommGroup G] [Fintype G] {A B : Finset (G × G)}
+variable {G : Type*} [AddCommGroup G] {A B : Finset (G × G)}
   {a b c d x y : G} {n : ℕ} {ε : ℝ}
 
 namespace Corners
@@ -55,7 +55,7 @@ private lemma noAccidental (hs : IsCornerFree (A : Set (G × G))) :
     simp only [mk_mem_triangleIndices] at ha hb hc
     exact .inl $ hs ⟨hc.1, hb.1, ha.1, hb.2.symm.trans ha.2⟩
 
-private lemma farFromTriangleFree_graph [DecidableEq G] (hε : ε * card G ^ 2 ≤ A.card) :
+private lemma farFromTriangleFree_graph [Fintype G] [DecidableEq G] (hε : ε * card G ^ 2 ≤ A.card) :
     (graph <| triangleIndices A).FarFromTriangleFree (ε / 9) := by
   refine farFromTriangleFree _ ?_
   simp_rw [card_triangleIndices, mul_comm_div, Nat.cast_pow, Nat.cast_add]
@@ -63,6 +63,8 @@ private lemma farFromTriangleFree_graph [DecidableEq G] (hε : ε * card G ^ 2 �
   simpa only [mul_comm] using hε
 
 end Corners
+
+variable [Fintype G]
 
 open Corners
 

--- a/Mathlib/FieldTheory/Perfect.lean
+++ b/Mathlib/FieldTheory/Perfect.lean
@@ -290,6 +290,7 @@ theorem roots_expand_image_frobenius_subset [DecidableEq R] :
   convert ← roots_expand_pow_image_iterateFrobenius_subset p 1 f
   apply pow_one
 
+section PerfectRing
 variable {p n f}
 variable [PerfectRing R p]
 
@@ -342,7 +343,9 @@ theorem roots_expand_image_frobenius [DecidableEq R] :
   rw [Finset.image_toFinset, roots_expand_map_frobenius,
       (roots f).toFinset_nsmul _ (expChar_pos R p).ne']
 
-variable (p n f) [DecidableEq R]
+end PerfectRing
+
+variable [DecidableEq R]
 
 /-- If `f` is a polynomial over an integral domain `R` of characteristic `p`, then there is
 a map from the set of roots of `Polynomial.expand R p f` to the set of roots of `f`.
@@ -366,6 +369,8 @@ noncomputable def rootsExpandPowToRoots :
 
 @[simp]
 theorem rootsExpandPowToRoots_apply (x) : (rootsExpandPowToRoots p n f x : R) = x ^ p ^ n := rfl
+
+variable [PerfectRing R p]
 
 /-- If `f` is a polynomial over a perfect integral domain `R` of characteristic `p`, then there is
 a bijection from the set of roots of `Polynomial.expand R p f` to the set of roots of `f`.

--- a/Mathlib/Geometry/Manifold/InteriorBoundary.lean
+++ b/Mathlib/Geometry/Manifold/InteriorBoundary.lean
@@ -159,7 +159,7 @@ variable {I}
   {E' : Type*} [NormedAddCommGroup E'] [NormedSpace 𝕜 E']
   {H' : Type*} [TopologicalSpace H']
   {N : Type*} [TopologicalSpace N] [ChartedSpace H' N]
-  (J : ModelWithCorners 𝕜 E' H') [SmoothManifoldWithCorners J N] {x : M} {y : N}
+  (J : ModelWithCorners 𝕜 E' H') {x : M} {y : N}
 
 /-- The interior of `M × N` is the product of the interiors of `M` and `N`. -/
 lemma ModelWithCorners.interior_prod :

--- a/Mathlib/LinearAlgebra/QuadraticForm/TensorProduct.lean
+++ b/Mathlib/LinearAlgebra/QuadraticForm/TensorProduct.lean
@@ -31,9 +31,11 @@ section CommRing
 variable [CommRing R] [CommRing A]
 variable [AddCommGroup M₁] [AddCommGroup M₂]
 variable [Algebra R A] [Module R M₁] [Module A M₁]
-variable [SMulCommClass R A M₁] [SMulCommClass A R M₁] [IsScalarTower R A M₁]
-variable [Module R M₂] [Invertible (2 : R)]
+variable [SMulCommClass R A M₁] [IsScalarTower R A M₁]
+variable [Module R M₂]
 
+section InvertibleTwo
+variable [Invertible (2 : R)]
 
 variable (R A) in
 /-- The tensor product of two quadratic forms injects into quadratic forms on tensor products.
@@ -105,6 +107,8 @@ theorem polarBilin_baseChange [Invertible (2 : A)] (Q : QuadraticForm R M₂) :
   rw [QuadraticForm.baseChange, BilinMap.baseChange, polarBilin_tmul, BilinMap.tmul,
     ← LinearMap.map_smul, smul_tmul', ← two_nsmul_associated R, coe_associatedHom, associated_sq,
     smul_comm, ← smul_assoc, two_smul, invOf_two_add_invOf_two, one_smul]
+
+end InvertibleTwo
 
 /-- If two quadratic forms from `A ⊗[R] M₂` agree on elements of the form `1 ⊗ m`, they are equal.
 

--- a/Mathlib/LinearAlgebra/Trace.lean
+++ b/Mathlib/LinearAlgebra/Trace.lean
@@ -145,9 +145,9 @@ theorem trace_eq_contract_of_basis' [Fintype ι] [DecidableEq ι] (b : Basis ι 
     LinearMap.trace R M = contractLeft R M ∘ₗ (dualTensorHomEquivOfBasis b).symm.toLinearMap := by
   simp [LinearEquiv.eq_comp_toLinearMap_symm, trace_eq_contract_of_basis b]
 
+section
 variable (R M)
 variable [Module.Free R M] [Module.Finite R M] [Module.Free R N] [Module.Finite R N]
-  [Module.Free R P] [Module.Finite R P]
 
 /-- When `M` is finite free, the trace of a linear map correspond to the contraction pairing under
 the isomorphism `End(M) ≃ M* ⊗ M`-/
@@ -257,10 +257,14 @@ theorem trace_comp_comm' (f : M →ₗ[R] N) (g : N →ₗ[R] M) :
   simp only [llcomp_apply', compr₂_apply, flip_apply] at h
   exact h
 
+end
+
+variable [Module.Free R N] [Module.Finite R N] [Module.Free R P] [Module.Finite R P] in
 lemma trace_comp_cycle (f : M →ₗ[R] N) (g : N →ₗ[R] P) (h : P →ₗ[R] M) :
     trace R P (g ∘ₗ f ∘ₗ h) = trace R N (f ∘ₗ h ∘ₗ g) := by
   rw [trace_comp_comm', comp_assoc]
 
+variable [Module.Free R M] [Module.Finite R M] [Module.Free R P] [Module.Finite R P] in
 lemma trace_comp_cycle' (f : M →ₗ[R] N) (g : N →ₗ[R] P) (h : P →ₗ[R] M) :
     trace R P ((g ∘ₗ f) ∘ₗ h) = trace R M ((h ∘ₗ g) ∘ₗ f) := by
   rw [trace_comp_comm', ← comp_assoc]
@@ -286,6 +290,7 @@ theorem IsProj.trace {p : Submodule R M} {f : M →ₗ[R] M} (h : IsProj p f) [M
     trace R M f = (finrank R p : R) := by
   rw [h.eq_conj_prodMap, trace_conj', trace_prodMap', trace_id, map_zero, add_zero]
 
+variable [Module.Free R M] [Module.Finite R M] in
 lemma isNilpotent_trace_of_isNilpotent {f : M →ₗ[R] M} (hf : IsNilpotent f) :
     IsNilpotent (trace R M f) := by
   let b : Basis _ R M := Module.Free.chooseBasis R M
@@ -293,6 +298,7 @@ lemma isNilpotent_trace_of_isNilpotent {f : M →ₗ[R] M} (hf : IsNilpotent f) 
   apply Matrix.isNilpotent_trace_of_isNilpotent
   simpa
 
+variable [Module.Free R M] [Module.Finite R M] in
 lemma trace_comp_eq_mul_of_commute_of_isNilpotent [IsReduced R] {f g : Module.End R M}
     (μ : R) (h_comm : Commute f g) (hg : IsNilpotent (g - algebraMap R _ μ)) :
     trace R M (f ∘ₗ g) = μ * trace R M f := by

--- a/Mathlib/LinearAlgebra/Trace.lean
+++ b/Mathlib/LinearAlgebra/Trace.lean
@@ -259,6 +259,8 @@ theorem trace_comp_comm' (f : M →ₗ[R] N) (g : N →ₗ[R] M) :
 
 end
 
+variable {N P}
+
 variable [Module.Free R N] [Module.Finite R N] [Module.Free R P] [Module.Finite R P] in
 lemma trace_comp_cycle (f : M →ₗ[R] N) (g : N →ₗ[R] P) (h : P →ₗ[R] M) :
     trace R P (g ∘ₗ f ∘ₗ h) = trace R N (f ∘ₗ h ∘ₗ g) := by

--- a/Mathlib/MeasureTheory/Constructions/Pi.lean
+++ b/Mathlib/MeasureTheory/Constructions/Pi.lean
@@ -867,7 +867,7 @@ theorem volume_preserving_pi_empty {ι : Type u} (α : ι → Type v) [Fintype �
     MeasurePreserving (MeasurableEquiv.ofUniqueOfUnique (∀ i, α i) Unit) volume volume :=
   measurePreserving_pi_empty fun _ => volume
 
-theorem measurePreserving_piFinsetUnion {ι} {α : ι → Type*}
+theorem measurePreserving_piFinsetUnion {ι : Type*} {α : ι → Type*}
     {_ : ∀ i, MeasurableSpace (α i)} [DecidableEq ι] {s t : Finset ι} (h : Disjoint s t)
     (μ : ∀ i, Measure (α i)) [∀ i, SigmaFinite (μ i)] :
     MeasurePreserving (MeasurableEquiv.piFinsetUnion α h)
@@ -877,12 +877,12 @@ theorem measurePreserving_piFinsetUnion {ι} {α : ι → Type*}
   measurePreserving_piCongrLeft (fun i : ↥(s ∪ t) ↦ μ i) e |>.comp <|
     measurePreserving_sumPiEquivProdPi_symm fun b ↦ μ (e b)
 
-theorem volume_preserving_piFinsetUnion {ι} [DecidableEq ι] (α : ι → Type*) {s t : Finset ι}
+theorem volume_preserving_piFinsetUnion {ι : Type*} [DecidableEq ι] (α : ι → Type*) {s t : Finset ι}
     (h : Disjoint s t) [∀ i, MeasureSpace (α i)] [∀ i, SigmaFinite (volume : Measure (α i))] :
     MeasurePreserving (MeasurableEquiv.piFinsetUnion α h) volume volume :=
   measurePreserving_piFinsetUnion h (fun _ ↦ volume)
 
-theorem measurePreserving_pi {ι} [Fintype ι] {α : ι → Type v} {β : ι → Type*}
+theorem measurePreserving_pi {ι : Type*} [Fintype ι] {α : ι → Type v} {β : ι → Type*}
     [∀ i, MeasureSpace (α i)] [∀ i, MeasurableSpace (β i)]
     (μ : (i : ι) → Measure (α i)) (ν : (i : ι) → Measure (β i))
     {f : (i : ι) → (α i) → (β i)} [∀ i, SigmaFinite (ν i)]

--- a/Mathlib/MeasureTheory/Constructions/Pi.lean
+++ b/Mathlib/MeasureTheory/Constructions/Pi.lean
@@ -867,7 +867,8 @@ theorem volume_preserving_pi_empty {ι : Type u} (α : ι → Type v) [Fintype �
     MeasurePreserving (MeasurableEquiv.ofUniqueOfUnique (∀ i, α i) Unit) volume volume :=
   measurePreserving_pi_empty fun _ => volume
 
-theorem measurePreserving_piFinsetUnion [DecidableEq ι] {s t : Finset ι} (h : Disjoint s t)
+theorem measurePreserving_piFinsetUnion {ι : Type u} [DecidableEq ι]
+    {α : ι → Type v} [∀ i, MeasureSpace (α i)] {s t : Finset ι} (h : Disjoint s t)
     (μ : ∀ i, Measure (α i)) [∀ i, SigmaFinite (μ i)] :
     MeasurePreserving (MeasurableEquiv.piFinsetUnion α h)
       ((Measure.pi fun i : s ↦ μ i).prod (Measure.pi fun i : t ↦ μ i))
@@ -876,13 +877,15 @@ theorem measurePreserving_piFinsetUnion [DecidableEq ι] {s t : Finset ι} (h : 
   measurePreserving_piCongrLeft (fun i : ↥(s ∪ t) ↦ μ i) e |>.comp <|
     measurePreserving_sumPiEquivProdPi_symm fun b ↦ μ (e b)
 
-theorem volume_preserving_piFinsetUnion (α : ι → Type*) [DecidableEq ι] {s t : Finset ι}
+theorem volume_preserving_piFinsetUnion {ι} [DecidableEq ι] (α : ι → Type*) {s t : Finset ι}
     (h : Disjoint s t) [∀ i, MeasureSpace (α i)] [∀ i, SigmaFinite (volume : Measure (α i))] :
     MeasurePreserving (MeasurableEquiv.piFinsetUnion α h) volume volume :=
   measurePreserving_piFinsetUnion h (fun _ ↦ volume)
 
-theorem measurePreserving_pi {β : ι → Type*} [∀ i, MeasurableSpace (β i)]
-    (ν : (i : ι) → Measure (β i)) {f : (i : ι) → (α i) → (β i)} [∀ i, SigmaFinite (ν i)]
+theorem measurePreserving_pi {ι} [Fintype ι] {α : ι → Type v} {β : ι → Type*}
+    [∀ i, MeasureSpace (α i)] [∀ i, MeasurableSpace (β i)]
+    (μ : (i : ι) → Measure (α i)) (ν : (i : ι) → Measure (β i))
+    {f : (i : ι) → (α i) → (β i)} [∀ i, SigmaFinite (ν i)]
     (hf : ∀ i, MeasurePreserving (f i) (μ i) (ν i)) :
     MeasurePreserving (fun a i ↦ f i (a i)) (Measure.pi μ) (Measure.pi ν) where
   measurable :=

--- a/Mathlib/MeasureTheory/Constructions/Pi.lean
+++ b/Mathlib/MeasureTheory/Constructions/Pi.lean
@@ -867,8 +867,8 @@ theorem volume_preserving_pi_empty {ι : Type u} (α : ι → Type v) [Fintype �
     MeasurePreserving (MeasurableEquiv.ofUniqueOfUnique (∀ i, α i) Unit) volume volume :=
   measurePreserving_pi_empty fun _ => volume
 
-theorem measurePreserving_piFinsetUnion {ι : Type u} [DecidableEq ι]
-    {α : ι → Type v} [∀ i, MeasureSpace (α i)] {s t : Finset ι} (h : Disjoint s t)
+theorem measurePreserving_piFinsetUnion {ι} {α : ι → Type*}
+    {_ : ∀ i, MeasurableSpace (α i)} [DecidableEq ι] {s t : Finset ι} (h : Disjoint s t)
     (μ : ∀ i, Measure (α i)) [∀ i, SigmaFinite (μ i)] :
     MeasurePreserving (MeasurableEquiv.piFinsetUnion α h)
       ((Measure.pi fun i : s ↦ μ i).prod (Measure.pi fun i : t ↦ μ i))

--- a/Mathlib/MeasureTheory/Constructions/Prod/Basic.lean
+++ b/Mathlib/MeasureTheory/Constructions/Prod/Basic.lean
@@ -466,11 +466,11 @@ theorem ae_ae_of_ae_prod {p : α × β → Prop} (h : ∀ᵐ z ∂μ.prod ν, p 
     ∀ᵐ x ∂μ, ∀ᵐ y ∂ν, p (x, y) :=
   measure_ae_null_of_prod_null h
 
-theorem ae_ae_eq_curry_of_prod {f g : α × β → γ} (h : f =ᵐ[μ.prod ν] g) :
+theorem ae_ae_eq_curry_of_prod {γ} {f g : α × β → γ} (h : f =ᵐ[μ.prod ν] g) :
     ∀ᵐ x ∂μ, curry f x =ᵐ[ν] curry g x :=
   ae_ae_of_ae_prod h
 
-theorem ae_ae_eq_of_ae_eq_uncurry {f g : α → β → γ} (h : uncurry f =ᵐ[μ.prod ν] uncurry g) :
+theorem ae_ae_eq_of_ae_eq_uncurry {γ} {f g : α → β → γ} (h : uncurry f =ᵐ[μ.prod ν] uncurry g) :
     ∀ᵐ x ∂μ, f x =ᵐ[ν] g x :=
   ae_ae_eq_curry_of_prod h
 

--- a/Mathlib/MeasureTheory/Constructions/Prod/Basic.lean
+++ b/Mathlib/MeasureTheory/Constructions/Prod/Basic.lean
@@ -466,11 +466,11 @@ theorem ae_ae_of_ae_prod {p : α × β → Prop} (h : ∀ᵐ z ∂μ.prod ν, p 
     ∀ᵐ x ∂μ, ∀ᵐ y ∂ν, p (x, y) :=
   measure_ae_null_of_prod_null h
 
-theorem ae_ae_eq_curry_of_prod {γ} {f g : α × β → γ} (h : f =ᵐ[μ.prod ν] g) :
+theorem ae_ae_eq_curry_of_prod {γ : Type*} {f g : α × β → γ} (h : f =ᵐ[μ.prod ν] g) :
     ∀ᵐ x ∂μ, curry f x =ᵐ[ν] curry g x :=
   ae_ae_of_ae_prod h
 
-theorem ae_ae_eq_of_ae_eq_uncurry {γ} {f g : α → β → γ} (h : uncurry f =ᵐ[μ.prod ν] uncurry g) :
+theorem ae_ae_eq_of_ae_eq_uncurry {γ : Type*} {f g : α → β → γ} (h : uncurry f =ᵐ[μ.prod ν] uncurry g) :
     ∀ᵐ x ∂μ, f x =ᵐ[ν] g x :=
   ae_ae_eq_curry_of_prod h
 

--- a/Mathlib/MeasureTheory/Constructions/Prod/Basic.lean
+++ b/Mathlib/MeasureTheory/Constructions/Prod/Basic.lean
@@ -470,8 +470,8 @@ theorem ae_ae_eq_curry_of_prod {γ : Type*} {f g : α × β → γ} (h : f =ᵐ[
     ∀ᵐ x ∂μ, curry f x =ᵐ[ν] curry g x :=
   ae_ae_of_ae_prod h
 
-theorem ae_ae_eq_of_ae_eq_uncurry {γ : Type*} {f g : α → β → γ} (h : uncurry f =ᵐ[μ.prod ν] uncurry g) :
-    ∀ᵐ x ∂μ, f x =ᵐ[ν] g x :=
+theorem ae_ae_eq_of_ae_eq_uncurry {γ : Type*} {f g : α → β → γ}
+    (h : uncurry f =ᵐ[μ.prod ν] uncurry g) : ∀ᵐ x ∂μ, f x =ᵐ[ν] g x :=
   ae_ae_eq_curry_of_prod h
 
 theorem ae_prod_mem_iff_ae_ae_mem {s : Set (α × β)} (hs : MeasurableSet s) :

--- a/Mathlib/MeasureTheory/Group/Measure.lean
+++ b/Mathlib/MeasureTheory/Group/Measure.lean
@@ -523,6 +523,7 @@ lemma tendsto_measure_smul_diff_isCompact_isClosed [LocallyCompactSpace G]
   ENNReal.nhds_zero_basis.tendsto_right_iff.mpr <| fun _ h ↦
     eventually_nhds_one_measure_smul_diff_lt hk h'k h.ne'
 
+section IsMulLeftInvariant
 variable [IsMulLeftInvariant μ]
 
 /-- If a left-invariant measure gives positive mass to a compact set, then it gives positive mass to
@@ -681,6 +682,8 @@ lemma measure_mul_closure_one (s : Set G) (μ : Measure G) :
 lemma _root_.IsCompact.measure_closure_eq_of_group {k : Set G} (hk : IsCompact k) (μ : Measure G) :
     μ (closure k) = μ k :=
   hk.measure_closure μ
+
+end IsMulLeftInvariant
 
 @[to_additive]
 lemma innerRegularWRT_isCompact_isClosed_measure_ne_top_of_group [h : InnerRegularCompactLTTop μ] :

--- a/Mathlib/MeasureTheory/Measure/HasOuterApproxClosed.lean
+++ b/Mathlib/MeasureTheory/Measure/HasOuterApproxClosed.lean
@@ -72,7 +72,7 @@ This formulation assumes:
  * boundedness holds almost everywhere.
 -/
 theorem measure_of_cont_bdd_of_tendsto_filter_indicator {ι : Type*} {L : Filter ι}
-    [L.IsCountablyGenerated] [TopologicalSpace Ω] [OpensMeasurableSpace Ω] (μ : Measure Ω)
+    [L.IsCountablyGenerated] (μ : Measure Ω)
     [IsFiniteMeasure μ] {c : ℝ≥0} {E : Set Ω} (E_mble : MeasurableSet E) (fs : ι → Ω →ᵇ ℝ≥0)
     (fs_bdd : ∀ᶠ i in L, ∀ᵐ ω : Ω ∂μ, fs i ω ≤ c)
     (fs_lim : ∀ᵐ ω ∂μ, Tendsto (fun i ↦ fs i ω) L (𝓝 (indicator E (fun _ ↦ (1 : ℝ≥0)) ω))) :
@@ -90,7 +90,7 @@ measure of the set.
 A similar result with more general assumptions is
 `MeasureTheory.measure_of_cont_bdd_of_tendsto_filter_indicator`.
 -/
-theorem measure_of_cont_bdd_of_tendsto_indicator [OpensMeasurableSpace Ω]
+theorem measure_of_cont_bdd_of_tendsto_indicator
     (μ : Measure Ω) [IsFiniteMeasure μ] {c : ℝ≥0} {E : Set Ω} (E_mble : MeasurableSet E)
     (fs : ℕ → Ω →ᵇ ℝ≥0) (fs_bdd : ∀ n ω, fs n ω ≤ c)
     (fs_lim : Tendsto (fun n ω ↦ fs n ω) atTop (𝓝 (indicator E fun _ ↦ (1 : ℝ≥0)))) :

--- a/Mathlib/RingTheory/Kaehler/Basic.lean
+++ b/Mathlib/RingTheory/Kaehler/Basic.lean
@@ -617,9 +617,8 @@ A --→ B
 R --→ S
 ```
 -/
-variable (A B : Type*) [CommRing A] [CommRing B] [Algebra R A] [Algebra R B]
-variable [Algebra A B] [Algebra S B] [IsScalarTower R A B] [IsScalarTower R S B]
-variable [SMulCommClass S A B]
+variable (A B : Type*) [CommRing A] [CommRing B] [Algebra R A]
+variable [Algebra A B] [Algebra S B]
 
 unsuppress_compilation in
 -- The map `(A →₀ A) →ₗ[A] (B →₀ B)`
@@ -639,7 +638,8 @@ The kernel of the presentation `⊕ₓ B dx ↠ Ω_{B/S}` is spanned by the imag
 kernel of `⊕ₓ A dx ↠ Ω_{A/R}` and all `ds` with `s : S`.
 See `kerTotal_map'` for the special case where `R = S`.
 -/
-theorem KaehlerDifferential.kerTotal_map (h : Function.Surjective (algebraMap A B)) :
+theorem KaehlerDifferential.kerTotal_map [Algebra R B] [IsScalarTower R A B] [IsScalarTower R S B]
+    (h : Function.Surjective (algebraMap A B)) :
     (KaehlerDifferential.kerTotal R A).map finsupp_map ⊔
         Submodule.span A (Set.range fun x : S => .single (algebraMap S B x) (1 : B)) =
       (KaehlerDifferential.kerTotal S B).restrictScalars _ := by
@@ -665,7 +665,8 @@ This is a special case of `kerTotal_map` where `R = S`.
 The kernel of the presentation `⊕ₓ B dx ↠ Ω_{B/R}` is spanned by the image of the
 kernel of `⊕ₓ A dx ↠ Ω_{A/R}` and all `da` with `a : A`.
 -/
-theorem KaehlerDifferential.kerTotal_map' (h : Function.Surjective (algebraMap A B)) :
+theorem KaehlerDifferential.kerTotal_map' [Algebra R B]
+    [IsScalarTower R A B] (h : Function.Surjective (algebraMap A B)) :
     (KaehlerDifferential.kerTotal R A ⊔
       Submodule.span A (Set.range fun x ↦ .single (algebraMap R A x) 1)).map finsupp_map =
       (KaehlerDifferential.kerTotal R B).restrictScalars _ := by
@@ -673,6 +674,8 @@ theorem KaehlerDifferential.kerTotal_map' (h : Function.Surjective (algebraMap A
   congr
   refine congr_arg Set.range ?_
   ext; simp [IsScalarTower.algebraMap_eq R A B]
+
+variable [Algebra R B] [IsScalarTower R A B] [IsScalarTower R S B] [SMulCommClass S A B]
 
 /-- The map `Ω[A⁄R] →ₗ[A] Ω[B⁄S]` given a square
 ```

--- a/Mathlib/RingTheory/Unramified/Finite.lean
+++ b/Mathlib/RingTheory/Unramified/Finite.lean
@@ -80,32 +80,6 @@ theorem iff_exists_tensorProduct [EssFiniteType R S] :
       use 1 ⊗ₜ[R] s - s ⊗ₜ[R] 1
       linear_combination ht₁ s
 
-variable [FormallyUnramified R S] [EssFiniteType R S]
-
-variable (R S) in
-/--
-A finite-type `R`-algebra `S` is (formally) unramified iff there exists a `t : S ⊗[R] S` satisfying
-1. `t` annihilates every `1 ⊗ s - s ⊗ 1`.
-2. the image of `t` is `1` under the map `S ⊗[R] S → S`.
-See `Algebra.FormallyUnramified.iff_exists_tensorProduct`.
-This is the choice of such a `t`.
--/
-noncomputable
-def elem : S ⊗[R] S :=
-  (iff_exists_tensorProduct.mp inferInstance).choose
-
-lemma one_tmul_sub_tmul_one_mul_elem
-    (s : S) : (1 ⊗ₜ s - s ⊗ₜ 1) * elem R S = 0 :=
-  (iff_exists_tensorProduct.mp inferInstance).choose_spec.1 s
-
-lemma one_tmul_mul_elem
-    (s : S) : (1 ⊗ₜ s) * elem R S = (s ⊗ₜ 1) * elem R S := by
-  rw [← sub_eq_zero, ← sub_mul, one_tmul_sub_tmul_one_mul_elem]
-
-lemma lmul_elem [EssFiniteType R S] [FormallyUnramified R S] :
-    TensorProduct.lmul' R (elem R S) = 1 :=
-  (iff_exists_tensorProduct.mp inferInstance).choose_spec.2
-
 lemma finite_of_free_aux (I) [DecidableEq I] (b : Basis I R S)
     (f : I →₀ S) (x : S) (a : I → I →₀ R) (ha : a = fun i ↦ b.repr (b i * x)) :
     (1 ⊗ₜ[R] x * Finsupp.sum f fun i y ↦ y ⊗ₜ[R] b i) =
@@ -144,6 +118,33 @@ lemma finite_of_free_aux (I) [DecidableEq I] (b : Basis I R S)
       and_imp, forall_exists_index]
     simp (config := {contextual := true})
   · exact fun _ _ ↦ rfl
+
+variable [FormallyUnramified R S] [EssFiniteType R S]
+
+variable (R S) in
+/--
+A finite-type `R`-algebra `S` is (formally) unramified iff there exists a `t : S ⊗[R] S` satisfying
+1. `t` annihilates every `1 ⊗ s - s ⊗ 1`.
+2. the image of `t` is `1` under the map `S ⊗[R] S → S`.
+See `Algebra.FormallyUnramified.iff_exists_tensorProduct`.
+This is the choice of such a `t`.
+-/
+noncomputable
+def elem : S ⊗[R] S :=
+  (iff_exists_tensorProduct.mp inferInstance).choose
+
+lemma one_tmul_sub_tmul_one_mul_elem
+    (s : S) : (1 ⊗ₜ s - s ⊗ₜ 1) * elem R S = 0 :=
+  (iff_exists_tensorProduct.mp inferInstance).choose_spec.1 s
+
+lemma one_tmul_mul_elem
+    (s : S) : (1 ⊗ₜ s) * elem R S = (s ⊗ₜ 1) * elem R S := by
+  rw [← sub_eq_zero, ← sub_mul, one_tmul_sub_tmul_one_mul_elem]
+
+lemma lmul_elem :
+    TensorProduct.lmul' R (elem R S) = 1 :=
+  (iff_exists_tensorProduct.mp inferInstance).choose_spec.2
+
 
 variable (R S)
 

--- a/Mathlib/RingTheory/WittVector/Basic.lean
+++ b/Mathlib/RingTheory/WittVector/Basic.lean
@@ -49,7 +49,7 @@ noncomputable section
 
 open MvPolynomial Function
 
-variable {p : ℕ} {R S T : Type*} [hp : Fact p.Prime] [CommRing R] [CommRing S] [CommRing T]
+variable {p : ℕ} {R S T : Type*} [CommRing R] [CommRing S] [CommRing T]
 variable {α : Type*} {β : Type*}
 
 local notation "𝕎" => WittVector p
@@ -76,9 +76,6 @@ theorem surjective (f : α → β) (hf : Surjective f) : Surjective (mapFun f : 
   ⟨mk _ fun n => Classical.choose <| hf <| x.coeff n,
     by ext n; simp only [mapFun, coeff_mk, comp_apply, Classical.choose_spec (hf (x.coeff n))]⟩
 
--- Porting note: using `(x y : 𝕎 R)` instead of `(x y : WittVector p R)` produced sorries.
-variable (f : R →+* S) (x y : WittVector p R)
-
 /-- Auxiliary tactic for showing that `mapFun` respects the ring operations. -/
 -- porting note: a very crude port.
 macro "map_fun_tac" : tactic => `(tactic| (
@@ -91,6 +88,10 @@ macro "map_fun_tac" : tactic => `(tactic| (
   apply eval₂Hom_congr (RingHom.ext_int _ _) _ rfl <;>
   ext ⟨i, k⟩ <;>
     fin_cases i <;> rfl))
+
+variable [Fact p.Prime]
+-- Porting note: using `(x y : 𝕎 R)` instead of `(x y : WittVector p R)` produced sorries.
+variable (f : R →+* S) (x y : WittVector p R)
 
 --  and until `pow`.
 -- We do not tag these lemmas as `@[simp]` because they will be bundled in `map` later on.
@@ -158,14 +159,15 @@ end Tactic
 
 section GhostFun
 
-variable (x y : WittVector p R)
-
 -- The following lemmas are not `@[simp]` because they will be bundled in `ghostMap` later on.
 
 @[local simp]
 theorem matrix_vecEmpty_coeff {R} (i j) :
     @coeff p R (Matrix.vecEmpty i) j = (Matrix.vecEmpty i : ℕ → R) j := by
   rcases i with ⟨_ | _ | _ | _ | i_val, ⟨⟩⟩
+
+variable [Fact p.Prime]
+variable (x y : WittVector p R)
 
 private theorem ghostFun_zero : ghostFun (0 : 𝕎 R) = 0 := by
   ghost_fun_tac 0, ![]
@@ -231,6 +233,8 @@ private def ghostEquiv' [Invertible (p : R)] : 𝕎 R ≃ (ℕ → R) where
     have := bind₁_xInTermsOfW_wittPolynomial p R n
     apply_fun aeval x at this
     simpa only [aeval_bind₁, aeval_X, ghostFun, aeval_wittPolynomial]
+
+variable [Fact p.Prime]
 
 @[local instance]
 private def comm_ring_aux₁ : CommRing (𝕎 (MvPolynomial R ℚ)) :=

--- a/Mathlib/RingTheory/WittVector/InitTail.lean
+++ b/Mathlib/RingTheory/WittVector/InitTail.lean
@@ -34,7 +34,7 @@ and shows how that polynomial interacts with `MvPolynomial.bind₁`.
 -/
 
 
-variable {p : ℕ} [hp : Fact p.Prime] (n : ℕ) {R : Type*} [CommRing R]
+variable {p : ℕ} (n : ℕ) {R : Type*} [CommRing R]
 
 -- type as `\bbW`
 local notation "𝕎" => WittVector p
@@ -78,6 +78,8 @@ instance select_isPoly {P : ℕ → Prop} : IsPoly p fun _ _ x => select P x := 
   rintro R _Rcr x
   funext i
   apply coeff_select
+
+variable [hp : Fact p.Prime]
 
 theorem select_add_select_not : ∀ x : 𝕎 R, select P x + select (fun i => ¬P i) x = x := by
   -- Porting note: TC search was insufficient to find this instance, even though all required
@@ -126,6 +128,8 @@ theorem coeff_add_of_disjoint (x y : 𝕎 R) (h : ∀ n, x.coeff n = 0 ∨ y.coe
       · rw [h n |>.resolve_right y0, zero_add]
 
 end Select
+
+variable [Fact p.Prime]
 
 /-- `WittVector.init n x` is the Witt vector of which the first `n` coefficients are those from `x`
 and all other coefficients are `0`.
@@ -186,6 +190,9 @@ theorem init_init (x : 𝕎 R) (n : ℕ) : init n (init n x) = init n x := by
   simp only [WittVector.init, WittVector.select, WittVector.coeff_mk]
   by_cases hi : i < n <;> simp [hi]
 
+section
+variable [Fact p.Prime]
+
 theorem init_add (x y : 𝕎 R) (n : ℕ) : init n (x + y) = init n (init n x + init n y) := by
   init_ring using wittAdd_vars
 
@@ -207,6 +214,7 @@ theorem init_zsmul (m : ℤ) (x : 𝕎 R) (n : ℕ) : init n (m • x) = init n 
 theorem init_pow (m : ℕ) (x : 𝕎 R) (n : ℕ) : init n (x ^ m) = init n (init n x ^ m) := by
   init_ring using fun p [Fact (Nat.Prime p)] n => wittPow_vars p m n
 
+end
 section
 
 variable (p)

--- a/Mathlib/RingTheory/WittVector/Teichmuller.lean
+++ b/Mathlib/RingTheory/WittVector/Teichmuller.lean
@@ -70,14 +70,14 @@ private theorem map_teichmullerFun (f : R →+* S) (r : R) :
   · rfl
   · exact f.map_zero
 
-private theorem teichmuller_mul_aux₁ {R} (x y : MvPolynomial R ℚ) :
+private theorem teichmuller_mul_aux₁ {R : Type*} (x y : MvPolynomial R ℚ) :
     teichmullerFun p (x * y) = teichmullerFun p x * teichmullerFun p y := by
   apply (ghostMap.bijective_of_invertible p (MvPolynomial R ℚ)).1
   rw [RingHom.map_mul]
   ext1 n
   simp only [Pi.mul_apply, ghostMap_apply, ghostComponent_teichmullerFun, mul_pow]
 
-private theorem teichmuller_mul_aux₂ {R} (x y : MvPolynomial R ℤ) :
+private theorem teichmuller_mul_aux₂ {R : Type*} (x y : MvPolynomial R ℤ) :
     teichmullerFun p (x * y) = teichmullerFun p x * teichmullerFun p y := by
   refine map_injective (MvPolynomial.map (Int.castRingHom ℚ))
     (MvPolynomial.map_injective _ Int.cast_injective) ?_

--- a/Mathlib/RingTheory/WittVector/Teichmuller.lean
+++ b/Mathlib/RingTheory/WittVector/Teichmuller.lean
@@ -70,14 +70,14 @@ private theorem map_teichmullerFun (f : R →+* S) (r : R) :
   · rfl
   · exact f.map_zero
 
-private theorem teichmuller_mul_aux₁ (x y : MvPolynomial R ℚ) :
+private theorem teichmuller_mul_aux₁ {R} (x y : MvPolynomial R ℚ) :
     teichmullerFun p (x * y) = teichmullerFun p x * teichmullerFun p y := by
   apply (ghostMap.bijective_of_invertible p (MvPolynomial R ℚ)).1
   rw [RingHom.map_mul]
   ext1 n
   simp only [Pi.mul_apply, ghostMap_apply, ghostComponent_teichmullerFun, mul_pow]
 
-private theorem teichmuller_mul_aux₂ (x y : MvPolynomial R ℤ) :
+private theorem teichmuller_mul_aux₂ {R} (x y : MvPolynomial R ℤ) :
     teichmullerFun p (x * y) = teichmullerFun p x * teichmullerFun p y := by
   refine map_injective (MvPolynomial.map (Int.castRingHom ℚ))
     (MvPolynomial.map_injective _ Int.cast_injective) ?_

--- a/Mathlib/RingTheory/WittVector/Verschiebung.lean
+++ b/Mathlib/RingTheory/WittVector/Verschiebung.lean
@@ -21,7 +21,7 @@ namespace WittVector
 
 open MvPolynomial
 
-variable {p : ℕ} {R S : Type*} [hp : Fact p.Prime] [CommRing R] [CommRing S]
+variable {p : ℕ} {R S : Type*} [CommRing R] [CommRing S]
 
 local notation "𝕎" => WittVector p -- type as `\bbW`
 
@@ -49,13 +49,13 @@ theorem verschiebungFun_coeff_succ (x : 𝕎 R) (n : ℕ) :
   rfl
 
 @[ghost_simps]
-theorem ghostComponent_zero_verschiebungFun (x : 𝕎 R) :
+theorem ghostComponent_zero_verschiebungFun [hp : Fact p.Prime]  (x : 𝕎 R) :
     ghostComponent 0 (verschiebungFun x) = 0 := by
   rw [ghostComponent_apply, aeval_wittPolynomial, Finset.range_one, Finset.sum_singleton,
     verschiebungFun_coeff_zero, pow_zero, pow_zero, pow_one, one_mul]
 
 @[ghost_simps]
-theorem ghostComponent_verschiebungFun (x : 𝕎 R) (n : ℕ) :
+theorem ghostComponent_verschiebungFun [hp : Fact p.Prime]  (x : 𝕎 R) (n : ℕ) :
     ghostComponent (n + 1) (verschiebungFun x) = p * ghostComponent n x := by
   simp only [ghostComponent_apply, aeval_wittPolynomial]
   rw [Finset.sum_range_succ', verschiebungFun_coeff, if_pos rfl,
@@ -96,6 +96,7 @@ example (p : ℕ) (f : ⦃R : Type _⦄ → [CommRing R] → WittVector p R → 
   inferInstance
 
 variable {p}
+variable [hp : Fact p.Prime]
 
 /--
 `verschiebung x` shifts the coefficients of `x` up by one, by inserting 0 as the 0th coefficient.
@@ -116,7 +117,7 @@ noncomputable def verschiebung : 𝕎 R →+ 𝕎 R where
 
 /-- `WittVector.verschiebung` is a polynomial function. -/
 @[is_poly]
-theorem verschiebung_isPoly : IsPoly p fun R _Rcr => @verschiebung p R hp _Rcr :=
+theorem verschiebung_isPoly : IsPoly p fun _ _ => verschiebung (p := p) :=
   verschiebungFun_isPoly p
 
 /-- verschiebung is a natural transformation -/

--- a/Mathlib/RingTheory/WittVector/Verschiebung.lean
+++ b/Mathlib/RingTheory/WittVector/Verschiebung.lean
@@ -49,13 +49,13 @@ theorem verschiebungFun_coeff_succ (x : 𝕎 R) (n : ℕ) :
   rfl
 
 @[ghost_simps]
-theorem ghostComponent_zero_verschiebungFun [hp : Fact p.Prime]  (x : 𝕎 R) :
+theorem ghostComponent_zero_verschiebungFun [hp : Fact p.Prime] (x : 𝕎 R) :
     ghostComponent 0 (verschiebungFun x) = 0 := by
   rw [ghostComponent_apply, aeval_wittPolynomial, Finset.range_one, Finset.sum_singleton,
     verschiebungFun_coeff_zero, pow_zero, pow_zero, pow_one, one_mul]
 
 @[ghost_simps]
-theorem ghostComponent_verschiebungFun [hp : Fact p.Prime]  (x : 𝕎 R) (n : ℕ) :
+theorem ghostComponent_verschiebungFun [hp : Fact p.Prime] (x : 𝕎 R) (n : ℕ) :
     ghostComponent (n + 1) (verschiebungFun x) = p * ghostComponent n x := by
   simp only [ghostComponent_apply, aeval_wittPolynomial]
   rw [Finset.sum_range_succ', verschiebungFun_coeff, if_pos rfl,


### PR DESCRIPTION
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
