### PR TITLE
[Merged by Bors] - feat(RingTheory): `Valuation.Integers.not_denselyOrdered_of_isPrincipalIdealRing`

### DIFF
--- a/Mathlib/RingTheory/Ideal/Basic.lean
+++ b/Mathlib/RingTheory/Ideal/Basic.lean
@@ -490,6 +490,9 @@ theorem mul_mem_right (h : a ∈ I) : a * b ∈ I :=
 
 variable {b}
 
+lemma mem_of_dvd (hab : a ∣ b) (ha : a ∈ I) : b ∈ I := by
+  obtain ⟨c, rfl⟩ := hab; exact I.mul_mem_right _ ha
+
 theorem pow_mem_of_mem (ha : a ∈ I) (n : ℕ) (hn : 0 < n) : a ^ n ∈ I :=
   Nat.casesOn n (Not.elim (by decide))
     (fun m _hm => (pow_succ a m).symm ▸ I.mul_mem_left (a ^ m) ha) hn

--- a/Mathlib/RingTheory/Valuation/Integers.lean
+++ b/Mathlib/RingTheory/Valuation/Integers.lean
@@ -160,19 +160,19 @@ lemma isPrincipal_iff_exists_isGreatest (hv : Integers v O) {I : Ideal O} :
     refine ⟨a, ?_⟩
     ext b
     simp only [Ideal.submodule_span_eq, Ideal.mem_span_singleton]
-    exact ⟨fun hb ↦ dvd_of_le hv (hx.2 <| Set.mem_image_of_mem _ hb), fun hb ↦ I.mem_of_dvd hb ha⟩
+    exact ⟨fun hb ↦ dvd_of_le hv (hx.2 <| mem_image_of_mem _ hb), fun hb ↦ I.mem_of_dvd hb ha⟩
 
 lemma not_denselyOrdered_of_isPrincipalIdealRing [IsPrincipalIdealRing O] (hv : Integers v O) :
     ¬ DenselyOrdered (range v) := by
   intro H
   -- nonunits as an ideal isn't defined here, nor shown to be equivalent to `v x < 1`
   set I : Ideal O := {
-    carrier := v ∘ algebraMap O F ⁻¹' Set.Iio (1 : Γ₀)
+    carrier := v ∘ algebraMap O F ⁻¹' Iio (1 : Γ₀)
     add_mem' := fun {a b} ha hb ↦ by simpa using map_add_lt v ha hb
     zero_mem' := by simp
     smul_mem' := by
       intro c x
-      simp only [Set.mem_preimage, Function.comp_apply, Set.mem_Iio, smul_eq_mul, _root_.map_mul]
+      simp only [mem_preimage, Function.comp_apply, mem_Iio, smul_eq_mul, _root_.map_mul]
       intro hx
       exact Right.mul_lt_one_of_le_of_lt (hv.map_le_one c) hx
   }
@@ -183,7 +183,7 @@ lemma not_denselyOrdered_of_isPrincipalIdealRing [IsPrincipalIdealRing O] (hv : 
       using IsPrincipalIdealRing.principal I
   obtain ⟨y, hy, hy₁⟩ : ∃ y, v (algebraMap O F x) < v y ∧ v y < 1 := by
     simpa only [Subtype.exists, Subtype.mk_lt_mk, exists_range_iff, exists_prop]
-      using H.dense ⟨v (algebraMap O F x), Set.mem_range_self _⟩ ⟨1, 1, v.map_one⟩ hx₁
+      using H.dense ⟨v (algebraMap O F x), mem_range_self _⟩ ⟨1, 1, v.map_one⟩ hx₁
   obtain ⟨z, rfl⟩ := hv.exists_of_le_one hy₁.le
   exact hy.not_le <| hx ⟨hy₁, mem_range_self _⟩
 

--- a/Mathlib/RingTheory/Valuation/Integers.lean
+++ b/Mathlib/RingTheory/Valuation/Integers.lean
@@ -13,6 +13,7 @@ The elements with valuation less than or equal to 1.
 TODO: Define characteristic predicate.
 -/
 
+open Set
 
 universe u v w
 
@@ -145,7 +146,7 @@ theorem eq_algebraMap_or_inv_eq_algebraMap (hv : Integers v O) (x : F) :
   exacts [⟨a, Or.inl ha.symm⟩, ⟨a, Or.inr ha.symm⟩]
 
 lemma isPrincipal_iff_exists_isGreatest (hv : Integers v O) {I : Ideal O} :
-    I.IsPrincipal ↔ ∃ x, IsGreatest ((v ∘ algebraMap O F) '' I) x := by
+    I.IsPrincipal ↔ ∃ x, IsGreatest (v ∘ algebraMap O F '' I) x := by
   constructor <;> rintro ⟨x, hx⟩
   · refine ⟨(v ∘ algebraMap O F) x, ?_, ?_⟩
     · refine Set.mem_image_of_mem _ ?_
@@ -159,50 +160,32 @@ lemma isPrincipal_iff_exists_isGreatest (hv : Integers v O) {I : Ideal O} :
     refine ⟨a, ?_⟩
     ext b
     simp only [Ideal.submodule_span_eq, Ideal.mem_span_singleton]
-    constructor <;> intro hb
-    · exact dvd_of_le hv (hx.right <| Set.mem_image_of_mem _ hb)
-    · obtain ⟨c, rfl⟩ := hb
-      exact Ideal.mul_mem_right c I ha
+    exact ⟨fun hb ↦ dvd_of_le hv (hx.2 <| Set.mem_image_of_mem _ hb), fun hb ↦ I.mem_of_dvd hb ha⟩
 
 lemma not_denselyOrdered_of_isPrincipalIdealRing [IsPrincipalIdealRing O] (hv : Integers v O) :
-    ¬ DenselyOrdered (Set.range v) := by
+    ¬ DenselyOrdered (range v) := by
   intro H
   -- nonunits as an ideal isn't defined here, nor shown to be equivalent to `v x < 1`
   set I : Ideal O := {
-    carrier := (v ∘ algebraMap O F) ⁻¹' Set.Iio (1 : Γ₀)
-    add_mem' := by
-      intro a b ha hb
-      simpa using map_add_lt v ha hb
+    carrier := v ∘ algebraMap O F ⁻¹' Set.Iio (1 : Γ₀)
+    add_mem' := fun {a b} ha hb ↦ by simpa using map_add_lt v ha hb
     zero_mem' := by simp
     smul_mem' := by
       intro c x
       simp only [Set.mem_preimage, Function.comp_apply, Set.mem_Iio, smul_eq_mul, _root_.map_mul]
       intro hx
       exact Right.mul_lt_one_of_le_of_lt (hv.map_le_one c) hx
-  } with hI
-  obtain ⟨x, hx⟩ : ∃ x, IsGreatest ((v ∘ algebraMap O F) '' I) x := by
-    rw [← hv.isPrincipal_iff_exists_isGreatest]
-    exact IsPrincipalIdealRing.principal I
-  simp only [hI, Submodule.coe_set_mk, AddSubmonoid.coe_set_mk,
-    AddSubsemigroup.coe_set_mk, Set.image_preimage_eq_inter_range] at hx
-  have := hx.left
-  simp only [Set.mem_inter_iff, Set.mem_Iio, Set.mem_range, Function.comp_apply] at this
-  obtain ⟨hx', y, rfl⟩ := this
-  rw [← v.map_one] at hx'
-  obtain ⟨⟨z, hzv⟩, hz, hz'⟩ := H.dense ⟨v (algebraMap O F y), Set.mem_range_self _⟩
-    ⟨v 1, Set.mem_range_self _⟩ hx'
-  simp only [Set.mem_range] at hzv
-  obtain ⟨z, rfl⟩ := hzv
-  have := hx.right
-  rw [mem_upperBounds] at this
-  refine (this _ ?_).not_lt hz
-  simp only [Set.mem_inter_iff, Set.mem_Iio, Set.mem_range, Function.comp_apply, and_imp,
-    forall_exists_index] at this
-  specialize this (v z) (by simpa using hz')
-  refine ⟨?_, ?_⟩
-  · simpa using hz'
-  · obtain ⟨a, rfl⟩ := hv.exists_of_le_one (by simpa using hz'.le)
-    simp
+  }
+  obtain ⟨x, hx₁, hx⟩ :
+    ∃ x, v (algebraMap O F x) < 1 ∧
+      v (algebraMap O F x) ∈ upperBounds (Iio 1 ∩ range (v ∘ algebraMap O F)) := by
+    simpa [I, IsGreatest, hv.isPrincipal_iff_exists_isGreatest, ← image_preimage_eq_inter_range]
+      using IsPrincipalIdealRing.principal I
+  obtain ⟨y, hy, hy₁⟩ : ∃ y, v (algebraMap O F x) < v y ∧ v y < 1 := by
+    simpa only [Subtype.exists, Subtype.mk_lt_mk, exists_range_iff, exists_prop]
+      using H.dense ⟨v (algebraMap O F x), Set.mem_range_self _⟩ ⟨1, 1, v.map_one⟩ hx₁
+  obtain ⟨z, rfl⟩ := hv.exists_of_le_one hy₁.le
+  exact hy.not_le <| hx ⟨hy₁, mem_range_self _⟩
 
 -- TODO: isPrincipalIdealRing_iff_not_denselyOrdered when MulArchimedean
 

--- a/Mathlib/RingTheory/Valuation/Integers.lean
+++ b/Mathlib/RingTheory/Valuation/Integers.lean
@@ -193,9 +193,7 @@ lemma not_denselyOrdered_of_isPrincipalIdealRing [IsPrincipalIdealRing O] (hv : 
     ⟨v 1, Set.mem_range_self _⟩ hx'
   simp only [Set.mem_range] at hzv
   obtain ⟨z, rfl⟩ := hzv
-  have := hx.right
-  rw [mem_upperBounds] at this
-  refine (this _ ?_).not_lt hz
+  refine (hx.right ?_).not_lt hz
   simp only [Set.mem_inter_iff, Set.mem_Iio, Set.mem_range, Function.comp_apply, and_imp,
     forall_exists_index] at this
   specialize this (v z) (by simpa using hz')

--- a/Mathlib/RingTheory/Valuation/Integers.lean
+++ b/Mathlib/RingTheory/Valuation/Integers.lean
@@ -193,7 +193,9 @@ lemma not_denselyOrdered_of_isPrincipalIdealRing [IsPrincipalIdealRing O] (hv : 
     ⟨v 1, Set.mem_range_self _⟩ hx'
   simp only [Set.mem_range] at hzv
   obtain ⟨z, rfl⟩ := hzv
-  refine (hx.right ?_).not_lt hz
+  have := hx.right
+  rw [mem_upperBounds] at this
+  refine (this _ ?_).not_lt hz
   simp only [Set.mem_inter_iff, Set.mem_Iio, Set.mem_range, Function.comp_apply, and_imp,
     forall_exists_index] at this
   specialize this (v z) (by simpa using hz')


### PR DESCRIPTION
On the way to the iff when the range of valuation on nonzeros is `MulArchimedean`.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
