### PR TITLE
[Merged by Bors] - fix: disable the longFile linter in downstream projects

### DIFF
--- a/Mathlib/Tactic/Linter/Lint.lean
+++ b/Mathlib/Tactic/Linter/Lint.lean
@@ -324,7 +324,7 @@ def longFileLinter : Linter where run := withSetOptionIn fun stx ↦ do
   let linterBound := linter.style.longFile.get (← getOptions)
   if linterBound == 0 then
     return
-  let defValue := linter.style.longFile.defValue
+  let defValue := 1500
   let smallOption := match stx with
       | `(set_option linter.style.longFile $x) => TSyntax.getNat ⟨x.raw⟩ ≤ defValue
       | _ => false

--- a/Mathlib/Tactic/Linter/Lint.lean
+++ b/Mathlib/Tactic/Linter/Lint.lean
@@ -308,8 +308,9 @@ The "longFile" linter emits a warning on files which are longer than a certain n
 
 /--
 The "longFile" linter emits a warning on files which are longer than a certain number of lines
-(1500 by default). If this option is set to `N` lines, the linter warns once a file has more than
-`N` lines. A value of `0` silences the linter entirely.
+(1500 by default on mathlib, no limit for downstream projects).
+If this option is set to `N` lines, the linter warns once a file has more than `N` lines.
+A value of `0` silences the linter entirely.
 -/
 register_option linter.style.longFile : Nat := {
   defValue := 0

--- a/Mathlib/Tactic/Linter/Lint.lean
+++ b/Mathlib/Tactic/Linter/Lint.lean
@@ -312,7 +312,7 @@ The "longFile" linter emits a warning on files which are longer than a certain n
 `N` lines. A value of `0` silences the linter entirely.
 -/
 register_option linter.style.longFile : Nat := {
-  defValue := 1500
+  defValue := 0
   descr := "enable the longFile linter"
 }
 

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -28,6 +28,7 @@ abbrev mathlibOnlyLinters : Array LeanOption := #[
   ⟨`linter.cdot, true⟩,
   ⟨`linter.dollarSyntax, true⟩,
   ⟨`linter.style.lambdaSyntax, true⟩,
+  ⟨`linter.style.longFile, .ofNat 1500⟩,
   ⟨`linter.longLine, true⟩,
   ⟨`linter.oldObtain, true,⟩,
   ⟨`linter.refine, true⟩,


### PR DESCRIPTION
[Reported on Zulip](https://leanprover.zulipchat.com/#narrow/stream/287929-mathlib4/topic/long.20file.20linter)

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
