### PR TITLE
[Merged by Bors] - feat(Order/WellFounded): WellFoundedLT.toOrderBot

### DIFF
--- a/Mathlib/Order/WellFounded.lean
+++ b/Mathlib/Order/WellFounded.lean
@@ -291,4 +291,4 @@ noncomputable def WellFoundedLT.toOrderBot {α} [LinearOrder α] [Nonempty α] [
 noncomputable def WellFoundedGT.toOrderTop {α} [LinearOrder α] [Nonempty α] [WellFoundedGT α] :
     OrderTop α :=
   have := WellFoundedLT.toOrderBot (α := αᵒᵈ)
-  inferInstanceAs <| OrderTop (αᵒᵈᵒᵈ)
+  inferInstanceAs (OrderTop αᵒᵈᵒᵈ)

--- a/Mathlib/Order/WellFounded.lean
+++ b/Mathlib/Order/WellFounded.lean
@@ -284,12 +284,11 @@ end WellFoundedLT
 /-- A nonempty linear order with well-founded `<` has a bottom element. -/
 noncomputable def WellFoundedLT.toOrderBot {α} [LinearOrder α] [Nonempty α] [h : WellFoundedLT α] :
     OrderBot α where
-  bot := h.wf.min Set.univ Set.univ_nonempty
+  bot := h.wf.min _ Set.univ_nonempty
   bot_le a := h.wf.min_le (Set.mem_univ a)
 
 /-- A nonempty linear order with well-founded `>` has a top element. -/
 noncomputable def WellFoundedGT.toOrderTop {α} [LinearOrder α] [Nonempty α] [WellFoundedGT α] :
-    OrderTop α := by
-  change OrderTop (αᵒᵈᵒᵈ)
+    OrderTop α :=
   have := WellFoundedLT.toOrderBot (α := αᵒᵈ)
-  infer_instance
+  inferInstanceAs <| OrderTop (αᵒᵈᵒᵈ)

--- a/Mathlib/Order/WellFounded.lean
+++ b/Mathlib/Order/WellFounded.lean
@@ -288,7 +288,7 @@ noncomputable def WellFoundedLT.toOrderBot {α} [LinearOrder α] [Nonempty α] [
   bot_le a := h.wf.min_le (Set.mem_univ a)
 
 /-- A nonempty linear order with well-founded `>` has a top element. -/
-noncomputable def WellFoundedGT.toOrderTop {α} [LinearOrder α] [Nonempty α] [h : WellFoundedGT α] :
+noncomputable def WellFoundedGT.toOrderTop {α} [LinearOrder α] [Nonempty α] [WellFoundedGT α] :
     OrderTop α := by
   change OrderTop (αᵒᵈᵒᵈ)
   have := WellFoundedLT.toOrderBot (α := αᵒᵈ)

--- a/Mathlib/Order/WellFounded.lean
+++ b/Mathlib/Order/WellFounded.lean
@@ -280,3 +280,16 @@ theorem StrictAnti.wellFoundedGT [WellFoundedLT β] (hf : StrictAnti f) : WellFo
   StrictMono.wellFoundedLT (α := αᵒᵈ) (fun _ _ h ↦ hf h)
 
 end WellFoundedLT
+
+/-- A nonempty linear order with well-founded `<` has a bottom element. -/
+noncomputable def WellFoundedLT.toOrderBot {α} [LinearOrder α] [Nonempty α] [h : WellFoundedLT α] :
+    OrderBot α where
+  bot := h.wf.min Set.univ Set.univ_nonempty
+  bot_le a := h.wf.min_le (Set.mem_univ a)
+
+/-- A nonempty linear order with well-founded `>` has a top element. -/
+noncomputable def WellFoundedGT.toOrderTop {α} [LinearOrder α] [Nonempty α] [h : WellFoundedGT α] :
+    OrderTop α := by
+  change OrderTop (αᵒᵈᵒᵈ)
+  have := WellFoundedLT.toOrderBot (α := αᵒᵈ)
+  infer_instance


### PR DESCRIPTION
A non-empty well-founded linear order has a bottom element.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
