### PR TITLE
[Merged by Bors] - feat(FermatLastTheorem): Add a relaxed variant of FLT allowing nonzero unit solutions 

### DIFF
--- a/Mathlib/NumberTheory/FLT/Basic.lean
+++ b/Mathlib/NumberTheory/FLT/Basic.lean
@@ -185,7 +185,7 @@ lemma fermatLastTheoremWith_of_fermatLastTheoremWith' {α : Type*} [CommSemiring
     FermatLastTheoremWith α n := by
   intro a b c ha hb hc heq
   rcases h a b c ha hb hc heq with ⟨d, a', b', c', ⟨eq_a, eq_b, eq_c⟩, ⟨ua, ub, uc⟩⟩
-  rw [eq_a, eq_b, eq_c, mul_pow, mul_pow, mul_pow, ←add_mul, mul_eq_mul_right_iff] at heq
+  rw [eq_a, eq_b, eq_c, mul_pow, mul_pow, mul_pow, ← add_mul, mul_eq_mul_right_iff] at heq
   cases' heq with heq hd
   · exact hn _ _ _ ua ub uc heq
   · obtain ⟨hd, hn⟩ := pow_eq_zero_iff'.mp hd
@@ -193,7 +193,7 @@ lemma fermatLastTheoremWith_of_fermatLastTheoremWith' {α : Type*} [CommSemiring
     apply ha
     rfl
 
-lemma fermatLastTheoremWith'_iff_fermatLastTheoremWith {α : Type*} [Semiring α]
+lemma fermatLastTheoremWith'_iff_fermatLastTheoremWith {α : Type*} [CommSemiring α] [IsDomain α]
     {n : ℕ} (hn : ∀ a b c : α, IsUnit a → IsUnit b → IsUnit c → a ^ n + b ^ n ≠ c ^ n) :
     FermatLastTheoremWith' α n ↔ FermatLastTheoremWith α n :=
   Iff.intro

--- a/Mathlib/NumberTheory/FLT/Basic.lean
+++ b/Mathlib/NumberTheory/FLT/Basic.lean
@@ -154,8 +154,8 @@ lemma fermatLastTheoremFor_iff_rat {n : ℕ} : FermatLastTheoremFor n ↔ Fermat
   (fermatLastTheoremWith_nat_int_rat_tfae n).out 0 2
 
 /--
-A relaxed variant of Fermat's Last Theorem over a given semiring with a specific exponent,
-allowing nonzero solutions of units.
+A relaxed variant of Fermat's Last Theorem over a given commutative semiring with a specific
+exponent, allowing nonzero solutions of units and their common multiples.
 
 1. The variant `FermatLastTheoremWith' α` is weaker than `FermatLastTheoremWith α` in general.
    In particular, it holds trivially for `[Field α]`.
@@ -165,36 +165,36 @@ allowing nonzero solutions of units.
    variant `FermatLastTheoremWith' α` is true. This polynomial variant of Fermat's Last Theorem
    can be shown elementarily using Mason--Stothers theorem.
 -/
-def FermatLastTheoremWith' (α : Type*) [Semiring α] (n : ℕ) : Prop :=
-  ∀ a b c : α, a ≠ 0 → b ≠ 0 → c ≠ 0 → a ^ n + b ^ n = c ^ n → IsUnit a ∧ IsUnit b ∧ IsUnit c
+def FermatLastTheoremWith' (α : Type*) [CommSemiring α] (n : ℕ) : Prop :=
+  ∀ a b c : α, a ≠ 0 → b ≠ 0 → c ≠ 0 → a ^ n + b ^ n = c ^ n →
+    ∃ d a' b' c', (a = a' * d ∧ b = b' * d ∧ c = c' * d) ∧ (IsUnit a' ∧ IsUnit b' ∧ IsUnit c')
 
-lemma FermatLastTheoremWith'.mono (hmn : m ∣ n) (hn : n ≠ 0) (hm : FermatLastTheoremWith' α m) :
-    FermatLastTheoremWith' α n := by
-  rintro a b c ha hb hc heq
-  obtain ⟨k, rfl⟩ := hmn
-  obtain ⟨_, hk⟩ := mul_ne_zero_iff.mp hn
-  simp_rw [pow_mul'] at heq
-  have t := (hm _ _ _ ?_ ?_ ?_ heq) <;> try exact pow_ne_zero _ ‹_›
-  simp only [isUnit_pow_iff hk] at t
-  exact t
-
-lemma fermatLastTheoremWith'_of_fermatLastTheoremWith {α : Type*} [Semiring α] {n : ℕ}
+lemma fermatLastTheoremWith'_of_fermatLastTheoremWith {α : Type*} [CommSemiring α] {n : ℕ}
     (h : FermatLastTheoremWith α n) : FermatLastTheoremWith' α n :=
   fun a b c _ _ _ _ ↦ by exfalso; apply h a b c <;> assumption
 
 lemma fermatLastTheoremWith'_of_field (α : Type*) [Field α] (n : ℕ) : FermatLastTheoremWith' α n :=
-  fun _ _ _ ha hb hc _ ↦ ⟨ha.isUnit, hb.isUnit, hc.isUnit⟩
+  fun a b c ha hb hc _ ↦
+    ⟨1, a, b, c,
+     ⟨(mul_one a).symm, (mul_one b).symm, (mul_one c).symm⟩,
+     ⟨ha.isUnit, hb.isUnit, hc.isUnit⟩⟩
 
-lemma fermatLastTheoremWith_of_fermatLastTheoremWith' {α : Type*} [Semiring α] {n : ℕ}
-    (h : FermatLastTheoremWith' α n)
+lemma fermatLastTheoremWith_of_fermatLastTheoremWith' {α : Type*} [CommSemiring α] [IsDomain α]
+    {n : ℕ} (h : FermatLastTheoremWith' α n)
     (hn : ∀ a b c : α, IsUnit a → IsUnit b → IsUnit c → a ^ n + b ^ n ≠ c ^ n) :
     FermatLastTheoremWith α n := by
   intro a b c ha hb hc heq
-  rcases h a b c ha hb hc heq with ⟨ua, ub, uc⟩
-  apply hn a b c <;> assumption
+  rcases h a b c ha hb hc heq with ⟨d, a', b', c', ⟨eq_a, eq_b, eq_c⟩, ⟨ua, ub, uc⟩⟩
+  rw [eq_a, eq_b, eq_c, mul_pow, mul_pow, mul_pow, ←add_mul, mul_eq_mul_right_iff] at heq
+  cases' heq with heq hd
+  · exact hn _ _ _ ua ub uc heq
+  · obtain ⟨hd, hn⟩ := pow_eq_zero_iff'.mp hd
+    rw [eq_a, hd, mul_zero] at ha
+    apply ha
+    rfl
 
-lemma fermatLastTheoremWith'_iff_fermatLastTheoremWith {α : Type*} [Semiring α] {n : ℕ}
-    (hn : ∀ a b c : α, IsUnit a → IsUnit b → IsUnit c → a ^ n + b ^ n ≠ c ^ n) :
+lemma fermatLastTheoremWith'_iff_fermatLastTheoremWith {α : Type*} [Semiring α]
+    {n : ℕ} (hn : ∀ a b c : α, IsUnit a → IsUnit b → IsUnit c → a ^ n + b ^ n ≠ c ^ n) :
     FermatLastTheoremWith' α n ↔ FermatLastTheoremWith α n :=
   Iff.intro
     (fun h ↦ fermatLastTheoremWith_of_fermatLastTheoremWith' h hn)

--- a/Mathlib/NumberTheory/FLT/Basic.lean
+++ b/Mathlib/NumberTheory/FLT/Basic.lean
@@ -215,7 +215,7 @@ lemma fermatLastTheoremWith'_nat_int_tfae (n : ℕ) :
     by_cases hn : n = 0
     · subst hn
       simp only [pow_zero, Int.reduceAdd, ne_eq, OfNat.ofNat_ne_one, not_false_eq_true]
-    · rw [←isUnit_pow_iff hn, Int.isUnit_iff] at ha hb hc
+    · rw [← isUnit_pow_iff hn, Int.isUnit_iff] at ha hb hc
       -- case division
       rcases ha with ha | ha <;> rcases hb with hb | hb <;> rcases hc with hc | hc <;>
         rw [ha, hb, hc] <;> decide

--- a/Mathlib/NumberTheory/FLT/Basic.lean
+++ b/Mathlib/NumberTheory/FLT/Basic.lean
@@ -181,17 +181,12 @@ lemma fermatLastTheoremWith'_of_field (α : Type*) [Field α] (n : ℕ) : Fermat
 
 lemma fermatLastTheoremWith_of_fermatLastTheoremWith' {α : Type*} [CommSemiring α] [IsDomain α]
     {n : ℕ} (h : FermatLastTheoremWith' α n)
-    (hn : ∀ a b c : α, IsUnit a → IsUnit b → IsUnit c → a ^ n + b ^ n ≠ c ^ n) :
+    (hn : ∀ {a b c : α}, IsUnit a → IsUnit b → IsUnit c → a ^ n + b ^ n ≠ c ^ n) :
     FermatLastTheoremWith α n := by
   intro a b c ha hb hc heq
-  rcases h a b c ha hb hc heq with ⟨d, a', b', c', ⟨eq_a, eq_b, eq_c⟩, ⟨ua, ub, uc⟩⟩
-  rw [eq_a, eq_b, eq_c, mul_pow, mul_pow, mul_pow, ← add_mul, mul_eq_mul_right_iff] at heq
-  cases' heq with heq hd
-  · exact hn _ _ _ ua ub uc heq
-  · obtain ⟨hd, hn⟩ := pow_eq_zero_iff'.mp hd
-    rw [eq_a, hd, mul_zero] at ha
-    apply ha
-    rfl
+  rcases h a b c ha hb hc heq with ⟨d, a', b', c', ⟨rfl, rfl, rfl⟩, ⟨ua, ub, uc⟩⟩
+  rw [mul_pow, mul_pow, mul_pow, ← add_mul] at heq
+  exact hn ua ub uc <| mul_right_cancel₀ (pow_ne_zero _ (right_ne_zero_of_mul ha)) heq
 
 lemma fermatLastTheoremWith'_iff_fermatLastTheoremWith {α : Type*} [CommSemiring α] [IsDomain α]
     {n : ℕ} (hn : ∀ a b c : α, IsUnit a → IsUnit b → IsUnit c → a ^ n + b ^ n ≠ c ^ n) :

--- a/Mathlib/NumberTheory/FLT/Basic.lean
+++ b/Mathlib/NumberTheory/FLT/Basic.lean
@@ -169,7 +169,7 @@ def FermatLastTheoremWith' (α : Type*) [CommSemiring α] (n : ℕ) : Prop :=
   ∀ a b c : α, a ≠ 0 → b ≠ 0 → c ≠ 0 → a ^ n + b ^ n = c ^ n →
     ∃ d a' b' c', (a = a' * d ∧ b = b' * d ∧ c = c' * d) ∧ (IsUnit a' ∧ IsUnit b' ∧ IsUnit c')
 
-lemma fermatLastTheoremWith'_of_fermatLastTheoremWith {α : Type*} [CommSemiring α] {n : ℕ}
+lemma FermatLastTheoremWith.fermatLastTheoremWith' {α : Type*} [CommSemiring α] {n : ℕ}
     (h : FermatLastTheoremWith α n) : FermatLastTheoremWith' α n :=
   fun a b c _ _ _ _ ↦ by exfalso; apply h a b c <;> assumption
 
@@ -179,21 +179,19 @@ lemma fermatLastTheoremWith'_of_field (α : Type*) [Field α] (n : ℕ) : Fermat
      ⟨(mul_one a).symm, (mul_one b).symm, (mul_one c).symm⟩,
      ⟨ha.isUnit, hb.isUnit, hc.isUnit⟩⟩
 
-lemma fermatLastTheoremWith_of_fermatLastTheoremWith' {α : Type*} [CommSemiring α] [IsDomain α]
+lemma FermatLastTheoremWith'.fermatLastTheoremWith {α : Type*} [CommSemiring α] [IsDomain α]
     {n : ℕ} (h : FermatLastTheoremWith' α n)
-    (hn : ∀ {a b c : α}, IsUnit a → IsUnit b → IsUnit c → a ^ n + b ^ n ≠ c ^ n) :
+    (hn : ∀ a b c : α, IsUnit a → IsUnit b → IsUnit c → a ^ n + b ^ n ≠ c ^ n) :
     FermatLastTheoremWith α n := by
   intro a b c ha hb hc heq
   rcases h a b c ha hb hc heq with ⟨d, a', b', c', ⟨rfl, rfl, rfl⟩, ⟨ua, ub, uc⟩⟩
   rw [mul_pow, mul_pow, mul_pow, ← add_mul] at heq
-  exact hn ua ub uc <| mul_right_cancel₀ (pow_ne_zero _ (right_ne_zero_of_mul ha)) heq
+  exact hn _ _ _ ua ub uc <| mul_right_cancel₀ (pow_ne_zero _ (right_ne_zero_of_mul ha)) heq
 
 lemma fermatLastTheoremWith'_iff_fermatLastTheoremWith {α : Type*} [CommSemiring α] [IsDomain α]
     {n : ℕ} (hn : ∀ a b c : α, IsUnit a → IsUnit b → IsUnit c → a ^ n + b ^ n ≠ c ^ n) :
     FermatLastTheoremWith' α n ↔ FermatLastTheoremWith α n :=
-  Iff.intro
-    (fun h ↦ fermatLastTheoremWith_of_fermatLastTheoremWith' h hn)
-    fermatLastTheoremWith'_of_fermatLastTheoremWith
+  Iff.intro (fun h ↦ h.fermatLastTheoremWith hn) (fun h ↦ h.fermatLastTheoremWith')
 
 lemma fermatLastTheoremWith'_nat_int_tfae (n : ℕ) :
     TFAE [FermatLastTheoremFor n, FermatLastTheoremWith' ℕ n, FermatLastTheoremWith' ℤ n] := by


### PR DESCRIPTION
Adds a variant `FermatLastTheoremWith'` of FLT for general commutative semirings, allowing nonzero unit solutions and their multiples.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

Supersedes #14270. I find this version less intrusive to the original statement of FLT.

The relaxed 'unit' variant `FermatLastTheoremWith' α` states that any nonzero solution to Fermat equation $a^n+b^n=c^n$ should be units $(a, b, c)$ or their common multiples. The stronger original `FermatLastTheoremWith α` states that there is no nonzero solution $(a, b, c)$ from the beginning.

For `α = ℕ` or `ℤ` the two statements are equivalent to the original FLT. A purpose of this is to include a polynomial version of FLT which is easy to prove (relevant Zulip discussion [here](https://leanprover.zulipchat.com/#narrow/stream/287929-mathlib4/topic/Mason-Stothers.20theorem.20and.20Polynomial.20FLT)). `FermatLastTheoremWith k[X]` is false for general field $k$, but `FermatLastTheoremWith' k[X]` is.
 
I speculate that for some integral ring `α` over `ℤ`, the original statement of FLT is false while the suggested unit variant is true. For example, take the integral closure of $\mathbb{Z}[w]$ where $w = (-1 + \sqrt{3} i ) / 2$ is the 3rd root of unity satisfying $w^3 = 1$. The original statement for $n = 6k + 1$ is false as $w^n + (w^2)^n = (-1)^n$, but note that the solutions only consists of units.

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
