### PR TITLE
[Merged by Bors] - feat(Measure/Typeclasses): prove `≪` both ways

### DIFF
--- a/Mathlib/MeasureTheory/Covering/Besicovitch.lean
+++ b/Mathlib/MeasureTheory/Covering/Besicovitch.lean
@@ -808,10 +808,10 @@ theorem exists_disjoint_closedBall_covering_ae_aux (μ : Measure α) [SFinite μ
         t.PairwiseDisjoint fun p => closedBall p.1 p.2 := by
   /- This is deduced from the finite measure case, by using a finite measure with respect to which
     the initial sigma-finite measure is absolutely continuous. -/
-  rcases exists_isFiniteMeasure_null_iff μ with ⟨ν, hν, hμν⟩
+  rcases exists_isFiniteMeasure_absolutelyContinuous μ with ⟨ν, hν, hμν, -⟩
   rcases exists_disjoint_closedBall_covering_ae_of_finiteMeasure_aux ν f s hf with
     ⟨t, t_count, ts, tr, tν, tdisj⟩
-  exact ⟨t, t_count, ts, tr, (hμν _).1 tν, tdisj⟩
+  exact ⟨t, t_count, ts, tr, hμν tν, tdisj⟩
 
 /-- The measurable Besicovitch covering theorem. Assume that, for any `x` in a set `s`,
 one is given a set of admissible closed balls centered at `x`, with arbitrarily small radii.

--- a/Mathlib/MeasureTheory/Covering/Besicovitch.lean
+++ b/Mathlib/MeasureTheory/Covering/Besicovitch.lean
@@ -808,10 +808,10 @@ theorem exists_disjoint_closedBall_covering_ae_aux (μ : Measure α) [SFinite μ
         t.PairwiseDisjoint fun p => closedBall p.1 p.2 := by
   /- This is deduced from the finite measure case, by using a finite measure with respect to which
     the initial sigma-finite measure is absolutely continuous. -/
-  rcases exists_absolutelyContinuous_isFiniteMeasure μ with ⟨ν, hν, hμν⟩
+  rcases exists_isFiniteMeasure_null_iff μ with ⟨ν, hν, hμν⟩
   rcases exists_disjoint_closedBall_covering_ae_of_finiteMeasure_aux ν f s hf with
     ⟨t, t_count, ts, tr, tν, tdisj⟩
-  exact ⟨t, t_count, ts, tr, hμν tν, tdisj⟩
+  exact ⟨t, t_count, ts, tr, (hμν _).1 tν, tdisj⟩
 
 /-- The measurable Besicovitch covering theorem. Assume that, for any `x` in a set `s`,
 one is given a set of admissible closed balls centered at `x`, with arbitrarily small radii.

--- a/Mathlib/MeasureTheory/Decomposition/Exhaustion.lean
+++ b/Mathlib/MeasureTheory/Decomposition/Exhaustion.lean
@@ -252,13 +252,13 @@ section SFinite
 lemma measure_eq_top_of_subset_compl_sigmaFiniteSetWRT [SFinite ν]
     (hs_subset : s ⊆ (μ.sigmaFiniteSetWRT ν)ᶜ) (hνs : ν s ≠ 0) :
     μ s = ∞ := by
-  have ⟨ν', hν', hνν'⟩ := exists_isFiniteMeasure_null_iff ν
+  have ⟨ν', hν', hνν', _⟩ := exists_isFiniteMeasure_absolutelyContinuous ν
   have h : ∃ s : Set α, MeasurableSet s ∧ SigmaFinite (μ.restrict s)
       ∧ (∀ t ⊆ sᶜ, ν t ≠ 0 → μ t = ∞) := by
     refine ⟨μ.sigmaFiniteSetWRT' ν', measurableSet_sigmaFiniteSetWRT',
       sigmaFinite_restrict_sigmaFiniteSetWRT' _ _,
       fun t ht_subset hνt ↦ measure_eq_top_of_subset_compl_sigmaFiniteSetWRT' ht_subset ?_⟩
-    exact fun hν't ↦ hνt ((hνν' _).1 hν't)
+    exact fun hν't ↦ hνt (hνν' hν't)
   rw [Measure.sigmaFiniteSetWRT, dif_pos h] at hs_subset
   exact h.choose_spec.2.2 s hs_subset hνs
 

--- a/Mathlib/MeasureTheory/Decomposition/Exhaustion.lean
+++ b/Mathlib/MeasureTheory/Decomposition/Exhaustion.lean
@@ -252,13 +252,13 @@ section SFinite
 lemma measure_eq_top_of_subset_compl_sigmaFiniteSetWRT [SFinite ν]
     (hs_subset : s ⊆ (μ.sigmaFiniteSetWRT ν)ᶜ) (hνs : ν s ≠ 0) :
     μ s = ∞ := by
-  have ⟨ν', hν', hνν'⟩ := exists_absolutelyContinuous_isFiniteMeasure ν
+  have ⟨ν', hν', hνν'⟩ := exists_isFiniteMeasure_null_iff ν
   have h : ∃ s : Set α, MeasurableSet s ∧ SigmaFinite (μ.restrict s)
-      ∧ (∀ t (_ : t ⊆ sᶜ) (_ : ν t ≠ 0), μ t = ∞) := by
+      ∧ (∀ t ⊆ sᶜ, ν t ≠ 0 → μ t = ∞) := by
     refine ⟨μ.sigmaFiniteSetWRT' ν', measurableSet_sigmaFiniteSetWRT',
       sigmaFinite_restrict_sigmaFiniteSetWRT' _ _,
       fun t ht_subset hνt ↦ measure_eq_top_of_subset_compl_sigmaFiniteSetWRT' ht_subset ?_⟩
-    exact fun hν't ↦ hνt (hνν' hν't)
+    exact fun hν't ↦ hνt ((hνν' _).1 hν't)
   rw [Measure.sigmaFiniteSetWRT, dif_pos h] at hs_subset
   exact h.choose_spec.2.2 s hs_subset hνs
 

--- a/Mathlib/MeasureTheory/Measure/Typeclasses.lean
+++ b/Mathlib/MeasureTheory/Measure/Typeclasses.lean
@@ -536,22 +536,24 @@ instance [SFinite μ] (s : Set α) : SFinite (μ.restrict s) :=
     by rw [← restrict_sum_of_countable, sum_sFiniteSeq]⟩
 
 variable (μ) in
-/-- For An s-finite measure, there exists a finite measure with the same null sets. -/
-theorem exists_isFiniteMeasure_null_iff [SFinite μ] :
-    ∃ ν : Measure α, IsFiniteMeasure ν ∧ ∀ s, ν s = 0 ↔ μ s = 0 := by
+/-- For an s-finite measure `μ`, there exists a finite measure `ν`
+such that each of `μ` and `ν` is absolutely continuous with respect to the other.
+-/
+theorem exists_isFiniteMeasure_absolutelyContinuous [SFinite μ] :
+    ∃ ν : Measure α, IsFiniteMeasure ν ∧ μ ≪ ν ∧ ν ≪ μ := by
   rcases ENNReal.exists_pos_tsum_mul_lt_of_countable top_ne_zero (sFiniteSeq μ · univ)
     fun _ ↦ measure_ne_top _ _ with ⟨c, hc₀, hc⟩
-  refine ⟨.sum fun n ↦ c n • sFiniteSeq μ n, ⟨by simpa [mul_comm] using hc⟩, fun s ↦ ?_⟩
-  conv_rhs => rw [← sum_sFiniteSeq μ, sum_apply_of_countable]
-  simp [(hc₀ _).ne']
+  have {s : Set α} : sum (fun n ↦ c n • sFiniteSeq μ n) s = 0 ↔ μ s = 0 := by
+    conv_rhs => rw [← sum_sFiniteSeq μ, sum_apply_of_countable]
+    simp [(hc₀ _).ne']
+  refine ⟨.sum fun n ↦ c n • sFiniteSeq μ n, ⟨?_⟩, fun _ ↦ this.1, fun _ ↦ this.2⟩
+  simpa [mul_comm] using hc
 
 variable (μ) in
-/-- An s-finite measure is absolutely continuous with respect to some finite measure. -/
-@[deprecated exists_isFiniteMeasure_null_iff (since := "2024-08-25")]
+@[deprecated exists_isFiniteMeasure_absolutelyContinuous (since := "2024-08-25")]
 theorem exists_absolutelyContinuous_isFiniteMeasure [SFinite μ] :
     ∃ ν : Measure α, IsFiniteMeasure ν ∧ μ ≪ ν :=
-  let ⟨ν, hν, hμν⟩ := exists_isFiniteMeasure_null_iff μ
-  ⟨ν, hν, fun s ↦ (hμν s).1⟩
+  let ⟨ν, hfin, h, _⟩ := exists_isFiniteMeasure_absolutelyContinuous μ; ⟨ν, hfin, h⟩
 
 end SFinite
 

--- a/Mathlib/MeasureTheory/Measure/Typeclasses.lean
+++ b/Mathlib/MeasureTheory/Measure/Typeclasses.lean
@@ -536,17 +536,22 @@ instance [SFinite μ] (s : Set α) : SFinite (μ.restrict s) :=
     by rw [← restrict_sum_of_countable, sum_sFiniteSeq]⟩
 
 variable (μ) in
-/-- An s-finite measure is absolutely continuous with respect to some finite measure. -/
-theorem exists_absolutelyContinuous_isFiniteMeasure [SFinite μ] :
-    ∃ ν : Measure α, IsFiniteMeasure ν ∧ μ ≪ ν := by
+/-- For An s-finite measure, there exists a finite measure with the same null sets. -/
+theorem exists_isFiniteMeasure_null_iff [SFinite μ] :
+    ∃ ν : Measure α, IsFiniteMeasure ν ∧ ∀ s, ν s = 0 ↔ μ s = 0 := by
   rcases ENNReal.exists_pos_tsum_mul_lt_of_countable top_ne_zero (sFiniteSeq μ · univ)
     fun _ ↦ measure_ne_top _ _ with ⟨c, hc₀, hc⟩
-  refine ⟨.sum fun n ↦ c n • sFiniteSeq μ n, ⟨?_⟩, ?_⟩
-  · simpa [mul_comm] using hc
-  · refine AbsolutelyContinuous.mk fun s hsm hs ↦ ?_
-    have : ∀ n, (sFiniteSeq μ n) s = 0 := by simpa [hsm, (hc₀ _).ne'] using hs
-    rw [← sum_sFiniteSeq μ, sum_apply _ hsm]
-    simp [this]
+  refine ⟨.sum fun n ↦ c n • sFiniteSeq μ n, ⟨by simpa [mul_comm] using hc⟩, fun s ↦ ?_⟩
+  conv_rhs => rw [← sum_sFiniteSeq μ, sum_apply_of_countable]
+  simp [(hc₀ _).ne']
+
+variable (μ) in
+/-- An s-finite measure is absolutely continuous with respect to some finite measure. -/
+@[deprecated exists_isFiniteMeasure_null_iff (since := "2024-08-25")]
+theorem exists_absolutelyContinuous_isFiniteMeasure [SFinite μ] :
+    ∃ ν : Measure α, IsFiniteMeasure ν ∧ μ ≪ ν :=
+  let ⟨ν, hν, hμν⟩ := exists_isFiniteMeasure_null_iff μ
+  ⟨ν, hν, fun s ↦ (hμν s).1⟩
 
 end SFinite
 


### PR DESCRIPTION
- Rename `exists_absolutelyContinuous_isFiniteMeasure` to `exists_isFiniteMeasure_absolutelyContinuous` to match the statement.
- Prove `ν ≪ μ`, not only `μ ≪ ν`.
- Turn the old lemma into a deprecated alias.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)