### PR TITLE
test: show the new output for too many imports

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -3966,6 +3966,7 @@ import Mathlib.SetTheory.Cardinal.CountableCover
 import Mathlib.SetTheory.Cardinal.Divisibility
 import Mathlib.SetTheory.Cardinal.ENat
 import Mathlib.SetTheory.Cardinal.Finite
+import Mathlib.SetTheory.Cardinal.Finsupp
 import Mathlib.SetTheory.Cardinal.Ordinal
 import Mathlib.SetTheory.Cardinal.PartENat
 import Mathlib.SetTheory.Cardinal.SchroederBernstein
@@ -3991,6 +3992,7 @@ import Mathlib.SetTheory.Ordinal.FixedPointApproximants
 import Mathlib.SetTheory.Ordinal.NaturalOps
 import Mathlib.SetTheory.Ordinal.Notation
 import Mathlib.SetTheory.Ordinal.Principal
+import Mathlib.SetTheory.Ordinal.Segfault
 import Mathlib.SetTheory.Ordinal.Topology
 import Mathlib.SetTheory.Surreal.Basic
 import Mathlib.SetTheory.Surreal.Dyadic

--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -3992,7 +3992,6 @@ import Mathlib.SetTheory.Ordinal.FixedPointApproximants
 import Mathlib.SetTheory.Ordinal.NaturalOps
 import Mathlib.SetTheory.Ordinal.Notation
 import Mathlib.SetTheory.Ordinal.Principal
-import Mathlib.SetTheory.Ordinal.Segfault
 import Mathlib.SetTheory.Ordinal.Topology
 import Mathlib.SetTheory.Surreal.Basic
 import Mathlib.SetTheory.Surreal.Dyadic

--- a/Mathlib/Algebra/MvPolynomial/Cardinal.lean
+++ b/Mathlib/Algebra/MvPolynomial/Cardinal.lean
@@ -5,7 +5,7 @@ Authors: Chris Hughes, Junyan Xu
 -/
 import Mathlib.Algebra.MvPolynomial.Equiv
 import Mathlib.Data.Finsupp.Fintype
-import Mathlib.SetTheory.Cardinal.Ordinal
+import Mathlib.SetTheory.Cardinal.Finsupp
 
 /-!
 # Cardinality of Multivariate Polynomial Ring

--- a/Mathlib/Algebra/Polynomial/Cardinal.lean
+++ b/Mathlib/Algebra/Polynomial/Cardinal.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Chris Hughes, Junyan Xu
 -/
 import Mathlib.Algebra.Polynomial.Basic
-import Mathlib.SetTheory.Cardinal.Ordinal
+import Mathlib.SetTheory.Cardinal.Finsupp
 
 /-!
 # Cardinality of Polynomial Ring

--- a/Mathlib/LinearAlgebra/Dimension/Free.lean
+++ b/Mathlib/LinearAlgebra/Dimension/Free.lean
@@ -6,6 +6,7 @@ Authors: Riccardo Brasca
 import Mathlib.LinearAlgebra.Dimension.StrongRankCondition
 import Mathlib.LinearAlgebra.FreeModule.Basic
 import Mathlib.LinearAlgebra.FreeModule.Finite.Basic
+import Mathlib.SetTheory.Cardinal.Finsupp
 
 /-!
 # Rank of free modules

--- a/Mathlib/SetTheory/Cardinal/Basic.lean
+++ b/Mathlib/SetTheory/Cardinal/Basic.lean
@@ -4,7 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johannes Hölzl, Mario Carneiro, Floris van Doorn
 -/
 import Mathlib.Data.Fintype.BigOperators
-import Mathlib.Data.Finsupp.Defs
 import Mathlib.Data.Set.Countable
 import Mathlib.Logic.Small.Set
 import Mathlib.Order.SuccPred.CompleteLinearOrder
@@ -78,7 +77,6 @@ Cantor's theorem, König's theorem, Konig's theorem
 -/
 
 assert_not_exists Field
-assert_not_exists Module
 
 open scoped Classical
 open Mathlib (Vector)
@@ -1216,14 +1214,6 @@ theorem mk_coe_finset {α : Type u} {s : Finset α} : #s = ↑(Finset.card s) :=
 
 theorem mk_finset_of_fintype [Fintype α] : #(Finset α) = 2 ^ Fintype.card α := by
   simp [Pow.pow]
-
-@[simp]
-theorem mk_finsupp_lift_of_fintype (α : Type u) (β : Type v) [Fintype α] [Zero β] :
-    #(α →₀ β) = lift.{u} #β ^ Fintype.card α := by
-  simpa using (@Finsupp.equivFunOnFinite α β _ _).cardinal_eq
-
-theorem mk_finsupp_of_fintype (α β : Type u) [Fintype α] [Zero β] :
-    #(α →₀ β) = #β ^ Fintype.card α := by simp
 
 theorem card_le_of_finset {α} (s : Finset α) : (s.card : Cardinal) ≤ #α :=
   @mk_coe_finset _ s ▸ mk_set_le _

--- a/Mathlib/SetTheory/Cardinal/Finsupp.lean
+++ b/Mathlib/SetTheory/Cardinal/Finsupp.lean
@@ -1,0 +1,72 @@
+/-
+Copyright (c) 2017 Johannes Hölzl. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Johannes Hölzl, Mario Carneiro, Floris van Doorn
+-/
+import Mathlib.SetTheory.Cardinal.Ordinal
+import Mathlib.Data.Finsupp.Basic
+import Mathlib.Data.Finsupp.Multiset
+
+/-! # Results on the cardinality of finitely supported functions and multisets. -/
+
+universe u v
+
+namespace Cardinal
+
+@[simp]
+theorem mk_finsupp_lift_of_fintype (α : Type u) (β : Type v) [Fintype α] [Zero β] :
+    #(α →₀ β) = lift.{u} #β ^ Fintype.card α := by
+  simpa using (@Finsupp.equivFunOnFinite α β _ _).cardinal_eq
+
+theorem mk_finsupp_of_fintype (α β : Type u) [Fintype α] [Zero β] :
+    #(α →₀ β) = #β ^ Fintype.card α := by simp
+
+@[simp]
+theorem mk_finsupp_lift_of_infinite (α : Type u) (β : Type v) [Infinite α] [Zero β] [Nontrivial β] :
+    #(α →₀ β) = max (lift.{v} #α) (lift.{u} #β) := by
+  apply le_antisymm
+  · calc
+      #(α →₀ β) ≤ #(Finset (α × β)) := mk_le_of_injective (Finsupp.graph_injective α β)
+      _ = #(α × β) := mk_finset_of_infinite _
+      _ = max (lift.{v} #α) (lift.{u} #β) := by
+        rw [mk_prod, mul_eq_max_of_aleph0_le_left] <;> simp
+
+  · apply max_le <;> rw [← lift_id #(α →₀ β), ← lift_umax]
+    · cases' exists_ne (0 : β) with b hb
+      exact lift_mk_le.{v}.2 ⟨⟨_, Finsupp.single_left_injective hb⟩⟩
+    · inhabit α
+      exact lift_mk_le.{u}.2 ⟨⟨_, Finsupp.single_injective default⟩⟩
+
+theorem mk_finsupp_of_infinite (α β : Type u) [Infinite α] [Zero β] [Nontrivial β] :
+    #(α →₀ β) = max #α #β := by simp
+
+@[simp]
+theorem mk_finsupp_lift_of_infinite' (α : Type u) (β : Type v) [Nonempty α] [Zero β] [Infinite β] :
+    #(α →₀ β) = max (lift.{v} #α) (lift.{u} #β) := by
+  cases fintypeOrInfinite α
+  · rw [mk_finsupp_lift_of_fintype]
+    have : ℵ₀ ≤ (#β).lift := aleph0_le_lift.2 (aleph0_le_mk β)
+    rw [max_eq_right (le_trans _ this), power_nat_eq this]
+    exacts [Fintype.card_pos, lift_le_aleph0.2 (lt_aleph0_of_finite _).le]
+  · apply mk_finsupp_lift_of_infinite
+
+theorem mk_finsupp_of_infinite' (α β : Type u) [Nonempty α] [Zero β] [Infinite β] :
+    #(α →₀ β) = max #α #β := by simp
+
+theorem mk_finsupp_nat (α : Type u) [Nonempty α] : #(α →₀ ℕ) = max #α ℵ₀ := by simp
+
+theorem mk_multiset_of_isEmpty (α : Type u) [IsEmpty α] : #(Multiset α) = 1 :=
+  Multiset.toFinsupp.toEquiv.cardinal_eq.trans (by simp)
+
+open scoped Classical
+
+@[simp]
+theorem mk_multiset_of_nonempty (α : Type u) [Nonempty α] : #(Multiset α) = max #α ℵ₀ :=
+  Multiset.toFinsupp.toEquiv.cardinal_eq.trans (mk_finsupp_nat α)
+
+theorem mk_multiset_of_infinite (α : Type u) [Infinite α] : #(Multiset α) = #α := by simp
+
+theorem mk_multiset_of_countable (α : Type u) [Countable α] [Nonempty α] : #(Multiset α) = ℵ₀ :=
+  Multiset.toFinsupp.toEquiv.cardinal_eq.trans (by simp)
+
+end Cardinal

--- a/Mathlib/SetTheory/Cardinal/Ordinal.lean
+++ b/Mathlib/SetTheory/Cardinal/Ordinal.lean
@@ -3,7 +3,6 @@ Copyright (c) 2017 Johannes Hölzl. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johannes Hölzl, Mario Carneiro, Floris van Doorn
 -/
-import Mathlib.Data.Finsupp.Multiset
 import Mathlib.Order.Bounded
 import Mathlib.SetTheory.Cardinal.PartENat
 import Mathlib.SetTheory.Ordinal.Principal
@@ -43,6 +42,8 @@ using ordinals.
 cardinal arithmetic (for infinite cardinals)
 -/
 
+assert_not_exists Module
+assert_not_exists Finsupp
 
 noncomputable section
 
@@ -1072,52 +1073,6 @@ theorem mk_finset_of_infinite (α : Type u) [Infinite α] : #(Finset α) = #α :
       calc
         #(Finset α) ≤ #(List α) := mk_le_of_surjective List.toFinset_surjective
         _ = #α := mk_list_eq_mk α
-
-@[simp]
-theorem mk_finsupp_lift_of_infinite (α : Type u) (β : Type v) [Infinite α] [Zero β] [Nontrivial β] :
-    #(α →₀ β) = max (lift.{v} #α) (lift.{u} #β) := by
-  apply le_antisymm
-  · calc
-      #(α →₀ β) ≤ #(Finset (α × β)) := mk_le_of_injective (Finsupp.graph_injective α β)
-      _ = #(α × β) := mk_finset_of_infinite _
-      _ = max (lift.{v} #α) (lift.{u} #β) := by
-        rw [mk_prod, mul_eq_max_of_aleph0_le_left] <;> simp
-
-  · apply max_le <;> rw [← lift_id #(α →₀ β), ← lift_umax]
-    · cases' exists_ne (0 : β) with b hb
-      exact lift_mk_le.{v}.2 ⟨⟨_, Finsupp.single_left_injective hb⟩⟩
-    · inhabit α
-      exact lift_mk_le.{u}.2 ⟨⟨_, Finsupp.single_injective default⟩⟩
-
-theorem mk_finsupp_of_infinite (α β : Type u) [Infinite α] [Zero β] [Nontrivial β] :
-    #(α →₀ β) = max #α #β := by simp
-
-@[simp]
-theorem mk_finsupp_lift_of_infinite' (α : Type u) (β : Type v) [Nonempty α] [Zero β] [Infinite β] :
-    #(α →₀ β) = max (lift.{v} #α) (lift.{u} #β) := by
-  cases fintypeOrInfinite α
-  · rw [mk_finsupp_lift_of_fintype]
-    have : ℵ₀ ≤ (#β).lift := aleph0_le_lift.2 (aleph0_le_mk β)
-    rw [max_eq_right (le_trans _ this), power_nat_eq this]
-    exacts [Fintype.card_pos, lift_le_aleph0.2 (lt_aleph0_of_finite _).le]
-  · apply mk_finsupp_lift_of_infinite
-
-theorem mk_finsupp_of_infinite' (α β : Type u) [Nonempty α] [Zero β] [Infinite β] :
-    #(α →₀ β) = max #α #β := by simp
-
-theorem mk_finsupp_nat (α : Type u) [Nonempty α] : #(α →₀ ℕ) = max #α ℵ₀ := by simp
-
-@[simp]
-theorem mk_multiset_of_nonempty (α : Type u) [Nonempty α] : #(Multiset α) = max #α ℵ₀ :=
-  Multiset.toFinsupp.toEquiv.cardinal_eq.trans (mk_finsupp_nat α)
-
-theorem mk_multiset_of_infinite (α : Type u) [Infinite α] : #(Multiset α) = #α := by simp
-
-theorem mk_multiset_of_isEmpty (α : Type u) [IsEmpty α] : #(Multiset α) = 1 :=
-  Multiset.toFinsupp.toEquiv.cardinal_eq.trans (by simp)
-
-theorem mk_multiset_of_countable (α : Type u) [Countable α] [Nonempty α] : #(Multiset α) = ℵ₀ :=
-  Multiset.toFinsupp.toEquiv.cardinal_eq.trans (by simp)
 
 theorem mk_bounded_set_le_of_infinite (α : Type u) [Infinite α] (c : Cardinal) :
     #{ t : Set α // #t ≤ c } ≤ #α ^ c := by

--- a/scripts/import_trans_difference.sh
+++ b/scripts/import_trans_difference.sh
@@ -91,5 +91,6 @@ printf '\n\n<details><summary>Import changes for all files</summary>\n\n%s\n\n</
         else { printf("|<details><summary>%s files</summary>%s</details>|%s|\n", nums[x], reds[x], x) }
       }
     }
+    printf("- Files with changed transitive imports: %s\n- Estimated characters: %s\n", fileCount, outputLength)
   }' transImports*.txt | sort -t'|' -n -k3
   ))"

--- a/scripts/import_trans_difference.sh
+++ b/scripts/import_trans_difference.sh
@@ -78,7 +78,7 @@ printf '\n\n<details><summary>Import changes for all files</summary>\n\n%s\n\n</
     for(fil in diff) {
       if(!(diff[fil] == 0)) {
         fileCount++
-        outputLength+=length(fil)
+        outputLength+=length(fil)+4
         nums[diff[fil]]++
         reds[diff[fil]]=reds[diff[fil]]" `"fil"`"
       }

--- a/scripts/import_trans_difference.sh
+++ b/scripts/import_trans_difference.sh
@@ -91,7 +91,6 @@ printf '\n\n<details><summary>Import changes for all files</summary>\n\n%s\n\n</
         else { printf("|<details><summary>%s files</summary>%s</details>|%s|\n", nums[x], reds[x], x) }
       }
     }
-    printf("- Files with changed transitive imports: %s\n- Estimated characters: %s\n", fileCount, outputLength)
   }' transImports*.txt | sort -t'|' -n -k3
   ))"
 

--- a/scripts/import_trans_difference.sh
+++ b/scripts/import_trans_difference.sh
@@ -72,7 +72,7 @@ git checkout "${currCommit}"
 
 printf '\n\n<details><summary>Import changes for all files</summary>\n\n%s\n\n</details>\n' "$(
   printf "|Files|Import difference|\n|-|-|\n"
-  (awk -F, -v all="${all}" '{ diff[$1]+=$2 } END {
+  (awk -F, -v all="${all}" -v ghLimit='261752' '{ diff[$1]+=$2 } END {
     fileCount=0
     outputLength=0
     for(fil in diff) {
@@ -83,7 +83,7 @@ printf '\n\n<details><summary>Import changes for all files</summary>\n\n%s\n\n</
         reds[diff[fil]]=reds[diff[fil]]" `"fil"`"
       }
     }
-    if ((all == 0) && (outputLength <= 2^2^4/2)) { # the size limit for messages on GitHub is 2^2^4
+    if ((all == 0) && (ghLimit/2 <= outputLength)) {
       printf("There are %s files with changed transitive imports taking up over %s characters: this is too many to display!\nYou can run `scripts/import_trans_difference.sh all` locally to see the whole output.", fileCount, outputLength)
     } else {
       for(x in reds) {
@@ -94,3 +94,7 @@ printf '\n\n<details><summary>Import changes for all files</summary>\n\n%s\n\n</
     printf("- Files with changed transitive imports: %s\n- Estimated characters: %s\n", fileCount, outputLength)
   }' transImports*.txt | sort -t'|' -n -k3
   ))"
+
+
+# allowed:    261752
+# disallowed: 261753

--- a/scripts/import_trans_difference.sh
+++ b/scripts/import_trans_difference.sh
@@ -83,7 +83,7 @@ printf '\n\n<details><summary>Import changes for all files</summary>\n\n%s\n\n</
         reds[diff[fil]]=reds[diff[fil]]" `"fil"`"
       }
     }
-    if ((all == 0) && (200 <= fileCount)) {
+    if ((all == 0) && (outputLength <= 2^2^4/2)) { # the size limit for messages on GitHub is 2^2^4
       printf("There are %s files with changed transitive imports taking up over %s characters: this is too many to display!\nYou can run `scripts/import_trans_difference.sh all` locally to see the whole output.", fileCount, outputLength)
     } else {
       for(x in reds) {

--- a/scripts/import_trans_difference.sh
+++ b/scripts/import_trans_difference.sh
@@ -82,7 +82,7 @@ printf '\n\n<details><summary>Import changes for all files</summary>\n\n%s\n\n</
       }
     }
     if ((all == 0) && (200 <= con)) {
-      printf("There are %s files with changed transitive imports: this is too many to display!\n", con)
+      printf("There are %s files with changed transitive imports: this is too many to display!\nYou can run `scripts/import_trans_difference.sh all` locally to see the whole output.", con)
     } else {
       for(x in reds) {
         if (nums[x] <= 2) { printf("|%s|%s|\n", reds[x], x) }

--- a/scripts/import_trans_difference.sh
+++ b/scripts/import_trans_difference.sh
@@ -46,6 +46,11 @@ fi
 #printf 'commit1: %s\ncommit2: %s\n' "$commit1" "$commit2"
 
 currCommit="$(git rev-parse --abbrev-ref HEAD)"
+# if we are in a detached head, `currCommit` would be the unhelpful `HEAD`
+# in this case, we fetch the commit hash
+if [ "${currCommit}" == "HEAD" ]
+  currCommit="$(git rev-parse HEAD)"
+fi
 
 getTransImports () {
   python3 scripts/count-trans-deps.py Mathlib |

--- a/scripts/import_trans_difference.sh
+++ b/scripts/import_trans_difference.sh
@@ -73,16 +73,18 @@ git checkout "${currCommit}"
 printf '\n\n<details><summary>Import changes for all files</summary>\n\n%s\n\n</details>\n' "$(
   printf "|Files|Import difference|\n|-|-|\n"
   (awk -F, -v all="${all}" '{ diff[$1]+=$2 } END {
-    con=0
+    fileCount=0
+    outputLength=0
     for(fil in diff) {
       if(!(diff[fil] == 0)) {
-        con++
+        fileCount++
+        outputLength+=length(fil)
         nums[diff[fil]]++
         reds[diff[fil]]=reds[diff[fil]]" `"fil"`"
       }
     }
-    if ((all == 0) && (200 <= con)) {
-      printf("There are %s files with changed transitive imports: this is too many to display!\nYou can run `scripts/import_trans_difference.sh all` locally to see the whole output.", con)
+    if ((all == 0) && (200 <= fileCount)) {
+      printf("There are %s files with changed transitive imports taking up over %s characters: this is too many to display!\nYou can run `scripts/import_trans_difference.sh all` locally to see the whole output.", fileCount, outputLength)
     } else {
       for(x in reds) {
         if (nums[x] <= 2) { printf("|%s|%s|\n", reds[x], x) }

--- a/scripts/import_trans_difference.sh
+++ b/scripts/import_trans_difference.sh
@@ -45,7 +45,7 @@ fi
 
 #printf 'commit1: %s\ncommit2: %s\n' "$commit1" "$commit2"
 
-currCommit="$(git rev-parse HEAD)"
+currCommit="$(git rev-parse --abbrev-ref HEAD)"
 
 getTransImports () {
   python3 scripts/count-trans-deps.py Mathlib |

--- a/scripts/import_trans_difference.sh
+++ b/scripts/import_trans_difference.sh
@@ -49,6 +49,7 @@ currCommit="$(git rev-parse --abbrev-ref HEAD)"
 # if we are in a detached head, `currCommit` would be the unhelpful `HEAD`
 # in this case, we fetch the commit hash
 if [ "${currCommit}" == "HEAD" ]
+then
   currCommit="$(git rev-parse HEAD)"
 fi
 


### PR DESCRIPTION
This PR merely accompanies #15583 and is intended as a testing ground for the import-diff changes.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
