### PR TITLE
[Merged by Bors] - feat(Order/SuccPred/LinearLocallyFinite): IsSuccArchimedean ↔ IsPredArchimedean on linear orders

### DIFF
--- a/Mathlib/Order/SuccPred/LinearLocallyFinite.lean
+++ b/Mathlib/Order/SuccPred/LinearLocallyFinite.lean
@@ -62,8 +62,7 @@ variable [SuccOrder ι] [PredOrder ι]
 
 instance (priority := 100) isPredArchimedean_of_isSuccArchimedean [IsSuccArchimedean ι] :
     IsPredArchimedean ι where
-  exists_pred_iterate_of_le := by
-    intro i j hij
+  exists_pred_iterate_of_le {i j} hij := by
     have h_exists := exists_succ_iterate_of_le hij
     obtain ⟨n, hn_eq, hn_lt_ne⟩ : ∃ n, succ^[n] i = j ∧ ∀ m < n, succ^[m] i ≠ j :=
       ⟨Nat.find h_exists, Nat.find_spec h_exists, fun m hmn ↦ Nat.find_min h_exists hmn⟩

--- a/Mathlib/Order/SuccPred/LinearLocallyFinite.lean
+++ b/Mathlib/Order/SuccPred/LinearLocallyFinite.lean
@@ -56,6 +56,41 @@ open Order
 
 variable {ι : Type*} [LinearOrder ι]
 
+namespace LinearOrder
+
+variable [SuccOrder ι] [PredOrder ι]
+
+instance (priority := 100) isPredArchimedean_of_isSuccArchimedean [IsSuccArchimedean ι] :
+    IsPredArchimedean ι where
+  exists_pred_iterate_of_le := by
+    intro i j hij
+    have h_exists := exists_succ_iterate_of_le hij
+    obtain ⟨n, hn_eq, hn_lt_ne⟩ : ∃ n, succ^[n] i = j ∧ ∀ m < n, succ^[m] i ≠ j :=
+      ⟨Nat.find h_exists, Nat.find_spec h_exists, fun m hmn ↦ Nat.find_min h_exists hmn⟩
+    refine ⟨n, ?_⟩
+    rw [← hn_eq]
+    induction' n with n
+    · simp only [Function.iterate_zero, id]
+    · rw [pred_succ_iterate_of_not_isMax]
+      rw [Nat.succ_sub_succ_eq_sub, tsub_zero]
+      suffices succ^[n] i < succ^[n.succ] i from not_isMax_of_lt this
+      refine lt_of_le_of_ne ?_ ?_
+      · rw [Function.iterate_succ']
+        exact le_succ _
+      · rw [hn_eq]
+        exact hn_lt_ne _ (Nat.lt_succ_self n)
+
+instance isSuccArchimedean_of_isPredArchimedean [IsPredArchimedean ι] : IsSuccArchimedean ι :=
+  inferInstanceAs (IsSuccArchimedean ιᵒᵈᵒᵈ)
+
+/-- In a linear `SuccOrder` that's also a `PredOrder`, `IsSuccArchimedean` and `IsPredArchimedean`
+are equivalent. -/
+theorem isSuccArchimedean_iff_isPredArchimedean : IsSuccArchimedean ι ↔ IsPredArchimedean ι :=
+  ⟨@isPredArchimedean_of_isSuccArchimedean _ _ _ _,
+    @isSuccArchimedean_of_isPredArchimedean _ _ _ _⟩
+
+end LinearOrder
+
 namespace LinearLocallyFiniteOrder
 
 /-- Successor in a linear order. This defines a true successor only when `i` is isolated from above,
@@ -142,48 +177,14 @@ instance (priority := 100) [LocallyFiniteOrder ι] : IsSuccArchimedean ι where
     have h_max : IsMax (succ^[n] i) := isMax_iterate_succ_of_eq_of_ne h_eq hnm.ne
     exact not_le.mpr (h_lt n) (h_max (h_lt n).le)
 
--- The `IsPredArchimedean` instance follows from the above and
--- `isPredArchimedean_of_isSuccArchimedean`.
+instance (priority := 100) [LocallyFiniteOrder ι] : IsPredArchimedean ι :=
+  inferInstance
 
 end LinearLocallyFiniteOrder
 
-namespace LinearOrder
-
-variable [SuccOrder ι] [PredOrder ι]
-
-instance (priority := 100) isPredArchimedean_of_isSuccArchimedean [IsSuccArchimedean ι] :
-    IsPredArchimedean ι where
-  exists_pred_iterate_of_le := by
-    intro i j hij
-    have h_exists := exists_succ_iterate_of_le hij
-    obtain ⟨n, hn_eq, hn_lt_ne⟩ : ∃ n, succ^[n] i = j ∧ ∀ m < n, succ^[m] i ≠ j :=
-      ⟨Nat.find h_exists, Nat.find_spec h_exists, fun m hmn ↦ Nat.find_min h_exists hmn⟩
-    refine ⟨n, ?_⟩
-    rw [← hn_eq]
-    induction' n with n
-    · simp only [Function.iterate_zero, id]
-    · rw [pred_succ_iterate_of_not_isMax]
-      rw [Nat.succ_sub_succ_eq_sub, tsub_zero]
-      suffices succ^[n] i < succ^[n.succ] i from not_isMax_of_lt this
-      refine lt_of_le_of_ne ?_ ?_
-      · rw [Function.iterate_succ']
-        exact le_succ _
-      · rw [hn_eq]
-        exact hn_lt_ne _ (Nat.lt_succ_self n)
-
-instance isSuccArchimedean_of_isPredArchimedean [IsPredArchimedean ι] : IsSuccArchimedean ι :=
-  inferInstanceAs (IsSuccArchimedean ιᵒᵈᵒᵈ)
-
-/-- In a linear `SuccOrder` that's also a `PredOrder`, `IsSuccArchimedean` and `IsPredArchimedean`
-are equivalent. -/
-theorem isSuccArchimedean_iff_isPredArchimedean : IsSuccArchimedean ι ↔ IsPredArchimedean ι :=
-  ⟨@isPredArchimedean_of_isSuccArchimedean _ _ _ _,
-    @isSuccArchimedean_of_isPredArchimedean _ _ _ _⟩
-
-end LinearOrder
-
 section toZ
 
+-- Requiring either of `IsSuccArchimedean` or `IsPredArchimedean` is equivalent.
 variable [SuccOrder ι] [IsSuccArchimedean ι] [PredOrder ι] {i0 i : ι}
 
 -- For "to_Z"

--- a/Mathlib/Order/SuccPred/LinearLocallyFinite.lean
+++ b/Mathlib/Order/SuccPred/LinearLocallyFinite.lean
@@ -171,8 +171,7 @@ instance (priority := 100) isPredArchimedean_of_isSuccArchimedean [IsSuccArchime
       · rw [hn_eq]
         exact hn_lt_ne _ (Nat.lt_succ_self n)
 
--- We don't make this an instance to avoid loops with `isPredArchimedean_of_isSuccArchimedean`.
-theorem isSuccArchimedean_of_isPredArchimedean [IsPredArchimedean ι] : IsSuccArchimedean ι :=
+instance isSuccArchimedean_of_isPredArchimedean [IsPredArchimedean ι] : IsSuccArchimedean ι :=
   inferInstanceAs (IsSuccArchimedean ιᵒᵈᵒᵈ)
 
 /-- In a linear `SuccOrder` that's also a `PredOrder`, `IsSuccArchimedean` and `IsPredArchimedean`

--- a/Mathlib/Order/SuccPred/LinearLocallyFinite.lean
+++ b/Mathlib/Order/SuccPred/LinearLocallyFinite.lean
@@ -111,7 +111,7 @@ noncomputable instance (priority := 100) [LocallyFiniteOrder ι] : SuccOrder ι 
   succ_le_of_lt h := succFn_le_of_lt _ _ h
 
 noncomputable instance (priority := 100) [LocallyFiniteOrder ι] : PredOrder ι :=
-  (inferInstance : PredOrder (OrderDual ιᵒᵈ))
+  inferInstanceAs (PredOrder ιᵒᵈᵒᵈ)
 
 instance (priority := 100) [LocallyFiniteOrder ι] : IsSuccArchimedean ι where
   exists_succ_iterate_of_le := by
@@ -141,6 +141,9 @@ instance (priority := 100) [LocallyFiniteOrder ι] : IsSuccArchimedean ι where
       · exact ⟨m, n, lt_of_le_of_ne h_le hnm_ne.symm, hnm_eq.symm⟩
     have h_max : IsMax (succ^[n] i) := isMax_iterate_succ_of_eq_of_ne h_eq hnm.ne
     exact not_le.mpr (h_lt n) (h_max (h_lt n).le)
+
+-- The `IsPredArchimedean` instance follows from the above and
+-- `isPredArchimedean_of_isSuccArchimedean`.
 
 end LinearLocallyFiniteOrder
 

--- a/Mathlib/Order/SuccPred/LinearLocallyFinite.lean
+++ b/Mathlib/Order/SuccPred/LinearLocallyFinite.lean
@@ -175,6 +175,8 @@ instance (priority := 100) isPredArchimedean_of_isSuccArchimedean [IsSuccArchime
 theorem isSuccArchimedean_of_isPredArchimedean [IsPredArchimedean ι] : IsSuccArchimedean ι :=
   inferInstanceAs (IsSuccArchimedean ιᵒᵈᵒᵈ)
 
+/-- In a linear `SuccOrder` that's also a `PredOrder`, `IsSuccArchimedean` and `IsPredArchimedean`
+are equivalent. -/
 theorem isSuccArchimedean_iff_isPredArchimedean : IsSuccArchimedean ι ↔ IsPredArchimedean ι :=
   ⟨@isPredArchimedean_of_isSuccArchimedean _ _ _ _,
     @isSuccArchimedean_of_isPredArchimedean _ _ _ _⟩

--- a/Mathlib/Order/SuccPred/LinearLocallyFinite.lean
+++ b/Mathlib/Order/SuccPred/LinearLocallyFinite.lean
@@ -86,8 +86,8 @@ instance isSuccArchimedean_of_isPredArchimedean [IsPredArchimedean ι] : IsSuccA
 /-- In a linear `SuccOrder` that's also a `PredOrder`, `IsSuccArchimedean` and `IsPredArchimedean`
 are equivalent. -/
 theorem isSuccArchimedean_iff_isPredArchimedean : IsSuccArchimedean ι ↔ IsPredArchimedean ι :=
-  ⟨@isPredArchimedean_of_isSuccArchimedean _ _ _ _,
-    @isSuccArchimedean_of_isPredArchimedean _ _ _ _⟩
+  ⟨fun  _ => isPredArchimedean_of_isSuccArchimedean,
+    fun  _ => isSuccArchimedean_of_isPredArchimedean⟩
 
 end LinearOrder
 

--- a/Mathlib/Order/SuccPred/LinearLocallyFinite.lean
+++ b/Mathlib/Order/SuccPred/LinearLocallyFinite.lean
@@ -113,10 +113,7 @@ noncomputable instance (priority := 100) [LocallyFiniteOrder ι] : SuccOrder ι 
 noncomputable instance (priority := 100) [LocallyFiniteOrder ι] : PredOrder ι :=
   (inferInstance : PredOrder (OrderDual ιᵒᵈ))
 
-end LinearLocallyFiniteOrder
-
-instance (priority := 100) LinearLocallyFiniteOrder.isSuccArchimedean [LocallyFiniteOrder ι] :
-    IsSuccArchimedean ι where
+instance (priority := 100) [LocallyFiniteOrder ι] : IsSuccArchimedean ι where
   exists_succ_iterate_of_le := by
     intro i j hij
     rw [le_iff_lt_or_eq] at hij
@@ -145,8 +142,14 @@ instance (priority := 100) LinearLocallyFiniteOrder.isSuccArchimedean [LocallyFi
     have h_max : IsMax (succ^[n] i) := isMax_iterate_succ_of_eq_of_ne h_eq hnm.ne
     exact not_le.mpr (h_lt n) (h_max (h_lt n).le)
 
-instance (priority := 100) LinearOrder.isPredArchimedean_of_isSuccArchimedean [SuccOrder ι]
-    [PredOrder ι] [IsSuccArchimedean ι] : IsPredArchimedean ι where
+end LinearLocallyFiniteOrder
+
+namespace LinearOrder
+
+variable [SuccOrder ι] [PredOrder ι]
+
+instance (priority := 100) isPredArchimedean_of_isSuccArchimedean [IsSuccArchimedean ι] :
+    IsPredArchimedean ι where
   exists_pred_iterate_of_le := by
     intro i j hij
     have h_exists := exists_succ_iterate_of_le hij
@@ -164,6 +167,16 @@ instance (priority := 100) LinearOrder.isPredArchimedean_of_isSuccArchimedean [S
         exact le_succ _
       · rw [hn_eq]
         exact hn_lt_ne _ (Nat.lt_succ_self n)
+
+-- We don't make this an instance to avoid loops with `isPredArchimedean_of_isSuccArchimedean`.
+theorem isSuccArchimedean_of_isPredArchimedean [IsPredArchimedean ι] : IsSuccArchimedean ι :=
+  inferInstanceAs (IsSuccArchimedean ιᵒᵈᵒᵈ)
+
+theorem isSuccArchimedean_iff_isPredArchimedean : IsSuccArchimedean ι ↔ IsPredArchimedean ι :=
+  ⟨@isPredArchimedean_of_isSuccArchimedean _ _ _ _,
+    @isSuccArchimedean_of_isPredArchimedean _ _ _ _⟩
+
+end LinearOrder
 
 section toZ
 


### PR DESCRIPTION
This result is immediate from dualizing existing results.

We also add a few missing (duplicate) instances for discoverability.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
