### PR TITLE
feat: use junk value in `Kernel.map`

### DIFF
--- a/Mathlib/MeasureTheory/Constructions/Polish/EmbeddingReal.lean
+++ b/Mathlib/MeasureTheory/Constructions/Polish/EmbeddingReal.lean
@@ -63,4 +63,9 @@ lemma measurableEmbedding_embeddingReal (Ω : Type*) [MeasurableSpace Ω] [Stand
     MeasurableEmbedding (embeddingReal Ω) :=
   (exists_measurableEmbedding_real Ω).choose_spec
 
+@[fun_prop]
+lemma measurable_embeddingReal (Ω : Type*) [MeasurableSpace Ω] [StandardBorelSpace Ω] :
+    Measurable (embeddingReal Ω) :=
+  (measurableEmbedding_embeddingReal Ω).measurable
+
 end MeasureTheory

--- a/Mathlib/MeasureTheory/MeasurableSpace/Basic.lean
+++ b/Mathlib/MeasureTheory/MeasurableSpace/Basic.lean
@@ -661,6 +661,7 @@ theorem Measurable.prod_mk {β γ} {_ : MeasurableSpace β} {_ : MeasurableSpace
     {g : α → γ} (hf : Measurable f) (hg : Measurable g) : Measurable fun a : α => (f a, g a) :=
   Measurable.prod hf hg
 
+@[fun_prop]
 theorem Measurable.prod_map [MeasurableSpace δ] {f : α → β} {g : γ → δ} (hf : Measurable f)
     (hg : Measurable g) : Measurable (Prod.map f g) :=
   (hf.comp measurable_fst).prod_mk (hg.comp measurable_snd)

--- a/Mathlib/Probability/Kernel/Composition.lean
+++ b/Mathlib/Probability/Kernel/Composition.lean
@@ -617,6 +617,10 @@ theorem map_of_not_measurable (κ : Kernel α β) {f : β → γ} (hf : ¬(Measu
     map κ f = map κ (fun _ ↦ defaultOfNotMeasurable f hf) := by
   simp [map, hf]
 
+@[simp] theorem mapOfMeasurable_eq_map (κ : Kernel α β) {f : β → γ} (hf : Measurable f) :
+    mapOfMeasurable κ f hf = map κ f := by
+  simp [map, hf]
+
 theorem map_apply (κ : Kernel α β) (hf : Measurable f) (a : α) : map κ f a = (κ a).map f := by
   simp only [map, hf, ↓reduceDIte, mapOfMeasurable]
   rfl
@@ -897,13 +901,14 @@ instance IsFiniteKernel.swapRight (κ : Kernel α (β × γ)) [IsFiniteKernel κ
 instance IsSFiniteKernel.swapRight (κ : Kernel α (β × γ)) [IsSFiniteKernel κ] :
     IsSFiniteKernel (swapRight κ) := by rw [Kernel.swapRight]; infer_instance
 
-/-- Define a `Kernel α β` from a `Kernel α (β × γ)` by taking the map of the first projection. -/
+/-- Define a `Kernel α β` from a `Kernel α (β × γ)` by taking the map of the first projection.
+We use `mapOfMeasurable` for better defeqs. -/
 noncomputable def fst (κ : Kernel α (β × γ)) : Kernel α β :=
-  map κ Prod.fst
+  mapOfMeasurable κ Prod.fst measurable_fst
 
-theorem fst_apply (κ : Kernel α (β × γ)) (a : α) : fst κ a = (κ a).map Prod.fst := by
-  simp only [fst, map, measurable_fst, ↓reduceDIte]
-  rfl
+theorem fst_eq (κ : Kernel α (β × γ)) : fst κ = map κ Prod.fst := by simp [fst]
+
+theorem fst_apply (κ : Kernel α (β × γ)) (a : α) : fst κ a = (κ a).map Prod.fst := rfl
 
 theorem fst_apply' (κ : Kernel α (β × γ)) (a : α) {s : Set β} (hs : MeasurableSet s) :
     fst κ a s = κ a {p | p.1 ∈ s} := by rw [fst_apply, Measure.map_apply measurable_fst hs]; rfl
@@ -914,16 +919,16 @@ lemma fst_zero : fst (0 : Kernel α (β × γ)) = 0 := by
 
 theorem lintegral_fst (κ : Kernel α (β × γ)) (a : α) {g : β → ℝ≥0∞} (hg : Measurable g) :
     ∫⁻ c, g c ∂fst κ a = ∫⁻ bc : β × γ, g bc.fst ∂κ a := by
-  rw [fst, lintegral_map _ measurable_fst a hg]
+  rw [fst_eq, lintegral_map _ measurable_fst a hg]
 
 instance IsMarkovKernel.fst (κ : Kernel α (β × γ)) [IsMarkovKernel κ] : IsMarkovKernel (fst κ) := by
-  rw [Kernel.fst]; infer_instance
+  rw [Kernel.fst_eq]; infer_instance
 
 instance IsFiniteKernel.fst (κ : Kernel α (β × γ)) [IsFiniteKernel κ] : IsFiniteKernel (fst κ) := by
-  rw [Kernel.fst]; infer_instance
+  rw [Kernel.fst_eq]; infer_instance
 
 instance IsSFiniteKernel.fst (κ : Kernel α (β × γ)) [IsSFiniteKernel κ] :
-    IsSFiniteKernel (fst κ) := by rw [Kernel.fst]; infer_instance
+    IsSFiniteKernel (fst κ) := by rw [Kernel.fst_eq]; infer_instance
 
 instance (priority := 100) isFiniteKernel_of_isFiniteKernel_fst {κ : Kernel α (β × γ)}
     [h : IsFiniteKernel (fst κ)] :
@@ -969,11 +974,12 @@ lemma fst_prodMkRight (κ : Kernel α (β × γ)) (δ : Type*) [MeasurableSpace 
 
 /-- Define a `Kernel α γ` from a `Kernel α (β × γ)` by taking the map of the second projection. -/
 noncomputable def snd (κ : Kernel α (β × γ)) : Kernel α γ :=
-  map κ Prod.snd
+  mapOfMeasurable κ Prod.snd measurable_snd
 
-theorem snd_apply (κ : Kernel α (β × γ)) (a : α) : snd κ a = (κ a).map Prod.snd := by
-  simp only [snd, map, measurable_snd, ↓reduceDIte]
-  rfl
+theorem snd_eq (κ : Kernel α (β × γ)) : snd κ = map κ Prod.snd := by
+  simp [snd]
+
+theorem snd_apply (κ : Kernel α (β × γ)) (a : α) : snd κ a = (κ a).map Prod.snd := rfl
 
 theorem snd_apply' (κ : Kernel α (β × γ)) (a : α) {s : Set γ} (hs : MeasurableSet s) :
     snd κ a s = κ a {p | p.2 ∈ s} := by rw [snd_apply, Measure.map_apply measurable_snd hs]; rfl
@@ -983,16 +989,16 @@ lemma snd_zero : snd (0 : Kernel α (β × γ)) = 0 := by simp [snd]
 
 theorem lintegral_snd (κ : Kernel α (β × γ)) (a : α) {g : γ → ℝ≥0∞} (hg : Measurable g) :
     ∫⁻ c, g c ∂snd κ a = ∫⁻ bc : β × γ, g bc.snd ∂κ a := by
-  rw [snd, lintegral_map _ measurable_snd a hg]
+  rw [snd_eq, lintegral_map _ measurable_snd a hg]
 
 instance IsMarkovKernel.snd (κ : Kernel α (β × γ)) [IsMarkovKernel κ] : IsMarkovKernel (snd κ) := by
-  rw [Kernel.snd]; infer_instance
+  rw [Kernel.snd_eq]; infer_instance
 
 instance IsFiniteKernel.snd (κ : Kernel α (β × γ)) [IsFiniteKernel κ] : IsFiniteKernel (snd κ) := by
-  rw [Kernel.snd]; infer_instance
+  rw [Kernel.snd_eq]; infer_instance
 
 instance IsSFiniteKernel.snd (κ : Kernel α (β × γ)) [IsSFiniteKernel κ] :
-    IsSFiniteKernel (snd κ) := by rw [Kernel.snd]; infer_instance
+    IsSFiniteKernel (snd κ) := by rw [Kernel.snd_eq]; infer_instance
 
 instance (priority := 100) isFiniteKernel_of_isFiniteKernel_snd {κ : Kernel α (β × γ)}
     [h : IsFiniteKernel (snd κ)] :

--- a/Mathlib/Probability/Kernel/Composition.lean
+++ b/Mathlib/Probability/Kernel/Composition.lean
@@ -974,7 +974,8 @@ lemma fst_prodMkLeft (δ : Type*) [MeasurableSpace δ] (κ : Kernel α (β × γ
 lemma fst_prodMkRight (κ : Kernel α (β × γ)) (δ : Type*) [MeasurableSpace δ] :
     fst (prodMkRight δ κ) = prodMkRight δ (fst κ) := rfl
 
-/-- Define a `Kernel α γ` from a `Kernel α (β × γ)` by taking the map of the second projection. -/
+/-- Define a `Kernel α γ` from a `Kernel α (β × γ)` by taking the map of the second projection.
+We use `mapOfMeasurable` for better defeqs. -/
 noncomputable def snd (κ : Kernel α (β × γ)) : Kernel α γ :=
   mapOfMeasurable κ Prod.snd measurable_snd
 

--- a/Mathlib/Probability/Kernel/Composition.lean
+++ b/Mathlib/Probability/Kernel/Composition.lean
@@ -876,12 +876,15 @@ instance IsSFiniteKernel.swapLeft (κ : Kernel (α × β) γ) [IsSFiniteKernel �
 @[simp] lemma swapLeft_prodMkRight (κ : Kernel α β) (γ : Type*) [MeasurableSpace γ] :
     swapLeft (prodMkRight γ κ) = prodMkLeft γ κ := rfl
 
-/-- Define a `Kernel α (γ × β)` from a `Kernel α (β × γ)` by taking the map of `Prod.swap`. -/
+/-- Define a `Kernel α (γ × β)` from a `Kernel α (β × γ)` by taking the map of `Prod.swap`.
+We use `mapOfMeasurable` in the definition for better defeqs. -/
 noncomputable def swapRight (κ : Kernel α (β × γ)) : Kernel α (γ × β) :=
-  map κ Prod.swap
+  mapOfMeasurable κ Prod.swap measurable_swap
 
-theorem swapRight_apply (κ : Kernel α (β × γ)) (a : α) : swapRight κ a = (κ a).map Prod.swap := by
-  simp only [swapRight, map, measurable_swap, ↓reduceDIte]
+lemma swapRight_eq (κ : Kernel α (β × γ)) : swapRight κ = map κ Prod.swap := by
+  simp [swapRight]
+
+theorem swapRight_apply (κ : Kernel α (β × γ)) (a : α) : swapRight κ a = (κ a).map Prod.swap :=
   rfl
 
 theorem swapRight_apply' (κ : Kernel α (β × γ)) (a : α) {s : Set (γ × β)} (hs : MeasurableSet s) :
@@ -890,16 +893,16 @@ theorem swapRight_apply' (κ : Kernel α (β × γ)) (a : α) {s : Set (γ × β
 
 theorem lintegral_swapRight (κ : Kernel α (β × γ)) (a : α) {g : γ × β → ℝ≥0∞} (hg : Measurable g) :
     ∫⁻ c, g c ∂swapRight κ a = ∫⁻ bc : β × γ, g bc.swap ∂κ a := by
-  rw [swapRight, lintegral_map _ measurable_swap a hg]
+  rw [swapRight_eq, lintegral_map _ measurable_swap a hg]
 
 instance IsMarkovKernel.swapRight (κ : Kernel α (β × γ)) [IsMarkovKernel κ] :
-    IsMarkovKernel (swapRight κ) := by rw [Kernel.swapRight]; infer_instance
+    IsMarkovKernel (swapRight κ) := by rw [Kernel.swapRight_eq]; infer_instance
 
 instance IsFiniteKernel.swapRight (κ : Kernel α (β × γ)) [IsFiniteKernel κ] :
-    IsFiniteKernel (swapRight κ) := by rw [Kernel.swapRight]; infer_instance
+    IsFiniteKernel (swapRight κ) := by rw [Kernel.swapRight_eq]; infer_instance
 
 instance IsSFiniteKernel.swapRight (κ : Kernel α (β × γ)) [IsSFiniteKernel κ] :
-    IsSFiniteKernel (swapRight κ) := by rw [Kernel.swapRight]; infer_instance
+    IsSFiniteKernel (swapRight κ) := by rw [Kernel.swapRight_eq]; infer_instance
 
 /-- Define a `Kernel α β` from a `Kernel α (β × γ)` by taking the map of the first projection.
 We use `mapOfMeasurable` for better defeqs. -/

--- a/Mathlib/Probability/Kernel/Composition.lean
+++ b/Mathlib/Probability/Kernel/Composition.lean
@@ -591,14 +591,15 @@ variable {γ δ : Type*} [MeasurableSpace γ] {mδ : MeasurableSpace δ} {f : β
 
 /-- When a function is not measurable, the target space is not empty. Therefore, we can choose
 a point there. Useful for junk values when some maps are not measurable. -/
-noncomputable def _root_.defaultOfNotMeasurable [MeasurableSpace γ] [MeasurableSpace δ]
+noncomputable def _root_.defaultOfNotMeasurable [MeasurableSpace δ]
     (f : γ → δ) (hf : ¬(Measurable f)) : δ := by
   refine Classical.choice ?_
   contrapose! hf
   simp only [not_nonempty_iff] at hf
   exact measurable_of_empty_codomain f
 
-/-- The pushforward of a kernel along a measurable function. -/
+/-- The pushforward of a kernel along a measurable function. This is an implementation detail,
+use `map κ f` instead. -/
 noncomputable def mapOfMeasurable (κ : Kernel α β) (f : β → γ) (hf : Measurable f) :
     Kernel α γ where
   toFun a := (κ a).map f

--- a/Mathlib/Probability/Kernel/Disintegration/Basic.lean
+++ b/Mathlib/Probability/Kernel/Disintegration/Basic.lean
@@ -163,8 +163,7 @@ instance condKernelCountable.instIsCondKernel [∀ a, IsMarkovKernel (κCond a)]
   constructor
   ext a s hs
   conv_rhs => rw [← (κ a).disintegrate (κCond a)]
-  simp_rw [compProd_apply _ _ _ hs, condKernelCountable_apply, Measure.compProd_apply hs,
-    fst_apply]
+  simp_rw [compProd_apply _ _ _ hs, condKernelCountable_apply, Measure.compProd_apply hs]
   congr
 
 end Countable

--- a/Mathlib/Probability/Kernel/Disintegration/Basic.lean
+++ b/Mathlib/Probability/Kernel/Disintegration/Basic.lean
@@ -163,7 +163,8 @@ instance condKernelCountable.instIsCondKernel [∀ a, IsMarkovKernel (κCond a)]
   constructor
   ext a s hs
   conv_rhs => rw [← (κ a).disintegrate (κCond a)]
-  simp_rw [compProd_apply _ _ _ hs, condKernelCountable_apply, Measure.compProd_apply hs]
+  simp_rw [compProd_apply _ _ _ hs, condKernelCountable_apply, Measure.compProd_apply hs,
+    fst_apply]
   congr
 
 end Countable

--- a/Mathlib/Probability/Kernel/Disintegration/StandardBorel.lean
+++ b/Mathlib/Probability/Kernel/Disintegration/StandardBorel.lean
@@ -234,22 +234,19 @@ instance instIsMarkovKernelBorelMarkovFromReal (η : Kernel α ℝ) [IsMarkovKer
   · rw [deterministic_apply]
     simp [(range_nonempty (embeddingReal Ω)).choose_spec]
 
-/-- For `κ' := map κ (Prod.map (id : β → β) e) (measurable_id.prod_map he.measurable)`, the
+/-- For `κ' := map κ (Prod.map (id : β → β) e)`, the
 hypothesis `hη` is `fst κ' ⊗ₖ η = κ'`. The conclusion of the lemma is
 `fst κ ⊗ₖ borelMarkovFromReal Ω η = comapRight (fst κ' ⊗ₖ η) _`. -/
 lemma compProd_fst_borelMarkovFromReal_eq_comapRight_compProd
     (κ : Kernel α (β × Ω)) [IsSFiniteKernel κ] (η : Kernel (α × β) ℝ) [IsSFiniteKernel η]
-    (hη : (fst (map κ (Prod.map (id : β → β) (embeddingReal Ω))
-        (measurable_id.prod_map (measurableEmbedding_embeddingReal Ω).measurable))) ⊗ₖ η
-      = map κ (Prod.map (id : β → β) (embeddingReal Ω))
-        (measurable_id.prod_map (measurableEmbedding_embeddingReal Ω).measurable)) :
+    (hη : (fst (map κ (Prod.map (id : β → β) (embeddingReal Ω)))) ⊗ₖ η
+      = map κ (Prod.map (id : β → β) (embeddingReal Ω))) :
     fst κ ⊗ₖ borelMarkovFromReal Ω η
-      = comapRight (fst (map κ (Prod.map (id : β → β) (embeddingReal Ω))
-          (measurable_id.prod_map (measurableEmbedding_embeddingReal Ω).measurable)) ⊗ₖ η)
+      = comapRight (fst (map κ (Prod.map (id : β → β) (embeddingReal Ω))) ⊗ₖ η)
         (MeasurableEmbedding.id.prod_mk (measurableEmbedding_embeddingReal Ω)) := by
   let e := embeddingReal Ω
   let he := measurableEmbedding_embeddingReal Ω
-  let κ' := map κ (Prod.map (id : β → β) e) (measurable_id.prod_map he.measurable)
+  let κ' := map κ (Prod.map (id : β → β) e)
   have hη' : fst κ' ⊗ₖ η = κ' := hη
   have h_prod_embed : MeasurableEmbedding (Prod.map (id : β → β) e) :=
     MeasurableEmbedding.id.prod_mk he
@@ -258,7 +255,8 @@ lemma compProd_fst_borelMarkovFromReal_eq_comapRight_compProd
   have h_fst : fst κ' = fst κ := by
     ext a u
     unfold_let κ'
-    rw [fst_apply, map_apply, Measure.map_map measurable_fst h_prod_embed.measurable, fst_apply]
+    rw [fst_apply, map_apply _ (by fun_prop), Measure.map_map measurable_fst
+      h_prod_embed.measurable, fst_apply]
     congr
   rw [h_fst]
   ext a t ht : 2

--- a/Mathlib/Probability/Kernel/Disintegration/StandardBorel.lean
+++ b/Mathlib/Probability/Kernel/Disintegration/StandardBorel.lean
@@ -266,7 +266,7 @@ lemma compProd_fst_borelMarkovFromReal_eq_comapRight_compProd
     rw [← h_fst]
     have h_compProd : κ' a (univ ×ˢ range e)ᶜ = 0 := by
       unfold_let κ'
-      rw [map_apply']
+      rw [map_apply' _ (by fun_prop)]
       swap; · exact (MeasurableSet.univ.prod he.measurableSet_range).compl
       suffices Prod.map id e ⁻¹' (univ ×ˢ range e)ᶜ = ∅ by rw [this]; simp
       ext x
@@ -284,26 +284,24 @@ lemma compProd_fst_borelMarkovFromReal_eq_comapRight_compProd
   rw [piecewise_apply, if_pos]
   exact ha
 
-/-- For `κ' := map κ (Prod.map (id : β → β) e) (measurable_id.prod_map he.measurable)`, the
+/-- For `κ' := map κ (Prod.map (id : β → β) e)`, the
 hypothesis `hη` is `fst κ' ⊗ₖ η = κ'`. With that hypothesis,
 `fst κ ⊗ₖ borelMarkovFromReal κ η = κ`.-/
 lemma compProd_fst_borelMarkovFromReal (κ : Kernel α (β × Ω)) [IsSFiniteKernel κ]
     (η : Kernel (α × β) ℝ) [IsSFiniteKernel η]
-    (hη : (fst (map κ (Prod.map (id : β → β) (embeddingReal Ω))
-        (measurable_id.prod_map (measurableEmbedding_embeddingReal Ω).measurable))) ⊗ₖ η
-      = map κ (Prod.map (id : β → β) (embeddingReal Ω))
-        (measurable_id.prod_map (measurableEmbedding_embeddingReal Ω).measurable)) :
+    (hη : (fst (map κ (Prod.map (id : β → β) (embeddingReal Ω)))) ⊗ₖ η
+      = map κ (Prod.map (id : β → β) (embeddingReal Ω))) :
     fst κ ⊗ₖ borelMarkovFromReal Ω η = κ := by
   let e := embeddingReal Ω
   let he := measurableEmbedding_embeddingReal Ω
-  let κ' := map κ (Prod.map (id : β → β) e) (measurable_id.prod_map he.measurable)
+  let κ' := map κ (Prod.map (id : β → β) e)
   have hη' : fst κ' ⊗ₖ η = κ' := hη
   have h_prod_embed : MeasurableEmbedding (Prod.map (id : β → β) e) :=
     MeasurableEmbedding.id.prod_mk he
   have : κ = comapRight κ' h_prod_embed := by
     ext c t : 2
     unfold_let κ'
-    rw [comapRight_apply, map_apply, h_prod_embed.comap_map]
+    rw [comapRight_apply, map_apply _ (by fun_prop), h_prod_embed.comap_map]
   conv_rhs => rw [this, ← hη']
   exact compProd_fst_borelMarkovFromReal_eq_comapRight_compProd κ η hη
 
@@ -318,9 +316,8 @@ A conditional kernel for `κ : Kernel α (γ × Ω)` where `γ` is countably gen
 standard Borel. -/
 noncomputable
 def condKernelBorel (κ : Kernel α (γ × Ω)) [IsFiniteKernel κ] : Kernel (α × γ) Ω :=
-  let e := embeddingReal Ω
-  let he := measurableEmbedding_embeddingReal Ω
-  let κ' := map κ (Prod.map (id : γ → γ) e) (measurable_id.prod_map he.measurable)
+  letI e := embeddingReal Ω
+  letI κ' := map κ (Prod.map (id : γ → γ) e)
   borelMarkovFromReal Ω (condKernelReal κ')
 
 instance instIsMarkovKernelCondKernelBorel (κ : Kernel α (γ × Ω)) [IsFiniteKernel κ] :
@@ -347,9 +344,8 @@ variable (κ : Kernel Unit (α × Ω)) [IsFiniteKernel κ]
 A conditional kernel for `κ : Kernel Unit (α × Ω)` where `Ω` is standard Borel. -/
 noncomputable
 def condKernelUnitBorel : Kernel (Unit × α) Ω :=
-  let e := embeddingReal Ω
-  let he := measurableEmbedding_embeddingReal Ω
-  let κ' := map κ (Prod.map (id : α → α) e) (measurable_id.prod_map he.measurable)
+  letI e := embeddingReal Ω
+  letI κ' := map κ (Prod.map (id : α → α) e)
   borelMarkovFromReal Ω (condKernelUnitReal κ')
 
 instance instIsMarkovKernelCondKernelUnitBorel : IsMarkovKernel κ.condKernelUnitBorel := by

--- a/Mathlib/Probability/Kernel/Disintegration/Unique.lean
+++ b/Mathlib/Probability/Kernel/Disintegration/Unique.lean
@@ -91,35 +91,35 @@ theorem eq_condKernel_of_measure_eq_compProd (κ : Kernel α Ω) [IsFiniteKernel
     rw [hρ'def, Measure.fst_apply, Measure.fst_apply, Measure.map_apply]
     exacts [rfl, Measurable.prod measurable_fst <| hf.measurable.comp measurable_snd,
       measurable_fst hs, hs, hs]
-  have hρ'' : ∀ᵐ x ∂ρ.fst, Kernel.map κ f hf.measurable x = ρ'.condKernel x := by
+  have hρ'' : ∀ᵐ x ∂ρ.fst, Kernel.map κ f x = ρ'.condKernel x := by
     rw [← hρ']
-    refine eq_condKernel_of_measure_eq_compProd_real (Kernel.map κ f hf.measurable) ?_
+    refine eq_condKernel_of_measure_eq_compProd_real (Kernel.map κ f) ?_
     ext s hs
     conv_lhs => rw [hρ'def, hκ]
     rw [Measure.map_apply (measurable_id.prod_map hf.measurable) hs, hρ',
       Measure.compProd_apply hs, Measure.compProd_apply (measurable_id.prod_map hf.measurable hs)]
     congr with a
-    rw [Kernel.map_apply']
+    rw [Kernel.map_apply' _ hf.measurable]
     exacts [rfl, measurable_prod_mk_left hs]
   suffices ∀ᵐ x ∂ρ.fst, ∀ s, MeasurableSet s → ρ'.condKernel x s = ρ.condKernel x (f ⁻¹' s) by
     filter_upwards [hρ'', this] with x hx h
-    rw [Kernel.map_apply] at hx
+    rw [Kernel.map_apply _ hf.measurable] at hx
     ext s hs
     rw [← Set.preimage_image_eq s hf.injective,
       ← Measure.map_apply hf.measurable <| hf.measurableSet_image.2 hs, hx,
       h _ <| hf.measurableSet_image.2 hs]
-  suffices ρ.map (Prod.map id f) = (ρ.fst ⊗ₘ (Kernel.map ρ.condKernel f hf.measurable)) by
+  suffices ρ.map (Prod.map id f) = (ρ.fst ⊗ₘ (Kernel.map ρ.condKernel f)) by
     rw [← hρ'] at this
     have heq := eq_condKernel_of_measure_eq_compProd_real _ this
     rw [hρ'] at heq
     filter_upwards [heq] with x hx s hs
-    rw [← hx, Kernel.map_apply, Measure.map_apply hf.measurable hs]
+    rw [← hx, Kernel.map_apply _ hf.measurable, Measure.map_apply hf.measurable hs]
   ext s hs
   conv_lhs => rw [← ρ.disintegrate ρ.condKernel]
   rw [Measure.compProd_apply hs, Measure.map_apply (measurable_id.prod_map hf.measurable) hs,
     Measure.compProd_apply]
   · congr with a
-    rw [Kernel.map_apply']
+    rw [Kernel.map_apply' _ hf.measurable]
     exacts [rfl, measurable_prod_mk_left hs]
   · exact measurable_id.prod_map hf.measurable hs
 

--- a/Mathlib/Probability/Kernel/RadonNikodym.lean
+++ b/Mathlib/Probability/Kernel/RadonNikodym.lean
@@ -88,8 +88,7 @@ noncomputable
 def rnDerivAux (κ η : Kernel α γ) (a : α) (x : γ) : ℝ :=
   if hα : Countable α then ((κ a).rnDeriv (η a) x).toReal
   else haveI := hαγ.countableOrCountablyGenerated.resolve_left hα
-    density (map κ (fun a ↦ (a, ()))
-      (@measurable_prod_mk_right γ Unit _ inferInstance _)) η a x univ
+    density (map κ (fun a ↦ (a, ()))) η a x univ
 
 lemma rnDerivAux_nonneg (hκη : κ ≤ η) {a : α} {x : γ} : 0 ≤ rnDerivAux κ η a x := by
   rw [rnDerivAux]
@@ -144,7 +143,7 @@ lemma setLIntegral_rnDerivAux (κ η : Kernel α γ) [IsFiniteKernel κ] [IsFini
     rw [ENNReal.ofReal_toReal hx_lt.ne]
   · have := hαγ.countableOrCountablyGenerated.resolve_left hα
     rw [setLIntegral_density ((fst_map_id_prod _ measurable_const).trans_le h_le) _
-      MeasurableSet.univ hs, map_apply' _ _ _ (hs.prod MeasurableSet.univ)]
+      MeasurableSet.univ hs, map_apply' _ (by fun_prop) _ (hs.prod MeasurableSet.univ)]
     congr with x
     simp
 


### PR DESCRIPTION
Currently, mapping a kernel by a function is only allowed if the function is measurable, with syntax `map kappa f hf`. We change it to use a junk value instead, so that we can write `map kappa f`. The gotcha is that we want the `map` of a Markov kernel to be a Markov kernel, for typeclass inference, so the junk value should not be zero. Instead, when `f` is not measurable, we map `kappa` by some constant function (note that the target type is nonempty, as otherwise `f` would be measurable!)

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
