### PR TITLE
chore(SetTheory/Ordinal/Basic): ditch `Ordinal.inductionOn`

### DIFF
--- a/Mathlib/SetTheory/Cardinal/Cofinality.lean
+++ b/Mathlib/SetTheory/Cardinal/Cofinality.lean
@@ -236,8 +236,8 @@ theorem cof_eq_sInf_lsub (o : Ordinal.{u}) : cof o =
 
 @[simp]
 theorem lift_cof (o) : Cardinal.lift.{u, v} (cof o) = cof (Ordinal.lift.{u, v} o) := by
-  refine inductionOn o ?_
-  intro α r _
+  refine Quotient.inductionOn o ?_
+  rintro ⟨α, r, _⟩
   apply le_antisymm
   · refine le_cof_type.2 fun S H => ?_
     have : Cardinal.lift.{u, v} #(ULift.up ⁻¹' S) ≤ #(S : Type (max u v)) := by
@@ -427,7 +427,7 @@ theorem cof_zero : cof 0 = 0 := by
 
 @[simp]
 theorem cof_eq_zero {o} : cof o = 0 ↔ o = 0 :=
-  ⟨inductionOn o fun α r _ z =>
+  ⟨Quotient.inductionOn o fun ⟨α, r, _⟩ z =>
       let ⟨S, hl, e⟩ := cof_eq r
       type_eq_zero_iff_isEmpty.2 <|
         ⟨fun a =>
@@ -441,7 +441,7 @@ theorem cof_ne_zero {o} : cof o ≠ 0 ↔ o ≠ 0 :=
 @[simp]
 theorem cof_succ (o) : cof (succ o) = 1 := by
   apply le_antisymm
-  · refine inductionOn o fun α r _ => ?_
+  · refine Quotient.inductionOn o fun ⟨α, r, _⟩ => ?_
     change cof (type _) ≤ _
     rw [← (_ : #_ = 1)]
     · apply cof_type_le
@@ -455,8 +455,8 @@ theorem cof_succ (o) : cof (succ o) = 1 := by
 
 @[simp]
 theorem cof_eq_one_iff_is_succ {o} : cof.{u} o = 1 ↔ ∃ a, o = succ a :=
-  ⟨inductionOn o fun α r _ z => by
-      rcases cof_eq r with ⟨S, hl, e⟩; rw [z] at e
+  ⟨Quotient.inductionOn o fun ⟨α, r, _⟩ z => by
+      rcases cof_eq r with ⟨S, hl, e⟩; rw [← type_def, z] at e
       cases' mk_ne_zero_iff.1 (by rw [e]; exact one_ne_zero) with a
       refine
         ⟨typein r a,

--- a/Mathlib/SetTheory/Cardinal/Ordinal.lean
+++ b/Mathlib/SetTheory/Cardinal/Ordinal.lean
@@ -117,7 +117,8 @@ def alephIdx.relIso : @RelIso Cardinal.{u} Ordinal.{u} (· < ·) (· < ·) :=
   @RelIso.ofSurjective Cardinal.{u} Ordinal.{u} (· < ·) (· < ·) alephIdx.initialSeg.{u} <|
     (InitialSeg.eq_or_principal alephIdx.initialSeg.{u}).resolve_right fun ⟨o, e⟩ => by
       have : ∀ c, alephIdx c < o := fun c => (e _).2 ⟨_, rfl⟩
-      refine Ordinal.inductionOn o ?_ this; intro α r _ h
+      refine Quotient.inductionOn o ?_ this
+      rintro ⟨α, r, _⟩ h
       let s := ⨆ a, invFun alephIdx (Ordinal.typein r a)
       apply (lt_succ s).not_le
       have I : Injective.{u+2, u+2} alephIdx := alephIdx.initialSeg.toEmbedding.injective

--- a/Mathlib/SetTheory/Ordinal/Arithmetic.lean
+++ b/Mathlib/SetTheory/Ordinal/Arithmetic.lean
@@ -68,7 +68,7 @@ variable {α : Type*} {β : Type*} {γ : Type*} {r : α → α → Prop} {s : β
 
 @[simp]
 theorem lift_add (a b : Ordinal.{v}) : lift.{u} (a + b) = lift.{u} a + lift.{u} b :=
-  Quotient.inductionOn₂ a b fun ⟨_α, _r, _⟩ ⟨_β, _s, _⟩ =>
+  Quotient.inductionOn₂ a b fun _ _ =>
     Quotient.sound
       ⟨(RelIso.preimage Equiv.ulift _).trans
           (RelIso.sumLexCongr (RelIso.preimage Equiv.ulift _) (RelIso.preimage Equiv.ulift _)).symm⟩
@@ -79,36 +79,33 @@ theorem lift_succ (a : Ordinal.{v}) : lift.{u} (succ a) = succ (lift.{u} a) := b
   rfl
 
 instance add_contravariantClass_le : ContravariantClass Ordinal.{u} Ordinal.{u} (· + ·) (· ≤ ·) :=
-  ⟨fun a b c =>
-    inductionOn a fun α r hr =>
-      inductionOn b fun β₁ s₁ hs₁ =>
-        inductionOn c fun β₂ s₂ hs₂ ⟨f⟩ =>
-          ⟨have fl : ∀ a, f (Sum.inl a) = Sum.inl a := fun a => by
-              simpa only [InitialSeg.trans_apply, InitialSeg.leAdd_apply] using
-                @InitialSeg.eq _ _ _ _ _
-                  ((InitialSeg.leAdd r s₁).trans f) (InitialSeg.leAdd r s₂) a
-            have : ∀ b, { b' // f (Sum.inr b) = Sum.inr b' } := by
-              intro b; cases e : f (Sum.inr b)
-              · rw [← fl] at e
-                have := f.inj' e
-                contradiction
-              · exact ⟨_, rfl⟩
-            let g (b) := (this b).1
-            have fr : ∀ b, f (Sum.inr b) = Sum.inr (g b) := fun b => (this b).2
-            ⟨⟨⟨g, fun x y h => by
-                  injection f.inj' (by rw [fr, fr, h] : f (Sum.inr x) = f (Sum.inr y))⟩,
-                @fun a b => by
-                  -- Porting note:
-                  --  `relEmbedding.coe_fn_to_embedding` & `initial_seg.coe_fn_to_rel_embedding`
-                  --  → `InitialSeg.coe_coe_fn`
-                  simpa only [Sum.lex_inr_inr, fr, InitialSeg.coe_coe_fn, Embedding.coeFn_mk] using
-                    @RelEmbedding.map_rel_iff _ _ _ _ f.toRelEmbedding (Sum.inr a) (Sum.inr b)⟩,
-              fun a b H => by
-                rcases f.init (by rw [fr] <;> exact Sum.lex_inr_inr.2 H) with ⟨a' | a', h⟩
-                · rw [fl] at h
-                  cases h
-                · rw [fr] at h
-                  exact ⟨a', Sum.inr.inj h⟩⟩⟩⟩
+  ⟨fun a b c => Quotient.inductionOn₃ a b c fun ⟨α, r, hr⟩ ⟨β₁, s₁, hs₁⟩ ⟨β₂, s₂, hs₂⟩ ⟨f⟩ =>
+    ⟨have fl : ∀ a, f (Sum.inl a) = Sum.inl a := fun a => by
+        simpa only [InitialSeg.trans_apply, InitialSeg.leAdd_apply] using
+          @InitialSeg.eq _ _ _ _ _
+            ((InitialSeg.leAdd r s₁).trans f) (InitialSeg.leAdd r s₂) a
+      have : ∀ b, { b' // f (Sum.inr b) = Sum.inr b' } := by
+        intro b; cases e : f (Sum.inr b)
+        · rw [← fl] at e
+          have := f.inj' e
+          contradiction
+        · exact ⟨_, rfl⟩
+      let g (b) := (this b).1
+      have fr : ∀ b, f (Sum.inr b) = Sum.inr (g b) := fun b => (this b).2
+      ⟨⟨⟨g, fun x y h => by
+            injection f.inj' (by rw [fr, fr, h] : f (Sum.inr x) = f (Sum.inr y))⟩,
+          @fun a b => by
+            -- Porting note:
+            --  `relEmbedding.coe_fn_to_embedding` & `initial_seg.coe_fn_to_rel_embedding`
+            --  → `InitialSeg.coe_coe_fn`
+            simpa only [Sum.lex_inr_inr, fr, InitialSeg.coe_coe_fn, Embedding.coeFn_mk] using
+              @RelEmbedding.map_rel_iff _ _ _ _ f.toRelEmbedding (Sum.inr a) (Sum.inr b)⟩,
+        fun a b H => by
+          rcases f.init (by rw [fr] <;> exact Sum.lex_inr_inr.2 H) with ⟨a' | a', h⟩
+          · rw [fl] at h
+            cases h
+          · rw [fr] at h
+            exact ⟨a', Sum.inr.inj h⟩⟩⟩⟩
 
 theorem add_left_cancel (a) {b c : Ordinal} : a + b = a + c ↔ b = c := by
   simp only [le_antisymm_iff, add_le_add_iff_left]
@@ -135,10 +132,10 @@ theorem add_right_cancel {a b : Ordinal} (n : ℕ) : a + n = b + n ↔ a = b := 
   simp only [le_antisymm_iff, add_le_add_iff_right]
 
 theorem add_eq_zero_iff {a b : Ordinal} : a + b = 0 ↔ a = 0 ∧ b = 0 :=
-  inductionOn a fun α r _ =>
-    inductionOn b fun β s _ => by
-      simp_rw [← type_sum_lex, type_eq_zero_iff_isEmpty]
-      exact isEmpty_sum
+  Quotient.inductionOn₂ a b fun _ _ => by
+    rw [type_def, type_def, ← type_sum_lex]
+    iterate 3 rw [type_eq_zero_iff_isEmpty]
+    exact isEmpty_sum
 
 theorem left_eq_zero_of_add_eq_zero {a b : Ordinal} (h : a + b = 0) : a = 0 :=
   (add_eq_zero_iff.1 h).1
@@ -416,29 +413,26 @@ theorem IsNormal.le_iff_eq {f} (H : IsNormal f) {a} : f a ≤ a ↔ f a = a :=
 theorem add_le_of_limit {a b c : Ordinal} (h : IsLimit b) : a + b ≤ c ↔ ∀ b' < b, a + b' ≤ c :=
   ⟨fun h b' l => (add_le_add_left l.le _).trans h, fun H =>
     le_of_not_lt <| by
-      -- Porting note: `induction` tactics are required because of the parser bug.
-      induction a using inductionOn with
-      | H α r =>
-        induction b using inductionOn with
-        | H β s =>
-          intro l
-          suffices ∀ x : β, Sum.Lex r s (Sum.inr x) (enum _ ⟨_, l⟩) by
-            -- Porting note: `revert` & `intro` is required because `cases'` doesn't replace
-            --               `enum _ _ l` in `this`.
-            revert this; cases' enum _ ⟨_, l⟩ with x x <;> intro this
-            · cases this (enum s ⟨0, h.pos⟩)
-            · exact irrefl _ (this _)
-          intro x
-          rw [← typein_lt_typein (Sum.Lex r s), typein_enum]
-          have := H _ (h.2 _ (typein_lt_type s x))
-          rw [add_succ, succ_le_iff] at this
-          refine
-            (RelEmbedding.ofMonotone (fun a => ?_) fun a b => ?_).ordinal_type_le.trans_lt this
-          · rcases a with ⟨a | b, h⟩
-            · exact Sum.inl a
-            · exact Sum.inr ⟨b, by cases h; assumption⟩
-          · rcases a with ⟨a | a, h₁⟩ <;> rcases b with ⟨b | b, h₂⟩ <;> cases h₁ <;> cases h₂ <;>
-              rintro ⟨⟩ <;> constructor <;> assumption⟩
+      revert h H
+      refine Quotient.inductionOn₂ a b ?_
+      rintro ⟨α, r, _⟩ ⟨β, s, _⟩ h H l
+      suffices ∀ x : β, Sum.Lex r s (Sum.inr x) (enum _ ⟨_, l⟩) by
+        -- Porting note: `revert` & `intro` is required because `cases'` doesn't replace
+        --               `enum _ _ l` in `this`.
+        revert this; cases' enum _ ⟨_, l⟩ with x x <;> intro this
+        · cases this (enum s ⟨0, h.pos⟩)
+        · exact irrefl _ (this _)
+      intro x
+      rw [← typein_lt_typein (Sum.Lex r s), typein_enum]
+      have := H _ (h.2 _ (typein_lt_type s x))
+      rw [add_succ, succ_le_iff] at this
+      refine
+        (RelEmbedding.ofMonotone (fun a => ?_) fun a b => ?_).ordinal_type_le.trans_lt this
+      · rcases a with ⟨a | b, h⟩
+        · exact Sum.inl a
+        · exact Sum.inr ⟨b, by cases h; assumption⟩
+      · rcases a with ⟨a | a, h₁⟩ <;> rcases b with ⟨b | b, h₂⟩ <;> cases h₁ <;> cases h₂ <;>
+          rintro ⟨⟩ <;> constructor <;> assumption⟩
 
 theorem add_isNormal (a : Ordinal) : IsNormal (a + ·) :=
   ⟨fun b => (add_lt_add_iff_left a).2 (lt_succ b), fun _b l _c => add_le_of_limit l⟩
@@ -557,7 +551,7 @@ instance monoid : Monoid Ordinal.{u} where
               rcases b with ⟨⟨b₁, b₂⟩, b₃⟩
               simp [Prod.lex_def, and_or_left, or_assoc, and_assoc]⟩⟩
   mul_one a :=
-    inductionOn a fun α r _ =>
+    Quotient.inductionOn a fun _ =>
       Quotient.sound
         ⟨⟨punitProd _, @fun a b => by
             rcases a with ⟨⟨⟨⟩⟩, a⟩; rcases b with ⟨⟨⟨⟩⟩, b⟩
@@ -565,7 +559,7 @@ instance monoid : Monoid Ordinal.{u} where
             simp only [eq_self_iff_true, true_and_iff]
             rfl⟩⟩
   one_mul a :=
-    inductionOn a fun α r _ =>
+    Quotient.inductionOn a fun _ =>
       Quotient.sound
         ⟨⟨prodPUnit _, @fun a b => by
             rcases a with ⟨a, ⟨⟨⟩⟩⟩; rcases b with ⟨b, ⟨⟨⟩⟩⟩
@@ -578,11 +572,10 @@ theorem type_prod_lex {α β : Type u} (r : α → α → Prop) (s : β → β �
   rfl
 
 private theorem mul_eq_zero' {a b : Ordinal} : a * b = 0 ↔ a = 0 ∨ b = 0 :=
-  inductionOn a fun α _ _ =>
-    inductionOn b fun β _ _ => by
-      simp_rw [← type_prod_lex, type_eq_zero_iff_isEmpty]
-      rw [or_comm]
-      exact isEmpty_prod
+  Quotient.inductionOn₂ a b fun ⟨α, r, _⟩ ⟨β, s, _⟩ => by
+    simp_rw [type_def, ← type_prod_lex, type_eq_zero_iff_isEmpty]
+    rw [or_comm]
+    exact isEmpty_prod
 
 instance monoidWithZero : MonoidWithZero Ordinal :=
   { Ordinal.monoid with
@@ -595,7 +588,7 @@ instance noZeroDivisors : NoZeroDivisors Ordinal :=
 
 @[simp]
 theorem lift_mul (a b : Ordinal.{v}) : lift.{u} (a * b) = lift.{u} a * lift.{u} b :=
-  Quotient.inductionOn₂ a b fun ⟨_α, _r, _⟩ ⟨_β, _s, _⟩ =>
+  Quotient.inductionOn₂ a b fun _ _ =>
     Quotient.sound
       ⟨(RelIso.preimage Equiv.ulift _).trans
           (RelIso.prodLexCongr (RelIso.preimage Equiv.ulift _)
@@ -607,7 +600,7 @@ theorem card_mul (a b) : card (a * b) = card a * card b :=
 
 instance leftDistribClass : LeftDistribClass Ordinal.{u} :=
   ⟨fun a b c =>
-    Quotient.inductionOn₃ a b c fun ⟨α, r, _⟩ ⟨β, s, _⟩ ⟨γ, t, _⟩ =>
+    Quotient.inductionOn₃ a b c fun _ _ _ =>
       Quotient.sound
         ⟨⟨sumProdDistrib _ _ _, by
           rintro ⟨a₁ | a₁, a₂⟩ ⟨b₁ | b₁, b₂⟩ <;>
@@ -622,7 +615,7 @@ theorem mul_succ (a b : Ordinal) : a * succ b = a * b + a :=
 
 instance mul_covariantClass_le : CovariantClass Ordinal.{u} Ordinal.{u} (· * ·) (· ≤ ·) :=
   ⟨fun c a b =>
-    Quotient.inductionOn₃ a b c fun ⟨α, r, _⟩ ⟨β, s, _⟩ ⟨γ, t, _⟩ ⟨f⟩ => by
+    Quotient.inductionOn₃ a b c fun ⟨α, r, _⟩ _ ⟨γ, t, _⟩ ⟨f⟩ => by
       refine
         (RelEmbedding.ofMonotone (fun a : α × γ => (f a.1, a.2)) fun a b h => ?_).ordinal_type_le
       cases' h with a₁ b₁ a₂ b₂ h' a b₁ b₂ h'
@@ -632,7 +625,7 @@ instance mul_covariantClass_le : CovariantClass Ordinal.{u} Ordinal.{u} (· * ·
 instance mul_swap_covariantClass_le :
     CovariantClass Ordinal.{u} Ordinal.{u} (swap (· * ·)) (· ≤ ·) :=
   ⟨fun c a b =>
-    Quotient.inductionOn₃ a b c fun ⟨α, r, _⟩ ⟨β, s, _⟩ ⟨γ, t, _⟩ ⟨f⟩ => by
+    Quotient.inductionOn₃ a b c fun ⟨α, r, _⟩ _ ⟨γ, t, _⟩ ⟨f⟩ => by
       refine
         (RelEmbedding.ofMonotone (fun a : γ × α => (a.1, f a.2)) fun a b h => ?_).ordinal_type_le
       cases' h with a₁ b₁ a₂ b₂ h' a b₁ b₂ h'
@@ -689,11 +682,10 @@ theorem mul_le_of_limit {a b c : Ordinal} (h : IsLimit b) : a * b ≤ c ↔ ∀ 
   ⟨fun h b' l => (mul_le_mul_left' l.le _).trans h, fun H =>
     -- Porting note: `induction` tactics are required because of the parser bug.
     le_of_not_lt <| by
-      induction a using inductionOn with
-      | H α r =>
-        induction b using inductionOn with
-        | H β s =>
-          exact mul_le_of_limit_aux h H⟩
+      revert h H
+      refine Quotient.inductionOn₂ a b ?_
+      intro _ _ h H
+      exact mul_le_of_limit_aux h H⟩
 
 theorem mul_isNormal {a : Ordinal} (h : 0 < a) : IsNormal (a * ·) :=
   -- Porting note(#12129): additional beta reduction needed
@@ -1286,12 +1278,13 @@ theorem lt_bsup {o : Ordinal.{u}} (f : ∀ a < o, Ordinal.{max u v}) {a} :
     a < bsup.{_, v} o f ↔ ∃ i hi, a < f i hi := by
   simpa only [not_forall, not_le] using not_congr (@bsup_le_iff.{_, v} _ f a)
 
-theorem IsNormal.bsup {f : Ordinal.{max u v} → Ordinal.{max u w}} (H : IsNormal f)
-    {o : Ordinal.{u}} :
-    ∀ (g : ∀ a < o, Ordinal), o ≠ 0 → f (bsup.{_, v} o g) = bsup.{_, w} o fun a h => f (g a h) :=
-  inductionOn o fun α r _ g h => by
-    haveI := type_ne_zero_iff_nonempty.1 h
-    rw [← sup_eq_bsup' r, IsNormal.sup.{_, v, w} H, ← sup_eq_bsup' r] <;> rfl
+theorem IsNormal.bsup {f : Ordinal.{max u v} → Ordinal.{max u w}}
+    {o : Ordinal.{u}} : IsNormal f →
+    ∀ (g : ∀ a < o, Ordinal), o ≠ 0 → f (bsup.{_, v} o g) = bsup.{_, w} o fun a h => f (g a h) := by
+  refine Quotient.inductionOn o ?_
+  rintro ⟨_, r, _⟩ H g h
+  have := type_ne_zero_iff_nonempty.1 h
+  rw [← sup_eq_bsup' r, IsNormal.sup.{_, v, w} H, ← sup_eq_bsup' r] <;> rfl
 
 theorem lt_bsup_of_ne_bsup {o : Ordinal.{u}} {f : ∀ a < o, Ordinal.{max u v}} :
     (∀ i h, f i h ≠ bsup.{_, v} o f) ↔ ∀ i h, f i h < bsup.{_, v} o f :=

--- a/Mathlib/SetTheory/Ordinal/Basic.lean
+++ b/Mathlib/SetTheory/Ordinal/Basic.lean
@@ -267,11 +267,6 @@ theorem type_preimage_aux {α β : Type u} (r : α → α → Prop) [IsWellOrder
     @type _ (fun x y => r (f x) (f y)) (inferInstanceAs (IsWellOrder β (↑f ⁻¹'o r))) = type r := by
   convert (RelIso.preimage f r).ordinal_type_eq
 
-@[elab_as_elim]
-theorem inductionOn {C : Ordinal → Prop} (o : Ordinal)
-    (H : ∀ (α r) [IsWellOrder α r], C (type r)) : C o :=
-  Quot.inductionOn o fun ⟨α, r, wo⟩ => @H α r wo
-
 /-! ### The order on ordinals -/
 
 /--
@@ -334,7 +329,7 @@ theorem _root_.PrincipalSeg.ordinal_type_lt {α β} {r : α → α → Prop} {s 
 
 @[simp]
 protected theorem zero_le (o : Ordinal) : 0 ≤ o :=
-  inductionOn o fun _ r _ => (InitialSeg.ofIsEmpty _ r).ordinal_type_le
+  Quotient.inductionOn o fun ⟨_, r, _⟩ => (InitialSeg.ofIsEmpty _ r).ordinal_type_le
 
 instance orderBot : OrderBot Ordinal where
   bot := 0
@@ -423,7 +418,7 @@ theorem typein_lt_typein (r : α → α → Prop) [IsWellOrder α r] {a b : α} 
 
 theorem typein_surj (r : α → α → Prop) [IsWellOrder α r] {o} (h : o < type r) :
     ∃ a, typein r a = o :=
-  inductionOn o (fun _ _ _ ⟨f⟩ => ⟨f.top, typein_top _⟩) h
+  Quotient.inductionOn o (fun _ ⟨f⟩ => ⟨f.top, typein_top _⟩) h
 
 theorem typein_injective (r : α → α → Prop) [IsWellOrder α r] : Injective (typein r) :=
   injective_of_increasing r (· < ·) (typein r) (typein_lt_typein r).2
@@ -478,7 +473,9 @@ theorem enum_lt_enum {r : α → α → Prop} [IsWellOrder α r] {o₁ o₂ : {o
 theorem relIso_enum' {α β : Type u} {r : α → α → Prop} {s : β → β → Prop} [IsWellOrder α r]
     [IsWellOrder β s] (f : r ≃r s) (o : Ordinal) :
     ∀ (hr : o < type r) (hs : o < type s), f (enum r ⟨o, hr⟩) = enum s ⟨o, hs⟩ := by
-  refine inductionOn o ?_; rintro γ t wo ⟨g⟩ ⟨h⟩
+  refine Quotient.inductionOn o ?_
+  rintro ⟨_, _, _⟩ ⟨g⟩ ⟨h⟩
+  dsimp
   rw [enum_type g, enum_type (PrincipalSeg.ltEquiv g f)]; rfl
 
 theorem relIso_enum {α β : Type u} {r : α → α → Prop} {s : β → β → Prop} [IsWellOrder α r]
@@ -518,7 +515,7 @@ theorem card_typein {r : α → α → Prop} [IsWellOrder α r] (x : α) :
   rfl
 
 theorem card_le_card {o₁ o₂ : Ordinal} : o₁ ≤ o₂ → card o₁ ≤ card o₂ :=
-  inductionOn o₁ fun _ _ _ => inductionOn o₂ fun _ _ _ ⟨⟨⟨f, _⟩, _⟩⟩ => ⟨f⟩
+  Quotient.inductionOn₂ o₁ o₂ fun _ _ ⟨⟨⟨f, _⟩, _⟩⟩ => ⟨f⟩
 
 @[simp]
 theorem card_zero : card 0 = 0 := mk_eq_zero _
@@ -573,7 +570,7 @@ theorem type_lift_preimage_aux {α : Type u} {β : Type v} (r : α → α → Pr
 -- @[simp] -- Porting note: simp lemma never applies, tested
 theorem lift_umax : lift.{max u v, u} = lift.{v, u} :=
   funext fun a =>
-    inductionOn a fun _ r _ =>
+    Quotient.inductionOn a fun ⟨_, r, _⟩ =>
       Quotient.sound ⟨(RelIso.preimage Equiv.ulift r).trans (RelIso.preimage Equiv.ulift r).symm⟩
 
 /-- `lift.{max v u, u}` equals `lift.{v, u}`. -/
@@ -584,7 +581,7 @@ theorem lift_umax' : lift.{max v u, u} = lift.{v, u} :=
 /-- An ordinal lifted to a lower or equal universe equals itself. -/
 -- @[simp] -- Porting note: simp lemma never applies, tested
 theorem lift_id' (a : Ordinal) : lift a = a :=
-  inductionOn a fun _ r _ => Quotient.sound ⟨RelIso.preimage Equiv.ulift r⟩
+  Quotient.inductionOn a fun ⟨_, r, _⟩ => Quotient.sound ⟨RelIso.preimage Equiv.ulift r⟩
 
 /-- An ordinal lifted to the same universe equals itself. -/
 @[simp]
@@ -598,7 +595,7 @@ theorem lift_uzero (a : Ordinal.{u}) : lift.{0} a = a :=
 
 @[simp]
 theorem lift_lift (a : Ordinal) : lift.{w} (lift.{v} a) = lift.{max v w} a :=
-  inductionOn a fun _ _ _ =>
+  Quotient.inductionOn a fun _ =>
     Quotient.sound
       ⟨(RelIso.preimage Equiv.ulift _).trans <|
           (RelIso.preimage Equiv.ulift _).trans (RelIso.preimage Equiv.ulift _).symm⟩
@@ -635,10 +632,9 @@ theorem lift_type_lt {α : Type u} {β : Type v} {r s} [IsWellOrder α r] [IsWel
 
 @[simp]
 theorem lift_le {a b : Ordinal} : lift.{u,v} a ≤ lift.{u,v} b ↔ a ≤ b :=
-  inductionOn a fun α r _ =>
-    inductionOn b fun β s _ => by
-      rw [← lift_umax]
-      exact lift_type_le.{_,_,u}
+  Quotient.inductionOn₂ a b fun ⟨α, r, _⟩ ⟨β, s, _⟩ => by
+    rw [← lift_umax]
+    exact lift_type_le
 
 @[simp]
 theorem lift_inj {a b : Ordinal} : lift.{u,v} a = lift.{u,v} b ↔ a = b := by
@@ -658,15 +654,15 @@ theorem lift_one : lift 1 = 1 :=
 
 @[simp]
 theorem lift_card (a) : Cardinal.lift.{u,v} (card a)= card (lift.{u,v} a) :=
-  inductionOn a fun _ _ _ => rfl
+  Quotient.inductionOn a fun _ => rfl
 
 theorem lift_down' {a : Cardinal.{u}} {b : Ordinal.{max u v}}
     (h : card.{max u v} b ≤ Cardinal.lift.{v,u} a) : ∃ a', lift.{v,u} a' = b :=
   let ⟨c, e⟩ := Cardinal.lift_down h
   Cardinal.inductionOn c
     (fun α =>
-      inductionOn b fun β s _ e' => by
-        rw [card_type, ← Cardinal.lift_id'.{max u v, u} #β, ← Cardinal.lift_umax.{u, v},
+      Quotient.inductionOn b fun ⟨β, s, _⟩ e' => by
+        rw [type_def, card_type, ← Cardinal.lift_id'.{max u v, u} #β, ← Cardinal.lift_umax.{u, v},
           lift_mk_eq.{u, max u v, max u v}] at e'
         cases' e' with f
         have g := RelIso.preimage f s
@@ -748,10 +744,10 @@ instance addMonoidWithOne : AddMonoidWithOne Ordinal.{u} where
   zero := 0
   one := 1
   zero_add o :=
-    inductionOn o fun α r _ =>
+    Quotient.inductionOn o fun ⟨α, r, _⟩ =>
       Eq.symm <| Quotient.sound ⟨⟨(emptySum PEmpty α).symm, Sum.lex_inr_inr⟩⟩
   add_zero o :=
-    inductionOn o fun α r _ =>
+    Quotient.inductionOn o fun ⟨α, r, _⟩ =>
       Eq.symm <| Quotient.sound ⟨⟨(sumEmpty α PEmpty).symm, Sum.lex_inl_inl⟩⟩
   add_assoc o₁ o₂ o₃ :=
     Quotient.inductionOn₃ o₁ o₂ o₃ fun ⟨α, r, _⟩ ⟨β, s, _⟩ ⟨γ, t, _⟩ =>
@@ -765,7 +761,7 @@ instance addMonoidWithOne : AddMonoidWithOne Ordinal.{u} where
 
 @[simp]
 theorem card_add (o₁ o₂ : Ordinal) : card (o₁ + o₂) = card o₁ + card o₂ :=
-  inductionOn o₁ fun _ __ => inductionOn o₂ fun _ _ _ => rfl
+  Quotient.inductionOn₂ o₁ o₂ fun _ _ => rfl
 
 @[simp]
 theorem type_sum_lex {α β : Type u} (r : α → α → Prop) (s : β → β → Prop) [IsWellOrder α r]
@@ -784,12 +780,9 @@ theorem card_ofNat (n : ℕ) [n.AtLeastTwo] :
 
 -- Porting note: Rewritten proof of elim, previous version was difficult to debug
 instance add_covariantClass_le : CovariantClass Ordinal.{u} Ordinal.{u} (· + ·) (· ≤ ·) where
-  elim := fun c a b h => by
-    revert h c
-    refine inductionOn a (fun α₁ r₁ _ ↦ ?_)
-    refine inductionOn b (fun α₂ r₂ _ ↦ ?_)
-    rintro c ⟨⟨⟨f, fo⟩, fi⟩⟩
-    refine inductionOn c (fun β s _ ↦ ?_)
+  elim := fun c a b => by
+    refine Quotient.inductionOn₃ a b c ?_
+    rintro _ _ _ ⟨⟨⟨f, fo⟩, fi⟩⟩
     refine ⟨⟨⟨(Embedding.refl.{u+1} _).sumMap f, ?_⟩, ?_⟩⟩
     · intros a b
       match a, b with
@@ -808,19 +801,16 @@ instance add_covariantClass_le : CovariantClass Ordinal.{u} Ordinal.{u} (· + ·
 -- Porting note: Rewritten proof of elim, previous version was difficult to debug
 instance add_swap_covariantClass_le :
     CovariantClass Ordinal.{u} Ordinal.{u} (swap (· + ·)) (· ≤ ·) where
-  elim := fun c a b h => by
-    revert h c
-    refine inductionOn a (fun α₁ r₁ _ ↦ ?_)
-    refine inductionOn b (fun α₂ r₂ _ ↦ ?_)
-    rintro c ⟨⟨⟨f, fo⟩, fi⟩⟩
-    refine inductionOn c (fun β s _ ↦ ?_)
-    exact @RelEmbedding.ordinal_type_le _ _ (Sum.Lex r₁ s) (Sum.Lex r₂ s) _ _
-              ⟨f.sumMap (Embedding.refl _), by
-                intro a b
-                constructor <;> intro H
-                · cases' a with a a <;> cases' b with b b <;> cases H <;> constructor <;>
-                    [rwa [← fo]; assumption]
-                · cases H <;> constructor <;> [rwa [fo]; assumption]⟩
+  elim := fun c a b => by
+    refine Quotient.inductionOn₃ a b c ?_
+    rintro _ _ _ ⟨⟨⟨f, fo⟩, fi⟩⟩
+    apply RelEmbedding.ordinal_type_le
+    use f.sumMap (Embedding.refl _)
+    intro a b
+    constructor <;> intro H
+    · cases' a with a a <;> cases' b with b b <;> cases H <;> constructor <;>
+        [rwa [← fo]; assumption]
+    · cases H <;> constructor <;> [rwa [fo]; assumption]
 
 theorem le_add_right (a b : Ordinal) : a ≤ a + b := by
   simpa only [add_zero] using add_le_add_left (Ordinal.zero_le b) a
@@ -836,10 +826,9 @@ instance linearOrder : LinearOrder Ordinal :=
       | _, Or.inr h => by rw [h]; exact Or.inr (le_add_left _ _)
       | Or.inl h₁, Or.inl h₂ => by
         revert h₁ h₂
-        refine inductionOn a ?_
-        intro α₁ r₁ _
-        refine inductionOn b ?_
-        intro α₂ r₂ _ ⟨f⟩ ⟨g⟩
+        refine Quotient.inductionOn₂ a b ?_
+        rintro ⟨α₁, r₁, _⟩ ⟨α₂, r₂, _⟩ ⟨f⟩ ⟨g⟩
+        dsimp
         rw [← typein_top f, ← typein_top g, le_iff_lt_or_eq, le_iff_lt_or_eq,
                  typein_lt_typein, typein_lt_typein]
         rcases trichotomous_of (Sum.Lex r₁ r₂) g.top f.top with (h | h | h) <;>
@@ -872,13 +861,12 @@ theorem sInf_empty : sInf (∅ : Set Ordinal) = 0 :=
 
 private theorem succ_le_iff' {a b : Ordinal} : a + 1 ≤ b ↔ a < b :=
   ⟨lt_of_lt_of_le
-      (inductionOn a fun α r _ =>
+      (Quotient.inductionOn a fun _ =>
         ⟨⟨⟨⟨fun x => Sum.inl x, fun _ _ => Sum.inl.inj⟩, Sum.lex_inl_inl⟩,
             Sum.inr PUnit.unit, fun b =>
             Sum.recOn b (fun x => ⟨fun _ => ⟨x, rfl⟩, fun _ => Sum.Lex.sep _ _⟩) fun x =>
               Sum.lex_inr_inr.trans ⟨False.elim, fun ⟨x, H⟩ => Sum.inl_ne_inr H⟩⟩⟩),
-    inductionOn a fun α r hr =>
-      inductionOn b fun β s hs ⟨⟨f, t, hf⟩⟩ => by
+    Quotient.inductionOn₂ a b fun ⟨α, r, hr⟩ ⟨β, s, hs⟩ ⟨⟨f, t, hf⟩⟩ => by
         haveI := hs
         refine ⟨⟨RelEmbedding.ofMonotone (Sum.rec f fun _ => t) (fun a b ↦ ?_), fun a b ↦ ?_⟩⟩
         · rcases a with (a | _) <;> rcases b with (b | _)
@@ -1058,16 +1046,17 @@ theorem univ_umax : univ.{u, max (u + 1) v} = univ.{u, v} :=
   `ordinal.{v}` as a principal segment when `u < v`. -/
 def lift.principalSeg : @PrincipalSeg Ordinal.{u} Ordinal.{max (u + 1) v} (· < ·) (· < ·) :=
   ⟨↑lift.initialSeg.{u, max (u + 1) v}, univ.{u, v}, by
-    refine fun b => inductionOn b ?_; intro β s _
+    intro b
+    refine b.inductionOn ?_
+    rintro ⟨β, s, _⟩
     rw [univ, ← lift_umax]; constructor <;> intro h
-    · rw [← lift_id (type s)] at h ⊢
+    · rw [type_def, ← lift_id (type s)] at h ⊢
       cases' lift_type_lt.{_,_,v}.1 h with f
       cases' f with f a hf
       exists a
       revert hf
-      -- Porting note: apply inductionOn does not work, refine does
-      refine inductionOn a ?_
-      intro α r _ hf
+      refine a.inductionOn ?_
+      rintro ⟨α, r, _⟩ hf
       refine
         lift_type_eq.{u, max (u + 1) v, max (u + 1) v}.2
           ⟨(RelIso.ofSurjective (RelEmbedding.ofMonotone ?_ ?_) ?_).symm⟩
@@ -1082,8 +1071,8 @@ def lift.principalSeg : @PrincipalSeg Ordinal.{u} Ordinal.{max (u + 1) v} (· < 
         simp [e]
     · cases' h with a e
       rw [← e]
-      refine inductionOn a ?_
-      intro α r _
+      refine a.inductionOn ?_
+      rintro ⟨α, r, _⟩
       exact lift_type_lt.{u, u + 1, max (u + 1) v}.2 ⟨typein.principalSeg r⟩⟩
 
 @[simp]
@@ -1141,9 +1130,9 @@ theorem ord_le_type (r : α → α → Prop) [h : IsWellOrder α r] : ord #α �
 
 theorem ord_le {c o} : ord c ≤ o ↔ c ≤ o.card :=
   inductionOn c fun α =>
-    Ordinal.inductionOn o fun β s _ => by
+    Quotient.inductionOn o fun ⟨β, s, _⟩ => by
       let ⟨r, _, e⟩ := ord_eq α
-      simp only [card_type]; constructor <;> intro h
+      simp only [type_def, card_type]; constructor <;> intro h
       · rw [e] at h
         exact
           let ⟨f⟩ := h


### PR DESCRIPTION
`Ordinal.inductionOn` was a specialized version of `Quotient.inductionOn` for `Ordinal`. This PR removes it.

There's three things I don't like about this theorem:

1. It has a misleading name - this has nothing to do with the much more common transfinite induction.
2. At best, it's barely more useful than `Quotient.inductionOn`. I only had to insert `type_def` in a couple of places.
3. When you don't actually want to name the arguments, there's more blank spaces you need to insert. I imagine this same reason is why we didn't have `Ordinal.inductionOn₂` or `Ordinal.inductionOn₃`, even though the quotient versions are used all over the place - that would be nine variables to introduce, most of which you won't need!

Deletions: 
- `Ordinal.inductionOn`

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[Zulip](https://leanprover.zulipchat.com/#narrow/stream/287929-mathlib4/topic/Ordinal.2EinductionOn)

The large diff is largely due to changed proof indentation.

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
