### PR TITLE
[Merged by Bors] - feat: disjoint union of topological spaces is commutative and associative

### DIFF
--- a/Mathlib/Logic/Equiv/Basic.lean
+++ b/Mathlib/Logic/Equiv/Basic.lean
@@ -3,7 +3,6 @@ Copyright (c) 2015 Microsoft Corporation. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Leonardo de Moura, Mario Carneiro
 -/
-import Aesop
 import Mathlib.Data.Bool.Basic
 import Mathlib.Data.Option.Defs
 import Mathlib.Data.Prod.Basic
@@ -379,8 +378,8 @@ def sumSumSumComm (α β γ δ) : (α ⊕ β) ⊕ γ ⊕ δ ≃ (α ⊕ γ) ⊕ 
       ∘ (Sum.map (Sum.map (@id α) (sumComm β γ).symm) (@id δ))
       ∘ (Sum.map (sumAssoc α γ β) (@id δ))
       ∘ (sumAssoc (α ⊕ γ) β δ).symm
-  left_inv x := by aesop
-  right_inv x := by aesop
+  left_inv x := by simp [Function.comp]
+  right_inv x := by simp [Function.comp]
 
 @[simp]
 theorem sumSumSumComm_symm (α β γ δ) : (sumSumSumComm α β γ δ).symm = sumSumSumComm α γ β δ :=

--- a/Mathlib/Logic/Equiv/Basic.lean
+++ b/Mathlib/Logic/Equiv/Basic.lean
@@ -3,6 +3,7 @@ Copyright (c) 2015 Microsoft Corporation. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Leonardo de Moura, Mario Carneiro
 -/
+import Aesop
 import Mathlib.Data.Bool.Basic
 import Mathlib.Data.Option.Defs
 import Mathlib.Data.Prod.Basic
@@ -363,6 +364,26 @@ theorem sumAssoc_symm_apply_inr_inl {α β γ} (b) :
 
 @[simp]
 theorem sumAssoc_symm_apply_inr_inr {α β γ} (c) : (sumAssoc α β γ).symm (inr (inr c)) = inr c :=
+  rfl
+
+/-- Four-way commutativity of `sum`. The name matches `add_add_add_comm`. -/
+@[simps apply]
+def sumSumSumComm (α β γ δ) : (α ⊕ β) ⊕ γ ⊕ δ ≃ (α ⊕ γ) ⊕ β ⊕ δ where
+  toFun :=
+    (sumAssoc (α ⊕ γ) β δ) ∘ (Sum.map (sumAssoc α γ β).symm (@id δ))
+      ∘ (Sum.map (Sum.map (@id α) (sumComm β γ)) (@id δ))
+      ∘ (Sum.map (sumAssoc α β γ) (@id δ))
+      ∘ (sumAssoc (α ⊕ β) γ δ).symm
+  invFun :=
+    (sumAssoc (α ⊕ β) γ δ) ∘ (Sum.map (sumAssoc α β γ).symm (@id δ))
+      ∘ (Sum.map (Sum.map (@id α) (sumComm β γ).symm) (@id δ))
+      ∘ (Sum.map (sumAssoc α γ β) (@id δ))
+      ∘ (sumAssoc (α ⊕ γ) β δ).symm
+  left_inv x := by aesop
+  right_inv x := by aesop
+
+@[simp]
+theorem sumSumSumComm_symm (α β γ δ) : (sumSumSumComm α β γ δ).symm = sumSumSumComm α γ β δ :=
   rfl
 
 /-- Sum with `IsEmpty` is equivalent to the original type. -/

--- a/Mathlib/Topology/Constructions.lean
+++ b/Mathlib/Topology/Constructions.lean
@@ -841,6 +841,10 @@ theorem continuous_inl : Continuous (@inl X Y) := ⟨fun _ => And.left⟩
 -- Porting note: the proof was `continuous_sup_rng_right continuous_coinduced_rng`
 theorem continuous_inr : Continuous (@inr X Y) := ⟨fun _ => And.right⟩
 
+@[fun_prop, continuity]
+lemma continuous_sum_swap : Continuous (@Sum.swap X Y) :=
+  Continuous.sum_elim continuous_inr continuous_inl
+
 theorem isOpen_sum_iff {s : Set (X ⊕ Y)} : IsOpen s ↔ IsOpen (inl ⁻¹' s) ∧ IsOpen (inr ⁻¹' s) :=
   Iff.rfl
 

--- a/Mathlib/Topology/Homeomorph.lean
+++ b/Mathlib/Topology/Homeomorph.lean
@@ -549,17 +549,13 @@ lemma sumAssoc_toEquiv : (sumAssoc X Y Z).toEquiv = Equiv.sumAssoc X Y Z := rfl
 def sumSumSumComm : (X ⊕ Y) ⊕ W ⊕ Z ≃ₜ (X ⊕ W) ⊕ Y ⊕ Z where
   toEquiv := Equiv.sumSumSumComm X Y W Z
   continuous_toFun := by
-    show Continuous ((Equiv.sumAssoc (X ⊕ W) Y Z) ∘ (Sum.map (Equiv.sumAssoc X W Y).symm (@id Z))
-      ∘ (Sum.map (Sum.map (@id X) (Equiv.sumComm Y W)) (@id Z))
-      ∘ (Sum.map (Equiv.sumAssoc X Y W) (@id Z))
-      ∘ (Equiv.sumAssoc (X ⊕ Y) W Z).symm)
+    unfold Equiv.sumSumSumComm
+    dsimp only
     have : Continuous (Sum.map (Sum.map (@id X) ⇑(Equiv.sumComm Y W)) (@id Z)) := by continuity
     fun_prop
   continuous_invFun := by
-    show Continuous ((Equiv.sumAssoc (X ⊕ Y) W Z) ∘ (Sum.map (Equiv.sumAssoc X Y W).symm (@id Z))
-      ∘ (Sum.map (Sum.map (@id X) (Equiv.sumComm Y W).symm) (@id Z))
-      ∘ (Sum.map (Equiv.sumAssoc X W Y) (@id Z))
-      ∘ (Equiv.sumAssoc (X ⊕ W) Y Z).symm)
+    unfold Equiv.sumSumSumComm
+    dsimp only
     have : Continuous (Sum.map (Sum.map (@id X) (Equiv.sumComm Y W).symm) (@id Z)) := by continuity
     fun_prop
 
@@ -607,6 +603,25 @@ def prodAssoc : (X × Y) × Z ≃ₜ X × Y × Z where
   continuous_toFun := continuous_fst.fst.prod_mk (continuous_fst.snd.prod_mk continuous_snd)
   continuous_invFun := (continuous_fst.prod_mk continuous_snd.fst).prod_mk continuous_snd.snd
   toEquiv := Equiv.prodAssoc X Y Z
+
+@[simp]
+lemma prodAssoc_toEquiv : (prodAssoc X Y Z).toEquiv = Equiv.prodAssoc X Y Z := rfl
+
+/-- Four-way commutativity of `prod`. The name matches `mul_mul_mul_comm`. -/
+def prodProdProdComm : (X × Y) × W × Z ≃ₜ (X × W) × Y × Z where
+  toEquiv := Equiv.prodProdProdComm X Y W Z
+  continuous_toFun := by
+    unfold Equiv.prodProdProdComm
+    dsimp only
+    fun_prop
+  continuous_invFun := by
+    unfold Equiv.prodProdProdComm
+    dsimp only
+    fun_prop
+
+@[simp]
+theorem prodProdProdComm_symm : (prodProdProdComm X Y W Z).symm = prodProdProdComm X W Y Z :=
+  rfl
 
 /-- `X × {*}` is homeomorphic to `X`. -/
 @[simps! (config := .asFn) apply]

--- a/Mathlib/Topology/Homeomorph.lean
+++ b/Mathlib/Topology/Homeomorph.lean
@@ -508,7 +508,9 @@ theorem prodCongr_symm (h₁ : X ≃ₜ X') (h₂ : Y ≃ₜ Y') :
 theorem coe_prodCongr (h₁ : X ≃ₜ X') (h₂ : Y ≃ₜ Y') : ⇑(h₁.prodCongr h₂) = Prod.map h₁ h₂ :=
   rfl
 
-section
+-- Commutativity and associativity of the disjoing union of topological spaces,
+-- and the sum with an empty space.
+section sum
 
 variable (X Y W Z)
 
@@ -579,6 +581,13 @@ def emptySum [IsEmpty Y] : Y ⊕ X ≃ₜ X := (sumComm Y X).trans (sumEmpty X Y
 
 @[simp] theorem coe_emptySum [IsEmpty Y] : (emptySum X Y).toEquiv = Equiv.emptySum Y X := rfl
 
+end sum
+
+-- Commutativity and associativity of the product of top. spaces, and the product with `PUnit`.
+section prod
+
+variable (X Y W Z)
+
 /-- `X × Y` is homeomorphic to `Y × X`. -/
 def prodComm : X × Y ≃ₜ Y × X where
   continuous_toFun := continuous_snd.prod_mk continuous_fst
@@ -619,7 +628,7 @@ def homeomorphOfUnique [Unique X] [Unique Y] : X ≃ₜ Y :=
     continuous_toFun := continuous_const
     continuous_invFun := continuous_const }
 
-end
+end prod
 
 /-- `Equiv.piCongrLeft` as a homeomorphism: this is the natural homeomorphism
 `Π i, Y (e i) ≃ₜ Π j, Y j` obtained from a bijection `ι ≃ ι'`. -/

--- a/Mathlib/Topology/Homeomorph.lean
+++ b/Mathlib/Topology/Homeomorph.lean
@@ -512,6 +512,38 @@ section
 
 variable (X Y Z)
 
+/-- `X ⊕ Y` is homeomorphic to `Y ⊕ X`. -/
+def sumComm : X ⊕ Y ≃ₜ Y ⊕ X where
+  toEquiv := Equiv.sumComm X Y
+  continuous_toFun := continuous_sum_swap
+  continuous_invFun := continuous_sum_swap
+
+@[simp]
+theorem sumComm_symm : (sumComm X Y).symm = sumComm Y X :=
+  rfl
+
+@[simp]
+theorem coe_sumComm : ⇑(sumComm X Y) = Sum.swap :=
+  rfl
+
+/-- `(X ⊕ Y) ⊕ Z` is homeomorphic to `X ⊕ (Y ⊕ Z)`. -/
+def sumAssoc : (X ⊕ Y) ⊕ Z ≃ₜ X ⊕ Y ⊕ Z where
+  toEquiv := Equiv.sumAssoc X Y Z
+  continuous_toFun := Continuous.sum_elim (by fun_prop) (by fun_prop)
+  continuous_invFun := Continuous.sum_elim (by fun_prop) (by fun_prop)
+
+/-- The sum of `X` with any empty topological space is homeomorphic to `X`. -/
+@[simps! (config := .asFn) apply]
+def sumEmpty [IsEmpty Y] : X ⊕ Y ≃ₜ X where
+  toEquiv := Equiv.sumEmpty X Y
+  continuous_toFun := Continuous.sum_elim continuous_id (by fun_prop)
+  continuous_invFun := continuous_inl
+
+/-- The sum of `X` with any empty topological space is homeomorphic to `X`. -/
+def emptySum [IsEmpty Y] : Y ⊕ X ≃ₜ X := (sumComm Y X).trans (sumEmpty X Y)
+
+@[simp] theorem coe_emptySum [IsEmpty Y] : (emptySum X Y).toEquiv = Equiv.emptySum Y X := rfl
+
 /-- `X × Y` is homeomorphic to `Y × X`. -/
 def prodComm : X × Y ≃ₜ Y × X where
   continuous_toFun := continuous_snd.prod_mk continuous_fst

--- a/Mathlib/Topology/Homeomorph.lean
+++ b/Mathlib/Topology/Homeomorph.lean
@@ -31,7 +31,7 @@ open Set Filter
 
 open Topology
 
-variable {X : Type*} {Y : Type*} {Z : Type*}
+variable {X Y W Z : Type*}
 
 -- not all spaces are homeomorphic to each other
 /-- Homeomorphism between `X` and `Y`, also called topological isomorphism -/
@@ -47,7 +47,7 @@ infixl:25 " ≃ₜ " => Homeomorph
 
 namespace Homeomorph
 
-variable [TopologicalSpace X] [TopologicalSpace Y] [TopologicalSpace Z]
+variable [TopologicalSpace X] [TopologicalSpace Y] [TopologicalSpace W] [TopologicalSpace Z]
   {X' Y' : Type*} [TopologicalSpace X'] [TopologicalSpace Y']
 
 theorem toEquiv_injective : Function.Injective (toEquiv : X ≃ₜ Y → X ≃ Y)
@@ -510,7 +510,7 @@ theorem coe_prodCongr (h₁ : X ≃ₜ X') (h₂ : Y ≃ₜ Y') : ⇑(h₁.prodC
 
 section
 
-variable (X Y Z)
+variable (X Y W Z)
 
 /-- `X ⊕ Y` is homeomorphic to `Y ⊕ X`. -/
 def sumComm : X ⊕ Y ≃ₜ Y ⊕ X where
@@ -542,10 +542,6 @@ def sumAssoc : (X ⊕ Y) ⊕ Z ≃ₜ X ⊕ Y ⊕ Z where
 
 @[simp]
 lemma sumAssoc_toEquiv : (sumAssoc X Y Z).toEquiv = Equiv.sumAssoc X Y Z := rfl
-
--- FIXME: move W further up...
-variable (X Y W Z : Type*)
-  [TopologicalSpace X] [TopologicalSpace Y] [TopologicalSpace Z] [TopologicalSpace W]
 
 /-- Four-way commutativity of the disjoint union. The name matches `add_add_add_comm`. -/
 def sumSumSumComm : (X ⊕ Y) ⊕ W ⊕ Z ≃ₜ (X ⊕ W) ⊕ Y ⊕ Z where

--- a/Mathlib/Topology/Homeomorph.lean
+++ b/Mathlib/Topology/Homeomorph.lean
@@ -541,7 +541,35 @@ def sumAssoc : (X ⊕ Y) ⊕ Z ≃ₜ X ⊕ Y ⊕ Z where
   continuous_invFun := continuous_sumAssoc_symm X Y Z
 
 @[simp]
-def sumAssoc_toEquiv : (sumAssoc X Y Z).toEquiv = Equiv.sumAssoc X Y Z := rfl
+lemma sumAssoc_toEquiv : (sumAssoc X Y Z).toEquiv = Equiv.sumAssoc X Y Z := rfl
+
+-- FIXME: move W further up...
+variable (X Y W Z : Type*)
+  [TopologicalSpace X] [TopologicalSpace Y] [TopologicalSpace Z] [TopologicalSpace W]
+
+/-- Four-way commutativity of the disjoint union. The name matches `add_add_add_comm`. -/
+def sumSumSumComm : (X ⊕ Y) ⊕ W ⊕ Z ≃ₜ (X ⊕ W) ⊕ Y ⊕ Z where
+  toEquiv := Equiv.sumSumSumComm X Y W Z
+  continuous_toFun := by
+    show Continuous ((Equiv.sumAssoc (X ⊕ W) Y Z) ∘ (Sum.map (Equiv.sumAssoc X W Y).symm (@id Z))
+      ∘ (Sum.map (Sum.map (@id X) (Equiv.sumComm Y W)) (@id Z))
+      ∘ (Sum.map (Equiv.sumAssoc X Y W) (@id Z))
+      ∘ (Equiv.sumAssoc (X ⊕ Y) W Z).symm)
+    have : Continuous (Sum.map (Sum.map (@id X) ⇑(Equiv.sumComm Y W)) (@id Z)) := by continuity
+    fun_prop
+  continuous_invFun := by
+    show Continuous ((Equiv.sumAssoc (X ⊕ Y) W Z) ∘ (Sum.map (Equiv.sumAssoc X Y W).symm (@id Z))
+      ∘ (Sum.map (Sum.map (@id X) (Equiv.sumComm Y W).symm) (@id Z))
+      ∘ (Sum.map (Equiv.sumAssoc X W Y) (@id Z))
+      ∘ (Equiv.sumAssoc (X ⊕ W) Y Z).symm)
+    have : Continuous (Sum.map (Sum.map (@id X) (Equiv.sumComm Y W).symm) (@id Z)) := by continuity
+    fun_prop
+
+@[simp]
+lemma sumSumSumComm_toEquiv : (sumSumSumComm X Y W Z).toEquiv = (Equiv.sumSumSumComm X Y W Z) := rfl
+
+@[simp]
+lemma sumSumSumComm_symm : (sumSumSumComm X Y W Z).symm = (sumSumSumComm X W Y Z) := rfl
 
 /-- The sum of `X` with any empty topological space is homeomorphic to `X`. -/
 @[simps! (config := .asFn) apply]

--- a/Mathlib/Topology/Homeomorph.lean
+++ b/Mathlib/Topology/Homeomorph.lean
@@ -526,11 +526,22 @@ theorem sumComm_symm : (sumComm X Y).symm = sumComm Y X :=
 theorem coe_sumComm : ⇑(sumComm X Y) = Sum.swap :=
   rfl
 
+@[continuity, fun_prop]
+lemma continuous_sumAssoc : Continuous (Equiv.sumAssoc X Y Z) :=
+  Continuous.sum_elim (by fun_prop) (by fun_prop)
+
+@[continuity, fun_prop]
+lemma continuous_sumAssoc_symm : Continuous (Equiv.sumAssoc X Y Z).symm :=
+  Continuous.sum_elim (by fun_prop) (by fun_prop)
+
 /-- `(X ⊕ Y) ⊕ Z` is homeomorphic to `X ⊕ (Y ⊕ Z)`. -/
 def sumAssoc : (X ⊕ Y) ⊕ Z ≃ₜ X ⊕ Y ⊕ Z where
   toEquiv := Equiv.sumAssoc X Y Z
-  continuous_toFun := Continuous.sum_elim (by fun_prop) (by fun_prop)
-  continuous_invFun := Continuous.sum_elim (by fun_prop) (by fun_prop)
+  continuous_toFun := continuous_sumAssoc X Y Z
+  continuous_invFun := continuous_sumAssoc_symm X Y Z
+
+@[simp]
+def sumAssoc_toEquiv : (sumAssoc X Y Z).toEquiv = Equiv.sumAssoc X Y Z := rfl
 
 /-- The sum of `X` with any empty topological space is homeomorphic to `X`. -/
 @[simps! (config := .asFn) apply]

--- a/Mathlib/Topology/Homeomorph.lean
+++ b/Mathlib/Topology/Homeomorph.lean
@@ -508,7 +508,7 @@ theorem prodCongr_symm (h₁ : X ≃ₜ X') (h₂ : Y ≃ₜ Y') :
 theorem coe_prodCongr (h₁ : X ≃ₜ X') (h₂ : Y ≃ₜ Y') : ⇑(h₁.prodCongr h₂) = Prod.map h₁ h₂ :=
   rfl
 
--- Commutativity and associativity of the disjoing union of topological spaces,
+-- Commutativity and associativity of the disjoint union of topological spaces,
 -- and the sum with an empty space.
 section sum
 


### PR DESCRIPTION
These results are fully analogous to existing results about products, but are missing in mathlib.
While at it, also add the four-way commutativity `sumSumSumComm`, whose product analogue is already in mathlib.

From my bordism theory project (which wants to prove smooth analogues of these results).

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
