### PR TITLE
[Merged by Bors] - feat(ModelTheory): Substructure-closure and finite generation in relational languages

### DIFF
--- a/Mathlib/ModelTheory/FinitelyGenerated.lean
+++ b/Mathlib/ModelTheory/FinitelyGenerated.lean
@@ -98,7 +98,7 @@ theorem fg_of_finite {s : L.Substructure M} [h : Finite s] : s.FG :=
 theorem finite_of_fg [L.IsRelational] {S : L.Substructure M} (h : S.FG) : Finite S := by
   obtain ⟨s, rfl⟩ := h
   have hs := s.finite_toSet
-  rw [← ((closure L).mem_closed_iff _).1 (closed_of_IsRelational L (↑s : Set M))] at hs
+  rw [← ((closure L).mem_closed_iff _).1 (mem_closed_of_IsRelational L (↑s : Set M))] at hs
   exact hs
 
 /-- A substructure of `M` is countably generated if it is the closure of a countable subset of `M`.

--- a/Mathlib/ModelTheory/FinitelyGenerated.lean
+++ b/Mathlib/ModelTheory/FinitelyGenerated.lean
@@ -92,6 +92,15 @@ theorem FG.of_map_embedding {N : Type*} [L.Structure N] (f : M ↪[L] N) {s : L.
   rw [h] at h'
   exact Hom.map_le_range h'
 
+theorem fg_of_finite {s : L.Substructure M} [h : Finite s] : s.FG :=
+  ⟨Set.Finite.toFinset h, by simp only [Finite.coe_toFinset, closure_eq]⟩
+
+theorem finite_of_fg [L.IsRelational] {S : L.Substructure M} (h : S.FG) : Finite S := by
+  obtain ⟨s, rfl⟩ := h
+  have hs := s.finite_toSet
+  rw [← ((closure L).mem_closed_iff _).1 (closed_of_IsRelational L (↑s : Set M))] at hs
+  exact hs
+
 /-- A substructure of `M` is countably generated if it is the closure of a countable subset of `M`.
 -/
 def CG (N : L.Substructure M) : Prop :=
@@ -172,7 +181,6 @@ open Substructure
 
 namespace Structure
 
-
 variable (L) (M)
 
 /-- A structure is finitely generated if it is the closure of a finite subset. -/
@@ -226,6 +234,12 @@ theorem FG.countable_embedding (N : Type*) [L.Structure N] [Countable N] (_ : FG
 instance Fg.instCountable_embedding (N : Type*) [L.Structure N]
     [Countable N] [h : FG L M] : Countable (M ↪[L] N) :=
   FG.countable_embedding N h
+
+theorem fg_of_finite [Finite M] : FG L M := by
+  simp only [fg_def, Substructure.fg_of_finite, topEquiv.toEquiv.finite_iff]
+
+theorem finite_of_fg [L.IsRelational] (h : FG L M) : Finite M :=
+  Finite.of_finite_univ (Substructure.finite_of_fg (fg_def.1 h))
 
 theorem cg_def : CG L M ↔ (⊤ : L.Substructure M).CG :=
   ⟨fun h => h.1, fun h => ⟨h⟩⟩

--- a/Mathlib/ModelTheory/FinitelyGenerated.lean
+++ b/Mathlib/ModelTheory/FinitelyGenerated.lean
@@ -92,17 +92,17 @@ theorem FG.of_map_embedding {N : Type*} [L.Structure N] (f : M ↪[L] N) {s : L.
   rw [h] at h'
   exact Hom.map_le_range h'
 
-theorem fg_of_finite {s : L.Substructure M} [h : Finite s] : s.FG :=
+theorem FG.of_finite {s : L.Substructure M} [h : Finite s] : s.FG :=
   ⟨Set.Finite.toFinset h, by simp only [Finite.coe_toFinset, closure_eq]⟩
 
-theorem finite_of_fg [L.IsRelational] {S : L.Substructure M} (h : S.FG) : Finite S := by
+theorem FG.finite [L.IsRelational] {S : L.Substructure M} (h : S.FG) : Finite S := by
   obtain ⟨s, rfl⟩ := h
   have hs := s.finite_toSet
   rw [← ((closure L).mem_closed_iff _).1 (mem_closed_of_isRelational L (↑s : Set M))] at hs
   exact hs
 
 theorem fg_iff_finite [L.IsRelational] {S : L.Substructure M} : S.FG ↔ Finite S :=
-  ⟨finite_of_fg, fun _ => fg_of_finite⟩
+  ⟨FG.finite, fun _ => FG.of_finite⟩
 
 /-- A substructure of `M` is countably generated if it is the closure of a countable subset of `M`.
 -/
@@ -238,14 +238,14 @@ instance Fg.instCountable_embedding (N : Type*) [L.Structure N]
     [Countable N] [h : FG L M] : Countable (M ↪[L] N) :=
   FG.countable_embedding N h
 
-theorem fg_of_finite [Finite M] : FG L M := by
-  simp only [fg_def, Substructure.fg_of_finite, topEquiv.toEquiv.finite_iff]
+theorem FG.of_finite [Finite M] : FG L M := by
+  simp only [fg_def, Substructure.FG.of_finite, topEquiv.toEquiv.finite_iff]
 
-theorem finite_of_fg [L.IsRelational] (h : FG L M) : Finite M :=
-  Finite.of_finite_univ (Substructure.finite_of_fg (fg_def.1 h))
+theorem FG.finite [L.IsRelational] (h : FG L M) : Finite M :=
+  Finite.of_finite_univ (Substructure.FG.finite (fg_def.1 h))
 
 theorem fg_iff_finite [L.IsRelational] : FG L M ↔ Finite M :=
-  ⟨finite_of_fg, fun _ => fg_of_finite⟩
+  ⟨FG.finite, fun _ => FG.of_finite⟩
 
 theorem cg_def : CG L M ↔ (⊤ : L.Substructure M).CG :=
   ⟨fun h => h.1, fun h => ⟨h⟩⟩

--- a/Mathlib/ModelTheory/FinitelyGenerated.lean
+++ b/Mathlib/ModelTheory/FinitelyGenerated.lean
@@ -98,8 +98,11 @@ theorem fg_of_finite {s : L.Substructure M} [h : Finite s] : s.FG :=
 theorem finite_of_fg [L.IsRelational] {S : L.Substructure M} (h : S.FG) : Finite S := by
   obtain ⟨s, rfl⟩ := h
   have hs := s.finite_toSet
-  rw [← ((closure L).mem_closed_iff _).1 (mem_closed_of_IsRelational L (↑s : Set M))] at hs
+  rw [← ((closure L).mem_closed_iff _).1 (mem_closed_of_isRelational L (↑s : Set M))] at hs
   exact hs
+
+theorem fg_iff_finite [L.IsRelational] {S : L.Substructure M} : S.FG ↔ Finite S :=
+  ⟨finite_of_fg, fun _ => fg_of_finite⟩
 
 /-- A substructure of `M` is countably generated if it is the closure of a countable subset of `M`.
 -/
@@ -240,6 +243,9 @@ theorem fg_of_finite [Finite M] : FG L M := by
 
 theorem finite_of_fg [L.IsRelational] (h : FG L M) : Finite M :=
   Finite.of_finite_univ (Substructure.finite_of_fg (fg_def.1 h))
+
+theorem fg_iff_finite [L.IsRelational] : FG L M ↔ Finite M :=
+  ⟨finite_of_fg, fun _ => fg_of_finite⟩
 
 theorem cg_def : CG L M ↔ (⊤ : L.Substructure M).CG :=
   ⟨fun h => h.1, fun h => ⟨h⟩⟩

--- a/Mathlib/ModelTheory/Substructures.lean
+++ b/Mathlib/ModelTheory/Substructures.lean
@@ -289,7 +289,21 @@ theorem lift_card_closure_le :
   refine lift_card_closure_le_card_term.trans (Term.card_le.trans ?_)
   rw [mk_sum, lift_umax.{w, u}]
 
+lemma closed_iff (s : Set M) :
+    (closure L).closed s ↔ ∀ {n}, ∀ f : L.Functions n, ClosedUnder f s := by
+  refine ⟨fun h n f => ?_, fun h => ?_⟩
+  · rw [← h]
+    exact Substructure.fun_mem _ _
+  · change closure L s = s
+    have h' : closure L s = ⟨s, h⟩ := closure_eq_of_le (refl _) subset_closure
+    rw [h']
+    rfl
+
 variable (L)
+
+@[simp]
+lemma closed_of_IsRelational [L.IsRelational] (s : Set M) : (closure L).closed s :=
+  (closed_iff s).2 (IsRelational.empty_functions _).elim
 
 theorem _root_.Set.Countable.substructure_closure
     [Countable (Σl, L.Functions l)] (h : s.Countable) : Countable.{w + 1} (closure L s) := by

--- a/Mathlib/ModelTheory/Substructures.lean
+++ b/Mathlib/ModelTheory/Substructures.lean
@@ -289,21 +289,19 @@ theorem lift_card_closure_le :
   refine lift_card_closure_le_card_term.trans (Term.card_le.trans ?_)
   rw [mk_sum, lift_umax.{w, u}]
 
-lemma closed_iff (s : Set M) :
-    (closure L).closed s ↔ ∀ {n}, ∀ f : L.Functions n, ClosedUnder f s := by
+lemma mem_closed_iff (s : Set M) :
+    s ∈ (closure L).closed ↔ ∀ {n}, ∀ f : L.Functions n, ClosedUnder f s := by
   refine ⟨fun h n f => ?_, fun h => ?_⟩
   · rw [← h]
     exact Substructure.fun_mem _ _
-  · change closure L s = s
-    have h' : closure L s = ⟨s, h⟩ := closure_eq_of_le (refl _) subset_closure
-    rw [h']
-    rfl
+  · have h' : closure L s = ⟨s, h⟩ := closure_eq_of_le (refl _) subset_closure
+    exact congr_arg _ h'
 
 variable (L)
 
 @[simp]
-lemma closed_of_IsRelational [L.IsRelational] (s : Set M) : (closure L).closed s :=
-  (closed_iff s).2 (IsRelational.empty_functions _).elim
+lemma mem_closed_of_IsRelational [L.IsRelational] (s : Set M) : s ∈ (closure L).closed :=
+  (mem_closed_iff s).2 (IsRelational.empty_functions _).elim
 
 theorem _root_.Set.Countable.substructure_closure
     [Countable (Σl, L.Functions l)] (h : s.Countable) : Countable.{w + 1} (closure L s) := by

--- a/Mathlib/ModelTheory/Substructures.lean
+++ b/Mathlib/ModelTheory/Substructures.lean
@@ -300,7 +300,7 @@ lemma mem_closed_iff (s : Set M) :
 variable (L)
 
 @[simp]
-lemma mem_closed_of_IsRelational [L.IsRelational] (s : Set M) : s ∈ (closure L).closed :=
+lemma mem_closed_of_isRelational [L.IsRelational] (s : Set M) : s ∈ (closure L).closed :=
   (mem_closed_iff s).2 (IsRelational.empty_functions _).elim
 
 theorem _root_.Set.Countable.substructure_closure


### PR DESCRIPTION
Shows that in relational languages, all sets are closed as substructures.
As a consequence, finiteness is the same as finite generation.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
