### PR TITLE
[Merged by Bors] - feat(CategoryTheory/Adjunction): dualize adjoint lifting theorem

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -1353,7 +1353,8 @@ import Mathlib.CategoryTheory.Adjunction.Basic
 import Mathlib.CategoryTheory.Adjunction.Comma
 import Mathlib.CategoryTheory.Adjunction.Evaluation
 import Mathlib.CategoryTheory.Adjunction.FullyFaithful
-import Mathlib.CategoryTheory.Adjunction.Lifting
+import Mathlib.CategoryTheory.Adjunction.Lifting.Left
+import Mathlib.CategoryTheory.Adjunction.Lifting.Right
 import Mathlib.CategoryTheory.Adjunction.Limits
 import Mathlib.CategoryTheory.Adjunction.Mates
 import Mathlib.CategoryTheory.Adjunction.Opposites

--- a/Mathlib/CategoryTheory/Adjunction/Lifting/Left.lean
+++ b/Mathlib/CategoryTheory/Adjunction/Lifting/Left.lean
@@ -17,8 +17,8 @@ The adjoint triangle theorem concerns a functor `U : B ⥤ C` with a left adjoin
 that `ε_X : FUX ⟶ X` is a regular epi. Then for any category `A` with coequalizers of reflexive
 pairs, a functor `R : A ⥤ B` has a left adjoint if (and only if) the composite `R ⋙ U` does.
 Note that the condition on `U` regarding `ε_X` is automatically satisfied in the case when `U` is
-a monadic functor, giving the corollary: `monadicAdjointTriangleLift`, i.e. if `U` is monadic,
-`A` has reflexive coequalizers then `R : A ⥤ B` has a left adjoint provided `R ⋙ U` does.
+a monadic functor, giving the corollary: `isRightAdjoint_triangle_lift_monadic`, i.e. if `U` is
+monadic, `A` has reflexive coequalizers then `R : A ⥤ B` has a left adjoint provided `R ⋙ U` does.
 
 The adjoint lifting theorem says that given a commutative square of functors (up to isomorphism):
 
@@ -38,10 +38,12 @@ than just a functor known to be a right adjoint. In docstrings, we write `(η, �
 and counit of the adjunction `adj₁ : F ⊣ U` and `(ι, δ)` for the unit and counit of the adjunction
 `adj₂ : F' ⊣ R ⋙ U`.
 
+This file has been adapted to `Mathlib.CategoryTheory.Adjunction.Lifting.Right`.
+Please try to keep them in sync.
+
 ## TODO
 
-Dualise to lift right adjoints through comonads (by reversing 1-cells) and dualise to lift right
-adjoints through monads (by reversing 2-cells), and the combination.
+Dualise to lift right adjoints through monads (by reversing 2-cells).
 
 ## References
 * https://ncatlab.org/nlab/show/adjoint+triangle+theorem
@@ -61,7 +63,7 @@ variable {A : Type u₁} {B : Type u₂} {C : Type u₃}
 variable [Category.{v₁} A] [Category.{v₂} B] [Category.{v₃} C]
 
 -- Hide implementation details in this namespace
-namespace LiftAdjoint
+namespace LiftLeftAdjoint
 
 variable {U : B ⥤ C} {F : C ⥤ B} (R : A ⥤ B) (F' : C ⥤ A)
 variable (adj₁ : F ⊣ U) (adj₂ : F' ⊣ R ⋙ U)
@@ -96,7 +98,7 @@ def otherMap (X) : F'.obj (U.obj (F.obj (U.obj X))) ⟶ F'.obj (U.obj X) :=
   F'.map (U.map (F.map (adj₂.unit.app _) ≫ adj₁.counit.app _)) ≫ adj₂.counit.app _
 
 /-- `(F'Uε_X, otherMap X)` is a reflexive pair: in particular if `A` has reflexive coequalizers then
-it has a coequalizer.
+this pair has a coequalizer.
 -/
 instance (X : B) :
     IsReflexivePair (F'.map (U.map (adj₁.counit.app X))) (otherMap _ _ adj₁ adj₂ X) :=
@@ -159,7 +161,7 @@ noncomputable def constructLeftAdjoint [∀ X : B, RegularEpi (adj₁.counit.app
   -- This used to be `simp`, but we need `aesop_cat` after leanprover/lean4#2644
   aesop_cat
 
-end LiftAdjoint
+end LiftLeftAdjoint
 
 /-- The adjoint triangle theorem: Suppose `U : B ⥤ C` has a left adjoint `F` such that each counit
 `ε_X : FUX ⟶ X` is a regular epimorphism. Then if a category `A` has coequalizers of reflexive
@@ -168,18 +170,18 @@ pairs, then a functor `R : A ⥤ B` has a left adjoint if the composite `R ⋙ U
 Note the converse is true (with weaker assumptions), by `Adjunction.comp`.
 See https://ncatlab.org/nlab/show/adjoint+triangle+theorem
 -/
-lemma adjointTriangleLift {U : B ⥤ C} {F : C ⥤ B} (R : A ⥤ B) (adj₁ : F ⊣ U)
+lemma isRightAdjoint_triangle_lift {U : B ⥤ C} {F : C ⥤ B} (R : A ⥤ B) (adj₁ : F ⊣ U)
     [∀ X : B, RegularEpi (adj₁.counit.app X)] [HasReflexiveCoequalizers A]
     [(R ⋙ U).IsRightAdjoint ] : R.IsRightAdjoint where
   exists_leftAdjoint :=
-    ⟨LiftAdjoint.constructLeftAdjoint R _ adj₁ (Adjunction.ofIsRightAdjoint _),
+    ⟨LiftLeftAdjoint.constructLeftAdjoint R _ adj₁ (Adjunction.ofIsRightAdjoint _),
       ⟨Adjunction.adjunctionOfEquivLeft _ _⟩⟩
 
 /-- If `R ⋙ U` has a left adjoint, the domain of `R` has reflexive coequalizers and `U` is a monadic
 functor, then `R` has a left adjoint.
-This is a special case of `adjointTriangleLift` which is often more useful in practice.
+This is a special case of `isRightAdjoint_triangle_lift` which is often more useful in practice.
 -/
-lemma monadicAdjointTriangleLift (U : B ⥤ C) [MonadicRightAdjoint U] {R : A ⥤ B}
+lemma isRightAdjoint_triangle_lift_monadic (U : B ⥤ C) [MonadicRightAdjoint U] {R : A ⥤ B}
     [HasReflexiveCoequalizers A] [(R ⋙ U).IsRightAdjoint] : R.IsRightAdjoint := by
   let R' : A ⥤ _ := R ⋙ Monad.comparison (monadicAdjunction U)
   rsuffices : R'.IsRightAdjoint
@@ -195,7 +197,7 @@ lemma monadicAdjointTriangleLift (U : B ⥤ C) [MonadicRightAdjoint U] {R : A �
     intro X
     simp only [Monad.adj_counit]
     exact ⟨_, _, _, _, Monad.beckAlgebraCoequalizer X⟩
-  exact adjointTriangleLift R' (Monad.adj _)
+  exact isRightAdjoint_triangle_lift R' (Monad.adj _)
 
 variable {D : Type u₄}
 variable [Category.{v₄} D]
@@ -214,12 +216,12 @@ Then `Q` has a left adjoint if `R` has a left adjoint.
 
 See https://ncatlab.org/nlab/show/adjoint+lifting+theorem
 -/
-lemma adjointSquareLift (Q : A ⥤ B) (V : B ⥤ D) (U : A ⥤ C) (R : C ⥤ D)
+lemma isRightAdjoint_square_lift (Q : A ⥤ B) (V : B ⥤ D) (U : A ⥤ C) (R : C ⥤ D)
     (comm : U ⋙ R ≅ Q ⋙ V) [U.IsRightAdjoint] [V.IsRightAdjoint] [R.IsRightAdjoint]
     [∀ X, RegularEpi ((Adjunction.ofIsRightAdjoint V).counit.app X)] [HasReflexiveCoequalizers A] :
     Q.IsRightAdjoint :=
   have := ((Adjunction.ofIsRightAdjoint (U ⋙ R)).ofNatIsoRight comm).isRightAdjoint
-  adjointTriangleLift Q (Adjunction.ofIsRightAdjoint V)
+  isRightAdjoint_triangle_lift Q (Adjunction.ofIsRightAdjoint V)
 
 /-- Suppose we have a commutative square of functors
 
@@ -234,10 +236,10 @@ Then `Q` has a left adjoint if `R` has a left adjoint.
 
 See https://ncatlab.org/nlab/show/adjoint+lifting+theorem
 -/
-lemma monadicAdjointSquareLift (Q : A ⥤ B) (V : B ⥤ D) (U : A ⥤ C) (R : C ⥤ D)
+lemma isRightAdjoint_square_lift_monadic (Q : A ⥤ B) (V : B ⥤ D) (U : A ⥤ C) (R : C ⥤ D)
     (comm : U ⋙ R ≅ Q ⋙ V) [U.IsRightAdjoint] [MonadicRightAdjoint V] [R.IsRightAdjoint]
     [HasReflexiveCoequalizers A] : Q.IsRightAdjoint :=
   have := ((Adjunction.ofIsRightAdjoint (U ⋙ R)).ofNatIsoRight comm).isRightAdjoint
-  monadicAdjointTriangleLift V
+  isRightAdjoint_triangle_lift_monadic V
 
 end CategoryTheory

--- a/Mathlib/CategoryTheory/Adjunction/Lifting/Left.lean
+++ b/Mathlib/CategoryTheory/Adjunction/Lifting/Left.lean
@@ -3,8 +3,6 @@ Copyright (c) 2020 Bhavik Mehta. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Bhavik Mehta
 -/
-import Mathlib.CategoryTheory.Limits.Shapes.Equalizers
-import Mathlib.CategoryTheory.Limits.Shapes.Reflexive
 import Mathlib.CategoryTheory.Monad.Adjunction
 import Mathlib.CategoryTheory.Monad.Coequalizer
 

--- a/Mathlib/CategoryTheory/Adjunction/Lifting/Left.lean
+++ b/Mathlib/CategoryTheory/Adjunction/Lifting/Left.lean
@@ -43,7 +43,9 @@ Please try to keep them in sync.
 
 ## TODO
 
-Dualise to lift right adjoints through monads (by reversing 2-cells).
+- Dualise to lift right adjoints through monads (by reversing 2-cells).
+- Investigate whether it is possible to give a more explicit description of the lifted adjoint,
+  especially in the case when the isomorphism `comm` is `Iso.refl _`
 
 ## References
 * https://ncatlab.org/nlab/show/adjoint+triangle+theorem

--- a/Mathlib/CategoryTheory/Adjunction/Lifting/Left.lean
+++ b/Mathlib/CategoryTheory/Adjunction/Lifting/Left.lean
@@ -11,6 +11,7 @@ import Mathlib.CategoryTheory.Monad.Coequalizer
 
 This file gives two constructions for building left adjoints: the adjoint triangle theorem and the
 adjoint lifting theorem.
+
 The adjoint triangle theorem concerns a functor `U : B ⥤ C` with a left adjoint `F` such
 that `ε_X : FUX ⟶ X` is a regular epi. Then for any category `A` with coequalizers of reflexive
 pairs, a functor `R : A ⥤ B` has a left adjoint if (and only if) the composite `R ⋙ U` does.
@@ -20,14 +21,16 @@ monadic, `A` has reflexive coequalizers then `R : A ⥤ B` has a left adjoint pr
 
 The adjoint lifting theorem says that given a commutative square of functors (up to isomorphism):
 
+```
       Q
     A → B
   U ↓   ↓ V
     C → D
       R
+```
 
-where `U` and `V` are monadic and `A` has reflexive coequalizers, then if `R` has a left adjoint
-then `Q` has a left adjoint.
+where `V` is monadic, `U` has a left adjoint, and `A` has reflexive coequalizers, then if `R` has a
+left adjoint then `Q` has a left adjoint.
 
 ## Implementation
 
@@ -204,11 +207,13 @@ variable [Category.{v₄} D]
 
 /-- Suppose we have a commutative square of functors
 
+```
       Q
     A → B
   U ↓   ↓ V
     C → D
       R
+```
 
 where `U` has a left adjoint, `A` has reflexive coequalizers and `V` has a left adjoint such that
 each component of the counit is a regular epi.
@@ -225,11 +230,13 @@ lemma isRightAdjoint_square_lift (Q : A ⥤ B) (V : B ⥤ D) (U : A ⥤ C) (R : 
 
 /-- Suppose we have a commutative square of functors
 
+```
       Q
     A → B
   U ↓   ↓ V
     C → D
       R
+```
 
 where `U` has a left adjoint, `A` has reflexive coequalizers and `V` is monadic.
 Then `Q` has a left adjoint if `R` has a left adjoint.

--- a/Mathlib/CategoryTheory/Adjunction/Lifting/Right.lean
+++ b/Mathlib/CategoryTheory/Adjunction/Lifting/Right.lean
@@ -3,8 +3,6 @@ Copyright (c) 2024 Dagur Asgeirsson. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Dagur Asgeirsson
 -/
-import Mathlib.CategoryTheory.Limits.Shapes.Equalizers
-import Mathlib.CategoryTheory.Limits.Shapes.Reflexive
 import Mathlib.CategoryTheory.Monad.Adjunction
 import Mathlib.CategoryTheory.Monad.Equalizer
 

--- a/Mathlib/CategoryTheory/Adjunction/Lifting/Right.lean
+++ b/Mathlib/CategoryTheory/Adjunction/Lifting/Right.lean
@@ -1,0 +1,239 @@
+/-
+Copyright (c) 2024 Dagur Asgeirsson. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Dagur Asgeirsson
+-/
+import Mathlib.CategoryTheory.Limits.Shapes.Equalizers
+import Mathlib.CategoryTheory.Limits.Shapes.Reflexive
+import Mathlib.CategoryTheory.Monad.Adjunction
+import Mathlib.CategoryTheory.Monad.Equalizer
+
+/-!
+# Adjoint lifting
+
+This file gives two constructions for building right adjoints: the adjoint triangle theorem and the
+adjoint lifting theorem.
+
+The adjoint triangle theorem concerns a functor `F : B ⥤ A` with a right adjoint `U` such
+that `η_X : X ⟶ UFX` is a regular mono. Then for any category `C` with equalizers of coreflexive
+pairs, a functor `L : C ⥤ B` has a right adjoint if (and only if) the composite `L ⋙ F` does.
+Note that the condition on `F` regarding `η_X` is automatically satisfied in the case when `F` is
+a comonadic functor, giving the corollary: `isLeftAdjoint_triangle_lift_comonadic`, i.e. if `F` is
+comonadic, `C` has coreflexive equalizers then `L : C ⥤ B` has a right adjoint provided `L ⋙ F`
+does.
+
+The adjoint lifting theorem says that given a commutative square of functors (up to isomorphism):
+
+      Q
+    A → B
+  U ↓   ↓ V
+    C → D
+      L
+
+where `V` is comonadic, `U` has a right adjoint and `A` has coreflexive equalizers, then if `L` has
+a right adjoint then `Q` has a right adjoint.
+
+## Implementation
+
+It is more convenient to prove this theorem by assuming we are given the explicit adjunction rather
+than just a functor known to be a right adjoint. In docstrings, we write `(η, ε)` for the unit
+and counit of the adjunction `adj₁ : F ⊣ U` and `(ι, δ)` for the unit and counit of the adjunction
+`adj₂ : L ⋙ F ⊣ U'`.
+
+This file has been adapted from `Mathlib.CategoryTheory.Adjunction.Lifting.Left`.
+Please try to keep them in sync.
+
+## TODO
+
+Dualise to lift left adjoints through comonads (by reversing 2-cells).
+
+## References
+* https://ncatlab.org/nlab/show/adjoint+triangle+theorem
+* https://ncatlab.org/nlab/show/adjoint+lifting+theorem
+* Adjoint Lifting Theorems for Categories of Algebras (PT Johnstone, 1975)
+* A unified approach to the lifting of adjoints (AJ Power, 1988)
+-/
+
+
+namespace CategoryTheory
+
+open Category Limits
+
+universe v₁ v₂ v₃ v₄ u₁ u₂ u₃ u₄
+
+variable {A : Type u₁} {B : Type u₂} {C : Type u₃}
+variable [Category.{v₁} A] [Category.{v₂} B] [Category.{v₃} C]
+
+-- Hide implementation details in this namespace
+namespace LiftRightAdjoint
+
+variable {U : A ⥤ B} {F : B ⥤ A} (L : C ⥤ B) (U' : A ⥤ C)
+variable (adj₁ : F ⊣ U) (adj₂ : L ⋙ F ⊣ U')
+
+/-- To show that `η_X` is an equalizer for `(UFη_X, η_UFX)`, it suffices to assume it's always an
+equalizer of something (i.e. a regular mono).
+-/
+def unitEqualises [∀ X : B, RegularMono (adj₁.unit.app X)] (X : B) :
+    IsLimit (Fork.ofι (adj₁.unit.app X) (adj₁.unit_naturality _)) :=
+  Fork.IsLimit.mk' _ fun s => by
+    refine ⟨(RegularMono.lift' (adj₁.unit.app X) s.ι ?_).1, ?_, ?_⟩
+    · rw [← cancel_mono (adj₁.unit.app (RegularMono.Z (adj₁.unit.app X)))]
+      rw [assoc, ← adj₁.unit_naturality RegularMono.left]
+      dsimp only [Functor.comp_obj]
+      erw [← assoc, ← s.condition, assoc, ← U.map_comp, ← F.map_comp, RegularMono.w, F.map_comp,
+        U.map_comp, s.condition_assoc, assoc, ← adj₁.unit_naturality RegularMono.right]
+      rfl
+    · apply (RegularMono.lift' (adj₁.unit.app X) s.ι _).2
+    · intro m hm
+      rw [← cancel_mono (adj₁.unit.app X)]
+      apply hm.trans (RegularMono.lift' (adj₁.unit.app X) s.ι _).2.symm
+
+/-- (Implementation)
+To construct the left adjoint, we use the coequalizer of `U' F η_X` with the composite
+
+`U' F X ⟶ U' F L U' F X ⟶ U' F U F L U' F X ⟶ U' F U F X`
+
+where the first morphism is `ι_U'FX`, the second is `U' F η_LU'FX` and the third is `U' F U δ_FX`.
+We will show that this equalizer exists and that it forms the object map for a right adjoint to `L`.
+-/
+def otherMap (X : B) : U'.obj (F.obj X) ⟶  U'.obj (F.obj (U.obj (F.obj X))) :=
+  adj₂.unit.app _ ≫ U'.map (F.map (adj₁.unit.app _ ≫ (U.map (adj₂.counit.app _))))
+
+/-- `(U'Fη_X, otherMap X)` is a coreflexive pair: in particular if `C` has coreflexive equalizers
+then this pair has an equalizer.
+-/
+instance (X : B) :
+    IsCoreflexivePair (U'.map (F.map (adj₁.unit.app X))) (otherMap _ _ adj₁ adj₂ X) :=
+  IsCoreflexivePair.mk' (U'.map (adj₁.counit.app (F.obj X)))
+    (by simp [← Functor.map_comp])
+    (by simp only [otherMap, assoc, ← Functor.map_comp]; simp)
+
+variable [HasCoreflexiveEqualizers C]
+
+/-- Construct the object part of the desired right adjoint as the equalizer of `U'Fη_Y` with
+`otherMap`.
+-/
+noncomputable def constructRightAdjointObj (Y : B) : C :=
+  equalizer (U'.map (F.map (adj₁.unit.app Y))) (otherMap _ _ adj₁ adj₂ Y)
+
+/-- The homset equivalence which helps show that `L` is a left adjoint. -/
+@[simps!]
+noncomputable def constructRightAdjointEquiv [∀ X : B, RegularMono (adj₁.unit.app X)] (Y : C)
+    (X : B) : (Y ⟶ constructRightAdjointObj _ _ adj₁ adj₂ X) ≃ (L.obj Y ⟶ X) :=
+  calc
+    (Y ⟶ constructRightAdjointObj _ _ adj₁ adj₂ X) ≃
+        { f : Y ⟶ U'.obj (F.obj X) //
+          f ≫ U'.map (F.map (adj₁.unit.app X)) = f ≫ (otherMap _ _ adj₁ adj₂ X) } :=
+      Fork.IsLimit.homIso (limit.isLimit _) _
+    _ ≃ { g : F.obj (L.obj Y) ⟶ F.obj X // F.map (adj₁.unit.app _≫ U.map g) =
+        g ≫ F.map (adj₁.unit.app _) } := by
+      apply (adj₂.homEquiv _ _).symm.subtypeEquiv _
+      intro f
+      rw [← (adj₂.homEquiv _ _).injective.eq_iff, eq_comm, otherMap,
+        ← adj₂.homEquiv_naturality_right_symm, adj₂.homEquiv_unit, ← adj₂.unit_naturality_assoc,
+        adj₂.homEquiv_counit]
+      simp
+    _ ≃ { z : L.obj Y ⟶ U.obj (F.obj X) //
+        z ≫ U.map (F.map (adj₁.unit.app X)) = z ≫ adj₁.unit.app (U.obj (F.obj X)) } := by
+      apply (adj₁.homEquiv _ _).subtypeEquiv
+      intro g
+      rw [← (adj₁.homEquiv _ _).injective.eq_iff, adj₁.homEquiv_unit,
+        adj₁.homEquiv_unit, adj₁.homEquiv_unit, eq_comm]
+      simp
+    _ ≃ (L.obj Y ⟶ X) := (Fork.IsLimit.homIso (unitEqualises adj₁ X) _).symm
+
+/-- Construct the right adjoint to `L`, with object map `constructRightAdjointObj`. -/
+noncomputable def constructRightAdjoint [∀ X : B, RegularMono (adj₁.unit.app X)] : B ⥤ C := by
+  refine Adjunction.rightAdjointOfEquiv
+    (fun X Y => (constructRightAdjointEquiv L _ adj₁ adj₂ X Y).symm) ?_
+  intro X Y Y' g h
+  rw [constructRightAdjointEquiv_symm_apply, constructRightAdjointEquiv_symm_apply,
+    Equiv.symm_apply_eq, Subtype.ext_iff]
+  dsimp
+  erw [Fork.IsLimit.homIso_natural, Fork.IsLimit.homIso_natural]
+  simp only [Fork.ofι_pt, Functor.map_comp, assoc, limit.cone_x]
+  erw [adj₂.homEquiv_naturality_left, Equiv.rightInverse_symm]
+  simp
+
+end LiftRightAdjoint
+
+/-- The adjoint triangle theorem: Suppose `U : B ⥤ C` has a left adjoint `F` such that each counit
+`ε_X : FUX ⟶ X` is a regular epimorphism. Then if a category `A` has coequalizers of reflexive
+pairs, then a functor `R : A ⥤ B` has a left adjoint if the composite `R ⋙ U` does.
+
+Note the converse is true (with weaker assumptions), by `Adjunction.comp`.
+See https://ncatlab.org/nlab/show/adjoint+triangle+theorem
+-/
+lemma isLeftAdjoint_triangle_lift  {U : A ⥤ B} {F : B ⥤ A} (L : C ⥤ B) (adj₁ : F ⊣ U)
+    [∀ X, RegularMono (adj₁.unit.app X)] [HasCoreflexiveEqualizers C]
+    [(L ⋙ F).IsLeftAdjoint ] : L.IsLeftAdjoint where
+  exists_rightAdjoint :=
+    ⟨LiftRightAdjoint.constructRightAdjoint L _ adj₁ (Adjunction.ofIsLeftAdjoint _),
+      ⟨Adjunction.adjunctionOfEquivRight _ _⟩⟩
+
+/-- If `R ⋙ U` has a left adjoint, the domain of `R` has reflexive coequalizers and `U` is a monadic
+functor, then `R` has a left adjoint.
+This is a special case of `isLeftAdjoint_triangle_lift` which is often more useful in practice.
+-/
+lemma isLeftAdjoint_triangle_lift_comonadic (F : B ⥤ A) [ComonadicLeftAdjoint F] {L : C ⥤ B}
+    [HasCoreflexiveEqualizers C] [(L ⋙ F).IsLeftAdjoint] : L.IsLeftAdjoint := by
+  let L' : _ ⥤ _ := L ⋙ Comonad.comparison (comonadicAdjunction F)
+  rsuffices : L'.IsLeftAdjoint
+  · let this : (L' ⋙ (Comonad.comparison (comonadicAdjunction F)).inv).IsLeftAdjoint := by
+      infer_instance
+    refine ((Adjunction.ofIsLeftAdjoint
+      (L' ⋙ (Comonad.comparison (comonadicAdjunction F)).inv)).ofNatIsoLeft ?_).isLeftAdjoint
+    exact isoWhiskerLeft L (Comonad.comparison _).asEquivalence.unitIso.symm ≪≫ L.leftUnitor
+  let this : (L' ⋙ Comonad.forget (comonadicAdjunction F).toComonad).IsLeftAdjoint := by
+    refine ((Adjunction.ofIsLeftAdjoint (L ⋙ F)).ofNatIsoLeft ?_).isLeftAdjoint
+    exact isoWhiskerLeft L (Comonad.comparisonForget (comonadicAdjunction F)).symm
+  let this : ∀ X, RegularMono ((Comonad.adj (comonadicAdjunction F).toComonad).unit.app X) := by
+    intro X
+    simp only [Comonad.adj_unit]
+    exact ⟨_, _, _, _, Comonad.beckCoalgebraEqualizer X⟩
+  exact isLeftAdjoint_triangle_lift L' (Comonad.adj _)
+
+variable {D : Type u₄}
+variable [Category.{v₄} D]
+
+/-- Suppose we have a commutative square of functors
+
+      Q
+    A → B
+  U ↓   ↓ V
+    C → D
+      R
+
+where `U` has a left adjoint, `A` has reflexive coequalizers and `V` has a left adjoint such that
+each component of the counit is a regular epi.
+Then `Q` has a left adjoint if `R` has a left adjoint.
+
+See https://ncatlab.org/nlab/show/adjoint+lifting+theorem
+-/
+lemma isLeftAdjoint_square_lift (Q : A ⥤ B) (V : B ⥤ D) (U : A ⥤ C) (L : C ⥤ D)
+    (comm : U ⋙ L ≅ Q ⋙ V) [U.IsLeftAdjoint] [V.IsLeftAdjoint] [L.IsLeftAdjoint]
+    [∀ X, RegularMono ((Adjunction.ofIsLeftAdjoint V).unit.app X)] [HasCoreflexiveEqualizers A] :
+    Q.IsLeftAdjoint :=
+  have := ((Adjunction.ofIsLeftAdjoint (U ⋙ L)).ofNatIsoLeft comm).isLeftAdjoint
+  isLeftAdjoint_triangle_lift Q (Adjunction.ofIsLeftAdjoint V)
+
+/-- Suppose we have a commutative square of functors
+
+      Q
+    A → B
+  U ↓   ↓ V
+    C → D
+      R
+
+where `U` has a left adjoint, `A` has reflexive coequalizers and `V` is monadic.
+Then `Q` has a left adjoint if `R` has a left adjoint.
+
+See https://ncatlab.org/nlab/show/adjoint+lifting+theorem
+-/
+lemma isLeftAdjoint_square_lift_comonadic (Q : A ⥤ B) (V : B ⥤ D) (U : A ⥤ C) (L : C ⥤ D)
+    (comm : U ⋙ L ≅ Q ⋙ V) [U.IsLeftAdjoint] [ComonadicLeftAdjoint V] [L.IsLeftAdjoint]
+    [HasCoreflexiveEqualizers A] : Q.IsLeftAdjoint :=
+  have := ((Adjunction.ofIsLeftAdjoint (U ⋙ L)).ofNatIsoLeft comm).isLeftAdjoint
+  isLeftAdjoint_triangle_lift_comonadic V
+
+end CategoryTheory

--- a/Mathlib/CategoryTheory/Adjunction/Lifting/Right.lean
+++ b/Mathlib/CategoryTheory/Adjunction/Lifting/Right.lean
@@ -45,7 +45,9 @@ Please try to keep them in sync.
 
 ## TODO
 
-Dualise to lift left adjoints through comonads (by reversing 2-cells).
+- Dualise to lift left adjoints through comonads (by reversing 2-cells).
+- Investigate whether it is possible to give a more explicit description of the lifted adjoint,
+  especially in the case when the isomorphism `comm` is `Iso.refl _`
 
 ## References
 * https://ncatlab.org/nlab/show/adjoint+triangle+theorem

--- a/Mathlib/CategoryTheory/Adjunction/Lifting/Right.lean
+++ b/Mathlib/CategoryTheory/Adjunction/Lifting/Right.lean
@@ -22,13 +22,15 @@ does.
 
 The adjoint lifting theorem says that given a commutative square of functors (up to isomorphism):
 
+```
       Q
     A → B
   U ↓   ↓ V
     C → D
       L
+```
 
-where `V` is comonadic, `U` has a right adjoint and `A` has coreflexive equalizers, then if `L` has
+where `V` is comonadic, `U` has a right adjoint, and `A` has coreflexive equalizers, then if `L` has
 a right adjoint then `Q` has a right adjoint.
 
 ## Implementation
@@ -157,8 +159,8 @@ noncomputable def constructRightAdjoint [∀ X : B, RegularMono (adj₁.unit.app
 
 end LiftRightAdjoint
 
-/-- The adjoint triangle theorem: Suppose `U : A ⥤ B` has a left adjoint `F` such that each counit
-`ε_X : FUX ⟶ X` is a regular epimorphism. Then if a category `C` has equalizers of coreflexive
+/-- The adjoint triangle theorem: Suppose `U : A ⥤ B` has a left adjoint `F` such that each unit
+`η_X : X ⟶ UFX` is a regular monomorphism. Then if a category `C` has equalizers of coreflexive
 pairs, then a functor `L : C ⥤ B` has a right adjoint if the composite `L ⋙ F` does.
 
 Note the converse is true (with weaker assumptions), by `Adjunction.comp`.
@@ -171,7 +173,7 @@ lemma isLeftAdjoint_triangle_lift {U : A ⥤ B} {F : B ⥤ A} (L : C ⥤ B) (adj
     ⟨LiftRightAdjoint.constructRightAdjoint L _ adj₁ (Adjunction.ofIsLeftAdjoint _),
       ⟨Adjunction.adjunctionOfEquivRight _ _⟩⟩
 
-/-- If `L ⋙ U` has a right adjoint, the domain of `R` has coreflexive equalizers and `U` is a
+/-- If `L ⋙ F` has a right adjoint, the domain of `L` has coreflexive equalizers and `F` is a
 comonadic functor, then `L` has a right adjoint.
 This is a special case of `isLeftAdjoint_triangle_lift` which is often more useful in practice.
 -/
@@ -198,11 +200,13 @@ variable [Category.{v₄} D]
 
 /-- Suppose we have a commutative square of functors
 
+```
       Q
     A → B
   U ↓   ↓ V
     C → D
       R
+```
 
 where `U` has a right adjoint, `A` has coreflexive equalizers and `V` has a right adjoint such that
 each component of the counit is a regular mono.
@@ -219,11 +223,13 @@ lemma isLeftAdjoint_square_lift (Q : A ⥤ B) (V : B ⥤ D) (U : A ⥤ C) (L : C
 
 /-- Suppose we have a commutative square of functors
 
+```
       Q
     A → B
   U ↓   ↓ V
     C → D
       R
+```
 
 where `U` has a right adjoint, `A` has reflexive equalizers and `V` is comonadic.
 Then `Q` has a right adjoint if `L` has a right adjoint.

--- a/Mathlib/CategoryTheory/Adjunction/Lifting/Right.lean
+++ b/Mathlib/CategoryTheory/Adjunction/Lifting/Right.lean
@@ -89,7 +89,7 @@ def unitEqualises [∀ X : B, RegularMono (adj₁.unit.app X)] (X : B) :
       apply hm.trans (RegularMono.lift' (adj₁.unit.app X) s.ι _).2.symm
 
 /-- (Implementation)
-To construct the left adjoint, we use the coequalizer of `U' F η_X` with the composite
+To construct the right adjoint, we use the equalizer of `U' F η_X` with the composite
 
 `U' F X ⟶ U' F L U' F X ⟶ U' F U F L U' F X ⟶ U' F U F X`
 
@@ -157,22 +157,22 @@ noncomputable def constructRightAdjoint [∀ X : B, RegularMono (adj₁.unit.app
 
 end LiftRightAdjoint
 
-/-- The adjoint triangle theorem: Suppose `U : B ⥤ C` has a left adjoint `F` such that each counit
-`ε_X : FUX ⟶ X` is a regular epimorphism. Then if a category `A` has coequalizers of reflexive
-pairs, then a functor `R : A ⥤ B` has a left adjoint if the composite `R ⋙ U` does.
+/-- The adjoint triangle theorem: Suppose `U : A ⥤ B` has a left adjoint `F` such that each counit
+`ε_X : FUX ⟶ X` is a regular epimorphism. Then if a category `C` has equalizers of coreflexive
+pairs, then a functor `L : C ⥤ B` has a right adjoint if the composite `L ⋙ F` does.
 
 Note the converse is true (with weaker assumptions), by `Adjunction.comp`.
 See https://ncatlab.org/nlab/show/adjoint+triangle+theorem
 -/
-lemma isLeftAdjoint_triangle_lift  {U : A ⥤ B} {F : B ⥤ A} (L : C ⥤ B) (adj₁ : F ⊣ U)
+lemma isLeftAdjoint_triangle_lift {U : A ⥤ B} {F : B ⥤ A} (L : C ⥤ B) (adj₁ : F ⊣ U)
     [∀ X, RegularMono (adj₁.unit.app X)] [HasCoreflexiveEqualizers C]
     [(L ⋙ F).IsLeftAdjoint ] : L.IsLeftAdjoint where
   exists_rightAdjoint :=
     ⟨LiftRightAdjoint.constructRightAdjoint L _ adj₁ (Adjunction.ofIsLeftAdjoint _),
       ⟨Adjunction.adjunctionOfEquivRight _ _⟩⟩
 
-/-- If `R ⋙ U` has a left adjoint, the domain of `R` has reflexive coequalizers and `U` is a monadic
-functor, then `R` has a left adjoint.
+/-- If `L ⋙ U` has a right adjoint, the domain of `R` has coreflexive equalizers and `U` is a
+comonadic functor, then `L` has a right adjoint.
 This is a special case of `isLeftAdjoint_triangle_lift` which is often more useful in practice.
 -/
 lemma isLeftAdjoint_triangle_lift_comonadic (F : B ⥤ A) [ComonadicLeftAdjoint F] {L : C ⥤ B}
@@ -204,9 +204,9 @@ variable [Category.{v₄} D]
     C → D
       R
 
-where `U` has a left adjoint, `A` has reflexive coequalizers and `V` has a left adjoint such that
-each component of the counit is a regular epi.
-Then `Q` has a left adjoint if `R` has a left adjoint.
+where `U` has a right adjoint, `A` has coreflexive equalizers and `V` has a right adjoint such that
+each component of the counit is a regular mono.
+Then `Q` has a right adjoint if `L` has a right adjoint.
 
 See https://ncatlab.org/nlab/show/adjoint+lifting+theorem
 -/
@@ -225,8 +225,8 @@ lemma isLeftAdjoint_square_lift (Q : A ⥤ B) (V : B ⥤ D) (U : A ⥤ C) (L : C
     C → D
       R
 
-where `U` has a left adjoint, `A` has reflexive coequalizers and `V` is monadic.
-Then `Q` has a left adjoint if `R` has a left adjoint.
+where `U` has a right adjoint, `A` has reflexive equalizers and `V` is comonadic.
+Then `Q` has a right adjoint if `L` has a right adjoint.
 
 See https://ncatlab.org/nlab/show/adjoint+lifting+theorem
 -/


### PR DESCRIPTION
This PR renames the file `CategoryTheory.Adjunction.Lifting` to `CategoryTheory.Adjunction.Lifting.Left` and dualizes it in a new file `CategoryTheory.Adjunction.Lifting.Right` to lift right adjoints through comonads.

It also changes some names in the original file which didn't follow naming conventions, as well as renaming the implementation namespace.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
