### PR TITLE
perf: investigate mixin TC slowness

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -4738,3 +4738,4 @@ import Mathlib.Util.Tactic
 import Mathlib.Util.TermBeta
 import Mathlib.Util.WhatsNew
 import Mathlib.Util.WithWeakNamespace
+import Mathlib.Util.WithoutInstances

--- a/Mathlib/Algebra/AddTorsor.lean
+++ b/Mathlib/Algebra/AddTorsor.lean
@@ -51,15 +51,15 @@ class AddTorsor (G : outParam Type*) (P : Type*) [outParam (AddGroup G)] extends
   /-- Torsor addition and subtraction with the same element cancels out. -/
   vadd_vsub' : ∀ (g : G) (p : P), g +ᵥ p -ᵥ p = g
 
-instance AddTorsor.instAddAction :
+@[instance] abbrev AddTorsor.instAddAction :
     ∀ {G P} {_ : AddGroup G} [AddTorsor G P], AddAction G P :=
   @AddTorsor.toAddAction
 
-instance AddTorsor.instVSub :
+@[instance] abbrev AddTorsor.instVSub :
     ∀ {G P} {_ : AddGroup G} [AddTorsor G P], VSub G P :=
   @AddTorsor.toVSub
 
-instance (priority := 100) AddTorsor.instNonempty :
+@[instance 100] abbrev AddTorsor.instNonempty :
     ∀ {G P} {_ : AddGroup G} [AddTorsor G P], Nonempty P :=
   @AddTorsor.nonempty
 

--- a/Mathlib/Algebra/AddTorsor.lean
+++ b/Mathlib/Algebra/AddTorsor.lean
@@ -37,12 +37,13 @@ multiplicative group actions).
 
 -/
 
+without_instances
 /-- An `AddTorsor G P` gives a structure to the nonempty type `P`,
 acted on by an `AddGroup G` with a transitive and free action given
 by the `+ᵥ` operation and a corresponding subtraction given by the
 `-ᵥ` operation. In the case of a vector space, it is an affine
 space. -/
-class AddTorsor (G : outParam Type*) (P : Type*) [AddGroup G] extends AddAction G P,
+class AddTorsor (G : outParam Type*) (P : Type*) [outParam (AddGroup G)] extends AddAction G P,
   VSub G P where
   [nonempty : Nonempty P]
   /-- Torsor subtraction and addition with the same element cancels out. -/
@@ -50,8 +51,17 @@ class AddTorsor (G : outParam Type*) (P : Type*) [AddGroup G] extends AddAction 
   /-- Torsor addition and subtraction with the same element cancels out. -/
   vadd_vsub' : ∀ (g : G) (p : P), g +ᵥ p -ᵥ p = g
 
- -- Porting note(#12096): removed `nolint instance_priority`; lint not ported yet
-attribute [instance 100] AddTorsor.nonempty
+instance AddTorsor.instAddAction :
+    ∀ {G P} {_ : AddGroup G} [AddTorsor G P], AddAction G P :=
+  @AddTorsor.toAddAction
+
+instance AddTorsor.instVSub :
+    ∀ {G P} {_ : AddGroup G} [AddTorsor G P], VSub G P :=
+  @AddTorsor.toVSub
+
+instance (priority := 100) AddTorsor.instNonempty :
+    ∀ {G P} {_ : AddGroup G} [AddTorsor G P], Nonempty P :=
+  @AddTorsor.nonempty
 
 -- Porting note(#12094): removed nolint; dangerous_instance linter not ported yet
 --attribute [nolint dangerous_instance] AddTorsor.toVSub

--- a/Mathlib/Algebra/Algebra/Defs.lean
+++ b/Mathlib/Algebra/Algebra/Defs.lean
@@ -104,7 +104,7 @@ class Algebra (R : Type u) (A : Type v) [outParam (CommSemiring R)] [outParam (S
   commutes' : ∀ r x, toRingHom r * x = x * toRingHom r
   smul_def' : ∀ r x, r • x = toRingHom r * x
 
-instance Algebra.instSMul :
+@[instance] abbrev Algebra.instSMul :
     ∀ {R A} {_ : CommSemiring R} {_ : Semiring A} [Algebra R A], SMul R A :=
   @Algebra.toSMul
 

--- a/Mathlib/Algebra/Algebra/Defs.lean
+++ b/Mathlib/Algebra/Algebra/Defs.lean
@@ -93,15 +93,20 @@ section Prio
 
 /- control priority of
 `instance [Algebra R A] : SMul R A` -/
+without_instances
 /-- An associative unital `R`-algebra is a semiring `A` equipped with a map into its center `R → A`.
 
 See the implementation notes in this file for discussion of the details of this definition.
 -/
 -- Porting note(#5171): unsupported @[nolint has_nonempty_instance]
-class Algebra (R : Type u) (A : Type v) [CommSemiring R] [Semiring A] extends SMul R A,
-  R →+* A where
+class Algebra (R : Type u) (A : Type v) [outParam (CommSemiring R)] [outParam (Semiring A)]
+    extends SMul R A, R →+* A where
   commutes' : ∀ r x, toRingHom r * x = x * toRingHom r
   smul_def' : ∀ r x, r • x = toRingHom r * x
+
+instance Algebra.instSMul :
+    ∀ {R A} {_ : CommSemiring R} {_ : Semiring A} [Algebra R A], SMul R A :=
+  @Algebra.toSMul
 
 end Prio
 
@@ -257,7 +262,8 @@ theorem algebra_ext {R : Type*} [CommSemiring R] {A : Type*} [Semiring A] (P Q :
   congr
 
 -- see Note [lower instance priority]
-instance (priority := 200) toModule : Module R A where
+instance (priority := 200) toModule {_ : CommSemiring R} {_ : Semiring A} [Algebra R A] :
+    Module R A where
   one_smul _ := by simp [smul_def']
   mul_smul := by simp [smul_def', mul_assoc]
   smul_add := by simp [smul_def', mul_add]

--- a/Mathlib/Algebra/Algebra/Operations.lean
+++ b/Mathlib/Algebra/Algebra/Operations.lean
@@ -367,8 +367,6 @@ theorem mul_smul_mul_eq_smul_mul_smul (x y : R) : (x * y) • (M * N) = (x • M
     erw [smul_mul_smul_comm x m y n]
     exact smul_mem_pointwise_smul _ _ _ (mul_mem_mul hm hn)
 
---set_option pp.explicit true in
-set_option trace.Meta.synthInstance true in
 /-- Sub-R-modules of an R-algebra form an idempotent semiring. -/
 instance idemSemiring : IdemSemiring (Submodule R A) :=
   { toAddSubmonoid_injective.semigroup _ fun m n : Submodule R A => mul_toAddSubmonoid m n,

--- a/Mathlib/Algebra/Algebra/Operations.lean
+++ b/Mathlib/Algebra/Algebra/Operations.lean
@@ -367,6 +367,8 @@ theorem mul_smul_mul_eq_smul_mul_smul (x y : R) : (x * y) • (M * N) = (x • M
     erw [smul_mul_smul_comm x m y n]
     exact smul_mem_pointwise_smul _ _ _ (mul_mem_mul hm hn)
 
+--set_option pp.explicit true in
+set_option trace.Meta.synthInstance true in
 /-- Sub-R-modules of an R-algebra form an idempotent semiring. -/
 instance idemSemiring : IdemSemiring (Submodule R A) :=
   { toAddSubmonoid_injective.semigroup _ fun m n : Submodule R A => mul_toAddSubmonoid m n,
@@ -379,8 +381,7 @@ instance idemSemiring : IdemSemiring (Submodule R A) :=
     mul_zero := mul_bot
     left_distrib := mul_sup
     right_distrib := sup_mul,
-    -- Porting note: removed `(by infer_instance : OrderBot (Submodule R A))`
-    bot_le := fun _ => bot_le }
+    bot_le := fun _ => @bot_le _ _ (by infer_instance : OrderBot (Submodule R A)) _ }
 
 variable (M)
 

--- a/Mathlib/Algebra/Algebra/Pi.lean
+++ b/Mathlib/Algebra/Algebra/Pi.lean
@@ -33,7 +33,7 @@ variable {f : I → Type v}
 variable (x y : ∀ i, f i) (i : I)
 variable (I f)
 
-instance algebra {r : CommSemiring R} [s : ∀ i, Semiring (f i)] [∀ i, Algebra R (f i)] :
+instance algebra [r : CommSemiring R] [s : ∀ i, Semiring (f i)] [∀ i, Algebra R (f i)] :
     Algebra R (∀ i : I, f i) :=
   { (Pi.ringHom fun i => algebraMap R (f i) : R →+* ∀ i : I, f i) with
     commutes' := fun a f => by ext; simp [Algebra.commutes]

--- a/Mathlib/Algebra/Category/AlgebraCat/Monoidal.lean
+++ b/Mathlib/Algebra/Category/AlgebraCat/Monoidal.lean
@@ -55,6 +55,7 @@ instance : MonoidalCategoryStruct (AlgebraCat.{u} R) where
   leftUnitor X := (Algebra.TensorProduct.lid R X).toAlgebraIso
   rightUnitor X := (Algebra.TensorProduct.rid R R X).toAlgebraIso
 
+set_option maxHeartbeats 400000 in
 theorem forget₂_map_associator_hom (X Y Z : AlgebraCat.{u} R) :
     (forget₂ (AlgebraCat R) (ModuleCat R)).map (α_ X Y Z).hom =
       (α_
@@ -63,6 +64,7 @@ theorem forget₂_map_associator_hom (X Y Z : AlgebraCat.{u} R) :
         (forget₂ _ (ModuleCat R) |>.obj Z)).hom := by
   rfl
 
+set_option maxHeartbeats 400000 in
 theorem forget₂_map_associator_inv (X Y Z : AlgebraCat.{u} R) :
     (forget₂ (AlgebraCat R) (ModuleCat R)).map (α_ X Y Z).inv =
       (α_
@@ -71,7 +73,7 @@ theorem forget₂_map_associator_inv (X Y Z : AlgebraCat.{u} R) :
         (forget₂ _ (ModuleCat R) |>.obj Z)).inv := by
   rfl
 
-set_option maxHeartbeats 800000 in
+set_option maxHeartbeats 1600000 in
 noncomputable instance instMonoidalCategory : MonoidalCategory (AlgebraCat.{u} R) :=
   Monoidal.induced
     (forget₂ (AlgebraCat R) (ModuleCat R))

--- a/Mathlib/Algebra/Category/ModuleCat/ChangeOfRings.lean
+++ b/Mathlib/Algebra/Category/ModuleCat/ChangeOfRings.lean
@@ -474,6 +474,7 @@ def HomEquiv.fromRestriction {X : ModuleCat R} {Y : ModuleCat S}
       dsimp
       rw [mul_smul]
 
+set_option maxHeartbeats 400000 in
 /-- Given `R`-module X and `S`-module Y, any `g : Y ⟶ (coextendScalars f).obj X`
 corresponds to `(restrictScalars f).obj Y ⟶ X` by `y ↦ g y 1`
 -/
@@ -492,6 +493,7 @@ def HomEquiv.toRestriction {X Y} (g : Y ⟶ (coextendScalars f).obj X) :
     simp
 
 -- Porting note: add to address timeout in unit'
+set_option maxHeartbeats 400000 in
 /-- Auxiliary definition for `unit'` -/
 def app' (Y : ModuleCat S) : Y →ₗ[S] (restrictScalars f ⋙ coextendScalars f).obj Y :=
   { toFun := fun y : Y =>
@@ -536,6 +538,7 @@ protected def unit' : 𝟭 (ModuleCat S) ⟶ restrictScalars f ⋙ coextendScala
       change s • (g y) = g (s • y)
       rw [map_smul]
 
+set_option maxHeartbeats 800000 in
 /-- The natural transformation from the composition of coextension and restriction of scalars to
 identity functor.
 -/
@@ -544,10 +547,12 @@ protected def counit' : coextendScalars f ⋙ restrictScalars f ⟶ 𝟭 (Module
   app X :=
     { toFun := fun g => g.toFun (1 : S)
       map_add' := fun x1 x2 => by
-        dsimp
+        dsimp only [Functor.id_obj, Functor.comp_obj, AddHom.toFun_eq_coe, LinearMap.coe_toAddHom]
         rw [LinearMap.add_apply]
       map_smul' := fun r (g : (restrictScalars f).obj ((coextendScalars f).obj X)) => by
-        dsimp
+        dsimp only [Functor.id_obj, Functor.comp_obj, AddHom.toFun_eq_coe, LinearMap.coe_toAddHom,
+          LinearMap.add_apply, id_eq, eq_mpr_eq_cast, cast_eq, restrictScalars.smul_def,
+          AddHom.coe_mk, RingHom.id_apply]
         rw [← LinearMap.coe_toAddHom, ← AddHom.toFun_eq_coe]
         rw [CoextendScalars.smul_apply (s := f r) (g := g) (s' := 1), one_mul, ← LinearMap.map_smul]
         rw [← LinearMap.coe_toAddHom, ← AddHom.toFun_eq_coe]
@@ -618,7 +623,7 @@ def HomEquiv.toRestrictScalars {X Y} (g : (extendScalars f).obj X ⟶ Y) :
   map_smul' r x := by
     letI : Module R S := Module.compHom S f
     letI : Module R Y := Module.compHom Y f
-    dsimp
+    dsimp only
     erw [RestrictScalars.smul_def, ← LinearMap.map_smul, tmul_smul]
     congr
 
@@ -674,6 +679,7 @@ def HomEquiv.fromExtendScalars {X Y} (g : X ⟶ (restrictScalars f).obj Y) :
       rw [mul_smul]
     | add _ _ ih1 ih2 => rw [smul_add, map_add, ih1, ih2, map_add, smul_add]
 
+set_option maxHeartbeats 800000 in
 /-- Given `R`-module X and `S`-module Y, `S`-linear linear maps `(extendScalars f).obj X ⟶ Y`
 bijectively correspond to `R`-linear maps `X ⟶ (restrictScalars f).obj Y`.
 -/
@@ -792,6 +798,7 @@ def counit : restrictScalars.{max v u₂,u₁,u₂} f ⋙ extendScalars f ⟶ �
     | add _ _ ih₁ ih₂ => rw [map_add, map_add]; congr 1
 end ExtendRestrictScalarsAdj
 
+set_option maxHeartbeats 400000 in
 /-- Given commutative rings `R, S` and a ring hom `f : R →+* S`, the extension and restriction of
 scalars by `f` are adjoint to each other.
 -/

--- a/Mathlib/Algebra/Category/ModuleCat/ChangeOfRings.lean
+++ b/Mathlib/Algebra/Category/ModuleCat/ChangeOfRings.lean
@@ -646,6 +646,8 @@ def HomEquiv.evalAt {X : ModuleCat R} {Y : ModuleCat S} (s : S)
       rw [AddHom.toFun_eq_coe, AddHom.coe_mk, RingHom.id_apply,
         LinearMap.map_smul, smul_comm r s (g x : Y)] )
 
+attribute [nolint simpNF] HomEquiv.evalAt_apply
+
 /--
 Given `R`-module X and `S`-module Y and a map `X ⟶ (restrictScalars f).obj Y`, i.e `R`-linear map
 `X ⟶ Y`, there is a map `(extend_scalars f).obj X ⟶ Y`, i.e `S`-linear map `S ⨂ X → Y` by

--- a/Mathlib/Algebra/Category/ModuleCat/Presheaf.lean
+++ b/Mathlib/Algebra/Category/ModuleCat/Presheaf.lean
@@ -506,6 +506,7 @@ When `X` is initial, we have `Module (R.obj X) (M.obj c)` for any `c : Cᵒᵖ`.
 
 -/
 
+set_option maxHeartbeats 400000 in
 /--
 Implementation of the functor `PresheafOfModules R ⥤ Cᵒᵖ ⥤ ModuleCat (R.obj X)`
 when `X` is initial.

--- a/Mathlib/Algebra/Category/ModuleCat/Presheaf/Limits.lean
+++ b/Mathlib/Algebra/Category/ModuleCat/Presheaf/Limits.lean
@@ -55,6 +55,7 @@ instance {X Y : Cᵒᵖ} (f : X ⟶ Y) :
   change HasLimit ((F ⋙ evaluation R Y) ⋙ ModuleCat.restrictScalars (R.map f))
   infer_instance
 
+set_option maxHeartbeats 400000 in
 set_option backward.isDefEq.lazyWhnfCore false in -- See https://github.com/leanprover-community/mathlib4/issues/12534
 /-- Given `F : J ⥤ PresheafOfModules.{v} R`, this is the `BundledCorePresheafOfModules R` which
 corresponds to the presheaf of modules which sends `X` to the limit of `F ⋙ evaluation R X`. -/

--- a/Mathlib/Algebra/Group/Action/Defs.lean
+++ b/Mathlib/Algebra/Group/Action/Defs.lean
@@ -7,6 +7,7 @@ import Mathlib.Algebra.Group.Commute.Defs
 import Mathlib.Algebra.Group.TypeTags
 import Mathlib.Algebra.Opposites
 import Mathlib.Logic.Embedding.Basic
+import Mathlib.Util.WithoutInstances
 
 /-!
 # Definitions of group actions
@@ -83,20 +84,27 @@ lemma smul_eq_mul (α : Type*) [Mul α] {a a' : α} : a • a' = a * a' := rfl
 instance RightCancelMonoid.faithfulSMul [RightCancelMonoid α] : FaithfulSMul α α :=
   ⟨fun h ↦ mul_right_cancel (h 1)⟩
 
+without_instances
 /-- Type class for additive monoid actions. -/
-class AddAction (G : Type*) (P : Type*) [AddMonoid G] extends VAdd G P where
+class AddAction (G : Type*) (P : Type*) [outParam (AddMonoid G)] extends VAdd G P where
   /-- Zero is a neutral element for `+ᵥ` -/
   protected zero_vadd : ∀ p : P, (0 : G) +ᵥ p = p
   /-- Associativity of `+` and `+ᵥ` -/
   add_vadd : ∀ (g₁ g₂ : G) (p : P), g₁ + g₂ +ᵥ p = g₁ +ᵥ (g₂ +ᵥ p)
 
+without_instances
 /-- Typeclass for multiplicative actions by monoids. This generalizes group actions. -/
 @[to_additive (attr := ext)]
-class MulAction (α : Type*) (β : Type*) [Monoid α] extends SMul α β where
+class MulAction (α : Type*) (β : Type*) [outParam (Monoid α)] extends SMul α β where
   /-- One is the neutral element for `•` -/
   protected one_smul : ∀ b : β, (1 : α) • b = b
   /-- Associativity of `•` and `*` -/
   mul_smul : ∀ (x y : α) (b : β), (x * y) • b = x • y • b
+
+@[to_additive]
+instance MulAction.instSMul :
+    ∀ {α β} {_ : Monoid α} [MulAction α β], SMul α β :=
+  @MulAction.toSMul
 
 /-!
 ### (Pre)transitive action

--- a/Mathlib/Algebra/Group/Action/Defs.lean
+++ b/Mathlib/Algebra/Group/Action/Defs.lean
@@ -101,8 +101,8 @@ class MulAction (α : Type*) (β : Type*) [outParam (Monoid α)] extends SMul α
   /-- Associativity of `•` and `*` -/
   mul_smul : ∀ (x y : α) (b : β), (x * y) • b = x • y • b
 
-@[to_additive]
-instance MulAction.instSMul :
+@[to_additive (attr := instance)]
+abbrev MulAction.instSMul :
     ∀ {α β} {_ : Monoid α} [MulAction α β], SMul α β :=
   @MulAction.toSMul
 

--- a/Mathlib/Algebra/GroupWithZero/Action/Defs.lean
+++ b/Mathlib/Algebra/GroupWithZero/Action/Defs.lean
@@ -87,10 +87,15 @@ lemma Commute.smul_left_iff₀ [Mul β] [SMulCommClass α β β] [IsScalarTower 
 
 end GroupWithZero
 
+without_instances
 /-- Typeclass for scalar multiplication that preserves `0` on the right. -/
-class SMulZeroClass (M A : Type*) [Zero A] extends SMul M A where
+class SMulZeroClass (M A : Type*) [outParam (Zero A)] extends SMul M A where
   /-- Multiplying `0` by a scalar gives `0` -/
   smul_zero : ∀ a : M, a • (0 : A) = 0
+
+instance SMulZeroClass.instSMul :
+    ∀ {M A} {_ : Zero A} [SMulZeroClass M A], SMul M A :=
+  @SMulZeroClass.toSMul
 
 section smul_zero
 
@@ -151,14 +156,19 @@ def SMulZeroClass.toZeroHom (x : M) :
 
 end smul_zero
 
+without_instances
 /-- Typeclass for scalar multiplication that preserves `0` and `+` on the right.
 
 This is exactly `DistribMulAction` without the `MulAction` part.
 -/
 @[ext]
-class DistribSMul (M A : Type*) [AddZeroClass A] extends SMulZeroClass M A where
+class DistribSMul (M A : Type*) [outParam (AddZeroClass A)] extends SMulZeroClass M A where
   /-- Scalar multiplication distributes across addition -/
   smul_add : ∀ (a : M) (x y : A), a • (x + y) = a • x + a • y
+
+instance DistribSMul.instSMulZeroClass :
+    ∀ {M A} {_ : AddZeroClass A} [DistribSMul M A], SMulZeroClass M A :=
+  @DistribSMul.toSMulZeroClass
 
 section DistribSMul
 
@@ -218,20 +228,27 @@ def DistribSMul.toAddMonoidHom (x : M) : A →+ A :=
 
 end DistribSMul
 
+without_instances
 /-- Typeclass for multiplicative actions on additive structures. This generalizes group modules. -/
 @[ext]
-class DistribMulAction (M A : Type*) [Monoid M] [AddMonoid A] extends MulAction M A where
+class DistribMulAction (M A : Type*) [outParam (Monoid M)] [outParam (AddMonoid A)] extends
+    MulAction M A where
   /-- Multiplying `0` by a scalar gives `0` -/
   smul_zero : ∀ a : M, a • (0 : A) = 0
   /-- Scalar multiplication distributes across addition -/
   smul_add : ∀ (a : M) (x y : A), a • (x + y) = a • x + a • y
+
+instance DistribMulAction.instMulAction :
+    ∀ {M A} {_ : Monoid M} {_ : AddMonoid A} [DistribMulAction M A], MulAction M A :=
+  @DistribMulAction.toMulAction
 
 section
 
 variable [Monoid M] [AddMonoid A] [DistribMulAction M A]
 
 -- See note [lower instance priority]
-instance (priority := 100) DistribMulAction.toDistribSMul : DistribSMul M A :=
+instance (priority := 100) DistribMulAction.toDistribSMul
+    {_ : Monoid M} {_ : AddMonoid A} [DistribMulAction M A] : DistribSMul M A :=
   { ‹DistribMulAction M A› with }
 
 -- Porting note: this probably is no longer relevant.
@@ -318,15 +335,20 @@ theorem smul_sub (r : M) (x y : A) : r • (x - y) = r • x - r • y := by
 
 end
 
+without_instances
 /-- Typeclass for multiplicative actions on multiplicative structures. This generalizes
 conjugation actions. -/
 @[ext]
-class MulDistribMulAction (M : Type*) (A : Type*) [Monoid M] [Monoid A] extends
-  MulAction M A where
+class MulDistribMulAction (M : Type*) (A : Type*) [outParam (Monoid M)] [outParam (Monoid A)]
+    extends MulAction M A where
   /-- Distributivity of `•` across `*` -/
   smul_mul : ∀ (r : M) (x y : A), r • (x * y) = r • x * r • y
   /-- Multiplying `1` by a scalar gives `1` -/
   smul_one : ∀ r : M, r • (1 : A) = 1
+
+instance MulDistribMulAction.instMulAction :
+    ∀ {M A} {_ : Monoid M} {_ : Monoid A} [MulDistribMulAction M A], MulAction M A :=
+  @MulDistribMulAction.toMulAction
 
 export MulDistribMulAction (smul_one)
 

--- a/Mathlib/Algebra/GroupWithZero/Action/Defs.lean
+++ b/Mathlib/Algebra/GroupWithZero/Action/Defs.lean
@@ -93,7 +93,7 @@ class SMulZeroClass (M A : Type*) [outParam (Zero A)] extends SMul M A where
   /-- Multiplying `0` by a scalar gives `0` -/
   smul_zero : ∀ a : M, a • (0 : A) = 0
 
-instance SMulZeroClass.instSMul :
+@[instance] abbrev SMulZeroClass.instSMul :
     ∀ {M A} {_ : Zero A} [SMulZeroClass M A], SMul M A :=
   @SMulZeroClass.toSMul
 
@@ -166,7 +166,7 @@ class DistribSMul (M A : Type*) [outParam (AddZeroClass A)] extends SMulZeroClas
   /-- Scalar multiplication distributes across addition -/
   smul_add : ∀ (a : M) (x y : A), a • (x + y) = a • x + a • y
 
-instance DistribSMul.instSMulZeroClass :
+@[instance] abbrev DistribSMul.instSMulZeroClass :
     ∀ {M A} {_ : AddZeroClass A} [DistribSMul M A], SMulZeroClass M A :=
   @DistribSMul.toSMulZeroClass
 
@@ -238,7 +238,7 @@ class DistribMulAction (M A : Type*) [outParam (Monoid M)] [outParam (AddMonoid 
   /-- Scalar multiplication distributes across addition -/
   smul_add : ∀ (a : M) (x y : A), a • (x + y) = a • x + a • y
 
-instance DistribMulAction.instMulAction :
+@[instance] abbrev DistribMulAction.instMulAction :
     ∀ {M A} {_ : Monoid M} {_ : AddMonoid A} [DistribMulAction M A], MulAction M A :=
   @DistribMulAction.toMulAction
 
@@ -346,7 +346,7 @@ class MulDistribMulAction (M : Type*) (A : Type*) [outParam (Monoid M)] [outPara
   /-- Multiplying `1` by a scalar gives `1` -/
   smul_one : ∀ r : M, r • (1 : A) = 1
 
-instance MulDistribMulAction.instMulAction :
+@[instance] abbrev MulDistribMulAction.instMulAction :
     ∀ {M A} {_ : Monoid M} {_ : Monoid A} [MulDistribMulAction M A], MulAction M A :=
   @MulDistribMulAction.toMulAction
 

--- a/Mathlib/Algebra/Module/Defs.lean
+++ b/Mathlib/Algebra/Module/Defs.lean
@@ -48,18 +48,23 @@ universe u v
 
 variable {α R k S M M₂ M₃ ι : Type*}
 
+without_instances
 /-- A module is a generalization of vector spaces to a scalar semiring.
   It consists of a scalar semiring `R` and an additive monoid of "vectors" `M`,
   connected by a "scalar multiplication" operation `r • x : M`
   (where `r : R` and `x : M`) with some natural associativity and
   distributivity axioms similar to those on a ring. -/
 @[ext]
-class Module (R : Type u) (M : Type v) [Semiring R] [AddCommMonoid M] extends
+class Module (R : Type u) (M : Type v) [outParam (Semiring R)] [outParam (AddCommMonoid M)] extends
   DistribMulAction R M where
   /-- Scalar multiplication distributes over addition from the right. -/
   protected add_smul : ∀ (r s : R) (x : M), (r + s) • x = r • x + s • x
   /-- Scalar multiplication by zero gives zero. -/
   protected zero_smul : ∀ x : M, (0 : R) • x = 0
+
+instance Module.instDistribMulAction :
+    ∀ {R M} {_ : Semiring R} {_ : AddCommMonoid M} [Module R M], DistribMulAction R M :=
+  @Module.toDistribMulAction
 
 section AddCommMonoid
 
@@ -67,7 +72,8 @@ variable [Semiring R] [AddCommMonoid M] [Module R M] (r s : R) (x y : M)
 
 -- see Note [lower instance priority]
 /-- A module over a semiring automatically inherits a `MulActionWithZero` structure. -/
-instance (priority := 100) Module.toMulActionWithZero : MulActionWithZero R M :=
+instance (priority := 100) Module.toMulActionWithZero
+    {_ : Semiring R} {_ : AddCommMonoid M} [Module R M] : MulActionWithZero R M :=
   { (inferInstance : MulAction R M) with
     smul_zero := smul_zero
     zero_smul := Module.zero_smul }

--- a/Mathlib/Algebra/Module/Defs.lean
+++ b/Mathlib/Algebra/Module/Defs.lean
@@ -62,7 +62,7 @@ class Module (R : Type u) (M : Type v) [outParam (Semiring R)] [outParam (AddCom
   /-- Scalar multiplication by zero gives zero. -/
   protected zero_smul : ∀ x : M, (0 : R) • x = 0
 
-instance Module.instDistribMulAction :
+@[instance] abbrev Module.instDistribMulAction :
     ∀ {R M} {_ : Semiring R} {_ : AddCommMonoid M} [Module R M], DistribMulAction R M :=
   @Module.toDistribMulAction
 

--- a/Mathlib/Algebra/Module/Pi.lean
+++ b/Mathlib/Algebra/Module/Pi.lean
@@ -53,7 +53,7 @@ instance mulActionWithZero' {g : I → Type*} [∀ i, MonoidWithZero (g i)] [∀
 
 variable (I f)
 
-instance module (α) {r : Semiring α} {m : ∀ i, AddCommMonoid <| f i} [∀ i, Module α <| f i] :
+instance module (α) [r : Semiring α] [m : ∀ i, AddCommMonoid <| f i] [∀ i, Module α <| f i] :
     @Module α (∀ i : I, f i) r (@Pi.addCommMonoid I f m) :=
   { Pi.distribMulAction _ with
     add_smul := fun _ _ _ => funext fun _ => add_smul _ _ _

--- a/Mathlib/Algebra/Ring/Action/Basic.lean
+++ b/Mathlib/Algebra/Ring/Action/Basic.lean
@@ -41,7 +41,7 @@ class MulSemiringAction (M : Type u) (R : Type v) [outParam (Monoid M)] [outPara
   /-- Scalar multiplication distributes across multiplication -/
   smul_mul : ∀ (g : M) (x y : R), g • (x * y) = g • x * g • y
 
-instance MulSemiringAction.instDistribMulAction :
+@[instance] abbrev MulSemiringAction.instDistribMulAction :
     ∀ {M R} {_ : Monoid M} {_ : Semiring R} [MulSemiringAction M R], DistribMulAction M R :=
   @MulSemiringAction.toDistribMulAction
 

--- a/Mathlib/Algebra/Ring/Action/Basic.lean
+++ b/Mathlib/Algebra/Ring/Action/Basic.lean
@@ -30,15 +30,20 @@ assert_not_exists Prod.fst_mul
 
 universe u v
 
+without_instances
 /-- Typeclass for multiplicative actions by monoids on semirings.
 
 This combines `DistribMulAction` with `MulDistribMulAction`. -/
-class MulSemiringAction (M : Type u) (R : Type v) [Monoid M] [Semiring R] extends
-  DistribMulAction M R where
+class MulSemiringAction (M : Type u) (R : Type v) [outParam (Monoid M)] [outParam (Semiring R)]
+    extends DistribMulAction M R where
   /-- Multipliying `1` by a scalar gives `1` -/
   smul_one : ∀ g : M, (g • (1 : R) : R) = 1
   /-- Scalar multiplication distributes across multiplication -/
   smul_mul : ∀ (g : M) (x y : R), g • (x * y) = g • x * g • y
+
+instance MulSemiringAction.instDistribMulAction :
+    ∀ {M R} {_ : Monoid M} {_ : Semiring R} [MulSemiringAction M R], DistribMulAction M R :=
+  @MulSemiringAction.toDistribMulAction
 
 section Semiring
 
@@ -46,7 +51,8 @@ variable (M N G : Type*) [Monoid M] [Monoid N] [Group G]
 variable (A R S F : Type v) [AddMonoid A] [Semiring R] [CommSemiring S]
 
 -- note we could not use `extends` since these typeclasses are made with `old_structure_cmd`
-instance (priority := 100) MulSemiringAction.toMulDistribMulAction [h : MulSemiringAction M R] :
+instance (priority := 100) MulSemiringAction.toMulDistribMulAction
+    {_ : Monoid M} {_ : Semiring R} [h : MulSemiringAction M R] :
     MulDistribMulAction M R :=
   { h with }
 

--- a/Mathlib/Algebra/Ring/Defs.lean
+++ b/Mathlib/Algebra/Ring/Defs.lean
@@ -426,10 +426,10 @@ This is implemented as a mixin for `Semiring α`.
 To obtain an integral domain use `[CommRing α] [IsDomain α]`. -/
 class IsDomain (α : Type u) [outParam (Semiring α)] extends IsCancelMulZero α, Nontrivial α : Prop
 
-instance IsDomain.instIsCancelMulZero :
+@[instance] abbrev IsDomain.instIsCancelMulZero :
     ∀ {α} {_ : Semiring α} [IsDomain α], IsCancelMulZero α :=
   @IsDomain.toIsCancelMulZero
 
-instance IsDomain.instNontrivial :
+@[instance] abbrev IsDomain.instNontrivial :
     ∀ {α} {_ : Semiring α} [IsDomain α], Nontrivial α :=
   @IsDomain.toNontrivial

--- a/Mathlib/Algebra/Ring/Defs.lean
+++ b/Mathlib/Algebra/Ring/Defs.lean
@@ -8,6 +8,7 @@ import Mathlib.Algebra.GroupWithZero.Defs
 import Mathlib.Data.Int.Cast.Defs
 import Mathlib.Tactic.Spread
 import Mathlib.Util.AssertExists
+import Mathlib.Util.WithoutInstances
 
 /-!
 # Semirings and rings
@@ -415,6 +416,7 @@ instance (priority := 100) CommRing.toAddCommGroupWithOne [s : CommRing α] :
     AddCommGroupWithOne α :=
   { s with }
 
+without_instances
 /-- A domain is a nontrivial semiring such that multiplication by a non zero element
 is cancellative on both sides. In other words, a nontrivial semiring `R` satisfying
 `∀ {a b c : R}, a ≠ 0 → a * b = a * c → b = c` and
@@ -422,4 +424,12 @@ is cancellative on both sides. In other words, a nontrivial semiring `R` satisfy
 
 This is implemented as a mixin for `Semiring α`.
 To obtain an integral domain use `[CommRing α] [IsDomain α]`. -/
-class IsDomain (α : Type u) [Semiring α] extends IsCancelMulZero α, Nontrivial α : Prop
+class IsDomain (α : Type u) [outParam (Semiring α)] extends IsCancelMulZero α, Nontrivial α : Prop
+
+instance IsDomain.instIsCancelMulZero :
+    ∀ {α} {_ : Semiring α} [IsDomain α], IsCancelMulZero α :=
+  @IsDomain.toIsCancelMulZero
+
+instance IsDomain.instNontrivial :
+    ∀ {α} {_ : Semiring α} [IsDomain α], Nontrivial α :=
+  @IsDomain.toNontrivial

--- a/Mathlib/Algebra/SMulWithZero.lean
+++ b/Mathlib/Algebra/SMulWithZero.lean
@@ -42,12 +42,17 @@ section Zero
 
 variable (R M)
 
+without_instances
 /-- `SMulWithZero` is a class consisting of a Type `R` with `0 ∈ R` and a scalar multiplication
 of `R` on a Type `M` with `0`, such that the equality `r • m = 0` holds if at least one among `r`
 or `m` equals `0`. -/
-class SMulWithZero [Zero R] [Zero M] extends SMulZeroClass R M where
+class SMulWithZero [outParam (Zero R)] [outParam (Zero M)] extends SMulZeroClass R M where
   /-- Scalar multiplication by the scalar `0` is `0`. -/
   zero_smul : ∀ m : M, (0 : R) • m = 0
+
+instance SMulWithZero.instSMulZeroClass :
+    ∀ {R M} {_ : Zero R} {_ : Zero M} [SMulWithZero R M], SMulZeroClass R M :=
+  @SMulWithZero.toSMulZeroClass
 
 instance MulZeroClass.toSMulWithZero [MulZeroClass R] : SMulWithZero R R where
   smul := (· * ·)
@@ -116,18 +121,25 @@ section MonoidWithZero
 variable [MonoidWithZero R] [MonoidWithZero R'] [Zero M]
 variable (R M)
 
+without_instances
 /-- An action of a monoid with zero `R` on a Type `M`, also with `0`, extends `MulAction` and
 is compatible with `0` (both in `R` and in `M`), with `1 ∈ R`, and with associativity of
 multiplication on the monoid `M`. -/
-class MulActionWithZero extends MulAction R M where
+class MulActionWithZero [outParam (MonoidWithZero R)] [outParam (Zero M)] extends
+    MulAction R M where
   -- these fields are copied from `SMulWithZero`, as `extends` behaves poorly
   /-- Scalar multiplication by any element send `0` to `0`. -/
   smul_zero : ∀ r : R, r • (0 : M) = 0
   /-- Scalar multiplication by the scalar `0` is `0`. -/
   zero_smul : ∀ m : M, (0 : R) • m = 0
 
+instance MulActionWithZero.instMulAction :
+    ∀ {R M} {_ : MonoidWithZero R} {_ : Zero M} [MulActionWithZero R M], MulAction R M :=
+  @MulActionWithZero.toMulAction
+
 -- see Note [lower instance priority]
-instance (priority := 100) MulActionWithZero.toSMulWithZero [m : MulActionWithZero R M] :
+instance (priority := 100) MulActionWithZero.toSMulWithZero
+    {_ : MonoidWithZero R} {_ : Zero M} [m : MulActionWithZero R M] :
     SMulWithZero R M :=
   { m with }
 

--- a/Mathlib/Algebra/SMulWithZero.lean
+++ b/Mathlib/Algebra/SMulWithZero.lean
@@ -50,7 +50,7 @@ class SMulWithZero [outParam (Zero R)] [outParam (Zero M)] extends SMulZeroClass
   /-- Scalar multiplication by the scalar `0` is `0`. -/
   zero_smul : ∀ m : M, (0 : R) • m = 0
 
-instance SMulWithZero.instSMulZeroClass :
+@[instance] abbrev SMulWithZero.instSMulZeroClass :
     ∀ {R M} {_ : Zero R} {_ : Zero M} [SMulWithZero R M], SMulZeroClass R M :=
   @SMulWithZero.toSMulZeroClass
 
@@ -133,7 +133,7 @@ class MulActionWithZero [outParam (MonoidWithZero R)] [outParam (Zero M)] extend
   /-- Scalar multiplication by the scalar `0` is `0`. -/
   zero_smul : ∀ m : M, (0 : R) • m = 0
 
-instance MulActionWithZero.instMulAction :
+@[instance] abbrev MulActionWithZero.instMulAction :
     ∀ {R M} {_ : MonoidWithZero R} {_ : Zero M} [MulActionWithZero R M], MulAction R M :=
   @MulActionWithZero.toMulAction
 

--- a/Mathlib/Analysis/NormedSpace/HahnBanach/Extension.lean
+++ b/Mathlib/Analysis/NormedSpace/HahnBanach/Extension.lean
@@ -169,7 +169,8 @@ theorem exists_dual_vector (x : E) (h : x ≠ 0) : ∃ g : E →L[𝕜] 𝕜, �
   · calc
       g x = g (⟨x, mem_span_singleton_self x⟩ : 𝕜 ∙ x) := by rw [coe_mk]
       _ = ((‖x‖ : 𝕜) • coord 𝕜 x h) (⟨x, mem_span_singleton_self x⟩ : 𝕜 ∙ x) := by rw [← hg.1]
-      _ = ‖x‖ := by simp
+      _ = ‖x‖ := by simp only [ContinuousLinearMap.coe_smul', Pi.smul_apply, coord_self,
+                      smul_eq_mul, mul_one]
 
 /-- Variant of Hahn-Banach, eliminating the hypothesis that `x` be nonzero, and choosing
     the dual element arbitrarily when `x = 0`. -/

--- a/Mathlib/CategoryTheory/IsConnected.lean
+++ b/Mathlib/CategoryTheory/IsConnected.lean
@@ -76,11 +76,11 @@ See <https://stacks.math.columbia.edu/tag/002S>
 class IsConnected (J : Type u₁) [outParam (Category.{v₁} J)] extends IsPreconnected J : Prop where
   [is_nonempty : Nonempty J]
 
-instance IsConnected.instIsPreconnected :
+@[instance] abbrev IsConnected.instIsPreconnected :
     ∀ {J} {_ : Category.{v₁} J} [IsConnected J], IsPreconnected J :=
   @IsConnected.toIsPreconnected
 
-instance (priority := 100) LocalRing.instNonempty :
+@[instance 100] abbrev LocalRing.instNonempty :
     ∀ {J} {_ : Category.{v₁} J} [IsConnected J], Nonempty J :=
   @IsConnected.is_nonempty
 

--- a/Mathlib/CategoryTheory/IsConnected.lean
+++ b/Mathlib/CategoryTheory/IsConnected.lean
@@ -7,6 +7,7 @@ import Mathlib.Data.List.Chain
 import Mathlib.CategoryTheory.PUnit
 import Mathlib.CategoryTheory.Groupoid
 import Mathlib.CategoryTheory.Category.ULift
+import Mathlib.Util.WithoutInstances
 
 /-!
 # Connected category
@@ -60,6 +61,7 @@ class IsPreconnected (J : Type u₁) [Category.{v₁} J] : Prop where
 
 attribute [inherit_doc IsPreconnected] IsPreconnected.iso_constant
 
+without_instances
 /-- We define a connected category as a _nonempty_ category for which every
 functor to a discrete category is constant.
 
@@ -71,10 +73,16 @@ This allows us to show that the functor X ⨯ - preserves connected limits.
 
 See <https://stacks.math.columbia.edu/tag/002S>
 -/
-class IsConnected (J : Type u₁) [Category.{v₁} J] extends IsPreconnected J : Prop where
+class IsConnected (J : Type u₁) [outParam (Category.{v₁} J)] extends IsPreconnected J : Prop where
   [is_nonempty : Nonempty J]
 
-attribute [instance 100] IsConnected.is_nonempty
+instance IsConnected.instIsPreconnected :
+    ∀ {J} {_ : Category.{v₁} J} [IsConnected J], IsPreconnected J :=
+  @IsConnected.toIsPreconnected
+
+instance (priority := 100) LocalRing.instNonempty :
+    ∀ {J} {_ : Category.{v₁} J} [IsConnected J], Nonempty J :=
+  @IsConnected.is_nonempty
 
 variable {J : Type u₁} [Category.{v₁} J]
 variable {K : Type u₂} [Category.{v₂} K]

--- a/Mathlib/CategoryTheory/Quotient/Linear.lean
+++ b/Mathlib/CategoryTheory/Quotient/Linear.lean
@@ -98,12 +98,14 @@ def linear (hr : ∀ (a : R) ⦃X Y : C⦄ (f₁ f₂ : X ⟶ Y) (_ : r f₁ f�
         obtain ⟨g, rfl⟩ := (functor r).map_surjective g
         rw [Linear.smul_eq, ← Functor.map_comp, ← Functor.map_comp,
           Linear.smul_eq, Linear.smul_comp]
+        all_goals exact hr
       comp_smul := by
         rintro ⟨X⟩ ⟨Y⟩ ⟨Z⟩ f a g
         obtain ⟨f, rfl⟩ := (functor r).map_surjective f
         obtain ⟨g, rfl⟩ := (functor r).map_surjective g
         rw [Linear.smul_eq, ← Functor.map_comp, ← Functor.map_comp,
-          Linear.smul_eq, Linear.comp_smul] }
+          Linear.smul_eq, Linear.comp_smul]
+        all_goals exact hr }
 
 instance linear_functor
     (hr : ∀ (a : R) ⦃X Y : C⦄ (f₁ f₂ : X ⟶ Y) (_ : r f₁ f₂), r (a • f₁) (a • f₂))

--- a/Mathlib/CategoryTheory/Quotient/Linear.lean
+++ b/Mathlib/CategoryTheory/Quotient/Linear.lean
@@ -98,14 +98,12 @@ def linear (hr : ∀ (a : R) ⦃X Y : C⦄ (f₁ f₂ : X ⟶ Y) (_ : r f₁ f�
         obtain ⟨g, rfl⟩ := (functor r).map_surjective g
         rw [Linear.smul_eq, ← Functor.map_comp, ← Functor.map_comp,
           Linear.smul_eq, Linear.smul_comp]
-        all_goals exact hr
       comp_smul := by
         rintro ⟨X⟩ ⟨Y⟩ ⟨Z⟩ f a g
         obtain ⟨f, rfl⟩ := (functor r).map_surjective f
         obtain ⟨g, rfl⟩ := (functor r).map_surjective g
         rw [Linear.smul_eq, ← Functor.map_comp, ← Functor.map_comp,
-          Linear.smul_eq, Linear.comp_smul]
-        all_goals exact hr }
+          Linear.smul_eq, Linear.comp_smul] }
 
 instance linear_functor
     (hr : ∀ (a : R) ⦃X Y : C⦄ (f₁ f₂ : X ⟶ Y) (_ : r f₁ f₂), r (a • f₁) (a • f₂))

--- a/Mathlib/Combinatorics/SimpleGraph/Regularity/Lemma.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Regularity/Lemma.lean
@@ -70,7 +70,7 @@ variable {α : Type*} [DecidableEq α] [Fintype α] (G : SimpleGraph α) [Decida
 /-- Effective **Szemerédi Regularity Lemma**: For any sufficiently large graph, there is an
 `ε`-uniform equipartition of bounded size (where the bound does not depend on the graph). -/
 theorem szemeredi_regularity (hε : 0 < ε) (hl : l ≤ card α) :
-    ∃ P : Finpartition univ,
+    ∃ P : Finpartition (univ : Finset α),
       P.IsEquipartition ∧ l ≤ P.parts.card ∧ P.parts.card ≤ bound ε l ∧ P.IsUniform G ε := by
   obtain hα | hα := le_total (card α) (bound ε l)
   -- If `card α ≤ bound ε l`, then the partition into singletons is acceptable.

--- a/Mathlib/GroupTheory/Subgroup/Simple.lean
+++ b/Mathlib/GroupTheory/Subgroup/Simple.lean
@@ -29,19 +29,26 @@ section
 
 variable (G) (A)
 
+without_instances
 /-- A `Group` is simple when it has exactly two normal `Subgroup`s. -/
-class IsSimpleGroup extends Nontrivial G : Prop where
+class IsSimpleGroup (G : Type*) [outParam (Group G)] extends Nontrivial G : Prop where
   /-- Any normal subgroup is either `⊥` or `⊤` -/
   eq_bot_or_eq_top_of_normal : ∀ H : Subgroup G, H.Normal → H = ⊥ ∨ H = ⊤
 
+without_instances
 /-- An `AddGroup` is simple when it has exactly two normal `AddSubgroup`s. -/
-class IsSimpleAddGroup extends Nontrivial A : Prop where
+class IsSimpleAddGroup (A : Type*) [outParam (AddGroup A)] extends Nontrivial A : Prop where
   /-- Any normal additive subgroup is either `⊥` or `⊤` -/
   eq_bot_or_eq_top_of_normal : ∀ H : AddSubgroup A, H.Normal → H = ⊥ ∨ H = ⊤
 
 attribute [to_additive] IsSimpleGroup
 
 variable {G} {A}
+
+@[to_additive]
+instance IsSimpleGroup.instNontrivial :
+    ∀ {G} {_ : Group G} [IsSimpleGroup G], Nontrivial G :=
+  @IsSimpleGroup.toNontrivial
 
 @[to_additive]
 theorem Subgroup.Normal.eq_bot_or_eq_top [IsSimpleGroup G] {H : Subgroup G} (Hn : H.Normal) :

--- a/Mathlib/GroupTheory/Subgroup/Simple.lean
+++ b/Mathlib/GroupTheory/Subgroup/Simple.lean
@@ -45,8 +45,8 @@ attribute [to_additive] IsSimpleGroup
 
 variable {G} {A}
 
-@[to_additive]
-instance IsSimpleGroup.instNontrivial :
+@[to_additive (attr := instance)]
+abbrev IsSimpleGroup.instNontrivial :
     ∀ {G} {_ : Group G} [IsSimpleGroup G], Nontrivial G :=
   @IsSimpleGroup.toNontrivial
 

--- a/Mathlib/LinearAlgebra/Matrix/BilinearForm.lean
+++ b/Mathlib/LinearAlgebra/Matrix/BilinearForm.lean
@@ -80,7 +80,7 @@ variable [Fintype n] [Fintype o]
 
 theorem toBilin'Aux_toMatrixAux [DecidableEq n] (B₂ : BilinForm R₂ (n → R₂)) :
     -- Porting note: had to hint the base ring even though it should be clear from context...
-    Matrix.toBilin'Aux (BilinForm.toMatrixAux (R₂ := R₂) (fun j => Pi.single j 1) B₂) = B₂ := by
+    Matrix.toBilin'Aux (BilinForm.toMatrixAux (fun j => Pi.single j (1 : R₂)) B₂) = B₂ := by
   rw [BilinForm.toMatrixAux, Matrix.toBilin'Aux, toLinearMap₂'Aux_toMatrix₂Aux]
 
 section ToMatrix'

--- a/Mathlib/LinearAlgebra/TensorProduct/Tower.lean
+++ b/Mathlib/LinearAlgebra/TensorProduct/Tower.lean
@@ -394,9 +394,6 @@ section rightComm
 
 /-- A tensor product analogue of `mul_right_comm`. -/
 def rightComm : (M ⊗[A] P) ⊗[R] Q ≃ₗ[A] (M ⊗[R] Q) ⊗[A] P :=
-  haveI : IsScalarTower R A (M →ₗ[A] P →ₗ[A] (M ⊗[A] P) ⊗[R] Q) := LinearMap.instIsScalarTower
-  haveI : LinearMap.CompatibleSMul (M ⊗[A] P →ₗ[A] (M ⊗[A] P) ⊗[R] Q)
-    (M →ₗ[A] P →ₗ[A] (M ⊗[A] P) ⊗[R] Q) R A := LinearMap.IsScalarTower.compatibleSMul
   LinearEquiv.ofLinear
     (lift <| TensorProduct.lift <| LinearMap.flip <|
       lcurry R A A M Q ((M ⊗[R] Q) ⊗[A] P) ∘ₗ (mk A A (M ⊗[R] Q) P).flip)

--- a/Mathlib/LinearAlgebra/TensorProduct/Tower.lean
+++ b/Mathlib/LinearAlgebra/TensorProduct/Tower.lean
@@ -394,6 +394,9 @@ section rightComm
 
 /-- A tensor product analogue of `mul_right_comm`. -/
 def rightComm : (M ⊗[A] P) ⊗[R] Q ≃ₗ[A] (M ⊗[R] Q) ⊗[A] P :=
+  haveI : IsScalarTower R A (M →ₗ[A] P →ₗ[A] (M ⊗[A] P) ⊗[R] Q) := LinearMap.instIsScalarTower
+  haveI : LinearMap.CompatibleSMul (M ⊗[A] P →ₗ[A] (M ⊗[A] P) ⊗[R] Q)
+    (M →ₗ[A] P →ₗ[A] (M ⊗[A] P) ⊗[R] Q) R A := LinearMap.IsScalarTower.compatibleSMul
   LinearEquiv.ofLinear
     (lift <| TensorProduct.lift <| LinearMap.flip <|
       lcurry R A A M Q ((M ⊗[R] Q) ⊗[A] P) ∘ₗ (mk A A (M ⊗[R] Q) P).flip)

--- a/Mathlib/Order/Atoms.lean
+++ b/Mathlib/Order/Atoms.lean
@@ -563,10 +563,16 @@ end CompleteAtomicBooleanAlgebra
 
 end Atomistic
 
+without_instances
 /-- An order is simple iff it has exactly two elements, `⊥` and `⊤`. -/
-class IsSimpleOrder (α : Type*) [LE α] [BoundedOrder α] extends Nontrivial α : Prop where
+class IsSimpleOrder (α : Type*) [outParam (LE α)] [outParam (BoundedOrder α)] extends
+    Nontrivial α : Prop where
   /-- Every element is either `⊥` or `⊤` -/
   eq_bot_or_eq_top : ∀ a : α, a = ⊥ ∨ a = ⊤
+
+instance IsSimpleOrder.instNontrivial :
+    ∀ {α} {_ : LE α} {_ : BoundedOrder α} [IsSimpleOrder α], Nontrivial α :=
+  @IsSimpleOrder.toNontrivial
 
 export IsSimpleOrder (eq_bot_or_eq_top)
 

--- a/Mathlib/Order/Atoms.lean
+++ b/Mathlib/Order/Atoms.lean
@@ -570,7 +570,7 @@ class IsSimpleOrder (α : Type*) [outParam (LE α)] [outParam (BoundedOrder α)]
   /-- Every element is either `⊥` or `⊤` -/
   eq_bot_or_eq_top : ∀ a : α, a = ⊥ ∨ a = ⊤
 
-instance IsSimpleOrder.instNontrivial :
+@[instance] abbrev IsSimpleOrder.instNontrivial :
     ∀ {α} {_ : LE α} {_ : BoundedOrder α} [IsSimpleOrder α], Nontrivial α :=
   @IsSimpleOrder.toNontrivial
 

--- a/Mathlib/Order/BooleanAlgebra.lean
+++ b/Mathlib/Order/BooleanAlgebra.lean
@@ -676,7 +676,7 @@ theorem codisjoint_himp_self_right : Codisjoint x (x ⇨ y) :=
   @disjoint_sdiff_self_right αᵒᵈ _ _ _
 
 theorem himp_le : x ⇨ y ≤ z ↔ y ≤ z ∧ Codisjoint x z :=
-  (@le_sdiff αᵒᵈ _ _ _ _).trans <| and_congr_right' <| @Codisjoint_comm _ (_) _ _ _
+  (@le_sdiff αᵒᵈ _ _ _ _).trans <| and_congr_right' <| @Codisjoint_comm α _ _ _ _
 
 @[simp] lemma himp_le_iff : x ⇨ y ≤ x ↔ x = ⊤ :=
   ⟨fun h ↦ codisjoint_self.1 <| codisjoint_himp_self_right.mono_right h, fun h ↦ le_top.trans h.ge⟩

--- a/Mathlib/Order/BoundedOrder.lean
+++ b/Mathlib/Order/BoundedOrder.lean
@@ -176,13 +176,14 @@ theorem OrderTop.ext_top {α} {hA : PartialOrder α} (A : OrderTop α) {hB : Par
   apply top_unique
   exact @le_top _ _ A _
 
+without_instances
 /-- An order is an `OrderBot` if it has a least element.
 We state this using a data mixin, holding the value of `⊥` and the least element constraint. -/
 class OrderBot (α : Type u) [outParam (LE α)] extends Bot α where
   /-- `⊥` is the least element -/
   bot_le : ∀ a : α, ⊥ ≤ a
 
-instance OrderBot.instBot :
+@[instance] abbrev OrderBot.instBot :
     ∀ {α} {_ : LE α} [OrderBot α], Bot α :=
   @OrderBot.toBot
 
@@ -413,15 +414,16 @@ end SemilatticeInfBot
 /-! ### Bounded order -/
 
 
+without_instances
 /-- A bounded order describes an order `(≤)` with a top and bottom element,
   denoted `⊤` and `⊥` respectively. -/
 class BoundedOrder (α : Type u) [outParam (LE α)] extends OrderTop α, OrderBot α
 
-instance BoundedOrder.instOrderTop :
+@[instance] abbrev BoundedOrder.instOrderTop :
     ∀ {α} {_ : LE α} [BoundedOrder α], OrderTop α :=
   @BoundedOrder.toOrderTop
 
-instance BoundedOrder.instOrderBot :
+@[instance] abbrev BoundedOrder.instOrderBot :
     ∀ {α} {_ : LE α} [BoundedOrder α], OrderBot α :=
   @BoundedOrder.toOrderBot
 

--- a/Mathlib/Order/BoundedOrder.lean
+++ b/Mathlib/Order/BoundedOrder.lean
@@ -6,6 +6,7 @@ Authors: Johannes Hölzl
 import Mathlib.Order.Lattice
 import Mathlib.Order.ULift
 import Mathlib.Tactic.PushNeg
+import Mathlib.Util.WithoutInstances
 
 /-!
 # ⊤ and ⊥, bounded lattices and variants
@@ -37,11 +38,16 @@ variable {α : Type u} {β : Type v} {γ δ : Type*}
 
 /-! ### Top, bottom element -/
 
+without_instances
 /-- An order is an `OrderTop` if it has a greatest element.
 We state this using a data mixin, holding the value of `⊤` and the greatest element constraint. -/
-class OrderTop (α : Type u) [LE α] extends Top α where
+class OrderTop (α : Type u) [outParam (LE α)] extends Top α where
   /-- `⊤` is the greatest element -/
   le_top : ∀ a : α, a ≤ ⊤
+
+instance OrderTop.instTop :
+    ∀ {α} {_ : LE α} [OrderTop α], Top α :=
+  @OrderTop.toTop
 
 section OrderTop
 
@@ -172,9 +178,13 @@ theorem OrderTop.ext_top {α} {hA : PartialOrder α} (A : OrderTop α) {hB : Par
 
 /-- An order is an `OrderBot` if it has a least element.
 We state this using a data mixin, holding the value of `⊥` and the least element constraint. -/
-class OrderBot (α : Type u) [LE α] extends Bot α where
+class OrderBot (α : Type u) [outParam (LE α)] extends Bot α where
   /-- `⊥` is the least element -/
   bot_le : ∀ a : α, ⊥ ≤ a
+
+instance OrderBot.instBot :
+    ∀ {α} {_ : LE α} [OrderBot α], Bot α :=
+  @OrderBot.toBot
 
 section OrderBot
 
@@ -405,7 +415,15 @@ end SemilatticeInfBot
 
 /-- A bounded order describes an order `(≤)` with a top and bottom element,
   denoted `⊤` and `⊥` respectively. -/
-class BoundedOrder (α : Type u) [LE α] extends OrderTop α, OrderBot α
+class BoundedOrder (α : Type u) [outParam (LE α)] extends OrderTop α, OrderBot α
+
+instance BoundedOrder.instOrderTop :
+    ∀ {α} {_ : LE α} [BoundedOrder α], OrderTop α :=
+  @BoundedOrder.toOrderTop
+
+instance BoundedOrder.instOrderBot :
+    ∀ {α} {_ : LE α} [BoundedOrder α], OrderBot α :=
+  @BoundedOrder.toOrderBot
 
 instance OrderDual.instBoundedOrder (α : Type u) [LE α] [BoundedOrder α] : BoundedOrder αᵒᵈ where
   __ := inferInstanceAs (OrderTop αᵒᵈ)

--- a/Mathlib/Order/BoundedOrder.lean
+++ b/Mathlib/Order/BoundedOrder.lean
@@ -45,7 +45,7 @@ class OrderTop (α : Type u) [outParam (LE α)] extends Top α where
   /-- `⊤` is the greatest element -/
   le_top : ∀ a : α, a ≤ ⊤
 
-instance OrderTop.instTop :
+@[instance] abbrev OrderTop.instTop :
     ∀ {α} {_ : LE α} [OrderTop α], Top α :=
   @OrderTop.toTop
 

--- a/Mathlib/Order/Category/BddDistLat.lean
+++ b/Mathlib/Order/Category/BddDistLat.lean
@@ -40,7 +40,7 @@ attribute [instance] BddDistLat.isBoundedOrder
 def of (α : Type*) [DistribLattice α] [BoundedOrder α] : BddDistLat :=
   -- Porting note: was `⟨⟨α⟩⟩`
   -- see https://github.com/leanprover-community/mathlib4/issues/4998
-  ⟨{α := α}⟩
+  ⟨⟨α, _⟩⟩
 
 @[simp]
 theorem coe_of (α : Type*) [DistribLattice α] [BoundedOrder α] : ↥(of α) = α :=

--- a/Mathlib/Order/Category/BddLat.lean
+++ b/Mathlib/Order/Category/BddLat.lean
@@ -41,7 +41,7 @@ attribute [instance] BddLat.isBoundedOrder
 /-- Construct a bundled `BddLat` from `Lattice` + `BoundedOrder`. -/
 def of (α : Type*) [Lattice α] [BoundedOrder α] : BddLat :=
   -- Porting note: was `⟨⟨α⟩⟩`, see https://github.com/leanprover-community/mathlib4/issues/4998
-  ⟨{α := α}⟩
+  ⟨⟨α, _⟩⟩
 
 @[simp]
 theorem coe_of (α : Type*) [Lattice α] [BoundedOrder α] : ↥(of α) = α :=

--- a/Mathlib/Order/Category/BddOrd.lean
+++ b/Mathlib/Order/Category/BddOrd.lean
@@ -37,7 +37,7 @@ attribute [instance] BddOrd.isBoundedOrder
 /-- Construct a bundled `BddOrd` from a `Fintype` `PartialOrder`. -/
 def of (α : Type*) [PartialOrder α] [BoundedOrder α] : BddOrd :=
   -- Porting note: was ⟨⟨α⟩⟩, see https://github.com/leanprover-community/mathlib4/issues/4998
-  ⟨{ α := α }⟩
+  ⟨⟨α, _⟩⟩
 
 @[simp]
 theorem coe_of (α : Type*) [PartialOrder α] [BoundedOrder α] : ↥(of α) = α :=

--- a/Mathlib/Order/Category/FinBddDistLat.lean
+++ b/Mathlib/Order/Category/FinBddDistLat.lean
@@ -41,14 +41,14 @@ attribute [instance] FinBddDistLat.isFintype
 def of (α : Type*) [DistribLattice α] [BoundedOrder α] [Fintype α] : FinBddDistLat :=
   -- Porting note: was `⟨⟨⟨α⟩⟩⟩`
   -- see https://github.com/leanprover-community/mathlib4/issues/4998
-  ⟨⟨{α := α}⟩⟩
+  ⟨⟨⟨α, _⟩⟩⟩
 
 /-- Construct a bundled `FinBddDistLat` from a `Nonempty` `BoundedOrder` `DistribLattice`. -/
 def of' (α : Type*) [DistribLattice α] [Fintype α] [Nonempty α] : FinBddDistLat :=
   haveI := Fintype.toBoundedOrder α
   -- Porting note: was `⟨⟨⟨α⟩⟩⟩`
   -- see https://github.com/leanprover-community/mathlib4/issues/4998
-  ⟨⟨{α := α}⟩⟩
+  ⟨⟨⟨α, _⟩⟩⟩
 
 instance : Inhabited FinBddDistLat :=
   ⟨of PUnit⟩

--- a/Mathlib/RingTheory/LocalRing/Defs.lean
+++ b/Mathlib/RingTheory/LocalRing/Defs.lean
@@ -31,6 +31,6 @@ class LocalRing (R : Type*) [outParam (Semiring R)] extends Nontrivial R : Prop 
     word, for every `a : R`, either `a` is a unit or `1 - a` is a unit. -/
   isUnit_or_isUnit_of_add_one {a b : R} (h : a + b = 1) : IsUnit a ∨ IsUnit b
 
-instance LocalRing.instNontrivial :
+@[instance] abbrev LocalRing.instNontrivial :
     ∀ {R} {_ : Semiring R} [LocalRing R], Nontrivial R :=
   @LocalRing.toNontrivial

--- a/Mathlib/RingTheory/LocalRing/Defs.lean
+++ b/Mathlib/RingTheory/LocalRing/Defs.lean
@@ -5,6 +5,7 @@ Authors: Kenny Lau, Chris Hughes, Mario Carneiro
 -/
 import Mathlib.Algebra.Group.Units
 import Mathlib.Algebra.Ring.Defs
+import Mathlib.Util.WithoutInstances
 
 /-!
 
@@ -20,10 +21,16 @@ Define local rings as commutative rings having a unique maximal ideal.
   `LocalRing.of_unique_max_ideal` and `LocalRing.maximal_ideal_unique`.
 
 -/
+
+without_instances
 /-- A semiring is local if it is nontrivial and `a` or `b` is a unit whenever `a + b = 1`.
 Note that `LocalRing` is a predicate. -/
-class LocalRing (R : Type*) [Semiring R] extends Nontrivial R : Prop where
+class LocalRing (R : Type*) [outParam (Semiring R)] extends Nontrivial R : Prop where
   of_is_unit_or_is_unit_of_add_one ::
   /-- in a local ring `R`, if `a + b = 1`, then either `a` is a unit or `b` is a unit. In another
     word, for every `a : R`, either `a` is a unit or `1 - a` is a unit. -/
   isUnit_or_isUnit_of_add_one {a b : R} (h : a + b = 1) : IsUnit a ∨ IsUnit b
+
+instance LocalRing.instNontrivial :
+    ∀ {R} {_ : Semiring R} [LocalRing R], Nontrivial R :=
+  @LocalRing.toNontrivial

--- a/Mathlib/RingTheory/MvPolynomial/Symmetric.lean
+++ b/Mathlib/RingTheory/MvPolynomial/Symmetric.lean
@@ -274,7 +274,7 @@ theorem degrees_esymm [Nontrivial R] {n : ℕ} (hpos : 0 < n) (hn : n ≤ Fintyp
       simp [Finsupp.toMultiset_sum_single]
     rw [degrees_def, support_esymm, sup_image, this]
     have : ((powersetCard n univ).sup (fun (x : Finset σ) => x)).val
-        = sup (powersetCard n univ) val := by
+        = sup (powersetCard n (univ : Finset σ)) val := by
       refine comp_sup_eq_sup_comp _ ?_ ?_
       · intros
         simp only [union_val, sup_eq_union]

--- a/Mathlib/Topology/Connected/Basic.lean
+++ b/Mathlib/Topology/Connected/Basic.lean
@@ -609,12 +609,20 @@ class PreconnectedSpace (α : Type u) [TopologicalSpace α] : Prop where
 
 export PreconnectedSpace (isPreconnected_univ)
 
+without_instances
 /-- A connected space is a nonempty one where there is no non-trivial open partition. -/
-class ConnectedSpace (α : Type u) [TopologicalSpace α] extends PreconnectedSpace α : Prop where
+class ConnectedSpace (α : Type u) [outParam (TopologicalSpace α)] extends
+    PreconnectedSpace α : Prop where
   /-- A connected space is nonempty. -/
   toNonempty : Nonempty α
 
-attribute [instance 50] ConnectedSpace.toNonempty  -- see Note [lower instance priority]
+instance ConnectedSpace.instPreconnectedSpace :
+    ∀ {α} {_ : TopologicalSpace α} [ConnectedSpace α], PreconnectedSpace α :=
+  @ConnectedSpace.toPreconnectedSpace
+
+instance (priority := 50) ConnectedSpace.instNonempty :
+    ∀ {α} {_ : TopologicalSpace α} [ConnectedSpace α], Nonempty α :=
+  @ConnectedSpace.toNonempty
 
 -- see Note [lower instance priority]
 theorem isConnected_univ [ConnectedSpace α] : IsConnected (univ : Set α) :=

--- a/Mathlib/Topology/Connected/Basic.lean
+++ b/Mathlib/Topology/Connected/Basic.lean
@@ -616,11 +616,11 @@ class ConnectedSpace (α : Type u) [outParam (TopologicalSpace α)] extends
   /-- A connected space is nonempty. -/
   toNonempty : Nonempty α
 
-instance ConnectedSpace.instPreconnectedSpace :
+@[instance] abbrev ConnectedSpace.instPreconnectedSpace :
     ∀ {α} {_ : TopologicalSpace α} [ConnectedSpace α], PreconnectedSpace α :=
   @ConnectedSpace.toPreconnectedSpace
 
-instance (priority := 50) ConnectedSpace.instNonempty :
+@[instance 50] abbrev ConnectedSpace.instNonempty :
     ∀ {α} {_ : TopologicalSpace α} [ConnectedSpace α], Nonempty α :=
   @ConnectedSpace.toNonempty
 

--- a/Mathlib/Topology/Irreducible.lean
+++ b/Mathlib/Topology/Irreducible.lean
@@ -143,13 +143,20 @@ class PreirreducibleSpace (X : Type*) [TopologicalSpace X] : Prop where
   /-- In a preirreducible space, `Set.univ` is a preirreducible set. -/
   isPreirreducible_univ : IsPreirreducible (univ : Set X)
 
+without_instances
 /-- An irreducible space is one that is nonempty
 and where there is no non-trivial pair of disjoint opens. -/
-class IrreducibleSpace (X : Type*) [TopologicalSpace X] extends PreirreducibleSpace X : Prop where
+class IrreducibleSpace (X : Type*) [outParam (TopologicalSpace X)] extends
+    PreirreducibleSpace X : Prop where
   toNonempty : Nonempty X
 
--- see Note [lower instance priority]
-attribute [instance 50] IrreducibleSpace.toNonempty
+instance IrreducibleSpace.instPreirreducibleSpace :
+    ∀ {X} {_ : TopologicalSpace X} [IrreducibleSpace X], PreirreducibleSpace X :=
+  @IrreducibleSpace.toPreirreducibleSpace
+
+instance (priority := 50) IrreducibleSpace.instNonempty :
+    ∀ {X} {_ : TopologicalSpace X} [IrreducibleSpace X], Nonempty X :=
+  @IrreducibleSpace.toNonempty
 
 theorem IrreducibleSpace.isIrreducible_univ (X : Type*) [TopologicalSpace X] [IrreducibleSpace X] :
     IsIrreducible (univ : Set X) :=

--- a/Mathlib/Topology/Irreducible.lean
+++ b/Mathlib/Topology/Irreducible.lean
@@ -150,11 +150,11 @@ class IrreducibleSpace (X : Type*) [outParam (TopologicalSpace X)] extends
     PreirreducibleSpace X : Prop where
   toNonempty : Nonempty X
 
-instance IrreducibleSpace.instPreirreducibleSpace :
+@[instance] abbrev IrreducibleSpace.instPreirreducibleSpace :
     ∀ {X} {_ : TopologicalSpace X} [IrreducibleSpace X], PreirreducibleSpace X :=
   @IrreducibleSpace.toPreirreducibleSpace
 
-instance (priority := 50) IrreducibleSpace.instNonempty :
+@[instance 50] abbrev IrreducibleSpace.instNonempty :
     ∀ {X} {_ : TopologicalSpace X} [IrreducibleSpace X], Nonempty X :=
   @IrreducibleSpace.toNonempty
 

--- a/Mathlib/Util/WithoutInstances.lean
+++ b/Mathlib/Util/WithoutInstances.lean
@@ -1,0 +1,27 @@
+/-
+Copyright (c) 2024 Yuyang Zhao. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Yuyang Zhao
+-/
+import Lean.Elab.Command
+import Lean.Meta.Instances
+
+/-!
+# `without_instances` command
+
+Do not add any instances to the environment.
+-/
+
+namespace Lean.Elab.Command
+
+open Meta
+
+/-- Do not add any instances to the environment. -/
+elab "without_instances " cmd:command : command => do
+  let globalInstances := globalInstanceExtension.ext.toEnvExtension.getState (← getEnv)
+  let instances := instanceExtension.ext.toEnvExtension.getState (← getEnv)
+  Lean.Elab.Command.elabCommand cmd
+  setEnv (globalInstanceExtension.ext.toEnvExtension.setState (← getEnv) globalInstances)
+  setEnv (instanceExtension.ext.toEnvExtension.setState (← getEnv) instances)
+
+end Lean.Elab.Command

--- a/scripts/noshake.json
+++ b/scripts/noshake.json
@@ -188,6 +188,7 @@
   "Mathlib.Util.Syntax",
   "Mathlib.Util.Tactic",
   "Mathlib.Util.WhatsNew",
+  "Mathlib.Util.WithoutInstances",
   "Mathlib.Util.WithWeakNamespace",
   "Qq"],
  "ignoreAll":

--- a/test/Variable.lean
+++ b/test/Variable.lean
@@ -23,7 +23,9 @@ example : DecidableEq α := inferInstance
 end
 
 section
-/-- info: Try this: variable? [Module R M] => [Semiring R] [AddCommMonoid M] [Module R M] -/
+/--
+info: Try this: variable? [Module R M] => [outParam (Semiring R)] [outParam (AddCommMonoid M)] [Module R M]
+-/
 #guard_msgs in
 variable? [Module R M]
 example : Semiring R := inferInstance
@@ -44,7 +46,7 @@ section
 /--
 warning: Calculated binders do not match the expected binders given after `=>`.
 ---
-info: Try this: variable? [Module R M] => [Semiring R] [AddCommMonoid M] [Module R M]
+info: Try this: variable? [Module R M] => [outParam (Semiring R)] [outParam (AddCommMonoid M)] [Module R M]
 -/
 #guard_msgs in
 variable? [Module R M] => [Ring R] [AddCommMonoid M] [Module R M]
@@ -53,7 +55,7 @@ end
 section
 /--
 error: failed to synthesize
-  Semiring R
+  outParam (Semiring R)
 Additional diagnostic information may be available using the `set_option diagnostics true` command.
 -/
 #guard_msgs in
@@ -91,8 +93,8 @@ section
 -- There are two different add operations on `A`.
 -- See also the next test.
 /--
-info: Try this: variable? [Module R A] [Algebra S A] => [Semiring R] [AddCommMonoid A] [Module R A] [CommSemiring S]
-  [Semiring A] [Algebra S A]
+info: Try this: variable? [Module R A] [Algebra S A] => [outParam (Semiring R)] [outParam (AddCommMonoid A)] [Module R A]
+  [outParam (CommSemiring S)] [outParam (Semiring A)] [Algebra S A]
 -/
 #guard_msgs in
 variable? [Module R A] [Algebra S A]
@@ -101,7 +103,8 @@ end
 section
 -- Similar to the previous test, but this time there is only a single add operation on `A`.
 /--
-info: Try this: variable? [Algebra S A] [Module R A] => [CommSemiring S] [Semiring A] [Algebra S A] [Semiring R] [Module R A]
+info: Try this: variable? [Algebra S A] [Module R A] => [outParam (CommSemiring S)] [outParam (Semiring A)] [Algebra S A]
+  [outParam (Semiring R)] [Module R A]
 -/
 #guard_msgs in
 variable? [Algebra S A] [Module R A]
@@ -109,8 +112,8 @@ end
 
 section
 /--
-info: Try this: variable? (f : Nat → Type) [∀ i, Module R (f i)] => (f : Nat → Type) [Semiring R]
-  [(i : ℕ) → AddCommMonoid (f i)] [∀ i, Module R (f i)]
+info: Try this: variable? (f : Nat → Type) [∀ i, Module R (f i)] => (f : Nat → Type) [outParam (Semiring R)]
+  [(i : ℕ) → outParam (AddCommMonoid (f i))] [∀ i, Module R (f i)]
 -/
 #guard_msgs in
 variable? (f : Nat → Type) [∀ i, Module R (f i)]
@@ -121,10 +124,11 @@ section
 /--
 warning: Instance argument can be inferred from earlier arguments.
 f : ℕ → Type
-inst✝ : (i : ℕ) → AddCommMonoid (f i)
+inst✝ : (i : ℕ) → outParam (AddCommMonoid (f i))
 ⊢ (i : ℕ) → Module ℕ (f i)
 ---
-info: Try this: variable? (f : Nat → Type) [∀ i, Module Nat (f i)] => (f : Nat → Type) [(i : ℕ) → AddCommMonoid (f i)]
+info: Try this: variable? (f : Nat → Type) [∀ i, Module Nat (f i)] => (f : Nat → Type)
+  [(i : ℕ) → outParam (AddCommMonoid (f i))]
 -/
 #guard_msgs in
 variable? (f : Nat → Type) [∀ i, Module Nat (f i)]
@@ -132,14 +136,18 @@ variable? (f : Nat → Type) [∀ i, Module Nat (f i)]
 end
 
 section
-/-- info: Try this: variable? [Algebra k V] => [CommSemiring k] [Semiring V] [Algebra k V] -/
+/--
+info: Try this: variable? [Algebra k V] => [outParam (CommSemiring k)] [outParam (Semiring V)] [Algebra k V]
+-/
 #guard_msgs in
 variable? [Algebra k V]
 end
 
 section
 -- Checking that `Algebra` doesn't introduce its own `CommSemiring k`.
-/-- info: Try this: variable? [Field k] [Algebra k A] => [Field k] [Semiring A] [Algebra k A] -/
+/--
+info: Try this: variable? [Field k] [Algebra k A] => [Field k] [outParam (Semiring A)] [Algebra k A]
+-/
 #guard_msgs in
 variable? [Field k] [Algebra k A]
 example : (inferInstance : Field k).toCommSemiring = (inferInstance : CommSemiring k) := rfl
@@ -158,20 +166,20 @@ example : AddCommGroup M := inferInstance
 example : Module R M := inferInstance
 end
 
-section
-/--
-info: Try this: variable? [VectorSpace k V] [Algebra k V] => [Field k] [AddCommGroup V] [Module k V] [Semiring V]
-  [Algebra k V]
--/
-#guard_msgs in
-variable? [VectorSpace k V] [Algebra k V]
-example : Field k := inferInstance
-example : AddCommGroup V := inferInstance
-example : Module k V := inferInstance
-example : Semiring V := inferInstance
-example : Algebra k V := inferInstance
+-- section
+-- /--
+-- info: Try this: variable? [VectorSpace k V] [Algebra k V] => [Field k] [AddCommGroup V] [Module k V] [Semiring V]
+--   [Algebra k V]
+-- -/
+-- #guard_msgs in
+-- variable? [VectorSpace k V] [Algebra k V]
+-- example : Field k := inferInstance
+-- example : AddCommGroup V := inferInstance
+-- example : Module k V := inferInstance
+-- example : Semiring V := inferInstance
+-- example : Algebra k V := inferInstance
 
-end
+-- end
 
 section
 #guard_msgs in


### PR DESCRIPTION
While trying to refactor algebraic order structures, I realized that mixin typeclass may cause significant slowness that needs to be fixed by modifying the typeclass synthesizing algorithm. I don't know enough about the details to modify it. I've recently found a solution that doesn't require any modifications to the synthesizing algorithm. But it needs to modify everything manually.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
