### PR TITLE
[Merged by Bors] - feat: generalise `mul_eq_one` etc. to cancellative monoids

### DIFF
--- a/Mathlib/Algebra/Group/Units.lean
+++ b/Mathlib/Algebra/Group/Units.lean
@@ -464,6 +464,72 @@ theorem val_div_eq_divp (u₁ u₂ : αˣ) : ↑(u₁ / u₂) = ↑u₁ /ₚ u�
 
 end Monoid
 
+namespace LeftCancelMonoid
+
+variable [LeftCancelMonoid α] [Subsingleton αˣ] {a b : α}
+
+@[to_additive]
+protected theorem eq_one_of_mul_right (h : a * b = 1) : a = 1 :=
+  congr_arg Units.inv <| Subsingleton.elim (Units.mk _ _ (by
+    rw [← mul_left_cancel_iff (a := a), ← mul_assoc, h, one_mul, mul_one]) h) 1
+
+@[to_additive]
+protected theorem eq_one_of_mul_left (h : a * b = 1) : b = 1 := by
+  rwa [LeftCancelMonoid.eq_one_of_mul_right h, one_mul] at h
+
+@[to_additive (attr := simp)]
+protected theorem mul_eq_one : a * b = 1 ↔ a = 1 ∧ b = 1 :=
+  ⟨fun h => ⟨LeftCancelMonoid.eq_one_of_mul_right h, LeftCancelMonoid.eq_one_of_mul_left h⟩, by
+    rintro ⟨rfl, rfl⟩
+    exact mul_one _⟩
+
+@[to_additive]
+protected theorem mul_ne_one : a * b ≠ 1 ↔ a ≠ 1 ∨ b ≠ 1 := by rw [not_iff_comm]; simp
+
+end LeftCancelMonoid
+
+namespace RightCancelMonoid
+
+variable [RightCancelMonoid α] [Subsingleton αˣ] {a b : α}
+
+@[to_additive]
+protected theorem eq_one_of_mul_right (h : a * b = 1) : a = 1 :=
+  congr_arg Units.inv <| Subsingleton.elim (Units.mk _ _ (by
+    rw [← mul_right_cancel_iff (a := b), mul_assoc, h, one_mul, mul_one]) h) 1
+
+@[to_additive]
+protected theorem eq_one_of_mul_left (h : a * b = 1) : b = 1 := by
+  rwa [RightCancelMonoid.eq_one_of_mul_right h, one_mul] at h
+
+@[to_additive (attr := simp)]
+protected theorem mul_eq_one : a * b = 1 ↔ a = 1 ∧ b = 1 :=
+  ⟨fun h => ⟨RightCancelMonoid.eq_one_of_mul_right h, RightCancelMonoid.eq_one_of_mul_left h⟩, by
+    rintro ⟨rfl, rfl⟩
+    exact mul_one _⟩
+
+@[to_additive]
+protected theorem mul_ne_one : a * b ≠ 1 ↔ a ≠ 1 ∨ b ≠ 1 := by rw [not_iff_comm]; simp
+
+end RightCancelMonoid
+
+section CancelMonoid
+
+variable [CancelMonoid α] [Subsingleton αˣ] {a b : α}
+
+@[to_additive]
+theorem eq_one_of_mul_right' (h : a * b = 1) : a = 1 := LeftCancelMonoid.eq_one_of_mul_right h
+
+@[to_additive]
+theorem eq_one_of_mul_left' (h : a * b = 1) : b = 1 := LeftCancelMonoid.eq_one_of_mul_left h
+
+@[to_additive (attr := simp)]
+theorem mul_eq_one' : a * b = 1 ↔ a = 1 ∧ b = 1 := LeftCancelMonoid.mul_eq_one
+
+@[to_additive]
+theorem mul_ne_one' : a * b ≠ 1 ↔ a ≠ 1 ∨ b ≠ 1 := LeftCancelMonoid.mul_ne_one
+
+end CancelMonoid
+
 section CommMonoid
 
 variable [CommMonoid α]
@@ -497,6 +563,8 @@ theorem mul_eq_one : a * b = 1 ↔ a = 1 ∧ b = 1 :=
   ⟨fun h => ⟨eq_one_of_mul_right h, eq_one_of_mul_left h⟩, by
     rintro ⟨rfl, rfl⟩
     exact mul_one _⟩
+
+@[to_additive] theorem mul_ne_one : a * b ≠ 1 ↔ a ≠ 1 ∨ b ≠ 1 := by rw [not_iff_comm]; simp
 
 end CommMonoid
 

--- a/Mathlib/Algebra/Group/Units.lean
+++ b/Mathlib/Algebra/Group/Units.lean
@@ -522,7 +522,7 @@ theorem eq_one_of_mul_right' (h : a * b = 1) : a = 1 := LeftCancelMonoid.eq_one_
 @[to_additive]
 theorem eq_one_of_mul_left' (h : a * b = 1) : b = 1 := LeftCancelMonoid.eq_one_of_mul_left h
 
-@[to_additive (attr := simp)]
+@[to_additive]
 theorem mul_eq_one' : a * b = 1 ↔ a = 1 ∧ b = 1 := LeftCancelMonoid.mul_eq_one
 
 @[to_additive]


### PR DESCRIPTION
More specifically `eq_one_of_mul_right`, `eq_one_of_mul_left`, `mul_eq_one` and a new simple corollary `mul_ne_one`. The `[Left|Right]CancelMonoid` versions are protected and the `CancelMonoid` versions are primed.

This is part of #15864. Note that these theorems cannot be generalised to `[Monoid α]` – see https://math.stackexchange.com/a/4535529/357390 for a counterexample monoid.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
