### PR TITLE
[Merged by Bors] - fix: error positioning in `linear_combination`

### DIFF
--- a/Mathlib/Tactic/LinearCombination.lean
+++ b/Mathlib/Tactic/LinearCombination.lean
@@ -126,7 +126,7 @@ theorem eq_of_add_pow [Ring α] [NoZeroDivisors α] (n : ℕ) (p : (a:α) = b)
   rw [← sub_eq_zero] at p ⊢; apply pow_eq_zero (n := n); rwa [sub_eq_zero, p] at H
 
 /-- Implementation of `linear_combination` and `linear_combination2`. -/
-def elabLinearCombination
+def elabLinearCombination (tk : Syntax)
     (norm? : Option Syntax.Tactic) (exp? : Option Syntax.NumLit) (input : Option Syntax.Term)
     (twoGoals := false) : Tactic.TacticM Unit := Tactic.withMainContext do
   let some (ty, _) := (← (← Tactic.getMainGoal).getType').eq? |
@@ -137,7 +137,7 @@ def elabLinearCombination
     match ← expandLinearCombo ty e with
     | .const c => `(Eq.refl $c)
     | .proof p => pure p
-  let norm := norm?.getD (Unhygienic.run <| withRef (← getRef) `(tactic| ring1))
+  let norm := norm?.getD (Unhygienic.run <| withRef tk `(tactic| ring1))
   Term.withoutErrToSorry <| Tactic.evalTactic <| ← withFreshMacroScope <|
   if twoGoals then
     `(tactic| (
@@ -238,12 +238,13 @@ example (a b : ℚ) (h : ∀ p q : ℚ, p = q) : 3*a + qc = 3*b + 2*qc := by
 syntax (name := linearCombination) "linear_combination"
   (normStx)? (expStx)? (ppSpace colGt term)? : tactic
 elab_rules : tactic
-  | `(tactic| linear_combination $[(norm := $tac)]? $[(exp := $n)]? $(e)?) =>
-    elabLinearCombination tac n e
+  | `(tactic| linear_combination%$tk $[(norm := $tac)]? $[(exp := $n)]? $(e)?) =>
+    elabLinearCombination tk tac n e
 
 @[inherit_doc linearCombination]
 syntax "linear_combination2" (normStx)? (ppSpace colGt term)? : tactic
 elab_rules : tactic
-  | `(tactic| linear_combination2 $[(norm := $tac)]? $(e)?) => elabLinearCombination tac none e true
+  | `(tactic| linear_combination2%$tk $[(norm := $tac)]? $(e)?) =>
+    elabLinearCombination tk tac none e true
 
 end Mathlib.Tactic.LinearCombination

--- a/Mathlib/Tactic/LinearCombination.lean
+++ b/Mathlib/Tactic/LinearCombination.lean
@@ -137,7 +137,7 @@ def elabLinearCombination
     match ← expandLinearCombo ty e with
     | .const c => `(Eq.refl $c)
     | .proof p => pure p
-  let norm := norm?.getD (Unhygienic.run `(tactic| ring1))
+  let norm := norm?.getD (Unhygienic.run <| withRef (← getRef) `(tactic| ring1))
   Term.withoutErrToSorry <| Tactic.evalTactic <| ← withFreshMacroScope <|
   if twoGoals then
     `(tactic| (


### PR DESCRIPTION
A tweak to `linear_combination` so that when the default normalization tactic fails, the "red underlines" appear on the `linear_combination` call itself, rather than just on the "by" at the start of the proof.  For example, compare before/after on this example:
```lean
import Mathlib

example {a : ℤ} (h : a = 1) : a = 2 := by
  linear_combination h
```

Zulip discussion:
https://leanprover.zulipchat.com/#narrow/stream/270676-lean4/topic/Propagating.20errors.20through.20Unhygienic.2Erun

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
