### PR TITLE
[Merged by Bors] - feat(Data/FinEnum): Option instance and Type recursor

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -2297,6 +2297,7 @@ import Mathlib.Data.Fin.Tuple.Sort
 import Mathlib.Data.Fin.Tuple.Take
 import Mathlib.Data.Fin.VecNotation
 import Mathlib.Data.FinEnum
+import Mathlib.Data.FinEnum.Option
 import Mathlib.Data.Finite.Card
 import Mathlib.Data.Finite.Defs
 import Mathlib.Data.Finite.Powerset

--- a/Mathlib/Data/FinEnum.lean
+++ b/Mathlib/Data/FinEnum.lean
@@ -89,12 +89,12 @@ theorem card_ulift [FinEnum (ULift α)] [FinEnum α] : card (ULift α) = card α
   Fin.equiv_iff_eq.mp ⟨equiv.symm.trans Equiv.ulift |>.trans equiv⟩
 
 section ULift
-variable [FinEnum α] (i : Fin (card α))
+variable [FinEnum α] (a : α) (a' : ULift α) (i : Fin (card α))
 
-@[simp] lemma up_equiv : ULift.up (equiv i) = equiv i := rfl
-@[simp] lemma down_equiv : (equiv i).down = equiv i := rfl
-@[simp] lemma up_equiv_symm : ULift.up (equiv.symm i) = equiv.symm i := rfl
-@[simp] lemma down_equiv_symm : (equiv.symm i).down = equiv.symm i := rfl
+@[simp] lemma up_equiv : equiv (ULift.up a) = equiv a := rfl
+@[simp] lemma down_equiv : equiv a'.down = equiv a' := rfl
+@[simp] lemma up_equiv_symm : ULift.up (equiv.symm i) = ULift.instFinEnum.equiv.symm i := rfl
+@[simp] lemma down_equiv_symm : (ULift.instFinEnum.equiv.symm i).down = equiv.symm i := rfl
 
 end ULift
 
@@ -184,13 +184,13 @@ theorem card_eq_fintypeCard {α : Type u} [FinEnum α] [Fintype α] : card α = 
 /-- Any two enumerations of the same type have the same length. -/
 theorem card_unique {α : Type u} (e₁ e₂ : FinEnum α) : e₁.card = e₂.card :=
   calc _
-  _ = _ := @card_eq_fintype_card _ e₁ inferInstance
+  _ = _ := @card_eq_fintypeCard _ e₁ inferInstance
   _ = _ := Fintype.card_congr' rfl
-  _ = _ := @card_eq_fintype_card _ e₂ inferInstance |>.symm
+  _ = _ := @card_eq_fintypeCard _ e₂ inferInstance |>.symm
 
 /-- A type indexable by `Fin 0` is empty and vice versa. -/
 theorem card_eq_zero_iff {α : Type u} [FinEnum α] : card α = 0 ↔ IsEmpty α :=
-  Eq.congr_left card_eq_fintype_card |>.trans Fintype.card_eq_zero_iff
+  Eq.congr_left card_eq_fintypeCard |>.trans Fintype.card_eq_zero_iff
 
 /-- Any enumeration of an empty type has length 0. -/
 theorem card_eq_zero {α : Type u} [FinEnum α] [IsEmpty α] : card α = 0 :=
@@ -198,7 +198,7 @@ theorem card_eq_zero {α : Type u} [FinEnum α] [IsEmpty α] : card α = 0 :=
 
 /-- A type indexable by `Fin n` with positive `n` is inhabited and vice versa. -/
 theorem card_pos_iff {α : Type u} [FinEnum α] : 0 < card α ↔ Nonempty α :=
-  card_eq_fintype_card (α := α) ▸ Fintype.card_pos_iff
+  card_eq_fintypeCard (α := α) ▸ Fintype.card_pos_iff
 
 /-- Any non-empty enumeration has more than one element. -/
 lemma card_pos {α : Type*} [FinEnum α] [Nonempty α] : 0 < card α :=
@@ -209,7 +209,7 @@ lemma card_ne_zero {α : Type*} [FinEnum α] [Nonempty α] : card α ≠ 0 := ca
 
 /-- Any enumeration of a type with unique inhabitant has length 1. -/
 theorem card_eq_one (α : Type u) [FinEnum α] [Unique α] : card α = 1 :=
-  card_eq_fintype_card.trans <| Fintype.card_eq_one_iff_nonempty_unique.mpr ⟨‹_›⟩
+  card_eq_fintypeCard.trans <| Fintype.card_eq_one_iff_nonempty_unique.mpr ⟨‹_›⟩
 
 instance [IsEmpty α] : Unique (FinEnum α) where
   default := ⟨0, Equiv.equivOfIsEmpty α (Fin 0)⟩

--- a/Mathlib/Data/FinEnum.lean
+++ b/Mathlib/Data/FinEnum.lean
@@ -91,10 +91,10 @@ theorem card_ulift [FinEnum (ULift α)] [FinEnum α] : card (ULift α) = card α
 section ULift
 variable [FinEnum α] (a : α) (a' : ULift α) (i : Fin (card α))
 
-@[simp] lemma up_equiv : equiv (ULift.up a) = equiv a := rfl
-@[simp] lemma down_equiv : equiv a'.down = equiv a' := rfl
-@[simp] lemma equiv_symm_up : ULift.up (equiv.symm i) = (equiv (α := ULift α)).symm i := rfl
-@[simp] lemma equiv_symm_down : ((equiv (α := ULift α)).symm i).down = equiv.symm i := rfl
+@[simp] lemma equiv_up : equiv (ULift.up a) = equiv a := rfl
+@[simp] lemma equiv_down : equiv a'.down = equiv a' := rfl
+@[simp] lemma up_equiv_symm : ULift.up (equiv.symm i) = (equiv (α := ULift α)).symm i := rfl
+@[simp] lemma down_equiv_symm : ((equiv (α := ULift α)).symm i).down = equiv.symm i := rfl
 
 end ULift
 

--- a/Mathlib/Data/FinEnum.lean
+++ b/Mathlib/Data/FinEnum.lean
@@ -57,24 +57,24 @@ def toList (α) [FinEnum α] : List α :=
   (List.finRange (card α)).map (equiv).symm
 
 /-- Any two enumerations of the same type have the same length. -/
-theorem card_eq_card (α : Type u) (e₁ e₂ : FinEnum α) : e₁.card = e₂.card :=
+theorem card_eq_card {α : Type u} (e₁ e₂ : FinEnum α) : e₁.card = e₂.card :=
   Fin.equiv_iff_eq.mp ⟨e₁.equiv.symm.trans e₂.equiv⟩
 
 /-- Any enumeration of an empty type has length 0. -/
-theorem card_eq_zero_of_IsEmpty (α : Type u) [FinEnum α] [IsEmpty α] : card α = 0 :=
+theorem card_eq_zero_of_IsEmpty {α : Type u} [FinEnum α] [IsEmpty α] : card α = 0 :=
   match h : card α with
   | 0 => rfl
   | _ + 1 => ‹IsEmpty α›.elim ((h ▸ equiv).symm 0)
 
 /-- Any enumeration of a non-empty type has a length with an actual predecessor. -/
-def card_eq_succ_of_Nonempty (α : Type u) [FinEnum α] [Nonempty α] : { n : ℕ // card α = n + 1 } :=
+def cardPredOfNonempty (α : Type u) [FinEnum α] [Nonempty α] : { n : ℕ // card α = n + 1 } :=
   match h : card α with
   | 0 => False.elim <| ‹Nonempty α›.elim ((h ▸ equiv) · |>.elim0)
   | n + 1 => ⟨n, rfl⟩
 
 /-- Any enumeration of a type with unique inhabitant has length 1. -/
 theorem card_eq_one_of_Unique (α : Type u) [FinEnum α] [Unique α] : card α = 1 :=
-  match card_eq_succ_of_Nonempty α with
+  match cardPredOfNonempty α with
   | ⟨0, h⟩ => h
   | ⟨n + 1, h⟩ =>
     let α₀ : α := equiv.symm ⟨0, h ▸ (n + 1).succ_pos⟩
@@ -86,9 +86,9 @@ instance [IsEmpty α] : Unique (FinEnum α) where
   uniq e := by
     show FinEnum.mk e.1 e.2 = _
     congr 1
-    · exact card_eq_zero_of_IsEmpty α
+    · exact card_eq_zero_of_IsEmpty
     · refine heq_of_cast_eq ?_ (Subsingleton.allEq _ _)
-      exact congrArg (α ≃ Fin ·) <| card_eq_zero_of_IsEmpty α
+      exact congrArg (α ≃ Fin ·) <| card_eq_zero_of_IsEmpty
     · funext x
       exact ‹IsEmpty α›.elim x
 
@@ -131,13 +131,13 @@ noncomputable def ofInjective {α β} (f : α → β) [DecidableEq α] [FinEnum 
 instance uliftId [FinEnum α] : FinEnum (ULift α) :=
   ⟨card α, Equiv.ulift.trans equiv⟩
 
-theorem card_ulift [FinEnum α] [FinEnum (ULift α)] : card (ULift α) = card α :=
+theorem card_ulift [FinEnum (ULift α)] [FinEnum α] : card (ULift α) = card α :=
   Fin.equiv_iff_eq.mp ⟨equiv.symm.trans Equiv.ulift |>.trans equiv⟩
 
 theorem uliftId_equiv [FinEnum α] (i : Fin (card α)) :
     equiv.symm i = (uliftId.equiv.symm i).down := rfl
 
-instance [IsEmpty α] : FinEnum α := default
+def ofIsEmpty [IsEmpty α] : FinEnum α := default
 
 instance pempty : FinEnum PEmpty :=
   ofList [] fun x => PEmpty.elim x
@@ -145,7 +145,7 @@ instance pempty : FinEnum PEmpty :=
 instance empty : FinEnum Empty :=
   ofList [] fun x => Empty.elim x
 
-instance [Unique α] : FinEnum α := default
+def ofUnique [Unique α] : FinEnum α := default
 
 instance punit : FinEnum PUnit :=
   ofList [PUnit.unit] fun x => by cases x; simp

--- a/Mathlib/Data/FinEnum.lean
+++ b/Mathlib/Data/FinEnum.lean
@@ -57,23 +57,20 @@ def toList (α) [FinEnum α] : List α :=
   (List.finRange (card α)).map (equiv).symm
 
 /-- Any two enumerations of the same type have the same length. -/
-theorem card_eq_card {α : Type u} (e₁ e₂ : FinEnum α) : e₁.card = e₂.card :=
+theorem card_unique {α : Type u} (e₁ e₂ : FinEnum α) : e₁.card = e₂.card :=
   Fin.equiv_iff_eq.mp ⟨e₁.equiv.symm.trans e₂.equiv⟩
 
 /-- Any enumeration of an empty type has length 0. -/
-theorem card_eq_zero_of_IsEmpty {α : Type u} [FinEnum α] [IsEmpty α] : card α = 0 :=
+theorem card_eq_zero {α : Type u} [FinEnum α] [IsEmpty α] : card α = 0 :=
   match h : card α with
   | 0 => rfl
   | _ + 1 => ‹IsEmpty α›.elim ((h ▸ equiv).symm 0)
 
-/-- Any enumeration of a non-empty type has a length with an actual predecessor. -/
-def cardPredOfNonempty (α : Type u) [FinEnum α] [Nonempty α] : { n : ℕ // card α = n + 1 } :=
-  match h : card α with
-  | 0 => False.elim <| ‹Nonempty α›.elim ((h ▸ equiv) · |>.elim0)
-  | n + 1 => ⟨n, rfl⟩
+lemma card_pos {α : Type*} [FinEnum α] [Nonempty α] : 0 < card α := sorry
+lemma card_ne_zero {α : Type*} [FinEnum α] [Nonempty α] : card α ≠ 0 := card_pos.ne'
 
 /-- Any enumeration of a type with unique inhabitant has length 1. -/
-theorem card_eq_one_of_Unique (α : Type u) [FinEnum α] [Unique α] : card α = 1 :=
+theorem card_eq_one (α : Type u) [FinEnum α] [Unique α] : card α = 1 :=
   match cardPredOfNonempty α with
   | ⟨0, h⟩ => h
   | ⟨n + 1, h⟩ =>

--- a/Mathlib/Data/FinEnum.lean
+++ b/Mathlib/Data/FinEnum.lean
@@ -137,6 +137,8 @@ theorem card_ulift [FinEnum (ULift α)] [FinEnum α] : card (ULift α) = card α
 theorem uliftId_equiv [FinEnum α] (i : Fin (card α)) :
     equiv.symm i = (uliftId.equiv.symm i).down := rfl
 
+/-- An empty type has a trivial enumeration. Not registered as an instance, to make sure that there
+aren't two definitionally differing instances around. -/
 def ofIsEmpty [IsEmpty α] : FinEnum α := default
 
 instance pempty : FinEnum PEmpty :=
@@ -145,6 +147,8 @@ instance pempty : FinEnum PEmpty :=
 instance empty : FinEnum Empty :=
   ofList [] fun x => Empty.elim x
 
+/-- A type with unique inhabitant has a trivial enumeration. Not registered as an instance, to make
+sure that there aren't two definitionally differing instances around. -/
 def ofUnique [Unique α] : FinEnum α := default
 
 instance punit : FinEnum PUnit :=

--- a/Mathlib/Data/FinEnum.lean
+++ b/Mathlib/Data/FinEnum.lean
@@ -81,14 +81,22 @@ noncomputable def ofInjective {α β} (f : α → β) [DecidableEq α] [FinEnum 
       use f x
       simp only [h, Function.partialInv_left])
 
-instance uliftId [FinEnum α] : FinEnum (ULift α) :=
+instance _root_.ULift.instFinEnum [FinEnum α] : FinEnum (ULift α) :=
   ⟨card α, Equiv.ulift.trans equiv⟩
 
+@[simp]
 theorem card_ulift [FinEnum (ULift α)] [FinEnum α] : card (ULift α) = card α :=
   Fin.equiv_iff_eq.mp ⟨equiv.symm.trans Equiv.ulift |>.trans equiv⟩
 
-theorem uliftId_equiv [FinEnum α] (i : Fin (card α)) :
-    equiv.symm i = (uliftId.equiv.symm i).down := rfl
+section ULift
+variable [FinEnum α] (i : Fin (card α))
+
+@[simp] lemma up_equiv : ULift.up (equiv i) = equiv i := rfl
+@[simp] lemma down_equiv : (equiv i).down = equiv i := rfl
+@[simp] lemma up_equiv_symm : ULift.up (equiv.symm i) = equiv.symm i := rfl
+@[simp] lemma down_equiv_symm : (equiv.symm i).down = equiv.symm i := rfl
+
+end ULift
 
 instance pempty : FinEnum PEmpty :=
   ofList [] fun x => PEmpty.elim x
@@ -108,6 +116,7 @@ instance sum {β} [FinEnum α] [FinEnum β] : FinEnum (α ⊕ β) :=
 instance fin {n} : FinEnum (Fin n) :=
   ofList (List.finRange _) (by simp)
 
+@[simp]
 theorem card_fin {n} [FinEnum (Fin n)] : card (Fin n) = n := Fin.equiv_iff_eq.mp ⟨equiv.symm⟩
 
 instance Quotient.enum [FinEnum α] (s : Setoid α) [DecidableRel ((· ≈ ·) : α → α → Prop)] :
@@ -169,7 +178,7 @@ instance (priority := 100) [FinEnum α] : Fintype α where
   complete := by intros; simp
 
 /-- The enumeration merely adds an ordering, leaving the cardinality as is. -/
-theorem card_eq_fintype_card {α : Type u} [FinEnum α] [Fintype α] : card α = Fintype.card α :=
+theorem card_eq_fintypeCard {α : Type u} [FinEnum α] [Fintype α] : card α = Fintype.card α :=
   Fintype.truncEquivFin α |>.inductionOn (fun h ↦ Fin.equiv_iff_eq.mp ⟨equiv.symm.trans h⟩)
 
 /-- Any two enumerations of the same type have the same length. -/

--- a/Mathlib/Data/FinEnum.lean
+++ b/Mathlib/Data/FinEnum.lean
@@ -93,8 +93,8 @@ variable [FinEnum α] (a : α) (a' : ULift α) (i : Fin (card α))
 
 @[simp] lemma up_equiv : equiv (ULift.up a) = equiv a := rfl
 @[simp] lemma down_equiv : equiv a'.down = equiv a' := rfl
-@[simp] lemma up_equiv_symm : ULift.up (equiv.symm i) = ULift.instFinEnum.equiv.symm i := rfl
-@[simp] lemma down_equiv_symm : (ULift.instFinEnum.equiv.symm i).down = equiv.symm i := rfl
+@[simp] lemma equiv_symm_up : ULift.up (equiv.symm i) = (equiv (α := ULift α)).symm i := rfl
+@[simp] lemma equiv_symm_down : ((equiv (α := ULift α)).symm i).down = equiv.symm i := rfl
 
 end ULift
 

--- a/Mathlib/Data/FinEnum/Option.lean
+++ b/Mathlib/Data/FinEnum/Option.lean
@@ -1,0 +1,68 @@
+/-
+Copyright (c) 2024 Tom Kranz. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Tom Kranz
+-/
+import Mathlib.Data.FinEnum
+import Mathlib.Logic.Equiv.Fin
+import Mathlib.Data.ULift
+
+/-!
+# FinEnum instance for Option
+
+Provides a recursor for FinEnum types like `Fintype.truncRecEmptyOption`, but capable of producing
+non-truncated data.
+
+## TODO
+* recreate rest of `Mathlib.Data.Fintype.Option`
+-/
+
+namespace FinEnum
+universe u v
+
+/-- The additional `Option.none` element doesn't negate enumerability. -/
+instance instFinEnumOption (α : Type u) [FinEnum α] : FinEnum (Option α) where
+  card := card α + 1
+  equiv := by
+    refine ⟨Option.rec 0 (Fin.succ ∘ equiv), Fin.cases none (some ∘ equiv.symm), ?_, ?_⟩
+    <;> [apply Option.rec; apply Fin.cases] <;> simp[Fin.succ_ne_zero]
+
+/-- A recursor principle for finite-and-enumerable types, analogous to `Nat.rec`.
+It effectively says that every `FinEnum` is either `Empty` or `Option α`, up to an `Equiv`.
+In contrast to the `Fintype` case, data can be transported along such an `Equiv`. -/
+def recEmptyOption {P : (α : Type u) → [FinEnum α] → Sort v}
+    (of_equiv : {α β : Type u} → [FinEnum α] → [FinEnum β] → α ≃ β → P α → P β)
+    (h_empty : P PEmpty.{u + 1})
+    (h_option : {α : Type u} → [FinEnum α] → P α → P (Option α))
+    (α : Type u) [FinEnum α] :
+    P α := by
+  generalize cardeq : ‹FinEnum α›.card = card
+  induction card generalizing α
+  case zero =>
+    have fzeroeq := Equiv.trans Equiv.ulift.{u} <| cardeq ▸ equiv.symm
+    have emptyeq := Equiv.trans Equiv.ulift <| Equiv.equivOfIsEmpty (Fin Nat.zero) PEmpty.{u+1}
+    have fzerofe := FinEnum.ofEquiv _ emptyeq
+    exact of_equiv fzeroeq <| of_equiv emptyeq.symm h_empty
+  case succ n ih _ =>
+    have ⟨fe, fecardeq⟩ : { e : _ // e.card = n } := ⟨FinEnum.mk n Equiv.ulift.{u}, rfl⟩
+    have fsucceq := Equiv.trans Equiv.ulift.{u} <| cardeq ▸ equiv.symm
+    have optioeq :=
+      Equiv.trans
+        Equiv.ulift <|
+        Equiv.trans (@finSuccEquivLast n) <| Equiv.optionCongr Equiv.ulift.symm
+    have opsumeq := Equiv.optionEquivSumPUnit.{u,u} <| ULift (Fin n)
+    have fssumeq := Equiv.trans optioeq opsumeq
+    have fssumfe := @FinEnum.sum _ _ fe FinEnum.punit.{u}
+    have fsuccfe := FinEnum.ofEquiv _ fssumeq
+    exact of_equiv fsucceq <| of_equiv optioeq.symm <| h_option <| @ih _ fe fecardeq
+
+/-- A recursor principle for finite-and-enumerable types, analogous to `Nat.recOn`.
+It effectively says that every `FinEnum` is either `Empty` or `Option α`, up to an `Equiv`.
+In contrast to the `Fintype` case, data can be transported along such an `Equiv`. -/
+def recOnEmptyOption {P : (α : Type u) → [FinEnum α] → Sort v}
+    {α : Type u} (aenum : FinEnum α)
+    (of_equiv : {α β : Type u} → [FinEnum α] → [FinEnum β] → α ≃ β → P α → P β)
+    (h_empty : P PEmpty.{u + 1})
+    (h_option : {α : Type u} → [FinEnum α] → P α → P (Option α)) :
+    P α := @recEmptyOption P of_equiv h_empty h_option α aenum
+end FinEnum

--- a/Mathlib/Data/FinEnum/Option.lean
+++ b/Mathlib/Data/FinEnum/Option.lean
@@ -35,7 +35,12 @@ It effectively says that every `FinEnum` is either `Empty` or `Option α`, up to
 by `Fin`s of equal cardinality.
 In contrast to the `Fintype` case, data can be transported along such an `Equiv`.
 Also, since order matters, the choice of element that gets replaced by `Option.none` has
-to be provided for every step. -/
+to be provided for every step.
+
+Since every `FinEnum` instance implies a `Fintype` instance and `Prop` is squashed already,
+`Fintype.induction_empty_option` can be used if a `Prop` needs to be constructed.
+Cf. `Data.Fintype.Option`
+-/
 def recEmptyOption {P : (α : Type u) → Sort v}
     (fin_choice : (n : ℕ) → Fin (n + 1))
     (of_equiv : {α β : Type u} → (_ : FinEnum α) → (_ : FinEnum β) → card β = card α → P α → P β )
@@ -92,8 +97,12 @@ theorem recEmptyOption_of_card_eq_succ {P : (α : Type u) → Sort v}
   · rcases Nat.succ.inj (n.prop.symm.trans ‹_›) with ⟨rfl⟩; rfl
 
 /-- A recursor principle for finite-and-enumerable types, analogous to `Nat.recOn`.
-It effectively says that every `FinEnum` is either `Empty` or `Option α`, up to an `Equiv`.
-In contrast to the `Fintype` case, data can be transported along such an `Equiv`. -/
+It effectively says that every `FinEnum` is either `Empty` or `Option α`, up to an `Equiv` mediated
+by `Fin`s of equal cardinality.
+In contrast to the `Fintype` case, data can be transported along such an `Equiv`.
+Also, since order matters, the choice of element that gets replaced by `Option.none` has
+to be provided for every step.
+-/
 abbrev recOnEmptyOption {P : (α : Type u) → Sort v}
     {α : Type u} (aenum : FinEnum α)
     (fin_choice : (n : ℕ) → Fin (n + 1))

--- a/Mathlib/Data/FinEnum/Option.lean
+++ b/Mathlib/Data/FinEnum/Option.lean
@@ -58,7 +58,7 @@ def recEmptyOption {P : Type u → Sort v}
 termination_by card α
 
 /--
-For an empty type, the recursion principle evaluates to whatever `of_equiv`
+For an empty type, the recursion principle evaluates to whatever `congr`
 makes of the base case.
 -/
 theorem recEmptyOption_of_card_eq_zero {P : Type u → Sort v}
@@ -76,8 +76,8 @@ theorem recEmptyOption_of_card_eq_zero {P : Type u → Sort v}
 
 /--
 For a type whose `card` has a predecessor `n`, the recursion principle evaluates to whatever
-`of_equiv` makes of the step result, where `Option.none` has been inserted into the
-`(fin_choice n)`th rank of the enumeration.
+`congr` makes of the step result, where `Option.none` has been inserted into the
+`(finChoice n)`th rank of the enumeration.
 -/
 theorem recEmptyOption_of_card_eq_succ {P : Type u → Sort v}
     (finChoice : (n : ℕ) → Fin (n + 1))

--- a/Mathlib/Data/FinEnum/Option.lean
+++ b/Mathlib/Data/FinEnum/Option.lean
@@ -5,7 +5,6 @@ Authors: Tom Kranz
 -/
 import Mathlib.Data.FinEnum
 import Mathlib.Logic.Equiv.Fin
-import Mathlib.Data.ULift
 
 /-!
 # FinEnum instance for Option

--- a/Mathlib/Data/FinEnum/Option.lean
+++ b/Mathlib/Data/FinEnum/Option.lean
@@ -40,11 +40,11 @@ Since every `FinEnum` instance implies a `Fintype` instance and `Prop` is squash
 `Fintype.induction_empty_option` can be used if a `Prop` needs to be constructed.
 Cf. `Data.Fintype.Option`
 -/
-def recEmptyOption {P : (α : Type u) → Sort v}
-    (fin_choice : (n : ℕ) → Fin (n + 1))
-    (of_equiv : {α β : Type u} → (_ : FinEnum α) → (_ : FinEnum β) → card β = card α → P α → P β )
-    (h_empty : P PEmpty.{u + 1})
-    (h_option : {α : Type u} → FinEnum α → P α → P (Option α))
+def recEmptyOption {P : Type u → Sort v}
+    (finChoice : (n : ℕ) → Fin (n + 1))
+    (congr : {α β : Type u} → (_ : FinEnum α) → (_ : FinEnum β) → card β = card α → P α → P β )
+    (empty : P PEmpty.{u + 1})
+    (option : {α : Type u} → FinEnum α → P α → P (Option α))
     (α : Type u) [FinEnum α] :
     P α :=
   match cardeq : card α with
@@ -58,7 +58,7 @@ def recEmptyOption {P : (α : Type u) → Sort v}
 termination_by card α
 
 /--
-For a type whose `card` disappears, the recursion principle evaluates to whatever `of_equiv`
+For an empty type, the recursion principle evaluates to whatever `of_equiv`
 makes of the base case.
 -/
 theorem recEmptyOption_of_card_eq_zero {P : (α : Type u) → Sort v}

--- a/Mathlib/Data/FinEnum/Option.lean
+++ b/Mathlib/Data/FinEnum/Option.lean
@@ -27,7 +27,7 @@ def insertNone (α : Type u) [FinEnum α] (i : Fin (card α + 1)) : FinEnum (Opt
 /-- This is an arbitrary choice of insertion rank for a default instance.
 It keeps the mapping of the existing `α`-inhabitants intact, modulo `Fin.castSucc`. -/
 instance instFinEnumOptionLast (α : Type u) [FinEnum α] : FinEnum (Option α) :=
-  insertNone α (Fin.last <| card α)
+  insertNone α (Fin.last _)
 
 /-- A recursor principle for finite-and-enumerable types, analogous to `Nat.rec`.
 It effectively says that every `FinEnum` is either `Empty` or `Option α`, up to an `Equiv` mediated
@@ -50,7 +50,7 @@ def recEmptyOption {P : Type u → Sort v}
   match cardeq : card α with
   | 0 => congr _ _ cardeq empty
   | n + 1 =>
-    let fN := uliftId (α := Fin n)
+    let fN := ULift.instFinEnum (α := Fin n)
     have : card (ULift.{u} <| Fin n) = n := card_ulift.trans card_fin
     congr (insertNone _ <| finChoice n) _
       (cardeq.trans <| congrArg Nat.succ this.symm) <|
@@ -68,7 +68,7 @@ theorem recEmptyOption_of_card_eq_zero {P : Type u → Sort v}
     (option : {α : Type u} → FinEnum α → P α → P (Option α))
     (α : Type u) [FinEnum α] (h : card α = 0) (_ : FinEnum PEmpty.{u + 1}) :
     recEmptyOption finChoice congr empty option α =
-      congr _ _ (h.trans <| card_eq_zero |>.symm) empty := by
+      congr _ _ (h.trans card_eq_zero.symm) empty := by
   unfold recEmptyOption
   split
   · congr 1; exact Subsingleton.allEq _ _
@@ -87,16 +87,13 @@ theorem recEmptyOption_of_card_pos {P : Type u → Sort v}
     (α : Type u) [FinEnum α] (h : 0 < card α) :
     recEmptyOption finChoice congr empty option α =
       congr (insertNone _ <| finChoice (card α - 1)) ‹_›
-        (calc _
-        _ = card _ + 1 := card_unique _ <| instFinEnumOptionLast _
-        _ = _ := congrArg (· + 1) <| card_unique _ uliftId |>.trans card_fin
-        _ = _ := (card α).succ_pred_eq_of_pos h).symm
-        (option uliftId <|
+        (congrArg (· + 1) card_fin |>.trans <| (card α).succ_pred_eq_of_pos h).symm
+        (option ULift.instFinEnum <|
           recEmptyOption finChoice congr empty option (ULift.{u} <| Fin (card α - 1))) := by
   conv => lhs; unfold recEmptyOption
   split
   · exact absurd (‹_› ▸ h) (card α).lt_irrefl
-  · rcases Nat.succ.inj <| (card α).succ_pred_eq_of_pos h |>.trans ‹_› with ⟨rfl⟩; rfl
+  · rcases Nat.succ.inj <| (card α).succ_pred_eq_of_pos h |>.trans ‹_› with rfl; rfl
 
 /-- A recursor principle for finite-and-enumerable types, analogous to `Nat.recOn`.
 It effectively says that every `FinEnum` is either `Empty` or `Option α`, up to an `Equiv` mediated

--- a/Mathlib/Data/FinEnum/Option.lean
+++ b/Mathlib/Data/FinEnum/Option.lean
@@ -45,17 +45,17 @@ def recEmptyOption {P : (α : Type u) → Sort v}
     (fin_choice : (n : ℕ) → Fin (n + 1))
     (of_equiv : {α β : Type u} → (_ : FinEnum α) → (_ : FinEnum β) → card β = card α → P α → P β )
     (h_empty : P PEmpty.{u + 1})
-    (h_option : {α : Type u} → [FinEnum α] → P α → P (Option α))
+    (h_option : {α : Type u} → FinEnum α → P α → P (Option α))
     (α : Type u) [FinEnum α] :
     P α :=
   match cardeq : card α with
   | 0 => of_equiv _ _ cardeq h_empty
   | n + 1 =>
-    have := uliftId (α := Fin n)
+    let fN := uliftId (α := Fin n)
     have : card (ULift.{u} <| Fin n) = n := card_ulift.trans card_fin
     of_equiv (insertNone _ <| fin_choice n) _
       (cardeq.trans <| congrArg Nat.succ this.symm) <|
-        h_option (recEmptyOption fin_choice of_equiv h_empty h_option _)
+        h_option fN (recEmptyOption fin_choice of_equiv h_empty h_option _)
 termination_by card α
 
 /--
@@ -66,10 +66,10 @@ theorem recEmptyOption_of_card_eq_zero {P : (α : Type u) → Sort v}
     (fin_choice : (n : ℕ) → Fin (n + 1))
     (of_equiv : {α β : Type u} → (_ : FinEnum α) → (_ : FinEnum β) → card β = card α → P α → P β )
     (h_empty : P PEmpty.{u + 1})
-    (h_option : {α : Type u} → [FinEnum α] → P α → P (Option α))
-    (α : Type u) [FinEnum α] [fe : FinEnum PEmpty.{u + 1}] (h : card α = 0) :
+    (h_option : {α : Type u} → FinEnum α → P α → P (Option α))
+    (α : Type u) [FinEnum α] (h : card α = 0) (_ : FinEnum PEmpty.{u + 1}) :
     recEmptyOption fin_choice of_equiv h_empty h_option α =
-      of_equiv _ _ (h.trans <| card_eq_zero_of_IsEmpty _ |>.symm) h_empty := by
+      of_equiv _ _ (h.trans <| card_eq_zero_of_IsEmpty |>.symm) h_empty := by
   unfold recEmptyOption
   split
   · congr 1; exact Subsingleton.allEq _ _
@@ -84,17 +84,17 @@ theorem recEmptyOption_of_card_eq_succ {P : (α : Type u) → Sort v}
     (fin_choice : (n : ℕ) → Fin (n + 1))
     (of_equiv : {α β : Type u} → (_ : FinEnum α) → (_ : FinEnum β) → card β = card α → P α → P β )
     (h_empty : P PEmpty.{u + 1})
-    (h_option : {α : Type u} → [FinEnum α] → P α → P (Option α))
+    (h_option : {α : Type u} → FinEnum α → P α → P (Option α))
     (α : Type u) [FinEnum α] (n : {n : ℕ // card α = n + 1}) :
     recEmptyOption fin_choice of_equiv h_empty h_option α =
       of_equiv (insertNone _ <| fin_choice n) _
         (n.prop.trans <| congrArg Nat.succ (card_ulift.trans card_fin).symm)
-        (h_option
-          (recEmptyOption fin_choice of_equiv h_empty h_option (ULift.{u} <| Fin n))) := by
+        (h_option uliftId <|
+          recEmptyOption fin_choice of_equiv h_empty h_option (ULift.{u} <| Fin n)) := by
   conv => lhs; unfold recEmptyOption
   split
   · exact Nat.noConfusion <| n.prop.symm.trans ‹_›
-  · rcases Nat.succ.inj (n.prop.symm.trans ‹_›) with ⟨rfl⟩; rfl
+  · rcases Nat.succ.inj <| n.prop.symm.trans ‹_› with ⟨rfl⟩; rfl
 
 /-- A recursor principle for finite-and-enumerable types, analogous to `Nat.recOn`.
 It effectively says that every `FinEnum` is either `Empty` or `Option α`, up to an `Equiv` mediated
@@ -108,7 +108,7 @@ abbrev recOnEmptyOption {P : (α : Type u) → Sort v}
     (fin_choice : (n : ℕ) → Fin (n + 1))
     (of_equiv : {α β : Type u} → (_ : FinEnum α) → (_ : FinEnum β) → card β = card α → P α → P β )
     (h_empty : P PEmpty.{u + 1})
-    (h_option : {α : Type u} → [FinEnum α] → P α → P (Option α)) :
+    (h_option : {α : Type u} → FinEnum α → P α → P (Option α)) :
     P α :=
   @recEmptyOption P fin_choice of_equiv h_empty h_option α aenum
 

--- a/Mathlib/Data/FinEnum/Option.lean
+++ b/Mathlib/Data/FinEnum/Option.lean
@@ -42,33 +42,33 @@ Cf. `Data.Fintype.Option`
 -/
 def recEmptyOption {P : Type u → Sort v}
     (finChoice : (n : ℕ) → Fin (n + 1))
-    (congr : {α β : Type u} → (_ : FinEnum α) → (_ : FinEnum β) → card β = card α → P α → P β )
+    (congr : {α β : Type u} → (_ : FinEnum α) → (_ : FinEnum β) → card β = card α → P α → P β)
     (empty : P PEmpty.{u + 1})
     (option : {α : Type u} → FinEnum α → P α → P (Option α))
     (α : Type u) [FinEnum α] :
     P α :=
   match cardeq : card α with
-  | 0 => of_equiv _ _ cardeq h_empty
+  | 0 => congr _ _ cardeq empty
   | n + 1 =>
     let fN := uliftId (α := Fin n)
     have : card (ULift.{u} <| Fin n) = n := card_ulift.trans card_fin
-    of_equiv (insertNone _ <| fin_choice n) _
+    congr (insertNone _ <| finChoice n) _
       (cardeq.trans <| congrArg Nat.succ this.symm) <|
-        h_option fN (recEmptyOption fin_choice of_equiv h_empty h_option _)
+        option fN (recEmptyOption finChoice congr empty option _)
 termination_by card α
 
 /--
 For an empty type, the recursion principle evaluates to whatever `of_equiv`
 makes of the base case.
 -/
-theorem recEmptyOption_of_card_eq_zero {P : (α : Type u) → Sort v}
-    (fin_choice : (n : ℕ) → Fin (n + 1))
-    (of_equiv : {α β : Type u} → (_ : FinEnum α) → (_ : FinEnum β) → card β = card α → P α → P β )
-    (h_empty : P PEmpty.{u + 1})
-    (h_option : {α : Type u} → FinEnum α → P α → P (Option α))
+theorem recEmptyOption_of_card_eq_zero {P : Type u → Sort v}
+    (finChoice : (n : ℕ) → Fin (n + 1))
+    (congr : {α β : Type u} → (_ : FinEnum α) → (_ : FinEnum β) → card β = card α → P α → P β)
+    (empty : P PEmpty.{u + 1})
+    (option : {α : Type u} → FinEnum α → P α → P (Option α))
     (α : Type u) [FinEnum α] (h : card α = 0) (_ : FinEnum PEmpty.{u + 1}) :
-    recEmptyOption fin_choice of_equiv h_empty h_option α =
-      of_equiv _ _ (h.trans <| card_eq_zero_of_IsEmpty |>.symm) h_empty := by
+    recEmptyOption finChoice congr empty option α =
+      congr _ _ (h.trans <| card_eq_zero_of_IsEmpty |>.symm) empty := by
   unfold recEmptyOption
   split
   · congr 1; exact Subsingleton.allEq _ _
@@ -79,17 +79,17 @@ For a type whose `card` has a predecessor `n`, the recursion principle evaluates
 `of_equiv` makes of the step result, where `Option.none` has been inserted into the
 `(fin_choice n)`th rank of the enumeration.
 -/
-theorem recEmptyOption_of_card_eq_succ {P : (α : Type u) → Sort v}
-    (fin_choice : (n : ℕ) → Fin (n + 1))
-    (of_equiv : {α β : Type u} → (_ : FinEnum α) → (_ : FinEnum β) → card β = card α → P α → P β )
-    (h_empty : P PEmpty.{u + 1})
-    (h_option : {α : Type u} → FinEnum α → P α → P (Option α))
+theorem recEmptyOption_of_card_eq_succ {P : Type u → Sort v}
+    (finChoice : (n : ℕ) → Fin (n + 1))
+    (congr : {α β : Type u} → (_ : FinEnum α) → (_ : FinEnum β) → card β = card α → P α → P β)
+    (empty : P PEmpty.{u + 1})
+    (option : {α : Type u} → FinEnum α → P α → P (Option α))
     (α : Type u) [FinEnum α] (n : {n : ℕ // card α = n + 1}) :
-    recEmptyOption fin_choice of_equiv h_empty h_option α =
-      of_equiv (insertNone _ <| fin_choice n) _
+    recEmptyOption finChoice congr empty option α =
+      congr (insertNone _ <| finChoice n) _
         (n.prop.trans <| congrArg Nat.succ (card_ulift.trans card_fin).symm)
-        (h_option uliftId <|
-          recEmptyOption fin_choice of_equiv h_empty h_option (ULift.{u} <| Fin n)) := by
+        (option uliftId <|
+          recEmptyOption finChoice congr empty option (ULift.{u} <| Fin n)) := by
   conv => lhs; unfold recEmptyOption
   split
   · exact Nat.noConfusion <| n.prop.symm.trans ‹_›
@@ -102,13 +102,13 @@ In contrast to the `Fintype` case, data can be transported along such an `Equiv`
 Also, since order matters, the choice of element that gets replaced by `Option.none` has
 to be provided for every step.
 -/
-abbrev recOnEmptyOption {P : (α : Type u) → Sort v}
+abbrev recOnEmptyOption {P : Type u → Sort v}
     {α : Type u} (aenum : FinEnum α)
-    (fin_choice : (n : ℕ) → Fin (n + 1))
-    (of_equiv : {α β : Type u} → (_ : FinEnum α) → (_ : FinEnum β) → card β = card α → P α → P β )
-    (h_empty : P PEmpty.{u + 1})
-    (h_option : {α : Type u} → FinEnum α → P α → P (Option α)) :
+    (finChoice : (n : ℕ) → Fin (n + 1))
+    (congr : {α β : Type u} → (_ : FinEnum α) → (_ : FinEnum β) → card β = card α → P α → P β)
+    (empty : P PEmpty.{u + 1})
+    (option : {α : Type u} → FinEnum α → P α → P (Option α)) :
     P α :=
-  @recEmptyOption P fin_choice of_equiv h_empty h_option α aenum
+  @recEmptyOption P finChoice congr empty option α aenum
 
 end FinEnum


### PR DESCRIPTION
Replicate `Data/Fintype/Option`, but yield non-truncated data.

First chunk of #12648

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
