### PR TITLE
[Merged by Bors] - feat(GroupTheory/Perm): composition of permutations is 1 iff they are inverses 

### DIFF
--- a/Mathlib/Algebra/Group/Basic.lean
+++ b/Mathlib/Algebra/Group/Basic.lean
@@ -645,6 +645,14 @@ theorem mul_eq_one_iff_inv_eq : a * b = 1 ↔ a⁻¹ = b := by
   rw [mul_eq_one_iff_eq_inv, inv_eq_iff_eq_inv]
 
 @[to_additive]
+theorem mul_eq_one_iff_eq_inv' : a * b = 1 ↔ b = a⁻¹ := by
+  rw [mul_eq_one_iff_inv_eq, eq_comm]
+
+@[to_additive]
+theorem mul_eq_one_iff_inv_eq' : a * b = 1 ↔ b⁻¹ = a := by
+  rw [mul_eq_one_iff_eq_inv, eq_comm]
+
+@[to_additive]
 theorem eq_inv_iff_mul_eq_one : a = b⁻¹ ↔ a * b = 1 :=
   mul_eq_one_iff_eq_inv.symm
 

--- a/Mathlib/Algebra/Group/Basic.lean
+++ b/Mathlib/Algebra/Group/Basic.lean
@@ -644,12 +644,12 @@ theorem mul_eq_one_iff_eq_inv : a * b = 1 ↔ a = b⁻¹ :=
 theorem mul_eq_one_iff_inv_eq : a * b = 1 ↔ a⁻¹ = b := by
   rw [mul_eq_one_iff_eq_inv, inv_eq_iff_eq_inv]
 
-/-- Variant of `mul_eq_one_iff_eq_inv` with swapped equality. --/
+/-- Variant of `mul_eq_one_iff_eq_inv` with swapped equality. -/
 @[to_additive]
 theorem mul_eq_one_iff_eq_inv' : a * b = 1 ↔ b = a⁻¹ := by
   rw [mul_eq_one_iff_inv_eq, eq_comm]
 
-/-- Variant of `mul_eq_one_iff_inv_eq` with swapped equality. --/
+/-- Variant of `mul_eq_one_iff_inv_eq` with swapped equality. -/
 @[to_additive]
 theorem mul_eq_one_iff_inv_eq' : a * b = 1 ↔ b⁻¹ = a := by
   rw [mul_eq_one_iff_eq_inv, eq_comm]

--- a/Mathlib/Algebra/Group/Basic.lean
+++ b/Mathlib/Algebra/Group/Basic.lean
@@ -644,10 +644,12 @@ theorem mul_eq_one_iff_eq_inv : a * b = 1 ↔ a = b⁻¹ :=
 theorem mul_eq_one_iff_inv_eq : a * b = 1 ↔ a⁻¹ = b := by
   rw [mul_eq_one_iff_eq_inv, inv_eq_iff_eq_inv]
 
+/-- Variant of `mul_eq_one_iff_eq_inv` with swapped equality. --/
 @[to_additive]
 theorem mul_eq_one_iff_eq_inv' : a * b = 1 ↔ b = a⁻¹ := by
   rw [mul_eq_one_iff_inv_eq, eq_comm]
 
+/-- Variant of `mul_eq_one_iff_inv_eq` with swapped equality. --/
 @[to_additive]
 theorem mul_eq_one_iff_inv_eq' : a * b = 1 ↔ b⁻¹ = a := by
   rw [mul_eq_one_iff_eq_inv, eq_comm]

--- a/Mathlib/GroupTheory/Perm/Basic.lean
+++ b/Mathlib/GroupTheory/Perm/Basic.lean
@@ -157,10 +157,10 @@ theorem symm_mul (e : Perm α) : e.symm * e = 1 :=
 theorem trans_eq_one_iff_eq_symm (e₁ e₂ : Equiv.Perm α) : e₁.trans e₂ = 1 ↔ e₁ = e₂.symm := by
   refine ⟨fun h ↦ ?_, fun h ↦ ?_⟩
   · ext x
-    have : e₁.trans e₂ x = x := by rw [h, coe_one, id_eq]
-    apply congrArg (⇑(e₂.symm)) at this
-    rw [trans_apply, symm_apply_apply] at this
-    exact this
+    replace h : e₁.trans e₂ x = x := by rw [h, coe_one, id_eq]
+    apply congrArg (⇑(e₂.symm)) at h
+    rw [trans_apply, symm_apply_apply] at h
+    exact h
   · rw [h, ← symm_mul]
     rfl
 

--- a/Mathlib/GroupTheory/Perm/Basic.lean
+++ b/Mathlib/GroupTheory/Perm/Basic.lean
@@ -154,8 +154,7 @@ theorem self_trans_inv (e : Perm α) : e.trans e⁻¹ = 1 :=
 theorem symm_mul (e : Perm α) : e.symm * e = 1 :=
   Equiv.self_trans_symm e
 
-theorem trans_eq_one_iff_eq_symm (e₁ e₂ : Equiv.Perm α) :
-  e₁.trans e₂ = 1 ↔ e₁ = e₂.symm := by
+theorem trans_eq_one_iff_eq_symm (e₁ e₂ : Equiv.Perm α) : e₁.trans e₂ = 1 ↔ e₁ = e₂.symm := by
   refine ⟨fun h ↦ ?_, fun h ↦ ?_⟩
   · ext x
     have : e₁.trans e₂ x = x := by rw [h, coe_one, id_eq]

--- a/Mathlib/GroupTheory/Perm/Basic.lean
+++ b/Mathlib/GroupTheory/Perm/Basic.lean
@@ -154,6 +154,17 @@ theorem self_trans_inv (e : Perm α) : e.trans e⁻¹ = 1 :=
 theorem symm_mul (e : Perm α) : e.symm * e = 1 :=
   Equiv.self_trans_symm e
 
+theorem trans_eq_one_iff_eq_symm (e₁ e₂ : Equiv.Perm α) :
+  e₁.trans e₂ = 1 ↔ e₁ = e₂.symm := by
+  refine ⟨fun h ↦ ?_, fun h ↦ ?_⟩
+  · ext x
+    have : e₁.trans e₂ x = x := by rw [h, coe_one, id_eq]
+    apply congrArg (⇑(e₂.symm)) at this
+    rw [trans_apply, symm_apply_apply] at this
+    exact this
+  · rw [h, ← symm_mul]
+    rfl
+
 /-! Lemmas about `Equiv.Perm.sumCongr` re-expressed via the group structure. -/
 
 

--- a/Mathlib/GroupTheory/Perm/Basic.lean
+++ b/Mathlib/GroupTheory/Perm/Basic.lean
@@ -154,15 +154,8 @@ theorem self_trans_inv (e : Perm α) : e.trans e⁻¹ = 1 :=
 theorem symm_mul (e : Perm α) : e.symm * e = 1 :=
   Equiv.self_trans_symm e
 
-theorem trans_eq_one_iff_eq_symm (e₁ e₂ : Equiv.Perm α) : e₁.trans e₂ = 1 ↔ e₁ = e₂.symm := by
-  refine ⟨fun h ↦ ?_, fun h ↦ ?_⟩
-  · ext x
-    replace h : e₁.trans e₂ x = x := by rw [h, coe_one, id_eq]
-    apply congrArg (⇑(e₂.symm)) at h
-    rw [trans_apply, symm_apply_apply] at h
-    exact h
-  · rw [h, ← symm_mul]
-    rfl
+theorem trans_eq_one_iff_eq_symm (e₁ e₂ : Equiv.Perm α) : e₁.trans e₂ = 1 ↔ e₁ = e₂.symm :=
+  mul_eq_one_iff_eq_inv'
 
 /-! Lemmas about `Equiv.Perm.sumCongr` re-expressed via the group structure. -/
 

--- a/Mathlib/GroupTheory/Perm/Basic.lean
+++ b/Mathlib/GroupTheory/Perm/Basic.lean
@@ -154,9 +154,6 @@ theorem self_trans_inv (e : Perm α) : e.trans e⁻¹ = 1 :=
 theorem symm_mul (e : Perm α) : e.symm * e = 1 :=
   Equiv.self_trans_symm e
 
-theorem trans_eq_one_iff_eq_symm (e₁ e₂ : Equiv.Perm α) : e₁.trans e₂ = 1 ↔ e₁ = e₂.symm :=
-  mul_eq_one_iff_eq_inv'
-
 /-! Lemmas about `Equiv.Perm.sumCongr` re-expressed via the group structure. -/
 
 

--- a/Mathlib/Logic/Equiv/Defs.lean
+++ b/Mathlib/Logic/Equiv/Defs.lean
@@ -301,6 +301,15 @@ theorem symm_bijective : Function.Bijective (Equiv.symm : (α ≃ β) → β ≃
 
 @[simp] theorem self_trans_symm (e : α ≃ β) : e.trans e.symm = Equiv.refl α := ext <| by simp
 
+theorem trans_eq_one_iff_eq_symm (f : α ≃ β) (g : β ≃ α) :
+    f.trans g = Equiv.refl α ↔ f = g.symm := by
+  refine ⟨fun h ↦ ?_, fun h ↦ ?_⟩
+  · ext x
+    apply g.injective
+    rw [← trans_apply, h, refl_apply, apply_symm_apply]
+  · rw [h, ← self_trans_symm]
+    rfl
+
 theorem trans_assoc {δ} (ab : α ≃ β) (bc : β ≃ γ) (cd : γ ≃ δ) :
     (ab.trans bc).trans cd = ab.trans (bc.trans cd) := Equiv.ext fun _ => rfl
 

--- a/Mathlib/Logic/Equiv/Defs.lean
+++ b/Mathlib/Logic/Equiv/Defs.lean
@@ -301,7 +301,7 @@ theorem symm_bijective : Function.Bijective (Equiv.symm : (α ≃ β) → β ≃
 
 @[simp] theorem self_trans_symm (e : α ≃ β) : e.trans e.symm = Equiv.refl α := ext <| by simp
 
-theorem trans_eq_one_iff_eq_symm (f : α ≃ β) (g : β ≃ α) :
+theorem trans_eq_refl_iff_eq_symm (f : α ≃ β) (g : β ≃ α) :
     f.trans g = Equiv.refl α ↔ f = g.symm := by
   refine ⟨fun h ↦ ?_, fun h ↦ ?_⟩
   · ext x

--- a/Mathlib/Logic/Equiv/Defs.lean
+++ b/Mathlib/Logic/Equiv/Defs.lean
@@ -301,15 +301,6 @@ theorem symm_bijective : Function.Bijective (Equiv.symm : (α ≃ β) → β ≃
 
 @[simp] theorem self_trans_symm (e : α ≃ β) : e.trans e.symm = Equiv.refl α := ext <| by simp
 
-theorem trans_eq_refl_iff_eq_symm (f : α ≃ β) (g : β ≃ α) :
-    f.trans g = Equiv.refl α ↔ f = g.symm := by
-  refine ⟨fun h ↦ ?_, fun h ↦ ?_⟩
-  · ext x
-    apply g.injective
-    rw [← trans_apply, h, refl_apply, apply_symm_apply]
-  · rw [h, ← self_trans_symm]
-    rfl
-
 theorem trans_assoc {δ} (ab : α ≃ β) (bc : β ≃ γ) (cd : γ ≃ δ) :
     (ab.trans bc).trans cd = ab.trans (bc.trans cd) := Equiv.ext fun _ => rfl
 
@@ -502,6 +493,10 @@ theorem eq_symm_comp {α β γ} (e : α ≃ β) (f : γ → α) (g : γ → β) 
 
 theorem symm_comp_eq {α β γ} (e : α ≃ β) (f : γ → α) (g : γ → β) : e.symm ∘ g = f ↔ g = e ∘ f :=
   ((Equiv.refl γ).arrowCongr e).symm_apply_eq
+
+theorem trans_eq_refl_iff_eq_symm (f : α ≃ β) (g : β ≃ α) :
+    f.trans g = Equiv.refl α ↔ f = g.symm := by
+  rw [← Equiv.coe_inj, coe_trans, coe_refl, ← eq_symm_comp, comp_id, Equiv.coe_inj]
 
 /-- `PUnit` sorts in any two universes are equivalent. -/
 def punitEquivPUnit : PUnit.{v} ≃ PUnit.{w} :=

--- a/Mathlib/Logic/Equiv/Defs.lean
+++ b/Mathlib/Logic/Equiv/Defs.lean
@@ -494,9 +494,22 @@ theorem eq_symm_comp {α β γ} (e : α ≃ β) (f : γ → α) (g : γ → β) 
 theorem symm_comp_eq {α β γ} (e : α ≃ β) (f : γ → α) (g : γ → β) : e.symm ∘ g = f ↔ g = e ∘ f :=
   ((Equiv.refl γ).arrowCongr e).symm_apply_eq
 
-theorem trans_eq_refl_iff_eq_symm (f : α ≃ β) (g : β ≃ α) :
+theorem trans_eq_refl_iff_eq_symm {f : α ≃ β} {g : β ≃ α} :
     f.trans g = Equiv.refl α ↔ f = g.symm := by
   rw [← Equiv.coe_inj, coe_trans, coe_refl, ← eq_symm_comp, comp_id, Equiv.coe_inj]
+
+theorem trans_eq_refl_iff_symm_eq {f : α ≃ β} {g : β ≃ α} :
+    f.trans g = Equiv.refl α ↔ f.symm = g := by
+  rw [trans_eq_refl_iff_eq_symm]
+  exact ⟨fun h ↦ h ▸ rfl, fun h ↦ h ▸ rfl⟩
+
+theorem eq_symm_trans_eq_refl {f : α ≃ β} {g : β ≃ α} :
+    f = g.symm ↔ f.trans g = Equiv.refl α :=
+  trans_eq_refl_iff_eq_symm.symm
+
+theorem symm_eq_trans_eq_refl_iff{f : α ≃ β} {g : β ≃ α} :
+    f.symm = g ↔ f.trans g = Equiv.refl α :=
+  trans_eq_refl_iff_symm_eq.symm
 
 /-- `PUnit` sorts in any two universes are equivalent. -/
 def punitEquivPUnit : PUnit.{v} ≃ PUnit.{w} :=

--- a/Mathlib/Logic/Equiv/Defs.lean
+++ b/Mathlib/Logic/Equiv/Defs.lean
@@ -503,11 +503,11 @@ theorem trans_eq_refl_iff_symm_eq {f : α ≃ β} {g : β ≃ α} :
   rw [trans_eq_refl_iff_eq_symm]
   exact ⟨fun h ↦ h ▸ rfl, fun h ↦ h ▸ rfl⟩
 
-theorem eq_symm_trans_eq_refl {f : α ≃ β} {g : β ≃ α} :
+theorem eq_symm_iff_trans_eq_refl {f : α ≃ β} {g : β ≃ α} :
     f = g.symm ↔ f.trans g = Equiv.refl α :=
   trans_eq_refl_iff_eq_symm.symm
 
-theorem symm_eq_trans_eq_refl_iff{f : α ≃ β} {g : β ≃ α} :
+theorem symm_eq_iff_trans_eq_refl {f : α ≃ β} {g : β ≃ α} :
     f.symm = g ↔ f.trans g = Equiv.refl α :=
   trans_eq_refl_iff_symm_eq.symm
 

--- a/test/RewriteSearch/Polynomial.lean
+++ b/test/RewriteSearch/Polynomial.lean
@@ -174,7 +174,7 @@ example {R : Type u} [Ring R] [Nontrivial R] (x : R) :
 #guard_msgs(drop info) in
 example {S : Type v} [Ring S] (c : S) :
     Polynomial.nextCoeff (Polynomial.X - Polynomial.C c) = -c := by
-  rw_search [-Polynomial.nextCoeff_X_sub_C]
+  rw_search
   -- Mathlib proof:
   -- rw [sub_eq_add_neg, ← map_neg C c, nextCoeff_X_add_C]
   done

--- a/test/RewriteSearch/Polynomial.lean
+++ b/test/RewriteSearch/Polynomial.lean
@@ -174,7 +174,7 @@ example {R : Type u} [Ring R] [Nontrivial R] (x : R) :
 #guard_msgs(drop info) in
 example {S : Type v} [Ring S] (c : S) :
     Polynomial.nextCoeff (Polynomial.X - Polynomial.C c) = -c := by
-  rw_search
+  rw_search [-Polynomial.nextCoeff_X_sub_C]
   -- Mathlib proof:
   -- rw [sub_eq_add_neg, ← map_neg C c, nextCoeff_X_add_C]
   done


### PR DESCRIPTION
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
