### PR TITLE
feat(CI): automatic labeling of PRs

### DIFF
--- a/.github/workflows/autolabel_action.yaml
+++ b/.github/workflows/autolabel_action.yaml
@@ -20,7 +20,7 @@ jobs:
 
       - run: |
           ./scripts/autolabels.sh long
-          printf 'Just the labels: "%s"\n' "$(./scripts/autolabels.sh)"
+          printf 'About to add the following labels: "%s"\n' "$(./scripts/autolabels.sh)"
           LABELS="$(./scripts/autolabels.sh)"
           printf $'gh issue edit \'%s\' --add-label \'%s\'\n' "$NUMBER" "$LABELS"
           if [ -z "$LABELS" ]

--- a/.github/workflows/autolabel_action.yaml
+++ b/.github/workflows/autolabel_action.yaml
@@ -1,0 +1,39 @@
+name: Apply at most one `t-`label to PRs
+
+on: pull_request
+
+jobs:
+  label-and-report-new-contributor:
+    runs-on: ubuntu-latest
+    # Don't run on forks, where we wouldn't have permissions to add the label anyway.
+    if: github.repository == 'leanprover-community/mathlib4'
+    permissions:
+      issues: write
+      checks: write
+      pull-requests: write
+      contents: read
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - run: |
+          ./scripts/autolabels.sh long
+          printf 'Just the labels: "%s"\n' "$(./scripts/autolabels.sh)"
+          LABELS="$(./scripts/autolabels.sh)"
+          printf $'gh issue edit \'%s\' --add-label \'%s\'\n' "$NUMBER" "$LABELS"
+          if [ -z "$LABELS" ]
+          then
+            printf 'No labels found\n'
+          elif [[ $LABELS != *,* ]]
+          then
+            printf 'Actually doing it!\n'
+            gh issue edit "$NUMBER" --add-label "$LABELS"
+          else
+            printf 'More than one label found: not adding a label\n'
+          fi
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          NUMBER: ${{ github.event.number }}

--- a/.github/workflows/autolabel_action.yaml
+++ b/.github/workflows/autolabel_action.yaml
@@ -3,7 +3,7 @@ name: Apply at most one `t-`label to PRs
 on: pull_request
 
 jobs:
-  label-and-report-new-contributor:
+  apply_one_t_label:
     runs-on: ubuntu-latest
     # Don't run on forks, where we wouldn't have permissions to add the label anyway.
     if: github.repository == 'leanprover-community/mathlib4'

--- a/scripts/autolabels.sh
+++ b/scripts/autolabels.sh
@@ -29,7 +29,7 @@ from `Tactic/anything_other_than_linter`.
 |t-linter                | Tactic/Linter                                                                     |
 |t-logic                 | Logic, ModelTheory                                                                |
 |t-measure-probability   | MeasureTheory, Probability, InformationTheory                                     |
-|t-meta                  | Tactic, Lean, Util, Mathport, Control, Testing                              |
+|t-meta                  | Tactic, Lean, Util, Mathport, Control, Testing                                    |
 |t-number-theory         | NumberTheory                                                                      |
 |t-order                 | Order                                                                             |
 |t-topology              | Topology, AlgebraicTopology                                                       |

--- a/scripts/autolabels.sh
+++ b/scripts/autolabels.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+
+ : <<'BASH_MODULE_DOCS'
+
+This file contains the dictionary for converting a modified dir into a github label,
+as well as the script to perform the conversion.
+
+Rules:
+* only lines starting with `|t-` are considered;
+* repeated spaces, commas and pipes (|) are ignored;
+* `Mathlib` is added by default to each `Root folder`.
+
+Exception: `Tactic/Linter` is converted into `Tactic-Linter` internally, to simplify separating it from
+`Tactic/anything_other_than_linter`.
+
+|Label                   |Root folders                                                                       |
+|-                       |-                                                                                  |
+|t-algebra               | Algebra, FieldTheory, RingTheory, GroupTheory, RepresentationTheory, LinearAlgebra|
+|t-algebraic-geometry    | AlgebraicGeometry, Geometry/RingedSpace                                           |
+|t-euclidean-geometry    | Geometry.Euclidean                                                                |
+|t-differential-geometry | Geometry/Manifold                                                                 |
+|t-analysis              | Analysis                                                                          |
+|t-category-theory       | CategoryTheory                                                                    |
+|t-combinatorics         | Combinatorics                                                                     |
+|t-computability         | Computability                                                                     |
+|t-condensed             | Condensed                                                                         |
+|t-data                  | Data                                                                              |
+|t-dynamics              | Dynamics                                                                          |
+|t-linter                | Tactic/Linter                                                                     |
+|t-logic                 | Logic, ModelTheory                                                                |
+|t-measure-probability   | MeasureTheory, Probability, InformationTheory                                     |
+|t-meta                  | Tactic, Lean, Init, Util, Mathport, Control, Testing                              |
+|t-number-theory         | NumberTheory                                                                      |
+|t-order                 | Order                                                                             |
+|t-topology              | Topology, AlgebraicTopology                                                       |
+|t-set-theory            | SetTheory                                                                         |
+
+BASH_MODULE_DOCS
+
+# strips replaces repeated `|, ` with a single space, then only keeps lines beginning with `t-`
+mdToSpaces () { tr -s '|, ' ' ' < scripts/autolabels.sh | sed -n 's=^ *t-=t-=p; /^BASH_MODULE_DOCS$/Q' ; }
+
+# parses the names of the files that have been modified and the dictionary above
+# whenever it finds a match, it stores it and prints a summary at the end.
+# there is a single input to this function:
+# if the input is `long`, it prints a full summary
+# if the input is anything else (including nothing), it prints just a comma-separated list of
+# labels found.
+(
+  mdToSpaces
+  git diff --name-only origin/master
+) |
+awk -v long="${1}" '
+    { gsub(/Tactic\/Linter/, "Tactic-Linter") }
+    (2 <= NF) {
+      for(i=2; i<=NF; i++) {
+        dir="Mathlib/"$i"/"
+        dirToLabel[dir]=$1
+      }
+    }
+    (1 == NF) { gitDiffs[$1]++ }
+  END{
+    for(fil in gitDiffs) {
+      fd=0
+      for(dir in dirToLabel) {
+        if (fil ~ dir) {
+          fd++
+          labelFor[dirToLabel[dir]]=labelFor[dirToLabel[dir]]"\n* "fil
+        }
+      }
+      if(fd == 0) { unlabeled[fil]=0 }
+    }
+    if (!(long == "long")){
+      labCount=0
+      for(l in labelFor) { labCount++ }
+      for(l in labelFor) {
+        labCount--
+        printf("%s%s", l, (labCount == 0)? "" : ",")
+      }
+    }
+    if (long == "long"){
+      print "applicable labels:"
+      for(l in labelFor) {
+        printf("* %s\n", l)
+      }
+      for(l in labelFor) {
+        printf("\nfound label %s for %s\n", l, labelFor[l])
+      }
+      print("\nno label found for")
+      for(fil in unlabeled) {
+        printf("* %s\n", fil)
+      }
+    }
+  }'

--- a/scripts/autolabels.sh
+++ b/scripts/autolabels.sh
@@ -2,13 +2,13 @@
 
  : <<'BASH_MODULE_DOCS'
 
-This file contains the dictionary for converting a modified dir into a github label,
-as well as the script to perform the conversion.
+This file contains the dictionary for converting a list of modified directories into a github label,
+as well as a script to actually compute which label(s) to apply to the current changes.
 
 Rules:
 * only lines starting with `|t-` are considered;
 * repeated spaces, commas and pipes (|) are ignored;
-* `Mathlib` is added by default to each `Root folder`.
+* `Mathlib` is added by default to each "root folder".
 
 Exception: `Tactic/Linter` is converted into `Tactic-Linter` internally, to simplify separating it from
 `Tactic/anything_other_than_linter`.

--- a/scripts/autolabels.sh
+++ b/scripts/autolabels.sh
@@ -5,19 +5,19 @@
 This file contains the dictionary for converting a list of modified directories into a github label,
 as well as a script to actually compute which label(s) to apply to the current changes.
 
-Rules:
+Dictionary entries must follow the following rules:
 * only lines starting with `|t-` are considered;
 * repeated spaces, commas and pipes (|) are ignored;
 * `Mathlib` is added by default to each "root folder".
 
-Exception: `Tactic/Linter` is converted into `Tactic-Linter` internally, to simplify separating it from
-`Tactic/anything_other_than_linter`.
+Exception: `Tactic/Linter` is converted into `Tactic-Linter` internally, to easily distinguish it
+from `Tactic/anything_other_than_linter`.
 
 |Label                   |Root folders                                                                       |
 |-                       |-                                                                                  |
 |t-algebra               | Algebra, FieldTheory, RingTheory, GroupTheory, RepresentationTheory, LinearAlgebra|
 |t-algebraic-geometry    | AlgebraicGeometry, Geometry/RingedSpace                                           |
-|t-euclidean-geometry    | Geometry.Euclidean                                                                |
+|t-euclidean-geometry    | Geometry/Euclidean                                                                |
 |t-differential-geometry | Geometry/Manifold                                                                 |
 |t-analysis              | Analysis                                                                          |
 |t-category-theory       | CategoryTheory                                                                    |
@@ -29,7 +29,7 @@ Exception: `Tactic/Linter` is converted into `Tactic-Linter` internally, to simp
 |t-linter                | Tactic/Linter                                                                     |
 |t-logic                 | Logic, ModelTheory                                                                |
 |t-measure-probability   | MeasureTheory, Probability, InformationTheory                                     |
-|t-meta                  | Tactic, Lean, Init, Util, Mathport, Control, Testing                              |
+|t-meta                  | Tactic, Lean, Util, Mathport, Control, Testing                              |
 |t-number-theory         | NumberTheory                                                                      |
 |t-order                 | Order                                                                             |
 |t-topology              | Topology, AlgebraicTopology                                                       |
@@ -37,7 +37,7 @@ Exception: `Tactic/Linter` is converted into `Tactic-Linter` internally, to simp
 
 BASH_MODULE_DOCS
 
-# strips replaces repeated `|, ` with a single space, then only keeps lines beginning with `t-`
+# replaces repeated `|, ` with a single space, then only keeps lines beginning with `t-`
 mdToSpaces () { tr -s '|, ' ' ' < scripts/autolabels.sh | sed -n 's=^ *t-=t-=p; /^BASH_MODULE_DOCS$/Q' ; }
 
 # parses the names of the files that have been modified and the dictionary above


### PR DESCRIPTION
This PR adds a CI action that tries to automatically label PRs with the appropriate `t-xxx` labels.

The script contains a "dictionary" to convert modified folders into `t-xxx` labels.
The script finds all possible labels for the files modified by the PR and, if there is exactly one possible label, applies it.

[Zulip discussion](https://leanprover.zulipchat.com/#narrow/stream/287929-mathlib4/topic/Auto-label.20PR.20topics)

---

In case it helps with reviewing, the action is adapted from the new contributor action.

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
