### PR TITLE
[Merged by Bors] - chore(SetTheory/Ordinal/Principal): clean up formatting

### DIFF
--- a/Mathlib/SetTheory/Ordinal/Principal.lean
+++ b/Mathlib/SetTheory/Ordinal/Principal.lean
@@ -24,16 +24,15 @@ We define principal or indecomposable ordinals, and we prove the standard proper
   of `fun x ↦ ω ^ x`.
 -/
 
-universe u v w
-
-noncomputable section
+universe u
 
 open Order
 
 namespace Ordinal
 
--- Porting note: commented out, doesn't seem necessary
---local infixr:0 "^" => @pow Ordinal Ordinal Ordinal.hasPow
+section Arbitrary
+
+variable {op : Ordinal → Ordinal → Ordinal}
 
 /-! ### Principal ordinals -/
 
@@ -42,40 +41,44 @@ namespace Ordinal
 ordinals less than it is closed under that operation. In standard mathematical usage, this term is
 almost exclusively used for additive and multiplicative principal ordinals.
 
-For simplicity, we break usual convention and regard 0 as principal. -/
+For simplicity, we break usual convention and regard `0` as principal. -/
 def Principal (op : Ordinal → Ordinal → Ordinal) (o : Ordinal) : Prop :=
   ∀ ⦃a b⦄, a < o → b < o → op a b < o
 
-theorem principal_iff_principal_swap {op : Ordinal → Ordinal → Ordinal} {o : Ordinal} :
-    Principal op o ↔ Principal (Function.swap op) o := by
+theorem principal_swap_iff {o : Ordinal} : Principal (Function.swap op) o ↔ Principal op o := by
   constructor <;> exact fun h a b ha hb => h hb ha
 
-theorem principal_zero {op : Ordinal → Ordinal → Ordinal} : Principal op 0 := fun a _ h =>
+theorem not_principal_iff {o : Ordinal} : ¬ Principal op o ↔ ∃ a < o, ∃ b < o, o ≤ op a b := by
+  simp [Principal]
+
+theorem principal_zero : Principal op 0 := fun a _ h =>
   (Ordinal.not_lt_zero a h).elim
 
 @[simp]
-theorem principal_one_iff {op : Ordinal → Ordinal → Ordinal} : Principal op 1 ↔ op 0 0 = 0 := by
+theorem principal_one_iff : Principal op 1 ↔ op 0 0 = 0 := by
   refine ⟨fun h => ?_, fun h a b ha hb => ?_⟩
   · rw [← lt_one_iff_zero]
     exact h zero_lt_one zero_lt_one
   · rwa [lt_one_iff_zero, ha, hb] at *
 
-theorem Principal.iterate_lt {op : Ordinal → Ordinal → Ordinal} {a o : Ordinal} (hao : a < o)
-    (ho : Principal op o) (n : ℕ) : (op a)^[n] a < o := by
+theorem Principal.iterate_lt {a o : Ordinal} (hao : a < o) (ho : Principal op o) (n : ℕ) :
+    (op a)^[n] a < o := by
   induction' n with n hn
   · rwa [Function.iterate_zero]
   · rw [Function.iterate_succ']
     exact ho hao hn
 
-theorem op_eq_self_of_principal {op : Ordinal → Ordinal → Ordinal} {a o : Ordinal.{u}} (hao : a < o)
-    (H : IsNormal (op a)) (ho : Principal op o) (ho' : IsLimit o) : op a o = o := by
+theorem op_eq_self_of_principal {a o : Ordinal.{u}} (hao : a < o) (H : IsNormal (op a))
+    (ho : Principal op o) (ho' : IsLimit o) : op a o = o := by
   refine le_antisymm ?_ (H.self_le _)
   rw [← IsNormal.bsup_eq.{u, u} H ho', bsup_le_iff]
   exact fun b hbo => (ho hao hbo).le
 
-theorem nfp_le_of_principal {op : Ordinal → Ordinal → Ordinal} {a o : Ordinal} (hao : a < o)
-    (ho : Principal op o) : nfp (op a) a ≤ o :=
+theorem nfp_le_of_principal {a o : Ordinal} (hao : a < o) (ho : Principal op o) :
+    nfp (op a) a ≤ o :=
   nfp_le fun n => (ho.iterate_lt hao n).le
+
+end Arbitrary
 
 /-! ### Principal ordinals are unbounded -/
 
@@ -85,8 +88,8 @@ we need to write `lt_blsub₂.{u}` twice below,
 where previously the universe annotation was not necessary.
 This appears to be correct behaviour, as `lt_blsub₂.{0}` also works. -/
 theorem principal_nfp_blsub₂ (op : Ordinal → Ordinal → Ordinal) (o : Ordinal) :
-    Principal op (nfp (fun o' => blsub₂.{u, u, u} o' o' (@fun a _ b _ => op a b)) o) :=
-  fun a b ha hb => by
+    Principal op (nfp (fun o' => blsub₂.{u, u, u} o' o' (@fun a _ b _ => op a b)) o) := by
+  intro a b ha hb
   rw [lt_nfp] at *
   cases' ha with m hm
   cases' hb with n hn
@@ -95,11 +98,12 @@ theorem principal_nfp_blsub₂ (op : Ordinal → Ordinal → Ordinal) (o : Ordin
     ((fun o' => blsub₂.{u, u, u} o' o' (@fun a _ b _ => op a b))^[n] o) with h h
   · use n + 1
     rw [Function.iterate_succ']
-    exact lt_blsub₂.{u} (@fun a _ b _ => op a b) (hm.trans_le h) hn
+    exact lt_blsub₂ (@fun a _ b _ => op a b) (hm.trans_le h) hn
   · use m + 1
     rw [Function.iterate_succ']
-    exact lt_blsub₂.{u} (@fun a _ b _ => op a b) hm (hn.trans_le h)
+    exact lt_blsub₂ (@fun a _ b _ => op a b) hm (hn.trans_le h)
 
+/-- Principal ordinals under any operation form a ZFC proper class. -/
 theorem unbounded_principal (op : Ordinal → Ordinal → Ordinal) :
     Set.Unbounded (· < ·) { o | Principal op o } := fun o =>
   ⟨_, principal_nfp_blsub₂ op o, (le_nfp _ o).not_lt⟩
@@ -139,60 +143,61 @@ theorem principal_add_iff_add_left_eq_self {o : Ordinal} :
     exact (add_isNormal a).strictMono hbo
 
 theorem exists_lt_add_of_not_principal_add {a} (ha : ¬Principal (· + ·) a) :
-    ∃ b c, b < a ∧ c < a ∧ b + c = a := by
-  unfold Principal at ha
-  push_neg at ha
-  rcases ha with ⟨b, c, hb, hc, H⟩
+    ∃ b < a, ∃ c < a, b + c = a := by
+  rw [not_principal_iff] at ha
+  rcases ha with ⟨b, hb, c, hc, H⟩
   refine
-    ⟨b, _, hb, lt_of_le_of_ne (sub_le_self a b) fun hab => ?_, Ordinal.add_sub_cancel_of_le hb.le⟩
+    ⟨b, hb, _, lt_of_le_of_ne (sub_le_self a b) fun hab => ?_, Ordinal.add_sub_cancel_of_le hb.le⟩
   rw [← sub_le, hab] at H
   exact H.not_lt hc
 
 theorem principal_add_iff_add_lt_ne_self {a} :
-    Principal (· + ·) a ↔ ∀ ⦃b c⦄, b < a → c < a → b + c ≠ a :=
-  ⟨fun ha b c hb hc => (ha hb hc).ne, fun H => by
+    Principal (· + ·) a ↔ ∀ b < a, ∀ c < a, b + c ≠ a :=
+  ⟨fun ha b hb c hc => (ha hb hc).ne, fun H => by
     by_contra! ha
-    rcases exists_lt_add_of_not_principal_add ha with ⟨b, c, hb, hc, rfl⟩
-    exact (H hb hc).irrefl⟩
+    rcases exists_lt_add_of_not_principal_add ha with ⟨b, hb, c, hc, rfl⟩
+    exact (H b hb c hc).irrefl⟩
 
-theorem add_omega {a : Ordinal} (h : a < omega) : a + omega = omega := by
+theorem add_omega {a : Ordinal} (h : a < ω) : a + ω = ω := by
   rcases lt_omega.1 h with ⟨n, rfl⟩
   clear h; induction' n with n IH
   · rw [Nat.cast_zero, zero_add]
   · rwa [Nat.cast_succ, add_assoc, one_add_of_omega_le (le_refl _)]
 
-theorem principal_add_omega : Principal (· + ·) omega :=
+theorem principal_add_omega : Principal (· + ·) ω :=
   principal_add_iff_add_left_eq_self.2 fun _ => add_omega
 
-theorem add_omega_opow {a b : Ordinal} (h : a < (omega^b)) : a + (omega^b) = (omega^b) := by
-  refine le_antisymm ?_ (le_add_left _ _)
+theorem add_omega_opow {a b : Ordinal} (h : a < ω ^ b) : a + ω ^ b = ω ^ b := by
+  refine le_antisymm ?_ (le_add_left _ a)
   induction' b using limitRecOn with b _ b l IH
   · rw [opow_zero, ← succ_zero, lt_succ_iff, Ordinal.le_zero] at h
     rw [h, zero_add]
   · rw [opow_succ] at h
     rcases (lt_mul_of_limit omega_isLimit).1 h with ⟨x, xo, ax⟩
-    refine le_trans (add_le_add_right (le_of_lt ax) _) ?_
+    apply (add_le_add_right ax.le _).trans
     rw [opow_succ, ← mul_add, add_omega xo]
   · rcases (lt_opow_of_limit omega_ne_zero l).1 h with ⟨x, xb, ax⟩
-    exact
-      (((add_isNormal a).trans (opow_isNormal one_lt_omega)).limit_le l).2 fun y yb =>
-        (add_le_add_left (opow_le_opow_right omega_pos (le_max_right _ _)) _).trans
-          (le_trans
-            (IH _ (max_lt xb yb) (ax.trans_le <| opow_le_opow_right omega_pos (le_max_left _ _)))
-            (opow_le_opow_right omega_pos <| le_of_lt <| max_lt xb yb))
+    apply (((add_isNormal a).trans <| opow_isNormal one_lt_omega).limit_le l).2
+    intro y yb
+    calc a + ω ^ y ≤ a + ω ^ max x y :=
+      add_le_add_left (opow_le_opow_right omega_pos (le_max_right x y)) _
+    _ ≤ ω ^ max x y :=
+      IH _ (max_lt xb yb) <| ax.trans_le <| opow_le_opow_right omega_pos <| le_max_left x y
+    _ ≤ ω ^ b :=
+      opow_le_opow_right omega_pos <| (max_lt xb yb).le
 
-theorem principal_add_omega_opow (o : Ordinal) : Principal (· + ·) (omega^o) :=
+theorem principal_add_omega_opow (o : Ordinal) : Principal (· + ·) (ω ^ o) :=
   principal_add_iff_add_left_eq_self.2 fun _ => add_omega_opow
 
 /-- The main characterization theorem for additive principal ordinals. -/
 theorem principal_add_iff_zero_or_omega_opow {o : Ordinal} :
-    Principal (· + ·) o ↔ o = 0 ∨ ∃ a : Ordinal, o = (omega^a) := by
+    Principal (· + ·) o ↔ o = 0 ∨ o ∈ Set.range (ω ^ · : Ordinal → Ordinal) := by
   rcases eq_or_ne o 0 with (rfl | ho)
   · simp only [principal_zero, Or.inl]
   · rw [principal_add_iff_add_left_eq_self]
     simp only [ho, false_or_iff]
     refine
-      ⟨fun H => ⟨_, ((lt_or_eq_of_le (opow_log_le_self _ ho)).resolve_left fun h => ?_).symm⟩,
+      ⟨fun H => ⟨_, ((lt_or_eq_of_le (opow_log_le_self _ ho)).resolve_left fun h => ?_)⟩,
         fun ⟨b, e⟩ => e.symm ▸ fun a => add_omega_opow⟩
     have := H _ h
     have := lt_opow_succ_log_self one_lt_omega o
@@ -202,14 +207,14 @@ theorem principal_add_iff_zero_or_omega_opow {o : Ordinal} :
     clear ao
     revert h'
     apply not_lt_of_le
-    suffices e : (omega^log omega o) * ↑n + o = o by
-      simpa only [e] using le_add_right ((omega^log omega o) * ↑n) o
+    suffices e : ω ^ log ω o * n + o = o by
+      simpa only [e] using le_add_right (ω ^ log ω o * ↑n) o
     induction' n with n IH
     · simp [Nat.cast_zero, mul_zero, zero_add]
-    simp only [Nat.cast_succ, mul_add_one, add_assoc, this, IH]
+    · simp only [Nat.cast_succ, mul_add_one, add_assoc, this, IH]
 
 theorem opow_principal_add_of_principal_add {a} (ha : Principal (· + ·) a) (b : Ordinal) :
-    Principal (· + ·) (a^b) := by
+    Principal (· + ·) (a ^ b) := by
   rcases principal_add_iff_zero_or_omega_opow.1 ha with (rfl | ⟨c, rfl⟩)
   · rcases eq_or_ne b 0 with (rfl | hb)
     · rw [opow_zero]
@@ -218,7 +223,7 @@ theorem opow_principal_add_of_principal_add {a} (ha : Principal (· + ·) a) (b 
   · rw [← opow_mul]
     exact principal_add_omega_opow _
 
-theorem add_absorp {a b c : Ordinal} (h₁ : a < (omega^b)) (h₂ : (omega^b) ≤ c) : a + c = c := by
+theorem add_absorp {a b c : Ordinal} (h₁ : a < ω ^ b) (h₂ : ω ^ b ≤ c) : a + c = c := by
   rw [← Ordinal.add_sub_cancel_of_le h₂, ← add_assoc, add_omega_opow h₁]
 
 theorem mul_principal_add_is_principal_add (a : Ordinal.{u}) {b : Ordinal.{u}} (hb₁ : b ≠ 1)
@@ -245,17 +250,15 @@ theorem principal_mul_one : Principal (· * ·) 1 := by
   rw [principal_one_iff]
   exact zero_mul _
 
-theorem principal_mul_two : Principal (· * ·) 2 := fun a b ha hb => by
-  have h₂ : succ (1 : Ordinal) = 2 := by simp
-  dsimp only
-  rw [← h₂, lt_succ_iff] at ha hb ⊢
+theorem principal_mul_two : Principal (· * ·) 2 := by
+  intro a b ha hb
+  rw [← succ_one, lt_succ_iff] at *
   convert mul_le_mul' ha hb
   exact (mul_one 1).symm
 
 theorem principal_mul_of_le_two {o : Ordinal} (ho : o ≤ 2) : Principal (· * ·) o := by
   rcases lt_or_eq_of_le ho with (ho | rfl)
-  · have h₂ : succ (1 : Ordinal) = 2 := by simp
-    rw [← h₂, lt_succ_iff] at ho
+  · rw [← succ_one, lt_succ_iff] at ho
     rcases lt_or_eq_of_le ho with (ho | rfl)
     · rw [lt_one_iff_zero.1 ho]
       exact principal_zero
@@ -294,17 +297,17 @@ theorem principal_mul_iff_mul_left_eq {o : Ordinal} :
     rw [← h a ha hao]
     exact (mul_isNormal ha).strictMono hbo
 
-theorem principal_mul_omega : Principal (· * ·) omega := fun a b ha hb =>
+theorem principal_mul_omega : Principal (· * ·) ω := fun a b ha hb =>
   match a, b, lt_omega.1 ha, lt_omega.1 hb with
   | _, _, ⟨m, rfl⟩, ⟨n, rfl⟩ => by
     dsimp only; rw [← natCast_mul]
     apply nat_lt_omega
 
-theorem mul_omega {a : Ordinal} (a0 : 0 < a) (ha : a < omega) : a * omega = omega :=
+theorem mul_omega {a : Ordinal} (a0 : 0 < a) (ha : a < ω) : a * ω = ω :=
   principal_mul_iff_mul_left_eq.1 principal_mul_omega a a0 ha
 
-theorem mul_lt_omega_opow {a b c : Ordinal} (c0 : 0 < c) (ha : a < (omega^c)) (hb : b < omega) :
-    a * b < (omega^c) := by
+theorem mul_lt_omega_opow {a b c : Ordinal} (c0 : 0 < c) (ha : a < ω ^ c) (hb : b < ω) :
+    a * b < ω ^ c := by
   rcases zero_or_succ_or_limit c with (rfl | ⟨c, rfl⟩ | l)
   · exact (lt_irrefl _).elim c0
   · rw [opow_succ] at ha
@@ -317,58 +320,60 @@ theorem mul_lt_omega_opow {a b c : Ordinal} (c0 : 0 < c) (ha : a < (omega^c)) (h
     rw [← opow_succ, opow_lt_opow_iff_right one_lt_omega]
     exact l.2 _ hx
 
-theorem mul_omega_opow_opow {a b : Ordinal} (a0 : 0 < a) (h : a < (omega^omega^b)) :
-    a * (omega^omega^b) = (omega^omega^b) := by
-  by_cases b0 : b = 0
-  · rw [b0, opow_zero, opow_one] at h ⊢
+theorem mul_omega_opow_opow {a b : Ordinal} (a0 : 0 < a) (h : a < ω ^ ω ^ b) :
+    a * ω ^ ω ^ b = ω ^ ω ^ b := by
+  obtain rfl | b0 := eq_or_ne b 0
+  · rw [opow_zero, opow_one] at h ⊢
     exact mul_omega a0 h
-  refine
-    le_antisymm ?_
-      (by simpa only [one_mul] using mul_le_mul_right' (one_le_iff_pos.2 a0) (omega^omega^b))
-  rcases (lt_opow_of_limit omega_ne_zero (opow_isLimit_left omega_isLimit b0)).1 h with ⟨x, xb, ax⟩
-  apply (mul_le_mul_right' (le_of_lt ax) _).trans
-  rw [← opow_add, add_omega_opow xb]
+  · apply le_antisymm
+    · obtain ⟨x, xb, ax⟩ :=
+        (lt_opow_of_limit omega_ne_zero (opow_isLimit_left omega_isLimit b0)).1 h
+      apply (mul_le_mul_right' (le_of_lt ax) _).trans
+      rw [← opow_add, add_omega_opow xb]
+    · conv_lhs => rw [← one_mul (ω ^ _)]
+      exact mul_le_mul_right' (one_le_iff_pos.2 a0) _
 
-theorem principal_mul_omega_opow_opow (o : Ordinal) : Principal (· * ·) (omega^omega^o) :=
+theorem principal_mul_omega_opow_opow (o : Ordinal) : Principal (· * ·) (ω ^ ω ^ o) :=
   principal_mul_iff_mul_left_eq.2 fun _ => mul_omega_opow_opow
 
 theorem principal_add_of_principal_mul_opow {o b : Ordinal} (hb : 1 < b)
-    (ho : Principal (· * ·) (b^o)) : Principal (· + ·) o := fun x y hx hy => by
+    (ho : Principal (· * ·) (b ^ o)) : Principal (· + ·) o := by
+  intro x y hx hy
   have := ho ((opow_lt_opow_iff_right hb).2 hx) ((opow_lt_opow_iff_right hb).2 hy)
-  dsimp only at *; rwa [← opow_add, opow_lt_opow_iff_right hb] at this
+  dsimp only at *
+  rwa [← opow_add, opow_lt_opow_iff_right hb] at this
 
 /-- The main characterization theorem for multiplicative principal ordinals. -/
 theorem principal_mul_iff_le_two_or_omega_opow_opow {o : Ordinal} :
-    Principal (· * ·) o ↔ o ≤ 2 ∨ ∃ a : Ordinal, o = (omega^omega^a) := by
+    Principal (· * ·) o ↔ o ≤ 2 ∨ o ∈ Set.range (ω ^ ω ^ · : Ordinal → Ordinal) := by
   refine ⟨fun ho => ?_, ?_⟩
   · rcases le_or_lt o 2 with ho₂ | ho₂
     · exact Or.inl ho₂
-    rcases principal_add_iff_zero_or_omega_opow.1 (principal_add_of_principal_mul ho ho₂.ne') with
+    · rcases principal_add_iff_zero_or_omega_opow.1 (principal_add_of_principal_mul ho ho₂.ne') with
       (rfl | ⟨a, rfl⟩)
-    · exact (Ordinal.not_lt_zero 2 ho₂).elim
-    rcases principal_add_iff_zero_or_omega_opow.1
-        (principal_add_of_principal_mul_opow one_lt_omega ho) with
-      (rfl | ⟨b, rfl⟩)
-    · simp
-    exact Or.inr ⟨b, rfl⟩
+      · exact (Ordinal.not_lt_zero 2 ho₂).elim
+      · rcases principal_add_iff_zero_or_omega_opow.1
+          (principal_add_of_principal_mul_opow one_lt_omega ho) with (rfl | ⟨b, rfl⟩)
+        · simp
+        · exact Or.inr ⟨b, rfl⟩
   · rintro (ho₂ | ⟨a, rfl⟩)
     · exact principal_mul_of_le_two ho₂
     · exact principal_mul_omega_opow_opow a
 
-theorem mul_omega_dvd {a : Ordinal} (a0 : 0 < a) (ha : a < omega) : ∀ {b}, omega ∣ b → a * b = b
+theorem mul_omega_dvd {a : Ordinal} (a0 : 0 < a) (ha : a < ω) : ∀ {b}, ω ∣ b → a * b = b
   | _, ⟨b, rfl⟩ => by rw [← mul_assoc, mul_omega a0 ha]
 
 theorem mul_eq_opow_log_succ {a b : Ordinal.{u}} (ha : a ≠ 0) (hb : Principal (· * ·) b)
-    (hb₂ : 2 < b) : a * b = (b^succ (log b a)) := by
+    (hb₂ : 2 < b) : a * b = b ^ succ (log b a) := by
   apply le_antisymm
   · have hbl := principal_mul_isLimit hb₂ hb
     rw [← IsNormal.bsup_eq.{u, u} (mul_isNormal (Ordinal.pos_iff_ne_zero.2 ha)) hbl, bsup_le_iff]
     intro c hcb
-    have hb₁ : 1 < b := (lt_succ 1).trans (by simpa using hb₂)
-    have hbo₀ : (b^b.log a) ≠ 0 := Ordinal.pos_iff_ne_zero.1 (opow_pos _ (zero_lt_one.trans hb₁))
-    apply le_trans (mul_le_mul_right' (le_of_lt (lt_mul_succ_div a hbo₀)) c)
+    have hb₁ : 1 < b := (lt_succ 1).trans (by rwa [succ_one])
+    have hbo₀ : b ^ log b a ≠ 0 := Ordinal.pos_iff_ne_zero.1 (opow_pos _ (zero_lt_one.trans hb₁))
+    apply (mul_le_mul_right' (le_of_lt (lt_mul_succ_div a hbo₀)) c).trans
     rw [mul_assoc, opow_succ]
-    refine mul_le_mul_left' (le_of_lt (hb (hbl.2 _ ?_) hcb)) _
+    refine mul_le_mul_left' (hb (hbl.2 _ ?_) hcb).le _
     rw [div_lt hbo₀, ← opow_succ]
     exact lt_opow_succ_log_self hb₁ _
   · rw [opow_succ]
@@ -377,16 +382,15 @@ theorem mul_eq_opow_log_succ {a b : Ordinal.{u}} (ha : a ≠ 0) (hb : Principal 
 /-! #### Exponential principal ordinals -/
 
 
-theorem principal_opow_omega : Principal (·^·) omega := fun a b ha hb =>
+theorem principal_opow_omega : Principal (· ^ ·) ω := fun a b ha hb =>
   match a, b, lt_omega.1 ha, lt_omega.1 hb with
   | _, _, ⟨m, rfl⟩, ⟨n, rfl⟩ => by
     simp_rw [← natCast_opow]
     apply nat_lt_omega
 
-theorem opow_omega {a : Ordinal} (a1 : 1 < a) (h : a < omega) : (a^omega) = omega :=
-  le_antisymm
-    ((opow_le_of_limit (one_le_iff_ne_zero.1 <| le_of_lt a1) omega_isLimit).2 fun _ hb =>
-      (principal_opow_omega h hb).le)
-    (right_le_opow _ a1)
+theorem opow_omega {a : Ordinal} (a1 : 1 < a) (h : a < ω) : a ^ ω = ω :=
+  ((opow_le_of_limit (one_le_iff_ne_zero.1 <| le_of_lt a1) omega_isLimit).2 fun _ hb =>
+      (principal_opow_omega h hb).le).antisymm
+  (right_le_opow _ a1)
 
 end Ordinal

--- a/Mathlib/SetTheory/Ordinal/Principal.lean
+++ b/Mathlib/SetTheory/Ordinal/Principal.lean
@@ -48,6 +48,11 @@ def Principal (op : Ordinal → Ordinal → Ordinal) (o : Ordinal) : Prop :=
 theorem principal_swap_iff {o : Ordinal} : Principal (Function.swap op) o ↔ Principal op o := by
   constructor <;> exact fun h a b ha hb => h hb ha
 
+@[deprecated principal_swap_iff (since := "2024-08-18")]
+theorem principal_iff_principal_swap {o : Ordinal} :
+    Principal op o ↔ Principal (Function.swap op) o :=
+  principal_swap_iff
+
 theorem not_principal_iff {o : Ordinal} : ¬ Principal op o ↔ ∃ a < o, ∃ b < o, o ≤ op a b := by
   simp [Principal]
 


### PR DESCRIPTION
This PR does the following:

- Clean up some term mode sorcery.
- Use the `ω` notation throughout.
- Remove unneeded parentheses.
- Indent proofs correctly.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
