### PR TITLE
[Merged by Bors] - chore: turn `induction'` into `induction`

### DIFF
--- a/Mathlib/Algebra/FreeAlgebra.lean
+++ b/Mathlib/Algebra/FreeAlgebra.lean
@@ -294,7 +294,7 @@ variable {A : Type*} [Semiring A] [Algebra R A]
 private def liftAux (f : X → A) : FreeAlgebra R X →ₐ[R] A where
   toFun a :=
     Quot.liftOn a (liftFun _ _ f) fun a b h ↦ by
-      induction' h
+      induction h
       · exact (algebraMap R A).map_add _ _
       · exact (algebraMap R A).map_mul _ _
       · apply Algebra.commutes

--- a/Mathlib/Algebra/Group/Conj.lean
+++ b/Mathlib/Algebra/Group/Conj.lean
@@ -99,7 +99,7 @@ theorem conj_pow {i : ℕ} {a b : α} : (a * b * a⁻¹) ^ i = a * b ^ i * a⁻�
 
 @[simp]
 theorem conj_zpow {i : ℤ} {a b : α} : (a * b * a⁻¹) ^ i = a * b ^ i * a⁻¹ := by
-  induction' i
+  induction i
   · change (a * b * a⁻¹) ^ (_ : ℤ) = a * b ^ (_ : ℤ) * a⁻¹
     simp [zpow_natCast]
   · simp only [zpow_negSucc, conj_pow, mul_inv_rev, inv_inv]

--- a/Mathlib/Algebra/Lie/CartanSubalgebra.lean
+++ b/Mathlib/Algebra/Lie/CartanSubalgebra.lean
@@ -59,9 +59,9 @@ theorem normalizer_eq_self_of_isCartanSubalgebra (H : LieSubalgebra R L) [H.IsCa
 @[simp]
 theorem ucs_eq_self_of_isCartanSubalgebra (H : LieSubalgebra R L) [H.IsCartanSubalgebra] (k : ℕ) :
     H.toLieSubmodule.ucs k = H.toLieSubmodule := by
-  induction' k with k ih
-  · simp
-  · simp [ih]
+  induction k with
+  | zero => simp
+  | succ k ih => simp [ih]
 
 theorem isCartanSubalgebra_iff_isUcsLimit : H.IsCartanSubalgebra ↔ H.toLieSubmodule.IsUcsLimit := by
   constructor

--- a/Mathlib/Algebra/Lie/Nilpotent.lean
+++ b/Mathlib/Algebra/Lie/Nilpotent.lean
@@ -64,9 +64,9 @@ theorem lcs_succ : N.lcs (k + 1) = ⁅(⊤ : LieIdeal R L), N.lcs k⁆ :=
 @[simp]
 lemma lcs_sup {N₁ N₂ : LieSubmodule R L M} {k : ℕ} :
     (N₁ ⊔ N₂).lcs k = N₁.lcs k ⊔ N₂.lcs k := by
-  induction' k with k ih
-  · simp
-  · simp only [LieSubmodule.lcs_succ, ih, LieSubmodule.lie_sup]
+  induction k with
+  | zero => simp
+  | succ k ih => simp only [LieSubmodule.lcs_succ, ih, LieSubmodule.lie_sup]
 
 end LieSubmodule
 
@@ -94,17 +94,19 @@ namespace LieSubmodule
 open LieModule
 
 theorem lcs_le_self : N.lcs k ≤ N := by
-  induction' k with k ih
-  · simp
-  · simp only [lcs_succ]
+  induction k with
+  | zero => simp
+  | succ k ih =>
+    simp only [lcs_succ]
     exact (LieSubmodule.mono_lie_right ⊤ ih).trans (N.lie_le_right ⊤)
 
 variable [LieModule R L M]
 
 theorem lowerCentralSeries_eq_lcs_comap : lowerCentralSeries R L N k = (N.lcs k).comap N.incl := by
-  induction' k with k ih
-  · simp
-  · simp only [lcs_succ, lowerCentralSeries_succ] at ih ⊢
+  induction k with
+  | zero => simp
+  | succ k ih =>
+    simp only [lcs_succ, lowerCentralSeries_succ] at ih ⊢
     have : N.lcs k ≤ N.incl.range := by
       rw [N.range_incl]
       apply lcs_le_self
@@ -123,9 +125,11 @@ variable (R L M)
 
 theorem antitone_lowerCentralSeries : Antitone <| lowerCentralSeries R L M := by
   intro l k
-  induction' k with k ih generalizing l <;> intro h
-  · exact (Nat.le_zero.mp h).symm ▸ le_rfl
-  · rcases Nat.of_le_succ h with (hk | hk)
+  induction k generalizing l with
+  | zero => exact fun h ↦ (Nat.le_zero.mp h).symm ▸ le_rfl
+  | succ k ih =>
+    intro h
+    rcases Nat.of_le_succ h with (hk | hk)
     · rw [lowerCentralSeries_succ]
       exact (LieSubmodule.mono_lie_right ⊤ (ih hk)).trans (LieSubmodule.lie_le_right _ _)
     · exact hk.symm ▸ le_rfl
@@ -156,38 +160,43 @@ variable [LieModule R L M]
 
 theorem iterate_toEnd_mem_lowerCentralSeries (x : L) (m : M) (k : ℕ) :
     (toEnd R L M x)^[k] m ∈ lowerCentralSeries R L M k := by
-  induction' k with k ih
-  · simp only [Function.iterate_zero, lowerCentralSeries_zero, LieSubmodule.mem_top]
-  · simp only [lowerCentralSeries_succ, Function.comp_apply, Function.iterate_succ',
+  induction k with
+  | zero => simp only [Function.iterate_zero, lowerCentralSeries_zero, LieSubmodule.mem_top]
+  | succ k ih =>
+    simp only [lowerCentralSeries_succ, Function.comp_apply, Function.iterate_succ',
       toEnd_apply_apply]
     exact LieSubmodule.lie_mem_lie (LieSubmodule.mem_top x) ih
 
 theorem iterate_toEnd_mem_lowerCentralSeries₂ (x y : L) (m : M) (k : ℕ) :
     (toEnd R L M x ∘ₗ toEnd R L M y)^[k] m ∈
       lowerCentralSeries R L M (2 * k) := by
-  induction' k with k ih
-  · simp
-  have hk : 2 * k.succ = (2 * k + 1) + 1 := rfl
-  simp only [lowerCentralSeries_succ, Function.comp_apply, Function.iterate_succ', hk,
+  induction k with
+  | zero => simp
+  | succ k ih =>
+    have hk : 2 * k.succ = (2 * k + 1) + 1 := rfl
+    simp only [lowerCentralSeries_succ, Function.comp_apply, Function.iterate_succ', hk,
       toEnd_apply_apply, LinearMap.coe_comp, toEnd_apply_apply]
-  refine LieSubmodule.lie_mem_lie (LieSubmodule.mem_top x) ?_
-  exact LieSubmodule.lie_mem_lie (LieSubmodule.mem_top y) ih
+    refine LieSubmodule.lie_mem_lie (LieSubmodule.mem_top x) ?_
+    exact LieSubmodule.lie_mem_lie (LieSubmodule.mem_top y) ih
 
 variable {R L M}
 
 theorem map_lowerCentralSeries_le (f : M →ₗ⁅R,L⁆ M₂) :
     (lowerCentralSeries R L M k).map f ≤ lowerCentralSeries R L M₂ k := by
-  induction' k with k ih
-  · simp only [lowerCentralSeries_zero, le_top]
-  · simp only [LieModule.lowerCentralSeries_succ, LieSubmodule.map_bracket_eq]
+  induction k with
+  | zero => simp only [lowerCentralSeries_zero, le_top]
+  | succ k ih =>
+    simp only [LieModule.lowerCentralSeries_succ, LieSubmodule.map_bracket_eq]
     exact LieSubmodule.mono_lie_right ⊤ ih
 
 lemma map_lowerCentralSeries_eq {f : M →ₗ⁅R,L⁆ M₂} (hf : Function.Surjective f) :
     (lowerCentralSeries R L M k).map f = lowerCentralSeries R L M₂ k := by
   apply le_antisymm (map_lowerCentralSeries_le k f)
-  induction' k with k ih
-  · rwa [lowerCentralSeries_zero, lowerCentralSeries_zero, top_le_iff, f.map_top, f.range_eq_top]
-  · simp only [lowerCentralSeries_succ, LieSubmodule.map_bracket_eq]
+  induction k with
+  | zero =>
+    rwa [lowerCentralSeries_zero, lowerCentralSeries_zero, top_le_iff, f.map_top, f.range_eq_top]
+  | succ =>
+    simp only [lowerCentralSeries_succ, LieSubmodule.map_bracket_eq]
     apply LieSubmodule.mono_lie_right
     assumption
 
@@ -197,9 +206,10 @@ open LieAlgebra
 
 theorem derivedSeries_le_lowerCentralSeries (k : ℕ) :
     derivedSeries R L k ≤ lowerCentralSeries R L L k := by
-  induction' k with k h
-  · rw [derivedSeries_def, derivedSeriesOfIdeal_zero, lowerCentralSeries_zero]
-  · have h' : derivedSeries R L k ≤ ⊤ := by simp only [le_top]
+  induction k with
+  | zero => rw [derivedSeries_def, derivedSeriesOfIdeal_zero, lowerCentralSeries_zero]
+  | succ k h =>
+    have h' : derivedSeries R L k ≤ ⊤ := by simp only [le_top]
     rw [derivedSeries_def, derivedSeriesOfIdeal_succ, lowerCentralSeries_succ]
     exact LieSubmodule.mono_lie h' h
 
@@ -413,9 +423,10 @@ theorem nontrivial_max_triv_of_isNilpotent [Nontrivial M] [IsNilpotent R L M] :
 theorem coe_lcs_range_toEnd_eq (k : ℕ) :
     (lowerCentralSeries R (toEnd R L M).range M k : Submodule R M) =
       lowerCentralSeries R L M k := by
-  induction' k with k ih
-  · simp
-  · simp only [lowerCentralSeries_succ, LieSubmodule.lieIdeal_oper_eq_linear_span', ←
+  induction k with
+  | zero => simp
+  | succ k ih =>
+    simp only [lowerCentralSeries_succ, LieSubmodule.lieIdeal_oper_eq_linear_span', ←
       (lowerCentralSeries R (toEnd R L M).range M k).mem_coeSubmodule, ih]
     congr
     ext m
@@ -459,15 +470,16 @@ theorem ucs_add (k l : ℕ) : N.ucs (k + l) = (N.ucs l).ucs k :=
 
 @[gcongr, mono]
 theorem ucs_mono (k : ℕ) (h : N₁ ≤ N₂) : N₁.ucs k ≤ N₂.ucs k := by
-  induction' k with k ih
-  · simpa
-  simp only [ucs_succ]
-  gcongr
+  induction k with
+  | zero => simpa
+  | succ k ih =>
+    simp only [ucs_succ]
+    gcongr
 
 theorem ucs_eq_self_of_normalizer_eq_self (h : N₁.normalizer = N₁) (k : ℕ) : N₁.ucs k = N₁ := by
-  induction' k with k ih
-  · simp
-  · rwa [ucs_succ, ih]
+  induction k with
+  | zero => simp
+  | succ k ih => rwa [ucs_succ, ih]
 
 /-- If a Lie module `M` contains a self-normalizing Lie submodule `N`, then all terms of the upper
 central series of `M` are contained in `N`.
@@ -481,9 +493,10 @@ theorem ucs_le_of_normalizer_eq_self (h : N₁.normalizer = N₁) (k : ℕ) :
   simp
 
 theorem lcs_add_le_iff (l k : ℕ) : N₁.lcs (l + k) ≤ N₂ ↔ N₁.lcs l ≤ N₂.ucs k := by
-  induction' k with k ih generalizing l
-  · simp
-  rw [(by abel : l + (k + 1) = l + 1 + k), ih, ucs_succ, lcs_succ, top_lie_le_iff_le_normalizer]
+  induction k generalizing l with
+  | zero => simp
+  | succ k ih =>
+    rw [(by abel : l + (k + 1) = l + 1 + k), ih, ucs_succ, lcs_succ, top_lie_le_iff_le_normalizer]
 
 theorem lcs_le_iff (k : ℕ) : N₁.lcs k ≤ N₂ ↔ N₁ ≤ N₂.ucs k := by
   -- Porting note: `convert` needed type annotations
@@ -504,9 +517,9 @@ theorem _root_.LieModule.isNilpotent_iff_exists_ucs_eq_top :
 
 theorem ucs_comap_incl (k : ℕ) :
     ((⊥ : LieSubmodule R L M).ucs k).comap N.incl = (⊥ : LieSubmodule R L N).ucs k := by
-  induction' k with k ih
-  · exact N.ker_incl
-  · simp [← ih]
+  induction k with
+  | zero => exact N.ker_incl
+  | succ k ih => simp [← ih]
 
 theorem isNilpotent_iff_exists_self_le_ucs :
     LieModule.IsNilpotent R L N ↔ ∃ k, N ≤ (⊥ : LieSubmodule R L M).ucs k := by
@@ -530,9 +543,10 @@ variable (hf : Surjective f) (hg : Surjective g) (hfg : ∀ x m, ⁅f x, g m⁆ 
 include hf hg hfg in
 theorem Function.Surjective.lieModule_lcs_map_eq (k : ℕ) :
     (lowerCentralSeries R L M k : Submodule R M).map g = lowerCentralSeries R L₂ M₂ k := by
-  induction' k with k ih
-  · simpa [LinearMap.range_eq_top]
-  · suffices
+  induction k with
+  | zero => simpa [LinearMap.range_eq_top]
+  | succ k ih =>
+    suffices
       g '' {m | ∃ (x : L) (n : _), n ∈ lowerCentralSeries R L M k ∧ ⁅x, n⁆ = m} =
         {m | ∃ (x : L₂) (n : _), n ∈ lowerCentralSeries R L M k ∧ ⁅x, g n⁆ = m} by
       simp only [← LieSubmodule.mem_coeSubmodule] at this
@@ -620,10 +634,12 @@ morphisms between Lie modules over different Lie algebras. -/
 theorem coe_lowerCentralSeries_ideal_quot_eq {I : LieIdeal R L} (k : ℕ) :
     LieSubmodule.toSubmodule (lowerCentralSeries R L (L ⧸ I) k) =
       LieSubmodule.toSubmodule (lowerCentralSeries R (L ⧸ I) (L ⧸ I) k) := by
-  induction' k with k ih
-  · simp only [LieModule.lowerCentralSeries_zero, LieSubmodule.top_coeSubmodule,
+  induction k with
+  | zero =>
+    simp only [LieModule.lowerCentralSeries_zero, LieSubmodule.top_coeSubmodule,
       LieIdeal.top_coe_lieSubalgebra, LieSubalgebra.top_coe_submodule]
-  · simp only [LieModule.lowerCentralSeries_succ, LieSubmodule.lieIdeal_oper_eq_linear_span]
+  | succ k ih =>
+    simp only [LieModule.lowerCentralSeries_succ, LieSubmodule.lieIdeal_oper_eq_linear_span]
     congr
     ext x
     constructor
@@ -639,9 +655,10 @@ theorem coe_lowerCentralSeries_ideal_quot_eq {I : LieIdeal R L} (k : ℕ) :
 -- Porting note: added `LieSubmodule.toSubmodule` in the statement
 theorem LieModule.coe_lowerCentralSeries_ideal_le {I : LieIdeal R L} (k : ℕ) :
     LieSubmodule.toSubmodule (lowerCentralSeries R I I k) ≤ lowerCentralSeries R L I k := by
-  induction' k with k ih
-  · simp
-  · simp only [LieModule.lowerCentralSeries_succ, LieSubmodule.lieIdeal_oper_eq_linear_span]
+  induction k with
+  | zero => simp
+  | succ k ih =>
+    simp only [LieModule.lowerCentralSeries_succ, LieSubmodule.lieIdeal_oper_eq_linear_span]
     apply Submodule.span_mono
     rintro x ⟨⟨y, -⟩, ⟨z, hz⟩, rfl : ⁅y, z⁆ = x⟩
     exact ⟨⟨y.val, LieSubmodule.mem_top _⟩, ⟨z, ih hz⟩, rfl⟩
@@ -661,9 +678,10 @@ theorem LieAlgebra.non_trivial_center_of_isNilpotent [Nontrivial L] [IsNilpotent
 
 theorem LieIdeal.map_lowerCentralSeries_le (k : ℕ) {f : L →ₗ⁅R⁆ L'} :
     LieIdeal.map f (lowerCentralSeries R L L k) ≤ lowerCentralSeries R L' L' k := by
-  induction' k with k ih
-  · simp only [LieModule.lowerCentralSeries_zero, le_top]
-  · simp only [LieModule.lowerCentralSeries_succ]
+  induction k with
+  | zero => simp only [LieModule.lowerCentralSeries_zero, le_top]
+  | succ k ih =>
+    simp only [LieModule.lowerCentralSeries_succ]
     exact le_trans (LieIdeal.map_bracket_le f) (LieSubmodule.mono_lie le_top ih)
 
 theorem LieIdeal.lowerCentralSeries_map_eq (k : ℕ) {f : L →ₗ⁅R⁆ L'} (h : Function.Surjective f) :
@@ -671,9 +689,9 @@ theorem LieIdeal.lowerCentralSeries_map_eq (k : ℕ) {f : L →ₗ⁅R⁆ L'} (h
   have h' : (⊤ : LieIdeal R L).map f = ⊤ := by
     rw [← f.idealRange_eq_map]
     exact f.idealRange_eq_top_of_surjective h
-  induction' k with k ih
-  · simp only [LieModule.lowerCentralSeries_zero]; exact h'
-  · simp only [LieModule.lowerCentralSeries_succ, LieIdeal.map_bracket_eq f h, ih, h']
+  induction k with
+  | zero => simp only [LieModule.lowerCentralSeries_zero]; exact h'
+  | succ k ih => simp only [LieModule.lowerCentralSeries_succ, LieIdeal.map_bracket_eq f h, ih, h']
 
 theorem Function.Injective.lieAlgebra_isNilpotent [h₁ : IsNilpotent R L'] {f : L →ₗ⁅R⁆ L'}
     (h₂ : Function.Injective f) : IsNilpotent R L :=
@@ -750,9 +768,10 @@ theorem lcs_top : (⊤ : LieIdeal R L).lcs M k = lowerCentralSeries R L M k :=
 -- Porting note: added `LieSubmodule.toSubmodule` in the statement
 theorem coe_lcs_eq [LieModule R L M] :
     LieSubmodule.toSubmodule (I.lcs M k) = lowerCentralSeries R I M k := by
-  induction' k with k ih
-  · simp
-  · simp_rw [lowerCentralSeries_succ, lcs_succ, LieSubmodule.lieIdeal_oper_eq_linear_span', ←
+  induction k with
+  | zero => simp
+  | succ k ih =>
+    simp_rw [lowerCentralSeries_succ, lcs_succ, LieSubmodule.lieIdeal_oper_eq_linear_span', ←
       (I.lcs M k).mem_coeSubmodule, ih, LieSubmodule.mem_coeSubmodule, LieSubmodule.mem_top,
       true_and, (I : LieSubalgebra R L).coe_bracket_of_module]
     congr
@@ -804,9 +823,9 @@ variable (R A L M : Type*) [CommRing R] [LieRing L] [LieAlgebra R L]
 lemma LieSubmodule.lowerCentralSeries_tensor_eq_baseChange (k : ℕ) :
     lowerCentralSeries A (A ⊗[R] L) (A ⊗[R] M) k =
     (lowerCentralSeries R L M k).baseChange A := by
-  induction' k with k ih
-  · simp
-  simp only [lowerCentralSeries_succ, ih, ← baseChange_top, lie_baseChange]
+  induction k with
+  | zero => simp
+  | succ k ih => simp only [lowerCentralSeries_succ, ih, ← baseChange_top, lie_baseChange]
 
 instance LieModule.instIsNilpotentTensor [IsNilpotent R L M] :
     IsNilpotent A (A ⊗[R] L) (A ⊗[R] M) := by

--- a/Mathlib/Algebra/Lie/Solvable.lean
+++ b/Mathlib/Algebra/Lie/Solvable.lean
@@ -131,11 +131,11 @@ variable {R L}
 
 theorem derivedSeries_eq_derivedSeriesOfIdeal_comap (k : ℕ) :
     derivedSeries R I k = (derivedSeriesOfIdeal R L k I).comap I.incl := by
-  induction' k with k ih
-  · simp only [derivedSeries_def, comap_incl_self, derivedSeriesOfIdeal_zero]
-  · simp only [derivedSeries_def, derivedSeriesOfIdeal_succ] at ih ⊢; rw [ih]
-    exact comap_bracket_incl_of_le I
-      (derivedSeriesOfIdeal_le_self I k) (derivedSeriesOfIdeal_le_self I k)
+  induction k with
+  | zero => simp only [derivedSeries_def, comap_incl_self, derivedSeriesOfIdeal_zero]
+  | succ k ih => simp only [derivedSeries_def, derivedSeriesOfIdeal_succ] at ih ⊢; rw [ih]
+    exact comap_bracket_incl_of_le I (derivedSeriesOfIdeal_le_self I k)
+      (derivedSeriesOfIdeal_le_self I k)
 
 theorem derivedSeries_eq_derivedSeriesOfIdeal_map (k : ℕ) :
     (derivedSeries R I k).map I.incl = derivedSeriesOfIdeal R L k I := by
@@ -156,18 +156,19 @@ theorem derivedSeries_add_eq_bot {k l : ℕ} {I J : LieIdeal R L} (hI : derivedS
     _ ≤ ⊥ := by rw [hI, hJ]; simp
 
 theorem derivedSeries_map_le (k : ℕ) : (derivedSeries R L' k).map f ≤ derivedSeries R L k := by
-  induction' k with k ih
-  · simp only [derivedSeries_def, derivedSeriesOfIdeal_zero, le_top]
-  · simp only [derivedSeries_def, derivedSeriesOfIdeal_succ] at ih ⊢
+  induction k with
+  | zero => simp only [derivedSeries_def, derivedSeriesOfIdeal_zero, le_top]
+  | succ k ih => simp only [derivedSeries_def, derivedSeriesOfIdeal_succ] at ih ⊢
     exact le_trans (map_bracket_le f) (LieSubmodule.mono_lie ih ih)
 
 theorem derivedSeries_map_eq (k : ℕ) (h : Function.Surjective f) :
     (derivedSeries R L' k).map f = derivedSeries R L k := by
-  induction' k with k ih
-  · change (⊤ : LieIdeal R L').map f = ⊤
+  induction k with
+  | zero =>
+    change (⊤ : LieIdeal R L').map f = ⊤
     rw [← f.idealRange_eq_map]
     exact f.idealRange_eq_top_of_surjective h
-  · simp only [derivedSeries_def, map_bracket_eq f h, ih, derivedSeriesOfIdeal_succ]
+  | succ k ih => simp only [derivedSeries_def, map_bracket_eq f h, ih, derivedSeriesOfIdeal_succ]
 
 theorem derivedSeries_succ_eq_top_iff (n : ℕ) :
     derivedSeries R L (n + 1) = ⊤ ↔ derivedSeries R L 1 = ⊤ := by

--- a/Mathlib/Algebra/Lie/Solvable.lean
+++ b/Mathlib/Algebra/Lie/Solvable.lean
@@ -133,7 +133,8 @@ theorem derivedSeries_eq_derivedSeriesOfIdeal_comap (k : ℕ) :
     derivedSeries R I k = (derivedSeriesOfIdeal R L k I).comap I.incl := by
   induction k with
   | zero => simp only [derivedSeries_def, comap_incl_self, derivedSeriesOfIdeal_zero]
-  | succ k ih => simp only [derivedSeries_def, derivedSeriesOfIdeal_succ] at ih ⊢; rw [ih]
+  | succ k ih =>
+    simp only [derivedSeries_def, derivedSeriesOfIdeal_succ] at ih ⊢; rw [ih]
     exact comap_bracket_incl_of_le I (derivedSeriesOfIdeal_le_self I k)
       (derivedSeriesOfIdeal_le_self I k)
 
@@ -158,7 +159,8 @@ theorem derivedSeries_add_eq_bot {k l : ℕ} {I J : LieIdeal R L} (hI : derivedS
 theorem derivedSeries_map_le (k : ℕ) : (derivedSeries R L' k).map f ≤ derivedSeries R L k := by
   induction k with
   | zero => simp only [derivedSeries_def, derivedSeriesOfIdeal_zero, le_top]
-  | succ k ih => simp only [derivedSeries_def, derivedSeriesOfIdeal_succ] at ih ⊢
+  | succ k ih =>
+    simp only [derivedSeries_def, derivedSeriesOfIdeal_succ] at ih ⊢
     exact le_trans (map_bracket_le f) (LieSubmodule.mono_lie ih ih)
 
 theorem derivedSeries_map_eq (k : ℕ) (h : Function.Surjective f) :

--- a/Mathlib/Algebra/Module/LinearMap/End.lean
+++ b/Mathlib/Algebra/Module/LinearMap/End.lean
@@ -138,9 +138,9 @@ theorem commute_pow_left_of_commute
     [Semiring R₂] [AddCommMonoid M₂] [Module R₂ M₂] {σ₁₂ : R →+* R₂}
     {f : M →ₛₗ[σ₁₂] M₂} {g : Module.End R M} {g₂ : Module.End R₂ M₂}
     (h : g₂.comp f = f.comp g) (k : ℕ) : (g₂ ^ k).comp f = f.comp (g ^ k) := by
-  induction' k with k ih
-  · simp only [pow_zero, one_eq_id, id_comp, comp_id]
-  · rw [pow_succ', pow_succ', LinearMap.mul_eq_comp, LinearMap.comp_assoc, ih,
+  induction k with
+  | zero => simp only [pow_zero, one_eq_id, id_comp, comp_id]
+  | succ k ih => rw [pow_succ', pow_succ', LinearMap.mul_eq_comp, LinearMap.comp_assoc, ih,
     ← LinearMap.comp_assoc, h, LinearMap.comp_assoc, LinearMap.mul_eq_comp]
 
 @[simp]

--- a/Mathlib/Algebra/Module/Submodule/Map.lean
+++ b/Mathlib/Algebra/Module/Submodule/Map.lean
@@ -191,9 +191,9 @@ theorem comap_mono {f : F} {q q' : Submodule R₂ M₂} : q ≤ q' → comap f q
 
 theorem le_comap_pow_of_le_comap (p : Submodule R M) {f : M →ₗ[R] M} (h : p ≤ p.comap f) (k : ℕ) :
     p ≤ p.comap (f ^ k) := by
-  induction' k with k ih
-  · simp [LinearMap.one_eq_id]
-  · simp [LinearMap.iterate_succ, comap_comp, h.trans (comap_mono ih)]
+  induction k with
+  | zero => simp [LinearMap.one_eq_id]
+  | succ k ih => simp [LinearMap.iterate_succ, comap_comp, h.trans (comap_mono ih)]
 
 section
 

--- a/Mathlib/Algebra/Order/Ring/Basic.lean
+++ b/Mathlib/Algebra/Order/Ring/Basic.lean
@@ -43,9 +43,10 @@ theorem zero_pow_le_one : ∀ n : ℕ, (0 : R) ^ n ≤ 1
 
 theorem pow_add_pow_le (hx : 0 ≤ x) (hy : 0 ≤ y) (hn : n ≠ 0) : x ^ n + y ^ n ≤ (x + y) ^ n := by
   rcases Nat.exists_eq_add_one_of_ne_zero hn with ⟨k, rfl⟩
-  induction' k with k ih
-  · simp only [zero_add, pow_one, le_refl]
-  · let n := k.succ
+  induction k with
+  | zero => simp only [zero_add, pow_one, le_refl]
+  | succ k ih =>
+    let n := k.succ
     have h1 := add_nonneg (mul_nonneg hx (pow_nonneg hy n)) (mul_nonneg hy (pow_nonneg hx n))
     have h2 := add_nonneg hx hy
     calc

--- a/Mathlib/Algebra/Polynomial/Basic.lean
+++ b/Mathlib/Algebra/Polynomial/Basic.lean
@@ -398,9 +398,9 @@ theorem monomial_mul_monomial (n m : ℕ) (r s : R) :
 
 @[simp]
 theorem monomial_pow (n : ℕ) (r : R) (k : ℕ) : monomial n r ^ k = monomial (n * k) (r ^ k) := by
-  induction' k with k ih
-  · simp [pow_zero, monomial_zero_one]
-  · simp [pow_succ, ih, monomial_mul_monomial, mul_add, add_comm]
+  induction k with
+  | zero => simp [pow_zero, monomial_zero_one]
+  | succ k ih => simp [pow_succ, ih, monomial_mul_monomial, mul_add, add_comm]
 
 theorem smul_monomial {S} [SMulZeroClass S R] (a : S) (n : ℕ) (b : R) :
     a • monomial n b = monomial n (a • b) :=
@@ -535,9 +535,9 @@ theorem monomial_mul_X (n : ℕ) (r : R) : monomial n r * X = monomial (n + 1) r
 @[simp]
 theorem monomial_mul_X_pow (n : ℕ) (r : R) (k : ℕ) :
     monomial n r * X ^ k = monomial (n + k) r := by
-  induction' k with k ih
-  · simp
-  · simp [ih, pow_succ, ← mul_assoc, add_assoc]
+  induction k with
+  | zero => simp
+  | succ k ih => simp [ih, pow_succ, ← mul_assoc, add_assoc]
 
 @[simp]
 theorem X_mul_monomial (n : ℕ) (r : R) : X * monomial n r = monomial (n + 1) r := by

--- a/Mathlib/Algebra/Polynomial/Degree/Lemmas.lean
+++ b/Mathlib/Algebra/Polynomial/Degree/Lemmas.lean
@@ -352,9 +352,9 @@ theorem natDegree_comp : natDegree (p.comp q) = natDegree p * natDegree q := by
 @[simp]
 theorem natDegree_iterate_comp (k : ℕ) :
     (p.comp^[k] q).natDegree = p.natDegree ^ k * q.natDegree := by
-  induction' k with k IH
-  · simp
-  · rw [Function.iterate_succ_apply', natDegree_comp, IH, pow_succ', mul_assoc]
+  induction k with
+  | zero => simp
+  | succ k IH => rw [Function.iterate_succ_apply', natDegree_comp, IH, pow_succ', mul_assoc]
 
 theorem leadingCoeff_comp (hq : natDegree q ≠ 0) :
     leadingCoeff (p.comp q) = leadingCoeff p * leadingCoeff q ^ natDegree p := by

--- a/Mathlib/Algebra/Polynomial/Derivative.lean
+++ b/Mathlib/Algebra/Polynomial/Derivative.lean
@@ -421,7 +421,8 @@ theorem dvd_iterate_derivative_pow (f : R[X]) (n : ℕ) {m : ℕ} (c : R) (hm : 
 theorem iterate_derivative_X_pow_eq_natCast_mul (n k : ℕ) :
     derivative^[k] (X ^ n : R[X]) = ↑(Nat.descFactorial n k : R[X]) * X ^ (n - k) := by
   induction k with
-  | zero => erw [Function.iterate_zero_apply, tsub_zero, Nat.descFactorial_zero, Nat.cast_one, one_mul]
+  | zero =>
+    erw [Function.iterate_zero_apply, tsub_zero, Nat.descFactorial_zero, Nat.cast_one, one_mul]
   | succ k ih =>
     rw [Function.iterate_succ_apply', ih, derivative_natCast_mul, derivative_X_pow, C_eq_natCast,
       Nat.descFactorial_succ, Nat.sub_sub, Nat.cast_mul]

--- a/Mathlib/Algebra/Polynomial/Derivative.lean
+++ b/Mathlib/Algebra/Polynomial/Derivative.lean
@@ -134,9 +134,9 @@ theorem derivative_smul {S : Type*} [Monoid S] [DistribMulAction S R] [IsScalarT
 @[simp]
 theorem iterate_derivative_smul {S : Type*} [Monoid S] [DistribMulAction S R] [IsScalarTower S R R]
     (s : S) (p : R[X]) (k : ℕ) : derivative^[k] (s • p) = s • derivative^[k] p := by
-  induction' k with k ih generalizing p
-  · simp
-  · simp [ih]
+  induction k generalizing p with
+  | zero => simp
+  | succ k ih => simp [ih]
 
 @[simp]
 theorem iterate_derivative_C_mul (a : R) (p : R[X]) (k : ℕ) :
@@ -420,9 +420,10 @@ theorem dvd_iterate_derivative_pow (f : R[X]) (n : ℕ) {m : ℕ} (c : R) (hm : 
 
 theorem iterate_derivative_X_pow_eq_natCast_mul (n k : ℕ) :
     derivative^[k] (X ^ n : R[X]) = ↑(Nat.descFactorial n k : R[X]) * X ^ (n - k) := by
-  induction' k with k ih
-  · erw [Function.iterate_zero_apply, tsub_zero, Nat.descFactorial_zero, Nat.cast_one, one_mul]
-  · rw [Function.iterate_succ_apply', ih, derivative_natCast_mul, derivative_X_pow, C_eq_natCast,
+  induction k with
+  | zero => erw [Function.iterate_zero_apply, tsub_zero, Nat.descFactorial_zero, Nat.cast_one, one_mul]
+  | succ k ih =>
+    rw [Function.iterate_succ_apply', ih, derivative_natCast_mul, derivative_X_pow, C_eq_natCast,
       Nat.descFactorial_succ, Nat.sub_sub, Nat.cast_mul]
     simp [mul_comm, mul_assoc, mul_left_comm]
 

--- a/Mathlib/Algebra/Polynomial/Eval.lean
+++ b/Mathlib/Algebra/Polynomial/Eval.lean
@@ -400,9 +400,9 @@ theorem eval_mul_X : (p * X).eval x = p.eval x * x := by
 
 @[simp]
 theorem eval_mul_X_pow {k : ℕ} : (p * X ^ k).eval x = p.eval x * x ^ k := by
-  induction' k with k ih
-  · simp
-  · simp [pow_succ, ← mul_assoc, ih]
+  induction k with
+  | zero => simp
+  | succ k ih => simp [pow_succ, ← mul_assoc, ih]
 
 theorem eval_sum (p : R[X]) (f : ℕ → R → R[X]) (x : R) :
     (p.sum f).eval x = p.sum fun n a => (f n a).eval x :=
@@ -511,15 +511,15 @@ theorem mul_X_comp : (p * X).comp r = p.comp r * r := by
 
 @[simp]
 theorem X_pow_comp {k : ℕ} : (X ^ k).comp p = p ^ k := by
-  induction' k with k ih
-  · simp
-  · simp [pow_succ, mul_X_comp, ih]
+  induction k with
+  | zero => simp
+  | succ k ih => simp [pow_succ, mul_X_comp, ih]
 
 @[simp]
 theorem mul_X_pow_comp {k : ℕ} : (p * X ^ k).comp r = p.comp r * r ^ k := by
-  induction' k with k ih
-  · simp
-  · simp [ih, pow_succ, ← mul_assoc, mul_X_comp]
+  induction k with
+  | zero => simp
+  | succ k ih => simp [ih, pow_succ, ← mul_assoc, mul_X_comp]
 
 @[simp]
 theorem C_mul_comp : (C a * p).comp r = C a * p.comp r := by

--- a/Mathlib/Algebra/Polynomial/Eval.lean
+++ b/Mathlib/Algebra/Polynomial/Eval.lean
@@ -898,9 +898,9 @@ theorem eval₂_comp {x : S} : eval₂ f x (p.comp q) = eval₂ f (eval₂ f x q
 @[simp]
 theorem iterate_comp_eval₂ (k : ℕ) (t : S) :
     eval₂ f t (p.comp^[k] q) = (fun x => eval₂ f x p)^[k] (eval₂ f t q) := by
-  induction' k with k IH
-  · simp
-  · rw [Function.iterate_succ_apply', Function.iterate_succ_apply', eval₂_comp, IH]
+  induction k with
+  | zero => simp
+  | succ k IH => rw [Function.iterate_succ_apply', Function.iterate_succ_apply', eval₂_comp, IH]
 
 end
 

--- a/Mathlib/Algebra/Quandle.lean
+++ b/Mathlib/Algebra/Quandle.lean
@@ -372,7 +372,7 @@ theorem fix_inv {x : Q} : x ◃⁻¹ x = x := by
 instance oppositeQuandle : Quandle Qᵐᵒᵖ where
   fix := by
     intro x
-    induction' x
+    induction x
     simp
 
 /-- The conjugation quandle of a group.  Each element of the group acts by


### PR DESCRIPTION
This PR turns `induction'` (soon to be deprecated) into `induction`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
