### PR TITLE
[Merged by Bors] - feat(ContinuousFunctionalCalculus): show that the non-unital CFC commutes with integration

### DIFF
--- a/Mathlib/Analysis/CStarAlgebra/ContinuousFunctionalCalculus/Integral.lean
+++ b/Mathlib/Analysis/CStarAlgebra/ContinuousFunctionalCalculus/Integral.lean
@@ -6,6 +6,7 @@ Authors: Frédéric Dupuis
 
 import Mathlib.Analysis.Normed.Algebra.Spectrum
 import Mathlib.Analysis.CStarAlgebra.ContinuousFunctionalCalculus.Unital
+import Mathlib.Analysis.CStarAlgebra.ContinuousFunctionalCalculus.NonUnital
 import Mathlib.MeasureTheory.Integral.SetIntegral
 
 /-!
@@ -19,15 +20,29 @@ that the integral commutes with the continuous functional calculus under appropr
 + `cfc_integral`: given a function `f : X → 𝕜 → 𝕜`, we have that
   `cfc (fun r => ∫ x, f x r ∂μ) a = ∫ x, cfc (f x) a ∂μ`
   under appropriate conditions
++ `cfcₙ_integral`: given a function `f : X → 𝕜 → 𝕜`, we have that
+  `cfcₙ (fun r => ∫ x, f x r ∂μ) a = ∫ x, cfcₙ (f x) a ∂μ`
+  under appropriate conditions
 
 ## TODO
 
-+ Prove a similar result for the non-unital case
 + Lift this to the case where the CFC is over `ℝ≥0`
 + Use this to prove operator monotonicity and concavity/convexity of `rpow` and `log`
 -/
 
 open MeasureTheory
+
+open scoped ContinuousMapZero
+
+theorem ContinuousMapZero.integral_apply {X Y R : Type*} [MeasurableSpace X]
+    {μ : MeasureTheory.Measure X} [NormedCommRing R] [TopologicalSpace Y] [Zero Y]
+    [CompactSpace Y] [NormedAlgebra ℝ R] [CompleteSpace R] {f : X → C(Y, R)₀}
+    (hf : MeasureTheory.Integrable f μ) (y : Y) :
+    (∫ (x : X), f x ∂μ) y = ∫ (x : X), (f x) y ∂μ := by
+  calc (∫ x, f x ∂μ) y = ContinuousMapZero.evalCLM ℝ y (∫ x, f x ∂μ) := rfl
+    _ = ∫ x, ContinuousMapZero.evalCLM ℝ y (f x) ∂μ :=
+          (ContinuousLinearMap.integral_comp_comm _ hf).symm
+    _ = _ := rfl
 
 section unital
 
@@ -36,12 +51,14 @@ variable {X : Type*} {𝕜 : Type*} {A : Type*} {p : A → Prop} [RCLike 𝕜]
   [NormedRing A] [StarRing A] [NormedAlgebra 𝕜 A] [NormedAlgebra ℝ A] [CompleteSpace A]
   [ContinuousFunctionalCalculus 𝕜 p]
 
-lemma cfcL_integral (a : A) (f : X → C(spectrum 𝕜 a, 𝕜)) (hf₁ : Integrable f μ) (ha : p a) :
-    ∫ x, cfcL ha (f x) ∂μ = cfcL ha (∫ x, f x ∂μ) := by
+lemma cfcL_integral (a : A) (f : X → C(spectrum 𝕜 a, 𝕜)) (hf₁ : Integrable f μ)
+    (ha : p a := by cfc_tac) :
+    ∫ x, cfcL (a := a) ha (f x) ∂μ = cfcL (a := a) ha (∫ x, f x ∂μ) := by
   rw [ContinuousLinearMap.integral_comp_comm _ hf₁]
 
-lemma cfcHom_integral (a : A) (f : X → C(spectrum 𝕜 a, 𝕜)) (hf₁ : Integrable f μ) (ha : p a) :
-    ∫ x, cfcHom ha (f x) ∂μ = cfcHom ha (∫ x, f x ∂μ) :=
+lemma cfcHom_integral (a : A) (f : X → C(spectrum 𝕜 a, 𝕜)) (hf₁ : Integrable f μ)
+    (ha : p a := by cfc_tac) :
+    ∫ x, cfcHom (a := a) ha (f x) ∂μ = cfcHom (a := a) ha (∫ x, f x ∂μ) :=
   cfcL_integral a f hf₁ ha
 
 open ContinuousMap in
@@ -80,3 +97,61 @@ lemma cfc_integral' [TopologicalSpace X] [OpensMeasurableSpace X] (f : X → �
   · exact ContinuousMap.curry ⟨_, hf⟩ |>.continuous
 
 end unital
+
+section nonunital
+
+variable {X : Type*} {𝕜 : Type*} {A : Type*} {p : A → Prop} [RCLike 𝕜]
+  [MeasurableSpace X] {μ : Measure X} [NonUnitalNormedRing A] [StarRing A] [CompleteSpace A]
+  [NormedSpace 𝕜 A] [NormedSpace ℝ A] [IsScalarTower 𝕜 A A] [SMulCommClass 𝕜 A A]
+  [NonUnitalContinuousFunctionalCalculus 𝕜 p]
+
+lemma cfcₙL_integral (a : A) (f : X → C(quasispectrum 𝕜 a, 𝕜)₀) (hf₁ : Integrable f μ)
+      (ha : p a := by cfc_tac) :
+      ∫ x, cfcₙL (a := a) ha (f x) ∂μ = cfcₙL (a := a) ha (∫ x, f x ∂μ) := by
+  rw [ContinuousLinearMap.integral_comp_comm _ hf₁]
+
+lemma cfcₙHom_integral (a : A) (f : X → C(quasispectrum 𝕜 a, 𝕜)₀) (hf₁ : Integrable f μ)
+    (ha : p a := by cfc_tac) :
+    ∫ x, cfcₙHom (a := a) ha (f x) ∂μ = cfcₙHom (a := a) ha (∫ x, f x ∂μ) :=
+  cfcₙL_integral a f hf₁ ha
+
+open ContinuousMapZero in
+/-- The non-unital continuous functional calculus commutes with integration. -/
+lemma cfcₙ_integral [TopologicalSpace X] [OpensMeasurableSpace X] (f : X → 𝕜 → 𝕜)
+    (bound : X → ℝ) (a : A) [SecondCountableTopologyEither X C(quasispectrum 𝕜 a, 𝕜)₀]
+    (hf₁ : ∀ x, ContinuousOn (f x) (quasispectrum 𝕜 a))
+    (hf₂ : ∀ x, f x 0 = 0)
+    (hf₃ : Continuous (fun x ↦ (⟨⟨_, hf₁ x |>.restrict⟩, hf₂ x⟩ : C(quasispectrum 𝕜 a, 𝕜)₀)))
+    (hbound : ∀ x, ∀ z ∈ quasispectrum 𝕜 a, ‖f x z‖ ≤ ‖bound x‖)
+    (hbound_finite_integral : HasFiniteIntegral bound μ) (ha : p a := by cfc_tac) :
+    cfcₙ (fun r => ∫ x, f x r ∂μ) a = ∫ x, cfcₙ (f x) a ∂μ := by
+  let fc : X → C(quasispectrum 𝕜 a, 𝕜)₀ := fun x => ⟨⟨_, (hf₁ x).restrict⟩, hf₂ x⟩
+  have fc_integrable : Integrable fc μ := by
+    refine ⟨hf₃.aestronglyMeasurable, ?_⟩
+    refine hbound_finite_integral.mono <| .of_forall fun x ↦ ?_
+    change ‖(fc x : C(quasispectrum  𝕜 a, 𝕜))‖ ≤ ‖bound x‖
+    rw [ContinuousMap.norm_le _ (norm_nonneg (bound x))]
+    exact fun z ↦ hbound x z.1 z.2
+  have h_int_fc : (quasispectrum 𝕜 a).restrict (∫ x, f x · ∂μ) = ∫ x, fc x ∂μ := by
+    ext; simp [integral_apply fc_integrable, fc]
+  have hcont₂ : ContinuousOn (fun r => ∫ x, f x r ∂μ) (quasispectrum 𝕜 a) := by
+    rw [continuousOn_iff_continuous_restrict]
+    convert map_continuous (∫ x, fc x ∂μ)
+  rw [integral_congr_ae (.of_forall fun _ ↦ cfcₙ_apply ..), cfcₙ_apply ..,
+    cfcₙHom_integral _ _ fc_integrable]
+  congr
+
+/-- The non-unital continuous functional calculus commutes with integration. -/
+lemma cfcₙ_integral' [TopologicalSpace X] [OpensMeasurableSpace X] (f : X → 𝕜 → 𝕜)
+    (bound : X → ℝ) (a : A) [SecondCountableTopologyEither X C(quasispectrum 𝕜 a, 𝕜)₀]
+    (hf : Continuous (fun x => (quasispectrum 𝕜 a).restrict (f x)).uncurry)
+    (hf₂ : ∀ x, f x 0 = 0)
+    (hbound : ∀ x, ∀ z ∈ quasispectrum 𝕜 a, ‖f x z‖ ≤ ‖bound x‖)
+    (hbound_finite_integral : HasFiniteIntegral bound μ) (ha : p a := by cfc_tac) :
+    cfcₙ (fun r => ∫ x, f x r ∂μ) a = ∫ x, cfcₙ (f x) a ∂μ := by
+  refine cfcₙ_integral f bound a ?_ hf₂ ?_ hbound hbound_finite_integral
+  · exact (continuousOn_iff_continuous_restrict.mpr <| hf.uncurry_left ·)
+  · sorry
+    --exact ContinuousMap.curry ⟨_, hf⟩ |>.continuous
+
+end nonunital

--- a/Mathlib/Analysis/CStarAlgebra/ContinuousFunctionalCalculus/Integral.lean
+++ b/Mathlib/Analysis/CStarAlgebra/ContinuousFunctionalCalculus/Integral.lean
@@ -31,18 +31,7 @@ that the integral commutes with the continuous functional calculus under appropr
 -/
 
 open MeasureTheory
-
 open scoped ContinuousMapZero
-
-theorem ContinuousMapZero.integral_apply {X Y R : Type*} [MeasurableSpace X]
-    {μ : MeasureTheory.Measure X} [NormedCommRing R] [TopologicalSpace Y] [Zero Y]
-    [CompactSpace Y] [NormedAlgebra ℝ R] [CompleteSpace R] {f : X → C(Y, R)₀}
-    (hf : MeasureTheory.Integrable f μ) (y : Y) :
-    (∫ (x : X), f x ∂μ) y = ∫ (x : X), (f x) y ∂μ := by
-  calc (∫ x, f x ∂μ) y = ContinuousMapZero.evalCLM ℝ y (∫ x, f x ∂μ) := rfl
-    _ = ∫ x, ContinuousMapZero.evalCLM ℝ y (f x) ∂μ :=
-          (ContinuousLinearMap.integral_comp_comm _ hf).symm
-    _ = _ := rfl
 
 section unital
 

--- a/Mathlib/Analysis/CStarAlgebra/ContinuousFunctionalCalculus/Integral.lean
+++ b/Mathlib/Analysis/CStarAlgebra/ContinuousFunctionalCalculus/Integral.lean
@@ -151,7 +151,8 @@ lemma cfcₙ_integral' [TopologicalSpace X] [OpensMeasurableSpace X] (f : X → 
     cfcₙ (fun r => ∫ x, f x r ∂μ) a = ∫ x, cfcₙ (f x) a ∂μ := by
   refine cfcₙ_integral f bound a ?_ hf₂ ?_ hbound hbound_finite_integral
   · exact (continuousOn_iff_continuous_restrict.mpr <| hf.uncurry_left ·)
-  · sorry
-    --exact ContinuousMap.curry ⟨_, hf⟩ |>.continuous
+  · let g := ((↑) : C(quasispectrum 𝕜 a, 𝕜)₀ → C(quasispectrum 𝕜 a, 𝕜))
+    refine (Inducing.continuous_iff (g := g) ((inducing_iff g).mpr rfl)).mpr ?_
+    exact ContinuousMap.curry ⟨_, hf⟩ |>.continuous
 
 end nonunital

--- a/Mathlib/Analysis/CStarAlgebra/ContinuousFunctionalCalculus/NonUnital.lean
+++ b/Mathlib/Analysis/CStarAlgebra/ContinuousFunctionalCalculus/NonUnital.lean
@@ -170,6 +170,17 @@ theorem cfcₙHom_comp [UniqueNonUnitalContinuousFunctionalCalculus R A] (f : C(
 
 end cfcₙHom
 
+section cfcₙL
+
+/-- `cfcₙHom` bundled as a continuous linear map. -/
+@[simps apply]
+noncomputable def cfcₙL {a : A} (ha : p a) : C(σₙ R a, R)₀ →L[R] A :=
+  { cfcₙHom ha with
+    toFun := cfcₙHom ha
+    map_smul' := map_smul _
+    cont := (cfcₙHom_closedEmbedding ha).continuous }
+
+end cfcₙL
 
 section CFCn
 

--- a/Mathlib/MeasureTheory/Integral/SetIntegral.lean
+++ b/Mathlib/MeasureTheory/Integral/SetIntegral.lean
@@ -7,7 +7,7 @@ import Mathlib.MeasureTheory.Integral.IntegrableOn
 import Mathlib.MeasureTheory.Integral.Bochner
 import Mathlib.MeasureTheory.Function.LocallyIntegrable
 import Mathlib.Topology.MetricSpace.ThickenedIndicator
-import Mathlib.Topology.ContinuousFunction.Compact
+import Mathlib.Topology.ContinuousFunction.ContinuousMapZero
 import Mathlib.Analysis.NormedSpace.HahnBanach.SeparatingDual
 
 /-!
@@ -1266,13 +1266,24 @@ theorem integral_comp_comm (L : E ≃L[𝕜] F) (φ : X → E) : ∫ x, L (φ x)
 
 end ContinuousLinearEquiv
 
-namespace ContinuousMap
+section ContinuousMap
 
-lemma integral_apply [TopologicalSpace Y] [CompactSpace Y] [NormedSpace ℝ E]
-    [CompleteSpace E] {f : X → C(Y, E)} (hf : Integrable f μ) (y : Y) :
-    (∫ x, f x ∂μ) y = ∫ x, f x y ∂μ := by
+variable [TopologicalSpace Y] [CompactSpace Y]
+
+lemma ContinuousMap.integral_apply [NormedSpace ℝ E] [CompleteSpace E] {f : X → C(Y, E)}
+    (hf : Integrable f μ) (y : Y) : (∫ x, f x ∂μ) y = ∫ x, f x y ∂μ := by
   calc (∫ x, f x ∂μ) y = ContinuousMap.evalCLM ℝ y (∫ x, f x ∂μ) := rfl
     _ = ∫ x, ContinuousMap.evalCLM ℝ y (f x) ∂μ :=
+          (ContinuousLinearMap.integral_comp_comm _ hf).symm
+    _ = _ := rfl
+
+open scoped ContinuousMapZero in
+theorem ContinuousMapZero.integral_apply {R : Type*} [NormedCommRing R] [Zero Y]
+    [NormedAlgebra ℝ R] [CompleteSpace R] {f : X → C(Y, R)₀}
+    (hf : MeasureTheory.Integrable f μ) (y : Y) :
+    (∫ (x : X), f x ∂μ) y = ∫ (x : X), (f x) y ∂μ := by
+  calc (∫ x, f x ∂μ) y = ContinuousMapZero.evalCLM ℝ y (∫ x, f x ∂μ) := rfl
+    _ = ∫ x, ContinuousMapZero.evalCLM ℝ y (f x) ∂μ :=
           (ContinuousLinearMap.integral_comp_comm _ hf).symm
     _ = _ := rfl
 


### PR DESCRIPTION
This PR shows that `cfcₙ (fun r => ∫ x, f x r ∂μ) a = ∫ x, cfcₙ(f x) a ∂μ` under appropriate conditions.

Note that #16013 (already merged) showed the corresponding result for the unital CFC.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
