### PR TITLE
[Merged by Bors] - feat: generalize universes in `preservesFiniteProductsOfPreservesBinaryAndTerminal`

### DIFF
--- a/Mathlib/CategoryTheory/Limits/Constructions/FiniteProductsOfBinaryProducts.lean
+++ b/Mathlib/CategoryTheory/Limits/Constructions/FiniteProductsOfBinaryProducts.lean
@@ -157,12 +157,12 @@ def preservesShapeFinOfPreservesBinaryAndTerminal (n : ℕ) :
     apply preservesLimitOfIsoDiagram F that
 
 /-- If `F` preserves the terminal object and binary products then it preserves finite products. -/
-def preservesFiniteProductsOfPreservesBinaryAndTerminal (J : Type) [Fintype J] :
+def preservesFiniteProductsOfPreservesBinaryAndTerminal (J : Type*) [Fintype J] :
     PreservesLimitsOfShape (Discrete J) F := by
   classical
     let e := Fintype.equivFin J
     haveI := preservesShapeFinOfPreservesBinaryAndTerminal F (Fintype.card J)
-    apply preservesLimitsOfShapeOfEquiv.{0, 0} (Discrete.equivalence e).symm
+    apply preservesLimitsOfShapeOfEquiv (Discrete.equivalence e).symm
 
 end Preserves
 

--- a/Mathlib/CategoryTheory/Limits/Constructions/FiniteProductsOfBinaryProducts.lean
+++ b/Mathlib/CategoryTheory/Limits/Constructions/FiniteProductsOfBinaryProducts.lean
@@ -288,12 +288,12 @@ def preservesShapeFinOfPreservesBinaryAndInitial (n : ℕ) :
     apply preservesColimitOfIsoDiagram F that
 
 /-- If `F` preserves the initial object and binary coproducts then it preserves finite products. -/
-def preservesFiniteCoproductsOfPreservesBinaryAndInitial (J : Type) [Fintype J] :
+def preservesFiniteCoproductsOfPreservesBinaryAndInitial (J : Type*) [Fintype J] :
     PreservesColimitsOfShape (Discrete J) F := by
   classical
     let e := Fintype.equivFin J
     haveI := preservesShapeFinOfPreservesBinaryAndInitial F (Fintype.card J)
-    apply preservesColimitsOfShapeOfEquiv.{0, 0} (Discrete.equivalence e).symm
+    apply preservesColimitsOfShapeOfEquiv (Discrete.equivalence e).symm
 
 end Preserves
 


### PR DESCRIPTION
---
I noticed some theorems that hold with more general universe parameters than given. Since this is just a generalization of a lemma, I assume there is no harm in doing this?


<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
