### PR TITLE
chore(Mathlib/Util): sort imports alphabetically

### DIFF
--- a/Mathlib/Util/AddRelatedDecl.lean
+++ b/Mathlib/Util/AddRelatedDecl.lean
@@ -3,9 +3,9 @@ Copyright (c) 2023 Scott Morrison. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Scott Morrison, Floris van Doorn
 -/
-import Mathlib.Init
 import Lean.Elab.DeclarationRange
 import Lean.Elab.Term
+import Mathlib.Init
 
 /-!
 # `addRelatedDecl`

--- a/Mathlib/Util/AssertExists.lean
+++ b/Mathlib/Util/AssertExists.lean
@@ -3,8 +3,8 @@ Copyright (c) 2022 Scott Morrison. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Patrick Massot, Scott Morrison
 -/
-import Mathlib.Init
 import Lean.Elab.Command
+import Mathlib.Init
 import Mathlib.Util.AssertExistsExt
 
 /-!

--- a/Mathlib/Util/AssertNoSorry.lean
+++ b/Mathlib/Util/AssertNoSorry.lean
@@ -4,9 +4,9 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: David Renshaw
 -/
 
-import Mathlib.Init
-import Lean.Util.CollectAxioms
 import Lean.Elab.Command
+import Lean.Util.CollectAxioms
+import Mathlib.Init
 
 /-!
 # Defines the `assert_no_sorry` command.

--- a/Mathlib/Util/AtomM.lean
+++ b/Mathlib/Util/AtomM.lean
@@ -3,8 +3,8 @@ Copyright (c) 2023 Mario Carneiro. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Mario Carneiro
 -/
-import Mathlib.Init
 import Lean.Meta.Tactic.Simp.Types
+import Mathlib.Init
 
 /-!
 # A monad for tracking and deduplicating atoms

--- a/Mathlib/Util/CompileInductive.lean
+++ b/Mathlib/Util/CompileInductive.lean
@@ -3,11 +3,11 @@ Copyright (c) 2023 Parth Shastri. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Parth Shastri, Gabriel Ebner, Mario Carneiro
 -/
-import Mathlib.Init
-import Lean.Elab.Command
 import Lean.Compiler.CSimpAttr
-import Lean.Util.FoldConsts
 import Lean.Data.AssocList
+import Lean.Elab.Command
+import Lean.Util.FoldConsts
+import Mathlib.Init
 
 /-!
 # Define the `compile_inductive%` command.

--- a/Mathlib/Util/CountHeartbeats.lean
+++ b/Mathlib/Util/CountHeartbeats.lean
@@ -3,9 +3,9 @@ Copyright (c) 2023 Scott Morrison. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Scott Morrison
 -/
-import Mathlib.Init
-import Lean.Util.Heartbeats
 import Lean.Meta.Tactic.TryThis
+import Lean.Util.Heartbeats
+import Mathlib.Init
 
 /-!
 Defines a command wrapper that prints the number of heartbeats used in the enclosed command.

--- a/Mathlib/Util/Delaborators.lean
+++ b/Mathlib/Util/Delaborators.lean
@@ -3,8 +3,8 @@ Copyright (c) 2023 Kyle Miller. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Kyle Miller
 -/
-import Mathlib.Init
 import Lean.PrettyPrinter.Delaborator.Builtins
+import Mathlib.Init
 
 /-! # Pi type notation
 

--- a/Mathlib/Util/DischargerAsTactic.lean
+++ b/Mathlib/Util/DischargerAsTactic.lean
@@ -3,10 +3,10 @@ Copyright (c) 2023 Alex J. Best. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Alex J. Best
 -/
-import Mathlib.Init
+import Batteries.Tactic.Exact
 import Lean.Elab.Tactic.Basic
 import Lean.Meta.Tactic.Simp.Rewrite
-import Batteries.Tactic.Exact
+import Mathlib.Init
 
 /-!
 ## Dischargers for `simp` to tactics

--- a/Mathlib/Util/Export.lean
+++ b/Mathlib/Util/Export.lean
@@ -3,9 +3,9 @@ Copyright (c) 2021 Microsoft Corporation. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Mario Carneiro
 -/
-import Mathlib.Init
 import Lean.CoreM
 import Lean.Util.FoldConsts
+import Mathlib.Init
 
 /-!
 A rudimentary export format, adapted from

--- a/Mathlib/Util/GetAllModules.lean
+++ b/Mathlib/Util/GetAllModules.lean
@@ -4,8 +4,8 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Mario Carneiro, Kim Morrison, Damiano Testa
 -/
 
-import Mathlib.Init
 import Lean.Util.Path
+import Mathlib.Init
 
 /-!
 # Utility functions for finding all `.lean` files or modules in a project.

--- a/Mathlib/Util/IncludeStr.lean
+++ b/Mathlib/Util/IncludeStr.lean
@@ -3,8 +3,8 @@ Copyright (c) 2021 Henrik Böving. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Henrik Böving, Xubai Wang
 -/
-import Mathlib.Init
 import Lean
+import Mathlib.Init
 
 /-!
 # Defines the `include_str` macro.

--- a/Mathlib/Util/LongNames.lean
+++ b/Mathlib/Util/LongNames.lean
@@ -3,9 +3,9 @@ Copyright (c) 2023 Scott Morrison. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Scott Morrison
 -/
-import Mathlib.Lean.Name
-import Mathlib.Lean.Expr.Basic
 import Lean.Elab.Command
+import Mathlib.Lean.Expr.Basic
+import Mathlib.Lean.Name
 
 /-!
 # Commands `#long_names` and `#long_instances`

--- a/Mathlib/Util/MemoFix.lean
+++ b/Mathlib/Util/MemoFix.lean
@@ -3,8 +3,8 @@ Copyright (c) 2022 Gabriel Ebner. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Gabriel Ebner, Edward Ayers
 -/
-import Std.Data.HashMap.Basic
 import Mathlib.Init
+import Std.Data.HashMap.Basic
 
 /-!
 # Fixpoint function with memoisation

--- a/Mathlib/Util/Notation3.lean
+++ b/Mathlib/Util/Notation3.lean
@@ -3,12 +3,12 @@ Copyright (c) 2021 Microsoft Corporation. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Mario Carneiro, Kyle Miller
 -/
+import Batteries.Lean.Syntax
+import Batteries.Linter.UnreachableTactic
+import Batteries.Util.ExtendedBinder
 import Mathlib.Lean.Elab.Term
 import Mathlib.Lean.PrettyPrinter.Delaborator
 import Mathlib.Tactic.ScopedNS
-import Batteries.Linter.UnreachableTactic
-import Batteries.Util.ExtendedBinder
-import Batteries.Lean.Syntax
 
 /-!
 # The notation3 macro, simulating Lean 3's notation.

--- a/Mathlib/Util/SleepHeartbeats.lean
+++ b/Mathlib/Util/SleepHeartbeats.lean
@@ -3,8 +3,8 @@ Copyright (c) 2023 Alex J. Best. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Alex J. Best
 -/
-import Mathlib.Init
 import Lean.Elab.Tactic.Basic
+import Mathlib.Init
 
 /-!
 # Defines `sleep_heartbeats` tactic.

--- a/Mathlib/Util/Superscript.lean
+++ b/Mathlib/Util/Superscript.lean
@@ -3,8 +3,8 @@ Copyright (c) 2023 Mario Carneiro. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Mario Carneiro
 -/
-import Mathlib.Init
 import Batteries.Tactic.Lint
+import Mathlib.Init
 
 /-!
 # A parser for superscripts and subscripts

--- a/Mathlib/Util/SynthesizeUsing.lean
+++ b/Mathlib/Util/SynthesizeUsing.lean
@@ -3,8 +3,8 @@ Copyright (c) 2022 Scott Morrison. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Scott Morrison
 -/
-import Mathlib.Init
 import Lean.Elab.Tactic.Basic
+import Mathlib.Init
 import Qq
 
 /-!

--- a/Mathlib/Util/Tactic.lean
+++ b/Mathlib/Util/Tactic.lean
@@ -3,8 +3,8 @@ Copyright (c) 2022 Arthur Paulino. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Arthur Paulino, Jannis Limperg
 -/
-import Mathlib.Init
 import Lean.MetavarContext
+import Mathlib.Init
 
 /-!
 # Miscellaneous helper functions for tactics.

--- a/Mathlib/Util/TermBeta.lean
+++ b/Mathlib/Util/TermBeta.lean
@@ -3,8 +3,8 @@ Copyright (c) 2023 Kyle Miller. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Kyle Miller
 -/
-import Mathlib.Init
 import Lean.Elab.Term
+import Mathlib.Init
 
 /-! `beta%` term elaborator
 

--- a/Mathlib/Util/WhatsNew.lean
+++ b/Mathlib/Util/WhatsNew.lean
@@ -3,8 +3,8 @@ Copyright (c) 2021 Microsoft Corporation. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Gabriel Ebner
 -/
-import Mathlib.Init
 import Lean
+import Mathlib.Init
 
 /-!
 Defines a command wrapper that prints the changes the command makes to the

--- a/Mathlib/Util/WithWeakNamespace.lean
+++ b/Mathlib/Util/WithWeakNamespace.lean
@@ -4,8 +4,8 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Mario Carneiro, Daniel Selsam, Gabriel Ebner
 -/
 
-import Mathlib.Init
 import Lean
+import Mathlib.Init
 
 /-!
 # Defines `with_weak_namespace` command.


### PR DESCRIPTION
This is easier to read and maintain (and could reduce merge conflicts, for example). Benchmarking results are neutral.

---
Context: #16419, of which this PR is a subset.

To verify that all modified lines in the last commit are import statements:

`% git diff HEAD~1 | grep '^[+-][^+-]' | cut -c2- | grep -v '^import '`

To verify that the total number of changes (additions and deletions) for any specific import statement is even:

`% git diff HEAD~1 | grep '^[+-][^+-]' | cut -c2- | sort | uniq -c | grep -v '[02468] import'`