### PR TITLE
[Merged by Bors] - chore(List): migrate more to `getElem`

### DIFF
--- a/Mathlib/Data/List/Iterate.lean
+++ b/Mathlib/Data/List/Iterate.lean
@@ -31,15 +31,17 @@ theorem getElem?_iterate (f : α → α) (a : α) :
   | n + 1, 0    , _ => by simp
   | n + 1, i + 1, h => by simp [getElem?_iterate f (f a) n i (by simpa using h)]
 
+@[deprecated getElem?_iterate (since := "2024-08-23")]
 theorem get?_iterate (f : α → α) (a : α) (n i : ℕ) (h : i < n) :
     get? (iterate f a n) i = f^[i] a := by
-  simp only [get?_eq_getElem?, length_iterate, h, Option.some.injEq, getElem?_iterate]
+  simp only [get?_eq_getElem?, getElem?_iterate, h]
 
 @[simp]
 theorem getElem_iterate (f : α → α) (a : α) (n : ℕ) (i : Nat) (h : i < (iterate f a n).length) :
-    (iterate f a n)[i] = f^[↑i] a :=
-  (get?_eq_some.1 <| get?_iterate f a n i (by simpa using h)).2
+    (iterate f a n)[i] = f^[i] a :=
+  getElem_eq_iff.2 <| getElem?_iterate _ _ _ _ <| by rwa [length_iterate] at h
 
+@[deprecated getElem_iterate (since := "2024-08-23")]
 theorem get_iterate (f : α → α) (a : α) (n : ℕ) (i : Fin (iterate f a n).length) :
     get (iterate f a n) i = f^[↑i] a := by
   simp
@@ -52,7 +54,7 @@ theorem mem_iterate {f : α → α} {a : α} {n : ℕ} {b : α} :
 @[simp]
 theorem range_map_iterate (n : ℕ) (f : α → α) (a : α) :
     (List.range n).map (f^[·] a) = List.iterate f a n := by
-  apply List.ext_get <;> simp
+  apply List.ext_getElem <;> simp
 
 theorem iterate_add (f : α → α) (a : α) (m n : ℕ) :
     iterate f a (m + n) = iterate f a m ++ iterate f (f^[m] a) n := by

--- a/Mathlib/Testing/SlimCheck/Gen.lean
+++ b/Mathlib/Testing/SlimCheck/Gen.lean
@@ -92,7 +92,7 @@ def oneOf (xs : Array (Gen α)) (pos : 0 < xs.size := by decide) : Gen α := do
 /-- Given a list of examples, choose one to create an example. -/
 def elements (xs : List α) (pos : 0 < xs.length) : Gen α := do
   let ⟨x, _, h2⟩ ← ULiftable.up <| chooseNatLt 0 xs.length pos
-  pure <| xs.get ⟨x, h2⟩
+  pure <| xs[x]
 
 open List in
 /-- Generate a random permutation of a given list. -/


### PR DESCRIPTION
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)