### PR TITLE
[Merged by Bors] - feat(Order/*): `CovBy` and `OrderIso`

### DIFF
--- a/Mathlib/Order/Cover.lean
+++ b/Mathlib/Order/Cover.lean
@@ -127,6 +127,13 @@ alias ⟨_, WCovBy.toDual⟩ := toDual_wcovBy_toDual_iff
 
 alias ⟨_, WCovBy.ofDual⟩ := ofDual_wcovBy_ofDual_iff
 
+theorem OrderIso.map_wcovBy {α β : Type*} [Preorder α] [Preorder β]
+    (f : α ≃o β) {x y : α} (h : x ⩿ y) : f x ⩿ f y := by
+  use f.monotone h.1
+  intro a
+  rw [← f.apply_symm_apply a, f.lt_iff_lt, f.lt_iff_lt]
+  apply h.2
+
 end Preorder
 
 section PartialOrder
@@ -312,6 +319,13 @@ theorem apply_covBy_apply_iff {E : Type*} [EquivLike E α β] [OrderIsoClass E �
 
 theorem covBy_of_eq_or_eq (hab : a < b) (h : ∀ c, a ≤ c → c ≤ b → c = a ∨ c = b) : a ⋖ b :=
   ⟨hab, fun c ha hb => (h c ha.le hb.le).elim ha.ne' hb.ne⟩
+
+theorem OrderIso.map_covBy {α β : Type*} [Preorder α] [Preorder β]
+    (f : α ≃o β) {x y : α} (h : x ⋖ y) : f x ⋖ f y := by
+  use f.strictMono h.1
+  intro a
+  rw [← f.apply_symm_apply a, f.lt_iff_lt, f.lt_iff_lt]
+  apply h.2
 
 end Preorder
 

--- a/Mathlib/Order/Cover.lean
+++ b/Mathlib/Order/Cover.lean
@@ -127,12 +127,18 @@ alias ⟨_, WCovBy.toDual⟩ := toDual_wcovBy_toDual_iff
 
 alias ⟨_, WCovBy.ofDual⟩ := ofDual_wcovBy_ofDual_iff
 
-theorem OrderIso.map_wcovBy {α β : Type*} [Preorder α] [Preorder β]
-    (f : α ≃o β) {x y : α} (h : x ⩿ y) : f x ⩿ f y := by
-  use f.monotone h.1
+theorem OrderEmbedding.wcovBy_of_apply {α β : Type*} [Preorder α] [Preorder β]
+    (f : α ↪o β) {x y : α} (h : f x ⩿ f y) : x ⩿ y := by
+  use f.le_iff_le.1 h.1
   intro a
-  rw [← f.apply_symm_apply a, f.lt_iff_lt, f.lt_iff_lt]
+  rw [← f.lt_iff_lt, ← f.lt_iff_lt]
   apply h.2
+
+theorem OrderIso.map_wcovBy {α β : Type*} [Preorder α] [Preorder β]
+    (f : α ≃o β) {x y : α} : f x ⩿ f y ↔ x ⩿ y := by
+  use f.toOrderEmbedding.wcovBy_of_apply
+  conv_lhs => rw [← f.symm_apply_apply x, ← f.symm_apply_apply y]
+  exact f.symm.toOrderEmbedding.wcovBy_of_apply
 
 end Preorder
 
@@ -320,12 +326,18 @@ theorem apply_covBy_apply_iff {E : Type*} [EquivLike E α β] [OrderIsoClass E �
 theorem covBy_of_eq_or_eq (hab : a < b) (h : ∀ c, a ≤ c → c ≤ b → c = a ∨ c = b) : a ⋖ b :=
   ⟨hab, fun c ha hb => (h c ha.le hb.le).elim ha.ne' hb.ne⟩
 
-theorem OrderIso.map_covBy {α β : Type*} [Preorder α] [Preorder β]
-    (f : α ≃o β) {x y : α} (h : x ⋖ y) : f x ⋖ f y := by
-  use f.strictMono h.1
+theorem OrderEmbedding.covBy_of_apply {α β : Type*} [Preorder α] [Preorder β]
+    (f : α ↪o β) {x y : α} (h : f x ⋖ f y) : x ⋖ y := by
+  use f.lt_iff_lt.1 h.1
   intro a
-  rw [← f.apply_symm_apply a, f.lt_iff_lt, f.lt_iff_lt]
+  rw [← f.lt_iff_lt, ← f.lt_iff_lt]
   apply h.2
+
+theorem OrderIso.map_covBy {α β : Type*} [Preorder α] [Preorder β]
+    (f : α ≃o β) {x y : α} : f x ⋖ f y ↔ x ⋖ y := by
+  use f.toOrderEmbedding.covBy_of_apply
+  conv_lhs => rw [← f.symm_apply_apply x, ← f.symm_apply_apply y]
+  exact f.symm.toOrderEmbedding.covBy_of_apply
 
 end Preorder
 

--- a/Mathlib/Order/Hom/Basic.lean
+++ b/Mathlib/Order/Hom/Basic.lean
@@ -1097,6 +1097,18 @@ theorem OrderIso.map_sup [SemilatticeSup α] [SemilatticeSup β] (f : α ≃o β
     f (x ⊔ y) = f x ⊔ f y :=
   f.dual.map_inf x y
 
+theorem OrderIso.isMax_apply {α β : Type*} [Preorder α] [Preorder β] (f : α ≃o β) {x : α} :
+    IsMax (f x) ↔ IsMax x := by
+  refine ⟨f.strictMono.isMax_of_apply, ?_⟩
+  conv_lhs => rw [← f.symm_apply_apply x]
+  exact f.symm.strictMono.isMax_of_apply
+
+theorem OrderIso.isMin_apply {α β : Type*} [Preorder α] [Preorder β] (f : α ≃o β) {x : α} :
+    IsMin (f x) ↔ IsMin x := by
+  refine ⟨f.strictMono.isMin_of_apply, ?_⟩
+  conv_lhs => rw [← f.symm_apply_apply x]
+  exact f.symm.strictMono.isMin_of_apply
+
 /-- Note that this goal could also be stated `(Disjoint on f) a b` -/
 theorem Disjoint.map_orderIso [SemilatticeInf α] [OrderBot α] [SemilatticeInf β] [OrderBot β]
     {a b : α} (f : α ≃o β) (ha : Disjoint a b) : Disjoint (f a) (f b) := by

--- a/Mathlib/Order/SuccPred/Basic.lean
+++ b/Mathlib/Order/SuccPred/Basic.lean
@@ -351,7 +351,7 @@ theorem _root_.OrderIso.map_succ {β : Type*} [PartialOrder β] [SuccOrder β] (
     f (succ a) = succ (f a) := by
   by_cases h : IsMax a
   · rw [h.succ_eq, (f.isMax_apply.2 h).succ_eq]
-  · exact (f.map_covBy <| covBy_succ_of_not_isMax h).succ_eq.symm
+  · exact (f.map_covBy.2 <| covBy_succ_of_not_isMax h).succ_eq.symm
 
 section NoMaxOrder
 

--- a/Mathlib/Order/SuccPred/Basic.lean
+++ b/Mathlib/Order/SuccPred/Basic.lean
@@ -347,6 +347,12 @@ lemma succ_eq_of_covBy (h : a ⋖ b) : succ a = b := (succ_le_of_lt h.lt).antisy
 
 alias _root_.CovBy.succ_eq := succ_eq_of_covBy
 
+theorem _root_.OrderIso.map_succ {β : Type*} [PartialOrder β] [SuccOrder β] (f : α ≃o β) (a : α) :
+    f (succ a) = succ (f a) := by
+  by_cases h : IsMax a
+  · rw [h.succ_eq, (f.isMax_apply.2 h).succ_eq]
+  · exact (f.map_covBy <| covBy_succ_of_not_isMax h).succ_eq.symm
+
 section NoMaxOrder
 
 variable [NoMaxOrder α]
@@ -715,6 +721,10 @@ theorem pred_le_le_iff {a b : α} : pred a ≤ b ∧ b ≤ a ↔ b = a ∨ b = p
 lemma pred_eq_of_covBy (h : a ⋖ b) : pred b = a := h.wcovBy.pred_le.antisymm (le_pred_of_lt h.lt)
 
 alias _root_.CovBy.pred_eq := pred_eq_of_covBy
+
+theorem _root_.OrderIso.map_pred {β : Type*} [PartialOrder β] [PredOrder β] (f : α ≃o β) (a : α) :
+    f (pred a) = pred (f a) :=
+  f.dual.map_succ a
 
 section NoMinOrder
 


### PR DESCRIPTION
We show that order isomorphisms map maximum elements, the covering relation, and successors.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
