### PR TITLE
[Merged by Bors] - fix: use GH_TOKEN in maintainer merge

### DIFF
--- a/.github/workflows/maintainer_merge_comment.yml
+++ b/.github/workflows/maintainer_merge_comment.yml
@@ -27,10 +27,9 @@ jobs:
         id: determine_topic
         run: |
           ./scripts/get_tlabel.sh "${PR}" >> "$GITHUB_OUTPUT"
-        with:
-          GH_TOKEN: ${{secrets.GITHUB_TOKEN}}
         env:
           PR:  /repos/{owner}/{repo}/issues/{pull_number}
+          GH_TOKEN: ${{secrets.GITHUB_TOKEN}}
 
       - name: Send message on Zulip
         uses: zulip/github-actions-zulip/send-message@v1

--- a/.github/workflows/maintainer_merge_comment.yml
+++ b/.github/workflows/maintainer_merge_comment.yml
@@ -27,8 +27,9 @@ jobs:
         id: determine_topic
         run: |
           ./scripts/get_tlabel.sh "${PR}" >> "$GITHUB_OUTPUT"
-        env:
+        with:
           GH_TOKEN: ${{secrets.GITHUB_TOKEN}}
+        env:
           PR:  /repos/{owner}/{repo}/issues/{pull_number}
 
       - name: Send message on Zulip

--- a/.github/workflows/maintainer_merge_comment.yml
+++ b/.github/workflows/maintainer_merge_comment.yml
@@ -54,7 +54,7 @@ jobs:
       - name: Add label to PR
         uses: actions/github-script@v6
         with:
-          GH_TOKEN: ${{secrets.GITHUB_TOKEN}}
+          github-token: ${{secrets.GITHUB_TOKEN}}
           script: |
             const { owner, repo, number: issue_number } = context.issue;
             await github.rest.issues.addLabels({ owner, repo, issue_number, labels: ['maintainer-merge'] });

--- a/.github/workflows/maintainer_merge_comment.yml
+++ b/.github/workflows/maintainer_merge_comment.yml
@@ -28,7 +28,7 @@ jobs:
         run: |
           ./scripts/get_tlabel.sh "${PR}" >> "$GITHUB_OUTPUT"
         env:
-          github-token: ${{secrets.GITHUB_TOKEN}}
+          GH_TOKEN: ${{secrets.GITHUB_TOKEN}}
           PR:  /repos/{owner}/{repo}/issues/{pull_number}
 
       - name: Send message on Zulip
@@ -54,7 +54,7 @@ jobs:
       - name: Add label to PR
         uses: actions/github-script@v6
         with:
-          github-token: ${{secrets.GITHUB_TOKEN}}
+          GH_TOKEN: ${{secrets.GITHUB_TOKEN}}
           script: |
             const { owner, repo, number: issue_number } = context.issue;
             await github.rest.issues.addLabels({ owner, repo, issue_number, labels: ['maintainer-merge'] });

--- a/.github/workflows/maintainer_merge_review.yml
+++ b/.github/workflows/maintainer_merge_review.yml
@@ -26,8 +26,9 @@ jobs:
         id: determine_topic
         run: |
           ./scripts/get_tlabel.sh "${PR}" >> "$GITHUB_OUTPUT"
-        env:
+        with:
           GH_TOKEN: ${{secrets.GITHUB_TOKEN}}
+        env:
           PR:  /repos/{owner}/{repo}/issues/{pull_number}
 
       - name: Send message on Zulip

--- a/.github/workflows/maintainer_merge_review.yml
+++ b/.github/workflows/maintainer_merge_review.yml
@@ -53,7 +53,7 @@ jobs:
       - name: Add label to PR
         uses: actions/github-script@v6
         with:
-          GH_TOKEN: ${{secrets.GITHUB_TOKEN}}
+          github-token: ${{secrets.GITHUB_TOKEN}}
           script: |
             const { owner, repo, number: issue_number } = context.issue;
             await github.rest.issues.addLabels({ owner, repo, issue_number, labels: ['maintainer-merge'] });

--- a/.github/workflows/maintainer_merge_review.yml
+++ b/.github/workflows/maintainer_merge_review.yml
@@ -27,7 +27,7 @@ jobs:
         run: |
           ./scripts/get_tlabel.sh "${PR}" >> "$GITHUB_OUTPUT"
         env:
-          github-token: ${{secrets.GITHUB_TOKEN}}
+          GH_TOKEN: ${{secrets.GITHUB_TOKEN}}
           PR:  /repos/{owner}/{repo}/issues/{pull_number}
 
       - name: Send message on Zulip
@@ -53,7 +53,7 @@ jobs:
       - name: Add label to PR
         uses: actions/github-script@v6
         with:
-          github-token: ${{secrets.GITHUB_TOKEN}}
+          GH_TOKEN: ${{secrets.GITHUB_TOKEN}}
           script: |
             const { owner, repo, number: issue_number } = context.issue;
             await github.rest.issues.addLabels({ owner, repo, issue_number, labels: ['maintainer-merge'] });

--- a/.github/workflows/maintainer_merge_review.yml
+++ b/.github/workflows/maintainer_merge_review.yml
@@ -26,10 +26,9 @@ jobs:
         id: determine_topic
         run: |
           ./scripts/get_tlabel.sh "${PR}" >> "$GITHUB_OUTPUT"
-        with:
-          GH_TOKEN: ${{secrets.GITHUB_TOKEN}}
         env:
           PR:  /repos/{owner}/{repo}/issues/{pull_number}
+          GH_TOKEN: ${{secrets.GITHUB_TOKEN}}
 
       - name: Send message on Zulip
         uses: zulip/github-actions-zulip/send-message@v1

--- a/.github/workflows/maintainer_merge_review_comment.yml
+++ b/.github/workflows/maintainer_merge_review_comment.yml
@@ -52,7 +52,7 @@ jobs:
       - name: Add label to PR
         uses: actions/github-script@v6
         with:
-          GH_TOKEN: ${{secrets.GITHUB_TOKEN}}
+          github-token: ${{secrets.GITHUB_TOKEN}}
           script: |
             const { owner, repo, number: issue_number } = context.issue;
             await github.rest.issues.addLabels({ owner, repo, issue_number, labels: ['maintainer-merge'] });

--- a/.github/workflows/maintainer_merge_review_comment.yml
+++ b/.github/workflows/maintainer_merge_review_comment.yml
@@ -25,8 +25,9 @@ jobs:
         id: determine_topic
         run: |
           ./scripts/get_tlabel.sh "${PR}" >> "$GITHUB_OUTPUT"
-        env:
+        with:
           GH_TOKEN: ${{secrets.GITHUB_TOKEN}}
+        env:
           PR:  /repos/{owner}/{repo}/issues/{pull_number}
 
       - name: Send message on Zulip

--- a/.github/workflows/maintainer_merge_review_comment.yml
+++ b/.github/workflows/maintainer_merge_review_comment.yml
@@ -26,7 +26,7 @@ jobs:
         run: |
           ./scripts/get_tlabel.sh "${PR}" >> "$GITHUB_OUTPUT"
         env:
-          github-token: ${{secrets.GITHUB_TOKEN}}
+          GH_TOKEN: ${{secrets.GITHUB_TOKEN}}
           PR:  /repos/{owner}/{repo}/issues/{pull_number}
 
       - name: Send message on Zulip
@@ -52,7 +52,7 @@ jobs:
       - name: Add label to PR
         uses: actions/github-script@v6
         with:
-          github-token: ${{secrets.GITHUB_TOKEN}}
+          GH_TOKEN: ${{secrets.GITHUB_TOKEN}}
           script: |
             const { owner, repo, number: issue_number } = context.issue;
             await github.rest.issues.addLabels({ owner, repo, issue_number, labels: ['maintainer-merge'] });

--- a/.github/workflows/maintainer_merge_review_comment.yml
+++ b/.github/workflows/maintainer_merge_review_comment.yml
@@ -25,10 +25,9 @@ jobs:
         id: determine_topic
         run: |
           ./scripts/get_tlabel.sh "${PR}" >> "$GITHUB_OUTPUT"
-        with:
-          GH_TOKEN: ${{secrets.GITHUB_TOKEN}}
         env:
           PR:  /repos/{owner}/{repo}/issues/{pull_number}
+          GH_TOKEN: ${{secrets.GITHUB_TOKEN}}
 
       - name: Send message on Zulip
         uses: zulip/github-actions-zulip/send-message@v1


### PR DESCRIPTION
This should really be the last fix!  :smile: 

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
