### PR TITLE
[Merged by Bors] - feat(ContinuousMapZero): add norm structure on `C(X, R)₀`

### DIFF
--- a/Mathlib/Topology/ContinuousFunction/ContinuousMapZero.lean
+++ b/Mathlib/Topology/ContinuousFunction/ContinuousMapZero.lean
@@ -197,6 +197,7 @@ lemma coe_toContinuousMapHom [StarRing R] [ContinuousStar R] :
     ⇑(toContinuousMapHom (X := X) (R := R)) = (↑) :=
   rfl
 
+/-- The coercion `C(X, R)₀ → C(X, R)` bundled as a continuous linear map. -/
 @[simps]
 def toContinuousMapCLM (M : Type*) [Semiring M] [Module M R] [ContinuousConstSMul M R] :
     C(X, R)₀ →L[M] C(X, R) where
@@ -204,6 +205,7 @@ def toContinuousMapCLM (M : Type*) [Semiring M] [Module M R] [ContinuousConstSMu
   map_add' _ _ := rfl
   map_smul' _ _ := rfl
 
+/-- The evaluation at a point, as a continuous linear map from `C(X, R)₀` to `R`. -/
 def evalCLM (𝕜 : Type*) {R : Type*} [CompactSpace X] [NormedField 𝕜] [NormedCommRing R]
     [NormedSpace 𝕜 R] (x : X) : C(X, R)₀ →L[𝕜] R :=
   (ContinuousMap.evalCLM 𝕜 x).comp (toContinuousMapCLM 𝕜 : C(X, R)₀ →L[𝕜] C(X, R))

--- a/Mathlib/Topology/ContinuousFunction/ContinuousMapZero.lean
+++ b/Mathlib/Topology/ContinuousFunction/ContinuousMapZero.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Jireh Loreaux
 -/
 import Mathlib.Topology.ContinuousFunction.Algebra
+import Mathlib.Topology.ContinuousFunction.Compact
 
 /-!
 # Continuous maps sending zero to zero
@@ -196,6 +197,21 @@ lemma coe_toContinuousMapHom [StarRing R] [ContinuousStar R] :
     ⇑(toContinuousMapHom (X := X) (R := R)) = (↑) :=
   rfl
 
+@[simps]
+def toContinuousMapCLM (M : Type*) [Semiring M] [Module M R] [ContinuousConstSMul M R] :
+    C(X, R)₀ →L[M] C(X, R) where
+  toFun f := f
+  map_add' _ _ := rfl
+  map_smul' _ _ := rfl
+
+def evalCLM (𝕜 : Type*) {R : Type*} [CompactSpace X] [NormedField 𝕜] [NormedCommRing R]
+    [NormedSpace 𝕜 R] (x : X) : C(X, R)₀ →L[𝕜] R :=
+  (ContinuousMap.evalCLM 𝕜 x).comp (toContinuousMapCLM 𝕜 : C(X, R)₀ →L[𝕜] C(X, R))
+
+@[simp]
+lemma evalCLM_apply {𝕜 : Type*} {R : Type*} [CompactSpace X] [NormedField 𝕜] [NormedCommRing R]
+    [NormedSpace 𝕜 R] (x : X) (f : C(X, R)₀) : evalCLM 𝕜 x f = f x := rfl
+
 /-- Coercion to a function as an `AddMonoidHom`. Similar to `ContinuousMap.coeFnAddMonoidHom`. -/
 def coeFnAddMonoidHom : C(X, R)₀ →+ X → R where
   toFun f := f
@@ -308,5 +324,28 @@ def nonUnitalStarAlgHom_postcomp (φ : R →⋆ₙₐ[M] S) (hφ : Continuous φ
   map_smul' r f := ext <| by simp
 
 end CompHoms
+
+section Norm
+
+variable {α : Type*} {𝕜 : Type*} {R : Type*} [TopologicalSpace α] [CompactSpace α] [Zero α]
+
+noncomputable instance [MetricSpace R] [Zero R]: MetricSpace C(α, R)₀ :=
+  ContinuousMapZero.uniformEmbedding_toContinuousMap.comapMetricSpace _
+
+noncomputable instance [NormedAddCommGroup R] : Norm C(α, R)₀ where
+  norm f := ‖(f : C(α, R))‖
+
+noncomputable instance [NormedCommRing R] : NonUnitalNormedCommRing C(α, R)₀ where
+  dist_eq f g := NormedAddGroup.dist_eq (f : C(α, R)) g
+  norm_mul f g := NormedRing.norm_mul (f : C(α, R)) g
+  mul_comm f g := mul_comm f g
+
+instance [NormedField 𝕜] [NormedCommRing R] [NormedAlgebra 𝕜 R] : NormedSpace 𝕜 C(α, R)₀ where
+  norm_smul_le r f := norm_smul_le r (f : C(α, R))
+
+instance [NormedCommRing R] [StarRing R] [CStarRing R] : CStarRing C(α, R)₀ where
+  norm_mul_self_le f := CStarRing.norm_mul_self_le (f : C(α, R))
+
+end Norm
 
 end ContinuousMapZero


### PR DESCRIPTION
This PR adds a norm structure on `C(X, R)₀`. This is needed to work with integral representations of functions defined via the non-unital continuous functional calculus.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
