### PR TITLE
feat: make `ZFSet.sInter` computable by going through `sUnion`

### DIFF
--- a/Mathlib/SetTheory/ZFC/Basic.lean
+++ b/Mathlib/SetTheory/ZFC/Basic.lean
@@ -813,8 +813,7 @@ theorem mem_sep {p : ZFSet.{u} → Prop} {x y : ZFSet.{u}} :
 theorem sep_empty f : (∅ : ZFSet).sep f = ∅ := by
   apply (eq_empty (ZFSet.sep f ∅)).mpr
   intro k mem
-  have ⟨ h, _ ⟩ := mem_sep.mp mem
-  exact not_mem_empty _ h
+  exact not_mem_empty _ (mem_sep.mp mem).1
 
 @[simp]
 theorem toSet_sep (a : ZFSet) (p : ZFSet → Prop) :
@@ -886,8 +885,8 @@ theorem mem_sInter {x y : ZFSet} (h : x.Nonempty) : y ∈ ⋂₀ x ↔ ∀ z ∈
   simp only [and_iff_right_iff_imp, mem_sep]
   intro mem
   apply mem_sUnion.mpr
-  replace ⟨ s, h ⟩ := h
-  exact ⟨ _, And.intro h (mem _ h) ⟩
+  replace ⟨s, h⟩ := h
+  exact ⟨_, h, mem _ h⟩
 
 @[simp]
 theorem sUnion_empty : ⋃₀ (∅ : ZFSet.{u}) = ∅ := by

--- a/Mathlib/SetTheory/ZFC/Basic.lean
+++ b/Mathlib/SetTheory/ZFC/Basic.lean
@@ -811,7 +811,7 @@ theorem mem_sep {p : ZFSet.{u} → Prop} {x y : ZFSet.{u}} :
 
 @[simp]
 theorem sep_empty f : (∅ : ZFSet).sep f = ∅ := by
-  apply (eq_empty (ZFSet.sep f ∅)).mpr
+  apply (eq_empty _).mpr
   intro k mem
   exact not_mem_empty _ (mem_sep.mp mem).1
 

--- a/Mathlib/SetTheory/ZFC/Basic.lean
+++ b/Mathlib/SetTheory/ZFC/Basic.lean
@@ -810,6 +810,13 @@ theorem mem_sep {p : ZFSet.{u} → Prop} {x y : ZFSet.{u}} :
         h⟩⟩
 
 @[simp]
+theorem sep_empty f : (∅ : ZFSet).sep f = ∅ := by
+  apply (eq_empty (ZFSet.sep f ∅)).mpr
+  intro k mem
+  have ⟨ h, _ ⟩ := mem_sep.mp mem
+  exact not_mem_empty _ h
+
+@[simp]
 theorem toSet_sep (a : ZFSet) (p : ZFSet → Prop) :
     (ZFSet.sep p a).toSet = { x ∈ a.toSet | p x } := by
   ext
@@ -863,8 +870,7 @@ prefix:110 "⋃₀ " => ZFSet.sUnion
 
 /-- The intersection operator, the collection of elements in all of the elements of a ZFC set. We
 special-case `⋂₀ ∅ = ∅`. -/
-noncomputable def sInter (x : ZFSet) : ZFSet := by
-   classical exact if h : x.Nonempty then ZFSet.sep (fun y => ∀ z ∈ x, y ∈ z) h.some else ∅
+def sInter (x : ZFSet) : ZFSet := (⋃₀ x).sep (fun y => ∀ z ∈ x, y ∈ z)
 
 @[inherit_doc]
 prefix:110 "⋂₀ " => ZFSet.sInter
@@ -876,9 +882,12 @@ theorem mem_sUnion {x y : ZFSet.{u}} : y ∈ ⋃₀ x ↔ ∃ z ∈ x, y ∈ z :
       ⟨fun ⟨z, h⟩ => ⟨⟦z⟧, h⟩, fun ⟨z, h⟩ => Quotient.inductionOn z (fun z h => ⟨z, h⟩) h⟩
 
 theorem mem_sInter {x y : ZFSet} (h : x.Nonempty) : y ∈ ⋂₀ x ↔ ∀ z ∈ x, y ∈ z := by
-  rw [sInter, dif_pos h]
-  simp only [mem_toSet, mem_sep, and_iff_right_iff_imp]
-  exact fun H => H _ h.some_mem
+  unfold sInter
+  simp only [and_iff_right_iff_imp, mem_sep]
+  intro mem
+  apply mem_sUnion.mpr
+  replace ⟨ s, h ⟩ := h
+  exact ⟨ _, And.intro h (mem _ h) ⟩
 
 @[simp]
 theorem sUnion_empty : ⋃₀ (∅ : ZFSet.{u}) = ∅ := by
@@ -886,7 +895,7 @@ theorem sUnion_empty : ⋃₀ (∅ : ZFSet.{u}) = ∅ := by
   simp
 
 @[simp]
-theorem sInter_empty : ⋂₀ (∅ : ZFSet) = ∅ := dif_neg <| by simp
+theorem sInter_empty : ⋂₀ (∅ : ZFSet) = ∅ := by simp [sInter]
 
 theorem mem_of_mem_sInter {x y z : ZFSet} (hy : y ∈ ⋂₀ x) (hz : z ∈ x) : y ∈ z := by
   rcases eq_empty_or_nonempty x with (rfl | hx)


### PR DESCRIPTION
this preserves the special case that sInter ∅ = ∅ because sUnion and sep both return ∅ when given ∅


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

cc @digama0 https://leanprover.zulipchat.com/#narrow/stream/287929-mathlib4/topic/computable.20ZFSet.2EsInter/near/457162229

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
