### PR TITLE
feat: convenience lemmas for `StarOrderedRing`

### DIFF
--- a/Mathlib/Algebra/Star/Order.lean
+++ b/Mathlib/Algebra/Star/Order.lean
@@ -244,6 +244,28 @@ theorem mul_star_self_pos [Nontrivial R] {x : R} (hx : IsRegular x) : 0 < x * st
 
 end NonUnitalSemiring
 
+section NonUnitalRing
+
+variable [NonUnitalRing R] [PartialOrder R] [StarRing R] [StarOrderedRing R]
+
+lemma IsSelfAdjoint.mul_nonneg_mul {a b : R} (ha : IsSelfAdjoint a) (hb : 0 ≤ b) :
+    0 ≤ a * b * a := by
+  simpa only [ha.star_eq] using conjugate_nonneg hb a
+
+lemma IsSelfAdjoint.mul_mul_le_mul_mul {a b c : R} (ha : IsSelfAdjoint a) (hbc : b ≤ c) :
+    a * b * a ≤ a * c * a := by
+  simpa only [ha.star_eq] using conjugate_le_conjugate hbc a
+
+lemma StarOrderedRing.mul_nonneg_mul {a b : R} (ha : 0 ≤ a) (hb : 0 ≤ b) :
+    0 ≤ a * b * a :=
+  IsSelfAdjoint.of_nonneg ha |>.mul_nonneg_mul hb
+
+lemma StarOrderedRing.mul_mul_le_mul_mul {a b c : R} (ha : 0 ≤ a) (hbc : b ≤ c) :
+    a * b * a ≤ a * c * a :=
+  IsSelfAdjoint.of_nonneg ha |>.mul_mul_le_mul_mul hbc
+
+end NonUnitalRing
+
 section Semiring
 variable [Semiring R] [PartialOrder R] [StarRing R] [StarOrderedRing R]
 


### PR DESCRIPTION
This adds a few convenience lemmas of the form `0 ≤ a * b * a` (or `a * b * a ≤ a * c * a`) when `a` is selfadjoint or nonnegative and `0 ≤ b` (or `b ≤ c`, respectively)

---

I'm open to better names, but I'm not really sure what would be best here.

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
