### PR TITLE
[Merged by Bors] - chore: rearrange imports between valuation rings and discrete valuation rings

### DIFF
--- a/Mathlib/RingTheory/DiscreteValuationRing/Basic.lean
+++ b/Mathlib/RingTheory/DiscreteValuationRing/Basic.lean
@@ -3,10 +3,10 @@ Copyright (c) 2020 Kevin Buzzard. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Kevin Buzzard
 -/
-import Mathlib.RingTheory.PrincipalIdealDomain
-import Mathlib.RingTheory.Valuation.PrimeMultiplicity
 import Mathlib.RingTheory.AdicCompletion.Basic
 import Mathlib.RingTheory.LocalRing.MaximalIdeal.Basic
+import Mathlib.RingTheory.Valuation.PrimeMultiplicity
+import Mathlib.RingTheory.Valuation.ValuationRing
 
 /-!
 # Discrete valuation rings
@@ -452,3 +452,31 @@ instance (R : Type*) [CommRing R] [IsDomain R] [DiscreteValuationRing R] :
     rwa [← addVal_eq_top_iff, PartENat.eq_top_iff_forall_le]
 
 end DiscreteValuationRing
+
+
+section
+
+variable (A : Type u) [CommRing A] [IsDomain A] [DiscreteValuationRing A]
+
+/-- A DVR is a valuation ring. -/
+instance (priority := 100) of_discreteValuationRing : ValuationRing A := by
+  constructor
+  intro a b
+  by_cases ha : a = 0; · use 0; right; simp [ha]
+  by_cases hb : b = 0; · use 0; left; simp [hb]
+  obtain ⟨ϖ, hϖ⟩ := DiscreteValuationRing.exists_irreducible A
+  obtain ⟨m, u, rfl⟩ := DiscreteValuationRing.eq_unit_mul_pow_irreducible ha hϖ
+  obtain ⟨n, v, rfl⟩ := DiscreteValuationRing.eq_unit_mul_pow_irreducible hb hϖ
+  rcases le_total m n with h | h
+  · use (u⁻¹ * v : Aˣ) * ϖ ^ (n - m); left
+    simp_rw [mul_comm (u : A), Units.val_mul, ← mul_assoc, mul_assoc _ (u : A)]
+    simp only [Units.mul_inv, mul_one, mul_comm _ (v : A), mul_assoc, ← pow_add]
+    congr 2
+    exact Nat.add_sub_of_le h
+  · use (v⁻¹ * u : Aˣ) * ϖ ^ (m - n); right
+    simp_rw [mul_comm (v : A), Units.val_mul, ← mul_assoc, mul_assoc _ (v : A)]
+    simp only [Units.mul_inv, mul_one, mul_comm _ (u : A), mul_assoc, ← pow_add]
+    congr 2
+    exact Nat.add_sub_of_le h
+
+end

--- a/Mathlib/RingTheory/DiscreteValuationRing/TFAE.lean
+++ b/Mathlib/RingTheory/DiscreteValuationRing/TFAE.lean
@@ -3,10 +3,9 @@ Copyright (c) 2022 Andrew Yang. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Andrew Yang
 -/
-import Mathlib.RingTheory.Ideal.Cotangent
 import Mathlib.RingTheory.DedekindDomain.Basic
-import Mathlib.RingTheory.Valuation.ValuationRing
-import Mathlib.RingTheory.Nakayama
+import Mathlib.RingTheory.DiscreteValuationRing.Basic
+import Mathlib.RingTheory.Ideal.Cotangent
 
 /-!
 

--- a/Mathlib/RingTheory/Valuation/ValuationRing.lean
+++ b/Mathlib/RingTheory/Valuation/ValuationRing.lean
@@ -3,12 +3,12 @@ Copyright (c) 2022 Adam Topaz. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Adam Topaz
 -/
-import Mathlib.RingTheory.Valuation.Integers
+import Mathlib.Algebra.EuclideanDomain.Basic
+import Mathlib.RingTheory.Bezout
+import Mathlib.RingTheory.LocalRing.Basic
 import Mathlib.RingTheory.Localization.FractionRing
 import Mathlib.RingTheory.Localization.Integer
-import Mathlib.RingTheory.DiscreteValuationRing.Basic
-import Mathlib.RingTheory.Bezout
-import Mathlib.Tactic.FieldSimp
+import Mathlib.RingTheory.Valuation.Integers
 
 /-!
 # Valuation Rings
@@ -33,6 +33,7 @@ We also show that, given a valuation `v` on a field `K`, the ring of valuation i
 valuation ring and `K` is the fraction field of this ring.
 -/
 
+assert_not_exists DiscreteValuationRing
 
 universe u v w
 
@@ -437,33 +438,6 @@ instance (priority := 100) of_field : ValuationRing K := by
   by_cases h : b = 0
   · use 0; left; simp [h]
   · use a * b⁻¹; right; field_simp
-
-end
-
-section
-
-variable (A : Type u) [CommRing A] [IsDomain A] [DiscreteValuationRing A]
-
-/-- A DVR is a valuation ring. -/
-instance (priority := 100) of_discreteValuationRing : ValuationRing A := by
-  constructor
-  intro a b
-  by_cases ha : a = 0; · use 0; right; simp [ha]
-  by_cases hb : b = 0; · use 0; left; simp [hb]
-  obtain ⟨ϖ, hϖ⟩ := DiscreteValuationRing.exists_irreducible A
-  obtain ⟨m, u, rfl⟩ := DiscreteValuationRing.eq_unit_mul_pow_irreducible ha hϖ
-  obtain ⟨n, v, rfl⟩ := DiscreteValuationRing.eq_unit_mul_pow_irreducible hb hϖ
-  rcases le_total m n with h | h
-  · use (u⁻¹ * v : Aˣ) * ϖ ^ (n - m); left
-    simp_rw [mul_comm (u : A), Units.val_mul, ← mul_assoc, mul_assoc _ (u : A)]
-    simp only [Units.mul_inv, mul_one, mul_comm _ (v : A), mul_assoc, ← pow_add]
-    congr 2
-    exact Nat.add_sub_of_le h
-  · use (v⁻¹ * u : Aˣ) * ϖ ^ (m - n); right
-    simp_rw [mul_comm (v : A), Units.val_mul, ← mul_assoc, mul_assoc _ (v : A)]
-    simp only [Units.mul_inv, mul_one, mul_comm _ (u : A), mul_assoc, ← pow_add]
-    congr 2
-    exact Nat.add_sub_of_le h
 
 end
 


### PR DESCRIPTION
Imports hopped back and forth between
`RingTheory/DiscreteValuationRing` and `RingTheory/Valuation`.
Now we make DVRs depend on valuation rings in the import graph,
by moving one instance about DVRs out of
`RingTheory/Valuation/ValuationRing.lean` into the folder on DVRs.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
