### PR TITLE
feat(Order/Basic): product order is subrelation of lexicographic order

### DIFF
--- a/Mathlib/Order/Basic.lean
+++ b/Mathlib/Order/Basic.lean
@@ -1172,6 +1172,23 @@ lemma mk_lt_mk_of_le_of_lt (h₁ : a₁ ≤ a₂) (h₂ : b₁ < b₂) : (a₁, 
 
 end Preorder
 
+section PartialOrder
+
+variable [PartialOrder α] [Preorder β] {x y : α × β}
+
+lemma toLex (h : x < y) : Prod.Lex (· < ·) (· < ·) x y := by
+  cases y
+  cases' lt_iff.1 h with h₁ h₂
+  · exact Lex.left _ _ h₁.1
+  · obtain h₂ | rfl := lt_or_eq_of_le h₂.1
+    · exact Lex.left _ _ h₂
+    · exact Lex.right _ h₂.2
+
+lemma Lex.lt_of_le_of_lt (h₁ : x.1 ≤ y.1) (h₂ : x.2 < y.2) : Prod.Lex (· < ·) (· < ·) x y :=
+  toLex (Prod.lt_of_le_of_lt h₁ h₂)
+
+end PartialOrder
+
 /-- The pointwise partial order on a product.
     (The lexicographic ordering is defined in `Order.Lexicographic`, and the instances are
     available via the type synonym `α ×ₗ β = α × β`.) -/

--- a/Mathlib/Order/Basic.lean
+++ b/Mathlib/Order/Basic.lean
@@ -1187,6 +1187,10 @@ lemma toLex (h : x < y) : Prod.Lex (· < ·) (· < ·) x y := by
 lemma Lex.lt_of_le_of_lt (h₁ : x.1 ≤ y.1) (h₂ : x.2 < y.2) : Prod.Lex (· < ·) (· < ·) x y :=
   toLex (Prod.lt_of_le_of_lt h₁ h₂)
 
+lemma Lex.mk_lt_of_le_of_lt {a₁ a₂ : α} {b₁ b₂ : β} (h₁ : a₁ ≤ a₂) (h₂ : b₁ < b₂) :
+    Prod.Lex (· < ·) (· < ·) (a₁, b₁) (a₂, b₂) :=
+  Lex.lt_of_le_of_lt h₁ h₂
+
 end PartialOrder
 
 /-- The pointwise partial order on a product.


### PR DESCRIPTION
The product order on `α × β` is a subrelation of `Prod.Lex (· < ·) (· < ·)` whenever `α` is a partial order.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

It'd be really nice if `decreasing_tactic` could be extended with `Lex.lt_of_le_of_lt`. Currently, the following code fails:
```lean 4
import Mathlib.Order.Basic
import Mathlib.Data.Nat.Defs

theorem recursion (a b : Nat) : True := by
  let (c, d) := (0, 0)
  have : c ≤ a := sorry
  have : d < b := sorry
  exact recursion c d -- failed to prove termination
termination_by (a, b)
```

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
