### PR TITLE
[Merged by Bors] - chore(tests/oldObtain): minor clean-ups

### DIFF
--- a/test/oldObtain.lean
+++ b/test/oldObtain.lean
@@ -7,6 +7,8 @@ import Mathlib.Tactic.Linter.OldObtain
 
 /-! Tests for the `oldObtain` linter. -/
 
+set_option linter.oldObtain false
+
 -- These cases are fine.
 theorem foo : True := by
   obtain := trivial
@@ -17,7 +19,6 @@ theorem foo : True := by
 
 -- These cases are linted against.
 
-set_option linter.oldObtain false in
 /--
 warning: Please remove stream-of-conciousness `obtain` syntax
 note: this linter can be disabled with `set_option linter.oldObtain false`
@@ -29,7 +30,6 @@ theorem foo' : True := by
   · trivial
   trivial
 
-set_option linter.oldObtain false in
 /--
 warning: Please remove stream-of-conciousness `obtain` syntax
 note: this linter can be disabled with `set_option linter.oldObtain false`


### PR DESCRIPTION
Rename the test to `oldObtain`, which better matches the others. And only disable the linter *once* in that file.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
