### PR TITLE
[Merged by Bors] - feat: Pontryagin duality for finite abelian groups

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -1233,6 +1233,8 @@ import Mathlib.Analysis.Distribution.AEEqOfIntegralContDiff
 import Mathlib.Analysis.Distribution.FourierSchwartz
 import Mathlib.Analysis.Distribution.SchwartzSpace
 import Mathlib.Analysis.Fourier.AddCircle
+import Mathlib.Analysis.Fourier.FiniteAbelian.Orthogonality
+import Mathlib.Analysis.Fourier.FiniteAbelian.PontryaginDuality
 import Mathlib.Analysis.Fourier.FourierTransform
 import Mathlib.Analysis.Fourier.FourierTransformDeriv
 import Mathlib.Analysis.Fourier.Inversion

--- a/Mathlib/Algebra/ModEq.lean
+++ b/Mathlib/Algebra/ModEq.lean
@@ -279,5 +279,16 @@ variable [DivisionRing α] {a b c p : α}
 @[simp] lemma div_modEq_div (hc : c ≠ 0) : a / c ≡ b / c [PMOD p] ↔ a ≡ b [PMOD (p * c)] := by
   simp [ModEq, ← sub_div, div_eq_iff hc, mul_assoc]
 
+@[simp] lemma mul_modEq_mul_right (hc : c ≠ 0) : a * c ≡ b * c [PMOD p] ↔ a ≡ b [PMOD (p / c)] := by
+  rw [div_eq_mul_inv, ← div_modEq_div (inv_ne_zero hc), div_inv_eq_mul, div_inv_eq_mul]
+
 end DivisionRing
+
+section Field
+variable [Field α] {a b c p : α}
+
+@[simp] lemma mul_modEq_mul_left (hc : c ≠ 0) : c * a ≡ c * b [PMOD p] ↔ a ≡ b [PMOD (p / c)] := by
+  simp [mul_comm c, hc]
+
+end Field
 end AddCommGroup

--- a/Mathlib/Analysis/Fourier/AddCircle.lean
+++ b/Mathlib/Analysis/Fourier/AddCircle.lean
@@ -127,7 +127,6 @@ theorem fourier_zero {x : AddCircle T} : fourier 0 x = 1 := by
   simp only [fourier_coe_apply]
   norm_num
 
-@[simp]
 theorem fourier_zero' {x : AddCircle T} : @toCircle T 0 = (1 : ℂ) := by
   have : fourier 0 x = @toCircle T 0 := by rw [fourier_apply, zero_smul]
   rw [← this]; exact fourier_zero

--- a/Mathlib/Analysis/Fourier/FiniteAbelian/Orthogonality.lean
+++ b/Mathlib/Analysis/Fourier/FiniteAbelian/Orthogonality.lean
@@ -1,0 +1,86 @@
+/-
+Copyright (c) 2023 Yaël Dillies, Bhavik Mehta. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Yaël Dillies, Bhavik Mehta
+-/
+import Mathlib.Algebra.BigOperators.Expect
+import Mathlib.Algebra.Group.AddChar
+import Mathlib.Analysis.RCLike.Inner
+
+/-!
+# Orthogonality of characters of a finite abelian group
+
+This file proves that characters of a finite abelian group are orthogonal, and in particular that
+there are at most as many characters as there are elements of the group.
+-/
+
+open Finset hiding card
+open Fintype (card)
+open Function RCLike
+open scoped BigOperators ComplexConjugate DirectSum
+
+variable {G H R : Type*}
+
+namespace AddChar
+section AddGroup
+variable [AddGroup G]
+
+section Semifield
+variable [Fintype G] [Semifield R] [IsDomain R] [CharZero R] {ψ : AddChar G R}
+
+lemma expect_eq_ite (ψ : AddChar G R) : 𝔼 a, ψ a = if ψ = 0 then 1 else 0 := by
+  simp [Fintype.expect_eq_sum_div_card, sum_eq_ite, ite_div]
+
+lemma expect_eq_zero_iff_ne_zero : 𝔼 x, ψ x = 0 ↔ ψ ≠ 0 := by
+  rw [expect_eq_ite, one_ne_zero.ite_eq_right_iff]
+
+lemma expect_ne_zero_iff_eq_zero : 𝔼 x, ψ x ≠ 0 ↔ ψ = 0 := expect_eq_zero_iff_ne_zero.not_left
+
+end Semifield
+
+section RCLike
+variable [RCLike R] [Fintype G]
+
+lemma wInner_cWeight_self (ψ : AddChar G R) : ⟪(ψ : G → R), ψ⟫ₙ_[R] = 1 := by
+  simp [wInner_cWeight_eq_expect, ψ.norm_apply, RCLike.conj_mul]
+
+end RCLike
+end AddGroup
+
+section AddCommGroup
+variable [AddCommGroup G]
+
+section RCLike
+variable [RCLike R] {ψ₁ ψ₂ : AddChar G R}
+
+lemma wInner_cWeight_eq_boole [Fintype G] (ψ₁ ψ₂ : AddChar G R) :
+    ⟪(ψ₁ : G → R), ψ₂⟫ₙ_[R] = if ψ₁ = ψ₂ then 1 else 0 := by
+  split_ifs with h
+  · rw [h, wInner_cWeight_self]
+  have : ψ₁⁻¹ * ψ₂ ≠ 1 := by rwa [Ne, inv_mul_eq_one]
+  simp_rw [wInner_cWeight_eq_expect, RCLike.inner_apply, ← inv_apply_eq_conj]
+  simpa [map_neg_eq_inv] using expect_eq_zero_iff_ne_zero.2 this
+
+lemma wInner_cWeight_eq_zero_iff_ne [Fintype G] : ⟪(ψ₁ : G → R), ψ₂⟫ₙ_[R] = 0 ↔ ψ₁ ≠ ψ₂ := by
+  rw [wInner_cWeight_eq_boole, one_ne_zero.ite_eq_right_iff]
+
+lemma wInner_cWeight_eq_one_iff_eq [Fintype G] : ⟪(ψ₁ : G → R), ψ₂⟫ₙ_[R] = 1 ↔ ψ₁ = ψ₂ := by
+  rw [wInner_cWeight_eq_boole, one_ne_zero.ite_eq_left_iff]
+
+variable (G R)
+
+protected lemma linearIndependent [Finite G] : LinearIndependent R ((⇑) : AddChar G R → G → R) := by
+  cases nonempty_fintype G
+  exact linearIndependent_of_ne_zero_of_wInner_cWeight_eq_zero coe_ne_zero
+    fun ψ₁ ψ₂ ↦ wInner_cWeight_eq_zero_iff_ne.2
+
+noncomputable instance instFintype [Finite G] : Fintype (AddChar G R) :=
+  @Fintype.ofFinite _ (AddChar.linearIndependent G R).finite
+
+@[simp] lemma card_addChar_le [Fintype G] : card (AddChar G R) ≤ card G := by
+  simpa only [Module.finrank_fintype_fun_eq_card] using
+    (AddChar.linearIndependent G R).fintype_card_le_finrank
+
+end RCLike
+end AddCommGroup
+end AddChar

--- a/Mathlib/Analysis/Fourier/FiniteAbelian/PontryaginDuality.lean
+++ b/Mathlib/Analysis/Fourier/FiniteAbelian/PontryaginDuality.lean
@@ -1,0 +1,206 @@
+/-
+Copyright (c) 2023 Yaël Dillies, Bhavik Mehta. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Yaël Dillies, Bhavik Mehta
+-/
+import Mathlib.Algebra.DirectSum.AddChar
+import Mathlib.Analysis.Fourier.FiniteAbelian.Orthogonality
+import Mathlib.Analysis.SpecialFunctions.Complex.Circle
+import Mathlib.GroupTheory.FiniteAbelian
+
+/-!
+# Pontryagin duality for finite abelian groups
+
+This file proves the Pontryagin duality in case of finite abelian groups. This states that any
+finite abelian group is canonically isomorphic to its double dual (the space of complex-valued
+characters of its space of complex-valued characters).
+
+We first prove it for `ZMod n` and then extend to all finite abelian groups using the
+Structure Theorem.
+
+## TODO
+
+Reuse the work done in `Mathlib.GroupTheory.FiniteAbelian.Duality`. This requires to write some more
+glue.
+-/
+
+noncomputable section
+
+open Circle Finset Function Multiplicative
+open Fintype (card)
+open Real hiding exp
+open scoped BigOperators DirectSum
+
+variable {α : Type*} [AddCommGroup α] {n : ℕ} {a b : α}
+
+namespace AddChar
+variable (n : ℕ) [NeZero n]
+
+/-- Indexing of the complex characters of `ZMod n`. `AddChar.zmod n x` is the character sending `y`
+to `e ^ (2 * π * i * x * y / n)`. -/
+def zmod (x : ZMod n) : AddChar (ZMod n) Circle :=
+  AddChar.compAddMonoidHom ⟨AddCircle.toCircle, AddCircle.toCircle_zero, AddCircle.toCircle_add⟩ <|
+    ZMod.toAddCircle.comp <| .mulLeft x
+
+@[simp] lemma zmod_intCast (x y : ℤ) : zmod n x y = exp (2 * π * (x * y / n)) := by
+  simp [zmod, ← Int.cast_mul x y, -Int.cast_mul, ZMod.toAddCircle_intCast,
+    AddCircle.toCircle_apply_mk]
+
+@[simp] lemma zmod_zero : zmod n 0 = 1 :=
+  DFunLike.ext _ _ <| by simp [ZMod.intCast_surjective.forall, zmod]
+
+variable {n}
+
+@[simp] lemma zmod_add : ∀ x y : ZMod n, zmod n (x + y) = zmod n x * zmod n y := by
+  simp [DFunLike.ext_iff, ← Int.cast_add, zmod, add_mul, add_div, map_add_eq_mul]
+
+lemma zmod_injective : Injective (zmod n) := by
+  simp_rw [Injective, ZMod.intCast_surjective.forall]
+  rintro x y h
+  have hn : (n : ℝ) ≠ 0 := NeZero.ne _
+  simpa [pi_ne_zero, exp_inj, hn, CharP.intCast_eq_intCast (ZMod n) n] using
+    (zmod_intCast ..).symm.trans <| (DFunLike.congr_fun h ((1 : ℤ) : ZMod n)).trans <|
+      zmod_intCast ..
+
+@[simp] lemma zmod_inj {x y : ZMod n} : zmod n x = zmod n y ↔ x = y := zmod_injective.eq_iff
+
+/-- `AddChar.zmod` bundled as an `AddChar`. -/
+def zmodHom : AddChar (ZMod n) (AddChar (ZMod n) Circle) where
+  toFun := zmod n
+  map_zero_eq_one' := by simp
+  map_add_eq_mul' := by simp
+
+/-- Character on a product of `ZMod`s given by `x ↦ ∏ i, e ^ (2 * π * I * x i * y / n)`. -/
+private def mkZModAux {ι : Type} [DecidableEq ι] (n : ι → ℕ) [∀ i, NeZero (n i)]
+    (u : ∀ i, ZMod (n i)) : AddChar (⨁ i, ZMod (n i)) Circle :=
+  AddChar.directSum fun i ↦ zmod (n i) (u i)
+
+private lemma mkZModAux_injective {ι : Type} [DecidableEq ι] {n : ι → ℕ} [∀ i, NeZero (n i)] :
+    Injective (mkZModAux n) :=
+  AddChar.directSum_injective.comp fun f g h ↦ by simpa [funext_iff] using h
+
+/-- The circle-valued characters of a finite abelian group are the same as its complex-valued
+characters. -/
+def circleEquivComplex [Finite α] : AddChar α Circle ≃+ AddChar α ℂ where
+  toFun ψ := toMonoidHomEquiv.symm <| coeHom.comp ψ.toMonoidHom
+  invFun ψ :=
+    { toFun := fun a ↦ (⟨ψ a, mem_sphere_zero_iff_norm.2 <| ψ.norm_apply _⟩ : Circle)
+      map_zero_eq_one' := by simp [Circle]
+      map_add_eq_mul' := fun a b ↦ by ext : 1; simp [map_add_eq_mul] }
+  left_inv ψ := by ext : 1; simp
+  right_inv ψ := by ext : 1; simp
+  map_add' ψ χ := rfl
+
+@[simp] lemma card_eq [Fintype α] : card (AddChar α ℂ) = card α := by
+  obtain ⟨ι, _, n, hn, ⟨e⟩⟩ := AddCommGroup.equiv_directSum_zmod_of_finite' α
+  classical
+  have hn' i : NeZero (n i) := by have := hn i; exact ⟨by positivity⟩
+  let f : α → AddChar α ℂ := fun a ↦ coeHom.compAddChar ((mkZModAux n <| e a).compAddMonoidHom e)
+  have hf : Injective f := circleEquivComplex.injective.comp
+    ((compAddMonoidHom_injective_left _ e.surjective).comp <| mkZModAux_injective.comp <|
+      DFunLike.coe_injective.comp <| e.injective.comp Additive.ofMul.injective)
+  exact (card_addChar_le _ _).antisymm (Fintype.card_le_of_injective _ hf)
+
+/-- `ZMod n` is (noncanonically) isomorphic to its group of characters. -/
+def zmodAddEquiv : ZMod n ≃+ AddChar (ZMod n) ℂ := by
+  refine AddEquiv.ofBijective
+    (circleEquivComplex.toAddMonoidHom.comp <| AddChar.toAddMonoidHom zmodHom) ?_
+  rw [Fintype.bijective_iff_injective_and_card, card_eq]
+  exact ⟨circleEquivComplex.injective.comp zmod_injective, rfl⟩
+
+@[simp] lemma zmodAddEquiv_apply (x : ZMod n) :
+    zmodAddEquiv x = circleEquivComplex (zmod n x) := rfl
+
+section Finite
+variable (α) [Finite α]
+
+/-- Complex-valued characters of a finite abelian group `α` form a basis of `α → ℂ`. -/
+def complexBasis : Basis (AddChar α ℂ) ℂ (α → ℂ) :=
+  basisOfLinearIndependentOfCardEqFinrank (AddChar.linearIndependent _ _) <| by
+    cases nonempty_fintype α; rw [card_eq, Module.finrank_fintype_fun_eq_card]
+
+@[simp, norm_cast]
+lemma coe_complexBasis : ⇑(complexBasis α) = ((⇑) : AddChar α ℂ → α → ℂ) := by
+  rw [complexBasis, coe_basisOfLinearIndependentOfCardEqFinrank]
+
+variable {α}
+
+@[simp]
+lemma complexBasis_apply (ψ : AddChar α ℂ) : complexBasis α ψ = ψ := by rw [coe_complexBasis]
+
+lemma exists_apply_ne_zero : (∃ ψ : AddChar α ℂ, ψ a ≠ 1) ↔ a ≠ 0 := by
+  refine ⟨?_, fun ha ↦ ?_⟩
+  · rintro ⟨ψ, hψ⟩ rfl
+    exact hψ ψ.map_zero_eq_one
+  classical
+  by_contra! h
+  let f : α → ℂ := fun b ↦ if a = b then 1 else 0
+  have h₀ := congr_fun ((complexBasis α).sum_repr f) 0
+  have h₁ := congr_fun ((complexBasis α).sum_repr f) a
+  simp only [complexBasis_apply, Fintype.sum_apply, Pi.smul_apply, h, smul_eq_mul, mul_one,
+    map_zero_eq_one, if_pos rfl, if_neg ha, f] at h₀ h₁
+  exact one_ne_zero (h₁.symm.trans h₀)
+
+lemma forall_apply_eq_zero : (∀ ψ : AddChar α ℂ, ψ a = 1) ↔ a = 0 := by
+  simpa using exists_apply_ne_zero.not
+
+lemma doubleDualEmb_injective : Injective (doubleDualEmb : α → AddChar (AddChar α ℂ) ℂ) :=
+  doubleDualEmb.ker_eq_bot_iff.1 <| eq_bot_iff.2 fun a ha ↦
+    forall_apply_eq_zero.1 fun ψ ↦ by simpa using DFunLike.congr_fun ha (Additive.ofMul ψ)
+
+lemma doubleDualEmb_bijective : Bijective (doubleDualEmb : α → AddChar (AddChar α ℂ) ℂ) := by
+  cases nonempty_fintype α
+  exact (Fintype.bijective_iff_injective_and_card _).2
+    ⟨doubleDualEmb_injective, card_eq.symm.trans card_eq.symm⟩
+
+@[simp]
+lemma doubleDualEmb_inj : (doubleDualEmb a : AddChar (AddChar α ℂ) ℂ) = doubleDualEmb b ↔ a = b :=
+  doubleDualEmb_injective.eq_iff
+
+@[simp] lemma doubleDualEmb_eq_zero : (doubleDualEmb a : AddChar (AddChar α ℂ) ℂ) = 0 ↔ a = 0 := by
+  rw [← map_zero doubleDualEmb, doubleDualEmb_inj]
+
+lemma doubleDualEmb_ne_zero : (doubleDualEmb a : AddChar (AddChar α ℂ) ℂ) ≠ 0 ↔ a ≠ 0 :=
+  doubleDualEmb_eq_zero.not
+
+/-- The double dual isomorphism of a finite abelian group. -/
+def doubleDualEquiv : α ≃+ AddChar (AddChar α ℂ) ℂ := .ofBijective _ doubleDualEmb_bijective
+
+@[simp]
+lemma coe_doubleDualEquiv : ⇑(doubleDualEquiv : α ≃+ AddChar (AddChar α ℂ) ℂ) = doubleDualEmb := rfl
+
+@[simp] lemma doubleDualEmb_doubleDualEquiv_symm_apply (a : AddChar (AddChar α ℂ) ℂ) :
+    doubleDualEmb (doubleDualEquiv.symm a) = a :=
+  doubleDualEquiv.apply_symm_apply _
+
+@[simp] lemma doubleDualEquiv_symm_doubleDualEmb_apply (a : AddChar (AddChar α ℂ) ℂ) :
+    doubleDualEquiv.symm (doubleDualEmb a) = a := doubleDualEquiv.symm_apply_apply _
+
+end Finite
+
+lemma sum_apply_eq_ite [Fintype α] [DecidableEq α] (a : α) :
+    ∑ ψ : AddChar α ℂ, ψ a = if a = 0 then (Fintype.card α : ℂ) else 0 := by
+  simpa using sum_eq_ite (doubleDualEmb a : AddChar (AddChar α ℂ) ℂ)
+
+lemma expect_apply_eq_ite [Fintype α] [DecidableEq α] (a : α) :
+    𝔼 ψ : AddChar α ℂ, ψ a = if a = 0 then 1 else 0 := by
+  simpa using expect_eq_ite (doubleDualEmb a : AddChar (AddChar α ℂ) ℂ)
+
+lemma sum_apply_eq_zero_iff_ne_zero [Finite α] : ∑ ψ : AddChar α ℂ, ψ a = 0 ↔ a ≠ 0 := by
+  classical
+  cases nonempty_fintype α
+  rw [sum_apply_eq_ite, Ne.ite_eq_right_iff]
+  exact Nat.cast_ne_zero.2 Fintype.card_ne_zero
+
+lemma sum_apply_ne_zero_iff_eq_zero [Finite α] : ∑ ψ : AddChar α ℂ, ψ a ≠ 0 ↔ a = 0 :=
+  sum_apply_eq_zero_iff_ne_zero.not_left
+
+lemma expect_apply_eq_zero_iff_ne_zero [Finite α] : 𝔼 ψ : AddChar α ℂ, ψ a = 0 ↔ a ≠ 0 := by
+  classical
+  cases nonempty_fintype α
+  rw [expect_apply_eq_ite, one_ne_zero.ite_eq_right_iff]
+
+lemma expect_apply_ne_zero_iff_eq_zero [Finite α] : 𝔼 ψ : AddChar α ℂ, ψ a ≠ 0 ↔ a = 0 :=
+  expect_apply_eq_zero_iff_ne_zero.not_left
+
+end AddChar

--- a/Mathlib/Analysis/Fourier/FiniteAbelian/PontryaginDuality.lean
+++ b/Mathlib/Analysis/Fourier/FiniteAbelian/PontryaginDuality.lean
@@ -6,7 +6,7 @@ Authors: Yaël Dillies, Bhavik Mehta
 import Mathlib.Algebra.DirectSum.AddChar
 import Mathlib.Analysis.Fourier.FiniteAbelian.Orthogonality
 import Mathlib.Analysis.SpecialFunctions.Complex.Circle
-import Mathlib.GroupTheory.FiniteAbelian
+import Mathlib.GroupTheory.FiniteAbelian.Basic
 
 /-!
 # Pontryagin duality for finite abelian groups

--- a/Mathlib/Analysis/SpecialFunctions/Complex/Circle.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Complex/Circle.lean
@@ -83,6 +83,9 @@ lemma exp_eq_one {r : ℝ} : exp r = 1 ↔ ∃ n : ℤ, r = n * (2 * π) := by
   simp [Circle.ext_iff, Complex.exp_eq_one_iff, ← mul_assoc, Complex.I_ne_zero,
     ← Complex.ofReal_inj]
 
+lemma exp_inj {r s : ℝ} : exp r = exp s ↔ r ≡ s [PMOD (2 * π)] := by
+  simp [AddCommGroup.ModEq, ← exp_eq_one, div_eq_one, eq_comm (a := exp r)]
+
 lemma exp_sub_two_pi (x : ℝ) : exp (x - 2 * π) = exp x := periodic_exp.sub_eq x
 lemma exp_add_two_pi (x : ℝ) : exp (x + 2 * π) = exp x := periodic_exp x
 
@@ -164,7 +167,7 @@ theorem toCircle_add (x : AddCircle T) (y : AddCircle T) :
   induction y using QuotientAddGroup.induction_on
   simp_rw [← coe_add, toCircle_apply_mk, mul_add, Circle.exp_add]
 
-lemma toCircle_zero : toCircle (0 : AddCircle T) = 1 := by
+@[simp] lemma toCircle_zero : toCircle (0 : AddCircle T) = 1 := by
   rw [← QuotientAddGroup.mk_zero, toCircle_apply_mk, mul_zero, Circle.exp_zero]
 
 theorem continuous_toCircle : Continuous (@toCircle T) :=


### PR DESCRIPTION
Prove Pontryagin duality in case of finite abelian groups.

This states that any finite abelian group is canonically isomorphic to its double dual (the space of complex-valued characters of its space of complex-valued characters).

We first prove it for `ZMod n` and then extend to all finite abelian groups using the Structure Theorem.

From LeanAPAP

Co-authored-by Bhavik Mehta <bhavikmehta8@gmail.com>

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->
- [x] depends on: #15441
- [x] depends on: #16447

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
