### PR TITLE
[Merged by Bors] - chore(CategoryTheory/Category): address some porting notes

### DIFF
--- a/Mathlib/CategoryTheory/Category/Pairwise.lean
+++ b/Mathlib/CategoryTheory/Category/Pairwise.lean
@@ -109,15 +109,11 @@ def diagramMap : ∀ {o₁ o₂ : Pairwise ι} (_ : o₁ ⟶ o₂), diagramObj U
   | _, _, left _ _ => homOfLE inf_le_left
   | _, _, right _ _ => homOfLE inf_le_right
 
--- Porting note: the fields map_id and map_comp were filled by hand, as generating them by `aesop`
--- causes a PANIC.
 /-- Given a function `U : ι → α` for `[SemilatticeInf α]`, we obtain a functor `Pairwise ι ⥤ α`,
 sending `single i` to `U i` and `pair i j` to `U i ⊓ U j`,
 and the morphisms to the obvious inequalities.
 -/
--- Porting note: We want `@[simps]` here, but this causes a PANIC in the linter.
--- (Which, worryingly, does not cause a linter failure!)
--- @[simps]
+@[simps]
 def diagram : Pairwise ι ⥤ α where
   obj := diagramObj U
   map := diagramMap U

--- a/Mathlib/CategoryTheory/Category/PartialFun.lean
+++ b/Mathlib/CategoryTheory/Category/PartialFun.lean
@@ -46,8 +46,6 @@ instance : CoeSort PartialFun Type* :=
 def of : Type* → PartialFun :=
   id
 
--- Porting note: removed this lemma which is useless because of the expansion of coercions
-
 instance : Inhabited PartialFun :=
   ⟨Type*⟩
 

--- a/Mathlib/CategoryTheory/Category/Preorder.lean
+++ b/Mathlib/CategoryTheory/Category/Preorder.lean
@@ -85,17 +85,6 @@ theorem leOfHom {x y : X} (h : x ⟶ y) : x ≤ y :=
 @[nolint defLemma, inherit_doc leOfHom]
 abbrev _root_.Quiver.Hom.le := @leOfHom
 
--- Porting note: why does this lemma exist? With proof irrelevance, we don't need to simplify proofs
--- @[simp]
-theorem leOfHom_homOfLE {x y : X} (h : x ≤ y) : h.hom.le = h :=
-  rfl
-
--- Porting note: linter gives: "Left-hand side does not simplify, when using the simp lemma on
--- itself. This usually means that it will never apply." removing simp? It doesn't fire
--- @[simp]
-theorem homOfLE_leOfHom {x y : X} (h : x ⟶ y) : h.le.hom = h :=
-  rfl
-
 lemma homOfLE_isIso_of_eq {x y : X} (h : x ≤ y) (heq : x = y) :
     IsIso (homOfLE h) :=
   ⟨homOfLE (le_of_eq heq.symm), by simp⟩

--- a/Mathlib/CategoryTheory/Category/Preorder.lean
+++ b/Mathlib/CategoryTheory/Category/Preorder.lean
@@ -85,6 +85,10 @@ theorem leOfHom {x y : X} (h : x ⟶ y) : x ≤ y :=
 @[nolint defLemma, inherit_doc leOfHom]
 abbrev _root_.Quiver.Hom.le := @leOfHom
 
+@[simp]
+theorem homOfLE_leOfHom {x y : X} (h : x ⟶ y) : h.le.hom = h :=
+  rfl
+
 lemma homOfLE_isIso_of_eq {x y : X} (h : x ≤ y) (heq : x = y) :
     IsIso (homOfLE h) :=
   ⟨homOfLE (le_of_eq heq.symm), by simp⟩


### PR DESCRIPTION
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
