### PR TITLE
[Merged by Bors] - feat(CategoryTheory/Elements): taking a functor to its category of elements is functorial

### DIFF
--- a/Mathlib/CategoryTheory/Elements.lean
+++ b/Mathlib/CategoryTheory/Elements.lean
@@ -64,6 +64,16 @@ instance categoryOfElements (F : C ⥤ Type w) : Category.{v} F.Elements where
   id p := ⟨𝟙 p.1, by aesop_cat⟩
   comp {X Y Z} f g := ⟨f.val ≫ g.val, by simp [f.2, g.2]⟩
 
+/-- The functor mapping a functor (C ⥤ Type w) to its category of elements -/
+def Functor.ElementsFunctor :  (C ⥤ Type w) ⥤ Cat where
+  obj F := Cat.of F.Elements
+  map {F G} n := {
+    obj := fun ⟨X,x⟩ ↦  ⟨X, n.app X x ⟩
+    map := fun ⟨X, x⟩ {Y} ⟨f,_⟩ ↦
+    match Y with | ⟨Y, y⟩ => ⟨f, by have := congrFun (n.naturality f) x;aesop_cat⟩
+  }
+
+
 namespace CategoryOfElements
 
 /-- Constructor for morphisms in the category of elements of a functor to types. -/

--- a/Mathlib/CategoryTheory/Elements.lean
+++ b/Mathlib/CategoryTheory/Elements.lean
@@ -71,6 +71,7 @@ def NatTrans.mapElements {F G : C ⥤ Type w} (φ : F ⟶ G) : F.Elements ⥤ G.
   map {p q} := fun ⟨f,h⟩ ↦ ⟨f, by have hb := congrFun (φ.naturality f) p.2; aesop_cat⟩
 
 /-- The functor mapping functors (C ⥤ Type w) to their category of elements -/
+@[simps]
 def Functor.elementsFunctor : (C ⥤ Type w) ⥤ Cat where
   obj F := Cat.of F.Elements
   map n := NatTrans.mapElements n

--- a/Mathlib/CategoryTheory/Elements.lean
+++ b/Mathlib/CategoryTheory/Elements.lean
@@ -70,7 +70,7 @@ def NatTrans.mapElements {F G : C ⥤ Type w} (φ : F ⟶ G) : F.Elements ⥤ G.
   obj := fun ⟨X, x⟩ ↦ ⟨_, φ.app X x⟩
   map {p q} := fun ⟨f,h⟩ ↦ ⟨f, by have hb := congrFun (φ.naturality f) p.2; aesop_cat⟩
 
-/-- The functor mapping functors (C ⥤ Type w) to their category of elements -/
+/-- The functor mapping functors `C ⥤ Type w` to their category of elements -/
 @[simps]
 def Functor.elementsFunctor : (C ⥤ Type w) ⥤ Cat where
   obj F := Cat.of F.Elements

--- a/Mathlib/CategoryTheory/Elements.lean
+++ b/Mathlib/CategoryTheory/Elements.lean
@@ -64,7 +64,7 @@ instance categoryOfElements (F : C ⥤ Type w) : Category.{v} F.Elements where
   id p := ⟨𝟙 p.1, by aesop_cat⟩
   comp {X Y Z} f g := ⟨f.val ≫ g.val, by simp [f.2, g.2]⟩
 
-/-- Natural transformations are mapped to functor between category of elements -/
+/-- Natural transformations are mapped to functors between category of elements -/
 @[simps]
 def NatTrans.mapElements {F G : C ⥤ Type w} (φ : F ⟶ G) : F.Elements ⥤ G.Elements where
   obj := fun ⟨X, x⟩ ↦ ⟨_, φ.app X x⟩

--- a/Mathlib/CategoryTheory/Elements.lean
+++ b/Mathlib/CategoryTheory/Elements.lean
@@ -71,9 +71,9 @@ def NatTrans.mapElements {F G : C ⥤ Type w} (φ : F ⟶ G) : F.Elements ⥤ G.
   map {p q} := fun ⟨f,h⟩ ↦ ⟨f, by have hb := congrFun (φ.naturality f) p.2; aesop_cat⟩
 
 /-- The functor mapping functors (C ⥤ Type w) to their category of elements -/
-def Functor.elementsFunctor :  (C ⥤ Type w) ⥤ Cat where
+def Functor.elementsFunctor : (C ⥤ Type w) ⥤ Cat where
   obj F := Cat.of F.Elements
-  map {F G} n := NatTrans.mapElements n
+  map n := NatTrans.mapElements n
 
 namespace CategoryOfElements
 

--- a/Mathlib/CategoryTheory/Elements.lean
+++ b/Mathlib/CategoryTheory/Elements.lean
@@ -64,15 +64,16 @@ instance categoryOfElements (F : C ⥤ Type w) : Category.{v} F.Elements where
   id p := ⟨𝟙 p.1, by aesop_cat⟩
   comp {X Y Z} f g := ⟨f.val ≫ g.val, by simp [f.2, g.2]⟩
 
-/-- The functor mapping a functor (C ⥤ Type w) to its category of elements -/
-def Functor.ElementsFunctor :  (C ⥤ Type w) ⥤ Cat where
-  obj F := Cat.of F.Elements
-  map {F G} n := {
-    obj := fun ⟨X,x⟩ ↦  ⟨X, n.app X x ⟩
-    map := fun ⟨X, x⟩ {Y} ⟨f,_⟩ ↦
-    match Y with | ⟨Y, y⟩ => ⟨f, by have := congrFun (n.naturality f) x;aesop_cat⟩
-  }
+/-- Natural transformations are mapped to functor between category of elements -/
+@[simps]
+def NatTrans.mapElements {F G : C ⥤ Type w} (φ : F ⟶ G) : F.Elements ⥤ G.Elements where
+  obj := fun ⟨X, x⟩ ↦ ⟨_, φ.app X x⟩
+  map {p q} := fun ⟨f,h⟩ ↦ ⟨f, by have hb := congrFun (φ.naturality f) p.2; aesop_cat⟩
 
+/-- The functor mapping functors (C ⥤ Type w) to their category of elements -/
+def Functor.elementsFunctor :  (C ⥤ Type w) ⥤ Cat where
+  obj F := Cat.of F.Elements
+  map {F G} n := NatTrans.mapElements n
 
 namespace CategoryOfElements
 

--- a/Mathlib/CategoryTheory/Elements.lean
+++ b/Mathlib/CategoryTheory/Elements.lean
@@ -68,7 +68,7 @@ instance categoryOfElements (F : C ⥤ Type w) : Category.{v} F.Elements where
 @[simps]
 def NatTrans.mapElements {F G : C ⥤ Type w} (φ : F ⟶ G) : F.Elements ⥤ G.Elements where
   obj := fun ⟨X, x⟩ ↦ ⟨_, φ.app X x⟩
-  map {p q} := fun ⟨f,h⟩ ↦ ⟨f, by have hb := congrFun (φ.naturality f) p.2; aesop_cat⟩
+  map {p q} := fun ⟨f, h⟩ ↦ ⟨f, by have hb := congrFun (φ.naturality f) p.2; aesop_cat⟩
 
 /-- The functor mapping functors `C ⥤ Type w` to their category of elements -/
 @[simps]


### PR DESCRIPTION

---

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
