### PR TITLE
[Merged by Bors] - chore: revert #15782

### DIFF
--- a/Mathlib/Algebra/BigOperators/Group/List.lean
+++ b/Mathlib/Algebra/BigOperators/Group/List.lean
@@ -21,7 +21,9 @@ of elements of a list and `List.alternatingProd`, `List.alternatingSum`, their a
 counterparts.
 -/
 
-assert_not_imported Mathlib.Algebra.Order.Group.Nat
+-- Make sure we haven't imported `Data.Nat.Order.Basic`
+assert_not_exists OrderedSub
+assert_not_exists Ring
 
 variable {ι α β M N P G : Type*}
 

--- a/Mathlib/Algebra/Field/Defs.lean
+++ b/Mathlib/Algebra/Field/Defs.lean
@@ -43,10 +43,11 @@ a `GroupWithZero` lemma instead.
 field, division ring, skew field, skew-field, skewfield
 -/
 
-assert_not_imported Mathlib.Tactic.Common
-
 -- `NeZero` should not be needed in the basic algebraic hierarchy.
 assert_not_exists NeZero
+
+-- Check that we have not imported `Mathlib.Tactic.Common` yet.
+assert_not_exists Mathlib.Tactic.scopedNS
 
 assert_not_exists MonoidHom
 

--- a/Mathlib/Data/List/Chain.lean
+++ b/Mathlib/Data/List/Chain.lean
@@ -18,7 +18,8 @@ A graph-specialized version is in development and will hopefully be added under 
 sometime soon.
 -/
 
-assert_not_imported Mathlib.Algebra.Order.Group.Nat
+-- Make sure we haven't imported `Data.Nat.Order.Basic`
+assert_not_exists OrderedSub
 
 universe u v
 

--- a/Mathlib/Data/List/GetD.lean
+++ b/Mathlib/Data/List/GetD.lean
@@ -14,9 +14,11 @@ import Mathlib.Util.AssertExists
 This file provides theorems for working with the `getD` and `getI` functions. These are used to
 access an element of a list by numerical index, with a default value as a fallback when the index
 is out of range.
+
 -/
 
-assert_not_imported Mathlib.Algebra.Order.Group.Nat
+-- Make sure we haven't imported `Data.Nat.Order.Basic`
+assert_not_exists OrderedSub
 
 namespace List
 


### PR DESCRIPTION
This breaks the speedcenter. Let's pull it back until we can get it figured out.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
