### PR TITLE
[Merged by Bors] - chore: better failures for `linear_combination`

### DIFF
--- a/Mathlib/Tactic/LinearCombination.lean
+++ b/Mathlib/Tactic/LinearCombination.lean
@@ -138,7 +138,7 @@ def elabLinearCombination
     | .const c => `(Eq.refl $c)
     | .proof p => pure p
   let norm := norm?.getD (Unhygienic.run `(tactic| ring1))
-  Tactic.evalTactic <| ← withFreshMacroScope <|
+  Term.withoutErrToSorry <| Tactic.evalTactic <| ← withFreshMacroScope <|
   if twoGoals then
     `(tactic| (
       refine eq_trans₃ $p ?a ?b

--- a/test/linear_combination.lean
+++ b/test/linear_combination.lean
@@ -184,13 +184,42 @@ example (x y : ℤ) (h1 : x * y + 2 * x = 1) (h2 : x = y) : x * y = -2 * y + 1 :
 
 /-! ### Cases that should fail -/
 
+-- FIXME unhelpful error message here but it's the fault of a `simp only` inside `ring1`
+/--
+error: ring failed, ring expressions not equal
+a : ℤ
+ha : a = 1
+⊢ False
+-/
+#guard_msgs in
+example (a : ℤ) (ha : a = 1) : a = 2 := by linear_combination ha
+
+/--
+error: ring failed, ring expressions not equal
+a : ℚ
+ha : a = 1
+⊢ -1 = 0
+-/
+#guard_msgs in
+example (a : ℚ) (ha : a = 1) : a = 2 := by linear_combination ha
+
 -- This should fail because the second coefficient has a different type than
 --   the equations it is being combined with.  This was a design choice for the
 --   sake of simplicity, but the tactic could potentially be modified to allow
 --   this behavior.
+/--
+error: application type mismatch
+  Mathlib.Tactic.LinearCombination.c_mul_pf h2 0
+argument
+  0
+has type
+  ℝ : Type
+but is expected to have type
+  ℤ : Type
+-/
+#guard_msgs in
 example (x y : ℤ) (h1 : x * y + 2 * x = 1) (h2 : x = y) : x * y + 2 * x = 1 := by
-  fail_if_success linear_combination h1 + (0 : ℝ) * h2
-  linear_combination h1
+  linear_combination h1 + (0 : ℝ) * h2
 
 -- This fails because the linear_combination tactic requires the equations
 --   and coefficients to use a type that fulfills the add_group condition,

--- a/test/linear_combination.lean
+++ b/test/linear_combination.lean
@@ -184,16 +184,6 @@ example (x y : ℤ) (h1 : x * y + 2 * x = 1) (h2 : x = y) : x * y = -2 * y + 1 :
 
 /-! ### Cases that should fail -/
 
--- FIXME unhelpful error message here but it's the fault of a `simp only` inside `ring1`
-/--
-error: ring failed, ring expressions not equal
-a : ℤ
-ha : a = 1
-⊢ False
--/
-#guard_msgs in
-example (a : ℤ) (ha : a = 1) : a = 2 := by linear_combination ha
-
 /--
 error: ring failed, ring expressions not equal
 a : ℚ


### PR DESCRIPTION
The implementation of `linear_combination` is as a macro performing effectively `refine ******; ring`.  If the term provided to `refine` fails to elaborate, Lean inserts sorries where needed and then continues on to `ring`.  This produces a confusing error message.  For example, the problem
```lean
example (x y : ℤ) (h1 : x * y + 2 * x = 1) (h2 : x = y) : x * y + 2 * x = 1 := by
  linear_combination h1 + (0 : ℝ) * h2
```
produces both the "true" error message
```
application type mismatch
  Mathlib.Tactic.LinearCombination.c_mul_pf h2 0
argument
  0
has type
  ℝ : Type
but is expected to have type
  ℤ : Type
```
and the "tactic is confused because it persevered when it shouldn't have" error message
```
ring failed, ring expressions not equal
x y : ℤ
h1 : x * y + 2 * x = 1
h2 : x = y
⊢ -(x * sorryAx ℤ true) + y * sorryAx ℤ true = 0
```

This PR fixes this by strategically inserting a `Term.withoutErrToSorry`.  In examples such as the above, it now stops after the `refine`, so the second error message does not appear.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
