### PR TITLE
[Merged by Bors] - feat: Actions on and by an order synonym

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -557,6 +557,7 @@ import Mathlib.Algebra.Order.Floor.Div
 import Mathlib.Algebra.Order.Floor.Prime
 import Mathlib.Algebra.Order.Group.Abs
 import Mathlib.Algebra.Order.Group.Action
+import Mathlib.Algebra.Order.Group.Action.Synonym
 import Mathlib.Algebra.Order.Group.Basic
 import Mathlib.Algebra.Order.Group.Bounds
 import Mathlib.Algebra.Order.Group.Cone
@@ -579,6 +580,7 @@ import Mathlib.Algebra.Order.Group.Unbundled.Abs
 import Mathlib.Algebra.Order.Group.Unbundled.Basic
 import Mathlib.Algebra.Order.Group.Unbundled.Int
 import Mathlib.Algebra.Order.Group.Units
+import Mathlib.Algebra.Order.GroupWithZero.Action.Synonym
 import Mathlib.Algebra.Order.GroupWithZero.Canonical
 import Mathlib.Algebra.Order.GroupWithZero.Synonym
 import Mathlib.Algebra.Order.GroupWithZero.Unbundled

--- a/Mathlib/Algebra/Order/Group/Action/Synonym.lean
+++ b/Mathlib/Algebra/Order/Group/Action/Synonym.lean
@@ -1,0 +1,88 @@
+/-
+Copyright (c) 2021 Yaël Dillies. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Yaël Dillies
+-/
+import Mathlib.Algebra.Group.Action.Defs
+import Mathlib.Algebra.Order.Group.Synonym
+
+/-!
+# Actions by and on order synonyms
+
+This PR transfers group action instances from a type `α` to `αᵒᵈ` and `Lex α`.
+
+## See also
+
+* `Mathlib.Algebra.Order.GroupWithZero.Action.Synonym`
+* `Mathlib.Algebra.Order.Module.Synonym`
+-/
+
+variable {M N α : Type*}
+
+namespace OrderDual
+
+@[to_additive]
+instance instMulAction [Monoid M] [MulAction M α] : MulAction Mᵒᵈ α := ‹MulAction M α›
+
+@[to_additive]
+instance instMulAction' [Monoid M] [MulAction M α] : MulAction M αᵒᵈ := ‹MulAction M α›
+
+@[to_additive]
+instance instSMulCommClass [SMul M α] [SMul N α] [SMulCommClass M N α] : SMulCommClass Mᵒᵈ N α :=
+  ‹SMulCommClass M N α›
+
+@[to_additive]
+instance instSMulCommClass' [SMul M α] [SMul N α] [SMulCommClass M N α] : SMulCommClass M Nᵒᵈ α :=
+  ‹SMulCommClass M N α›
+
+@[to_additive]
+instance instSMulCommClass'' [SMul M α] [SMul N α] [SMulCommClass M N α] : SMulCommClass M N αᵒᵈ :=
+  ‹SMulCommClass M N α›
+
+@[to_additive instVAddAssocClass]
+instance instIsScalarTower [SMul M N] [SMul M α] [SMul N α] [IsScalarTower M N α] :
+    IsScalarTower Mᵒᵈ N α := ‹IsScalarTower M N α›
+
+@[to_additive instVAddAssocClass']
+instance instIsScalarTower' [SMul M N] [SMul M α] [SMul N α] [IsScalarTower M N α] :
+    IsScalarTower M Nᵒᵈ α := ‹IsScalarTower M N α›
+
+@[to_additive instVAddAssocClass'']
+instance instIsScalarTower'' [SMul M N] [SMul M α] [SMul N α] [IsScalarTower M N α] :
+    IsScalarTower M N αᵒᵈ := ‹IsScalarTower M N α›
+
+end OrderDual
+
+namespace Lex
+
+@[to_additive]
+instance instMulAction [Monoid M] [MulAction M α] : MulAction (Lex M) α := ‹MulAction M α›
+
+@[to_additive]
+instance instMulAction' [Monoid M] [MulAction M α] : MulAction M (Lex α) := ‹MulAction M α›
+
+@[to_additive]
+instance instSMulCommClass [SMul M α] [SMul N α] [SMulCommClass M N α] :
+    SMulCommClass (Lex M) N α := ‹SMulCommClass M N α›
+
+@[to_additive]
+instance instSMulCommClass' [SMul M α] [SMul N α] [SMulCommClass M N α] :
+    SMulCommClass M (Lex N) α := ‹SMulCommClass M N α›
+
+@[to_additive]
+instance instSMulCommClass'' [SMul M α] [SMul N α] [SMulCommClass M N α] :
+    SMulCommClass M N (Lex α) := ‹SMulCommClass M N α›
+
+@[to_additive instVAddAssocClass]
+instance instIsScalarTower [SMul M N] [SMul M α] [SMul N α] [IsScalarTower M N α] :
+    IsScalarTower (Lex M) N α := ‹IsScalarTower M N α›
+
+@[to_additive instVAddAssocClass']
+instance instIsScalarTower' [SMul M N] [SMul M α] [SMul N α] [IsScalarTower M N α] :
+    IsScalarTower M (Lex N) α := ‹IsScalarTower M N α›
+
+@[to_additive instVAddAssocClass'']
+instance instIsScalarTower'' [SMul M N] [SMul M α] [SMul N α] [IsScalarTower M N α] :
+    IsScalarTower M N (Lex α) := ‹IsScalarTower M N α›
+
+end Lex

--- a/Mathlib/Algebra/Order/GroupWithZero/Action/Synonym.lean
+++ b/Mathlib/Algebra/Order/GroupWithZero/Action/Synonym.lean
@@ -1,0 +1,78 @@
+/-
+Copyright (c) 2021 Yaël Dillies. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Yaël Dillies
+-/
+import Mathlib.Algebra.Order.GroupWithZero.Synonym
+import Mathlib.Algebra.SMulWithZero
+import Mathlib.Tactic.Common
+
+/-!
+# Actions by and on order synonyms
+
+This PR transfers group action with zero instances from a type `α` to `αᵒᵈ` and `Lex α`. Note that
+the `SMul` instances are already defined in `Mathlib.Algebra.Order.Group.Synonym`.
+
+## See also
+
+* `Mathlib.Algebra.Order.Group.Action.Synonym`
+* `Mathlib.Algebra.Order.Module.Synonym`
+-/
+
+variable {G₀ M₀ : Type*}
+
+namespace OrderDual
+
+instance instSMulWithZero [Zero G₀] [Zero M₀] [SMulWithZero G₀ M₀] : SMulWithZero G₀ᵒᵈ M₀ :=
+  ‹SMulWithZero G₀ M₀›
+
+instance instSMulWithZero' [Zero G₀] [Zero M₀] [SMulWithZero G₀ M₀] : SMulWithZero G₀ M₀ᵒᵈ :=
+  ‹SMulWithZero G₀ M₀›
+
+instance instDistribSMul [AddZeroClass M₀] [DistribSMul G₀ M₀] : DistribSMul G₀ᵒᵈ M₀ :=
+  ‹DistribSMul G₀ M₀›
+
+instance instDistribSMul' [AddZeroClass M₀] [DistribSMul G₀ M₀] : DistribSMul G₀ M₀ᵒᵈ :=
+  ‹DistribSMul G₀ M₀›
+
+instance instDistribMulAction [Monoid G₀] [AddMonoid M₀] [DistribMulAction G₀ M₀] :
+    DistribMulAction G₀ᵒᵈ M₀ := ‹DistribMulAction G₀ M₀›
+
+instance instDistribMulAction' [Monoid G₀] [AddMonoid M₀] [DistribMulAction G₀ M₀] :
+    DistribMulAction G₀ M₀ᵒᵈ := ‹DistribMulAction G₀ M₀›
+
+instance instMulActionWithZero [MonoidWithZero G₀] [AddMonoid M₀] [MulActionWithZero G₀ M₀] :
+    MulActionWithZero G₀ᵒᵈ M₀ := ‹MulActionWithZero G₀ M₀›
+
+instance instMulActionWithZero' [MonoidWithZero G₀] [AddMonoid M₀] [MulActionWithZero G₀ M₀] :
+    MulActionWithZero G₀ M₀ᵒᵈ := ‹MulActionWithZero G₀ M₀›
+
+end OrderDual
+
+namespace Lex
+
+instance instSMulWithZero [Zero G₀] [Zero M₀] [SMulWithZero G₀ M₀] : SMulWithZero (Lex G₀) M₀ :=
+  ‹SMulWithZero G₀ M₀›
+
+instance instSMulWithZero' [Zero G₀] [Zero M₀] [SMulWithZero G₀ M₀] : SMulWithZero G₀ (Lex M₀) :=
+  ‹SMulWithZero G₀ M₀›
+
+instance instDistribSMul [AddZeroClass M₀] [DistribSMul G₀ M₀] : DistribSMul (Lex G₀) M₀ :=
+  ‹DistribSMul G₀ M₀›
+
+instance instDistribSMul' [AddZeroClass M₀] [DistribSMul G₀ M₀] : DistribSMul G₀ (Lex M₀) :=
+  ‹DistribSMul G₀ M₀›
+
+instance instDistribMulAction [Monoid G₀] [AddMonoid M₀] [DistribMulAction G₀ M₀] :
+    DistribMulAction (Lex G₀) M₀ := ‹DistribMulAction G₀ M₀›
+
+instance instDistribMulAction' [Monoid G₀] [AddMonoid M₀] [DistribMulAction G₀ M₀] :
+    DistribMulAction G₀ (Lex M₀) := ‹DistribMulAction G₀ M₀›
+
+instance instMulActionWithZero [MonoidWithZero G₀] [AddMonoid M₀] [MulActionWithZero G₀ M₀] :
+    MulActionWithZero (Lex G₀) M₀ := ‹MulActionWithZero G₀ M₀›
+
+instance instMulActionWithZero' [MonoidWithZero G₀] [AddMonoid M₀] [MulActionWithZero G₀ M₀] :
+    MulActionWithZero G₀ (Lex M₀) := ‹MulActionWithZero G₀ M₀›
+
+end Lex

--- a/Mathlib/Algebra/Order/Module/Defs.lean
+++ b/Mathlib/Algebra/Order/Module/Defs.lean
@@ -5,7 +5,7 @@ Authors: Yaël Dillies
 -/
 import Mathlib.Algebra.Module.Defs
 import Mathlib.Algebra.Order.Field.Defs
-import Mathlib.Algebra.Order.Module.Synonym
+import Mathlib.Algebra.Order.GroupWithZero.Action.Synonym
 import Mathlib.Tactic.Positivity.Core
 
 /-!

--- a/Mathlib/Algebra/Order/Module/Defs.lean
+++ b/Mathlib/Algebra/Order/Module/Defs.lean
@@ -3,8 +3,9 @@ Copyright (c) 2023 Yaël Dillies. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Yaël Dillies
 -/
+import Mathlib.Algebra.Module.Defs
 import Mathlib.Algebra.Order.Field.Defs
-import Mathlib.Algebra.Order.GroupWithZero.Unbundled
+import Mathlib.Algebra.Order.Field.Unbundled.Basic
 import Mathlib.Algebra.Order.Module.Synonym
 import Mathlib.Tactic.Positivity.Core
 

--- a/Mathlib/Algebra/Order/Module/Defs.lean
+++ b/Mathlib/Algebra/Order/Module/Defs.lean
@@ -5,7 +5,6 @@ Authors: Yaël Dillies
 -/
 import Mathlib.Algebra.Module.Defs
 import Mathlib.Algebra.Order.Field.Defs
-import Mathlib.Algebra.Order.Field.Unbundled.Basic
 import Mathlib.Algebra.Order.Module.Synonym
 import Mathlib.Tactic.Positivity.Core
 

--- a/Mathlib/Algebra/Order/Module/Synonym.lean
+++ b/Mathlib/Algebra/Order/Module/Synonym.lean
@@ -4,83 +4,25 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Yaël Dillies
 -/
 import Mathlib.Algebra.Module.Defs
-import Mathlib.Algebra.Order.GroupWithZero.Synonym
+import Mathlib.Algebra.Order.GroupWithZero.Action.Synonym
 import Mathlib.Algebra.Order.Ring.Synonym
 
 /-!
 # Action instances for `OrderDual`
 
-This file provides instances of algebraic actions for `OrderDual`. Note that the `SMul` instances
-are already defined in `Mathlib.Algebra.Order.Group.Synonym`.
+
+This PR transfers group action with zero instances from a type `α` to `αᵒᵈ` and `Lex α`. Note that
+the `SMul` instances are already defined in `Mathlib.Algebra.Order.Group.Synonym`.
 
 ## See also
 
-* `Mathlib.Algebra.Order.Group.Synonym`
-* `Mathlib.Algebra.Order.Ring.Synonym`
+* `Mathlib.Algebra.Order.Group.Action.Synonym`
+* `Mathlib.Algebra.Order.GroupWithZero.Action.Synonym`
 -/
 
+variable {α β : Type*}
+
 namespace OrderDual
-variable {α β γ : Type*}
-
-instance instSMulWithZero [Zero α] [Zero β] [SMulWithZero α β] : SMulWithZero αᵒᵈ β where
-  zero_smul := zero_smul α
-  smul_zero := smul_zero (M := α)
-
-instance instSMulWithZero' [Zero α] [Zero β] [SMulWithZero α β] : SMulWithZero α βᵒᵈ where
-  zero_smul := zero_smul _ (M := β)
-  smul_zero := smul_zero (A := β)
-
-@[to_additive]
-instance instMulAction [Monoid α] [MulAction α β] : MulAction αᵒᵈ β where
-  one_smul := one_smul α
-  mul_smul := mul_smul (α := α)
-
-@[to_additive]
-instance instMulAction' [Monoid α] [MulAction α β] : MulAction α βᵒᵈ where
-  one_smul := one_smul _ (α := β)
-  mul_smul := mul_smul (β := β)
-
-@[to_additive]
-instance instSMulCommClass [SMul β γ] [SMul α γ] [SMulCommClass α β γ] : SMulCommClass αᵒᵈ β γ :=
-   ‹SMulCommClass α β γ›
-
-@[to_additive]
-instance instSMulCommClass' [SMul β γ] [SMul α γ] [SMulCommClass α β γ] : SMulCommClass α βᵒᵈ γ :=
-  ‹SMulCommClass α β γ›
-
-@[to_additive]
-instance instSMulCommClass'' [SMul β γ] [SMul α γ] [SMulCommClass α β γ] : SMulCommClass α β γᵒᵈ :=
-  ‹SMulCommClass α β γ›
-
-@[to_additive instVAddAssocClass]
-instance instIsScalarTower [SMul α β] [SMul β γ] [SMul α γ] [IsScalarTower α β γ] :
-   IsScalarTower αᵒᵈ β γ := ‹IsScalarTower α β γ›
-
-@[to_additive instVAddAssocClass']
-instance instIsScalarTower' [SMul α β] [SMul β γ] [SMul α γ] [IsScalarTower α β γ] :
-    IsScalarTower α βᵒᵈ γ := ‹IsScalarTower α β γ›
-
-@[to_additive instVAddAssocClass'']
-instance instIsScalarTower'' [SMul α β] [SMul β γ] [SMul α γ] [IsScalarTower α β γ] :
-    IsScalarTower α β γᵒᵈ := ‹IsScalarTower α β γ›
-
-instance instMulActionWithZero [MonoidWithZero α] [AddMonoid β] [MulActionWithZero α β] :
-    MulActionWithZero αᵒᵈ β :=
-  { OrderDual.instMulAction, OrderDual.instSMulWithZero with }
-
-instance instMulActionWithZero' [MonoidWithZero α] [AddMonoid β] [MulActionWithZero α β] :
-    MulActionWithZero α βᵒᵈ :=
-  { OrderDual.instMulAction', OrderDual.instSMulWithZero' with }
-
-instance instDistribMulAction [MonoidWithZero α] [AddMonoid β] [DistribMulAction α β] :
-    DistribMulAction αᵒᵈ β where
-  smul_add := smul_add (M := α)
-  smul_zero := smul_zero (M := α)
-
-instance instDistribMulAction' [MonoidWithZero α] [AddMonoid β] [DistribMulAction α β] :
-    DistribMulAction α βᵒᵈ where
-  smul_add := smul_add (A := β)
-  smul_zero := smul_zero (A := β)
 
 instance instModule [Semiring α] [AddCommMonoid β] [Module α β] : Module αᵒᵈ β where
   add_smul := add_smul (R := α)
@@ -91,3 +33,13 @@ instance instModule' [Semiring α] [AddCommMonoid β] [Module α β] : Module α
   zero_smul := zero_smul _
 
 end OrderDual
+
+namespace Lex
+
+instance instModule [Semiring α] [AddCommMonoid β] [Module α β] : Module (Lex α) β :=
+  ‹Module α β›
+
+instance instModule' [Semiring α] [AddCommMonoid β] [Module α β] : Module α (Lex β) :=
+  ‹Module α β›
+
+end Lex

--- a/Mathlib/Algebra/Order/Monovary.lean
+++ b/Mathlib/Algebra/Order/Monovary.lean
@@ -6,6 +6,7 @@ Authors: Yaël Dillies
 import Mathlib.Algebra.Order.Field.Basic
 import Mathlib.Algebra.Order.Group.Instances
 import Mathlib.Algebra.Order.Module.OrderedSMul
+import Mathlib.Algebra.Order.Module.Synonym
 import Mathlib.Algebra.Order.Monoid.Unbundled.MinMax
 import Mathlib.Order.Monotone.Monovary
 

--- a/Mathlib/Algebra/Order/Rearrangement.lean
+++ b/Mathlib/Algebra/Order/Rearrangement.lean
@@ -4,8 +4,9 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Mantas Bakšys
 -/
 import Mathlib.Algebra.BigOperators.Group.Finset
-import Mathlib.Algebra.Order.Module.OrderedSMul
 import Mathlib.Algebra.Order.Group.Instances
+import Mathlib.Algebra.Order.Module.OrderedSMul
+import Mathlib.Algebra.Order.Module.Synonym
 import Mathlib.Data.Prod.Lex
 import Mathlib.Data.Set.Image
 import Mathlib.GroupTheory.Perm.Support

--- a/Mathlib/Analysis/Convex/Basic.lean
+++ b/Mathlib/Analysis/Convex/Basic.lean
@@ -5,6 +5,7 @@ Authors: Alexander Bentkamp, Yury Kudryashov, Yaël Dillies
 -/
 import Mathlib.Algebra.Order.BigOperators.Ring.Finset
 import Mathlib.Algebra.Order.Module.OrderedSMul
+import Mathlib.Algebra.Order.Module.Synonym
 import Mathlib.Analysis.Convex.Star
 import Mathlib.LinearAlgebra.AffineSpace.AffineSubspace
 

--- a/Mathlib/Analysis/Convex/Star.lean
+++ b/Mathlib/Analysis/Convex/Star.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Yaël Dillies
 -/
 import Mathlib.Algebra.Module.LinearMap.Prod
+import Mathlib.Algebra.Order.Module.Synonym
 import Mathlib.Algebra.Order.Group.Instances
 import Mathlib.Analysis.Convex.Segment
 import Mathlib.Tactic.GCongr

--- a/Mathlib/LinearAlgebra/AffineSpace/Ordered.lean
+++ b/Mathlib/LinearAlgebra/AffineSpace/Ordered.lean
@@ -4,9 +4,10 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Yury Kudryashov
 -/
 import Mathlib.Algebra.CharP.Invertible
+import Mathlib.Algebra.Order.Group.Instances
 import Mathlib.Algebra.Order.Invertible
 import Mathlib.Algebra.Order.Module.OrderedSMul
-import Mathlib.Algebra.Order.Group.Instances
+import Mathlib.Algebra.Order.Module.Synonym
 import Mathlib.LinearAlgebra.AffineSpace.Slope
 import Mathlib.LinearAlgebra.AffineSpace.Midpoint
 import Mathlib.Tactic.FieldSimp

--- a/scripts/noshake.json
+++ b/scripts/noshake.json
@@ -379,6 +379,7 @@
   "Mathlib.Analysis.InnerProductSpace.Basic":
   ["Mathlib.Algebra.Module.LinearMap.Basic"],
   "Mathlib.Analysis.Distribution.SchwartzSpace": ["Mathlib.Tactic.MoveAdd"],
+  "Mathlib.Analysis.Convex.Star": ["Mathlib.Algebra.Order.Module.Synonym"],
   "Mathlib.Analysis.Convex.Basic":
   ["Mathlib.Algebra.Order.BigOperators.Ring.Finset"],
   "Mathlib.Analysis.CStarAlgebra.ContinuousFunctionalCalculus.NonUnital":


### PR DESCRIPTION
Complete the API about actions on and by `OrderDual`/`Lex`.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
