### PR TITLE
[Merged by Bors] - feat: the lambdaSyntax linter

### DIFF
--- a/Mathlib/Tactic/Linter/Lint.lean
+++ b/Mathlib/Tactic/Linter/Lint.lean
@@ -30,7 +30,7 @@ Linter that checks whether a structure should be in Prop.
     -- remark: using `Lean.Meta.isProp` doesn't suffice here, because it doesn't (always?)
     -- recognize predicates as propositional.
     let isProp ← forallTelescopeReducing (← inferType (← mkConstWithLevelParams declName))
-      fun _ ty => return ty == .sort .zero
+      fun _ ty ↦ return ty == .sort .zero
     if isProp then return none
     let projs := (getStructureInfo? (← getEnv) declName).get!.fieldNames
     if projs.isEmpty then return none -- don't flag empty structures
@@ -87,18 +87,18 @@ def getIds : Syntax → Array Syntax
   | .node _ `Batteries.Tactic.Alias.alias args => args[2:3]
   | .node _ ``Lean.Parser.Command.export args => (args[3:4] : Array Syntax).map (·[0])
   | stx@(.node _ _ args) =>
-    ((args.attach.map fun ⟨a, _⟩ => getIds a).foldl (· ++ ·) #[stx]).filter (·.getKind == ``declId)
+    ((args.attach.map fun ⟨a, _⟩ ↦ getIds a).foldl (· ++ ·) #[stx]).filter (·.getKind == ``declId)
   | _ => default
 
 @[inherit_doc linter.dupNamespace]
-def dupNamespace : Linter where run := withSetOptionIn fun stx => do
+def dupNamespace : Linter where run := withSetOptionIn fun stx ↦ do
   if Linter.getLinterValue linter.dupNamespace (← getOptions) then
     match getIds stx with
       | #[id] =>
         let ns := (← getScope).currNamespace
         let declName := ns ++ (if id.getKind == ``declId then id[0].getId else id.getId)
         let nm := declName.components
-        let some (dup, _) := nm.zip (nm.tailD []) |>.find? fun (x, y) => x == y
+        let some (dup, _) := nm.zip (nm.tailD []) |>.find? fun (x, y) ↦ x == y
           | return
         Linter.logLint linter.dupNamespace id
           m!"The namespace '{dup}' is duplicated in the declaration '{declName}'"
@@ -182,7 +182,7 @@ def findCDot : Syntax → Array Syntax
   | stx@(.node _ kind args) =>
     let dargs := (args.map findCDot).flatten
     match kind with
-      | ``Lean.Parser.Term.cdot | ``cdotTk=> dargs.push stx
+      | ``Lean.Parser.Term.cdot | ``cdotTk => dargs.push stx
       | _ =>  dargs
   |_ => #[]
 
@@ -196,7 +196,7 @@ def unwanted_cdot (stx : Syntax) : Array Syntax :=
 namespace CDotLinter
 
 @[inherit_doc linter.cdot]
-def cdotLinter : Linter where run := withSetOptionIn fun stx => do
+def cdotLinter : Linter where run := withSetOptionIn fun stx ↦ do
     unless Linter.getLinterValue linter.cdot (← getOptions) do
       return
     if (← MonadState.get).messages.hasErrors then
@@ -325,7 +325,7 @@ def longLineLinter : Linter where run := withSetOptionIn fun stx ↦ do
       else return stx
     let sstr := stx.getSubstring?
     let fm ← getFileMap
-    let longLines := ((sstr.getD default).splitOn "\n").filter fun line =>
+    let longLines := ((sstr.getD default).splitOn "\n").filter fun line ↦
       (100 < (fm.toPosition line.stopPos).column)
     for line in longLines do
       if !(line.containsSubstr "http") then

--- a/Mathlib/Tactic/Linter/Lint.lean
+++ b/Mathlib/Tactic/Linter/Lint.lean
@@ -268,7 +268,7 @@ namespace LambdaSyntaxLinter
 /--
 `findLambdaSyntax stx` extracts from `stx` all syntax nodes of `kind` `Term.fun`. -/
 partial
-def findLambdaSyntax : Syntax → Array Syntax
+def findLambdaSyntax : Syntax → Array (Syntax)
   | stx@(.node _ kind args) =>
     let dargs := (args.map findLambdaSyntax).flatten
     match kind with
@@ -282,12 +282,10 @@ def lambdaSyntaxLinter : Linter where run := withSetOptionIn fun stx ↦ do
       return
     if (← MonadState.get).messages.hasErrors then
       return
-
     for s in findLambdaSyntax stx do
-      -- XXX: find a better way to extract the actual syntax used...
-      if s!"{s.getArgs[0]!}" == "\"λ\"" then
-        Linter.logLint linter.lambdaSyntax s m!"
-        Please use 'fun' and not λ to define anonymous functions.\
+      if let .atom _ "λ" := s.getArgs[0]! then
+        Linter.logLint linter.lambdaSyntax s m!"\
+        Please use 'fun' and not 'λ' to define anonymous functions.\n\
         The latter syntax has been deprecated in mathlib 4."
 
 initialize addLinter lambdaSyntaxLinter

--- a/Mathlib/Tactic/Linter/Lint.lean
+++ b/Mathlib/Tactic/Linter/Lint.lean
@@ -263,7 +263,7 @@ register_option linter.style.lambdaSyntax : Bool := {
   descr := "enable the `lambdaSyntax` linter"
 }
 
-namespace Style.lambdaSyntaxLinter
+namespace Style.lambdaSyntax
 
 /--
 `findLambdaSyntax stx` extracts from `stx` all syntax nodes of `kind` `Term.fun`. -/
@@ -290,7 +290,7 @@ def lambdaSyntaxLinter : Linter where run := withSetOptionIn fun stx ↦ do
 
 initialize addLinter lambdaSyntaxLinter
 
-end Style.lambdaSyntaxLinter
+end Style.lambdaSyntax
 
 /-! # The "longLine linter" -/
 

--- a/Mathlib/Tactic/Linter/Lint.lean
+++ b/Mathlib/Tactic/Linter/Lint.lean
@@ -263,7 +263,7 @@ register_option linter.lambdaSyntax : Bool := {
   descr := "enable the `lambdaSyntax` linter"
 }
 
-namespace lambdaSyntaxLinter
+namespace LambdaSyntaxLinter
 
 /--
 `findLambdaSyntax stx` extracts from `stx` all syntax nodes of `kind` `Term.fun`. -/
@@ -276,6 +276,7 @@ def findLambdaSyntax : Syntax → Array Syntax
       | _ =>  dargs
   |_ => #[]
 
+@[inherit_doc linter.lambdaSyntax]
 def lambdaSyntaxLinter : Linter where run := withSetOptionIn fun stx ↦ do
     unless Linter.getLinterValue linter.lambdaSyntax (← getOptions) do
       return
@@ -283,7 +284,7 @@ def lambdaSyntaxLinter : Linter where run := withSetOptionIn fun stx ↦ do
       return
 
     for s in findLambdaSyntax stx do
-      -- XXX: find a better way to extract the syntax...
+      -- XXX: find a better way to extract the actual syntax used...
       if s!"{s.getArgs[0]!}" == "\"λ\"" then
         Linter.logLint linter.lambdaSyntax s m!"
         Please use 'fun' and not λ to define anonymous functions.\
@@ -291,7 +292,7 @@ def lambdaSyntaxLinter : Linter where run := withSetOptionIn fun stx ↦ do
 
 initialize addLinter lambdaSyntaxLinter
 
-end lambdaSyntaxLinter
+end LambdaSyntaxLinter
 
 /-! # The "longLine linter" -/
 

--- a/Mathlib/Tactic/Linter/Lint.lean
+++ b/Mathlib/Tactic/Linter/Lint.lean
@@ -258,17 +258,17 @@ prefers the latter as it is considered more readable.
 /--
 The `lambdaSyntax` linter flags uses of the symbol `λ` to define anonymous functions.
 This is syntactically equivalent to the `fun` keyword; mathlib style prefers using the latter.-/
-register_option linter.lambdaSyntax : Bool := {
+register_option linter.style.lambdaSyntax : Bool := {
   defValue := false
   descr := "enable the `lambdaSyntax` linter"
 }
 
-namespace LambdaSyntaxLinter
+namespace Style.lambdaSyntaxLinter
 
 /--
 `findLambdaSyntax stx` extracts from `stx` all syntax nodes of `kind` `Term.fun`. -/
 partial
-def findLambdaSyntax : Syntax → Array (Syntax)
+def findLambdaSyntax : Syntax → Array Syntax
   | stx@(.node _ kind args) =>
     let dargs := (args.map findLambdaSyntax).flatten
     match kind with
@@ -276,21 +276,21 @@ def findLambdaSyntax : Syntax → Array (Syntax)
       | _ =>  dargs
   |_ => #[]
 
-@[inherit_doc linter.lambdaSyntax]
+@[inherit_doc linter.style.lambdaSyntax]
 def lambdaSyntaxLinter : Linter where run := withSetOptionIn fun stx ↦ do
-    unless Linter.getLinterValue linter.lambdaSyntax (← getOptions) do
+    unless Linter.getLinterValue linter.style.lambdaSyntax (← getOptions) do
       return
     if (← MonadState.get).messages.hasErrors then
       return
     for s in findLambdaSyntax stx do
       if let .atom _ "λ" := s.getArgs[0]! then
-        Linter.logLint linter.lambdaSyntax s m!"\
+        Linter.logLint linter.style.lambdaSyntax s m!"\
         Please use 'fun' and not 'λ' to define anonymous functions.\n\
         The latter syntax has been deprecated in mathlib 4."
 
 initialize addLinter lambdaSyntaxLinter
 
-end LambdaSyntaxLinter
+end Style.lambdaSyntaxLinter
 
 /-! # The "longLine linter" -/
 

--- a/Mathlib/Tactic/Linter/Lint.lean
+++ b/Mathlib/Tactic/Linter/Lint.lean
@@ -259,7 +259,7 @@ prefers the latter as it is considered more readable.
 The `lambdaSyntax` linter flags uses of the symbol `λ` to define anonymous functions.
 This is syntactically equivalent to the `fun` keyword; mathlib style prefers using the latter.-/
 register_option linter.lambdaSyntax : Bool := {
-  defValue := true
+  defValue := false
   descr := "enable the `lambdaSyntax` linter"
 }
 

--- a/Mathlib/Tactic/Linter/Lint.lean
+++ b/Mathlib/Tactic/Linter/Lint.lean
@@ -285,7 +285,7 @@ def lambdaSyntaxLinter : Linter where run := withSetOptionIn fun stx ↦ do
       return
     for s in findLambdaSyntax stx do
       if let .atom _ "λ" := s[0] then
-        Linter.logLint linter.style.lambdaSyntax s m!"\
+        Linter.logLint linter.style.lambdaSyntax s[0] m!"\
         Please use 'fun' and not 'λ' to define anonymous functions.\n\
         The 'λ' syntax is deprecated in mathlib4."
 

--- a/Mathlib/Tactic/Linter/Lint.lean
+++ b/Mathlib/Tactic/Linter/Lint.lean
@@ -273,7 +273,7 @@ def findLambdaSyntax : Syntax → Array Syntax
   | stx@(.node _ kind args) =>
     let dargs := (args.map findLambdaSyntax).flatten
     match kind with
-      | ``Parser.Term.fun => dargs.push stx[0]
+      | ``Parser.Term.fun => dargs.push stx
       | _ =>  dargs
   |_ => #[]
 
@@ -284,10 +284,10 @@ def lambdaSyntaxLinter : Linter where run := withSetOptionIn fun stx ↦ do
     if (← MonadState.get).messages.hasErrors then
       return
     for s in findLambdaSyntax stx do
-      if let .atom _ "λ" := s then
+      if let .atom _ "λ" := s[0] then
         Linter.logLint linter.style.lambdaSyntax s m!"\
         Please use 'fun' and not 'λ' to define anonymous functions.\n\
-        The 'λ'-syntax is deprecated in mathlib4."
+        The 'λ' syntax is deprecated in mathlib4."
 
 initialize addLinter lambdaSyntaxLinter
 

--- a/Mathlib/Tactic/Linter/Lint.lean
+++ b/Mathlib/Tactic/Linter/Lint.lean
@@ -257,7 +257,8 @@ prefers the latter as it is considered more readable.
 
 /--
 The `lambdaSyntax` linter flags uses of the symbol `λ` to define anonymous functions.
-This is syntactically equivalent to the `fun` keyword; mathlib style prefers using the latter.-/
+This is syntactically equivalent to the `fun` keyword; mathlib style prefers using the latter.
+-/
 register_option linter.style.lambdaSyntax : Bool := {
   defValue := false
   descr := "enable the `lambdaSyntax` linter"
@@ -272,7 +273,7 @@ def findLambdaSyntax : Syntax → Array Syntax
   | stx@(.node _ kind args) =>
     let dargs := (args.map findLambdaSyntax).flatten
     match kind with
-      | ``Parser.Term.fun => dargs.push stx
+      | ``Parser.Term.fun => dargs.push stx[0]
       | _ =>  dargs
   |_ => #[]
 
@@ -283,10 +284,10 @@ def lambdaSyntaxLinter : Linter where run := withSetOptionIn fun stx ↦ do
     if (← MonadState.get).messages.hasErrors then
       return
     for s in findLambdaSyntax stx do
-      if let .atom _ "λ" := s.getArgs[0]! then
+      if let .atom _ "λ" := s then
         Linter.logLint linter.style.lambdaSyntax s m!"\
         Please use 'fun' and not 'λ' to define anonymous functions.\n\
-        The latter syntax has been deprecated in mathlib 4."
+        The 'λ'-syntax is deprecated in mathlib4."
 
 initialize addLinter lambdaSyntaxLinter
 

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -11,7 +11,7 @@ abbrev mathlibOnlyLinters : Array LeanOption := #[
   ⟨`linter.hashCommand, true⟩,
   ⟨`linter.missingEnd, true⟩,
   ⟨`linter.cdot, true⟩,
-  ⟨`linter.lambdaSyntax, true⟩,
+  ⟨`linter.style.lambdaSyntax, true⟩,
   ⟨`linter.longLine, true⟩,
   ⟨`linter.oldObtain, true,⟩,
   ⟨`linter.refine, true⟩,

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -11,6 +11,7 @@ abbrev mathlibOnlyLinters : Array LeanOption := #[
   ⟨`linter.hashCommand, true⟩,
   ⟨`linter.missingEnd, true⟩,
   ⟨`linter.cdot, true⟩,
+  ⟨`linter.lambdaSyntax, true⟩,
   ⟨`linter.longLine, true⟩,
   ⟨`linter.oldObtain, true,⟩,
   ⟨`linter.refine, true⟩,

--- a/test/Lint.lean
+++ b/test/Lint.lean
@@ -107,24 +107,24 @@ instance (f g : Nat → Nat) : Inhabited Nat where
 
 section lambdaSyntaxLinter
 
-set_option linter.lambdaSyntax false
+set_option linter.style.lambdaSyntax false
 
 /--
 warning: Please use 'fun' and not 'λ' to define anonymous functions.
 The latter syntax has been deprecated in mathlib 4.
-note: this linter can be disabled with `set_option linter.lambdaSyntax false`
+note: this linter can be disabled with `set_option linter.style.lambdaSyntax false`
 -/
 #guard_msgs in
-set_option linter.lambdaSyntax true in
+set_option linter.style.lambdaSyntax true in
 example : ℕ → ℕ := λ _ ↦ 0
 
 /--
 warning: Please use 'fun' and not 'λ' to define anonymous functions.
 The latter syntax has been deprecated in mathlib 4.
-note: this linter can be disabled with `set_option linter.lambdaSyntax false`
+note: this linter can be disabled with `set_option linter.style.lambdaSyntax false`
 -/
 #guard_msgs in
-set_option linter.lambdaSyntax true in
+set_option linter.style.lambdaSyntax true in
 def foo : Bool := by
   let _f : ℕ → ℕ := λ _ ↦ 0
   exact true
@@ -134,10 +134,10 @@ example : ℕ → ℕ := fun n ↦ n - 1
 /--
 warning: Please use 'fun' and not 'λ' to define anonymous functions.
 The latter syntax has been deprecated in mathlib 4.
-note: this linter can be disabled with `set_option linter.lambdaSyntax false`
+note: this linter can be disabled with `set_option linter.style.lambdaSyntax false`
 -/
 #guard_msgs in
-set_option linter.lambdaSyntax true in
+set_option linter.style.lambdaSyntax true in
 example : ℕ → ℕ := by exact λ n ↦ 3 * n + 1
 
 /--
@@ -145,18 +145,18 @@ warning: declaration uses 'sorry'
 ---
 warning: Please use 'fun' and not 'λ' to define anonymous functions.
 The latter syntax has been deprecated in mathlib 4.
-note: this linter can be disabled with `set_option linter.lambdaSyntax false`
+note: this linter can be disabled with `set_option linter.style.lambdaSyntax false`
 ---
 warning: Please use 'fun' and not 'λ' to define anonymous functions.
 The latter syntax has been deprecated in mathlib 4.
-note: this linter can be disabled with `set_option linter.lambdaSyntax false`
+note: this linter can be disabled with `set_option linter.style.lambdaSyntax false`
 ---
 warning: Please use 'fun' and not 'λ' to define anonymous functions.
 The latter syntax has been deprecated in mathlib 4.
-note: this linter can be disabled with `set_option linter.lambdaSyntax false`
+note: this linter can be disabled with `set_option linter.style.lambdaSyntax false`
 -/
 #guard_msgs in
-set_option linter.lambdaSyntax true in
+set_option linter.style.lambdaSyntax true in
 example : ℕ → ℕ → ℕ → ℕ := by
   have (n : ℕ) : True := trivial
   have : (Set.univ : Set ℕ) = ⋃ (i : ℕ), (Set.iUnion λ j ↦ ({0, j} : Set ℕ)) := sorry
@@ -166,18 +166,18 @@ example : ℕ → ℕ → ℕ → ℕ := by
 /--
 warning: Please use 'fun' and not 'λ' to define anonymous functions.
 The latter syntax has been deprecated in mathlib 4.
-note: this linter can be disabled with `set_option linter.lambdaSyntax false`
+note: this linter can be disabled with `set_option linter.style.lambdaSyntax false`
 ---
 warning: Please use 'fun' and not 'λ' to define anonymous functions.
 The latter syntax has been deprecated in mathlib 4.
-note: this linter can be disabled with `set_option linter.lambdaSyntax false`
+note: this linter can be disabled with `set_option linter.style.lambdaSyntax false`
 ---
 warning: Please use 'fun' and not 'λ' to define anonymous functions.
 The latter syntax has been deprecated in mathlib 4.
-note: this linter can be disabled with `set_option linter.lambdaSyntax false`
+note: this linter can be disabled with `set_option linter.style.lambdaSyntax false`
 -/
 #guard_msgs in
-set_option linter.lambdaSyntax true in
+set_option linter.style.lambdaSyntax true in
 example : True := by
   have : 0 = 0 ∧ 0 = 0 ∧ 1 + 3 = 4 := by
     refine ⟨by trivial, by
@@ -196,15 +196,15 @@ example : True := by
 /--
 warning: Please use 'fun' and not 'λ' to define anonymous functions.
 The latter syntax has been deprecated in mathlib 4.
-note: this linter can be disabled with `set_option linter.lambdaSyntax false`
+note: this linter can be disabled with `set_option linter.style.lambdaSyntax false`
 -/
 #guard_msgs in
-set_option linter.lambdaSyntax true in
-example : ℕ → ℕ := set_option linter.lambdaSyntax false in λ _ ↦ 0
+set_option linter.style.lambdaSyntax true in
+example : ℕ → ℕ := set_option linter.style.lambdaSyntax false in λ _ ↦ 0
 
-set_option linter.lambdaSyntax false
+set_option linter.style.lambdaSyntax false
 #guard_msgs in
-example : ℕ → ℕ := set_option linter.lambdaSyntax true in λ _ ↦ 0
+example : ℕ → ℕ := set_option linter.style.lambdaSyntax true in λ _ ↦ 0
 
 end lambdaSyntaxLinter
 

--- a/test/Lint.lean
+++ b/test/Lint.lean
@@ -109,8 +109,8 @@ section lambdaSyntaxLinter
 set_option linter.lambdaSyntax false
 
 /--
-warning:
-        Please use 'fun' and not λ to define anonymous functions.The latter syntax has been deprecated in mathlib 4.
+warning: Please use 'fun' and not 'λ' to define anonymous functions.
+The latter syntax has been deprecated in mathlib 4.
 note: this linter can be disabled with `set_option linter.lambdaSyntax false`
 -/
 #guard_msgs in
@@ -118,8 +118,8 @@ set_option linter.lambdaSyntax true in
 example : ℕ → ℕ := λ _ ↦ 0
 
 /--
-warning:
-        Please use 'fun' and not λ to define anonymous functions.The latter syntax has been deprecated in mathlib 4.
+warning: Please use 'fun' and not 'λ' to define anonymous functions.
+The latter syntax has been deprecated in mathlib 4.
 note: this linter can be disabled with `set_option linter.lambdaSyntax false`
 -/
 #guard_msgs in

--- a/test/Lint.lean
+++ b/test/Lint.lean
@@ -1,5 +1,6 @@
 import Mathlib.Tactic.Linter.Lint
 import Mathlib.Tactic.ToAdditive
+import Mathlib.Order.SetNotation
 
 -- TODO: the linter also runs on the #guard_msg, so disable it once
 -- See https://leanprover.zulipchat.com/#narrow/stream/348111-std4/topic/.23guard_msgs.20doesn't.20silence.20warnings/near/423534679
@@ -130,9 +131,80 @@ def foo : Bool := by
 
 example : ℕ → ℕ := fun n ↦ n - 1
 
+/--
+warning: Please use 'fun' and not 'λ' to define anonymous functions.
+The latter syntax has been deprecated in mathlib 4.
+note: this linter can be disabled with `set_option linter.lambdaSyntax false`
+-/
+#guard_msgs in
+set_option linter.lambdaSyntax true in
+example : ℕ → ℕ := by exact λ n ↦ 3 * n + 1
+
+/--
+warning: declaration uses 'sorry'
+---
+warning: Please use 'fun' and not 'λ' to define anonymous functions.
+The latter syntax has been deprecated in mathlib 4.
+note: this linter can be disabled with `set_option linter.lambdaSyntax false`
+---
+warning: Please use 'fun' and not 'λ' to define anonymous functions.
+The latter syntax has been deprecated in mathlib 4.
+note: this linter can be disabled with `set_option linter.lambdaSyntax false`
+---
+warning: Please use 'fun' and not 'λ' to define anonymous functions.
+The latter syntax has been deprecated in mathlib 4.
+note: this linter can be disabled with `set_option linter.lambdaSyntax false`
+-/
+#guard_msgs in
+set_option linter.lambdaSyntax true in
+example : ℕ → ℕ → ℕ → ℕ := by
+  have (n : ℕ) : True := trivial
+  have : (Set.univ : Set ℕ) = ⋃ (i : ℕ), (Set.iUnion λ j ↦ ({0, j} : Set ℕ)) := sorry
+  have : ∃ m : ℕ, ⋃ i : ℕ, (Set.univ : Set ℕ) = ∅ := sorry
+  exact λ _a ↦ fun _b ↦ λ _c ↦ 0
+
+/--
+warning: Please use 'fun' and not 'λ' to define anonymous functions.
+The latter syntax has been deprecated in mathlib 4.
+note: this linter can be disabled with `set_option linter.lambdaSyntax false`
+---
+warning: Please use 'fun' and not 'λ' to define anonymous functions.
+The latter syntax has been deprecated in mathlib 4.
+note: this linter can be disabled with `set_option linter.lambdaSyntax false`
+---
+warning: Please use 'fun' and not 'λ' to define anonymous functions.
+The latter syntax has been deprecated in mathlib 4.
+note: this linter can be disabled with `set_option linter.lambdaSyntax false`
+-/
+#guard_msgs in
+set_option linter.lambdaSyntax true in
 example : True := by
-  let _g : ℕ → ℕ := fun n ↦ 3 * n + 1
+  have : 0 = 0 ∧ 0 = 0 ∧ 1 + 3 = 4 := by
+    refine ⟨by trivial, by
+      let _f := λ n : ℕ ↦ 0;
+      have : ℕ := by
+        · -- comment
+          · have := λ k : ℕ ↦ -5
+            · exact 0
+      refine ⟨by trivial, have := λ k : ℕ ↦ -5; by simp⟩
+      ⟩
   trivial
+
+-- Code such as the following would require walking the infotree instead:
+-- the inner set_option is ignore (in either direction).
+-- As this seems unlikely to occur by accident and its use is dubious, we don't worry about this.
+/--
+warning: Please use 'fun' and not 'λ' to define anonymous functions.
+The latter syntax has been deprecated in mathlib 4.
+note: this linter can be disabled with `set_option linter.lambdaSyntax false`
+-/
+#guard_msgs in
+set_option linter.lambdaSyntax true in
+example : ℕ → ℕ := set_option linter.lambdaSyntax false in λ _ ↦ 0
+
+set_option linter.lambdaSyntax false
+#guard_msgs in
+example : ℕ → ℕ := set_option linter.lambdaSyntax true in λ _ ↦ 0
 
 end lambdaSyntaxLinter
 

--- a/test/Lint.lean
+++ b/test/Lint.lean
@@ -104,6 +104,55 @@ instance (f g : Nat → Nat) : Inhabited Nat where
       · have : Nat := f $ g $ 0
         · exact 0
 
+section lambdaSyntaxLinter
+
+set_option linter.lambdaSyntax false
+
+/--
+warning:
+        Please use 'fun' and not λ to define anonymous functions.The latter syntax has been deprecated in mathlib 4.
+note: this linter can be disabled with `set_option linter.lambdaSyntax false`
+-/
+#guard_msgs in
+set_option linter.lambdaSyntax true in
+example : ℕ → ℕ := λ _ ↦ 0
+
+/--
+warning:
+        Please use 'fun' and not λ to define anonymous functions.The latter syntax has been deprecated in mathlib 4.
+note: this linter can be disabled with `set_option linter.lambdaSyntax false`
+-/
+#guard_msgs in
+set_option linter.lambdaSyntax true in
+def foo : Bool := by
+  let _f : ℕ → ℕ := λ _ ↦ 0
+  exact true
+
+example : ℕ → ℕ := fun n ↦ n - 1
+
+example : True := by
+  let _g : ℕ → ℕ := fun n ↦ 3 * n + 1
+  trivial
+
+end lambdaSyntaxLinter
+
+set_option linter.dollarSyntax false in
+/--
+warning: Please use '<|' instead of '$' for the pipe operator.
+note: this linter can be disabled with `set_option linter.dollarSyntax false`
+---
+warning: Please use '<|' instead of '$' for the pipe operator.
+note: this linter can be disabled with `set_option linter.dollarSyntax false`
+-/
+#guard_msgs in
+set_option linter.dollarSyntax true in
+attribute [instance] Int.add in
+instance (f g : Nat → Nat) : Inhabited Nat where
+  default := by
+    · have := 0
+      · have : Nat := f $ g $ 0
+        · exact 0
+
 set_option linter.longLine false
 /--
 warning: This line exceeds the 100 character limit, please shorten it!

--- a/test/Lint.lean
+++ b/test/Lint.lean
@@ -111,7 +111,7 @@ set_option linter.style.lambdaSyntax false
 
 /--
 warning: Please use 'fun' and not 'λ' to define anonymous functions.
-The latter syntax has been deprecated in mathlib 4.
+The 'λ' syntax is deprecated in mathlib4.
 note: this linter can be disabled with `set_option linter.style.lambdaSyntax false`
 -/
 #guard_msgs in
@@ -120,7 +120,7 @@ example : ℕ → ℕ := λ _ ↦ 0
 
 /--
 warning: Please use 'fun' and not 'λ' to define anonymous functions.
-The latter syntax has been deprecated in mathlib 4.
+The 'λ' syntax is deprecated in mathlib4.
 note: this linter can be disabled with `set_option linter.style.lambdaSyntax false`
 -/
 #guard_msgs in
@@ -133,7 +133,7 @@ example : ℕ → ℕ := fun n ↦ n - 1
 
 /--
 warning: Please use 'fun' and not 'λ' to define anonymous functions.
-The latter syntax has been deprecated in mathlib 4.
+The 'λ' syntax is deprecated in mathlib4.
 note: this linter can be disabled with `set_option linter.style.lambdaSyntax false`
 -/
 #guard_msgs in
@@ -144,15 +144,15 @@ example : ℕ → ℕ := by exact λ n ↦ 3 * n + 1
 warning: declaration uses 'sorry'
 ---
 warning: Please use 'fun' and not 'λ' to define anonymous functions.
-The latter syntax has been deprecated in mathlib 4.
+The 'λ' syntax is deprecated in mathlib4.
 note: this linter can be disabled with `set_option linter.style.lambdaSyntax false`
 ---
 warning: Please use 'fun' and not 'λ' to define anonymous functions.
-The latter syntax has been deprecated in mathlib 4.
+The 'λ' syntax is deprecated in mathlib4.
 note: this linter can be disabled with `set_option linter.style.lambdaSyntax false`
 ---
 warning: Please use 'fun' and not 'λ' to define anonymous functions.
-The latter syntax has been deprecated in mathlib 4.
+The 'λ' syntax is deprecated in mathlib4.
 note: this linter can be disabled with `set_option linter.style.lambdaSyntax false`
 -/
 #guard_msgs in
@@ -165,15 +165,15 @@ example : ℕ → ℕ → ℕ → ℕ := by
 
 /--
 warning: Please use 'fun' and not 'λ' to define anonymous functions.
-The latter syntax has been deprecated in mathlib 4.
+The 'λ' syntax is deprecated in mathlib4.
 note: this linter can be disabled with `set_option linter.style.lambdaSyntax false`
 ---
 warning: Please use 'fun' and not 'λ' to define anonymous functions.
-The latter syntax has been deprecated in mathlib 4.
+The 'λ' syntax is deprecated in mathlib4.
 note: this linter can be disabled with `set_option linter.style.lambdaSyntax false`
 ---
 warning: Please use 'fun' and not 'λ' to define anonymous functions.
-The latter syntax has been deprecated in mathlib 4.
+The 'λ' syntax is deprecated in mathlib4.
 note: this linter can be disabled with `set_option linter.style.lambdaSyntax false`
 -/
 #guard_msgs in
@@ -195,7 +195,7 @@ example : True := by
 -- As this seems unlikely to occur by accident and its use is dubious, we don't worry about this.
 /--
 warning: Please use 'fun' and not 'λ' to define anonymous functions.
-The latter syntax has been deprecated in mathlib 4.
+The 'λ' syntax is deprecated in mathlib4.
 note: this linter can be disabled with `set_option linter.style.lambdaSyntax false`
 -/
 #guard_msgs in


### PR DESCRIPTION
The mathlib style guide states clearly that using \lambda for anonymous functions is disallowed, and the fun keyword is preferred. This linter enforces this.

---

I have decided to call the linter option `linter.style.lambdaSyntax`, fareshadowing the analogous renaming of options in #15971.
This linter is actually pretty simple: most of this PR are detailed tests.

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
