### PR TITLE
[Merged by Bors] - chore(RingTheory/UniqueFactorizationDomain): make `WfDvdMonoid α` an abbreviation for `IsWellFounded α DvdNotUnit`

### DIFF
--- a/Mathlib/RingTheory/DedekindDomain/Ideal.lean
+++ b/Mathlib/RingTheory/DedekindDomain/Ideal.lean
@@ -609,7 +609,7 @@ theorem Ideal.dvdNotUnit_iff_lt {I J : Ideal A} : DvdNotUnit I J ↔ J < I :=
       (mt Ideal.dvd_iff_le.mp (not_le_of_lt h))⟩
 
 instance : WfDvdMonoid (Ideal A) where
-  wellFounded_dvdNotUnit := by
+  wf := by
     have : WellFoundedGT (Ideal A) := inferInstance
     convert this.wf
     ext

--- a/Mathlib/RingTheory/Polynomial/Basic.lean
+++ b/Mathlib/RingTheory/Polynomial/Basic.lean
@@ -840,14 +840,14 @@ namespace Polynomial
 
 instance (priority := 100) wfDvdMonoid {R : Type*} [CommRing R] [IsDomain R] [WfDvdMonoid R] :
     WfDvdMonoid R[X] where
-  wellFounded_dvdNotUnit := by
+  wf := by
     classical
       refine
         RelHomClass.wellFounded
           (⟨fun p : R[X] =>
               ((if p = 0 then ⊤ else ↑p.degree : WithTop (WithBot ℕ)), p.leadingCoeff), ?_⟩ :
             DvdNotUnit →r Prod.Lex (· < ·) DvdNotUnit)
-          (wellFounded_lt.prod_lex ‹WfDvdMonoid R›.wellFounded_dvdNotUnit)
+          (wellFounded_lt.prod_lex ‹WfDvdMonoid R›.wf)
       rintro a b ⟨ane0, ⟨c, ⟨not_unit_c, rfl⟩⟩⟩
       dsimp
       rw [Polynomial.degree_mul, if_neg ane0]

--- a/Mathlib/RingTheory/UniqueFactorizationDomain.lean
+++ b/Mathlib/RingTheory/UniqueFactorizationDomain.lean
@@ -141,7 +141,11 @@ theorem WfDvdMonoid.of_wellFoundedLT_associates [CancelCommMonoidWithZero α]
 @[deprecated WfDvdMonoid.of_wellFoundedLT_associates (since := "2024-09-02")]
 theorem WfDvdMonoid.of_wellFounded_associates [CancelCommMonoidWithZero α]
     (h : WellFounded ((· < ·) : Associates α → Associates α → Prop)) : WfDvdMonoid α :=
-  WfDvdMonoid.of_wellFoundedLT_associates ⟨h⟩
+  WfDvdMonoid.of_wfDvdMonoid_associates
+    ⟨by
+      convert h
+      ext
+      exact Associates.dvdNotUnit_iff_lt⟩
 
 theorem WfDvdMonoid.iff_wellFounded_associates [CancelCommMonoidWithZero α] :
     WfDvdMonoid α ↔ WellFoundedLT (Associates α) :=

--- a/Mathlib/RingTheory/UniqueFactorizationDomain.lean
+++ b/Mathlib/RingTheory/UniqueFactorizationDomain.lean
@@ -34,10 +34,12 @@ local infixl:50 " ~ᵤ " => Associated
 condition on divisibility and to the ascending chain condition on
 principal ideals in an integral domain.
   -/
-class WfDvdMonoid (α : Type*) [CommMonoidWithZero α] : Prop where
-  wellFounded_dvdNotUnit : WellFounded (@DvdNotUnit α _)
+abbrev WfDvdMonoid (α : Type*) [CommMonoidWithZero α] : Prop :=
+  IsWellFounded α DvdNotUnit
 
-export WfDvdMonoid (wellFounded_dvdNotUnit)
+theorem wellFounded_dvdNotUnit {α : Type*} [CommMonoidWithZero α] [h : WfDvdMonoid α] :
+    WellFounded (DvdNotUnit (α := α)) :=
+  h.wf
 
 -- see Note [lower instance priority]
 instance (priority := 100) IsNoetherianRing.wfDvdMonoid [CommRing α] [IsDomain α]
@@ -61,8 +63,8 @@ variable [WfDvdMonoid α]
 instance wfDvdMonoid_associates : WfDvdMonoid (Associates α) :=
   ⟨(mk_surjective.wellFounded_iff mk_dvdNotUnit_mk_iff.symm).1 wellFounded_dvdNotUnit⟩
 
-theorem wellFounded_associates : WellFounded ((· < ·) : Associates α → Associates α → Prop) :=
-  Subrelation.wf dvdNotUnit_of_lt wellFounded_dvdNotUnit
+theorem wellFoundedLT_associates : WellFoundedLT (Associates α) :=
+  ⟨Subrelation.wf dvdNotUnit_of_lt wellFounded_dvdNotUnit⟩
 
 -- Porting note: elab_as_elim can only be global and cannot be changed on an imported decl
 -- attribute [local elab_as_elim] WellFounded.fix
@@ -124,17 +126,17 @@ theorem isRelPrime_of_no_irreducible_factors {x y : α} (nonzero : ¬(x = 0 ∧ 
 
 end WfDvdMonoid
 
-theorem WfDvdMonoid.of_wellFounded_associates [CancelCommMonoidWithZero α]
-    (h : WellFounded ((· < ·) : Associates α → Associates α → Prop)) : WfDvdMonoid α :=
+theorem WfDvdMonoid.of_wellFoundedLT_associates [CancelCommMonoidWithZero α]
+    (h : WellFoundedLT (Associates α)) : WfDvdMonoid α :=
   WfDvdMonoid.of_wfDvdMonoid_associates
     ⟨by
-      convert h
+      convert h.wf
       ext
       exact Associates.dvdNotUnit_iff_lt⟩
 
 theorem WfDvdMonoid.iff_wellFounded_associates [CancelCommMonoidWithZero α] :
-    WfDvdMonoid α ↔ WellFounded ((· < ·) : Associates α → Associates α → Prop) :=
-  ⟨by apply WfDvdMonoid.wellFounded_associates, WfDvdMonoid.of_wellFounded_associates⟩
+    WfDvdMonoid α ↔ WellFoundedLT (Associates α) :=
+  ⟨by apply WfDvdMonoid.wellFoundedLT_associates, WfDvdMonoid.of_wellFoundedLT_associates⟩
 
 theorem WfDvdMonoid.max_power_factor' [CommMonoidWithZero α] [WfDvdMonoid α] {a₀ x : α}
     (h : a₀ ≠ 0) (hx : ¬IsUnit x) : ∃ (n : ℕ) (a : α), ¬x ∣ a ∧ a₀ = x ^ n * a := by
@@ -176,8 +178,8 @@ To define a UFD using the definition in terms of multisets
 of prime factors, use the definition `of_exists_prime_factors`
 
 -/
-class UniqueFactorizationMonoid (α : Type*) [CancelCommMonoidWithZero α] extends WfDvdMonoid α :
-  Prop where
+class UniqueFactorizationMonoid (α : Type*) [CancelCommMonoidWithZero α] extends
+    IsWellFounded α DvdNotUnit : Prop where
   protected irreducible_iff_prime : ∀ {a : α}, Irreducible a ↔ Prime a
 
 /-- Can't be an instance because it would cause a loop `ufm → WfDvdMonoid → ufm → ...`. -/
@@ -1935,7 +1937,7 @@ theorem Ideal.IsPrime.exists_mem_prime_of_ne_bot {R : Type*} [CommSemiring R] [I
 namespace Nat
 
 instance instWfDvdMonoid : WfDvdMonoid ℕ where
-  wellFounded_dvdNotUnit := by
+  wf := by
     refine RelHomClass.wellFounded
       (⟨fun x : ℕ => if x = 0 then (⊤ : ℕ∞) else x, ?_⟩ : DvdNotUnit →r (· < ·)) wellFounded_lt
     intro a b h

--- a/Mathlib/RingTheory/UniqueFactorizationDomain.lean
+++ b/Mathlib/RingTheory/UniqueFactorizationDomain.lean
@@ -138,6 +138,11 @@ theorem WfDvdMonoid.of_wellFoundedLT_associates [CancelCommMonoidWithZero α]
       ext
       exact Associates.dvdNotUnit_iff_lt⟩
 
+@[deprecated WfDvdMonoid.of_wellFoundedLT_associates (since := "2024-09-02")]
+theorem WfDvdMonoid.of_wellFounded_associates [CancelCommMonoidWithZero α]
+    (h : WellFounded (Associates α)) : WfDvdMonoid α :=
+  WfDvdMonoid.of_wellFounded_associates ⟨h⟩ 
+
 theorem WfDvdMonoid.iff_wellFounded_associates [CancelCommMonoidWithZero α] :
     WfDvdMonoid α ↔ WellFoundedLT (Associates α) :=
   ⟨by apply WfDvdMonoid.wellFoundedLT_associates, WfDvdMonoid.of_wellFoundedLT_associates⟩

--- a/Mathlib/RingTheory/UniqueFactorizationDomain.lean
+++ b/Mathlib/RingTheory/UniqueFactorizationDomain.lean
@@ -66,6 +66,10 @@ instance wfDvdMonoid_associates : WfDvdMonoid (Associates α) :=
 theorem wellFoundedLT_associates : WellFoundedLT (Associates α) :=
   ⟨Subrelation.wf dvdNotUnit_of_lt wellFounded_dvdNotUnit⟩
 
+@[deprecated wellFoundedLT_associates (since := "2024-09-02")]
+theorem wellFounded_associates : WellFounded ((· < ·) : Associates α → Associates α → Prop) :=
+  Subrelation.wf dvdNotUnit_of_lt wellFounded_dvdNotUnit
+
 -- Porting note: elab_as_elim can only be global and cannot be changed on an imported decl
 -- attribute [local elab_as_elim] WellFounded.fix
 

--- a/Mathlib/RingTheory/UniqueFactorizationDomain.lean
+++ b/Mathlib/RingTheory/UniqueFactorizationDomain.lean
@@ -140,8 +140,8 @@ theorem WfDvdMonoid.of_wellFoundedLT_associates [CancelCommMonoidWithZero α]
 
 @[deprecated WfDvdMonoid.of_wellFoundedLT_associates (since := "2024-09-02")]
 theorem WfDvdMonoid.of_wellFounded_associates [CancelCommMonoidWithZero α]
-    (h : WellFounded (Associates α)) : WfDvdMonoid α :=
-  WfDvdMonoid.of_wellFounded_associates ⟨h⟩ 
+    (h : WellFounded ((· < ·) : Associates α → Associates α → Prop)) : WfDvdMonoid α :=
+  WfDvdMonoid.of_wellFoundedLT_associates ⟨h⟩
 
 theorem WfDvdMonoid.iff_wellFounded_associates [CancelCommMonoidWithZero α] :
     WfDvdMonoid α ↔ WellFoundedLT (Associates α) :=


### PR DESCRIPTION
We also rewrite some `WellFounded ((· < ·) : α → α → Prop)` lemmas in terms of the much less clunky `WellFoundedLT α`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
