### PR TITLE
[Merged by Bors] - chore: remove `autoImplicit` from `Logic.Equiv.Basic`

### DIFF
--- a/Mathlib/Logic/Basic.lean
+++ b/Mathlib/Logic/Basic.lean
@@ -416,16 +416,13 @@ theorem eqRec_heq' {α : Sort*} {a' : α} {motive : (a : α) → a' = a → Sort
     HEq (@Eq.rec α a' motive p a t) p := by
   subst t; rfl
 
-set_option autoImplicit true in
-theorem rec_heq_of_heq {C : α → Sort*} {x : C a} {y : β} (e : a = b) (h : HEq x y) :
-    HEq (e ▸ x) y := by subst e; exact h
+theorem rec_heq_of_heq {α β : Sort _} {a b : α} {C : α → Sort*} {x : C a} {y : β}
+    (e : a = b) (h : HEq x y) : HEq (e ▸ x) y := by subst e; exact h
 
-set_option autoImplicit true in
-theorem rec_heq_iff_heq {C : α → Sort*} {x : C a} {y : β} {e : a = b} :
+theorem rec_heq_iff_heq {α β : Sort _} {a b : α} {C : α → Sort*} {x : C a} {y : β} {e : a = b} :
     HEq (e ▸ x) y ↔ HEq x y := by subst e; rfl
 
-set_option autoImplicit true in
-theorem heq_rec_iff_heq {C : α → Sort*} {x : β} {y : C a} {e : a = b} :
+theorem heq_rec_iff_heq {α β : Sort _} {a b : α} {C : α → Sort*} {x : β} {y : C a} {e : a = b} :
     HEq x (e ▸ y) ↔ HEq x y := by subst e; rfl
 
 end Equality

--- a/Mathlib/Logic/Equiv/Basic.lean
+++ b/Mathlib/Logic/Equiv/Basic.lean
@@ -50,13 +50,14 @@ universe u v
 
 open Function
 
+-- Unless required to be `Type*`, all variables in this file are `Sort*`
 variable {α α₁ α₂ β β₁ β₂ γ γ₁ γ₂ δ ε ι ι' ι'' : Sort*}
 
 namespace Equiv
 
 /-- `PProd α β` is equivalent to `α × β` -/
 @[simps apply symm_apply]
-def pprodEquivProd {α β : Type*} : PProd α β ≃ α × β where
+def pprodEquivProd {α β} : PProd α β ≃ α × β where
   toFun x := (x.1, x.2)
   invFun x := ⟨x.1, x.2⟩
   left_inv := fun _ => rfl
@@ -74,13 +75,13 @@ def pprodCongr (e₁ : α ≃ β) (e₂ : γ ≃ δ) : PProd α γ ≃ PProd β 
 
 /-- Combine two equivalences using `PProd` in the domain and `Prod` in the codomain. -/
 @[simps! apply symm_apply]
-def pprodProd {α₂ β₂ : Type*} (ea : α₁ ≃ α₂) (eb : β₁ ≃ β₂) :
+def pprodProd {α₂ β₂} (ea : α₁ ≃ α₂) (eb : β₁ ≃ β₂) :
     PProd α₁ β₁ ≃ α₂ × β₂ :=
   (ea.pprodCongr eb).trans pprodEquivProd
 
 /-- Combine two equivalences using `PProd` in the codomain and `Prod` in the domain. -/
 @[simps! apply symm_apply]
-def prodPProd {α₁ β₁ : Type*} (ea : α₁ ≃ α₂) (eb : β₁ ≃ β₂) :
+def prodPProd {α₁ β₁} (ea : α₁ ≃ α₂) (eb : β₁ ≃ β₂) :
     α₁ × β₁ ≃ PProd α₂ β₂ :=
   (ea.symm.pprodProd eb.symm).symm
 
@@ -93,11 +94,11 @@ def pprodEquivProdPLift : PProd α β ≃ PLift α × PLift β :=
 `Prod.map` as an equivalence. -/
 -- Porting note: in Lean 3 there was also a @[congr] tag
 @[simps (config := .asFn) apply]
-def prodCongr {α₁ α₂ β₁ β₂ : Type*} (e₁ : α₁ ≃ α₂) (e₂ : β₁ ≃ β₂) : α₁ × β₁ ≃ α₂ × β₂ :=
+def prodCongr {α₁ α₂ β₁ β₂} (e₁ : α₁ ≃ α₂) (e₂ : β₁ ≃ β₂) : α₁ × β₁ ≃ α₂ × β₂ :=
   ⟨Prod.map e₁ e₂, Prod.map e₁.symm e₂.symm, fun ⟨a, b⟩ => by simp, fun ⟨a, b⟩ => by simp⟩
 
 @[simp]
-theorem prodCongr_symm {α₁ α₂ β₁ β₂ : Type*} (e₁ : α₁ ≃ α₂) (e₂ : β₁ ≃ β₂) :
+theorem prodCongr_symm {α₁ α₂ β₁ β₂} (e₁ : α₁ ≃ α₂) (e₂ : β₁ ≃ β₂) :
     (prodCongr e₁ e₂).symm = prodCongr e₁.symm e₂.symm :=
   rfl
 
@@ -111,7 +112,7 @@ theorem coe_prodComm (α β) : (⇑(prodComm α β) : α × β → β × α) = P
   rfl
 
 @[simp]
-theorem prodComm_apply {α β : Type*} (x : α × β) : prodComm α β x = x.swap :=
+theorem prodComm_apply {α β} (x : α × β) : prodComm α β x = x.swap :=
   rfl
 
 @[simp]
@@ -126,14 +127,14 @@ def prodAssoc (α β γ) : (α × β) × γ ≃ α × β × γ :=
 
 /-- Four-way commutativity of `prod`. The name matches `mul_mul_mul_comm`. -/
 @[simps apply]
-def prodProdProdComm (α β γ δ : Type*) : (α × β) × γ × δ ≃ (α × γ) × β × δ where
+def prodProdProdComm (α β γ δ) : (α × β) × γ × δ ≃ (α × γ) × β × δ where
   toFun abcd := ((abcd.1.1, abcd.2.1), (abcd.1.2, abcd.2.2))
   invFun acbd := ((acbd.1.1, acbd.2.1), (acbd.1.2, acbd.2.2))
   left_inv := fun ⟨⟨_a, _b⟩, ⟨_c, _d⟩⟩ => rfl
   right_inv := fun ⟨⟨_a, _c⟩, ⟨_b, _d⟩⟩ => rfl
 
 @[simp]
-theorem prodProdProdComm_symm (α β γ δ : Type*) :
+theorem prodProdProdComm_symm (α β γ δ) :
     (prodProdProdComm α β γ δ).symm = prodProdProdComm α γ β δ :=
   rfl
 
@@ -169,15 +170,14 @@ def prodUnique (α β) [Unique β] : α × β ≃ α :=
   ((Equiv.refl α).prodCongr <| equivPUnit.{_,1} β).trans <| prodPUnit α
 
 @[simp]
-theorem coe_prodUnique {α β : Type*} [Unique β] : (⇑(prodUnique α β) : α × β → α) = Prod.fst :=
+theorem coe_prodUnique {α β} [Unique β] : (⇑(prodUnique α β) : α × β → α) = Prod.fst :=
   rfl
 
-theorem prodUnique_apply {α β : Type*} [Unique β] (x : α × β) : prodUnique α β x = x.1 :=
+theorem prodUnique_apply {α β} [Unique β] (x : α × β) : prodUnique α β x = x.1 :=
   rfl
 
 @[simp]
-theorem prodUnique_symm_apply {α β : Type*} [Unique β] (x : α) :
-    (prodUnique α β).symm x = (x, default) :=
+theorem prodUnique_symm_apply {α β} [Unique β] (x : α) : (prodUnique α β).symm x = (x, default) :=
   rfl
 
 /-- Any `Unique` type is a left identity for type product up to equivalence. -/
@@ -185,14 +185,14 @@ def uniqueProd (α β) [Unique β] : β × α ≃ α :=
   ((equivPUnit.{_,1} β).prodCongr <| Equiv.refl α).trans <| punitProd α
 
 @[simp]
-theorem coe_uniqueProd {α β : Type*} [Unique β] : (⇑(uniqueProd α β) : β × α → α) = Prod.snd :=
+theorem coe_uniqueProd {α β} [Unique β] : (⇑(uniqueProd α β) : β × α → α) = Prod.snd :=
   rfl
 
-theorem uniqueProd_apply {α β : Type*} [Unique β] (x : β × α) : uniqueProd α β x = x.2 :=
+theorem uniqueProd_apply {α β} [Unique β] (x : β × α) : uniqueProd α β x = x.2 :=
   rfl
 
 @[simp]
-theorem uniqueProd_symm_apply {α β : Type*} [Unique β] (x : α) :
+theorem uniqueProd_symm_apply {α β} [Unique β] (x : α) :
     (uniqueProd α β).symm x = (default, x) :=
   rfl
 
@@ -202,16 +202,16 @@ def sigmaUnique (α) (β : α → Type*) [∀ a, Unique (β a)] : (a : α) × (�
   (Equiv.sigmaCongrRight fun a ↦ equivPUnit.{_,1} (β a)).trans <| sigmaPUnit α
 
 @[simp]
-theorem coe_sigmaUnique {α : Type*} {β : α → Type*} [∀ a, Unique (β a)] :
+theorem coe_sigmaUnique {α} {β : α → Type*} [∀ a, Unique (β a)] :
     (⇑(sigmaUnique α β) : (a : α) × (β a) → α) = Sigma.fst :=
   rfl
 
-theorem sigmaUnique_apply {α : Type*} {β : α → Type*} [∀ a, Unique (β a)] (x : (a : α) × β a) :
+theorem sigmaUnique_apply {α} {β : α → Type*} [∀ a, Unique (β a)] (x : (a : α) × β a) :
     sigmaUnique α β x = x.1 :=
   rfl
 
 @[simp]
-theorem sigmaUnique_symm_apply {α : Type*} {β : α → Type*} [∀ a, Unique (β a)] (x : α) :
+theorem sigmaUnique_symm_apply {α} {β : α → Type*} [∀ a, Unique (β a)] (x : α) :
     (sigmaUnique α β).symm x = ⟨x, default⟩ :=
   rfl
 
@@ -246,7 +246,7 @@ def psumEquivSum (α β) : α ⊕' β ≃ α ⊕ β where
 
 /-- If `α ≃ α'` and `β ≃ β'`, then `α ⊕ β ≃ α' ⊕ β'`. This is `Sum.map` as an equivalence. -/
 @[simps apply]
-def sumCongr (ea : α₁ ≃ α₂) (eb : β₁ ≃ β₂) : α₁ ⊕ β₁ ≃ α₂ ⊕ β₂ :=
+def sumCongr {α₁ α₂ β₁ β₂} (ea : α₁ ≃ α₂) (eb : β₁ ≃ β₂) : α₁ ⊕ β₁ ≃ α₂ ⊕ β₂ :=
   ⟨Sum.map ea eb, Sum.map ea.symm eb.symm, fun x => by simp, fun x => by simp⟩
 
 /-- If `α ≃ α'` and `β ≃ β'`, then `α ⊕' β ≃ α' ⊕' β'`. -/
@@ -257,33 +257,35 @@ def psumCongr (e₁ : α ≃ β) (e₂ : γ ≃ δ) : α ⊕' γ ≃ β ⊕' δ 
   right_inv := by rintro (x | x) <;> simp
 
 /-- Combine two `Equiv`s using `PSum` in the domain and `Sum` in the codomain. -/
-def psumSum (ea : α₁ ≃ α₂) (eb : β₁ ≃ β₂) :
+def psumSum {α₂ β₂} (ea : α₁ ≃ α₂) (eb : β₁ ≃ β₂) :
     α₁ ⊕' β₁ ≃ α₂ ⊕ β₂ :=
   (ea.psumCongr eb).trans (psumEquivSum _ _)
 
 /-- Combine two `Equiv`s using `Sum` in the domain and `PSum` in the codomain. -/
-def sumPSum (ea : α₁ ≃ α₂) (eb : β₁ ≃ β₂) :
+def sumPSum {α₁ β₁} (ea : α₁ ≃ α₂) (eb : β₁ ≃ β₂) :
     α₁ ⊕ β₁ ≃ α₂ ⊕' β₂ :=
   (ea.symm.psumSum eb.symm).symm
 
 @[simp]
-theorem sumCongr_trans (e : α₁ ≃ β₁) (f : α₂ ≃ β₂) (g : β₁ ≃ γ₁) (h : β₂ ≃ γ₂) :
+theorem sumCongr_trans {α₁ α₂ β₁ β₂ γ₁ γ₂} (e : α₁ ≃ β₁) (f : α₂ ≃ β₂) (g : β₁ ≃ γ₁) (h : β₂ ≃ γ₂) :
     (Equiv.sumCongr e f).trans (Equiv.sumCongr g h) = Equiv.sumCongr (e.trans g) (f.trans h) := by
   ext i
   cases i <;> rfl
 
 @[simp]
-theorem sumCongr_symm (e : α ≃ β) (f : γ ≃ δ) :
+theorem sumCongr_symm {α β γ δ} (e : α ≃ β) (f : γ ≃ δ) :
     (Equiv.sumCongr e f).symm = Equiv.sumCongr e.symm f.symm :=
   rfl
 
 @[simp]
-theorem sumCongr_refl : Equiv.sumCongr (Equiv.refl α) (Equiv.refl β) = Equiv.refl (α ⊕ β) := by
+theorem sumCongr_refl {α β} :
+    Equiv.sumCongr (Equiv.refl α) (Equiv.refl β) = Equiv.refl (α ⊕ β) := by
   ext i
   cases i <;> rfl
 
 /-- A subtype of a sum is equivalent to a sum of subtypes. -/
-def subtypeSum {p : α ⊕ β → Prop} : {c // p c} ≃ {a // p (Sum.inl a)} ⊕ {b // p (Sum.inr b)} where
+def subtypeSum {α β} {p : α ⊕ β → Prop} :
+    {c // p c} ≃ {a // p (Sum.inl a)} ⊕ {b // p (Sum.inr b)} where
   toFun c := match h : c.1 with
     | Sum.inl a => Sum.inl ⟨a, h ▸ c.2⟩
     | Sum.inr b => Sum.inr ⟨b, h ▸ c.2⟩
@@ -296,25 +298,25 @@ def subtypeSum {p : α ⊕ β → Prop} : {c // p c} ≃ {a // p (Sum.inl a)} �
 namespace Perm
 
 /-- Combine a permutation of `α` and of `β` into a permutation of `α ⊕ β`. -/
-abbrev sumCongr (ea : Equiv.Perm α) (eb : Equiv.Perm β) : Equiv.Perm (α ⊕ β) :=
+abbrev sumCongr {α β} (ea : Equiv.Perm α) (eb : Equiv.Perm β) : Equiv.Perm (α ⊕ β) :=
   Equiv.sumCongr ea eb
 
 @[simp]
-theorem sumCongr_apply (ea : Equiv.Perm α) (eb : Equiv.Perm β) (x : α ⊕ β) :
+theorem sumCongr_apply {α β} (ea : Equiv.Perm α) (eb : Equiv.Perm β) (x : α ⊕ β) :
     sumCongr ea eb x = Sum.map (⇑ea) (⇑eb) x :=
   Equiv.sumCongr_apply ea eb x
 
 -- Porting note: it seems the general theorem about `Equiv` is now applied, so there's no need
 -- to have this version also have `@[simp]`. Similarly for below.
-theorem sumCongr_trans (e : Equiv.Perm α) (f : Equiv.Perm β) (g : Equiv.Perm α)
+theorem sumCongr_trans {α β} (e : Equiv.Perm α) (f : Equiv.Perm β) (g : Equiv.Perm α)
     (h : Equiv.Perm β) : (sumCongr e f).trans (sumCongr g h) = sumCongr (e.trans g) (f.trans h) :=
   Equiv.sumCongr_trans e f g h
 
-theorem sumCongr_symm (e : Equiv.Perm α) (f : Equiv.Perm β) :
+theorem sumCongr_symm {α β} (e : Equiv.Perm α) (f : Equiv.Perm β) :
     (sumCongr e f).symm = sumCongr e.symm f.symm :=
   Equiv.sumCongr_symm e f
 
-theorem sumCongr_refl : sumCongr (Equiv.refl α) (Equiv.refl β) = Equiv.refl (α ⊕ β) :=
+theorem sumCongr_refl {α β} : sumCongr (Equiv.refl α) (Equiv.refl β) = Equiv.refl (α ⊕ β) :=
   Equiv.sumCongr_refl
 
 end Perm
@@ -341,15 +343,15 @@ def sumAssoc (α β γ) : (α ⊕ β) ⊕ γ ≃ α ⊕ (β ⊕ γ) :=
     rintro (_ | ⟨_ | _⟩) <;> rfl⟩
 
 @[simp]
-theorem sumAssoc_apply_inl_inl (a) : sumAssoc α β γ (inl (inl a)) = inl a :=
+theorem sumAssoc_apply_inl_inl {α β γ} (a) : sumAssoc α β γ (inl (inl a)) = inl a :=
   rfl
 
 @[simp]
-theorem sumAssoc_apply_inl_inr (b) : sumAssoc α β γ (inl (inr b)) = inr (inl b) :=
+theorem sumAssoc_apply_inl_inr {α β γ} (b) : sumAssoc α β γ (inl (inr b)) = inr (inl b) :=
   rfl
 
 @[simp]
-theorem sumAssoc_apply_inr (c) : sumAssoc α β γ (inr c) = inr (inr c) :=
+theorem sumAssoc_apply_inr {α β γ} (c) : sumAssoc α β γ (inr c) = inr (inr c) :=
   rfl
 
 @[simp]
@@ -377,7 +379,7 @@ def sumEmpty (α β) [IsEmpty β] : α ⊕ β ≃ α where
   right_inv _ := rfl
 
 @[simp]
-theorem sumEmpty_apply_inl [IsEmpty β] (a : α) : sumEmpty α β (Sum.inl a) = a :=
+theorem sumEmpty_apply_inl {α β} [IsEmpty β] (a : α) : sumEmpty α β (Sum.inl a) = a :=
   rfl
 
 /-- The sum of `IsEmpty` with any type is equivalent to that type. -/
@@ -386,7 +388,7 @@ def emptySum (α β) [IsEmpty α] : α ⊕ β ≃ β :=
   (sumComm _ _).trans <| sumEmpty _ _
 
 @[simp]
-theorem emptySum_apply_inr [IsEmpty α] (b : β) : emptySum α β (Sum.inr b) = b :=
+theorem emptySum_apply_inr {α β} [IsEmpty α] (b : β) : emptySum α β (Sum.inr b) = b :=
   rfl
 
 /-- `Option α` is equivalent to `α ⊕ PUnit` -/
@@ -396,23 +398,23 @@ def optionEquivSumPUnit (α) : Option α ≃ α ⊕ PUnit :=
     fun s => by rcases s with (_ | ⟨⟨⟩⟩) <;> rfl⟩
 
 @[simp]
-theorem optionEquivSumPUnit_none : optionEquivSumPUnit α none = Sum.inr PUnit.unit :=
+theorem optionEquivSumPUnit_none {α} : optionEquivSumPUnit α none = Sum.inr PUnit.unit :=
   rfl
 
 @[simp]
-theorem optionEquivSumPUnit_some (a) : optionEquivSumPUnit α (some a) = Sum.inl a :=
+theorem optionEquivSumPUnit_some {α} (a) : optionEquivSumPUnit α (some a) = Sum.inl a :=
   rfl
 
 @[simp]
-theorem optionEquivSumPUnit_coe (a : α) : optionEquivSumPUnit α a = Sum.inl a :=
+theorem optionEquivSumPUnit_coe {α} (a : α) : optionEquivSumPUnit α a = Sum.inl a :=
   rfl
 
 @[simp]
-theorem optionEquivSumPUnit_symm_inl (a) : (optionEquivSumPUnit α).symm (Sum.inl a) = a :=
+theorem optionEquivSumPUnit_symm_inl {α} (a) : (optionEquivSumPUnit α).symm (Sum.inl a) = a :=
   rfl
 
 @[simp]
-theorem optionEquivSumPUnit_symm_inr (a) : (optionEquivSumPUnit α).symm (Sum.inr a) = none :=
+theorem optionEquivSumPUnit_symm_inr {α} (a) : (optionEquivSumPUnit α).symm (Sum.inr a) = none :=
   rfl
 
 /-- The set of `x : Option α` such that `isSome x` is equivalent to `α`. -/
@@ -426,7 +428,7 @@ def optionIsSomeEquiv (α) : { x : Option α // x.isSome } ≃ α where
 /-- The product over `Option α` of `β a` is the binary product of the
 product over `α` of `β (some α)` and `β none` -/
 @[simps]
-def piOptionEquivProd {β : Option α → Type*} :
+def piOptionEquivProd {α} {β : Option α → Type*} :
     (∀ a : Option α, β a) ≃ β none × ∀ a : α, β (some a) where
   toFun f := (f none, fun a => f (some a))
   invFun x a := Option.casesOn a x.fst x.snd
@@ -437,7 +439,7 @@ def piOptionEquivProd {β : Option α → Type*} :
 `β` to be types from the same universe, so it cannot be used directly to transfer theorems about
 sigma types to theorems about sum types. In many cases one can use `ULift` to work around this
 difficulty. -/
-def sumEquivSigmaBool (α β : Type u) : α ⊕ β ≃ Σ b : Bool, b.casesOn α β :=
+def sumEquivSigmaBool (α β) : α ⊕ β ≃ Σ b : Bool, b.casesOn α β :=
   ⟨fun s => s.elim (fun x => ⟨false, x⟩) fun x => ⟨true, x⟩, fun s =>
     match s with
     | ⟨false, a⟩ => inl a

--- a/Mathlib/Logic/Equiv/Basic.lean
+++ b/Mathlib/Logic/Equiv/Basic.lean
@@ -46,11 +46,11 @@ In this file we continue the work on equivalences begun in `Logic/Equiv/Defs.lea
 equivalence, congruence, bijective map
 -/
 
-set_option autoImplicit true
-
-universe u
+universe u v
 
 open Function
+
+variable {α α₁ α₂ β β₁ β₂ γ γ₁ γ₂ δ ε ι ι' ι'': Type*}
 
 namespace Equiv
 
@@ -66,7 +66,7 @@ def pprodEquivProd : PProd α β ≃ α × β where
 `PProd α γ ≃ PProd β δ`. -/
 -- Porting note: in Lean 3 this had `@[congr]`
 @[simps apply]
-def pprodCongr (e₁ : α ≃ β) (e₂ : γ ≃ δ) : PProd α γ ≃ PProd β δ where
+def pprodCongr {α β γ δ : Sort*} (e₁ : α ≃ β) (e₂ : γ ≃ δ) : PProd α γ ≃ PProd β δ where
   toFun x := ⟨e₁ x.1, e₂ x.2⟩
   invFun x := ⟨e₁.symm x.1, e₂.symm x.2⟩
   left_inv := fun ⟨x, y⟩ => by simp
@@ -74,19 +74,19 @@ def pprodCongr (e₁ : α ≃ β) (e₂ : γ ≃ δ) : PProd α γ ≃ PProd β 
 
 /-- Combine two equivalences using `PProd` in the domain and `Prod` in the codomain. -/
 @[simps! apply symm_apply]
-def pprodProd (ea : α₁ ≃ α₂) (eb : β₁ ≃ β₂) :
+def pprodProd {α₁ β₁ : Sort*} (ea : α₁ ≃ α₂) (eb : β₁ ≃ β₂) :
     PProd α₁ β₁ ≃ α₂ × β₂ :=
   (ea.pprodCongr eb).trans pprodEquivProd
 
 /-- Combine two equivalences using `PProd` in the codomain and `Prod` in the domain. -/
 @[simps! apply symm_apply]
-def prodPProd (ea : α₁ ≃ α₂) (eb : β₁ ≃ β₂) :
+def prodPProd {α₂ β₂ : Sort*} (ea : α₁ ≃ α₂) (eb : β₁ ≃ β₂) :
     α₁ × β₁ ≃ PProd α₂ β₂ :=
   (ea.symm.pprodProd eb.symm).symm
 
 /-- `PProd α β` is equivalent to `PLift α × PLift β` -/
 @[simps! apply symm_apply]
-def pprodEquivProdPLift : PProd α β ≃ PLift α × PLift β :=
+def pprodEquivProdPLift {α β : Sort*} : PProd α β ≃ PLift α × PLift β :=
   Equiv.plift.symm.pprodProd Equiv.plift.symm
 
 /-- Product of two equivalences. If `α₁ ≃ α₂` and `β₁ ≃ β₂`, then `α₁ × β₁ ≃ α₂ × β₂`. This is
@@ -250,19 +250,19 @@ def sumCongr (ea : α₁ ≃ α₂) (eb : β₁ ≃ β₂) : α₁ ⊕ β₁ ≃
   ⟨Sum.map ea eb, Sum.map ea.symm eb.symm, fun x => by simp, fun x => by simp⟩
 
 /-- If `α ≃ α'` and `β ≃ β'`, then `α ⊕' β ≃ α' ⊕' β'`. -/
-def psumCongr (e₁ : α ≃ β) (e₂ : γ ≃ δ) : α ⊕' γ ≃ β ⊕' δ where
+def psumCongr {α β γ δ : Sort*} (e₁ : α ≃ β) (e₂ : γ ≃ δ) : α ⊕' γ ≃ β ⊕' δ where
   toFun x := PSum.casesOn x (PSum.inl ∘ e₁) (PSum.inr ∘ e₂)
   invFun x := PSum.casesOn x (PSum.inl ∘ e₁.symm) (PSum.inr ∘ e₂.symm)
   left_inv := by rintro (x | x) <;> simp
   right_inv := by rintro (x | x) <;> simp
 
 /-- Combine two `Equiv`s using `PSum` in the domain and `Sum` in the codomain. -/
-def psumSum (ea : α₁ ≃ α₂) (eb : β₁ ≃ β₂) :
+def psumSum {α₁ β₁ : Sort*} (ea : α₁ ≃ α₂) (eb : β₁ ≃ β₂) :
     α₁ ⊕' β₁ ≃ α₂ ⊕ β₂ :=
   (ea.psumCongr eb).trans (psumEquivSum _ _)
 
 /-- Combine two `Equiv`s using `Sum` in the domain and `PSum` in the codomain. -/
-def sumPSum (ea : α₁ ≃ α₂) (eb : β₁ ≃ β₂) :
+def sumPSum {α₂ β₂ : Sort*} (ea : α₁ ≃ α₂) (eb : β₁ ≃ β₂) :
     α₁ ⊕ β₁ ≃ α₂ ⊕' β₂ :=
   (ea.symm.psumSum eb.symm).symm
 
@@ -605,7 +605,8 @@ section
 
 /-- A family of equivalences `∀ a, β₁ a ≃ β₂ a` generates an equivalence between `∀ a, β₁ a` and
 `∀ a, β₂ a`. -/
-def piCongrRight {β₁ β₂ : α → Sort*} (F : ∀ a, β₁ a ≃ β₂ a) : (∀ a, β₁ a) ≃ (∀ a, β₂ a) :=
+def piCongrRight {α : Sort*} {β₁ β₂ : α → Sort*} (F : ∀ a, β₁ a ≃ β₂ a) :
+    (∀ a, β₁ a) ≃ (∀ a, β₂ a) :=
   ⟨fun H a => F a (H a), fun H a => (F a).symm (H a), fun H => funext <| by simp,
     fun H => funext <| by simp⟩
 
@@ -978,10 +979,10 @@ def uniqueCongr (e : α ≃ β) : Unique α ≃ Unique β where
   right_inv _ := Subsingleton.elim _ _
 
 /-- If `α` is equivalent to `β`, then `IsEmpty α` is equivalent to `IsEmpty β`. -/
-theorem isEmpty_congr (e : α ≃ β) : IsEmpty α ↔ IsEmpty β :=
+theorem isEmpty_congr {α β : Sort*} (e : α ≃ β) : IsEmpty α ↔ IsEmpty β :=
   ⟨fun h => @Function.isEmpty _ _ h e.symm, fun h => @Function.isEmpty _ _ h e⟩
 
-protected theorem isEmpty (e : α ≃ β) [IsEmpty β] : IsEmpty α :=
+protected theorem isEmpty {α β : Sort*} (e : α ≃ β) [IsEmpty β] : IsEmpty α :=
   e.isEmpty_congr.mpr ‹_›
 
 section
@@ -1233,7 +1234,7 @@ end
 
 section subtypeEquivCodomain
 
-variable [DecidableEq X] {x : X}
+variable {X Y : Type*} [DecidableEq X] {x : X}
 
 /-- The type of all functions `X → Y` with prescribed values for all `x' ≠ x`
 is equivalent to the codomain `Y`. -/
@@ -1359,7 +1360,7 @@ theorem subtypeQuotientEquivQuotientSubtype_symm_mk (p₁ : α → Prop)
 
 section Swap
 
-variable [DecidableEq α]
+variable {α β : Sort*} [DecidableEq α]
 
 /-- A helper function for `Equiv.swap`. -/
 def swapCore (a b r : α) : α :=
@@ -1518,6 +1519,8 @@ end Equiv
 
 namespace Function.Involutive
 
+variable {α : Sort*}
+
 /-- Convert an involutive function `f` to a permutation with `toFun = invFun = f`. -/
 def toPerm (f : α → α) (h : Involutive f) : Equiv.Perm α :=
   ⟨f, f, h.leftInverse, h.rightInverse⟩
@@ -1538,10 +1541,10 @@ theorem symm_eq_self_of_involutive (f : Equiv.Perm α) (h : Involutive f) : f.sy
 
 end Function.Involutive
 
-theorem PLift.eq_up_iff_down_eq {x : PLift α} {y : α} : x = PLift.up y ↔ x.down = y :=
+theorem PLift.eq_up_iff_down_eq {α : Sort*} {x : PLift α} {y : α} : x = PLift.up y ↔ x.down = y :=
   Equiv.plift.eq_symm_apply
 
-theorem Function.Injective.map_swap [DecidableEq α] [DecidableEq β] {f : α → β}
+theorem Function.Injective.map_swap {α β : Sort*} [DecidableEq α] [DecidableEq β] {f : α → β}
     (hf : Function.Injective f) (x y z : α) :
     f (Equiv.swap x y z) = Equiv.swap (f x) (f y) (f z) := by
   conv_rhs => rw [Equiv.swap_apply_def]
@@ -1554,7 +1557,7 @@ namespace Equiv
 
 section
 
-variable (P : α → Sort w) (e : α ≃ β)
+variable {α β : Sort*} (P : α → Sort*) (e : α ≃ β)
 
 /-- Transport dependent functions through an equivalence of the base space.
 -/
@@ -1592,7 +1595,7 @@ end
 
 section
 
-variable (P : β → Sort w) (e : α ≃ β)
+variable {α β : Sort*} (P : β → Sort*) (e : α ≃ β)
 
 /-- Transporting dependent functions through an equivalence of the base,
 expressed as a "simplification".
@@ -1644,7 +1647,7 @@ end
 
 section
 
-variable {W : α → Sort w} {Z : β → Sort z} (h₁ : α ≃ β) (h₂ : ∀ a : α, W a ≃ Z (h₁ a))
+variable {α β : Sort*} {W : α → Sort*} {Z : β → Sort*} (h₁ : α ≃ β) (h₂ : ∀ a : α, W a ≃ Z (h₁ a))
 
 /-- Transport dependent functions through
 an equivalence of the base spaces and a family
@@ -1670,7 +1673,8 @@ end
 
 section
 
-variable {W : α → Sort w} {Z : β → Sort z} (h₁ : α ≃ β) (h₂ : ∀ b : β, W (h₁.symm b) ≃ Z b)
+variable {α β : Sort*} {W : α → Sort*} {Z : β → Sort*} (h₁ : α ≃ β)
+  (h₂ : ∀ b : β, W (h₁.symm b) ≃ Z b)
 
 /-- Transport dependent functions through
 an equivalence of the base spaces and a family
@@ -1718,9 +1722,7 @@ end BinaryOp
 
 section ULift
 
-@[simp]
-theorem ulift_symm_down (x : α) : (Equiv.ulift.{u, v}.symm x).down = x :=
-  rfl
+@[simp] theorem ulift_symm_down (x : α) : (Equiv.ulift.symm x).down = x := rfl
 
 end ULift
 
@@ -1751,8 +1753,8 @@ def subsingletonProdSelfEquiv [Subsingleton α] : α × α ≃ α where
 
 /-- To give an equivalence between two subsingleton types, it is sufficient to give any two
     functions between them. -/
-def equivOfSubsingletonOfSubsingleton [Subsingleton α] [Subsingleton β] (f : α → β) (g : β → α) :
-    α ≃ β where
+def equivOfSubsingletonOfSubsingleton {α β : Sort*} [Subsingleton α] [Subsingleton β]
+    (f : α → β) (g : β → α) : α ≃ β where
   toFun := f
   invFun := g
   left_inv _ := Subsingleton.elim _ _
@@ -1769,10 +1771,12 @@ def uniqueUniqueEquiv : Unique (Unique α) ≃ Unique α :=
     { default := h, uniq := fun _ => Subsingleton.elim _ _ }
 
 /-- If `Unique β`, then `Unique α` is equivalent to `α ≃ β`. -/
-def uniqueEquivEquivUnique (α : Sort u) (β : Sort v) [Unique β] : Unique α ≃ (α ≃ β) :=
+def uniqueEquivEquivUnique (α β : Sort*) [Unique β] : Unique α ≃ (α ≃ β) :=
   equivOfSubsingletonOfSubsingleton (fun _ => Equiv.equivOfUnique _ _) Equiv.unique
 
 namespace Function
+
+variable {α α' β : Sort*}
 
 theorem update_comp_equiv [DecidableEq α'] [DecidableEq α] (f : α → β)
     (g : α' ≃ α) (a : α) (v : β) :

--- a/Mathlib/Logic/Equiv/Basic.lean
+++ b/Mathlib/Logic/Equiv/Basic.lean
@@ -51,7 +51,7 @@ universe u v
 open Function
 
 -- Unless required to be `Type*`, all variables in this file are `Sort*`
-variable {α α₁ α₂ β β₁ β₂ γ γ₁ γ₂ δ ε ι ι' ι'' : Sort*}
+variable {α α₁ α₂ β β₁ β₂ γ γ₁ γ₂ δ ι ι' ι'' : Sort*}
 
 namespace Equiv
 
@@ -488,32 +488,32 @@ def sumCompl {α : Type*} (p : α → Prop) [DecidablePred p] :
     split_ifs <;> rfl
 
 @[simp]
-theorem sumCompl_apply_inl (p : α → Prop) [DecidablePred p] (x : { a // p a }) :
+theorem sumCompl_apply_inl {α} (p : α → Prop) [DecidablePred p] (x : { a // p a }) :
     sumCompl p (Sum.inl x) = x :=
   rfl
 
 @[simp]
-theorem sumCompl_apply_inr (p : α → Prop) [DecidablePred p] (x : { a // ¬p a }) :
+theorem sumCompl_apply_inr {α} (p : α → Prop) [DecidablePred p] (x : { a // ¬p a }) :
     sumCompl p (Sum.inr x) = x :=
   rfl
 
 @[simp]
-theorem sumCompl_apply_symm_of_pos (p : α → Prop) [DecidablePred p] (a : α) (h : p a) :
+theorem sumCompl_apply_symm_of_pos {α} (p : α → Prop) [DecidablePred p] (a : α) (h : p a) :
     (sumCompl p).symm a = Sum.inl ⟨a, h⟩ :=
   dif_pos h
 
 @[simp]
-theorem sumCompl_apply_symm_of_neg (p : α → Prop) [DecidablePred p] (a : α) (h : ¬p a) :
+theorem sumCompl_apply_symm_of_neg {α} (p : α → Prop) [DecidablePred p] (a : α) (h : ¬p a) :
     (sumCompl p).symm a = Sum.inr ⟨a, h⟩ :=
   dif_neg h
 
 /-- Combines an `Equiv` between two subtypes with an `Equiv` between their complements to form a
   permutation. -/
-def subtypeCongr {p q : α → Prop} [DecidablePred p] [DecidablePred q]
+def subtypeCongr {α} {p q : α → Prop} [DecidablePred p] [DecidablePred q]
     (e : { x // p x } ≃ { x // q x }) (f : { x // ¬p x } ≃ { x // ¬q x }) : Perm α :=
   (sumCompl p).symm.trans ((sumCongr e f).trans (sumCompl q))
 
-variable {p : ε → Prop} [DecidablePred p]
+variable {ε : Type*} {p : ε → Prop} [DecidablePred p]
 variable (ep ep' : Perm { a // p a }) (en en' : Perm { a // ¬p a })
 
 /-- Combining permutations on `ε` that permute only inside or outside the subtype
@@ -625,7 +625,7 @@ theorem piComm_symm {φ : α → β → Sort*} : (piComm φ).symm = (piComm <| s
 to the type of dependent functions of two arguments (i.e., functions to the space of functions).
 
 This is `Sigma.curry` and `Sigma.uncurry` together as an equiv. -/
-def piCurry {β : α → Type*} (γ : ∀ a, β a → Type*) :
+def piCurry {α} {β : α → Type*} (γ : ∀ a, β a → Type*) :
     (∀ x : Σ i, β i, γ x.1 x.2) ≃ ∀ a b, γ a b where
   toFun := Sigma.curry
   invFun := Sigma.uncurry
@@ -633,12 +633,12 @@ def piCurry {β : α → Type*} (γ : ∀ a, β a → Type*) :
   right_inv := Sigma.curry_uncurry
 
 -- `simps` overapplies these but `simps (config := .asFn)` under-applies them
-@[simp] theorem piCurry_apply {β : α → Type*} (γ : ∀ a, β a → Type*)
+@[simp] theorem piCurry_apply {α} {β : α → Type*} (γ : ∀ a, β a → Type*)
     (f : ∀ x : Σ i, β i, γ x.1 x.2) :
     piCurry γ f = Sigma.curry f :=
   rfl
 
-@[simp] theorem piCurry_symm_apply {β : α → Type*} (γ : ∀ a, β a → Type*) (f : ∀ a b, γ a b) :
+@[simp] theorem piCurry_symm_apply {α} {β : α → Type*} (γ : ∀ a, β a → Type*) (f : ∀ a b, γ a b) :
     (piCurry γ).symm f = Sigma.uncurry f :=
   rfl
 
@@ -646,7 +646,7 @@ end
 
 section prodCongr
 
-variable (e : α₁ → β₁ ≃ β₂)
+variable {α₁ α₂ β₁ β₂ : Type*} (e : α₁ → β₁ ≃ β₂)
 
 /-- A family of equivalences `∀ (a : α₁), β₁ ≃ β₂` generates an equivalence
 between `β₁ × α₁` and `β₂ × α₁`. -/
@@ -718,7 +718,8 @@ theorem sigmaEquivProd_sigmaCongrRight :
 -- See also `Equiv.ofPreimageEquiv`.
 /-- A family of equivalences between fibers gives an equivalence between domains. -/
 @[simps!]
-def ofFiberEquiv {f : α → γ} {g : β → γ} (e : ∀ c, { a // f a = c } ≃ { b // g b = c }) : α ≃ β :=
+def ofFiberEquiv {α β γ} {f : α → γ} {g : β → γ}
+    (e : ∀ c, { a // f a = c } ≃ { b // g b = c }) : α ≃ β :=
   (sigmaFiberEquiv f).symm.trans <| (Equiv.sigmaCongrRight e).trans (sigmaFiberEquiv g)
 
 theorem ofFiberEquiv_map {α β γ} {f : α → γ} {g : β → γ}

--- a/Mathlib/Logic/Equiv/Basic.lean
+++ b/Mathlib/Logic/Equiv/Basic.lean
@@ -872,7 +872,7 @@ theorem sumProdDistrib_symm_apply_right {α β γ} (b : β × γ) :
   rfl
 
 /-- Type product is left distributive with respect to type sum up to an equivalence. -/
-def prodSumDistrib (α β γ : Type*) : α × (β ⊕ γ) ≃ (α × β) ⊕ (α × γ) :=
+def prodSumDistrib (α β γ) : α × (β ⊕ γ) ≃ (α × β) ⊕ (α × γ) :=
   calc
     α × (β ⊕ γ) ≃ (β ⊕ γ) × α := prodComm _ _
     _ ≃ (β × α) ⊕ (γ × α) := sumProdDistrib _ _ _
@@ -909,7 +909,7 @@ def sigmaSumDistrib {ι} (α β : ι → Type*) :
 /-- The product of an indexed sum of types (formally, a `Sigma`-type `Σ i, α i`) by a type `β` is
 equivalent to the sum of products `Σ i, (α i × β)`. -/
 @[simps apply symm_apply]
-def sigmaProdDistrib {ι} (α : ι → Type*) (β : Type*) : (Σ i, α i) × β ≃ Σ i, α i × β :=
+def sigmaProdDistrib {ι} (α : ι → Type*) (β) : (Σ i, α i) × β ≃ Σ i, α i × β :=
   ⟨fun p => ⟨p.1.1, (p.1.2, p.2)⟩, fun p => (⟨p.1, p.2.1⟩, p.2.2), fun p => by
     rcases p with ⟨⟨_, _⟩, _⟩
     rfl, fun p => by
@@ -1002,7 +1002,7 @@ def subtypeEquiv {p : α → Prop} {q : β → Prop} (e : α ≃ β) (h : ∀ a,
   left_inv a := Subtype.ext <| by simp
   right_inv b := Subtype.ext <| by simp
 
-lemma coe_subtypeEquiv_eq_map {X Y : Type*} {p : X → Prop} {q : Y → Prop} (e : X ≃ Y)
+lemma coe_subtypeEquiv_eq_map {X Y} {p : X → Prop} {q : Y → Prop} (e : X ≃ Y)
     (h : ∀ x, p x ↔ q (e x)) : ⇑(e.subtypeEquiv h) = Subtype.map e (h · |>.mp) :=
   rfl
 

--- a/Mathlib/Logic/Equiv/Basic.lean
+++ b/Mathlib/Logic/Equiv/Basic.lean
@@ -51,7 +51,7 @@ universe u v
 open Function
 
 -- Unless required to be `Type*`, all variables in this file are `Sort*`
-variable {α α₁ α₂ β β₁ β₂ γ γ₁ γ₂ δ ι ι' ι'' : Sort*}
+variable {α α₁ α₂ β β₁ β₂ γ γ₁ γ₂ δ : Sort*}
 
 namespace Equiv
 
@@ -744,7 +744,7 @@ end prodCongr
 
 namespace Perm
 
-variable [DecidableEq α₁] (a : α₁) (e : Perm β₁)
+variable {α₁ β₁ : Type*} [DecidableEq α₁] (a : α₁) (e : Perm β₁)
 
 /-- `prodExtendRight a e` extends `e : Perm β` to `Perm (α × β)` by sending `(a, b)` to
 `(a, e b)` and keeping the other `(a', b)` fixed. -/
@@ -804,7 +804,8 @@ open Sum
 /-- The type of dependent functions on a sum type `ι ⊕ ι'` is equivalent to the type of pairs of
 functions on `ι` and on `ι'`. This is a dependent version of `Equiv.sumArrowEquivProdArrow`. -/
 @[simps]
-def sumPiEquivProdPi (π : ι ⊕ ι' → Type*) : (∀ i, π i) ≃ (∀ i, π (inl i)) × ∀ i', π (inr i') where
+def sumPiEquivProdPi {ι ι'} (π : ι ⊕ ι' → Type*) :
+    (∀ i, π i) ≃ (∀ i, π (inl i)) × ∀ i', π (inr i') where
   toFun f := ⟨fun i => f (inl i), fun i' => f (inr i')⟩
   invFun g := Sum.rec g.1 g.2
   left_inv f := by ext (i | i) <;> rfl
@@ -813,7 +814,7 @@ def sumPiEquivProdPi (π : ι ⊕ ι' → Type*) : (∀ i, π i) ≃ (∀ i, π 
 /-- The equivalence between a product of two dependent functions types and a single dependent
 function type. Basically a symmetric version of `Equiv.sumPiEquivProdPi`. -/
 @[simps!]
-def prodPiEquivSumPi (π : ι → Type u) (π' : ι' → Type u) :
+def prodPiEquivSumPi {ι ι'} (π : ι → Type u) (π' : ι' → Type u) :
     ((∀ i, π i) × ∀ i', π' i') ≃ ∀ i, Sum.elim π π' i :=
   sumPiEquivProdPi (Sum.elim π π') |>.symm
 
@@ -825,22 +826,22 @@ def sumArrowEquivProdArrow (α β γ : Type*) : (α ⊕ β → γ) ≃ (α → �
     rfl⟩
 
 @[simp]
-theorem sumArrowEquivProdArrow_apply_fst (f : α ⊕ β → γ) (a : α) :
+theorem sumArrowEquivProdArrow_apply_fst {α β γ} (f : α ⊕ β → γ) (a : α) :
     (sumArrowEquivProdArrow α β γ f).1 a = f (inl a) :=
   rfl
 
 @[simp]
-theorem sumArrowEquivProdArrow_apply_snd (f : α ⊕ β → γ) (b : β) :
+theorem sumArrowEquivProdArrow_apply_snd {α β γ} (f : α ⊕ β → γ) (b : β) :
     (sumArrowEquivProdArrow α β γ f).2 b = f (inr b) :=
   rfl
 
 @[simp]
-theorem sumArrowEquivProdArrow_symm_apply_inl (f : α → γ) (g : β → γ) (a : α) :
+theorem sumArrowEquivProdArrow_symm_apply_inl {α β γ} (f : α → γ) (g : β → γ) (a : α) :
     ((sumArrowEquivProdArrow α β γ).symm (f, g)) (inl a) = f a :=
   rfl
 
 @[simp]
-theorem sumArrowEquivProdArrow_symm_apply_inr (f : α → γ) (g : β → γ) (b : β) :
+theorem sumArrowEquivProdArrow_symm_apply_inr {α β γ} (f : α → γ) (g : β → γ) (b : β) :
     ((sumArrowEquivProdArrow α β γ).symm (f, g)) (inr b) = g b :=
   rfl
 
@@ -851,22 +852,22 @@ def sumProdDistrib (α β γ) : (α ⊕ β) × γ ≃ α × γ ⊕ β × γ :=
       rintro ⟨_ | _, _⟩ <;> rfl, by rintro (⟨_, _⟩ | ⟨_, _⟩) <;> rfl⟩
 
 @[simp]
-theorem sumProdDistrib_apply_left (a : α) (c : γ) :
+theorem sumProdDistrib_apply_left {α β γ} (a : α) (c : γ) :
     sumProdDistrib α β γ (Sum.inl a, c) = Sum.inl (a, c) :=
   rfl
 
 @[simp]
-theorem sumProdDistrib_apply_right (b : β) (c : γ) :
+theorem sumProdDistrib_apply_right {α β γ} (b : β) (c : γ) :
     sumProdDistrib α β γ (Sum.inr b, c) = Sum.inr (b, c) :=
   rfl
 
 @[simp]
-theorem sumProdDistrib_symm_apply_left (a : α × γ) :
+theorem sumProdDistrib_symm_apply_left {α β γ} (a : α × γ) :
     (sumProdDistrib α β γ).symm (inl a) = (inl a.1, a.2) :=
   rfl
 
 @[simp]
-theorem sumProdDistrib_symm_apply_right (b : β × γ) :
+theorem sumProdDistrib_symm_apply_right {α β γ} (b : β × γ) :
     (sumProdDistrib α β γ).symm (inr b) = (inr b.1, b.2) :=
   rfl
 
@@ -878,28 +879,28 @@ def prodSumDistrib (α β γ : Type*) : α × (β ⊕ γ) ≃ (α × β) ⊕ (α
     _ ≃ (α × β) ⊕ (α × γ) := sumCongr (prodComm _ _) (prodComm _ _)
 
 @[simp]
-theorem prodSumDistrib_apply_left (a : α) (b : β) :
+theorem prodSumDistrib_apply_left {α β γ} (a : α) (b : β) :
     prodSumDistrib α β γ (a, Sum.inl b) = Sum.inl (a, b) :=
   rfl
 
 @[simp]
-theorem prodSumDistrib_apply_right (a : α) (c : γ) :
+theorem prodSumDistrib_apply_right {α β γ} (a : α) (c : γ) :
     prodSumDistrib α β γ (a, Sum.inr c) = Sum.inr (a, c) :=
   rfl
 
 @[simp]
-theorem prodSumDistrib_symm_apply_left (a : α × β) :
+theorem prodSumDistrib_symm_apply_left {α β γ} (a : α × β) :
     (prodSumDistrib α β γ).symm (inl a) = (a.1, inl a.2) :=
   rfl
 
 @[simp]
-theorem prodSumDistrib_symm_apply_right (a : α × γ) :
+theorem prodSumDistrib_symm_apply_right {α β γ} (a : α × γ) :
     (prodSumDistrib α β γ).symm (inr a) = (a.1, inr a.2) :=
   rfl
 
 /-- An indexed sum of disjoint sums of types is equivalent to the sum of the indexed sums. -/
 @[simps]
-def sigmaSumDistrib (α β : ι → Type*) :
+def sigmaSumDistrib {ι} (α β : ι → Type*) :
     (Σ i, α i ⊕ β i) ≃ (Σ i, α i) ⊕ (Σ i, β i) :=
   ⟨fun p => p.2.map (Sigma.mk p.1) (Sigma.mk p.1),
     Sum.elim (Sigma.map id fun _ => Sum.inl) (Sigma.map id fun _ => Sum.inr), fun p => by
@@ -908,7 +909,7 @@ def sigmaSumDistrib (α β : ι → Type*) :
 /-- The product of an indexed sum of types (formally, a `Sigma`-type `Σ i, α i`) by a type `β` is
 equivalent to the sum of products `Σ i, (α i × β)`. -/
 @[simps apply symm_apply]
-def sigmaProdDistrib (α : ι → Type*) (β : Type*) : (Σ i, α i) × β ≃ Σ i, α i × β :=
+def sigmaProdDistrib {ι} (α : ι → Type*) (β : Type*) : (Σ i, α i) × β ≃ Σ i, α i × β :=
   ⟨fun p => ⟨p.1.1, (p.1.2, p.2)⟩, fun p => (⟨p.1, p.2.1⟩, p.2.2), fun p => by
     rcases p with ⟨⟨_, _⟩, _⟩
     rfl, fun p => by
@@ -967,7 +968,7 @@ def intEquivNatSumNat : ℤ ≃ ℕ ⊕ ℕ where
 end
 
 /-- An equivalence between `α` and `β` generates an equivalence between `List α` and `List β`. -/
-def listEquivOfEquiv (e : α ≃ β) : List α ≃ List β where
+def listEquivOfEquiv {α β} (e : α ≃ β) : List α ≃ List β where
   toFun := List.map e
   invFun := List.map e.symm
   left_inv l := by rw [List.map_map, e.symm_comp_self, List.map_id]
@@ -1631,13 +1632,13 @@ lemma piCongrLeft_apply_eq_cast {P : β → Sort v} {e : α ≃ β}
     piCongrLeft P e f b = cast (congr_arg P (e.apply_symm_apply b)) (f (e.symm b)) :=
   Eq.rec_eq_cast _ _
 
-theorem piCongrLeft_sum_inl (π : ι'' → Type*) (e : ι ⊕ ι' ≃ ι'') (f : ∀ i, π (e (inl i)))
+theorem piCongrLeft_sum_inl {ι ι' ι''} (π : ι'' → Type*) (e : ι ⊕ ι' ≃ ι'') (f : ∀ i, π (e (inl i)))
     (g : ∀ i, π (e (inr i))) (i : ι) :
     piCongrLeft π e (sumPiEquivProdPi (fun x => π (e x)) |>.symm (f, g)) (e (inl i)) = f i := by
   simp_rw [piCongrLeft_apply_eq_cast, sumPiEquivProdPi_symm_apply,
     sum_rec_congr _ _ _ (e.symm_apply_apply (inl i)), cast_cast, cast_eq]
 
-theorem piCongrLeft_sum_inr (π : ι'' → Type*) (e : ι ⊕ ι' ≃ ι'') (f : ∀ i, π (e (inl i)))
+theorem piCongrLeft_sum_inr {ι ι' ι''} (π : ι'' → Type*) (e : ι ⊕ ι' ≃ ι'') (f : ∀ i, π (e (inl i)))
     (g : ∀ i, π (e (inr i))) (j : ι') :
     piCongrLeft π e (sumPiEquivProdPi (fun x => π (e x)) |>.symm (f, g)) (e (inr j)) = g j := by
   simp_rw [piCongrLeft_apply_eq_cast, sumPiEquivProdPi_symm_apply,

--- a/Mathlib/Logic/Equiv/Basic.lean
+++ b/Mathlib/Logic/Equiv/Basic.lean
@@ -50,13 +50,13 @@ universe u v
 
 open Function
 
-variable {α α₁ α₂ β β₁ β₂ γ γ₁ γ₂ δ ε ι ι' ι'': Type*}
+variable {α α₁ α₂ β β₁ β₂ γ γ₁ γ₂ δ ε ι ι' ι'' : Sort*}
 
 namespace Equiv
 
 /-- `PProd α β` is equivalent to `α × β` -/
 @[simps apply symm_apply]
-def pprodEquivProd : PProd α β ≃ α × β where
+def pprodEquivProd {α β : Type*} : PProd α β ≃ α × β where
   toFun x := (x.1, x.2)
   invFun x := ⟨x.1, x.2⟩
   left_inv := fun _ => rfl
@@ -66,7 +66,7 @@ def pprodEquivProd : PProd α β ≃ α × β where
 `PProd α γ ≃ PProd β δ`. -/
 -- Porting note: in Lean 3 this had `@[congr]`
 @[simps apply]
-def pprodCongr {α β γ δ : Sort*} (e₁ : α ≃ β) (e₂ : γ ≃ δ) : PProd α γ ≃ PProd β δ where
+def pprodCongr (e₁ : α ≃ β) (e₂ : γ ≃ δ) : PProd α γ ≃ PProd β δ where
   toFun x := ⟨e₁ x.1, e₂ x.2⟩
   invFun x := ⟨e₁.symm x.1, e₂.symm x.2⟩
   left_inv := fun ⟨x, y⟩ => by simp
@@ -74,30 +74,30 @@ def pprodCongr {α β γ δ : Sort*} (e₁ : α ≃ β) (e₂ : γ ≃ δ) : PPr
 
 /-- Combine two equivalences using `PProd` in the domain and `Prod` in the codomain. -/
 @[simps! apply symm_apply]
-def pprodProd {α₁ β₁ : Sort*} (ea : α₁ ≃ α₂) (eb : β₁ ≃ β₂) :
+def pprodProd {α₂ β₂ : Type*} (ea : α₁ ≃ α₂) (eb : β₁ ≃ β₂) :
     PProd α₁ β₁ ≃ α₂ × β₂ :=
   (ea.pprodCongr eb).trans pprodEquivProd
 
 /-- Combine two equivalences using `PProd` in the codomain and `Prod` in the domain. -/
 @[simps! apply symm_apply]
-def prodPProd {α₂ β₂ : Sort*} (ea : α₁ ≃ α₂) (eb : β₁ ≃ β₂) :
+def prodPProd {α₁ β₁ : Type*} (ea : α₁ ≃ α₂) (eb : β₁ ≃ β₂) :
     α₁ × β₁ ≃ PProd α₂ β₂ :=
   (ea.symm.pprodProd eb.symm).symm
 
 /-- `PProd α β` is equivalent to `PLift α × PLift β` -/
 @[simps! apply symm_apply]
-def pprodEquivProdPLift {α β : Sort*} : PProd α β ≃ PLift α × PLift β :=
+def pprodEquivProdPLift : PProd α β ≃ PLift α × PLift β :=
   Equiv.plift.symm.pprodProd Equiv.plift.symm
 
 /-- Product of two equivalences. If `α₁ ≃ α₂` and `β₁ ≃ β₂`, then `α₁ × β₁ ≃ α₂ × β₂`. This is
 `Prod.map` as an equivalence. -/
 -- Porting note: in Lean 3 there was also a @[congr] tag
 @[simps (config := .asFn) apply]
-def prodCongr (e₁ : α₁ ≃ α₂) (e₂ : β₁ ≃ β₂) : α₁ × β₁ ≃ α₂ × β₂ :=
+def prodCongr {α₁ α₂ β₁ β₂ : Type*} (e₁ : α₁ ≃ α₂) (e₂ : β₁ ≃ β₂) : α₁ × β₁ ≃ α₂ × β₂ :=
   ⟨Prod.map e₁ e₂, Prod.map e₁.symm e₂.symm, fun ⟨a, b⟩ => by simp, fun ⟨a, b⟩ => by simp⟩
 
 @[simp]
-theorem prodCongr_symm (e₁ : α₁ ≃ α₂) (e₂ : β₁ ≃ β₂) :
+theorem prodCongr_symm {α₁ α₂ β₁ β₂ : Type*} (e₁ : α₁ ≃ α₂) (e₂ : β₁ ≃ β₂) :
     (prodCongr e₁ e₂).symm = prodCongr e₁.symm e₂.symm :=
   rfl
 
@@ -111,7 +111,7 @@ theorem coe_prodComm (α β) : (⇑(prodComm α β) : α × β → β × α) = P
   rfl
 
 @[simp]
-theorem prodComm_apply (x : α × β) : prodComm α β x = x.swap :=
+theorem prodComm_apply {α β : Type*} (x : α × β) : prodComm α β x = x.swap :=
   rfl
 
 @[simp]
@@ -169,14 +169,14 @@ def prodUnique (α β) [Unique β] : α × β ≃ α :=
   ((Equiv.refl α).prodCongr <| equivPUnit.{_,1} β).trans <| prodPUnit α
 
 @[simp]
-theorem coe_prodUnique [Unique β] : (⇑(prodUnique α β) : α × β → α) = Prod.fst :=
+theorem coe_prodUnique {α β : Type*} [Unique β] : (⇑(prodUnique α β) : α × β → α) = Prod.fst :=
   rfl
 
-theorem prodUnique_apply [Unique β] (x : α × β) : prodUnique α β x = x.1 :=
+theorem prodUnique_apply {α β : Type*} [Unique β] (x : α × β) : prodUnique α β x = x.1 :=
   rfl
 
 @[simp]
-theorem prodUnique_symm_apply [Unique β] (x : α) :
+theorem prodUnique_symm_apply {α β : Type*} [Unique β] (x : α) :
     (prodUnique α β).symm x = (x, default) :=
   rfl
 
@@ -185,14 +185,14 @@ def uniqueProd (α β) [Unique β] : β × α ≃ α :=
   ((equivPUnit.{_,1} β).prodCongr <| Equiv.refl α).trans <| punitProd α
 
 @[simp]
-theorem coe_uniqueProd [Unique β] : (⇑(uniqueProd α β) : β × α → α) = Prod.snd :=
+theorem coe_uniqueProd {α β : Type*} [Unique β] : (⇑(uniqueProd α β) : β × α → α) = Prod.snd :=
   rfl
 
-theorem uniqueProd_apply [Unique β] (x : β × α) : uniqueProd α β x = x.2 :=
+theorem uniqueProd_apply {α β : Type*} [Unique β] (x : β × α) : uniqueProd α β x = x.2 :=
   rfl
 
 @[simp]
-theorem uniqueProd_symm_apply [Unique β] (x : α) :
+theorem uniqueProd_symm_apply {α β : Type*} [Unique β] (x : α) :
     (uniqueProd α β).symm x = (default, x) :=
   rfl
 
@@ -202,16 +202,16 @@ def sigmaUnique (α) (β : α → Type*) [∀ a, Unique (β a)] : (a : α) × (�
   (Equiv.sigmaCongrRight fun a ↦ equivPUnit.{_,1} (β a)).trans <| sigmaPUnit α
 
 @[simp]
-theorem coe_sigmaUnique {β : α → Type*} [∀ a, Unique (β a)] :
+theorem coe_sigmaUnique {α : Type*} {β : α → Type*} [∀ a, Unique (β a)] :
     (⇑(sigmaUnique α β) : (a : α) × (β a) → α) = Sigma.fst :=
   rfl
 
-theorem sigmaUnique_apply {β : α → Type*} [∀ a, Unique (β a)] (x : (a : α) × β a) :
+theorem sigmaUnique_apply {α : Type*} {β : α → Type*} [∀ a, Unique (β a)] (x : (a : α) × β a) :
     sigmaUnique α β x = x.1 :=
   rfl
 
 @[simp]
-theorem sigmaUnique_symm_apply {β : α → Type*} [∀ a, Unique (β a)] (x : α) :
+theorem sigmaUnique_symm_apply {α : Type*} {β : α → Type*} [∀ a, Unique (β a)] (x : α) :
     (sigmaUnique α β).symm x = ⟨x, default⟩ :=
   rfl
 
@@ -250,19 +250,19 @@ def sumCongr (ea : α₁ ≃ α₂) (eb : β₁ ≃ β₂) : α₁ ⊕ β₁ ≃
   ⟨Sum.map ea eb, Sum.map ea.symm eb.symm, fun x => by simp, fun x => by simp⟩
 
 /-- If `α ≃ α'` and `β ≃ β'`, then `α ⊕' β ≃ α' ⊕' β'`. -/
-def psumCongr {α β γ δ : Sort*} (e₁ : α ≃ β) (e₂ : γ ≃ δ) : α ⊕' γ ≃ β ⊕' δ where
+def psumCongr (e₁ : α ≃ β) (e₂ : γ ≃ δ) : α ⊕' γ ≃ β ⊕' δ where
   toFun x := PSum.casesOn x (PSum.inl ∘ e₁) (PSum.inr ∘ e₂)
   invFun x := PSum.casesOn x (PSum.inl ∘ e₁.symm) (PSum.inr ∘ e₂.symm)
   left_inv := by rintro (x | x) <;> simp
   right_inv := by rintro (x | x) <;> simp
 
 /-- Combine two `Equiv`s using `PSum` in the domain and `Sum` in the codomain. -/
-def psumSum {α₁ β₁ : Sort*} (ea : α₁ ≃ α₂) (eb : β₁ ≃ β₂) :
+def psumSum (ea : α₁ ≃ α₂) (eb : β₁ ≃ β₂) :
     α₁ ⊕' β₁ ≃ α₂ ⊕ β₂ :=
   (ea.psumCongr eb).trans (psumEquivSum _ _)
 
 /-- Combine two `Equiv`s using `Sum` in the domain and `PSum` in the codomain. -/
-def sumPSum {α₂ β₂ : Sort*} (ea : α₁ ≃ α₂) (eb : β₁ ≃ β₂) :
+def sumPSum (ea : α₁ ≃ α₂) (eb : β₁ ≃ β₂) :
     α₁ ⊕ β₁ ≃ α₂ ⊕' β₂ :=
   (ea.symm.psumSum eb.symm).symm
 
@@ -605,8 +605,7 @@ section
 
 /-- A family of equivalences `∀ a, β₁ a ≃ β₂ a` generates an equivalence between `∀ a, β₁ a` and
 `∀ a, β₂ a`. -/
-def piCongrRight {α : Sort*} {β₁ β₂ : α → Sort*} (F : ∀ a, β₁ a ≃ β₂ a) :
-    (∀ a, β₁ a) ≃ (∀ a, β₂ a) :=
+def piCongrRight {β₁ β₂ : α → Sort*} (F : ∀ a, β₁ a ≃ β₂ a) : (∀ a, β₁ a) ≃ (∀ a, β₂ a) :=
   ⟨fun H a => F a (H a), fun H a => (F a).symm (H a), fun H => funext <| by simp,
     fun H => funext <| by simp⟩
 
@@ -979,10 +978,10 @@ def uniqueCongr (e : α ≃ β) : Unique α ≃ Unique β where
   right_inv _ := Subsingleton.elim _ _
 
 /-- If `α` is equivalent to `β`, then `IsEmpty α` is equivalent to `IsEmpty β`. -/
-theorem isEmpty_congr {α β : Sort*} (e : α ≃ β) : IsEmpty α ↔ IsEmpty β :=
+theorem isEmpty_congr (e : α ≃ β) : IsEmpty α ↔ IsEmpty β :=
   ⟨fun h => @Function.isEmpty _ _ h e.symm, fun h => @Function.isEmpty _ _ h e⟩
 
-protected theorem isEmpty {α β : Sort*} (e : α ≃ β) [IsEmpty β] : IsEmpty α :=
+protected theorem isEmpty (e : α ≃ β) [IsEmpty β] : IsEmpty α :=
   e.isEmpty_congr.mpr ‹_›
 
 section
@@ -1234,7 +1233,7 @@ end
 
 section subtypeEquivCodomain
 
-variable {X Y : Type*} [DecidableEq X] {x : X}
+variable [DecidableEq X] {x : X}
 
 /-- The type of all functions `X → Y` with prescribed values for all `x' ≠ x`
 is equivalent to the codomain `Y`. -/
@@ -1360,7 +1359,7 @@ theorem subtypeQuotientEquivQuotientSubtype_symm_mk (p₁ : α → Prop)
 
 section Swap
 
-variable {α β : Sort*} [DecidableEq α]
+variable [DecidableEq α]
 
 /-- A helper function for `Equiv.swap`. -/
 def swapCore (a b r : α) : α :=
@@ -1519,8 +1518,6 @@ end Equiv
 
 namespace Function.Involutive
 
-variable {α : Sort*}
-
 /-- Convert an involutive function `f` to a permutation with `toFun = invFun = f`. -/
 def toPerm (f : α → α) (h : Involutive f) : Equiv.Perm α :=
   ⟨f, f, h.leftInverse, h.rightInverse⟩
@@ -1541,10 +1538,10 @@ theorem symm_eq_self_of_involutive (f : Equiv.Perm α) (h : Involutive f) : f.sy
 
 end Function.Involutive
 
-theorem PLift.eq_up_iff_down_eq {α : Sort*} {x : PLift α} {y : α} : x = PLift.up y ↔ x.down = y :=
+theorem PLift.eq_up_iff_down_eq {x : PLift α} {y : α} : x = PLift.up y ↔ x.down = y :=
   Equiv.plift.eq_symm_apply
 
-theorem Function.Injective.map_swap {α β : Sort*} [DecidableEq α] [DecidableEq β] {f : α → β}
+theorem Function.Injective.map_swap [DecidableEq α] [DecidableEq β] {f : α → β}
     (hf : Function.Injective f) (x y z : α) :
     f (Equiv.swap x y z) = Equiv.swap (f x) (f y) (f z) := by
   conv_rhs => rw [Equiv.swap_apply_def]
@@ -1557,7 +1554,7 @@ namespace Equiv
 
 section
 
-variable {α β : Sort*} (P : α → Sort*) (e : α ≃ β)
+variable (P : α → Sort w) (e : α ≃ β)
 
 /-- Transport dependent functions through an equivalence of the base space.
 -/
@@ -1595,7 +1592,7 @@ end
 
 section
 
-variable {α β : Sort*} (P : β → Sort*) (e : α ≃ β)
+variable (P : β → Sort w) (e : α ≃ β)
 
 /-- Transporting dependent functions through an equivalence of the base,
 expressed as a "simplification".
@@ -1647,7 +1644,7 @@ end
 
 section
 
-variable {α β : Sort*} {W : α → Sort*} {Z : β → Sort*} (h₁ : α ≃ β) (h₂ : ∀ a : α, W a ≃ Z (h₁ a))
+variable {W : α → Sort w} {Z : β → Sort z} (h₁ : α ≃ β) (h₂ : ∀ a : α, W a ≃ Z (h₁ a))
 
 /-- Transport dependent functions through
 an equivalence of the base spaces and a family
@@ -1673,8 +1670,7 @@ end
 
 section
 
-variable {α β : Sort*} {W : α → Sort*} {Z : β → Sort*} (h₁ : α ≃ β)
-  (h₂ : ∀ b : β, W (h₁.symm b) ≃ Z b)
+variable {W : α → Sort w} {Z : β → Sort z} (h₁ : α ≃ β) (h₂ : ∀ b : β, W (h₁.symm b) ≃ Z b)
 
 /-- Transport dependent functions through
 an equivalence of the base spaces and a family
@@ -1722,7 +1718,9 @@ end BinaryOp
 
 section ULift
 
-@[simp] theorem ulift_symm_down (x : α) : (Equiv.ulift.symm x).down = x := rfl
+@[simp]
+theorem ulift_symm_down (x : α) : (Equiv.ulift.{u, v}.symm x).down = x :=
+  rfl
 
 end ULift
 
@@ -1753,8 +1751,8 @@ def subsingletonProdSelfEquiv [Subsingleton α] : α × α ≃ α where
 
 /-- To give an equivalence between two subsingleton types, it is sufficient to give any two
     functions between them. -/
-def equivOfSubsingletonOfSubsingleton {α β : Sort*} [Subsingleton α] [Subsingleton β]
-    (f : α → β) (g : β → α) : α ≃ β where
+def equivOfSubsingletonOfSubsingleton [Subsingleton α] [Subsingleton β] (f : α → β) (g : β → α) :
+    α ≃ β where
   toFun := f
   invFun := g
   left_inv _ := Subsingleton.elim _ _
@@ -1771,12 +1769,10 @@ def uniqueUniqueEquiv : Unique (Unique α) ≃ Unique α :=
     { default := h, uniq := fun _ => Subsingleton.elim _ _ }
 
 /-- If `Unique β`, then `Unique α` is equivalent to `α ≃ β`. -/
-def uniqueEquivEquivUnique (α β : Sort*) [Unique β] : Unique α ≃ (α ≃ β) :=
+def uniqueEquivEquivUnique (α : Sort u) (β : Sort v) [Unique β] : Unique α ≃ (α ≃ β) :=
   equivOfSubsingletonOfSubsingleton (fun _ => Equiv.equivOfUnique _ _) Equiv.unique
 
 namespace Function
-
-variable {α α' β : Sort*}
 
 theorem update_comp_equiv [DecidableEq α'] [DecidableEq α] (f : α → β)
     (g : α' ≃ α) (a : α) (v : β) :

--- a/Mathlib/Logic/Equiv/Basic.lean
+++ b/Mathlib/Logic/Equiv/Basic.lean
@@ -46,7 +46,7 @@ In this file we continue the work on equivalences begun in `Logic/Equiv/Defs.lea
 equivalence, congruence, bijective map
 -/
 
-universe u v
+universe u v w z
 
 open Function
 
@@ -1081,25 +1081,25 @@ def subtypeSubtypeEquivSubtypeInter {α : Type u} (p q : α → Prop) :
 /-- If the outer subtype has more restrictive predicate than the inner one,
 then we can drop the latter. -/
 @[simps!]
-def subtypeSubtypeEquivSubtype {p q : α → Prop} (h : ∀ {x}, q x → p x) :
+def subtypeSubtypeEquivSubtype {α} {p q : α → Prop} (h : ∀ {x}, q x → p x) :
     { x : Subtype p // q x.1 } ≃ Subtype q :=
   (subtypeSubtypeEquivSubtypeInter p _).trans <| subtypeEquivRight fun _ => and_iff_right_of_imp h
 
 /-- If a proposition holds for all elements, then the subtype is
 equivalent to the original type. -/
 @[simps apply symm_apply]
-def subtypeUnivEquiv {p : α → Prop} (h : ∀ x, p x) : Subtype p ≃ α :=
+def subtypeUnivEquiv {α} {p : α → Prop} (h : ∀ x, p x) : Subtype p ≃ α :=
   ⟨fun x => x, fun x => ⟨x, h x⟩, fun _ => Subtype.eq rfl, fun _ => rfl⟩
 
 /-- A subtype of a sigma-type is a sigma-type over a subtype. -/
-def subtypeSigmaEquiv (p : α → Type v) (q : α → Prop) : { y : Sigma p // q y.1 } ≃ Σ x :
+def subtypeSigmaEquiv {α} (p : α → Type v) (q : α → Prop) : { y : Sigma p // q y.1 } ≃ Σ x :
     Subtype q, p x.1 :=
   ⟨fun x => ⟨⟨x.1.1, x.2⟩, x.1.2⟩, fun x => ⟨⟨x.1.1, x.2⟩, x.1.2⟩, fun _ => rfl,
     fun _ => rfl⟩
 
 /-- A sigma type over a subtype is equivalent to the sigma set over the original type,
 if the fiber is empty outside of the subset -/
-def sigmaSubtypeEquivOfSubset (p : α → Type v) (q : α → Prop) (h : ∀ x, p x → q x) :
+def sigmaSubtypeEquivOfSubset {α} (p : α → Type v) (q : α → Prop) (h : ∀ x, p x → q x) :
     (Σ x : Subtype q, p x) ≃ Σ x : α, p x :=
   (subtypeSigmaEquiv p q).symm.trans <| subtypeUnivEquiv fun x => h x.1 x.2
 
@@ -1129,7 +1129,7 @@ def sigmaSubtypeFiberEquivSubtype {α β : Type*} (f : α → β) {p : α → Pr
 
 /-- A sigma type over an `Option` is equivalent to the sigma set over the original type,
 if the fiber is empty at none. -/
-def sigmaOptionEquivOfSome (p : Option α → Type v) (h : p none → False) :
+def sigmaOptionEquivOfSome {α} (p : Option α → Type v) (h : p none → False) :
     (Σ x : Option α, p x) ≃ Σ x : α, p (some x) :=
   haveI h' : ∀ x, p x → x.isSome := by
     intro x
@@ -1168,7 +1168,7 @@ def subtypePiEquivPi {β : α → Sort v} {p : ∀ a, β a → Prop} :
 
 /-- A subtype of a product defined by componentwise conditions
 is equivalent to a product of subtypes. -/
-def subtypeProdEquivProd {p : α → Prop} {q : β → Prop} :
+def subtypeProdEquivProd {α β} {p : α → Prop} {q : β → Prop} :
     { c : α × β // p c.1 ∧ q c.2 } ≃ { a // p a } × { b // q b } where
   toFun := fun x => ⟨⟨x.1.1, x.2.1⟩, ⟨x.1.2, x.2.2⟩⟩
   invFun := fun x => ⟨⟨x.1.1, x.2.1⟩, ⟨x.1.2, x.2.2⟩⟩
@@ -1177,14 +1177,15 @@ def subtypeProdEquivProd {p : α → Prop} {q : β → Prop} :
 
 /-- A subtype of a `Prod` that depends only on the first component is equivalent to the
 corresponding subtype of the first type times the second type. -/
-def prodSubtypeFstEquivSubtypeProd {p : α → Prop} : {s : α × β // p s.1} ≃ {a // p a} × β where
+def prodSubtypeFstEquivSubtypeProd {α β} {p : α → Prop} :
+    {s : α × β // p s.1} ≃ {a // p a} × β where
   toFun x := ⟨⟨x.1.1, x.2⟩, x.1.2⟩
   invFun x := ⟨⟨x.1.1, x.2⟩, x.1.2⟩
   left_inv _ := rfl
   right_inv _ := rfl
 
 /-- A subtype of a `Prod` is equivalent to a sigma type whose fibers are subtypes. -/
-def subtypeProdEquivSigmaSubtype (p : α → β → Prop) :
+def subtypeProdEquivSigmaSubtype {α β} (p : α → β → Prop) :
     { x : α × β // p x.1 x.2 } ≃ Σa, { b : β // p a b } where
   toFun x := ⟨x.1.1, x.1.2, x.property⟩
   invFun x := ⟨⟨x.1, x.2⟩, x.2.property⟩
@@ -1237,7 +1238,7 @@ end
 
 section subtypeEquivCodomain
 
-variable [DecidableEq X] {x : X}
+variable {X Y : Sort*} [DecidableEq X] {x : X}
 
 /-- The type of all functions `X → Y` with prescribed values for all `x' ≠ x`
 is equivalent to the codomain `Y`. -/
@@ -1723,7 +1724,7 @@ end BinaryOp
 section ULift
 
 @[simp]
-theorem ulift_symm_down (x : α) : (Equiv.ulift.{u, v}.symm x).down = x :=
+theorem ulift_symm_down {α} (x : α) : (Equiv.ulift.{u, v}.symm x).down = x :=
   rfl
 
 end ULift
@@ -1747,7 +1748,7 @@ theorem Function.Injective.swap_comp
   funext fun _ => hf.swap_apply _ _ _
 
 /-- If `α` is a subsingleton, then it is equivalent to `α × α`. -/
-def subsingletonProdSelfEquiv [Subsingleton α] : α × α ≃ α where
+def subsingletonProdSelfEquiv {α} [Subsingleton α] : α × α ≃ α where
   toFun p := p.1
   invFun a := (a, a)
   left_inv _ := Subsingleton.elim _ _
@@ -1777,6 +1778,8 @@ def uniqueEquivEquivUnique (α : Sort u) (β : Sort v) [Unique β] : Unique α �
   equivOfSubsingletonOfSubsingleton (fun _ => Equiv.equivOfUnique _ _) Equiv.unique
 
 namespace Function
+
+variable {α' : Sort*}
 
 theorem update_comp_equiv [DecidableEq α'] [DecidableEq α] (f : α → β)
     (g : α' ≃ α) (a : α) (v : β) :


### PR DESCRIPTION
Split from #16154.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
