### PR TITLE
[Merged by Bors] - fix: disable the dollarSyntax linter by default

### DIFF
--- a/Mathlib/Tactic/Linter/Lint.lean
+++ b/Mathlib/Tactic/Linter/Lint.lean
@@ -221,11 +221,11 @@ These are disallowed by the mathlib style guide, as using `<|` pairs better with
 /-- The `dollarSyntax` linter flags uses of `<|` that are achieved by typing `$`.
 These are disallowed by the mathlib style guide, as using `<|` pairs better with `|>`. -/
 register_option linter.dollarSyntax : Bool := {
-  defValue := true
+  defValue := false
   descr := "enable the `dollarSyntax` linter"
 }
 
-namespace DollarSyntaxLinter
+namespace Style.dollarSyntaxLinter
 
 /-- `findDollarSyntax stx` extracts from `stx` the syntax nodes of `kind` `$`. -/
 partial
@@ -248,7 +248,7 @@ def dollarSyntaxLinter : Linter where run := withSetOptionIn fun stx ↦ do
 
 initialize addLinter dollarSyntaxLinter
 
-end DollarSyntaxLinter
+end Style.dollarSyntaxLinter
 
 /-! # The "longLine linter" -/
 

--- a/Mathlib/Tactic/Linter/Lint.lean
+++ b/Mathlib/Tactic/Linter/Lint.lean
@@ -225,7 +225,7 @@ register_option linter.dollarSyntax : Bool := {
   descr := "enable the `dollarSyntax` linter"
 }
 
-namespace Style.dollarSyntaxLinter
+namespace Style.dollarSyntax
 
 /-- `findDollarSyntax stx` extracts from `stx` the syntax nodes of `kind` `$`. -/
 partial
@@ -248,7 +248,7 @@ def dollarSyntaxLinter : Linter where run := withSetOptionIn fun stx ↦ do
 
 initialize addLinter dollarSyntaxLinter
 
-end Style.dollarSyntaxLinter
+end Style.dollarSyntax
 
 /-! # The "longLine linter" -/
 

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -11,6 +11,7 @@ abbrev mathlibOnlyLinters : Array LeanOption := #[
   ⟨`linter.hashCommand, true⟩,
   ⟨`linter.missingEnd, true⟩,
   ⟨`linter.cdot, true⟩,
+  ⟨`linter.dollarSyntax, true⟩,
   ⟨`linter.longLine, true⟩,
   ⟨`linter.oldObtain, true,⟩,
   ⟨`linter.refine, true⟩,


### PR DESCRIPTION
And move the linter to the Style namespace.

---

Follow-up to #15909, taking into account #15616.

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
