### PR TITLE
[Merged by Bors] - fix: `assert_not_exists` takes at least one input

### DIFF
--- a/Mathlib/Util/AssertExists.lean
+++ b/Mathlib/Util/AssertExists.lean
@@ -75,7 +75,7 @@ among the transitive imports of the current file.
 It also checks that each one of `m₁ m₂ ... mₙ` is actually the name of an existing module, just
 one that is not currently imported!
 -/
-elab "assert_not_imported " ids:ident* : command => do
+elab "assert_not_imported " ids:ident+ : command => do
   let mods := (← getEnv).allImportedModuleNames
   for id in ids do
     if mods.contains id.getId then logWarningAt id m!"the module '{id}' is (transitively) imported"


### PR DESCRIPTION
[Reported on Zulip](https://leanprover.zulipchat.com/#narrow/stream/217875-Is-there-code-for-X.3F/topic/assert_not_imported/near/462220460).

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
