### PR TITLE
[Merged by Bors] - chore: make two arguments of Finsupp.total implicit

### DIFF
--- a/Mathlib/Algebra/Algebra/Subalgebra/Operations.lean
+++ b/Mathlib/Algebra/Algebra/Subalgebra/Operations.lean
@@ -67,7 +67,7 @@ theorem mem_of_finset_sum_eq_one_of_pow_smul_mem
   exact ⟨⟨_, hn i⟩, rfl⟩
 
 theorem mem_of_span_eq_top_of_smul_pow_mem
-    (s : Set S) (l : s →₀ S) (hs : Finsupp.total s S S (↑) l = 1)
+    (s : Set S) (l : s →₀ S) (hs : Finsupp.total S ((↑) : s → S) l = 1)
     (hs' : s ⊆ S') (hl : ∀ i, l i ∈ S') (x : S) (H : ∀ r : s, ∃ n : ℕ, (r : S) ^ n • x ∈ S') :
     x ∈ S' :=
   mem_of_finset_sum_eq_one_of_pow_smul_mem S' l.support (↑) l hs (fun x => hs' x.2) hl x H

--- a/Mathlib/Algebra/Module/FinitePresentation.lean
+++ b/Mathlib/Algebra/Module/FinitePresentation.lean
@@ -145,7 +145,7 @@ lemma Module.finitePresentation_of_surjective [h : Module.FinitePresentation R M
   classical
   obtain ⟨s, hs, hs'⟩ := h
   obtain ⟨t, ht⟩ := hl'
-  have H : Function.Surjective (Finsupp.total R (Subtype.val : s → M)) :=
+  have H : Function.Surjective (Finsupp.total R ((↑) : s → M)) :=
     LinearMap.range_eq_top.mp (by rw [Finsupp.range_total, Subtype.range_val, ← hs]; rfl)
   apply Module.finitePresentation_of_free_of_surjective (l ∘ₗ Finsupp.total R Subtype.val)
     (hl.comp H)
@@ -161,7 +161,7 @@ lemma Module.FinitePresentation.fg_ker [Module.Finite R M]
     (LinearMap.ker l).FG := by
   classical
   obtain ⟨s, hs, hs'⟩ := h
-  have H : Function.Surjective (Finsupp.total R (Subtype.val : s → N)) :=
+  have H : Function.Surjective (Finsupp.total R ((↑) : s → N)) :=
     LinearMap.range_eq_top.mp (by rw [Finsupp.range_total, Subtype.range_val, ← hs]; rfl)
   obtain ⟨f, hf⟩ : ∃ f : (s →₀ R) →ₗ[R] M, l ∘ₗ f = (Finsupp.total R Subtype.val) := by
     choose f hf using show _ from hl
@@ -192,7 +192,7 @@ lemma Module.finitePresentation_of_ker [Module.FinitePresentation R N]
     · rw [Submodule.map_top, LinearMap.range_eq_top.mpr hl]; exact Module.Finite.out
     · rw [top_inf_eq, ← Submodule.fg_top]; exact Module.Finite.out
   refine ⟨s, hs, ?_⟩
-  let π := Finsupp.total R (Subtype.val : s → M)
+  let π := Finsupp.total R ((↑) : s → M)
   have H : Function.Surjective π :=
     LinearMap.range_eq_top.mp (by rw [Finsupp.range_total, Subtype.range_val, ← hs]; rfl)
   have inst : Module.Finite R (LinearMap.ker (l ∘ₗ π)) := by
@@ -227,7 +227,7 @@ lemma Module.FinitePresentation.exists_lift_of_isLocalizedModule
     [h : Module.FinitePresentation R M] (g : M →ₗ[R] N') :
     ∃ (h : M →ₗ[R] N) (s : S), f ∘ₗ h = s • g := by
   obtain ⟨σ, hσ, τ, hτ⟩ := h
-  let π := Finsupp.total R (Subtype.val : σ → M)
+  let π := Finsupp.total R ((↑) : σ → M)
   have hπ : Function.Surjective π :=
     LinearMap.range_eq_top.mp (by rw [Finsupp.range_total, Subtype.range_val, ← hσ]; rfl)
   classical

--- a/Mathlib/Algebra/Module/FinitePresentation.lean
+++ b/Mathlib/Algebra/Module/FinitePresentation.lean
@@ -57,7 +57,7 @@ and the kernel of the presentation `Rˢ → M` is also finitely generated.
 -/
 class Module.FinitePresentation : Prop where
   out : ∃ (s : Finset M), Submodule.span R (s : Set M) = ⊤ ∧
-    (LinearMap.ker (Finsupp.total R (Subtype.val : s → M))).FG
+    (LinearMap.ker (Finsupp.total R ((↑) : s → M))).FG
 
 instance (priority := 100) [h : Module.FinitePresentation R M] : Module.Finite R M := by
   obtain ⟨s, hs₁, _⟩ := h

--- a/Mathlib/Algebra/Module/FinitePresentation.lean
+++ b/Mathlib/Algebra/Module/FinitePresentation.lean
@@ -57,7 +57,7 @@ and the kernel of the presentation `Rˢ → M` is also finitely generated.
 -/
 class Module.FinitePresentation : Prop where
   out : ∃ (s : Finset M), Submodule.span R (s : Set M) = ⊤ ∧
-    (LinearMap.ker (Finsupp.total s M R Subtype.val)).FG
+    (LinearMap.ker (Finsupp.total R (Subtype.val : s → M))).FG
 
 instance (priority := 100) [h : Module.FinitePresentation R M] : Module.Finite R M := by
   obtain ⟨s, hs₁, _⟩ := h
@@ -78,7 +78,7 @@ theorem Module.FinitePresentation.equiv_quotient [fp : Module.FinitePresentation
       Module.Free R L ∧ Module.Finite R L ∧ K.FG := by
   obtain ⟨ι, ⟨hι₁, hι₂⟩⟩ := fp
   use ι →₀ R, inferInstance, inferInstance
-  use LinearMap.ker (Finsupp.total { x // x ∈ ι } M R Subtype.val)
+  use LinearMap.ker (Finsupp.total R Subtype.val)
   refine ⟨(LinearMap.quotKerEquivOfSurjective _ ?_).symm, inferInstance, inferInstance, hι₂⟩
   apply LinearMap.range_eq_top.mp
   simpa only [Finsupp.range_total, Subtype.range_coe_subtype, Finset.setOf_mem]
@@ -145,12 +145,12 @@ lemma Module.finitePresentation_of_surjective [h : Module.FinitePresentation R M
   classical
   obtain ⟨s, hs, hs'⟩ := h
   obtain ⟨t, ht⟩ := hl'
-  have H : Function.Surjective (Finsupp.total s M R Subtype.val) :=
+  have H : Function.Surjective (Finsupp.total R (Subtype.val : s → M)) :=
     LinearMap.range_eq_top.mp (by rw [Finsupp.range_total, Subtype.range_val, ← hs]; rfl)
-  apply Module.finitePresentation_of_free_of_surjective (l ∘ₗ Finsupp.total s M R Subtype.val)
+  apply Module.finitePresentation_of_free_of_surjective (l ∘ₗ Finsupp.total R Subtype.val)
     (hl.comp H)
   choose σ hσ using (show _ from H)
-  have : Finsupp.total s M R Subtype.val '' (σ '' t) = t := by
+  have : Finsupp.total R Subtype.val '' (σ '' t) = t := by
     simp only [Set.image_image, hσ, Set.image_id']
   rw [LinearMap.ker_comp, ← ht, ← this, ← Submodule.map_span, Submodule.comap_map_eq,
     ← Finset.coe_image]
@@ -161,11 +161,11 @@ lemma Module.FinitePresentation.fg_ker [Module.Finite R M]
     (LinearMap.ker l).FG := by
   classical
   obtain ⟨s, hs, hs'⟩ := h
-  have H : Function.Surjective (Finsupp.total s N R Subtype.val) :=
+  have H : Function.Surjective (Finsupp.total R (Subtype.val : s → N)) :=
     LinearMap.range_eq_top.mp (by rw [Finsupp.range_total, Subtype.range_val, ← hs]; rfl)
-  obtain ⟨f, hf⟩ : ∃ f : (s →₀ R) →ₗ[R] M, l ∘ₗ f = (Finsupp.total s N R Subtype.val) := by
+  obtain ⟨f, hf⟩ : ∃ f : (s →₀ R) →ₗ[R] M, l ∘ₗ f = (Finsupp.total R Subtype.val) := by
     choose f hf using show _ from hl
-    exact ⟨Finsupp.total s M R (fun i ↦ f i), by ext; simp [hf]⟩
+    exact ⟨Finsupp.total R (fun i ↦ f i), by ext; simp [hf]⟩
   have : (LinearMap.ker l).map (LinearMap.range f).mkQ = ⊤ := by
     rw [← top_le_iff]
     rintro x -
@@ -192,7 +192,7 @@ lemma Module.finitePresentation_of_ker [Module.FinitePresentation R N]
     · rw [Submodule.map_top, LinearMap.range_eq_top.mpr hl]; exact Module.Finite.out
     · rw [top_inf_eq, ← Submodule.fg_top]; exact Module.Finite.out
   refine ⟨s, hs, ?_⟩
-  let π := Finsupp.total s M R Subtype.val
+  let π := Finsupp.total R (Subtype.val : s → M)
   have H : Function.Surjective π :=
     LinearMap.range_eq_top.mp (by rw [Finsupp.range_total, Subtype.range_val, ← hs]; rfl)
   have inst : Module.Finite R (LinearMap.ker (l ∘ₗ π)) := by
@@ -227,7 +227,7 @@ lemma Module.FinitePresentation.exists_lift_of_isLocalizedModule
     [h : Module.FinitePresentation R M] (g : M →ₗ[R] N') :
     ∃ (h : M →ₗ[R] N) (s : S), f ∘ₗ h = s • g := by
   obtain ⟨σ, hσ, τ, hτ⟩ := h
-  let π := Finsupp.total σ M R Subtype.val
+  let π := Finsupp.total R (Subtype.val : σ → M)
   have hπ : Function.Surjective π :=
     LinearMap.range_eq_top.mp (by rw [Finsupp.range_total, Subtype.range_val, ← hσ]; rfl)
   classical
@@ -235,15 +235,15 @@ lemma Module.FinitePresentation.exists_lift_of_isLocalizedModule
   let i : σ → N :=
     fun x ↦ (∏ j ∈ σ.erase x.1, (s (g j)).2) • (s (g x)).1
   let s₀ := ∏ j ∈ σ, (s (g j)).2
-  have hi : f ∘ₗ Finsupp.total σ N R i = (s₀ • g) ∘ₗ π := by
+  have hi : f ∘ₗ Finsupp.total R i = (s₀ • g) ∘ₗ π := by
     ext j
     simp only [LinearMap.coe_comp, Function.comp_apply, Finsupp.lsingle_apply, Finsupp.total_single,
       one_smul, LinearMap.map_smul_of_tower, ← hs, LinearMap.smul_apply, i, s₀, π]
     rw [← mul_smul, Finset.prod_erase_mul]
     exact j.prop
-  have : ∀ x : τ, ∃ s : S, s • (Finsupp.total σ N R i x) = 0 := by
+  have : ∀ x : τ, ∃ s : S, s • (Finsupp.total R i x) = 0 := by
     intros x
-    convert_to ∃ s : S, s • (Finsupp.total σ N R i x) = s • 0
+    convert_to ∃ s : S, s • (Finsupp.total R i x) = s • 0
     · simp only [smul_zero]
     apply IsLocalizedModule.exists_of_eq (S := S) (f := f)
     rw [← LinearMap.comp_apply, map_zero, hi, LinearMap.comp_apply]
@@ -252,7 +252,7 @@ lemma Module.FinitePresentation.exists_lift_of_isLocalizedModule
     exact Submodule.subset_span x.prop
   choose s' hs' using this
   let s₁ := ∏ i : τ, s' i
-  have : LinearMap.ker π ≤ LinearMap.ker (s₁ • Finsupp.total σ N R i) := by
+  have : LinearMap.ker π ≤ LinearMap.ker (s₁ • Finsupp.total R i) := by
     rw [← hτ, Submodule.span_le]
     intro x hxσ
     simp only [s₁]

--- a/Mathlib/Algebra/Module/Projective.lean
+++ b/Mathlib/Algebra/Module/Projective.lean
@@ -72,7 +72,7 @@ open Finsupp
   definitions. -/
 class Module.Projective (R : Type*) [Semiring R] (P : Type*) [AddCommMonoid P] [Module R P] :
     Prop where
-  out : ∃ s : P →ₗ[R] P →₀ R, Function.LeftInverse (Finsupp.total P P R id) s
+  out : ∃ s : P →ₗ[R] P →₀ R, Function.LeftInverse (Finsupp.total R id) s
 
 namespace Module
 
@@ -82,11 +82,11 @@ variable {R : Type*} [Semiring R] {P : Type*} [AddCommMonoid P] [Module R P] {M 
   [AddCommMonoid M] [Module R M] {N : Type*} [AddCommMonoid N] [Module R N]
 
 theorem projective_def :
-    Projective R P ↔ ∃ s : P →ₗ[R] P →₀ R, Function.LeftInverse (Finsupp.total P P R id) s :=
+    Projective R P ↔ ∃ s : P →ₗ[R] P →₀ R, Function.LeftInverse (Finsupp.total R id) s :=
   ⟨fun h => h.1, fun h => ⟨h⟩⟩
 
 theorem projective_def' :
-    Projective R P ↔ ∃ s : P →ₗ[R] P →₀ R, Finsupp.total P P R id ∘ₗ s = .id := by
+    Projective R P ↔ ∃ s : P →ₗ[R] P →₀ R, Finsupp.total R id ∘ₗ s = .id := by
   simp_rw [projective_def, DFunLike.ext_iff, Function.LeftInverse, comp_apply, id_apply]
 
 /-- A projective R-module has the property that maps from it lift along surjections. -/
@@ -101,7 +101,7 @@ theorem projective_lifting_property [h : Projective R P] (f : M →ₗ[R] N) (g 
     `P →ₗ N` and a random splitting of the surjection `M →ₗ N`, and we get
     a map `φ : (P →₀ R) →ₗ M`.
     -/
-  let φ : (P →₀ R) →ₗ[R] M := Finsupp.total _ _ _ fun p => Function.surjInv hf (g p)
+  let φ : (P →₀ R) →ₗ[R] M := Finsupp.total _ fun p => Function.surjInv hf (g p)
   -- By projectivity we have a map `P →ₗ (P →₀ R)`;
   cases' h.out with s hs
   -- Compose to get `P →ₗ M`. This works.
@@ -117,7 +117,7 @@ theorem Projective.of_lifting_property'' {R : Type u} [Semiring R] {P : Type v} 
     [Module R P] (huniv : ∀ (f : (P →₀ R) →ₗ[R] P), Function.Surjective f →
       ∃ h : P →ₗ[R] (P →₀ R), f.comp h = .id) :
     Projective R P :=
-  projective_def'.2 <| huniv (Finsupp.total P P R (id : P → P))
+  projective_def'.2 <| huniv (Finsupp.total R (id : P → P))
     (total_surjective _ Function.surjective_id)
 
 variable {Q : Type*} [AddCommMonoid Q] [Module R Q]
@@ -164,7 +164,7 @@ variable [IsScalarTower R₀ R M] [AddCommGroup N] [Module R₀ N]
 
 theorem Projective.of_split [Module.Projective R M]
     (i : P →ₗ[R] M) (s : M →ₗ[R] P) (H : s.comp i = LinearMap.id) : Module.Projective R P := by
-  obtain ⟨g, hg⟩ := projective_lifting_property (Finsupp.total P P R id) s
+  obtain ⟨g, hg⟩ := projective_lifting_property (Finsupp.total R id) s
     (fun x ↦ ⟨Finsupp.single x 1, by simp⟩)
   refine ⟨g.comp i, fun x ↦ ?_⟩
   rw [LinearMap.comp_apply, ← LinearMap.comp_apply, hg,
@@ -178,7 +178,7 @@ theorem Projective.of_equiv [Module.Projective R M]
 theorem Projective.iff_split : Module.Projective R P ↔
     ∃ (M : Type max u v) (_ : AddCommGroup M) (_ : Module R M) (_ : Module.Free R M)
       (i : P →ₗ[R] M) (s : M →ₗ[R] P), s.comp i = LinearMap.id :=
-  ⟨fun ⟨i, hi⟩ ↦ ⟨P →₀ R, _, _, inferInstance, i, Finsupp.total P P R id, LinearMap.ext hi⟩,
+  ⟨fun ⟨i, hi⟩ ↦ ⟨P →₀ R, _, _, inferInstance, i, Finsupp.total R id, LinearMap.ext hi⟩,
     fun ⟨_, _, _, _, i, s, H⟩ ↦ Projective.of_split i s H⟩
 
 /-- A quotient of a projective module is projective iff it is a direct summand. -/
@@ -197,11 +197,11 @@ instance Projective.tensorProduct [hM : Module.Projective R M] [hN : Module.Proj
     fapply Projective.of_split (R := R) (M := ((M →₀ R) ⊗[R₀] (N →₀ R₀)))
     · exact (AlgebraTensorModule.map sM (LinearMap.id (R := R₀) (M := N →₀ R₀)))
     · exact (AlgebraTensorModule.map
-        (Finsupp.total M M R id) (LinearMap.id (R := R₀) (M := N →₀ R₀)))
+        (Finsupp.total R id) (LinearMap.id (R := R₀) (M := N →₀ R₀)))
     · ext; simp [hsM _]
   fapply Projective.of_split (R := R) (M := (M ⊗[R₀] (N →₀ R₀)))
   · exact (AlgebraTensorModule.map (LinearMap.id (R := R) (M := M)) sN)
-  · exact (AlgebraTensorModule.map (LinearMap.id (R := R) (M := M)) (Finsupp.total N N R₀ id))
+  · exact (AlgebraTensorModule.map (LinearMap.id (R := R) (M := M)) (Finsupp.total R₀ id))
   · ext; simp [hsN _]
 
 end Ring

--- a/Mathlib/Analysis/InnerProductSpace/Basic.lean
+++ b/Mathlib/Analysis/InnerProductSpace/Basic.lean
@@ -829,7 +829,7 @@ theorem orthonormal_subtype_iff_ite [DecidableEq E] {s : Set E} :
 /-- The inner product of a linear combination of a set of orthonormal vectors with one of those
 vectors picks out the coefficient of that vector. -/
 theorem Orthonormal.inner_right_finsupp {v : ι → E} (hv : Orthonormal 𝕜 v) (l : ι →₀ 𝕜) (i : ι) :
-    ⟪v i, Finsupp.total ι E 𝕜 v l⟫ = l i := by
+    ⟪v i, Finsupp.total 𝕜 v l⟫ = l i := by
   classical
   simpa [Finsupp.total_apply, Finsupp.inner_sum, orthonormal_iff_ite.mp hv] using Eq.symm
 
@@ -849,7 +849,7 @@ theorem Orthonormal.inner_right_fintype [Fintype ι] {v : ι → E} (hv : Orthon
 /-- The inner product of a linear combination of a set of orthonormal vectors with one of those
 vectors picks out the coefficient of that vector. -/
 theorem Orthonormal.inner_left_finsupp {v : ι → E} (hv : Orthonormal 𝕜 v) (l : ι →₀ 𝕜) (i : ι) :
-    ⟪Finsupp.total ι E 𝕜 v l, v i⟫ = conj (l i) := by rw [← inner_conj_symm, hv.inner_right_finsupp]
+    ⟪Finsupp.total 𝕜 v l, v i⟫ = conj (l i) := by rw [← inner_conj_symm, hv.inner_right_finsupp]
 
 /-- The inner product of a linear combination of a set of orthonormal vectors with one of those
 vectors picks out the coefficient of that vector. -/
@@ -868,13 +868,13 @@ theorem Orthonormal.inner_left_fintype [Fintype ι] {v : ι → E} (hv : Orthono
 /-- The inner product of two linear combinations of a set of orthonormal vectors, expressed as
 a sum over the first `Finsupp`. -/
 theorem Orthonormal.inner_finsupp_eq_sum_left {v : ι → E} (hv : Orthonormal 𝕜 v) (l₁ l₂ : ι →₀ 𝕜) :
-    ⟪Finsupp.total ι E 𝕜 v l₁, Finsupp.total ι E 𝕜 v l₂⟫ = l₁.sum fun i y => conj y * l₂ i := by
+    ⟪Finsupp.total 𝕜 v l₁, Finsupp.total 𝕜 v l₂⟫ = l₁.sum fun i y => conj y * l₂ i := by
   simp only [l₁.total_apply _, Finsupp.sum_inner, hv.inner_right_finsupp, smul_eq_mul]
 
 /-- The inner product of two linear combinations of a set of orthonormal vectors, expressed as
 a sum over the second `Finsupp`. -/
 theorem Orthonormal.inner_finsupp_eq_sum_right {v : ι → E} (hv : Orthonormal 𝕜 v) (l₁ l₂ : ι →₀ 𝕜) :
-    ⟪Finsupp.total ι E 𝕜 v l₁, Finsupp.total ι E 𝕜 v l₂⟫ = l₂.sum fun i y => conj (l₁ i) * y := by
+    ⟪Finsupp.total 𝕜 v l₁, Finsupp.total 𝕜 v l₂⟫ = l₂.sum fun i y => conj (l₁ i) * y := by
   simp only [l₂.total_apply _, Finsupp.inner_sum, hv.inner_left_finsupp, mul_comm, smul_eq_mul]
 
 /-- The inner product of two linear combinations of a set of orthonormal vectors, expressed as
@@ -900,7 +900,7 @@ theorem Orthonormal.linearIndependent {v : ι → E} (hv : Orthonormal 𝕜 v) :
   rw [linearIndependent_iff]
   intro l hl
   ext i
-  have key : ⟪v i, Finsupp.total ι E 𝕜 v l⟫ = ⟪v i, 0⟫ := by rw [hl]
+  have key : ⟪v i, Finsupp.total 𝕜 v l⟫ = ⟪v i, 0⟫ := by rw [hl]
   simpa only [hv.inner_right_finsupp, inner_zero_right] using key
 
 /-- A subfamily of an orthonormal family (i.e., a composition with an injective map) is an
@@ -932,7 +932,7 @@ theorem Orthonormal.toSubtypeRange {v : ι → E} (hv : Orthonormal 𝕜 v) :
 set. -/
 theorem Orthonormal.inner_finsupp_eq_zero {v : ι → E} (hv : Orthonormal 𝕜 v) {s : Set ι} {i : ι}
     (hi : i ∉ s) {l : ι →₀ 𝕜} (hl : l ∈ Finsupp.supported 𝕜 𝕜 s) :
-    ⟪Finsupp.total ι E 𝕜 v l, v i⟫ = 0 := by
+    ⟪Finsupp.total 𝕜 v l, v i⟫ = 0 := by
   rw [Finsupp.mem_supported'] at hl
   simp only [hv.inner_left_finsupp, hl i hi, map_zero]
 

--- a/Mathlib/Analysis/InnerProductSpace/Projection.lean
+++ b/Mathlib/Analysis/InnerProductSpace/Projection.lean
@@ -1329,7 +1329,7 @@ theorem maximal_orthonormal_iff_orthogonalComplement_eq_bot (hv : Orthonormal �
     intro hxv y hy
     have hxv' : (⟨x, hxu⟩ : u) ∉ ((↑) ⁻¹' v : Set u) := by simp [huv, hxv]
     obtain ⟨l, hl, rfl⟩ :
-      ∃ l ∈ Finsupp.supported 𝕜 𝕜 ((↑) ⁻¹' v : Set u), (Finsupp.total (↥u) E 𝕜 (↑)) l = y := by
+      ∃ l ∈ Finsupp.supported 𝕜 𝕜 ((↑) ⁻¹' v : Set u), (Finsupp.total 𝕜 ((↑) : u → E)) l = y := by
       rw [← Finsupp.mem_span_image_iff_total]
       simp [huv, inter_eq_self_of_subset_right, hy]
     exact hu.inner_finsupp_eq_zero hxv' hl

--- a/Mathlib/Data/Finsupp/Weight.lean
+++ b/Mathlib/Data/Finsupp/Weight.lean
@@ -72,7 +72,7 @@ variable [AddCommMonoid M]
 /-- The `weight` of the finitely supported function `f : σ →₀ ℕ`
 with respect to `w : σ → M` is the sum `∑(f i)•(w i)`. -/
 noncomputable def weight : (σ →₀ ℕ) →+ M :=
-  (Finsupp.total σ M ℕ w).toAddMonoidHom
+  (Finsupp.total ℕ w).toAddMonoidHom
 
 @[deprecated weight (since := "2024-07-20")]
 alias _root_.MvPolynomial.weightedDegree := weight

--- a/Mathlib/LinearAlgebra/Basis/Basic.lean
+++ b/Mathlib/LinearAlgebra/Basis/Basic.lean
@@ -51,7 +51,7 @@ end Coord
 protected theorem linearIndependent : LinearIndependent R b :=
   linearIndependent_iff.mpr fun l hl =>
     calc
-      l = b.repr (Finsupp.total _ _ _ b l) := (b.repr_total l).symm
+      l = b.repr (Finsupp.total _ b l) := (b.repr_total l).symm
       _ = 0 := by rw [hl, LinearEquiv.map_zero]
 
 protected theorem ne_zero [Nontrivial R] (i) : b i ≠ 0 :=
@@ -227,7 +227,7 @@ variable (hli : LinearIndependent R v) (hsp : ⊤ ≤ span R (range v))
 protected noncomputable def mk : Basis ι R M :=
   .ofRepr
     { hli.repr.comp (LinearMap.id.codRestrict _ fun _ => hsp Submodule.mem_top) with
-      invFun := Finsupp.total _ _ _ v
+      invFun := Finsupp.total _ v
       left_inv := fun x => hli.total_repr ⟨x, _⟩
       right_inv := fun _ => hli.repr_eq rfl }
 
@@ -236,7 +236,7 @@ theorem mk_repr : (Basis.mk hli hsp).repr x = hli.repr ⟨x, hsp Submodule.mem_t
   rfl
 
 theorem mk_apply (i : ι) : Basis.mk hli hsp i = v i :=
-  show Finsupp.total _ _ _ v _ = v i by simp
+  show Finsupp.total _ v _ = v i by simp
 
 @[simp]
 theorem coe_mk : ⇑(Basis.mk hli hsp) = v :=

--- a/Mathlib/LinearAlgebra/Basis/Cardinality.lean
+++ b/Mathlib/LinearAlgebra/Basis/Cardinality.lean
@@ -103,7 +103,7 @@ theorem union_support_maximal_linearIndependent_eq_range_basis {ι : Type w} (b 
     intro l z
     rw [Finsupp.total_option] at z
     simp only [v', Option.elim'] at z
-    change _ + Finsupp.total κ M R v l.some = 0 at z
+    change _ + Finsupp.total R v l.some = 0 at z
     -- We have some linear combination of `b b'` and the `v i`, which we want to show is trivial.
     -- We'll first show the coefficient of `b b'` is zero,
     -- by expressing the `v i` in the basis `b`, and using that the `v i` have no `b b'` term.

--- a/Mathlib/LinearAlgebra/Basis/Defs.lean
+++ b/Mathlib/LinearAlgebra/Basis/Defs.lean
@@ -134,23 +134,23 @@ theorem repr_self_apply (j) [Decidable (i = j)] : b.repr (b i) j = if i = j then
   rw [repr_self, Finsupp.single_apply]
 
 @[simp]
-theorem repr_symm_apply (v) : b.repr.symm v = Finsupp.total ι M R b v :=
+theorem repr_symm_apply (v) : b.repr.symm v = Finsupp.total R b v :=
   calc
     b.repr.symm v = b.repr.symm (v.sum Finsupp.single) := by simp
     _ = v.sum fun i vi => b.repr.symm (Finsupp.single i vi) := map_finsupp_sum ..
-    _ = Finsupp.total ι M R b v := by simp only [repr_symm_single, Finsupp.total_apply]
+    _ = Finsupp.total R b v := by simp only [repr_symm_single, Finsupp.total_apply]
 
 @[simp]
-theorem coe_repr_symm : ↑b.repr.symm = Finsupp.total ι M R b :=
+theorem coe_repr_symm : ↑b.repr.symm = Finsupp.total R b :=
   LinearMap.ext fun v => b.repr_symm_apply v
 
 @[simp]
-theorem repr_total (v) : b.repr (Finsupp.total _ _ _ b v) = v := by
+theorem repr_total (v) : b.repr (Finsupp.total _ b v) = v := by
   rw [← b.coe_repr_symm]
   exact b.repr.apply_symm_apply v
 
 @[simp]
-theorem total_repr : Finsupp.total _ _ _ b (b.repr x) = x := by
+theorem total_repr : Finsupp.total _ b (b.repr x) = x := by
   rw [← b.coe_repr_symm]
   exact b.repr.symm_apply_apply x
 
@@ -551,7 +551,7 @@ you can recover an `AddEquiv` by setting `S := ℕ`.
 See library note [bundled maps over different rings].
 -/
 def constr : (ι → M') ≃ₗ[S] M →ₗ[R] M' where
-  toFun f := (Finsupp.total M' M' R id).comp <| Finsupp.lmapDomain R R f ∘ₗ ↑b.repr
+  toFun f := (Finsupp.total R id).comp <| Finsupp.lmapDomain R R f ∘ₗ ↑b.repr
   invFun f i := f (b i)
   left_inv f := by
     ext
@@ -567,7 +567,7 @@ def constr : (ι → M') ≃ₗ[S] M →ₗ[R] M' where
     simp
 
 theorem constr_def (f : ι → M') :
-    constr (M' := M') b S f = Finsupp.total M' M' R id ∘ₗ Finsupp.lmapDomain R R f ∘ₗ ↑b.repr :=
+    constr (M' := M') b S f = Finsupp.total R id ∘ₗ Finsupp.lmapDomain R R f ∘ₗ ↑b.repr :=
   rfl
 
 theorem constr_apply (f : ι → M') (x : M) :

--- a/Mathlib/LinearAlgebra/DFinsupp.lean
+++ b/Mathlib/LinearAlgebra/DFinsupp.lean
@@ -429,7 +429,7 @@ theorem lsum_comp_mapRange_toSpanSingleton [∀ m : R, Decidable (m ≠ 0)] (p :
         ((mapRange.linearMap fun i => LinearMap.toSpanSingleton R (↥(p i)) ⟨v i, hv i⟩ :
               _ →ₗ[R] _).comp
           (finsuppLequivDFinsupp R : (ι →₀ R) ≃ₗ[R] _).toLinearMap) =
-      Finsupp.total ι N R v := by
+      Finsupp.total R v := by
   ext
   simp
 

--- a/Mathlib/LinearAlgebra/Dimension/StrongRankCondition.lean
+++ b/Mathlib/LinearAlgebra/Dimension/StrongRankCondition.lean
@@ -106,7 +106,7 @@ theorem Basis.le_span'' {ι : Type*} [Fintype ι] (b : Basis ι R M) {w : Set M}
   -- We construct a surjective linear map `(w → R) →ₗ[R] (ι → R)`,
   -- by expressing a linear combination in `w` as a linear combination in `ι`.
   fapply card_le_of_surjective' R
-  · exact b.repr.toLinearMap.comp (Finsupp.total w M R (↑))
+  · exact b.repr.toLinearMap.comp (Finsupp.total R (↑))
   · apply Surjective.comp (g := b.repr.toLinearMap)
     · apply LinearEquiv.surjective
     rw [← LinearMap.range_eq_top, Finsupp.range_total]
@@ -177,7 +177,7 @@ theorem linearIndependent_le_span_aux' {ι : Type*} [Fintype ι] (v : ι → M)
   · apply Finsupp.total
     exact fun i => Span.repr R w ⟨v i, s (mem_range_self i)⟩
   · intro f g h
-    apply_fun Finsupp.total w M R (↑) at h
+    apply_fun Finsupp.total R ((↑) : w → M) at h
     simp only [Finsupp.total_total, Submodule.coe_mk, Span.finsupp_total_repr] at h
     rw [← sub_eq_zero, ← LinearMap.map_sub] at h
     exact sub_eq_zero.mp (linearIndependent_iff.mp i _ h)

--- a/Mathlib/LinearAlgebra/Dual.lean
+++ b/Mathlib/LinearAlgebra/Dual.lean
@@ -281,7 +281,7 @@ theorem toDual_apply (i j : ι) : b.toDual (b i) (b j) = if i = j then 1 else 0 
 
 @[simp]
 theorem toDual_total_left (f : ι →₀ R) (i : ι) :
-    b.toDual (Finsupp.total ι M R b f) (b i) = f i := by
+    b.toDual (Finsupp.total R b f) (b i) = f i := by
   rw [Finsupp.total_apply, Finsupp.sum, _root_.map_sum, LinearMap.sum_apply]
   simp_rw [LinearMap.map_smul, LinearMap.smul_apply, toDual_apply, smul_eq_mul, mul_boole,
     Finset.sum_ite_eq']
@@ -291,7 +291,7 @@ theorem toDual_total_left (f : ι →₀ R) (i : ι) :
 
 @[simp]
 theorem toDual_total_right (f : ι →₀ R) (i : ι) :
-    b.toDual (b i) (Finsupp.total ι M R b f) = f i := by
+    b.toDual (b i) (Finsupp.total R b f) = f i := by
   rw [Finsupp.total_apply, Finsupp.sum, _root_.map_sum]
   simp_rw [LinearMap.map_smul, toDual_apply, smul_eq_mul, mul_boole, Finset.sum_ite_eq]
   split_ifs with h
@@ -335,7 +335,7 @@ theorem toDual_ker : LinearMap.ker b.toDual = ⊥ :=
 theorem toDual_range [Finite ι] : LinearMap.range b.toDual = ⊤ := by
   refine eq_top_iff'.2 fun f => ?_
   let lin_comb : ι →₀ R := Finsupp.equivFunOnFinite.symm fun i => f (b i)
-  refine ⟨Finsupp.total ι M R b lin_comb, b.ext fun i => ?_⟩
+  refine ⟨Finsupp.total R b lin_comb, b.ext fun i => ?_⟩
   rw [b.toDual_eq_repr _ i, repr_total b]
   rfl
 
@@ -396,7 +396,7 @@ theorem dualBasis_apply_self (i j : ι) : b.dualBasis i (b j) =
   rw [@eq_comm _ j i]
 
 theorem total_dualBasis (f : ι →₀ R) (i : ι) :
-    Finsupp.total ι (Dual R M) R b.dualBasis f (b i) = f i := by
+    Finsupp.total R b.dualBasis f (b i) = f i := by
   cases nonempty_fintype ι
   rw [Finsupp.total_apply, Finsupp.sum_fintype, LinearMap.sum_apply]
   · simp_rw [LinearMap.smul_apply, smul_eq_mul, dualBasis_apply_self, mul_boole,
@@ -457,7 +457,7 @@ end CommRing
 /-- `simp` normal form version of `total_dualBasis` -/
 @[simp]
 theorem total_coord [CommRing R] [AddCommGroup M] [Module R M] [Finite ι] (b : Basis ι R M)
-    (f : ι →₀ R) (i : ι) : Finsupp.total ι (Dual R M) R b.coord f (b i) = f i := by
+    (f : ι →₀ R) (i : ι) : Finsupp.total R b.coord f (b i) = f i := by
   haveI := Classical.decEq ι
   rw [← coe_dualBasis, total_dualBasis]
 
@@ -708,11 +708,11 @@ theorem coeffs_apply (h : DualBases e ε) (m : M) (i : ι) : h.coeffs m i = ε i
   rfl
 
 /-- linear combinations of elements of `e`.
-This is a convenient abbreviation for `Finsupp.total _ M R e l` -/
+This is a convenient abbreviation for `Finsupp.total R e l` -/
 def lc {ι} (e : ι → M) (l : ι →₀ R) : M :=
   l.sum fun (i : ι) (a : R) => a • e i
 
-theorem lc_def (e : ι → M) (l : ι →₀ R) : lc e l = Finsupp.total _ _ R e l :=
+theorem lc_def (e : ι → M) (l : ι →₀ R) : lc e l = Finsupp.total R e l :=
   rfl
 
 open Module

--- a/Mathlib/LinearAlgebra/Finsupp.lean
+++ b/Mathlib/LinearAlgebra/Finsupp.lean
@@ -23,7 +23,7 @@ interpreted as a submodule of `α →₀ M`. We also define `LinearMap` versions
   linear map;
 * `Finsupp.restrictDom`: `Finsupp.filter` as a linear map to `Finsupp.supported s`;
 * `Finsupp.lsum`: `Finsupp.sum` or `Finsupp.liftAddHom` as a `LinearMap`;
-* `Finsupp.total α M R (v : ι → M)`: sends `l : ι → R` to the linear combination of `v i` with
+* `Finsupp.total R (v : ι → M)`: sends `l : ι → R` to the linear combination of `v i` with
   coefficients `l i`;
 * `Finsupp.totalOn`: a restricted version of `Finsupp.total` with domain `Finsupp.supported R R s`
   and codomain `Submodule.span R (v '' s)`;
@@ -589,7 +589,7 @@ end LComapDomain
 
 section Total
 
-variable (α) (M) (R)
+variable (R)
 variable {α' : Type*} {M' : Type*} [AddCommMonoid M'] [Module R M'] (v : α → M) {v' : α' → M'}
 
 /-- Interprets (l : α →₀ R) as linear combination of the elements in the family (v : α → M) and
@@ -597,58 +597,58 @@ variable {α' : Type*} {M' : Type*} [AddCommMonoid M'] [Module R M'] (v : α →
 protected def total : (α →₀ R) →ₗ[R] M :=
   Finsupp.lsum ℕ fun i => LinearMap.id.smulRight (v i)
 
-variable {α M v}
+variable {v}
 
-theorem total_apply (l : α →₀ R) : Finsupp.total α M R v l = l.sum fun i a => a • v i :=
+theorem total_apply (l : α →₀ R) : Finsupp.total R v l = l.sum fun i a => a • v i :=
   rfl
 
 theorem total_apply_of_mem_supported {l : α →₀ R} {s : Finset α}
-    (hs : l ∈ supported R R (↑s : Set α)) : Finsupp.total α M R v l = s.sum fun i => l i • v i :=
+    (hs : l ∈ supported R R (↑s : Set α)) : Finsupp.total R v l = s.sum fun i => l i • v i :=
   Finset.sum_subset hs fun x _ hxg =>
     show l x • v x = 0 by rw [not_mem_support_iff.1 hxg, zero_smul]
 
 @[simp]
-theorem total_single (c : R) (a : α) : Finsupp.total α M R v (single a c) = c • v a := by
+theorem total_single (c : R) (a : α) : Finsupp.total R v (single a c) = c • v a := by
   simp [total_apply, sum_single_index]
 
-theorem total_zero_apply (x : α →₀ R) : (Finsupp.total α M R 0) x = 0 := by
+theorem total_zero_apply (x : α →₀ R) : (Finsupp.total R (0 : α → M)) x = 0 := by
   simp [Finsupp.total_apply]
 
 variable (α M)
 
 @[simp]
-theorem total_zero : Finsupp.total α M R 0 = 0 :=
+theorem total_zero : Finsupp.total R (0 : α → M) = 0 :=
   LinearMap.ext (total_zero_apply R)
 
 variable {α M}
 
 theorem apply_total (f : M →ₗ[R] M') (v) (l : α →₀ R) :
-    f (Finsupp.total α M R v l) = Finsupp.total α M' R (f ∘ v) l := by
+    f (Finsupp.total R v l) = Finsupp.total R (f ∘ v) l := by
   apply Finsupp.induction_linear l <;> simp (config := { contextual := true })
 
 theorem apply_total_id (f : M →ₗ[R] M') (l : M →₀ R) :
-    f (Finsupp.total M M R _root_.id l) = Finsupp.total M M' R f l :=
+    f (Finsupp.total R _root_.id l) = Finsupp.total R f l :=
   apply_total ..
 
-theorem total_unique [Unique α] (l : α →₀ R) (v) :
-    Finsupp.total α M R v l = l default • v default := by rw [← total_single, ← unique_single l]
+theorem total_unique [Unique α] (l : α →₀ R) (v : α → M) :
+    Finsupp.total R v l = l default • v default := by rw [← total_single, ← unique_single l]
 
 theorem total_surjective (h : Function.Surjective v) :
-    Function.Surjective (Finsupp.total α M R v) := by
+    Function.Surjective (Finsupp.total R v) := by
   intro x
   obtain ⟨y, hy⟩ := h x
   exact ⟨Finsupp.single y 1, by simp [hy]⟩
 
-theorem total_range (h : Function.Surjective v) : LinearMap.range (Finsupp.total α M R v) = ⊤ :=
+theorem total_range (h : Function.Surjective v) : LinearMap.range (Finsupp.total R v) = ⊤ :=
   range_eq_top.2 <| total_surjective R h
 
 /-- Any module is a quotient of a free module. This is stated as surjectivity of
-`Finsupp.total M M R id : (M →₀ R) →ₗ[R] M`. -/
+`Finsupp.total R id : (M →₀ R) →ₗ[R] M`. -/
 theorem total_id_surjective (M) [AddCommMonoid M] [Module R M] :
-    Function.Surjective (Finsupp.total M M R _root_.id) :=
+    Function.Surjective (Finsupp.total R (id : M → M)) :=
   total_surjective R Function.surjective_id
 
-theorem range_total : LinearMap.range (Finsupp.total α M R v) = span R (range v) := by
+theorem range_total : LinearMap.range (Finsupp.total R v) = span R (range v) := by
   ext x
   constructor
   · intro hx
@@ -665,36 +665,37 @@ theorem range_total : LinearMap.range (Finsupp.total α M R v) = span R (range v
     simp [hi]
 
 theorem lmapDomain_total (f : α → α') (g : M →ₗ[R] M') (h : ∀ i, g (v i) = v' (f i)) :
-    (Finsupp.total α' M' R v').comp (lmapDomain R R f) = g.comp (Finsupp.total α M R v) := by
+    (Finsupp.total R v').comp (lmapDomain R R f) = g.comp (Finsupp.total R v) := by
   ext l
   simp [total_apply, Finsupp.sum_mapDomain_index, add_smul, h]
 
 theorem total_comp_lmapDomain (f : α → α') :
-    (Finsupp.total α' M' R v').comp (Finsupp.lmapDomain R R f) = Finsupp.total α M' R (v' ∘ f) := by
+    (Finsupp.total R v').comp (Finsupp.lmapDomain R R f) = Finsupp.total R (v' ∘ f) := by
   ext
   simp
 
 @[simp]
 theorem total_embDomain (f : α ↪ α') (l : α →₀ R) :
-    (Finsupp.total α' M' R v') (embDomain f l) = (Finsupp.total α M' R (v' ∘ f)) l := by
+    (Finsupp.total R v') (embDomain f l) = (Finsupp.total R (v' ∘ f)) l := by
   simp [total_apply, Finsupp.sum, support_embDomain, embDomain_apply]
 
 @[simp]
 theorem total_mapDomain (f : α → α') (l : α →₀ R) :
-    (Finsupp.total α' M' R v') (mapDomain f l) = (Finsupp.total α M' R (v' ∘ f)) l :=
+    (Finsupp.total R v') (mapDomain f l) = (Finsupp.total R (v' ∘ f)) l :=
   LinearMap.congr_fun (total_comp_lmapDomain _ _) l
 
 @[simp]
 theorem total_equivMapDomain (f : α ≃ α') (l : α →₀ R) :
-    (Finsupp.total α' M' R v') (equivMapDomain f l) = (Finsupp.total α M' R (v' ∘ f)) l := by
+    (Finsupp.total R v') (equivMapDomain f l) = (Finsupp.total R (v' ∘ f)) l := by
   rw [equivMapDomain_eq_mapDomain, total_mapDomain]
 
 /-- A version of `Finsupp.range_total` which is useful for going in the other direction -/
-theorem span_eq_range_total (s : Set M) : span R s = LinearMap.range (Finsupp.total s M R (↑)) := by
+theorem span_eq_range_total (s : Set M) :
+    span R s = LinearMap.range (Finsupp.total R ((↑) : s → M)) := by
   rw [range_total, Subtype.range_coe_subtype, Set.setOf_mem_eq]
 
 theorem mem_span_iff_total (s : Set M) (x : M) :
-    x ∈ span R s ↔ ∃ l : s →₀ R, Finsupp.total s M R (↑) l = x :=
+    x ∈ span R s ↔ ∃ l : s →₀ R, Finsupp.total R (↑) l = x :=
   (SetLike.ext_iff.1 <| span_eq_range_total _ _) x
 
 variable {R}
@@ -706,7 +707,7 @@ theorem mem_span_range_iff_exists_finsupp {v : α → M} {x : M} :
 variable (R)
 
 theorem span_image_eq_map_total (s : Set α) :
-    span R (v '' s) = Submodule.map (Finsupp.total α M R v) (supported R R s) := by
+    span R (v '' s) = Submodule.map (Finsupp.total R v) (supported R R s) := by
   apply span_eq_of_le
   · intro x hx
     rw [Set.mem_image] at hx
@@ -726,18 +727,18 @@ theorem span_image_eq_map_total (s : Set α) :
     simp [this]
 
 theorem mem_span_image_iff_total {s : Set α} {x : M} :
-    x ∈ span R (v '' s) ↔ ∃ l ∈ supported R R s, Finsupp.total α M R v l = x := by
+    x ∈ span R (v '' s) ↔ ∃ l ∈ supported R R s, Finsupp.total R v l = x := by
   rw [span_image_eq_map_total]
   simp
 
 theorem total_option (v : Option α → M) (f : Option α →₀ R) :
-    Finsupp.total (Option α) M R v f =
-      f none • v none + Finsupp.total α M R (v ∘ Option.some) f.some := by
+    Finsupp.total R v f =
+      f none • v none + Finsupp.total R (v ∘ Option.some) f.some := by
   rw [total_apply, sum_option_index_smul, total_apply]; simp
 
 theorem total_total {α β : Type*} (A : α → M) (B : β → α →₀ R) (f : β →₀ R) :
-    Finsupp.total α M R A (Finsupp.total β (α →₀ R) R B f) =
-      Finsupp.total β M R (fun b => Finsupp.total α M R A (B b)) f := by
+    Finsupp.total R A (Finsupp.total R B f) =
+      Finsupp.total R (fun b => Finsupp.total R A (B b)) f := by
   classical
   simp only [total_apply]
   apply induction_linear f
@@ -747,7 +748,7 @@ theorem total_total {α β : Type*} (A : α → M) (B : β → α →₀ R) (f :
   · simp [sum_single_index, sum_smul_index, smul_sum, mul_smul]
 
 @[simp]
-theorem total_fin_zero (f : Fin 0 → M) : Finsupp.total (Fin 0) M R f = 0 := by
+theorem total_fin_zero (f : Fin 0 → M) : Finsupp.total R f = 0 := by
   ext i
   apply finZeroElim i
 
@@ -759,7 +760,7 @@ subset of the vectors in `v`, mapping it to the span of those vectors.
 The subset is indicated by a set `s : Set α` of indices.
 -/
 protected def totalOn (s : Set α) : supported R R s →ₗ[R] span R (v '' s) :=
-  LinearMap.codRestrict _ ((Finsupp.total _ _ _ v).comp (Submodule.subtype (supported R R s)))
+  LinearMap.codRestrict _ ((Finsupp.total _ v).comp (Submodule.subtype (supported R R s)))
     fun ⟨l, hl⟩ => (mem_span_image_iff_total _).2 ⟨l, hl, rfl⟩
 
 variable {α} {M} {v}
@@ -771,17 +772,17 @@ theorem totalOn_range (s : Set α) : LinearMap.range (Finsupp.totalOn α M R v s
   exact (span_image_eq_map_total _ _).le
 
 theorem total_comp (f : α' → α) :
-    Finsupp.total α' M R (v ∘ f) = (Finsupp.total α M R v).comp (lmapDomain R R f) := by
+    Finsupp.total R (v ∘ f) = (Finsupp.total R v).comp (lmapDomain R R f) := by
   ext
   simp [total_apply]
 
 theorem total_comapDomain (f : α → α') (l : α' →₀ R) (hf : Set.InjOn f (f ⁻¹' ↑l.support)) :
-    Finsupp.total α M R v (Finsupp.comapDomain f l hf) =
+    Finsupp.total R v (Finsupp.comapDomain f l hf) =
       (l.support.preimage f hf).sum fun i => l (f i) • v i := by
   rw [Finsupp.total_apply]; rfl
 
 theorem total_onFinset {s : Finset α} {f : α → R} (g : α → M) (hf : ∀ a, f a ≠ 0 → a ∈ s) :
-    Finsupp.total α M R g (Finsupp.onFinset s f hf) = Finset.sum s fun x : α => f x • g x := by
+    Finsupp.total R g (Finsupp.onFinset s f hf) = Finset.sum s fun x : α => f x • g x := by
   classical
   simp only [Finsupp.total_apply, Finsupp.sum, Finsupp.onFinset_apply, Finsupp.support_onFinset]
   rw [Finset.sum_filter_of_ne]
@@ -1063,7 +1064,7 @@ theorem Fintype.total_apply_single [DecidableEq α] (i : α) (r : R) :
 
 variable (S)
 
-theorem Finsupp.total_eq_fintype_total_apply (x : α → R) : Finsupp.total α M R v
+theorem Finsupp.total_eq_fintype_total_apply (x : α → R) : Finsupp.total R v
     ((Finsupp.linearEquivFunOnFinite R R α).symm x) = Fintype.total R S v x := by
   apply Finset.sum_subset
   · exact Finset.subset_univ _
@@ -1072,7 +1073,7 @@ theorem Finsupp.total_eq_fintype_total_apply (x : α → R) : Finsupp.total α M
     exact zero_smul _ _
 
 theorem Finsupp.total_eq_fintype_total :
-    (Finsupp.total α M R v).comp (Finsupp.linearEquivFunOnFinite R R α).symm.toLinearMap =
+    (Finsupp.total R v).comp (Finsupp.linearEquivFunOnFinite R R α).symm.toLinearMap =
       Fintype.total R S v :=
   LinearMap.ext <| Finsupp.total_eq_fintype_total_apply R S v
 
@@ -1124,7 +1125,7 @@ irreducible_def Span.repr (w : Set M) (x : span R w) : w →₀ R :=
 
 @[simp]
 theorem Span.finsupp_total_repr {w : Set M} (x : span R w) :
-    Finsupp.total w M R (↑) (Span.repr R w x) = x := by
+    Finsupp.total R ((↑) : w → M) (Span.repr R w x) = x := by
   rw [Span.repr_def]
   exact ((Finsupp.mem_span_iff_total _ _ _).mp x.2).choose_spec
 
@@ -1135,7 +1136,7 @@ protected theorem Submodule.finsupp_sum_mem {ι β : Type*} [Zero β] (S : Submo
   AddSubmonoidClass.finsupp_sum_mem S f g h
 
 theorem LinearMap.map_finsupp_total (f : M →ₗ[R] N) {ι : Type*} {g : ι → M} (l : ι →₀ R) :
-    f (Finsupp.total ι M R g l) = Finsupp.total ι N R (f ∘ g) l := by
+    f (Finsupp.total R g l) = Finsupp.total R (f ∘ g) l := by
   -- Porting note: `(· ∘ ·)` is required.
   simp only [Finsupp.total_apply, Finsupp.total_apply, Finsupp.sum, map_sum, map_smul, (· ∘ ·)]
 

--- a/Mathlib/LinearAlgebra/Finsupp.lean
+++ b/Mathlib/LinearAlgebra/Finsupp.lean
@@ -592,7 +592,7 @@ section Total
 variable (R)
 variable {α' : Type*} {M' : Type*} [AddCommMonoid M'] [Module R M'] (v : α → M) {v' : α' → M'}
 
-/-- Interprets (l : α →₀ R) as linear combination of the elements in the family (v : α → M) and
+/-- Interprets (l : α →₀ R) as a linear combination of the elements in the family (v : α → M) and
     evaluates this linear combination. -/
 protected def total : (α →₀ R) →ₗ[R] M :=
   Finsupp.lsum ℕ fun i => LinearMap.id.smulRight (v i)

--- a/Mathlib/LinearAlgebra/LinearDisjoint.lean
+++ b/Mathlib/LinearAlgebra/LinearDisjoint.lean
@@ -211,12 +211,12 @@ such that the family `{ m_i * n_j }` in `S` is `R`-linearly independent
 (in this result it is stated as the relevant `Finsupp.total` is injective),
 then `M` and `N` are linearly disjoint. -/
 theorem of_basis_mul' {κ ι : Type*} (m : Basis κ R M) (n : Basis ι R N)
-    (H : Function.Injective (Finsupp.total (κ × ι) S R fun i ↦ m i.1 * n i.2)) :
+    (H : Function.Injective (Finsupp.total R fun i : κ × ι ↦ (m i.1 * n i.2 : S))) :
     M.LinearDisjoint N := by
   let i0 := (finsuppTensorFinsupp' R κ ι).symm
   let i1 := TensorProduct.congr m.repr n.repr
   let i := mulMap M N ∘ₗ (i0.trans i1.symm).toLinearMap
-  have : i = Finsupp.total (κ × ι) S R fun i ↦ m i.1 * n i.2 := by
+  have : i = Finsupp.total R fun i : κ × ι ↦ (m i.1 * n i.2 : S) := by
     ext x
     simp [i, i0, i1, finsuppTensorFinsupp'_symm_single_eq_single_one_tmul]
   simp_rw [← this, i, LinearMap.coe_comp, LinearEquiv.coe_coe, EquivLike.injective_comp] at H
@@ -354,13 +354,13 @@ theorem linearIndependent_mul_of_flat_left (H : M.LinearDisjoint N) [Module.Flat
     (hn : LinearIndependent R n) : LinearIndependent R fun (i : κ × ι) ↦ (m i.1).1 * (n i.2).1 := by
   rw [LinearIndependent, LinearMap.ker_eq_bot] at hm hn ⊢
   let i0 := (finsuppTensorFinsupp' R κ ι).symm
-  let i1 := LinearMap.rTensor (ι →₀ R) (Finsupp.total κ M R m)
-  let i2 := LinearMap.lTensor M (Finsupp.total ι N R n)
+  let i1 := LinearMap.rTensor (ι →₀ R) (Finsupp.total R m)
+  let i2 := LinearMap.lTensor M (Finsupp.total R n)
   let i := mulMap M N ∘ₗ i2 ∘ₗ i1 ∘ₗ i0.toLinearMap
   have h1 : Function.Injective i1 := Module.Flat.rTensor_preserves_injective_linearMap _ hm
   have h2 : Function.Injective i2 := Module.Flat.lTensor_preserves_injective_linearMap _ hn
   have h : Function.Injective i := H.injective.comp h2 |>.comp h1 |>.comp i0.injective
-  have : i = Finsupp.total (κ × ι) S R fun i ↦ (m i.1).1 * (n i.2).1 := by
+  have : i = Finsupp.total R fun i ↦ (m i.1).1 * (n i.2).1 := by
     ext x
     simp [i, i0, i1, i2, finsuppTensorFinsupp'_symm_single_eq_single_one_tmul]
   rwa [this] at h
@@ -375,13 +375,13 @@ theorem linearIndependent_mul_of_flat_right (H : M.LinearDisjoint N) [Module.Fla
     (hn : LinearIndependent R n) : LinearIndependent R fun (i : κ × ι) ↦ (m i.1).1 * (n i.2).1 := by
   rw [LinearIndependent, LinearMap.ker_eq_bot] at hm hn ⊢
   let i0 := (finsuppTensorFinsupp' R κ ι).symm
-  let i1 := LinearMap.lTensor (κ →₀ R) (Finsupp.total ι N R n)
-  let i2 := LinearMap.rTensor N (Finsupp.total κ M R m)
+  let i1 := LinearMap.lTensor (κ →₀ R) (Finsupp.total R n)
+  let i2 := LinearMap.rTensor N (Finsupp.total R m)
   let i := mulMap M N ∘ₗ i2 ∘ₗ i1 ∘ₗ i0.toLinearMap
   have h1 : Function.Injective i1 := Module.Flat.lTensor_preserves_injective_linearMap _ hn
   have h2 : Function.Injective i2 := Module.Flat.rTensor_preserves_injective_linearMap _ hm
   have h : Function.Injective i := H.injective.comp h2 |>.comp h1 |>.comp i0.injective
-  have : i = Finsupp.total (κ × ι) S R fun i ↦ (m i.1).1 * (n i.2).1 := by
+  have : i = Finsupp.total R fun i ↦ (m i.1).1 * (n i.2).1 := by
     ext x
     simp [i, i0, i1, i2, finsuppTensorFinsupp'_symm_single_eq_single_one_tmul]
   rwa [this] at h

--- a/Mathlib/LinearAlgebra/LinearIndependent.lean
+++ b/Mathlib/LinearAlgebra/LinearIndependent.lean
@@ -21,10 +21,10 @@ This file defines linear independence in a module or vector space.
 
 It is inspired by Isabelle/HOL's linear algebra, and hence indirectly by HOL Light.
 
-We define `LinearIndependent R v` as `ker (Finsupp.total ι M R v) = ⊥`. Here `Finsupp.total` is the
+We define `LinearIndependent R v` as `ker (Finsupp.total R v) = ⊥`. Here `Finsupp.total` is the
 linear map sending a function `f : ι →₀ R` with finite support to the linear combination of vectors
 from `v` with these coefficients. Then we prove that several other statements are equivalent to this
-one, including injectivity of `Finsupp.total ι M R v` and some versions with explicitly written
+one, including injectivity of `Finsupp.total R v` and some versions with explicitly written
 linear combinations.
 
 ## Main definitions
@@ -97,7 +97,7 @@ variable (R) (v)
 
 /-- `LinearIndependent R v` states the family of vectors `v` is linearly independent over `R`. -/
 def LinearIndependent : Prop :=
-  LinearMap.ker (Finsupp.total ι M R v) = ⊥
+  LinearMap.ker (Finsupp.total R v) = ⊥
 
 open Lean PrettyPrinter.Delaborator SubExpr in
 /-- Delaborator for `LinearIndependent` that suggests pretty printing with type hints
@@ -122,7 +122,7 @@ def delabLinearIndependent : Delab :=
 variable {R} {v}
 
 theorem linearIndependent_iff :
-    LinearIndependent R v ↔ ∀ l, Finsupp.total ι M R v l = 0 → l = 0 := by
+    LinearIndependent R v ↔ ∀ l, Finsupp.total R v l = 0 → l = 0 := by
   simp [LinearIndependent, LinearMap.ker_eq_bot']
 
 theorem linearIndependent_iff' :
@@ -406,7 +406,7 @@ section Subtype
 
 theorem linearIndependent_comp_subtype {s : Set ι} :
     LinearIndependent R (v ∘ (↑) : s → M) ↔
-      ∀ l ∈ Finsupp.supported R R s, (Finsupp.total ι M R v) l = 0 → l = 0 := by
+      ∀ l ∈ Finsupp.supported R R s, (Finsupp.total R v) l = 0 → l = 0 := by
   simp only [linearIndependent_iff, (· ∘ ·), Finsupp.mem_supported, Finsupp.total_apply,
     Set.subset_def, Finset.mem_coe]
   constructor
@@ -423,7 +423,7 @@ theorem linearIndependent_comp_subtype {s : Set ι} :
 
 theorem linearDependent_comp_subtype' {s : Set ι} :
     ¬LinearIndependent R (v ∘ (↑) : s → M) ↔
-      ∃ f : ι →₀ R, f ∈ Finsupp.supported R R s ∧ Finsupp.total ι M R v f = 0 ∧ f ≠ 0 := by
+      ∃ f : ι →₀ R, f ∈ Finsupp.supported R R s ∧ Finsupp.total R v f = 0 ∧ f ≠ 0 := by
   simp [linearIndependent_comp_subtype, and_left_comm]
 
 /-- A version of `linearDependent_comp_subtype'` with `Finsupp.total` unfolded. -/
@@ -434,17 +434,17 @@ theorem linearDependent_comp_subtype {s : Set ι} :
 
 theorem linearIndependent_subtype {s : Set M} :
     LinearIndependent R (fun x => x : s → M) ↔
-      ∀ l ∈ Finsupp.supported R R s, (Finsupp.total M M R id) l = 0 → l = 0 := by
+      ∀ l ∈ Finsupp.supported R R s, (Finsupp.total R id) l = 0 → l = 0 := by
   apply linearIndependent_comp_subtype (v := id)
 
 theorem linearIndependent_comp_subtype_disjoint {s : Set ι} :
     LinearIndependent R (v ∘ (↑) : s → M) ↔
-      Disjoint (Finsupp.supported R R s) (LinearMap.ker <| Finsupp.total ι M R v) := by
+      Disjoint (Finsupp.supported R R s) (LinearMap.ker <| Finsupp.total R v) := by
   rw [linearIndependent_comp_subtype, LinearMap.disjoint_ker]
 
 theorem linearIndependent_subtype_disjoint {s : Set M} :
     LinearIndependent R (fun x => x : s → M) ↔
-      Disjoint (Finsupp.supported R R s) (LinearMap.ker <| Finsupp.total M M R id) := by
+      Disjoint (Finsupp.supported R R s) (LinearMap.ker <| Finsupp.total R id) := by
   apply linearIndependent_comp_subtype_disjoint (v := id)
 
 theorem linearIndependent_iff_totalOn {s : Set M} :
@@ -516,16 +516,16 @@ variable [Module R M] [Module R M'] [Module R M'']
 variable {a b : R} {x y : M}
 
 theorem linearIndependent_iff_injective_total :
-    LinearIndependent R v ↔ Function.Injective (Finsupp.total ι M R v) :=
+    LinearIndependent R v ↔ Function.Injective (Finsupp.total R v) :=
   linearIndependent_iff.trans
-    (injective_iff_map_eq_zero (Finsupp.total ι M R v).toAddMonoidHom).symm
+    (injective_iff_map_eq_zero (Finsupp.total R v).toAddMonoidHom).symm
 
 alias ⟨LinearIndependent.injective_total, _⟩ := linearIndependent_iff_injective_total
 
 theorem LinearIndependent.injective [Nontrivial R] (hv : LinearIndependent R v) : Injective v := by
   intro i j hij
   let l : ι →₀ R := Finsupp.single i (1 : R) - Finsupp.single j 1
-  have h_total : Finsupp.total ι M R v l = 0 := by
+  have h_total : Finsupp.total R v l = 0 := by
     simp_rw [l, LinearMap.map_sub, Finsupp.total_apply]
     simp [hij]
   have h_single_eq : Finsupp.single i (1 : R) = Finsupp.single j 1 := by
@@ -657,7 +657,7 @@ theorem LinearIndependent.eq_of_smul_apply_eq_smul_apply {M : Type*} [AddCommGro
     {v : ι → M} (li : LinearIndependent R v) (c d : R) (i j : ι) (hc : c ≠ 0)
     (h : c • v i = d • v j) : i = j := by
   let l : ι →₀ R := Finsupp.single i c - Finsupp.single j d
-  have h_total : Finsupp.total ι M R v l = 0 := by
+  have h_total : Finsupp.total R v l = 0 := by
     simp_rw [l, LinearMap.map_sub, Finsupp.total_apply]
     simp [h]
   have h_single_eq : Finsupp.single i c = Finsupp.single j d := by
@@ -690,7 +690,7 @@ theorem LinearIndependent.not_mem_span_image [Nontrivial R] (hv : LinearIndepend
   simpa using h
 
 theorem LinearIndependent.total_ne_of_not_mem_support [Nontrivial R] (hv : LinearIndependent R v)
-    {x : ι} (f : ι →₀ R) (h : x ∉ f.support) : Finsupp.total ι M R v f ≠ v x := by
+    {x : ι} (f : ι →₀ R) (h : x ∉ f.support) : Finsupp.total R v f ≠ v x := by
   replace h : x ∉ (f.support : Set ι) := h
   have p := hv.not_mem_span_image h
   intro w
@@ -803,7 +803,7 @@ variable (hv : LinearIndependent R v)
 @[simps (config := { rhsMd := default }) symm_apply]
 def LinearIndependent.totalEquiv (hv : LinearIndependent R v) :
     (ι →₀ R) ≃ₗ[R] span R (range v) := by
-  apply LinearEquiv.ofBijective (LinearMap.codRestrict (span R (range v)) (Finsupp.total ι M R v) _)
+  apply LinearEquiv.ofBijective (LinearMap.codRestrict (span R (range v)) (Finsupp.total R v) _)
   constructor
   · rw [← LinearMap.ker_eq_bot, LinearMap.ker_codRestrict]
     · apply hv
@@ -819,7 +819,7 @@ def LinearIndependent.totalEquiv (hv : LinearIndependent R v) :
 --               different from the theorem on Lean 3, and not simp-normal form.
 @[simp]
 theorem LinearIndependent.totalEquiv_apply_coe (hv : LinearIndependent R v) (l : ι →₀ R) :
-    hv.totalEquiv l = Finsupp.total ι M R v l := rfl
+    hv.totalEquiv l = Finsupp.total R v l := rfl
 
 /-- Linear combination representing a vector in the span of linearly independent vectors.
 
@@ -830,11 +830,11 @@ def LinearIndependent.repr (hv : LinearIndependent R v) : span R (range v) →�
   hv.totalEquiv.symm
 
 @[simp]
-theorem LinearIndependent.total_repr (x) : Finsupp.total ι M R v (hv.repr x) = x :=
+theorem LinearIndependent.total_repr (x) : Finsupp.total R v (hv.repr x) = x :=
   Subtype.ext_iff.1 (LinearEquiv.apply_symm_apply hv.totalEquiv x)
 
 theorem LinearIndependent.total_comp_repr :
-    (Finsupp.total ι M R v).comp hv.repr = Submodule.subtype _ :=
+    (Finsupp.total R v).comp hv.repr = Submodule.subtype _ :=
   LinearMap.ext <| hv.total_repr
 
 theorem LinearIndependent.repr_ker : LinearMap.ker hv.repr = ⊥ := by
@@ -844,10 +844,10 @@ theorem LinearIndependent.repr_range : LinearMap.range hv.repr = ⊤ := by
   rw [LinearIndependent.repr, LinearEquiv.range]
 
 theorem LinearIndependent.repr_eq {l : ι →₀ R} {x : span R (range v)}
-    (eq : Finsupp.total ι M R v l = ↑x) : hv.repr x = l := by
+    (eq : Finsupp.total R v l = ↑x) : hv.repr x = l := by
   have :
     ↑((LinearIndependent.totalEquiv hv : (ι →₀ R) →ₗ[R] span R (range v)) l) =
-      Finsupp.total ι M R v l :=
+      Finsupp.total R v l :=
     rfl
   have : (LinearIndependent.totalEquiv hv : (ι →₀ R) →ₗ[R] span R (range v)) l = x := by
     rw [eq] at this
@@ -979,12 +979,12 @@ theorem surjective_of_linearIndependent_of_span [Nontrivial R] (hv : LinearIndep
   intro i
   let repr : (span R (range (v ∘ f)) : Type _) → ι' →₀ R := (hv.comp f f.injective).repr
   let l := (repr ⟨v i, hss (mem_range_self i)⟩).mapDomain f
-  have h_total_l : Finsupp.total ι M R v l = v i := by
+  have h_total_l : Finsupp.total R v l = v i := by
     dsimp only [l]
     rw [Finsupp.total_mapDomain]
     rw [(hv.comp f f.injective).total_repr]
     -- Porting note: `rfl` isn't necessary.
-  have h_total_eq : (Finsupp.total ι M R v) l = (Finsupp.total ι M R v) (Finsupp.single i 1) := by
+  have h_total_eq : (Finsupp.total R v) l = (Finsupp.total R v) (Finsupp.single i 1) := by
     rw [h_total_l, Finsupp.total_single, one_smul]
   have l_eq : l = _ := LinearMap.ker_eq_bot.1 hv h_total_eq
   dsimp only [l] at l_eq

--- a/Mathlib/LinearAlgebra/TensorAlgebra/Basis.lean
+++ b/Mathlib/LinearAlgebra/TensorAlgebra/Basis.lean
@@ -35,7 +35,7 @@ with its index. -/
 noncomputable def equivFreeAlgebra (b : Basis κ R M) :
     TensorAlgebra R M ≃ₐ[R] FreeAlgebra R κ :=
   AlgEquiv.ofAlgHom
-    (TensorAlgebra.lift _ (Finsupp.total _ _ _ (FreeAlgebra.ι _) ∘ₗ b.repr.toLinearMap))
+    (TensorAlgebra.lift _ (Finsupp.total _ (FreeAlgebra.ι _) ∘ₗ b.repr.toLinearMap))
     (FreeAlgebra.lift _ (ι R ∘ b))
     (by ext; simp)
     (hom_ext <| b.ext fun i => by simp)

--- a/Mathlib/LinearAlgebra/TensorProduct/Submodule.lean
+++ b/Mathlib/LinearAlgebra/TensorProduct/Submodule.lean
@@ -234,13 +234,13 @@ theorem comm_trans_rTensorOne :
 
 variable {M} in
 theorem mulLeftMap_eq_mulMap_comp {ι : Type*} [DecidableEq ι] (m : ι → M) :
-    mulLeftMap N m = mulMap M N ∘ₗ LinearMap.rTensor N (Finsupp.total ι M R m) ∘ₗ
+    mulLeftMap N m = mulMap M N ∘ₗ LinearMap.rTensor N (Finsupp.total R m) ∘ₗ
       (TensorProduct.finsuppScalarLeft R N ι).symm.toLinearMap := by
   ext; simp
 
 variable {N} in
 theorem mulRightMap_eq_mulMap_comp {ι : Type*} [DecidableEq ι] (n : ι → N) :
-    mulRightMap M n = mulMap M N ∘ₗ LinearMap.lTensor M (Finsupp.total ι N R n) ∘ₗ
+    mulRightMap M n = mulMap M N ∘ₗ LinearMap.lTensor M (Finsupp.total R n) ∘ₗ
       (TensorProduct.finsuppScalarRight R M ι).symm.toLinearMap := by
   ext; simp
 

--- a/Mathlib/LinearAlgebra/TensorProduct/Vanishing.lean
+++ b/Mathlib/LinearAlgebra/TensorProduct/Vanishing.lean
@@ -102,7 +102,7 @@ vanishes, then it vanishes trivially. -/
 theorem vanishesTrivially_of_sum_tmul_eq_zero (hm : Submodule.span R (Set.range m) = ⊤)
     (hmn : ∑ i, m i ⊗ₜ n i = (0 : M ⊗[R] N)) : VanishesTrivially R m n := by
   -- Define a map $G \colon R^\iota \to M$ whose matrix entries are the $m_i$. It is surjective.
-  set G : (ι →₀ R) →ₗ[R] M := Finsupp.total ι M R m with hG
+  set G : (ι →₀ R) →ₗ[R] M := Finsupp.total R m with hG
   have G_basis_eq (i : ι) : G (Finsupp.single i 1) = m i := by simp [hG, toModule_lof]
   have G_surjective : Surjective G := by
     apply LinearMap.range_eq_top.mp

--- a/Mathlib/RepresentationTheory/GroupCohomology/Hilbert90.lean
+++ b/Mathlib/RepresentationTheory/GroupCohomology/Hilbert90.lean
@@ -55,7 +55,7 @@ variable {K L : Type*} [Field K] [Field L] [Algebra K L] [FiniteDimensional K L]
 
 /-- Given `f : Aut_K(L) → Lˣ`, the sum `∑ f(φ) • φ` for `φ ∈ Aut_K(L)`, as a function `L → L`. -/
 noncomputable def aux (f : (L ≃ₐ[K] L) → Lˣ) : L → L :=
-  Finsupp.total (L ≃ₐ[K] L) (L → L) L (fun φ => φ)
+  Finsupp.total L (fun φ : L ≃ₐ[K] L ↦ (φ : L → L))
     (Finsupp.equivFunOnFinite.symm (fun φ => (f φ : L)))
 
 theorem aux_ne_zero (f : (L ≃ₐ[K] L) → Lˣ) : aux f ≠ 0 :=

--- a/Mathlib/RepresentationTheory/GroupCohomology/Resolution.lean
+++ b/Mathlib/RepresentationTheory/GroupCohomology/Resolution.lean
@@ -565,11 +565,11 @@ def forget₂ToModuleCatHomotopyEquiv :
 
 /-- The hom of `k`-linear `G`-representations `k[G¹] → k` sending `∑ nᵢgᵢ ↦ ∑ nᵢ`. -/
 def ε : Rep.ofMulAction k G (Fin 1 → G) ⟶ Rep.trivial k G k where
-  hom := Finsupp.total _ _ _ fun _ => (1 : k)
+  hom := Finsupp.total _ fun _ => (1 : k)
   comm g := Finsupp.lhom_ext' fun _ => LinearMap.ext_ring (by
     show
-      Finsupp.total (Fin 1 → G) k k (fun _ => (1 : k)) (Finsupp.mapDomain _ (Finsupp.single _ _)) =
-        Finsupp.total (Fin 1 → G) k k (fun _ => (1 : k)) (Finsupp.single _ _)
+      Finsupp.total k (fun _ => (1 : k)) (Finsupp.mapDomain _ (Finsupp.single _ _)) =
+        Finsupp.total k (fun _ => (1 : k)) (Finsupp.single _ _)
     simp only [Finsupp.mapDomain_single, Finsupp.total_single])
 
 /-- The homotopy equivalence of complexes of `k`-modules between the standard resolution of `k` as
@@ -583,7 +583,7 @@ theorem forget₂ToModuleCatHomotopyEquiv_f_0_eq :
   convert Category.id_comp (X := (forget₂ToModuleCat k G).X 0) _
   · dsimp only [HomotopyEquiv.ofIso, compForgetAugmentedIso]
     simp only [Iso.symm_hom, eqToIso.inv, HomologicalComplex.eqToHom_f, eqToHom_refl]
-  trans (Finsupp.total _ _ _ fun _ => (1 : k)).comp ((ModuleCat.free k).map (terminal.from _))
+  trans (Finsupp.total _ fun _ => (1 : k)).comp ((ModuleCat.free k).map (terminal.from _))
   · dsimp
     erw [Finsupp.lmapDomain_total (α := Fin 1 → G) (R := k) (α' := ⊤_ Type u)
         (v := fun _ => (1 : k)) (v' := fun _ => (1 : k))

--- a/Mathlib/RingTheory/AlgebraicIndependent.lean
+++ b/Mathlib/RingTheory/AlgebraicIndependent.lean
@@ -106,8 +106,8 @@ theorem algebraMap_injective : Injective (algebraMap R A) := by
 
 theorem linearIndependent : LinearIndependent R x := by
   rw [linearIndependent_iff_injective_total]
-  have : Finsupp.total ι A R x =
-      (MvPolynomial.aeval x).toLinearMap.comp (Finsupp.total ι _ R X) := by
+  have : Finsupp.total R x =
+      (MvPolynomial.aeval x).toLinearMap.comp (Finsupp.total R X) := by
     ext
     simp
   rw [this]

--- a/Mathlib/RingTheory/Artinian.lean
+++ b/Mathlib/RingTheory/Artinian.lean
@@ -355,7 +355,7 @@ theorem isArtinian_of_fg_of_artinian {R M} [Ring R] [AddCommGroup M] [Module R M
   haveI := Classical.decEq R
   have : ∀ x ∈ s, x ∈ N := fun x hx => hs ▸ Submodule.subset_span hx
   refine @isArtinian_of_surjective _ ((↑s : Set M) →₀ R) N _ _ _ _ _ ?_ ?_ isArtinian_finsupp
-  · exact Finsupp.total (↑s : Set M) N R (fun i => ⟨i, hs ▸ subset_span i.2⟩)
+  · exact Finsupp.total R (fun i => ⟨i, hs ▸ subset_span i.2⟩)
   · rw [← LinearMap.range_eq_top, eq_top_iff,
        ← map_le_map_iff_of_injective (show Injective (Submodule.subtype N)
          from Subtype.val_injective), Submodule.map_top, range_subtype,

--- a/Mathlib/RingTheory/Finiteness.lean
+++ b/Mathlib/RingTheory/Finiteness.lean
@@ -278,8 +278,8 @@ theorem fg_of_fg_map_of_fg_inf_ker {R M P : Type*} [Ring R] [AddCommGroup M] [Mo
   rcases this with ⟨l, hl1, hl2⟩
   refine
     mem_sup.2
-      ⟨(Finsupp.total M M R id).toFun ((Finsupp.lmapDomain R R g : (P →₀ R) → M →₀ R) l), ?_,
-        x - Finsupp.total M M R id ((Finsupp.lmapDomain R R g : (P →₀ R) → M →₀ R) l), ?_,
+      ⟨(Finsupp.total R id).toFun ((Finsupp.lmapDomain R R g : (P →₀ R) → M →₀ R) l), ?_,
+        x - Finsupp.total R id ((Finsupp.lmapDomain R R g : (P →₀ R) → M →₀ R) l), ?_,
         add_sub_cancel _ _⟩
   · rw [← Set.image_id (g '' ↑t1), Finsupp.mem_span_image_iff_total]
     refine ⟨_, ?_, rfl⟩

--- a/Mathlib/RingTheory/Flat/EquationalCriterion.lean
+++ b/Mathlib/RingTheory/Flat/EquationalCriterion.lean
@@ -144,8 +144,8 @@ theorem tfae_equational_criterion : List.TFAE [
       _ = 0                                 := hfx
     obtain ⟨κ, hκ, a', y', ⟨ha'y', ha'⟩⟩ := h₄ this
     use κ, hκ
-    use Finsupp.total ι (κ →₀ R) R (fun i ↦ equivFunOnFinite.symm (a' i))
-    use Finsupp.total κ M R y'
+    use Finsupp.total R (fun i ↦ equivFunOnFinite.symm (a' i))
+    use Finsupp.total R y'
     constructor
     · apply Finsupp.basisSingleOne.ext
       intro i
@@ -156,7 +156,7 @@ theorem tfae_equational_criterion : List.TFAE [
   tfae_have 5 → 4
   · intro h₅ ι hi f x hfx
     let f' : ι →₀ R := equivFunOnFinite.symm f
-    let x' : (ι →₀ R) →ₗ[R] M := Finsupp.total ι M R x
+    let x' : (ι →₀ R) →ₗ[R] M := Finsupp.total R x
     have : x' f' = 0 := by simpa [x', f', total_apply, sum_fintype] using hfx
     obtain ⟨κ, hκ, a', y', ha'y', ha'⟩ := h₅ this
     refine ⟨κ, hκ, fun i ↦ a' (single i 1), fun j ↦ y' (single j 1), fun i ↦ ?_, fun j ↦ ?_⟩

--- a/Mathlib/RingTheory/Ideal/Operations.lean
+++ b/Mathlib/RingTheory/Ideal/Operations.lean
@@ -1187,7 +1187,7 @@ variable (v : ι → M) (hv : Submodule.span R (Set.range v) = ⊤)
 
 /-- A variant of `Finsupp.total` that takes in vectors valued in `I`. -/
 noncomputable def finsuppTotal : (ι →₀ I) →ₗ[R] M :=
-  (Finsupp.total ι M R v).comp (Finsupp.mapRange.linearMap I.subtype)
+  (Finsupp.total R v).comp (Finsupp.mapRange.linearMap I.subtype)
 
 variable {ι M v}
 

--- a/Mathlib/RingTheory/Kaehler/Basic.lean
+++ b/Mathlib/RingTheory/Kaehler/Basic.lean
@@ -557,7 +557,7 @@ theorem KaehlerDifferential.derivationQuotKerTotal_apply (x) :
 
 theorem KaehlerDifferential.derivationQuotKerTotal_lift_comp_total :
     (KaehlerDifferential.derivationQuotKerTotal R S).liftKaehlerDifferential.comp
-        (Finsupp.total S (Ω[S⁄R]) S (KaehlerDifferential.D R S)) =
+        (Finsupp.total S (KaehlerDifferential.D R S)) =
       Submodule.mkQ _ := by
   apply Finsupp.lhom_ext
   intro a b
@@ -565,7 +565,7 @@ theorem KaehlerDifferential.derivationQuotKerTotal_lift_comp_total :
   simp [KaehlerDifferential.derivationQuotKerTotal_apply]
 
 theorem KaehlerDifferential.kerTotal_eq :
-    LinearMap.ker (Finsupp.total S (Ω[S⁄R]) S (KaehlerDifferential.D R S)) =
+    LinearMap.ker (Finsupp.total S (KaehlerDifferential.D R S)) =
       KaehlerDifferential.kerTotal R S := by
   apply le_antisymm
   · conv_rhs => rw [← (KaehlerDifferential.kerTotal R S).ker_mkQ]
@@ -575,7 +575,7 @@ theorem KaehlerDifferential.kerTotal_eq :
     rintro _ ((⟨⟨x, y⟩, rfl⟩ | ⟨⟨x, y⟩, rfl⟩) | ⟨x, rfl⟩) <;> dsimp <;> simp [LinearMap.mem_ker]
 
 theorem KaehlerDifferential.total_surjective :
-    Function.Surjective (Finsupp.total S (Ω[S⁄R]) S (KaehlerDifferential.D R S)) := by
+    Function.Surjective (Finsupp.total S (KaehlerDifferential.D R S)) := by
   rw [← LinearMap.range_eq_top, Finsupp.range_total, KaehlerDifferential.span_range_derivation]
 
 /-- `Ω[S⁄R]` is isomorphic to `S` copies of `S` with kernel `KaehlerDifferential.kerTotal`. -/
@@ -583,7 +583,7 @@ theorem KaehlerDifferential.total_surjective :
 noncomputable def KaehlerDifferential.quotKerTotalEquiv :
     ((S →₀ S) ⧸ KaehlerDifferential.kerTotal R S) ≃ₗ[S] Ω[S⁄R] :=
   { (KaehlerDifferential.kerTotal R S).liftQ
-      (Finsupp.total S (Ω[S⁄R]) S (KaehlerDifferential.D R S))
+      (Finsupp.total S (KaehlerDifferential.D R S))
       (KaehlerDifferential.kerTotal_eq R S).ge with
     invFun := (KaehlerDifferential.derivationQuotKerTotal R S).liftKaehlerDifferential
     left_inv := by
@@ -704,7 +704,7 @@ theorem KaehlerDifferential.map_D (x : A) :
 theorem KaehlerDifferential.ker_map :
     LinearMap.ker (KaehlerDifferential.map R S A B) =
       (((kerTotal S B).restrictScalars A).comap finsupp_map).map
-        (Finsupp.total A (Ω[A⁄R]) A (D R A)) := by
+        (Finsupp.total (M := Ω[A⁄R]) A (D R A)) := by
   rw [← Submodule.map_comap_eq_of_surjective (total_surjective R A) (LinearMap.ker _)]
   congr 1
   ext x
@@ -720,7 +720,7 @@ theorem KaehlerDifferential.ker_map :
 
 lemma KaehlerDifferential.ker_map_of_surjective (h : Function.Surjective (algebraMap A B)) :
     LinearMap.ker (map R R A B) =
-      (LinearMap.ker finsupp_map).map (Finsupp.total A _ A (D R A)) := by
+      (LinearMap.ker finsupp_map).map (Finsupp.total A (D R A)) := by
   rw [ker_map, ← kerTotal_map' R A B h, Submodule.comap_map_eq, Submodule.map_sup,
     Submodule.map_sup, ← kerTotal_eq, ← Submodule.comap_bot,
     Submodule.map_comap_eq_of_surjective (total_surjective _ _),
@@ -770,7 +770,7 @@ lemma KaehlerDifferential.range_mapBaseChange :
       · simp [smul_add, *]
       · simp
     · rw [map_add]; exact add_mem ‹_› ‹_›
-  · convert_to (kerTotal A B).map (Finsupp.total B (Ω[B⁄R]) B (D R B)) ≤ _
+  · convert_to (kerTotal A B).map (Finsupp.total B (D R B)) ≤ _
     · rw [KaehlerDifferential.ker_map]
       congr 1
       convert Submodule.comap_id _

--- a/Mathlib/RingTheory/Kaehler/Polynomial.lean
+++ b/Mathlib/RingTheory/Kaehler/Polynomial.lean
@@ -27,7 +27,7 @@ section MvPolynomial
 def KaehlerDifferential.mvPolynomialEquiv (σ : Type*) :
     Ω[MvPolynomial σ R⁄R] ≃ₗ[MvPolynomial σ R] σ →₀ MvPolynomial σ R where
   __ := (MvPolynomial.mkDerivation _ (Finsupp.single · 1)).liftKaehlerDifferential
-  invFun := Finsupp.total σ _ _ (fun x ↦ D _ _ (MvPolynomial.X x))
+  invFun := Finsupp.total (α := σ) _ (fun x ↦ D _ _ (MvPolynomial.X x))
   right_inv := by
     intro x
     induction' x using Finsupp.induction_linear with _ _ _ _ a b

--- a/Mathlib/RingTheory/LocalRing/Module.lean
+++ b/Mathlib/RingTheory/LocalRing/Module.lean
@@ -152,7 +152,7 @@ theorem free_of_maximalIdeal_rTensor_injective [Module.FinitePresentation R M]
     isNoetherian_of_isNoetherianRing_of_finite k (k ⊗[R] (I →₀ R))
   choose f hf using TensorProduct.mk_surjective R M k Ideal.Quotient.mk_surjective
   -- By choosing an arbitrary lift of `b` to `I → M`, we get a surjection `i : Rᴵ → M`.
-  let i := Finsupp.total I M R (f ∘ b)
+  let i := Finsupp.total R (f ∘ b)
   have hi : Surjective i := by
     rw [← LinearMap.range_eq_top, Finsupp.range_total]
     exact LocalRing.span_eq_top_of_tmul_eq_basis (R := R) (f := f ∘ b) b (fun _ ↦ hf _)

--- a/Mathlib/RingTheory/Unramified/Finite.lean
+++ b/Mathlib/RingTheory/Unramified/Finite.lean
@@ -90,7 +90,7 @@ lemma finite_of_free_aux (I) [DecidableEq I] (b : Basis I R S)
   let a i := b.repr (b i * x)
   conv_lhs =>
     simp only [TensorProduct.tmul_mul_tmul, one_mul, mul_comm x (b _),
-      ← show ∀ i, Finsupp.total _ _ _ b (a i) = b i * x from fun _ ↦ b.total_repr _]
+      ← show ∀ i, Finsupp.total _ b (a i) = b i * x from fun _ ↦ b.total_repr _]
   conv_lhs => simp only [Finsupp.total, Finsupp.coe_lsum,
     LinearMap.coe_smulRight, LinearMap.id_coe, id_eq, Finsupp.sum, TensorProduct.tmul_sum,
     ← TensorProduct.smul_tmul]


### PR DESCRIPTION
See discussion at https://leanprover.zulipchat.com/#narrow/stream/287929-mathlib4/topic/Finsupp.2Etotal.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
