### PR TITLE
[Merged by Bors] - doc(LinearAlgebra/FreeProduct): remove untrue TODOs

### DIFF
--- a/Mathlib/LinearAlgebra/FreeProduct/Basic.lean
+++ b/Mathlib/LinearAlgebra/FreeProduct/Basic.lean
@@ -40,8 +40,6 @@ is just `PiTensorProduct`.)
 
 ## TODO
 - Induction principle for `FreeProduct`
-- Equivalence of `FreeProduct` with `PiTensorProduct` in the commutative case and with
-  `FreeAlgebra R ⨁ (i : ι), A i`
 
 -/
 universe u v w w'


### PR DESCRIPTION
Neither TODO turned out to be mathematically true: `FreeProduct` imposes more structure than `FreeAlgebra`, specifically combining adjacent elements from the same algebra, and my categorical argument for the isomorphism with `PiTensorProduct` in the commutative case was faulty.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
