### PR TITLE
[Merged by Bors] - feat(Data/Finset/Sort): Every finite linear order embeds into every infinite linear order

### DIFF
--- a/Mathlib/Data/Finset/Sort.lean
+++ b/Mathlib/Data/Finset/Sort.lean
@@ -241,3 +241,20 @@ theorem sort_univ (n : ℕ) : Finset.univ.sort (fun x y : Fin n => x ≤ y) = Li
     (List.pairwise_le_finRange n)
 
 end Fin
+
+/-- Given a `Fintype` `α` of cardinality `k`, the map `orderIsoOfFin s h` is the increasing
+bijection between `Fin k` and `α` as an `OrderIso`. Here, `h` is a proof that the cardinality of `α`
+is `k`. We use this instead of an iso `Fin (Fintype.card α) ≃o α` to avoid casting issues in further
+uses of this function. -/
+def Fintype.orderIsoOfFin (α : Type*) [LinearOrder α] [Fintype α] {k : ℕ} (h : Fintype.card α = k) :
+    Fin k ≃o α :=
+  (Finset.univ.orderIsoOfFin h).trans
+    ((OrderIso.setCongr _ _ Finset.coe_univ).trans OrderIso.Set.univ)
+
+/-- Any finite linear order order-embeds into any infinite linear order. -/
+lemma nonempty_orderEmbedding_of_finite_infinite
+  (α : Type*) [LinearOrder α] [hα : Finite α]
+  (β : Type*) [LinearOrder β] [hβ : Infinite β] : Nonempty (α ↪o β) := by
+  haveI := Fintype.ofFinite α
+  obtain ⟨s, hs⟩ := Infinite.exists_subset_card_eq β (Fintype.card α)
+  exact ⟨((Fintype.orderIsoOfFin α rfl).symm.toOrderEmbedding).trans (s.orderEmbOfFin hs)⟩

--- a/Mathlib/Data/Finset/Sort.lean
+++ b/Mathlib/Data/Finset/Sort.lean
@@ -253,8 +253,8 @@ def Fintype.orderIsoOfFin (α : Type*) [LinearOrder α] [Fintype α] {k : ℕ} (
 
 /-- Any finite linear order order-embeds into any infinite linear order. -/
 lemma nonempty_orderEmbedding_of_finite_infinite
-  (α : Type*) [LinearOrder α] [hα : Finite α]
-  (β : Type*) [LinearOrder β] [hβ : Infinite β] : Nonempty (α ↪o β) := by
+    (α : Type*) [LinearOrder α] [hα : Finite α]
+    (β : Type*) [LinearOrder β] [hβ : Infinite β] : Nonempty (α ↪o β) := by
   haveI := Fintype.ofFinite α
   obtain ⟨s, hs⟩ := Infinite.exists_subset_card_eq β (Fintype.card α)
   exact ⟨((Fintype.orderIsoOfFin α rfl).symm.toOrderEmbedding).trans (s.orderEmbOfFin hs)⟩

--- a/Mathlib/Data/Finset/Sort.lean
+++ b/Mathlib/Data/Finset/Sort.lean
@@ -242,11 +242,12 @@ theorem sort_univ (n : ℕ) : Finset.univ.sort (fun x y : Fin n => x ≤ y) = Li
 
 end Fin
 
-/-- Given a `Fintype` `α` of cardinality `k`, the map `orderIsoOfFin s h` is the increasing
+/-- Given a `Fintype` `α` of cardinality `k`, the map `orderIsoFinOfCardEq s h` is the increasing
 bijection between `Fin k` and `α` as an `OrderIso`. Here, `h` is a proof that the cardinality of `α`
 is `k`. We use this instead of an iso `Fin (Fintype.card α) ≃o α` to avoid casting issues in further
 uses of this function. -/
-def Fintype.orderIsoOfFin (α : Type*) [LinearOrder α] [Fintype α] {k : ℕ} (h : Fintype.card α = k) :
+def Fintype.orderIsoFinOfCardEq
+    (α : Type*) [LinearOrder α] [Fintype α] {k : ℕ} (h : Fintype.card α = k) :
     Fin k ≃o α :=
   (Finset.univ.orderIsoOfFin h).trans
     ((OrderIso.setCongr _ _ Finset.coe_univ).trans OrderIso.Set.univ)
@@ -257,4 +258,4 @@ lemma nonempty_orderEmbedding_of_finite_infinite
     (β : Type*) [LinearOrder β] [hβ : Infinite β] : Nonempty (α ↪o β) := by
   haveI := Fintype.ofFinite α
   obtain ⟨s, hs⟩ := Infinite.exists_subset_card_eq β (Fintype.card α)
-  exact ⟨((Fintype.orderIsoOfFin α rfl).symm.toOrderEmbedding).trans (s.orderEmbOfFin hs)⟩
+  exact ⟨((Fintype.orderIsoFinOfCardEq α rfl).symm.toOrderEmbedding).trans (s.orderEmbOfFin hs)⟩


### PR DESCRIPTION
Constructs `Fintype.orderIsoOfFin` along the lines of `Finset.orderIsoOfFin`
Shows that every finite linear order embeds into every infinite linear order

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
