### PR TITLE
[Merged by Bors] - feat(Data/List/Sigma): Lemmas relating `List.dlookup` and `List.map`

### DIFF
--- a/Mathlib/Data/List/Sigma.lean
+++ b/Mathlib/Data/List/Sigma.lean
@@ -204,6 +204,25 @@ theorem lookup_ext {l₀ l₁ : List (Sigma β)} (nd₀ : l₀.NodupKeys) (nd₁
   mem_ext nd₀.nodup nd₁.nodup fun ⟨a, b⟩ => by
     rw [← mem_dlookup_iff, ← mem_dlookup_iff, h] <;> assumption
 
+theorem dlookup_map₁ {γ δ} [DecidableEq γ]
+    {l : List (Σ _ : α, δ)} {f : α → γ} (hf : Function.Injective f) (a : α) :
+    (l.map fun x => ⟨f x.1, x.2⟩ : List (Σ _ : γ, δ)).dlookup (f a) = l.dlookup a := by
+  induction' l with b l IH
+  · rw [map_nil, dlookup_nil, dlookup_nil]
+  · rw [map_cons]
+    obtain h | h := eq_or_ne (f a) (f b.1)
+    · rw [h, hf h, dlookup_cons_eq, dlookup_cons_eq]
+    · rw [dlookup_cons_ne _ _ h, dlookup_cons_ne _ _ (fun he => (he ▸ h) rfl), IH]
+
+theorem dlookup_map₂ {γ δ} {l : List (Σ _ : α, γ)} {f : γ → δ} (a : α) :
+    (l.map fun x => ⟨x.1, f x.2⟩ : List (Σ _ : α, δ)).dlookup a = (l.dlookup a).map f := by
+  induction' l with b l IH
+  · rw [map_nil, dlookup_nil, dlookup_nil, Option.map_none']
+  · rw [map_cons]
+    obtain rfl | h := eq_or_ne a b.1
+    · rw [dlookup_cons_eq, dlookup_cons_eq, Option.map_some']
+    · rw [dlookup_cons_ne _ _ h, dlookup_cons_ne _ _ (fun he => (he ▸ h) rfl), IH]
+
 /-! ### `lookupAll` -/
 
 

--- a/Mathlib/Data/List/Sigma.lean
+++ b/Mathlib/Data/List/Sigma.lean
@@ -214,8 +214,8 @@ theorem dlookup_map₁ {γ δ} [DecidableEq γ]
     · rw [h, hf h, dlookup_cons_eq, dlookup_cons_eq]
     · rw [dlookup_cons_ne _ _ h, dlookup_cons_ne _ _ (fun he => (he ▸ h) rfl), IH]
 
-theorem dlookup_map₂ {γ δ} {l : List (Σ _ : α, γ)} {f : γ → δ} (a : α) :
-    (l.map fun x => ⟨x.1, f x.2⟩ : List (Σ _ : α, δ)).dlookup a = (l.dlookup a).map f := by
+theorem dlookup_map₂ {γ δ : α → Type*} {l : List (Σ a, γ a)} {f : ∀ a, γ a → δ a} (a : α) :
+    (l.map fun x => ⟨x.1, f _ x.2⟩ : List (Σ a, δ a)).dlookup a = (l.dlookup a).map (f a) := by
   induction' l with b l IH
   · rw [map_nil, dlookup_nil, dlookup_nil, Option.map_none']
   · rw [map_cons]

--- a/Mathlib/Data/List/Sigma.lean
+++ b/Mathlib/Data/List/Sigma.lean
@@ -26,11 +26,11 @@ If `α : Type*` and `β : α → Type*`, then we regard `s : Sigma β` as having
 - `List.kextract` returns a value with a given key and the rest of the values.
 -/
 
-universe u v
+universe u u' v v'
 
 namespace List
 
-variable {α : Type u} {β : α → Type v} {l l₁ l₂ : List (Sigma β)}
+variable {α : Type u} {α' : Type u'} {β : α → Type v} {β' : α' → Type v'} {l l₁ l₂ : List (Sigma β)}
 
 /-! ### `keys` -/
 
@@ -131,7 +131,7 @@ theorem mem_ext {l₀ l₁ : List (Sigma β)} (nd₀ : l₀.Nodup) (nd₁ : l₁
     (h : ∀ x, x ∈ l₀ ↔ x ∈ l₁) : l₀ ~ l₁ :=
   (perm_ext_iff_of_nodup nd₀ nd₁).2 h
 
-variable [DecidableEq α]
+variable [DecidableEq α] [DecidableEq α']
 
 /-! ### `dlookup` -/
 
@@ -204,24 +204,24 @@ theorem lookup_ext {l₀ l₁ : List (Sigma β)} (nd₀ : l₀.NodupKeys) (nd₁
   mem_ext nd₀.nodup nd₁.nodup fun ⟨a, b⟩ => by
     rw [← mem_dlookup_iff, ← mem_dlookup_iff, h] <;> assumption
 
-theorem dlookup_map₁ {γ δ} [DecidableEq γ]
-    {l : List (Σ _ : α, δ)} {f : α → γ} (hf : Function.Injective f) (a : α) :
-    (l.map fun x => ⟨f x.1, x.2⟩ : List (Σ _ : γ, δ)).dlookup (f a) = l.dlookup a := by
-  induction' l with b l IH
-  · rw [map_nil, dlookup_nil, dlookup_nil]
-  · rw [map_cons]
-    obtain h | h := eq_or_ne (f a) (f b.1)
-    · rw [h, hf h, dlookup_cons_eq, dlookup_cons_eq]
-    · rw [dlookup_cons_ne _ _ h, dlookup_cons_ne _ _ (fun he => (he ▸ h) rfl), IH]
-
-theorem dlookup_map₂ {γ δ : α → Type*} {l : List (Σ a, γ a)} {f : ∀ a, γ a → δ a} (a : α) :
-    (l.map fun x => ⟨x.1, f _ x.2⟩ : List (Σ a, δ a)).dlookup a = (l.dlookup a).map (f a) := by
+theorem dlookup_map (l : List (Sigma β))
+    {f : α → α'} (hf : Function.Injective f) (g : ∀ a, β a → β' (f a)) (a : α) :
+    (l.map fun x => ⟨f x.1, g _ x.2⟩).dlookup (f a) = (l.dlookup a).map (g a) := by
   induction' l with b l IH
   · rw [map_nil, dlookup_nil, dlookup_nil, Option.map_none']
   · rw [map_cons]
     obtain rfl | h := eq_or_ne a b.1
     · rw [dlookup_cons_eq, dlookup_cons_eq, Option.map_some']
-    · rw [dlookup_cons_ne _ _ h, dlookup_cons_ne _ _ (fun he => (he ▸ h) rfl), IH]
+    · rw [dlookup_cons_ne _ _ h, dlookup_cons_ne _ _ (fun he => h <| hf he), IH]
+
+theorem dlookup_map₁ {β : Type v} (l : List (Σ _ : α, β))
+    {f : α → α'} (hf : Function.Injective f) (a : α) :
+    (l.map fun x => ⟨f x.1, x.2⟩ : List (Σ _ : α', β)).dlookup (f a) = l.dlookup a := by
+  rw [dlookup_map (β' := fun _ => β) l hf (fun _ x => x) a, Option.map_id'']
+
+theorem dlookup_map₂ {γ δ : α → Type*} {l : List (Σ a, γ a)} {f : ∀ a, γ a → δ a} (a : α) :
+    (l.map fun x => ⟨x.1, f _ x.2⟩ : List (Σ a, δ a)).dlookup a = (l.dlookup a).map (f a) :=
+  dlookup_map l Function.injective_id _ _
 
 /-! ### `lookupAll` -/
 


### PR DESCRIPTION
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

Conflicts with #15951 but can be merged in either order.

These are admittedly very specific results, but I make use of `dlookup_map₁` in an upcoming PR.

I don't know if dependent versions of these can exist.

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
