### PR TITLE
[Merged by Bors] - chore(Computability/ContextFreeGrammar): change the definition `Langu…

### DIFF
--- a/Mathlib/Computability/ContextFreeGrammar.lean
+++ b/Mathlib/Computability/ContextFreeGrammar.lean
@@ -53,10 +53,10 @@ inductive Rewrites (r : ContextFreeRule T N) : List (Symbol T N) → List (Symbo
       r.Rewrites (x :: s₁) (x :: s₂)
 
 lemma Rewrites.exists_parts {r : ContextFreeRule T N} {u v : List (Symbol T N)}
-    (hyp : r.Rewrites u v) :
+    (hr : r.Rewrites u v) :
     ∃ p q : List (Symbol T N),
       u = p ++ [Symbol.nonterminal r.input] ++ q ∧ v = p ++ r.output ++ q := by
-  induction hyp with
+  induction hr with
   | head s =>
     use [], s
     simp
@@ -181,7 +181,7 @@ lemma Derives.append_left {v w : List (Symbol T g.NT)}
   | refl => rfl
   | tail _ last ih => exact ih.trans_produces <| last.append_left p
 
-/-- Add extra prefix to context-free deriving. -/
+/-- Add extra postfix to context-free deriving. -/
 lemma Derives.append_right {v w : List (Symbol T g.NT)}
     (hvw : g.Derives v w) (p : List (Symbol T g.NT)) :
     g.Derives (v ++ p) (w ++ p) := by
@@ -193,7 +193,10 @@ end ContextFreeGrammar
 
 /-- Context-free languages are defined by context-free grammars. -/
 def Language.IsContextFree (L : Language T) : Prop :=
-  ∃ g : ContextFreeGrammar.{uT} T, g.language = L
+  ∃ g : ContextFreeGrammar.{0} T, g.language = L
+
+proof_wanted Language.isContextFree_iff {L : Language T} :
+    L.IsContextFree ↔ ∃ g : ContextFreeGrammar.{uN} T, g.language = L
 
 section closure_reversal
 


### PR DESCRIPTION
…age.IsContextFree` for consistency with #13554


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
