### PR TITLE
[Merged by Bors] - fix: disable the haveLet linter

### DIFF
--- a/Mathlib/Tactic/Linter/HaveLetLinter.lean
+++ b/Mathlib/Tactic/Linter/HaveLetLinter.lean
@@ -39,7 +39,7 @@ There are three settings:
 The default value is `1`.
 -/
 register_option linter.haveLet : Nat := {
-  defValue := 1
+  defValue := 0
   descr := "enable the `have` vs `let` linter:\n\
             * 0 -- inactive;\n\
             * 1 -- active only on noisy declarations;\n\

--- a/test/HaveLetLinter.lean
+++ b/test/HaveLetLinter.lean
@@ -1,6 +1,8 @@
 import Mathlib.Tactic.Linter.HaveLetLinter
 import Mathlib.Tactic.Tauto
 
+set_option linter.haveLet 1
+
 /--
 A tactic that adds a vacuous `sorry`. Useful for testing the chattiness of the `haveLet` linter.
 -/


### PR DESCRIPTION
At least, until I fix a bug, reported both on [Mathlib](https://leanprover.zulipchat.com/#narrow/stream/287929-mathlib4/topic/haveLet.20linter.20crashing.20under.20.60byAsSorry.60) and on projects depending on [Mathlib](https://leanprover.zulipchat.com/#narrow/stream/412902-Polynomial-Freiman-Ruzsa-conjecture/topic/Outstanding.20tasks.2C.20version.202.2E0/near/464281461).

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
