### PR TITLE
[Merged by Bors] - docs: fix some outdated paths related to `Equiv`

### DIFF
--- a/Mathlib/Algebra/Group/Aut.lean
+++ b/Mathlib/Algebra/Group/Aut.lean
@@ -17,7 +17,7 @@ The definition of multiplication in the automorphism groups agrees with function
 multiplication in `Equiv.Perm`, and multiplication in `CategoryTheory.End`, but not with
 `CategoryTheory.comp`.
 
-This file is kept separate from `Algebra/Group/Equiv` so that `GroupTheory.Perm` is free to use
+This file is kept separate from `Algebra/Group/Equiv/*` so that `GroupTheory.Perm` is free to use
 equivalences (and other files that use them) before the group structure is defined.
 
 ## Tags

--- a/Mathlib/Algebra/Group/Aut.lean
+++ b/Mathlib/Algebra/Group/Aut.lean
@@ -17,7 +17,7 @@ The definition of multiplication in the automorphism groups agrees with function
 multiplication in `Equiv.Perm`, and multiplication in `CategoryTheory.End`, but not with
 `CategoryTheory.comp`.
 
-This file is kept separate from `Data/Equiv/MulAdd` so that `GroupTheory.Perm` is free to use
+This file is kept separate from `Algebra/Group/Equiv` so that `GroupTheory.Perm` is free to use
 equivalences (and other files that use them) before the group structure is defined.
 
 ## Tags

--- a/Mathlib/Algebra/Ring/Aut.lean
+++ b/Mathlib/Algebra/Ring/Aut.lean
@@ -18,7 +18,7 @@ The definition of multiplication in the automorphism group agrees with function 
 multiplication in `Equiv.Perm`, and multiplication in `CategoryTheory.End`, but not with
 `CategoryTheory.comp`.
 
-This file is kept separate from `Data/Equiv/Ring` so that `GroupTheory.Perm` is free to use
+This file is kept separate from `Algebra/Ring/Equiv.lean` so that `GroupTheory.Perm` is free to use
 equivalences (and other files that use them) before the group structure is defined.
 
 ## Tags

--- a/Mathlib/Data/Finset/Basic.lean
+++ b/Mathlib/Data/Finset/Basic.lean
@@ -105,8 +105,9 @@ In Lean, we use lattice notation to talk about things involving unions and inter
 
 ### Equivalences between finsets
 
-* The `Mathlib/Data/Equiv.lean` files describe a general type of equivalence, so look in there for
-  any lemmas. There is some API for rewriting sums and products from `s` to `t` given that `s ≃ t`.
+* The `Mathlib/Logic/Equiv/Defs.lean` files describe a general type of equivalence, so look in there
+  for any lemmas. There is some API for rewriting sums and products from `s` to `t` given that
+  `s ≃ t`.
   TODO: examples
 
 ## Tags

--- a/Mathlib/GroupTheory/Perm/Finite.lean
+++ b/Mathlib/GroupTheory/Perm/Finite.lean
@@ -13,7 +13,7 @@ import Mathlib.Logic.Equiv.Fintype
 # Permutations on `Fintype`s
 
 This file contains miscellaneous lemmas about `Equiv.Perm` and `Equiv.swap`, building on top
-of those in `Data/Equiv/Basic` and other files in `GroupTheory/Perm/*`.
+of those in `Logic/Equiv/Basic.lean` and other files in `GroupTheory/Perm/*`.
 -/
 
 universe u v

--- a/Mathlib/Logic/Equiv/Basic.lean
+++ b/Mathlib/Logic/Equiv/Basic.lean
@@ -38,7 +38,7 @@ In this file we continue the work on equivalences begun in `Logic/Equiv/Defs.lea
     `eb : β₁ ≃ β₂` using `Prod.map`.
 
   More definitions of this kind can be found in other files.
-  E.g., `Data/Equiv/TransferInstance.lean` does it for many algebraic type classes like
+  E.g., `Logic/Equiv/TransferInstance.lean` does it for many algebraic type classes like
   `Group`, `Module`, etc.
 
 ## Tags


### PR DESCRIPTION
These paths refer to files and folders that used to exist but not anymore due to refactors such as [mathlib3#12929](https://github.com/leanprover-community/mathlib3/pull/12929) and [mathlib3#8095](https://github.com/leanprover-community/mathlib4/pull/8095).

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
