### PR TITLE
[Merged by Bors] - feat: Prop-valued version of `RCLike` structure for normed fields

### DIFF
--- a/Mathlib/Analysis/Calculus/MeanValue.lean
+++ b/Mathlib/Analysis/Calculus/MeanValue.lean
@@ -428,7 +428,7 @@ variable {𝕜 G : Type*} [NontriviallyNormedField 𝕜] [IsRCLikeNormedField �
   [NormedSpace 𝕜 E] [NormedAddCommGroup G] [NormedSpace 𝕜 G]
   {f g : E → G} {C : ℝ} {s : Set E} {x y : E} {f' g' : E → E →L[𝕜] G} {φ : E →L[𝕜] G}
 
-instance : PathConnectedSpace 𝕜 := by
+instance (priority := 100) : PathConnectedSpace 𝕜 := by
   letI : RCLike 𝕜 := IsRCLikeNormedField.rclike 𝕜
   infer_instance
 

--- a/Mathlib/Analysis/Calculus/MeanValue.lean
+++ b/Mathlib/Analysis/Calculus/MeanValue.lean
@@ -416,22 +416,24 @@ end
 ### Vector-valued functions `f : E → G`
 
 Theorems in this section work both for real and complex differentiable functions. We use assumptions
-`[RCLike 𝕜] [NormedSpace 𝕜 E] [NormedSpace 𝕜 G]` to achieve this result. For the domain `E` we
-also assume `[NormedSpace ℝ E]` to have a notion of a `Convex` set. -/
+`[NontriviallyNormedField 𝕜] [IsRCLikeNormedField 𝕜] [NormedSpace 𝕜 E] [NormedSpace 𝕜 G]` to
+achieve this result. For the domain `E` we also assume `[NormedSpace ℝ E]` to have a notion
+of a `Convex` set. -/
 
 section
 
-variable {𝕜 G : Type*} [RCLike 𝕜] [NormedSpace 𝕜 E] [NormedAddCommGroup G] [NormedSpace 𝕜 G]
-
 namespace Convex
 
-variable {f g : E → G} {C : ℝ} {s : Set E} {x y : E} {f' g' : E → E →L[𝕜] G} {φ : E →L[𝕜] G}
+variable {𝕜 G : Type*} [NontriviallyNormedField 𝕜] [IsRCLikeNormedField 𝕜]
+  [NormedSpace 𝕜 E] [NormedAddCommGroup G] [NormedSpace 𝕜 G]
+  {f g : E → G} {C : ℝ} {s : Set E} {x y : E} {f' g' : E → E →L[𝕜] G} {φ : E →L[𝕜] G}
 
 /-- The mean value theorem on a convex set: if the derivative of a function is bounded by `C`, then
 the function is `C`-Lipschitz. Version with `HasFDerivWithinAt`. -/
 theorem norm_image_sub_le_of_norm_hasFDerivWithin_le
     (hf : ∀ x ∈ s, HasFDerivWithinAt f (f' x) s x) (bound : ∀ x ∈ s, ‖f' x‖ ≤ C) (hs : Convex ℝ s)
     (xs : x ∈ s) (ys : y ∈ s) : ‖f y - f x‖ ≤ C * ‖y - x‖ := by
+  letI : RCLike 𝕜 := IsRCLikeNormedField.rclike 𝕜
   letI : NormedSpace ℝ G := RestrictScalars.normedSpace ℝ 𝕜 G
   /- By composition with `AffineMap.lineMap x y`, we reduce to a statement for functions defined
     on `[0,1]`, for which it is proved in `norm_image_sub_le_of_norm_deriv_le_segment`.
@@ -524,6 +526,7 @@ theorem _root_.lipschitzWith_of_nnnorm_fderiv_le
     {E : Type*} [NormedAddCommGroup E] [NormedSpace 𝕜 E] {f : E → G}
     {C : ℝ≥0} (hf : Differentiable 𝕜 f)
     (bound : ∀ x, ‖fderiv 𝕜 f x‖₊ ≤ C) : LipschitzWith C f := by
+  letI : RCLike 𝕜 := IsRCLikeNormedField.rclike 𝕜
   let A : NormedSpace ℝ E := RestrictScalars.normedSpace ℝ 𝕜 E
   rw [← lipschitzOnWith_univ]
   exact lipschitzOnWith_of_nnnorm_fderiv_le (fun x _ ↦ hf x) (fun x _ ↦ bound x) convex_univ
@@ -573,6 +576,7 @@ theorem _root_.is_const_of_fderiv_eq_zero
     {E : Type*} [NormedAddCommGroup E] [NormedSpace 𝕜 E] {f : E → G}
     (hf : Differentiable 𝕜 f) (hf' : ∀ x, fderiv 𝕜 f x = 0)
     (x y : E) : f x = f y := by
+  letI : RCLike 𝕜 := IsRCLikeNormedField.rclike 𝕜
   let A : NormedSpace ℝ E := RestrictScalars.normedSpace ℝ 𝕜 E
   exact convex_univ.is_const_of_fderivWithin_eq_zero hf.differentiableOn
     (fun x _ => by rw [fderivWithin_univ]; exact hf' x) trivial trivial
@@ -591,6 +595,7 @@ theorem _root_.eq_of_fderiv_eq
     {E : Type*} [NormedAddCommGroup E] [NormedSpace 𝕜 E] {f g : E → G}
     (hf : Differentiable 𝕜 f) (hg : Differentiable 𝕜 g)
     (hf' : ∀ x, fderiv 𝕜 f x = fderiv 𝕜 g x) (x : E) (hfgx : f x = g x) : f = g := by
+  letI : RCLike 𝕜 := IsRCLikeNormedField.rclike 𝕜
   let A : NormedSpace ℝ E := RestrictScalars.normedSpace ℝ 𝕜 E
   suffices Set.univ.EqOn f g from funext fun x => this <| mem_univ x
   exact convex_univ.eqOn_of_fderivWithin_eq hf.differentiableOn hg.differentiableOn
@@ -600,7 +605,8 @@ end Convex
 
 namespace Convex
 
-variable {f f' : 𝕜 → G} {s : Set 𝕜} {x y : 𝕜}
+variable {𝕜 G : Type*} [RCLike 𝕜] [NormedAddCommGroup G] [NormedSpace 𝕜 G]
+  {f f' : 𝕜 → G} {s : Set 𝕜} {x y : 𝕜}
 
 /-- The mean value theorem on a convex set in dimension 1: if the derivative of a function is
 bounded by `C`, then the function is `C`-Lipschitz. Version with `HasDerivWithinAt`. -/

--- a/Mathlib/Analysis/Calculus/MeanValue.lean
+++ b/Mathlib/Analysis/Calculus/MeanValue.lean
@@ -428,6 +428,10 @@ variable {𝕜 G : Type*} [NontriviallyNormedField 𝕜] [IsRCLikeNormedField �
   [NormedSpace 𝕜 E] [NormedAddCommGroup G] [NormedSpace 𝕜 G]
   {f g : E → G} {C : ℝ} {s : Set E} {x y : E} {f' g' : E → E →L[𝕜] G} {φ : E →L[𝕜] G}
 
+instance : PathConnectedSpace 𝕜 := by
+  letI : RCLike 𝕜 := IsRCLikeNormedField.rclike 𝕜
+  infer_instance
+
 /-- The mean value theorem on a convex set: if the derivative of a function is bounded by `C`, then
 the function is `C`-Lipschitz. Version with `HasFDerivWithinAt`. -/
 theorem norm_image_sub_le_of_norm_hasFDerivWithin_le

--- a/Mathlib/Analysis/Calculus/SmoothSeries.lean
+++ b/Mathlib/Analysis/Calculus/SmoothSeries.lean
@@ -26,8 +26,8 @@ open Set Metric TopologicalSpace Function Asymptotics Filter
 
 open scoped Topology NNReal
 
-variable {α β 𝕜 E F : Type*} [RCLike 𝕜] [NormedAddCommGroup E] [NormedSpace 𝕜 E]
-  [NormedAddCommGroup F] [CompleteSpace F] {u : α → ℝ}
+variable {α β 𝕜 E F : Type*} [NontriviallyNormedField 𝕜] [IsRCLikeNormedField 𝕜]
+  [NormedAddCommGroup E] [NormedSpace 𝕜 E] [NormedAddCommGroup F] [CompleteSpace F] {u : α → ℝ}
 
 /-! ### Differentiability -/
 

--- a/Mathlib/Analysis/Calculus/SmoothSeries.lean
+++ b/Mathlib/Analysis/Calculus/SmoothSeries.lean
@@ -100,6 +100,7 @@ then the series converges everywhere. -/
 theorem summable_of_summable_hasFDerivAt (hu : Summable u)
     (hf : ∀ n x, HasFDerivAt (f n) (f' n x) x) (hf' : ∀ n x, ‖f' n x‖ ≤ u n)
     (hf0 : Summable fun n => f n x₀) (x : E) : Summable fun n => f n x := by
+  letI : RCLike 𝕜 := IsRCLikeNormedField.rclike 𝕜
   let _ : NormedSpace ℝ E := NormedSpace.restrictScalars ℝ 𝕜 _
   exact summable_of_summable_hasFDerivAt_of_isPreconnected hu isOpen_univ isPreconnected_univ
     (fun n x _ => hf n x) (fun n x _ => hf' n x) (mem_univ _) hf0 (mem_univ _)
@@ -119,6 +120,7 @@ then the series is differentiable and its derivative is the sum of the derivativ
 theorem hasFDerivAt_tsum (hu : Summable u) (hf : ∀ n x, HasFDerivAt (f n) (f' n x) x)
     (hf' : ∀ n x, ‖f' n x‖ ≤ u n) (hf0 : Summable fun n => f n x₀) (x : E) :
     HasFDerivAt (fun y => ∑' n, f n y) (∑' n, f' n x) x := by
+  letI : RCLike 𝕜 := IsRCLikeNormedField.rclike 𝕜
   let A : NormedSpace ℝ E := NormedSpace.restrictScalars ℝ 𝕜 _
   exact hasFDerivAt_tsum_of_isPreconnected hu isOpen_univ isPreconnected_univ
     (fun n x _ => hf n x) (fun n x _ => hf' n x) (mem_univ _) hf0 (mem_univ _)

--- a/Mathlib/Analysis/Calculus/UniformLimitsDeriv.lean
+++ b/Mathlib/Analysis/Calculus/UniformLimitsDeriv.lean
@@ -99,7 +99,8 @@ open scoped uniformity Filter Topology
 
 section LimitsOfDerivatives
 
-variable {ι : Type*} {l : Filter ι} {E : Type*} [NormedAddCommGroup E] {𝕜 : Type*} [RCLike 𝕜]
+variable {ι : Type*} {l : Filter ι} {E : Type*} [NormedAddCommGroup E] {𝕜 : Type*}
+  [NontriviallyNormedField 𝕜] [IsRCLikeNormedField 𝕜]
   [NormedSpace 𝕜 E] {G : Type*} [NormedAddCommGroup G] [NormedSpace 𝕜 G] {f : ι → E → G}
   {g : E → G} {f' : ι → E → E →L[𝕜] G} {g' : E → E →L[𝕜] G} {x : E}
 
@@ -110,6 +111,7 @@ sequence in a neighborhood of `x`. -/
 theorem uniformCauchySeqOnFilter_of_fderiv (hf' : UniformCauchySeqOnFilter f' l (𝓝 x))
     (hf : ∀ᶠ n : ι × E in l ×ˢ 𝓝 x, HasFDerivAt (f n.1) (f' n.1 n.2) n.2)
     (hfg : Cauchy (map (fun n => f n x) l)) : UniformCauchySeqOnFilter f l (𝓝 x) := by
+  letI : RCLike 𝕜 := IsRCLikeNormedField.rclike 𝕜
   letI : NormedSpace ℝ E := NormedSpace.restrictScalars ℝ 𝕜 _
   rw [SeminormedAddGroup.uniformCauchySeqOnFilter_iff_tendstoUniformlyOnFilter_zero] at hf' ⊢
   suffices
@@ -173,6 +175,7 @@ convergence. See `cauchy_map_of_uniformCauchySeqOn_fderiv`.
 theorem uniformCauchySeqOn_ball_of_fderiv {r : ℝ} (hf' : UniformCauchySeqOn f' l (Metric.ball x r))
     (hf : ∀ n : ι, ∀ y : E, y ∈ Metric.ball x r → HasFDerivAt (f n) (f' n y) y)
     (hfg : Cauchy (map (fun n => f n x) l)) : UniformCauchySeqOn f l (Metric.ball x r) := by
+  letI : RCLike 𝕜 := IsRCLikeNormedField.rclike 𝕜
   letI : NormedSpace ℝ E := NormedSpace.restrictScalars ℝ 𝕜 _
   have : NeBot l := (cauchy_map_iff.1 hfg).1
   rcases le_or_lt r 0 with (hr | hr)

--- a/Mathlib/Analysis/Calculus/UniformLimitsDeriv.lean
+++ b/Mathlib/Analysis/Calculus/UniformLimitsDeriv.lean
@@ -252,7 +252,11 @@ theorem cauchy_map_of_uniformCauchySeqOn_fderiv {s : Set E} (hs : IsOpen s) (h's
 /-- If `f_n → g` pointwise and the derivatives `(f_n)' → h` _uniformly_ converge, then
 in fact for a fixed `y`, the difference quotients `‖z - y‖⁻¹ • (f_n z - f_n y)` converge
 _uniformly_ to `‖z - y‖⁻¹ • (g z - g y)` -/
-theorem difference_quotients_converge_uniformly (hf' : TendstoUniformlyOnFilter f' g' l (𝓝 x))
+theorem difference_quotients_converge_uniformly
+    {E : Type*} [NormedAddCommGroup E] {𝕜 : Type*} [RCLike 𝕜]
+    [NormedSpace 𝕜 E] {G : Type*} [NormedAddCommGroup G] [NormedSpace 𝕜 G] {f : ι → E → G}
+    {g : E → G} {f' : ι → E → E →L[𝕜] G} {g' : E → E →L[𝕜] G} {x : E}
+    (hf' : TendstoUniformlyOnFilter f' g' l (𝓝 x))
     (hf : ∀ᶠ n : ι × E in l ×ˢ 𝓝 x, HasFDerivAt (f n.1) (f' n.1 n.2) n.2)
     (hfg : ∀ᶠ y : E in 𝓝 x, Tendsto (fun n => f n y) l (𝓝 (g y))) :
     TendstoUniformlyOnFilter (fun n : ι => fun y : E => (‖y - x‖⁻¹ : 𝕜) • (f n y - f n x))
@@ -305,6 +309,7 @@ theorem hasFDerivAt_of_tendstoUniformlyOnFilter [NeBot l]
     (hf' : TendstoUniformlyOnFilter f' g' l (𝓝 x))
     (hf : ∀ᶠ n : ι × E in l ×ˢ 𝓝 x, HasFDerivAt (f n.1) (f' n.1 n.2) n.2)
     (hfg : ∀ᶠ y in 𝓝 x, Tendsto (fun n => f n y) l (𝓝 (g y))) : HasFDerivAt g (g' x) x := by
+  letI : RCLike 𝕜 := IsRCLikeNormedField.rclike 𝕜
   -- The proof strategy follows several steps:
   --   1. The quantifiers in the definition of the derivative are
   --      `∀ ε > 0, ∃δ > 0, ∀y ∈ B_δ(x)`. We will introduce a quantifier in the middle:
@@ -439,7 +444,8 @@ In this section, we provide `deriv` equivalents of the `fderiv` lemmas in the pr
 -/
 
 
-variable {ι : Type*} {l : Filter ι} {𝕜 : Type*} [RCLike 𝕜] {G : Type*} [NormedAddCommGroup G]
+variable {ι : Type*} {l : Filter ι} {𝕜 : Type*} [NontriviallyNormedField 𝕜]
+  {G : Type*} [NormedAddCommGroup G]
   [NormedSpace 𝕜 G] {f : ι → 𝕜 → G} {g : 𝕜 → G} {f' : ι → 𝕜 → G} {g' : 𝕜 → G} {x : 𝕜}
 
 /-- If our derivatives converge uniformly, then the Fréchet derivatives converge uniformly -/
@@ -463,6 +469,8 @@ theorem UniformCauchySeqOnFilter.one_smulRight {l' : Filter 𝕜}
     ContinuousLinearMap.one_apply]
   rw [← smul_sub, norm_smul, mul_comm]
   gcongr
+
+variable [IsRCLikeNormedField 𝕜]
 
 theorem uniformCauchySeqOnFilter_of_deriv (hf' : UniformCauchySeqOnFilter f' l (𝓝 x))
     (hf : ∀ᶠ n : ι × 𝕜 in l ×ˢ 𝓝 x, HasDerivAt (f n.1) (f' n.1 n.2) n.2)

--- a/Mathlib/Analysis/NormedSpace/HahnBanach/Extension.lean
+++ b/Mathlib/Analysis/NormedSpace/HahnBanach/Extension.lean
@@ -62,159 +62,17 @@ section RCLike
 
 -- open RCLike
 
-class IsRorC (𝕜 : Type*) [hk : NormedField 𝕜] : Prop :=
-  out : ∃ h : RCLike 𝕜, h.toNormedField = hk
 
-instance {𝕜 : Type*} [h : RCLike 𝕜] : IsRorC 𝕜 := ⟨⟨h, rfl⟩⟩
-
-instance : IsRorC ℝ := by infer_instance
-
-suppress_compilation
-
-/-- A copy of an `RCLike` field in which the `NormedField` field is adjusted to be become defeq
-to a propeq one. -/
-def RCLike.copy {𝕜 : Type*} (h : RCLike 𝕜)  (hk : NormedField 𝕜)
-    (h'' : h.toNormedField = hk) : RCLike 𝕜 where
-  __ := hk
-  lt_norm_lt := fun x y hx hy ↦ by simpa [h''] using h.lt_norm_lt x y hx hy
-  -- star fields
-  star := (@StarMul.toInvolutiveStar _ (_) (@StarRing.toStarMul _ (_) h.toStarRing)).star
-  star_involutive :=
-    @star_involutive _ (@StarMul.toInvolutiveStar _ (_) (@StarRing.toStarMul _ (_) h.toStarRing))
-  star_mul x y := by
-    convert @star_mul _ (_)  (@StarRing.toStarMul _ (_) h.toStarRing) x y <;> simp only [h'']
-  star_add x y := by
-    convert @StarRing.star_add _ (_) h.toStarRing x y <;> simp only [h'']
-  smul := (@Algebra.toSMul _ _ _ (_) (@NormedAlgebra.toAlgebra _ _ _ (_) h.toNormedAlgebra)).smul
-  -- algebra fields
-  toFun := @Algebra.toRingHom _ _ _ (_) (@NormedAlgebra.toAlgebra _ _ _ (_) h.toNormedAlgebra)
-  map_one' := sorry /-by
-    let Z := (@Algebra.toRingHom _ _ _ (_) (@NormedAlgebra.toAlgebra _ _ _ (_) h.toNormedAlgebra))
-    convert @OneHom.map_one' _ _ _ (_) (@MonoidHom.toOneHom _ _ _ (_)
-      (@RingHom.toMonoidHom _ _ _ (_) Z))
-    simp only [h'']-/
-  map_mul' x y := sorry /-by
-    let Z := (@Algebra.toRingHom _ _ _ (_) (@NormedAlgebra.toAlgebra _ _ _ (_) h.toNormedAlgebra))
-    convert @MulHom.map_mul' _ _ _ (_) (@MonoidHom.toMulHom _ _ _ (_)
-      (@RingHom.toMonoidHom _ _ _ (_) Z)) x y <;>
-    simp only [h'']-/
-  map_zero' := sorry /-by
-    let Z := (@Algebra.toRingHom _ _ _ (_) (@NormedAlgebra.toAlgebra _ _ _ (_) h.toNormedAlgebra))
-    convert @ZeroHom.map_zero' _ _ _ (_) (@AddMonoidHom.toZeroHom _ _ _ (_)
-      (@RingHom.toAddMonoidHom _ _ _ (_) Z)) <;>
-    simp only [h'']-/
-  map_add' x y := sorry /-by
-    let Z := (@Algebra.toRingHom _ _ _ (_) (@NormedAlgebra.toAlgebra _ _ _ (_) h.toNormedAlgebra))
-    convert @AddHom.map_add' _ _ _ (_) (@AddMonoidHom.toAddHom _ _ _ (_)
-      (@RingHom.toAddMonoidHom _ _ _ (_) Z)) x y <;>
-    simp only [h'']-/
-  commutes' r x := sorry /-by
-    convert @Algebra.commutes' _ _ _ (_) (@NormedAlgebra.toAlgebra _ _ _ (_) h.toNormedAlgebra) r x
-    <;> simp only [h''] -/
-  smul_def' r x := sorry /-by
-    convert @Algebra.smul_def' _ _ _ (_) (@NormedAlgebra.toAlgebra _ _ _ (_) h.toNormedAlgebra) r x
-    <;> simp only [h'']-/
-  norm_smul_le r x := by
-    convert @NormedAlgebra.norm_smul_le _ _ _ (_) h.toNormedAlgebra r x <;> simp only [h'']
-  complete := by
-    convert @CompleteSpace.complete _ (_) h.toCompleteSpace <;> simp only [h'']
-  -- RCLike fields
-  re :=
-    { toFun := h.re
-      map_zero' := by
-        convert @ZeroHom.map_zero' _ _ (_) _ (@AddMonoidHom.toZeroHom _ _ (_) _ h.re)
-        simp only [h'']
-      map_add' := by
-        intro x y
-        convert @AddHom.map_add' _ _ (_) _ (@AddMonoidHom.toAddHom _ _ (_) _ h.re) x y
-        <;> simp only [h''] }
-  im :=
-    { toFun := h.im
-      map_zero' := by
-        convert @ZeroHom.map_zero' _ _ (_) _ (@AddMonoidHom.toZeroHom _ _ (_) _ h.im)
-        simp only [h'']
-      map_add' := by
-        intro x y
-        convert @AddHom.map_add' _ _ (_) _ (@AddMonoidHom.toAddHom _ _ (_) _ h.im) x y
-        <;> simp only [h''] }
-  I := h.I
-  I_re_ax := sorry -- by convert h.I_re_ax <;> simp only [h'']
-  I_mul_I_ax := sorry -- by convert h.I_mul_I_ax <;> simp only [h'']
-  re_add_im_ax z := sorry -- by convert h.re_add_im_ax z <;> simp only [h'']
-  ofReal_re_ax r := sorry -- by convert h.ofReal_re_ax r <;> simp only [h'']
-  ofReal_im_ax r := sorry -- by convert h.ofReal_im_ax r <;> simp only [h'']
-  mul_re_ax z w := by convert h.mul_re_ax z w <;> simp only [h'']
-  mul_im_ax z w := by convert h.mul_im_ax z w <;> simp only [h'']
-  conj_re_ax z := by convert h.conj_re_ax z <;> simp only [h'']
-  conj_im_ax z := by convert h.conj_im_ax z <;> simp only [h'']
-  conj_I_ax := by convert h.conj_I_ax <;> simp only [h'']
-  norm_sq_eq_def_ax z := by convert h.norm_sq_eq_def_ax z <;> simp only [h'']
-  mul_im_I_ax := sorry
-  le_iff_re_im := sorry
-  toPartialOrder := h.toPartialOrder
-  toDecidableEq := h.toDecidableEq
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-#exit
-
-  star :=
-  star_involutive :=
-  #exit
-
-  star_mul', 'star_add', 'smul', 'toFun', 'map_one'', 'map_mul'', 'map_zero'', 'map_add'', 'commutes'', 'smul_def'', 'norm_smul_le', 'complete', 're', 'im', 'I', 'I_re_ax', 'I_mul_I_ax', 're_add_im_ax', 'ofReal_re_ax', 'ofReal_im_ax', 'mul_re_ax', 'mul_im_ax', 'conj_re_ax', 'conj_im_ax', 'conj_I_ax', 'norm_sq_eq_def_ax', 'mul_im_I_ax', 'le_iff_re_im'
-
-
-
-#exit
-
-
-  let A : DenselyNormedField 𝕜 :=
-  { toNormedField := hk
-    lt_norm_lt := fun x y hx hy ↦ by simpa [h''] using h.lt_norm_lt x y hx hy }
-  let B : StarRing 𝕜 where
-    __ := hk
-
-
-#exit
-
-  refine
-  { toDenselyNormedField := A
-
-
-  }
-
-
-#exit
-
-variable {𝕜 : Type*} [RCLike 𝕜] {E F : Type*}
+variable {𝕜 : Type*} [NontriviallyNormedField 𝕜] [IsROrCNormedField 𝕜] {E F : Type*}
   [SeminormedAddCommGroup E] [NormedSpace 𝕜 E]
   [NormedAddCommGroup F] [NormedSpace 𝕜 F]
+
+open RCLike
 
 /-- **Hahn-Banach theorem** for continuous linear functions over `𝕜` satisfying `RCLike 𝕜`. -/
 theorem exists_extension_norm_eq (p : Subspace 𝕜 E) (f : p →L[𝕜] 𝕜) :
     ∃ g : E →L[𝕜] 𝕜, (∀ x : p, g x = f x) ∧ ‖g‖ = ‖f‖ := by
+  letI : RCLike 𝕜 := IsRorC.rclike 𝕜
   letI : Module ℝ E := RestrictScalars.module ℝ 𝕜 E
   letI : IsScalarTower ℝ 𝕜 E := RestrictScalars.isScalarTower _ _ _
   letI : NormedSpace ℝ E := NormedSpace.restrictScalars _ 𝕜 _
@@ -264,6 +122,7 @@ we provide no estimates on the norm of the extension.
 lemma ContinuousLinearMap.exist_extension_of_finiteDimensional_range {p : Submodule 𝕜 E}
     (f : p →L[𝕜] F) [FiniteDimensional 𝕜 (LinearMap.range f)] :
     ∃ g : E →L[𝕜] F, f = g.comp p.subtypeL := by
+  letI : RCLike 𝕜 := IsRorC.rclike 𝕜
   set b := finBasis 𝕜 (LinearMap.range f)
   set e := b.equivFunL
   set fi := fun i ↦ (LinearMap.toContinuousLinearMap (b.coord i)).comp
@@ -287,8 +146,6 @@ variable (𝕜 : Type v) [RCLike 𝕜]
 variable {E : Type u} [NormedAddCommGroup E] [NormedSpace 𝕜 E]
 
 open ContinuousLinearEquiv Submodule
-
-open scoped Classical
 
 theorem coord_norm' {x : E} (h : x ≠ 0) : ‖(‖x‖ : 𝕜) • coord 𝕜 x h‖ = 1 := by
   #adaptation_note

--- a/Mathlib/Analysis/NormedSpace/HahnBanach/Extension.lean
+++ b/Mathlib/Analysis/NormedSpace/HahnBanach/Extension.lean
@@ -63,7 +63,7 @@ section RCLike
 -- open RCLike
 
 
-variable {𝕜 : Type*} [NontriviallyNormedField 𝕜] [IsROrCNormedField 𝕜] {E F : Type*}
+variable {𝕜 : Type*} [NontriviallyNormedField 𝕜] [IsRCLikeNormedField 𝕜] {E F : Type*}
   [SeminormedAddCommGroup E] [NormedSpace 𝕜 E]
   [NormedAddCommGroup F] [NormedSpace 𝕜 F]
 
@@ -72,7 +72,7 @@ open RCLike
 /-- **Hahn-Banach theorem** for continuous linear functions over `𝕜` satisfying `RCLike 𝕜`. -/
 theorem exists_extension_norm_eq (p : Subspace 𝕜 E) (f : p →L[𝕜] 𝕜) :
     ∃ g : E →L[𝕜] 𝕜, (∀ x : p, g x = f x) ∧ ‖g‖ = ‖f‖ := by
-  letI : RCLike 𝕜 := IsRorC.rclike 𝕜
+  letI : RCLike 𝕜 := IsRCLikeNormedField.rclike.rclike 𝕜
   letI : Module ℝ E := RestrictScalars.module ℝ 𝕜 E
   letI : IsScalarTower ℝ 𝕜 E := RestrictScalars.isScalarTower _ _ _
   letI : NormedSpace ℝ E := NormedSpace.restrictScalars _ 𝕜 _
@@ -122,7 +122,7 @@ we provide no estimates on the norm of the extension.
 lemma ContinuousLinearMap.exist_extension_of_finiteDimensional_range {p : Submodule 𝕜 E}
     (f : p →L[𝕜] F) [FiniteDimensional 𝕜 (LinearMap.range f)] :
     ∃ g : E →L[𝕜] F, f = g.comp p.subtypeL := by
-  letI : RCLike 𝕜 := IsRorC.rclike 𝕜
+  letI : RCLike 𝕜 := IsRCLikeNormedField.rclike 𝕜
   set b := finBasis 𝕜 (LinearMap.range f)
   set e := b.equivFunL
   set fi := fun i ↦ (LinearMap.toContinuousLinearMap (b.coord i)).comp

--- a/Mathlib/Analysis/NormedSpace/HahnBanach/Extension.lean
+++ b/Mathlib/Analysis/NormedSpace/HahnBanach/Extension.lean
@@ -69,8 +69,7 @@ instance {𝕜 : Type*} [h : RCLike 𝕜] : IsRorC 𝕜 := ⟨⟨h, rfl⟩⟩
 
 instance : IsRorC ℝ := by infer_instance
 
-lemma foo {𝕜 : Type*} (h : RCLike 𝕜) : True := by
-  let Z := h.toStar
+suppress_compilation
 
 /-- A copy of an `RCLike` field in which the `NormedField` field is adjusted to be become defeq
 to a propeq one. -/
@@ -119,6 +118,7 @@ def RCLike.copy {𝕜 : Type*} (h : RCLike 𝕜)  (hk : NormedField 𝕜)
     convert @NormedAlgebra.norm_smul_le _ _ _ (_) h.toNormedAlgebra r x <;> simp only [h'']
   complete := by
     convert @CompleteSpace.complete _ (_) h.toCompleteSpace <;> simp only [h'']
+  -- RCLike fields
   re :=
     { toFun := h.re
       map_zero' := by
@@ -138,6 +138,23 @@ def RCLike.copy {𝕜 : Type*} (h : RCLike 𝕜)  (hk : NormedField 𝕜)
         convert @AddHom.map_add' _ _ (_) _ (@AddMonoidHom.toAddHom _ _ (_) _ h.im) x y
         <;> simp only [h''] }
   I := h.I
+  I_re_ax := sorry -- by convert h.I_re_ax <;> simp only [h'']
+  I_mul_I_ax := sorry -- by convert h.I_mul_I_ax <;> simp only [h'']
+  re_add_im_ax z := sorry -- by convert h.re_add_im_ax z <;> simp only [h'']
+  ofReal_re_ax r := sorry -- by convert h.ofReal_re_ax r <;> simp only [h'']
+  ofReal_im_ax r := sorry -- by convert h.ofReal_im_ax r <;> simp only [h'']
+  mul_re_ax z w := by convert h.mul_re_ax z w <;> simp only [h'']
+  mul_im_ax z w := by convert h.mul_im_ax z w <;> simp only [h'']
+  conj_re_ax z := by convert h.conj_re_ax z <;> simp only [h'']
+  conj_im_ax z := by convert h.conj_im_ax z <;> simp only [h'']
+  conj_I_ax := by convert h.conj_I_ax <;> simp only [h'']
+  norm_sq_eq_def_ax z := by convert h.norm_sq_eq_def_ax z <;> simp only [h'']
+  mul_im_I_ax := sorry
+  le_iff_re_im := sorry
+  toPartialOrder := h.toPartialOrder
+  toDecidableEq := h.toDecidableEq
+
+
 
 
 

--- a/Mathlib/Analysis/NormedSpace/HahnBanach/Extension.lean
+++ b/Mathlib/Analysis/NormedSpace/HahnBanach/Extension.lean
@@ -66,8 +66,6 @@ variable {𝕜 : Type*} [NontriviallyNormedField 𝕜] [IsRCLikeNormedField 𝕜
   [SeminormedAddCommGroup E] [NormedSpace 𝕜 E]
   [NormedAddCommGroup F] [NormedSpace 𝕜 F]
 
-open RCLike
-
 /-- **Hahn-Banach theorem** for continuous linear functions over `𝕜`
 satisfying `IsRCLikeNormedField 𝕜`. -/
 theorem exists_extension_norm_eq (p : Subspace 𝕜 E) (f : p →L[𝕜] 𝕜) :

--- a/Mathlib/Analysis/NormedSpace/HahnBanach/Extension.lean
+++ b/Mathlib/Analysis/NormedSpace/HahnBanach/Extension.lean
@@ -60,8 +60,7 @@ end Real
 
 section RCLike
 
--- open RCLike
-
+open RCLike
 
 variable {𝕜 : Type*} [NontriviallyNormedField 𝕜] [IsRCLikeNormedField 𝕜] {E F : Type*}
   [SeminormedAddCommGroup E] [NormedSpace 𝕜 E]
@@ -72,7 +71,7 @@ open RCLike
 /-- **Hahn-Banach theorem** for continuous linear functions over `𝕜` satisfying `RCLike 𝕜`. -/
 theorem exists_extension_norm_eq (p : Subspace 𝕜 E) (f : p →L[𝕜] 𝕜) :
     ∃ g : E →L[𝕜] 𝕜, (∀ x : p, g x = f x) ∧ ‖g‖ = ‖f‖ := by
-  letI : RCLike 𝕜 := IsRCLikeNormedField.rclike.rclike 𝕜
+  letI : RCLike 𝕜 := IsRCLikeNormedField.rclike 𝕜
   letI : Module ℝ E := RestrictScalars.module ℝ 𝕜 E
   letI : IsScalarTower ℝ 𝕜 E := RestrictScalars.isScalarTower _ _ _
   letI : NormedSpace ℝ E := NormedSpace.restrictScalars _ 𝕜 _

--- a/Mathlib/Analysis/NormedSpace/HahnBanach/Extension.lean
+++ b/Mathlib/Analysis/NormedSpace/HahnBanach/Extension.lean
@@ -60,7 +60,136 @@ end Real
 
 section RCLike
 
-open RCLike
+-- open RCLike
+
+class IsRorC (𝕜 : Type*) [hk : NormedField 𝕜] : Prop :=
+  out : ∃ h : RCLike 𝕜, h.toNormedField = hk
+
+instance {𝕜 : Type*} [h : RCLike 𝕜] : IsRorC 𝕜 := ⟨⟨h, rfl⟩⟩
+
+instance : IsRorC ℝ := by infer_instance
+
+lemma foo {𝕜 : Type*} (h : RCLike 𝕜) : True := by
+  let Z := h.toStar
+
+/-- A copy of an `RCLike` field in which the `NormedField` field is adjusted to be become defeq
+to a propeq one. -/
+def RCLike.copy {𝕜 : Type*} (h : RCLike 𝕜)  (hk : NormedField 𝕜)
+    (h'' : h.toNormedField = hk) : RCLike 𝕜 where
+  __ := hk
+  lt_norm_lt := fun x y hx hy ↦ by simpa [h''] using h.lt_norm_lt x y hx hy
+  -- star fields
+  star := (@StarMul.toInvolutiveStar _ (_) (@StarRing.toStarMul _ (_) h.toStarRing)).star
+  star_involutive :=
+    @star_involutive _ (@StarMul.toInvolutiveStar _ (_) (@StarRing.toStarMul _ (_) h.toStarRing))
+  star_mul x y := by
+    convert @star_mul _ (_)  (@StarRing.toStarMul _ (_) h.toStarRing) x y <;> simp only [h'']
+  star_add x y := by
+    convert @StarRing.star_add _ (_) h.toStarRing x y <;> simp only [h'']
+  smul := (@Algebra.toSMul _ _ _ (_) (@NormedAlgebra.toAlgebra _ _ _ (_) h.toNormedAlgebra)).smul
+  -- algebra fields
+  toFun := @Algebra.toRingHom _ _ _ (_) (@NormedAlgebra.toAlgebra _ _ _ (_) h.toNormedAlgebra)
+  map_one' := sorry /-by
+    let Z := (@Algebra.toRingHom _ _ _ (_) (@NormedAlgebra.toAlgebra _ _ _ (_) h.toNormedAlgebra))
+    convert @OneHom.map_one' _ _ _ (_) (@MonoidHom.toOneHom _ _ _ (_)
+      (@RingHom.toMonoidHom _ _ _ (_) Z))
+    simp only [h'']-/
+  map_mul' x y := sorry /-by
+    let Z := (@Algebra.toRingHom _ _ _ (_) (@NormedAlgebra.toAlgebra _ _ _ (_) h.toNormedAlgebra))
+    convert @MulHom.map_mul' _ _ _ (_) (@MonoidHom.toMulHom _ _ _ (_)
+      (@RingHom.toMonoidHom _ _ _ (_) Z)) x y <;>
+    simp only [h'']-/
+  map_zero' := sorry /-by
+    let Z := (@Algebra.toRingHom _ _ _ (_) (@NormedAlgebra.toAlgebra _ _ _ (_) h.toNormedAlgebra))
+    convert @ZeroHom.map_zero' _ _ _ (_) (@AddMonoidHom.toZeroHom _ _ _ (_)
+      (@RingHom.toAddMonoidHom _ _ _ (_) Z)) <;>
+    simp only [h'']-/
+  map_add' x y := sorry /-by
+    let Z := (@Algebra.toRingHom _ _ _ (_) (@NormedAlgebra.toAlgebra _ _ _ (_) h.toNormedAlgebra))
+    convert @AddHom.map_add' _ _ _ (_) (@AddMonoidHom.toAddHom _ _ _ (_)
+      (@RingHom.toAddMonoidHom _ _ _ (_) Z)) x y <;>
+    simp only [h'']-/
+  commutes' r x := sorry /-by
+    convert @Algebra.commutes' _ _ _ (_) (@NormedAlgebra.toAlgebra _ _ _ (_) h.toNormedAlgebra) r x
+    <;> simp only [h''] -/
+  smul_def' r x := sorry /-by
+    convert @Algebra.smul_def' _ _ _ (_) (@NormedAlgebra.toAlgebra _ _ _ (_) h.toNormedAlgebra) r x
+    <;> simp only [h'']-/
+  norm_smul_le r x := by
+    convert @NormedAlgebra.norm_smul_le _ _ _ (_) h.toNormedAlgebra r x <;> simp only [h'']
+  complete := by
+    convert @CompleteSpace.complete _ (_) h.toCompleteSpace <;> simp only [h'']
+  re :=
+    { toFun := h.re
+      map_zero' := by
+        convert @ZeroHom.map_zero' _ _ (_) _ (@AddMonoidHom.toZeroHom _ _ (_) _ h.re)
+        simp only [h'']
+      map_add' := by
+        intro x y
+        convert @AddHom.map_add' _ _ (_) _ (@AddMonoidHom.toAddHom _ _ (_) _ h.re) x y
+        <;> simp only [h''] }
+  im :=
+    { toFun := h.im
+      map_zero' := by
+        convert @ZeroHom.map_zero' _ _ (_) _ (@AddMonoidHom.toZeroHom _ _ (_) _ h.im)
+        simp only [h'']
+      map_add' := by
+        intro x y
+        convert @AddHom.map_add' _ _ (_) _ (@AddMonoidHom.toAddHom _ _ (_) _ h.im) x y
+        <;> simp only [h''] }
+  I := h.I
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+#exit
+
+  star :=
+  star_involutive :=
+  #exit
+
+  star_mul', 'star_add', 'smul', 'toFun', 'map_one'', 'map_mul'', 'map_zero'', 'map_add'', 'commutes'', 'smul_def'', 'norm_smul_le', 'complete', 're', 'im', 'I', 'I_re_ax', 'I_mul_I_ax', 're_add_im_ax', 'ofReal_re_ax', 'ofReal_im_ax', 'mul_re_ax', 'mul_im_ax', 'conj_re_ax', 'conj_im_ax', 'conj_I_ax', 'norm_sq_eq_def_ax', 'mul_im_I_ax', 'le_iff_re_im'
+
+
+
+#exit
+
+
+  let A : DenselyNormedField 𝕜 :=
+  { toNormedField := hk
+    lt_norm_lt := fun x y hx hy ↦ by simpa [h''] using h.lt_norm_lt x y hx hy }
+  let B : StarRing 𝕜 where
+    __ := hk
+
+
+#exit
+
+  refine
+  { toDenselyNormedField := A
+
+
+  }
+
+
+#exit
 
 variable {𝕜 : Type*} [RCLike 𝕜] {E F : Type*}
   [SeminormedAddCommGroup E] [NormedSpace 𝕜 E]

--- a/Mathlib/Analysis/NormedSpace/HahnBanach/Extension.lean
+++ b/Mathlib/Analysis/NormedSpace/HahnBanach/Extension.lean
@@ -68,7 +68,8 @@ variable {𝕜 : Type*} [NontriviallyNormedField 𝕜] [IsRCLikeNormedField 𝕜
 
 open RCLike
 
-/-- **Hahn-Banach theorem** for continuous linear functions over `𝕜` satisfying `RCLike 𝕜`. -/
+/-- **Hahn-Banach theorem** for continuous linear functions over `𝕜`
+satisfying `IsRCLikeNormedField 𝕜`. -/
 theorem exists_extension_norm_eq (p : Subspace 𝕜 E) (f : p →L[𝕜] 𝕜) :
     ∃ g : E →L[𝕜] 𝕜, (∀ x : p, g x = f x) ∧ ‖g‖ = ‖f‖ := by
   letI : RCLike 𝕜 := IsRCLikeNormedField.rclike 𝕜
@@ -112,8 +113,7 @@ open FiniteDimensional
 
 /-- Corollary of the **Hahn-Banach theorem**: if `f : p → F` is a continuous linear map
 from a submodule of a normed space `E` over `𝕜`, `𝕜 = ℝ` or `𝕜 = ℂ`,
-with a finite dimensional range,
-then `f` admits an extension to a continuous linear map `E → F`.
+with a finite dimensional range, then `f` admits an extension to a continuous linear map `E → F`.
 
 Note that contrary to the case `F = 𝕜`, see `exists_extension_norm_eq`,
 we provide no estimates on the norm of the extension.

--- a/Mathlib/Analysis/RCLike/Basic.lean
+++ b/Mathlib/Analysis/RCLike/Basic.lean
@@ -1067,7 +1067,7 @@ To endow such a field with a compatible `RCLike` structure in a proof, use
 class IsRCLikeNormedField (𝕜 : Type*) [hk : NormedField 𝕜] : Prop :=
   out : ∃ h : RCLike 𝕜, hk = h.toNormedField
 
-instance {𝕜 : Type*} [h : RCLike 𝕜] : IsRCLikeNormedField 𝕜 := ⟨⟨h, rfl⟩⟩
+instance (priority := 100) (𝕜 : Type*) [h : RCLike 𝕜] : IsRCLikeNormedField 𝕜 := ⟨⟨h, rfl⟩⟩
 
 /-- A copy of an `RCLike` field in which the `NormedField` field is adjusted to be become defeq
 to a propeq one. -/

--- a/Mathlib/Analysis/RCLike/Basic.lean
+++ b/Mathlib/Analysis/RCLike/Basic.lean
@@ -1058,3 +1058,62 @@ lemma map_neg_eq_conj [AddCommGroup G] (ψ : AddChar G K) (x : G) : ψ (-x) = co
   rw [map_neg_eq_inv, inv_apply_eq_conj]
 
 end AddChar
+
+namespace RCLike
+
+/-- A mixin over a normed field, saying that the norm field structure is the same as `ℝ` or `ℂ`.
+To endow such a field with a compatible `RCLike` structure in a proof, use
+`letI := IsROrCNormedField.rclike 𝕜`.-/
+class IsROrCNormedField (𝕜 : Type*) [hk : NormedField 𝕜] : Prop :=
+  out : ∃ h : RCLike 𝕜, hk = h.toNormedField
+
+instance {𝕜 : Type*} [h : RCLike 𝕜] : IsROrCNormedField 𝕜 := ⟨⟨h, rfl⟩⟩
+
+/-- A copy of an `RCLike` field in which the `NormedField` field is adjusted to be become defeq
+to a propeq one. -/
+noncomputable def copy_of_normedField {𝕜 : Type*} (h : RCLike 𝕜) (hk : NormedField 𝕜)
+    (h'' : hk = h.toNormedField) : RCLike 𝕜 where
+  __ := hk
+  toPartialOrder := h.toPartialOrder
+  toDecidableEq := h.toDecidableEq
+  complete := by subst h''; exact h.complete
+  lt_norm_lt := by subst h''; exact h.lt_norm_lt
+  -- star fields
+  star := (@StarMul.toInvolutiveStar _ (_) (@StarRing.toStarMul _ (_) h.toStarRing)).star
+  star_involutive := by subst h''; exact h.star_involutive
+  star_mul := by subst h''; exact h.star_mul
+  star_add := by subst h''; exact h.star_add
+  -- algebra fields
+  smul := (@Algebra.toSMul _ _ _ (_) (@NormedAlgebra.toAlgebra _ _ _ (_) h.toNormedAlgebra)).smul
+  toFun := @Algebra.toRingHom _ _ _ (_) (@NormedAlgebra.toAlgebra _ _ _ (_) h.toNormedAlgebra)
+  map_one' := by subst h''; exact h.map_one'
+  map_mul' := by subst h''; exact h.map_mul'
+  map_zero' := by subst h''; exact h.map_zero'
+  map_add' := by subst h''; exact h.map_add'
+  commutes' := by subst h''; exact h.commutes'
+  smul_def' := by subst h''; exact h.smul_def'
+  norm_smul_le := by subst h''; exact h.norm_smul_le
+  -- RCLike fields
+  re := by subst h''; exact h.re
+  im := by subst h''; exact h.im
+  I := h.I
+  I_re_ax := by subst h''; exact h.I_re_ax
+  I_mul_I_ax := by subst h''; exact h.I_mul_I_ax
+  re_add_im_ax := by subst h''; exact h.re_add_im_ax
+  ofReal_re_ax := by subst h''; exact h.ofReal_re_ax
+  ofReal_im_ax := by subst h''; exact h.ofReal_im_ax
+  mul_re_ax := by subst h''; exact h.mul_re_ax
+  mul_im_ax := by subst h''; exact h.mul_im_ax
+  conj_re_ax := by subst h''; exact h.conj_re_ax
+  conj_im_ax := by subst h''; exact h.conj_im_ax
+  conj_I_ax := by subst h''; exact h.conj_I_ax
+  norm_sq_eq_def_ax := by subst h''; exact h.norm_sq_eq_def_ax
+  mul_im_I_ax := by subst h''; exact h.mul_im_I_ax
+  le_iff_re_im := by subst h''; exact h.le_iff_re_im
+
+noncomputable def IsROrCNormedField.rclike (𝕜 : Type*)
+    [hk : NormedField 𝕜] [h : IsROrCNormedField 𝕜] : RCLike 𝕜 := by
+  choose p hp using h.out
+  exact p.copy_of_normedField hk hp
+
+end RCLike

--- a/Mathlib/Analysis/RCLike/Basic.lean
+++ b/Mathlib/Analysis/RCLike/Basic.lean
@@ -1067,7 +1067,7 @@ To endow such a field with a compatible `RCLike` structure in a proof, use
 class IsRCLikeNormedField (𝕜 : Type*) [hk : NormedField 𝕜] : Prop :=
   out : ∃ h : RCLike 𝕜, hk = h.toNormedField
 
-instance {𝕜 : Type*} [h : RCLike 𝕜] : IsROrCNormedField 𝕜 := ⟨⟨h, rfl⟩⟩
+instance {𝕜 : Type*} [h : RCLike 𝕜] : IsRCLikeNormedField 𝕜 := ⟨⟨h, rfl⟩⟩
 
 /-- A copy of an `RCLike` field in which the `NormedField` field is adjusted to be become defeq
 to a propeq one. -/

--- a/Mathlib/Analysis/RCLike/Basic.lean
+++ b/Mathlib/Analysis/RCLike/Basic.lean
@@ -1111,6 +1111,8 @@ noncomputable def RCLike.copy_of_normedField {𝕜 : Type*} (h : RCLike 𝕜) (h
   mul_im_I_ax := by subst h''; exact h.mul_im_I_ax
   le_iff_re_im := by subst h''; exact h.le_iff_re_im
 
+/-- Given a normed field `𝕜` satisfying `IsRCLikeNormedField 𝕜`, build an associated `RCLike 𝕜`
+structure on `𝕜` which is definitionally compatible with the given normed field structure. -/
 noncomputable def IsRCLikeNormedField.rclike (𝕜 : Type*)
     [hk : NormedField 𝕜] [h : IsRCLikeNormedField 𝕜] : RCLike 𝕜 := by
   choose p hp using h.out

--- a/Mathlib/Analysis/RCLike/Basic.lean
+++ b/Mathlib/Analysis/RCLike/Basic.lean
@@ -1063,8 +1063,8 @@ namespace RCLike
 
 /-- A mixin over a normed field, saying that the norm field structure is the same as `ℝ` or `ℂ`.
 To endow such a field with a compatible `RCLike` structure in a proof, use
-`letI := IsROrCNormedField.rclike 𝕜`.-/
-class IsROrCNormedField (𝕜 : Type*) [hk : NormedField 𝕜] : Prop :=
+`letI := IsRCLikeNormedField.rclike 𝕜`.-/
+class IsRCLikeNormedField (𝕜 : Type*) [hk : NormedField 𝕜] : Prop :=
   out : ∃ h : RCLike 𝕜, hk = h.toNormedField
 
 instance {𝕜 : Type*} [h : RCLike 𝕜] : IsROrCNormedField 𝕜 := ⟨⟨h, rfl⟩⟩
@@ -1111,8 +1111,8 @@ noncomputable def copy_of_normedField {𝕜 : Type*} (h : RCLike 𝕜) (hk : Nor
   mul_im_I_ax := by subst h''; exact h.mul_im_I_ax
   le_iff_re_im := by subst h''; exact h.le_iff_re_im
 
-noncomputable def IsROrCNormedField.rclike (𝕜 : Type*)
-    [hk : NormedField 𝕜] [h : IsROrCNormedField 𝕜] : RCLike 𝕜 := by
+noncomputable def IsRCLikeNormedField.rclike (𝕜 : Type*)
+    [hk : NormedField 𝕜] [h : IsRCLikeNormedField 𝕜] : RCLike 𝕜 := by
   choose p hp using h.out
   exact p.copy_of_normedField hk hp
 

--- a/Mathlib/Analysis/RCLike/Basic.lean
+++ b/Mathlib/Analysis/RCLike/Basic.lean
@@ -1059,7 +1059,7 @@ lemma map_neg_eq_conj [AddCommGroup G] (ψ : AddChar G K) (x : G) : ψ (-x) = co
 
 end AddChar
 
-namespace RCLike
+section
 
 /-- A mixin over a normed field, saying that the norm field structure is the same as `ℝ` or `ℂ`.
 To endow such a field with a compatible `RCLike` structure in a proof, use
@@ -1071,7 +1071,7 @@ instance {𝕜 : Type*} [h : RCLike 𝕜] : IsRCLikeNormedField 𝕜 := ⟨⟨h,
 
 /-- A copy of an `RCLike` field in which the `NormedField` field is adjusted to be become defeq
 to a propeq one. -/
-noncomputable def copy_of_normedField {𝕜 : Type*} (h : RCLike 𝕜) (hk : NormedField 𝕜)
+noncomputable def RCLike.copy_of_normedField {𝕜 : Type*} (h : RCLike 𝕜) (hk : NormedField 𝕜)
     (h'' : hk = h.toNormedField) : RCLike 𝕜 where
   __ := hk
   toPartialOrder := h.toPartialOrder
@@ -1116,4 +1116,4 @@ noncomputable def IsRCLikeNormedField.rclike (𝕜 : Type*)
   choose p hp using h.out
   exact p.copy_of_normedField hk hp
 
-end RCLike
+end

--- a/Mathlib/MeasureTheory/Integral/SetIntegral.lean
+++ b/Mathlib/MeasureTheory/Integral/SetIntegral.lean
@@ -1161,10 +1161,8 @@ as `ContinuousLinearMap.compLp`. We take advantage of this construction here.
 -/
 
 open scoped ComplexConjugate
-open RCLike
 
-variable {μ : Measure X} {𝕜 : Type*} [NontriviallyNormedField 𝕜]
-  [NormedAddCommGroup E] [NormedSpace 𝕜 E]
+variable {μ : Measure X} {𝕜 : Type*} [RCLike 𝕜] [NormedAddCommGroup E] [NormedSpace 𝕜 E]
   [NormedAddCommGroup F] [NormedSpace 𝕜 F] {p : ENNReal}
 
 namespace ContinuousLinearMap
@@ -1186,11 +1184,10 @@ theorem continuous_integral_comp_L1 (L : E →L[𝕜] F) :
     Continuous fun φ : X →₁[μ] E => ∫ x : X, L (φ x) ∂μ := by
   rw [← funext L.integral_compLp]; exact continuous_integral.comp (L.compLpL 1 μ).continuous
 
-variable [CompleteSpace F] [NormedSpace ℝ E] [IsRCLikeNormedField 𝕜]
+variable [CompleteSpace F] [NormedSpace ℝ E]
 
-theorem integral_comp_comm  [CompleteSpace E] (L : E →L[𝕜] F) {φ : X → E} (φ_int : Integrable φ μ) :
+theorem integral_comp_comm [CompleteSpace E] (L : E →L[𝕜] F) {φ : X → E} (φ_int : Integrable φ μ) :
     ∫ x, L (φ x) ∂μ = L (∫ x, φ x ∂μ) := by
-  letI := IsRCLikeNormedField.rclike 𝕜
   apply φ_int.induction (P := fun φ => ∫ x, L (φ x) ∂μ = L (∫ x, φ x ∂μ))
   · intro e s s_meas _
     rw [integral_indicator_const e s_meas, ← @smul_one_smul E ℝ 𝕜 _ _ _ _ _ (μ s).toReal e,
@@ -1207,9 +1204,7 @@ theorem integral_comp_comm  [CompleteSpace E] (L : E →L[𝕜] F) {φ : X → E
     · exact integral_congr_ae (hfg.fun_comp L).symm
     · rw [integral_congr_ae hfg.symm]
 
-theorem integral_apply {𝕜 : Type*} [RCLike 𝕜]
-    {E H : Type*} [NormedAddCommGroup E] [NormedSpace 𝕜 E]
-    [NormedAddCommGroup H] [NormedSpace 𝕜 H] {φ : X → H →L[𝕜] E}
+theorem integral_apply {H : Type*} [NormedAddCommGroup H] [NormedSpace 𝕜 H] {φ : X → H →L[𝕜] E}
     (φ_int : Integrable φ μ) (v : H) : (∫ x, φ x ∂μ) v = ∫ x, φ x v ∂μ := by
   by_cases hE : CompleteSpace E
   · exact ((ContinuousLinearMap.apply 𝕜 E v).integral_comp_comm φ_int).symm

--- a/Mathlib/MeasureTheory/Integral/SetIntegral.lean
+++ b/Mathlib/MeasureTheory/Integral/SetIntegral.lean
@@ -1161,8 +1161,10 @@ as `ContinuousLinearMap.compLp`. We take advantage of this construction here.
 -/
 
 open scoped ComplexConjugate
+open RCLike
 
-variable {μ : Measure X} {𝕜 : Type*} [RCLike 𝕜] [NormedAddCommGroup E] [NormedSpace 𝕜 E]
+variable {μ : Measure X} {𝕜 : Type*} [NontriviallyNormedField 𝕜]
+  [NormedAddCommGroup E] [NormedSpace 𝕜 E]
   [NormedAddCommGroup F] [NormedSpace 𝕜 F] {p : ENNReal}
 
 namespace ContinuousLinearMap
@@ -1184,10 +1186,11 @@ theorem continuous_integral_comp_L1 (L : E →L[𝕜] F) :
     Continuous fun φ : X →₁[μ] E => ∫ x : X, L (φ x) ∂μ := by
   rw [← funext L.integral_compLp]; exact continuous_integral.comp (L.compLpL 1 μ).continuous
 
-variable [CompleteSpace F] [NormedSpace ℝ E]
+variable [CompleteSpace F] [NormedSpace ℝ E] [IsRCLikeNormedField 𝕜]
 
-theorem integral_comp_comm [CompleteSpace E] (L : E →L[𝕜] F) {φ : X → E} (φ_int : Integrable φ μ) :
+theorem integral_comp_comm  [CompleteSpace E] (L : E →L[𝕜] F) {φ : X → E} (φ_int : Integrable φ μ) :
     ∫ x, L (φ x) ∂μ = L (∫ x, φ x ∂μ) := by
+  letI := IsRCLikeNormedField.rclike 𝕜
   apply φ_int.induction (P := fun φ => ∫ x, L (φ x) ∂μ = L (∫ x, φ x ∂μ))
   · intro e s s_meas _
     rw [integral_indicator_const e s_meas, ← @smul_one_smul E ℝ 𝕜 _ _ _ _ _ (μ s).toReal e,
@@ -1204,7 +1207,9 @@ theorem integral_comp_comm [CompleteSpace E] (L : E →L[𝕜] F) {φ : X → E}
     · exact integral_congr_ae (hfg.fun_comp L).symm
     · rw [integral_congr_ae hfg.symm]
 
-theorem integral_apply {H : Type*} [NormedAddCommGroup H] [NormedSpace 𝕜 H] {φ : X → H →L[𝕜] E}
+theorem integral_apply {𝕜 : Type*} [RCLike 𝕜]
+    {E H : Type*} [NormedAddCommGroup E] [NormedSpace 𝕜 E]
+    [NormedAddCommGroup H] [NormedSpace 𝕜 H] {φ : X → H →L[𝕜] E}
     (φ_int : Integrable φ μ) (v : H) : (∫ x, φ x ∂μ) v = ∫ x, φ x v ∂μ := by
   by_cases hE : CompleteSpace E
   · exact ((ContinuousLinearMap.apply 𝕜 E v).integral_comp_comm φ_int).symm


### PR DESCRIPTION
Motivation: I want a typeclass to be able to say that some classes of functions have symmetric second derivative wrt some normed field (this is a key point when defining the Lie algebra of a Lie group). Over R or C, this is true for C^2 functions. Over a general field, this is true for analytic functions. A first step is to have a typeclass saying whether a given normed field is R or C, implemented in this PR.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
