### PR TITLE
[Merged by Bors] - feat (RingTheory/HahnSeries) : coefficient-wise map

### DIFF
--- a/Mathlib/RingTheory/HahnSeries/Addition.lean
+++ b/Mathlib/RingTheory/HahnSeries/Addition.lean
@@ -28,7 +28,7 @@ open scoped Classical
 
 noncomputable section
 
-variable {Γ R : Type*}
+variable {Γ Γ' R S U V : Type*}
 
 namespace HahnSeries
 
@@ -66,6 +66,10 @@ theorem add_coeff' {x y : HahnSeries Γ R} : (x + y).coeff = x.coeff + y.coeff :
 theorem add_coeff {x y : HahnSeries Γ R} {a : Γ} : (x + y).coeff a = x.coeff a + y.coeff a :=
   rfl
 
+@[simp]
+protected lemma map_add [AddMonoid S] (f : R →+ S) {x y : HahnSeries Γ R} :
+    ((x + y).map f : HahnSeries Γ S) = x.map f + y.map f := by
+  ext; simp
 /--
 `addOppositeEquiv` is an additive monoid isomorphism between
 Hahn series over `Γ` with coefficients in the opposite additive monoid `Rᵃᵒᵖ`
@@ -210,7 +214,7 @@ def coeff.addMonoidHom (g : Γ) : HahnSeries Γ R →+ R where
 
 section Domain
 
-variable {Γ' : Type*} [PartialOrder Γ']
+variable [PartialOrder Γ']
 
 theorem embDomain_add (f : Γ ↪o Γ') (x y : HahnSeries Γ R) :
     embDomain f (x + y) = embDomain f x + embDomain f y := by
@@ -261,12 +265,9 @@ theorem support_neg {x : HahnSeries Γ R} : (-x).support = x.support := by
   simp
 
 @[simp]
-theorem sub_coeff' {x y : HahnSeries Γ R} : (x - y).coeff = x.coeff - y.coeff := by
-  ext
-  simp [sub_eq_add_neg]
-
-theorem sub_coeff {x y : HahnSeries Γ R} {a : Γ} : (x - y).coeff a = x.coeff a - y.coeff a := by
-  simp
+protected lemma map_neg [AddGroup S] (f : R →+ S) {x : HahnSeries Γ R} :
+    ((-x).map f : HahnSeries Γ S) = -(x.map f) := by
+  ext; simp
 
 theorem orderTop_neg {x : HahnSeries Γ R} : (-x).orderTop = x.orderTop := by
   simp only [orderTop, support_neg, neg_eq_zero]
@@ -276,6 +277,19 @@ theorem order_neg [Zero Γ] {f : HahnSeries Γ R} : (-f).order = f.order := by
   by_cases hf : f = 0
   · simp only [hf, neg_zero]
   simp only [order, support_neg, neg_eq_zero]
+
+@[simp]
+theorem sub_coeff' {x y : HahnSeries Γ R} : (x - y).coeff = x.coeff - y.coeff := by
+  ext
+  simp [sub_eq_add_neg]
+
+theorem sub_coeff {x y : HahnSeries Γ R} {a : Γ} : (x - y).coeff a = x.coeff a - y.coeff a := by
+  simp
+
+@[simp]
+protected lemma map_sub [AddGroup S] (f : R →+ S) {x y : HahnSeries Γ R} :
+    ((x - y).map f : HahnSeries Γ S) = x.map f - y.map f := by
+  ext; simp
 
 theorem min_orderTop_le_orderTop_sub {Γ} [LinearOrder Γ] {x y : HahnSeries Γ R} :
     min x.orderTop y.orderTop ≤ (x - y).orderTop := by
@@ -377,7 +391,7 @@ end DistribMulAction
 
 section Module
 
-variable [PartialOrder Γ] [Semiring R] {V : Type*} [AddCommMonoid V] [Module R V]
+variable [PartialOrder Γ] [Semiring R] [AddCommMonoid V] [Module R V]
 
 instance : Module R (HahnSeries Γ V) :=
   { inferInstanceAs (DistribMulAction R (HahnSeries Γ V)) with
@@ -401,9 +415,14 @@ def single.linearMap (a : Γ) : V →ₗ[R] HahnSeries Γ V :=
 def coeff.linearMap (g : Γ) : HahnSeries Γ V →ₗ[R] V :=
   { coeff.addMonoidHom g with map_smul' := fun _ _ => rfl }
 
+@[simp]
+protected lemma map_smul [AddCommMonoid U] [Module R U] (f : U →ₗ[R] V) {r : R}
+    {x : HahnSeries Γ U} : (r • x).map f = r • ((x.map f) : HahnSeries Γ V) := by
+  ext; simp
+
 section Domain
 
-variable {Γ' : Type*} [PartialOrder Γ']
+variable [PartialOrder Γ']
 
 theorem embDomain_smul (f : Γ ↪o Γ') (r : R) (x : HahnSeries Γ R) :
     embDomain f (r • x) = r • embDomain f x := by

--- a/Mathlib/RingTheory/HahnSeries/Basic.lean
+++ b/Mathlib/RingTheory/HahnSeries/Basic.lean
@@ -25,6 +25,8 @@ in the file `RingTheory/LaurentSeries`.
   coefficient if `x ≠ 0`, and is `⊤` when `x = 0`.
 * `order x` is a minimal element of `Γ` where `x` has a nonzero coefficient if `x ≠ 0`, and is zero
   when `x = 0`.
+* `map` takes each coefficient of a Hahn series to its target under a zero-preserving map.
+* `embDomain` preserves coefficients, but embeds the index set `Γ` in a larger poset.
 
 ## References
 - [J. van der Hoeven, *Operators on Generalized Power Series*][van_der_hoeven]
@@ -110,9 +112,10 @@ theorem support_eq_empty_iff {x : HahnSeries Γ R} : x.support = ∅ ↔ x = 0 :
 
 /-- The map of Hahn series induced by applying a zero-preserving map to each coefficient. -/
 @[simps]
-def map [Zero S] (x : HahnSeries Γ R) (f : ZeroHom R S) : HahnSeries Γ S where
+def map [Zero S] (x : HahnSeries Γ R) {F : Type*} [FunLike F R S] [ZeroHomClass F R S] (f : F) :
+    HahnSeries Γ S where
   coeff g := f (x.coeff g)
-  isPWO_support' := x.isPWO_support.mono <| Function.support_comp_subset (ZeroHom.map_zero f) _
+  isPWO_support' := x.isPWO_support.mono <| Function.support_comp_subset (ZeroHomClass.map_zero f) _
 
 @[simp]
 protected lemma map_zero [Zero S] (f : ZeroHom R S) :

--- a/Mathlib/RingTheory/HahnSeries/Basic.lean
+++ b/Mathlib/RingTheory/HahnSeries/Basic.lean
@@ -205,6 +205,11 @@ theorem single_ne_zero (h : r ≠ 0) : single a r ≠ 0 := fun con =>
 theorem single_eq_zero_iff {a : Γ} {r : R} : single a r = 0 ↔ r = 0 :=
   map_eq_zero_iff _ <| single_injective a
 
+@[simp]
+protected lemma map_single [Zero S] (f : ZeroHom R S) : (single a r).map f = single a (f r) := by
+  ext g
+  by_cases h : g = a <;> simp [h]
+
 instance [Nonempty Γ] [Nontrivial R] : Nontrivial (HahnSeries Γ R) :=
   ⟨by
     obtain ⟨r, s, rs⟩ := exists_pair_ne R

--- a/Mathlib/RingTheory/HahnSeries/Basic.lean
+++ b/Mathlib/RingTheory/HahnSeries/Basic.lean
@@ -43,7 +43,7 @@ structure HahnSeries (Γ : Type*) (R : Type*) [PartialOrder Γ] [Zero R] where
   coeff : Γ → R
   isPWO_support' : (Function.support coeff).IsPWO
 
-variable {Γ : Type*} {R : Type*}
+variable {Γ Γ' R S : Type*}
 
 namespace HahnSeries
 
@@ -108,8 +108,19 @@ nonrec theorem support_nonempty_iff {x : HahnSeries Γ R} : x.support.Nonempty �
 theorem support_eq_empty_iff {x : HahnSeries Γ R} : x.support = ∅ ↔ x = 0 :=
   Function.support_eq_empty_iff.trans coeff_fun_eq_zero_iff
 
+/-- The map of Hahn series induced by applying a zero-preserving map to each coefficient. -/
+@[simps]
+def map [Zero S] (x : HahnSeries Γ R) (f : ZeroHom R S) : HahnSeries Γ S where
+  coeff g := f (x.coeff g)
+  isPWO_support' := x.isPWO_support.mono <| Function.support_comp_subset (ZeroHom.map_zero f) _
+
+@[simp]
+protected lemma map_zero [Zero S] (f : ZeroHom R S) :
+    (0 : HahnSeries Γ R).map f = 0 := by
+  ext; simp
+
 /-- Change a HahnSeries with coefficients in HahnSeries to a HahnSeries on the Lex product. -/
-def ofIterate {Γ' : Type*} [PartialOrder Γ'] (x : HahnSeries Γ (HahnSeries Γ' R)) :
+def ofIterate [PartialOrder Γ'] (x : HahnSeries Γ (HahnSeries Γ' R)) :
     HahnSeries (Γ ×ₗ Γ') R where
   coeff := fun g => coeff (coeff x g.1) g.2
   isPWO_support' := by
@@ -125,7 +136,7 @@ lemma mk_eq_zero (f : Γ → R) (h) : HahnSeries.mk f h = 0 ↔ f = 0 := by
   rfl
 
 /-- Change a Hahn series on a lex product to a Hahn series with coefficients in a Hahn series. -/
-def toIterate {Γ' : Type*} [PartialOrder Γ'] (x : HahnSeries (Γ ×ₗ Γ') R) :
+def toIterate [PartialOrder Γ'] (x : HahnSeries (Γ ×ₗ Γ') R) :
     HahnSeries Γ (HahnSeries Γ' R) where
   coeff := fun g => {
     coeff := fun g' => coeff x (g, g')
@@ -141,7 +152,7 @@ def toIterate {Γ' : Type*} [PartialOrder Γ'] (x : HahnSeries (Γ ×ₗ Γ') R)
 
 /-- The equivalence between iterated Hahn series and Hahn series on the lex product. -/
 @[simps]
-def iterateEquiv {Γ' : Type*} [PartialOrder Γ'] :
+def iterateEquiv [PartialOrder Γ'] :
     HahnSeries Γ (HahnSeries Γ' R) ≃ HahnSeries (Γ ×ₗ Γ') R where
   toFun := ofIterate
   invFun := toIterate
@@ -364,7 +375,7 @@ end Order
 
 section Domain
 
-variable {Γ' : Type*} [PartialOrder Γ']
+variable [PartialOrder Γ']
 
 open Classical in
 /-- Extends the domain of a `HahnSeries` by an `OrderEmbedding`. -/

--- a/Mathlib/RingTheory/HahnSeries/Multiplication.lean
+++ b/Mathlib/RingTheory/HahnSeries/Multiplication.lean
@@ -36,7 +36,7 @@ open Finset Function Pointwise
 
 noncomputable section
 
-variable {Γ Γ' R V : Type*}
+variable {Γ Γ' R S V : Type*}
 
 namespace HahnSeries
 
@@ -72,6 +72,12 @@ theorem order_one [MulZeroOneClass R] : order (1 : HahnSeries Γ R) = 0 := by
 @[simp]
 theorem leadingCoeff_one [MulZeroOneClass R] : (1 : HahnSeries Γ R).leadingCoeff = 1 := by
   simp [leadingCoeff_eq]
+
+@[simp]
+protected lemma map_one [MonoidWithZero R] [MonoidWithZero S] (f : R →*₀ S) :
+    (1 : HahnSeries Γ R).map f = (1 : HahnSeries Γ S) := by
+  ext g
+  by_cases h : g = 0 <;> simp [h]
 
 end HahnSeries
 
@@ -346,6 +352,19 @@ theorem mul_coeff [NonUnitalNonAssocSemiring R] {x y : HahnSeries Γ R} {a : Γ}
     (x * y).coeff a =
       ∑ ij ∈ addAntidiagonal x.isPWO_support y.isPWO_support a, x.coeff ij.fst * y.coeff ij.snd :=
   rfl
+
+protected lemma map_mul [NonUnitalNonAssocSemiring R] [NonUnitalNonAssocSemiring S] (f : R →ₙ+* S)
+    {x y : HahnSeries Γ R} : (x * y).map f = (x.map f : HahnSeries Γ S) * (y.map f) := by
+  ext
+  simp only [map_coeff, mul_coeff, ZeroHom.coe_coe, map_sum, map_mul]
+  refine Eq.symm (sum_subset (fun gh hgh => ?_) (fun gh hgh hz => ?_))
+  · simp_all only [mem_addAntidiagonal, mem_support, map_coeff, ZeroHom.coe_coe, ne_eq, and_true]
+    exact ⟨fun h => hgh.1 (map_zero f ▸ congrArg f h), fun h => hgh.2.1 (map_zero f ▸ congrArg f h)⟩
+  · simp_all only [mem_addAntidiagonal, mem_support, ne_eq, map_coeff, ZeroHom.coe_coe, and_true,
+      not_and, not_not]
+    by_cases h : f (x.coeff gh.1) = 0
+    · exact mul_eq_zero_of_left h (f (y.coeff gh.2))
+    · exact mul_eq_zero_of_right (f (x.coeff gh.1)) (hz h)
 
 theorem mul_coeff_left' [NonUnitalNonAssocSemiring R] {x y : HahnSeries Γ R} {a : Γ} {s : Set Γ}
     (hs : s.IsPWO) (hxs : x.support ⊆ s) :
@@ -640,6 +659,12 @@ theorem C_zero : C (0 : R) = (0 : HahnSeries Γ R) :=
 --@[simp] Porting note (#10618): simp can prove it
 theorem C_one : C (1 : R) = (1 : HahnSeries Γ R) :=
   C.map_one
+
+@[simp]
+theorem map_C [NonAssocSemiring S] (a : R) (f : R →+* S) :
+    ((C a).map f : HahnSeries Γ S) = C (f a) := by
+  ext g
+  by_cases h : g = 0 <;> simp [h]
 
 theorem C_injective : Function.Injective (C : R → HahnSeries Γ R) := by
   intro r s rs

--- a/Mathlib/RingTheory/HahnSeries/Multiplication.lean
+++ b/Mathlib/RingTheory/HahnSeries/Multiplication.lean
@@ -660,7 +660,6 @@ theorem C_zero : C (0 : R) = (0 : HahnSeries Γ R) :=
 theorem C_one : C (1 : R) = (1 : HahnSeries Γ R) :=
   C.map_one
 
-@[simp]
 theorem map_C [NonAssocSemiring S] (a : R) (f : R →+* S) :
     ((C a).map f : HahnSeries Γ S) = C (f a) := by
   ext g

--- a/Mathlib/RingTheory/HahnSeries/PowerSeries.lean
+++ b/Mathlib/RingTheory/HahnSeries/PowerSeries.lean
@@ -31,7 +31,7 @@ open Finset Function Pointwise Polynomial
 
 noncomputable section
 
-variable {Γ : Type*} {R : Type*}
+variable {Γ R : Type*}
 
 namespace HahnSeries
 
@@ -107,7 +107,7 @@ theorem ofPowerSeries_C (r : R) : ofPowerSeries Γ R (PowerSeries.C R r) = HahnS
     single_coeff]
   split_ifs with hn
   · subst hn
-    convert @embDomain_coeff ℕ R _ _ Γ _ _ _ 0 <;> simp
+    convert @embDomain_coeff ℕ Γ R _ _ _ _ _ 0 <;> simp
   · rw [embDomain_notin_image_support]
     simp only [not_exists, Set.mem_image, toPowerSeries_symm_apply_coeff, mem_support,
       PowerSeries.coeff_C]
@@ -120,7 +120,7 @@ theorem ofPowerSeries_X : ofPowerSeries Γ R PowerSeries.X = single 1 1 := by
   simp only [single_coeff, ofPowerSeries_apply, RingHom.coe_mk]
   split_ifs with hn
   · rw [hn]
-    convert @embDomain_coeff ℕ R _ _ Γ _ _ _ 1 <;> simp
+    convert @embDomain_coeff ℕ Γ R _ _ _ _ _ 1 <;> simp
   · rw [embDomain_notin_image_support]
     simp only [not_exists, Set.mem_image, toPowerSeries_symm_apply_coeff, mem_support,
       PowerSeries.coeff_X]

--- a/Mathlib/RingTheory/HahnSeries/PowerSeries.lean
+++ b/Mathlib/RingTheory/HahnSeries/PowerSeries.lean
@@ -107,7 +107,7 @@ theorem ofPowerSeries_C (r : R) : ofPowerSeries Γ R (PowerSeries.C R r) = HahnS
     single_coeff]
   split_ifs with hn
   · subst hn
-    convert @embDomain_coeff ℕ Γ R _ _ _ _ _ 0 <;> simp
+    convert embDomain_coeff (a := 0) <;> simp
   · rw [embDomain_notin_image_support]
     simp only [not_exists, Set.mem_image, toPowerSeries_symm_apply_coeff, mem_support,
       PowerSeries.coeff_C]
@@ -120,7 +120,7 @@ theorem ofPowerSeries_X : ofPowerSeries Γ R PowerSeries.X = single 1 1 := by
   simp only [single_coeff, ofPowerSeries_apply, RingHom.coe_mk]
   split_ifs with hn
   · rw [hn]
-    convert @embDomain_coeff ℕ Γ R _ _ _ _ _ 1 <;> simp
+    convert embDomain_coeff (a := 1) <;> simp
   · rw [embDomain_notin_image_support]
     simp only [not_exists, Set.mem_image, toPowerSeries_symm_apply_coeff, mem_support,
       PowerSeries.coeff_X]


### PR DESCRIPTION
This PR introduces `HahnSeries.map` which applies a zero-preserving map to each coefficient. We more or less copy the `Polynomial.map` API.

---

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
