### PR TITLE
[Merged by Bors] - feat(CategoryTheory): Equivalence between certain comma categories and products

### DIFF
--- a/Mathlib/CategoryTheory/Closed/Cartesian.lean
+++ b/Mathlib/CategoryTheory/Closed/Cartesian.lean
@@ -232,8 +232,8 @@ The typeclass argument is explicit: any instance can be used.
 -/
 def expTerminalIsoSelf [Exponentiable (⊤_ C)] : (⊤_ C) ⟹ X ≅ X :=
   Yoneda.ext ((⊤_ C) ⟹ X) X
-    (fun {Y} f => (prod.leftUnitor Y).inv ≫ CartesianClosed.uncurry f)
-    (fun {Y} f => CartesianClosed.curry ((prod.leftUnitor Y).hom ≫ f))
+    (fun {Y} f => (Limits.prod.leftUnitor Y).inv ≫ CartesianClosed.uncurry f)
+    (fun {Y} f => CartesianClosed.curry ((Limits.prod.leftUnitor Y).hom ≫ f))
     (fun g => by
       rw [curry_eq_iff, Iso.hom_inv_id_assoc])
     (fun g => by simp)

--- a/Mathlib/CategoryTheory/Closed/Zero.lean
+++ b/Mathlib/CategoryTheory/Closed/Zero.lean
@@ -37,7 +37,7 @@ then each homset has exactly one element.
 def uniqueHomsetOfInitialIsoTerminal [HasInitial C] (i : ⊥_ C ≅ ⊤_ C) (X Y : C) : Unique (X ⟶ Y) :=
   Equiv.unique <|
     calc
-      (X ⟶ Y) ≃ (X ⨯ ⊤_ C ⟶ Y) := Iso.homCongr (prod.rightUnitor _).symm (Iso.refl _)
+      (X ⟶ Y) ≃ (X ⨯ ⊤_ C ⟶ Y) := Iso.homCongr (Limits.prod.rightUnitor _).symm (Iso.refl _)
       _ ≃ (X ⨯ ⊥_ C ⟶ Y) := (Iso.homCongr (prod.mapIso (Iso.refl _) i.symm) (Iso.refl _))
       _ ≃ (⊥_ C ⟶ Y ^^ X) := (exp.adjunction _).homEquiv _ _
 

--- a/Mathlib/CategoryTheory/Comma/Basic.lean
+++ b/Mathlib/CategoryTheory/Comma/Basic.lean
@@ -6,6 +6,8 @@ Authors: Scott Morrison, Johan Commelin, Bhavik Mehta
 import Mathlib.CategoryTheory.Iso
 import Mathlib.CategoryTheory.Functor.Category
 import Mathlib.CategoryTheory.EqToHom
+import Mathlib.CategoryTheory.PUnit
+import Mathlib.CategoryTheory.Products.Unitor
 
 /-!
 # Comma categories
@@ -408,6 +410,37 @@ def post (L : A ⥤ T) (R : B ⥤ T) (F : T ⥤ C) : Comma L R ⥤ Comma (L ⋙ 
     { left := f.left
       right := f.right
       w := by simp only [Functor.comp_map, ← F.map_comp, f.w] }
+
+/-- The canonical functor from the product of two categories to the comma category of their
+respective functors into `Discrete PUnit`. -/
+@[simps]
+def PUnitPUnitFromProd (L : A ⥤ Discrete PUnit) (R : B ⥤ Discrete PUnit) :
+    A × B ⥤ Comma L R where
+  obj X :=
+    { left := X.1
+      right := X.2
+      hom := Discrete.eqToHom rfl }
+  map {X} {Y} f :=
+    { left := f.1
+      right := f.2 }
+
+/-- Taking the comma category of two functors into `Discrete PUnit` results in something
+is equivalent to their product. -/
+def PUnitPUnitIso (L : A ⥤ Discrete PUnit) (R : B ⥤ Discrete PUnit) :
+    Comma L R ≌ A × B :=
+  Equivalence.mk ((fst L R).prod' (snd L R)) (PUnitPUnitFromProd L R)
+    { hom := 𝟙 _, inv := 𝟙 _ }
+    { hom := 𝟙 _, inv := 𝟙 _ }
+
+/-- Taking the comma category of a functor into `A ⥤ Discrete PUnit` and the identity
+`Discrete PUnit ⥤ Discrete PUnit` results in a category equivalent to `A`. -/
+def PUnitIdIso (L : A ⥤ Discrete PUnit) : Comma L (Functor.id _) ≌ A :=
+  (PUnitPUnitIso L _).trans (prod.rightUnitorEquivalence A)
+
+/-- Taking the comma category of the identity `Discrete PUnit ⥤ Discrete PUnit`
+and a functor `B ⥤ Discrete PUnit` results in a category equivalent to `B`. -/
+def IdPUnitIso (R : B ⥤ Discrete PUnit) : Comma (Functor.id _) R ≌ B :=
+  (PUnitPUnitIso _ R).trans (prod.leftUnitorEquivalence B)
 
 end
 

--- a/Mathlib/CategoryTheory/Comma/Basic.lean
+++ b/Mathlib/CategoryTheory/Comma/Basic.lean
@@ -441,7 +441,7 @@ def toPUnitIdEquiv (L : A ⥤ Discrete PUnit) (R : Discrete PUnit ⥤ Discrete P
   (equivProd L _).trans (prod.rightUnitorEquivalence A)
 
 @[simp]
-def toPUnitIdEquiv_functor_iso {L : A ⥤ Discrete PUnit}
+theorem toPUnitIdEquiv_functor_iso {L : A ⥤ Discrete PUnit}
     {R : Discrete PUnit ⥤ Discrete PUnit} :
     (toPUnitIdEquiv L R).functor = fst L R :=
   rfl
@@ -454,7 +454,7 @@ def toIdPUnitEquiv (L : Discrete PUnit ⥤ Discrete PUnit) (R : B ⥤ Discrete P
   (equivProd _ R).trans (prod.leftUnitorEquivalence B)
 
 @[simp]
-def toIdPUnitEquiv_functor_iso {L : Discrete PUnit ⥤ Discrete PUnit}
+theorem toIdPUnitEquiv_functor_iso {L : Discrete PUnit ⥤ Discrete PUnit}
     {R : B ⥤ Discrete PUnit} :
     (toIdPUnitEquiv L R).functor = snd L R :=
   rfl

--- a/Mathlib/CategoryTheory/Comma/Basic.lean
+++ b/Mathlib/CategoryTheory/Comma/Basic.lean
@@ -6,7 +6,6 @@ Authors: Scott Morrison, Johan Commelin, Bhavik Mehta
 import Mathlib.CategoryTheory.Iso
 import Mathlib.CategoryTheory.Functor.Category
 import Mathlib.CategoryTheory.EqToHom
-import Mathlib.CategoryTheory.PUnit
 import Mathlib.CategoryTheory.Products.Unitor
 
 /-!

--- a/Mathlib/CategoryTheory/Comma/Basic.lean
+++ b/Mathlib/CategoryTheory/Comma/Basic.lean
@@ -414,7 +414,7 @@ def post (L : A ⥤ T) (R : B ⥤ T) (F : T ⥤ C) : Comma L R ⥤ Comma (L ⋙ 
 /-- The canonical functor from the product of two categories to the comma category of their
 respective functors into `Discrete PUnit`. -/
 @[simps]
-def PUnitPUnitFromProd (L : A ⥤ Discrete PUnit) (R : B ⥤ Discrete PUnit) :
+def fromProd (L : A ⥤ Discrete PUnit) (R : B ⥤ Discrete PUnit) :
     A × B ⥤ Comma L R where
   obj X :=
     { left := X.1
@@ -426,21 +426,38 @@ def PUnitPUnitFromProd (L : A ⥤ Discrete PUnit) (R : B ⥤ Discrete PUnit) :
 
 /-- Taking the comma category of two functors into `Discrete PUnit` results in something
 is equivalent to their product. -/
-def PUnitPUnitIso (L : A ⥤ Discrete PUnit) (R : B ⥤ Discrete PUnit) :
+@[simps!]
+def equivProd (L : A ⥤ Discrete PUnit) (R : B ⥤ Discrete PUnit) :
     Comma L R ≌ A × B :=
-  Equivalence.mk ((fst L R).prod' (snd L R)) (PUnitPUnitFromProd L R)
+  Equivalence.mk ((fst L R).prod' (snd L R)) (fromProd L R)
     { hom := 𝟙 _, inv := 𝟙 _ }
     { hom := 𝟙 _, inv := 𝟙 _ }
 
 /-- Taking the comma category of a functor into `A ⥤ Discrete PUnit` and the identity
 `Discrete PUnit ⥤ Discrete PUnit` results in a category equivalent to `A`. -/
-def PUnitIdIso (L : A ⥤ Discrete PUnit) : Comma L (Functor.id _) ≌ A :=
-  (PUnitPUnitIso L _).trans (prod.rightUnitorEquivalence A)
+@[simps!]
+def toPUnitIdEquiv (L : A ⥤ Discrete PUnit) (R : Discrete PUnit ⥤ Discrete PUnit) :
+    Comma L R ≌ A :=
+  (equivProd L _).trans (prod.rightUnitorEquivalence A)
+
+@[simp]
+def toPUnitIdEquiv_functor_iso {L : A ⥤ Discrete PUnit}
+    {R : Discrete PUnit ⥤ Discrete PUnit} :
+    (toPUnitIdEquiv L R).functor = fst L R :=
+  rfl
 
 /-- Taking the comma category of the identity `Discrete PUnit ⥤ Discrete PUnit`
 and a functor `B ⥤ Discrete PUnit` results in a category equivalent to `B`. -/
-def IdPUnitIso (R : B ⥤ Discrete PUnit) : Comma (Functor.id _) R ≌ B :=
-  (PUnitPUnitIso _ R).trans (prod.leftUnitorEquivalence B)
+@[simps!]
+def toIdPUnitEquiv (L : Discrete PUnit ⥤ Discrete PUnit) (R : B ⥤ Discrete PUnit) :
+    Comma L R ≌ B :=
+  (equivProd _ R).trans (prod.leftUnitorEquivalence B)
+
+@[simp]
+def toIdPUnitEquiv_functor_iso {L : Discrete PUnit ⥤ Discrete PUnit}
+    {R : B ⥤ Discrete PUnit} :
+    (toIdPUnitEquiv L R).functor = snd L R :=
+  rfl
 
 end
 

--- a/Mathlib/CategoryTheory/Dialectica/Monoidal.lean
+++ b/Mathlib/CategoryTheory/Dialectica/Monoidal.lean
@@ -58,11 +58,11 @@ local notation "π(" a ", " b ")" => prod.lift a b
 
 /-- Left unit cancellation `1 ⊗ X ≅ X` in `Dial C`. -/
 @[simps!] def leftUnitor (X : Dial C) : tensorObj tensorUnit X ≅ X :=
-  isoMk (prod.leftUnitor _) (prod.leftUnitor _) <| by simp [Subobject.pullback_top]
+  isoMk (Limits.prod.leftUnitor _) (Limits.prod.leftUnitor _) <| by simp [Subobject.pullback_top]
 
 /-- Right unit cancellation `X ⊗ 1 ≅ X` in `Dial C`. -/
 @[simps!] def rightUnitor (X : Dial C) : tensorObj X tensorUnit ≅ X :=
-  isoMk (prod.rightUnitor _) (prod.rightUnitor _) <| by simp [Subobject.pullback_top]
+  isoMk (Limits.prod.rightUnitor _) (Limits.prod.rightUnitor _) <| by simp [Subobject.pullback_top]
 
 /-- The associator for tensor, `(X ⊗ Y) ⊗ Z ≅ X ⊗ (Y ⊗ Z)` in `Dial C`. -/
 @[simps!]

--- a/Mathlib/CategoryTheory/Monoidal/OfHasFiniteProducts.lean
+++ b/Mathlib/CategoryTheory/Monoidal/OfHasFiniteProducts.lean
@@ -51,8 +51,8 @@ def monoidalOfHasFiniteProducts [HasTerminal C] [HasBinaryProducts C] : Monoidal
     tensorHom := fun f g ↦ Limits.prod.map f g
     tensorUnit := ⊤_ C
     associator := prod.associator
-    leftUnitor := fun P ↦ prod.leftUnitor P
-    rightUnitor := fun P ↦ prod.rightUnitor P
+    leftUnitor := fun P ↦ Limits.prod.leftUnitor P
+    rightUnitor := fun P ↦ Limits.prod.rightUnitor P
   }
   .ofTensorHom
     (pentagon := prod.pentagon)


### PR DESCRIPTION
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
