### PR TITLE
[Merged by Bors] - perf(CharP/CharZero): scope simp theorems with weak keys

### DIFF
--- a/Mathlib/Algebra/CharP/Two.lean
+++ b/Mathlib/Algebra/CharP/Two.lean
@@ -26,7 +26,7 @@ variable [Semiring R] [CharP R 2]
 
 theorem two_eq_zero : (2 : R) = 0 := by rw [← Nat.cast_two, CharP.cast_eq_zero]
 
-@[simp]
+@[scoped simp]
 theorem add_self_eq_zero (x : R) : x + x = 0 := by rw [← two_smul R x, two_eq_zero, zero_smul]
 
 end Semiring
@@ -35,14 +35,14 @@ section Ring
 
 variable [Ring R] [CharP R 2]
 
-@[simp]
+@[scoped simp]
 theorem neg_eq (x : R) : -x = x := by
   rw [neg_eq_iff_add_eq_zero, ← two_smul R x, two_eq_zero, zero_smul]
 
 theorem neg_eq' : Neg.neg = (id : R → R) :=
   funext neg_eq
 
-@[simp]
+@[scoped simp]
 theorem sub_eq_add (x y : R) : x - y = x + y := by rw [sub_eq_add_neg, neg_eq]
 
 theorem sub_eq_add' : HSub.hSub = ((· + ·) : R → R → R) :=

--- a/Mathlib/Algebra/CharZero/Lemmas.lean
+++ b/Mathlib/Algebra/CharZero/Lemmas.lean
@@ -87,10 +87,10 @@ section
 
 variable {R : Type*} [NonAssocRing R] [NoZeroDivisors R] [CharZero R]
 
-@[simp] theorem neg_eq_self_iff {a : R} : -a = a ↔ a = 0 :=
+@[scoped simp] theorem CharZero.neg_eq_self_iff {a : R} : -a = a ↔ a = 0 :=
   neg_eq_iff_add_eq_zero.trans add_self_eq_zero
 
-@[simp] theorem eq_neg_self_iff {a : R} : a = -a ↔ a = 0 :=
+@[scoped simp] theorem CharZero.eq_neg_self_iff {a : R} : a = -a ↔ a = 0 :=
   eq_neg_iff_add_eq_zero.trans add_self_eq_zero
 
 theorem nat_mul_inj {n : ℕ} {a b : R} (h : (n : R) * a = (n : R) * b) : n = 0 ∨ a = b := by

--- a/Mathlib/Analysis/Complex/Isometry.lean
+++ b/Mathlib/Analysis/Complex/Isometry.lean
@@ -30,6 +30,8 @@ noncomputable section
 
 open Complex
 
+open CharZero
+
 open ComplexConjugate
 
 local notation "|" x "|" => Complex.abs x

--- a/Mathlib/Geometry/Euclidean/Triangle.lean
+++ b/Mathlib/Geometry/Euclidean/Triangle.lean
@@ -36,6 +36,8 @@ unnecessarily.
 
 noncomputable section
 
+open scoped CharZero
+
 open scoped Classical
 
 open scoped Real

--- a/Mathlib/NumberTheory/LSeries/HurwitzZetaOdd.lean
+++ b/Mathlib/NumberTheory/LSeries/HurwitzZetaOdd.lean
@@ -43,7 +43,7 @@ various versions of the Jacobi theta function.
 noncomputable section
 
 open Complex hiding abs_of_nonneg
-open Filter Topology Asymptotics Real Set MeasureTheory
+open CharZero Filter Topology Asymptotics Real Set MeasureTheory
 open scoped ComplexConjugate
 
 namespace HurwitzZeta

--- a/Mathlib/NumberTheory/LSeries/RiemannZeta.lean
+++ b/Mathlib/NumberTheory/LSeries/RiemannZeta.lean
@@ -43,7 +43,7 @@ proved in `Mathlib.NumberTheory.LSeries.HurwitzZetaEven`.
 -/
 
 
-open MeasureTheory Set Filter Asymptotics TopologicalSpace Real Asymptotics
+open CharZero MeasureTheory Set Filter Asymptotics TopologicalSpace Real Asymptotics
   Classical HurwitzZeta
 
 open Complex hiding exp norm_eq_abs abs_of_nonneg abs_two continuous_exp

--- a/Mathlib/NumberTheory/LegendreSymbol/Basic.lean
+++ b/Mathlib/NumberTheory/LegendreSymbol/Basic.lean
@@ -235,9 +235,9 @@ theorem eq_zero_mod_of_eq_neg_one {p : ℕ} [Fact p.Prime] {a : ℤ} (h : legend
     simp at h
   by_contra hf
   cases' imp_iff_or_not.mp (not_and'.mp hf) with hx hy
-  · rw [eq_one_of_sq_sub_mul_sq_eq_zero' ha hx hxy, eq_neg_self_iff] at h
+  · rw [eq_one_of_sq_sub_mul_sq_eq_zero' ha hx hxy, CharZero.eq_neg_self_iff] at h
     exact one_ne_zero h
-  · rw [eq_one_of_sq_sub_mul_sq_eq_zero ha hy hxy, eq_neg_self_iff] at h
+  · rw [eq_one_of_sq_sub_mul_sq_eq_zero ha hy hxy, CharZero.eq_neg_self_iff] at h
     exact one_ne_zero h
 
 /-- If `legendreSym p a = -1` and `p` divides `x^2 - a*y^2`, then `p` must divide `x` and `y`. -/

--- a/Mathlib/NumberTheory/LegendreSymbol/JacobiSymbol.lean
+++ b/Mathlib/NumberTheory/LegendreSymbol/JacobiSymbol.lean
@@ -260,7 +260,7 @@ theorem eq_neg_one_at_prime_divisor_of_eq_neg_one {a : ℤ} {n : ℕ} (h : J(a |
     ∃ p : ℕ, p.Prime ∧ p ∣ n ∧ J(a | p) = -1 := by
   have hn₀ : n ≠ 0 := by
     rintro rfl
-    rw [zero_right, eq_neg_self_iff] at h
+    rw [zero_right, CharZero.eq_neg_self_iff] at h
     exact one_ne_zero h
   have hf₀ (p) (hp : p ∈ n.primeFactorsList) : p ≠ 0 := (Nat.pos_of_mem_primeFactorsList hp).ne.symm
   rw [← Nat.prod_primeFactorsList hn₀, list_prod_right hf₀] at h

--- a/Mathlib/NumberTheory/LegendreSymbol/QuadraticChar/Basic.lean
+++ b/Mathlib/NumberTheory/LegendreSymbol/QuadraticChar/Basic.lean
@@ -213,7 +213,7 @@ when the domain has odd characteristic. -/
 theorem quadraticChar_ne_one (hF : ringChar F ≠ 2) : quadraticChar F ≠ 1 := by
   rcases quadraticChar_exists_neg_one' hF with ⟨a, ha⟩
   intro hχ
-  simp only [hχ, one_apply a.isUnit, eq_neg_self_iff, one_ne_zero] at ha
+  simp only [hχ, one_apply a.isUnit, one_ne_zero] at ha
 
 set_option linter.deprecated false in
 @[deprecated quadraticChar_ne_one (since := "2024-06-16")]

--- a/Mathlib/NumberTheory/Pell.lean
+++ b/Mathlib/NumberTheory/Pell.lean
@@ -72,7 +72,7 @@ We then set up an API for `Pell.Solution₁ d`.
 -/
 
 
-open Zsqrtd
+open CharZero Zsqrtd
 
 /-- An element of `ℤ√d` has norm one (i.e., `a.re^2 - d*a.im^2 = 1`) if and only if
 it is contained in the submonoid of unitary elements.


### PR DESCRIPTION
These have keys like `HAdd.hAdd _ _ _ _ _ _` but are specific to characteristic two and zero.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
