### PR TITLE
[Merged by Bors] - feat: Real-valued double counting

### DIFF
--- a/Mathlib/Combinatorics/Enumerative/DoubleCounting.lean
+++ b/Mathlib/Combinatorics/Enumerative/DoubleCounting.lean
@@ -3,8 +3,8 @@ Copyright (c) 2022 Yaël Dillies. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Yaël Dillies
 -/
+import Mathlib.Algebra.BigOperators.Ring
 import Mathlib.Algebra.Order.BigOperators.Group.Finset
-import Mathlib.Data.Set.Subsingleton
 
 /-!
 # Double countings
@@ -30,7 +30,7 @@ and `t`.
 
 open Finset Function Relator
 
-variable {α β : Type*}
+variable {R α β : Type*}
 
 /-! ### Bipartite graph -/
 
@@ -71,21 +71,98 @@ theorem sum_card_bipartiteAbove_eq_sum_card_bipartiteBelow [∀ a b, Decidable (
   simp_rw [card_eq_sum_ones, bipartiteAbove, bipartiteBelow, sum_filter]
   exact sum_comm
 
-/-- Double counting argument. Considering `r` as a bipartite graph, the LHS is a lower bound on the
-number of edges while the RHS is an upper bound. -/
+section OrderedSemiring
+variable [OrderedSemiring R] [DecidablePred (r a)] [∀ a, Decidable (r a b)] {m n : R}
+
+/-- **Double counting** argument.
+
+Considering `r` as a bipartite graph, the LHS is a lower bound on the number of edges while the RHS
+is an upper bound. -/
+theorem card_nsmul_le_card_nsmul [∀ a b, Decidable (r a b)]
+    (hm : ∀ a ∈ s, m ≤ (t.bipartiteAbove r a).card)
+    (hn : ∀ b ∈ t, (s.bipartiteBelow r b).card ≤ n) : s.card • m ≤ t.card • n :=
+  calc
+    _ ≤ ∑ a in s, ((t.bipartiteAbove r a).card : R) := s.card_nsmul_le_sum _ _ hm
+    _ = ∑ b in t, ((s.bipartiteBelow r b).card : R) := by
+      norm_cast; rw [sum_card_bipartiteAbove_eq_sum_card_bipartiteBelow]
+    _ ≤ _ := t.sum_le_card_nsmul _ _ hn
+
+/-- **Double counting** argument.
+
+Considering `r` as a bipartite graph, the LHS is a lower bound on the number of edges while the RHS
+is an upper bound. -/
+theorem card_nsmul_le_card_nsmul' [∀ a b, Decidable (r a b)]
+    (hn : ∀ b ∈ t, n ≤ (s.bipartiteBelow r b).card)
+    (hm : ∀ a ∈ s, (t.bipartiteAbove r a).card ≤ m) : t.card • n ≤ s.card • m :=
+  card_nsmul_le_card_nsmul (swap r) hn hm
+
+end OrderedSemiring
+
+section StrictOrderedSemiring
+variable [StrictOrderedSemiring R] (r : α → β → Prop) {s : Finset α} {t : Finset β}
+  (a a' : α) (b b' : β) [DecidablePred (r a)] [∀ a, Decidable (r a b)] {m n : R}
+
+/-- **Double counting** argument.
+
+Considering `r` as a bipartite graph, the LHS is a strict lower bound on the number of edges while
+the RHS is an upper bound. -/
+theorem card_nsmul_lt_card_nsmul_of_lt_of_le [∀ a b, Decidable (r a b)] (hs : s.Nonempty)
+    (hm : ∀ a ∈ s, m < (t.bipartiteAbove r a).card)
+    (hn : ∀ b ∈ t, (s.bipartiteBelow r b).card ≤ n) : s.card • m < t.card • n :=
+  calc
+    _ = ∑ _a ∈ s, m := by rw [sum_const]
+    _ < ∑ a ∈ s, ((t.bipartiteAbove r a).card : R) := sum_lt_sum_of_nonempty hs hm
+    _ = ∑ b in t, ((s.bipartiteBelow r b).card : R) := by
+      norm_cast; rw [sum_card_bipartiteAbove_eq_sum_card_bipartiteBelow]
+    _ ≤ _ := t.sum_le_card_nsmul _ _ hn
+
+/-- **Double counting** argument.
+
+Considering `r` as a bipartite graph, the LHS is a lower bound on the number of edges while the RHS
+is a strict upper bound. -/
+theorem card_nsmul_lt_card_nsmul_of_le_of_lt [∀ a b, Decidable (r a b)] (ht : t.Nonempty)
+    (hm : ∀ a ∈ s, m ≤ (t.bipartiteAbove r a).card)
+    (hn : ∀ b ∈ t, (s.bipartiteBelow r b).card < n) : s.card • m < t.card • n :=
+  calc
+    _ ≤ ∑ a in s, ((t.bipartiteAbove r a).card : R) := s.card_nsmul_le_sum _ _ hm
+    _ = ∑ b in t, ((s.bipartiteBelow r b).card : R) := by
+      norm_cast; rw [sum_card_bipartiteAbove_eq_sum_card_bipartiteBelow]
+    _ < ∑ _b ∈ t, n := sum_lt_sum_of_nonempty ht hn
+    _ = _ := sum_const _
+
+/-- **Double counting** argument.
+
+Considering `r` as a bipartite graph, the LHS is a strict lower bound on the number of edges while
+the RHS is an upper bound. -/
+theorem card_nsmul_lt_card_nsmul_of_lt_of_le' [∀ a b, Decidable (r a b)] (ht : t.Nonempty)
+    (hn : ∀ b ∈ t, n < (s.bipartiteBelow r b).card)
+    (hm : ∀ a ∈ s, (t.bipartiteAbove r a).card ≤ m) : t.card • n < s.card • m :=
+  card_nsmul_lt_card_nsmul_of_lt_of_le (swap r) ht hn hm
+
+/-- **Double counting** argument.
+
+Considering `r` as a bipartite graph, the LHS is a lower bound on the number of edges while the RHS
+is a strict upper bound. -/
+theorem card_nsmul_lt_card_nsmul_of_le_of_lt' [∀ a b, Decidable (r a b)] (hs : s.Nonempty)
+    (hn : ∀ b ∈ t, n ≤ (s.bipartiteBelow r b).card)
+    (hm : ∀ a ∈ s, (t.bipartiteAbove r a).card < m) : t.card • n < s.card • m :=
+  card_nsmul_lt_card_nsmul_of_le_of_lt (swap r) hs hn hm
+
+end StrictOrderedSemiring
+
+/-- **Double counting** argument.
+
+Considering `r` as a bipartite graph, the LHS is a lower bound on the number of edges while the RHS
+is an upper bound. -/
 theorem card_mul_le_card_mul [∀ a b, Decidable (r a b)]
     (hm : ∀ a ∈ s, m ≤ (t.bipartiteAbove r a).card)
     (hn : ∀ b ∈ t, (s.bipartiteBelow r b).card ≤ n) : s.card * m ≤ t.card * n :=
-  calc
-    _ ≤ ∑ a ∈ s, (t.bipartiteAbove r a).card := s.card_nsmul_le_sum _ _ hm
-    _ = ∑ b ∈ t, (s.bipartiteBelow r b).card :=
-      sum_card_bipartiteAbove_eq_sum_card_bipartiteBelow _
-    _ ≤ _ := t.sum_le_card_nsmul _ _ hn
+  card_nsmul_le_card_nsmul _ hm hn
 
 theorem card_mul_le_card_mul' [∀ a b, Decidable (r a b)]
     (hn : ∀ b ∈ t, n ≤ (s.bipartiteBelow r b).card)
     (hm : ∀ a ∈ s, (t.bipartiteAbove r a).card ≤ m) : t.card * n ≤ s.card * m :=
-  card_mul_le_card_mul (swap r) hn hm
+  card_nsmul_le_card_nsmul' _ hn hm
 
 theorem card_mul_eq_card_mul [∀ a b, Decidable (r a b)]
     (hm : ∀ a ∈ s, (t.bipartiteAbove r a).card = m)


### PR DESCRIPTION
Generalise the existing double counting arguments to real numbers. This is useful to avoid dealing with floors and ceils everywhere.

From LeanAPAP


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
