### PR TITLE
[Merged by Bors] - chore: Deprecate `Real.mul_pos`

### DIFF
--- a/Mathlib/Analysis/MeanInequalities.lean
+++ b/Mathlib/Analysis/MeanInequalities.lean
@@ -268,7 +268,7 @@ theorem harm_mean_le_geom_mean_weighted (w z : ι → ℝ) (hs : s.Nonempty) (hw
     have p_pos : 0 < ∏ i in s, (z i)⁻¹ ^ w i :=
       prod_pos fun i hi => rpow_pos_of_pos (inv_pos.2 (hz i hi)) _
     have s_pos : 0 < ∑ i in s, w i * (z i)⁻¹ :=
-      sum_pos (fun i hi => Real.mul_pos (hw i hi) (inv_pos.2 (hz i hi))) hs
+      sum_pos (fun i hi => mul_pos (hw i hi) (inv_pos.2 (hz i hi))) hs
     norm_num at this
     rw [← inv_le_inv s_pos p_pos] at this
     apply le_trans this

--- a/Mathlib/Analysis/SpecialFunctions/Log/ENNRealLog.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Log/ENNRealLog.lean
@@ -163,7 +163,7 @@ theorem log_mul_add {x y : ℝ≥0∞} : log (x * y) = log x + log y := by
     rcases ENNReal.trichotomy y with (rfl | rfl | y_real)
     · simp
     · simp [Ne.symm (ne_of_lt (ENNReal.toReal_pos_iff.1 x_real).1)]
-    · have xy_real := Real.mul_pos x_real y_real
+    · have xy_real := mul_pos x_real y_real
       rw [← ENNReal.toReal_mul] at xy_real
       rw_mod_cast [log_pos_real' xy_real, log_pos_real' y_real, ENNReal.toReal_mul]
       exact Real.log_mul (Ne.symm (ne_of_lt x_real)) (Ne.symm (ne_of_lt y_real))

--- a/Mathlib/Analysis/SpecialFunctions/Log/ENNRealLog.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Log/ENNRealLog.lean
@@ -163,10 +163,10 @@ theorem log_mul_add {x y : ℝ≥0∞} : log (x * y) = log x + log y := by
     rcases ENNReal.trichotomy y with (rfl | rfl | y_real)
     · simp
     · simp [Ne.symm (ne_of_lt (ENNReal.toReal_pos_iff.1 x_real).1)]
-    · have xy_real := mul_pos x_real y_real
-      rw [← ENNReal.toReal_mul] at xy_real
-      rw_mod_cast [log_pos_real' xy_real, log_pos_real' y_real, ENNReal.toReal_mul]
+    · rw_mod_cast [log_pos_real', log_pos_real' y_real, ENNReal.toReal_mul]
       exact Real.log_mul (Ne.symm (ne_of_lt x_real)) (Ne.symm (ne_of_lt y_real))
+      rw [toReal_mul]
+      positivity
 
 theorem log_pow {x : ℝ≥0∞} {n : ℕ} : log (x ^ n) = n * log x := by
   cases' Nat.eq_zero_or_pos n with n_zero n_pos

--- a/Mathlib/Data/Real/Basic.lean
+++ b/Mathlib/Data/Real/Basic.lean
@@ -343,22 +343,25 @@ protected theorem zero_lt_one : (0 : ℝ) < 1 := by
 protected theorem fact_zero_lt_one : Fact ((0 : ℝ) < 1) :=
   ⟨Real.zero_lt_one⟩
 
+@[deprecated mul_pos (since := "2024-08-15")]
 protected theorem mul_pos {a b : ℝ} : 0 < a → 0 < b → 0 < a * b := by
   induction' a using Real.ind_mk with a
   induction' b using Real.ind_mk with b
   simpa only [mk_lt, mk_pos, ← mk_mul] using CauSeq.mul_pos
 
-instance : StrictOrderedCommRing ℝ :=
-  { Real.commRing, Real.partialOrder,
-    Real.semiring with
-    exists_pair_ne := ⟨0, 1, Real.zero_lt_one.ne⟩
-    add_le_add_left := by
-      simp only [le_iff_eq_or_lt]
-      rintro a b ⟨rfl, h⟩
-      · simp only [lt_self_iff_false, or_false, forall_const]
-      · exact fun c => Or.inr ((add_lt_add_iff_left c).2 ‹_›)
-    zero_le_one := le_of_lt Real.zero_lt_one
-    mul_pos := @Real.mul_pos }
+instance instStrictOrderedCommRing : StrictOrderedCommRing ℝ where
+  __ := Real.commRing
+  exists_pair_ne := ⟨0, 1, Real.zero_lt_one.ne⟩
+  add_le_add_left := by
+    simp only [le_iff_eq_or_lt]
+    rintro a b ⟨rfl, h⟩
+    · simp only [lt_self_iff_false, or_false, forall_const]
+    · exact fun c => Or.inr ((add_lt_add_iff_left c).2 ‹_›)
+  zero_le_one := le_of_lt Real.zero_lt_one
+  mul_pos a b :=  by
+    induction' a using Real.ind_mk with a
+    induction' b using Real.ind_mk with b
+    simpa only [mk_lt, mk_pos, ← mk_mul] using CauSeq.mul_pos
 
 instance strictOrderedRing : StrictOrderedRing ℝ :=
   inferInstance

--- a/Mathlib/MeasureTheory/Measure/LevyProkhorovMetric.lean
+++ b/Mathlib/MeasureTheory/Measure/LevyProkhorovMetric.lean
@@ -412,7 +412,7 @@ lemma LevyProkhorov.continuous_toProbabilityMeasure :
     have key := (tendsto_integral_meas_thickening_le f (A := Ioc 0 ‖f‖) (by simp) P).comp ε_of_room'
     have aux : ∀ (z : ℝ), Iio (z + δ/2) ∈ 𝓝 z := fun z ↦ Iio_mem_nhds (by linarith)
     filter_upwards [key (aux _), ε_of_room <| Iio_mem_nhds <| half_pos <|
-                      Real.mul_pos (inv_pos.mpr norm_f_pos) δ_pos]
+                      mul_pos (inv_pos.mpr norm_f_pos) δ_pos]
       with n hn hn'
     simp only [mem_preimage, mem_Iio] at *
     specialize εs_pos n


### PR DESCRIPTION
This is a special of the more general `mul_pos`


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
