### PR TITLE
[Merged by Bors] - feat(ContextFreeGrammar): More lemmas about reversal

### DIFF
--- a/Mathlib/Computability/ContextFreeGrammar.lean
+++ b/Mathlib/Computability/ContextFreeGrammar.lean
@@ -19,8 +19,11 @@ nonterminal symbol on the left-hand side of each rule.
 * `Language.IsContextFree.reverse`: The class of context-free languages is closed under reversal.
 -/
 
+open Function
+
 universe uT uN in
 /-- Rule that rewrites a single nonterminal to any string (a list of symbols). -/
+@[ext]
 structure ContextFreeRule (T : Type uT) (N : Type uN) where
   /-- Input nonterminal a.k.a. left-hand side. -/
   input : N
@@ -40,7 +43,7 @@ universe uT uN
 variable {T : Type uT}
 
 namespace ContextFreeRule
-variable {N : Type uN}
+variable {N : Type uN} {r : ContextFreeRule T N} {u v : List (Symbol T N)}
 
 /-- Inductive definition of a single application of a given context-free rule `r` to a string `u`;
 `r.Rewrites u v` means that the `r` sends `u` to `v` (there may be multiple such strings `v`). -/
@@ -52,8 +55,7 @@ inductive Rewrites (r : ContextFreeRule T N) : List (Symbol T N) → List (Symbo
   | cons (x : Symbol T N) {s₁ s₂ : List (Symbol T N)} (hrs : Rewrites r s₁ s₂) :
       r.Rewrites (x :: s₁) (x :: s₂)
 
-lemma Rewrites.exists_parts {r : ContextFreeRule T N} {u v : List (Symbol T N)}
-    (hr : r.Rewrites u v) :
+lemma Rewrites.exists_parts (hr : r.Rewrites u v) :
     ∃ p q : List (Symbol T N),
       u = p ++ [Symbol.nonterminal r.input] ++ q ∧ v = p ++ r.output ++ q := by
   induction hr with
@@ -65,6 +67,9 @@ lemma Rewrites.exists_parts {r : ContextFreeRule T N} {u v : List (Symbol T N)}
     use x :: p', q'
     simp
 
+lemma Rewrites.input_output : r.Rewrites [.nonterminal r.input] r.output := by
+  simpa using head []
+
 lemma rewrites_of_exists_parts (r : ContextFreeRule T N) (p q : List (Symbol T N)) :
     r.Rewrites (p ++ [Symbol.nonterminal r.input] ++ q) (p ++ r.output ++ q) := by
   induction p with
@@ -74,22 +79,22 @@ lemma rewrites_of_exists_parts (r : ContextFreeRule T N) (p q : List (Symbol T N
 /-- Rule `r` rewrites string `u` is to string `v` iff they share both a prefix `p` and postfix `q`
 such that the remaining middle part of `u` is the input of `r` and the remaining middle part
 of `u` is the output of `r`. -/
-theorem rewrites_iff {r : ContextFreeRule T N} (u v : List (Symbol T N)) :
+theorem rewrites_iff :
     r.Rewrites u v ↔ ∃ p q : List (Symbol T N),
       u = p ++ [Symbol.nonterminal r.input] ++ q ∧ v = p ++ r.output ++ q :=
   ⟨Rewrites.exists_parts, by rintro ⟨p, q, rfl, rfl⟩; apply rewrites_of_exists_parts⟩
 
 /-- Add extra prefix to context-free rewriting. -/
-lemma Rewrites.append_left {r : ContextFreeRule T N} {v w : List (Symbol T N)}
-    (hvw : r.Rewrites v w) (p : List (Symbol T N)) : r.Rewrites (p ++ v) (p ++ w) := by
+lemma Rewrites.append_left (hvw : r.Rewrites u v) (p : List (Symbol T N)) :
+    r.Rewrites (p ++ u) (p ++ v) := by
   rw [rewrites_iff] at *
   rcases hvw with ⟨x, y, hxy⟩
   use p ++ x, y
   simp_all
 
 /-- Add extra postfix to context-free rewriting. -/
-lemma Rewrites.append_right {r : ContextFreeRule T N} {v w : List (Symbol T N)}
-    (hvw : r.Rewrites v w) (p : List (Symbol T N)) : r.Rewrites (v ++ p) (w ++ p) := by
+lemma Rewrites.append_right (hvw : r.Rewrites u v) (p : List (Symbol T N)) :
+    r.Rewrites (u ++ p) (v ++ p) := by
   rw [rewrites_iff] at *
   rcases hvw with ⟨x, y, hxy⟩
   use x, y ++ p
@@ -200,59 +205,97 @@ proof_wanted Language.isContextFree_iff {L : Language T} :
 
 section closure_reversal
 
+namespace ContextFreeRule
+variable {N : Type uN} {r : ContextFreeRule T N} {u v : List (Symbol T N)}
+
 /-- Rules for a grammar for a reversed language. -/
-def ContextFreeRule.reverse {N : Type uN} (r : ContextFreeRule T N) : ContextFreeRule T N :=
-  ⟨r.input, r.output.reverse⟩
+def reverse (r : ContextFreeRule T N) : ContextFreeRule T N := ⟨r.input, r.output.reverse⟩
+
+@[simp] lemma reverse_reverse (r : ContextFreeRule T N) : r.reverse.reverse = r := by simp [reverse]
+
+@[simp] lemma reverse_comp_reverse :
+    reverse ∘ reverse = (id : ContextFreeRule T N → ContextFreeRule T N) := by ext : 1; simp
+
+lemma reverse_involutive : Involutive (reverse : ContextFreeRule T N → ContextFreeRule T N) :=
+  reverse_reverse
+
+lemma reverse_bijective : Bijective (reverse : ContextFreeRule T N → ContextFreeRule T N) :=
+  reverse_involutive.bijective
+
+lemma reverse_injective : Injective (reverse : ContextFreeRule T N → ContextFreeRule T N) :=
+  reverse_involutive.injective
+
+lemma reverse_surjective : Surjective (reverse : ContextFreeRule T N → ContextFreeRule T N) :=
+  reverse_involutive.surjective
+
+protected lemma Rewrites.reverse : ∀ {u v}, r.Rewrites u v → r.reverse.Rewrites u.reverse v.reverse
+  | _, _, head s => by simpa using .append_left .input_output _
+  | _, _, @cons _ _ _ x u v h => by simpa using h.reverse.append_right _
+
+lemma rewrites_reverse : r.reverse.Rewrites u.reverse v.reverse ↔ r.Rewrites u v :=
+  ⟨fun h ↦ by simpa using h.reverse, .reverse⟩
+
+@[simp] lemma rewrites_reverse_comm : r.reverse.Rewrites u v ↔ r.Rewrites u.reverse v.reverse := by
+  rw [← rewrites_reverse, reverse_reverse]
+
+end ContextFreeRule
+
+namespace ContextFreeGrammar
+variable {g : ContextFreeGrammar T} {u v : List (Symbol T g.NT)} {w : List T}
 
 /-- Grammar for a reversed language. -/
-def ContextFreeGrammar.reverse (g : ContextFreeGrammar T) : ContextFreeGrammar T :=
+@[simps] def reverse (g : ContextFreeGrammar T) : ContextFreeGrammar T :=
   ⟨g.NT, g.initial, g.rules.map .reverse⟩
 
-lemma ContextFreeRule.reverse_involutive {N : Type uN} :
-    Function.Involutive (@ContextFreeRule.reverse T N) := by
-  intro x
-  simp [ContextFreeRule.reverse]
+@[simp] lemma reverse_reverse (g : ContextFreeGrammar T) : g.reverse.reverse = g := by
+  simp [reverse, Finset.map_map]
 
-lemma ContextFreeGrammar.reverse_involutive :
-    Function.Involutive (@ContextFreeGrammar.reverse T) := by
-  intro x
-  simp [ContextFreeGrammar.reverse, ContextFreeRule.reverse_involutive]
+lemma reverse_involutive : Involutive (reverse : ContextFreeGrammar T → ContextFreeGrammar T) :=
+  reverse_reverse
 
-lemma ContextFreeGrammar.reverse_derives (g : ContextFreeGrammar T) {s : List (Symbol T g.NT)}
-    (hgs : g.reverse.Derives [Symbol.nonterminal g.reverse.initial] s) :
-    g.Derives [Symbol.nonterminal g.initial] s.reverse := by
-  induction hgs with
-  | refl =>
-    rw [List.reverse_singleton]
-    apply ContextFreeGrammar.Derives.refl
-  | tail _ orig ih =>
-    apply ContextFreeGrammar.Derives.trans_produces ih
-    obtain ⟨r, rin, rewr⟩ := orig
-    simp only [ContextFreeGrammar.reverse, List.mem_map] at rin
-    obtain ⟨r₀, rin₀, rfl⟩ := rin
-    refine ⟨r₀, rin₀, ?_⟩
-    rw [ContextFreeRule.rewrites_iff] at rewr ⊢
-    rcases rewr with ⟨p, q, rfl, rfl⟩
-    use q.reverse, p.reverse
-    simp [ContextFreeRule.reverse]
+lemma reverse_bijective : Bijective (reverse : ContextFreeGrammar T → ContextFreeGrammar T) :=
+  reverse_involutive.bijective
 
-lemma ContextFreeGrammar.reverse_mem_language_of_mem_reverse_language (g : ContextFreeGrammar T)
-    {w : List T} (hgw : w ∈ g.reverse.language) :
-    w.reverse ∈ g.language := by
-  convert g.reverse_derives hgw
-  simp [List.map_reverse]
+lemma reverse_injective : Injective (reverse : ContextFreeGrammar T → ContextFreeGrammar T) :=
+  reverse_involutive.injective
 
-lemma ContextFreeGrammar.mem_reverse_language_iff_reverse_mem_language (g : ContextFreeGrammar T)
-    (w : List T) :
-    w ∈ g.reverse.language ↔ w.reverse ∈ g.language := by
-  refine ⟨reverse_mem_language_of_mem_reverse_language _, fun hw => ?_⟩
-  rw [← ContextFreeGrammar.reverse_involutive g] at hw
-  rw [← List.reverse_reverse w]
-  exact g.reverse.reverse_mem_language_of_mem_reverse_language hw
+lemma reverse_surjective : Surjective (reverse : ContextFreeGrammar T → ContextFreeGrammar T) :=
+  reverse_involutive.surjective
+
+lemma produces_reverse : g.reverse.Produces u.reverse v.reverse ↔ g.Produces u v :=
+  (Equiv.ofBijective _ ContextFreeRule.reverse_bijective).exists_congr
+    (by simp [ContextFreeRule.reverse_involutive.eq_iff])
+
+alias ⟨_, Produces.reverse⟩ := produces_reverse
+
+@[simp] lemma produces_reverse_comm : g.reverse.Produces u v ↔ g.Produces u.reverse v.reverse :=
+  (Equiv.ofBijective _ ContextFreeRule.reverse_bijective).exists_congr
+    (by simp [ContextFreeRule.reverse_involutive.eq_iff])
+
+protected lemma Derives.reverse (hg : g.Derives u v) : g.reverse.Derives u.reverse v.reverse := by
+  induction hg with
+  | refl => rfl
+  | tail _ orig ih => exact ih.trans_produces orig.reverse
+
+lemma derives_reverse : g.reverse.Derives u.reverse v.reverse ↔ g.Derives u v :=
+  ⟨fun h ↦ by convert h.reverse <;> simp, .reverse⟩
+
+@[simp] lemma derives_reverse_comm : g.reverse.Derives u v ↔ g.Derives u.reverse v.reverse := by
+  rw [iff_comm, ← derives_reverse, List.reverse_reverse, List.reverse_reverse]
+
+lemma generates_reverse : g.reverse.Generates u.reverse ↔ g.Generates u := by simp [Generates]
+
+alias ⟨_, Generates.reverse⟩ := generates_reverse
+
+@[simp] lemma generates_reverse_comm : g.reverse.Generates u ↔ g.Generates u.reverse := by
+  simp [Generates]
+
+@[simp] lemma language_reverse : g.reverse.language = g.language.reverse := by ext; simp
+
+end ContextFreeGrammar
 
 /-- The class of context-free languages is closed under reversal. -/
-theorem Language.IsContextFree.reverse (L : Language T) :
-    L.IsContextFree → L.reverse.IsContextFree :=
-  fun ⟨g, hg⟩ => ⟨g.reverse, hg ▸ Set.ext g.mem_reverse_language_iff_reverse_mem_language⟩
+theorem Language.IsContextFree.reverse (L : Language T) : 
+    L.IsContextFree → L.reverse.IsContextFree := by rintro ⟨g, rfl⟩; exact ⟨g.reverse, by simp⟩
 
 end closure_reversal

--- a/Mathlib/Computability/ContextFreeGrammar.lean
+++ b/Mathlib/Computability/ContextFreeGrammar.lean
@@ -295,7 +295,7 @@ alias ⟨_, Generates.reverse⟩ := generates_reverse
 end ContextFreeGrammar
 
 /-- The class of context-free languages is closed under reversal. -/
-theorem Language.IsContextFree.reverse (L : Language T) : 
+theorem Language.IsContextFree.reverse (L : Language T) :
     L.IsContextFree → L.reverse.IsContextFree := by rintro ⟨g, rfl⟩; exact ⟨g.reverse, by simp⟩
 
 end closure_reversal

--- a/Mathlib/Logic/Embedding/Basic.lean
+++ b/Mathlib/Logic/Embedding/Basic.lean
@@ -132,6 +132,11 @@ protected def trans {α β γ} (f : α ↪ β) (g : β ↪ γ) : α ↪ γ :=
 
 instance : Trans Embedding Embedding Embedding := ⟨Embedding.trans⟩
 
+@[simp] lemma mk_id {α} : mk id injective_id = .refl α := rfl
+
+@[simp] lemma mk_trans_mk {α β γ} (f : α → β) (g : β → γ) (hf hg) :
+    (mk f hf).trans (mk g hg) = mk (g ∘ f) (hg.comp hf) := rfl
+
 @[simp]
 theorem equiv_toEmbedding_trans_symm_toEmbedding {α β : Sort*} (e : α ≃ β) :
     e.toEmbedding.trans e.symm.toEmbedding = Embedding.refl _ := by


### PR DESCRIPTION
A lot of API was missing

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
