### PR TITLE
feat(Field): add theorems in Stacks Project Chapter 09FA Fields

### DIFF
--- a/Mathlib/Algebra/Field/Defs.lean
+++ b/Mathlib/Algebra/Field/Defs.lean
@@ -171,7 +171,9 @@ to control the specific definitions for some special cases of `K` (in particular
 See also note [forgetful inheritance].
 
 If the field has positive characteristic `p`, our division by zero convention forces
-`ratCast (1 / p) = 1 / 0 = 0`. -/
+`ratCast (1 / p) = 1 / 0 = 0`.
+
+[Stacks: Definition 09FD, first part](https://stacks.math.columbia.edu/tag/09FD) -/
 class Field (K : Type u) extends CommRing K, DivisionRing K
 
 -- see Note [lower instance priority]

--- a/Mathlib/Algebra/Field/Subfield.lean
+++ b/Mathlib/Algebra/Field/Subfield.lean
@@ -145,7 +145,9 @@ end SubfieldClass
 
 /-- `Subfield R` is the type of subfields of `R`. A subfield of `R` is a subset `s` that is a
   multiplicative submonoid and an additive subgroup. Note in particular that it shares the
-  same 0 and 1 as R. -/
+  same 0 and 1 as R.
+
+  [Stacks: Definition 09FD, second part](https://stacks.math.columbia.edu/tag/09FD) -/
 structure Subfield (K : Type u) [DivisionRing K] extends Subring K where
   /-- A subfield is closed under multiplicative inverses. -/
   inv_mem' : ∀ x ∈ carrier, x⁻¹ ∈ carrier


### PR DESCRIPTION
Add theorems in Stacks Project Chapter 09FA Fields that are not in mathlib.

Co-authored-by:

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

- [x] depends on: #16105 

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
