### PR TITLE
perf(Algebra.CharTwo/Zero): scope lemmas 

### DIFF
--- a/Archive/Imo/Imo1960Q2.lean
+++ b/Archive/Imo/Imo1960Q2.lean
@@ -36,6 +36,7 @@ structure IsGood (x : ℝ) : Prop where
   /-- The number belongs to the domain of the denominator. -/
   denom_dom : (1 - sqrt (2 * x + 1)) ^ 2 ≠ 0
 
+open scoped OfNat in -- to use `no_index`ed simp lemmas for `ofNat`
 /-- Solution of IMO 1960 Q2: solutions of the inequality
 are the numbers of the half-closed interval \([-1/2, 45/8)\) except for the number zero. -/
 theorem isGood_iff {x} : IsGood x ↔ x ∈ Ico (-1/2) (45/8) \ {0} := by

--- a/Archive/Imo/Imo1986Q5.lean
+++ b/Archive/Imo/Imo1986Q5.lean
@@ -66,6 +66,7 @@ theorem map_eq (x : ℝ≥0) : f x = 2 / (2 - x) :=
 
 end IsGood
 
+open scoped OfNat in -- to use `no_index`ed simp lemmas for `ofNat`
 theorem isGood_iff {f : ℝ≥0 → ℝ≥0} : IsGood f ↔ f = fun x ↦ 2 / (2 - x) := by
   refine ⟨fun hf ↦ funext hf.map_eq, ?_⟩
   rintro rfl

--- a/Archive/Imo/Imo2024Q6.lean
+++ b/Archive/Imo/Imo2024Q6.lean
@@ -225,6 +225,7 @@ lemma floor_fExample (x : ℚ) :
     rw [Int.floor_eq_iff]
     simp [(Int.fract_nonneg x).lt_of_ne' h, (Int.fract_lt_one x).le]
 
+open scoped OfNat in -- to use `no_index`ed simp lemmas for `ofNat`
 lemma card_range_fExample : #(Set.range (fun x ↦ fExample x + fExample (-x))) = 2 := by
   have h : Set.range (fun x ↦ fExample x + fExample (-x)) = {0, -2} := by
     ext x

--- a/Archive/Wiedijk100Theorems/HeronsFormula.lean
+++ b/Archive/Wiedijk100Theorems/HeronsFormula.lean
@@ -30,6 +30,7 @@ local notation "√" => Real.sqrt
 variable {V : Type*} {P : Type*} [NormedAddCommGroup V] [InnerProductSpace ℝ V] [MetricSpace P]
   [NormedAddTorsor V P]
 
+open scoped OfNat in -- to use `no_index`ed simp lemmas for `ofNat`
 /-- **Heron's formula**: The area of a triangle with side lengths `a`, `b`, and `c` is
   `√(s * (s - a) * (s - b) * (s - c))` where `s = (a + b + c) / 2` is the semiperimeter.
   We show this by equating this formula to `a * b * sin γ`, where `γ` is the angle opposite

--- a/Mathlib/Algebra/CharP/Two.lean
+++ b/Mathlib/Algebra/CharP/Two.lean
@@ -26,7 +26,7 @@ variable [Semiring R] [CharP R 2]
 
 theorem two_eq_zero : (2 : R) = 0 := by rw [← Nat.cast_two, CharP.cast_eq_zero]
 
-@[simp]
+@[scoped simp]
 theorem add_self_eq_zero (x : R) : x + x = 0 := by rw [← two_smul R x, two_eq_zero, zero_smul]
 
 end Semiring
@@ -35,14 +35,14 @@ section Ring
 
 variable [Ring R] [CharP R 2]
 
-@[simp]
+@[scoped simp]
 theorem neg_eq (x : R) : -x = x := by
   rw [neg_eq_iff_add_eq_zero, ← two_smul R x, two_eq_zero, zero_smul]
 
 theorem neg_eq' : Neg.neg = (id : R → R) :=
   funext neg_eq
 
-@[simp]
+@[scoped simp]
 theorem sub_eq_add (x y : R) : x - y = x + y := by rw [sub_eq_add_neg, neg_eq]
 
 theorem sub_eq_add' : HSub.hSub = ((· + ·) : R → R → R) :=

--- a/Mathlib/Algebra/CharZero/Defs.lean
+++ b/Mathlib/Algebra/CharZero/Defs.lean
@@ -95,19 +95,19 @@ namespace OfNat
 
 variable [AddMonoidWithOne R] [CharZero R]
 
-@[simp] lemma ofNat_ne_zero (n : ℕ) [n.AtLeastTwo] : (no_index (ofNat n) : R) ≠ 0 :=
+@[scoped simp] lemma ofNat_ne_zero (n : ℕ) [n.AtLeastTwo] : (no_index (ofNat n) : R) ≠ 0 :=
   Nat.cast_ne_zero.2 (NeZero.ne n)
 
-@[simp] lemma zero_ne_ofNat (n : ℕ) [n.AtLeastTwo] : 0 ≠ (no_index (ofNat n) : R) :=
+@[scoped simp] lemma zero_ne_ofNat (n : ℕ) [n.AtLeastTwo] : 0 ≠ (no_index (ofNat n) : R) :=
   (ofNat_ne_zero n).symm
 
-@[simp] lemma ofNat_ne_one (n : ℕ) [n.AtLeastTwo] : (no_index (ofNat n) : R) ≠ 1 :=
+@[scoped simp] lemma ofNat_ne_one (n : ℕ) [n.AtLeastTwo] : (no_index (ofNat n) : R) ≠ 1 :=
   Nat.cast_ne_one.2 (Nat.AtLeastTwo.ne_one)
 
-@[simp] lemma one_ne_ofNat (n : ℕ) [n.AtLeastTwo] : (1 : R) ≠ no_index (ofNat n) :=
+@[scoped simp] lemma one_ne_ofNat (n : ℕ) [n.AtLeastTwo] : (1 : R) ≠ no_index (ofNat n) :=
   (ofNat_ne_one n).symm
 
-@[simp] lemma ofNat_eq_ofNat {m n : ℕ} [m.AtLeastTwo] [n.AtLeastTwo] :
+@[scoped simp] lemma ofNat_eq_ofNat {m n : ℕ} [m.AtLeastTwo] [n.AtLeastTwo] :
     (no_index (ofNat m) : R) = no_index (ofNat n) ↔ (ofNat m : ℕ) = ofNat n :=
   Nat.cast_inj
 

--- a/Mathlib/Algebra/CharZero/Lemmas.lean
+++ b/Mathlib/Algebra/CharZero/Lemmas.lean
@@ -87,10 +87,10 @@ section
 
 variable {R : Type*} [NonAssocRing R] [NoZeroDivisors R] [CharZero R]
 
-@[simp] theorem neg_eq_self_iff {a : R} : -a = a ↔ a = 0 :=
+@[scoped simp] theorem CharZero.neg_eq_self_iff {a : R} : -a = a ↔ a = 0 :=
   neg_eq_iff_add_eq_zero.trans add_self_eq_zero
 
-@[simp] theorem eq_neg_self_iff {a : R} : a = -a ↔ a = 0 :=
+@[scoped simp] theorem CharZero.eq_neg_self_iff {a : R} : a = -a ↔ a = 0 :=
   eq_neg_iff_add_eq_zero.trans add_self_eq_zero
 
 theorem nat_mul_inj {n : ℕ} {a b : R} (h : (n : R) * a = (n : R) * b) : n = 0 ∨ a = b := by

--- a/Mathlib/Algebra/Lie/Sl2.lean
+++ b/Mathlib/Algebra/Lie/Sl2.lean
@@ -126,6 +126,7 @@ lemma lie_e_pow_succ_toEnd_f (n : ℕ) :
     congr
     ring
 
+open scoped OfNat in -- to use `no_index`ed simp lemmas for `ofNat`
 /-- The eigenvalue of a primitive vector must be a natural number if the representation is
 finite-dimensional. -/
 lemma exists_nat [IsNoetherian R M] [NoZeroSMulDivisors R M] [IsDomain R] [CharZero R] :

--- a/Mathlib/Algebra/Lie/Weights/Killing.lean
+++ b/Mathlib/Algebra/Lie/Weights/Killing.lean
@@ -366,6 +366,7 @@ lemma root_apply_cartanEquivDual_symm_ne_zero {α : Weight K H L} (hα : α.IsNo
     simpa using this
   exact Submodule.mem_inf.mp ⟨hα, cartanEquivDual_symm_apply_mem_corootSpace K L H α⟩
 
+open scoped OfNat in -- to use `no_index`ed simp lemmas for `ofNat`
 lemma root_apply_coroot {α : Weight K H L} (hα : α.IsNonZero) :
     α (coroot α) = 2 := by
   rw [← Weight.coe_coe]
@@ -378,6 +379,7 @@ lemma traceForm_coroot (α : Weight K H L) (x : H) :
   rw [coroot, map_nsmul, map_smul, LinearMap.smul_apply, LinearMap.smul_apply]
   congr 2
 
+open scoped OfNat in -- to use `no_index`ed simp lemmas for `ofNat`
 @[simp] lemma coroot_eq_zero_iff {α : Weight K H L} :
     coroot α = 0 ↔ α.IsZero := by
   refine ⟨fun hα ↦ ?_, fun hα ↦ ?_⟩
@@ -388,6 +390,7 @@ lemma traceForm_coroot (α : Weight K H L) (x : H) :
 @[simp]
 lemma coroot_zero [Nontrivial L] : coroot (0 : Weight K H L) = 0 := by simp [Weight.isZero_zero]
 
+open scoped OfNat in -- to use `no_index`ed simp lemmas for `ofNat`
 lemma coe_corootSpace_eq_span_singleton (α : Weight K H L) :
     (corootSpace α).toSubmodule = K ∙ coroot α := by
   if hα : α.IsZero then
@@ -447,6 +450,7 @@ lemma traceForm_eq_zero_of_mem_ker_of_mem_span_coroot {α : Weight K H L} {x y :
     · have := traceForm_eq_zero_of_mem_ker_of_mem_span_coroot hx hy
       rwa [traceForm_comm] at this
 
+open scoped OfNat in -- to use `no_index`ed simp lemmas for `ofNat`
 @[simp] lemma coroot_eq_iff (α β : Weight K H L) :
     coroot α = coroot β ↔ α = β := by
   refine ⟨fun hyp ↦ ?_, fun h ↦ by rw [h]⟩
@@ -495,6 +499,7 @@ lemma exists_isSl2Triple_of_weight_isNonZero {α : Weight K H L} (hα : α.IsNon
     rw [lie_smul, lie_smul, smul_lie, this]
     simp [← smul_assoc, f, hh, mul_comm _ (2 * (α h)⁻¹)]
 
+open scoped OfNat in -- to use `no_index`ed simp lemmas for `ofNat`
 lemma _root_.IsSl2Triple.h_eq_coroot {α : Weight K H L} (hα : α.IsNonZero)
     {h e f : L} (ht : IsSl2Triple h e f) (heα : e ∈ rootSpace H α) (hfα : f ∈ rootSpace H (- α)) :
     h = coroot α := by

--- a/Mathlib/Algebra/Lie/Weights/RootSystem.lean
+++ b/Mathlib/Algebra/Lie/Weights/RootSystem.lean
@@ -288,6 +288,7 @@ lemma rootSpace_two_smul : rootSpace H (2 • α) = ⊥ := by
   simpa [chainTopCoeff_zero_right α hα] using
     weightSpace_chainTopCoeff_add_one_nsmul_add α (0 : Weight K H L) hα
 
+open scoped OfNat in -- to use `no_index`ed simp lemmas for `ofNat`
 lemma rootSpace_one_div_two_smul : rootSpace H ((2⁻¹ : K) • α) = ⊥ := by
   by_contra h
   let W : Weight K H L := ⟨_, h⟩
@@ -299,6 +300,7 @@ lemma rootSpace_one_div_two_smul : rootSpace H ((2⁻¹ : K) • α) = ⊥ := by
     apply_fun (2 • ·) at e; simpa [hW] using e)
   rwa [hW] at this
 
+open scoped OfNat in -- to use `no_index`ed simp lemmas for `ofNat`
 lemma eq_neg_one_or_eq_zero_or_eq_one_of_eq_smul (k : K) (h : (β : H → K) = k • α) :
     k = -1 ∨ k = 0 ∨ k = 1 := by
   cases subsingleton_or_nontrivial L

--- a/Mathlib/AlgebraicGeometry/EllipticCurve/DivisionPolynomial/Degree.lean
+++ b/Mathlib/AlgebraicGeometry/EllipticCurve/DivisionPolynomial/Degree.lean
@@ -178,6 +178,7 @@ private lemma expDegree_rec (m : ℕ) :
 private def expCoeff (n : ℕ) : ℤ :=
   if Even n then n / 2 else n
 
+open scoped OfNat in -- to use `no_index`ed simp lemmas for `ofNat`
 private lemma expCoeff_cast (n : ℕ) : (expCoeff n : ℚ) = if Even n then (n / 2 : ℚ) else n := by
   rcases n.even_or_odd' with ⟨n, rfl | rfl⟩ <;> simp [expCoeff, n.not_even_two_mul_add_one]
 

--- a/Mathlib/AlgebraicGeometry/EllipticCurve/Projective.lean
+++ b/Mathlib/AlgebraicGeometry/EllipticCurve/Projective.lean
@@ -274,21 +274,18 @@ lemma nonsingularLift_some (X Y : R) :
 
 variable {F : Type u} [Field F] {W : Projective F}
 
+set_option says.verify true in
 lemma equiv_of_Z_eq_zero {P Q : Fin 3 → F} (hP : W.Nonsingular P) (hQ : W.Nonsingular Q)
     (hPz : P z = 0) (hQz : Q z = 0) : P ≈ Q := by
   rw [fin3_def P, hPz] at hP ⊢
   rw [fin3_def Q, hQz] at hQ ⊢
-  simp? [nonsingular_iff, equation_iff] at hP hQ says
-    simp only [Nat.succ_eq_add_one, Nat.reduceAdd, Fin.isValue, nonsingular_iff,
-      equation_iff, Matrix.cons_val_one, Matrix.head_cons, Matrix.cons_val_two, Matrix.tail_cons,
-      mul_zero, Matrix.cons_val_zero, add_zero, ne_eq, OfNat.ofNat_ne_zero, not_false_eq_true,
-      zero_pow, zero_eq_mul, pow_eq_zero_iff, not_or, sub_self, not_true_eq_false, false_or]
-    at hP hQ
-  simp? [pow_eq_zero hP.left.symm, pow_eq_zero hQ.left.symm] at * says
-    simp only [Fin.isValue, pow_eq_zero hP.left.symm, ne_eq, OfNat.ofNat_ne_zero,
-      not_false_eq_true, zero_pow, not_true_eq_false, and_false, mul_zero, zero_mul, add_zero,
-      pow_eq_zero_iff, false_or, true_and, pow_eq_zero hQ.left.symm, Nat.succ_eq_add_one,
-      Nat.reduceAdd] at *
+  simp only [Nat.succ_eq_add_one, Nat.reduceAdd, Fin.isValue, nonsingular_iff, equation_iff,
+    Matrix.cons_val_one, Matrix.head_cons, Matrix.cons_val_two, Matrix.tail_cons, mul_zero,
+    Matrix.cons_val_zero, add_zero, ne_eq, Nat.add_one_ne_zero, not_false_eq_true, zero_pow,
+    zero_eq_mul, pow_eq_zero_iff, not_or, sub_self, not_true_eq_false, false_or] at hP hQ
+  simp only [Fin.isValue, pow_eq_zero hP.left.symm, ne_eq, Nat.add_one_ne_zero, not_false_eq_true,
+    zero_pow, not_true_eq_false, and_false, mul_zero, zero_mul, add_zero, pow_eq_zero_iff, false_or,
+    true_and, pow_eq_zero hQ.left.symm, Nat.succ_eq_add_one, Nat.reduceAdd] at *
   exact ⟨Units.mk0 (P y / Q y) <| div_ne_zero hP hQ, by simp [div_mul_cancel₀ _ hQ]⟩
 
 lemma equiv_zero_of_Z_eq_zero {P : Fin 3 → F} (h : W.Nonsingular P) (hPz : P z = 0) :

--- a/Mathlib/AlgebraicTopology/FundamentalGroupoid/Basic.lean
+++ b/Mathlib/AlgebraicTopology/FundamentalGroupoid/Basic.lean
@@ -117,6 +117,7 @@ section TransRefl
 def transReflReparamAux (t : I) : ℝ :=
   if (t : ℝ) ≤ 1 / 2 then 2 * t else 1
 
+open scoped OfNat in -- to use `no_index`ed simp lemmas for `ofNat`
 @[continuity]
 theorem continuous_transReflReparamAux : Continuous transReflReparamAux := by
   refine continuous_if_le ?_ ?_ (Continuous.continuousOn ?_) (Continuous.continuousOn ?_) ?_ <;>

--- a/Mathlib/Analysis/Calculus/FDeriv/Symmetric.lean
+++ b/Mathlib/Analysis/Calculus/FDeriv/Symmetric.lean
@@ -249,6 +249,7 @@ theorem Convex.second_derivative_within_at_symmetric_of_mem_interior {v w : E}
       field_simp [LT.lt.ne' hpos, SMul.smul]
   simpa only [sub_eq_zero] using isLittleO_const_const_iff.1 B
 
+open scoped OfNat in -- to use `no_index`ed simp lemmas for `ofNat`
 /-- If a function is differentiable inside a convex set with nonempty interior, and has a second
 derivative at a point of this convex set, then this second derivative is symmetric. -/
 theorem Convex.second_derivative_within_at_symmetric {s : Set E} (s_conv : Convex ℝ s)

--- a/Mathlib/Analysis/Complex/CauchyIntegral.lean
+++ b/Mathlib/Analysis/Complex/CauchyIntegral.lean
@@ -436,6 +436,7 @@ theorem circleIntegral_sub_inv_smul_of_differentiable_on_off_countable_aux {R : 
   exacts [(hc'.smul (hc.mono sphere_subset_closedBall)).circleIntegrable hR.le,
     (hc'.smul continuousOn_const).circleIntegrable hR.le]
 
+open scoped OfNat in -- to use `no_index`ed simp lemmas for `ofNat`
 /-- **Cauchy integral formula**: if `f : ℂ → E` is continuous on a closed disc of radius `R` and is
 complex differentiable at all but countably many points of its interior, then for any `w` in this
 interior we have $\frac{1}{2πi}\oint_{|z-c|=R}(z-w)^{-1}f(z)\,dz=f(w)$.
@@ -473,6 +474,7 @@ theorem two_pi_I_inv_smul_circleIntegral_sub_inv_smul_of_differentiable_on_off_c
     exact this.not_lt Cardinal.aleph0_lt_continuum
   exact ⟨g x, (hlu_sub hx.1).1, (hlu_sub hx.1).2, hx.2⟩
 
+open scoped OfNat in -- to use `no_index`ed simp lemmas for `ofNat`
 /-- **Cauchy integral formula**: if `f : ℂ → E` is continuous on a closed disc of radius `R` and is
 complex differentiable at all but countably many points of its interior, then for any `w` in this
 interior we have $\oint_{|z-c|=R}(z-w)^{-1}f(z)\,dz=2πif(w)$.

--- a/Mathlib/Analysis/Complex/Isometry.lean
+++ b/Mathlib/Analysis/Complex/Isometry.lean
@@ -61,7 +61,8 @@ theorem rotation_ne_conjLIE (a : circle) : rotation a ≠ conjLIE := by
   have h1 : rotation a 1 = conj 1 := LinearIsometryEquiv.congr_fun h 1
   have hI : rotation a I = conj I := LinearIsometryEquiv.congr_fun h I
   rw [rotation_apply, RingHom.map_one, mul_one] at h1
-  rw [rotation_apply, conj_I, ← neg_one_mul, mul_left_inj' I_ne_zero, h1, eq_neg_self_iff] at hI
+  rw [rotation_apply, conj_I, ← neg_one_mul, mul_left_inj' I_ne_zero,
+    h1, CharZero.eq_neg_self_iff] at hI
   exact one_ne_zero hI
 
 /-- Takes an element of `ℂ ≃ₗᵢ[ℝ] ℂ` and checks if it is a rotation, returns an element of the

--- a/Mathlib/Analysis/Complex/UpperHalfPlane/Metric.lean
+++ b/Mathlib/Analysis/Complex/UpperHalfPlane/Metric.lean
@@ -104,6 +104,7 @@ theorem dist_le_dist_coe_div_sqrt (z w : ℍ) : dist z w ≤ dist (z : ℂ) w / 
   rw [dist_le_iff_le_sinh, ← div_mul_eq_div_div_swap, self_le_sinh_iff]
   positivity
 
+open scoped OfNat in -- to use `no_index`ed simp lemmas for `ofNat`
 /-- An auxiliary `MetricSpace` instance on the upper half-plane. This instance has bad projection
 to `TopologicalSpace`. We replace it later. -/
 def metricSpaceAux : MetricSpace ℍ where

--- a/Mathlib/Analysis/Convex/Between.lean
+++ b/Mathlib/Analysis/Convex/Between.lean
@@ -784,6 +784,7 @@ theorem wbtw_iff_sameRay_vsub {x y z : P} : Wbtw R x y z ↔ SameRay R (y -ᵥ x
 
 variable (R)
 
+open scoped OfNat in -- to use `no_index`ed simp lemmas for `ofNat`
 theorem wbtw_pointReflection (x y : P) : Wbtw R y x (pointReflection R x y) := by
   refine ⟨2⁻¹, ⟨by norm_num, by norm_num⟩, ?_⟩
   rw [lineMap_apply, pointReflection_apply, vadd_vsub_assoc, ← two_smul R (x -ᵥ y)]

--- a/Mathlib/Analysis/Fourier/AddCircle.lean
+++ b/Mathlib/Analysis/Fourier/AddCircle.lean
@@ -453,6 +453,7 @@ theorem hasDerivAt_fourier_neg (n : ℤ) (x : ℝ) :
 
 variable {T}
 
+open scoped OfNat in -- to use `no_index`ed simp lemmas for `ofNat`
 theorem has_antideriv_at_fourier_neg (hT : Fact (0 < T)) {n : ℤ} (hn : n ≠ 0) (x : ℝ) :
     HasDerivAt (fun y : ℝ => (T : ℂ) / (-2 * π * I * n) * fourier (-n) (y : AddCircle T))
       (fourier (-n) (x : AddCircle T)) x := by

--- a/Mathlib/Analysis/NormedSpace/Connected.lean
+++ b/Mathlib/Analysis/NormedSpace/Connected.lean
@@ -29,6 +29,7 @@ section TopologicalVectorSpace
 variable {E : Type*} [AddCommGroup E] [Module ℝ E]
   [TopologicalSpace E] [ContinuousAdd E] [ContinuousSMul ℝ E]
 
+open scoped OfNat in -- to use `no_index`ed simp lemmas for `ofNat`
 /-- In a real vector space of dimension `> 1`, the complement of any countable set is path
 connected. -/
 theorem Set.Countable.isPathConnected_compl_of_one_lt_rank

--- a/Mathlib/Analysis/SpecialFunctions/Complex/Arg.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Complex/Arg.lean
@@ -247,6 +247,7 @@ theorem arg_eq_pi_div_two_iff {z : ℂ} : arg z = π / 2 ↔ z.re = 0 ∧ 0 < z.
     rintro ⟨rfl : x = 0, hy : 0 < y⟩
     rw [← arg_I, ← arg_real_mul I hy, ofReal_mul', I_re, I_im, mul_zero, mul_one]
 
+open scoped OfNat in -- to use `no_index`ed simp lemmas for `ofNat`
 theorem arg_eq_neg_pi_div_two_iff {z : ℂ} : arg z = -(π / 2) ↔ z.re = 0 ∧ z.im < 0 := by
   by_cases h₀ : z = 0; · simp [h₀, lt_irrefl, Real.pi_ne_zero]
   constructor
@@ -406,6 +407,7 @@ theorem arg_neg_eq_arg_sub_pi_iff {x : ℂ} :
       simp [hr.not_lt, ← add_eq_zero_iff_eq_neg, Real.pi_ne_zero]
   · simp [hi, arg_neg_eq_arg_sub_pi_of_im_pos]
 
+open scoped OfNat in -- to use `no_index`ed simp lemmas for `ofNat`
 theorem arg_neg_eq_arg_add_pi_iff {x : ℂ} :
     arg (-x) = arg x + π ↔ x.im < 0 ∨ x.im = 0 ∧ 0 < x.re := by
   rcases lt_trichotomy x.im 0 with (hi | hi | hi)

--- a/Mathlib/Analysis/SpecialFunctions/ImproperIntegrals.lean
+++ b/Mathlib/Analysis/SpecialFunctions/ImproperIntegrals.lean
@@ -168,6 +168,7 @@ theorem integral_Ioi_cpow_of_lt {a : ℂ} (ha : a.re < -1) {c : ℝ} (hc : 0 < c
   simp_rw [neg_neg, Complex.norm_eq_abs, Complex.abs_cpow_eq_rpow_re_of_pos hx, Complex.add_re,
     Complex.one_re]
 
+open scoped OfNat in -- to use `no_index`ed simp lemmas for `ofNat`
 theorem integrable_inv_one_add_sq : Integrable fun (x : ℝ) ↦ (1 + x ^ 2)⁻¹ := by
   suffices Integrable fun (x : ℝ) ↦ (1 + ‖x‖ ^ 2) ^ ((-2 : ℝ) / 2) by simpa [rpow_neg_one]
   exact integrable_rpow_neg_one_add_norm_sq (by simp)

--- a/Mathlib/Analysis/SpecialFunctions/Integrals.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Integrals.lean
@@ -760,6 +760,7 @@ theorem integral_sin_pow_even_mul_cos_pow_even (m n : ℕ) :
       ∫ x in a..b, ((1 - cos (2 * x)) / 2) ^ m * ((1 + cos (2 * x)) / 2) ^ n := by
   field_simp [pow_mul, sin_sq, cos_sq, ← sub_sub, (by ring : (2 : ℝ) - 1 = 1)]
 
+open scoped OfNat in -- to use `no_index`ed simp lemmas for `ofNat`
 @[simp]
 theorem integral_sin_sq_mul_cos_sq :
     ∫ x in a..b, sin x ^ 2 * cos x ^ 2 = (b - a) / 8 - (sin (4 * b) - sin (4 * a)) / 32 := by

--- a/Mathlib/Analysis/SpecialFunctions/Trigonometric/Bounds.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Trigonometric/Bounds.lean
@@ -54,6 +54,7 @@ lemma sin_le (hx : 0 ≤ x) : sin x ≤ x := by
 lemma lt_sin (hx : x < 0) : x < sin x := by simpa using sin_lt <| neg_pos.2 hx
 lemma le_sin (hx : x ≤ 0) : x ≤ sin x := by simpa using sin_le <| neg_nonneg.2 hx
 
+open scoped OfNat in -- to use `no_index`ed simp lemmas for `ofNat`
 lemma one_sub_sq_div_two_le_cos : 1 - x ^ 2 / 2 ≤ cos x := by
   wlog hx₀ : 0 ≤ x
   · simpa using this $ neg_nonneg.2 $ le_of_not_le hx₀

--- a/Mathlib/Combinatorics/SimpleGraph/LapMatrix.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/LapMatrix.lean
@@ -95,6 +95,7 @@ theorem posSemidef_lapMatrix [LinearOrderedField R] [StarRing R]
     rw [star_trivial, ← toLinearMap₂'_apply', lapMatrix_toLinearMap₂']
     positivity
 
+open scoped OfNat in -- to use `no_index`ed simp lemmas for `ofNat`
 theorem lapMatrix_toLinearMap₂'_apply'_eq_zero_iff_forall_adj [LinearOrderedField R] (x : V → R) :
     Matrix.toLinearMap₂' R (G.lapMatrix R) x x = 0 ↔ ∀ i j : V, G.Adj i j → x i = x j := by
   simp (disch := intros; positivity)

--- a/Mathlib/Combinatorics/SimpleGraph/Triangle/Basic.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Triangle/Basic.lean
@@ -59,6 +59,7 @@ nonrec lemma EdgeDisjointTriangles.mono (h : G ≤ H) (hH : H.EdgeDisjointTriang
 
 @[simp] lemma locallyLinear_bot : (⊥ : SimpleGraph α).LocallyLinear := by simp [LocallyLinear]
 
+open scoped OfNat in -- to use `no_index`ed simp lemmas for `ofNat`
 lemma EdgeDisjointTriangles.map (f : α ↪ β) (hG : G.EdgeDisjointTriangles) :
     (G.map f).EdgeDisjointTriangles := by
   rw [EdgeDisjointTriangles, cliqueSet_map (by norm_num : 3 ≠ 1),

--- a/Mathlib/Computability/AkraBazzi/GrowsPolynomially.lean
+++ b/Mathlib/Computability/AkraBazzi/GrowsPolynomially.lean
@@ -150,6 +150,7 @@ lemma eventually_zero_of_frequently_zero (hf : GrowsPolynomially f) (hf' : ∃�
       exact le_of_max_le_left hx₀_ge
     exact_mod_cast Nat.floor_le this
 
+open scoped OfNat in -- to use `no_index`ed simp lemmas for `ofNat`
 lemma eventually_atTop_nonneg_or_nonpos (hf : GrowsPolynomially f) :
     (∀ᶠ x in atTop, 0 ≤ f x) ∨ (∀ᶠ x in atTop, f x ≤ 0) := by
   obtain ⟨c₁, _, c₂, _, h⟩ := hf (1/2) (by norm_num)

--- a/Mathlib/Data/Complex/Module.lean
+++ b/Mathlib/Data/Complex/Module.lean
@@ -487,6 +487,7 @@ lemma Complex.coe_selfAdjointEquiv (z : selfAdjoint ℂ) :
   simpa [selfAdjointEquiv_symm_apply]
     using (congr_arg Subtype.val <| Complex.selfAdjointEquiv.left_inv z)
 
+open scoped OfNat in -- to use `no_index`ed simp lemmas for `ofNat`
 @[simp]
 lemma realPart_ofReal (r : ℝ) : (ℜ (r : ℂ) : ℂ) = r := by
   rw [realPart_apply_coe, star_def, conj_ofReal, ← two_smul ℝ (r : ℂ)]

--- a/Mathlib/Data/ENNReal/Inv.lean
+++ b/Mathlib/Data/ENNReal/Inv.lean
@@ -429,6 +429,7 @@ protected theorem half_lt_self (hz : a ≠ 0) (ht : a ≠ ∞) : a / 2 < a := by
 protected theorem half_le_self : a / 2 ≤ a :=
   le_add_self.trans_eq <| ENNReal.add_halves _
 
+open OfNat in -- to use `no_index`ed simp lemmas for `ofNat`
 theorem sub_half (h : a ≠ ∞) : a - a / 2 = a / 2 := by
   lift a to ℝ≥0 using h
   exact sub_eq_of_add_eq (mul_ne_top coe_ne_top <| by simp) (ENNReal.add_halves a)

--- a/Mathlib/Data/Set/Card.lean
+++ b/Mathlib/Data/Set/Card.lean
@@ -311,6 +311,7 @@ theorem exists_ne_of_one_lt_encard (h : 1 < s.encard) (a : α) : ∃ b ∈ s, b 
   apply hne
   rw [h' b hb, h' b' hb']
 
+open scoped OfNat in -- to use `no_index`ed simp lemmas for `ofNat`
 theorem encard_eq_two : s.encard = 2 ↔ ∃ x y, x ≠ y ∧ s = {x, y} := by
   refine ⟨fun h ↦ ?_, fun ⟨x, y, hne, hs⟩ ↦ by rw [hs, encard_pair hne]⟩
   obtain ⟨x, hx⟩ := nonempty_of_encard_ne_zero (s := s) (by rw [h]; simp)
@@ -320,6 +321,7 @@ theorem encard_eq_two : s.encard = 2 ↔ ∃ x y, x ≠ y ∧ s = {x, y} := by
   refine ⟨x, y, by rintro rfl; exact (h.symm.subset rfl).2 rfl, ?_⟩
   rw [← h, insert_diff_singleton, insert_eq_of_mem hx]
 
+open OfNat in -- to use `no_index`ed simp lemmas for `ofNat`
 theorem encard_eq_three {α : Type u_1} {s : Set α} :
     encard s = 3 ↔ ∃ x y z, x ≠ y ∧ x ≠ z ∧ y ≠ z ∧ s = {x, y, z} := by
   refine ⟨fun h ↦ ?_, fun ⟨x, y, z, hxy, hyz, hxz, hs⟩ ↦ ?_⟩
@@ -1020,12 +1022,14 @@ theorem ncard_eq_succ {n : ℕ} (hs : s.Finite := by toFinite_tac) :
   rintro ⟨a, t, hat, h, rfl⟩
   rw [← h, ncard_insert_of_not_mem hat (hs.subset ((subset_insert a t).trans_eq h))]
 
+open OfNat in -- to use `no_index`ed simp lemmas for `ofNat`
 theorem ncard_eq_two : s.ncard = 2 ↔ ∃ x y, x ≠ y ∧ s = {x, y} := by
   rw [← encard_eq_two, ncard_def, ← Nat.cast_inj (R := ℕ∞), Nat.cast_ofNat]
   refine ⟨fun h ↦ ?_, fun h ↦ ?_⟩
   · rwa [ENat.coe_toNat] at h; rintro h'; simp [h'] at h
   rw [h]; rfl
 
+open OfNat in -- to use `no_index`ed simp lemmas for `ofNat`
 theorem ncard_eq_three : s.ncard = 3 ↔ ∃ x y z, x ≠ y ∧ x ≠ z ∧ y ≠ z ∧ s = {x, y, z} := by
   rw [← encard_eq_three, ncard_def, ← Nat.cast_inj (R := ℕ∞), Nat.cast_ofNat]
   refine ⟨fun h ↦ ?_, fun h ↦ ?_⟩

--- a/Mathlib/Geometry/Euclidean/Angle/Oriented/Basic.lean
+++ b/Mathlib/Geometry/Euclidean/Angle/Oriented/Basic.lean
@@ -592,6 +592,7 @@ theorem eq_zero_or_angle_eq_zero_or_pi_of_sign_oangle_eq_zero {x y : V}
   rw [Real.Angle.sign_eq_zero_iff] at h
   rcases h with (h | h) <;> simp [h, Real.pi_pos.le]
 
+open scoped OfNat in -- to use `no_index`ed simp lemmas for `ofNat`
 /-- If two unoriented angles are equal, and the signs of the corresponding oriented angles are
 equal, then the oriented angles are equal (even in degenerate cases). -/
 theorem oangle_eq_of_angle_eq_of_sign_eq {w x y z : V}
@@ -671,6 +672,7 @@ theorem oangle_eq_zero_iff_angle_eq_zero {x y : V} (hx : x ≠ 0) (hy : y ≠ 0)
     rw [h] at ha
     simpa using ha
 
+open scoped OfNat in -- to use `no_index`ed simp lemmas for `ofNat`
 /-- The oriented angle between two vectors is `π` if and only if the unoriented angle is `π`. -/
 theorem oangle_eq_pi_iff_angle_eq_pi {x y : V} :
     o.oangle x y = π ↔ InnerProductGeometry.angle x y = π := by

--- a/Mathlib/Geometry/Euclidean/Angle/Sphere.lean
+++ b/Mathlib/Geometry/Euclidean/Angle/Sphere.lean
@@ -141,6 +141,7 @@ theorem abs_oangle_center_right_toReal_lt_pi_div_two {s : Sphere P} {p₁ p₂ :
   abs_oangle_left_toReal_lt_pi_div_two_of_dist_eq
     (dist_center_eq_dist_center_of_mem_sphere' hp₂ hp₁)
 
+open scoped OfNat in -- to use `no_index`ed simp lemmas for `ofNat`
 /-- Given two points on a circle, the center of that circle may be expressed explicitly as a
 multiple (by half the tangent of the angle between the chord and the radius at one of those
 points) of a `π / 2` rotation of the vector between those points, plus the midpoint of those
@@ -170,6 +171,7 @@ theorem inv_tan_div_two_smul_rotation_pi_div_two_vadd_midpoint_eq_center {s : Sp
   rw [add_comm,
     two_zsmul_oangle_center_add_two_zsmul_oangle_eq_pi hp₁ hp₂ hp₃ hp₁p₂.symm hp₂p₃ hp₁p₃]
 
+open scoped OfNat in -- to use `no_index`ed simp lemmas for `ofNat`
 /-- Given two points on a circle, the radius of that circle may be expressed explicitly as half
 the distance between those two points divided by the cosine of the angle between the chord and
 the radius at one of those points. -/

--- a/Mathlib/Geometry/Euclidean/PerpBisector.lean
+++ b/Mathlib/Geometry/Euclidean/PerpBisector.lean
@@ -48,6 +48,7 @@ theorem mem_perpBisector_iff_inner_eq_zero :
     c ∈ perpBisector p₁ p₂ ↔ ⟪c -ᵥ midpoint ℝ p₁ p₂, p₂ -ᵥ p₁⟫ = 0 :=
   inner_eq_zero_symm
 
+open scoped OfNat in -- to use `no_index`ed simp lemmas for `ofNat`
 theorem mem_perpBisector_iff_inner_pointReflection_vsub_eq_zero :
     c ∈ perpBisector p₁ p₂ ↔ ⟪Equiv.pointReflection c p₁ -ᵥ p₂, p₂ -ᵥ p₁⟫ = 0 := by
   rw [mem_perpBisector_iff_inner_eq_zero, Equiv.pointReflection_apply,
@@ -75,6 +76,7 @@ theorem direction_perpBisector (p₁ p₂ : P) :
   ext x
   exact Submodule.mem_orthogonal_singleton_iff_inner_right.symm
 
+open scoped OfNat in -- to use `no_index`ed simp lemmas for `ofNat`
 theorem mem_perpBisector_iff_inner_eq_inner :
     c ∈ perpBisector p₁ p₂ ↔ ⟪c -ᵥ p₁, p₂ -ᵥ p₁⟫ = ⟪c -ᵥ p₂, p₁ -ᵥ p₂⟫ := by
   rw [Iff.comm, mem_perpBisector_iff_inner_eq_zero, ← add_neg_eq_zero, ← inner_neg_right,

--- a/Mathlib/Geometry/Euclidean/Triangle.lean
+++ b/Mathlib/Geometry/Euclidean/Triangle.lean
@@ -36,6 +36,8 @@ unnecessarily.
 
 noncomputable section
 
+open scoped CharZero
+
 open scoped Classical
 
 open scoped Real

--- a/Mathlib/Geometry/Manifold/Instances/Sphere.lean
+++ b/Mathlib/Geometry/Manifold/Instances/Sphere.lean
@@ -133,6 +133,7 @@ theorem stereoInvFunAux_mem (hv : ‖v‖ = 1) {w : E} (hw : w ∈ (ℝ ∙ v)�
     Real.norm_eq_abs, hv]
   ring
 
+open scoped OfNat in -- to use `no_index`ed simp lemmas for `ofNat`
 theorem hasFDerivAt_stereoInvFunAux (v : E) :
     HasFDerivAt (stereoInvFunAux v) (ContinuousLinearMap.id ℝ E) 0 := by
   have h₀ : HasFDerivAt (fun w : E => ‖w‖ ^ 2) (0 : E →L[ℝ] ℝ) 0 := by

--- a/Mathlib/LinearAlgebra/Dimension/RankNullity.lean
+++ b/Mathlib/LinearAlgebra/Dimension/RankNullity.lean
@@ -58,6 +58,7 @@ lemma exists_set_linearIndependent :
     ∃ s : Set M, #s = Module.rank R M ∧ LinearIndependent (ι := s) R Subtype.val :=
   HasRankNullity.exists_set_linearIndependent M
 
+open scoped OfNat in -- to use `no_index`ed simp lemmas for `ofNat`
 variable (R) in
 theorem nontrivial_of_hasRankNullity : Nontrivial R := by
   refine (subsingleton_or_nontrivial R).resolve_left fun H ↦ ?_

--- a/Mathlib/LinearAlgebra/RootSystem/Basic.lean
+++ b/Mathlib/LinearAlgebra/RootSystem/Basic.lean
@@ -117,6 +117,7 @@ protected lemma ext [CharZero R] [NoZeroSMulDivisors R M]
   · exact hr ▸ he ▸ P₂.coroot_root_two i
   · exact hr ▸ he ▸ P₂.mapsTo_reflection_root i
 
+open scoped OfNat in -- to use `no_index`ed simp lemmas for `ofNat`
 private lemma coroot_eq_coreflection_of_root_eq' [CharZero R] [NoZeroSMulDivisors R M]
     (p : PerfectPairing R M N)
     (root : ι ↪ M)
@@ -211,6 +212,7 @@ protected lemma ext [CharZero R] [NoZeroSMulDivisors R M]
   · exact P₁.coroot_root_two i
   · exact P₁.mapsTo_reflection_root i
 
+open scoped OfNat in -- to use `no_index`ed simp lemmas for `ofNat`
 private lemma coroot_eq_coreflection_of_root_eq_of_span_eq_top [CharZero R] [NoZeroSMulDivisors R M]
     (p : PerfectPairing R M N)
     (root : ι ↪ M)

--- a/Mathlib/LinearAlgebra/RootSystem/Defs.lean
+++ b/Mathlib/LinearAlgebra/RootSystem/Defs.lean
@@ -120,9 +120,11 @@ namespace RootPairing
 variable {ι R M N}
 variable (P : RootPairing ι R M N) (i j : ι)
 
+open scoped OfNat in -- to use `no_index`ed simp lemmas for `ofNat`
 lemma ne_zero [CharZero R] : (P.root i : M) ≠ 0 :=
   fun h ↦ by simpa [h] using P.root_coroot_two i
 
+open scoped OfNat in -- to use `no_index`ed simp lemmas for `ofNat`
 lemma ne_zero' [CharZero R] : (P.coroot i : N) ≠ 0 :=
   fun h ↦ by simpa [h] using P.root_coroot_two i
 

--- a/Mathlib/MeasureTheory/Measure/Stieltjes.lean
+++ b/Mathlib/MeasureTheory/Measure/Stieltjes.lean
@@ -234,6 +234,7 @@ theorem length_subadditive_Icc_Ioo {a b : ℝ} {c d : ℕ → ℝ} (ss : Icc a b
   · rintro x ⟨h₁, h₂⟩
     exact (cv ⟨h₁, le_trans h₂ (le_of_lt cb)⟩).resolve_left (mt And.left (not_lt_of_le h₂))
 
+open scoped OfNat in -- to use `no_index`ed simp lemmas for `ofNat`
 @[simp]
 theorem outer_Ioc (a b : ℝ) : f.outer (Ioc a b) = ofReal (f b - f a) := by
   /- It suffices to show that, if `(a, b]` is covered by sets `s i`, then `f b - f a` is bounded

--- a/Mathlib/MeasureTheory/Measure/WithDensityFinite.lean
+++ b/Mathlib/MeasureTheory/Measure/WithDensityFinite.lean
@@ -90,6 +90,7 @@ lemma toFiniteAux_eq_zero_iff [SFinite μ] : μ.toFiniteAux = 0 ↔ μ = 0 := by
   specialize h n
   simpa [ENNReal.mul_eq_top, measure_ne_top] using h
 
+open scoped OfNat in -- to use `no_index`ed simp lemmas for `ofNat`
 lemma toFiniteAux_univ_le_one (μ : Measure α) [SFinite μ] : μ.toFiniteAux Set.univ ≤ 1 := by
   rw [toFiniteAux_apply]
   have h_le_pow : ∀ n, (2 ^ (n + 1) * sFiniteSeq μ n Set.univ)⁻¹ * sFiniteSeq μ n Set.univ

--- a/Mathlib/NumberTheory/LSeries/HurwitzZetaEven.lean
+++ b/Mathlib/NumberTheory/LSeries/HurwitzZetaEven.lean
@@ -209,11 +209,7 @@ lemma hasSum_int_evenKernel₀ (a : ℝ) {t : ℝ} (ht : 0 < t) :
 lemma hasSum_int_cosKernel₀ (a : ℝ) {t : ℝ} (ht : 0 < t) :
     HasSum (fun n : ℤ ↦ if n = 0 then 0 else cexp (2 * π * I * a * n) * rexp (-π * n ^ 2 * t))
     (↑(cosKernel a t) - 1) := by
-  simpa? using hasSum_ite_sub_hasSum (hasSum_int_cosKernel a ht) 0
-  says simpa only [neg_mul, ofReal_exp, ofReal_neg, ofReal_mul, ofReal_pow, ofReal_intCast,
-    Int.cast_zero, mul_zero, Complex.exp_zero, ne_eq, OfNat.ofNat_ne_zero, not_false_eq_true,
-    zero_pow, zero_mul, Real.exp_zero, ofReal_one, mul_one] using
-    hasSum_ite_sub_hasSum (hasSum_int_cosKernel a ht) 0
+  simpa using hasSum_ite_sub_hasSum (hasSum_int_cosKernel a ht) 0
 
 lemma hasSum_nat_cosKernel₀ (a : ℝ) {t : ℝ} (ht : 0 < t) :
     HasSum (fun n : ℕ ↦ 2 * Real.cos (2 * π * a * (n + 1)) * rexp (-π * (n + 1) ^ 2 * t))

--- a/Mathlib/NumberTheory/LSeries/HurwitzZetaOdd.lean
+++ b/Mathlib/NumberTheory/LSeries/HurwitzZetaOdd.lean
@@ -42,6 +42,7 @@ various versions of the Jacobi theta function.
 
 noncomputable section
 
+open CharZero
 open Complex hiding abs_of_nonneg
 open Filter Topology Asymptotics Real Set MeasureTheory
 open scoped ComplexConjugate

--- a/Mathlib/NumberTheory/LSeries/RiemannZeta.lean
+++ b/Mathlib/NumberTheory/LSeries/RiemannZeta.lean
@@ -44,7 +44,7 @@ proved in `Mathlib.NumberTheory.LSeries.HurwitzZetaEven`.
 
 
 open MeasureTheory Set Filter Asymptotics TopologicalSpace Real Asymptotics
-  Classical HurwitzZeta
+  Classical HurwitzZeta CharZero
 
 open Complex hiding exp norm_eq_abs abs_of_nonneg abs_two continuous_exp
 

--- a/Mathlib/NumberTheory/LegendreSymbol/Basic.lean
+++ b/Mathlib/NumberTheory/LegendreSymbol/Basic.lean
@@ -235,9 +235,9 @@ theorem eq_zero_mod_of_eq_neg_one {p : ℕ} [Fact p.Prime] {a : ℤ} (h : legend
     simp at h
   by_contra hf
   cases' imp_iff_or_not.mp (not_and'.mp hf) with hx hy
-  · rw [eq_one_of_sq_sub_mul_sq_eq_zero' ha hx hxy, eq_neg_self_iff] at h
+  · rw [eq_one_of_sq_sub_mul_sq_eq_zero' ha hx hxy, CharZero.eq_neg_self_iff] at h
     exact one_ne_zero h
-  · rw [eq_one_of_sq_sub_mul_sq_eq_zero ha hy hxy, eq_neg_self_iff] at h
+  · rw [eq_one_of_sq_sub_mul_sq_eq_zero ha hy hxy, CharZero.eq_neg_self_iff] at h
     exact one_ne_zero h
 
 /-- If `legendreSym p a = -1` and `p` divides `x^2 - a*y^2`, then `p` must divide `x` and `y`. -/

--- a/Mathlib/NumberTheory/LegendreSymbol/JacobiSymbol.lean
+++ b/Mathlib/NumberTheory/LegendreSymbol/JacobiSymbol.lean
@@ -260,7 +260,7 @@ theorem eq_neg_one_at_prime_divisor_of_eq_neg_one {a : ℤ} {n : ℕ} (h : J(a |
     ∃ p : ℕ, p.Prime ∧ p ∣ n ∧ J(a | p) = -1 := by
   have hn₀ : n ≠ 0 := by
     rintro rfl
-    rw [zero_right, eq_neg_self_iff] at h
+    rw [zero_right, CharZero.eq_neg_self_iff] at h
     exact one_ne_zero h
   have hf₀ (p) (hp : p ∈ n.primeFactorsList) : p ≠ 0 := (Nat.pos_of_mem_primeFactorsList hp).ne.symm
   rw [← Nat.prod_primeFactorsList hn₀, list_prod_right hf₀] at h

--- a/Mathlib/NumberTheory/LegendreSymbol/QuadraticChar/Basic.lean
+++ b/Mathlib/NumberTheory/LegendreSymbol/QuadraticChar/Basic.lean
@@ -213,7 +213,7 @@ when the domain has odd characteristic. -/
 theorem quadraticChar_ne_one (hF : ringChar F ≠ 2) : quadraticChar F ≠ 1 := by
   rcases quadraticChar_exists_neg_one' hF with ⟨a, ha⟩
   intro hχ
-  simp only [hχ, one_apply a.isUnit, eq_neg_self_iff, one_ne_zero] at ha
+  simp only [hχ, one_apply a.isUnit, CharZero.eq_neg_self_iff, one_ne_zero] at ha
 
 set_option linter.deprecated false in
 @[deprecated quadraticChar_ne_one (since := "2024-06-16")]

--- a/Mathlib/NumberTheory/Pell.lean
+++ b/Mathlib/NumberTheory/Pell.lean
@@ -400,7 +400,8 @@ theorem exists_iff_not_isSquare (h₀ : 0 < d) :
   refine ⟨?_, exists_of_not_isSquare h₀⟩
   rintro ⟨x, y, hxy, hy⟩ ⟨a, rfl⟩
   rw [← sq, ← mul_pow, sq_sub_sq] at hxy
-  simpa [hy, mul_self_pos.mp h₀, sub_eq_add_neg, eq_neg_self_iff] using Int.eq_of_mul_eq_one hxy
+  simpa [hy, mul_self_pos.mp h₀, sub_eq_add_neg, CharZero.eq_neg_self_iff]
+    using Int.eq_of_mul_eq_one hxy
 
 namespace Solution₁
 

--- a/Mathlib/RingTheory/Discriminant.lean
+++ b/Mathlib/RingTheory/Discriminant.lean
@@ -165,6 +165,7 @@ theorem discr_powerBasis_eq_prod' [Algebra.IsSeparable K L] (e : Fin pb.dim ≃ 
 
 local notation "n" => finrank K L
 
+open scoped OfNat in -- to use `no_index`ed simp lemmas for `ofNat`
 /-- A variation of `Algebra.discr_powerBasis_eq_prod`. -/
 theorem discr_powerBasis_eq_prod'' [Algebra.IsSeparable K L] (e : Fin pb.dim ≃ (L →ₐ[K] E)) :
     algebraMap K E (discr K pb.basis) =

--- a/Mathlib/RingTheory/RootsOfUnity/Complex.lean
+++ b/Mathlib/RingTheory/RootsOfUnity/Complex.lean
@@ -28,6 +28,7 @@ open Polynomial Real
 
 open scoped Nat Real
 
+open scoped OfNat in -- to use `no_index`ed simp lemmas for `ofNat`
 theorem isPrimitiveRoot_exp_of_coprime (i n : ℕ) (h0 : n ≠ 0) (hi : i.Coprime n) :
     IsPrimitiveRoot (exp (2 * π * I * (i / n))) n := by
   rw [IsPrimitiveRoot.iff_def]

--- a/Mathlib/Topology/MetricSpace/Closeds.lean
+++ b/Mathlib/Topology/MetricSpace/Closeds.lean
@@ -82,6 +82,7 @@ theorem isClosed_subsets_of_isClosed (hs : IsClosed s) :
 theorem Closeds.edist_eq {s t : Closeds α} : edist s t = hausdorffEdist (s : Set α) t :=
   rfl
 
+open scoped OfNat in -- to use `no_index`ed simp lemmas for `ofNat`
 /-- In a complete space, the type of closed subsets is complete for the
 Hausdorff edistance. -/
 instance Closeds.completeSpace [CompleteSpace α] : CompleteSpace (Closeds α) := by

--- a/Mathlib/Topology/MetricSpace/PiNat.lean
+++ b/Mathlib/Topology/MetricSpace/PiNat.lean
@@ -272,6 +272,7 @@ protected theorem dist_triangle (x y z : ∀ n, E n) : dist x z ≤ dist x y + d
     dist x z ≤ max (dist x y) (dist y z) := dist_triangle_nonarch x y z
     _ ≤ dist x y + dist y z := max_le_add_of_nonneg (PiNat.dist_nonneg _ _) (PiNat.dist_nonneg _ _)
 
+open scoped OfNat in -- to use `no_index`ed simp lemmas for `ofNat`
 protected theorem eq_of_dist_eq_zero (x y : ∀ n, E n) (hxy : dist x y = 0) : x = y := by
   rcases eq_or_ne x y with (rfl | h); · rfl
   simp [dist_eq_of_ne h] at hxy

--- a/Mathlib/Topology/Metrizable/Uniformity.lean
+++ b/Mathlib/Topology/Metrizable/Uniformity.lean
@@ -173,6 +173,7 @@ theorem le_two_mul_dist_ofPreNNDist (d : X → X → ℝ≥0) (dist_self : ∀ x
 
 end PseudoMetricSpace
 
+open scoped OfNat in -- to use `no_index`ed simp lemmas for `ofNat`
 -- Porting note (#11083): this is slower than in Lean3 for some reason...
 /-- If `X` is a uniform space with countably generated uniformity filter, there exists a
 `PseudoMetricSpace` structure compatible with the `UniformSpace` structure. Use

--- a/test/FieldSimp.lean
+++ b/test/FieldSimp.lean
@@ -54,6 +54,7 @@ example (x : ℚ) (h₀ : x ≠ 0) :
   field_simp
   ring
 
+open scoped OfNat in -- to use `no_index`ed simp lemmas for `ofNat`
 /-- Use a custom discharger -/
 example (x : ℚ) (h₀ : x ≠ 0) :
     (4 / x)⁻¹ * ((3 * x^3) / x)^2 * ((1 / (2 * x))⁻¹)^3 = 18 * x^8 := by


### PR DESCRIPTION
These have very general keys but narrow application. We scope them to their namespaces.

In particular, the `no_index`ed `ofNat` simp theorems are now explicitly opted into. If the handling of `ofNat` changes in core, this makes it easy to update.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
