### PR TITLE
[Merged by Bors] - refactor: remove `simp` priority from theorem

### DIFF
--- a/Mathlib/Data/List/Basic.lean
+++ b/Mathlib/Data/List/Basic.lean
@@ -562,7 +562,6 @@ theorem get_cons {l : List α} {a : α} {n} (hl) :
   · contradiction
   rfl
 
-@[simp 1100]
 theorem modifyHead_modifyHead (l : List α) (f g : α → α) :
     (l.modifyHead f).modifyHead g = l.modifyHead (g ∘ f) := by cases l <;> simp
 


### PR DESCRIPTION
The simplifier used to always unfold the definition of the function
`List.modifyHead` because it had the `simp` attribute. This behavior
hindered the simplifier from using lemmas about the function. To fix
this issue, I opened leanprover-community/batteries#790 and it was
merged on May 10.

Now, the `simp` priority in the theorem `List.modifyHead_modifyHead` is
no longer needed. leanprover-community/batteries#756 was supposed to
remove the priority from it while also moving it from Mathlib to
Batteries. But the pull request hasn't been merged for almost five
months, hence this PR.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
