### PR TITLE
[Merged by Bors] - chore: backports for leanprover/lean4#4814 (part 31)

### DIFF
--- a/Mathlib/Analysis/NormedSpace/HahnBanach/Separation.lean
+++ b/Mathlib/Analysis/NormedSpace/HahnBanach/Separation.lean
@@ -205,8 +205,7 @@ theorem iInter_halfspaces_eq (hs₁ : Convex ℝ s) (hs₂ : IsClosed s) :
 
 namespace RCLike
 
-variable [RCLike 𝕜] [TopologicalSpace E] [AddCommGroup E] [TopologicalAddGroup E]
-  [Module 𝕜 E] [Module ℝ E] [ContinuousSMul 𝕜 E] [IsScalarTower ℝ 𝕜 E]
+variable [RCLike 𝕜] [Module 𝕜 E] [ContinuousSMul 𝕜 E] [IsScalarTower ℝ 𝕜 E]
 
 /--Real linear extension of continuous extension of `LinearMap.extendTo𝕜'` -/
 noncomputable def extendTo𝕜'ₗ : (E →L[ℝ] ℝ) →ₗ[ℝ] (E →L[𝕜] 𝕜) :=

--- a/Mathlib/CategoryTheory/Triangulated/Yoneda.lean
+++ b/Mathlib/CategoryTheory/Triangulated/Yoneda.lean
@@ -48,7 +48,8 @@ lemma preadditiveYoneda_map_distinguished
 noncomputable instance (A : Cᵒᵖ) : (preadditiveCoyoneda.obj A).ShiftSequence ℤ :=
   Functor.ShiftSequence.tautological _ _
 
-lemma preadditiveCoyoneda_homologySequenceδ_apply {C : Type*} [Category C] [Preadditive C] [HasShift C ℤ]
+lemma preadditiveCoyoneda_homologySequenceδ_apply
+    {C : Type*} [Category C] [Preadditive C] [HasShift C ℤ]
     (A : Cᵒᵖ) (T : Triangle C) (n₀ n₁ : ℤ) (h : n₀ + 1 = n₁) (x : A.unop ⟶ T.obj₃⟦n₀⟧) :
     (preadditiveCoyoneda.obj A).homologySequenceδ T n₀ n₁ h x =
       x ≫ T.mor₃⟦n₀⟧' ≫ (shiftFunctorAdd' C 1 n₀ n₁ (by omega)).inv.app _ := by

--- a/Mathlib/CategoryTheory/Triangulated/Yoneda.lean
+++ b/Mathlib/CategoryTheory/Triangulated/Yoneda.lean
@@ -48,7 +48,7 @@ lemma preadditiveYoneda_map_distinguished
 noncomputable instance (A : Cᵒᵖ) : (preadditiveCoyoneda.obj A).ShiftSequence ℤ :=
   Functor.ShiftSequence.tautological _ _
 
-lemma preadditiveCoyoneda_homologySequenceδ_apply
+lemma preadditiveCoyoneda_homologySequenceδ_apply {C} [Category C] [Preadditive C] [HasShift C ℤ]
     (A : Cᵒᵖ) (T : Triangle C) (n₀ n₁ : ℤ) (h : n₀ + 1 = n₁) (x : A.unop ⟶ T.obj₃⟦n₀⟧) :
     (preadditiveCoyoneda.obj A).homologySequenceδ T n₀ n₁ h x =
       x ≫ T.mor₃⟦n₀⟧' ≫ (shiftFunctorAdd' C 1 n₀ n₁ (by omega)).inv.app _ := by

--- a/Mathlib/CategoryTheory/Triangulated/Yoneda.lean
+++ b/Mathlib/CategoryTheory/Triangulated/Yoneda.lean
@@ -48,7 +48,7 @@ lemma preadditiveYoneda_map_distinguished
 noncomputable instance (A : Cᵒᵖ) : (preadditiveCoyoneda.obj A).ShiftSequence ℤ :=
   Functor.ShiftSequence.tautological _ _
 
-lemma preadditiveCoyoneda_homologySequenceδ_apply {C} [Category C] [Preadditive C] [HasShift C ℤ]
+lemma preadditiveCoyoneda_homologySequenceδ_apply {C : Type*} [Category C] [Preadditive C] [HasShift C ℤ]
     (A : Cᵒᵖ) (T : Triangle C) (n₀ n₁ : ℤ) (h : n₀ + 1 = n₁) (x : A.unop ⟶ T.obj₃⟦n₀⟧) :
     (preadditiveCoyoneda.obj A).homologySequenceδ T n₀ n₁ h x =
       x ≫ T.mor₃⟦n₀⟧' ≫ (shiftFunctorAdd' C 1 n₀ n₁ (by omega)).inv.app _ := by

--- a/Mathlib/MeasureTheory/Integral/Marginal.lean
+++ b/Mathlib/MeasureTheory/Integral/Marginal.lean
@@ -65,7 +65,7 @@ namespace MeasureTheory
 section LMarginal
 
 variable {δ δ' : Type*} {π : δ → Type*} [∀ x, MeasurableSpace (π x)]
-variable {μ : ∀ i, Measure (π i)} [∀ i, SigmaFinite (μ i)] [DecidableEq δ]
+variable {μ : ∀ i, Measure (π i)} [DecidableEq δ]
 variable {s t : Finset δ} {f g : (∀ i, π i) → ℝ≥0∞} {x y : ∀ i, π i} {i : δ}
 
 /-- Integrate `f(x₁,…,xₙ)` over all variables `xᵢ` where `i ∈ s`. Return a function in the
@@ -85,7 +85,8 @@ notation "∫⋯∫⁻_" s ", " f => lmarginal (fun _ ↦ volume) s f
 
 variable (μ)
 
-theorem _root_.Measurable.lmarginal (hf : Measurable f) : Measurable (∫⋯∫⁻_s, f ∂μ) := by
+theorem _root_.Measurable.lmarginal [∀ i, SigmaFinite (μ i)] (hf : Measurable f) :
+    Measurable (∫⋯∫⁻_s, f ∂μ) := by
   refine Measurable.lintegral_prod_right ?_
   refine hf.comp ?_
   rw [measurable_pi_iff]; intro i
@@ -113,6 +114,25 @@ theorem lmarginal_update_of_mem {i : δ} (hi : i ∈ s)
   have : j ≠ i := by rintro rfl; exact hj hi
   apply update_noteq this
 
+variable {μ} in
+theorem lmarginal_singleton (f : (∀ i, π i) → ℝ≥0∞) (i : δ) :
+    ∫⋯∫⁻_{i}, f ∂μ = fun x => ∫⁻ xᵢ, f (Function.update x i xᵢ) ∂μ i := by
+  let α : Type _ := ({i} : Finset δ)
+  let e := (MeasurableEquiv.piUnique fun j : α ↦ π j).symm
+  ext1 x
+  calc (∫⋯∫⁻_{i}, f ∂μ) x
+      = ∫⁻ (y : π (default : α)), f (updateFinset x {i} (e y)) ∂μ (default : α) := by
+        simp_rw [lmarginal, measurePreserving_piUnique (fun j : ({i} : Finset δ) ↦ μ j) |>.symm _
+          |>.lintegral_map_equiv]
+    _ = ∫⁻ xᵢ, f (Function.update x i xᵢ) ∂μ i := by simp [update_eq_updateFinset]; rfl
+
+variable {μ} in
+@[gcongr]
+theorem lmarginal_mono {f g : (∀ i, π i) → ℝ≥0∞} (hfg : f ≤ g) : ∫⋯∫⁻_s, f ∂μ ≤ ∫⋯∫⁻_s, g ∂μ :=
+  fun _ => lintegral_mono fun _ => hfg _
+
+variable [∀ i, SigmaFinite (μ i)]
+
 theorem lmarginal_union (f : (∀ i, π i) → ℝ≥0∞) (hf : Measurable f)
     (hst : Disjoint s t) : ∫⋯∫⁻_s ∪ t, f ∂μ = ∫⋯∫⁻_s, ∫⋯∫⁻_t, f ∂μ ∂μ := by
   ext1 x
@@ -137,17 +157,6 @@ theorem lmarginal_union' (f : (∀ i, π i) → ℝ≥0∞) (hf : Measurable f) 
   rw [Finset.union_comm, lmarginal_union μ f hf hst.symm]
 
 variable {μ}
-
-theorem lmarginal_singleton (f : (∀ i, π i) → ℝ≥0∞) (i : δ) :
-    ∫⋯∫⁻_{i}, f ∂μ = fun x => ∫⁻ xᵢ, f (Function.update x i xᵢ) ∂μ i := by
-  let α : Type _ := ({i} : Finset δ)
-  let e := (MeasurableEquiv.piUnique fun j : α ↦ π j).symm
-  ext1 x
-  calc (∫⋯∫⁻_{i}, f ∂μ) x
-      = ∫⁻ (y : π (default : α)), f (updateFinset x {i} (e y)) ∂μ (default : α) := by
-        simp_rw [lmarginal, measurePreserving_piUnique (fun j : ({i} : Finset δ) ↦ μ j) |>.symm _
-          |>.lintegral_map_equiv]
-    _ = ∫⁻ xᵢ, f (Function.update x i xᵢ) ∂μ i := by simp [update_eq_updateFinset]; rfl
 
 /-- Peel off a single integral from a `lmarginal` integral at the beginning (compare with
 `lmarginal_insert'`, which peels off an integral at the end). -/
@@ -178,12 +187,6 @@ theorem lmarginal_erase' (f : (∀ i, π i) → ℝ≥0∞) (hf : Measurable f) 
     (hi : i ∈ s) :
     ∫⋯∫⁻_s, f ∂μ = ∫⋯∫⁻_(erase s i), (fun x ↦ ∫⁻ xᵢ, f (Function.update x i xᵢ) ∂μ i) ∂μ := by
   simpa [insert_erase hi] using lmarginal_insert' _ hf (not_mem_erase i s)
-
-open Filter
-
-@[gcongr]
-theorem lmarginal_mono {f g : (∀ i, π i) → ℝ≥0∞} (hfg : f ≤ g) : ∫⋯∫⁻_s, f ∂μ ≤ ∫⋯∫⁻_s, g ∂μ :=
-  fun _ => lintegral_mono fun _ => hfg _
 
 @[simp] theorem lmarginal_univ [Fintype δ] {f : (∀ i, π i) → ℝ≥0∞} :
     ∫⋯∫⁻_univ, f ∂μ = fun _ => ∫⁻ x, f x ∂Measure.pi μ := by


### PR DESCRIPTION
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
