### PR TITLE
[Merged by Bors] - feat: generalise LinearEquiv.curry to R-modules

### DIFF
--- a/Mathlib/Algebra/Module/Equiv/Basic.lean
+++ b/Mathlib/Algebra/Module/Equiv/Basic.lean
@@ -403,23 +403,23 @@ end Subsingleton
 
 section Uncurry
 
-variable [Semiring R] [Semiring R₂] [Semiring R₃]
-variable [AddCommMonoid M] [AddCommMonoid M₂] [AddCommMonoid M₃]
-variable (V V₂ R)
+variable [Semiring R]
+variable [AddCommMonoid M] [Module R M]
+variable (V V₂ R M)
 
 /-- Linear equivalence between a curried and uncurried function.
   Differs from `TensorProduct.curry`. -/
-protected def curry : (V × V₂ → R) ≃ₗ[R] V → V₂ → R :=
+protected def curry : (V × V₂ → M) ≃ₗ[R] V → V₂ → M :=
   { Equiv.curry _ _ _ with
     map_add' := fun _ _ ↦ rfl
     map_smul' := fun _ _ ↦ rfl }
 
 @[simp]
-theorem coe_curry : ⇑(LinearEquiv.curry R V V₂) = curry :=
+theorem coe_curry : ⇑(LinearEquiv.curry R M V V₂) = curry :=
   rfl
 
 @[simp]
-theorem coe_curry_symm : ⇑(LinearEquiv.curry R V V₂).symm = uncurry :=
+theorem coe_curry_symm : ⇑(LinearEquiv.curry R M V V₂).symm = uncurry :=
   rfl
 
 end Uncurry


### PR DESCRIPTION
Generalise statement of `LinearEquiv.curry` from `(ι × κ) → R ≃ₗ[R] ι → κ → R` to `(ι × κ) → M ≃ₗ[R] ι → κ → M` with `M` an `R`-module.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)

(I also remove some spurious variables.)

This PR changes the number of inputs to the declaration, as now both `R` and `M` need to be given. The fact that mathlib compiles without the change is evidence that this function is not currently used anywhere in mathlib. I need the more general version for a forthcoming PR #16122 .