### PR TITLE
refactor(ConditionallyCompleteLattice): adhere to `csSup` vs. `sSup` naming convention

### DIFF
--- a/Mathlib/Data/ENNReal/Basic.lean
+++ b/Mathlib/Data/ENNReal/Basic.lean
@@ -617,11 +617,11 @@ end Order
 section CompleteLattice
 variable {ι : Sort*} {f : ι → ℝ≥0}
 
-theorem coe_sSup {s : Set ℝ≥0} : BddAbove s → (↑(sSup s) : ℝ≥0∞) = ⨆ a ∈ s, ↑a :=
-  WithTop.coe_sSup
+theorem coe_csSup {s : Set ℝ≥0} : BddAbove s → (↑(sSup s) : ℝ≥0∞) = ⨆ a ∈ s, ↑a :=
+  WithTop.coe_csSup
 
 theorem coe_sInf {s : Set ℝ≥0} (hs : s.Nonempty) : (↑(sInf s) : ℝ≥0∞) = ⨅ a ∈ s, ↑a :=
-  WithTop.coe_sInf hs (OrderBot.bddBelow s)
+  WithTop.coe_sInf hs
 
 theorem coe_iSup {ι : Sort*} {f : ι → ℝ≥0} (hf : BddAbove (range f)) :
     (↑(iSup f) : ℝ≥0∞) = ⨆ a, ↑(f a) :=
@@ -629,7 +629,7 @@ theorem coe_iSup {ι : Sort*} {f : ι → ℝ≥0} (hf : BddAbove (range f)) :
 
 @[norm_cast]
 theorem coe_iInf {ι : Sort*} [Nonempty ι] (f : ι → ℝ≥0) : (↑(iInf f) : ℝ≥0∞) = ⨅ a, ↑(f a) :=
-  WithTop.coe_iInf (OrderBot.bddBelow _)
+  WithTop.coe_iInf
 
 theorem coe_mem_upperBounds {s : Set ℝ≥0} :
     ↑r ∈ upperBounds (ofNNReal '' s) ↔ r ∈ upperBounds s := by

--- a/Mathlib/Data/ENNReal/Basic.lean
+++ b/Mathlib/Data/ENNReal/Basic.lean
@@ -625,6 +625,8 @@ variable {ι : Sort*} {f : ι → ℝ≥0}
 theorem coe_csSup {s : Set ℝ≥0} : BddAbove s → (↑(sSup s) : ℝ≥0∞) = ⨆ a ∈ s, ↑a :=
   WithTop.coe_csSup
 
+@[deprecated (since := "2024-08-09")] alias coe_sSup := coe_csSup
+
 theorem coe_sInf {s : Set ℝ≥0} (hs : s.Nonempty) : (↑(sInf s) : ℝ≥0∞) = ⨅ a ∈ s, ↑a :=
   WithTop.coe_sInf hs
 

--- a/Mathlib/Data/ENNReal/Basic.lean
+++ b/Mathlib/Data/ENNReal/Basic.lean
@@ -625,7 +625,7 @@ theorem coe_sInf {s : Set ℝ≥0} (hs : s.Nonempty) : (↑(sInf s) : ℝ≥0∞
 
 theorem coe_iSup {ι : Sort*} {f : ι → ℝ≥0} (hf : BddAbove (range f)) :
     (↑(iSup f) : ℝ≥0∞) = ⨆ a, ↑(f a) :=
-  WithTop.coe_iSup _ hf
+  WithTop.coe_ciSup _ hf
 
 @[norm_cast]
 theorem coe_iInf {ι : Sort*} [Nonempty ι] (f : ι → ℝ≥0) : (↑(iInf f) : ℝ≥0∞) = ⨅ a, ↑(f a) :=

--- a/Mathlib/Data/ENat/Lattice.lean
+++ b/Mathlib/Data/ENat/Lattice.lean
@@ -38,6 +38,8 @@ lemma iInf_coe_lt_top : ⨅ i, (f i : ℕ∞) < ⊤ ↔ Nonempty ι := WithTop.i
 
 lemma coe_csSup : BddAbove s → ↑(sSup s) = ⨆ a ∈ s, (a : ℕ∞) := WithTop.coe_csSup
 
+@[deprecated (since := "2024-08-09")] alias coe_sSup := coe_csSup
+
 lemma coe_sInf (hs : s.Nonempty) : ↑(sInf s) = ⨅ a ∈ s, (a : ℕ∞) := WithTop.coe_sInf hs
 
 lemma coe_iSup : BddAbove (range f) → ↑(⨆ i, f i) = ⨆ i, (f i : ℕ∞) := WithTop.coe_ciSup _

--- a/Mathlib/Data/ENat/Lattice.lean
+++ b/Mathlib/Data/ENat/Lattice.lean
@@ -33,15 +33,13 @@ lemma iInf_coe_ne_top : ⨅ i, (f i : ℕ∞) ≠ ⊤ ↔ Nonempty ι := by
   rw [Ne, iInf_coe_eq_top, not_isEmpty_iff]
 lemma iInf_coe_lt_top : ⨅ i, (f i : ℕ∞) < ⊤ ↔ Nonempty ι := WithTop.iInf_coe_lt_top
 
-lemma coe_sSup : BddAbove s → ↑(sSup s) = ⨆ a ∈ s, (a : ℕ∞) := WithTop.coe_sSup
+lemma coe_csSup : BddAbove s → ↑(sSup s) = ⨆ a ∈ s, (a : ℕ∞) := WithTop.coe_csSup
 
-lemma coe_sInf (hs : s.Nonempty) : ↑(sInf s) = ⨅ a ∈ s, (a : ℕ∞) :=
-  WithTop.coe_sInf hs (OrderBot.bddBelow s)
+lemma coe_sInf (hs : s.Nonempty) : ↑(sInf s) = ⨅ a ∈ s, (a : ℕ∞) := WithTop.coe_sInf hs
 
-lemma coe_iSup : BddAbove (range f) → ↑(⨆ i, f i) = ⨆ i, (f i : ℕ∞) := WithTop.coe_iSup _
+lemma coe_iSup : BddAbove (range f) → ↑(⨆ i, f i) = ⨆ i, (f i : ℕ∞) := WithTop.coe_ciSup _
 
-@[norm_cast] lemma coe_iInf [Nonempty ι] : ↑(⨅ i, f i) = ⨅ i, (f i : ℕ∞) :=
-  WithTop.coe_iInf (OrderBot.bddBelow _)
+@[norm_cast] lemma coe_iInf [Nonempty ι] : ↑(⨅ i, f i) = ⨅ i, (f i : ℕ∞) := WithTop.coe_iInf
 
 @[simp]
 lemma iInf_eq_top_of_isEmpty [IsEmpty ι] : ⨅ i, (f i : ℕ∞) = ⊤ :=

--- a/Mathlib/Order/ConditionallyCompleteLattice/Basic.lean
+++ b/Mathlib/Order/ConditionallyCompleteLattice/Basic.lean
@@ -60,21 +60,37 @@ noncomputable instance WithBot.instInfSet [InfSet α] :
     InfSet (WithBot α) :=
   ⟨(WithTop.instSupSet (α := αᵒᵈ)).sSup⟩
 
-theorem WithTop.sSup_eq [SupSet α] {s : Set (WithTop α)} (hs : ⊤ ∉ s)
+theorem WithTop.csSup_eq [SupSet α] {s : Set (WithTop α)} (hs : ⊤ ∉ s)
     (hs' : BddAbove ((↑) ⁻¹' s : Set α)) : sSup s = ↑(sSup ((↑) ⁻¹' s) : α) :=
   (if_neg hs).trans <| if_pos hs'
 
-theorem WithTop.sInf_eq [InfSet α] {s : Set (WithTop α)} (hs : ¬s ⊆ {⊤}) (h's : BddBelow s) :
+theorem WithTop.sSup_eq [SupSet α] [OrderTop α] {s : Set (WithTop α)} (hs : ⊤ ∉ s) :
+    sSup s = ↑(sSup ((↑) ⁻¹' s) : α) :=
+  WithTop.csSup_eq hs (OrderTop.bddAbove _)
+
+theorem WithTop.csInf_eq [InfSet α] {s : Set (WithTop α)} (hs : ¬s ⊆ {⊤}) (h's : BddBelow s) :
     sInf s = ↑(sInf ((↑) ⁻¹' s) : α) :=
   if_neg <| by simp [hs, h's]
 
-theorem WithBot.sInf_eq [InfSet α] {s : Set (WithBot α)} (hs : ⊥ ∉ s)
+theorem WithTop.sInf_eq [InfSet α] [OrderBot α] {s : Set (WithTop α)} (hs : ¬s ⊆ {⊤}) :
+    sInf s = ↑(sInf ((↑) ⁻¹' s) : α) :=
+  WithTop.csInf_eq hs (OrderBot.bddBelow _)
+
+theorem WithBot.csInf_eq [InfSet α] {s : Set (WithBot α)} (hs : ⊥ ∉ s)
     (hs' : BddBelow ((↑) ⁻¹' s : Set α)) : sInf s = ↑(sInf ((↑) ⁻¹' s) : α) :=
   (if_neg hs).trans <| if_pos hs'
 
-theorem WithBot.sSup_eq [SupSet α] {s : Set (WithBot α)} (hs : ¬s ⊆ {⊥}) (h's : BddAbove s) :
+theorem WithBot.sInf_eq [InfSet α] [OrderBot α] {s : Set (WithBot α)} (hs : ⊥ ∉ s) :
+    sInf s = ↑(sInf ((↑) ⁻¹' s) : α) :=
+  WithBot.csInf_eq hs (OrderBot.bddBelow _)
+
+theorem WithBot.csSup_eq [SupSet α] {s : Set (WithBot α)} (hs : ¬s ⊆ {⊥}) (h's : BddAbove s) :
     sSup s = ↑(sSup ((↑) ⁻¹' s) : α) :=
-  WithTop.sInf_eq (α := αᵒᵈ) hs h's
+  WithTop.csInf_eq (α := αᵒᵈ) hs h's
+
+theorem WithBot.sSup_eq [SupSet α] [OrderTop α] {s : Set (WithBot α)} (hs : ¬s ⊆ {⊥}) :
+    sSup s = ↑(sSup ((↑) ⁻¹' s) : α) :=
+  WithBot.csSup_eq hs (OrderTop.bddAbove _)
 
 @[simp]
 theorem WithTop.sInf_empty [InfSet α] : sInf (∅ : Set (WithTop α)) = ⊤ :=
@@ -84,7 +100,7 @@ theorem WithTop.sInf_empty [InfSet α] : sInf (∅ : Set (WithTop α)) = ⊤ :=
 theorem WithTop.iInf_empty [IsEmpty ι] [InfSet α] (f : ι → WithTop α) :
     ⨅ i, f i = ⊤ := by rw [iInf, range_eq_empty, WithTop.sInf_empty]
 
-theorem WithTop.coe_sInf' [InfSet α] {s : Set α} (hs : s.Nonempty) (h's : BddBelow s) :
+theorem WithTop.coe_csInf' [InfSet α] {s : Set α} (hs : s.Nonempty) (h's : BddBelow s) :
     ↑(sInf s) = (sInf ((fun (a : α) ↦ ↑a) '' s) : WithTop α) := by
   classical
   obtain ⟨x, hx⟩ := hs
@@ -96,12 +112,21 @@ theorem WithTop.coe_sInf' [InfSet α] {s : Set α} (hs : s.Nonempty) (h's : BddB
   · rw [preimage_image_eq]
     exact Option.some_injective _
 
-@[norm_cast]
-theorem WithTop.coe_iInf [Nonempty ι] [InfSet α] {f : ι → α} (hf : BddBelow (range f)) :
-    ↑(⨅ i, f i) = (⨅ i, f i : WithTop α) := by
-  rw [iInf, iInf, WithTop.coe_sInf' (range_nonempty f) hf, ← range_comp, Function.comp_def]
+theorem WithTop.coe_sInf' [InfSet α] [OrderBot α] {s : Set α} (hs : s.Nonempty)  :
+    ↑(sInf s) = (sInf ((fun (a : α) ↦ ↑a) '' s) : WithTop α) :=
+  WithTop.coe_csInf' hs (OrderBot.bddBelow _)
 
-theorem WithTop.coe_sSup' [SupSet α] {s : Set α} (hs : BddAbove s) :
+@[norm_cast]
+theorem WithTop.coe_ciInf [Nonempty ι] [InfSet α] {f : ι → α} (hf : BddBelow (range f)) :
+    ↑(⨅ i, f i) = (⨅ i, f i : WithTop α) := by
+  rw [iInf, iInf, WithTop.coe_csInf' (range_nonempty f) hf, ← range_comp, Function.comp_def]
+
+@[norm_cast]
+theorem WithTop.coe_iInf [Nonempty ι] [InfSet α] [OrderBot α] {f : ι → α} :
+    ↑(⨅ i, f i) = (⨅ i, f i : WithTop α) :=
+  WithTop.coe_ciInf (OrderBot.bddBelow _)
+
+theorem WithTop.coe_csSup' [SupSet α] {s : Set α} (hs : BddAbove s) :
     ↑(sSup s) = (sSup ((fun (a : α) ↦ ↑a) '' s) : WithTop α) := by
   classical
   change _ = ite _ _ _
@@ -109,10 +134,19 @@ theorem WithTop.coe_sSup' [SupSet α] {s : Set α} (hs : BddAbove s) :
   · exact Option.some_injective _
   · rintro ⟨x, _, ⟨⟩⟩
 
+theorem WithTop.coe_sSup' [SupSet α] [OrderTop α] {s : Set α} :
+    ↑(sSup s) = (sSup ((fun (a : α) ↦ ↑a) '' s) : WithTop α) :=
+  WithTop.coe_csSup' (OrderTop.bddAbove _)
+
 @[norm_cast]
-theorem WithTop.coe_iSup [SupSet α] (f : ι → α) (h : BddAbove (Set.range f)) :
+theorem WithTop.coe_ciSup [SupSet α] (f : ι → α) (h : BddAbove (Set.range f)) :
     ↑(⨆ i, f i) = (⨆ i, f i : WithTop α) := by
-  rw [iSup, iSup, WithTop.coe_sSup' h, ← range_comp, Function.comp_def]
+  rw [iSup, iSup, WithTop.coe_csSup' h, ← range_comp, Function.comp_def]
+
+@[norm_cast]
+theorem WithTop.coe_iSup [SupSet α] [OrderTop α] (f : ι → α) :
+    ↑(⨆ i, f i) = (⨆ i, f i : WithTop α) :=
+  WithTop.coe_ciSup f (OrderTop.bddAbove _)
 
 @[simp]
 theorem WithBot.sSup_empty [SupSet α] : sSup (∅ : Set (WithBot α)) = ⊥ :=
@@ -126,24 +160,44 @@ theorem WithBot.ciSup_empty [IsEmpty ι] [SupSet α] (f : ι → WithBot α) :
   WithTop.iInf_empty (α := αᵒᵈ) _
 
 @[norm_cast]
-theorem WithBot.coe_sSup' [SupSet α] {s : Set α} (hs : s.Nonempty) (h's : BddAbove s) :
+theorem WithBot.coe_csSup' [SupSet α] {s : Set α} (hs : s.Nonempty) (h's : BddAbove s) :
     ↑(sSup s) = (sSup ((fun (a : α) ↦ ↑a) '' s) : WithBot α) :=
-  WithTop.coe_sInf' (α := αᵒᵈ) hs h's
+  WithTop.coe_csInf' (α := αᵒᵈ) hs h's
 
 @[norm_cast]
-theorem WithBot.coe_iSup [Nonempty ι] [SupSet α] {f : ι → α} (hf : BddAbove (range f)) :
+theorem WithBot.coe_sSup' [SupSet α] [OrderTop α] {s : Set α} (hs : s.Nonempty) :
+    ↑(sSup s) = (sSup ((fun (a : α) ↦ ↑a) '' s) : WithBot α) :=
+  WithBot.coe_csSup' hs (OrderTop.bddAbove _)
+
+@[norm_cast]
+theorem WithBot.coe_ciSup [Nonempty ι] [SupSet α] {f : ι → α} (hf : BddAbove (range f)) :
     ↑(⨆ i, f i) = (⨆ i, f i : WithBot α) :=
-  WithTop.coe_iInf (α := αᵒᵈ) hf
+  WithTop.coe_ciInf (α := αᵒᵈ) hf
 
 @[norm_cast]
-theorem WithBot.coe_sInf' [InfSet α] {s : Set α} (hs : BddBelow s) :
+theorem WithBot.coe_iSup [Nonempty ι] [SupSet α] [OrderTop α] {f : ι → α} :
+    ↑(⨆ i, f i) = (⨆ i, f i : WithBot α) :=
+  WithBot.coe_ciSup (OrderTop.bddAbove _)
+
+@[norm_cast]
+theorem WithBot.coe_csInf' [InfSet α] {s : Set α} (hs : BddBelow s) :
     ↑(sInf s) = (sInf ((fun (a : α) ↦ ↑a) '' s) : WithBot α) :=
-  WithTop.coe_sSup' (α := αᵒᵈ) hs
+  WithTop.coe_csSup' (α := αᵒᵈ) hs
 
 @[norm_cast]
-theorem WithBot.coe_iInf [InfSet α] (f : ι → α) (h : BddBelow (Set.range f)) :
+theorem WithBot.coe_sInf' [InfSet α] [OrderBot α] {s : Set α} :
+    ↑(sInf s) = (sInf ((fun (a : α) ↦ ↑a) '' s) : WithBot α) :=
+  WithBot.coe_csInf' (OrderBot.bddBelow _)
+
+@[norm_cast]
+theorem WithBot.coe_ciInf [InfSet α] (f : ι → α) (h : BddBelow (Set.range f)) :
     ↑(⨅ i, f i) = (⨅ i, f i : WithBot α) :=
-  WithTop.coe_iSup (α := αᵒᵈ) _ h
+  WithTop.coe_ciSup (α := αᵒᵈ) _ h
+
+@[norm_cast]
+theorem WithBot.coe_iInf [InfSet α] [OrderBot α] (f : ι → α) :
+    ↑(⨅ i, f i) = (⨅ i, f i : WithBot α) :=
+  WithBot.coe_ciInf f (OrderBot.bddBelow _)
 
 end
 
@@ -1338,16 +1392,26 @@ noncomputable instance : CompleteLinearOrder (WithTop α) where
   le_sInf s := (isGLB_sInf s).2
   sInf_le s := (isGLB_sInf s).1
 
+/-- A version of `WithTop.coe_csSup'` with a more convenient but less general statement. -/
+@[norm_cast]
+theorem coe_csSup {s : Set α} (hb : BddAbove s) : ↑(sSup s) = (⨆ a ∈ s, ↑a : WithTop α) := by
+  rw [coe_csSup' hb, sSup_image]
+
 /-- A version of `WithTop.coe_sSup'` with a more convenient but less general statement. -/
 @[norm_cast]
-theorem coe_sSup {s : Set α} (hb : BddAbove s) : ↑(sSup s) = (⨆ a ∈ s, ↑a : WithTop α) := by
-  rw [coe_sSup' hb, sSup_image]
+theorem coe_sSup [OrderTop α] {s : Set α} : ↑(sSup s) = (⨆ a ∈ s, ↑a : WithTop α) :=
+  coe_csSup (OrderTop.bddAbove _)
 
-/-- A version of `WithTop.coe_sInf'` with a more convenient but less general statement. -/
+/-- A version of `WithTop.coe_csInf'` with a more convenient but less general statement. -/
 @[norm_cast]
-theorem coe_sInf {s : Set α} (hs : s.Nonempty) (h's : BddBelow s) :
+theorem coe_csInf {s : Set α} (hs : s.Nonempty) (h's : BddBelow s) :
     ↑(sInf s) = (⨅ a ∈ s, ↑a : WithTop α) := by
-  rw [coe_sInf' hs h's, sInf_image]
+  rw [coe_csInf' hs h's, sInf_image]
+
+@[norm_cast]
+theorem coe_sInf [OrderBot α] {s : Set α} (hs : s.Nonempty):
+    ↑(sInf s) = (⨅ a ∈ s, ↑a : WithTop α) :=
+  coe_csInf hs (OrderBot.bddBelow _)
 
 end WithTop
 

--- a/Mathlib/Order/ConditionallyCompleteLattice/Basic.lean
+++ b/Mathlib/Order/ConditionallyCompleteLattice/Basic.lean
@@ -86,6 +86,9 @@ theorem WithBot.csInf_eq [InfSet α] {s : Set (WithBot α)} (hs : ⊥ ∉ s)
     (hs' : BddBelow ((↑) ⁻¹' s : Set α)) : sInf s = ↑(sInf ((↑) ⁻¹' s) : α) :=
   (if_neg hs).trans <| if_pos hs'
 
+/--
+The more general version of this lemma, previously under this name, is now `WithBot.csInf_eq`.
+-/
 theorem WithBot.sInf_eq [InfSet α] [OrderBot α] {s : Set (WithBot α)} (hs : ⊥ ∉ s) :
     sInf s = ↑(sInf ((↑) ⁻¹' s) : α) :=
   WithBot.csInf_eq hs (OrderBot.bddBelow _)
@@ -94,6 +97,9 @@ theorem WithBot.csSup_eq [SupSet α] {s : Set (WithBot α)} (hs : ¬s ⊆ {⊥})
     sSup s = ↑(sSup ((↑) ⁻¹' s) : α) :=
   WithTop.csInf_eq (α := αᵒᵈ) hs h's
 
+/--
+The more general version of this lemma, previously under this name, is now `WithBot.csSup_eq`.
+-/
 theorem WithBot.sSup_eq [SupSet α] [OrderTop α] {s : Set (WithBot α)} (hs : ¬s ⊆ {⊥}) :
     sSup s = ↑(sSup ((↑) ⁻¹' s) : α) :=
   WithBot.csSup_eq hs (OrderTop.bddAbove _)

--- a/Mathlib/Order/ConditionallyCompleteLattice/Basic.lean
+++ b/Mathlib/Order/ConditionallyCompleteLattice/Basic.lean
@@ -64,6 +64,9 @@ theorem WithTop.csSup_eq [SupSet α] {s : Set (WithTop α)} (hs : ⊤ ∉ s)
     (hs' : BddAbove ((↑) ⁻¹' s : Set α)) : sSup s = ↑(sSup ((↑) ⁻¹' s) : α) :=
   (if_neg hs).trans <| if_pos hs'
 
+/--
+The more general version of this lemma, previously under this name, is now `WithTop.csSup_eq`.
+-/
 theorem WithTop.sSup_eq [SupSet α] [OrderTop α] {s : Set (WithTop α)} (hs : ⊤ ∉ s) :
     sSup s = ↑(sSup ((↑) ⁻¹' s) : α) :=
   WithTop.csSup_eq hs (OrderTop.bddAbove _)
@@ -72,6 +75,9 @@ theorem WithTop.csInf_eq [InfSet α] {s : Set (WithTop α)} (hs : ¬s ⊆ {⊤})
     sInf s = ↑(sInf ((↑) ⁻¹' s) : α) :=
   if_neg <| by simp [hs, h's]
 
+/--
+The more general version of this lemma, previously under this name, is now `WithTop.csInf_eq`.
+-/
 theorem WithTop.sInf_eq [InfSet α] [OrderBot α] {s : Set (WithTop α)} (hs : ¬s ⊆ {⊤}) :
     sInf s = ↑(sInf ((↑) ⁻¹' s) : α) :=
   WithTop.csInf_eq hs (OrderBot.bddBelow _)
@@ -112,6 +118,9 @@ theorem WithTop.coe_csInf' [InfSet α] {s : Set α} (hs : s.Nonempty) (h's : Bdd
   · rw [preimage_image_eq]
     exact Option.some_injective _
 
+/--
+The more general version of this lemma, previously under this name, is now `WithTop.coe_csInf'`.
+-/
 theorem WithTop.coe_sInf' [InfSet α] [OrderBot α] {s : Set α} (hs : s.Nonempty)  :
     ↑(sInf s) = (sInf ((fun (a : α) ↦ ↑a) '' s) : WithTop α) :=
   WithTop.coe_csInf' hs (OrderBot.bddBelow _)
@@ -121,6 +130,9 @@ theorem WithTop.coe_ciInf [Nonempty ι] [InfSet α] {f : ι → α} (hf : BddBel
     ↑(⨅ i, f i) = (⨅ i, f i : WithTop α) := by
   rw [iInf, iInf, WithTop.coe_csInf' (range_nonempty f) hf, ← range_comp, Function.comp_def]
 
+/--
+The more general version of this lemma, previously under this name, is now `WithTop.coe_ciInf'`.
+-/
 @[norm_cast]
 theorem WithTop.coe_iInf [Nonempty ι] [InfSet α] [OrderBot α] {f : ι → α} :
     ↑(⨅ i, f i) = (⨅ i, f i : WithTop α) :=
@@ -134,6 +146,9 @@ theorem WithTop.coe_csSup' [SupSet α] {s : Set α} (hs : BddAbove s) :
   · exact Option.some_injective _
   · rintro ⟨x, _, ⟨⟩⟩
 
+/--
+The more general version of this lemma, previously under this name, is now `WithTop.coe_csSup'`.
+-/
 theorem WithTop.coe_sSup' [SupSet α] [OrderTop α] {s : Set α} :
     ↑(sSup s) = (sSup ((fun (a : α) ↦ ↑a) '' s) : WithTop α) :=
   WithTop.coe_csSup' (OrderTop.bddAbove _)
@@ -143,6 +158,9 @@ theorem WithTop.coe_ciSup [SupSet α] (f : ι → α) (h : BddAbove (Set.range f
     ↑(⨆ i, f i) = (⨆ i, f i : WithTop α) := by
   rw [iSup, iSup, WithTop.coe_csSup' h, ← range_comp, Function.comp_def]
 
+/--
+The more general version of this lemma, previously under this name, is now `WithTop.coe_ciSup`.
+-/
 @[norm_cast]
 theorem WithTop.coe_iSup [SupSet α] [OrderTop α] (f : ι → α) :
     ↑(⨆ i, f i) = (⨆ i, f i : WithTop α) :=
@@ -164,6 +182,9 @@ theorem WithBot.coe_csSup' [SupSet α] {s : Set α} (hs : s.Nonempty) (h's : Bdd
     ↑(sSup s) = (sSup ((fun (a : α) ↦ ↑a) '' s) : WithBot α) :=
   WithTop.coe_csInf' (α := αᵒᵈ) hs h's
 
+/--
+The more general version of this lemma, previously under this name, is now `WithBot.coe_csSup'`.
+-/
 @[norm_cast]
 theorem WithBot.coe_sSup' [SupSet α] [OrderTop α] {s : Set α} (hs : s.Nonempty) :
     ↑(sSup s) = (sSup ((fun (a : α) ↦ ↑a) '' s) : WithBot α) :=
@@ -174,6 +195,9 @@ theorem WithBot.coe_ciSup [Nonempty ι] [SupSet α] {f : ι → α} (hf : BddAbo
     ↑(⨆ i, f i) = (⨆ i, f i : WithBot α) :=
   WithTop.coe_ciInf (α := αᵒᵈ) hf
 
+/--
+The more general version of this lemma, previously under this name, is now `WithBot.coe_ciSup`.
+-/
 @[norm_cast]
 theorem WithBot.coe_iSup [Nonempty ι] [SupSet α] [OrderTop α] {f : ι → α} :
     ↑(⨆ i, f i) = (⨆ i, f i : WithBot α) :=
@@ -184,6 +208,9 @@ theorem WithBot.coe_csInf' [InfSet α] {s : Set α} (hs : BddBelow s) :
     ↑(sInf s) = (sInf ((fun (a : α) ↦ ↑a) '' s) : WithBot α) :=
   WithTop.coe_csSup' (α := αᵒᵈ) hs
 
+/--
+The more general version of this lemma, previously under this name, is now `WithBot.coe_ciInf'`.
+-/
 @[norm_cast]
 theorem WithBot.coe_sInf' [InfSet α] [OrderBot α] {s : Set α} :
     ↑(sInf s) = (sInf ((fun (a : α) ↦ ↑a) '' s) : WithBot α) :=
@@ -194,6 +221,9 @@ theorem WithBot.coe_ciInf [InfSet α] (f : ι → α) (h : BddBelow (Set.range f
     ↑(⨅ i, f i) = (⨅ i, f i : WithBot α) :=
   WithTop.coe_ciSup (α := αᵒᵈ) _ h
 
+/--
+The more general version of this lemma, previously under this name, is now `WithBot.coe_ciInf`.
+-/
 @[norm_cast]
 theorem WithBot.coe_iInf [InfSet α] [OrderBot α] (f : ι → α) :
     ↑(⨅ i, f i) = (⨅ i, f i : WithBot α) :=
@@ -1397,7 +1427,11 @@ noncomputable instance : CompleteLinearOrder (WithTop α) where
 theorem coe_csSup {s : Set α} (hb : BddAbove s) : ↑(sSup s) = (⨆ a ∈ s, ↑a : WithTop α) := by
   rw [coe_csSup' hb, sSup_image]
 
-/-- A version of `WithTop.coe_sSup'` with a more convenient but less general statement. -/
+/--
+A version of `WithTop.coe_sSup'` with a more convenient but less general statement.
+
+The more general version of this lemma, previously under this name, is now `WithTop.coe_csSup'`.
+-/
 @[norm_cast]
 theorem coe_sSup [OrderTop α] {s : Set α} : ↑(sSup s) = (⨆ a ∈ s, ↑a : WithTop α) :=
   coe_csSup (OrderTop.bddAbove _)
@@ -1408,6 +1442,11 @@ theorem coe_csInf {s : Set α} (hs : s.Nonempty) (h's : BddBelow s) :
     ↑(sInf s) = (⨅ a ∈ s, ↑a : WithTop α) := by
   rw [coe_csInf' hs h's, sInf_image]
 
+/--
+A version of `WithTop.coe_sInf'` with a more convenient but less general statement.
+
+The more general version of this lemma, previously under this name, is now `WithTop.coe_csInf`.
+-/
 @[norm_cast]
 theorem coe_sInf [OrderBot α] {s : Set α} (hs : s.Nonempty):
     ↑(sInf s) = (⨅ a ∈ s, ↑a : WithTop α) :=

--- a/scripts/style-exceptions.txt
+++ b/scripts/style-exceptions.txt
@@ -17,7 +17,7 @@ Mathlib/Data/Finset/Basic.lean : line 1 : ERR_NUM_LIN : 3100 file contains 2999 
 Mathlib/Data/Finset/Lattice.lean : line 1 : ERR_NUM_LIN : 2100 file contains 1968 lines, try to split it up
 Mathlib/Data/Finset/Pointwise.lean : line 1 : ERR_NUM_LIN : 2200 file contains 2032 lines, try to split it up
 Mathlib/Data/Finsupp/Basic.lean : line 1 : ERR_NUM_LIN : 1900 file contains 1703 lines, try to split it up
-Mathlib/Data/List/Basic.lean : line 1 : ERR_NUM_LIN : 2900 file contains 2764 lines, try to split it up
+Mathlib/Data/List/Basic.lean : line 1 : ERR_NUM_LIN : 2700 file contains 2598 lines, try to split it up
 Mathlib/Data/Matrix/Basic.lean : line 1 : ERR_NUM_LIN : 2700 file contains 2519 lines, try to split it up
 Mathlib/Data/Multiset/Basic.lean : line 1 : ERR_NUM_LIN : 2900 file contains 2725 lines, try to split it up
 Mathlib/Data/Num/Lemmas.lean : line 1 : ERR_NUM_LIN : 1700 file contains 1576 lines, try to split it up

--- a/scripts/style-exceptions.txt
+++ b/scripts/style-exceptions.txt
@@ -42,7 +42,7 @@ Mathlib/MeasureTheory/Integral/SetIntegral.lean : line 1 : ERR_NUM_LIN : 1700 fi
 Mathlib/MeasureTheory/Integral/SetToL1.lean : line 1 : ERR_NUM_LIN : 1800 file contains 1640 lines, try to split it up
 Mathlib/MeasureTheory/Measure/MeasureSpace.lean : line 1 : ERR_NUM_LIN : 2200 file contains 2008 lines, try to split it up
 Mathlib/Order/CompleteLattice.lean : line 1 : ERR_NUM_LIN : 1900 file contains 1709 lines, try to split it up
-Mathlib/Order/ConditionallyCompleteLattice/Basic.lean : line 1 : ERR_NUM_LIN : 1700 file contains 1549 lines, try to split it up
+Mathlib/Order/ConditionallyCompleteLattice/Basic.lean : line 1 : ERR_NUM_LIN : 1900 file contains 1549 lines, try to split it up
 Mathlib/Order/Filter/AtTopBot.lean : line 1 : ERR_NUM_LIN : 2000 file contains 1828 lines, try to split it up
 Mathlib/Order/Filter/Basic.lean : line 1 : ERR_NUM_LIN : 3000 file contains 2898 lines, try to split it up
 Mathlib/Order/Hom/Lattice.lean : line 1 : ERR_NUM_LIN : 1800 file contains 1661 lines, try to split it up


### PR DESCRIPTION
We currently have
```
theorem WithTop.coe_iSup [SupSet α] (f : ι → α) (h : BddAbove (Set.range f)) :
    ↑(⨆ i, f i) = (⨆ i, f i : WithTop α)
```
and I wanted to add
```
theorem WithBot.coe_iSup_OrderTop {ι : Type*} [Nonempty ι] [SupSet α] [OrderTop α] {f : ι → α} :
    ↑(⨆ i, f i) = (⨆ i, f i : WithBot α) :=
  WithBot.coe_iSup (OrderTop.bddAbove (Set.range f))
```

Based on the docs at https://leanprover-community.github.io/mathlib4_docs/Mathlib/Order/ConditionallyCompleteLattice/Basic.html which state

> To differentiate the statements between complete lattices and conditionally complete lattices, we prefix `sInf` and `sSup` in the statements by `c`, giving `csInf` and `csSup`. For instance, [`sInf_le`](https://leanprover-community.github.io/mathlib4_docs/Mathlib/Order/CompleteLattice.html#sInf_le) is a statement in complete lattices ensuring `sInf s ≤ x`, while [`csInf_le`](https://leanprover-community.github.io/mathlib4_docs/Mathlib/Order/ConditionallyCompleteLattice/Basic.html#csInf_le) is the same statement in conditionally complete lattices with an additional assumption that `s` is bounded below.

This PR enformces that naming convention:

* A fair number of lemmas about `WithTop/Bot` and
  `iSup`/`sSup`/`iInf`/`sInf` with explicit `BddAbove` assumptions are
  renamed to have the `c` prefix.  
* For all these lemmas, a non `c`-prefix variant is added with
  `OrderTop`/`OrderBot` constraints.
* Docstrings are added/extended to mention this renaming.

Zulip discussion:
https://leanprover.zulipchat.com/#narrow/stream/287929-mathlib4/topic/WithTop.2Ecoe_iSup.20or.20WithTop.2Ecoe_ciSup

From the Carleson project.
