### PR TITLE
[Merged by Bors] - doc(ModelTheory/PartialEquiv): Improved docstring for partial equivalences in model theory

### DIFF
--- a/Mathlib/ModelTheory/PartialEquiv.lean
+++ b/Mathlib/ModelTheory/PartialEquiv.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2024 Gabin Kolly. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Aaron Anderson, Gabin Kolly
+Authors: Aaron Anderson, Gabin Kolly, David Wärn
 -/
 import Mathlib.ModelTheory.DirectLimit
 import Mathlib.Order.Ideal
@@ -12,7 +12,26 @@ This file defines partial isomorphisms between first-order structures.
 
 ## Main Definitions
 - `FirstOrder.Language.PartialEquiv` is defined so that `L.PartialEquiv M N`, annotated
-  `M ≃ₚ[L] N`, is the type of equivalences between substructures of `M` and `N`.
+  `M ≃ₚ[L] N`, is the type of equivalences between substructures of `M` and `N`. These can be
+  ordered, with an order that is defined here in terms of a commutative square, but could also be
+  defined as the order on the graphs of the partial equivalences under inclusion as subsets of
+  `M × N`.
+- `FirstOrder.Language.FGEquiv` is the type of partial equivalences `M ≃ₚ[L] N` with
+  finitely-generated domain (or equivalently, codomain).
+- `FirstOrder.Language.IsExtensionPair` is defined so that `L.IsExtensionPair M N` indicates that
+  any finitely-generated partial equivalence from `M` to `N` can be extended to include an arbitrary
+  element `m : M` in its domain.
+
+## Main Results
+- `FirstOrder.Language.embedding_from_cg` shows that if structures `M` and `N` form an equivalence
+  pair with `M` countably-generated, then any finite-generated partial equivalence between them
+  can be extended to an embedding `M ↪[L] N`.
+- `FirstOrder.Language.equiv_from_cg` shows that if countably-generated structures `M` and `N` form
+  an equivalence pair in both directions, then any finite-generated partial equivalence between them
+  can be extended to an isomorphism `M ↪[L] N`.
+- The proofs of these results are adapted in part from David Wärn's approach to countable dense
+  linear orders, a special case of this phenomenon in the case where `L = Language.order`.
+
 -/
 
 universe u v w w'


### PR DESCRIPTION
Adds `FGEquiv` and `IsExtensionPair` to the list of definitions
Adds `embedding_from_cg` and `equiv_from_cg` to the list of results
Adds David Wärn to the author list, given the inspiration from the file `Order/CountableDenseLinearOrder`

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
