### PR TITLE
[Merged by Bors] - refactor: Generalise the rearrangement inequality

### DIFF
--- a/Mathlib/Algebra/Order/Rearrangement.lean
+++ b/Mathlib/Algebra/Order/Rearrangement.lean
@@ -4,7 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Mantas Bakšys
 -/
 import Mathlib.Algebra.BigOperators.Group.Finset
-import Mathlib.Algebra.Order.Group.Instances
 import Mathlib.Algebra.Order.Module.OrderedSMul
 import Mathlib.Algebra.Order.Module.Synonym
 import Mathlib.Data.Prod.Lex
@@ -46,15 +45,15 @@ file because it is easily deducible from the `Monovary` API.
 
 open Equiv Equiv.Perm Finset Function OrderDual
 
-variable {ι α β : Type*}
+variable {ι α β : Type*} [LinearOrderedSemiring α] [ExistsAddOfLE α]
+  [LinearOrderedCancelAddCommMonoid β] [Module α β]
 
 /-! ### Scalar multiplication versions -/
 
+/-! #### Weak rearrangement inequality -/
 
-section SMul
-
-variable [LinearOrderedRing α] [LinearOrderedAddCommGroup β] [Module α β] [OrderedSMul α β]
-  {s : Finset ι} {σ : Perm ι} {f : ι → α} {g : ι → β}
+section weak_inequality
+variable [PosSMulMono α β] {s : Finset ι} {σ : Perm ι} {f : ι → α} {g : ι → β}
 
 /-- **Rearrangement Inequality**: Pointwise scalar multiplication of `f` and `g` is maximized when
 `f` and `g` monovary together. Stated by permuting the entries of `g`. -/
@@ -106,6 +105,61 @@ theorem MonovaryOn.sum_smul_comp_perm_le_sum_smul (hfg : MonovaryOn f g s)
     rintro rfl
     exact has hx.2
 
+/-- **Rearrangement Inequality**: Pointwise scalar multiplication of `f` and `g` is minimized when
+`f` and `g` antivary together. Stated by permuting the entries of `g`. -/
+theorem AntivaryOn.sum_smul_le_sum_smul_comp_perm (hfg : AntivaryOn f g s)
+    (hσ : {x | σ x ≠ x} ⊆ s) : ∑ i ∈ s, f i • g i ≤ ∑ i ∈ s, f i • g (σ i) :=
+  hfg.dual_right.sum_smul_comp_perm_le_sum_smul hσ
+
+/-- **Rearrangement Inequality**: Pointwise scalar multiplication of `f` and `g` is maximized when
+`f` and `g` monovary together. Stated by permuting the entries of `f`. -/
+theorem MonovaryOn.sum_comp_perm_smul_le_sum_smul (hfg : MonovaryOn f g s)
+    (hσ : {x | σ x ≠ x} ⊆ s) : ∑ i ∈ s, f (σ i) • g i ≤ ∑ i ∈ s, f i • g i := by
+  convert hfg.sum_smul_comp_perm_le_sum_smul
+    (show { x | σ⁻¹ x ≠ x } ⊆ s by simp only [set_support_inv_eq, hσ]) using 1
+  exact σ.sum_comp' s (fun i j ↦ f i • g j) hσ
+
+/-- **Rearrangement Inequality**: Pointwise scalar multiplication of `f` and `g` is minimized when
+`f` and `g` antivary together. Stated by permuting the entries of `f`. -/
+theorem AntivaryOn.sum_smul_le_sum_comp_perm_smul (hfg : AntivaryOn f g s)
+    (hσ : {x | σ x ≠ x} ⊆ s) : ∑ i ∈ s, f i • g i ≤ ∑ i ∈ s, f (σ i) • g i := by
+  convert hfg.sum_smul_le_sum_smul_comp_perm
+    (show { x | σ⁻¹ x ≠ x } ⊆ s by simp only [set_support_inv_eq, hσ]) using 1
+  exact σ.sum_comp' s (fun i j ↦ f i • g j) hσ
+
+variable [Fintype ι]
+
+/-- **Rearrangement Inequality**: Pointwise scalar multiplication of `f` and `g` is maximized when
+`f` and `g` monovary together. Stated by permuting the entries of `g`. -/
+theorem Monovary.sum_smul_comp_perm_le_sum_smul (hfg : Monovary f g) :
+    ∑ i, f i • g (σ i) ≤ ∑ i, f i • g i :=
+  (hfg.monovaryOn _).sum_smul_comp_perm_le_sum_smul fun _ _ ↦ mem_univ _
+
+/-- **Rearrangement Inequality**: Pointwise scalar multiplication of `f` and `g` is minimized when
+`f` and `g` antivary together. Stated by permuting the entries of `g`. -/
+theorem Antivary.sum_smul_le_sum_smul_comp_perm (hfg : Antivary f g) :
+    ∑ i, f i • g i ≤ ∑ i, f i • g (σ i) :=
+  (hfg.antivaryOn _).sum_smul_le_sum_smul_comp_perm fun _ _ ↦ mem_univ _
+
+/-- **Rearrangement Inequality**: Pointwise scalar multiplication of `f` and `g` is maximized when
+`f` and `g` monovary together. Stated by permuting the entries of `f`. -/
+theorem Monovary.sum_comp_perm_smul_le_sum_smul (hfg : Monovary f g) :
+    ∑ i, f (σ i) • g i ≤ ∑ i, f i • g i :=
+  (hfg.monovaryOn _).sum_comp_perm_smul_le_sum_smul fun _ _ ↦ mem_univ _
+
+/-- **Rearrangement Inequality**: Pointwise scalar multiplication of `f` and `g` is minimized when
+`f` and `g` antivary together. Stated by permuting the entries of `f`. -/
+theorem Antivary.sum_smul_le_sum_comp_perm_smul (hfg : Antivary f g) :
+    ∑ i, f i • g i ≤ ∑ i, f (σ i) • g i :=
+  (hfg.antivaryOn _).sum_smul_le_sum_comp_perm_smul fun _ _ ↦ mem_univ _
+
+end weak_inequality
+
+/-! #### Equality case of the rearrangement inequality -/
+
+section equality_case
+variable [PosSMulStrictMono α β] {s : Finset ι} {σ : Perm ι} {f : ι → α} {g : ι → β}
+
 /-- **Equality case of the Rearrangement Inequality**: Pointwise scalar multiplication of `f` and
 `g`, which monovary together, is unchanged by a permutation if and only if `f` and `g ∘ σ` monovary
 together. Stated by permuting the entries of `g`. -/
@@ -134,22 +188,13 @@ theorem MonovaryOn.sum_smul_comp_perm_eq_sum_smul_iff (hfg : MonovaryOn f g s)
   · convert h.sum_smul_comp_perm_le_sum_smul ((set_support_inv_eq _).subset.trans hσ) using 1
     simp_rw [Function.comp_apply, apply_inv_self]
 
-/-- **Strict inequality case of the Rearrangement Inequality**: Pointwise scalar multiplication of
-`f` and `g`, which monovary together, is strictly decreased by a permutation if and only if
-`f` and `g ∘ σ` do not monovary together. Stated by permuting the entries of `g`. -/
-theorem MonovaryOn.sum_smul_comp_perm_lt_sum_smul_iff (hfg : MonovaryOn f g s)
+/-- **Equality case of the Rearrangement Inequality**: Pointwise scalar multiplication of `f` and
+`g`, which antivary together, is unchanged by a permutation if and only if `f` and `g ∘ σ` antivary
+together. Stated by permuting the entries of `g`. -/
+theorem AntivaryOn.sum_smul_comp_perm_eq_sum_smul_iff (hfg : AntivaryOn f g s)
     (hσ : {x | σ x ≠ x} ⊆ s) :
-    ∑ i ∈ s, f i • g (σ i) < ∑ i ∈ s, f i • g i ↔ ¬MonovaryOn f (g ∘ σ) s := by
-  simp [← hfg.sum_smul_comp_perm_eq_sum_smul_iff hσ, lt_iff_le_and_ne,
-    hfg.sum_smul_comp_perm_le_sum_smul hσ]
-
-/-- **Rearrangement Inequality**: Pointwise scalar multiplication of `f` and `g` is maximized when
-`f` and `g` monovary together. Stated by permuting the entries of `f`. -/
-theorem MonovaryOn.sum_comp_perm_smul_le_sum_smul (hfg : MonovaryOn f g s)
-    (hσ : {x | σ x ≠ x} ⊆ s) : ∑ i ∈ s, f (σ i) • g i ≤ ∑ i ∈ s, f i • g i := by
-  convert hfg.sum_smul_comp_perm_le_sum_smul
-    (show { x | σ⁻¹ x ≠ x } ⊆ s by simp only [set_support_inv_eq, hσ]) using 1
-  exact σ.sum_comp' s (fun i j ↦ f i • g j) hσ
+    ∑ i ∈ s, f i • g (σ i) = ∑ i ∈ s, f i • g i ↔ AntivaryOn f (g ∘ σ) s :=
+  (hfg.dual_right.sum_smul_comp_perm_eq_sum_smul_iff hσ).trans monovaryOn_toDual_right
 
 /-- **Equality case of the Rearrangement Inequality**: Pointwise scalar multiplication of `f` and
 `g`, which monovary together, is unchanged by a permutation if and only if `f ∘ σ` and `g` monovary
@@ -171,49 +216,6 @@ theorem MonovaryOn.sum_comp_perm_smul_eq_sum_smul_iff (hfg : MonovaryOn f g s)
     · rw [σ.symm.eq_preimage_iff_image_eq]
       exact Set.image_perm hσinv
 
-/-- **Strict inequality case of the Rearrangement Inequality**: Pointwise scalar multiplication of
-`f` and `g`, which monovary together, is strictly decreased by a permutation if and only if
-`f ∘ σ` and `g` do not monovary together. Stated by permuting the entries of `f`. -/
-theorem MonovaryOn.sum_comp_perm_smul_lt_sum_smul_iff (hfg : MonovaryOn f g s)
-    (hσ : {x | σ x ≠ x} ⊆ s) :
-    ∑ i ∈ s, f (σ i) • g i < ∑ i ∈ s, f i • g i ↔ ¬MonovaryOn (f ∘ σ) g s := by
-  simp [← hfg.sum_comp_perm_smul_eq_sum_smul_iff hσ, lt_iff_le_and_ne,
-    hfg.sum_comp_perm_smul_le_sum_smul hσ]
-
-/-- **Rearrangement Inequality**: Pointwise scalar multiplication of `f` and `g` is minimized when
-`f` and `g` antivary together. Stated by permuting the entries of `g`. -/
-theorem AntivaryOn.sum_smul_le_sum_smul_comp_perm (hfg : AntivaryOn f g s)
-    (hσ : {x | σ x ≠ x} ⊆ s) : ∑ i ∈ s, f i • g i ≤ ∑ i ∈ s, f i • g (σ i) :=
-  hfg.dual_right.sum_smul_comp_perm_le_sum_smul hσ
-
-/-- **Equality case of the Rearrangement Inequality**: Pointwise scalar multiplication of `f` and
-`g`, which antivary together, is unchanged by a permutation if and only if `f` and `g ∘ σ` antivary
-together. Stated by permuting the entries of `g`. -/
-theorem AntivaryOn.sum_smul_comp_perm_eq_sum_smul_iff (hfg : AntivaryOn f g s)
-    (hσ : {x | σ x ≠ x} ⊆ s) :
-    ∑ i ∈ s, f i • g (σ i) = ∑ i ∈ s, f i • g i ↔ AntivaryOn f (g ∘ σ) s :=
-  (hfg.dual_right.sum_smul_comp_perm_eq_sum_smul_iff hσ).trans monovaryOn_toDual_right
-
-@[deprecated (since := "2024-06-25")]
-alias AntivaryOn.sum_smul_eq_sum_smul_comp_perm_iff := AntivaryOn.sum_smul_comp_perm_eq_sum_smul_iff
-
-/-- **Strict inequality case of the Rearrangement Inequality**: Pointwise scalar multiplication of
-`f` and `g`, which antivary together, is strictly decreased by a permutation if and only if
-`f` and `g ∘ σ` do not antivary together. Stated by permuting the entries of `g`. -/
-theorem AntivaryOn.sum_smul_lt_sum_smul_comp_perm_iff (hfg : AntivaryOn f g s)
-    (hσ : {x | σ x ≠ x} ⊆ s) :
-    ∑ i ∈ s, f i • g i < ∑ i ∈ s, f i • g (σ i) ↔ ¬AntivaryOn f (g ∘ σ) s := by
-  simp [← hfg.sum_smul_comp_perm_eq_sum_smul_iff hσ, lt_iff_le_and_ne, eq_comm,
-    hfg.sum_smul_le_sum_smul_comp_perm hσ]
-
-/-- **Rearrangement Inequality**: Pointwise scalar multiplication of `f` and `g` is minimized when
-`f` and `g` antivary together. Stated by permuting the entries of `f`. -/
-theorem AntivaryOn.sum_smul_le_sum_comp_perm_smul (hfg : AntivaryOn f g s)
-    (hσ : {x | σ x ≠ x} ⊆ s) : ∑ i ∈ s, f i • g i ≤ ∑ i ∈ s, f (σ i) • g i := by
-  convert hfg.sum_smul_le_sum_smul_comp_perm
-    (show { x | σ⁻¹ x ≠ x } ⊆ s by simp only [set_support_inv_eq, hσ]) using 1
-  exact σ.sum_comp' s (fun i j ↦ f i • g j) hσ
-
 /-- **Equality case of the Rearrangement Inequality**: Pointwise scalar multiplication of `f` and
 `g`, which antivary together, is unchanged by a permutation if and only if `f ∘ σ` and `g` antivary
 together. Stated by permuting the entries of `f`. -/
@@ -224,6 +226,79 @@ theorem AntivaryOn.sum_comp_perm_smul_eq_sum_smul_iff (hfg : AntivaryOn f g s)
 
 @[deprecated (since := "2024-06-25")]
 alias AntivaryOn.sum_smul_eq_sum_comp_perm_smul_iff := AntivaryOn.sum_comp_perm_smul_eq_sum_smul_iff
+
+variable [Fintype ι]
+
+/-- **Equality case of the Rearrangement Inequality**: Pointwise scalar multiplication of `f` and
+`g`, which monovary together, is unchanged by a permutation if and only if `f` and `g ∘ σ` monovary
+together. Stated by permuting the entries of `g`. -/
+theorem Monovary.sum_smul_comp_perm_eq_sum_smul_iff (hfg : Monovary f g) :
+    ∑ i, f i • g (σ i) = ∑ i, f i • g i ↔ Monovary f (g ∘ σ) := by
+  simp [(hfg.monovaryOn _).sum_smul_comp_perm_eq_sum_smul_iff fun _ _ ↦ mem_univ _]
+
+/-- **Equality case of the Rearrangement Inequality**: Pointwise scalar multiplication of `f` and
+`g`, which monovary together, is unchanged by a permutation if and only if `f ∘ σ` and `g` monovary
+together. Stated by permuting the entries of `g`. -/
+theorem Monovary.sum_comp_perm_smul_eq_sum_smul_iff (hfg : Monovary f g) :
+    ∑ i, f (σ i) • g i = ∑ i, f i • g i ↔ Monovary (f ∘ σ) g := by
+  simp [(hfg.monovaryOn _).sum_comp_perm_smul_eq_sum_smul_iff fun _ _ ↦ mem_univ _]
+
+/-- **Equality case of the Rearrangement Inequality**: Pointwise scalar multiplication of `f` and
+`g`, which antivary together, is unchanged by a permutation if and only if `f` and `g ∘ σ` antivary
+together. Stated by permuting the entries of `g`. -/
+theorem Antivary.sum_smul_comp_perm_eq_sum_smul_iff (hfg : Antivary f g) :
+    ∑ i, f i • g (σ i) = ∑ i, f i • g i ↔ Antivary f (g ∘ σ) := by
+  simp [(hfg.antivaryOn _).sum_smul_comp_perm_eq_sum_smul_iff fun _ _ ↦ mem_univ _]
+
+@[deprecated (since := "2024-06-25")]
+alias Antivary.sum_smul_eq_sum_smul_comp_perm_iff := Antivary.sum_smul_comp_perm_eq_sum_smul_iff
+
+/-- **Equality case of the Rearrangement Inequality**: Pointwise scalar multiplication of `f` and
+`g`, which antivary together, is unchanged by a permutation if and only if `f ∘ σ` and `g` antivary
+together. Stated by permuting the entries of `f`. -/
+theorem Antivary.sum_comp_perm_smul_eq_sum_smul_iff (hfg : Antivary f g) :
+    ∑ i, f (σ i) • g i = ∑ i, f i • g i ↔ Antivary (f ∘ σ) g := by
+  simp [(hfg.antivaryOn _).sum_comp_perm_smul_eq_sum_smul_iff fun _ _ ↦ mem_univ _]
+
+@[deprecated (since := "2024-06-25")]
+alias Antivary.sum_smul_eq_sum_comp_perm_smul_iff := Antivary.sum_comp_perm_smul_eq_sum_smul_iff
+
+end equality_case
+
+/-! #### Strict rearrangement inequality -/
+
+section strict_inequality
+variable [PosSMulStrictMono α β] {s : Finset ι} {σ : Perm ι} {f : ι → α} {g : ι → β}
+
+/-- **Strict inequality case of the Rearrangement Inequality**: Pointwise scalar multiplication of
+`f` and `g`, which monovary together, is strictly decreased by a permutation if and only if
+`f` and `g ∘ σ` do not monovary together. Stated by permuting the entries of `g`. -/
+theorem MonovaryOn.sum_smul_comp_perm_lt_sum_smul_iff (hfg : MonovaryOn f g s)
+    (hσ : {x | σ x ≠ x} ⊆ s) :
+    ∑ i ∈ s, f i • g (σ i) < ∑ i ∈ s, f i • g i ↔ ¬MonovaryOn f (g ∘ σ) s := by
+  simp [← hfg.sum_smul_comp_perm_eq_sum_smul_iff hσ, lt_iff_le_and_ne,
+    hfg.sum_smul_comp_perm_le_sum_smul hσ]
+
+/-- **Strict inequality case of the Rearrangement Inequality**: Pointwise scalar multiplication of
+`f` and `g`, which antivary together, is strictly decreased by a permutation if and only if
+`f` and `g ∘ σ` do not antivary together. Stated by permuting the entries of `g`. -/
+theorem AntivaryOn.sum_smul_lt_sum_smul_comp_perm_iff
+    (hfg : AntivaryOn f g s) (hσ : {x | σ x ≠ x} ⊆ s) :
+    ∑ i ∈ s, f i • g i < ∑ i ∈ s, f i • g (σ i) ↔ ¬AntivaryOn f (g ∘ σ) s := by
+  simp [← hfg.sum_smul_comp_perm_eq_sum_smul_iff hσ, lt_iff_le_and_ne, eq_comm,
+    hfg.sum_smul_le_sum_smul_comp_perm hσ]
+
+/-- **Strict inequality case of the Rearrangement Inequality**: Pointwise scalar multiplication of
+`f` and `g`, which monovary together, is strictly decreased by a permutation if and only if
+`f ∘ σ` and `g` do not monovary together. Stated by permuting the entries of `f`. -/
+theorem MonovaryOn.sum_comp_perm_smul_lt_sum_smul_iff (hfg : MonovaryOn f g s)
+    (hσ : {x | σ x ≠ x} ⊆ s) :
+    ∑ i ∈ s, f (σ i) • g i < ∑ i ∈ s, f i • g i ↔ ¬MonovaryOn (f ∘ σ) g s := by
+  simp [← hfg.sum_comp_perm_smul_eq_sum_smul_iff hσ, lt_iff_le_and_ne,
+    hfg.sum_comp_perm_smul_le_sum_smul hσ]
+
+@[deprecated (since := "2024-06-25")]
+alias AntivaryOn.sum_smul_eq_sum_smul_comp_perm_iff := AntivaryOn.sum_smul_comp_perm_eq_sum_smul_iff
 
 /-- **Strict inequality case of the Rearrangement Inequality**: Pointwise scalar multiplication of
 `f` and `g`, which antivary together, is strictly decreased by a permutation if and only if
@@ -236,38 +311,12 @@ theorem AntivaryOn.sum_smul_lt_sum_comp_perm_smul_iff (hfg : AntivaryOn f g s)
 
 variable [Fintype ι]
 
-/-- **Rearrangement Inequality**: Pointwise scalar multiplication of `f` and `g` is maximized when
-`f` and `g` monovary together. Stated by permuting the entries of `g`. -/
-theorem Monovary.sum_smul_comp_perm_le_sum_smul (hfg : Monovary f g) :
-    ∑ i, f i • g (σ i) ≤ ∑ i, f i • g i :=
-  (hfg.monovaryOn _).sum_smul_comp_perm_le_sum_smul fun _ _ ↦ mem_univ _
-
-/-- **Equality case of the Rearrangement Inequality**: Pointwise scalar multiplication of `f` and
-`g`, which monovary together, is unchanged by a permutation if and only if `f` and `g ∘ σ` monovary
-together. Stated by permuting the entries of `g`. -/
-theorem Monovary.sum_smul_comp_perm_eq_sum_smul_iff (hfg : Monovary f g) :
-    ∑ i, f i • g (σ i) = ∑ i, f i • g i ↔ Monovary f (g ∘ σ) := by
-  simp [(hfg.monovaryOn _).sum_smul_comp_perm_eq_sum_smul_iff fun _ _ ↦ mem_univ _]
-
 /-- **Strict inequality case of the Rearrangement Inequality**: Pointwise scalar multiplication of
 `f` and `g`, which monovary together, is strictly decreased by a permutation if and only if
 `f` and `g ∘ σ` do not monovary together. Stated by permuting the entries of `g`. -/
 theorem Monovary.sum_smul_comp_perm_lt_sum_smul_iff (hfg : Monovary f g) :
     ∑ i, f i • g (σ i) < ∑ i, f i • g i ↔ ¬Monovary f (g ∘ σ) := by
   simp [(hfg.monovaryOn _).sum_smul_comp_perm_lt_sum_smul_iff fun _ _ ↦ mem_univ _]
-
-/-- **Rearrangement Inequality**: Pointwise scalar multiplication of `f` and `g` is maximized when
-`f` and `g` monovary together. Stated by permuting the entries of `f`. -/
-theorem Monovary.sum_comp_perm_smul_le_sum_smul (hfg : Monovary f g) :
-    ∑ i, f (σ i) • g i ≤ ∑ i, f i • g i :=
-  (hfg.monovaryOn _).sum_comp_perm_smul_le_sum_smul fun _ _ ↦ mem_univ _
-
-/-- **Equality case of the Rearrangement Inequality**: Pointwise scalar multiplication of `f` and
-`g`, which monovary together, is unchanged by a permutation if and only if `f ∘ σ` and `g` monovary
-together. Stated by permuting the entries of `g`. -/
-theorem Monovary.sum_comp_perm_smul_eq_sum_smul_iff (hfg : Monovary f g) :
-    ∑ i, f (σ i) • g i = ∑ i, f i • g i ↔ Monovary (f ∘ σ) g := by
-  simp [(hfg.monovaryOn _).sum_comp_perm_smul_eq_sum_smul_iff fun _ _ ↦ mem_univ _]
 
 /-- **Strict inequality case of the Rearrangement Inequality**: Pointwise scalar multiplication of
 `f` and `g`, which monovary together, is strictly decreased by a permutation if and only if
@@ -276,44 +325,12 @@ theorem Monovary.sum_comp_perm_smul_lt_sum_smul_iff (hfg : Monovary f g) :
     ∑ i, f (σ i) • g i < ∑ i, f i • g i ↔ ¬Monovary (f ∘ σ) g := by
   simp [(hfg.monovaryOn _).sum_comp_perm_smul_lt_sum_smul_iff fun _ _ ↦ mem_univ _]
 
-/-- **Rearrangement Inequality**: Pointwise scalar multiplication of `f` and `g` is minimized when
-`f` and `g` antivary together. Stated by permuting the entries of `g`. -/
-theorem Antivary.sum_smul_le_sum_smul_comp_perm (hfg : Antivary f g) :
-    ∑ i, f i • g i ≤ ∑ i, f i • g (σ i) :=
-  (hfg.antivaryOn _).sum_smul_le_sum_smul_comp_perm fun _ _ ↦ mem_univ _
-
-/-- **Equality case of the Rearrangement Inequality**: Pointwise scalar multiplication of `f` and
-`g`, which antivary together, is unchanged by a permutation if and only if `f` and `g ∘ σ` antivary
-together. Stated by permuting the entries of `g`. -/
-theorem Antivary.sum_smul_comp_perm_eq_sum_smul_iff (hfg : Antivary f g) :
-    ∑ i, f i • g (σ i) = ∑ i, f i • g i ↔ Antivary f (g ∘ σ) := by
-  simp [(hfg.antivaryOn _).sum_smul_comp_perm_eq_sum_smul_iff fun _ _ ↦ mem_univ _]
-
-@[deprecated (since := "2024-06-25")]
-alias Antivary.sum_smul_eq_sum_smul_comp_perm_iff := Antivary.sum_smul_comp_perm_eq_sum_smul_iff
-
 /-- **Strict inequality case of the Rearrangement Inequality**: Pointwise scalar multiplication of
 `f` and `g`, which antivary together, is strictly decreased by a permutation if and only if
 `f` and `g ∘ σ` do not antivary together. Stated by permuting the entries of `g`. -/
 theorem Antivary.sum_smul_lt_sum_smul_comp_perm_iff (hfg : Antivary f g) :
     ∑ i, f i • g i < ∑ i, f i • g (σ i) ↔ ¬Antivary f (g ∘ σ) := by
   simp [(hfg.antivaryOn _).sum_smul_lt_sum_smul_comp_perm_iff fun _ _ ↦ mem_univ _]
-
-/-- **Rearrangement Inequality**: Pointwise scalar multiplication of `f` and `g` is minimized when
-`f` and `g` antivary together. Stated by permuting the entries of `f`. -/
-theorem Antivary.sum_smul_le_sum_comp_perm_smul (hfg : Antivary f g) :
-    ∑ i, f i • g i ≤ ∑ i, f (σ i) • g i :=
-  (hfg.antivaryOn _).sum_smul_le_sum_comp_perm_smul fun _ _ ↦ mem_univ _
-
-/-- **Equality case of the Rearrangement Inequality**: Pointwise scalar multiplication of `f` and
-`g`, which antivary together, is unchanged by a permutation if and only if `f ∘ σ` and `g` antivary
-together. Stated by permuting the entries of `f`. -/
-theorem Antivary.sum_comp_perm_smul_eq_sum_smul_iff (hfg : Antivary f g) :
-    ∑ i, f (σ i) • g i = ∑ i, f i • g i ↔ Antivary (f ∘ σ) g := by
-  simp [(hfg.antivaryOn _).sum_comp_perm_smul_eq_sum_smul_iff fun _ _ ↦ mem_univ _]
-
-@[deprecated (since := "2024-06-25")]
-alias Antivary.sum_smul_eq_sum_comp_perm_smul_iff := Antivary.sum_comp_perm_smul_eq_sum_smul_iff
 
 /-- **Strict inequality case of the Rearrangement Inequality**: Pointwise scalar multiplication of
 `f` and `g`, which antivary together, is strictly decreased by a permutation if and only if
@@ -322,7 +339,7 @@ theorem Antivary.sum_smul_lt_sum_comp_perm_smul_iff (hfg : Antivary f g) :
     ∑ i, f i • g i < ∑ i, f (σ i) • g i ↔ ¬Antivary (f ∘ σ) g := by
   simp [(hfg.antivaryOn _).sum_smul_lt_sum_comp_perm_smul_iff fun _ _ ↦ mem_univ _]
 
-end SMul
+end strict_inequality
 
 /-!
 ### Multiplication versions
@@ -330,16 +347,13 @@ end SMul
 Special cases of the above when scalar multiplication is actually multiplication.
 -/
 
-
 section Mul
-
-
-variable [LinearOrderedRing α] {s : Finset ι} {σ : Perm ι} {f g : ι → α}
+variable {s : Finset ι} {σ : Perm ι} {f g : ι → α}
 
 /-- **Rearrangement Inequality**: Pointwise multiplication of `f` and `g` is maximized when `f` and
 `g` monovary together. Stated by permuting the entries of `g`. -/
-theorem MonovaryOn.sum_mul_comp_perm_le_sum_mul (hfg : MonovaryOn f g s)
-    (hσ : {x | σ x ≠ x} ⊆ s) : ∑ i ∈ s, f i * g (σ i) ≤ ∑ i ∈ s, f i * g i :=
+theorem MonovaryOn.sum_mul_comp_perm_le_sum_mul (hfg : MonovaryOn f g s) (hσ : {x | σ x ≠ x} ⊆ s) :
+    ∑ i ∈ s, f i * g (σ i) ≤ ∑ i ∈ s, f i * g i :=
   hfg.sum_smul_comp_perm_le_sum_smul hσ
 
 /-- **Equality case of the Rearrangement Inequality**: Pointwise multiplication of `f` and `g`,

--- a/Mathlib/Algebra/Order/Rearrangement.lean
+++ b/Mathlib/Algebra/Order/Rearrangement.lean
@@ -40,6 +40,11 @@ convenience.
 
 The case for `Monotone`/`Antitone` pairs of functions over a `LinearOrder` is not deduced in this
 file because it is easily deducible from the `Monovary` API.
+
+## TODO
+
+Add equality cases for when the permute function is injective. This comes from the following fact:
+If `Monovary f g`, `Injective g` and `σ` is a permutation, then `Monovary f (g ∘ σ) ↔ σ = 1`.
 -/
 
 

--- a/Mathlib/Algebra/Order/Rearrangement.lean
+++ b/Mathlib/Algebra/Order/Rearrangement.lean
@@ -124,10 +124,8 @@ theorem MonovaryOn.sum_comp_perm_smul_le_sum_smul (hfg : MonovaryOn f g s)
 /-- **Rearrangement Inequality**: Pointwise scalar multiplication of `f` and `g` is minimized when
 `f` and `g` antivary together on `s`. Stated by permuting the entries of `f`. -/
 theorem AntivaryOn.sum_smul_le_sum_comp_perm_smul (hfg : AntivaryOn f g s)
-    (hσ : {x | σ x ≠ x} ⊆ s) : ∑ i ∈ s, f i • g i ≤ ∑ i ∈ s, f (σ i) • g i := by
-  convert hfg.sum_smul_le_sum_smul_comp_perm
-    (show { x | σ⁻¹ x ≠ x } ⊆ s by simp only [set_support_inv_eq, hσ]) using 1
-  exact σ.sum_comp' s (fun i j ↦ f i • g j) hσ
+    (hσ : {x | σ x ≠ x} ⊆ s) : ∑ i ∈ s, f i • g i ≤ ∑ i ∈ s, f (σ i) • g i :=
+  hfg.dual_right.sum_comp_perm_smul_le_sum_smul hσ
 
 variable [Fintype ι]
 

--- a/Mathlib/Algebra/Order/Rearrangement.lean
+++ b/Mathlib/Algebra/Order/Rearrangement.lean
@@ -56,7 +56,7 @@ section weak_inequality
 variable [PosSMulMono α β] {s : Finset ι} {σ : Perm ι} {f : ι → α} {g : ι → β}
 
 /-- **Rearrangement Inequality**: Pointwise scalar multiplication of `f` and `g` is maximized when
-`f` and `g` monovary together. Stated by permuting the entries of `g`. -/
+`f` and `g` monovary together on `s`. Stated by permuting the entries of `g`. -/
 theorem MonovaryOn.sum_smul_comp_perm_le_sum_smul (hfg : MonovaryOn f g s)
     (hσ : {x | σ x ≠ x} ⊆ s) : ∑ i ∈ s, f i • g (σ i) ≤ ∑ i ∈ s, f i • g i := by
   classical
@@ -106,13 +106,13 @@ theorem MonovaryOn.sum_smul_comp_perm_le_sum_smul (hfg : MonovaryOn f g s)
     exact has hx.2
 
 /-- **Rearrangement Inequality**: Pointwise scalar multiplication of `f` and `g` is minimized when
-`f` and `g` antivary together. Stated by permuting the entries of `g`. -/
+`f` and `g` antivary together on `s`. Stated by permuting the entries of `g`. -/
 theorem AntivaryOn.sum_smul_le_sum_smul_comp_perm (hfg : AntivaryOn f g s)
     (hσ : {x | σ x ≠ x} ⊆ s) : ∑ i ∈ s, f i • g i ≤ ∑ i ∈ s, f i • g (σ i) :=
   hfg.dual_right.sum_smul_comp_perm_le_sum_smul hσ
 
 /-- **Rearrangement Inequality**: Pointwise scalar multiplication of `f` and `g` is maximized when
-`f` and `g` monovary together. Stated by permuting the entries of `f`. -/
+`f` and `g` monovary together on `s`. Stated by permuting the entries of `f`. -/
 theorem MonovaryOn.sum_comp_perm_smul_le_sum_smul (hfg : MonovaryOn f g s)
     (hσ : {x | σ x ≠ x} ⊆ s) : ∑ i ∈ s, f (σ i) • g i ≤ ∑ i ∈ s, f i • g i := by
   convert hfg.sum_smul_comp_perm_le_sum_smul
@@ -120,7 +120,7 @@ theorem MonovaryOn.sum_comp_perm_smul_le_sum_smul (hfg : MonovaryOn f g s)
   exact σ.sum_comp' s (fun i j ↦ f i • g j) hσ
 
 /-- **Rearrangement Inequality**: Pointwise scalar multiplication of `f` and `g` is minimized when
-`f` and `g` antivary together. Stated by permuting the entries of `f`. -/
+`f` and `g` antivary together on `s`. Stated by permuting the entries of `f`. -/
 theorem AntivaryOn.sum_smul_le_sum_comp_perm_smul (hfg : AntivaryOn f g s)
     (hσ : {x | σ x ≠ x} ⊆ s) : ∑ i ∈ s, f i • g i ≤ ∑ i ∈ s, f (σ i) • g i := by
   convert hfg.sum_smul_le_sum_smul_comp_perm
@@ -161,8 +161,8 @@ section equality_case
 variable [PosSMulStrictMono α β] {s : Finset ι} {σ : Perm ι} {f : ι → α} {g : ι → β}
 
 /-- **Equality case of the Rearrangement Inequality**: Pointwise scalar multiplication of `f` and
-`g`, which monovary together, is unchanged by a permutation if and only if `f` and `g ∘ σ` monovary
-together. Stated by permuting the entries of `g`. -/
+`g`, which monovary together on `s`, is unchanged by a permutation if and only if `f` and `g ∘ σ`
+monovary together on `s`. Stated by permuting the entries of `g`. -/
 theorem MonovaryOn.sum_smul_comp_perm_eq_sum_smul_iff (hfg : MonovaryOn f g s)
     (hσ : {x | σ x ≠ x} ⊆ s) :
     ∑ i ∈ s, f i • g (σ i) = ∑ i ∈ s, f i • g i ↔ MonovaryOn f (g ∘ σ) s := by
@@ -189,16 +189,16 @@ theorem MonovaryOn.sum_smul_comp_perm_eq_sum_smul_iff (hfg : MonovaryOn f g s)
     simp_rw [Function.comp_apply, apply_inv_self]
 
 /-- **Equality case of the Rearrangement Inequality**: Pointwise scalar multiplication of `f` and
-`g`, which antivary together, is unchanged by a permutation if and only if `f` and `g ∘ σ` antivary
-together. Stated by permuting the entries of `g`. -/
+`g`, which antivary together on `s`, is unchanged by a permutation if and only if `f` and `g ∘ σ`
+antivary together on `s`. Stated by permuting the entries of `g`. -/
 theorem AntivaryOn.sum_smul_comp_perm_eq_sum_smul_iff (hfg : AntivaryOn f g s)
     (hσ : {x | σ x ≠ x} ⊆ s) :
     ∑ i ∈ s, f i • g (σ i) = ∑ i ∈ s, f i • g i ↔ AntivaryOn f (g ∘ σ) s :=
   (hfg.dual_right.sum_smul_comp_perm_eq_sum_smul_iff hσ).trans monovaryOn_toDual_right
 
 /-- **Equality case of the Rearrangement Inequality**: Pointwise scalar multiplication of `f` and
-`g`, which monovary together, is unchanged by a permutation if and only if `f ∘ σ` and `g` monovary
-together. Stated by permuting the entries of `f`. -/
+`g`, which monovary together on `s`, is unchanged by a permutation if and only if `f ∘ σ` and `g`
+monovary together on `s`. Stated by permuting the entries of `f`. -/
 theorem MonovaryOn.sum_comp_perm_smul_eq_sum_smul_iff (hfg : MonovaryOn f g s)
     (hσ : {x | σ x ≠ x} ⊆ s) :
     ∑ i ∈ s, f (σ i) • g i = ∑ i ∈ s, f i • g i ↔ MonovaryOn (f ∘ σ) g s := by
@@ -217,8 +217,8 @@ theorem MonovaryOn.sum_comp_perm_smul_eq_sum_smul_iff (hfg : MonovaryOn f g s)
       exact Set.image_perm hσinv
 
 /-- **Equality case of the Rearrangement Inequality**: Pointwise scalar multiplication of `f` and
-`g`, which antivary together, is unchanged by a permutation if and only if `f ∘ σ` and `g` antivary
-together. Stated by permuting the entries of `f`. -/
+`g`, which antivary together on `s`, is unchanged by a permutation if and only if `f ∘ σ` and `g`
+antivary together on `s`. Stated by permuting the entries of `f`. -/
 theorem AntivaryOn.sum_comp_perm_smul_eq_sum_smul_iff (hfg : AntivaryOn f g s)
     (hσ : {x | σ x ≠ x} ⊆ s) :
     ∑ i ∈ s, f (σ i) • g i = ∑ i ∈ s, f i • g i ↔ AntivaryOn (f ∘ σ) g s :=
@@ -271,8 +271,8 @@ section strict_inequality
 variable [PosSMulStrictMono α β] {s : Finset ι} {σ : Perm ι} {f : ι → α} {g : ι → β}
 
 /-- **Strict inequality case of the Rearrangement Inequality**: Pointwise scalar multiplication of
-`f` and `g`, which monovary together, is strictly decreased by a permutation if and only if
-`f` and `g ∘ σ` do not monovary together. Stated by permuting the entries of `g`. -/
+`f` and `g`, which monovary together on `s`, is strictly decreased by a permutation if and only if
+`f` and `g ∘ σ` do not monovary together on `s`. Stated by permuting the entries of `g`. -/
 theorem MonovaryOn.sum_smul_comp_perm_lt_sum_smul_iff (hfg : MonovaryOn f g s)
     (hσ : {x | σ x ≠ x} ⊆ s) :
     ∑ i ∈ s, f i • g (σ i) < ∑ i ∈ s, f i • g i ↔ ¬MonovaryOn f (g ∘ σ) s := by
@@ -280,8 +280,8 @@ theorem MonovaryOn.sum_smul_comp_perm_lt_sum_smul_iff (hfg : MonovaryOn f g s)
     hfg.sum_smul_comp_perm_le_sum_smul hσ]
 
 /-- **Strict inequality case of the Rearrangement Inequality**: Pointwise scalar multiplication of
-`f` and `g`, which antivary together, is strictly decreased by a permutation if and only if
-`f` and `g ∘ σ` do not antivary together. Stated by permuting the entries of `g`. -/
+`f` and `g`, which antivary together on `s`, is strictly decreased by a permutation if and only if
+`f` and `g ∘ σ` do not antivary together on `s`. Stated by permuting the entries of `g`. -/
 theorem AntivaryOn.sum_smul_lt_sum_smul_comp_perm_iff
     (hfg : AntivaryOn f g s) (hσ : {x | σ x ≠ x} ⊆ s) :
     ∑ i ∈ s, f i • g i < ∑ i ∈ s, f i • g (σ i) ↔ ¬AntivaryOn f (g ∘ σ) s := by
@@ -289,8 +289,8 @@ theorem AntivaryOn.sum_smul_lt_sum_smul_comp_perm_iff
     hfg.sum_smul_le_sum_smul_comp_perm hσ]
 
 /-- **Strict inequality case of the Rearrangement Inequality**: Pointwise scalar multiplication of
-`f` and `g`, which monovary together, is strictly decreased by a permutation if and only if
-`f ∘ σ` and `g` do not monovary together. Stated by permuting the entries of `f`. -/
+`f` and `g`, which monovary together on `s`, is strictly decreased by a permutation if and only if
+`f ∘ σ` and `g` do not monovary together on `s`. Stated by permuting the entries of `f`. -/
 theorem MonovaryOn.sum_comp_perm_smul_lt_sum_smul_iff (hfg : MonovaryOn f g s)
     (hσ : {x | σ x ≠ x} ⊆ s) :
     ∑ i ∈ s, f (σ i) • g i < ∑ i ∈ s, f i • g i ↔ ¬MonovaryOn (f ∘ σ) g s := by
@@ -301,8 +301,8 @@ theorem MonovaryOn.sum_comp_perm_smul_lt_sum_smul_iff (hfg : MonovaryOn f g s)
 alias AntivaryOn.sum_smul_eq_sum_smul_comp_perm_iff := AntivaryOn.sum_smul_comp_perm_eq_sum_smul_iff
 
 /-- **Strict inequality case of the Rearrangement Inequality**: Pointwise scalar multiplication of
-`f` and `g`, which antivary together, is strictly decreased by a permutation if and only if
-`f ∘ σ` and `g` do not antivary together. Stated by permuting the entries of `f`. -/
+`f` and `g`, which antivary together on `s`, is strictly decreased by a permutation if and only if
+`f ∘ σ` and `g` do not antivary together on `s`. Stated by permuting the entries of `f`. -/
 theorem AntivaryOn.sum_smul_lt_sum_comp_perm_smul_iff (hfg : AntivaryOn f g s)
     (hσ : {x | σ x ≠ x} ⊆ s) :
     ∑ i ∈ s, f i • g i < ∑ i ∈ s, f (σ i) • g i ↔ ¬AntivaryOn (f ∘ σ) g s := by
@@ -351,80 +351,80 @@ section Mul
 variable {s : Finset ι} {σ : Perm ι} {f g : ι → α}
 
 /-- **Rearrangement Inequality**: Pointwise multiplication of `f` and `g` is maximized when `f` and
-`g` monovary together. Stated by permuting the entries of `g`. -/
+`g` monovary together on `s`. Stated by permuting the entries of `g`. -/
 theorem MonovaryOn.sum_mul_comp_perm_le_sum_mul (hfg : MonovaryOn f g s) (hσ : {x | σ x ≠ x} ⊆ s) :
     ∑ i ∈ s, f i * g (σ i) ≤ ∑ i ∈ s, f i * g i :=
   hfg.sum_smul_comp_perm_le_sum_smul hσ
 
 /-- **Equality case of the Rearrangement Inequality**: Pointwise multiplication of `f` and `g`,
-which monovary together, is unchanged by a permutation if and only if `f` and `g ∘ σ` monovary
-together. Stated by permuting the entries of `g`. -/
+which monovary together on `s`, is unchanged by a permutation if and only if `f` and `g ∘ σ`
+monovary together on `s`. Stated by permuting the entries of `g`. -/
 theorem MonovaryOn.sum_mul_comp_perm_eq_sum_mul_iff (hfg : MonovaryOn f g s)
     (hσ : {x | σ x ≠ x} ⊆ s) :
     ∑ i ∈ s, f i * g (σ i) = ∑ i ∈ s, f i * g i ↔ MonovaryOn f (g ∘ σ) s :=
   hfg.sum_smul_comp_perm_eq_sum_smul_iff hσ
 
 /-- **Strict inequality case of the Rearrangement Inequality**: Pointwise scalar multiplication of
-`f` and `g`, which monovary together, is strictly decreased by a permutation if and only if
-`f` and `g ∘ σ` do not monovary together. Stated by permuting the entries of `g`. -/
+`f` and `g`, which monovary together on `s`, is strictly decreased by a permutation if and only if
+`f` and `g ∘ σ` do not monovary together on `s`. Stated by permuting the entries of `g`. -/
 theorem MonovaryOn.sum_mul_comp_perm_lt_sum_mul_iff (hfg : MonovaryOn f g s)
     (hσ : {x | σ x ≠ x} ⊆ s) :
     ∑ i ∈ s, f i • g (σ i) < ∑ i ∈ s, f i • g i ↔ ¬MonovaryOn f (g ∘ σ) s :=
   hfg.sum_smul_comp_perm_lt_sum_smul_iff hσ
 
 /-- **Rearrangement Inequality**: Pointwise multiplication of `f` and `g` is maximized when `f` and
-`g` monovary together. Stated by permuting the entries of `f`. -/
+`g` monovary together on `s`. Stated by permuting the entries of `f`. -/
 theorem MonovaryOn.sum_comp_perm_mul_le_sum_mul (hfg : MonovaryOn f g s)
     (hσ : {x | σ x ≠ x} ⊆ s) : ∑ i ∈ s, f (σ i) * g i ≤ ∑ i ∈ s, f i * g i :=
   hfg.sum_comp_perm_smul_le_sum_smul hσ
 
 /-- **Equality case of the Rearrangement Inequality**: Pointwise multiplication of `f` and `g`,
-which monovary together, is unchanged by a permutation if and only if `f ∘ σ` and `g` monovary
-together. Stated by permuting the entries of `f`. -/
+which monovary together on `s`, is unchanged by a permutation if and only if `f ∘ σ` and `g`
+monovary together on `s`. Stated by permuting the entries of `f`. -/
 theorem MonovaryOn.sum_comp_perm_mul_eq_sum_mul_iff (hfg : MonovaryOn f g s)
     (hσ : {x | σ x ≠ x} ⊆ s) :
     ∑ i ∈ s, f (σ i) * g i = ∑ i ∈ s, f i * g i ↔ MonovaryOn (f ∘ σ) g s :=
   hfg.sum_comp_perm_smul_eq_sum_smul_iff hσ
 
 /-- **Strict inequality case of the Rearrangement Inequality**: Pointwise multiplication of
-`f` and `g`, which monovary together, is strictly decreased by a permutation if and only if
-`f ∘ σ` and `g` do not monovary together. Stated by permuting the entries of `f`. -/
+`f` and `g`, which monovary together on `s`, is strictly decreased by a permutation if and only if
+`f ∘ σ` and `g` do not monovary together on `s`. Stated by permuting the entries of `f`. -/
 theorem MonovaryOn.sum_comp_perm_mul_lt_sum_mul_iff (hfg : MonovaryOn f g s)
     (hσ : {x | σ x ≠ x} ⊆ s) :
     ∑ i ∈ s, f (σ i) * g i < ∑ i ∈ s, f i * g i ↔ ¬MonovaryOn (f ∘ σ) g s :=
   hfg.sum_comp_perm_smul_lt_sum_smul_iff hσ
 
 /-- **Rearrangement Inequality**: Pointwise multiplication of `f` and `g` is minimized when `f` and
-`g` antivary together. Stated by permuting the entries of `g`. -/
+`g` antivary together on `s`. Stated by permuting the entries of `g`. -/
 theorem AntivaryOn.sum_mul_le_sum_mul_comp_perm (hfg : AntivaryOn f g s)
     (hσ : {x | σ x ≠ x} ⊆ s) : ∑ i ∈ s, f i * g i ≤ ∑ i ∈ s, f i * g (σ i) :=
   hfg.sum_smul_le_sum_smul_comp_perm hσ
 
 /-- **Equality case of the Rearrangement Inequality**: Pointwise multiplication of `f` and `g`,
-which antivary together, is unchanged by a permutation if and only if `f` and `g ∘ σ` antivary
-together. Stated by permuting the entries of `g`. -/
+which antivary together on `s`, is unchanged by a permutation if and only if `f` and `g ∘ σ`
+antivary together on `s`. Stated by permuting the entries of `g`. -/
 theorem AntivaryOn.sum_mul_eq_sum_mul_comp_perm_iff (hfg : AntivaryOn f g s)
     (hσ : {x | σ x ≠ x} ⊆ s) :
     ∑ i ∈ s, f i * g (σ i) = ∑ i ∈ s, f i * g i ↔ AntivaryOn f (g ∘ σ) s :=
   hfg.sum_smul_comp_perm_eq_sum_smul_iff hσ
 
 /-- **Strict inequality case of the Rearrangement Inequality**: Pointwise multiplication of
-`f` and `g`, which antivary together, is strictly decreased by a permutation if and only if
-`f` and `g ∘ σ` do not antivary together. Stated by permuting the entries of `g`. -/
+`f` and `g`, which antivary together on `s`, is strictly decreased by a permutation if and only if
+`f` and `g ∘ σ` do not antivary together on `s`. Stated by permuting the entries of `g`. -/
 theorem AntivaryOn.sum_mul_lt_sum_mul_comp_perm_iff (hfg : AntivaryOn f g s)
     (hσ : {x | σ x ≠ x} ⊆ s) :
     ∑ i ∈ s, f i * g i < ∑ i ∈ s, f i * g (σ i) ↔ ¬AntivaryOn f (g ∘ σ) s :=
   hfg.sum_smul_lt_sum_smul_comp_perm_iff hσ
 
 /-- **Rearrangement Inequality**: Pointwise multiplication of `f` and `g` is minimized when `f` and
-`g` antivary together. Stated by permuting the entries of `f`. -/
+`g` antivary together on `s`. Stated by permuting the entries of `f`. -/
 theorem AntivaryOn.sum_mul_le_sum_comp_perm_mul (hfg : AntivaryOn f g s)
     (hσ : {x | σ x ≠ x} ⊆ s) : ∑ i ∈ s, f i * g i ≤ ∑ i ∈ s, f (σ i) * g i :=
   hfg.sum_smul_le_sum_comp_perm_smul hσ
 
 /-- **Equality case of the Rearrangement Inequality**: Pointwise multiplication of `f` and `g`,
-which antivary together, is unchanged by a permutation if and only if `f ∘ σ` and `g` antivary
-together. Stated by permuting the entries of `f`. -/
+which antivary together on `s`, is unchanged by a permutation if and only if `f ∘ σ` and `g`
+antivary together on `s`. Stated by permuting the entries of `f`. -/
 theorem AntivaryOn.sum_comp_perm_mul_eq_sum_mul_iff (hfg : AntivaryOn f g s)
     (hσ : {x | σ x ≠ x} ⊆ s) :
     ∑ i ∈ s, f (σ i) * g i = ∑ i ∈ s, f i * g i ↔ AntivaryOn (f ∘ σ) g s :=
@@ -434,8 +434,8 @@ theorem AntivaryOn.sum_comp_perm_mul_eq_sum_mul_iff (hfg : AntivaryOn f g s)
 alias AntivaryOn.sum_mul_eq_sum_comp_perm_mul_iff := AntivaryOn.sum_comp_perm_mul_eq_sum_mul_iff
 
 /-- **Strict inequality case of the Rearrangement Inequality**: Pointwise multiplication of
-`f` and `g`, which antivary together, is strictly decreased by a permutation if and only if
-`f ∘ σ` and `g` do not antivary together. Stated by permuting the entries of `f`. -/
+`f` and `g`, which antivary together on `s`, is strictly decreased by a permutation if and only if
+`f ∘ σ` and `g` do not antivary together on `s`. Stated by permuting the entries of `f`. -/
 theorem AntivaryOn.sum_mul_lt_sum_comp_perm_mul_iff (hfg : AntivaryOn f g s)
     (hσ : {x | σ x ≠ x} ⊆ s) :
     ∑ i ∈ s, f i * g i < ∑ i ∈ s, f (σ i) * g i ↔ ¬AntivaryOn (f ∘ σ) g s :=

--- a/Mathlib/Algebra/Order/Rearrangement.lean
+++ b/Mathlib/Algebra/Order/Rearrangement.lean
@@ -50,6 +50,8 @@ variable {ι α β : Type*} [LinearOrderedSemiring α] [ExistsAddOfLE α]
 
 /-! ### Scalar multiplication versions -/
 
+section SMul
+
 /-! #### Weak rearrangement inequality -/
 
 section weak_inequality
@@ -282,8 +284,8 @@ theorem MonovaryOn.sum_smul_comp_perm_lt_sum_smul_iff (hfg : MonovaryOn f g s)
 /-- **Strict inequality case of the Rearrangement Inequality**: Pointwise scalar multiplication of
 `f` and `g`, which antivary together on `s`, is strictly decreased by a permutation if and only if
 `f` and `g ∘ σ` do not antivary together on `s`. Stated by permuting the entries of `g`. -/
-theorem AntivaryOn.sum_smul_lt_sum_smul_comp_perm_iff
-    (hfg : AntivaryOn f g s) (hσ : {x | σ x ≠ x} ⊆ s) :
+theorem AntivaryOn.sum_smul_lt_sum_smul_comp_perm_iff (hfg : AntivaryOn f g s)
+    (hσ : {x | σ x ≠ x} ⊆ s) :
     ∑ i ∈ s, f i • g i < ∑ i ∈ s, f i • g (σ i) ↔ ¬AntivaryOn f (g ∘ σ) s := by
   simp [← hfg.sum_smul_comp_perm_eq_sum_smul_iff hσ, lt_iff_le_and_ne, eq_comm,
     hfg.sum_smul_le_sum_smul_comp_perm hσ]
@@ -340,6 +342,7 @@ theorem Antivary.sum_smul_lt_sum_comp_perm_smul_iff (hfg : Antivary f g) :
   simp [(hfg.antivaryOn _).sum_smul_lt_sum_comp_perm_smul_iff fun _ _ ↦ mem_univ _]
 
 end strict_inequality
+end SMul
 
 /-!
 ### Multiplication versions

--- a/scripts/noshake.json
+++ b/scripts/noshake.json
@@ -404,6 +404,7 @@
   ["Mathlib.AlgebraicTopology.AlternatingFaceMapComplex"],
   "Mathlib.Algebra.Star.Module": ["Mathlib.Algebra.Module.LinearMap.Star"],
   "Mathlib.Algebra.Ring.CentroidHom": ["Mathlib.Algebra.Algebra.Defs"],
+  "Mathlib.Algebra.Order.Module.Defs": ["Mathlib.Algebra.Order.Module.Synonym"],
   "Mathlib.Algebra.Order.CauSeq.Basic": ["Mathlib.Data.Setoid.Basic"],
   "Mathlib.Algebra.Module.LinearMap.Star":
   ["Mathlib.Algebra.Module.Equiv",

--- a/scripts/noshake.json
+++ b/scripts/noshake.json
@@ -404,7 +404,6 @@
   ["Mathlib.AlgebraicTopology.AlternatingFaceMapComplex"],
   "Mathlib.Algebra.Star.Module": ["Mathlib.Algebra.Module.LinearMap.Star"],
   "Mathlib.Algebra.Ring.CentroidHom": ["Mathlib.Algebra.Algebra.Defs"],
-  "Mathlib.Algebra.Order.Module.Defs": ["Mathlib.Algebra.Order.Module.Synonym"],
   "Mathlib.Algebra.Order.CauSeq.Basic": ["Mathlib.Data.Setoid.Basic"],
   "Mathlib.Algebra.Module.LinearMap.Star":
   ["Mathlib.Algebra.Module.Equiv",


### PR DESCRIPTION
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->
- [x] depends on: #13950
- [x] depends on: #15813
- [x] depends on: #15814
- [x] depends on: #16940

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
