### PR TITLE
[Merged by Bors] - feat(CategoryTheory/ConnectedComponents) : extracted a definition from Cat to be used by categories in general

### DIFF
--- a/Mathlib/CategoryTheory/Category/Cat/Adjunction.lean
+++ b/Mathlib/CategoryTheory/Category/Cat/Adjunction.lean
@@ -52,11 +52,9 @@ def typeToCatObjectsAdj : typeToCat ⊣ Cat.objects where
 /-- The connected components functor -/
 def connectedComponents : Cat.{v, u} ⥤ Type u where
   obj C := ConnectedComponents C
-  map F :=
-    Quotient.lift (Quotient.mk (Zigzag.setoid _) ∘ F.obj)
-      (fun _ _ ↦ Quot.sound ∘ zigzag_obj_of_zigzag F)
-  map_id _ := funext fun x ↦ (Quotient.exists_rep x).elim (fun _ h ↦ by simp [<- h]; rfl)
-  map_comp _ _ := funext fun x ↦ (Quotient.exists_rep x).elim (fun _ h => by simp [<- h])
+  map F := Functor.mapConnectedComponents F
+  map_id _ := funext fun x ↦ (Quotient.exists_rep x).elim (fun _ h ↦ by subst h; rfl)
+  map_comp _ _ := funext fun x ↦ (Quotient.exists_rep x).elim (fun _ h => by subst h;rfl)
 
 /-- `typeToCat : Type ⥤ Cat` is right adjoint to `connectedComponents : Cat ⥤ Type` -/
 def connectedComponentsTypeToCatAdj : connectedComponents ⊣ typeToCat where

--- a/Mathlib/CategoryTheory/ConnectedComponents.lean
+++ b/Mathlib/CategoryTheory/ConnectedComponents.lean
@@ -39,8 +39,8 @@ def ConnectedComponents (J : Type u₁) [Category.{v₁} J] : Type u₁ :=
 /-- The map `ConnectedComponents J → ConnectedComponents K` induced by a functor `J ⥤ K`. -/
 def Functor.mapConnectedComponents {K : Type u₂} [Category.{v₂} K] (F : J ⥤ K)
     (x : ConnectedComponents J) : ConnectedComponents K :=
-  Quotient.lift (Quotient.mk (Zigzag.setoid _) ∘ F.obj)
-    (fun _ _ ↦ Quot.sound ∘ zigzag_obj_of_zigzag F) x
+  x |> Quotient.lift (Quotient.mk (Zigzag.setoid _) ∘ F.obj)
+    (fun _ _ ↦ Quot.sound ∘ zigzag_obj_of_zigzag F)
 
 @[simp]
 lemma image_of_cc_is_cc_of_image {K : Type u₂} [Category.{v₂} K] (F : J ⥤ K) :

--- a/Mathlib/CategoryTheory/ConnectedComponents.lean
+++ b/Mathlib/CategoryTheory/ConnectedComponents.lean
@@ -43,9 +43,8 @@ def Functor.mapConnectedComponents {K : Type u₂} [Category.{v₂} K] (F : J �
     (fun _ _ ↦ Quot.sound ∘ zigzag_obj_of_zigzag F)
 
 @[simp]
-lemma image_of_cc_is_cc_of_image {K : Type u₂} [Category.{v₂} K] (F : J ⥤ K) :
-    F.mapConnectedComponents ∘ (Quotient.mk (Zigzag.setoid J))
-      =  Quotient.mk (Zigzag.setoid K) ∘ F.obj := rfl
+lemma Functor.mapConnectedComponents_mk {K : Type u₂} [Category.{v₂} K] (F : J ⥤ K) (j : J) :
+    F.mapConnectedComponents (Quotient.mk _ j) = Quotient.mk _ (F.obj j) := rfl
 
 instance [Inhabited J] : Inhabited (ConnectedComponents J) :=
   ⟨Quotient.mk'' default⟩

--- a/Mathlib/CategoryTheory/ConnectedComponents.lean
+++ b/Mathlib/CategoryTheory/ConnectedComponents.lean
@@ -36,7 +36,7 @@ variable {J : Type u₁} [Category.{v₁} J]
 def ConnectedComponents (J : Type u₁) [Category.{v₁} J] : Type u₁ :=
   Quotient (Zigzag.setoid J)
 
-/-- Functors are mapped to functions from the connected components of their domain and target -/
+/-- The map `ConnectedComponents J → ConnectedComponents K` induced by a functor `J ⥤ K`. -/
 def Functor.mapConnectedComponents  {K : Type u₂} [Category.{v₂} K] (F : J ⥤ K)
     (x : ConnectedComponents J) : ConnectedComponents K :=
   Quotient.lift (Quotient.mk (Zigzag.setoid _) ∘ F.obj)

--- a/Mathlib/CategoryTheory/ConnectedComponents.lean
+++ b/Mathlib/CategoryTheory/ConnectedComponents.lean
@@ -36,6 +36,12 @@ variable {J : Type u₁} [Category.{v₁} J]
 def ConnectedComponents (J : Type u₁) [Category.{v₁} J] : Type u₁ :=
   Quotient (Zigzag.setoid J)
 
+/-- Functors are mapped to functions from the connected components of their domain and target -/
+def Functor.mapConnectedComponents  {K : Type u₂} [Category.{v₂} K] (F : J ⥤ K) :
+    ConnectedComponents J → ConnectedComponents K :=
+  Quotient.lift (Quotient.mk (Zigzag.setoid _) ∘ F.obj)
+    (fun _ _ ↦ Quot.sound ∘ zigzag_obj_of_zigzag F)
+
 instance [Inhabited J] : Inhabited (ConnectedComponents J) :=
   ⟨Quotient.mk'' default⟩
 

--- a/Mathlib/CategoryTheory/ConnectedComponents.lean
+++ b/Mathlib/CategoryTheory/ConnectedComponents.lean
@@ -42,6 +42,11 @@ def Functor.mapConnectedComponents {K : Type u₂} [Category.{v₂} K] (F : J �
   Quotient.lift (Quotient.mk (Zigzag.setoid _) ∘ F.obj)
     (fun _ _ ↦ Quot.sound ∘ zigzag_obj_of_zigzag F) x
 
+@[simp]
+lemma image_of_cc_is_cc_of_image {K : Type u₂} [Category.{v₂} K] (F : J ⥤ K) :
+    F.mapConnectedComponents ∘ (Quotient.mk (Zigzag.setoid J))
+      =  Quotient.mk (Zigzag.setoid K) ∘ F.obj := rfl
+
 instance [Inhabited J] : Inhabited (ConnectedComponents J) :=
   ⟨Quotient.mk'' default⟩
 

--- a/Mathlib/CategoryTheory/ConnectedComponents.lean
+++ b/Mathlib/CategoryTheory/ConnectedComponents.lean
@@ -37,7 +37,7 @@ def ConnectedComponents (J : Type u₁) [Category.{v₁} J] : Type u₁ :=
   Quotient (Zigzag.setoid J)
 
 /-- The map `ConnectedComponents J → ConnectedComponents K` induced by a functor `J ⥤ K`. -/
-def Functor.mapConnectedComponents  {K : Type u₂} [Category.{v₂} K] (F : J ⥤ K)
+def Functor.mapConnectedComponents {K : Type u₂} [Category.{v₂} K] (F : J ⥤ K)
     (x : ConnectedComponents J) : ConnectedComponents K :=
   Quotient.lift (Quotient.mk (Zigzag.setoid _) ∘ F.obj)
     (fun _ _ ↦ Quot.sound ∘ zigzag_obj_of_zigzag F) x

--- a/Mathlib/CategoryTheory/ConnectedComponents.lean
+++ b/Mathlib/CategoryTheory/ConnectedComponents.lean
@@ -37,10 +37,10 @@ def ConnectedComponents (J : Type u₁) [Category.{v₁} J] : Type u₁ :=
   Quotient (Zigzag.setoid J)
 
 /-- Functors are mapped to functions from the connected components of their domain and target -/
-def Functor.mapConnectedComponents  {K : Type u₂} [Category.{v₂} K] (F : J ⥤ K) :
-    ConnectedComponents J → ConnectedComponents K :=
+def Functor.mapConnectedComponents  {K : Type u₂} [Category.{v₂} K] (F : J ⥤ K)
+    (x : ConnectedComponents J) : ConnectedComponents K :=
   Quotient.lift (Quotient.mk (Zigzag.setoid _) ∘ F.obj)
-    (fun _ _ ↦ Quot.sound ∘ zigzag_obj_of_zigzag F)
+    (fun _ _ ↦ Quot.sound ∘ zigzag_obj_of_zigzag F) x
 
 instance [Inhabited J] : Inhabited (ConnectedComponents J) :=
   ⟨Quotient.mk'' default⟩


### PR DESCRIPTION
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
