### PR TITLE
[Merged by Bors] - chore(Archive): remove most bare open Classical

### DIFF
--- a/Archive/Imo/Imo1986Q5.lean
+++ b/Archive/Imo/Imo1986Q5.lean
@@ -26,7 +26,7 @@ Formalization is based on
 with minor modifications.
 -/
 
-open Set NNReal Classical
+open NNReal
 
 namespace Imo1986Q5
 

--- a/Archive/Sensitivity.lean
+++ b/Archive/Sensitivity.lean
@@ -33,14 +33,11 @@ The project was developed at https://github.com/leanprover-community/lean-sensit
 archived at https://github.com/leanprover-community/mathlib/blob/master/archive/sensitivity.lean
 -/
 
-
-
 namespace Sensitivity
 
 /-! The next two lines assert we do not want to give a constructive proof,
 but rather use classical logic. -/
 noncomputable section
-open scoped Classical
 
 local notation "√" => Real.sqrt
 
@@ -194,6 +191,7 @@ noncomputable def ε : ∀ {n : ℕ}, Q n → V n →ₗ[ℝ] ℝ
 
 variable {n : ℕ}
 
+open Classical in
 theorem duality (p q : Q n) : ε p (e q) = if p = q then 1 else 0 := by
   induction' n with n IH
   · rw [show p = q from Subsingleton.elim (α := Q 0) p q]
@@ -225,6 +223,7 @@ theorem epsilon_total {v : V n} (h : ∀ p : Q n, (ε p) v = 0) : v = 0 := by
 
 open Module
 
+open Classical in
 /-- `e` and `ε` are dual families of vectors. It implies that `e` is indeed a basis
 and `ε` computes coefficients of decompositions of vectors on that basis. -/
 theorem dualBases_e_ε (n : ℕ) : DualBases (@e n) (@ε n) where
@@ -237,9 +236,11 @@ since this cardinal is finite, as a natural number in `finrank_V` -/
 
 theorem dim_V : Module.rank ℝ (V n) = 2 ^ n := by
   have : Module.rank ℝ (V n) = (2 ^ n : ℕ) := by
+    classical
     rw [rank_eq_card_basis (dualBases_e_ε _).basis, Q.card]
   assumption_mod_cast
 
+open Classical in
 instance : FiniteDimensional ℝ (V n) :=
   FiniteDimensional.of_fintype_basis (dualBases_e_ε _).basis
 
@@ -285,7 +286,7 @@ theorem f_squared : ∀ v : V n, (f n) (f n v) = (n : ℝ) • v := by
 /-! We now compute the matrix of `f` in the `e` basis (`p` is the line index,
 `q` the column index). -/
 
-
+open Classical in
 theorem f_matrix : ∀ p q : Q n, |ε q (f n (e p))| = if p ∈ q.adjacent then 1 else 0 := by
   induction' n with n IH
   · intro p q
@@ -360,7 +361,7 @@ local notation "Card " X:70 => Finset.card (Set.toFinset X)
 equipped with their subspace structures. The notations come from the general
 theory of lattices, with inf and sup (also known as meet and join). -/
 
-
+open Classical in
 /-- If a subset `H` of `Q (m+1)` has cardinal at least `2^m + 1` then the
 subspace of `V (m+1)` spanned by the corresponding basis vectors non-trivially
 intersects the range of `g m`. -/
@@ -395,6 +396,7 @@ theorem exists_eigenvalue (H : Set (Q m.succ)) (hH : Card H ≥ 2 ^ m + 1) :
   rw [Set.toFinset_card] at hH
   linarith
 
+open Classical in
 /-- **Huang sensitivity theorem** also known as the **Huang degree theorem** -/
 theorem huang_degree_theorem (H : Set (Q m.succ)) (hH : Card H ≥ 2 ^ m + 1) :
     ∃ q, q ∈ H ∧ √ (m + 1) ≤ Card H ∩ q.adjacent := by

--- a/Archive/Wiedijk100Theorems/AscendingDescendingSequences.lean
+++ b/Archive/Wiedijk100Theorems/AscendingDescendingSequences.lean
@@ -21,12 +21,9 @@ https://en.wikipedia.org/wiki/Erdos-Szekeres_theorem#Pigeonhole_principle.
 sequences, increasing, decreasing, Ramsey, Erdos-Szekeres, Erdős–Szekeres, Erdős-Szekeres
 -/
 
-
 variable {α : Type*} [LinearOrder α] {β : Type*}
 
 open Function Finset
-
-open scoped Classical
 
 namespace Theorems100
 

--- a/Archive/Wiedijk100Theorems/FriendshipGraphs.lean
+++ b/Archive/Wiedijk100Theorems/FriendshipGraphs.lean
@@ -38,7 +38,6 @@ be phrased in terms of counting walks.
 
 -/
 
-
 open scoped Classical
 
 namespace Theorems100

--- a/Archive/Wiedijk100Theorems/SumOfPrimeReciprocalsDiverges.lean
+++ b/Archive/Wiedijk100Theorems/SumOfPrimeReciprocalsDiverges.lean
@@ -38,10 +38,6 @@ The formalization follows Erdős's proof by upper and lower estimates.
 https://en.wikipedia.org/wiki/Divergence_of_the_sum_of_the_reciprocals_of_the_primes
 -/
 
-
-
-open scoped Classical
-
 open Filter Finset
 
 namespace Theorems100
@@ -57,6 +53,7 @@ of `p`, i.e., those `e < x` for which there is a prime `p ∈ (k, x]` that divid
 def U (x k : ℕ) :=
   Finset.biUnion (P x k) (fun p => Finset.filter (fun e => p ∣ e + 1) (range x))
 
+open Classical in
 /-- Those `e < x` for which `e + 1` is a product of powers of primes smaller than or equal to `k`.
 -/
 noncomputable def M (x k : ℕ) :=
@@ -217,6 +214,7 @@ theorem Real.tendsto_sum_one_div_prime_atTop :
   -- This is indeed a partition, so `|U| + |M| = |range x| = x`.
   have h2 : x = card U' + card M' := by
     rw [← card_range x, hU', hM', ← range_sdiff_eq_biUnion]
+    classical
     exact (card_sdiff_add_card_eq_card (Finset.filter_subset _ _)).symm
   -- But for the `x` we have chosen above, both `|U|` and `|M|` are less than or equal to `x / 2`,
   -- and for U, the inequality is strict.


### PR DESCRIPTION
A few files remain, which use it pretty pervasively: I was not sure if removing it there would have been an improvement.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
