### PR TITLE
[Merged by Bors] - feat(Order/SuccPred/Limit): `mem_range_succ_or_isSuccLimit`

### DIFF
--- a/Mathlib/Order/SuccPred/Limit.lean
+++ b/Mathlib/Order/SuccPred/Limit.lean
@@ -120,6 +120,9 @@ theorem mem_range_succ_of_not_isSuccLimit (h : ¬IsSuccLimit a) : a ∈ range (@
   cases' not_isSuccLimit_iff.1 h with b hb
   exact ⟨b, hb.2⟩
 
+theorem mem_range_succ_or_isSuccLimit (a) : a ∈ range (@succ α _ _) ∨ IsSuccLimit a :=
+  or_iff_not_imp_right.2 <| mem_range_succ_of_not_isSuccLimit
+
 theorem isSuccLimit_of_succ_lt (H : ∀ a < b, succ a < b) : IsSuccLimit b := fun a hab =>
   (H a hab.lt).ne (CovBy.succ_eq hab)
 
@@ -334,6 +337,9 @@ than itself. -/
 theorem mem_range_pred_of_not_isPredLimit (h : ¬IsPredLimit a) : a ∈ range (@pred α _ _) := by
   cases' not_isPredLimit_iff.1 h with b hb
   exact ⟨b, hb.2⟩
+
+theorem mem_range_pred_or_isPredLimit (a) : a ∈ range (@pred α _ _) ∨ IsPredLimit a :=
+  or_iff_not_imp_right.2 <| mem_range_pred_of_not_isPredLimit
 
 theorem isPredLimit_of_pred_lt (H : ∀ a > b, pred a < b) : IsPredLimit b := fun a hab =>
   (H a hab.lt).ne (CovBy.pred_eq hab)


### PR DESCRIPTION
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
