### PR TITLE
[Merged by Bors] - fix(update_dependencies.yml): actually get and use the sha of the branch

### DIFF
--- a/.github/workflows/update_dependencies.yml
+++ b/.github/workflows/update_dependencies.yml
@@ -23,9 +23,8 @@ jobs:
 
       - name: Get sha of branch
         id: sha
-        # the branch is protected so it should always exist, but we || exit 0 just in case it's missing
         run: |
-          echo "sha=$(git rev-parse update-dependencies-bot-use-only || exit 0)" >> "$GITHUB_ENV"
+          echo "sha=$(git rev-parse --verify update-dependencies-bot-use-only)" >> "$GITHUB_ENV"
 
       - name: Get PR and labels
         if: ${{ steps.sha.outputs.sha }}

--- a/.github/workflows/update_dependencies.yml
+++ b/.github/workflows/update_dependencies.yml
@@ -21,6 +21,11 @@ jobs:
           fetch-depth: 0
           token: "${{ secrets.UPDATE_DEPENDENCIES_TOKEN }}"
 
+      - name: Get sha of branch
+        id: sha
+        run: |
+          echo "sha=$(git rev-parse update-dependencies-bot-use-only)" >> "$GITHUB_ENV"
+
       - name: Get PR and labels
         id: PR # all the steps below are skipped if 'ready-to-merge' is in the list of labels found here
         uses: 8BitJonny/gh-get-current-pr@3.0.0
@@ -28,6 +33,7 @@ jobs:
         # https://github.com/8BitJonny/gh-get-current-pr/issues/8
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
+          sha: ${{ steps.sha.outputs.sha }}
           # Only return if PR is still open
           filterOutClosed: true
 

--- a/.github/workflows/update_dependencies.yml
+++ b/.github/workflows/update_dependencies.yml
@@ -23,10 +23,12 @@ jobs:
 
       - name: Get sha of branch
         id: sha
+        # the branch is protected so it should always exist, but we || exit 0 just in case it's missing
         run: |
-          echo "sha=$(git rev-parse update-dependencies-bot-use-only)" >> "$GITHUB_ENV"
+          echo "sha=$(git rev-parse update-dependencies-bot-use-only || exit 0)" >> "$GITHUB_ENV"
 
       - name: Get PR and labels
+        if: ${{ steps.sha.outputs.sha }}
         id: PR # all the steps below are skipped if 'ready-to-merge' is in the list of labels found here
         uses: 8BitJonny/gh-get-current-pr@3.0.0
         # TODO: this may not work properly if the same commit is pushed to multiple branches:


### PR DESCRIPTION
The bot has been ignoring the `ready-to-merge` label on the update dependencies PR (cf. #16491 and e.g. [this run](https://github.com/leanprover-community/mathlib4/actions/runs/10712268074/job/29702381709)). The issue seems to be the following: the workflow is triggered by the `cron` event, so the "Get PR and labels" step cannot actually find the PR without us providing a `sha` ref.

So in this PR we try to get and provide that `sha` in an additional step.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
