### PR TITLE
fix: hack for binary numbers in Stacks Tags

### DIFF
--- a/Mathlib/Tactic/StacksAttribute.lean
+++ b/Mathlib/Tactic/StacksAttribute.lean
@@ -70,6 +70,8 @@ initialize Lean.registerBuiltinAttribute {
     match tag.getSubstring? with
       | none => logWarning "Please, enter a Tag after `stacks`."
       | some str =>
+        -- replacing `«` and `»` is useful to allow parsing of `0B8R` that would otherwise be
+        -- treated as a binary number and produce an error.  This is intended as a temporary fix
         let str := (str.toString.trimRight.replace "«" "").replace "»" ""
         if str.length != 4 then
           logWarningAt tag

--- a/Mathlib/Tactic/StacksAttribute.lean
+++ b/Mathlib/Tactic/StacksAttribute.lean
@@ -70,7 +70,7 @@ initialize Lean.registerBuiltinAttribute {
     match tag.getSubstring? with
       | none => logWarning "Please, enter a Tag after `stacks`."
       | some str =>
-        let str := str.toString.trimRight
+        let str := (str.toString.trimRight.replace "«" "").replace "»" ""
         if str.length != 4 then
           logWarningAt tag
             m!"Tag '{str}' is {str.length} characters long, but it should be 4 characters long"

--- a/test/StacksAttribute.lean
+++ b/test/StacksAttribute.lean
@@ -24,7 +24,7 @@ warning: Please, enter a Tag after `stacks`.
 warning: Please, enter a Tag after `stacks`.
 -/
 #guard_msgs in
-@[stacks "", stacks]
+@[stacks "", stacks,stacks «0B81»]
 example : True := .intro
 
 /--

--- a/test/StacksAttribute.lean
+++ b/test/StacksAttribute.lean
@@ -24,7 +24,7 @@ warning: Please, enter a Tag after `stacks`.
 warning: Please, enter a Tag after `stacks`.
 -/
 #guard_msgs in
-@[stacks "", stacks,stacks «0B81»]
+@[stacks "", stacks, stacks «0B81»]
 example : True := .intro
 
 /--


### PR DESCRIPTION
While I find the time to actually fix the issue with parsing, this is a temporary solution for being able to use `@[stacks 0BR8]`.

[Reported on Zulip](https://leanprover.zulipchat.com/#narrow/stream/113488-general/topic/stacks.20tags/near/465660576)

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
