### PR TITLE
[Merged by Bors] - feat(NumberTheory/JacobiSum/Basic): add file (def., basic API)

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -3334,6 +3334,7 @@ import Mathlib.NumberTheory.Harmonic.EulerMascheroni
 import Mathlib.NumberTheory.Harmonic.GammaDeriv
 import Mathlib.NumberTheory.Harmonic.Int
 import Mathlib.NumberTheory.Harmonic.ZetaAsymp
+import Mathlib.NumberTheory.JacobiSum.Basic
 import Mathlib.NumberTheory.KummerDedekind
 import Mathlib.NumberTheory.LSeries.AbstractFuncEq
 import Mathlib.NumberTheory.LSeries.Basic

--- a/Mathlib/NumberTheory/JacobiSum/Basic.lean
+++ b/Mathlib/NumberTheory/JacobiSum/Basic.lean
@@ -1,0 +1,120 @@
+/-
+Copyright (c) 2024 Michael Stoll. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Michael Stoll
+-/
+import Mathlib.NumberTheory.MulChar.Basic
+import Mathlib.Algebra.Module.BigOperators
+
+/-!
+# Jacobi Sums
+
+This file defines the *Jacobi sum* of two multiplicative characters `χ` and `ψ` on a finite
+commutative ring `R` with values in another commutative ring `R'`:
+
+`jacobiSum χ ψ = ∑ x : R, χ x * ψ (1 - x)`
+
+(see `jacobiSum`) and provides some basic results and API lemmas on Jacobi sums.
+
+## References
+
+We essentially follow
+* [K. Ireland, M. Rosen, *A classical introduction to modern number theory*
+   (Section 8.3)][IrelandRosen1990]
+
+but generalize where appropriate.
+
+This is based on Lean code written as part of the bachelor's thesis of Alexander Spahl.
+-/
+
+open BigOperators Finset
+
+/-!
+### Jacobi sums: definition and first properties
+-/
+
+section Def
+
+namespace Finset
+
+-- Is this useful enough to be non-private?
+private lemma sum_eq_sum_one_sub {R M : Type*} [Ring R] [Fintype R] [AddCommMonoid M] (f : R → M) :
+    Finset.sum univ f = Finset.sum univ fun x ↦ f (1 - x) := by
+  refine Fintype.sum_bijective (1 - ·) (Function.Involutive.bijective ?_) _ _ fun x ↦ ?_
+  · simp only [Function.Involutive, sub_sub_cancel, implies_true]
+  · simp only [sub_sub_cancel]
+
+end Finset
+
+-- need `Fintype` instead of `Finite` for `Finset.sum` etc.
+variable {R R' : Type*} [CommRing R] [Fintype R] [CommRing R']
+
+/- The *Jacobi sum* of two multiplicative characters on a finite commutative ring. -/
+def jacobiSum (χ ψ : MulChar R R') : R' :=
+  ∑ x : R, χ x * ψ (1 - x)
+
+lemma jacobiSum_comm (χ ψ : MulChar R R') : jacobiSum χ ψ = jacobiSum ψ χ := by
+  simp only [jacobiSum]
+  convert sum_eq_sum_one_sub fun x ↦ χ x * ψ (1 - x) using 2 with x
+  simp only [mul_comm, sub_sub_cancel]
+
+/-- The Jacobi sum is compatible with ring homomorphisms. -/
+lemma jacobiSum_ringHomComp {R'' : Type*} [CommRing R''] (χ ψ : MulChar R R') (f : R' →+* R'') :
+    jacobiSum (χ.ringHomComp f) (ψ.ringHomComp f) = f (jacobiSum χ ψ) := by
+  simp only [jacobiSum, MulChar.ringHomComp, MulChar.coe_mk, MonoidHom.coe_mk, OneHom.coe_mk,
+    map_sum, map_mul]
+
+end Def
+
+/-!
+### Jacobi sums over finite fields
+-/
+
+section FiniteField
+
+variable {F R : Type*} [Field F] [Fintype F] [DecidableEq F] [CommRing R]
+
+/-- The Jacobi sum of two multiplicative characters on a finite field `F` can be written
+as a sum over `F \ {0,1}`. -/
+lemma jacobiSum_eq_sum_sdiff (χ ψ : MulChar F R) :
+    jacobiSum χ ψ = ∑ x ∈ univ \ {0,1}, χ x * ψ (1 - x) := by
+  simp only [jacobiSum, subset_univ, sum_sdiff_eq_sub, mem_singleton, zero_ne_one,
+    not_false_eq_true, sum_insert, isUnit_iff_ne_zero, ne_eq, not_true_eq_false,
+    MulCharClass.map_nonunit, sub_zero, map_one, mul_one, sum_singleton, sub_self, mul_zero,
+    add_zero]
+
+private lemma jacobiSum_eq_aux (χ ψ : MulChar F R) :
+    jacobiSum χ ψ = ∑ x : F, χ x + ∑ x : F, ψ x - Fintype.card F +
+                      ∑ x ∈ univ \ {0, 1}, (χ x - 1) * (ψ (1 - x) - 1) := by
+  rw [jacobiSum]
+  conv =>
+    enter [1, 2, x]
+    rw [show ∀ x y : R, x * y = x + y - 1 + (x - 1) * (y - 1) by intros; ring]
+  rw [sum_add_distrib, sum_sub_distrib, sum_add_distrib, ← sum_eq_sum_one_sub,
+    Fintype.card_eq_sum_ones, Nat.cast_sum, Nat.cast_one, sum_sdiff_eq_sub (subset_univ _),
+    ← sub_zero (_ - _ + _), add_sub_assoc]
+  congr
+  rw [sum_pair zero_ne_one, sub_zero, ψ.map_one, χ.map_one, sub_self, mul_zero, zero_mul, add_zero]
+
+/-- If `1` is the trivial multiplicative character on a finite field `F`, then `J(1,1) = #F-2`. -/
+theorem jacobiSum_triv_triv : jacobiSum (1 : MulChar F R) 1 = Fintype.card F - 2 := by
+  rw [show 1 = MulChar.trivial F R from rfl, jacobiSum_eq_sum_sdiff]
+  have : ∀ x ∈ univ \ {0, 1}, (MulChar.trivial F R) x * (MulChar.trivial F R) (1 - x) = 1 := by
+    intros x hx
+    have hx' : IsUnit (x * (1 - x)) := by
+      simp only [mem_sdiff, mem_univ, mem_insert, mem_singleton, not_or, ← ne_eq, true_and] at hx
+      simp only [isUnit_iff_ne_zero]
+      exact mul_ne_zero hx.1 <| sub_ne_zero.mpr hx.2.symm
+    rw [← map_mul, MulChar.trivial_apply, if_pos hx']
+  calc ∑ x ∈ univ \ {0, 1}, (MulChar.trivial F R) x * (MulChar.trivial F R) (1 - x)
+  _ = ∑ _ ∈ @univ F _ \ {0, 1}, (1 : R) := sum_congr rfl this
+  _ = Finset.card (@univ F _ \ {0, 1}) := (cast_card _).symm
+  _ = Fintype.card F - 2 := by
+    rw [card_sdiff (subset_univ _), card_univ, card_pair zero_ne_one]
+    obtain ⟨m, hm⟩ : ∃ m : ℕ, Fintype.card F = 1 + m + 1 :=
+      Nat.exists_eq_add_of_lt Fintype.one_lt_card
+    rw [show 1 + m + 1 = m + 2 by ring] at hm
+    simp only [hm, add_tsub_cancel_right (α := ℕ), Nat.cast_add, Nat.cast_ofNat,
+      add_sub_cancel_right]
+
+end FiniteField

--- a/Mathlib/NumberTheory/JacobiSum/Basic.lean
+++ b/Mathlib/NumberTheory/JacobiSum/Basic.lean
@@ -49,7 +49,7 @@ end Finset
 -- need `Fintype` instead of `Finite` for `Finset.sum` etc.
 variable {R R' : Type*} [CommRing R] [Fintype R] [CommRing R']
 
-/- The *Jacobi sum* of two multiplicative characters on a finite commutative ring. -/
+/-- The *Jacobi sum* of two multiplicative characters on a finite commutative ring. -/
 def jacobiSum (χ ψ : MulChar R R') : R' :=
   ∑ x : R, χ x * ψ (1 - x)
 

--- a/Mathlib/NumberTheory/JacobiSum/Basic.lean
+++ b/Mathlib/NumberTheory/JacobiSum/Basic.lean
@@ -100,12 +100,8 @@ theorem jacobiSum_trivial_trivial :
   _ = ∑ _ ∈ univ \ {0, 1}, 1 := sum_congr rfl this
   _ = Finset.card (univ \ {0, 1}) := (cast_card _).symm
   _ = Fintype.card F - 2 := by
-    rw [card_sdiff (subset_univ _), card_univ, card_pair zero_ne_one]
-    obtain ⟨m, hm⟩ : ∃ m : ℕ, Fintype.card F = 1 + m + 1 :=
-      Nat.exists_eq_add_of_lt Fintype.one_lt_card
-    rw [show 1 + m + 1 = m + 2 by ring] at hm
-    simp only [hm, add_tsub_cancel_right (α := ℕ), Nat.cast_add, Nat.cast_ofNat,
-      add_sub_cancel_right]
+    rw [card_sdiff (subset_univ _), card_univ, card_pair zero_ne_one,
+      Nat.cast_sub <| Nat.add_one_le_of_lt Fintype.one_lt_card, Nat.cast_two]
 
 /-- If `1` is the trivial multiplicative character on a finite field `F`, then `J(1,1) = #F-2`. -/
 theorem jacobiSum_one_one : jacobiSum (1 : MulChar F R) 1 = Fintype.card F - 2 :=

--- a/Mathlib/NumberTheory/JacobiSum/Basic.lean
+++ b/Mathlib/NumberTheory/JacobiSum/Basic.lean
@@ -35,16 +35,12 @@ open BigOperators Finset
 
 section Def
 
-namespace Finset
-
 -- Is this useful enough to be non-private?
-private lemma sum_eq_sum_one_sub {R M : Type*} [Ring R] [Fintype R] [AddCommMonoid M] (f : R → M) :
-    Finset.sum univ f = Finset.sum univ fun x ↦ f (1 - x) := by
-  refine Fintype.sum_bijective (1 - ·) (Function.Involutive.bijective ?_) _ _ fun x ↦ ?_
-  · simp only [Function.Involutive, sub_sub_cancel, implies_true]
-  · simp only [sub_sub_cancel]
-
-end Finset
+private
+lemma Finset.sum_one_sub_eq_sum {R M : Type*} [Ring R] [Fintype R] [AddCommMonoid M] (f : R → M) :
+    Finset.sum univ (fun x ↦ f (1 - x)) = Finset.sum univ f := by
+  refine Fintype.sum_bijective (1 - ·) (Function.Involutive.bijective ?_) _ _ fun _ ↦ rfl
+  simp only [Function.Involutive, sub_sub_cancel, implies_true]
 
 -- need `Fintype` instead of `Finite` for `Finset.sum` etc.
 variable {R R' : Type*} [CommRing R] [Fintype R] [CommRing R']
@@ -55,7 +51,7 @@ def jacobiSum (χ ψ : MulChar R R') : R' :=
 
 lemma jacobiSum_comm (χ ψ : MulChar R R') : jacobiSum χ ψ = jacobiSum ψ χ := by
   simp only [jacobiSum]
-  convert sum_eq_sum_one_sub fun x ↦ χ x * ψ (1 - x) using 2 with x
+  convert (sum_one_sub_eq_sum fun x ↦ χ x * ψ (1 - x)).symm using 2 with x
   simp only [mul_comm, sub_sub_cancel]
 
 /-- The Jacobi sum is compatible with ring homomorphisms. -/
@@ -90,7 +86,7 @@ private lemma jacobiSum_eq_aux (χ ψ : MulChar F R) :
   conv =>
     enter [1, 2, x]
     rw [show ∀ x y : R, x * y = x + y - 1 + (x - 1) * (y - 1) by intros; ring]
-  rw [sum_add_distrib, sum_sub_distrib, sum_add_distrib, ← sum_eq_sum_one_sub,
+  rw [sum_add_distrib, sum_sub_distrib, sum_add_distrib, sum_one_sub_eq_sum,
     Fintype.card_eq_sum_ones, Nat.cast_sum, Nat.cast_one, sum_sdiff_eq_sub (subset_univ _),
     ← sub_zero (_ - _ + _), add_sub_assoc]
   congr

--- a/Mathlib/NumberTheory/JacobiSum/Basic.lean
+++ b/Mathlib/NumberTheory/JacobiSum/Basic.lean
@@ -87,7 +87,7 @@ private lemma jacobiSum_eq_aux (χ ψ : MulChar F R) :
   rw [sum_pair zero_ne_one, sub_zero, ψ.map_one, χ.map_one, sub_self, mul_zero, zero_mul, add_zero]
 
 /-- If `1` is the trivial multiplicative character on a finite field `F`, then `J(1,1) = #F-2`. -/
-theorem jacobiSum_triv_triv : jacobiSum (1 : MulChar F R) 1 = Fintype.card F - 2 := by
+theorem jacobiSum_one_one : jacobiSum (1 : MulChar F R) 1 = Fintype.card F - 2 := by
   rw [show 1 = MulChar.trivial F R from rfl, jacobiSum_eq_sum_sdiff]
   have : ∀ x ∈ univ \ {0, 1}, (MulChar.trivial F R) x * (MulChar.trivial F R) (1 - x) = 1 := by
     intros x hx
@@ -106,5 +106,11 @@ theorem jacobiSum_triv_triv : jacobiSum (1 : MulChar F R) 1 = Fintype.card F - 2
     rw [show 1 + m + 1 = m + 2 by ring] at hm
     simp only [hm, add_tsub_cancel_right (α := ℕ), Nat.cast_add, Nat.cast_ofNat,
       add_sub_cancel_right]
+
+/-- The Jacobi sum of twice the trivial multiplicative character on a finite field `F`
+equals `#F-2`. -/
+theorem jacobiSum_trivial_trivial :
+    jacobiSum (MulChar.trivial F R) (MulChar.trivial F R) = Fintype.card F - 2 :=
+  jacobiSum_one_one ..
 
 end FiniteField

--- a/Mathlib/NumberTheory/JacobiSum/Basic.lean
+++ b/Mathlib/NumberTheory/JacobiSum/Basic.lean
@@ -86,16 +86,16 @@ private lemma jacobiSum_eq_aux (χ ψ : MulChar F R) :
   congr
   rw [sum_pair zero_ne_one, sub_zero, ψ.map_one, χ.map_one, sub_self, mul_zero, zero_mul, add_zero]
 
-/-- If `1` is the trivial multiplicative character on a finite field `F`, then `J(1,1) = #F-2`. -/
-theorem jacobiSum_one_one : jacobiSum (1 : MulChar F R) 1 = Fintype.card F - 2 := by
-  rw [show 1 = MulChar.trivial F R from rfl, jacobiSum_eq_sum_sdiff]
+/-- The Jacobi sum of twice the trivial multiplicative character on a finite field `F`
+equals `#F-2`. -/
+theorem jacobiSum_trivial_trivial :
+    jacobiSum (MulChar.trivial F R) (MulChar.trivial F R) = Fintype.card F - 2 := by
+  rw [jacobiSum_eq_sum_sdiff]
   have : ∀ x ∈ univ \ {0, 1}, (MulChar.trivial F R) x * (MulChar.trivial F R) (1 - x) = 1 := by
     intros x hx
-    have hx' : IsUnit (x * (1 - x)) := by
-      simp only [mem_sdiff, mem_univ, mem_insert, mem_singleton, not_or, ← ne_eq, true_and] at hx
-      simp only [isUnit_iff_ne_zero]
-      exact mul_ne_zero hx.1 <| sub_ne_zero.mpr hx.2.symm
-    rw [← map_mul, MulChar.trivial_apply, if_pos hx']
+    rw [← map_mul, MulChar.trivial_apply, if_pos]
+    simp only [mem_sdiff, mem_univ, mem_insert, mem_singleton, not_or, ← ne_eq, true_and] at hx
+    simpa only [isUnit_iff_ne_zero, mul_ne_zero_iff, ne_eq, sub_eq_zero, @eq_comm _ _ x] using hx
   calc ∑ x ∈ univ \ {0, 1}, (MulChar.trivial F R) x * (MulChar.trivial F R) (1 - x)
   _ = ∑ _ ∈ univ \ {0, 1}, 1 := sum_congr rfl this
   _ = Finset.card (univ \ {0, 1}) := (cast_card _).symm
@@ -107,10 +107,8 @@ theorem jacobiSum_one_one : jacobiSum (1 : MulChar F R) 1 = Fintype.card F - 2 :
     simp only [hm, add_tsub_cancel_right (α := ℕ), Nat.cast_add, Nat.cast_ofNat,
       add_sub_cancel_right]
 
-/-- The Jacobi sum of twice the trivial multiplicative character on a finite field `F`
-equals `#F-2`. -/
-theorem jacobiSum_trivial_trivial :
-    jacobiSum (MulChar.trivial F R) (MulChar.trivial F R) = Fintype.card F - 2 :=
-  jacobiSum_one_one ..
+/-- If `1` is the trivial multiplicative character on a finite field `F`, then `J(1,1) = #F-2`. -/
+theorem jacobiSum_one_one : jacobiSum (1 : MulChar F R) 1 = Fintype.card F - 2 :=
+  jacobiSum_trivial_trivial
 
 end FiniteField

--- a/Mathlib/NumberTheory/JacobiSum/Basic.lean
+++ b/Mathlib/NumberTheory/JacobiSum/Basic.lean
@@ -50,9 +50,9 @@ def jacobiSum (χ ψ : MulChar R R') : R' :=
   ∑ x : R, χ x * ψ (1 - x)
 
 lemma jacobiSum_comm (χ ψ : MulChar R R') : jacobiSum χ ψ = jacobiSum ψ χ := by
-  simp only [jacobiSum]
-  convert (sum_one_sub_eq_sum fun x ↦ χ x * ψ (1 - x)).symm using 2 with x
-  simp only [mul_comm, sub_sub_cancel]
+  simp only [jacobiSum, mul_comm (χ _)]
+  rw [← sum_one_sub_eq_sum]
+  simp only [sub_sub_cancel]
 
 /-- The Jacobi sum is compatible with ring homomorphisms. -/
 lemma jacobiSum_ringHomComp {R'' : Type*} [CommRing R''] (χ ψ : MulChar R R') (f : R' →+* R'') :

--- a/Mathlib/NumberTheory/JacobiSum/Basic.lean
+++ b/Mathlib/NumberTheory/JacobiSum/Basic.lean
@@ -103,8 +103,8 @@ theorem jacobiSum_triv_triv : jacobiSum (1 : MulChar F R) 1 = Fintype.card F - 2
       exact mul_ne_zero hx.1 <| sub_ne_zero.mpr hx.2.symm
     rw [← map_mul, MulChar.trivial_apply, if_pos hx']
   calc ∑ x ∈ univ \ {0, 1}, (MulChar.trivial F R) x * (MulChar.trivial F R) (1 - x)
-  _ = ∑ _ ∈ @univ F _ \ {0, 1}, (1 : R) := sum_congr rfl this
-  _ = Finset.card (@univ F _ \ {0, 1}) := (cast_card _).symm
+  _ = ∑ _ ∈ univ \ {0, 1}, 1 := sum_congr rfl this
+  _ = Finset.card (univ \ {0, 1}) := (cast_card _).symm
   _ = Fintype.card F - 2 := by
     rw [card_sdiff (subset_univ _), card_univ, card_pair zero_ne_one]
     obtain ⟨m, hm⟩ : ∃ m : ℕ, Fintype.card F = 1 + m + 1 :=

--- a/Mathlib/NumberTheory/JacobiSum/Basic.lean
+++ b/Mathlib/NumberTheory/JacobiSum/Basic.lean
@@ -35,14 +35,7 @@ open BigOperators Finset
 
 section Def
 
--- Is this useful enough to be non-private?
-private
-lemma Finset.sum_one_sub_eq_sum {R M : Type*} [Ring R] [Fintype R] [AddCommMonoid M] (f : R → M) :
-    Finset.sum univ (fun x ↦ f (1 - x)) = Finset.sum univ f := by
-  refine Fintype.sum_bijective (1 - ·) (Function.Involutive.bijective ?_) _ _ fun _ ↦ rfl
-  simp only [Function.Involutive, sub_sub_cancel, implies_true]
-
--- need `Fintype` instead of `Finite` for `Finset.sum` etc.
+-- need `Fintype` instead of `Finite` to make `jacobiSum` computable.
 variable {R R' : Type*} [CommRing R] [Fintype R] [CommRing R']
 
 /-- The *Jacobi sum* of two multiplicative characters on a finite commutative ring. -/
@@ -51,8 +44,8 @@ def jacobiSum (χ ψ : MulChar R R') : R' :=
 
 lemma jacobiSum_comm (χ ψ : MulChar R R') : jacobiSum χ ψ = jacobiSum ψ χ := by
   simp only [jacobiSum, mul_comm (χ _)]
-  rw [← sum_one_sub_eq_sum]
-  simp only [sub_sub_cancel]
+  rw [← (Equiv.subLeft 1).sum_comp]
+  simp only [Equiv.subLeft_apply, sub_sub_cancel]
 
 /-- The Jacobi sum is compatible with ring homomorphisms. -/
 lemma jacobiSum_ringHomComp {R'' : Type*} [CommRing R''] (χ ψ : MulChar R R') (f : R' →+* R'') :
@@ -86,9 +79,10 @@ private lemma jacobiSum_eq_aux (χ ψ : MulChar F R) :
   conv =>
     enter [1, 2, x]
     rw [show ∀ x y : R, x * y = x + y - 1 + (x - 1) * (y - 1) by intros; ring]
-  rw [sum_add_distrib, sum_sub_distrib, sum_add_distrib, sum_one_sub_eq_sum,
-    Fintype.card_eq_sum_ones, Nat.cast_sum, Nat.cast_one, sum_sdiff_eq_sub (subset_univ _),
-    ← sub_zero (_ - _ + _), add_sub_assoc]
+  rw [sum_add_distrib, sum_sub_distrib, sum_add_distrib]
+  conv => enter [1, 1, 1, 2, 2, x]; rw [← Equiv.subLeft_apply 1]
+  rw [(Equiv.subLeft 1).sum_comp ψ, Fintype.card_eq_sum_ones, Nat.cast_sum, Nat.cast_one,
+    sum_sdiff_eq_sub (subset_univ _), ← sub_zero (_ - _ + _), add_sub_assoc]
   congr
   rw [sum_pair zero_ne_one, sub_zero, ψ.map_one, χ.map_one, sub_self, mul_zero, zero_mul, add_zero]
 


### PR DESCRIPTION
This adds a new folder `NumberTheory/JacobiSum` and a first file `Basic.lean` in it, which defines the *Jacobi sum* of two multiplicative characters (on a finite commutative ring with values in another commutative ring) and provides some first results.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
