### PR TITLE
[Merged by Bors] - feat(ModelTheory): Better uses of `IsAlgebraic` and `IsRelational`

### DIFF
--- a/Mathlib/ModelTheory/Algebra/Ring/Basic.lean
+++ b/Mathlib/ModelTheory/Algebra/Ring/Basic.lean
@@ -64,6 +64,8 @@ namespace Ring
 
 open ringFunc Language
 
+instance : IsAlgebraic Language.ring := ⟨fun _ => instIsEmptyEmpty⟩
+
 /-- This instance does not get inferred without `instDecidableEqFunctions` in
 `ModelTheory/Basic`. -/
 example (n : ℕ) : DecidableEq (Language.ring.Functions n) := inferInstance
@@ -225,7 +227,6 @@ def compatibleRingOfRing (R : Type*) [Add R] [Mul R] [Neg R] [One R] [Zero R] :
       | _, .neg => fun x => -x 0
       | _, .zero => fun _ => 0
       | _, .one => fun _ => 1
-    RelMap := Empty.elim,
     funMap_add := fun _ => rfl,
     funMap_mul := fun _ => rfl,
     funMap_neg := fun _ => rfl,

--- a/Mathlib/ModelTheory/Algebra/Ring/Basic.lean
+++ b/Mathlib/ModelTheory/Algebra/Ring/Basic.lean
@@ -59,12 +59,11 @@ inductive ringFunc : ℕ → Type
 def Language.ring : Language :=
   { Functions := ringFunc
     Relations := fun _ => Empty }
+  deriving IsAlgebraic
 
 namespace Ring
 
 open ringFunc Language
-
-instance : IsAlgebraic Language.ring := ⟨fun _ => instIsEmptyEmpty⟩
 
 /-- This instance does not get inferred without `instDecidableEqFunctions` in
 `ModelTheory/Basic`. -/

--- a/Mathlib/ModelTheory/Basic.lean
+++ b/Mathlib/ModelTheory/Basic.lean
@@ -268,10 +268,10 @@ variable (L) (M : Type w)
 class Structure where
   /-- Interpretation of the function symbols -/
   funMap : ∀ {n}, L.Functions n → (Fin n → M) → M :=
-    by intros; trivial
+    by exact fun {n} => (IsRelational.empty_functions _).elim
   /-- Interpretation of the relation symbols -/
   RelMap : ∀ {n}, L.Relations n → (Fin n → M) → Prop :=
-    by intros; trivial
+    by exact fun {n} => (IsAlgebraic.empty_relations _).elim
 
 variable (N : Type w') [L.Structure M] [L.Structure N]
 

--- a/Mathlib/ModelTheory/Basic.lean
+++ b/Mathlib/ModelTheory/Basic.lean
@@ -267,9 +267,11 @@ variable (L) (M : Type w)
 @[ext]
 class Structure where
   /-- Interpretation of the function symbols -/
-  funMap : ∀ {n}, L.Functions n → (Fin n → M) → M
+  funMap : ∀ {n}, L.Functions n → (Fin n → M) → M :=
+    by intros; trivial
   /-- Interpretation of the relation symbols -/
-  RelMap : ∀ {n}, L.Relations n → (Fin n → M) → Prop
+  RelMap : ∀ {n}, L.Relations n → (Fin n → M) → Prop :=
+    by intros; trivial
 
 variable (N : Type w') [L.Structure M] [L.Structure N]
 
@@ -935,8 +937,7 @@ end SumStructure
 section Empty
 
 /-- Any type can be made uniquely into a structure over the empty language. -/
-def emptyStructure : Language.empty.Structure M :=
-  ⟨Empty.elim, Empty.elim⟩
+def emptyStructure : Language.empty.Structure M where
 
 instance : Unique (Language.empty.Structure M) :=
   ⟨⟨Language.emptyStructure⟩, fun a => by

--- a/Mathlib/ModelTheory/Basic.lean
+++ b/Mathlib/ModelTheory/Basic.lean
@@ -110,18 +110,25 @@ unary and binary relations. -/
 protected def mk₂ (c f₁ f₂ : Type u) (r₁ r₂ : Type v) : Language :=
   ⟨Sequence₂ c f₁ f₂, Sequence₂ PEmpty r₁ r₂⟩
 
+variable (L : Language.{u, v})
+
+/-- A language is relational when it has no function symbols. -/
+abbrev IsRelational : Prop := ∀ n, IsEmpty (L.Functions n)
+
+/-- A language is algebraic when it has no relation symbols. -/
+abbrev IsAlgebraic := ∀ n, IsEmpty (L.Relations n)
+
 /-- The empty language has no symbols. -/
 protected def empty : Language :=
   ⟨fun _ => Empty, fun _ => Empty⟩
+  deriving IsAlgebraic, IsRelational
 
 instance : Inhabited Language :=
   ⟨Language.empty⟩
 
 /-- The sum of two languages consists of the disjoint union of their symbols. -/
-protected def sum (L : Language.{u, v}) (L' : Language.{u', v'}) : Language :=
+protected def sum (L' : Language.{u', v'}) : Language :=
   ⟨fun n => L.Functions n ⊕ L'.Functions n, fun n => L.Relations n ⊕ L'.Relations n⟩
-
-variable (L : Language.{u, v})
 
 /-- The type of constants in a given language. -/
 -- Porting note(#5171): this linter isn't ported yet.
@@ -144,16 +151,6 @@ def Symbols :=
 def card : Cardinal :=
   #L.Symbols
 
-/-- A language is relational when it has no function symbols. -/
-class IsRelational : Prop where
-  /-- There are no function symbols in the language. -/
-  empty_functions : ∀ n, IsEmpty (L.Functions n)
-
-/-- A language is algebraic when it has no relation symbols. -/
-class IsAlgebraic : Prop where
-  /-- There are no relation symbols in the language. -/
-  empty_relations : ∀ n, IsEmpty (L.Relations n)
-
 variable {L} {L' : Language.{u', v'}}
 
 theorem card_eq_card_functions_add_card_relations :
@@ -162,42 +159,23 @@ theorem card_eq_card_functions_add_card_relations :
         Cardinal.sum fun l => Cardinal.lift.{u} #(L.Relations l) := by
   simp [card, Symbols]
 
-instance [L.IsRelational] {n : ℕ} : IsEmpty (L.Functions n) :=
-  IsRelational.empty_functions n
-
-instance [L.IsAlgebraic] {n : ℕ} : IsEmpty (L.Relations n) :=
-  IsAlgebraic.empty_relations n
-
-instance isRelational_of_empty_functions {symb : ℕ → Type*} :
-    IsRelational ⟨fun _ => Empty, symb⟩ :=
-  ⟨fun _ => instIsEmptyEmpty⟩
-
-instance isAlgebraic_of_empty_relations {symb : ℕ → Type*} : IsAlgebraic ⟨symb, fun _ => Empty⟩ :=
-  ⟨fun _ => instIsEmptyEmpty⟩
-
-instance isRelational_empty : IsRelational Language.empty :=
-  Language.isRelational_of_empty_functions
-
-instance isAlgebraic_empty : IsAlgebraic Language.empty :=
-  Language.isAlgebraic_of_empty_relations
-
 instance isRelational_sum [L.IsRelational] [L'.IsRelational] : IsRelational (L.sum L') :=
-  ⟨fun _ => instIsEmptySum⟩
+  fun _ => instIsEmptySum
 
 instance isAlgebraic_sum [L.IsAlgebraic] [L'.IsAlgebraic] : IsAlgebraic (L.sum L') :=
-  ⟨fun _ => instIsEmptySum⟩
+  fun _ => instIsEmptySum
 
 instance isRelational_mk₂ {c f₁ f₂ : Type u} {r₁ r₂ : Type v} [h0 : IsEmpty c] [h1 : IsEmpty f₁]
     [h2 : IsEmpty f₂] : IsRelational (Language.mk₂ c f₁ f₂ r₁ r₂) :=
-  ⟨fun n =>
+  fun n =>
     Nat.casesOn n h0 fun n => Nat.casesOn n h1 fun n => Nat.casesOn n h2 fun _ =>
-      inferInstanceAs (IsEmpty PEmpty)⟩
+      inferInstanceAs (IsEmpty PEmpty)
 
 instance isAlgebraic_mk₂ {c f₁ f₂ : Type u} {r₁ r₂ : Type v} [h1 : IsEmpty r₁] [h2 : IsEmpty r₂] :
     IsAlgebraic (Language.mk₂ c f₁ f₂ r₁ r₂) :=
-  ⟨fun n =>
+  fun n =>
     Nat.casesOn n (inferInstanceAs (IsEmpty PEmpty)) fun n =>
-      Nat.casesOn n h1 fun n => Nat.casesOn n h2 fun _ => inferInstanceAs (IsEmpty PEmpty)⟩
+      Nat.casesOn n h1 fun n => Nat.casesOn n h2 fun _ => inferInstanceAs (IsEmpty PEmpty)
 
 instance subsingleton_mk₂_functions {c f₁ f₂ : Type u} {r₁ r₂ : Type v} [h0 : Subsingleton c]
     [h1 : Subsingleton f₁] [h2 : Subsingleton f₂] {n : ℕ} :
@@ -267,11 +245,11 @@ variable (L) (M : Type w)
 @[ext]
 class Structure where
   /-- Interpretation of the function symbols -/
-  funMap : ∀ {n}, L.Functions n → (Fin n → M) → M :=
-    by exact fun {n} => (IsRelational.empty_functions _).elim
+  funMap : ∀ {n}, L.Functions n → (Fin n → M) → M := by
+    exact fun {n} => isEmptyElim
   /-- Interpretation of the relation symbols -/
-  RelMap : ∀ {n}, L.Relations n → (Fin n → M) → Prop :=
-    by exact fun {n} => (IsAlgebraic.empty_relations _).elim
+  RelMap : ∀ {n}, L.Relations n → (Fin n → M) → Prop := by
+    exact fun {n} => isEmptyElim
 
 variable (N : Type w') [L.Structure M] [L.Structure N]
 
@@ -431,7 +409,7 @@ instance (priority := 100) StrongHomClass.homClass {F : Type*} [L.Structure M]
 theorem HomClass.strongHomClassOfIsAlgebraic [L.IsAlgebraic] {F M N} [L.Structure M] [L.Structure N]
     [FunLike F M N] [HomClass L F M N] : StrongHomClass L F M N where
   map_fun := HomClass.map_fun
-  map_rel _ n R _ := (IsAlgebraic.empty_relations n).elim R
+  map_rel _ _ := isEmptyElim
 
 theorem HomClass.map_constants {F M N} [L.Structure M] [L.Structure N] [FunLike F M N]
     [HomClass L F M N] (φ : F) (c : L.Constants) : φ c = c :=

--- a/Mathlib/ModelTheory/Graph.lean
+++ b/Mathlib/ModelTheory/Graph.lean
@@ -104,7 +104,7 @@ theorem structure_simpleGraphOfStructure [S : Language.graph.Structure V] [V ⊨
     (simpleGraphOfStructure V).structure = S := by
   ext
   case funMap n f xs =>
-    exact (IsRelational.empty_functions n).elim f
+    exact isEmptyElim f
   case RelMap n r xs =>
     rw [iff_eq_eq]
     cases' n with n

--- a/Mathlib/ModelTheory/LanguageMap.lean
+++ b/Mathlib/ModelTheory/LanguageMap.lean
@@ -47,10 +47,10 @@ variable (L : Language.{u, v}) (L' : Language.{u', v'}) {M : Type w} [L.Structur
 
 /-- A language homomorphism maps the symbols of one language to symbols of another. -/
 structure LHom where
-  onFunction : ∀ ⦃n⦄, L.Functions n → L'.Functions n :=
-    by exact fun {n} => (IsRelational.empty_functions n).elim
-  onRelation : ∀ ⦃n⦄, L.Relations n → L'.Relations n :=
-    by exact fun {n} => (IsAlgebraic.empty_relations n).elim
+  onFunction : ∀ ⦃n⦄, L.Functions n → L'.Functions n := by
+    exact fun {n} => (IsRelational.empty_functions n).elim
+  onRelation : ∀ ⦃n⦄, L.Relations n → L'.Relations n :=by
+    exact fun {n} => (IsAlgebraic.empty_relations n).elim
 
 @[inherit_doc FirstOrder.Language.LHom]
 infixl:10 " →ᴸ " => LHom
@@ -221,11 +221,11 @@ noncomputable def defaultExpansion (ϕ : L →ᴸ L')
 all symbols on that structure. -/
 class IsExpansionOn (M : Type*) [L.Structure M] [L'.Structure M] : Prop where
   map_onFunction :
-    ∀ {n} (f : L.Functions n) (x : Fin n → M), funMap (ϕ.onFunction f) x = funMap f x :=
-      by exact fun {n} => (IsRelational.empty_functions _).elim
+    ∀ {n} (f : L.Functions n) (x : Fin n → M), funMap (ϕ.onFunction f) x = funMap f x := by
+      exact fun {n} => (IsRelational.empty_functions _).elim
   map_onRelation :
-    ∀ {n} (R : L.Relations n) (x : Fin n → M), RelMap (ϕ.onRelation R) x = RelMap R x :=
-      by exact fun {n} => (IsAlgebraic.empty_relations _).elim
+    ∀ {n} (R : L.Relations n) (x : Fin n → M), RelMap (ϕ.onRelation R) x = RelMap R x := by
+      exact fun {n} => (IsAlgebraic.empty_relations _).elim
 
 @[simp]
 theorem map_onFunction {M : Type*} [L.Structure M] [L'.Structure M] [ϕ.IsExpansionOn M] {n}

--- a/Mathlib/ModelTheory/LanguageMap.lean
+++ b/Mathlib/ModelTheory/LanguageMap.lean
@@ -47,8 +47,10 @@ variable (L : Language.{u, v}) (L' : Language.{u', v'}) {M : Type w} [L.Structur
 
 /-- A language homomorphism maps the symbols of one language to symbols of another. -/
 structure LHom where
-  onFunction : ∀ ⦃n⦄, L.Functions n → L'.Functions n
-  onRelation : ∀ ⦃n⦄, L.Relations n → L'.Relations n
+  onFunction : ∀ ⦃n⦄, L.Functions n → L'.Functions n :=
+    by exact fun {n} => (IsRelational.empty_functions n).elim
+  onRelation : ∀ ⦃n⦄, L.Relations n → L'.Relations n :=
+    by exact fun {n} => (IsAlgebraic.empty_relations n).elim
 
 @[inherit_doc FirstOrder.Language.LHom]
 infixl:10 " →ᴸ " => LHom
@@ -97,8 +99,7 @@ variable (L L')
 
 /-- The inclusion of an empty language into any other language. -/
 @[simps]
-protected def ofIsEmpty [L.IsAlgebraic] [L.IsRelational] : L →ᴸ L' :=
-  ⟨fun n => (IsRelational.empty_functions n).elim, fun n => (IsAlgebraic.empty_relations n).elim⟩
+protected def ofIsEmpty [L.IsAlgebraic] [L.IsRelational] : L →ᴸ L' where
 
 variable {L L'} {L'' : Language}
 
@@ -219,9 +220,12 @@ noncomputable def defaultExpansion (ϕ : L →ᴸ L')
 /-- A language homomorphism is an expansion on a structure if it commutes with the interpretation of
 all symbols on that structure. -/
 class IsExpansionOn (M : Type*) [L.Structure M] [L'.Structure M] : Prop where
-  map_onFunction : ∀ {n} (f : L.Functions n) (x : Fin n → M), funMap (ϕ.onFunction f) x = funMap f x
-  map_onRelation : ∀ {n} (R : L.Relations n) (x : Fin n → M),
-    RelMap (ϕ.onRelation R) x = RelMap R x
+  map_onFunction :
+    ∀ {n} (f : L.Functions n) (x : Fin n → M), funMap (ϕ.onFunction f) x = funMap f x :=
+      by exact fun {n} => (IsRelational.empty_functions _).elim
+  map_onRelation :
+    ∀ {n} (R : L.Relations n) (x : Fin n → M), RelMap (ϕ.onRelation R) x = RelMap R x :=
+      by exact fun {n} => (IsAlgebraic.empty_relations _).elim
 
 @[simp]
 theorem map_onFunction {M : Type*} [L.Structure M] [L'.Structure M] [ϕ.IsExpansionOn M] {n}
@@ -237,9 +241,7 @@ instance id_isExpansionOn (M : Type*) [L.Structure M] : IsExpansionOn (LHom.id L
   ⟨fun _ _ => rfl, fun _ _ => rfl⟩
 
 instance ofIsEmpty_isExpansionOn (M : Type*) [L.Structure M] [L'.Structure M] [L.IsAlgebraic]
-    [L.IsRelational] : IsExpansionOn (LHom.ofIsEmpty L L') M :=
-  ⟨fun {n} => (IsRelational.empty_functions n).elim,
-   fun {n} => (IsAlgebraic.empty_relations n).elim⟩
+    [L.IsRelational] : IsExpansionOn (LHom.ofIsEmpty L L') M where
 
 instance sumElim_isExpansionOn {L'' : Language} (ψ : L'' →ᴸ L') (M : Type*) [L.Structure M]
     [L'.Structure M] [L''.Structure M] [ϕ.IsExpansionOn M] [ψ.IsExpansionOn M] :

--- a/Mathlib/ModelTheory/LanguageMap.lean
+++ b/Mathlib/ModelTheory/LanguageMap.lean
@@ -48,9 +48,9 @@ variable (L : Language.{u, v}) (L' : Language.{u', v'}) {M : Type w} [L.Structur
 /-- A language homomorphism maps the symbols of one language to symbols of another. -/
 structure LHom where
   onFunction : ∀ ⦃n⦄, L.Functions n → L'.Functions n := by
-    exact fun {n} => (IsRelational.empty_functions n).elim
+    exact fun {n} => isEmptyElim
   onRelation : ∀ ⦃n⦄, L.Relations n → L'.Relations n :=by
-    exact fun {n} => (IsAlgebraic.empty_relations n).elim
+    exact fun {n} => isEmptyElim
 
 @[inherit_doc FirstOrder.Language.LHom]
 infixl:10 " →ᴸ " => LHom
@@ -222,10 +222,10 @@ all symbols on that structure. -/
 class IsExpansionOn (M : Type*) [L.Structure M] [L'.Structure M] : Prop where
   map_onFunction :
     ∀ {n} (f : L.Functions n) (x : Fin n → M), funMap (ϕ.onFunction f) x = funMap f x := by
-      exact fun {n} => (IsRelational.empty_functions _).elim
+      exact fun {n} => isEmptyElim
   map_onRelation :
     ∀ {n} (R : L.Relations n) (x : Fin n → M), RelMap (ϕ.onRelation R) x = RelMap R x := by
-      exact fun {n} => (IsAlgebraic.empty_relations _).elim
+      exact fun {n} => isEmptyElim
 
 @[simp]
 theorem map_onFunction {M : Type*} [L.Structure M] [L'.Structure M] [ϕ.IsExpansionOn M] {n}

--- a/Mathlib/ModelTheory/Substructures.lean
+++ b/Mathlib/ModelTheory/Substructures.lean
@@ -301,7 +301,7 @@ variable (L)
 
 @[simp]
 lemma mem_closed_of_isRelational [L.IsRelational] (s : Set M) : s ∈ (closure L).closed :=
-  (mem_closed_iff s).2 (IsRelational.empty_functions _).elim
+  (mem_closed_iff s).2 isEmptyElim
 
 theorem _root_.Set.Countable.substructure_closure
     [Countable (Σl, L.Functions l)] (h : s.Countable) : Countable.{w + 1} (closure L s) := by


### PR DESCRIPTION
Redefines `IsAlgebraic` and `IsRelational` as `abbrev`s, removing the need for some explicit instances.
The constructors for `Structure`, `LHom` and `LHom.IsExpansionOn` will, by default, skip the definition on relations in algebraic languages and the definition on functions in relational languages.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
