### PR TITLE
[Merged by Bors] - chore: add ascription for delicate-to-elaborate expression

### DIFF
--- a/Counterexamples/ZeroDivisorsInAddMonoidAlgebras.lean
+++ b/Counterexamples/ZeroDivisorsInAddMonoidAlgebras.lean
@@ -233,7 +233,8 @@ example {α} [Ring α] [Nontrivial α] : ∃ f g : AddMonoidAlgebra α F, f ≠ 
   zero_divisors_of_periodic (1 : F) le_rfl (by simp [two_smul]) z01.ne'
 
 example {α} [Zero α] :
-    2 • (Finsupp.single 0 1 : α →₀ F) = Finsupp.single 0 1 ∧ (Finsupp.single 0 1 : α →₀ F) ≠ 0 :=
+    2 • (Finsupp.single 0 1 : α →₀ F) = (Finsupp.single 0 1 : α →₀ F)
+      ∧ (Finsupp.single 0 1 : α →₀ F) ≠ 0 :=
   ⟨smul_single _ _ _, by simp [Ne, Finsupp.single_eq_zero, z01.ne]⟩
 
 end F


### PR DESCRIPTION
The expression `2 • (Finsupp.single 0 1 : α →₀ F) = Finsupp.single 0 1` only accidentally elaborates. The binop elaborator fails to compute a "max type" for this, since the right-hand `Finsupp.single 0 1` does not have a fully specified type yet, so it falls back to a strategy where it propagates the LHS type to the RHS. However, the rest of the process then depends on the exact order that default instances are applied. If the default instances for the RHS apply first, it specializes to `ℕ →₀ ℕ` and elaboration fails, but if the LHS ones apply first, then the SMul manages to specialize to `ℕ → (α →₀ F) → (α →₀ F)`, and it succeeds.

This came up while experimenting with performance improvements to the binop elaborator.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
