### PR TITLE
[Merged by Bors] - feat(mk_all): import Batteries in Mathlib.lean

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -1,3 +1,4 @@
+import Batteries
 import Mathlib.Algebra.AddConstMap.Basic
 import Mathlib.Algebra.AddConstMap.Equiv
 import Mathlib.Algebra.AddTorsor

--- a/scripts/lint-style.lean
+++ b/scripts/lint-style.lean
@@ -25,7 +25,9 @@ def lintStyleCli (args : Cli.Parsed) : IO UInt32 := do
   -- Read all module names to lint.
   let mut allModules := #[]
   for s in ["Archive.lean", "Counterexamples.lean", "Mathlib.lean"] do
-    allModules := allModules.append ((← IO.FS.lines s).map (·.stripPrefix "import "))
+    -- note: since we manually add "Batteries" to "Mathlib.lean", we remove it here manually
+    allModules := allModules.append ((← IO.FS.lines s).filter (!·.containsSubstr "Batteries")
+      |>.map (·.stripPrefix "import "))
   let numberErrorFiles ← lintModules allModules mode
   -- Make sure to return an exit code of at most 125, so this return value can be used further
   -- in shell scripts.

--- a/scripts/mk_all.lean
+++ b/scripts/mk_all.lean
@@ -50,7 +50,10 @@ def mkAllCLI (args : Parsed) : IO UInt32 := do
   let mut updates := 0
   for d in libs.reverse do  -- reverse to create `Mathlib/Tactic.lean` before `Mathlib.lean`
     let fileName := addExtension d "lean"
-    let allFiles ← getAllModulesSorted git d
+    let mut allFiles ← getAllModulesSorted git d
+    -- mathlib exception: manually import Batteries in `Mathlib.lean`
+    if d == "Mathlib" then
+      allFiles := #["Batteries"] ++ allFiles
     let fileContent := ("\n".intercalate (allFiles.map ("import " ++ ·)).toList).push '\n'
     if !(← pathExists fileName) then
       if check then


### PR DESCRIPTION
Add a special case for Mathlib to add `import Batteries` to `Mathlib.lean`

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
