### PR TITLE
[Merged by Bors] - fix: mm use github.event.pull_request.number

### DIFF
--- a/.github/workflows/maintainer_merge_review.yml
+++ b/.github/workflows/maintainer_merge_review.yml
@@ -27,7 +27,7 @@ jobs:
         run: |
           ./scripts/get_tlabel.sh "${PR}" >> "$GITHUB_OUTPUT"
         env:
-          PR:  /repos/leanprover-community/mathlib4/issues/${{ github.event.issue.number }}
+          PR:  /repos/leanprover-community/mathlib4/issues/${{ github.event.pull_request.number }}
           GH_TOKEN: ${{secrets.GITHUB_TOKEN}}
 
       - name: Send message on Zulip

--- a/.github/workflows/maintainer_merge_review_comment.yml
+++ b/.github/workflows/maintainer_merge_review_comment.yml
@@ -26,7 +26,7 @@ jobs:
         run: |
           ./scripts/get_tlabel.sh "${PR}" >> "$GITHUB_OUTPUT"
         env:
-          PR:  /repos/leanprover-community/mathlib4/issues/${{ github.event.issue.number }}
+          PR:  /repos/leanprover-community/mathlib4/issues/${{ github.event.pull_request.number }}
           GH_TOKEN: ${{secrets.GITHUB_TOKEN}}
 
       - name: Send message on Zulip


### PR DESCRIPTION
The `maintainer merge` action from *comment* works with `github.event.issue.number`, but the actions from review (comment or body) probably require `github.event.pull_request.number`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
