### PR TITLE
[Merged by Bors] - doc(Tactic): expand `ring` and `ring_nf` docstrings

### DIFF
--- a/Mathlib/Tactic/Ring/RingNF.lean
+++ b/Mathlib/Tactic/Ring/RingNF.lean
@@ -196,6 +196,12 @@ which rewrites all ring expressions into a normal form.
   * `recursive`: if true, `ring_nf` will also recurse into atoms
 * `ring_nf` works as both a tactic and a conv tactic.
   In tactic mode, `ring_nf at h` can be used to rewrite in a hypothesis.
+
+
+This can be used non-terminally to normalize ring expressions in the goal such as
+`⊢ P (x + x + x)` ~> `⊢ P (x * 3)`, as well as being able to prove some equations that
+`ring` cannot because they involve ring reasoning inside a subterm, such as
+`sin (x + y) + sin (y + x) = 2 * sin (x + y)`.
 -/
 elab (name := ringNF) "ring_nf" tk:"!"? cfg:(config ?) loc:(location)? : tactic => do
   let mut cfg ← elabConfig cfg
@@ -249,11 +255,6 @@ example (n : ℕ) (m : ℤ) : 2^(n+1) * m = 2 * 2^n * m := by ring
 example (a b : ℤ) (n : ℕ) : (a + b)^(n + 2) = (a^2 + b^2 + a * b + b * a) * (a + b)^n := by ring
 example (x y : ℕ) : x + id y = y + id x := by ring!
 ```
-
-This can be used non-terminally to normalize ring expressions in the goal such as
-`⊢ P (x + x + x)` ~> `⊢ P (x * 3)`, as well as being able to prove some equations that
-`ring` cannot because they involve ring reasoning inside a subterm, such as
-`sin (x + y) + sin (y + x) = 2 * sin (x + y)`.
 -/
 macro (name := ring) "ring" : tactic =>
   `(tactic| first | ring1 | try_this ring_nf)

--- a/Mathlib/Tactic/Ring/RingNF.lean
+++ b/Mathlib/Tactic/Ring/RingNF.lean
@@ -243,8 +243,8 @@ elab (name := ring1NF) "ring1_nf" tk:"!"? cfg:(config ?) : tactic => do
 
 /--
 Tactic for evaluating expressions in *commutative* (semi)rings, allowing for variables in the
-exponent. It uses `ring1` and `ring_nf` in succession so, if `ring1` fails, `ring_nf` will
-not be called.
+exponent. If the goal is not appropriate for `ring` (e.g. not an equality) `ring_nf` will be
+suggested.
 
 * `ring!` will use a more aggressive reducibility setting to determine equality of atoms.
 * `ring1` fails if the target is not an equality.
@@ -254,6 +254,7 @@ For example:
 example (n : ℕ) (m : ℤ) : 2^(n+1) * m = 2 * 2^n * m := by ring
 example (a b : ℤ) (n : ℕ) : (a + b)^(n + 2) = (a^2 + b^2 + a * b + b * a) * (a + b)^n := by ring
 example (x y : ℕ) : x + id y = y + id x := by ring!
+example (x : ℕ) (h : x * 2 > 5): x + x > 5 := by ring; assumption -- suggests ring_nf
 ```
 -/
 macro (name := ring) "ring" : tactic =>

--- a/Mathlib/Tactic/Ring/RingNF.lean
+++ b/Mathlib/Tactic/Ring/RingNF.lean
@@ -249,6 +249,11 @@ example (n : ℕ) (m : ℤ) : 2^(n+1) * m = 2 * 2^n * m := by ring
 example (a b : ℤ) (n : ℕ) : (a + b)^(n + 2) = (a^2 + b^2 + a * b + b * a) * (a + b)^n := by ring
 example (x y : ℕ) : x + id y = y + id x := by ring!
 ```
+
+This can be used non-terminally to normalize ring expressions in the goal such as
+`⊢ P (x + x + x)` ~> `⊢ P (x * 3)`, as well as being able to prove some equations that
+`ring` cannot because they involve ring reasoning inside a subterm, such as
+`sin (x + y) + sin (y + x) = 2 * sin (x + y)`.
 -/
 macro (name := ring) "ring" : tactic =>
   `(tactic| first | ring1 | try_this ring_nf)

--- a/Mathlib/Tactic/Ring/RingNF.lean
+++ b/Mathlib/Tactic/Ring/RingNF.lean
@@ -197,7 +197,6 @@ which rewrites all ring expressions into a normal form.
 * `ring_nf` works as both a tactic and a conv tactic.
   In tactic mode, `ring_nf at h` can be used to rewrite in a hypothesis.
 
-
 This can be used non-terminally to normalize ring expressions in the goal such as
 `⊢ P (x + x + x)` ~> `⊢ P (x * 3)`, as well as being able to prove some equations that
 `ring` cannot because they involve ring reasoning inside a subterm, such as
@@ -244,7 +243,8 @@ elab (name := ring1NF) "ring1_nf" tk:"!"? cfg:(config ?) : tactic => do
 
 /--
 Tactic for evaluating expressions in *commutative* (semi)rings, allowing for variables in the
-exponent.
+exponent. It uses `ring1` and `ring_nf` in succession so, if `ring1` fails, `ring_nf` will
+not be called.
 
 * `ring!` will use a more aggressive reducibility setting to determine equality of atoms.
 * `ring1` fails if the target is not an equality.


### PR DESCRIPTION
Copy some explanations from other comments into the actual `ring_nf` docstring. Add details to `ring` docstring.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
