### PR TITLE
[Merged by Bors] - feat: maintainer merge `generic` posts `maintainer merge`

### DIFF
--- a/scripts/get_tlabel.sh
+++ b/scripts/get_tlabel.sh
@@ -17,13 +17,16 @@ PR="${1}"
 
 >&2 printf $'Using PR: \'%s\'\n' "${PR}"
 
-tlabels="$(gh api --jq '.labels.[].name' "${PR}" | grep -- '^t-' || printf 'generic')"
+tlabels="$(gh api --jq '.labels.[].name' "${PR}" | grep -- '^t-' || printf 'generic\nlabel')"
 # print to error, since the stdout is captured into `GITHUB_OUTPUT
 >&2 printf 't-labels:\n---\n%s\n---\n' "${tlabels}"
-# if there isn't exactly 1 `t-xxx` label, use `generic`
+# if there is exactly 1 `t-xxx` label, use `maintainer merge: t-xxx`
+# if there isn't exactly 1 `t-xxx` label, use `maintainer merge`
 if [[ "$(wc -l <<<"${tlabels}")" -ne 1 ]]; then
-  tlabels="generic"
+  topicName="maintainer merge"
+else
+  topicName="maintainer merge: ${tlabels}"
 fi
-topicName="maintainer merge: ${tlabels}"
+
 >&2 printf $'Post to topic: \'%s\'"\n' "${topicName}"
 echo "topic=${topicName}"


### PR DESCRIPTION
Right now, `maintainer merge`ing a PR that does not have a unique `t-label` posts in `maintainer merge: generic`.  This PR changes the topic to `maintainer merge`.

Suggested by Yaël.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
