### PR TITLE
[Merged by Bors] - chore(AEDisjoint): generalize 2 lemmas to `Sort*`

### DIFF
--- a/Mathlib/MeasureTheory/Measure/AEDisjoint.lean
+++ b/Mathlib/MeasureTheory/Measure/AEDisjoint.lean
@@ -77,12 +77,12 @@ protected theorem congr (h : AEDisjoint μ s t) (hu : u =ᵐ[μ] s) (hv : v =ᵐ
   mono_ae h (Filter.EventuallyEq.le hu) (Filter.EventuallyEq.le hv)
 
 @[simp]
-theorem iUnion_left_iff [Countable ι] {s : ι → Set α} :
+theorem iUnion_left_iff {ι : Sort*} [Countable ι] {s : ι → Set α} :
     AEDisjoint μ (⋃ i, s i) t ↔ ∀ i, AEDisjoint μ (s i) t := by
   simp only [AEDisjoint, iUnion_inter, measure_iUnion_null_iff]
 
 @[simp]
-theorem iUnion_right_iff [Countable ι] {t : ι → Set α} :
+theorem iUnion_right_iff {ι : Sort*} [Countable ι] {t : ι → Set α} :
     AEDisjoint μ s (⋃ i, t i) ↔ ∀ i, AEDisjoint μ s (t i) := by
   simp only [AEDisjoint, inter_iUnion, measure_iUnion_null_iff]
 


### PR DESCRIPTION
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)