### PR TITLE
[Merged by Bors] - fix(lint-style): make sure Python style errors fail the linting step; fix --fix mode

### DIFF
--- a/Mathlib/Geometry/Manifold/Instances/Real.lean
+++ b/Mathlib/Geometry/Manifold/Instances/Real.lean
@@ -180,7 +180,7 @@ scoped[Manifold]
       ModelWithCorners ℝ (EuclideanSpace ℝ (Fin n)) (EuclideanHalfSpace n))
 
 lemma range_modelWithCornersEuclideanHalfSpace (n : ℕ) [NeZero n] :
-  range (𝓡∂ n) = { y | 0 ≤ y 0 } := range_euclideanHalfSpace n
+    range (𝓡∂ n) = { y | 0 ≤ y 0 } := range_euclideanHalfSpace n
 
 lemma interior_range_modelWithCornersEuclideanHalfSpace (n : ℕ) [NeZero n] :
     interior (range (𝓡∂ n)) = { y | 0 < y 0 } := by

--- a/Mathlib/Geometry/Manifold/Instances/Real.lean
+++ b/Mathlib/Geometry/Manifold/Instances/Real.lean
@@ -180,7 +180,7 @@ scoped[Manifold]
       ModelWithCorners ℝ (EuclideanSpace ℝ (Fin n)) (EuclideanHalfSpace n))
 
 lemma range_modelWithCornersEuclideanHalfSpace (n : ℕ) [NeZero n] :
-    range (𝓡∂ n) = { y | 0 ≤ y 0 } := range_euclideanHalfSpace n
+range (𝓡∂ n) = { y | 0 ≤ y 0 } := range_euclideanHalfSpace n
 
 lemma interior_range_modelWithCornersEuclideanHalfSpace (n : ℕ) [NeZero n] :
     interior (range (𝓡∂ n)) = { y | 0 < y 0 } := by

--- a/Mathlib/Geometry/Manifold/Instances/Real.lean
+++ b/Mathlib/Geometry/Manifold/Instances/Real.lean
@@ -180,7 +180,7 @@ scoped[Manifold]
       ModelWithCorners ℝ (EuclideanSpace ℝ (Fin n)) (EuclideanHalfSpace n))
 
 lemma range_modelWithCornersEuclideanHalfSpace (n : ℕ) [NeZero n] :
-range (𝓡∂ n) = { y | 0 ≤ y 0 } := range_euclideanHalfSpace n
+    range (𝓡∂ n) = { y | 0 ≤ y 0 } := range_euclideanHalfSpace n
 
 lemma interior_range_modelWithCornersEuclideanHalfSpace (n : ℕ) [NeZero n] :
     interior (range (𝓡∂ n)) = { y | 0 < y 0 } := by

--- a/Mathlib/Tactic/Linter/TextBased.lean
+++ b/Mathlib/Tactic/Linter/TextBased.lean
@@ -457,10 +457,12 @@ def lintModules (moduleNames : Array String) (mode : OutputSetting) (fix : Bool)
     -- or wait until lint-style.py is fully rewritten in Lean.
     let args := if fix then #["--fix"] else #[]
     let pythonOutput ← IO.Process.run { cmd := "./scripts/print-style-errors.sh", args := args }
-    if pythonOutput != "" then IO.println pythonOutput
+    if pythonOutput != "" then
+      numberErrorFiles := numberErrorFiles + 1
+      IO.print pythonOutput
     formatErrors allUnexpectedErrors style
-    if numberErrorFiles > 0 && mode matches OutputSetting.print _ then
-      IO.println s!"error: found {allUnexpectedErrors.size} new style errors\n\
+    if allUnexpectedErrors.size > 0 && mode matches OutputSetting.print _ then
+      IO.println s!"error: found {allUnexpectedErrors.size} new style error(s)\n\
         run `lake exe lint-style --update` to ignore all of them"
   | OutputSetting.update =>
     formatErrors allUnexpectedErrors ErrorFormat.humanReadable

--- a/Mathlib/Tactic/Linter/TextBased.lean
+++ b/Mathlib/Tactic/Linter/TextBased.lean
@@ -460,7 +460,7 @@ def lintModules (moduleNames : Array String) (mode : OutputSetting) (fix : Bool)
     if pythonOutput != "" then
       numberErrorFiles := numberErrorFiles + 1
       IO.print pythonOutput
-    formatErrors allUnexpectedErrors style        ;    let n := 42
+    formatErrors allUnexpectedErrors style
     if allUnexpectedErrors.size > 0 && mode matches OutputSetting.print _ then
       IO.println s!"error: found {allUnexpectedErrors.size} new style error(s)\n\
         run `lake exe lint-style --update` to ignore all of them"

--- a/Mathlib/Tactic/Linter/TextBased.lean
+++ b/Mathlib/Tactic/Linter/TextBased.lean
@@ -460,7 +460,7 @@ def lintModules (moduleNames : Array String) (mode : OutputSetting) (fix : Bool)
     if pythonOutput != "" then
       numberErrorFiles := numberErrorFiles + 1
       IO.print pythonOutput
-    formatErrors allUnexpectedErrors style         ;    let n := 42
+    formatErrors allUnexpectedErrors style        ;    let n := 42
     if allUnexpectedErrors.size > 0 && mode matches OutputSetting.print _ then
       IO.println s!"error: found {allUnexpectedErrors.size} new style error(s)\n\
         run `lake exe lint-style --update` to ignore all of them"

--- a/Mathlib/Tactic/Linter/TextBased.lean
+++ b/Mathlib/Tactic/Linter/TextBased.lean
@@ -460,7 +460,7 @@ def lintModules (moduleNames : Array String) (mode : OutputSetting) (fix : Bool)
     if pythonOutput != "" then
       numberErrorFiles := numberErrorFiles + 1
       IO.print pythonOutput
-    formatErrors allUnexpectedErrors style
+    formatErrors allUnexpectedErrors style         ;    let n := 42
     if allUnexpectedErrors.size > 0 && mode matches OutputSetting.print _ then
       IO.println s!"error: found {allUnexpectedErrors.size} new style error(s)\n\
         run `lake exe lint-style --update` to ignore all of them"

--- a/scripts/print-style-errors.sh
+++ b/scripts/print-style-errors.sh
@@ -6,6 +6,6 @@
 
 # use C locale so that sorting is the same on macOS and Linux
 # see https://unix.stackexchange.com/questions/362728/why-does-gnu-sort-sort-differently-on-my-osx-machine-and-linux-machine
-find Mathlib -name '*.lean' | xargs ./scripts/lint-style.py | LC_ALL=C sort
-find Archive -name '*.lean' | xargs ./scripts/lint-style.py | LC_ALL=C sort
-find Counterexamples -name '*.lean' | xargs ./scripts/lint-style.py | LC_ALL=C sort
+find Mathlib -name '*.lean' | xargs ./scripts/lint-style.py "$@" | LC_ALL=C sort
+find Archive -name '*.lean' | xargs ./scripts/lint-style.py "$@" | LC_ALL=C sort
+find Counterexamples -name '*.lean' | xargs ./scripts/lint-style.py "$@" | LC_ALL=C sort


### PR DESCRIPTION
We need to pass any --fix flag down to `lint-style.py`; this detail got lost along the rewrite.

While at it, tweak the formatting of error messages slightly: avoid an extra newline after the Python output,
and pluralise errors more correctly.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
