### PR TITLE
[Merged by Bors] - feat: subset lemmas for `Finset` intervals

### DIFF
--- a/Mathlib/Analysis/InnerProductSpace/GramSchmidtOrtho.lean
+++ b/Mathlib/Analysis/InnerProductSpace/GramSchmidtOrtho.lean
@@ -137,7 +137,7 @@ theorem gramSchmidt_mem_span (f : ι → E) :
     (Submodule.sum_mem _ fun k hk => ?_)
   let hkj : k < j := (Finset.mem_Iio.1 hk).trans_le hij
   exact smul_mem _ _
-    (span_mono (image_subset f <| Iic_subset_Iic.2 hkj.le) <| gramSchmidt_mem_span _ le_rfl)
+    (span_mono (image_subset f <| Set.Iic_subset_Iic.2 hkj.le) <| gramSchmidt_mem_span _ le_rfl)
 termination_by j => j
 
 theorem span_gramSchmidt_Iic (f : ι → E) (c : ι) :

--- a/Mathlib/Order/Interval/Finset/Basic.lean
+++ b/Mathlib/Order/Interval/Finset/Basic.lean
@@ -334,6 +334,12 @@ lemma nonempty_Ici : (Ici a).Nonempty := ⟨a, mem_Ici.2 le_rfl⟩
 @[simp, aesop safe apply (rule_sets := [finsetNonempty])]
 lemma nonempty_Ioi : (Ioi a).Nonempty ↔ ¬ IsMax a := by simp [Finset.Nonempty]
 
+theorem Ici_subset_Ici : Ici a ⊆ Ici b ↔ b ≤ a := by
+  simpa [← coe_subset] using Set.Ici_subset_Ici
+
+theorem Ioi_subset_Ioi (h : a ≤ b) : Ioi b ⊆ Ioi a := by
+  simpa [← coe_subset] using Set.Ioi_subset_Ioi h
+
 variable [LocallyFiniteOrder α]
 
 theorem Icc_subset_Ici_self : Icc a b ⊆ Ici a := by
@@ -362,6 +368,12 @@ variable [LocallyFiniteOrderBot α]
 
 @[simp] lemma nonempty_Iic : (Iic a).Nonempty := ⟨a, mem_Iic.2 le_rfl⟩
 @[simp] lemma nonempty_Iio : (Iio a).Nonempty ↔ ¬ IsMin a := by simp [Finset.Nonempty]
+
+theorem Iic_subset_Iic : Iic a ⊆ Iic b ↔ a ≤ b := by
+  simpa [← coe_subset] using Set.Iic_subset_Iic
+
+theorem Iio_subset_Iio (h : a ≤ b) : Iio a ⊆ Iio b := by
+  simpa [← coe_subset] using Set.Iio_subset_Iio h
 
 variable [LocallyFiniteOrder α]
 


### PR DESCRIPTION
`Finset` version for `Ici_subset_Ici`, `Ioi_subset_Ioi`, `Iic_subset_Iic` and `Iio_subset_Iio`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
