### PR TITLE
[Merged by Bors] - feat: add `assert_not_imported` command

### DIFF
--- a/Mathlib/Util/AssertExists.lean
+++ b/Mathlib/Util/AssertExists.lean
@@ -69,7 +69,7 @@ elab "assert_not_exists " n:ident : command => do
     and exist in order to ensure that \"complicated\" parts of the library \
     are not accidentally introduced as dependencies of \"simple\" parts of the library."
 
-/-- `assert_not_imported m₁ m₂ ... mₙ` checks that each one of the modules `m₁ m₂ ... mₙ` are not
+/-- `assert_not_imported m₁ m₂ ... mₙ` checks that each one of the modules `m₁ m₂ ... mₙ` is not
 among the transitive imports of the current file.
 
 It also checks that each one of `m₁ m₂ ... mₙ` is actually the name of an existing module, just

--- a/Mathlib/Util/AssertExists.lean
+++ b/Mathlib/Util/AssertExists.lean
@@ -68,3 +68,16 @@ elab "assert_not_exists " n:ident : command => do
     These invariants are maintained by `assert_not_exists` statements, \
     and exist in order to ensure that \"complicated\" parts of the library \
     are not accidentally introduced as dependencies of \"simple\" parts of the library."
+
+/-- `assert_not_imported m₁ m₂ ... mₙ` checks that each one of the modules `m₁ m₂ ... mₙ` are not
+among the transitive imports of the current file.
+
+It also checks that each one of `m₁ m₂ ... mₙ` is actually the name of an existing module, just
+one that is not currently imported!
+-/
+elab "assert_not_imported " ids:ident* : command => do
+  let mods := (← getEnv).allImportedModuleNames
+  for id in ids do
+    if mods.contains id.getId then logWarningAt id m!"'{id}' is imported"
+    if let none ← (← searchPathRef.get).findModuleWithExt "olean" id.getId then
+      logWarningAt id m!"'{id}' does not exist"

--- a/test/AssertExists.lean
+++ b/test/AssertExists.lean
@@ -1,0 +1,12 @@
+import Mathlib.Util.AssertExists
+
+/--
+warning: 'Lean.Elab.Command' is imported
+---
+warning: 'I_do_not_exist' does not exist
+-/
+#guard_msgs in
+assert_not_imported
+  Mathlib.Tactic.Common
+  Lean.Elab.Command
+  I_do_not_exist


### PR DESCRIPTION
This PR introduces the new command `assert_not_imported m₁ m₂ ... mₙ`.

The command checks that each one of the modules `m₁ m₂ ... mₙ` are not among the transitive imports of the current file.

It also checks that each one of `m₁ m₂ ... mₙ` is actually the name of an existing module, just one that is not currently imported!

[Zulip thread](https://leanprover.zulipchat.com/#narrow/stream/217875-Is-there-code-for-X.3F/topic/assert_not_imported)

---

Note: this has been tested on one Linux computer, on one MacOs computer and on the online Lean server.

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
