### PR TITLE
[Merged by Bors] - fix: do not get cache if Mathlib.Init is unavailable

### DIFF
--- a/.github/workflows/bors.yml
+++ b/.github/workflows/bors.yml
@@ -162,10 +162,10 @@ jobs:
       - name: get cache
         id: get
         run: |
-          lake exe cache clean
+          rm -rf .lake/build/lib/Mathlib/
           # Fail quickly if the cache is completely cold, by checking for Mathlib.Init
           lake exe cache get Mathlib.Init
-          ! test -e .lake/build/lib/Mathlib/Init.olean || lake exe cache get
+          lake build --no-build Mathlib.Init && lake exe cache get || echo "No cache for 'Mathlib.Init' available"
 
       - name: build mathlib
         id: build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -169,10 +169,10 @@ jobs:
       - name: get cache
         id: get
         run: |
-          lake exe cache clean
+          rm -rf .lake/build/lib/Mathlib/
           # Fail quickly if the cache is completely cold, by checking for Mathlib.Init
           lake exe cache get Mathlib.Init
-          ! test -e .lake/build/lib/Mathlib/Init.olean || lake exe cache get
+          lake build --no-build Mathlib.Init && lake exe cache get || echo "No cache for 'Mathlib.Init' available"
 
       - name: build mathlib
         id: build

--- a/.github/workflows/build.yml.in
+++ b/.github/workflows/build.yml.in
@@ -148,10 +148,10 @@ jobs:
       - name: get cache
         id: get
         run: |
-          lake exe cache clean
+          rm -rf .lake/build/lib/Mathlib/
           # Fail quickly if the cache is completely cold, by checking for Mathlib.Init
           lake exe cache get Mathlib.Init
-          ! test -e .lake/build/lib/Mathlib/Init.olean || lake exe cache get
+          lake build --no-build Mathlib.Init && lake exe cache get || echo "No cache for 'Mathlib.Init' available"
 
       - name: build mathlib
         id: build

--- a/.github/workflows/build_fork.yml
+++ b/.github/workflows/build_fork.yml
@@ -166,10 +166,10 @@ jobs:
       - name: get cache
         id: get
         run: |
-          lake exe cache clean
+          rm -rf .lake/build/lib/Mathlib/
           # Fail quickly if the cache is completely cold, by checking for Mathlib.Init
           lake exe cache get Mathlib.Init
-          ! test -e .lake/build/lib/Mathlib/Init.olean || lake exe cache get
+          lake build --no-build Mathlib.Init && lake exe cache get || echo "No cache for 'Mathlib.Init' available"
 
       - name: build mathlib
         id: build


### PR DESCRIPTION
You can see a few attempts and tests #16435: the final commits test what happens with and without cache for `Mathlib.Init`.

Reported on [Zulip](https://leanprover.zulipchat.com/#narrow/stream/287929-mathlib4/topic/.2316028.20.28checking.20if.20the.20cache.20is.20cold.20in.20CI.29.20seems.20broken.3F)

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
