### PR TITLE
[Merged by Bors] - feat(Data/Nat/Factorial): add descFactorial_le and descFactorial_mul_descFactorial

### DIFF
--- a/Mathlib/Data/Nat/Factorial/Basic.lean
+++ b/Mathlib/Data/Nat/Factorial/Basic.lean
@@ -375,7 +375,7 @@ theorem descFactorial_eq_div {n k : ℕ} (h : k ≤ n) : n.descFactorial k = n !
 theorem descFactorial_le (n : ℕ) {k m : ℕ} (h : k ≤ m) :
     k.descFactorial n ≤ m.descFactorial n := by
   induction n with
-  | zero => exact Nat.le_of_ble_eq_true rfl
+  | zero => rfl
   | succ n ih =>
     rw [descFactorial_succ, descFactorial_succ]
     apply Nat.mul_le_mul

--- a/Mathlib/Data/Nat/Factorial/Basic.lean
+++ b/Mathlib/Data/Nat/Factorial/Basic.lean
@@ -372,7 +372,7 @@ theorem descFactorial_eq_div {n k : ℕ} (h : k ≤ n) : n.descFactorial k = n !
   rw [factorial_mul_descFactorial h]
   exact (Nat.mul_div_cancel' <| factorial_dvd_factorial <| Nat.sub_le n k).symm
 
-theorem descFactorial_le (n k m : ℕ) (h : k ≤ m) :
+theorem descFactorial_le (n : ℕ) {k m : ℕ} (h : k ≤ m) :
     k.descFactorial n ≤ m.descFactorial n := by
   induction n with
   | zero => exact Nat.le_of_ble_eq_true rfl

--- a/Mathlib/Data/Nat/Factorial/Basic.lean
+++ b/Mathlib/Data/Nat/Factorial/Basic.lean
@@ -354,11 +354,52 @@ theorem factorial_mul_descFactorial : ∀ {n k : ℕ}, k ≤ n → (n - k)! * n.
     rw [succ_descFactorial_succ, succ_sub_succ, ← Nat.mul_assoc, Nat.mul_comm (n - k)!,
       Nat.mul_assoc, factorial_mul_descFactorial (Nat.succ_le_succ_iff.1 h), factorial_succ]
 
+theorem descFactorial_mul_descFactorial {n : ℕ} : ∀ {m k : ℕ}, k ≤ m →
+  (n - k).descFactorial (m - k) * n.descFactorial k = n.descFactorial m
+  | m, 0 => fun _ => by rw [Nat.sub_zero, Nat.sub_zero, descFactorial_zero, Nat.mul_one]
+  | 0, Nat.succ k => fun h => by
+    exfalso
+    exact Nat.not_succ_le_zero k h
+  | Nat.succ m, Nat.succ k => fun h => by
+    rw [Nat.succ_sub_succ, descFactorial_succ, ← Nat.mul_assoc, Nat.mul_comm _ (n - k)]
+    by_cases h1 : n - k = n - k.succ + 1
+    rw [h1]
+    rw [← succ_descFactorial_succ (n - k.succ) _]
+    rw [← h1]
+    rw [descFactorial_succ]
+    have h2 : n - k - (m - k) = n - m
+    refine Nat.sub_sub_sub_cancel_right ?h2.h
+    exact Nat.le_of_lt_succ h
+    rw [h2]
+    rw [mul_assoc]
+    rw [descFactorial_mul_descFactorial]
+    rw [descFactorial_succ]
+    exact Nat.le_of_lt_succ h
+    have h3 : n - k = 0
+    omega
+    rw [h3]
+    rw [zero_mul]
+    rw [zero_mul]
+    have h4 : n < m.succ
+    omega
+    exact Eq.symm ((fun {_} => descFactorial_eq_zero_iff_lt.mpr) h4)
+
 /-- Avoid in favor of `Nat.factorial_mul_descFactorial` if you can. ℕ-division isn't worth it. -/
 theorem descFactorial_eq_div {n k : ℕ} (h : k ≤ n) : n.descFactorial k = n ! / (n - k)! := by
   apply Nat.mul_left_cancel (n - k).factorial_pos
   rw [factorial_mul_descFactorial h]
   exact (Nat.mul_div_cancel' <| factorial_dvd_factorial <| Nat.sub_le n k).symm
+
+theorem descFactorial_le (n k m : ℕ) (h : k ≤ m) :
+  k.descFactorial n ≤ m.descFactorial n :=
+by
+  induction n with
+  | zero => exact Nat.le_of_ble_eq_true rfl
+  | succ n ih =>
+    rw [descFactorial_succ, descFactorial_succ]
+    apply Nat.mul_le_mul
+    exact Nat.sub_le_sub_right h n
+    exact ih
 
 theorem pow_sub_le_descFactorial (n : ℕ) : ∀ k : ℕ, (n + 1 - k) ^ k ≤ n.descFactorial k
   | 0 => by rw [descFactorial_zero, Nat.pow_zero]

--- a/Mathlib/Data/Nat/Factorial/Basic.lean
+++ b/Mathlib/Data/Nat/Factorial/Basic.lean
@@ -378,9 +378,7 @@ theorem descFactorial_le (n : ℕ) {k m : ℕ} (h : k ≤ m) :
   | zero => rfl
   | succ n ih =>
     rw [descFactorial_succ, descFactorial_succ]
-    apply Nat.mul_le_mul
-    exact Nat.sub_le_sub_right h n
-    exact ih
+    exact Nat.mul_le_mul (Nat.sub_le_sub_right h n) ih
 
 theorem pow_sub_le_descFactorial (n : ℕ) : ∀ k : ℕ, (n + 1 - k) ^ k ≤ n.descFactorial k
   | 0 => by rw [descFactorial_zero, Nat.pow_zero]

--- a/Mathlib/Data/Nat/Factorial/Basic.lean
+++ b/Mathlib/Data/Nat/Factorial/Basic.lean
@@ -355,7 +355,7 @@ theorem factorial_mul_descFactorial : ∀ {n k : ℕ}, k ≤ n → (n - k)! * n.
       Nat.mul_assoc, factorial_mul_descFactorial (Nat.succ_le_succ_iff.1 h), factorial_succ]
 
 theorem descFactorial_mul_descFactorial {n : ℕ} : ∀ {m k : ℕ}, k ≤ m →
-  (n - k).descFactorial (m - k) * n.descFactorial k = n.descFactorial m
+    (n - k).descFactorial (m - k) * n.descFactorial k = n.descFactorial m
   | m, 0 => fun _ => by rw [Nat.sub_zero, Nat.sub_zero, descFactorial_zero, Nat.mul_one]
   | 0, Nat.succ k => fun h => by
     exfalso
@@ -367,21 +367,19 @@ theorem descFactorial_mul_descFactorial {n : ℕ} : ∀ {m k : ℕ}, k ≤ m →
     rw [← succ_descFactorial_succ (n - k.succ) _]
     rw [← h1]
     rw [descFactorial_succ]
-    have h2 : n - k - (m - k) = n - m
-    refine Nat.sub_sub_sub_cancel_right ?h2.h
-    exact Nat.le_of_lt_succ h
+    have h2 : n - k - (m - k) = n - m := by
+      apply Nat.sub_sub_sub_cancel_right ?h2.h
+      exact Nat.le_of_lt_succ h
     rw [h2]
-    rw [mul_assoc]
+    rw [Nat.mul_assoc]
     rw [descFactorial_mul_descFactorial]
     rw [descFactorial_succ]
     exact Nat.le_of_lt_succ h
-    have h3 : n - k = 0
-    omega
+    have h3 : n - k = 0 := by omega
     rw [h3]
-    rw [zero_mul]
-    rw [zero_mul]
-    have h4 : n < m.succ
-    omega
+    rw [Nat.zero_mul]
+    rw [Nat.zero_mul]
+    have h4 : n < m.succ := by omega
     exact Eq.symm ((fun {_} => descFactorial_eq_zero_iff_lt.mpr) h4)
 
 /-- Avoid in favor of `Nat.factorial_mul_descFactorial` if you can. ℕ-division isn't worth it. -/
@@ -391,8 +389,7 @@ theorem descFactorial_eq_div {n k : ℕ} (h : k ≤ n) : n.descFactorial k = n !
   exact (Nat.mul_div_cancel' <| factorial_dvd_factorial <| Nat.sub_le n k).symm
 
 theorem descFactorial_le (n k m : ℕ) (h : k ≤ m) :
-  k.descFactorial n ≤ m.descFactorial n :=
-by
+    k.descFactorial n ≤ m.descFactorial n := by
   induction n with
   | zero => exact Nat.le_of_ble_eq_true rfl
   | succ n ih =>

--- a/Mathlib/Data/Nat/Factorial/Basic.lean
+++ b/Mathlib/Data/Nat/Factorial/Basic.lean
@@ -354,33 +354,17 @@ theorem factorial_mul_descFactorial : ∀ {n k : ℕ}, k ≤ n → (n - k)! * n.
     rw [succ_descFactorial_succ, succ_sub_succ, ← Nat.mul_assoc, Nat.mul_comm (n - k)!,
       Nat.mul_assoc, factorial_mul_descFactorial (Nat.succ_le_succ_iff.1 h), factorial_succ]
 
-theorem descFactorial_mul_descFactorial {n : ℕ} : ∀ {m k : ℕ}, k ≤ m →
-    (n - k).descFactorial (m - k) * n.descFactorial k = n.descFactorial m
-  | m, 0 => fun _ => by rw [Nat.sub_zero, Nat.sub_zero, descFactorial_zero, Nat.mul_one]
-  | 0, Nat.succ k => fun h => by
-    exfalso
-    exact Nat.not_succ_le_zero k h
-  | Nat.succ m, Nat.succ k => fun h => by
-    rw [Nat.succ_sub_succ, descFactorial_succ, ← Nat.mul_assoc, Nat.mul_comm _ (n - k)]
-    by_cases h1 : n - k = n - k.succ + 1
-    rw [h1]
-    rw [← succ_descFactorial_succ (n - k.succ) _]
-    rw [← h1]
-    rw [descFactorial_succ]
-    have h2 : n - k - (m - k) = n - m := by
-      apply Nat.sub_sub_sub_cancel_right ?h2.h
-      exact Nat.le_of_lt_succ h
-    rw [h2]
-    rw [Nat.mul_assoc]
-    rw [descFactorial_mul_descFactorial]
-    rw [descFactorial_succ]
-    exact Nat.le_of_lt_succ h
-    have h3 : n - k = 0 := by omega
-    rw [h3]
-    rw [Nat.zero_mul]
-    rw [Nat.zero_mul]
-    have h4 : n < m.succ := by omega
-    exact Eq.symm ((fun {_} => descFactorial_eq_zero_iff_lt.mpr) h4)
+theorem descFactorial_mul_descFactorial {k m n : ℕ} (hkm : k ≤ m) :
+    (n - k).descFactorial (m - k) * n.descFactorial k = n.descFactorial m := by
+  by_cases hmn : m ≤ n
+  · apply Nat.mul_left_cancel (n - m).factorial_pos
+    rw [factorial_mul_descFactorial hmn, show n - m = (n - k) - (m - k) by omega, ← Nat.mul_assoc,
+      factorial_mul_descFactorial (show m - k ≤ n - k by omega),
+      factorial_mul_descFactorial (le_trans hkm hmn)]
+  · rw [descFactorial_eq_zero_iff_lt.mpr (show n < m by omega)]
+    by_cases hkn : k ≤ n
+    · rw [descFactorial_eq_zero_iff_lt.mpr (show n - k < m - k by omega), Nat.zero_mul]
+    · rw [descFactorial_eq_zero_iff_lt.mpr (show n < k by omega), Nat.mul_zero]
 
 /-- Avoid in favor of `Nat.factorial_mul_descFactorial` if you can. ℕ-division isn't worth it. -/
 theorem descFactorial_eq_div {n k : ℕ} (h : k ≤ n) : n.descFactorial k = n ! / (n - k)! := by


### PR DESCRIPTION
Add two basic theorems involving falling factorials. Note that `descFactorial_mul_descFactorial` collapses to `Nat.factorial_mul_descFactorial` when `m = n`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
