### PR TITLE
[Merged by Bors] - chore: turn `induction'` into `induction`

### DIFF
--- a/Mathlib/Algebra/Group/Support.lean
+++ b/Mathlib/Algebra/Group/Support.lean
@@ -209,9 +209,10 @@ theorem mulSupport_mul [MulOneClass M] (f g : α → M) :
 @[to_additive]
 theorem mulSupport_pow [Monoid M] (f : α → M) (n : ℕ) :
     (mulSupport fun x => f x ^ n) ⊆ mulSupport f := by
-  induction' n with n hfn
-  · simp [pow_zero, mulSupport_one]
-  · simpa only [pow_succ'] using (mulSupport_mul f _).trans (union_subset Subset.rfl hfn)
+  induction n with
+  | zero => simp [pow_zero, mulSupport_one]
+  | succ n hfn =>
+      simpa only [pow_succ'] using (mulSupport_mul f _).trans (union_subset Subset.rfl hfn)
 
 section DivisionMonoid
 

--- a/Mathlib/Algebra/Group/Support.lean
+++ b/Mathlib/Algebra/Group/Support.lean
@@ -212,7 +212,7 @@ theorem mulSupport_pow [Monoid M] (f : α → M) (n : ℕ) :
   induction n with
   | zero => simp [pow_zero, mulSupport_one]
   | succ n hfn =>
-      simpa only [pow_succ'] using (mulSupport_mul f _).trans (union_subset Subset.rfl hfn)
+    simpa only [pow_succ'] using (mulSupport_mul f _).trans (union_subset Subset.rfl hfn)
 
 section DivisionMonoid
 

--- a/Mathlib/Algebra/Polynomial/Basic.lean
+++ b/Mathlib/Algebra/Polynomial/Basic.lean
@@ -772,9 +772,9 @@ theorem support_trinomial' (k m n : ℕ) (x y z : R) :
 end Fewnomials
 
 theorem X_pow_eq_monomial (n) : X ^ n = monomial n (1 : R) := by
-  induction' n with n hn
-  · rw [pow_zero, monomial_zero_one]
-  · rw [pow_succ, hn, X, monomial_mul_monomial, one_mul]
+  induction n with
+  | zero => rw [pow_zero, monomial_zero_one]
+  | succ n hn => rw [pow_succ, hn, X, monomial_mul_monomial, one_mul]
 
 @[simp high]
 theorem toFinsupp_X_pow (n : ℕ) : (X ^ n).toFinsupp = Finsupp.single n (1 : R) := by

--- a/Mathlib/Algebra/Polynomial/Div.lean
+++ b/Mathlib/Algebra/Polynomial/Div.lean
@@ -41,14 +41,15 @@ theorem X_pow_dvd_iff {f : R[X]} {n : ℕ} : X ^ n ∣ f ↔ ∀ d < n, f.coeff 
   ⟨fun ⟨g, hgf⟩ d hd => by
     simp only [hgf, coeff_X_pow_mul', ite_eq_right_iff, not_le_of_lt hd, IsEmpty.forall_iff],
     fun hd => by
-    induction' n with n hn
-    · simp [pow_zero, one_dvd]
-    · obtain ⟨g, hgf⟩ := hn fun d : ℕ => fun H : d < n => hd _ (Nat.lt_succ_of_lt H)
-      have := coeff_X_pow_mul g n 0
-      rw [zero_add, ← hgf, hd n (Nat.lt_succ_self n)] at this
-      obtain ⟨k, hgk⟩ := Polynomial.X_dvd_iff.mpr this.symm
-      use k
-      rwa [pow_succ, mul_assoc, ← hgk]⟩
+    induction n with
+    | zero => simp [pow_zero, one_dvd]
+    | succ n hn =>
+        obtain ⟨g, hgf⟩ := hn fun d : ℕ => fun H : d < n => hd _ (Nat.lt_succ_of_lt H)
+        have := coeff_X_pow_mul g n 0
+        rw [zero_add, ← hgf, hd n (Nat.lt_succ_self n)] at this
+        obtain ⟨k, hgk⟩ := Polynomial.X_dvd_iff.mpr this.symm
+        use k
+        rwa [pow_succ, mul_assoc, ← hgk]⟩
 
 variable {p q : R[X]}
 

--- a/Mathlib/Algebra/Polynomial/Div.lean
+++ b/Mathlib/Algebra/Polynomial/Div.lean
@@ -44,12 +44,12 @@ theorem X_pow_dvd_iff {f : R[X]} {n : ℕ} : X ^ n ∣ f ↔ ∀ d < n, f.coeff 
     induction n with
     | zero => simp [pow_zero, one_dvd]
     | succ n hn =>
-        obtain ⟨g, hgf⟩ := hn fun d : ℕ => fun H : d < n => hd _ (Nat.lt_succ_of_lt H)
-        have := coeff_X_pow_mul g n 0
-        rw [zero_add, ← hgf, hd n (Nat.lt_succ_self n)] at this
-        obtain ⟨k, hgk⟩ := Polynomial.X_dvd_iff.mpr this.symm
-        use k
-        rwa [pow_succ, mul_assoc, ← hgk]⟩
+      obtain ⟨g, hgf⟩ := hn fun d : ℕ => fun H : d < n => hd _ (Nat.lt_succ_of_lt H)
+      have := coeff_X_pow_mul g n 0
+      rw [zero_add, ← hgf, hd n (Nat.lt_succ_self n)] at this
+      obtain ⟨k, hgk⟩ := Polynomial.X_dvd_iff.mpr this.symm
+      use k
+      rwa [pow_succ, mul_assoc, ← hgk]⟩
 
 variable {p q : R[X]}
 

--- a/Mathlib/Algebra/Polynomial/Laurent.lean
+++ b/Mathlib/Algebra/Polynomial/Laurent.lean
@@ -365,10 +365,9 @@ it follow that `Q` is true on all Laurent polynomials. -/
 theorem reduce_to_polynomial_of_mul_T (f : R[T;T⁻¹]) {Q : R[T;T⁻¹] → Prop}
     (Qf : ∀ f : R[X], Q (toLaurent f)) (QT : ∀ f, Q (f * T 1) → Q f) : Q f := by
   induction' f using LaurentPolynomial.induction_on_mul_T with f n
-  induction' n with n hn
-  · simpa only [Nat.zero_eq, Nat.cast_zero, neg_zero, T_zero, mul_one] using Qf _
-  · convert QT _ _
-    simpa using hn
+  induction n with
+    | zero => simpa only [Nat.zero_eq, Nat.cast_zero, neg_zero, T_zero, mul_one] using Qf _
+    | succ n hn => convert QT _ _; simpa using hn
 
 section Support
 

--- a/Mathlib/Algebra/Polynomial/Laurent.lean
+++ b/Mathlib/Algebra/Polynomial/Laurent.lean
@@ -366,8 +366,8 @@ theorem reduce_to_polynomial_of_mul_T (f : R[T;T⁻¹]) {Q : R[T;T⁻¹] → Pro
     (Qf : ∀ f : R[X], Q (toLaurent f)) (QT : ∀ f, Q (f * T 1) → Q f) : Q f := by
   induction' f using LaurentPolynomial.induction_on_mul_T with f n
   induction n with
-    | zero => simpa only [Nat.zero_eq, Nat.cast_zero, neg_zero, T_zero, mul_one] using Qf _
-    | succ n hn => convert QT _ _; simpa using hn
+  | zero => simpa only [Nat.zero_eq, Nat.cast_zero, neg_zero, T_zero, mul_one] using Qf _
+  | succ n hn => convert QT _ _; simpa using hn
 
 section Support
 

--- a/Mathlib/Algebra/Polynomial/Monic.lean
+++ b/Mathlib/Algebra/Polynomial/Monic.lean
@@ -206,9 +206,9 @@ theorem eq_one_of_map_eq_one {S : Type*} [Semiring S] [Nontrivial S] (f : R →+
   rw [← hndeg, ← Polynomial.leadingCoeff, hp.leadingCoeff, C.map_one]
 
 theorem natDegree_pow (hp : p.Monic) (n : ℕ) : (p ^ n).natDegree = n * p.natDegree := by
-  induction' n with n hn
-  · simp
-  · rw [pow_succ, (hp.pow n).natDegree_mul hp, hn, Nat.succ_mul, add_comm]
+  induction n with
+  | zero => simp
+  | succ n hn => rw [pow_succ, (hp.pow n).natDegree_mul hp, hn, Nat.succ_mul, add_comm]
 
 end Monic
 

--- a/Mathlib/Algebra/Regular/SMul.lean
+++ b/Mathlib/Algebra/Regular/SMul.lean
@@ -136,8 +136,8 @@ theorem pow (n : ℕ) (ra : IsSMulRegular M a) : IsSMulRegular M (a ^ n) := by
   induction n with
   | zero => rw [pow_zero]; simp only [one]
   | succ n hn =>
-      rw [pow_succ']
-      exact (ra.smul_iff (a ^ n)).mpr hn
+    rw [pow_succ']
+    exact (ra.smul_iff (a ^ n)).mpr hn
 
 /-- An element `a` is `M`-regular if and only if a positive power of `a` is `M`-regular. -/
 theorem pow_iff {n : ℕ} (n0 : 0 < n) : IsSMulRegular M (a ^ n) ↔ IsSMulRegular M a := by

--- a/Mathlib/Algebra/Regular/SMul.lean
+++ b/Mathlib/Algebra/Regular/SMul.lean
@@ -133,10 +133,11 @@ theorem of_mul_eq_one (h : a * b = 1) : IsSMulRegular M b :=
 
 /-- Any power of an `M`-regular element is `M`-regular. -/
 theorem pow (n : ℕ) (ra : IsSMulRegular M a) : IsSMulRegular M (a ^ n) := by
-  induction' n with n hn
-  · rw [pow_zero]; simp only [one]
-  · rw [pow_succ']
-    exact (ra.smul_iff (a ^ n)).mpr hn
+  induction n with
+  | zero => rw [pow_zero]; simp only [one]
+  | succ n hn =>
+      rw [pow_succ']
+      exact (ra.smul_iff (a ^ n)).mpr hn
 
 /-- An element `a` is `M`-regular if and only if a positive power of `a` is `M`-regular. -/
 theorem pow_iff {n : ℕ} (n0 : 0 < n) : IsSMulRegular M (a ^ n) ↔ IsSMulRegular M a := by

--- a/Mathlib/Analysis/Asymptotics/SuperpolynomialDecay.lean
+++ b/Mathlib/Analysis/Asymptotics/SuperpolynomialDecay.lean
@@ -103,9 +103,9 @@ theorem SuperpolynomialDecay.mul_param (hf : SuperpolynomialDecay l k f) :
 
 theorem SuperpolynomialDecay.param_pow_mul (hf : SuperpolynomialDecay l k f) (n : ℕ) :
     SuperpolynomialDecay l k (k ^ n * f) := by
-  induction' n with n hn
-  · simpa only [Nat.zero_eq, one_mul, pow_zero] using hf
-  · simpa only [pow_succ', mul_assoc] using hn.param_mul
+  induction n with
+  | zero => simpa only [Nat.zero_eq, one_mul, pow_zero] using hf
+  | succ n hn => simpa only [pow_succ', mul_assoc] using hn.param_mul
 
 theorem SuperpolynomialDecay.mul_param_pow (hf : SuperpolynomialDecay l k f) (n : ℕ) :
     SuperpolynomialDecay l k (f * k ^ n) :=
@@ -260,10 +260,11 @@ theorem superpolynomialDecay_mul_param_iff (hk : Tendsto k l atTop) :
 
 theorem superpolynomialDecay_param_pow_mul_iff (hk : Tendsto k l atTop) (n : ℕ) :
     SuperpolynomialDecay l k (k ^ n * f) ↔ SuperpolynomialDecay l k f := by
-  induction' n with n hn
-  · simp
-  · simpa [pow_succ, ← mul_comm k, mul_assoc,
-      superpolynomialDecay_param_mul_iff (k ^ n * f) hk] using hn
+  induction n with
+  | zero => simp
+  | succ n hn =>
+      simpa [pow_succ, ← mul_comm k, mul_assoc,
+             superpolynomialDecay_param_mul_iff (k ^ n * f) hk] using hn
 
 theorem superpolynomialDecay_mul_param_pow_iff (hk : Tendsto k l atTop) (n : ℕ) :
     SuperpolynomialDecay l k (f * k ^ n) ↔ SuperpolynomialDecay l k f := by

--- a/Mathlib/Analysis/Asymptotics/SuperpolynomialDecay.lean
+++ b/Mathlib/Analysis/Asymptotics/SuperpolynomialDecay.lean
@@ -263,8 +263,8 @@ theorem superpolynomialDecay_param_pow_mul_iff (hk : Tendsto k l atTop) (n : ℕ
   induction n with
   | zero => simp
   | succ n hn =>
-      simpa [pow_succ, ← mul_comm k, mul_assoc,
-             superpolynomialDecay_param_mul_iff (k ^ n * f) hk] using hn
+    simpa [pow_succ, ← mul_comm k, mul_assoc,
+      superpolynomialDecay_param_mul_iff (k ^ n * f) hk] using hn
 
 theorem superpolynomialDecay_mul_param_pow_iff (hk : Tendsto k l atTop) (n : ℕ) :
     SuperpolynomialDecay l k (f * k ^ n) ↔ SuperpolynomialDecay l k f := by

--- a/Mathlib/Analysis/SpecialFunctions/Gamma/Basic.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Gamma/Basic.lean
@@ -327,9 +327,9 @@ theorem Gamma_nat_eq_factorial (n : ℕ) : Gamma (n + 1) = n ! := by
   induction n with
   | zero => simp
   | succ n hn =>
-      rw [Gamma_add_one n.succ <| Nat.cast_ne_zero.mpr <| Nat.succ_ne_zero n]
-      simp only [Nat.cast_succ, Nat.factorial_succ, Nat.cast_mul]
-      congr
+    rw [Gamma_add_one n.succ <| Nat.cast_ne_zero.mpr <| Nat.succ_ne_zero n]
+    simp only [Nat.cast_succ, Nat.factorial_succ, Nat.cast_mul]
+    congr
 
 @[simp]
 theorem Gamma_ofNat_eq_factorial (n : ℕ) [(n + 1).AtLeastTwo] :

--- a/Mathlib/Analysis/SpecialFunctions/Gamma/Basic.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Gamma/Basic.lean
@@ -324,10 +324,12 @@ theorem Gamma_eq_integral {s : ℂ} (hs : 0 < s.re) : Gamma s = GammaIntegral s 
 theorem Gamma_one : Gamma 1 = 1 := by rw [Gamma_eq_integral] <;> simp
 
 theorem Gamma_nat_eq_factorial (n : ℕ) : Gamma (n + 1) = n ! := by
-  induction' n with n hn
-  · simp
-  · rw [Gamma_add_one n.succ <| Nat.cast_ne_zero.mpr <| Nat.succ_ne_zero n]
-    simp only [Nat.cast_succ, Nat.factorial_succ, Nat.cast_mul]; congr
+  induction n with
+  | zero => simp
+  | succ n hn =>
+      rw [Gamma_add_one n.succ <| Nat.cast_ne_zero.mpr <| Nat.succ_ne_zero n]
+      simp only [Nat.cast_succ, Nat.factorial_succ, Nat.cast_mul]
+      congr
 
 @[simp]
 theorem Gamma_ofNat_eq_factorial (n : ℕ) [(n + 1).AtLeastTwo] :

--- a/Mathlib/Analysis/SpecialFunctions/Gamma/BohrMollerup.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Gamma/BohrMollerup.lean
@@ -152,13 +152,14 @@ theorem f_nat_eq (hf_feq : ∀ {y : ℝ}, 0 < y → f (y + 1) = f y + log y) (hn
 
 theorem f_add_nat_eq (hf_feq : ∀ {y : ℝ}, 0 < y → f (y + 1) = f y + log y) (hx : 0 < x) (n : ℕ) :
     f (x + n) = f x + ∑ m ∈ Finset.range n, log (x + m) := by
-  induction' n with n hn
-  · simp
-  · have : x + n.succ = x + n + 1 := by push_cast; ring
-    rw [this, hf_feq, hn]
-    · rw [Finset.range_succ, Finset.sum_insert Finset.not_mem_range_self]
-      abel
-    · linarith [(Nat.cast_nonneg n : 0 ≤ (n : ℝ))]
+  induction n with
+  | zero => simp
+  | succ n hn =>
+      have : x + n.succ = x + n + 1 := by push_cast; ring
+      rw [this, hf_feq, hn]
+      · rw [Finset.range_succ, Finset.sum_insert Finset.not_mem_range_self]
+        abel
+      · linarith [(Nat.cast_nonneg n : 0 ≤ (n : ℝ))]
 
 /-- Linear upper bound for `f (x + n)` on unit interval -/
 theorem f_add_nat_le (hf_conv : ConvexOn ℝ (Ioi 0) f)

--- a/Mathlib/Analysis/SpecialFunctions/Gamma/BohrMollerup.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Gamma/BohrMollerup.lean
@@ -155,11 +155,11 @@ theorem f_add_nat_eq (hf_feq : ∀ {y : ℝ}, 0 < y → f (y + 1) = f y + log y)
   induction n with
   | zero => simp
   | succ n hn =>
-      have : x + n.succ = x + n + 1 := by push_cast; ring
-      rw [this, hf_feq, hn]
-      · rw [Finset.range_succ, Finset.sum_insert Finset.not_mem_range_self]
-        abel
-      · linarith [(Nat.cast_nonneg n : 0 ≤ (n : ℝ))]
+    have : x + n.succ = x + n + 1 := by push_cast; ring
+    rw [this, hf_feq, hn]
+    · rw [Finset.range_succ, Finset.sum_insert Finset.not_mem_range_self]
+      abel
+    · linarith [(Nat.cast_nonneg n : 0 ≤ (n : ℝ))]
 
 /-- Linear upper bound for `f (x + n)` on unit interval -/
 theorem f_add_nat_le (hf_conv : ConvexOn ℝ (Ioi 0) f)

--- a/Mathlib/CategoryTheory/Triangulated/Pretriangulated.lean
+++ b/Mathlib/CategoryTheory/Triangulated/Pretriangulated.lean
@@ -399,12 +399,12 @@ lemma shift_distinguished (n : ℤ) :
     isomorphic_distinguished _ (hb _ (ha _ hT)) _
       ((Triangle.shiftFunctorAdd' C _ _ _ hc).app T)
   obtain (n|n) := n
-  · induction' n with n hn
-    · exact H_zero
-    · exact H_add hn H_one rfl
-  · induction' n with n hn
-    · exact H_neg_one
-    · exact H_add hn H_neg_one rfl
+  · induction n with
+      | zero =>  exact H_zero
+      | succ n hn => exact H_add hn H_one rfl
+  · induction n with
+      | zero => exact H_neg_one
+      | succ n hn => exact H_add hn H_neg_one rfl
 
 end Triangle
 

--- a/Mathlib/CategoryTheory/Triangulated/Pretriangulated.lean
+++ b/Mathlib/CategoryTheory/Triangulated/Pretriangulated.lean
@@ -400,11 +400,11 @@ lemma shift_distinguished (n : ℤ) :
       ((Triangle.shiftFunctorAdd' C _ _ _ hc).app T)
   obtain (n|n) := n
   · induction n with
-      | zero =>  exact H_zero
-      | succ n hn => exact H_add hn H_one rfl
+    | zero =>  exact H_zero
+    | succ n hn => exact H_add hn H_one rfl
   · induction n with
-      | zero => exact H_neg_one
-      | succ n hn => exact H_add hn H_neg_one rfl
+    | zero => exact H_neg_one
+    | succ n hn => exact H_add hn H_neg_one rfl
 
 end Triangle
 

--- a/Mathlib/Combinatorics/Derangements/Finite.lean
+++ b/Mathlib/Combinatorics/Derangements/Finite.lean
@@ -78,10 +78,11 @@ theorem numDerangements_add_two (n : ℕ) :
 
 theorem numDerangements_succ (n : ℕ) :
     (numDerangements (n + 1) : ℤ) = (n + 1) * (numDerangements n : ℤ) - (-1) ^ n := by
-  induction' n with n hn
-  · rfl
-  · simp only [numDerangements_add_two, hn, pow_succ, Int.ofNat_mul, Int.ofNat_add, Int.ofNat_succ]
-    ring
+  induction n with
+  | zero => rfl
+  | succ n hn =>
+      simp only [numDerangements_add_two, hn, pow_succ, Int.ofNat_mul, Int.ofNat_add, Int.ofNat_succ]
+      ring
 
 theorem card_derangements_fin_eq_numDerangements {n : ℕ} :
     card (derangements (Fin n)) = numDerangements n := by

--- a/Mathlib/Combinatorics/Derangements/Finite.lean
+++ b/Mathlib/Combinatorics/Derangements/Finite.lean
@@ -81,7 +81,7 @@ theorem numDerangements_succ (n : ℕ) :
   induction n with
   | zero => rfl
   | succ n hn =>
-      simp only [numDerangements_add_two, hn, pow_succ, Int.ofNat_mul, Int.ofNat_add, Int.ofNat_succ]
+      simp only [numDerangements_add_two, hn, pow_succ, Int.ofNat_mul, Int.ofNat_add]
       ring
 
 theorem card_derangements_fin_eq_numDerangements {n : ℕ} :

--- a/Mathlib/Combinatorics/Derangements/Finite.lean
+++ b/Mathlib/Combinatorics/Derangements/Finite.lean
@@ -81,8 +81,8 @@ theorem numDerangements_succ (n : ℕ) :
   induction n with
   | zero => rfl
   | succ n hn =>
-      simp only [numDerangements_add_two, hn, pow_succ, Int.ofNat_mul, Int.ofNat_add]
-      ring
+    simp only [numDerangements_add_two, hn, pow_succ, Int.ofNat_mul, Int.ofNat_add]
+    ring
 
 theorem card_derangements_fin_eq_numDerangements {n : ℕ} :
     card (derangements (Fin n)) = numDerangements n := by

--- a/Mathlib/FieldTheory/Finite/Basic.lean
+++ b/Mathlib/FieldTheory/Finite/Basic.lean
@@ -351,9 +351,10 @@ theorem frobenius_pow {p : ℕ} [Fact p.Prime] [CharP K p] {n : ℕ} (hcard : q 
     frobenius K p ^ n = 1 := by
   ext x; conv_rhs => rw [RingHom.one_def, RingHom.id_apply, ← pow_card x, hcard]
   clear hcard
-  induction' n with n hn
-  · simp
-  · rw [pow_succ', pow_succ, pow_mul, RingHom.mul_def, RingHom.comp_apply, frobenius_def, hn]
+  induction n with
+  | zero => simp
+  | succ n hn =>
+    rw [pow_succ', pow_succ, pow_mul, RingHom.mul_def, RingHom.comp_apply, frobenius_def, hn]
 
 open Polynomial
 

--- a/Mathlib/FieldTheory/Finite/Basic.lean
+++ b/Mathlib/FieldTheory/Finite/Basic.lean
@@ -221,9 +221,9 @@ theorem pow_card (a : K) : a ^ q = a := by
     pow_card_sub_one_eq_one a h, one_mul]
 
 theorem pow_card_pow (n : ℕ) (a : K) : a ^ q ^ n = a := by
-  induction' n with n ih
-  · simp
-  · simp [pow_succ, pow_mul, ih, pow_card]
+  induction n with
+  | zero => simp
+  | succ n ih => simp [pow_succ, pow_mul, ih, pow_card]
 
 end
 
@@ -471,9 +471,9 @@ theorem pow_card {p : ℕ} [Fact p.Prime] (x : ZMod p) : x ^ p = x := by
 
 @[simp]
 theorem pow_card_pow {n p : ℕ} [Fact p.Prime] (x : ZMod p) : x ^ p ^ n = x := by
-  induction' n with n ih
-  · simp
-  · simp [pow_succ, pow_mul, ih, pow_card]
+  induction n with
+  | zero => simp
+  | succ n ih => simp [pow_succ, pow_mul, ih, pow_card]
 
 @[simp]
 theorem frobenius_zmod (p : ℕ) [Fact p.Prime] : frobenius (ZMod p) p = RingHom.id _ := by

--- a/Mathlib/GroupTheory/Perm/Basic.lean
+++ b/Mathlib/GroupTheory/Perm/Basic.lean
@@ -346,9 +346,9 @@ private theorem pow_aux (hf : ∀ x, p x ↔ p (f x)) : ∀ {n : ℕ} (x), p x �
 @[simp]
 theorem subtypePerm_pow (f : Perm α) (n : ℕ) (hf) :
     (f.subtypePerm hf : Perm { x // p x }) ^ n = (f ^ n).subtypePerm (pow_aux hf) := by
-  induction' n with n ih
-  · simp
-  · simp_rw [pow_succ', ih, subtypePerm_mul]
+  induction n with
+  | zero => simp
+  | succ n ih => simp_rw [pow_succ', ih, subtypePerm_mul]
 
 private theorem zpow_aux (hf : ∀ x, p x ↔ p (f x)) : ∀ {n : ℤ} (x), p x ↔ p ((f ^ n) x)
   | Int.ofNat n => pow_aux hf
@@ -359,9 +359,9 @@ private theorem zpow_aux (hf : ∀ x, p x ↔ p (f x)) : ∀ {n : ℤ} (x), p x 
 @[simp]
 theorem subtypePerm_zpow (f : Perm α) (n : ℤ) (hf) :
     (f.subtypePerm hf ^ n : Perm { x // p x }) = (f ^ n).subtypePerm (zpow_aux hf) := by
-  induction' n with n ih
-  · exact subtypePerm_pow _ _ _
-  · simp only [zpow_negSucc, subtypePerm_pow, subtypePerm_inv]
+  induction n with
+  | ofNat n => exact subtypePerm_pow _ _ _
+  | negSucc n => simp only [zpow_negSucc, subtypePerm_pow, subtypePerm_inv]
 
 variable [DecidablePred p] {a : α}
 

--- a/Mathlib/GroupTheory/Perm/Cycle/Factors.lean
+++ b/Mathlib/GroupTheory/Perm/Cycle/Factors.lean
@@ -61,10 +61,11 @@ theorem cycleOf_inv (f : Perm α) [DecidableRel f.SameCycle] (x : α) :
 theorem cycleOf_pow_apply_self (f : Perm α) [DecidableRel f.SameCycle] (x : α) :
     ∀ n : ℕ, (cycleOf f x ^ n) x = (f ^ n) x := by
   intro n
-  induction' n with n hn
-  · rfl
-  · rw [pow_succ', mul_apply, cycleOf_apply, hn, if_pos, pow_succ', mul_apply]
-    exact ⟨n, rfl⟩
+  induction n with
+  | zero => rfl
+  | succ n hn =>
+      rw [pow_succ', mul_apply, cycleOf_apply, hn, if_pos, pow_succ', mul_apply]
+      exact ⟨n, rfl⟩
 
 @[simp]
 theorem cycleOf_zpow_apply_self (f : Perm α) [DecidableRel f.SameCycle] (x : α) :

--- a/Mathlib/GroupTheory/Perm/Cycle/Factors.lean
+++ b/Mathlib/GroupTheory/Perm/Cycle/Factors.lean
@@ -64,8 +64,8 @@ theorem cycleOf_pow_apply_self (f : Perm α) [DecidableRel f.SameCycle] (x : α)
   induction n with
   | zero => rfl
   | succ n hn =>
-      rw [pow_succ', mul_apply, cycleOf_apply, hn, if_pos, pow_succ', mul_apply]
-      exact ⟨n, rfl⟩
+    rw [pow_succ', mul_apply, cycleOf_apply, hn, if_pos, pow_succ', mul_apply]
+    exact ⟨n, rfl⟩
 
 @[simp]
 theorem cycleOf_zpow_apply_self (f : Perm α) [DecidableRel f.SameCycle] (x : α) :

--- a/Mathlib/GroupTheory/Perm/List.lean
+++ b/Mathlib/GroupTheory/Perm/List.lean
@@ -267,11 +267,12 @@ theorem formPerm_rotate_one (l : List α) (h : Nodup l) : formPerm (l.rotate 1) 
 
 theorem formPerm_rotate (l : List α) (h : Nodup l) (n : ℕ) :
     formPerm (l.rotate n) = formPerm l := by
-  induction' n with n hn
-  · simp
-  · rw [← rotate_rotate, formPerm_rotate_one, hn]
-    rwa [IsRotated.nodup_iff]
-    exact IsRotated.forall l n
+  induction n with
+  | zero => simp
+  | succ n hn =>
+      rw [← rotate_rotate, formPerm_rotate_one, hn]
+      rwa [IsRotated.nodup_iff]
+      exact IsRotated.forall l n
 
 theorem formPerm_eq_of_isRotated {l l' : List α} (hd : Nodup l) (h : l ~r l') :
     formPerm l = formPerm l' := by
@@ -294,10 +295,11 @@ theorem formPerm_reverse : ∀ l : List α, formPerm l.reverse = (formPerm l)⁻
 theorem formPerm_pow_apply_getElem (l : List α) (w : Nodup l) (n : ℕ) (i : ℕ) (h : i < l.length) :
     (formPerm l ^ n) l[i] =
       l[(i + n) % l.length]'(Nat.mod_lt _ (i.zero_le.trans_lt h)) := by
-  induction' n with n hn
-  · simp [Nat.mod_eq_of_lt h]
-  · simp [pow_succ', mul_apply, hn, formPerm_apply_getElem _ w, Nat.succ_eq_add_one,
-      ← Nat.add_assoc]
+  induction n with
+  | zero => simp [Nat.mod_eq_of_lt h]
+  | succ n hn =>
+      simp [pow_succ', mul_apply, hn, formPerm_apply_getElem _ w, Nat.succ_eq_add_one,
+            ← Nat.add_assoc]
 
 @[deprecated formPerm_pow_apply_getElem (since := "2024-08-03")]
 theorem formPerm_pow_apply_get (l : List α) (h : Nodup l) (n : ℕ) (i : Fin l.length) :

--- a/Mathlib/GroupTheory/Perm/List.lean
+++ b/Mathlib/GroupTheory/Perm/List.lean
@@ -270,9 +270,9 @@ theorem formPerm_rotate (l : List α) (h : Nodup l) (n : ℕ) :
   induction n with
   | zero => simp
   | succ n hn =>
-      rw [← rotate_rotate, formPerm_rotate_one, hn]
-      rwa [IsRotated.nodup_iff]
-      exact IsRotated.forall l n
+    rw [← rotate_rotate, formPerm_rotate_one, hn]
+    rwa [IsRotated.nodup_iff]
+    exact IsRotated.forall l n
 
 theorem formPerm_eq_of_isRotated {l l' : List α} (hd : Nodup l) (h : l ~r l') :
     formPerm l = formPerm l' := by
@@ -298,8 +298,8 @@ theorem formPerm_pow_apply_getElem (l : List α) (w : Nodup l) (n : ℕ) (i : �
   induction n with
   | zero => simp [Nat.mod_eq_of_lt h]
   | succ n hn =>
-      simp [pow_succ', mul_apply, hn, formPerm_apply_getElem _ w, Nat.succ_eq_add_one,
-            ← Nat.add_assoc]
+    simp [pow_succ', mul_apply, hn, formPerm_apply_getElem _ w, Nat.succ_eq_add_one,
+      ← Nat.add_assoc]
 
 @[deprecated formPerm_pow_apply_getElem (since := "2024-08-03")]
 theorem formPerm_pow_apply_get (l : List α) (h : Nodup l) (n : ℕ) (i : Fin l.length) :

--- a/Mathlib/GroupTheory/Solvable.lean
+++ b/Mathlib/GroupTheory/Solvable.lean
@@ -47,9 +47,9 @@ theorem derivedSeries_succ (n : ℕ) :
 
 -- Porting note: had to provide inductive hypothesis explicitly
 theorem derivedSeries_normal (n : ℕ) : (derivedSeries G n).Normal := by
-  induction' n with n ih
-  · exact (⊤ : Subgroup G).normal_of_characteristic
-  · exact @Subgroup.commutator_normal G _ (derivedSeries G n) (derivedSeries G n) ih ih
+  induction n with
+  | zero => exact (⊤ : Subgroup G).normal_of_characteristic
+  | succ n ih => exact @Subgroup.commutator_normal G _ (derivedSeries G n) (derivedSeries G n) ih ih
 
 -- Porting note: higher simp priority to restore Lean 3 behavior
 @[simp 1100]

--- a/Mathlib/NumberTheory/Padics/PadicVal.lean
+++ b/Mathlib/NumberTheory/Padics/PadicVal.lean
@@ -639,12 +639,12 @@ theorem padicValNat_factorial_mul_add {n : ℕ} (m : ℕ) [hp : Fact p.Prime] (h
   induction n with
   | zero => rw [add_zero]
   | succ n hn =>
-      rw [add_succ, factorial_succ,
-          padicValNat.mul (succ_ne_zero (p * m + n)) <| factorial_ne_zero (p * m + _),
-          hn <| lt_of_succ_lt h, ← add_succ,
-          padicValNat_eq_zero_of_mem_Ioo ⟨(Nat.lt_add_of_pos_right <| succ_pos n),
-            (Nat.mul_add _ _ _▸ Nat.mul_one _ ▸ ((add_lt_add_iff_left (p * m)).mpr h))⟩,
-          zero_add]
+    rw [add_succ, factorial_succ,
+      padicValNat.mul (succ_ne_zero (p * m + n)) <| factorial_ne_zero (p * m + _),
+      hn <| lt_of_succ_lt h, ← add_succ,
+      padicValNat_eq_zero_of_mem_Ioo ⟨(Nat.lt_add_of_pos_right <| succ_pos n),
+        (Nat.mul_add _ _ _▸ Nat.mul_one _ ▸ ((add_lt_add_iff_left (p * m)).mpr h))⟩,
+      zero_add]
 
 /-- The `p`-adic valuation of `n!` is equal to the `p`-adic valuation of the factorial of the
 largest multiple of `p` below `n`, i.e. `(p * ⌊n / p⌋)!`. -/

--- a/Mathlib/NumberTheory/Padics/PadicVal.lean
+++ b/Mathlib/NumberTheory/Padics/PadicVal.lean
@@ -635,15 +635,17 @@ theorem padicValNat_eq_zero_of_mem_Ioo {m k : ℕ}
   padicValNat.eq_zero_of_not_dvd <| not_dvd_of_between_consec_multiples hm.1 hm.2
 
 theorem padicValNat_factorial_mul_add {n : ℕ} (m : ℕ) [hp : Fact p.Prime] (h : n < p) :
+theorem padicValNat_factorial_mul_add {n : ℕ} (m : ℕ) [hp : Fact p.Prime] (h : n < p) :
     padicValNat p (p * m + n) ! = padicValNat p (p * m) ! := by
-  induction' n with n hn
-  · rw [add_zero]
-  · rw [add_succ, factorial_succ,
-      padicValNat.mul (succ_ne_zero (p * m + n)) <| factorial_ne_zero (p * m + _),
-      hn <| lt_of_succ_lt h, ← add_succ,
-      padicValNat_eq_zero_of_mem_Ioo ⟨(Nat.lt_add_of_pos_right <| succ_pos n),
-        (Nat.mul_add _ _ _▸ Nat.mul_one _ ▸ ((add_lt_add_iff_left (p * m)).mpr h))⟩,
-      zero_add]
+  induction n with
+  | zero => rw [add_zero]
+  | succ n hn =>
+      rw [add_succ, factorial_succ,
+          padicValNat.mul (succ_ne_zero (p * m + n)) <| factorial_ne_zero (p * m + _),
+          hn <| lt_of_succ_lt h, ← add_succ,
+          padicValNat_eq_zero_of_mem_Ioo ⟨(Nat.lt_add_of_pos_right <| succ_pos n),
+            (Nat.mul_add _ _ _▸ Nat.mul_one _ ▸ ((add_lt_add_iff_left (p * m)).mpr h))⟩,
+          zero_add]
 
 /-- The `p`-adic valuation of `n!` is equal to the `p`-adic valuation of the factorial of the
 largest multiple of `p` below `n`, i.e. `(p * ⌊n / p⌋)!`. -/

--- a/Mathlib/NumberTheory/Padics/PadicVal.lean
+++ b/Mathlib/NumberTheory/Padics/PadicVal.lean
@@ -635,7 +635,6 @@ theorem padicValNat_eq_zero_of_mem_Ioo {m k : ℕ}
   padicValNat.eq_zero_of_not_dvd <| not_dvd_of_between_consec_multiples hm.1 hm.2
 
 theorem padicValNat_factorial_mul_add {n : ℕ} (m : ℕ) [hp : Fact p.Prime] (h : n < p) :
-theorem padicValNat_factorial_mul_add {n : ℕ} (m : ℕ) [hp : Fact p.Prime] (h : n < p) :
     padicValNat p (p * m + n) ! = padicValNat p (p * m) ! := by
   induction n with
   | zero => rw [add_zero]

--- a/Mathlib/RingTheory/Binomial.lean
+++ b/Mathlib/RingTheory/Binomial.lean
@@ -171,9 +171,9 @@ theorem ascPochhammer_smeval_cast (R : Type*) [Semiring R] {S : Type*} [NonAssoc
   induction n with
   | zero => simp only [Nat.zero_eq, ascPochhammer_zero, smeval_one, one_smul]
   | succ n hn =>
-      simp only [ascPochhammer_succ_right, mul_add, smeval_add, smeval_mul_X, ← Nat.cast_comm]
-      simp only [← C_eq_natCast, smeval_C_mul, hn, Nat.cast_smul_eq_nsmul R n]
-      simp only [nsmul_eq_mul, Nat.cast_id]
+    simp only [ascPochhammer_succ_right, mul_add, smeval_add, smeval_mul_X, ← Nat.cast_comm]
+    simp only [← C_eq_natCast, smeval_C_mul, hn, Nat.cast_smul_eq_nsmul R n]
+    simp only [nsmul_eq_mul, Nat.cast_id]
 
 variable {R S : Type*}
 

--- a/Mathlib/RingTheory/Binomial.lean
+++ b/Mathlib/RingTheory/Binomial.lean
@@ -168,11 +168,12 @@ namespace Polynomial
 theorem ascPochhammer_smeval_cast (R : Type*) [Semiring R] {S : Type*} [NonAssocSemiring S]
     [Pow S ℕ] [Module R S] [IsScalarTower R S S] [NatPowAssoc S]
     (x : S) (n : ℕ) : (ascPochhammer R n).smeval x = (ascPochhammer ℕ n).smeval x := by
-  induction' n with n hn
-  · simp only [Nat.zero_eq, ascPochhammer_zero, smeval_one, one_smul]
-  · simp only [ascPochhammer_succ_right, mul_add, smeval_add, smeval_mul_X, ← Nat.cast_comm]
-    simp only [← C_eq_natCast, smeval_C_mul, hn, Nat.cast_smul_eq_nsmul R n]
-    simp only [nsmul_eq_mul, Nat.cast_id]
+  induction n with
+  | zero => simp only [Nat.zero_eq, ascPochhammer_zero, smeval_one, one_smul]
+  | succ n hn =>
+      simp only [ascPochhammer_succ_right, mul_add, smeval_add, smeval_mul_X, ← Nat.cast_comm]
+      simp only [← C_eq_natCast, smeval_C_mul, hn, Nat.cast_smul_eq_nsmul R n]
+      simp only [nsmul_eq_mul, Nat.cast_id]
 
 variable {R S : Type*}
 


### PR DESCRIPTION
This PR substitutes the (soon to be deprecated) `induction'` with `induction`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
