### PR TITLE
perf: use foldl for implementation of Multiset.fold

### DIFF
--- a/Mathlib/Data/Multiset/Fold.lean
+++ b/Mathlib/Data/Multiset/Fold.lean
@@ -43,6 +43,15 @@ theorem fold_eq_foldl (b : α) (s : Multiset α) :
     fold op b s = foldl op (right_comm _ hc.comm ha.assoc) b s :=
   Quot.inductionOn s fun _ => coe_fold_l _ _ _
 
+private def fold_impl: α → Multiset α → α :=
+  foldl op (right_comm _ hc.comm ha.assoc)
+
+@[csimp]
+private theorem fold_eq_fold_impl: @fold = @fold_impl := by {
+  funext
+  exact fold_eq_foldl _ _ _
+}
+
 @[simp]
 theorem fold_zero (b : α) : (0 : Multiset α).fold op b = b :=
   rfl


### PR DESCRIPTION
This avoids a costly call to List.foldr, and directly usestail-recursive definitions for Multiset.fold.

---

This is step 1 of what was discussed on [Zulip](https://leanprover.zulipchat.com/#narrow/stream/287929-mathlib4/topic/Stack.20overflow.20because.20of.20Multiset.2Efold/near/456797715).

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
