### PR TITLE
perf: work with `Expr`s rather than `Term`s in `linear_combination`

### DIFF
--- a/Mathlib/AlgebraicGeometry/EllipticCurve/Jacobian.lean
+++ b/Mathlib/AlgebraicGeometry/EllipticCurve/Jacobian.lean
@@ -392,7 +392,7 @@ lemma nonsingular_of_Z_eq_zero {P : Fin 3 → R} (hPz : P z = 0) :
 
 lemma nonsingular_zero [Nontrivial R] : W'.Nonsingular ![1, 1, 0] := by
   simp only [nonsingular_of_Z_eq_zero, equation_zero, true_and, fin3_def_ext, ← not_and_or]
-  exact fun h => one_ne_zero <| by linear_combination (norm := ring1) h.1 - h.2.1
+  exact fun h => one_ne_zero (α := R) <| by linear_combination (norm := ring1) h.1 - h.2.1
 
 lemma nonsingular_some (X Y : R) : W'.Nonsingular ![X, Y, 1] ↔ W'.toAffine.Nonsingular X Y := by
   simp_rw [nonsingular_iff, equation_some, fin3_def_ext, Affine.nonsingular_iff',

--- a/Mathlib/AlgebraicGeometry/EllipticCurve/Weierstrass.lean
+++ b/Mathlib/AlgebraicGeometry/EllipticCurve/Weierstrass.lean
@@ -245,29 +245,29 @@ lemma variableChange_comp (C C' : VariableChange R) (W : WeierstrassCurve R) :
     W.variableChange (C.comp C') = (W.variableChange C').variableChange C := by
   simp only [VariableChange.comp, variableChange]
   ext <;> simp only [mul_inv, Units.val_mul]
-  · linear_combination (norm := ring1) C.u⁻¹ * C.s * 2 * C'.u.inv_mul
+  · linear_combination (norm := ring1) ↑C.u⁻¹ * C.s * 2 * C'.u.inv_mul
   · linear_combination (norm := ring1)
-      C.s * (-C'.s * 2 - W.a₁) * C.u⁻¹ ^ 2 * C'.u⁻¹ * C'.u.inv_mul
+      C.s * (-C'.s * 2 - W.a₁) * C.u⁻¹ ^ 2 * ↑C'.u⁻¹ * C'.u.inv_mul
         + (C.r * 3 - C.s ^ 2) * C.u⁻¹ ^ 2 * pow_mul_pow_eq_one 2 C'.u.inv_mul
   · linear_combination (norm := ring1)
-      C.r * (C'.s * 2 + W.a₁) * C.u⁻¹ ^ 3 * C'.u⁻¹ * pow_mul_pow_eq_one 2 C'.u.inv_mul
+      C.r * (C'.s * 2 + W.a₁) * ↑C.u⁻¹ ^ 3 * ↑C'.u⁻¹ * pow_mul_pow_eq_one 2 C'.u.inv_mul
         + C.t * 2 * C.u⁻¹ ^ 3 * pow_mul_pow_eq_one 3 C'.u.inv_mul
   · linear_combination (norm := ring1)
-      C.s * (-W.a₃ - C'.r * W.a₁ - C'.t * 2) * C.u⁻¹ ^ 4 * C'.u⁻¹ ^ 3 * C'.u.inv_mul
-        + C.u⁻¹ ^ 4 * C'.u⁻¹ ^ 2 * (C.r * C'.r * 6 + C.r * W.a₂ * 2 - C'.s * C.r * W.a₁ * 2
+      C.s * (-W.a₃ - C'.r * W.a₁ - C'.t * 2) * ↑C.u⁻¹ ^ 4 * ↑C'.u⁻¹ ^ 3 * C'.u.inv_mul
+        + C.u⁻¹ ^ 4 * ↑C'.u⁻¹ ^ 2 * (C.r * C'.r * 6 + C.r * W.a₂ * 2 - C'.s * C.r * W.a₁ * 2
           - C'.s ^ 2 * C.r * 2) * pow_mul_pow_eq_one 2 C'.u.inv_mul
-        - C.u⁻¹ ^ 4 * C'.u⁻¹ * (C.s * C'.s * C.r * 2 + C.s * C.r * W.a₁ + C'.s * C.t * 2
+        - ↑C.u⁻¹ ^ 4 * ↑C'.u⁻¹ * (C.s * C'.s * C.r * 2 + C.s * C.r * W.a₁ + C'.s * C.t * 2
           + C.t * W.a₁) * pow_mul_pow_eq_one 3 C'.u.inv_mul
-        + C.u⁻¹ ^ 4 * (C.r ^ 2 * 3 - C.s * C.t * 2) * pow_mul_pow_eq_one 4 C'.u.inv_mul
+        + ↑C.u⁻¹ ^ 4 * (C.r ^ 2 * 3 - C.s * C.t * 2) * pow_mul_pow_eq_one 4 C'.u.inv_mul
   · linear_combination (norm := ring1)
-      C.r * C.u⁻¹ ^ 6 * C'.u⁻¹ ^ 4 * (C'.r * W.a₂ * 2 - C'.r * C'.s * W.a₁ + C'.r ^ 2 * 3 + W.a₄
+      C.r * C.u⁻¹ ^ 6 * ↑C'.u⁻¹ ^ 4 * (C'.r * W.a₂ * 2 - C'.r * C'.s * W.a₁ + C'.r ^ 2 * 3 + W.a₄
           - C'.s * C'.t * 2 - C'.s * W.a₃ - C'.t * W.a₁) * pow_mul_pow_eq_one 2 C'.u.inv_mul
-        - C.u⁻¹ ^ 6 * C'.u⁻¹ ^ 3 * C.t * (C'.r * W.a₁ + C'.t * 2 + W.a₃)
+        - ↑C.u⁻¹ ^ 6 * ↑C'.u⁻¹ ^ 3 * C.t * (C'.r * W.a₁ + C'.t * 2 + W.a₃)
           * pow_mul_pow_eq_one 3 C'.u.inv_mul
-        + C.r ^ 2 * C.u⁻¹ ^ 6 * C'.u⁻¹ ^ 2 * (C'.r * 3 + W.a₂ - C'.s * W.a₁ - C'.s ^ 2)
+        + C.r ^ 2 * ↑C.u⁻¹ ^ 6 * C'.u⁻¹ ^ 2 * (C'.r * 3 + W.a₂ - C'.s * W.a₁ - C'.s ^ 2)
           * pow_mul_pow_eq_one 4 C'.u.inv_mul
-        - C.r * C.t * C.u⁻¹ ^ 6 * C'.u⁻¹ * (C'.s * 2 + W.a₁) * pow_mul_pow_eq_one 5 C'.u.inv_mul
-        + C.u⁻¹ ^ 6 * (C.r ^ 3 - C.t ^ 2) * pow_mul_pow_eq_one 6 C'.u.inv_mul
+        - C.r * C.t * ↑C.u⁻¹ ^ 6 * ↑C'.u⁻¹ * (C'.s * 2 + W.a₁) * pow_mul_pow_eq_one 5 C'.u.inv_mul
+        + ↑C.u⁻¹ ^ 6 * (C.r ^ 3 - C.t ^ 2) * pow_mul_pow_eq_one 6 C'.u.inv_mul
 
 instance instMulActionVariableChange : MulAction (VariableChange R) (WeierstrassCurve R) where
   smul := fun C W => W.variableChange C

--- a/Mathlib/Tactic/LinearCombination.lean
+++ b/Mathlib/Tactic/LinearCombination.lean
@@ -178,9 +178,8 @@ def elabLinearCombination
         let mvar ← mkFreshExprMVar q($a' - $b' - ($a - $b) = 0)
         pure (q(eq_of_add (a' := $a') (b' := $b') $p), #[mvar])
   (← Tactic.getMainGoal).assign (mkAppN e mvars)
-  for mvar in mvars do
-    Tactic.setGoals [mvar.mvarId!]
-    Tactic.evalTactic norm
+  Tactic.setGoals (mvars.toList.map Expr.mvarId!)
+  Tactic.allGoals (Tactic.evalTactic norm)
 
 /--
 The `(norm := $tac)` syntax says to use `tac` as a normalization postprocessor for

--- a/Mathlib/Tactic/LinearCombination.lean
+++ b/Mathlib/Tactic/LinearCombination.lean
@@ -124,7 +124,7 @@ partial def expandLinearCombo {u : Level} (α : Q(Type u)) : Term → TermElabM 
     | none =>
       -- unfortunately we should now re-elaborate `e`, knowing that it represents a constant of
       -- type `α`
-      let e' ← elabTerm e (some α)
+      let e' ← elabTermEnsuringTypeQ e α
       synthesizeSyntheticMVarsNoPostponing
       return LinearCombination.const e'
 

--- a/Mathlib/Tactic/LinearCombination.lean
+++ b/Mathlib/Tactic/LinearCombination.lean
@@ -141,7 +141,7 @@ theorem eq_of_add_pow [Ring α] [NoZeroDivisors α] (n : ℕ) (p : (a:α) = b)
 def elabLinearCombination
     (norm? : Option Syntax.Tactic) (exp? : Option Syntax.NumLit) (input : Option Syntax.Term)
     (twoGoals := false) : Tactic.TacticM Unit := Tactic.withMainContext do
-  let eqData := (← Lean.Elab.Tactic.getMainTarget).eq?.get!
+  let eqData := (← Tactic.getMainTarget).consumeMData.eq?.get!
   let .sort u ← whnf (← inferType eqData.1) | unreachable!
   let some v := u.dec | throwError "not a type"
   let ((α : Q(Type v)), (a' : Q($α)), (b':Q($α))) := eqData

--- a/Mathlib/Tactic/LinearCombination.lean
+++ b/Mathlib/Tactic/LinearCombination.lean
@@ -175,13 +175,10 @@ def elabLinearCombination
         let _i ← synthInstanceQ q(AddGroup ($α : Type v))
         let mvar ← mkFreshExprMVar q($a' - $b' - ($a - $b) = 0)
         pure (q(eq_of_add (a' := $a') (b' := $b') $p), #[mvar])
-  Tactic.liftMetaTactic fun g ↦ do
-    g.assign (mkAppN e mvars)
-    return mvars.toList.map Expr.mvarId!
-  let mvarIds ← Tactic.getGoals
-  for mvarId in mvarIds do
-      Tactic.setGoals [mvarId]
-      Tactic.evalTactic norm
+  (← Tactic.getMainGoal).assign (mkAppN e mvars)
+  for mvar in mvars do
+    Tactic.setGoals [mvar.mvarId!]
+    Tactic.evalTactic norm
 
 /--
 The `(norm := $tac)` syntax says to use `tac` as a normalization postprocessor for

--- a/Mathlib/Tactic/LinearCombination.lean
+++ b/Mathlib/Tactic/LinearCombination.lean
@@ -66,15 +66,13 @@ namespace LinearCombination
 /--
 Performs macro expansion of a linear combination expression,
 using `+`/`-`/`*`/`/` on equations and values.
-* `some p` means that `p` is a syntax corresponding to a proof of an equation.
+* `.proof a b p` means that `p` is a syntax corresponding to a proof of an equation.
   For example, if `h : a = b` then `expandLinearCombo (2 * h)` returns `some (c_add_pf 2 h)`
   which is a proof of `2 * a = 2 * b`.
-* `none` means that the input expression is not an equation but a value;
+* `.const e` means that the input expression is not an equation but a value;
   the input syntax itself is used in this case.
 -/
-partial def expandLinearCombo {u : Level} (α : Q(Type u)) (stx : Syntax.Term) :
-    TermElabM (LinearCombination α) := do
-  match stx with
+partial def expandLinearCombo {u : Level} (α : Q(Type u)) : Term → TermElabM (LinearCombination α)
   | `(($e)) => expandLinearCombo α e
   | `($e₁ + $e₂) => do
     let _i ← synthInstanceQ q(Add $α)
@@ -126,9 +124,9 @@ partial def expandLinearCombo {u : Level} (α : Q(Type u)) (stx : Syntax.Term) :
     | none =>
       -- unfortunately we should now re-elaborate `e`, knowing that it represents a constant of
       -- type `α`
-      let e ← elabTerm e (some α)
+      let e' ← elabTerm e (some α)
       synthesizeSyntheticMVarsNoPostponing
-      return LinearCombination.const e
+      return LinearCombination.const e'
 
 theorem eq_trans₃ (p : (a:α) = b) (p₁ : a = a') (p₂ : b = b') : a' = b' := p₁ ▸ p₂ ▸ p
 

--- a/Mathlib/Tactic/LinearCombination.lean
+++ b/Mathlib/Tactic/LinearCombination.lean
@@ -30,11 +30,12 @@ Lastly, calls a normalization tactic on this target.
 
 -/
 
-namespace Mathlib.Tactic.LinearCombination
+namespace Mathlib.Tactic
 open Lean hiding Rat
-open Elab Meta Term
+open Elab Meta Term Qq
 
 variable {α : Type*} {a a' a₁ a₂ b b' b₁ b₂ c : α}
+namespace LinearCombination
 
 theorem pf_add_c [Add α] (p : a = b) (c : α) : a + c = b + c := p ▸ rfl
 theorem c_add_pf [Add α] (p : b = c) (a : α) : a + b = a + c := p ▸ rfl
@@ -51,11 +52,16 @@ theorem pf_div_c [Div α] (p : a = b) (c : α) : a / c = b / c := p ▸ rfl
 theorem c_div_pf [Div α] (p : b = c) (a : α) : a / b = a / c := p ▸ rfl
 theorem div_pf [Div α] (p₁ : (a₁:α) = b₁) (p₂ : a₂ = b₂) : a₁ / a₂ = b₁ / b₂ := p₁ ▸ p₂ ▸ rfl
 
-open Qq
+end LinearCombination
 
-inductive _root_.Mathlib.Tactic.LinearCombination {u : Level} (α : Q(Type u))
+/-- Basic data structure for the `linear_combination` tactic: the subexpressions of a term presented
+as an argument to the `linear_combination` tactic are supposed to represent either constants (of
+type `α`) or proofs of equality between two terms of type `alpha`. -/
+inductive LinearCombination {u : Level} (α : Q(Type u))
   | const : Q($α) → LinearCombination α
   | proof (a b : Q($α)) : Q($a = $b) → LinearCombination α
+
+namespace LinearCombination
 
 /--
 Performs macro expansion of a linear combination expression,

--- a/Mathlib/Tactic/LinearCombination.lean
+++ b/Mathlib/Tactic/LinearCombination.lean
@@ -66,11 +66,11 @@ namespace LinearCombination
 /--
 Performs macro expansion of a linear combination expression,
 using `+`/`-`/`*`/`/` on equations and values.
-* `.proof a b p` means that `p` is a syntax corresponding to a proof of the equation `a = b`.
-  For example, if `h : x = y` then `expandLinearCombo (2 * h)` returns `some (c_add_pf 2 h)`
-  which is a proof of `2 * x = 2 * y`.
+* `.proof a b p` means that `p` is an expression corresponding to a proof of the equation `a = b`.
+  For example, if `h : x = y` then `expandLinearCombo _ (2 * h)` returns
+  `.proof (2 * x) (2 * y) (c_add_pf 2 h)` which represents a proof of `2 * x = 2 * y`.
 * `.const e` means that the input expression is not an equation but a value;
-  the input syntax itself is used in this case.
+  the input syntax itself is elaborated and used in this case.
 -/
 partial def expandLinearCombo {u : Level} (α : Q(Type u)) : Term → TermElabM (LinearCombination α)
   | `(($e)) => expandLinearCombo α e

--- a/Mathlib/Tactic/LinearCombination.lean
+++ b/Mathlib/Tactic/LinearCombination.lean
@@ -66,9 +66,9 @@ namespace LinearCombination
 /--
 Performs macro expansion of a linear combination expression,
 using `+`/`-`/`*`/`/` on equations and values.
-* `.proof a b p` means that `p` is a syntax corresponding to a proof of an equation.
-  For example, if `h : a = b` then `expandLinearCombo (2 * h)` returns `some (c_add_pf 2 h)`
-  which is a proof of `2 * a = 2 * b`.
+* `.proof a b p` means that `p` is a syntax corresponding to a proof of the equation `a = b`.
+  For example, if `h : x = y` then `expandLinearCombo (2 * h)` returns `some (c_add_pf 2 h)`
+  which is a proof of `2 * x = 2 * y`.
 * `.const e` means that the input expression is not an equation but a value;
   the input syntax itself is used in this case.
 -/

--- a/test/linear_combination.lean
+++ b/test/linear_combination.lean
@@ -274,3 +274,9 @@ example (K : Type*) [Field K] [CharZero K] {x y z p q : K}
             59049 * q ^ 7 * p * x ^ 2) *
           h₂
   exact test_sorry
+
+set_option linter.unusedTactic false in
+example {a b c : ℤ} (h1 : a = 2) (h2 : b = c) : a + b = 2 + c := by
+  linear_combination2 (norm := skip) h1 + h2
+  · ring
+  · ring

--- a/test/linear_combination.lean
+++ b/test/linear_combination.lean
@@ -4,6 +4,8 @@ import Mathlib.Tactic.Linarith
 
 set_option autoImplicit true
 
+private axiom test_sorry : ∀ {α}, α
+
 -- We deliberately mock R here so that we don't have to import the deps
 axiom Real : Type
 notation "ℝ" => Real
@@ -236,15 +238,15 @@ example {r s a b : ℕ} (h₁ : (r : ℤ) = a + 1) (h₂ : (s : ℤ) = b + 1) :
     r * s = (a + 1 : ℤ) * (b + 1) := by
   linear_combination (↑b + 1) * h₁ + ↑r * h₂
 
--- Macro-heavy implementation at the time of the port (Nov 2022) was 120,000 heartbeats
--- Reimplementation using Qq (Aug 2024) brings this to 20,000 heartbeats
-set_option maxHeartbeats 30000 in
+-- Macro-heavy implementation at the time of the port (Nov 2022) was 110,000 heartbeats
+-- Reimplementation using Qq (Aug 2024) brings this to 7,500 heartbeats
+set_option maxHeartbeats 10000 in
 example (K : Type*) [Field K] [CharZero K] {x y z p q : K}
     (h₀ : 3 * x ^ 2 + z ^ 2 * p = 0)
     (h₁ : z * (2 * y) = 0)
     (h₂ : -y ^ 2 + p * x * (2 * z) + q * (3 * z ^ 2) = 0) :
     ((27 * q ^ 2 + 4 * p ^ 3) * x) ^ 4 = 0 := by
-  linear_combination
+  linear_combination (norm := skip)
     (256 / 3 * p ^ 12 * x ^ 2 + 128 * q * p ^ 11 * x * z + 2304 * q ^ 2 * p ^ 9 * x ^ 2 +
                                 2592 * q ^ 3 * p ^ 8 * x * z -
                               64 * q * p ^ 10 * y ^ 2 +
@@ -271,3 +273,4 @@ example (K : Type*) [Field K] [CharZero K] {x y z p q : K}
               13122 * q ^ 6 * p ^ 3 * x * z -
             59049 * q ^ 7 * p * x ^ 2) *
           h₂
+  exact test_sorry

--- a/test/linear_combination.lean
+++ b/test/linear_combination.lean
@@ -118,6 +118,10 @@ example {α} [h : CommRing α] {a b c d e f : α} (h1 : a * d = b * c) (h2 : c *
 example (x y z w : ℚ) (hzw : z = w) : x * z + 2 * y * z = x * w + 2 * y * w := by
   linear_combination (x + 2 * y) * hzw
 
+example (x : ℤ) : x ^ 2 = x ^ 2 := by linear_combination x ^ 2
+
+example (x y : ℤ) (h : x = 0) : y ^ 2 * x = 0 := by linear_combination y ^ 2 * h
+
 /-! ### Cases that explicitly use a config -/
 
 example (x y : ℚ) (h1 : 3 * x + 2 * y = 10) (h2 : 2 * x + 5 * y = 3) : -11 * y + 1 = 11 + 1 := by
@@ -230,3 +234,39 @@ example (h : g a = g b) : a ^ 4 = b ^ 4 := by
 example {r s a b : ℕ} (h₁ : (r : ℤ) = a + 1) (h₂ : (s : ℤ) = b + 1) :
     r * s = (a + 1 : ℤ) * (b + 1) := by
   linear_combination (↑b + 1) * h₁ + ↑r * h₂
+
+-- Macro-heavy implementation at the time of the port (Nov 2022) was 120,000 heartbeats
+-- Reimplementation using Qq (Aug 2024) brings this to 20,000 heartbeats
+set_option maxHeartbeats 30000 in
+example (K : Type*) [Field K] [CharZero K] {x y z p q : K}
+    (h₀ : 3 * x ^ 2 + z ^ 2 * p = 0)
+    (h₁ : z * (2 * y) = 0)
+    (h₂ : -y ^ 2 + p * x * (2 * z) + q * (3 * z ^ 2) = 0) :
+    ((27 * q ^ 2 + 4 * p ^ 3) * x) ^ 4 = 0 := by
+  linear_combination
+    (256 / 3 * p ^ 12 * x ^ 2 + 128 * q * p ^ 11 * x * z + 2304 * q ^ 2 * p ^ 9 * x ^ 2 +
+                                2592 * q ^ 3 * p ^ 8 * x * z -
+                              64 * q * p ^ 10 * y ^ 2 +
+                            23328 * q ^ 4 * p ^ 6 * x ^ 2 +
+                          17496 * q ^ 5 * p ^ 5 * x * z -
+                        1296 * q ^ 3 * p ^ 7 * y ^ 2 +
+                      104976 * q ^ 6 * p ^ 3 * x ^ 2 +
+                    39366 * q ^ 7 * p ^ 2 * x * z -
+                  8748 * q ^ 5 * p ^ 4 * y ^ 2 +
+                177147 * q ^ 8 * x ^ 2 -
+              19683 * q ^ 7 * p * y ^ 2) *
+            h₀ +
+          (-(64 / 3 * p ^ 12 * x * y) + 32 * q * p ^ 11 * z * y - 432 * q ^ 2 * p ^ 9 * x * y +
+                      648 * q ^ 3 * p ^ 8 * z * y -
+                    2916 * q ^ 4 * p ^ 6 * x * y +
+                  4374 * q ^ 5 * p ^ 5 * z * y -
+                6561 * q ^ 6 * p ^ 3 * x * y +
+              19683 / 2 * q ^ 7 * p ^ 2 * z * y) *
+            h₁ +
+        (-(128 / 3 * p ^ 12 * x * z) - 192 * q * p ^ 10 * x ^ 2 - 864 * q ^ 2 * p ^ 9 * x * z -
+                    3888 * q ^ 3 * p ^ 7 * x ^ 2 -
+                  5832 * q ^ 4 * p ^ 6 * x * z -
+                26244 * q ^ 5 * p ^ 4 * x ^ 2 -
+              13122 * q ^ 6 * p ^ 3 * x * z -
+            59049 * q ^ 7 * p * x ^ 2) *
+          h₂

--- a/test/linear_combination.lean
+++ b/test/linear_combination.lean
@@ -186,6 +186,7 @@ example (x y : ℤ) (h1 : x * y + 2 * x = 1) (h2 : x = y) : x * y = -2 * y + 1 :
 --   the equations it is being combined with.  This was a design choice for the
 --   sake of simplicity, but the tactic could potentially be modified to allow
 --   this behavior.
+set_option linter.unusedVariables false in
 example (x y : ℤ) (h1 : x * y + 2 * x = 1) (h2 : x = y) : x * y + 2 * x = 1 := by
   fail_if_success linear_combination h1 + (0 : ℝ) * h2
   linear_combination h1


### PR DESCRIPTION
This is a rewrite of the proof-construction in the `linear_combination` tactic to work around the issue https://github.com/leanprover/lean4/issues/4861.  Previously, a proof was built up as a `Term`, like
```
``(pf_add_c $p₁ $e₂)
```
The change is to instead build it up as an `Expr`, like `q(pf_add_c $p₁ $e₂)`.

I don't fully understand why, but this gives a 10x speedup on (at least some) large examples.  I have added one such example (which arose in real life as a `polyrith` output) to the test file.  There doesn't seem to be any big change on "normal-sized" examples -- it's possibly a little faster, but not much.

Trade-offs in this implementation:
- The tactic no longer solves equality goals in which the type is a metavariable.
- The default interpretation of coercions in coefficients of a `linear_combination` is now "deeper in", so coercions "on the outside" of a coefficient need to be written manually.  Example: for `a : Kˣ`, `x y : K`, and `h : x = y`, the coefficient `a⁻¹` in `linear_combination a⁻¹ * h` is now parsed as `(a:K)⁻¹`, so it is necessary to write `↑a⁻¹` to have the coercion happen outside the inversion. 

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
