### PR TITLE
[Merged by Bors] - feat(Data/Nat/Choose): add basic lemmas

### DIFF
--- a/Mathlib/Data/Nat/Choose/Basic.lean
+++ b/Mathlib/Data/Nat/Choose/Basic.lean
@@ -60,6 +60,21 @@ theorem choose_succ_succ (n k : ℕ) : choose (succ n) (succ k) = choose n k + c
 theorem choose_succ_succ' (n k : ℕ) : choose (n + 1) (k + 1) = choose n k + choose n (k + 1) :=
   rfl
 
+theorem choose_succ_left (n k : ℕ) (hk : 1 ≤ k) :
+    choose (n + 1) k = choose n (k - 1) + choose n k := by
+  obtain ⟨l, rfl⟩ : ∃ l, k = l + 1 := Nat.exists_eq_add_of_le' hk
+  rfl
+
+theorem choose_succ_right (n k : ℕ) (hn : 1 ≤ n) :
+    choose n (k + 1) = choose (n - 1) k + choose (n - 1) (k + 1) := by
+  obtain ⟨l, rfl⟩ : ∃ l, n = l + 1 := Nat.exists_eq_add_of_le' hn
+  rfl
+
+theorem choose_eq_choose_pred_add (n k : ℕ) (hn : 1 ≤ n) (hk : 1 ≤ k) :
+    choose n k = choose (n - 1) (k - 1) + choose (n - 1) k := by
+  obtain ⟨l, rfl⟩ : ∃ l, k = l + 1 := Nat.exists_eq_add_of_le' hk
+  rw [choose_succ_right _ _ hn, Nat.add_one_sub_one]
+
 theorem choose_eq_zero_of_lt : ∀ {n k}, n < k → choose n k = 0
   | _, 0, hk => absurd hk (Nat.not_lt_zero _)
   | 0, k + 1, _ => choose_zero_succ _

--- a/Mathlib/Data/Nat/Choose/Basic.lean
+++ b/Mathlib/Data/Nat/Choose/Basic.lean
@@ -70,7 +70,7 @@ theorem choose_succ_right (n k : ℕ) (hn : 1 ≤ n) :
   obtain ⟨l, rfl⟩ : ∃ l, n = l + 1 := Nat.exists_eq_add_of_le' hn
   rfl
 
-theorem choose_eq_choose_pred_add (n k : ℕ) (hn : 1 ≤ n) (hk : 1 ≤ k) :
+theorem choose_eq_choose_pred_add {n k : ℕ} (hn : 1 ≤ n) (hk : 1 ≤ k) :
     choose n k = choose (n - 1) (k - 1) + choose (n - 1) k := by
   obtain ⟨l, rfl⟩ : ∃ l, k = l + 1 := Nat.exists_eq_add_of_le' hk
   rw [choose_succ_right _ _ hn, Nat.add_one_sub_one]

--- a/Mathlib/Data/Nat/Choose/Basic.lean
+++ b/Mathlib/Data/Nat/Choose/Basic.lean
@@ -60,17 +60,17 @@ theorem choose_succ_succ (n k : ℕ) : choose (succ n) (succ k) = choose n k + c
 theorem choose_succ_succ' (n k : ℕ) : choose (n + 1) (k + 1) = choose n k + choose n (k + 1) :=
   rfl
 
-theorem choose_succ_left (n k : ℕ) (hk : 1 ≤ k) :
+theorem choose_succ_left (n k : ℕ) (hk : 0 < k) :
     choose (n + 1) k = choose n (k - 1) + choose n k := by
   obtain ⟨l, rfl⟩ : ∃ l, k = l + 1 := Nat.exists_eq_add_of_le' hk
   rfl
 
-theorem choose_succ_right (n k : ℕ) (hn : 1 ≤ n) :
+theorem choose_succ_right (n k : ℕ) (hn : 0 < n) :
     choose n (k + 1) = choose (n - 1) k + choose (n - 1) (k + 1) := by
   obtain ⟨l, rfl⟩ : ∃ l, n = l + 1 := Nat.exists_eq_add_of_le' hn
   rfl
 
-theorem choose_eq_choose_pred_add {n k : ℕ} (hn : 1 ≤ n) (hk : 1 ≤ k) :
+theorem choose_eq_choose_pred_add {n k : ℕ} (hn : 0 < n) (hk : 0 < k) :
     choose n k = choose (n - 1) (k - 1) + choose (n - 1) k := by
   obtain ⟨l, rfl⟩ : ∃ l, k = l + 1 := Nat.exists_eq_add_of_le' hk
   rw [choose_succ_right _ _ hn, Nat.add_one_sub_one]


### PR DESCRIPTION
Adds basic lemmas for writing `Nat.choose` as a sum of two previous `Nat.choose`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
