### PR TITLE
[Merged by Bors] - fix(Linter/Textbased): account for different path separators in path comparison

### DIFF
--- a/Mathlib/Tactic/Linter/TextBased.lean
+++ b/Mathlib/Tactic/Linter/TextBased.lean
@@ -146,8 +146,9 @@ inductive ComparisonResult
 and, if it is, if we prefer replacing the new exception or keeping the previous one. -/
 def compare (existing new : ErrorContext) : ComparisonResult :=
   -- Two comparable error contexts must have the same path.
-  if existing.path != new.path then
-    ComparisonResult.Different
+  -- To avoid issues with different path separators across different operating systems,
+  -- we compare the set of path components instead.
+  if existing.path.components != existing.path.components then ComparisonResult.Different
   -- We entirely ignore their line numbers: not sure if this is best.
 
   -- NB: keep the following in sync with `parse?_errorContext` below.

--- a/Mathlib/Tactic/Linter/TextBased.lean
+++ b/Mathlib/Tactic/Linter/TextBased.lean
@@ -148,7 +148,7 @@ def compare (existing new : ErrorContext) : ComparisonResult :=
   -- Two comparable error contexts must have the same path.
   -- To avoid issues with different path separators across different operating systems,
   -- we compare the set of path components instead.
-  if existing.path.components != existing.path.components then ComparisonResult.Different
+  if existing.path.components != new.path.components then ComparisonResult.Different
   -- We entirely ignore their line numbers: not sure if this is best.
 
   -- NB: keep the following in sync with `parse?_errorContext` below.


### PR DESCRIPTION
The previous code considered two exceptions different if they used different path separators (such as when running on Windows, with the exceptions file being created on a Linux system).
Compare the set of path components instead: this is agnostic to the path separator used.

The mk_all script had a similar issue (see #13845, making the sorting of files platform-independent, in the face of different path separators which sort differently): its solution (sorting module names instead) would also work here, but is less pretty, as it the conversion to module names is in the IO monad. Comparing path components works just fine in our context.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
