### PR TITLE
[Merged by Bors] - chore(ModelTheory/Order): Reorganization for future refactoring

### DIFF
--- a/Mathlib/ModelTheory/Order.lean
+++ b/Mathlib/ModelTheory/Order.lean
@@ -276,4 +276,3 @@ end order_to_structure
 end Language
 
 end FirstOrder
-#lint

--- a/Mathlib/ModelTheory/Order.lean
+++ b/Mathlib/ModelTheory/Order.lean
@@ -61,6 +61,9 @@ class IsOrdered (L : Language.{u, v}) where
 
 export IsOrdered (leSymb)
 
+instance : IsOrdered Language.order :=
+  ⟨Unit.unit⟩
+
 section IsOrdered
 
 variable [IsOrdered L]
@@ -79,9 +82,6 @@ variable (L)
  language. -/
 def orderLHom : Language.order →ᴸ L :=
   LHom.mk₂ Empty.elim Empty.elim Empty.elim Empty.elim fun _ => leSymb
-
-instance : IsOrdered Language.order :=
-  ⟨Unit.unit⟩
 
 @[simp]
 theorem orderLHom_leSymb :

--- a/Mathlib/ModelTheory/Order.lean
+++ b/Mathlib/ModelTheory/Order.lean
@@ -56,6 +56,7 @@ end Order
 
 /-- A language is ordered if it has a symbol representing `≤`. -/
 class IsOrdered (L : Language.{u, v}) where
+  /-- The relation symbol representing `≤`. -/
   leSymb : L.Relations 2
 
 export IsOrdered (leSymb)
@@ -275,3 +276,4 @@ end order_to_structure
 end Language
 
 end FirstOrder
+#lint

--- a/Mathlib/ModelTheory/Order.lean
+++ b/Mathlib/ModelTheory/Order.lean
@@ -36,7 +36,6 @@ namespace FirstOrder
 
 namespace Language
 
-
 open FirstOrder Structure
 
 variable {L : Language.{u, v}} {α : Type w} {M : Type w'} {n : ℕ}
@@ -44,9 +43,6 @@ variable {L : Language.{u, v}} {α : Type w} {M : Type w'} {n : ℕ}
 /-- The language consisting of a single relation representing `≤`. -/
 protected def order : Language :=
   Language.mk₂ Empty Empty Empty Empty Unit
-
-instance orderStructure [LE M] : Language.order.Structure M :=
-  Structure.mk₂ Empty.elim Empty.elim Empty.elim Empty.elim fun _ => (· ≤ ·)
 
 namespace Order
 
@@ -83,26 +79,17 @@ variable (L)
 def orderLHom : Language.order →ᴸ L :=
   LHom.mk₂ Empty.elim Empty.elim Empty.elim Empty.elim fun _ => leSymb
 
-end IsOrdered
-
 instance : IsOrdered Language.order :=
   ⟨Unit.unit⟩
 
 @[simp]
-theorem orderLHom_leSymb [L.IsOrdered] :
+theorem orderLHom_leSymb :
     (orderLHom L).onRelation leSymb = (leSymb : L.Relations 2) :=
   rfl
 
 @[simp]
 theorem orderLHom_order : orderLHom Language.order = LHom.id Language.order :=
   LHom.funext (Subsingleton.elim _ _) (Subsingleton.elim _ _)
-
-instance sum.instIsOrdered : IsOrdered (L.sum Language.order) :=
-  ⟨Sum.inr IsOrdered.leSymb⟩
-
-section
-
-variable (L) [IsOrdered L]
 
 /-- The theory of preorders. -/
 def preorderTheory : L.Theory :=
@@ -154,9 +141,15 @@ def denselyOrderedSentence : L.Sentence :=
 def dlo : L.Theory :=
   L.linearOrderTheory ∪ {L.noTopOrderSentence, L.noBotOrderSentence, L.denselyOrderedSentence}
 
-end
+end IsOrdered
+
+instance sum.instIsOrdered : IsOrdered (L.sum Language.order) :=
+  ⟨Sum.inr IsOrdered.leSymb⟩
 
 variable (L M)
+
+instance orderStructure [LE M] : Language.order.Structure M :=
+  Structure.mk₂ Empty.elim Empty.elim Empty.elim Empty.elim fun _ => (· ≤ ·)
 
 /-- A structure is ordered if its language has a `≤` symbol whose interpretation is -/
 abbrev OrderedStructure [IsOrdered L] [LE M] [L.Structure M] : Prop :=
@@ -165,59 +158,33 @@ abbrev OrderedStructure [IsOrdered L] [LE M] [L.Structure M] : Prop :=
 variable {L M}
 
 @[simp]
-theorem orderedStructure_iff [IsOrdered L] [LE M] [L.Structure M] :
-    L.OrderedStructure M ↔ LHom.IsExpansionOn (orderLHom L) M :=
-  Iff.rfl
-
-instance orderedStructure_LE [LE M] : OrderedStructure Language.order M := by
-  rw [orderedStructure_iff, orderLHom_order]
-  exact LHom.id_isExpansionOn M
-
-instance model_preorder [Preorder M] : M ⊨ Language.order.preorderTheory := by
-  simp only [preorderTheory, Theory.model_iff, Set.mem_insert_iff, Set.mem_singleton_iff,
-    forall_eq_or_imp, Relations.realize_reflexive, relMap_apply₂, forall_eq,
-    Relations.realize_transitive]
-  exact ⟨le_refl, fun _ _ _ => le_trans⟩
-
-instance model_partialOrder [PartialOrder M] : M ⊨ Language.order.partialOrderTheory := by
-  simp only [partialOrderTheory, Theory.model_iff, Set.mem_insert_iff, Set.mem_singleton_iff,
-    forall_eq_or_imp, Relations.realize_reflexive, relMap_apply₂, Relations.realize_antisymmetric,
-    forall_eq, Relations.realize_transitive]
-  exact ⟨le_refl, fun _ _ => le_antisymm, fun _ _ _ => le_trans⟩
-
-instance model_linearOrder [LinearOrder M] : M ⊨ Language.order.linearOrderTheory := by
-  simp only [linearOrderTheory, Theory.model_iff, Set.mem_insert_iff, Set.mem_singleton_iff,
-    forall_eq_or_imp, Relations.realize_reflexive, relMap_apply₂, Relations.realize_antisymmetric,
-    Relations.realize_transitive, forall_eq, Relations.realize_total]
-  exact ⟨le_refl, fun _ _ => le_antisymm, fun _ _ _ => le_trans, le_total⟩
-
-section OrderedStructure
-
-variable [IsOrdered L] [L.Structure M]
-
-@[simp]
-theorem relMap_leSymb [LE M] [L.OrderedStructure M] {a b : M} :
+theorem relMap_leSymb [IsOrdered L] [LE M] [L.Structure M] [L.OrderedStructure M] {a b : M} :
     RelMap (leSymb : L.Relations 2) ![a, b] ↔ a ≤ b := by
   rw [← orderLHom_leSymb, LHom.map_onRelation]
   rfl
 
 @[simp]
-theorem Term.realize_le [LE M] [L.OrderedStructure M] {t₁ t₂ : L.Term (α ⊕ (Fin n))} {v : α → M}
-    {xs : Fin n → M} :
-    (t₁.le t₂).Realize v xs ↔ t₁.realize (Sum.elim v xs) ≤ t₂.realize (Sum.elim v xs) := by
-  simp [Term.le]
+theorem orderedStructure_iff [IsOrdered L] [LE M] [L.Structure M] :
+    L.OrderedStructure M ↔ LHom.IsExpansionOn (orderLHom L) M :=
+  Iff.rfl
 
-@[simp]
-theorem Term.realize_lt [Preorder M] [L.OrderedStructure M] {t₁ t₂ : L.Term (α ⊕ (Fin n))}
-    {v : α → M} {xs : Fin n → M} :
-    (t₁.lt t₂).Realize v xs ↔ t₁.realize (Sum.elim v xs) < t₂.realize (Sum.elim v xs) := by
-  simp [Term.lt, lt_iff_le_not_le]
+section order_to_structure
 
-end OrderedStructure
+variable [IsOrdered L] [L.Structure M]
 
 section LE
 
-variable [LE M]
+variable [LE M] [L.OrderedStructure M]
+
+instance orderedStructure_LE [LE M] : OrderedStructure Language.order M := by
+  rw [orderedStructure_iff, orderLHom_order]
+  exact LHom.id_isExpansionOn M
+
+@[simp]
+theorem Term.realize_le {t₁ t₂ : L.Term (α ⊕ (Fin n))} {v : α → M}
+    {xs : Fin n → M} :
+    (t₁.le t₂).Realize v xs ↔ t₁.realize (Sum.elim v xs) ≤ t₂.realize (Sum.elim v xs) := by
+  simp [Term.le]
 
 theorem realize_noTopOrder_iff : M ⊨ Language.order.noTopOrderSentence ↔ NoTopOrder M := by
   simp only [noTopOrderSentence, Sentence.Realize, Formula.Realize, BoundedFormula.realize_all,
@@ -245,7 +212,23 @@ theorem realize_noBotOrder [h : NoBotOrder M] : M ⊨ Language.order.noBotOrderS
 
 end LE
 
-theorem realize_denselyOrdered_iff [Preorder M] :
+section Preorder
+
+variable [Preorder M]
+
+instance model_preorder : M ⊨ Language.order.preorderTheory := by
+  simp only [preorderTheory, Theory.model_iff, Set.mem_insert_iff, Set.mem_singleton_iff,
+    forall_eq_or_imp, Relations.realize_reflexive, relMap_apply₂, forall_eq,
+    Relations.realize_transitive]
+  exact ⟨le_refl, fun _ _ _ => le_trans⟩
+
+@[simp]
+theorem Term.realize_lt [L.OrderedStructure M] {t₁ t₂ : L.Term (α ⊕ (Fin n))}
+    {v : α → M} {xs : Fin n → M} :
+    (t₁.lt t₂).Realize v xs ↔ t₁.realize (Sum.elim v xs) < t₂.realize (Sum.elim v xs) := by
+  simp [Term.lt, lt_iff_le_not_le]
+
+theorem realize_denselyOrdered_iff :
     M ⊨ Language.order.denselyOrderedSentence ↔ DenselyOrdered M := by
   simp only [denselyOrderedSentence, Sentence.Realize, Formula.Realize,
     BoundedFormula.realize_imp, BoundedFormula.realize_all, Term.realize, Term.realize_lt,
@@ -255,17 +238,39 @@ theorem realize_denselyOrdered_iff [Preorder M] :
   exact exists_between ab
 
 @[simp]
-theorem realize_denselyOrdered [Preorder M] [h : DenselyOrdered M] :
+theorem realize_denselyOrdered [h : DenselyOrdered M] :
     M ⊨ Language.order.denselyOrderedSentence :=
   realize_denselyOrdered_iff.2 h
 
-instance model_dlo [LinearOrder M] [DenselyOrdered M] [NoTopOrder M] [NoBotOrder M] :
+end Preorder
+
+instance model_partialOrder [PartialOrder M] : M ⊨ Language.order.partialOrderTheory := by
+  simp only [partialOrderTheory, Theory.model_iff, Set.mem_insert_iff, Set.mem_singleton_iff,
+    forall_eq_or_imp, Relations.realize_reflexive, relMap_apply₂, Relations.realize_antisymmetric,
+    forall_eq, Relations.realize_transitive]
+  exact ⟨le_refl, fun _ _ => le_antisymm, fun _ _ _ => le_trans⟩
+
+section LinearOrder
+
+variable [LinearOrder M]
+
+instance model_linearOrder : M ⊨ Language.order.linearOrderTheory := by
+  simp only [linearOrderTheory, Theory.model_iff, Set.mem_insert_iff, Set.mem_singleton_iff,
+    forall_eq_or_imp, Relations.realize_reflexive, relMap_apply₂, Relations.realize_antisymmetric,
+    Relations.realize_transitive, forall_eq, Relations.realize_total]
+  exact ⟨le_refl, fun _ _ => le_antisymm, fun _ _ _ => le_trans, le_total⟩
+
+instance model_dlo [DenselyOrdered M] [NoTopOrder M] [NoBotOrder M] :
     M ⊨ Language.order.dlo := by
   simp only [dlo, Set.union_insert, Set.union_singleton, Theory.model_iff, Set.mem_insert_iff,
     forall_eq_or_imp, realize_noTopOrder, realize_noBotOrder, realize_denselyOrdered,
     true_and_iff]
   rw [← Theory.model_iff]
   infer_instance
+
+end LinearOrder
+
+end order_to_structure
 
 end Language
 


### PR DESCRIPTION
Reorganizes the file `ModelTheory/Order` to allow for future refactoring, including making `orderStructure` no longer an instance.
The new organization puts purely syntactical constructions first, and then separates out a separate section of results that use order instances to model-theoretic facts and data. This will make it easier to make `orderStructure` not a global instance, and introduce instances going the other direction, from model-theoretic instances to orders.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
