### PR TITLE
[Merged by Bors] - feat(LocallyCompact): generalize `*Embedding.locallyCompactSpace`

### DIFF
--- a/Mathlib/Topology/Basic.lean
+++ b/Mathlib/Topology/Basic.lean
@@ -156,6 +156,12 @@ theorem isClosed_const {p : Prop} : IsClosed { _x : X | p } := ⟨isOpen_const (
 
 @[simp] theorem isClosed_univ : IsClosed (univ : Set X) := isClosed_const
 
+lemma IsOpen.isLocallyClosed (hs : IsOpen s) : IsLocallyClosed s :=
+  ⟨_, _, hs, isClosed_univ, (inter_univ _).symm⟩
+
+lemma IsClosed.isLocallyClosed (hs : IsClosed s) : IsLocallyClosed s :=
+  ⟨_, _, isOpen_univ, hs, (univ_inter _).symm⟩
+
 theorem IsClosed.union : IsClosed s₁ → IsClosed s₂ → IsClosed (s₁ ∪ s₂) := by
   simpa only [← isOpen_compl_iff, compl_union] using IsOpen.inter
 

--- a/Mathlib/Topology/Compactness/LocallyCompact.lean
+++ b/Mathlib/Topology/Compactness/LocallyCompact.lean
@@ -169,28 +169,37 @@ theorem exists_compact_between [LocallyCompactSpace X] {K U : Set X} (hK : IsCom
   let ⟨L, hKL, hL, hLU⟩ := exists_mem_nhdsSet_isCompact_mapsTo continuous_id hK hU h_KU
   ⟨L, hL, subset_interior_iff_mem_nhdsSet.2 hKL, hLU⟩
 
+/-- If `f` is a topology inducing map with a locally compact codomain and a locally closed range,
+then the domain of `f` is a locally compact space. -/
+theorem Inducing.locallyCompactSpace [LocallyCompactSpace Y] {f : X → Y} (hf : Inducing f)
+    (h : IsLocallyClosed (range f)) : LocallyCompactSpace X := by
+  rcases h with ⟨U, Z, hU, hZ, hUZ⟩
+  have (x : X) : (𝓝 x).HasBasis (fun s ↦ (s ∈ 𝓝 (f x) ∧ IsCompact s) ∧ s ⊆ U)
+      (fun s ↦ f ⁻¹' (s ∩ Z)) := by
+    have H : U ∈ 𝓝 (f x) := hU.mem_nhds (hUZ.subset <| mem_range_self _).1
+    rw [hf.nhds_eq_comap, ← comap_nhdsWithin_range, hUZ,
+      nhdsWithin_inter_of_mem (nhdsWithin_le_nhds H)]
+    exact (nhdsWithin_hasBasis ((compact_basis_nhds (f x)).restrict_subset H) _).comap _
+  refine .of_hasBasis this fun x s ⟨⟨_, hs⟩, hsU⟩ ↦ ?_
+  rw [hf.isCompact_preimage_iff]
+  exacts [hs.inter_right hZ, hUZ ▸ by gcongr]
+
 protected theorem ClosedEmbedding.locallyCompactSpace [LocallyCompactSpace Y] {f : X → Y}
     (hf : ClosedEmbedding f) : LocallyCompactSpace X :=
-  haveI : ∀ x : X, (𝓝 x).HasBasis (fun s => s ∈ 𝓝 (f x) ∧ IsCompact s) (f ⁻¹' ·) := fun x ↦ by
-    rw [hf.toInducing.nhds_eq_comap]
-    exact (compact_basis_nhds _).comap _
-  .of_hasBasis this fun x s hs => hf.isCompact_preimage hs.2
+  hf.toInducing.locallyCompactSpace hf.isClosed_range.isLocallyClosed
+
+protected theorem OpenEmbedding.locallyCompactSpace [LocallyCompactSpace Y] {f : X → Y}
+    (hf : OpenEmbedding f) : LocallyCompactSpace X :=
+  hf.toInducing.locallyCompactSpace hf.isOpen_range.isLocallyClosed
+
+protected theorem IsLocallyClosed.locallyCompactSpace [LocallyCompactSpace X] {s : Set X}
+    (hs : IsLocallyClosed s) : LocallyCompactSpace s :=
+  embedding_subtype_val.locallyCompactSpace <| by rwa [Subtype.range_val]
 
 protected theorem IsClosed.locallyCompactSpace [LocallyCompactSpace X] {s : Set X}
     (hs : IsClosed s) : LocallyCompactSpace s :=
-  (closedEmbedding_subtype_val hs).locallyCompactSpace
-
-protected theorem OpenEmbedding.locallyCompactSpace [LocallyCompactSpace Y] {f : X → Y}
-    (hf : OpenEmbedding f) : LocallyCompactSpace X := by
-  have : ∀ x : X,
-      (𝓝 x).HasBasis (fun s ↦ (s ∈ 𝓝 (f x) ∧ IsCompact s) ∧ s ⊆ range f) (f ⁻¹' ·) := fun x ↦ by
-    rw [hf.nhds_eq_comap]
-    exact ((compact_basis_nhds _).restrict_subset <| hf.isOpen_range.mem_nhds <|
-      mem_range_self _).comap _
-  refine .of_hasBasis this fun x s hs => ?_
-  rw [hf.toInducing.isCompact_iff, image_preimage_eq_of_subset hs.2]
-  exact hs.1.2
+  hs.isLocallyClosed.locallyCompactSpace
 
 protected theorem IsOpen.locallyCompactSpace [LocallyCompactSpace X] {s : Set X} (hs : IsOpen s) :
     LocallyCompactSpace s :=
-  hs.openEmbedding_subtype_val.locallyCompactSpace
+  hs.isLocallyClosed.locallyCompactSpace

--- a/Mathlib/Topology/LocallyClosed.lean
+++ b/Mathlib/Topology/LocallyClosed.lean
@@ -88,12 +88,6 @@ lemma isClosed_preimage_val_coborder :
     IsClosed (coborder s ↓∩ s) := by
   rw [isClosed_preimage_val, inter_eq_right.mpr subset_coborder, coborder_inter_closure]
 
-lemma IsOpen.isLocallyClosed (hs : IsOpen s) : IsLocallyClosed s :=
-  ⟨_, _, hs, isClosed_univ, (inter_univ _).symm⟩
-
-lemma IsClosed.isLocallyClosed (hs : IsClosed s) : IsLocallyClosed s :=
-  ⟨_, _, isOpen_univ, hs, (univ_inter _).symm⟩
-
 lemma IsLocallyClosed.inter (hs : IsLocallyClosed s) (ht : IsLocallyClosed t) :
     IsLocallyClosed (s ∩ t) := by
   obtain ⟨U₁, Z₁, hU₁, hZ₁, rfl⟩ := hs


### PR DESCRIPTION
to `Inducing` maps

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)