### PR TITLE
[Merged by Bors] - chore: rm relaxedAutoImplicit from lakefile

### DIFF
--- a/Mathlib/Tactic/Ring/Basic.lean
+++ b/Mathlib/Tactic/Ring/Basic.lean
@@ -136,7 +136,6 @@ end
 
 
 -- In this file, we would like to use multi-character auto-implicits.
-set_option relaxedAutoImplicit true
 set_option autoImplicit true
 
 mutual -- partial only to speed up compilation
@@ -212,7 +211,6 @@ partial def ExSum.cast {a : Q($arg)} : ExSum sα a → Σ a, ExSum sβ a
 end
 
 set_option autoImplicit false
-set_option relaxedAutoImplicit false
 
 variable {u : Lean.Level}
 

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -5,8 +5,7 @@ open Lake DSL
 package mathlib where
   leanOptions := #[
     ⟨`pp.unicode.fun, true⟩, -- pretty-prints `fun a ↦ b`
-    ⟨`autoImplicit, false⟩,
-    ⟨`relaxedAutoImplicit, false⟩
+    ⟨`autoImplicit, false⟩
   ]
   -- These are additional settings which do not affect the lake hash,
   -- so they can be enabled in CI and disabled locally or vice versa.


### PR DESCRIPTION
The `relaxedAutoImplicit` option has no effect if `autoImplicit` is false, so this has no impact on most of mathlib. However, when enabling `autoImplicit` locally, it is annoying (and slightly non-discoverable) that one must also enable `relaxedAutoImplicit` in many cases to actually get auto-implicits.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
