### PR TITLE
[Merged by Bors] - chore: Don't simplify `Odd n` to `¬ Even n`, but the other way around

### DIFF
--- a/Archive/Wiedijk100Theorems/Konigsberg.lean
+++ b/Archive/Wiedijk100Theorems/Konigsberg.lean
@@ -73,7 +73,7 @@ lemma not_even_degree_iff (w : Verts) : ¬Even (degree w) ↔ w = V1 ∨ w = V2 
 lemma setOf_odd_degree_eq :
     {v | Odd (graph.degree v)} = {Verts.V1, Verts.V2, Verts.V3, Verts.V4} := by
   ext w
-  simp [not_even_degree_iff]
+  simp [not_even_degree_iff, ← Nat.not_even_iff_odd]
 
 /-- The Königsberg graph is not Eulerian. -/
 theorem not_isEulerian {u v : Verts} (p : graph.Walk u v) (h : p.IsEulerian) : False := by

--- a/Archive/Wiedijk100Theorems/PerfectNumbers.lean
+++ b/Archive/Wiedijk100Theorems/PerfectNumbers.lean
@@ -29,9 +29,6 @@ https://en.wikipedia.org/wiki/Euclid%E2%80%93Euler_theorem
 
 namespace Theorems100
 
-theorem odd_mersenne_succ (k : ℕ) : ¬2 ∣ mersenne (k + 1) := by
-  simp [← even_iff_two_dvd, ← Nat.even_add_one, parity_simps]
-
 namespace Nat
 
 open ArithmeticFunction Finset
@@ -43,10 +40,9 @@ theorem sigma_two_pow_eq_mersenne_succ (k : ℕ) : σ 1 (2 ^ k) = mersenne (k + 
 /-- Euclid's theorem that Mersenne primes induce perfect numbers -/
 theorem perfect_two_pow_mul_mersenne_of_prime (k : ℕ) (pr : (mersenne (k + 1)).Prime) :
     Nat.Perfect (2 ^ k * mersenne (k + 1)) := by
-  rw [Nat.perfect_iff_sum_divisors_eq_two_mul, ← mul_assoc, ← pow_succ',
-    ← sigma_one_apply, mul_comm,
-    isMultiplicative_sigma.map_mul_of_coprime
-      (Nat.prime_two.coprime_pow_of_not_dvd (odd_mersenne_succ _)),
+  rw [Nat.perfect_iff_sum_divisors_eq_two_mul, ← mul_assoc, ← pow_succ', ← sigma_one_apply,
+    mul_comm,
+    isMultiplicative_sigma.map_mul_of_coprime ((Odd.coprime_two_right (by simp)).pow_right _),
     sigma_two_pow_eq_mersenne_succ]
   · simp [pr, Nat.prime_two, sigma_one_apply]
   · positivity
@@ -81,9 +77,8 @@ theorem eq_two_pow_mul_prime_mersenne_of_even_perfect {n : ℕ} (ev : Even n) (p
   rw [Nat.perfect_iff_sum_divisors_eq_two_mul hpos, ← sigma_one_apply,
     isMultiplicative_sigma.map_mul_of_coprime (Nat.prime_two.coprime_pow_of_not_dvd hm).symm,
     sigma_two_pow_eq_mersenne_succ, ← mul_assoc, ← pow_succ'] at perf
-  rcases Nat.Coprime.dvd_of_dvd_mul_left
-      (Nat.prime_two.coprime_pow_of_not_dvd (odd_mersenne_succ _)) (Dvd.intro _ perf) with
-    ⟨j, rfl⟩
+  obtain ⟨j, rfl⟩ := ((Odd.coprime_two_right (by simp)).pow_right _).dvd_of_dvd_mul_left
+    (Dvd.intro _ perf)
   rw [← mul_assoc, mul_comm _ (mersenne _), mul_assoc] at perf
   have h := mul_left_cancel₀ (by positivity) perf
   rw [sigma_one_apply, Nat.sum_divisors_eq_sum_properDivisors_add_self, ← succ_mersenne, add_mul,

--- a/Mathlib/Algebra/BigOperators/Ring/Nat.lean
+++ b/Mathlib/Algebra/BigOperators/Ring/Nat.lean
@@ -22,11 +22,11 @@ lemma even_sum_iff_even_card_odd {s : Finset ι} (f : ι → ℕ) :
   rw [← Finset.sum_filter_add_sum_filter_not _ (fun x ↦ Even (f x)), Nat.even_add]
   simp only [Finset.mem_filter, and_imp, imp_self, implies_true, Finset.even_sum, true_iff]
   rw [Nat.even_iff, Finset.sum_nat_mod, Finset.sum_filter]
-  simp (config := { contextual := true }) only [← Nat.odd_iff_not_even, Nat.odd_iff.mp]
+  simp (config := { contextual := true }) only [Nat.not_even_iff_odd, Nat.odd_iff.mp]
   simp_rw [← Finset.sum_filter, ← Nat.even_iff, Finset.card_eq_sum_ones]
 
 lemma odd_sum_iff_odd_card_odd {s : Finset ι} (f : ι → ℕ) :
     Odd (∑ i ∈ s, f i) ↔ Odd (s.filter fun x ↦ Odd (f x)).card := by
-  simp only [Nat.odd_iff_not_even, even_sum_iff_even_card_odd]
+  simp only [← Nat.not_even_iff_odd, even_sum_iff_even_card_odd]
 
 end Finset

--- a/Mathlib/Algebra/Field/Power.lean
+++ b/Mathlib/Algebra/Field/Power.lean
@@ -22,7 +22,7 @@ section DivisionRing
 variable [DivisionRing α] {n : ℤ}
 
 theorem Odd.neg_zpow (h : Odd n) (a : α) : (-a) ^ n = -a ^ n := by
-  have hn : n ≠ 0 := by rintro rfl; exact Int.odd_iff_not_even.1 h even_zero
+  have hn : n ≠ 0 := by rintro rfl; exact Int.not_even_iff_odd.2 h even_zero
   obtain ⟨k, rfl⟩ := h
   simp_rw [zpow_add' (.inr (.inl hn)), zpow_one, zpow_mul, zpow_two, neg_mul_neg,
     neg_mul_eq_mul_neg]

--- a/Mathlib/Algebra/GeomSum.lean
+++ b/Mathlib/Algebra/GeomSum.lean
@@ -123,7 +123,7 @@ theorem neg_one_geom_sum [Ring α] {n : ℕ} :
     simp only [geom_sum_succ', Nat.even_add_one, hk]
     split_ifs with h
     · rw [h.neg_one_pow, add_zero]
-    · rw [(Nat.odd_iff_not_even.2 h).neg_one_pow, neg_add_cancel]
+    · rw [(Nat.not_even_iff_odd.1 h).neg_one_pow, neg_add_cancel]
 
 theorem geom_sum₂_self {α : Type*} [CommRing α] (x : α) (n : ℕ) :
     ∑ i ∈ range n, x ^ i * x ^ (n - 1 - i) = n * x ^ (n - 1) :=
@@ -484,7 +484,7 @@ theorem Odd.geom_sum_pos [LinearOrderedRing α] (h : Odd n) : 0 < ∑ i ∈ rang
   rcases n with (_ | _ | k)
   · exact ((show ¬Odd 0 by decide) h).elim
   · simp only [zero_add, range_one, sum_singleton, pow_zero, zero_lt_one]
-  rw [Nat.odd_iff_not_even] at h
+  rw [← Nat.not_even_iff_odd] at h
   rcases lt_trichotomy (x + 1) 0 with (hx | hx | hx)
   · have := geom_sum_alternating_of_lt_neg_one hx k.one_lt_succ_succ
     simp only [h, if_false] at this
@@ -495,7 +495,7 @@ theorem Odd.geom_sum_pos [LinearOrderedRing α] (h : Odd n) : 0 < ∑ i ∈ rang
 theorem geom_sum_pos_iff [LinearOrderedRing α] (hn : n ≠ 0) :
     (0 < ∑ i ∈ range n, x ^ i) ↔ Odd n ∨ 0 < x + 1 := by
   refine ⟨fun h => ?_, ?_⟩
-  · rw [or_iff_not_imp_left, ← not_le, ← Nat.even_iff_not_odd]
+  · rw [or_iff_not_imp_left, ← not_le, Nat.not_odd_iff_even]
     refine fun hn hx => h.not_le ?_
     simpa [if_pos hn] using geom_sum_alternating_of_le_neg_one hx n
   · rintro (hn | hx')
@@ -528,7 +528,7 @@ theorem geom_sum_eq_zero_iff_neg_one [LinearOrderedRing α] (hn : n ≠ 0) :
 theorem geom_sum_neg_iff [LinearOrderedRing α] (hn : n ≠ 0) :
     ∑ i ∈ range n, x ^ i < 0 ↔ Even n ∧ x + 1 < 0 := by
   rw [← not_iff_not, not_lt, le_iff_lt_or_eq, eq_comm,
-    or_congr (geom_sum_pos_iff hn) (geom_sum_eq_zero_iff_neg_one hn), Nat.odd_iff_not_even, ←
+    or_congr (geom_sum_pos_iff hn) (geom_sum_eq_zero_iff_neg_one hn), ← Nat.not_even_iff_odd, ←
     add_eq_zero_iff_eq_neg, not_and, not_lt, le_iff_lt_or_eq, eq_comm, ← imp_iff_not_or, or_comm,
     and_comm, Decidable.and_or_imp, or_comm]
 

--- a/Mathlib/Algebra/Order/Field/Power.lean
+++ b/Mathlib/Algebra/Order/Field/Power.lean
@@ -133,7 +133,7 @@ protected lemma Odd.zpow_nonneg_iff (hn : Odd n) : 0 ≤ a ^ n ↔ 0 ≤ a :=
 theorem Odd.zpow_nonpos_iff (hn : Odd n) : a ^ n ≤ 0 ↔ a ≤ 0 := by
   rw [le_iff_lt_or_eq, le_iff_lt_or_eq, hn.zpow_neg_iff, zpow_eq_zero_iff]
   rintro rfl
-  exact Int.odd_iff_not_even.1 hn even_zero
+  exact Int.not_even_iff_odd.2 hn even_zero
 
 lemma Odd.zpow_pos_iff (hn : Odd n) : 0 < a ^ n ↔ 0 < a := lt_iff_lt_of_le_iff_le hn.zpow_nonpos_iff
 

--- a/Mathlib/Algebra/Order/Ring/Abs.lean
+++ b/Mathlib/Algebra/Order/Ring/Abs.lean
@@ -196,7 +196,7 @@ lemma pow_eq_one_iff_cases : a ^ n = 1 ↔ n = 0 ∨ a = 1 ∨ a = -1 ∧ Even n
 lemma pow_eq_neg_pow_iff (hb : b ≠ 0) : a ^ n = -b ^ n ↔ a = -b ∧ Odd n :=
   match n.even_or_odd with
   | .inl he =>
-    suffices a ^ n > -b ^ n by simpa [he] using this.ne'
+    suffices a ^ n > -b ^ n by simpa [he, not_odd_iff_even.2 he] using this.ne'
     lt_of_lt_of_le (by simp [he.pow_pos hb]) (he.pow_nonneg _)
   | .inr ho => by
     simp only [ho, and_true, ← ho.neg_pow, (ho.strictMono_pow (R := R)).injective.eq_iff]
@@ -226,7 +226,7 @@ lemma Even.mod_even (hn : Even n) (ha : Even a) : Even (n % a) :=
   (Even.mod_even_iff ha).mpr hn
 
 lemma Odd.of_dvd_nat (hn : Odd n) (hm : m ∣ n) : Odd m :=
-  odd_iff_not_even.2 <| mt hm.even (odd_iff_not_even.1 hn)
+  not_even_iff_odd.1 <| mt hm.even (not_even_iff_odd.2 hn)
 
 /-- `2` is not a factor of an odd natural number. -/
 lemma Odd.ne_two_of_dvd_nat {m n : ℕ} (hn : Odd n) (hm : m ∣ n) : m ≠ 2 := by

--- a/Mathlib/Algebra/Order/Ring/Int.lean
+++ b/Mathlib/Algebra/Order/Ring/Int.lean
@@ -51,7 +51,7 @@ instance instOrderedRing : OrderedRing ℤ := StrictOrderedRing.toOrderedRing'
 /-! ### Miscellaneous lemmas -/
 
 lemma isCompl_even_odd : IsCompl { n : ℤ | Even n } { n | Odd n } := by
-  simp [← Set.compl_setOf, isCompl_compl]
+  simp [← not_even_iff_odd, ← Set.compl_setOf, isCompl_compl]
 
 lemma _root_.Nat.cast_natAbs {α : Type*} [AddGroupWithOne α] (n : ℤ) : (n.natAbs : α) = |n| := by
   rw [← natCast_natAbs, Int.cast_natCast]

--- a/Mathlib/Algebra/Order/Ring/Nat.lean
+++ b/Mathlib/Algebra/Order/Ring/Nat.lean
@@ -59,6 +59,6 @@ instance instOrderedCommSemiring : OrderedCommSemiring ℕ :=
 /-! ### Miscellaneous lemmas -/
 
 lemma isCompl_even_odd : IsCompl { n : ℕ | Even n } { n | Odd n } := by
-  simp only [← Set.compl_setOf, isCompl_compl, odd_iff_not_even]
+  simp only [← Set.compl_setOf, isCompl_compl, ← not_even_iff_odd]
 
 end Nat

--- a/Mathlib/Algebra/Ring/Int.lean
+++ b/Mathlib/Algebra/Ring/Int.lean
@@ -97,19 +97,24 @@ lemma odd_iff : Odd n ↔ n % 2 = 1 where
 
 lemma not_odd_iff : ¬Odd n ↔ n % 2 = 0 := by rw [odd_iff, emod_two_ne_one]
 
+@[simp] lemma not_odd_iff_even : ¬Odd n ↔ Even n := by rw [not_odd_iff, even_iff]
+@[simp] lemma not_even_iff_odd : ¬Even n ↔ Odd n := by rw [not_even_iff, odd_iff]
+
+@[deprecated not_odd_iff_even (since := "2024-08-21")]
 lemma even_iff_not_odd : Even n ↔ ¬Odd n := by rw [not_odd_iff, even_iff]
 
-@[simp] lemma odd_iff_not_even : Odd n ↔ ¬Even n := by rw [not_even_iff, odd_iff]
+@[deprecated not_even_iff_odd (since := "2024-08-21")]
+lemma odd_iff_not_even : Odd n ↔ ¬Even n := by rw [not_even_iff, odd_iff]
 
-lemma even_or_odd (n : ℤ) : Even n ∨ Odd n := Or.imp_right odd_iff_not_even.2 <| em <| Even n
+lemma even_or_odd (n : ℤ) : Even n ∨ Odd n := Or.imp_right not_even_iff_odd.1 <| em <| Even n
 
 lemma even_or_odd' (n : ℤ) : ∃ k, n = 2 * k ∨ n = 2 * k + 1 := by
   simpa only [two_mul, exists_or, Odd, Even] using even_or_odd n
 
 lemma even_xor'_odd (n : ℤ) : Xor' (Even n) (Odd n) := by
   cases even_or_odd n with
-  | inl h => exact Or.inl ⟨h, even_iff_not_odd.mp h⟩
-  | inr h => exact Or.inr ⟨h, odd_iff_not_even.mp h⟩
+  | inl h => exact Or.inl ⟨h, not_odd_iff_even.2 h⟩
+  | inr h => exact Or.inr ⟨h, not_even_iff_odd.2 h⟩
 
 lemma even_xor'_odd' (n : ℤ) : ∃ k, Xor' (n = 2 * k) (n = 2 * k + 1) := by
   rcases even_or_odd n with (⟨k, rfl⟩ | ⟨k, rfl⟩) <;> use k
@@ -118,40 +123,40 @@ lemma even_xor'_odd' (n : ℤ) : ∃ k, Xor' (n = 2 * k) (n = 2 * k + 1) := by
   · simp only [Xor', add_right_eq_self, false_or_iff, eq_self_iff_true, not_true, not_false_iff,
       one_ne_zero, and_self_iff]
 
-instance : DecidablePred (Odd : ℤ → Prop) := fun _ => decidable_of_iff _ odd_iff_not_even.symm
+instance : DecidablePred (Odd : ℤ → Prop) := fun _ => decidable_of_iff _ not_even_iff_odd
 
 lemma even_add' : Even (m + n) ↔ (Odd m ↔ Odd n) := by
-  rw [even_add, even_iff_not_odd, even_iff_not_odd, not_iff_not]
+  rw [even_add, ← not_odd_iff_even, ← not_odd_iff_even, not_iff_not]
 
 lemma not_even_two_mul_add_one (n : ℤ) : ¬ Even (2 * n + 1) :=
-  odd_iff_not_even.1 <| odd_two_mul_add_one n
+  not_even_iff_odd.2 <| odd_two_mul_add_one n
 
 lemma even_sub' : Even (m - n) ↔ (Odd m ↔ Odd n) := by
-  rw [even_sub, even_iff_not_odd, even_iff_not_odd, not_iff_not]
+  rw [even_sub, ← not_odd_iff_even, ← not_odd_iff_even, not_iff_not]
 
-lemma odd_mul : Odd (m * n) ↔ Odd m ∧ Odd n := by simp [not_or, parity_simps]
+lemma odd_mul : Odd (m * n) ↔ Odd m ∧ Odd n := by simp [← not_even_iff_odd, not_or, parity_simps]
 
 lemma Odd.of_mul_left (h : Odd (m * n)) : Odd m := (odd_mul.mp h).1
 
 lemma Odd.of_mul_right (h : Odd (m * n)) : Odd n := (odd_mul.mp h).2
 
 @[parity_simps] lemma odd_pow {n : ℕ} : Odd (m ^ n) ↔ Odd m ∨ n = 0 := by
-  rw [← not_iff_not, ← even_iff_not_odd, not_or, ← even_iff_not_odd, even_pow]
+  rw [← not_iff_not, not_odd_iff_even, not_or, not_odd_iff_even, even_pow]
 
 lemma odd_pow' {n : ℕ} (h : n ≠ 0) : Odd (m ^ n) ↔ Odd m := odd_pow.trans <| or_iff_left h
 
 @[parity_simps] lemma odd_add : Odd (m + n) ↔ (Odd m ↔ Even n) := by
-  rw [odd_iff_not_even, even_add, not_iff, odd_iff_not_even]
+  rw [← not_even_iff_odd, even_add, not_iff, ← not_even_iff_odd]
 
 lemma odd_add' : Odd (m + n) ↔ (Odd n ↔ Even m) := by rw [add_comm, odd_add]
 
-lemma ne_of_odd_add (h : Odd (m + n)) : m ≠ n := fun hnot ↦ by simp [hnot, parity_simps] at h
+lemma ne_of_odd_add (h : Odd (m + n)) : m ≠ n := by rintro rfl; simp [← not_even_iff_odd] at h
 
 @[parity_simps] lemma odd_sub : Odd (m - n) ↔ (Odd m ↔ Even n) := by
-  rw [odd_iff_not_even, even_sub, not_iff, odd_iff_not_even]
+  rw [← not_even_iff_odd, even_sub, not_iff, ← not_even_iff_odd]
 
 lemma odd_sub' : Odd (m - n) ↔ (Odd n ↔ Even m) := by
-  rw [odd_iff_not_even, even_sub, not_iff, not_iff_comm, odd_iff_not_even]
+  rw [← not_even_iff_odd, even_sub, not_iff, not_iff_comm, ← not_even_iff_odd]
 
 lemma even_mul_succ_self (n : ℤ) : Even (n * (n + 1)) := by
   simpa [even_mul, parity_simps] using n.even_or_odd
@@ -161,7 +166,7 @@ lemma even_mul_pred_self (n : ℤ) : Even (n * (n - 1)) := by
 
 -- Porting note (#10618): was simp. simp can prove this.
 @[norm_cast] lemma odd_coe_nat (n : ℕ) : Odd (n : ℤ) ↔ Odd n := by
-  rw [odd_iff_not_even, Nat.odd_iff_not_even, even_coe_nat]
+  rw [← not_even_iff_odd, ← Nat.not_even_iff_odd, even_coe_nat]
 
 @[simp] lemma natAbs_even : Even n.natAbs ↔ Even n := by
   simp [even_iff_two_dvd, dvd_natAbs, natCast_dvd.symm]
@@ -169,7 +174,7 @@ lemma even_mul_pred_self (n : ℤ) : Even (n * (n - 1)) := by
 -- Porting note (#10618): was simp. simp can prove this.
 --@[simp]
 lemma natAbs_odd : Odd n.natAbs ↔ Odd n := by
-  rw [odd_iff_not_even, Nat.odd_iff_not_even, natAbs_even]
+  rw [← not_even_iff_odd, ← Nat.not_even_iff_odd, natAbs_even]
 
 alias ⟨_, _root_.Even.natAbs⟩ := natAbs_even
 

--- a/Mathlib/Algebra/Ring/NegOnePow.lean
+++ b/Mathlib/Algebra/Ring/NegOnePow.lean
@@ -55,7 +55,7 @@ lemma negOnePow_two_mul_add_one (n : ℤ) : (2 * n + 1).negOnePow = -1 :=
 lemma negOnePow_eq_one_iff (n : ℤ) : n.negOnePow = 1 ↔ Even n := by
   constructor
   · intro h
-    rw [Int.even_iff_not_odd]
+    rw [← Int.not_odd_iff_even]
     intro h'
     simp only [negOnePow_odd _ h'] at h
     contradiction
@@ -64,7 +64,7 @@ lemma negOnePow_eq_one_iff (n : ℤ) : n.negOnePow = 1 ↔ Even n := by
 lemma negOnePow_eq_neg_one_iff (n : ℤ) : n.negOnePow = -1 ↔ Odd n := by
   constructor
   · intro h
-    rw [Int.odd_iff_not_even]
+    rw [← Int.not_even_iff_odd]
     intro h'
     rw [negOnePow_even _ h'] at h
     contradiction
@@ -92,9 +92,9 @@ lemma negOnePow_eq_iff (n₁ n₂ : ℤ) :
   by_cases h₂ : Even n₂
   · rw [negOnePow_even _ h₂, Int.even_sub, negOnePow_eq_one_iff]
     tauto
-  · rw [← Int.odd_iff_not_even] at h₂
+  · rw [Int.not_even_iff_odd] at h₂
     rw [negOnePow_odd _ h₂, Int.even_sub, negOnePow_eq_neg_one_iff,
-      Int.even_iff_not_odd, Int.even_iff_not_odd]
+      ← Int.not_odd_iff_even, ← Int.not_odd_iff_even]
     tauto
 
 @[simp]

--- a/Mathlib/Algebra/Ring/Parity.lean
+++ b/Mathlib/Algebra/Ring/Parity.lean
@@ -211,15 +211,20 @@ instance : DecidablePred (Odd : ℕ → Prop) := fun _ ↦ decidable_of_iff _ od
 
 lemma not_odd_iff : ¬Odd n ↔ n % 2 = 0 := by rw [odd_iff, mod_two_ne_one]
 
+@[simp] lemma not_odd_iff_even : ¬Odd n ↔ Even n := by rw [not_odd_iff, even_iff]
+@[simp] lemma not_even_iff_odd : ¬Even n ↔ Odd n := by rw [not_even_iff, odd_iff]
+
+@[deprecated not_odd_iff_even (since := "2024-08-21")]
 lemma even_iff_not_odd : Even n ↔ ¬Odd n := by rw [not_odd_iff, even_iff]
 
-@[simp] lemma odd_iff_not_even : Odd n ↔ ¬Even n := by rw [not_even_iff, odd_iff]
+@[deprecated not_even_iff_odd (since := "2024-08-21")]
+lemma odd_iff_not_even : Odd n ↔ ¬Even n := by rw [not_even_iff, odd_iff]
 
 lemma _root_.Odd.not_two_dvd_nat (h : Odd n) : ¬(2 ∣ n) := by
-  rwa [← even_iff_two_dvd, ← odd_iff_not_even]
+  rwa [← even_iff_two_dvd, not_even_iff_odd]
 
 lemma even_xor_odd (n : ℕ) : Xor' (Even n) (Odd n) := by
-  simp [Xor', odd_iff_not_even, Decidable.em (Even n)]
+  simp [Xor', ← not_even_iff_odd, Decidable.em (Even n)]
 
 lemma even_or_odd (n : ℕ) : Even n ∨ Odd n := (even_xor_odd n).or
 
@@ -242,16 +247,16 @@ lemma mod_two_add_add_odd_mod_two (m : ℕ) {n : ℕ} (hn : Odd n) : m % 2 + (m 
   rw [add_comm, mod_two_add_succ_mod_two]
 
 lemma even_add' : Even (m + n) ↔ (Odd m ↔ Odd n) := by
-  rw [even_add, even_iff_not_odd, even_iff_not_odd, not_iff_not]
+  rw [even_add, ← not_odd_iff_even, ← not_odd_iff_even, not_iff_not]
 
 set_option linter.deprecated false in
 @[simp] lemma not_even_bit1 (n : ℕ) : ¬Even (2 * n + 1) := by simp [parity_simps]
 
 lemma not_even_two_mul_add_one (n : ℕ) : ¬ Even (2 * n + 1) :=
-  odd_iff_not_even.1 <| odd_two_mul_add_one n
+  not_even_iff_odd.2 <| odd_two_mul_add_one n
 
 lemma even_sub' (h : n ≤ m) : Even (m - n) ↔ (Odd m ↔ Odd n) := by
-  rw [even_sub h, even_iff_not_odd, even_iff_not_odd, not_iff_not]
+  rw [even_sub h, ← not_odd_iff_even, ← not_odd_iff_even, not_iff_not]
 
 lemma Odd.sub_odd (hm : Odd m) (hn : Odd n) : Even (m - n) :=
   (le_total n m).elim (fun h ↦ by simp only [even_sub' h, *]) fun h ↦ by
@@ -259,7 +264,7 @@ lemma Odd.sub_odd (hm : Odd m) (hn : Odd n) : Even (m - n) :=
 
 alias _root_.Odd.tsub_odd := Nat.Odd.sub_odd
 
-lemma odd_mul : Odd (m * n) ↔ Odd m ∧ Odd n := by simp [not_or, even_mul]
+lemma odd_mul : Odd (m * n) ↔ Odd m ∧ Odd n := by simp [not_or, even_mul, ← not_even_iff_odd]
 
 lemma Odd.of_mul_left (h : Odd (m * n)) : Odd m :=
   (odd_mul.mp h).1
@@ -271,20 +276,20 @@ lemma even_div : Even (m / n) ↔ m % (2 * n) / n = 0 := by
   rw [even_iff_two_dvd, dvd_iff_mod_eq_zero, ← Nat.mod_mul_right_div_self, mul_comm]
 
 @[parity_simps] lemma odd_add : Odd (m + n) ↔ (Odd m ↔ Even n) := by
-  rw [odd_iff_not_even, even_add, not_iff, odd_iff_not_even]
+  rw [← not_even_iff_odd, even_add, not_iff, ← not_even_iff_odd]
 
 lemma odd_add' : Odd (m + n) ↔ (Odd n ↔ Even m) := by rw [add_comm, odd_add]
 
-lemma ne_of_odd_add (h : Odd (m + n)) : m ≠ n := fun hnot ↦ by simp [hnot] at h
+lemma ne_of_odd_add (h : Odd (m + n)) : m ≠ n := by rintro rfl; simp [← not_even_iff_odd] at h
 
 @[parity_simps] lemma odd_sub (h : n ≤ m) : Odd (m - n) ↔ (Odd m ↔ Even n) := by
-  rw [odd_iff_not_even, even_sub h, not_iff, odd_iff_not_even]
+  rw [← not_even_iff_odd, even_sub h, not_iff, ← not_even_iff_odd]
 
 lemma Odd.sub_even (h : n ≤ m) (hm : Odd m) (hn : Even n) : Odd (m - n) :=
   (odd_sub h).mpr <| iff_of_true hm hn
 
 lemma odd_sub' (h : n ≤ m) : Odd (m - n) ↔ (Odd n ↔ Even m) := by
-  rw [odd_iff_not_even, even_sub h, not_iff, not_iff_comm, odd_iff_not_even]
+  rw [← not_even_iff_odd, even_sub h, not_iff, not_iff_comm, ← not_even_iff_odd]
 
 lemma Even.sub_odd (h : n ≤ m) (hm : Even m) (hn : Odd n) : Odd (m - n) :=
   (odd_sub' h).mpr <| iff_of_true hn hm
@@ -342,16 +347,16 @@ lemma iterate_odd (hf : Involutive f) (hn : Odd n) : f^[n] = f := by
   rw [iterate_add, hf.iterate_two_mul, id_comp, iterate_one]
 
 lemma iterate_eq_self (hf : Involutive f) (hne : f ≠ id) : f^[n] = f ↔ Odd n :=
-  ⟨fun H ↦ odd_iff_not_even.2 fun hn ↦ hne <| by rwa [hf.iterate_even hn, eq_comm] at H,
+  ⟨fun H ↦ not_even_iff_odd.1 fun hn ↦ hne <| by rwa [hf.iterate_even hn, eq_comm] at H,
     hf.iterate_odd⟩
 
 lemma iterate_eq_id (hf : Involutive f) (hne : f ≠ id) : f^[n] = id ↔ Even n :=
-  ⟨fun H ↦ even_iff_not_odd.2 fun hn ↦ hne <| by rwa [hf.iterate_odd hn] at H, hf.iterate_even⟩
+  ⟨fun H ↦ not_odd_iff_even.1 fun hn ↦ hne <| by rwa [hf.iterate_odd hn] at H, hf.iterate_even⟩
 
 end Involutive
 end Function
 
 lemma neg_one_pow_eq_one_iff_even {R : Type*} [Monoid R] [HasDistribNeg R] {n : ℕ}
     (h : (-1 : R) ≠ 1) : (-1 : R) ^ n = 1 ↔ Even n where
-  mp h' := of_not_not fun hn ↦ h <| (Odd.neg_one_pow <| odd_iff_not_even.mpr hn).symm.trans h'
+  mp h' := of_not_not fun hn ↦ h <| (not_even_iff_odd.1 hn).neg_one_pow.symm.trans h'
   mpr := Even.neg_one_pow

--- a/Mathlib/Analysis/SpecialFunctions/Complex/LogBounds.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Complex/LogBounds.lean
@@ -60,7 +60,7 @@ def logTaylor (n : ℕ) : ℂ → ℂ := fun z ↦ ∑ j ∈ Finset.range n, (-1
 
 lemma logTaylor_zero : logTaylor 0 = fun _ ↦ 0 := by
   funext
-  simp only [logTaylor, Finset.range_zero, Nat.odd_iff_not_even, Int.cast_pow, Int.cast_neg,
+  simp only [logTaylor, Finset.range_zero, ← Nat.not_even_iff_odd, Int.cast_pow, Int.cast_neg,
     Int.cast_one, Finset.sum_empty]
 
 lemma logTaylor_succ (n : ℕ) :
@@ -79,10 +79,10 @@ lemma hasDerivAt_logTaylor (n : ℕ) (z : ℂ) :
   | zero => simp [logTaylor_succ, logTaylor_zero, Pi.add_def, hasDerivAt_const]
   | succ n ih =>
     rw [logTaylor_succ]
-    simp only [cpow_natCast, Nat.cast_add, Nat.cast_one, Nat.odd_iff_not_even,
+    simp only [cpow_natCast, Nat.cast_add, Nat.cast_one, ← Nat.not_even_iff_odd,
       Finset.sum_range_succ, (show (-1) ^ (n + 1 + 1) = (-1) ^ n by ring)]
     refine HasDerivAt.add ih ?_
-    simp only [Nat.odd_iff_not_even, Int.cast_pow, Int.cast_neg, Int.cast_one, mul_div_assoc]
+    simp only [← Nat.not_even_iff_odd, Int.cast_pow, Int.cast_neg, Int.cast_one, mul_div_assoc]
     have : HasDerivAt (fun x : ℂ ↦ (x ^ (n + 1) / (n + 1))) (z ^ n) z := by
       simp_rw [div_eq_mul_inv]
       convert HasDerivAt.mul_const (hasDerivAt_pow (n + 1) z) (((n : ℂ) + 1)⁻¹) using 1

--- a/Mathlib/Combinatorics/SimpleGraph/ConcreteColorings.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/ConcreteColorings.lean
@@ -62,7 +62,7 @@ theorem Coloring.even_length_iff_congr {α} {G : SimpleGraph α}
 theorem Coloring.odd_length_iff_not_congr {α} {G : SimpleGraph α}
     (c : G.Coloring Bool) {u v : α} (p : G.Walk u v) :
     Odd p.length ↔ (¬c u ↔ c v) := by
-  rw [Nat.odd_iff_not_even, c.even_length_iff_congr p]
+  rw [← Nat.not_even_iff_odd, c.even_length_iff_congr p]
   tauto
 
 theorem Walk.three_le_chromaticNumber_of_odd_loop {α} {G : SimpleGraph α} {u : α} (p : G.Walk u u)

--- a/Mathlib/Combinatorics/SimpleGraph/DegreeSum.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/DegreeSum.lean
@@ -122,7 +122,7 @@ theorem even_card_odd_degree_vertices [Fintype V] [DecidableRel G.Adj] :
       exact ZMod.ne_zero_iff_odd.symm
     · intro v
       simp only [true_and_iff, mem_filter, mem_univ, Ne]
-      rw [ZMod.eq_zero_iff_even, ZMod.eq_one_iff_odd, Nat.odd_iff_not_even, imp_self]
+      rw [ZMod.eq_zero_iff_even, ZMod.eq_one_iff_odd, ← Nat.not_even_iff_odd, imp_self]
       trivial
 
 theorem odd_card_odd_degree_vertices_ne [Fintype V] [DecidableEq V] [DecidableRel G.Adj] (v : V)

--- a/Mathlib/Combinatorics/SimpleGraph/Matching.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Matching.lean
@@ -217,7 +217,7 @@ lemma odd_matches_node_outside {u : Set V} {c : ConnectedComponent (Subgraph.del
       and_true] at hv' ⊢
     trivial
 
-  apply Nat.odd_iff_not_even.mp codd
+  apply Nat.not_even_iff_odd.2 codd
   haveI : Fintype ↑(Subgraph.induce M (Subtype.val '' supp c)).verts := Fintype.ofFinite _
   classical
   have hMeven := Subgraph.IsMatching.even_card hMmatch

--- a/Mathlib/Combinatorics/SimpleGraph/Trails.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Trails.lean
@@ -135,7 +135,7 @@ theorem IsEulerian.card_filter_odd_degree [Fintype V] [DecidableRel G.Adj] {u v 
     (h : s = (Finset.univ : Finset V).filter fun v => Odd (G.degree v)) :
     s.card = 0 ∨ s.card = 2 := by
   subst s
-  simp only [Nat.odd_iff_not_even, Finset.card_eq_zero]
+  simp only [← Nat.not_even_iff_odd, Finset.card_eq_zero]
   simp only [ht.even_degree_iff, Ne, not_forall, not_and, Classical.not_not, exists_prop]
   obtain rfl | hn := eq_or_ne u v
   · left

--- a/Mathlib/Data/Nat/Factorization/Basic.lean
+++ b/Mathlib/Data/Nat/Factorization/Basic.lean
@@ -244,7 +244,7 @@ two `2 ^ k`. -/
 theorem exists_eq_two_pow_mul_odd {n : ℕ} (hn : n ≠ 0) :
     ∃ k m : ℕ, Odd m ∧ n = 2 ^ k * m :=
   let ⟨k, m, hm, hn⟩ := exists_eq_pow_mul_and_not_dvd hn 2 (succ_ne_self 1)
-  ⟨k, m, odd_iff_not_even.mpr (mt Even.two_dvd hm), hn⟩
+  ⟨k, m, not_even_iff_odd.1 (mt Even.two_dvd hm), hn⟩
 
 theorem dvd_iff_div_factorization_eq_tsub {d n : ℕ} (hd : d ≠ 0) (hdn : d ≤ n) :
     d ∣ n ↔ (n / d).factorization = n.factorization - d.factorization := by

--- a/Mathlib/Data/Nat/Prime/Basic.lean
+++ b/Mathlib/Data/Nat/Prime/Basic.lean
@@ -132,7 +132,7 @@ theorem Prime.not_dvd_mul {p m n : ℕ} (pp : Prime p) (Hm : ¬p ∣ m) (Hn : ¬
   mt pp.dvd_mul.1 <| by simp [Hm, Hn]
 
 @[simp] lemma coprime_two_left : Coprime 2 n ↔ Odd n := by
-  rw [prime_two.coprime_iff_not_dvd, odd_iff_not_even, even_iff_two_dvd]
+  rw [prime_two.coprime_iff_not_dvd, ← not_even_iff_odd, even_iff_two_dvd]
 
 @[simp] lemma coprime_two_right : n.Coprime 2 ↔ Odd n := coprime_comm.trans coprime_two_left
 

--- a/Mathlib/FieldTheory/KummerExtension.lean
+++ b/Mathlib/FieldTheory/KummerExtension.lean
@@ -197,7 +197,7 @@ theorem X_pow_sub_C_irreducible_of_odd
     {n : ℕ} (hn : Odd n) {a : K} (ha : ∀ p : ℕ, p.Prime → p ∣ n → ∀ b : K, b ^ p ≠ a) :
     Irreducible (X ^ n - C a) := by
   induction n using induction_on_primes generalizing K a with
-  | h₀ => simp at hn
+  | h₀ => simp [← Nat.not_even_iff_odd] at hn
   | h₁ => simpa using irreducible_X_sub_C a
   | h p n hp IH =>
     rw [mul_comm]

--- a/Mathlib/GroupTheory/CommutingProbability.lean
+++ b/Mathlib/GroupTheory/CommutingProbability.lean
@@ -166,7 +166,7 @@ lemma reciprocalFactors_odd {n : ℕ} (h1 : n ≠ 1) (h2 : Odd n) :
   have h0 : n ≠ 0 := by
     rintro rfl
     norm_num at h2
-  rw [reciprocalFactors, dif_neg h0, dif_neg h1, if_neg (Nat.odd_iff_not_even.mp h2)]
+  rw [reciprocalFactors, dif_neg h0, dif_neg h1, if_neg (Nat.not_even_iff_odd.2 h2)]
 
 /-- A finite product of Dihedral groups. -/
 abbrev Product (l : List ℕ) : Type :=

--- a/Mathlib/GroupTheory/CommutingProbability.lean
+++ b/Mathlib/GroupTheory/CommutingProbability.lean
@@ -165,7 +165,7 @@ lemma reciprocalFactors_odd {n : ℕ} (h1 : n ≠ 1) (h2 : Odd n) :
     reciprocalFactors n = n % 4 * n :: reciprocalFactors (n / 4 + 1) := by
   have h0 : n ≠ 0 := by
     rintro rfl
-    norm_num at h2
+    norm_num [← Nat.not_even_iff_odd] at h2
   rw [reciprocalFactors, dif_neg h0, dif_neg h1, if_neg (Nat.not_even_iff_odd.2 h2)]
 
 /-- A finite product of Dihedral groups. -/

--- a/Mathlib/GroupTheory/Coxeter/Basic.lean
+++ b/Mathlib/GroupTheory/Coxeter/Basic.lean
@@ -437,10 +437,10 @@ theorem prod_alternatingWord_eq_prod_alternatingWord_sub (i i' : B) (m : ℕ) (h
     repeat rw [Int.mul_ediv_cancel _ (by norm_num)]
     rw [zpow_sub, zpow_natCast, simple_mul_simple_pow' cs i i', ← inv_zpow]
     simp
-  · have : ¬Even (2 * k + 1) := Int.odd_iff_not_even.mp ⟨k, rfl⟩
+  · have : ¬Even (2 * k + 1) := Int.not_even_iff_odd.2 ⟨k, rfl⟩
     rw [if_neg this]
     have : ¬Even (↑(M i i') * 2 - (2 * k + 1)) :=
-      Int.odd_iff_not_even.mp ⟨↑(M i i') - k - 1, by ring⟩
+      Int.not_even_iff_odd.2 ⟨↑(M i i') - k - 1, by ring⟩
     rw [if_neg this]
 
     rw [(by ring : ↑(M i i') * 2 - (2 * k + 1) = -1 + (-k + ↑(M i i')) * 2),

--- a/Mathlib/GroupTheory/Coxeter/Basic.lean
+++ b/Mathlib/GroupTheory/Coxeter/Basic.lean
@@ -399,7 +399,7 @@ theorem alternatingWord_succ' (i i' : B) (m : ℕ) :
   · rw [alternatingWord]
     nth_rw 1 [ih i' i]
     rw [alternatingWord]
-    simp [Nat.even_add_one]
+    simp [Nat.even_add_one, ← Nat.not_even_iff_odd]
 
 @[simp]
 theorem length_alternatingWord (i i' : B) (m : ℕ) :

--- a/Mathlib/GroupTheory/FixedPointFree.lean
+++ b/Mathlib/GroupTheory/FixedPointFree.lean
@@ -84,7 +84,7 @@ theorem odd_card_of_involutive (hφ : FixedPointFree φ) (h2 : Function.Involuti
     Odd (Nat.card G) := by
   have := Fintype.ofFinite G
   by_contra h
-  rw [← Nat.even_iff_not_odd, even_iff_two_dvd, Nat.card_eq_fintype_card] at h
+  rw [Nat.not_odd_iff_even, even_iff_two_dvd, Nat.card_eq_fintype_card] at h
   obtain ⟨g, hg⟩ := exists_prime_orderOf_dvd_card 2 h
   exact hφ.orderOf_ne_two_of_involutive h2 g hg
 

--- a/Mathlib/LinearAlgebra/Matrix/Determinant/Basic.lean
+++ b/Mathlib/LinearAlgebra/Matrix/Determinant/Basic.lean
@@ -760,7 +760,7 @@ theorem det_fin_three (A : Matrix (Fin 3) (Fin 3) R) :
       A 0 0 * A 1 1 * A 2 2 - A 0 0 * A 1 2 * A 2 1
       - A 0 1 * A 1 0 * A 2 2 + A 0 1 * A 1 2 * A 2 0
       + A 0 2 * A 1 0 * A 2 1 - A 0 2 * A 1 1 * A 2 0 := by
-  simp only [det_succ_row_zero, Nat.odd_iff_not_even, submatrix_apply, Fin.succ_zero_eq_one,
+  simp only [det_succ_row_zero, ← Nat.not_even_iff_odd, submatrix_apply, Fin.succ_zero_eq_one,
     submatrix_submatrix, det_unique, Fin.default_eq_zero, comp_apply, Fin.succ_one_eq_two,
     Fin.sum_univ_succ, Fin.val_zero, Fin.zero_succAbove, univ_unique, Fin.val_succ,
     Fin.coe_fin_one, Fin.succ_succAbove_zero, sum_singleton, Fin.succ_succAbove_one, even_add_self]

--- a/Mathlib/NumberTheory/Cyclotomic/Discriminant.lean
+++ b/Mathlib/NumberTheory/Cyclotomic/Discriminant.lean
@@ -189,7 +189,7 @@ theorem discr_prime_pow_eq_unit_mul_pow [IsCyclotomicExtension {p ^ k} K L]
   by_cases heven : Even ((p ^ k : ℕ).totient / 2)
   · exact ⟨1, (p : ℕ) ^ (k - 1) * ((p - 1) * k - 1), by rw [heven.neg_one_pow]; norm_num⟩
   · exact ⟨-1, (p : ℕ) ^ (k - 1) * ((p - 1) * k - 1), by
-      rw [(odd_iff_not_even.2 heven).neg_one_pow]; norm_num⟩
+      rw [(not_even_iff_odd.1 heven).neg_one_pow]; norm_num⟩
 
 /-- If `p` is an odd prime and `IsCyclotomicExtension {p} K L`, then
 `discr K (hζ.powerBasis K).basis = (-1) ^ ((p - 1) / 2) * p ^ (p - 2)` if

--- a/Mathlib/NumberTheory/Cyclotomic/PrimitiveRoots.lean
+++ b/Mathlib/NumberTheory/Cyclotomic/PrimitiveRoots.lean
@@ -243,7 +243,7 @@ theorem exists_neg_pow_of_isOfFinOrder [IsCyclotomicExtension {n} ℚ K]
     convert IsPrimitiveRoot.orderOf (-ζ)
     rw [neg_eq_neg_one_mul, (Commute.all _ _).orderOf_mul_eq_mul_orderOf_of_coprime]
     · simp [hζ.eq_orderOf]
-    · simp [← hζ.eq_orderOf, Nat.not_even_iff_odd.2 hno]
+    · simp [← hζ.eq_orderOf, hno]
   obtain ⟨k, hkpos, hkn⟩ := isOfFinOrder_iff_pow_eq_one.1 hx
   obtain ⟨l, hl, hlroot⟩ := (isRoot_of_unity_iff hkpos _).1 hkn
   have hlzero : NeZero l := ⟨fun h ↦ by simp [h] at hl⟩

--- a/Mathlib/NumberTheory/Cyclotomic/PrimitiveRoots.lean
+++ b/Mathlib/NumberTheory/Cyclotomic/PrimitiveRoots.lean
@@ -243,7 +243,7 @@ theorem exists_neg_pow_of_isOfFinOrder [IsCyclotomicExtension {n} ℚ K]
     convert IsPrimitiveRoot.orderOf (-ζ)
     rw [neg_eq_neg_one_mul, (Commute.all _ _).orderOf_mul_eq_mul_orderOf_of_coprime]
     · simp [hζ.eq_orderOf]
-    · simp [← hζ.eq_orderOf, Nat.odd_iff_not_even.1 hno]
+    · simp [← hζ.eq_orderOf, Nat.not_even_iff_odd.2 hno]
   obtain ⟨k, hkpos, hkn⟩ := isOfFinOrder_iff_pow_eq_one.1 hx
   obtain ⟨l, hl, hlroot⟩ := (isRoot_of_unity_iff hkpos _).1 hkn
   have hlzero : NeZero l := ⟨fun h ↦ by simp [h] at hl⟩

--- a/Mathlib/NumberTheory/EllipticDivisibilitySequence.lean
+++ b/Mathlib/NumberTheory/EllipticDivisibilitySequence.lean
@@ -119,7 +119,7 @@ def preNormEDS' (b c d : R) : ℕ → R
         preNormEDS' b c d (m + 1) * preNormEDS' b c d (m + 3) ^ 3 * (if Even m then 1 else b)
     else
       have h5 : m + 5 < n + 5 := add_lt_add_right
-        (Nat.div_lt_self (Nat.odd_iff_not_even.mpr hn).pos <| Nat.lt_succ_self 1) 5
+        (Nat.div_lt_self (Nat.not_even_iff_odd.1 hn).pos <| Nat.lt_succ_self 1) 5
       preNormEDS' b c d (m + 2) ^ 2 * preNormEDS' b c d (m + 3) * preNormEDS' b c d (m + 5) -
         preNormEDS' b c d (m + 1) * preNormEDS' b c d (m + 3) * preNormEDS' b c d (m + 4) ^ 2
 

--- a/Mathlib/NumberTheory/LucasLehmer.lean
+++ b/Mathlib/NumberTheory/LucasLehmer.lean
@@ -59,6 +59,12 @@ theorem mersenne_le_mersenne {p q : ℕ} : mersenne p ≤ mersenne q ↔ p ≤ q
 
 @[simp] theorem mersenne_zero : mersenne 0 = 0 := rfl
 
+@[simp] lemma mersenne_odd : ∀ {p : ℕ}, Odd (mersenne p) ↔ p ≠ 0
+  | 0 => by simp
+  | p + 1 => by
+    simpa using Nat.Even.sub_odd (one_le_pow_of_one_le one_le_two _)
+      (even_two.pow_of_ne_zero p.succ_ne_zero) odd_one
+
 @[simp] theorem mersenne_pos {p : ℕ} : 0 < mersenne p ↔ 0 < p := mersenne_lt_mersenne (p := 0)
 
 namespace Mathlib.Meta.Positivity

--- a/Mathlib/NumberTheory/Multiplicity.lean
+++ b/Mathlib/NumberTheory/Multiplicity.lean
@@ -257,7 +257,7 @@ theorem Int.sq_mod_four_eq_one_of_odd {x : ℤ} : Odd x → x ^ 2 % 4 = 1 := by
 
 theorem Int.two_pow_two_pow_add_two_pow_two_pow {x y : ℤ} (hx : ¬2 ∣ x) (hxy : 4 ∣ x - y) (i : ℕ) :
     multiplicity 2 (x ^ 2 ^ i + y ^ 2 ^ i) = ↑(1 : ℕ) := by
-  have hx_odd : Odd x := by rwa [Int.odd_iff_not_even, even_iff_two_dvd]
+  have hx_odd : Odd x := by rwa [← Int.not_even_iff_odd, even_iff_two_dvd]
   have hxy_even : Even (x - y) := even_iff_two_dvd.mpr (dvd_trans (by decide) hxy)
   have hy_odd : Odd y := by simpa using hx_odd.sub_even hxy_even
   refine multiplicity.eq_coe_iff.mpr ⟨?_, ?_⟩
@@ -287,7 +287,7 @@ theorem Int.two_pow_two_pow_sub_pow_two_pow {x y : ℤ} (n : ℕ) (hxy : 4 ∣ x
 
 theorem Int.two_pow_sub_pow' {x y : ℤ} (n : ℕ) (hxy : 4 ∣ x - y) (hx : ¬2 ∣ x) :
     multiplicity 2 (x ^ n - y ^ n) = multiplicity 2 (x - y) + multiplicity (2 : ℤ) n := by
-  have hx_odd : Odd x := by rwa [Int.odd_iff_not_even, even_iff_two_dvd]
+  have hx_odd : Odd x := by rwa [← Int.not_even_iff_odd, even_iff_two_dvd]
   have hxy_even : Even (x - y) := even_iff_two_dvd.mpr (dvd_trans (by decide) hxy)
   have hy_odd : Odd y := by simpa using hx_odd.sub_even hxy_even
   cases' n with n
@@ -300,7 +300,7 @@ theorem Int.two_pow_sub_pow' {x y : ℤ} (n : ℕ) (hxy : 4 ∣ x - y) (hx : ¬2
   · norm_cast
   · exact Int.prime_two
   · simpa only [even_iff_two_dvd] using hx_odd.pow.sub_odd hy_odd.pow
-  · simpa only [even_iff_two_dvd, Int.odd_iff_not_even] using hx_odd.pow
+  · simpa only [even_iff_two_dvd, ← Int.not_even_iff_odd] using hx_odd.pow
   erw [Int.natCast_dvd_natCast]
   -- `erw` to deal with `2 : ℤ` vs `(2 : ℕ) : ℤ`
   contrapose! hpn
@@ -313,7 +313,7 @@ theorem Int.two_pow_sub_pow {x y : ℤ} {n : ℕ} (hxy : 2 ∣ x - y) (hx : ¬2 
     multiplicity 2 (x ^ n - y ^ n) + 1 =
       multiplicity 2 (x + y) + multiplicity 2 (x - y) + multiplicity (2 : ℤ) n := by
   have hy : Odd y := by
-    rw [← even_iff_two_dvd, ← Int.odd_iff_not_even] at hx
+    rw [← even_iff_two_dvd, Int.not_even_iff_odd] at hx
     replace hxy := (@even_neg _ _ (x - y)).mpr (even_iff_two_dvd.mpr hxy)
     convert Even.add_odd hxy hx
     abel
@@ -324,7 +324,7 @@ theorem Int.two_pow_sub_pow {x y : ℤ} {n : ℕ} (hxy : 2 ∣ x - y) (hx : ¬2 
     rw [Int.dvd_iff_emod_eq_zero, Int.sub_emod, Int.sq_mod_four_eq_one_of_odd _,
       Int.sq_mod_four_eq_one_of_odd hy]
     · norm_num
-    · simp only [Int.odd_iff_not_even, even_iff_two_dvd, hx, not_false_iff]
+    · simp only [← Int.not_even_iff_odd, even_iff_two_dvd, hx, not_false_iff]
   rw [Int.two_pow_sub_pow' d hxy4 _, sq_sub_sq, ← Int.ofNat_mul_out, multiplicity.mul Int.prime_two,
     multiplicity.mul Int.prime_two]
   · suffices multiplicity (2 : ℤ) ↑(2 : ℕ) = 1 by rw [this, add_comm (1 : PartENat), ← add_assoc]
@@ -333,9 +333,9 @@ theorem Int.two_pow_sub_pow {x y : ℤ} {n : ℕ} (hxy : 2 ∣ x - y) (hx : ¬2 
     · apply Prime.not_unit
       simp only [← Nat.prime_iff, Nat.prime_two]
     · exact two_ne_zero
-  · rw [← even_iff_two_dvd, ← Int.odd_iff_not_even]
+  · rw [← even_iff_two_dvd, Int.not_even_iff_odd]
     apply Odd.pow
-    simp only [Int.odd_iff_not_even, even_iff_two_dvd, hx, not_false_iff]
+    simp only [← Int.not_even_iff_odd, even_iff_two_dvd, hx, not_false_iff]
 
 theorem Nat.two_pow_sub_pow {x y : ℕ} (hxy : 2 ∣ x - y) (hx : ¬2 ∣ x) {n : ℕ} (hn : Even n) :
     multiplicity 2 (x ^ n - y ^ n) + 1 =

--- a/Mathlib/NumberTheory/NumberField/Embeddings.lean
+++ b/Mathlib/NumberTheory/NumberField/Embeddings.lean
@@ -1021,11 +1021,11 @@ variable {K}
 
 lemma IsUnramifiedAtInfinitePlaces_of_odd_card_aut [IsGalois k K] [FiniteDimensional k K]
     (h : Odd (Fintype.card <| K ≃ₐ[k] K)) : IsUnramifiedAtInfinitePlaces k K :=
-  ⟨fun _ ↦ not_not.mp (Nat.odd_iff_not_even.mp h ∘ InfinitePlace.even_card_aut_of_not_isUnramified)⟩
+  ⟨fun _ ↦ not_not.mp (Nat.not_even_iff_odd.2 h ∘ InfinitePlace.even_card_aut_of_not_isUnramified)⟩
 
 lemma IsUnramifiedAtInfinitePlaces_of_odd_finrank [IsGalois k K]
     (h : Odd (FiniteDimensional.finrank k K)) : IsUnramifiedAtInfinitePlaces k K :=
-  ⟨fun _ ↦ not_not.mp (Nat.odd_iff_not_even.mp h ∘ InfinitePlace.even_finrank_of_not_isUnramified)⟩
+  ⟨fun _ ↦ not_not.mp (Nat.not_even_iff_odd.2 h ∘ InfinitePlace.even_finrank_of_not_isUnramified)⟩
 
 variable (k K)
 

--- a/Mathlib/NumberTheory/Primorial.lean
+++ b/Mathlib/NumberTheory/Primorial.lean
@@ -41,7 +41,7 @@ theorem primorial_pos (n : ℕ) : 0 < n# :=
 
 theorem primorial_succ {n : ℕ} (hn1 : n ≠ 1) (hn : Odd n) : (n + 1)# = n# := by
   refine prod_congr ?_ fun _ _ ↦ rfl
-  rw [range_succ, filter_insert, if_neg fun h ↦ odd_iff_not_even.mp hn _]
+  rw [range_succ, filter_insert, if_neg fun h ↦ not_even_iff_odd.2 hn _]
   exact fun h ↦ h.even_sub_one <| mt succ.inj hn1
 
 theorem primorial_add (m n : ℕ) :

--- a/Mathlib/NumberTheory/SumTwoSquares.lean
+++ b/Mathlib/NumberTheory/SumTwoSquares.lean
@@ -216,7 +216,7 @@ theorem Nat.eq_sq_add_sq_iff {n : ℕ} :
     exact even_two_mul _
   · obtain ⟨b, a, hb₀, ha₀, hab, hb⟩ := Nat.sq_mul_squarefree_of_pos hn₀
     refine ⟨a, b, hab.symm, (ZMod.isSquare_neg_one_iff hb).mpr fun {q} hqp hqb hq4 => ?_⟩
-    refine Nat.odd_iff_not_even.mp ?_ (H hqp hq4)
+    refine Nat.not_even_iff_odd.2 ?_ (H hqp hq4)
     have hqb' : padicValNat q b = 1 :=
       b.factorization_def hqp ▸ le_antisymm (hb.natFactorization_le_one _)
         ((hqp.dvd_iff_one_le_factorization hb₀.ne').mp hqb)

--- a/Mathlib/RingTheory/Polynomial/Cyclotomic/Eval.lean
+++ b/Mathlib/RingTheory/Polynomial/Cyclotomic/Eval.lean
@@ -80,7 +80,7 @@ theorem cyclotomic_pos {n : ℕ} (hn : 2 < n) {R} [LinearOrderedCommRing R] (x :
     cases' h with hk hx
     · refine (ih _ hi.2.2 (Nat.two_lt_of_ne ?_ hi.1 ?_)).le <;> rintro rfl
       · exact hn'.ne' (zero_dvd_iff.mp hi.2.1)
-      · exact even_iff_not_odd.mp (even_iff_two_dvd.mpr hi.2.1) hk
+      · exact not_odd_iff_even.2 (even_iff_two_dvd.mpr hi.2.1) hk
     · rcases eq_or_ne i 2 with (rfl | hk)
       · simpa only [eval_X, eval_one, cyclotomic_two, eval_add] using hx.le
       refine (ih _ hi.2.2 (Nat.two_lt_of_ne ?_ hi.1 hk)).le

--- a/Mathlib/RingTheory/Polynomial/Hermite/Basic.lean
+++ b/Mathlib/RingTheory/Polynomial/Hermite/Basic.lean
@@ -197,7 +197,7 @@ theorem coeff_hermite (n k : ℕ) :
       if Even (n + k) then (-1 : ℤ) ^ ((n - k) / 2) * (n - k - 1)‼ * Nat.choose n k else 0 := by
   split_ifs with h
   · exact coeff_hermite_of_even_add h
-  · exact coeff_hermite_of_odd_add (Nat.odd_iff_not_even.mpr h)
+  · exact coeff_hermite_of_odd_add (Nat.not_even_iff_odd.1 h)
 
 end CoeffExplicit
 


### PR DESCRIPTION
This is simply not simpler

From LeanAPAP

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
