### PR TITLE
[Merged by Bors] - chore(assert_not_exists): tweak message

### DIFF
--- a/Mathlib/Util/AssertExists.lean
+++ b/Mathlib/Util/AssertExists.lean
@@ -78,6 +78,6 @@ one that is not currently imported!
 elab "assert_not_imported " ids:ident* : command => do
   let mods := (← getEnv).allImportedModuleNames
   for id in ids do
-    if mods.contains id.getId then logWarningAt id m!"'{id}' is imported"
+    if mods.contains id.getId then logWarningAt id m!"the module '{id}' is (transitively) imported"
     if let none ← (← searchPathRef.get).findModuleWithExt "olean" id.getId then
-      logWarningAt id m!"'{id}' does not exist"
+      logErrorAt id m!"the module '{id}' does not exist"

--- a/test/AssertExists.lean
+++ b/test/AssertExists.lean
@@ -1,9 +1,9 @@
 import Mathlib.Util.AssertExists
 
 /--
-warning: 'Lean.Elab.Command' is imported
+warning: the module 'Lean.Elab.Command' is (transitively) imported
 ---
-warning: 'I_do_not_exist' does not exist
+error: the module 'I_do_not_exist' does not exist
 -/
 #guard_msgs in
 assert_not_imported


### PR DESCRIPTION
Also, upgrade the warning about a non-existing module to an error.

------

The latter change seems more logical to me (it is clearly an error, at least in this command) --- but I could be convinced otherwise.

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
