### PR TITLE
[Merged by Bors] - feat: add `abbrev`s to `decl_diff`

### DIFF
--- a/scripts/declarations_diff.sh
+++ b/scripts/declarations_diff.sh
@@ -42,7 +42,7 @@ The script uses some heuristics to guide this process.
 BASH_DOC_MODULE
 
 ## we narrow the diff to lines beginning with `theorem`, `lemma` and a few other commands
-begs="(theorem|lemma|inductive|structure|def|class|instance|alias)"
+begs="(theorem|lemma|inductive|structure|def|class|instance|alias|abbrev)"
 
 if [ "${1}" == "long" ]
 then

--- a/scripts/declarations_diff.sh
+++ b/scripts/declarations_diff.sh
@@ -181,4 +181,5 @@ def testingLongDiff2 im a def
 def testingLongDiff3 im a def
 @[trying to fool you] instance. the messing dot
 alias ⟨d1, d2⟩ := d  check the "split an iff alias"
+abbrev a_new_one := I was not here before
 ReferenceTest


### PR DESCRIPTION
Prompted by #16169.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
