### PR TITLE
[Merged by Bors] - golf: found by the have vs let linter

### DIFF
--- a/Mathlib/Analysis/Convolution.lean
+++ b/Mathlib/Analysis/Convolution.lean
@@ -1227,10 +1227,10 @@ theorem contDiffOn_convolution_right_with_param {f : G → E} {n : ℕ∞} (L : 
   let eE' : Type max uE' uG uF uP := ULift.{max uG uF uP} E'
   let eF : Type max uF uG uE' uP := ULift.{max uG uE' uP} F
   let eP : Type max uP uG uE' uF := ULift.{max uG uE' uF} P
-  have isoG : eG ≃L[𝕜] G := ContinuousLinearEquiv.ulift
-  have isoE' : eE' ≃L[𝕜] E' := ContinuousLinearEquiv.ulift
-  have isoF : eF ≃L[𝕜] F := ContinuousLinearEquiv.ulift
-  have isoP : eP ≃L[𝕜] P := ContinuousLinearEquiv.ulift
+  let isoG : eG ≃L[𝕜] G := ContinuousLinearEquiv.ulift
+  let isoE' : eE' ≃L[𝕜] E' := ContinuousLinearEquiv.ulift
+  let isoF : eF ≃L[𝕜] F := ContinuousLinearEquiv.ulift
+  let isoP : eP ≃L[𝕜] P := ContinuousLinearEquiv.ulift
   let ef := f ∘ isoG
   let eμ : Measure eG := Measure.map isoG.symm μ
   let eg : eP → eG → eE' := fun ep ex => isoE'.symm (g (isoP ep) (isoG ex))
@@ -1246,11 +1246,7 @@ theorem contDiffOn_convolution_right_with_param {f : G → E} {n : ℕ∞} (L : 
       simp only [eg, (· ∘ ·), ContinuousLinearEquiv.prod_apply, LinearIsometryEquiv.coe_coe,
         ContinuousLinearEquiv.map_eq_zero_iff]
       exact hgs _ _ hp hx
-    · apply (locallyIntegrable_map_homeomorph isoG.symm.toHomeomorph).2
-      convert hf
-      ext1 x
-      simp only [ef, ContinuousLinearEquiv.coe_toHomeomorph, (· ∘ ·),
-        ContinuousLinearEquiv.apply_symm_apply]
+    · exact (locallyIntegrable_map_homeomorph isoG.symm.toHomeomorph).2 hf
     · apply isoE'.symm.contDiff.comp_contDiffOn
       apply hg.comp (isoP.prod isoG).contDiff.contDiffOn
       rintro ⟨p, x⟩ ⟨hp, -⟩
@@ -1269,13 +1265,8 @@ theorem contDiffOn_convolution_right_with_param {f : G → E} {n : ℕ∞} (L : 
       ContinuousLinearEquiv.prod_apply]
     simp only [R, convolution, coe_comp', ContinuousLinearEquiv.coe_coe, (· ∘ ·)]
     rw [ClosedEmbedding.integral_map, ← isoF.integral_comp_comm]
-    swap; · exact isoG.symm.toHomeomorph.closedEmbedding
-    congr 1
-    ext1 a
-    simp only [ef, eg, eL, (· ∘ ·), ContinuousLinearEquiv.apply_symm_apply, coe_comp',
-      ContinuousLinearEquiv.prod_apply, ContinuousLinearEquiv.map_sub,
-      ContinuousLinearEquiv.arrowCongr, ContinuousLinearEquiv.arrowCongrSL_symm_apply,
-      ContinuousLinearEquiv.coe_coe, Function.comp_apply, ContinuousLinearEquiv.apply_symm_apply]
+    · rfl
+    · exact isoG.symm.toHomeomorph.closedEmbedding
   simp_rw [this] at A
   exact A
 


### PR DESCRIPTION
The `have` vs `let` linter had flagged these `have` as "should be `let`s" and changing them made the proof simpler.

---

I could not get `!bench` to work, but these are the timings locally:
```lean
count_heartbeats in version with `let`
Used 49399 heartbeats, which is less than the current maximum of 200000.

count_heartbeats in version with `have`
Used 55316 heartbeats, which is less than the current maximum of 200000.
```

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
