### PR TITLE
[Merged by Bors] - feat: Compute derivative of `fun x ↦ f (a - x)`

### DIFF
--- a/Mathlib/Analysis/Calculus/Deriv/Add.lean
+++ b/Mathlib/Analysis/Calculus/Deriv/Add.lean
@@ -132,6 +132,14 @@ lemma differentiableAt_comp_add_const {a b : 𝕜} :
     DifferentiableAt 𝕜 (fun x ↦ f (x + b)) a ↔ DifferentiableAt 𝕜 f (a + b) := by
   simpa [add_comm b] using differentiableAt_comp_const_add (f := f) (b := b)
 
+lemma differentiableAt_iff_comp_const_add {a b : 𝕜} :
+    DifferentiableAt 𝕜 f a ↔ DifferentiableAt 𝕜 (fun x ↦ f (b + x)) (-b + a) := by
+  simp [differentiableAt_comp_const_add]
+
+lemma differentiableAt_iff_comp_add_const {a b : 𝕜} :
+    DifferentiableAt 𝕜 f a ↔ DifferentiableAt 𝕜 (fun x ↦ f (x + b)) (a - b) := by
+  simp [differentiableAt_comp_add_const]
+
 end Add
 
 section Sum
@@ -335,6 +343,10 @@ theorem deriv_const_sub (c : F) : deriv (fun y => c - f y) x = -deriv f x := by
   simp only [← derivWithin_univ,
     derivWithin_const_sub (uniqueDiffWithinAt_univ : UniqueDiffWithinAt 𝕜 _ _)]
 
+lemma differentiableAt_comp_sub_const {a b : 𝕜} :
+    DifferentiableAt 𝕜 (fun x ↦ f (x - b)) a ↔ DifferentiableAt 𝕜 f (a - b) := by
+  simp [sub_eq_add_neg, differentiableAt_comp_add_const]
+
 lemma differentiableAt_comp_const_sub {a b : 𝕜} :
     DifferentiableAt 𝕜 (fun x ↦ f (b - x)) a ↔ DifferentiableAt 𝕜 f (b - a) := by
   refine ⟨fun H ↦ ?_, fun H ↦ H.comp a (differentiable_id.const_sub _).differentiableAt⟩
@@ -343,8 +355,12 @@ lemma differentiableAt_comp_const_sub {a b : 𝕜} :
   ext
   simp
 
+lemma differentiableAt_iff_comp_sub_const {a b : 𝕜} :
+    DifferentiableAt 𝕜 f a ↔ DifferentiableAt 𝕜 (fun x ↦ f (x - b)) (a + b) := by
+  simp [sub_eq_add_neg, differentiableAt_comp_add_const]
+
 lemma differentiableAt_iff_comp_const_sub {a b : 𝕜} :
     DifferentiableAt 𝕜 f a ↔ DifferentiableAt 𝕜 (fun x ↦ f (b - x)) (b - a) := by
-  simp_rw [← differentiableAt_comp_const_sub, _root_.sub_sub_cancel]
+  simp [differentiableAt_comp_const_sub]
 
 end Sub

--- a/Mathlib/Analysis/Calculus/Deriv/Add.lean
+++ b/Mathlib/Analysis/Calculus/Deriv/Add.lean
@@ -120,6 +120,18 @@ theorem deriv_const_add (c : F) : deriv (fun y => c + f y) x = deriv f x := by
 theorem deriv_const_add' (c : F) : (deriv fun y => c + f y) = deriv f :=
   funext fun _ => deriv_const_add c
 
+lemma differentiableAt_comp_const_add {a b : 𝕜} :
+    DifferentiableAt 𝕜 (fun x ↦ f (b + x)) a ↔ DifferentiableAt 𝕜 f (b + a) := by
+  refine ⟨fun H ↦ ?_, fun H ↦ H.comp _ (differentiable_id.const_add _).differentiableAt⟩
+  convert DifferentiableAt.comp (b + a) (by simpa)
+    (differentiable_id.const_add (-b)).differentiableAt
+  ext
+  simp
+
+lemma differentiableAt_comp_add_const {a b : 𝕜} :
+    DifferentiableAt 𝕜 (fun x ↦ f (x + b)) a ↔ DifferentiableAt 𝕜 f (a + b) := by
+  simpa [add_comm b] using differentiableAt_comp_const_add (f := f) (b := b)
+
 end Add
 
 section Sum
@@ -237,12 +249,16 @@ theorem not_differentiableAt_abs_zero : ¬ DifferentiableAt ℝ (abs : ℝ → �
       (hasDerivWithinAt_neg _ _).congr_of_mem (fun _ h ↦ abs_of_nonpos h) Set.right_mem_Iic
   linarith
 
-lemma differentiableAt_comp_neg_iff {a : 𝕜} :
-    DifferentiableAt 𝕜 f (-a) ↔ DifferentiableAt 𝕜 (fun x ↦ f (-x)) a := by
-  refine ⟨fun H ↦ H.comp a differentiable_neg.differentiableAt, fun H ↦ ?_⟩
+lemma differentiableAt_comp_neg {a : 𝕜} :
+    DifferentiableAt 𝕜 (fun x ↦ f (-x)) a ↔ DifferentiableAt 𝕜 f (-a) := by
+  refine ⟨fun H ↦ ?_, fun H ↦ H.comp a differentiable_neg.differentiableAt⟩
   convert ((neg_neg a).symm ▸ H).comp (-a) differentiable_neg.differentiableAt
   ext
   simp only [Function.comp_apply, neg_neg]
+
+lemma differentiableAt_iff_comp_neg {a : 𝕜} :
+    DifferentiableAt 𝕜 f a ↔ DifferentiableAt 𝕜 (fun x ↦ f (-x)) (-a) := by
+  simp_rw [← differentiableAt_comp_neg, neg_neg]
 
 end Neg2
 
@@ -318,5 +334,17 @@ theorem derivWithin_const_sub (hxs : UniqueDiffWithinAt 𝕜 s x) (c : F) :
 theorem deriv_const_sub (c : F) : deriv (fun y => c - f y) x = -deriv f x := by
   simp only [← derivWithin_univ,
     derivWithin_const_sub (uniqueDiffWithinAt_univ : UniqueDiffWithinAt 𝕜 _ _)]
+
+lemma differentiableAt_comp_const_sub {a b : 𝕜} :
+    DifferentiableAt 𝕜 (fun x ↦ f (b - x)) a ↔ DifferentiableAt 𝕜 f (b - a) := by
+  refine ⟨fun H ↦ ?_, fun H ↦ H.comp a (differentiable_id.const_sub _).differentiableAt⟩
+  convert ((sub_sub_cancel _ a).symm ▸ H).comp (b - a)
+    (differentiable_id.const_sub _).differentiableAt
+  ext
+  simp
+
+lemma differentiableAt_iff_comp_const_sub {a b : 𝕜} :
+    DifferentiableAt 𝕜 f a ↔ DifferentiableAt 𝕜 (fun x ↦ f (b - x)) (b - a) := by
+  simp_rw [← differentiableAt_comp_const_sub, _root_.sub_sub_cancel]
 
 end Sub

--- a/Mathlib/Analysis/Calculus/Deriv/Shift.lean
+++ b/Mathlib/Analysis/Calculus/Deriv/Shift.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2023 Michael Stoll. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Michael Stoll
+Authors: Michael Stoll, Yaël Dillies
 -/
 import Mathlib.Analysis.Calculus.Deriv.Add
 import Mathlib.Analysis.Calculus.Deriv.Comp
@@ -9,40 +9,55 @@ import Mathlib.Analysis.Calculus.Deriv.Comp
 /-!
 ### Invariance of the derivative under translation
 
-We show that if a function `h` has derivative `h'` at a point `a + x`, then `h (a + ·)`
-has derivative `h'` at `x`. Similarly for `x + a`.
+We show that if a function `f` has derivative `f'` at a point `a + x`, then `f (a + ·)`
+has derivative `f'` at `x`. Similarly for `x + a`.
 -/
 
-/-- Translation in the domain does not change the derivative. -/
-lemma HasDerivAt.comp_const_add {𝕜 : Type*} [NontriviallyNormedField 𝕜] (a x : 𝕜) {𝕜' : Type*}
-    [NormedAddCommGroup 𝕜'] [NormedSpace 𝕜 𝕜'] {h : 𝕜 → 𝕜'} {h' : 𝕜'}
-    (hh : HasDerivAt h h' (a + x)) :
-    HasDerivAt (fun x ↦ h (a + x)) h' x := by
-  simpa [Function.comp_def] using HasDerivAt.scomp (𝕜 := 𝕜) x hh <| hasDerivAt_id' x |>.const_add a
+variable {𝕜 F : Type*} [NontriviallyNormedField 𝕜] [NormedAddCommGroup F] [NormedSpace 𝕜 F]
+  {f : 𝕜 → F} {f' : F}
 
 /-- Translation in the domain does not change the derivative. -/
-lemma HasDerivAt.comp_add_const {𝕜 : Type*} [NontriviallyNormedField 𝕜] (x a : 𝕜) {𝕜' : Type*}
-    [NormedAddCommGroup 𝕜'] [NormedSpace 𝕜 𝕜'] {h : 𝕜 → 𝕜'} {h' : 𝕜'}
-    (hh : HasDerivAt h h' (x + a)) :
-    HasDerivAt (fun x ↦ h (x + a)) h' x := by
-  simpa [Function.comp_def] using HasDerivAt.scomp (𝕜 := 𝕜) x hh <| hasDerivAt_id' x |>.add_const a
+lemma HasDerivAt.comp_const_add (a x : 𝕜) (hf : HasDerivAt f f' (a + x)) :
+    HasDerivAt (fun x ↦ f (a + x)) f' x := by
+  simpa [Function.comp_def] using HasDerivAt.scomp (𝕜 := 𝕜) x hf <| hasDerivAt_id' x |>.const_add a
+
+/-- Translation in the domain does not change the derivative. -/
+lemma HasDerivAt.comp_add_const (x a : 𝕜) (hf : HasDerivAt f f' (x + a)) :
+    HasDerivAt (fun x ↦ f (x + a)) f' x := by
+  simpa [Function.comp_def] using HasDerivAt.scomp (𝕜 := 𝕜) x hf <| hasDerivAt_id' x |>.add_const a
+
+/-- Translation in the domain does not change the derivative. -/
+lemma HasDerivAt.comp_const_sub (a x : 𝕜) (hf : HasDerivAt f f' (a - x)) :
+    HasDerivAt (fun x ↦ f (a - x)) (-f') x := by
+  simpa [Function.comp_def] using HasDerivAt.scomp (𝕜 := 𝕜) x hf <| hasDerivAt_id' x |>.const_sub a
+
+/-- Translation in the domain does not change the derivative. -/
+lemma HasDerivAt.comp_sub_const (x a : 𝕜) (hf : HasDerivAt f f' (x - a)) :
+    HasDerivAt (fun x ↦ f (x - a)) f' x := by
+  simpa [Function.comp_def] using HasDerivAt.scomp (𝕜 := 𝕜) x hf <| hasDerivAt_id' x |>.sub_const a
+
+variable (f) (a x : 𝕜)
 
 /-- The derivative of `x ↦ f (-x)` at `a` is the negative of the derivative of `f` at `-a`. -/
-lemma deriv_comp_neg {𝕜 : Type*} [NontriviallyNormedField 𝕜] {F : Type*} [NormedAddCommGroup F]
-    [NormedSpace 𝕜 F] (f : 𝕜 → F) (a : 𝕜) : deriv (fun x ↦ f (-x)) a = -deriv f (-a) := by
-  by_cases h : DifferentiableAt 𝕜 f (-a)
-  · simpa only [deriv_neg, neg_one_smul] using deriv.scomp a h (differentiable_neg _)
-  · rw [deriv_zero_of_not_differentiableAt (mt differentiableAt_comp_neg_iff.mpr h),
-      deriv_zero_of_not_differentiableAt h, neg_zero]
+lemma deriv_comp_neg : deriv (fun x ↦ f (-x)) x = -deriv f (-x) := by
+  by_cases f : DifferentiableAt 𝕜 f (-x)
+  · simpa only [deriv_neg, neg_one_smul] using deriv.scomp _ f (differentiable_neg _)
+  · rw [deriv_zero_of_not_differentiableAt (differentiableAt_comp_neg.not.2 f),
+      deriv_zero_of_not_differentiableAt f, neg_zero]
 
 /-- Translation in the domain does not change the derivative. -/
-lemma deriv_comp_const_add {𝕜 : Type*} [NontriviallyNormedField 𝕜] (a x : 𝕜) {𝕜' : Type*}
-    [NormedAddCommGroup 𝕜'] [NormedSpace 𝕜 𝕜'] {h : 𝕜 → 𝕜'}
-    (hh : DifferentiableAt 𝕜 h (a + x)) :
-    deriv (fun x ↦ h (a + x)) x = deriv h (a + x) := HasDerivAt.deriv hh.hasDerivAt.comp_const_add
+lemma deriv_comp_const_add : deriv (fun x ↦ f (a + x)) x = deriv f (a + x) := by
+  by_cases hf : DifferentiableAt 𝕜 f (a + x)
+  · exact HasDerivAt.deriv hf.hasDerivAt.comp_const_add
+  · rw [deriv_zero_of_not_differentiableAt (differentiableAt_comp_const_add.not.2 hf),
+      deriv_zero_of_not_differentiableAt hf]
 
 /-- Translation in the domain does not change the derivative. -/
-lemma deriv_comp_add_const {𝕜 : Type*} [NontriviallyNormedField 𝕜] (a x : 𝕜) {𝕜' : Type*}
-    [NormedAddCommGroup 𝕜'] [NormedSpace 𝕜 𝕜'] {h : 𝕜 → 𝕜'}
-    (hh : DifferentiableAt 𝕜 h (x + a)) :
-    deriv (fun x ↦ h (x + a)) x = deriv h (x + a) := HasDerivAt.deriv hh.hasDerivAt.comp_add_const
+lemma deriv_comp_add_const : deriv (fun x ↦ f (x + a)) x = deriv f (x + a) := by
+  simpa [add_comm] using deriv_comp_const_add f a x
+
+lemma deriv_comp_const_sub : deriv (fun x ↦ f (a - x)) x = -deriv f (a - x) := by
+  simp_rw [sub_eq_add_neg, deriv_comp_neg (f $ a + ·), deriv_comp_const_add]
+
+lemma deriv_comp_sub_const : deriv (fun x ↦ f (x - a)) x = deriv f (x - a) := by
+  simp_rw [sub_eq_add_neg, deriv_comp_add_const]

--- a/Mathlib/NumberTheory/Harmonic/GammaDeriv.lean
+++ b/Mathlib/NumberTheory/Harmonic/GammaDeriv.lean
@@ -46,7 +46,7 @@ lemma deriv_Gamma_nat (n : ℕ) :
     exact fun m ↦ ne_of_gt (by linarith)
   -- Express derivative at general `n` in terms of value at `1` using recurrence relation
   have hder_rec (x : ℝ) (hx : 0 < x) : deriv f (x + 1) = deriv f x + 1 / x := by
-    rw [← deriv_comp_add_const _ _ (hder <| by positivity), one_div, ← deriv_log,
+    rw [← deriv_comp_add_const, one_div, ← deriv_log,
       ← deriv_add (hder <| by positivity) (differentiableAt_log hx.ne')]
     apply EventuallyEq.deriv_eq
     filter_upwards [eventually_gt_nhds hx] using h_rec
@@ -108,7 +108,6 @@ lemma hasDerivAt_Gamma_one_half : HasDerivAt Gamma (-√π * (γ + 2 * log 2)) (
       (by norm_num : 1/2 + 1/2 = (1 : ℝ)), Gamma_one, mul_one,
       eulerMascheroniConstant_eq_neg_deriv, add_neg_cancel, mul_zero, add_zero]
     · apply h_diff; norm_num -- s = 1
-    · apply h_diff; norm_num -- s = 1/2
     · exact ((h_diff (by norm_num)).hasDerivAt.comp_add_const).differentiableAt -- s = 1
   _ = (deriv (fun s ↦ Gamma (2 * s) * 2 ^ (1 - 2 * s) * √π) (1 / 2)) + √π * γ := by
     rw [funext Gamma_mul_Gamma_add_half]


### PR DESCRIPTION
... and similar. Also generalise existing lemmas to not require differentiability assumptions.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
