### PR TITLE
[Merged by Bors] - fix: silence `aesop` in `cfc_cont_tac`

### DIFF
--- a/Mathlib/Tactic/ContinuousFunctionalCalculus.lean
+++ b/Mathlib/Tactic/ContinuousFunctionalCalculus.lean
@@ -26,7 +26,10 @@ macro_rules
 specifically concerning continuity of the functions involved. -/
 syntax (name := cfcContTac) "cfc_cont_tac" : tactic
 macro_rules
-  | `(tactic| cfc_cont_tac) => `(tactic| try (first | fun_prop (disch := aesop) | assumption))
+  | `(tactic| cfc_cont_tac) =>
+    `(tactic| try (first
+      | fun_prop (disch := aesop (config := {warnOnNonterminal := false}))
+      | assumption))
 
 /-- A tactic used to automatically discharge goals relating to the non-unital continuous functional
 calculus, specifically concerning whether `f 0 = 0`. -/


### PR DESCRIPTION
If `aesop` fails to discharge a goal in one branch of `fun_prop`, as implemened in `cfc_cont_tac`, it can emit a warning saying it failed to close the goal. If `fun_prop (disch := aesop)` then *succeeds* in a later branch of the same call, then the proof succeeds, but the warning is still emitted, causing the file to be noisy. Even worse, because this is called as an `autoParam`, there is no syntax in the file on which to emit the warning, so it just gets emitted at the top of the file.

This changes the configuration of `aesop` to `warnOnNonterminal := false` when used in `cfc_cont_tac`.

Note: this won't affect debugging or proof writing, because in that case the user will need to disable the use of the `autoParam` anyway by writing their own terms (or `fun_prop` calls).

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
