### PR TITLE
[Merged by Bors] - chore: replace last uses of `lambda` instead of `fun`

### DIFF
--- a/Mathlib/Analysis/Analytic/Composition.lean
+++ b/Mathlib/Analysis/Analytic/Composition.lean
@@ -856,7 +856,7 @@ where `v' = (v_l, v_{l+1}, ..., v_{m-1})`. Therefore, we get
 r.comp (q.comp p) n v =
 ∑_{c : Composition n} ∑_{d₀ : Composition (c.blocksFun 0),
   ..., d_{c.length - 1} : Composition (c.blocksFun (c.length - 1))}
-  r c.length (λ i, q dᵢ.length (applyComposition p dᵢ v'ᵢ))
+  r c.length (fun i ↦ q dᵢ.length (applyComposition p dᵢ v'ᵢ))
 ```
 To show that these terms coincide, we need to explain how to reindex the sums to put them in
 bijection (and then the terms we are summing will correspond to each other). Suppose we have a

--- a/Mathlib/CategoryTheory/Bicategory/NaturalTransformation/Strong.lean
+++ b/Mathlib/CategoryTheory/Bicategory/NaturalTransformation/Strong.lean
@@ -116,7 +116,7 @@ variable (F : OplaxFunctor B C)
 /-- The identity strong natural transformation. -/
 @[simps!]
 def id : StrongOplaxNatTrans F F :=
-  mkOfOplax (OplaxNatTrans.id F) { naturality := λ f ↦ (ρ_ (F.map f)) ≪≫ (λ_ (F.map f)).symm }
+  mkOfOplax (OplaxNatTrans.id F) { naturality := fun f ↦ (ρ_ (F.map f)) ≪≫ (λ_ (F.map f)).symm }
 
 @[simp]
 lemma id.toOplax : (id F).toOplax = OplaxNatTrans.id F :=
@@ -183,7 +183,7 @@ end
 @[simps!]
 def vcomp (η : StrongOplaxNatTrans F G) (θ : StrongOplaxNatTrans G H) : StrongOplaxNatTrans F H :=
   mkOfOplax (OplaxNatTrans.vcomp η.toOplax θ.toOplax)
-    { naturality := λ {a b} f ↦
+    { naturality := fun {a b} f ↦
         (α_ _ _ _).symm ≪≫ whiskerRightIso (η.naturality f) (θ.app b) ≪≫
         (α_ _ _ _) ≪≫ whiskerLeftIso (η.app a) (θ.naturality f) ≪≫ (α_ _ _ _).symm }
 end

--- a/Mathlib/Data/Real/Sqrt.lean
+++ b/Mathlib/Data/Real/Sqrt.lean
@@ -115,15 +115,14 @@ noncomputable def sqrt (x : ℝ) : ℝ :=
 @[inherit_doc]
 prefix:max "√" => Real.sqrt
 
-/- quotient.lift_on x
-  (λ f, mk ⟨sqrt_aux f, (sqrt_aux_converges f).fst⟩)
-  (λ f g e, begin
-    rcases sqrt_aux_converges f with ⟨hf, x, x0, xf, xs⟩,
-    rcases sqrt_aux_converges g with ⟨hg, y, y0, yg, ys⟩,
-    refine xs.trans (eq.trans _ ys.symm),
-    rw [← @mul_self_inj_of_nonneg ℝ _ x y x0 y0, xf, yg],
-    congr' 1, exact quotient.sound e
-  end)-/
+/- Quotient.liftOn x
+  (fun f ↦ mk ⟨sqrt_aux f, (sqrt_aux_converges f).fst⟩)
+  (fun f g e := by
+    rcases sqrt_aux_converges f with ⟨hf, x, x0, xf, xs⟩
+    rcases sqrt_aux_converges g with ⟨hg, y, y0, yg, ys⟩
+    refine xs.trans (eq.trans _ ys.symm)
+    rw [← @mul_self_inj_of_nonneg ℝ _ x y x0 y0, xf, yg]
+    congr' 1, exact quotient.sound e) -/
 variable {x y : ℝ}
 
 @[simp, norm_cast]

--- a/Mathlib/Lean/Meta/CongrTheorems.lean
+++ b/Mathlib/Lean/Meta/CongrTheorems.lean
@@ -129,7 +129,7 @@ instance {α : Sort u} [inst : FastIsEmpty α] {β : (x : α) → Sort v} :
 
 instance {α : Sort u} {β : (x : α) → Sort v} [inst : ∀ x, FastSubsingleton (β x)] :
     FastSubsingleton ((x : α) → β x) where
-  inst := have := λ x => (inst x).inst; inferInstance
+  inst := have := fun x ↦ (inst x).inst; inferInstance
 
 /--
 Runs `mx` in a context where all local `Subsingleton` and `IsEmpty` instances

--- a/Mathlib/Order/Filter/NAry.lean
+++ b/Mathlib/Order/Filter/NAry.lean
@@ -59,7 +59,7 @@ theorem map₂_mk_eq_prod (f : Filter α) (g : Filter β) : map₂ Prod.mk f g =
 
 -- lemma image2_mem_map₂_iff (hm : injective2 m) : image2 m s t ∈ map₂ m f g ↔ s ∈ f ∧ t ∈ g :=
 -- ⟨by { rintro ⟨u, v, hu, hv, h⟩, rw image2_subset_image2_iff hm at h,
---   exact ⟨mem_of_superset hu h.1, mem_of_superset hv h.2⟩ }, λ h, image2_mem_map₂ h.1 h.2⟩
+--   exact ⟨mem_of_superset hu h.1, mem_of_superset hv h.2⟩ }, fun h ↦ image2_mem_map₂ h.1 h.2⟩
 theorem map₂_mono (hf : f₁ ≤ f₂) (hg : g₁ ≤ g₂) : map₂ m f₁ g₁ ≤ map₂ m f₂ g₂ :=
   fun _ ⟨s, hs, t, ht, hst⟩ => ⟨s, hf hs, t, hg ht, hst⟩
 

--- a/Mathlib/RingTheory/UniqueFactorizationDomain.lean
+++ b/Mathlib/RingTheory/UniqueFactorizationDomain.lean
@@ -1849,7 +1849,7 @@ noncomputable def fintypeSubtypeDvd {M : Type*} [CancelCommMonoidWithZero M]
   haveI : NormalizationMonoid M := UniqueFactorizationMonoid.normalizationMonoid
   haveI := Classical.decEq M
   haveI := Classical.decEq (Associates M)
-  -- We'll show `λ (u : Mˣ) (f ⊆ factors y) → u * Π f` is injective
+  -- We'll show `fun (u : Mˣ) (f ⊆ factors y) ↦ u * Π f` is injective
   -- and has image exactly the divisors of `y`.
   refine
     Fintype.ofFinset

--- a/Mathlib/Tactic/FunProp/ToBatteries.lean
+++ b/Mathlib/Tactic/FunProp/ToBatteries.lean
@@ -35,7 +35,7 @@ def isOrderedSubsetOf {α} [Inhabited α] [DecidableEq α] (a b : Array α) : Bo
 
 private def letTelescopeImpl {α} (e : Expr) (k : Array Expr → Expr → MetaM α) :
     MetaM α :=
-  lambdaLetTelescope e λ xs b => do
+  lambdaLetTelescope e fun xs b ↦ do
     if let .some i ← xs.findIdxM? (fun x ↦ do pure ¬(← x.fvarId!.isLetVar)) then
       k xs[0:i] (← mkLambdaFVars xs[i:] b)
     else
@@ -98,18 +98,18 @@ def mkProdProj (x : Expr) (i : Nat) (n : Nat) : MetaM Expr := do
 i.e. `#[xs.1, xs.2.1, xs.2.2.1, ..., xs.2..2]` -/
 def mkProdSplitElem (xs : Expr) (n : Nat) : MetaM (Array Expr) :=
   (Array.range n)
-    |>.mapM (λ i => mkProdProj xs i n)
+    |>.mapM (fun i ↦ mkProdProj xs i n)
 
 /-- Uncurry function `f` in `n` arguments. -/
 def mkUncurryFun (n : Nat) (f : Expr) : MetaM Expr := do
   if n ≤ 1 then
     return f
-  forallBoundedTelescope (← inferType f) n λ xs _ => do
-    let xProdName : String ← xs.foldlM (init:="") λ n x =>
+  forallBoundedTelescope (← inferType f) n fun xs _ ↦ do
+    let xProdName : String ← xs.foldlM (init:="") fun n x ↦
       do return (n ++ toString (← x.fvarId!.getUserName).eraseMacroScopes)
     let xProdType ← inferType (← mkProdElem xs)
 
-    withLocalDecl (.mkSimple xProdName) default xProdType λ xProd => do
+    withLocalDecl (.mkSimple xProdName) default xProdType fun xProd ↦ do
       let xs' ← mkProdSplitElem xProd n
       mkLambdaFVars #[xProd] (← mkAppM' f xs').headBeta
 

--- a/Mathlib/Tactic/NormNum/Prime.lean
+++ b/Mathlib/Tactic/NormNum/Prime.lean
@@ -57,7 +57,7 @@ theorem minFacHelper_0 (n : ℕ)
     (h1 : Nat.ble (nat_lit 2) n = true) (h2 : nat_lit 1 = n % (nat_lit 2)) :
     MinFacHelper n (nat_lit 3) := by
   refine ⟨by norm_num, by norm_num, ?_⟩
-  refine (le_minFac'.mpr λ p hp hpn ↦ ?_).resolve_left (Nat.ne_of_gt (Nat.le_of_ble_eq_true h1))
+  refine (le_minFac'.mpr fun p hp hpn ↦ ?_).resolve_left (Nat.ne_of_gt (Nat.le_of_ble_eq_true h1))
   rcases hp.eq_or_lt with rfl|h
   · simp [(Nat.dvd_iff_mod_eq_zero ..).1 hpn] at h2
   · exact h
@@ -81,13 +81,13 @@ theorem minFacHelper_1 {n k k' : ℕ} (e : k + 2 = k') (h : MinFacHelper n k)
 
 theorem minFacHelper_2 {n k k' : ℕ} (e : k + 2 = k') (nk : ¬ Nat.Prime k)
     (h : MinFacHelper n k) : MinFacHelper n k' := by
-  refine minFacHelper_1 e h λ h2 ↦ ?_
+  refine minFacHelper_1 e h fun h2 ↦ ?_
   rw [← h2] at nk
   exact nk <| minFac_prime h.one_lt.ne'
 
 theorem minFacHelper_3 {n k k' : ℕ} (e : k + 2 = k') (nk : (n % k).beq 0 = false)
     (h : MinFacHelper n k) : MinFacHelper n k' := by
-  refine minFacHelper_1 e h λ h2 ↦ ?_
+  refine minFacHelper_1 e h fun h2 ↦ ?_
   have nk := Nat.ne_of_beq_eq_false nk
   rw [← Nat.dvd_iff_mod_eq_zero, ← h2] at nk
   exact nk <| minFac_dvd n
@@ -109,7 +109,7 @@ theorem isNat_minFac_4 : {n n' k : ℕ} →
   | n, _, k, ⟨rfl⟩, h1, h2 => by
     refine ⟨(Nat.prime_def_minFac.mp ?_).2⟩
     rw [Nat.prime_def_le_sqrt]
-    refine ⟨h1.one_lt, λ m hm hmn h2mn ↦ ?_⟩
+    refine ⟨h1.one_lt, fun m hm hmn h2mn ↦ ?_⟩
     exact lt_irrefl m <| calc
       m ≤ sqrt n   := hmn
       _ < k        := sqrt_lt.mpr (ble_eq_false.mp h2)

--- a/Mathlib/Tactic/Simps/Basic.lean
+++ b/Mathlib/Tactic/Simps/Basic.lean
@@ -535,7 +535,7 @@ partial def getCompositeOfProjectionsAux (proj : String) (e : Expr) (pos : Array
   initialize_simps_projections (toFun_toFun_toFun → myMul)
   ```
   we will be able to generate the "projection"
-    `λ {A} (f : gradedFun A) (x : A i) (y : A j) ↦ ↑(↑(f.toFun i j) x) y`,
+    `fun {A} (f : gradedFun A) (x : A i) (y : A j) ↦ ↑(↑(f.toFun i j) x) y`,
   which projection notation cannot do. -/
 def getCompositeOfProjections (structName : Name) (proj : String) : MetaM (Expr × Array Nat) := do
   let strExpr ← mkConstWithLevelParams structName

--- a/Mathlib/Tactic/Simps/NotationClass.lean
+++ b/Mathlib/Tactic/Simps/NotationClass.lean
@@ -46,7 +46,7 @@ We partly define this as a separate definition so that the unused arguments lint
 def findArgType : Type := Name → Name → Array Expr → MetaM (Array (Option Expr))
 
 /-- Find arguments for a notation class -/
-def defaultfindArgs : findArgType := λ _ className args => do
+def defaultfindArgs : findArgType := fun _ className args ↦ do
   let some classExpr := (← getEnv).find? className | throwError "no such class {className}"
   let arity := classExpr.type.forallArity
   if arity == args.size then
@@ -58,29 +58,29 @@ def defaultfindArgs : findArgType := λ _ className args => do
       {className}"
 
 /-- Find arguments by duplicating the first argument. Used for `pow`. -/
-def copyFirst : findArgType := λ _ _ args => return (args.push <| args[0]?.getD default).map some
+def copyFirst : findArgType := fun _ _ args ↦ return (args.push <| args[0]?.getD default).map some
 
 /-- Find arguments by duplicating the first argument. Used for `smul`. -/
-def copySecond : findArgType := λ _ _ args => return (args.push <| args[1]?.getD default).map some
+def copySecond : findArgType := fun _ _ args ↦ return (args.push <| args[1]?.getD default).map some
 
 /-- Find arguments by prepending `ℕ` and duplicating the first argument. Used for `nsmul`. -/
-def nsmulArgs : findArgType := λ _ _ args =>
+def nsmulArgs : findArgType := fun _ _ args ↦
   return #[Expr.const `Nat [], args[0]?.getD default] ++ args |>.map some
 
 /-- Find arguments by prepending `ℤ` and duplicating the first argument. Used for `zsmul`. -/
-def zsmulArgs : findArgType := λ _ _ args =>
+def zsmulArgs : findArgType := fun _ _ args ↦
   return #[Expr.const `Int [], args[0]?.getD default] ++ args |>.map some
 
 /-- Find arguments for the `Zero` class. -/
-def findZeroArgs : findArgType := λ _ _ args =>
+def findZeroArgs : findArgType := fun _ _ args ↦
   return #[some <| args[0]?.getD default, some <| mkRawNatLit 0]
 
 /-- Find arguments for the `One` class. -/
-def findOneArgs : findArgType := λ _ _ args =>
+def findOneArgs : findArgType := fun _ _ args ↦
   return #[some <| args[0]?.getD default, some <| mkRawNatLit 1]
 
 /-- Find arguments of a coercion class (`DFunLike` or `SetLike`) -/
-def findCoercionArgs : findArgType := λ str className args => do
+def findCoercionArgs : findArgType := fun str className args ↦ do
   let some classExpr := (← getEnv).find? className | throwError "no such class {className}"
   let arity := classExpr.type.forallArity
   let eStr := mkAppN (← mkConstWithLevelParams str) args


### PR DESCRIPTION
Split out from #15896.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
