### PR TITLE
[Merged by Bors] - feat(CategoryTheory/Limits): epi/mono in functor categories

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -1542,6 +1542,7 @@ import Mathlib.CategoryTheory.Limits.FintypeCat
 import Mathlib.CategoryTheory.Limits.Fubini
 import Mathlib.CategoryTheory.Limits.FullSubcategory
 import Mathlib.CategoryTheory.Limits.FunctorCategory
+import Mathlib.CategoryTheory.Limits.FunctorCategoryEpiMono
 import Mathlib.CategoryTheory.Limits.FunctorToTypes
 import Mathlib.CategoryTheory.Limits.HasLimits
 import Mathlib.CategoryTheory.Limits.IndYoneda

--- a/Mathlib/CategoryTheory/Adjunction/Evaluation.lean
+++ b/Mathlib/CategoryTheory/Adjunction/Evaluation.lean
@@ -73,13 +73,6 @@ def evaluationAdjunctionRight (c : C) : evaluationLeftAdjoint D c ⊣ (evaluatio
 instance evaluationIsRightAdjoint (c : C) : ((evaluation _ D).obj c).IsRightAdjoint  :=
   ⟨_, ⟨evaluationAdjunctionRight _ _⟩⟩
 
-theorem NatTrans.mono_iff_mono_app {F G : C ⥤ D} (η : F ⟶ G) : Mono η ↔ ∀ c, Mono (η.app c) := by
-  constructor
-  · intro h c
-    exact (inferInstance : Mono (((evaluation _ _).obj c).map η))
-  · intro _
-    apply NatTrans.mono_of_mono_app
-
 end
 
 section
@@ -127,13 +120,6 @@ def evaluationAdjunctionLeft (c : C) : (evaluation _ _).obj c ⊣ evaluationRigh
 
 instance evaluationIsLeftAdjoint (c : C) : ((evaluation _ D).obj c).IsLeftAdjoint :=
   ⟨_, ⟨evaluationAdjunctionLeft _ _⟩⟩
-
-theorem NatTrans.epi_iff_epi_app {F G : C ⥤ D} (η : F ⟶ G) : Epi η ↔ ∀ c, Epi (η.app c) := by
-  constructor
-  · intro h c
-    exact (inferInstance : Epi (((evaluation _ _).obj c).map η))
-  · intros
-    apply NatTrans.epi_of_epi_app
 
 end
 

--- a/Mathlib/CategoryTheory/Adjunction/Evaluation.lean
+++ b/Mathlib/CategoryTheory/Adjunction/Evaluation.lean
@@ -73,6 +73,15 @@ def evaluationAdjunctionRight (c : C) : evaluationLeftAdjoint D c ⊣ (evaluatio
 instance evaluationIsRightAdjoint (c : C) : ((evaluation _ D).obj c).IsRightAdjoint  :=
   ⟨_, ⟨evaluationAdjunctionRight _ _⟩⟩
 
+/-- See also the file `CategoryTheory.Limits.FunctorCategoryEpiMono`
+for a similar result under a `HasPullbacks` assumption. -/
+theorem NatTrans.mono_iff_mono_app' {F G : C ⥤ D} (η : F ⟶ G) : Mono η ↔ ∀ c, Mono (η.app c) := by
+  constructor
+  · intro h c
+    exact (inferInstance : Mono (((evaluation _ _).obj c).map η))
+  · intro _
+    apply NatTrans.mono_of_mono_app
+
 end
 
 section
@@ -120,6 +129,16 @@ def evaluationAdjunctionLeft (c : C) : (evaluation _ _).obj c ⊣ evaluationRigh
 
 instance evaluationIsLeftAdjoint (c : C) : ((evaluation _ D).obj c).IsLeftAdjoint :=
   ⟨_, ⟨evaluationAdjunctionLeft _ _⟩⟩
+
+
+/-- See also the file `CategoryTheory.Limits.FunctorCategoryEpiMono`
+for a similar result under a `HasPushouts` assumption. -/
+theorem NatTrans.epi_iff_epi_app' {F G : C ⥤ D} (η : F ⟶ G) : Epi η ↔ ∀ c, Epi (η.app c) := by
+  constructor
+  · intro h c
+    exact (inferInstance : Epi (((evaluation _ _).obj c).map η))
+  · intros
+    apply NatTrans.epi_of_epi_app
 
 end
 

--- a/Mathlib/CategoryTheory/Limits/FunctorCategoryEpiMono.lean
+++ b/Mathlib/CategoryTheory/Limits/FunctorCategoryEpiMono.lean
@@ -1,0 +1,61 @@
+/-
+Copyright (c) 2024 Joël Riou. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Joël Riou
+-/
+import Mathlib.CategoryTheory.Limits.Constructions.EpiMono
+import Mathlib.CategoryTheory.Limits.FunctorCategory
+
+/-!
+# Monomorphisms and epimorphisms in functor categories
+
+A natural transformation `f : F ⟶ G` between functors `K ⥤ C`
+is a mono (resp. epi) iff for all `k : K`, `f.app k` is,
+at least when `C` has pullbacks (resp. pushouts),
+see `NatTrans.mono_iff_mono_app` and `NatTrans.epi_iff_epi_app`.
+
+-/
+
+universe v v' v'' u u' u''
+
+namespace CategoryTheory
+
+open Limits
+
+variable {K : Type u} [Category.{v} K] {C : Type u'} [Category.{v'} C]
+  {D : Type u''} [Category.{v''} D] {F G : K ⥤ C} (f : F ⟶ G)
+section
+
+variable [HasPullbacks C]
+
+instance [Mono f] (k : K) : Mono (f.app k) :=
+  inferInstanceAs (Mono (((evaluation K C).obj k).map f))
+
+lemma NatTrans.mono_iff_mono_app : Mono f ↔ ∀ (k : K), Mono (f.app k) :=
+  ⟨fun _ ↦ inferInstance, fun _ ↦ mono_of_mono_app _⟩
+
+instance [Mono f] (H : C ⥤ D) [H.PreservesMonomorphisms] :
+    Mono (whiskerRight f H) := by
+  have : ∀ X, Mono ((whiskerRight f H).app X) := by intros; dsimp; infer_instance
+  apply NatTrans.mono_of_mono_app
+
+end
+
+section
+
+variable [HasPushouts C]
+
+instance [Epi f] (k : K) : Epi (f.app k) :=
+  inferInstanceAs (Epi (((evaluation K C).obj k).map f))
+
+lemma NatTrans.epi_iff_epi_app : Epi f ↔ ∀ (k : K), Epi (f.app k) :=
+  ⟨fun _ ↦ inferInstance, fun _ ↦ epi_of_epi_app _⟩
+
+instance [Epi f] (H : C ⥤ D) [H.PreservesEpimorphisms] :
+    Epi (whiskerRight f H) := by
+  have : ∀ X, Epi ((whiskerRight f H).app X) := by intros; dsimp; infer_instance
+  apply NatTrans.epi_of_epi_app
+
+end
+
+end CategoryTheory

--- a/Mathlib/CategoryTheory/Sites/Subsheaf.lean
+++ b/Mathlib/CategoryTheory/Sites/Subsheaf.lean
@@ -5,6 +5,7 @@ Authors: Andrew Yang
 -/
 import Mathlib.CategoryTheory.Elementwise
 import Mathlib.CategoryTheory.Adjunction.Evaluation
+import Mathlib.CategoryTheory.Limits.FunctorCategoryEpiMono
 import Mathlib.Tactic.CategoryTheory.Elementwise
 import Mathlib.CategoryTheory.Adhesive
 import Mathlib.CategoryTheory.Sites.ConcreteSheafification

--- a/Mathlib/CategoryTheory/Sites/Subsheaf.lean
+++ b/Mathlib/CategoryTheory/Sites/Subsheaf.lean
@@ -359,7 +359,7 @@ instance isIso_toImagePresheaf {F F' : Cᵒᵖ ⥤ TypeMax.{v, w}} (f : F ⟶ F'
     rw [isIso_iff_bijective]
     constructor
     · intro x y e
-      have := (NatTrans.mono_iff_mono_app _ _).mp hf X
+      have := (NatTrans.mono_iff_mono_app f).mp hf X
       rw [mono_iff_injective] at this
       exact this (congr_arg Subtype.val e : _)
     · rintro ⟨_, ⟨x, rfl⟩⟩

--- a/Mathlib/CategoryTheory/Sites/Subsheaf.lean
+++ b/Mathlib/CategoryTheory/Sites/Subsheaf.lean
@@ -4,7 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Andrew Yang
 -/
 import Mathlib.CategoryTheory.Elementwise
-import Mathlib.CategoryTheory.Adjunction.Evaluation
 import Mathlib.CategoryTheory.Limits.FunctorCategoryEpiMono
 import Mathlib.Tactic.CategoryTheory.Elementwise
 import Mathlib.CategoryTheory.Adhesive

--- a/Mathlib/Topology/Sheaves/Stalks.lean
+++ b/Mathlib/Topology/Sheaves/Stalks.lean
@@ -6,7 +6,6 @@ Authors: Scott Morrison, Justus Springer
 import Mathlib.Topology.Category.TopCat.OpenNhds
 import Mathlib.Topology.Sheaves.Presheaf
 import Mathlib.Topology.Sheaves.SheafCondition.UniqueGluing
-import Mathlib.CategoryTheory.Adjunction.Evaluation
 import Mathlib.CategoryTheory.Limits.Types
 import Mathlib.CategoryTheory.Limits.Preserves.Filtered
 import Mathlib.CategoryTheory.Limits.Final

--- a/Mathlib/Topology/Sheaves/Stalks.lean
+++ b/Mathlib/Topology/Sheaves/Stalks.lean
@@ -474,7 +474,7 @@ instance stalkFunctor_preserves_mono (x : X) :
       (app_injective_iff_stalkFunctor_map_injective f.1).mpr
         (fun c =>
           (ConcreteCategory.mono_iff_injective_of_preservesPullback (f.1.app (op c))).mp
-            ((NatTrans.mono_iff_mono_app _ f.1).mp
+            ((NatTrans.mono_iff_mono_app f.1).mp
                 (CategoryTheory.presheaf_mono_of_mono ..) <|
               op c))
         x⟩
@@ -486,7 +486,7 @@ theorem stalk_mono_of_mono {F G : Sheaf C X} (f : F ⟶ G) [Mono f] :
 theorem mono_of_stalk_mono {F G : Sheaf C X} (f : F ⟶ G) [∀ x, Mono <| (stalkFunctor C x).map f.1] :
     Mono f :=
   (Sheaf.Hom.mono_iff_presheaf_mono _ _ _).mpr <|
-    (NatTrans.mono_iff_mono_app _ _).mpr fun U =>
+    (NatTrans.mono_iff_mono_app _).mpr fun U =>
       (ConcreteCategory.mono_iff_injective_of_preservesPullback _).mpr <|
         app_injective_of_stalkFunctor_map_injective f.1 U.unop fun ⟨_x, _hx⟩ =>
           (ConcreteCategory.mono_iff_injective_of_preservesPullback _).mp <| inferInstance


### PR DESCRIPTION
In this file, we obtain new versions of lemmas `NatTrans.mono_iff_mono_app` (resp. `NatTrans.epi_iff_epi_app`) when the category has pullbacks (resp. pushouts). The previous versions of these lemmas were deduced from the existence of adjunctions which relied on the existence of (co)products.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
