### PR TITLE
[Merged by Bors] - feat(SetTheory/Ordinal/Arithmetic): `a * b / (a * c) = b / c` and `(x * y) % (x * z) = x * (y % z)`

### DIFF
--- a/Mathlib/SetTheory/Ordinal/Arithmetic.lean
+++ b/Mathlib/SetTheory/Ordinal/Arithmetic.lean
@@ -824,17 +824,25 @@ theorem div_eq_zero_of_lt {a b : Ordinal} (h : a < b) : a / b = 0 := by
 theorem mul_div_cancel (a) {b : Ordinal} (b0 : b ≠ 0) : b * a / b = a := by
   simpa only [add_zero, zero_div] using mul_add_div a b0 0
 
-theorem mul_div_mul_cancel {a : Ordinal} (ha : a ≠ 0) (b c) : a * b / (a * c) = b / c := by
-  have ha' := Ordinal.pos_iff_ne_zero.2 ha
-  obtain rfl | hc := eq_zero_or_pos c
+theorem mul_add_div_mul {a c : Ordinal} (hc : c < a) (b d : Ordinal) :
+    (a * b + c) / (a * d) = b / d := by
+  have ha : a ≠ 0 := ((Ordinal.zero_le c).trans_lt hc).ne'
+  obtain rfl | hd := eq_or_ne d 0
   · rw [mul_zero, div_zero, div_zero]
-  · have h := mul_ne_zero ha hc.ne'
+  · have H := mul_ne_zero ha hd
     apply le_antisymm
-    · rw [div_le h, mul_assoc]
-      apply mul_lt_mul_of_pos_left _ ha'
-      rw [← div_le hc.ne']
-    · rw [div_le hc.ne']
-      rw [← mul_lt_mul_iff_left ha', ← mul_assoc, ← div_le h]
+    · rw [← lt_succ_iff, div_lt H, mul_assoc]
+      · apply (add_lt_add_left hc _).trans_le
+        rw [← mul_succ]
+        apply mul_le_mul_left'
+        rw [succ_le_iff]
+        exact lt_mul_succ_div b hd
+    · rw [le_div H, mul_assoc]
+      exact (mul_le_mul_left' (mul_div_le b d) a).trans (le_add_right _ c)
+
+theorem mul_div_mul_cancel {a : Ordinal} (ha : a ≠ 0) (b c) : a * b / (a * c) = b / c := by
+  convert mul_add_div_mul (Ordinal.pos_iff_ne_zero.2 ha) b c using 1
+  rw [add_zero]
 
 @[simp]
 theorem div_one (a : Ordinal) : a / 1 = a := by

--- a/Mathlib/SetTheory/Ordinal/Arithmetic.lean
+++ b/Mathlib/SetTheory/Ordinal/Arithmetic.lean
@@ -757,7 +757,7 @@ theorem div_nonempty {a b : Ordinal} (h : b ≠ 0) : { o | a < b * succ o }.None
 
 /-- `a / b` is the unique ordinal `o` satisfying `a = b * o + o'` with `o' < b`. -/
 instance div : Div Ordinal :=
-  ⟨fun a b => if _h : b = 0 then 0 else sInf { o | a < b * succ o }⟩
+  ⟨fun a b => if b = 0 then 0 else sInf { o | a < b * succ o }⟩
 
 @[simp]
 theorem div_zero (a : Ordinal) : a / 0 = 0 :=
@@ -823,6 +823,18 @@ theorem div_eq_zero_of_lt {a b : Ordinal} (h : a < b) : a / b = 0 := by
 @[simp]
 theorem mul_div_cancel (a) {b : Ordinal} (b0 : b ≠ 0) : b * a / b = a := by
   simpa only [add_zero, zero_div] using mul_add_div a b0 0
+
+theorem mul_div_mul_cancel {a : Ordinal} (ha : a ≠ 0) (b c) : a * b / (a * c) = b / c := by
+  have ha' := Ordinal.pos_iff_ne_zero.2 ha
+  obtain rfl | hc := eq_zero_or_pos c
+  · rw [mul_zero, div_zero, div_zero]
+  · have h := mul_ne_zero ha hc.ne'
+    apply le_antisymm
+    · rw [div_le h, mul_assoc]
+      apply mul_lt_mul_of_pos_left _ ha'
+      rw [← div_le hc.ne']
+    · rw [div_le hc.ne']
+      rw [← mul_lt_mul_iff_left ha', ← mul_assoc, ← div_le h]
 
 @[simp]
 theorem div_one (a : Ordinal) : a / 1 = a := by
@@ -935,6 +947,12 @@ theorem mul_add_mod_self (x y z : Ordinal) : (x * y + z) % x = z % x := by
 @[simp]
 theorem mul_mod (x y : Ordinal) : x * y % x = 0 := by
   simpa using mul_add_mod_self x y 0
+
+theorem mul_mod_mul (x y z : Ordinal) : (x * y) % (x * z) = x * (y % z) := by
+  obtain rfl | hx := eq_or_ne x 0
+  · repeat rw [zero_mul]
+    rw [zero_mod]
+  · rw [mod_def, mul_div_mul_cancel hx, mul_assoc, ← mul_sub, ← mod_def]
 
 theorem mod_mod_of_dvd (a : Ordinal) {b c : Ordinal} (h : c ∣ b) : a % b % c = a % c := by
   nth_rw 2 [← div_add_mod a b]

--- a/Mathlib/SetTheory/Ordinal/Arithmetic.lean
+++ b/Mathlib/SetTheory/Ordinal/Arithmetic.lean
@@ -956,11 +956,17 @@ theorem mul_add_mod_self (x y z : Ordinal) : (x * y + z) % x = z % x := by
 theorem mul_mod (x y : Ordinal) : x * y % x = 0 := by
   simpa using mul_add_mod_self x y 0
 
+theorem mul_add_mod_mul {w x : Ordinal} (hw : w < x) (y z : Ordinal) :
+    (x * y + w) % (x * z) = x * (y % z) + w := by
+  rw [mod_def, mul_add_div_mul hw]
+  apply sub_eq_of_add_eq
+  rw [← add_assoc, mul_assoc, ← mul_add, div_add_mod]
+
 theorem mul_mod_mul (x y z : Ordinal) : (x * y) % (x * z) = x * (y % z) := by
-  obtain rfl | hx := eq_or_ne x 0
-  · repeat rw [zero_mul]
-    rw [zero_mod]
-  · rw [mod_def, mul_div_mul_cancel hx, mul_assoc, ← mul_sub, ← mod_def]
+  obtain rfl | hx := Ordinal.eq_zero_or_pos x
+  · simp
+  · convert mul_add_mod_mul hx y z using 1 <;>
+    rw [add_zero]
 
 theorem mod_mod_of_dvd (a : Ordinal) {b c : Ordinal} (h : c ∣ b) : a % b % c = a % c := by
   nth_rw 2 [← div_add_mod a b]


### PR DESCRIPTION
Equalities like these prop up in the lemmas about the Cantor normal form.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
