### PR TITLE
[Merged by Bors] - feat(Order/SuccPred/Basic): relax typeclass assumptions on `IsWellOrder.toIsPredArchimedean`

### DIFF
--- a/Mathlib/Combinatorics/SimpleGraph/Walk.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Walk.lean
@@ -765,160 +765,61 @@ lemma notNilRec_cons {motive : {u w : V} → (p : G.Walk u w) → ¬ p.Nil → S
     motive (q.cons h) Walk.not_nil_cons) (h' : G.Adj u v) (q' : G.Walk v w) :
     @Walk.notNilRec _ _ _ _ _ cons _ _ = cons h' q' := by rfl
 
-/-- The second vertex of a walk. The nil walk gets the only vertex in it. -/
-def snd : G.Walk v w → V
-| nil' v => v
-| cons' u v w hadj _ => v
+/-- The second vertex along a non-nil walk. -/
+def sndOfNotNil (p : G.Walk v w) (hp : ¬ p.Nil) : V :=
+  p.notNilRec (@fun _ u _ _ _ => u) hp
 
-/-- The penultimate vertex of a walk. The nil walk gets the only vertex in it. -/
-def penultimate {v u : V} : G.Walk v u → V
-| nil => v
-| cons hadj nil => v
-| cons _ p => p.penultimate
-
-@[simp]
-lemma snd_nil : (@nil _ G v).snd = v := rfl
-
-@[simp]
-lemma snd_cons {t u v} (p : G.Walk u v) (h : G.Adj t u) : (p.cons h).snd = u := rfl
-
-@[simp]
-lemma penultimate_nil : (@nil _ G v).penultimate = v := rfl
-
-@[simp]
-lemma penultimate_cons_nil (h : G.Adj u v) : (cons h nil).penultimate = u := rfl
-
-@[simp]
-lemma penultimate_cons_cons {w'} (h : G.Adj u v) (h₂ : G.Adj v w) (p : G.Walk w w') :
-  (cons h (cons h₂ p)).penultimate = (cons h₂ p).penultimate := rfl
-
-lemma penultimate_cons_of_not_nil (h : G.Adj u v) (p : G.Walk v w) (hp : ¬ p.Nil) :
-    (cons h p).penultimate = p.penultimate :=
-  p.notNilRec (by simp) hp h
-
-@[simp]
-lemma penultimate_concat {t u v} (p : G.Walk u v) (h : G.Adj v t) :
-    (p.concat h).penultimate = v := by
-  induction p
-  · rfl
-  · rw [concat_cons, penultimate_cons_of_not_nil]
-    · simp [*]
-    · simp [concat, nil_iff_length_eq]
-
-@[simp] lemma adj_snd_of_not_nil {p : G.Walk v w} (hp : ¬ p.Nil) :
-    G.Adj v p.snd :=
+@[simp] lemma adj_sndOfNotNil {p : G.Walk v w} (hp : ¬ p.Nil) :
+    G.Adj v (p.sndOfNotNil hp) :=
   p.notNilRec (fun h _ => h) hp
 
-@[simp]
-lemma adj_penultimate_of_not_nil {p : G.Walk v w} (hp : ¬ p.Nil) :
-    G.Adj p.penultimate w := by
-  induction p with
-  | nil => simp at hp
-  | cons hadj p hind =>
-    cases p with
-    | nil => exact hadj
-    | _ => simp [hind]
-
-/-- The walk obtained by removing the first dart of a walk. -/
-def tail : (p : G.Walk u v) → G.Walk p.snd v
-| nil => nil
-| cons' u _ w hadj p => p
-
-def dropLast {v u : V} : (p : G.Walk v u) → G.Walk v p.penultimate
-| nil => nil
-| cons hadj nil => nil
-| cons hadj (cons hadj2 p) => cons hadj (cons hadj2 p).dropLast
-
-@[simp]
-lemma tail_nil : (@nil _ G v).tail = nil := rfl
-
-@[simp]
-lemma tail_cons {t u v} (p : G.Walk u v) (h : G.Adj t u) :
-    (p.cons h).tail = p := rfl
-
-@[simp]
-lemma dropLast_nil : (@nil _ G v).dropLast = nil := rfl
-
-@[simp]
-lemma dropLast_cons_nil (h : G.Adj u v) : (cons h nil).dropLast = nil := rfl
-
-@[simp]
-lemma dropLast_cons_cons {w'} (h : G.Adj u v) (h₂ : G.Adj v w) (p : G.Walk w w') :
-  (cons h (cons h₂ p)).dropLast = cons h (cons h₂ p).dropLast := rfl
-
-lemma dropLast_cons_of_not_nil (h : G.Adj u v) (p : G.Walk v w) (hp : ¬ p.Nil) :
-    (cons h p).dropLast = cons h (p.dropLast.copy rfl (penultimate_cons_of_not_nil _ _ hp).symm) :=
-  p.notNilRec (by simp) hp h
-
-@[simp]
-lemma dropLast_concat {t u v} (p : G.Walk u v) (h : G.Adj v t) :
-    (p.concat h).dropLast = p.copy rfl (by simp) := by
-  induction p
-  · rfl
-  · simp_rw [concat_cons]
-    rw [dropLast_cons_of_not_nil]
-    · simp [*]
-    · simp [concat, nil_iff_length_eq]
+/-- The walk obtained by removing the first dart of a non-nil walk. -/
+def tail (p : G.Walk u v) (hp : ¬ p.Nil) : G.Walk (p.sndOfNotNil hp) v :=
+  p.notNilRec (fun _ q => q) hp
 
 /-- The first dart of a walk. -/
 @[simps]
 def firstDart (p : G.Walk v w) (hp : ¬ p.Nil) : G.Dart where
   fst := v
-  snd := p.snd
-  adj := p.adj_snd_of_not_nil hp
+  snd := p.sndOfNotNil hp
+  adj := p.adj_sndOfNotNil hp
 
 lemma edge_firstDart (p : G.Walk v w) (hp : ¬ p.Nil) :
-    (p.firstDart hp).edge = s(v, p.snd) := rfl
+    (p.firstDart hp).edge = s(v, p.sndOfNotNil hp) := rfl
 
 variable {x y : V} -- TODO: rename to u, v, w instead?
 
 @[simp] lemma cons_tail_eq (p : G.Walk x y) (hp : ¬ p.Nil) :
-    p.tail.cons (p.adj_snd_of_not_nil hp) = p :=
+    cons (p.adj_sndOfNotNil hp) (p.tail hp) = p :=
   p.notNilRec (fun _ _ => rfl) hp
 
-@[simp]
-lemma conact_dropLast_eq (p : G.Walk x y) (hp : ¬ p.Nil) :
-    p.dropLast.concat (p.adj_penultimate_of_not_nil hp) = p := by
-  induction p with
-  | nil => simp at hp
-  | cons hadj p hind =>
-    cases p with
-    | nil => rfl
-    | _ => simp [hind]
-
 @[simp] lemma cons_support_tail (p : G.Walk x y) (hp : ¬p.Nil) :
-    x :: p.tail.support = p.support := by
-  rw [← support_cons, cons_tail_eq p hp]
+    x :: (p.tail hp).support = p.support := by
+  rw [← support_cons, cons_tail_eq]
 
 @[simp] lemma length_tail_add_one {p : G.Walk x y} (hp : ¬ p.Nil) :
-    p.tail.length + 1 = p.length := by
-  rw [← length_cons, cons_tail_eq p hp]
+    (p.tail hp).length + 1 = p.length := by
+  rw [← length_cons, cons_tail_eq]
 
 @[simp] lemma nil_copy {x' y' : V} {p : G.Walk x y} (hx : x = x') (hy : y = y') :
     (p.copy hx hy).Nil = p.Nil := by
   subst_vars; rfl
 
-@[simp]
-lemma support_tail (p : G.Walk u v) (hnp : ¬p.Nil) :
-    p.tail.support = p.support.tail := by
-  rw [← cons_support_tail p hnp, List.tail_cons]
+@[simp] lemma support_tail (p : G.Walk v v) (hp) :
+    (p.tail hp).support = p.support.tail := by
+  rw [← cons_support_tail p hp, List.tail_cons]
 
 @[simp]
-lemma snd_mem_support : (p : G.Walk u v) → p.snd ∈ p.support
-| nil => by simp
-| cons _ _ => by simp
+lemma tail_cons {t u v} (p : G.Walk u v) (h : G.Adj t u) :
+    (p.cons h).tail not_nil_cons = p := by
+  unfold Walk.tail; simp only [notNilRec_cons]
 
-@[simp]
-lemma penultimate_mem_support (p : G.Walk u v) : p.penultimate ∈ p.support := by
-  induction p with
-  | nil => simp
-  | cons hadj p hind =>
-    cases p with
-    | nil => simp
-    | _ =>
-      simp only [support_cons, List.mem_cons] at hind
-      simp [hind]
-
+lemma tail_support_eq_support_tail (p : G.Walk u v) (hnp : ¬p.Nil) :
+    (p.tail hnp).support = p.support.tail :=
+  p.notNilRec (by
+    intro u v w huv q
+    unfold Walk.tail
+    simp only [notNilRec_cons, Walk.support_cons, List.tail_cons]) hnp
 
 /-! ### Walk decompositions -/
 
@@ -1094,16 +995,17 @@ theorem exists_boundary_dart {u v : V} (p : G.Walk u v) (S : Set V) (uS : u ∈ 
       exact ⟨d, List.Mem.tail _ hd, hcd⟩
     · exact ⟨⟨(x, y), a⟩, List.Mem.head _, uS, h⟩
 
-lemma getVert_tail {u v n} (p : G.Walk u v) :
-    p.tail.getVert n = p.getVert (n + 1) := by
-  match p with
-  | nil => rfl
-  | cons hadj p => rfl
+lemma getVert_tail {u v n} (p : G.Walk u v) (hnp: ¬ p.Nil) :
+    (p.tail hnp).getVert n = p.getVert (n + 1) :=
+  p.notNilRec (fun _ _ ↦ by simp only [tail_cons, cons_getVert_succ]) hnp
 
-lemma getVert_one (p : G.Walk u v) : p.getVert 1 = p.snd := by
-  match p with
-  | nil => rfl
-  | cons _ p => simp
+@[simp]
+lemma cons_sndOfNotNil (q : G.Walk v w) (hadj : G.Adj u v) :
+    (q.cons hadj).sndOfNotNil not_nil_cons = v := by
+  unfold sndOfNotNil; simp only [notNilRec_cons]
+
+lemma getVert_one (p : G.Walk u v) (hnp : ¬ p.Nil) : p.getVert 1 = p.sndOfNotNil hnp :=
+  p.notNilRec (fun _ _ ↦ by simp only [cons_getVert_succ, getVert_zero, cons_sndOfNotNil]) hnp
 
 /-- Given a walk `w` and a node in the support, there exists a natural `n`, such that given node
 is the `n`-th node (zero-indexed) in the walk. In addition, `n` is at most the length of the path.
@@ -1130,17 +1032,13 @@ theorem mem_support_iff_exists_getVert {u v w : V} {p : G.Walk v w} :
         rw [@nil_iff_length_eq]
         have : 1 ≤ p.length := by omega
         exact Nat.not_eq_zero_of_lt this
-      rw [← support_tail _ hnp]
+      rw [← tail_support_eq_support_tail _ hnp]
       rw [mem_support_iff_exists_getVert]
       use n - 1
-      simp only [Nat.sub_le_iff_le_add, length_tail_add_one hnp, getVert_tail]
+      simp only [Nat.sub_le_iff_le_add, length_tail_add_one, getVert_tail]
       have : n - 1 + 1 = n := by omega
       rwa [this]
 termination_by p.length
-decreasing_by
-  simp_wf
-  rw [← length_tail_add_one hnp]
-  omega
 
 end Walk
 

--- a/Mathlib/Order/SuccPred/Basic.lean
+++ b/Mathlib/Order/SuccPred/Basic.lean
@@ -1358,9 +1358,9 @@ end bdd_range
 
 section IsWellOrder
 
-variable [LinearOrder α]
+variable [PartialOrder α]
 
-instance (priority := 100) IsWellOrder.toIsPredArchimedean [h : IsWellOrder α (· < ·)]
+instance (priority := 100) IsWellFounded.toIsPredArchimedean [h : IsWellFounded α (· < ·)]
     [PredOrder α] : IsPredArchimedean α :=
   ⟨fun {a b} => by
     refine WellFounded.fix (C := fun b => a ≤ b → ∃ n, Nat.iterate pred n b = a)
@@ -1369,14 +1369,14 @@ instance (priority := 100) IsWellOrder.toIsPredArchimedean [h : IsWellOrder α (
     replace hab := eq_or_lt_of_le hab
     rcases hab with (rfl | hab)
     · exact ⟨0, rfl⟩
-    rcases le_or_lt b (pred b) with hb | hb
-    · cases (min_of_le_pred hb).not_lt hab
+    rcases eq_or_lt_of_le (pred_le b) with hb | hb
+    · cases (min_of_le_pred hb.ge).not_lt hab
     dsimp at ih
     obtain ⟨k, hk⟩ := ih (pred b) hb (le_pred_of_lt hab)
     refine ⟨k + 1, ?_⟩
     rw [iterate_add_apply, iterate_one, hk]⟩
 
-instance (priority := 100) IsWellOrder.toIsSuccArchimedean [h : IsWellOrder α (· > ·)]
+instance (priority := 100) IsWellFounded.toIsSuccArchimedean [h : IsWellFounded α (· > ·)]
     [SuccOrder α] : IsSuccArchimedean α :=
   let h : IsPredArchimedean αᵒᵈ := by infer_instance
   ⟨h.1⟩

--- a/Mathlib/Order/SuccPred/Basic.lean
+++ b/Mathlib/Order/SuccPred/Basic.lean
@@ -1360,7 +1360,7 @@ section IsWellFounded
 
 variable [PartialOrder α]
 
-instance (priority := 100) IsWellFounded.toIsPredArchimedean [h : IsWellFounded α (· < ·)]
+instance (priority := 100) IsWellFounded.toIsPredArchimedean [h : WellFoundedLT α]
     [PredOrder α] : IsPredArchimedean α :=
   ⟨fun {a b} => by
     refine WellFounded.fix (C := fun b => a ≤ b → ∃ n, Nat.iterate pred n b = a)
@@ -1376,7 +1376,7 @@ instance (priority := 100) IsWellFounded.toIsPredArchimedean [h : IsWellFounded 
     refine ⟨k + 1, ?_⟩
     rw [iterate_add_apply, iterate_one, hk]⟩
 
-instance (priority := 100) IsWellFounded.toIsSuccArchimedean [h : IsWellFounded α (· > ·)]
+instance (priority := 100) IsWellFounded.toIsSuccArchimedean [h : WellFoundedGT α]
     [SuccOrder α] : IsSuccArchimedean α :=
   let h : IsPredArchimedean αᵒᵈ := by infer_instance
   ⟨h.1⟩

--- a/Mathlib/Order/SuccPred/Basic.lean
+++ b/Mathlib/Order/SuccPred/Basic.lean
@@ -1360,7 +1360,7 @@ section IsWellFounded
 
 variable [PartialOrder α]
 
-instance (priority := 100) IsWellFounded.toIsPredArchimedean [h : WellFoundedLT α]
+instance (priority := 100) WellFoundedLT.toIsPredArchimedean [h : WellFoundedLT α]
     [PredOrder α] : IsPredArchimedean α :=
   ⟨fun {a b} => by
     refine WellFounded.fix (C := fun b => a ≤ b → ∃ n, Nat.iterate pred n b = a)
@@ -1376,7 +1376,7 @@ instance (priority := 100) IsWellFounded.toIsPredArchimedean [h : WellFoundedLT 
     refine ⟨k + 1, ?_⟩
     rw [iterate_add_apply, iterate_one, hk]⟩
 
-instance (priority := 100) IsWellFounded.toIsSuccArchimedean [h : WellFoundedGT α]
+instance (priority := 100) WellFoundedGT.toIsSuccArchimedean [h : WellFoundedGT α]
     [SuccOrder α] : IsSuccArchimedean α :=
   let h : IsPredArchimedean αᵒᵈ := by infer_instance
   ⟨h.1⟩

--- a/Mathlib/Order/SuccPred/Basic.lean
+++ b/Mathlib/Order/SuccPred/Basic.lean
@@ -1356,7 +1356,7 @@ lemma StrictAnti.not_bddBelow_range [NoMaxOrder α] [PredOrder β] [IsPredArchim
 
 end bdd_range
 
-section IsWellOrder
+section IsWellFounded
 
 variable [PartialOrder α]
 
@@ -1381,7 +1381,7 @@ instance (priority := 100) IsWellFounded.toIsSuccArchimedean [h : IsWellFounded 
   let h : IsPredArchimedean αᵒᵈ := by infer_instance
   ⟨h.1⟩
 
-end IsWellOrder
+end IsWellFounded
 
 section OrderBot
 


### PR DESCRIPTION
Make `IsWellOrder.toIsPredArchimedean` and `IsWellOrder.toIsSuccArchimedean` work with non-linear orders.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
