### PR TITLE
[Merged by Bors] - feat(Data/List/Sort): `List.Sorted.cons`

### DIFF
--- a/Mathlib/Data/List/Sort.lean
+++ b/Mathlib/Data/List/Sort.lean
@@ -74,7 +74,7 @@ nonrec theorem Sorted.cons {r : α → α → Prop} [IsTrans α r] {l : List α}
     (hab : r a b) (h : Sorted r (b :: l)) : Sorted r (a :: b :: l) :=
   h.cons <| forall_mem_cons.2 ⟨hab, fun _ hx => _root_.trans hab <| rel_of_sorted_cons h _ hx⟩
 
-theorem Sorted.cons_iff {r : α → α → Prop} [IsTrans α r] {l : List α} {a b : α} :
+theorem sorted_cons {r : α → α → Prop} [IsTrans α r] {l : List α} {a b : α} :
     Sorted r (b :: a :: l) ↔ r b a ∧ Sorted r (a :: l) := by
   constructor
   · intro h

--- a/Mathlib/Data/List/Sort.lean
+++ b/Mathlib/Data/List/Sort.lean
@@ -74,7 +74,7 @@ nonrec theorem Sorted.cons {r : α → α → Prop} [IsTrans α r] {l : List α}
     (hab : r a b) (h : Sorted r (b :: l)) : Sorted r (a :: b :: l) :=
   h.cons <| forall_mem_cons.2 ⟨hab, fun _ hx => _root_.trans hab <| rel_of_sorted_cons h _ hx⟩
 
-theorem sorted_cons {r : α → α → Prop} [IsTrans α r] {l : List α} {a b : α} :
+theorem sorted_cons_cons {r : α → α → Prop} [IsTrans α r] {l : List α} {a b : α} :
     Sorted r (b :: a :: l) ↔ r b a ∧ Sorted r (a :: l) := by
   constructor
   · intro h

--- a/Mathlib/Data/List/Sort.lean
+++ b/Mathlib/Data/List/Sort.lean
@@ -71,13 +71,21 @@ theorem rel_of_sorted_cons {a : α} {l : List α} : Sorted r (a :: l) → ∀ b 
   rel_of_pairwise_cons
 
 theorem Sorted.cons {r : α → α → Prop} [IsTrans α r] {l : List α} {a b : α}
-    (ha : Sorted r (a :: l)) (h : r b a) : Sorted r (b :: a :: l) := by
+    (h : r b a) (ha : Sorted r (a :: l)) : Sorted r (b :: a :: l) := by
   refine List.pairwise_cons.2 ⟨?_, ha⟩
   rintro c (_ | _)
   · exact h
   · apply trans h
     apply rel_of_sorted_cons ha
     assumption
+
+theorem Sorted.cons_iff {r : α → α → Prop} [IsTrans α r] {l : List α} {a b : α} :
+    r b a ∧ Sorted r (a :: l) ↔ Sorted r (b :: a :: l) := by
+  constructor
+  · rintro ⟨h, ha⟩
+    exact ha.cons h
+  · intro h
+    exact ⟨rel_of_sorted_cons h _ (mem_cons_self a _), h.of_cons⟩
 
 theorem Sorted.head!_le [Inhabited α] [Preorder α] {a : α} {l : List α} (h : Sorted (· < ·) l)
     (ha : a ∈ l) : l.head! ≤ a := by

--- a/Mathlib/Data/List/Sort.lean
+++ b/Mathlib/Data/List/Sort.lean
@@ -75,12 +75,12 @@ nonrec theorem Sorted.cons {r : α → α → Prop} [IsTrans α r] {l : List α}
   ha.cons <| forall_mem_cons.2 ⟨h, fun _ hx => _root_.trans h <| rel_of_sorted_cons ha _ hx⟩
 
 theorem Sorted.cons_iff {r : α → α → Prop} [IsTrans α r] {l : List α} {a b : α} :
-    r b a ∧ Sorted r (a :: l) ↔ Sorted r (b :: a :: l) := by
+    Sorted r (b :: a :: l) ↔ r b a ∧ Sorted r (a :: l) := by
   constructor
-  · rintro ⟨h, ha⟩
-    exact ha.cons h
   · intro h
     exact ⟨rel_of_sorted_cons h _ (mem_cons_self a _), h.of_cons⟩
+  · rintro ⟨h, ha⟩
+    exact ha.cons h
 
 theorem Sorted.head!_le [Inhabited α] [Preorder α] {a : α} {l : List α} (h : Sorted (· < ·) l)
     (ha : a ∈ l) : l.head! ≤ a := by

--- a/Mathlib/Data/List/Sort.lean
+++ b/Mathlib/Data/List/Sort.lean
@@ -70,9 +70,9 @@ theorem Sorted.tail {r : α → α → Prop} {l : List α} (h : Sorted r l) : So
 theorem rel_of_sorted_cons {a : α} {l : List α} : Sorted r (a :: l) → ∀ b ∈ l, r a b :=
   rel_of_pairwise_cons
 
-theorem Sorted.cons {r : α → α → Prop} [IsTrans α r] {l : List α} {a b : α}
+nonrec theorem Sorted.cons {r : α → α → Prop} [IsTrans α r] {l : List α} {a b : α}
     (h : r b a) (ha : Sorted r (a :: l)) : Sorted r (b :: a :: l) :=
-  Pairwise.cons (forall_mem_cons.2 ⟨h, fun _ hx => _root_.trans h <| rel_of_sorted_cons ha _ hx⟩) ha
+  ha.cons <| forall_mem_cons.2 ⟨h, fun _ hx => _root_.trans h <| rel_of_sorted_cons ha _ hx⟩
 
 theorem Sorted.cons_iff {r : α → α → Prop} [IsTrans α r] {l : List α} {a b : α} :
     r b a ∧ Sorted r (a :: l) ↔ Sorted r (b :: a :: l) := by

--- a/Mathlib/Data/List/Sort.lean
+++ b/Mathlib/Data/List/Sort.lean
@@ -71,13 +71,8 @@ theorem rel_of_sorted_cons {a : α} {l : List α} : Sorted r (a :: l) → ∀ b 
   rel_of_pairwise_cons
 
 theorem Sorted.cons {r : α → α → Prop} [IsTrans α r] {l : List α} {a b : α}
-    (h : r b a) (ha : Sorted r (a :: l)) : Sorted r (b :: a :: l) := by
-  refine List.pairwise_cons.2 ⟨?_, ha⟩
-  rintro c (_ | _)
-  · exact h
-  · apply trans h
-    apply rel_of_sorted_cons ha
-    assumption
+    (h : r b a) (ha : Sorted r (a :: l)) : Sorted r (b :: a :: l) :=
+  Pairwise.cons (forall_mem_cons.2 ⟨h, fun _ hx => _root_.trans h <| rel_of_sorted_cons ha _ hx⟩) ha
 
 theorem Sorted.cons_iff {r : α → α → Prop} [IsTrans α r] {l : List α} {a b : α} :
     r b a ∧ Sorted r (a :: l) ↔ Sorted r (b :: a :: l) := by

--- a/Mathlib/Data/List/Sort.lean
+++ b/Mathlib/Data/List/Sort.lean
@@ -70,6 +70,15 @@ theorem Sorted.tail {r : α → α → Prop} {l : List α} (h : Sorted r l) : So
 theorem rel_of_sorted_cons {a : α} {l : List α} : Sorted r (a :: l) → ∀ b ∈ l, r a b :=
   rel_of_pairwise_cons
 
+theorem Sorted.cons {r : α → α → Prop} [IsTrans α r] {l : List α} {a b : α}
+    (ha : Sorted r (a :: l)) (h : r b a) : Sorted r (b :: a :: l) := by
+  refine List.pairwise_cons.2 ⟨?_, ha⟩
+  rintro c (_ | _)
+  · exact h
+  · apply trans h
+    apply rel_of_sorted_cons ha
+    assumption
+
 theorem Sorted.head!_le [Inhabited α] [Preorder α] {a : α} {l : List α} (h : Sorted (· < ·) l)
     (ha : a ∈ l) : l.head! ≤ a := by
   rw [← List.cons_head!_tail (List.ne_nil_of_mem ha)] at h ha

--- a/Mathlib/Data/List/Sort.lean
+++ b/Mathlib/Data/List/Sort.lean
@@ -71,8 +71,8 @@ theorem rel_of_sorted_cons {a : α} {l : List α} : Sorted r (a :: l) → ∀ b 
   rel_of_pairwise_cons
 
 nonrec theorem Sorted.cons {r : α → α → Prop} [IsTrans α r] {l : List α} {a b : α}
-    (h : r b a) (ha : Sorted r (a :: l)) : Sorted r (b :: a :: l) :=
-  ha.cons <| forall_mem_cons.2 ⟨h, fun _ hx => _root_.trans h <| rel_of_sorted_cons ha _ hx⟩
+    (hab : r a b) (h : Sorted r (b :: l)) : Sorted r (a :: b :: l) :=
+  h.cons <| forall_mem_cons.2 ⟨hab, fun _ hx => _root_.trans hab <| rel_of_sorted_cons h _ hx⟩
 
 theorem Sorted.cons_iff {r : α → α → Prop} [IsTrans α r] {l : List α} {a b : α} :
     r b a ∧ Sorted r (a :: l) ↔ Sorted r (b :: a :: l) := by


### PR DESCRIPTION
If `a :: l` is sorted under a transitive relation `r` and `r b a`, then `b :: a :: l` is sorted too.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
