### PR TITLE
[Merged by Bors] - chore: turn `induction'` into `induction`

### DIFF
--- a/Mathlib/Algebra/Ring/Hom/Defs.lean
+++ b/Mathlib/Algebra/Ring/Hom/Defs.lean
@@ -598,7 +598,7 @@ instance instMonoid : Monoid (α →+* α) where
   mul_one := comp_id
   one_mul := id_comp
   mul_assoc f g h := comp_assoc _ _ _
-  npow n f := (npowRec n f).copy f^[n] $ by induction' n <;> simp [npowRec, *]
+  npow n f := (npowRec n f).copy f^[n] $ by induction n <;> simp [npowRec, *]
   npow_succ n f := DFunLike.coe_injective $ Function.iterate_succ _ _
 
 @[simp, norm_cast] lemma coe_pow (f : α →+* α) (n : ℕ) : ⇑(f ^ n) = f^[n] := rfl

--- a/Mathlib/AlgebraicTopology/DoldKan/NReflectsIso.lean
+++ b/Mathlib/AlgebraicTopology/DoldKan/NReflectsIso.lean
@@ -48,15 +48,17 @@ instance : (N₁ : SimplicialObject C ⥤ Karoubi (ChainComplex C ℕ)).Reflects
       AlternatingFaceMapComplex.map_f, N₁_obj_p, Karoubi.id_f, assoc] at h₁ h₂ h₃
     -- we have to construct an inverse to f in degree n, by induction on n
     intro n
-    induction' n with n hn
+    induction n with
     -- degree 0
-    · use (inv (N₁.map f)).f.f 0
+    | zero =>
+      use (inv (N₁.map f)).f.f 0
       have h₁₀ := h₁ 0
       have h₂₀ := h₂ 0
       dsimp at h₁₀ h₂₀
       simp only [id_comp, comp_id] at h₁₀ h₂₀
       tauto
-    · haveI := hn
+    | succ n hn =>
+      haveI := hn
       use φ { a := PInfty.f (n + 1) ≫ (inv (N₁.map f)).f.f (n + 1)
               b := fun i => inv (f.app (op [n])) ≫ X.σ i }
       simp only [MorphComponents.id, ← id_φ, ← preComp_φ, preComp, ← postComp_φ, postComp,

--- a/Mathlib/Analysis/Analytic/Meromorphic.lean
+++ b/Mathlib/Analysis/Analytic/Meromorphic.lean
@@ -133,14 +133,14 @@ lemma div {f g : 𝕜 → 𝕜} {x : 𝕜} (hf : MeromorphicAt f x) (hg : Meromo
   (div_eq_mul_inv f g).symm ▸ (hf.mul hg.inv)
 
 lemma pow {f : 𝕜 → 𝕜} {x : 𝕜} (hf : MeromorphicAt f x) (n : ℕ) : MeromorphicAt (f ^ n) x := by
-  induction' n with m hm
-  · simpa only [pow_zero] using MeromorphicAt.const 1 x
-  · simpa only [pow_succ] using hm.mul hf
+  induction n with
+  | zero => simpa only [pow_zero] using MeromorphicAt.const 1 x
+  | succ m hm => simpa only [pow_succ] using hm.mul hf
 
 lemma zpow {f : 𝕜 → 𝕜} {x : 𝕜} (hf : MeromorphicAt f x) (n : ℤ) : MeromorphicAt (f ^ n) x := by
-  induction' n with m m
-  · simpa only [Int.ofNat_eq_coe, zpow_natCast] using hf.pow m
-  · simpa only [zpow_negSucc, inv_iff] using hf.pow (m + 1)
+  induction n with
+  | ofNat m => simpa only [Int.ofNat_eq_coe, zpow_natCast] using hf.pow m
+  | negSucc m => simpa only [zpow_negSucc, inv_iff] using hf.pow (m + 1)
 
 /-- The order of vanishing of a meromorphic function, as an element of `ℤ ∪ ∞` (to include the
 case of functions identically 0 near `x`). -/

--- a/Mathlib/Analysis/Calculus/Taylor.lean
+++ b/Mathlib/Analysis/Calculus/Taylor.lean
@@ -167,21 +167,23 @@ theorem hasDerivWithinAt_taylorWithinEval {f : ℝ → E} {x y : ℝ} {n : ℕ} 
     (hf' : DifferentiableWithinAt ℝ (iteratedDerivWithin n f s) s y) :
     HasDerivWithinAt (fun t => taylorWithinEval f n s t x)
       (((n ! : ℝ)⁻¹ * (x - y) ^ n) • iteratedDerivWithin (n + 1) f s y) s' y := by
-  induction' n with k hk
-  · simp only [taylor_within_zero_eval, Nat.factorial_zero, Nat.cast_one, inv_one, pow_zero,
+  induction n with
+  | zero =>
+    simp only [taylor_within_zero_eval, Nat.factorial_zero, Nat.cast_one, inv_one, pow_zero,
       mul_one, zero_add, one_smul]
     simp only [iteratedDerivWithin_zero] at hf'
     rw [iteratedDerivWithin_one (hs_unique _ (h hy))]
     exact hf'.hasDerivWithinAt.mono h
-  simp_rw [Nat.add_succ, taylorWithinEval_succ]
-  simp only [add_zero, Nat.factorial_succ, Nat.cast_mul, Nat.cast_add, Nat.cast_one]
-  have coe_lt_succ : (k : WithTop ℕ) < k.succ := Nat.cast_lt.2 k.lt_succ_self
-  have hdiff : DifferentiableOn ℝ (iteratedDerivWithin k f s) s' :=
-    (hf.differentiableOn_iteratedDerivWithin coe_lt_succ hs_unique).mono h
-  specialize hk hf.of_succ ((hdiff y hy).mono_of_mem hs')
-  convert hk.add (hasDerivWithinAt_taylor_coeff_within hs'_unique
-    (nhdsWithin_mono _ h self_mem_nhdsWithin) hf') using 1
-  exact (add_sub_cancel _ _).symm
+  | succ k hk =>
+    simp_rw [Nat.add_succ, taylorWithinEval_succ]
+    simp only [add_zero, Nat.factorial_succ, Nat.cast_mul, Nat.cast_add, Nat.cast_one]
+    have coe_lt_succ : (k : WithTop ℕ) < k.succ := Nat.cast_lt.2 k.lt_succ_self
+    have hdiff : DifferentiableOn ℝ (iteratedDerivWithin k f s) s' :=
+      (hf.differentiableOn_iteratedDerivWithin coe_lt_succ hs_unique).mono h
+    specialize hk hf.of_succ ((hdiff y hy).mono_of_mem hs')
+    convert hk.add (hasDerivWithinAt_taylor_coeff_within hs'_unique
+      (nhdsWithin_mono _ h self_mem_nhdsWithin) hf') using 1
+    exact (add_sub_cancel _ _).symm
 
 /-- Calculate the derivative of the Taylor polynomial with respect to `x₀`.
 

--- a/Mathlib/Analysis/Calculus/Taylor.lean
+++ b/Mathlib/Analysis/Calculus/Taylor.lean
@@ -98,17 +98,18 @@ theorem taylor_within_zero_eval (f : ℝ → E) (s : Set ℝ) (x₀ x : ℝ) :
 @[simp]
 theorem taylorWithinEval_self (f : ℝ → E) (n : ℕ) (s : Set ℝ) (x₀ : ℝ) :
     taylorWithinEval f n s x₀ x₀ = f x₀ := by
-  induction' n with k hk
-  · exact taylor_within_zero_eval _ _ _ _
-  simp [hk]
+  induction n with
+  | zero => exact taylor_within_zero_eval _ _ _ _
+  | succ k hk => simp [hk]
 
 theorem taylor_within_apply (f : ℝ → E) (n : ℕ) (s : Set ℝ) (x₀ x : ℝ) :
     taylorWithinEval f n s x₀ x =
       ∑ k ∈ Finset.range (n + 1), ((k ! : ℝ)⁻¹ * (x - x₀) ^ k) • iteratedDerivWithin k f s x₀ := by
-  induction' n with k hk
-  · simp
-  rw [taylorWithinEval_succ, Finset.sum_range_succ, hk]
-  simp [Nat.factorial]
+  induction n with
+  | zero => simp
+  | succ k hk =>
+    rw [taylorWithinEval_succ, Finset.sum_range_succ, hk]
+    simp [Nat.factorial]
 
 /-- If `f` is `n` times continuous differentiable on a set `s`, then the Taylor polynomial
   `taylorWithinEval f n s x₀ x` is continuous in `x₀`. -/

--- a/Mathlib/Analysis/Convex/SpecificFunctions/Deriv.lean
+++ b/Mathlib/Analysis/Convex/SpecificFunctions/Deriv.lean
@@ -67,17 +67,18 @@ theorem Finset.prod_nonneg_of_card_nonpos_even {α β : Type*} [LinearOrderedCom
 theorem int_prod_range_nonneg (m : ℤ) (n : ℕ) (hn : Even n) :
     0 ≤ ∏ k ∈ Finset.range n, (m - k) := by
   rcases hn with ⟨n, rfl⟩
-  induction' n with n ihn
-  · simp
-  rw [← two_mul] at ihn
-  rw [← two_mul, mul_add, mul_one, ← one_add_one_eq_two, ← add_assoc,
-    Finset.prod_range_succ, Finset.prod_range_succ, mul_assoc]
-  refine mul_nonneg ihn ?_; generalize (1 + 1) * n = k
-  rcases le_or_lt m k with hmk | hmk
-  · have : m ≤ k + 1 := hmk.trans (lt_add_one (k : ℤ)).le
-    convert mul_nonneg_of_nonpos_of_nonpos (sub_nonpos_of_le hmk) _
-    convert sub_nonpos_of_le this
-  · exact mul_nonneg (sub_nonneg_of_le hmk.le) (sub_nonneg_of_le hmk)
+  induction n with
+  | zero => simp
+  | succ n ihn =>
+    rw [← two_mul] at ihn
+    rw [← two_mul, mul_add, mul_one, ← one_add_one_eq_two, ← add_assoc,
+      Finset.prod_range_succ, Finset.prod_range_succ, mul_assoc]
+    refine mul_nonneg ihn ?_; generalize (1 + 1) * n = k
+    rcases le_or_lt m k with hmk | hmk
+    · have : m ≤ k + 1 := hmk.trans (lt_add_one (k : ℤ)).le
+      convert mul_nonneg_of_nonpos_of_nonpos (sub_nonpos_of_le hmk) _
+      convert sub_nonpos_of_le this
+    · exact mul_nonneg (sub_nonneg_of_le hmk.le) (sub_nonneg_of_le hmk)
 
 theorem int_prod_range_pos {m : ℤ} {n : ℕ} (hn : Even n) (hm : m ∉ Ico (0 : ℤ) n) :
     0 < ∏ k ∈ Finset.range n, (m - k) := by

--- a/Mathlib/Analysis/Convolution.lean
+++ b/Mathlib/Analysis/Convolution.lean
@@ -1178,10 +1178,12 @@ theorem contDiffOn_convolution_right_with_param_aux {G : Type uP} {E' : Type uP}
     `n` (but for this we need the spaces at the different steps of the induction to live in the same
     universe, which is why we make the assumption in the lemma that all the relevant spaces
     come from the same universe). -/
-  induction' n using ENat.nat_induction with n ih ih generalizing g E' F
-  · rw [contDiffOn_zero] at hg ⊢
+  induction n using ENat.nat_induction generalizing g E' F with
+  | h0 =>
+    rw [contDiffOn_zero] at hg ⊢
     exact continuousOn_convolution_right_with_param L hk hgs hf hg
-  · let f' : P → G → P × G →L[𝕜] F := fun p a =>
+  | hsuc n ih =>
+    let f' : P → G → P × G →L[𝕜] F := fun p a =>
       (f ⋆[L.precompR (P × G), μ] fun x : G => fderiv 𝕜 (uncurry g) (p, x)) a
     have A : ∀ q₀ : P × G, q₀.1 ∈ s →
         HasFDerivAt (fun q : P × G => (f ⋆[L, μ] g q.1) q.2) (f' q₀.1 q₀.2) q₀ :=
@@ -1205,9 +1207,9 @@ theorem contDiffOn_convolution_right_with_param_aux {G : Type uP} {E' : Type uP}
         exact hgs p y hp hy
       apply ih (L.precompR (P × G) : _) B
       convert hg.2
-  · rw [contDiffOn_top] at hg ⊢
-    intro n
-    exact ih n L hgs (hg n)
+  | htop ih =>
+    rw [contDiffOn_top] at hg ⊢
+    exact fun n ↦ ih n L hgs (hg n)
 
 /-- The convolution `f * g` is `C^n` when `f` is locally integrable and `g` is `C^n` and compactly
 supported. Version where `g` depends on an additional parameter in an open subset `s` of a

--- a/Mathlib/Analysis/Distribution/SchwartzSpace.lean
+++ b/Mathlib/Analysis/Distribution/SchwartzSpace.lean
@@ -1002,20 +1002,22 @@ theorem iteratedPDeriv_succ_left {n : ℕ} (m : Fin (n + 1) → E) (f : 𝓢(E, 
 
 theorem iteratedPDeriv_succ_right {n : ℕ} (m : Fin (n + 1) → E) (f : 𝓢(E, F)) :
     iteratedPDeriv 𝕜 m f = iteratedPDeriv 𝕜 (Fin.init m) (pderivCLM 𝕜 (m (Fin.last n)) f) := by
-  induction' n with n IH
-  · rw [iteratedPDeriv_zero, iteratedPDeriv_one]
+  induction n with
+  | zero =>
+    rw [iteratedPDeriv_zero, iteratedPDeriv_one]
     rfl
   -- The proof is `∂^{n + 2} = ∂ ∂^{n + 1} = ∂ ∂^n ∂ = ∂^{n+1} ∂`
-  have hmzero : Fin.init m 0 = m 0 := by simp only [Fin.init_def, Fin.castSucc_zero]
-  have hmtail : Fin.tail m (Fin.last n) = m (Fin.last n.succ) := by
-    simp only [Fin.tail_def, Fin.succ_last]
-  calc
-    _ = pderivCLM 𝕜 (m 0) (iteratedPDeriv 𝕜 _ f) := iteratedPDeriv_succ_left _ _ _
-    _ = pderivCLM 𝕜 (m 0) ((iteratedPDeriv 𝕜 _) ((pderivCLM 𝕜 _) f)) := by
-      congr 1
-      exact IH _
-    _ = _ := by
-      simp only [hmtail, iteratedPDeriv_succ_left, hmzero, Fin.tail_init_eq_init_tail]
+  | succ n IH =>
+    have hmzero : Fin.init m 0 = m 0 := by simp only [Fin.init_def, Fin.castSucc_zero]
+    have hmtail : Fin.tail m (Fin.last n) = m (Fin.last n.succ) := by
+      simp only [Fin.tail_def, Fin.succ_last]
+    calc
+      _ = pderivCLM 𝕜 (m 0) (iteratedPDeriv 𝕜 _ f) := iteratedPDeriv_succ_left _ _ _
+      _ = pderivCLM 𝕜 (m 0) ((iteratedPDeriv 𝕜 _) ((pderivCLM 𝕜 _) f)) := by
+        congr 1
+        exact IH _
+      _ = _ := by
+        simp only [hmtail, iteratedPDeriv_succ_left, hmzero, Fin.tail_init_eq_init_tail]
 
 theorem iteratedPDeriv_eq_iteratedFDeriv {n : ℕ} {m : Fin n → E} {f : 𝓢(E, F)} {x : E} :
     iteratedPDeriv 𝕜 m f x = iteratedFDeriv ℝ n f x m := by

--- a/Mathlib/Analysis/Hofer.lean
+++ b/Mathlib/Analysis/Hofer.lean
@@ -37,7 +37,6 @@ theorem hofer {X : Type*} [MetricSpace X] [CompleteSpace X] (x : X) (ε : ℝ) (
     push_neg at H
     have := H (ε / 2 ^ k) (by positivity) x' (by simp [ε_pos.le, one_le_two])
     simpa [reformulation] using this
-  clear reformulation
   haveI : Nonempty X := ⟨x⟩
   choose! F hF using H
   -- Use the axiom of choice
@@ -48,32 +47,29 @@ theorem hofer {X : Type*} [MetricSpace X] [CompleteSpace X] (x : X) (ε : ℝ) (
     ∀ n,
       d (u n) x ≤ 2 * ε ∧ 2 ^ n * ϕ x ≤ ϕ (u n) →
         d (u n) (u <| n + 1) ≤ ε / 2 ^ n ∧ 2 * ϕ (u n) < ϕ (u <| n + 1) := by
-    intro n
-    exact hF n (u n)
-  clear hF
+    exact fun n ↦ hF n (u n)
   -- Key properties of u, to be proven by induction
   have key : ∀ n, d (u n) (u (n + 1)) ≤ ε / 2 ^ n ∧ 2 * ϕ (u n) < ϕ (u (n + 1)) := by
     intro n
-    induction' n using Nat.case_strong_induction_on with n IH
-    · simpa [u, ε_pos.le] using hu 0
-    have A : d (u (n + 1)) x ≤ 2 * ε := by
-      rw [dist_comm]
-      let r := range (n + 1) -- range (n+1) = {0, ..., n}
-      calc
-        d (u 0) (u (n + 1)) ≤ ∑ i ∈ r, d (u i) (u <| i + 1) := dist_le_range_sum_dist u (n + 1)
-        _ ≤ ∑ i ∈ r, ε / 2 ^ i :=
-          (sum_le_sum fun i i_in => (IH i <| Nat.lt_succ_iff.mp <| Finset.mem_range.mp i_in).1)
-        _ = (∑ i ∈ r, (1 / 2 : ℝ) ^ i) * ε := by
-          rw [Finset.sum_mul]
-          congr with i
-          field_simp
-        _ ≤ 2 * ε := by gcongr; apply sum_geometric_two_le
-    have B : 2 ^ (n + 1) * ϕ x ≤ ϕ (u (n + 1)) := by
-      refine @geom_le (ϕ ∘ u) _ zero_le_two (n + 1) fun m hm => ?_
-      exact (IH _ <| Nat.lt_add_one_iff.1 hm).2.le
-    exact hu (n + 1) ⟨A, B⟩
+    induction n using Nat.case_strong_induction_on with
+    | hz => simpa [u, ε_pos.le] using hu 0
+    | hi n IH =>
+      have A : d (u (n + 1)) x ≤ 2 * ε := by
+        rw [dist_comm]
+        let r := range (n + 1) -- range (n+1) = {0, ..., n}
+        calc
+          d (u 0) (u (n + 1)) ≤ ∑ i ∈ r, d (u i) (u <| i + 1) := dist_le_range_sum_dist u (n + 1)
+          _ ≤ ∑ i ∈ r, ε / 2 ^ i :=
+            (sum_le_sum fun i i_in => (IH i <| Nat.lt_succ_iff.mp <| Finset.mem_range.mp i_in).1)
+          _ = (∑ i ∈ r, (1 / 2 : ℝ) ^ i) * ε := by
+            rw [Finset.sum_mul]
+            field_simp
+          _ ≤ 2 * ε := by gcongr; apply sum_geometric_two_le
+      have B : 2 ^ (n + 1) * ϕ x ≤ ϕ (u (n + 1)) := by
+        refine @geom_le (ϕ ∘ u) _ zero_le_two (n + 1) fun m hm => ?_
+        exact (IH _ <| Nat.lt_add_one_iff.1 hm).2.le
+      exact hu (n + 1) ⟨A, B⟩
   cases' forall_and.mp key with key₁ key₂
-  clear hu key
   -- Hence u is Cauchy
   have cauchy_u : CauchySeq u := by
     refine cauchySeq_of_le_geometric _ ε one_half_lt_one fun n => ?_

--- a/Mathlib/Analysis/PSeries.lean
+++ b/Mathlib/Analysis/PSeries.lean
@@ -81,18 +81,19 @@ theorem le_sum_condensed (hf : ∀ ⦃m n⦄, 0 < m → m ≤ n → f n ≤ f m)
 theorem sum_schlomilch_le' (hf : ∀ ⦃m n⦄, 1 < m → m ≤ n → f n ≤ f m) (h_pos : ∀ n, 0 < u n)
     (hu : Monotone u) (n : ℕ) :
     (∑ k ∈ range n, (u (k + 1) - u k) • f (u (k + 1))) ≤ ∑ k ∈ Ico (u 0 + 1) (u n + 1), f k := by
-  induction' n with n ihn
-  · simp
-  suffices (u (n + 1) - u n) • f (u (n + 1)) ≤ ∑ k ∈ Ico (u n + 1) (u (n + 1) + 1), f k by
-    rw [sum_range_succ, ← sum_Ico_consecutive]
-    exacts [add_le_add ihn this,
-      (add_le_add_right (hu n.zero_le) _ : u 0 + 1 ≤ u n + 1),
-      add_le_add_right (hu n.le_succ) _]
-  have : ∀ k ∈ Ico (u n + 1) (u (n + 1) + 1), f (u (n + 1)) ≤ f k := fun k hk =>
-    hf (Nat.lt_of_le_of_lt (Nat.succ_le_of_lt (h_pos n)) <| (Nat.lt_succ_of_le le_rfl).trans_le
-      (mem_Ico.mp hk).1) (Nat.le_of_lt_succ <| (mem_Ico.mp hk).2)
-  convert sum_le_sum this
-  simp [pow_succ, mul_two]
+  induction n with
+  | zero => simp
+  | succ n ihn =>
+    suffices (u (n + 1) - u n) • f (u (n + 1)) ≤ ∑ k ∈ Ico (u n + 1) (u (n + 1) + 1), f k by
+      rw [sum_range_succ, ← sum_Ico_consecutive]
+      exacts [add_le_add ihn this,
+        (add_le_add_right (hu n.zero_le) _ : u 0 + 1 ≤ u n + 1),
+        add_le_add_right (hu n.le_succ) _]
+    have : ∀ k ∈ Ico (u n + 1) (u (n + 1) + 1), f (u (n + 1)) ≤ f k := fun k hk =>
+      hf (Nat.lt_of_le_of_lt (Nat.succ_le_of_lt (h_pos n)) <| (Nat.lt_succ_of_le le_rfl).trans_le
+        (mem_Ico.mp hk).1) (Nat.le_of_lt_succ <| (mem_Ico.mp hk).2)
+    convert sum_le_sum this
+    simp [pow_succ, mul_two]
 
 theorem sum_condensed_le' (hf : ∀ ⦃m n⦄, 1 < m → m ≤ n → f n ≤ f m) (n : ℕ) :
     (∑ k ∈ range n, 2 ^ k • f (2 ^ (k + 1))) ≤ ∑ k ∈ Ico 2 (2 ^ n + 1), f k := by

--- a/Mathlib/Analysis/SpecialFunctions/Gamma/Basic.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Gamma/Basic.lean
@@ -343,9 +343,10 @@ theorem Gamma_zero : Gamma 0 = 0 := by
 
 /-- At `-n` for `n ∈ ℕ`, the Gamma function is undefined; by convention we assign it the value 0. -/
 theorem Gamma_neg_nat_eq_zero (n : ℕ) : Gamma (-n) = 0 := by
-  induction' n with n IH
-  · rw [Nat.cast_zero, neg_zero, Gamma_zero]
-  · have A : -(n.succ : ℂ) ≠ 0 := by
+  induction n with
+  | zero => rw [Nat.cast_zero, neg_zero, Gamma_zero]
+  | succ n IH =>
+    have A : -(n.succ : ℂ) ≠ 0 := by
       rw [neg_ne_zero, Nat.cast_ne_zero]
       apply Nat.succ_ne_zero
     have : -(n : ℂ) = -↑n.succ + 1 := by simp
@@ -581,11 +582,13 @@ theorem Gamma_ne_zero {s : ℝ} (hs : ∀ m : ℕ, s ≠ -m) : Gamma s ≠ 0 := 
     rw [neg_lt, Nat.cast_add, Nat.cast_one]
     exact Nat.lt_floor_add_one _
   intro n
-  induction' n with _ n_ih generalizing s
-  · intro hs
+  induction n generalizing s with
+  | zero =>
+    intro hs
     refine (Gamma_pos_of_pos ?_).ne'
     rwa [Nat.cast_zero, neg_zero] at hs
-  · intro hs'
+  | succ _ n_ih =>
+    intro hs'
     have : Gamma (s + 1) ≠ 0 := by
       apply n_ih
       · intro m


### PR DESCRIPTION
This PR turns `induction'` (soon to be deprecated) into `induction` and golfs a few proofs.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
