### PR TITLE
[Merged by Bors] - feat(KrullDimension): height refactor, initial stuff

### DIFF
--- a/Mathlib/Order/KrullDimension.lean
+++ b/Mathlib/Order/KrullDimension.lean
@@ -117,6 +117,9 @@ lemma height_mono : Monotone (α := α) height := by
   intros p hlast _
   apply length_le_height y p (hlast ▸ hxy)
 
+@[gcongr] protected lemma _root_.GCongr.height_le_height (a b : α) (hab : a ≤ b) :
+    height a ≤ height b := height_mono hab
+
 end height
 
 section krullDim

--- a/Mathlib/Order/KrullDimension.lean
+++ b/Mathlib/Order/KrullDimension.lean
@@ -89,7 +89,7 @@ lemma height_le (x : α) (n : ℕ∞) :
     (∀ (p : LTSeries α), p.last = x → p.length ≤ n) → height x ≤ n :=
   (height_le_iff x n).mpr
 
-lemma le_height_of_last_le (x : α) (p : LTSeries α) (hlast : p.last ≤ x) :
+lemma length_le_height (x : α) (p : LTSeries α) (hlast : p.last ≤ x) :
     p.length ≤ height x := by
   by_cases hlen0 : p.length ≠ 0
   · let p' := p.eraseLast.snoc x (by

--- a/Mathlib/Order/KrullDimension.lean
+++ b/Mathlib/Order/KrullDimension.lean
@@ -17,12 +17,12 @@ In case that `α` is empty, then its Krull dimension is defined to be negative i
 length of all series `a₀ < a₁ < ... < aₙ` is unbounded, then its Krull dimension is defined to be
 positive infinity.
 
-For `a : α`, its height (in ℕ∞) is defined to be `sup {n | a₀ < a₁ < ... < aₙ = a}` while its
+For `a : α`, its height (in `ℕ∞`) is defined to be `sup {n | a₀ < a₁ < ... < aₙ = a}` while its
 coheight is defined to be `sup {n | a = a₀ < a₁ < ... < aₙ}` .
 
 ## Main results
 
-* The Krull dimension is the same as that in the dual order (`krullDim_orderDual`).
+* The Krull dimension is the same as that of the dual order (`krullDim_orderDual`).
 
 * The Krull dimension is the supremum of the heights of the elements (`krullDim_eq_iSup_height`).
 
@@ -110,7 +110,7 @@ lemma le_height_of_last_le (x : α) (p : LTSeries α) (hlast : p.last ≤ x) :
   · simp_all
 
 lemma length_le_height_last (p : LTSeries α) : p.length ≤ height p.last :=
-  le_height_of_last_le _ p (le_refl _)
+  le_height_of_last_le _ p le_rfl
 
 lemma height_mono : Monotone (α := α) height := by
   intro x y hxy
@@ -134,7 +134,7 @@ lemma krullDim_nonneg_of_nonempty [Nonempty α] : 0 ≤ krullDim α :=
   le_sSup ⟨⟨0, fun _ ↦ @Nonempty.some α inferInstance, fun f ↦ f.elim0⟩, rfl⟩
 
 /-- A definition of krullDim for nonempty `α` that avoids `WithBot` -/
-lemma krullDim_eq_of_nonempty [Nonempty α] :
+lemma krullDim_eq_iSup_length [Nonempty α] :
     krullDim α = ⨆ (p : LTSeries α), (p.length : ℕ∞) := by
   unfold krullDim
   rw [WithBot.coe_iSup (OrderTop.bddAbove _)]

--- a/Mathlib/Order/KrullDimension.lean
+++ b/Mathlib/Order/KrullDimension.lean
@@ -17,8 +17,8 @@ In case that `α` is empty, then its Krull dimension is defined to be negative i
 length of all series `a₀ < a₁ < ... < aₙ` is unbounded, then its Krull dimension is defined to be
 positive infinity.
 
-For `a : α`, its height (in `ℕ∞`) is defined to be `sup {n | a₀ < a₁ < ... < aₙ = a}` while its
-coheight is defined to be `sup {n | a = a₀ < a₁ < ... < aₙ}` .
+For `a : α`, its height (in `ℕ∞`) is defined to be `sup {n | a₀ < a₁ < ... < aₙ ≤ a}` while its
+coheight is defined to be `sup {n | a ≤ a₀ < a₁ < ... < aₙ}` .
 
 ## Main results
 
@@ -55,10 +55,10 @@ noncomputable def krullDim (α : Type*) [Preorder α] : WithBot ℕ∞ :=
 
 /--
 The **height** of an element `a` in a preorder `α` is the supremum of the rightmost index of all
-relation series of `α` ordered by `<` and ending with `a`.
+relation series of `α` ordered by `<` and ending below or at `a`.
 -/
 noncomputable def height {α : Type*} [Preorder α] (a : α) : ℕ∞ :=
-  ⨆ (p : LTSeries α) (_ : p.last = a), p.length
+  ⨆ (p : LTSeries α) (_ : p.last ≤ a), p.length
 
 /--
 The **coheight** of an element `a` in a preorder `α` is the supremum of the rightmost index of all
@@ -82,11 +82,11 @@ variable [Preorder α] [Preorder β]
 -/
 
 lemma height_le_iff (x : α) (n : ℕ∞) :
-    height x ≤ n ↔ ∀ (p : LTSeries α), p.last = x → p.length ≤ n := by
+    height x ≤ n ↔ ∀ (p : LTSeries α), p.last ≤ x → p.length ≤ n := by
   simp [height, iSup_le_iff]
 
 lemma height_le (x : α) (n : ℕ∞) :
-    (∀ (p : LTSeries α), p.last = x → p.length ≤ n) → height x ≤ n :=
+    (∀ (p : LTSeries α), p.last ≤ x → p.length ≤ n) → height x ≤ n :=
   (height_le_iff x n).mpr
 
 lemma length_le_height (x : α) (p : LTSeries α) (hlast : p.last ≤ x) :
@@ -110,11 +110,8 @@ lemma length_le_height (x : α) (p : LTSeries α) (hlast : p.last ≤ x) :
 lemma length_le_height_last (p : LTSeries α) : p.length ≤ height p.last :=
   length_le_height _ p le_rfl
 
-lemma height_mono : Monotone (α := α) height := by
-  intro x y hxy
-  apply height_le
-  intros p hlast _
-  apply length_le_height y p (hlast ▸ hxy)
+lemma height_mono : Monotone (α := α) height :=
+  fun _ _ hab ↦ biSup_mono (fun _ hla => hla.trans hab)
 
 @[gcongr] protected lemma _root_.GCongr.height_le_height (a b : α) (hab : a ≤ b) :
     height a ≤ height b := height_mono hab

--- a/Mathlib/Order/KrullDimension.lean
+++ b/Mathlib/Order/KrullDimension.lean
@@ -6,8 +6,6 @@ Authors: Jujian Zhang, Fangming Li, Joachim Breitner
 
 import Mathlib.Order.RelSeries
 import Mathlib.Data.ENat.Lattice
-import Mathlib.Topology.Order.Monotone
-import Mathlib.Topology.Instances.ENat
 
 /-!
 # Krull dimension of a preordered set and height of an element

--- a/Mathlib/Order/KrullDimension.lean
+++ b/Mathlib/Order/KrullDimension.lean
@@ -24,20 +24,11 @@ coheight is defined to be `sup {n | a = a₀ < a₁ < ... < aₙ}` .
 
 ## Main results
 
-* The Krull dimension is the same as that in the dual order.
+* The Krull dimension is the same as that in the dual order (`krullDim_orderDual`).
 
-* The Krull dimension is the supremum of the heights of the elements, or their coheights.
+* The Krull dimension is the supremum of the heights of the elements (`krullDim_eq_iSup_height`).
 
-* The height in the dual order equals the coheight, and vice versa.
-
-* The height is monotone, and strictly monone if finite.
-
-* The height is the supremum of the successor of the height of all elements of lower height.
-
-* The elements of height zero are the minimal elements, and the elements of height `n` are minimal
-  among those of height `≥ n`.
-
-* Concrete calculations for the height and Krull dimension in ℕ, ℤ, `WithTop`, `WithBot` and ℕ∞.
+* The height is monotone.
 
 ## Design notes
 

--- a/Mathlib/Order/KrullDimension.lean
+++ b/Mathlib/Order/KrullDimension.lean
@@ -191,7 +191,7 @@ lemma krullDim_eq_iSup_height : krullDim α = ⨆ (a : α), ↑(height a) := by
       intro p
       suffices p.length ≤ ⨆ (a : α), height a by
         exact (WithBot.unbot'_le_iff fun _ => this).mp this
-      apply le_iSup_of_le p.last (length_le_height_last p)
+      apply le_iSup_of_le p.last (length_le_height_last (p := p))
     · rw [krullDim_eq_iSup_length]
       simp only [WithBot.coe_le_coe, iSup_le_iff]
       intro x

--- a/Mathlib/Order/KrullDimension.lean
+++ b/Mathlib/Order/KrullDimension.lean
@@ -104,7 +104,7 @@ lemma length_le_height {p : LTSeries α} {x : α} (hlast : p.last ≤ x) :
     simp [p']
   · simp_all
 
-lemma length_le_height_last (p : LTSeries α) : p.length ≤ height p.last :=
+lemma length_le_height_last {p : LTSeries α} : p.length ≤ height p.last :=
   length_le_height le_rfl
 
 lemma height_mono : Monotone (α := α) height :=

--- a/Mathlib/Order/KrullDimension.lean
+++ b/Mathlib/Order/KrullDimension.lean
@@ -187,9 +187,6 @@ lemma krullDim_eq_of_orderIso (f : α ≃o β) : krullDim α = krullDim β :=
 
 /--
 The Krull dimension is the supremum of the element's heights.
-
-If `α` is `Nonempty`, then `krullDim_eq_iSup_height_of_nonempty`, with the coercion from
-`ℕ∞` to `WithBot ℕ∞` outside the supremum, can be more convenient.
 -/
 lemma krullDim_eq_iSup_height : krullDim α = ⨆ (a : α), (height a : WithBot ℕ∞) := by
   cases isEmpty_or_nonempty α with

--- a/Mathlib/Order/KrullDimension.lean
+++ b/Mathlib/Order/KrullDimension.lean
@@ -1,26 +1,47 @@
 /-
 Copyright (c) 2023 Jujian Zhang. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Jujian Zhang, Fangming Li
+Authors: Jujian Zhang, Fangming Li, Joachim Breitner
 -/
 
 import Mathlib.Order.RelSeries
-import Mathlib.Order.WithBot
-import Mathlib.Data.Nat.Lattice
+import Mathlib.Data.ENat.Lattice
+import Mathlib.Topology.Order.Monotone
+import Mathlib.Topology.Instances.ENat
 
 /-!
-# Krull dimension of a preordered set
+# Krull dimension of a preordered set and height of an element
 
-If `α` is a preordered set, then `krullDim α` is defined to be `sup {n | a₀ < a₁ < ... < aₙ}`.
+If `α` is a preordered set, then `krullDim α : WithBot ℕ∞` is defined to be
+`sup {n | a₀ < a₁ < ... < aₙ}`.
+
 In case that `α` is empty, then its Krull dimension is defined to be negative infinity; if the
-length of all series `a₀ < a₁ < ... < aₙ` is unbounded, then its Krull dimension is defined to
-be positive infinity.
+length of all series `a₀ < a₁ < ... < aₙ` is unbounded, then its Krull dimension is defined to be
+positive infinity.
 
-For `a : α`, its height is defined to be the krull dimension of the subset `(-∞, a]` while its
-coheight is defined to be the krull dimension of `[a, +∞)`.
+For `a : α`, its height (in ℕ∞) is defined to be `sup {n | a₀ < a₁ < ... < aₙ = a}` while its
+coheight is defined to be `sup {n | a = a₀ < a₁ < ... < aₙ}` .
 
-## Implementation notes
-Krull dimensions are defined to take value in `WithBot (WithTop ℕ)` so that `(-∞) + (+∞)` is
+## Main results
+
+* The Krull dimension is the same as that in the dual order.
+
+* The Krull dimension is the supremum of the heights of the elements, or their coheights.
+
+* The height in the dual order equals the coheight, and vice versa.
+
+* The height is monotone, and strictly monone if finite.
+
+* The height is the supremum of the successor of the height of all elements of lower height.
+
+* The elements of height zero are the minimal elements, and the elements of height `n` are minimal
+  among those of height `≥ n`.
+
+* Concrete calculations for the height and Krull dimension in ℕ, ℤ, `WithTop`, `WithBot` and ℕ∞.
+
+## Design notes
+
+Krull dimensions are defined to take value in `WithBot ℕ∞` so that `(-∞) + (+∞)` is
 also negative infinity. This is because we want Krull dimensions to be additive with respect
 to product of varieties so that `-∞` being the Krull dimension of empty variety is equal to
 sum of `-∞` and the Krull dimension of any other varieties.
@@ -30,32 +51,91 @@ in this file would generalize as well. But we don't think it would be useful, so
 Krull dimension of a preorder.
 -/
 
-section definitions
+namespace Order
 
-variable (α : Type*) [Preorder α]
+section definitions
 
 /--
 The **Krull dimension** of a preorder `α` is the supremum of the rightmost index of all relation
-series of `α` order by `<`. If there is no series `a₀ < a₁ < ... < aₙ` in `α`, then its Krull
+series of `α` ordered by `<`. If there is no series `a₀ < a₁ < ... < aₙ` in `α`, then its Krull
 dimension is defined to be negative infinity; if the length of all series `a₀ < a₁ < ... < aₙ` is
 unbounded, its Krull dimension is defined to be positive infinity.
 -/
-noncomputable def krullDim : WithBot (WithTop ℕ) :=
+noncomputable def krullDim (α : Type*) [Preorder α] : WithBot ℕ∞ :=
   ⨆ (p : LTSeries α), p.length
 
 /--
-Height of an element `a` of a preordered set `α` is the Krull dimension of the subset `(-∞, a]`
+The **height** of an element `a` in a preorder `α` is the supremum of the rightmost index of all
+relation series of `α` ordered by `<` and ending with `a`.
 -/
-noncomputable def height (a : α) : WithBot (WithTop ℕ) := krullDim (Set.Iic a)
+noncomputable def height {α : Type*} [Preorder α] (a : α) : ℕ∞ :=
+  ⨆ (p : LTSeries α) (_ : p.last = a), p.length
 
 /--
-Coheight of an element `a` of a pre-ordered set `α` is the Krull dimension of the subset `[a, +∞)`
+The **coheight** of an element `a` in a preorder `α` is the supremum of the rightmost index of all
+relation series of `α` ordered by `<` and beginning with `a`.
+
+The definition of `coheight` is via the `height` in the dual order, in order to easily transfer
+theorems between `height` and `coheight`. See `coheight_eq_isup_head` for the definition with a
+series ordered by `<` and beginning with `a`.
 -/
-noncomputable def coheight (a : α) : WithBot (WithTop ℕ) := krullDim (Set.Ici a)
+noncomputable def coheight {α : Type*} [Preorder α] (a : α) : ℕ∞ := height (α := αᵒᵈ) a
 
 end definitions
 
+section height
+
+variable {α β : Type*}
+
+variable [Preorder α] [Preorder β]
+
+/-!
+## Height
+-/
+
+lemma height_le_iff (x : α) (n : ℕ∞) :
+    height x ≤ n ↔ ∀ (p : LTSeries α), p.last = x → p.length ≤ n := by
+  simp [height, iSup_le_iff]
+
+lemma height_le (x : α) (n : ℕ∞) :
+    (∀ (p : LTSeries α), p.last = x → p.length ≤ n) → height x ≤ n :=
+  (height_le_iff x n).mpr
+
+lemma le_height_of_last_le (x : α) (p : LTSeries α) (hlast : p.last ≤ x) :
+    p.length ≤ height x := by
+  by_cases hlen0 : p.length ≠ 0
+  · let p' := p.eraseLast.snoc x (by
+      apply lt_of_lt_of_le
+      · apply p.step ⟨p.length - 1, by omega⟩
+      · convert hlast
+        simp only [Fin.succ_mk, Nat.succ_eq_add_one, RelSeries.last, Fin.last]
+        congr; omega)
+    suffices p'.length ≤ height x by
+      simp [p'] at this
+      convert this
+      norm_cast
+      omega
+    apply le_iSup_of_le p'
+    apply le_iSup_of_le (by simp [p'])
+    exact le_refl _
+  · simp_all
+
+lemma length_le_height_last (p : LTSeries α) : p.length ≤ height p.last :=
+  le_height_of_last_le _ p (le_refl _)
+
+lemma height_mono : Monotone (α := α) height := by
+  intro x y hxy
+  apply height_le
+  intros p hlast _
+  apply le_height_of_last_le y p (hlast ▸ hxy)
+
+end height
+
 section krullDim
+
+/-!
+## Krull dimension
+-/
 
 variable {α β : Type*}
 
@@ -63,6 +143,13 @@ variable [Preorder α] [Preorder β]
 
 lemma krullDim_nonneg_of_nonempty [Nonempty α] : 0 ≤ krullDim α :=
   le_sSup ⟨⟨0, fun _ ↦ @Nonempty.some α inferInstance, fun f ↦ f.elim0⟩, rfl⟩
+
+/-- A definition of krullDim for nonempty `α` that avoids `WithBot` -/
+lemma krullDim_eq_of_nonempty [Nonempty α] :
+    krullDim α = ⨆ (p : LTSeries α), (p.length : ℕ∞) := by
+  unfold krullDim
+  rw [WithBot.coe_iSup (OrderTop.bddAbove _)]
+  rfl
 
 lemma krullDim_eq_bot_of_isEmpty [IsEmpty α] : krullDim α = ⊥ := WithBot.ciSup_empty _
 
@@ -80,9 +167,6 @@ lemma krullDim_eq_top_of_infiniteDimensionalOrder [InfiniteDimensionalOrder α] 
 
 lemma krullDim_le_of_strictMono (f : α → β) (hf : StrictMono f) : krullDim α ≤ krullDim β :=
   iSup_le <| fun p ↦ le_sSup ⟨p.map f hf, rfl⟩
-
-lemma height_mono {a b : α} (h : a ≤ b) : height α a ≤ height α b :=
-  krullDim_le_of_strictMono (fun x ↦ ⟨x, le_trans x.2 h⟩) <| fun _ _ ↦ id
 
 lemma krullDim_eq_length_of_finiteDimensionalOrder [FiniteDimensionalOrder α] :
     krullDim α = (LTSeries.longestOf α).length :=
@@ -106,15 +190,32 @@ lemma krullDim_eq_of_orderIso (f : α ≃o β) : krullDim α = krullDim β :=
   le_antisymm (krullDim_le_of_strictMono _ f.strictMono) <|
     krullDim_le_of_strictMono _ f.symm.strictMono
 
-lemma krullDim_eq_iSup_height : krullDim α = ⨆ (a : α), height α a :=
-  le_antisymm
-    (iSup_le fun i ↦ le_iSup_of_le (i ⟨i.length, lt_add_one _⟩) <|
-    le_sSup ⟨⟨_, fun m ↦ ⟨i m, i.strictMono.monotone <| show m.1 ≤ i.length by omega⟩,
-      i.step⟩, rfl⟩) <|
-    iSup_le fun a ↦ krullDim_le_of_strictMono Subtype.val fun _ _ h ↦ h
-
 @[simp] lemma krullDim_orderDual : krullDim αᵒᵈ = krullDim α :=
   le_antisymm (iSup_le fun i ↦ le_sSup ⟨i.reverse, rfl⟩) <|
     iSup_le fun i ↦ le_sSup ⟨i.reverse, rfl⟩
 
+/--
+The Krull dimension is the supremum of the element's heights.
+
+If `α` is `Nonempty`, then `krullDim_eq_iSup_height_of_nonempty`, with the coercion from
+`ℕ∞` to `WithBot ℕ∞` outside the supremum, can be more convenient.
+-/
+lemma krullDim_eq_iSup_height : krullDim α = ⨆ (a : α), (height a : WithBot ℕ∞) := by
+  cases isEmpty_or_nonempty α with
+  | inl h => simp [krullDim_eq_bot_of_isEmpty]
+  | inr h =>
+    rw [← WithBot.coe_iSup (OrderTop.bddAbove _)]
+    apply le_antisymm
+    · apply iSup_le
+      intro p
+      suffices p.length ≤ ⨆ (a : α), height a by
+        exact (WithBot.unbot'_le_iff fun _ => this).mp this
+      apply le_iSup_of_le p.last (length_le_height_last p)
+    · rw [krullDim_eq_of_nonempty]
+      simp only [WithBot.coe_le_coe, iSup_le_iff]
+      intro x
+      exact height_le _ _ (fun p _ ↦ le_iSup_of_le p (le_refl _))
+
 end krullDim
+
+end Order

--- a/Mathlib/Order/KrullDimension.lean
+++ b/Mathlib/Order/KrullDimension.lean
@@ -103,9 +103,8 @@ lemma length_le_height (x : α) (p : LTSeries α) (hlast : p.last ≤ x) :
       convert this
       norm_cast
       omega
-    apply le_iSup_of_le p'
-    apply le_iSup_of_le (by simp [p'])
-    exact le_refl _
+    refine le_iSup₂_of_le p' ?_ le_rfl
+    simp [p']
   · simp_all
 
 lemma length_le_height_last (p : LTSeries α) : p.length ≤ height p.last :=

--- a/Mathlib/Order/KrullDimension.lean
+++ b/Mathlib/Order/KrullDimension.lean
@@ -182,7 +182,7 @@ lemma krullDim_eq_of_orderIso (f : α ≃o β) : krullDim α = krullDim β :=
     iSup_le fun i ↦ le_sSup ⟨i.reverse, rfl⟩
 
 /--
-The Krull dimension is the supremum of the element's heights.
+The Krull dimension is the supremum of the elements' heights.
 -/
 lemma krullDim_eq_iSup_height : krullDim α = ⨆ (a : α), ↑(height a) := by
   cases isEmpty_or_nonempty α with

--- a/Mathlib/Order/KrullDimension.lean
+++ b/Mathlib/Order/KrullDimension.lean
@@ -77,19 +77,16 @@ variable {α β : Type*}
 
 variable [Preorder α] [Preorder β]
 
+
 /-!
 ## Height
 -/
 
-lemma height_le_iff (x : α) (n : ℕ∞) :
+lemma height_le {x : α} {n : ℕ∞} :
     height x ≤ n ↔ ∀ (p : LTSeries α), p.last ≤ x → p.length ≤ n := by
   simp [height, iSup_le_iff]
 
-lemma height_le (x : α) (n : ℕ∞) :
-    (∀ (p : LTSeries α), p.last ≤ x → p.length ≤ n) → height x ≤ n :=
-  (height_le_iff x n).mpr
-
-lemma length_le_height (x : α) (p : LTSeries α) (hlast : p.last ≤ x) :
+lemma length_le_height {p : LTSeries α} {x : α} (hlast : p.last ≤ x) :
     p.length ≤ height x := by
   by_cases hlen0 : p.length ≠ 0
   · let p' := p.eraseLast.snoc x (by
@@ -108,7 +105,7 @@ lemma length_le_height (x : α) (p : LTSeries α) (hlast : p.last ≤ x) :
   · simp_all
 
 lemma length_le_height_last (p : LTSeries α) : p.length ≤ height p.last :=
-  length_le_height _ p le_rfl
+  length_le_height le_rfl
 
 lemma height_mono : Monotone (α := α) height :=
   fun _ _ hab ↦ biSup_mono (fun _ hla => hla.trans hab)
@@ -198,7 +195,7 @@ lemma krullDim_eq_iSup_height : krullDim α = ⨆ (a : α), ↑(height a) := by
     · rw [krullDim_eq_iSup_length]
       simp only [WithBot.coe_le_coe, iSup_le_iff]
       intro x
-      exact height_le _ _ (fun p _ ↦ le_iSup_of_le p (le_refl _))
+      exact height_le.mpr fun p _ ↦ le_iSup_of_le p le_rfl
 
 end krullDim
 

--- a/Mathlib/Order/KrullDimension.lean
+++ b/Mathlib/Order/KrullDimension.lean
@@ -187,7 +187,7 @@ lemma krullDim_eq_of_orderIso (f : α ≃o β) : krullDim α = krullDim β :=
 /--
 The Krull dimension is the supremum of the element's heights.
 -/
-lemma krullDim_eq_iSup_height : krullDim α = ⨆ (a : α), (height a : WithBot ℕ∞) := by
+lemma krullDim_eq_iSup_height : krullDim α = ⨆ (a : α), ↑(height a) := by
   cases isEmpty_or_nonempty α with
   | inl h => simp [krullDim_eq_bot_of_isEmpty]
   | inr h =>

--- a/Mathlib/Order/KrullDimension.lean
+++ b/Mathlib/Order/KrullDimension.lean
@@ -65,8 +65,7 @@ The **coheight** of an element `a` in a preorder `α` is the supremum of the rig
 relation series of `α` ordered by `<` and beginning with `a`.
 
 The definition of `coheight` is via the `height` in the dual order, in order to easily transfer
-theorems between `height` and `coheight`. See `coheight_eq_isup_head` for the definition with a
-series ordered by `<` and beginning with `a`.
+theorems between `height` and `coheight`.
 -/
 noncomputable def coheight {α : Type*} [Preorder α] (a : α) : ℕ∞ := height (α := αᵒᵈ) a
 

--- a/Mathlib/Order/KrullDimension.lean
+++ b/Mathlib/Order/KrullDimension.lean
@@ -71,16 +71,15 @@ noncomputable def coheight {α : Type*} [Preorder α] (a : α) : ℕ∞ := heigh
 
 end definitions
 
+/-!
+## Height
+-/
+
 section height
 
 variable {α β : Type*}
 
 variable [Preorder α] [Preorder β]
-
-
-/-!
-## Height
--/
 
 lemma height_le {x : α} {n : ℕ∞} :
     height x ≤ n ↔ ∀ (p : LTSeries α), p.last ≤ x → p.length ≤ n := by
@@ -115,11 +114,11 @@ lemma height_mono : Monotone (α := α) height :=
 
 end height
 
-section krullDim
-
 /-!
 ## Krull dimension
 -/
+
+section krullDim
 
 variable {α β : Type*}
 

--- a/Mathlib/Order/KrullDimension.lean
+++ b/Mathlib/Order/KrullDimension.lean
@@ -109,13 +109,13 @@ lemma length_le_height (x : α) (p : LTSeries α) (hlast : p.last ≤ x) :
   · simp_all
 
 lemma length_le_height_last (p : LTSeries α) : p.length ≤ height p.last :=
-  le_height_of_last_le _ p le_rfl
+  length_le_height _ p le_rfl
 
 lemma height_mono : Monotone (α := α) height := by
   intro x y hxy
   apply height_le
   intros p hlast _
-  apply le_height_of_last_le y p (hlast ▸ hxy)
+  apply length_le_height y p (hlast ▸ hxy)
 
 end height
 
@@ -199,7 +199,7 @@ lemma krullDim_eq_iSup_height : krullDim α = ⨆ (a : α), (height a : WithBot 
       suffices p.length ≤ ⨆ (a : α), height a by
         exact (WithBot.unbot'_le_iff fun _ => this).mp this
       apply le_iSup_of_le p.last (length_le_height_last p)
-    · rw [krullDim_eq_of_nonempty]
+    · rw [krullDim_eq_iSup_length]
       simp only [WithBot.coe_le_coe, iSup_le_iff]
       intro x
       exact height_le _ _ (fun p _ ↦ le_iSup_of_le p (le_refl _))

--- a/Mathlib/Topology/KrullDimension.lean
+++ b/Mathlib/Topology/KrullDimension.lean
@@ -23,5 +23,5 @@ open TopologicalSpace
 The Krull dimension of a topological space is the supremum of lengths of chains of
 closed irreducible sets.
 -/
-noncomputable def topologicalKrullDim (T : Type _) [TopologicalSpace T] : WithBot ℕ∞ :=
+noncomputable def topologicalKrullDim (T : Type*) [TopologicalSpace T] : WithBot ℕ∞ :=
   Order.krullDim (IrreducibleCloseds T)

--- a/Mathlib/Topology/KrullDimension.lean
+++ b/Mathlib/Topology/KrullDimension.lean
@@ -23,6 +23,5 @@ open TopologicalSpace
 The Krull dimension of a topological space is the supremum of lengths of chains of
 closed irreducible sets.
 -/
-noncomputable def topologicalKrullDim (T : Type _) [TopologicalSpace T] :
-    WithBot (WithTop ℕ) :=
-  krullDim (IrreducibleCloseds T)
+noncomputable def topologicalKrullDim (T : Type _) [TopologicalSpace T] : WithBot ℕ∞ :=
+  Order.krullDim (IrreducibleCloseds T)


### PR DESCRIPTION
This refactors and extends the definition of `height`. Notable changes:

 * Everything put into `namespace Order`
 * Type of `krullDim` changed from `WithBot (WithTop Nat)` to `WithBot ENat`.
 * Type of `height` changed from `WithBot (WithTop Nat)` to `ENat`.
 * Definition of `height` via `LTSeries` rather than krullDim

From the Carleson project.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

This PR is a trimmed version of #15524 to include just those steps needed to recreate
the existing API; see #15524 where some of the things are going.

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
