### PR TITLE
chore: deprecate `Order.Nat`

### DIFF
--- a/Mathlib/Algebra/IsPrimePow.lean
+++ b/Mathlib/Algebra/IsPrimePow.lean
@@ -4,7 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Bhavik Mehta
 -/
 import Mathlib.Algebra.Order.Ring.Nat
-import Mathlib.Order.Nat
 import Mathlib.Data.Nat.Prime.Basic
 
 /-!

--- a/Mathlib/Data/Finset/Grade.lean
+++ b/Mathlib/Data/Finset/Grade.lean
@@ -6,7 +6,6 @@ Authors: Yaël Dillies
 import Mathlib.Data.Set.Finite.Basic
 import Mathlib.Order.Atoms
 import Mathlib.Order.Grade
-import Mathlib.Order.Nat
 
 /-!
 # Finsets and multisets form a graded order

--- a/Mathlib/Data/Finset/Lattice/Fold.lean
+++ b/Mathlib/Data/Finset/Lattice/Fold.lean
@@ -3,12 +3,10 @@ Copyright (c) 2018 Mario Carneiro. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Mario Carneiro
 -/
-import Mathlib.Data.Finset.Fold
 import Mathlib.Data.Finset.Sum
 import Mathlib.Data.Multiset.Lattice
 import Mathlib.Data.Set.BooleanAlgebra
 import Mathlib.Order.Hom.BoundedLattice
-import Mathlib.Order.Nat
 
 /-!
 # Lattice operations on finsets

--- a/Mathlib/Data/Nat/Basic.lean
+++ b/Mathlib/Data/Nat/Basic.lean
@@ -26,7 +26,6 @@ open Function
 namespace Nat
 variable {a b c d m n k : ℕ} {p : ℕ → Prop}
 
--- TODO: Move the `LinearOrder ℕ` instance to `Order.Nat` (https://github.com/leanprover-community/mathlib4/pull/13092).
 instance instLinearOrder : LinearOrder ℕ where
   le := Nat.le
   le_refl := @Nat.le_refl

--- a/Mathlib/Data/Nat/Cast/SetInterval.lean
+++ b/Mathlib/Data/Nat/Cast/SetInterval.lean
@@ -6,7 +6,6 @@ Authors: Yury Kudryashov
 import Mathlib.Algebra.Order.Ring.Int
 import Mathlib.Data.Nat.Cast.Order.Basic
 import Mathlib.Order.Interval.Set.OrdConnected
-import Mathlib.Order.Nat
 import Mathlib.Order.UpperLower.Basic
 
 /-!

--- a/Mathlib/Data/Nat/Find.lean
+++ b/Mathlib/Data/Nat/Find.lean
@@ -3,9 +3,9 @@ Copyright (c) 2015 Microsoft Corporation. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Leonardo de Moura, Johannes Hölzl, Mario Carneiro
 -/
-
-import Mathlib.Data.Nat.Basic
 import Batteries.WF
+import Mathlib.Data.Nat.Basic
+import Mathlib.Order.Bounds.Defs
 
 /-!
 # `Nat.find` and `Nat.findGreatest`
@@ -146,6 +146,20 @@ lemma find_add {hₘ : ∃ m, p (m + n)} {hₙ : ∃ n, p n} (hn : n ≤ Nat.fin
     refine (le_find_iff _ _).2 fun m hm hpm => Nat.not_le.2 hm ?_
     rw [Nat.sub_le_iff_le_add]
     exact find_le hpm
+
+section Order
+
+/-- `Nat.find` is the minimum natural number satisfying a predicate `p`. -/
+lemma isLeast_find {p : ℕ → Prop} [DecidablePred p] (hp : ∃ n, p n) :
+    IsLeast {n | p n} (Nat.find hp) :=
+  ⟨Nat.find_spec hp, fun _ ↦ Nat.find_min' hp⟩
+
+/-- `Nat.find` is the minimum element of a nonempty set of natural numbers. -/
+lemma _root_.Set.Nonempty.isLeast_natFind {s : Set ℕ} [DecidablePred (· ∈ s)] (hs : s.Nonempty) :
+    IsLeast s (Nat.find hs) :=
+  Nat.isLeast_find hs
+
+end Order
 
 end Find
 

--- a/Mathlib/Data/Nat/SuccPred.lean
+++ b/Mathlib/Data/Nat/SuccPred.lean
@@ -4,14 +4,11 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Yaël Dillies
 -/
 import Mathlib.Algebra.Order.Group.Nat
-import Mathlib.Algebra.Ring.Nat
 import Mathlib.Algebra.Order.Monoid.Unbundled.WithTop
 import Mathlib.Algebra.Order.Sub.Unbundled.Basic
 import Mathlib.Algebra.Order.SuccPred
+import Mathlib.Algebra.Ring.Nat
 import Mathlib.Data.Fin.Basic
-import Mathlib.Order.Nat
-import Mathlib.Order.SuccPred.Archimedean
-import Mathlib.Order.SuccPred.WithBot
 
 /-!
 # Successors and predecessors of naturals

--- a/Mathlib/Data/Rat/Cast/Defs.lean
+++ b/Mathlib/Data/Rat/Cast/Defs.lean
@@ -9,7 +9,6 @@ import Mathlib.Algebra.Group.Commute.Basic
 import Mathlib.Algebra.GroupWithZero.Units.Lemmas
 import Mathlib.Data.Int.Cast.Lemmas
 import Mathlib.Data.Rat.Lemmas
-import Mathlib.Order.Nat
 
 /-!
 # Casts for Rational Numbers

--- a/Mathlib/Order/BoundedOrder/Basic.lean
+++ b/Mathlib/Order/BoundedOrder/Basic.lean
@@ -611,3 +611,16 @@ theorem bot_eq_false : ⊥ = false :=
   rfl
 
 end Bool
+
+namespace Nat
+
+instance instOrderBot : OrderBot ℕ where
+  bot := 0
+  bot_le := zero_le
+
+instance instNoMaxOrder : NoMaxOrder ℕ where
+  exists_gt n := ⟨n + 1, n.lt_succ_self⟩
+
+@[simp high] protected lemma bot_eq_zero : ⊥ = 0 := rfl
+
+end Nat

--- a/Mathlib/Order/Filter/AtTopBot/Basic.lean
+++ b/Mathlib/Order/Filter/AtTopBot/Basic.lean
@@ -3,9 +3,8 @@ Copyright (c) 2017 Johannes Hölzl. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johannes Hölzl, Jeremy Avigad, Yury Kudryashov, Patrick Massot
 -/
-import Mathlib.Order.Filter.Bases.Basic
 import Mathlib.Order.Filter.AtTopBot.Tendsto
-import Mathlib.Order.Nat
+import Mathlib.Order.Filter.Bases.Basic
 import Mathlib.Tactic.Subsingleton
 
 /-!

--- a/Mathlib/Order/Nat.lean
+++ b/Mathlib/Order/Nat.lean
@@ -5,41 +5,6 @@ Authors: Floris van Doorn, Leonardo de Moura, Jeremy Avigad, Mario Carneiro
 -/
 import Mathlib.Data.Nat.Find
 import Mathlib.Order.BoundedOrder.Basic
-import Mathlib.Order.Bounds.Defs
+import Mathlib.Tactic.Linter.DeprecatedModule
 
-/-!
-# The natural numbers form a linear order
-
-This file contains the linear order instance on the natural numbers.
-
-See note [foundational algebra order theory].
-
-## TODO
-
-Move the `LinearOrder ℕ` instance here (https://github.com/leanprover-community/mathlib4/pull/13092).
--/
-
-namespace Nat
-
-instance instOrderBot : OrderBot ℕ where
-  bot := 0
-  bot_le := zero_le
-
-instance instNoMaxOrder : NoMaxOrder ℕ where
-  exists_gt n := ⟨n + 1, n.lt_succ_self⟩
-
-/-! ### Miscellaneous lemmas -/
-
-@[simp high] protected lemma bot_eq_zero : ⊥ = 0 := rfl
-
-/-- `Nat.find` is the minimum natural number satisfying a predicate `p`. -/
-lemma isLeast_find {p : ℕ → Prop} [DecidablePred p] (hp : ∃ n, p n) :
-    IsLeast {n | p n} (Nat.find hp) :=
-  ⟨Nat.find_spec hp, fun _ ↦ Nat.find_min' hp⟩
-
-end Nat
-
-/-- `Nat.find` is the minimum element of a nonempty set of natural numbers. -/
-lemma Set.Nonempty.isLeast_natFind {s : Set ℕ} [DecidablePred (· ∈ s)] (hs : s.Nonempty) :
-    IsLeast s (Nat.find hs) :=
-  Nat.isLeast_find hs
+deprecated_module (since := "2025-04-16")

--- a/Mathlib/RingTheory/Multiplicity.lean
+++ b/Mathlib/RingTheory/Multiplicity.lean
@@ -4,11 +4,12 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Robert Y. Lewis, Chris Hughes, Daniel Weber
 -/
 import Batteries.Data.Nat.Gcd
+import Mathlib.Algebra.BigOperators.Group.Finset.Basic
 import Mathlib.Algebra.GroupWithZero.Associated
 import Mathlib.Algebra.Ring.Divisibility.Basic
 import Mathlib.Algebra.Ring.Int.Defs
 import Mathlib.Data.ENat.Basic
-import Mathlib.Algebra.BigOperators.Group.Finset.Basic
+import Mathlib.Data.Nat.Find
 
 /-!
 # Multiplicity of a divisor

--- a/Mathlib/SetTheory/Cardinal/Order.lean
+++ b/Mathlib/SetTheory/Cardinal/Order.lean
@@ -7,7 +7,6 @@ import Mathlib.Algebra.Order.GroupWithZero.Canonical
 import Mathlib.Algebra.Order.Ring.Canonical
 import Mathlib.Data.Fintype.Option
 import Mathlib.Order.InitialSeg
-import Mathlib.Order.Nat
 import Mathlib.Order.SuccPred.CompleteLinearOrder
 import Mathlib.SetTheory.Cardinal.Defs
 import Mathlib.SetTheory.Cardinal.SchroederBernstein


### PR DESCRIPTION
* Move the two `Nat` instances and `bot_eq_zero` to `Order.BoundedOrder.Basic`. We also remove the TODO relating to #13092, as it was tried and it was agreed not to be a good idea.
* Move the other two lemmas in `Order.Nat` to `Data.Nat.Find`.