### PR TITLE
[Merged by Bors] - feat(Filter): add disjoint_comap_iff_map etc

### DIFF
--- a/Mathlib/Order/Filter/Basic.lean
+++ b/Mathlib/Order/Filter/Basic.lean
@@ -2399,7 +2399,7 @@ theorem disjoint_comap_iff_map {f : α → β} {F : Filter α} {G : Filter β} :
     Disjoint F (comap f G) ↔ Disjoint (map f F) G := by
   simp only [disjoint_iff, ← Filter.push_pull, map_eq_bot_iff]
 
-theorem disjoint_comap_iff_map {f : α → β} {F : Filter α} {G : Filter β} :
+theorem disjoint_comap_iff_map' {f : α → β} {F : Filter α} {G : Filter β} :
     Disjoint (comap f G) F ↔ Disjoint G (map f F) := by
   simp only [disjoint_iff, ← Filter.push_pull', map_eq_bot_iff]
 

--- a/Mathlib/Order/Filter/Basic.lean
+++ b/Mathlib/Order/Filter/Basic.lean
@@ -2264,13 +2264,6 @@ theorem comap_eval_neBot {ι : Type*} {α : ι → Type*} [∀ j, Nonempty (α j
     (f : Filter (α i)) [NeBot f] : (comap (eval i) f).NeBot :=
   comap_eval_neBot_iff.2 ‹_›
 
-theorem comap_inf_principal_neBot_of_image_mem {f : Filter β} {m : α → β} (hf : NeBot f) {s : Set α}
-    (hs : m '' s ∈ f) : NeBot (comap m f ⊓ 𝓟 s) := by
-  refine ⟨compl_compl s ▸ mt mem_of_eq_bot ?_⟩
-  rintro ⟨t, ht, hts⟩
-  rcases hf.nonempty_of_mem (inter_mem hs ht) with ⟨_, ⟨x, hxs, rfl⟩, hxt⟩
-  exact absurd hxs (hts hxt)
-
 theorem comap_coe_neBot_of_le_principal {s : Set γ} {l : Filter γ} [h : NeBot l] (h' : l ≤ 𝓟 s) :
     NeBot (comap ((↑) : s → γ) l) :=
   h.comap_of_range_mem <| (@Subtype.range_coe γ s).symm ▸ h' (mem_principal_self s)
@@ -2401,6 +2394,27 @@ protected theorem push_pull (f : α → β) (F : Filter α) (G : Filter β) :
 
 protected theorem push_pull' (f : α → β) (F : Filter α) (G : Filter β) :
     map f (comap f G ⊓ F) = G ⊓ map f F := by simp only [Filter.push_pull, inf_comm]
+
+theorem disjoint_comap_iff_map {f : α → β} {F : Filter α} {G : Filter β} :
+    Disjoint F (comap f G) ↔ Disjoint (map f F) G := by
+  simp only [disjoint_iff, ← Filter.push_pull, map_eq_bot_iff]
+
+theorem disjoint_comap_iff_map {f : α → β} {F : Filter α} {G : Filter β} :
+    Disjoint (comap f G) F ↔ Disjoint G (map f F) := by
+  simp only [disjoint_iff, ← Filter.push_pull', map_eq_bot_iff]
+
+theorem neBot_inf_comap_iff_map {f : α → β} {F : Filter α} {G : Filter β} :
+    NeBot (F ⊓ comap f G) ↔ NeBot (map f F ⊓ G) := by
+  rw [← map_neBot_iff, Filter.push_pull]
+
+theorem neBot_inf_comap_iff_map' {f : α → β} {F : Filter α} {G : Filter β} :
+    NeBot (comap f G ⊓ F) ↔ NeBot (G ⊓ map f F) := by
+  rw [← map_neBot_iff, Filter.push_pull']
+
+theorem comap_inf_principal_neBot_of_image_mem {f : Filter β} {m : α → β} (hf : NeBot f) {s : Set α}
+    (hs : m '' s ∈ f) : NeBot (comap m f ⊓ 𝓟 s) := by
+  rw [neBot_inf_comap_iff_map', map_principal, ← frequently_mem_iff_neBot]
+  exact Eventually.frequently hs
 
 theorem principal_eq_map_coe_top (s : Set α) : 𝓟 s = map ((↑) : s → α) ⊤ := by simp
 


### PR DESCRIPTION
These are simple corollaries of `Filter.push_pull`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
