### PR TITLE
[Merged by Bors] - feat: When `NNRat.cast` is less/greater than `1`

### DIFF
--- a/Mathlib/Data/Rat/Cast/Order.lean
+++ b/Mathlib/Data/Rat/Cast/Order.lean
@@ -132,10 +132,10 @@ def castOrderEmbedding : ℚ≥0 ↪o K :=
 @[simp] lemma cast_pos : (0 : K) < q ↔ 0 < q := by norm_cast
 @[norm_cast] lemma cast_lt_zero : (q : K) < 0 ↔ q < 0 := by norm_cast
 @[simp] lemma not_cast_lt_zero : ¬(q : K) < 0 := mod_cast not_lt_zero'
-@[simp, norm_cast] lemma cast_le_one : (p : K) ≤ 1 ↔ p ≤ 1 := by norm_cast
-@[simp, norm_cast] lemma one_le_cast : 1 ≤ (p : K) ↔ 1 ≤ p := by norm_cast
-@[simp, norm_cast] lemma cast_lt_one : (p : K) < 1 ↔ p < 1 := by norm_cast
-@[simp, norm_cast] lemma one_lt_cast : 1 < (p : K) ↔ 1 < p := by norm_cast
+@[simp] lemma cast_le_one : (p : K) ≤ 1 ↔ p ≤ 1 := by norm_cast
+@[simp] lemma one_le_cast : 1 ≤ (p : K) ↔ 1 ≤ p := by norm_cast
+@[simp] lemma cast_lt_one : (p : K) < 1 ↔ p < 1 := by norm_cast
+@[simp] lemma one_lt_cast : 1 < (p : K) ↔ 1 < p := by norm_cast
 
 @[simp, norm_cast] lemma cast_min (p q : ℚ≥0) : (↑(min p q) : K) = min (p : K) (q : K) :=
   (@cast_mono K _).map_min

--- a/Mathlib/Data/Rat/Cast/Order.lean
+++ b/Mathlib/Data/Rat/Cast/Order.lean
@@ -132,6 +132,10 @@ def castOrderEmbedding : ℚ≥0 ↪o K :=
 @[simp] lemma cast_pos : (0 : K) < q ↔ 0 < q := by norm_cast
 @[norm_cast] lemma cast_lt_zero : (q : K) < 0 ↔ q < 0 := by norm_cast
 @[simp] lemma not_cast_lt_zero : ¬(q : K) < 0 := mod_cast not_lt_zero'
+@[simp, norm_cast] lemma cast_le_one : (p : K) ≤ 1 ↔ p ≤ 1 := by norm_cast
+@[simp, norm_cast] lemma one_le_cast : 1 ≤ (p : K) ↔ 1 ≤ p := by norm_cast
+@[simp, norm_cast] lemma cast_lt_one : (p : K) < 1 ↔ p < 1 := by norm_cast
+@[simp, norm_cast] lemma one_lt_cast : 1 < (p : K) ↔ 1 < p := by norm_cast
 
 @[simp, norm_cast] lemma cast_min (p q : ℚ≥0) : (↑(min p q) : K) = min (p : K) (q : K) :=
   (@cast_mono K _).map_min

--- a/Mathlib/Data/Rat/Cast/Order.lean
+++ b/Mathlib/Data/Rat/Cast/Order.lean
@@ -137,6 +137,23 @@ def castOrderEmbedding : ℚ≥0 ↪o K :=
 @[simp] lemma cast_lt_one : (p : K) < 1 ↔ p < 1 := by norm_cast
 @[simp] lemma one_lt_cast : 1 < (p : K) ↔ 1 < p := by norm_cast
 
+section ofNat
+variable {n : ℕ} [n.AtLeastTwo]
+
+@[simp] lemma cast_le_ofNat : (p : K) ≤ no_index (OfNat.ofNat n) ↔ p ≤ OfNat.ofNat n := by
+  simp [← cast_le (K := K)]
+
+@[simp] lemma ofNat_le_cast : no_index (OfNat.ofNat n) ≤ (p : K) ↔ OfNat.ofNat n ≤ p := by
+  simp [← cast_le (K := K)]
+
+@[simp] lemma cast_lt_ofNat : (p : K) < no_index (OfNat.ofNat n) ↔ p < OfNat.ofNat n := by
+  simp [← cast_lt (K := K)]
+
+@[simp] lemma ofNat_lt_cast : no_index (OfNat.ofNat n) < (p : K) ↔ OfNat.ofNat n < p := by
+  simp [← cast_lt (K := K)]
+
+end ofNat
+
 @[simp, norm_cast] lemma cast_min (p q : ℚ≥0) : (↑(min p q) : K) = min (p : K) (q : K) :=
   (@cast_mono K _).map_min
 


### PR DESCRIPTION
From LeanAPAP


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
