### PR TITLE
[Merged by Bors] - feat: interior, closure and frontier of Euclidean half-spaces

### DIFF
--- a/Mathlib/Geometry/Manifold/Instances/Real.lean
+++ b/Mathlib/Geometry/Manifold/Instances/Real.lean
@@ -90,6 +90,26 @@ theorem range_euclideanHalfSpace (n : ℕ) [Zero (Fin n)] :
   Subtype.range_val
 @[deprecated (since := "2024-04-05")] alias range_half_space := range_euclideanHalfSpace
 
+-- TODO: generalise these lemmas to other values of `p`
+
+theorem interior_halfspace {a : ℝ} {n : ℕ} (i : Fin n) :
+    interior { y : EuclideanSpace ℝ (Fin n) | a ≤ y i } = { y | a < y i } := by
+  let f : (EuclideanSpace ℝ (Fin n)) →L[ℝ] ℝ := ContinuousLinearMap.proj i
+  change interior (f ⁻¹' Set.Ici a) = f ⁻¹' Set.Ioi a
+  rw [f.interior_preimage (Function.surjective_eval _), interior_Ici]
+
+theorem closure_halfspace {a : ℝ} {n : ℕ} (i : Fin n) :
+    closure { y : EuclideanSpace ℝ (Fin n) | a ≤ y i } = { y | a ≤ y i } := by
+  let f : (EuclideanSpace ℝ (Fin n)) →L[ℝ] ℝ := ContinuousLinearMap.proj i
+  change closure (f ⁻¹' Set.Ici a) = f ⁻¹' Set.Ici a
+  rw [f.closure_preimage (Function.surjective_eval _), closure_Ici]
+
+theorem frontier_halfspace {a : ℝ} {n : ℕ} (i : Fin n) :
+    frontier { y : EuclideanSpace ℝ (Fin n) | a ≤ y i } = { y | a = y i } := by
+  rw [frontier, interior_halfspace, closure_halfspace]
+  ext y
+  simpa only [mem_diff, mem_setOf_eq, not_lt] using antisymm_iff
+
 theorem range_euclideanQuadrant (n : ℕ) :
     (range fun x : EuclideanQuadrant n => x.val) = { y | ∀ i : Fin n, 0 ≤ y i } :=
   Subtype.range_val
@@ -156,6 +176,25 @@ scoped[Manifold]
   notation "𝓡∂ " n =>
     (modelWithCornersEuclideanHalfSpace n :
       ModelWithCorners ℝ (EuclideanSpace ℝ (Fin n)) (EuclideanHalfSpace n))
+
+lemma range_modelWithCornersEuclideanHalfSpace (n : ℕ) [Zero (Fin n)] :
+  range (𝓡∂ n) = { y | 0 ≤ y 0 } := range_euclideanHalfSpace n
+
+lemma interior_range_modelWithCornersEuclideanHalfSpace (n : ℕ) [Zero (Fin n)] :
+    interior (range (𝓡∂ n)) = { y | 0 < y 0 } := by
+  calc interior (range (𝓡∂ n))
+    _ = interior ({ y | 0 ≤ y 0}) := by
+      congr!
+      apply range_euclideanHalfSpace
+    _ = { y | 0 < y 0 } := interior_halfspace 0
+
+lemma frontier_range_modelWithCornersEuclideanHalfSpace (n : ℕ) [Zero (Fin n)] :
+    frontier (range (𝓡∂ n)) = { y | 0 = y 0 } := by
+  calc frontier (range (𝓡∂ n))
+    _ = frontier ({ y | 0 ≤ y 0 }) := by
+      congr!
+      apply range_euclideanHalfSpace
+    _ = { y | 0 = y 0 } := frontier_halfspace 0
 
 /-- The left chart for the topological space `[x, y]`, defined on `[x,y)` and sending `x` to `0` in
 `EuclideanHalfSpace 1`.

--- a/Mathlib/Geometry/Manifold/Instances/Real.lean
+++ b/Mathlib/Geometry/Manifold/Instances/Real.lean
@@ -47,7 +47,7 @@ open scoped Manifold
 /-- The half-space in `ℝ^n`, used to model manifolds with boundary. We only define it when
 `1 ≤ n`, as the definition only makes sense in this case.
 -/
-def EuclideanHalfSpace (n : ℕ) [Zero (Fin n)] : Type :=
+def EuclideanHalfSpace (n : ℕ) [NeZero n] : Type :=
   { x : EuclideanSpace ℝ (Fin n) // 0 ≤ x 0 }
 
 /--
@@ -64,13 +64,13 @@ without the following reducibility attribute (which is only set in this section)
 
 variable {n : ℕ}
 
-instance [Zero (Fin n)] : TopologicalSpace (EuclideanHalfSpace n) :=
+instance [NeZero n] : TopologicalSpace (EuclideanHalfSpace n) :=
   instTopologicalSpaceSubtype
 
 instance : TopologicalSpace (EuclideanQuadrant n) :=
   instTopologicalSpaceSubtype
 
-instance [Zero (Fin n)] : Inhabited (EuclideanHalfSpace n) :=
+instance [NeZero n] : Inhabited (EuclideanHalfSpace n) :=
   ⟨⟨0, le_rfl⟩⟩
 
 instance : Inhabited (EuclideanQuadrant n) :=
@@ -81,11 +81,11 @@ theorem EuclideanQuadrant.ext (x y : EuclideanQuadrant n) (h : x.1 = y.1) : x = 
   Subtype.eq h
 
 @[ext]
-theorem EuclideanHalfSpace.ext [Zero (Fin n)] (x y : EuclideanHalfSpace n)
+theorem EuclideanHalfSpace.ext [NeZero n] (x y : EuclideanHalfSpace n)
     (h : x.1 = y.1) : x = y :=
   Subtype.eq h
 
-theorem range_euclideanHalfSpace (n : ℕ) [Zero (Fin n)] :
+theorem range_euclideanHalfSpace (n : ℕ) [NeZero n] :
     (range fun x : EuclideanHalfSpace n => x.val) = { y | 0 ≤ y 0 } :=
   Subtype.range_val
 @[deprecated (since := "2024-04-05")] alias range_half_space := range_euclideanHalfSpace
@@ -123,7 +123,7 @@ end
 Definition of the model with corners `(EuclideanSpace ℝ (Fin n), EuclideanHalfSpace n)`, used as
 a model for manifolds with boundary. In the locale `Manifold`, use the shortcut `𝓡∂ n`.
 -/
-def modelWithCornersEuclideanHalfSpace (n : ℕ) [Zero (Fin n)] :
+def modelWithCornersEuclideanHalfSpace (n : ℕ) [NeZero n] :
     ModelWithCorners ℝ (EuclideanSpace ℝ (Fin n)) (EuclideanHalfSpace n) where
   toFun := Subtype.val
   invFun x := ⟨update x 0 (max (x 0) 0), by simp [le_refl]⟩

--- a/Mathlib/Geometry/Manifold/Instances/Real.lean
+++ b/Mathlib/Geometry/Manifold/Instances/Real.lean
@@ -90,23 +90,22 @@ theorem range_euclideanHalfSpace (n : ℕ) [Zero (Fin n)] :
   Subtype.range_val
 @[deprecated (since := "2024-04-05")] alias range_half_space := range_euclideanHalfSpace
 
--- TODO: generalise these lemmas to other values of `p`
+open ENNReal in
+theorem interior_halfspace {n : ℕ} {p : ℝ≥0∞} {a : ℝ} {i : Fin n} :
+    interior { y : PiLp p (fun _ : Fin n ↦ ℝ) | a ≤ y i } = { y | a < y i } := by
+  let f : PiLp p (fun _ : Fin n ↦ ℝ) →L[ℝ] ℝ := ContinuousLinearMap.proj i
+  simpa [interior_Ici] using f.interior_preimage (Function.surjective_eval _) (Ici a)
 
-theorem interior_halfspace {a : ℝ} {n : ℕ} (i : Fin n) :
-    interior { y : EuclideanSpace ℝ (Fin n) | a ≤ y i } = { y | a < y i } := by
-  let f : (EuclideanSpace ℝ (Fin n)) →L[ℝ] ℝ := ContinuousLinearMap.proj i
-  change interior (f ⁻¹' Set.Ici a) = f ⁻¹' Set.Ioi a
-  rw [f.interior_preimage (Function.surjective_eval _), interior_Ici]
-
-theorem closure_halfspace {a : ℝ} {n : ℕ} (i : Fin n) :
+open ENNReal in
+theorem closure_halfspace {n : ℕ} {p : ℝ≥0∞} {a : ℝ} {i : Fin n} :
     closure { y : EuclideanSpace ℝ (Fin n) | a ≤ y i } = { y | a ≤ y i } := by
-  let f : (EuclideanSpace ℝ (Fin n)) →L[ℝ] ℝ := ContinuousLinearMap.proj i
-  change closure (f ⁻¹' Set.Ici a) = f ⁻¹' Set.Ici a
-  rw [f.closure_preimage (Function.surjective_eval _), closure_Ici]
+  let f : PiLp p (fun _ : Fin n ↦ ℝ) →L[ℝ] ℝ := ContinuousLinearMap.proj i
+  simpa [closure_Ici] using f.closure_preimage (Function.surjective_eval _) (Ici a)
 
-theorem frontier_halfspace {a : ℝ} {n : ℕ} (i : Fin n) :
+open ENNReal in
+theorem frontier_halfspace {n : ℕ} {p : ℝ≥0∞} {a : ℝ} {i : Fin n} :
     frontier { y : EuclideanSpace ℝ (Fin n) | a ≤ y i } = { y | a = y i } := by
-  rw [frontier, interior_halfspace, closure_halfspace]
+  rw [frontier, closure_halfspace (p := p), interior_halfspace]
   ext y
   simpa only [mem_diff, mem_setOf_eq, not_lt] using antisymm_iff
 
@@ -186,7 +185,7 @@ lemma interior_range_modelWithCornersEuclideanHalfSpace (n : ℕ) [Zero (Fin n)]
     _ = interior ({ y | 0 ≤ y 0}) := by
       congr!
       apply range_euclideanHalfSpace
-    _ = { y | 0 < y 0 } := interior_halfspace 0
+    _ = { y | 0 < y 0 } := interior_halfspace
 
 lemma frontier_range_modelWithCornersEuclideanHalfSpace (n : ℕ) [Zero (Fin n)] :
     frontier (range (𝓡∂ n)) = { y | 0 = y 0 } := by
@@ -194,7 +193,7 @@ lemma frontier_range_modelWithCornersEuclideanHalfSpace (n : ℕ) [Zero (Fin n)]
     _ = frontier ({ y | 0 ≤ y 0 }) := by
       congr!
       apply range_euclideanHalfSpace
-    _ = { y | 0 = y 0 } := frontier_halfspace 0
+    _ = { y | 0 = y 0 } := frontier_halfspace (p := 2)
 
 /-- The left chart for the topological space `[x, y]`, defined on `[x,y)` and sending `x` to `0` in
 `EuclideanHalfSpace 1`.

--- a/Mathlib/Geometry/Manifold/Instances/Real.lean
+++ b/Mathlib/Geometry/Manifold/Instances/Real.lean
@@ -91,19 +91,22 @@ theorem range_euclideanHalfSpace (n : ℕ) [Zero (Fin n)] :
 @[deprecated (since := "2024-04-05")] alias range_half_space := range_euclideanHalfSpace
 
 open ENNReal in
-theorem interior_halfspace {n : ℕ} {p : ℝ≥0∞} {a : ℝ} {i : Fin n} :
+@[simp]
+theorem interior_halfspace {n : ℕ} (p : ℝ≥0∞) (a : ℝ) (i : Fin n) :
     interior { y : PiLp p (fun _ : Fin n ↦ ℝ) | a ≤ y i } = { y | a < y i } := by
   let f : PiLp p (fun _ : Fin n ↦ ℝ) →L[ℝ] ℝ := ContinuousLinearMap.proj i
   simpa [interior_Ici] using f.interior_preimage (Function.surjective_eval _) (Ici a)
 
 open ENNReal in
-theorem closure_halfspace {n : ℕ} {p : ℝ≥0∞} {a : ℝ} {i : Fin n} :
+@[simp]
+theorem closure_halfspace {n : ℕ} (p : ℝ≥0∞) (a : ℝ) (i : Fin n) :
     closure { y : PiLp p (fun _ : Fin n ↦ ℝ) | a ≤ y i } = { y | a ≤ y i } := by
   let f : PiLp p (fun _ : Fin n ↦ ℝ) →L[ℝ] ℝ := ContinuousLinearMap.proj i
   simpa [closure_Ici] using f.closure_preimage (Function.surjective_eval _) (Ici a)
 
 open ENNReal in
-theorem frontier_halfspace {n : ℕ} {p : ℝ≥0∞} {a : ℝ} {i : Fin n} :
+@[simp]
+theorem frontier_halfspace {n : ℕ} (p : ℝ≥0∞) (a : ℝ) (i : Fin n) :
     frontier { y : PiLp p (fun _ : Fin n ↦ ℝ) | a ≤ y i } = { y | a = y i } := by
   rw [frontier, closure_halfspace, interior_halfspace]
   ext y
@@ -176,24 +179,24 @@ scoped[Manifold]
     (modelWithCornersEuclideanHalfSpace n :
       ModelWithCorners ℝ (EuclideanSpace ℝ (Fin n)) (EuclideanHalfSpace n))
 
-lemma range_modelWithCornersEuclideanHalfSpace (n : ℕ) [Zero (Fin n)] :
+lemma range_modelWithCornersEuclideanHalfSpace (n : ℕ) [NeZero n] :
   range (𝓡∂ n) = { y | 0 ≤ y 0 } := range_euclideanHalfSpace n
 
-lemma interior_range_modelWithCornersEuclideanHalfSpace (n : ℕ) [Zero (Fin n)] :
+lemma interior_range_modelWithCornersEuclideanHalfSpace (n : ℕ) [NeZero n] :
     interior (range (𝓡∂ n)) = { y | 0 < y 0 } := by
   calc interior (range (𝓡∂ n))
     _ = interior ({ y | 0 ≤ y 0}) := by
       congr!
       apply range_euclideanHalfSpace
-    _ = { y | 0 < y 0 } := interior_halfspace
+    _ = { y | 0 < y 0 } := interior_halfspace _ _ _
 
-lemma frontier_range_modelWithCornersEuclideanHalfSpace (n : ℕ) [Zero (Fin n)] :
+lemma frontier_range_modelWithCornersEuclideanHalfSpace (n : ℕ) [NeZero n] :
     frontier (range (𝓡∂ n)) = { y | 0 = y 0 } := by
   calc frontier (range (𝓡∂ n))
     _ = frontier ({ y | 0 ≤ y 0 }) := by
       congr!
       apply range_euclideanHalfSpace
-    _ = { y | 0 = y 0 } := frontier_halfspace (p := 2)
+    _ = { y | 0 = y 0 } := frontier_halfspace 2 _ _
 
 /-- The left chart for the topological space `[x, y]`, defined on `[x,y)` and sending `x` to `0` in
 `EuclideanHalfSpace 1`.

--- a/Mathlib/Geometry/Manifold/Instances/Real.lean
+++ b/Mathlib/Geometry/Manifold/Instances/Real.lean
@@ -98,14 +98,14 @@ theorem interior_halfspace {n : ℕ} {p : ℝ≥0∞} {a : ℝ} {i : Fin n} :
 
 open ENNReal in
 theorem closure_halfspace {n : ℕ} {p : ℝ≥0∞} {a : ℝ} {i : Fin n} :
-    closure { y : EuclideanSpace ℝ (Fin n) | a ≤ y i } = { y | a ≤ y i } := by
+    closure { y : PiLp p (fun _ : Fin n ↦ ℝ) | a ≤ y i } = { y | a ≤ y i } := by
   let f : PiLp p (fun _ : Fin n ↦ ℝ) →L[ℝ] ℝ := ContinuousLinearMap.proj i
   simpa [closure_Ici] using f.closure_preimage (Function.surjective_eval _) (Ici a)
 
 open ENNReal in
 theorem frontier_halfspace {n : ℕ} {p : ℝ≥0∞} {a : ℝ} {i : Fin n} :
-    frontier { y : EuclideanSpace ℝ (Fin n) | a ≤ y i } = { y | a = y i } := by
-  rw [frontier, closure_halfspace (p := p), interior_halfspace]
+    frontier { y : PiLp p (fun _ : Fin n ↦ ℝ) | a ≤ y i } = { y | a = y i } := by
+  rw [frontier, closure_halfspace, interior_halfspace]
   ext y
   simpa only [mem_diff, mem_setOf_eq, not_lt] using antisymm_iff
 


### PR DESCRIPTION
Preparatory lemmas towards proving that the real interval $[x,y]$ has boundary {x,y} as a smooth manifold.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
