### PR TITLE
[Merged by Bors] - chore: deprecate MulEquiv.map_mul, AddEquiv.map_add

### DIFF
--- a/Mathlib/Algebra/Group/Aut.lean
+++ b/Mathlib/Algebra/Group/Aut.lean
@@ -106,8 +106,8 @@ instance applyMulDistribMulAction {M} [Monoid M] : MulDistribMulAction (MulAut M
   smul := (· <| ·)
   one_smul _ := rfl
   mul_smul _ _ _ := rfl
-  smul_one := MulEquiv.map_one
-  smul_mul := MulEquiv.map_mul
+  smul_one := map_one
+  smul_mul := map_mul
 
 @[simp]
 protected theorem smul_def {M} [Monoid M] (f : MulAut M) (a : M) : f • a = f a :=
@@ -211,8 +211,8 @@ def toPerm : AddAut A →* Equiv.Perm A where
 This generalizes `Function.End.applyMulAction`. -/
 instance applyDistribMulAction {A} [AddMonoid A] : DistribMulAction (AddAut A) A where
   smul := (· <| ·)
-  smul_zero := AddEquiv.map_zero
-  smul_add := AddEquiv.map_add
+  smul_zero := map_zero
+  smul_add := map_add
   one_smul _ := rfl
   mul_smul _ _ _ := rfl
 

--- a/Mathlib/Algebra/Group/Conj.lean
+++ b/Mathlib/Algebra/Group/Conj.lean
@@ -86,11 +86,11 @@ theorem isConj_iff {a b : α} : IsConj a b ↔ ∃ c : α, c * a * c⁻¹ = b :=
 -- Porting note: not in simp NF.
 -- @[simp]
 theorem conj_inv {a b : α} : (b * a * b⁻¹)⁻¹ = b * a⁻¹ * b⁻¹ :=
-  ((MulAut.conj b).map_inv a).symm
+  (map_inv (MulAut.conj b) a).symm
 
 @[simp]
 theorem conj_mul {a b c : α} : b * a * b⁻¹ * (b * c * b⁻¹) = b * (a * c) * b⁻¹ :=
-  ((MulAut.conj b).map_mul a c).symm
+  (map_mul (MulAut.conj b) a c).symm
 
 @[simp]
 theorem conj_pow {i : ℕ} {a b : α} : (a * b * a⁻¹) ^ i = a * b ^ i * a⁻¹ := by

--- a/Mathlib/Algebra/Group/Equiv/Basic.lean
+++ b/Mathlib/Algebra/Group/Equiv/Basic.lean
@@ -215,6 +215,9 @@ theorem coe_toMulHom {f : M ≃* N} : (f.toMulHom : M → N) = f := rfl
 protected theorem map_mul (f : M ≃* N) : ∀ x y, f (x * y) = f x * f y :=
   _root_.map_mul f
 
+attribute [deprecated map_mul (since := "2024-08-08")] MulEquiv.map_mul
+attribute [deprecated map_add (since := "2024-08-08")] AddEquiv.map_add
+
 /-- Makes a multiplicative isomorphism from a bijection which preserves multiplication. -/
 @[to_additive "Makes an additive isomorphism from a bijection which preserves addition."]
 def mk' (f : M ≃ N) (h : ∀ x y, f (x * y) = f x * f y) : M ≃* N := ⟨f, h⟩
@@ -245,7 +248,7 @@ https://leanprover.zulipchat.com/#narrow/stream/287929-mathlib4/topic/!4.234183.
 @[to_additive]
 lemma symm_map_mul {M N : Type*} [Mul M] [Mul N] (h : M ≃* N) (x y : N) :
     h.symm (x * y) = h.symm x * h.symm y :=
-  (h.toMulHom.inverse h.toEquiv.symm h.left_inv h.right_inv).map_mul x y
+  map_mul (h.toMulHom.inverse h.toEquiv.symm h.left_inv h.right_inv) x y
 
 /-- The inverse of an isomorphism is an isomorphism. -/
 @[to_additive (attr := symm) "The inverse of an isomorphism is an isomorphism."]
@@ -301,7 +304,7 @@ theorem refl_symm : (refl M).symm = refl M := rfl
 def trans (h1 : M ≃* N) (h2 : N ≃* P) : M ≃* P :=
   { h1.toEquiv.trans h2.toEquiv with
     map_mul' := fun x y => show h2 (h1 (x * y)) = h2 (h1 x) * h2 (h1 y) by
-      rw [h1.map_mul, h2.map_mul] }
+      rw [map_mul, map_mul] }
 
 /-- `e.symm` is a right inverse of `e`, written as `e (e.symm y) = y`. -/
 @[to_additive (attr := simp) "`e.symm` is a right inverse of `e`, written as `e (e.symm y) = y`."]
@@ -543,7 +546,7 @@ def piCongrRight {η : Type*} {Ms Ns : η → Type*} [∀ j, Mul (Ms j)] [∀ j,
   { Equiv.piCongrRight fun j => (es j).toEquiv with
     toFun := fun x j => es j (x j),
     invFun := fun x j => (es j).symm (x j),
-    map_mul' := fun x y => funext fun j => (es j).map_mul (x j) (y j) }
+    map_mul' := fun x y => funext fun j => map_mul (es j) (x j) (y j) }
 
 @[to_additive (attr := simp)]
 theorem piCongrRight_refl {η : Type*} {Ms : η → Type*} [∀ j, Mul (Ms j)] :

--- a/Mathlib/Algebra/Group/Equiv/TypeTags.lean
+++ b/Mathlib/Algebra/Group/Equiv/TypeTags.lean
@@ -22,13 +22,13 @@ def AddEquiv.toMultiplicative [AddZeroClass G] [AddZeroClass H] :
     invFun := AddMonoidHom.toMultiplicative f.symm.toAddMonoidHom
     left_inv := f.left_inv
     right_inv := f.right_inv
-    map_mul' := f.map_add }
+    map_mul' := map_add f }
   invFun f :=
   { toFun := AddMonoidHom.toMultiplicative.symm f.toMonoidHom
     invFun := AddMonoidHom.toMultiplicative.symm f.symm.toMonoidHom
     left_inv := f.left_inv
     right_inv := f.right_inv
-    map_add' := f.map_mul }
+    map_add' := map_mul f }
   left_inv x := by ext; rfl
   right_inv x := by ext; rfl
 
@@ -41,13 +41,13 @@ def MulEquiv.toAdditive [MulOneClass G] [MulOneClass H] :
     invFun := MonoidHom.toAdditive f.symm.toMonoidHom
     left_inv := f.left_inv
     right_inv := f.right_inv
-    map_add' := f.map_mul }
+    map_add' := map_mul f }
   invFun f :=
   { toFun := MonoidHom.toAdditive.symm f.toAddMonoidHom
     invFun := MonoidHom.toAdditive.symm f.symm.toAddMonoidHom
     left_inv := f.left_inv
     right_inv := f.right_inv
-    map_mul' := f.map_add }
+    map_mul' := map_add f }
   left_inv x := by ext; rfl
   right_inv x := by ext; rfl
 
@@ -60,13 +60,13 @@ def AddEquiv.toMultiplicative' [MulOneClass G] [AddZeroClass H] :
     invFun := AddMonoidHom.toMultiplicative'' f.symm.toAddMonoidHom
     left_inv := f.left_inv
     right_inv := f.right_inv
-    map_mul' := f.map_add }
+    map_mul' := map_add f }
   invFun f :=
   { toFun := AddMonoidHom.toMultiplicative'.symm f.toMonoidHom
     invFun := AddMonoidHom.toMultiplicative''.symm f.symm.toMonoidHom
     left_inv := f.left_inv
     right_inv := f.right_inv
-    map_add' := f.map_mul }
+    map_add' := map_mul f }
   left_inv x := by ext; rfl
   right_inv x := by ext; rfl
 
@@ -84,13 +84,13 @@ def AddEquiv.toMultiplicative'' [AddZeroClass G] [MulOneClass H] :
     invFun := AddMonoidHom.toMultiplicative' f.symm.toAddMonoidHom
     left_inv := f.left_inv
     right_inv := f.right_inv
-    map_mul' := f.map_add }
+    map_mul' := map_add f }
   invFun f :=
   { toFun := AddMonoidHom.toMultiplicative''.symm f.toMonoidHom
     invFun := AddMonoidHom.toMultiplicative'.symm f.symm.toMonoidHom
     left_inv := f.left_inv
     right_inv := f.right_inv
-    map_add' := f.map_mul }
+    map_add' := map_mul f }
   left_inv x := by ext; rfl
   right_inv x := by ext; rfl
 

--- a/Mathlib/Algebra/Group/Opposite.lean
+++ b/Mathlib/Algebra/Group/Opposite.lean
@@ -572,12 +572,12 @@ def MulEquiv.op {α β} [Mul α] [Mul β] : α ≃* β ≃ (αᵐᵒᵖ ≃* β�
     { toFun := MulOpposite.op ∘ f ∘ unop, invFun := MulOpposite.op ∘ f.symm ∘ unop,
       left_inv := fun x => unop_injective (f.symm_apply_apply x.unop),
       right_inv := fun x => unop_injective (f.apply_symm_apply x.unop),
-      map_mul' := fun x y => unop_injective (f.map_mul y.unop x.unop) }
+      map_mul' := fun x y => unop_injective (map_mul f y.unop x.unop) }
   invFun f :=
     { toFun := unop ∘ f ∘ MulOpposite.op, invFun := unop ∘ f.symm ∘ MulOpposite.op,
       left_inv := fun x => by simp,
       right_inv := fun x => by simp,
-      map_mul' := fun x y => congr_arg unop (f.map_mul (MulOpposite.op y) (MulOpposite.op x)) }
+      map_mul' := fun x y => congr_arg unop (map_mul f (MulOpposite.op y) (MulOpposite.op x)) }
   left_inv _ := rfl
   right_inv _ := rfl
 

--- a/Mathlib/Algebra/Group/Prod.lean
+++ b/Mathlib/Algebra/Group/Prod.lean
@@ -612,7 +612,7 @@ end
 @[to_additive prodCongr "Product of additive isomorphisms; the maps come from `Equiv.prodCongr`."]
 def prodCongr (f : M ≃* M') (g : N ≃* N') : M × N ≃* M' × N' :=
   { f.toEquiv.prodCongr g.toEquiv with
-    map_mul' := fun _ _ => Prod.ext (f.map_mul _ _) (g.map_mul _ _) }
+    map_mul' := fun _ _ => Prod.ext (map_mul f _ _) (map_mul g _ _) }
 
 /-- Multiplying by the trivial monoid doesn't change the structure. -/
 @[to_additive uniqueProd "Multiplying by the trivial monoid doesn't change the structure."]

--- a/Mathlib/Algebra/Group/Submonoid/Membership.lean
+++ b/Mathlib/Algebra/Group/Submonoid/Membership.lean
@@ -482,7 +482,7 @@ def powLogEquiv [DecidableEq M] {n : M} (h : Function.Injective fun m : ℕ => n
 
 theorem log_mul [DecidableEq M] {n : M} (h : Function.Injective fun m : ℕ => n ^ m)
     (x y : powers (n : M)) : log (x * y) = log x + log y :=
-  (powLogEquiv h).symm.map_mul x y
+  map_mul (powLogEquiv h).symm x y
 
 theorem log_pow_int_eq_self {x : ℤ} (h : 1 < x.natAbs) (m : ℕ) : log (pow x m) = m :=
   (powLogEquiv (Int.pow_right_injective h)).symm_apply_apply _

--- a/Mathlib/CategoryTheory/Conj.lean
+++ b/Mathlib/CategoryTheory/Conj.lean
@@ -41,11 +41,11 @@ theorem conj_apply (f : End X) : α.conj f = α.inv ≫ f ≫ α.hom :=
 
 @[simp]
 theorem conj_comp (f g : End X) : α.conj (f ≫ g) = α.conj f ≫ α.conj g :=
-  α.conj.map_mul g f
+  map_mul α.conj g f
 
 @[simp]
 theorem conj_id : α.conj (𝟙 X) = 𝟙 Y :=
-  α.conj.map_one
+  map_one α.conj
 
 @[simp]
 theorem refl_conj (f : End X) : (Iso.refl X).conj f = f := by
@@ -85,7 +85,7 @@ theorem trans_conjAut {Z : C} (β : Y ≅ Z) (f : Aut X) :
 
 /- Porting note (#10618): removed `@[simp]`; simp can prove this -/
 theorem conjAut_mul (f g : Aut X) : α.conjAut (f * g) = α.conjAut f * α.conjAut g :=
-  α.conjAut.map_mul f g
+  map_mul α.conjAut f g
 
 @[simp]
 theorem conjAut_trans (f g : Aut X) : α.conjAut (f ≪≫ g) = α.conjAut f ≪≫ α.conjAut g :=
@@ -93,11 +93,11 @@ theorem conjAut_trans (f g : Aut X) : α.conjAut (f ≪≫ g) = α.conjAut f ≪
 
 /- Porting note (#10618): removed `@[simp]`; simp can prove this -/
 theorem conjAut_pow (f : Aut X) (n : ℕ) : α.conjAut (f ^ n) = α.conjAut f ^ n :=
-  α.conjAut.toMonoidHom.map_pow f n
+  map_pow α.conjAut f n
 
 /- Porting note (#10618): removed `@[simp]`; simp can prove this -/
 theorem conjAut_zpow (f : Aut X) (n : ℤ) : α.conjAut (f ^ n) = α.conjAut f ^ n :=
-  α.conjAut.toMonoidHom.map_zpow f n
+  map_zpow α.conjAut f n
 
 end Iso
 

--- a/Mathlib/Data/DFinsupp/Basic.lean
+++ b/Mathlib/Data/DFinsupp/Basic.lean
@@ -1819,12 +1819,12 @@ theorem comp_liftAddHom {δ : Type*} [∀ i, AddZeroClass (β i)] [AddCommMonoid
 @[simp]
 theorem sumAddHom_zero [∀ i, AddZeroClass (β i)] [AddCommMonoid γ] :
     (sumAddHom fun i => (0 : β i →+ γ)) = 0 :=
-  (liftAddHom (β := β) : (∀ i, β i →+ γ) ≃+ _).map_zero
+  map_zero (liftAddHom (β := β))
 
 @[simp]
 theorem sumAddHom_add [∀ i, AddZeroClass (β i)] [AddCommMonoid γ] (g : ∀ i, β i →+ γ)
     (h : ∀ i, β i →+ γ) : (sumAddHom fun i => g i + h i) = sumAddHom g + sumAddHom h :=
-  (liftAddHom (β := β)).map_add _ _
+  map_add (liftAddHom (β := β)) _ _
 
 @[simp]
 theorem sumAddHom_singleAddHom [∀ i, AddCommMonoid (β i)] :

--- a/Mathlib/Data/Finsupp/Multiset.lean
+++ b/Mathlib/Data/Finsupp/Multiset.lean
@@ -147,7 +147,7 @@ theorem toFinsupp_apply (s : Multiset α) (a : α) : toFinsupp s a = s.count a :
 theorem toFinsupp_zero : toFinsupp (0 : Multiset α) = 0 := _root_.map_zero _
 
 theorem toFinsupp_add (s t : Multiset α) : toFinsupp (s + t) = toFinsupp s + toFinsupp t :=
-  toFinsupp.map_add s t
+  _root_.map_add toFinsupp s t
 
 @[simp]
 theorem toFinsupp_singleton (a : α) : toFinsupp ({a} : Multiset α) = Finsupp.single a 1 := by

--- a/Mathlib/Data/Matrix/Basic.lean
+++ b/Mathlib/Data/Matrix/Basic.lean
@@ -1263,7 +1263,7 @@ def mapMatrix (f : α ≃+ β) : Matrix m n α ≃+ Matrix m n β :=
   { f.toEquiv.mapMatrix with
     toFun := fun M => M.map f
     invFun := fun M => M.map f.symm
-    map_add' := Matrix.map_add f f.map_add }
+    map_add' := Matrix.map_add f (map_add f) }
 
 @[simp]
 theorem mapMatrix_refl : (AddEquiv.refl α).mapMatrix = AddEquiv.refl (Matrix m n α) :=

--- a/Mathlib/Deprecated/Group.lean
+++ b/Mathlib/Deprecated/Group.lean
@@ -122,7 +122,7 @@ variable {M : Type*} {N : Type*} [MulOneClass M] [MulOneClass N]
 /-- A multiplicative isomorphism preserves multiplication (deprecated). -/
 @[to_additive "An additive isomorphism preserves addition (deprecated)."]
 theorem isMulHom (h : M ≃* N) : IsMulHom h :=
-  ⟨h.map_mul⟩
+  ⟨map_mul h⟩
 
 /-- A multiplicative bijection between two monoids is a monoid hom
   (deprecated -- use `MulEquiv.toMonoidHom`). -/
@@ -130,7 +130,7 @@ theorem isMulHom (h : M ≃* N) : IsMulHom h :=
       "An additive bijection between two additive monoids is an additive
       monoid hom (deprecated). "]
 theorem isMonoidHom (h : M ≃* N) : IsMonoidHom h :=
-  { map_mul := h.map_mul
+  { map_mul := map_mul h
     map_one := h.map_one }
 
 end MulEquiv
@@ -216,7 +216,7 @@ theorem MonoidHom.isGroupHom {G H : Type*} {_ : Group G} {_ : Group H} (f : G �
 @[to_additive]
 theorem MulEquiv.isGroupHom {G H : Type*} {_ : Group G} {_ : Group H} (h : G ≃* H) :
     IsGroupHom h :=
-  { map_mul := h.map_mul }
+  { map_mul := map_mul h }
 
 /-- Construct `IsGroupHom` from its only hypothesis. -/
 @[to_additive "Construct `IsAddGroupHom` from its only hypothesis."]

--- a/Mathlib/GroupTheory/Commensurable.lean
+++ b/Mathlib/GroupTheory/Commensurable.lean
@@ -57,7 +57,7 @@ def quotConjEquiv (H K : Subgroup G) (g : ConjAct G) :
   Quotient.congr (K.equivSMul g).toEquiv fun a b => by
     dsimp
     rw [← Quotient.eq'', ← Quotient.eq'', QuotientGroup.eq, QuotientGroup.eq,
-      Subgroup.mem_subgroupOf, Subgroup.mem_subgroupOf, ← MulEquiv.map_inv, ← MulEquiv.map_mul,
+      Subgroup.mem_subgroupOf, Subgroup.mem_subgroupOf, ← map_inv, ← map_mul,
       Subgroup.equivSMul_apply_coe]
     exact Subgroup.smul_mem_pointwise_smul_iff.symm
 

--- a/Mathlib/GroupTheory/MonoidLocalization/Basic.lean
+++ b/Mathlib/GroupTheory/MonoidLocalization/Basic.lean
@@ -1133,7 +1133,7 @@ def ofMulEquivOfLocalizations (k : N ≃* P) : LocalizationMap S P :=
     (fun v ↦
       let ⟨z, hz⟩ := k.toEquiv.surjective v
       let ⟨x, hx⟩ := f.surj z
-      ⟨x, show v * k _ = k _ by rw [← hx, k.map_mul, ← hz]; rfl⟩)
+      ⟨x, show v * k _ = k _ by rw [← hx, map_mul, ← hz]; rfl⟩)
     fun x y ↦ (k.apply_eq_iff_eq.trans f.eq_iff_exists).1
 
 @[to_additive (attr := simp)]
@@ -1214,7 +1214,7 @@ def ofMulEquivOfDom {k : P ≃* M} (H : T.map k.toMonoidHom = S) : LocalizationM
         fun ⟨c, hc⟩ ↦
           let ⟨d, hd⟩ := k.toEquiv.surjective c
           ⟨⟨d, H' ▸ show k d ∈ S from hd.symm ▸ c.2⟩, by
-            erw [← hd, ← k.map_mul, ← k.map_mul] at hc; exact k.toEquiv.injective hc⟩
+            erw [← hd, ← map_mul k, ← map_mul k] at hc; exact k.toEquiv.injective hc⟩
 
 @[to_additive (attr := simp)]
 theorem ofMulEquivOfDom_apply {k : P ≃* M} (H : T.map k.toMonoidHom = S) (x) :

--- a/Mathlib/GroupTheory/Subgroup/Center.lean
+++ b/Mathlib/GroupTheory/Subgroup/Center.lean
@@ -74,7 +74,7 @@ instance centerCharacteristic : (center G).Characteristic := by
   refine characteristic_iff_comap_le.mpr fun ϕ g hg => ?_
   rw [mem_center_iff]
   intro h
-  rw [← ϕ.injective.eq_iff, ϕ.map_mul, ϕ.map_mul]
+  rw [← ϕ.injective.eq_iff, map_mul, map_mul]
   exact (hg.comm (ϕ h)).symm
 
 theorem _root_.CommGroup.center_eq_top {G : Type*} [CommGroup G] : center G = ⊤ := by

--- a/Mathlib/RingTheory/UniqueFactorizationDomain.lean
+++ b/Mathlib/RingTheory/UniqueFactorizationDomain.lean
@@ -374,7 +374,7 @@ theorem MulEquiv.uniqueFactorizationMonoid (e : α ≃* β) (hα : UniqueFactori
         he ▸ e.prime_iff.1 (hp c hc),
         Units.map e.toMonoidHom u,
       by
-        erw [Multiset.prod_hom, ← e.map_mul, h]
+        erw [Multiset.prod_hom, ← map_mul e, h]
         simp⟩
 
 theorem MulEquiv.uniqueFactorizationMonoid_iff (e : α ≃* β) :


### PR DESCRIPTION
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
