### PR TITLE
[Merged by Bors] - feat: the translation operator

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -293,6 +293,7 @@ import Mathlib.Algebra.Group.Subsemigroup.Basic
 import Mathlib.Algebra.Group.Subsemigroup.Membership
 import Mathlib.Algebra.Group.Subsemigroup.Operations
 import Mathlib.Algebra.Group.Support
+import Mathlib.Algebra.Group.Translate
 import Mathlib.Algebra.Group.TypeTags
 import Mathlib.Algebra.Group.ULift
 import Mathlib.Algebra.Group.UniqueProds.Basic

--- a/Mathlib/Algebra/Group/Translate.lean
+++ b/Mathlib/Algebra/Group/Translate.lean
@@ -13,9 +13,17 @@ import Mathlib.GroupTheory.GroupAction.DomAct.Basic
 
 This file defines the translation of a function from a group by an element of that group.
 
-# Notation
+## Notation
 
 `τ a f` is notation for `translate a f`.
+
+## See also
+
+Generally, translation is the same as acting on the domain by subtraction. This setting is
+abstracted by `DomAddAct` in such a way that `τ a f = DomAddAct.mk (-a) +ᵥ f` (see
+`translate_eq_domAddActMk_vadd`). Using `DomAddAct` is irritating in applications because of this
+negation appearing inside `DomAddAct.mk`. Although mathematically equivalent, the pen and paper
+convention is that translating is an action by subtraction, not by addition.
 -/
 
 open Function Set

--- a/Mathlib/Algebra/Group/Translate.lean
+++ b/Mathlib/Algebra/Group/Translate.lean
@@ -1,5 +1,5 @@
 /-
-Copyright (c) 2024 Yaël Dillies. All rights reserved.
+Copyright (c) 2023 Yaël Dillies. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Yaël Dillies
 -/

--- a/Mathlib/Algebra/Group/Translate.lean
+++ b/Mathlib/Algebra/Group/Translate.lean
@@ -1,0 +1,79 @@
+/-
+Copyright (c) 2024 Yaël Dillies. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Yaël Dillies
+-/
+import Mathlib.Algebra.BigOperators.Pi
+import Mathlib.Data.Set.Pointwise.SMul
+
+/-!
+# Translation operator
+
+This file defines the translation of a function from a group by an element of that group.
+
+# Notation
+
+`τ a f` is notation for `translate a f`.
+-/
+
+open Function Set
+open scoped Pointwise
+
+variable {ι α β M G H : Type*} [AddCommGroup G]
+
+/-- Translation of a function in a group by an element of that group.
+`τ a f` is defined as `x ↦ f (x - a)`.  -/
+def translate (a : G) (f : G → α) : G → α := fun x ↦ f (x - a)
+
+@[inherit_doc] scoped[translate] notation "τ " => translate
+
+open scoped translate
+
+@[simp] lemma translate_apply (a : G) (f : G → α) (x : G) : τ a f x = f (x - a) := rfl
+@[simp] lemma translate_zero (f : G → α) : τ 0 f = f := by ext; simp
+
+lemma translate_translate (a b : G) (f : G → α) : τ a (τ b f) = τ (a + b) f := by
+  ext; simp [sub_sub]
+
+lemma translate_add (a b : G) (f : G → α) : τ (a + b) f = τ a (τ b f) := by ext; simp [sub_sub]
+
+lemma translate_add' (a b : G) (f : G → α) : τ (a + b) f = τ b (τ a f) := by
+  rw [add_comm, translate_add]
+
+lemma translate_comm (a b : G) (f : G → α) : τ a (τ b f) = τ b (τ a f) := by
+  rw [← translate_add, translate_add']
+
+-- We make `simp` push the `τ` outside
+@[simp] lemma comp_translate (a : G) (f : G → α) (g : α → β) : g ∘ τ a f = τ a (g ∘ f) := rfl
+
+@[simp]
+lemma translate_smul_right [SMul H α] (a : G) (f : G → α) (c : H) : τ a (c • f) = c • τ a f := rfl
+
+@[simp] lemma translate_zero_right [Zero α] (a : G) : τ a (0 : G → α) = 0 := rfl
+lemma translate_add_right [Add α] (a : G) (f g : G → α) : τ a (f + g) = τ a f + τ a g := rfl
+lemma translate_sub_right [Sub α] (a : G) (f g : G → α) : τ a (f - g) = τ a f - τ a g := rfl
+lemma translate_neg_right [Neg α] (a : G) (f : G → α) : τ a (-f) = -τ a f := rfl
+
+section AddCommMonoid
+variable [AddCommMonoid M]
+
+lemma translate_sum_right (a : G) (f : ι → G → M) (s : Finset ι) :
+    τ a (∑ i in s, f i) = ∑ i in s, τ a (f i) := by ext; simp
+
+lemma sum_translate [Fintype G] (a : G) (f : G → M) : ∑ b, τ a f b = ∑ b, f b :=
+  Fintype.sum_equiv (Equiv.subRight _) _ _ fun _ ↦ rfl
+
+end AddCommMonoid
+
+section AddCommGroup
+variable [AddCommGroup H]
+
+@[simp] lemma support_translate (a : G) (f : G → H) : support (τ a f) = a +ᵥ support f := by
+  ext; simp [mem_vadd_set_iff_neg_vadd_mem, sub_eq_neg_add]
+
+end AddCommGroup
+
+variable [CommMonoid M]
+
+lemma translate_prod_right (a : G) (f : ι → G → M) (s : Finset ι) :
+    τ a (∏ i in s, f i) = ∏ i in s, τ a (f i) := by ext; simp

--- a/Mathlib/Algebra/Group/Translate.lean
+++ b/Mathlib/Algebra/Group/Translate.lean
@@ -4,7 +4,9 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Yaël Dillies
 -/
 import Mathlib.Algebra.BigOperators.Pi
+import Mathlib.Algebra.Group.Pi.Basic
 import Mathlib.Data.Set.Pointwise.SMul
+import Mathlib.GroupTheory.GroupAction.DomAct.Basic
 
 /-!
 # Translation operator
@@ -37,6 +39,7 @@ lemma translate_translate (a b : G) (f : G → α) : τ a (τ b f) = τ (a + b) 
 
 lemma translate_add (a b : G) (f : G → α) : τ (a + b) f = τ a (τ b f) := by ext; simp [sub_sub]
 
+/-- See `translate_add`-/
 lemma translate_add' (a b : G) (f : G → α) : τ (a + b) f = τ b (τ a f) := by
   rw [add_comm, translate_add]
 
@@ -45,6 +48,9 @@ lemma translate_comm (a b : G) (f : G → α) : τ a (τ b f) = τ b (τ a f) :=
 
 -- We make `simp` push the `τ` outside
 @[simp] lemma comp_translate (a : G) (f : G → α) (g : α → β) : g ∘ τ a f = τ a (g ∘ f) := rfl
+
+lemma translate_eq_domAddActMk_vadd (a : G) (f : G → α) : τ a f = DomAddAct.mk (-a) +ᵥ f := by
+  ext; simp [DomAddAct.vadd_apply, sub_eq_neg_add]
 
 @[simp]
 lemma translate_smul_right [SMul H α] (a : G) (f : G → α) (c : H) : τ a (c • f) = c • τ a f := rfl


### PR DESCRIPTION
Define translation of a function by an element of its domain

From LeanAPAP

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->
I don't really like this code, but it is foundational for discrete analysis and I have found no nice way around using it. I would like to know @urkud's opinion as I am aware he needs translation for dynamical systems. Here are a few points of concern I am aware of:
* There is no multiplicative version. That's because I do not need the multiplicative version and wouldn't know how to call it
* This is basically an action by `DomMulAct`. The trouble is that it would be inconvenient to state it this way because I would also need to stick some `op` in there. And generally this action is wide-spread in LeanAPAP and I want custom notation for it.

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
