### PR TITLE
[Merged by Bors] - chore(CategoryTheory/Adjunction): fix some formatting issues in `Mates` file

### DIFF
--- a/Mathlib/CategoryTheory/Adjunction/Mates.lean
+++ b/Mathlib/CategoryTheory/Adjunction/Mates.lean
@@ -45,8 +45,8 @@ open Category Functor Adjunction NatTrans
 
 section mateEquiv
 
-variable {C : Type u₁} {D : Type u₂}{E : Type u₃} {F : Type u₄}
-variable [Category.{v₁} C] [Category.{v₂} D][Category.{v₃} E] [Category.{v₄} F]
+variable {C : Type u₁} {D : Type u₂} {E : Type u₃} {F : Type u₄}
+variable [Category.{v₁} C] [Category.{v₂} D] [Category.{v₃} E] [Category.{v₄} F]
 variable {G : C ⥤ E} {H : D ⥤ F} {L₁ : C ⥤ D} {R₁ : D ⥤ C} {L₂ : E ⥤ F} {R₂ : F ⥤ E}
 variable (adj₁ : L₁ ⊣ R₁) (adj₂ : L₂ ⊣ R₂)
 
@@ -119,9 +119,7 @@ theorem unit_mateEquiv (α : G ⋙ L₂ ⟶ L₁ ⋙ H) (c : C) :
     rw [← R₂.map_comp, ← Functor.comp_map G L₂, α.naturality]
   rw [R₂.map_comp]
   slice_lhs 3 4 =>
-    {
-      rw [← R₂.map_comp, Functor.comp_map L₁ H, ← H.map_comp, left_triangle_components]
-    }
+    rw [← R₂.map_comp, Functor.comp_map L₁ H, ← H.map_comp, left_triangle_components]
   simp only [comp_obj, map_id, comp_id]
 
 /-- A component of a transposed version of the inverse mates correspondence. -/
@@ -136,10 +134,10 @@ end mateEquiv
 section mateEquivVComp
 
 variable {A : Type u₁} {B : Type u₂} {C : Type u₃} {D : Type u₄} {E : Type u₅} {F : Type u₆}
-variable [Category.{v₁} A] [Category.{v₂} B][Category.{v₃} C]
-variable [Category.{v₄} D] [Category.{v₅} E][Category.{v₆} F]
-variable {G₁ : A ⥤ C}{G₂ : C ⥤ E}{H₁ : B ⥤ D}{H₂ : D ⥤ F}
-variable {L₁ : A ⥤ B}{R₁ : B ⥤ A} {L₂ : C ⥤ D}{R₂ : D ⥤ C}{L₃ : E ⥤ F}{R₃ : F ⥤ E}
+variable [Category.{v₁} A] [Category.{v₂} B] [Category.{v₃} C]
+variable [Category.{v₄} D] [Category.{v₅} E] [Category.{v₆} F]
+variable {G₁ : A ⥤ C} {G₂ : C ⥤ E} {H₁ : B ⥤ D} {H₂ : D ⥤ F}
+variable {L₁ : A ⥤ B} {R₁ : B ⥤ A} {L₂ : C ⥤ D} {R₂ : D ⥤ C} {L₃ : E ⥤ F} {R₃ : F ⥤ E}
 variable (adj₁ : L₁ ⊣ R₁) (adj₂ : L₂ ⊣ R₂) (adj₃ : L₃ ⊣ R₃)
 
 /-- Squares between left adjoints can be composed "vertically" by pasting. -/
@@ -162,32 +160,21 @@ theorem mateEquiv_vcomp
   simp only [comp_obj, Equiv.coe_fn_mk, whiskerLeft_comp, whiskerLeft_twice, whiskerRight_comp,
     assoc, comp_app, whiskerLeft_app, whiskerRight_app, id_obj, Functor.comp_map,
     whiskerRight_twice]
-  slice_rhs 1 4 =>
-    {
-      rw [← assoc, ← assoc, ← unit_naturality (adj₃)]
-    }
+  slice_rhs 1 4 => rw [← assoc, ← assoc, ← unit_naturality (adj₃)]
   rw [L₃.map_comp, R₃.map_comp]
   slice_rhs 2 4 =>
-    {
-      rw [← R₃.map_comp, ← R₃.map_comp, ← assoc, ← L₃.map_comp, ← G₂.map_comp, ← G₂.map_comp]
-      rw [← Functor.comp_map G₂ L₃, β.naturality]
-    }
+    rw [← R₃.map_comp, ← R₃.map_comp, ← assoc, ← L₃.map_comp, ← G₂.map_comp, ← G₂.map_comp]
+    rw [← Functor.comp_map G₂ L₃, β.naturality]
   rw [(L₂ ⋙ H₂).map_comp, R₃.map_comp, R₃.map_comp]
   slice_rhs 4 5 =>
-    {
-      rw [← R₃.map_comp, Functor.comp_map L₂ _, ← Functor.comp_map _ L₂, ← H₂.map_comp]
-      rw [adj₂.counit.naturality]
-    }
+    rw [← R₃.map_comp, Functor.comp_map L₂ _, ← Functor.comp_map _ L₂, ← H₂.map_comp]
+    rw [adj₂.counit.naturality]
   simp only [comp_obj, Functor.comp_map, map_comp, id_obj, Functor.id_map, assoc]
   slice_rhs 4 5 =>
-    {
-      rw [← R₃.map_comp, ← H₂.map_comp, ← Functor.comp_map _ L₂, adj₂.counit.naturality]
-    }
+    rw [← R₃.map_comp, ← H₂.map_comp, ← Functor.comp_map _ L₂, adj₂.counit.naturality]
   simp only [comp_obj, id_obj, Functor.id_map, map_comp, assoc]
   slice_rhs 3 4 =>
-    {
-      rw [← R₃.map_comp, ← H₂.map_comp, left_triangle_components]
-    }
+    rw [← R₃.map_comp, ← H₂.map_comp, left_triangle_components]
   simp only [map_id, id_comp]
 
 end mateEquivVComp
@@ -195,11 +182,11 @@ end mateEquivVComp
 section mateEquivHComp
 
 variable {A : Type u₁} {B : Type u₂} {C : Type u₃} {D : Type u₄} {E : Type u₅} {F : Type u₆}
-variable [Category.{v₁} A] [Category.{v₂} B][Category.{v₃} C]
-variable [Category.{v₄} D] [Category.{v₅} E][Category.{v₆} F]
-variable {G : A ⥤ D}{H : B ⥤ E}{K : C ⥤ F}
-variable {L₁ : A ⥤ B}{R₁ : B ⥤ A} {L₂ : D ⥤ E}{R₂ : E ⥤ D}
-variable {L₃ : B ⥤ C}{R₃ : C ⥤ B} {L₄ : E ⥤ F}{R₄ : F ⥤ E}
+variable [Category.{v₁} A] [Category.{v₂} B] [Category.{v₃} C]
+variable [Category.{v₄} D] [Category.{v₅} E] [Category.{v₆} F]
+variable {G : A ⥤ D} {H : B ⥤ E} {K : C ⥤ F}
+variable {L₁ : A ⥤ B} {R₁ : B ⥤ A} {L₂ : D ⥤ E} {R₂ : E ⥤ D}
+variable {L₃ : B ⥤ C} {R₃ : C ⥤ B} {L₄ : E ⥤ F} {R₄ : F ⥤ E}
 variable (adj₁ : L₁ ⊣ R₁) (adj₂ : L₂ ⊣ R₂) (adj₃ : L₃ ⊣ R₃) (adj₄ : L₄ ⊣ R₄)
 
 /-- Squares between left adjoints can be composed "horizontally" by pasting. -/
@@ -223,14 +210,10 @@ theorem mateEquiv_hcomp
     Equiv.coe_fn_mk, comp_app, whiskerLeft_app, whiskerRight_app, id_obj, associator_inv_app,
     Functor.comp_map, associator_hom_app, map_id, id_comp, whiskerRight_twice]
   slice_rhs 2 4 =>
-    {
-      rw [← R₂.map_comp, ← R₂.map_comp, ← assoc, ← unit_naturality (adj₄)]
-    }
+    rw [← R₂.map_comp, ← R₂.map_comp, ← assoc, ← unit_naturality (adj₄)]
   rw [R₂.map_comp, L₄.map_comp, R₄.map_comp, R₂.map_comp]
   slice_rhs 4 5 =>
-    {
-      rw [← R₂.map_comp, ← R₄.map_comp, ← Functor.comp_map _ L₄ , β.naturality]
-    }
+    rw [← R₂.map_comp, ← R₄.map_comp, ← Functor.comp_map _ L₄ , β.naturality]
   simp only [comp_obj, Functor.comp_map, map_comp, assoc]
 
 end mateEquivHComp
@@ -240,9 +223,9 @@ section mateEquivSquareComp
 variable {A : Type u₁} {B : Type u₂} {C : Type u₃}
 variable {D : Type u₄} {E : Type u₅} {F : Type u₆}
 variable {X : Type u₇} {Y : Type u₈} {Z : Type u₉}
-variable [Category.{v₁} A] [Category.{v₂} B][Category.{v₃} C]
-variable [Category.{v₄} D] [Category.{v₅} E][Category.{v₆} F]
-variable [Category.{v₇} X] [Category.{v₈} Y][Category.{v₉} Z]
+variable [Category.{v₁} A] [Category.{v₂} B] [Category.{v₃} C]
+variable [Category.{v₄} D] [Category.{v₅} E] [Category.{v₆} F]
+variable [Category.{v₇} X] [Category.{v₈} Y] [Category.{v₉} Z]
 variable {G₁ : A ⥤ D} {H₁ : B ⥤ E} {K₁ : C ⥤ F} {G₂ : D ⥤ X} {H₂ : E ⥤ Y} {K₂ : F ⥤ Z}
 variable {L₁ : A ⥤ B} {R₁ : B ⥤ A} {L₂ : B ⥤ C} {R₂ : C ⥤ B} {L₃ : D ⥤ E} {R₃ : E ⥤ D}
 variable {L₄ : E ⥤ F} {R₄ : F ⥤ E} {L₅ : X ⥤ Y} {R₅ : Y ⥤ X} {L₆ : Y ⥤ Z} {R₆ : Z ⥤ Y}
@@ -275,9 +258,7 @@ theorem leftAdjointSquare.comp_hvcomp
   ext a
   simp only [comp_obj, comp_app, map_comp, assoc]
   slice_rhs 2 3 =>
-    {
-      rw [← Functor.comp_map _ L₆, δ.naturality]
-    }
+    rw [← Functor.comp_map _ L₆, δ.naturality]
   simp only [comp_obj, Functor.comp_map, assoc]
 
 /-- Squares of squares between right adjoints can be composed by iterating vertical and horizontal
@@ -306,9 +287,7 @@ theorem rightAdjointSquare.comp_hvcomp
   ext c
   simp only [comp_obj, comp_app, map_comp, assoc]
   slice_rhs 2 3 =>
-    {
-      rw [← Functor.comp_map _ R₅, ← γ.naturality]
-    }
+    rw [← Functor.comp_map _ R₅, ← γ.naturality]
   simp only [comp_obj, Functor.comp_map, assoc]
 
 /-- The mates equivalence commutes with composition of squares of squares. These results form the
@@ -445,7 +424,7 @@ theorem conjugateEquiv_comm {α : L₂ ⟶ L₁} {β : L₁ ⟶ L₂} (βα : β
     conjugateEquiv adj₁ adj₂ α ≫ conjugateEquiv adj₂ adj₁ β = 𝟙 _ := by
   rw [conjugateEquiv_comp, βα, conjugateEquiv_id]
 
-theorem conjugateEquiv_symm_comm {α : R₁ ⟶ R₂}{β : R₂ ⟶ R₁} (αβ : α ≫ β = 𝟙 _) :
+theorem conjugateEquiv_symm_comm {α : R₁ ⟶ R₂} {β : R₂ ⟶ R₁} (αβ : α ≫ β = 𝟙 _) :
     (conjugateEquiv adj₂ adj₁).symm β ≫ (conjugateEquiv adj₁ adj₂).symm α = 𝟙 _ := by
   rw [conjugateEquiv_symm_comp, αβ, conjugateEquiv_symm_id]
 
@@ -503,11 +482,11 @@ noncomputable def conjugateIsoEquiv : (L₂ ≅ L₁) ≃ (R₁ ≅ R₂) where
 end ConjugateIsomorphism
 
 section IteratedmateEquiv
-variable {A : Type u₁} {B : Type u₂}{C : Type u₃} {D : Type u₄}
-variable [Category.{v₁} A] [Category.{v₂} B][Category.{v₃} C] [Category.{v₄} D]
-variable {F₁ : A ⥤ C}{U₁ : C ⥤ A} {F₂ : B ⥤ D} {U₂ : D ⥤ B}
+variable {A : Type u₁} {B : Type u₂} {C : Type u₃} {D : Type u₄}
+variable [Category.{v₁} A] [Category.{v₂} B] [Category.{v₃} C] [Category.{v₄} D]
+variable {F₁ : A ⥤ C} {U₁ : C ⥤ A} {F₂ : B ⥤ D} {U₂ : D ⥤ B}
 variable {L₁ : A ⥤ B} {R₁ : B ⥤ A} {L₂ : C ⥤ D} {R₂ : D ⥤ C}
-variable (adj₁ : L₁ ⊣ R₁) (adj₂ : L₂ ⊣ R₂) (adj₃ : F₁ ⊣ U₁)(adj₄ : F₂ ⊣ U₂)
+variable (adj₁ : L₁ ⊣ R₁) (adj₂ : L₂ ⊣ R₂) (adj₃ : F₁ ⊣ U₁) (adj₄ : F₂ ⊣ U₂)
 
 /-- When all four functors in a sequare are left adjoints, the mates operation can be iterated:
 
@@ -542,11 +521,11 @@ end IteratedmateEquiv
 
 section mateEquivconjugateEquivVComp
 
-variable {A : Type u₁} {B : Type u₂} {C : Type u₃}{D : Type u₄}
-variable [Category.{v₁} A] [Category.{v₂} B][Category.{v₃} C]
+variable {A : Type u₁} {B : Type u₂} {C : Type u₃} {D : Type u₄}
+variable [Category.{v₁} A] [Category.{v₂} B] [Category.{v₃} C]
 variable [Category.{v₄} D]
 variable {G : A ⥤ C} {H : B ⥤ D}
-variable {L₁ : A ⥤ B} {R₁ : B ⥤ A} {L₂ : C ⥤ D} {R₂ : D ⥤ C} {L₃ : C ⥤ D}{R₃ : D ⥤ C}
+variable {L₁ : A ⥤ B} {R₁ : B ⥤ A} {L₂ : C ⥤ D} {R₂ : D ⥤ C} {L₃ : C ⥤ D} {R₃ : D ⥤ C}
 variable (adj₁ : L₁ ⊣ R₁) (adj₂ : L₂ ⊣ R₂) (adj₃ : L₃ ⊣ R₃)
 
 /-- Composition of a squares between left adjoints with a conjugate square. -/
@@ -581,8 +560,8 @@ end mateEquivconjugateEquivVComp
 
 section conjugateEquivmateEquivVComp
 
-variable {A : Type u₁} {B : Type u₂} {C : Type u₃}{D : Type u₄}
-variable [Category.{v₁} A] [Category.{v₂} B][Category.{v₃} C]
+variable {A : Type u₁} {B : Type u₂} {C : Type u₃} {D : Type u₄}
+variable [Category.{v₁} A] [Category.{v₂} B] [Category.{v₃} C]
 variable [Category.{v₄} D]
 variable {G : A ⥤ C} {H : B ⥤ D}
 variable {L₁ : A ⥤ B} {R₁ : B ⥤ A} {L₂ : A ⥤ B} {R₂ : B ⥤ A} {L₃ : C ⥤ D} {R₃ : D ⥤ C}


### PR DESCRIPTION

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
