### PR TITLE
[Merged by Bors] - feat(Combinatorics/SimpleGraph): darts and edges are injective for walks, length of paths and trails are bounded

### DIFF
--- a/Mathlib/Combinatorics/SimpleGraph/Path.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Path.lean
@@ -179,7 +179,7 @@ theorem IsTrail.count_edges_eq_one [DecidableEq V] {u v : V} {p : G.Walk u v} (h
   List.count_eq_one_of_mem h.edges_nodup he
 
 theorem IsTrail.length_le_card_edgeFinset [Fintype G.edgeSet] {u v : V}
-    (w : G.Walk u v) {h : w.IsTrail} : w.length ≤ G.edgeFinset.card := by
+    {w : G.Walk u v} (h : w.IsTrail) : w.length ≤ G.edgeFinset.card := by
   classical
   let edges := w.edges.toFinset
   have : edges.card = w.length := length_edges _ ▸ List.toFinset_card_of_nodup h.edges_nodup
@@ -187,7 +187,7 @@ theorem IsTrail.length_le_card_edgeFinset [Fintype G.edgeSet] {u v : V}
   have : edges ⊆ G.edgeFinset := by
     intro e h
     refine mem_edgeFinset.mpr ?_
-    apply SimpleGraph.Walk.edges_subset_edgeSet w
+    apply w.edges_subset_edgeSet
     simpa [edges] using h
   exact Finset.card_le_card this
 

--- a/Mathlib/Combinatorics/SimpleGraph/Path.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Path.lean
@@ -178,6 +178,19 @@ theorem IsTrail.count_edges_eq_one [DecidableEq V] {u v : V} {p : G.Walk u v} (h
     {e : Sym2 V} (he : e ∈ p.edges) : p.edges.count e = 1 :=
   List.count_eq_one_of_mem h.edges_nodup he
 
+theorem IsTrail.length_le_card_edgeFinset [Fintype G.edgeSet] {u v : V}
+    (w : G.Walk u v) {h : w.IsTrail} : w.length ≤ G.edgeFinset.card := by
+  classical
+  let edges := w.edges.toFinset
+  have : edges.card = w.length := length_edges _ ▸ List.toFinset_card_of_nodup h.edges_nodup
+  rw [← this]
+  have : edges ⊆ G.edgeFinset := by
+    intro e h
+    refine mem_edgeFinset.mpr ?_
+    apply SimpleGraph.Walk.edges_subset_edgeSet w
+    simpa [edges] using h
+  exact Finset.card_le_card this
+
 theorem IsPath.nil {u : V} : (nil : G.Walk u u).IsPath := by constructor <;> simp
 
 theorem IsPath.of_cons {u v w : V} {h : G.Adj u v} {p : G.Walk v w} :
@@ -213,6 +226,16 @@ theorem IsPath.of_append_right {u v w : V} {p : G.Walk u v} {q : G.Walk v w}
   rw [← isPath_reverse_iff] at h ⊢
   rw [reverse_append] at h
   apply h.of_append_left
+
+theorem IsPath.length_lt_card_V [Fintype V] {u v : V} (w : G.Walk u v) {h : w.IsPath} :
+    w.length < Fintype.card V := by
+  classical
+  apply Nat.lt_of_add_one_le
+  let support := w.support.toFinset
+  have : support.card = w.length + 1 :=
+    length_support _ ▸ List.toFinset_card_of_nodup h.support_nodup
+  rw [← this]
+  exact Finset.card_le_card (Finset.subset_univ support)
 
 @[simp]
 theorem IsCycle.not_of_nil {u : V} : ¬(nil : G.Walk u u).IsCycle := fun h => h.ne_nil rfl

--- a/Mathlib/Combinatorics/SimpleGraph/Path.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Path.lean
@@ -227,16 +227,6 @@ theorem IsPath.of_append_right {u v w : V} {p : G.Walk u v} {q : G.Walk v w}
   rw [reverse_append] at h
   apply h.of_append_left
 
-theorem IsPath.length_lt_card_V [Fintype V] {u v : V} (w : G.Walk u v) {h : w.IsPath} :
-    w.length < Fintype.card V := by
-  classical
-  apply Nat.lt_of_add_one_le
-  let support := w.support.toFinset
-  have : support.card = w.length + 1 :=
-    length_support _ ▸ List.toFinset_card_of_nodup h.support_nodup
-  rw [← this]
-  exact Finset.card_le_card (Finset.subset_univ support)
-
 @[simp]
 theorem IsCycle.not_of_nil {u : V} : ¬(nil : G.Walk u u).IsCycle := fun h => h.ne_nil rfl
 

--- a/Mathlib/Combinatorics/SimpleGraph/Walk.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Walk.lean
@@ -713,6 +713,20 @@ theorem edges_nodup_of_support_nodup {u v : V} {p : G.Walk u v} (h : p.support.N
     simp only [edges_cons, support_cons, List.nodup_cons] at h ⊢
     exact ⟨fun h' => h.1 (fst_mem_support_of_mem_edges p' h'), ih h.2⟩
 
+theorem edges_injective {u v : V} : Function.Injective (Walk.edges : G.Walk u v → List (Sym2 V))
+  | .nil, .nil, _ => by simp
+  | .nil, .cons _ _, h => by simp at h
+  | .cons _ _, .nil, h => by simp at h
+  | .cons' u v c h₁ w₁, .cons' _ v' _ h₂ w₂, h => by
+    have h₁ : u ≠ v  := by rintro rfl; exact G.loopless _ h₁
+    have h₂ : u ≠ v' := by rintro rfl; exact G.loopless _ h₂
+    obtain ⟨rfl, h₃⟩ : v = v' ∧ w₁.edges = w₂.edges := by simpa [h₁, h₂] using h
+    obtain rfl := Walk.edges_injective h₃
+    rfl
+
+theorem darts_injective {u v : V} : Function.Injective (Walk.darts : G.Walk u v → List G.Dart) :=
+  edges_injective.of_comp
+
 /-- Predicate for the empty walk.
 
 Solves the dependent type problem where `p = G.Walk.nil` typechecks

--- a/Mathlib/Combinatorics/SimpleGraph/Walk.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Walk.lean
@@ -714,7 +714,7 @@ theorem edges_nodup_of_support_nodup {u v : V} {p : G.Walk u v} (h : p.support.N
     exact ⟨fun h' => h.1 (fst_mem_support_of_mem_edges p' h'), ih h.2⟩
 
 theorem edges_injective {u v : V} : Function.Injective (Walk.edges : G.Walk u v → List (Sym2 V))
-  | .nil, .nil, _ => by simp
+  | .nil, .nil, _ => rfl
   | .nil, .cons _ _, h => by simp at h
   | .cons _ _, .nil, h => by simp at h
   | .cons' u v c h₁ w₁, .cons' _ v' _ h₂ w₂, h => by

--- a/Mathlib/Combinatorics/SimpleGraph/Walk.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Walk.lean
@@ -718,9 +718,8 @@ theorem edges_injective {u v : V} : Function.Injective (Walk.edges : G.Walk u v 
   | .nil, .cons _ _, h => by simp at h
   | .cons _ _, .nil, h => by simp at h
   | .cons' u v c h₁ w₁, .cons' _ v' _ h₂ w₂, h => by
-    have h₁ : u ≠ v  := by rintro rfl; exact G.loopless _ h₁
-    have h₂ : u ≠ v' := by rintro rfl; exact G.loopless _ h₂
-    obtain ⟨rfl, h₃⟩ : v = v' ∧ w₁.edges = w₂.edges := by simpa [h₁, h₂] using h
+    have h₃ : u ≠ v' := by rintro rfl; exact G.loopless _ h₂
+    obtain ⟨rfl, h₃⟩ : v = v' ∧ w₁.edges = w₂.edges := by simpa [h₁, h₃] using h
     obtain rfl := Walk.edges_injective h₃
     rfl
 


### PR DESCRIPTION
Provide theorems stating that `SimpleGraph.Walk.darts` and `SimpleGraph.Walk.edges` are injective functions, and that the length of `SimpleGraph.Walk.IsTrail` and `SimpleGraph.Walk.IsPath` is bounded for finite graphs.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
