### PR TITLE
[Merged by Bors] - fix: add `all` flag to import summary script

### DIFF
--- a/scripts/import_trans_difference.sh
+++ b/scripts/import_trans_difference.sh
@@ -72,18 +72,18 @@ git checkout "${currCommit}"
 
 printf '\n\n<details><summary>Import changes for all files</summary>\n\n%s\n\n</details>\n' "$(
   printf "|Files|Import difference|\n|-|-|\n"
-  (awk -F, -v all="${all}" '{ diff[$1]+=$2 } END {
+  (awk -F, -v all="${all}" -v ghLimit='261752' '{ diff[$1]+=$2 } END {
     fileCount=0
     outputLength=0
     for(fil in diff) {
       if(!(diff[fil] == 0)) {
         fileCount++
-        outputLength+=length(fil)
+        outputLength+=length(fil)+4
         nums[diff[fil]]++
         reds[diff[fil]]=reds[diff[fil]]" `"fil"`"
       }
     }
-    if ((all == 0) && (200 <= fileCount)) {
+    if ((all == 0) && (ghLimit/2 <= outputLength)) {
       printf("There are %s files with changed transitive imports taking up over %s characters: this is too many to display!\nYou can run `scripts/import_trans_difference.sh all` locally to see the whole output.", fileCount, outputLength)
     } else {
       for(x in reds) {

--- a/scripts/import_trans_difference.sh
+++ b/scripts/import_trans_difference.sh
@@ -21,7 +21,7 @@ The output is of the form
 with collapsible tabs for file entries with at least 3 files.
 BASH_MODULE_DOCS
 
-# `all=1` is the flag to print all import changes, without capping at 200
+# `all=1` is the flag to print all import changes, without cut-off
 all=0
 if [ "${1}" == "all" ]
 then

--- a/scripts/import_trans_difference.sh
+++ b/scripts/import_trans_difference.sh
@@ -82,7 +82,7 @@ printf '\n\n<details><summary>Import changes for all files</summary>\n\n%s\n\n</
       }
     }
     if ((all == 0) && (200 <= con)) {
-      printf("There are %s files with changed transitive imports: this is too many to display!\n", con)
+      printf("There are %s files with changed transitive imports: this is too many to display!\nYou can run `scripts/import_trans_difference.sh all` locally to see the whole output.", con)
     } else {
       for(x in reds) {
         if (nums[x] <= 2) { printf("|%s|%s|\n", reds[x], x) }

--- a/scripts/import_trans_difference.sh
+++ b/scripts/import_trans_difference.sh
@@ -46,6 +46,11 @@ fi
 #printf 'commit1: %s\ncommit2: %s\n' "$commit1" "$commit2"
 
 currCommit="$(git rev-parse --abbrev-ref HEAD)"
+# if we are in a detached head, `currCommit` would be the unhelpful `HEAD`
+# in this case, we fetch the commit hash
+if [ "${currCommit}" == "HEAD" ]
+  currCommit="$(git rev-parse HEAD)"
+fi
 
 getTransImports () {
   python3 scripts/count-trans-deps.py Mathlib |

--- a/scripts/import_trans_difference.sh
+++ b/scripts/import_trans_difference.sh
@@ -73,16 +73,18 @@ git checkout "${currCommit}"
 printf '\n\n<details><summary>Import changes for all files</summary>\n\n%s\n\n</details>\n' "$(
   printf "|Files|Import difference|\n|-|-|\n"
   (awk -F, -v all="${all}" '{ diff[$1]+=$2 } END {
-    con=0
+    fileCount=0
+    outputLength=0
     for(fil in diff) {
       if(!(diff[fil] == 0)) {
-        con++
+        fileCount++
+        outputLength+=length(fil)
         nums[diff[fil]]++
         reds[diff[fil]]=reds[diff[fil]]" `"fil"`"
       }
     }
-    if ((all == 0) && (200 <= con)) {
-      printf("There are %s files with changed transitive imports: this is too many to display!\nYou can run `scripts/import_trans_difference.sh all` locally to see the whole output.", con)
+    if ((all == 0) && (200 <= fileCount)) {
+      printf("There are %s files with changed transitive imports taking up over %s characters: this is too many to display!\nYou can run `scripts/import_trans_difference.sh all` locally to see the whole output.", fileCount, outputLength)
     } else {
       for(x in reds) {
         if (nums[x] <= 2) { printf("|%s|%s|\n", reds[x], x) }

--- a/scripts/import_trans_difference.sh
+++ b/scripts/import_trans_difference.sh
@@ -45,7 +45,7 @@ fi
 
 #printf 'commit1: %s\ncommit2: %s\n' "$commit1" "$commit2"
 
-currCommit="$(git rev-parse HEAD)"
+currCommit="$(git rev-parse --abbrev-ref HEAD)"
 
 getTransImports () {
   python3 scripts/count-trans-deps.py Mathlib |

--- a/scripts/import_trans_difference.sh
+++ b/scripts/import_trans_difference.sh
@@ -49,6 +49,7 @@ currCommit="$(git rev-parse --abbrev-ref HEAD)"
 # if we are in a detached head, `currCommit` would be the unhelpful `HEAD`
 # in this case, we fetch the commit hash
 if [ "${currCommit}" == "HEAD" ]
+then
   currCommit="$(git rev-parse HEAD)"
 fi
 


### PR DESCRIPTION
Summary of the PR

* Add the `all` flag to the import diff script: running
  ```bash
  ./scripts/import_trans_difference.sh all
  ```
  will not limit the output to ~~200 modified files~~ ~130k characters, but will print the whole import diff.

* Increase the size cut-off for printing the full output of the `import-diff script` to roughly half the size allowed in GitHub comments.

* Add a comment that you can run the script locally.
  The script switches over between commits and creates new files to store the information that it gathers from the various steps and can be intrusive: the automation is designed more to be ran in CI, with a fresh clone, than locally with possibly uncommitted changes, so I am not too sure that this is a good idea.

#15584 shows the new script in action: the printed comment there exceeds the previous limits of the script.

[Zulip discussion](https://leanprover.zulipchat.com/#narrow/stream/287929-mathlib4/topic/There.20are.201617.20files.20with.20changed.20transitive.20imports.20.2E.2E.2E)

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
