### PR TITLE
[Merged by Bors] - chore: clean up List/Indexes

### DIFF
--- a/Mathlib/Data/List/Basic.lean
+++ b/Mathlib/Data/List/Basic.lean
@@ -36,6 +36,10 @@ variable {ι : Type*} {α : Type u} {β : Type v} {γ : Type w} {l₁ l₂ : Lis
 -- Porting note: Delete this attribute
 -- attribute [inline] List.head!
 
+theorem getElem?_eq (l : List α) (i : Nat) :
+    l[i]? = if h : i < l.length then some l[i] else none := by
+  split <;> simp_all
+
 /-- There is only one list of an empty type -/
 instance uniqueOfIsEmpty [IsEmpty α] : Unique (List α) :=
   { instInhabitedList with

--- a/Mathlib/Data/List/Indexes.lean
+++ b/Mathlib/Data/List/Indexes.lean
@@ -25,34 +25,11 @@ variable {α : Type u} {β : Type v}
 
 section MapIdx
 
--- Porting note: Add back old definition because it's easier for writing proofs.
-
-/-- Lean3 `map_with_index` helper function -/
-protected def oldMapIdxCore (f : ℕ → α → β) : ℕ → List α → List β
-  | _, []      => []
-  | k, a :: as => f k a :: List.oldMapIdxCore f (k + 1) as
-
-/-- Given a function `f : ℕ → α → β` and `as : List α`, `as = [a₀, a₁, ...]`, returns the list
-`[f 0 a₀, f 1 a₁, ...]`. -/
-protected def oldMapIdx (f : ℕ → α → β) (as : List α) : List β :=
-  List.oldMapIdxCore f 0 as
-
 @[simp]
 theorem mapIdx_nil {α β} (f : ℕ → α → β) : mapIdx f [] = [] :=
   rfl
 
-protected theorem oldMapIdxCore_eq (l : List α) (f : ℕ → α → β) (n : ℕ) :
-    l.oldMapIdxCore f n = l.oldMapIdx fun i a ↦ f (i + n) a := by
-  induction' l with hd tl hl generalizing f n
-  · rfl
-  · rw [List.oldMapIdx]
-    simp only [List.oldMapIdxCore, hl, Nat.add_left_comm, Nat.add_comm, Nat.add_zero]
 
--- Porting note: convert new definition to old definition.
---   A few new theorems are added to achieve this
---   1. Prove that `oldMapIdxCore f (l ++ [e]) = oldMapIdxCore f l ++ [f l.length e]`
---   2. Prove that `oldMapIdx f (l ++ [e]) = oldMapIdx f l ++ [f l.length e]`
---   3. Prove list induction using `∀ l e, p [] → (p l → p (l ++ [e])) → p l`
 theorem list_reverse_induction (p : List α → Prop) (base : p [])
     (ind : ∀ (l : List α) (e : α), p l → p (l ++ [e])) : (∀ (l : List α), p l) := by
   let q := fun l ↦ p (reverse l)
@@ -64,39 +41,6 @@ theorem list_reverse_induction (p : List α → Prop) (base : p [])
   induction' l with head tail ih
   · apply pq; simp only [reverse_nil, base]
   · apply pq; simp only [reverse_cons]; apply ind; apply qp; rw [reverse_reverse]; exact ih
-
-protected theorem oldMapIdxCore_append : ∀ (f : ℕ → α → β) (n : ℕ) (l₁ l₂ : List α),
-    List.oldMapIdxCore f n (l₁ ++ l₂) =
-    List.oldMapIdxCore f n l₁ ++ List.oldMapIdxCore f (n + l₁.length) l₂ := by
-  intros f n l₁ l₂
-  generalize e : (l₁ ++ l₂).length = len
-  revert n l₁ l₂
-  induction' len with len ih <;> intros n l₁ l₂ h
-  · have l₁_nil : l₁ = [] := by
-      cases l₁
-      · rfl
-      · contradiction
-    have l₂_nil : l₂ = [] := by
-      cases l₂
-      · rfl
-      · rw [List.length_append] at h; contradiction
-    simp only [l₁_nil, l₂_nil]; rfl
-  · cases' l₁ with head tail
-    · rfl
-    · simp only [List.oldMapIdxCore, List.append_eq, length_cons, cons_append,cons.injEq, true_and]
-      suffices n + Nat.succ (length tail) = n + 1 + tail.length by
-        rw [this]
-        apply ih (n + 1) _ _ _
-        simp only [cons_append, length_cons, length_append, Nat.succ.injEq] at h
-        simp only [length_append, h]
-      rw [Nat.add_assoc]; simp only [Nat.add_comm]
-
-protected theorem oldMapIdx_append : ∀ (f : ℕ → α → β) (l : List α) (e : α),
-    List.oldMapIdx f (l ++ [e]) = List.oldMapIdx f l ++ [f l.length e] := by
-  intros f l e
-  unfold List.oldMapIdx
-  rw [List.oldMapIdxCore_append f 0 l [e]]
-  simp only [Nat.zero_add]; rfl
 
 theorem mapIdxGo_append : ∀ (f : ℕ → α → β) (l₁ l₂ : List α) (arr : Array β),
     mapIdx.go f (l₁ ++ l₂) arr = mapIdx.go f l₂ (List.toArray (mapIdx.go f l₁ arr)) := by
@@ -136,14 +80,6 @@ theorem mapIdx_append_one : ∀ (f : ℕ → α → β) (l : List α) (e : α),
   simp only [mapIdx.go, Array.size_toArray, mapIdxGo_length, length_nil, Nat.add_zero,
     Array.toList_eq, Array.push_data, Array.data_toArray]
 
-protected theorem new_def_eq_old_def :
-    ∀ (f : ℕ → α → β) (l : List α), l.mapIdx f = List.oldMapIdx f l := by
-  intro f
-  apply list_reverse_induction
-  · rfl
-  · intro l e h
-    rw [List.oldMapIdx_append, mapIdx_append_one, h]
-
 @[local simp]
 theorem map_enumFrom_eq_zipWith : ∀ (l : List α) (n : ℕ) (f : ℕ → α → β),
     map (uncurry f) (enumFrom n l) = zipWith (fun i ↦ f (i + n)) (range (length l)) l := by
@@ -168,13 +104,46 @@ theorem map_enumFrom_eq_zipWith : ∀ (l : List α) (n : ℕ) (f : ℕ → α �
         simp only [comp, Nat.add_assoc, Nat.add_comm, Nat.add_succ]
       simp only [length_cons, Nat.succ.injEq] at e; exact e
 
+theorem length_mapIdx_go (f : ℕ → α → β) : ∀ (l : List α) (arr : Array β),
+    (mapIdx.go f l arr).length = l.length + arr.size
+  | [], _ => by simp [mapIdx.go]
+  | a :: l, _ => by
+    simp only [mapIdx.go, length_cons]
+    rw [length_mapIdx_go]
+    simp
+    omega
+
+@[simp] theorem length_mapIdx (l : List α) (f : ℕ → α → β) : (l.mapIdx f).length = l.length := by
+  simp [mapIdx, length_mapIdx_go]
+
+theorem getElem?_mapIdx_go (f : ℕ → α → β) : ∀ (l : List α) (arr : Array β) (i : ℕ),
+    (mapIdx.go f l arr)[i]? =
+      if h : i < arr.size then some arr[i] else Option.map (f i) l[i - arr.size]?
+  | [], arr, i => by
+    simp [mapIdx.go, getElem?_eq, Array.getElem_eq_data_getElem]
+  | a :: l, arr, i => by
+    rw [mapIdx.go, getElem?_mapIdx_go]
+    simp only [Array.size_push]
+    split <;> split
+    · simp only [Option.some.injEq]
+      rw [Array.getElem_eq_data_getElem]
+      simp only [Array.push_data]
+      rw [getElem_append_left, Array.getElem_eq_data_getElem]
+    · have : i = arr.size := by omega
+      simp_all
+    · omega
+    · have : i - arr.size = i - (arr.size + 1) + 1 := by omega
+      simp_all
+
+@[simp] theorem getElem?_mapIdx (l : List α) (f : ℕ → α → β) (i : ℕ) :
+    (l.mapIdx f)[i]? = Option.map (f i) l[i]? := by
+  simp [mapIdx, getElem?_mapIdx_go]
+
 theorem mapIdx_eq_enum_map (l : List α) (f : ℕ → α → β) :
     l.mapIdx f = l.enum.map (Function.uncurry f) := by
-  rw [List.new_def_eq_old_def]
-  induction' l with hd tl hl generalizing f
-  · rfl
-  · rw [List.oldMapIdx, List.oldMapIdxCore, List.oldMapIdxCore_eq, hl]
-    simp [map, enum_eq_zip_range, map_uncurry_zip_eq_zipWith]
+  ext1 i
+  simp only [getElem?_mapIdx, Option.map, getElem?_map, getElem?_enum]
+  split <;> simp
 
 @[simp]
 theorem mapIdx_cons (l : List α) (f : ℕ → α → β) (a : α) :
@@ -187,12 +156,6 @@ theorem mapIdx_append (K L : List α) (f : ℕ → α → β) :
   induction' K with a J IH generalizing f
   · rfl
   · simp [IH fun i ↦ f (i + 1), Nat.add_assoc]
-
-@[simp]
-theorem length_mapIdx (l : List α) (f : ℕ → α → β) : (l.mapIdx f).length = l.length := by
-  induction' l with hd tl IH generalizing f
-  · rfl
-  · simp [IH]
 
 @[simp]
 theorem mapIdx_eq_nil {f : ℕ → α → β} {l : List α} : List.mapIdx f l = [] ↔ l = [] := by
@@ -210,6 +173,79 @@ theorem mapIdx_eq_ofFn (l : List α) (f : ℕ → α → β) :
   induction l generalizing f with
   | nil => simp
   | cons _ _ IH => simp [IH]
+
+section deprecated
+
+/-- Lean3 `map_with_index` helper function -/
+@[deprecated (since := "2024-08-15")]
+protected def oldMapIdxCore (f : ℕ → α → β) : ℕ → List α → List β
+  | _, []      => []
+  | k, a :: as => f k a :: List.oldMapIdxCore f (k + 1) as
+
+set_option linter.deprecated false in
+/-- Given a function `f : ℕ → α → β` and `as : List α`, `as = [a₀, a₁, ...]`, returns the list
+`[f 0 a₀, f 1 a₁, ...]`. -/
+@[deprecated (since := "2024-08-15")]
+protected def oldMapIdx (f : ℕ → α → β) (as : List α) : List β :=
+  List.oldMapIdxCore f 0 as
+
+set_option linter.deprecated false in
+@[deprecated (since := "2024-08-15")]
+protected theorem oldMapIdxCore_eq (l : List α) (f : ℕ → α → β) (n : ℕ) :
+    l.oldMapIdxCore f n = l.oldMapIdx fun i a ↦ f (i + n) a := by
+  induction' l with hd tl hl generalizing f n
+  · rfl
+  · rw [List.oldMapIdx]
+    simp only [List.oldMapIdxCore, hl, Nat.add_left_comm, Nat.add_comm, Nat.add_zero]
+
+set_option linter.deprecated false in
+@[deprecated (since := "2024-08-15")]
+protected theorem oldMapIdxCore_append : ∀ (f : ℕ → α → β) (n : ℕ) (l₁ l₂ : List α),
+    List.oldMapIdxCore f n (l₁ ++ l₂) =
+    List.oldMapIdxCore f n l₁ ++ List.oldMapIdxCore f (n + l₁.length) l₂ := by
+  intros f n l₁ l₂
+  generalize e : (l₁ ++ l₂).length = len
+  revert n l₁ l₂
+  induction' len with len ih <;> intros n l₁ l₂ h
+  · have l₁_nil : l₁ = [] := by
+      cases l₁
+      · rfl
+      · contradiction
+    have l₂_nil : l₂ = [] := by
+      cases l₂
+      · rfl
+      · rw [List.length_append] at h; contradiction
+    simp only [l₁_nil, l₂_nil]; rfl
+  · cases' l₁ with head tail
+    · rfl
+    · simp only [List.oldMapIdxCore, List.append_eq, length_cons, cons_append,cons.injEq, true_and]
+      suffices n + Nat.succ (length tail) = n + 1 + tail.length by
+        rw [this]
+        apply ih (n + 1) _ _ _
+        simp only [cons_append, length_cons, length_append, Nat.succ.injEq] at h
+        simp only [length_append, h]
+      rw [Nat.add_assoc]; simp only [Nat.add_comm]
+
+set_option linter.deprecated false in
+@[deprecated (since := "2024-08-15")]
+protected theorem oldMapIdx_append : ∀ (f : ℕ → α → β) (l : List α) (e : α),
+    List.oldMapIdx f (l ++ [e]) = List.oldMapIdx f l ++ [f l.length e] := by
+  intros f l e
+  unfold List.oldMapIdx
+  rw [List.oldMapIdxCore_append f 0 l [e]]
+  simp only [Nat.zero_add]; rfl
+
+set_option linter.deprecated false in
+@[deprecated (since := "2024-08-15")]
+protected theorem new_def_eq_old_def :
+    ∀ (f : ℕ → α → β) (l : List α), l.mapIdx f = List.oldMapIdx f l := by
+  intro f
+  apply list_reverse_induction
+  · rfl
+  · intro l e h
+    rw [List.oldMapIdx_append, mapIdx_append_one, h]
+
+end deprecated
 
 end MapIdx
 


### PR DESCRIPTION
There had been a bit of a mess here of shims connecting back to a Lean 3 era definition. Rip it all out, replacing the proofs that required these shims, and deprecate the now unneeded mess.