### PR TITLE
[Merged by Bors] - feat(Logic/Equiv): involutions are inverses of themselves

### DIFF
--- a/Mathlib/Logic/Equiv/Basic.lean
+++ b/Mathlib/Logic/Equiv/Basic.lean
@@ -1532,6 +1532,15 @@ theorem toPerm_symm {f : α → α} (h : Involutive f) : (h.toPerm f).symm = h.t
 theorem toPerm_involutive {f : α → α} (h : Involutive f) : Involutive (h.toPerm f) :=
   h
 
+theorem leftInverse_iff {f g : α → α} (h : Involutive f) :
+    g.LeftInverse f ↔ g = f :=
+  ⟨fun hg ↦ funext fun x ↦ by rw [← h x, hg, h], fun he ↦ he ▸ h.leftInverse⟩
+
+@[simp]
+theorem symm_eq_self_of_involutive (f : Equiv.Perm α) (h : Involutive f) : f.symm = f := by
+  ext x
+  exact congrFun (h.leftInverse_iff.mp f.left_inv) x
+
 end Function.Involutive
 
 theorem PLift.eq_up_iff_down_eq {x : PLift α} {y : α} : x = PLift.up y ↔ x.down = y :=

--- a/Mathlib/Logic/Equiv/Basic.lean
+++ b/Mathlib/Logic/Equiv/Basic.lean
@@ -1533,9 +1533,8 @@ theorem toPerm_involutive {f : α → α} (h : Involutive f) : Involutive (h.toP
   h
 
 @[simp]
-theorem symm_eq_self_of_involutive (f : Equiv.Perm α) (h : Involutive f) : f.symm = f := by
-  ext x
-  exact congrFun (h.leftInverse_iff.mp f.left_inv) x
+theorem symm_eq_self_of_involutive (f : Equiv.Perm α) (h : Involutive f) : f.symm = f :=
+  DFunLike.coe_injective (h.leftInverse_iff.mp f.left_inv)
 
 end Function.Involutive
 

--- a/Mathlib/Logic/Equiv/Basic.lean
+++ b/Mathlib/Logic/Equiv/Basic.lean
@@ -1532,10 +1532,6 @@ theorem toPerm_symm {f : α → α} (h : Involutive f) : (h.toPerm f).symm = h.t
 theorem toPerm_involutive {f : α → α} (h : Involutive f) : Involutive (h.toPerm f) :=
   h
 
-theorem leftInverse_iff {f g : α → α} (h : Involutive f) :
-    g.LeftInverse f ↔ g = f :=
-  ⟨fun hg ↦ funext fun x ↦ by rw [← h x, hg, h], fun he ↦ he ▸ h.leftInverse⟩
-
 @[simp]
 theorem symm_eq_self_of_involutive (f : Equiv.Perm α) (h : Involutive f) : f.symm = f := by
   ext x

--- a/Mathlib/Logic/Equiv/Basic.lean
+++ b/Mathlib/Logic/Equiv/Basic.lean
@@ -1532,7 +1532,6 @@ theorem toPerm_symm {f : α → α} (h : Involutive f) : (h.toPerm f).symm = h.t
 theorem toPerm_involutive {f : α → α} (h : Involutive f) : Involutive (h.toPerm f) :=
   h
 
-@[simp]
 theorem symm_eq_self_of_involutive (f : Equiv.Perm α) (h : Involutive f) : f.symm = f :=
   DFunLike.coe_injective (h.leftInverse_iff.mp f.left_inv)
 

--- a/Mathlib/Logic/Equiv/Defs.lean
+++ b/Mathlib/Logic/Equiv/Defs.lean
@@ -294,9 +294,7 @@ theorem symm_bijective : Function.Bijective (Equiv.symm : (α ≃ β) → β ≃
 @[simp]
 theorem symm_eq_self_of_involution (f : Equiv.Perm α) (h : Function.Involutive f) : f.symm = f := by
   ext x
-  calc f.symm x = f.symm (f (f x)) := by rw [h x]
-              _ = (f.symm ∘ f) (f x) := rfl
-              _ = id (f x) := by rw [symm_comp_self]
+  rw [← h x, symm_apply_apply, h]
 
 @[simp] theorem trans_refl (e : α ≃ β) : e.trans (Equiv.refl β) = e := by cases e; rfl
 

--- a/Mathlib/Logic/Equiv/Defs.lean
+++ b/Mathlib/Logic/Equiv/Defs.lean
@@ -292,7 +292,7 @@ theorem symm_bijective : Function.Bijective (Equiv.symm : (α ≃ β) → β ≃
   Function.bijective_iff_has_inverse.mpr ⟨_, symm_symm, symm_symm⟩
 
 @[simp]
-theorem symm_eq_self_of_involution (f : Equiv.Perm α) (h : Function.Involutive f) : f.symm = f := by
+theorem symm_eq_self_of_involutive (f : Equiv.Perm α) (h : Function.Involutive f) : f.symm = f := by
   ext x
   rw [← h x, symm_apply_apply, h]
 

--- a/Mathlib/Logic/Equiv/Defs.lean
+++ b/Mathlib/Logic/Equiv/Defs.lean
@@ -291,11 +291,6 @@ theorem eq_symm_apply {α β} (e : α ≃ β) {x y} : y = e.symm x ↔ e y = x :
 theorem symm_bijective : Function.Bijective (Equiv.symm : (α ≃ β) → β ≃ α) :=
   Function.bijective_iff_has_inverse.mpr ⟨_, symm_symm, symm_symm⟩
 
-@[simp]
-theorem symm_eq_self_of_involutive (f : Equiv.Perm α) (h : Function.Involutive f) : f.symm = f := by
-  ext x
-  rw [← h x, symm_apply_apply, h]
-
 @[simp] theorem trans_refl (e : α ≃ β) : e.trans (Equiv.refl β) = e := by cases e; rfl
 
 @[simp] theorem refl_symm : (Equiv.refl α).symm = Equiv.refl α := rfl

--- a/Mathlib/Logic/Equiv/Defs.lean
+++ b/Mathlib/Logic/Equiv/Defs.lean
@@ -291,6 +291,13 @@ theorem eq_symm_apply {α β} (e : α ≃ β) {x y} : y = e.symm x ↔ e y = x :
 theorem symm_bijective : Function.Bijective (Equiv.symm : (α ≃ β) → β ≃ α) :=
   Function.bijective_iff_has_inverse.mpr ⟨_, symm_symm, symm_symm⟩
 
+@[simp]
+theorem symm_eq_self_of_involution (f : Equiv.Perm α) (h : Function.Involutive f) : f.symm = f := by
+  ext x
+  calc f.symm x = f.symm (f (f x)) := by rw [h x]
+              _ = (f.symm ∘ f) (f x) := rfl
+              _ = id (f x) := by rw [symm_comp_self]
+
 @[simp] theorem trans_refl (e : α ≃ β) : e.trans (Equiv.refl β) = e := by cases e; rfl
 
 @[simp] theorem refl_symm : (Equiv.refl α).symm = Equiv.refl α := rfl

--- a/Mathlib/Logic/Function/Basic.lean
+++ b/Mathlib/Logic/Function/Basic.lean
@@ -763,6 +763,10 @@ theorem comp_self : f ∘ f = id :=
 
 protected theorem leftInverse : LeftInverse f f := h
 
+theorem leftInverse_iff {g : α → α} :
+    g.LeftInverse f ↔ g = f :=
+  ⟨fun hg ↦ funext fun x ↦ by rw [← h x, hg, h], fun he ↦ he ▸ h.leftInverse⟩
+
 protected theorem rightInverse : RightInverse f f := h
 
 protected theorem injective : Injective f := h.leftInverse.injective


### PR DESCRIPTION
This lemma is ported from to lean4 from Kyle Miller's [repo](https://github.com/kmill/lean-graphs). It is used while proving a lemma about combinatorial maps.

Co-authored-by: Kyle Miller <kmill31415@gmail.com>

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
