### PR TITLE
doc(Topology/Algebra/InfiniteSums/Def): fix typo and clarify docstrings

### DIFF
--- a/Mathlib/Topology/Algebra/InfiniteSum/Defs.lean
+++ b/Mathlib/Topology/Algebra/InfiniteSum/Defs.lean
@@ -90,8 +90,10 @@ def Multipliable (f : β → α) : Prop :=
   ∃ a, HasProd f a
 
 open scoped Classical in
-/-- `∏' i, f i` is the product of `f` it exists, or 1 otherwise. -/
-@[to_additive "`∑' i, f i` is the sum of `f` it exists, or 0 otherwise."]
+/-- `∏' i, f i` is the product of `f` if it exists and is unconditionally convergent,
+or 1 otherwise. -/
+@[to_additive "`∑' i, f i` is the sum of `f` if it exists and is unconditionally convergent,
+or 0 otherwise."]
 noncomputable irreducible_def tprod {β} (f : β → α) :=
   if h : Multipliable f then
   /- Note that the product might not be uniquely defined if the topology is not separated.


### PR DESCRIPTION
Fix typos for missing "if" and "it" in documentation for tprod and tsum. Included mention that conditionally convergent infinite sum/prods will default to 0/1 respectively.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
