### PR TITLE
[Merged by Bors] - feat(CategoryTheory/Galois): topology of fundamental group

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -1498,6 +1498,7 @@ import Mathlib.CategoryTheory.Galois.Decomposition
 import Mathlib.CategoryTheory.Galois.Examples
 import Mathlib.CategoryTheory.Galois.GaloisObjects
 import Mathlib.CategoryTheory.Galois.Prorepresentability
+import Mathlib.CategoryTheory.Galois.Topology
 import Mathlib.CategoryTheory.Generator
 import Mathlib.CategoryTheory.GlueData
 import Mathlib.CategoryTheory.GradedObject

--- a/Mathlib/CategoryTheory/FintypeCat.lean
+++ b/Mathlib/CategoryTheory/FintypeCat.lean
@@ -4,9 +4,9 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Bhavik Mehta, Adam Topaz
 -/
 import Mathlib.CategoryTheory.ConcreteCategory.Basic
-import Mathlib.CategoryTheory.FullSubcategory
+import Mathlib.CategoryTheory.Endomorphism
 import Mathlib.CategoryTheory.Skeletal
-import Mathlib.Data.Fintype.Card
+import Mathlib.Data.Finite.Basic
 
 /-!
 # The category of finite types.
@@ -98,6 +98,15 @@ def equivEquivIso {A B : FintypeCat} : A ≃ B ≃ (A ≅ B) where
       right_inv := congr_fun i.inv_hom_id }
   left_inv := by aesop_cat
   right_inv := by aesop_cat
+
+instance foo (X Y : FintypeCat) : Finite (X ⟶ Y) :=
+  inferInstanceAs <| Finite (X → Y)
+
+instance (X Y : FintypeCat) : Finite (X ≅ Y) :=
+  Finite.of_injective _ (fun _ _ h ↦ Iso.ext h)
+
+instance (X : FintypeCat) : Finite (Aut X) :=
+  inferInstanceAs <| Finite (X ≅ X)
 
 universe u
 

--- a/Mathlib/CategoryTheory/Galois/Topology.lean
+++ b/Mathlib/CategoryTheory/Galois/Topology.lean
@@ -46,13 +46,14 @@ lemma autEmbedding_injective : Function.Injective (autEmbedding F) := by
   have : σ.app X = τ.app X := congr_fun h X
   rw [← Iso.app_hom, ← Iso.app_hom, this]
 
-instance (X : C) : TopologicalSpace (F.obj X) := ⊥
-instance (X : C) : DiscreteTopology (F.obj X) := ⟨rfl⟩
-instance (X : C) : TopologicalSpace (Aut (F.obj X)) := ⊥
-instance (X : C) : DiscreteTopology (Aut (F.obj X)) := ⟨rfl⟩
+scoped instance (X : C) : TopologicalSpace (F.obj X) := ⊥
+scoped instance (X : C) : DiscreteTopology (F.obj X) := ⟨rfl⟩
+scoped instance (X : C) : TopologicalSpace (Aut (F.obj X)) := ⊥
+scoped instance (X : C) : DiscreteTopology (Aut (F.obj X)) := ⟨rfl⟩
 
 /-- `Aut F` is equipped with the by the embedding into `∀ X, Aut (F.obj X)` induced embedding. -/
-instance : TopologicalSpace (Aut F) := TopologicalSpace.induced (autEmbedding F) inferInstance
+instance : TopologicalSpace (Aut F) :=
+  TopologicalSpace.induced (autEmbedding F) inferInstance
 
 /-- The image of `Aut F` in `∀ X, Aut (F.obj X)` are precisely the compatible families of
 automorphisms. -/

--- a/Mathlib/CategoryTheory/Galois/Topology.lean
+++ b/Mathlib/CategoryTheory/Galois/Topology.lean
@@ -1,0 +1,137 @@
+/-
+Copyright (c) 2024 Christian Merten. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Christian Merten
+-/
+import Mathlib.CategoryTheory.Endomorphism
+import Mathlib.CategoryTheory.FintypeCat
+import Mathlib.Topology.Algebra.Group.Basic
+
+/-!
+
+# Topology of fundamental group
+
+In this file we define a natural topology on the automorphism group of a functor
+`F : C ⥤ FintypeCat`: It is defined as the subspace topology induced by the natural
+embedding of `Aut F` into `∀ X, Aut (F.obj X)` where
+`Aut (F.obj X)` carries the discrete topology.
+
+## References
+
+- Stacks Project: Tag 0BMQ
+
+-/
+universe u₁ u₂ v₁ v₂ v w
+
+namespace CategoryTheory
+
+namespace PreGaloisCategory
+
+open Functor
+
+variable {C : Type u₁} [Category.{u₂} C] (F : C ⥤ FintypeCat.{w})
+
+/-- For a functor `F : C ⥤ FintypeCat`, the canonical embedding of `Aut F` into
+the product over `Aut (F.obj X)` for all objects `X`. -/
+def autEmbedding : Aut F →* ∀ X, Aut (F.obj X) :=
+  MonoidHom.mk' (fun σ X ↦ σ.app X) (fun _ _ ↦ rfl)
+
+@[simp]
+lemma autEmbedding_apply (σ : Aut F) (X : C) : autEmbedding F σ X = σ.app X :=
+  rfl
+
+lemma autEmbedding_injective : Function.Injective (autEmbedding F) := by
+  intro σ τ h
+  ext X x
+  have : σ.app X = τ.app X := congr_fun h X
+  rw [← Iso.app_hom, ← Iso.app_hom, this]
+
+instance (X : C) : TopologicalSpace (F.obj X) := ⊥
+instance (X : C) : DiscreteTopology (F.obj X) := ⟨rfl⟩
+instance (X : C) : TopologicalSpace (Aut (F.obj X)) := ⊥
+instance (X : C) : DiscreteTopology (Aut (F.obj X)) := ⟨rfl⟩
+
+/-- `Aut F` is equipped with the by the embedding into `∀ X, Aut (F.obj X)` induced embedding. -/
+instance : TopologicalSpace (Aut F) := TopologicalSpace.induced (autEmbedding F) inferInstance
+
+/-- The image of `Aut F` in `∀ X, Aut (F.obj X)` are precisely the compatible families of
+automorphisms. -/
+lemma autEmbedding_range :
+    Set.range (autEmbedding F) =
+      { a | ∀ (X Y : C) (f : X ⟶ Y), F.map f ≫ (a Y).hom = (a X).hom ≫ F.map f } := by
+  ext a
+  simp only [Set.mem_range, Set.mem_setOf_eq]
+  constructor
+  · intro ⟨σ, h⟩
+    rw [← h]
+    exact σ.hom.naturality
+  · intro h
+    use NatIso.ofComponents (fun X => (a X))
+    rfl
+
+/-- The image of `Aut F` in `∀ X, Aut (F.obj X)` is closed. -/
+lemma autEmbedding_range_isClosed : IsClosed (Set.range (autEmbedding F)) := by
+  rw [autEmbedding_range, ← isOpen_compl_iff, isOpen_iff_forall_mem_open]
+  intro a h
+  simp only [Set.mem_compl_iff, Set.mem_setOf_eq, not_forall] at h
+  obtain ⟨X, Y, f, (h : (a Y).hom ∘ F.map f ≠ F.map f ∘ (a X).hom)⟩ := h
+  rw [Function.ne_iff] at h
+  obtain ⟨x, hx⟩ := h
+  let sx (A : C) : Set (Aut (F.obj A)) :=
+    { γ | ∀ (h : X ⟶ A), γ.hom (F.map h x) = (a A).hom (F.map h x) }
+  let sy (A : C) : Set (Aut (F.obj A)) :=
+    { γ | ∀ (h : Y ⟶ A), γ.hom (F.map h (F.map f x)) = (a A).hom (F.map h (F.map f x)) }
+  have hx : IsOpen (Set.pi {X} sx) := isOpen_set_pi (Set.toFinite {X}) (fun _ _ ↦ trivial)
+  have hy : IsOpen (Set.pi {Y} sy) := isOpen_set_pi (Set.toFinite {Y}) (fun _ _ ↦ trivial)
+  use Set.pi {X} sx ∩ Set.pi {Y} sy
+  refine ⟨?_, IsOpen.inter hx hy, ?_⟩
+  · intro γ hγ
+    simp only [Set.singleton_pi] at hγ
+    simp only [Set.mem_compl_iff, Set.mem_setOf_eq, not_forall]
+    use X, Y, f
+    rw [← ne_eq, Function.ne_iff]
+    use x
+    simp only [FintypeCat.comp_apply]
+    have hty : (γ Y).hom (F.map f x) = (a Y).hom (F.map f x) := by simpa using hγ.2 (𝟙 Y)
+    have htx : (γ X).hom x = (a X).hom x := by simpa using hγ.1 (𝟙 X)
+    rwa [htx, hty]
+  · simp [sx, sy]
+
+lemma autEmbedding_closedEmbedding : ClosedEmbedding (autEmbedding F) where
+  induced := rfl
+  inj := autEmbedding_injective F
+  isClosed_range := autEmbedding_range_isClosed F
+
+instance (X Y : C) : Finite (F.obj X ⟶ F.obj Y) :=
+  inferInstanceAs <| Finite (F.obj X → F.obj Y)
+
+instance (X : C) : Finite (Aut (F.obj X)) :=
+  Finite.of_injective _ (fun _ _ h ↦ Iso.ext h)
+
+instance : CompactSpace (Aut F) := ClosedEmbedding.compactSpace (autEmbedding_closedEmbedding F)
+
+instance : T2Space (Aut F) :=
+  T2Space.of_injective_continuous (autEmbedding_injective F) continuous_induced_dom
+
+instance : TotallyDisconnectedSpace (Aut F) :=
+  (Embedding.isTotallyDisconnected_range (autEmbedding_closedEmbedding F).embedding).mp
+    (isTotallyDisconnected_of_totallyDisconnectedSpace _)
+
+instance : ContinuousMul (Aut F) :=
+  Inducing.continuousMul (autEmbedding F)
+    (autEmbedding_closedEmbedding F).toInducing
+
+instance : ContinuousInv (Aut F) :=
+  Inducing.continuousInv (autEmbedding_closedEmbedding F).toInducing (fun _ ↦ rfl)
+
+instance : TopologicalGroup (Aut F) := ⟨⟩
+
+instance (X : C) : SMul (Aut (F.obj X)) (F.obj X) := ⟨fun σ a => σ.hom a⟩
+
+instance (X : C) : ContinuousSMul (Aut (F.obj X)) (F.obj X) := by
+  constructor
+  fun_prop
+
+end PreGaloisCategory
+
+end CategoryTheory

--- a/Mathlib/CategoryTheory/Galois/Topology.lean
+++ b/Mathlib/CategoryTheory/Galois/Topology.lean
@@ -46,10 +46,17 @@ lemma autEmbedding_injective : Function.Injective (autEmbedding F) := by
   have : σ.app X = τ.app X := congr_fun h X
   rw [← Iso.app_hom, ← Iso.app_hom, this]
 
+/-- We put the discrete topology on `F.obj X`. -/
 scoped instance (X : C) : TopologicalSpace (F.obj X) := ⊥
-scoped instance (X : C) : DiscreteTopology (F.obj X) := ⟨rfl⟩
+
+@[scoped instance]
+lemma obj_discreteTopology (X : C) : DiscreteTopology (F.obj X) := ⟨rfl⟩
+
+/-- We put the discrete topology on `Aut (F.obj X)`. -/
 scoped instance (X : C) : TopologicalSpace (Aut (F.obj X)) := ⊥
-scoped instance (X : C) : DiscreteTopology (Aut (F.obj X)) := ⟨rfl⟩
+
+@[scoped instance]
+lemma aut_discreteTopology (X : C) : DiscreteTopology (Aut (F.obj X)) := ⟨rfl⟩
 
 /-- `Aut F` is equipped with the by the embedding into `∀ X, Aut (F.obj X)` induced embedding. -/
 instance : TopologicalSpace (Aut F) :=

--- a/Mathlib/CategoryTheory/Galois/Topology.lean
+++ b/Mathlib/CategoryTheory/Galois/Topology.lean
@@ -110,12 +110,6 @@ lemma autEmbedding_closedEmbedding : ClosedEmbedding (autEmbedding F) where
   inj := autEmbedding_injective F
   isClosed_range := autEmbedding_range_isClosed F
 
-instance (X Y : C) : Finite (F.obj X ⟶ F.obj Y) :=
-  inferInstanceAs <| Finite (F.obj X → F.obj Y)
-
-instance (X : C) : Finite (Aut (F.obj X)) :=
-  Finite.of_injective _ (fun _ _ h ↦ Iso.ext h)
-
 instance : CompactSpace (Aut F) := ClosedEmbedding.compactSpace (autEmbedding_closedEmbedding F)
 
 instance : T2Space (Aut F) :=

--- a/Mathlib/CategoryTheory/Galois/Topology.lean
+++ b/Mathlib/CategoryTheory/Galois/Topology.lean
@@ -3,7 +3,7 @@ Copyright (c) 2024 Christian Merten. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Christian Merten
 -/
-import Mathlib.CategoryTheory.Endomorphism
+import Mathlib.CategoryTheory.Comma.Arrow
 import Mathlib.CategoryTheory.FintypeCat
 import Mathlib.Topology.Algebra.Group.Basic
 
@@ -66,44 +66,19 @@ instance : TopologicalSpace (Aut F) :=
 automorphisms. -/
 lemma autEmbedding_range :
     Set.range (autEmbedding F) =
-      { a | ∀ (X Y : C) (f : X ⟶ Y), F.map f ≫ (a Y).hom = (a X).hom ≫ F.map f } := by
+      ⋂ (f : Arrow C), { a | F.map f.hom ≫ (a f.right).hom = (a f.left).hom ≫ F.map f.hom } := by
   ext a
-  simp only [Set.mem_range, Set.mem_setOf_eq]
-  constructor
-  · intro ⟨σ, h⟩
-    rw [← h]
-    exact σ.hom.naturality
-  · intro h
-    use NatIso.ofComponents (fun X => a X)
+  simp only [Set.mem_range, id_obj, Set.mem_iInter, Set.mem_setOf_eq]
+  refine ⟨fun ⟨σ, h⟩ i ↦ h.symm ▸ σ.hom.naturality i.hom, fun h ↦ ?_⟩
+  · use NatIso.ofComponents (fun X => a X) (fun {X Y} f ↦ h ⟨X, Y, f⟩)
     rfl
 
 /-- The image of `Aut F` in `∀ X, Aut (F.obj X)` is closed. -/
 lemma autEmbedding_range_isClosed : IsClosed (Set.range (autEmbedding F)) := by
-  rw [autEmbedding_range, ← isOpen_compl_iff, isOpen_iff_forall_mem_open]
-  intro a h
-  simp only [Set.mem_compl_iff, Set.mem_setOf_eq, not_forall] at h
-  obtain ⟨X, Y, f, (h : (a Y).hom ∘ F.map f ≠ F.map f ∘ (a X).hom)⟩ := h
-  rw [Function.ne_iff] at h
-  obtain ⟨x, hx⟩ := h
-  let sx (A : C) : Set (Aut (F.obj A)) :=
-    { γ | ∀ (h : X ⟶ A), γ.hom (F.map h x) = (a A).hom (F.map h x) }
-  let sy (A : C) : Set (Aut (F.obj A)) :=
-    { γ | ∀ (h : Y ⟶ A), γ.hom (F.map h (F.map f x)) = (a A).hom (F.map h (F.map f x)) }
-  have hx : IsOpen (Set.pi {X} sx) := isOpen_set_pi (Set.toFinite {X}) (fun _ _ ↦ trivial)
-  have hy : IsOpen (Set.pi {Y} sy) := isOpen_set_pi (Set.toFinite {Y}) (fun _ _ ↦ trivial)
-  use Set.pi {X} sx ∩ Set.pi {Y} sy
-  refine ⟨?_, IsOpen.inter hx hy, ?_⟩
-  · intro γ hγ
-    simp only [Set.singleton_pi] at hγ
-    simp only [Set.mem_compl_iff, Set.mem_setOf_eq, not_forall]
-    use X, Y, f
-    rw [← ne_eq, Function.ne_iff]
-    use x
-    simp only [FintypeCat.comp_apply]
-    have hty : (γ Y).hom (F.map f x) = (a Y).hom (F.map f x) := by simpa using hγ.2 (𝟙 Y)
-    have htx : (γ X).hom x = (a X).hom x := by simpa using hγ.1 (𝟙 X)
-    rwa [htx, hty]
-  · simp [sx, sy]
+  rw [autEmbedding_range]
+  refine isClosed_iInter (fun f ↦ isClosed_eq (X := F.obj f.left → F.obj f.right) ?_ ?_)
+  · fun_prop
+  · fun_prop
 
 lemma autEmbedding_closedEmbedding : ClosedEmbedding (autEmbedding F) where
   induced := rfl

--- a/Mathlib/CategoryTheory/Galois/Topology.lean
+++ b/Mathlib/CategoryTheory/Galois/Topology.lean
@@ -74,7 +74,7 @@ lemma autEmbedding_range :
     rw [← h]
     exact σ.hom.naturality
   · intro h
-    use NatIso.ofComponents (fun X => (a X))
+    use NatIso.ofComponents (fun X => a X)
     rfl
 
 /-- The image of `Aut F` in `∀ X, Aut (F.obj X)` is closed. -/


### PR DESCRIPTION
Introduces a natural pro-finite topology on the fundamental group of a fiber functor.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
