### PR TITLE
[Merged by Bors] - feat: linter for `admit` (use `sorry` instead)

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -4126,6 +4126,7 @@ import Mathlib.Tactic.Linarith.Preprocessing
 import Mathlib.Tactic.Linarith.Verification
 import Mathlib.Tactic.LinearCombination
 import Mathlib.Tactic.Linter
+import Mathlib.Tactic.Linter.AdmitLinter
 import Mathlib.Tactic.Linter.GlobalAttributeIn
 import Mathlib.Tactic.Linter.HashCommandLinter
 import Mathlib.Tactic.Linter.HaveLetLinter

--- a/Mathlib/Tactic.lean
+++ b/Mathlib/Tactic.lean
@@ -119,6 +119,7 @@ import Mathlib.Tactic.Linarith.Preprocessing
 import Mathlib.Tactic.Linarith.Verification
 import Mathlib.Tactic.LinearCombination
 import Mathlib.Tactic.Linter
+import Mathlib.Tactic.Linter.AdmitLinter
 import Mathlib.Tactic.Linter.GlobalAttributeIn
 import Mathlib.Tactic.Linter.HashCommandLinter
 import Mathlib.Tactic.Linter.HaveLetLinter

--- a/Mathlib/Tactic/Linter/AdmitLinter.lean
+++ b/Mathlib/Tactic/Linter/AdmitLinter.lean
@@ -1,5 +1,5 @@
 /-
-Copyright (c) 2024 Damiano Testa. All rights reserved.
+Copyright (c) 2024 Adomas Baliuka. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Damiano Testa, Adomas Baliuka
 -/
@@ -23,7 +23,7 @@ namespace Mathlib.Linter.admit
 
 /-- The admit linter emits a warning on usages of `admit`. -/
 register_option linter.admit : Bool := {
-  defValue := true
+  defValue := false
   descr := "enable the admit linter"
 }
 

--- a/Mathlib/Tactic/Linter/AdmitLinter.lean
+++ b/Mathlib/Tactic/Linter/AdmitLinter.lean
@@ -1,0 +1,62 @@
+/-
+Copyright (c) 2024 Damiano Testa. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Damiano Testa, Adomas Baliuka
+-/
+import Lean.Elab.Command
+import Lean.Linter.Util
+
+/-!
+# The "admit" linter
+
+The "admit" linter flags usages of the `admit` tactic.
+
+The tactics `admit` and `sorry` are synonyms.
+The use of `sorry` is much more common and should be preferred.
+
+This linter is an incentive to discourage uses of `admit`, without being a ban.
+-/
+
+open Lean Elab
+
+namespace Mathlib.Linter.admit
+
+/-- The admit linter emits a warning on usages of `admit`. -/
+register_option linter.admit : Bool := {
+  defValue := true
+  descr := "enable the admit linter"
+}
+
+syntax (name := admit) "admit " : tactic
+/-- `admit` is a shorthand for `exact sorry`. -/
+macro "admit" : tactic => `(tactic| exact @sorryAx _ false)
+
+/-- `getadmit t` returns all usages of the `admit` tactic in the input syntax `t`. -/
+partial
+def getadmit : Syntax → Array Syntax
+  | stx@(.node _ kind args) =>
+    let rargs := (args.map getadmit).flatten
+    if kind == ``admit then rargs.push stx else rargs
+  | _ => default
+
+/-- The "admit" linter flags usages of the `admit` tactic.
+
+The tactics `admit` and `sorry` are synonyms.
+The use of `sorry` is much more common and should be preferred.
+-/
+def getLinterHash (o : Options) : Bool := Linter.getLinterValue linter.admit o
+
+@[inherit_doc getLinterHash]
+def admitLinter : Linter where run := withSetOptionIn fun _stx => do
+  unless getLinterHash (← getOptions) do
+    return
+  if (← MonadState.get).messages.hasErrors then
+    return
+  for stx in (getadmit _stx) do
+    Linter.logLint linter.admit stx
+      "The `admit` tactic is discouraged: \
+      please consider using the synonymous `sorry` instead."
+
+initialize addLinter admitLinter
+
+end Mathlib.Linter.admit

--- a/Mathlib/Tactic/Linter/AdmitLinter.lean
+++ b/Mathlib/Tactic/Linter/AdmitLinter.lean
@@ -42,11 +42,8 @@ def getAdmit (stx : Syntax) : Array Syntax :=
 The tactics `admit` and `sorry` are synonyms.
 The use of `sorry` is much more common and should be preferred.
 -/
-def getLinterHash (o : Options) : Bool := Linter.getLinterValue linter.admit o
-
-@[inherit_doc getLinterHash]
 def admitLinter : Linter where run := withSetOptionIn fun stx => do
-  unless getLinterHash (← getOptions) do
+  unless Linter.getLinterValue linter.admit (← getOptions) do
     return
   if (← MonadState.get).messages.hasErrors then
     return

--- a/Mathlib/Tactic/Linter/AdmitLinter.lean
+++ b/Mathlib/Tactic/Linter/AdmitLinter.lean
@@ -17,15 +17,17 @@ The use of `sorry` is much more common and should be preferred.
 This linter is an incentive to discourage uses of `admit`, without being a ban.
 -/
 
-open Lean Elab
-
-namespace Mathlib.Linter.admit
+namespace Mathlib.Linter
 
 /-- The admit linter emits a warning on usages of `admit`. -/
 register_option linter.admit : Bool := {
   defValue := false
   descr := "enable the admit linter"
 }
+
+namespace AdmitLinter
+
+open Lean Elab
 
 /-- `getAdmit t` returns all usages of the `admit` tactic in the input syntax `t`. -/
 partial
@@ -54,4 +56,4 @@ def admitLinter : Linter where run := withSetOptionIn fun stx => do
 
 initialize addLinter admitLinter
 
-end Mathlib.Linter.admit
+end AdmitLinter

--- a/test/AdmitLinter.lean
+++ b/test/AdmitLinter.lean
@@ -1,0 +1,36 @@
+import Mathlib.Tactic.Linter.AdmitLinter
+
+/--
+warning: declaration uses 'sorry'
+---
+warning: The `admit` tactic is discouraged: please consider using the synonymous `sorry` instead.
+note: this linter can be disabled with `set_option linter.admit false`
+-/
+#guard_msgs in
+set_option linter.admit true in
+example : True := by admit
+
+/--
+warning: declaration uses 'sorry'
+---
+warning: The `admit` tactic is discouraged: please consider using the synonymous `sorry` instead.
+note: this linter can be disabled with `set_option linter.admit false`
+---
+warning: The `admit` tactic is discouraged: please consider using the synonymous `sorry` instead.
+note: this linter can be disabled with `set_option linter.admit false`
+---
+warning: The `admit` tactic is discouraged: please consider using the synonymous `sorry` instead.
+note: this linter can be disabled with `set_option linter.admit false`
+---
+warning: The `admit` tactic is discouraged: please consider using the synonymous `sorry` instead.
+note: this linter can be disabled with `set_option linter.admit false`
+-/
+#guard_msgs in
+set_option linter.admit true in
+example : True ∧ True := by
+  have : True := by
+    · admit
+  let foo : Nat := by admit
+  refine ⟨?_, ?_⟩
+  · admit
+  · admit


### PR DESCRIPTION
The "admit" linter flags usages of the `admit` tactic.

The tactics `admit` and `sorry` are synonyms.
The use of `sorry` is much more common and should be preferred.

---
See also [zulip discussion](https://leanprover.zulipchat.com/#narrow/stream/113489-new-members/topic/.E2.9C.94.20difference.20between.20sorry.20and.20admit/near/459519146)

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
