### PR TITLE
[Merged by Bors] - chore: protect TensorProduct.{map_one, map_mul}

### DIFF
--- a/Mathlib/LinearAlgebra/TensorProduct/Basic.lean
+++ b/Mathlib/LinearAlgebra/TensorProduct/Basic.lean
@@ -827,10 +827,10 @@ theorem map_id : map (id : M →ₗ[R] M) (id : N →ₗ[R] N) = .id := by
   simp only [mk_apply, id_coe, compr₂_apply, _root_.id, map_tmul]
 
 @[simp]
-theorem map_one : map (1 : M →ₗ[R] M) (1 : N →ₗ[R] N) = 1 :=
+protected theorem map_one : map (1 : M →ₗ[R] M) (1 : N →ₗ[R] N) = 1 :=
   map_id
 
-theorem map_mul (f₁ f₂ : M →ₗ[R] M) (g₁ g₂ : N →ₗ[R] N) :
+protected theorem map_mul (f₁ f₂ : M →ₗ[R] M) (g₁ g₂ : N →ₗ[R] N) :
     map (f₁ * f₂) (g₁ * g₂) = map f₁ g₁ * map f₂ g₂ :=
   map_comp f₁ f₂ g₁ g₂
 
@@ -838,8 +838,8 @@ theorem map_mul (f₁ f₂ : M →ₗ[R] M) (g₁ g₂ : N →ₗ[R] N) :
 protected theorem map_pow (f : M →ₗ[R] M) (g : N →ₗ[R] N) (n : ℕ) :
     map f g ^ n = map (f ^ n) (g ^ n) := by
   induction' n with n ih
-  · simp only [Nat.zero_eq, pow_zero, map_one]
-  · simp only [pow_succ', ih, map_mul]
+  · simp only [pow_zero, TensorProduct.map_one]
+  · simp only [pow_succ', ih, TensorProduct.map_mul]
 
 theorem map_add_left (f₁ f₂ : M →ₗ[R] P) (g : N →ₗ[R] Q) :
     map (f₁ + f₂) g = map f₁ g + map f₂ g := by

--- a/Mathlib/LinearAlgebra/TensorProduct/Graded/Internal.lean
+++ b/Mathlib/LinearAlgebra/TensorProduct/Graded/Internal.lean
@@ -307,7 +307,7 @@ def lift (f : A →ₐ[R] C) (g : B →ₐ[R] C)
       ∘ₗ ((of R 𝒜 ℬ).symm : 𝒜 ᵍ⊗[R] ℬ →ₗ[R] A ⊗[R] B))
     (by
       dsimp [Algebra.TensorProduct.one_def]
-      simp only [_root_.map_one, mul_one])
+      simp only [map_one, mul_one])
     (by
       rw [LinearMap.map_mul_iff]
       ext a₁ : 3
@@ -320,7 +320,7 @@ def lift (f : A →ₐ[R] C) (g : B →ₐ[R] C)
       rw [@Units.smul_def _ _ (_) (_), ← Int.cast_smul_eq_zsmul R, map_smul, map_smul, map_smul]
       rw [Int.cast_smul_eq_zsmul R, ← @Units.smul_def _ _ (_) (_)]
       rw [of_symm_of, map_tmul, LinearMap.mul'_apply]
-      simp_rw [AlgHom.toLinearMap_apply, _root_.map_mul]
+      simp_rw [AlgHom.toLinearMap_apply, map_mul]
       simp_rw [mul_assoc (f a₁), ← mul_assoc _ _ (g b₂), h_anti_commutes, mul_smul_comm,
         smul_mul_assoc, smul_smul, Int.units_mul_self, one_smul])
 
@@ -340,14 +340,14 @@ def liftEquiv :
   toFun fg := lift 𝒜 ℬ _ _ fg.prop
   invFun F := ⟨(F.comp (includeLeft 𝒜 ℬ), F.comp (includeRight 𝒜 ℬ)), fun i j a b => by
     dsimp
-    rw [← _root_.map_mul, ← _root_.map_mul F, tmul_coe_mul_coe_tmul, one_mul, mul_one,
-      AlgHom.map_smul_of_tower, tmul_one_mul_one_tmul, smul_smul, Int.units_mul_self, one_smul]⟩
-  left_inv fg := by ext <;> (dsimp; simp only [_root_.map_one, mul_one, one_mul])
+    rw [← map_mul, ← map_mul F, tmul_coe_mul_coe_tmul, one_mul, mul_one, AlgHom.map_smul_of_tower,
+      tmul_one_mul_one_tmul, smul_smul, Int.units_mul_self, one_smul]⟩
+  left_inv fg := by ext <;> (dsimp; simp only [map_one, mul_one, one_mul])
   right_inv F := by
     apply AlgHom.toLinearMap_injective
     ext
     dsimp
-    rw [← _root_.map_mul, tmul_one_mul_one_tmul]
+    rw [← map_mul, tmul_one_mul_one_tmul]
 
 /-- Two algebra morphism from the graded tensor product agree if their compositions with the left
 and right inclusions agree. -/

--- a/Mathlib/RepresentationTheory/Basic.lean
+++ b/Mathlib/RepresentationTheory/Basic.lean
@@ -371,8 +371,8 @@ tensor product `V ⊗[k] W`.
 -/
 noncomputable def tprod : Representation k G (V ⊗[k] W) where
   toFun g := TensorProduct.map (ρV g) (ρW g)
-  map_one' := by simp only [_root_.map_one, TensorProduct.map_one]
-  map_mul' g h := by simp only [_root_.map_mul, TensorProduct.map_mul]
+  map_one' := by simp only [map_one, TensorProduct.map_one]
+  map_mul' g h := by simp only [map_mul, TensorProduct.map_mul]
 
 local notation ρV " ⊗ " ρW => tprod ρV ρW
 

--- a/Mathlib/RingTheory/Bialgebra/Hom.lean
+++ b/Mathlib/RingTheory/Bialgebra/Hom.lean
@@ -67,7 +67,7 @@ instance (priority := 100) toAlgHomClass : AlgHomClass F R A B where
   map_add := map_add
   map_zero := map_zero
   commutes := fun c r => by
-    simp only [Algebra.algebraMap_eq_smul_one, map_smul, _root_.map_one]
+    simp only [Algebra.algebraMap_eq_smul_one, map_smul, map_one]
 
 /-- Turn an element of a type `F` satisfying `BialgHomClass F R A B` into an actual
 `BialgHom`. This is declared as the default coercion from `F` to `A →ₐc[R] B`. -/

--- a/Mathlib/RingTheory/Generators.lean
+++ b/Mathlib/RingTheory/Generators.lean
@@ -145,7 +145,7 @@ def localizationAway : Generators R S where
     letI n : ℕ := (IsLocalization.Away.sec r s).2
     C a * X () ^ n
   aeval_val_σ' s := by
-    rw [_root_.map_mul, algHom_C, map_pow, aeval_X]
+    rw [map_mul, algHom_C, map_pow, aeval_X]
     simp only [← IsLocalization.Away.sec_spec, map_pow, IsLocalization.Away.invSelf]
     rw [← IsLocalization.mk'_pow, one_pow, ← IsLocalization.mk'_one (M := Submonoid.powers r) S r]
     rw [← IsLocalization.mk'_pow, one_pow, mul_assoc, ← IsLocalization.mk'_mul]
@@ -168,9 +168,9 @@ def comp (Q : Generators S T) (P : Generators R S) : Generators R T where
     have (x : P.Ring) : aeval (algebraMap S T ∘ P.val) x = algebraMap S T (aeval P.val x) := by
       rw [map_aeval, aeval_def, coe_eval₂Hom, ← IsScalarTower.algebraMap_eq, Function.comp]
     conv_rhs => rw [← Q.aeval_val_σ s, ← (Q.σ s).sum_single]
-    simp only [map_finsupp_sum, _root_.map_mul, aeval_rename, Sum.elim_comp_inr, this, aeval_val_σ,
-      aeval_monomial, _root_.map_one, Finsupp.prod_mapDomain_index_inj Sum.inl_injective,
-      Sum.elim_inl, one_mul, single_eq_monomial]
+    simp only [map_finsupp_sum, map_mul, aeval_rename, Sum.elim_comp_inr, this, aeval_val_σ,
+      aeval_monomial, map_one, Finsupp.prod_mapDomain_index_inj Sum.inl_injective, Sum.elim_inl,
+      one_mul, single_eq_monomial]
 
 variable (S) in
 /-- If `R → S → T` is a tower of algebras, a family of generators `R[X] → T`
@@ -310,7 +310,7 @@ noncomputable def Hom.comp [IsScalarTower R' R'' S''] [IsScalarTower R' S' S'']
     induction g.val x using MvPolynomial.induction_on with
     | h_C r => simp [← IsScalarTower.algebraMap_apply]
     | h_add x y hx hy => simp only [map_add, hx, hy]
-    | h_X p i hp => simp only [_root_.map_mul, hp, aeval_X, aeval_val]
+    | h_X p i hp => simp only [map_mul, hp, aeval_X, aeval_val]
 
 @[simp]
 lemma Hom.comp_id [Algebra R S'] [IsScalarTower R R' S'] [IsScalarTower R S S'] (f : Hom P P') :
@@ -334,7 +334,7 @@ lemma Hom.toAlgHom_comp_apply
   induction x using MvPolynomial.induction_on with
   | h_C r => simp only [← MvPolynomial.algebraMap_eq, AlgHom.map_algebraMap]
   | h_add x y hx hy => simp only [map_add, hx, hy]
-  | h_X p i hp => simp only [_root_.map_mul, hp, toAlgHom_X, comp_val]; rfl
+  | h_X p i hp => simp only [map_mul, hp, toAlgHom_X, comp_val]; rfl
 
 variable {T} [CommRing T] [Algebra R T] [Algebra S T] [IsScalarTower R S T]
 
@@ -438,7 +438,7 @@ instance {R₁ R₂} [CommRing R₁] [CommRing R₂] [Algebra R₁ S] [Algebra R
   constructor
   intros r s m
   show algebraMap R₂ S (r • s) • m = (algebraMap _ S r) • (algebraMap _ S s) • m
-  rw [Algebra.smul_def, _root_.map_mul, mul_smul, ← IsScalarTower.algebraMap_apply]
+  rw [Algebra.smul_def, map_mul, mul_smul, ← IsScalarTower.algebraMap_apply]
 
 lemma Cotangent.val_smul''' {R₀} [CommRing R₀] [Algebra R₀ S] (r : R₀) (x : P.Cotangent) :
     (r • x).val = P.σ (algebraMap R₀ S r) • x.val := rfl
@@ -488,7 +488,7 @@ def Cotangent.map (f : Hom P P') : P.Cotangent →ₗ[S] P'.Cotangent where
       ← algebraMap_apply, algebraMap_smul, val_smul', val_of, ← (Ideal.toCotangent _).map_smul]
     congr 1
     ext1
-    simp only [SetLike.val_smul, smul_eq_mul, _root_.map_mul]
+    simp only [SetLike.val_smul, smul_eq_mul, map_mul]
 
 @[simp]
 lemma Cotangent.map_mk (f : Hom P P') (x) :

--- a/Mathlib/RingTheory/IsTensorProduct.lean
+++ b/Mathlib/RingTheory/IsTensorProduct.lean
@@ -213,10 +213,9 @@ noncomputable nonrec def IsBaseChange.equiv : S ⊗[R] M ≃ₗ[S] N :=
       · rw [smul_zero, map_zero, smul_zero]
       · intro x y
         -- porting note (#10745): was simp [smul_tmul', Algebra.ofId_apply]
-        simp only [Algebra.linearMap_apply, lift.tmul, smul_eq_mul,
-          LinearMap.mul_apply, LinearMap.smul_apply, IsTensorProduct.equiv_apply,
-          Module.algebraMap_end_apply, _root_.map_mul, smul_tmul', eq_self_iff_true,
-          LinearMap.coe_restrictScalars, LinearMap.flip_apply]
+        simp only [Algebra.linearMap_apply, lift.tmul, smul_eq_mul, LinearMap.mul_apply,
+          LinearMap.smul_apply, IsTensorProduct.equiv_apply, Module.algebraMap_end_apply, map_mul,
+          smul_tmul', eq_self_iff_true, LinearMap.coe_restrictScalars, LinearMap.flip_apply]
       · intro x y hx hy
         rw [map_add, smul_add, map_add, smul_add, hx, hy] }
 
@@ -353,8 +352,7 @@ theorem Algebra.IsPushout.symm (h : Algebra.IsPushout R S R' S') : Algebra.IsPus
     · intro x y
       simp only [smul_tmul', smul_eq_mul, TensorProduct.comm_tmul, smul_def,
         TensorProduct.algebraMap_apply, id.map_eq_id, RingHom.id_apply, TensorProduct.tmul_mul_tmul,
-        one_mul, h.1.equiv_tmul, AlgHom.toLinearMap_apply, _root_.map_mul,
-        IsScalarTower.coe_toAlgHom']
+        one_mul, h.1.equiv_tmul, AlgHom.toLinearMap_apply, map_mul, IsScalarTower.coe_toAlgHom']
       ring
     · intro x y hx hy
       rw [map_add, map_add, smul_add, map_add, map_add, hx, hy, smul_add]
@@ -399,7 +397,7 @@ noncomputable def Algebra.pushoutDesc [H : Algebra.IsPushout R S R' S'] {A : Typ
   have : ∀ x, H.out.lift g.toLinearMap (algebraMap R' S' x) = g x := H.out.lift_eq _
   refine AlgHom.ofLinearMap ((H.out.lift g.toLinearMap).restrictScalars R) ?_ ?_
   · dsimp only [LinearMap.restrictScalars_apply]
-    rw [← (algebraMap R' S').map_one, this, _root_.map_one]
+    rw [← (algebraMap R' S').map_one, this, map_one]
   · intro x y
     refine H.out.inductionOn x _ ?_ ?_ ?_ ?_
     · rw [zero_mul, map_zero, zero_mul]
@@ -417,7 +415,7 @@ noncomputable def Algebra.pushoutDesc [H : Algebra.IsPushout R S R' S'] {A : Typ
     · rw [mul_zero, map_zero, mul_zero]
     · intro y
       dsimp
-      rw [← _root_.map_mul, this, this, _root_.map_mul]
+      rw [← map_mul, this, this, map_mul]
     · intro s s' e
       rw [mul_comm, smul_mul_assoc, LinearMap.map_smul, LinearMap.map_smul, mul_comm, e]
       change f s * (g x * _) = g x * (f s * _)
@@ -435,7 +433,7 @@ theorem Algebra.pushoutDesc_left [H : Algebra.IsPushout R S R' S'] {A : Type*} [
         show f (r • s) * a = r • (f s * a) by rw [map_smul, smul_mul_assoc] }
   haveI : IsScalarTower S A A := { smul_assoc := fun r a b => mul_assoc _ _ _ }
   rw [Algebra.algebraMap_eq_smul_one, pushoutDesc_apply, map_smul, ←
-    Algebra.pushoutDesc_apply S' f g H, _root_.map_one]
+    Algebra.pushoutDesc_apply S' f g H, map_one]
   exact mul_one (f x)
 
 theorem Algebra.lift_algHom_comp_left [Algebra.IsPushout R S R' S'] {A : Type*} [Semiring A]
@@ -467,7 +465,7 @@ theorem Algebra.IsPushout.algHom_ext [H : Algebra.IsPushout R S R' S'] {A : Type
   · simp only [map_zero]
   · exact AlgHom.congr_fun h₁
   · intro s s' e
-    rw [Algebra.smul_def, _root_.map_mul, _root_.map_mul, e]
+    rw [Algebra.smul_def, map_mul, map_mul, e]
     congr 1
     exact (AlgHom.congr_fun h₂ s : _)
   · intro s₁ s₂ e₁ e₂

--- a/Mathlib/RingTheory/Kaehler/CotangentComplex.lean
+++ b/Mathlib/RingTheory/Kaehler/CotangentComplex.lean
@@ -111,7 +111,7 @@ lemma map_tmul (f : Hom P P') (x y) :
 lemma repr_map (f : Hom P P') (i j) :
     P'.cotangentSpaceBasis.repr (CotangentSpace.map f (P.cotangentSpaceBasis i)) j =
       aeval P'.val (pderiv j (f.val i)) := by
-  simp only [cotangentSpaceBasis_apply, map_tmul, _root_.map_one, Hom.toAlgHom_X,
+  simp only [cotangentSpaceBasis_apply, map_tmul, map_one, Hom.toAlgHom_X,
     cotangentSpaceBasis_repr_one_tmul]
 
 universe w'' u'' v''
@@ -129,7 +129,7 @@ lemma map_id :
     CotangentSpace.map (.id P) = LinearMap.id := by
   apply P.cotangentSpaceBasis.ext
   intro i
-  simp only [cotangentSpaceBasis_apply, map_tmul, _root_.map_one, Hom.toAlgHom_X, Hom.id_val,
+  simp only [cotangentSpaceBasis_apply, map_tmul, map_one, Hom.toAlgHom_X, Hom.id_val,
     LinearMap.id_coe, id_eq]
 
 lemma map_comp (f : Hom P P') (g : Hom P' P'') :
@@ -137,7 +137,7 @@ lemma map_comp (f : Hom P P') (g : Hom P' P'') :
       (CotangentSpace.map g).restrictScalars S ∘ₗ CotangentSpace.map f := by
   apply P.cotangentSpaceBasis.ext
   intro i
-  simp only [cotangentSpaceBasis_apply, map_tmul, _root_.map_one, Hom.toAlgHom_X, Hom.comp_val,
+  simp only [cotangentSpaceBasis_apply, map_tmul, map_one, Hom.toAlgHom_X, Hom.comp_val,
     LinearMap.coe_comp, LinearMap.coe_restrictScalars, Function.comp_apply]
   rfl
 
@@ -148,8 +148,7 @@ lemma map_comp_apply (f : Hom P P') (g : Hom P' P'') (x) :
 lemma map_cotangentComplex (f : Hom P P') (x) :
     CotangentSpace.map f (P.cotangentComplex x) = P'.cotangentComplex (.map f x) := by
   obtain ⟨x, rfl⟩ := Cotangent.mk_surjective x
-  rw [cotangentComplex_mk, map_tmul, _root_.map_one, Cotangent.map_mk,
-    cotangentComplex_mk]
+  rw [cotangentComplex_mk, map_tmul, map_one, Cotangent.map_mk, cotangentComplex_mk]
 
 lemma map_comp_cotangentComplex (f : Hom P P') :
     CotangentSpace.map f ∘ₗ P.cotangentComplex =
@@ -180,7 +179,7 @@ lemma Hom.sub_aux (f g : Hom P P') (x y) :
         coe_eval₂Hom, ← aeval_def, ker, RingHom.mem_ker, map_sub, algebraMap_toAlgHom, aeval_val_σ,
         sub_self]
   convert this using 1
-  simp only [_root_.map_mul]
+  simp only [map_mul]
   ring
 
 /--
@@ -222,8 +221,7 @@ def Hom.sub (f g : Hom P P') : P.CotangentSpace →ₗ[S] P'.Cotangent := by
     simp only [LinearMap.coe_comp, LinearMap.coe_restrictScalars, Function.comp_apply,
       Cotangent.val_mk, Cotangent.val_zero, Ideal.toCotangent_eq_zero]
     erw [LinearMap.codRestrict_apply]
-    simp only [LinearMap.sub_apply, AlgHom.toLinearMap_apply, _root_.map_one, sub_self,
-      Submodule.zero_mem]
+    simp only [LinearMap.sub_apply, AlgHom.toLinearMap_apply, map_one, sub_self, Submodule.zero_mem]
   · intro x y
     ext
     simp only [LinearMap.coe_comp, LinearMap.coe_restrictScalars, Function.comp_apply,
@@ -249,7 +247,7 @@ lemma CotangentSpace.map_sub_map (f g : Hom P P') :
       P'.cotangentComplex.restrictScalars S ∘ₗ (f.sub g) := by
   apply P.cotangentSpaceBasis.ext
   intro i
-  simp only [cotangentSpaceBasis_apply, LinearMap.sub_apply, map_tmul, _root_.map_one,
+  simp only [cotangentSpaceBasis_apply, LinearMap.sub_apply, map_tmul, map_one,
     Hom.toAlgHom_X, LinearMap.coe_comp, LinearMap.coe_restrictScalars, Function.comp_apply,
     Hom.sub_one_tmul, cotangentComplex_mk, Hom.subToKer_apply_coe, map_sub, tmul_sub]
 

--- a/Mathlib/RingTheory/Presentation.lean
+++ b/Mathlib/RingTheory/Presentation.lean
@@ -200,13 +200,13 @@ private lemma span_range_relation_eq_ker_baseChange :
           id.map_eq_id, RingHom.id_apply, e]
         erw [← MvPolynomial.algebraMap_eq, AlgEquiv.commutes]
         simp only [TensorProduct.algebraMap_apply, id.map_eq_id, RingHom.id_apply,
-          TensorProduct.map_tmul, AlgHom.coe_id, id_eq, _root_.map_one, algebraMap_eq]
+          TensorProduct.map_tmul, AlgHom.coe_id, id_eq, map_one, algebraMap_eq]
         erw [aeval_C]
         simp
       | h_add p q hp hq => simp only [map_add, hp, hq]
       | h_X p i hp =>
-        simp only [_root_.map_mul, algebraTensorAlgEquiv_symm_X, hp, TensorProduct.map_tmul,
-          _root_.map_one, IsScalarTower.coe_toAlgHom', Generators.algebraMap_apply, aeval_X, e]
+        simp only [map_mul, algebraTensorAlgEquiv_symm_X, hp, TensorProduct.map_tmul, map_one,
+          IsScalarTower.coe_toAlgHom', Generators.algebraMap_apply, aeval_X, e]
         congr
         erw [aeval_X]
         rw [Generators.baseChange_val]
@@ -216,8 +216,7 @@ private lemma span_range_relation_eq_ker_baseChange :
       Ideal.map_map, Ideal.map_span, ← Set.range_comp] at H'
     convert H'
     simp only [AlgHom.toRingHom_eq_coe, RingHom.coe_comp, RingHom.coe_coe, Function.comp_apply,
-      TensorProduct.includeRight_apply, TensorProduct.lift_tmul, _root_.map_one, mapAlgHom_apply,
-      one_mul]
+      TensorProduct.includeRight_apply, TensorProduct.lift_tmul, map_one, mapAlgHom_apply, one_mul]
     rfl
 
 /-- If `P` is a presentation of `S` over `R` and `T` is an `R`-algebra, we

--- a/Mathlib/RingTheory/Smooth/Kaehler.lean
+++ b/Mathlib/RingTheory/Smooth/Kaehler.lean
@@ -51,10 +51,10 @@ def derivationOfSectionOfKerSqZero (f : P →ₐ[R] S) (hf' : (RingHom.ker f) ^ 
   map_add' x y := by simp only [map_add, AddSubmonoid.mk_add_mk, Subtype.mk.injEq]; ring
   map_smul' x y := by
     ext
-    simp only [Algebra.smul_def, _root_.map_mul, ← IsScalarTower.algebraMap_apply,
-      AlgHom.commutes, RingHom.id_apply, Submodule.coe_smul_of_tower]
+    simp only [Algebra.smul_def, map_mul, ← IsScalarTower.algebraMap_apply, AlgHom.commutes,
+      RingHom.id_apply, Submodule.coe_smul_of_tower]
     ring
-  map_one_eq_zero' := by simp only [LinearMap.coe_mk, AddHom.coe_mk, _root_.map_one, sub_self,
+  map_one_eq_zero' := by simp only [LinearMap.coe_mk, AddHom.coe_mk, map_one, sub_self,
     AddSubmonoid.mk_eq_zero]
   leibniz' a b := by
     have : (a - g (f a)) * (b - g (f b)) = 0 := by
@@ -65,8 +65,8 @@ def derivationOfSectionOfKerSqZero (f : P →ₐ[R] S) (hf' : (RingHom.ker f) ^ 
     ext
     rw [← sub_eq_zero]
     conv_rhs => rw [← neg_zero, ← this]
-    simp only [LinearMap.coe_mk, AddHom.coe_mk, _root_.map_mul, SetLike.mk_smul_mk, smul_eq_mul,
-      mul_sub, AddSubmonoid.mk_add_mk, sub_mul, neg_sub]
+    simp only [LinearMap.coe_mk, AddHom.coe_mk, map_mul, SetLike.mk_smul_mk, smul_eq_mul, mul_sub,
+      AddSubmonoid.mk_add_mk, sub_mul, neg_sub]
     ring
 
 variable (hf' : (RingHom.ker (algebraMap P S)) ^ 2 = ⊥)
@@ -80,7 +80,7 @@ lemma isScalarTower_of_section_of_ker_sqZero :
   intro p s m
   ext
   show g (p • s) * m = p * (g s * m)
-  simp only [Algebra.smul_def, _root_.map_mul, mul_assoc, mul_left_comm _ (g s)]
+  simp only [Algebra.smul_def, map_mul, mul_assoc, mul_left_comm _ (g s)]
   congr 1
   rw [← sub_eq_zero, ← Ideal.mem_bot, ← hf', pow_two, ← sub_mul]
   refine Ideal.mul_mem_mul ?_ m.2

--- a/Mathlib/RingTheory/TensorProduct/Basic.lean
+++ b/Mathlib/RingTheory/TensorProduct/Basic.lean
@@ -462,7 +462,7 @@ theorem ext ⦃f g : (A ⊗[R] B) →ₐ[S] C⦄
   ext a b
   have := congr_arg₂ HMul.hMul (AlgHom.congr_fun ha a) (AlgHom.congr_fun hb b)
   dsimp at *
-  rwa [← _root_.map_mul, ← _root_.map_mul, tmul_mul_tmul, one_mul, mul_one] at this
+  rwa [← map_mul, ← map_mul, tmul_mul_tmul, one_mul, mul_one] at this
 
 theorem ext' {g h : A ⊗[R] B →ₐ[S] C} (H : ∀ a b, g (a ⊗ₜ b) = h (a ⊗ₜ b)) : g = h :=
   ext (AlgHom.ext fun _ => H _ _) (AlgHom.ext fun _ => H _ _)
@@ -693,8 +693,8 @@ def lift (f : A →ₐ[S] C) (g : B →ₐ[R] C) (hfg : ∀ x y, Commute (f x) (
           map_smul' := fun c g => LinearMap.ext fun x => rfl }
       LinearMap.flip <| (restr ∘ₗ LinearMap.mul S C ∘ₗ f.toLinearMap).flip ∘ₗ g)
     (fun a₁ a₂ b₁ b₂ => show f (a₁ * a₂) * g (b₁ * b₂) = f a₁ * g b₁ * (f a₂ * g b₂) by
-      rw [_root_.map_mul, _root_.map_mul, (hfg a₂ b₁).mul_mul_mul_comm])
-    (show f 1 * g 1 = 1 by rw [_root_.map_one, _root_.map_one, one_mul])
+      rw [map_mul, map_mul, (hfg a₂ b₁).mul_mul_mul_comm])
+    (show f 1 * g 1 = 1 by rw [map_one, map_one, one_mul])
 
 @[simp]
 theorem lift_tmul (f : A →ₐ[S] C) (g : B →ₐ[R] C) (hfg : ∀ x y, Commute (f x) (g y))


### PR DESCRIPTION
It's quite common to use the root ones, even with the TensorProduct namespace opened.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
