### PR TITLE
[Merged by Bors] - feat(Algebra/Group): define even and odd functions

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -241,6 +241,7 @@ import Mathlib.Algebra.Group.Embedding
 import Mathlib.Algebra.Group.Equiv.Basic
 import Mathlib.Algebra.Group.Equiv.TypeTags
 import Mathlib.Algebra.Group.Even
+import Mathlib.Algebra.Group.EvenFunction
 import Mathlib.Algebra.Group.Ext
 import Mathlib.Algebra.Group.Fin.Basic
 import Mathlib.Algebra.Group.Fin.Tuple

--- a/Mathlib/Algebra/Group/EvenFunction.lean
+++ b/Mathlib/Algebra/Group/EvenFunction.lean
@@ -12,9 +12,9 @@ import Mathlib.Algebra.Module.Defs
 We define even functions `α → β` assuming `α` has a negation, and odd functions assuming both `α`
 and `β` have negation.
 
-These definitions are called `EvenFun` and `OddFun` to avoid conflicting with the root-level
-definitions `Even` and `Odd` (which, for functions, mean that the function takes even resp. odd
-_values_, a wholly different concept).
+These definitions are `Function.Even` and `Function.Odd`; and they are `protected`, to avoid
+conflicting with the root-level definitions `Even` and `Odd` (which, for functions, mean that the
+function takes even resp. odd _values_, a wholly different concept).
 -/
 
 namespace Function

--- a/Mathlib/Algebra/Group/EvenFunction.lean
+++ b/Mathlib/Algebra/Group/EvenFunction.lean
@@ -22,43 +22,47 @@ namespace Function
 variable {α β : Type*} [Neg α]
 
 /-- A function `f` is _even_ if it satisfies `f (-x) = f x` for all `x`. -/
-def EvenFun (f : α → β) : Prop := ∀ a, f (-a) = f a
+protected def Even (f : α → β) : Prop := ∀ a, f (-a) = f a
 
 /-- A function `f` is _odd_ if it satisfies `f (-x) = -f x` for all `x`. -/
-def OddFun [Neg β] (f : α → β) : Prop := ∀ a, f (-a) = -(f a)
+protected def Odd [Neg β] (f : α → β) : Prop := ∀ a, f (-a) = -(f a)
 
 /-- Any constant function is even. -/
-lemma EvenFun.const (b : β) : EvenFun (fun _ : α ↦ b) := fun _ ↦ rfl
+lemma Even.const (b : β) : Function.Even (fun _ : α ↦ b) := fun _ ↦ rfl
+
+/-- The zero function is even. -/
+lemma Even.zero [Zero β] : Function.Even (fun (_ : α) ↦ (0 : β)) := Even.const 0
 
 /-- The zero function is odd. -/
-lemma OddFun.zero [NegZeroClass β] : OddFun (fun (_ : α) ↦ (0 : β)) := fun _ ↦ neg_zero.symm
+lemma Odd.zero [NegZeroClass β] : Function.Odd (fun (_ : α) ↦ (0 : β)) := fun _ ↦ neg_zero.symm
 
 section composition
 
 variable {γ : Type*}
 
 /-- If `f` is arbitrary and `g` is even, then `f ∘ g` is even. -/
-lemma EvenFun.left_comp {g : α → β} (hg : EvenFun g) (f : β → γ) : EvenFun (f ∘ g) :=
+lemma Even.left_comp {g : α → β} (hg : g.Even) (f : β → γ) : (f ∘ g).Even :=
   (congr_arg f <| hg ·)
 
 /-- If `f` is even and `g` is odd, then `f ∘ g` is even. -/
-lemma EvenFun.comp_oddFun [Neg β] {f : β → γ} (hf : EvenFun f) {g : α → β} (hg : OddFun g) :
-    EvenFun (f ∘ g) :=
-  fun r ↦ by rw [comp_apply, hg, hf, comp_apply]
+lemma Even.comp_odd [Neg β] {f : β → γ} (hf : f.Even) {g : α → β} (hg : g.Odd) :
+    (f ∘ g).Even := by
+  intro a
+  simp only [comp_apply, hg a, hf _]
 
 /-- If `f` and `g` are odd, then `f ∘ g` is odd. -/
-lemma OddFun.comp_oddFun [Neg β] [Neg γ] {f : β → γ} (hf : OddFun f) {g : α → β} (hg : OddFun g) :
-    OddFun (f ∘ g) :=
-  fun r ↦ by rw [comp_apply, hg, hf, comp_apply]
+lemma Odd.comp_odd [Neg β] [Neg γ] {f : β → γ} (hf : f.Odd) {g : α → β} (hg : g.Odd) :
+    (f ∘ g).Odd := by
+  intro a
+  simp only [comp_apply, hg a, hf _]
 
 end composition
 
-lemma EvenFun.add [Add β] {f g : α → β} (hf : EvenFun f) (hg : EvenFun g) : EvenFun (f + g) := by
+lemma Even.add [Add β] {f g : α → β} (hf : f.Even) (hg : g.Even) : (f + g).Even := by
   intro a
   simp only [hf a, hg a, Pi.add_apply]
 
-lemma OddFun.add [SubtractionCommMonoid β] {f g : α → β} (hf : OddFun f) (hg : OddFun g) :
-    OddFun (f + g) := by
+lemma Odd.add [SubtractionCommMonoid β] {f g : α → β} (hf : f.Odd) (hg : g.Odd) : (f + g).Odd := by
   intro a
   simp only [hf a, hg a, Pi.add_apply, neg_add]
 
@@ -66,32 +70,31 @@ section smul
 
 variable {γ : Type*} {f : α → β} {g : α → γ}
 
-lemma EvenFun.smul_evenFun [SMul β γ] (hf : EvenFun f) (hg : EvenFun g) : EvenFun (f • g) := by
+lemma Even.smul_even [SMul β γ] (hf : f.Even) (hg : g.Even) : (f • g).Even := by
   intro a
   simp only [Pi.smul_apply', hf a, hg a]
 
-lemma EvenFun.smul_oddFun [Monoid β] [AddGroup γ] [DistribMulAction β γ]
-    (hf : EvenFun f) (hg : OddFun g) :
-    OddFun (f • g) := by
+lemma Even.smul_odd [Monoid β] [AddGroup γ] [DistribMulAction β γ] (hf : f.Even) (hg : g.Odd) :
+    (f • g).Odd := by
   intro a
   simp only [Pi.smul_apply', hf a, hg a, smul_neg]
 
-lemma OddFun.smul_evenFun [Ring β] [AddCommGroup γ] [Module β γ] (hf : OddFun f) (hg : EvenFun g) :
-    OddFun (f • g) := by
+lemma Odd.smul_even [Ring β] [AddCommGroup γ] [Module β γ] (hf : f.Odd) (hg : g.Even) :
+    (f • g).Odd := by
   intro a
   simp only [Pi.smul_apply', hf a, hg a, neg_smul]
 
-lemma OddFun.smul_oddFun [Ring β] [AddCommGroup γ] [Module β γ] (hf : OddFun f) (hg : OddFun g) :
-    EvenFun (f • g) := by
+lemma Odd.smul_odd [Ring β] [AddCommGroup γ] [Module β γ] (hf : f.Odd) (hg : g.Odd) :
+    (f • g).Even := by
   intro a
   simp only [Pi.smul_apply', hf a, hg a, smul_neg, neg_smul, neg_neg]
 
-lemma EvenFun.const_smul [SMul β γ] (hg : EvenFun g) (r : β) : EvenFun (r • g) := by
+lemma Even.const_smul [SMul β γ] (hg : g.Even) (r : β) : (r • g).Even := by
   intro a
   simp only [Pi.smul_apply, hg a]
 
-lemma OddFun.const_smul [Monoid β] [AddGroup γ] [DistribMulAction β γ] (hg : OddFun g) (r : β) :
-    OddFun (r • g) := by
+lemma Odd.const_smul [Monoid β] [AddGroup γ] [DistribMulAction β γ] (hg : g.Odd) (r : β) :
+    (r • g).Odd := by
   intro a
   simp only [Pi.smul_apply, hg a, smul_neg]
 
@@ -101,19 +104,19 @@ section mul
 
 variable {R : Type*} [Mul R] {f g : α → R}
 
-lemma EvenFun.mul_evenFun (hf : EvenFun f) (hg : EvenFun g) : EvenFun (f * g) := by
+lemma Even.mul_even (hf : f.Even) (hg : g.Even) : (f * g).Even := by
   intro a
   simp only [Pi.mul_apply, hf a, hg a]
 
-lemma EvenFun.mul_oddFun [HasDistribNeg R] (hf : EvenFun f) (hg : OddFun g) : OddFun (f * g) := by
+lemma Even.mul_odd [HasDistribNeg R] (hf : f.Even) (hg : g.Odd) : (f * g).Odd := by
   intro a
   simp only [Pi.mul_apply, hf a, hg a, mul_neg]
 
-lemma OddFun.mul_evenFun [HasDistribNeg R] (hf : OddFun f) (hg : EvenFun g) : OddFun (f * g) := by
+lemma Odd.mul_even [HasDistribNeg R] (hf : f.Odd) (hg : g.Even) : (f * g).Odd := by
   intro a
   simp only [Pi.mul_apply, hf a, hg a, neg_mul]
 
-lemma OddFun.mul_oddFun [HasDistribNeg R] (hf : OddFun f) (hg : OddFun g) : EvenFun (f * g) := by
+lemma Odd.mul_odd [HasDistribNeg R] (hf : f.Odd) (hg : g.Odd) : (f * g).Even := by
   intro a
   simp only [Pi.mul_apply, hf a, hg a, mul_neg, neg_mul, neg_neg]
 
@@ -123,8 +126,8 @@ end mul
 If `f` is both even and odd, and its target is a torsion-free commutative additive group,
 then `f = 0`.
 -/
-lemma zero_of_evenFun_and_oddFun [AddCommGroup β] [NoZeroSMulDivisors ℕ β]
-    {f : α → β} (he : EvenFun f) (ho : OddFun f) :
+lemma zero_of_even_and_odd [AddCommGroup β] [NoZeroSMulDivisors ℕ β]
+    {f : α → β} (he : f.Even) (ho : f.Odd) :
     f = 0 := by
   ext r
   rw [Pi.zero_apply, ← neg_eq_self ℕ, ← ho, he]

--- a/Mathlib/Algebra/Group/EvenFunction.lean
+++ b/Mathlib/Algebra/Group/EvenFunction.lean
@@ -1,0 +1,132 @@
+/-
+Copyright (c) 2024 David Loeffler. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: David Loeffler
+-/
+import Mathlib.Algebra.Group.Action.Pi
+import Mathlib.Algebra.Module.Defs
+
+/-!
+# Even and odd functions
+
+We define even functions `α → β` assuming `α` has a negation, and odd functions assuming both `α`
+and `β` have negation.
+
+These definitions are called `EvenFun` and `OddFun` to avoid conflicting with the root-level
+definitions `Even` and `Odd` (which, for functions, mean that the function takes even resp. odd
+_values_, a wholly different concept).
+-/
+
+namespace Function
+
+variable {α β : Type*} [Neg α]
+
+/-- A function `f` is _even_ if it satisfies `f (-x) = f x` for all `x`. -/
+def EvenFun (f : α → β) : Prop := ∀ a, f (-a) = f a
+
+/-- A function `f` is _odd_ if it satisfies `f (-x) = -f x` for all `x`. -/
+def OddFun [Neg β] (f : α → β) : Prop := ∀ a, f (-a) = -(f a)
+
+/-- Any constant function is even. -/
+lemma EvenFun.const (b : β) : EvenFun (fun _ : α ↦ b) := fun _ ↦ rfl
+
+/-- The zero function is odd. -/
+lemma OddFun.zero [NegZeroClass β] : OddFun (fun (_ : α) ↦ (0 : β)) := fun _ ↦ neg_zero.symm
+
+section composition
+
+variable {γ : Type*}
+
+/-- If `f` is arbitrary and `g` is even, then `f ∘ g` is even. -/
+lemma EvenFun.left_comp {g : α → β} (hg : EvenFun g) (f : β → γ) : EvenFun (f ∘ g) :=
+  (congr_arg f <| hg ·)
+
+/-- If `f` is even and `g` is odd, then `f ∘ g` is even. -/
+lemma EvenFun.comp_oddFun [Neg β] {f : β → γ} (hf : EvenFun f) {g : α → β} (hg : OddFun g) :
+    EvenFun (f ∘ g) :=
+  fun r ↦ by rw [comp_apply, hg, hf, comp_apply]
+
+/-- If `f` and `g` are odd, then `f ∘ g` is odd. -/
+lemma OddFun.comp_oddFun [Neg β] [Neg γ] {f : β → γ} (hf : OddFun f) {g : α → β} (hg : OddFun g) :
+    OddFun (f ∘ g) :=
+  fun r ↦ by rw [comp_apply, hg, hf, comp_apply]
+
+end composition
+
+lemma EvenFun.add [Add β] {f g : α → β} (hf : EvenFun f) (hg : EvenFun g) : EvenFun (f + g) := by
+  intro a
+  simp only [hf a, hg a, Pi.add_apply]
+
+lemma OddFun.add [SubtractionCommMonoid β] {f g : α → β} (hf : OddFun f) (hg : OddFun g) :
+    OddFun (f + g) := by
+  intro a
+  simp only [hf a, hg a, Pi.add_apply, neg_add]
+
+section smul
+
+variable {γ : Type*} {f : α → β} {g : α → γ}
+
+lemma EvenFun.smul_evenFun [SMul β γ] (hf : EvenFun f) (hg : EvenFun g) : EvenFun (f • g) := by
+  intro a
+  simp only [Pi.smul_apply', hf a, hg a]
+
+lemma EvenFun.smul_oddFun [Monoid β] [AddGroup γ] [DistribMulAction β γ]
+    (hf : EvenFun f) (hg : OddFun g) :
+    OddFun (f • g) := by
+  intro a
+  simp only [Pi.smul_apply', hf a, hg a, smul_neg]
+
+lemma OddFun.smul_evenFun [Ring β] [AddCommGroup γ] [Module β γ] (hf : OddFun f) (hg : EvenFun g) :
+    OddFun (f • g) := by
+  intro a
+  simp only [Pi.smul_apply', hf a, hg a, neg_smul]
+
+lemma OddFun.smul_oddFun [Ring β] [AddCommGroup γ] [Module β γ] (hf : OddFun f) (hg : OddFun g) :
+    EvenFun (f • g) := by
+  intro a
+  simp only [Pi.smul_apply', hf a, hg a, smul_neg, neg_smul, neg_neg]
+
+lemma EvenFun.const_smul [SMul β γ] (hg : EvenFun g) (r : β) : EvenFun (r • g) := by
+  intro a
+  simp only [Pi.smul_apply, hg a]
+
+lemma OddFun.const_smul [Monoid β] [AddGroup γ] [DistribMulAction β γ] (hg : OddFun g) (r : β) :
+    OddFun (r • g) := by
+  intro a
+  simp only [Pi.smul_apply, hg a, smul_neg]
+
+end smul
+
+section mul
+
+variable {R : Type*} [Mul R] {f g : α → R}
+
+lemma EvenFun.mul_evenFun (hf : EvenFun f) (hg : EvenFun g) : EvenFun (f * g) := by
+  intro a
+  simp only [Pi.mul_apply, hf a, hg a]
+
+lemma EvenFun.mul_oddFun [HasDistribNeg R] (hf : EvenFun f) (hg : OddFun g) : OddFun (f * g) := by
+  intro a
+  simp only [Pi.mul_apply, hf a, hg a, mul_neg]
+
+lemma OddFun.mul_evenFun [HasDistribNeg R] (hf : OddFun f) (hg : EvenFun g) : OddFun (f * g) := by
+  intro a
+  simp only [Pi.mul_apply, hf a, hg a, neg_mul]
+
+lemma OddFun.mul_oddFun [HasDistribNeg R] (hf : OddFun f) (hg : OddFun g) : EvenFun (f * g) := by
+  intro a
+  simp only [Pi.mul_apply, hf a, hg a, mul_neg, neg_mul, neg_neg]
+
+end mul
+
+/--
+If `f` is both even and odd, and its target is a torsion-free commutative additive group,
+then `f = 0`.
+-/
+lemma zero_of_evenFun_and_oddFun [AddCommGroup β] [NoZeroSMulDivisors ℕ β]
+    {f : α → β} (he : EvenFun f) (ho : OddFun f) :
+    f = 0 := by
+  ext r
+  rw [Pi.zero_apply, ← neg_eq_self ℕ, ← ho, he]
+
+end Function


### PR DESCRIPTION
Define predicates `Function.Even` and `Function.Odd` for functions satisfying `f (-x) = f x` resp. `f (-x) = -(f x)`, and prove some simple properties of these.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
