### PR TITLE
[Merged by Bors] - feat(ModelTheory): More general ways of deriving `DecidableEq` for logic symbols

### DIFF
--- a/Mathlib/ModelTheory/Algebra/Ring/Basic.lean
+++ b/Mathlib/ModelTheory/Algebra/Ring/Basic.lean
@@ -64,6 +64,14 @@ namespace Ring
 
 open ringFunc Language
 
+/-- This instance does not get inferred without `instDecidableEqFunctions` in
+`ModelTheory/Basic`. -/
+example (n : ℕ) : DecidableEq (Language.ring.Functions n) := inferInstance
+
+/-- This instance does not get inferred without `instDecidableEqRelations` in
+`ModelTheory/Basic`. -/
+example (n : ℕ) : DecidableEq (Language.ring.Relations n) := inferInstance
+
 /-- `RingFunc.add`, but with the defeq type `Language.ring.Functions 2` instead
 of `RingFunc 2` -/
 abbrev addFunc : Language.ring.Functions 2 := add

--- a/Mathlib/ModelTheory/Algebra/Ring/Basic.lean
+++ b/Mathlib/ModelTheory/Algebra/Ring/Basic.lean
@@ -64,12 +64,6 @@ namespace Ring
 
 open ringFunc Language
 
-instance (n : ℕ) : DecidableEq (Language.ring.Functions n) := by
-  dsimp [Language.ring]; infer_instance
-
-instance (n : ℕ) : DecidableEq (Language.ring.Relations n) := by
-  dsimp [Language.ring]; infer_instance
-
 /-- `RingFunc.add`, but with the defeq type `Language.ring.Functions 2` instead
 of `RingFunc 2` -/
 abbrev addFunc : Language.ring.Functions 2 := add

--- a/Mathlib/ModelTheory/Basic.lean
+++ b/Mathlib/ModelTheory/Basic.lean
@@ -250,9 +250,15 @@ theorem card_mk₂ (c f₁ f₂ : Type u) (r₁ r₂ : Type v) :
           Cardinal.lift.{u} #r₁ + Cardinal.lift.{u} #r₂ := by
   simp [card_eq_card_functions_add_card_relations, add_assoc]
 
-instance {f : ℕ → Type*} {R : ℕ → Type*} (n : ℕ) [DecidableEq (f n)] :
+/-- Passes a `DecidableEq` instance on a type of function symbols through the  `Language`
+constructor. Despite the fact that this is proven by `inferInstance`, it is still needed -
+see the `example`s in `ModelTheory/Ring/Basic`.  -/
+instance instDecidableEqFunctions {f : ℕ → Type*} {R : ℕ → Type*} (n : ℕ) [DecidableEq (f n)] :
     DecidableEq ((⟨f, R⟩ : Language).Functions n) := inferInstance
 
+/-- Passes a `DecidableEq` instance on a type of relation symbols through the  `Language`
+constructor. Despite the fact that this is proven by `inferInstance`, it is still needed -
+see the `example`s in `ModelTheory/Ring/Basic`.  -/
 instance {f : ℕ → Type*} {R : ℕ → Type*} (n : ℕ) [DecidableEq (R n)] :
     DecidableEq ((⟨f, R⟩ : Language).Relations n) := inferInstance
 

--- a/Mathlib/ModelTheory/Basic.lean
+++ b/Mathlib/ModelTheory/Basic.lean
@@ -255,7 +255,7 @@ instance instDecidableEqFunctions {f : ℕ → Type*} {R : ℕ → Type*} (n : �
 /-- Passes a `DecidableEq` instance on a type of relation symbols through the  `Language`
 constructor. Despite the fact that this is proven by `inferInstance`, it is still needed -
 see the `example`s in `ModelTheory/Ring/Basic`.  -/
-instance {f : ℕ → Type*} {R : ℕ → Type*} (n : ℕ) [DecidableEq (R n)] :
+instance instDecidableEqRelations {f : ℕ → Type*} {R : ℕ → Type*} (n : ℕ) [DecidableEq (R n)] :
     DecidableEq ((⟨f, R⟩ : Language).Relations n) := inferInstance
 
 variable (L) (M : Type w)

--- a/Mathlib/ModelTheory/Basic.lean
+++ b/Mathlib/ModelTheory/Basic.lean
@@ -81,6 +81,16 @@ instance inhabited₂ [h : Inhabited a₂] : Inhabited (Sequence₂ a₀ a₁ a�
 
 instance {n : ℕ} : IsEmpty (Sequence₂ a₀ a₁ a₂ (n + 3)) := inferInstanceAs (IsEmpty PEmpty)
 
+instance [DecidableEq a₀] [DecidableEq a₁] [DecidableEq a₂] {n : ℕ} :
+    DecidableEq (Sequence₂ a₀ a₁ a₂ n) := by
+  cases n with
+  | zero => infer_instance
+  | succ n => cases n with
+    | zero => infer_instance
+    | succ n => cases n with
+      | zero => infer_instance
+      | succ n => infer_instance
+
 @[simp]
 theorem lift_mk {i : ℕ} :
     Cardinal.lift.{v,u} #(Sequence₂ a₀ a₁ a₂ i)
@@ -239,6 +249,12 @@ theorem card_mk₂ (c f₁ f₂ : Type u) (r₁ r₂ : Type v) :
       Cardinal.lift.{v} #c + Cardinal.lift.{v} #f₁ + Cardinal.lift.{v} #f₂ +
           Cardinal.lift.{u} #r₁ + Cardinal.lift.{u} #r₂ := by
   simp [card_eq_card_functions_add_card_relations, add_assoc]
+
+instance {f : ℕ → Type*} {R : ℕ → Type*} (n : ℕ) [DecidableEq (f n)] :
+    DecidableEq ((⟨f, R⟩ : Language).Functions n) := inferInstance
+
+instance {f : ℕ → Type*} {R : ℕ → Type*} (n : ℕ) [DecidableEq (R n)] :
+    DecidableEq ((⟨f, R⟩ : Language).Relations n) := inferInstance
 
 variable (L) (M : Type w)
 

--- a/Mathlib/ModelTheory/Basic.lean
+++ b/Mathlib/ModelTheory/Basic.lean
@@ -82,14 +82,10 @@ instance inhabited₂ [h : Inhabited a₂] : Inhabited (Sequence₂ a₀ a₁ a�
 instance {n : ℕ} : IsEmpty (Sequence₂ a₀ a₁ a₂ (n + 3)) := inferInstanceAs (IsEmpty PEmpty)
 
 instance [DecidableEq a₀] [DecidableEq a₁] [DecidableEq a₂] {n : ℕ} :
-    DecidableEq (Sequence₂ a₀ a₁ a₂ n) := by
-  cases n with
-  | zero => infer_instance
-  | succ n => cases n with
-    | zero => infer_instance
-    | succ n => cases n with
-      | zero => infer_instance
-      | succ n => infer_instance
+    DecidableEq (Sequence₂ a₀ a₁ a₂ n) :=
+  match n with
+  | 0 | 1 | 2 => ‹_›
+  | _ + 3 => inferInstance
 
 @[simp]
 theorem lift_mk {i : ℕ} :


### PR DESCRIPTION
Replaces two `DecidableEq` instances in `ModelTheory/Ring/Basic` with more general instances.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
