### PR TITLE
[Merged by Bors] - fix(add_label_from_*): whitelist bots, create workflow for review comments

### DIFF
--- a/.github/workflows/add_label_from_review.yml
+++ b/.github/workflows/add_label_from_review.yml
@@ -10,47 +10,13 @@ jobs:
     if: (startsWith(github.event.review.body, 'bors r+') || contains(toJSON(github.event.review.body), '\nbors r+') || startsWith(github.event.review.body, 'bors merge') || contains(toJSON(github.event.review.body), '\nbors merge'))
     runs-on: ubuntu-latest
     steps:
-      - uses: octokit/request-action@v2.x
-        name: Get PR head
-        id: get_pr_head
+      - id: user_permission
+        uses: actions-cool/check-user-permission@v2
         with:
-          route: GET /repos/:repository/pulls/:pull_number
-          repository: ${{ github.repository }}
-          pull_number: ${{ github.event.pull_request.number }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.TRIAGE_TOKEN }}
+          require: 'write'
+          token: ${{ secrets.TRIAGE_TOKEN }}
 
-      # Parse steps.get_pr_head.outputs.data, since it is a string
-      - id: parse_pr_head
-        name: Parse PR head
-        uses: gr2m/get-json-paths-action@v1.x
-        with:
-          json: ${{ steps.get_pr_head.outputs.data }}
-          head_user: 'head.user.login'
-
-      # we skip the rest if this PR is from a fork,
-      # since the GITHUB_TOKEN doesn't have write perms
-      - if: steps.parse_pr_head.outputs.head_user == 'leanprover-community'
-        uses: octokit/request-action@v2.x
-        name: Get comment author
-        id: get_user
-        with:
-          route: GET /repos/:repository/collaborators/:username/permission
-          repository: ${{ github.repository }}
-          username: ${{ github.event.review.user.login }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.TRIAGE_TOKEN }}
-
-      # Parse steps.get_user.outputs.data, since it is a string
-      - if: steps.parse_pr_head.outputs.head_user == 'leanprover-community'
-        id: parse_user
-        name: Parse comment author permission
-        uses: gr2m/get-json-paths-action@v1.x
-        with:
-          json: ${{ steps.get_user.outputs.data }}
-          permission: 'permission'
-
-      - if: (steps.parse_pr_head.outputs.head_user == 'leanprover-community') && (steps.parse_user.outputs.permission == 'admin')
+      - if: (steps.user_permission.outputs.require-result == 'true') || (github.event.review.user.login == 'leanprover-community-mathlib4-bot') || (github.event.review.user.login == 'leanprover-community-bot-assistant')
         uses: octokit/request-action@v2.x
         id: add_label
         name: Add label
@@ -62,7 +28,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.TRIAGE_TOKEN }}
 
-      - if: (steps.parse_pr_head.outputs.head_user == 'leanprover-community') && (steps.parse_user.outputs.permission == 'admin')
+      - if: (steps.user_permission.outputs.require-result == 'true') || (github.event.review.user.login == 'leanprover-community-mathlib4-bot') || (github.event.review.user.login == 'leanprover-community-bot-assistant')
         id: remove_labels
         name: Remove "awaiting-author"
         # we use curl rather than octokit/request-action so that the job won't fail
@@ -77,47 +43,13 @@ jobs:
     if: (startsWith(github.event.review.body, 'bors d') || contains(toJSON(github.event.review.body), '\nbors d'))
     runs-on: ubuntu-latest
     steps:
-      - uses: octokit/request-action@v2.x
-        name: Get PR head
-        id: get_pr_head
+      - id: user_permission
+        uses: actions-cool/check-user-permission@v2
         with:
-          route: GET /repos/:repository/pulls/:pull_number
-          repository: ${{ github.repository }}
-          pull_number: ${{ github.event.pull_request.number }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.TRIAGE_TOKEN }}
+          require: 'write'
+          token: ${{ secrets.TRIAGE_TOKEN }}
 
-      # Parse steps.get_pr_head.outputs.data, since it is a string
-      - id: parse_pr_head
-        name: Parse PR head
-        uses: gr2m/get-json-paths-action@v1.x
-        with:
-          json: ${{ steps.get_pr_head.outputs.data }}
-          head_user: 'head.user.login'
-
-      # we skip the rest if this PR is from a fork,
-      # since the GITHUB_TOKEN doesn't have write perms
-      - if: steps.parse_pr_head.outputs.head_user == 'leanprover-community'
-        uses: octokit/request-action@v2.x
-        name: Get comment author
-        id: get_user
-        with:
-          route: GET /repos/:repository/collaborators/:username/permission
-          repository: ${{ github.repository }}
-          username: ${{ github.event.review.user.login }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.TRIAGE_TOKEN }}
-
-      # Parse steps.get_user.outputs.data, since it is a string
-      - if: steps.parse_pr_head.outputs.head_user == 'leanprover-community'
-        id: parse_user
-        name: Parse comment author permission
-        uses: gr2m/get-json-paths-action@v1.x
-        with:
-          json: ${{ steps.get_user.outputs.data }}
-          permission: 'permission'
-
-      - if: (steps.parse_pr_head.outputs.head_user == 'leanprover-community') && (steps.parse_user.outputs.permission == 'admin')
+      - if: (steps.user_permission.outputs.require-result == 'true') || (github.event.review.user.login == 'leanprover-community-mathlib4-bot') || (github.event.review.user.login == 'leanprover-community-bot-assistant')
         uses: octokit/request-action@v2.x
         id: add_label
         name: Add label

--- a/.github/workflows/add_label_from_review_comment.yml
+++ b/.github/workflows/add_label_from_review_comment.yml
@@ -1,19 +1,20 @@
-name: Add "ready-to-merge" and "delegated" label from comment
+name: Add "ready-to-merge" and "delegated" label from PR review comment
 
 on:
-  issue_comment:
+  pull_request_review_comment:
     types: [created]
 
 jobs:
   add_ready_to_merge_label:
     name: Add ready-to-merge label
-    if: github.event.issue.pull_request && (startsWith(github.event.comment.body, 'bors r+') || contains(toJSON(github.event.comment.body), '\nbors r+') || startsWith(github.event.comment.body, 'bors merge') || contains(toJSON(github.event.comment.body), '\nbors merge'))
+    if: (startsWith(github.event.comment.body, 'bors r+') || contains(toJSON(github.event.comment.body), '\nbors r+') || startsWith(github.event.comment.body, 'bors merge') || contains(toJSON(github.event.comment.body), '\nbors merge'))
     runs-on: ubuntu-latest
     steps:
       - id: user_permission
         uses: actions-cool/check-user-permission@v2
         with:
-          require: 'admin'
+          require: 'write'
+          token: ${{ secrets.TRIAGE_TOKEN }}
 
       - if: (steps.user_permission.outputs.require-result == 'true') || (github.event.comment.user.login == 'leanprover-community-mathlib4-bot') || (github.event.comment.user.login == 'leanprover-community-bot-assistant')
         uses: octokit/request-action@v2.x
@@ -22,10 +23,10 @@ jobs:
         with:
           route: POST /repos/:repository/issues/:issue_number/labels
           repository: ${{ github.repository }}
-          issue_number: ${{ github.event.issue.number }}
+          issue_number: ${{ github.event.pull_request.number }}
           labels: '["ready-to-merge"]'
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.TRIAGE_TOKEN }}
 
       - if: (steps.user_permission.outputs.require-result == 'true') || (github.event.comment.user.login == 'leanprover-community-mathlib4-bot') || (github.event.comment.user.login == 'leanprover-community-bot-assistant')
         id: remove_labels
@@ -34,18 +35,19 @@ jobs:
         # (and send an annoying email) if the labels don't exist
         run: |
           curl --request DELETE \
-            --url https://api.github.com/repos/${{ github.repository }}/issues/${{ github.event.issue.number }}/labels/awaiting-author \
-            --header 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}'
+            --url https://api.github.com/repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/labels/awaiting-author \
+            --header 'authorization: Bearer ${{ secrets.TRIAGE_TOKEN }}'
 
   add_delegated_label:
     name: Add delegated label
-    if: github.event.issue.pull_request && (startsWith(github.event.comment.body, 'bors d') || contains(toJSON(github.event.comment.body), '\nbors d'))
+    if: (startsWith(github.event.comment.body, 'bors d') || contains(toJSON(github.event.comment.body), '\nbors d'))
     runs-on: ubuntu-latest
     steps:
       - id: user_permission
         uses: actions-cool/check-user-permission@v2
         with:
-          require: 'admin'
+          require: 'write'
+          token: ${{ secrets.TRIAGE_TOKEN }}
 
       - if: (steps.user_permission.outputs.require-result == 'true') || (github.event.comment.user.login == 'leanprover-community-mathlib4-bot') || (github.event.comment.user.login == 'leanprover-community-bot-assistant')
         uses: octokit/request-action@v2.x
@@ -54,7 +56,7 @@ jobs:
         with:
           route: POST /repos/:repository/issues/:issue_number/labels
           repository: ${{ github.repository }}
-          issue_number: ${{ github.event.issue.number }}
+          issue_number: ${{ github.event.pull_request.number }}
           labels: '["delegated"]'
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.TRIAGE_TOKEN }}


### PR DESCRIPTION
Currently leanprover-community-mathlib4-bot and leanprover-community-bot-assistant write `bors merge` on PRs but the PRs do not get the ready-to-merge label because the workflow checks that the user has admin permissions. This usually wouldn't matter, but our "update dependencies" workflow uses the "ready-to-merge" label to determine whether to push another commit to its branch, so for example [this PR](https://github.com/leanprover-community/mathlib4/pull/16508#issuecomment-2331777031) got canceled by a bot push when it was already on the bors queue.

In this PR I whitelist these two bots, and also take the opportunity to update these old workflows, replacing some outdated actions with the permission checking action we're using in the "bot fix style" workflows. 

One side effect is that these workflows will now run in forks if CI is enabled, which I think is (1) not a problem (2) probably extremely rare. (Anyone who wants them to work properly in their fork will need to create a repo secret named "TRIAGE_TOKEN" with public_repo permissions.)

Finally, I create the until-now-missing workflow that responds to review comments.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)

Everything has been tested in my fork of mathlib4: https://github.com/bryangingechen/mathlib4/pull/11