### PR TITLE
[Merged by Bors] - chore(tests): fix linter warnings

### DIFF
--- a/Mathlib/Data/Option/Basic.lean
+++ b/Mathlib/Data/Option/Basic.lean
@@ -355,7 +355,6 @@ theorem elim_apply {f : γ → α → β} {x : α → β} {i : Option γ} {y : �
 
 @[simp]
 lemma bnot_isSome (a : Option α) : (! a.isSome) = a.isNone := by
-  funext
   cases a <;> simp
 
 @[simp]
@@ -365,7 +364,6 @@ lemma bnot_comp_isSome : (! ·) ∘ @Option.isSome α = Option.isNone := by
 
 @[simp]
 lemma bnot_isNone (a : Option α) : (! a.isNone) = a.isSome := by
-  funext
   cases a <;> simp
 
 @[simp]

--- a/Mathlib/Tactic/Convert.lean
+++ b/Mathlib/Tactic/Convert.lean
@@ -46,7 +46,8 @@ def Lean.MVarId.convertLocalDecl (g : MVarId) (fvarId : FVarId) (typeNew : Expr)
     (patterns : List (TSyntax `rcasesPat) := []) :
     MetaM (MVarId × List MVarId) := g.withContext do
   let typeOld ← fvarId.getType
-  let v ← mkFreshExprMVar (← mkAppM ``Eq (if symm then #[typeNew, typeOld] else #[typeOld, typeNew]))
+  let v ← mkFreshExprMVar (← mkAppM ``Eq
+    (if symm then #[typeNew, typeOld] else #[typeOld, typeNew]))
   let pf ← if symm then mkEqSymm v else pure v
   let res ← g.replaceLocalDecl fvarId typeNew pf
   let gs ← v.mvarId!.congrN! depth config patterns

--- a/Mathlib/Tactic/FunProp/Core.lean
+++ b/Mathlib/Tactic/FunProp/Core.lean
@@ -39,7 +39,8 @@ sythesized value{indentExpr val}\nis not definitionally equal to{indentExpr x}"
     return false
 
 
-/-- Synthesize arguments `xs` either with typeclass synthesis, with `fun_prop` or with discharger. -/
+/-- Synthesize arguments `xs` either with typeclass synthesis,
+with `fun_prop` or with a discharger. -/
 def synthesizeArgs (thmId : Origin) (xs : Array Expr) (bis : Array BinderInfo)
     (funProp : Expr → FunPropM (Option Result)) :
     FunPropM Bool := do

--- a/Mathlib/Tactic/FunProp/Types.lean
+++ b/Mathlib/Tactic/FunProp/Types.lean
@@ -152,8 +152,8 @@ Messages are logged only when `transitionDepth = 0` i.e. when `fun_prop` is **no
 function property like continuity from another property like differentiability.
 The main reason is that if the user forgets to add a continuity theorem for function `foo` then
 `fun_prop` should report that there is a continuity theorem for `foo` missing. If we would log
-messages `transitionDepth > 0` then user will see messages saying that there is a missing theorem for
-differentiability, smoothness, ... for `foo`.  -/
+messages `transitionDepth > 0` then user will see messages saying that there is a missing theorem
+for differentiability, smoothness, ... for `foo`.  -/
 def logError (msg : String) : FunPropM Unit := do
   if (← read).transitionDepth = 0 then
     modify fun s =>

--- a/Mathlib/Tactic/Linter/TextBased.lean
+++ b/Mathlib/Tactic/Linter/TextBased.lean
@@ -410,7 +410,8 @@ def lintFile (path : FilePath) (sizeLimit : Option ℕ) (exceptions : Array Erro
   let allOutput := (Array.map (fun lint ↦
     (Array.map (fun (e, n) ↦ ErrorContext.mk e n path)) (lint lines))) allLinters
   -- This this list is not sorted: for github, this is fine.
-  errors := errors.append (allOutput.flatten.filter (fun e ↦ (e.find?_comparable exceptions).isNone))
+  errors := errors.append
+    (allOutput.flatten.filter (fun e ↦ (e.find?_comparable exceptions).isNone))
   return errors
 
 /-- Lint a collection of modules for style violations.

--- a/test/Clean.lean
+++ b/test/Clean.lean
@@ -51,3 +51,5 @@ example : True := by
   guard_hyp z :ₛ Nat := let_fun x := 1; x + x
 
   trivial
+
+end Tests

--- a/test/DefEqTransformations.lean
+++ b/test/DefEqTransformations.lean
@@ -182,3 +182,5 @@ example (n : Fin 5) : n = ⟨n.val2, n.prop2⟩ := by
   eta_struct
   guard_target =ₛ n = n
   rfl
+
+end Tests

--- a/test/InferParam.lean
+++ b/test/InferParam.lean
@@ -19,3 +19,5 @@ example : 0 ≤ 2 + 2 := by
 example : 0 ≤ 2 + 2 := by
   apply zero_le_add'
   infer_param
+
+end InferParamTest

--- a/test/TermCongr.lean
+++ b/test/TermCongr.lean
@@ -160,3 +160,5 @@ example {s t : α → Prop} (h : s = t) (p : α → Prop) :
   congr(∀ (n : Subtype $h), p n)
 
 end limitations
+
+end Tests

--- a/test/Use.lean
+++ b/test/Use.lean
@@ -227,3 +227,5 @@ example (h1 : 1 > 0) : ∃ (n : Nat) (_h : n > 0), n = n := by
 example : let P : Nat → Prop := fun _x => ∃ _n : Nat, True; P 1 := by
   intro P
   use 1
+
+end UseTests

--- a/test/convert.lean
+++ b/test/convert.lean
@@ -125,3 +125,5 @@ example (x y z : Nat) (h : x + y = z) : y + x = z := by
   convert_to y + x = _ at h
   · rw [Nat.add_comm]
   exact h
+
+end Tests

--- a/test/notation3.lean
+++ b/test/notation3.lean
@@ -202,3 +202,5 @@ notation3 "δNat" => (default : Nat)
 #guard_msgs in #check (default : Nat)
 /-- info: δNat : ℕ -/
 #guard_msgs in #check @default Nat (Inhabited.mk 5)
+
+end Test


### PR DESCRIPTION
Fix long lines, remove unused tactics and add missing end commands.
The remaining changes are silencing linters in `tests`, which cannot be backported. Split out from #15845.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
