### PR TITLE
[Merged by Bors] - chore: Fix precedence of `~r` infix for `IsRotated`

### DIFF
--- a/Mathlib/Data/List/Rotate.lean
+++ b/Mathlib/Data/List/Rotate.lean
@@ -374,7 +374,9 @@ def IsRotated : Prop :=
   ∃ n, l.rotate n = l'
 
 @[inherit_doc List.IsRotated]
-infixr:1000 " ~r " => IsRotated
+infixr:50 " ~r " => IsRotated
+
+example {a : α} {l : List α} : a :: l ~r a :: l := sorry
 
 variable {l l'}
 

--- a/Mathlib/Data/List/Rotate.lean
+++ b/Mathlib/Data/List/Rotate.lean
@@ -376,8 +376,6 @@ def IsRotated : Prop :=
 @[inherit_doc List.IsRotated]
 infixr:50 " ~r " => IsRotated
 
-example {a : α} {l : List α} : a :: l ~r a :: l := sorry
-
 variable {l l'}
 
 @[refl]

--- a/Mathlib/Data/List/Rotate.lean
+++ b/Mathlib/Data/List/Rotate.lean
@@ -374,6 +374,7 @@ def IsRotated : Prop :=
   ∃ n, l.rotate n = l'
 
 @[inherit_doc List.IsRotated]
+-- This matches the precedence of the infix `~` for `List.Perm`, and of other relation infixes
 infixr:50 " ~r " => IsRotated
 
 variable {l l'}


### PR DESCRIPTION

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
