### PR TITLE
[Merged by Bors] - chore(Algebra/Lie): rename weightSpace to genWeightspace

### DIFF
--- a/Mathlib/Algebra/Lie/TraceForm.lean
+++ b/Mathlib/Algebra/Lie/TraceForm.lean
@@ -103,22 +103,22 @@ lemma traceForm_lieInvariant : (traceForm R L M).lieInvariant L := by
   exact isNilpotent_toEnd_of_isNilpotent₂ R L M x y
 
 @[simp]
-lemma traceForm_weightSpace_eq [Module.Free R M]
+lemma traceForm_genWeightSpace_eq [Module.Free R M]
     [IsDomain R] [IsPrincipalIdealRing R]
     [LieAlgebra.IsNilpotent R L] [IsNoetherian R M] [LinearWeights R L M] (χ : L → R) (x y : L) :
-    traceForm R L (weightSpace M χ) x y = finrank R (weightSpace M χ) • (χ x * χ y) := by
-  set d := finrank R (weightSpace M χ)
+    traceForm R L (genWeightSpace M χ) x y = finrank R (genWeightSpace M χ) • (χ x * χ y) := by
+  set d := finrank R (genWeightSpace M χ)
   have h₁ : χ y • d • χ x - χ y • χ x • (d : R) = 0 := by simp [mul_comm (χ x)]
   have h₂ : χ x • d • χ y = d • (χ x * χ y) := by
     simpa [nsmul_eq_mul, smul_eq_mul] using mul_left_comm (χ x) d (χ y)
-  have := traceForm_eq_zero_of_isNilpotent R L (shiftedWeightSpace R L M χ)
+  have := traceForm_eq_zero_of_isNilpotent R L (shiftedGenWeightSpace R L M χ)
   replace this := LinearMap.congr_fun (LinearMap.congr_fun this x) y
   rwa [LinearMap.zero_apply, LinearMap.zero_apply, traceForm_apply_apply,
-    shiftedWeightSpace.toEnd_eq, shiftedWeightSpace.toEnd_eq,
+    shiftedGenWeightSpace.toEnd_eq, shiftedGenWeightSpace.toEnd_eq,
     ← LinearEquiv.conj_comp, LinearMap.trace_conj', LinearMap.comp_sub, LinearMap.sub_comp,
     LinearMap.sub_comp, map_sub, map_sub, map_sub, LinearMap.comp_smul, LinearMap.smul_comp,
     LinearMap.comp_id, LinearMap.id_comp, LinearMap.map_smul, LinearMap.map_smul,
-    trace_toEnd_weightSpace, trace_toEnd_weightSpace,
+    trace_toEnd_genWeightSpace, trace_toEnd_genWeightSpace,
     LinearMap.comp_smul, LinearMap.smul_comp, LinearMap.id_comp, map_smul, map_smul,
     LinearMap.trace_id, ← traceForm_apply_apply, h₁, h₂, sub_zero, sub_eq_zero] at this
 
@@ -159,9 +159,9 @@ lemma traceForm_apply_eq_zero_of_mem_lcs_of_mem_center {x y : L}
 /-- Given a bilinear form `B` on a representation `M` of a nilpotent Lie algebra `L`, if `B` is
 invariant (in the sense that the action of `L` is skew-adjoint wrt `B`) then components of the
 Fitting decomposition of `M` are orthogonal wrt `B`. -/
-lemma eq_zero_of_mem_weightSpace_mem_posFitting [LieAlgebra.IsNilpotent R L]
+lemma eq_zero_of_mem_genWeightSpace_mem_posFitting [LieAlgebra.IsNilpotent R L]
     {B : LinearMap.BilinForm R M} (hB : ∀ (x : L) (m n : M), B ⁅x, m⁆ n = - B m ⁅x, n⁆)
-    {m₀ m₁ : M} (hm₀ : m₀ ∈ weightSpace M (0 : L → R)) (hm₁ : m₁ ∈ posFittingComp R L M) :
+    {m₀ m₁ : M} (hm₀ : m₀ ∈ genWeightSpace M (0 : L → R)) (hm₁ : m₁ ∈ posFittingComp R L M) :
     B m₀ m₁ = 0 := by
   replace hB : ∀ x (k : ℕ) m n, B m ((φ x ^ k) n) = (- 1 : R) ^ k • B ((φ x ^ k) m) n := by
     intro x k
@@ -177,7 +177,7 @@ lemma eq_zero_of_mem_weightSpace_mem_posFitting [LieAlgebra.IsNilpotent R L]
     apply LieSubmodule.iSup_induction _ hm₁ this (map_zero _)
     aesop
   clear hm₁ m₁; intro x m₁ hm₁
-  simp only [mem_weightSpace, Pi.zero_apply, zero_smul, sub_zero] at hm₀
+  simp only [mem_genWeightSpace, Pi.zero_apply, zero_smul, sub_zero] at hm₀
   obtain ⟨k, hk⟩ := hm₀ x
   obtain ⟨m, rfl⟩ := (mem_posFittingCompOf R x m₁).mp hm₁ k
   simp [hB, hk]
@@ -211,20 +211,21 @@ open TensorProduct
 
 variable [LieAlgebra.IsNilpotent R L] [IsDomain R] [IsPrincipalIdealRing R]
 
-lemma traceForm_eq_sum_weightSpaceOf
+lemma traceForm_eq_sum_genWeightSpaceOf
     [NoZeroSMulDivisors R M] [IsNoetherian R M] [IsTriangularizable R L M] (z : L) :
     traceForm R L M =
-    ∑ χ ∈ (finite_weightSpaceOf_ne_bot R L M z).toFinset, traceForm R L (weightSpaceOf M χ z) := by
+    ∑ χ ∈ (finite_genWeightSpaceOf_ne_bot R L M z).toFinset,
+      traceForm R L (genWeightSpaceOf M χ z) := by
   ext x y
   have hxy : ∀ χ : R, MapsTo ((toEnd R L M x).comp (toEnd R L M y))
-      (weightSpaceOf M χ z) (weightSpaceOf M χ z) :=
+      (genWeightSpaceOf M χ z) (genWeightSpaceOf M χ z) :=
     fun χ m hm ↦ LieSubmodule.lie_mem _ <| LieSubmodule.lie_mem _ hm
-  have hfin : {χ : R | (weightSpaceOf M χ z : Submodule R M) ≠ ⊥}.Finite := by
-    convert finite_weightSpaceOf_ne_bot R L M z
-    exact LieSubmodule.coeSubmodule_eq_bot_iff (weightSpaceOf M _ _)
+  have hfin : {χ : R | (genWeightSpaceOf M χ z : Submodule R M) ≠ ⊥}.Finite := by
+    convert finite_genWeightSpaceOf_ne_bot R L M z
+    exact LieSubmodule.coeSubmodule_eq_bot_iff (genWeightSpaceOf M _ _)
   classical
   have hds := DirectSum.isInternal_submodule_of_independent_of_iSup_eq_top
-    (LieSubmodule.independent_iff_coe_toSubmodule.mp <| independent_weightSpaceOf R L M z)
+    (LieSubmodule.independent_iff_coe_toSubmodule.mp <| independent_genWeightSpaceOf R L M z)
     (IsTriangularizable.iSup_eq_top z)
   simp only [LinearMap.coeFn_sum, Finset.sum_apply, traceForm_apply_apply,
     LinearMap.trace_eq_sum_trace_restrict' hds hfin hxy]
@@ -275,7 +276,7 @@ lemma lowerCentralSeries_one_inf_center_le_ker_traceForm [Module.Free R M] [Modu
   apply LinearMap.trace_comp_eq_zero_of_commute_of_trace_restrict_eq_zero
   · exact IsTriangularizable.iSup_eq_top (1 ⊗ₜ[R] x)
   · exact fun μ ↦ trace_toEnd_eq_zero_of_mem_lcs A (A ⊗[R] L)
-      (weightSpaceOf (A ⊗[R] M) μ (1 ⊗ₜ x)) (le_refl 1) hz
+      (genWeightSpaceOf (A ⊗[R] M) μ (1 ⊗ₜ x)) (le_refl 1) hz
   · exact commute_toEnd_of_mem_center_right (A ⊗[R] M) hzc (1 ⊗ₜ x)
 
 /-- A nilpotent Lie algebra with a representation whose trace form is non-singular is Abelian. -/
@@ -342,7 +343,7 @@ lemma killingForm_eq_zero_of_mem_zeroRoot_mem_posFitting
     (hx₀ : x₀ ∈ LieAlgebra.zeroRootSubalgebra R L H)
     (hx₁ : x₁ ∈ LieModule.posFittingComp R H L) :
     killingForm R L x₀ x₁ = 0 :=
-  LieModule.eq_zero_of_mem_weightSpace_mem_posFitting R H L
+  LieModule.eq_zero_of_mem_genWeightSpace_mem_posFitting R H L
     (fun x y z ↦ LieModule.traceForm_apply_lie_apply' R L L x y z) hx₀ hx₁
 
 namespace LieIdeal
@@ -395,20 +396,20 @@ variable [Field K] [LieAlgebra K L] [Module K M] [LieModule K L M] [FiniteDimens
 variable [LieAlgebra.IsNilpotent K L] [LinearWeights K L M] [IsTriangularizable K L M]
 
 lemma traceForm_eq_sum_finrank_nsmul_mul (x y : L) :
-    traceForm K L M x y = ∑ χ : Weight K L M, finrank K (weightSpace M χ) • (χ x * χ y) := by
+    traceForm K L M x y = ∑ χ : Weight K L M, finrank K (genWeightSpace M χ) • (χ x * χ y) := by
   have hxy : ∀ χ : Weight K L M, MapsTo (toEnd K L M x ∘ₗ toEnd K L M y)
-      (weightSpace M χ) (weightSpace M χ) :=
+      (genWeightSpace M χ) (genWeightSpace M χ) :=
     fun χ m hm ↦ LieSubmodule.lie_mem _ <| LieSubmodule.lie_mem _ hm
   classical
   have hds := DirectSum.isInternal_submodule_of_independent_of_iSup_eq_top
-    (LieSubmodule.independent_iff_coe_toSubmodule.mp <| independent_weightSpace' K L M)
-    (LieSubmodule.iSup_eq_top_iff_coe_toSubmodule.mp <| iSup_weightSpace_eq_top' K L M)
+    (LieSubmodule.independent_iff_coe_toSubmodule.mp <| independent_genWeightSpace' K L M)
+    (LieSubmodule.iSup_eq_top_iff_coe_toSubmodule.mp <| iSup_genWeightSpace_eq_top' K L M)
   simp_rw [traceForm_apply_apply, LinearMap.trace_eq_sum_trace_restrict hds hxy,
-    ← traceForm_weightSpace_eq K L M _ x y]
+    ← traceForm_genWeightSpace_eq K L M _ x y]
   rfl
 
 lemma traceForm_eq_sum_finrank_nsmul :
-    traceForm K L M = ∑ χ : Weight K L M, finrank K (weightSpace M χ) •
+    traceForm K L M = ∑ χ : Weight K L M, finrank K (genWeightSpace M χ) •
       (χ : L →ₗ[K] K).smulRight (χ : L →ₗ[K] K) := by
   ext
   rw [traceForm_eq_sum_finrank_nsmul_mul, ← Finset.sum_attach]

--- a/Mathlib/Algebra/Lie/Weights/Basic.lean
+++ b/Mathlib/Algebra/Lie/Weights/Basic.lean
@@ -25,16 +25,16 @@ Basic definitions and properties of the above ideas are provided in this file.
 
 ## Main definitions
 
-  * `LieModule.weightSpaceOf`
-  * `LieModule.weightSpace`
+  * `LieModule.genWeightSpaceOf`
+  * `LieModule.genWeightSpace`
   * `LieModule.Weight`
   * `LieModule.posFittingCompOf`
   * `LieModule.posFittingComp`
-  * `LieModule.iSup_ucs_eq_weightSpace_zero`
+  * `LieModule.iSup_ucs_eq_genWeightSpace_zero`
   * `LieModule.iInf_lowerCentralSeries_eq_posFittingComp`
-  * `LieModule.isCompl_weightSpace_zero_posFittingComp`
-  * `LieModule.independent_weightSpace`
-  * `LieModule.iSup_weightSpace_eq_top`
+  * `LieModule.isCompl_genWeightSpace_zero_posFittingComp`
+  * `LieModule.independent_genWeightSpace`
+  * `LieModule.iSup_genWeightSpace_eq_top`
 
 ## References
 
@@ -53,9 +53,9 @@ namespace LieModule
 open Set Function LieAlgebra TensorProduct TensorProduct.LieModule
 open scoped TensorProduct
 
-section notation_weightSpaceOf
+section notation_genWeightSpaceOf
 
-/-- Until we define `LieModule.weightSpaceOf`, it is useful to have some notation as follows: -/
+/-- Until we define `LieModule.genWeightSpaceOf`, it is useful to have some notation as follows: -/
 local notation3 "𝕎("M", " χ", " x")" => (toEnd R L M x).maxGenEigenspace χ
 
 /-- See also `bourbaki1975b` Chapter VII §1.1, Proposition 2 (ii). -/
@@ -143,10 +143,10 @@ lemma lie_mem_maxGenEigenspace_toEnd
 variable (M)
 
 /-- If `M` is a representation of a nilpotent Lie algebra `L`, `χ` is a scalar, and `x : L`, then
-`weightSpaceOf M χ x` is the maximal generalized `χ`-eigenspace of the action of `x` on `M`.
+`genWeightSpaceOf M χ x` is the maximal generalized `χ`-eigenspace of the action of `x` on `M`.
 
 It is a Lie submodule because `L` is nilpotent. -/
-def weightSpaceOf [LieAlgebra.IsNilpotent R L] (χ : R) (x : L) : LieSubmodule R L M :=
+def genWeightSpaceOf [LieAlgebra.IsNilpotent R L] (χ : R) (x : L) : LieSubmodule R L M :=
   { 𝕎(M, χ, x) with
     lie_mem := by
       intro y m hm
@@ -155,33 +155,34 @@ def weightSpaceOf [LieAlgebra.IsNilpotent R L] (χ : R) (x : L) : LieSubmodule R
       rw [← zero_add χ]
       exact lie_mem_maxGenEigenspace_toEnd (by simp) hm }
 
-end notation_weightSpaceOf
+end notation_genWeightSpaceOf
 
 variable (M)
 variable [LieAlgebra.IsNilpotent R L]
 
-theorem mem_weightSpaceOf (χ : R) (x : L) (m : M) :
-    m ∈ weightSpaceOf M χ x ↔ ∃ k : ℕ, ((toEnd R L M x - χ • ↑1) ^ k) m = 0 := by
-  simp [weightSpaceOf]
+theorem mem_genWeightSpaceOf (χ : R) (x : L) (m : M) :
+    m ∈ genWeightSpaceOf M χ x ↔ ∃ k : ℕ, ((toEnd R L M x - χ • ↑1) ^ k) m = 0 := by
+  simp [genWeightSpaceOf]
 
-theorem coe_weightSpaceOf_zero (x : L) :
-    ↑(weightSpaceOf M (0 : R) x) = ⨆ k, LinearMap.ker (toEnd R L M x ^ k) := by
-  simp [weightSpaceOf, Module.End.maxGenEigenspace]
+theorem coe_genWeightSpaceOf_zero (x : L) :
+    ↑(genWeightSpaceOf M (0 : R) x) = ⨆ k, LinearMap.ker (toEnd R L M x ^ k) := by
+  simp [genWeightSpaceOf, Module.End.maxGenEigenspace]
 
-/-- If `M` is a representation of a nilpotent Lie algebra `L` and `χ : L → R` is a family of
-scalars, then `weightSpace M χ` is the intersection of the maximal generalized `χ x`-eigenspaces of
-the action of `x` on `M` as `x` ranges over `L`.
+/-- If `M` is a representation of a nilpotent Lie algebra `L`
+and `χ : L → R` is a family of scalars,
+then `genWeightSpace M χ` is the intersection of the maximal generalized `χ x`-eigenspaces
+of the action of `x` on `M` as `x` ranges over `L`.
 
 It is a Lie submodule because `L` is nilpotent. -/
-def weightSpace (χ : L → R) : LieSubmodule R L M :=
-  ⨅ x, weightSpaceOf M (χ x) x
+def genWeightSpace (χ : L → R) : LieSubmodule R L M :=
+  ⨅ x, genWeightSpaceOf M (χ x) x
 
-theorem mem_weightSpace (χ : L → R) (m : M) :
-    m ∈ weightSpace M χ ↔ ∀ x, ∃ k : ℕ, ((toEnd R L M x - χ x • ↑1) ^ k) m = 0 := by
-  simp [weightSpace, mem_weightSpaceOf]
+theorem mem_genWeightSpace (χ : L → R) (m : M) :
+    m ∈ genWeightSpace M χ ↔ ∀ x, ∃ k : ℕ, ((toEnd R L M x - χ x • ↑1) ^ k) m = 0 := by
+  simp [genWeightSpace, mem_genWeightSpaceOf]
 
-lemma weightSpace_le_weightSpaceOf (x : L) (χ : L → R) :
-    weightSpace M χ ≤ weightSpaceOf M (χ x) x :=
+lemma genWeightSpace_le_genWeightSpaceOf (x : L) (χ : L → R) :
+    genWeightSpace M χ ≤ genWeightSpaceOf M (χ x) x :=
   iInf_le _ x
 
 variable (R L) in
@@ -190,7 +191,7 @@ non-trivial. -/
 structure Weight where
   /-- The family of eigenvalues corresponding to a weight. -/
   toFun : L → R
-  weightSpace_ne_bot' : weightSpace M toFun ≠ ⊥
+  genWeightSpace_ne_bot' : genWeightSpace M toFun ≠ ⊥
 
 namespace Weight
 
@@ -202,7 +203,7 @@ instance instFunLike : FunLike (Weight R L M) L R where
     (↑(⟨χ, h⟩ : Weight R L M) : L → R) = χ :=
   rfl
 
-lemma weightSpace_ne_bot (χ : Weight R L M) : weightSpace M χ ≠ ⊥ := χ.weightSpace_ne_bot'
+lemma genWeightSpace_ne_bot (χ : Weight R L M) : genWeightSpace M χ ≠ ⊥ := χ.genWeightSpace_ne_bot'
 
 variable {M}
 
@@ -212,19 +213,19 @@ variable {M}
 lemma ext_iff' {χ₁ χ₂ : Weight R L M} : (χ₁ : L → R) = χ₂ ↔ χ₁ = χ₂ := by aesop
 
 lemma exists_ne_zero (χ : Weight R L M) :
-    ∃ x ∈ weightSpace M χ, x ≠ 0 := by
-  simpa [LieSubmodule.eq_bot_iff] using χ.weightSpace_ne_bot
+    ∃ x ∈ genWeightSpace M χ, x ≠ 0 := by
+  simpa [LieSubmodule.eq_bot_iff] using χ.genWeightSpace_ne_bot
 
 instance [Subsingleton M] : IsEmpty (Weight R L M) :=
   ⟨fun h ↦ h.2 (Subsingleton.elim _ _)⟩
 
-instance [Nontrivial (weightSpace M (0 : L → R))] : Zero (Weight R L M) :=
+instance [Nontrivial (genWeightSpace M (0 : L → R))] : Zero (Weight R L M) :=
   ⟨0, fun e ↦ not_nontrivial (⊥ : LieSubmodule R L M) (e ▸ ‹_›)⟩
 
 @[simp]
-lemma coe_zero [Nontrivial (weightSpace M (0 : L → R))] : ((0 : Weight R L M) : L → R) = 0 := rfl
+lemma coe_zero [Nontrivial (genWeightSpace M (0 : L → R))] : ((0 : Weight R L M) : L → R) = 0 := rfl
 
-lemma zero_apply [Nontrivial (weightSpace M (0 : L → R))] (x) : (0 : Weight R L M) x = 0 := rfl
+lemma zero_apply [Nontrivial (genWeightSpace M (0 : L → R))] (x) : (0 : Weight R L M) x = 0 := rfl
 
 /-- The proposition that a weight of a Lie module is zero.
 
@@ -236,28 +237,28 @@ def IsZero (χ : Weight R L M) := (χ : L → R) = 0
 
 @[simp] lemma coe_eq_zero_iff (χ : Weight R L M) : (χ : L → R) = 0 ↔ χ.IsZero := Iff.rfl
 
-lemma isZero_iff_eq_zero [Nontrivial (weightSpace M (0 : L → R))] {χ : Weight R L M} :
+lemma isZero_iff_eq_zero [Nontrivial (genWeightSpace M (0 : L → R))] {χ : Weight R L M} :
     χ.IsZero ↔ χ = 0 := Weight.ext_iff' (χ₂ := 0)
 
-lemma isZero_zero [Nontrivial (weightSpace M (0 : L → R))] : IsZero (0 : Weight R L M) := rfl
+lemma isZero_zero [Nontrivial (genWeightSpace M (0 : L → R))] : IsZero (0 : Weight R L M) := rfl
 
 /-- The proposition that a weight of a Lie module is non-zero. -/
 abbrev IsNonZero (χ : Weight R L M) := ¬ IsZero (χ : Weight R L M)
 
-lemma isNonZero_iff_ne_zero [Nontrivial (weightSpace M (0 : L → R))] {χ : Weight R L M} :
+lemma isNonZero_iff_ne_zero [Nontrivial (genWeightSpace M (0 : L → R))] {χ : Weight R L M} :
     χ.IsNonZero ↔ χ ≠ 0 := isZero_iff_eq_zero.not
 
 variable (R L M) in
 /-- The set of weights is equivalent to a subtype. -/
-def equivSetOf : Weight R L M ≃ {χ : L → R | weightSpace M χ ≠ ⊥} where
+def equivSetOf : Weight R L M ≃ {χ : L → R | genWeightSpace M χ ≠ ⊥} where
   toFun w := ⟨w.1, w.2⟩
   invFun w := ⟨w.1, w.2⟩
   left_inv w := by simp
   right_inv w := by simp
 
-lemma weightSpaceOf_ne_bot (χ : Weight R L M) (x : L) :
-    weightSpaceOf M (χ x) x ≠ ⊥ := by
-  have : ⨅ x, weightSpaceOf M (χ x) x ≠ ⊥ := χ.weightSpace_ne_bot
+lemma genWeightSpaceOf_ne_bot (χ : Weight R L M) (x : L) :
+    genWeightSpaceOf M (χ x) x ≠ ⊥ := by
+  have : ⨅ x, genWeightSpaceOf M (χ x) x ≠ ⊥ := χ.genWeightSpace_ne_bot
   contrapose! this
   rw [eq_bot_iff]
   exact le_of_le_of_eq (iInf_le _ _) this
@@ -265,7 +266,7 @@ lemma weightSpaceOf_ne_bot (χ : Weight R L M) (x : L) :
 lemma hasEigenvalueAt (χ : Weight R L M) (x : L) :
     (toEnd R L M x).HasEigenvalue (χ x) := by
   obtain ⟨k : ℕ, hk : (toEnd R L M x).genEigenspace (χ x) k ≠ ⊥⟩ := by
-    simpa [Module.End.maxGenEigenspace, weightSpaceOf] using χ.weightSpaceOf_ne_bot x
+    simpa [Module.End.maxGenEigenspace, genWeightSpaceOf] using χ.genWeightSpaceOf_ne_bot x
   exact Module.End.hasEigenvalue_of_hasGenEigenvalue hk
 
 lemma apply_eq_zero_of_isNilpotent [NoZeroSMulDivisors R M] [IsReduced R]
@@ -275,91 +276,92 @@ lemma apply_eq_zero_of_isNilpotent [NoZeroSMulDivisors R M] [IsReduced R]
 
 end Weight
 
-/-- See also the more useful form `LieModule.zero_weightSpace_eq_top_of_nilpotent`. -/
+/-- See also the more useful form `LieModule.zero_genWeightSpace_eq_top_of_nilpotent`. -/
 @[simp]
-theorem zero_weightSpace_eq_top_of_nilpotent' [IsNilpotent R L M] :
-    weightSpace M (0 : L → R) = ⊤ := by
+theorem zero_genWeightSpace_eq_top_of_nilpotent' [IsNilpotent R L M] :
+    genWeightSpace M (0 : L → R) = ⊤ := by
   ext
-  simp [weightSpace, weightSpaceOf]
+  simp [genWeightSpace, genWeightSpaceOf]
 
-theorem coe_weightSpace_of_top (χ : L → R) :
-    (weightSpace M (χ ∘ (⊤ : LieSubalgebra R L).incl) : Submodule R M) = weightSpace M χ := by
+theorem coe_genWeightSpace_of_top (χ : L → R) :
+    (genWeightSpace M (χ ∘ (⊤ : LieSubalgebra R L).incl) : Submodule R M) = genWeightSpace M χ := by
   ext m
-  simp only [mem_weightSpace, LieSubmodule.mem_coeSubmodule, Subtype.forall]
+  simp only [mem_genWeightSpace, LieSubmodule.mem_coeSubmodule, Subtype.forall]
   apply forall_congr'
   simp
 
 @[simp]
-theorem zero_weightSpace_eq_top_of_nilpotent [IsNilpotent R L M] :
-    weightSpace M (0 : (⊤ : LieSubalgebra R L) → R) = ⊤ := by
+theorem zero_genWeightSpace_eq_top_of_nilpotent [IsNilpotent R L M] :
+    genWeightSpace M (0 : (⊤ : LieSubalgebra R L) → R) = ⊤ := by
   ext m
-  simp only [mem_weightSpace, Pi.zero_apply, zero_smul, sub_zero, Subtype.forall, forall_true_left,
-    LieSubalgebra.toEnd_mk, LieSubalgebra.mem_top, LieSubmodule.mem_top, iff_true]
+  simp only [mem_genWeightSpace, Pi.zero_apply, zero_smul, sub_zero, Subtype.forall,
+    forall_true_left, LieSubalgebra.toEnd_mk, LieSubalgebra.mem_top, LieSubmodule.mem_top, iff_true]
   intro x
   obtain ⟨k, hk⟩ := exists_forall_pow_toEnd_eq_zero R L M
   exact ⟨k, by simp [hk x]⟩
 
-theorem exists_weightSpace_le_ker_of_isNoetherian [IsNoetherian R M] (χ : L → R) (x : L) :
+theorem exists_genWeightSpace_le_ker_of_isNoetherian [IsNoetherian R M] (χ : L → R) (x : L) :
     ∃ k : ℕ,
-      weightSpace M χ ≤ LinearMap.ker ((toEnd R L M x - algebraMap R _ (χ x)) ^ k) := by
+      genWeightSpace M χ ≤ LinearMap.ker ((toEnd R L M x - algebraMap R _ (χ x)) ^ k) := by
   use (toEnd R L M x).maxGenEigenspaceIndex (χ x)
   intro m hm
   replace hm : m ∈ (toEnd R L M x).maxGenEigenspace (χ x) :=
-    weightSpace_le_weightSpaceOf M x χ hm
+    genWeightSpace_le_genWeightSpaceOf M x χ hm
   rwa [Module.End.maxGenEigenspace_eq] at hm
 
 variable (R) in
-theorem exists_weightSpace_zero_le_ker_of_isNoetherian
+theorem exists_genWeightSpace_zero_le_ker_of_isNoetherian
     [IsNoetherian R M] (x : L) :
-    ∃ k : ℕ, weightSpace M (0 : L → R) ≤ LinearMap.ker (toEnd R L M x ^ k) := by
-  simpa using exists_weightSpace_le_ker_of_isNoetherian M (0 : L → R) x
+    ∃ k : ℕ, genWeightSpace M (0 : L → R) ≤ LinearMap.ker (toEnd R L M x ^ k) := by
+  simpa using exists_genWeightSpace_le_ker_of_isNoetherian M (0 : L → R) x
 
 lemma isNilpotent_toEnd_sub_algebraMap [IsNoetherian R M] (χ : L → R) (x : L) :
-    _root_.IsNilpotent <| toEnd R L (weightSpace M χ) x - algebraMap R _ (χ x) := by
-  have : toEnd R L (weightSpace M χ) x - algebraMap R _ (χ x) =
+    _root_.IsNilpotent <| toEnd R L (genWeightSpace M χ) x - algebraMap R _ (χ x) := by
+  have : toEnd R L (genWeightSpace M χ) x - algebraMap R _ (χ x) =
       (toEnd R L M x - algebraMap R _ (χ x)).restrict
         (fun m hm ↦ sub_mem (LieSubmodule.lie_mem _ hm) (Submodule.smul_mem _ _ hm)) := by
     rfl
-  obtain ⟨k, hk⟩ := exists_weightSpace_le_ker_of_isNoetherian M χ x
+  obtain ⟨k, hk⟩ := exists_genWeightSpace_le_ker_of_isNoetherian M χ x
   use k
   ext ⟨m, hm⟩
   simpa [this, LinearMap.pow_restrict _, LinearMap.restrict_apply] using hk hm
 
 /-- A (nilpotent) Lie algebra acts nilpotently on the zero weight space of a Noetherian Lie
 module. -/
-theorem isNilpotent_toEnd_weightSpace_zero [IsNoetherian R M] (x : L) :
-    _root_.IsNilpotent <| toEnd R L (weightSpace M (0 : L → R)) x := by
+theorem isNilpotent_toEnd_genWeightSpace_zero [IsNoetherian R M] (x : L) :
+    _root_.IsNilpotent <| toEnd R L (genWeightSpace M (0 : L → R)) x := by
   simpa using isNilpotent_toEnd_sub_algebraMap M (0 : L → R) x
 
 /-- By Engel's theorem, the zero weight space of a Noetherian Lie module is nilpotent. -/
 instance [IsNoetherian R M] :
-    IsNilpotent R L (weightSpace M (0 : L → R)) :=
-  isNilpotent_iff_forall'.mpr <| isNilpotent_toEnd_weightSpace_zero M
+    IsNilpotent R L (genWeightSpace M (0 : L → R)) :=
+  isNilpotent_iff_forall'.mpr <| isNilpotent_toEnd_genWeightSpace_zero M
 
 variable (R L)
 
 @[simp]
-lemma weightSpace_zero_normalizer_eq_self :
-    (weightSpace M (0 : L → R)).normalizer = weightSpace M 0 := by
+lemma genWeightSpace_zero_normalizer_eq_self :
+    (genWeightSpace M (0 : L → R)).normalizer = genWeightSpace M 0 := by
   refine le_antisymm ?_ (LieSubmodule.le_normalizer _)
   intro m hm
   rw [LieSubmodule.mem_normalizer] at hm
-  simp only [mem_weightSpace, Pi.zero_apply, zero_smul, sub_zero] at hm ⊢
+  simp only [mem_genWeightSpace, Pi.zero_apply, zero_smul, sub_zero] at hm ⊢
   intro y
   obtain ⟨k, hk⟩ := hm y y
   use k + 1
   simpa [pow_succ, LinearMap.mul_eq_comp]
 
-lemma iSup_ucs_le_weightSpace_zero :
-    ⨆ k, (⊥ : LieSubmodule R L M).ucs k ≤ weightSpace M (0 : L → R) := by
-  simpa using LieSubmodule.ucs_le_of_normalizer_eq_self (weightSpace_zero_normalizer_eq_self R L M)
+lemma iSup_ucs_le_genWeightSpace_zero :
+    ⨆ k, (⊥ : LieSubmodule R L M).ucs k ≤ genWeightSpace M (0 : L → R) := by
+  simpa using
+    LieSubmodule.ucs_le_of_normalizer_eq_self (genWeightSpace_zero_normalizer_eq_self R L M)
 
 /-- See also `LieModule.iInf_lowerCentralSeries_eq_posFittingComp`. -/
-lemma iSup_ucs_eq_weightSpace_zero [IsNoetherian R M] :
-    ⨆ k, (⊥ : LieSubmodule R L M).ucs k = weightSpace M (0 : L → R) := by
+lemma iSup_ucs_eq_genWeightSpace_zero [IsNoetherian R M] :
+    ⨆ k, (⊥ : LieSubmodule R L M).ucs k = genWeightSpace M (0 : L → R) := by
   obtain ⟨k, hk⟩ := (LieSubmodule.isNilpotent_iff_exists_self_le_ucs
-    <| weightSpace M (0 : L → R)).mp inferInstance
-  refine le_antisymm (iSup_ucs_le_weightSpace_zero R L M) (le_trans hk ?_)
+    <| genWeightSpace M (0 : L → R)).mp inferInstance
+  refine le_antisymm (iSup_ucs_le_genWeightSpace_zero R L M) (le_trans hk ?_)
   exact le_iSup (fun k ↦ (⊥ : LieSubmodule R L M).ucs k) k
 
 variable {L}
@@ -369,7 +371,7 @@ variable {L}
 `range φₓ ⊇ range φₓ² ⊇ range φₓ³ ⊇ ⋯` where `φₓ : End R M := toEnd R L M x`. We call this
 the "positive Fitting component" because with appropriate assumptions (e.g., `R` is a field and
 `M` is finite-dimensional) `φₓ` induces the so-called Fitting decomposition: `M = M₀ ⊕ M₁` where
-`M₀ = weightSpaceOf M 0 x` and `M₁ = posFittingCompOf R M x`.
+`M₀ = genWeightSpaceOf M 0 x` and `M₁ = posFittingCompOf R M x`.
 
 It is a Lie submodule because `L` is nilpotent. -/
 def posFittingCompOf (x : L) : LieSubmodule R L M :=
@@ -439,7 +441,7 @@ lemma posFittingComp_le_iInf_lowerCentralSeries :
     posFittingComp R L M ≤ ⨅ k, lowerCentralSeries R L M k := by
   simp [posFittingComp]
 
-/-- See also `LieModule.iSup_ucs_eq_weightSpace_zero`. -/
+/-- See also `LieModule.iSup_ucs_eq_genWeightSpace_zero`. -/
 @[simp] lemma iInf_lowerCentralSeries_eq_posFittingComp
     [IsNoetherian R M] [IsArtinian R M] :
     ⨅ k, lowerCentralSeries R L M k = posFittingComp R L M := by
@@ -485,24 +487,24 @@ lemma map_posFittingComp_le :
   use f n
   rw [LieModule.toEnd_pow_apply_map, hn]
 
-lemma map_weightSpace_le :
-    (weightSpace M χ).map f ≤ weightSpace M₂ χ := by
+lemma map_genWeightSpace_le :
+    (genWeightSpace M χ).map f ≤ genWeightSpace M₂ χ := by
   rw [LieSubmodule.map_le_iff_le_comap]
   intro m hm
-  simp only [LieSubmodule.mem_comap, mem_weightSpace]
+  simp only [LieSubmodule.mem_comap, mem_genWeightSpace]
   intro x
   have : (toEnd R L M₂ x - χ x • ↑1) ∘ₗ f = f ∘ₗ (toEnd R L M x - χ x • ↑1) := by
     ext; simp
-  obtain ⟨k, h⟩ := (mem_weightSpace _ _ _).mp hm x
+  obtain ⟨k, h⟩ := (mem_genWeightSpace _ _ _).mp hm x
   exact ⟨k, by simpa [h] using LinearMap.congr_fun (LinearMap.commute_pow_left_of_commute this k) m⟩
 
 variable {f}
 
-lemma comap_weightSpace_eq_of_injective (hf : Injective f) :
-    (weightSpace M₂ χ).comap f = weightSpace M χ := by
+lemma comap_genWeightSpace_eq_of_injective (hf : Injective f) :
+    (genWeightSpace M₂ χ).comap f = genWeightSpace M χ := by
   refine le_antisymm (fun m hm ↦ ?_) ?_
-  · simp only [LieSubmodule.mem_comap, mem_weightSpace] at hm
-    simp only [mem_weightSpace]
+  · simp only [LieSubmodule.mem_comap, mem_genWeightSpace] at hm
+    simp only [mem_genWeightSpace]
     intro x
     have h : (toEnd R L M₂ x - χ x • ↑1) ∘ₗ f =
              f ∘ₗ (toEnd R L M x - χ x • ↑1) := by ext; simp
@@ -512,18 +514,19 @@ lemma comap_weightSpace_eq_of_injective (hf : Injective f) :
       rw [← f.map_zero] at this; exact hf this
     simpa [hk] using (LinearMap.congr_fun (LinearMap.commute_pow_left_of_commute h k) m).symm
   · rw [← LieSubmodule.map_le_iff_le_comap]
-    exact map_weightSpace_le f
+    exact map_genWeightSpace_le f
 
-lemma map_weightSpace_eq_of_injective (hf : Injective f) :
-    (weightSpace M χ).map f = weightSpace M₂ χ ⊓ f.range := by
-  refine le_antisymm (le_inf_iff.mpr ⟨map_weightSpace_le f, LieSubmodule.map_le_range f⟩) ?_
+lemma map_genWeightSpace_eq_of_injective (hf : Injective f) :
+    (genWeightSpace M χ).map f = genWeightSpace M₂ χ ⊓ f.range := by
+  refine le_antisymm (le_inf_iff.mpr ⟨map_genWeightSpace_le f, LieSubmodule.map_le_range f⟩) ?_
   rintro - ⟨hm, ⟨m, rfl⟩⟩
-  simp only [← comap_weightSpace_eq_of_injective hf, LieSubmodule.mem_map, LieSubmodule.mem_comap]
+  simp only [← comap_genWeightSpace_eq_of_injective hf, LieSubmodule.mem_map,
+    LieSubmodule.mem_comap]
   exact ⟨m, hm, rfl⟩
 
-lemma map_weightSpace_eq (e : M ≃ₗ⁅R,L⁆ M₂) :
-    (weightSpace M χ).map e = weightSpace M₂ χ := by
-  simp [map_weightSpace_eq_of_injective e.injective]
+lemma map_genWeightSpace_eq (e : M ≃ₗ⁅R,L⁆ M₂) :
+    (genWeightSpace M χ).map e = genWeightSpace M₂ χ := by
+  simp [map_genWeightSpace_eq_of_injective e.injective]
 
 lemma map_posFittingComp_eq (e : M ≃ₗ⁅R,L⁆ M₂) :
     (posFittingComp R L M).map e = posFittingComp R L M₂ := by
@@ -549,11 +552,11 @@ lemma posFittingComp_map_incl_sup_of_codisjoint [IsNoetherian R M] [IsArtinian R
     LieSubmodule.lowerCentralSeries_map_eq_lcs, ← LieSubmodule.lcs_sup, lowerCentralSeries,
     h.eq_top]
 
-lemma weightSpace_weightSpaceOf_map_incl (x : L) (χ : L → R) :
-    (weightSpace (weightSpaceOf M (χ x) x) χ).map (weightSpaceOf M (χ x) x).incl =
-    weightSpace M χ := by
-  simpa [map_weightSpace_eq_of_injective (weightSpaceOf M (χ x) x).injective_incl]
-    using weightSpace_le_weightSpaceOf M x χ
+lemma genWeightSpace_genWeightSpaceOf_map_incl (x : L) (χ : L → R) :
+    (genWeightSpace (genWeightSpaceOf M (χ x) x) χ).map (genWeightSpaceOf M (χ x) x).incl =
+    genWeightSpace M χ := by
+  simpa [map_genWeightSpace_eq_of_injective (genWeightSpaceOf M (χ x) x).injective_incl]
+    using genWeightSpace_le_genWeightSpaceOf M x χ
 
 end map_comap
 
@@ -561,34 +564,35 @@ section fitting_decomposition
 
 variable [IsNoetherian R M] [IsArtinian R M]
 
-lemma isCompl_weightSpaceOf_zero_posFittingCompOf (x : L) :
-    IsCompl (weightSpaceOf M 0 x) (posFittingCompOf R M x) := by
+lemma isCompl_genWeightSpaceOf_zero_posFittingCompOf (x : L) :
+    IsCompl (genWeightSpaceOf M 0 x) (posFittingCompOf R M x) := by
   simpa only [isCompl_iff, codisjoint_iff, disjoint_iff, ← LieSubmodule.coe_toSubmodule_eq_iff,
     LieSubmodule.sup_coe_toSubmodule, LieSubmodule.inf_coe_toSubmodule,
-    LieSubmodule.top_coeSubmodule, LieSubmodule.bot_coeSubmodule, coe_weightSpaceOf_zero] using
+    LieSubmodule.top_coeSubmodule, LieSubmodule.bot_coeSubmodule, coe_genWeightSpaceOf_zero] using
     (toEnd R L M x).isCompl_iSup_ker_pow_iInf_range_pow
 
 /-- This lemma exists only to simplify the proof of
-`LieModule.isCompl_weightSpace_zero_posFittingComp`. -/
-private lemma isCompl_weightSpace_zero_posFittingComp_aux
-    (h : ∀ N < (⊤ : LieSubmodule R L M), IsCompl (weightSpace N 0) (posFittingComp R L N)) :
-    IsCompl (weightSpace M 0) (posFittingComp R L M) := by
-  set M₀ := weightSpace M (0 : L → R)
+`LieModule.isCompl_genWeightSpace_zero_posFittingComp`. -/
+private lemma isCompl_genWeightSpace_zero_posFittingComp_aux
+    (h : ∀ N < (⊤ : LieSubmodule R L M), IsCompl (genWeightSpace N 0) (posFittingComp R L N)) :
+    IsCompl (genWeightSpace M 0) (posFittingComp R L M) := by
+  set M₀ := genWeightSpace M (0 : L → R)
   set M₁ := posFittingComp R L M
-  rcases forall_or_exists_not (fun (x : L) ↦ weightSpaceOf M (0 : R) x = ⊤)
-    with h | ⟨x, hx : weightSpaceOf M (0 : R) x ≠ ⊤⟩
+  rcases forall_or_exists_not (fun (x : L) ↦ genWeightSpaceOf M (0 : R) x = ⊤)
+    with h | ⟨x, hx : genWeightSpaceOf M (0 : R) x ≠ ⊤⟩
   · suffices IsNilpotent R L M by simp [M₀, M₁, isCompl_top_bot]
-    replace h : M₀ = ⊤ := by simpa [M₀, weightSpace]
+    replace h : M₀ = ⊤ := by simpa [M₀, genWeightSpace]
     rw [← LieModule.isNilpotent_of_top_iff', ← h]
     infer_instance
-  · set M₀ₓ := weightSpaceOf M (0 : R) x
+  · set M₀ₓ := genWeightSpaceOf M (0 : R) x
     set M₁ₓ := posFittingCompOf R M x
-    set M₀ₓ₀ := weightSpace M₀ₓ (0 : L → R)
+    set M₀ₓ₀ := genWeightSpace M₀ₓ (0 : L → R)
     set M₀ₓ₁ := posFittingComp R L M₀ₓ
-    have h₁ : IsCompl M₀ₓ M₁ₓ := isCompl_weightSpaceOf_zero_posFittingCompOf R L M x
+    have h₁ : IsCompl M₀ₓ M₁ₓ := isCompl_genWeightSpaceOf_zero_posFittingCompOf R L M x
     have h₂ : IsCompl M₀ₓ₀ M₀ₓ₁ := h M₀ₓ hx.lt_top
     have h₃ : M₀ₓ₀.map M₀ₓ.incl = M₀ := by
-      rw [map_weightSpace_eq_of_injective M₀ₓ.injective_incl, inf_eq_left, LieSubmodule.range_incl]
+      rw [map_genWeightSpace_eq_of_injective M₀ₓ.injective_incl, inf_eq_left,
+        LieSubmodule.range_incl]
       exact iInf_le _ x
     have h₄ : M₀ₓ₁.map M₀ₓ.incl ⊔ M₁ₓ = M₁ := by
       apply le_antisymm <| sup_le_iff.mpr
@@ -602,49 +606,49 @@ private lemma isCompl_weightSpace_zero_posFittingComp_aux
     · rwa [← LieSubmodule.map_sup, h₂.sup_eq_top, LieModuleHom.map_top, LieSubmodule.range_incl]
 
 /-- This is the Fitting decomposition of the Lie module `M`. -/
-lemma isCompl_weightSpace_zero_posFittingComp :
-    IsCompl (weightSpace M 0) (posFittingComp R L M) := by
-  let P : LieSubmodule R L M → Prop := fun N ↦ IsCompl (weightSpace N 0) (posFittingComp R L N)
+lemma isCompl_genWeightSpace_zero_posFittingComp :
+    IsCompl (genWeightSpace M 0) (posFittingComp R L M) := by
+  let P : LieSubmodule R L M → Prop := fun N ↦ IsCompl (genWeightSpace N 0) (posFittingComp R L N)
   suffices P ⊤ by
     let e := LieModuleEquiv.ofTop R L M
-    rw [← map_weightSpace_eq e, ← map_posFittingComp_eq e]
+    rw [← map_genWeightSpace_eq e, ← map_posFittingComp_eq e]
     exact (LieSubmodule.orderIsoMapComap e).isCompl_iff.mp this
   refine (LieSubmodule.wellFounded_of_isArtinian R L M).induction (C := P) _ fun N hN ↦ ?_
-  refine isCompl_weightSpace_zero_posFittingComp_aux R L N fun N' hN' ↦ ?_
-  suffices IsCompl (weightSpace (N'.map N.incl) 0) (posFittingComp R L (N'.map N.incl)) by
+  refine isCompl_genWeightSpace_zero_posFittingComp_aux R L N fun N' hN' ↦ ?_
+  suffices IsCompl (genWeightSpace (N'.map N.incl) 0) (posFittingComp R L (N'.map N.incl)) by
     let e := LieSubmodule.equivMapOfInjective N' N.injective_incl
-    rw [← map_weightSpace_eq e, ← map_posFittingComp_eq e] at this
+    rw [← map_genWeightSpace_eq e, ← map_posFittingComp_eq e] at this
     exact (LieSubmodule.orderIsoMapComap e).isCompl_iff.mpr this
   exact hN _ (LieSubmodule.map_incl_lt_iff_lt_top.mpr hN')
 
 end fitting_decomposition
 
-lemma disjoint_weightSpaceOf [NoZeroSMulDivisors R M] {x : L} {φ₁ φ₂ : R} (h : φ₁ ≠ φ₂) :
-    Disjoint (weightSpaceOf M φ₁ x) (weightSpaceOf M φ₂ x) := by
+lemma disjoint_genWeightSpaceOf [NoZeroSMulDivisors R M] {x : L} {φ₁ φ₂ : R} (h : φ₁ ≠ φ₂) :
+    Disjoint (genWeightSpaceOf M φ₁ x) (genWeightSpaceOf M φ₂ x) := by
   rw [LieSubmodule.disjoint_iff_coe_toSubmodule]
   exact Module.End.disjoint_iSup_genEigenspace _ h
 
-lemma disjoint_weightSpace [NoZeroSMulDivisors R M] {χ₁ χ₂ : L → R} (h : χ₁ ≠ χ₂) :
-    Disjoint (weightSpace M χ₁) (weightSpace M χ₂) := by
+lemma disjoint_genWeightSpace [NoZeroSMulDivisors R M] {χ₁ χ₂ : L → R} (h : χ₁ ≠ χ₂) :
+    Disjoint (genWeightSpace M χ₁) (genWeightSpace M χ₂) := by
   obtain ⟨x, hx⟩ : ∃ x, χ₁ x ≠ χ₂ x := Function.ne_iff.mp h
-  exact (disjoint_weightSpaceOf R L M hx).mono
-    (weightSpace_le_weightSpaceOf M x χ₁) (weightSpace_le_weightSpaceOf M x χ₂)
+  exact (disjoint_genWeightSpaceOf R L M hx).mono
+    (genWeightSpace_le_genWeightSpaceOf M x χ₁) (genWeightSpace_le_genWeightSpaceOf M x χ₂)
 
-lemma injOn_weightSpace [NoZeroSMulDivisors R M] :
-    InjOn (fun (χ : L → R) ↦ weightSpace M χ) {χ | weightSpace M χ ≠ ⊥} := by
-  rintro χ₁ _ χ₂ hχ₂ (hχ₁₂ : weightSpace M χ₁ = weightSpace M χ₂)
+lemma injOn_genWeightSpace [NoZeroSMulDivisors R M] :
+    InjOn (fun (χ : L → R) ↦ genWeightSpace M χ) {χ | genWeightSpace M χ ≠ ⊥} := by
+  rintro χ₁ _ χ₂ hχ₂ (hχ₁₂ : genWeightSpace M χ₁ = genWeightSpace M χ₂)
   contrapose! hχ₂
-  simpa [hχ₁₂] using disjoint_weightSpace R L M hχ₂
+  simpa [hχ₁₂] using disjoint_genWeightSpace R L M hχ₂
 
 /-- Lie module weight spaces are independent.
 
-See also `LieModule.independent_weightSpace'`. -/
-lemma independent_weightSpace [NoZeroSMulDivisors R M] :
-    CompleteLattice.Independent fun (χ : L → R) ↦ weightSpace M χ := by
+See also `LieModule.independent_genWeightSpace'`. -/
+lemma independent_genWeightSpace [NoZeroSMulDivisors R M] :
+    CompleteLattice.Independent fun (χ : L → R) ↦ genWeightSpace M χ := by
   classical
   suffices ∀ χ (s : Finset (L → R)) (_ : χ ∉ s),
-      Disjoint (weightSpace M χ) (s.sup fun (χ : L → R) ↦ weightSpace M χ) by
-    simpa only [CompleteLattice.independent_iff_supIndep_of_injOn (injOn_weightSpace R L M),
+      Disjoint (genWeightSpace M χ) (s.sup fun (χ : L → R) ↦ genWeightSpace M χ) by
+    simpa only [CompleteLattice.independent_iff_supIndep_of_injOn (injOn_genWeightSpace R L M),
       Finset.supIndep_iff_disjoint_erase] using fun s χ _ ↦ this _ _ (s.not_mem_erase χ)
   intro χ₁ s
   induction' s using Finset.induction_on with χ₂ s _ ih
@@ -655,22 +659,22 @@ lemma independent_weightSpace [NoZeroSMulDivisors R M] :
   rw [Finset.sup_insert, disjoint_iff, LieSubmodule.eq_bot_iff]
   rintro x ⟨hx, hx'⟩
   simp only [SetLike.mem_coe, LieSubmodule.mem_coeSubmodule] at hx hx'
-  suffices x ∈ weightSpace M χ₂ by
-    rw [← LieSubmodule.mem_bot (R := R) (L := L), ← (disjoint_weightSpace R L M hχ₁₂).eq_bot]
+  suffices x ∈ genWeightSpace M χ₂ by
+    rw [← LieSubmodule.mem_bot (R := R) (L := L), ← (disjoint_genWeightSpace R L M hχ₁₂).eq_bot]
     exact ⟨hx, this⟩
   obtain ⟨y, hy, z, hz, rfl⟩ := (LieSubmodule.mem_sup _ _ _).mp hx'; clear hx'
   suffices ∀ l, ∃ (k : ℕ),
       ((toEnd R L M l - algebraMap R (Module.End R M) (χ₂ l)) ^ k) (y + z) ∈
-      weightSpace M χ₁ ⊓ Finset.sup s fun χ ↦ weightSpace M χ by
-    simpa only [ih.eq_bot, LieSubmodule.mem_bot, mem_weightSpace] using this
+      genWeightSpace M χ₁ ⊓ Finset.sup s fun χ ↦ genWeightSpace M χ by
+    simpa only [ih.eq_bot, LieSubmodule.mem_bot, mem_genWeightSpace] using this
   intro l
   let g : Module.End R M := toEnd R L M l - algebraMap R (Module.End R M) (χ₂ l)
-  obtain ⟨k, hk : (g ^ k) y = 0⟩ := (mem_weightSpace _ _ _).mp hy l
+  obtain ⟨k, hk : (g ^ k) y = 0⟩ := (mem_genWeightSpace _ _ _).mp hy l
   refine ⟨k, (LieSubmodule.mem_inf _ _ _).mp ⟨?_, ?_⟩⟩
   · exact LieSubmodule.mapsTo_pow_toEnd_sub_algebraMap _ hx
   · rw [map_add, hk, zero_add]
-    suffices (s.sup fun χ ↦ weightSpace M χ : Submodule R M).map (g ^ k) ≤
-        s.sup fun χ ↦ weightSpace M χ by
+    suffices (s.sup fun χ ↦ genWeightSpace M χ : Submodule R M).map (g ^ k) ≤
+        s.sup fun χ ↦ genWeightSpace M χ by
       refine this (Submodule.mem_map_of_mem ?_)
       simp_rw [← LieSubmodule.mem_coeSubmodule, Finset.sup_eq_iSup,
         LieSubmodule.iSup_coe_toSubmodule, ← Finset.sup_eq_iSup] at hz
@@ -681,29 +685,29 @@ lemma independent_weightSpace [NoZeroSMulDivisors R M] :
     rintro - ⟨u, hu, rfl⟩
     exact LieSubmodule.mapsTo_pow_toEnd_sub_algebraMap _ hu
 
-lemma independent_weightSpace' [NoZeroSMulDivisors R M] :
-    CompleteLattice.Independent fun χ : Weight R L M ↦ weightSpace M χ :=
-  (independent_weightSpace R L M).comp <|
+lemma independent_genWeightSpace' [NoZeroSMulDivisors R M] :
+    CompleteLattice.Independent fun χ : Weight R L M ↦ genWeightSpace M χ :=
+  (independent_genWeightSpace R L M).comp <|
     Subtype.val_injective.comp (Weight.equivSetOf R L M).injective
 
-lemma independent_weightSpaceOf [NoZeroSMulDivisors R M] (x : L) :
-    CompleteLattice.Independent fun (χ : R) ↦ weightSpaceOf M χ x := by
+lemma independent_genWeightSpaceOf [NoZeroSMulDivisors R M] (x : L) :
+    CompleteLattice.Independent fun (χ : R) ↦ genWeightSpaceOf M χ x := by
   rw [LieSubmodule.independent_iff_coe_toSubmodule]
   exact (toEnd R L M x).independent_genEigenspace
 
-lemma finite_weightSpaceOf_ne_bot [NoZeroSMulDivisors R M] [IsNoetherian R M] (x : L) :
-    {χ : R | weightSpaceOf M χ x ≠ ⊥}.Finite :=
+lemma finite_genWeightSpaceOf_ne_bot [NoZeroSMulDivisors R M] [IsNoetherian R M] (x : L) :
+    {χ : R | genWeightSpaceOf M χ x ≠ ⊥}.Finite :=
   CompleteLattice.WellFounded.finite_ne_bot_of_independent
-    (LieSubmodule.wellFounded_of_noetherian R L M) (independent_weightSpaceOf R L M x)
+    (LieSubmodule.wellFounded_of_noetherian R L M) (independent_genWeightSpaceOf R L M x)
 
-lemma finite_weightSpace_ne_bot [NoZeroSMulDivisors R M] [IsNoetherian R M] :
-    {χ : L → R | weightSpace M χ ≠ ⊥}.Finite :=
+lemma finite_genWeightSpace_ne_bot [NoZeroSMulDivisors R M] [IsNoetherian R M] :
+    {χ : L → R | genWeightSpace M χ ≠ ⊥}.Finite :=
   CompleteLattice.WellFounded.finite_ne_bot_of_independent
-    (LieSubmodule.wellFounded_of_noetherian R L M) (independent_weightSpace R L M)
+    (LieSubmodule.wellFounded_of_noetherian R L M) (independent_genWeightSpace R L M)
 
 instance Weight.instFinite [NoZeroSMulDivisors R M] [IsNoetherian R M] :
     Finite (Weight R L M) := by
-  have : Finite {χ : L → R | weightSpace M χ ≠ ⊥} := finite_weightSpace_ne_bot R L M
+  have : Finite {χ : L → R | genWeightSpace M χ ≠ ⊥} := finite_genWeightSpace_ne_bot R L M
   exact Finite.of_injective (equivSetOf R L M) (equivSetOf R L M).injective
 
 noncomputable instance Weight.instFintype [NoZeroSMulDivisors R M] [IsNoetherian R M] :
@@ -725,18 +729,18 @@ instance [IsTriangularizable R L M] : IsTriangularizable R (LieModule.toEnd R L 
   iSup_eq_top := by rintro ⟨-, x, rfl⟩; exact IsTriangularizable.iSup_eq_top x
 
 @[simp]
-lemma iSup_weightSpaceOf_eq_top [IsTriangularizable R L M] (x : L) :
-    ⨆ (φ : R), weightSpaceOf M φ x = ⊤ := by
+lemma iSup_genWeightSpaceOf_eq_top [IsTriangularizable R L M] (x : L) :
+    ⨆ (φ : R), genWeightSpaceOf M φ x = ⊤ := by
   rw [← LieSubmodule.coe_toSubmodule_eq_iff, LieSubmodule.iSup_coe_toSubmodule,
     LieSubmodule.top_coeSubmodule]
   exact IsTriangularizable.iSup_eq_top x
 
 open LinearMap FiniteDimensional in
 @[simp]
-lemma trace_toEnd_weightSpace [IsDomain R] [IsPrincipalIdealRing R]
+lemma trace_toEnd_genWeightSpace [IsDomain R] [IsPrincipalIdealRing R]
     [Module.Free R M] [Module.Finite R M] (χ : L → R) (x : L) :
-    trace R _ (toEnd R L (weightSpace M χ) x) = finrank R (weightSpace M χ) • χ x := by
-  suffices _root_.IsNilpotent ((toEnd R L (weightSpace M χ) x) - χ x • LinearMap.id) by
+    trace R _ (toEnd R L (genWeightSpace M χ) x) = finrank R (genWeightSpace M χ) • χ x := by
+  suffices _root_.IsNilpotent ((toEnd R L (genWeightSpace M χ) x) - χ x • LinearMap.id) by
     replace this := (isNilpotent_trace_of_isNilpotent this).eq_zero
     rwa [map_sub, map_smul, trace_id, sub_eq_zero, smul_eq_mul, mul_comm,
       ← nsmul_eq_mul] at this
@@ -761,41 +765,43 @@ instance (N : LieSubmodule K L M) [IsTriangularizable K L M] : IsTriangularizabl
 
 /-- For a triangularizable Lie module in finite dimensions, the weight spaces span the entire space.
 
-See also `LieModule.iSup_weightSpace_eq_top'`. -/
-lemma iSup_weightSpace_eq_top [IsTriangularizable K L M] :
-    ⨆ χ : L → K, weightSpace M χ = ⊤ := by
+See also `LieModule.iSup_genWeightSpace_eq_top'`. -/
+lemma iSup_genWeightSpace_eq_top [IsTriangularizable K L M] :
+    ⨆ χ : L → K, genWeightSpace M χ = ⊤ := by
   induction' h_dim : finrank K M using Nat.strong_induction_on with n ih generalizing M
-  obtain h' | ⟨y : L, hy : ¬ ∃ φ, weightSpaceOf M φ y = ⊤⟩ :=
-    forall_or_exists_not (fun (x : L) ↦ ∃ (φ : K), weightSpaceOf M φ x = ⊤)
+  obtain h' | ⟨y : L, hy : ¬ ∃ φ, genWeightSpaceOf M φ y = ⊤⟩ :=
+    forall_or_exists_not (fun (x : L) ↦ ∃ (φ : K), genWeightSpaceOf M φ x = ⊤)
   · choose χ hχ using h'
-    replace hχ : weightSpace M χ = ⊤ := by simpa only [weightSpace, hχ] using iInf_top
-    exact eq_top_iff.mpr <| hχ ▸ le_iSup (weightSpace M) χ
-  · replace hy : ∀ φ, finrank K (weightSpaceOf M φ y) < n := fun φ ↦ by
+    replace hχ : genWeightSpace M χ = ⊤ := by simpa only [genWeightSpace, hχ] using iInf_top
+    exact eq_top_iff.mpr <| hχ ▸ le_iSup (genWeightSpace M) χ
+  · replace hy : ∀ φ, finrank K (genWeightSpaceOf M φ y) < n := fun φ ↦ by
       simp_rw [not_exists, ← lt_top_iff_ne_top] at hy; exact h_dim ▸ Submodule.finrank_lt (hy φ)
-    replace ih : ∀ φ, ⨆ χ : L → K, weightSpace (weightSpaceOf M φ y) χ = ⊤ :=
-      fun φ ↦ ih _ (hy φ) (weightSpaceOf M φ y) rfl
-    replace ih : ∀ φ, ⨆ (χ : L → K) (_ : χ y = φ), weightSpace (weightSpaceOf M φ y) χ = ⊤ := by
+    replace ih : ∀ φ, ⨆ χ : L → K, genWeightSpace (genWeightSpaceOf M φ y) χ = ⊤ :=
+      fun φ ↦ ih _ (hy φ) (genWeightSpaceOf M φ y) rfl
+    replace ih : ∀ φ, ⨆ (χ : L → K) (_ : χ y = φ),
+        genWeightSpace (genWeightSpaceOf M φ y) χ = ⊤ := by
       intro φ
-      suffices ∀ χ : L → K, χ y ≠ φ → weightSpace (weightSpaceOf M φ y) χ = ⊥ by
+      suffices ∀ χ : L → K, χ y ≠ φ → genWeightSpace (genWeightSpaceOf M φ y) χ = ⊥ by
         specialize ih φ; rw [iSup_split, biSup_congr this] at ih; simpa using ih
       intro χ hχ
-      rw [eq_bot_iff, ← (weightSpaceOf M φ y).ker_incl, LieModuleHom.ker,
-        ← LieSubmodule.map_le_iff_le_comap, map_weightSpace_eq_of_injective
-        (weightSpaceOf M φ y).injective_incl, LieSubmodule.range_incl, ← disjoint_iff_inf_le]
-      exact (disjoint_weightSpaceOf K L M hχ).mono_left (weightSpace_le_weightSpaceOf M y χ)
-    replace ih : ∀ φ, ⨆ (χ : L → K) (_ : χ y = φ), weightSpace M χ = weightSpaceOf M φ y := by
+      rw [eq_bot_iff, ← (genWeightSpaceOf M φ y).ker_incl, LieModuleHom.ker,
+        ← LieSubmodule.map_le_iff_le_comap, map_genWeightSpace_eq_of_injective
+        (genWeightSpaceOf M φ y).injective_incl, LieSubmodule.range_incl, ← disjoint_iff_inf_le]
+      exact (disjoint_genWeightSpaceOf K L M hχ).mono_left
+        (genWeightSpace_le_genWeightSpaceOf M y χ)
+    replace ih : ∀ φ, ⨆ (χ : L → K) (_ : χ y = φ), genWeightSpace M χ = genWeightSpaceOf M φ y := by
       intro φ
-      have : ∀ (χ : L → K) (_ : χ y = φ), weightSpace M χ =
-          (weightSpace (weightSpaceOf M φ y) χ).map (weightSpaceOf M φ y).incl := fun χ hχ ↦ by
-        rw [← hχ, weightSpace_weightSpaceOf_map_incl]
+      have (χ : L → K) (hχ : χ y = φ) : genWeightSpace M χ =
+          (genWeightSpace (genWeightSpaceOf M φ y) χ).map (genWeightSpaceOf M φ y).incl := by
+        rw [← hχ, genWeightSpace_genWeightSpaceOf_map_incl]
       simp_rw [biSup_congr this, ← LieSubmodule.map_iSup, ih, LieModuleHom.map_top,
         LieSubmodule.range_incl]
     simpa only [← ih, iSup_comm (ι := K), iSup_iSup_eq_right] using
-      iSup_weightSpaceOf_eq_top K L M y
+      iSup_genWeightSpaceOf_eq_top K L M y
 
-lemma iSup_weightSpace_eq_top' [IsTriangularizable K L M] :
-    ⨆ χ : Weight K L M, weightSpace M χ = ⊤ := by
-  have := iSup_weightSpace_eq_top K L M
+lemma iSup_genWeightSpace_eq_top' [IsTriangularizable K L M] :
+    ⨆ χ : Weight K L M, genWeightSpace M χ = ⊤ := by
+  have := iSup_genWeightSpace_eq_top K L M
   erw [← iSup_ne_bot_subtype, ← (Weight.equivSetOf K L M).iSup_comp] at this
   exact this
 

--- a/Mathlib/Algebra/Lie/Weights/Cartan.lean
+++ b/Mathlib/Algebra/Lie/Weights/Cartan.lean
@@ -42,38 +42,39 @@ open TensorProduct.LieModule LieModule
 /-- Given a nilpotent Lie subalgebra `H ⊆ L`, the root space of a map `χ : H → R` is the weight
 space of `L` regarded as a module of `H` via the adjoint action. -/
 abbrev rootSpace (χ : H → R) : LieSubmodule R H L :=
-  weightSpace L χ
+  genWeightSpace L χ
 
 theorem zero_rootSpace_eq_top_of_nilpotent [IsNilpotent R L] :
     rootSpace (⊤ : LieSubalgebra R L) 0 = ⊤ :=
-  zero_weightSpace_eq_top_of_nilpotent L
+  zero_genWeightSpace_eq_top_of_nilpotent L
 
 @[simp]
-theorem rootSpace_comap_eq_weightSpace (χ : H → R) :
-    (rootSpace H χ).comap H.incl' = weightSpace H χ :=
-  comap_weightSpace_eq_of_injective Subtype.coe_injective
+theorem rootSpace_comap_eq_genWeightSpace (χ : H → R) :
+    (rootSpace H χ).comap H.incl' = genWeightSpace H χ :=
+  comap_genWeightSpace_eq_of_injective Subtype.coe_injective
 
 variable {H}
 
-theorem lie_mem_weightSpace_of_mem_weightSpace {χ₁ χ₂ : H → R} {x : L} {m : M}
-    (hx : x ∈ rootSpace H χ₁) (hm : m ∈ weightSpace M χ₂) : ⁅x, m⁆ ∈ weightSpace M (χ₁ + χ₂) := by
-  rw [weightSpace, LieSubmodule.mem_iInf]
+theorem lie_mem_genWeightSpace_of_mem_genWeightSpace {χ₁ χ₂ : H → R} {x : L} {m : M}
+    (hx : x ∈ rootSpace H χ₁) (hm : m ∈ genWeightSpace M χ₂) :
+    ⁅x, m⁆ ∈ genWeightSpace M (χ₁ + χ₂) := by
+  rw [genWeightSpace, LieSubmodule.mem_iInf]
   intro y
-  replace hx : x ∈ weightSpaceOf L (χ₁ y) y := by
-    rw [rootSpace, weightSpace, LieSubmodule.mem_iInf] at hx; exact hx y
-  replace hm : m ∈ weightSpaceOf M (χ₂ y) y := by
-    rw [weightSpace, LieSubmodule.mem_iInf] at hm; exact hm y
+  replace hx : x ∈ genWeightSpaceOf L (χ₁ y) y := by
+    rw [rootSpace, genWeightSpace, LieSubmodule.mem_iInf] at hx; exact hx y
+  replace hm : m ∈ genWeightSpaceOf M (χ₂ y) y := by
+    rw [genWeightSpace, LieSubmodule.mem_iInf] at hm; exact hm y
   exact lie_mem_maxGenEigenspace_toEnd hx hm
 
 lemma toEnd_pow_apply_mem {χ₁ χ₂ : H → R} {x : L} {m : M}
-    (hx : x ∈ rootSpace H χ₁) (hm : m ∈ weightSpace M χ₂) (n) :
-    (toEnd R L M x ^ n : Module.End R M) m ∈ weightSpace M (n • χ₁ + χ₂) := by
+    (hx : x ∈ rootSpace H χ₁) (hm : m ∈ genWeightSpace M χ₂) (n) :
+    (toEnd R L M x ^ n : Module.End R M) m ∈ genWeightSpace M (n • χ₁ + χ₂) := by
   induction n with
   | zero => simpa using hm
   | succ n IH =>
     simp only [pow_succ', LinearMap.mul_apply, toEnd_apply_apply,
       Nat.cast_add, Nat.cast_one, rootSpace]
-    convert lie_mem_weightSpace_of_mem_weightSpace hx IH using 2
+    convert lie_mem_genWeightSpace_of_mem_genWeightSpace hx IH using 2
     rw [succ_nsmul, ← add_assoc, add_comm (n • _)]
 
 variable (R L H M)
@@ -82,10 +83,11 @@ variable (R L H M)
 which is close to the deterministic timeout limit.
 -/
 def rootSpaceWeightSpaceProductAux {χ₁ χ₂ χ₃ : H → R} (hχ : χ₁ + χ₂ = χ₃) :
-    rootSpace H χ₁ →ₗ[R] weightSpace M χ₂ →ₗ[R] weightSpace M χ₃ where
+    rootSpace H χ₁ →ₗ[R] genWeightSpace M χ₂ →ₗ[R] genWeightSpace M χ₃ where
   toFun x :=
     { toFun := fun m =>
-        ⟨⁅(x : L), (m : M)⁆, hχ ▸ lie_mem_weightSpace_of_mem_weightSpace x.property m.property⟩
+        ⟨⁅(x : L), (m : M)⁆,
+          hχ ▸ lie_mem_genWeightSpace_of_mem_genWeightSpace x.property m.property⟩
       map_add' := fun m n => by simp only [LieSubmodule.coe_add, lie_add]; rfl
       map_smul' := fun t m => by
         dsimp only
@@ -108,8 +110,8 @@ def rootSpaceWeightSpaceProductAux {χ₁ χ₂ χ₃ : H → R} (hχ : χ₁ + 
 /-- Given a nilpotent Lie subalgebra `H ⊆ L` together with `χ₁ χ₂ : H → R`, there is a natural
 `R`-bilinear product of root vectors and weight vectors, compatible with the actions of `H`. -/
 def rootSpaceWeightSpaceProduct (χ₁ χ₂ χ₃ : H → R) (hχ : χ₁ + χ₂ = χ₃) :
-    rootSpace H χ₁ ⊗[R] weightSpace M χ₂ →ₗ⁅R,H⁆ weightSpace M χ₃ :=
-  liftLie R H (rootSpace H χ₁) (weightSpace M χ₂) (weightSpace M χ₃)
+    rootSpace H χ₁ ⊗[R] genWeightSpace M χ₂ →ₗ⁅R,H⁆ genWeightSpace M χ₃ :=
+  liftLie R H (rootSpace H χ₁) (genWeightSpace M χ₂) (genWeightSpace M χ₃)
     { toLinearMap := rootSpaceWeightSpaceProductAux R L H M hχ
       map_lie' := fun {x y} => by
         ext m
@@ -119,18 +121,18 @@ def rootSpaceWeightSpaceProduct (χ₁ χ₂ χ₃ : H → R) (hχ : χ₁ + χ�
 
 @[simp]
 theorem coe_rootSpaceWeightSpaceProduct_tmul (χ₁ χ₂ χ₃ : H → R) (hχ : χ₁ + χ₂ = χ₃)
-    (x : rootSpace H χ₁) (m : weightSpace M χ₂) :
+    (x : rootSpace H χ₁) (m : genWeightSpace M χ₂) :
     (rootSpaceWeightSpaceProduct R L H M χ₁ χ₂ χ₃ hχ (x ⊗ₜ m) : M) = ⁅(x : L), (m : M)⁆ := by
   simp only [rootSpaceWeightSpaceProduct, rootSpaceWeightSpaceProductAux, coe_liftLie_eq_lift_coe,
     AddHom.toFun_eq_coe, LinearMap.coe_toAddHom, lift_apply, LinearMap.coe_mk, AddHom.coe_mk,
     Submodule.coe_mk]
 
-theorem mapsTo_toEnd_weightSpace_add_of_mem_rootSpace (α χ : H → R)
+theorem mapsTo_toEnd_genWeightSpace_add_of_mem_rootSpace (α χ : H → R)
     {x : L} (hx : x ∈ rootSpace H α) :
-    MapsTo (toEnd R L M x) (weightSpace M χ) (weightSpace M (α + χ)) := by
+    MapsTo (toEnd R L M x) (genWeightSpace M χ) (genWeightSpace M (α + χ)) := by
   intro m hm
   let x' : rootSpace H α := ⟨x, hx⟩
-  let m' : weightSpace M χ := ⟨m, hm⟩
+  let m' : genWeightSpace M χ := ⟨m, hm⟩
   exact (rootSpaceWeightSpaceProduct R L H M α χ (α + χ) rfl (x' ⊗ₜ m')).property
 
 /-- Given a nilpotent Lie subalgebra `H ⊆ L` together with `χ₁ χ₂ : H → R`, there is a natural
@@ -163,12 +165,12 @@ theorem coe_zeroRootSubalgebra : (zeroRootSubalgebra R L H : Submodule R L) = ro
 theorem mem_zeroRootSubalgebra (x : L) :
     x ∈ zeroRootSubalgebra R L H ↔ ∀ y : H, ∃ k : ℕ, (toEnd R H L y ^ k) x = 0 := by
   change x ∈ rootSpace H 0 ↔ _
-  simp only [mem_weightSpace, Pi.zero_apply, zero_smul, sub_zero]
+  simp only [mem_genWeightSpace, Pi.zero_apply, zero_smul, sub_zero]
 
 theorem toLieSubmodule_le_rootSpace_zero : H.toLieSubmodule ≤ rootSpace H 0 := by
   intro x hx
   simp only [LieSubalgebra.mem_toLieSubmodule] at hx
-  simp only [mem_weightSpace, Pi.zero_apply, sub_zero, zero_smul]
+  simp only [mem_genWeightSpace, Pi.zero_apply, sub_zero, zero_smul]
   intro y
   obtain ⟨k, hk⟩ := (inferInstance : IsNilpotent R H)
   use k
@@ -189,7 +191,7 @@ theorem toLieSubmodule_le_rootSpace_zero : H.toLieSubmodule ≤ rootSpace H 0 :=
   exact h
 
 /-- This enables the instance `Zero (Weight R H L)`. -/
-instance [Nontrivial H] : Nontrivial (weightSpace L (0 : H → R)) := by
+instance [Nontrivial H] : Nontrivial (genWeightSpace L (0 : H → R)) := by
   obtain ⟨⟨x, hx⟩, ⟨y, hy⟩, e⟩ := exists_pair_ne H
   exact ⟨⟨x, toLieSubmodule_le_rootSpace_zero R L H hx⟩,
     ⟨y, toLieSubmodule_le_rootSpace_zero R L H hy⟩, by simpa using e⟩

--- a/Mathlib/Algebra/Lie/Weights/Chain.lean
+++ b/Mathlib/Algebra/Lie/Weights/Chain.lean
@@ -25,12 +25,12 @@ We provide basic definitions and results to support `α`-chain techniques in thi
 
 ## Main definitions / results
 
- * `LieModule.exists₂_weightSpace_smul_add_eq_bot`: given weights `χ₁`, `χ₂` if `χ₁ ≠ 0`, we can
+ * `LieModule.exists₂_genWeightSpace_smul_add_eq_bot`: given weights `χ₁`, `χ₂` if `χ₁ ≠ 0`, we can
    find `p < 0` and `q > 0` such that the weight spaces `p • χ₁ + χ₂` and `q • χ₁ + χ₂` are both
    trivial.
- * `LieModule.weightSpaceChain`: given weights `χ₁`, `χ₂` together with integers `p` and `q`, this
-   is the sum of the weight spaces `k • χ₁ + χ₂` for `p < k < q`.
- * `LieModule.trace_toEnd_weightSpaceChain_eq_zero`: given a root `α` relative to a Cartan
+ * `LieModule.genWeightSpaceChain`: given weights `χ₁`, `χ₂` together with integers `p` and `q`,
+   this is the sum of the weight spaces `k • χ₁ + χ₂` for `p < k < q`.
+ * `LieModule.trace_toEnd_genWeightSpaceChain_eq_zero`: given a root `α` relative to a Cartan
    subalgebra `H`, there is a natural ideal `corootSpace α` in `H`. This lemma
    states that this ideal acts by trace-zero endomorphisms on the sum of root spaces of any
    `α`-chain, provided the weight spaces at the endpoints are both trivial.
@@ -57,28 +57,28 @@ section
 variable [NoZeroSMulDivisors ℤ R] [NoZeroSMulDivisors R M] [IsNoetherian R M] (hχ₁ : χ₁ ≠ 0)
 include hχ₁
 
-lemma eventually_weightSpace_smul_add_eq_bot :
-    ∀ᶠ (k : ℕ) in Filter.atTop, weightSpace M (k • χ₁ + χ₂) = ⊥ := by
+lemma eventually_genWeightSpace_smul_add_eq_bot :
+    ∀ᶠ (k : ℕ) in Filter.atTop, genWeightSpace M (k • χ₁ + χ₂) = ⊥ := by
   let f : ℕ → L → R := fun k ↦ k • χ₁ + χ₂
   suffices Injective f by
     rw [← Nat.cofinite_eq_atTop, Filter.eventually_cofinite, ← finite_image_iff this.injOn]
-    apply (finite_weightSpace_ne_bot R L M).subset
+    apply (finite_genWeightSpace_ne_bot R L M).subset
     simp [f]
   intro k l hkl
   replace hkl : (k : ℤ) • χ₁ = (l : ℤ) • χ₁ := by
     simpa only [f, add_left_inj, natCast_zsmul] using hkl
   exact Nat.cast_inj.mp <| smul_left_injective ℤ hχ₁ hkl
 
-lemma exists_weightSpace_smul_add_eq_bot :
-    ∃ k > 0, weightSpace M (k • χ₁ + χ₂) = ⊥ :=
-  (Nat.eventually_pos.and <| eventually_weightSpace_smul_add_eq_bot M χ₁ χ₂ hχ₁).exists
+lemma exists_genWeightSpace_smul_add_eq_bot :
+    ∃ k > 0, genWeightSpace M (k • χ₁ + χ₂) = ⊥ :=
+  (Nat.eventually_pos.and <| eventually_genWeightSpace_smul_add_eq_bot M χ₁ χ₂ hχ₁).exists
 
-lemma exists₂_weightSpace_smul_add_eq_bot :
+lemma exists₂_genWeightSpace_smul_add_eq_bot :
     ∃ᵉ (p < (0 : ℤ)) (q > (0 : ℤ)),
-      weightSpace M (p • χ₁ + χ₂) = ⊥ ∧
-      weightSpace M (q • χ₁ + χ₂) = ⊥ := by
-  obtain ⟨q, hq₀, hq⟩ := exists_weightSpace_smul_add_eq_bot M χ₁ χ₂ hχ₁
-  obtain ⟨p, hp₀, hp⟩ := exists_weightSpace_smul_add_eq_bot M (-χ₁) χ₂ (neg_ne_zero.mpr hχ₁)
+      genWeightSpace M (p • χ₁ + χ₂) = ⊥ ∧
+      genWeightSpace M (q • χ₁ + χ₂) = ⊥ := by
+  obtain ⟨q, hq₀, hq⟩ := exists_genWeightSpace_smul_add_eq_bot M χ₁ χ₂ hχ₁
+  obtain ⟨p, hp₀, hp⟩ := exists_genWeightSpace_smul_add_eq_bot M (-χ₁) χ₂ (neg_ne_zero.mpr hχ₁)
   refine ⟨-(p : ℤ), by simpa, q, by simpa, ?_, ?_⟩
   · rw [neg_smul, ← smul_neg, natCast_zsmul]
     exact hp
@@ -90,28 +90,28 @@ end
 /-- Given two (potential) weights `χ₁` and `χ₂` together with integers `p` and `q`, it is often
 useful to study the sum of weight spaces associated to the family of weights `k • χ₁ + χ₂` for
 `p < k < q`. -/
-def weightSpaceChain : LieSubmodule R L M :=
-  ⨆ k ∈ Ioo p q, weightSpace M (k • χ₁ + χ₂)
+def genWeightSpaceChain : LieSubmodule R L M :=
+  ⨆ k ∈ Ioo p q, genWeightSpace M (k • χ₁ + χ₂)
 
-lemma weightSpaceChain_def :
-    weightSpaceChain M χ₁ χ₂ p q = ⨆ k ∈ Ioo p q, weightSpace M (k • χ₁ + χ₂) :=
+lemma genWeightSpaceChain_def :
+    genWeightSpaceChain M χ₁ χ₂ p q = ⨆ k ∈ Ioo p q, genWeightSpace M (k • χ₁ + χ₂) :=
   rfl
 
-lemma weightSpaceChain_def' :
-    weightSpaceChain M χ₁ χ₂ p q = ⨆ k ∈ Finset.Ioo p q, weightSpace M (k • χ₁ + χ₂) := by
+lemma genWeightSpaceChain_def' :
+    genWeightSpaceChain M χ₁ χ₂ p q = ⨆ k ∈ Finset.Ioo p q, genWeightSpace M (k • χ₁ + χ₂) := by
   have : ∀ (k : ℤ), k ∈ Ioo p q ↔ k ∈ Finset.Ioo p q := by simp
-  simp_rw [weightSpaceChain_def, this]
+  simp_rw [genWeightSpaceChain_def, this]
 
 @[simp]
-lemma weightSpaceChain_neg :
-    weightSpaceChain M (-χ₁) χ₂ (-q) (-p) = weightSpaceChain M χ₁ χ₂ p q := by
+lemma genWeightSpaceChain_neg :
+    genWeightSpaceChain M (-χ₁) χ₂ (-q) (-p) = genWeightSpaceChain M χ₁ χ₂ p q := by
   let e : ℤ ≃ ℤ := neg_involutive.toPerm
-  simp_rw [weightSpaceChain, ← e.biSup_comp (Ioo p q)]
+  simp_rw [genWeightSpaceChain, ← e.biSup_comp (Ioo p q)]
   simp [e, -mem_Ioo, neg_mem_Ioo_iff]
 
-lemma weightSpace_le_weightSpaceChain {k : ℤ} (hk : k ∈ Ioo p q) :
-    weightSpace M (k • χ₁ + χ₂) ≤ weightSpaceChain M χ₁ χ₂ p q :=
-  le_biSup (fun i ↦ weightSpace M (i • χ₁ + χ₂)) hk
+lemma genWeightSpace_le_genWeightSpaceChain {k : ℤ} (hk : k ∈ Ioo p q) :
+    genWeightSpace M (k • χ₁ + χ₂) ≤ genWeightSpaceChain M χ₁ χ₂ p q :=
+  le_biSup (fun i ↦ genWeightSpace M (i • χ₁ + χ₂)) hk
 
 end IsNilpotent
 
@@ -121,56 +121,56 @@ open LieAlgebra
 
 variable {H : LieSubalgebra R L} (α χ : H → R) (p q : ℤ)
 
-lemma lie_mem_weightSpaceChain_of_weightSpace_eq_bot_right [LieAlgebra.IsNilpotent R H]
-    (hq : weightSpace M (q • α + χ) = ⊥)
+lemma lie_mem_genWeightSpaceChain_of_genWeightSpace_eq_bot_right [LieAlgebra.IsNilpotent R H]
+    (hq : genWeightSpace M (q • α + χ) = ⊥)
     {x : L} (hx : x ∈ rootSpace H α)
-    {y : M} (hy : y ∈ weightSpaceChain M α χ p q) :
-    ⁅x, y⁆ ∈ weightSpaceChain M α χ p q := by
-  rw [weightSpaceChain, iSup_subtype'] at hy
+    {y : M} (hy : y ∈ genWeightSpaceChain M α χ p q) :
+    ⁅x, y⁆ ∈ genWeightSpaceChain M α χ p q := by
+  rw [genWeightSpaceChain, iSup_subtype'] at hy
   induction' hy using LieSubmodule.iSup_induction' with k z hz z₁ z₂ _ _ hz₁ hz₂
   · obtain ⟨k, hk⟩ := k
-    suffices weightSpace M ((k + 1) • α + χ) ≤ weightSpaceChain M α χ p q by
+    suffices genWeightSpace M ((k + 1) • α + χ) ≤ genWeightSpaceChain M α χ p q by
       apply this
       simpa using (rootSpaceWeightSpaceProduct R L H M α (k • α + χ) ((k + 1) • α + χ)
         (by rw [add_smul]; abel) (⟨x, hx⟩ ⊗ₜ ⟨z, hz⟩)).property
-    rw [weightSpaceChain]
+    rw [genWeightSpaceChain]
     rcases eq_or_ne (k + 1) q with rfl | hk'; · simp only [hq, bot_le]
     replace hk' : k + 1 ∈ Ioo p q := ⟨by linarith [hk.1], lt_of_le_of_ne hk.2 hk'⟩
-    exact le_biSup (fun k ↦ weightSpace M (k • α + χ)) hk'
+    exact le_biSup (fun k ↦ genWeightSpace M (k • α + χ)) hk'
   · simp
   · rw [lie_add]
     exact add_mem hz₁ hz₂
 
-lemma lie_mem_weightSpaceChain_of_weightSpace_eq_bot_left [LieAlgebra.IsNilpotent R H]
-    (hp : weightSpace M (p • α + χ) = ⊥)
+lemma lie_mem_genWeightSpaceChain_of_genWeightSpace_eq_bot_left [LieAlgebra.IsNilpotent R H]
+    (hp : genWeightSpace M (p • α + χ) = ⊥)
     {x : L} (hx : x ∈ rootSpace H (-α))
-    {y : M} (hy : y ∈ weightSpaceChain M α χ p q) :
-    ⁅x, y⁆ ∈ weightSpaceChain M α χ p q := by
-  replace hp : weightSpace M ((-p) • (-α) + χ) = ⊥ := by rwa [smul_neg, neg_smul, neg_neg]
-  rw [← weightSpaceChain_neg] at hy ⊢
-  exact lie_mem_weightSpaceChain_of_weightSpace_eq_bot_right M (-α) χ (-q) (-p) hp hx hy
+    {y : M} (hy : y ∈ genWeightSpaceChain M α χ p q) :
+    ⁅x, y⁆ ∈ genWeightSpaceChain M α χ p q := by
+  replace hp : genWeightSpace M ((-p) • (-α) + χ) = ⊥ := by rwa [smul_neg, neg_smul, neg_neg]
+  rw [← genWeightSpaceChain_neg] at hy ⊢
+  exact lie_mem_genWeightSpaceChain_of_genWeightSpace_eq_bot_right M (-α) χ (-q) (-p) hp hx hy
 
 section IsCartanSubalgebra
 
 variable [H.IsCartanSubalgebra] [IsNoetherian R L]
 
-lemma trace_toEnd_weightSpaceChain_eq_zero
-    (hp : weightSpace M (p • α + χ) = ⊥)
-    (hq : weightSpace M (q • α + χ) = ⊥)
+lemma trace_toEnd_genWeightSpaceChain_eq_zero
+    (hp : genWeightSpace M (p • α + χ) = ⊥)
+    (hq : genWeightSpace M (q • α + χ) = ⊥)
     {x : H} (hx : x ∈ corootSpace α) :
-    LinearMap.trace R _ (toEnd R H (weightSpaceChain M α χ p q) x) = 0 := by
+    LinearMap.trace R _ (toEnd R H (genWeightSpaceChain M α χ p q) x) = 0 := by
   rw [LieAlgebra.mem_corootSpace'] at hx
   induction hx using Submodule.span_induction'
   · next u hu =>
     obtain ⟨y, hy, z, hz, hyz⟩ := hu
-    let f : Module.End R (weightSpaceChain M α χ p q) :=
+    let f : Module.End R (genWeightSpaceChain M α χ p q) :=
       { toFun := fun ⟨m, hm⟩ ↦ ⟨⁅(y : L), m⁆,
-          lie_mem_weightSpaceChain_of_weightSpace_eq_bot_right M α χ p q hq hy hm⟩
+          lie_mem_genWeightSpaceChain_of_genWeightSpace_eq_bot_right M α χ p q hq hy hm⟩
         map_add' := fun _ _ ↦ by simp
         map_smul' := fun t m ↦ by simp }
-    let g : Module.End R (weightSpaceChain M α χ p q) :=
+    let g : Module.End R (genWeightSpaceChain M α χ p q) :=
       { toFun := fun ⟨m, hm⟩ ↦ ⟨⁅(z : L), m⁆,
-          lie_mem_weightSpaceChain_of_weightSpace_eq_bot_left M α χ p q hp hz hm⟩
+          lie_mem_genWeightSpaceChain_of_genWeightSpace_eq_bot_left M α χ p q hp hz hm⟩
         map_add' := fun _ _ ↦ by simp
         map_smul' := fun t m ↦ by simp }
     have hfg : toEnd R H _ u = ⁅f, g⁆ := by ext; simp [f, g, ← hyz]
@@ -188,30 +188,30 @@ semisimple Lie algebra form a root system. It shows that the restriction of `α`
 the restriction of every root to `I` vanishes (which cannot happen in a semisimple Lie algebra). -/
 lemma exists_forall_mem_corootSpace_smul_add_eq_zero
     [IsDomain R] [IsPrincipalIdealRing R] [CharZero R] [NoZeroSMulDivisors R M] [IsNoetherian R M]
-    (hα : α ≠ 0) (hχ : weightSpace M χ ≠ ⊥) :
+    (hα : α ≠ 0) (hχ : genWeightSpace M χ ≠ ⊥) :
     ∃ a b : ℤ, 0 < b ∧ ∀ x ∈ corootSpace α, (a • α + b • χ) x = 0 := by
-  obtain ⟨p, hp₀, q, hq₀, hp, hq⟩ := exists₂_weightSpace_smul_add_eq_bot M α χ hα
-  let a := ∑ i ∈ Finset.Ioo p q, finrank R (weightSpace M (i • α + χ)) • i
-  let b := ∑ i ∈ Finset.Ioo p q, finrank R (weightSpace M (i • α + χ))
+  obtain ⟨p, hp₀, q, hq₀, hp, hq⟩ := exists₂_genWeightSpace_smul_add_eq_bot M α χ hα
+  let a := ∑ i ∈ Finset.Ioo p q, finrank R (genWeightSpace M (i • α + χ)) • i
+  let b := ∑ i ∈ Finset.Ioo p q, finrank R (genWeightSpace M (i • α + χ))
   have hb : 0 < b := by
-    replace hχ : Nontrivial (weightSpace M χ) := by rwa [LieSubmodule.nontrivial_iff_ne_bot]
+    replace hχ : Nontrivial (genWeightSpace M χ) := by rwa [LieSubmodule.nontrivial_iff_ne_bot]
     refine Finset.sum_pos' (fun _ _ ↦ zero_le _) ⟨0, Finset.mem_Ioo.mpr ⟨hp₀, hq₀⟩, ?_⟩
     rw [zero_smul, zero_add]
     exact finrank_pos
   refine ⟨a, b, Int.ofNat_pos.mpr hb, fun x hx ↦ ?_⟩
-  let N : ℤ → Submodule R M := fun k ↦ weightSpace M (k • α + χ)
+  let N : ℤ → Submodule R M := fun k ↦ genWeightSpace M (k • α + χ)
   have h₁ : CompleteLattice.Independent fun (i : Finset.Ioo p q) ↦ N i := by
     rw [← LieSubmodule.independent_iff_coe_toSubmodule]
-    refine (independent_weightSpace R H M).comp fun i j hij ↦ ?_
+    refine (independent_genWeightSpace R H M).comp fun i j hij ↦ ?_
     exact SetCoe.ext <| smul_left_injective ℤ hα <| by rwa [add_left_inj] at hij
   have h₂ : ∀ i, MapsTo (toEnd R H M x) ↑(N i) ↑(N i) := fun _ _ ↦ LieSubmodule.lie_mem _
-  have h₃ : weightSpaceChain M α χ p q = ⨆ i ∈ Finset.Ioo p q, N i := by
-    simp_rw [weightSpaceChain_def', LieSubmodule.iSup_coe_toSubmodule]
-  rw [← trace_toEnd_weightSpaceChain_eq_zero M α χ p q hp hq hx,
+  have h₃ : genWeightSpaceChain M α χ p q = ⨆ i ∈ Finset.Ioo p q, N i := by
+    simp_rw [genWeightSpaceChain_def', LieSubmodule.iSup_coe_toSubmodule]
+  rw [← trace_toEnd_genWeightSpaceChain_eq_zero M α χ p q hp hq hx,
     ← LieSubmodule.toEnd_restrict_eq_toEnd,
-    LinearMap.trace_eq_sum_trace_restrict_of_eq_biSup _ h₁ h₂ (weightSpaceChain M α χ p q) h₃]
+    LinearMap.trace_eq_sum_trace_restrict_of_eq_biSup _ h₁ h₂ (genWeightSpaceChain M α χ p q) h₃]
   simp_rw [LieSubmodule.toEnd_restrict_eq_toEnd,
-    trace_toEnd_weightSpace, Pi.add_apply, Pi.smul_apply, smul_add, ← smul_assoc,
+    trace_toEnd_genWeightSpace, Pi.add_apply, Pi.smul_apply, smul_add, ← smul_assoc,
     Finset.sum_add_distrib, ← Finset.sum_smul, natCast_zsmul]
 
 end IsCartanSubalgebra
@@ -230,8 +230,8 @@ noncomputable
 def chainTopCoeff : ℕ :=
   letI := Classical.propDecidable
   if hα : α = 0 then 0 else
-  Nat.pred <| Nat.find (show ∃ n, weightSpace M (n • α + β : L → R) = ⊥ from
-    (eventually_weightSpace_smul_add_eq_bot M α β hα).exists)
+  Nat.pred <| Nat.find (show ∃ n, genWeightSpace M (n • α + β : L → R) = ⊥ from
+    (eventually_genWeightSpace_smul_add_eq_bot M α β hα).exists)
 
 /-- This is the largest `n : ℕ` such that `-i • α + β` is a weight for all `0 ≤ i ≤ n`. -/
 noncomputable
@@ -251,66 +251,66 @@ include hα
 lemma chainTopCoeff_add_one :
     letI := Classical.propDecidable
     chainTopCoeff α β + 1 =
-      Nat.find (eventually_weightSpace_smul_add_eq_bot M α β hα).exists := by
+      Nat.find (eventually_genWeightSpace_smul_add_eq_bot M α β hα).exists := by
   classical
   rw [chainTopCoeff, dif_neg hα]
   apply Nat.succ_pred_eq_of_pos
   rw [zero_lt_iff]
   intro e
-  have : weightSpace M (0 • α + β : L → R) = ⊥ := by
+  have : genWeightSpace M (0 • α + β : L → R) = ⊥ := by
     rw [← e]
-    exact Nat.find_spec (eventually_weightSpace_smul_add_eq_bot M α β hα).exists
-  exact β.weightSpace_ne_bot _ (by simpa only [zero_smul, zero_add] using this)
+    exact Nat.find_spec (eventually_genWeightSpace_smul_add_eq_bot M α β hα).exists
+  exact β.genWeightSpace_ne_bot _ (by simpa only [zero_smul, zero_add] using this)
 
-lemma weightSpace_chainTopCoeff_add_one_nsmul_add :
-    weightSpace M ((chainTopCoeff α β + 1) • α + β : L → R) = ⊥ := by
+lemma genWeightSpace_chainTopCoeff_add_one_nsmul_add :
+    genWeightSpace M ((chainTopCoeff α β + 1) • α + β : L → R) = ⊥ := by
   classical
   rw [chainTopCoeff_add_one _ _ hα]
-  exact Nat.find_spec (eventually_weightSpace_smul_add_eq_bot M α β hα).exists
+  exact Nat.find_spec (eventually_genWeightSpace_smul_add_eq_bot M α β hα).exists
 
-lemma weightSpace_chainTopCoeff_add_one_zsmul_add :
-    weightSpace M ((chainTopCoeff α β + 1 : ℤ) • α + β : L → R) = ⊥ := by
-  rw [← weightSpace_chainTopCoeff_add_one_nsmul_add α β hα, ← Nat.cast_smul_eq_nsmul ℤ,
+lemma genWeightSpace_chainTopCoeff_add_one_zsmul_add :
+    genWeightSpace M ((chainTopCoeff α β + 1 : ℤ) • α + β : L → R) = ⊥ := by
+  rw [← genWeightSpace_chainTopCoeff_add_one_nsmul_add α β hα, ← Nat.cast_smul_eq_nsmul ℤ,
     Nat.cast_add, Nat.cast_one]
 
-lemma weightSpace_chainBotCoeff_sub_one_zsmul_sub :
-    weightSpace M ((-chainBotCoeff α β - 1 : ℤ) • α + β : L → R) = ⊥ := by
+lemma genWeightSpace_chainBotCoeff_sub_one_zsmul_sub :
+    genWeightSpace M ((-chainBotCoeff α β - 1 : ℤ) • α + β : L → R) = ⊥ := by
   rw [sub_eq_add_neg, ← neg_add, neg_smul, ← smul_neg, chainBotCoeff,
-    weightSpace_chainTopCoeff_add_one_zsmul_add _ _ (by simpa using hα)]
+    genWeightSpace_chainTopCoeff_add_one_zsmul_add _ _ (by simpa using hα)]
 
 end
 
-lemma weightSpace_nsmul_add_ne_bot_of_le {n} (hn : n ≤ chainTopCoeff α β) :
-    weightSpace M (n • α + β : L → R) ≠ ⊥ := by
+lemma genWeightSpace_nsmul_add_ne_bot_of_le {n} (hn : n ≤ chainTopCoeff α β) :
+    genWeightSpace M (n • α + β : L → R) ≠ ⊥ := by
   by_cases hα : α = 0
-  · rw [hα, smul_zero, zero_add]; exact β.weightSpace_ne_bot
+  · rw [hα, smul_zero, zero_add]; exact β.genWeightSpace_ne_bot
   classical
   rw [← Nat.lt_succ, Nat.succ_eq_add_one, chainTopCoeff_add_one _ _ hα] at hn
-  exact Nat.find_min (eventually_weightSpace_smul_add_eq_bot M α β hα).exists hn
+  exact Nat.find_min (eventually_genWeightSpace_smul_add_eq_bot M α β hα).exists hn
 
-lemma weightSpace_zsmul_add_ne_bot {n : ℤ}
+lemma genWeightSpace_zsmul_add_ne_bot {n : ℤ}
     (hn : -chainBotCoeff α β ≤ n) (hn' : n ≤ chainTopCoeff α β) :
-      weightSpace M (n • α + β : L → R) ≠ ⊥ := by
+      genWeightSpace M (n • α + β : L → R) ≠ ⊥ := by
   rcases n with (n | n)
   · simp only [Int.ofNat_eq_coe, Nat.cast_le, Nat.cast_smul_eq_nsmul] at hn' ⊢
-    exact weightSpace_nsmul_add_ne_bot_of_le α β hn'
+    exact genWeightSpace_nsmul_add_ne_bot_of_le α β hn'
   · simp only [Int.negSucc_eq, ← Nat.cast_succ, neg_le_neg_iff, Nat.cast_le] at hn ⊢
     rw [neg_smul, ← smul_neg, Nat.cast_smul_eq_nsmul]
-    exact weightSpace_nsmul_add_ne_bot_of_le (-α) β hn
+    exact genWeightSpace_nsmul_add_ne_bot_of_le (-α) β hn
 
-lemma weightSpace_neg_zsmul_add_ne_bot {n : ℕ} (hn : n ≤ chainBotCoeff α β) :
-    weightSpace M ((-n : ℤ) • α + β : L → R) ≠ ⊥ := by
-  apply weightSpace_zsmul_add_ne_bot α β <;> omega
+lemma genWeightSpace_neg_zsmul_add_ne_bot {n : ℕ} (hn : n ≤ chainBotCoeff α β) :
+    genWeightSpace M ((-n : ℤ) • α + β : L → R) ≠ ⊥ := by
+  apply genWeightSpace_zsmul_add_ne_bot α β <;> omega
 
 /-- The last weight in an `α`-chain through `β`. -/
 noncomputable
 def chainTop (α : L → R) (β : Weight R L M) : Weight R L M :=
-  ⟨chainTopCoeff α β • α + β, weightSpace_nsmul_add_ne_bot_of_le α β le_rfl⟩
+  ⟨chainTopCoeff α β • α + β, genWeightSpace_nsmul_add_ne_bot_of_le α β le_rfl⟩
 
 /-- The first weight in an `α`-chain through `β`. -/
 noncomputable
 def chainBot (α : L → R) (β : Weight R L M) : Weight R L M :=
-  ⟨(- chainBotCoeff α β : ℤ) • α + β, weightSpace_neg_zsmul_add_ne_bot α β le_rfl⟩
+  ⟨(- chainBotCoeff α β : ℤ) • α + β, genWeightSpace_neg_zsmul_add_ne_bot α β le_rfl⟩
 
 lemma coe_chainTop' : (chainTop α β : L → R) = chainTopCoeff α β • α + β := rfl
 
@@ -328,19 +328,20 @@ section
 variable (hα : α ≠ 0)
 include hα
 
-lemma weightSpace_add_chainTop :
-    weightSpace M (α + chainTop α β : L → R) = ⊥ := by
-  rw [coe_chainTop', ← add_assoc, ← succ_nsmul', weightSpace_chainTopCoeff_add_one_nsmul_add _ _ hα]
+lemma genWeightSpace_add_chainTop :
+    genWeightSpace M (α + chainTop α β : L → R) = ⊥ := by
+  rw [coe_chainTop', ← add_assoc, ← succ_nsmul',
+    genWeightSpace_chainTopCoeff_add_one_nsmul_add _ _ hα]
 
-lemma weightSpace_neg_add_chainBot :
-    weightSpace M (-α + chainBot α β : L → R) = ⊥ := by
-  rw [← chainTop_neg, weightSpace_add_chainTop _ _ (by simpa using hα)]
+lemma genWeightSpace_neg_add_chainBot :
+    genWeightSpace M (-α + chainBot α β : L → R) = ⊥ := by
+  rw [← chainTop_neg, genWeightSpace_add_chainTop _ _ (by simpa using hα)]
 
-lemma chainTop_isNonZero' (hα' : weightSpace M α ≠ ⊥) :
+lemma chainTop_isNonZero' (hα' : genWeightSpace M α ≠ ⊥) :
     (chainTop α β).IsNonZero := by
   by_contra e
   apply hα'
-  rw [← add_zero (α : L → R), ← e, weightSpace_add_chainTop _ _ hα]
+  rw [← add_zero (α : L → R), ← e, genWeightSpace_add_chainTop _ _ hα]
 
 end
 

--- a/Mathlib/Algebra/Lie/Weights/Killing.lean
+++ b/Mathlib/Algebra/Lie/Weights/Killing.lean
@@ -52,7 +52,7 @@ lemma ker_restrict_eq_bot_of_isCartanSubalgebra
     [IsNoetherian R L] [IsArtinian R L] (H : LieSubalgebra R L) [H.IsCartanSubalgebra] :
     LinearMap.ker ((killingForm R L).restrict H) = ⊥ := by
   have h : Codisjoint (rootSpace H 0) (LieModule.posFittingComp R H L) :=
-    (LieModule.isCompl_weightSpace_zero_posFittingComp R H L).codisjoint
+    (LieModule.isCompl_genWeightSpace_zero_posFittingComp R H L).codisjoint
   replace h : Codisjoint (H : Submodule R L) (LieModule.posFittingComp R H L : Submodule R L) := by
     rwa [codisjoint_iff, ← LieSubmodule.coe_toSubmodule_eq_iff, LieSubmodule.sup_coe_toSubmodule,
       LieSubmodule.top_coeSubmodule, rootSpace_zero_eq R L H, LieSubalgebra.coe_toLieSubmodule,
@@ -109,12 +109,12 @@ lemma killingForm_apply_eq_zero_of_mem_rootSpace_of_add_ne_zero {α β : H → K
   have hσ : ∀ γ, σ γ ≠ γ := fun γ ↦ by simpa only [σ, ← add_assoc] using add_left_ne_self.mpr hαβ
   let f : Module.End K L := (ad K L x) ∘ₗ (ad K L y)
   have hf : ∀ γ, MapsTo f (rootSpace H γ) (rootSpace H (σ γ)) := fun γ ↦
-    (mapsTo_toEnd_weightSpace_add_of_mem_rootSpace K L H L α (β + γ) hx).comp <|
-      mapsTo_toEnd_weightSpace_add_of_mem_rootSpace K L H L β γ hy
+    (mapsTo_toEnd_genWeightSpace_add_of_mem_rootSpace K L H L α (β + γ) hx).comp <|
+      mapsTo_toEnd_genWeightSpace_add_of_mem_rootSpace K L H L β γ hy
   classical
   have hds := DirectSum.isInternal_submodule_of_independent_of_iSup_eq_top
-    (LieSubmodule.independent_iff_coe_toSubmodule.mp <| independent_weightSpace K H L)
-    (LieSubmodule.iSup_eq_top_iff_coe_toSubmodule.mp <| iSup_weightSpace_eq_top K H L)
+    (LieSubmodule.independent_iff_coe_toSubmodule.mp <| independent_genWeightSpace K H L)
+    (LieSubmodule.iSup_eq_top_iff_coe_toSubmodule.mp <| iSup_genWeightSpace_eq_top K H L)
   exact LinearMap.trace_eq_zero_of_mapsTo_ne hds σ hσ hf
 
 /-- Elements of the `α` root space which are Killing-orthogonal to the `-α` root space are
@@ -125,7 +125,7 @@ lemma mem_ker_killingForm_of_mem_rootSpace_of_forall_rootSpace_neg
     x ∈ LinearMap.ker (killingForm K L) := by
   rw [LinearMap.mem_ker]
   ext y
-  have hy : y ∈ ⨆ β, rootSpace H β := by simp [iSup_weightSpace_eq_top K H L]
+  have hy : y ∈ ⨆ β, rootSpace H β := by simp [iSup_genWeightSpace_eq_top K H L]
   induction hy using LieSubmodule.iSup_induction' with
   | hN β y hy =>
     by_cases hαβ : α + β = 0
@@ -197,7 +197,7 @@ lemma lie_eq_killingForm_smul_of_mem_rootSpace_of_mem_rootSpace_neg_aux
   apply mem_ker_killingForm_of_mem_rootSpace_of_forall_rootSpace_neg (α := (0 : H → K))
   · simp only [rootSpace_zero_eq, LieSubalgebra.mem_toLieSubmodule]
     refine sub_mem ?_ (H.smul_mem _ α'.property)
-    simpa using mapsTo_toEnd_weightSpace_add_of_mem_rootSpace K L H L α (-α) heα hfα
+    simpa using mapsTo_toEnd_genWeightSpace_add_of_mem_rootSpace K L H L α (-α) heα hfα
   · intro z hz
     replace hz : z ∈ H := by simpa using hz
     have he : ⁅z, e⁆ = α ⟨z, hz⟩ • e := aux ⟨z, hz⟩
@@ -211,7 +211,7 @@ assuming `K` has characteristic zero). -/
 lemma cartanEquivDual_symm_apply_mem_corootSpace (α : Weight K H L) :
     (cartanEquivDual H).symm α ∈ corootSpace α := by
   obtain ⟨e : L, he₀ : e ≠ 0, he : ∀ x, ⁅x, e⁆ = α x • e⟩ := exists_forall_lie_eq_smul K H L α
-  have heα : e ∈ rootSpace H α := (mem_weightSpace L α e).mpr fun x ↦ ⟨1, by simp [← he x]⟩
+  have heα : e ∈ rootSpace H α := (mem_genWeightSpace L α e).mpr fun x ↦ ⟨1, by simp [← he x]⟩
   obtain ⟨f, hfα, hf⟩ : ∃ f ∈ rootSpace H (-α), killingForm K L e f ≠ 0 := by
     contrapose! he₀
     simpa using mem_ker_killingForm_of_mem_rootSpace_of_forall_rootSpace_neg K L H heα he₀
@@ -264,7 +264,7 @@ lemma isSemisimple_ad_of_mem_isCartanSubalgebra {x : L} (hx : x ∈ H) :
   /- Note that the semisimple part `S` is just a scalar action on each root space. -/
   have aux {α : H → K} {y : L} (hy : y ∈ rootSpace H α) : S y = α x' • y := by
     replace hy : y ∈ (ad K L x).maxGenEigenspace (α x') :=
-      (weightSpace_le_weightSpaceOf L x' α) hy
+      (genWeightSpace_le_genWeightSpaceOf L x' α) hy
     rw [maxGenEigenspace_eq] at hy
     set k := maxGenEigenspaceIndex (ad K L x) (α x')
     rw [apply_eq_of_mem_genEigenspace_of_comm_of_isSemisimple_of_isNilpotent_sub hy hS₀ hS hN]
@@ -272,12 +272,12 @@ lemma isSemisimple_ad_of_mem_isCartanSubalgebra {x : L} (hx : x ∈ H) :
   have h_der (y z : L) (α β : H → K) (hy : y ∈ rootSpace H α) (hz : z ∈ rootSpace H β) :
       S ⁅y, z⁆ = ⁅S y, z⁆ + ⁅y, S z⁆ := by
     have hyz : ⁅y, z⁆ ∈ rootSpace H (α + β) :=
-      mapsTo_toEnd_weightSpace_add_of_mem_rootSpace K L H L α β hy hz
+      mapsTo_toEnd_genWeightSpace_add_of_mem_rootSpace K L H L α β hy hz
     rw [aux hy, aux hz, aux hyz, smul_lie, lie_smul, ← add_smul, ← Pi.add_apply]
   /- Thus `S` is a derivation since root spaces span. -/
   replace h_der (y z : L) : S ⁅y, z⁆ = ⁅S y, z⁆ + ⁅y, S z⁆ := by
-    have hy : y ∈ ⨆ α : H → K, rootSpace H α := by simp [iSup_weightSpace_eq_top]
-    have hz : z ∈ ⨆ α : H → K, rootSpace H α := by simp [iSup_weightSpace_eq_top]
+    have hy : y ∈ ⨆ α : H → K, rootSpace H α := by simp [iSup_genWeightSpace_eq_top]
+    have hz : z ∈ ⨆ α : H → K, rootSpace H α := by simp [iSup_genWeightSpace_eq_top]
     induction hy using LieSubmodule.iSup_induction' with
     | hN α y hy =>
       induction hz using LieSubmodule.iSup_induction' with
@@ -313,7 +313,7 @@ lemma isSemisimple_ad_of_mem_isCartanSubalgebra {x : L} (hx : x ∈ H) :
 lemma lie_eq_smul_of_mem_rootSpace {α : H → K} {x : L} (hx : x ∈ rootSpace H α) (h : H) :
     ⁅h, x⁆ = α h • x := by
   replace hx : x ∈ (ad K L h).maxGenEigenspace (α h) :=
-    weightSpace_le_weightSpaceOf L h α hx
+    genWeightSpace_le_genWeightSpaceOf L h α hx
   rw [(isSemisimple_ad_of_mem_isCartanSubalgebra
     h.property).maxGenEigenspace_eq_eigenspace, Module.End.mem_eigenspace_iff] at hx
   simpa using hx
@@ -360,7 +360,7 @@ lemma eq_zero_of_apply_eq_zero_of_mem_corootSpace
   replace hx : x ∈ ⨅ β : Weight K H L, β.ker := by
     refine (Submodule.mem_iInf _).mpr fun β ↦ ?_
     obtain ⟨a, b, hb, hab⟩ :=
-      exists_forall_mem_corootSpace_smul_add_eq_zero L α β hα β.weightSpace_ne_bot
+      exists_forall_mem_corootSpace_smul_add_eq_zero L α β hα β.genWeightSpace_ne_bot
     simpa [hαx, hb.ne'] using hab _ hx
   simpa using hx
 
@@ -528,7 +528,7 @@ lemma _root_.IsSl2Triple.h_eq_coroot {α : Weight K H L} (hα : α.IsNonZero)
 lemma finrank_rootSpace_eq_one (α : Weight K H L) (hα : α.IsNonZero) :
     finrank K (rootSpace H α) = 1 := by
   suffices ¬ 1 < finrank K (rootSpace H α) by
-    have h₀ : finrank K (rootSpace H α) ≠ 0 := by simpa using α.weightSpace_ne_bot
+    have h₀ : finrank K (rootSpace H α) ≠ 0 := by simpa using α.genWeightSpace_ne_bot
     omega
   intro contra
   obtain ⟨h, e, f, ht, heα, hfα⟩ := exists_isSl2Triple_of_weight_isNonZero hα
@@ -571,7 +571,7 @@ variable {α : Weight K H L}
 instance : InvolutiveNeg (Weight K H L) where
   neg α := ⟨-α, by
     by_cases hα : α.IsZero
-    · convert α.weightSpace_ne_bot; rw [hα, neg_zero]
+    · convert α.genWeightSpace_ne_bot; rw [hα, neg_zero]
     · intro e
       obtain ⟨x, hx, x_ne0⟩ := α.exists_ne_zero
       have := mem_ker_killingForm_of_mem_rootSpace_of_forall_rootSpace_neg K L H hx

--- a/Mathlib/Algebra/Lie/Weights/Linear.lean
+++ b/Mathlib/Algebra/Lie/Weights/Linear.lean
@@ -12,7 +12,7 @@ import Mathlib.LinearAlgebra.FreeModule.PID
 
 Given a Lie module `M` over a nilpotent Lie algebra `L` with coefficients in `R`, one frequently
 studies `M` via its weights. These are functions `χ : L → R` whose corresponding weight space
-`LieModule.weightSpace M χ`, is non-trivial. If `L` is Abelian or if `R` has characteristic zero
+`LieModule.genWeightSpace M χ`, is non-trivial. If `L` is Abelian or if `R` has characteristic zero
 (and `M` is finite-dimensional) then such `χ` are necessarily `R`-linear. However in general
 non-linear weights do exist. For example if we take:
  * `R`: the field with two elements (or indeed any perfect field of characteristic two),
@@ -49,9 +49,9 @@ namespace LieModule
 /-- A typeclass encoding the fact that a given Lie module has linear weights, vanishing on the
 derived ideal. -/
 class LinearWeights [LieAlgebra.IsNilpotent R L] : Prop :=
-  map_add : ∀ χ : L → R, weightSpace M χ ≠ ⊥ → ∀ x y, χ (x + y) = χ x + χ y
-  map_smul : ∀ χ : L → R, weightSpace M χ ≠ ⊥ → ∀ (t : R) x, χ (t • x) = t • χ x
-  map_lie : ∀ χ : L → R, weightSpace M χ ≠ ⊥ → ∀ x y : L, χ ⁅x, y⁆ = 0
+  map_add : ∀ χ : L → R, genWeightSpace M χ ≠ ⊥ → ∀ x y, χ (x + y) = χ x + χ y
+  map_smul : ∀ χ : L → R, genWeightSpace M χ ≠ ⊥ → ∀ (t : R) x, χ (t • x) = t • χ x
+  map_lie : ∀ χ : L → R, genWeightSpace M χ ≠ ⊥ → ∀ x y : L, χ ⁅x, y⁆ = 0
 
 namespace Weight
 
@@ -61,22 +61,22 @@ variable [LieAlgebra.IsNilpotent R L] [LinearWeights R L M] (χ : Weight R L M)
 @[simps]
 def toLinear : L →ₗ[R] R where
   toFun := χ
-  map_add' := LinearWeights.map_add χ χ.weightSpace_ne_bot
-  map_smul' := LinearWeights.map_smul χ χ.weightSpace_ne_bot
+  map_add' := LinearWeights.map_add χ χ.genWeightSpace_ne_bot
+  map_smul' := LinearWeights.map_smul χ χ.genWeightSpace_ne_bot
 
 instance instCoeLinearMap : CoeOut (Weight R L M) (L →ₗ[R] R) where
   coe := Weight.toLinear R L M
 
 instance instLinearMapClass : LinearMapClass (Weight R L M) R L R where
-  map_add χ := LinearWeights.map_add χ χ.weightSpace_ne_bot
-  map_smulₛₗ χ := LinearWeights.map_smul χ χ.weightSpace_ne_bot
+  map_add χ := LinearWeights.map_add χ χ.genWeightSpace_ne_bot
+  map_smulₛₗ χ := LinearWeights.map_smul χ χ.genWeightSpace_ne_bot
 
 variable {R L M χ}
 
 @[simp]
 lemma apply_lie (x y : L) :
     χ ⁅x, y⁆ = 0 :=
-  LinearWeights.map_lie χ χ.weightSpace_ne_bot x y
+  LinearWeights.map_lie χ χ.genWeightSpace_ne_bot x y
 
 @[simp] lemma coe_coe : (↑(χ : L →ₗ[R] R) : L → R) = (χ : L → R) := rfl
 
@@ -93,17 +93,17 @@ end Weight
 /-- For an Abelian Lie algebra, the weights of any Lie module are linear. -/
 instance instLinearWeightsOfIsLieAbelian [IsLieAbelian L] [NoZeroSMulDivisors R M] :
     LinearWeights R L M :=
-  have aux : ∀ (χ : L → R), weightSpace M χ ≠ ⊥ → ∀ (x y : L), χ (x + y) = χ x + χ y := by
+  have aux : ∀ (χ : L → R), genWeightSpace M χ ≠ ⊥ → ∀ (x y : L), χ (x + y) = χ x + χ y := by
     have h : ∀ x y, Commute (toEnd R L M x) (toEnd R L M y) := fun x y ↦ by
       rw [commute_iff_lie_eq, ← LieHom.map_lie, trivial_lie_zero, LieHom.map_zero]
     intro χ hχ x y
-    simp_rw [Ne, ← LieSubmodule.coe_toSubmodule_eq_iff, weightSpace, weightSpaceOf,
+    simp_rw [Ne, ← LieSubmodule.coe_toSubmodule_eq_iff, genWeightSpace, genWeightSpaceOf,
       LieSubmodule.iInf_coe_toSubmodule, LieSubmodule.bot_coeSubmodule] at hχ
     exact Module.End.map_add_of_iInf_genEigenspace_ne_bot_of_commute
       (toEnd R L M).toLinearMap χ hχ h x y
   { map_add := aux
     map_smul := fun χ hχ t x ↦ by
-      simp_rw [Ne, ← LieSubmodule.coe_toSubmodule_eq_iff, weightSpace, weightSpaceOf,
+      simp_rw [Ne, ← LieSubmodule.coe_toSubmodule_eq_iff, genWeightSpace, genWeightSpaceOf,
         LieSubmodule.iInf_coe_toSubmodule, LieSubmodule.bot_coeSubmodule] at hχ
       exact Module.End.map_smul_of_iInf_genEigenspace_ne_bot
         (toEnd R L M).toLinearMap χ hχ t x
@@ -117,23 +117,23 @@ open FiniteDimensional
 variable [IsDomain R] [IsPrincipalIdealRing R] [Module.Free R M] [Module.Finite R M]
   [LieAlgebra.IsNilpotent R L]
 
-lemma trace_comp_toEnd_weightSpace_eq (χ : L → R) :
-    LinearMap.trace R _ ∘ₗ (toEnd R L (weightSpace M χ)).toLinearMap =
-    finrank R (weightSpace M χ) • χ := by
+lemma trace_comp_toEnd_genWeightSpace_eq (χ : L → R) :
+    LinearMap.trace R _ ∘ₗ (toEnd R L (genWeightSpace M χ)).toLinearMap =
+    finrank R (genWeightSpace M χ) • χ := by
   ext x
-  let n := toEnd R L (weightSpace M χ) x - χ x • LinearMap.id
-  have h₁ : toEnd R L (weightSpace M χ) x = n + χ x • LinearMap.id := eq_add_of_sub_eq rfl
+  let n := toEnd R L (genWeightSpace M χ) x - χ x • LinearMap.id
+  have h₁ : toEnd R L (genWeightSpace M χ) x = n + χ x • LinearMap.id := eq_add_of_sub_eq rfl
   have h₂ : LinearMap.trace R _ n = 0 := IsReduced.eq_zero _ <|
     LinearMap.isNilpotent_trace_of_isNilpotent <| isNilpotent_toEnd_sub_algebraMap M χ x
   rw [LinearMap.comp_apply, LieHom.coe_toLinearMap, h₁, map_add, h₂]
   simp [mul_comm (χ x)]
 
 @[deprecated (since := "2024-04-06")]
-alias trace_comp_toEnd_weight_space_eq := trace_comp_toEnd_weightSpace_eq
+alias trace_comp_toEnd_weight_space_eq := trace_comp_toEnd_genWeightSpace_eq
 
 variable {R L M} in
-lemma zero_lt_finrank_weightSpace {χ : L → R} (hχ : weightSpace M χ ≠ ⊥) :
-    0 < finrank R (weightSpace M χ) := by
+lemma zero_lt_finrank_genWeightSpace {χ : L → R} (hχ : genWeightSpace M χ ≠ ⊥) :
+    0 < finrank R (genWeightSpace M χ) := by
   rwa [← LieSubmodule.nontrivial_iff_ne_bot, ← rank_pos_iff_nontrivial (R := R), ← finrank_eq_rank,
     Nat.cast_pos] at hχ
 
@@ -142,90 +142,91 @@ on the derived ideal. -/
 instance instLinearWeightsOfCharZero [CharZero R] :
     LinearWeights R L M where
   map_add χ hχ x y := by
-    rw [← smul_right_inj (zero_lt_finrank_weightSpace hχ).ne', smul_add, ← Pi.smul_apply,
-      ← Pi.smul_apply, ← Pi.smul_apply, ← trace_comp_toEnd_weightSpace_eq, map_add]
+    rw [← smul_right_inj (zero_lt_finrank_genWeightSpace hχ).ne', smul_add, ← Pi.smul_apply,
+      ← Pi.smul_apply, ← Pi.smul_apply, ← trace_comp_toEnd_genWeightSpace_eq, map_add]
   map_smul χ hχ t x := by
-    rw [← smul_right_inj (zero_lt_finrank_weightSpace hχ).ne', smul_comm, ← Pi.smul_apply,
-      ← Pi.smul_apply (finrank R _), ← trace_comp_toEnd_weightSpace_eq, map_smul]
+    rw [← smul_right_inj (zero_lt_finrank_genWeightSpace hχ).ne', smul_comm, ← Pi.smul_apply,
+      ← Pi.smul_apply (finrank R _), ← trace_comp_toEnd_genWeightSpace_eq, map_smul]
   map_lie χ hχ x y := by
-    rw [← smul_right_inj (zero_lt_finrank_weightSpace hχ).ne', nsmul_zero, ← Pi.smul_apply,
-      ← trace_comp_toEnd_weightSpace_eq, LinearMap.comp_apply, LieHom.coe_toLinearMap,
+    rw [← smul_right_inj (zero_lt_finrank_genWeightSpace hχ).ne', nsmul_zero, ← Pi.smul_apply,
+      ← trace_comp_toEnd_genWeightSpace_eq, LinearMap.comp_apply, LieHom.coe_toLinearMap,
       LieHom.map_lie, Ring.lie_def, map_sub, LinearMap.trace_mul_comm, sub_self]
 
 end FiniteDimensional
 
 variable [LieAlgebra.IsNilpotent R L] (χ : L → R)
 
-/-- A type synonym for the `χ`-weight space but with the action of `x : L` on `m : weightSpace M χ`,
-shifted to act as `⁅x, m⁆ - χ x • m`. -/
-def shiftedWeightSpace := weightSpace M χ
+/-- A type synonym for the `χ`-weight space but with the action of `x : L`
+on `m : genWeightSpace M χ`, shifted to act as `⁅x, m⁆ - χ x • m`. -/
+def shiftedGenWeightSpace := genWeightSpace M χ
 
-namespace shiftedWeightSpace
+namespace shiftedGenWeightSpace
 
-private lemma aux [h : Nontrivial (shiftedWeightSpace R L M χ)] : weightSpace M χ ≠ ⊥ :=
+private lemma aux [h : Nontrivial (shiftedGenWeightSpace R L M χ)] : genWeightSpace M χ ≠ ⊥ :=
   (LieSubmodule.nontrivial_iff_ne_bot _ _ _).mp h
 
 variable [LinearWeights R L M]
 
-instance : LieRingModule L (shiftedWeightSpace R L M χ) where
+instance : LieRingModule L (shiftedGenWeightSpace R L M χ) where
   bracket x m := ⁅x, m⁆ - χ x • m
   add_lie x y m := by
-    nontriviality shiftedWeightSpace R L M χ
+    nontriviality shiftedGenWeightSpace R L M χ
     simp only [add_lie, LinearWeights.map_add χ (aux R L M χ), add_smul]
     abel
   lie_add x m n := by
-    nontriviality shiftedWeightSpace R L M χ
+    nontriviality shiftedGenWeightSpace R L M χ
     simp only [lie_add, LinearWeights.map_add χ (aux R L M χ), smul_add]
     abel
   leibniz_lie x y m := by
-    nontriviality shiftedWeightSpace R L M χ
+    nontriviality shiftedGenWeightSpace R L M χ
     simp only [lie_sub, lie_smul, lie_lie, LinearWeights.map_lie χ (aux R L M χ), zero_smul,
       sub_zero, smul_sub, smul_comm (χ x)]
     abel
 
-@[simp] lemma coe_lie_shiftedWeightSpace_apply (x : L) (m : shiftedWeightSpace R L M χ) :
+@[simp] lemma coe_lie_shiftedGenWeightSpace_apply (x : L) (m : shiftedGenWeightSpace R L M χ) :
     ⁅x, m⁆ = ⁅x, (m : M)⁆ - χ x • m :=
   rfl
 
-instance : LieModule R L (shiftedWeightSpace R L M χ) where
+instance : LieModule R L (shiftedGenWeightSpace R L M χ) where
   smul_lie t x m := by
-    nontriviality shiftedWeightSpace R L M χ
+    nontriviality shiftedGenWeightSpace R L M χ
     apply Subtype.ext
-    simp only [coe_lie_shiftedWeightSpace_apply, smul_lie, LinearWeights.map_smul χ (aux R L M χ),
-      SetLike.val_smul, smul_sub, sub_right_inj, smul_assoc t]
+    simp only [coe_lie_shiftedGenWeightSpace_apply, smul_lie,
+      LinearWeights.map_smul χ (aux R L M χ), smul_assoc t, SetLike.val_smul, smul_sub]
   lie_smul t x m := by
-    nontriviality shiftedWeightSpace R L M χ
+    nontriviality shiftedGenWeightSpace R L M χ
     apply Subtype.ext
-    simp only [coe_lie_shiftedWeightSpace_apply, lie_smul, LinearWeights.map_smul χ (aux R L M χ),
-      SetLike.val_smul, smul_sub, sub_right_inj, smul_comm t]
+    simp only [coe_lie_shiftedGenWeightSpace_apply, SetLike.val_smul, lie_smul, smul_sub,
+      smul_comm t]
 
-/-- Forgetting the action of `L`, the spaces `weightSpace M χ` and `shiftedWeightSpace R L M χ` are
-equivalent. -/
-@[simps!] def shift : weightSpace M χ ≃ₗ[R] shiftedWeightSpace R L M χ := LinearEquiv.refl R _
+/-- Forgetting the action of `L`,
+the spaces `genWeightSpace M χ` and `shiftedGenWeightSpace R L M χ` are equivalent. -/
+@[simps!] def shift : genWeightSpace M χ ≃ₗ[R] shiftedGenWeightSpace R L M χ := LinearEquiv.refl R _
 
 lemma toEnd_eq (x : L) :
-    toEnd R L (shiftedWeightSpace R L M χ) x =
-    (shift R L M χ).conj (toEnd R L (weightSpace M χ) x - χ x • LinearMap.id) := by
+    toEnd R L (shiftedGenWeightSpace R L M χ) x =
+    (shift R L M χ).conj (toEnd R L (genWeightSpace M χ) x - χ x • LinearMap.id) := by
   ext; simp [LinearEquiv.conj_apply]
 
 /-- By Engel's theorem, if `M` is Noetherian, the shifted action `⁅x, m⁆ - χ x • m` makes the
 `χ`-weight space into a nilpotent Lie module. -/
-instance [IsNoetherian R M] : IsNilpotent R L (shiftedWeightSpace R L M χ) :=
+instance [IsNoetherian R M] : IsNilpotent R L (shiftedGenWeightSpace R L M χ) :=
   LieModule.isNilpotent_iff_forall'.mpr fun x ↦ isNilpotent_toEnd_sub_algebraMap M χ x
 
-end shiftedWeightSpace
+end shiftedGenWeightSpace
 
 /-- Given a Lie module `M` of a Lie algebra `L` with coefficients in `R`, if a function `χ : L → R`
 has a simultaneous generalized eigenvector for the action of `L` then it has a simultaneous true
 eigenvector, provided `M` is Noetherian and has linear weights. -/
 lemma exists_forall_lie_eq_smul [LinearWeights R L M] [IsNoetherian R M] (χ : Weight R L M) :
     ∃ m : M, m ≠ 0 ∧ ∀ x : L, ⁅x, m⁆ = χ x • m := by
-  replace hχ : Nontrivial (shiftedWeightSpace R L M χ) :=
-    (LieSubmodule.nontrivial_iff_ne_bot R L M).mpr χ.weightSpace_ne_bot
+  replace hχ : Nontrivial (shiftedGenWeightSpace R L M χ) :=
+    (LieSubmodule.nontrivial_iff_ne_bot R L M).mpr χ.genWeightSpace_ne_bot
   obtain ⟨⟨⟨m, _⟩, hm₁⟩, hm₂⟩ :=
-    @exists_ne _ (nontrivial_max_triv_of_isNilpotent R L (shiftedWeightSpace R L M χ)) 0
+    @exists_ne _ (nontrivial_max_triv_of_isNilpotent R L (shiftedGenWeightSpace R L M χ)) 0
   simp_rw [LieSubmodule.mem_coeSubmodule, mem_maxTrivSubmodule, Subtype.ext_iff,
-    shiftedWeightSpace.coe_lie_shiftedWeightSpace_apply, ZeroMemClass.coe_zero, sub_eq_zero] at hm₁
+    shiftedGenWeightSpace.coe_lie_shiftedGenWeightSpace_apply,
+    ZeroMemClass.coe_zero, sub_eq_zero] at hm₁
   exact ⟨m, by simpa using hm₂, hm₁⟩
 
 end LieModule

--- a/Mathlib/Algebra/Lie/Weights/RootSystem.lean
+++ b/Mathlib/Algebra/Lie/Weights/RootSystem.lean
@@ -50,9 +50,9 @@ private lemma chainLength_aux (hα : α.IsNonZero) {x} (hx : x ∈ rootSpace H (
   obtain ⟨h, e, f, isSl2, he, hf⟩ := exists_isSl2Triple_of_weight_isNonZero hα
   obtain rfl := isSl2.h_eq_coroot hα he hf
   have : isSl2.HasPrimitiveVectorWith x (chainTop α β (coroot α)) :=
-    have := lie_mem_weightSpace_of_mem_weightSpace he hx
+    have := lie_mem_genWeightSpace_of_mem_genWeightSpace he hx
     ⟨hx', by rw [← lie_eq_smul_of_mem_rootSpace hx]; rfl,
-      by rwa [weightSpace_add_chainTop α β hα] at this⟩
+      by rwa [genWeightSpace_add_chainTop α β hα] at this⟩
   obtain ⟨μ, hμ⟩ := this.exists_nat
   exact ⟨μ, by rw [← Nat.cast_smul_eq_nsmul K, ← hμ, lie_eq_smul_of_mem_rootSpace hx]⟩
 
@@ -101,8 +101,8 @@ lemma rootSpace_neg_nsmul_add_chainTop_of_le {n : ℕ} (hn : n ≤ chainLength �
   obtain ⟨h, e, f, isSl2, he, hf⟩ := exists_isSl2Triple_of_weight_isNonZero hα
   obtain rfl := isSl2.h_eq_coroot hα he hf
   have prim : isSl2.HasPrimitiveVectorWith x (chainLength α β : K) :=
-    have := lie_mem_weightSpace_of_mem_weightSpace he hx
-    ⟨x_ne0, (chainLength_smul _ _ hx).symm, by rwa [weightSpace_add_chainTop _ _ hα] at this⟩
+    have := lie_mem_genWeightSpace_of_mem_genWeightSpace he hx
+    ⟨x_ne0, (chainLength_smul _ _ hx).symm, by rwa [genWeightSpace_add_chainTop _ _ hα] at this⟩
   simp only [← smul_neg, ne_eq, LieSubmodule.eq_bot_iff, not_forall]
   exact ⟨_, toEnd_pow_apply_mem hf hx n, prim.pow_toEnd_f_ne_zero_of_eq_nat rfl hn⟩
 
@@ -127,14 +127,14 @@ lemma rootSpace_neg_nsmul_add_chainTop_of_lt (hα : α.IsNonZero) {n : ℕ} (hn 
     ring
   have := rootSpace_neg_nsmul_add_chainTop_of_le (-α) W H₁
   rw [Weight.coe_neg, ← smul_neg, neg_neg, ← Weight.coe_neg, H₂] at this
-  exact this (weightSpace_chainTopCoeff_add_one_nsmul_add α β hα)
+  exact this (genWeightSpace_chainTopCoeff_add_one_nsmul_add α β hα)
 
 lemma chainTopCoeff_le_chainLength : chainTopCoeff α β ≤ chainLength α β := by
   by_cases hα : α.IsZero
   · simp only [hα.eq, chainTopCoeff_zero, zero_le]
   rw [← not_lt, ← Nat.succ_le]
   intro e
-  apply weightSpace_nsmul_add_ne_bot_of_le α β
+  apply genWeightSpace_nsmul_add_ne_bot_of_le α β
     (Nat.sub_le (chainTopCoeff α β) (chainLength α β).succ)
   rw [← Nat.cast_smul_eq_nsmul ℤ, Nat.cast_sub e, sub_smul, sub_eq_neg_add,
     add_assoc, ← coe_chainTop, Nat.cast_smul_eq_nsmul]
@@ -148,7 +148,7 @@ lemma chainBotCoeff_add_chainTopCoeff :
   · rw [← Nat.le_sub_iff_add_le (chainTopCoeff_le_chainLength α β),
       ← not_lt, ← Nat.succ_le, chainBotCoeff, ← Weight.coe_neg]
     intro e
-    apply weightSpace_nsmul_add_ne_bot_of_le _ _ e
+    apply genWeightSpace_nsmul_add_ne_bot_of_le _ _ e
     rw [← Nat.cast_smul_eq_nsmul ℤ, Nat.cast_succ, Nat.cast_sub (chainTopCoeff_le_chainLength α β),
       LieModule.Weight.coe_neg, smul_neg, ← neg_smul, neg_add_rev, neg_sub, sub_eq_neg_add,
       ← add_assoc, ← neg_add_rev, add_smul, add_assoc, ← coe_chainTop, neg_smul,
@@ -160,7 +160,7 @@ lemma chainBotCoeff_add_chainTopCoeff :
     rw [← Nat.succ_add, ← Nat.cast_smul_eq_nsmul ℤ, ← neg_smul, coe_chainTop, ← add_assoc,
       ← add_smul, Nat.cast_add, neg_add, add_assoc, neg_add_cancel, add_zero, neg_smul, ← smul_neg,
       Nat.cast_smul_eq_nsmul]
-    exact weightSpace_chainTopCoeff_add_one_nsmul_add (-α) β (Weight.IsNonZero.neg hα)
+    exact genWeightSpace_chainTopCoeff_add_one_nsmul_add (-α) β (Weight.IsNonZero.neg hα)
 
 lemma chainTopCoeff_add_chainBotCoeff :
     chainTopCoeff α β + chainBotCoeff α β = chainLength α β := by
@@ -254,13 +254,13 @@ lemma chainTopCoeff_zero_right [Nontrivial L] (hα : α.IsNonZero) :
   · rw [Nat.one_le_iff_ne_zero]
     intro e
     exact α.2 (by simpa [e, Weight.coe_zero] using
-      weightSpace_chainTopCoeff_add_one_nsmul_add α (0 : Weight K H L) hα)
+      genWeightSpace_chainTopCoeff_add_one_nsmul_add α (0 : Weight K H L) hα)
   obtain ⟨x, hx, x_ne0⟩ := (chainTop α (0 : Weight K H L)).exists_ne_zero
   obtain ⟨h, e, f, isSl2, he, hf⟩ := exists_isSl2Triple_of_weight_isNonZero hα
   obtain rfl := isSl2.h_eq_coroot hα he hf
   have prim : isSl2.HasPrimitiveVectorWith x (chainLength α (0 : Weight K H L) : K) :=
-    have := lie_mem_weightSpace_of_mem_weightSpace he hx
-    ⟨x_ne0, (chainLength_smul _ _ hx).symm, by rwa [weightSpace_add_chainTop _ _ hα] at this⟩
+    have := lie_mem_genWeightSpace_of_mem_genWeightSpace he hx
+    ⟨x_ne0, (chainLength_smul _ _ hx).symm, by rwa [genWeightSpace_add_chainTop _ _ hα] at this⟩
   obtain ⟨k, hk⟩ : ∃ k : K, k • f =
       (toEnd K L L f ^ (chainTopCoeff α (0 : Weight K H L) + 1)) x := by
     have : (toEnd K L L f ^ (chainTopCoeff α (0 : Weight K H L) + 1)) x ∈ rootSpace H (-α) := by
@@ -290,7 +290,7 @@ lemma rootSpace_two_smul (hα : α.IsNonZero) : rootSpace H (2 • α) = ⊥ := 
   cases subsingleton_or_nontrivial L
   · exact IsEmpty.elim inferInstance α
   simpa [chainTopCoeff_zero_right α hα] using
-    weightSpace_chainTopCoeff_add_one_nsmul_add α (0 : Weight K H L) hα
+    genWeightSpace_chainTopCoeff_add_one_nsmul_add α (0 : Weight K H L) hα
 
 lemma rootSpace_one_div_two_smul (hα : α.IsNonZero) : rootSpace H ((2⁻¹ : K) • α) = ⊥ := by
   by_contra h
@@ -298,7 +298,7 @@ lemma rootSpace_one_div_two_smul (hα : α.IsNonZero) : rootSpace H ((2⁻¹ : K
   have hW : 2 • (W : H → K) = α := by
     show 2 • (2⁻¹ : K) • (α : H → K) = α
     rw [← Nat.cast_smul_eq_nsmul K, smul_smul]; simp
-  apply α.weightSpace_ne_bot
+  apply α.genWeightSpace_ne_bot
   have := rootSpace_two_smul W (fun (e : (W : H → K) = 0) ↦ hα <| by
     apply_fun (2 • ·) at e; simpa [hW] using e)
   rwa [hW] at this
@@ -353,9 +353,9 @@ lemma eq_neg_or_eq_of_eq_smul (hβ : β.IsNonZero) (k : K) (h : (β : H → K) =
 /-- The reflection of a root along another. -/
 def reflectRoot (α β : Weight K H L) : Weight K H L where
   toFun := β - β (coroot α) • α
-  weightSpace_ne_bot' := by
+  genWeightSpace_ne_bot' := by
     by_cases hα : α.IsZero
-    · simpa [hα.eq] using β.weightSpace_ne_bot
+    · simpa [hα.eq] using β.genWeightSpace_ne_bot
     rw [sub_eq_neg_add, apply_coroot_eq_cast α β, ← neg_smul, ← Int.cast_neg,
       Int.cast_smul_eq_zsmul, rootSpace_zsmul_add_ne_bot_iff α β hα]
     omega


### PR DESCRIPTION
There are two variants of the concept of weight space,
similar to the two concepts of eigenspace and generalized eigenspace.
This PR renames `weightSpace` to `genWeightSpace`
so that the name `weightSpace` can be reused for the
version of weight spaces using non-generalized eigenspaces.

Moves:
- coe_lie_shiftedWeightSpace_apply -> coe_lie_shiftedgenWeightSpace_apply
- coe_weightSpaceOf_zero -> coe_genWeightSpaceOf_zero
- coe_weightSpace_of_top -> coe_genWeightSpace_of_top
- comap_weightSpace_eq_of_injective -> comap_genWeightSpace_eq_of_injective
- disjoint_weightSpace -> disjoint_genWeightSpace
- disjoint_weightSpaceOf -> disjoint_genWeightSpaceOf
- eq_zero_of_mem_weightSpace_mem_posFitting -> eq_zero_of_mem_genWeightSpace_mem_posFitting
- eventually_weightSpace_smul_add_eq_bot -> eventually_genWeightSpace_smul_add_eq_bot
- exists_weightSpace_le_ker_of_isNoetherian -> exists_genWeightSpace_le_ker_of_isNoetherian
- exists_weightSpace_smul_add_eq_bot -> exists_genWeightSpace_smul_add_eq_bot
- exists_weightSpace_zero_le_ker_of_isNoetherian -> exists_genWeightSpace_zero_le_ker_of_isNoetherian
- exists₂_weightSpace_smul_add_eq_bot -> exists₂_genWeightSpace_smul_add_eq_bot
- finite_weightSpaceOf_ne_bot -> finite_genWeightSpaceOf_ne_bot
- finite_weightSpace_ne_bot -> finite_genWeightSpace_ne_bot
- iSup_ucs_eq_weightSpace_zero -> iSup_ucs_eq_genWeightSpace_zero
- iSup_ucs_le_weightSpace_zero -> iSup_ucs_le_genWeightSpace_zero
- iSup_weightSpaceOf_eq_top -> iSup_genWeightSpaceOf_eq_top
- iSup_weightSpace_eq_top -> iSup_genWeightSpace_eq_top
- iSup_weightSpace_eq_top' -> iSup_genWeightSpace_eq_top'
- independent_weightSpace -> independent_genWeightSpace
- independent_weightSpace' -> independent_genWeightSpace'
- independent_weightSpaceOf -> independent_genWeightSpaceOf
- injOn_weightSpace -> injOn_genWeightSpace
- isCompl_weightSpaceOf_zero_posFittingCompOf -> isCompl_genWeightSpaceOf_zero_posFittingCompOf
- isCompl_weightSpace_zero_posFittingComp -> isCompl_genWeightSpace_zero_posFittingComp
- isNilpotent_toEnd_weightSpace_zero -> isNilpotent_toEnd_genWeightSpace_zero
- lie_mem_weightSpaceChain_of_weightSpace_eq_bot_left -> lie_mem_genWeightSpaceChain_of_genWeightSpace_eq_bot_left
- lie_mem_weightSpaceChain_of_weightSpace_eq_bot_right -> lie_mem_genWeightSpaceChain_of_genWeightSpace_eq_bot_right
- lie_mem_weightSpace_of_mem_weightSpace -> lie_mem_genWeightSpace_of_mem_genWeightSpace
- map_weightSpace_eq -> map_genWeightSpace_eq
- map_weightSpace_eq_of_injective -> map_genWeightSpace_eq_of_injective
- map_weightSpace_le -> map_genWeightSpace_le
- mapsTo_toEnd_weightSpace_add_of_mem_rootSpace -> mapsTo_toEnd_genWeightSpace_add_of_mem_rootSpace
- mem_weightSpace -> mem_genWeightSpace
- mem_weightSpaceOf -> mem_genWeightSpaceOf
- rootSpace_comap_eq_weightSpace -> rootSpace_comap_eq_genWeightSpace
- shiftedWeightSpace -> shiftedgenWeightSpace
- traceForm_eq_sum_weightSpaceOf -> traceForm_eq_sum_genWeightSpaceOf
- traceForm_weightSpace_eq -> traceForm_genWeightSpace_eq
- trace_comp_toEnd_weightSpace_eq -> trace_comp_toEnd_genWeightSpace_eq
- trace_toEnd_weightSpace -> trace_toEnd_genWeightSpace
- trace_toEnd_weightSpaceChain_eq_zero -> trace_toEnd_genWeightSpaceChain_eq_zero
- weightSpace -> genWeightSpace
- weightSpaceChain -> genWeightSpaceChain
- weightSpaceChain_def -> genWeightSpaceChain_def
- weightSpaceChain_def' -> genWeightSpaceChain_def'
- weightSpaceChain_neg -> genWeightSpaceChain_neg
- weightSpaceOf -> genWeightSpaceOf
- weightSpaceOf_ne_bot -> genWeightSpaceOf_ne_bot
- weightSpace_add_chainTop -> genWeightSpace_add_chainTop
- weightSpace_chainBotCoeff_sub_one_zsmul_sub -> genWeightSpace_chainBotCoeff_sub_one_zsmul_sub
- weightSpace_chainTopCoeff_add_one_nsmul_add -> genWeightSpace_chainTopCoeff_add_one_nsmul_add
- weightSpace_chainTopCoeff_add_one_zsmul_add -> genWeightSpace_chainTopCoeff_add_one_zsmul_add
- weightSpace_le_weightSpaceChain -> genWeightSpace_le_genWeightSpaceChain
- weightSpace_le_weightSpaceOf -> genWeightSpace_le_genWeightSpaceOf
- weightSpace_ne_bot -> genWeightSpace_ne_bot
- weightSpace_neg_add_chainBot -> genWeightSpace_neg_add_chainBot
- weightSpace_neg_zsmul_add_ne_bot -> genWeightSpace_neg_zsmul_add_ne_bot
- weightSpace_nsmul_add_ne_bot_of_le -> genWeightSpace_nsmul_add_ne_bot_of_le
- weightSpace_weightSpaceOf_map_incl -> genWeightSpace_genWeightSpaceOf_map_incl
- weightSpace_zero_normalizer_eq_self -> genWeightSpace_zero_normalizer_eq_self
- weightSpace_zsmul_add_ne_bot -> genWeightSpace_zsmul_add_ne_bot
- zero_lt_finrank_weightSpace -> zero_lt_finrank_genWeightSpace
- zero_weightSpace_eq_top_of_nilpotent -> zero_genWeightSpace_eq_top_of_nilpotent
- zero_weightSpace_eq_top_of_nilpotent' -> zero_genWeightSpace_eq_top_of_nilpotent'



---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
