### PR TITLE
[Merged by Bors] - chore(SetTheory/Ordinal/FixedPoint): Rewrite dumb theorems about zero function

### DIFF
--- a/Mathlib/SetTheory/Ordinal/FixedPoint.lean
+++ b/Mathlib/SetTheory/Ordinal/FixedPoint.lean
@@ -477,6 +477,21 @@ theorem deriv_eq_enumOrd (H : IsNormal f) : deriv f = enumOrd (Function.fixedPoi
 theorem deriv_eq_id_of_nfp_eq_id {f : Ordinal → Ordinal} (h : nfp f = id) : deriv f = id :=
   (IsNormal.eq_iff_zero_and_succ (deriv_isNormal _) IsNormal.refl).2 <| by simp [h]
 
+@[simp]
+theorem nfp_zero : nfp 0 = id := by
+  rw [← sup_iterate_eq_nfp]
+  refine funext fun a => (sup_le fun n => ?_).antisymm (le_sup (fun n => (0 * ·)^[n] a) 0)
+  induction' n with n _
+  · rfl
+  rw [Function.iterate_succ']
+  change 0 * _ ≤ a
+  rw [zero_mul]
+  exact Ordinal.zero_le a
+
+@[simp]
+theorem deriv_zero' : deriv 0 = id :=
+  deriv_eq_id_of_nfp_eq_id nfp_zero
+
 end
 
 /-! ### Fixed points of addition -/
@@ -541,21 +556,6 @@ theorem nfp_mul_zero (a : Ordinal) : nfp (a * ·) 0 = 0 := by
   intro n
   induction' n with n hn; · rfl
   dsimp only; rwa [iterate_succ_apply, mul_zero]
-
-@[simp]
-theorem nfp_zero_mul : nfp (HMul.hMul 0) = id := by
-  rw [← sup_iterate_eq_nfp]
-  refine funext fun a => (sup_le fun n => ?_).antisymm (le_sup (fun n => (0 * ·)^[n] a) 0)
-  induction' n with n _
-  · rfl
-  rw [Function.iterate_succ']
-  change 0 * _ ≤ a
-  rw [zero_mul]
-  exact Ordinal.zero_le a
-
-@[simp]
-theorem deriv_mul_zero : deriv (HMul.hMul 0) = id :=
-  deriv_eq_id_of_nfp_eq_id nfp_zero_mul
 
 theorem nfp_mul_eq_opow_omega {a b : Ordinal} (hb : 0 < b) (hba : b ≤ (a^omega)) :
     nfp (a * ·) b = (a^omega.{u}) := by

--- a/Mathlib/SetTheory/Ordinal/FixedPoint.lean
+++ b/Mathlib/SetTheory/Ordinal/FixedPoint.lean
@@ -492,6 +492,7 @@ theorem deriv_zero : deriv 0 = id :=
 
 theorem deriv_zero_left (a) : deriv 0 a = a := by
   rw [deriv_zero]
+  rfl
 
 end
 
@@ -562,10 +563,7 @@ theorem nfp_mul_eq_opow_omega {a b : Ordinal} (hb : 0 < b) (hba : b ≤ (a^omega
     nfp (a * ·) b = (a^omega.{u}) := by
   rcases eq_zero_or_pos a with ha | ha
   · rw [ha, zero_opow omega_ne_zero] at hba ⊢
-    rw [Ordinal.le_zero.1 hba]
-    convert congr_fun nfp_zero 0
-    ext
-    rw [zero_mul]
+    simp_rw [Ordinal.le_zero.1 hba, zero_mul, nfp_zero]
     rfl
   apply le_antisymm
   · apply nfp_le_fp (mul_isNormal ha).monotone hba

--- a/Mathlib/SetTheory/Ordinal/FixedPoint.lean
+++ b/Mathlib/SetTheory/Ordinal/FixedPoint.lean
@@ -486,6 +486,10 @@ theorem nfp_zero : nfp 0 = id := by
   rw [Function.iterate_succ']
   exact Ordinal.zero_le a
 
+theorem nfp_zero_left (a) : nfp 0 a = a := by
+  rw [nfp_zero]
+  rfl
+
 @[simp]
 theorem deriv_zero : deriv 0 = id :=
   deriv_eq_id_of_nfp_eq_id nfp_zero
@@ -563,8 +567,8 @@ theorem nfp_mul_eq_opow_omega {a b : Ordinal} (hb : 0 < b) (hba : b ≤ (a^omega
     nfp (a * ·) b = (a^omega.{u}) := by
   rcases eq_zero_or_pos a with ha | ha
   · rw [ha, zero_opow omega_ne_zero] at hba ⊢
-    simp_rw [Ordinal.le_zero.1 hba, zero_mul, nfp_zero]
-    rfl
+    simp_rw [Ordinal.le_zero.1 hba, zero_mul]
+    exact nfp_zero_left 0
   apply le_antisymm
   · apply nfp_le_fp (mul_isNormal ha).monotone hba
     rw [← opow_one_add, one_add_omega]

--- a/Mathlib/SetTheory/Ordinal/FixedPoint.lean
+++ b/Mathlib/SetTheory/Ordinal/FixedPoint.lean
@@ -490,7 +490,7 @@ theorem nfp_zero : nfp 0 = id := by
 theorem deriv_zero : deriv 0 = id :=
   deriv_eq_id_of_nfp_eq_id nfp_zero
 
-theorem deriv_zero_left (a) : deriv 0 a = a :=
+theorem deriv_zero_left (a) : deriv 0 a = a := by
   rw [deriv_zero]
 
 end

--- a/Mathlib/SetTheory/Ordinal/FixedPoint.lean
+++ b/Mathlib/SetTheory/Ordinal/FixedPoint.lean
@@ -480,12 +480,10 @@ theorem deriv_eq_id_of_nfp_eq_id {f : Ordinal → Ordinal} (h : nfp f = id) : de
 @[simp]
 theorem nfp_zero : nfp 0 = id := by
   rw [← sup_iterate_eq_nfp]
-  refine funext fun a => (sup_le fun n => ?_).antisymm (le_sup (fun n => (0 * ·)^[n] a) 0)
+  refine funext fun a => (sup_le fun n => ?_).antisymm (le_sup (fun n => 0^[n] a) 0)
   induction' n with n _
   · rfl
   rw [Function.iterate_succ']
-  change 0 * _ ≤ a
-  rw [zero_mul]
   exact Ordinal.zero_le a
 
 @[simp]
@@ -561,7 +559,10 @@ theorem nfp_mul_eq_opow_omega {a b : Ordinal} (hb : 0 < b) (hba : b ≤ (a^omega
     nfp (a * ·) b = (a^omega.{u}) := by
   rcases eq_zero_or_pos a with ha | ha
   · rw [ha, zero_opow omega_ne_zero] at hba ⊢
-    rw [Ordinal.le_zero.1 hba, nfp_zero_mul]
+    rw [Ordinal.le_zero.1 hba]
+    convert congr_fun nfp_zero 0
+    ext
+    rw [zero_mul]
     rfl
   apply le_antisymm
   · apply nfp_le_fp (mul_isNormal ha).monotone hba

--- a/Mathlib/SetTheory/Ordinal/FixedPoint.lean
+++ b/Mathlib/SetTheory/Ordinal/FixedPoint.lean
@@ -442,7 +442,7 @@ theorem deriv_eq_derivFamily (f : Ordinal → Ordinal) : deriv f = derivFamily f
   rfl
 
 @[simp]
-theorem deriv_zero (f) : deriv f 0 = nfp f 0 :=
+theorem deriv_zero_right (f) : deriv f 0 = nfp f 0 :=
   derivFamily_zero _
 
 @[simp]
@@ -487,8 +487,11 @@ theorem nfp_zero : nfp 0 = id := by
   exact Ordinal.zero_le a
 
 @[simp]
-theorem deriv_zero' : deriv 0 = id :=
+theorem deriv_zero : deriv 0 = id :=
   deriv_eq_id_of_nfp_eq_id nfp_zero
+
+theorem deriv_zero_left (a) : deriv 0 a = a :=
+  rw [deriv_zero]
 
 end
 
@@ -511,7 +514,7 @@ theorem nfp_add_eq_mul_omega {a b} (hba : b ≤ a * omega) : nfp (a + ·) b = a 
 
 theorem add_eq_right_iff_mul_omega_le {a b : Ordinal} : a + b = b ↔ a * omega ≤ b := by
   refine ⟨fun h => ?_, fun h => ?_⟩
-  · rw [← nfp_add_zero a, ← deriv_zero]
+  · rw [← nfp_add_zero a, ← deriv_zero_right]
     cases' (add_isNormal a).fp_iff_deriv.1 h with c hc
     rw [← hc]
     exact (deriv_isNormal _).monotone (Ordinal.zero_le _)
@@ -527,7 +530,7 @@ theorem deriv_add_eq_mul_omega_add (a b : Ordinal.{u}) : deriv (a + ·) b = a * 
   revert b
   rw [← funext_iff, IsNormal.eq_iff_zero_and_succ (deriv_isNormal _) (add_isNormal _)]
   refine ⟨?_, fun a h => ?_⟩
-  · rw [deriv_zero, add_zero]
+  · rw [deriv_zero_right, add_zero]
     exact nfp_add_zero a
   · rw [deriv_succ, h, add_succ]
     exact nfp_eq_self (add_eq_right_iff_mul_omega_le.2 ((le_add_right _ _).trans (le_succ _)))
@@ -624,7 +627,7 @@ theorem deriv_mul_eq_opow_omega_mul {a : Ordinal.{u}} (ha : 0 < a) (b) :
   rw [← funext_iff,
     IsNormal.eq_iff_zero_and_succ (deriv_isNormal _) (mul_isNormal (opow_pos omega ha))]
   refine ⟨?_, fun c h => ?_⟩
-  · dsimp only; rw [deriv_zero, nfp_mul_zero, mul_zero]
+  · dsimp only; rw [deriv_zero_right, nfp_mul_zero, mul_zero]
   · rw [deriv_succ, h]
     exact nfp_mul_opow_omega_add c ha zero_lt_one (one_le_iff_pos.2 (opow_pos _ ha))
 


### PR DESCRIPTION
Two theorems referred to the function `fun x => 0 * x`, which is just the zero function. Also, added applied versions of theorems referring to function equality.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

The name `deriv_zero` is used for `deriv f 0 = nfp f 0` and `deriv 0 = id`. Should either of these be renamed?

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
