### PR TITLE
[Merged by Bors] - chore: turn some `induction'` to `induction`

### DIFF
--- a/Mathlib/Algebra/Algebra/Basic.lean
+++ b/Mathlib/Algebra/Algebra/Basic.lean
@@ -123,9 +123,10 @@ theorem mul_sub_algebraMap_commutes [Ring A] [Algebra R A] (x : A) (r : R) :
 
 theorem mul_sub_algebraMap_pow_commutes [Ring A] [Algebra R A] (x : A) (r : R) (n : ℕ) :
     x * (x - algebraMap R A r) ^ n = (x - algebraMap R A r) ^ n * x := by
-  induction' n with n ih
-  · simp
-  · rw [pow_succ', ← mul_assoc, mul_sub_algebraMap_commutes, mul_assoc, ih, ← mul_assoc]
+  induction n with
+  | zero => simp
+  | succ n ih =>
+    rw [pow_succ', ← mul_assoc, mul_sub_algebraMap_commutes, mul_assoc, ih, ← mul_assoc]
 
 end CommSemiring
 

--- a/Mathlib/Algebra/Associated/Basic.lean
+++ b/Mathlib/Algebra/Associated/Basic.lean
@@ -68,15 +68,17 @@ theorem not_dvd_mul {a b : α} (ha : ¬ p ∣ a) (hb : ¬ p ∣ b) : ¬ p ∣ a 
   hp.dvd_mul.not.mpr <| not_or.mpr ⟨ha, hb⟩
 
 theorem dvd_of_dvd_pow (hp : Prime p) {a : α} {n : ℕ} (h : p ∣ a ^ n) : p ∣ a := by
-  induction' n with n ih
-  · rw [pow_zero] at h
+  induction n with
+  | zero =>
+    rw [pow_zero] at h
     have := isUnit_of_dvd_one h
     have := not_unit hp
     contradiction
-  rw [pow_succ'] at h
-  cases' dvd_or_dvd hp h with dvd_a dvd_pow
-  · assumption
-  exact ih dvd_pow
+  | succ n ih =>
+    rw [pow_succ'] at h
+    cases' dvd_or_dvd hp h with dvd_a dvd_pow
+    · assumption
+    · exact ih dvd_pow
 
 theorem dvd_pow_iff_dvd {a : α} {n : ℕ} (hn : n ≠ 0) : p ∣ a ^ n ↔ p ∣ a :=
   ⟨hp.dvd_of_dvd_pow, (dvd_pow · hn)⟩
@@ -123,10 +125,12 @@ theorem Prime.left_dvd_or_dvd_right_of_dvd_mul [CancelCommMonoidWithZero α] {p 
 
 theorem Prime.pow_dvd_of_dvd_mul_left [CancelCommMonoidWithZero α] {p a b : α} (hp : Prime p)
     (n : ℕ) (h : ¬p ∣ a) (h' : p ^ n ∣ a * b) : p ^ n ∣ b := by
-  induction' n with n ih
-  · rw [pow_zero]
+  induction n with
+  | zero =>
+    rw [pow_zero]
     exact one_dvd b
-  · obtain ⟨c, rfl⟩ := ih (dvd_trans (pow_dvd_pow p n.le_succ) h')
+  | succ n ih =>
+    obtain ⟨c, rfl⟩ := ih (dvd_trans (pow_dvd_pow p n.le_succ) h')
     rw [pow_succ]
     apply mul_dvd_mul_left _ ((hp.dvd_or_dvd _).resolve_left h)
     rwa [← mul_dvd_mul_iff_left (pow_ne_zero n hp.ne_zero), ← pow_succ, mul_left_comm]
@@ -493,9 +497,9 @@ theorem Associated.mul_mul [CommMonoid α] {a₁ a₂ b₁ b₂ : α}
     (h₁ : a₁ ~ᵤ b₁) (h₂ : a₂ ~ᵤ b₂) : a₁ * a₂ ~ᵤ b₁ * b₂ := (h₁.mul_right _).trans (h₂.mul_left _)
 
 theorem Associated.pow_pow [CommMonoid α] {a b : α} {n : ℕ} (h : a ~ᵤ b) : a ^ n ~ᵤ b ^ n := by
-  induction' n with n ih
-  · simp [Associated.refl]
-  convert h.mul_mul ih <;> rw [pow_succ']
+  induction n with
+  | zero => simp [Associated.refl]
+  | succ n ih => convert h.mul_mul ih <;> rw [pow_succ']
 
 protected theorem Associated.dvd [Monoid α] {a b : α} : a ~ᵤ b → a ∣ b := fun ⟨u, hu⟩ =>
   ⟨u, hu.symm⟩
@@ -1130,17 +1134,19 @@ theorem pow_injective_of_not_unit [CancelCommMonoidWithZero α] {q : α} (hq : �
 
 theorem dvd_prime_pow [CancelCommMonoidWithZero α] {p q : α} (hp : Prime p) (n : ℕ) :
     q ∣ p ^ n ↔ ∃ i ≤ n, Associated q (p ^ i) := by
-  induction' n with n ih generalizing q
-  · simp [← isUnit_iff_dvd_one, associated_one_iff_isUnit]
-  refine ⟨fun h => ?_, fun ⟨i, hi, hq⟩ => hq.dvd.trans (pow_dvd_pow p hi)⟩
-  rw [pow_succ'] at h
-  rcases hp.left_dvd_or_dvd_right_of_dvd_mul h with (⟨q, rfl⟩ | hno)
-  · rw [mul_dvd_mul_iff_left hp.ne_zero, ih] at h
-    rcases h with ⟨i, hi, hq⟩
-    refine ⟨i + 1, Nat.succ_le_succ hi, (hq.mul_left p).trans ?_⟩
-    rw [pow_succ']
-  · obtain ⟨i, hi, hq⟩ := ih.mp hno
-    exact ⟨i, hi.trans n.le_succ, hq⟩
+  induction n generalizing q with
+  | zero =>
+    simp [← isUnit_iff_dvd_one, associated_one_iff_isUnit]
+  | succ n ih =>
+    refine ⟨fun h => ?_, fun ⟨i, hi, hq⟩ => hq.dvd.trans (pow_dvd_pow p hi)⟩
+    rw [pow_succ'] at h
+    rcases hp.left_dvd_or_dvd_right_of_dvd_mul h with (⟨q, rfl⟩ | hno)
+    · rw [mul_dvd_mul_iff_left hp.ne_zero, ih] at h
+      rcases h with ⟨i, hi, hq⟩
+      refine ⟨i + 1, Nat.succ_le_succ hi, (hq.mul_left p).trans ?_⟩
+      rw [pow_succ']
+    · obtain ⟨i, hi, hq⟩ := ih.mp hno
+      exact ⟨i, hi.trans n.le_succ, hq⟩
 
 end CancelCommMonoidWithZero
 

--- a/Mathlib/Algebra/BigOperators/Group/Finset.lean
+++ b/Mathlib/Algebra/BigOperators/Group/Finset.lean
@@ -1504,9 +1504,10 @@ lemma prod_powersetCard (n : ℕ) (s : Finset α) (f : ℕ → β) :
 @[to_additive]
 theorem prod_flip {n : ℕ} (f : ℕ → β) :
     (∏ r ∈ range (n + 1), f (n - r)) = ∏ k ∈ range (n + 1), f k := by
-  induction' n with n ih
-  · rw [prod_range_one, prod_range_one]
-  · rw [prod_range_succ', prod_range_succ _ (Nat.succ n)]
+  induction n with
+  | zero => rw [prod_range_one, prod_range_one]
+  | succ n ih =>
+    rw [prod_range_succ', prod_range_succ _ (Nat.succ n)]
     simp [← ih]
 
 @[to_additive]

--- a/Mathlib/Algebra/Group/Int.lean
+++ b/Mathlib/Algebra/Group/Int.lean
@@ -207,7 +207,7 @@ lemma even_sub : Even (m - n) ↔ (Even m ↔ Even n) := by simp [sub_eq_add_neg
   simp [even_iff, h₁, h₂, Int.mul_emod]
 
 @[parity_simps] lemma even_pow {n : ℕ} : Even (m ^ n) ↔ Even m ∧ n ≠ 0 := by
-  induction' n with n ih <;> simp [*, even_mul, pow_succ]; tauto
+  induction n <;> simp [*, even_mul, pow_succ]; tauto
 
 lemma even_pow' {n : ℕ} (h : n ≠ 0) : Even (m ^ n) ↔ Even m := even_pow.trans <| and_iff_left h
 

--- a/Mathlib/Algebra/Group/Nat.lean
+++ b/Mathlib/Algebra/Group/Nat.lean
@@ -123,7 +123,7 @@ lemma two_not_dvd_two_mul_sub_one : ∀ {n}, 0 < n → ¬2 ∣ 2 * n - 1
 /-- If `m` and `n` are natural numbers, then the natural number `m^n` is even
 if and only if `m` is even and `n` is positive. -/
 @[parity_simps] lemma even_pow : Even (m ^ n) ↔ Even m ∧ n ≠ 0 := by
-  induction' n with n ih <;> simp (config := { contextual := true }) [*, pow_succ', even_mul]
+  induction n <;> simp (config := { contextual := true }) [*, pow_succ', even_mul]
 
 lemma even_pow' (h : n ≠ 0) : Even (m ^ n) ↔ Even m := even_pow.trans <| and_iff_left h
 

--- a/Mathlib/Algebra/Group/Semiconj/Defs.lean
+++ b/Mathlib/Algebra/Group/Semiconj/Defs.lean
@@ -104,10 +104,12 @@ variable [Monoid M]
 
 @[to_additive (attr := simp)]
 theorem pow_right {a x y : M} (h : SemiconjBy a x y) (n : ℕ) : SemiconjBy a (x ^ n) (y ^ n) := by
-  induction' n with n ih
-  · rw [pow_zero, pow_zero]
+  induction n with
+  | zero =>
+    rw [pow_zero, pow_zero]
     exact SemiconjBy.one_right _
-  · rw [pow_succ, pow_succ]
+  | succ n ih =>
+    rw [pow_succ, pow_succ]
     exact ih.mul_right h
 
 end Monoid

--- a/Mathlib/Algebra/Lie/Sl2.lean
+++ b/Mathlib/Algebra/Lie/Sl2.lean
@@ -99,9 +99,10 @@ local notation "ψ" n => ((toEnd R L M f) ^ n) m
 
 lemma lie_h_pow_toEnd_f (n : ℕ) :
     ⁅h, ψ n⁆ = (μ - 2 * n) • ψ n := by
-  induction' n with n ih
-  · simpa using P.lie_h
-  · rw [pow_succ', LinearMap.mul_apply, toEnd_apply_apply, Nat.cast_add, Nat.cast_one,
+  induction n with
+  | zero => simpa using P.lie_h
+  | succ n ih =>
+    rw [pow_succ', LinearMap.mul_apply, toEnd_apply_apply, Nat.cast_add, Nat.cast_one,
       leibniz_lie h, t.lie_lie_smul_f R, ← neg_smul, ih, lie_smul, smul_lie, ← add_smul]
     congr
     ring
@@ -116,11 +117,12 @@ lemma lie_f_pow_toEnd_f (P : HasPrimitiveVectorWith t m μ) (n : ℕ) :
 
 lemma lie_e_pow_succ_toEnd_f (n : ℕ) :
     ⁅e, ψ (n + 1)⁆ = ((n + 1) * (μ - n)) • ψ n := by
-  induction' n with n ih
-  · simp only [zero_add, pow_one, toEnd_apply_apply, Nat.cast_zero, sub_zero, one_mul,
+  induction n with
+  | zero => simp only [zero_add, pow_one, toEnd_apply_apply, Nat.cast_zero, sub_zero, one_mul,
       pow_zero, LinearMap.one_apply, leibniz_lie e, t.lie_e_f, P.lie_e, P.lie_h, lie_zero,
       add_zero]
-  · rw [pow_succ', LinearMap.mul_apply, toEnd_apply_apply, leibniz_lie e, t.lie_e_f,
+  | succ n ih =>
+     rw [pow_succ', LinearMap.mul_apply, toEnd_apply_apply, leibniz_lie e, t.lie_e_f,
       lie_h_pow_toEnd_f P, ih, lie_smul, lie_f_pow_toEnd_f P, ← add_smul,
       Nat.cast_add, Nat.cast_one]
     congr

--- a/Mathlib/Algebra/Lie/Sl2.lean
+++ b/Mathlib/Algebra/Lie/Sl2.lean
@@ -118,11 +118,12 @@ lemma lie_f_pow_toEnd_f (P : HasPrimitiveVectorWith t m μ) (n : ℕ) :
 lemma lie_e_pow_succ_toEnd_f (n : ℕ) :
     ⁅e, ψ (n + 1)⁆ = ((n + 1) * (μ - n)) • ψ n := by
   induction n with
-  | zero => simp only [zero_add, pow_one, toEnd_apply_apply, Nat.cast_zero, sub_zero, one_mul,
-      pow_zero, LinearMap.one_apply, leibniz_lie e, t.lie_e_f, P.lie_e, P.lie_h, lie_zero,
-      add_zero]
+  | zero =>
+      simp only [zero_add, pow_one, toEnd_apply_apply, Nat.cast_zero, sub_zero, one_mul,
+        pow_zero, LinearMap.one_apply, leibniz_lie e, t.lie_e_f, P.lie_e, P.lie_h, lie_zero,
+        add_zero]
   | succ n ih =>
-     rw [pow_succ', LinearMap.mul_apply, toEnd_apply_apply, leibniz_lie e, t.lie_e_f,
+    rw [pow_succ', LinearMap.mul_apply, toEnd_apply_apply, leibniz_lie e, t.lie_e_f,
       lie_h_pow_toEnd_f P, ih, lie_smul, lie_f_pow_toEnd_f P, ← add_smul,
       Nat.cast_add, Nat.cast_one]
     congr

--- a/Mathlib/Algebra/Module/Defs.lean
+++ b/Mathlib/Algebra/Module/Defs.lean
@@ -327,9 +327,9 @@ variable (R)
 
 /-- `nsmul` is equal to any other module structure via a cast. -/
 lemma Nat.cast_smul_eq_nsmul (n : ℕ) (b : M) : (n : R) • b = n • b := by
-  induction' n with n ih
-  · rw [Nat.cast_zero, zero_smul, zero_smul]
-  · rw [Nat.cast_succ, add_smul, add_smul, one_smul, ih, one_smul]
+  induction n with
+  | zero => rw [Nat.cast_zero, zero_smul, zero_smul]
+  | succ n ih => rw [Nat.cast_succ, add_smul, add_smul, one_smul, ih, one_smul]
 
 /-- `nsmul` is equal to any other module structure via a cast. -/
 -- See note [no_index around OfNat.ofNat]

--- a/Mathlib/Algebra/Module/Submodule/LinearMap.lean
+++ b/Mathlib/Algebra/Module/Submodule/LinearMap.lean
@@ -229,9 +229,10 @@ variable {f' : M →ₗ[R] M}
 
 theorem pow_apply_mem_of_forall_mem {p : Submodule R M} (n : ℕ) (h : ∀ x ∈ p, f' x ∈ p) (x : M)
     (hx : x ∈ p) : (f' ^ n) x ∈ p := by
-  induction' n with n ih generalizing x
-  · simpa
-  · simpa only [iterate_succ, coe_comp, Function.comp_apply, restrict_apply] using ih _ (h _ hx)
+  induction n generalizing x with
+  | zero => simpa
+  | succ n ih =>
+    simpa only [iterate_succ, coe_comp, Function.comp_apply, restrict_apply] using ih _ (h _ hx)
 
 theorem pow_restrict {p : Submodule R M} (n : ℕ) (h : ∀ x ∈ p, f' x ∈ p)
     (h' := pow_apply_mem_of_forall_mem n h) :

--- a/Mathlib/Algebra/MvPolynomial/Variables.lean
+++ b/Mathlib/Algebra/MvPolynomial/Variables.lean
@@ -117,9 +117,10 @@ theorem vars_one : (1 : MvPolynomial σ R).vars = ∅ :=
 
 theorem vars_pow (φ : MvPolynomial σ R) (n : ℕ) : (φ ^ n).vars ⊆ φ.vars := by
   classical
-  induction' n with n ih
-  · simp
-  · rw [pow_succ']
+  induction n with
+  | zero => simp
+  | succ n ih =>
+    rw [pow_succ']
     apply Finset.Subset.trans (vars_mul _ _)
     exact Finset.union_subset (Finset.Subset.refl _) ih
 

--- a/Mathlib/Algebra/Order/CauSeq/Basic.lean
+++ b/Mathlib/Algebra/Order/CauSeq/Basic.lean
@@ -516,9 +516,9 @@ theorem smul_equiv_smul {G : Type*} [SMul G β] [IsScalarTower G β β] {f1 f2 :
     mul_equiv_mul (const_equiv.mpr <| Eq.refl <| c • (1 : β)) hf
 
 theorem pow_equiv_pow {f1 f2 : CauSeq β abv} (hf : f1 ≈ f2) (n : ℕ) : f1 ^ n ≈ f2 ^ n := by
-  induction' n with n ih
-  · simp only [Nat.zero_eq, pow_zero, Setoid.refl]
-  · simpa only [pow_succ'] using mul_equiv_mul hf ih
+  induction n with
+  | zero => simp only [Nat.zero_eq, pow_zero, Setoid.refl]
+  | succ n ih => simpa only [pow_succ'] using mul_equiv_mul hf ih
 
 end Ring
 

--- a/Mathlib/Algebra/Order/Group/Nat.lean
+++ b/Mathlib/Algebra/Order/Group/Nat.lean
@@ -39,9 +39,9 @@ instance instLinearOrderedCancelAddCommMonoid : LinearOrderedCancelAddCommMonoid
 
 instance instOrderedSub : OrderedSub ℕ := by
   refine ⟨fun m n k ↦ ?_⟩
-  induction' n with n ih generalizing k
-  · simp
-  · simp only [sub_succ, pred_le_iff, ih, succ_add, add_succ]
+  induction n generalizing k with
+  | zero => simp
+  | succ n ih => simp only [sub_succ, pred_le_iff, ih, succ_add, add_succ]
 
 /-! ### Miscellaneous lemmas -/
 

--- a/Mathlib/Algebra/Polynomial/Basic.lean
+++ b/Mathlib/Algebra/Polynomial/Basic.lean
@@ -478,9 +478,9 @@ theorem monomial_one_one_eq_X : monomial 1 (1 : R) = X :=
   rfl
 
 theorem monomial_one_right_eq_X_pow (n : ℕ) : monomial n (1 : R) = X ^ n := by
-  induction' n with n ih
-  · simp [monomial_zero_one]
-  · rw [pow_succ, ← ih, ← monomial_one_one_eq_X, monomial_mul_monomial, mul_one]
+  induction n with
+  | zero => simp [monomial_zero_one]
+  | succ n ih => rw [pow_succ, ← ih, ← monomial_one_one_eq_X, monomial_mul_monomial, mul_one]
 
 @[simp]
 theorem toFinsupp_X : X.toFinsupp = Finsupp.single 1 (1 : R) :=
@@ -496,9 +496,10 @@ theorem X_mul : X * p = p * X := by
   simp [AddMonoidAlgebra.mul_apply, AddMonoidAlgebra.sum_single_index, add_comm]
 
 theorem X_pow_mul {n : ℕ} : X ^ n * p = p * X ^ n := by
-  induction' n with n ih
-  · simp
-  · conv_lhs => rw [pow_succ]
+  induction n with
+  | zero => simp
+  | succ n ih =>
+    conv_lhs => rw [pow_succ]
     rw [mul_assoc, X_mul, ← mul_assoc, ih, mul_assoc, ← pow_succ]
 
 /-- Prefer putting constants to the left of `X`.

--- a/Mathlib/Algebra/Polynomial/Eval.lean
+++ b/Mathlib/Algebra/Polynomial/Eval.lean
@@ -104,10 +104,9 @@ def eval₂AddMonoidHom : R[X] →+ S where
 
 @[simp]
 theorem eval₂_natCast (n : ℕ) : (n : R[X]).eval₂ f x = n := by
-  induction' n with n ih
-  -- Porting note: `Nat.zero_eq` is required.
-  · simp only [eval₂_zero, Nat.cast_zero, Nat.zero_eq]
-  · rw [n.cast_succ, eval₂_add, ih, eval₂_one, n.cast_succ]
+  induction n with -- Porting note: `Nat.zero_eq` is required.
+  | zero => simp only [eval₂_zero, Nat.cast_zero, Nat.zero_eq]
+  | succ n ih => rw [n.cast_succ, eval₂_add, ih, eval₂_one, n.cast_succ]
 
 @[deprecated (since := "2024-04-17")]
 alias eval₂_nat_cast := eval₂_natCast

--- a/Mathlib/Algebra/Polynomial/Eval.lean
+++ b/Mathlib/Algebra/Polynomial/Eval.lean
@@ -104,8 +104,8 @@ def eval₂AddMonoidHom : R[X] →+ S where
 
 @[simp]
 theorem eval₂_natCast (n : ℕ) : (n : R[X]).eval₂ f x = n := by
-  induction n with -- Porting note: `Nat.zero_eq` is required.
-  | zero => simp only [eval₂_zero, Nat.cast_zero, Nat.zero_eq]
+  induction n with
+  | zero => simp only [eval₂_zero, Nat.cast_zero]
   | succ n ih => rw [n.cast_succ, eval₂_add, ih, eval₂_one, n.cast_succ]
 
 @[deprecated (since := "2024-04-17")]

--- a/Mathlib/Algebra/Polynomial/FieldDivision.lean
+++ b/Mathlib/Algebra/Polynomial/FieldDivision.lean
@@ -93,10 +93,12 @@ theorem lt_rootMultiplicity_of_isRoot_iterate_derivative_of_mem_nonZeroDivisors'
     n < p.rootMultiplicity t := by
   apply lt_rootMultiplicity_of_isRoot_iterate_derivative_of_mem_nonZeroDivisors h hroot
   clear hroot
-  induction' n with n ih
-  · simp only [Nat.zero_eq, Nat.factorial_zero, Nat.cast_one]
+  induction n with
+  | zero =>
+    simp only [Nat.zero_eq, Nat.factorial_zero, Nat.cast_one]
     exact Submonoid.one_mem _
-  · rw [Nat.factorial_succ, Nat.cast_mul, mul_mem_nonZeroDivisors]
+  | succ n ih =>
+    rw [Nat.factorial_succ, Nat.cast_mul, mul_mem_nonZeroDivisors]
     exact ⟨hnzd _ le_rfl n.succ_ne_zero, ih fun m h ↦ hnzd m (h.trans n.le_succ)⟩
 
 theorem lt_rootMultiplicity_iff_isRoot_iterate_derivative_of_mem_nonZeroDivisors

--- a/Mathlib/Algebra/Polynomial/Smeval.lean
+++ b/Mathlib/Algebra/Polynomial/Smeval.lean
@@ -107,9 +107,9 @@ theorem smeval_add : (p + q).smeval x = p.smeval x + q.smeval x := by
   · rw [smul_pow, smul_pow, smul_pow, add_smul]
 
 theorem smeval_natCast (n : ℕ) : (n : R[X]).smeval x = n • x ^ 0 := by
-  induction' n with n ih
-  · simp only [smeval_zero, Nat.cast_zero, Nat.zero_eq, zero_smul]
-  · rw [n.cast_succ, smeval_add, ih, smeval_one, ← add_nsmul]
+  induction n with
+  | zero => simp only [smeval_zero, Nat.cast_zero, Nat.zero_eq, zero_smul]
+  | succ n ih => rw [n.cast_succ, smeval_add, ih, smeval_one, ← add_nsmul]
 
 @[deprecated (since := "2024-04-17")]
 alias smeval_nat_cast := smeval_natCast

--- a/Mathlib/Algebra/TrivSqZeroExt.lean
+++ b/Mathlib/Algebra/TrivSqZeroExt.lean
@@ -585,9 +585,10 @@ theorem snd_pow_of_smul_comm [Monoid R] [AddMonoid M] [DistribMulAction R M]
 where
   aux : ∀ n : ℕ, x.snd <• x.fst ^ n = x.fst ^ n •> x.snd := by
     intro n
-    induction' n with n ih
-    · simp
-    · rw [pow_succ, op_mul, mul_smul, mul_smul, ← h, smul_comm (_ : R) (op x.fst) x.snd, ih]
+    induction n with
+    | zero => simp
+    | succ n ih =>
+      rw [pow_succ, op_mul, mul_smul, mul_smul, ← h, smul_comm (_ : R) (op x.fst) x.snd, ih]
 
 theorem snd_pow_of_smul_comm' [Monoid R] [AddMonoid M] [DistribMulAction R M]
     [DistribMulAction Rᵐᵒᵖ M] [SMulCommClass R Rᵐᵒᵖ M] (x : tsze R M) (n : ℕ)

--- a/Mathlib/RingTheory/Ideal/Basic.lean
+++ b/Mathlib/RingTheory/Ideal/Basic.lean
@@ -221,10 +221,12 @@ theorem IsPrime.mem_or_mem_of_mul_eq_zero {I : Ideal α} (hI : I.IsPrime) {x y :
 
 theorem IsPrime.mem_of_pow_mem {I : Ideal α} (hI : I.IsPrime) {r : α} (n : ℕ) (H : r ^ n ∈ I) :
     r ∈ I := by
-  induction' n with n ih
-  · rw [pow_zero] at H
+  induction n with
+  | zero =>
+    rw [pow_zero] at H
     exact (mt (eq_top_iff_one _).2 hI.1).elim H
-  · rw [pow_succ] at H
+  | succ n ih =>
+    rw [pow_succ] at H
     exact Or.casesOn (hI.mem_or_mem H) ih id
 
 theorem not_isPrime_iff {I : Ideal α} :

--- a/Mathlib/RingTheory/MvPowerSeries/Basic.lean
+++ b/Mathlib/RingTheory/MvPowerSeries/Basic.lean
@@ -384,9 +384,9 @@ theorem X_def (s : σ) : X s = monomial R (single s 1) 1 :=
   rfl
 
 theorem X_pow_eq (s : σ) (n : ℕ) : (X s : MvPowerSeries σ R) ^ n = monomial R (single s n) 1 := by
-  induction' n with n ih
-  · simp
-  · rw [pow_succ, ih, Finsupp.single_add, X, monomial_mul_monomial, one_mul]
+  induction n with
+  | zero => simp
+  | succ n ih => rw [pow_succ, ih, Finsupp.single_add, X, monomial_mul_monomial, one_mul]
 
 theorem coeff_X_pow [DecidableEq σ] (m : σ →₀ ℕ) (s : σ) (n : ℕ) :
     coeff R m ((X s : MvPowerSeries σ R) ^ n) = if m = single s n then 1 else 0 := by

--- a/Mathlib/RingTheory/Polynomial/Hermite/Basic.lean
+++ b/Mathlib/RingTheory/Polynomial/Hermite/Basic.lean
@@ -35,7 +35,6 @@ This file defines `Polynomial.hermite n`, the `n`th probabilists' Hermite polyno
 
 -/
 
-
 noncomputable section
 
 open Polynomial
@@ -53,9 +52,9 @@ theorem hermite_succ (n : ℕ) : hermite (n + 1) = X * hermite n - derivative (h
   rw [hermite]
 
 theorem hermite_eq_iterate (n : ℕ) : hermite n = (fun p => X * p - derivative p)^[n] 1 := by
-  induction' n with n ih
-  · rfl
-  · rw [Function.iterate_succ_apply', ← ih, hermite_succ]
+  induction n with
+  | zero => rfl
+  | succ n ih => rw [Function.iterate_succ_apply', ← ih, hermite_succ]
 
 @[simp]
 theorem hermite_zero : hermite 0 = C 1 :=
@@ -83,17 +82,18 @@ theorem coeff_hermite_succ_succ (n k : ℕ) : coeff (hermite (n + 1)) (k + 1) =
 theorem coeff_hermite_of_lt {n k : ℕ} (hnk : n < k) : coeff (hermite n) k = 0 := by
   obtain ⟨k, rfl⟩ := Nat.exists_eq_add_of_lt hnk
   clear hnk
-  induction' n with n ih generalizing k
-  · apply coeff_C
-  · have : n + k + 1 + 2 = n + (k + 2) + 1 := by ring
-    rw [coeff_hermite_succ_succ, add_right_comm, this, ih k, ih (k + 2),
-      mul_zero, sub_zero]
+  induction n generalizing k with
+  | zero => exact coeff_C
+  | succ n ih =>
+    have : n + k + 1 + 2 = n + (k + 2) + 1 := by ring
+    rw [coeff_hermite_succ_succ, add_right_comm, this, ih k, ih (k + 2), mul_zero, sub_zero]
 
 @[simp]
 theorem coeff_hermite_self (n : ℕ) : coeff (hermite n) n = 1 := by
-  induction' n with n ih
-  · apply coeff_C
-  · rw [coeff_hermite_succ_succ, ih, coeff_hermite_of_lt, mul_zero, sub_zero]
+  induction n with
+  | zero => exact coeff_C
+  | succ n ih =>
+    rw [coeff_hermite_succ_succ, ih, coeff_hermite_of_lt, mul_zero, sub_zero]
     simp
 
 @[simp]
@@ -116,13 +116,17 @@ theorem hermite_monic (n : ℕ) : (hermite n).Monic :=
   leadingCoeff_hermite n
 
 theorem coeff_hermite_of_odd_add {n k : ℕ} (hnk : Odd (n + k)) : coeff (hermite n) k = 0 := by
-  induction' n with n ih generalizing k
-  · rw [zero_add k] at hnk
+  induction n  generalizing k with
+  | zero =>
+    rw [zero_add k] at hnk
     exact coeff_hermite_of_lt hnk.pos
-  · cases' k with k
-    · rw [Nat.succ_add_eq_add_succ] at hnk
+  | succ n ih =>
+    cases k with
+    | zero =>
+      rw [Nat.succ_add_eq_add_succ] at hnk
       rw [coeff_hermite_succ_zero, ih hnk, neg_zero]
-    · rw [coeff_hermite_succ_succ, ih, ih, mul_zero, sub_zero]
+    | succ k =>
+      rw [coeff_hermite_succ_succ, ih, ih, mul_zero, sub_zero]
       · rwa [Nat.succ_add_eq_add_succ] at hnk
       · rw [(by rw [Nat.succ_add, Nat.add_succ] : n.succ + k.succ = n + k + 2)] at hnk
         exact (Nat.odd_add.mp hnk).mpr even_two

--- a/Mathlib/RingTheory/Polynomial/Pochhammer.lean
+++ b/Mathlib/RingTheory/Polynomial/Pochhammer.lean
@@ -76,9 +76,9 @@ variable {S} {T : Type v} [Semiring T]
 @[simp]
 theorem ascPochhammer_map (f : S →+* T) (n : ℕ) :
     (ascPochhammer S n).map f = ascPochhammer T n := by
-  induction' n with n ih
-  · simp
-  · simp [ih, ascPochhammer_succ_left, map_comp]
+  induction n with
+  | zero => simp
+  | succ n ih => simp [ih, ascPochhammer_succ_left, map_comp]
 
 theorem ascPochhammer_eval₂ (f : S →+* T) (n : ℕ) (t : T) :
     (ascPochhammer T n).eval t = (ascPochhammer S n).eval₂ f t := by
@@ -116,9 +116,10 @@ theorem ascPochhammer_succ_right (n : ℕ) :
     apply_fun Polynomial.map (algebraMap ℕ S) at h
     simpa only [ascPochhammer_map, Polynomial.map_mul, Polynomial.map_add, map_X,
       Polynomial.map_natCast] using h
-  induction' n with n ih
-  · simp
-  · conv_lhs =>
+  induction n with
+  | zero => simp
+  | succ n ih =>
+    conv_lhs =>
       rw [ascPochhammer_succ_left, ih, mul_comp, ← mul_assoc, ← ascPochhammer_succ_left, add_comp,
           X_comp, natCast_comp, add_assoc, add_comm (1 : ℕ[X]), ← Nat.cast_succ]
 
@@ -175,10 +176,12 @@ section StrictOrderedSemiring
 variable {S : Type*} [StrictOrderedSemiring S]
 
 theorem ascPochhammer_pos (n : ℕ) (s : S) (h : 0 < s) : 0 < (ascPochhammer S n).eval s := by
-  induction' n with n ih
-  · simp only [Nat.zero_eq, ascPochhammer_zero, eval_one]
+  induction n with
+  | zero =>
+    simp only [Nat.zero_eq, ascPochhammer_zero, eval_one]
     exact zero_lt_one
-  · rw [ascPochhammer_succ_right, mul_add, eval_add, ← Nat.cast_comm, eval_natCast_mul, eval_mul_X,
+  | succ n ih =>
+    rw [ascPochhammer_succ_right, mul_add, eval_add, ← Nat.cast_comm, eval_natCast_mul, eval_mul_X,
       Nat.cast_comm, ← mul_add]
     exact mul_pos ih (lt_of_lt_of_le h (le_add_of_nonneg_right (Nat.cast_nonneg n)))
 
@@ -252,9 +255,9 @@ variable {R} {T : Type v} [Ring T]
 @[simp]
 theorem descPochhammer_map (f : R →+* T) (n : ℕ) :
     (descPochhammer R n).map f = descPochhammer T n := by
-  induction' n with n ih
-  · simp
-  · simp [ih, descPochhammer_succ_left, map_comp]
+  induction n with
+  | zero => simp
+  | succ n ih => simp [ih, descPochhammer_succ_left, map_comp]
 end
 
 @[simp, norm_cast]
@@ -281,9 +284,10 @@ theorem descPochhammer_succ_right (n : ℕ) :
     apply_fun Polynomial.map (algebraMap ℤ R) at h
     simpa [descPochhammer_map, Polynomial.map_mul, Polynomial.map_add, map_X,
       Polynomial.map_intCast] using h
-  induction' n with n ih
-  · simp [descPochhammer]
-  · conv_lhs =>
+  induction n with
+  | zero => simp [descPochhammer]
+  | succ n ih =>
+    conv_lhs =>
       rw [descPochhammer_succ_left, ih, mul_comp, ← mul_assoc, ← descPochhammer_succ_left, sub_comp,
           X_comp, natCast_comp]
     rw [Nat.cast_add, Nat.cast_one, sub_add_eq_sub_sub_swap]


### PR DESCRIPTION
This PR turns some (soon to be deprecated?) `induction'` into `induction`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
