### PR TITLE
[Merged by Bors] - chore: split Analysis.Normed.Field.Basic

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -1172,6 +1172,7 @@ import Mathlib.Analysis.Normed.Algebra.Unitization
 import Mathlib.Analysis.Normed.Algebra.UnitizationL1
 import Mathlib.Analysis.Normed.Field.Basic
 import Mathlib.Analysis.Normed.Field.InfiniteSum
+import Mathlib.Analysis.Normed.Field.Lemmas
 import Mathlib.Analysis.Normed.Field.UnitBall
 import Mathlib.Analysis.Normed.Group.AddCircle
 import Mathlib.Analysis.Normed.Group.AddTorsor

--- a/Mathlib/Analysis/Asymptotics/Asymptotics.lean
+++ b/Mathlib/Analysis/Asymptotics/Asymptotics.lean
@@ -3,6 +3,7 @@ Copyright (c) 2019 Jeremy Avigad. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Jeremy Avigad, Yury Kudryashov
 -/
+import Mathlib.Analysis.Normed.Group.Bounded
 import Mathlib.Analysis.Normed.Group.InfiniteSum
 import Mathlib.Analysis.Normed.MulAction
 import Mathlib.Topology.Algebra.Order.LiminfLimsup

--- a/Mathlib/Analysis/LocallyConvex/WeakDual.lean
+++ b/Mathlib/Analysis/LocallyConvex/WeakDual.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Moritz Doll
 -/
 import Mathlib.Topology.Algebra.Module.WeakDual
-import Mathlib.Analysis.Normed.Field.Basic
+import Mathlib.Analysis.Normed.Field.Lemmas
 import Mathlib.Analysis.LocallyConvex.WithSeminorms
 
 /-!

--- a/Mathlib/Analysis/Normed/Field/Basic.lean
+++ b/Mathlib/Analysis/Normed/Field/Basic.lean
@@ -5,16 +5,9 @@ Authors: Patrick Massot, Johannes Hölzl
 -/
 import Mathlib.Algebra.Algebra.NonUnitalSubalgebra
 import Mathlib.Algebra.Algebra.Subalgebra.Basic
-import Mathlib.Algebra.Group.AddChar
-import Mathlib.Algebra.Order.Ring.Finset
-import Mathlib.Analysis.Normed.Group.Bounded
 import Mathlib.Analysis.Normed.Group.Constructions
-import Mathlib.Analysis.Normed.Group.Rat
 import Mathlib.Analysis.Normed.Group.Submodule
-import Mathlib.Analysis.Normed.Group.Uniform
-import Mathlib.GroupTheory.OrderOfElement
-import Mathlib.Topology.Instances.NNReal
-import Mathlib.Topology.MetricSpace.DilationEquiv
+import Mathlib.Data.Set.Pointwise.Interval
 
 /-!
 # Normed fields
@@ -24,12 +17,20 @@ definitions.
 -/
 
 -- Guard against import creep.
+assert_not_exists AddChar
+assert_not_exists comap_norm_atTop
+assert_not_exists DilationEquiv
+assert_not_exists Finset.sup_mul_le_mul_sup_of_nonneg
+assert_not_exists IsOfFinOrder
+assert_not_exists Isometry.norm_map_of_map_one
+assert_not_exists NNReal.isOpen_Ico_zero
+assert_not_exists Rat.norm_cast_real
 assert_not_exists RestrictScalars
 
-variable {α : Type*} {β : Type*} {γ : Type*} {ι : Type*}
+variable {α : Type*} {β : Type*} {ι : Type*}
 
-open Filter Metric Bornology
-open scoped Topology NNReal ENNReal uniformity Pointwise
+open Filter
+open scoped Topology NNReal
 
 /-- A non-unital seminormed ring is a not-necessarily-unital ring
 endowed with a seminorm which satisfies the inequality `‖x y‖ ≤ ‖x‖ ‖y‖`. -/
@@ -224,17 +225,6 @@ theorem one_le_norm_one (β) [NormedRing β] [Nontrivial β] : 1 ≤ ‖(1 : β)
 theorem one_le_nnnorm_one (β) [NormedRing β] [Nontrivial β] : 1 ≤ ‖(1 : β)‖₊ :=
   one_le_norm_one β
 
-theorem Filter.Tendsto.zero_mul_isBoundedUnder_le {f g : ι → α} {l : Filter ι}
-    (hf : Tendsto f l (𝓝 0)) (hg : IsBoundedUnder (· ≤ ·) l ((‖·‖) ∘ g)) :
-    Tendsto (fun x => f x * g x) l (𝓝 0) :=
-  hf.op_zero_isBoundedUnder_le hg (· * ·) norm_mul_le
-
-theorem Filter.isBoundedUnder_le_mul_tendsto_zero {f g : ι → α} {l : Filter ι}
-    (hf : IsBoundedUnder (· ≤ ·) l (norm ∘ f)) (hg : Tendsto g l (𝓝 0)) :
-    Tendsto (fun x => f x * g x) l (𝓝 0) :=
-  hg.op_zero_isBoundedUnder_le hf (flip (· * ·)) fun x y =>
-    (norm_mul_le y x).trans_eq (mul_comm _ _)
-
 /-- In a seminormed ring, the left-multiplication `AddMonoidHom` is bounded. -/
 theorem mulLeft_bound (x : α) : ∀ y : α, ‖AddMonoidHom.mulLeft x y‖ ≤ ‖x‖ * ‖y‖ :=
   norm_mul_le x
@@ -301,21 +291,6 @@ instance Prod.nonUnitalSeminormedRing [NonUnitalSeminormedRing β] :
         _ = ‖x‖ * ‖y‖ := rfl
          }
 
-/-- Non-unital seminormed ring structure on the product of finitely many non-unital seminormed
-rings, using the sup norm. -/
-instance Pi.nonUnitalSeminormedRing {π : ι → Type*} [Fintype ι]
-    [∀ i, NonUnitalSeminormedRing (π i)] : NonUnitalSeminormedRing (∀ i, π i) :=
-  { Pi.seminormedAddCommGroup, Pi.nonUnitalRing with
-    norm_mul := fun x y =>
-      NNReal.coe_mono <|
-        calc
-          (Finset.univ.sup fun i => ‖x i * y i‖₊) ≤
-              Finset.univ.sup ((fun i => ‖x i‖₊) * fun i => ‖y i‖₊) :=
-            Finset.sup_mono_fun fun _ _ => norm_mul_le _ _
-          _ ≤ (Finset.univ.sup fun i => ‖x i‖₊) * Finset.univ.sup fun i => ‖y i‖₊ :=
-            Finset.sup_mul_le_mul_sup_of_nonneg _ (fun _ _ => zero_le _) fun _ _ => zero_le _
-           }
-
 instance MulOpposite.instNonUnitalSeminormedRing : NonUnitalSeminormedRing αᵐᵒᵖ where
   __ := instNonUnitalRing
   __ := instSeminormedAddCommGroup
@@ -358,6 +333,7 @@ instance (priority := 75) SubalgebraClass.normedRing {S 𝕜 E : Type*} [CommRin
     (s : S) : NormedRing s :=
   { seminormedRing s with
     eq_of_dist_eq_zero := eq_of_dist_eq_zero }
+
 
 theorem Nat.norm_cast_le : ∀ n : ℕ, ‖(n : α)‖ ≤ n * ‖(1 : α)‖
   | 0 => by simp
@@ -437,12 +413,6 @@ instance ULift.seminormedRing : SeminormedRing (ULift α) :=
 instance Prod.seminormedRing [SeminormedRing β] : SeminormedRing (α × β) :=
   { nonUnitalSeminormedRing, instRing with }
 
-/-- Seminormed ring structure on the product of finitely many seminormed rings,
-  using the sup norm. -/
-instance Pi.seminormedRing {π : ι → Type*} [Fintype ι] [∀ i, SeminormedRing (π i)] :
-    SeminormedRing (∀ i, π i) :=
-  { Pi.nonUnitalSeminormedRing, Pi.ring with }
-
 instance MulOpposite.instSeminormedRing : SeminormedRing αᵐᵒᵖ where
   __ := instRing
   __ := instNonUnitalSeminormedRing
@@ -484,12 +454,6 @@ using the sup norm. -/
 instance Prod.nonUnitalNormedRing [NonUnitalNormedRing β] : NonUnitalNormedRing (α × β) :=
   { Prod.nonUnitalSeminormedRing, Prod.normedAddCommGroup with }
 
-/-- Normed ring structure on the product of finitely many non-unital normed rings, using the sup
-norm. -/
-instance Pi.nonUnitalNormedRing {π : ι → Type*} [Fintype ι] [∀ i, NonUnitalNormedRing (π i)] :
-    NonUnitalNormedRing (∀ i, π i) :=
-  { Pi.nonUnitalSeminormedRing, Pi.normedAddCommGroup with }
-
 instance MulOpposite.instNonUnitalNormedRing : NonUnitalNormedRing αᵐᵒᵖ where
   __ := instNonUnitalRing
   __ := instNonUnitalSeminormedRing
@@ -514,11 +478,6 @@ instance ULift.normedRing : NormedRing (ULift α) :=
 instance Prod.normedRing [NormedRing β] : NormedRing (α × β) :=
   { nonUnitalNormedRing, instRing with }
 
-/-- Normed ring structure on the product of finitely many normed rings, using the sup norm. -/
-instance Pi.normedRing {π : ι → Type*} [Fintype ι] [∀ i, NormedRing (π i)] :
-    NormedRing (∀ i, π i) :=
-  { Pi.seminormedRing, Pi.normedAddCommGroup with }
-
 instance MulOpposite.instNormedRing : NormedRing αᵐᵒᵖ where
   __ := instRing
   __ := instSeminormedRing
@@ -538,12 +497,6 @@ commutative rings, using the sup norm. -/
 instance Prod.nonUnitalSeminormedCommRing [NonUnitalSeminormedCommRing β] :
     NonUnitalSeminormedCommRing (α × β) :=
   { nonUnitalSeminormedRing, instNonUnitalCommRing with }
-
-/-- Non-unital seminormed commutative ring structure on the product of finitely many non-unital
-seminormed commutative rings, using the sup norm. -/
-instance Pi.nonUnitalSeminormedCommRing {π : ι → Type*} [Fintype ι]
-    [∀ i, NonUnitalSeminormedCommRing (π i)] : NonUnitalSeminormedCommRing (∀ i, π i) :=
-  { Pi.nonUnitalSeminormedRing, Pi.nonUnitalCommRing with }
 
 instance MulOpposite.instNonUnitalSeminormedCommRing : NonUnitalSeminormedCommRing αᵐᵒᵖ where
   __ := instNonUnitalSeminormedRing
@@ -578,12 +531,6 @@ instance Prod.nonUnitalNormedCommRing [NonUnitalNormedCommRing β] :
     NonUnitalNormedCommRing (α × β) :=
   { Prod.nonUnitalSeminormedCommRing, Prod.normedAddCommGroup with }
 
-/-- Normed commutative ring structure on the product of finitely many non-unital normed
-commutative rings, using the sup norm. -/
-instance Pi.nonUnitalNormedCommRing {π : ι → Type*} [Fintype ι]
-    [∀ i, NonUnitalNormedCommRing (π i)] : NonUnitalNormedCommRing (∀ i, π i) :=
-  { Pi.nonUnitalSeminormedCommRing, Pi.normedAddCommGroup with }
-
 instance MulOpposite.instNonUnitalNormedCommRing : NonUnitalNormedCommRing αᵐᵒᵖ where
   __ := instNonUnitalNormedRing
   __ := instNonUnitalSeminormedCommRing
@@ -601,12 +548,6 @@ instance ULift.seminormedCommRing : SeminormedCommRing (ULift α) :=
   using the sup norm. -/
 instance Prod.seminormedCommRing [SeminormedCommRing β] : SeminormedCommRing (α × β) :=
   { Prod.nonUnitalSeminormedCommRing, instCommRing with }
-
-/-- Seminormed commutative ring structure on the product of finitely many seminormed commutative
-rings, using the sup norm. -/
-instance Pi.seminormedCommRing {π : ι → Type*} [Fintype ι] [∀ i, SeminormedCommRing (π i)] :
-    SeminormedCommRing (∀ i, π i) :=
-  { Pi.nonUnitalSeminormedCommRing, Pi.ring with }
 
 instance MulOpposite.instSeminormedCommRing : SeminormedCommRing αᵐᵒᵖ where
   __ := instSeminormedRing
@@ -638,47 +579,11 @@ norm. -/
 instance Prod.normedCommRing [NormedCommRing β] : NormedCommRing (α × β) :=
   { nonUnitalNormedRing, instCommRing with }
 
-/-- Normed commutative ring structure on the product of finitely many normed commutative rings,
-using the sup norm. -/
-instance Pi.normedCommutativeRing {π : ι → Type*} [Fintype ι] [∀ i, NormedCommRing (π i)] :
-    NormedCommRing (∀ i, π i) :=
-  { Pi.seminormedCommRing, Pi.normedAddCommGroup with }
-
 instance MulOpposite.instNormedCommRing : NormedCommRing αᵐᵒᵖ where
   __ := instNormedRing
   __ := instSeminormedCommRing
 
 end NormedCommRing
-
--- see Note [lower instance priority]
-instance (priority := 100) semi_normed_ring_top_monoid [NonUnitalSeminormedRing α] :
-    ContinuousMul α :=
-  ⟨continuous_iff_continuousAt.2 fun x =>
-      tendsto_iff_norm_sub_tendsto_zero.2 <| by
-        have : ∀ e : α × α,
-            ‖e.1 * e.2 - x.1 * x.2‖ ≤ ‖e.1‖ * ‖e.2 - x.2‖ + ‖e.1 - x.1‖ * ‖x.2‖ := by
-          intro e
-          calc
-            ‖e.1 * e.2 - x.1 * x.2‖ ≤ ‖e.1 * (e.2 - x.2) + (e.1 - x.1) * x.2‖ := by
-              rw [_root_.mul_sub, _root_.sub_mul, sub_add_sub_cancel]
-            -- Porting note: `ENNReal.{mul_sub, sub_mul}` should be protected
-            _ ≤ ‖e.1‖ * ‖e.2 - x.2‖ + ‖e.1 - x.1‖ * ‖x.2‖ :=
-              norm_add_le_of_le (norm_mul_le _ _) (norm_mul_le _ _)
-        refine squeeze_zero (fun e => norm_nonneg _) this ?_
-        convert
-          ((continuous_fst.tendsto x).norm.mul
-                ((continuous_snd.tendsto x).sub tendsto_const_nhds).norm).add
-            (((continuous_fst.tendsto x).sub tendsto_const_nhds).norm.mul _)
-        -- Porting note: `show` used to select a goal to work on
-        rotate_right
-        · show Tendsto _ _ _
-          exact tendsto_const_nhds
-        · simp⟩
-
--- see Note [lower instance priority]
-/-- A seminormed ring is a topological ring. -/
-instance (priority := 100) semi_normed_top_ring [NonUnitalSeminormedRing α] :
-    TopologicalRing α where
 
 section NormedDivisionRing
 
@@ -763,117 +668,6 @@ theorem dist_inv_inv₀ {z w : α} (hz : z ≠ 0) (hw : w ≠ 0) :
 theorem nndist_inv_inv₀ {z w : α} (hz : z ≠ 0) (hw : w ≠ 0) :
     nndist z⁻¹ w⁻¹ = nndist z w / (‖z‖₊ * ‖w‖₊) :=
   NNReal.eq <| dist_inv_inv₀ hz hw
-
-lemma antilipschitzWith_mul_left {a : α} (ha : a ≠ 0) : AntilipschitzWith (‖a‖₊⁻¹) (a * ·) :=
-  AntilipschitzWith.of_le_mul_dist fun _ _ ↦ by simp [dist_eq_norm, ← _root_.mul_sub, ha]
-
-lemma antilipschitzWith_mul_right {a : α} (ha : a ≠ 0) : AntilipschitzWith (‖a‖₊⁻¹) (· * a) :=
-  AntilipschitzWith.of_le_mul_dist fun _ _ ↦ by
-    simp [dist_eq_norm, ← _root_.sub_mul, ← mul_comm (‖a‖), ha]
-
-/-- Multiplication by a nonzero element `a` on the left
-as a `DilationEquiv` of a normed division ring. -/
-@[simps!]
-def DilationEquiv.mulLeft (a : α) (ha : a ≠ 0) : α ≃ᵈ α where
-  toEquiv := Equiv.mulLeft₀ a ha
-  edist_eq' := ⟨‖a‖₊, nnnorm_ne_zero_iff.2 ha, fun x y ↦ by
-    simp [edist_nndist, nndist_eq_nnnorm, ← mul_sub]⟩
-
-/-- Multiplication by a nonzero element `a` on the right
-as a `DilationEquiv` of a normed division ring. -/
-@[simps!]
-def DilationEquiv.mulRight (a : α) (ha : a ≠ 0) : α ≃ᵈ α where
-  toEquiv := Equiv.mulRight₀ a ha
-  edist_eq' := ⟨‖a‖₊, nnnorm_ne_zero_iff.2 ha, fun x y ↦ by
-    simp [edist_nndist, nndist_eq_nnnorm, ← sub_mul, ← mul_comm (‖a‖₊)]⟩
-
-namespace Filter
-
-@[simp]
-lemma comap_mul_left_cobounded {a : α} (ha : a ≠ 0) :
-    comap (a * ·) (cobounded α) = cobounded α :=
-  Dilation.comap_cobounded (DilationEquiv.mulLeft a ha)
-
-@[simp]
-lemma map_mul_left_cobounded {a : α} (ha : a ≠ 0) :
-    map (a * ·) (cobounded α) = cobounded α :=
-  DilationEquiv.map_cobounded (DilationEquiv.mulLeft a ha)
-
-@[simp]
-lemma comap_mul_right_cobounded {a : α} (ha : a ≠ 0) :
-    comap (· * a) (cobounded α) = cobounded α :=
-  Dilation.comap_cobounded (DilationEquiv.mulRight a ha)
-
-@[simp]
-lemma map_mul_right_cobounded {a : α} (ha : a ≠ 0) :
-    map (· * a) (cobounded α) = cobounded α :=
-  DilationEquiv.map_cobounded (DilationEquiv.mulRight a ha)
-
-/-- Multiplication on the left by a nonzero element of a normed division ring tends to infinity at
-infinity. -/
-theorem tendsto_mul_left_cobounded {a : α} (ha : a ≠ 0) :
-    Tendsto (a * ·) (cobounded α) (cobounded α) :=
-  (map_mul_left_cobounded ha).le
-
-/-- Multiplication on the right by a nonzero element of a normed division ring tends to infinity at
-infinity. -/
-theorem tendsto_mul_right_cobounded {a : α} (ha : a ≠ 0) :
-    Tendsto (· * a) (cobounded α) (cobounded α) :=
-  (map_mul_right_cobounded ha).le
-
-@[simp]
-lemma inv_cobounded₀ : (cobounded α)⁻¹ = 𝓝[≠] 0 := by
-  rw [← comap_norm_atTop, ← Filter.comap_inv, ← comap_norm_nhdsWithin_Ioi_zero,
-    ← inv_atTop₀, ← Filter.comap_inv]
-  simp only [comap_comap, Function.comp_def, norm_inv]
-
-@[simp]
-lemma inv_nhdsWithin_ne_zero : (𝓝[≠] (0 : α))⁻¹ = cobounded α := by
-  rw [← inv_cobounded₀, inv_inv]
-
-lemma tendsto_inv₀_cobounded' : Tendsto Inv.inv (cobounded α) (𝓝[≠] 0) :=
-  inv_cobounded₀.le
-
-theorem tendsto_inv₀_cobounded : Tendsto Inv.inv (cobounded α) (𝓝 0) :=
-  tendsto_inv₀_cobounded'.mono_right inf_le_left
-
-lemma tendsto_inv₀_nhdsWithin_ne_zero : Tendsto Inv.inv (𝓝[≠] 0) (cobounded α) :=
-  inv_nhdsWithin_ne_zero.le
-
-end Filter
-
--- see Note [lower instance priority]
-instance (priority := 100) NormedDivisionRing.to_hasContinuousInv₀ : HasContinuousInv₀ α := by
-  refine ⟨fun r r0 => tendsto_iff_norm_sub_tendsto_zero.2 ?_⟩
-  have r0' : 0 < ‖r‖ := norm_pos_iff.2 r0
-  rcases exists_between r0' with ⟨ε, ε0, εr⟩
-  have : ∀ᶠ e in 𝓝 r, ‖e⁻¹ - r⁻¹‖ ≤ ‖r - e‖ / ‖r‖ / ε := by
-    filter_upwards [(isOpen_lt continuous_const continuous_norm).eventually_mem εr] with e he
-    have e0 : e ≠ 0 := norm_pos_iff.1 (ε0.trans he)
-    calc
-      ‖e⁻¹ - r⁻¹‖ = ‖r‖⁻¹ * ‖r - e‖ * ‖e‖⁻¹ := by
-        rw [← norm_inv, ← norm_inv, ← norm_mul, ← norm_mul, _root_.mul_sub, _root_.sub_mul,
-          mul_assoc _ e, inv_mul_cancel₀ r0, mul_inv_cancel₀ e0, one_mul, mul_one]
-      -- Porting note: `ENNReal.{mul_sub, sub_mul}` should be `protected`
-      _ = ‖r - e‖ / ‖r‖ / ‖e‖ := by field_simp [mul_comm]
-      _ ≤ ‖r - e‖ / ‖r‖ / ε := by gcongr
-  refine squeeze_zero' (Eventually.of_forall fun _ => norm_nonneg _) this ?_
-  refine (((continuous_const.sub continuous_id).norm.div_const _).div_const _).tendsto' _ _ ?_
-  simp
-
--- see Note [lower instance priority]
-/-- A normed division ring is a topological division ring. -/
-instance (priority := 100) NormedDivisionRing.to_topologicalDivisionRing :
-    TopologicalDivisionRing α where
-
-protected lemma IsOfFinOrder.norm_eq_one (ha : IsOfFinOrder a) : ‖a‖ = 1 :=
-  ((normHom : α →*₀ ℝ).toMonoidHom.isOfFinOrder ha).eq_one <| norm_nonneg _
-
-example [Monoid β] (φ : β →* α) {x : β} {k : ℕ+} (h : x ^ (k : ℕ) = 1) :
-    ‖φ x‖ = 1 := (φ.isOfFinOrder <| isOfFinOrder_iff_pow_eq_one.2 ⟨_, k.2, h⟩).norm_eq_one
-
-@[simp] lemma AddChar.norm_apply {G : Type*} [AddLeftCancelMonoid G] [Finite G] (ψ : AddChar G α)
-    (x : G) : ‖ψ x‖ = 1 := (ψ.toMonoidHom.isOfFinOrder <| isOfFinOrder_of_finite _).norm_eq_one
 
 end NormedDivisionRing
 
@@ -987,11 +781,6 @@ instance denselyOrdered_range_nnnorm : DenselyOrdered (Set.range (nnnorm : α �
     let ⟨z, h⟩ := exists_lt_nnnorm_lt α hxy
     exact ⟨⟨‖z‖₊, z, rfl⟩, h⟩
 
-theorem denseRange_nnnorm : DenseRange (nnnorm : α → ℝ≥0) :=
-  dense_of_exists_between fun _ _ hr =>
-    let ⟨x, h⟩ := exists_lt_nnnorm_lt α hr
-    ⟨‖x‖₊, ⟨x, rfl⟩, h⟩
-
 end Densely
 
 end NormedField
@@ -1044,14 +833,6 @@ theorem norm_eq (x : ℝ≥0) : ‖(x : ℝ)‖ = x := by rw [Real.norm_eq_abs, 
 theorem nnnorm_eq (x : ℝ≥0) : ‖(x : ℝ)‖₊ = x :=
   NNReal.eq <| Real.norm_of_nonneg x.2
 
-lemma lipschitzWith_sub : LipschitzWith 2 (fun (p : ℝ≥0 × ℝ≥0) ↦ p.1 - p.2) := by
-  rw [← isometry_subtype_coe.lipschitzWith_iff]
-  have : Isometry (Prod.map ((↑) : ℝ≥0 → ℝ) ((↑) : ℝ≥0 → ℝ)) :=
-    isometry_subtype_coe.prod_map isometry_subtype_coe
-  convert (((LipschitzWith.prod_fst.comp this.lipschitz).sub
-    (LipschitzWith.prod_snd.comp this.lipschitz)).max_const 0)
-  norm_num
-
 end NNReal
 
 @[simp 1001] -- Porting note: increase priority so that the LHS doesn't simplify
@@ -1075,24 +856,6 @@ theorem NormedAddCommGroup.tendsto_atTop' [Nonempty α] [SemilatticeSup α] [NoM
     {β : Type*} [SeminormedAddCommGroup β] {f : α → β} {b : β} :
     Tendsto f atTop (𝓝 b) ↔ ∀ ε, 0 < ε → ∃ N, ∀ n, N < n → ‖f n - b‖ < ε :=
   (atTop_basis_Ioi.tendsto_iff Metric.nhds_basis_ball).trans (by simp [dist_eq_norm])
-
-instance Int.instNormedCommRing : NormedCommRing ℤ where
-  __ := instCommRing
-  __ := instNormedAddCommGroup
-  norm_mul m n := by simp only [norm, Int.cast_mul, abs_mul, le_rfl]
-
-instance Int.instNormOneClass : NormOneClass ℤ :=
-  ⟨by simp [← Int.norm_cast_real]⟩
-
-instance Rat.instNormedField : NormedField ℚ where
-  __ := instField
-  __ := instNormedAddCommGroup
-  norm_mul' a b := by simp only [norm, Rat.cast_mul, abs_mul]
-
-instance Rat.instDenselyNormedField : DenselyNormedField ℚ where
-  lt_norm_lt r₁ r₂ h₀ hr :=
-    let ⟨q, h⟩ := exists_rat_btwn hr
-    ⟨q, by rwa [← Rat.norm_cast_real, Real.norm_eq_abs, abs_of_pos (h₀.trans_lt h.1)]⟩
 
 section RingHomIsometric
 

--- a/Mathlib/Analysis/Normed/Field/InfiniteSum.lean
+++ b/Mathlib/Analysis/Normed/Field/InfiniteSum.lean
@@ -3,7 +3,7 @@ Copyright (c) 2021 Anatole Dedecker. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Anatole Dedecker
 -/
-import Mathlib.Analysis.Normed.Field.Basic
+import Mathlib.Analysis.Normed.Field.Lemmas
 import Mathlib.Analysis.Normed.Group.InfiniteSum
 import Mathlib.Topology.Algebra.InfiniteSum.Real
 

--- a/Mathlib/Analysis/Normed/Field/Lemmas.lean
+++ b/Mathlib/Analysis/Normed/Field/Lemmas.lean
@@ -1,0 +1,335 @@
+/-
+Copyright (c) 2018 Patrick Massot. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Patrick Massot, Johannes Hölzl
+-/
+
+import Mathlib.Algebra.Group.AddChar
+import Mathlib.Algebra.Order.Ring.Finset
+import Mathlib.Analysis.Normed.Field.Basic
+import Mathlib.Analysis.Normed.Group.Bounded
+import Mathlib.Analysis.Normed.Group.Rat
+import Mathlib.Analysis.Normed.Group.Uniform
+import Mathlib.Topology.Instances.NNReal
+import Mathlib.Topology.MetricSpace.DilationEquiv
+
+/-!
+# Normed fields
+
+In this file we continue building the theory of (semi)normed rings and fields.
+-/
+
+-- Guard against import creep.
+assert_not_exists RestrictScalars
+
+variable {α : Type*} {β : Type*} {ι : Type*}
+
+open Filter Bornology
+open scoped Topology NNReal Pointwise
+
+section NonUnitalSeminormedRing
+
+variable [NonUnitalSeminormedRing α]
+
+theorem Filter.Tendsto.zero_mul_isBoundedUnder_le {f g : ι → α} {l : Filter ι}
+    (hf : Tendsto f l (𝓝 0)) (hg : IsBoundedUnder (· ≤ ·) l ((‖·‖) ∘ g)) :
+    Tendsto (fun x => f x * g x) l (𝓝 0) :=
+  hf.op_zero_isBoundedUnder_le hg (· * ·) norm_mul_le
+
+theorem Filter.isBoundedUnder_le_mul_tendsto_zero {f g : ι → α} {l : Filter ι}
+    (hf : IsBoundedUnder (· ≤ ·) l (norm ∘ f)) (hg : Tendsto g l (𝓝 0)) :
+    Tendsto (fun x => f x * g x) l (𝓝 0) :=
+  hg.op_zero_isBoundedUnder_le hf (flip (· * ·)) fun x y =>
+    (norm_mul_le y x).trans_eq (mul_comm _ _)
+
+/-- Non-unital seminormed ring structure on the product of finitely many non-unital seminormed
+rings, using the sup norm. -/
+instance Pi.nonUnitalSeminormedRing {π : ι → Type*} [Fintype ι]
+    [∀ i, NonUnitalSeminormedRing (π i)] : NonUnitalSeminormedRing (∀ i, π i) :=
+  { Pi.seminormedAddCommGroup, Pi.nonUnitalRing with
+    norm_mul := fun x y =>
+      NNReal.coe_mono <|
+        calc
+          (Finset.univ.sup fun i => ‖x i * y i‖₊) ≤
+              Finset.univ.sup ((fun i => ‖x i‖₊) * fun i => ‖y i‖₊) :=
+            Finset.sup_mono_fun fun _ _ => norm_mul_le _ _
+          _ ≤ (Finset.univ.sup fun i => ‖x i‖₊) * Finset.univ.sup fun i => ‖y i‖₊ :=
+            Finset.sup_mul_le_mul_sup_of_nonneg _ (fun _ _ => zero_le _) fun _ _ => zero_le _
+           }
+
+end NonUnitalSeminormedRing
+
+section SeminormedRing
+
+variable [SeminormedRing α]
+
+/-- Seminormed ring structure on the product of finitely many seminormed rings,
+  using the sup norm. -/
+instance Pi.seminormedRing {π : ι → Type*} [Fintype ι] [∀ i, SeminormedRing (π i)] :
+    SeminormedRing (∀ i, π i) :=
+  { Pi.nonUnitalSeminormedRing, Pi.ring with }
+
+end SeminormedRing
+
+section NonUnitalNormedRing
+
+variable [NonUnitalNormedRing α]
+
+/-- Normed ring structure on the product of finitely many non-unital normed rings, using the sup
+norm. -/
+instance Pi.nonUnitalNormedRing {π : ι → Type*} [Fintype ι] [∀ i, NonUnitalNormedRing (π i)] :
+    NonUnitalNormedRing (∀ i, π i) :=
+  { Pi.nonUnitalSeminormedRing, Pi.normedAddCommGroup with }
+
+end NonUnitalNormedRing
+
+section NormedRing
+
+variable [NormedRing α]
+
+/-- Normed ring structure on the product of finitely many normed rings, using the sup norm. -/
+instance Pi.normedRing {π : ι → Type*} [Fintype ι] [∀ i, NormedRing (π i)] :
+    NormedRing (∀ i, π i) :=
+  { Pi.seminormedRing, Pi.normedAddCommGroup with }
+
+end NormedRing
+
+section NonUnitalSeminormedCommRing
+
+variable [NonUnitalSeminormedCommRing α]
+
+/-- Non-unital seminormed commutative ring structure on the product of finitely many non-unital
+seminormed commutative rings, using the sup norm. -/
+instance Pi.nonUnitalSeminormedCommRing {π : ι → Type*} [Fintype ι]
+    [∀ i, NonUnitalSeminormedCommRing (π i)] : NonUnitalSeminormedCommRing (∀ i, π i) :=
+  { Pi.nonUnitalSeminormedRing, Pi.nonUnitalCommRing with }
+
+end NonUnitalSeminormedCommRing
+
+section NonUnitalNormedCommRing
+
+variable [NonUnitalNormedCommRing α]
+
+/-- Normed commutative ring structure on the product of finitely many non-unital normed
+commutative rings, using the sup norm. -/
+instance Pi.nonUnitalNormedCommRing {π : ι → Type*} [Fintype ι]
+    [∀ i, NonUnitalNormedCommRing (π i)] : NonUnitalNormedCommRing (∀ i, π i) :=
+  { Pi.nonUnitalSeminormedCommRing, Pi.normedAddCommGroup with }
+
+end NonUnitalNormedCommRing
+
+section SeminormedCommRing
+
+variable [SeminormedCommRing α]
+
+/-- Seminormed commutative ring structure on the product of finitely many seminormed commutative
+rings, using the sup norm. -/
+instance Pi.seminormedCommRing {π : ι → Type*} [Fintype ι] [∀ i, SeminormedCommRing (π i)] :
+    SeminormedCommRing (∀ i, π i) :=
+  { Pi.nonUnitalSeminormedCommRing, Pi.ring with }
+
+end SeminormedCommRing
+
+section NormedCommRing
+
+variable [NormedCommRing α]
+
+/-- Normed commutative ring structure on the product of finitely many normed commutative rings,
+using the sup norm. -/
+instance Pi.normedCommutativeRing {π : ι → Type*} [Fintype ι] [∀ i, NormedCommRing (π i)] :
+    NormedCommRing (∀ i, π i) :=
+  { Pi.seminormedCommRing, Pi.normedAddCommGroup with }
+
+end NormedCommRing
+
+-- see Note [lower instance priority]
+instance (priority := 100) semi_normed_ring_top_monoid [NonUnitalSeminormedRing α] :
+    ContinuousMul α :=
+  ⟨continuous_iff_continuousAt.2 fun x =>
+      tendsto_iff_norm_sub_tendsto_zero.2 <| by
+        have : ∀ e : α × α,
+            ‖e.1 * e.2 - x.1 * x.2‖ ≤ ‖e.1‖ * ‖e.2 - x.2‖ + ‖e.1 - x.1‖ * ‖x.2‖ := by
+          intro e
+          calc
+            ‖e.1 * e.2 - x.1 * x.2‖ ≤ ‖e.1 * (e.2 - x.2) + (e.1 - x.1) * x.2‖ := by
+              rw [_root_.mul_sub, _root_.sub_mul, sub_add_sub_cancel]
+            -- Porting note: `ENNReal.{mul_sub, sub_mul}` should be protected
+            _ ≤ ‖e.1‖ * ‖e.2 - x.2‖ + ‖e.1 - x.1‖ * ‖x.2‖ :=
+              norm_add_le_of_le (norm_mul_le _ _) (norm_mul_le _ _)
+        refine squeeze_zero (fun e => norm_nonneg _) this ?_
+        convert
+          ((continuous_fst.tendsto x).norm.mul
+                ((continuous_snd.tendsto x).sub tendsto_const_nhds).norm).add
+            (((continuous_fst.tendsto x).sub tendsto_const_nhds).norm.mul _)
+        -- Porting note: `show` used to select a goal to work on
+        rotate_right
+        · show Tendsto _ _ _
+          exact tendsto_const_nhds
+        · simp⟩
+
+-- see Note [lower instance priority]
+/-- A seminormed ring is a topological ring. -/
+instance (priority := 100) semi_normed_top_ring [NonUnitalSeminormedRing α] :
+    TopologicalRing α where
+
+section NormedDivisionRing
+
+variable [NormedDivisionRing α] {a : α}
+
+lemma antilipschitzWith_mul_left {a : α} (ha : a ≠ 0) : AntilipschitzWith (‖a‖₊⁻¹) (a * ·) :=
+  AntilipschitzWith.of_le_mul_dist fun _ _ ↦ by simp [dist_eq_norm, ← _root_.mul_sub, ha]
+
+lemma antilipschitzWith_mul_right {a : α} (ha : a ≠ 0) : AntilipschitzWith (‖a‖₊⁻¹) (· * a) :=
+  AntilipschitzWith.of_le_mul_dist fun _ _ ↦ by
+    simp [dist_eq_norm, ← _root_.sub_mul, ← mul_comm (‖a‖), ha]
+
+/-- Multiplication by a nonzero element `a` on the left
+as a `DilationEquiv` of a normed division ring. -/
+@[simps!]
+def DilationEquiv.mulLeft (a : α) (ha : a ≠ 0) : α ≃ᵈ α where
+  toEquiv := Equiv.mulLeft₀ a ha
+  edist_eq' := ⟨‖a‖₊, nnnorm_ne_zero_iff.2 ha, fun x y ↦ by
+    simp [edist_nndist, nndist_eq_nnnorm, ← mul_sub]⟩
+
+/-- Multiplication by a nonzero element `a` on the right
+as a `DilationEquiv` of a normed division ring. -/
+@[simps!]
+def DilationEquiv.mulRight (a : α) (ha : a ≠ 0) : α ≃ᵈ α where
+  toEquiv := Equiv.mulRight₀ a ha
+  edist_eq' := ⟨‖a‖₊, nnnorm_ne_zero_iff.2 ha, fun x y ↦ by
+    simp [edist_nndist, nndist_eq_nnnorm, ← sub_mul, ← mul_comm (‖a‖₊)]⟩
+
+namespace Filter
+
+@[simp]
+lemma comap_mul_left_cobounded {a : α} (ha : a ≠ 0) :
+    comap (a * ·) (cobounded α) = cobounded α :=
+  Dilation.comap_cobounded (DilationEquiv.mulLeft a ha)
+
+@[simp]
+lemma map_mul_left_cobounded {a : α} (ha : a ≠ 0) :
+    map (a * ·) (cobounded α) = cobounded α :=
+  DilationEquiv.map_cobounded (DilationEquiv.mulLeft a ha)
+
+@[simp]
+lemma comap_mul_right_cobounded {a : α} (ha : a ≠ 0) :
+    comap (· * a) (cobounded α) = cobounded α :=
+  Dilation.comap_cobounded (DilationEquiv.mulRight a ha)
+
+@[simp]
+lemma map_mul_right_cobounded {a : α} (ha : a ≠ 0) :
+    map (· * a) (cobounded α) = cobounded α :=
+  DilationEquiv.map_cobounded (DilationEquiv.mulRight a ha)
+
+/-- Multiplication on the left by a nonzero element of a normed division ring tends to infinity at
+infinity. -/
+theorem tendsto_mul_left_cobounded {a : α} (ha : a ≠ 0) :
+    Tendsto (a * ·) (cobounded α) (cobounded α) :=
+  (map_mul_left_cobounded ha).le
+
+/-- Multiplication on the right by a nonzero element of a normed division ring tends to infinity at
+infinity. -/
+theorem tendsto_mul_right_cobounded {a : α} (ha : a ≠ 0) :
+    Tendsto (· * a) (cobounded α) (cobounded α) :=
+  (map_mul_right_cobounded ha).le
+
+@[simp]
+lemma inv_cobounded₀ : (cobounded α)⁻¹ = 𝓝[≠] 0 := by
+  rw [← comap_norm_atTop, ← Filter.comap_inv, ← comap_norm_nhdsWithin_Ioi_zero,
+    ← inv_atTop₀, ← Filter.comap_inv]
+  simp only [comap_comap, Function.comp_def, norm_inv]
+
+@[simp]
+lemma inv_nhdsWithin_ne_zero : (𝓝[≠] (0 : α))⁻¹ = cobounded α := by
+  rw [← inv_cobounded₀, inv_inv]
+
+lemma tendsto_inv₀_cobounded' : Tendsto Inv.inv (cobounded α) (𝓝[≠] 0) :=
+  inv_cobounded₀.le
+
+theorem tendsto_inv₀_cobounded : Tendsto Inv.inv (cobounded α) (𝓝 0) :=
+  tendsto_inv₀_cobounded'.mono_right inf_le_left
+
+lemma tendsto_inv₀_nhdsWithin_ne_zero : Tendsto Inv.inv (𝓝[≠] 0) (cobounded α) :=
+  inv_nhdsWithin_ne_zero.le
+
+end Filter
+
+-- see Note [lower instance priority]
+instance (priority := 100) NormedDivisionRing.to_hasContinuousInv₀ : HasContinuousInv₀ α := by
+  refine ⟨fun r r0 => tendsto_iff_norm_sub_tendsto_zero.2 ?_⟩
+  have r0' : 0 < ‖r‖ := norm_pos_iff.2 r0
+  rcases exists_between r0' with ⟨ε, ε0, εr⟩
+  have : ∀ᶠ e in 𝓝 r, ‖e⁻¹ - r⁻¹‖ ≤ ‖r - e‖ / ‖r‖ / ε := by
+    filter_upwards [(isOpen_lt continuous_const continuous_norm).eventually_mem εr] with e he
+    have e0 : e ≠ 0 := norm_pos_iff.1 (ε0.trans he)
+    calc
+      ‖e⁻¹ - r⁻¹‖ = ‖r‖⁻¹ * ‖r - e‖ * ‖e‖⁻¹ := by
+        rw [← norm_inv, ← norm_inv, ← norm_mul, ← norm_mul, _root_.mul_sub, _root_.sub_mul,
+          mul_assoc _ e, inv_mul_cancel₀ r0, mul_inv_cancel₀ e0, one_mul, mul_one]
+      -- Porting note: `ENNReal.{mul_sub, sub_mul}` should be `protected`
+      _ = ‖r - e‖ / ‖r‖ / ‖e‖ := by field_simp [mul_comm]
+      _ ≤ ‖r - e‖ / ‖r‖ / ε := by gcongr
+  refine squeeze_zero' (Eventually.of_forall fun _ => norm_nonneg _) this ?_
+  refine (((continuous_const.sub continuous_id).norm.div_const _).div_const _).tendsto' _ _ ?_
+  simp
+
+-- see Note [lower instance priority]
+/-- A normed division ring is a topological division ring. -/
+instance (priority := 100) NormedDivisionRing.to_topologicalDivisionRing :
+    TopologicalDivisionRing α where
+
+protected lemma IsOfFinOrder.norm_eq_one (ha : IsOfFinOrder a) : ‖a‖ = 1 :=
+  ((normHom : α →*₀ ℝ).toMonoidHom.isOfFinOrder ha).eq_one <| norm_nonneg _
+
+example [Monoid β] (φ : β →* α) {x : β} {k : ℕ+} (h : x ^ (k : ℕ) = 1) :
+    ‖φ x‖ = 1 := (φ.isOfFinOrder <| isOfFinOrder_iff_pow_eq_one.2 ⟨_, k.2, h⟩).norm_eq_one
+
+@[simp] lemma AddChar.norm_apply {G : Type*} [AddLeftCancelMonoid G] [Finite G] (ψ : AddChar G α)
+    (x : G) : ‖ψ x‖ = 1 := (ψ.toMonoidHom.isOfFinOrder <| isOfFinOrder_of_finite _).norm_eq_one
+
+end NormedDivisionRing
+
+namespace NormedField
+
+section Densely
+
+variable (α) [DenselyNormedField α]
+
+theorem denseRange_nnnorm : DenseRange (nnnorm : α → ℝ≥0) :=
+  dense_of_exists_between fun _ _ hr =>
+    let ⟨x, h⟩ := exists_lt_nnnorm_lt α hr
+    ⟨‖x‖₊, ⟨x, rfl⟩, h⟩
+
+end Densely
+
+end NormedField
+
+namespace NNReal
+
+lemma lipschitzWith_sub : LipschitzWith 2 (fun (p : ℝ≥0 × ℝ≥0) ↦ p.1 - p.2) := by
+  rw [← isometry_subtype_coe.lipschitzWith_iff]
+  have : Isometry (Prod.map ((↑) : ℝ≥0 → ℝ) ((↑) : ℝ≥0 → ℝ)) :=
+    isometry_subtype_coe.prod_map isometry_subtype_coe
+  convert (((LipschitzWith.prod_fst.comp this.lipschitz).sub
+    (LipschitzWith.prod_snd.comp this.lipschitz)).max_const 0)
+  norm_num
+
+end NNReal
+
+instance Int.instNormedCommRing : NormedCommRing ℤ where
+  __ := instCommRing
+  __ := instNormedAddCommGroup
+  norm_mul m n := by simp only [norm, Int.cast_mul, abs_mul, le_rfl]
+
+instance Int.instNormOneClass : NormOneClass ℤ :=
+  ⟨by simp [← Int.norm_cast_real]⟩
+
+instance Rat.instNormedField : NormedField ℚ where
+  __ := instField
+  __ := instNormedAddCommGroup
+  norm_mul' a b := by simp only [norm, Rat.cast_mul, abs_mul]
+
+instance Rat.instDenselyNormedField : DenselyNormedField ℚ where
+  lt_norm_lt r₁ r₂ h₀ hr :=
+    let ⟨q, h⟩ := exists_rat_btwn hr
+    ⟨q, by rwa [← Rat.norm_cast_real, Real.norm_eq_abs, abs_of_pos (h₀.trans_lt h.1)]⟩

--- a/Mathlib/Analysis/Normed/Field/UnitBall.lean
+++ b/Mathlib/Analysis/Normed/Field/UnitBall.lean
@@ -3,7 +3,7 @@ Copyright (c) 2022 Yury Kudryashov. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Yury Kudryashov, Heather Macbeth
 -/
-import Mathlib.Analysis.Normed.Field.Basic
+import Mathlib.Analysis.Normed.Field.Lemmas
 import Mathlib.Analysis.Normed.Group.BallSphere
 
 /-!

--- a/Mathlib/Analysis/Normed/Module/Basic.lean
+++ b/Mathlib/Analysis/Normed/Module/Basic.lean
@@ -8,7 +8,7 @@ import Mathlib.Algebra.Algebra.Prod
 import Mathlib.Algebra.Algebra.Rat
 import Mathlib.Algebra.Algebra.RestrictScalars
 import Mathlib.Algebra.Module.Rat
-import Mathlib.Analysis.Normed.Field.Basic
+import Mathlib.Analysis.Normed.Field.Lemmas
 import Mathlib.Analysis.Normed.MulAction
 
 /-!

--- a/Mathlib/Analysis/Normed/MulAction.lean
+++ b/Mathlib/Analysis/Normed/MulAction.lean
@@ -3,8 +3,8 @@ Copyright (c) 2023 Eric Wieser. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Eric Wieser
 -/
-import Mathlib.Topology.MetricSpace.Algebra
 import Mathlib.Analysis.Normed.Field.Basic
+import Mathlib.Topology.MetricSpace.Algebra
 
 /-!
 # Lemmas for `BoundedSMul` over normed additive groups

--- a/Mathlib/Analysis/Normed/Operator/ContinuousLinearMap.lean
+++ b/Mathlib/Analysis/Normed/Operator/ContinuousLinearMap.lean
@@ -3,8 +3,9 @@ Copyright (c) 2019 Jan-David Salchow. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Jan-David Salchow, Sébastien Gouëzel, Jean Lo
 -/
-import Mathlib.Topology.Algebra.Module.Basic
+import Mathlib.Analysis.Normed.Group.Uniform
 import Mathlib.Analysis.Normed.MulAction
+import Mathlib.Topology.Algebra.Module.Basic
 
 /-! # Constructions of continuous linear maps between (semi-)normed spaces
 

--- a/Mathlib/Analysis/Normed/Order/Basic.lean
+++ b/Mathlib/Analysis/Normed/Order/Basic.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Anatole Dedecker, Yaël Dillies
 -/
 import Mathlib.Algebra.Order.Group.TypeTags
-import Mathlib.Analysis.Normed.Field.Basic
+import Mathlib.Analysis.Normed.Field.Lemmas
 
 /-!
 # Ordered normed spaces

--- a/Mathlib/Analysis/Normed/Ring/Seminorm.lean
+++ b/Mathlib/Analysis/Normed/Ring/Seminorm.lean
@@ -3,7 +3,7 @@ Copyright (c) 2022 María Inés de Frutos-Fernández. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: María Inés de Frutos-Fernández, Yaël Dillies
 -/
-import Mathlib.Analysis.Normed.Field.Basic
+import Mathlib.Analysis.Normed.Field.Lemmas
 import Mathlib.Analysis.SpecialFunctions.Pow.Real
 
 /-!

--- a/Mathlib/Analysis/NormedSpace/Int.lean
+++ b/Mathlib/Analysis/NormedSpace/Int.lean
@@ -3,7 +3,7 @@ Copyright (c) 2021 Johan Commelin. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johan Commelin
 -/
-import Mathlib.Analysis.Normed.Field.Basic
+import Mathlib.Analysis.Normed.Field.Lemmas
 
 /-!
 # The integers as normed ring

--- a/Mathlib/Analysis/SumOverResidueClass.lean
+++ b/Mathlib/Analysis/SumOverResidueClass.lean
@@ -3,9 +3,9 @@ Copyright (c) 2024 Michael Stoll. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Michael Stoll
 -/
+import Mathlib.Analysis.Normed.Field.Basic
 import Mathlib.Data.ZMod.Basic
 import Mathlib.Topology.Instances.ENNReal
-import Mathlib.Analysis.Normed.Field.Basic
 
 /-!
 # Sums over residue classes

--- a/Mathlib/NumberTheory/LegendreSymbol/GaussEisensteinLemmas.lean
+++ b/Mathlib/NumberTheory/LegendreSymbol/GaussEisensteinLemmas.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Chris Hughes
 -/
 import Mathlib.NumberTheory.LegendreSymbol.Basic
-import Mathlib.Analysis.Normed.Field.Basic
+import Mathlib.Analysis.Normed.Field.Lemmas
 
 /-!
 # Lemmas of Gauss and Eisenstein

--- a/Mathlib/NumberTheory/Ostrowski.lean
+++ b/Mathlib/NumberTheory/Ostrowski.lean
@@ -6,7 +6,7 @@ María Inés de Frutos-Fernández, Sam van Gool, Silvain Rideau-Kikuchi, Amos Tu
 Francesco Veneziano
 -/
 
-import Mathlib.Analysis.Normed.Field.Basic
+import Mathlib.Analysis.Normed.Field.Lemmas
 import Mathlib.Analysis.SpecialFunctions.Log.Base
 import Mathlib.Analysis.SpecialFunctions.Pow.Real
 import Mathlib.Analysis.Normed.Ring.Seminorm

--- a/Mathlib/NumberTheory/Padics/PadicNumbers.lean
+++ b/Mathlib/NumberTheory/Padics/PadicNumbers.lean
@@ -5,7 +5,7 @@ Authors: Robert Y. Lewis
 -/
 import Mathlib.RingTheory.Valuation.Basic
 import Mathlib.NumberTheory.Padics.PadicNorm
-import Mathlib.Analysis.Normed.Field.Basic
+import Mathlib.Analysis.Normed.Field.Lemmas
 import Mathlib.Tactic.Peel
 import Mathlib.Topology.MetricSpace.Ultra.Basic
 

--- a/Mathlib/NumberTheory/Zsqrtd/QuadraticReciprocity.lean
+++ b/Mathlib/NumberTheory/Zsqrtd/QuadraticReciprocity.lean
@@ -5,7 +5,7 @@ Authors: Chris Hughes
 -/
 import Mathlib.NumberTheory.Zsqrtd.GaussianInt
 import Mathlib.NumberTheory.LegendreSymbol.Basic
-import Mathlib.Analysis.Normed.Field.Basic
+import Mathlib.Analysis.Normed.Field.Lemmas
 
 /-!
 # Facts about the gaussian integers relying on quadratic reciprocity.

--- a/Mathlib/Topology/Algebra/Polynomial.lean
+++ b/Mathlib/Topology/Algebra/Polynomial.lean
@@ -6,7 +6,7 @@ Authors: Robert Y. Lewis
 import Mathlib.Algebra.Polynomial.AlgebraMap
 import Mathlib.Algebra.Polynomial.Inductions
 import Mathlib.Algebra.Polynomial.Splits
-import Mathlib.Analysis.Normed.Field.Basic
+import Mathlib.Analysis.Normed.Field.Lemmas
 import Mathlib.RingTheory.Polynomial.Vieta
 
 /-!

--- a/Mathlib/Topology/Algebra/Valued/NormedValued.lean
+++ b/Mathlib/Topology/Algebra/Valued/NormedValued.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: María Inés de Frutos-Fernández
 -/
 import Mathlib.Analysis.Normed.Field.Basic
+import Mathlib.Analysis.Normed.Group.Uniform
 import Mathlib.RingTheory.Valuation.RankOne
 import Mathlib.Topology.Algebra.Valued.ValuationTopology
 

--- a/Mathlib/Topology/Bornology/BoundedOperation.lean
+++ b/Mathlib/Topology/Bornology/BoundedOperation.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Kalle Kytölä
 -/
 import Mathlib.Analysis.Normed.Group.Basic
-import Mathlib.Analysis.Normed.Field.Basic
+import Mathlib.Analysis.Normed.Field.Lemmas
 
 /-!
 # Bounded operations

--- a/Mathlib/Topology/MetricSpace/CauSeqFilter.lean
+++ b/Mathlib/Topology/MetricSpace/CauSeqFilter.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Robert Y. Lewis, Sébastien Gouëzel
 -/
 import Mathlib.Analysis.Normed.Field.Basic
+import Mathlib.Topology.MetricSpace.Cauchy
 
 /-!
 # Completeness in terms of `Cauchy` filters vs `isCauSeq` sequences

--- a/Mathlib/Topology/MetricSpace/Polish.lean
+++ b/Mathlib/Topology/MetricSpace/Polish.lean
@@ -3,11 +3,12 @@ Copyright (c) 2022 Sébastien Gouëzel. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Sébastien Gouëzel
 -/
+import Mathlib.Analysis.Normed.Field.Basic
+import Mathlib.Topology.Instances.Nat
 import Mathlib.Topology.MetricSpace.PiNat
 import Mathlib.Topology.MetricSpace.Isometry
 import Mathlib.Topology.MetricSpace.Gluing
 import Mathlib.Topology.Sets.Opens
-import Mathlib.Analysis.Normed.Field.Basic
 
 /-!
 # Polish spaces


### PR DESCRIPTION
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

I haven't thought much about the exact split, just worked off the necessary imports. Happy to take suggestions.

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
