### PR TITLE
[Merged by Bors] - feat: improve `subst_hom_lift` macro

### DIFF
--- a/Mathlib/CategoryTheory/FiberedCategory/HomLift.lean
+++ b/Mathlib/CategoryTheory/FiberedCategory/HomLift.lean
@@ -52,7 +52,7 @@ class Functor.IsHomLift {R S : 𝒮} {a b : 𝒳} (f : R ⟶ S) (φ : a ⟶ b) :
   cond : IsHomLiftAux p f φ
 
 /-- `subst_hom_lift p f φ` tries to substitute `f` with `p(φ)` by using `p.IsHomLift f φ` -/
-macro "subst_hom_lift" p:ident f:ident φ:ident : tactic =>
+macro "subst_hom_lift" p:term:max f:term:max φ:term:max : tactic =>
   `(tactic| obtain ⟨⟩ := Functor.IsHomLift.cond (p := $p) (f := $f) (φ := $φ))
 
 /-- For any arrow `φ : a ⟶ b` in `𝒳`, `φ` lifts the arrow `p.map φ` in the base `𝒮`-/

--- a/test/CategoryTheory/SubstHomLift.lean
+++ b/test/CategoryTheory/SubstHomLift.lean
@@ -1,0 +1,25 @@
+import Mathlib.CategoryTheory.FiberedCategory.HomLift
+
+universe u₁ v₁ u₂ v₂
+
+open CategoryTheory Category
+
+variable {𝒮 : Type u₁} {𝒳 : Type u₂} [Category.{v₁} 𝒳] [Category.{v₂} 𝒮] (p : 𝒳 ⥤ 𝒮)
+
+
+/-- Testing simple substitution -/
+example {R S : 𝒮} {a b : 𝒳} (f : R ⟶ S) (φ : a ⟶ b) [p.IsHomLift f φ] : f = f := by
+  subst_hom_lift p f φ
+  rename_i h
+  guard_hyp h : p.IsHomLift (p.map φ) φ
+  guard_target = p.map φ = p.map φ
+  trivial
+
+/-- Test substitution with more complicated expression -/
+example {R S T : 𝒮} {a b c : 𝒳} (f : R ⟶ S) (g : S ⟶ T) (φ : a ⟶ b) (ψ : b ⟶ c)
+    [p.IsHomLift f (φ ≫ ψ)] : f = f := by
+  subst_hom_lift p f (φ ≫ ψ)
+  rename_i h
+  guard_hyp h : p.IsHomLift (p.map (φ ≫ ψ)) (φ ≫ ψ)
+  guard_target = p.map (φ ≫ ψ) = p.map (φ ≫ ψ)
+  trivial


### PR DESCRIPTION
Previously this macro was defined in a very naive way, and only took idents as arguments. Now it can handle more complicated arguments, e.g. if the function `f` is of the form `F.map g` for some functor `F`

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
