### PR TITLE
[Merged by Bors] - feat (Algebra/Module/Submodule/Equiv) : add apply_ofBijective_symm_apply

### DIFF
--- a/Mathlib/Algebra/Module/Submodule/Equiv.lean
+++ b/Mathlib/Algebra/Module/Submodule/Equiv.lean
@@ -186,6 +186,11 @@ theorem ofBijective_symm_apply_apply [RingHomInvPair σ₁₂ σ₂₁] [RingHom
     (ofBijective f h).symm (f x) = x := by
   simp [LinearEquiv.symm_apply_eq]
 
+@[simp]
+theorem apply_ofBijective_symm_apply [RingHomInvPair σ₁₂ σ₂₁] [RingHomInvPair σ₂₁ σ₁₂] {h}
+    (x : M₂) : f ((ofBijective f h).symm x) = x := by
+  rw [← ofBijective_apply f ((ofBijective f h).symm x), apply_symm_apply]
+
 end
 
 end AddCommMonoid


### PR DESCRIPTION
This PR adds a version of the immediately previous lemma with  the order of map and inverse reversed.

---

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
