### PR TITLE
[Merged by Bors] - feat(Order/SuccPred/CompleteLinearOrder): `ConditionallyCompleteLinearOrder.toSuccOrder`

### DIFF
--- a/Mathlib/Order/ConditionallyCompleteLattice/Basic.lean
+++ b/Mathlib/Order/ConditionallyCompleteLattice/Basic.lean
@@ -251,8 +251,8 @@ instance (priority := 100) CompleteLinearOrder.toConditionallyCompleteLinearOrde
 
 open scoped Classical in
 /-- A well founded linear order is conditionally complete, with a bottom element. -/
-noncomputable abbrev IsWellOrder.conditionallyCompleteLinearOrderBot (α : Type*)
-  [i₁ : _root_.LinearOrder α] [i₂ : OrderBot α] [h : IsWellOrder α (· < ·)] :
+noncomputable abbrev WellFoundedLT.conditionallyCompleteLinearOrderBot (α : Type*)
+  [i₁ : LinearOrder α] [i₂ : OrderBot α] [h : WellFoundedLT α] :
     ConditionallyCompleteLinearOrderBot α :=
   { i₁, i₂, LinearOrder.toLattice with
     sInf := fun s => if hs : s.Nonempty then h.wf.min s hs else ⊥
@@ -1106,7 +1106,7 @@ theorem cbiInf_eq_of_not_forall {p : ι → Prop} {f : Subtype p → α} (hp : �
 
 open Function
 
-variable [IsWellOrder α (· < ·)]
+variable [WellFoundedLT α]
 
 theorem sInf_eq_argmin_on (hs : s.Nonempty) : sInf s = argminOn id wellFounded_lt s hs :=
   IsLeast.csInf_eq ⟨argminOn_mem _ _ _ _, fun _ ha => argminOn_le id _ _ ha⟩

--- a/Mathlib/Order/SuccPred/CompleteLinearOrder.lean
+++ b/Mathlib/Order/SuccPred/CompleteLinearOrder.lean
@@ -60,6 +60,8 @@ lemma IsGLB.exists_of_nonempty_of_not_isPredLimit
     ∃ i, f i = x := hf.mem_of_nonempty_of_not_isPredLimit (Set.range_nonempty f) hx
 
 open Classical in
+/-- Every conditionally complete linear order is a successor order, by setting the succesor of an
+element to the infimum of all larger elements. -/
 noncomputable def ConditionallyCompleteLinearOrder.toSuccOrder [WellFoundedLT α] :
     SuccOrder α where
   succ a := if IsMax a then a else sInf {b | a < b}

--- a/Mathlib/Order/SuccPred/CompleteLinearOrder.lean
+++ b/Mathlib/Order/SuccPred/CompleteLinearOrder.lean
@@ -61,7 +61,7 @@ lemma IsGLB.exists_of_nonempty_of_not_isPredLimit
 
 open Classical in
 /-- Every conditionally complete linear order with well-founded `<` is a successor order, by setting
-the succesor of an element to the infimum of all larger elements. -/
+the successor of an element to be the infimum of all larger elements. -/
 noncomputable def ConditionallyCompleteLinearOrder.toSuccOrder [WellFoundedLT α] :
     SuccOrder α where
   succ a := if IsMax a then a else sInf {b | a < b}

--- a/Mathlib/Order/SuccPred/CompleteLinearOrder.lean
+++ b/Mathlib/Order/SuccPred/CompleteLinearOrder.lean
@@ -60,7 +60,7 @@ lemma IsGLB.exists_of_nonempty_of_not_isPredLimit
     ∃ i, f i = x := hf.mem_of_nonempty_of_not_isPredLimit (Set.range_nonempty f) hx
 
 open Classical in
-noncomputable def ConditionallyCompleteLinearOrder.toSuccOrder [IsWellOrder α (· < ·)] :
+noncomputable def ConditionallyCompleteLinearOrder.toSuccOrder [WellFoundedLT α] :
     SuccOrder α where
   succ a := if IsMax a then a else sInf {b | a < b}
   le_succ a := by

--- a/Mathlib/Order/SuccPred/CompleteLinearOrder.lean
+++ b/Mathlib/Order/SuccPred/CompleteLinearOrder.lean
@@ -76,14 +76,12 @@ noncomputable def ConditionallyCompleteLinearOrder.toSuccOrder [WellFoundedLT α
     simp [h] at hs
     rw [not_isMax_iff] at h
     exact hs.not_lt (csInf_mem h)
-  le_of_lt_succ := by
-    intro b a hs
+  le_of_lt_succ {b a} hs := by
     by_cases h : IsMax a
     · simpa [h] using le_of_lt hs
     · simp [h] at hs
       simpa using not_mem_of_lt_csInf hs ⟨a, fun _ hc => hc.le⟩
-  succ_le_of_lt := by
-    intro a b ha
+  succ_le_of_lt {a b} ha := by
     simp [ha.not_isMax]
     exact csInf_le ⟨a, fun _ hc => hc.le⟩ ha
 

--- a/Mathlib/Order/SuccPred/CompleteLinearOrder.lean
+++ b/Mathlib/Order/SuccPred/CompleteLinearOrder.lean
@@ -59,6 +59,32 @@ lemma IsGLB.exists_of_nonempty_of_not_isPredLimit
     (hf : IsGLB (Set.range f) x) (hx : ¬ IsPredLimit x) :
     ∃ i, f i = x := hf.mem_of_nonempty_of_not_isPredLimit (Set.range_nonempty f) hx
 
+open Classical in
+noncomputable def ConditionallyCompleteLinearOrder.toSuccOrder [IsWellOrder α (· < ·)] :
+    SuccOrder α where
+  succ a := if IsMax a then a else sInf {b | a < b}
+  le_succ a := by
+    by_cases h : IsMax a
+    · simp [h]
+    · simp only [h, ↓reduceIte]
+      rw [not_isMax_iff] at h
+      exact le_csInf h (fun b => le_of_lt)
+  max_of_succ_le hs := by
+    by_contra h
+    simp [h] at hs
+    rw [not_isMax_iff] at h
+    exact hs.not_lt (csInf_mem h)
+  le_of_lt_succ := by
+    intro b a hs
+    by_cases h : IsMax a
+    · simpa [h] using le_of_lt hs
+    · simp [h] at hs
+      simpa using not_mem_of_lt_csInf hs ⟨a, fun _ hc => hc.le⟩
+  succ_le_of_lt := by
+    intro a b ha
+    simp [ha.not_isMax]
+    exact csInf_le ⟨a, fun _ hc => hc.le⟩ ha
+
 end ConditionallyCompleteLinearOrder
 
 section ConditionallyCompleteLinearOrderBot

--- a/Mathlib/Order/SuccPred/CompleteLinearOrder.lean
+++ b/Mathlib/Order/SuccPred/CompleteLinearOrder.lean
@@ -60,8 +60,8 @@ lemma IsGLB.exists_of_nonempty_of_not_isPredLimit
     ∃ i, f i = x := hf.mem_of_nonempty_of_not_isPredLimit (Set.range_nonempty f) hx
 
 open Classical in
-/-- Every conditionally complete linear order is a successor order, by setting the succesor of an
-element to the infimum of all larger elements. -/
+/-- Every conditionally complete linear order with well-founded `<` is a successor order, by setting
+the succesor of an element to the infimum of all larger elements. -/
 noncomputable def ConditionallyCompleteLinearOrder.toSuccOrder [WellFoundedLT α] :
     SuccOrder α where
   succ a := if IsMax a then a else sInf {b | a < b}

--- a/Mathlib/SetTheory/Cardinal/Basic.lean
+++ b/Mathlib/SetTheory/Cardinal/Basic.lean
@@ -687,7 +687,7 @@ instance : SuccOrder Cardinal := ConditionallyCompleteLinearOrder.toSuccOrder
 
 theorem succ_def (c : Cardinal) : succ c = sInf { c' | c < c' } :=
   dif_neg <| not_isMax c
-  
+
 theorem succ_pos : ∀ c : Cardinal, 0 < succ c :=
   bot_lt_succ
 

--- a/Mathlib/SetTheory/Cardinal/Basic.lean
+++ b/Mathlib/SetTheory/Cardinal/Basic.lean
@@ -683,15 +683,12 @@ lemma iInf_eq_zero_iff {ι : Sort*} {f : ι → Cardinal} :
   simp [iInf, sInf_eq_zero_iff]
 
 /-- Note that the successor of `c` is not the same as `c + 1` except in the case of finite `c`. -/
-instance : SuccOrder Cardinal :=
-  SuccOrder.ofSuccLeIff (fun c => sInf { c' | c < c' })
-    -- Porting note: Needed to insert `by apply` in the next line
-    ⟨by apply lt_of_lt_of_le <| csInf_mem <| exists_gt _,
-    -- Porting note used to be just `csInf_le'`
-    fun h ↦ csInf_le' h⟩
+instance : SuccOrder Cardinal := ConditionallyCompleteLinearOrder.toSuccOrder
 
-theorem succ_def (c : Cardinal) : succ c = sInf { c' | c < c' } :=
-  rfl
+theorem succ_def (c : Cardinal) : succ c = sInf { c' | c < c' } := by
+  classical
+  change ite _ _ _ = _
+  simp
 
 theorem succ_pos : ∀ c : Cardinal, 0 < succ c :=
   bot_lt_succ

--- a/Mathlib/SetTheory/Cardinal/Basic.lean
+++ b/Mathlib/SetTheory/Cardinal/Basic.lean
@@ -663,7 +663,7 @@ instance : WellFoundedLT Cardinal.{u} :=
 instance wo : @IsWellOrder Cardinal.{u} (· < ·) where
 
 instance : ConditionallyCompleteLinearOrderBot Cardinal :=
-  IsWellOrder.conditionallyCompleteLinearOrderBot _
+  WellFoundedLT.conditionallyCompleteLinearOrderBot _
 
 @[simp]
 theorem sInf_empty : sInf (∅ : Set Cardinal.{u}) = 0 :=
@@ -685,11 +685,9 @@ lemma iInf_eq_zero_iff {ι : Sort*} {f : ι → Cardinal} :
 /-- Note that the successor of `c` is not the same as `c + 1` except in the case of finite `c`. -/
 instance : SuccOrder Cardinal := ConditionallyCompleteLinearOrder.toSuccOrder
 
-theorem succ_def (c : Cardinal) : succ c = sInf { c' | c < c' } := by
-  classical
-  change ite _ _ _ = _
-  simp
-
+theorem succ_def (c : Cardinal) : succ c = sInf { c' | c < c' } :=
+  dif_neg <| not_isMax c
+  
 theorem succ_pos : ∀ c : Cardinal, 0 < succ c :=
   bot_lt_succ
 

--- a/Mathlib/SetTheory/Ordinal/Basic.lean
+++ b/Mathlib/SetTheory/Ordinal/Basic.lean
@@ -866,7 +866,7 @@ instance wellFoundedLT : WellFoundedLT Ordinal :=
 instance isWellOrder : IsWellOrder Ordinal (· < ·) where
 
 instance : ConditionallyCompleteLinearOrderBot Ordinal :=
-  IsWellOrder.conditionallyCompleteLinearOrderBot _
+  WellFoundedLT.conditionallyCompleteLinearOrderBot _
 
 theorem max_zero_left : ∀ a : Ordinal, max 0 a = a :=
   max_bot_left


### PR DESCRIPTION
Every complete linear order with well-founded `<` is a successor order.

We also change some `LinearOrder α` + `IsWellOrder α (<)` to `LinearOrder α` + `WellFoundedLT α`. Note that these instances are mathematically equivalent, but the former has redundant assumptions.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
