### PR TITLE
[Merged by Bors] - chore: rename IsAlgClosure fields

### DIFF
--- a/Mathlib/FieldTheory/IsAlgClosed/AlgebraicClosure.lean
+++ b/Mathlib/FieldTheory/IsAlgClosed/AlgebraicClosure.lean
@@ -405,7 +405,7 @@ instance : IsAlgClosure k (AlgebraicClosure k) := by
   exact ⟨inferInstance, (algEquivAlgebraicClosureAux k).symm.isAlgebraic⟩
 
 instance isAlgebraic : Algebra.IsAlgebraic k (AlgebraicClosure k) :=
-  IsAlgClosure.algebraic
+  IsAlgClosure.isAlgebraic
 
 instance [CharZero k] : CharZero (AlgebraicClosure k) :=
   charZero_of_injective_algebraMap (RingHom.injective (algebraMap k (AlgebraicClosure k)))

--- a/Mathlib/FieldTheory/IsAlgClosed/Basic.lean
+++ b/Mathlib/FieldTheory/IsAlgClosed/Basic.lean
@@ -202,10 +202,13 @@ lemma Polynomial.isCoprime_iff_aeval_ne_zero_of_isAlgClosed (K : Type v) [Field 
 /-- Typeclass for an extension being an algebraic closure. -/
 class IsAlgClosure (R : Type u) (K : Type v) [CommRing R] [Field K] [Algebra R K]
     [NoZeroSMulDivisors R K] : Prop where
-  alg_closed : IsAlgClosed K
-  algebraic : Algebra.IsAlgebraic R K
+  isAlgClosed : IsAlgClosed K
+  isAlgebraic : Algebra.IsAlgebraic R K
 
-attribute [instance] IsAlgClosure.algebraic
+@[deprecated (since := "2024-08-31")] alias IsAlgClosure.alg_closed := IsAlgClosure.isAlgClosed
+@[deprecated (since := "2024-08-31")] alias IsAlgClosure.algebraic := IsAlgClosure.isAlgebraic
+
+attribute [instance] IsAlgClosure.isAlgebraic
 
 theorem isAlgClosure_iff (K : Type v) [Field K] [Algebra k K] :
     IsAlgClosure k K ↔ IsAlgClosed K ∧ Algebra.IsAlgebraic k K :=
@@ -213,8 +216,8 @@ theorem isAlgClosure_iff (K : Type v) [Field K] [Algebra k K] :
 
 instance (priority := 100) IsAlgClosure.normal (R K : Type*) [Field R] [Field K] [Algebra R K]
     [IsAlgClosure R K] : Normal R K where
-  toIsAlgebraic := IsAlgClosure.algebraic
-  splits' _ := @IsAlgClosed.splits_codomain _ _ _ (IsAlgClosure.alg_closed R) _ _ _
+  toIsAlgebraic := IsAlgClosure.isAlgebraic
+  splits' _ := @IsAlgClosed.splits_codomain _ _ _ (IsAlgClosure.isAlgClosed R) _ _ _
 
 instance (priority := 100) IsAlgClosure.separable (R K : Type*) [Field R] [Field K] [Algebra R K]
     [IsAlgClosure R K] [CharZero R] : Algebra.IsSeparable R K :=
@@ -298,9 +301,9 @@ end IsAlgClosed
 namespace IsAlgClosure
 
 -- Porting note: errors with
--- > cannot find synthesization order for instance alg_closed with type
+-- > cannot find synthesization order for instance isAlgClosed with type
 -- > all remaining arguments have metavariables
--- attribute [local instance] IsAlgClosure.alg_closed
+-- attribute [local instance] IsAlgClosure.isAlgClosed
 
 section
 
@@ -311,9 +314,9 @@ variable [Algebra R L] [NoZeroSMulDivisors R L] [IsAlgClosure R L]
 /-- A (random) isomorphism between two algebraic closures of `R`. -/
 noncomputable def equiv : L ≃ₐ[R] M :=
   -- Porting note (#10754): added to replace local instance above
-  haveI : IsAlgClosed L := IsAlgClosure.alg_closed R
-  haveI : IsAlgClosed M := IsAlgClosure.alg_closed R
-  AlgEquiv.ofBijective _ (IsAlgClosure.algebraic.algHom_bijective₂
+  haveI : IsAlgClosed L := IsAlgClosure.isAlgClosed R
+  haveI : IsAlgClosed M := IsAlgClosure.isAlgClosed R
+  AlgEquiv.ofBijective _ (IsAlgClosure.isAlgebraic.algHom_bijective₂
     (IsAlgClosed.lift : L →ₐ[R] M)
     (IsAlgClosed.lift : M →ₐ[R] L)).1
 
@@ -332,7 +335,7 @@ variable [Algebra K J] [Algebra J L] [IsAlgClosure J L] [Algebra K L] [IsScalarT
 /-- If `J` is an algebraic extension of `K` and `L` is an algebraic closure of `J`, then it is
   also an algebraic closure of `K`. -/
 theorem ofAlgebraic [hKJ : Algebra.IsAlgebraic K J] : IsAlgClosure K L :=
-  ⟨IsAlgClosure.alg_closed J, hKJ.trans⟩
+  ⟨IsAlgClosure.isAlgClosed J, hKJ.trans⟩
 
 /-- A (random) isomorphism between an algebraic closure of `R` and an algebraic closure of
   an algebraic extension of `R` -/
@@ -343,8 +346,8 @@ noncomputable def equivOfAlgebraic' [Nontrivial S] [NoZeroSMulDivisors R S]
     exact (Function.Injective.comp (NoZeroSMulDivisors.algebraMap_injective S L)
             (NoZeroSMulDivisors.algebraMap_injective R S) : _)
   letI : IsAlgClosure R L :=
-    { alg_closed := IsAlgClosure.alg_closed S
-      algebraic := ‹_› }
+    { isAlgClosed := IsAlgClosure.isAlgClosed S
+      isAlgebraic := ‹_› }
   exact IsAlgClosure.equiv _ _ _
 
 /-- A (random) isomorphism between an algebraic closure of `K` and an algebraic closure
@@ -371,7 +374,7 @@ noncomputable def equivOfEquivAux (hSR : S ≃+* R) :
   haveI : IsScalarTower S R L :=
     IsScalarTower.of_algebraMap_eq (by simp [RingHom.algebraMap_toAlgebra])
   haveI : NoZeroSMulDivisors R S := NoZeroSMulDivisors.of_algebraMap_injective hSR.symm.injective
-  have : Algebra.IsAlgebraic R L := (IsAlgClosure.algebraic.tower_top_of_injective
+  have : Algebra.IsAlgebraic R L := (IsAlgClosure.isAlgebraic.tower_top_of_injective
     (show Function.Injective (algebraMap S R) from hSR.injective))
   refine
     ⟨equivOfAlgebraic' R S L M, ?_⟩

--- a/Mathlib/FieldTheory/IsAlgClosed/Classification.lean
+++ b/Mathlib/FieldTheory/IsAlgClosed/Classification.lean
@@ -92,8 +92,8 @@ variable (hv : AlgebraicIndependent R v)
 theorem isAlgClosure_of_transcendence_basis [IsAlgClosed K] (hv : IsTranscendenceBasis R v) :
     IsAlgClosure (Algebra.adjoin R (Set.range v)) K :=
   letI := RingHom.domain_nontrivial (algebraMap R K)
-  { alg_closed := by infer_instance
-    algebraic := hv.isAlgebraic }
+  { isAlgClosed := by infer_instance
+    isAlgebraic := hv.isAlgebraic }
 
 variable (hw : AlgebraicIndependent R w)
 

--- a/Mathlib/FieldTheory/IsSepClosed.lean
+++ b/Mathlib/FieldTheory/IsSepClosed.lean
@@ -214,8 +214,8 @@ instance (priority := 100) IsSepClosure.isAlgClosure_of_perfectField
 then it is also a separable closure of `k`. -/
 instance (priority := 100) IsSepClosure.of_isAlgClosure_of_perfectField
     [Algebra k K] [IsAlgClosure k K] [PerfectField k] : IsSepClosure k K :=
-  ⟨haveI := IsAlgClosure.alg_closed (R := k) (K := K); inferInstance,
-    (IsAlgClosure.algebraic (R := k) (K := K)).isSeparable_of_perfectField⟩
+  ⟨haveI := IsAlgClosure.isAlgClosed (R := k) (K := K); inferInstance,
+    (IsAlgClosure.isAlgebraic (R := k) (K := K)).isSeparable_of_perfectField⟩
 
 variable {k} {K}
 

--- a/Mathlib/FieldTheory/PurelyInseparable.lean
+++ b/Mathlib/FieldTheory/PurelyInseparable.lean
@@ -789,8 +789,8 @@ end
 purely inseparable. -/
 theorem isSepClosed_iff_isPurelyInseparable_algebraicClosure [IsAlgClosure F E] :
     IsSepClosed F ↔ IsPurelyInseparable F E :=
-  ⟨fun _ ↦ IsAlgClosure.algebraic.isPurelyInseparable_of_isSepClosed, fun H ↦ by
-    haveI := IsAlgClosure.alg_closed F (K := E)
+  ⟨fun _ ↦ IsAlgClosure.isAlgebraic.isPurelyInseparable_of_isSepClosed, fun H ↦ by
+    haveI := IsAlgClosure.isAlgClosed F (K := E)
     rwa [← separableClosure.eq_bot_iff, IsSepClosed.separableClosure_eq_bot_iff] at H⟩
 
 variable {F E} in
@@ -823,7 +823,7 @@ theorem perfectField_of_isSeparable_of_perfectField_top [Algebra.IsSeparable F E
 separable. -/
 theorem perfectField_iff_isSeparable_algebraicClosure [IsAlgClosure F E] :
     PerfectField F ↔ Algebra.IsSeparable F E :=
-  ⟨fun _ ↦ IsSepClosure.separable, fun _ ↦ haveI : IsAlgClosed E := IsAlgClosure.alg_closed F
+  ⟨fun _ ↦ IsSepClosure.separable, fun _ ↦ haveI : IsAlgClosed E := IsAlgClosure.isAlgClosed F
     perfectField_of_isSeparable_of_perfectField_top F E⟩
 
 namespace Field


### PR DESCRIPTION
to match the naming convention (rule 4).

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
