### PR TITLE
chore(Algebra/Ring/Semireal/Defs): relax `IsSemireal` typeclass constraint

### DIFF
--- a/Mathlib/Algebra/Ring/Semireal/Defs.lean
+++ b/Mathlib/Algebra/Ring/Semireal/Defs.lean
@@ -42,6 +42,6 @@ class IsSemireal [AddMonoid R] [Mul R] [One R] [Neg R] : Prop where
 @[deprecated (since := "2024-08-09")] alias isSemireal.neg_one_not_SumSq :=
   IsSemireal.not_isSumSq_neg_one
 
-instance [LinearOrderedField R] : IsSemireal R where
+instance [LinearOrderedRing R] : IsSemireal R where
   non_trivial := zero_ne_one
   not_isSumSq_neg_one := fun h ↦ (not_le (α := R)).2 neg_one_lt_zero h.nonneg


### PR DESCRIPTION
Typeclass constraint on instance of `IsSemireal` relaxed from `LinearOrderedField` to `LinearOrderedRing`. This instance requires `LinearOrderedSemiring` and well as negation, so this is now the most general instance possible.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
