### PR TITLE
feat(Logic/Small/Defs): `Small.{max u v, u} α`

### DIFF
--- a/Mathlib/Logic/Small/Defs.lean
+++ b/Mathlib/Logic/Small/Defs.lean
@@ -67,6 +67,9 @@ theorem small_map {α : Type*} {β : Type*} [hβ : Small.{w} β] (e : α ≃ β)
   let ⟨_, ⟨f⟩⟩ := hβ.equiv_small
   Small.mk' (e.trans f)
 
+instance small_ulift (α : Type u) [Small.{v} α] : Small.{v} (ULift.{w} α) :=
+  small_map Equiv.ulift
+
 theorem small_lift (α : Type u) [hα : Small.{v} α] : Small.{max v w} α :=
   let ⟨⟨_, ⟨f⟩⟩⟩ := hα
   Small.mk' <| f.trans (Equiv.ulift.{w}).symm
@@ -80,16 +83,13 @@ lemma small_max (α : Type v) : Small.{max w v} α :=
   inferInstance
 
 lemma small_zero (α : Type) : Small.{w} α :=
-  small_max α
+  inferInstance
 
-instance (priority := 100) small_succ (α : Type v) : Small.{v + 1} α :=
-  small_max.{v + 1} α
-
-instance small_ulift (α : Type u) [Small.{v} α] : Small.{v} (ULift.{w} α) :=
-  small_map Equiv.ulift
+lemma small_succ (α : Type v) : Small.{v + 1} α :=
+  inferInstance
 
 theorem small_type : Small.{max (u + 1) v} (Type u) :=
-  small_max.{max (u + 1) v} _
+  inferInstance
 
 section
 

--- a/Mathlib/Logic/Small/Defs.lean
+++ b/Mathlib/Logic/Small/Defs.lean
@@ -71,14 +71,19 @@ theorem small_lift (α : Type u) [hα : Small.{v} α] : Small.{max v w} α :=
   let ⟨⟨_, ⟨f⟩⟩⟩ := hα
   Small.mk' <| f.trans (Equiv.ulift.{w}).symm
 
-/- This was an instance but useless due to https://github.com/leanprover/lean4/issues/2297. -/
+/- Once https://github.com/leanprover/lean4/issues/2297 is fixed, this should be deprecated
+in favor of `small_max`. -/
+instance (priority := 50) small_of_lift (α : Type v) [Small.{u} (ULift.{u} α)] : Small.{u} α :=
+  small_map Equiv.ulift.symm
+
 lemma small_max (α : Type v) : Small.{max w v} α :=
-  small_lift.{v, w} α
+  inferInstance
 
-instance small_zero (α : Type) : Small.{w} α := small_max α
+lemma small_zero (α : Type) : Small.{w} α :=
+  small_max α
 
-instance (priority := 100) small_succ (α : Type v) : Small.{v+1} α :=
-  small_lift.{v, v+1} α
+instance (priority := 100) small_succ (α : Type v) : Small.{v + 1} α :=
+  small_max.{v + 1} α
 
 instance small_ulift (α : Type u) [Small.{v} α] : Small.{v} (ULift.{w} α) :=
   small_map Equiv.ulift

--- a/Mathlib/Logic/Small/Defs.lean
+++ b/Mathlib/Logic/Small/Defs.lean
@@ -79,6 +79,8 @@ in favor of `small_max`. -/
 instance (priority := 50) small_of_lift (α : Type v) [Small.{u} (ULift.{u} α)] : Small.{u} α :=
   small_map Equiv.ulift.symm
 
+-- A `Small.{max w v} α` instance for `α : Type v` is found from
+-- `Small.{max u v, max u v} (ULift.{w} α)`.
 lemma small_max (α : Type v) : Small.{max w v} α := inferInstance
 lemma small_zero (α : Type) : Small.{w} α := inferInstance
 lemma small_succ (α : Type v) : Small.{v + 1} α := inferInstance

--- a/Mathlib/Logic/Small/Defs.lean
+++ b/Mathlib/Logic/Small/Defs.lean
@@ -79,17 +79,10 @@ in favor of `small_max`. -/
 instance (priority := 50) small_of_lift (α : Type v) [Small.{u} (ULift.{u} α)] : Small.{u} α :=
   small_map Equiv.ulift.symm
 
-lemma small_max (α : Type v) : Small.{max w v} α :=
-  inferInstance
-
-lemma small_zero (α : Type) : Small.{w} α :=
-  inferInstance
-
-lemma small_succ (α : Type v) : Small.{v + 1} α :=
-  inferInstance
-
-theorem small_type : Small.{max (u + 1) v} (Type u) :=
-  inferInstance
+lemma small_max (α : Type v) : Small.{max w v} α := inferInstance
+lemma small_zero (α : Type) : Small.{w} α := inferInstance
+lemma small_succ (α : Type v) : Small.{v + 1} α := inferInstance
+lemma small_type : Small.{max (u + 1) v} (Type u) := inferInstance
 
 section
 


### PR DESCRIPTION
By using @alreadydone's suggestion on https://github.com/leanprover/lean4/issues/2297#issuecomment-1767008247, we can make it so that typeclass inference can find a `Small.{max u v} α` instance for `α : Type u`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

`small_of_lift` loops with itself, is that a problem? Are there any performance issues that could arise out of this?

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
