### PR TITLE
[Merged by Bors] - feat: add lemmas for ofComplex evaluations outside UpperHalfPlane

### DIFF
--- a/Mathlib/Analysis/Complex/UpperHalfPlane/Topology.lean
+++ b/Mathlib/Analysis/Complex/UpperHalfPlane/Topology.lean
@@ -127,8 +127,32 @@ scoped notation "↑ₕ" f => f ∘ ofComplex
 lemma ofComplex_apply (z : ℍ) : ofComplex (z : ℂ) = z :=
   OpenEmbedding.toPartialHomeomorph_left_inv ..
 
-lemma comp_ofComplex (f : ℍ → ℂ) (z : ℍ) : (↑ₕ f) z = f z := by
-  rw [Function.comp_apply, ofComplex_apply]
+lemma ofComplex_apply_eq_ite (w : ℂ) :
+    ofComplex w = if hw : 0 < w.im then ⟨w, hw⟩ else Classical.choice inferInstance := by
+  split_ifs with hw
+  · exact ofComplex_apply ⟨w, hw⟩
+  · change (Function.invFunOn UpperHalfPlane.coe Set.univ w) = _
+    simp only [invFunOn, dite_eq_right_iff, mem_univ, true_and]
+    rintro ⟨a, rfl⟩
+    exact (a.prop.not_le (by simpa using hw)).elim
+
+lemma ofComplex_apply_of_im_nonpos {w : ℂ} (hw : w.im ≤ 0) :
+    ofComplex w = Classical.choice inferInstance := by
+  simp [ofComplex_apply_eq_ite w, hw]
+
+lemma ofComplex_apply_eq_of_im_nonpos {w w' : ℂ} (hw : w.im ≤ 0) (hw' : w'.im ≤ 0) :
+    ofComplex w = ofComplex w' := by
+  simp [ofComplex_apply_of_im_nonpos, hw, hw']
+
+lemma comp_ofComplex (f : ℍ → ℂ) (z : ℍ) : (↑ₕ f) z = f z :=
+  congrArg _ <| ofComplex_apply z
+
+lemma comp_ofComplex_of_im_pos (f : ℍ → ℂ) (z : ℂ) (hz : 0 < z.im) : (↑ₕ f) z = f ⟨z, hz⟩ :=
+  congrArg _ <| ofComplex_apply ⟨z, hz⟩
+
+lemma comp_ofComplex_of_im_le_zero (f : ℍ → ℂ) (z z' : ℂ) (hz : z.im ≤ 0) (hz' : z'.im ≤ 0)  :
+    (↑ₕ f) z = (↑ₕ f) z' := by
+  simp [ofComplex_apply_of_im_nonpos, hz, hz']
 
 end UpperHalfPlane
 


### PR DESCRIPTION
This is useful in many places to remove `(hz : 0 < z.im)` hypotheses.