### PR TITLE
[Merged by Bors] - chore(TopologicalSpace.Opens): introduce `Opens.inclusion` 

### DIFF
--- a/Mathlib/AlgebraicGeometry/AffineScheme.lean
+++ b/Mathlib/AlgebraicGeometry/AffineScheme.lean
@@ -312,7 +312,7 @@ theorem _root_.AlgebraicGeometry.Scheme.Hom.isAffineOpen_iff_of_isOpenImmersion
     (IsOpenImmersion.isoOfRangeEq (X.ofRestrict U.openEmbedding ≫ f) (Y.ofRestrict _) ?_).hom ?_ hU,
     fun hU => hU.image_of_isOpenImmersion f⟩
   · erw [Scheme.comp_val_base, coe_comp, Set.range_comp] -- now `erw` after #13170
-    dsimp [Opens.coe_inclusion, Scheme.restrict]
+    dsimp [Opens.coe_inclusion', Scheme.restrict]
     erw [Subtype.range_coe, Subtype.range_coe] -- now `erw` after #13170
     rfl
   · infer_instance
@@ -418,7 +418,7 @@ theorem exists_basicOpen_le {V : X.Opens} (x : V) (h : ↑x ∈ U) :
   have : IsAffine _ := hU
   obtain ⟨_, ⟨_, ⟨r, rfl⟩, rfl⟩, h₁, h₂⟩ :=
     (isBasis_basicOpen U).exists_subset_of_mem_open (x.2 : (⟨x, h⟩ : U) ∈ _)
-      ((Opens.map U.inclusion).obj V).isOpen
+      ((Opens.map U.inclusion').obj V).isOpen
   have :
     U.ι ''ᵁ (U.toScheme.basicOpen r) =
       X.basicOpen (X.presheaf.map (eqToHom U.openEmbedding_obj_top.symm).op r) := by

--- a/Mathlib/AlgebraicGeometry/OpenImmersion.lean
+++ b/Mathlib/AlgebraicGeometry/OpenImmersion.lean
@@ -209,7 +209,7 @@ theorem exists_affine_mem_range_and_range_subset
     ∃ (R : CommRingCat) (f : Spec R ⟶ X),
       IsOpenImmersion f ∧ x ∈ Set.range f.1.base ∧ Set.range f.1.base ⊆ U := by
   obtain ⟨⟨V, hxV⟩, R, ⟨e⟩⟩ := X.2 x
-  have : e.hom.1.base ⟨x, hxV⟩ ∈ (Opens.map (e.inv.1.base ≫ V.inclusion)).obj U :=
+  have : e.hom.1.base ⟨x, hxV⟩ ∈ (Opens.map (e.inv.1.base ≫ V.inclusion')).obj U :=
     show ((e.hom ≫ e.inv).1.base ⟨x, hxV⟩).1 ∈ U from e.hom_inv_id ▸ hxU
   obtain ⟨_, ⟨_, ⟨r : R, rfl⟩, rfl⟩, hr, hr'⟩ :=
     PrimeSpectrum.isBasis_basic_opens.exists_subset_of_mem_open this (Opens.is_open' _)

--- a/Mathlib/AlgebraicGeometry/Restrict.lean
+++ b/Mathlib/AlgebraicGeometry/Restrict.lean
@@ -69,7 +69,7 @@ lemma ι_appLE (V W e) :
     U.ι.appLE V W e =
       X.presheaf.map (homOfLE (x := U.ι ''ᵁ W) (Set.image_subset_iff.mpr ‹_›)).op := by
   simp only [Hom.appLE, ι_app, Functor.op_obj, Opens.carrier_eq_coe, toScheme_presheaf_map,
-    Quiver.Hom.unop_op, Hom.opensFunctor_map_homOfLE, Opens.coe_inclusion, ← Functor.map_comp]
+    Quiver.Hom.unop_op, Hom.opensFunctor_map_homOfLE, Opens.coe_inclusion', ← Functor.map_comp]
   rfl
 
 @[simp]
@@ -89,7 +89,7 @@ lemma ι_image_top : U.ι ''ᵁ ⊤ = U :=
 
 @[simp]
 lemma ι_preimage_self : U.ι ⁻¹ᵁ U = ⊤ :=
-  Opens.inclusion_map_eq_top _
+  Opens.inclusion'_map_eq_top _
 
 instance ι_appLE_isIso :
     IsIso (U.ι.appLE U ⊤ U.ι_preimage_self.ge) := by
@@ -234,7 +234,7 @@ theorem Scheme.restrictFunctor_map_base {U V : X.Opens} (i : U ⟶ V) :
 theorem Scheme.restrictFunctor_map_app_aux {U V : X.Opens} (i : U ⟶ V) (W : Opens V) :
     U.ι ''ᵁ ((X.restrictFunctor.map i).1 ⁻¹ᵁ W) ≤ V.ι ''ᵁ W := by
   simp only [← SetLike.coe_subset_coe, IsOpenMap.functor_obj_coe, Set.image_subset_iff,
-    Scheme.restrictFunctor_map_base, Opens.map_coe, Opens.inclusion_apply]
+    Scheme.restrictFunctor_map_base, Opens.map_coe, Opens.inclusion'_apply]
   rintro _ h
   exact ⟨_, h, rfl⟩
 
@@ -466,7 +466,7 @@ def morphismRestrictRestrict {X Y : Scheme.{u}} (f : X ⟶ Y) (U : Y.Opens) (V :
   refine Arrow.isoMk' _ _ (Scheme.restrictRestrict _ _ _ ≪≫ Scheme.restrictIsoOfEq _ ?_)
     (Scheme.restrictRestrict _ _ _) ?_
   · ext x
-    simp only [IsOpenMap.functor_obj_coe, Opens.coe_inclusion,
+    simp only [IsOpenMap.functor_obj_coe, Opens.coe_inclusion',
       Opens.map_coe, Set.mem_image, Set.mem_preimage, SetLike.mem_coe, morphismRestrict_val_base]
     constructor
     · rintro ⟨⟨a, h₁⟩, h₂, rfl⟩
@@ -488,7 +488,7 @@ def morphismRestrictRestrictBasicOpen {X Y : Scheme.{u}} (f : X ⟶ Y) (U : Y.Op
   refine morphismRestrictRestrict _ _ _ ≪≫ morphismRestrictEq _ ?_
   have e := Scheme.preimage_basicOpen U.ι r
   rw [Scheme.Opens.ι_app] at e
-  rw [← U.toScheme.basicOpen_res_eq _ (eqToHom U.inclusion_map_eq_top).op]
+  rw [← U.toScheme.basicOpen_res_eq _ (eqToHom U.inclusion'_map_eq_top).op]
   erw [← comp_apply]
   erw [← Y.presheaf.map_comp]
   rw [eqToHom_op, eqToHom_op, eqToHom_map, eqToHom_trans]

--- a/Mathlib/Geometry/Manifold/ChartedSpace.lean
+++ b/Mathlib/Geometry/Manifold/ChartedSpace.lean
@@ -1161,21 +1161,15 @@ theorem chartAt_subtype_val_symm_eventuallyEq (U : Opens M) {x : U} :
   exact Filter.eventuallyEq_of_mem heUx_nhds (e.subtypeRestr_symm_eqOn ⟨x⟩)
 
 theorem chartAt_inclusion_symm_eventuallyEq {U V : Opens M} (hUV : U ≤ V) {x : U} :
-    #adaptation_note
-    /--
-    After lean4#5020, many instances for Lie algebras and manifolds are no longer found.
-    See https://leanprover.zulipchat.com/#narrow/stream/428973-nightly-testing/topic/.2316244.20adaptations.20for.20nightly-2024-08-28/near/466219124
-    -/
-    letI : ChartedSpace H V := V.instChartedSpace
-    (chartAt H (Set.inclusion hUV x)).symm
-    =ᶠ[𝓝 (chartAt H (Set.inclusion hUV x) (Set.inclusion hUV x))]
-    Set.inclusion hUV ∘ (chartAt H x).symm := by
+    (chartAt H (Opens.inclusion hUV x)).symm
+    =ᶠ[𝓝 (chartAt H (Opens.inclusion hUV x) (Set.inclusion hUV x))]
+    Opens.inclusion hUV ∘ (chartAt H x).symm := by
   set e := chartAt H (x : M)
   have heUx_nhds : (e.subtypeRestr ⟨x⟩).target ∈ 𝓝 (e x) := by
     apply (e.subtypeRestr ⟨x⟩).open_target.mem_nhds
     exact e.map_subtype_source ⟨x⟩ (mem_chart_source _ _)
   exact Filter.eventuallyEq_of_mem heUx_nhds <| e.subtypeRestr_symm_eqOn_of_le ⟨x⟩
-    ⟨Set.inclusion hUV x⟩ hUV
+    ⟨Opens.inclusion hUV x⟩ hUV
 end TopologicalSpace.Opens
 
 /-- Restricting a chart of `M` to an open subset `s` yields a chart in the maximal atlas of `s`.

--- a/Mathlib/Geometry/Manifold/ContMDiff/Basic.lean
+++ b/Mathlib/Geometry/Manifold/ContMDiff/Basic.lean
@@ -328,14 +328,7 @@ theorem ContMDiff.extend_one [T2Space M] [One M'] {n : ℕ∞} {U : Opens M} {f 
   exact diff.contMDiffAt
 
 theorem contMDiff_inclusion {n : ℕ∞} {U V : Opens M} (h : U ≤ V) :
-    #adaptation_note
-    /--
-    After lean4#5020, many instances for Lie algebras and manifolds are no longer found.
-    See https://leanprover.zulipchat.com/#narrow/stream/428973-nightly-testing/topic/.2316244.20adaptations.20for.20nightly-2024-08-28/near/466219124
-    -/
-    letI : ChartedSpace H U := U.instChartedSpace
-    letI : ChartedSpace H V := V.instChartedSpace
-    ContMDiff I I n (Set.inclusion h : U → V) := by
+    ContMDiff I I n (Opens.inclusion h : U → V) := by
   rintro ⟨x, hx : x ∈ U⟩
   apply (contDiffWithinAt_localInvariantProp I I n).liftProp_inclusion
   intro y
@@ -354,14 +347,7 @@ theorem Smooth.extend_one [T2Space M] [One M'] {U : Opens M} {f : U → M'}
   ContMDiff.extend_one supp diff
 
 theorem smooth_inclusion {U V : Opens M} (h : U ≤ V) :
-    #adaptation_note
-    /--
-    After lean4#5020, many instances for Lie algebras and manifolds are no longer found.
-    See https://leanprover.zulipchat.com/#narrow/stream/428973-nightly-testing/topic/.2316244.20adaptations.20for.20nightly-2024-08-28/near/466219124
-    -/
-    letI : ChartedSpace H U := U.instChartedSpace
-    letI : ChartedSpace H V := V.instChartedSpace
-    Smooth I I (Set.inclusion h : U → V) :=
+    Smooth I I (Opens.inclusion h : U → V) :=
   contMDiff_inclusion h
 
 end Inclusion

--- a/Mathlib/Geometry/Manifold/LocalInvariantProperties.lean
+++ b/Mathlib/Geometry/Manifold/LocalInvariantProperties.lean
@@ -515,18 +515,9 @@ theorem liftProp_subtype_val {Q : (H → H) → Set H → H → Prop} (hG : Loca
 
 theorem liftProp_inclusion {Q : (H → H) → Set H → H → Prop} (hG : LocalInvariantProp G G Q)
     (hQ : ∀ y, Q id univ y) {U V : Opens M} (hUV : U ≤ V) :
-    letI : ChartedSpace H { x // x ∈ V } := V.instChartedSpace
-    letI : ChartedSpace H { x // x ∈ U } := U.instChartedSpace
-    LiftProp Q (Set.inclusion hUV : U → V) := by
-  #adaptation_note
-  /--
-  After lean4#5020, many instances for Lie algebras and manifolds are no longer found.
-  See https://leanprover.zulipchat.com/#narrow/stream/428973-nightly-testing/topic/.2316244.20adaptations.20for.20nightly-2024-08-28/near/466219124
-  -/
-  letI : ChartedSpace H { x // x ∈ V } := V.instChartedSpace
-  letI : ChartedSpace H { x // x ∈ U } := U.instChartedSpace
+    LiftProp Q (Opens.inclusion hUV : U → V) := by
   intro x
-  show LiftPropAt Q (id ∘ inclusion hUV) x
+  show LiftPropAt Q (id ∘ Opens.inclusion hUV) x
   rw [← hG.liftPropAt_iff_comp_inclusion hUV]
   apply hG.liftProp_id hQ
 

--- a/Mathlib/Geometry/Manifold/Sheaf/Basic.lean
+++ b/Mathlib/Geometry/Manifold/Sheaf/Basic.lean
@@ -55,13 +55,7 @@ def StructureGroupoid.LocalInvariantProp.localPredicate (hG : LocalInvariantProp
   res := by
     intro U V i f h x
     have hUV : U ≤ V := CategoryTheory.leOfHom i
-    #adaptation_note
-    /--
-    After lean4#5020, many instances for Lie algebras and manifolds are no longer found.
-    See https://leanprover.zulipchat.com/#narrow/stream/428973-nightly-testing/topic/.2316244.20adaptations.20for.20nightly-2024-08-28/near/466219124
-    -/
-    letI : ChartedSpace H U := U.instChartedSpace
-    show ChartedSpace.LiftPropAt P (f ∘ Set.inclusion hUV) x
+    show ChartedSpace.LiftPropAt P (f ∘ Opens.inclusion hUV) x
     rw [← hG.liftPropAt_iff_comp_inclusion hUV]
     apply h
   locality := by
@@ -69,7 +63,7 @@ def StructureGroupoid.LocalInvariantProp.localPredicate (hG : LocalInvariantProp
     obtain ⟨U, hxU, i, hU : ChartedSpace.LiftProp P (f ∘ i)⟩ := h x
     let x' : U := ⟨x, hxU⟩
     have hUV : U ≤ V := CategoryTheory.leOfHom i
-    have : ChartedSpace.LiftPropAt P f (inclusion hUV x') := by
+    have : ChartedSpace.LiftPropAt P f (Opens.inclusion hUV x') := by
       rw [hG.liftPropAt_iff_comp_inclusion hUV]
       exact hU x'
     convert this

--- a/Mathlib/Geometry/Manifold/Sheaf/LocallyRingedSpace.lean
+++ b/Mathlib/Geometry/Manifold/Sheaf/LocallyRingedSpace.lean
@@ -94,12 +94,6 @@ theorem smoothSheafCommRing.isUnit_stalk_iff {x : M}
         apply inv_mul_cancel₀
         exact hVf y
     · intro y
-      #adaptation_note
-      /--
-      After lean4#5020, many instances for Lie algebras and manifolds are no longer found.
-      See https://leanprover.zulipchat.com/#narrow/stream/428973-nightly-testing/topic/.2316244.20adaptations.20for.20nightly-2024-08-28/near/466219124
-      -/
-      letI : ChartedSpace HM V := V.instChartedSpace
       exact ((contDiffAt_inv _ (hVf y)).contMDiffAt).comp y
         (f.smooth.comp (smooth_inclusion hUV)).smoothAt
 

--- a/Mathlib/Geometry/RingedSpace/PresheafedSpace.lean
+++ b/Mathlib/Geometry/RingedSpace/PresheafedSpace.lean
@@ -340,7 +340,7 @@ theorem restrict_top_presheaf (X : PresheafedSpace C) :
     (X.restrict (Opens.openEmbedding ⊤)).presheaf =
       (Opens.inclusionTopIso X.carrier).inv _* X.presheaf := by
   dsimp
-  rw [Opens.inclusion_top_functor X.carrier]
+  rw [Opens.inclusion'_top_functor X.carrier]
   rfl
 
 theorem ofRestrict_top_c (X : PresheafedSpace C) :

--- a/Mathlib/Topology/Category/TopCat/OpenNhds.lean
+++ b/Mathlib/Topology/Category/TopCat/OpenNhds.lean
@@ -86,7 +86,7 @@ def inclusion (x : X) : OpenNhds x ⥤ Opens X :=
 theorem inclusion_obj (x : X) (U) (p) : (inclusion x).obj ⟨U, p⟩ = U :=
   rfl
 
-theorem openEmbedding {x : X} (U : OpenNhds x) : OpenEmbedding U.1.inclusion :=
+theorem openEmbedding {x : X} (U : OpenNhds x) : OpenEmbedding U.1.inclusion' :=
   U.1.openEmbedding
 
 /-- The preimage functor from neighborhoods of `f x` to neighborhoods of `x`. -/

--- a/Mathlib/Topology/Category/TopCat/Opens.lean
+++ b/Mathlib/Topology/Category/TopCat/Opens.lean
@@ -111,21 +111,21 @@ theorem toTopCat_map (X : TopCat.{u}) {U V : Opens X} {f : U ⟶ V} {x} {h} :
 /-- The inclusion map from an open subset to the whole space, as a morphism in `TopCat`.
 -/
 @[simps (config := .asFn)]
-def inclusion {X : TopCat.{u}} (U : Opens X) : (toTopCat X).obj U ⟶ X where
+def inclusion' {X : TopCat.{u}} (U : Opens X) : (toTopCat X).obj U ⟶ X where
   toFun := _
   continuous_toFun := continuous_subtype_val
 
 @[simp]
-theorem coe_inclusion {X : TopCat} {U : Opens X} :
-    (inclusion U : U → X) = Subtype.val := rfl
+theorem coe_inclusion' {X : TopCat} {U : Opens X} :
+    (inclusion' U : U → X) = Subtype.val := rfl
 
-theorem openEmbedding {X : TopCat.{u}} (U : Opens X) : OpenEmbedding (inclusion U) :=
+theorem openEmbedding {X : TopCat.{u}} (U : Opens X) : OpenEmbedding (inclusion' U) :=
   IsOpen.openEmbedding_subtype_val U.2
 
 /-- The inclusion of the top open subset (i.e. the whole space) is an isomorphism.
 -/
 def inclusionTopIso (X : TopCat.{u}) : (toTopCat X).obj ⊤ ≅ X where
-  hom := inclusion ⊤
+  hom := inclusion' ⊤
   inv := ⟨fun x => ⟨x, trivial⟩, continuous_def.2 fun U ⟨_, hS, hSU⟩ => hSU ▸ hS⟩
 
 /-- `Opens.map f` gives the functor from open sets in Y to open set in X,
@@ -310,7 +310,7 @@ theorem openEmbedding_obj_top {X : TopCat} (U : Opens X) :
   exact Set.image_univ.trans Subtype.range_coe
 
 @[simp]
-theorem inclusion_map_eq_top {X : TopCat} (U : Opens X) : (Opens.map U.inclusion).obj U = ⊤ := by
+theorem inclusion'_map_eq_top {X : TopCat} (U : Opens X) : (Opens.map U.inclusion').obj U = ⊤ := by
   ext1
   exact Subtype.coe_preimage_self _
 
@@ -318,7 +318,7 @@ theorem inclusion_map_eq_top {X : TopCat} (U : Opens X) : (Opens.map U.inclusion
 theorem adjunction_counit_app_self {X : TopCat} (U : Opens X) :
     U.openEmbedding.isOpenMap.adjunction.counit.app U = eqToHom (by simp) := Subsingleton.elim _ _
 
-theorem inclusion_top_functor (X : TopCat) :
+theorem inclusion'_top_functor (X : TopCat) :
     (@Opens.openEmbedding X ⊤).isOpenMap.functor = map (inclusionTopIso X).inv := by
   refine CategoryTheory.Functor.ext ?_ ?_
   · intro U
@@ -336,8 +336,8 @@ theorem functor_obj_map_obj {X Y : TopCat} {f : X ⟶ Y} (hf : IsOpenMap f) (U :
     exact ⟨x, hx, rfl⟩
 
 -- Porting note: added to ease the proof of `functor_map_eq_inf`
-lemma set_range_forget_map_inclusion {X : TopCat} (U : Opens X) :
-    Set.range ((forget TopCat).map (inclusion U)) = (U : Set X) := by
+lemma set_range_forget_map_inclusion' {X : TopCat} (U : Opens X) :
+    Set.range ((forget TopCat).map (inclusion' U)) = (U : Set X) := by
   ext x
   constructor
   · rintro ⟨x, rfl⟩
@@ -347,10 +347,10 @@ lemma set_range_forget_map_inclusion {X : TopCat} (U : Opens X) :
 
 @[simp]
 theorem functor_map_eq_inf {X : TopCat} (U V : Opens X) :
-    U.openEmbedding.isOpenMap.functor.obj ((Opens.map U.inclusion).obj V) = V ⊓ U := by
+    U.openEmbedding.isOpenMap.functor.obj ((Opens.map U.inclusion').obj V) = V ⊓ U := by
   ext1
   refine Set.image_preimage_eq_inter_range.trans ?_
-  erw [set_range_forget_map_inclusion U]
+  erw [set_range_forget_map_inclusion' U]
   rfl
 
 theorem map_functor_eq' {X U : TopCat} (f : U ⟶ X) (hf : OpenEmbedding f) (V) :
@@ -359,7 +359,7 @@ theorem map_functor_eq' {X U : TopCat} (f : U ⟶ X) (hf : OpenEmbedding f) (V) 
 
 @[simp]
 theorem map_functor_eq {X : TopCat} {U : Opens X} (V : Opens U) :
-    ((Opens.map U.inclusion).obj <| U.openEmbedding.isOpenMap.functor.obj V) = V :=
+    ((Opens.map U.inclusion').obj <| U.openEmbedding.isOpenMap.functor.obj V) = V :=
   TopologicalSpace.Opens.map_functor_eq' _ U.openEmbedding V
 
 @[simp]

--- a/Mathlib/Topology/Gluing.lean
+++ b/Mathlib/Topology/Gluing.lean
@@ -342,8 +342,8 @@ instance (h : MkCore.{u}) (i j : h.J) : IsIso (h.t i j) := by
 
 /-- (Implementation) the restricted transition map to be fed into `TopCat.GlueData`. -/
 def MkCore.t' (h : MkCore.{u}) (i j k : h.J) :
-    pullback (h.V i j).inclusion (h.V i k).inclusion ⟶
-      pullback (h.V j k).inclusion (h.V j i).inclusion := by
+    pullback (h.V i j).inclusion' (h.V i k).inclusion' ⟶
+      pullback (h.V j k).inclusion' (h.V j i).inclusion' := by
   refine (pullbackIsoProdSubtype _ _).hom ≫ ⟨?_, ?_⟩ ≫ (pullbackIsoProdSubtype _ _).inv
   · intro x
     refine ⟨⟨⟨(h.t i j x.1.1).1, ?_⟩, h.t i j x.1.1⟩, rfl⟩
@@ -361,7 +361,7 @@ def mk' (h : MkCore.{u}) : TopCat.GlueData where
   J := h.J
   U := h.U
   V i := (Opens.toTopCat _).obj (h.V i.1 i.2)
-  f i j := (h.V i j).inclusion
+  f i j := (h.V i j).inclusion'
   f_id i := by
     -- Porting note (#12129): additional beta reduction needed
     beta_reduce
@@ -410,7 +410,7 @@ def ofOpenSubsets : TopCat.GlueData.{u} :=
   mk'.{u}
     { J
       U := fun i => (Opens.toTopCat <| TopCat.of α).obj (U i)
-      V := fun i j => (Opens.map <| Opens.inclusion _).obj (U j)
+      V := fun i j => (Opens.map <| Opens.inclusion' _).obj (U j)
       t := fun i j => ⟨fun x => ⟨⟨x.1.1, x.2⟩, x.1.2⟩, by
         -- Porting note: was `continuity`, see https://github.com/leanprover-community/mathlib4/issues/5030
         refine Continuous.subtype_mk ?_ ?_
@@ -429,13 +429,13 @@ This map is an open embedding (`fromOpenSubsetsGlue_openEmbedding`),
 and its range is `⋃ i, (U i : Set α)` (`range_fromOpenSubsetsGlue`).
 -/
 def fromOpenSubsetsGlue : (ofOpenSubsets U).toGlueData.glued ⟶ TopCat.of α :=
-  Multicoequalizer.desc _ _ (fun x => Opens.inclusion _) (by rintro ⟨i, j⟩; ext x; rfl)
+  Multicoequalizer.desc _ _ (fun x => Opens.inclusion' _) (by rintro ⟨i, j⟩; ext x; rfl)
 
 -- Porting note: `elementwise` here produces a bad lemma,
 -- where too much has been simplified, despite the `nosimp`.
 @[simp, elementwise nosimp]
 theorem ι_fromOpenSubsetsGlue (i : J) :
-    (ofOpenSubsets U).toGlueData.ι i ≫ fromOpenSubsetsGlue U = Opens.inclusion _ :=
+    (ofOpenSubsets U).toGlueData.ι i ≫ fromOpenSubsetsGlue U = Opens.inclusion' _ :=
   Multicoequalizer.π_desc _ _ _ _ _
 
 theorem fromOpenSubsetsGlue_injective : Function.Injective (fromOpenSubsetsGlue U) := by
@@ -457,7 +457,7 @@ theorem fromOpenSubsetsGlue_isOpenMap : IsOpenMap (fromOpenSubsetsGlue U) := by
   rw [isOpen_iff_forall_mem_open]
   rintro _ ⟨x, hx, rfl⟩
   obtain ⟨i, ⟨x, hx'⟩, rfl⟩ := (ofOpenSubsets U).ι_jointly_surjective x
-  use fromOpenSubsetsGlue U '' s ∩ Set.range (@Opens.inclusion (TopCat.of α) (U i))
+  use fromOpenSubsetsGlue U '' s ∩ Set.range (@Opens.inclusion' (TopCat.of α) (U i))
   use Set.inter_subset_left
   constructor
   · erw [← Set.image_preimage_eq_inter_range]

--- a/Mathlib/Topology/Sets/Opens.lean
+++ b/Mathlib/Topology/Sets/Opens.lean
@@ -104,7 +104,7 @@ theorem ext {U V : Opens α} (h : (U : Set α) = V) : U = V :=
 theorem coe_inj {U V : Opens α} : (U : Set α) = V ↔ U = V :=
   SetLike.ext'_iff.symm
 
-/-- A version of `Set.inclusion` not required definitional abuse -/
+/-- A version of `Set.inclusion` not requiring definitional abuse -/
 abbrev inclusion {U V : Opens α} (h : U ≤ V) : U → V := Set.inclusion h
 
 protected theorem isOpen (U : Opens α) : IsOpen (U : Set α) :=

--- a/Mathlib/Topology/Sets/Opens.lean
+++ b/Mathlib/Topology/Sets/Opens.lean
@@ -104,6 +104,9 @@ theorem ext {U V : Opens α} (h : (U : Set α) = V) : U = V :=
 theorem coe_inj {U V : Opens α} : (U : Set α) = V ↔ U = V :=
   SetLike.ext'_iff.symm
 
+/-- A version of `Set.inclusion` not required definitional abuse -/
+abbrev inclusion {U V : Opens α} (h : U ≤ V) : U → V := Set.inclusion h
+
 protected theorem isOpen (U : Opens α) : IsOpen (U : Set α) :=
   U.is_open'
 


### PR DESCRIPTION
Currently we use `Set.inclusion` to construct functions between `Opens`. This is a form of defeq abuse which is exposed by leanprover/lean4#5020. In this PR, we introduce `Opens.inclusion` and replace uses of `Set.inclusion` with it to avoid passing through a coercion to `Set`. Since there is a version, not analogous to `Set.inclusion`, squatting on this name we rename it to `Opens.inclusion'`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
