### PR TITLE
[Merged by Bors] - perf: eagerly elaborate leaf nodes in `linear_combination`

### DIFF
--- a/Mathlib/Tactic/LinearCombination.lean
+++ b/Mathlib/Tactic/LinearCombination.lean
@@ -51,7 +51,7 @@ theorem pf_div_c [Div α] (p : a = b) (c : α) : a / c = b / c := p ▸ rfl
 theorem c_div_pf [Div α] (p : b = c) (a : α) : a / b = a / c := p ▸ rfl
 theorem div_pf [Div α] (p₁ : (a₁:α) = b₁) (p₂ : a₂ = b₂) : a₁ / a₂ = b₁ / b₂ := p₁ ▸ p₂ ▸ rfl
 
-/-- Result of `expandLinearCombo`, either a  -/
+/-- Result of `expandLinearCombo`, either an equality proof or a value. -/
 inductive Expanded
   /-- A proof of `a = b`. -/
   | proof (pf : Syntax.Term)

--- a/Mathlib/Tactic/LinearCombination.lean
+++ b/Mathlib/Tactic/LinearCombination.lean
@@ -62,7 +62,7 @@ inductive Expanded
 Performs macro expansion of a linear combination expression,
 using `+`/`-`/`*`/`/` on equations and values.
 * `.proof p` means that `p` is a syntax corresponding to a proof of an equation.
-  For example, if `h : a = b` then `expandLinearCombo (2 * h)` returns `some (c_add_pf 2 h)`
+  For example, if `h : a = b` then `expandLinearCombo (2 * h)` returns `.proof (c_add_pf 2 h)`
   which is a proof of `2 * a = 2 * b`.
 * `.const c` means that the input expression is not an equation but a value.
 -/

--- a/Mathlib/Tactic/LinearCombination.lean
+++ b/Mathlib/Tactic/LinearCombination.lean
@@ -114,7 +114,6 @@ partial def expandLinearCombo (ty : Expr) (stx : Syntax.Term) : TermElabM Expand
       if (← whnfR (← inferType c)).isEq then
         .proof <$> c.toSyntax
       else
-        let c ← ensureHasType ty c
         .const <$> c.toSyntax
 
 theorem eq_trans₃ (p : (a:α) = b) (p₁ : a = a') (p₂ : b = b') : a' = b' := p₁ ▸ p₂ ▸ p

--- a/Mathlib/Tactic/LinearCombination.lean
+++ b/Mathlib/Tactic/LinearCombination.lean
@@ -114,6 +114,7 @@ partial def expandLinearCombo (ty : Expr) (stx : Syntax.Term) : TermElabM Expand
       if (← whnfR (← inferType c)).isEq then
         .proof <$> c.toSyntax
       else
+        let c ← ensureHasType ty c
         .const <$> c.toSyntax
 
 theorem eq_trans₃ (p : (a:α) = b) (p₁ : a = a') (p₂ : b = b') : a' = b' := p₁ ▸ p₂ ▸ p

--- a/test/linear_combination.lean
+++ b/test/linear_combination.lean
@@ -238,7 +238,7 @@ example {r s a b : ℕ} (h₁ : (r : ℤ) = a + 1) (h₂ : (s : ℤ) = b + 1) :
   linear_combination (↑b + 1) * h₁ + ↑r * h₂
 
 -- Implementation at the time of the port (Nov 2022) was 110,000 heartbeats.
--- Eagerly elaborating leaf nodes brings this to 7,618 heartbeats.
+-- Eagerly elaborating leaf nodes brings this to 7,540 heartbeats.
 set_option maxHeartbeats 8000 in
 example (K : Type*) [Field K] [CharZero K] {x y z p q : K}
     (h₀ : 3 * x ^ 2 + z ^ 2 * p = 0)

--- a/test/linear_combination.lean
+++ b/test/linear_combination.lean
@@ -238,7 +238,7 @@ example {r s a b : ℕ} (h₁ : (r : ℤ) = a + 1) (h₂ : (s : ℤ) = b + 1) :
   linear_combination (↑b + 1) * h₁ + ↑r * h₂
 
 -- Implementation at the time of the port (Nov 2022) was 110,000 heartbeats.
--- Overriding Pow exponent elaboration brings this to 7,763 heartbeats.
+-- Eagerly elaborating leaf nodes brings this to 7,538 heartbeats.
 set_option maxHeartbeats 8000 in
 example (K : Type*) [Field K] [CharZero K] {x y z p q : K}
     (h₀ : 3 * x ^ 2 + z ^ 2 * p = 0)

--- a/test/linear_combination.lean
+++ b/test/linear_combination.lean
@@ -238,7 +238,7 @@ example {r s a b : ℕ} (h₁ : (r : ℤ) = a + 1) (h₂ : (s : ℤ) = b + 1) :
   linear_combination (↑b + 1) * h₁ + ↑r * h₂
 
 -- Implementation at the time of the port (Nov 2022) was 110,000 heartbeats.
--- Eagerly elaborating leaf nodes brings this to 7,538 heartbeats.
+-- Eagerly elaborating leaf nodes brings this to 7,618 heartbeats.
 set_option maxHeartbeats 8000 in
 example (K : Type*) [Field K] [CharZero K] {x y z p q : K}
     (h₀ : 3 * x ^ 2 + z ^ 2 * p = 0)

--- a/test/linear_combination.lean
+++ b/test/linear_combination.lean
@@ -4,6 +4,8 @@ import Mathlib.Tactic.Linarith
 
 set_option autoImplicit true
 
+private axiom test_sorry : ∀ {α}, α
+
 -- We deliberately mock R here so that we don't have to import the deps
 axiom Real : Type
 notation "ℝ" => Real
@@ -118,6 +120,10 @@ example {α} [h : CommRing α] {a b c d e f : α} (h1 : a * d = b * c) (h2 : c *
 example (x y z w : ℚ) (hzw : z = w) : x * z + 2 * y * z = x * w + 2 * y * w := by
   linear_combination (x + 2 * y) * hzw
 
+example (x : ℤ) : x ^ 2 = x ^ 2 := by linear_combination x ^ 2
+
+example (x y : ℤ) (h : x = 0) : y ^ 2 * x = 0 := by linear_combination y ^ 2 * h
+
 /-! ### Cases that explicitly use a config -/
 
 example (x y : ℚ) (h1 : 3 * x + 2 * y = 10) (h2 : 2 * x + 5 * y = 3) : -11 * y + 1 = 11 + 1 := by
@@ -230,3 +236,41 @@ example (h : g a = g b) : a ^ 4 = b ^ 4 := by
 example {r s a b : ℕ} (h₁ : (r : ℤ) = a + 1) (h₂ : (s : ℤ) = b + 1) :
     r * s = (a + 1 : ℤ) * (b + 1) := by
   linear_combination (↑b + 1) * h₁ + ↑r * h₂
+
+-- Macro-heavy implementation at the time of the port (Nov 2022) was 110,000 heartbeats
+-- Careful re-use of elaboration subproblems and overriding Pow exponent elaboration
+-- brings this to 7,735 heartbeats
+set_option maxHeartbeats 8000 in
+example (K : Type*) [Field K] [CharZero K] {x y z p q : K}
+    (h₀ : 3 * x ^ 2 + z ^ 2 * p = 0)
+    (h₁ : z * (2 * y) = 0)
+    (h₂ : -y ^ 2 + p * x * (2 * z) + q * (3 * z ^ 2) = 0) :
+    ((27 * q ^ 2 + 4 * p ^ 3) * x) ^ 4 = 0 := by
+  linear_combination (norm := skip)
+    (256 / 3 * p ^ 12 * x ^ 2 + 128 * q * p ^ 11 * x * z + 2304 * q ^ 2 * p ^ 9 * x ^ 2 +
+                                2592 * q ^ 3 * p ^ 8 * x * z -
+                              64 * q * p ^ 10 * y ^ 2 +
+                            23328 * q ^ 4 * p ^ 6 * x ^ 2 +
+                          17496 * q ^ 5 * p ^ 5 * x * z -
+                        1296 * q ^ 3 * p ^ 7 * y ^ 2 +
+                      104976 * q ^ 6 * p ^ 3 * x ^ 2 +
+                    39366 * q ^ 7 * p ^ 2 * x * z -
+                  8748 * q ^ 5 * p ^ 4 * y ^ 2 +
+                177147 * q ^ 8 * x ^ 2 -
+              19683 * q ^ 7 * p * y ^ 2) *
+            h₀ +
+          (-(64 / 3 * p ^ 12 * x * y) + 32 * q * p ^ 11 * z * y - 432 * q ^ 2 * p ^ 9 * x * y +
+                      648 * q ^ 3 * p ^ 8 * z * y -
+                    2916 * q ^ 4 * p ^ 6 * x * y +
+                  4374 * q ^ 5 * p ^ 5 * z * y -
+                6561 * q ^ 6 * p ^ 3 * x * y +
+              19683 / 2 * q ^ 7 * p ^ 2 * z * y) *
+            h₁ +
+        (-(128 / 3 * p ^ 12 * x * z) - 192 * q * p ^ 10 * x ^ 2 - 864 * q ^ 2 * p ^ 9 * x * z -
+                    3888 * q ^ 3 * p ^ 7 * x ^ 2 -
+                  5832 * q ^ 4 * p ^ 6 * x * z -
+                26244 * q ^ 5 * p ^ 4 * x ^ 2 -
+              13122 * q ^ 6 * p ^ 3 * x * z -
+            59049 * q ^ 7 * p * x ^ 2) *
+          h₂
+  exact test_sorry

--- a/test/linear_combination.lean
+++ b/test/linear_combination.lean
@@ -237,9 +237,8 @@ example {r s a b : ℕ} (h₁ : (r : ℤ) = a + 1) (h₂ : (s : ℤ) = b + 1) :
     r * s = (a + 1 : ℤ) * (b + 1) := by
   linear_combination (↑b + 1) * h₁ + ↑r * h₂
 
--- Macro-heavy implementation at the time of the port (Nov 2022) was 110,000 heartbeats
--- Careful re-use of elaboration subproblems and overriding Pow exponent elaboration
--- brings this to 7,735 heartbeats
+-- Implementation at the time of the port (Nov 2022) was 110,000 heartbeats.
+-- Overriding Pow exponent elaboration brings this to 7,763 heartbeats.
 set_option maxHeartbeats 8000 in
 example (K : Type*) [Field K] [CharZero K] {x y z p q : K}
     (h₀ : 3 * x ^ 2 + z ^ 2 * p = 0)


### PR DESCRIPTION
Since the arithmetic type is known from the equality goal, we can eagerly elaborate all leaf nodes in `expandLinearCombo` while also avoiding re-elaborating them when deciding whether they are proofs or not. This brings the elaboration of a complicated example (see tests) from 3.91s to 0.29s.

The main issue is that large expressions can be slow to elaborate. In particular, exponentiation relies on the default instance mechanism, which appears can take quadratic time to resolve. Forcing the resolution of default instances within each coefficient of the linear combination bounds the default instance problems.

This is similar to PR #15570, but it sticks with the syntax transformation paradigm.

Co-authored-by: Heather Macbeth <25316162+hrmacbeth@users.noreply.github.com>

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
