### PR TITLE
[Merged by Bors] - perf(CategoryTheory/Sites/Sheaf): speed up a slow proof

### DIFF
--- a/Mathlib/CategoryTheory/Sites/Sheaf.lean
+++ b/Mathlib/CategoryTheory/Sites/Sheaf.lean
@@ -636,26 +636,22 @@ def isSheafForIsSheafFor' (P : Cᵒᵖ ⥤ A) (s : A ⥤ Type max v₁ u₁)
     [∀ J, PreservesLimitsOfShape (Discrete.{max v₁ u₁} J) s] (U : C) (R : Presieve U) :
     IsLimit (s.mapCone (Fork.ofι _ (w R P))) ≃
       IsLimit (Fork.ofι _ (Equalizer.Presieve.w (P ⋙ s) R)) := by
-  apply Equiv.trans (isLimitMapConeForkEquiv _ _) _
-  apply (IsLimit.postcomposeHomEquiv _ _).symm.trans (IsLimit.equivIsoLimit _)
-  · apply NatIso.ofComponents _ _
-    · rintro (_ | _)
-      · apply PreservesProduct.iso s
-      · apply PreservesProduct.iso s
-    · rintro _ _ (_ | _)
-      · refine limit.hom_ext (fun j => ?_)
-        dsimp [Equalizer.Presieve.firstMap, firstMap]
-        simp only [limit.lift_π, map_lift_piComparison, assoc, Fan.mk_π_app, Functor.map_comp]
-        rw [piComparison_comp_π_assoc]
-      · refine limit.hom_ext (fun j => ?_)
-        dsimp [Equalizer.Presieve.secondMap, secondMap]
-        simp only [limit.lift_π, map_lift_piComparison, assoc, Fan.mk_π_app, Functor.map_comp]
-        rw [piComparison_comp_π_assoc]
-      · dsimp
-        simp
-  · refine Fork.ext (Iso.refl _) ?_
-    dsimp [Equalizer.forkMap, forkMap]
-    simp [Fork.ι]
+  let e : parallelPair (s.map (firstMap R P)) (s.map (secondMap R P)) ≅
+    parallelPair (Equalizer.Presieve.firstMap (P ⋙ s) R)
+      (Equalizer.Presieve.secondMap (P ⋙ s) R) := by
+    refine parallelPair.ext (PreservesProduct.iso s _) ((PreservesProduct.iso s _))
+      (limit.hom_ext (fun j => ?_)) (limit.hom_ext (fun j => ?_))
+    · dsimp [Equalizer.Presieve.firstMap, firstMap]
+      simp only [map_lift_piComparison, Functor.map_comp, limit.lift_π, Fan.mk_pt,
+        Fan.mk_π_app, assoc, piComparison_comp_π_assoc]
+    · dsimp [Equalizer.Presieve.secondMap, secondMap]
+      simp only [map_lift_piComparison, Functor.map_comp, limit.lift_π, Fan.mk_pt,
+        Fan.mk_π_app, assoc, piComparison_comp_π_assoc]
+  refine Equiv.trans (isLimitMapConeForkEquiv _ _) ?_
+  refine (IsLimit.postcomposeHomEquiv e _).symm.trans
+    (IsLimit.equivIsoLimit (Fork.ext (Iso.refl _) ?_))
+  dsimp [Equalizer.forkMap, forkMap, e, Fork.ι]
+  simp only [id_comp, map_lift_piComparison]
 
 -- Remark : this lemma uses `A'` not `A`; `A'` is `A` but with a universe
 -- restriction. Can it be generalised?


### PR DESCRIPTION

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
