### PR TITLE
feat(RingTheory/MvPolynomial/Ideal): introduce new lemmas about MvPolynomial Ideals

### DIFF
--- a/Mathlib/RingTheory/MvPolynomial/Ideal.lean
+++ b/Mathlib/RingTheory/MvPolynomial/Ideal.lean
@@ -49,4 +49,42 @@ theorem mem_ideal_span_X_image {x : MvPolynomial σ R} {s : Set σ} :
   refine this.trans ?_
   simp [Nat.one_le_iff_ne_zero]
 
+/-- If a set `A` is contained in the span of another `B` then the span of `A` is also contained. -/
+lemma sub_span_span_sub {A B : Set (MvPolynomial σ R)} (h : A ⊆ Ideal.span B) :
+    SetLike.coe (Ideal.span A) ⊆ Ideal.span B := by
+  simp only [SetLike.coe_subset_coe, Ideal.span_le.mpr h]
+
+/-- Spans of two sets `A`, `B` are equal if and only if each is contained in the span of the
+other -/
+lemma span_eq_iff_basis_sub (A B : Set (MvPolynomial σ R)) :
+    Ideal.span A = Ideal.span B ↔ A ⊆ Ideal.span B ∧ B ⊆ Ideal.span A := by
+  constructor
+  · intro h
+    constructor
+    · simpa [← h] using Ideal.subset_span
+    · simpa [h] using Ideal.subset_span
+  · intro ⟨hA, hB⟩
+    simpa [← SetLike.coe_set_eq, Set.Subset.antisymm_iff] using
+    ⟨sub_span_span_sub hA, sub_span_span_sub hB⟩
+
+/-- If an element is a member of the basis of a span, it is in the span. -/
+lemma mem_basis_mem_span {x : MvPolynomial σ R} {A : Set (MvPolynomial σ R)} (h : x ∈ A) :
+    x ∈ Ideal.span A := by
+  apply Ideal.subset_span
+  simp_all only
+
+variable [Nontrivial R]
+
+/-- If a monomial `m` is contained in the span of a basis of monomials, there must be an
+element of the basis dividing `m`. -/
+lemma mem_span_exists_dvd_mem_basis {S : Set (σ →₀ ℕ)} (s : σ →₀ ℕ)
+    (h : monomial s 1 ∈ Ideal.span ((fun s ↦ monomial s (1 : R)) '' S)) :
+    ∃ i ∈ S, monomial i (1 : R) ∣ monomial s 1 := by
+ classical
+ rcases mem_ideal_span_monomial_image_iff_dvd.1 h s (by
+  simp only [support_monomial, if_neg one_ne_zero, Finset.mem_singleton_self]) with ⟨j, hS, hj⟩
+ use j, hS
+ simpa [coeff_monomial, if_pos] using hj
+
+
 end MvPolynomial

--- a/Mathlib/RingTheory/MvPolynomial/Ideal.lean
+++ b/Mathlib/RingTheory/MvPolynomial/Ideal.lean
@@ -51,7 +51,7 @@ theorem mem_ideal_span_X_image {x : MvPolynomial σ R} {s : Set σ} :
 
 /-- If a set `A` is contained in the span of another `B` then the span of `A` is also contained. -/
 lemma sub_span_span_sub {A B : Set (MvPolynomial σ R)} (h : A ⊆ Ideal.span B) :
-    SetLike.coe (Ideal.span A) ⊆ Ideal.span B := by
+    (Ideal.span A : Set (MvPolynomial σ R)) ⊆ Ideal.span B := by
   simp only [SetLike.coe_subset_coe, Ideal.span_le.mpr h]
 
 /-- Spans of two sets `A`, `B` are equal if and only if each is contained in the span of the

--- a/Mathlib/RingTheory/MvPolynomial/Ideal.lean
+++ b/Mathlib/RingTheory/MvPolynomial/Ideal.lean
@@ -65,7 +65,7 @@ lemma span_eq_iff_basis_sub (A B : Set (MvPolynomial σ R)) :
     · simpa [h] using Ideal.subset_span
   · intro ⟨hA, hB⟩
     simpa [← SetLike.coe_set_eq, Set.Subset.antisymm_iff] using
-    ⟨sub_span_span_sub hA, sub_span_span_sub hB⟩
+      ⟨sub_span_span_sub hA, sub_span_span_sub hB⟩
 
 /-- If an element is a member of the basis of a span, it is in the span. -/
 lemma mem_basis_mem_span {x : MvPolynomial σ R} {A : Set (MvPolynomial σ R)} (h : x ∈ A) :

--- a/Mathlib/RingTheory/MvPolynomial/Ideal.lean
+++ b/Mathlib/RingTheory/MvPolynomial/Ideal.lean
@@ -80,11 +80,11 @@ element of the basis dividing `m`. -/
 lemma mem_span_exists_dvd_mem_basis {S : Set (σ →₀ ℕ)} (s : σ →₀ ℕ)
     (h : monomial s 1 ∈ Ideal.span ((fun s ↦ monomial s (1 : R)) '' S)) :
     ∃ i ∈ S, monomial i (1 : R) ∣ monomial s 1 := by
- classical
- rcases mem_ideal_span_monomial_image_iff_dvd.1 h s (by
-  simp only [support_monomial, if_neg one_ne_zero, Finset.mem_singleton_self]) with ⟨j, hS, hj⟩
- use j, hS
- simpa [coeff_monomial, if_pos] using hj
+  classical
+  rcases mem_ideal_span_monomial_image_iff_dvd.1 h s (by
+    simp only [support_monomial, if_neg one_ne_zero, Finset.mem_singleton_self]) with ⟨j, hS, hj⟩
+  use j, hS
+  simpa [coeff_monomial, if_pos] using hj
 
 
 end MvPolynomial


### PR DESCRIPTION
Four new lemmas about MvPolynomialIdeals `sub_span_span_sub`, `span_eq_iff_basis_sub`, `mem_basis_mem_span`, `mem_span_exists_dvd_mem_basis`. 

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
