### PR TITLE
chore(Nat/GCD): split off `GCD/Defs` from `GCD/Basic`

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -2552,7 +2552,6 @@ import Mathlib.Data.ZMod.Coprime
 import Mathlib.Data.ZMod.Defs
 import Mathlib.Data.ZMod.Factorial
 import Mathlib.Data.ZMod.IntUnitsPower
-import Mathlib.Data.ZMod.ModEq
 import Mathlib.Data.ZMod.Module
 import Mathlib.Data.ZMod.Parity
 import Mathlib.Data.ZMod.Quotient

--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -2359,6 +2359,7 @@ import Mathlib.Data.Nat.Fib.Basic
 import Mathlib.Data.Nat.Fib.Zeckendorf
 import Mathlib.Data.Nat.Find
 import Mathlib.Data.Nat.GCD.Basic
+import Mathlib.Data.Nat.GCD.Defs
 import Mathlib.Data.Nat.GCD.BigOperators
 import Mathlib.Data.Nat.Hyperoperation
 import Mathlib.Data.Nat.Lattice

--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -2359,8 +2359,8 @@ import Mathlib.Data.Nat.Fib.Basic
 import Mathlib.Data.Nat.Fib.Zeckendorf
 import Mathlib.Data.Nat.Find
 import Mathlib.Data.Nat.GCD.Basic
-import Mathlib.Data.Nat.GCD.Defs
 import Mathlib.Data.Nat.GCD.BigOperators
+import Mathlib.Data.Nat.GCD.Defs
 import Mathlib.Data.Nat.Hyperoperation
 import Mathlib.Data.Nat.Lattice
 import Mathlib.Data.Nat.Log
@@ -2552,6 +2552,7 @@ import Mathlib.Data.ZMod.Coprime
 import Mathlib.Data.ZMod.Defs
 import Mathlib.Data.ZMod.Factorial
 import Mathlib.Data.ZMod.IntUnitsPower
+import Mathlib.Data.ZMod.ModEq
 import Mathlib.Data.ZMod.Module
 import Mathlib.Data.ZMod.Parity
 import Mathlib.Data.ZMod.Quotient

--- a/Mathlib/Data/Nat/Factors.lean
+++ b/Mathlib/Data/Nat/Factors.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Leonardo de Moura, Jeremy Avigad, Mario Carneiro
 -/
 import Mathlib.Algebra.BigOperators.Ring.List
+import Mathlib.Data.Nat.GCD.Basic
 import Mathlib.Data.Nat.Prime.Defs
 import Mathlib.Data.List.Prime
 import Mathlib.Data.List.Sort

--- a/Mathlib/Data/Nat/GCD/Basic.lean
+++ b/Mathlib/Data/Nat/GCD/Basic.lean
@@ -6,7 +6,7 @@ Authors: Jeremy Avigad, Leonardo de Moura
 import Mathlib.Algebra.GroupWithZero.Divisibility
 import Mathlib.Algebra.Ring.Nat
 import Mathlib.Init.Data.Nat.Lemmas
-import Mathlib.Data.Nat.GCD.Defs
+import Mathlib.Order.Basic
 
 /-!
 # Definitions and properties of `Nat.gcd`, `Nat.lcm`, and `Nat.coprime`

--- a/Mathlib/Data/Nat/GCD/Basic.lean
+++ b/Mathlib/Data/Nat/GCD/Basic.lean
@@ -3,11 +3,10 @@ Copyright (c) 2014 Jeremy Avigad. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Jeremy Avigad, Leonardo de Moura
 -/
-import Mathlib.Order.Lattice
 import Mathlib.Algebra.GroupWithZero.Divisibility
 import Mathlib.Algebra.Ring.Nat
 import Mathlib.Init.Data.Nat.Lemmas
-import Mathlib.Order.Basic
+import Mathlib.Data.Nat.GCD.Defs
 
 /-!
 # Definitions and properties of `Nat.gcd`, `Nat.lcm`, and `Nat.coprime`
@@ -131,8 +130,6 @@ theorem lcm_mul_right {m n k : ℕ} : (m * n).lcm (k * n) = m.lcm k * n := by
 
 See also `Nat.coprime_of_dvd` and `Nat.coprime_of_dvd'` to prove `Nat.Coprime m n`.
 -/
-
-instance (m n : ℕ) : Decidable (Coprime m n) := inferInstanceAs (Decidable (gcd m n = 1))
 
 theorem Coprime.lcm_eq_mul {m n : ℕ} (h : Coprime m n) : lcm m n = m * n := by
   rw [← one_mul (lcm m n), ← h.gcd_eq_one, gcd_mul_lcm]

--- a/Mathlib/Data/Nat/GCD/Defs.lean
+++ b/Mathlib/Data/Nat/GCD/Defs.lean
@@ -5,6 +5,10 @@ Authors: Jeremy Avigad, Leonardo de Moura
 -/
 import Mathlib.Order.Basic
 
+/-!
+# Definition of `Nat.Coprime`
+-/
+
 namespace Nat
 
 /-!

--- a/Mathlib/Data/Nat/GCD/Defs.lean
+++ b/Mathlib/Data/Nat/GCD/Defs.lean
@@ -1,0 +1,18 @@
+/-
+Copyright (c) 2014 Jeremy Avigad. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Jeremy Avigad, Leonardo de Moura
+-/
+import Mathlib.Order.Basic
+
+namespace Nat
+
+/-!
+### `Coprime`
+
+See also `Nat.coprime_of_dvd` and `Nat.coprime_of_dvd'` to prove `Nat.Coprime m n`.
+-/
+
+instance (m n : ℕ) : Decidable (Coprime m n) := inferInstanceAs (Decidable (gcd m n = 1))
+
+end Nat

--- a/Mathlib/Data/Nat/Prime/Defs.lean
+++ b/Mathlib/Data/Nat/Prime/Defs.lean
@@ -5,7 +5,7 @@ Authors: Leonardo de Moura, Jeremy Avigad, Mario Carneiro
 -/
 import Mathlib.Algebra.Associated.Basic
 import Mathlib.Algebra.Ring.Parity
-import Mathlib.Data.Nat.GCD.Basic
+import Mathlib.Data.Nat.GCD.Defs
 
 /-!
 # Prime numbers

--- a/Mathlib/Data/Rat/Encodable.lean
+++ b/Mathlib/Data/Rat/Encodable.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johannes Hölzl, Mario Carneiro
 -/
 import Mathlib.Logic.Encodable.Basic
-import Mathlib.Data.Nat.GCD.Basic
+import Mathlib.Data.Nat.GCD.Defs
 import Mathlib.Data.Rat.Init
 
 /-! # The rationals are `Encodable`.

--- a/Mathlib/Dynamics/PeriodicPts.lean
+++ b/Mathlib/Dynamics/PeriodicPts.lean
@@ -6,6 +6,7 @@ Authors: Yury Kudryashov
 import Mathlib.Algebra.GroupPower.IterateHom
 import Mathlib.Algebra.Ring.Divisibility.Basic
 import Mathlib.Data.List.Cycle
+import Mathlib.Data.Nat.GCD.Basic
 import Mathlib.Data.Nat.Prime.Basic
 import Mathlib.Data.PNat.Basic
 import Mathlib.Dynamics.FixedPoints.Basic

--- a/scripts/noshake.json
+++ b/scripts/noshake.json
@@ -346,6 +346,7 @@
   "Mathlib.Data.PEquiv": ["Batteries.Tactic.Congr"],
   "Mathlib.Data.Ordmap.Ordnode": ["Mathlib.Data.Option.Basic"],
   "Mathlib.Data.Option.NAry": ["Batteries.Tactic.Init"],
+  "Mathlib.Data.Nat.GCD.Defs": ["Mathlib.Order.Basic"],
   "Mathlib.Data.Nat.Find": ["Batteries.WF"],
   "Mathlib.Data.Multiset.Bind": ["Mathlib.Algebra.GroupWithZero.Action.Defs"],
   "Mathlib.Data.List.TFAE": ["Batteries.Tactic.Classical"],


### PR DESCRIPTION
Move definition of `Coprime` into the new `GCD/Defs`. Reduces what is imported by `Prime/Defs` and other files.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
