### PR TITLE
[Merged by Bors] - feat(GroupTheory/Index): `exists_pow_mem_of_index_ne_zero`

### DIFF
--- a/Mathlib/GroupTheory/Index.lean
+++ b/Mathlib/GroupTheory/Index.lean
@@ -397,6 +397,56 @@ lemma finite_quotient_of_pretransitive_of_index_ne_zero {X : Type*} [MulAction G
   have := (MulAction.pretransitive_iff_subsingleton_quotient G X).1 inferInstance
   exact finite_quotient_of_finite_quotient_of_index_ne_zero hi
 
+@[to_additive]
+lemma exists_pow_mem_of_index_ne_zero (h : H.index ≠ 0) (a : G) :
+    ∃ n, 0 < n ∧ n ≤ H.index ∧ a ^ n ∈ H := by
+  suffices ∃ n₁ n₂, n₁ < n₂ ∧ n₂ ≤ H.index ∧ ((a ^ n₂ : G) : G ⧸ H) = ((a ^ n₁ : G) : G ⧸ H) by
+    rcases this with ⟨n₁, n₂, hlt, hle, he⟩
+    refine ⟨n₂ - n₁, by omega, by omega, ?_⟩
+    rw [eq_comm, QuotientGroup.eq, ← zpow_natCast, ← zpow_natCast, ← zpow_neg, ← zpow_add,
+        add_comm] at he
+    rw [← zpow_natCast]
+    convert he
+    omega
+  suffices ∃ n₁ n₂, n₁ ≠ n₂ ∧ n₁ ≤ H.index ∧ n₂ ≤ H.index ∧
+      ((a ^ n₂ : G) : G ⧸ H) = ((a ^ n₁ : G) : G ⧸ H) by
+    rcases this with ⟨n₁, n₂, hne, hle₁, hle₂, he⟩
+    rcases hne.lt_or_lt with hlt | hlt
+    · exact ⟨n₁, n₂, hlt, hle₂, he⟩
+    · exact ⟨n₂, n₁, hlt, hle₁, he.symm⟩
+  by_contra hc
+  simp_rw [not_exists] at hc
+  let f : (Set.Icc 0 H.index) → G ⧸ H := fun n ↦ (a ^ (n : ℕ) : G)
+  have hf : Function.Injective f := by
+    rintro ⟨n₁, h₁, hle₁⟩ ⟨n₂, h₂, hle₂⟩ he
+    have hc' := hc n₁ n₂
+    dsimp only [f] at he
+    simpa [hle₁, hle₂, he] using hc'
+  have := (fintypeOfIndexNeZero h).finite
+  have hcard := Finite.card_le_of_injective f hf
+  simp [← index_eq_card] at hcard
+
+@[to_additive]
+lemma exists_pow_mem_of_relindex_ne_zero (h : H.relindex K ≠ 0) {a : G} (ha : a ∈ K) :
+    ∃ n, 0 < n ∧ n ≤ H.relindex K ∧ a ^ n ∈ H ⊓ K := by
+  rcases exists_pow_mem_of_index_ne_zero h ⟨a, ha⟩ with ⟨n, hlt, hle, he⟩
+  refine ⟨n, hlt, hle, ?_⟩
+  simpa [pow_mem ha, mem_subgroupOf] using he
+
+@[to_additive]
+lemma pow_mem_of_index_ne_zero_of_dvd (h : H.index ≠ 0) (a : G) {n : ℕ}
+    (hn : ∀ m, 0 < m → m ≤ H.index → m ∣ n) : a ^ n ∈ H := by
+  rcases exists_pow_mem_of_index_ne_zero h a with ⟨m, hlt, hle, he⟩
+  rcases hn m hlt hle with ⟨k, rfl⟩
+  rw [pow_mul]
+  exact pow_mem he _
+
+@[to_additive]
+lemma pow_mem_of_relindex_ne_zero_of_dvd (h : H.relindex K ≠ 0) {a : G} (ha : a ∈ K) {n : ℕ}
+    (hn : ∀ m, 0 < m → m ≤ H.relindex K → m ∣ n) : a ^ n ∈ H ⊓ K := by
+  convert pow_mem_of_index_ne_zero_of_dvd h ⟨a, ha⟩ hn
+  simp [pow_mem ha, mem_subgroupOf]
+
 section FiniteIndex
 
 variable (H K)


### PR DESCRIPTION
Add the lemma

```lean
@[to_additive]
lemma exists_pow_mem_of_index_ne_zero (h : H.index ≠ 0) (a : G) :
    ∃ n, 0 < n ∧ n ≤ H.index ∧ a ^ n ∈ H := by
```

and three similar lemmas.  These are essentially more general versions of `sq_mem_of_index_two` for arbitrary finite index.

From AperiodicMonotilesLean.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
