### PR TITLE
[Merged by Bors] - refactor(ModelTheory): Prove preservation results at the level of `HomClass` and `StrongHomClass`

### DIFF
--- a/Mathlib/ModelTheory/Bundled.lean
+++ b/Mathlib/ModelTheory/Bundled.lean
@@ -111,7 +111,8 @@ def equivInduced {M : ModelType.{u, v, w} T} {N : Type w'} (e : M ≃ N) :
     ModelType.{u, v, w'} T where
   Carrier := N
   struc := e.inducedStructure
-  is_model := @Equiv.theory_model L M N _ e.inducedStructure T e.inducedStructureEquiv _
+  is_model := @StrongHomClass.theory_model L M N _ e.inducedStructure T
+    _ _ _ e.inducedStructureEquiv _
   nonempty' := e.symm.nonempty
 
 instance of_small (M : Type w) [Nonempty M] [L.Structure M] [M ⊨ T] [h : Small.{w'} M] :

--- a/Mathlib/ModelTheory/ElementaryMaps.lean
+++ b/Mathlib/ModelTheory/ElementaryMaps.lean
@@ -248,9 +248,9 @@ theorem isElementary_of_exists (f : M ↪[L] N)
   refine fun n φ => φ.recOn ?_ ?_ ?_ ?_ ?_
   · exact fun {_} _ => Iff.rfl
   · intros
-    simp [BoundedFormula.Realize, ← Sum.comp_elim, Embedding.realize_term]
+    simp [BoundedFormula.Realize, ← Sum.comp_elim, HomClass.realize_term]
   · intros
-    simp only [BoundedFormula.Realize, ← Sum.comp_elim, realize_term]
+    simp only [BoundedFormula.Realize, ← Sum.comp_elim, HomClass.realize_term]
     erw [map_rel f]
   · intro _ _ _ ih1 ih2 _
     simp [ih1, ih2]
@@ -301,7 +301,7 @@ end Equiv
 @[simp]
 theorem realize_term_substructure {α : Type*} {S : L.Substructure M} (v : α → S) (t : L.Term α) :
     t.realize ((↑) ∘ v) = (↑(t.realize v) : M) :=
-  S.subtype.realize_term t
+  HomClass.realize_term S.subtype
 
 end Language
 

--- a/Mathlib/ModelTheory/Satisfiability.lean
+++ b/Mathlib/ModelTheory/Satisfiability.lean
@@ -571,7 +571,7 @@ theorem Categorical.isComplete (h : κ.Categorical T) (h1 : ℵ₀ ≤ κ)
     obtain ⟨TF⟩ := h (MNT.toModel T) (MNF.toModel T) hNT hNF
     exact
       ((MNT.realize_sentence φ).trans
-        ((TF.realize_sentence φ).trans (MNF.realize_sentence φ).symm)).1 hMT⟩
+        ((StrongHomClass.realize_sentence TF φ).trans (MNF.realize_sentence φ).symm)).1 hMT⟩
 
 theorem empty_theory_categorical (T : Language.empty.Theory) : κ.Categorical T := fun M N hM hN =>
   by rw [empty.nonempty_equiv_iff, hM, hN]

--- a/Mathlib/ModelTheory/Semantics.lean
+++ b/Mathlib/ModelTheory/Semantics.lean
@@ -201,24 +201,15 @@ theorem realize_onTerm [L'.Structure M] (φ : L →ᴸ L') [φ.IsExpansionOn M] 
 end LHom
 
 @[simp]
-theorem Hom.realize_term (g : M →[L] N) {t : L.Term α} {v : α → M} :
+theorem HomClass.realize_term {F : Type*} [FunLike F M N] [HomClass L F M N]
+    (g : F) {t : L.Term α} {v : α → M} :
     t.realize (g ∘ v) = g (t.realize v) := by
   induction t
   · rfl
-  · rw [Term.realize, Term.realize, g.map_fun]
+  · rw [Term.realize, Term.realize, HomClass.map_fun]
     refine congr rfl ?_
     ext x
     simp [*]
-
-@[simp]
-theorem Embedding.realize_term {v : α → M} (t : L.Term α) (g : M ↪[L] N) :
-    t.realize (g ∘ v) = g (t.realize v) :=
-  g.toHom.realize_term
-
-@[simp]
-theorem Equiv.realize_term {v : α → M} (t : L.Term α) (g : M ≃[L] N) :
-    t.realize (g ∘ v) = g (t.realize v) :=
-  g.toHom.realize_term
 
 variable {n : ℕ}
 
@@ -842,16 +833,19 @@ theorem realize_iInf (s : Finset β) (f : β → L.BoundedFormula α n)
 
 end BoundedFormula
 
-namespace Equiv
+namespace StrongHomClass
+
+variable {F : Type*} [EquivLike F M N] [StrongHomClass L F M N] (g : F)
 
 @[simp]
-theorem realize_boundedFormula (g : M ≃[L] N) (φ : L.BoundedFormula α n) {v : α → M}
+theorem realize_boundedFormula (φ : L.BoundedFormula α n) {v : α → M}
     {xs : Fin n → M} : φ.Realize (g ∘ v) (g ∘ xs) ↔ φ.Realize v xs := by
   induction' φ with _ _ _ _ _ _ _ _ _ _ _ ih1 ih2 _ _ ih3
   · rfl
-  · simp only [BoundedFormula.Realize, ← Sum.comp_elim, Equiv.realize_term, g.injective.eq_iff]
-  · simp only [BoundedFormula.Realize, ← Sum.comp_elim, Equiv.realize_term]
-    exact g.map_rel _ _
+  · simp only [BoundedFormula.Realize, ← Sum.comp_elim, HomClass.realize_term,
+      EmbeddingLike.apply_eq_iff_eq g]
+  · simp only [BoundedFormula.Realize, ← Sum.comp_elim, HomClass.realize_term]
+    exact StrongHomClass.map_rel g _ _
   · rw [BoundedFormula.Realize, ih1, ih2, BoundedFormula.Realize]
   · rw [BoundedFormula.Realize, BoundedFormula.Realize]
     constructor
@@ -860,26 +854,29 @@ theorem realize_boundedFormula (g : M ≃[L] N) (φ : L.BoundedFormula α n) {v 
       rw [← Fin.comp_snoc, ih3] at h'
       exact h'
     · intro h a
-      have h' := h (g.symm a)
-      rw [← ih3, Fin.comp_snoc, g.apply_symm_apply] at h'
+      have h' := h (EquivLike.inv g a)
+      rw [← ih3, Fin.comp_snoc, EquivLike.apply_inv_apply g] at h'
       exact h'
 
 @[simp]
-theorem realize_formula (g : M ≃[L] N) (φ : L.Formula α) {v : α → M} :
+theorem realize_formula (φ : L.Formula α) {v : α → M} :
     φ.Realize (g ∘ v) ↔ φ.Realize v := by
-  rw [Formula.Realize, Formula.Realize, ← g.realize_boundedFormula φ, iff_eq_eq,
+  rw [Formula.Realize, Formula.Realize, ← realize_boundedFormula g φ, iff_eq_eq,
     Unique.eq_default (g ∘ default)]
 
-theorem realize_sentence (g : M ≃[L] N) (φ : L.Sentence) : M ⊨ φ ↔ N ⊨ φ := by
-  rw [Sentence.Realize, Sentence.Realize, ← g.realize_formula, Unique.eq_default (g ∘ default)]
+include g
 
-theorem theory_model (g : M ≃[L] N) [M ⊨ T] : N ⊨ T :=
-  ⟨fun φ hφ => (g.realize_sentence φ).1 (Theory.realize_sentence_of_mem T hφ)⟩
+theorem realize_sentence (φ : L.Sentence) : M ⊨ φ ↔ N ⊨ φ := by
+  rw [Sentence.Realize, Sentence.Realize, ← realize_formula g,
+    Unique.eq_default (g ∘ default)]
 
-theorem elementarilyEquivalent (g : M ≃[L] N) : M ≅[L] N :=
-  elementarilyEquivalent_iff.2 g.realize_sentence
+theorem theory_model [M ⊨ T] : N ⊨ T :=
+  ⟨fun φ hφ => (realize_sentence g φ).1 (Theory.realize_sentence_of_mem T hφ)⟩
 
-end Equiv
+theorem elementarilyEquivalent : M ≅[L] N :=
+  elementarilyEquivalent_iff.2 (realize_sentence g)
+
+end StrongHomClass
 
 namespace Relations
 

--- a/Mathlib/ModelTheory/Substructures.lean
+++ b/Mathlib/ModelTheory/Substructures.lean
@@ -607,13 +607,13 @@ theorem coe_topEquiv :
 theorem realize_boundedFormula_top {α : Type*} {n : ℕ} {φ : L.BoundedFormula α n}
     {v : α → (⊤ : L.Substructure M)} {xs : Fin n → (⊤ : L.Substructure M)} :
     φ.Realize v xs ↔ φ.Realize (((↑) : _ → M) ∘ v) ((↑) ∘ xs) := by
-  rw [← Substructure.topEquiv.realize_boundedFormula φ]
+  rw [← StrongHomClass.realize_boundedFormula Substructure.topEquiv φ]
   simp
 
 @[simp]
 theorem realize_formula_top {α : Type*} {φ : L.Formula α} {v : α → (⊤ : L.Substructure M)} :
     φ.Realize v ↔ φ.Realize (((↑) : (⊤ : L.Substructure M) → M) ∘ v) := by
-  rw [← Substructure.topEquiv.realize_formula φ]
+  rw [← StrongHomClass.realize_formula Substructure.topEquiv φ]
   simp
 
 /-- A dependent version of `Substructure.closure_induction`. -/


### PR DESCRIPTION
Prove results about various kinds of first-order maps preserving the values of terms and formulas at a level of higher generality, in terms of `HomClass` or `StrongHomClass` and `EquivLike`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
