### PR TITLE
[Merged by Bors] - chore: clean up some naming around `Matrix.stdBasisMatrix`

### DIFF
--- a/Mathlib/Data/Matrix/Basis.lean
+++ b/Mathlib/Data/Matrix/Basis.lean
@@ -81,9 +81,8 @@ theorem stdBasisMatrix_eq_single_vecMulVec_single (i : m) (j : n) :
 theorem std_basis_eq_basis_mul_basis (i : m) (j : n) :
     stdBasisMatrix i j (1 : α) =
       vecMulVec (fun i' => ite (i = i') 1 0) fun j' => ite (j = j') 1 0 := by
-  ext i' j'
-  -- Porting note: lean3 didn't apply `mul_ite`.
-  simp [-mul_ite, stdBasisMatrix, vecMulVec, ite_and]
+  rw [stdBasisMatrix_eq_single_vecMulVec_single]
+  congr! with i <;> simp only [Pi.single_apply, eq_comm]
 
 -- todo: the old proof used fintypes, I don't know `Finsupp` but this feels generalizable
 @[elab_as_elim]

--- a/Mathlib/Data/Matrix/Basis.lean
+++ b/Mathlib/Data/Matrix/Basis.lean
@@ -56,7 +56,7 @@ theorem mulVec_stdBasisMatrix [Fintype m] (i : n) (j : m) (c : α) (x : m → α
   · simp
   simp [h, h.symm]
 
-theorem matrix_eq_sum_std_basis [Fintype m] [Fintype n] (x : Matrix m n α) :
+theorem matrix_eq_sum_stdBasisMatrix [Fintype m] [Fintype n] (x : Matrix m n α) :
     x = ∑ i : m, ∑ j : n, stdBasisMatrix i j (x i j) := by
   ext i j; symm
   iterate 2 rw [Finset.sum_apply]
@@ -67,9 +67,17 @@ theorem matrix_eq_sum_std_basis [Fintype m] [Fintype n] (x : Matrix m n α) :
     -- Porting note(#12717): `simp` seems unwilling to apply `Fintype.sum_apply`
     simp (config := { unfoldPartialApp := true }) [stdBasisMatrix, (Fintype.sum_apply), hj']
 
+@[deprecated (since := "2024-08-11")] alias matrix_eq_sum_std_basis := matrix_eq_sum_stdBasisMatrix
+
+theorem stdBasisMatrix_eq_single_vecMulVec_single (i : m) (j : n) :
+    stdBasisMatrix i j (1 : α) = vecMulVec (Pi.single i 1) (Pi.single j 1) := by
+  ext i' j'
+  -- Porting note: lean3 didn't apply `mul_ite`.
+  simp [-mul_ite, stdBasisMatrix, vecMulVec, ite_and, Pi.single_apply, eq_comm]
+
 -- TODO: tie this up with the `Basis` machinery of linear algebra
 -- this is not completely trivial because we are indexing by two types, instead of one
--- TODO: add `std_basis_vec`
+@[deprecated stdBasisMatrix_eq_single_vecMulVec_single (since := "2024-08-11")]
 theorem std_basis_eq_basis_mul_basis (i : m) (j : n) :
     stdBasisMatrix i j (1 : α) =
       vecMulVec (fun i' => ite (i = i') 1 0) fun j' => ite (j = j') 1 0 := by
@@ -83,7 +91,7 @@ protected theorem induction_on' [Finite m] [Finite n] {P : Matrix m n α → Pro
     (h_zero : P 0) (h_add : ∀ p q, P p → P q → P (p + q))
     (h_std_basis : ∀ (i : m) (j : n) (x : α), P (stdBasisMatrix i j x)) : P M := by
   cases nonempty_fintype m; cases nonempty_fintype n
-  rw [matrix_eq_sum_std_basis M, ← Finset.sum_product']
+  rw [matrix_eq_sum_stdBasisMatrix M, ← Finset.sum_product']
   apply Finset.sum_induction _ _ h_add h_zero
   · intros
     apply h_std_basis

--- a/Mathlib/RingTheory/MatrixAlgebra.lean
+++ b/Mathlib/RingTheory/MatrixAlgebra.lean
@@ -95,7 +95,7 @@ theorem invFun_algebraMap (M : Matrix n n R) : invFun R A n (M.map (algebraMap R
   dsimp [invFun]
   simp only [Algebra.algebraMap_eq_smul_one, smul_tmul, ← tmul_sum, mul_boole]
   congr
-  conv_rhs => rw [matrix_eq_sum_std_basis M]
+  conv_rhs => rw [matrix_eq_sum_stdBasisMatrix M]
   convert Finset.sum_product (β := Matrix n n R); simp
 
 theorem right_inv (M : Matrix n n A) : (toFunAlgHom R A n) (invFun R A n M) = M := by
@@ -103,7 +103,7 @@ theorem right_inv (M : Matrix n n A) : (toFunAlgHom R A n) (invFun R A n M) = M 
     mul_boole, toFunAlgHom_apply, RingHom.map_zero, RingHom.map_one, Matrix.map_apply,
     Pi.smul_def]
   convert Finset.sum_product (β := Matrix n n A)
-  conv_lhs => rw [matrix_eq_sum_std_basis M]
+  conv_lhs => rw [matrix_eq_sum_stdBasisMatrix M]
   refine Finset.sum_congr rfl fun i _ => Finset.sum_congr rfl fun j _ => Matrix.ext fun a b => ?_
   simp only [stdBasisMatrix, smul_apply, Matrix.map_apply]
   split_ifs <;> aesop
@@ -144,10 +144,14 @@ theorem matrixEquivTensor_apply (M : Matrix n n A) :
 
 -- Porting note: short circuiting simplifier from simplifying left hand side
 @[simp (high)]
-theorem matrixEquivTensor_apply_std_basis (i j : n) (x : A) :
+theorem matrixEquivTensor_apply_stdBasisMatrix (i j : n) (x : A) :
     matrixEquivTensor R A n (stdBasisMatrix i j x) = x ⊗ₜ stdBasisMatrix i j 1 := by
   have t : ∀ p : n × n, i = p.1 ∧ j = p.2 ↔ p = (i, j) := by aesop
   simp [ite_tmul, t, stdBasisMatrix]
+
+@[deprecated (since := "2024-08-11")] alias matrixEquivTensor_apply_std_basis :=
+  matrixEquivTensor_apply_stdBasisMatrix
+
 
 @[simp]
 theorem matrixEquivTensor_apply_symm (a : A) (M : Matrix n n R) :

--- a/Mathlib/RingTheory/MatrixAlgebra.lean
+++ b/Mathlib/RingTheory/MatrixAlgebra.lean
@@ -152,7 +152,6 @@ theorem matrixEquivTensor_apply_stdBasisMatrix (i j : n) (x : A) :
 @[deprecated (since := "2024-08-11")] alias matrixEquivTensor_apply_std_basis :=
   matrixEquivTensor_apply_stdBasisMatrix
 
-
 @[simp]
 theorem matrixEquivTensor_apply_symm (a : A) (M : Matrix n n R) :
     (matrixEquivTensor R A n).symm (a ⊗ₜ M) = M.map fun x => a * algebraMap R A x :=

--- a/Mathlib/RingTheory/PolynomialAlgebra.lean
+++ b/Mathlib/RingTheory/PolynomialAlgebra.lean
@@ -222,7 +222,7 @@ open Finset
 unseal Algebra.TensorProduct.mul in
 theorem matPolyEquiv_coeff_apply_aux_1 (i j : n) (k : ℕ) (x : R) :
     matPolyEquiv (stdBasisMatrix i j <| monomial k x) = monomial k (stdBasisMatrix i j x) := by
-  simp only [matPolyEquiv, AlgEquiv.trans_apply, matrixEquivTensor_apply_std_basis]
+  simp only [matPolyEquiv, AlgEquiv.trans_apply, matrixEquivTensor_apply_stdBasisMatrix]
   apply (polyEquivTensor R (Matrix n n R)).injective
   simp only [AlgEquiv.apply_symm_apply,Algebra.TensorProduct.comm_tmul,
     polyEquivTensor_apply, eval₂_monomial]


### PR DESCRIPTION
`std_basis` is a lean3-ism.

In future we might want to rename this to `Matrix.single`.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
