### PR TITLE
[Merged by Bors] - feat(Category/Cat): add API lemmas

### DIFF
--- a/Mathlib/CategoryTheory/Category/Cat.lean
+++ b/Mathlib/CategoryTheory/Category/Cat.lean
@@ -75,6 +75,10 @@ instance category : LargeCategory.{max v u} Cat.{v, u} :=
   StrictBicategory.category Cat.{v, u}
 
 @[simp]
+theorem id_obj {C : Cat} (X : C) : (𝟙 C : C ⥤ C).obj X = X :=
+  rfl
+
+@[simp]
 theorem id_map {C : Cat} {X Y : C} (f : X ⟶ Y) : (𝟙 C : C ⥤ C).map f = f :=
   rfl
 
@@ -88,6 +92,13 @@ theorem comp_map {C D E : Cat} (F : C ⟶ D) (G : D ⟶ E) {X Y : C} (f : X ⟶ 
   rfl
 
 @[simp]
+theorem id_app {C D : Cat} (F : C ⟶ D) (X : C) : (𝟙 F : F ⟶ F).app X = 𝟙 (F.obj X) := rfl
+
+@[simp]
+theorem comp_app {C D : Cat} {F G H : C ⟶ D} (α : F ⟶ G) (β : G ⟶ H) (X : C) :
+    (α ≫ β).app X = α.app X ≫ β.app X := rfl
+
+@[simp]
 lemma whiskerLeft_app {C D E : Cat} (F : C ⟶ D) {G H : D ⟶ E} (η : G ⟶ H) (X : C) :
     (F ◁ η).app X = η.app (F.obj X) :=
   rfl
@@ -96,6 +107,11 @@ lemma whiskerLeft_app {C D E : Cat} (F : C ⟶ D) {G H : D ⟶ E} (η : G ⟶ H)
 lemma whiskerRight_app {C D E : Cat} {F G : C ⟶ D} (H : D ⟶ E) (η : F ⟶ G) (X : C) :
     (η ▷ H).app X = H.map (η.app X) :=
   rfl
+
+@[simp]
+theorem eqToHom_app {C D : Cat} (F G : C ⟶ D) (h : F = G) (X : C) :
+    (eqToHom h).app X = eqToHom (Functor.congr_obj h X) :=
+  CategoryTheory.eqToHom_app h X
 
 lemma leftUnitor_hom_app {B C : Cat} (F : B ⟶ C) (X : B) : (λ_ F).hom.app X = eqToHom (by simp) :=
   rfl

--- a/Mathlib/CategoryTheory/Grothendieck.lean
+++ b/Mathlib/CategoryTheory/Grothendieck.lean
@@ -166,18 +166,13 @@ def map (α : F ⟶ G) : Grothendieck F ⥤ Grothendieck G where
   map {X Y} f :=
   { base := f.base
     fiber := (eqToHom (α.naturality f.base).symm).app X.fiber ≫ (α.app Y.base).map f.fiber }
-  map_id X := by
-    simp only [Cat.comp_obj, id_fiber', eqToHom_map]
-    congr 1
-    rw [eqToHom_app, eqToHom_trans]
+  map_id X := by simp only [Cat.eqToHom_app, id_fiber', eqToHom_map, eqToHom_trans]; rfl
   map_comp {X Y Z} f g := by
     dsimp
     congr 1
     simp only [comp_fiber' f g, ← Category.assoc, Functor.map_comp, eqToHom_map]
     congr 1
-    simp only [Cat.comp_obj, eqToHom_trans, eqToHom_map, Cat.comp_map, eqToHom_trans_assoc,
-      Category.assoc]
-    rw [eqToHom_app, eqToHom_app, eqToHom_app]
+    simp only [Cat.eqToHom_app, Cat.comp_obj, eqToHom_trans, eqToHom_map, Category.assoc]
     erw [Functor.congr_hom (α.naturality g.base).symm f.fiber]
     simp
 
@@ -198,9 +193,7 @@ theorem map_id_eq : map (𝟙 F) = 𝟙 (Cat.of <| Grothendieck <| F) := by
     rfl
   · intro X Y f
     simp [map_map]
-    congr
-    rw [NatTrans.id_app]
-    simp
+    rfl
 
 /-- Making the equality of functors into an isomorphism. Note: we should avoid equality of functors
 if possible, and we should prefer `map_id_iso` to `map_id_eq` whenever we can. -/
@@ -218,9 +211,7 @@ theorem map_comp_eq (α : F ⟶ G) (β : G ⟶ H) :
       eqToHom_refl, Functor.comp_map, Functor.map_comp, Category.comp_id, Category.id_comp]
     fapply Grothendieck.ext
     · rfl
-    · simp only [eqToHom_refl, Category.id_comp]
-      erw [eqToHom_app, eqToHom_app, eqToHom_app, eqToHom_map]
-      simp only [Cat.comp_obj, eqToHom_trans_assoc]
+    · simp
 
 /-- Making the equality of functors into an isomorphism. Note: we should avoid equality of functors
 if possible, and we should prefer `map_comp_iso` to `map_comp_eq` whenever we can. -/


### PR DESCRIPTION
This PR adds more API lemmas about the bicategory of categories `Cat`. These are added as `simp` is not able to use the corresponding `NatTrans` lemmas when working with 2-morphisms in the bicategory `Cat`.

Due to this some proofs in `CategoryTheory/Grothendieck` can be golfed.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
