### PR TITLE
[Merged by Bors] - feat(CategoryTheory.Bicategory.Strict): remove simp attribute from `associator_eqToIso`

### DIFF
--- a/Mathlib/CategoryTheory/Bicategory/LocallyDiscrete.lean
+++ b/Mathlib/CategoryTheory/Bicategory/LocallyDiscrete.lean
@@ -106,6 +106,9 @@ instance locallyDiscreteBicategory.strict : Strict (LocallyDiscrete C) where
   comp_id f := Discrete.ext (Category.comp_id _)
   assoc f g h := Discrete.ext (Category.assoc _ _ _)
 
+attribute [local simp]
+  Strict.leftUnitor_eqToIso Strict.rightUnitor_eqToIso Strict.associator_eqToIso
+
 variable {I : Type u₁} [Category.{v₁} I] {B : Type u₂} [Bicategory.{w₂, v₂} B] [Strict B]
 
 /--

--- a/Mathlib/CategoryTheory/Bicategory/Strict.lean
+++ b/Mathlib/CategoryTheory/Bicategory/Strict.lean
@@ -50,15 +50,6 @@ class Bicategory.Strict : Prop where
     ∀ {a b c d : B} (f : a ⟶ b) (g : b ⟶ c) (h : c ⟶ d), α_ f g h = eqToIso (assoc f g h) := by
     aesop_cat
 
--- Porting note: not adding simp to:
--- Bicategory.Strict.id_comp
--- Bicategory.Strict.comp_id
--- Bicategory.Strict.assoc
-attribute [simp]
-   Bicategory.Strict.leftUnitor_eqToIso
-   Bicategory.Strict.rightUnitor_eqToIso
-   Bicategory.Strict.associator_eqToIso
-
 -- see Note [lower instance priority]
 /-- Category structure on a strict bicategory -/
 instance (priority := 100) StrictBicategory.category [Bicategory.Strict B] : Category B where


### PR DESCRIPTION
Context: https://leanprover.zulipchat.com/#narrow/stream/287929-mathlib4/topic/.60comp_id.60.20in.20.60Cat.60/near/444866404

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
