### PR TITLE
[Merged by Bors] - chore: add missing end

### DIFF
--- a/Mathlib/Algebra/Group/Hom/CompTypeclasses.lean
+++ b/Mathlib/Algebra/Group/Hom/CompTypeclasses.lean
@@ -106,3 +106,5 @@ theorem comp_assoc {Q : Type*} [Monoid Q]
     exact ⟨by simp only [← κ.comp_eq, ← h, ← κ'.comp_eq, MonoidHom.comp_assoc]⟩
 
 end MonoidHom.CompTriple
+
+end MonoidHomCompTriple

--- a/Mathlib/Algebra/Order/Monoid/OrderDual.lean
+++ b/Mathlib/Algebra/Order/Monoid/OrderDual.lean
@@ -9,7 +9,6 @@ import Mathlib.Algebra.Order.Monoid.Defs
 
 /-! # Ordered monoid structures on the order dual. -/
 
-
 universe u
 
 variable {α : Type u}

--- a/Mathlib/Algebra/Order/Monoid/Unbundled/OrderDual.lean
+++ b/Mathlib/Algebra/Order/Monoid/Unbundled/OrderDual.lean
@@ -62,3 +62,5 @@ instance covariantClass_swap_mul_lt [LT α] [Mul α]
   ⟨c.1.flip⟩
 
 
+
+end OrderDual

--- a/Mathlib/Algebra/Order/Monoid/Unbundled/OrderDual.lean
+++ b/Mathlib/Algebra/Order/Monoid/Unbundled/OrderDual.lean
@@ -8,7 +8,6 @@ import Mathlib.Algebra.Order.Monoid.Unbundled.Defs
 
 /-! # Unbundled ordered monoid structures on the order dual. -/
 
-
 universe u
 
 variable {α : Type u}
@@ -60,7 +59,5 @@ instance covariantClass_swap_mul_lt [LT α] [Mul α]
     [c : CovariantClass α α (swap (· * ·)) (· < ·)] :
     CovariantClass αᵒᵈ αᵒᵈ (swap (· * ·)) (· < ·) :=
   ⟨c.1.flip⟩
-
-
 
 end OrderDual

--- a/Mathlib/Algebra/Order/Ring/Unbundled/Basic.lean
+++ b/Mathlib/Algebra/Order/Ring/Unbundled/Basic.lean
@@ -1004,3 +1004,5 @@ end LinearOrderedRing
 @[deprecated (since := "2023-12-23")] alias zero_le_mul_right := mul_nonneg_iff_of_pos_right
 @[deprecated (since := "2023-12-23")] alias zero_lt_mul_left := mul_pos_iff_of_pos_left
 @[deprecated (since := "2023-12-23")] alias zero_lt_mul_right := mul_pos_iff_of_pos_right
+
+end OrderedCommRing

--- a/Mathlib/Data/Array/Defs.lean
+++ b/Mathlib/Data/Array/Defs.lean
@@ -32,3 +32,5 @@ where cyclicPermuteAux : Array α → List Nat → α → Nat → Array α
 /-- Permute the array using a list of cycles. -/
 def permute! [Inhabited α] (a : Array α) (ls : List (List Nat)) : Array α :=
 ls.foldl (init := a) (·.cyclicPermute! ·)
+
+end Array

--- a/Mathlib/Data/Int/Defs.lean
+++ b/Mathlib/Data/Int/Defs.lean
@@ -604,3 +604,5 @@ attribute [simp] natCast_pow
 @[deprecated (since := "2024-04-02")] alias sign_coe_nat_of_nonzero := sign_natCast_of_ne_zero
 @[deprecated (since := "2024-04-02")] alias toNat_coe_nat := toNat_natCast
 @[deprecated (since := "2024-04-02")] alias toNat_coe_nat_add_one := toNat_natCast_add_one
+
+end Int

--- a/Mathlib/Data/List/GetD.lean
+++ b/Mathlib/Data/List/GetD.lean
@@ -135,3 +135,5 @@ theorem getI_eq_iget_get? (n : ℕ) : l.getI n = (l.get? n).iget := by
 theorem getI_zero_eq_headI : l.getI 0 = l.headI := by cases l <;> rfl
 
 end getI
+
+end List

--- a/Mathlib/Data/MLList/IO.lean
+++ b/Mathlib/Data/MLList/IO.lean
@@ -50,3 +50,5 @@ where put
   stdin.putStr input
   stdin.flush
   return child
+
+end MLList

--- a/Mathlib/Data/MLList/Split.lean
+++ b/Mathlib/Data/MLList/Split.lean
@@ -108,3 +108,5 @@ starting a new sublist each time a predicate changes from `false` to `true`.
 -/
 def splitAtBecomesTrue (L : MLList m α) (p : α → Bool) : MLList m (List α) :=
   L.splitAtBecomesTrueM fun a => pure (.up (p a))
+
+end MLList

--- a/Mathlib/Data/Nat/Find.lean
+++ b/Mathlib/Data/Nat/Find.lean
@@ -223,3 +223,5 @@ theorem findGreatest_of_ne_zero (h : Nat.findGreatest P n = m) (h0 : m ≠ 0) : 
   (findGreatest_eq_iff.1 h).2.1 h0
 
 end FindGreatest
+
+end Nat

--- a/Mathlib/Data/Option/Defs.lean
+++ b/Mathlib/Data/Option/Defs.lean
@@ -99,3 +99,5 @@ instance liftOrGet_isId (f : α → α → α) : Std.LawfulIdentity (liftOrGet f
 def _root_.Lean.LOption.toOption {α} : Lean.LOption α → Option α
   | .some a => some a
   | _ => none
+
+end Option

--- a/Mathlib/Init/Data/Int/Order.lean
+++ b/Mathlib/Init/Data/Int/Order.lean
@@ -52,3 +52,5 @@ instance instLinearOrder : LinearOrder ℤ where
 
 protected theorem eq_zero_or_eq_zero_of_mul_eq_zero {a b : ℤ} (h : a * b = 0) : a = 0 ∨ b = 0 :=
   Int.mul_eq_zero.mp h
+
+end Int

--- a/Mathlib/Lean/Elab/Term.lean
+++ b/Mathlib/Lean/Elab/Term.lean
@@ -23,8 +23,4 @@ def elabPattern (patt : Term) (expectedType? : Option Expr) : TermElabM Expr := 
       synthesizeSyntheticMVars (postpone := .no) (ignoreStuckTC := true)
       instantiateMVars t
 
-end Term
-
-end Elab
-
-end Lean
+end Lean.Elab.Term

--- a/Mathlib/Lean/Elab/Term.lean
+++ b/Mathlib/Lean/Elab/Term.lean
@@ -22,3 +22,9 @@ def elabPattern (patt : Term) (expectedType? : Option Expr) : TermElabM Expr := 
       let t ← elabTerm patt expectedType?
       synthesizeSyntheticMVars (postpone := .no) (ignoreStuckTC := true)
       instantiateMVars t
+
+end Term
+
+end Elab
+
+end Lean

--- a/Mathlib/Lean/Exception.lean
+++ b/Mathlib/Lean/Exception.lean
@@ -38,3 +38,7 @@ and the only commonality is the prefix of the string, so that's what we look for
 -/
 def isFailedToSynthesize (e : Exception) : IO Bool := do
   pure <| (← e.toMessageData.toString).startsWith "failed to synthesize"
+
+end Exception
+
+end Lean

--- a/Mathlib/Lean/GoalsLocation.lean
+++ b/Mathlib/Lean/GoalsLocation.lean
@@ -30,3 +30,9 @@ def location : GoalsLocation → MetaM (Option Name)
   | ⟨_, .hypType fvarId _⟩  => some <$> fvarId.getUserName
   | ⟨_, .hypValue fvarId _⟩ => some <$> fvarId.getUserName
   | ⟨_, .target _⟩          => return none
+
+end GoalsLocation
+
+end SubExpr
+
+end Lean

--- a/Mathlib/Lean/GoalsLocation.lean
+++ b/Mathlib/Lean/GoalsLocation.lean
@@ -31,8 +31,4 @@ def location : GoalsLocation → MetaM (Option Name)
   | ⟨_, .hypValue fvarId _⟩ => some <$> fvarId.getUserName
   | ⟨_, .target _⟩          => return none
 
-end GoalsLocation
-
-end SubExpr
-
-end Lean
+end Lean.SubExpr.GoalsLocation

--- a/Mathlib/Lean/Json.lean
+++ b/Mathlib/Lean/Json.lean
@@ -39,3 +39,5 @@ instance {α : Type u} [FromJson α] (p : α → Prop) [DecidablePred p] : FromJ
 
 instance {α : Type u} [ToJson α] (p : α → Prop) : ToJson (Subtype p) where
   toJson x := toJson x.val
+
+end Lean

--- a/Mathlib/Lean/Meta/KAbstractPositions.lean
+++ b/Mathlib/Lean/Meta/KAbstractPositions.lean
@@ -87,3 +87,7 @@ example (h : [5] ≠ []) : List.getLast [5] h = 5 := by
 def kabstractIsTypeCorrect (e subExpr : Expr) (pos : SubExpr.Pos) : MetaM Bool := do
   withLocalDeclD `_a (← inferType subExpr) fun fvar => do
     isTypeCorrect (← replaceSubexpr (fun _ => pure fvar) pos e)
+
+end Meta
+
+end Lean

--- a/Mathlib/Lean/Meta/KAbstractPositions.lean
+++ b/Mathlib/Lean/Meta/KAbstractPositions.lean
@@ -88,6 +88,4 @@ def kabstractIsTypeCorrect (e subExpr : Expr) (pos : SubExpr.Pos) : MetaM Bool :
   withLocalDeclD `_a (← inferType subExpr) fun fvar => do
     isTypeCorrect (← replaceSubexpr (fun _ => pure fvar) pos e)
 
-end Meta
-
-end Lean
+end Lean.Meta

--- a/Mathlib/Lean/PrettyPrinter/Delaborator.lean
+++ b/Mathlib/Lean/PrettyPrinter/Delaborator.lean
@@ -37,3 +37,9 @@ def OptionsPerPos.setBool (opts : OptionsPerPos) (p : SubExpr.Pos) (n : Name) (v
     OptionsPerPos :=
   let e := opts.findD p {} |>.setBool n v
   opts.insert p e
+
+end Delaborator
+
+end PrettyPrinter
+
+end Lean

--- a/Mathlib/Lean/PrettyPrinter/Delaborator.lean
+++ b/Mathlib/Lean/PrettyPrinter/Delaborator.lean
@@ -38,8 +38,4 @@ def OptionsPerPos.setBool (opts : OptionsPerPos) (p : SubExpr.Pos) (n : Name) (v
   let e := opts.findD p {} |>.setBool n v
   opts.insert p e
 
-end Delaborator
-
-end PrettyPrinter
-
-end Lean
+end Lean.PrettyPrinter.Delaborator

--- a/Mathlib/Logic/Function/CompTypeclasses.lean
+++ b/Mathlib/Logic/Function/CompTypeclasses.lean
@@ -64,3 +64,5 @@ lemma comp_apply {M N P : Type*}
   rw [← h.comp_eq, Function.comp_apply]
 
 end CompTriple
+
+end CompTriple

--- a/Mathlib/Tactic/Abel.lean
+++ b/Mathlib/Tactic/Abel.lean
@@ -563,8 +563,4 @@ macro (name := abelConv) "abel" : conv =>
 @[inherit_doc abelConv] macro "abel!" : conv =>
   `(conv| first | discharge => abel1! | try_this abel_nf!)
 
-end Abel
-
-end Tactic
-
-end Mathlib
+end Mathlib.Tactic.Abel

--- a/Mathlib/Tactic/ApplyAt.lean
+++ b/Mathlib/Tactic/ApplyAt.lean
@@ -38,3 +38,5 @@ elab "apply" t:term "at" i:ident : tactic => withSynthesize <| withMainContext d
     (← mkAppOptM' f (mvs.pop.push ldecl.toExpr |>.map fun e => some e))
   let (_, mainGoal) ← mainGoal.intro1P
   replaceMainGoal <| [mainGoal] ++ mvs.pop.toList.map fun e => e.mvarId!
+
+end Mathlib.Tactic

--- a/Mathlib/Tactic/ApplyFun.lean
+++ b/Mathlib/Tactic/ApplyFun.lean
@@ -214,3 +214,5 @@ elab_rules : tactic | `(tactic| apply_fun $f $[$loc]? $[using $P]?) => do
     (atTarget := withMainContext do
       replaceMainGoal <| ← applyFunTarget f P (← getMainGoal))
     (failed := fun _ ↦ throwError "apply_fun failed")
+
+end Mathlib.Tactic

--- a/Mathlib/Tactic/ApplyWith.lean
+++ b/Mathlib/Tactic/ApplyWith.lean
@@ -23,3 +23,5 @@ open Lean Meta Elab Tactic Term
 elab (name := applyWith) "apply" " (" &"config" " := " cfg:term ") " e:term : tactic => do
   let cfg ← unsafe evalTerm ApplyConfig (mkConst ``ApplyConfig) cfg
   evalApplyLikeTactic (·.apply · cfg) e
+
+end Mathlib.Tactic

--- a/Mathlib/Tactic/ArithMult.lean
+++ b/Mathlib/Tactic/ArithMult.lean
@@ -41,3 +41,5 @@ proof term. -/
 macro (name := arith_mult?) "arith_mult?" c:Aesop.tactic_clause* : tactic =>
 `(tactic|
   { show_term { arith_mult $c* } })
+
+end ArithmeticFunction

--- a/Mathlib/Tactic/Basic.lean
+++ b/Mathlib/Tactic/Basic.lean
@@ -157,3 +157,5 @@ elab (name := clearValue) "clear_value" hs:(ppSpace colGt term:max)+ : tactic =>
       replaceMainGoal [mvarId]
 
 attribute [pp_with_univ] ULift PUnit PEmpty
+
+end Mathlib.Tactic

--- a/Mathlib/Tactic/Bound/Attribute.lean
+++ b/Mathlib/Tactic/Bound/Attribute.lean
@@ -138,6 +138,4 @@ context. A typical example is exposing an inequality field of a structure, such 
 macro "bound_forward" : attr =>
   `(attr|aesop safe forward (rule_sets := [$(Lean.mkIdent `Bound):ident]))
 
-end Bound
-
-end Mathlib.Tactic
+end Mathlib.Tactic.Bound

--- a/Mathlib/Tactic/Bound/Attribute.lean
+++ b/Mathlib/Tactic/Bound/Attribute.lean
@@ -137,3 +137,7 @@ context. A typical example is exposing an inequality field of a structure, such 
 `HasPowerSeriesOnBall.r_pos`. -/
 macro "bound_forward" : attr =>
   `(attr|aesop safe forward (rule_sets := [$(Lean.mkIdent `Bound):ident]))
+
+end Bound
+
+end Mathlib.Tactic

--- a/Mathlib/Tactic/Cases.lean
+++ b/Mathlib/Tactic/Cases.lean
@@ -164,3 +164,5 @@ elab (name := cases') "cases' " tgts:(Parser.Tactic.casesTarget,+) usingArg:((" 
       let subgoals ← ElimApp.evalNames elimInfo result.alts withArg
          (numEqs := targets.size) (toClear := targetsNew) (toTag := toTag)
       setGoals <| subgoals.toList ++ gs
+
+end Mathlib.Tactic

--- a/Mathlib/Tactic/CasesM.lean
+++ b/Mathlib/Tactic/CasesM.lean
@@ -164,3 +164,5 @@ constructorm* _ ∨ _, _ ∧ _, True
 elab (name := constructorM) "constructorm" recursive:"*"? ppSpace pats:term,+ : tactic => do
   let pats ← elabPatterns pats.getElems
   liftMetaTactic (constructorMatching · (matchPatterns pats) recursive.isSome)
+
+end Mathlib.Tactic

--- a/Mathlib/Tactic/CategoryTheory/BicategoryCoherence.lean
+++ b/Mathlib/Tactic/CategoryTheory/BicategoryCoherence.lean
@@ -159,6 +159,4 @@ theorem assoc_liftHom₂ {f g h i : a ⟶ b} [LiftHom f] [LiftHom g] [LiftHom h]
     (η : f ⟶ g) (θ : g ⟶ h) (ι : h ⟶ i) [LiftHom₂ η] [LiftHom₂ θ] : η ≫ θ ≫ ι = (η ≫ θ) ≫ ι :=
   (Category.assoc _ _ _).symm
 
-end BicategoryCoherence
-
-end Mathlib.Tactic
+end Mathlib.Tactic.BicategoryCoherence

--- a/Mathlib/Tactic/CategoryTheory/BicategoryCoherence.lean
+++ b/Mathlib/Tactic/CategoryTheory/BicategoryCoherence.lean
@@ -161,6 +161,4 @@ theorem assoc_liftHom₂ {f g h i : a ⟶ b} [LiftHom f] [LiftHom g] [LiftHom h]
 
 end BicategoryCoherence
 
-end Tactic
-
-end Mathlib
+end Mathlib.Tactic

--- a/Mathlib/Tactic/CategoryTheory/Coherence.lean
+++ b/Mathlib/Tactic/CategoryTheory/Coherence.lean
@@ -293,6 +293,4 @@ elab_rules : tactic
 
 end Coherence
 
-end Tactic
-
-end Mathlib
+end Mathlib.Tactic

--- a/Mathlib/Tactic/Check.lean
+++ b/Mathlib/Tactic/Check.lean
@@ -55,3 +55,5 @@ Like the `#check` command, the `#check` tactic allows stuck typeclass instance p
 These become metavariables in the output.
 -/
 elab tk:"#check " colGt term:term : tactic => elabCheckTactic tk true term
+
+end Mathlib.Tactic

--- a/Mathlib/Tactic/Choose.lean
+++ b/Mathlib/Tactic/Choose.lean
@@ -220,3 +220,5 @@ elab_rules : tactic
 syntax "choose!" (ppSpace colGt binderIdent)+ (" using " term)? : tactic
 macro_rules
   | `(tactic| choose! $[$ids]* $[using $h]?) => `(tactic| choose ! $[$ids]* $[using $h]?)
+
+end Mathlib.Tactic.Choose

--- a/Mathlib/Tactic/ClearExcept.lean
+++ b/Mathlib/Tactic/ClearExcept.lean
@@ -35,8 +35,4 @@ elab_rules : tactic
             toClear := toClear.push decl.fvarId
       goal.tryClearMany toClear
 
-end Tactic
-
-end Elab
-
-end Lean
+end Lean.Elab.Tactic

--- a/Mathlib/Tactic/ClearExcept.lean
+++ b/Mathlib/Tactic/ClearExcept.lean
@@ -34,3 +34,9 @@ elab_rules : tactic
           if let none ← isClass? decl.type then
             toClear := toClear.push decl.fvarId
       goal.tryClearMany toClear
+
+end Tactic
+
+end Elab
+
+end Lean

--- a/Mathlib/Tactic/ClearExclamation.lean
+++ b/Mathlib/Tactic/ClearExclamation.lean
@@ -17,3 +17,5 @@ elab (name := clear!) "clear!" hs:(ppSpace colGt ident)* : tactic => do
   let fvarIds ← getFVarIds hs
   liftMetaTactic1 fun goal ↦ do
     goal.tryClearMany <| (← collectForwardDeps (fvarIds.map .fvar) true).map (·.fvarId!)
+
+end Mathlib.Tactic

--- a/Mathlib/Tactic/Clear_.lean
+++ b/Mathlib/Tactic/Clear_.lean
@@ -22,3 +22,5 @@ elab (name := clear_) "clear_" : tactic =>
           if let none ← isClass? decl.type then
             toClear := toClear.push decl.fvarId
     goal.tryClearMany toClear
+
+end Mathlib.Tactic

--- a/Mathlib/Tactic/Coe.lean
+++ b/Mathlib/Tactic/Coe.lean
@@ -61,3 +61,5 @@ elab "(" "↥" ")" : term <= expectedType =>
       ensureHasType b ty
     else
       throwError "cannot coerce to sort{indentExpr x}"
+
+end Lean.Elab.Term.CoeImpl

--- a/Mathlib/Tactic/CongrM.lean
+++ b/Mathlib/Tactic/CongrM.lean
@@ -76,3 +76,5 @@ elab_rules : tactic
       let gStx ← Term.exprToSyntax (← getMainTarget)
       -- Gives the expected type to `refine` as a workaround for its elaboration order.
       evalTactic <| ← `(tactic| refine (congr($(⟨pattern⟩)) : $gStx))
+
+end Mathlib.Tactic

--- a/Mathlib/Tactic/Conv.lean
+++ b/Mathlib/Tactic/Conv.lean
@@ -134,3 +134,5 @@ syntax "#simp" (&" only")? (simpArgs)? " =>"? ppSpace term : command
 macro_rules
   | `(#simp%$tk $[only%$o]? $[[$args,*]]? $[=>]? $e) =>
     `(#conv%$tk simp $[only%$o]? $[[$args,*]]? => $e)
+
+end Mathlib.Tactic.Conv

--- a/Mathlib/Tactic/Core.lean
+++ b/Mathlib/Tactic/Core.lean
@@ -258,3 +258,5 @@ def getPackageDir (pkg : String) : IO System.FilePath := do
 
 /-- Returns the mathlib root directory. -/
 def getMathlibDir := getPackageDir "Mathlib"
+
+end Mathlib

--- a/Mathlib/Tactic/ExistsI.lean
+++ b/Mathlib/Tactic/ExistsI.lean
@@ -31,3 +31,5 @@ example : ∃ x : Nat, ∃ y : Nat, x = y := by
 -/
 macro "existsi " es:term,+ : tactic =>
   `(tactic| refine ⟨$es,*, ?_⟩)
+
+end Mathlib.Tactic

--- a/Mathlib/Tactic/Explode.lean
+++ b/Mathlib/Tactic/Explode.lean
@@ -271,3 +271,7 @@ elab "#explode " stx:term : command => withoutModifyingEnv <| Command.runTermEla
     let entries ← explode e
     let fitchTable : MessageData ← entriesToMessageData entries
     logInfo <|← addMessageContext m!"{heading}\n\n{fitchTable}\n"
+
+end Explode
+
+end Mathlib

--- a/Mathlib/Tactic/Explode/Datatypes.lean
+++ b/Mathlib/Tactic/Explode/Datatypes.lean
@@ -85,3 +85,7 @@ def Entries.add (entries : Entries) (expr : Expr) (entry : Entry) : Entry × Ent
 This is used by `let` bindings where `expr` is an fvar. -/
 def Entries.addSynonym (entries : Entries) (expr : Expr) (entry : Entry) : Entries :=
   ⟨entries.s.insert expr entry, entries.l⟩
+
+end Explode
+
+end Mathlib

--- a/Mathlib/Tactic/Explode/Pretty.lean
+++ b/Mathlib/Tactic/Explode/Pretty.lean
@@ -63,3 +63,7 @@ def entriesToMessageData (entries : Entries) : MetaM MessageData := do
   let paddedThms ← padRight <| entries.l.map (·.thm)
 
   rowToMessageData paddedLines paddedDeps paddedThms entries.l
+
+end Explode
+
+end Mathlib

--- a/Mathlib/Tactic/ExtractGoal.lean
+++ b/Mathlib/Tactic/ExtractGoal.lean
@@ -168,3 +168,5 @@ elab_rules : tactic
       let cmd := if ← Meta.isProp ty then "theorem" else "def"
       pure m!"{cmd} {sig} := sorry"
     logInfo msg
+
+end Mathlib.Tactic.ExtractGoal

--- a/Mathlib/Tactic/FailIfNoProgress.lean
+++ b/Mathlib/Tactic/FailIfNoProgress.lean
@@ -81,3 +81,5 @@ elab_rules : tactic
   let goal ← getMainGoal
   let l ← runAndFailIfNoProgress goal (evalTactic tacs)
   replaceMainGoal l
+
+end Mathlib.Tactic

--- a/Mathlib/Tactic/FieldSimp.lean
+++ b/Mathlib/Tactic/FieldSimp.lean
@@ -194,8 +194,4 @@ elab_rules : tactic
 
   _ ← simpLocation r.ctx {} dis loc
 
-end FieldSimp
-
-end Tactic
-
-end Mathlib
+end Mathlib.Tactic.FieldSimp

--- a/Mathlib/Tactic/Find.lean
+++ b/Mathlib/Tactic/Find.lean
@@ -135,3 +135,5 @@ elab "#find " t:term : tactic => do
   let t ← Term.elabTerm t none
   Term.synthesizeSyntheticMVars (postpone := .no) (ignoreStuckTC := true)
   findType t
+
+end Mathlib.Tactic.Find

--- a/Mathlib/Tactic/FunProp/Attr.lean
+++ b/Mathlib/Tactic/FunProp/Attr.lean
@@ -38,3 +38,9 @@ initialize funPropAttr : Unit ←
     erase := fun _declName =>
       throwError "can't remove `funProp` attribute (not implemented yet)"
   }
+
+end FunProp
+
+end Meta
+
+end Mathlib

--- a/Mathlib/Tactic/FunProp/Attr.lean
+++ b/Mathlib/Tactic/FunProp/Attr.lean
@@ -39,8 +39,6 @@ initialize funPropAttr : Unit ←
       throwError "can't remove `funProp` attribute (not implemented yet)"
   }
 
-end FunProp
-
-end Meta
+end Meta.FunProp
 
 end Mathlib

--- a/Mathlib/Tactic/FunProp/Core.lean
+++ b/Mathlib/Tactic/FunProp/Core.lean
@@ -690,3 +690,9 @@ mutual
           return none
 
 end
+
+end FunProp
+
+end Meta
+
+end Mathlib

--- a/Mathlib/Tactic/FunProp/Core.lean
+++ b/Mathlib/Tactic/FunProp/Core.lean
@@ -691,8 +691,6 @@ mutual
 
 end
 
-end FunProp
-
-end Meta
+end Meta.FunProp
 
 end Mathlib

--- a/Mathlib/Tactic/FunProp/Decl.lean
+++ b/Mathlib/Tactic/FunProp/Decl.lean
@@ -153,8 +153,6 @@ def tacticToDischarge (tacticCode : TSyntax `tactic) : Expr → MetaM (Option Ex
 
     return result?
 
-end FunProp
-
-end Meta
+end Meta.FunProp
 
 end Mathlib

--- a/Mathlib/Tactic/FunProp/Decl.lean
+++ b/Mathlib/Tactic/FunProp/Decl.lean
@@ -152,3 +152,9 @@ def tacticToDischarge (tacticCode : TSyntax `tactic) : Expr → MetaM (Option Ex
     let (result?, _) ← runTac?.run {} {}
 
     return result?
+
+end FunProp
+
+end Meta
+
+end Mathlib

--- a/Mathlib/Tactic/FunProp/Elab.lean
+++ b/Mathlib/Tactic/FunProp/Elab.lean
@@ -84,3 +84,9 @@ def funPropTac : Tactic
         throwError msg
 
   | _ => throwUnsupportedSyntax
+
+end FunProp
+
+end Meta
+
+end Mathlib

--- a/Mathlib/Tactic/FunProp/Elab.lean
+++ b/Mathlib/Tactic/FunProp/Elab.lean
@@ -85,8 +85,6 @@ def funPropTac : Tactic
 
   | _ => throwUnsupportedSyntax
 
-end FunProp
-
-end Meta
+end Meta.FunProp
 
 end Mathlib

--- a/Mathlib/Tactic/FunProp/FunctionData.lean
+++ b/Mathlib/Tactic/FunProp/FunctionData.lean
@@ -292,3 +292,9 @@ def FunctionData.decompositionOverArgs (fData : FunctionData) (args : Array Nat)
       return (f,g)
   catch _ =>
     return none
+
+end FunProp
+
+end Meta
+
+end Mathlib

--- a/Mathlib/Tactic/FunProp/FunctionData.lean
+++ b/Mathlib/Tactic/FunProp/FunctionData.lean
@@ -293,8 +293,6 @@ def FunctionData.decompositionOverArgs (fData : FunctionData) (args : Array Nat)
   catch _ =>
     return none
 
-end FunProp
-
-end Meta
+end Meta.FunProp
 
 end Mathlib

--- a/Mathlib/Tactic/FunProp/Mor.lean
+++ b/Mathlib/Tactic/FunProp/Mor.lean
@@ -150,3 +150,11 @@ def mkAppN (f : Expr) (xs : Array Arg) : Expr :=
     match x with
     | ⟨x, .none⟩ => (f.app x)
     | ⟨x, .some coe⟩ => (coe.app f).app x)
+
+end Mor
+
+end FunProp
+
+end Meta
+
+end Mathlib

--- a/Mathlib/Tactic/FunProp/Mor.lean
+++ b/Mathlib/Tactic/FunProp/Mor.lean
@@ -153,8 +153,6 @@ def mkAppN (f : Expr) (xs : Array Arg) : Expr :=
 
 end Mor
 
-end FunProp
-
-end Meta
+end Meta.FunProp
 
 end Mathlib

--- a/Mathlib/Tactic/FunProp/RefinedDiscrTree.lean
+++ b/Mathlib/Tactic/FunProp/RefinedDiscrTree.lean
@@ -1152,3 +1152,11 @@ def mapArraysM (d : RefinedDiscrTree α) (f : Array α → m (Array β)) : m (Re
 /-- Apply a function to the array of values at each node in a `RefinedDiscrTree`. -/
 def mapArrays (d : RefinedDiscrTree α) (f : Array α → Array β) : RefinedDiscrTree β :=
   d.mapArraysM (m := Id) f
+
+end RefinedDiscrTree
+
+end FunProp
+
+end Meta
+
+end Mathlib

--- a/Mathlib/Tactic/FunProp/RefinedDiscrTree.lean
+++ b/Mathlib/Tactic/FunProp/RefinedDiscrTree.lean
@@ -1153,10 +1153,4 @@ def mapArraysM (d : RefinedDiscrTree α) (f : Array α → m (Array β)) : m (Re
 def mapArrays (d : RefinedDiscrTree α) (f : Array α → Array β) : RefinedDiscrTree β :=
   d.mapArraysM (m := Id) f
 
-end RefinedDiscrTree
-
-end FunProp
-
-end Meta
-
-end Mathlib
+end Mathlib.Meta.FunProp.RefinedDiscrTree

--- a/Mathlib/Tactic/FunProp/StateList.lean
+++ b/Mathlib/Tactic/FunProp/StateList.lean
@@ -170,8 +170,4 @@ instance StateListT.monadControl : MonadControl m (StateListT σ m) where
   liftWith := fun f => do let s ← get; liftM (f (fun x => x s))
   restoreM := fun x _ => x
 
-end FunProp
-
-end Meta
-
-end Mathlib
+end Mathlib.Meta.FunProp

--- a/Mathlib/Tactic/FunProp/StateList.lean
+++ b/Mathlib/Tactic/FunProp/StateList.lean
@@ -169,3 +169,9 @@ instance StateListT.monadControl : MonadControl m (StateListT σ m) where
   stM      := StateList σ
   liftWith := fun f => do let s ← get; liftM (f (fun x => x s))
   restoreM := fun x _ => x
+
+end FunProp
+
+end Meta
+
+end Mathlib

--- a/Mathlib/Tactic/FunProp/Theorems.lean
+++ b/Mathlib/Tactic/FunProp/Theorems.lean
@@ -389,3 +389,9 @@ function property: {thm.funPropName}"
 transition theorem: {thm.thmName}
 function property: {thm.funPropName}"
     transitionTheoremsExt.add thm attrKind
+
+end FunProp
+
+end Meta
+
+end Mathlib

--- a/Mathlib/Tactic/FunProp/Theorems.lean
+++ b/Mathlib/Tactic/FunProp/Theorems.lean
@@ -390,8 +390,6 @@ transition theorem: {thm.thmName}
 function property: {thm.funPropName}"
     transitionTheoremsExt.add thm attrKind
 
-end FunProp
-
-end Meta
+end Meta.FunProp
 
 end Mathlib

--- a/Mathlib/Tactic/FunProp/ToBatteries.lean
+++ b/Mathlib/Tactic/FunProp/ToBatteries.lean
@@ -131,8 +131,6 @@ def etaExpand1 (f : Expr) : MetaM Expr := do
     withDefault do forallBoundedTelescope (← inferType f) (.some 1) fun xs _ => do
       mkLambdaFVars xs (mkAppN f xs)
 
-end FunProp
-
-end Meta
+end Meta.FunProp
 
 end Mathlib

--- a/Mathlib/Tactic/FunProp/ToBatteries.lean
+++ b/Mathlib/Tactic/FunProp/ToBatteries.lean
@@ -130,3 +130,9 @@ def etaExpand1 (f : Expr) : MetaM Expr := do
   else
     withDefault do forallBoundedTelescope (← inferType f) (.some 1) fun xs _ => do
       mkLambdaFVars xs (mkAppN f xs)
+
+end FunProp
+
+end Meta
+
+end Mathlib

--- a/Mathlib/Tactic/FunProp/Types.lean
+++ b/Mathlib/Tactic/FunProp/Types.lean
@@ -162,3 +162,9 @@ def logError (msg : String) : FunPropM Unit := do
           s.msgLog
         else
           msg::s.msgLog}
+
+end FunProp
+
+end Meta
+
+end Mathlib

--- a/Mathlib/Tactic/FunProp/Types.lean
+++ b/Mathlib/Tactic/FunProp/Types.lean
@@ -163,8 +163,6 @@ def logError (msg : String) : FunPropM Unit := do
         else
           msg::s.msgLog}
 
-end FunProp
-
-end Meta
+end Meta.FunProp
 
 end Mathlib

--- a/Mathlib/Tactic/GCongr/Core.lean
+++ b/Mathlib/Tactic/GCongr/Core.lean
@@ -527,3 +527,7 @@ elab_rules : tactic
       let g := Lean.MessageData.joinSep (unsolvedGoals.map Lean.MessageData.ofExpr) Format.line
       throwError "rel failed, cannot prove goal by 'substituting' the listed relationships. \
         The steps which could not be automatically justified were:\n{g}"
+
+end GCongr
+
+end Mathlib.Tactic

--- a/Mathlib/Tactic/GCongr/ForwardAttr.lean
+++ b/Mathlib/Tactic/GCongr/ForwardAttr.lean
@@ -52,3 +52,7 @@ initialize registerBuiltinAttribute {
       setEnv <| forwardExt.addEntry env (declName, ext)
     | _ => throwUnsupportedSyntax
 }
+
+end GCongr
+
+end Mathlib.Tactic

--- a/Mathlib/Tactic/GeneralizeProofs.lean
+++ b/Mathlib/Tactic/GeneralizeProofs.lean
@@ -520,3 +520,5 @@ elab (name := generalizeProofsElab) "generalize_proofs" config?:(Parser.Tactic.c
         let g' ← mkFreshExprSyntheticOpaqueMVar (← g.getType) (← g.getTag)
         g.assign g'
         return g'.mvarId!
+
+end Mathlib.Tactic

--- a/Mathlib/Tactic/Group.lean
+++ b/Mathlib/Tactic/Group.lean
@@ -86,8 +86,4 @@ macro_rules
 | `(tactic| group $[$loc]?) =>
   `(tactic| repeat (fail_if_no_progress (aux_group₁ $[$loc]? <;> aux_group₂ $[$loc]?)))
 
-end Group
-
-end Tactic
-
-end Mathlib
+end Mathlib.Tactic.Group

--- a/Mathlib/Tactic/Have.lean
+++ b/Mathlib/Tactic/Have.lean
@@ -101,3 +101,5 @@ elab_rules : tactic
 | `(tactic| let $n:optBinderIdent $bs* $[: $t:term]?) => withMainContext do
   let (goal1, goal2) ← haveLetCore (← getMainGoal) n bs t true
   replaceMainGoal [goal1, goal2]
+
+end Mathlib.Tactic

--- a/Mathlib/Tactic/HaveI.lean
+++ b/Mathlib/Tactic/HaveI.lean
@@ -41,3 +41,5 @@ macro_rules
 -/
 macro "letI' " hd:haveDecl : doElem =>
   `(doElem| assert! letIDummy $hd:haveDecl)
+
+end Mathlib.Tactic.HaveI

--- a/Mathlib/Tactic/HelpCmd.lean
+++ b/Mathlib/Tactic/HelpCmd.lean
@@ -316,3 +316,5 @@ syntax withPosition("#help " colGt &"command" "+"?
 macro_rules
   | `(#help command%$tk $[+%$more]? $(id)?) =>
     `(#help cat$[+%$more]? $(mkIdentFrom tk `command) $(id)?)
+
+end Mathlib.Tactic

--- a/Mathlib/Tactic/ITauto.lean
+++ b/Mathlib/Tactic/ITauto.lean
@@ -732,3 +732,5 @@ macro_rules
 --     category := DocCategory.tactic
 --     declNames := [`tactic.interactive.itauto]
 --     tags := ["logic", "propositional logic", "intuitionistic logic", "decision procedure"] }
+
+end Mathlib.Tactic.ITauto

--- a/Mathlib/Tactic/InferParam.lean
+++ b/Mathlib/Tactic/InferParam.lean
@@ -32,3 +32,5 @@ elab (name := inferOptParam) "infer_param" : tactic => do
       evalTactic tacticSyntax
   else throwError
     "`infer_param` only solves goals of the form `optParam _ _` or `autoParam _ _`, not {tgt}"
+
+end Mathlib.Tactic

--- a/Mathlib/Tactic/Inhabit.lean
+++ b/Mathlib/Tactic/Inhabit.lean
@@ -55,8 +55,4 @@ elab_rules : tactic
     let goal ← evalInhabit (← getMainGoal) h_name term
     replaceMainGoal [goal]
 
-end Tactic
-
-end Elab
-
-end Lean
+end Lean.Elab.Tactic

--- a/Mathlib/Tactic/Inhabit.lean
+++ b/Mathlib/Tactic/Inhabit.lean
@@ -54,3 +54,9 @@ elab_rules : tactic
   | `(tactic| inhabit $[$h_name:ident :]? $term) => do
     let goal ← evalInhabit (← getMainGoal) h_name term
     replaceMainGoal [goal]
+
+end Tactic
+
+end Elab
+
+end Lean

--- a/Mathlib/Tactic/IntervalCases.lean
+++ b/Mathlib/Tactic/IntervalCases.lean
@@ -397,6 +397,4 @@ elab_rules : tactic
       cont x xs[1]? subst g e lbs ubs (mustUseBounds := false)
     | _, _, _ => throwUnsupportedSyntax
 
-end Tactic
-
-end Mathlib
+end Mathlib.Tactic

--- a/Mathlib/Tactic/IrreducibleDef.lean
+++ b/Mathlib/Tactic/IrreducibleDef.lean
@@ -113,3 +113,9 @@ elab mods:declModifiers "irreducible_def" n_id:declId n_def:(irredDefLemma)?
     attribute [$attrs:attrInstance,*] $n)
   if prot.isSome then
     modifyEnv (addProtected · ((← getCurrNamespace) ++ n.getId))
+
+end Command
+
+end Elab
+
+end Lean

--- a/Mathlib/Tactic/IrreducibleDef.lean
+++ b/Mathlib/Tactic/IrreducibleDef.lean
@@ -114,8 +114,4 @@ elab mods:declModifiers "irreducible_def" n_id:declId n_def:(irredDefLemma)?
   if prot.isSome then
     modifyEnv (addProtected · ((← getCurrNamespace) ++ n.getId))
 
-end Command
-
-end Elab
-
-end Lean
+end Lean.Elab.Command

--- a/Mathlib/Tactic/Linarith/Oracle/SimplexAlgorithm/PositiveVector.lean
+++ b/Mathlib/Tactic/Linarith/Oracle/SimplexAlgorithm/PositiveVector.lean
@@ -98,3 +98,7 @@ def findPositiveVector {n m : Nat} {matType : Nat → Nat → Type} [UsableInSim
     return extractSolution res.snd
   else
     throwError "Simplex Algorithm failed"
+
+end SimplexAlgorithm
+
+end Linarith

--- a/Mathlib/Tactic/LinearCombination.lean
+++ b/Mathlib/Tactic/LinearCombination.lean
@@ -246,8 +246,4 @@ syntax "linear_combination2" (normStx)? (ppSpace colGt term)? : tactic
 elab_rules : tactic
   | `(tactic| linear_combination2 $[(norm := $tac)]? $(e)?) => elabLinearCombination tac none e true
 
-end LinearCombination
-
-end Tactic
-
-end Mathlib
+end Mathlib.Tactic.LinearCombination

--- a/Mathlib/Tactic/Linter/HaveLetLinter.lean
+++ b/Mathlib/Tactic/Linter/HaveLetLinter.lean
@@ -129,3 +129,9 @@ def haveLetLinter : Linter where run := withSetOptionIn fun _stx => do
           You can disable this linter using `set_option linter.haveLet 0`"
 
 initialize addLinter haveLetLinter
+
+end haveLet
+
+end Linter
+
+end Mathlib

--- a/Mathlib/Tactic/Linter/HaveLetLinter.lean
+++ b/Mathlib/Tactic/Linter/HaveLetLinter.lean
@@ -132,6 +132,4 @@ initialize addLinter haveLetLinter
 
 end haveLet
 
-end Linter
-
-end Mathlib
+end Mathlib.Linter

--- a/Mathlib/Tactic/MkIffOfInductiveProp.lean
+++ b/Mathlib/Tactic/MkIffOfInductiveProp.lean
@@ -411,3 +411,5 @@ initialize Lean.registerBuiltinAttribute {
       | _ => throwError "unrecognized syntax"
     mkIffOfInductivePropImpl decl tgt idStx
 }
+
+end Mathlib.Tactic.MkIff

--- a/Mathlib/Tactic/ModCases.lean
+++ b/Mathlib/Tactic/ModCases.lean
@@ -191,8 +191,4 @@ elab_rules : tactic
     | ~q(ℕ) => NatMod.modCases h e n
     | _ => throwError "mod_cases only works with Int and Nat"
 
-end ModCases
-
-end Tactic
-
-end Mathlib
+end Mathlib.Tactic.ModCases

--- a/Mathlib/Tactic/Monotonicity/Attr.lean
+++ b/Mathlib/Tactic/Monotonicity/Attr.lean
@@ -30,3 +30,9 @@ initialize ext : LabelExtension ← (
 relations on its domain and range, and possibly with side conditions."
   let mono := `mono
   registerLabelAttr mono descr mono)
+
+end Attr
+
+end Monotonicity
+
+end Mathlib.Tactic

--- a/Mathlib/Tactic/Monotonicity/Basic.lean
+++ b/Mathlib/Tactic/Monotonicity/Basic.lean
@@ -53,3 +53,7 @@ elab_rules : tactic
     transparency := .reducible
     exfalso := false }
   liftMetaTactic fun g => do processSyntax cfg false false [] [] #[mkIdent `mono] [g]
+
+end Monotonicity
+
+end Mathlib.Tactic

--- a/Mathlib/Tactic/MoveAdd.lean
+++ b/Mathlib/Tactic/MoveAdd.lean
@@ -459,3 +459,7 @@ elab "move_mul" rws:rwRuleSeq : tactic => do
   evalTactic (← `(tactic| move_oper $hmul $rws))
 
 end parsing
+
+end MoveAdd
+
+end Mathlib

--- a/Mathlib/Tactic/Nontriviality/Core.lean
+++ b/Mathlib/Tactic/Nontriviality/Core.lean
@@ -123,3 +123,7 @@ syntax (name := nontriviality) "nontriviality" (ppSpace colGt term)?
       g.assert `inst ty m
     let g ← liftM <| tac <|> nontrivialityByElim α g stx[2][1].getSepArgs
     replaceMainGoal [(← g.intro1).2]
+
+end Nontriviality
+
+end Mathlib.Tactic

--- a/Mathlib/Tactic/NormNum/Core.lean
+++ b/Mathlib/Tactic/NormNum/Core.lean
@@ -357,3 +357,5 @@ Unlike `norm_num`, this command does not fail when no simplifications are made.
 macro (name := normNumCmd) "#norm_num" cfg:(config)? o:(&" only")?
     args:(Parser.Tactic.simpArgs)? " :"? ppSpace e:term : command =>
   `(command| #conv norm_num $(cfg)? $[only%$o]? $(args)? => $e)
+
+end Mathlib.Tactic

--- a/Mathlib/Tactic/NormNum/Result.lean
+++ b/Mathlib/Tactic/NormNum/Result.lean
@@ -468,3 +468,5 @@ def Result.eqTrans {α : Q(Type u)} {a b : Q($α)} (eq : Q($a = $b)) : Result b 
   | .isRat inst q n d proof => Result.isRat inst q n d q($eq ▸ $proof)
 
 end Meta.NormNum
+
+end Mathlib

--- a/Mathlib/Tactic/NthRewrite.lean
+++ b/Mathlib/Tactic/NthRewrite.lean
@@ -146,3 +146,5 @@ macro (name := nthRwSeq) "nth_rw" c:(config)? ppSpace n:num+ s:rwRuleSeq l:(loca
     `(tactic| (nth_rewrite $(c)? $[$n]* [$rs,*] $(l)?; with_annotate_state $rbrak
       (try (with_reducible rfl))))
   | _ => Macro.throwUnsupported
+
+end Mathlib.Tactic

--- a/Mathlib/Tactic/PPWithUniv.lean
+++ b/Mathlib/Tactic/PPWithUniv.lean
@@ -47,3 +47,7 @@ initialize registerBuiltinAttribute {
       let attr ← Elab.elabAttr <| ← `(Term.attrInstance| delab $(mkIdent <| `app ++ src))
       liftTermElabM <| Term.applyAttributes ``delabWithUniv #[{attr with kind}]
   | _ => throwUnsupportedSyntax }
+
+end PPWithUniv
+
+end Mathlib

--- a/Mathlib/Tactic/Peel.lean
+++ b/Mathlib/Tactic/Peel.lean
@@ -244,8 +244,4 @@ macro_rules
   | `(tactic| peel $[$n:num]? $[$e:term]? $[with $h*]? using $u:term) =>
     `(tactic| peel $[$n:num]? $[$e:term]? $[with $h*]?; exact $u)
 
-end Peel
-
-end Tactic
-
-end Mathlib
+end Mathlib.Tactic.Peel

--- a/Mathlib/Tactic/Polyrith.lean
+++ b/Mathlib/Tactic/Polyrith.lean
@@ -426,8 +426,4 @@ elab_rules : tactic
       if !traceMe then Lean.Meta.Tactic.TryThis.addSuggestion tk stx
     | .error g => replaceMainGoal [g]
 
-end Polyrith
-
-end Tactic
-
-end Mathlib
+end Mathlib.Tactic.Polyrith

--- a/Mathlib/Tactic/Positivity/Core.lean
+++ b/Mathlib/Tactic/Positivity/Core.lean
@@ -414,6 +414,4 @@ elab (name := positivity) "positivity" : tactic => do
 
 end Positivity
 
-end Tactic
-
-end Mathlib
+end Mathlib.Tactic

--- a/Mathlib/Tactic/Propose.lean
+++ b/Mathlib/Tactic/Propose.lean
@@ -143,3 +143,5 @@ macro_rules
     `(tactic| have?%$tk ! $[: $type]? using $terms,*)
   | `(tactic| have!?%$tk $[: $type]? using $terms,*) =>
     `(tactic| have?%$tk ! $[: $type]? using $terms,*)
+
+end Mathlib.Tactic.Propose

--- a/Mathlib/Tactic/PushNeg.lean
+++ b/Mathlib/Tactic/PushNeg.lean
@@ -235,3 +235,5 @@ elab "push_neg" loc:(location)? : tactic =>
     pushNegLocalDecl
     pushNegTarget
     (fun _ ↦ logInfo "push_neg couldn't find a negation to push")
+
+end Mathlib.Tactic.PushNeg

--- a/Mathlib/Tactic/Qify.lean
+++ b/Mathlib/Tactic/Qify.lean
@@ -75,6 +75,4 @@ alias int_cast_ne := intCast_ne
 
 end Qify
 
-end Tactic
-
-end Mathlib
+end Mathlib.Tactic

--- a/Mathlib/Tactic/Recall.lean
+++ b/Mathlib/Tactic/Recall.lean
@@ -77,3 +77,5 @@ elab_rules : command
       else
         unless binders.getNumArgs == 0 do
           throwError "expected type after ':'"
+
+end Mathlib.Tactic.Recall

--- a/Mathlib/Tactic/Recover.lean
+++ b/Mathlib/Tactic/Recover.lean
@@ -67,3 +67,5 @@ elab "recover " tacs:tacticSeq : tactic => do
     let unassignedMVarDependencies ← getUnassignedGoalMVarDependencies mvarId
     unassigned := unassigned.insertMany unassignedMVarDependencies.toList
   setGoals <| ((← getGoals) ++ unassigned.toList).eraseDups
+
+end Mathlib.Tactic

--- a/Mathlib/Tactic/Relation/Rfl.lean
+++ b/Mathlib/Tactic/Relation/Rfl.lean
@@ -41,3 +41,5 @@ def _root_.Lean.Expr.relSidesIfRefl? (e : Expr) : MetaM (Option (Name × Expr ×
       | some n => return some (n, lhs, rhs)
       | none => return none
   return none
+
+end Mathlib.Tactic

--- a/Mathlib/Tactic/Relation/Symm.lean
+++ b/Mathlib/Tactic/Relation/Symm.lean
@@ -32,3 +32,5 @@ def _root_.Lean.Expr.relSidesIfSymm? (e : Expr) : MetaM (Option (Name × Expr ×
       | some n => return some (n, lhs, rhs)
       | none => return none
   return none
+
+end Mathlib.Tactic

--- a/Mathlib/Tactic/Relation/Trans.lean
+++ b/Mathlib/Tactic/Relation/Trans.lean
@@ -218,3 +218,5 @@ set_option hygiene false in
 macro_rules
   | `(tactic| transitivity) => `(tactic| trans)
   | `(tactic| transitivity $e) => `(tactic| trans $e)
+
+end Mathlib.Tactic

--- a/Mathlib/Tactic/Rename.lean
+++ b/Mathlib/Tactic/Rename.lean
@@ -38,3 +38,5 @@ elab_rules : tactic
     withMainContext do
       for fvar in ids, tgt in bs do
         Elab.Term.addTermInfo' tgt (mkFVar fvar)
+
+end Mathlib.Tactic

--- a/Mathlib/Tactic/RenameBVar.lean
+++ b/Mathlib/Tactic/RenameBVar.lean
@@ -49,3 +49,5 @@ elab "rename_bvar " old:ident " → " new:ident loc?:(location)? : tactic => do
       (fun fvarId ↦ renameBVarHyp mvarId fvarId old.getId new.getId)
       (renameBVarTarget mvarId old.getId new.getId)
       fun _ ↦ throwError "unexpected location syntax"
+
+end Mathlib.Tactic

--- a/Mathlib/Tactic/Replace.lean
+++ b/Mathlib/Tactic/Replace.lean
@@ -60,3 +60,5 @@ elab_rules : tactic
     match hId? with
     | some hId => replaceMainGoal [goal1, (← observing? <| goal2.clear hId).getD goal2]
     | none     => replaceMainGoal [goal1, goal2]
+
+end Mathlib.Tactic

--- a/Mathlib/Tactic/RewriteSearch.lean
+++ b/Mathlib/Tactic/RewriteSearch.lean
@@ -328,6 +328,4 @@ elab_rules : tactic |
 
 end RewriteSearch
 
-end Tactic
-
-end Mathlib
+end Mathlib.Tactic

--- a/Mathlib/Tactic/Rify.lean
+++ b/Mathlib/Tactic/Rify.lean
@@ -86,8 +86,4 @@ alias rat_cast_ne := ratCast_ne
 @[rify_simps] lemma ofNat_rat_real (a : ℕ) [a.AtLeastTwo] :
     ((no_index (OfNat.ofNat a : ℚ)) : ℝ) = (OfNat.ofNat a : ℝ) := rfl
 
-end Rify
-
-end Tactic
-
-end Mathlib
+end Mathlib.Tactic.Rify

--- a/Mathlib/Tactic/Ring/Basic.lean
+++ b/Mathlib/Tactic/Ring/Basic.lean
@@ -1219,6 +1219,4 @@ elab (name := ring1) "ring1" tk:"!"? : tactic => liftMetaMAtMain fun g ↦ do
 
 end Ring
 
-end Tactic
-
-end Mathlib
+end Mathlib.Tactic

--- a/Mathlib/Tactic/Ring/PNat.lean
+++ b/Mathlib/Tactic/Ring/PNat.lean
@@ -42,6 +42,4 @@ instance {n n' k} [h1 : CSLiftVal (n : ℕ+) n'] :
 
 end Ring
 
-end Tactic
-
-end Mathlib
+end Mathlib.Tactic

--- a/Mathlib/Tactic/Ring/RingNF.lean
+++ b/Mathlib/Tactic/Ring/RingNF.lean
@@ -275,6 +275,4 @@ macro (name := ringConv) "ring" : conv =>
 
 end RingNF
 
-end Tactic
-
-end Mathlib
+end Mathlib.Tactic

--- a/Mathlib/Tactic/Sat/FromLRAT.lean
+++ b/Mathlib/Tactic/Sat/FromLRAT.lean
@@ -669,3 +669,7 @@ elab "from_lrat " cnf:term:max ppSpace lrat:term:max : term => do
 example : ∀ (a b : Prop), (¬a ∧ ¬b ∨ a ∧ ¬b) ∨ ¬a ∧ b ∨ a ∧ b := from_lrat
   "p cnf 2 4  1 2 0  -1 2 0  1 -2 0  -1 -2 0"
   "5 -2 0 4 3 0  5 d 3 4 0  6 1 0 5 1 0  6 d 1 0  7 0 5 2 6 0"
+
+end Sat
+
+end Mathlib.Tactic

--- a/Mathlib/Tactic/Says.lean
+++ b/Mathlib/Tactic/Says.lean
@@ -134,3 +134,7 @@ elab_rules : tactic
     evalTactic result
 
 initialize Batteries.Linter.UnreachableTactic.addIgnoreTacticKind `Mathlib.Tactic.Says.says
+
+end Says
+
+end Mathlib.Tactic

--- a/Mathlib/Tactic/ScopedNS.lean
+++ b/Mathlib/Tactic/ScopedNS.lean
@@ -53,3 +53,5 @@ macro_rules
   | `(scoped[$ns] attribute [$[$attr:attr],*] $ids*) =>
     `(with_weak_namespace $(mkIdentFrom ns <| rootNamespace ++ ns.getId)
       attribute [$[scoped $attr:attr],*] $ids*)
+
+end Mathlib.Tactic

--- a/Mathlib/Tactic/Set.lean
+++ b/Mathlib/Tactic/Set.lean
@@ -75,3 +75,5 @@ elab_rules : tactic
       evalTactic (← `(tactic| have%$tk
         $h : ($(← Term.exprToSyntax vale) : $(← Term.exprToSyntax ty)) = $a := rfl))
     | _, _ => pure ()
+
+end Mathlib.Tactic

--- a/Mathlib/Tactic/SimpIntro.lean
+++ b/Mathlib/Tactic/SimpIntro.lean
@@ -74,3 +74,5 @@ elab "simp_intro" cfg:(config)? disch:(discharger)?
     g.withContext do
       let g? ← simpIntroCore g ctx (simprocs := simprocs) discharge? more.isSome ids.toList
       replaceMainGoal <| if let some g := g? then [g] else []
+
+end Mathlib.Tactic

--- a/Mathlib/Tactic/SimpRw.lean
+++ b/Mathlib/Tactic/SimpRw.lean
@@ -78,3 +78,5 @@ elab s:"simp_rw " cfg:(config)? rws:rwRuleSeq g:(location)? : tactic => focus do
         `(tactic| simp%$e $[$cfg]? only [← $e:term] $g ?)
       else
         `(tactic| simp%$e $[$cfg]? only [$e:term] $g ?))
+
+end Mathlib.Tactic

--- a/Mathlib/Tactic/SplitIfs.lean
+++ b/Mathlib/Tactic/SplitIfs.lean
@@ -154,3 +154,5 @@ elab_rules : tactic
     splitIfsCore loc names []
     for name in ← names.get do
       logWarningAt name m!"unused name: {name}"
+
+end Mathlib.Tactic

--- a/Mathlib/Tactic/Substs.lean
+++ b/Mathlib/Tactic/Substs.lean
@@ -22,3 +22,7 @@ syntax (name := substs) "substs" (colGt ppSpace ident)* : tactic
 
 macro_rules
 | `(tactic| substs $xs:ident*) => `(tactic| ($[subst $xs]*))
+
+end Substs
+
+end Mathlib.Tactic

--- a/Mathlib/Tactic/SuccessIfFailWithMsg.lean
+++ b/Mathlib/Tactic/SuccessIfFailWithMsg.lean
@@ -52,3 +52,5 @@ elab_rules : tactic
   Term.withoutErrToSorry <| withoutRecover do
     let msg ← unsafe Term.evalTerm String (.const ``String []) msg
     successIfFailWithMessage msg (evalTacticSeq tacs) tacs
+
+end Mathlib.Tactic

--- a/Mathlib/Tactic/SwapVar.lean
+++ b/Mathlib/Tactic/SwapVar.lean
@@ -46,3 +46,5 @@ elab "swap_var " swapRules:(colGt swapRule),+ : tactic => do
       return lctx.setUserName fvarId₁ n₂ |>.setUserName fvarId₂ n₁
   let mdecl := { mdecl with lctx := lctx }
   modifyMCtx fun mctx ↦ { mctx with decls := mctx.decls.insert mvarId mdecl }
+
+end Mathlib.Tactic

--- a/Mathlib/Tactic/TFAE.lean
+++ b/Mathlib/Tactic/TFAE.lean
@@ -236,3 +236,7 @@ elab_rules : tactic
           let q2 ← AtomM.addAtom ty.bindingBody!
           hyps := hyps.push (q1, q2, hyp)
       proveTFAE hyps (← get).atoms is tfaeListQ
+
+end TFAE
+
+end Mathlib.Tactic

--- a/Mathlib/Tactic/Tauto.lean
+++ b/Mathlib/Tactic/Tauto.lean
@@ -220,3 +220,5 @@ syntax (name := tauto) "tauto" (config)? : tactic
 elab_rules : tactic | `(tactic| tauto $[$cfg:config]?) => do
   let _cfg ← elabConfig (mkOptionalNode cfg)
   tautology
+
+end Mathlib.Tactic.Tauto

--- a/Mathlib/Tactic/TermCongr.lean
+++ b/Mathlib/Tactic/TermCongr.lean
@@ -638,3 +638,7 @@ def elabTermCongr : Term.TermElab := fun stx expectedType? => do
     let ty ← mkEq res.lhs res.rhs
     mkExpectedTypeHint pf ty
   | _ => throwUnsupportedSyntax
+
+end TermCongr
+
+end Mathlib.Tactic

--- a/Mathlib/Tactic/TryThis.lean
+++ b/Mathlib/Tactic/TryThis.lean
@@ -26,3 +26,5 @@ elab tk:"try_this" tac:tactic : tactic => do
 elab tk:"try_this" tac:conv : conv => do
   Elab.Tactic.evalTactic tac
   Meta.Tactic.TryThis.addSuggestion tk tac (origSpan? := ← getRef)
+
+end Mathlib.Tactic

--- a/Mathlib/Tactic/Use.lean
+++ b/Mathlib/Tactic/Use.lean
@@ -202,3 +202,5 @@ elab (name := useSyntax)
 @[inherit_doc useSyntax]
 elab "use!" discharger?:(Parser.Tactic.discharger)? ppSpace args:term,+ : tactic => do
   runUse true (← mkUseDischarger discharger?) args.getElems.toList
+
+end Mathlib.Tactic

--- a/Mathlib/Tactic/Variable.lean
+++ b/Mathlib/Tactic/Variable.lean
@@ -308,3 +308,9 @@ where
 def ignorevariable? : Lean.Linter.IgnoreFunction := fun _ stack _ =>
   stack.matches [`null, none, `null, ``Mathlib.Command.Variable.variable?]
   || stack.matches [`null, none, `null, `null, ``Mathlib.Command.Variable.variable?]
+
+end Variable
+
+end Command
+
+end Mathlib

--- a/Mathlib/Tactic/WLOG.lean
+++ b/Mathlib/Tactic/WLOG.lean
@@ -138,3 +138,5 @@ elab_rules : tactic
   let goal ← getMainGoal
   let { reductionGoal, hypothesisGoal .. } ← goal.wlog h P xs H
   replaceMainGoal [reductionGoal, hypothesisGoal]
+
+end Mathlib.Tactic

--- a/Mathlib/Tactic/Widget/Calc.lean
+++ b/Mathlib/Tactic/Widget/Calc.lean
@@ -143,8 +143,4 @@ elab_rules : tactic
     isFirst := false
   evalCalc (← `(tactic|calc%$calcstx $stx))
 
-end Tactic
-
-end Elab
-
-end Lean
+end Lean.Elab.Tactic

--- a/Mathlib/Tactic/Widget/Calc.lean
+++ b/Mathlib/Tactic/Widget/Calc.lean
@@ -142,3 +142,9 @@ elab_rules : tactic
     Widget.savePanelWidgetInfo CalcPanel.javascriptHash (pure json) proofTerm
     isFirst := false
   evalCalc (← `(tactic|calc%$calcstx $stx))
+
+end Tactic
+
+end Elab
+
+end Lean

--- a/Mathlib/Tactic/Widget/CommDiag.lean
+++ b/Mathlib/Tactic/Widget/CommDiag.lean
@@ -137,6 +137,4 @@ def commutativeSquarePresenter : ExprPresenter where
 
 end Widget
 
-end Tactic
-
-end Mathlib
+end Mathlib.Tactic

--- a/Mathlib/Tactic/Widget/InteractiveUnfold.lean
+++ b/Mathlib/Tactic/Widget/InteractiveUnfold.lean
@@ -242,3 +242,7 @@ def elabUnfoldCommand : Command.CommandElab := fun stx =>
       let unfolds := unfolds.toList.map (m! "· {·}")
       logInfo (m! "Unfolds for {e}:\n"
         ++ .joinSep unfolds "\n")
+
+end InteractiveUnfold
+
+end Mathlib.Tactic

--- a/Mathlib/Tactic/Zify.lean
+++ b/Mathlib/Tactic/Zify.lean
@@ -117,3 +117,7 @@ variable {R : Type*} [AddGroupWithOne R]
 
 @[norm_cast] theorem Nat.cast_sub_of_lt {m n} (h : m < n) :
     ((n - m : ℕ) : R) = n - m := Nat.cast_sub h.le
+
+end Zify
+
+end Mathlib.Tactic

--- a/Mathlib/Util/AddRelatedDecl.lean
+++ b/Mathlib/Util/AddRelatedDecl.lean
@@ -74,3 +74,5 @@ def addRelatedDecl (src : Name) (suffix : String) (ref : Syntax)
     let attrs ← elabAttrs attrs
     Term.applyAttributes src attrs
     Term.applyAttributes tgt attrs
+
+end Mathlib.Tactic

--- a/Mathlib/Util/AssertExists.lean
+++ b/Mathlib/Util/AssertExists.lean
@@ -80,3 +80,5 @@ elab "assert_not_imported " ids:ident+ : command => do
   let mods := (← getEnv).allImportedModuleNames
   for id in ids do
     if mods.contains id.getId then logWarningAt id m!"the module '{id}' is (transitively) imported"
+
+end

--- a/Mathlib/Util/AtomM.lean
+++ b/Mathlib/Util/AtomM.lean
@@ -47,3 +47,5 @@ def AtomM.addAtom (e : Expr) : AtomM Nat := do
     if ← withTransparency (← read).red <| isDefEq e c.atoms[i] then
       return i
   modifyGet fun c ↦ (c.atoms.size, { c with atoms := c.atoms.push e })
+
+end Mathlib.Tactic

--- a/Mathlib/Util/CountHeartbeats.lean
+++ b/Mathlib/Util/CountHeartbeats.lean
@@ -147,3 +147,7 @@ elab "count_heartbeats! " n:(num)? "in" ppLine cmd:command : command => do
   -- Then run once more, keeping the state.
   let counts := (← elabForHeartbeats cmd (revert := false)) :: counts
   logVariation counts
+
+end CountHeartbeats
+
+end Mathlib

--- a/Mathlib/Util/IncludeStr.lean
+++ b/Mathlib/Util/IncludeStr.lean
@@ -19,3 +19,5 @@ elab (name := includeStr) "include_str " str:str : term => do
   let some srcDir := srcPath.parent | throwError "{srcPath} not in a valid directory"
   let path := srcDir / str
   Lean.mkStrLit <$> IO.FS.readFile path
+
+end Mathlib.Util

--- a/Mathlib/Util/Notation3.lean
+++ b/Mathlib/Util/Notation3.lean
@@ -620,3 +620,7 @@ macro_rules
   | `($[$doc]? $(attr)? scoped[$ns] notation3 $(prec)? $(n)? $(prio)? $(pp)? $items* => $t) =>
     `(with_weak_namespace $(mkIdentFrom ns <| rootNamespace ++ ns.getId)
       $[$doc]? $(attr)? scoped notation3 $(prec)? $(n)? $(prio)? $(pp)? $items* => $t)
+
+end Notation3
+
+end Mathlib

--- a/Mathlib/Util/Superscript.lean
+++ b/Mathlib/Util/Superscript.lean
@@ -281,3 +281,5 @@ initialize
   registerAlias `subscript ``subscript subscript
   registerAliasCore Formatter.formatterAliasesRef `subscript subscript.formatter
   registerAliasCore Parenthesizer.parenthesizerAliasesRef `subscript subscript.parenthesizer
+
+end Mathlib.Tactic

--- a/Mathlib/Util/Tactic.lean
+++ b/Mathlib/Util/Tactic.lean
@@ -72,3 +72,5 @@ exist in the local context of `mvarId`, nothing happens.
 def modifyLocalDecl [MonadMCtx m] (mvarId : MVarId) (fvarId : FVarId)
     (f : LocalDecl → LocalDecl) : m Unit :=
   modifyLocalContext mvarId fun lctx ↦ lctx.modifyLocalDecl fvarId f
+
+end Mathlib.Tactic

--- a/Mathlib/Util/TermBeta.lean
+++ b/Mathlib/Util/TermBeta.lean
@@ -37,3 +37,5 @@ def elabBeta : TermElab := fun stx expectedType? =>
     let e ← elabTerm t expectedType?
     return (← instantiateMVars e).headBeta
   | _ => throwUnsupportedSyntax
+
+end Mathlib.Util.TermBeta

--- a/Mathlib/Util/WhatsNew.lean
+++ b/Mathlib/Util/WhatsNew.lean
@@ -118,6 +118,4 @@ elab "whatsnew " "in" ppLine cmd:command : command => do
     let newEnv ← getEnv
     logInfo (← liftCoreM <| whatsNew oldEnv newEnv)
 
-end WhatsNew
-
-end Mathlib
+end Mathlib.WhatsNew

--- a/Mathlib/Util/WhatsNew.lean
+++ b/Mathlib/Util/WhatsNew.lean
@@ -117,3 +117,7 @@ elab "whatsnew " "in" ppLine cmd:command : command => do
   finally
     let newEnv ← getEnv
     logInfo (← liftCoreM <| whatsNew oldEnv newEnv)
+
+end WhatsNew
+
+end Mathlib

--- a/Mathlib/Util/WithWeakNamespace.lean
+++ b/Mathlib/Util/WithWeakNamespace.lean
@@ -38,3 +38,5 @@ def withWeakNamespace {α : Type} (ns : Name) (m : CommandElabM α) : CommandEla
 /-- Changes the current namespace without causing scoped things to go out of scope -/
 elab "with_weak_namespace " ns:ident cmd:command : command =>
   withWeakNamespace ns.getId (elabCommand cmd)
+
+end Lean.Elab.Command


### PR DESCRIPTION
Fix mathlib for running the missingEnd linter everywhere. Prerequiste to #15845.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
