### PR TITLE
[Merged by Bors] - chore(CategoryTheory/Limits): remove two porting notes

### DIFF
--- a/Mathlib/CategoryTheory/Limits/IsLimit.lean
+++ b/Mathlib/CategoryTheory/Limits/IsLimit.lean
@@ -60,9 +60,6 @@ structure IsLimit (t : Cone F) where
   uniq : ∀ (s : Cone F) (m : s.pt ⟶ t.pt) (_ : ∀ j : J, m ≫ t.π.app j = s.π.app j), m = lift s := by
     aesop_cat
 
--- Porting note (#10618):  simp can prove this. Linter complains it still exists
-attribute [-simp, nolint simpNF] IsLimit.mk.injEq
-
 attribute [reassoc (attr := simp)] IsLimit.fac
 
 namespace IsLimit
@@ -515,9 +512,6 @@ structure IsColimit (t : Cocone F) where
     aesop_cat
 
 attribute [reassoc (attr := simp)] IsColimit.fac
-
--- Porting note (#10618): simp can prove this. Linter claims it still is tagged with simp
-attribute [-simp, nolint simpNF] IsColimit.mk.injEq
 
 namespace IsColimit
 


### PR DESCRIPTION
This appears to have been a bug in the `simpNF` linter which is now fixed

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
