### PR TITLE
[Merged by Bors] - chore(CI): skip full `cache get` if cache looks completely cold

### DIFF
--- a/.github/workflows/bors.yml
+++ b/.github/workflows/bors.yml
@@ -163,9 +163,9 @@ jobs:
         id: get
         run: |
           lake exe cache clean
-          # Fail quickly if the cache is completely cold, by checking for Batteries.WF
-          lake exe cache get Batteries.WF
-          ! test -e ./.lake/packages/batteries/.lake/build/lib/Batteries/WF.olean || lake exe cache get
+          # Fail quickly if the cache is completely cold, by checking for Mathlib.Init
+          lake exe cache get Mathlib.Init
+          ! test -e .lake/build/lib/Mathlib/Init.olean || lake exe cache get
 
       - name: build mathlib
         id: build

--- a/.github/workflows/bors.yml
+++ b/.github/workflows/bors.yml
@@ -163,7 +163,9 @@ jobs:
         id: get
         run: |
           lake exe cache clean
-          lake exe cache get
+          # Fail quickly if the cache is completely cold, by checking for Batteries.WF
+          lake exe cache get Batteries.WF
+          ! test -e ./.lake/packages/batteries/.lake/build/lib/Batteries/WF.olean || lake exe cache get
 
       - name: build mathlib
         id: build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -170,7 +170,9 @@ jobs:
         id: get
         run: |
           lake exe cache clean
-          lake exe cache get
+          # Fail quickly if the cache is completely cold, by checking for Batteries.WF
+          lake exe cache get Batteries.WF
+          ! test -e ./.lake/packages/batteries/.lake/build/lib/Batteries/WF.olean || lake exe cache get
 
       - name: build mathlib
         id: build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -170,9 +170,9 @@ jobs:
         id: get
         run: |
           lake exe cache clean
-          # Fail quickly if the cache is completely cold, by checking for Batteries.WF
-          lake exe cache get Batteries.WF
-          ! test -e ./.lake/packages/batteries/.lake/build/lib/Batteries/WF.olean || lake exe cache get
+          # Fail quickly if the cache is completely cold, by checking for Mathlib.Init
+          lake exe cache get Mathlib.Init
+          ! test -e .lake/build/lib/Mathlib/Init.olean || lake exe cache get
 
       - name: build mathlib
         id: build

--- a/.github/workflows/build.yml.in
+++ b/.github/workflows/build.yml.in
@@ -149,7 +149,9 @@ jobs:
         id: get
         run: |
           lake exe cache clean
-          lake exe cache get
+          # Fail quickly if the cache is completely cold, by checking for Batteries.WF
+          lake exe cache get Batteries.WF
+          ! test -e ./.lake/packages/batteries/.lake/build/lib/Batteries/WF.olean || lake exe cache get
 
       - name: build mathlib
         id: build

--- a/.github/workflows/build.yml.in
+++ b/.github/workflows/build.yml.in
@@ -149,9 +149,9 @@ jobs:
         id: get
         run: |
           lake exe cache clean
-          # Fail quickly if the cache is completely cold, by checking for Batteries.WF
-          lake exe cache get Batteries.WF
-          ! test -e ./.lake/packages/batteries/.lake/build/lib/Batteries/WF.olean || lake exe cache get
+          # Fail quickly if the cache is completely cold, by checking for Mathlib.Init
+          lake exe cache get Mathlib.Init
+          ! test -e .lake/build/lib/Mathlib/Init.olean || lake exe cache get
 
       - name: build mathlib
         id: build

--- a/.github/workflows/build_fork.yml
+++ b/.github/workflows/build_fork.yml
@@ -167,7 +167,9 @@ jobs:
         id: get
         run: |
           lake exe cache clean
-          lake exe cache get
+          # Fail quickly if the cache is completely cold, by checking for Batteries.WF
+          lake exe cache get Batteries.WF
+          ! test -e ./.lake/packages/batteries/.lake/build/lib/Batteries/WF.olean || lake exe cache get
 
       - name: build mathlib
         id: build

--- a/.github/workflows/build_fork.yml
+++ b/.github/workflows/build_fork.yml
@@ -167,9 +167,9 @@ jobs:
         id: get
         run: |
           lake exe cache clean
-          # Fail quickly if the cache is completely cold, by checking for Batteries.WF
-          lake exe cache get Batteries.WF
-          ! test -e ./.lake/packages/batteries/.lake/build/lib/Batteries/WF.olean || lake exe cache get
+          # Fail quickly if the cache is completely cold, by checking for Mathlib.Init
+          lake exe cache get Mathlib.Init
+          ! test -e .lake/build/lib/Mathlib/Init.olean || lake exe cache get
 
       - name: build mathlib
         id: build


### PR DESCRIPTION
if the current toolchain has never been built on the CI, then spending
close to 4mins to look for each mathlib file is wasteful. So this checks
the existence a cache file for some file in `batteries` (I picked
`Batteries.WF`). If that is not present, then very likely the current
toolchain has not been tested yet, and we can skip the full `lake
cache`.

This speeds up mostly new `pr-testing` CI branches, or after a push to
the lean PR.
