### PR TITLE
[Merged by Bors] - feat(Polynomial): natDegree_add_eq_left_of_degree_lt

### DIFF
--- a/Mathlib/Algebra/Polynomial/Degree/Definitions.lean
+++ b/Mathlib/Algebra/Polynomial/Degree/Definitions.lean
@@ -614,13 +614,21 @@ theorem degree_add_eq_left_of_degree_lt (h : degree q < degree p) : degree (p + 
 theorem degree_add_eq_right_of_degree_lt (h : degree p < degree q) : degree (p + q) = degree q := by
   rw [add_comm, degree_add_eq_left_of_degree_lt h]
 
+theorem natDegree_add_eq_left_of_degree_lt (h : degree q < degree p) :
+    natDegree (p + q) = natDegree p :=
+  natDegree_eq_of_degree_eq (degree_add_eq_left_of_degree_lt h)
+
 theorem natDegree_add_eq_left_of_natDegree_lt (h : natDegree q < natDegree p) :
     natDegree (p + q) = natDegree p :=
-  natDegree_eq_of_degree_eq (degree_add_eq_left_of_degree_lt (degree_lt_degree h))
+  natDegree_add_eq_left_of_degree_lt (degree_lt_degree h)
+
+theorem natDegree_add_eq_right_of_degree_lt (h : degree p < degree q) :
+    natDegree (p + q) = natDegree q :=
+  natDegree_eq_of_degree_eq (degree_add_eq_right_of_degree_lt h)
 
 theorem natDegree_add_eq_right_of_natDegree_lt (h : natDegree p < natDegree q) :
     natDegree (p + q) = natDegree q :=
-  natDegree_eq_of_degree_eq (degree_add_eq_right_of_degree_lt (degree_lt_degree h))
+  natDegree_add_eq_right_of_degree_lt (degree_lt_degree h)
 
 theorem degree_add_C (hp : 0 < degree p) : degree (p + C a) = degree p :=
   add_comm (C a) p ▸ degree_add_eq_right_of_degree_lt <| lt_of_le_of_lt degree_C_le hp


### PR DESCRIPTION
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
