### PR TITLE
[Merged by Bors] - chore: reduce imports for Data.Nat.GCD.Basic

### DIFF
--- a/Mathlib/Data/Nat/GCD/Basic.lean
+++ b/Mathlib/Data/Nat/GCD/Basic.lean
@@ -3,21 +3,22 @@ Copyright (c) 2014 Jeremy Avigad. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Jeremy Avigad, Leonardo de Moura
 -/
-import Mathlib.Order.Lattice
 import Mathlib.Algebra.GroupWithZero.Divisibility
 import Mathlib.Algebra.Ring.Nat
 import Mathlib.Init.Data.Nat.Lemmas
-import Mathlib.Order.Basic
 
 /-!
-# Definitions and properties of `Nat.gcd`, `Nat.lcm`, and `Nat.coprime`
+# Properties of `Nat.gcd`, `Nat.lcm`, and `Nat.Coprime`
+
+Definitions are provided in batteries.
 
 Generalizations of these are provided in a later file as `GCDMonoid.gcd` and
 `GCDMonoid.lcm`.
 
-Note that the global `IsCoprime` is not a straightforward generalization of `Nat.coprime`, see
+Note that the global `IsCoprime` is not a straightforward generalization of `Nat.Coprime`, see
 `Nat.isCoprime_iff_coprime` for the connection between the two.
 
+Most of this file could be moved to batteries as well.
 -/
 
 assert_not_exists OrderedCommMonoid
@@ -210,7 +211,7 @@ theorem coprime_self_sub_right {m n : ℕ} (h : m ≤ n) : Coprime n (n - m) ↔
 @[simp]
 theorem coprime_pow_left_iff {n : ℕ} (hn : 0 < n) (a b : ℕ) :
     Nat.Coprime (a ^ n) b ↔ Nat.Coprime a b := by
-  obtain ⟨n, rfl⟩ := exists_eq_succ_of_ne_zero hn.ne'
+  obtain ⟨n, rfl⟩ := exists_eq_succ_of_ne_zero (Nat.ne_of_gt hn)
   rw [Nat.pow_succ, Nat.coprime_mul_iff_left]
   exact ⟨And.right, fun hab => ⟨hab.pow_left _, hab⟩⟩
 


### PR DESCRIPTION
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

I don't feel strongly about this; I accidentally noticed how weak the dependency was.

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
