### PR TITLE
chore: fix remaining linters in mathlib and tests

### DIFF
--- a/Mathlib/Data/Option/Basic.lean
+++ b/Mathlib/Data/Option/Basic.lean
@@ -355,7 +355,6 @@ theorem elim_apply {f : γ → α → β} {x : α → β} {i : Option γ} {y : �
 
 @[simp]
 lemma bnot_isSome (a : Option α) : (! a.isSome) = a.isNone := by
-  funext
   cases a <;> simp
 
 @[simp]
@@ -365,7 +364,6 @@ lemma bnot_comp_isSome : (! ·) ∘ @Option.isSome α = Option.isNone := by
 
 @[simp]
 lemma bnot_isNone (a : Option α) : (! a.isNone) = a.isSome := by
-  funext
   cases a <;> simp
 
 @[simp]

--- a/Mathlib/Tactic/Convert.lean
+++ b/Mathlib/Tactic/Convert.lean
@@ -46,7 +46,8 @@ def Lean.MVarId.convertLocalDecl (g : MVarId) (fvarId : FVarId) (typeNew : Expr)
     (patterns : List (TSyntax `rcasesPat) := []) :
     MetaM (MVarId × List MVarId) := g.withContext do
   let typeOld ← fvarId.getType
-  let v ← mkFreshExprMVar (← mkAppM ``Eq (if symm then #[typeNew, typeOld] else #[typeOld, typeNew]))
+  let v ← mkFreshExprMVar (← mkAppM ``Eq
+    (if symm then #[typeNew, typeOld] else #[typeOld, typeNew]))
   let pf ← if symm then mkEqSymm v else pure v
   let res ← g.replaceLocalDecl fvarId typeNew pf
   let gs ← v.mvarId!.congrN! depth config patterns

--- a/Mathlib/Tactic/FunProp/Core.lean
+++ b/Mathlib/Tactic/FunProp/Core.lean
@@ -39,7 +39,8 @@ sythesized value{indentExpr val}\nis not definitionally equal to{indentExpr x}"
     return false
 
 
-/-- Synthesize arguments `xs` either with typeclass synthesis, with `fun_prop` or with discharger. -/
+/-- Synthesize arguments `xs` either with typeclass synthesis,
+with `fun_prop` or with a discharger. -/
 def synthesizeArgs (thmId : Origin) (xs : Array Expr) (bis : Array BinderInfo)
     (funProp : Expr → FunPropM (Option Result)) :
     FunPropM Bool := do

--- a/Mathlib/Tactic/FunProp/Types.lean
+++ b/Mathlib/Tactic/FunProp/Types.lean
@@ -152,8 +152,8 @@ Messages are logged only when `transitionDepth = 0` i.e. when `fun_prop` is **no
 function property like continuity from another property like differentiability.
 The main reason is that if the user forgets to add a continuity theorem for function `foo` then
 `fun_prop` should report that there is a continuity theorem for `foo` missing. If we would log
-messages `transitionDepth > 0` then user will see messages saying that there is a missing theorem for
-differentiability, smoothness, ... for `foo`.  -/
+messages `transitionDepth > 0` then user will see messages saying that there is a missing theorem
+for differentiability, smoothness, ... for `foo`.  -/
 def logError (msg : String) : FunPropM Unit := do
   if (← read).transitionDepth = 0 then
     modify fun s =>

--- a/Mathlib/Tactic/Linter/TextBased.lean
+++ b/Mathlib/Tactic/Linter/TextBased.lean
@@ -410,7 +410,8 @@ def lintFile (path : FilePath) (sizeLimit : Option ℕ) (exceptions : Array Erro
   let allOutput := (Array.map (fun lint ↦
     (Array.map (fun (e, n) ↦ ErrorContext.mk e n path)) (lint lines))) allLinters
   -- This this list is not sorted: for github, this is fine.
-  errors := errors.append (allOutput.flatten.filter (fun e ↦ (e.find?_comparable exceptions).isNone))
+  errors := errors.append
+    (allOutput.flatten.filter (fun e ↦ (e.find?_comparable exceptions).isNone))
   return errors
 
 /-- Lint a collection of modules for style violations.

--- a/Mathlib/Util/SleepHeartbeats.lean
+++ b/Mathlib/Util/SleepHeartbeats.lean
@@ -34,7 +34,6 @@ elab "sleep_heartbeats " n:num : tactic => do
      option -/
   | some m => sleepAtLeastHeartbeats (m * 1000)
 
-set_option linter.unusedTactic false in
 example : 1 = 1 := by
   sleep_heartbeats 1000
   rfl

--- a/Mathlib/Util/SleepHeartbeats.lean
+++ b/Mathlib/Util/SleepHeartbeats.lean
@@ -34,6 +34,7 @@ elab "sleep_heartbeats " n:num : tactic => do
      option -/
   | some m => sleepAtLeastHeartbeats (m * 1000)
 
+set_option linter.unusedTactic false in
 example : 1 = 1 := by
   sleep_heartbeats 1000
   rfl

--- a/test/Change.lean
+++ b/test/Change.lean
@@ -1,5 +1,6 @@
 import Mathlib.Tactic.Change
 
+set_option linter.setOption false
 set_option pp.unicode.fun true
 set_option autoImplicit true
 

--- a/test/Check.lean
+++ b/test/Check.lean
@@ -6,6 +6,8 @@ open Lean PrettyPrinter Delaborator in @[delab mvar] def delabMVar : Delab := do
   unless kind.isNatural do failure
   `(?m)
 
+set_option linter.unusedTactic false
+
 /-!
 Basic check of `#check`
 -/

--- a/test/Clean.lean
+++ b/test/Clean.lean
@@ -51,3 +51,5 @@ example : True := by
   guard_hyp z :ₛ Nat := let_fun x := 1; x + x
 
   trivial
+
+end Tests

--- a/test/Clear!.lean
+++ b/test/Clear!.lean
@@ -13,7 +13,8 @@ example [delete_this : Inhabited Nat] : Inhabited Nat := by
   infer_instance
 
 -- Confirms clear! can clear the dependencies of multiple hypotheses
-example (delete_this : Nat) (delete_this2 : Nat) (_delete_this_dep : delete_this = delete_this2) : Nat := by
+example (delete_this : Nat) (delete_this2 : Nat) (_delete_this_dep : delete_this = delete_this2) :
+    Nat := by
   clear! delete_this delete_this2
   fail_if_success assumption
   exact 0

--- a/test/ClearExcept.lean
+++ b/test/ClearExcept.lean
@@ -1,5 +1,7 @@
 import Mathlib.Tactic.ClearExcept
 
+set_option linter.unusedTactic false
+
 -- Most basic test
 example (_delete_this : Nat) (dont_delete_this : Int) : Nat := by
   clear * - dont_delete_this
@@ -12,13 +14,16 @@ example [dont_delete_this : Inhabited Nat] (dont_delete_this2 : Prop) : Inhabite
   assumption
 
 -- Confirms that clearExcept can clear hypotheses even when they have dependencies
-example (delete_this : Nat) (_delete_this2 : delete_this = delete_this) (dont_delete_this : Int) : Nat := by
+example (delete_this : Nat) (_delete_this2 : delete_this = delete_this) (dont_delete_this : Int) :
+    Nat := by
   clear * - dont_delete_this
   fail_if_success assumption
   exact dont_delete_this.toNat
 
--- Confirms that clearExcept does not clear hypotheses when they have dependencies that should not be cleared
-example (dont_delete_this : Nat) (dont_delete_this2 : dont_delete_this = dont_delete_this) : Nat := by
+-- Confirms that clearExcept does not clear hypotheses
+-- when they have dependencies that should not be cleared
+example (dont_delete_this : Nat) (dont_delete_this2 : dont_delete_this = dont_delete_this) :
+    Nat := by
   clear * - dont_delete_this2
   exact dont_delete_this
 

--- a/test/Clear_.lean
+++ b/test/Clear_.lean
@@ -1,6 +1,8 @@
 import Mathlib.Tactic.Clear_
 import Mathlib.Tactic.Replace
 
+set_option linter.unusedTactic false
+
 -- Most basic test
 example (_delete_this : Nat) : Nat := by
   clear_
@@ -19,14 +21,16 @@ example (_delete_this : Nat) (dont_delete_this : Int) : Nat := by
   exact dont_delete_this.toNat
 
 -- Confirms that clear_ can clear hypotheses even when they have dependencies
-example (_delete_this : Type) (_delete_this_dep : _delete_this) (_delete_this_rw : _delete_this = Nat)
-  (_delete_this_dep_dep : _delete_this_dep = _delete_this_dep) : Nat := by
+example (_delete_this : Type) (_delete_this_dep : _delete_this)
+    (_delete_this_rw : _delete_this = Nat)
+    (_delete_this_dep_dep : _delete_this_dep = _delete_this_dep) : Nat := by
   clear_
   fail_if_success
     rw [← _delete_this_rw]
   exact 0
 
--- Confirms that clear_ does not clear hypotheses when they have dependencies that should not be cleared
+-- Confirms that clear_ does not clear hypotheses
+-- when they have dependencies that should not be cleared
 example (_dont_delete_this : Type) (dep : _dont_delete_this) : _dont_delete_this := by
   clear_
   assumption

--- a/test/DefEqTransformations.lean
+++ b/test/DefEqTransformations.lean
@@ -6,6 +6,8 @@ set_option autoImplicit true
 private axiom test_sorry : ∀ {α}, α
 namespace Tests
 
+set_option linter.unusedTactic false
+
 example : id (1 = 1) := by
   with_reducible whnf
   guard_target =ₛ id (1 = 1)
@@ -182,3 +184,5 @@ example (n : Fin 5) : n = ⟨n.val2, n.prop2⟩ := by
   eta_struct
   guard_target =ₛ n = n
   rfl
+
+end Tests

--- a/test/DeriveToExpr.lean
+++ b/test/DeriveToExpr.lean
@@ -57,6 +57,7 @@ instance {α : Type u} [ToExpr α] [ToLevel.{u+1}] : ToExpr (Bool → α) where
 
 deriving instance ToExpr for Bar
 
+set_option linter.unusedTactic false in
 example : True := by
   run_tac do
     let f : Bool → Nat | false => 0 | true => 1

--- a/test/ExtractGoal.lean
+++ b/test/ExtractGoal.lean
@@ -3,6 +3,7 @@ import Mathlib.Init.Data.Nat.Lemmas
 import Mathlib.Order.Basic
 import Mathlib.Data.Nat.Defs
 
+set_option linter.setOption false
 set_option pp.unicode.fun true
 set_option autoImplicit true
 set_option linter.unusedVariables false

--- a/test/ExtractLets.lean
+++ b/test/ExtractLets.lean
@@ -32,7 +32,6 @@ example (h : let x := 1; let y := 2; x + 1 = y) : True := by
 
 example (h : let x := 1; let y := 2; x + 1 = y) : True := by
   extract_lets x at h
-  intros
   guard_hyp x : Nat := 1
   guard_hyp h :ₛ let y := 2; x + 1 = y
   trivial

--- a/test/GuardGoalNums.lean
+++ b/test/GuardGoalNums.lean
@@ -1,5 +1,7 @@
 import Mathlib.Tactic.GuardGoalNums
 
+set_option linter.unusedTactic false
+
 example : true ∧ true := by
   constructor
   guard_goal_nums 2

--- a/test/GuardHypNums.lean
+++ b/test/GuardHypNums.lean
@@ -1,5 +1,7 @@
 import Mathlib.Tactic.GuardHypNums
 
+set_option linter.unusedTactic false
+
 example (a b c : Nat) (_ : a = b) (_ : c = 3) : true := by
   guard_hyp_nums 6
   trivial

--- a/test/HashCommandLinter.lean
+++ b/test/HashCommandLinter.lean
@@ -47,6 +47,7 @@ note: this linter can be disabled with `set_option linter.hashCommand false`
 #guard_msgs in
 #guard true
 
+set_option linter.unusedTactic false in
 /--
 warning: `#`-commands, such as '#check_tactic', are not allowed in 'Mathlib'
 note: this linter can be disabled with `set_option linter.hashCommand false`

--- a/test/InferParam.lean
+++ b/test/InferParam.lean
@@ -19,3 +19,5 @@ example : 0 ≤ 2 + 2 := by
 example : 0 ≤ 2 + 2 := by
   apply zero_le_add'
   infer_param
+
+end InferParamTest

--- a/test/Lint.lean
+++ b/test/Lint.lean
@@ -59,6 +59,7 @@ export Nat (add)
 end add
 
 set_option linter.cdot false in
+set_option linter.globalAttributeIn false in
 /--
 warning: Please, use '·' (typed as `\.`) instead of '.' as 'cdot'.
 note: this linter can be disabled with `set_option linter.cdot false`

--- a/test/MfldSetTac.lean
+++ b/test/MfldSetTac.lean
@@ -24,7 +24,8 @@ section stub_lemmas
 structure PartialHomeomorph (α : Type u) (β : Type u) extends PartialEquiv α β
 
 noncomputable
-instance PartialHomeomorph.has_coe_to_fun : CoeFun (PartialHomeomorph α β) (fun _ ↦ α → β) := test_sorry
+instance PartialHomeomorph.has_coe_to_fun : CoeFun (PartialHomeomorph α β) (fun _ ↦ α → β) :=
+  test_sorry
 
 noncomputable
 def PartialHomeomorph.symm (_e : PartialHomeomorph α β) : PartialHomeomorph β α := test_sorry
@@ -55,7 +56,8 @@ noncomputable
 def ModelWithCorners.symm (_I : ModelWithCorners 𝕜 E H) : PartialEquiv E H := test_sorry
 
 noncomputable
-instance ModelWithCorners.has_coe_to_fun : CoeFun (ModelWithCorners 𝕜 E H) (fun _ ↦ H → E) := test_sorry
+instance ModelWithCorners.has_coe_to_fun : CoeFun (ModelWithCorners 𝕜 E H) (fun _ ↦ H → E) :=
+  test_sorry
 
 @[mfld_simps] lemma ModelWithCorners.left_inv (I : ModelWithCorners 𝕜 E H) (x : H) :
   I.symm (I x) = x :=

--- a/test/MinImports.lean
+++ b/test/MinImports.lean
@@ -94,7 +94,7 @@ set_option linter.minImports false in
 
 /--
 warning: Imports increased to
-[Init.Guard, Lean.Parser.Term, Mathlib.Data.Int.Notation]
+[Init.Guard, Mathlib.Data.Int.Notation]
 note: this linter can be disabled with `set_option linter.minImports false`
 -/
 #guard_msgs in

--- a/test/MinImports.lean
+++ b/test/MinImports.lean
@@ -37,8 +37,7 @@ noncomputable instance : Semiring Nat := inferInstance
 /--
 info: ℤ : Type
 ---
-info: import Lean.Parser.Command
-import Mathlib.Data.Int.Notation
+info: import Mathlib.Data.Int.Notation
 -/
 #guard_msgs in
 #min_imports in #check ℤ
@@ -78,7 +77,7 @@ lemma hi (n : ℕ) : n = n := by extract_goal; rfl
 
 /--
 warning: Imports increased to
-[Init.Guard, Lean.Parser.Term, Mathlib.Data.Int.Notation]
+[Init.Guard, Mathlib.Data.Int.Notation]
 note: this linter can be disabled with `set_option linter.minImports false`
 -/
 #guard_msgs in

--- a/test/SimpRw.lean
+++ b/test/SimpRw.lean
@@ -34,6 +34,7 @@ example {a : Nat}
   (∀ b, a - 1 ≤ b) = ∀ b c : Nat, c < a → c < b + 1 := by
   simp_rw [h1, h2]
 
+set_option linter.unusedTactic false in
 -- `simp_rw` respects config options
 example : 1 = 2 := by
   let a := 2

--- a/test/SplitIfs.lean
+++ b/test/SplitIfs.lean
@@ -73,6 +73,7 @@ example (P Q : Prop) (w : if P then (if Q then true else true) else true = true)
   · trivial
   · trivial
 
+set_option linter.unusedTactic false in
 example (u : Nat) : (if u = u then 0 else 1) = 0 := by
   have h : u = u := by rfl
   split_ifs

--- a/test/TermBeta.lean
+++ b/test/TermBeta.lean
@@ -1,5 +1,6 @@
 import Mathlib.Util.TermBeta
 -- On command line, tests format functions with => rather than ↦ without this.
+set_option linter.setOption false
 set_option pp.unicode.fun true
 
 /-- info: (fun x ↦ x) true : Bool -/

--- a/test/TermCongr.lean
+++ b/test/TermCongr.lean
@@ -160,3 +160,5 @@ example {s t : α → Prop} (h : s = t) (p : α → Prop) :
   congr(∀ (n : Subtype $h), p n)
 
 end limitations
+
+end Tests

--- a/test/TypeCheck.lean
+++ b/test/TypeCheck.lean
@@ -1,5 +1,7 @@
 import Mathlib.Tactic.TypeCheck
 
+set_option linter.unusedTactic false
+
 /-- A term where `inferType` returns `Prop`, but which does not type check. -/
 elab "wrong" : term =>
   return Lean.mkApp2 (.const ``id [.zero]) (.sort .zero) (.app (.sort .zero) (.sort .zero))

--- a/test/UnsetOption.lean
+++ b/test/UnsetOption.lean
@@ -1,5 +1,7 @@
 import Mathlib.Tactic.UnsetOption
 
+set_option linter.setOption false
+set_option linter.unusedTactic false
 set_option pp.all true
 
 example : True := by

--- a/test/Use.lean
+++ b/test/Use.lean
@@ -205,8 +205,8 @@ example (α : Type u) : Embedding α α × Unit := by
 -- Note(kmill): mathlib3 `use` would try to rewrite any lingering existentials with
 -- `exists_prop` to turn them into conjunctions. It did not do this recursively.
 
--- example : ∃ (n : Nat) (h : n > 0), n = n :=
--- by
+set_option linter.longLine false in
+-- example : ∃ (n : Nat) (h : n > 0), n = n := by
 --   use 1
 --   -- goal should now be `1 > 0 ∧ 1 = 1`, whereas it would be `∃ (H : 1 > 0), 1 = 1` after existsi 1.
 --   guard_target = 1 > 0 ∧ 1 = 1
@@ -227,3 +227,5 @@ example (h1 : 1 > 0) : ∃ (n : Nat) (_h : n > 0), n = n := by
 example : let P : Nat → Prop := fun _x => ∃ _n : Nat, True; P 1 := by
   intro P
   use 1
+
+end UseTests

--- a/test/basicTactics.lean
+++ b/test/basicTactics.lean
@@ -5,6 +5,7 @@ example : ∀ a b : Nat, a = b → b = a := by
   introv h
   exact h.symm
 
+set_option linter.unusedTactic false in
 example (n : Nat) : n = n := by
   induction n
   exacts [rfl, rfl]
@@ -45,6 +46,7 @@ example (n m : Nat) : Unit := by
   cases m
   iterate exact ()
 
+set_option linter.unusedTactic false in
 example (n : Nat) : Nat := by
   iterate exact () -- silently succeeds, after iterating 0 times
   iterate exact n

--- a/test/casesm.lean
+++ b/test/casesm.lean
@@ -2,6 +2,7 @@ import Mathlib.Tactic.CasesM
 
 set_option autoImplicit true
 
+set_option linter.unusedTactic false in
 example (h : a ∧ b ∨ c ∧ d) (h2 : e ∧ f) : True := by
   casesm* _∨_, _∧_
   · clear ‹a› ‹b› ‹e› ‹f›; (fail_if_success clear ‹c›); trivial

--- a/test/convert.lean
+++ b/test/convert.lean
@@ -110,6 +110,7 @@ example : True := by
 -- Prior to https://github.com/leanprover/lean4/pull/4493 it did,
 -- because previously bodies of `example`s were (confusingly!) allowed to
 -- affect the elaboration of the signature!
+set_option linter.unusedTactic false in
 example {α β : Type u} [Fintype α] [Fintype β] : Fintype.card α = Fintype.card β := by
   congr!
   guard_target = Fintype.card α = Fintype.card β
@@ -125,3 +126,5 @@ example (x y z : Nat) (h : x + y = z) : y + x = z := by
   convert_to y + x = _ at h
   · rw [Nat.add_comm]
   exact h
+
+end Tests

--- a/test/fail_if_no_progress.lean
+++ b/test/fail_if_no_progress.lean
@@ -2,6 +2,7 @@ import Mathlib.Tactic.FailIfNoProgress
 import Mathlib.Tactic.Basic
 
 set_option linter.unusedVariables false
+set_option linter.setOption false
 set_option pp.unicode.fun true
 
 section success

--- a/test/fun_prop_dev.lean
+++ b/test/fun_prop_dev.lean
@@ -13,6 +13,8 @@ This file is designed for development of fun_prop and does not depend on most of
 two function properties `Con` and `Lin` which roughly correspond to `Continuity` and `IsLinearMap`.
 -/
 
+set_option linter.longLine false
+
 open Function
 
 variable {α β γ δ ι : Type _} {E : α → Type _}

--- a/test/itauto.lean
+++ b/test/itauto.lean
@@ -55,6 +55,7 @@ example (b : Bool) : ¬b ∨ b := by itauto *
 example (p : Prop) : ¬p ∨ p := by itauto! [p]
 example (p : Prop) : ¬p ∨ p := by itauto! *
 
+set_option linter.unusedTactic false in
 -- failure tests
 example (p q r : Prop) : True := by
   haveI : p ∨ ¬p := by (fail_if_success itauto); sorry

--- a/test/meta.lean
+++ b/test/meta.lean
@@ -11,6 +11,7 @@ namespace Tests
 open Lean Meta
 
 private axiom test_sorry : ∀ {α}, α
+set_option linter.setOption false in
 set_option pp.unicode.fun true
 
 def eTrue := Expr.const ``True []
@@ -58,6 +59,8 @@ elab "test_forallNot_of_notExists" t:term : tactic => do
   let (ety', e') ← Expr.forallNot_of_notExists ety' e
   unless ← isDefEq ety' (← inferType e') do throwError "bad proof"
   logInfo m!"{ety'}"
+
+set_option linter.unusedTactic false
 
 /-- info: ∀ (x : Nat), ¬0 < x -/
 #guard_msgs in

--- a/test/notation3.lean
+++ b/test/notation3.lean
@@ -2,6 +2,7 @@ import Mathlib.Util.Notation3
 import Mathlib.Init.Data.Nat.Lemmas
 import Mathlib.Data.Nat.Defs
 
+set_option linter.setOption false
 set_option pp.unicode.fun true
 set_option autoImplicit true
 
@@ -151,6 +152,7 @@ matcher from the expansion. (Use `set_option trace.notation3 true` to get some d
 end
 
 section
+set_option linter.unusedTactic false
 local notation3 (prettyPrint := false) "#" n => Fin.mk n (by decide)
 
 example : Fin 5 := #1
@@ -202,3 +204,5 @@ notation3 "δNat" => (default : Nat)
 #guard_msgs in #check (default : Nat)
 /-- info: δNat : ℕ -/
 #guard_msgs in #check @default Nat (Inhabited.mk 5)
+
+end Test

--- a/test/recover.lean
+++ b/test/recover.lean
@@ -1,5 +1,7 @@
 import Mathlib.Tactic.Recover
 
+set_option linter.unusedTactic false
+
 /-- problematic tactic for testing recovery -/
 elab "this" "is" "a" "problem" : tactic =>
   Lean.Elab.Tactic.setGoals []

--- a/test/says.lean
+++ b/test/says.lean
@@ -57,6 +57,7 @@ example (x y : List α) : (x ++ y).length = x.length + y.length := by
   simp? says simp only []
 
 set_option linter.unreachableTactic false
+set_option linter.unusedTactic false in
 -- Now we check that `says` does not consume following tactics unless they are indented.
 /--
 error: Tactic `simp` did not produce any messages.

--- a/test/symm.lean
+++ b/test/symm.lean
@@ -15,6 +15,7 @@ def sameParity : Nat → Nat → Prop
 
 example (a b : Nat) : sameParity a b → sameParity b a := by intros; symm; assumption
 
+set_option linter.unusedTactic false in
 example (a b c : Nat) (ab : a = b) (bc : b = c) : c = a := by
   symm_saturate
   -- Run twice to check that we don't add repeated copies.
@@ -43,7 +44,8 @@ infixl:25 " ≃* " => MulEquiv
 
 @[symm]
 def foo_symm {M N : Type _} [Mul M] [Mul N] (h : M ≃* N) : N ≃* M :=
-  { h.toEquiv.symm with map_mul' := (h.toMulHom.inverse h.toEquiv.symm h.left_inv h.right_inv).map_mul }
+  { h.toEquiv.symm with map_mul' :=
+    (h.toMulHom.inverse h.toEquiv.symm h.left_inv h.right_inv).map_mul }
 
 def MyEq (n m : Nat) := ∃ k, n + k = m ∧ m + k = n
 

--- a/test/trace.lean
+++ b/test/trace.lean
@@ -1,4 +1,7 @@
 import Mathlib.Tactic.Trace
+
+set_option linter.unusedTactic false
+
 /--
 info: 7
 -/

--- a/test/trans.lean
+++ b/test/trans.lean
@@ -90,6 +90,7 @@ example {A B C : Prop} (h : A → B) (g : B → C) : A → C := by
   · guard_target =ₛ B → C
     exact g
 
+set_option linter.unusedTactic false in
 /-- `trans` for arrows between types. -/
 example {A B C : Type} (h : A → B) (g : B → C) : A → C := by
   trans
@@ -99,6 +100,7 @@ example {A B C : Type} (h : A → B) (g : B → C) : A → C := by
 
 universe u v w
 
+set_option linter.unusedTactic false in
 /-- `trans` for arrows between types. -/
 example {A : Type u} {B : Type v} {C : Type w} (h : A → B) (g : B → C) : A → C := by
   trans


### PR DESCRIPTION
Remove two unused tactics; fix a few long lines, and make sure all tests disable the linters they want to ignore.

In at least one instance, this has to wait for #15845, as the respective linter is not available yet.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
