### PR TITLE
[Merged by Bors] - chore(dependent-issues.yml): bump to final unreleased version of action

### DIFF
--- a/.github/workflows/dependent-issues.yml
+++ b/.github/workflows/dependent-issues.yml
@@ -18,7 +18,7 @@ jobs:
   check:
     runs-on: ubuntu-latest
     steps:
-      - uses: z0al/dependent-issues@v1
+      - uses: z0al/dependent-issues@75d554cd9494b6e1766bc9d08a81c26444ad5c5a
         env:
           # (Required) The token to use to make API calls to GitHub.
           GITHUB_TOKEN: ${{ secrets.DEPENDENT_ISSUES_TOKEN }}


### PR DESCRIPTION
The dependent-issues workflow uses up a bunch of our Github API quota since it tries to check the status of *every single open PR* and [thus frequently fails](https://github.com/leanprover-community/mathlib4/actions/workflows/dependent-issues.yml). It turns out the [`z0al/dependent-issues`](https://github.com/z0al/dependent-issues) action that it depends on has been archived, however the maintainer was kind enough to merge [a PR](https://github.com/z0al/dependent-issues/pull/546) which makes the action only check PRs with the "blocked-by-other-PR" label, which significantly reduces the API usage.

In this PR, I replace the `v1` tag (which was pointing to [an older version of the action](https://github.com/z0al/dependent-issues/releases/tag/v1.5.2)) with the ref of [the final commit](https://github.com/z0al/dependent-issues/commit/75d554cd9494b6e1766bc9d08a81c26444ad5c5a) to the dependent-issues action repo. (I checked the forks of the action and it didn't seem that any of them had taken up the mantle of successor.) I've checked the diff of the abovementioned fix to the dependent-issues action and tested this lightly in my fork of mathlib4 and the code does do what it says on the tin.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)

