### PR TITLE
[Merged by Bors] - feat(Prod.Basic/UniformSpace.Basic): Two lemmas about swap.

### DIFF
--- a/Mathlib/Data/Prod/Basic.lean
+++ b/Mathlib/Data/Prod/Basic.lean
@@ -179,6 +179,10 @@ is equal to the composition of `Prod.swap` with `Prod.map g f`.-/
 theorem map_comp_swap (f : α → β) (g : γ → δ) :
     Prod.map f g ∘ Prod.swap = Prod.swap ∘ Prod.map g f := rfl
 
+theorem _root_.Function.Semiconj.swap_map (f : α → α) (g : β → β) :
+    Function.Semiconj swap (map f g) (map g f) :=
+  Function.semiconj_iff_comp_eq.2 (map_comp_swap g f).symm
+
 theorem eq_iff_fst_eq_snd_eq : ∀ {p q : α × β}, p = q ↔ p.1 = q.1 ∧ p.2 = q.2
   | ⟨p₁, p₂⟩, ⟨q₁, q₂⟩ => by simp
 

--- a/Mathlib/Topology/UniformSpace/Basic.lean
+++ b/Mathlib/Topology/UniformSpace/Basic.lean
@@ -1441,9 +1441,6 @@ theorem toTopologicalSpace_prod {α} {β} [u : UniformSpace α] [v : UniformSpac
       @instTopologicalSpaceProd α β u.toTopologicalSpace v.toTopologicalSpace :=
   rfl
 
-theorem uniformContinuous_swap : UniformContinuous (Prod.swap : α × β → β × α) :=
-  uniformContinuous_snd.prod_mk uniformContinuous_fst
-
 /-- A version of `UniformContinuous.inf_dom_left` for binary functions -/
 theorem uniformContinuous_inf_dom_left₂ {α β γ} {f : α → β → γ} {ua1 ua2 : UniformSpace α}
     {ub1 ub2 : UniformSpace β} {uc1 : UniformSpace γ}

--- a/Mathlib/Topology/UniformSpace/Basic.lean
+++ b/Mathlib/Topology/UniformSpace/Basic.lean
@@ -1441,6 +1441,9 @@ theorem toTopologicalSpace_prod {α} {β} [u : UniformSpace α] [v : UniformSpac
       @instTopologicalSpaceProd α β u.toTopologicalSpace v.toTopologicalSpace :=
   rfl
 
+theorem uniformContinuous_swap : UniformContinuous (Prod.swap : α × β → β × α) :=
+  uniformContinuous_snd.prod_mk uniformContinuous_fst
+
 /-- A version of `UniformContinuous.inf_dom_left` for binary functions -/
 theorem uniformContinuous_inf_dom_left₂ {α β γ} {f : α → β → γ} {ua1 ua2 : UniformSpace α}
     {ub1 ub2 : UniformSpace β} {uc1 : UniformSpace γ}


### PR DESCRIPTION
A special case  of lemma `map_comp_swap` in `Data.Prod.Basic` is restated in terms of `Function.Semiconj`.

~~Also, with little surprise, `swap` is uniformly continuous.~~

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
