### PR TITLE
[Merged by Bors] - feat: add a `DecidableEq` instance to `FirstOrder.Language.Term`

### DIFF
--- a/Mathlib/ModelTheory/Syntax.lean
+++ b/Mathlib/ModelTheory/Syntax.lean
@@ -79,6 +79,18 @@ variable {L}
 
 namespace Term
 
+instance instDecidableEq [DecidableEq α] [∀ n, DecidableEq (L.Functions n)] : DecidableEq (L.Term α)
+  | .var a, .var b => decidable_of_iff (a = b) <| by simp
+  | @Term.func _ _ m f xs, @Term.func _ _ n g ys =>
+      if h : m = n then
+        letI : DecidableEq (L.Term α) := instDecidableEq
+        decidable_of_iff (f = h ▸ g ∧ ∀ i : Fin m, xs i = ys (Fin.cast h i)) <| by
+          subst h
+          simp [Function.funext_iff]
+      else
+        .isFalse <| by simp [h]
+  | .var _, .func _ _ | .func _ _, .var _ => .isFalse <| by simp
+
 open Finset
 
 /-- The `Finset` of variables used in a given term. -/


### PR DESCRIPTION
[Zulip thread](https://leanprover.zulipchat.com/#narrow/stream/113488-general/topic/.60Fin.20n.20-.3E.20a.60.20decidability/near/462419034)

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
