### PR TITLE
[Merged by Bors] - doc(Data/Finset/Lattice): fix typos in docstrings

### DIFF
--- a/Mathlib/Data/Finset/Lattice.lean
+++ b/Mathlib/Data/Finset/Lattice.lean
@@ -1307,13 +1307,13 @@ protected theorem min_eq_bot [OrderBot α] {s : Finset α} : s.min = ⊥ ↔ ⊥
   Finset.max_eq_top (α := αᵒᵈ)
 
 /-- Given a nonempty finset `s` in a linear order `α`, then `s.min' h` is its minimum, as an
-element of `α`, where `h` is a proof of nonemptiness. Without this assumption, use instead `s.min`,
+element of `α`, where `H` is a proof of nonemptiness. Without this assumption, use instead `s.min`,
 taking values in `WithTop α`. -/
 def min' (s : Finset α) (H : s.Nonempty) : α :=
   inf' s H id
 
 /-- Given a nonempty finset `s` in a linear order `α`, then `s.max' h` is its maximum, as an
-element of `α`, where `h` is a proof of nonemptiness. Without this assumption, use instead `s.max`,
+element of `α`, where `H` is a proof of nonemptiness. Without this assumption, use instead `s.max`,
 taking values in `WithBot α`. -/
 def max' (s : Finset α) (H : s.Nonempty) : α :=
   sup' s H id

--- a/Mathlib/Data/Finset/Lattice.lean
+++ b/Mathlib/Data/Finset/Lattice.lean
@@ -1306,13 +1306,13 @@ protected theorem le_min_iff {m : WithTop α} {s : Finset α} : m ≤ s.min ↔ 
 protected theorem min_eq_bot [OrderBot α] {s : Finset α} : s.min = ⊥ ↔ ⊥ ∈ s :=
   Finset.max_eq_top (α := αᵒᵈ)
 
-/-- Given a nonempty finset `s` in a linear order `α`, then `s.min' h` is its minimum, as an
+/-- Given a nonempty finset `s` in a linear order `α`, then `s.min' H` is its minimum, as an
 element of `α`, where `H` is a proof of nonemptiness. Without this assumption, use instead `s.min`,
 taking values in `WithTop α`. -/
 def min' (s : Finset α) (H : s.Nonempty) : α :=
   inf' s H id
 
-/-- Given a nonempty finset `s` in a linear order `α`, then `s.max' h` is its maximum, as an
+/-- Given a nonempty finset `s` in a linear order `α`, then `s.max' H` is its maximum, as an
 element of `α`, where `H` is a proof of nonemptiness. Without this assumption, use instead `s.max`,
 taking values in `WithBot α`. -/
 def max' (s : Finset α) (H : s.Nonempty) : α :=


### PR DESCRIPTION
In the docstrings of `Finset.min'` and `Finset.max'` a hypothesis named `H` was referred to as `h`. Even though the text was consistent, I think it is confusing when the docstring uses a different name compared to the definition.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
