### PR TITLE
[Merged by Bors] - feat(Data/List/Sigma): Lemmas relating `List.dlookup` and `List.append`

### DIFF
--- a/Mathlib/Data/List/Sigma.lean
+++ b/Mathlib/Data/List/Sigma.lean
@@ -282,16 +282,15 @@ theorem perm_lookupAll (a : α) {l₁ l₂ : List (Sigma β)} (nd₁ : l₁.Nodu
     (p : l₁ ~ l₂) : lookupAll a l₁ = lookupAll a l₂ := by
   simp [lookupAll_eq_dlookup, nd₁, nd₂, perm_dlookup a nd₁ nd₂ p]
 
-theorem dlookup_append {l₀ : List (Sigma β)} {a : α} (l₁ : List (Sigma β)) :
-    (l₀ ++ l₁).dlookup a = (l₀.dlookup a).or (l₁.dlookup a) := by
-  induction' l₀ with b l₀ IH
-  · rfl
-  · rw [cons_append]
-    obtain rfl | hb := eq_or_ne a b.1
-    · iterate 2 rw [dlookup_cons_eq]
-      rfl
-    · iterate 2 rw [dlookup_cons_ne _ _ hb]
-      exact IH
+theorem dlookup_append (l₁ l₂ : List (Sigma β)) (a : α) :
+    (l₁ ++ l₂).dlookup a = (l₁.dlookup a).or (l₂.dlookup a) := by
+  induction l₁ with
+  | nil => rfl
+  | cons x l₁ IH =>
+    rw [cons_append]
+    obtain rfl | hb := Decidable.eq_or_ne a x.1
+    · rw [dlookup_cons_eq, dlookup_cons_eq, Option.or]
+    · rw [dlookup_cons_ne _ _ hb, dlookup_cons_ne _ _ hb, IH]
 
 /-! ### `kreplace` -/
 

--- a/Mathlib/Data/List/Sigma.lean
+++ b/Mathlib/Data/List/Sigma.lean
@@ -282,6 +282,24 @@ theorem perm_lookupAll (a : α) {l₁ l₂ : List (Sigma β)} (nd₁ : l₁.Nodu
     (p : l₁ ~ l₂) : lookupAll a l₁ = lookupAll a l₂ := by
   simp [lookupAll_eq_dlookup, nd₁, nd₂, perm_dlookup a nd₁ nd₂ p]
 
+theorem dlookup_append_of_not_mem_left {l₀ : List (Sigma β)} {a : α} (h : a ∉ l₀.keys)
+    (l₁ : List (Sigma β)) : (l₀ ++ l₁).dlookup a = l₁.dlookup a := by
+  induction' l₀ with b l₀ IH
+  · rfl
+  · rw [keys_cons, mem_cons, not_or] at h
+    rw [cons_append, dlookup_cons_ne _ _ h.1, IH]
+    exact h.2
+
+theorem dlookup_append_of_not_mem_right {l₁ : List (Sigma β)} {a : α} (l₀ : List (Sigma β))
+    (h : a ∉ l₁.keys) : (l₀ ++ l₁).dlookup a = l₀.dlookup a := by
+  induction' l₀ with b l₀ IH
+  · rwa [nil_append, dlookup_nil, dlookup_eq_none]
+  · rw [cons_append]
+    obtain rfl | hab := eq_or_ne a b.1
+    · iterate 2 rw [dlookup_cons_eq]
+    · iterate 2 rw [dlookup_cons_ne _ _ hab]
+      rw [IH]
+
 /-! ### `kreplace` -/
 
 

--- a/Mathlib/Data/List/Sigma.lean
+++ b/Mathlib/Data/List/Sigma.lean
@@ -282,23 +282,16 @@ theorem perm_lookupAll (a : α) {l₁ l₂ : List (Sigma β)} (nd₁ : l₁.Nodu
     (p : l₁ ~ l₂) : lookupAll a l₁ = lookupAll a l₂ := by
   simp [lookupAll_eq_dlookup, nd₁, nd₂, perm_dlookup a nd₁ nd₂ p]
 
-theorem dlookup_append_of_not_mem_left {l₀ : List (Sigma β)} {a : α} (h : a ∉ l₀.keys)
-    (l₁ : List (Sigma β)) : (l₀ ++ l₁).dlookup a = l₁.dlookup a := by
+theorem dlookup_append {l₀ : List (Sigma β)} {a : α} (l₁ : List (Sigma β)) :
+    (l₀ ++ l₁).dlookup a = (l₀.dlookup a).or (l₁.dlookup a) := by
   induction' l₀ with b l₀ IH
   · rfl
-  · rw [keys_cons, mem_cons, not_or] at h
-    rw [cons_append, dlookup_cons_ne _ _ h.1, IH]
-    exact h.2
-
-theorem dlookup_append_of_not_mem_right {l₁ : List (Sigma β)} {a : α} (l₀ : List (Sigma β))
-    (h : a ∉ l₁.keys) : (l₀ ++ l₁).dlookup a = l₀.dlookup a := by
-  induction' l₀ with b l₀ IH
-  · rwa [nil_append, dlookup_nil, dlookup_eq_none]
   · rw [cons_append]
-    obtain rfl | hab := eq_or_ne a b.1
+    obtain rfl | hb := eq_or_ne a b.1
     · iterate 2 rw [dlookup_cons_eq]
-    · iterate 2 rw [dlookup_cons_ne _ _ hab]
-      rw [IH]
+      rfl
+    · iterate 2 rw [dlookup_cons_ne _ _ hb]
+      exact IH
 
 /-! ### `kreplace` -/
 


### PR DESCRIPTION
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

Conflicts with #15928 but can be merged in any order.

Both of these lemmas are used in my development of the Cantor normal form.

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
