### PR TITLE
[Merged by Bors] - docs(Bicategory/Functor): fix some nolint doc entries and porting notes

### DIFF
--- a/Mathlib/CategoryTheory/Bicategory/Functor/Lax.lean
+++ b/Mathlib/CategoryTheory/Bicategory/Functor/Lax.lean
@@ -58,24 +58,24 @@ structure LaxFunctor (B: Type u₁) [Bicategory.{w₁, v₁} B] (C : Type u₂) 
   mapId (a : B) : 𝟙 (obj a) ⟶ map (𝟙 a)
   /-- The 2-morphism underlying the lax functoriality constraint. -/
   mapComp {a b c : B} (f : a ⟶ b) (g : b ⟶ c) : map f ≫ map g ⟶ map (f ≫ g)
-  /-- Naturality of the lax functoriality constraight, on the left. -/
+  /-- Naturality of the lax functoriality constraint, on the left. -/
   mapComp_naturality_left :
     ∀ {a b c : B} {f f' : a ⟶ b} (η : f ⟶ f') (g : b ⟶ c),
       mapComp f g ≫ map₂ (η ▷ g) = map₂ η ▷ map g ≫ mapComp f' g:= by aesop_cat
-  /-- Naturality of the lax functoriality constraight, on the right. -/
+  /-- Naturality of the lax functoriality constraint, on the right. -/
   mapComp_naturality_right :
     ∀ {a b c : B} (f : a ⟶ b) {g g' : b ⟶ c} (η : g ⟶ g'),
      mapComp f g ≫ map₂ (f ◁ η) = map f ◁ map₂ η ≫ mapComp f g' := by aesop_cat
-  /-- Lax associativity -/
+  /-- Lax associativity. -/
   map₂_associator :
     ∀ {a b c d : B} (f : a ⟶ b) (g : b ⟶ c) (h : c ⟶ d),
       mapComp f g ▷ map h ≫ mapComp (f ≫ g) h ≫ map₂ (α_ f g h).hom =
       (α_ (map f) (map g) (map h)).hom ≫ map f ◁ mapComp g h ≫ mapComp f (g ≫ h) := by aesop_cat
-  /-- Lax left unity -/
+  /-- Lax left unity. -/
   map₂_leftUnitor :
     ∀ {a b : B} (f : a ⟶ b),
       map₂ (λ_ f).inv = (λ_ (map f)).inv ≫ mapId a ▷ map f ≫ mapComp (𝟙 a) f := by aesop_cat
-  /-- Lax right unity -/
+  /-- Lax right unity. -/
   map₂_rightUnitor :
     ∀ {a b : B} (f : a ⟶ b),
       map₂ (ρ_ f).inv = (ρ_ (map f)).inv ≫ map f ◁ mapId b ≫ mapComp f (𝟙 b) := by aesop_cat
@@ -166,16 +166,15 @@ def comp {D : Type u₃} [Bicategory.{w₃, v₃} D] (F : LaxFunctor B C) (G : L
 
 See `Pseudofunctor.mkOfLax`. -/
 structure PseudoCore (F : LaxFunctor B C) where
+  /-- The isomorphism giving rise to the lax unity constraint -/
   mapIdIso (a : B) : F.map (𝟙 a) ≅ 𝟙 (F.obj a)
+  /-- The isomorphism giving rise to the lax functoriality constraint -/
   mapCompIso {a b c : B} (f : a ⟶ b) (g : b ⟶ c) : F.map (f ≫ g) ≅ F.map f ≫ F.map g
+  /-- `mapIdIso` gives rise to the lax unity constraint -/
   mapIdIso_inv {a : B} : (mapIdIso a).inv = F.mapId a := by aesop_cat
+  /-- `mapCompIso` gives rise to the lax functoriality constraint -/
   mapCompIso_inv {a b c : B} (f : a ⟶ b) (g : b ⟶ c) : (mapCompIso f g).inv = F.mapComp f g := by
     aesop_cat
-
-attribute [nolint docBlame] CategoryTheory.LaxFunctor.PseudoCore.mapIdIso
-  CategoryTheory.LaxFunctor.PseudoCore.mapCompIso
-  CategoryTheory.LaxFunctor.PseudoCore.mapIdIso_inv
-  CategoryTheory.LaxFunctor.PseudoCore.mapCompIso_inv
 
 attribute [simp] PseudoCore.mapIdIso_inv PseudoCore.mapCompIso_inv
 

--- a/Mathlib/CategoryTheory/Bicategory/Functor/Oplax.lean
+++ b/Mathlib/CategoryTheory/Bicategory/Functor/Oplax.lean
@@ -121,7 +121,7 @@ instance : Inhabited (OplaxFunctor B B) :=
   ⟨id B⟩
 
 /-- Composition of oplax functors. -/
--- @[simps]
+--@[simps]
 def comp (F : OplaxFunctor B C) (G : OplaxFunctor C D) : OplaxFunctor B D where
   toPrelaxFunctor := F.toPrelaxFunctor.comp G.toPrelaxFunctor
   mapId := fun a => (G.mapFunctor _ _).map (F.mapId a) ≫ G.mapId (F.obj a)

--- a/Mathlib/CategoryTheory/Bicategory/Functor/Oplax.lean
+++ b/Mathlib/CategoryTheory/Bicategory/Functor/Oplax.lean
@@ -36,17 +36,6 @@ section
 variable {B : Type u₁} [Bicategory.{w₁, v₁} B] {C : Type u₂} [Bicategory.{w₂, v₂} C]
 variable {D : Type u₃} [Bicategory.{w₃, v₃} D]
 
--- Porting note: in Lean 3 the below auxiliary definition was only used once, in the definition
--- of oplax functor, with a comment that it had to be used to fix a timeout. The timeout is
--- not present in Lean 4, however Lean 4 is not as good at seeing through the definition,
--- meaning that `simp` wasn't functioning as well as it should. I have hence removed
--- the auxiliary definition.
---@[simp]
---def OplaxFunctor.Map₂AssociatorAux (obj : B → C) (map : ∀ {X Y : B}, (X ⟶ Y) → (obj X ⟶ obj Y))
---    (map₂ : ∀ {a b : B} {f g : a ⟶ b}, (f ⟶ g) → (map f ⟶ map g))
---    (map_comp : ∀ {a b c : B} (f : a ⟶ b) (g : b ⟶ c), map (f ≫ g) ⟶ map f ≫ map g) {a b c d : B}
---    (f : a ⟶ b) (g : b ⟶ c) (h : c ⟶ d) : Prop := ...
-
 /-- An oplax functor `F` between bicategories `B` and `C` consists of a function between objects
 `F.obj`, a function between 1-morphisms `F.map`, and a function between 2-morphisms `F.map₂`.
 
@@ -60,28 +49,32 @@ of 2-morphisms.
 -/
 structure OplaxFunctor (B : Type u₁) [Bicategory.{w₁, v₁} B] (C : Type u₂)
   [Bicategory.{w₂, v₂} C] extends PrelaxFunctor B C where
+  /-- The 2-morphism underlying the oplax unity constraint. -/
   mapId (a : B) : map (𝟙 a) ⟶ 𝟙 (obj a)
+  /-- The 2-morphism underlying the oplax functoriality constraint. -/
   mapComp {a b c : B} (f : a ⟶ b) (g : b ⟶ c) : map (f ≫ g) ⟶ map f ≫ map g
+  /-- Naturality of the oplax functoriality constraint, on the left. -/
   mapComp_naturality_left :
     ∀ {a b c : B} {f f' : a ⟶ b} (η : f ⟶ f') (g : b ⟶ c),
       map₂ (η ▷ g) ≫ mapComp f' g = mapComp f g ≫ map₂ η ▷ map g := by
     aesop_cat
+  /-- Naturality of the lax functoriality constraight, on the right. -/
   mapComp_naturality_right :
     ∀ {a b c : B} (f : a ⟶ b) {g g' : b ⟶ c} (η : g ⟶ g'),
       map₂ (f ◁ η) ≫ mapComp f g' = mapComp f g ≫ map f ◁ map₂ η := by
     aesop_cat
-  -- Porting note: `map₂_associator_aux` was used here in lean 3, but this was a hack
-  -- to avoid a timeout; we revert this hack here (because it was causing other problems
-  -- and was not necessary in lean 4)
+  /-- Oplax associativity. -/
   map₂_associator :
     ∀ {a b c d : B} (f : a ⟶ b) (g : b ⟶ c) (h : c ⟶ d),
       map₂ (α_ f g h).hom ≫ mapComp f (g ≫ h) ≫ map f ◁ mapComp g h =
     mapComp (f ≫ g) h ≫ mapComp f g ▷ map h ≫ (α_ (map f) (map g) (map h)).hom := by
     aesop_cat
+  /-- Oplax left unity. -/
   map₂_leftUnitor :
     ∀ {a b : B} (f : a ⟶ b),
       map₂ (λ_ f).hom = mapComp (𝟙 a) f ≫ mapId a ▷ map f ≫ (λ_ (map f)).hom := by
     aesop_cat
+  /-- Oplax right unity. -/
   map₂_rightUnitor :
     ∀ {a b : B} (f : a ⟶ b),
       map₂ (ρ_ f).hom = mapComp f (𝟙 b) ≫ map f ◁ mapId b ≫ (ρ_ (map f)).hom := by
@@ -100,14 +93,6 @@ section
 /-- The underlying prelax functor. -/
 add_decl_doc OplaxFunctor.toPrelaxFunctor
 
-attribute [nolint docBlame] CategoryTheory.OplaxFunctor.mapId
-  CategoryTheory.OplaxFunctor.mapComp
-  CategoryTheory.OplaxFunctor.mapComp_naturality_left
-  CategoryTheory.OplaxFunctor.mapComp_naturality_right
-  CategoryTheory.OplaxFunctor.map₂_associator
-  CategoryTheory.OplaxFunctor.map₂_leftUnitor
-  CategoryTheory.OplaxFunctor.map₂_rightUnitor
-
 variable (F : OplaxFunctor B C)
 
 @[reassoc]
@@ -115,7 +100,7 @@ lemma mapComp_assoc_right {a b c d : B} (f : a ⟶ b) (g : b ⟶ c) (h : c ⟶ d
     F.mapComp f (g ≫ h) ≫ F.map f ◁ F.mapComp g h = F.map₂ (α_ f g h).inv ≫
     F.mapComp (f ≫ g) h ≫ F.mapComp f g ▷ F.map h ≫
     (α_ (F.map f) (F.map g) (F.map h)).hom := by
-  rw [← @map₂_associator, ← F.map₂_comp_assoc]
+  rw [← F.map₂_associator, ← F.map₂_comp_assoc]
   simp
 
 @[reassoc]
@@ -124,15 +109,6 @@ lemma mapComp_assoc_left {a b c d : B} (f : a ⟶ b) (g : b ⟶ c) (h : c ⟶ d)
     F.map₂ (α_ f g h).hom ≫ F.mapComp f (g ≫ h) ≫ F.map f ◁ F.mapComp g h
     ≫ (α_ (F.map f) (F.map g) (F.map h)).inv := by
   simp
-
--- Porting note: `to_prelax_eq_coe` and `to_prelaxFunctor_obj` are
--- syntactic tautologies in lean 4
-
--- Porting note: removed lemma `to_prelaxFunctor_map` relating the now
--- nonexistent `PrelaxFunctor.map` and `OplaxFunctor.map`
-
--- Porting note: removed lemma `to_prelaxFunctor_map₂` relating
--- `PrelaxFunctor.map₂` to nonexistent `OplaxFunctor.map₂`
 
 /-- The identity oplax functor. -/
 @[simps]
@@ -145,7 +121,7 @@ instance : Inhabited (OplaxFunctor B B) :=
   ⟨id B⟩
 
 /-- Composition of oplax functors. -/
---@[simps]
+-- @[simps]
 def comp (F : OplaxFunctor B C) (G : OplaxFunctor C D) : OplaxFunctor B D where
   toPrelaxFunctor := F.toPrelaxFunctor.comp G.toPrelaxFunctor
   mapId := fun a => (G.mapFunctor _ _).map (F.mapId a) ≫ G.mapId (F.obj a)
@@ -161,8 +137,6 @@ def comp (F : OplaxFunctor B C) (G : OplaxFunctor C D) : OplaxFunctor B D where
       mapComp_naturality_right, assoc]
   map₂_associator := fun f g h => by
     dsimp
-    -- Porting note: if you use the `map₂_associator_aux` hack in the definition of
-    -- `map₂_associator` then the `simp only` call below does not seem to apply `map₂_associator`
     simp only [map₂_associator, ← PrelaxFunctor.map₂_comp_assoc, ← mapComp_naturality_right_assoc,
       whiskerLeft_comp, assoc]
     simp only [map₂_associator, PrelaxFunctor.map₂_comp, mapComp_naturality_left_assoc,
@@ -177,23 +151,20 @@ def comp (F : OplaxFunctor B C) (G : OplaxFunctor C D) : OplaxFunctor B D where
       whiskerLeft_comp, assoc]
 
 /-- A structure on an oplax functor that promotes an oplax functor to a pseudofunctor.
-See `Pseudofunctor.mkOfOplax`.
--/
+
+See `Pseudofunctor.mkOfOplax`. -/
 -- Porting note(#5171): linter not ported yet
 -- @[nolint has_nonempty_instance]
--- Porting note: removing primes in structure name because
--- my understanding is that they're no longer needed
 structure PseudoCore (F : OplaxFunctor B C) where
+  /-- The isomorphism giving rise to the oplax unity constraint -/
   mapIdIso (a : B) : F.map (𝟙 a) ≅ 𝟙 (F.obj a)
+  /-- The isomorphism giving rise to the oplax functoriality constraint -/
   mapCompIso {a b c : B} (f : a ⟶ b) (g : b ⟶ c) : F.map (f ≫ g) ≅ F.map f ≫ F.map g
+  /-- `mapIdIso` gives rise to the oplax unity constraint -/
   mapIdIso_hom : ∀ {a : B}, (mapIdIso a).hom = F.mapId a := by aesop_cat
+  /-- `mapCompIso` gives rise to the oplax functoriality constraint -/
   mapCompIso_hom :
     ∀ {a b c : B} (f : a ⟶ b) (g : b ⟶ c), (mapCompIso f g).hom = F.mapComp f g := by aesop_cat
-
-attribute [nolint docBlame] CategoryTheory.OplaxFunctor.PseudoCore.mapIdIso
-  CategoryTheory.OplaxFunctor.PseudoCore.mapCompIso
-  CategoryTheory.OplaxFunctor.PseudoCore.mapIdIso_hom
-  CategoryTheory.OplaxFunctor.PseudoCore.mapCompIso_hom
 
 attribute [simp] PseudoCore.mapIdIso_hom PseudoCore.mapCompIso_hom
 


### PR DESCRIPTION
Adds documentation to structures, and removes some no longer necessary porting notes.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

There is only one porting note left in `Oplax.lean` now, and I am not sure if I should remove it, since I don't know anything about this `has_nonempty_instance` linter.

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
