### PR TITLE
[Merged by Bors] - feat(ContinuousFunctionalCalculus): Show that integration commutes with the CFC

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -914,6 +914,7 @@ import Mathlib.Analysis.BoxIntegral.Partition.Tagged
 import Mathlib.Analysis.CStarAlgebra.Basic
 import Mathlib.Analysis.CStarAlgebra.ContinuousFunctionalCalculus.Basic
 import Mathlib.Analysis.CStarAlgebra.ContinuousFunctionalCalculus.Instances
+import Mathlib.Analysis.CStarAlgebra.ContinuousFunctionalCalculus.Integral
 import Mathlib.Analysis.CStarAlgebra.ContinuousFunctionalCalculus.NonUnital
 import Mathlib.Analysis.CStarAlgebra.ContinuousFunctionalCalculus.Order
 import Mathlib.Analysis.CStarAlgebra.ContinuousFunctionalCalculus.Restrict

--- a/Mathlib/Analysis/CStarAlgebra/ContinuousFunctionalCalculus/Integral.lean
+++ b/Mathlib/Analysis/CStarAlgebra/ContinuousFunctionalCalculus/Integral.lean
@@ -4,7 +4,8 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Frédéric Dupuis
 -/
 
-import Mathlib.Analysis.CStarAlgebra.ContinuousFunctionalCalculus.Instances
+import Mathlib.Analysis.Normed.Algebra.Spectrum
+import Mathlib.Analysis.CStarAlgebra.ContinuousFunctionalCalculus.Unital
 import Mathlib.MeasureTheory.Integral.SetIntegral
 
 /-!
@@ -46,7 +47,7 @@ lemma cfcHom_integral (a : A) (f : X → C(spectrum 𝕜 a, 𝕜)) (hf₁ : Inte
     filter_upwards with x
     simp only [cfcHom_eq_cfcCLM ha]
   rw [h₁, cfcHom_eq_cfcCLM ha]
-  exact cfcCLM_integral a (fun x ↦ f x) hf₁ ha
+  exact cfcCLM_integral a f hf₁ ha
 
 open ContinuousMap in
 /-- The continuous functional calculus commutes with integration. -/

--- a/Mathlib/Analysis/CStarAlgebra/ContinuousFunctionalCalculus/Integral.lean
+++ b/Mathlib/Analysis/CStarAlgebra/ContinuousFunctionalCalculus/Integral.lean
@@ -51,7 +51,7 @@ lemma cfcHom_integral (a : A) (f : X → C(spectrum 𝕜 a, 𝕜)) (hf₁ : Inte
 open ContinuousMap in
 /-- The continuous functional calculus commutes with integration. -/
 lemma cfc_integral [TopologicalSpace X] [OpensMeasurableSpace X] (f : X → 𝕜 → 𝕜)
-    (bound : X → ℝ) (a : A) [SecondCountableTopologyEither X C(↑(spectrum 𝕜 a), 𝕜)]
+    (bound : X → ℝ) (a : A) [SecondCountableTopologyEither X C(spectrum 𝕜 a, 𝕜)]
     (hf : Continuous (fun x => (spectrum 𝕜 a).restrict (f x)).uncurry)
     (hbound : ∀ x, ∀ z ∈ spectrum 𝕜 a, ‖f x z‖ ≤ ‖bound x‖)
     (hbound_integrable : Integrable bound μ) (ha : p a := by cfc_tac) :
@@ -76,22 +76,17 @@ lemma cfc_integral [TopologicalSpace X] [OpensMeasurableSpace X] (f : X → 𝕜
     exact hbound x z.1 z.2
   have hcont₂ : ContinuousOn (fun r => ∫ x, f x r ∂μ) (spectrum 𝕜 a) := by
     have h₁ : (spectrum 𝕜 a).restrict (fun r => ∫ x, f x r ∂μ) = fun r => (∫ x, fc x ∂μ) r := by
-      ext r
-      rw [integral_apply fc_integrable]
-      simp [fc]
+      ext
+      simp only [integral_apply fc_integrable, Set.restrict_apply, coe_mk, fc]
     rw [continuousOn_iff_continuous_restrict, h₁]
-    exact ContinuousMap.continuous (∫ (x : X), fc x ∂μ)
+    exact ContinuousMap.continuous _
   have hrw : (fun x => cfc (f x) a) =ᵐ[μ] fun x => cfcHom ha (fc x) := by
-    apply Filter.Eventually.of_forall
-    intro x
+    refine Filter.Eventually.of_forall fun x => ?_
     simp only
     rw [cfc_apply ..]
-  rw [integral_congr_ae hrw, cfc_apply ..]
-  rw [cfcHom_integral _ _ fc_integrable]
+  rw [integral_congr_ae hrw, cfc_apply .., cfcHom_integral _ _ fc_integrable]
   congr 1
-  ext t
-  simp only [coe_mk, restrict_apply]
-  rw [integral_apply fc_integrable]
-  simp [fc]
+  ext
+  simp only [coe_mk, restrict_apply, integral_apply fc_integrable, Set.restrict_apply, coe_mk, fc]
 
 end unital

--- a/Mathlib/Analysis/CStarAlgebra/ContinuousFunctionalCalculus/Integral.lean
+++ b/Mathlib/Analysis/CStarAlgebra/ContinuousFunctionalCalculus/Integral.lean
@@ -30,10 +30,10 @@ open MeasureTheory
 
 section unital
 
-variable {X : Type*} {𝕜 : Type*} {A : Type*} {p : A → Prop} [RCLike 𝕜] [MeasurableSpace X]
-  [NormedRing A] [StarRing A] [NormedAlgebra 𝕜 A]
-  [NormedAlgebra ℝ A] [CompleteSpace A]
-  [ContinuousFunctionalCalculus 𝕜 p] {μ : MeasureTheory.Measure X}
+variable {X : Type*} {𝕜 : Type*} {A : Type*} {p : A → Prop} [RCLike 𝕜]
+  [MeasurableSpace X] {μ : Measure X}
+  [NormedRing A] [StarRing A] [NormedAlgebra 𝕜 A] [NormedAlgebra ℝ A] [CompleteSpace A]
+  [ContinuousFunctionalCalculus 𝕜 p]
 
 variable {b : A}
 
@@ -51,12 +51,14 @@ lemma cfcHom_integral (a : A) (f : X → C(spectrum 𝕜 a, 𝕜)) (hf₁ : Inte
   exact cfcCLM_integral a (fun x ↦ f x) hf₁ ha
 
 open ContinuousMap in
-lemma cfc_integral [TopologicalSpace X] [OpensMeasurableSpace X] {μ : Measure X} (f : X → 𝕜 → 𝕜)
+/-- The continuous functional calculus commutes with integration. -/
+lemma cfc_integral [TopologicalSpace X] [OpensMeasurableSpace X] (f : X → 𝕜 → 𝕜)
     (bound : X → ℝ) (a : A) [SecondCountableTopologyEither X C(↑(spectrum 𝕜 a), 𝕜)]
     (hf : Continuous (fun x => (spectrum 𝕜 a).restrict (f x)).uncurry)
     (hbound : ∀ x, ∀ z ∈ spectrum 𝕜 a, ‖f x z‖ ≤ ‖bound x‖)
-    (hbound_integrable : Integrable bound μ) (ha : p a) :
+    (hbound_integrable : Integrable bound μ) (ha : p a := by cfc_tac) :
     cfc (fun r => ∫ x, f x r ∂μ) a = ∫ x, cfc (f x) a ∂μ := by
+  have ha : p a := ha   -- Needed due to weird autoparam bug
   have hcont : ∀ x, ContinuousOn (f x) (spectrum 𝕜 a) := by
     intro x
     rw [continuousOn_iff_continuous_restrict]

--- a/Mathlib/Analysis/CStarAlgebra/ContinuousFunctionalCalculus/Integral.lean
+++ b/Mathlib/Analysis/CStarAlgebra/ContinuousFunctionalCalculus/Integral.lean
@@ -1,0 +1,97 @@
+/-
+Copyright (c) 2024 Frédéric Dupuis. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Frédéric Dupuis
+-/
+
+import Mathlib.Analysis.CStarAlgebra.ContinuousFunctionalCalculus.Instances
+import Mathlib.MeasureTheory.Integral.SetIntegral
+
+/-!
+# Integrals and the continuous functional calculus
+
+This file gives results about integrals of the form `∫ x, cfc (f x) a`. Most notably, we show
+that the integral commutes with the continuous functional calculus under appropriate conditions.
+
+## Main declarations
+
++ `cfc_integral`: given a function `f : X → 𝕜 → 𝕜`, we have that
+  `cfc (fun r => ∫ x, f x r ∂μ) a = ∫ x, cfc (f x) a ∂μ`
+  under appropriate conditions
+
+## TODO
+
++ Prove a similar result for the non-unital case
++ Lift this to the case where the CFC is over `ℝ≥0`
++ Use this to prove operator monotonicity and concavity/convexity of `rpow` and `log`
+-/
+
+open MeasureTheory
+
+section unital
+
+variable {X : Type*} {𝕜 : Type*} {A : Type*} {p : A → Prop} [RCLike 𝕜] [MeasurableSpace X]
+  [NormedRing A] [StarRing A] [NormedAlgebra 𝕜 A]
+  [NormedAlgebra ℝ A] [CompleteSpace A]
+  [ContinuousFunctionalCalculus 𝕜 p] {μ : MeasureTheory.Measure X}
+
+variable {b : A}
+
+lemma cfcCLM_integral (a : A) (f : X → C(spectrum 𝕜 a, 𝕜)) (hf₁ : Integrable f μ) (ha : p a) :
+    ∫ x, cfcCLM ha (f x) ∂μ = cfcCLM ha (∫ x, f x ∂μ) := by
+  rw [ContinuousLinearMap.integral_comp_comm _ hf₁]
+
+lemma cfcHom_integral (a : A) (f : X → C(spectrum 𝕜 a, 𝕜)) (hf₁ : Integrable f μ) (ha : p a) :
+    ∫ x, cfcHom ha (f x) ∂μ = cfcHom ha (∫ x, f x ∂μ) := by
+  have h₁ : ∫ x, cfcHom ha (f x) ∂μ = ∫ x, cfcCLM ha (f x) ∂μ := by
+    refine integral_congr_ae ?_
+    filter_upwards with x
+    simp only [cfcHom_eq_cfcCLM ha]
+  rw [h₁, cfcHom_eq_cfcCLM ha]
+  exact cfcCLM_integral a (fun x ↦ f x) hf₁ ha
+
+open ContinuousMap in
+lemma cfc_integral [TopologicalSpace X] [OpensMeasurableSpace X] {μ : Measure X} (f : X → 𝕜 → 𝕜)
+    (bound : X → ℝ) (a : A) [SecondCountableTopologyEither X C(↑(spectrum 𝕜 a), 𝕜)]
+    (hf : Continuous (fun x => (spectrum 𝕜 a).restrict (f x)).uncurry)
+    (hbound : ∀ x, ∀ z ∈ spectrum 𝕜 a, ‖f x z‖ ≤ ‖bound x‖)
+    (hbound_integrable : Integrable bound μ) (ha : p a) :
+    cfc (fun r => ∫ x, f x r ∂μ) a = ∫ x, cfc (f x) a ∂μ := by
+  have hcont : ∀ x, ContinuousOn (f x) (spectrum 𝕜 a) := by
+    intro x
+    rw [continuousOn_iff_continuous_restrict]
+    exact hf.uncurry_left x
+  let fc : X → C(spectrum 𝕜 a, 𝕜) := fun x => ⟨_, (hcont x).restrict⟩
+  have fc_cont : Continuous fc := by
+    refine continuous_of_continuous_uncurry fc ?_
+    simp only [coe_mk, restrict_apply, fc]
+    exact hf
+  have fc_integrable : Integrable fc μ := by
+    refine ⟨fc_cont.aestronglyMeasurable, ?_⟩
+    refine HasFiniteIntegral.mono (g := bound) (hbound_integrable.hasFiniteIntegral) ?_
+    refine Filter.Eventually.of_forall fun x => ?_
+    rw [norm_le _ (norm_nonneg (bound x))]
+    intro z
+    simp only [coe_mk, restrict_apply, fc]
+    exact hbound x z.1 z.2
+  have hcont₂ : ContinuousOn (fun r => ∫ x, f x r ∂μ) (spectrum 𝕜 a) := by
+    have h₁ : (spectrum 𝕜 a).restrict (fun r => ∫ x, f x r ∂μ) = fun r => (∫ x, fc x ∂μ) r := by
+      ext r
+      rw [integral_apply fc_integrable]
+      simp [fc]
+    rw [continuousOn_iff_continuous_restrict, h₁]
+    exact ContinuousMap.continuous (∫ (x : X), fc x ∂μ)
+  have hrw : (fun x => cfc (f x) a) =ᵐ[μ] fun x => cfcHom ha (fc x) := by
+    apply Filter.Eventually.of_forall
+    intro x
+    simp only
+    rw [cfc_apply ..]
+  rw [integral_congr_ae hrw, cfc_apply ..]
+  rw [cfcHom_integral _ _ fc_integrable]
+  congr 1
+  ext t
+  simp only [coe_mk, restrict_apply]
+  rw [integral_apply fc_integrable]
+  simp [fc]
+
+end unital

--- a/Mathlib/Analysis/CStarAlgebra/ContinuousFunctionalCalculus/Integral.lean
+++ b/Mathlib/Analysis/CStarAlgebra/ContinuousFunctionalCalculus/Integral.lean
@@ -36,18 +36,18 @@ variable {X : Type*} {𝕜 : Type*} {A : Type*} {p : A → Prop} [RCLike 𝕜]
   [NormedRing A] [StarRing A] [NormedAlgebra 𝕜 A] [NormedAlgebra ℝ A] [CompleteSpace A]
   [ContinuousFunctionalCalculus 𝕜 p]
 
-lemma cfcCLM_integral (a : A) (f : X → C(spectrum 𝕜 a, 𝕜)) (hf₁ : Integrable f μ) (ha : p a) :
-    ∫ x, cfcCLM ha (f x) ∂μ = cfcCLM ha (∫ x, f x ∂μ) := by
+lemma cfcL_integral (a : A) (f : X → C(spectrum 𝕜 a, 𝕜)) (hf₁ : Integrable f μ) (ha : p a) :
+    ∫ x, cfcL ha (f x) ∂μ = cfcL ha (∫ x, f x ∂μ) := by
   rw [ContinuousLinearMap.integral_comp_comm _ hf₁]
 
 lemma cfcHom_integral (a : A) (f : X → C(spectrum 𝕜 a, 𝕜)) (hf₁ : Integrable f μ) (ha : p a) :
     ∫ x, cfcHom ha (f x) ∂μ = cfcHom ha (∫ x, f x ∂μ) := by
-  have h₁ : ∫ x, cfcHom ha (f x) ∂μ = ∫ x, cfcCLM ha (f x) ∂μ := by
+  have h₁ : ∫ x, cfcHom ha (f x) ∂μ = ∫ x, cfcL ha (f x) ∂μ := by
     refine integral_congr_ae ?_
     filter_upwards with x
-    simp only [cfcHom_eq_cfcCLM ha]
-  rw [h₁, cfcHom_eq_cfcCLM ha]
-  exact cfcCLM_integral a f hf₁ ha
+    simp only [cfcHom_eq_cfcL ha]
+  rw [h₁, cfcHom_eq_cfcL ha]
+  exact cfcL_integral a f hf₁ ha
 
 open ContinuousMap in
 /-- The continuous functional calculus commutes with integration. -/

--- a/Mathlib/Analysis/CStarAlgebra/ContinuousFunctionalCalculus/Integral.lean
+++ b/Mathlib/Analysis/CStarAlgebra/ContinuousFunctionalCalculus/Integral.lean
@@ -35,8 +35,6 @@ variable {X : Type*} {𝕜 : Type*} {A : Type*} {p : A → Prop} [RCLike 𝕜]
   [NormedRing A] [StarRing A] [NormedAlgebra 𝕜 A] [NormedAlgebra ℝ A] [CompleteSpace A]
   [ContinuousFunctionalCalculus 𝕜 p]
 
-variable {b : A}
-
 lemma cfcCLM_integral (a : A) (f : X → C(spectrum 𝕜 a, 𝕜)) (hf₁ : Integrable f μ) (ha : p a) :
     ∫ x, cfcCLM ha (f x) ∂μ = cfcCLM ha (∫ x, f x ∂μ) := by
   rw [ContinuousLinearMap.integral_comp_comm _ hf₁]

--- a/Mathlib/Analysis/CStarAlgebra/ContinuousFunctionalCalculus/Integral.lean
+++ b/Mathlib/Analysis/CStarAlgebra/ContinuousFunctionalCalculus/Integral.lean
@@ -41,53 +41,31 @@ lemma cfcL_integral (a : A) (f : X → C(spectrum 𝕜 a, 𝕜)) (hf₁ : Integr
   rw [ContinuousLinearMap.integral_comp_comm _ hf₁]
 
 lemma cfcHom_integral (a : A) (f : X → C(spectrum 𝕜 a, 𝕜)) (hf₁ : Integrable f μ) (ha : p a) :
-    ∫ x, cfcHom ha (f x) ∂μ = cfcHom ha (∫ x, f x ∂μ) := by
-  have h₁ : ∫ x, cfcHom ha (f x) ∂μ = ∫ x, cfcL ha (f x) ∂μ := by
-    refine integral_congr_ae ?_
-    filter_upwards with x
-    simp only [cfcHom_eq_cfcL ha]
-  rw [h₁, cfcHom_eq_cfcL ha]
-  exact cfcL_integral a f hf₁ ha
+    ∫ x, cfcHom ha (f x) ∂μ = cfcHom ha (∫ x, f x ∂μ) :=
+  cfcL_integral a f hf₁ ha
 
 open ContinuousMap in
 /-- The continuous functional calculus commutes with integration. -/
 lemma cfc_integral [TopologicalSpace X] [OpensMeasurableSpace X] (f : X → 𝕜 → 𝕜)
     (bound : X → ℝ) (a : A) [SecondCountableTopologyEither X C(spectrum 𝕜 a, 𝕜)]
-    (hf : Continuous (fun x => (spectrum 𝕜 a).restrict (f x)).uncurry)
+    (hf₁ : ∀ x, ContinuousOn (f x) (spectrum 𝕜 a))
+    (hf₂ : Continuous (fun x ↦ (⟨_, hf₁ x |>.restrict⟩ : C(spectrum 𝕜 a, 𝕜))))
     (hbound : ∀ x, ∀ z ∈ spectrum 𝕜 a, ‖f x z‖ ≤ ‖bound x‖)
     (hbound_integrable : Integrable bound μ) (ha : p a := by cfc_tac) :
     cfc (fun r => ∫ x, f x r ∂μ) a = ∫ x, cfc (f x) a ∂μ := by
-  have ha : p a := ha   -- Needed due to weird autoparam bug
-  have hcont : ∀ x, ContinuousOn (f x) (spectrum 𝕜 a) := by
-    intro x
-    rw [continuousOn_iff_continuous_restrict]
-    exact hf.uncurry_left x
-  let fc : X → C(spectrum 𝕜 a, 𝕜) := fun x => ⟨_, (hcont x).restrict⟩
-  have fc_cont : Continuous fc := by
-    refine continuous_of_continuous_uncurry fc ?_
-    simp only [coe_mk, restrict_apply, fc]
-    exact hf
+  let fc : X → C(spectrum 𝕜 a, 𝕜) := fun x => ⟨_, (hf₁ x).restrict⟩
   have fc_integrable : Integrable fc μ := by
-    refine ⟨fc_cont.aestronglyMeasurable, ?_⟩
-    refine HasFiniteIntegral.mono (g := bound) (hbound_integrable.hasFiniteIntegral) ?_
-    refine Filter.Eventually.of_forall fun x => ?_
+    refine ⟨hf₂.aestronglyMeasurable, ?_⟩
+    refine hbound_integrable.hasFiniteIntegral.mono <| .of_forall fun x ↦ ?_
     rw [norm_le _ (norm_nonneg (bound x))]
-    intro z
-    simp only [coe_mk, restrict_apply, fc]
-    exact hbound x z.1 z.2
+    exact fun z ↦ hbound x z.1 z.2
+  have h_int_fc : (spectrum 𝕜 a).restrict (∫ x, f x · ∂μ) = ∫ x, fc x ∂μ := by
+    ext; simp [integral_apply fc_integrable, fc]
   have hcont₂ : ContinuousOn (fun r => ∫ x, f x r ∂μ) (spectrum 𝕜 a) := by
-    have h₁ : (spectrum 𝕜 a).restrict (fun r => ∫ x, f x r ∂μ) = fun r => (∫ x, fc x ∂μ) r := by
-      ext
-      simp only [integral_apply fc_integrable, Set.restrict_apply, coe_mk, fc]
-    rw [continuousOn_iff_continuous_restrict, h₁]
-    exact ContinuousMap.continuous _
-  have hrw : (fun x => cfc (f x) a) =ᵐ[μ] fun x => cfcHom ha (fc x) := by
-    refine Filter.Eventually.of_forall fun x => ?_
-    simp only
-    rw [cfc_apply ..]
-  rw [integral_congr_ae hrw, cfc_apply .., cfcHom_integral _ _ fc_integrable]
-  congr 1
-  ext
-  simp only [coe_mk, restrict_apply, integral_apply fc_integrable, Set.restrict_apply, coe_mk, fc]
+    rw [continuousOn_iff_continuous_restrict]
+    convert map_continuous (∫ x, fc x ∂μ)
+  rw [integral_congr_ae (.of_forall fun _ ↦ cfc_apply ..), cfc_apply ..,
+    cfcHom_integral _ _ fc_integrable]
+  congr
 
 end unital

--- a/Mathlib/Analysis/CStarAlgebra/ContinuousFunctionalCalculus/Integral.lean
+++ b/Mathlib/Analysis/CStarAlgebra/ContinuousFunctionalCalculus/Integral.lean
@@ -51,12 +51,12 @@ lemma cfc_integral [TopologicalSpace X] [OpensMeasurableSpace X] (f : X → 𝕜
     (hf₁ : ∀ x, ContinuousOn (f x) (spectrum 𝕜 a))
     (hf₂ : Continuous (fun x ↦ (⟨_, hf₁ x |>.restrict⟩ : C(spectrum 𝕜 a, 𝕜))))
     (hbound : ∀ x, ∀ z ∈ spectrum 𝕜 a, ‖f x z‖ ≤ ‖bound x‖)
-    (hbound_integrable : Integrable bound μ) (ha : p a := by cfc_tac) :
+    (hbound_finite_integral : HasFiniteIntegral bound μ) (ha : p a := by cfc_tac) :
     cfc (fun r => ∫ x, f x r ∂μ) a = ∫ x, cfc (f x) a ∂μ := by
   let fc : X → C(spectrum 𝕜 a, 𝕜) := fun x => ⟨_, (hf₁ x).restrict⟩
   have fc_integrable : Integrable fc μ := by
     refine ⟨hf₂.aestronglyMeasurable, ?_⟩
-    refine hbound_integrable.hasFiniteIntegral.mono <| .of_forall fun x ↦ ?_
+    refine hbound_finite_integral.mono <| .of_forall fun x ↦ ?_
     rw [norm_le _ (norm_nonneg (bound x))]
     exact fun z ↦ hbound x z.1 z.2
   have h_int_fc : (spectrum 𝕜 a).restrict (∫ x, f x · ∂μ) = ∫ x, fc x ∂μ := by
@@ -73,9 +73,9 @@ lemma cfc_integral' [TopologicalSpace X] [OpensMeasurableSpace X] (f : X → �
     (bound : X → ℝ) (a : A) [SecondCountableTopologyEither X C(spectrum 𝕜 a, 𝕜)]
     (hf : Continuous (fun x => (spectrum 𝕜 a).restrict (f x)).uncurry)
     (hbound : ∀ x, ∀ z ∈ spectrum 𝕜 a, ‖f x z‖ ≤ ‖bound x‖)
-    (hbound_integrable : Integrable bound μ) (ha : p a := by cfc_tac) :
+    (hbound_finite_integral : HasFiniteIntegral bound μ) (ha : p a := by cfc_tac) :
     cfc (fun r => ∫ x, f x r ∂μ) a = ∫ x, cfc (f x) a ∂μ := by
-  refine cfc_integral f bound a ?_ ?_ hbound hbound_integrable
+  refine cfc_integral f bound a ?_ ?_ hbound hbound_finite_integral
   · exact (continuousOn_iff_continuous_restrict.mpr <| hf.uncurry_left ·)
   · exact ContinuousMap.curry ⟨_, hf⟩ |>.continuous
 

--- a/Mathlib/Analysis/CStarAlgebra/ContinuousFunctionalCalculus/Integral.lean
+++ b/Mathlib/Analysis/CStarAlgebra/ContinuousFunctionalCalculus/Integral.lean
@@ -68,4 +68,15 @@ lemma cfc_integral [TopologicalSpace X] [OpensMeasurableSpace X] (f : X → 𝕜
     cfcHom_integral _ _ fc_integrable]
   congr
 
+/-- The continuous functional calculus commutes with integration. -/
+lemma cfc_integral' [TopologicalSpace X] [OpensMeasurableSpace X] (f : X → 𝕜 → 𝕜)
+    (bound : X → ℝ) (a : A) [SecondCountableTopologyEither X C(spectrum 𝕜 a, 𝕜)]
+    (hf : Continuous (fun x => (spectrum 𝕜 a).restrict (f x)).uncurry)
+    (hbound : ∀ x, ∀ z ∈ spectrum 𝕜 a, ‖f x z‖ ≤ ‖bound x‖)
+    (hbound_integrable : Integrable bound μ) (ha : p a := by cfc_tac) :
+    cfc (fun r => ∫ x, f x r ∂μ) a = ∫ x, cfc (f x) a ∂μ := by
+  refine cfc_integral f bound a ?_ ?_ hbound hbound_integrable
+  · exact (continuousOn_iff_continuous_restrict.mpr <| hf.uncurry_left ·)
+  · exact ContinuousMap.curry ⟨_, hf⟩ |>.continuous
+
 end unital

--- a/Mathlib/Analysis/CStarAlgebra/ContinuousFunctionalCalculus/Unital.lean
+++ b/Mathlib/Analysis/CStarAlgebra/ContinuousFunctionalCalculus/Unital.lean
@@ -260,10 +260,10 @@ theorem cfcHom_comp [UniqueContinuousFunctionalCalculus R A] (f : C(spectrum R a
 
 end cfcHom
 
-section cfcCLM
+section cfcL
 
 /-- `cfcHom` bundled as a continuous linear map. -/
-noncomputable def cfcCLM {a : A} (ha : p a) : C(spectrum R a, R) →L[R] A :=
+noncomputable def cfcL {a : A} (ha : p a) : C(spectrum R a, R) →L[R] A :=
   { cfcHom ha with
     map_smul' := fun c f => by
       simp only [AlgHom.toRingHom_eq_coe, RingHom.toMonoidHom_eq_coe,
@@ -271,7 +271,7 @@ noncomputable def cfcCLM {a : A} (ha : p a) : C(spectrum R a, R) →L[R] A :=
         LinearMapClass.map_smul, StarAlgHom.coe_toAlgHom, RingHom.id_apply]
     cont := (cfcHom_closedEmbedding ha).continuous }
 
-end cfcCLM
+end cfcL
 
 section CFC
 
@@ -323,13 +323,13 @@ lemma cfcHom_eq_cfc_extend {a : A} (g : R → R) (ha : p a) (f : C(spectrum R a,
   rw [cfc_apply ..]
   congr!
 
-lemma cfc_eq_cfcCLM {a : A} {f : R → R} (ha : p a) (hf : ContinuousOn f (spectrum R a)) :
-    cfc f a = cfcCLM ha ⟨_, hf.restrict⟩ := by
+lemma cfc_eq_cfcL {a : A} {f : R → R} (ha : p a) (hf : ContinuousOn f (spectrum R a)) :
+    cfc f a = cfcL ha ⟨_, hf.restrict⟩ := by
   rw [cfc_def, dif_pos ⟨ha, hf⟩]
   rfl
 
-lemma cfcHom_eq_cfcCLM {a : A} {f : C(spectrum R a, R)} (ha : p a) :
-    cfcHom ha f = cfcCLM ha f := rfl
+lemma cfcHom_eq_cfcL {a : A} {f : C(spectrum R a, R)} (ha : p a) :
+    cfcHom ha f = cfcL ha f := rfl
 
 lemma cfc_cases (P : A → Prop) (a : A) (f : R → R) (h₀ : P 0)
     (haf : (hf : ContinuousOn f (spectrum R a)) → (ha : p a) → P (cfcHom ha ⟨_, hf.restrict⟩)) :

--- a/Mathlib/Analysis/CStarAlgebra/ContinuousFunctionalCalculus/Unital.lean
+++ b/Mathlib/Analysis/CStarAlgebra/ContinuousFunctionalCalculus/Unital.lean
@@ -262,6 +262,7 @@ end cfcHom
 
 section cfcCLM
 
+/-- `cfcHom` bundled as a continuous linear map. -/
 noncomputable def cfcCLM {a : A} (ha : p a) : C(spectrum R a, R) →L[R] A :=
   { cfcHom ha with
     map_smul' := fun c f => by

--- a/Mathlib/Analysis/CStarAlgebra/ContinuousFunctionalCalculus/Unital.lean
+++ b/Mathlib/Analysis/CStarAlgebra/ContinuousFunctionalCalculus/Unital.lean
@@ -260,6 +260,18 @@ theorem cfcHom_comp [UniqueContinuousFunctionalCalculus R A] (f : C(spectrum R a
 
 end cfcHom
 
+section cfcCLM
+
+noncomputable def cfcCLM {a : A} (ha : p a) : C(spectrum R a, R) →L[R] A :=
+  { cfcHom ha with
+    map_smul' := fun c f => by
+      simp only [AlgHom.toRingHom_eq_coe, RingHom.toMonoidHom_eq_coe,
+        OneHom.toFun_eq_coe, MonoidHom.toOneHom_coe, MonoidHom.coe_coe, RingHom.coe_coe,
+        LinearMapClass.map_smul, StarAlgHom.coe_toAlgHom, RingHom.id_apply]
+    cont := (cfcHom_closedEmbedding ha).continuous }
+
+end cfcCLM
+
 section CFC
 
 open scoped Classical in
@@ -309,6 +321,14 @@ lemma cfcHom_eq_cfc_extend {a : A} (g : R → R) (ha : p a) (f : C(spectrum R a,
     continuousOn_iff_continuous_restrict.mpr <| h ▸ map_continuous f
   rw [cfc_apply ..]
   congr!
+
+lemma cfc_eq_cfcCLM {a : A} {f : R → R} (ha : p a) (hf : ContinuousOn f (spectrum R a)) :
+    cfc f a = cfcCLM ha ⟨_, hf.restrict⟩ := by
+  rw [cfc_def, dif_pos ⟨ha, hf⟩]
+  rfl
+
+lemma cfcHom_eq_cfcCLM {a : A} {f : C(spectrum R a, R)} (ha : p a) :
+    cfcHom ha f = cfcCLM ha f := rfl
 
 lemma cfc_cases (P : A → Prop) (a : A) (f : R → R) (h₀ : P 0)
     (haf : (hf : ContinuousOn f (spectrum R a)) → (ha : p a) → P (cfcHom ha ⟨_, hf.restrict⟩)) :

--- a/Mathlib/Analysis/CStarAlgebra/ContinuousFunctionalCalculus/Unital.lean
+++ b/Mathlib/Analysis/CStarAlgebra/ContinuousFunctionalCalculus/Unital.lean
@@ -263,12 +263,11 @@ end cfcHom
 section cfcL
 
 /-- `cfcHom` bundled as a continuous linear map. -/
+@[simps apply]
 noncomputable def cfcL {a : A} (ha : p a) : C(spectrum R a, R) →L[R] A :=
   { cfcHom ha with
-    map_smul' := fun c f => by
-      simp only [AlgHom.toRingHom_eq_coe, RingHom.toMonoidHom_eq_coe,
-        OneHom.toFun_eq_coe, MonoidHom.toOneHom_coe, MonoidHom.coe_coe, RingHom.coe_coe,
-        LinearMapClass.map_smul, StarAlgHom.coe_toAlgHom, RingHom.id_apply]
+    toFun := cfcHom ha
+    map_smul' := map_smul _
     cont := (cfcHom_closedEmbedding ha).continuous }
 
 end cfcL
@@ -325,11 +324,7 @@ lemma cfcHom_eq_cfc_extend {a : A} (g : R → R) (ha : p a) (f : C(spectrum R a,
 
 lemma cfc_eq_cfcL {a : A} {f : R → R} (ha : p a) (hf : ContinuousOn f (spectrum R a)) :
     cfc f a = cfcL ha ⟨_, hf.restrict⟩ := by
-  rw [cfc_def, dif_pos ⟨ha, hf⟩]
-  rfl
-
-lemma cfcHom_eq_cfcL {a : A} {f : C(spectrum R a, R)} (ha : p a) :
-    cfcHom ha f = cfcL ha f := rfl
+  rw [cfc_def, dif_pos ⟨ha, hf⟩, cfcL_apply]
 
 lemma cfc_cases (P : A → Prop) (a : A) (f : R → R) (h₀ : P 0)
     (haf : (hf : ContinuousOn f (spectrum R a)) → (ha : p a) → P (cfcHom ha ⟨_, hf.restrict⟩)) :


### PR DESCRIPTION
This PR shows that `cfc (fun r => ∫ x, f x r ∂μ) a = ∫ x, cfc (f x) a ∂μ` under appropriate conditions.

The continuity condition given here is enough for most applications (I think) and reasonably easy to apply for the integral representations this is meant for, but I would be open to suggestions.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
