### PR TITLE
[Merged by Bors] - chore: add the stacks attribute and extension

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -4248,6 +4248,7 @@ import Mathlib.Tactic.Simps.NotationClass
 import Mathlib.Tactic.SlimCheck
 import Mathlib.Tactic.SplitIfs
 import Mathlib.Tactic.Spread
+import Mathlib.Tactic.StacksAttribute
 import Mathlib.Tactic.Subsingleton
 import Mathlib.Tactic.Substs
 import Mathlib.Tactic.SuccessIfFailWithMsg

--- a/Mathlib/Tactic.lean
+++ b/Mathlib/Tactic.lean
@@ -203,6 +203,7 @@ import Mathlib.Tactic.Simps.NotationClass
 import Mathlib.Tactic.SlimCheck
 import Mathlib.Tactic.SplitIfs
 import Mathlib.Tactic.Spread
+import Mathlib.Tactic.StacksAttribute
 import Mathlib.Tactic.Subsingleton
 import Mathlib.Tactic.Substs
 import Mathlib.Tactic.SuccessIfFailWithMsg

--- a/Mathlib/Tactic/StacksAttribute.lean
+++ b/Mathlib/Tactic/StacksAttribute.lean
@@ -58,9 +58,6 @@ See the [Tags page](https://stacks.math.columbia.edu/tags) in the Stacks project
 -/
 syntax (name := stacks) "stacks " (stackTag)? (ppSpace str)? : attr
 
-initialize stacksTagAttribute : TagAttribute ←
-  registerTagAttribute `stacks1 "hel"
-
 initialize Lean.registerBuiltinAttribute {
   name := `stacks
   descr := "Apply a Stacks project tag to a theorem."

--- a/Mathlib/Tactic/StacksAttribute.lean
+++ b/Mathlib/Tactic/StacksAttribute.lean
@@ -1,7 +1,7 @@
 /-
-Copyright (c) 2024 Dmaiano Testa. All rights reserved.
+Copyright (c) 2024 Damiano Testa. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Dmaiano Testa
+Authors: Damiano Testa
 -/
 import Lean.Parser.Syntax
 

--- a/Mathlib/Tactic/StacksAttribute.lean
+++ b/Mathlib/Tactic/StacksAttribute.lean
@@ -84,10 +84,19 @@ end Mathlib.Stacks
 
 open Mathlib.Stacks
 /--
-`getSortedTags env` returns the array of `Tags`, sorted by alphabetical order of declaration name.
+`getSortedStackProjectTags env` returns the array of `Tags`, sorted by alphabetical order of tag.
 -/
-def Lean.Environment.getSortedTags (env : Environment) : Array Tag :=
-  tagExt.getState env |>.toArray.qsort (·.declName.toString < ·.declName.toString)
+def Lean.Environment.getSortedStackProjectTags (env : Environment) : Array Tag :=
+  tagExt.getState env |>.toArray.qsort (·.tag < ·.tag)
+
+/--
+`getSortedStackProjectDeclNames env tag` returns the array of declaration names of results
+with Stacks Project tag equal to `tag`.
+-/
+def Lean.Environment.getSortedStackProjectDeclNames (env : Environment) (tag : String) :
+    Array Name :=
+  let tags := env.getSortedStackProjectTags
+  tags.filterMap fun d => if d.tag == tag then some d.declName else none
 
 /--
 `#stacks_tags` retrieves all declarations that have the `stacks` attribute.
@@ -100,7 +109,7 @@ The variant `#stacks_tags!` also adds the theorem statement after each summary l
 -/
 elab (name := Mathlib.Stacks.stacksTags) "#stacks_tags" tk:("!")?: command => do
   let env ← getEnv
-  let entries := env.getSortedTags
+  let entries := env.getSortedStackProjectTags
   if entries.isEmpty then logInfo "No tags found." else
   let mut msgs := #[m!""]
   for d in entries do

--- a/Mathlib/Tactic/StacksAttribute.lean
+++ b/Mathlib/Tactic/StacksAttribute.lean
@@ -37,7 +37,8 @@ initialize Lean.registerBuiltinAttribute {
   name := `stacks
   descr := "Apply a Stacks project tag to a theorem."
   add := fun _decl stx _attrKind => Lean.withRef stx do
-    -- check that there are no spaces in the tag
+    -- check that the tag consists of 4 characters and
+    -- that only digits and uppercase letter are present
     let tag := stx[1]
     if let some s := tag.getSubstring? then
       let str := s.toString.trimRight

--- a/Mathlib/Tactic/StacksAttribute.lean
+++ b/Mathlib/Tactic/StacksAttribute.lean
@@ -1,0 +1,41 @@
+/-
+Copyright (c) 2024 Dmaiano Testa. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Dmaiano Testa
+-/
+import Lean.Parser.Syntax
+
+/-!
+The `stacks` attribute.
+-/
+
+open Lean
+
+namespace Mathlib.Stacks
+
+/--
+The syntax for a Stacks tag: it is an optional number followed by an optional identifier.
+This allows `044Q3` and `GH3F6` as possibilities.
+-/
+declare_syntax_cat stackTags
+
+@[inherit_doc Parser.Category.stackTags]
+syntax (num)? (ident)? : stackTags
+
+/-- The `stacks` attribute.
+Use it as `@[stacks TAG "Optional comment"]`.
+The `TAG` is mandatory.
+-/
+syntax (name := stacks) "stacks " (stackTags)? (str)? : attr
+
+initialize Lean.registerBuiltinAttribute {
+  name := `stacks
+  descr := "Apply a Stacks project tag to a theorem."
+  applicationTime := .afterCompilation
+  add := fun _decl stx _attrKind => Lean.withRef stx do
+    match stx with
+      | `(attr| stacks $_:stackTags $_:str) => return
+      | `(attr| stacks $_:stackTags) => return
+      | _ => logWarning "Please, enter a Tag after `stacks`."
+  erase := fun _decl => return
+}

--- a/Mathlib/Tactic/StacksAttribute.lean
+++ b/Mathlib/Tactic/StacksAttribute.lean
@@ -89,7 +89,7 @@ open Mathlib.Stacks
 /--
 `getSortedTags env` returns the array of `Tags`, sorted by alphabetical order of declaration name.
 -/
-def _root_.Lean.Environment.getSortedTags (env : Environment) : Array Tag :=
+def Lean.Environment.getSortedTags (env : Environment) : Array Tag :=
   tagExt.getState env |>.toArray.qsort (·.declName.toString < ·.declName.toString)
 
 open Elab Command in

--- a/Mathlib/Tactic/StacksAttribute.lean
+++ b/Mathlib/Tactic/StacksAttribute.lean
@@ -31,11 +31,9 @@ syntax (name := stacks) "stacks " (stackTags)? (str)? : attr
 initialize Lean.registerBuiltinAttribute {
   name := `stacks
   descr := "Apply a Stacks project tag to a theorem."
-  applicationTime := .afterCompilation
   add := fun _decl stx _attrKind => Lean.withRef stx do
     match stx with
       | `(attr| stacks $_:stackTags $_:str) => return
       | `(attr| stacks $_:stackTags) => return
       | _ => logWarning "Please, enter a Tag after `stacks`."
-  erase := fun _decl => return
 }

--- a/Mathlib/Tactic/StacksAttribute.lean
+++ b/Mathlib/Tactic/StacksAttribute.lean
@@ -3,7 +3,7 @@ Copyright (c) 2024 Damiano Testa. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Damiano Testa
 -/
-import Lean.Attributes
+import Lean.Elab.Command
 
 /-!
 # The `stacks` attribute
@@ -15,6 +15,31 @@ This allows tagging of mathlib lemmas with the corresponding
 open Lean
 
 namespace Mathlib.Stacks
+
+/-- `Tag` is the structure that carries the data to check if a declaration or an
+import are meant to exist somewhere in Mathlib. -/
+structure Tag where
+  /-- The Stacks Project tag. -/
+  tag : String
+  /-- The name of the declaration with the given tag. -/
+  declName : Name
+  deriving BEq, Hashable
+
+/-- Defines the `tagExt` extension for adding a `HashSet` of `Tag`s
+to the environment. -/
+initialize tagExt : SimplePersistentEnvExtension Tag (HashSet Tag) ←
+  registerSimplePersistentEnvExtension {
+    addImportedFn := fun as => as.foldl HashSet.insertMany {}
+    addEntryFn := .insert
+  }
+
+/--
+`addTagEntry tag declName` takes as input the `String` `tag` and the `Name` `declName` of
+a declaration with the `stacks` attribute.
+It extends the `Tag` environment extension with the data `tag, declName`.
+-/
+def addTagEntry {m : Type → Type} [MonadEnv m] (tag : String) (declName : Name) : m Unit :=
+  modifyEnv (tagExt.addEntry · { tag := tag, declName := declName })
 
 /--
 The syntax for a Stacks tag: it is an optional number followed by an optional identifier.
@@ -33,22 +58,60 @@ See the [Tags page](https://stacks.math.columbia.edu/tags) in the Stacks project
 -/
 syntax (name := stacks) "stacks " (stackTag)? (ppSpace str)? : attr
 
+initialize stacksTagAttribute : TagAttribute ←
+  registerTagAttribute `stacks1 "hel"
+
 initialize Lean.registerBuiltinAttribute {
   name := `stacks
   descr := "Apply a Stacks project tag to a theorem."
-  add := fun _decl stx _attrKind => Lean.withRef stx do
+  add := fun decl stx _attrKind => Lean.withRef stx do
     -- check that the tag consists of 4 characters and
     -- that only digits and uppercase letter are present
     let tag := stx[1]
-    if let some s := tag.getSubstring? then
-      let str := s.toString.trimRight
-      if str.length != 4 then
-        logWarningAt tag
-          m!"Tag '{str}' is {str.length} characters long, but it should be 4 characters long"
-      if 2 ≤ (str.split (fun c => (!c.isUpper) && !c.isDigit)).length then
-        logWarningAt tag m!"Tag '{str}' should only consist of digits and uppercase letters"
-    match stx with
-      | `(attr| stacks $_:stackTag $_:str) => return
-      | `(attr| stacks $_:stackTag) => return
-      | _ => logWarning "Please, enter a Tag after `stacks`."
+    match tag.getSubstring? with
+      | none => logWarning "Please, enter a Tag after `stacks`."
+      | some str =>
+        let str := str.toString.trimRight
+        if str.length != 4 then
+          logWarningAt tag
+            m!"Tag '{str}' is {str.length} characters long, but it should be 4 characters long"
+        else if 2 ≤ (str.split (fun c => (!c.isUpper) && !c.isDigit)).length then
+          logWarningAt tag m!"Tag '{str}' should only consist of digits and uppercase letters"
+        else match stx with
+          | `(attr| stacks $_:stackTag $_:str) => addTagEntry str decl
+          | `(attr| stacks $_:stackTag) => addTagEntry str decl
+          | _ => Elab.throwUnsupportedSyntax
 }
+
+end Mathlib.Stacks
+
+open Mathlib.Stacks
+/--
+`getSortedTags env` returns the array of `Tags`, sorted by alphabetical order of declaration name.
+-/
+def _root_.Lean.Environment.getSortedTags (env : Environment) : Array Tag :=
+  tagExt.getState env |>.toArray.qsort (·.declName.toString < ·.declName.toString)
+
+open Elab Command in
+/--
+`#stacks_tags` retrieves all declarations that have the `stacks` attribute.
+
+For each found declaration, it prints a line
+```
+'declaration_name' corresponds to tag 'declaration_tag'.
+```
+The variant `#stacks_tags!` also adds the theorem statement after each summary line.
+-/
+elab (name := Mathlib.Stacks.stacksTags) "#stacks_tags" tk:("!")?: command => do
+  let env ← getEnv
+  let entries := env.getSortedTags
+  if entries.isEmpty then logInfo "No tags found." else
+  let mut msgs := #[m!""]
+  for d in entries do
+    let dname ← liftCoreM do realizeGlobalConstNoOverloadWithInfo (mkIdent d.declName)
+    msgs := msgs.push m!"'{dname}' corresponds to tag '{d.tag}'."
+    if tk.isSome then
+      let dType := ((env.find? dname).getD default).type
+      msgs := (msgs.push m!"{dType}").push ""
+  let msg := MessageData.joinSep msgs.toList "\n"
+  logInfo msg

--- a/Mathlib/Tactic/StacksAttribute.lean
+++ b/Mathlib/Tactic/StacksAttribute.lean
@@ -29,7 +29,7 @@ syntax (num)? (ident)? : stackTag
 Use it as `@[stacks TAG "Optional comment"]`.
 The `TAG` is mandatory.
 
-See the [Tags page](stacks.math.columbia.edu/tags) in the Stacks project for more details.
+See the [Tags page](https://stacks.math.columbia.edu/tags) in the Stacks project for more details.
 -/
 syntax (name := stacks) "stacks " (stackTag)? (str)? : attr
 

--- a/Mathlib/Tactic/StacksAttribute.lean
+++ b/Mathlib/Tactic/StacksAttribute.lean
@@ -31,7 +31,7 @@ The `TAG` is mandatory.
 
 See the [Tags page](https://stacks.math.columbia.edu/tags) in the Stacks project for more details.
 -/
-syntax (name := stacks) "stacks " (stackTag)? (str)? : attr
+syntax (name := stacks) "stacks " (stackTag)? (ppSpace str)? : attr
 
 initialize Lean.registerBuiltinAttribute {
   name := `stacks

--- a/Mathlib/Tactic/StacksAttribute.lean
+++ b/Mathlib/Tactic/StacksAttribute.lean
@@ -7,6 +7,9 @@ import Lean.Attributes
 
 /-!
 The `stacks` attribute.
+
+This allows tagging of mathlib lemmas with the corresponding
+[Tags](stacks.math.columbia.edu/tags) from the Stacks Project.
 -/
 
 open Lean
@@ -25,6 +28,8 @@ syntax (num)? (ident)? : stackTags
 /-- The `stacks` attribute.
 Use it as `@[stacks TAG "Optional comment"]`.
 The `TAG` is mandatory.
+
+See the [Tags page](stacks.math.columbia.edu/tags) in the Stacks project for more details.
 -/
 syntax (name := stacks) "stacks " (stackTags)? (str)? : attr
 

--- a/Mathlib/Tactic/StacksAttribute.lean
+++ b/Mathlib/Tactic/StacksAttribute.lean
@@ -6,7 +6,7 @@ Authors: Damiano Testa
 import Lean.Attributes
 
 /-!
-The `stacks` attribute.
+# The `stacks` attribute
 
 This allows tagging of mathlib lemmas with the corresponding
 [Tags](https://stacks.math.columbia.edu/tags) from the Stacks Project.

--- a/Mathlib/Tactic/StacksAttribute.lean
+++ b/Mathlib/Tactic/StacksAttribute.lean
@@ -36,9 +36,9 @@ initialize tagExt : SimplePersistentEnvExtension Tag (HashSet Tag) ←
   }
 
 /--
-`addTagEntry tag declName` takes as input the `String` `tag` and the `Name` `declName` of
-a declaration with the `stacks` attribute.
-It extends the `Tag` environment extension with the data `tag, declName`.
+`addTagEntry declName tag comment` takes as input the `Name` `declName` of a declaration and
+the `String`s `tag` and `comment` of the `stacks` attribute.
+It extends the `Tag` environment extension with the data `declName, tag, comment`.
 -/
 def addTagEntry {m : Type → Type} [MonadEnv m] (declName : Name) (tag comment : String) : m Unit :=
   modifyEnv (tagExt.addEntry · { declName := declName, tag := tag, comment := comment })

--- a/Mathlib/Tactic/StacksAttribute.lean
+++ b/Mathlib/Tactic/StacksAttribute.lean
@@ -32,6 +32,11 @@ initialize Lean.registerBuiltinAttribute {
   name := `stacks
   descr := "Apply a Stacks project tag to a theorem."
   add := fun _decl stx _attrKind => Lean.withRef stx do
+    -- check that there are no spaces in the tag
+    let tag := stx[1]
+    if let some s := tag.getSubstring? then
+      if 2 ≤ (s.trim.splitOn " ").length then
+        logWarningAt tag m!"Spaces are not allowed in '{s}'"
     match stx with
       | `(attr| stacks $_:stackTags $_:str) => return
       | `(attr| stacks $_:stackTags) => return

--- a/Mathlib/Tactic/StacksAttribute.lean
+++ b/Mathlib/Tactic/StacksAttribute.lean
@@ -9,7 +9,7 @@ import Lean.Attributes
 The `stacks` attribute.
 
 This allows tagging of mathlib lemmas with the corresponding
-[Tags](stacks.math.columbia.edu/tags) from the Stacks Project.
+[Tags](https://stacks.math.columbia.edu/tags) from the Stacks Project.
 -/
 
 open Lean

--- a/Mathlib/Tactic/StacksAttribute.lean
+++ b/Mathlib/Tactic/StacksAttribute.lean
@@ -35,8 +35,12 @@ initialize Lean.registerBuiltinAttribute {
     -- check that there are no spaces in the tag
     let tag := stx[1]
     if let some s := tag.getSubstring? then
-      if 2 ≤ (s.trim.splitOn " ").length then
-        logWarningAt tag m!"Spaces are not allowed in '{s}'"
+      let str := s.toString.trimRight
+      if str.length != 4 then
+        logWarningAt tag
+          m!"Tag '{str}' is {str.length} characters long, but it should be 4 characters long"
+      if 2 ≤ (str.split (fun c => (!c.isUpper) && !c.isDigit)).length then
+        logWarningAt tag m!"Tag '{str}' should only consist of digits and uppercase letters"
     match stx with
       | `(attr| stacks $_:stackTags $_:str) => return
       | `(attr| stacks $_:stackTags) => return

--- a/Mathlib/Tactic/StacksAttribute.lean
+++ b/Mathlib/Tactic/StacksAttribute.lean
@@ -3,7 +3,7 @@ Copyright (c) 2024 Damiano Testa. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Damiano Testa
 -/
-import Lean.Parser.Syntax
+import Lean.Attributes
 
 /-!
 The `stacks` attribute.

--- a/Mathlib/Tactic/StacksAttribute.lean
+++ b/Mathlib/Tactic/StacksAttribute.lean
@@ -20,10 +20,10 @@ namespace Mathlib.Stacks
 The syntax for a Stacks tag: it is an optional number followed by an optional identifier.
 This allows `044Q3` and `GH3F6` as possibilities.
 -/
-declare_syntax_cat stackTags
+declare_syntax_cat stackTag
 
-@[inherit_doc Parser.Category.stackTags]
-syntax (num)? (ident)? : stackTags
+@[inherit_doc Parser.Category.stackTag]
+syntax (num)? (ident)? : stackTag
 
 /-- The `stacks` attribute.
 Use it as `@[stacks TAG "Optional comment"]`.
@@ -31,7 +31,7 @@ The `TAG` is mandatory.
 
 See the [Tags page](stacks.math.columbia.edu/tags) in the Stacks project for more details.
 -/
-syntax (name := stacks) "stacks " (stackTags)? (str)? : attr
+syntax (name := stacks) "stacks " (stackTag)? (str)? : attr
 
 initialize Lean.registerBuiltinAttribute {
   name := `stacks
@@ -47,7 +47,7 @@ initialize Lean.registerBuiltinAttribute {
       if 2 ≤ (str.split (fun c => (!c.isUpper) && !c.isDigit)).length then
         logWarningAt tag m!"Tag '{str}' should only consist of digits and uppercase letters"
     match stx with
-      | `(attr| stacks $_:stackTags $_:str) => return
-      | `(attr| stacks $_:stackTags) => return
+      | `(attr| stacks $_:stackTag $_:str) => return
+      | `(attr| stacks $_:stackTag) => return
       | _ => logWarning "Please, enter a Tag after `stacks`."
 }

--- a/test/StacksAttribute.lean
+++ b/test/StacksAttribute.lean
@@ -1,5 +1,9 @@
 import Mathlib.Tactic.StacksAttribute
 
+/-- info: No tags found. -/
+#guard_msgs in
+#stacks_tags
+
 /--
 warning: Tag '04 Q' should only consist of digits and uppercase letters
 ---
@@ -9,7 +13,7 @@ warning: Tag 'loA1' should only consist of digits and uppercase letters
 -/
 #guard_msgs in
 @[stacks 04 Q "", stacks A04Q "A comment", stacks 044QQ , stacks loA1]
-example : True := .intro
+theorem tagged : True := .intro
 
 /--
 warning: Please, enter a Tag after `stacks`.
@@ -19,3 +23,19 @@ warning: Please, enter a Tag after `stacks`.
 #guard_msgs in
 @[stacks "", stacks]
 example : True := .intro
+
+
+/--
+info:
+'tagged' corresponds to tag 'A04Q'.
+-/
+#guard_msgs in
+#stacks_tags
+
+/--
+info:
+'tagged' corresponds to tag 'A04Q'.
+True
+-/
+#guard_msgs in
+#stacks_tags!

--- a/test/StacksAttribute.lean
+++ b/test/StacksAttribute.lean
@@ -1,6 +1,12 @@
 import Mathlib.Tactic.StacksAttribute
 
-/-- warning: Spaces are not allowed in '044 Q ' -/
+/--
+warning: Tag '04 Q' should only consist of digits and uppercase letters
+---
+warning: Tag '044QQ' is 5 characters long, but it should be 4 characters long
+---
+warning: Tag 'lowe' should only consist of digits and uppercase letters
+-/
 #guard_msgs in
-@[stacks 044 Q "", stacks A044Q "A comment", stacks A044Q ]
+@[stacks 04 Q "", stacks A04Q "A comment", stacks 044QQ , stacks lowe]
 example : True := .intro

--- a/test/StacksAttribute.lean
+++ b/test/StacksAttribute.lean
@@ -10,3 +10,12 @@ warning: Tag 'loA1' should only consist of digits and uppercase letters
 #guard_msgs in
 @[stacks 04 Q "", stacks A04Q "A comment", stacks 044QQ , stacks loA1]
 example : True := .intro
+
+/--
+warning: Please, enter a Tag after `stacks`.
+---
+warning: Please, enter a Tag after `stacks`.
+-/
+#guard_msgs in
+@[stacks "", stacks]
+example : True := .intro

--- a/test/StacksAttribute.lean
+++ b/test/StacksAttribute.lean
@@ -4,6 +4,7 @@ import Mathlib.Tactic.StacksAttribute
 #guard_msgs in
 #stacks_tags
 
+namespace X
 /--
 warning: Tag '04 Q' should only consist of digits and uppercase letters
 ---
@@ -14,6 +15,8 @@ warning: Tag 'loA1' should only consist of digits and uppercase letters
 #guard_msgs in
 @[stacks 04 Q "", stacks A04Q "A comment", stacks 044QQ , stacks loA1]
 theorem tagged : True := .intro
+
+end X
 
 /--
 warning: Please, enter a Tag after `stacks`.
@@ -27,14 +30,14 @@ example : True := .intro
 
 /--
 info:
-'tagged' corresponds to tag 'A04Q'.
+'X.tagged' corresponds to tag 'A04Q'.
 -/
 #guard_msgs in
 #stacks_tags
 
 /--
 info:
-'tagged' corresponds to tag 'A04Q'.
+'X.tagged' corresponds to tag 'A04Q'.
 True
 -/
 #guard_msgs in

--- a/test/StacksAttribute.lean
+++ b/test/StacksAttribute.lean
@@ -13,7 +13,7 @@ warning: Tag '044QQ' is 5 characters long, but it should be 4 characters long
 warning: Tag 'loA1' should only consist of digits and uppercase letters
 -/
 #guard_msgs in
-@[stacks 04 Q "", stacks A04Q "A comment", stacks 044QQ , stacks loA1]
+@[stacks 04 Q "", stacks A04Q "A comment", stacks 044QQ, stacks loA1]
 theorem tagged : True := .intro
 
 end X
@@ -29,14 +29,14 @@ example : True := .intro
 
 /--
 info:
-'X.tagged' corresponds to tag 'A04Q'.
+'X.tagged' corresponds to tag 'A04Q'. (A comment)
 -/
 #guard_msgs in
 #stacks_tags
 
 /--
 info:
-'X.tagged' corresponds to tag 'A04Q'.
+'X.tagged' corresponds to tag 'A04Q'. (A comment)
 True
 -/
 #guard_msgs in

--- a/test/StacksAttribute.lean
+++ b/test/StacksAttribute.lean
@@ -1,0 +1,6 @@
+import Mathlib.Tactic.StacksAttribute
+
+/-- warning: Spaces are not allowed in '044 Q ' -/
+#guard_msgs in
+@[stacks 044 Q "", stacks A044Q "A comment", stacks A044Q ]
+example : True := .intro

--- a/test/StacksAttribute.lean
+++ b/test/StacksAttribute.lean
@@ -27,7 +27,6 @@ warning: Please, enter a Tag after `stacks`.
 @[stacks "", stacks]
 example : True := .intro
 
-
 /--
 info:
 'X.tagged' corresponds to tag 'A04Q'.

--- a/test/StacksAttribute.lean
+++ b/test/StacksAttribute.lean
@@ -5,8 +5,8 @@ warning: Tag '04 Q' should only consist of digits and uppercase letters
 ---
 warning: Tag '044QQ' is 5 characters long, but it should be 4 characters long
 ---
-warning: Tag 'lowe' should only consist of digits and uppercase letters
+warning: Tag 'loA1' should only consist of digits and uppercase letters
 -/
 #guard_msgs in
-@[stacks 04 Q "", stacks A04Q "A comment", stacks 044QQ , stacks lowe]
+@[stacks 04 Q "", stacks A04Q "A comment", stacks 044QQ , stacks loA1]
 example : True := .intro


### PR DESCRIPTION
This extends the simple attribute of #16179 with an environment extension that tracks also the declaration names and tags.

The `#stacks_tags` command retrieves all declarations that have the `stacks` attribute.

For each found declaration, it prints a line
```
'declaration_name' corresponds to tag 'declaration_tag'.
```
The variant `#stacks_tags!` also adds the theorem statement after each summary line.

[Zulip thread](https://leanprover.zulipchat.com/#narrow/stream/113488-general/topic/stacks.20tags)

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
