### PR TITLE
chore: use emoji-variant-selector `\uFE0F` for emojis ✅️,❌️,💥️,🟡️

### DIFF
--- a/.github/workflows/lean4checker.yml
+++ b/.github/workflows/lean4checker.yml
@@ -96,7 +96,7 @@ jobs:
           type: 'stream'
           topic: 'lean4checker'
           content: |
-            ✅ lean4checker [succeeded](${{ steps.ci_url.outputs.summary }}) on ${{ github.sha }}
+            ✅️ lean4checker [succeeded](${{ steps.ci_url.outputs.summary }}) on ${{ github.sha }}
 
       - name: Post failure message on Zulip
         if: failure()
@@ -109,7 +109,7 @@ jobs:
           type: 'stream'
           topic: 'lean4checker failure'
           content: |
-            ❌ lean4checker [failed](${{ steps.ci_url.outputs.summary }}) on ${{ github.sha }}
+            ❌️ lean4checker [failed](${{ steps.ci_url.outputs.summary }}) on ${{ github.sha }}
         continue-on-error: true
 
       - name: Post failure message on Zulip main topic
@@ -123,5 +123,5 @@ jobs:
           type: 'stream'
           topic: 'lean4checker'
           content: |
-            ❌ lean4checker failed on ${{ github.sha }}
+            ❌️ lean4checker failed on ${{ github.sha }}
         continue-on-error: true

--- a/.github/workflows/nightly_detect_failure.yml
+++ b/.github/workflows/nightly_detect_failure.yml
@@ -22,7 +22,7 @@ jobs:
         type: 'stream'
         topic: 'Mathlib status updates'
         content: |
-          ❌ The latest CI for Mathlib's branch#nightly-testing has [failed](https://github.com/${{ github.repository }}/actions/runs/${{ github.event.workflow_run.id }}) ([${{ github.sha }}](https://github.com/${{ github.repository }}/commit/${{ github.sha }})).
+          ❌️ The latest CI for Mathlib's branch#nightly-testing has [failed](https://github.com/${{ github.repository }}/actions/runs/${{ github.event.workflow_run.id }}) ([${{ github.sha }}](https://github.com/${{ github.repository }}/commit/${{ github.sha }})).
 
   handle_success:
     if: ${{ github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.head_branch == 'nightly-testing' }}
@@ -105,13 +105,13 @@ jobs:
         }
         response = client.get_messages(request)
         messages = response['messages']
-        if not messages or messages[0]['content'] != f"✅ The latest CI for Mathlib's branch#nightly-testing has succeeded! ([{os.getenv('SHA')}](https://github.com/${{ github.repository }}/commit/{os.getenv('SHA')}))":
+        if not messages or messages[0]['content'] != f"✅️ The latest CI for Mathlib's branch#nightly-testing has succeeded! ([{os.getenv('SHA')}](https://github.com/${{ github.repository }}/commit/{os.getenv('SHA')}))":
             # Post the success message
             request = {
                 'type': 'stream',
                 'to': 'nightly-testing',
                 'topic': 'Mathlib status updates',
-                'content': f"✅ The latest CI for Mathlib's branch#nightly-testing has succeeded! ([{os.getenv('SHA')}](https://github.com/${{ github.repository }}/commit/{os.getenv('SHA')}))"
+                'content': f"✅️ The latest CI for Mathlib's branch#nightly-testing has succeeded! ([{os.getenv('SHA')}](https://github.com/${{ github.repository }}/commit/{os.getenv('SHA')}))"
             }
             result = client.send_message(request)
             print(result)

--- a/.github/workflows/update_dependencies_zulip.yml
+++ b/.github/workflows/update_dependencies_zulip.yml
@@ -24,7 +24,7 @@ jobs:
           result-encoding: string
           script: |
             const owner = context.repo.owner, repo = context.repo.repo;
-            let output = "❌ `lake update` [failed](" + context.payload.workflow_run.html_url + "). "
+            let output = "❌️ `lake update` [failed](" + context.payload.workflow_run.html_url + "). "
             let prs = context.payload.workflow_run.pull_requests
             if (prs.length) {
               for (let pr of prs) {

--- a/scripts/lean-pr-testing-comments.sh
+++ b/scripts/lean-pr-testing-comments.sh
@@ -79,7 +79,7 @@ if [[ "$branch_name" =~ ^lean-pr-testing-([0-9]+)$ ]]; then
   branch="[lean-pr-testing-$pr_number](https://github.com/leanprover-community/mathlib4/compare/nightly-testing...lean-pr-testing-$pr_number)"
   # Depending on the success/failure, set the appropriate message
   if [ "$LINT_OUTCOME" == "cancelled" ] || [ "$TEST_OUTCOME" == "cancelled" ] || [ "$COUNTEREXAMPLES_OUTCOME" == "cancelled" ] || [ "$ARCHIVE_OUTCOME" == "cancelled" ] || [ "$NOISY_OUTCOME" == "cancelled" ] || [ "$BUILD_OUTCOME" == "cancelled" ]; then
-    message="- 🟡 Mathlib branch $branch build against this PR was cancelled. ($current_time) [View Log]($WORKFLOW_URL)"
+    message="- 🟡️ Mathlib branch $branch build against this PR was cancelled. ($current_time) [View Log]($WORKFLOW_URL)"
   elif [ "$TEST_OUTCOME" == "success" ]; then
     message="- ✅️ Mathlib branch $branch has successfully built against this PR. ($current_time) [View Log]($WORKFLOW_URL)"
   elif [ "$BUILD_OUTCOME" == "failure" ] ; then
@@ -95,7 +95,7 @@ if [[ "$branch_name" =~ ^lean-pr-testing-([0-9]+)$ ]]; then
   elif [ "$TEST_OUTCOME" == "failure" ]; then
     message="- ❌️ Mathlib branch $branch built against this PR, but testing failed. ($current_time) [View Log]($WORKFLOW_URL)"
   else
-    message="- 🟡 Mathlib branch $branch build this PR didn't complete normally. ($current_time) [View Log]($WORKFLOW_URL)"
+    message="- 🟡️ Mathlib branch $branch build this PR didn't complete normally. ($current_time) [View Log]($WORKFLOW_URL)"
   fi
 
   echo "$message"

--- a/scripts/lean-pr-testing-comments.sh
+++ b/scripts/lean-pr-testing-comments.sh
@@ -81,19 +81,19 @@ if [[ "$branch_name" =~ ^lean-pr-testing-([0-9]+)$ ]]; then
   if [ "$LINT_OUTCOME" == "cancelled" ] || [ "$TEST_OUTCOME" == "cancelled" ] || [ "$COUNTEREXAMPLES_OUTCOME" == "cancelled" ] || [ "$ARCHIVE_OUTCOME" == "cancelled" ] || [ "$NOISY_OUTCOME" == "cancelled" ] || [ "$BUILD_OUTCOME" == "cancelled" ]; then
     message="- 🟡 Mathlib branch $branch build against this PR was cancelled. ($current_time) [View Log]($WORKFLOW_URL)"
   elif [ "$TEST_OUTCOME" == "success" ]; then
-    message="- ✅ Mathlib branch $branch has successfully built against this PR. ($current_time) [View Log]($WORKFLOW_URL)"
+    message="- ✅️ Mathlib branch $branch has successfully built against this PR. ($current_time) [View Log]($WORKFLOW_URL)"
   elif [ "$BUILD_OUTCOME" == "failure" ] ; then
-    message="- 💥 Mathlib branch $branch build failed against this PR. ($current_time) [View Log]($WORKFLOW_URL)"
+    message="- 💥️ Mathlib branch $branch build failed against this PR. ($current_time) [View Log]($WORKFLOW_URL)"
   elif [ "$LINT_OUTCOME" == "failure" ]; then
-    message="- ❌ Mathlib branch $branch built against this PR, but linting failed. ($current_time) [View Log]($WORKFLOW_URL)"
+    message="- ❌️ Mathlib branch $branch built against this PR, but linting failed. ($current_time) [View Log]($WORKFLOW_URL)"
   elif [ "$COUNTEREXAMPLES_OUTCOME" == "failure" ]; then
-    message="- ❌ Mathlib branch $branch built against this PR, but the counterexamples library failed. ($current_time) [View Log]($WORKFLOW_URL)"
+    message="- ❌️ Mathlib branch $branch built against this PR, but the counterexamples library failed. ($current_time) [View Log]($WORKFLOW_URL)"
   elif [ "$ARCHIVE_OUTCOME" == "failure" ]; then
-    message="- ❌ Mathlib branch $branch built against this PR, but the archive failed. ($current_time) [View Log]($WORKFLOW_URL)"
+    message="- ❌️ Mathlib branch $branch built against this PR, but the archive failed. ($current_time) [View Log]($WORKFLOW_URL)"
   elif [ "$NOISY_OUTCOME" == "failure" ]; then
-    message="- ❌ Mathlib branch $branch built against this PR, but was unexpectedly noisy. ($current_time) [View Log]($WORKFLOW_URL)"
+    message="- ❌️ Mathlib branch $branch built against this PR, but was unexpectedly noisy. ($current_time) [View Log]($WORKFLOW_URL)"
   elif [ "$TEST_OUTCOME" == "failure" ]; then
-    message="- ❌ Mathlib branch $branch built against this PR, but testing failed. ($current_time) [View Log]($WORKFLOW_URL)"
+    message="- ❌️ Mathlib branch $branch built against this PR, but testing failed. ($current_time) [View Log]($WORKFLOW_URL)"
   else
     message="- 🟡 Mathlib branch $branch build this PR didn't complete normally. ($current_time) [View Log]($WORKFLOW_URL)"
   fi

--- a/test/AssertExists.lean
+++ b/test/AssertExists.lean
@@ -12,10 +12,10 @@ theorem Nats : True := .intro
 
 /--
 info:
-✅ 'Nats' (declaration) asserted in 'test.AssertExists'.
+✅️ 'Nats' (declaration) asserted in 'test.AssertExists'.
 ---
-✅ means the declaration or import exists.
-❌ means the declaration or import does not exist.
+✅️ means the declaration or import exists.
+❌️ means the declaration or import does not exist.
 -/
 #guard_msgs in
 #check_assertions
@@ -31,23 +31,23 @@ assert_not_imported
 
 /--
 warning:
-✅ 'Nats' (declaration) asserted in 'test.AssertExists'.
-❌ 'I_do_not_exist' (module) asserted in 'test.AssertExists'.
-❌ 'Mathlib.Tactic.Common' (module) asserted in 'test.AssertExists'.
+✅️ 'Nats' (declaration) asserted in 'test.AssertExists'.
+❌️ 'I_do_not_exist' (module) asserted in 'test.AssertExists'.
+❌️ 'Mathlib.Tactic.Common' (module) asserted in 'test.AssertExists'.
 ---
-✅ means the declaration or import exists.
-❌ means the declaration or import does not exist.
+✅️ means the declaration or import exists.
+❌️ means the declaration or import does not exist.
 -/
 #guard_msgs in
 #check_assertions
 
 /--
 warning:
-❌ 'I_do_not_exist' (module) asserted in 'test.AssertExists'.
-❌ 'Mathlib.Tactic.Common' (module) asserted in 'test.AssertExists'.
+❌️ 'I_do_not_exist' (module) asserted in 'test.AssertExists'.
+❌️ 'Mathlib.Tactic.Common' (module) asserted in 'test.AssertExists'.
 ---
-✅ means the declaration or import exists.
-❌ means the declaration or import does not exist.
+✅️ means the declaration or import exists.
+❌️ means the declaration or import does not exist.
 -/
 #guard_msgs in
 #check_assertions!


### PR DESCRIPTION
Append the emoji-variant selector `\uFE0F` to these 4 unicode symbols which should always be rendered as emojis.


---

This has been done in core, so it makes sense to do the same in Mathlib.

- [x] depends on: leanprover/lean4#5173
- [ ] depends on: #16215

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text] (might address this in a more rigorous way)

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
