### PR TITLE
[Merged by Bors] - chore(update_dependencies*.yml): switch to a new access token

### DIFF
--- a/.github/workflows/update_dependencies.yml
+++ b/.github/workflows/update_dependencies.yml
@@ -12,7 +12,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          token: "${{ secrets.NIGHTLY_TESTING }}"
+          token: "${{ secrets.UPDATE_DEPENDENCIES_TOKEN }}"
 
       - name: Get PR and labels
         id: PR # all the steps below are skipped if 'ready-to-merge' is in the list of labels found here
@@ -52,7 +52,7 @@ jobs:
         if: ${{ !contains(steps.PR.outputs.pr_labels, 'ready-to-merge') }}
         uses: peter-evans/create-pull-request@v6
         with:
-          token: "${{ secrets.NIGHTLY_TESTING }}"
+          token: "${{ secrets.UPDATE_DEPENDENCIES_TOKEN }}"
           commit-message: "chore: update Mathlib dependencies ${{ env.timestamp }}"
           # this branch is referenced in update_dependencies_zulip.yml
           branch: "update-dependencies-bot-use-only"

--- a/.github/workflows/update_dependencies_zulip.yml
+++ b/.github/workflows/update_dependencies_zulip.yml
@@ -1,7 +1,5 @@
 name: Monitor Dependency Update Failures
 
-# This action currently uses the NIGHTLY_TESTING secret, but could be moved to a separate secret.
-
 on:
   workflow_run:
     workflows: ["continuous integration"]

--- a/.github/workflows/update_dependencies_zulip.yml
+++ b/.github/workflows/update_dependencies_zulip.yml
@@ -20,7 +20,7 @@ jobs:
         uses: actions/github-script@v7
         id: construct_message
         with:
-          github-token: ${{ secrets.NIGHTLY_TESTING }}
+          github-token: ${{ secrets.UPDATE_DEPENDENCIES_TOKEN }}
           result-encoding: string
           script: |
             const owner = context.repo.owner, repo = context.repo.repo;


### PR DESCRIPTION
It's better if the NIGHTLY_TESTING token is reserved for the nightly-testing-* branches.

This should also hopefully help with API limits.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
