### PR TITLE
[Merged by Bors] - chore(CategoryTheory/Adjunction): address a few porting notes in `Opposites` file

### DIFF
--- a/Mathlib/CategoryTheory/Adjunction/Basic.lean
+++ b/Mathlib/CategoryTheory/Adjunction/Basic.lean
@@ -251,11 +251,6 @@ structure CoreHomEquiv (F : C ⥤ D) (G : D ⥤ C) where
 
 namespace CoreHomEquiv
 
--- Porting note: Workaround not needed in Lean 4.
--- restate_axiom homEquiv_naturality_left_symm'
-
--- restate_axiom homEquiv_naturality_right'
-
 attribute [simp] homEquiv_naturality_left_symm homEquiv_naturality_right
 
 variable {F : C ⥤ D} {G : D ⥤ C} (adj : CoreHomEquiv F G) {X' X : C} {Y Y' : D}

--- a/Mathlib/CategoryTheory/Adjunction/Basic.lean
+++ b/Mathlib/CategoryTheory/Adjunction/Basic.lean
@@ -174,13 +174,13 @@ theorem homEquiv_naturality_right_square_iff (f : X' ⟶ X) (g : X ⟶ G.obj Y')
 @[simp]
 theorem left_triangle : whiskerRight adj.unit F ≫ whiskerLeft F adj.counit = 𝟙 _ := by
   ext; dsimp
-  erw [← adj.homEquiv_counit, Equiv.symm_apply_eq, adj.homEquiv_unit]
+  rw [← adj.homEquiv_counit, Equiv.symm_apply_eq, adj.homEquiv_unit]
   simp
 
 @[simp]
 theorem right_triangle : whiskerLeft G adj.unit ≫ whiskerRight adj.counit G = 𝟙 _ := by
   ext; dsimp
-  erw [← adj.homEquiv_unit, ← Equiv.eq_symm_apply, adj.homEquiv_counit]
+  rw [← adj.homEquiv_unit, ← Equiv.eq_symm_apply, adj.homEquiv_counit]
   simp
 
 variable (X Y)
@@ -306,23 +306,19 @@ variable {F : C ⥤ D} {G : D ⥤ C}
 `F.obj X ⟶ Y` and `X ⟶ G.obj Y`. -/
 @[simps]
 def mkOfHomEquiv (adj : CoreHomEquiv F G) : F ⊣ G :=
-  -- See note [dsimp, simp].
   { adj with
     unit :=
       { app := fun X => (adj.homEquiv X (F.obj X)) (𝟙 (F.obj X))
         naturality := by
           intros
-          erw [← adj.homEquiv_naturality_left, ← adj.homEquiv_naturality_right]
-          dsimp; simp }
+          simp [← adj.homEquiv_naturality_left, ← adj.homEquiv_naturality_right] }
     counit :=
       { app := fun Y => (adj.homEquiv _ _).invFun (𝟙 (G.obj Y))
         naturality := by
           intros
-          erw [← adj.homEquiv_naturality_left_symm, ← adj.homEquiv_naturality_right_symm]
-          dsimp; simp }
-    homEquiv_unit := @fun X Y f => by erw [← adj.homEquiv_naturality_right]; simp
-    homEquiv_counit := @fun X Y f => by erw [← adj.homEquiv_naturality_left_symm]; simp
-  }
+          simp [← adj.homEquiv_naturality_left_symm, ← adj.homEquiv_naturality_right_symm] }
+    homEquiv_unit := @fun X Y f => by simp [← adj.homEquiv_naturality_right]
+    homEquiv_counit := @fun X Y f => by simp [← adj.homEquiv_naturality_left_symm] }
 
 /-- Construct an adjunction between functors `F` and `G` given a unit and counit for the adjunction
 satisfying the triangle identities. -/
@@ -452,12 +448,7 @@ def adjunctionOfEquivLeft : leftAdjointOfEquiv e he ⊣ G :=
         have {X : C} {Y Y' : D} (f : X ⟶ G.obj Y) (g : Y ⟶ Y') :
             (e X Y').symm (f ≫ G.map g) = (e X Y).symm f ≫ g := by
           rw [Equiv.symm_apply_eq, he]; simp
-        erw [← this, ← Equiv.apply_eq_iff_eq (e X' Y)]
-        simp only [leftAdjointOfEquiv_obj, Equiv.apply_symm_apply, assoc]
-        congr
-        rw [← he]
-        simp
-    }
+        simp [← this, ← Equiv.apply_eq_iff_eq (e X' Y), ← he] }
 
 end ConstructLeft
 
@@ -494,10 +485,10 @@ def adjunctionOfEquivRight (he : ∀ X' X Y f g, e X' Y (F.map f ≫ g) = f ≫ 
   mkOfHomEquiv
     { homEquiv := e
       homEquiv_naturality_left_symm := by
-        intro X X' Y f g; rw [Equiv.symm_apply_eq]; dsimp; rw [he]; simp
+        intro X X' Y f g; rw [Equiv.symm_apply_eq]; simp [he]
       homEquiv_naturality_right := by
         intro X Y Y' g h
-        erw [← he, Equiv.apply_eq_iff_eq, ← assoc, he'' e he, comp_id, Equiv.symm_apply_apply] }
+        simp [← he, reassoc_of% (he'' e)] }
 
 end ConstructRight
 
@@ -534,16 +525,7 @@ variable (e : C ≌ D)
 simply use `e.symm.toAdjunction`. -/
 @[simps! unit counit]
 def toAdjunction : e.functor ⊣ e.inverse :=
-  mkOfUnitCounit
-    ⟨e.unit, e.counit, by
-      ext
-      dsimp
-      simp only [id_comp]
-      exact e.functor_unit_comp _, by
-      ext
-      dsimp
-      simp only [id_comp]
-      exact e.unit_inverse_comp _⟩
+  mkOfUnitCounit ⟨e.unit, e.counit, by ext; simp, by ext; simp⟩
 
 lemma isLeftAdjoint_functor : e.functor.IsLeftAdjoint where
   exists_rightAdjoint := ⟨_, ⟨e.toAdjunction⟩⟩

--- a/Mathlib/CategoryTheory/Adjunction/Basic.lean
+++ b/Mathlib/CategoryTheory/Adjunction/Basic.lean
@@ -64,7 +64,7 @@ structure Adjunction (F : C ⥤ D) (G : D ⥤ C) where
   /-- The counit of an adjunction -/
   counit : G.comp F ⟶ 𝟭 D
   /-- The relationship between the unit and hom set equivalence of an adjunction -/
-  homEquiv_unit : ∀ {X Y f}, (homEquiv X Y) f = (unit : _ ⟶ _).app X ≫ G.map f := by aesop_cat
+  homEquiv_unit : ∀ {X Y f}, (homEquiv X Y) f = unit.app X ≫ G.map f := by aesop_cat
   /-- The relationship between the counit and hom set equivalence of an adjunction -/
   homEquiv_counit : ∀ {X Y g}, (homEquiv X Y).symm g = F.map g ≫ counit.app Y := by aesop_cat
 
@@ -103,7 +103,7 @@ noncomputable def Adjunction.ofIsRightAdjoint (right : C ⥤ D) [right.IsRightAd
 
 namespace Adjunction
 
-attribute [simp 1100] homEquiv_unit homEquiv_counit
+attribute [simp] homEquiv_unit homEquiv_counit
 
 section
 

--- a/Mathlib/CategoryTheory/Adjunction/Basic.lean
+++ b/Mathlib/CategoryTheory/Adjunction/Basic.lean
@@ -260,22 +260,10 @@ attribute [simp] homEquiv_naturality_left_symm homEquiv_naturality_right
 
 variable {F : C ⥤ D} {G : D ⥤ C} (adj : CoreHomEquiv F G) {X' X : C} {Y Y' : D}
 
-@[simp]
-theorem homEquiv_naturality_left_aux (f : X' ⟶ X) (g : F.obj X ⟶ Y) :
-    (adj.homEquiv X' (F.obj X)) (F.map f) ≫ G.map g = f ≫ (adj.homEquiv X Y) g := by
-  rw [← homEquiv_naturality_right, ← Equiv.eq_symm_apply]; simp
-
--- @[simp] -- Porting note: LHS simplifies, added aux lemma above
 theorem homEquiv_naturality_left (f : X' ⟶ X) (g : F.obj X ⟶ Y) :
     (adj.homEquiv X' Y) (F.map f ≫ g) = f ≫ (adj.homEquiv X Y) g := by
   rw [← Equiv.eq_symm_apply]; simp
 
-@[simp]
-theorem homEquiv_naturality_right_symm_aux (f : X ⟶ G.obj Y) (g : Y ⟶ Y') :
-    F.map f ≫ (adj.homEquiv (G.obj Y) Y').symm (G.map g) = (adj.homEquiv X Y).symm f ≫ g := by
-  rw [← homEquiv_naturality_left_symm, Equiv.symm_apply_eq]; simp
-
--- @[simp] -- Porting note: LHS simplifies, added aux lemma above
 theorem homEquiv_naturality_right_symm (f : X ⟶ G.obj Y) (g : Y ⟶ Y') :
     (adj.homEquiv X Y').symm (f ≫ G.map g) = (adj.homEquiv X Y).symm f ≫ g := by
   rw [Equiv.symm_apply_eq]; simp
@@ -361,11 +349,6 @@ def mkOfUnitCounit (adj : CoreUnitCounit F G) : F ⊣ G :=
           dsimp at t
           simp only [id_comp] at t
           exact t } }
-
-/- Porting note: simpNF linter claims these are solved by simp but that
-is not true -/
-attribute [nolint simpNF] CategoryTheory.Adjunction.mkOfUnitCounit_homEquiv_symm_apply
-attribute [nolint simpNF] CategoryTheory.Adjunction.mkOfUnitCounit_homEquiv_apply
 
 /-- The adjunction between the identity functor on a category and itself. -/
 def id : 𝟭 C ⊣ 𝟭 C where

--- a/Mathlib/CategoryTheory/Adjunction/Basic.lean
+++ b/Mathlib/CategoryTheory/Adjunction/Basic.lean
@@ -103,7 +103,7 @@ noncomputable def Adjunction.ofIsRightAdjoint (right : C ⥤ D) [right.IsRightAd
 
 namespace Adjunction
 
-attribute [simp] homEquiv_unit homEquiv_counit
+attribute [simp 1100] homEquiv_unit homEquiv_counit
 
 section
 

--- a/Mathlib/CategoryTheory/Adjunction/Basic.lean
+++ b/Mathlib/CategoryTheory/Adjunction/Basic.lean
@@ -52,7 +52,7 @@ constructors `mkOfHomEquiv` or `mkOfUnitCounit`. To construct a left adjoint,
 there are also constructors `leftAdjointOfEquiv` and `adjunctionOfEquivLeft` (as
 well as their duals) which can be simpler in practice.
 
-Uniqueness of adjoints is shown in `CategoryTheory.Adjunction.Unique`.
+Uniqueness of adjoints is shown in `CategoryTheory.Adjunction.Opposites`.
 
 See <https://stacks.math.columbia.edu/tag/0037>.
 -/
@@ -63,9 +63,11 @@ structure Adjunction (F : C ⥤ D) (G : D ⥤ C) where
   unit : 𝟭 C ⟶ F.comp G
   /-- The counit of an adjunction -/
   counit : G.comp F ⟶ 𝟭 D
-  /-- The relationship between the unit and hom set equivalence of an adjunction -/
-  homEquiv_unit : ∀ {X Y f}, (homEquiv X Y) f = unit.app X ≫ G.map f := by aesop_cat
-  /-- The relationship between the counit and hom set equivalence of an adjunction -/
+  -- Porting note: It's strange that this `Prop` is being flagged by the `docBlame` linter
+  /-- Naturality of the unit of an adjunction -/
+  homEquiv_unit : ∀ {X Y f}, (homEquiv X Y) f = (unit : _ ⟶ _).app X ≫ G.map f := by aesop_cat
+  -- Porting note: It's strange that this `Prop` is being flagged by the `docBlame` linter
+  /-- Naturality of the counit of an adjunction -/
   homEquiv_counit : ∀ {X Y g}, (homEquiv X Y).symm g = F.map g ≫ counit.app Y := by aesop_cat
 
 /-- The notation `F ⊣ G` stands for `Adjunction F G` representing that `F` is left adjoint to `G` -/
@@ -103,6 +105,11 @@ noncomputable def Adjunction.ofIsRightAdjoint (right : C ⥤ D) [right.IsRightAd
 
 namespace Adjunction
 
+-- Porting note: Workaround not needed in Lean 4
+-- restate_axiom homEquiv_unit'
+
+-- restate_axiom homEquiv_counit'
+
 attribute [simp] homEquiv_unit homEquiv_counit
 
 section
@@ -125,23 +132,35 @@ theorem homEquiv_id (X : C) : adj.homEquiv X _ (𝟙 _) = adj.unit.app X := by s
 
 theorem homEquiv_symm_id (X : D) : (adj.homEquiv _ X).symm (𝟙 _) = adj.counit.app X := by simp
 
+/-
+Porting note: `nolint simpNF` as the linter was complaining that this was provable using `simp`
+but it is in fact not. Also the `docBlame` linter expects a docstring even though this is `Prop`
+valued
+-/
+@[simp, nolint simpNF]
 theorem homEquiv_naturality_left_symm (f : X' ⟶ X) (g : X ⟶ G.obj Y) :
     (adj.homEquiv X' Y).symm (f ≫ g) = F.map f ≫ (adj.homEquiv X Y).symm g := by
-  simp
+  rw [homEquiv_counit, F.map_comp, assoc, adj.homEquiv_counit.symm]
 
+-- Porting note: Same as above
+@[simp, nolint simpNF]
 theorem homEquiv_naturality_left (f : X' ⟶ X) (g : F.obj X ⟶ Y) :
     (adj.homEquiv X' Y) (F.map f ≫ g) = f ≫ (adj.homEquiv X Y) g := by
   rw [← Equiv.eq_symm_apply]
-  simp only [Equiv.symm_apply_apply, eq_self_iff_true, homEquiv_naturality_left_symm]
+  simp only [Equiv.symm_apply_apply,eq_self_iff_true,homEquiv_naturality_left_symm]
 
+-- Porting note: Same as above
+@[simp, nolint simpNF]
 theorem homEquiv_naturality_right (f : F.obj X ⟶ Y) (g : Y ⟶ Y') :
     (adj.homEquiv X Y') (f ≫ g) = (adj.homEquiv X Y) f ≫ G.map g := by
-  simp
+  rw [homEquiv_unit, G.map_comp, ← assoc, ← homEquiv_unit]
 
+-- Porting note: Same as above
+@[simp, nolint simpNF]
 theorem homEquiv_naturality_right_symm (f : X ⟶ G.obj Y) (g : Y ⟶ Y') :
     (adj.homEquiv X Y').symm (f ≫ G.map g) = (adj.homEquiv X Y).symm f ≫ g := by
   rw [Equiv.symm_apply_eq]
-  simp only [homEquiv_naturality_right, eq_self_iff_true, Equiv.apply_symm_apply]
+  simp only [homEquiv_naturality_right,eq_self_iff_true,Equiv.apply_symm_apply]
 
 @[reassoc]
 theorem homEquiv_naturality_left_square (f : X' ⟶ X) (g : F.obj X ⟶ Y')
@@ -174,13 +193,13 @@ theorem homEquiv_naturality_right_square_iff (f : X' ⟶ X) (g : X ⟶ G.obj Y')
 @[simp]
 theorem left_triangle : whiskerRight adj.unit F ≫ whiskerLeft F adj.counit = 𝟙 _ := by
   ext; dsimp
-  rw [← adj.homEquiv_counit, Equiv.symm_apply_eq, adj.homEquiv_unit]
+  erw [← adj.homEquiv_counit, Equiv.symm_apply_eq, adj.homEquiv_unit]
   simp
 
 @[simp]
 theorem right_triangle : whiskerLeft G adj.unit ≫ whiskerRight adj.counit G = 𝟙 _ := by
   ext; dsimp
-  rw [← adj.homEquiv_unit, ← Equiv.eq_symm_apply, adj.homEquiv_counit]
+  erw [← adj.homEquiv_unit, ← Equiv.eq_symm_apply, adj.homEquiv_counit]
   simp
 
 variable (X Y)
@@ -251,14 +270,31 @@ structure CoreHomEquiv (F : C ⥤ D) (G : D ⥤ C) where
 
 namespace CoreHomEquiv
 
+-- Porting note: Workaround not needed in Lean 4.
+-- restate_axiom homEquiv_naturality_left_symm'
+
+-- restate_axiom homEquiv_naturality_right'
+
 attribute [simp] homEquiv_naturality_left_symm homEquiv_naturality_right
 
 variable {F : C ⥤ D} {G : D ⥤ C} (adj : CoreHomEquiv F G) {X' X : C} {Y Y' : D}
 
+@[simp]
+theorem homEquiv_naturality_left_aux (f : X' ⟶ X) (g : F.obj X ⟶ Y) :
+    (adj.homEquiv X' (F.obj X)) (F.map f) ≫ G.map g = f ≫ (adj.homEquiv X Y) g := by
+  rw [← homEquiv_naturality_right, ← Equiv.eq_symm_apply]; simp
+
+-- @[simp] -- Porting note: LHS simplifies, added aux lemma above
 theorem homEquiv_naturality_left (f : X' ⟶ X) (g : F.obj X ⟶ Y) :
     (adj.homEquiv X' Y) (F.map f ≫ g) = f ≫ (adj.homEquiv X Y) g := by
   rw [← Equiv.eq_symm_apply]; simp
 
+@[simp]
+theorem homEquiv_naturality_right_symm_aux (f : X ⟶ G.obj Y) (g : Y ⟶ Y') :
+    F.map f ≫ (adj.homEquiv (G.obj Y) Y').symm (G.map g) = (adj.homEquiv X Y).symm f ≫ g := by
+  rw [← homEquiv_naturality_left_symm, Equiv.symm_apply_eq]; simp
+
+-- @[simp] -- Porting note: LHS simplifies, added aux lemma above
 theorem homEquiv_naturality_right_symm (f : X ⟶ G.obj Y) (g : Y ⟶ Y') :
     (adj.homEquiv X Y').symm (f ≫ G.map g) = (adj.homEquiv X Y).symm f ≫ g := by
   rw [Equiv.symm_apply_eq]; simp
@@ -301,19 +337,23 @@ variable {F : C ⥤ D} {G : D ⥤ C}
 `F.obj X ⟶ Y` and `X ⟶ G.obj Y`. -/
 @[simps]
 def mkOfHomEquiv (adj : CoreHomEquiv F G) : F ⊣ G :=
+  -- See note [dsimp, simp].
   { adj with
     unit :=
       { app := fun X => (adj.homEquiv X (F.obj X)) (𝟙 (F.obj X))
         naturality := by
           intros
-          simp [← adj.homEquiv_naturality_left, ← adj.homEquiv_naturality_right] }
+          erw [← adj.homEquiv_naturality_left, ← adj.homEquiv_naturality_right]
+          dsimp; simp }
     counit :=
       { app := fun Y => (adj.homEquiv _ _).invFun (𝟙 (G.obj Y))
         naturality := by
           intros
-          simp [← adj.homEquiv_naturality_left_symm, ← adj.homEquiv_naturality_right_symm] }
-    homEquiv_unit := @fun X Y f => by simp [← adj.homEquiv_naturality_right]
-    homEquiv_counit := @fun X Y f => by simp [← adj.homEquiv_naturality_left_symm] }
+          erw [← adj.homEquiv_naturality_left_symm, ← adj.homEquiv_naturality_right_symm]
+          dsimp; simp }
+    homEquiv_unit := @fun X Y f => by erw [← adj.homEquiv_naturality_right]; simp
+    homEquiv_counit := @fun X Y f => by erw [← adj.homEquiv_naturality_left_symm]; simp
+  }
 
 /-- Construct an adjunction between functors `F` and `G` given a unit and counit for the adjunction
 satisfying the triangle identities. -/
@@ -340,6 +380,11 @@ def mkOfUnitCounit (adj : CoreUnitCounit F G) : F ⊣ G :=
           dsimp at t
           simp only [id_comp] at t
           exact t } }
+
+/- Porting note: simpNF linter claims these are solved by simp but that
+is not true -/
+attribute [nolint simpNF] CategoryTheory.Adjunction.mkOfUnitCounit_homEquiv_symm_apply
+attribute [nolint simpNF] CategoryTheory.Adjunction.mkOfUnitCounit_homEquiv_apply
 
 /-- The adjunction between the identity functor on a category and itself. -/
 def id : 𝟭 C ⊣ 𝟭 C where
@@ -443,7 +488,12 @@ def adjunctionOfEquivLeft : leftAdjointOfEquiv e he ⊣ G :=
         have {X : C} {Y Y' : D} (f : X ⟶ G.obj Y) (g : Y ⟶ Y') :
             (e X Y').symm (f ≫ G.map g) = (e X Y).symm f ≫ g := by
           rw [Equiv.symm_apply_eq, he]; simp
-        simp [← this, ← Equiv.apply_eq_iff_eq (e X' Y), ← he] }
+        erw [← this, ← Equiv.apply_eq_iff_eq (e X' Y)]
+        simp only [leftAdjointOfEquiv_obj, Equiv.apply_symm_apply, assoc]
+        congr
+        rw [← he]
+        simp
+    }
 
 end ConstructLeft
 
@@ -480,10 +530,10 @@ def adjunctionOfEquivRight (he : ∀ X' X Y f g, e X' Y (F.map f ≫ g) = f ≫ 
   mkOfHomEquiv
     { homEquiv := e
       homEquiv_naturality_left_symm := by
-        intro X X' Y f g; rw [Equiv.symm_apply_eq]; simp [he]
+        intro X X' Y f g; rw [Equiv.symm_apply_eq]; dsimp; rw [he]; simp
       homEquiv_naturality_right := by
         intro X Y Y' g h
-        simp [← he, reassoc_of% (he'' e)] }
+        erw [← he, Equiv.apply_eq_iff_eq, ← assoc, he'' e he, comp_id, Equiv.symm_apply_apply] }
 
 end ConstructRight
 
@@ -520,7 +570,16 @@ variable (e : C ≌ D)
 simply use `e.symm.toAdjunction`. -/
 @[simps! unit counit]
 def toAdjunction : e.functor ⊣ e.inverse :=
-  mkOfUnitCounit ⟨e.unit, e.counit, by ext; simp, by ext; simp⟩
+  mkOfUnitCounit
+    ⟨e.unit, e.counit, by
+      ext
+      dsimp
+      simp only [id_comp]
+      exact e.functor_unit_comp _, by
+      ext
+      dsimp
+      simp only [id_comp]
+      exact e.unit_inverse_comp _⟩
 
 lemma isLeftAdjoint_functor : e.functor.IsLeftAdjoint where
   exists_rightAdjoint := ⟨_, ⟨e.toAdjunction⟩⟩

--- a/Mathlib/CategoryTheory/Adjunction/Basic.lean
+++ b/Mathlib/CategoryTheory/Adjunction/Basic.lean
@@ -52,7 +52,7 @@ constructors `mkOfHomEquiv` or `mkOfUnitCounit`. To construct a left adjoint,
 there are also constructors `leftAdjointOfEquiv` and `adjunctionOfEquivLeft` (as
 well as their duals) which can be simpler in practice.
 
-Uniqueness of adjoints is shown in `CategoryTheory.Adjunction.Opposites`.
+Uniqueness of adjoints is shown in `CategoryTheory.Adjunction.Unique`.
 
 See <https://stacks.math.columbia.edu/tag/0037>.
 -/
@@ -63,11 +63,9 @@ structure Adjunction (F : C ⥤ D) (G : D ⥤ C) where
   unit : 𝟭 C ⟶ F.comp G
   /-- The counit of an adjunction -/
   counit : G.comp F ⟶ 𝟭 D
-  -- Porting note: It's strange that this `Prop` is being flagged by the `docBlame` linter
-  /-- Naturality of the unit of an adjunction -/
+  /-- The relationship between the unit and hom set equivalence of an adjunction -/
   homEquiv_unit : ∀ {X Y f}, (homEquiv X Y) f = (unit : _ ⟶ _).app X ≫ G.map f := by aesop_cat
-  -- Porting note: It's strange that this `Prop` is being flagged by the `docBlame` linter
-  /-- Naturality of the counit of an adjunction -/
+  /-- The relationship between the counit and hom set equivalence of an adjunction -/
   homEquiv_counit : ∀ {X Y g}, (homEquiv X Y).symm g = F.map g ≫ counit.app Y := by aesop_cat
 
 /-- The notation `F ⊣ G` stands for `Adjunction F G` representing that `F` is left adjoint to `G` -/
@@ -105,11 +103,6 @@ noncomputable def Adjunction.ofIsRightAdjoint (right : C ⥤ D) [right.IsRightAd
 
 namespace Adjunction
 
--- Porting note: Workaround not needed in Lean 4
--- restate_axiom homEquiv_unit'
-
--- restate_axiom homEquiv_counit'
-
 attribute [simp] homEquiv_unit homEquiv_counit
 
 section
@@ -132,35 +125,23 @@ theorem homEquiv_id (X : C) : adj.homEquiv X _ (𝟙 _) = adj.unit.app X := by s
 
 theorem homEquiv_symm_id (X : D) : (adj.homEquiv _ X).symm (𝟙 _) = adj.counit.app X := by simp
 
-/-
-Porting note: `nolint simpNF` as the linter was complaining that this was provable using `simp`
-but it is in fact not. Also the `docBlame` linter expects a docstring even though this is `Prop`
-valued
--/
-@[simp, nolint simpNF]
 theorem homEquiv_naturality_left_symm (f : X' ⟶ X) (g : X ⟶ G.obj Y) :
     (adj.homEquiv X' Y).symm (f ≫ g) = F.map f ≫ (adj.homEquiv X Y).symm g := by
-  rw [homEquiv_counit, F.map_comp, assoc, adj.homEquiv_counit.symm]
+  simp
 
--- Porting note: Same as above
-@[simp, nolint simpNF]
 theorem homEquiv_naturality_left (f : X' ⟶ X) (g : F.obj X ⟶ Y) :
     (adj.homEquiv X' Y) (F.map f ≫ g) = f ≫ (adj.homEquiv X Y) g := by
   rw [← Equiv.eq_symm_apply]
-  simp only [Equiv.symm_apply_apply,eq_self_iff_true,homEquiv_naturality_left_symm]
+  simp only [Equiv.symm_apply_apply, eq_self_iff_true, homEquiv_naturality_left_symm]
 
--- Porting note: Same as above
-@[simp, nolint simpNF]
 theorem homEquiv_naturality_right (f : F.obj X ⟶ Y) (g : Y ⟶ Y') :
     (adj.homEquiv X Y') (f ≫ g) = (adj.homEquiv X Y) f ≫ G.map g := by
-  rw [homEquiv_unit, G.map_comp, ← assoc, ← homEquiv_unit]
+  simp
 
--- Porting note: Same as above
-@[simp, nolint simpNF]
 theorem homEquiv_naturality_right_symm (f : X ⟶ G.obj Y) (g : Y ⟶ Y') :
     (adj.homEquiv X Y').symm (f ≫ G.map g) = (adj.homEquiv X Y).symm f ≫ g := by
   rw [Equiv.symm_apply_eq]
-  simp only [homEquiv_naturality_right,eq_self_iff_true,Equiv.apply_symm_apply]
+  simp only [homEquiv_naturality_right, eq_self_iff_true, Equiv.apply_symm_apply]
 
 @[reassoc]
 theorem homEquiv_naturality_left_square (f : X' ⟶ X) (g : F.obj X ⟶ Y')

--- a/Mathlib/CategoryTheory/Adjunction/Opposites.lean
+++ b/Mathlib/CategoryTheory/Adjunction/Opposites.lean
@@ -27,9 +27,6 @@ variable {C : Type u₁} [Category.{v₁} C] {D : Type u₂} [Category.{v₂} D]
 
 namespace CategoryTheory.Adjunction
 
-lemma functor_comp_op {E : Type*} [Category E] {F : C ⥤ D} {G : D ⥤ E} :
-    F.op ⋙ G.op = (F ⋙ G).op := by rfl
-
 /-- If `G.op` is adjoint to `F.op` then `F` is adjoint to `G`. -/
 @[simps! unit_app counit_app]
 def adjointOfOpAdjointOp (F : C ⥤ D) (G : D ⥤ C) (h : G.op ⊣ F.op) : F ⊣ G :=

--- a/Mathlib/CategoryTheory/Adjunction/Opposites.lean
+++ b/Mathlib/CategoryTheory/Adjunction/Opposites.lean
@@ -27,6 +27,11 @@ variable {C : Type u₁} [Category.{v₁} C] {D : Type u₂} [Category.{v₂} D]
 
 namespace CategoryTheory.Adjunction
 
+attribute [local simp 2000] homEquiv_unit homEquiv_counit
+
+lemma functor_comp_op {E : Type*} [Category E] {F : C ⥤ D} {G : D ⥤ E} :
+    F.op ⋙ G.op = (F ⋙ G).op := by rfl
+
 /-- If `G.op` is adjoint to `F.op` then `F` is adjoint to `G`. -/
 @[simps! unit_app counit_app]
 def adjointOfOpAdjointOp (F : C ⥤ D) (G : D ⥤ C) (h : G.op ⊣ F.op) : F ⊣ G :=
@@ -70,21 +75,15 @@ def opAdjointOpOfAdjoint (F : C ⥤ D) (G : D ⥤ C) (h : G ⊣ F) : F.op ⊣ G.
     homEquiv := fun X Y =>
       (opEquiv _ Y).trans ((h.homEquiv _ _).symm.trans (opEquiv X (Opposite.op _)).symm)
     homEquiv_naturality_left_symm := by
-      -- Porting note: This proof was handled by `obviously` in mathlib3.
-      intros X' X Y f g
-      dsimp [opEquiv]
-      -- Porting note: Why is `erw` needed here?
-      -- https://github.com/leanprover-community/mathlib4/issues/5164
-      erw [homEquiv_unit, homEquiv_unit]
-      simp
+      -- Porting note: This proof was handled by `obviously` in mathlib3. The only obstruction to
+      -- automation fully kicking in here is that the `@[simps]` lemmas of `opEquiv` aren't firing.
+      intros
+      simp [opEquiv]
     homEquiv_naturality_right := by
-      -- Porting note: This proof was handled by `obviously` in mathlib3.
-      intros X' X Y f g
-      dsimp [opEquiv]
-      -- Porting note: Why is `erw` needed here?
-      -- https://github.com/leanprover-community/mathlib4/issues/5164
-      erw [homEquiv_counit, homEquiv_counit]
-      simp }
+      -- Porting note: This proof was handled by `obviously` in mathlib3. The only obstruction to
+      -- automation fully kicking in here is that the `@[simps]` lemmas of `opEquiv` aren't firing.
+      intros
+      simp [opEquiv] }
 
 /-- If `G` is adjoint to `F.unop` then `F` is adjoint to `G.op`. -/
 def adjointOpOfAdjointUnop (F : Cᵒᵖ ⥤ Dᵒᵖ) (G : D ⥤ C) (h : G ⊣ F.unop) : F ⊣ G.op :=

--- a/Mathlib/CategoryTheory/Adjunction/Opposites.lean
+++ b/Mathlib/CategoryTheory/Adjunction/Opposites.lean
@@ -27,8 +27,6 @@ variable {C : Type u₁} [Category.{v₁} C] {D : Type u₂} [Category.{v₂} D]
 
 namespace CategoryTheory.Adjunction
 
-attribute [local simp 2000] homEquiv_unit homEquiv_counit
-
 lemma functor_comp_op {E : Type*} [Category E] {F : C ⥤ D} {G : D ⥤ E} :
     F.op ⋙ G.op = (F ⋙ G).op := by rfl
 

--- a/Mathlib/CategoryTheory/Adjunction/Opposites.lean
+++ b/Mathlib/CategoryTheory/Adjunction/Opposites.lean
@@ -28,10 +28,6 @@ variable {C : Type u₁} [Category.{v₁} C] {D : Type u₂} [Category.{v₂} D]
 namespace CategoryTheory.Adjunction
 
 /-- If `G.op` is adjoint to `F.op` then `F` is adjoint to `G`. -/
--- Porting note: in mathlib3 we generated all the default `simps` lemmas.
--- However the `simpNF` linter correctly flags some of these as unsuitable simp lemmas.
--- `unit_app` and `counit_app` appear to suffice (tested in mathlib3).
--- See also the porting note on opAdjointOpOfAdjoint
 @[simps! unit_app counit_app]
 def adjointOfOpAdjointOp (F : C ⥤ D) (G : D ⥤ C) (h : G.op ⊣ F.op) : F ⊣ G :=
   Adjunction.mkOfHomEquiv {
@@ -69,10 +65,6 @@ def unopAdjointUnopOfAdjoint (F : Cᵒᵖ ⥤ Dᵒᵖ) (G : Dᵒᵖ ⥤ Cᵒᵖ)
 
 /-- If `G` is adjoint to `F` then `F.op` is adjoint to `G.op`. -/
 @[simps! unit_app counit_app]
--- Porting note: in mathlib3 we generated all the default `simps` lemmas.
--- However the `simpNF` linter correctly flags some of these as unsuitable simp lemmas.
--- `unit_app` and `counit_app` appear to suffice (tested in mathlib3).
--- See also the porting note on adjointOfOpAdjointOp
 def opAdjointOpOfAdjoint (F : C ⥤ D) (G : D ⥤ C) (h : G ⊣ F) : F.op ⊣ G.op :=
   Adjunction.mkOfHomEquiv {
     homEquiv := fun X Y =>


### PR DESCRIPTION
---

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
