### PR TITLE
[Merged by Bors] - feat(Data/Finsupp/Defs): Support of `f + single a b`

### DIFF
--- a/Mathlib/Data/Finsupp/Defs.lean
+++ b/Mathlib/Data/Finsupp/Defs.lean
@@ -910,6 +910,20 @@ theorem support_add_eq [DecidableEq α] {g₁ g₂ : α →₀ M} (h : Disjoint 
 theorem single_add (a : α) (b₁ b₂ : M) : single a (b₁ + b₂) = single a b₁ + single a b₂ :=
   (zipWith_single_single _ _ _ _ _).symm
 
+theorem support_single_add [DecidableEq α] {a : α} {b : M} {f : α →₀ M}
+    (ha : a ∉ f.support) (hb : b ≠ 0) : support (single a b + f) = insert a f.support := by
+  have H := support_single_ne_zero a hb
+  apply (support_add_eq _).trans
+  · rw [H, insert_eq]
+  · rwa [H, disjoint_singleton_left]
+
+theorem support_add_single [DecidableEq α] {a : α} {b : M} {f : α →₀ M}
+    (ha : a ∉ f.support) (hb : b ≠ 0) : support (f + single a b) = insert a f.support := by
+  have H := support_single_ne_zero a hb
+  apply (support_add_eq _).trans
+  · rw [H, union_comm, insert_eq]
+  · rwa [H, disjoint_singleton_right]
+
 instance instAddZeroClass : AddZeroClass (α →₀ M) :=
   DFunLike.coe_injective.addZeroClass _ coe_zero coe_add
 

--- a/Mathlib/Data/Finsupp/Defs.lean
+++ b/Mathlib/Data/Finsupp/Defs.lean
@@ -910,19 +910,19 @@ theorem support_add_eq [DecidableEq α] {g₁ g₂ : α →₀ M} (h : Disjoint 
 theorem single_add (a : α) (b₁ b₂ : M) : single a (b₁ + b₂) = single a b₁ + single a b₂ :=
   (zipWith_single_single _ _ _ _ _).symm
 
-theorem support_single_add [DecidableEq α] {a : α} {b : M} {f : α →₀ M}
-    (ha : a ∉ f.support) (hb : b ≠ 0) : support (single a b + f) = insert a f.support := by
+theorem support_single_add {a : α} {b : M} {f : α →₀ M} (ha : a ∉ f.support) (hb : b ≠ 0) :
+    support (single a b + f) = cons a f.support ha := by
+  classical
   have H := support_single_ne_zero a hb
-  apply (support_add_eq _).trans
-  · rw [H, insert_eq]
-  · rwa [H, disjoint_singleton_left]
+  rw [support_add_eq, H, cons_eq_insert, insert_eq]
+  rwa [H, disjoint_singleton_left]
 
-theorem support_add_single [DecidableEq α] {a : α} {b : M} {f : α →₀ M}
-    (ha : a ∉ f.support) (hb : b ≠ 0) : support (f + single a b) = insert a f.support := by
+theorem support_add_single {a : α} {b : M} {f : α →₀ M} (ha : a ∉ f.support) (hb : b ≠ 0) :
+    support (f + single a b) = cons a f.support ha := by
+  classical
   have H := support_single_ne_zero a hb
-  apply (support_add_eq _).trans
-  · rw [H, union_comm, insert_eq]
-  · rwa [H, disjoint_singleton_right]
+  rw [support_add_eq, H, union_comm, cons_eq_insert, insert_eq]
+  rwa [H, disjoint_singleton_right]
 
 instance instAddZeroClass : AddZeroClass (α →₀ M) :=
   DFunLike.coe_injective.addZeroClass _ coe_zero coe_add


### PR DESCRIPTION
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

Used within my work with the Cantor normal form.

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
