### PR TITLE
feat(SetTheory/Ordinal/CantorNormalForm): Coefficients of CNF as finsupp

### DIFF
--- a/Mathlib/SetTheory/Ordinal/CantorNormalForm.lean
+++ b/Mathlib/SetTheory/Ordinal/CantorNormalForm.lean
@@ -178,13 +178,15 @@ theorem CNF_exponents_sorted (b o : Ordinal) : (CNF.exponents b o).Sorted (· > 
         intro a H
         exact (le_log_of_mem_CNF_exponents H).trans_lt <| log_mod_opow_log_lt_log_self hb hbo
 
+theorem CNF_nodupKeys (b o : Ordinal) : (CNF b o).NodupKeys :=
+  (CNF_exponents_sorted b o).nodup
+
 open AList Finsupp
 
 /-- Cantor normal form `CNF` as an `AList`. -/
 @[pp_nodot]
-def CNF_AList (b o : Ordinal) : AList (fun _ : Ordinal => Ordinal) where
-  entries := CNF b o
-  nodupKeys := (CNF_exponents_sorted b o).nodup
+def CNF_AList (b o : Ordinal) : AList (fun _ : Ordinal => Ordinal) :=
+  ⟨_, CNF_nodupKeys b o⟩
 
 @[simp]
 theorem CNF_AList_entries (b o : Ordinal) : (CNF_AList b o).entries = CNF b o :=
@@ -193,6 +195,20 @@ theorem CNF_AList_entries (b o : Ordinal) : (CNF_AList b o).entries = CNF b o :=
 @[simp]
 theorem CNF_AList_keys (b o : Ordinal) : (CNF_AList b o).keys = CNF.exponents b o :=
   rfl
+
+@[simp]
+theorem mem_CNF_AList_iff {b o e : Ordinal} : e ∈ CNF_AList b o ↔ e ∈ CNF.exponents b o :=
+  Iff.rfl
+
+@[simp]
+theorem mem_CNF_AList_lookup_iff {b o e c : Ordinal} :
+    c ∈ (CNF_AList b o).lookup e ↔ ⟨e, c⟩ ∈ CNF b o :=
+  mem_lookup_iff
+
+@[simp]
+theorem CNF_AList_eq_empty {b o : Ordinal} : CNF_AList b o = ∅ ↔ o = 0 := by
+  rw [AList.ext_iff]
+  exact CNF_eq_nil
 
 /-- `CNF_coeff b o` is the finitely supported function returning the coefficient of `b^e` in the
 `CNF` of `o`, for each `e`. -/

--- a/Mathlib/SetTheory/Ordinal/CantorNormalForm.lean
+++ b/Mathlib/SetTheory/Ordinal/CantorNormalForm.lean
@@ -3,6 +3,7 @@ Copyright (c) 2018 Mario Carneiro. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Mario Carneiro
 -/
+import Mathlib.Data.List.Sigma
 import Mathlib.SetTheory.Ordinal.Arithmetic
 import Mathlib.SetTheory.Ordinal.Exponential
 
@@ -40,22 +41,20 @@ namespace Ordinal
 /-- Inducts on the base `b` expansion of an ordinal. -/
 @[elab_as_elim]
 noncomputable def CNFRec (b : Ordinal) {C : Ordinal → Sort*} (H0 : C 0)
-    (H : ∀ o, o ≠ 0 → C (o % b ^ log b o) → C o) : ∀ o, C o := fun o ↦ by
-    by_cases h : o = 0
-    · rw [h]; exact H0
-    · exact H o h (CNFRec _ H0 H (o % b ^ log b o))
-    termination_by o => o
-    decreasing_by exact mod_opow_log_lt_self b h
+    (H : ∀ o, o ≠ 0 → C (o % b ^ log b o) → C o) (o : Ordinal) : C o :=
+  if h : o = 0 then h ▸ H0 else H o h (CNFRec _ H0 H (o % b ^ log b o))
+termination_by o
+decreasing_by exact mod_opow_log_lt_self b h
 
 @[simp]
 theorem CNFRec_zero {C : Ordinal → Sort*} (b : Ordinal) (H0 : C 0)
-    (H : ∀ o, o ≠ 0 → C (o % b ^ log b o) → C o) : @CNFRec b C H0 H 0 = H0 := by
+    (H : ∀ o, o ≠ 0 → C (o % b ^ log b o) → C o) : CNFRec b H0 H 0 = H0 := by
   rw [CNFRec, dif_pos rfl]
-  rfl
 
 theorem CNFRec_pos (b : Ordinal) {o : Ordinal} {C : Ordinal → Sort*} (ho : o ≠ 0) (H0 : C 0)
     (H : ∀ o, o ≠ 0 → C (o % b ^ log b o) → C o) :
-    @CNFRec b C H0 H o = H o ho (@CNFRec b C H0 H _) := by rw [CNFRec, dif_neg ho]
+    CNFRec b H0 H o = H o ho (@CNFRec b C H0 H _) := by
+  rw [CNFRec, dif_neg ho]
 
 /-- The Cantor normal form of an ordinal `o` is the list of coefficients and exponents in the
 base-`b` expansion of `o`.
@@ -64,21 +63,35 @@ We special-case `CNF 0 o = CNF 1 o = [(0, o)]` for `o ≠ 0`.
 
 `CNF b (b ^ u₁ * v₁ + b ^ u₂ * v₂) = [(u₁, v₁), (u₂, v₂)]` -/
 @[pp_nodot]
-def CNF (b o : Ordinal) : List (Ordinal × Ordinal) :=
-  CNFRec b [] (fun o _ho IH ↦ (log b o, o / b ^ log b o)::IH) o
+def CNF (b o : Ordinal) : List (Σ _ : Ordinal, Ordinal) :=
+  CNFRec b [] (fun o _ho IH ↦ ⟨log b o, o / b ^ log b o⟩::IH) o
+
+/-- The exponents of the Cantor normal form are stored in the first entries. -/
+abbrev CNF.exponents (b o : Ordinal) := (CNF b o).keys
+/-- The coefficients of the Cantor normal form are stored in the second entries. -/
+abbrev CNF.coefficients (b o : Ordinal) := (CNF b o).map Sigma.snd
 
 @[simp]
 theorem CNF_zero (b : Ordinal) : CNF b 0 = [] :=
   CNFRec_zero b _ _
 
-/-- Recursive definition for the Cantor normal form. -/
+@[simp]
+theorem CNF.exponents_zero (b : Ordinal) : CNF.exponents b 0 = [] := by
+  rw [exponents, CNF_zero, keys_nil]
+
+@[simp]
+theorem CNF.coefficients_zero (b : Ordinal) : CNF.coefficients b 0 = [] := by
+  rw [coefficients, CNF_zero, map_nil]
+
 theorem CNF_ne_zero {b o : Ordinal} (ho : o ≠ 0) :
-    CNF b o = (log b o, o / b ^ log b o)::CNF b (o % b ^ log b o) :=
+    CNF b o = ⟨log b o, o / b ^ log b o⟩::CNF b (o % b ^ log b o) :=
   CNFRec_pos b ho _ _
 
-theorem zero_CNF {o : Ordinal} (ho : o ≠ 0) : CNF 0 o = [⟨0, o⟩] := by simp [CNF_ne_zero ho]
+theorem zero_CNF {o : Ordinal} (ho : o ≠ 0) : CNF 0 o = [⟨0, o⟩] := by
+  simp [CNF_ne_zero ho, CNF_zero]
 
-theorem one_CNF {o : Ordinal} (ho : o ≠ 0) : CNF 1 o = [⟨0, o⟩] := by simp [CNF_ne_zero ho]
+theorem one_CNF {o : Ordinal} (ho : o ≠ 0) : CNF 1 o = [⟨0, o⟩] := by
+  simp [CNF_ne_zero ho, CNF_zero]
 
 theorem CNF_of_le_one {b o : Ordinal} (hb : b ≤ 1) (ho : o ≠ 0) : CNF b o = [⟨0, o⟩] := by
   rcases le_one_iff.1 hb with (rfl | rfl)
@@ -94,51 +107,59 @@ theorem CNF_foldr (b o : Ordinal) : (CNF b o).foldr (fun p r ↦ b ^ p.1 * p.2 +
     (fun o ho IH ↦ by rw [CNF_ne_zero ho, foldr_cons, IH, div_add_mod]) o
 
 /-- Every exponent in the Cantor normal form `CNF b o` is less or equal to `log b o`. -/
-theorem CNF_fst_le_log {b o : Ordinal.{u}} {x : Ordinal × Ordinal} :
-    x ∈ CNF b o → x.1 ≤ log b o := by
+theorem le_log_of_mem_CNF_exponents {b o : Ordinal.{u}} {x : Ordinal} :
+    x ∈ CNF.exponents b o → x ≤ log b o := by
+  rw [CNF.exponents]
   refine CNFRec b ?_ (fun o ho H ↦ ?_) o
   · rw [CNF_zero]
-    intro contra; contradiction
-  · rw [CNF_ne_zero ho, mem_cons]
+    rintro ⟨⟩
+  · rw [CNF_ne_zero ho, keys_cons, mem_cons]
     rintro (rfl | h)
     · exact le_rfl
     · exact (H h).trans (log_mono_right _ (mod_opow_log_lt_self b ho).le)
 
-/-- Every exponent in the Cantor normal form `CNF b o` is less or equal to `o`. -/
-theorem CNF_fst_le {b o : Ordinal.{u}} {x : Ordinal × Ordinal} (h : x ∈ CNF b o) : x.1 ≤ o :=
-  (CNF_fst_le_log h).trans <| log_le_self _ _
-
 /-- Every coefficient in a Cantor normal form is positive. -/
-theorem CNF_lt_snd {b o : Ordinal.{u}} {x : Ordinal × Ordinal} : x ∈ CNF b o → 0 < x.2 := by
-  refine CNFRec b (by simp) (fun o ho IH ↦ ?_) o
-  rw [CNF_ne_zero ho]
-  rintro (h | ⟨_, h⟩)
-  · exact div_opow_log_pos b ho
-  · exact IH h
+theorem pos_of_mem_CNF_coefficients {b o : Ordinal.{u}} {x : Ordinal} :
+    x ∈ CNF.coefficients b o → 0 < x := by
+  rw [CNF.coefficients]
+  refine CNFRec b ?_ ?_ o
+  · simp
+  · intro o ho IH
+    rw [CNF_ne_zero ho]
+    rintro (h | ⟨_, h⟩)
+    · exact div_opow_log_pos b ho
+    · exact IH h
 
 /-- Every coefficient in the Cantor normal form `CNF b o` is less than `b`. -/
-theorem CNF_snd_lt {b o : Ordinal.{u}} (hb : 1 < b) {x : Ordinal × Ordinal} :
-    x ∈ CNF b o → x.2 < b := by
+theorem lt_of_mem_CNF_coefficients {b o : Ordinal.{u}} (hb : 1 < b) {x : Ordinal} :
+    x ∈ CNF.coefficients b o → x < b := by
+  rw [CNF.coefficients]
   refine CNFRec b ?_ (fun o ho IH ↦ ?_) o
-  · simp only [CNF_zero, not_mem_nil, IsEmpty.forall_iff]
+  · rw [CNF_zero]
+    rintro ⟨⟩
   · rw [CNF_ne_zero ho]
     intro h
     cases' (mem_cons.mp h) with h h
-    · rw [h]; simpa only using div_opow_log_lt o hb
+    · rw [h]
+      simpa only using div_opow_log_lt o hb
     · exact IH h
 
-/-- The exponents of the Cantor normal form are decreasing. -/
-theorem CNF_sorted (b o : Ordinal) : ((CNF b o).map Prod.fst).Sorted (· > ·) := by
-  refine CNFRec b ?_ (fun o ho IH ↦ ?_) o
-  · simp only [gt_iff_lt, CNF_zero, map_nil, sorted_nil]
-  · rcases le_or_lt b 1 with hb | hb
-    · simp only [CNF_of_le_one hb ho, gt_iff_lt, map_cons, map, sorted_singleton]
-    · cases' lt_or_le o b with hob hbo
-      · simp only [CNF_of_lt ho hob, gt_iff_lt, map_cons, map, sorted_singleton]
-      · rw [CNF_ne_zero ho, map_cons, sorted_cons]
-        refine ⟨fun a H ↦ ?_, IH⟩
-        rw [mem_map] at H
-        rcases H with ⟨⟨a, a'⟩, H, rfl⟩
-        exact (CNF_fst_le_log H).trans_lt (log_mod_opow_log_lt_log_self hb ho hbo)
+/-- The exponents of the `CNF` are a decreasing sequence. -/
+theorem CNF_exponents_sorted (b o : Ordinal) : (CNF.exponents b o).Sorted (· > ·) := by
+  rw [CNF.exponents]
+  refine CNFRec b ?_ ?_ o
+  · rw [CNF_zero]
+    exact sorted_nil
+  · intro o ho IH
+    obtain hb | hb := le_or_gt b 1
+    · rw [CNF_of_le_one hb ho]
+      exact sorted_singleton _
+    · obtain hbo | hbo := lt_or_le o b
+      · rw [CNF_of_lt ho hbo]
+        exact sorted_singleton _
+      · rw [CNF_ne_zero ho, keys_cons, sorted_cons]
+        refine ⟨?_, IH⟩
+        intro a H
+        exact (le_log_of_mem_CNF_exponents H).trans_lt <| log_mod_opow_log_lt_log_self hb hbo
 
 end Ordinal

--- a/Mathlib/SetTheory/Ordinal/CantorNormalForm.lean
+++ b/Mathlib/SetTheory/Ordinal/CantorNormalForm.lean
@@ -202,7 +202,7 @@ theorem mem_CNF_AList_iff {b o e : Ordinal} : e ∈ CNF_AList b o ↔ e ∈ CNF.
 
 @[simp]
 theorem mem_CNF_AList_lookup_iff {b o e c : Ordinal} :
-    c ∈ (CNF_AList b o).lookup e ↔ ⟨e, c⟩ ∈ CNF b o :=
+    (CNF_AList b o).lookup e = some c ↔ ⟨e, c⟩ ∈ CNF b o :=
   mem_lookup_iff
 
 @[simp]

--- a/Mathlib/SetTheory/Ordinal/CantorNormalForm.lean
+++ b/Mathlib/SetTheory/Ordinal/CantorNormalForm.lean
@@ -55,6 +55,8 @@ theorem CNFRec_pos (b : Ordinal) {o : Ordinal} {C : Ordinal → Sort*} (ho : o �
     CNFRec b H0 H o = H o ho (@CNFRec b C H0 H _) := by
   rw [CNFRec, dif_neg ho]
 
+/-! ### Cantor normal form as a list -/
+
 /-- The Cantor normal form of an ordinal `o` is the list of coefficients and exponents in the
 base-`b` expansion of `o`.
 
@@ -181,46 +183,19 @@ theorem CNF_exponents_sorted (b o : Ordinal) : (CNF.exponents b o).Sorted (· > 
 theorem CNF_nodupKeys (b o : Ordinal) : (CNF b o).NodupKeys :=
   (CNF_exponents_sorted b o).nodup
 
+/-! ### Cantor normal form as a finsupp -/
+
 open AList Finsupp
-
-/-- Cantor normal form `CNF` as an `AList`. -/
-@[pp_nodot]
-def CNF_AList (b o : Ordinal) : AList (fun _ : Ordinal => Ordinal) :=
-  ⟨_, CNF_nodupKeys b o⟩
-
-@[simp]
-theorem CNF_AList_entries (b o : Ordinal) : (CNF_AList b o).entries = CNF b o :=
-  rfl
-
-@[simp]
-theorem CNF_AList_keys (b o : Ordinal) : (CNF_AList b o).keys = CNF.exponents b o :=
-  rfl
-
-@[simp]
-theorem mem_CNF_AList_iff {b o e : Ordinal} : e ∈ CNF_AList b o ↔ e ∈ CNF.exponents b o :=
-  Iff.rfl
-
-@[simp]
-theorem mem_CNF_AList_lookup_iff {b o e c : Ordinal} :
-    (CNF_AList b o).lookup e = some c ↔ ⟨e, c⟩ ∈ CNF b o :=
-  mem_lookup_iff
-
-@[simp]
-theorem CNF_AList_eq_empty {b o : Ordinal} : CNF_AList b o = ∅ ↔ o = 0 := by
-  rw [AList.ext_iff]
-  exact CNF_eq_nil
 
 /-- `CNF_coeff b o` is the finitely supported function returning the coefficient of `b ^ e` in the
 `CNF` of `o`, for each `e`. -/
 @[pp_nodot]
 def CNF_coeff (b o : Ordinal) : Ordinal →₀ Ordinal :=
-  (CNF_AList b o).lookupFinsupp
+  lookupFinsupp ⟨_, CNF_nodupKeys b o⟩
 
 theorem CNF_coeff_of_mem_CNF {b o e c : Ordinal} (h : ⟨e, c⟩ ∈ CNF b o) :
     CNF_coeff b o e = c := by
-  rw [← CNF_AList_entries] at h
-  rw [CNF_coeff, lookupFinsupp_apply, mem_lookup_iff.2 h]
-  rfl
+  rw [CNF_coeff, lookupFinsupp_apply, mem_lookup_iff.2 h, Option.getD_some]
 
 theorem CNF_coeff_of_not_mem_CNF {b o e : Ordinal} (h : e ∉ CNF.exponents b o) :
     CNF_coeff b o e = 0 := by

--- a/Mathlib/SetTheory/Ordinal/CantorNormalForm.lean
+++ b/Mathlib/SetTheory/Ordinal/CantorNormalForm.lean
@@ -182,8 +182,8 @@ theorem CNF_AList_entries (b o : Ordinal) : (CNF_AList b o).entries = CNF b o :=
 theorem CNF_AList_keys (b o : Ordinal) : (CNF_AList b o).keys = CNF.exponents b o :=
   rfl
 
-/-- The finitely supported function returning the coefficients of the `CNF` associated to each
-exponent. -/
+/-- `CNF_coeff b o` is the finitely supported function, returning the coefficient of `b^e` in the
+`CNF` of `o`, for each `e`. -/
 @[pp_nodot]
 def CNF_coeff (b o : Ordinal) : Ordinal →₀ Ordinal :=
   (CNF_AList b o).lookupFinsupp

--- a/Mathlib/SetTheory/Ordinal/CantorNormalForm.lean
+++ b/Mathlib/SetTheory/Ordinal/CantorNormalForm.lean
@@ -59,17 +59,17 @@ theorem CNFRec_pos (b : Ordinal) {o : Ordinal} {C : Ordinal → Sort*} (ho : o �
 /-- The Cantor normal form of an ordinal `o` is the list of coefficients and exponents in the
 base-`b` expansion of `o`.
 
-We special-case `CNF 0 o = CNF 1 o = [(0, o)]` for `o ≠ 0`.
+We special-case `CNF 0 o = CNF 1 o = [⟨0, o⟩]` for `o ≠ 0`.
 
-`CNF b (b ^ u₁ * v₁ + b ^ u₂ * v₂) = [(u₁, v₁), (u₂, v₂)]` -/
+`CNF b (b ^ u₁ * v₁ + b ^ u₂ * v₂) = [⟨u₁, v₁⟩, ⟨u₂, v₂⟩]` -/
 @[pp_nodot]
 def CNF (b o : Ordinal) : List (Σ _ : Ordinal, Ordinal) :=
   CNFRec b [] (fun o _ho IH ↦ ⟨log b o, o / b ^ log b o⟩::IH) o
 
 /-- The exponents of the Cantor normal form are stored in the first entries. -/
-abbrev CNF.exponents (b o : Ordinal) := (CNF b o).keys
+def CNF.exponents (b o : Ordinal) := (CNF b o).keys
 /-- The coefficients of the Cantor normal form are stored in the second entries. -/
-abbrev CNF.coefficients (b o : Ordinal) := (CNF b o).map Sigma.snd
+def CNF.coefficients (b o : Ordinal) := (CNF b o).map Sigma.snd
 
 @[simp]
 theorem CNF_zero (b : Ordinal) : CNF b 0 = [] :=
@@ -79,9 +79,8 @@ theorem CNF_zero (b : Ordinal) : CNF b 0 = [] :=
 theorem CNF.exponents_zero (b : Ordinal) : CNF.exponents b 0 = [] := by
   rw [exponents, CNF_zero, keys_nil]
 
-theorem CNF_mem_exponents_iff {b o e : Ordinal} :
-    e ∈ CNF.exponents b o ↔ ∃ c, ⟨e, c⟩ ∈ CNF b o := by
-  rw [CNF.exponents, mem_keys]
+theorem CNF_mem_exponents_iff {b o e : Ordinal} : e ∈ CNF.exponents b o ↔ ∃ c, ⟨e, c⟩ ∈ CNF b o :=
+  mem_keys
 
 @[simp]
 theorem CNF.coefficients_zero (b : Ordinal) : CNF.coefficients b 0 = [] := by
@@ -113,8 +112,7 @@ theorem CNF_of_lt {b o : Ordinal} (ho : o ≠ 0) (hb : o < b) : CNF b o = [⟨0,
 /-- Evaluating the Cantor normal form of an ordinal returns the ordinal. -/
 theorem CNF_foldr (b o : Ordinal) : (CNF b o).foldr (fun p r ↦ b ^ p.1 * p.2 + r) 0 = o := by
   refine CNFRec b ?_ ?_ o
-  · rw [CNF_zero]
-    rfl
+  · simp
   · intro o ho IH
     rw [CNF_ne_zero ho, foldr_cons, IH, div_add_mod]
 
@@ -123,8 +121,7 @@ theorem le_log_of_mem_CNF_exponents {b o : Ordinal.{u}} {x : Ordinal} :
     x ∈ CNF.exponents b o → x ≤ log b o := by
   rw [CNF.exponents]
   refine CNFRec b ?_ ?_ o
-  · rw [CNF_zero]
-    rintro ⟨⟩
+  · simp
   · intro o ho H
     rw [CNF_ne_zero ho, keys_cons, mem_cons]
     rintro (rfl | h)
@@ -148,21 +145,18 @@ theorem lt_of_mem_CNF_coefficients {b o : Ordinal.{u}} (hb : 1 < b) {x : Ordinal
     x ∈ CNF.coefficients b o → x < b := by
   rw [CNF.coefficients]
   refine CNFRec b ?_ ?_ o
-  · rw [CNF_zero]
-    rintro ⟨⟩
+  · simp
   · intro o ho IH h
     rw [CNF_ne_zero ho] at h
-    cases' (mem_cons.mp h) with h h
-    · rw [h]
-      simpa only using div_opow_log_lt o hb
+    obtain rfl | h := mem_cons.mp h
+    · simpa only using div_opow_log_lt o hb
     · exact IH h
 
 /-- The exponents of the `CNF` are a decreasing sequence. -/
 theorem CNF_exponents_sorted (b o : Ordinal) : (CNF.exponents b o).Sorted (· > ·) := by
   rw [CNF.exponents]
   refine CNFRec b ?_ ?_ o
-  · rw [CNF_zero]
-    exact sorted_nil
+  · simp
   · intro o ho IH
     obtain hb | hb := le_or_gt b 1
     · rw [CNF_of_le_one hb ho]

--- a/Mathlib/SetTheory/Ordinal/CantorNormalForm.lean
+++ b/Mathlib/SetTheory/Ordinal/CantorNormalForm.lean
@@ -89,10 +89,10 @@ theorem CNF_ne_zero {b o : Ordinal} (ho : o ≠ 0) :
   CNFRec_pos b ho _ _
 
 theorem zero_CNF {o : Ordinal} (ho : o ≠ 0) : CNF 0 o = [⟨0, o⟩] := by
-  simp [CNF_ne_zero ho, CNF_zero]
+  simp [CNF_ne_zero ho]
 
 theorem one_CNF {o : Ordinal} (ho : o ≠ 0) : CNF 1 o = [⟨0, o⟩] := by
-  simp [CNF_ne_zero ho, CNF_zero]
+  simp [CNF_ne_zero ho]
 
 theorem CNF_of_le_one {b o : Ordinal} (hb : b ≤ 1) (ho : o ≠ 0) : CNF b o = [⟨0, o⟩] := by
   rcases le_one_iff.1 hb with (rfl | rfl)
@@ -103,18 +103,22 @@ theorem CNF_of_lt {b o : Ordinal} (ho : o ≠ 0) (hb : o < b) : CNF b o = [⟨0,
   simp only [CNF_ne_zero ho, log_eq_zero hb, opow_zero, div_one, mod_one, CNF_zero]
 
 /-- Evaluating the Cantor normal form of an ordinal returns the ordinal. -/
-theorem CNF_foldr (b o : Ordinal) : (CNF b o).foldr (fun p r ↦ b ^ p.1 * p.2 + r) 0 = o :=
-  CNFRec b (by rw [CNF_zero]; rfl)
-    (fun o ho IH ↦ by rw [CNF_ne_zero ho, foldr_cons, IH, div_add_mod]) o
+theorem CNF_foldr (b o : Ordinal) : (CNF b o).foldr (fun p r ↦ b ^ p.1 * p.2 + r) 0 = o := by
+  refine CNFRec b ?_ ?_ o
+  · rw [CNF_zero]
+    rfl
+  · intro o ho IH
+    rw [CNF_ne_zero ho, foldr_cons, IH, div_add_mod]
 
 /-- Every exponent in the Cantor normal form `CNF b o` is less or equal to `log b o`. -/
 theorem le_log_of_mem_CNF_exponents {b o : Ordinal.{u}} {x : Ordinal} :
     x ∈ CNF.exponents b o → x ≤ log b o := by
   rw [CNF.exponents]
-  refine CNFRec b ?_ (fun o ho H ↦ ?_) o
+  refine CNFRec b ?_ ?_ o
   · rw [CNF_zero]
     rintro ⟨⟩
-  · rw [CNF_ne_zero ho, keys_cons, mem_cons]
+  · intro o ho H
+    rw [CNF_ne_zero ho, keys_cons, mem_cons]
     rintro (rfl | h)
     · exact le_rfl
     · exact (H h).trans (log_mono_right _ (mod_opow_log_lt_self b ho).le)
@@ -135,11 +139,11 @@ theorem pos_of_mem_CNF_coefficients {b o : Ordinal.{u}} {x : Ordinal} :
 theorem lt_of_mem_CNF_coefficients {b o : Ordinal.{u}} (hb : 1 < b) {x : Ordinal} :
     x ∈ CNF.coefficients b o → x < b := by
   rw [CNF.coefficients]
-  refine CNFRec b ?_ (fun o ho IH ↦ ?_) o
+  refine CNFRec b ?_ ?_ o
   · rw [CNF_zero]
     rintro ⟨⟩
-  · rw [CNF_ne_zero ho]
-    intro h
+  · intro o ho IH h
+    rw [CNF_ne_zero ho] at h
     cases' (mem_cons.mp h) with h h
     · rw [h]
       simpa only using div_opow_log_lt o hb
@@ -155,8 +159,8 @@ theorem CNF_exponents_sorted (b o : Ordinal) : (CNF.exponents b o).Sorted (· > 
     obtain hb | hb := le_or_gt b 1
     · rw [CNF_of_le_one hb ho]
       exact sorted_singleton _
-    · obtain hbo | hbo := lt_or_le o b
-      · rw [CNF_of_lt ho hbo]
+    · obtain hob | hbo := lt_or_le o b
+      · rw [CNF_of_lt ho hob]
         exact sorted_singleton _
       · rw [CNF_ne_zero ho, keys_cons, sorted_cons]
         refine ⟨?_, IH⟩

--- a/Mathlib/SetTheory/Ordinal/CantorNormalForm.lean
+++ b/Mathlib/SetTheory/Ordinal/CantorNormalForm.lean
@@ -83,6 +83,7 @@ theorem CNF.exponents_zero (b : Ordinal) : CNF.exponents b 0 = [] := by
 theorem CNF.coefficients_zero (b : Ordinal) : CNF.coefficients b 0 = [] := by
   rw [coefficients, CNF_zero, map_nil]
 
+/-- Recursive definition for the Cantor normal form. -/
 theorem CNF_ne_zero {b o : Ordinal} (ho : o ≠ 0) :
     CNF b o = ⟨log b o, o / b ^ log b o⟩::CNF b (o % b ^ log b o) :=
   CNFRec_pos b ho _ _

--- a/Mathlib/SetTheory/Ordinal/CantorNormalForm.lean
+++ b/Mathlib/SetTheory/Ordinal/CantorNormalForm.lean
@@ -79,9 +79,17 @@ theorem CNF_zero (b : Ordinal) : CNF b 0 = [] :=
 theorem CNF.exponents_zero (b : Ordinal) : CNF.exponents b 0 = [] := by
   rw [exponents, CNF_zero, keys_nil]
 
+theorem CNF_mem_exponents_iff {b o e : Ordinal} :
+    e ∈ CNF.exponents b o ↔ ∃ c, ⟨e, c⟩ ∈ CNF b o := by
+  rw [CNF.exponents, mem_keys]
+
 @[simp]
 theorem CNF.coefficients_zero (b : Ordinal) : CNF.coefficients b 0 = [] := by
   rw [coefficients, CNF_zero, map_nil]
+
+theorem CNF_mem_coefficients_iff {b o c : Ordinal} :
+    c ∈ CNF.coefficients b o ↔ ∃ e, ⟨e, c⟩ ∈ CNF b o := by
+  simp [CNF.coefficients]
 
 /-- Recursive definition for the Cantor normal form. -/
 theorem CNF_ne_zero {b o : Ordinal} (ho : o ≠ 0) :

--- a/Mathlib/SetTheory/Ordinal/CantorNormalForm.lean
+++ b/Mathlib/SetTheory/Ordinal/CantorNormalForm.lean
@@ -204,7 +204,7 @@ theorem CNF_coeff_zero_apply (b e : Ordinal) : CNF_coeff b 0 e = 0 := by
   exact not_mem_nil e
 
 @[simp]
-theorem CNF_coeff_zero_right (b : Ordinal) : CNF_coeff b 0 = 0 := by
+theorem CNF_coeff_zero (b : Ordinal) : CNF_coeff b 0 = 0 := by
   ext e
   exact CNF_coeff_zero_apply b e
 
@@ -223,11 +223,11 @@ theorem CNF_coeff_of_le_one {b : Ordinal} (hb : b ≤ 1) (o : Ordinal) :
       simpa using ha
 
 @[simp]
-theorem CNF_coeff_zero_left (o : Ordinal) : CNF_coeff 0 o = single 0 o :=
+theorem zero_CNF_coeff (o : Ordinal) : CNF_coeff 0 o = single 0 o :=
   CNF_coeff_of_le_one zero_le_one o
 
 @[simp]
-theorem CNF_coeff_one (o : Ordinal) : CNF_coeff 1 o = single 0 o :=
+theorem one_CNF_coeff (o : Ordinal) : CNF_coeff 1 o = single 0 o :=
   CNF_coeff_of_le_one le_rfl o
 
 end Ordinal

--- a/Mathlib/SetTheory/Ordinal/CantorNormalForm.lean
+++ b/Mathlib/SetTheory/Ordinal/CantorNormalForm.lean
@@ -94,6 +94,16 @@ theorem CNF_ne_zero {b o : Ordinal} (ho : o ≠ 0) :
     CNF b o = ⟨log b o, o / b ^ log b o⟩::CNF b (o % b ^ log b o) :=
   CNFRec_pos b ho _ _
 
+@[simp]
+theorem CNF_eq_nil {b o : Ordinal} : CNF b o = [] ↔ o = 0 := by
+  constructor
+  · intro h
+    by_contra ho
+    rw [CNF_ne_zero ho] at h
+    exact cons_ne_nil _ _ h
+  · rintro rfl
+    exact CNF_zero b
+
 theorem zero_CNF {o : Ordinal} (ho : o ≠ 0) : CNF 0 o = [⟨0, o⟩] := by
   simp [CNF_ne_zero ho]
 

--- a/Mathlib/SetTheory/Ordinal/CantorNormalForm.lean
+++ b/Mathlib/SetTheory/Ordinal/CantorNormalForm.lean
@@ -210,7 +210,7 @@ theorem CNF_AList_eq_empty {b o : Ordinal} : CNF_AList b o = ∅ ↔ o = 0 := by
   rw [AList.ext_iff]
   exact CNF_eq_nil
 
-/-- `CNF_coeff b o` is the finitely supported function returning the coefficient of `b^e` in the
+/-- `CNF_coeff b o` is the finitely supported function returning the coefficient of `b ^ e` in the
 `CNF` of `o`, for each `e`. -/
 @[pp_nodot]
 def CNF_coeff (b o : Ordinal) : Ordinal →₀ Ordinal :=

--- a/Mathlib/SetTheory/Ordinal/CantorNormalForm.lean
+++ b/Mathlib/SetTheory/Ordinal/CantorNormalForm.lean
@@ -184,7 +184,7 @@ theorem CNF_AList_entries (b o : Ordinal) : (CNF_AList b o).entries = CNF b o :=
 theorem CNF_AList_keys (b o : Ordinal) : (CNF_AList b o).keys = CNF.exponents b o :=
   rfl
 
-/-- `CNF_coeff b o` is the finitely supported function, returning the coefficient of `b^e` in the
+/-- `CNF_coeff b o` is the finitely supported function returning the coefficient of `b^e` in the
 `CNF` of `o`, for each `e`. -/
 @[pp_nodot]
 def CNF_coeff (b o : Ordinal) : Ordinal →₀ Ordinal :=

--- a/Mathlib/SetTheory/Ordinal/Exponential.lean
+++ b/Mathlib/SetTheory/Ordinal/Exponential.lean
@@ -330,11 +330,11 @@ theorem mod_opow_log_lt_self (b : Ordinal) {o : Ordinal} (ho : o ≠ 0) : o % (b
   · simpa using Ordinal.pos_iff_ne_zero.2 ho
   · exact (mod_lt _ <| opow_ne_zero _ hb).trans_le (opow_log_le_self _ ho)
 
-theorem log_mod_opow_log_lt_log_self {b o : Ordinal} (hb : 1 < b) (ho : o ≠ 0) (hbo : b ≤ o) :
+theorem log_mod_opow_log_lt_log_self {b o : Ordinal} (hb : 1 < b) (hbo : b ≤ o) :
     log b (o % (b ^ log b o)) < log b o := by
   rcases eq_or_ne (o % (b ^ log b o)) 0 with h | h
   · rw [h, log_zero_right]
-    apply log_pos hb ho hbo
+    exact log_pos hb (one_le_iff_ne_zero.1 (hb.le.trans hbo)) hbo
   · rw [← succ_le_iff, succ_log_def hb h]
     apply csInf_le'
     apply mod_lt


### PR DESCRIPTION
We introduce `CNF_coeff b o e`, which returns the coefficient of `b^e` in the Cantor Normal Form of `o`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

- [ ] depends on: #15915

I'm not sure if `CNF_Alist` and `CNF_coeff` adhere to naming conventions. Naming suggestions welcome.

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
