### PR TITLE
chore(Order/WellFounded): Use `WellFoundedLT` / `WellFoundedGT`

### DIFF
--- a/Archive/Imo/Imo1988Q6.lean
+++ b/Archive/Imo/Imo1988Q6.lean
@@ -130,9 +130,9 @@ theorem constant_descent_vieta_jumping (x y : ℕ) {claim : Prop} {H : ℕ → �
     rwa [exceptional_empty, Set.diff_empty]
   -- We are now set for an infinite descent argument.
   -- Let m be the smallest element of the nonempty set S.
-  let m : ℕ := WellFounded.min Nat.lt_wfRel.wf S S_nonempty
-  have m_mem : m ∈ S := WellFounded.min_mem Nat.lt_wfRel.wf S S_nonempty
-  have m_min : ∀ k ∈ S, ¬k < m := fun k hk => WellFounded.not_lt_min Nat.lt_wfRel.wf S S_nonempty hk
+  let m : ℕ := WellFoundedLT.min S S_nonempty
+  have m_mem : m ∈ S := WellFoundedLT.min_mem S S_nonempty
+  have m_min : ∀ k ∈ S, m ≤ k := fun k hk => WellFoundedLT.min_le S S_nonempty hk
   -- It suffices to show that there is point (a,b) with b ∈ S and b < m.
   rsuffices ⟨p', p'_mem, p'_small⟩ : ∃ p' : ℕ × ℕ, p'.2 ∈ S ∧ p'.2 < m
   · solve_by_elim

--- a/Mathlib/CategoryTheory/CofilteredSystem.lean
+++ b/Mathlib/CategoryTheory/CofilteredSystem.lean
@@ -241,7 +241,7 @@ theorem isMittagLeffler_of_exists_finite_range
     (h : ∀ j : J, ∃ (i : _) (f : i ⟶ j), (range <| F.map f).Finite) : F.IsMittagLeffler := by
   intro j
   obtain ⟨i, hi, hf⟩ := h j
-  obtain ⟨m, ⟨i, f, hm⟩, hmin⟩ := Finset.wellFoundedLT.wf.has_min
+  obtain ⟨m, ⟨i, f, hm⟩, hmin⟩ := Finset.wellFoundedLT.has_min
     { s : Finset (F.obj j) | ∃ (i : _) (f : i ⟶ j), ↑s = range (F.map f) }
     ⟨_, i, hi, hf.coe_toFinset⟩
   refine ⟨i, f, fun k g =>

--- a/Mathlib/Data/DFinsupp/WellFounded.lean
+++ b/Mathlib/Data/DFinsupp/WellFounded.lean
@@ -229,10 +229,10 @@ instance Pi.wellFoundedLT [Finite ι] [∀ i, Preorder (α i)] [hw : ∀ i, Well
   ⟨by
     obtain h | ⟨⟨x⟩⟩ := isEmpty_or_nonempty (∀ i, α i)
     · convert emptyWf.wf
-    letI : ∀ i, Zero (α i) := fun i => ⟨(hw i).wf.min ⊤ ⟨x i, trivial⟩⟩
+    letI : ∀ i, Zero (α i) := fun i => ⟨(hw i).min ⊤ ⟨x i, trivial⟩⟩
     haveI := Fintype.ofFinite ι
     refine InvImage.wf equivFunOnFintype.symm (DFinsupp.wellFoundedLT fun i a => ?_).wf
-    exact (hw i).wf.not_lt_min ⊤ _ trivial⟩
+    exact (hw i).not_lt_min ⊤ _ trivial⟩
 
 instance Function.wellFoundedLT {α} [Finite ι] [Preorder α] [WellFoundedLT α] :
     WellFoundedLT (ι → α) :=

--- a/Mathlib/Order/ConditionallyCompleteLattice/Basic.lean
+++ b/Mathlib/Order/ConditionallyCompleteLattice/Basic.lean
@@ -252,31 +252,31 @@ instance (priority := 100) CompleteLinearOrder.toConditionallyCompleteLinearOrde
 open scoped Classical in
 /-- A well founded linear order is conditionally complete, with a bottom element. -/
 noncomputable abbrev IsWellOrder.conditionallyCompleteLinearOrderBot (α : Type*)
-  [i₁ : _root_.LinearOrder α] [i₂ : OrderBot α] [h : IsWellOrder α (· < ·)] :
+  [i₁ : _root_.LinearOrder α] [i₂ : OrderBot α] [IsWellOrder α (· < ·)] :
     ConditionallyCompleteLinearOrderBot α :=
   { i₁, i₂, LinearOrder.toLattice with
-    sInf := fun s => if hs : s.Nonempty then h.wf.min s hs else ⊥
+    sInf := fun s => if hs : s.Nonempty then WellFoundedLT.min s hs else ⊥
     csInf_le := fun s a _ has => by
       have s_ne : s.Nonempty := ⟨a, has⟩
-      simpa [s_ne] using not_lt.1 (h.wf.not_lt_min s s_ne has)
+      simpa [s_ne] using WellFoundedLT.min_le has
     le_csInf := fun s a hs has => by
       simp only [hs, dif_pos]
-      exact has (h.wf.min_mem s hs)
-    sSup := fun s => if hs : (upperBounds s).Nonempty then h.wf.min _ hs else ⊥
+      exact has (WellFoundedLT.min_mem s hs)
+    sSup := fun s => if hs : (upperBounds s).Nonempty then WellFoundedLT.min _ hs else ⊥
     le_csSup := fun s a hs has => by
       have h's : (upperBounds s).Nonempty := hs
       simp only [h's, dif_pos]
-      exact h.wf.min_mem _ h's has
+      exact WellFoundedLT.min_mem _ h's has
     csSup_le := fun s a _ has => by
       have h's : (upperBounds s).Nonempty := ⟨a, has⟩
       simp only [h's, dif_pos]
-      simpa using h.wf.not_lt_min _ h's has
-    csSup_empty := by simpa using eq_bot_iff.2 (not_lt.1 <| h.wf.not_lt_min _ _ <| mem_univ ⊥)
+      exact WellFoundedLT.min_le has
+    csSup_empty := by simpa using eq_bot_iff.2 (WellFoundedLT.min_le <| mem_univ ⊥)
     csSup_of_not_bddAbove := by
       intro s H
       have B : ¬((upperBounds s).Nonempty) := H
       simp only [B, dite_false, upperBounds_empty, univ_nonempty, dite_true]
-      exact le_antisymm bot_le (WellFounded.min_le _ (mem_univ _))
+      exact bot_le.antisymm (WellFoundedLT.min_le (mem_univ _))
     csInf_of_not_bddBelow := fun s H ↦ (H (OrderBot.bddBelow s)).elim }
 
 namespace OrderDual
@@ -1108,12 +1108,12 @@ open Function
 
 variable [IsWellOrder α (· < ·)]
 
-theorem sInf_eq_argmin_on (hs : s.Nonempty) : sInf s = argminOn id wellFounded_lt s hs :=
-  IsLeast.csInf_eq ⟨argminOn_mem _ _ _ _, fun _ ha => argminOn_le id _ _ ha⟩
+theorem sInf_eq_argmin_on (hs : s.Nonempty) : sInf s = argminOn id s hs :=
+  IsLeast.csInf_eq ⟨argminOn_mem _ _ _, fun _ ha => argminOn_le id _ ha⟩
 
 theorem isLeast_csInf (hs : s.Nonempty) : IsLeast s (sInf s) := by
   rw [sInf_eq_argmin_on hs]
-  exact ⟨argminOn_mem _ _ _ _, fun a ha => argminOn_le id _ _ ha⟩
+  exact ⟨argminOn_mem _ _ _, fun a ha => argminOn_le id _ ha⟩
 
 theorem le_csInf_iff' (hs : s.Nonempty) : b ≤ sInf s ↔ b ∈ lowerBounds s :=
   le_isGLB_iff (isLeast_csInf hs).isGLB

--- a/Mathlib/Order/IsWellOrderLimitElement.lean
+++ b/Mathlib/Order/IsWellOrderLimitElement.lean
@@ -38,7 +38,7 @@ lemma self_le_wellOrderSucc (a : α) : a ≤ wellOrderSucc a := by
 lemma wellOrderSucc_le {a b : α} (ha : a < b) : wellOrderSucc a ≤ b := by
   dsimp [wellOrderSucc, WellFounded.succ]
   rw [dif_pos ⟨_, ha⟩]
-  exact WellFounded.min_le _ ha
+  exact WellFoundedLT.min_le ha
 
 lemma self_lt_wellOrderSucc {a b : α} (h : a < b) : a < wellOrderSucc a :=
   IsWellFounded.wf.lt_succ ⟨b, h⟩

--- a/Mathlib/Order/SuccPred/Basic.lean
+++ b/Mathlib/Order/SuccPred/Basic.lean
@@ -176,11 +176,11 @@ variable (α)
 
 /-- A well-order is a `SuccOrder`. -/
 noncomputable def SuccOrder.ofLinearWellFoundedLT [WellFoundedLT α] : SuccOrder α :=
-  ofCore (fun a ↦ if h : (Ioi a).Nonempty then wellFounded_lt.min _ h else a)
+  ofCore (fun a ↦ if h : (Ioi a).Nonempty then WellFoundedLT.min _ h else a)
     (fun ha _ ↦ by
       rw [not_isMax_iff] at ha
       simp_rw [Set.Nonempty, mem_Ioi, dif_pos ha]
-      exact ⟨(wellFounded_lt.min_le · ha), lt_of_lt_of_le (wellFounded_lt.min_mem _ ha)⟩)
+      exact ⟨(WellFoundedLT.min_le · ha), lt_of_lt_of_le (WellFoundedLT.min_mem _ ha)⟩)
     fun a ha ↦ dif_neg (not_not_intro ha <| not_isMax_iff.mpr ·)
 
 /-- A linear order with well-founded greater-than relation is a `PredOrder`. -/

--- a/Mathlib/SetTheory/Ordinal/Arithmetic.lean
+++ b/Mathlib/SetTheory/Ordinal/Arithmetic.lean
@@ -1962,7 +1962,7 @@ theorem eq_enumOrd (f : Ordinal → Ordinal) (hS : Unbounded (· < ·) S) :
     StrictMono f ∧ range f = S ↔ f = enumOrd S := by
   constructor
   · rintro ⟨h₁, h₂⟩
-    rwa [← lt_wf.eq_strictMono_iff_eq_range h₁ (enumOrd_strictMono hS), range_enumOrd hS]
+    rwa [← WellFoundedLT.eq_strictMono_iff_eq_range h₁ (enumOrd_strictMono hS), range_enumOrd hS]
   · rintro rfl
     exact ⟨enumOrd_strictMono hS, range_enumOrd hS⟩
 

--- a/Mathlib/SetTheory/Ordinal/Arithmetic.lean
+++ b/Mathlib/SetTheory/Ordinal/Arithmetic.lean
@@ -378,7 +378,7 @@ theorem IsNormal.inj {f} (H : IsNormal f) {a b} : f a = f b ↔ a = b := by
   simp only [le_antisymm_iff, H.le_iff]
 
 theorem IsNormal.self_le {f} (H : IsNormal f) (a) : a ≤ f a :=
-  lt_wf.self_le_of_strictMono H.strictMono a
+  WellFoundedLT.id_le_of_strictMono H.strictMono a
 
 theorem IsNormal.le_set {f o} (H : IsNormal f) (p : Set Ordinal) (p0 : p.Nonempty) (b)
     (H₂ : ∀ o, b ≤ o ↔ ∀ a ∈ p, a ≤ o) : f b ≤ o ↔ ∀ a ∈ p, f a ≤ o :=
@@ -1943,7 +1943,7 @@ theorem enumOrd_surjective (hS : Unbounded (· < ·) S) : ∀ s ∈ S, ∃ a, en
       exact (enumOrd_strictMono hS hab).trans_le hb
     · by_contra! h
       exact
-        (le_csSup ⟨s, fun a => (lt_wf.self_le_of_strictMono (enumOrd_strictMono hS) a).trans⟩
+        (le_csSup ⟨s, fun a => (WellFoundedLT.id_le_of_strictMono (enumOrd_strictMono hS) a).trans⟩
               (enumOrd_succ_le hS hs h)).not_lt
           (lt_succ _)⟩
 


### PR DESCRIPTION
This has two main benefits:
- `WellFoundedGT.max` has the correct name
- Typeclass inference allows us to golf a bunch of proofs.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
