### PR TITLE
[Merged by Bors] - feat(SetTheory/Cardinal/Continuum): `x ^ ℵ₀ = 𝔠` for `2 ≤ x ≤ 𝔠`

### DIFF
--- a/Mathlib/SetTheory/Cardinal/Continuum.lean
+++ b/Mathlib/SetTheory/Cardinal/Continuum.lean
@@ -166,15 +166,22 @@ theorem continuum_mul_ofNat {n : ℕ} [Nat.AtLeastTwo n] : 𝔠 * no_index (OfNa
 
 
 @[simp]
-theorem aleph0_power_aleph0 : aleph0.{u} ^ aleph0.{u} = 𝔠 :=
+theorem aleph0_power_aleph0 : ℵ₀ ^ ℵ₀ = 𝔠 :=
   power_self_eq le_rfl
 
 @[simp]
-theorem nat_power_aleph0 {n : ℕ} (hn : 2 ≤ n) : (n ^ aleph0.{u} : Cardinal.{u}) = 𝔠 :=
+theorem nat_power_aleph0 {n : ℕ} (hn : 2 ≤ n) : n ^ ℵ₀ = 𝔠 :=
   nat_power_eq le_rfl hn
 
 @[simp]
-theorem continuum_power_aleph0 : continuum.{u} ^ aleph0.{u} = 𝔠 := by
+theorem continuum_power_aleph0 : 𝔠 ^ ℵ₀ = 𝔠 := by
   rw [← two_power_aleph0, ← power_mul, mul_eq_left le_rfl le_rfl aleph0_ne_zero]
+
+theorem power_aleph0_of_le_continuum {x : Cardinal} (h₁ : 2 ≤ x) (h₂ : x ≤ 𝔠) : x ^ ℵ₀ = 𝔠 := by
+  apply le_antisymm
+  · rw [← continuum_power_aleph0]
+    exact power_le_power_right h₂
+  · rw [← two_power_aleph0]
+    exact power_le_power_right h₁
 
 end Cardinal


### PR DESCRIPTION
We also make sure `ℵ₀` and `𝔠` notation is used throughout the file.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
