### PR TITLE
[Merged by Bors] - chore(SetTheory/Game/PGame): simplify ofLists API

### DIFF
--- a/Mathlib/SetTheory/Game/PGame.lean
+++ b/Mathlib/SetTheory/Game/PGame.lean
@@ -161,29 +161,31 @@ theorem rightMoves_ofLists (L R : List PGame) : (ofLists L R).RightMoves = ULift
   rfl
 
 /-- Converts a number into a left move for `ofLists`. -/
+@[simps!]
 def toOfListsLeftMoves {L R : List PGame} : Fin L.length ≃ (ofLists L R).LeftMoves :=
-  ((Equiv.cast (leftMoves_ofLists L R).symm).trans Equiv.ulift).symm
+  Equiv.ulift.symm
 
 /-- Converts a number into a right move for `ofLists`. -/
+@[simps!]
 def toOfListsRightMoves {L R : List PGame} : Fin R.length ≃ (ofLists L R).RightMoves :=
-  ((Equiv.cast (rightMoves_ofLists L R).symm).trans Equiv.ulift).symm
-
-theorem ofLists_moveLeft {L R : List PGame} (i : Fin L.length) :
-    (ofLists L R).moveLeft (toOfListsLeftMoves i) = L[i] :=
-  rfl
+  Equiv.ulift.symm
 
 @[simp]
 theorem ofLists_moveLeft' {L R : List PGame} (i : (ofLists L R).LeftMoves) :
-    (ofLists L R).moveLeft i = L[toOfListsLeftMoves.symm i] :=
+    (ofLists L R).moveLeft i = L[i.down.val] :=
   rfl
 
-theorem ofLists_moveRight {L R : List PGame} (i : Fin R.length) :
-    (ofLists L R).moveRight (toOfListsRightMoves i) = R[i] :=
+theorem ofLists_moveLeft {L R : List PGame} (i : Fin L.length) :
+    (ofLists L R).moveLeft (ULift.up i) = L[i] :=
   rfl
 
 @[simp]
 theorem ofLists_moveRight' {L R : List PGame} (i : (ofLists L R).RightMoves) :
-    (ofLists L R).moveRight i = R[toOfListsRightMoves.symm i] :=
+    (ofLists L R).moveRight i = R[i.down.val] :=
+  rfl
+
+theorem ofLists_moveRight {L R : List PGame} (i : Fin R.length) :
+    (ofLists L R).moveRight (toOfListsRightMoves i) = R[i] :=
   rfl
 
 /-- A variant of `PGame.recOn` expressed in terms of `PGame.moveLeft` and `PGame.moveRight`.

--- a/Mathlib/SetTheory/Game/PGame.lean
+++ b/Mathlib/SetTheory/Game/PGame.lean
@@ -163,13 +163,13 @@ theorem rightMoves_ofLists (L R : List PGame) : (ofLists L R).RightMoves = ULift
 /-- Converts a number into a left move for `ofLists`.
 
 This is just an abbreviation for `Equiv.ULift.symm` -/
-abbrev toOfListsLeftMoves : Fin L.length ≃ (ofLists L R).LeftMoves :=
+abbrev toOfListsLeftMoves {L R : List PGame} : Fin L.length ≃ (ofLists L R).LeftMoves :=
   Equiv.ULift.symm
 
 /-- Converts a number into a right move for `ofLists`.
 
 This is just an abbreviation for `Equiv.ULift.symm` -/
-abbrev toOfListsRightMoves : Fin R.length ≃ (ofLists L R).RightMoves :=
+abbrev toOfListsRightMoves {L R : List PGame} : Fin R.length ≃ (ofLists L R).RightMoves :=
   Equiv.ULift.symm
 
 @[simp]

--- a/Mathlib/SetTheory/Game/PGame.lean
+++ b/Mathlib/SetTheory/Game/PGame.lean
@@ -160,7 +160,6 @@ theorem leftMoves_ofLists (L R : List PGame) : (ofLists L R).LeftMoves = ULift (
 theorem rightMoves_ofLists (L R : List PGame) : (ofLists L R).RightMoves = ULift (Fin R.length) :=
   rfl
 
-
 /-- Converts a number into a left move for `ofLists`.
 
 This is just an abbreviation for `Equiv.ULift.symm` -/

--- a/Mathlib/SetTheory/Game/PGame.lean
+++ b/Mathlib/SetTheory/Game/PGame.lean
@@ -160,16 +160,6 @@ theorem leftMoves_ofLists (L R : List PGame) : (ofLists L R).LeftMoves = ULift (
 theorem rightMoves_ofLists (L R : List PGame) : (ofLists L R).RightMoves = ULift (Fin R.length) :=
   rfl
 
-/-- Converts a number into a left move for `ofLists`. -/
-@[simps!]
-def toOfListsLeftMoves {L R : List PGame} : Fin L.length ≃ (ofLists L R).LeftMoves :=
-  Equiv.ulift.symm
-
-/-- Converts a number into a right move for `ofLists`. -/
-@[simps!]
-def toOfListsRightMoves {L R : List PGame} : Fin R.length ≃ (ofLists L R).RightMoves :=
-  Equiv.ulift.symm
-
 @[simp]
 theorem ofLists_moveLeft' {L R : List PGame} (i : (ofLists L R).LeftMoves) :
     (ofLists L R).moveLeft i = L[i.down.val] :=
@@ -185,7 +175,7 @@ theorem ofLists_moveRight' {L R : List PGame} (i : (ofLists L R).RightMoves) :
   rfl
 
 theorem ofLists_moveRight {L R : List PGame} (i : Fin R.length) :
-    (ofLists L R).moveRight (toOfListsRightMoves i) = R[i] :=
+    (ofLists L R).moveRight (ULift.up i) = R[i] :=
   rfl
 
 /-- A variant of `PGame.recOn` expressed in terms of `PGame.moveLeft` and `PGame.moveRight`.

--- a/Mathlib/SetTheory/Game/PGame.lean
+++ b/Mathlib/SetTheory/Game/PGame.lean
@@ -160,9 +160,16 @@ theorem leftMoves_ofLists (L R : List PGame) : (ofLists L R).LeftMoves = ULift (
 theorem rightMoves_ofLists (L R : List PGame) : (ofLists L R).RightMoves = ULift (Fin R.length) :=
   rfl
 
+
+/-- Converts a number into a left move for `ofLists`.
+
+This is just an abbreviation for `Equiv.ULift.symm` -/
 abbrev toOfListsLeftMoves : Fin L.length ≃ (ofLists L R).LeftMoves :=
   Equiv.ULift.symm
 
+/-- Converts a number into a right move for `ofLists`.
+
+This is just an abbreviation for `Equiv.ULift.symm` -/
 abbrev toOfListsRightMoves : Fin R.length ≃ (ofLists L R).RightMoves :=
   Equiv.ULift.symm
 

--- a/Mathlib/SetTheory/Game/PGame.lean
+++ b/Mathlib/SetTheory/Game/PGame.lean
@@ -162,15 +162,15 @@ theorem rightMoves_ofLists (L R : List PGame) : (ofLists L R).RightMoves = ULift
 
 /-- Converts a number into a left move for `ofLists`.
 
-This is just an abbreviation for `Equiv.ULift.symm` -/
+This is just an abbreviation for `Equiv.ulift.symm` -/
 abbrev toOfListsLeftMoves {L R : List PGame} : Fin L.length ≃ (ofLists L R).LeftMoves :=
-  Equiv.ULift.symm
+  Equiv.ulift.symm
 
 /-- Converts a number into a right move for `ofLists`.
 
-This is just an abbreviation for `Equiv.ULift.symm` -/
+This is just an abbreviation for `Equiv.ulift.symm` -/
 abbrev toOfListsRightMoves {L R : List PGame} : Fin R.length ≃ (ofLists L R).RightMoves :=
-  Equiv.ULift.symm
+  Equiv.ulift.symm
 
 @[simp]
 theorem ofLists_moveLeft' {L R : List PGame} (i : (ofLists L R).LeftMoves) :

--- a/Mathlib/SetTheory/Game/PGame.lean
+++ b/Mathlib/SetTheory/Game/PGame.lean
@@ -160,6 +160,12 @@ theorem leftMoves_ofLists (L R : List PGame) : (ofLists L R).LeftMoves = ULift (
 theorem rightMoves_ofLists (L R : List PGame) : (ofLists L R).RightMoves = ULift (Fin R.length) :=
   rfl
 
+abbrev toOfListsLeftMoves : Fin L.length ≃ (ofLists L R).LeftMoves :=
+  Equiv.ULift.symm
+
+abbrev toOfListsRightMoves : Fin R.length ≃ (ofLists L R).RightMoves :=
+  Equiv.ULift.symm
+
 @[simp]
 theorem ofLists_moveLeft' {L R : List PGame} (i : (ofLists L R).LeftMoves) :
     (ofLists L R).moveLeft i = L[i.down.val] :=


### PR DESCRIPTION
The equation `(ofLists L R).LeftMoves = ULift (Fin L.length)` (ditto for `RightMoves`) is entirely def-eq in Lean 4. As such, `toOfListsLeftMoves` doesn't solve the same problem that other `toXLeftMoves` equivalences do, which is provide this correspondence without having to tediously figure out how to rewrite the equality. We instead turn this into an abbreviation for `ULift.up` and `ULift.down`, which has the nice side effect of making `simp` much more capable of simplifying equations involving `ofLists`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

To be clear, I don't recall if this was def-eq in Lean 3. I imagine not, as we probably wouldn't have been using `Equiv.cast` otherwise.

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
