### PR TITLE
[Merged by Bors] - fix({bot_fix_style*,lint_and_suggest}.yml): don't use continue-on-error

### DIFF
--- a/.github/workflows/bot_fix_style_comment.yaml
+++ b/.github/workflows/bot_fix_style_comment.yaml
@@ -69,11 +69,14 @@ jobs:
       - name: lint references.bib
         if: steps.user_permission.outputs.require-result == 'true'
         run: |
+          # ignoring the return code allows the following `reviewdog` step to add GitHub suggestions
           ./scripts/lint-bib.sh || true
 
       - name: update {Mathlib, Tactic, Counterexamples, Archive}.lean
         if: steps.user_permission.outputs.require-result == 'true'
-        run: lake exe mk_all || true
+        run: |
+          # ignoring the return code allows the following `reviewdog` step to add GitHub suggestions
+          lake exe mk_all || true
 
       - name: Commit and push changes
         if: steps.user_permission.outputs.require-result == 'true'

--- a/.github/workflows/bot_fix_style_comment.yaml
+++ b/.github/workflows/bot_fix_style_comment.yaml
@@ -9,7 +9,6 @@ jobs:
     name: Fix style issues from lint
     if: (github.event.issue.pull_request) && (startsWith(github.event.comment.body, 'bot fix style') || contains(toJSON(github.event.comment.body), '\nbot fix style'))
     runs-on: ubuntu-latest
-    continue-on-error: true  # do not annoy the user when linting fails, as expected
     steps:
       - id: user_permission
         uses: actions-cool/check-user-permission@v2
@@ -58,7 +57,6 @@ jobs:
 
       - name: lint
         if: steps.user_permission.outputs.require-result == 'true'
-        continue-on-error: true  # allows the following `reviewdog` step to add GitHub suggestions
         run: |
           lake exe lint-style --fix
 
@@ -70,14 +68,12 @@ jobs:
 
       - name: lint references.bib
         if: steps.user_permission.outputs.require-result == 'true'
-        continue-on-error: true  # allows the following `reviewdog` step to add GitHub suggestions
         run: |
-          ./scripts/lint-bib.sh
+          ./scripts/lint-bib.sh || true
 
       - name: update {Mathlib, Tactic, Counterexamples, Archive}.lean
         if: steps.user_permission.outputs.require-result == 'true'
-        continue-on-error: true  # allows the following `reviewdog` step to add GitHub suggestions
-        run: lake exe mk_all
+        run: lake exe mk_all || true
 
       - name: Commit and push changes
         if: steps.user_permission.outputs.require-result == 'true'

--- a/.github/workflows/bot_fix_style_review.yaml
+++ b/.github/workflows/bot_fix_style_review.yaml
@@ -10,7 +10,6 @@ jobs:
     name: Fix style issues from lint
     if: (startsWith(github.event.review.body, 'bot fix style') || contains(toJSON(github.event.review.body), '\nbot fix style'))
     runs-on: ubuntu-latest
-    continue-on-error: true  # do not annoy the user when linting fails, as expected
     steps:
       - id: user_permission
         uses: actions-cool/check-user-permission@v2
@@ -64,7 +63,6 @@ jobs:
 
       - name: lint
         if: steps.user_permission.outputs.require-result == 'true'
-        continue-on-error: true  # allows the following `reviewdog` step to add GitHub suggestions
         run: |
           lake exe lint-style --fix
 
@@ -76,14 +74,12 @@ jobs:
 
       - name: lint references.bib
         if: steps.user_permission.outputs.require-result == 'true'
-        continue-on-error: true  # allows the following `reviewdog` step to add GitHub suggestions
         run: |
-          ./scripts/lint-bib.sh
+          ./scripts/lint-bib.sh || true
 
       - name: update {Mathlib, Tactic, Counterexamples, Archive}.lean
         if: steps.user_permission.outputs.require-result == 'true'
-        continue-on-error: true  # allows the following `reviewdog` step to add GitHub suggestions
-        run: lake exe mk_all
+        run: lake exe mk_all || true
 
       - name: Commit and push changes
         if: steps.user_permission.outputs.require-result == 'true'

--- a/.github/workflows/bot_fix_style_review.yaml
+++ b/.github/workflows/bot_fix_style_review.yaml
@@ -75,11 +75,14 @@ jobs:
       - name: lint references.bib
         if: steps.user_permission.outputs.require-result == 'true'
         run: |
+          # ignoring the return code allows the following `reviewdog` step to add GitHub suggestions
           ./scripts/lint-bib.sh || true
 
       - name: update {Mathlib, Tactic, Counterexamples, Archive}.lean
         if: steps.user_permission.outputs.require-result == 'true'
-        run: lake exe mk_all || true
+        run: |
+          # ignoring the return code allows the following `reviewdog` step to add GitHub suggestions
+          lake exe mk_all || true
 
       - name: Commit and push changes
         if: steps.user_permission.outputs.require-result == 'true'

--- a/.github/workflows/bot_fix_style_review_comment.yaml
+++ b/.github/workflows/bot_fix_style_review_comment.yaml
@@ -9,7 +9,6 @@ jobs:
     name: Fix style issues from lint
     if: (startsWith(github.event.comment.body, 'bot fix style') || contains(toJSON(github.event.comment.body), '\nbot fix style'))
     runs-on: ubuntu-latest
-    continue-on-error: true  # do not annoy the user when linting fails, as expected
     steps:
       - id: user_permission
         uses: actions-cool/check-user-permission@v2
@@ -62,7 +61,6 @@ jobs:
 
       - name: lint
         if: steps.user_permission.outputs.require-result == 'true'
-        continue-on-error: true  # allows the following `reviewdog` step to add GitHub suggestions
         run: |
           lake exe lint-style --fix
 
@@ -74,14 +72,12 @@ jobs:
 
       - name: lint references.bib
         if: steps.user_permission.outputs.require-result == 'true'
-        continue-on-error: true  # allows the following `reviewdog` step to add GitHub suggestions
         run: |
-          ./scripts/lint-bib.sh
+          ./scripts/lint-bib.sh || true
 
       - name: update {Mathlib, Tactic, Counterexamples, Archive}.lean
         if: steps.user_permission.outputs.require-result == 'true'
-        continue-on-error: true  # allows the following `reviewdog` step to add GitHub suggestions
-        run: lake exe mk_all
+        run: lake exe mk_all || true
 
       - name: Commit and push changes
         if: steps.user_permission.outputs.require-result == 'true'

--- a/.github/workflows/bot_fix_style_review_comment.yaml
+++ b/.github/workflows/bot_fix_style_review_comment.yaml
@@ -73,11 +73,14 @@ jobs:
       - name: lint references.bib
         if: steps.user_permission.outputs.require-result == 'true'
         run: |
+          # ignoring the return code allows the following `reviewdog` step to add GitHub suggestions
           ./scripts/lint-bib.sh || true
 
       - name: update {Mathlib, Tactic, Counterexamples, Archive}.lean
         if: steps.user_permission.outputs.require-result == 'true'
-        run: lake exe mk_all || true
+        run: |
+          # ignoring the return code allows the following `reviewdog` step to add GitHub suggestions
+          lake exe mk_all || true
 
       - name: Commit and push changes
         if: steps.user_permission.outputs.require-result == 'true'

--- a/.github/workflows/lint_and_suggest_pr.yml
+++ b/.github/workflows/lint_and_suggest_pr.yml
@@ -30,7 +30,6 @@ jobs:
 
       # if you update this step (or its dependencies), please also update them in bot_fix_style_comment.yaml
       - name: lint
-        continue-on-error: true  # allows the following `reviewdog` step to add GitHub suggestions
         run: |
           lake exe lint-style --fix
 
@@ -46,9 +45,8 @@ jobs:
 
       # if you update this step (or its dependencies), please also update them in bot_fix_style_comment.yaml
       - name: lint references.bib
-        continue-on-error: true  # allows the following `reviewdog` step to add GitHub suggestions
         run: |
-          ./scripts/lint-bib.sh
+          ./scripts/lint-bib.sh || true
 
       - name: suggester / lint-bib
         uses: reviewdog/action-suggester@v1
@@ -75,8 +73,7 @@ jobs:
 
       # if you update this step (or its dependencies), please also update them in bot_fix_style_comment.yaml
       - name: update {Mathlib, Tactic, Counterexamples, Archive}.lean
-        continue-on-error: true  # allows the following `reviewdog` step to add GitHub suggestions
-        run: lake exe mk_all
+        run: lake exe mk_all || true
 
       - name: suggester / import list
         uses: reviewdog/action-suggester@v1

--- a/.github/workflows/lint_and_suggest_pr.yml
+++ b/.github/workflows/lint_and_suggest_pr.yml
@@ -46,6 +46,7 @@ jobs:
       # if you update this step (or its dependencies), please also update them in bot_fix_style_comment.yaml
       - name: lint references.bib
         run: |
+          # ignoring the return code allows the following `reviewdog` step to add GitHub suggestions
           ./scripts/lint-bib.sh || true
 
       - name: suggester / lint-bib
@@ -73,7 +74,9 @@ jobs:
 
       # if you update this step (or its dependencies), please also update them in bot_fix_style_comment.yaml
       - name: update {Mathlib, Tactic, Counterexamples, Archive}.lean
-        run: lake exe mk_all || true
+        run: 
+          # ignoring the return code allows the following `reviewdog` step to add GitHub suggestions
+          lake exe mk_all || true
 
       - name: suggester / import list
         uses: reviewdog/action-suggester@v1


### PR DESCRIPTION
These workflows had linting steps which were expected to fail with nonzero exit codes and then have those failures ignored by the (step-level) [`continue-on-error` setting](https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#jobsjob_idstepscontinue-on-error). This setting only allows the workflow to continue executing; the error still shows up as a red x in the step, and also causes the entire job to fail, unless [`continue-on-error` is set at the job level](https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#jobsjob_idcontinue-on-error), which we ended up doing for the "bot fix style" workflows.

With this setting active, the job will succeed regardless of any errors that occur, which has the downside that errors in other steps might not get noticed.

In #16301 the exit code was changed for `lint-style --fix` making the step-level `continue-on-error` setting unnecessary for those linting steps. In this PR I:
- add `|| true` to the end of other such linting steps so that their exit codes are also ignored, which let me
- remove all step-level `continue-on-error` settings, which let me
- remove all job-level `continue-on-error` settings

In summary, error reporting for these workflows will now be much more informative.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
