### PR TITLE
[Merged by Bors] - feat(NumberTheory/JacobiSum/Basic): more Jacobi sum values

### DIFF
--- a/Mathlib/NumberTheory/JacobiSum/Basic.lean
+++ b/Mathlib/NumberTheory/JacobiSum/Basic.lean
@@ -145,8 +145,8 @@ theorem jacobiSum_nontrivial_inv {χ : MulChar F R} (hχ : χ ≠ 1) : jacobiSum
   rw [this, ← add_eq_zero_iff_eq_neg, ← sum_eq_sum_diff_singleton_add (mem_univ (-1 : F))]
   exact MulChar.sum_eq_zero_of_ne_one hχ
 
-/-- If `χ` and `ψ` are multiplicative characters on a finite field `F` such that
-`χψ` is nontrivial, then `g(χψ) * J(χ,ψ) = g(χ) * g(ψ)`. -/
+/-- If `χ` and `φ` are multiplicative characters on a finite field `F` such that
+`χφ` is nontrivial, then `g(χφ) * J(χ,φ) = g(χ) * g(φ)`. -/
 theorem jacobiSum_mul_nontrivial {χ φ : MulChar F R} (h : χ * φ ≠ 1) (ψ : AddChar F R) :
     gaussSum (χ * φ) ψ * jacobiSum χ φ = gaussSum χ ψ * gaussSum φ ψ := by
   rw [gaussSum_mul _ _ ψ, sum_eq_sum_diff_singleton_add (mem_univ (0 : F))]

--- a/Mathlib/NumberTheory/JacobiSum/Basic.lean
+++ b/Mathlib/NumberTheory/JacobiSum/Basic.lean
@@ -111,12 +111,14 @@ variable [IsDomain R] -- needed for `MulChar.sum_eq_zero_of_ne_one`
 
 /-- If `χ` is a nontrivial multiplicative character on a finite field `F`, then `J(1,χ) = -1`. -/
 theorem jacobiSum_one_nontrivial {χ : MulChar F R} (hχ : χ ≠ 1) : jacobiSum 1 χ = -1 := by
-  rw [jacobiSum_eq_aux, MulChar.sum_eq_zero_of_ne_one hχ, MulChar.sum_one_eq_card_units,
-    Fintype.card_eq_card_units_add_one (α := F), add_zero, Nat.cast_add, Nat.cast_one,
-    ← sub_sub, sub_self, zero_sub, add_right_eq_self]
-  convert sum_const_zero with x hx
-  simp only [mem_sdiff, mem_univ, mem_insert, mem_singleton, not_or, true_and] at hx
-  rw [MulChar.one_apply <| isUnit_iff_ne_zero.mpr hx.1, sub_self, zero_mul]
+  have : ∑ x ∈ univ \ {0, 1}, ((1 : MulChar F R) x - 1) * (χ (1 - x) - 1) = 0 := by
+    apply Finset.sum_eq_zero
+    simp (config := { contextual := true }) only [mem_sdiff, mem_univ, mem_insert, mem_singleton,
+      not_or, ← isUnit_iff_ne_zero, true_and, MulChar.one_apply, sub_self, zero_mul, and_imp,
+      implies_true]
+  simp only [jacobiSum_eq_aux, MulChar.sum_one_eq_card_units, MulChar.sum_eq_zero_of_ne_one hχ,
+    add_zero, Fintype.card_eq_card_units_add_one (α := F), Nat.cast_add, Nat.cast_one,
+    sub_add_cancel_left, this]
 
 /-- If `χ` is a nontrivial multiplicative character on a finite field `F`,
 then `J(χ,χ⁻¹) = -χ(-1)`. -/

--- a/Mathlib/NumberTheory/JacobiSum/Basic.lean
+++ b/Mathlib/NumberTheory/JacobiSum/Basic.lean
@@ -58,18 +58,19 @@ end Def
 ### Jacobi sums over finite fields
 -/
 
-section FiniteField
+section CommRing
 
-variable {F R : Type*} [Field F] [Fintype F] [DecidableEq F] [CommRing R]
+variable {F R : Type*} [CommRing F] [Nontrivial F] [Fintype F] [DecidableEq F] [CommRing R]
 
-/-- The Jacobi sum of two multiplicative characters on a finite field `F` can be written
-as a sum over `F \ {0,1}`. -/
+/-- The Jacobi sum of two multiplicative characters on a nontrivial finite commutative ring `F`
+can be written as a sum over `F \ {0,1}`. -/
 lemma jacobiSum_eq_sum_sdiff (χ ψ : MulChar F R) :
     jacobiSum χ ψ = ∑ x ∈ univ \ {0,1}, χ x * ψ (1 - x) := by
-  simp only [jacobiSum, subset_univ, sum_sdiff_eq_sub, mem_singleton, zero_ne_one,
-    not_false_eq_true, sum_insert, isUnit_iff_ne_zero, ne_eq, not_true_eq_false,
-    MulCharClass.map_nonunit, sub_zero, map_one, mul_one, sum_singleton, sub_self, mul_zero,
-    add_zero]
+  simp only [jacobiSum, subset_univ, sum_sdiff_eq_sub, sub_eq_add_neg, self_eq_add_right,
+    neg_eq_zero]
+  apply sum_eq_zero
+  simp only [mem_insert, mem_singleton, forall_eq_or_imp, χ.map_zero, neg_zero, add_zero, map_one,
+    mul_one, forall_eq, add_neg_cancel, ψ.map_zero, mul_zero, and_self]
 
 private lemma jacobiSum_eq_aux (χ ψ : MulChar F R) :
     jacobiSum χ ψ = ∑ x : F, χ x + ∑ x : F, ψ x - Fintype.card F +
@@ -84,6 +85,12 @@ private lemma jacobiSum_eq_aux (χ ψ : MulChar F R) :
     sum_sdiff_eq_sub (subset_univ _), ← sub_zero (_ - _ + _), add_sub_assoc]
   congr
   rw [sum_pair zero_ne_one, sub_zero, ψ.map_one, χ.map_one, sub_self, mul_zero, zero_mul, add_zero]
+
+end CommRing
+
+section FiniteField
+
+variable {F R : Type*} [Field F] [Fintype F] [DecidableEq F] [CommRing R]
 
 /-- The Jacobi sum of twice the trivial multiplicative character on a finite field `F`
 equals `#F-2`. -/


### PR DESCRIPTION
This adds more results on Jacobi sums.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
