### PR TITLE
[Merged by Bors] - chore: correct `open` -> `open scoped`

### DIFF
--- a/Mathlib/Algebra/BigOperators/Group/Finset.lean
+++ b/Mathlib/Algebra/BigOperators/Group/Finset.lean
@@ -214,7 +214,7 @@ macro_rules (kind := bigprodin)
   | `(∏ $x:ident : $t in $s, $r) => `(∏ $x:ident ∈ ($s : Finset $t), $r)
 
 open Lean Meta Parser.Term PrettyPrinter.Delaborator SubExpr
-open Batteries.ExtendedBinder
+open scoped Batteries.ExtendedBinder
 
 /-- Delaborator for `Finset.prod`. The `pp.piBinderTypes` option controls whether
 to show the domain type when the product is over `Finset.univ`. -/

--- a/Mathlib/Algebra/ContinuedFractions/Computation/ApproximationCorollaries.lean
+++ b/Mathlib/Algebra/ContinuedFractions/Computation/ApproximationCorollaries.lean
@@ -37,11 +37,9 @@ Moreover, we show the convergence of the continued fractions computations, that 
 convergence, fractions
 -/
 
-
 variable {K : Type*} (v : K) [LinearOrderedField K] [FloorRing K]
 
 open GenContFract (of)
-open GenContFract
 open scoped Topology
 
 namespace GenContFract

--- a/Mathlib/Algebra/Group/Subgroup/Basic.lean
+++ b/Mathlib/Algebra/Group/Subgroup/Basic.lean
@@ -86,7 +86,7 @@ assert_not_exists Multiset
 assert_not_exists Ring
 
 open Function
-open Int
+open scoped Int
 
 variable {G G' G'' : Type*} [Group G] [Group G'] [Group G'']
 variable {A : Type*} [AddGroup A]

--- a/Mathlib/Algebra/Lie/Weights/Basic.lean
+++ b/Mathlib/Algebra/Lie/Weights/Basic.lean
@@ -50,8 +50,7 @@ variable {K R L M : Type*} [CommRing R] [LieRing L] [LieAlgebra R L]
 
 namespace LieModule
 
-open Set Function LieAlgebra TensorProduct TensorProduct.LieModule
-open scoped TensorProduct
+open Set Function  TensorProduct TensorProduct.LieModule
 
 section notation_genWeightSpaceOf
 

--- a/Mathlib/Algebra/Lie/Weights/Basic.lean
+++ b/Mathlib/Algebra/Lie/Weights/Basic.lean
@@ -50,7 +50,7 @@ variable {K R L M : Type*} [CommRing R] [LieRing L] [LieAlgebra R L]
 
 namespace LieModule
 
-open Set Function  TensorProduct TensorProduct.LieModule
+open Set Function TensorProduct LieModule
 
 section notation_genWeightSpaceOf
 

--- a/Mathlib/Algebra/Polynomial/Basic.lean
+++ b/Mathlib/Algebra/Polynomial/Basic.lean
@@ -49,8 +49,6 @@ equivalence is also registered as a ring equiv in `Polynomial.toFinsuppIso`. The
 in general not be used once the basic API for polynomials is constructed.
 -/
 
-
-
 noncomputable section
 
 /-- `Polynomial R` is the type of univariate polynomials over `R`.
@@ -65,8 +63,6 @@ structure Polynomial (R : Type*) [Semiring R] where ofFinsupp ::
 open AddMonoidAlgebra
 open Finsupp hiding single
 open Function hiding Commute
-
-open Polynomial
 
 namespace Polynomial
 

--- a/Mathlib/Analysis/Analytic/CPolynomial.lean
+++ b/Mathlib/Analysis/Analytic/CPolynomial.lean
@@ -42,10 +42,8 @@ We develop the basic properties of these notions, notably:
 variable {𝕜 E F G : Type*} [NontriviallyNormedField 𝕜] [NormedAddCommGroup E] [NormedSpace 𝕜 E]
   [NormedAddCommGroup F] [NormedSpace 𝕜 F] [NormedAddCommGroup G] [NormedSpace 𝕜 G]
 
-open scoped Classical
-open Topology NNReal Filter ENNReal
-
-open Set Filter Asymptotics
+open scoped Classical Topology
+open Set Filter Asymptotics NNReal ENNReal
 
 variable {f g : E → F} {p pf pg : FormalMultilinearSeries 𝕜 E F} {x : E} {r r' : ℝ≥0∞} {n m : ℕ}
 

--- a/Mathlib/Analysis/Analytic/Constructions.lean
+++ b/Mathlib/Analysis/Analytic/Constructions.lean
@@ -19,10 +19,8 @@ We show that the following are analytic:
 
 noncomputable section
 
-open scoped Classical
-open Topology NNReal Filter ENNReal
-
-open Set Filter Asymptotics
+open scoped Classical Topology
+open Filter Asymptotics ENNReal NNReal
 
 variable {α : Type*}
 variable {𝕜 : Type*} [NontriviallyNormedField 𝕜]

--- a/Mathlib/Analysis/Analytic/Linear.lean
+++ b/Mathlib/Analysis/Analytic/Linear.lean
@@ -12,7 +12,6 @@ In this file we prove that a `ContinuousLinearMap` defines an analytic function 
 the formal power series `f x = f a + f (x - a)`. We also prove similar results for multilinear maps.
 -/
 
-
 variable {𝕜 : Type*} [NontriviallyNormedField 𝕜] {E : Type*} [NormedAddCommGroup E]
   [NormedSpace 𝕜 E] {F : Type*} [NormedAddCommGroup F] [NormedSpace 𝕜 F] {G : Type*}
   [NormedAddCommGroup G] [NormedSpace 𝕜 G]

--- a/Mathlib/Analysis/Asymptotics/Asymptotics.lean
+++ b/Mathlib/Analysis/Asymptotics/Asymptotics.lean
@@ -44,11 +44,8 @@ it suffices to assume that `f` is zero wherever `g` is. (This generalization is 
 the Fréchet derivative.)
 -/
 
-
-open Filter Set
-
 open scoped Classical
-open Topology Filter NNReal
+open Set Topology Filter NNReal
 
 namespace Asymptotics
 

--- a/Mathlib/Analysis/BoxIntegral/Box/Basic.lean
+++ b/Mathlib/Analysis/BoxIntegral/Box/Basic.lean
@@ -51,13 +51,11 @@ that returns the box `⟨l, u, _⟩` if it is nonempty and `⊥` otherwise.
 rectangular box
 -/
 
-
 open Set Function Metric Filter
 
 noncomputable section
 
-open scoped Classical
-open NNReal Topology
+open scoped Classical NNReal Topology
 
 namespace BoxIntegral
 

--- a/Mathlib/Analysis/BoxIntegral/Partition/Additive.lean
+++ b/Mathlib/Analysis/BoxIntegral/Partition/Additive.lean
@@ -26,7 +26,6 @@ In this file we define box-additive functions and prove that a function such tha
 rectangular box, additive function
 -/
 
-
 noncomputable section
 
 open scoped Classical

--- a/Mathlib/Analysis/BoxIntegral/Partition/Basic.lean
+++ b/Mathlib/Analysis/BoxIntegral/Partition/Basic.lean
@@ -36,11 +36,8 @@ We also define a `SemilatticeInf` structure on `BoxIntegral.Prepartition I` for 
 rectangular box, partition
 -/
 
-
 open Set Finset Function
-
-open scoped Classical
-open NNReal
+open scoped Classical NNReal
 
 noncomputable section
 

--- a/Mathlib/Analysis/BoxIntegral/Partition/Filter.lean
+++ b/Mathlib/Analysis/BoxIntegral/Partition/Filter.lean
@@ -163,11 +163,8 @@ prepartition (and consider the special case `π = ⊥` separately if needed).
 integral, rectangular box, partition, filter
 -/
 
-
 open Set Function Filter Metric Finset Bool
-
-open scoped Classical
-open Topology Filter NNReal
+open scoped Classical Topology Filter NNReal
 
 noncomputable section
 

--- a/Mathlib/Analysis/BoxIntegral/Partition/Split.lean
+++ b/Mathlib/Analysis/BoxIntegral/Partition/Split.lean
@@ -35,12 +35,9 @@ is available as `BoxIntegral.Prepartition.compl`.
 rectangular box, partition, hyperplane
 -/
 
-
 noncomputable section
 
 open scoped Classical
-open Filter
-
 open Function Set Filter
 
 namespace BoxIntegral

--- a/Mathlib/Analysis/Calculus/Deriv/Add.lean
+++ b/Mathlib/Analysis/Calculus/Deriv/Add.lean
@@ -23,9 +23,9 @@ derivative
 universe u v w
 
 open scoped Classical
-open Topology Filter ENNReal
+open scoped Topology Filter ENNReal
 
-open Filter Asymptotics Set
+open Asymptotics Set
 
 variable {𝕜 : Type u} [NontriviallyNormedField 𝕜]
 variable {F : Type v} [NormedAddCommGroup F] [NormedSpace 𝕜 F]

--- a/Mathlib/Analysis/Calculus/Deriv/Comp.lean
+++ b/Mathlib/Analysis/Calculus/Deriv/Comp.lean
@@ -34,8 +34,7 @@ derivative, chain rule
 
 universe u v w
 
-open scoped Classical
-open Topology Filter ENNReal
+open scoped Classical Topology Filter ENNReal
 
 open Filter Asymptotics Set
 

--- a/Mathlib/Analysis/Calculus/Deriv/Inv.lean
+++ b/Mathlib/Analysis/Calculus/Deriv/Inv.lean
@@ -23,9 +23,7 @@ derivative
 
 universe u v w
 
-open scoped Classical
-open Topology Filter ENNReal
-
+open scoped Classical Topology ENNReal
 open Filter Asymptotics Set
 
 open ContinuousLinearMap (smulRight smulRight_one_eq_iff)

--- a/Mathlib/Analysis/Calculus/Deriv/Inverse.lean
+++ b/Mathlib/Analysis/Calculus/Deriv/Inverse.lean
@@ -24,9 +24,7 @@ derivative, inverse function
 
 universe u v w
 
-open scoped Classical
-open Topology Filter ENNReal
-
+open scoped Classical Topology ENNReal
 open Filter Asymptotics Set
 
 variable {𝕜 : Type u} [NontriviallyNormedField 𝕜]

--- a/Mathlib/Analysis/SpecialFunctions/Gamma/Deligne.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Gamma/Deligne.lean
@@ -28,7 +28,6 @@ This file defines these functions, and proves some elementary properties, includ
 formula which is an important input in functional equations of (un-completed) Dirichlet L-functions.
 -/
 
-
 open Filter Topology Asymptotics Real Set MeasureTheory
 open Complex hiding abs_of_nonneg
 

--- a/Mathlib/Computability/Halting.lean
+++ b/Mathlib/Computability/Halting.lean
@@ -16,7 +16,6 @@ A universal partial recursive function, Rice's theorem, and the halting problem.
 * [Mario Carneiro, *Formalizing computability theory via partial recursive functions*][carneiro2019]
 -/
 
-
 open Mathlib (Vector)
 open Encodable Denumerable
 

--- a/Mathlib/Computability/Primrec.lean
+++ b/Mathlib/Computability/Primrec.lean
@@ -28,7 +28,6 @@ for this.)
 * [Mario Carneiro, *Formalizing computability theory via partial recursive functions*][carneiro2019]
 -/
 
-
 open Mathlib (Vector)
 open Denumerable Encodable Function
 

--- a/Mathlib/Data/DFinsupp/Notation.lean
+++ b/Mathlib/Data/DFinsupp/Notation.lean
@@ -19,9 +19,7 @@ is correct.
 
 namespace DFinsupp
 
-open Lean
-open Lean.Parser
-open Lean.Parser.Term
+open Lean Parser Term
 
 attribute [term_parser] Finsupp.stxSingle₀ Finsupp.stxUpdate₀
 

--- a/Mathlib/Data/Fin/VecNotation.lean
+++ b/Mathlib/Data/Fin/VecNotation.lean
@@ -208,8 +208,7 @@ theorem cons_val_fin_one (x : α) (u : Fin 0 → α) : ∀ (i : Fin 1), vecCons 
 theorem cons_fin_one (x : α) (u : Fin 0 → α) : vecCons x u = fun _ => x :=
   funext (cons_val_fin_one x u)
 
-open Lean in
-open Qq in
+open Lean Qq in
 protected instance _root_.PiFin.toExpr [ToLevel.{u}] [ToExpr α] (n : ℕ) : ToExpr (Fin n → α) :=
   have lu := toLevel.{u}
   have eα : Q(Type $lu) := toTypeExpr α

--- a/Mathlib/Data/Finsupp/Notation.lean
+++ b/Mathlib/Data/Finsupp/Notation.lean
@@ -15,9 +15,7 @@ This file provides `fun₀ | 3 => a | 7 => b` notation for `Finsupp`, which desu
 
 namespace Finsupp
 
-open Lean
-open Lean.Parser
-open Lean.Parser.Term
+open Lean Parser Term
 
 -- A variant of `Lean.Parser.Term.matchAlts` with less line wrapping.
 @[nolint docBlame] -- we do not want any doc hover on this notation.

--- a/Mathlib/Data/Matrix/Notation.lean
+++ b/Mathlib/Data/Matrix/Notation.lean
@@ -46,8 +46,8 @@ variable {α : Type u} {o n m : ℕ} {m' : Type uₘ} {n' : Type uₙ} {o' : Typ
 open Matrix
 
 section toExpr
-open Lean
-open Qq
+
+open Lean Qq
 
 /-- Matrices can be reflected whenever their entries can. We insert a `Matrix.of` to
 prevent immediate decay to a function. -/

--- a/Mathlib/Dynamics/Circle/RotationNumber/TranslationNumber.lean
+++ b/Mathlib/Dynamics/Circle/RotationNumber/TranslationNumber.lean
@@ -115,7 +115,6 @@ Here are some short-term goals.
 circle homeomorphism, rotation number
 -/
 
-
 open Filter Set Int Topology
 open Function hiding Commute
 

--- a/Mathlib/GroupTheory/Perm/Cycle/Type.lean
+++ b/Mathlib/GroupTheory/Perm/Cycle/Type.lean
@@ -31,7 +31,6 @@ In this file we define the cycle type of a permutation.
   there exists an element of order `p` in `G`. This is known as Cauchy's theorem.
 -/
 
-
 namespace Equiv.Perm
 
 open Mathlib (Vector)

--- a/Mathlib/GroupTheory/Subgroup/Center.lean
+++ b/Mathlib/GroupTheory/Subgroup/Center.lean
@@ -15,9 +15,6 @@ import Mathlib.GroupTheory.Submonoid.Center
 assert_not_exists Multiset
 assert_not_exists Ring
 
-open Function
-open Int
-
 variable {G : Type*} [Group G]
 
 namespace Subgroup

--- a/Mathlib/GroupTheory/Subgroup/Centralizer.lean
+++ b/Mathlib/GroupTheory/Subgroup/Centralizer.lean
@@ -10,10 +10,6 @@ import Mathlib.GroupTheory.Submonoid.Centralizer
 # Centralizers of subgroups
 -/
 
-
-open Function
-open Int
-
 variable {G : Type*} [Group G]
 
 namespace Subgroup

--- a/Mathlib/LinearAlgebra/BilinearForm/TensorProduct.lean
+++ b/Mathlib/LinearAlgebra/BilinearForm/TensorProduct.lean
@@ -30,8 +30,7 @@ namespace LinearMap
 
 namespace BilinMap
 
-open LinearMap (BilinMap)
-open LinearMap (BilinForm)
+open LinearMap (BilinMap BilinForm)
 
 section CommSemiring
 variable [CommSemiring R] [CommSemiring A]

--- a/Mathlib/LinearAlgebra/CliffordAlgebra/Contraction.lean
+++ b/Mathlib/LinearAlgebra/CliffordAlgebra/Contraction.lean
@@ -40,8 +40,7 @@ Within this file, we use the local notation
 
 -/
 
-open LinearMap (BilinMap)
-open LinearMap (BilinForm)
+open LinearMap (BilinMap BilinForm)
 
 universe u1 u2 u3
 

--- a/Mathlib/LinearAlgebra/Eigenspace/Matrix.lean
+++ b/Mathlib/LinearAlgebra/Eigenspace/Matrix.lean
@@ -22,8 +22,7 @@ section SpectrumDiagonal
 
 variable {R n M : Type*} [DecidableEq n] [Fintype n]
 
-open Matrix
-open Module.End
+open Matrix Module.End
 
 section NontrivialCommRing
 

--- a/Mathlib/LinearAlgebra/Matrix/Charpoly/Coeff.lean
+++ b/Mathlib/LinearAlgebra/Matrix/Charpoly/Coeff.lean
@@ -298,7 +298,6 @@ end Ideal
 
 section reverse
 
-open Polynomial
 open LaurentPolynomial hiding C
 
 /-- The reverse of the characteristic polynomial of a matrix.

--- a/Mathlib/LinearAlgebra/QuadraticForm/Basic.lean
+++ b/Mathlib/LinearAlgebra/QuadraticForm/Basic.lean
@@ -75,14 +75,12 @@ has some further discusion.
 quadratic map, homogeneous polynomial, quadratic polynomial
 -/
 
-
 universe u v w
 
 variable {S T : Type*}
 variable {R : Type*} {M N P A : Type*}
 
-open LinearMap (BilinMap)
-open LinearMap (BilinForm)
+open LinearMap (BilinMap BilinForm)
 
 section Polar
 

--- a/Mathlib/LinearAlgebra/QuadraticForm/QuadraticModuleCat.lean
+++ b/Mathlib/LinearAlgebra/QuadraticForm/QuadraticModuleCat.lean
@@ -25,8 +25,7 @@ variable {R}
 
 namespace QuadraticModuleCat
 
-open QuadraticForm
-open QuadraticMap
+open QuadraticForm QuadraticMap
 
 instance : CoeSort (QuadraticModuleCat.{v} R) (Type v) :=
   ⟨(·.carrier)⟩

--- a/Mathlib/LinearAlgebra/QuadraticForm/QuadraticModuleCat/Monoidal.lean
+++ b/Mathlib/LinearAlgebra/QuadraticForm/QuadraticModuleCat/Monoidal.lean
@@ -35,8 +35,7 @@ variable {R : Type u} [CommRing R] [Invertible (2 : R)]
 
 namespace QuadraticModuleCat
 
-open QuadraticMap
-open QuadraticForm
+open QuadraticMap QuadraticForm
 
 namespace instMonoidalCategory
 

--- a/Mathlib/LinearAlgebra/QuadraticForm/TensorProduct.lean
+++ b/Mathlib/LinearAlgebra/QuadraticForm/TensorProduct.lean
@@ -20,10 +20,8 @@ universe uR uA uM₁ uM₂
 
 variable {R : Type uR} {A : Type uA} {M₁ : Type uM₁} {M₂ : Type uM₂}
 
-open TensorProduct
-open LinearMap (BilinMap)
-open LinearMap (BilinForm)
-open QuadraticMap
+open LinearMap (BilinMap BilinForm)
+open TensorProduct QuadraticMap
 
 namespace QuadraticForm
 

--- a/Mathlib/LinearAlgebra/Reflection.lean
+++ b/Mathlib/LinearAlgebra/Reflection.lean
@@ -40,7 +40,7 @@ should connect (or unify) these definitions with `Module.reflecton` defined here
 
 -/
 
-open Set Function Pointwise
+open Function Set
 open Module hiding Finite
 open Submodule (span)
 

--- a/Mathlib/Logic/Equiv/List.lean
+++ b/Mathlib/Logic/Equiv/List.lean
@@ -14,7 +14,6 @@ This file defines some additional constructive equivalences using `Encodable` an
 function on `ℕ`.
 -/
 
-
 open Mathlib (Vector)
 open Nat List
 


### PR DESCRIPTION
If a file contains two subsequent lines `open X Y Z` and `open P Q R`, most likely one of these is meant to be `open scoped`:
as I understand it, this is a mistake during the port, where `open_locale` ought to have get translated as `open scoped` (and not `open`).

We fix a few of these: sometimes, the other `open`s are used now, in which case we merge these statements.
If some item occurs as both open and open scoped, we delete the latter (as `open` implies the effects of `open scoped`).

Let me be bold and label this as technical debt: as fixing a late (and mostly benign) mis-port.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
