### PR TITLE
[Merged by Bors] - feat: add some convenience lemmas for `spectrum` and `inv`

### DIFF
--- a/Mathlib/Algebra/Algebra/Spectrum.lean
+++ b/Mathlib/Algebra/Algebra/Spectrum.lean
@@ -295,6 +295,27 @@ theorem sub_singleton_eq (a : A) (r : R) : σ a - {r} = σ (a - ↑ₐ r) := by
 
 end ScalarRing
 
+section ScalarSemifield
+
+variable {R : Type u} {A : Type v} [Semifield R] [Ring A] [Algebra R A]
+
+@[simp]
+lemma inv₀_mem_iff {r : R} {a : Aˣ} :
+    r⁻¹ ∈ spectrum R (a : A) ↔ r ∈ spectrum R (↑a⁻¹ : A) := by
+  obtain (rfl | hr) := eq_or_ne r 0
+  · simp [zero_mem_iff]
+  · lift r to Rˣ using hr.isUnit
+    simp [inv_mem_iff]
+
+lemma inv₀_mem_inv_iff {r : R} {a : Aˣ} :
+    r⁻¹ ∈ spectrum R (↑a⁻¹ : A) ↔ r ∈ spectrum R (a : A) := by
+  simp
+
+alias ⟨of_inv₀_mem, inv₀_mem⟩ := inv₀_mem_iff
+alias ⟨of_inv₀_mem_inv, inv₀_mem_inv⟩ := inv₀_mem_inv_iff
+
+end ScalarSemifield
+
 section ScalarField
 
 variable {𝕜 : Type u} {A : Type v}


### PR DESCRIPTION

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
