### PR TITLE
[Merged by Bors] - feat(NumberTheory/GaussSum): add two results

### DIFF
--- a/Mathlib/NumberTheory/GaussSum.lean
+++ b/Mathlib/NumberTheory/GaussSum.lean
@@ -62,7 +62,6 @@ variable {R' : Type v} [CommRing R']
 ### Definition and first properties
 -/
 
-
 /-- Definition of the Gauss sum associated to a multiplicative and an additive character. -/
 def gaussSum (χ : MulChar R R') (ψ : AddChar R R') : R' :=
   ∑ a, χ a * ψ a
@@ -80,8 +79,23 @@ end GaussSumDef
 ### The product of two Gauss sums
 -/
 
-
 section GaussSumProd
+
+open Finset in
+/-- A formula for the product of two Gauss sums with the same additive character. -/
+lemma gaussSum_mul {R : Type u} [CommRing R] [Fintype R] {R' : Type v} [CommRing R']
+    (χ φ : MulChar R R') (ψ : AddChar R R') :
+    gaussSum χ ψ * gaussSum φ ψ = ∑ t : R, ∑ x : R, χ x * φ (t - x) * ψ t := by
+  rw [gaussSum, gaussSum, sum_mul_sum]
+  conv => enter [1, 2, x, 2, x_1]; rw [mul_mul_mul_comm]
+  simp only [← ψ.map_add_eq_mul]
+  have sum_eq x : ∑ y : R, χ x * φ y * ψ (x + y) = ∑ y : R, χ x * φ (y - x) * ψ y := by
+    rw [sum_bij (fun a _ ↦ a + x)]
+    · simp only [mem_univ, forall_true_left, forall_const]
+    · simp only [mem_univ, add_left_inj, imp_self, forall_const]
+    · exact fun b _ ↦ ⟨b - x, mem_univ _, by rw [sub_add_cancel]⟩
+    · exact fun a _ ↦ by rw [add_sub_cancel_right, add_comm]
+  rw [sum_congr rfl fun x _ ↦ sum_eq x, sum_comm]
 
 -- In the following, we need `R` to be a finite field and `R'` to be a domain.
 variable {R : Type u} [Field R] [Fintype R] {R' : Type v} [CommRing R'] [IsDomain R']
@@ -116,6 +130,12 @@ theorem gaussSum_mul_gaussSum_eq_card {χ : MulChar R R'} (hχ : χ ≠ 1) {ψ :
   rw [Finset.sum_ite_eq' Finset.univ (1 : R)]
   simp only [Finset.mem_univ, map_one, one_mul, if_true]
 
+/-- The Gauss sum of a nontrivial character on a finite field does not vanish. -/
+lemma gaussSum_ne_zero_of_nontrivial (h : (Fintype.card R : R') ≠ 0) {χ : MulChar R R'}
+    (hχ : χ ≠ 1) {ψ : AddChar R R'} (hψ : ψ.IsPrimitive) :
+    gaussSum χ ψ ≠ 0 :=
+  fun H ↦ h.symm <| zero_mul (gaussSum χ⁻¹ _) ▸ H ▸ gaussSum_mul_gaussSum_eq_card hχ hψ
+
 /-- When `χ` is a nontrivial quadratic character, then the square of `gaussSum χ ψ`
 is `χ(-1)` times the cardinality of `R`. -/
 theorem gaussSum_sq {χ : MulChar R R'} (hχ₁ : χ ≠ 1) (hχ₂ : IsQuadratic χ)
@@ -131,7 +151,6 @@ end GaussSumProd
 /-!
 ### Gauss sums and Frobenius
 -/
-
 
 section gaussSum_frob
 
@@ -174,7 +193,6 @@ end gaussSum_frob
 /-!
 ### Values of quadratic characters
 -/
-
 
 section GaussSumValues
 
@@ -234,7 +252,6 @@ This can be used to show that the quadratic character of `F` takes the value
 The proof uses the Gauss sum of `χ₈` and a primitive additive character on `ℤ/8ℤ`;
 in this way, the result is reduced to `card_pow_char_pow`.
 -/
-
 
 open ZMod
 


### PR DESCRIPTION
This adds
```lean
lemma gaussSum_mul {R : Type u} [CommRing R] [Fintype R] {R' : Type v} [CommRing R']
    (χ φ : MulChar R R') (ψ : AddChar R R') :
    gaussSum χ ψ * gaussSum φ ψ = ∑ t : R, ∑ x : R, χ x * φ (t - x) * ψ t
```
and
```lean
lemma gaussSum_ne_zero_of_nontrivial {R : Type u} [Field R] [Fintype R] {R' : Type v} [CommRing R']
    [IsDomain R'] (h : (Fintype.card R : R') ≠ 0) {χ : MulChar R R'} (hχ : χ ≠ 1) {ψ : AddChar R R'}
    (hψ : ψ.IsPrimitive) :
    gaussSum χ ψ ≠ 0
```
which will be needed in results on Jacobi sums (coming soon).

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
