### PR TITLE
[Merged by Bors] - feat(SetTheory/Ordinal/Basic): prove linear order instance earlier

### DIFF
--- a/Mathlib/Order/InitialSeg.lean
+++ b/Mathlib/Order/InitialSeg.lean
@@ -6,6 +6,7 @@ Authors: Mario Carneiro, Floris van Doorn
 import Mathlib.Logic.Equiv.Set
 import Mathlib.Order.RelIso.Set
 import Mathlib.Order.WellFounded
+import Mathlib.Data.Sum.Order
 /-!
 # Initial and principal segments
 
@@ -420,36 +421,40 @@ theorem wellFounded_iff_principalSeg.{u} {β : Type u} {s : β → β → Prop} 
 /-! ### Properties of initial and principal segments -/
 
 
+namespace InitialSeg
+
 /-- To an initial segment taking values in a well order, one can associate either a principal
 segment (if the range is not everything, hence one can take as top the minimum of the complement
 of the range) or an order isomorphism (if the range is everything). -/
-noncomputable def InitialSeg.ltOrEq [IsWellOrder β s] (f : r ≼i s) : (r ≺i s) ⊕ (r ≃r s) := by
+noncomputable def ltOrEq [IsWellOrder β s] (f : r ≼i s) : (r ≺i s) ⊕ (r ≃r s) := by
   by_cases h : Surjective f
   · exact Sum.inr (RelIso.ofSurjective f h)
   · have h' : _ := (InitialSeg.eq_or_principal f).resolve_left h
     exact Sum.inl ⟨f, Classical.choose h', Classical.choose_spec h'⟩
 
-theorem InitialSeg.ltOrEq_apply_left [IsWellOrder β s] (f : r ≼i s) (g : r ≺i s) (a : α) :
+theorem ltOrEq_apply_left [IsWellOrder β s] (f : r ≼i s) (g : r ≺i s) (a : α) :
     g a = f a :=
   @InitialSeg.eq α β r s _ g f a
 
-theorem InitialSeg.ltOrEq_apply_right [IsWellOrder β s] (f : r ≼i s) (g : r ≃r s) (a : α) :
+theorem ltOrEq_apply_right [IsWellOrder β s] (f : r ≼i s) (g : r ≃r s) (a : α) :
     g a = f a :=
   InitialSeg.eq (InitialSeg.ofIso g) f a
 
 /-- Composition of an initial segment taking values in a well order and a principal segment. -/
-noncomputable def InitialSeg.leLT [IsWellOrder β s] [IsTrans γ t] (f : r ≼i s) (g : s ≺i t) :
+noncomputable def leLT [IsWellOrder β s] [IsTrans γ t] (f : r ≼i s) (g : s ≺i t) :
     r ≺i t :=
   match f.ltOrEq with
   | Sum.inl f' => f'.trans g
   | Sum.inr f' => PrincipalSeg.equivLT f' g
 
 @[simp]
-theorem InitialSeg.leLT_apply [IsWellOrder β s] [IsTrans γ t] (f : r ≼i s) (g : s ≺i t) (a : α) :
+theorem leLT_apply [IsWellOrder β s] [IsTrans γ t] (f : r ≼i s) (g : s ≺i t) (a : α) :
     (f.leLT g) a = g (f a) := by
   delta InitialSeg.leLT; cases' f.ltOrEq with f' f'
   · simp only [PrincipalSeg.trans_apply, f.ltOrEq_apply_left]
   · simp only [PrincipalSeg.equivLT_apply, f.ltOrEq_apply_right]
+
+end InitialSeg
 
 namespace RelEmbedding
 
@@ -498,5 +503,23 @@ theorem collapse_apply [IsWellOrder β s] (f : r ↪r s) (a) : collapse f a = (c
   rfl
 
 end RelEmbedding
+
+/-- For any two well orders, one is an initial segment of the other. -/
+noncomputable def InitialSeg.total (r s) [IsWellOrder α r] [IsWellOrder β s] :
+    (r ≼i s) ⊕ (s ≼i r) :=
+  match (leAdd r s).ltOrEq, (RelEmbedding.sumLexInr r s).collapse.ltOrEq with
+  | Sum.inl f, Sum.inr g => Sum.inl <| f.ltEquiv g.symm
+  | Sum.inr f, Sum.inl g => Sum.inr <| g.ltEquiv f.symm
+  | Sum.inr f, Sum.inr g => Sum.inl <| InitialSeg.ofIso (f.trans g.symm)
+  | Sum.inl f, Sum.inl g => Classical.choice <| by
+      obtain h | h | h := trichotomous_of (Sum.Lex r s) f.top g.top
+      · exact ⟨Sum.inl <| (f.codRestrict {x | Sum.Lex r s x g.top}
+          (fun a => _root_.trans (f.lt_top a) h) h).ltEquiv g.subrelIso⟩
+      · let f := f.subrelIso
+        rw [h] at f
+        exact ⟨Sum.inl <| InitialSeg.ofIso (f.symm.trans g.subrelIso)⟩
+      · exact ⟨Sum.inr <| (g.codRestrict {x | Sum.Lex r s x f.top}
+          (fun a => _root_.trans (g.lt_top a) h) h).ltEquiv f.subrelIso⟩
+
 attribute [nolint simpNF] PrincipalSeg.ofElement_apply PrincipalSeg.subrelIso_symm_apply
   PrincipalSeg.apply_subrelIso PrincipalSeg.subrelIso_apply

--- a/Mathlib/SetTheory/Ordinal/Basic.lean
+++ b/Mathlib/SetTheory/Ordinal/Basic.lean
@@ -294,9 +294,11 @@ For `Ordinal`:
 
 * less-equal is defined such that well orders `r` and `s` satisfy `type r ≤ type s` if there exists
   a function embedding `r` as an *initial* segment of `s`.
-
 * less-than is defined such that well orders `r` and `s` satisfy `type r < type s` if there exists
   a function embedding `r` as a *principal* segment of `s`.
+
+Note that most of the relevant results on initial and principal segments are proved in the
+`Order/InitialSeg` file.
 -/
 instance partialOrder : PartialOrder Ordinal where
   le a b :=
@@ -317,10 +319,16 @@ instance partialOrder : PartialOrder Ordinal where
   lt_iff_le_not_le a b :=
     Quotient.inductionOn₂ a b fun _ _ =>
       ⟨fun ⟨f⟩ => ⟨⟨f⟩, fun ⟨g⟩ => (f.ltLe g).irrefl⟩, fun ⟨⟨f⟩, h⟩ =>
-        Sum.recOn f.ltOrEq (fun g => ⟨g⟩) fun g => (h ⟨InitialSeg.ofIso g.symm⟩).elim⟩
+        f.ltOrEq.recOn (fun g => ⟨g⟩) fun g => (h ⟨InitialSeg.ofIso g.symm⟩).elim⟩
   le_antisymm a b :=
     Quotient.inductionOn₂ a b fun _ _ ⟨h₁⟩ ⟨h₂⟩ =>
       Quot.sound ⟨InitialSeg.antisymm h₁ h₂⟩
+
+instance linearOrder : LinearOrder Ordinal :=
+  {inferInstanceAs (PartialOrder Ordinal) with
+    le_total := fun a b => Quotient.inductionOn₂ a b fun ⟨α, r, _⟩ ⟨β, s, _⟩ =>
+      (InitialSeg.total r s).recOn (fun f => Or.inl ⟨f⟩) fun f => Or.inr ⟨f⟩
+    decidableLE := Classical.decRel _ }
 
 theorem type_le_iff {α β} {r : α → α → Prop} {s : β → β → Prop} [IsWellOrder α r]
     [IsWellOrder β s] : type r ≤ type s ↔ Nonempty (r ≼i s) :=
@@ -512,6 +520,14 @@ theorem lt_wf : @WellFounded Ordinal (· < ·) :=
 
 instance wellFoundedRelation : WellFoundedRelation Ordinal :=
   ⟨(· < ·), lt_wf⟩
+
+instance wellFoundedLT : WellFoundedLT Ordinal :=
+  ⟨lt_wf⟩
+
+instance isWellOrder : IsWellOrder Ordinal (· < ·) where
+
+instance : ConditionallyCompleteLinearOrderBot Ordinal :=
+  WellFoundedLT.conditionallyCompleteLinearOrderBot _
 
 /-- Reformulation of well founded induction on ordinals as a lemma that works with the
 `induction` tactic, as in `induction i using Ordinal.induction with | h i IH => ?_`. -/
@@ -847,32 +863,6 @@ theorem le_add_right (a b : Ordinal) : a ≤ a + b := by
 
 theorem le_add_left (a b : Ordinal) : a ≤ b + a := by
   simpa only [zero_add] using add_le_add_right (Ordinal.zero_le b) a
-
-instance linearOrder : LinearOrder Ordinal :=
-  {inferInstanceAs (PartialOrder Ordinal) with
-    le_total := fun a b =>
-      match lt_or_eq_of_le (le_add_left b a), lt_or_eq_of_le (le_add_right a b) with
-      | Or.inr h, _ => by rw [h]; exact Or.inl (le_add_right _ _)
-      | _, Or.inr h => by rw [h]; exact Or.inr (le_add_left _ _)
-      | Or.inl h₁, Or.inl h₂ => by
-        revert h₁ h₂
-        refine inductionOn a ?_
-        intro α₁ r₁ _
-        refine inductionOn b ?_
-        intro α₂ r₂ _ ⟨f⟩ ⟨g⟩
-        rw [← typein_top f, ← typein_top g, le_iff_lt_or_eq, le_iff_lt_or_eq,
-                 typein_lt_typein, typein_lt_typein]
-        rcases trichotomous_of (Sum.Lex r₁ r₂) g.top f.top with (h | h | h) <;>
-          [exact Or.inl (Or.inl h); (left; right; rw [h]); exact Or.inr (Or.inl h)]
-    decidableLE := Classical.decRel _ }
-
-instance wellFoundedLT : WellFoundedLT Ordinal :=
-  ⟨lt_wf⟩
-
-instance isWellOrder : IsWellOrder Ordinal (· < ·) where
-
-instance : ConditionallyCompleteLinearOrderBot Ordinal :=
-  WellFoundedLT.conditionallyCompleteLinearOrderBot _
 
 theorem max_zero_left : ∀ a : Ordinal, max 0 a = a :=
   max_bot_left

--- a/Mathlib/SetTheory/Ordinal/Basic.lean
+++ b/Mathlib/SetTheory/Ordinal/Basic.lean
@@ -298,7 +298,7 @@ For `Ordinal`:
   a function embedding `r` as a *principal* segment of `s`.
 
 Note that most of the relevant results on initial and principal segments are proved in the
-`Order/InitialSeg` file.
+`Order.InitialSeg` file.
 -/
 instance partialOrder : PartialOrder Ordinal where
   le a b :=


### PR DESCRIPTION
We show that for any two well-orders, one is an initial segment of the other, without relying on ordinal addition or anything of the sort. By doing this, we can move the `LinearOrder` instance on ordinals right next to the partial order one. 

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
