### PR TITLE
[Merged by Bors] - feat(Data/List/Forall2): Add lemmas about List.map and SublistForall₂

### DIFF
--- a/Mathlib/Data/List/Forall2.lean
+++ b/Mathlib/Data/List/Forall2.lean
@@ -324,4 +324,26 @@ theorem Sublist.sublistForall₂ {l₁ l₂ : List α} (h : l₁ <+ l₂) [IsRef
 theorem tail_sublistForall₂_self [IsRefl α Rₐ] (l : List α) : SublistForall₂ Rₐ l.tail l :=
   l.tail_sublist.sublistForall₂
 
+@[simp]
+theorem sublistForall₂_map_left_iff {f : γ → α} :
+    ∀ {l u}, SublistForall₂ R (map f l) u ↔ SublistForall₂ (fun c b => R (f c) b) l u := by
+  simp [sublistForall₂_iff]
+
+@[simp]
+theorem sublistForall₂_map_right_iff {f : γ → β} :
+    ∀ {l u}, SublistForall₂ R l (map f u) ↔ SublistForall₂ (fun a c => R a (f c)) l u := by
+  simp [sublistForall₂_iff]
+  intro l u
+  constructor
+  · rintro ⟨l1, h1, h2⟩
+    rw [sublist_map_iff] at h2
+    obtain ⟨l', hl1, hl2⟩ := h2
+    use l'
+    rw [hl2] at h1
+    simpa [hl1] using h1
+  · rintro ⟨l1, h1, h2⟩
+    use l1.map f
+    simp [h1, h2.map]
+
+
 end List

--- a/Mathlib/Data/List/Forall2.lean
+++ b/Mathlib/Data/List/Forall2.lean
@@ -325,15 +325,14 @@ theorem tail_sublistForall₂_self [IsRefl α Rₐ] (l : List α) : SublistForal
   l.tail_sublist.sublistForall₂
 
 @[simp]
-theorem sublistForall₂_map_left_iff {f : γ → α} :
-    ∀ {l u}, SublistForall₂ R (map f l) u ↔ SublistForall₂ (fun c b => R (f c) b) l u := by
+theorem sublistForall₂_map_left_iff {f : γ → α} {l₁ : List γ} {l₂ : List β} :
+    SublistForall₂ R (map f l₁) l₂ ↔ SublistForall₂ (fun c b => R (f c) b) l₁ l₂ := by
   simp [sublistForall₂_iff]
 
 @[simp]
-theorem sublistForall₂_map_right_iff {f : γ → β} :
-    ∀ {l u}, SublistForall₂ R l (map f u) ↔ SublistForall₂ (fun a c => R a (f c)) l u := by
-  simp [sublistForall₂_iff]
-  intro l u
+theorem sublistForall₂_map_right_iff {f : γ → β} {l₁ : List α} {l₂ : List γ} :
+    SublistForall₂ R l₁ (map f l₂) ↔ SublistForall₂ (fun a c => R a (f c)) l₁ l₂ := by
+  simp only [sublistForall₂_iff]
   constructor
   · rintro ⟨l1, h1, h2⟩
     rw [sublist_map_iff] at h2

--- a/Mathlib/Data/List/Forall2.lean
+++ b/Mathlib/Data/List/Forall2.lean
@@ -345,5 +345,4 @@ theorem sublistForall₂_map_right_iff {f : γ → β} :
     use l1.map f
     simp [h1, h2.map]
 
-
 end List

--- a/Mathlib/Data/List/Forall2.lean
+++ b/Mathlib/Data/List/Forall2.lean
@@ -335,10 +335,8 @@ theorem sublistForall₂_map_right_iff {f : γ → β} {l₁ : List α} {l₂ : 
   simp only [sublistForall₂_iff]
   constructor
   · rintro ⟨l1, h1, h2⟩
-    rw [sublist_map_iff] at h2
-    obtain ⟨l', hl1, hl2⟩ := h2
+    obtain ⟨l', hl1, rfl⟩ := sublist_map_iff.mp h2
     use l'
-    rw [hl2] at h1
     simpa [hl1] using h1
   · rintro ⟨l1, h1, h2⟩
     use l1.map f


### PR DESCRIPTION
Add lemmas about the interaction of List.map with SublistForall₂, analogous to `forall₂_map_left_iff` and `forall₂_map_right_iff`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
