### PR TITLE
[Merged by Bors] - chore(Algebra/Order/Monoid/Submonoid): Don't import `GroupWithZero`

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -583,6 +583,7 @@ import Mathlib.Algebra.Order.Group.Unbundled.Int
 import Mathlib.Algebra.Order.Group.Units
 import Mathlib.Algebra.Order.GroupWithZero.Action.Synonym
 import Mathlib.Algebra.Order.GroupWithZero.Canonical
+import Mathlib.Algebra.Order.GroupWithZero.Submonoid
 import Mathlib.Algebra.Order.GroupWithZero.Synonym
 import Mathlib.Algebra.Order.GroupWithZero.Unbundled
 import Mathlib.Algebra.Order.GroupWithZero.WithZero

--- a/Mathlib/Algebra/Order/GroupWithZero/Submonoid.lean
+++ b/Mathlib/Algebra/Order/GroupWithZero/Submonoid.lean
@@ -1,0 +1,27 @@
+/-
+Copyright (c) 2021 Chris Birkbeck. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Chris Birkbeck
+-/
+import Mathlib.Algebra.Group.Submonoid.Basic
+import Mathlib.Algebra.Order.GroupWithZero.Unbundled
+
+/-!
+# The submonoid of positive elements
+-/
+
+namespace Submonoid
+variable (α) [MulZeroOneClass α] [PartialOrder α] [PosMulStrictMono α] [ZeroLEOneClass α]
+  [NeZero (1 : α)] {a : α}
+
+/-- The submonoid of positive elements. -/
+@[simps] def pos : Submonoid α where
+  carrier := Set.Ioi 0
+  one_mem' := zero_lt_one
+  mul_mem' := mul_pos
+
+variable {α}
+
+@[simp] lemma mem_pos : a ∈ pos α ↔ 0 < a := Iff.rfl
+
+end Submonoid

--- a/Mathlib/Algebra/Order/Monoid/Submonoid.lean
+++ b/Mathlib/Algebra/Order/Monoid/Submonoid.lean
@@ -3,15 +3,14 @@ Copyright (c) 2021 Damiano Testa. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Damiano Testa
 -/
-
 import Mathlib.Algebra.Group.Submonoid.Operations
-import Mathlib.Algebra.Order.GroupWithZero.Unbundled
 import Mathlib.Algebra.Order.Monoid.Basic
-import Mathlib.Algebra.Order.ZeroLEOne
 
 /-!
 # Ordered instances on submonoids
 -/
+
+assert_not_exists MonoidWithZero
 
 namespace SubmonoidClass
 variable {M S : Type*} [SetLike S M]
@@ -103,21 +102,4 @@ variable {M}
 @[to_additive (attr := simp) mem_nonneg] lemma mem_oneLE : a ∈ oneLE M ↔ 1 ≤ a := Iff.rfl
 
 end Preorder
-
-section MulZeroClass
-variable (α) [MulZeroOneClass α] [PartialOrder α] [PosMulStrictMono α] [ZeroLEOneClass α]
-  [NeZero (1 : α)] {a : α}
-
-/-- The submonoid of positive elements. -/
-@[simps] def pos : Submonoid α where
-  carrier := Set.Ioi 0
-  one_mem' := zero_lt_one
-  mul_mem' := mul_pos
-
-variable {α}
-
-@[simp] lemma mem_pos : a ∈ pos α ↔ 0 < a := Iff.rfl
-
-end MulZeroClass
-
 end Submonoid

--- a/Mathlib/Algebra/Ring/Subring/Units.lean
+++ b/Mathlib/Algebra/Ring/Subring/Units.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Chris Birkbeck
 -/
 import Mathlib.Algebra.Group.Subgroup.Basic
-import Mathlib.Algebra.Order.Monoid.Submonoid
+import Mathlib.Algebra.Order.GroupWithZero.Submonoid
 import Mathlib.Algebra.Order.Ring.Defs
 
 /-!


### PR DESCRIPTION
Move `Submonoid.pos` to a new file `Algebra.Order.GroupWithZero.Submonoid`. Credit Chris for https://github.com/leanprover-community/mathlib3/pull/8466


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
