### PR TITLE
[Merged by Bors] - feat: more tail recursion when finding Mersenne primes

### DIFF
--- a/Archive/Examples/MersennePrimes.lean
+++ b/Archive/Examples/MersennePrimes.lean
@@ -95,7 +95,7 @@ locally it works fine, but in CI it fails with `(kernel) deep recursion detected
 --   lucas_lehmer_sufficiency _ (by norm_num) (by norm_num)
 
 /-
-`mersenne 9941` fails with `(kernel) deep recursion detected` locally as well.
+`mersenne 11213` fails with `(kernel) deep recursion detected` locally as well.
 -/
 -- example : (mersenne 11213).Prime :=
 --   lucas_lehmer_sufficiency _ (by norm_num) (by norm_num)

--- a/Archive/Examples/MersennePrimes.lean
+++ b/Archive/Examples/MersennePrimes.lean
@@ -80,12 +80,22 @@ example : (mersenne 4253).Prime :=
 example : (mersenne 4423).Prime :=
   lucas_lehmer_sufficiency _ (by norm_num) (by norm_num)
 
-example : (mersenne 9689).Prime :=
-  lucas_lehmer_sufficiency _ (by norm_num) (by norm_num)
+/-
+`mersenne 9689` seems to be system dependent:
+locally it works fine, but in CI it fails with `(kernel) deep recursion detected`
+-/
+-- example : (mersenne 9689).Prime :=
+--   lucas_lehmer_sufficiency _ (by norm_num) (by norm_num)
 
-example : (mersenne 9941).Prime :=
-  lucas_lehmer_sufficiency _ (by norm_num) (by norm_num)
+/-
+`mersenne 9941` seems to be system dependent:
+locally it works fine, but in CI it fails with `(kernel) deep recursion detected`
+-/
+-- example : (mersenne 9941).Prime :=
+--   lucas_lehmer_sufficiency _ (by norm_num) (by norm_num)
 
--- (kernel) deep recursion detected:
+/-
+`mersenne 9941` fails with `(kernel) deep recursion detected` locally as well.
+-/
 -- example : (mersenne 11213).Prime :=
 --   lucas_lehmer_sufficiency _ (by norm_num) (by norm_num)

--- a/Archive/Examples/MersennePrimes.lean
+++ b/Archive/Examples/MersennePrimes.lean
@@ -80,8 +80,12 @@ example : (mersenne 4253).Prime :=
 example : (mersenne 4423).Prime :=
   lucas_lehmer_sufficiency _ (by norm_num) (by norm_num)
 
--- First failure ("deep recursion detected")
-/-
 example : (mersenne 9689).Prime :=
   lucas_lehmer_sufficiency _ (by norm_num) (by norm_num)
--/
+
+example : (mersenne 9941).Prime :=
+  lucas_lehmer_sufficiency _ (by norm_num) (by norm_num)
+
+-- (kernel) deep recursion detected:
+-- example : (mersenne 11213).Prime :=
+--   lucas_lehmer_sufficiency _ (by norm_num) (by norm_num)

--- a/Mathlib/NumberTheory/LucasLehmer.lean
+++ b/Mathlib/NumberTheory/LucasLehmer.lean
@@ -536,17 +536,54 @@ theorem sMod'_eq_sMod (p k : ℕ) (hp : 2 ≤ p) : (sMod' (2 ^ p - 1) k : ℤ) =
     rw [← add_sub_assoc, sub_eq_add_neg, add_assoc, add_comm _ (-2), ← add_assoc,
       Int.add_emod_self, ← sub_eq_add_neg]
 
-lemma testTrueHelper (p : ℕ) (hp : Nat.blt 1 p = true) (h : sMod' (2 ^ p - 1) (p - 2) = 0) :
+/-- Tail-recursive version of `sMod''`. -/
+def sMod'' (q : ℕ) (k : Nat) : ℕ :=
+  aux k (4 % q)
+where
+  aux : ℕ → ℕ → ℕ
+  | 0, acc => acc
+  | n + 1, acc => aux n ((acc ^ 2 + (q - 2)) % q)
+
+/--
+Generalization of `sMod'` with arbitrary base case,
+useful for proving `sMod''` and `sMod'` agree.
+-/
+def sMod'gen (b : ℕ) (q : ℕ) : ℕ → ℕ
+  | 0 => b
+  | i + 1 => (sMod'gen b q i ^ 2 + (q - 2)) % q
+
+theorem sMod'gen_eq (q k : ℕ) : sMod'gen (4 % q) q k = sMod' q k := by
+  induction k with
+  | zero => rfl
+  | succ k ih => rw [sMod'gen, ih, sMod', ← ih]
+
+theorem sMod''_eq_sMod' (q : ℕ) (i : ℕ) : sMod'' q i = sMod' q i := by
+  rw [sMod'', helper, sMod'gen_eq]
+where
+  helper b q k : sMod''.aux q k b = sMod'gen b q k := by
+    induction k generalizing b with
+    | zero => rfl
+    | succ k ih =>
+      rw [sMod''.aux, ih, sMod'gen]
+      clear ih
+      induction k with
+      | zero => rfl
+      | succ k ih =>
+        rw [sMod'gen, ih, sMod'gen]
+
+lemma testTrueHelper (p : ℕ) (hp : Nat.blt 1 p = true) (h : sMod'' (2 ^ p - 1) (p - 2) = 0) :
     LucasLehmerTest p := by
   rw [Nat.blt_eq] at hp
-  rw [LucasLehmerTest, LucasLehmer.residue_eq_zero_iff_sMod_eq_zero p hp, ← sMod'_eq_sMod p _ hp, h]
+  rw [LucasLehmerTest, LucasLehmer.residue_eq_zero_iff_sMod_eq_zero p hp, ← sMod'_eq_sMod p _ hp,
+    ← sMod''_eq_sMod', h]
   rfl
 
 lemma testFalseHelper (p : ℕ) (hp : Nat.blt 1 p = true)
-    (h : Nat.ble 1 (sMod' (2 ^ p - 1) (p - 2))) : ¬ LucasLehmerTest p := by
+    (h : Nat.ble 1 (sMod'' (2 ^ p - 1) (p - 2))) : ¬ LucasLehmerTest p := by
   rw [Nat.blt_eq] at hp
   rw [Nat.ble_eq, Nat.succ_le, Nat.pos_iff_ne_zero] at h
-  rw [LucasLehmerTest, LucasLehmer.residue_eq_zero_iff_sMod_eq_zero p hp, ← sMod'_eq_sMod p _ hp]
+  rw [LucasLehmerTest, LucasLehmer.residue_eq_zero_iff_sMod_eq_zero p hp, ← sMod'_eq_sMod p _ hp,
+    ← sMod''_eq_sMod']
   simpa using h
 
 theorem isNat_lucasLehmerTest : {p np : ℕ} →
@@ -567,13 +604,13 @@ def evalLucasLehmerTest : NormNumExt where eval {u α} e := do
   unless 1 < np do
     failure
   haveI' h1ltp : Nat.blt 1 $ep =Q true := ⟨⟩
-  if sMod' (2 ^ np - 1) (np - 2) = 0 then
-    haveI' hs : sMod' (2 ^ $ep - 1) ($ep - 2) =Q 0 := ⟨⟩
+  if sMod'' (2 ^ np - 1) (np - 2) = 0 then
+    haveI' hs : sMod'' (2 ^ $ep - 1) ($ep - 2) =Q 0 := ⟨⟩
     have pf : Q(LucasLehmerTest $ep) := q(testTrueHelper $ep $h1ltp $hs)
     have pf' : Q(LucasLehmerTest $p) := q(isNat_lucasLehmerTest $hp $pf)
     return .isTrue pf'
   else
-    haveI' hs : Nat.ble 1 (sMod' (2 ^ $ep - 1) ($ep - 2)) =Q true := ⟨⟩
+    haveI' hs : Nat.ble 1 (sMod'' (2 ^ $ep - 1) ($ep - 2)) =Q true := ⟨⟩
     have pf : Q(¬ LucasLehmerTest $ep) := q(testFalseHelper $ep $h1ltp $hs)
     have pf' : Q(¬ LucasLehmerTest $p) := q(isNat_not_lucasLehmerTest $hp $pf)
     return .isFalse pf'

--- a/Mathlib/NumberTheory/LucasLehmer.lean
+++ b/Mathlib/NumberTheory/LucasLehmer.lean
@@ -540,6 +540,7 @@ theorem sMod'_eq_sMod (p k : ℕ) (hp : 2 ≤ p) : (sMod' (2 ^ p - 1) k : ℤ) =
 def sMod'' (q : ℕ) (k : Nat) : ℕ :=
   aux k (4 % q)
 where
+  /-- Helper function for `sMod''`. -/
   aux : ℕ → ℕ → ℕ
   | 0, acc => acc
   | n + 1, acc => aux n ((acc ^ 2 + (q - 2)) % q)


### PR DESCRIPTION
Previously the failure at `(mersenne 9689).Prime` was a stack overflow in a `norm_num` helper function. Making the relevant function tail-recursive solves that.

We now fail with `(kernel) deep recursion detected`, at an apparently system dependent step:
* in CI, we still fail at `mersenne 9689` (just with a different error)
* on my machine we now succeed at `9689` and `9941`, then fail at `11213`.
