### PR TITLE
feat(RingTheory): isotypic components

### DIFF
--- a/Mathlib/Order/CompactlyGenerated/Basic.lean
+++ b/Mathlib/Order/CompactlyGenerated/Basic.lean
@@ -592,6 +592,12 @@ theorem exists_setIndependent_isCompl_sSup_atoms (h : sSup { a : α | IsAtom a }
     · exact s_atoms x hx
     · exact ha
 
+proof_wanted exists_setIndependent_isCompl_sSup_sub_atoms {α : Type*} [CompleteLattice α]
+[IsModularLattice α] [IsCompactlyGenerated α]
+(t : Set α) (ht : ∀ a ∈ t, IsAtom a) (hhh : sSup t = ⊤) (b : α) :
+  ∃ (s : Set α), CompleteLattice.SetIndependent s ∧
+  IsCompl b (sSup s) ∧ ∀ ⦃a : α⦄, a ∈ s → a ∈ t 
+
 theorem exists_setIndependent_of_sSup_atoms_eq_top (h : sSup { a : α | IsAtom a } = ⊤) :
     ∃ s : Set α, CompleteLattice.SetIndependent s ∧ sSup s = ⊤ ∧ ∀ ⦃a⦄, a ∈ s → IsAtom a :=
   let ⟨s, s_ind, s_top, s_atoms⟩ := exists_setIndependent_isCompl_sSup_atoms h ⊥

--- a/Mathlib/RingTheory/Isotypic.lean
+++ b/Mathlib/RingTheory/Isotypic.lean
@@ -1,0 +1,267 @@
+import Mathlib.RingTheory.SimpleModule
+import Mathlib.Algebra.Module.Equiv
+import Mathlib.Algebra.Category.ModuleCat.Simple
+import Mathlib.Algebra.Module.Submodule.Ker
+import Mathlib.Algebra.DirectSum.Basic
+import Mathlib.Algebra.DirectSum.Module
+
+
+/-!
+# Isotypic Components
+
+## Main Definitions
+  * `isoset R M C` defines the set of all submodules of a module `M` that are isomorphic to module `C`
+   (which we shall call a generator).
+  * `isotypic R M C` defines the supremum of the isoset. In particular, this should only be used when `C` is a simple module,
+   so we use an alternative definition isoset, by taking all possible images of homomorphisms `C →ₗ[R] M` instead.
+   (Note: This alternative definition for isoset will make it include `⊥`, but when taking supremum, this won't matter for
+   `isotypic R M C`.)
+  *
+
+## Main Results
+  * `isotypic_mapsTo_isotypic`:
+    any module homomorphism keeps isotypic components within isotypic components of the same generator.
+  * `IsSemisimpleModule.sSup_isotypics_eq_top`:
+    a semisimple module is the supremum of all its isotypic components
+  * `iso_semisimple`:
+    all isotypic components are semisimple
+
+## TODO
+  * Establish that isotypic components are isomorphic to a direct sum of
+    a set of isomorphic copies of its generator (and in particular, the
+    cardinality of this set is unique)
+  * Use the above fact to establish that an isotypic component has a unique generator
+    up to isomorphisms
+  * Establish that the endomorphism ring of a finite isotypic component is a matrix ring
+    over a division ring (namely, over the endomorphism ring of the generator)
+  * Establish that a finitely generated semisimple module is a unique finite direct sum of
+    finite isotypic components
+  * Apply the above for a proof of Wedderburn-Artin by taking the endomorphism ring
+    of the semisimple ring, and obtaining the direct product of the endomorphism rings
+    of the isotypic components
+
+-/
+
+
+variable (R) [Ring R] (M C : Type*)
+  [AddCommGroup M] [Module R M]
+  [AddCommGroup C] [Module R C]
+
+
+---------------- ISOMORPHISM NOTATION
+
+def isoset' : Set (Submodule R M) :=
+  {N : Submodule R M | Nonempty (C ≃ₗ[R] N)}
+
+def isoset :
+Set (Submodule R M) :=
+  {LinearMap.range i | (i : C →ₗ[R] M)}
+
+abbrev isotypic' : (Submodule R M) :=
+  sSup (isoset' R M C)
+
+/-- We define isotypic to be an indexed supremum to be more compatible
+  with other theorems down the line. -/
+def isotypic :
+Submodule R M := (⨆ (i : C →ₗ[R] M), LinearMap.range i)
+
+/-- A convenient form to turn isotypic into a non-indexed supremum, for when that is needed. -/
+lemma isotypic_eq_sSup_isoset : isotypic R M C = sSup (isoset R M C) := by
+  rw[isotypic, isoset, iSup, Set.range]
+
+section DefinitionUnification
+
+variable [IsSimpleModule R C]
+
+lemma isoset_le_insert_zero_isoset' :
+  isoset R M C ⊆ isoset' R M C ∪ {0} := by
+  rw[isoset, isoset']; intro x hx; rw[Set.mem_setOf] at hx
+  obtain ⟨w, hw⟩ := hx
+  simp; rw[<-hw]
+  exact Or.symm (IsSimpleModule.mapsTo_equiv_or_zero R M C w)
+
+lemma isoset'_le_isoset :
+  isoset' R M C ⊆ isoset R M C := by
+  rw[isoset, isoset']; intro x f; rw[Set.mem_setOf] at f
+  apply Classical.choice at f; rw[Set.mem_setOf]
+  use (x.subtype ∘ₗ f)
+  rw[LinearMap.range_comp, LinearEquiv.range]
+  exact Submodule.map_subtype_top x
+
+
+theorem isotypic_eq_isotypic' :
+  isotypic R M C = isotypic' R M C := by
+  rw[isotypic_eq_sSup_isoset,isotypic']
+  apply le_antisymm
+  · have h : sSup (isoset' R M C) = sSup (isoset' R M C ∪ {0}) := by
+      rw[sSup_union]; simp
+    rw[h]; apply sSup_le_sSup
+    exact isoset_le_insert_zero_isoset' R M C
+  · apply sSup_le_sSup
+    exact isoset'_le_isoset R M C
+
+end DefinitionUnification
+
+section IndependentOfSimple
+
+theorem isotypic_mapsTo_isotypic (N)
+[AddCommGroup N] [Module R N] (f : M →ₗ[R] N) :
+   Submodule.map f (isotypic R M C) ≤ isotypic R N C := by
+  rw[isotypic, isotypic, Submodule.map_iSup, iSup, iSup]
+  apply sSup_le_sSup_of_forall_exists_le
+  intro x hx; rw[Set.mem_range] at hx; obtain ⟨w, hw⟩ := hx
+  simp
+  use (LinearMap.comp f w)
+  rw[<- hw, LinearMap.range_comp]
+
+end IndependentOfSimple
+
+section DependentOnSimple
+
+/-- The set of all simple submodules. -/
+def IsSimpleModule.set_submodule : Set (Submodule R M) :=
+  {S : Submodule R M | IsSimpleModule R S}
+
+/-- The set of all atomic submodules. -/
+def IsAtom.set_submodule : Set (Submodule R M) :=
+  {S : Submodule R M | IsAtom S}
+
+/-- A convenience tool for switching between IsSimpleModule and IsAtom
+  within the definition of a set. -/
+@[simp]
+lemma IsSimpleModule.set_submodule_eq_IsAtom.set_submodule : IsSimpleModule.set_submodule R M = IsAtom.set_submodule R M := by
+  rw[IsSimpleModule.set_submodule, IsAtom.set_submodule]
+  apply le_antisymm
+  · intro x hx; rw[Set.mem_setOf]; rw[Set.mem_setOf] at hx
+    exact isSimpleModule_iff_isAtom.mp hx
+  · intro x hx; rw[Set.mem_setOf]; rw[Set.mem_setOf] at hx
+    exact isSimpleModule_iff_isAtom.mpr hx
+
+/-- The set of all isosets generated by a simple module. -/
+def set_submodule_isoset : Set (Set (Submodule R M)) :=
+  {isoset R M S | S : IsSimpleModule.set_submodule R M}
+
+/-- The set of all isotypic components generated by a simple module. -/
+def set_submodule_isotypic : Set (Submodule R M) :=
+  {isotypic R M S | S : IsSimpleModule.set_submodule R M}
+
+lemma sUnion_of_set_submodule_isoset_le_IsSimpleModule.set_submodule :
+  ⋃₀ (set_submodule_isoset R M) ⊆ (IsSimpleModule.set_submodule R M) ∪ {0} := by
+  rw[Set.sUnion, set_submodule_isoset, IsSimpleModule.set_submodule]
+  apply sSup_le
+  intro y hy
+  simp at hy; obtain ⟨w, hw⟩ := hy
+  obtain ⟨hwl, hwr⟩ := hw; rw[isoset] at hwr
+  simp; intro a ha; rw[<-hwr] at ha; rw[Set.mem_setOf] at ha; obtain ⟨f, hf⟩ := ha
+  have hhf := LinearMap.injective_or_eq_zero f
+  simp
+  cases hhf with
+  | inl h =>
+    have hg := LinearMap.surjective_rangeRestrict f
+    rw[<-LinearMap.ker_eq_bot,<-LinearMap.ker_rangeRestrict,LinearMap.ker_eq_bot] at h
+    have hhg : Function.Bijective f.rangeRestrict := by
+      rw[Function.Bijective]
+      exact And.intro h hg
+    have swa := LinearMap.isSimpleModule_iff_of_bijective f.rangeRestrict hhg
+    rw[hf] at swa; rw[<-swa]
+    exact Or.inr hwl
+  | inr h =>
+    rw[h, LinearMap.range_zero] at hf
+    symm at hf
+    exact Or.inl hf
+
+lemma IsSimpleModule.set_submodule_le_sUnion_of_set_submodule_isoset :
+  (IsSimpleModule.set_submodule R M) ⊆ ⋃₀ (set_submodule_isoset R M) := by
+  rw[Set.sUnion, set_submodule_isoset, IsSimpleModule.set_submodule]
+  simp; intro y hy; rw[Set.mem_setOf] at hy; simp; use y
+  apply And.intro; exact hy
+  rw[isoset]; rw[Set.mem_setOf]
+  use (LinearMap.domRestrict LinearMap.id y)
+  apply le_antisymm
+  repeat
+    intro x; simp
+
+lemma sSup_sUnion_of_set_submodule_isoset_eq_sSup_IsSimpleModule.set_submodule :
+  sSup (⋃₀ (set_submodule_isoset R M)) = sSup (IsSimpleModule.set_submodule R M) := by
+  apply le_antisymm
+  · have h : sSup (IsSimpleModule.set_submodule R M) = sSup (IsSimpleModule.set_submodule R M ∪ {0}) := by
+      rw[sSup_union]; simp
+    rw[h]
+    apply sSup_le_sSup
+    exact sUnion_of_set_submodule_isoset_le_IsSimpleModule.set_submodule R M
+  · apply sSup_le_sSup
+    exact IsSimpleModule.set_submodule_le_sUnion_of_set_submodule_isoset R M
+
+lemma sSup_IsSimpleModule.set_submodule_eq_sSup_set_submodule_isotypic :
+  sSup (IsSimpleModule.set_submodule R M) = sSup (set_submodule_isotypic R M) := by
+  rw[<- sSup_sUnion_of_set_submodule_isoset_eq_sSup_IsSimpleModule.set_submodule, sSup_sUnion, set_submodule_isotypic]
+  apply le_antisymm
+  · apply iSup_le
+    intro x; apply iSup_le; intro hx; rw[set_submodule_isoset] at hx; simp at hx
+    obtain ⟨w, hw⟩ := hx
+    rw[<- hw.right, <-isotypic_eq_sSup_isoset]; apply le_sSup; simp
+    use w; exact And.intro hw.left rfl
+  · apply sSup_le; intro x hx; simp at hx
+    obtain ⟨w, hw⟩ := hx
+    rw[le_iSup_iff]; simp
+    intro b hb
+    have hbb := hb (isoset R M w); rw[set_submodule_isoset] at hbb
+    simp at hbb; have hww := hbb w hw.left rfl
+    rw[<- hw.right, isotypic_eq_sSup_isoset]; exact sSup_le hww
+
+/-- A semisimple module is the supremum of all its isotypic components. -/
+theorem IsSemisimpleModule.sSup_isotypics_eq_top
+(h : IsSemisimpleModule R M) :
+  sSup (set_submodule_isotypic R M) = ⊤ := by
+  rw[<-sSup_IsSimpleModule.set_submodule_eq_sSup_set_submodule_isotypic, IsSimpleModule.set_submodule]
+  exact IsSemisimpleModule.sSup_simples_eq_top
+
+variable [IsSimpleModule R C]
+
+/-- The isotypic component of an isotypic component using its own generator
+  is the top submodule. -/
+lemma isotypic_of_isotypic_eq_top :
+  isotypic R ((isotypic R M C)) C = ⊤ := by
+  let cmap := (⨆ (i : C →ₗ[R] M), LinearMap.range i).subtype
+  have hc : Function.Injective cmap := Subtype.coe_injective
+  have htop := Submodule.comap_subtype_self (isotypic R M C)
+  apply le_antisymm
+  · exact le_top
+  · rw[<-htop, isotypic, isotypic]
+    rw[<-(Submodule.comap_map_eq_of_injective hc (⨆ i, LinearMap.range i))]
+    apply Submodule.comap_mono
+    simp
+    intro f
+    rw[le_iSup_iff]
+    intro k hk
+    have hf : LinearMap.range f ≤ ⨆ (i : C →ₗ[R] M), LinearMap.range i := by
+      rw[<-isotypic, isotypic_eq_sSup_isoset, isoset]; apply le_sSup
+      use f
+    let f_to_iso := (Submodule.inclusion hf) ∘ₗ (f.rangeRestrict)
+    have hu := hk f_to_iso
+    rw[LinearMap.range_comp, LinearMap.range_rangeRestrict, Submodule.map_top] at hu
+    rw[Submodule.range_inclusion] at hu
+    rw[Submodule.map_comap_eq_self] at hu
+    exact hu
+    rw[Submodule.range_subtype]
+    exact hf
+
+/-- In particular, a subset of the atoms of `isotypic R M S` have supremum equal to `⊤`. -/
+lemma sSup_of_isoset'_of_isotypic_eq_top :
+  sSup (isoset' R ((isotypic R M C)) C) = ⊤ := by
+  rw[<-isotypic', <-isotypic_eq_isotypic']
+  · exact isotypic_of_isotypic_eq_top R M C
+
+
+/-- Isotypic components are semisimple modules. -/
+theorem iso_semisimple :
+  IsSemisimpleModule R (isotypic R M C) := by
+  rw[<- sSup_simples_eq_top_iff_isSemisimpleModule]
+  have hS : isoset R (isotypic R M C) C ⊆ {m | IsSimpleModule R m} ∪ {0} := by
+    intro x mx; simp; rw[isoset] at mx; rw[Set.mem_setOf] at mx
+    obtain ⟨l, hl⟩ := mx
+    rw[<- hl]
+    exact Or.symm (IsSimpleModule.mapsTo_simple_or_zero R (isotypic R M C) C l)
+  simp at hS; apply sSup_le_sSup_of_subset_insert_bot at hS
+  rw[<-isotypic_eq_sSup_isoset, isotypic_of_isotypic_eq_top, top_le_iff] at hS
+  exact hS

--- a/Mathlib/RingTheory/SimpleModule.lean
+++ b/Mathlib/RingTheory/SimpleModule.lean
@@ -382,6 +382,41 @@ theorem bijective_of_ne_zero [IsSimpleModule R M] [IsSimpleModule R N] {f : M �
     Function.Bijective f :=
   f.bijective_or_eq_zero.resolve_right h
 
+/-- The image of a homomorphism from a simple module is either isomorphic
+  to the simple module or is zero. -/
+lemma IsSimpleModule.mapsTo_equiv_or_zero
+[IsSimpleModule R N] (l : N →ₗ[R] M) :
+  Nonempty (N ≃ₗ[R] (LinearMap.range l)) ∨ (LinearMap.range l) = 0 := by
+  have hl := LinearMap.injective_or_eq_zero l
+  cases hl with
+  | inl hl =>
+  left
+  have hls := LinearMap.surjective_rangeRestrict l
+  have hli : Function.Injective l.rangeRestrict := by
+    rw[<-LinearMapClass.ker_eq_bot, LinearMap.ker_rangeRestrict]
+    exact LinearMap.ker_eq_bot_of_injective hl
+  have hlb : Function.Bijective l.rangeRestrict := And.intro hli hls
+  rw[Function.bijective_iff_has_inverse] at hlb
+  obtain ⟨g, hg⟩ := hlb
+  use l.rangeRestrict
+  · use g
+  · exact hg.left
+  · exact hg.right
+  | inr hl =>
+  right; rw[hl]; exact LinearMap.range_zero
+
+/-- The image of a homomorphism from a simple module is either simple or zero. -/
+lemma IsSimpleModule.mapsTo_simple_or_zero
+[IsSimpleModule R N] (l : N →ₗ[R] M) :
+  IsSimpleModule R (LinearMap.range l) ∨ (LinearMap.range l) = 0 := by
+  cases (IsSimpleModule.mapsTo_equiv_or_zero R M S l) with
+  | inl h =>
+  left
+  apply Classical.choice at h
+  exact IsSimpleModule.congr h.symm
+  | inr h =>
+  right; exact h
+
 theorem isCoatom_ker_of_surjective [IsSimpleModule R N] {f : M →ₗ[R] N}
     (hf : Function.Surjective f) : IsCoatom (LinearMap.ker f) := by
   rw [← isSimpleModule_iff_isCoatom]


### PR DESCRIPTION
Added isotypic components to RingTheory, added lemmas in SimpleModule that aid in some proofs

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
