### PR TITLE
feat(SetTheory/ZFC): make `ZFSet.map` computable

### DIFF
--- a/Mathlib/SetTheory/ZFC/Basic.lean
+++ b/Mathlib/SetTheory/ZFC/Basic.lean
@@ -448,7 +448,8 @@ theorem mem_image {f : PSet.{u} → PSet.{u}} (H : ∀ x y, Equiv x y → Equiv 
     ⟨fun ⟨a, ya⟩ => ⟨A a, Mem.mk A a, ya⟩, fun ⟨_, ⟨a, za⟩, yz⟩ => ⟨a, yz.trans <| H _ _ za⟩⟩
 
 /-- Kuratowski ordered pair -/
-def pair (x y : PSet) : PSet := {{x}, {x, y}}
+def pair (x y : PSet) : PSet :=
+  {{x}, {x, y}}
 
 theorem pair_equiv_iff {x y x' y' : PSet.{u}} :
     Equiv (pair x y) (pair x' y') ↔ Equiv x x' ∧ Equiv y y' := by


### PR DESCRIPTION
This PR makes `ZFSet.map` computable, resolving a TODO in `SetTheory/ZFC/Basic.lean`.

It defines `PSet.pair` as Kuratowski ordered pair for `PSet` and uses it to prove `mapDefinableAux` computably. It also simplifies `ZFSet.pair_inj` as a quotient of `PSet.pair_equiv_iff`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
