### PR TITLE
[Merged by Bors] - chore: remove `autoImplicit` from `Archive, Cache, Data`

### DIFF
--- a/Archive/Examples/IfNormalization/Result.lean
+++ b/Archive/Examples/IfNormalization/Result.lean
@@ -15,8 +15,6 @@ import Mathlib.Tactic.Recall
 See `Statement.lean` for background.
 -/
 
-set_option autoImplicit true
-
 macro "◾" : tactic => `(tactic| aesop)
 macro "◾" : term => `(term| by aesop)
 
@@ -30,17 +28,19 @@ attribute [local simp] normalized hasNestedIf hasConstantIf hasRedundantIf disjo
 
 attribute [local simp] apply_ite ite_eq_iff'
 
+variable {b : Bool} {f : ℕ → Bool} {i : ℕ} {t e : IfExpr}
+
 /-!
 Simp lemmas for `eval`.
 We don't want a `simp` lemma for `(ite i t e).eval` in general, only once we know the shape of `i`.
 -/
-@[simp] theorem eval_lit : (lit b).eval f  = b := rfl
-@[simp] theorem eval_var : (var i).eval f  = f i := rfl
+@[simp] theorem eval_lit : (lit b).eval f = b := rfl
+@[simp] theorem eval_var : (var i).eval f = f i := rfl
 @[simp] theorem eval_ite_lit :
     (ite (.lit b) t e).eval f = bif b then t.eval f else e.eval f := rfl
 @[simp] theorem eval_ite_var :
     (ite (.var i) t e).eval f = bif f i then t.eval f else e.eval f := rfl
-@[simp] theorem eval_ite_ite :
+@[simp] theorem eval_ite_ite {a b c d e : IfExpr} :
     (ite (ite a b c) d e).eval f = (ite a (ite b d e) (ite c d e)).eval f := by
   cases h : eval f a <;> simp_all [eval]
 

--- a/Archive/Examples/IfNormalization/WithoutAesop.lean
+++ b/Archive/Examples/IfNormalization/WithoutAesop.lean
@@ -17,14 +17,12 @@ In this variant we eschew the use of `aesop`, and instead write out the proofs.
 we put primes on the declarations in the file.)
 -/
 
-set_option autoImplicit true
-
 namespace IfExpr
 
 attribute [local simp] eval normalized hasNestedIf hasConstantIf hasRedundantIf disjoint vars
   List.disjoint max_add_add_right max_mul_mul_left Nat.lt_add_one_iff le_add_of_le_right
 
-theorem eval_ite_ite' :
+theorem eval_ite_ite' {a b c d e : IfExpr} {f : ℕ → Bool} :
     (ite (ite a b c) d e).eval f = (ite a (ite b d e) (ite c d e)).eval f := by
   cases h : eval f a <;> simp_all
 

--- a/Cache/IO.lean
+++ b/Cache/IO.lean
@@ -10,7 +10,7 @@ import Lean.Data.RBTree
 import Lean.Data.Json.Printer
 import Lean.Data.Json.Parser
 
-set_option autoImplicit true
+variable {α : Type}
 
 /-- Removes a parent path from the beginning of a path -/
 def System.FilePath.withoutParent (path parent : FilePath) : FilePath :=

--- a/Cache/Requests.lean
+++ b/Cache/Requests.lean
@@ -6,8 +6,6 @@ Authors: Arthur Paulino
 import Lean.Data.Json.Parser
 import Cache.Hashing
 
-set_option autoImplicit true
-
 namespace Cache.Requests
 
 -- FRO cache is flaky so disable until we work out the kinks: https://leanprover.zulipchat.com/#narrow/stream/113488-general/topic/The.20cache.20doesn't.20work/near/411058849
@@ -255,7 +253,7 @@ def QueryType.prefix : QueryType → String
   | commits => "&prefix=c/"
   | all     => default
 
-def formatError : IO α :=
+def formatError {α : Type} : IO α :=
   throw <| IO.userError "Invalid format for curl return"
 
 def QueryType.desc : QueryType → String

--- a/Mathlib/Data/MLList/BestFirst.lean
+++ b/Mathlib/Data/MLList/BestFirst.lean
@@ -87,9 +87,7 @@ structure BestFirstNode {α : Sort*} {ω : Type*} (prio : α → Thunk ω) (ε :
   (We will assume we have `[∀ a : α, Estimator (prio a) (ε a)]`.) -/
   estimator : ε key
 
-set_option autoImplicit true
-
-variable {α : Type} {prio : α → Thunk ω} {ε : α → Type} [LinearOrder ω]
+variable {ω α : Type} {prio : α → Thunk ω} {ε : α → Type} [LinearOrder ω]
   [∀ a, Estimator (prio a) (ε a)]
   [I : ∀ a : α, WellFoundedGT (range (bound (prio a) : ε a → ω))]
   {m : Type → Type} [Monad m] {β : Type}

--- a/Mathlib/Data/Vector/Basic.lean
+++ b/Mathlib/Data/Vector/Basic.lean
@@ -17,17 +17,13 @@ import Mathlib.Control.Traversable.Basic
 This file introduces the infix notation `::ᵥ` for `Vector.cons`.
 -/
 
-set_option autoImplicit true
-
 universe u
 
-variable {n : ℕ}
+variable {α β γ σ φ : Type*} {m n : ℕ}
 
 namespace Mathlib
 
 namespace Vector
-
-variable {α : Type*}
 
 @[inherit_doc]
 infixr:67 " ::ᵥ " => Vector.cons
@@ -690,7 +686,7 @@ instance : LawfulTraversable.{u} (flip Vector n) where
 
 section Simp
 
-variable (xs : Vector α n)
+variable {x : α} {y : β} {s : σ} (xs : Vector α n)
 
 @[simp]
 theorem replicate_succ (val : α) :
@@ -729,7 +725,7 @@ theorem get_map₂ (v₁ : Vector α n) (v₂ : Vector β n) (f : α → β → 
     · simp only [get_cons_succ, ih]
 
 @[simp]
-theorem mapAccumr_cons :
+theorem mapAccumr_cons {f : α → σ → σ × β} :
     mapAccumr f (x ::ᵥ xs) s
     = let r := mapAccumr f xs s
       let q := f x r.1
@@ -737,7 +733,7 @@ theorem mapAccumr_cons :
   rfl
 
 @[simp]
-theorem mapAccumr₂_cons :
+theorem mapAccumr₂_cons {f : α → β → σ → σ × φ} :
     mapAccumr₂ f (x ::ᵥ xs) (y ::ᵥ ys) s
     = let r := mapAccumr₂ f xs ys s
       let q := f x y r.1

--- a/Mathlib/Data/Vector/Defs.lean
+++ b/Mathlib/Data/Vector/Defs.lean
@@ -20,8 +20,7 @@ def Vector (α : Type u) (n : ℕ) :=
 
 namespace Vector
 
-variable {α : Type u} {β : Type v} {φ : Type w}
-variable {n : ℕ}
+variable {α β σ φ : Type*} {n : ℕ}
 
 instance [DecidableEq α] : DecidableEq (Vector α n) :=
   inferInstanceAs (DecidableEq {l : List α // l.length = n})
@@ -137,8 +136,6 @@ section Accum
 
 open Prod
 
-variable {σ : Type}
-
 /-- Runs a function over a vector returning the intermediate results and a
 final result.
 -/
@@ -150,8 +147,7 @@ def mapAccumr (f : α → σ → σ × β) : Vector α n → σ → σ × Vector
 /-- Runs a function over a pair of vectors returning the intermediate results and a
 final result.
 -/
-def mapAccumr₂ {α β σ φ : Type} (f : α → β → σ → σ × φ) :
-    Vector α n → Vector β n → σ → σ × Vector φ n
+def mapAccumr₂ (f : α → β → σ → σ × φ) : Vector α n → Vector β n → σ → σ × Vector φ n
   | ⟨x, px⟩, ⟨y, py⟩, c =>
     let res := List.mapAccumr₂ f x y c
     ⟨res.1, res.2, by simp [*, res]⟩

--- a/Mathlib/Data/Vector/MapLemmas.lean
+++ b/Mathlib/Data/Vector/MapLemmas.lean
@@ -10,7 +10,7 @@ import Mathlib.Data.Vector.Snoc
   This file establishes a set of normalization lemmas for `map`/`mapAccumr` operations on vectors
 -/
 
-set_option autoImplicit true
+variable {α β γ ζ σ σ₁ σ₂ φ : Type*} {n : ℕ} {s : σ} {s₁ : σ₁} {s₂ : σ₂}
 
 namespace Mathlib
 
@@ -36,12 +36,12 @@ theorem mapAccumr_mapAccumr :
   induction xs using Vector.revInductionOn generalizing s₁ s₂ <;> simp_all
 
 @[simp]
-theorem mapAccumr_map (f₂ : α → β) :
+theorem mapAccumr_map {s : σ₁} (f₂ : α → β) :
     (mapAccumr f₁ (map f₂ xs) s) = (mapAccumr (fun x s => f₁ (f₂ x) s) xs s) := by
   induction xs using Vector.revInductionOn generalizing s <;> simp_all
 
 @[simp]
-theorem map_mapAccumr (f₁ : β → γ) :
+theorem map_mapAccumr {s : σ₂} (f₁ : β → γ) :
     (map f₁ (mapAccumr f₂ xs s).snd) = (mapAccumr (fun x s =>
         let r := (f₂ x s); (r.fst, f₁ r.snd)
       ) xs s).snd := by
@@ -222,7 +222,7 @@ accumulation state
 section RedundantState
 variable {xs : Vector α n} {ys : Vector β n}
 
-protected theorem map_eq_mapAccumr :
+protected theorem map_eq_mapAccumr {f : α → β} :
     map f xs = (mapAccumr (fun x (_ : Unit) ↦ ((), f x)) xs ()).snd := by
   induction xs using Vector.revInductionOn <;> simp_all
 
@@ -240,7 +240,7 @@ theorem mapAccumr_eq_map {f : α → σ → σ × β} {s₀ : σ} (S : Set σ) (
   use fun s _ => s ∈ S, h₀
   exact @fun s _q a h => ⟨closure a s h, out a s s₀ h h₀⟩
 
-protected theorem map₂_eq_mapAccumr₂ :
+protected theorem map₂_eq_mapAccumr₂ {f : α → β → γ} :
     map₂ f xs ys = (mapAccumr₂ (fun x y (_ : Unit) ↦ ((), f x y)) xs ys ()).snd := by
   induction xs, ys using Vector.revInductionOn₂ <;> simp_all
 

--- a/Mathlib/Data/Vector/Snoc.lean
+++ b/Mathlib/Data/Vector/Snoc.lean
@@ -16,21 +16,21 @@ import Mathlib.Data.Vector.Basic
   `snoc xs x` for its inductive case. Effectively doing induction from right-to-left
 -/
 
-set_option autoImplicit true
-
 namespace Mathlib
 
 namespace Vector
+
+variable {α β σ φ : Type*} {n : ℕ} {x : α} {s : σ} (xs : Vector α n)
 
 /-- Append a single element to the end of a vector -/
 def snoc : Vector α n → α → Vector α (n+1) :=
   fun xs x => append xs (x ::ᵥ Vector.nil)
 
-/-!
-## Simplification lemmas
--/
+/-! ## Simplification lemmas -/
+
 section Simp
-variable (xs : Vector α n)
+
+variable {y : α}
 
 @[simp]
 theorem snoc_cons : (x ::ᵥ xs).snoc y = x ::ᵥ (xs.snoc y) :=
@@ -64,9 +64,8 @@ theorem replicate_succ_to_snoc (val : α) :
 
 end Simp
 
-/-!
-## Reverse induction principle
--/
+/-! ## Reverse induction principle -/
+
 section Induction
 
 /-- Define `C v` by *reverse* induction on `v : Vector α n`.
@@ -115,24 +114,20 @@ def revCasesOn {C : ∀ {n : ℕ}, Vector α n → Sort*} {n : ℕ} (v : Vector 
 
 end Induction
 
-/-!
-## More simplification lemmas
--/
+/-! ## More simplification lemmas -/
 
 section Simp
 
-variable (xs : Vector α n)
-
 @[simp]
-theorem map_snoc : map f (xs.snoc x) = (map f xs).snoc (f x) := by
+theorem map_snoc {f : α → β} : map f (xs.snoc x) = (map f xs).snoc (f x) := by
   induction xs <;> simp_all
 
 @[simp]
-theorem mapAccumr_nil : mapAccumr f Vector.nil s = (s, Vector.nil) :=
+theorem mapAccumr_nil {f : α → σ → σ × β} {s : σ} : mapAccumr f Vector.nil s = (s, Vector.nil) :=
   rfl
 
 @[simp]
-theorem mapAccumr_snoc :
+theorem mapAccumr_snoc {f : α → σ → σ × β} {s : σ} :
     mapAccumr f (xs.snoc x) s
     = let q := f x s
       let r := mapAccumr f xs q.1
@@ -144,17 +139,19 @@ theorem mapAccumr_snoc :
 variable (ys : Vector β n)
 
 @[simp]
-theorem map₂_snoc : map₂ f (xs.snoc x) (ys.snoc y) = (map₂ f xs ys).snoc (f x y) := by
+theorem map₂_snoc {f : α → β → σ} {y : β} :
+    map₂ f (xs.snoc x) (ys.snoc y) = (map₂ f xs ys).snoc (f x y) := by
   induction xs, ys using Vector.inductionOn₂ <;> simp_all
 
 @[simp]
-theorem mapAccumr₂_nil : mapAccumr₂ f Vector.nil Vector.nil s = (s, Vector.nil) :=
+theorem mapAccumr₂_nil {f : α → β → σ → σ × φ} :
+    mapAccumr₂ f Vector.nil Vector.nil s = (s, Vector.nil) :=
   rfl
 
 @[simp]
 theorem mapAccumr₂_snoc (f : α → β → σ → σ × φ) (x : α) (y : β) :
-    mapAccumr₂ f (xs.snoc x) (ys.snoc y) c
-    = let q := f x y c
+    mapAccumr₂ f (xs.snoc x) (ys.snoc y) s
+    = let q := f x y s
       let r := mapAccumr₂ f xs ys q.1
       (r.1, r.2.snoc q.2) := by
   induction xs, ys using Vector.inductionOn₂ <;> simp_all

--- a/Mathlib/Deprecated/HashMap.lean
+++ b/Mathlib/Deprecated/HashMap.lean
@@ -8,6 +8,7 @@ nothing from the mathlib3 file `data.hash_map` is reflected here.
 The porting header is just here to mark that no further work on `data.hash_map` is desired.
 -/
 import Mathlib.Init
+import Mathlib.Tactic.TypeStar
 import Batteries.Data.HashMap.Basic
 import Batteries.Data.RBMap.Basic
 
@@ -17,7 +18,7 @@ import Batteries.Data.RBMap.Basic
 These should be replaced by proper implementations in Batteries.
 -/
 
-set_option autoImplicit true
+variable {α β : Type*}
 
 namespace Batteries.HashMap
 

--- a/Mathlib/Topology/MetricSpace/Gluing.lean
+++ b/Mathlib/Topology/MetricSpace/Gluing.lean
@@ -580,8 +580,7 @@ attribute [local instance] inductivePremetric
 def InductiveLimit (I : ∀ n, Isometry (f n)) : Type _ :=
   @SeparationQuotient _ (inductivePremetric I).toUniformSpace.toTopologicalSpace
 
-set_option autoImplicit true in
-instance : MetricSpace (InductiveLimit (f := f) I) :=
+instance {I : ∀ (n : ℕ), Isometry (f n)} : MetricSpace (InductiveLimit (f := f) I) :=
   inferInstanceAs <| MetricSpace <|
     @SeparationQuotient _ (inductivePremetric I).toUniformSpace.toTopologicalSpace
 


### PR DESCRIPTION
Split from #16154 – this PR contains just the less contentious changes. Four non-test files will remain after this.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
