### PR TITLE
[Merged by Bors] - doc(Algebra.Lie.NonUnitalNonAssocAlgebra): add documentation linking Lie algebras and NonUnitalNonAssociative rings

### DIFF
--- a/Mathlib/Algebra/Lie/NonUnitalNonAssocAlgebra.lean
+++ b/Mathlib/Algebra/Lie/NonUnitalNonAssocAlgebra.lean
@@ -24,7 +24,7 @@ algebra and we provide some basic definitions for doing so here.
 ## Main definitions
 
   * `CommutatorRing` turns a Lie ring into a `NonUnitalNonAssocSemiring` by turning its
-    `Bracket` (denoted `⁅, ⁆`) into a `Mul` (denoted `*`).
+    `Bracket` (denoted `⁅ , ⁆`) into a `Mul` (denoted `*`).
   * `LieHom.toNonUnitalAlgHom`
 
 ## Tags

--- a/Mathlib/Algebra/Lie/NonUnitalNonAssocAlgebra.lean
+++ b/Mathlib/Algebra/Lie/NonUnitalNonAssocAlgebra.lean
@@ -14,8 +14,8 @@ separate `Mul` typeclass used for general algebras.
 
 It is useful to have a special typeclass for Lie algebras because:
  * it enables us to use the traditional notation `⁅x, y⁆` for the Lie multiplication,
- * associative algebras carry a natural Lie algebra structure via the ring commutator and so we need
-   them to carry both `Mul` and `Bracket` simultaneously,
+ * associative algebras carry a natural Lie algebra structure via the ring commutator and so we
+   need them to carry both `Mul` and `Bracket` simultaneously,
  * more generally, Poisson algebras (not yet defined) need both typeclasses.
 
 However there are times when it is convenient to be able to regard a Lie algebra as a general

--- a/Mathlib/Algebra/Ring/Defs.lean
+++ b/Mathlib/Algebra/Ring/Defs.lean
@@ -112,7 +112,7 @@ that `Semiring -> NonAssocSemiring` is tried before `NonAssocRing -> NonAssocSem
 TODO: clean this once lean4#2115 is fixed
 -/
 
-/-- A not-necessarily-unital, not-necessarily-associative semiring. See `CommutatoRing` and the documentation thereof
+/-- A not-necessarily-unital, not-necessarily-associative semiring. See `CommutatorRing` and the documentation thereof
 in you need to out a `NonUnitalNonAssocSemiring` instance on a Lie ring/algebra. -/
 class NonUnitalNonAssocSemiring (α : Type u) extends AddCommMonoid α, Distrib α, MulZeroClass α
 

--- a/Mathlib/Algebra/Ring/Defs.lean
+++ b/Mathlib/Algebra/Ring/Defs.lean
@@ -24,7 +24,7 @@ the present file is about their interaction.
   addition, for example `Units`.
 * `(NonUnital)(NonAssoc)(Semi)Ring`: Typeclasses for possibly non-unital or non-associative
   rings and semirings. Some combinations are not defined yet because they haven't found use.
-  For Lie Rings, there is a type synonim `CommutatorRing` defined in
+  For Lie Rings, there is a type synonym `CommutatorRing` defined in
   `Mathlib/Algebra/Algebra/NonUnitalHom.lean` turning the bracket into a multiplication so that the
   instance `instNonUnitalNonAssocSemiringCommutatorRing` can be defined.
 

--- a/Mathlib/Algebra/Ring/Defs.lean
+++ b/Mathlib/Algebra/Ring/Defs.lean
@@ -23,7 +23,10 @@ the present file is about their interaction.
   dealing with multiplicative submonoids which are closed under negation without being closed under
   addition, for example `Units`.
 * `(NonUnital)(NonAssoc)(Semi)Ring`: Typeclasses for possibly non-unital or non-associative
-  rings and semirings. Some combinations are not defined yet because they haven't found use.
+  rings and semirings. Some combinations are not defined yet because they haven't found use. 
+  For Lie Rings, there is a type synonim `CommutatorRing` defined in `Mathlib/Algebra/Algebra/NonUnitalHom.lean`
+  turning the bracket into a multiplication so that the instance `instNonUnitalNonAssocSemiringCommutatorRing`
+  can be defined.
 
 ## Tags
 
@@ -109,7 +112,8 @@ that `Semiring -> NonAssocSemiring` is tried before `NonAssocRing -> NonAssocSem
 TODO: clean this once lean4#2115 is fixed
 -/
 
-/-- A not-necessarily-unital, not-necessarily-associative semiring. -/
+/-- A not-necessarily-unital, not-necessarily-associative semiring. See `CommutatoRing` and the documentation thereof
+in you need to out a `NonUnitalNonAssocSemiring` instance on a Lie ring/algebra. -/
 class NonUnitalNonAssocSemiring (α : Type u) extends AddCommMonoid α, Distrib α, MulZeroClass α
 
 /-- An associative but not-necessarily unital semiring. -/

--- a/Mathlib/Algebra/Ring/Defs.lean
+++ b/Mathlib/Algebra/Ring/Defs.lean
@@ -23,10 +23,10 @@ the present file is about their interaction.
   dealing with multiplicative submonoids which are closed under negation without being closed under
   addition, for example `Units`.
 * `(NonUnital)(NonAssoc)(Semi)Ring`: Typeclasses for possibly non-unital or non-associative
-  rings and semirings. Some combinations are not defined yet because they haven't found use. 
-  For Lie Rings, there is a type synonim `CommutatorRing` defined in `Mathlib/Algebra/Algebra/NonUnitalHom.lean`
-  turning the bracket into a multiplication so that the instance `instNonUnitalNonAssocSemiringCommutatorRing`
-  can be defined.
+  rings and semirings. Some combinations are not defined yet because they haven't found use.
+  For Lie Rings, there is a type synonim `CommutatorRing` defined in
+  `Mathlib/Algebra/Algebra/NonUnitalHom.lean` turning the bracket into a multiplication so that the
+  instance `instNonUnitalNonAssocSemiringCommutatorRing` can be defined.
 
 ## Tags
 
@@ -112,8 +112,9 @@ that `Semiring -> NonAssocSemiring` is tried before `NonAssocRing -> NonAssocSem
 TODO: clean this once lean4#2115 is fixed
 -/
 
-/-- A not-necessarily-unital, not-necessarily-associative semiring. See `CommutatorRing` and the documentation thereof
-in you need to out a `NonUnitalNonAssocSemiring` instance on a Lie ring/algebra. -/
+/-- A not-necessarily-unital, not-necessarily-associative semiring. See `CommutatorRing` and the
+  documentation thereof in case you need a `NonUnitalNonAssocSemiring` instance on a Lie ring
+  or a Lie algebra. -/
 class NonUnitalNonAssocSemiring (α : Type u) extends AddCommMonoid α, Distrib α, MulZeroClass α
 
 /-- An associative but not-necessarily unital semiring. -/


### PR DESCRIPTION
Add some docs about `CommutatorRing` pointing back and forth between `CommutatorRing`s and `NonAssociative` rings.