### PR TITLE
[Merged by Bors] - feat(Order/SuccPred/Basic): `succ_eq_sInf`

### DIFF
--- a/Mathlib/Order/SuccPred/Basic.lean
+++ b/Mathlib/Order/SuccPred/Basic.lean
@@ -3,7 +3,7 @@ Copyright (c) 2021 Yaël Dillies. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Yaël Dillies
 -/
-import Mathlib.Order.CompleteLattice
+import Mathlib.Order.ConditionallyCompleteLattice.Basic
 import Mathlib.Order.Cover
 import Mathlib.Order.GaloisConnection
 import Mathlib.Order.Iterate
@@ -505,18 +505,22 @@ instance [PartialOrder α] : Subsingleton (SuccOrder α) :=
     · exact (@IsMax.succ_eq _ _ h₀ _ ha).trans ha.succ_eq.symm
     · exact @CovBy.succ_eq _ _ h₀ _ _ (covBy_succ_of_not_isMax ha)⟩
 
-section CompleteLattice
+section Lattice
 
-variable [CompleteLattice α] [SuccOrder α]
-
-theorem succ_eq_iInf (a : α) : succ a = ⨅ (b) (_ : a < b), b := by
-  refine le_antisymm (le_iInf fun b => le_iInf succ_le_of_lt) ?_
+theorem succ_eq_sInf [CompleteLattice α] [SuccOrder α] (a : α) :
+    succ a = sInf (Set.Ioi a) := by
+  apply (le_sInf fun b => succ_le_of_lt).antisymm
   obtain rfl | ha := eq_or_ne a ⊤
   · rw [succ_top]
     exact le_top
-  exact iInf₂_le _ (lt_succ_iff_ne_top.2 ha)
+  · exact sInf_le (lt_succ_iff_ne_top.2 ha)
 
-end CompleteLattice
+theorem succ_eq_csInf [ConditionallyCompleteLattice α] [SuccOrder α] [NoMaxOrder α] (a : α) :
+    succ a = sInf (Set.Ioi a) := by
+  apply (le_csInf nonempty_Ioi fun b => succ_le_of_lt).antisymm
+  exact csInf_le ⟨a, fun b => le_of_lt⟩ <| lt_succ a
+
+end Lattice
 
 /-! ### Predecessor order -/
 
@@ -812,18 +816,17 @@ instance [PartialOrder α] : Subsingleton (PredOrder α) :=
     · exact (@IsMin.pred_eq _ _ h₀ _ ha).trans ha.pred_eq.symm
     · exact @CovBy.pred_eq _ _ h₀ _ _ (pred_covBy_of_not_isMin ha)⟩
 
-section CompleteLattice
+section Lattice
 
-variable [CompleteLattice α] [PredOrder α]
+theorem pred_eq_sSup [CompleteLattice α] [PredOrder α] :
+    ∀ a : α, pred a = sSup (Set.Iio a) :=
+  succ_eq_sInf (α := αᵒᵈ)
 
-theorem pred_eq_iSup (a : α) : pred a = ⨆ (b) (_ : b < a), b := by
-  refine le_antisymm ?_ (iSup_le fun b => iSup_le le_pred_of_lt)
-  obtain rfl | ha := eq_or_ne a ⊥
-  · rw [pred_bot]
-    exact bot_le
-  · exact @le_iSup₂ _ _ (fun b => b < a) _ (fun a _ => a) (pred a) (pred_lt_iff_ne_bot.2 ha)
+theorem pred_eq_csSup [ConditionallyCompleteLattice α] [PredOrder α] [NoMinOrder α] :
+    ∀ a : α, pred a = sSup (Set.Iio a) :=
+  succ_eq_csInf (α := αᵒᵈ)
 
-end CompleteLattice
+end Lattice
 
 /-! ### Successor-predecessor orders -/
 

--- a/Mathlib/Order/SuccPred/Basic.lean
+++ b/Mathlib/Order/SuccPred/Basic.lean
@@ -505,8 +505,6 @@ instance [PartialOrder α] : Subsingleton (SuccOrder α) :=
     · exact (@IsMax.succ_eq _ _ h₀ _ ha).trans ha.succ_eq.symm
     · exact @CovBy.succ_eq _ _ h₀ _ _ (covBy_succ_of_not_isMax ha)⟩
 
-section Lattice
-
 theorem succ_eq_sInf [CompleteLattice α] [SuccOrder α] (a : α) :
     succ a = sInf (Set.Ioi a) := by
   apply (le_sInf fun b => succ_le_of_lt).antisymm
@@ -519,8 +517,6 @@ theorem succ_eq_csInf [ConditionallyCompleteLattice α] [SuccOrder α] [NoMaxOrd
     succ a = sInf (Set.Ioi a) := by
   apply (le_csInf nonempty_Ioi fun b => succ_le_of_lt).antisymm
   exact csInf_le ⟨a, fun b => le_of_lt⟩ <| lt_succ a
-
-end Lattice
 
 /-! ### Predecessor order -/
 
@@ -816,8 +812,6 @@ instance [PartialOrder α] : Subsingleton (PredOrder α) :=
     · exact (@IsMin.pred_eq _ _ h₀ _ ha).trans ha.pred_eq.symm
     · exact @CovBy.pred_eq _ _ h₀ _ _ (pred_covBy_of_not_isMin ha)⟩
 
-section Lattice
-
 theorem pred_eq_sSup [CompleteLattice α] [PredOrder α] :
     ∀ a : α, pred a = sSup (Set.Iio a) :=
   succ_eq_sInf (α := αᵒᵈ)
@@ -825,8 +819,6 @@ theorem pred_eq_sSup [CompleteLattice α] [PredOrder α] :
 theorem pred_eq_csSup [ConditionallyCompleteLattice α] [PredOrder α] [NoMinOrder α] :
     ∀ a : α, pred a = sSup (Set.Iio a) :=
   succ_eq_csInf (α := αᵒᵈ)
-
-end Lattice
 
 /-! ### Successor-predecessor orders -/
 

--- a/Mathlib/Order/SuccPred/Basic.lean
+++ b/Mathlib/Order/SuccPred/Basic.lean
@@ -820,12 +820,12 @@ theorem pred_eq_sSup [CompleteLattice α] [PredOrder α] :
     ∀ a : α, pred a = sSup (Set.Iio a) :=
   succ_eq_sInf (α := αᵒᵈ)
 
-theorem pred_eq_iSup [CompleteLattice α] [PredOrder α] : ∀ a : α, pred a = ⨆ b < a, b :=
-  succ_eq_iInf (α := αᵒᵈ)
+theorem pred_eq_iSup [CompleteLattice α] [PredOrder α] (a : α) : pred a = ⨆ b < a, b :=
+  succ_eq_iInf (α := αᵒᵈ) a
 
-theorem pred_eq_csSup [ConditionallyCompleteLattice α] [PredOrder α] [NoMinOrder α] :
-    ∀ a : α, pred a = sSup (Set.Iio a) :=
-  succ_eq_csInf (α := αᵒᵈ)
+theorem pred_eq_csSup [ConditionallyCompleteLattice α] [PredOrder α] [NoMinOrder α] (a : α) :
+    pred a = sSup (Set.Iio a) :=
+  succ_eq_csInf (α := αᵒᵈ) a
 
 /-! ### Successor-predecessor orders -/
 

--- a/Mathlib/Order/SuccPred/Basic.lean
+++ b/Mathlib/Order/SuccPred/Basic.lean
@@ -513,7 +513,7 @@ theorem succ_eq_sInf [CompleteLattice α] [SuccOrder α] (a : α) :
     exact le_top
   · exact sInf_le (lt_succ_iff_ne_top.2 ha)
 
-theorem succ_eq_iInf [CompleteLattice α] [SuccOrder α] (a : α) : succ a = ⨅ (b) (_ : a < b), b := by
+theorem succ_eq_iInf [CompleteLattice α] [SuccOrder α] (a : α) : succ a = ⨅ b > a, b := by
   rw [succ_eq_sInf, iInf_subtype', iInf, Subtype.range_coe_subtype]
   rfl
 
@@ -820,7 +820,7 @@ theorem pred_eq_sSup [CompleteLattice α] [PredOrder α] :
     ∀ a : α, pred a = sSup (Set.Iio a) :=
   succ_eq_sInf (α := αᵒᵈ)
 
-theorem pred_eq_iSup [CompleteLattice α] [PredOrder α] (a : α) : pred a = ⨆ (b) (_ : b < a), b :=
+theorem pred_eq_iSup [CompleteLattice α] [PredOrder α] : ∀ a : α, pred a = ⨆ b < a, b :=
   succ_eq_iInf (α := αᵒᵈ)
 
 theorem pred_eq_csSup [ConditionallyCompleteLattice α] [PredOrder α] [NoMinOrder α] :

--- a/Mathlib/Order/SuccPred/Basic.lean
+++ b/Mathlib/Order/SuccPred/Basic.lean
@@ -513,6 +513,10 @@ theorem succ_eq_sInf [CompleteLattice α] [SuccOrder α] (a : α) :
     exact le_top
   · exact sInf_le (lt_succ_iff_ne_top.2 ha)
 
+theorem succ_eq_iInf [CompleteLattice α] [SuccOrder α] (a : α) : succ a = ⨅ (b) (_ : a < b), b := by
+  rw [succ_eq_sInf, iInf_subtype', iInf, Subtype.range_coe_subtype]
+  rfl
+
 theorem succ_eq_csInf [ConditionallyCompleteLattice α] [SuccOrder α] [NoMaxOrder α] (a : α) :
     succ a = sInf (Set.Ioi a) := by
   apply (le_csInf nonempty_Ioi fun b => succ_le_of_lt).antisymm
@@ -815,6 +819,9 @@ instance [PartialOrder α] : Subsingleton (PredOrder α) :=
 theorem pred_eq_sSup [CompleteLattice α] [PredOrder α] :
     ∀ a : α, pred a = sSup (Set.Iio a) :=
   succ_eq_sInf (α := αᵒᵈ)
+
+theorem pred_eq_iSup [CompleteLattice α] [PredOrder α] (a : α) : pred a = ⨆ (b) (_ : b < a), b :=
+  succ_eq_iInf (α := αᵒᵈ)
 
 theorem pred_eq_csSup [ConditionallyCompleteLattice α] [PredOrder α] [NoMinOrder α] :
     ∀ a : α, pred a = sSup (Set.Iio a) :=


### PR DESCRIPTION
We prove that the successor of an element is the infimum of those greater than it, both in a complete lattice and a conditionally complete lattice with no maxima.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
