### PR TITLE
[Merged by Bors] - style: replace `$` with `<|`

### DIFF
--- a/LongestPole/Main.lean
+++ b/LongestPole/Main.lean
@@ -22,7 +22,7 @@ open Lean Meta
 /-- Runs a terminal command and retrieves its output -/
 def runCmd (cmd : String) (args : Array String) (throwFailure := true) : IO String := do
   let out ← IO.Process.output { cmd := cmd, args := args }
-  if out.exitCode != 0 && throwFailure then throw $ IO.userError out.stderr
+  if out.exitCode != 0 && throwFailure then throw <| IO.userError out.stderr
   else return out.stdout
 
 def runCurl (args : Array String) (throwFailure := true) : IO String := do

--- a/Mathlib/Algebra/Associated/Basic.lean
+++ b/Mathlib/Algebra/Associated/Basic.lean
@@ -851,8 +851,8 @@ instance uniqueUnits : Unique (Associates α)ˣ where
   uniq := by
     rintro ⟨a, b, hab, hba⟩
     revert hab hba
-    exact Quotient.inductionOn₂ a b $ fun a b hab hba ↦ Units.ext $ Quotient.sound $
-      associated_one_of_associated_mul_one $ Quotient.exact hab
+    exact Quotient.inductionOn₂ a b <| fun a b hab hba ↦ Units.ext <| Quotient.sound <|
+      associated_one_of_associated_mul_one <| Quotient.exact hab
 
 @[deprecated (since := "2024-07-22")] alias mul_eq_one_iff := mul_eq_one
 @[deprecated (since := "2024-07-22")] protected alias units_eq_one := Subsingleton.elim

--- a/Mathlib/Algebra/BigOperators/Group/Finset.lean
+++ b/Mathlib/Algebra/BigOperators/Group/Finset.lean
@@ -456,7 +456,7 @@ of `s`, and over all subsets of `s` to which one adds `x`. -/
 of `s`, and over all subsets of `s` to which one adds `x`."]
 lemma prod_powerset_cons (ha : a ∉ s) (f : Finset α → β) :
     ∏ t ∈ (s.cons a ha).powerset, f t = (∏ t ∈ s.powerset, f t) *
-      ∏ t ∈ s.powerset.attach, f (cons a t $ not_mem_mono (mem_powerset.1 t.2) ha) := by
+      ∏ t ∈ s.powerset.attach, f (cons a t <| not_mem_mono (mem_powerset.1 t.2) ha) := by
   classical
   simp_rw [cons_eq_insert]
   rw [prod_powerset_insert ha, prod_attach _ fun t ↦ f (insert a t)]
@@ -721,7 +721,7 @@ but differ in the type of their element, `univ.pi t` is a `Finset (Π a ∈ univ
 lemma prod_univ_pi [DecidableEq ι] [Fintype ι] {κ : ι → Type*} (t : ∀ i, Finset (κ i))
     (f : (∀ i ∈ (univ : Finset ι), κ i) → β) :
     ∏ x ∈ univ.pi t, f x = ∏ x ∈ Fintype.piFinset t, f fun a _ ↦ x a := by
-  apply prod_nbij' (fun x i ↦ x i $ mem_univ _) (fun x i _ ↦ x i) <;> simp
+  apply prod_nbij' (fun x i ↦ x i <| mem_univ _) (fun x i _ ↦ x i) <;> simp
 
 @[to_additive (attr := simp)]
 lemma prod_diag [DecidableEq α] (s : Finset α) (f : α × α → β) :
@@ -1751,7 +1751,7 @@ variable [DecidableEq ι] [CancelCommMonoid α] {s t : Finset ι} {f : ι → α
 @[to_additive]
 lemma prod_sdiff_eq_prod_sdiff_iff :
     ∏ i ∈ s \ t, f i = ∏ i ∈ t \ s, f i ↔ ∏ i ∈ s, f i = ∏ i ∈ t, f i :=
-  eq_comm.trans $ eq_iff_eq_of_mul_eq_mul $ by
+  eq_comm.trans <| eq_iff_eq_of_mul_eq_mul <| by
     rw [← prod_union disjoint_sdiff_self_left, ← prod_union disjoint_sdiff_self_left,
       sdiff_union_self_eq_union, sdiff_union_self_eq_union, union_comm]
 
@@ -1985,7 +1985,7 @@ theorem prod_subtype_mul_prod_subtype {α β : Type*} [Fintype α] [CommMonoid �
 
 @[to_additive] lemma prod_subset {s : Finset ι} {f : ι → α} (h : ∀ i, f i ≠ 1 → i ∈ s) :
     ∏ i ∈ s, f i = ∏ i, f i :=
-  Finset.prod_subset s.subset_univ $ by simpa [not_imp_comm (a := _ ∈ s)]
+  Finset.prod_subset s.subset_univ <| by simpa [not_imp_comm (a := _ ∈ s)]
 
 @[to_additive]
 lemma prod_ite_eq_ite_exists (p : ι → Prop) [DecidablePred p] (h : ∀ i j, p i → p j → i = j)
@@ -2032,7 +2032,7 @@ variable [CommMonoid α]
 @[to_additive (attr := simp)]
 lemma prod_attach_univ [Fintype ι] (f : {i // i ∈ @univ ι _} → α) :
     ∏ i ∈ univ.attach, f i = ∏ i, f ⟨i, mem_univ _⟩ :=
-  Fintype.prod_equiv (Equiv.subtypeUnivEquiv mem_univ) _ _ $ by simp
+  Fintype.prod_equiv (Equiv.subtypeUnivEquiv mem_univ) _ _ <| by simp
 
 @[to_additive]
 theorem prod_erase_attach [DecidableEq ι] {s : Finset ι} (f : ι → α) (i : ↑s) :

--- a/Mathlib/Algebra/Field/Basic.lean
+++ b/Mathlib/Algebra/Field/Basic.lean
@@ -256,9 +256,9 @@ protected abbrev divisionSemiring [DivisionSemiring β] (zero : f 0 = 0) (one : 
     (natCast : ∀ n : ℕ, f n = n) (nnratCast : ∀ q : ℚ≥0, f q = q) : DivisionSemiring α where
   toSemiring := hf.semiring f zero one add mul nsmul npow natCast
   __ := hf.groupWithZero f zero one mul inv div npow zpow
-  nnratCast_def q := hf $ by rw [nnratCast, NNRat.cast_def, div, natCast, natCast]
+  nnratCast_def q := hf <| by rw [nnratCast, NNRat.cast_def, div, natCast, natCast]
   nnqsmul := (· • ·)
-  nnqsmul_def q a := hf $ by rw [nnqsmul, NNRat.smul_def, mul, nnratCast]
+  nnqsmul_def q a := hf <| by rw [nnqsmul, NNRat.smul_def, mul, nnratCast]
 
 /-- Pullback a `DivisionSemiring` along an injective function. -/
 -- See note [reducible non-instances]
@@ -274,9 +274,9 @@ protected abbrev divisionRing [DivisionRing β] (zero : f 0 = 0) (one : f 1 = 1)
   toRing := hf.ring f zero one add mul neg sub nsmul zsmul npow natCast intCast
   __ := hf.groupWithZero f zero one mul inv div npow zpow
   __ := hf.divisionSemiring f zero one add mul inv div nsmul nnqsmul npow zpow natCast nnratCast
-  ratCast_def q := hf $ by erw [ratCast, div, intCast, natCast, Rat.cast_def]
+  ratCast_def q := hf <| by erw [ratCast, div, intCast, natCast, Rat.cast_def]
   qsmul := (· • ·)
-  qsmul_def q a := hf $ by erw [qsmul, mul, Rat.smul_def, ratCast]
+  qsmul_def q a := hf <| by erw [qsmul, mul, Rat.smul_def, ratCast]
 
 /-- Pullback a `Field` along an injective function. -/
 -- See note [reducible non-instances]

--- a/Mathlib/Algebra/Field/Opposite.lean
+++ b/Mathlib/Algebra/Field/Opposite.lean
@@ -35,7 +35,7 @@ instance instDivisionSemiring [DivisionSemiring α] : DivisionSemiring αᵐᵒ�
   __ := instGroupWithZero
   nnqsmul := _
   nnqsmul_def := fun q a => rfl
-  nnratCast_def q := unop_injective $ by rw [unop_nnratCast, unop_div, unop_natCast, unop_natCast,
+  nnratCast_def q := unop_injective <| by rw [unop_nnratCast, unop_div, unop_natCast, unop_natCast,
     NNRat.cast_def, div_eq_mul_inv, Nat.cast_comm]
 
 instance instDivisionRing [DivisionRing α] : DivisionRing αᵐᵒᵖ where
@@ -63,7 +63,7 @@ instance instDivisionSemiring [DivisionSemiring α] : DivisionSemiring αᵃᵒ�
   __ := instGroupWithZero
   nnqsmul := _
   nnqsmul_def := fun q a => rfl
-  nnratCast_def q := unop_injective $ by rw [unop_nnratCast, unop_div, unop_natCast, unop_natCast,
+  nnratCast_def q := unop_injective <| by rw [unop_nnratCast, unop_div, unop_natCast, unop_natCast,
     NNRat.cast_def, div_eq_mul_inv]
 
 instance instDivisionRing [DivisionRing α] : DivisionRing αᵃᵒᵖ where

--- a/Mathlib/Algebra/Group/Action/Defs.lean
+++ b/Mathlib/Algebra/Group/Action/Defs.lean
@@ -489,7 +489,7 @@ end Mul
 variable [Group H] [MulAction G H] [SMulCommClass G H H] [IsScalarTower G H H]
 
 lemma smul_inv (g : G) (a : H) : (g • a)⁻¹ = g⁻¹ • a⁻¹ :=
-  inv_eq_of_mul_eq_one_right $ by rw [smul_mul_smul, mul_inv_cancel, mul_inv_cancel, one_smul]
+  inv_eq_of_mul_eq_one_right <| by rw [smul_mul_smul, mul_inv_cancel, mul_inv_cancel, one_smul]
 
 lemma smul_zpow (g : G) (a : H) (n : ℤ) : (g • a) ^ n = g ^ n • a ^ n := by
   cases n <;> simp [smul_pow, smul_inv]

--- a/Mathlib/Algebra/Group/Basic.lean
+++ b/Mathlib/Algebra/Group/Basic.lean
@@ -189,11 +189,11 @@ lemma pow_sub_mul_pow (a : M) (h : m ≤ n) : a ^ (n - m) * a ^ m = a ^ n := by
 
 @[to_additive sub_one_nsmul_add]
 lemma mul_pow_sub_one (hn : n ≠ 0) (a : M) : a * a ^ (n - 1) = a ^ n := by
-  rw [← pow_succ', Nat.sub_add_cancel $ Nat.one_le_iff_ne_zero.2 hn]
+  rw [← pow_succ', Nat.sub_add_cancel <| Nat.one_le_iff_ne_zero.2 hn]
 
 @[to_additive add_sub_one_nsmul]
 lemma pow_sub_one_mul (hn : n ≠ 0) (a : M) : a ^ (n - 1) * a = a ^ n := by
-  rw [← pow_succ, Nat.sub_add_cancel $ Nat.one_le_iff_ne_zero.2 hn]
+  rw [← pow_succ, Nat.sub_add_cancel <| Nat.one_le_iff_ne_zero.2 hn]
 
 /-- If `x ^ n = 1`, then `x ^ m` is the same as `x ^ (m % n)` -/
 @[to_additive nsmul_eq_mod_nsmul "If `n • x = 0`, then `m • x` is the same as `(m % n) • x`"]

--- a/Mathlib/Algebra/Group/Hom/Defs.lean
+++ b/Mathlib/Algebra/Group/Hom/Defs.lean
@@ -837,8 +837,8 @@ instance : Monoid (Monoid.End M) where
   mul_assoc _ _ _ := MonoidHom.comp_assoc _ _ _
   mul_one := MonoidHom.comp_id
   one_mul := MonoidHom.id_comp
-  npow n f := (npowRec n f).copy f^[n] $ by induction n <;> simp [npowRec, *] <;> rfl
-  npow_succ n f := DFunLike.coe_injective $ Function.iterate_succ _ _
+  npow n f := (npowRec n f).copy f^[n] <| by induction n <;> simp [npowRec, *] <;> rfl
+  npow_succ n f := DFunLike.coe_injective <| Function.iterate_succ _ _
 
 instance : Inhabited (Monoid.End M) := ⟨1⟩
 
@@ -878,8 +878,8 @@ instance monoid : Monoid (AddMonoid.End A) where
   mul_assoc _ _ _ := AddMonoidHom.comp_assoc _ _ _
   mul_one := AddMonoidHom.comp_id
   one_mul := AddMonoidHom.id_comp
-  npow n f := (npowRec n f).copy (Nat.iterate f n) $ by induction n <;> simp [npowRec, *] <;> rfl
-  npow_succ n f := DFunLike.coe_injective $ Function.iterate_succ _ _
+  npow n f := (npowRec n f).copy (Nat.iterate f n) <| by induction n <;> simp [npowRec, *] <;> rfl
+  npow_succ n f := DFunLike.coe_injective <| Function.iterate_succ _ _
 
 @[simp, norm_cast] lemma coe_pow (f : AddMonoid.End A) (n : ℕ) : (↑(f ^ n) : A → A) = f^[n] := rfl
 

--- a/Mathlib/Algebra/GroupWithZero/Basic.lean
+++ b/Mathlib/Algebra/GroupWithZero/Basic.lean
@@ -150,7 +150,7 @@ lemma pow_eq_zero_of_le : ∀ {m n} (hmn : m ≤ n) (ha : a ^ m = 0), a ^ n = 0
   | _, _, Nat.le.refl, ha => ha
   | _, _, Nat.le.step hmn, ha => by rw [pow_succ, pow_eq_zero_of_le hmn ha, zero_mul]
 
-lemma ne_zero_pow (hn : n ≠ 0) (ha : a ^ n ≠ 0) : a ≠ 0 := by rintro rfl; exact ha $ zero_pow hn
+lemma ne_zero_pow (hn : n ≠ 0) (ha : a ^ n ≠ 0) : a ≠ 0 := by rintro rfl; exact ha <| zero_pow hn
 
 @[simp]
 lemma zero_pow_eq_zero [Nontrivial M₀] : (0 : M₀) ^ n = 0 ↔ n ≠ 0 :=

--- a/Mathlib/Algebra/GroupWithZero/Center.lean
+++ b/Mathlib/Algebra/GroupWithZero/Center.lean
@@ -38,7 +38,7 @@ lemma center_units_subset : center G₀ˣ ⊆ ((↑) : G₀ˣ → G₀) ⁻¹' c
   intro u hu a
   obtain rfl | ha := eq_or_ne a 0
   · rw [zero_mul, mul_zero]
-  · exact congr_arg Units.val $ hu $ Units.mk0 a ha
+  · exact congr_arg Units.val <| hu <| Units.mk0 a ha
 
 /-- In a group with zero, the center of the units is the preimage of the center. -/
 lemma center_units_eq : center G₀ˣ = ((↑) : G₀ˣ → G₀) ⁻¹' center G₀ :=

--- a/Mathlib/Algebra/GroupWithZero/Hom.lean
+++ b/Mathlib/Algebra/GroupWithZero/Hom.lean
@@ -175,11 +175,11 @@ lemma comp_assoc (f : α →*₀ β) (g : β →*₀ γ) (h : γ →*₀ δ) :
 
 lemma cancel_right {g₁ g₂ : β →*₀ γ} {f : α →*₀ β} (hf : Surjective f) :
     g₁.comp f = g₂.comp f ↔ g₁ = g₂ :=
-  ⟨fun h ↦ ext $ hf.forall.2 (DFunLike.ext_iff.1 h), fun h ↦ h ▸ rfl⟩
+  ⟨fun h ↦ ext <| hf.forall.2 (DFunLike.ext_iff.1 h), fun h ↦ h ▸ rfl⟩
 
 lemma cancel_left {g : β →*₀ γ} {f₁ f₂ : α →*₀ β} (hg : Injective g) :
     g.comp f₁ = g.comp f₂ ↔ f₁ = f₂ :=
-  ⟨fun h ↦ ext fun x ↦ hg $ by rw [← comp_apply, h,
+  ⟨fun h ↦ ext fun x ↦ hg <| by rw [← comp_apply, h,
     comp_apply], fun h ↦ h ▸ rfl⟩
 
 lemma toMonoidHom_injective : Injective (toMonoidHom : (α →*₀ β) → α →* β) :=

--- a/Mathlib/Algebra/GroupWithZero/NonZeroDivisors.lean
+++ b/Mathlib/Algebra/GroupWithZero/NonZeroDivisors.lean
@@ -283,7 +283,7 @@ def unitsNonZeroDivisorsEquiv : M₀⁰ˣ ≃* M₀ˣ where
   right_inv _ := rfl
 
 @[simp, norm_cast] lemma nonZeroDivisors.associated_coe : Associated (a : M₀) b ↔ Associated a b :=
-  unitsNonZeroDivisorsEquiv.symm.exists_congr_left.trans $ by simp [Associated]; norm_cast
+  unitsNonZeroDivisorsEquiv.symm.exists_congr_left.trans <| by simp [Associated]; norm_cast
 
 end MonoidWithZero
 

--- a/Mathlib/Algebra/Homology/ShortComplex/ExactFunctor.lean
+++ b/Mathlib/Algebra/Homology/ShortComplex/ExactFunctor.lean
@@ -112,8 +112,8 @@ lemma preservesFiniteLimits_tfae : List.TFAE
     [
       ∀ (S : ShortComplex C), S.ShortExact → (S.map F).Exact ∧ Mono (F.map S.f),
       ∀ (S : ShortComplex C), S.Exact ∧ Mono S.f → (S.map F).Exact ∧ Mono (F.map S.f),
-      ∀ ⦃X Y : C⦄ (f : X ⟶ Y), Nonempty $ PreservesLimit (parallelPair f 0) F,
-      Nonempty $ PreservesFiniteLimits F
+      ∀ ⦃X Y : C⦄ (f : X ⟶ Y), Nonempty <| PreservesLimit (parallelPair f 0) F,
+      Nonempty <| PreservesFiniteLimits F
     ] := by
   tfae_have 1 → 2
   · rintro hF S ⟨hS, hf⟩
@@ -123,7 +123,7 @@ lemma preservesFiniteLimits_tfae : List.TFAE
     let φ : T.map F ⟶ S.map F :=
       { τ₁ := 𝟙 _
         τ₂ := 𝟙 _
-        τ₃ := F.map $ Abelian.factorThruCoimage S.g
+        τ₃ := F.map <| Abelian.factorThruCoimage S.g
         comm₂₃ := show 𝟙 _ ≫ F.map _ = F.map (cokernel.π _) ≫ _ by
           rw [Category.id_comp, ← F.map_comp, cokernel.π_desc] }
     exact (exact_iff_of_epi_of_isIso_of_mono φ).1 (hF T ⟨(S.exact_iff_exact_coimage_π).1 hS⟩).1
@@ -171,8 +171,8 @@ lemma preservesFiniteColimits_tfae : List.TFAE
     [
       ∀ (S : ShortComplex C), S.ShortExact → (S.map F).Exact ∧ Epi (F.map S.g),
       ∀ (S : ShortComplex C), S.Exact ∧ Epi S.g → (S.map F).Exact ∧ Epi (F.map S.g),
-      ∀ ⦃X Y : C⦄ (f : X ⟶ Y), Nonempty $ PreservesColimit (parallelPair f 0) F,
-      Nonempty $ PreservesFiniteColimits F
+      ∀ ⦃X Y : C⦄ (f : X ⟶ Y), Nonempty <| PreservesColimit (parallelPair f 0) F,
+      Nonempty <| PreservesFiniteColimits F
     ] := by
   tfae_have 1 → 2
   · rintro hF S ⟨hS, hf⟩
@@ -180,7 +180,7 @@ lemma preservesFiniteColimits_tfae : List.TFAE
     refine ⟨?_, inferInstance⟩
     let T := ShortComplex.mk (Abelian.image.ι S.f) S.g (Abelian.image_ι_comp_eq_zero S.zero)
     let φ : S.map F ⟶ T.map F :=
-      { τ₁ := F.map $ Abelian.factorThruImage S.f
+      { τ₁ := F.map <| Abelian.factorThruImage S.f
         τ₂ := 𝟙 _
         τ₃ := 𝟙 _
         comm₁₂ := show _ ≫ F.map (kernel.ι _) = F.map _ ≫ 𝟙 _ by
@@ -235,10 +235,10 @@ lemma exact_tfae : List.TFAE
 
   tfae_have 2 → 1
   · intro hF S hS
-    have : Mono (S.map F).f := exact_iff_mono _ (by simp) |>.1 $
-      hF (.mk (0 : 0 ⟶ S.X₁) S.f $ by simp) (exact_iff_mono _ (by simp) |>.2 hS.mono_f)
-    have : Epi (S.map F).g := exact_iff_epi _ (by simp) |>.1 $
-      hF (.mk S.g (0 : S.X₃ ⟶ 0) $ by simp) (exact_iff_epi _ (by simp) |>.2 hS.epi_g)
+    have : Mono (S.map F).f := exact_iff_mono _ (by simp) |>.1 <|
+      hF (.mk (0 : 0 ⟶ S.X₁) S.f <| by simp) (exact_iff_mono _ (by simp) |>.2 hS.mono_f)
+    have : Epi (S.map F).g := exact_iff_epi _ (by simp) |>.1 <|
+      hF (.mk S.g (0 : S.X₃ ⟶ 0) <| by simp) (exact_iff_epi _ (by simp) |>.2 hS.epi_g)
     exact ⟨hF S hS.exact⟩
 
   tfae_have 3 → 4

--- a/Mathlib/Algebra/MvPolynomial/Degrees.lean
+++ b/Mathlib/Algebra/MvPolynomial/Degrees.lean
@@ -435,7 +435,7 @@ theorem totalDegree_finset_sum {ι : Type*} (s : Finset ι) (f : ι → MvPolyno
 
 lemma totalDegree_finsetSum_le {ι : Type*} {s : Finset ι} {f : ι → MvPolynomial σ R} {d : ℕ}
     (hf : ∀ i ∈ s, (f i).totalDegree ≤ d) : (s.sum f).totalDegree ≤ d :=
-  (totalDegree_finset_sum ..).trans $ Finset.sup_le hf
+  (totalDegree_finset_sum ..).trans <| Finset.sup_le hf
 
 lemma degreeOf_le_totalDegree (f : MvPolynomial σ R) (i : σ) : f.degreeOf i ≤ f.totalDegree :=
   degreeOf_le_iff.mpr fun d hd ↦ (eq_or_ne (d i) 0).elim (·.trans_le zero_le') fun h ↦

--- a/Mathlib/Algebra/Order/Antidiag/Pi.lean
+++ b/Mathlib/Algebra/Order/Antidiag/Pi.lean
@@ -75,7 +75,7 @@ where
           (fun ab => (aux d ab.2).1.map {
               toFun := Fin.cons (ab.1)
               inj' := Fin.cons_right_injective _ })
-          (fun i _hi j _hj hij => Finset.disjoint_left.2 fun t hti htj => hij $ by
+          (fun i _hi j _hj hij => Finset.disjoint_left.2 fun t hti htj => hij <| by
             simp_rw [Finset.mem_map, Embedding.coeFn_mk] at hti htj
             obtain ⟨ai, hai, hij'⟩ := hti
             obtain ⟨aj, haj, rfl⟩ := htj
@@ -106,7 +106,7 @@ choice.
 
 /-- The finset of functions `ι → μ` with support contained in `s` and sum `n`. -/
 def piAntidiag (s : Finset ι) (n : μ) : Finset (ι → μ) := by
-  refine (Fintype.truncEquivFinOfCardEq $ Fintype.card_coe s).lift
+  refine (Fintype.truncEquivFinOfCardEq <| Fintype.card_coe s).lift
     (fun e ↦ (finAntidiagonal s.card n).map ⟨fun f i ↦ if hi : i ∈ s then f (e ⟨i, hi⟩) else 0, ?_⟩)
     fun e₁ e₂ ↦ ?_
   · rintro f g hfg
@@ -114,7 +114,7 @@ def piAntidiag (s : Finset ι) (n : μ) : Finset (ι → μ) := by
     simpa using congr_fun hfg (e.symm i)
   · ext f
     simp only [mem_map, mem_finAntidiagonal]
-    refine Equiv.exists_congr ((e₁.symm.trans e₂).arrowCongr $ .refl _) fun g ↦ ?_
+    refine Equiv.exists_congr ((e₁.symm.trans e₂).arrowCongr <| .refl _) fun g ↦ ?_
     have := Fintype.sum_equiv (e₂.symm.trans e₁) _ g fun _ ↦ rfl
     aesop
 
@@ -162,7 +162,7 @@ lemma pairwiseDisjoint_piAntidiag_map_addRightEmbedding (hi : i ∉ s) (n : μ) 
   simp only [ne_eq, antidiagonal_congr' hab hcd, disjoint_left, mem_map, mem_piAntidiag,
     addRightEmbedding_apply, not_exists, not_and, and_imp, forall_exists_index]
   rintro hfg _ f rfl - rfl g rfl - hgf
-  exact hfg $ by simpa [sum_add_distrib, hi] using congr_arg (∑ j ∈ s, · j) hgf.symm
+  exact hfg <| by simpa [sum_add_distrib, hi] using congr_arg (∑ j ∈ s, · j) hgf.symm
 
 lemma piAntidiag_cons (hi : i ∉ s)  (n : μ) :
     piAntidiag (cons i s hi) n = (antidiagonal n).disjiUnion (fun p : μ × μ ↦

--- a/Mathlib/Algebra/Order/CauSeq/Basic.lean
+++ b/Mathlib/Algebra/Order/CauSeq/Basic.lean
@@ -116,7 +116,7 @@ lemma bounded (hf : IsCauSeq abv f) : ∃ r, ∀ i, abv (f i) < r := by
   refine ⟨R i + 1, fun j ↦ ?_⟩
   obtain hji | hij := le_total j i
   · exact (this i _ hji).trans_lt (lt_add_one _)
-  · simpa using (abv_add abv _ _).trans_lt $ add_lt_add_of_le_of_lt (this i _ le_rfl) (h _ hij)
+  · simpa using (abv_add abv _ _).trans_lt <| add_lt_add_of_le_of_lt (this i _ le_rfl) (h _ hij)
 
 lemma bounded' (hf : IsCauSeq abv f) (x : α) : ∃ r > x, ∀ i, abv (f i) < r :=
   let ⟨r, h⟩ := hf.bounded

--- a/Mathlib/Algebra/Order/CauSeq/BigOperators.lean
+++ b/Mathlib/Algebra/Order/CauSeq/BigOperators.lean
@@ -94,7 +94,7 @@ theorem _root_.cauchy_product (ha : IsCauSeq abs fun m ↦ ∑ n ∈ range m, ab
         abv (f i) * abv ((∑ k ∈ range (K - i), g k) - ∑ k ∈ range K, g k)) ≤
       ∑ i ∈ range (max N M + 1), abv (f i) * (ε / (2 * P)) := by
     gcongr with m hmJ
-    refine le_of_lt $ hN (K - m) (le_tsub_of_add_le_left $ hK.trans' ?_) K hKN.le
+    refine le_of_lt <| hN (K - m) (le_tsub_of_add_le_left <| hK.trans' ?_) K hKN.le
     rw [two_mul]
     gcongr
     · exact (mem_range.1 hmJ).le
@@ -133,8 +133,9 @@ theorem _root_.cauchy_product (ha : IsCauSeq abs fun m ↦ ∑ n ∈ range m, ab
         rw [← sum_mul, ← sum_range_sub_sum_range (le_of_lt hNMK)]
         have := lt_of_le_of_lt (abv_nonneg _ _) (hQ 0)
         gcongr
-        exact (le_abs_self _).trans_lt $ hM _ ((Nat.le_succ_of_le (le_max_right _ _)).trans hNMK.le)
-          _  $ Nat.le_succ_of_le $ le_max_right _ _
+        exact (le_abs_self _).trans_lt <|
+          hM _ ((Nat.le_succ_of_le (le_max_right _ _)).trans hNMK.le) _ <|
+            Nat.le_succ_of_le <| le_max_right _ _
 
 variable [Archimedean α]
 
@@ -172,7 +173,7 @@ lemma of_decreasing_bounded (f : ℕ → α) {a : α} {m : ℕ} (ham : ∀ n ≥
 
 lemma of_mono_bounded (f : ℕ → α) {a : α} {m : ℕ} (ham : ∀ n ≥ m, |f n| ≤ a)
     (hnm : ∀ n ≥ m, f n ≤ f n.succ) : IsCauSeq abs f :=
-  (of_decreasing_bounded (-f) (a := a) (m := m) (by simpa using ham) $ by simpa using hnm).of_neg
+  (of_decreasing_bounded (-f) (a := a) (m := m) (by simpa using ham) <| by simpa using hnm).of_neg
 
 lemma geo_series [Nontrivial β] (x : β) (hx1 : abv x < 1) :
     IsCauSeq abv fun n ↦ ∑ m ∈ range n, x ^ m := by

--- a/Mathlib/Algebra/Order/Floor/Div.lean
+++ b/Mathlib/Algebra/Order/Floor/Div.lean
@@ -124,7 +124,7 @@ variable [LinearOrderedAddCommMonoid α] [OrderedAddCommMonoid β] [SMulZeroClas
 lemma floorDiv_le_ceilDiv : b ⌊/⌋ a ≤ b ⌈/⌉ a := by
   obtain ha | ha := le_or_lt a 0
   · simp [ha]
-  · exact le_of_smul_le_smul_left ((smul_floorDiv_le ha).trans $ le_smul_ceilDiv ha) ha
+  · exact le_of_smul_le_smul_left ((smul_floorDiv_le ha).trans <| le_smul_ceilDiv ha) ha
 
 end LinearOrderedAddCommMonoid
 
@@ -135,11 +135,11 @@ section FloorDiv
 variable [FloorDiv α β] {a : α}
 
 @[simp] lemma floorDiv_one [Nontrivial α] (b : β) : b ⌊/⌋ (1 : α) = b :=
-  eq_of_forall_le_iff $ fun c ↦ by simp [zero_lt_one' α]
+  eq_of_forall_le_iff <| fun c ↦ by simp [zero_lt_one' α]
 
 @[simp] lemma smul_floorDiv [PosSMulMono α β] [PosSMulReflectLE α β] (ha : 0 < a) (b : β) :
     a • b ⌊/⌋ a = b :=
-  eq_of_forall_le_iff $ by simp [smul_le_smul_iff_of_pos_left, ha]
+  eq_of_forall_le_iff <| by simp [smul_le_smul_iff_of_pos_left, ha]
 
 end FloorDiv
 
@@ -147,11 +147,11 @@ section CeilDiv
 variable [CeilDiv α β] {a : α}
 
 @[simp] lemma ceilDiv_one [Nontrivial α] (b : β) : b ⌈/⌉ (1 : α) = b :=
-  eq_of_forall_ge_iff $ fun c ↦ by simp [zero_lt_one' α]
+  eq_of_forall_ge_iff <| fun c ↦ by simp [zero_lt_one' α]
 
 @[simp] lemma smul_ceilDiv [PosSMulMono α β] [PosSMulReflectLE α β] (ha : 0 < a) (b : β) :
     a • b ⌈/⌉ a = b :=
-  eq_of_forall_ge_iff $ by simp [smul_le_smul_iff_of_pos_left, ha]
+  eq_of_forall_ge_iff <| by simp [smul_le_smul_iff_of_pos_left, ha]
 
 end CeilDiv
 
@@ -177,14 +177,14 @@ namespace Nat
 instance instFloorDiv : FloorDiv ℕ ℕ where
   floorDiv := HDiv.hDiv
   floorDiv_gc a ha := by simpa [mul_comm] using Nat.galoisConnection_mul_div ha
-  floorDiv_nonpos a ha b := by rw [ha.antisymm $ zero_le _, Nat.div_zero]
+  floorDiv_nonpos a ha b := by rw [ha.antisymm <| zero_le _, Nat.div_zero]
   zero_floorDiv := Nat.zero_div
 
 instance instCeilDiv : CeilDiv ℕ ℕ where
   ceilDiv a b := (a + b - 1) / b
   ceilDiv_gc a ha b c := by
-    simp [div_le_iff_le_mul_add_pred ha, add_assoc, tsub_add_cancel_of_le $ succ_le_iff.2 ha]
-  ceilDiv_nonpos a ha b := by simp_rw [ha.antisymm $ zero_le _, Nat.div_zero]
+    simp [div_le_iff_le_mul_add_pred ha, add_assoc, tsub_add_cancel_of_le <| succ_le_iff.2 ha]
+  ceilDiv_nonpos a ha b := by simp_rw [ha.antisymm <| zero_le _, Nat.div_zero]
   zero_ceilDiv a := by cases a <;> simp [Nat.div_eq_zero_iff]
 
 @[simp] lemma floorDiv_eq_div (a b : ℕ) : a ⌊/⌋ b = a / b := rfl

--- a/Mathlib/Algebra/Order/Group/Basic.lean
+++ b/Mathlib/Algebra/Order/Group/Basic.lean
@@ -89,7 +89,7 @@ that here because importing that definition would create import cycles."]
 lemma zpow_left_injective (hn : n ≠ 0) : Injective ((· ^ n) : α → α) := by
   obtain hn | hn := hn.lt_or_lt
   · refine fun a b (hab : a ^ n = b ^ n) ↦
-      (zpow_strictMono_left _ $ Int.neg_pos_of_neg hn).injective ?_
+      (zpow_strictMono_left _ <| Int.neg_pos_of_neg hn).injective ?_
     rw [zpow_neg, zpow_neg, hab]
   · exact (zpow_strictMono_left _ hn).injective
 

--- a/Mathlib/Algebra/Order/Group/PosPart.lean
+++ b/Mathlib/Algebra/Order/Group/PosPart.lean
@@ -206,7 +206,7 @@ variable [LinearOrder α] [Group α] {a : α}
   rw [oneLePart, ← maxDefault, ← sup_eq_maxDefault]; simp_rw [sup_comm]
 
 @[to_additive (attr := simp) posPart_pos_iff] lemma one_lt_oneLePart_iff : 1 < a⁺ᵐ ↔ 1 < a :=
-  lt_iff_lt_of_le_iff_le $ (one_le_oneLePart _).le_iff_eq.trans oneLePart_eq_one
+  lt_iff_lt_of_le_iff_le <| (one_le_oneLePart _).le_iff_eq.trans oneLePart_eq_one
 
 @[to_additive posPart_eq_of_posPart_pos]
 lemma oneLePart_of_one_lt_oneLePart (ha : 1 < a⁺ᵐ) : a⁺ᵐ = a := by
@@ -219,7 +219,7 @@ variable [CovariantClass α α (· * ·) (· ≤ ·)]
   simp_rw [← one_le_inv']; rw [leOnePart, ← maxDefault, ← sup_eq_maxDefault]; simp_rw [sup_comm]
 
 @[to_additive (attr := simp) negPart_pos_iff] lemma one_lt_ltOnePart_iff : 1 < a⁻ᵐ ↔ a < 1 :=
-  lt_iff_lt_of_le_iff_le $ (one_le_leOnePart _).le_iff_eq.trans leOnePart_eq_one
+  lt_iff_lt_of_le_iff_le <| (one_le_leOnePart _).le_iff_eq.trans leOnePart_eq_one
 
 end covariantmul
 end LinearOrder

--- a/Mathlib/Algebra/Order/Module/Algebra.lean
+++ b/Mathlib/Algebra/Order/Module/Algebra.lean
@@ -91,7 +91,7 @@ def evalAlgebraMap : PositivityExt where eval {u β} _zβ _pβ e := do
       let _instβring ← synthInstanceQ q(OrderedSemiring $β)
       let _instαβsmul ← synthInstanceQ q(SMulPosMono $α $β)
       assertInstancesCommute
-      return .nonnegative q(algebraMap_nonneg $β $ le_of_lt $pa)
+      return .nonnegative q(algebraMap_nonneg $β <| le_of_lt $pa)
   | .nonnegative pa =>
     let _instαring ← synthInstanceQ q(OrderedCommSemiring $α)
     let _instβring ← synthInstanceQ q(OrderedSemiring $β)

--- a/Mathlib/Algebra/Order/Module/Rat.lean
+++ b/Mathlib/Algebra/Order/Module/Rat.lean
@@ -33,7 +33,7 @@ variable [LinearOrderedSemifield α]
 
 instance LinearOrderedSemifield.toPosSMulStrictMono_rat : PosSMulStrictMono ℚ≥0 α where
   elim q hq a b hab := by
-    rw [NNRat.smul_def, NNRat.smul_def]; exact mul_lt_mul_of_pos_left hab $ NNRat.cast_pos.2 hq
+    rw [NNRat.smul_def, NNRat.smul_def]; exact mul_lt_mul_of_pos_left hab <| NNRat.cast_pos.2 hq
 
 end LinearOrderedSemifield
 
@@ -42,6 +42,6 @@ variable [LinearOrderedField α]
 
 instance LinearOrderedField.toPosSMulStrictMono_rat : PosSMulStrictMono ℚ α where
   elim q hq a b hab := by
-    rw [Rat.smul_def, Rat.smul_def]; exact mul_lt_mul_of_pos_left hab $ Rat.cast_pos.2 hq
+    rw [Rat.smul_def, Rat.smul_def]; exact mul_lt_mul_of_pos_left hab <| Rat.cast_pos.2 hq
 
 end LinearOrderedField

--- a/Mathlib/Algebra/Order/Monoid/Canonical/Defs.lean
+++ b/Mathlib/Algebra/Order/Monoid/Canonical/Defs.lean
@@ -112,7 +112,7 @@ theorem bot_eq_one : (⊥ : α) = 1 :=
   le_antisymm bot_le (one_le ⊥)
 
 @[to_additive] instance CanonicallyOrderedCommMonoid.toUniqueUnits : Unique αˣ where
-  uniq a := Units.ext ((mul_eq_one_iff_of_one_le (α := α) (one_le _) $ one_le _).1 a.mul_inv).1
+  uniq a := Units.ext ((mul_eq_one_iff_of_one_le (α := α) (one_le _) <| one_le _).1 a.mul_inv).1
 
 @[deprecated (since := "2024-07-24")] alias mul_eq_one_iff := mul_eq_one
 @[deprecated (since := "2024-07-24")] alias add_eq_zero_iff := add_eq_zero

--- a/Mathlib/Algebra/Order/Ring/Abs.lean
+++ b/Mathlib/Algebra/Order/Ring/Abs.lean
@@ -111,13 +111,13 @@ lemma abs_lt_of_sq_lt_sq (h : a ^ 2 < b ^ 2) (hb : 0 ≤ b) : |a| < b := by
   rwa [← abs_of_nonneg hb, ← sq_lt_sq]
 
 lemma abs_lt_of_sq_lt_sq' (h : a ^ 2 < b ^ 2) (hb : 0 ≤ b) : -b < a ∧ a < b :=
-  abs_lt.1 $ abs_lt_of_sq_lt_sq h hb
+  abs_lt.1 <| abs_lt_of_sq_lt_sq h hb
 
 lemma abs_le_of_sq_le_sq (h : a ^ 2 ≤ b ^ 2) (hb : 0 ≤ b) : |a| ≤ b := by
   rwa [← abs_of_nonneg hb, ← sq_le_sq]
 
 lemma abs_le_of_sq_le_sq' (h : a ^ 2 ≤ b ^ 2) (hb : 0 ≤ b) : -b ≤ a ∧ a ≤ b :=
-  abs_le.1 $ abs_le_of_sq_le_sq h hb
+  abs_le.1 <| abs_le_of_sq_le_sq h hb
 
 lemma sq_eq_sq_iff_abs_eq_abs (a b : α) : a ^ 2 = b ^ 2 ↔ |a| = |b| := by
   simp only [le_antisymm_iff, sq_le_sq]

--- a/Mathlib/Algebra/Order/Ring/Basic.lean
+++ b/Mathlib/Algebra/Order/Ring/Basic.lean
@@ -269,12 +269,12 @@ lemma add_pow_le (ha : 0 ≤ a) (hb : 0 ≤ b) : ∀ n, (a + b) ^ n ≤ 2 ^ (n -
     rw [pow_succ]
     calc
       _ ≤ 2 ^ n * (a ^ (n + 1) + b ^ (n + 1)) * (a + b) :=
-          mul_le_mul_of_nonneg_right (add_pow_le ha hb (n + 1)) $ add_nonneg ha hb
+          mul_le_mul_of_nonneg_right (add_pow_le ha hb (n + 1)) <| add_nonneg ha hb
       _ = 2 ^ n * (a ^ (n + 2) + b ^ (n + 2) + (a ^ (n + 1) * b + b ^ (n + 1) * a)) := by
           rw [mul_assoc, mul_add, add_mul, add_mul, ← pow_succ, ← pow_succ, add_comm _ (b ^ _),
             add_add_add_comm, add_comm (_ * a)]
       _ ≤ 2 ^ n * (a ^ (n + 2) + b ^ (n + 2) + (a ^ (n + 1) * a + b ^ (n + 1) * b)) :=
-          mul_le_mul_of_nonneg_left (add_le_add_left ?_ _) $ pow_nonneg (zero_le_two (α := R)) _
+          mul_le_mul_of_nonneg_left (add_le_add_left ?_ _) <| pow_nonneg (zero_le_two (α := R)) _
       _ = _ := by simp only [← pow_succ, ← two_mul, ← mul_assoc]; rfl
     · obtain hab | hba := le_total a b
       · exact mul_add_mul_le_mul_add_mul (pow_le_pow_left ha hab _) hab
@@ -289,7 +289,7 @@ protected lemma Even.add_pow_le (hn : Even n) :
     _ = 2 ^ n * (a ^ 2 + b ^ 2) ^ n := by -- TODO: Should be `Nat.cast_commute`
         rw [Commute.mul_pow]; simp [Commute, SemiconjBy, two_mul, mul_two]
     _ ≤ 2 ^ n * (2 ^ (n - 1) * ((a ^ 2) ^ n + (b ^ 2) ^ n)) := mul_le_mul_of_nonneg_left
-          (add_pow_le (sq_nonneg _) (sq_nonneg _) _) $ pow_nonneg (zero_le_two (α := R)) _
+          (add_pow_le (sq_nonneg _) (sq_nonneg _) _) <| pow_nonneg (zero_le_two (α := R)) _
     _ = _ := by
       simp only [← mul_assoc, ← pow_add, ← pow_mul]
       cases n

--- a/Mathlib/Algebra/Order/Ring/Unbundled/Basic.lean
+++ b/Mathlib/Algebra/Order/Ring/Unbundled/Basic.lean
@@ -151,7 +151,7 @@ lemma pow_le_pow_of_le_one [ZeroLEOneClass α] [PosMulMono α] [MulPosMono α]
   | _, _, Nat.le.refl => le_rfl
   | _, _, Nat.le.step h => by
     rw [pow_succ']
-    exact (mul_le_of_le_one_left (pow_nonneg ha₀ _) ha₁).trans $ pow_le_pow_of_le_one ha₀ ha₁ h
+    exact (mul_le_of_le_one_left (pow_nonneg ha₀ _) ha₁).trans <| pow_le_pow_of_le_one ha₀ ha₁ h
 
 lemma pow_le_of_le_one [ZeroLEOneClass α] [PosMulMono α] [MulPosMono α]
     (h₀ : 0 ≤ a) (h₁ : a ≤ 1) {n : ℕ} (hn : n ≠ 0) : a ^ n ≤ a :=

--- a/Mathlib/Algebra/Order/Ring/WithTop.lean
+++ b/Mathlib/Algebra/Order/Ring/WithTop.lean
@@ -30,10 +30,10 @@ instance instMulZeroClass : MulZeroClass (WithTop α) where
     | ⊤, (b : α) => if b = 0 then 0 else ⊤
     | ⊤, ⊤ => ⊤
   mul_zero a := match a with
-    | (a : α) => congr_arg some $ mul_zero _
+    | (a : α) => congr_arg some <| mul_zero _
     | ⊤ => if_pos rfl
   zero_mul b := match b with
-    | (b : α) => congr_arg some $ zero_mul _
+    | (b : α) => congr_arg some <| zero_mul _
     | ⊤ => if_pos rfl
 
 @[simp, norm_cast] lemma coe_mul (a b : α) : (↑(a * b) : WithTop α) = a * b := rfl

--- a/Mathlib/Algebra/Polynomial/Degree/TrailingDegree.lean
+++ b/Mathlib/Algebra/Polynomial/Degree/TrailingDegree.lean
@@ -122,7 +122,7 @@ theorem natTrailingDegree_le_of_ne_zero (h : coeff p n ≠ 0) : natTrailingDegre
   constructor
   · rintro h
     by_contra hp
-    obtain ⟨n, hpn, hn⟩ := by simpa using min_mem_image_coe $ support_nonempty.2 hp
+    obtain ⟨n, hpn, hn⟩ := by simpa using min_mem_image_coe <| support_nonempty.2 hp
     obtain rfl := (trailingDegree_eq_iff_natTrailingDegree_eq hp).1 hn.symm
     exact hpn h
   · rintro rfl
@@ -139,7 +139,7 @@ lemma trailingDegree_eq_zero : trailingDegree p = 0 ↔ coeff p 0 ≠ 0 :=
   simp [natTrailingDegree, or_comm]
 
 lemma natTrailingDegree_ne_zero : natTrailingDegree p ≠ 0 ↔ p ≠ 0 ∧ coeff p 0 = 0 :=
-  natTrailingDegree_eq_zero.not.trans $ by rw [not_or, not_ne_iff]
+  natTrailingDegree_eq_zero.not.trans <| by rw [not_or, not_ne_iff]
 
 lemma trailingDegree_ne_zero : trailingDegree p ≠ 0 ↔ coeff p 0 = 0 :=
   trailingDegree_eq_zero.not_left

--- a/Mathlib/Algebra/Polynomial/EraseLead.lean
+++ b/Mathlib/Algebra/Polynomial/EraseLead.lean
@@ -202,7 +202,7 @@ theorem eraseLead_natDegree_le (f : R[X]) : (eraseLead f).natDegree ≤ f.natDeg
 
 lemma natDegree_eraseLead (h : f.nextCoeff ≠ 0) : f.eraseLead.natDegree = f.natDegree - 1 := by
   have := natDegree_pos_of_nextCoeff_ne_zero h
-  refine f.eraseLead_natDegree_le.antisymm $ le_natDegree_of_ne_zero ?_
+  refine f.eraseLead_natDegree_le.antisymm <| le_natDegree_of_ne_zero ?_
   rwa [eraseLead_coeff_of_ne _ (tsub_lt_self _ _).ne, ← nextCoeff_of_natDegree_pos]
   all_goals positivity
 

--- a/Mathlib/Algebra/Polynomial/RingDivision.lean
+++ b/Mathlib/Algebra/Polynomial/RingDivision.lean
@@ -130,7 +130,7 @@ theorem natDegree_pow (p : R[X]) (n : ℕ) : natDegree (p ^ n) = n * natDegree p
   classical
   obtain rfl | hp := eq_or_ne p 0
   · obtain rfl | hn := eq_or_ne n 0 <;> simp [*]
-  exact natDegree_pow' $ by
+  exact natDegree_pow' <| by
     rw [← leadingCoeff_pow, Ne, leadingCoeff_eq_zero]; exact pow_ne_zero _ hp
 
 theorem degree_le_mul_left (p : R[X]) (hq : q ≠ 0) : degree p ≤ degree (p * q) := by

--- a/Mathlib/Algebra/Ring/Hom/Defs.lean
+++ b/Mathlib/Algebra/Ring/Hom/Defs.lean
@@ -598,8 +598,8 @@ instance instMonoid : Monoid (α →+* α) where
   mul_one := comp_id
   one_mul := id_comp
   mul_assoc f g h := comp_assoc _ _ _
-  npow n f := (npowRec n f).copy f^[n] $ by induction n <;> simp [npowRec, *]
-  npow_succ n f := DFunLike.coe_injective $ Function.iterate_succ _ _
+  npow n f := (npowRec n f).copy f^[n] <| by induction n <;> simp [npowRec, *]
+  npow_succ n f := DFunLike.coe_injective <| Function.iterate_succ _ _
 
 @[simp, norm_cast] lemma coe_pow (f : α →+* α) (n : ℕ) : ⇑(f ^ n) = f^[n] := rfl
 

--- a/Mathlib/Algebra/Ring/Parity.lean
+++ b/Mathlib/Algebra/Ring/Parity.lean
@@ -143,7 +143,7 @@ lemma Odd.pow_add_pow_eq_zero [IsCancelAdd α] (hn : Odd n) (hab : a + b = 0) :
   obtain ⟨k, rfl⟩ := hn
   induction' k with k ih
   · simpa
-  have : a ^ 2 = b ^ 2 := add_right_cancel $
+  have : a ^ 2 = b ^ 2 := add_right_cancel <|
     calc
       a ^ 2 + a * b = 0 := by rw [sq, ← mul_add, hab, mul_zero]
       _ = b ^ 2 + a * b := by rw [sq, ← add_mul, add_comm, hab, zero_mul]

--- a/Mathlib/AlgebraicGeometry/Modules/Tilde.lean
+++ b/Mathlib/AlgebraicGeometry/Modules/Tilde.lean
@@ -136,7 +136,7 @@ def tildeInType : Sheaf (Type u) (PrimeSpectrum.Top R) :=
 
 instance (U : (Opens (PrimeSpectrum.Top R))ᵒᵖ) :
     AddCommGroup (M.tildeInType.1.obj U) :=
-  inferInstanceAs $ AddCommGroup (Tilde.sectionsSubmodule M U)
+  inferInstanceAs <| AddCommGroup (Tilde.sectionsSubmodule M U)
 
 /--
 `M^~` as a presheaf of abelian groups over `Spec R`
@@ -159,7 +159,7 @@ def tildeInAddCommGrp : Sheaf AddCommGrp (PrimeSpectrum.Top R) :=
 
 noncomputable instance (U : (Opens (PrimeSpectrum.Top R))ᵒᵖ) :
     Module ((Spec (.of R)).ringCatSheaf.1.obj U) (M.tildeInAddCommGrp.1.obj U) :=
-  inferInstanceAs $ Module _ (Tilde.sectionsSubmodule M U)
+  inferInstanceAs <| Module _ (Tilde.sectionsSubmodule M U)
 
 /--
 `M^~` as a sheaf of `𝒪_{Spec R}`-modules

--- a/Mathlib/AlgebraicGeometry/Stalk.lean
+++ b/Mathlib/AlgebraicGeometry/Stalk.lean
@@ -37,12 +37,12 @@ theorem IsAffineOpen.fromSpecStalk_eq {X : Scheme} (x : X) {U V : X.Opens}
     Opens.isBasis_iff_nbhd.mp (isBasis_affine_open X) (show x ∈ U ⊓ V from ⟨hxU, hxV⟩)
   transitivity fromSpecStalk h₁ h₂
   · delta fromSpecStalk
-    rw [← hU.map_fromSpec h₁ (homOfLE $ h₃.trans inf_le_left).op]
+    rw [← hU.map_fromSpec h₁ (homOfLE <| h₃.trans inf_le_left).op]
     erw [← Scheme.Spec_map (X.presheaf.map _).op, ← Scheme.Spec_map (X.presheaf.germ ⟨x, h₂⟩).op]
     rw [← Functor.map_comp_assoc, ← op_comp, TopCat.Presheaf.germ_res, Scheme.Spec_map,
       Quiver.Hom.unop_op]
   · delta fromSpecStalk
-    rw [← hV.map_fromSpec h₁ (homOfLE $ h₃.trans inf_le_right).op]
+    rw [← hV.map_fromSpec h₁ (homOfLE <| h₃.trans inf_le_right).op]
     erw [← Scheme.Spec_map (X.presheaf.map _).op, ← Scheme.Spec_map (X.presheaf.germ ⟨x, h₂⟩).op]
     rw [← Functor.map_comp_assoc, ← op_comp, TopCat.Presheaf.germ_res, Scheme.Spec_map,
       Quiver.Hom.unop_op]

--- a/Mathlib/Analysis/CStarAlgebra/Multiplier.lean
+++ b/Mathlib/Analysis/CStarAlgebra/Multiplier.lean
@@ -559,8 +559,8 @@ theorem norm_fst_eq_snd (a : 𝓜(𝕜, A)) : ‖a.fst‖ = ‖a.snd‖ := by
       intro b
       convert mul_le_mul_right' (mul_le_mul_left' (f.le_opNNNorm b) C) ‖b‖₊ using 1
       ring
-    have := NNReal.div_le_of_le_mul $ f.opNNNorm_le_bound _ $ by
-      simpa only [sqrt_sq, sqrt_mul] using fun b ↦ sqrt_le_sqrt.2 $ (h b).trans (h1 b)
+    have := NNReal.div_le_of_le_mul <| f.opNNNorm_le_bound _ <| by
+      simpa only [sqrt_sq, sqrt_mul] using fun b ↦ sqrt_le_sqrt.2 <| (h b).trans (h1 b)
     convert NNReal.rpow_le_rpow this two_pos.le
     · simp only [NNReal.rpow_two, div_pow, sq_sqrt]
       simp only [sq, mul_self_div_self]

--- a/Mathlib/Analysis/Calculus/Deriv/Shift.lean
+++ b/Mathlib/Analysis/Calculus/Deriv/Shift.lean
@@ -57,7 +57,7 @@ lemma deriv_comp_add_const : deriv (fun x ↦ f (x + a)) x = deriv f (x + a) := 
   simpa [add_comm] using deriv_comp_const_add f a x
 
 lemma deriv_comp_const_sub : deriv (fun x ↦ f (a - x)) x = -deriv f (a - x) := by
-  simp_rw [sub_eq_add_neg, deriv_comp_neg (f $ a + ·), deriv_comp_const_add]
+  simp_rw [sub_eq_add_neg, deriv_comp_neg (f <| a + ·), deriv_comp_const_add]
 
 lemma deriv_comp_sub_const : deriv (fun x ↦ f (x - a)) x = deriv f (x - a) := by
   simp_rw [sub_eq_add_neg, deriv_comp_add_const]

--- a/Mathlib/Analysis/Convex/Combination.lean
+++ b/Mathlib/Analysis/Convex/Combination.lean
@@ -376,7 +376,7 @@ lemma Finset.mem_convexHull' {s : Finset E} {x : E} :
     x ∈ convexHull R (s : Set E) ↔
       ∃ w : E → R, (∀ y ∈ s, 0 ≤ w y) ∧ ∑ y ∈ s, w y = 1 ∧ ∑ y ∈ s, w y • y = x := by
   rw [mem_convexHull]
-  refine exists_congr fun w ↦ and_congr_right' $ and_congr_right fun hw ↦ ?_
+  refine exists_congr fun w ↦ and_congr_right' <| and_congr_right fun hw ↦ ?_
   simp_rw [centerMass_eq_of_sum_1 _ _ hw, id_eq]
 
 theorem Set.Finite.convexHull_eq {s : Set E} (hs : s.Finite) : convexHull R s =
@@ -517,13 +517,13 @@ variable {s t t₁ t₂ : Finset E}
 lemma AffineIndependent.convexHull_inter (hs : AffineIndependent R ((↑) : s → E))
     (ht₁ : t₁ ⊆ s) (ht₂ : t₂ ⊆ s) :
     convexHull R (t₁ ∩ t₂ : Set E) = convexHull R t₁ ∩ convexHull R t₂ := by
-  refine (Set.subset_inter (convexHull_mono inf_le_left) $
+  refine (Set.subset_inter (convexHull_mono inf_le_left) <|
     convexHull_mono inf_le_right).antisymm ?_
   simp_rw [Set.subset_def, mem_inter_iff, Set.inf_eq_inter, ← coe_inter, mem_convexHull']
   rintro x ⟨⟨w₁, h₁w₁, h₂w₁, h₃w₁⟩, w₂, -, h₂w₂, h₃w₂⟩
   let w (x : E) : R := (if x ∈ t₁ then w₁ x else 0) - if x ∈ t₂ then w₂ x else 0
   have h₁w : ∑ i ∈ s, w i = 0 := by simp [w, Finset.inter_eq_right.2, *]
-  replace hs := hs.eq_zero_of_sum_eq_zero_subtype h₁w $ by
+  replace hs := hs.eq_zero_of_sum_eq_zero_subtype h₁w <| by
     simp only [w, sub_smul, zero_smul, ite_smul, Finset.sum_sub_distrib, ← Finset.sum_filter, h₃w₁,
       Finset.filter_mem_eq_inter, Finset.inter_eq_right.2 ht₁, Finset.inter_eq_right.2 ht₂, h₃w₂,
       sub_self]
@@ -593,7 +593,7 @@ lemma mem_convexHull_pi (h : ∀ i ∈ s, x i ∈ convexHull 𝕜 (t i)) : x ∈
 
 @[simp] lemma convexHull_pi (s : Set ι) (t : Π i, Set (E i)) :
     convexHull 𝕜 (s.pi t) = s.pi (fun i ↦ convexHull 𝕜 (t i)) :=
-  Set.Subset.antisymm (convexHull_min (Set.pi_mono fun _ _ ↦ subset_convexHull _ _) $ convex_pi $
+  Set.Subset.antisymm (convexHull_min (Set.pi_mono fun _ _ ↦ subset_convexHull _ _) <| convex_pi <|
     fun _ _ ↦ convex_convexHull _ _) fun _ ↦ mem_convexHull_pi
 
 end pi

--- a/Mathlib/Analysis/Convex/Cone/Closure.lean
+++ b/Mathlib/Analysis/Convex/Cone/Closure.lean
@@ -51,7 +51,7 @@ variable {E : Type*} [AddCommMonoid E] [TopologicalSpace E] [ContinuousAdd E] [M
   [ContinuousConstSMul 𝕜 E]
 
 lemma toConvexCone_closure_pointed (K : PointedCone 𝕜 E) : (K : ConvexCone 𝕜 E).closure.Pointed :=
-  subset_closure $ PointedCone.toConvexCone_pointed _
+  subset_closure <| PointedCone.toConvexCone_pointed _
 
 /-- The closure of a pointed cone inside a topological space as a pointed cone. This
 construction is mainly used for defining maps between proper cones. -/

--- a/Mathlib/Analysis/Convex/Deriv.lean
+++ b/Mathlib/Analysis/Convex/Deriv.lean
@@ -239,7 +239,7 @@ lemma convexOn_of_hasDerivWithinAt2_nonneg {D : Set ℝ} (hD : Convex ℝ D) {f 
     convert hf''₀ _ hx using 1
     dsimp
     rw [deriv_eqOn isOpen_interior (fun y hy ↦ ?_) hx]
-    exact (hf'' _ hy).congr this $ by rw [this hy]
+    exact (hf'' _ hy).congr this <| by rw [this hy]
 
 /-- If a function `f` is continuous on a convex set `D ⊆ ℝ`, is twice differentiable on its
 interior, and `f''` is nonpositive on the interior, then `f` is concave on `D`. -/
@@ -255,7 +255,7 @@ lemma concaveOn_of_hasDerivWithinAt2_nonpos {D : Set ℝ} (hD : Convex ℝ D) {f
     convert hf''₀ _ hx using 1
     dsimp
     rw [deriv_eqOn isOpen_interior (fun y hy ↦ ?_) hx]
-    exact (hf'' _ hy).congr this $ by rw [this hy]
+    exact (hf'' _ hy).congr this <| by rw [this hy]
 
 /-- If a function `f` is continuous on a convex set `D ⊆ ℝ` and `f''` is strictly positive on the
 interior, then `f` is strictly convex on `D`.

--- a/Mathlib/Analysis/InnerProductSpace/TwoDim.lean
+++ b/Mathlib/Analysis/InnerProductSpace/TwoDim.lean
@@ -418,7 +418,7 @@ theorem nonneg_inner_and_areaForm_eq_zero_iff_sameRay (x y : E) :
     have hx' : 0 < ‖x‖ := by simpa using hx
     have ha' : 0 ≤ a := nonneg_of_mul_nonneg_left ha (by positivity)
     have hb' : b = 0 := eq_zero_of_ne_zero_of_mul_right_eq_zero (pow_ne_zero 2 hx'.ne') hb
-    exact (SameRay.sameRay_nonneg_smul_right x ha').add_right $ by simp [hb']
+    exact (SameRay.sameRay_nonneg_smul_right x ha').add_right <| by simp [hb']
   · intro h
     obtain ⟨r, hr, rfl⟩ := h.exists_nonneg_left hx
     simp only [inner_smul_right, real_inner_self_eq_norm_sq, LinearMap.map_smulₛₗ,

--- a/Mathlib/Analysis/MeanInequalities.lean
+++ b/Mathlib/Analysis/MeanInequalities.lean
@@ -823,10 +823,10 @@ lemma inner_le_weight_mul_Lp_of_nonneg (s : Finset ι) {p : ℝ} (hp : 1 ≤ p) 
   · cases' H' with H' H' <;> simp [H', -one_div, -sum_eq_zero_iff, -rpow_eq_zero_iff, H]
   replace H' : (∀ i ∈ s, w i ≠ ⊤) ∧ ∀ i ∈ s, w i * f i ^ p ≠ ⊤ := by
     simpa [rpow_eq_top_iff,hp₀, hp₁, hp₀.not_lt, hp₁.not_lt, sum_eq_top_iff, not_or] using H'
-  have := coe_le_coe.2 $ NNReal.inner_le_weight_mul_Lp s hp.le (fun i ↦ ENNReal.toNNReal (w i))
+  have := coe_le_coe.2 <| NNReal.inner_le_weight_mul_Lp s hp.le (fun i ↦ ENNReal.toNNReal (w i))
     fun i ↦ ENNReal.toNNReal (f i)
   rw [coe_mul] at this
-  simp_rw [← coe_rpow_of_nonneg _ $ inv_nonneg.2 hp₀.le, coe_finset_sum, ENNReal.toNNReal_rpow,
+  simp_rw [← coe_rpow_of_nonneg _ <| inv_nonneg.2 hp₀.le, coe_finset_sum, ENNReal.toNNReal_rpow,
     ← ENNReal.toNNReal_mul, sum_congr rfl fun i hi ↦ coe_toNNReal (H'.2 i hi)] at this
   simp [← ENNReal.coe_rpow_of_nonneg, hp₀.le, hp₁.le] at this
   convert this using 2 with i hi

--- a/Mathlib/Analysis/Normed/Field/Basic.lean
+++ b/Mathlib/Analysis/Normed/Field/Basic.lean
@@ -843,7 +843,7 @@ instance (priority := 100) NormedDivisionRing.to_topologicalDivisionRing :
     TopologicalDivisionRing α where
 
 protected lemma IsOfFinOrder.norm_eq_one (ha : IsOfFinOrder a) : ‖a‖ = 1 :=
-  ((normHom : α →*₀ ℝ).toMonoidHom.isOfFinOrder ha).eq_one $ norm_nonneg _
+  ((normHom : α →*₀ ℝ).toMonoidHom.isOfFinOrder ha).eq_one <| norm_nonneg _
 
 example [Monoid β] (φ : β →* α) {x : β} {k : ℕ+} (h : x ^ (k : ℕ) = 1) :
     ‖φ x‖ = 1 := (φ.isOfFinOrder <| isOfFinOrder_iff_pow_eq_one.2 ⟨_, k.2, h⟩).norm_eq_one

--- a/Mathlib/Analysis/Normed/Order/UpperLower.lean
+++ b/Mathlib/Analysis/Normed/Order/UpperLower.lean
@@ -142,8 +142,8 @@ lemma dist_anti_right_pi : AntitoneOn (dist x) (Iic x) := by
 
 lemma dist_le_dist_of_le_pi (ha : a₂ ≤ a₁) (h₁ : a₁ ≤ b₁) (hb : b₁ ≤ b₂) :
     dist a₁ b₁ ≤ dist a₂ b₂ :=
-  (dist_mono_right_pi h₁ (h₁.trans hb) hb).trans $
-    dist_anti_left_pi (ha.trans $ h₁.trans hb) (h₁.trans hb) ha
+  (dist_mono_right_pi h₁ (h₁.trans hb) hb).trans <|
+    dist_anti_left_pi (ha.trans <| h₁.trans hb) (h₁.trans hb) ha
 
 theorem IsUpperSet.exists_subset_ball (hs : IsUpperSet s) (hx : x ∈ closure s) (hδ : 0 < δ) :
     ∃ y, closedBall y (δ / 4) ⊆ closedBall x δ ∧ closedBall y (δ / 4) ⊆ interior s := by
@@ -213,7 +213,7 @@ protected lemma IsClosed.lowerClosure_pi (hs : IsClosed s) (hs' : BddAbove s) :
   haveI : BoundedGENhdsClass ℝ := by infer_instance
   obtain ⟨a, ha⟩ := hx.bddBelow_range
   obtain ⟨b, hb, φ, hφ, hbf⟩ := tendsto_subseq_of_bounded (hs'.isBounded_inter bddBelow_Ici) fun n ↦
-    ⟨hg n, (ha $ mem_range_self _).trans $ hfg _⟩
+    ⟨hg n, (ha <| mem_range_self _).trans <| hfg _⟩
   exact ⟨b, closure_minimal inter_subset_left hs hb,
     le_of_tendsto_of_tendsto' (hx.comp hφ.tendsto_atTop) hbf fun _ ↦ hfg _⟩
 
@@ -225,14 +225,14 @@ protected lemma IsClopen.lowerClosure_pi (hs : IsClopen s) (hs' : BddAbove s) :
 
 lemma closure_upperClosure_comm_pi (hs : BddBelow s) :
     closure (upperClosure s : Set (ι → ℝ)) = upperClosure (closure s) :=
-  (closure_minimal (upperClosure_anti subset_closure) $
-      isClosed_closure.upperClosure_pi hs.closure).antisymm $
+  (closure_minimal (upperClosure_anti subset_closure) <|
+      isClosed_closure.upperClosure_pi hs.closure).antisymm <|
     upperClosure_min (closure_mono subset_upperClosure) (upperClosure s).upper.closure
 
 lemma closure_lowerClosure_comm_pi (hs : BddAbove s) :
     closure (lowerClosure s : Set (ι → ℝ)) = lowerClosure (closure s) :=
-  (closure_minimal (lowerClosure_mono subset_closure) $
-        isClosed_closure.lowerClosure_pi hs.closure).antisymm $
+  (closure_minimal (lowerClosure_mono subset_closure) <|
+        isClosed_closure.lowerClosure_pi hs.closure).antisymm <|
     lowerClosure_min (closure_mono subset_lowerClosure) (lowerClosure s).lower.closure
 
 end Finite

--- a/Mathlib/Analysis/RCLike/Basic.lean
+++ b/Mathlib/Analysis/RCLike/Basic.lean
@@ -418,7 +418,7 @@ theorem mul_conj (z : K) : z * conj z = ‖z‖ ^ 2 := by
 theorem conj_mul (z : K) : conj z * z = ‖z‖ ^ 2 := by rw [mul_comm, mul_conj]
 
 lemma inv_eq_conj (hz : ‖z‖ = 1) : z⁻¹ = conj z :=
-  inv_eq_of_mul_eq_one_left $ by simp_rw [conj_mul, hz, algebraMap.coe_one, one_pow]
+  inv_eq_of_mul_eq_one_left <| by simp_rw [conj_mul, hz, algebraMap.coe_one, one_pow]
 
 theorem normSq_sub (z w : K) : normSq (z - w) = normSq z + normSq w - 2 * re (z * conj w) := by
   simp only [normSq_add, sub_eq_add_neg, map_neg, mul_neg, normSq_neg, map_neg]

--- a/Mathlib/Analysis/SpecialFunctions/Complex/Arg.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Complex/Arg.lean
@@ -107,7 +107,7 @@ theorem arg_cos_add_sin_mul_I {θ : ℝ} (hθ : θ ∈ Set.Ioc (-π) π) : arg (
 lemma arg_exp_mul_I (θ : ℝ) :
     arg (exp (θ * I)) = toIocMod (mul_pos two_pos Real.pi_pos) (-π) θ := by
   convert arg_cos_add_sin_mul_I (θ := toIocMod (mul_pos two_pos Real.pi_pos) (-π) θ) _ using 2
-  · rw [← exp_mul_I, eq_sub_of_add_eq $ toIocMod_add_toIocDiv_zsmul _ _ θ, ofReal_sub,
+  · rw [← exp_mul_I, eq_sub_of_add_eq <| toIocMod_add_toIocDiv_zsmul _ _ θ, ofReal_sub,
       ofReal_zsmul, ofReal_mul, ofReal_ofNat, exp_mul_I_periodic.sub_zsmul_eq]
   · convert toIocMod_mem_Ioc _ _ _
     ring
@@ -312,7 +312,7 @@ lemma abs_eq_one_iff' : abs x = 1 ↔ ∃ θ ∈ Set.Ioc (-π) π, exp (θ * I) 
     refine ⟨toIocMod (mul_pos two_pos Real.pi_pos) (-π) θ, ?_, ?_⟩
     · convert toIocMod_mem_Ioc _ _ _
       ring
-    · rw [eq_sub_of_add_eq $ toIocMod_add_toIocDiv_zsmul _ _ θ, ofReal_sub,
+    · rw [eq_sub_of_add_eq <| toIocMod_add_toIocDiv_zsmul _ _ θ, ofReal_sub,
       ofReal_zsmul, ofReal_mul, ofReal_ofNat, exp_mul_I_periodic.sub_zsmul_eq]
   · rintro ⟨θ, _, rfl⟩
     exact ⟨θ, rfl⟩

--- a/Mathlib/Analysis/SpecialFunctions/Trigonometric/Bounds.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Trigonometric/Bounds.lean
@@ -56,7 +56,7 @@ lemma le_sin (hx : x ≤ 0) : x ≤ sin x := by simpa using sin_le <| neg_nonneg
 
 lemma one_sub_sq_div_two_le_cos : 1 - x ^ 2 / 2 ≤ cos x := by
   wlog hx₀ : 0 ≤ x
-  · simpa using this $ neg_nonneg.2 $ le_of_not_le hx₀
+  · simpa using this <| neg_nonneg.2 <| le_of_not_le hx₀
   suffices MonotoneOn (fun x ↦ cos x + x ^ 2 / 2) (Ici 0) by
     simpa using this left_mem_Ici hx₀ hx₀
   refine monotoneOn_of_hasDerivWithinAt_nonneg
@@ -69,12 +69,12 @@ lemma one_sub_sq_div_two_le_cos : 1 - x ^ 2 / 2 ≤ cos x := by
 lemma two_div_pi_mul_le_sin (hx₀ : 0 ≤ x) (hx : x ≤ π / 2) : 2 / π * x ≤ sin x := by
   rw [← sub_nonneg]
   suffices ConcaveOn ℝ (Icc 0 (π / 2)) (fun x ↦ sin x - 2 / π * x) by
-    refine (le_min ?_ ?_).trans $ this.min_le_of_mem_Icc ⟨hx₀, hx⟩ <;> field_simp
+    refine (le_min ?_ ?_).trans <| this.min_le_of_mem_Icc ⟨hx₀, hx⟩ <;> field_simp
   exact concaveOn_of_hasDerivWithinAt2_nonpos (convex_Icc ..)
-    (Continuous.continuousOn $ by fun_prop)
-    (fun x _ ↦ ((hasDerivAt_sin ..).sub $ (hasDerivAt_id ..).const_mul (2 / π)).hasDerivWithinAt)
+    (Continuous.continuousOn <| by fun_prop)
+    (fun x _ ↦ ((hasDerivAt_sin ..).sub <| (hasDerivAt_id ..).const_mul (2 / π)).hasDerivWithinAt)
     (fun x _ ↦ (hasDerivAt_cos ..).hasDerivWithinAt.sub_const _)
-    fun x hx ↦ neg_nonpos.2 $ sin_nonneg_of_mem_Icc $ Icc_subset_Icc_right (by linarith) $
+    fun x hx ↦ neg_nonpos.2 <| sin_nonneg_of_mem_Icc <| Icc_subset_Icc_right (by linarith) <|
     interior_subset hx
 
 /-- **Jordan's inequality** for negative values. -/
@@ -88,11 +88,11 @@ lemma one_sub_two_div_pi_mul_le_cos (hx₀ : 0 ≤ x) (hx : x ≤ π / 2) : 1 - 
 
 lemma cos_quadratic_upper_bound (hx : |x| ≤ π) : cos x ≤ 1 - 2 / π ^ 2 * x ^ 2 := by
   wlog hx₀ : 0 ≤ x
-  · simpa using this (by rwa [abs_neg]) $ neg_nonneg.2 $ le_of_not_le hx₀
+  · simpa using this (by rwa [abs_neg]) <| neg_nonneg.2 <| le_of_not_le hx₀
   rw [abs_of_nonneg hx₀] at hx
   -- TODO: `compute_deriv` tactic?
   have hderiv (x) : HasDerivAt (fun x ↦ 1 - 2 / π ^ 2 * x ^ 2 - cos x) _ x :=
-    (((hasDerivAt_pow ..).const_mul _).const_sub _).sub $ hasDerivAt_cos _
+    (((hasDerivAt_pow ..).const_mul _).const_sub _).sub <| hasDerivAt_cos _
   simp only [Nat.cast_ofNat, Nat.succ_sub_succ_eq_sub, tsub_zero, pow_one, ← neg_sub', neg_sub,
     ← mul_assoc] at hderiv
   have hmono : MonotoneOn (fun x ↦ 1 - 2 / π ^ 2 * x ^ 2 - cos x) (Icc 0 (π / 2)) := by
@@ -100,7 +100,7 @@ lemma cos_quadratic_upper_bound (hx : |x| ≤ π) : cos x ≤ 1 - 2 / π ^ 2 * x
     set_option tactic.skipAssignedInstances false in
     refine monotoneOn_of_hasDerivWithinAt_nonneg
       (convex_Icc ..)
-      (Continuous.continuousOn $ by fun_prop)
+      (Continuous.continuousOn <| by fun_prop)
       (fun x _ ↦ (hderiv _).hasDerivWithinAt)
       fun x hx ↦ sub_nonneg.2 ?_
     have ⟨hx₀, hx⟩ := interior_subset hx
@@ -113,20 +113,20 @@ lemma cos_quadratic_upper_bound (hx : |x| ≤ π) : cos x ≤ 1 - 2 / π ^ 2 * x
     -- Compiles without this option, but somewhat slower.
     set_option tactic.skipAssignedInstances false in
     refine concaveOn_of_hasDerivWithinAt2_nonpos (convex_Icc ..)
-      (Continuous.continuousOn $ by fun_prop) (fun x _ ↦ (hderiv _).hasDerivWithinAt)
-      (fun x _ ↦ ((hasDerivAt_sin ..).sub $ (hasDerivAt_id ..).const_mul _).hasDerivWithinAt)
+      (Continuous.continuousOn <| by fun_prop) (fun x _ ↦ (hderiv _).hasDerivWithinAt)
+      (fun x _ ↦ ((hasDerivAt_sin ..).sub <| (hasDerivAt_id ..).const_mul _).hasDerivWithinAt)
       fun x hx ↦ ?_
     have ⟨hx, hx'⟩ := interior_subset hx
     calc
       _ ≤ (0 : ℝ) - 0 := by
           gcongr
-          · exact cos_nonpos_of_pi_div_two_le_of_le hx $ hx'.trans $ by linarith
+          · exact cos_nonpos_of_pi_div_two_le_of_le hx <| hx'.trans <| by linarith
           · positivity
       _ = 0 := sub_zero _
   rw [← sub_nonneg]
   obtain hx' | hx' := le_total x (π / 2)
-  · simpa using hmono (left_mem_Icc.2 $ by positivity) ⟨hx₀, hx'⟩ hx₀
-  · refine (le_min ?_ ?_).trans $ hconc.min_le_of_mem_Icc ⟨hx', hx⟩ <;> field_simp <;> norm_num
+  · simpa using hmono (left_mem_Icc.2 <| by positivity) ⟨hx₀, hx'⟩ hx₀
+  · refine (le_min ?_ ?_).trans <| hconc.min_le_of_mem_Icc ⟨hx', hx⟩ <;> field_simp <;> norm_num
 
 /-- For 0 < x ≤ 1 we have x - x ^ 3 / 4 < sin x.
 

--- a/Mathlib/CategoryTheory/Category/PartialFun.lean
+++ b/Mathlib/CategoryTheory/Category/PartialFun.lean
@@ -145,7 +145,7 @@ noncomputable def partialFunEquivPointed : PartialFun.{u} ≌ Pointed :=
             · intro h
               split_ifs at h with ha
               rw [some_inj] at h
-              exact ⟨b, ⟨ha, h.symm⟩, rfl⟩) $
+              exact ⟨b, ⟨ha, h.symm⟩, rfl⟩) <|
     NatIso.ofComponents
       (fun X ↦ Pointed.Iso.mk (by classical exact Equiv.optionSubtypeNe X.point) (by rfl))
       fun {X Y} f ↦ Pointed.Hom.ext <| funext fun a ↦ by

--- a/Mathlib/CategoryTheory/Limits/ConcreteCategory/WithAlgebraicStructures.lean
+++ b/Mathlib/CategoryTheory/Limits/ConcreteCategory/WithAlgebraicStructures.lean
@@ -70,8 +70,8 @@ lemma colimit_no_zero_smul_divisor
   obtain ⟨j'', H⟩ := H
   simpa [elementwise_of% (colimit.w F), map_zero] using congr(colimit.ι F _
     $(H (IsFiltered.sup {j, j', j''} { ⟨j, j', by simp, by simp, i⟩ })
-      (IsFiltered.toSup _ _ $ by simp)
-      (F.map (IsFiltered.toSup _ _ $ by simp) x)
+      (IsFiltered.toSup _ _ <| by simp)
+      (F.map (IsFiltered.toSup _ _ <| by simp) x)
       (by rw [← IsFiltered.toSup_commutes (f := i) (mY := by simp) (mf := by simp), F.map_comp,
         comp_apply, ← map_smul, ← map_smul, h, map_zero])))
 

--- a/Mathlib/Combinatorics/Additive/AP/Three/Defs.lean
+++ b/Mathlib/Combinatorics/Additive/AP/Three/Defs.lean
@@ -141,7 +141,7 @@ lemma IsMulFreimanIso.threeGPFree_congr (hf : IsMulFreimanIso 2 s t f) :
     obtain ⟨a, ha, rfl⟩ := hf.bijOn.surjOn hfa
     obtain ⟨b, hb, rfl⟩ := hf.bijOn.surjOn hfb
     obtain ⟨c, hc, rfl⟩ := hf.bijOn.surjOn hfc
-    exact congr_arg f $ hs ha hb hc $ (hf.mul_eq_mul ha hc hb hb).1 habc
+    exact congr_arg f <| hs ha hb hc <| (hf.mul_eq_mul ha hc hb hb).1 habc
 
 @[to_additive]
 theorem ThreeGPFree.image' [FunLike F α β] [MulHomClass F α β] (f : F) (hf : (s * s).InjOn f)
@@ -184,7 +184,7 @@ lemma ThreeGPFree.eq_right (hs : ThreeGPFree s) :
 @[to_additive]
 theorem ThreeGPFree.smul_set (hs : ThreeGPFree s) : ThreeGPFree (a • s) := by
   rintro _ ⟨b, hb, rfl⟩ _ ⟨c, hc, rfl⟩ _ ⟨d, hd, rfl⟩ h
-  exact congr_arg (a • ·) $ hs hb hc hd $ by simpa [mul_mul_mul_comm _ _ a] using h
+  exact congr_arg (a • ·) <| hs hb hc hd <| by simpa [mul_mul_mul_comm _ _ a] using h
 
 @[to_additive] lemma threeGPFree_smul_set : ThreeGPFree (a • s) ↔ ThreeGPFree s where
   mp hs b hb c hc d hd h := mul_left_cancel
@@ -214,7 +214,7 @@ variable [CancelCommMonoidWithZero α] [NoZeroDivisors α] {s : Set α} {a : α}
 
 lemma ThreeGPFree.smul_set₀ (hs : ThreeGPFree s) (ha : a ≠ 0) : ThreeGPFree (a • s) := by
   rintro _ ⟨b, hb, rfl⟩ _ ⟨c, hc, rfl⟩ _ ⟨d, hd, rfl⟩ h
-  exact congr_arg (a • ·) $ hs hb hc hd $ by simpa [mul_mul_mul_comm _ _ a, ha] using h
+  exact congr_arg (a • ·) <| hs hb hc hd <| by simpa [mul_mul_mul_comm _ _ a, ha] using h
 
 theorem threeGPFree_smul_set₀ (ha : a ≠ 0) : ThreeGPFree (a • s) ↔ ThreeGPFree s :=
   ⟨fun hs b hb c hc d hd h ↦
@@ -441,7 +441,7 @@ theorem addRothNumber_Ico (a b : ℕ) : addRothNumber (Ico a b) = rothNumberNat 
 
 lemma Fin.addRothNumber_eq_rothNumberNat (hkn : 2 * k ≤ n) :
     addRothNumber (Iio k : Finset (Fin n.succ)) = rothNumberNat k :=
-  IsAddFreimanIso.addRothNumber_congr $ mod_cast isAddFreimanIso_Iio two_ne_zero hkn
+  IsAddFreimanIso.addRothNumber_congr <| mod_cast isAddFreimanIso_Iio two_ne_zero hkn
 
 lemma Fin.addRothNumber_le_rothNumberNat (k n : ℕ) (hkn : k ≤ n) :
     addRothNumber (Iio k : Finset (Fin n.succ)) ≤ rothNumberNat k := by

--- a/Mathlib/Combinatorics/Additive/Corner/Defs.lean
+++ b/Mathlib/Combinatorics/Additive/Corner/Defs.lean
@@ -55,7 +55,7 @@ lemma IsCorner.mono (hAB : A ⊆ B) (hA : IsCorner A x₁ y₁ x₂ y₂) : IsCo
   add_eq_add := hA.add_eq_add
 
 lemma IsCornerFree.mono (hAB : A ⊆ B) (hB : IsCornerFree B) : IsCornerFree A :=
-  fun _x₁ _y₁ _x₂ _y₂ hxyd ↦ hB $ hxyd.mono hAB
+  fun _x₁ _y₁ _x₂ _y₂ hxyd ↦ hB <| hxyd.mono hAB
 
 @[simp] lemma not_isCorner_empty : ¬ IsCorner ∅ x₁ y₁ x₂ y₂ := by simp [isCorner_iff]
 
@@ -76,7 +76,7 @@ lemma IsCorner.image (hf : IsAddFreimanHom 2 s t f) (hAs : (A : Set (G × G)) �
 lemma IsCornerFree.of_image (hf : IsAddFreimanHom 2 s t f) (hf' : s.InjOn f)
     (hAs : (A : Set (G × G)) ⊆ s ×ˢ s) (hA : IsCornerFree (Prod.map f f '' A)) : IsCornerFree A :=
   fun _x₁ _y₁ _x₂ _y₂ hxy ↦
-    hf' (hAs hxy.fst_fst_mem).1 (hAs hxy.snd_fst_mem).1 $ hA $ hxy.image hf hAs
+    hf' (hAs hxy.fst_fst_mem).1 (hAs hxy.snd_fst_mem).1 <| hA <| hxy.image hf hAs
 
 lemma isCorner_image (hf : IsAddFreimanIso 2 s t f) (hAs : A ⊆ s ×ˢ s)
     (hx₁ : x₁ ∈ s) (hy₁ : y₁ ∈ s) (hx₂ : x₂ ∈ s) (hy₂ : y₂ ∈ s) :

--- a/Mathlib/Combinatorics/Additive/Corner/Roth.lean
+++ b/Mathlib/Combinatorics/Additive/Corner/Roth.lean
@@ -53,7 +53,7 @@ private lemma noAccidental (hs : IsCornerFree (A : Set (G × G))) :
     NoAccidental (triangleIndices A) where
   eq_or_eq_or_eq a a' b b' c c' ha hb hc := by
     simp only [mk_mem_triangleIndices] at ha hb hc
-    exact .inl $ hs ⟨hc.1, hb.1, ha.1, hb.2.symm.trans ha.2⟩
+    exact .inl <| hs ⟨hc.1, hb.1, ha.1, hb.2.symm.trans ha.2⟩
 
 private lemma farFromTriangleFree_graph [Fintype G] [DecidableEq G] (hε : ε * card G ^ 2 ≤ A.card) :
     (graph <| triangleIndices A).FarFromTriangleFree (ε / 9) := by
@@ -96,7 +96,7 @@ theorem corners_theorem (ε : ℝ) (hε : 0 < ε) (hG : cornersTheoremBound ε �
   classical
   have h₁ := (farFromTriangleFree_graph hAε).le_card_cliqueFinset
   rw [card_triangles, card_triangleIndices] at h₁
-  convert h₁.trans (Nat.cast_le.2 $ card_le_univ _) using 1 <;> simp <;> ring
+  convert h₁.trans (Nat.cast_le.2 <| card_le_univ _) using 1 <;> simp <;> ring
 
 /-- The **corners theorem** for `ℕ`.
 
@@ -118,8 +118,8 @@ theorem corners_theorem_nat (hε : 0 < ε) (hn : cornersTheoremBound (ε / 9) �
     omega
   rw [this] at hA
   have := Fin.isAddFreimanIso_Iio two_ne_zero (le_refl (2 * n))
-  have := hA.of_image this.isAddFreimanHom Fin.val_injective.injOn $ by
-    refine Set.image_subset_iff.2 $ hAn.trans fun x hx ↦ ?_
+  have := hA.of_image this.isAddFreimanHom Fin.val_injective.injOn <| by
+    refine Set.image_subset_iff.2 <| hAn.trans fun x hx ↦ ?_
     simp only [coe_range, Set.mem_prod, Set.mem_Iio] at hx
     exact ⟨Fin.natCast_strictMono (by omega) hx.1, Fin.natCast_strictMono (by omega) hx.2⟩
   rw [← coe_image] at this
@@ -155,10 +155,10 @@ theorem roth_3ap_theorem (ε : ℝ) (hε : 0 < ε) (hG : cornersTheoremBound ε 
       ∃ x₁ y₁ x₂ y₂, y₁ - x₁ ∈ A ∧ y₂ - x₁ ∈ A ∧ y₁ - x₂ ∈ A ∧ x₁ + y₂ = x₂ + y₁ ∧ x₁ ≠ x₂ := by
     simpa [IsCornerFree, isCorner_iff, B, -exists_and_left, -exists_and_right]
       using corners_theorem ε hε hG B this
-  have := hA hx₂y₁ hx₁y₁ hx₁y₂ $ by -- TODO: This really ought to just be `by linear_combination h`
+  have := hA hx₂y₁ hx₁y₁ hx₁y₂ <| by -- TODO: This really ought to just be `by linear_combination h`
     rw [sub_add_sub_comm, add_comm, add_sub_add_comm, add_right_cancel_iff,
       sub_eq_sub_iff_add_eq_add, add_comm, hxy, add_comm]
-  exact hx₁x₂ $ by simpa using this.symm
+  exact hx₁x₂ <| by simpa using this.symm
 
 /-- **Roth's theorem** for `ℕ`.
 
@@ -176,8 +176,8 @@ theorem roth_3ap_theorem_nat (ε : ℝ) (hε : 0 < ε) (hG : cornersTheoremBound
     omega
   rw [this] at hA
   have := Fin.isAddFreimanIso_Iio two_ne_zero (le_refl (2 * n))
-  have := hA.of_image this.isAddFreimanHom Fin.val_injective.injOn $ Set.image_subset_iff.2 $
-      hAn.trans fun x hx ↦ Fin.natCast_strictMono (by omega) $ by
+  have := hA.of_image this.isAddFreimanHom Fin.val_injective.injOn <| Set.image_subset_iff.2 <|
+      hAn.trans fun x hx ↦ Fin.natCast_strictMono (by omega) <| by
         simpa only [coe_range, Set.mem_Iio] using hx
   rw [← coe_image] at this
   refine roth_3ap_theorem (ε / 3) (by positivity) (by simp; omega) _ ?_ this
@@ -188,7 +188,7 @@ theorem roth_3ap_theorem_nat (ε : ℝ) (hε : 0 < ε) (hG : cornersTheoremBound
     _ ≤ A.card := hAε
     _ = _ := by
       rw [card_image_of_injOn]
-      exact (CharP.natCast_injOn_Iio (Fin (2 * n).succ) (2 * n).succ).mono $ hAn.trans $ by
+      exact (CharP.natCast_injOn_Iio (Fin (2 * n).succ) (2 * n).succ).mono <| hAn.trans <| by
         simp; omega
 
 open Asymptotics Filter

--- a/Mathlib/Combinatorics/Additive/Dissociation.lean
+++ b/Mathlib/Combinatorics/Additive/Dissociation.lean
@@ -39,7 +39,7 @@ def MulDissociated (s : Set α) : Prop := {t : Finset α | ↑t ⊆ s}.InjOn (�
 
 @[to_additive] lemma mulDissociated_iff_sum_eq_subsingleton :
     MulDissociated s ↔ ∀ a, {t : Finset α | ↑t ⊆ s ∧ ∏ x in t, x = a}.Subsingleton :=
-  ⟨fun hs _ _t ht _u hu ↦ hs ht.1 hu.1 $ ht.2.trans hu.2.symm,
+  ⟨fun hs _ _t ht _u hu ↦ hs ht.1 hu.1 <| ht.2.trans hu.2.symm,
     fun hs _t ht _u hu htu ↦ hs _ ⟨ht, htu⟩ ⟨hu, rfl⟩⟩
 
 @[to_additive] lemma MulDissociated.subset {t : Set α} (hst : s ⊆ t) (ht : MulDissociated t) :
@@ -137,13 +137,13 @@ lemma exists_subset_mulSpan_card_le_of_forall_mulDissociated
   by_cases ha' : a ∈ s'
   · exact subset_mulSpan ha'
   obtain ⟨t, u, ht, hu, htu⟩ := not_mulDissociated_iff_exists_disjoint.1 fun h ↦
-    hs'max _ (insert_subset_iff.2 ⟨ha, hs'.1⟩) h $ ssubset_insert ha'
+    hs'max _ (insert_subset_iff.2 ⟨ha, hs'.1⟩) h <| ssubset_insert ha'
   by_cases hat : a ∈ t
   · have : a = (∏ b in u, b) / ∏ b in t.erase a, b := by
       rw [prod_erase_eq_div hat, htu.2.2, div_div_self']
     rw [this]
     exact prod_div_prod_mem_mulSpan
-      ((subset_insert_iff_of_not_mem $ disjoint_left.1 htu.1 hat).1 hu) (subset_insert_iff.1 ht)
+      ((subset_insert_iff_of_not_mem <| disjoint_left.1 htu.1 hat).1 hu) (subset_insert_iff.1 ht)
   rw [coe_subset, subset_insert_iff_of_not_mem hat] at ht
   by_cases hau : a ∈ u
   · have : a = (∏ b in t, b) / ∏ b in u.erase a, b := by

--- a/Mathlib/Combinatorics/Additive/Energy.lean
+++ b/Mathlib/Combinatorics/Additive/Energy.lean
@@ -132,7 +132,7 @@ variable {s t}
 @[to_additive] lemma mulEnergy_eq_sum_sq [Fintype α] (s t : Finset α) :
     Eₘ[s, t] = ∑ a, ((s ×ˢ t).filter fun (x, y) ↦ x * y = a).card ^ 2 := by
   rw [mulEnergy_eq_sum_sq']
-  exact Fintype.sum_subset $ by aesop (add simp [filter_eq_empty_iff, mul_mem_mul])
+  exact Fintype.sum_subset <| by aesop (add simp [filter_eq_empty_iff, mul_mem_mul])
 
 @[to_additive card_sq_le_card_mul_addEnergy]
 lemma card_sq_le_card_mul_mulEnergy (s t u : Finset α) :

--- a/Mathlib/Combinatorics/Additive/ErdosGinzburgZiv.lean
+++ b/Mathlib/Combinatorics/Additive/ErdosGinzburgZiv.lean
@@ -67,14 +67,14 @@ private theorem ZMod.erdos_ginzburg_ziv_prime (a : ι → ZMod p) (hs : s.card =
   have hpN : p ∣ N := char_dvd_card_solutions_of_add_lt p
     (totalDegree_f₁_add_totalDegree_f₂.trans_eq hs')
   -- Hence, `2 ≤ p ≤ N` and we can make a common root `x ≠ 0`.
-  obtain ⟨x, hx⟩ := Fintype.exists_ne_of_one_lt_card ((Fact.out : p.Prime).one_lt.trans_le $
+  obtain ⟨x, hx⟩ := Fintype.exists_ne_of_one_lt_card ((Fact.out : p.Prime).one_lt.trans_le <|
     Nat.le_of_dvd hN₀ hpN) zero_sol
   -- This common root gives us the required subsequence, namely the `i ∈ s` such that `x i ≠ 0`.
   refine ⟨(s.attach.filter fun a ↦ x.1 a ≠ 0).map ⟨(↑), Subtype.val_injective⟩, ?_, ?_, ?_⟩
   · simp (config := { contextual := true }) [subset_iff]
   -- From `f₁ x = 0`, we get that `p` divides the number of `a` such that `x a ≠ 0`.
   · rw [card_map]
-    refine Nat.eq_of_dvd_of_lt_two_mul (Finset.card_pos.2 ?_).ne' ?_ $
+    refine Nat.eq_of_dvd_of_lt_two_mul (Finset.card_pos.2 ?_).ne' ?_ <|
       (Finset.card_filter_le _ _).trans_lt ?_
     -- This number is nonzero because `x ≠ 0`.
     · rw [← Subtype.coe_ne_coe, Function.ne_iff] at hx
@@ -135,11 +135,11 @@ theorem Int.erdos_ginzburg_ziv (a : ι → ℤ) (hs : 2 * n - 1 ≤ s.card) :
       -- `t ∈ ℬ` of `(∑ i ∈ t, a i) / n` is divisible by `m`.
       obtain ⟨ℬ, hℬ𝒜, hℬcard, hℬ⟩ := ihm (fun t ↦ (∑ i ∈ t, a i) / n) h𝒜card.ge
       -- We are done.
-      refine ⟨ℬ.biUnion fun x ↦ x, biUnion_subset.2 fun t ht ↦ (h𝒜 $ hℬ𝒜 ht).1, ?_, ?_⟩
-      · rw [card_biUnion (h𝒜disj.mono hℬ𝒜), sum_const_nat fun t ht ↦ (h𝒜 $ hℬ𝒜 ht).2.1, hℬcard]
+      refine ⟨ℬ.biUnion fun x ↦ x, biUnion_subset.2 fun t ht ↦ (h𝒜 <| hℬ𝒜 ht).1, ?_, ?_⟩
+      · rw [card_biUnion (h𝒜disj.mono hℬ𝒜), sum_const_nat fun t ht ↦ (h𝒜 <| hℬ𝒜 ht).2.1, hℬcard]
       rwa [sum_biUnion, natCast_mul, mul_comm, ← Int.dvd_div_iff_mul_dvd, Int.sum_div]
-      · exact fun t ht ↦ (h𝒜 $ hℬ𝒜 ht).2.2
-      · exact dvd_sum fun t ht ↦ (h𝒜 $ hℬ𝒜 ht).2.2
+      · exact fun t ht ↦ (h𝒜 <| hℬ𝒜 ht).2.2
+      · exact dvd_sum fun t ht ↦ (h𝒜 <| hℬ𝒜 ht).2.2
       · exact h𝒜disj.mono hℬ𝒜
     -- Now, let's find those `2 * m - 1` sets.
     rintro k hk
@@ -165,12 +165,12 @@ theorem Int.erdos_ginzburg_ziv (a : ι → ℤ) (hs : 2 * n - 1 ≤ s.card) :
     have : t₀ ∉ 𝒜 := by
       rintro h
       obtain rfl : n = 0 := by
-        simpa [← card_eq_zero, ht₀card] using sdiff_disjoint.mono ht₀ $ subset_biUnion_of_mem id h
+        simpa [← card_eq_zero, ht₀card] using sdiff_disjoint.mono ht₀ <| subset_biUnion_of_mem id h
       omega
     refine ⟨𝒜.cons t₀ this, by rw [card_cons, h𝒜card], ?_, ?_⟩
     · simp only [cons_eq_insert, coe_insert, Set.pairwise_insert_of_symmetric symmetric_disjoint,
         mem_coe, ne_eq]
-      exact ⟨h𝒜disj, fun t ht _ ↦ sdiff_disjoint.mono ht₀ $ subset_biUnion_of_mem id ht⟩
+      exact ⟨h𝒜disj, fun t ht _ ↦ sdiff_disjoint.mono ht₀ <| subset_biUnion_of_mem id ht⟩
     · simp only [cons_eq_insert, mem_insert, forall_eq_or_imp, and_assoc]
       exact ⟨ht₀.trans sdiff_subset, ht₀card, ht₀sum, h𝒜⟩
 

--- a/Mathlib/Combinatorics/Additive/FreimanHom.lean
+++ b/Mathlib/Combinatorics/Additive/FreimanHom.lean
@@ -319,7 +319,7 @@ namespace Fin
 variable {k m n : ℕ}
 
 private lemma aux (hm : m ≠ 0) (hkmn : m * k ≤ n) : k < (n + 1) :=
-  Nat.lt_succ_iff.2 $ le_trans (Nat.le_mul_of_pos_left _ hm.bot_lt) hkmn
+  Nat.lt_succ_iff.2 <| le_trans (Nat.le_mul_of_pos_left _ hm.bot_lt) hkmn
 
 /-- **No wrap-around principle**.
 
@@ -335,7 +335,7 @@ lemma isAddFreimanIso_Iic (hm : m ≠ 0) (hkmn : m * k ≤ n) :
     have (u : Multiset (Fin (n + 1))) : Nat.castRingHom _ (u.map val).sum = u.sum := by simp
     rw [← this, ← this]
     have {u : Multiset (Fin (n + 1))} (huk : ∀ x ∈ u, x ≤ k) (hu : card u = m) :
-        (u.map val).sum < (n + 1) := Nat.lt_succ_iff.2 $ hkmn.trans' $ by
+        (u.map val).sum < (n + 1) := Nat.lt_succ_iff.2 <| hkmn.trans' <| by
       rw [← hu, ← card_map]
       refine sum_le_card_nsmul (u.map val) k ?_
       simpa [le_iff_val_le_val, -val_fin_le, Nat.mod_eq_of_lt, aux hm hkmn] using huk

--- a/Mathlib/Combinatorics/Colex.lean
+++ b/Mathlib/Combinatorics/Colex.lean
@@ -345,15 +345,15 @@ lemma lt_iff_exists_filter_lt :
     have mem_u {w : α} : w ∈ u ↔ w ∈ t ∧ w ∉ s ∧ ∀ a ∈ s, a ∉ t → a < w := by simp [u, and_assoc]
     have hu : u.Nonempty := h.imp fun _ ↦ mem_u.2
     let m := max' _ hu
-    have ⟨hmt, hms, hm⟩ : m ∈ t ∧ m ∉ s ∧ ∀ a ∈ s, a ∉ t → a < m := mem_u.1 $ max'_mem _ _
+    have ⟨hmt, hms, hm⟩ : m ∈ t ∧ m ∉ s ∧ ∀ a ∈ s, a ∉ t → a < m := mem_u.1 <| max'_mem _ _
     refine ⟨m, hmt, hms, fun a hma ↦ ⟨fun has ↦ not_imp_comm.1 (hm _ has) hma.asymm, fun hat ↦ ?_⟩⟩
     by_contra has
     have hau : a ∈ u := mem_u.2 ⟨hat, has, fun b hbs hbt ↦ (hm _ hbs hbt).trans hma⟩
-    exact hma.not_le $ le_max' _ _ hau
+    exact hma.not_le <| le_max' _ _ hau
   · rintro ⟨w, hwt, hws, hw⟩
     refine ⟨w, hwt, hws, fun a has hat ↦ ?_⟩
     by_contra! hwa
-    exact hat $ (hw $ hwa.lt_of_ne $ ne_of_mem_of_not_mem hwt hat).1 has
+    exact hat <| (hw <| hwa.lt_of_ne <| ne_of_mem_of_not_mem hwt hat).1 has
 
 /-- If `s ≤ t` in colex and `s.card ≤ t.card`, then `s \ {a} ≤ t \ {min t}` for any `a ∈ s`. -/
 lemma erase_le_erase_min' (hst : toColex s ≤ toColex t) (hcard : s.card ≤ t.card) (ha : a ∈ s) :
@@ -364,9 +364,9 @@ lemma erase_le_erase_min' (hst : toColex s ≤ toColex t) (hcard : s.card ≤ t.
   -- Case on whether `s = t`
   obtain rfl | h' := eq_or_ne s t
   -- If `s = t`, then `s \ {a} ≤ s \ {m}` because `m ≤ a`
-  · exact (erase_le_erase ha $ min'_mem _ _).2 $ min'_le _ _ $ ha
+  · exact (erase_le_erase ha <| min'_mem _ _).2 <| min'_le _ _ <| ha
   -- If `s ≠ t`, call `w` the colex witness. Case on whether `w < a` or `a < w`
-  replace hst := hst.lt_of_ne $ toColex_inj.not.2 h'
+  replace hst := hst.lt_of_ne <| toColex_inj.not.2 h'
   simp only [lt_iff_exists_filter_lt, mem_sdiff, filter_inj, and_assoc] at hst
   obtain ⟨w, hwt, hws, hw⟩ := hst
   obtain hwa | haw := (ne_of_mem_of_not_mem ha hws).symm.lt_or_lt
@@ -379,14 +379,15 @@ lemma erase_le_erase_min' (hst : toColex s ≤ toColex t) (hcard : s.card ≤ t.
     obtain rfl | hbt := hbt
     · assumption
     · by_contra! hab
-      exact hbt $ (hw $ hwa.trans_le hab).1 $ mem_of_mem_erase hbs
+      exact hbt <| (hw <| hwa.trans_le hab).1 <| mem_of_mem_erase hbs
   -- If `a < w`, case on whether `m < w` or `m = w`
   obtain rfl | hmw : m = w ∨ m < w := (min'_le _ _ hwt).eq_or_lt
   -- If `m = w`, then `s \ {a} = t \ {m}`
   · have : erase t m ⊆ erase s a := by
       rintro b hb
       rw [mem_erase] at hb ⊢
-      exact ⟨(haw.trans_le $ min'_le _ _ hb.2).ne', (hw $ hb.1.lt_of_le' $ min'_le _ _ hb.2).2 hb.2⟩
+      exact ⟨(haw.trans_le <| min'_le _ _ hb.2).ne',
+        (hw <| hb.1.lt_of_le' <| min'_le _ _ hb.2).2 hb.2⟩
     rw [eq_of_subset_of_card_le this]
     rw [card_erase_of_mem ha, card_erase_of_mem (min'_mem _ _)]
     exact tsub_le_tsub_right hcard _
@@ -398,7 +399,7 @@ lemma erase_le_erase_min' (hst : toColex s ≤ toColex t) (hcard : s.card ≤ t.
     obtain rfl | hbt := hbt
     · assumption
     · by_contra! hwb
-      exact hbt $ (hw $ hwb.lt_of_ne $ ne_of_mem_of_not_mem hwt hbt).1 $ mem_of_mem_erase hbs
+      exact hbt <| (hw <| hwb.lt_of_ne <| ne_of_mem_of_not_mem hwt hbt).1 <| mem_of_mem_erase hbs
 
 /-- Strictly monotone functions preserve the colex ordering. -/
 lemma toColex_image_le_toColex_image (hf : StrictMono f) :

--- a/Mathlib/Combinatorics/SetFamily/AhlswedeZhang.lean
+++ b/Mathlib/Combinatorics/SetFamily/AhlswedeZhang.lean
@@ -87,9 +87,9 @@ private lemma Fintype.sum_div_mul_card_choose_card :
   have (n) (hn : n ∈ range (card α + 1)) :
       ((card α).choose n / ((card α - n) * (card α).choose n) : ℚ) = (card α - n : ℚ)⁻¹ := by
     rw [div_mul_cancel_right₀]
-    exact cast_ne_zero.2 (choose_pos $ mem_range_succ_iff.1 hn).ne'
+    exact cast_ne_zero.2 (choose_pos <| mem_range_succ_iff.1 hn).ne'
   simp only [sum_congr rfl this, mul_eq_mul_left_iff, cast_eq_zero]
-  convert Or.inl $ sum_range_reflect _ _ with a ha
+  convert Or.inl <| sum_range_reflect _ _ with a ha
   rw [add_tsub_cancel_right, cast_sub (mem_range_succ_iff.mp ha)]
 
 end
@@ -124,7 +124,7 @@ lemma truncatedSup_of_mem (h : a ∈ lowerClosure s) :
 
 lemma truncatedSup_of_not_mem (h : a ∉ lowerClosure s) : truncatedSup s a = ⊤ := dif_neg h
 
-@[simp] lemma truncatedSup_empty (a : α) : truncatedSup ∅ a = ⊤ := truncatedSup_of_not_mem $ by simp
+@[simp] lemma truncatedSup_empty (a : α) : truncatedSup ∅ a = ⊤ := truncatedSup_of_not_mem (by simp)
 
 @[simp] lemma truncatedSup_singleton (b a : α) : truncatedSup {b} a = if a ≤ b then b else ⊤ := by
   simp [truncatedSup]; split_ifs <;> simp [Finset.filter_true_of_mem, *]
@@ -133,7 +133,7 @@ lemma le_truncatedSup : a ≤ truncatedSup s a := by
   rw [truncatedSup]
   split_ifs with h
   · obtain ⟨ℬ, hb, h⟩ := h
-    exact h.trans $ le_sup' id $ mem_filter.2 ⟨hb, h⟩
+    exact h.trans <| le_sup' id <| mem_filter.2 ⟨hb, h⟩
   · exact le_top
 
 lemma map_truncatedSup [@DecidableRel β (· ≤ ·)] (e : α ≃o β) (s : Finset α) (a : α) :
@@ -201,10 +201,10 @@ lemma truncatedInf_le : truncatedInf s a ≤ a := by
   unfold truncatedInf
   split_ifs with h
   · obtain ⟨b, hb, hba⟩ := h
-    exact hba.trans' $ inf'_le id $ mem_filter.2 ⟨hb, ‹_›⟩
+    exact hba.trans' <| inf'_le id <| mem_filter.2 ⟨hb, ‹_›⟩
   · exact bot_le
 
-@[simp] lemma truncatedInf_empty (a : α) : truncatedInf ∅ a = ⊥ := truncatedInf_of_not_mem $ by simp
+@[simp] lemma truncatedInf_empty (a : α) : truncatedInf ∅ a = ⊥ := truncatedInf_of_not_mem (by simp)
 
 @[simp] lemma truncatedInf_singleton (b a : α) : truncatedInf {b} a = if b ≤ a then b else ⊥ := by
   simp only [truncatedInf, coe_singleton, upperClosure_singleton, UpperSet.mem_Ici_iff,
@@ -245,7 +245,7 @@ lemma truncatedInf_union_right (hs : a ∉ upperClosure s) (ht : a ∈ upperClos
 
 lemma truncatedInf_union_of_not_mem (hs : a ∉ upperClosure s) (ht : a ∉ upperClosure t) :
     truncatedInf (s ∪ t) a = ⊥ :=
-  truncatedInf_of_not_mem $ by rw [coe_union, upperClosure_union]; exact fun h ↦ h.elim hs ht
+  truncatedInf_of_not_mem <| by rw [coe_union, upperClosure_union]; exact fun h ↦ h.elim hs ht
 
 end SemilatticeInf
 
@@ -277,11 +277,11 @@ lemma truncatedInf_sups (hs : a ∈ upperClosure s) (ht : a ∈ upperClosure t) 
 
 lemma truncatedSup_infs_of_not_mem (ha : a ∉ lowerClosure s ⊓ lowerClosure t) :
     truncatedSup (s ⊼ t) a = ⊤ :=
-  truncatedSup_of_not_mem $ by rwa [coe_infs, lowerClosure_infs]
+  truncatedSup_of_not_mem <| by rwa [coe_infs, lowerClosure_infs]
 
 lemma truncatedInf_sups_of_not_mem (ha : a ∉ upperClosure s ⊔ upperClosure t) :
     truncatedInf (s ⊻ t) a = ⊥ :=
-  truncatedInf_of_not_mem $ by rwa [coe_sups, upperClosure_sups]
+  truncatedInf_of_not_mem <| by rwa [coe_sups, upperClosure_sups]
 
 end DistribLattice
 
@@ -301,8 +301,8 @@ variable [DecidableEq α] [Fintype α]
 lemma card_truncatedSup_union_add_card_truncatedSup_infs (𝒜 ℬ : Finset (Finset α)) (s : Finset α) :
     (truncatedSup (𝒜 ∪ ℬ) s).card + (truncatedSup (𝒜 ⊼ ℬ) s).card =
       (truncatedSup 𝒜 s).card + (truncatedSup ℬ s).card := by
-  by_cases h𝒜 : s ∈ lowerClosure (𝒜 : Set $ Finset α) <;>
-    by_cases hℬ : s ∈ lowerClosure (ℬ : Set $ Finset α)
+  by_cases h𝒜 : s ∈ lowerClosure (𝒜 : Set <| Finset α) <;>
+    by_cases hℬ : s ∈ lowerClosure (ℬ : Set <| Finset α)
   · rw [truncatedSup_union h𝒜 hℬ, truncatedSup_infs h𝒜 hℬ]
     exact card_union_add_card_inter _ _
   · rw [truncatedSup_union_left h𝒜 hℬ, truncatedSup_of_not_mem hℬ,
@@ -315,8 +315,8 @@ lemma card_truncatedSup_union_add_card_truncatedSup_infs (𝒜 ℬ : Finset (Fin
 lemma card_truncatedInf_union_add_card_truncatedInf_sups (𝒜 ℬ : Finset (Finset α)) (s : Finset α) :
     (truncatedInf (𝒜 ∪ ℬ) s).card + (truncatedInf (𝒜 ⊻ ℬ) s).card =
       (truncatedInf 𝒜 s).card + (truncatedInf ℬ s).card := by
-  by_cases h𝒜 : s ∈ upperClosure (𝒜 : Set $ Finset α) <;>
-    by_cases hℬ : s ∈ upperClosure (ℬ : Set $ Finset α)
+  by_cases h𝒜 : s ∈ upperClosure (𝒜 : Set <| Finset α) <;>
+    by_cases hℬ : s ∈ upperClosure (ℬ : Set <| Finset α)
   · rw [truncatedInf_union h𝒜 hℬ, truncatedInf_sups h𝒜 hℬ]
     exact card_inter_add_card_union _ _
   · rw [truncatedInf_union_left h𝒜 hℬ, truncatedInf_of_not_mem hℬ,
@@ -365,7 +365,7 @@ lemma IsAntichain.le_infSum (h𝒜 : IsAntichain (· ⊆ ·) (𝒜 : Set (Finset
     _ ≤ _ := sum_le_univ_sum_of_nonneg fun s ↦ by positivity
   refine sum_congr rfl fun s hs ↦ ?_
   rw [truncatedInf_of_isAntichain h𝒜 hs, div_mul_cancel_left₀]
-  have := (nonempty_iff_ne_empty.2 $ ne_of_mem_of_not_mem hs h𝒜₀).card_pos
+  have := (nonempty_iff_ne_empty.2 <| ne_of_mem_of_not_mem hs h𝒜₀).card_pos
   positivity
 
 variable [Nonempty α]

--- a/Mathlib/Combinatorics/SimpleGraph/Basic.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Basic.lean
@@ -816,7 +816,7 @@ theorem deleteEdges_deleteEdges (s s' : Set (Sym2 V)) :
 lemma deleteEdges_le (s : Set (Sym2 V)) : G.deleteEdges s ≤ G := sdiff_le
 
 lemma deleteEdges_anti (h : s₁ ⊆ s₂) : G.deleteEdges s₂ ≤ G.deleteEdges s₁ :=
-  sdiff_le_sdiff_left $ fromEdgeSet_mono h
+  sdiff_le_sdiff_left <| fromEdgeSet_mono h
 
 lemma deleteEdges_mono (h : G ≤ H) : G.deleteEdges s ≤ H.deleteEdges s := sdiff_le_sdiff_right h
 

--- a/Mathlib/Combinatorics/SimpleGraph/Coloring.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Coloring.lean
@@ -370,8 +370,8 @@ lemma chromaticNumber_eq_iff_forall_surjective (hG : G.Colorable n) :
   rw [← hG.chromaticNumber_le.ge_iff_eq, le_chromaticNumber_iff_forall_surjective]
 
 theorem chromaticNumber_bot [Nonempty V] : (⊥ : SimpleGraph V).chromaticNumber = 1 := by
-  have : (⊥ : SimpleGraph V).Colorable 1 := ⟨.mk 0 $ by simp⟩
-  exact this.chromaticNumber_le.antisymm $ ENat.one_le_iff_pos.2 $ chromaticNumber_pos this
+  have : (⊥ : SimpleGraph V).Colorable 1 := ⟨.mk 0 <| by simp⟩
+  exact this.chromaticNumber_le.antisymm <| ENat.one_le_iff_pos.2 <| chromaticNumber_pos this
 
 @[simp]
 theorem chromaticNumber_top [Fintype V] : (⊤ : SimpleGraph V).chromaticNumber = Fintype.card V := by

--- a/Mathlib/Combinatorics/SimpleGraph/Connectivity/WalkCounting.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Connectivity/WalkCounting.lean
@@ -169,7 +169,7 @@ instance : Decidable G.Connected := by
   infer_instance
 
 instance instDecidableMemSupp (c : G.ConnectedComponent) (v : V) : Decidable (v ∈ c.supp) :=
-  c.recOn (fun w ↦ decidable_of_iff (G.Reachable v w) $ by simp)
+  c.recOn (fun w ↦ decidable_of_iff (G.Reachable v w) <| by simp)
     (fun _ _ _ _ ↦ Subsingleton.elim _ _)
 
 lemma odd_card_iff_odd_components : Odd (Nat.card V) ↔

--- a/Mathlib/Combinatorics/SimpleGraph/Hamiltonian.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Hamiltonian.lean
@@ -59,7 +59,7 @@ lemma IsHamiltonian.support_toFinset (hp : p.IsHamiltonian) : p.support.toFinset
 
 /-- The length of a hamiltonian path is one less than the number of vertices of the graph. -/
 lemma IsHamiltonian.length_eq (hp : p.IsHamiltonian) : p.length = Fintype.card α - 1 :=
-  eq_tsub_of_add_eq $ by
+  eq_tsub_of_add_eq <| by
     rw [← length_support, ← List.sum_toFinset_count_eq_length, Finset.sum_congr rfl fun _ _ ↦ hp _,
       ← card_eq_sum_ones, hp.support_toFinset, card_univ]
 
@@ -128,7 +128,7 @@ def IsHamiltonian (G : SimpleGraph α) : Prop :=
 
 lemma IsHamiltonian.mono {H : SimpleGraph α} (hGH : G ≤ H) (hG : G.IsHamiltonian) :
     H.IsHamiltonian :=
-  fun hα ↦ let ⟨_, p, hp⟩ := hG hα; ⟨_, p.map $ .ofLE hGH, hp.map _ bijective_id⟩
+  fun hα ↦ let ⟨_, p, hp⟩ := hG hα; ⟨_, p.map <| .ofLE hGH, hp.map _ bijective_id⟩
 
 lemma IsHamiltonian.connected (hG : G.IsHamiltonian) : G.Connected where
   preconnected a b := by
@@ -138,7 +138,7 @@ lemma IsHamiltonian.connected (hG : G.IsHamiltonian) : G.Connected where
     obtain ⟨_, p, hp⟩ := hG Fintype.one_lt_card.ne'
     have a_mem := hp.mem_support a
     have b_mem := hp.mem_support b
-    exact ((p.takeUntil a a_mem).reverse.append $ p.takeUntil b b_mem).reachable
-  nonempty := not_isEmpty_iff.1 fun _ ↦ by simpa using hG $ by simp [@Fintype.card_eq_zero]
+    exact ((p.takeUntil a a_mem).reverse.append <| p.takeUntil b b_mem).reachable
+  nonempty := not_isEmpty_iff.1 fun _ ↦ by simpa using hG <| by simp [@Fintype.card_eq_zero]
 
 end SimpleGraph

--- a/Mathlib/Combinatorics/SimpleGraph/Regularity/Uniform.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Regularity/Uniform.lean
@@ -86,7 +86,7 @@ lemma isUniform_one : G.IsUniform (1 : 𝕜) s t := by
 variable {G}
 
 lemma IsUniform.pos (hG : G.IsUniform ε s t) : 0 < ε :=
-  not_le.1 fun hε ↦ (hε.trans $ abs_nonneg _).not_lt $ hG (empty_subset _) (empty_subset _)
+  not_le.1 fun hε ↦ (hε.trans <| abs_nonneg _).not_lt <| hG (empty_subset _) (empty_subset _)
     (by simpa using mul_nonpos_of_nonneg_of_nonpos (Nat.cast_nonneg _) hε)
     (by simpa using mul_nonpos_of_nonneg_of_nonpos (Nat.cast_nonneg _) hε)
 
@@ -302,7 +302,7 @@ lemma IsEquipartition.card_interedges_sparsePairs_le (hP : P.IsEquipartition) (h
 private lemma aux {i j : ℕ} (hj : 0 < j) : j * (j - 1) * (i / j + 1) ^ 2 < (i + j) ^ 2 := by
   have : j * (j - 1) < j ^ 2 := by
     rw [sq]; exact Nat.mul_lt_mul_of_pos_left (Nat.sub_lt hj zero_lt_one) hj
-  apply (Nat.mul_lt_mul_of_pos_right this $ pow_pos Nat.succ_pos' _).trans_le
+  apply (Nat.mul_lt_mul_of_pos_right this <| pow_pos Nat.succ_pos' _).trans_le
   rw [← mul_pow]
   exact Nat.pow_le_pow_of_le_left (add_le_add_right (Nat.mul_div_le i j) _) _
 
@@ -332,10 +332,10 @@ lemma IsEquipartition.card_biUnion_offDiag_le (hε : 0 < ε) (hP : P.IsEquiparti
   rw [div_le_iff (Nat.cast_pos.2 (P.parts_nonempty hA.ne_empty).card_pos)]
   have : (A.card : 𝕜) + P.parts.card ≤ 2 * A.card := by
     rw [two_mul]; exact add_le_add_left (Nat.cast_le.2 P.card_parts_le_card) _
-  refine (mul_le_mul_of_nonneg_left this $ by positivity).trans ?_
+  refine (mul_le_mul_of_nonneg_left this <| by positivity).trans ?_
   suffices 1 ≤ ε/4 * P.parts.card by
     rw [mul_left_comm, ← sq]
-    convert mul_le_mul_of_nonneg_left this (mul_nonneg zero_le_two $ sq_nonneg (A.card : 𝕜))
+    convert mul_le_mul_of_nonneg_left this (mul_nonneg zero_le_two <| sq_nonneg (A.card : 𝕜))
       using 1 <;> ring
   rwa [← div_le_iff', one_div_div]
   positivity
@@ -347,7 +347,7 @@ lemma IsEquipartition.sum_nonUniforms_lt' (hA : A.Nonempty) (hε : 0 < ε) (hP :
     _ ≤ (P.nonUniforms G ε).card • (↑(A.card / P.parts.card + 1) : 𝕜) ^ 2 :=
       sum_le_card_nsmul _ _ _ ?_
     _ = _ := nsmul_eq_mul _ _
-    _ ≤ _ := mul_le_mul_of_nonneg_right hG $ by positivity
+    _ ≤ _ := mul_le_mul_of_nonneg_right hG <| by positivity
     _ < _ := ?_
   · simp only [Prod.forall, Finpartition.mk_mem_nonUniforms, and_imp]
     rintro U V hU hV - -
@@ -418,7 +418,7 @@ lemma unreduced_edges_subset :
   obtain rfl | hUV := eq_or_ne U V
   · exact Or.inr (Or.inl ⟨U, hU, hx, hy, G.ne_of_adj h⟩)
   by_cases h₂ : G.IsUniform (ε/8) U V
-  · exact Or.inr $ Or.inr ⟨U, V, hU, hV, hUV, h' _ hU _ hV hx hy hUV h₂, hx, hy, h⟩
+  · exact Or.inr <| Or.inr ⟨U, V, hU, hV, hUV, h' _ hU _ hV hx hy hUV h₂, hx, hy, h⟩
   · exact Or.inl ⟨U, V, hU, hV, hUV, h₂, hx, hy⟩
 
 end SimpleGraph

--- a/Mathlib/Combinatorics/SimpleGraph/Triangle/Basic.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Triangle/Basic.lean
@@ -52,7 +52,7 @@ protected lemma LocallyLinear.edgeDisjointTriangles : G.LocallyLinear → G.Edge
   And.left
 
 nonrec lemma EdgeDisjointTriangles.mono (h : G ≤ H) (hH : H.EdgeDisjointTriangles) :
-    G.EdgeDisjointTriangles := hH.mono $ cliqueSet_mono h
+    G.EdgeDisjointTriangles := hH.mono <| cliqueSet_mono h
 
 @[simp] lemma edgeDisjointTriangles_bot : (⊥ : SimpleGraph α).EdgeDisjointTriangles := by
   simp [EdgeDisjointTriangles]
@@ -133,7 +133,7 @@ alias ⟨EdgeDisjointTriangles.mem_sym2_subsingleton, _⟩ :=
 variable [DecidableEq α] [Fintype α] [DecidableRel G.Adj]
 
 instance EdgeDisjointTriangles.instDecidable : Decidable G.EdgeDisjointTriangles :=
-  decidable_of_iff ((G.cliqueFinset 3 : Set (Finset α)).Pairwise fun x y ↦ ((x ∩ y).card ≤ 1)) $ by
+  decidable_of_iff ((G.cliqueFinset 3 : Set (Finset α)).Pairwise fun x y ↦ ((x ∩ y).card ≤ 1)) <| by
     simp only [coe_cliqueFinset, EdgeDisjointTriangles, Finset.card_le_one, ← coe_inter]; rfl
 
 instance LocallyLinear.instDecidable : Decidable G.LocallyLinear := And.decidable
@@ -151,7 +151,7 @@ lemma EdgeDisjointTriangles.card_edgeFinset_le (hG : G.EdgeDisjointTriangles) :
     simp [insert_subset, *]
   · simpa only [card_le_one, mem_bipartiteBelow, and_imp, Set.Subsingleton, Set.mem_setOf_eq,
       mem_cliqueFinset_iff, mem_cliqueSet_iff]
-      using hG.mem_sym2_subsingleton (G.not_isDiag_of_mem_edgeSet $ mem_edgeFinset.1 he)
+      using hG.mem_sym2_subsingleton (G.not_isDiag_of_mem_edgeSet <| mem_edgeFinset.1 he)
 
 lemma LocallyLinear.card_edgeFinset (hG : G.LocallyLinear) :
     G.edgeFinset.card = 3 * (G.cliqueFinset 3).card := by
@@ -165,7 +165,7 @@ lemma LocallyLinear.card_edgeFinset (hG : G.LocallyLinear) :
   rintro _ a b c hab hac hbc rfl
   calc
     _ ≤ ({s(a, b), s(a, c), s(b, c)} : Finset _).card := card_le_card ?_
-    _ ≤ 3 := (card_insert_le _ _).trans (succ_le_succ $ (card_insert_le _ _).trans_eq $ by
+    _ ≤ 3 := (card_insert_le _ _).trans (succ_le_succ <| (card_insert_le _ _).trans_eq <| by
       rw [card_singleton])
   simp only [subset_iff, Sym2.forall, mem_sym2_iff, le_eq_subset, mem_bipartiteBelow, mem_insert,
     mem_edgeFinset, mem_singleton, and_imp, mem_edgeSet, Sym2.mem_iff, forall_eq_or_imp,
@@ -213,7 +213,7 @@ private lemma farFromTriangleFree_of_disjoint_triangles_aux {tris : Finset (Fins
     by_contra! h
     refine hH t ?_
     simp only [not_and, mem_sdiff, not_not, mem_edgeFinset, mem_edgeSet] at h
-    obtain ⟨x, y, z, xy, xz, yz, rfl⟩ := is3Clique_iff.1 (mem_cliqueFinset_iff.1 $ htris ht)
+    obtain ⟨x, y, z, xy, xz, yz, rfl⟩ := is3Clique_iff.1 (mem_cliqueFinset_iff.1 <| htris ht)
     rw [is3Clique_triple_iff]
     refine ⟨h _ _ ?_ ?_ xy.ne xy, h _ _ ?_ ?_ xz.ne xz, h _ _ ?_ ?_ yz.ne yz⟩ <;> simp
   choose fx fy hfx hfy hfne fmem using this
@@ -237,9 +237,9 @@ lemma farFromTriangleFree_of_disjoint_triangles (tris : Finset (Finset α))
     G.FarFromTriangleFree ε := by
   rw [farFromTriangleFree_iff]
   intros H _ hG hH
-  rw [← Nat.cast_sub (card_le_card $ edgeFinset_mono hG)]
+  rw [← Nat.cast_sub (card_le_card <| edgeFinset_mono hG)]
   exact tris_big.trans
-    (Nat.cast_le.2 $ farFromTriangleFree_of_disjoint_triangles_aux htris pd hG hH)
+    (Nat.cast_le.2 <| farFromTriangleFree_of_disjoint_triangles_aux htris pd hG hH)
 
 protected lemma EdgeDisjointTriangles.farFromTriangleFree (hG : G.EdgeDisjointTriangles)
     (tris_big : ε * (card α ^ 2 : ℕ) ≤ (G.cliqueFinset 3).card) :
@@ -275,7 +275,7 @@ lemma FarFromTriangleFree.lt_half (hG : G.FarFromTriangleFree ε) : ε < 2⁻¹ 
   apply tsub_lt_self <;> positivity
 
 lemma FarFromTriangleFree.lt_one (hG : G.FarFromTriangleFree ε) : ε < 1 :=
-  hG.lt_half.trans $ inv_lt_one one_lt_two
+  hG.lt_half.trans <| inv_lt_one one_lt_two
 
 theorem FarFromTriangleFree.nonpos (h₀ : G.FarFromTriangleFree ε) (h₁ : G.CliqueFree 3) :
     ε ≤ 0 := by

--- a/Mathlib/Combinatorics/SimpleGraph/Triangle/Counting.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Triangle/Counting.lean
@@ -29,13 +29,13 @@ namespace SimpleGraph
 
 /-- The vertices of `s` whose density in `t` is `ε` less than expected. -/
 private noncomputable def badVertices (ε : ℝ) (s t : Finset α) : Finset α :=
-  s.filter fun x ↦ (t.filter $ G.Adj x).card < (G.edgeDensity s t - ε) * t.card
+  s.filter fun x ↦ (t.filter <| G.Adj x).card < (G.edgeDensity s t - ε) * t.card
 
 private lemma card_interedges_badVertices_le :
     (Rel.interedges G.Adj (badVertices G ε s t) t).card ≤
       (badVertices G ε s t).card * t.card * (G.edgeDensity s t - ε) := by
   classical
-  refine (Nat.cast_le.2 $ (card_le_card $ subset_of_eq (Rel.interedges_eq_biUnion _)).trans
+  refine (Nat.cast_le.2 <| (card_le_card <| subset_of_eq (Rel.interedges_eq_biUnion _)).trans
     card_biUnion_le).trans ?_
   simp_rw [Nat.cast_sum, card_map, ← nsmul_eq_mul, smul_mul_assoc, mul_comm (t.card : ℝ)]
   exact sum_le_card_nsmul _ _ _ fun x hx ↦ (mem_filter.1 hx).2.le
@@ -44,14 +44,14 @@ private lemma edgeDensity_badVertices_le (hε : 0 ≤ ε) (dst : 2 * ε ≤ G.ed
     G.edgeDensity (badVertices G ε s t) t ≤ G.edgeDensity s t - ε := by
   rw [edgeDensity_def]
   push_cast
-  refine div_le_of_nonneg_of_le_mul (by positivity) (sub_nonneg_of_le $ by linarith) ?_
+  refine div_le_of_nonneg_of_le_mul (by positivity) (sub_nonneg_of_le <| by linarith) ?_
   rw [mul_comm]
   exact G.card_interedges_badVertices_le
 
 private lemma card_badVertices_le (dst : 2 * ε ≤ G.edgeDensity s t) (hst : G.IsUniform ε s t) :
     (badVertices G ε s t).card ≤ s.card * ε := by
   have hε : ε ≤ 1 := (le_mul_of_one_le_of_le_of_nonneg (by norm_num) le_rfl hst.pos.le).trans
-    (dst.trans $ by exact_mod_cast edgeDensity_le_one _ _ _)
+    (dst.trans <| by exact_mod_cast edgeDensity_le_one _ _ _)
   by_contra! h
   have : |(G.edgeDensity (badVertices G ε s t) t - G.edgeDensity s t : ℝ)| < ε :=
     hst (filter_subset _ _) Subset.rfl h.le (mul_le_of_le_one_right (Nat.cast_nonneg _) hε)
@@ -61,7 +61,7 @@ private lemma card_badVertices_le (dst : 2 * ε ≤ G.edgeDensity s t) (hst : G.
 /-- A subset of the triangles constructed in a weird way to make them easy to count. -/
 private lemma triangle_split_helper [DecidableEq α] :
     (s \ (badVertices G ε s t ∪ badVertices G ε s u)).biUnion
-      (fun x ↦ (G.interedges (t.filter $ G.Adj x) (u.filter $ G.Adj x)).image (x, ·)) ⊆
+      (fun x ↦ (G.interedges (t.filter <| G.Adj x) (u.filter <| G.Adj x)).image (x, ·)) ⊆
       (s ×ˢ t ×ˢ u).filter (fun (x, y, z) ↦ G.Adj x y ∧ G.Adj x z ∧ G.Adj y z) := by
   rintro ⟨x, y, z⟩
   simp only [mem_filter, mem_product, mem_biUnion, mem_sdiff, exists_prop, mem_union,
@@ -109,18 +109,18 @@ lemma triangle_counting'
   let X' := s \ (badVertices G ε s t ∪ badVertices G ε s u)
   have : X'.biUnion _ ⊆ (s ×ˢ t ×ˢ u).filter fun (a, b, c) ↦ G.Adj a b ∧ G.Adj a c ∧ G.Adj b c :=
     triangle_split_helper _
-  refine le_trans ?_ (Nat.cast_le.2 $ card_le_card this)
+  refine le_trans ?_ (Nat.cast_le.2 <| card_le_card this)
   rw [card_biUnion, Nat.cast_sum]
-  · apply le_trans _ (card_nsmul_le_sum X' _ _ $ G.good_vertices_triangle_card dst dsu dtu utu)
+  · apply le_trans _ (card_nsmul_le_sum X' _ _ <| G.good_vertices_triangle_card dst dsu dtu utu)
     rw [nsmul_eq_mul]
     have := hst.pos.le
     suffices hX' : (1 - 2 * ε) * s.card ≤ X'.card by
-      exact Eq.trans_le (by ring) (mul_le_mul_of_nonneg_right hX' $ by positivity)
+      exact Eq.trans_le (by ring) (mul_le_mul_of_nonneg_right hX' <| by positivity)
     have i : badVertices G ε s t ∪ badVertices G ε s u ⊆ s :=
       union_subset (filter_subset _ _) (filter_subset _ _)
     rw [sub_mul, one_mul, card_sdiff i, Nat.cast_sub (card_le_card i), sub_le_sub_iff_left,
       mul_assoc, mul_comm ε, two_mul]
-    refine (Nat.cast_le.2 $ card_union_le _ _).trans ?_
+    refine (Nat.cast_le.2 <| card_union_le _ _).trans ?_
     rw [Nat.cast_add]
     exact add_le_add h₁ h₂
   rintro a _ b _ t

--- a/Mathlib/Combinatorics/SimpleGraph/Triangle/Removal.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Triangle/Removal.lean
@@ -61,7 +61,7 @@ private lemma card_bound (hP₁ : P.IsEquipartition) (hP₃ : P.parts.card ≤ b
   calc
     _ ≤ card α / (2 * P.parts.card : ℝ) := by gcongr
     _ ≤ ↑(card α / P.parts.card) :=
-      (div_le_iff' (by positivity)).2 $ mod_cast (aux ‹_› P.card_parts_le_card).le
+      (div_le_iff' (by positivity)).2 <| mod_cast (aux ‹_› P.card_parts_le_card).le
     _ ≤ (s.card : ℝ) := mod_cast hP₁.average_le_card_part hX
 
 private lemma triangle_removal_aux (hε : 0 < ε) (hP₁ : P.IsEquipartition)

--- a/Mathlib/Combinatorics/SimpleGraph/Triangle/Tripartite.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Triangle/Tripartite.lean
@@ -211,7 +211,7 @@ section Fintype
 variable [Fintype α] [Fintype β] [Fintype γ]
 
 lemma cliqueFinset_eq_image [NoAccidental t] : (graph t).cliqueFinset 3 = t.image toTriangle :=
-  coe_injective $ by push_cast; exact cliqueSet_eq_image _
+  coe_injective <| by push_cast; exact cliqueSet_eq_image _
 
 lemma cliqueFinset_eq_map [NoAccidental t] : (graph t).cliqueFinset 3 = t.map toTriangle := by
   simp [cliqueFinset_eq_image, map_eq_image]
@@ -224,7 +224,7 @@ lemma farFromTriangleFree [ExplicitDisjoint t] {ε : 𝕜}
     (graph t).FarFromTriangleFree ε :=
   farFromTriangleFree_of_disjoint_triangles (t.map toTriangle)
     (map_subset_iff_subset_preimage.2 fun x hx ↦ by simpa using toTriangle_is3Clique hx)
-    (map_toTriangle_disjoint t) $ by simpa [add_assoc] using ht
+    (map_toTriangle_disjoint t) <| by simpa [add_assoc] using ht
 
 end Fintype
 end DecidableEq

--- a/Mathlib/Computability/Primrec.lean
+++ b/Mathlib/Computability/Primrec.lean
@@ -1001,9 +1001,9 @@ theorem nat_strong_rec (f : α → ℕ → σ) {g : α → List σ → Option σ
 theorem listLookup [DecidableEq α] : Primrec₂ (List.lookup : α → List (α × β) → Option β) :=
   (to₂ <| list_rec snd (const none) <|
     to₂ <|
-      cond (Primrec.beq.comp (fst.comp fst) (fst.comp $ fst.comp snd))
-        (option_some.comp $ snd.comp $ fst.comp snd)
-        (snd.comp $ snd.comp snd)).of_eq
+      cond (Primrec.beq.comp (fst.comp fst) (fst.comp <| fst.comp snd))
+        (option_some.comp <| snd.comp <| fst.comp snd)
+        (snd.comp <| snd.comp snd)).of_eq
   fun a ps => by
   induction' ps with p ps ih <;> simp [List.lookup, *]
   cases ha : a == p.1 <;> simp [ha]
@@ -1016,7 +1016,7 @@ theorem nat_omega_rec' (f : β → σ) {m : β → ℕ} {l : β → List β} {g 
   let mapGraph (M : List (β × σ)) (bs : List β) : List σ := bs.bind (Option.toList <| M.lookup ·)
   let bindList (b : β) : ℕ → List β := fun n ↦ n.rec [b] fun _ bs ↦ bs.bind l
   let graph (b : β) : ℕ → List (β × σ) := fun i ↦ i.rec [] fun i ih ↦
-    (bindList b (m b - i)).filterMap fun b' ↦ (g b' $ mapGraph ih (l b')).map (b', ·)
+    (bindList b (m b - i)).filterMap fun b' ↦ (g b' <| mapGraph ih (l b')).map (b', ·)
   have mapGraph_primrec : Primrec₂ mapGraph :=
     to₂ <| list_bind snd <| optionToList.comp₂ <| listLookup.comp₂ .right (fst.comp₂ .left)
   have bindList_primrec : Primrec₂ (bindList) :=
@@ -1028,9 +1028,9 @@ theorem nat_omega_rec' (f : β → σ) {m : β → ℕ} {l : β → List β} {g 
       to₂ <| listFilterMap
         (bindList_primrec.comp
           (fst.comp fst)
-          (nat_sub.comp (hm.comp $ fst.comp fst) (fst.comp snd))) <|
+          (nat_sub.comp (hm.comp <| fst.comp fst) (fst.comp snd))) <|
             to₂ <| option_map
-              (hg.comp snd (mapGraph_primrec.comp (snd.comp $ snd.comp fst) (hl.comp snd)))
+              (hg.comp snd (mapGraph_primrec.comp (snd.comp <| snd.comp fst) (hl.comp snd)))
               (Primrec₂.pair.comp₂ (snd.comp₂ .left) .right)
   have : Primrec (fun b => ((graph b (m b + 1)).get? 0).map Prod.snd) :=
     option_map (list_get?.comp (graph_primrec.comp Primrec.id (succ.comp hm)) (const 0))
@@ -1043,14 +1043,14 @@ theorem nat_omega_rec' (f : β → σ) {m : β → ℕ} {l : β → List β} {g 
           induction' k with k ih <;> simp [bindList]
           intro a₂ a₁ ha₁ ha₂
           have : k ≤ m b :=
-            Nat.lt_succ.mp (by simpa using Nat.add_lt_of_lt_sub $ Nat.zero_lt_of_lt (ih a₁ ha₁))
+            Nat.lt_succ.mp (by simpa using Nat.add_lt_of_lt_sub <| Nat.zero_lt_of_lt (ih a₁ ha₁))
           have : m a₁ ≤ m b - k :=
             Nat.lt_succ.mp (by rw [← Nat.succ_sub this]; simpa using ih a₁ ha₁)
           exact lt_of_lt_of_le (Ord a₁ a₂ ha₂) this
         List.eq_nil_iff_forall_not_mem.mpr
           (by intro b' ha'; by_contra; simpa using bindList_m_lt (m b + 1) b' ha')
       have mapGraph_graph {bs bs' : List β} (has : bs' ⊆ bs) :
-          mapGraph (bs.map $ fun x => (x, f x)) bs' = bs'.map f := by
+          mapGraph (bs.map <| fun x => (x, f x)) bs' = bs'.map f := by
         induction' bs' with b bs' ih <;> simp [mapGraph]
         · have : b ∈ bs ∧ bs' ⊆ bs := by simpa using has
           rcases this with ⟨ha, has'⟩

--- a/Mathlib/Data/Complex/Abs.lean
+++ b/Mathlib/Data/Complex/Abs.lean
@@ -232,7 +232,7 @@ theorem isCauSeq_re (f : CauSeq ℂ Complex.abs) : IsCauSeq abs' fun n => (f n).
 
 theorem isCauSeq_im (f : CauSeq ℂ Complex.abs) : IsCauSeq abs' fun n => (f n).im := fun ε ε0 =>
   (f.cauchy ε0).imp fun i H j ij ↦ by
-    simpa only [← ofReal_sub, abs_ofReal, sub_re] using (abs_im_le_abs _).trans_lt $ H _ ij
+    simpa only [← ofReal_sub, abs_ofReal, sub_re] using (abs_im_le_abs _).trans_lt <| H _ ij
 
 /-- The real part of a complex Cauchy sequence, as a real Cauchy sequence. -/
 noncomputable def cauSeqRe (f : CauSeq ℂ Complex.abs) : CauSeq ℝ abs' :=

--- a/Mathlib/Data/Fin/Basic.lean
+++ b/Mathlib/Data/Fin/Basic.lean
@@ -111,10 +111,10 @@ protected lemma lt_of_lt_of_le : a < b → b ≤ c → a < c := Nat.lt_of_lt_of_
 protected lemma le_rfl : a ≤ a := Nat.le_refl _
 protected lemma lt_iff_le_and_ne : a < b ↔ a ≤ b ∧ a ≠ b := by
   rw [← val_ne_iff]; exact Nat.lt_iff_le_and_ne
-protected lemma lt_or_lt_of_ne (h : a ≠ b) : a < b ∨ b < a := Nat.lt_or_lt_of_ne $ val_ne_iff.2 h
+protected lemma lt_or_lt_of_ne (h : a ≠ b) : a < b ∨ b < a := Nat.lt_or_lt_of_ne <| val_ne_iff.2 h
 protected lemma lt_or_le (a b : Fin n) : a < b ∨ b ≤ a := Nat.lt_or_ge _ _
 protected lemma le_or_lt (a b : Fin n) : a ≤ b ∨ b < a := (b.lt_or_le a).symm
-protected lemma le_of_eq (hab : a = b) : a ≤ b := Nat.le_of_eq $ congr_arg val hab
+protected lemma le_of_eq (hab : a = b) : a ≤ b := Nat.le_of_eq <| congr_arg val hab
 protected lemma ge_of_eq (hab : a = b) : b ≤ a := Fin.le_of_eq hab.symm
 protected lemma eq_or_lt_of_le : a ≤ b → a = b ∨ a < b := by
   rw [Fin.ext_iff]; exact Nat.eq_or_lt_of_le
@@ -127,10 +127,10 @@ lemma lt_last_iff_ne_last {a : Fin (n + 1)} : a < last n ↔ a ≠ last n := by
   simp [Fin.lt_iff_le_and_ne, le_last]
 
 lemma ne_zero_of_lt {a b : Fin (n + 1)} (hab : a < b) : b ≠ 0 :=
-  Fin.ne_of_gt $ Fin.lt_of_le_of_lt a.zero_le hab
+  Fin.ne_of_gt <| Fin.lt_of_le_of_lt a.zero_le hab
 
 lemma ne_last_of_lt {a b : Fin (n + 1)} (hab : a < b) : a ≠ last n :=
-  Fin.ne_of_lt $ Fin.lt_of_lt_of_le hab b.le_last
+  Fin.ne_of_lt <| Fin.lt_of_lt_of_le hab b.le_last
 
 /-- Equivalence between `Fin n` and `{ i // i < n }`. -/
 @[simps apply symm_apply]
@@ -979,7 +979,7 @@ lemma succAbove_castSucc_of_le (p i : Fin n) (h : p ≤ i) : succAbove p.castSuc
   succAbove_castSucc_of_le _ _ Fin.le_rfl
 
 lemma succAbove_pred_of_lt (p i : Fin (n + 1)) (h : p < i)
-    (hi := Fin.ne_of_gt $ Fin.lt_of_le_of_lt p.zero_le h) : succAbove p (i.pred hi) = i := by
+    (hi := Fin.ne_of_gt <| Fin.lt_of_le_of_lt p.zero_le h) : succAbove p (i.pred hi) = i := by
   rw [succAbove_of_lt_succ _ _ (succ_pred _ _ ▸ h), succ_pred]
 
 lemma succAbove_pred_of_le (p i : Fin (n + 1)) (h : i ≤ p) (hi : i ≠ 0) :
@@ -989,7 +989,7 @@ lemma succAbove_pred_of_le (p i : Fin (n + 1)) (h : i ≤ p) (hi : i ≠ 0) :
     succAbove p (p.pred h) = (p.pred h).castSucc := succAbove_pred_of_le _ _ Fin.le_rfl h
 
 lemma succAbove_castPred_of_lt (p i : Fin (n + 1)) (h : i < p)
-    (hi := Fin.ne_of_lt $ Nat.lt_of_lt_of_le h p.le_last) : succAbove p (i.castPred hi) = i := by
+    (hi := Fin.ne_of_lt <| Nat.lt_of_lt_of_le h p.le_last) : succAbove p (i.castPred hi) = i := by
   rw [succAbove_of_castSucc_lt _ _ (castSucc_castPred _ _ ▸ h), castSucc_castPred]
 
 lemma succAbove_castPred_of_le (p i : Fin (n + 1)) (h : p ≤ i) (hi : i ≠ last n) :
@@ -1028,9 +1028,9 @@ lemma succAbove_right_injective : Injective p.succAbove := by
   split_ifs at hij with hi hj hj
   · exact castSucc_injective _ hij
   · rw [hij] at hi
-    cases hj $ Nat.lt_trans j.castSucc_lt_succ hi
+    cases hj <| Nat.lt_trans j.castSucc_lt_succ hi
   · rw [← hij] at hj
-    cases hi $ Nat.lt_trans i.castSucc_lt_succ hj
+    cases hi <| Nat.lt_trans i.castSucc_lt_succ hj
   · exact succ_injective _ hij
 
 /-- Given a fixed pivot `p : Fin (n + 1)`, `p.succAbove` is injective. -/
@@ -1089,7 +1089,7 @@ lemma succAbove_lt_iff_castSucc_lt (p : Fin (n + 1)) (i : Fin n) :
   cases' castSucc_lt_or_lt_succ p i with H H
   · rwa [iff_true_right H, succAbove_of_castSucc_lt _ _ H]
   · rw [castSucc_lt_iff_succ_le, iff_false_right (Fin.not_le.2 H), succAbove_of_lt_succ _ _ H]
-    exact Fin.not_lt.2 $ Fin.le_of_lt H
+    exact Fin.not_lt.2 <| Fin.le_of_lt H
 
 lemma succAbove_lt_iff_succ_le (p : Fin (n + 1)) (i : Fin n) :
     p.succAbove i < p ↔ succ i ≤ p := by
@@ -1101,7 +1101,7 @@ lemma lt_succAbove_iff_le_castSucc (p : Fin (n + 1)) (i : Fin n) :
     p < p.succAbove i ↔ p ≤ castSucc i := by
   cases' castSucc_lt_or_lt_succ p i with H H
   · rw [iff_false_right (Fin.not_le.2 H), succAbove_of_castSucc_lt _ _ H]
-    exact Fin.not_lt.2 $ Fin.le_of_lt H
+    exact Fin.not_lt.2 <| Fin.le_of_lt H
   · rwa [succAbove_of_lt_succ _ _ H, iff_true_left H, le_castSucc_iff]
 
 lemma lt_succAbove_iff_lt_castSucc (p : Fin (n + 1)) (i : Fin n) :
@@ -1114,12 +1114,12 @@ lemma succAbove_pos [NeZero n] (p : Fin (n + 1)) (i : Fin n) (h : 0 < i) : 0 < p
   · simp [succAbove_of_le_castSucc _ _ (Fin.not_lt.1 H)]
 
 lemma castPred_succAbove (x : Fin n) (y : Fin (n + 1)) (h : castSucc x < y)
-    (h' := Fin.ne_last_of_lt $ (succAbove_lt_iff_castSucc_lt ..).2 h) :
+    (h' := Fin.ne_last_of_lt <| (succAbove_lt_iff_castSucc_lt ..).2 h) :
     (y.succAbove x).castPred h' = x := by
   rw [castPred_eq_iff_eq_castSucc, succAbove_of_castSucc_lt _ _ h]
 
 lemma pred_succAbove (x : Fin n) (y : Fin (n + 1)) (h : y ≤ castSucc x)
-    (h' := Fin.ne_zero_of_lt $ (lt_succAbove_iff_le_castSucc ..).2 h) :
+    (h' := Fin.ne_zero_of_lt <| (lt_succAbove_iff_le_castSucc ..).2 h) :
     (y.succAbove x).pred h' = x := by simp only [succAbove_of_le_castSucc _ _ h, pred_succ]
 
 lemma exists_succAbove_eq {x y : Fin (n + 1)} (h : x ≠ y) : ∃ z, y.succAbove z = x := by
@@ -1208,11 +1208,11 @@ section PredAbove
 def predAbove (p : Fin n) (i : Fin (n + 1)) : Fin n :=
   if h : castSucc p < i
   then pred i (Fin.ne_zero_of_lt h)
-  else castPred i (Fin.ne_of_lt $ Fin.lt_of_le_of_lt (Fin.not_lt.1 h) (castSucc_lt_last _))
+  else castPred i (Fin.ne_of_lt <| Fin.lt_of_le_of_lt (Fin.not_lt.1 h) (castSucc_lt_last _))
 
 lemma predAbove_of_le_castSucc (p : Fin n) (i : Fin (n + 1)) (h : i ≤ castSucc p)
-    (hi := Fin.ne_of_lt $ Fin.lt_of_le_of_lt h $ castSucc_lt_last _) :
-    p.predAbove i = i.castPred hi := dif_neg $ Fin.not_lt.2 h
+    (hi := Fin.ne_of_lt <| Fin.lt_of_le_of_lt h <| castSucc_lt_last _) :
+    p.predAbove i = i.castPred hi := dif_neg <| Fin.not_lt.2 h
 
 lemma predAbove_of_lt_succ (p : Fin n) (i : Fin (n + 1)) (h : i < succ p)
     (hi := Fin.ne_last_of_lt h) : p.predAbove i = i.castPred hi :=
@@ -1222,7 +1222,7 @@ lemma predAbove_of_castSucc_lt (p : Fin n) (i : Fin (n + 1)) (h : castSucc p < i
     (hi := Fin.ne_zero_of_lt h) : p.predAbove i = i.pred hi := dif_pos h
 
 lemma predAbove_of_succ_le (p : Fin n) (i : Fin (n + 1)) (h : succ p ≤ i)
-    (hi := Fin.ne_of_gt $ Fin.lt_of_lt_of_le (succ_pos _) h) :
+    (hi := Fin.ne_of_gt <| Fin.lt_of_lt_of_le (succ_pos _) h) :
     p.predAbove i = i.pred hi := predAbove_of_castSucc_lt _ _ (castSucc_lt_iff_succ_le.mpr h)
 
 lemma predAbove_succ_of_lt (p i : Fin n) (h : i < p) (hi := succ_ne_last_of_lt h) :
@@ -1250,7 +1250,7 @@ lemma predAbove_pred_of_lt (p i : Fin (n + 1)) (h : i < p) (hp := Fin.ne_zero_of
   rw [predAbove_of_lt_succ _ _ (succ_pred _ _ ▸ h)]
 
 lemma predAbove_pred_of_le (p i : Fin (n + 1)) (h : p ≤ i) (hp : p ≠ 0)
-    (hi := Fin.ne_of_gt $ Fin.lt_of_lt_of_le (Fin.pos_iff_ne_zero.2 hp) h) :
+    (hi := Fin.ne_of_gt <| Fin.lt_of_lt_of_le (Fin.pos_iff_ne_zero.2 hp) h) :
   (pred p hp).predAbove i = pred i hi := by rw [predAbove_of_succ_le _ _ (succ_pred _ _ ▸ h)]
 
 lemma predAbove_pred_self (p : Fin (n + 1)) (hp : p ≠ 0) : (pred p hp).predAbove p = pred p hp :=
@@ -1261,7 +1261,7 @@ lemma predAbove_castPred_of_lt (p i : Fin (n + 1)) (h : p < i) (hp := Fin.ne_las
   rw [predAbove_of_castSucc_lt _ _ (castSucc_castPred _ _ ▸ h)]
 
 lemma predAbove_castPred_of_le (p i : Fin (n + 1)) (h : i ≤ p) (hp : p ≠ last n)
-    (hi := Fin.ne_of_lt $ Fin.lt_of_le_of_lt h $ Fin.lt_last_iff_ne_last.2 hp) :
+    (hi := Fin.ne_of_lt <| Fin.lt_of_le_of_lt h <| Fin.lt_last_iff_ne_last.2 hp) :
     (castPred p hp).predAbove i = castPred i hi := by
   rw [predAbove_of_le_castSucc _ _ (castSucc_castPred _ _ ▸ h)]
 
@@ -1335,7 +1335,7 @@ then back to `Fin n` by subtracting one from anything above `p` is the identity.
 lemma predAbove_succAbove (p : Fin n) (i : Fin n) : p.predAbove ((castSucc p).succAbove i) = i := by
   obtain h | h := p.le_or_lt i
   · rw [succAbove_castSucc_of_le _ _ h, predAbove_succ_of_le _ _ h]
-  · rw [succAbove_castSucc_of_lt _ _ h, predAbove_castSucc_of_le _ _ $ Fin.le_of_lt h]
+  · rw [succAbove_castSucc_of_lt _ _ h, predAbove_castSucc_of_le _ _ <| Fin.le_of_lt h]
 
 /-- `succ` commutes with `predAbove`. -/
 @[simp] lemma succ_predAbove_succ (a : Fin n) (b : Fin (n + 1)) :

--- a/Mathlib/Data/Fin/Tuple/Curry.lean
+++ b/Mathlib/Data/Fin/Tuple/Curry.lean
@@ -73,7 +73,7 @@ variable {n : ℕ} {p : Fin n → Type u} {τ : Type u}
 theorem curry_uncurry (f : Function.FromTypes p τ) : curry (uncurry f) = f := by
   induction n with
   | zero => rfl
-  | succ n ih => exact funext (ih $ f ·)
+  | succ n ih => exact funext (ih <| f ·)
 
 @[simp]
 theorem uncurry_curry (f : ((i : Fin n) → p i) → τ) :

--- a/Mathlib/Data/Fin/Tuple/Finset.lean
+++ b/Mathlib/Data/Fin/Tuple/Finset.lean
@@ -29,7 +29,7 @@ lemma cons_mem_piFinset_cons {x₀ : α 0} {x : ∀ i : Fin n, α i.succ}
   simp_rw [mem_piFinset_succ, cons_zero, tail_cons]
 
 lemma snoc_mem_piFinset_snoc {x : ∀ i : Fin n, α i.castSucc} {xₙ : α (.last n)}
-    {s : ∀ i : Fin n, Finset (α i.castSucc)} {sₙ : Finset (α $ .last n)} :
+    {s : ∀ i : Fin n, Finset (α i.castSucc)} {sₙ : Finset (α <| .last n)} :
     snoc x xₙ ∈ piFinset (snoc s sₙ) ↔ x ∈ piFinset s ∧ xₙ ∈ sₙ := by
   simp_rw [mem_piFinset_succ', init_snoc, snoc_last]
 

--- a/Mathlib/Data/Finset/Basic.lean
+++ b/Mathlib/Data/Finset/Basic.lean
@@ -1592,7 +1592,7 @@ theorem erase_empty (a : α) : erase ∅ a = ∅ :=
   rfl
 
 protected lemma Nontrivial.erase_nonempty (hs : s.Nontrivial) : (s.erase a).Nonempty :=
-  (hs.exists_ne a).imp $ by aesop
+  (hs.exists_ne a).imp <| by aesop
 
 @[simp] lemma erase_nonempty (ha : a ∈ s) : (s.erase a).Nonempty ↔ s.Nontrivial := by
   simp only [Finset.Nonempty, mem_erase, and_comm (b := _ ∈ _)]

--- a/Mathlib/Data/Finset/Card.lean
+++ b/Mathlib/Data/Finset/Card.lean
@@ -426,7 +426,7 @@ lemma surj_on_of_inj_on_of_card_le (f : ∀ a ∈ s, β) (hf : ∀ a ha, f a ha 
     intro ⟨_, _⟩ ⟨_, _⟩ h
     exact Subtype.eq <| hinj _ _ _ _ h
   obtain rfl : image (fun a : { a // a ∈ s } => f a a.prop) s.attach = t :=
-    eq_of_subset_of_card_le (image_subset_iff.2 $ by simpa) (by simp [hst, h])
+    eq_of_subset_of_card_le (image_subset_iff.2 <| by simpa) (by simp [hst, h])
   simp only [mem_image, mem_attach, true_and, Subtype.exists, forall_exists_index]
   exact fun b a ha hb ↦ ⟨a, ha, hb.symm⟩
 

--- a/Mathlib/Data/Finset/Density.lean
+++ b/Mathlib/Data/Finset/Density.lean
@@ -82,10 +82,10 @@ protected alias ⟨_, Nonempty.dens_pos⟩ := dens_pos
 protected alias ⟨_, Nonempty.dens_ne_zero⟩ := dens_ne_zero
 
 lemma dens_le_dens (h : s ⊆ t) : dens s ≤ dens t :=
-  div_le_div_of_nonneg_right (mod_cast card_mono h) $ by positivity
+  div_le_div_of_nonneg_right (mod_cast card_mono h) <| by positivity
 
 lemma dens_lt_dens (h : s ⊂ t) : dens s < dens t :=
-  div_lt_div_of_pos_right (mod_cast card_strictMono h) $ by
+  div_lt_div_of_pos_right (mod_cast card_strictMono h) <| by
     cases isEmpty_or_nonempty α
     · simp [Subsingleton.elim s t, ssubset_irrfl] at h
     · exact mod_cast Fintype.card_pos
@@ -134,7 +134,7 @@ lemma dens_sdiff_add_dens (s t : Finset α) : dens (s \ t) + dens t = (s ∪ t).
   rw [← dens_union_of_disjoint sdiff_disjoint, sdiff_union_self_eq_union]
 
 lemma dens_sdiff_comm (h : card s = card t) : dens (s \ t) = dens (t \ s) :=
-  add_left_injective (dens t) $ by
+  add_left_injective (dens t) <| by
     simp_rw [dens_sdiff_add_dens, union_comm s, ← dens_sdiff_add_dens, dens, h]
 
 @[simp]

--- a/Mathlib/Data/Finset/Powerset.lean
+++ b/Mathlib/Data/Finset/Powerset.lean
@@ -112,12 +112,12 @@ instance decidableForallOfDecidableSubsets {s : Finset α} {p : ∀ t ⊆ s, Pro
 /-- For predicate `p` decidable on subsets, it is decidable whether `p` holds for any subset. -/
 instance decidableExistsOfDecidableSubsets' {s : Finset α} {p : Finset α → Prop}
     [∀ t, Decidable (p t)] : Decidable (∃ t ⊆ s, p t) :=
-  decidable_of_iff (∃ (t : _) (_h : t ⊆ s), p t) $ by simp
+  decidable_of_iff (∃ (t : _) (_h : t ⊆ s), p t) <| by simp
 
 /-- For predicate `p` decidable on subsets, it is decidable whether `p` holds for every subset. -/
 instance decidableForallOfDecidableSubsets' {s : Finset α} {p : Finset α → Prop}
     [∀ t, Decidable (p t)] : Decidable (∀ t ⊆ s, p t) :=
-  decidable_of_iff (∀ (t : _) (_h : t ⊆ s), p t) $ by simp
+  decidable_of_iff (∀ (t : _) (_h : t ⊆ s), p t) <| by simp
 
 end Powerset
 
@@ -195,7 +195,7 @@ theorem powersetCard_zero (s : Finset α) : s.powersetCard 0 = {∅} := by
       exact ⟨empty_subset s, rfl⟩⟩
 
 lemma powersetCard_empty_subsingleton (n : ℕ) :
-    (powersetCard n (∅ : Finset α) : Set $ Finset α).Subsingleton := by
+    (powersetCard n (∅ : Finset α) : Set <| Finset α).Subsingleton := by
   simp [Set.Subsingleton, subset_empty]
 
 @[simp]
@@ -209,9 +209,9 @@ theorem powersetCard_one (s : Finset α) :
 
 @[simp]
 lemma powersetCard_eq_empty : powersetCard n s = ∅ ↔ s.card < n := by
-  refine ⟨?_, fun h ↦ card_eq_zero.1 $ by rw [card_powersetCard, Nat.choose_eq_zero_of_lt h]⟩
+  refine ⟨?_, fun h ↦ card_eq_zero.1 <| by rw [card_powersetCard, Nat.choose_eq_zero_of_lt h]⟩
   contrapose!
-  exact fun h ↦ nonempty_iff_ne_empty.1 $ (exists_subset_card_eq h).imp $ by simp
+  exact fun h ↦ nonempty_iff_ne_empty.1 <| (exists_subset_card_eq h).imp <| by simp
 
 @[simp] lemma powersetCard_card_add (s : Finset α) (hn : 0 < n) :
     s.powersetCard (s.card + n) = ∅ := by simpa

--- a/Mathlib/Data/Fintype/BigOperators.lean
+++ b/Mathlib/Data/Fintype/BigOperators.lean
@@ -148,7 +148,7 @@ lemma card_filter_piFinset_eq_of_mem [∀ i, DecidableEq (α i)]
 
 lemma card_filter_piFinset_const_eq_of_mem (s : Finset κ) (i : ι) {x : κ} (hx : x ∈ s) :
     ((piFinset fun _ ↦ s).filter fun f ↦ f i = x).card = s.card ^ (card ι - 1) :=
-  (card_filter_piFinset_eq_of_mem _ _ hx).trans $ by
+  (card_filter_piFinset_eq_of_mem _ _ hx).trans <| by
     rw [prod_const s.card, card_erase_of_mem (mem_univ _), card_univ]
 
 lemma card_filter_piFinset_eq [∀ i, DecidableEq (α i)] (s : ∀ i, Finset (α i)) (i : ι) (a : α i) :
@@ -161,7 +161,7 @@ lemma card_filter_piFinset_eq [∀ i, DecidableEq (α i)] (s : ∀ i, Finset (α
 lemma card_filter_piFinset_const (s : Finset κ) (i : ι) (j : κ) :
     ((piFinset fun _ ↦ s).filter fun f ↦ f i = j).card =
       if j ∈ s then s.card ^ (card ι - 1) else 0 :=
-  (card_filter_piFinset_eq _ _ _).trans $ by
+  (card_filter_piFinset_eq _ _ _).trans <| by
     rw [prod_const s.card, card_erase_of_mem (mem_univ _), card_univ]
 
 end Fintype

--- a/Mathlib/Data/Int/Star.lean
+++ b/Mathlib/Data/Int/Star.lean
@@ -23,7 +23,7 @@ namespace Int
   refine le_antisymm (closure_le.2 <| range_subset_iff.2 hn.pow_nonneg) fun x hx ↦ ?_
   have : x = x.natAbs • 1 ^ n := by simpa [eq_comm (a := x)] using hx
   rw [this]
-  exact nsmul_mem (subset_closure $ mem_range_self _) _
+  exact nsmul_mem (subset_closure <| mem_range_self _) _
 
 @[simp]
 lemma addSubmonoid_closure_range_mul_self : closure (range fun x : ℤ ↦ x * x) = nonneg _ := by

--- a/Mathlib/Data/List/Perm.lean
+++ b/Mathlib/Data/List/Perm.lean
@@ -570,7 +570,7 @@ theorem nodup_permutations'Aux_iff {s : List α} {x : α} : Nodup (permutations'
   intro H
   obtain ⟨k, hk, hk'⟩ := nthLe_of_mem H
   rw [nodup_iff_nthLe_inj] at h
-  refine k.succ_ne_self.symm $ h k (k + 1) ?_ ?_ ?_
+  refine k.succ_ne_self.symm <| h k (k + 1) ?_ ?_ ?_
   · simpa [Nat.lt_succ_iff] using hk.le
   · simpa using hk
   rw [nthLe_permutations'Aux, nthLe_permutations'Aux]

--- a/Mathlib/Data/List/Range.lean
+++ b/Mathlib/Data/List/Range.lean
@@ -169,7 +169,7 @@ lemma mem_mem_ranges_iff_lt_natSum (l : List ℕ) {n : ℕ} :
 
 /-- The members of `l.ranges` have no duplicate -/
 theorem ranges_nodup {l s : List ℕ} (hs : s ∈ ranges l) : s.Nodup :=
-  (List.pairwise_join.mp $ by rw [ranges_join']; exact nodup_range _).1 s hs
+  (List.pairwise_join.mp <| by rw [ranges_join']; exact nodup_range _).1 s hs
 
 end Ranges
 

--- a/Mathlib/Data/Matrix/Composition.lean
+++ b/Mathlib/Data/Matrix/Composition.lean
@@ -57,7 +57,7 @@ def compRingEquiv : Matrix I I (Matrix J J R) ≃+* Matrix (I × J) (I × J) R w
   __ := Matrix.compAddEquiv I I J J R
   map_mul' _ _ := by
     ext _ _
-    exact (Matrix.sum_apply _ _ _ _).trans $ Eq.symm Fintype.sum_prod_type
+    exact (Matrix.sum_apply _ _ _ _).trans <| Eq.symm Fintype.sum_prod_type
 
 end Semiring
 

--- a/Mathlib/Data/Multiset/Basic.lean
+++ b/Mathlib/Data/Multiset/Basic.lean
@@ -1468,7 +1468,7 @@ theorem sub_eq_fold_erase (s t : Multiset α) : s - t = foldl erase erase_comm s
 
 @[simp]
 theorem card_sub {s t : Multiset α} (h : t ≤ s) : card (s - t) = card s - card t :=
-  Nat.eq_sub_of_add_eq $ by rw [← card_add, tsub_add_cancel_of_le h]
+  Nat.eq_sub_of_add_eq <| by rw [← card_add, tsub_add_cancel_of_le h]
 
 /-! ### Union -/
 
@@ -2206,7 +2206,7 @@ theorem ext' {s t : Multiset α} : (∀ a, count a s = count a t) → s = t :=
   ext.2
 
 lemma count_injective : Injective fun (s : Multiset α) a ↦ s.count a :=
-  fun _s _t hst ↦ ext' $ congr_fun hst
+  fun _s _t hst ↦ ext' <| congr_fun hst
 
 @[simp]
 theorem coe_inter (s t : List α) : (s ∩ t : Multiset α) = (s.bagInter t : List α) := by ext; simp

--- a/Mathlib/Data/Multiset/Bind.lean
+++ b/Mathlib/Data/Multiset/Bind.lean
@@ -191,7 +191,7 @@ theorem le_bind {α β : Type*} {f : α → Multiset β} (S : Multiset α) {x : 
     f x ≤ S.bind f := by
   classical
   refine le_iff_count.2 fun a ↦ ?_
-  obtain ⟨m', hm'⟩ := exists_cons_of_mem $ mem_map_of_mem (fun b ↦ count a (f b)) hx
+  obtain ⟨m', hm'⟩ := exists_cons_of_mem <| mem_map_of_mem (fun b ↦ count a (f b)) hx
   rw [count_bind, hm', sum_cons]
   exact Nat.le_add_right _ _
 

--- a/Mathlib/Data/Multiset/Fintype.lean
+++ b/Mathlib/Data/Multiset/Fintype.lean
@@ -130,7 +130,7 @@ namespace Multiset
     have : card (s.1.filter fun x ↦ a = x.1) ≤ card (s.1.filter fun x ↦ a = x.1) - 1 := by
       simpa [Finset.card, eq_comm] using Finset.card_mono h
     omega
-  exact Nat.le_of_pred_lt (han.trans_lt $ by simpa using hsm hn)
+  exact Nat.le_of_pred_lt (han.trans_lt <| by simpa using hsm hn)
 
 end Multiset
 

--- a/Mathlib/Data/NNRat/Defs.lean
+++ b/Mathlib/Data/NNRat/Defs.lean
@@ -343,7 +343,7 @@ lemma divNat_inj (h₁ : d₁ ≠ 0) (h₂ : d₂ ≠ 0) : divNat n₁ d₁ = di
 @[simp] lemma divNat_zero (n : ℕ) : divNat n 0 = 0 := by simp [divNat]; rfl
 
 @[simp] lemma num_divNat_den (q : ℚ≥0) : divNat q.num q.den = q :=
-  ext $ by rw [← (q : ℚ).mkRat_num_den']; simp [num_coe, den_coe]
+  ext <| by rw [← (q : ℚ).mkRat_num_den']; simp [num_coe, den_coe]
 
 lemma natCast_eq_divNat (n : ℕ) : (n : ℚ≥0) = divNat n 1 := (num_divNat_den _).symm
 

--- a/Mathlib/Data/Nat/Cast/Basic.lean
+++ b/Mathlib/Data/Nat/Cast/Basic.lean
@@ -130,7 +130,7 @@ theorem map_ofNat' {A} [AddMonoidWithOne A] [FunLike F A B] [AddMonoidHomClass F
   { toFun := fun n ↦ n • (1 : A)
     map_zero' := zero_nsmul _
     map_add' := add_nsmul _ }
-  exact eq_natCast' f $ by simp [f]
+  exact eq_natCast' f <| by simp [f]
 
 end AddMonoidHomClass
 

--- a/Mathlib/Data/Nat/Cast/Order/Field.lean
+++ b/Mathlib/Data/Nat/Cast/Order/Field.lean
@@ -22,7 +22,7 @@ variable {α : Type*} [LinearOrderedSemifield α]
 
 lemma cast_inv_le_one : ∀ n : ℕ, (n⁻¹ : α) ≤ 1
   | 0 => by simp
-  | n + 1 => inv_le_one $ by simp [Nat.cast_nonneg]
+  | n + 1 => inv_le_one <| by simp [Nat.cast_nonneg]
 
 /-- Natural division is always less than division in the field. -/
 theorem cast_div_le {m n : ℕ} : ((m / n : ℕ) : α) ≤ m / n := by

--- a/Mathlib/Data/Nat/Choose/Lucas.lean
+++ b/Mathlib/Data/Nat/Choose/Lucas.lean
@@ -47,7 +47,7 @@ theorem choose_modEq_choose_mod_mul_choose_div :
     rw [Prod.mk.injEq]
     constructor <;> intro h
     · simp only [mem_product, mem_range] at hx
-      have h' : x₁ < p := lt_of_lt_of_le hx.left $ mod_lt _ Fin.size_pos'
+      have h' : x₁ < p := lt_of_lt_of_le hx.left <| mod_lt _ Fin.size_pos'
       rw [h, add_mul_mod_self_left, add_mul_div_left _ _ Fin.size_pos', eq_comm (b := x₂)]
       exact ⟨mod_eq_of_lt h', self_eq_add_left.mpr (div_eq_of_lt h')⟩
     · rw [← h.left, ← h.right, mod_add_div]

--- a/Mathlib/Data/Nat/Defs.lean
+++ b/Mathlib/Data/Nat/Defs.lean
@@ -139,7 +139,7 @@ lemma one_lt_iff_ne_zero_and_ne_one : ∀ {n : ℕ}, 1 < n ↔ n ≠ 0 ∧ n ≠
 
 lemma le_one_iff_eq_zero_or_eq_one : ∀ {n : ℕ}, n ≤ 1 ↔ n = 0 ∨ n = 1 := by simp [le_succ_iff]
 
-@[simp] lemma lt_one_iff : n < 1 ↔ n = 0 := Nat.lt_succ_iff.trans $ by rw [le_zero_eq]
+@[simp] lemma lt_one_iff : n < 1 ↔ n = 0 := Nat.lt_succ_iff.trans <| by rw [le_zero_eq]
 
 lemma one_le_of_lt (h : a < b) : 1 ≤ b := Nat.lt_of_le_of_lt (Nat.zero_le _) h
 
@@ -316,9 +316,9 @@ lemma mul_eq_left (ha : a ≠ 0) : a * b = a ↔ b = 1 := by simpa using Nat.mul
 lemma mul_eq_right (hb : b ≠ 0) : a * b = b ↔ a = 1 := by simpa using Nat.mul_left_inj hb (c := 1)
 
 -- TODO: Deprecate
-lemma mul_right_eq_self_iff (ha : 0 < a) : a * b = a ↔ b = 1 := mul_eq_left $ ne_of_gt ha
+lemma mul_right_eq_self_iff (ha : 0 < a) : a * b = a ↔ b = 1 := mul_eq_left <| ne_of_gt ha
 
-lemma mul_left_eq_self_iff (hb : 0 < b) : a * b = b ↔ a = 1 := mul_eq_right $ ne_of_gt hb
+lemma mul_left_eq_self_iff (hb : 0 < b) : a * b = b ↔ a = 1 := mul_eq_right <| ne_of_gt hb
 
 protected lemma le_of_mul_le_mul_right (h : a * c ≤ b * c) (hc : 0 < c) : a ≤ b :=
   Nat.le_of_mul_le_mul_left (by simpa [Nat.mul_comm]) hc
@@ -361,7 +361,7 @@ lemma succ_mul_pos (m : ℕ) (hn : 0 < n) : 0 < succ m * n := Nat.mul_pos m.succ
 lemma mul_self_le_mul_self (h : m ≤ n) : m * m ≤ n * n := Nat.mul_le_mul h h
 
 lemma mul_lt_mul'' (hac : a < c) (hbd : b < d) : a * b < c * d :=
-  Nat.mul_lt_mul_of_lt_of_le hac (Nat.le_of_lt hbd) $ by omega
+  Nat.mul_lt_mul_of_lt_of_le hac (Nat.le_of_lt hbd) <| by omega
 
 lemma mul_self_lt_mul_self (h : m < n) : m * m < n * n := mul_lt_mul'' h h
 
@@ -387,7 +387,7 @@ lemma add_sub_one_le_mul (ha : a ≠ 0) (hb : b ≠ 0) : a + b - 1 ≤ a * b := 
   cases a
   · cases ha rfl
   · rw [succ_add, Nat.add_one_sub_one, succ_mul]
-    exact Nat.add_le_add_right (Nat.le_mul_of_pos_right _ $ Nat.pos_iff_ne_zero.2 hb) _
+    exact Nat.add_le_add_right (Nat.le_mul_of_pos_right _ <| Nat.pos_iff_ne_zero.2 hb) _
 
 protected lemma add_le_mul {a : ℕ} (ha : 2 ≤ a) : ∀ {b : ℕ} (_ : 2 ≤ b), a + b ≤ a * b
   | 2, _ => by omega
@@ -421,10 +421,10 @@ protected lemma div_le_div_right (h : a ≤ b) : a / c ≤ b / c :=
     (le_div_iff_mul_le' hc).2 <| Nat.le_trans (Nat.div_mul_le_self _ _) h
 
 lemma lt_of_div_lt_div (h : a / c < b / c) : a < b :=
-  Nat.lt_of_not_le fun hab ↦ Nat.not_le_of_lt h $ Nat.div_le_div_right hab
+  Nat.lt_of_not_le fun hab ↦ Nat.not_le_of_lt h <| Nat.div_le_div_right hab
 
 protected lemma div_pos (hba : b ≤ a) (hb : 0 < b) : 0 < a / b :=
-  Nat.pos_of_ne_zero fun h ↦ Nat.lt_irrefl a $
+  Nat.pos_of_ne_zero fun h ↦ Nat.lt_irrefl a <|
     calc
       a = a % b := by simpa [h] using (mod_add_div a b).symm
       _ < b := mod_lt a hb
@@ -504,7 +504,7 @@ protected lemma div_le_of_le_mul' (h : m ≤ k * n) : m / k ≤ n := by
 
 protected lemma div_le_div_of_mul_le_mul (hd : d ≠ 0) (hdc : d ∣ c) (h : a * d ≤ c * b) :
     a / b ≤ c / d :=
-  Nat.div_le_of_le_mul' $ by
+  Nat.div_le_of_le_mul' <| by
     rwa [← Nat.mul_div_assoc _ hdc, Nat.le_div_iff_mul_le (Nat.pos_iff_ne_zero.2 hd), b.mul_comm]
 
 protected lemma div_le_self' (m n : ℕ) : m / n ≤ m := by
@@ -641,7 +641,7 @@ lemma one_lt_two_pow' (n : ℕ) : 1 < 2 ^ (n + 1) := one_lt_pow n.succ_ne_zero (
 lemma mul_lt_mul_pow_succ (ha : 0 < a) (hb : 1 < b) : n * b < a * b ^ (n + 1) := by
   rw [Nat.pow_succ, ← Nat.mul_assoc, Nat.mul_lt_mul_right (Nat.lt_trans Nat.zero_lt_one hb)]
   exact Nat.lt_of_le_of_lt (Nat.le_mul_of_pos_left _ ha)
-    ((Nat.mul_lt_mul_left ha).2 $ Nat.lt_pow_self hb _)
+    ((Nat.mul_lt_mul_left ha).2 <| Nat.lt_pow_self hb _)
 
 lemma sq_sub_sq (a b : ℕ) : a ^ 2 - b ^ 2 = (a + b) * (a - b) := by
   simpa [Nat.pow_succ] using Nat.mul_self_sub_mul_self_eq a b
@@ -1038,7 +1038,7 @@ lemma eq_of_dvd_of_lt_two_mul (ha : a ≠ 0) (hdvd : b ∣ a) (hlt : a < 2 * b) 
     cases Nat.not_le_of_lt hlt (Nat.mul_le_mul_right _ (by omega))
 
 lemma mod_eq_iff_lt (hn : n ≠ 0) : m % n = m ↔ m < n :=
-  ⟨fun h ↦ by rw [← h]; exact mod_lt _ $ Nat.pos_iff_ne_zero.2 hn, mod_eq_of_lt⟩
+  ⟨fun h ↦ by rw [← h]; exact mod_lt _ <| Nat.pos_iff_ne_zero.2 hn, mod_eq_of_lt⟩
 
 @[simp]
 lemma mod_succ_eq_iff_lt : m % n.succ = m ↔ m < n.succ :=
@@ -1098,12 +1098,12 @@ protected lemma dvd_add_right (h : a ∣ b) : a ∣ b + c ↔ a ∣ c := (Nat.dv
 /-- special case of `mul_dvd_mul_iff_left` for `ℕ`.
 Duplicated here to keep simple imports for this file. -/
 protected lemma mul_dvd_mul_iff_left (ha : 0 < a) : a * b ∣ a * c ↔ b ∣ c :=
-  exists_congr fun d ↦ by rw [Nat.mul_assoc, Nat.mul_right_inj $ ne_of_gt ha]
+  exists_congr fun d ↦ by rw [Nat.mul_assoc, Nat.mul_right_inj <| ne_of_gt ha]
 
 /-- special case of `mul_dvd_mul_iff_right` for `ℕ`.
 Duplicated here to keep simple imports for this file. -/
 protected lemma mul_dvd_mul_iff_right (hc : 0 < c) : a * c ∣ b * c ↔ a ∣ b :=
-  exists_congr fun d ↦ by rw [Nat.mul_right_comm, Nat.mul_left_inj $ ne_of_gt hc]
+  exists_congr fun d ↦ by rw [Nat.mul_right_comm, Nat.mul_left_inj <| ne_of_gt hc]
 
 -- Moved to Batteries
 
@@ -1474,7 +1474,7 @@ lemma not_exists_sq' : m ^ 2 < n → n < (m + 1) ^ 2 → ¬∃ t, t ^ 2 = n := b
 
 instance decidableLoHi (lo hi : ℕ) (P : ℕ → Prop) [H : DecidablePred P] :
     Decidable (∀ x, lo ≤ x → x < hi → P x) :=
-  decidable_of_iff (∀ x < hi - lo, P (lo + x)) $ by
+  decidable_of_iff (∀ x < hi - lo, P (lo + x)) <| by
     refine ⟨fun al x hl hh ↦ ?_,
       fun al x h ↦ al _ (Nat.le_add_right _ _) (Nat.lt_sub_iff_add_lt'.1 h)⟩
     have := al (x - lo) ((Nat.sub_lt_sub_iff_right hl).2 hh)

--- a/Mathlib/Data/Nat/Factorial/Basic.lean
+++ b/Mathlib/Data/Nat/Factorial/Basic.lean
@@ -86,7 +86,7 @@ theorem factorial_lt (hn : 0 < n) : n ! < m ! ↔ n < m := by
     exact Nat.mul_pos hk k.factorial_pos
   induction h generalizing hn with
   | refl => exact this hn
-  | step hnk ih => exact lt_trans (ih hn) $ this <| lt_trans hn <| lt_of_succ_le hnk
+  | step hnk ih => exact lt_trans (ih hn) <| this <| lt_trans hn <| lt_of_succ_le hnk
 
 @[gcongr]
 lemma factorial_lt_of_lt {m n : ℕ} (hn : 0 < n) (h : n < m) : n ! < m ! := (factorial_lt hn).mpr h

--- a/Mathlib/Data/Nat/Factorization/Root.lean
+++ b/Mathlib/Data/Nat/Factorization/Root.lean
@@ -68,7 +68,7 @@ lemma floorRoot_ne_zero : floorRoot n a ≠ 0 ↔ n ≠ 0 ∧ a ≠ 0 := by
   simp (config := { contextual := true }) [floorRoot, not_imp_not, not_or]
 
 @[simp] lemma floorRoot_eq_zero : floorRoot n a = 0 ↔ n = 0 ∨ a = 0 :=
-  floorRoot_ne_zero.not_right.trans $ by simp only [not_and_or, ne_eq, not_not]
+  floorRoot_ne_zero.not_right.trans <| by simp only [not_and_or, ne_eq, not_not]
 
 @[simp] lemma factorization_floorRoot (n a : ℕ) :
     (floorRoot n a).factorization = a.factorization ⌊/⌋ n := by
@@ -130,7 +130,7 @@ lemma ceilRoot_ne_zero : ceilRoot n a ≠ 0 ↔ n ≠ 0 ∧ a ≠ 0 := by
   simp (config := { contextual := true }) [ceilRoot_def, not_imp_not, not_or]
 
 @[simp] lemma ceilRoot_eq_zero : ceilRoot n a = 0 ↔ n = 0 ∨ a = 0 :=
-  ceilRoot_ne_zero.not_right.trans $ by simp only [not_and_or, ne_eq, not_not]
+  ceilRoot_ne_zero.not_right.trans <| by simp only [not_and_or, ne_eq, not_not]
 
 @[simp] lemma factorization_ceilRoot (n a : ℕ) :
     (ceilRoot n a).factorization = a.factorization ⌈/⌉ n := by

--- a/Mathlib/Data/Nat/Find.lean
+++ b/Mathlib/Data/Nat/Find.lean
@@ -200,7 +200,7 @@ lemma findGreatest_mono_right (P : ℕ → Prop) [DecidablePred P] {m n} (hmn : 
   · simp
   rw [findGreatest_succ]
   split_ifs
-  · exact le_trans ih $ le_trans (findGreatest_le _) (le_succ _)
+  · exact le_trans ih <| le_trans (findGreatest_le _) (le_succ _)
   · exact ih
 
 lemma findGreatest_mono_left [DecidablePred Q] (hPQ : ∀ n, P n → Q n) (n : ℕ) :

--- a/Mathlib/Data/Nat/Log.lean
+++ b/Mathlib/Data/Nat/Log.lean
@@ -60,7 +60,7 @@ theorem log_of_one_lt_of_le {b n : ℕ} (h : 1 < b) (hn : b ≤ n) : log b n = l
   rw [log]
   exact if_pos ⟨hn, h⟩
 
-@[simp] lemma log_zero_left : ∀ n, log 0 n = 0 := log_of_left_le_one $ Nat.zero_le _
+@[simp] lemma log_zero_left : ∀ n, log 0 n = 0 := log_of_left_le_one <| Nat.zero_le _
 
 @[simp]
 theorem log_zero_right (b : ℕ) : log b 0 = 0 :=

--- a/Mathlib/Data/Real/ConjExponents.lean
+++ b/Mathlib/Data/Real/ConjExponents.lean
@@ -106,10 +106,10 @@ theorem inv_add_inv_conj_ennreal : (ENNReal.ofReal p)⁻¹ + (ENNReal.ofReal q)�
 end
 
 protected lemma inv_inv (ha : 0 < a) (hb : 0 < b) (hab : a + b = 1) : a⁻¹.IsConjExponent b⁻¹ :=
-  ⟨one_lt_inv ha $ by linarith, by simpa only [inv_inv]⟩
+  ⟨one_lt_inv ha <| by linarith, by simpa only [inv_inv]⟩
 
 lemma inv_one_sub_inv (ha₀ : 0 < a) (ha₁ : a < 1) : a⁻¹.IsConjExponent (1 - a)⁻¹ :=
-  .inv_inv ha₀ (sub_pos_of_lt ha₁) $ add_tsub_cancel_of_le ha₁.le
+  .inv_inv ha₀ (sub_pos_of_lt ha₁) <| add_tsub_cancel_of_le ha₁.le
 
 lemma one_sub_inv_inv (ha₀ : 0 < a) (ha₁ : a < 1) : (1 - a)⁻¹.IsConjExponent a⁻¹ :=
   (inv_one_sub_inv ha₀ ha₁).symm
@@ -195,11 +195,11 @@ end
 
 protected lemma inv_inv (ha : a ≠ 0) (hb : b ≠ 0) (hab : a + b = 1) :
     a⁻¹.IsConjExponent b⁻¹ :=
-  ⟨one_lt_inv ha.bot_lt $ by rw [← hab]; exact lt_add_of_pos_right _ hb.bot_lt, by
+  ⟨one_lt_inv ha.bot_lt <| by rw [← hab]; exact lt_add_of_pos_right _ hb.bot_lt, by
     simpa only [inv_inv] using hab⟩
 
 lemma inv_one_sub_inv (ha₀ : a ≠ 0) (ha₁ : a < 1) : a⁻¹.IsConjExponent (1 - a)⁻¹ :=
-  .inv_inv ha₀ (tsub_pos_of_lt ha₁).ne' $ add_tsub_cancel_of_le ha₁.le
+  .inv_inv ha₀ (tsub_pos_of_lt ha₁).ne' <| add_tsub_cancel_of_le ha₁.le
 
 lemma one_sub_inv_inv (ha₀ : a ≠ 0) (ha₁ : a < 1) : (1 - a)⁻¹.IsConjExponent a⁻¹ :=
   (inv_one_sub_inv ha₀ ha₁).symm

--- a/Mathlib/Data/Real/Sqrt.lean
+++ b/Mathlib/Data/Real/Sqrt.lean
@@ -267,7 +267,7 @@ alias ⟨_, sqrt_pos_of_pos⟩ := sqrt_pos
 
 lemma sqrt_le_sqrt_iff' (hx : 0 < x) : √x ≤ √y ↔ x ≤ y := by
   obtain hy | hy := le_total y 0
-  · exact iff_of_false ((sqrt_eq_zero_of_nonpos hy).trans_lt $ sqrt_pos.2 hx).not_le
+  · exact iff_of_false ((sqrt_eq_zero_of_nonpos hy).trans_lt <| sqrt_pos.2 hx).not_le
       (hy.trans_lt hx).not_le
   · exact sqrt_le_sqrt_iff hy
 
@@ -433,7 +433,7 @@ open Finset
 /-- **Cauchy-Schwarz inequality** for finsets using square roots in `ℝ≥0`. -/
 lemma sum_mul_le_sqrt_mul_sqrt (s : Finset ι) (f g : ι → ℝ≥0) :
     ∑ i ∈ s, f i * g i ≤ sqrt (∑ i ∈ s, f i ^ 2) * sqrt (∑ i ∈ s, g i ^ 2) :=
-  (le_sqrt_iff_sq_le.2 $ sum_mul_sq_le_sq_mul_sq _ _ _).trans_eq <| sqrt_mul _ _
+  (le_sqrt_iff_sq_le.2 <| sum_mul_sq_le_sq_mul_sq _ _ _).trans_eq <| sqrt_mul _ _
 
 /-- **Cauchy-Schwarz inequality** for finsets using square roots in `ℝ≥0`. -/
 lemma sum_sqrt_mul_sqrt_le (s : Finset ι) (f g : ι → ℝ≥0) :

--- a/Mathlib/Data/Set/Function.lean
+++ b/Mathlib/Data/Set/Function.lean
@@ -929,7 +929,7 @@ theorem BijOn.image_eq (h : BijOn f s t) : f '' s = t :=
   h.surjOn.image_eq_of_mapsTo h.mapsTo
 
 lemma BijOn.forall {p : β → Prop} (hf : BijOn f s t) : (∀ b ∈ t, p b) ↔ ∀ a ∈ s, p (f a) where
-  mp h a ha := h _ $ hf.mapsTo ha
+  mp h a ha := h _ <| hf.mapsTo ha
   mpr h b hb := by obtain ⟨a, ha, rfl⟩ := hf.surjOn hb; exact h _ ha
 
 lemma BijOn.exists {p : β → Prop} (hf : BijOn f s t) : (∃ b ∈ t, p b) ↔ ∃ a ∈ s, p (f a) where

--- a/Mathlib/Data/Set/Image.lean
+++ b/Mathlib/Data/Set/Image.lean
@@ -191,7 +191,7 @@ theorem _root_.Function.Injective.mem_set_image {f : α → β} (hf : Injective 
 
 lemma preimage_subset_of_surjOn {t : Set β} (hf : Injective f) (h : SurjOn f s t) :
     f ⁻¹' t ⊆ s := fun _ hx ↦
-  hf.mem_set_image.1 $ h hx
+  hf.mem_set_image.1 <| h hx
 
 theorem forall_mem_image {f : α → β} {s : Set α} {p : β → Prop} :
     (∀ y ∈ f '' s, p y) ↔ ∀ ⦃x⦄, x ∈ s → p (f x) := by simp

--- a/Mathlib/FieldTheory/IsAlgClosed/AlgebraicClosure.lean
+++ b/Mathlib/FieldTheory/IsAlgClosed/AlgebraicClosure.lean
@@ -379,7 +379,7 @@ instance instGroupWithZero : GroupWithZero (AlgebraicClosure k) :=
   let e := algEquivAlgebraicClosureAux k
   { inv := fun a ↦ e.symm (e a)⁻¹
     inv_zero := by simp
-    mul_inv_cancel := fun a ha ↦ e.injective $ by simp [(AddEquivClass.map_ne_zero_iff _).2 ha]
+    mul_inv_cancel := fun a ha ↦ e.injective <| by simp [(AddEquivClass.map_ne_zero_iff _).2 ha]
     __ := e.surjective.nontrivial }
 
 instance instField : Field (AlgebraicClosure k) where
@@ -392,9 +392,9 @@ instance instField : Field (AlgebraicClosure k) where
   nnratCast_def q := by change algebraMap k _ _ = _; simp_rw [NNRat.cast_def, map_div₀, map_natCast]
   ratCast_def q := by
     change algebraMap k _ _ = _; rw [Rat.cast_def, map_div₀, map_intCast, map_natCast]
-  nnqsmul_def q x := Quotient.inductionOn x fun p ↦ congr_arg Quotient.mk'' $ by
+  nnqsmul_def q x := Quotient.inductionOn x fun p ↦ congr_arg Quotient.mk'' <| by
     ext; simp [MvPolynomial.algebraMap_eq, NNRat.smul_def]
-  qsmul_def q x := Quotient.inductionOn x fun p ↦ congr_arg Quotient.mk'' $ by
+  qsmul_def q x := Quotient.inductionOn x fun p ↦ congr_arg Quotient.mk'' <| by
     ext; simp [MvPolynomial.algebraMap_eq, Rat.smul_def]
 
 instance isAlgClosed : IsAlgClosed (AlgebraicClosure k) :=

--- a/Mathlib/FieldTheory/SplittingField/Construction.lean
+++ b/Mathlib/FieldTheory/SplittingField/Construction.lean
@@ -245,7 +245,7 @@ instance instGroupWithZero : GroupWithZero (SplittingField f) :=
   let e := algEquivSplittingFieldAux f
   { inv := fun a ↦ e.symm (e a)⁻¹
     inv_zero := by simp
-    mul_inv_cancel := fun a ha ↦ e.injective $ by simp [(AddEquivClass.map_ne_zero_iff _).2 ha]
+    mul_inv_cancel := fun a ha ↦ e.injective <| by simp [(AddEquivClass.map_ne_zero_iff _).2 ha]
     __ := e.surjective.nontrivial }
 
 instance instField : Field (SplittingField f) where
@@ -258,9 +258,9 @@ instance instField : Field (SplittingField f) where
   nnratCast_def q := by change algebraMap K _ _ = _; simp_rw [NNRat.cast_def, map_div₀, map_natCast]
   ratCast_def q := by
     change algebraMap K _ _ = _; rw [Rat.cast_def, map_div₀, map_intCast, map_natCast]
-  nnqsmul_def q x := Quotient.inductionOn x fun p ↦ congr_arg Quotient.mk'' $ by
+  nnqsmul_def q x := Quotient.inductionOn x fun p ↦ congr_arg Quotient.mk'' <| by
     ext; simp [MvPolynomial.algebraMap_eq, NNRat.smul_def]
-  qsmul_def q x := Quotient.inductionOn x fun p ↦ congr_arg Quotient.mk'' $ by
+  qsmul_def q x := Quotient.inductionOn x fun p ↦ congr_arg Quotient.mk'' <| by
     ext; simp [MvPolynomial.algebraMap_eq, Rat.smul_def]
 
 instance instCharZero [CharZero K] : CharZero (SplittingField f) :=

--- a/Mathlib/Geometry/Euclidean/Angle/Unoriented/Affine.lean
+++ b/Mathlib/Geometry/Euclidean/Angle/Unoriented/Affine.lean
@@ -134,7 +134,7 @@ nonrec theorem angle_le_pi (p1 p2 p3 : P) : ∠ p1 p2 p3 ≤ π :=
 @[simp] lemma angle_self_right (p₀ p : P) : ∠ p p₀ p₀ = π / 2 := by rw [angle_comm, angle_self_left]
 
 /-- The angle ∠ABA at a point is `0`, unless `A = B`. -/
-theorem angle_self_of_ne (h : p ≠ p₀) : ∠ p p₀ p = 0 := angle_self $ vsub_ne_zero.2 h
+theorem angle_self_of_ne (h : p ≠ p₀) : ∠ p p₀ p = 0 := angle_self <| vsub_ne_zero.2 h
 
 @[deprecated (since := "2024-02-14")] alias angle_eq_left := angle_self_left
 @[deprecated (since := "2024-02-14")] alias angle_eq_right := angle_self_right

--- a/Mathlib/GroupTheory/FiniteAbelian.lean
+++ b/Mathlib/GroupTheory/FiniteAbelian.lean
@@ -75,7 +75,7 @@ private def directSumNeZeroMulEquiv (ι : Type) [DecidableEq ι] (p : ι → ℕ
     · rw [map_zero, map_zero]
     · rw [DirectSum.toAddMonoid_of]
       split_ifs with h
-      · simp [(ZMod.subsingleton_iff.2 $ by rw [h, pow_zero]).elim x 0]
+      · simp [(ZMod.subsingleton_iff.2 <| by rw [h, pow_zero]).elim x 0]
       · simp_rw [directSumNeZeroMulHom, DirectSum.toAddMonoid_of]
     · rw [map_add, map_add, hx, hy]
   map_add' := map_add (directSumNeZeroMulHom p n)

--- a/Mathlib/GroupTheory/OrderOfElement.lean
+++ b/Mathlib/GroupTheory/OrderOfElement.lean
@@ -902,12 +902,12 @@ theorem zpow_mod_card (a : G) (n : ℤ) : a ^ (n % Fintype.card G : ℤ) = a ^ n
 
 @[to_additive (attr := simp) mod_natCard_nsmul]
 lemma pow_mod_natCard {G} [Group G] (a : G) (n : ℕ) : a ^ (n % Nat.card G) = a ^ n := by
-  rw [eq_comm, ← pow_mod_orderOf, ← Nat.mod_mod_of_dvd n $ orderOf_dvd_natCard _, pow_mod_orderOf]
+  rw [eq_comm, ← pow_mod_orderOf, ← Nat.mod_mod_of_dvd n <| orderOf_dvd_natCard _, pow_mod_orderOf]
 
 @[to_additive (attr := simp) mod_natCard_zsmul]
 lemma zpow_mod_natCard {G} [Group G] (a : G) (n : ℤ) : a ^ (n % Nat.card G : ℤ) = a ^ n := by
-  rw [eq_comm, ← zpow_mod_orderOf,
-    ← Int.emod_emod_of_dvd n $ Int.natCast_dvd_natCast.2 $ orderOf_dvd_natCard _, zpow_mod_orderOf]
+  rw [eq_comm, ← zpow_mod_orderOf, ← Int.emod_emod_of_dvd n <|
+    Int.natCast_dvd_natCast.2 <| orderOf_dvd_natCard _, zpow_mod_orderOf]
 
 /-- If `gcd(|G|,n)=1` then the `n`th power map is a bijection -/
 @[to_additive (attr := simps) "If `gcd(|G|,n)=1` then the smul by `n` is a bijection"]
@@ -1114,7 +1114,7 @@ lemma charP_of_prime_pow_injective (R) [Ring R] [Fintype R] (p n : ℕ) [hp : Fa
   obtain ⟨c, hc⟩ := CharP.exists R
   have hcpn : c ∣ p ^ n := by rw [← CharP.cast_eq_zero_iff R c, ← hn, Nat.cast_card_eq_zero]
   obtain ⟨i, hi, rfl⟩ : ∃ i ≤ n, c = p ^ i := by rwa [Nat.dvd_prime_pow hp.1] at hcpn
-  obtain rfl : i = n := hR i hi $ by rw [← Nat.cast_pow, CharP.cast_eq_zero]
+  obtain rfl : i = n := hR i hi <| by rw [← Nat.cast_pow, CharP.cast_eq_zero]
   assumption
 
 namespace SemiconjBy

--- a/Mathlib/GroupTheory/Perm/Basic.lean
+++ b/Mathlib/GroupTheory/Perm/Basic.lean
@@ -36,9 +36,9 @@ instance permGroup : Group (Perm α) where
   mul_one := refl_trans
   inv_mul_cancel := self_trans_symm
   npow n f := f ^ n
-  npow_succ n f := coe_fn_injective $ Function.iterate_succ _ _
+  npow_succ n f := coe_fn_injective <| Function.iterate_succ _ _
   zpow := zpowRec fun n f ↦ f ^ n
-  zpow_succ' n f := coe_fn_injective $ Function.iterate_succ _ _
+  zpow_succ' n f := coe_fn_injective <| Function.iterate_succ _ _
 
 @[simp]
 theorem default_eq : (default : Perm α) = 1 :=

--- a/Mathlib/LinearAlgebra/AffineSpace/FiniteDimensional.lean
+++ b/Mathlib/LinearAlgebra/AffineSpace/FiniteDimensional.lean
@@ -156,8 +156,8 @@ theorem finrank_vectorSpan_range_le [Fintype ι] (p : ι → P) {n : ℕ} (hc : 
 /-- The `vectorSpan` of an indexed family of `n + 1` points has dimension at most `n`. -/
 lemma finrank_vectorSpan_range_add_one_le [Fintype ι] [Nonempty ι] (p : ι → P) :
     finrank k (vectorSpan k (Set.range p)) + 1 ≤ Fintype.card ι :=
-  (le_tsub_iff_right $ Nat.succ_le_iff.2 Fintype.card_pos).1 $ finrank_vectorSpan_range_le _ _
-    (tsub_add_cancel_of_le $ Nat.succ_le_iff.2 Fintype.card_pos).symm
+  (le_tsub_iff_right <| Nat.succ_le_iff.2 Fintype.card_pos).1 <| finrank_vectorSpan_range_le _ _
+    (tsub_add_cancel_of_le <| Nat.succ_le_iff.2 Fintype.card_pos).symm
 
 /-- `n + 1` points are affinely independent if and only if their
 `vectorSpan` has dimension `n`. -/
@@ -241,7 +241,7 @@ lemma AffineIndependent.card_lt_card_of_affineSpan_lt_affineSpan {s t : Finset V
   · simp [Set.subset_empty_iff] at hst
   have := hs'.to_subtype
   have := ht'.to_set.to_subtype
-  have dir_lt := AffineSubspace.direction_lt_of_nonempty (k := k) hst $ hs'.to_set.affineSpan k
+  have dir_lt := AffineSubspace.direction_lt_of_nonempty (k := k) hst <| hs'.to_set.affineSpan k
   rw [direction_affineSpan, direction_affineSpan,
     ← @Subtype.range_coe _ (s : Set V), ← @Subtype.range_coe _ (t : Set V)] at dir_lt
   have finrank_lt := add_lt_add_right (Submodule.finrank_lt_finrank_of_lt dir_lt) 1

--- a/Mathlib/LinearAlgebra/Matrix/ZPow.lean
+++ b/Mathlib/LinearAlgebra/Matrix/ZPow.lean
@@ -216,7 +216,7 @@ theorem zpow_add_one_of_ne_neg_one {A : M} : ∀ n : ℤ, n ≠ -1 → A ^ (n + 
     rcases nonsing_inv_cancel_or_zero A with (⟨h, _⟩ | h)
     · apply zpow_add_one (isUnit_det_of_left_inverse h)
     · show A ^ (-((n + 1 : ℕ) : ℤ)) = A ^ (-((n + 2 : ℕ) : ℤ)) * A
-      simp_rw [zpow_neg_natCast, ← inv_pow', h, zero_pow $ Nat.succ_ne_zero _, zero_mul]
+      simp_rw [zpow_neg_natCast, ← inv_pow', h, zero_pow <| Nat.succ_ne_zero _, zero_mul]
 
 theorem zpow_mul (A : M) (h : IsUnit A.det) : ∀ m n : ℤ, A ^ (m * n) = (A ^ m) ^ n
   | (m : ℕ), (n : ℕ) => by rw [zpow_natCast, zpow_natCast, ← pow_mul, ← zpow_natCast, Int.ofNat_mul]

--- a/Mathlib/LinearAlgebra/Prod.lean
+++ b/Mathlib/LinearAlgebra/Prod.lean
@@ -871,7 +871,7 @@ theorem tailing_disjoint_tunnel_succ (f : M × N →ₗ[R] M) (i : Injective f) 
 
 @[deprecated (since := "2024-06-05")]
 theorem tailing_sup_tunnel_succ_le_tunnel (f : M × N →ₗ[R] M) (i : Injective f) (n : ℕ) :
-    tailing f i n ⊔ (OrderDual.ofDual (α := Submodule R M) $ tunnel f i (n + 1)) ≤
+    tailing f i n ⊔ (OrderDual.ofDual (α := Submodule R M) <| tunnel f i (n + 1)) ≤
       (OrderDual.ofDual (α := Submodule R M) <| tunnel f i n) := by
   dsimp [tailing, tunnel, tunnel', tunnelAux]
   erw [← Submodule.map_sup, sup_comm, Submodule.fst_sup_snd, Submodule.map_comp, Submodule.map_comp]

--- a/Mathlib/LinearAlgebra/Ray.lean
+++ b/Mathlib/LinearAlgebra/Ray.lean
@@ -106,7 +106,7 @@ lemma sameRay_nonneg_smul_right (v : M) (h : 0 ≤ a) : SameRay R v (a • v) :=
   obtain h | h := (algebraMap_nonneg R h).eq_or_gt
   · rw [← algebraMap_smul R a v, h, zero_smul]
     exact zero_right _
-  · refine Or.inr $ Or.inr ⟨algebraMap S R a, 1, h, by nontriviality R; exact zero_lt_one, ?_⟩
+  · refine Or.inr <| Or.inr ⟨algebraMap S R a, 1, h, by nontriviality R; exact zero_lt_one, ?_⟩
     rw [algebraMap_smul, one_smul]
 
 /-- A nonnegative multiple of a vector is in the same ray as that vector. -/

--- a/Mathlib/Logic/Equiv/Defs.lean
+++ b/Mathlib/Logic/Equiv/Defs.lean
@@ -721,13 +721,13 @@ protected lemma exists_congr_left : (∃ a, p a) ↔ ∃ b, p (e.symm b) :=
   e.symm.exists_congr_right.symm
 
 protected lemma exists_congr (h : ∀ a, p a ↔ q (e a)) : (∃ a, p a) ↔ ∃ b, q b :=
-  e.exists_congr_left.trans $ by simp [h]
+  e.exists_congr_left.trans <| by simp [h]
 
 protected lemma exists_congr' (h : ∀ b, p (e.symm b) ↔ q b) : (∃ a, p a) ↔ ∃ b, q b :=
-  e.exists_congr_left.trans $ by simp [h]
+  e.exists_congr_left.trans <| by simp [h]
 
 protected lemma existsUnique_congr_right : (∃! a, q (e a)) ↔ ∃! b, q b :=
-  e.exists_congr $ by simpa using fun _ _ ↦ e.forall_congr (by simp)
+  e.exists_congr <| by simpa using fun _ _ ↦ e.forall_congr (by simp)
 
 protected lemma existsUnique_congr_left : (∃! a, p a) ↔ ∃! b, p (e.symm b) :=
   e.symm.existsUnique_congr_right.symm
@@ -739,12 +739,12 @@ alias exists_unique_congr_left := Equiv.existsUnique_congr_right
 alias exists_unique_congr_left' := Equiv.existsUnique_congr_left
 
 protected lemma existsUnique_congr (h : ∀ a, p a ↔ q (e a)) : (∃! a, p a) ↔ ∃! b, q b :=
-  e.existsUnique_congr_left.trans $ by simp [h]
+  e.existsUnique_congr_left.trans <| by simp [h]
 
 @[deprecated (since := "2024-06-11")] alias exists_unique_congr := Equiv.existsUnique_congr
 
 protected lemma existsUnique_congr' (h : ∀ b, p (e.symm b) ↔ q b) : (∃! a, p a) ↔ ∃! b, q b :=
-  e.existsUnique_congr_left.trans $ by simp [h]
+  e.existsUnique_congr_left.trans <| by simp [h]
 
 -- We next build some higher arity versions of `Equiv.forall_congr`.
 -- Although they appear to just be repeated applications of `Equiv.forall_congr`,
@@ -756,7 +756,7 @@ protected lemma existsUnique_congr' (h : ∀ b, p (e.symm b) ↔ q b) : (∃! a,
 protected theorem forall₂_congr {α₁ α₂ β₁ β₂ : Sort*} {p : α₁ → β₁ → Prop} {q : α₂ → β₂ → Prop}
     (eα : α₁ ≃ α₂) (eβ : β₁ ≃ β₂) (h : ∀ {x y}, p x y ↔ q (eα x) (eβ y)) :
     (∀ x y, p x y) ↔ ∀ x y, q x y :=
-  eα.forall_congr fun _ ↦ eβ.forall_congr $ @h _
+  eα.forall_congr fun _ ↦ eβ.forall_congr <| @h _
 
 protected theorem forall₂_congr' {α₁ α₂ β₁ β₂ : Sort*} {p : α₁ → β₁ → Prop} {q : α₂ → β₂ → Prop}
     (eα : α₁ ≃ α₂) (eβ : β₁ ≃ β₂) (h : ∀ {x y}, p (eα.symm x) (eβ.symm y) ↔ q x y) :
@@ -766,7 +766,7 @@ protected theorem forall₃_congr
     {α₁ α₂ β₁ β₂ γ₁ γ₂ : Sort*} {p : α₁ → β₁ → γ₁ → Prop} {q : α₂ → β₂ → γ₂ → Prop}
     (eα : α₁ ≃ α₂) (eβ : β₁ ≃ β₂) (eγ : γ₁ ≃ γ₂) (h : ∀ {x y z}, p x y z ↔ q (eα x) (eβ y) (eγ z)) :
     (∀ x y z, p x y z) ↔ ∀ x y z, q x y z :=
-  Equiv.forall₂_congr _ _ <| Equiv.forall_congr _ $ @h _ _
+  Equiv.forall₂_congr _ _ <| Equiv.forall_congr _ <| @h _ _
 
 protected theorem forall₃_congr'
     {α₁ α₂ β₁ β₂ γ₁ γ₂ : Sort*} {p : α₁ → β₁ → γ₁ → Prop} {q : α₂ → β₂ → γ₂ → Prop}

--- a/Mathlib/Logic/Godel/GodelBetaFunction.lean
+++ b/Mathlib/Logic/Godel/GodelBetaFunction.lean
@@ -46,7 +46,7 @@ lemma coprime_mul_succ {n m a} (h : n ≤ m) (ha : m - n ∣ a) : Coprime (n * a
   Nat.coprime_of_dvd fun p pp hn hm => by
     have : p ∣ (m - n) * a := by
       simpa [Nat.succ_sub_succ, ← Nat.mul_sub_right_distrib] using
-        Nat.dvd_sub (Nat.succ_le_succ $ Nat.mul_le_mul_right a h) hm hn
+        Nat.dvd_sub (Nat.succ_le_succ <| Nat.mul_le_mul_right a h) hm hn
     have : p ∣ a := by
       rcases (Nat.Prime.dvd_mul pp).mp this with (hp | hp)
       · exact Nat.dvd_trans hp ha
@@ -62,7 +62,7 @@ private def coprimes (a : Fin m → ℕ) : Fin m → ℕ := fun i => (i + 1) * (
 
 lemma coprimes_lt (a : Fin m → ℕ) (i) : a i < coprimes a i := by
   have h₁ : a i < supOfSeq a :=
-    Nat.lt_add_one_iff.mpr (le_max_of_le_right $ Finset.le_sup (by simp))
+    Nat.lt_add_one_iff.mpr (le_max_of_le_right <| Finset.le_sup (by simp))
   have h₂ : supOfSeq a ≤ (i + 1) * (supOfSeq a)! + 1 :=
     le_trans (self_le_factorial _) (le_trans (Nat.le_mul_of_pos_left (supOfSeq a)! (succ_pos i))
       (le_add_right _ _))
@@ -75,7 +75,7 @@ private lemma pairwise_coprime_coprimes (a : Fin m → ℕ) : Pairwise (Coprime 
   unfold Function.onFun coprimes
   have hja : j < supOfSeq a := lt_of_lt_of_le j.prop (le_step (le_max_left _ _))
   exact coprime_mul_succ
-    (Nat.succ_le_succ $ le_of_lt ltij)
+    (Nat.succ_le_succ <| le_of_lt ltij)
     (Nat.dvd_factorial
       (by simp [Nat.succ_sub_succ, ltij])
       (by simpa only [Nat.succ_sub_succ] using le_of_lt (lt_of_le_of_lt (sub_le j i) hja)))

--- a/Mathlib/MeasureTheory/Constructions/BorelSpace/Metric.lean
+++ b/Mathlib/MeasureTheory/Constructions/BorelSpace/Metric.lean
@@ -196,7 +196,7 @@ theorem exists_borelSpace_of_countablyGenerated_of_separatesPoints (α : Type*)
     ∃ τ : TopologicalSpace α, SecondCountableTopology α ∧ T4Space α ∧ BorelSpace α := by
   rcases measurableEquiv_nat_bool_of_countablyGenerated α with ⟨s, ⟨f⟩⟩
   letI := induced f inferInstance
-  let F := f.toEquiv.toHomeomorphOfInducing $ inducing_induced _
+  let F := f.toEquiv.toHomeomorphOfInducing <| inducing_induced _
   exact ⟨inferInstance, F.secondCountableTopology, F.symm.t4Space,
     MeasurableEmbedding.borelSpace f.measurableEmbedding F.inducing⟩
 

--- a/Mathlib/MeasureTheory/Constructions/EventuallyMeasurable.lean
+++ b/Mathlib/MeasureTheory/Constructions/EventuallyMeasurable.lean
@@ -75,7 +75,7 @@ namespace EventuallyMeasurableSpace
 
 instance measurableSingleton [MeasurableSingletonClass α] :
     @MeasurableSingletonClass α (EventuallyMeasurableSpace m l) :=
-  @MeasurableSingletonClass.mk _ (_) $ fun x => (MeasurableSet.singleton x).eventuallyMeasurableSet
+  @MeasurableSingletonClass.mk _ (_) <| fun x => (MeasurableSet.singleton x).eventuallyMeasurableSet
 
 end EventuallyMeasurableSpace
 

--- a/Mathlib/MeasureTheory/Function/Intersectivity.lean
+++ b/Mathlib/MeasureTheory/Function/Intersectivity.lean
@@ -62,27 +62,27 @@ lemma bergelson' {s : ℕ → Set α} (hs : ∀ n, MeasurableSet (s n)) (hr₀ :
     simp only [f, Pi.natCast_def, Pi.smul_apply, Pi.inv_apply, Finset.sum_apply, eq_self_iff_true,
     forall_const, imp_true_iff, smul_eq_mul]
   have hf n : Measurable (f n) := Measurable.mul' (@measurable_const ℝ≥0∞ _ _ _ (↑(n + 1))⁻¹)
-      (Finset.measurable_sum' _ fun i _ ↦ measurable_one.indicator $ hs i)
+      (Finset.measurable_sum' _ fun i _ ↦ measurable_one.indicator <| hs i)
   have hf₁ n : f n ≤ 1 := by
     rintro a
     rw [hfapp, ← ENNReal.div_eq_inv_mul]
-    refine (ENNReal.div_le_iff_le_mul (Or.inl $ Nat.cast_ne_zero.2 n.succ_ne_zero) $
+    refine (ENNReal.div_le_iff_le_mul (Or.inl <| Nat.cast_ne_zero.2 n.succ_ne_zero) <|
       Or.inr one_ne_zero).2 ?_
     rw [mul_comm, ← nsmul_eq_mul, ← Finset.card_range n.succ]
     exact Finset.sum_le_card_nsmul _ _ _ fun _ _ ↦ indicator_le (fun _ _ ↦ le_rfl) _
   -- By assumption, `f n` has integral at least `r`.
   have hrf n : r ≤ ∫⁻ a, f n a ∂μ := by
     simp_rw [hfapp]
-    rw [lintegral_const_mul _ (Finset.measurable_sum _ fun _ _ ↦ measurable_one.indicator $ hs _),
+    rw [lintegral_const_mul _ (Finset.measurable_sum _ fun _ _ ↦ measurable_one.indicator <| hs _),
       lintegral_finset_sum _ fun _ _ ↦ measurable_one.indicator (hs _)]
     simp only [lintegral_indicator_one (hs _)]
     rw [← ENNReal.div_eq_inv_mul, ENNReal.le_div_iff_mul_le (by simp) (by simp), ← nsmul_eq_mul']
     simpa using Finset.card_nsmul_le_sum (Finset.range (n + 1)) _ _ fun _ _ ↦ hr _
   -- Collect some basic fact
-  have hμ : μ ≠ 0 := by rintro rfl; exact hr₀ $ le_bot_iff.1 $ hr 0
+  have hμ : μ ≠ 0 := by rintro rfl; exact hr₀ <| le_bot_iff.1 <| hr 0
   have : ∫⁻ x, limsup (f · x) atTop ∂μ ≤ μ univ := by
     rw [← lintegral_one]
-    exact lintegral_mono fun a ↦ limsup_le_of_le ⟨0, fun R _ ↦ bot_le⟩ $
+    exact lintegral_mono fun a ↦ limsup_le_of_le ⟨0, fun R _ ↦ bot_le⟩ <|
       Eventually.of_forall fun n ↦ hf₁ _ _
   -- By the first moment method, there exists some `x ∉ N` such that `limsup f n x` is at least `r`.
   obtain ⟨x, hxN, hx⟩ := exists_not_mem_null_laverage_le hμ
@@ -90,23 +90,23 @@ lemma bergelson' {s : ℕ → Set α} (hs : ∀ n, MeasurableSet (s n)) (hr₀ :
   replace hx : r / μ univ ≤ limsup (f · x) atTop :=
     calc
       _ ≤ limsup (⨍⁻ x, f · x ∂μ) atTop := le_limsup_of_le ⟨1, eventually_map.2 ?_⟩ fun b hb ↦ ?_
-      _ ≤ ⨍⁻ x, limsup (f · x) atTop ∂μ := limsup_lintegral_le 1 hf (ae_of_all _ $ hf₁ ·) (by simp)
+      _ ≤ ⨍⁻ x, limsup (f · x) atTop ∂μ := limsup_lintegral_le 1 hf (ae_of_all _ <| hf₁ ·) (by simp)
       _ ≤ limsup (f · x) atTop := hx
   -- This exactly means that the `s n` containing `x` have all their finite intersection non-null.
   · refine ⟨{n | x ∈ s n}, fun hxs ↦ ?_, fun u hux hu ↦ ?_⟩
     -- This next block proves that a set of strictly positive natural density is infinite, mixed
     -- with the fact that `{n | x ∈ s n}` has strictly positive natural density.
     -- TODO: Separate it out to a lemma once we have a natural density API.
-    · refine ENNReal.div_ne_zero.2 ⟨hr₀, measure_ne_top _ _⟩ $ eq_bot_mono hx $ Tendsto.limsup_eq $
-        tendsto_of_tendsto_of_tendsto_of_le_of_le tendsto_const_nhds
+    · refine ENNReal.div_ne_zero.2 ⟨hr₀, measure_ne_top _ _⟩ <| eq_bot_mono hx <|
+        Tendsto.limsup_eq <| tendsto_of_tendsto_of_tendsto_of_le_of_le tendsto_const_nhds
         (h := fun n ↦ (n.succ : ℝ≥0∞)⁻¹ * hxs.toFinset.card) ?_ bot_le fun n ↦ mul_le_mul_left' ?_ _
-      · simpa using ENNReal.Tendsto.mul_const (ENNReal.tendsto_inv_nat_nhds_zero.comp $
-          tendsto_add_atTop_nat 1) (.inr $ ENNReal.natCast_ne_top _)
+      · simpa using ENNReal.Tendsto.mul_const (ENNReal.tendsto_inv_nat_nhds_zero.comp <|
+          tendsto_add_atTop_nat 1) (.inr <| ENNReal.natCast_ne_top _)
       · classical
         simpa only [Finset.sum_apply, indicator_apply, Pi.one_apply, Finset.sum_boole, Nat.cast_le]
           using Finset.card_le_card fun m hm ↦ hxs.mem_toFinset.2 (Finset.mem_filter.1 hm).2
     · simp_rw [← hu.mem_toFinset]
-      exact hN₁ _ ⟨x, mem_iInter₂.2 fun n hn ↦ hux $ hu.mem_toFinset.1 hn, hxN⟩
+      exact hN₁ _ ⟨x, mem_iInter₂.2 fun n hn ↦ hux <| hu.mem_toFinset.1 hn, hxN⟩
   · refine Eventually.of_forall fun n ↦ ?_
     obtain rfl | _ := eq_zero_or_neZero μ
     · simp
@@ -121,9 +121,9 @@ measure at least `r` has an infinite subset whose finite intersections all have 
 lemma bergelson [Infinite ι] {s : ι → Set α} (hs : ∀ i, MeasurableSet (s i)) (hr₀ : r ≠ 0)
     (hr : ∀ i, r ≤ μ (s i)) :
     ∃ t : Set ι, t.Infinite ∧ ∀ ⦃u⦄, u ⊆ t → u.Finite → 0 < μ (⋂ i ∈ u, s i) := by
-  obtain ⟨t, ht, h⟩ := bergelson' (fun n ↦ hs $ Infinite.natEmbedding _ n) hr₀ (fun n ↦ hr _)
-  refine ⟨_, ht.image $ (Infinite.natEmbedding _).injective.injOn, fun u hut hu ↦
-    (h (preimage_subset_of_surjOn (Infinite.natEmbedding _).injective hut) $ hu.preimage
-    (Embedding.injective _).injOn).trans_le $ measure_mono $ subset_iInter₂ fun i hi ↦ ?_⟩
+  obtain ⟨t, ht, h⟩ := bergelson' (fun n ↦ hs <| Infinite.natEmbedding _ n) hr₀ (fun n ↦ hr _)
+  refine ⟨_, ht.image <| (Infinite.natEmbedding _).injective.injOn, fun u hut hu ↦
+    (h (preimage_subset_of_surjOn (Infinite.natEmbedding _).injective hut) <| hu.preimage
+    (Embedding.injective _).injOn).trans_le <| measure_mono <| subset_iInter₂ fun i hi ↦ ?_⟩
   obtain ⟨n, -, rfl⟩ := hut hi
   exact iInter₂_subset n hi

--- a/Mathlib/MeasureTheory/MeasurableSpace/CountablyGenerated.lean
+++ b/Mathlib/MeasureTheory/MeasurableSpace/CountablyGenerated.lean
@@ -89,7 +89,7 @@ lemma generateFrom_natGeneratingSequence (α : Type*) [m : MeasurableSpace α]
 
 lemma measurableSet_natGeneratingSequence [MeasurableSpace α] [CountablyGenerated α] (n : ℕ) :
     MeasurableSet (natGeneratingSequence α n) :=
-  measurableSet_countableGeneratingSet $ Set.enumerateCountable_mem _
+  measurableSet_countableGeneratingSet <| Set.enumerateCountable_mem _
     empty_mem_countableGeneratingSet n
 
 theorem CountablyGenerated.comap [m : MeasurableSpace β] [h : CountablyGenerated β] (f : α → β) :
@@ -159,7 +159,7 @@ theorem separating_of_generateFrom (S : Set (Set α))
   letI := generateFrom S
   intros x y hxy
   rw [← forall_generateFrom_mem_iff_mem_iff] at hxy
-  exact separatesPoints_def $ fun _ hs ↦ (hxy _ hs).mp
+  exact separatesPoints_def <| fun _ hs ↦ (hxy _ hs).mp
 
 theorem SeparatesPoints.mono {m m' : MeasurableSpace α} [hsep : @SeparatesPoints _ m] (h : m ≤ m') :
     @SeparatesPoints _ m' := @SeparatesPoints.mk _ m' fun _ _ hxy ↦
@@ -194,12 +194,12 @@ theorem CountablySeparated.subtype_iff [MeasurableSpace α] {s : Set α} :
 
 instance (priority := 100) Subtype.separatesPoints [MeasurableSpace α] [h : SeparatesPoints α]
     {s : Set α} : SeparatesPoints s :=
-  ⟨fun _ _ hxy ↦ Subtype.val_injective $ h.1 _ _ fun _ ht ↦ hxy _ $ measurable_subtype_coe ht⟩
+  ⟨fun _ _ hxy ↦ Subtype.val_injective <| h.1 _ _ fun _ ht ↦ hxy _ <| measurable_subtype_coe ht⟩
 
 instance (priority := 100) Subtype.countablySeparated [MeasurableSpace α]
     [h : CountablySeparated α] {s : Set α} : CountablySeparated s := by
   rw [CountablySeparated.subtype_iff]
-  exact h.countably_separated.mono (fun s ↦ id) $ subset_univ _
+  exact h.countably_separated.mono (fun s ↦ id) <| subset_univ _
 
 instance (priority := 100) separatesPoints_of_measurableSingletonClass [MeasurableSpace α]
     [MeasurableSingletonClass α] : SeparatesPoints α := by
@@ -235,7 +235,7 @@ theorem exists_countablyGenerated_le_of_countablySeparated [m : MeasurableSpace 
   refine ⟨generateFrom b, ?_, ?_, generateFrom_le hbm⟩
   · use b
   rw [@separatesPoints_iff]
-  exact fun x y hxy ↦ hb _ trivial _ trivial fun _ hs ↦ hxy _ $ measurableSet_generateFrom hs
+  exact fun x y hxy ↦ hb _ trivial _ trivial fun _ hs ↦ hxy _ <| measurableSet_generateFrom hs
 
 open Function
 
@@ -270,9 +270,9 @@ the Cantor Space. -/
 theorem measurableEquiv_nat_bool_of_countablyGenerated [MeasurableSpace α]
     [CountablyGenerated α] [SeparatesPoints α] :
     ∃ s : Set (ℕ → Bool), Nonempty (α ≃ᵐ s) := by
-  use range (mapNatBool α), Equiv.ofInjective _ $
+  use range (mapNatBool α), Equiv.ofInjective _ <|
     injective_mapNatBool _,
-    Measurable.subtype_mk $ measurable_mapNatBool _
+    Measurable.subtype_mk <| measurable_mapNatBool _
   simp_rw [← generateFrom_natGeneratingSequence α]
   apply measurable_generateFrom
   rintro _ ⟨n, rfl⟩
@@ -299,7 +299,7 @@ theorem measurableSingletonClass_of_countablySeparated
   rcases measurable_injection_nat_bool_of_countablySeparated α with ⟨f, fmeas, finj⟩
   refine ⟨fun x ↦ ?_⟩
   rw [← finj.preimage_image {x}, image_singleton]
-  exact fmeas $ MeasurableSet.singleton _
+  exact fmeas <| MeasurableSet.singleton _
 
 end SeparatesPoints
 

--- a/Mathlib/MeasureTheory/Measure/FiniteMeasure.lean
+++ b/Mathlib/MeasureTheory/Measure/FiniteMeasure.lean
@@ -130,7 +130,7 @@ theorem toMeasure_injective : Function.Injective ((↑) : FiniteMeasure Ω → M
 
 instance instFunLike : FunLike (FiniteMeasure Ω) (Set Ω) ℝ≥0 where
   coe μ s := ((μ : Measure Ω) s).toNNReal
-  coe_injective' μ ν h := toMeasure_injective $ Measure.ext fun s _ ↦ by
+  coe_injective' μ ν h := toMeasure_injective <| Measure.ext fun s _ ↦ by
     simpa [ENNReal.toNNReal_eq_toNNReal_iff, measure_ne_top] using congr_fun h s
 
 lemma coeFn_def (μ : FiniteMeasure Ω) : μ = fun s ↦ ((μ : Measure Ω) s).toNNReal := rfl

--- a/Mathlib/MeasureTheory/Measure/Haar/Quotient.lean
+++ b/Mathlib/MeasureTheory/Measure/Haar/Quotient.lean
@@ -228,7 +228,7 @@ theorem MeasureTheory.QuotientMeasureEqMeasurePreimage.haarMeasure_quotient [Loc
     MeasureTheory.QuotientMeasureEqMeasurePreimage.mulInvariantMeasure_quotient ν
   rw [haarMeasure_unique μ K']
   have finiteCovol : covolume Γ.op G ν ≠ ⊤ :=
-    ne_top_of_lt $ QuotientMeasureEqMeasurePreimage.covolume_ne_top μ (ν := ν)
+    ne_top_of_lt <| QuotientMeasureEqMeasurePreimage.covolume_ne_top μ (ν := ν)
   obtain ⟨s, fund_dom_s⟩ := i
   rw [fund_dom_s.covolume_eq_volume] at finiteCovol
   -- TODO: why `rw` fails?

--- a/Mathlib/MeasureTheory/Measure/ProbabilityMeasure.lean
+++ b/Mathlib/MeasureTheory/Measure/ProbabilityMeasure.lean
@@ -128,7 +128,7 @@ theorem toMeasure_injective : Function.Injective ((↑) : ProbabilityMeasure Ω 
 
 instance instFunLike : FunLike (ProbabilityMeasure Ω) (Set Ω) ℝ≥0 where
   coe μ s := ((μ : Measure Ω) s).toNNReal
-  coe_injective' μ ν h := toMeasure_injective $ Measure.ext fun s _ ↦ by
+  coe_injective' μ ν h := toMeasure_injective <| Measure.ext fun s _ ↦ by
     simpa [ENNReal.toNNReal_eq_toNNReal_iff, measure_ne_top] using congr_fun h s
 
 lemma coeFn_def (μ : ProbabilityMeasure Ω) : μ = fun s ↦ ((μ : Measure Ω) s).toNNReal := rfl

--- a/Mathlib/MeasureTheory/Order/UpperLower.lean
+++ b/Mathlib/MeasureTheory/Order/UpperLower.lean
@@ -64,7 +64,7 @@ private lemma aux₀
   intro H
   obtain ⟨ε, -, hε', hε₀⟩ := exists_seq_strictAnti_tendsto_nhdsWithin (0 : ℝ)
   refine not_eventually.2
-    (Frequently.of_forall fun _ ↦ lt_irrefl $ ENNReal.ofReal $ 4⁻¹ ^ Fintype.card ι)
+    (Frequently.of_forall fun _ ↦ lt_irrefl <| ENNReal.ofReal <| 4⁻¹ ^ Fintype.card ι)
     ((Filter.Tendsto.eventually_lt (H.comp hε₀) tendsto_const_nhds ?_).mono fun n ↦
       lt_of_le_of_lt ?_)
   on_goal 2 =>
@@ -72,7 +72,8 @@ private lemma aux₀
       ENNReal.ofReal (4⁻¹ ^ Fintype.card ι)
         = volume (closedBall (f (ε n) (hε' n)) (ε n / 4)) / volume (closedBall x (ε n)) := ?_
       _ ≤ volume (closure s ∩ closedBall x (ε n)) / volume (closedBall x (ε n)) := by
-        gcongr; exact subset_inter ((hf₁ _ $ hε' n).trans interior_subset_closure) $ hf₀ _ $ hε' n
+        gcongr
+        exact subset_inter ((hf₁ _ <| hε' n).trans interior_subset_closure) <| hf₀ _ <| hε' n
     have := hε' n
     rw [Real.volume_pi_closedBall, Real.volume_pi_closedBall, ← ENNReal.ofReal_div_of_pos,
       ← div_pow, mul_div_mul_left _ _ (two_ne_zero' ℝ), div_right_comm, div_self, one_div]
@@ -92,14 +93,14 @@ private lemma aux₁
   intro H
   obtain ⟨ε, -, hε', hε₀⟩ := exists_seq_strictAnti_tendsto_nhdsWithin (0 : ℝ)
   refine not_eventually.2
-      (Frequently.of_forall fun _ ↦ lt_irrefl $ 1 - ENNReal.ofReal (4⁻¹ ^ Fintype.card ι))
-      ((Filter.Tendsto.eventually_lt tendsto_const_nhds (H.comp hε₀) $
+      (Frequently.of_forall fun _ ↦ lt_irrefl <| 1 - ENNReal.ofReal (4⁻¹ ^ Fintype.card ι))
+      ((Filter.Tendsto.eventually_lt tendsto_const_nhds (H.comp hε₀) <|
             ENNReal.sub_lt_self ENNReal.one_ne_top one_ne_zero ?_).mono
         fun n ↦ lt_of_le_of_lt' ?_)
   on_goal 2 =>
     calc
       volume (closure s ∩ closedBall x (ε n)) / volume (closedBall x (ε n))
-        ≤ volume (closedBall x (ε n) \ closedBall (f (ε n) $ hε' n) (ε n / 4)) /
+        ≤ volume (closedBall x (ε n) \ closedBall (f (ε n) <| hε' n) (ε n / 4)) /
           volume (closedBall x (ε n)) := by
         gcongr
         rw [diff_eq_compl_inter]
@@ -124,9 +125,9 @@ theorem IsUpperSet.null_frontier (hs : IsUpperSet s) : volume (frontier s) = 0 :
   by_cases h : x ∈ closure s <;>
     simp only [mem_compl_iff, mem_setOf, h, not_false_eq_true, indicator_of_not_mem,
       indicator_of_mem, Pi.one_apply]
-  · refine aux₁ fun _ ↦ hs.compl.exists_subset_ball $ frontier_subset_closure ?_
+  · refine aux₁ fun _ ↦ hs.compl.exists_subset_ball <| frontier_subset_closure ?_
     rwa [frontier_compl]
-  · exact aux₀ fun _ ↦ hs.exists_subset_ball $ frontier_subset_closure hx
+  · exact aux₀ fun _ ↦ hs.exists_subset_ball <| frontier_subset_closure hx
 
 theorem IsLowerSet.null_frontier (hs : IsLowerSet s) : volume (frontier s) = 0 := by
   refine measure_mono_null (fun x hx ↦ ?_)
@@ -135,13 +136,13 @@ theorem IsLowerSet.null_frontier (hs : IsLowerSet s) : volume (frontier s) = 0 :
   by_cases h : x ∈ closure s <;>
     simp only [mem_compl_iff, mem_setOf, h, not_false_eq_true, indicator_of_not_mem,
       indicator_of_mem, Pi.one_apply]
-  · refine aux₁ fun _ ↦ hs.compl.exists_subset_ball $ frontier_subset_closure ?_
+  · refine aux₁ fun _ ↦ hs.compl.exists_subset_ball <| frontier_subset_closure ?_
     rwa [frontier_compl]
-  · exact aux₀ fun _ ↦ hs.exists_subset_ball $ frontier_subset_closure hx
+  · exact aux₀ fun _ ↦ hs.exists_subset_ball <| frontier_subset_closure hx
 
 theorem Set.OrdConnected.null_frontier (hs : s.OrdConnected) : volume (frontier s) = 0 := by
   rw [← hs.upperClosure_inter_lowerClosure]
-  exact measure_mono_null (frontier_inter_subset _ _) $ measure_union_null
+  exact measure_mono_null (frontier_inter_subset _ _) <| measure_union_null
     (measure_inter_null_of_null_left _ (UpperSet.upper _).null_frontier)
     (measure_inter_null_of_null_right _ (LowerSet.lower _).null_frontier)
 

--- a/Mathlib/MeasureTheory/OuterMeasure/AE.lean
+++ b/Mathlib/MeasureTheory/OuterMeasure/AE.lean
@@ -121,7 +121,7 @@ theorem ae_eq_trans {f g h : α → β} (h₁ : f =ᵐ[μ] g) (h₂ : g =ᵐ[μ]
   refine ⟨fun h a ha ↦ by simpa [ha] using (h {a}ᶜ).1, fun h s ↦ ⟨fun hs ↦ ?_, ?_⟩⟩
   · rw [← compl_empty_iff, ← not_nonempty_iff_eq_empty]
     rintro ⟨a, ha⟩
-    exact h _ $ measure_mono_null (singleton_subset_iff.2 ha) hs
+    exact h _ <| measure_mono_null (singleton_subset_iff.2 ha) hs
   · rintro rfl
     simp
 

--- a/Mathlib/NumberTheory/NumberField/Units/Basic.lean
+++ b/Mathlib/NumberTheory/NumberField/Units/Basic.lean
@@ -102,7 +102,7 @@ def torsion : Subgroup (𝓞 K)ˣ := CommGroup.torsion (𝓞 K)ˣ
 theorem mem_torsion {x : (𝓞 K)ˣ} [NumberField K] :
     x ∈ torsion K ↔ ∀ w : InfinitePlace K, w x = 1 := by
   rw [eq_iff_eq (x : K) 1, torsion, CommGroup.mem_torsion]
-  refine ⟨fun hx φ ↦ (((φ.comp $ algebraMap (𝓞 K) K).toMonoidHom.comp $
+  refine ⟨fun hx φ ↦ (((φ.comp <| algebraMap (𝓞 K) K).toMonoidHom.comp <|
     Units.coeHom _).isOfFinOrder hx).norm_eq_one, fun h ↦ isOfFinOrder_iff_pow_eq_one.2 ?_⟩
   obtain ⟨n, hn, hx⟩ := Embeddings.pow_eq_one_of_norm_eq_one K ℂ x.val.isIntegral_coe h
   exact ⟨n, hn, by ext; rw [NumberField.RingOfIntegers.coe_eq_algebraMap, coe_pow, hx,

--- a/Mathlib/Order/Antichain.lean
+++ b/Mathlib/Order/Antichain.lean
@@ -283,11 +283,11 @@ variable [PartialOrder α] [PartialOrder β] {f : α → β} {s : Set α}
 
 lemma IsAntichain.of_strictMonoOn_antitoneOn (hf : StrictMonoOn f s) (hf' : AntitoneOn f s) :
     IsAntichain (· ≤ ·) s :=
-  fun _a ha _b hb hab' hab ↦ (hf ha hb $ hab.lt_of_ne hab').not_le (hf' ha hb hab)
+  fun _a ha _b hb hab' hab ↦ (hf ha hb <| hab.lt_of_ne hab').not_le (hf' ha hb hab)
 
 lemma IsAntichain.of_monotoneOn_strictAntiOn (hf : MonotoneOn f s) (hf' : StrictAntiOn f s) :
     IsAntichain (· ≤ ·) s :=
-  fun _a ha _b hb hab' hab ↦ (hf ha hb hab).not_lt (hf' ha hb $ hab.lt_of_ne hab')
+  fun _a ha _b hb hab' hab ↦ (hf ha hb hab).not_lt (hf' ha hb <| hab.lt_of_ne hab')
 
 end General
 

--- a/Mathlib/Order/Basic.lean
+++ b/Mathlib/Order/Basic.lean
@@ -400,7 +400,7 @@ lemma exists_forall_ge_and [LinearOrder α] {p q : α → Prop} :
     (∃ i, ∀ j ≥ i, p j) → (∃ i, ∀ j ≥ i, q j) → ∃ i, ∀ j ≥ i, p j ∧ q j
   | ⟨a, ha⟩, ⟨b, hb⟩ =>
     let ⟨c, hac, hbc⟩ := exists_ge_of_linear a b
-    ⟨c, fun _d hcd ↦ ⟨ha _ $ hac.trans hcd, hb _ $ hbc.trans hcd⟩⟩
+    ⟨c, fun _d hcd ↦ ⟨ha _ <| hac.trans hcd, hb _ <| hbc.trans hcd⟩⟩
 
 theorem lt_imp_lt_of_le_imp_le {β} [LinearOrder α] [Preorder β] {a b : α} {c d : β}
     (H : a ≤ b → c ≤ d) (h : d < c) : b < a :=

--- a/Mathlib/Order/BooleanAlgebra.lean
+++ b/Mathlib/Order/BooleanAlgebra.lean
@@ -767,7 +767,7 @@ protected abbrev Function.Injective.booleanAlgebra [Sup α] [Inf α] [Top α] [B
   sdiff_eq a b := by
     refine hf ((map_sdiff _ _).trans (sdiff_eq.trans ?_))
     rw [map_inf, map_compl]
-  himp_eq a b := hf $ (map_himp _ _).trans $ himp_eq.trans $ by rw [map_sup, map_compl]
+  himp_eq a b := hf <| (map_himp _ _).trans <| himp_eq.trans <| by rw [map_sup, map_compl]
 
 end lift
 

--- a/Mathlib/Order/Category/BoolAlg.lean
+++ b/Mathlib/Order/Category/BoolAlg.lean
@@ -106,6 +106,6 @@ theorem boolAlg_dual_comp_forget_to_bddDistLat :
 /-- The powerset functor. `Set` as a contravariant functor. -/
 @[simps]
 def typeToBoolAlgOp : Type u ⥤ BoolAlgᵒᵖ where
-  obj X := op $ BoolAlg.of (Set X)
+  obj X := op <| BoolAlg.of (Set X)
   map {X Y} f := Quiver.Hom.op
     (CompleteLatticeHom.setPreimage f : BoundedLatticeHom (Set Y) (Set X))

--- a/Mathlib/Order/Directed.lean
+++ b/Mathlib/Order/Directed.lean
@@ -269,14 +269,14 @@ variable {f : α → β} {s : Set α}
 lemma constant_of_monotone_antitone [IsDirected α (· ≤ ·)] (hf : Monotone f) (hf' : Antitone f)
     (a b : α) : f a = f b := by
   obtain ⟨c, hac, hbc⟩ := exists_ge_ge a b
-  exact le_antisymm ((hf hac).trans $ hf' hbc) ((hf hbc).trans $ hf' hac)
+  exact le_antisymm ((hf hac).trans <| hf' hbc) ((hf hbc).trans <| hf' hac)
 
 /-- If `f` is monotone and antitone on a directed set `s`, then `f` is constant on `s`. -/
 lemma constant_of_monotoneOn_antitoneOn (hf : MonotoneOn f s) (hf' : AntitoneOn f s)
     (hs : DirectedOn (· ≤ ·) s) : ∀ ⦃a⦄, a ∈ s → ∀ ⦃b⦄, b ∈ s → f a = f b := by
   rintro a ha b hb
   obtain ⟨c, hc, hac, hbc⟩ := hs _ ha _ hb
-  exact le_antisymm ((hf ha hc hac).trans $ hf' hb hc hbc) ((hf hb hc hbc).trans $ hf' ha hc hac)
+  exact le_antisymm ((hf ha hc hac).trans <| hf' hb hc hbc) ((hf hb hc hbc).trans <| hf' ha hc hac)
 
 end Preorder
 

--- a/Mathlib/Order/Filter/AtTopBot.lean
+++ b/Mathlib/Order/Filter/AtTopBot.lean
@@ -793,7 +793,7 @@ end OrderedSemiring
 
 theorem zero_pow_eventuallyEq [MonoidWithZero α] :
     (fun n : ℕ => (0 : α) ^ n) =ᶠ[atTop] fun _ => 0 :=
-  eventually_atTop.2 ⟨1, fun _n hn ↦ zero_pow $ Nat.one_le_iff_ne_zero.1 hn⟩
+  eventually_atTop.2 ⟨1, fun _n hn ↦ zero_pow <| Nat.one_le_iff_ne_zero.1 hn⟩
 
 section OrderedRing
 

--- a/Mathlib/Order/Filter/CountableSeparatingOn.lean
+++ b/Mathlib/Order/Filter/CountableSeparatingOn.lean
@@ -127,13 +127,13 @@ theorem HasCountableSeparatingOn.subtype_iff {α : Type*} {p : Set α → Prop} 
     HasCountableSeparatingOn t (fun u ↦ ∃ v, p v ∧ (↑) ⁻¹' v = u) univ ↔
     HasCountableSeparatingOn α p t := by
   constructor <;> intro h
-  · exact h.of_subtype $ fun s ↦ id
+  · exact h.of_subtype <| fun s ↦ id
   rcases h with ⟨S, Sct, Sp, hS⟩
   use {Subtype.val ⁻¹' s | s ∈ S}, Sct.image _, ?_, ?_
   · rintro u ⟨t, tS, rfl⟩
     exact ⟨t, Sp _ tS, rfl⟩
   rintro x - y - hxy
-  exact Subtype.val_injective $ hS _ (Subtype.coe_prop _) _ (Subtype.coe_prop _)
+  exact Subtype.val_injective <| hS _ (Subtype.coe_prop _) _ (Subtype.coe_prop _)
     fun s hs ↦ hxy (Subtype.val ⁻¹' s) ⟨s, hs, rfl⟩
 
 namespace Filter

--- a/Mathlib/Order/Filter/Curry.lean
+++ b/Mathlib/Order/Filter/Curry.lean
@@ -79,11 +79,11 @@ theorem frequently_curry_prod_iff {α β : Type*} {l : Filter α} {m : Filter β
   refine ⟨fun h => ?_, fun ⟨hs, ht⟩ => ?_⟩
   · exact frequently_prod_and.mp (Frequently.filter_mono h curry_le_prod)
   rw [frequently_curry_iff]
-  exact Frequently.mono hs $ fun x hx => Frequently.mono ht (by simp[hx])
+  exact Frequently.mono hs <| fun x hx => Frequently.mono ht (by simp [hx])
 
 theorem prod_mem_curry {α β : Type*} {l : Filter α} {m : Filter β} {s : Set α} {t : Set β}
     (hs : s ∈ l) (ht : t ∈ m) : s ×ˢ t ∈ l.curry m :=
-  curry_le_prod $ prod_mem_prod hs ht
+  curry_le_prod <| prod_mem_prod hs ht
 
 theorem eventually_curry_prod_iff {α β : Type*} {l : Filter α} {m : Filter β}
     [NeBot l] [NeBot m] (s : Set α) (t : Set β) :

--- a/Mathlib/Order/Interval/Finset/Nat.lean
+++ b/Mathlib/Order/Interval/Finset/Nat.lean
@@ -83,7 +83,7 @@ theorem card_Ioo : (Ioo a b).card = b - a - 1 :=
 
 @[simp]
 theorem card_uIcc : (uIcc a b).card = (b - a : ℤ).natAbs + 1 :=
-  (card_Icc _ _).trans $ by rw [← Int.natCast_inj, sup_eq_max, inf_eq_min, Int.ofNat_sub] <;> omega
+  (card_Icc _ _).trans <| by rw [← Int.natCast_inj, sup_eq_max, inf_eq_min, Int.ofNat_sub] <;> omega
 
 @[simp]
 lemma card_Iic : (Iic b).card = b + 1 := by rw [Iic_eq_Icc, card_Icc, Nat.bot_eq_zero, Nat.sub_zero]
@@ -199,7 +199,7 @@ theorem mod_injOn_Ico (n a : ℕ) : Set.InjOn (· % a) (Finset.Ico n (n + a)) :=
   rw [Ico_succ_left_eq_erase_Ico, succ_add, succ_eq_add_one,
     Ico_succ_right_eq_insert_Ico (by omega)]
   rintro k hk l hl (hkl : k % a = l % a)
-  have ha : 0 < a := Nat.pos_iff_ne_zero.2 $ by rintro rfl; simp at hk
+  have ha : 0 < a := Nat.pos_iff_ne_zero.2 <| by rintro rfl; simp at hk
   simp only [Finset.mem_coe, Finset.mem_insert, Finset.mem_erase] at hk hl
   rcases hk with ⟨hkn, rfl | hk⟩ <;> rcases hl with ⟨hln, rfl | hl⟩
   · rfl

--- a/Mathlib/Order/Interval/Set/Image.lean
+++ b/Mathlib/Order/Interval/Set/Image.lean
@@ -431,18 +431,18 @@ lemma directedOn_le_Iic (b : α) : DirectedOn (· ≤ ·) (Iic b) :=
   fun _x hx _y hy ↦ ⟨b, le_rfl, hx, hy⟩
 
 lemma directedOn_le_Icc (a b : α) : DirectedOn (· ≤ ·) (Icc a b) :=
-  fun _x hx _y hy ↦ ⟨b, right_mem_Icc.2 $ hx.1.trans hx.2, hx.2, hy.2⟩
+  fun _x hx _y hy ↦ ⟨b, right_mem_Icc.2 <| hx.1.trans hx.2, hx.2, hy.2⟩
 
 lemma directedOn_le_Ioc (a b : α) : DirectedOn (· ≤ ·) (Ioc a b) :=
-  fun _x hx _y hy ↦ ⟨b, right_mem_Ioc.2 $ hx.1.trans_le hx.2, hx.2, hy.2⟩
+  fun _x hx _y hy ↦ ⟨b, right_mem_Ioc.2 <| hx.1.trans_le hx.2, hx.2, hy.2⟩
 
 lemma directedOn_ge_Ici (a : α) : DirectedOn (· ≥ ·) (Ici a) :=
   fun _x hx _y hy ↦ ⟨a, le_rfl, hx, hy⟩
 
 lemma directedOn_ge_Icc (a b : α) : DirectedOn (· ≥ ·) (Icc a b) :=
-  fun _x hx _y hy ↦ ⟨a, left_mem_Icc.2 $ hx.1.trans hx.2, hx.1, hy.1⟩
+  fun _x hx _y hy ↦ ⟨a, left_mem_Icc.2 <| hx.1.trans hx.2, hx.1, hy.1⟩
 
 lemma directedOn_ge_Ico (a b : α) : DirectedOn (· ≥ ·) (Ico a b) :=
-  fun _x hx _y hy ↦ ⟨a, left_mem_Ico.2 $ hx.1.trans_lt hx.2, hx.1, hy.1⟩
+  fun _x hx _y hy ↦ ⟨a, left_mem_Ico.2 <| hx.1.trans_lt hx.2, hx.1, hy.1⟩
 
 end Preorder

--- a/Mathlib/Order/Part.lean
+++ b/Mathlib/Order/Part.lean
@@ -47,10 +47,10 @@ section seq
 variable {β γ : Type _} {f : α → Part (β → γ)} {g : α → Part β}
 
 lemma Monotone.partSeq (hf : Monotone f) (hg : Monotone g) : Monotone fun x ↦ f x <*> g x := by
-  simpa only [seq_eq_bind_map] using hf.partBind $ Monotone.of_apply₂ fun _ ↦ hg.partMap
+  simpa only [seq_eq_bind_map] using hf.partBind <| Monotone.of_apply₂ fun _ ↦ hg.partMap
 
 lemma Antitone.partSeq (hf : Antitone f) (hg : Antitone g) : Antitone fun x ↦ f x <*> g x := by
-  simpa only [seq_eq_bind_map] using hf.partBind $ Antitone.of_apply₂ fun _ ↦ hg.partMap
+  simpa only [seq_eq_bind_map] using hf.partBind <| Antitone.of_apply₂ fun _ ↦ hg.partMap
 
 end seq
 

--- a/Mathlib/Order/RelSeries.lean
+++ b/Mathlib/Order/RelSeries.lean
@@ -184,7 +184,7 @@ theorem subsingleton_of_length_eq_zero (hs : s.length = 0) : {x | x ∈ s}.Subsi
   exact finCongr (by rw [hs, zero_add]) |>.injective <| Subsingleton.elim (α := Fin 1) _ _
 
 theorem length_ne_zero_of_nontrivial (h : {x | x ∈ s}.Nontrivial) : s.length ≠ 0 :=
-  fun hs ↦ h.not_subsingleton $ subsingleton_of_length_eq_zero hs
+  fun hs ↦ h.not_subsingleton <| subsingleton_of_length_eq_zero hs
 
 theorem length_pos_of_nontrivial (h : {x | x ∈ s}.Nontrivial) : 0 < s.length :=
   Nat.pos_iff_ne_zero.mpr <| length_ne_zero_of_nontrivial h

--- a/Mathlib/Order/SuccPred/Basic.lean
+++ b/Mathlib/Order/SuccPred/Basic.lean
@@ -266,7 +266,7 @@ theorem succ_mono : Monotone (succ : α → α) := fun _ _ => succ_le_succ
 lemma le_succ_of_wcovBy (h : a ⩿ b) : b ≤ succ a := by
   obtain hab | ⟨-, hba⟩ := h.covBy_or_le_and_le
   · by_contra hba
-    exact h.2 (lt_succ_of_not_isMax hab.lt.not_isMax) $ hab.lt.succ_le.lt_of_not_le hba
+    exact h.2 (lt_succ_of_not_isMax hab.lt.not_isMax) <| hab.lt.succ_le.lt_of_not_le hba
   · exact hba.trans (le_succ _)
 
 alias _root_.WCovBy.le_succ := le_succ_of_wcovBy

--- a/Mathlib/Order/SupClosed.lean
+++ b/Mathlib/Order/SupClosed.lean
@@ -315,8 +315,8 @@ protected lemma Set.Finite.supClosure (hs : s.Finite) : (supClosure s).Finite :=
 
 @[simp] lemma supClosure_prod (s : Set α) (t : Set β) :
     supClosure (s ×ˢ t) = supClosure s ×ˢ supClosure t :=
-  le_antisymm (supClosure_min (Set.prod_mono subset_supClosure subset_supClosure) $
-    supClosed_supClosure.prod supClosed_supClosure) $ by
+  le_antisymm (supClosure_min (Set.prod_mono subset_supClosure subset_supClosure) <|
+    supClosed_supClosure.prod supClosed_supClosure) <| by
       rintro ⟨_, _⟩ ⟨⟨u, hu, hus, rfl⟩, v, hv, hvt, rfl⟩
       refine ⟨u ×ˢ v, hu.product hv, ?_, ?_⟩
       · simpa only [coe_product] using Set.prod_mono hus hvt
@@ -387,8 +387,8 @@ protected lemma Set.Finite.infClosure (hs : s.Finite) : (infClosure s).Finite :=
 
 @[simp] lemma infClosure_prod (s : Set α) (t : Set β) :
     infClosure (s ×ˢ t) = infClosure s ×ˢ infClosure t :=
-  le_antisymm (infClosure_min (Set.prod_mono subset_infClosure subset_infClosure) $
-    infClosed_infClosure.prod infClosed_infClosure) $ by
+  le_antisymm (infClosure_min (Set.prod_mono subset_infClosure subset_infClosure) <|
+    infClosed_infClosure.prod infClosed_infClosure) <| by
       rintro ⟨_, _⟩ ⟨⟨u, hu, hus, rfl⟩, v, hv, hvt, rfl⟩
       refine ⟨u ×ˢ v, hu.product hv, ?_, ?_⟩
       · simpa only [coe_product] using Set.prod_mono hus hvt

--- a/Mathlib/Order/UpperLower/Basic.lean
+++ b/Mathlib/Order/UpperLower/Basic.lean
@@ -536,7 +536,7 @@ instance completeLattice : CompleteLattice (UpperSet α) :=
     (fun _ _ => rfl) (fun _ => rfl) (fun _ => rfl) rfl rfl
 
 instance completelyDistribLattice : CompletelyDistribLattice (UpperSet α) :=
-  .ofMinimalAxioms $
+  .ofMinimalAxioms <|
     (toDual.injective.comp SetLike.coe_injective).completelyDistribLatticeMinimalAxioms .of _
       (fun _ _ => rfl) (fun _ _ => rfl) (fun _ => rfl) (fun _ => rfl) rfl rfl
 
@@ -671,7 +671,7 @@ instance completeLattice : CompleteLattice (LowerSet α) :=
     (fun _ => rfl) rfl rfl
 
 instance completelyDistribLattice : CompletelyDistribLattice (LowerSet α) :=
-  .ofMinimalAxioms $ SetLike.coe_injective.completelyDistribLatticeMinimalAxioms .of _
+  .ofMinimalAxioms <| SetLike.coe_injective.completelyDistribLatticeMinimalAxioms .of _
     (fun _ _ => rfl) (fun _ _ => rfl) (fun _ => rfl) (fun _ => rfl) rfl rfl
 
 instance : Inhabited (LowerSet α) :=

--- a/Mathlib/RingTheory/Flat/Basic.lean
+++ b/Mathlib/RingTheory/Flat/Basic.lean
@@ -281,7 +281,7 @@ lemma lTensor_exact [Small.{v} R] [flat : Flat R M] ⦃N N' N'' : Type v⦄
   suffices exact1 : Function.Exact (f.lTensor M) (π.lTensor M) by
     rw [show g = ι.comp π by aesop, lTensor_comp]
     exact exact1.comp_injective
-      (inj := iff_lTensor_preserves_injective_linearMap R M |>.mp flat _ $ by
+      (inj := iff_lTensor_preserves_injective_linearMap R M |>.mp flat _ <| by
         simpa [ι] using Subtype.val_injective)
       (h0 := map_zero _)
 
@@ -301,7 +301,7 @@ lemma rTensor_exact [Small.{v} R] [flat : Flat R M] ⦃N N' N'' : Type v⦄
   suffices exact1 : Function.Exact (f.rTensor M) (π.rTensor M) by
     rw [show g = ι.comp π by aesop, rTensor_comp]
     exact exact1.comp_injective
-      (inj := iff_rTensor_preserves_injective_linearMap R M |>.mp flat _ $ by
+      (inj := iff_rTensor_preserves_injective_linearMap R M |>.mp flat _ <| by
         simpa [ι] using Subtype.val_injective)
       (h0 := map_zero _)
 

--- a/Mathlib/RingTheory/Flat/CategoryTheory.lean
+++ b/Mathlib/RingTheory/Flat/CategoryTheory.lean
@@ -36,32 +36,32 @@ namespace Module.Flat
 
 variable {R : Type u} [CommRing R] (M : ModuleCat.{u} R)
 
-lemma lTensor_shortComplex_exact [Flat R M] (C : ShortComplex $ ModuleCat R) (hC : C.Exact) :
+lemma lTensor_shortComplex_exact [Flat R M] (C : ShortComplex <| ModuleCat R) (hC : C.Exact) :
     C.map (tensorLeft M) |>.Exact := by
   rw [moduleCat_exact_iff_function_exact] at hC ⊢
   exact lTensor_exact M hC
 
-lemma rTensor_shortComplex_exact [Flat R M] (C : ShortComplex $ ModuleCat R) (hC : C.Exact) :
+lemma rTensor_shortComplex_exact [Flat R M] (C : ShortComplex <| ModuleCat R) (hC : C.Exact) :
     C.map (tensorRight M) |>.Exact := by
   rw [moduleCat_exact_iff_function_exact] at hC ⊢
   exact rTensor_exact M hC
 
 lemma iff_lTensor_preserves_shortComplex_exact :
     Flat R M ↔
-    ∀ (C : ShortComplex $ ModuleCat R) (_ : C.Exact), (C.map (tensorLeft M) |>.Exact) :=
-  ⟨fun _ _ ↦ lTensor_shortComplex_exact _ _, fun H ↦ iff_lTensor_exact.2 $
+    ∀ (C : ShortComplex <| ModuleCat R) (_ : C.Exact), (C.map (tensorLeft M) |>.Exact) :=
+  ⟨fun _ _ ↦ lTensor_shortComplex_exact _ _, fun H ↦ iff_lTensor_exact.2 <|
     fun _ _ _ _ _ _ _ _ _ f g h ↦
-      moduleCat_exact_iff_function_exact _ |>.1 $
+      moduleCat_exact_iff_function_exact _ |>.1 <|
       H (.mk (ModuleCat.ofHom f) (ModuleCat.ofHom g)
         (DFunLike.ext _ _ h.apply_apply_eq_zero))
           (moduleCat_exact_iff_function_exact _ |>.2 h)⟩
 
 lemma iff_rTensor_preserves_shortComplex_exact :
     Flat R M ↔
-    ∀ (C : ShortComplex $ ModuleCat R) (_ : C.Exact), (C.map (tensorRight M) |>.Exact) :=
-  ⟨fun _ _ ↦ rTensor_shortComplex_exact _ _, fun H ↦ iff_rTensor_exact.2 $
+    ∀ (C : ShortComplex <| ModuleCat R) (_ : C.Exact), (C.map (tensorRight M) |>.Exact) :=
+  ⟨fun _ _ ↦ rTensor_shortComplex_exact _ _, fun H ↦ iff_rTensor_exact.2 <|
     fun _ _ _ _ _ _ _ _ _ f g h ↦
-      moduleCat_exact_iff_function_exact _ |>.1 $
+      moduleCat_exact_iff_function_exact _ |>.1 <|
       H (.mk (ModuleCat.ofHom f) (ModuleCat.ofHom g)
         (DFunLike.ext _ _ h.apply_apply_eq_zero))
           (moduleCat_exact_iff_function_exact _ |>.2 h)⟩

--- a/Mathlib/RingTheory/HahnSeries/Summable.lean
+++ b/Mathlib/RingTheory/HahnSeries/Summable.lean
@@ -505,7 +505,7 @@ instance instField [Field R] : Field (HahnSeries Γ R) where
       (single (-x.order)) (x.leadingCoeff)⁻¹ *
         (SummableFamily.powers _ (unit_aux x (inv_mul_cancel₀ (leadingCoeff_ne_iff.mpr x0)))).hsum
   inv_zero := dif_pos rfl
-  mul_inv_cancel x x0 := (congr rfl (dif_neg x0)).trans $ by
+  mul_inv_cancel x x0 := (congr rfl (dif_neg x0)).trans <| by
     have h :=
       SummableFamily.one_sub_self_mul_hsum_powers
         (unit_aux x (inv_mul_cancel₀ (leadingCoeff_ne_iff.mpr x0)))

--- a/Mathlib/RingTheory/Ideal/Operations.lean
+++ b/Mathlib/RingTheory/Ideal/Operations.lean
@@ -1093,7 +1093,7 @@ theorem subset_union_prime' {R : Type u} [CommRing R] {s : Finset ι} {f : ι �
     · rw [Set.mem_iUnion₂] at ht
       rcases ht with ⟨j, hjt, hj⟩
       simp only [Finset.inf_eq_iInf, SetLike.mem_coe, Submodule.mem_iInf] at hr
-      exact hs $ Or.inr $ Set.mem_biUnion hjt <|
+      exact hs <| Or.inr <| Set.mem_biUnion hjt <|
         add_sub_cancel_left r s ▸ (f j).sub_mem hj <| hr j hjt
 
 /-- Prime avoidance. Atiyah-Macdonald 1.11, Eisenbud 3.3, Stacks 00DS, Matsumura Ex.1.6. -/

--- a/Mathlib/RingTheory/Polynomial/Bernstein.lean
+++ b/Mathlib/RingTheory/Polynomial/Bernstein.lean
@@ -87,7 +87,7 @@ theorem eval_at_1 (n ν : ℕ) : (bernsteinPolynomial R n ν).eval 1 = if ν = n
   split_ifs with h
   · subst h; simp
   · obtain hνn | hnν := Ne.lt_or_lt h
-    · simp [zero_pow $ Nat.sub_ne_zero_of_lt hνn]
+    · simp [zero_pow <| Nat.sub_ne_zero_of_lt hνn]
     · simp [Nat.choose_eq_zero_of_lt hnν]
 
 theorem derivative_succ_aux (n ν : ℕ) :

--- a/Mathlib/RingTheory/Polynomial/Cyclotomic/Expand.lean
+++ b/Mathlib/RingTheory/Polynomial/Cyclotomic/Expand.lean
@@ -167,7 +167,7 @@ theorem isRoot_cyclotomic_prime_pow_mul_iff_of_charP {m k p : ℕ} {R : Type*} [
   · rw [← isRoot_cyclotomic_iff, IsRoot.def] at h
     rw [cyclotomic_mul_prime_pow_eq R (NeZero.not_char_dvd R p m) hk, IsRoot.def, eval_pow,
       h, zero_pow]
-    exact Nat.sub_ne_zero_of_lt $ pow_right_strictMono hp.out.one_lt $ Nat.pred_lt hk.ne'
+    exact Nat.sub_ne_zero_of_lt <| pow_right_strictMono hp.out.one_lt <| Nat.pred_lt hk.ne'
 
 end CharP
 

--- a/Mathlib/RingTheory/TwoSidedIdeal/Basic.lean
+++ b/Mathlib/RingTheory/TwoSidedIdeal/Basic.lean
@@ -83,7 +83,7 @@ def orderIsoRingCon : TwoSidedIdeal R ≃o RingCon R where
   invFun := .mk
   left_inv _ := rfl
   right_inv _ := rfl
-  map_rel_iff' {I J} := Iff.symm $ le_iff.trans ⟨fun h x y r => by rw [rel_iff] at r ⊢; exact h r,
+  map_rel_iff' {I J} := Iff.symm <| le_iff.trans ⟨fun h x y r => by rw [rel_iff] at r ⊢; exact h r,
     fun h x hx => by rw [SetLike.mem_coe, mem_iff] at hx ⊢; exact h hx⟩
 
 lemma ringCon_injective : Function.Injective (TwoSidedIdeal.ringCon (R := R)) := by

--- a/Mathlib/RingTheory/TwoSidedIdeal/Lattice.lean
+++ b/Mathlib/RingTheory/TwoSidedIdeal/Lattice.lean
@@ -73,7 +73,7 @@ lemma mem_inf {I J : TwoSidedIdeal R} {x : R} :
   Iff.rfl
 
 instance : SupSet (TwoSidedIdeal R) where
-  sSup s := { ringCon := sSup $ TwoSidedIdeal.ringCon '' s }
+  sSup s := { ringCon := sSup <| TwoSidedIdeal.ringCon '' s }
 
 lemma sSup_ringCon (S : Set (TwoSidedIdeal R)) :
     (sSup S).ringCon = sSup (TwoSidedIdeal.ringCon '' S) := rfl
@@ -83,11 +83,11 @@ lemma iSup_ringCon {ι : Type*} (I : ι → TwoSidedIdeal R) :
   simp only [iSup, sSup_ringCon]; congr; ext; simp
 
 instance : CompleteSemilatticeSup (TwoSidedIdeal R) where
-  sSup_le s I h := by simp_rw [ringCon_le_iff] at h ⊢; exact sSup_le $ by aesop
-  le_sSup s I hI := by rw [ringCon_le_iff]; exact le_sSup $ by aesop
+  sSup_le s I h := by simp_rw [ringCon_le_iff] at h ⊢; exact sSup_le <| by aesop
+  le_sSup s I hI := by rw [ringCon_le_iff]; exact le_sSup <| by aesop
 
 instance : InfSet (TwoSidedIdeal R) where
-  sInf s := { ringCon := sInf $ TwoSidedIdeal.ringCon '' s }
+  sInf s := { ringCon := sInf <| TwoSidedIdeal.ringCon '' s }
 
 lemma sInf_ringCon (S : Set (TwoSidedIdeal R)) :
     (sInf S).ringCon = sInf (TwoSidedIdeal.ringCon '' S) := rfl
@@ -97,8 +97,8 @@ lemma iInf_ringCon {ι : Type*} (I : ι → TwoSidedIdeal R) :
   simp only [iInf, sInf_ringCon]; congr!; ext; simp
 
 instance : CompleteSemilatticeInf (TwoSidedIdeal R) where
-  le_sInf s I h := by simp_rw [ringCon_le_iff] at h ⊢; exact le_sInf $ by aesop
-  sInf_le s I hI := by rw [ringCon_le_iff]; exact sInf_le $ by aesop
+  le_sInf s I h := by simp_rw [ringCon_le_iff] at h ⊢; exact le_sInf <| by aesop
+  sInf_le s I hI := by rw [ringCon_le_iff]; exact sInf_le <| by aesop
 
 lemma mem_iInf {ι : Type*} {I : ι → TwoSidedIdeal R} {x : R} :
     x ∈ iInf I ↔ ∀ i, x ∈ I i :=

--- a/Mathlib/RingTheory/WittVector/DiscreteValuationRing.lean
+++ b/Mathlib/RingTheory/WittVector/DiscreteValuationRing.lean
@@ -120,7 +120,7 @@ theorem exists_eq_pow_p_mul (a : 𝕎 k) (ha : a ≠ 0) :
   rw [← this] at hcm
   refine ⟨m, b, ?_, ?_⟩
   · contrapose! hc
-    simp [hc, zero_pow $ pow_ne_zero _ hp.out.ne_zero]
+    simp [hc, zero_pow <| pow_ne_zero _ hp.out.ne_zero]
   · simp_rw [← mul_left_iterate (p : 𝕎 k) m]
     convert hcm using 2
     ext1 x

--- a/Mathlib/RingTheory/WittVector/InitTail.lean
+++ b/Mathlib/RingTheory/WittVector/InitTail.lean
@@ -101,7 +101,7 @@ theorem select_add_select_not : ∀ x : 𝕎 R, select P x + select (fun i => ¬
   refine fun m _ => mul_eq_mul_left_iff.mpr (Or.inl ?_)
   rw [ite_pow, zero_pow (pow_ne_zero _ hp.out.ne_zero)]
   by_cases Pm : P m
-  · rw [if_pos Pm, if_neg $ not_not_intro Pm, zero_pow Fin.size_pos'.ne', add_zero]
+  · rw [if_pos Pm, if_neg <| not_not_intro Pm, zero_pow Fin.size_pos'.ne', add_zero]
   · rwa [if_neg Pm, if_pos, zero_add]
 
 theorem coeff_add_of_disjoint (x y : 𝕎 R) (h : ∀ n, x.coeff n = 0 ∨ y.coeff n = 0) :

--- a/Mathlib/SetTheory/Game/Basic.lean
+++ b/Mathlib/SetTheory/Game/Basic.lean
@@ -198,7 +198,7 @@ lemma bddAbove_range_of_small {ι : Type*} [Small.{u} ι] (f : ι → Game.{u}) 
     BddAbove (Set.range f) := by
   obtain ⟨x, hx⟩ := PGame.bddAbove_range_of_small (Quotient.out ∘ f)
   refine ⟨⟦x⟧, Set.forall_mem_range.2 fun i ↦ ?_⟩
-  simpa [PGame.le_iff_game_le] using hx $ Set.mem_range_self i
+  simpa [PGame.le_iff_game_le] using hx <| Set.mem_range_self i
 
 /-- A small set of games is bounded above. -/
 lemma bddAbove_of_small (s : Set Game.{u}) [Small.{u} s] : BddAbove s := by
@@ -209,7 +209,7 @@ lemma bddBelow_range_of_small {ι : Type*} [Small.{u} ι] (f : ι → Game.{u}) 
     BddBelow (Set.range f) := by
   obtain ⟨x, hx⟩ := PGame.bddBelow_range_of_small (Quotient.out ∘ f)
   refine ⟨⟦x⟧, Set.forall_mem_range.2 fun i ↦ ?_⟩
-  simpa [PGame.le_iff_game_le] using hx $ Set.mem_range_self i
+  simpa [PGame.le_iff_game_le] using hx <| Set.mem_range_self i
 
 /-- A small set of games is bounded below. -/
 lemma bddBelow_of_small (s : Set Game.{u}) [Small.{u} s] : BddBelow s := by

--- a/Mathlib/SetTheory/Game/PGame.lean
+++ b/Mathlib/SetTheory/Game/PGame.lean
@@ -638,7 +638,7 @@ theorem leftResponse_spec {x : PGame} (h : 0 ≤ x) (j : x.RightMoves) :
 /-- A small family of pre-games is bounded above. -/
 lemma bddAbove_range_of_small {ι : Type*} [Small.{u} ι] (f : ι → PGame.{u}) :
     BddAbove (Set.range f) := by
-  let x : PGame.{u} := ⟨Σ i, (f $ (equivShrink.{u} ι).symm i).LeftMoves, PEmpty,
+  let x : PGame.{u} := ⟨Σ i, (f <| (equivShrink.{u} ι).symm i).LeftMoves, PEmpty,
     fun x ↦ moveLeft _ x.2, PEmpty.elim⟩
   refine ⟨x, Set.forall_mem_range.2 fun i ↦ ?_⟩
   rw [← (equivShrink ι).symm_apply_apply i, le_iff_forall_lf]
@@ -651,7 +651,7 @@ lemma bddAbove_of_small (s : Set PGame.{u}) [Small.{u} s] : BddAbove s := by
 /-- A small family of pre-games is bounded below. -/
 lemma bddBelow_range_of_small {ι : Type*} [Small.{u} ι] (f : ι → PGame.{u}) :
     BddBelow (Set.range f) := by
-  let x : PGame.{u} := ⟨PEmpty, Σ i, (f $ (equivShrink.{u} ι).symm i).RightMoves, PEmpty.elim,
+  let x : PGame.{u} := ⟨PEmpty, Σ i, (f <| (equivShrink.{u} ι).symm i).RightMoves, PEmpty.elim,
     fun x ↦ moveRight _ x.2⟩
   refine ⟨x, Set.forall_mem_range.2 fun i ↦ ?_⟩
   rw [← (equivShrink ι).symm_apply_apply i, le_iff_forall_lf]

--- a/Mathlib/Tactic/Cases.lean
+++ b/Mathlib/Tactic/Cases.lean
@@ -57,7 +57,7 @@ def ElimApp.evalNames (elimInfo : ElimInfo) (alts : Array ElimApp.Alt) (withArg 
     let (introduced, g) ← g.introNP generalized.size
     let subst := (generalized.zip introduced).foldl (init := subst) fun subst (a, b) =>
       subst.insert a (.fvar b)
-    let g ← liftM $ toClear.foldlM (·.tryClear) g
+    let g ← liftM <| toClear.foldlM (·.tryClear) g
     g.withContext do
       for (stx, fvar) in toTag do
         Term.addLocalVarInfo stx (subst.get fvar)

--- a/Mathlib/Tactic/FunProp/RefinedDiscrTree.lean
+++ b/Mathlib/Tactic/FunProp/RefinedDiscrTree.lean
@@ -135,16 +135,16 @@ inductive Key where
   deriving Inhabited, BEq, Repr
 
 private nonrec def Key.hash : Key → UInt64
-  | .star i     => mixHash 7883 $ hash i
+  | .star i     => mixHash 7883 <| hash i
   | .opaque     => 342
-  | .const n a  => mixHash 5237 $ mixHash (hash n) (hash a)
-  | .fvar  n a  => mixHash 8765 $ mixHash (hash n) (hash a)
-  | .bvar i a   => mixHash 4323 $ mixHash (hash i) (hash a)
-  | .lit v      => mixHash 1879 $ hash v
+  | .const n a  => mixHash 5237 <| mixHash (hash n) (hash a)
+  | .fvar  n a  => mixHash 8765 <| mixHash (hash n) (hash a)
+  | .bvar i a   => mixHash 4323 <| mixHash (hash i) (hash a)
+  | .lit v      => mixHash 1879 <| hash v
   | .sort       => 2411
   | .lam        => 4742
   | .«forall»   => 9752
-  | .proj s i a => mixHash (hash a) $ mixHash (hash s) (hash i)
+  | .proj s i a => mixHash (hash a) <| mixHash (hash s) (hash i)
 
 instance : Hashable Key := ⟨Key.hash⟩
 
@@ -242,7 +242,7 @@ def Trie.children! : Trie α → Array (Key × Trie α)
   | .values _ => panic! "did not expect .values constructor"
 
 private partial def Trie.format [ToFormat α] : Trie α → Format
-  | .node cs => Format.group $ Format.paren $
+  | .node cs => Format.group <| Format.paren <|
     "node " ++ Format.join (cs.toList.map fun (k, c) =>
       Format.line ++ Format.paren (format (prepend k c)))
   | .values vs => if vs.isEmpty then Format.nil else Std.format vs
@@ -708,7 +708,7 @@ partial def mkDTExprAux (e : Expr) (root : Bool) : ReaderT Context MetaM DTExpr 
   | _           => unreachable!
 
 
-private abbrev M := StateListT (AssocList Expr DTExpr) $ ReaderT Context MetaM
+private abbrev M := StateListT (AssocList Expr DTExpr) <| ReaderT Context MetaM
 
 /-
 Caching values is a bit dangerous, because when two expressions are be equal and they live under
@@ -889,7 +889,7 @@ termination_by vs.size - i
 partial def insertInTrie [BEq α] (keys : Array Key) (v : α) (i : Nat) : Trie α → Trie α
   | .node cs =>
       let k := keys[i]!
-      let c := Id.run $ cs.binInsertM
+      let c := Id.run <| cs.binInsertM
         (fun a b => a.1 < b.1)
         (fun (k', s) => (k', insertInTrie keys v (i+1) s))
         (fun _ => (k, Trie.singleton keys v (i+1)))
@@ -982,7 +982,7 @@ private structure State where
   mvarAssignments : Std.HashMap MVarId (Array Key) := {}
 
 
-private abbrev M := ReaderT Context $ StateListM State
+private abbrev M := ReaderT Context <| StateListM State
 
 /-- Return all values from `x` in an array, together with their scores. -/
 private def M.run (unify : Bool) (config : WhnfCoreConfig) (x : M (Trie α)) :

--- a/Mathlib/Tactic/Positivity/Basic.lean
+++ b/Mathlib/Tactic/Positivity/Basic.lean
@@ -484,9 +484,9 @@ def evalRatNum : PositivityExt where eval {u α} _ _ e := do
     let pα : Q(PartialOrder ℚ) := q(inferInstance)
     assumeInstancesCommute
     match ← core zα pα a with
-    | .positive pa => pure $ .positive q(num_pos_of_pos $pa)
-    | .nonnegative pa => pure $ .nonnegative q(num_nonneg_of_nonneg $pa)
-    | .nonzero pa => pure $ .nonzero q(num_ne_zero_of_ne_zero $pa)
+    | .positive pa => pure <| .positive q(num_pos_of_pos $pa)
+    | .nonnegative pa => pure <| .nonnegative q(num_nonneg_of_nonneg $pa)
+    | .nonzero pa => pure <| .nonzero q(num_ne_zero_of_ne_zero $pa)
     | .none => pure .none
   | _, _ => throwError "not Rat.num"
 
@@ -496,7 +496,7 @@ def evalRatDen : PositivityExt where eval {u α} _ _ e := do
   match u, α, e with
   | 0, ~q(ℕ), ~q(Rat.den $a) =>
     assumeInstancesCommute
-    pure $ .positive q(den_pos $a)
+    pure <| .positive q(den_pos $a)
   | _, _ => throwError "not Rat.num"
 
 /-- Extension for `posPart`. `a⁺` is always nonegative, and positive if `a` is. -/

--- a/Mathlib/Tactic/Widget/InteractiveUnfold.lean
+++ b/Mathlib/Tactic/Widget/InteractiveUnfold.lean
@@ -161,7 +161,7 @@ def renderUnfolds (e : Expr) (occ : Option Nat) (loc : Option Name) (range : Lsp
         #[<span className="font-code" style={json% { "white-space" : "pre-wrap" }}> {
           Html.ofComponent MakeEditLink
             (.ofReplaceRange doc.meta range tactic)
-            #[.text $ Format.pretty $ (← Meta.ppExpr unfold)] }
+            #[.text <| Format.pretty <| (← Meta.ppExpr unfold)] }
         </span>]
       } </li>
   return <details «open»={true}>
@@ -221,7 +221,7 @@ Click on a suggestion to replace `unfold?` by a tactic that performs this rewrit
 elab stx:"unfold?" : tactic => do
   let some range := (← getFileMap).rangeOfStx? stx | return
   Widget.savePanelWidgetInfo (hash UnfoldComponent.javascript)
-    (pure $ json% { replaceRange : $range }) stx
+    (pure <| json% { replaceRange : $range }) stx
 
 /-- `#unfold? e` gives all unfolds of `e`.
 In tactic mode, use `unfold?` instead. -/

--- a/Mathlib/Topology/Basic.lean
+++ b/Mathlib/Topology/Basic.lean
@@ -1085,7 +1085,7 @@ theorem mem_closure_iff_nhdsWithin_neBot : x ∈ closure s ↔ NeBot (𝓝[s] x)
 lemma nhdsWithin_neBot : (𝓝[s] x).NeBot ↔ ∀ ⦃t⦄, t ∈ 𝓝 x → (t ∩ s).Nonempty := by
   rw [nhdsWithin, inf_neBot_iff]
   exact forall₂_congr fun U _ ↦
-    ⟨fun h ↦ h (mem_principal_self _), fun h u hsu ↦ h.mono $ inter_subset_inter_right _ hsu⟩
+    ⟨fun h ↦ h (mem_principal_self _), fun h u hsu ↦ h.mono <| inter_subset_inter_right _ hsu⟩
 
 @[gcongr]
 theorem nhdsWithin_mono (x : X) {s t : Set X} (h : s ⊆ t) : 𝓝[s] x ≤ 𝓝[t] x :=

--- a/Mathlib/Topology/Inseparable.lean
+++ b/Mathlib/Topology/Inseparable.lean
@@ -358,7 +358,7 @@ lemma specializingMap_iff_isClosed_image_closure_singleton (hf : Continuous f) :
   exact isClosed_closure
 
 lemma IsClosedMap.specializingMap (hf : IsClosedMap f) : SpecializingMap f :=
-  specializingMap_iff_stableUnderSpecialization_image_singleton.mpr $
+  specializingMap_iff_stableUnderSpecialization_image_singleton.mpr <|
     fun _ ↦ (hf _ isClosed_closure).stableUnderSpecialization
 
 lemma Inducing.specializingMap (hf : Inducing f) (h : StableUnderSpecialization (range f)) :

--- a/Mathlib/Topology/Order/Bornology.lean
+++ b/Mathlib/Topology/Order/Bornology.lean
@@ -71,10 +71,10 @@ protected lemma BddAbove.isBounded (hs₀ : BddAbove s) (hs₁ : BddBelow s) : I
   isBounded_iff_bddBelow_bddAbove.2 ⟨hs₁, hs₀⟩
 
 lemma BddBelow.isBounded_inter (hs : BddBelow s) (ht : BddAbove t) : IsBounded (s ∩ t) :=
-  (hs.mono inter_subset_left).isBounded $ ht.mono inter_subset_right
+  (hs.mono inter_subset_left).isBounded <| ht.mono inter_subset_right
 
 lemma BddAbove.isBounded_inter (hs : BddAbove s) (ht : BddBelow t) : IsBounded (s ∩ t) :=
-  (hs.mono inter_subset_left).isBounded $ ht.mono inter_subset_right
+  (hs.mono inter_subset_left).isBounded <| ht.mono inter_subset_right
 
 instance OrderDual.instIsOrderBornology : IsOrderBornology αᵒᵈ where
   isBounded_iff_bddBelow_bddAbove s := by

--- a/Mathlib/Topology/Order/IntermediateValue.lean
+++ b/Mathlib/Topology/Order/IntermediateValue.lean
@@ -641,7 +641,7 @@ theorem Continuous.strictMonoOn_of_inj_rigidity {f : α → δ}
   let t := max b y
   have hsa : s ≤ a := min_le_left a x
   have hbt : b ≤ t := le_max_left b y
-  have hst : s ≤ t := hsa.trans $ hbt.trans' hab.le
+  have hst : s ≤ t := hsa.trans <| hbt.trans' hab.le
   have hf_mono_st : StrictMonoOn f (Icc s t) ∨ StrictAntiOn f (Icc s t) := by
     letI := Icc.completeLinearOrder hst
     have := Continuous.strictMono_of_inj_boundedOrder' (f := Set.restrict (Icc s t) f)


### PR DESCRIPTION
The mathlib style guide requires using `<|` instead of `$`. The linter in #15909 will enforce this.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
