### PR TITLE
[Merged by Bors] - refactor(Order/SuccPred/Limit): `IsSuccLimit` → `IsSuccPrelimit`

### DIFF
--- a/Mathlib/Order/SuccPred/CompleteLinearOrder.lean
+++ b/Mathlib/Order/SuccPred/CompleteLinearOrder.lean
@@ -8,7 +8,7 @@ import Mathlib.Order.ConditionallyCompleteLattice.Basic
 
 /-!
 
-# Relation between `IsSuccLimit` and `iSup` in (conditionally) complete linear orders.
+# Relation between `IsSuccPrelimit` and `iSup` in (conditionally) complete linear orders.
 
 -/
 
@@ -19,45 +19,69 @@ variable {ι α : Type*}
 section ConditionallyCompleteLinearOrder
 variable [ConditionallyCompleteLinearOrder α] [Nonempty ι] {f : ι → α} {s : Set α} {x : α}
 
-lemma csSup_mem_of_not_isSuccLimit
-    (hne : s.Nonempty) (hbdd : BddAbove s) (hlim : ¬ IsSuccLimit (sSup s)) :
+lemma csSup_mem_of_not_isSuccPrelimit
+    (hne : s.Nonempty) (hbdd : BddAbove s) (hlim : ¬ IsSuccPrelimit (sSup s)) :
     sSup s ∈ s := by
   obtain ⟨y, hy⟩ := not_forall_not.mp hlim
   obtain ⟨i, his, hi⟩ := exists_lt_of_lt_csSup hne hy.lt
   exact eq_of_le_of_not_lt (le_csSup hbdd his) (hy.2 hi) ▸ his
 
-lemma csInf_mem_of_not_isPredLimit
-    (hne : s.Nonempty) (hbdd : BddBelow s) (hlim : ¬ IsPredLimit (sInf s)) :
+@[deprecated csSup_mem_of_not_isSuccPrelimit (since := "2024-09-05")]
+alias csSup_mem_of_not_isSuccLimit := csSup_mem_of_not_isSuccPrelimit
+
+lemma csInf_mem_of_not_isPredPrelimit
+    (hne : s.Nonempty) (hbdd : BddBelow s) (hlim : ¬ IsPredPrelimit (sInf s)) :
     sInf s ∈ s := by
   obtain ⟨y, hy⟩ := not_forall_not.mp hlim
   obtain ⟨i, his, hi⟩ := exists_lt_of_csInf_lt hne hy.lt
   exact eq_of_le_of_not_lt (csInf_le hbdd his) (hy.2 · hi) ▸ his
 
-lemma exists_eq_ciSup_of_not_isSuccLimit
-    (hf : BddAbove (Set.range f)) (hf' : ¬ IsSuccLimit (⨆ i, f i)) :
+@[deprecated csInf_mem_of_not_isPredPrelimit (since := "2024-09-05")]
+alias csInf_mem_of_not_isPredLimit := csInf_mem_of_not_isPredPrelimit
+
+lemma exists_eq_ciSup_of_not_isSuccPrelimit
+    (hf : BddAbove (Set.range f)) (hf' : ¬ IsSuccPrelimit (⨆ i, f i)) :
     ∃ i, f i = ⨆ i, f i :=
-  csSup_mem_of_not_isSuccLimit (Set.range_nonempty f) hf hf'
+  csSup_mem_of_not_isSuccPrelimit (Set.range_nonempty f) hf hf'
 
-lemma exists_eq_ciInf_of_not_isPredLimit
-    (hf : BddBelow (Set.range f)) (hf' : ¬ IsPredLimit (⨅ i, f i)) :
+@[deprecated exists_eq_ciSup_of_not_isSuccPrelimit (since := "2024-09-05")]
+alias exists_eq_ciSup_of_not_isSuccLimit := exists_eq_ciSup_of_not_isSuccPrelimit
+
+lemma exists_eq_ciInf_of_not_isPredPrelimit
+    (hf : BddBelow (Set.range f)) (hf' : ¬ IsPredPrelimit (⨅ i, f i)) :
     ∃ i, f i = ⨅ i, f i :=
-  csInf_mem_of_not_isPredLimit (Set.range_nonempty f) hf hf'
+  csInf_mem_of_not_isPredPrelimit (Set.range_nonempty f) hf hf'
 
-lemma IsLUB.mem_of_nonempty_of_not_isSuccLimit
-    (hs : IsLUB s x) (hne : s.Nonempty) (hx : ¬ IsSuccLimit x) : x ∈ s :=
-  hs.csSup_eq hne ▸ csSup_mem_of_not_isSuccLimit hne hs.bddAbove (hs.csSup_eq hne ▸ hx)
+@[deprecated exists_eq_ciInf_of_not_isPredPrelimit (since := "2024-09-05")]
+alias exists_eq_ciInf_of_not_isPredLimit := exists_eq_ciInf_of_not_isPredPrelimit
 
-lemma IsGLB.mem_of_nonempty_of_not_isPredLimit
-    (hs : IsGLB s x) (hne : s.Nonempty) (hx : ¬ IsPredLimit x) : x ∈ s :=
-  hs.csInf_eq hne ▸ csInf_mem_of_not_isPredLimit hne hs.bddBelow (hs.csInf_eq hne ▸ hx)
+lemma IsLUB.mem_of_nonempty_of_not_isSuccPrelimit
+    (hs : IsLUB s x) (hne : s.Nonempty) (hx : ¬ IsSuccPrelimit x) : x ∈ s :=
+  hs.csSup_eq hne ▸ csSup_mem_of_not_isSuccPrelimit hne hs.bddAbove (hs.csSup_eq hne ▸ hx)
 
-lemma IsLUB.exists_of_nonempty_of_not_isSuccLimit
-    (hf : IsLUB (Set.range f) x) (hx : ¬ IsSuccLimit x) :
-    ∃ i, f i = x := hf.mem_of_nonempty_of_not_isSuccLimit (Set.range_nonempty f) hx
+@[deprecated IsLUB.mem_of_nonempty_of_not_isSuccPrelimit (since := "2024-09-05")]
+alias IsLUB.mem_of_nonempty_of_not_isSuccLimit := IsLUB.mem_of_nonempty_of_not_isSuccPrelimit
 
-lemma IsGLB.exists_of_nonempty_of_not_isPredLimit
-    (hf : IsGLB (Set.range f) x) (hx : ¬ IsPredLimit x) :
-    ∃ i, f i = x := hf.mem_of_nonempty_of_not_isPredLimit (Set.range_nonempty f) hx
+lemma IsGLB.mem_of_nonempty_of_not_isPredPrelimit
+    (hs : IsGLB s x) (hne : s.Nonempty) (hx : ¬ IsPredPrelimit x) : x ∈ s :=
+  hs.csInf_eq hne ▸ csInf_mem_of_not_isPredPrelimit hne hs.bddBelow (hs.csInf_eq hne ▸ hx)
+
+@[deprecated IsGLB.mem_of_nonempty_of_not_isPredPrelimit (since := "2024-09-05")]
+alias IsGLB.mem_of_nonempty_of_not_isPredLimit := IsGLB.mem_of_nonempty_of_not_isPredPrelimit
+
+lemma IsLUB.exists_of_nonempty_of_not_isSuccPrelimit
+    (hf : IsLUB (Set.range f) x) (hx : ¬ IsSuccPrelimit x) :
+    ∃ i, f i = x := hf.mem_of_nonempty_of_not_isSuccPrelimit (Set.range_nonempty f) hx
+
+@[deprecated IsLUB.exists_of_nonempty_of_not_isSuccPrelimit (since := "2024-09-05")]
+alias IsLUB.exists_of_nonempty_of_not_isSuccLimit := IsLUB.exists_of_nonempty_of_not_isSuccPrelimit
+
+lemma IsGLB.exists_of_nonempty_of_not_isPredPrelimit
+    (hf : IsGLB (Set.range f) x) (hx : ¬ IsPredPrelimit x) :
+    ∃ i, f i = x := hf.mem_of_nonempty_of_not_isPredPrelimit (Set.range_nonempty f) hx
+
+@[deprecated IsGLB.exists_of_nonempty_of_not_isPredPrelimit (since := "2024-09-05")]
+alias IsGLB.exists_of_nonempty_of_not_isPredLimit := IsGLB.exists_of_nonempty_of_not_isPredPrelimit
 
 open Classical in
 /-- Every conditionally complete linear order with well-founded `<` is a successor order, by setting
@@ -85,60 +109,90 @@ end ConditionallyCompleteLinearOrder
 section ConditionallyCompleteLinearOrderBot
 variable [ConditionallyCompleteLinearOrderBot α] {f : ι → α} {s : Set α} {x : α}
 
-/-- See `csSup_mem_of_not_isSuccLimit` for the `ConditionallyCompleteLinearOrder` version. -/
-lemma csSup_mem_of_not_isSuccLimit'
-    (hbdd : BddAbove s) (hlim : ¬ IsSuccLimit (sSup s)) :
+/-- See `csSup_mem_of_not_isSuccPrelimit` for the `ConditionallyCompleteLinearOrder` version. -/
+lemma csSup_mem_of_not_isSuccPrelimit'
+    (hbdd : BddAbove s) (hlim : ¬ IsSuccPrelimit (sSup s)) :
     sSup s ∈ s := by
   obtain (rfl|hs) := s.eq_empty_or_nonempty
-  · simp [isSuccLimit_bot] at hlim
-  · exact csSup_mem_of_not_isSuccLimit hs hbdd hlim
+  · simp [isSuccPrelimit_bot] at hlim
+  · exact csSup_mem_of_not_isSuccPrelimit hs hbdd hlim
 
-/-- See `exists_eq_ciSup_of_not_isSuccLimit` for the
+@[deprecated csSup_mem_of_not_isSuccPrelimit' (since := "2024-09-05")]
+alias csSup_mem_of_not_isSuccLimit' := csSup_mem_of_not_isSuccPrelimit'
+
+/-- See `exists_eq_ciSup_of_not_isSuccPrelimit` for the
 `ConditionallyCompleteLinearOrder` version. -/
-lemma exists_eq_ciSup_of_not_isSuccLimit'
-    (hf : BddAbove (Set.range f)) (hf' : ¬ IsSuccLimit (⨆ i, f i)) :
+lemma exists_eq_ciSup_of_not_isSuccPrelimit'
+    (hf : BddAbove (Set.range f)) (hf' : ¬ IsSuccPrelimit (⨆ i, f i)) :
     ∃ i, f i = ⨆ i, f i :=
-  csSup_mem_of_not_isSuccLimit' hf hf'
+  csSup_mem_of_not_isSuccPrelimit' hf hf'
 
-lemma IsLUB.mem_of_not_isSuccLimit (hs : IsLUB s x) (hx : ¬ IsSuccLimit x) :
+@[deprecated exists_eq_ciSup_of_not_isSuccPrelimit' (since := "2024-09-05")]
+alias exists_eq_ciSup_of_not_isSuccLimit' := exists_eq_ciSup_of_not_isSuccPrelimit'
+
+lemma IsLUB.mem_of_not_isSuccPrelimit (hs : IsLUB s x) (hx : ¬ IsSuccPrelimit x) :
     x ∈ s := by
   obtain (rfl|hs') := s.eq_empty_or_nonempty
-  · simp [show x = ⊥ by simpa using hs, isSuccLimit_bot] at hx
-  · exact hs.mem_of_nonempty_of_not_isSuccLimit hs' hx
+  · simp [show x = ⊥ by simpa using hs, isSuccPrelimit_bot] at hx
+  · exact hs.mem_of_nonempty_of_not_isSuccPrelimit hs' hx
 
-lemma IsLUB.exists_of_not_isSuccLimit (hf : IsLUB (Set.range f) x) (hx : ¬ IsSuccLimit x) :
-    ∃ i, f i = x := hf.mem_of_not_isSuccLimit hx
+@[deprecated IsLUB.mem_of_not_isSuccPrelimit (since := "2024-09-05")]
+alias IsLUB.mem_of_not_isSuccLimit := IsLUB.mem_of_not_isSuccPrelimit
+
+lemma IsLUB.exists_of_not_isSuccPrelimit (hf : IsLUB (Set.range f) x) (hx : ¬ IsSuccPrelimit x) :
+    ∃ i, f i = x := hf.mem_of_not_isSuccPrelimit hx
+
+@[deprecated IsLUB.exists_of_not_isSuccPrelimit (since := "2024-09-05")]
+alias IsLUB.exists_of_not_isSuccLimit := IsLUB.exists_of_not_isSuccPrelimit
 
 end ConditionallyCompleteLinearOrderBot
 
 section CompleteLinearOrder
 variable [CompleteLinearOrder α] {s : Set α} {f : ι → α} {x : α}
 
-lemma sSup_mem_of_not_isSuccLimit (hlim : ¬ IsSuccLimit (sSup s)) :
+lemma sSup_mem_of_not_isSuccPrelimit (hlim : ¬ IsSuccPrelimit (sSup s)) :
     sSup s ∈ s := by
   obtain ⟨y, hy⟩ := not_forall_not.mp hlim
   obtain ⟨i, his, hi⟩ := lt_sSup_iff.mp hy.lt
   exact eq_of_le_of_not_lt (le_sSup his) (hy.2 hi) ▸ his
 
-lemma sInf_mem_of_not_isPredLimit (hlim : ¬ IsPredLimit (sInf s)) :
+@[deprecated sSup_mem_of_not_isSuccPrelimit (since := "2024-09-05")]
+alias sSup_mem_of_not_isSuccLimit := sSup_mem_of_not_isSuccPrelimit
+
+lemma sInf_mem_of_not_isPredPrelimit (hlim : ¬ IsPredPrelimit (sInf s)) :
     sInf s ∈ s := by
   obtain ⟨y, hy⟩ := not_forall_not.mp hlim
   obtain ⟨i, his, hi⟩ := sInf_lt_iff.mp hy.lt
   exact eq_of_le_of_not_lt (sInf_le his) (hy.2 · hi) ▸ his
 
-lemma exists_eq_iSup_of_not_isSuccLimit (hf : ¬ IsSuccLimit (⨆ i, f i)) :
+@[deprecated sInf_mem_of_not_isPredPrelimit (since := "2024-09-05")]
+alias sInf_mem_of_not_isPredLimit := sInf_mem_of_not_isPredPrelimit
+
+lemma exists_eq_iSup_of_not_isSuccPrelimit (hf : ¬ IsSuccPrelimit (⨆ i, f i)) :
     ∃ i, f i = ⨆ i, f i :=
-  sSup_mem_of_not_isSuccLimit hf
+  sSup_mem_of_not_isSuccPrelimit hf
 
-lemma exists_eq_iInf_of_not_isPredLimit (hf : ¬ IsPredLimit (⨅ i, f i)) :
+@[deprecated exists_eq_iSup_of_not_isSuccPrelimit (since := "2024-09-05")]
+alias exists_eq_iSup_of_not_isSuccLimit := exists_eq_iSup_of_not_isSuccPrelimit
+
+lemma exists_eq_iInf_of_not_isPredPrelimit (hf : ¬ IsPredPrelimit (⨅ i, f i)) :
     ∃ i, f i = ⨅ i, f i :=
-  sInf_mem_of_not_isPredLimit hf
+  sInf_mem_of_not_isPredPrelimit hf
 
-lemma IsGLB.mem_of_not_isPredLimit (hs : IsGLB s x) (hx : ¬ IsPredLimit x) :
+@[deprecated exists_eq_iInf_of_not_isPredPrelimit (since := "2024-09-05")]
+alias exists_eq_iInf_of_not_isPredLimit := exists_eq_iInf_of_not_isPredPrelimit
+
+lemma IsGLB.mem_of_not_isPredPrelimit (hs : IsGLB s x) (hx : ¬ IsPredPrelimit x) :
     x ∈ s :=
-  hs.sInf_eq ▸ sInf_mem_of_not_isPredLimit (hs.sInf_eq ▸ hx)
+  hs.sInf_eq ▸ sInf_mem_of_not_isPredPrelimit (hs.sInf_eq ▸ hx)
 
-lemma IsGLB.exists_of_not_isPredLimit (hf : IsGLB (Set.range f) x) (hx : ¬ IsPredLimit x) :
-    ∃ i, f i = x := hf.mem_of_not_isPredLimit hx
+@[deprecated IsGLB.mem_of_not_isPredPrelimit (since := "2024-09-05")]
+alias IsGLB.mem_of_not_isPredLimit := IsGLB.mem_of_not_isPredPrelimit
+
+lemma IsGLB.exists_of_not_isPredPrelimit (hf : IsGLB (Set.range f) x) (hx : ¬ IsPredPrelimit x) :
+    ∃ i, f i = x := hf.mem_of_not_isPredPrelimit hx
+
+@[deprecated IsGLB.exists_of_not_isPredPrelimit (since := "2024-09-05")]
+alias IsGLB.exists_of_not_isPredLimit := IsGLB.exists_of_not_isPredPrelimit
 
 end CompleteLinearOrder

--- a/Mathlib/Order/SuccPred/Limit.lean
+++ b/Mathlib/Order/SuccPred/Limit.lean
@@ -9,11 +9,14 @@ import Mathlib.Order.BoundedOrder
 /-!
 # Successor and predecessor limits
 
-We define the predicate `Order.IsSuccLimit` for "successor limits", values that don't cover any
-others. They are so named since they can't be the successors of anything smaller. We define
-`Order.IsPredLimit` analogously, and prove basic results.
+We define the predicate `Order.IsSuccPrelimit` for "successor pre-limits", values that don't cover
+any others. They are so named since they can't be the successors of anything smaller. We define
+`Order.IsPredPrelimit` analogously, and prove basic results.
 
 ## TODO
+
+For some applications, it's desirable to exclude the case where an element is minimal. A future PR
+will introduce `IsSuccLimit` for this usage.
 
 The plan is to eventually replace `Ordinal.IsLimit` and `Cardinal.IsLimit` with the common
 predicate `Order.IsSuccLimit`.
@@ -33,18 +36,30 @@ section LT
 
 variable [LT α]
 
-/-- A successor limit is a value that doesn't cover any other.
+/-- A successor pre-limit is a value that doesn't cover any other.
 
-It's so named because in a successor order, a successor limit can't be the successor of anything
-smaller. -/
-def IsSuccLimit (a : α) : Prop :=
+It's so named because in a successor order, a successor pre-limit can't be the successor of anything
+smaller.
+
+For some applications, it's desirable to exclude the case where an element is minimal. A future PR
+will introduce `IsSuccLimit` for this usage. -/
+def IsSuccPrelimit (a : α) : Prop :=
   ∀ b, ¬b ⋖ a
 
-theorem not_isSuccLimit_iff_exists_covBy (a : α) : ¬IsSuccLimit a ↔ ∃ b, b ⋖ a := by
-  simp [IsSuccLimit]
+@[deprecated IsSuccPrelimit (since := "2024-09-05")]
+alias IsSuccLimit := IsSuccPrelimit
+
+theorem not_isSuccPrelimit_iff_exists_covBy (a : α) : ¬IsSuccPrelimit a ↔ ∃ b, b ⋖ a := by
+  simp [IsSuccPrelimit]
+
+@[deprecated not_isSuccPrelimit_iff_exists_covBy (since := "2024-09-05")]
+alias not_isSuccLimit_iff_exists_covBy := not_isSuccPrelimit_iff_exists_covBy
 
 @[simp]
-theorem isSuccLimit_of_dense [DenselyOrdered α] (a : α) : IsSuccLimit a := fun _ => not_covBy
+theorem isSuccPrelimit_of_dense [DenselyOrdered α] (a : α) : IsSuccPrelimit a := fun _ => not_covBy
+
+@[deprecated isSuccPrelimit_of_dense (since := "2024-09-05")]
+alias isSuccLimit_of_dense := isSuccPrelimit_of_dense
 
 end LT
 
@@ -52,32 +67,50 @@ section Preorder
 
 variable [Preorder α] {a : α}
 
-protected theorem _root_.IsMin.isSuccLimit : IsMin a → IsSuccLimit a := fun h _ hab =>
+protected theorem _root_.IsMin.isSuccPrelimit : IsMin a → IsSuccPrelimit a := fun h _ hab =>
   not_isMin_of_lt hab.lt h
 
-theorem isSuccLimit_bot [OrderBot α] : IsSuccLimit (⊥ : α) :=
-  IsMin.isSuccLimit isMin_bot
+@[deprecated _root_.IsMin.isSuccPrelimit (since := "2024-09-05")]
+alias _root_.IsMin.isSuccLimit := _root_.IsMin.isSuccPrelimit
+
+theorem isSuccPrelimit_bot [OrderBot α] : IsSuccPrelimit (⊥ : α) :=
+  IsMin.isSuccPrelimit isMin_bot
+
+@[deprecated isSuccPrelimit_bot (since := "2024-09-05")]
+alias isSuccLimit_bot := isSuccPrelimit_bot
 
 variable [SuccOrder α]
 
-protected theorem IsSuccLimit.isMax (h : IsSuccLimit (succ a)) : IsMax a := by
+protected theorem IsSuccPrelimit.isMax (h : IsSuccPrelimit (succ a)) : IsMax a := by
   by_contra H
   exact h a (covBy_succ_of_not_isMax H)
 
-theorem not_isSuccLimit_succ_of_not_isMax (ha : ¬IsMax a) : ¬IsSuccLimit (succ a) := by
+@[deprecated IsSuccPrelimit.isMax (since := "2024-09-05")]
+alias IsSuccLimit.isMax := IsSuccPrelimit.isMax
+
+theorem not_isSuccPrelimit_succ_of_not_isMax (ha : ¬IsMax a) : ¬IsSuccPrelimit (succ a) := by
   contrapose! ha
   exact ha.isMax
+
+@[deprecated not_isSuccPrelimit_succ_of_not_isMax (since := "2024-09-05")]
+alias not_isSuccLimit_succ_of_not_isMax := not_isSuccPrelimit_succ_of_not_isMax
 
 section NoMaxOrder
 
 variable [NoMaxOrder α]
 
-theorem IsSuccLimit.succ_ne (h : IsSuccLimit a) (b : α) : succ b ≠ a := by
+theorem IsSuccPrelimit.succ_ne (h : IsSuccPrelimit a) (b : α) : succ b ≠ a := by
   rintro rfl
   exact not_isMax _ h.isMax
 
+@[deprecated IsSuccPrelimit.succ_ne (since := "2024-09-05")]
+alias IsSuccLimit.succ_ne := IsSuccPrelimit.succ_ne
+
 @[simp]
-theorem not_isSuccLimit_succ (a : α) : ¬IsSuccLimit (succ a) := fun h => h.succ_ne _ rfl
+theorem not_isSuccPrelimit_succ (a : α) : ¬IsSuccPrelimit (succ a) := fun h => h.succ_ne _ rfl
+
+@[deprecated not_isSuccPrelimit_succ (since := "2024-09-05")]
+alias not_isSuccLimit_succ := not_isSuccPrelimit_succ
 
 end NoMaxOrder
 
@@ -85,17 +118,27 @@ section IsSuccArchimedean
 
 variable [IsSuccArchimedean α]
 
-theorem IsSuccLimit.isMin_of_noMax [NoMaxOrder α] (h : IsSuccLimit a) : IsMin a := fun b hb => by
+theorem IsSuccPrelimit.isMin_of_noMax [NoMaxOrder α] (h : IsSuccPrelimit a) : IsMin a := by
+  intro b hb
   rcases hb.exists_succ_iterate with ⟨_ | n, rfl⟩
   · exact le_rfl
   · rw [iterate_succ_apply'] at h
-    exact (not_isSuccLimit_succ _ h).elim
+    exact (not_isSuccPrelimit_succ _ h).elim
+
+@[deprecated IsSuccPrelimit.isMin_of_noMax (since := "2024-09-05")]
+alias IsSuccLimit.isMin_of_noMax := IsSuccPrelimit.isMin_of_noMax
 
 @[simp]
-theorem isSuccLimit_iff_of_noMax [NoMaxOrder α] : IsSuccLimit a ↔ IsMin a :=
-  ⟨IsSuccLimit.isMin_of_noMax, IsMin.isSuccLimit⟩
+theorem isSuccPrelimit_iff_of_noMax [NoMaxOrder α] : IsSuccPrelimit a ↔ IsMin a :=
+  ⟨IsSuccPrelimit.isMin_of_noMax, IsMin.isSuccPrelimit⟩
 
-theorem not_isSuccLimit_of_noMax [NoMinOrder α] [NoMaxOrder α] : ¬IsSuccLimit a := by simp
+@[deprecated isSuccPrelimit_iff_of_noMax (since := "2024-09-05")]
+alias isSuccLimit_iff_of_noMax := isSuccPrelimit_iff_of_noMax
+
+theorem not_isSuccPrelimit_of_noMax [NoMinOrder α] [NoMaxOrder α] : ¬IsSuccPrelimit a := by simp
+
+@[deprecated not_isSuccPrelimit_of_noMax (since := "2024-09-05")]
+alias not_isSuccLimit_of_noMax := not_isSuccPrelimit_of_noMax
 
 end IsSuccArchimedean
 
@@ -105,28 +148,43 @@ section PartialOrder
 
 variable [PartialOrder α] [SuccOrder α] {a b : α} {C : α → Sort*}
 
-theorem isSuccLimit_of_succ_ne (h : ∀ b, succ b ≠ a) : IsSuccLimit a := fun b hba =>
+theorem isSuccPrelimit_of_succ_ne (h : ∀ b, succ b ≠ a) : IsSuccPrelimit a := fun b hba =>
   h b (CovBy.succ_eq hba)
 
-theorem not_isSuccLimit_iff : ¬IsSuccLimit a ↔ ∃ b, ¬IsMax b ∧ succ b = a := by
-  rw [not_isSuccLimit_iff_exists_covBy]
+@[deprecated isSuccPrelimit_of_succ_ne (since := "2024-09-05")]
+alias isSuccLimit_of_succ_ne := isSuccPrelimit_of_succ_ne
+
+theorem not_isSuccPrelimit_iff : ¬IsSuccPrelimit a ↔ ∃ b, ¬IsMax b ∧ succ b = a := by
+  rw [not_isSuccPrelimit_iff_exists_covBy]
   refine exists_congr fun b => ⟨fun hba => ⟨hba.lt.not_isMax, (CovBy.succ_eq hba)⟩, ?_⟩
   rintro ⟨h, rfl⟩
   exact covBy_succ_of_not_isMax h
 
-/-- See `not_isSuccLimit_iff` for a version that states that `a` is a successor of a value other
+@[deprecated not_isSuccPrelimit_iff (since := "2024-09-05")]
+alias not_isSuccLimit_iff := not_isSuccPrelimit_iff
+
+/-- See `not_isSuccPrelimit_iff` for a version that states that `a` is a successor of a value other
 than itself. -/
-theorem mem_range_succ_of_not_isSuccLimit (h : ¬IsSuccLimit a) : a ∈ range (@succ α _ _) := by
-  cases' not_isSuccLimit_iff.1 h with b hb
+theorem mem_range_succ_of_not_isSuccPrelimit (h : ¬IsSuccPrelimit a) : a ∈ range (@succ α _ _) := by
+  cases' not_isSuccPrelimit_iff.1 h with b hb
   exact ⟨b, hb.2⟩
 
-theorem mem_range_succ_or_isSuccLimit (a) : a ∈ range (@succ α _ _) ∨ IsSuccLimit a :=
-  or_iff_not_imp_right.2 <| mem_range_succ_of_not_isSuccLimit
+@[deprecated mem_range_succ_of_not_isSuccPrelimit (since := "2024-09-05")]
+alias mem_range_succ_of_not_isSuccLimit := mem_range_succ_of_not_isSuccPrelimit
 
-theorem isSuccLimit_of_succ_lt (H : ∀ a < b, succ a < b) : IsSuccLimit b := fun a hab =>
+theorem mem_range_succ_or_isSuccPrelimit (a) : a ∈ range (@succ α _ _) ∨ IsSuccPrelimit a :=
+  or_iff_not_imp_right.2 <| mem_range_succ_of_not_isSuccPrelimit
+
+@[deprecated mem_range_succ_or_isSuccPrelimit (since := "2024-09-05")]
+alias mem_range_succ_or_isSuccLimit := mem_range_succ_or_isSuccPrelimit
+
+theorem isSuccPrelimit_of_succ_lt (H : ∀ a < b, succ a < b) : IsSuccPrelimit b := fun a hab =>
   (H a hab.lt).ne (CovBy.succ_eq hab)
 
-theorem IsSuccLimit.succ_lt (hb : IsSuccLimit b) (ha : a < b) : succ a < b := by
+@[deprecated isSuccPrelimit_of_succ_lt (since := "2024-09-05")]
+alias isSuccLimit_of_succ_lt := isSuccPrelimit_of_succ_lt
+
+theorem IsSuccPrelimit.succ_lt (hb : IsSuccPrelimit b) (ha : a < b) : succ a < b := by
   by_cases h : IsMax a
   · rwa [h.succ_eq]
   · rw [lt_iff_le_and_ne, succ_le_iff_of_not_isMax h]
@@ -134,22 +192,37 @@ theorem IsSuccLimit.succ_lt (hb : IsSuccLimit b) (ha : a < b) : succ a < b := by
     subst hab
     exact (h hb.isMax).elim
 
-theorem IsSuccLimit.succ_lt_iff (hb : IsSuccLimit b) : succ a < b ↔ a < b :=
+@[deprecated IsSuccPrelimit.succ_lt (since := "2024-09-05")]
+alias IsSuccLimit.succ_lt := IsSuccPrelimit.succ_lt
+
+theorem IsSuccPrelimit.succ_lt_iff (hb : IsSuccPrelimit b) : succ a < b ↔ a < b :=
   ⟨fun h => (le_succ a).trans_lt h, hb.succ_lt⟩
 
-theorem isSuccLimit_iff_succ_lt : IsSuccLimit b ↔ ∀ a < b, succ a < b :=
-  ⟨fun hb _ => hb.succ_lt, isSuccLimit_of_succ_lt⟩
+@[deprecated IsSuccPrelimit.succ_lt_iff (since := "2024-09-05")]
+alias IsSuccLimit.succ_lt_iff := IsSuccPrelimit.succ_lt_iff
+
+theorem isSuccPrelimit_iff_succ_lt : IsSuccPrelimit b ↔ ∀ a < b, succ a < b :=
+  ⟨fun hb _ => hb.succ_lt, isSuccPrelimit_of_succ_lt⟩
+
+@[deprecated isSuccPrelimit_iff_succ_lt (since := "2024-09-05")]
+alias isSuccLimit_iff_succ_lt := isSuccPrelimit_iff_succ_lt
 
 section NoMaxOrder
 
 variable [NoMaxOrder α]
 
-theorem isSuccLimit_iff_succ_ne : IsSuccLimit a ↔ ∀ b, succ b ≠ a :=
-  ⟨IsSuccLimit.succ_ne, isSuccLimit_of_succ_ne⟩
+theorem isSuccPrelimit_iff_succ_ne : IsSuccPrelimit a ↔ ∀ b, succ b ≠ a :=
+  ⟨IsSuccPrelimit.succ_ne, isSuccPrelimit_of_succ_ne⟩
 
-theorem not_isSuccLimit_iff' : ¬IsSuccLimit a ↔ a ∈ range (@succ α _ _) := by
-  simp_rw [isSuccLimit_iff_succ_ne, not_forall, not_ne_iff]
+@[deprecated isSuccPrelimit_iff_succ_ne (since := "2024-09-05")]
+alias isSuccLimit_iff_succ_ne := isSuccPrelimit_iff_succ_ne
+
+theorem not_isSuccPrelimit_iff' : ¬IsSuccPrelimit a ↔ a ∈ range (@succ α _ _) := by
+  simp_rw [isSuccPrelimit_iff_succ_ne, not_forall, not_ne_iff]
   rfl
+
+@[deprecated not_isSuccPrelimit_iff' (since := "2024-09-05")]
+alias not_isSuccLimit_iff' := not_isSuccPrelimit_iff'
 
 end NoMaxOrder
 
@@ -157,18 +230,27 @@ section IsSuccArchimedean
 
 variable [IsSuccArchimedean α]
 
-protected theorem IsSuccLimit.isMin (h : IsSuccLimit a) : IsMin a := fun b hb => by
+protected theorem IsSuccPrelimit.isMin (h : IsSuccPrelimit a) : IsMin a := fun b hb => by
   revert h
   refine Succ.rec (fun _ => le_rfl) (fun c _ H hc => ?_) hb
   have := hc.isMax.succ_eq
   rw [this] at hc ⊢
   exact H hc
 
-@[simp]
-theorem isSuccLimit_iff : IsSuccLimit a ↔ IsMin a :=
-  ⟨IsSuccLimit.isMin, IsMin.isSuccLimit⟩
+@[deprecated IsSuccPrelimit.isMin (since := "2024-09-05")]
+alias IsSuccLimit.isMin := IsSuccPrelimit.isMin
 
-theorem not_isSuccLimit [NoMinOrder α] : ¬IsSuccLimit a := by simp
+@[simp]
+theorem isSuccPrelimit_iff : IsSuccPrelimit a ↔ IsMin a :=
+  ⟨IsSuccPrelimit.isMin, IsMin.isSuccPrelimit⟩
+
+@[deprecated isSuccPrelimit_iff (since := "2024-09-05")]
+alias isSuccLimit_iff := isSuccPrelimit_iff
+
+theorem not_isSuccPrelimit [NoMinOrder α] : ¬IsSuccPrelimit a := by simp
+
+@[deprecated not_isSuccPrelimit (since := "2024-09-05")]
+alias not_isSuccLimit := not_isSuccPrelimit
 
 end IsSuccArchimedean
 
@@ -181,29 +263,50 @@ section LT
 
 variable [LT α] {a : α}
 
-/-- A predecessor limit is a value that isn't covered by any other.
+/-- A successor pre-limit is a value that isn't covered by any other.
 
 It's so named because in a predecessor order, a predecessor limit can't be the predecessor of
-anything greater. -/
-def IsPredLimit (a : α) : Prop :=
+anything greater.
+
+For some applications, it's desirable to exclude the case where an element is maximal. A future PR
+will introduce `IsPredLimit` for this usage. -/
+def IsPredPrelimit (a : α) : Prop :=
   ∀ b, ¬a ⋖ b
 
-theorem not_isPredLimit_iff_exists_covBy (a : α) : ¬IsPredLimit a ↔ ∃ b, a ⋖ b := by
-  simp [IsPredLimit]
+@[deprecated IsPredPrelimit (since := "2024-09-05")]
+alias IsPredLimit := IsPredPrelimit
 
-theorem isPredLimit_of_dense [DenselyOrdered α] (a : α) : IsPredLimit a := fun _ => not_covBy
+theorem not_isPredPrelimit_iff_exists_covBy (a : α) : ¬IsPredPrelimit a ↔ ∃ b, a ⋖ b := by
+  simp [IsPredPrelimit]
+
+@[deprecated not_isPredPrelimit_iff_exists_covBy (since := "2024-09-05")]
+alias not_isPredLimit_iff_exists_covBy := not_isPredPrelimit_iff_exists_covBy
+
+theorem isPredPrelimit_of_dense [DenselyOrdered α] (a : α) : IsPredPrelimit a := fun _ => not_covBy
+
+@[deprecated isPredPrelimit_of_dense (since := "2024-09-05")]
+alias isPredLimit_of_dense := isPredPrelimit_of_dense
 
 @[simp]
-theorem isSuccLimit_toDual_iff : IsSuccLimit (toDual a) ↔ IsPredLimit a := by
-  simp [IsSuccLimit, IsPredLimit]
+theorem isSuccPrelimit_toDual_iff : IsSuccPrelimit (toDual a) ↔ IsPredPrelimit a := by
+  simp [IsSuccPrelimit, IsPredPrelimit]
+
+@[deprecated isSuccPrelimit_toDual_iff (since := "2024-09-05")]
+alias isSuccLimit_toDual_iff := isSuccPrelimit_toDual_iff
 
 @[simp]
-theorem isPredLimit_toDual_iff : IsPredLimit (toDual a) ↔ IsSuccLimit a := by
-  simp [IsSuccLimit, IsPredLimit]
+theorem isPredPrelimit_toDual_iff : IsPredPrelimit (toDual a) ↔ IsSuccPrelimit a := by
+  simp [IsSuccPrelimit, IsPredPrelimit]
 
-alias ⟨_, isPredLimit.dual⟩ := isSuccLimit_toDual_iff
+@[deprecated isPredPrelimit_toDual_iff (since := "2024-09-05")]
+alias isPredLimit_toDual_iff := isPredPrelimit_toDual_iff
 
-alias ⟨_, isSuccLimit.dual⟩ := isPredLimit_toDual_iff
+alias ⟨_, IsPredPrelimit.dual⟩ := isSuccPrelimit_toDual_iff
+alias ⟨_, IsSuccPrelimit.dual⟩ := isPredPrelimit_toDual_iff
+@[deprecated IsPredPrelimit.dual (since := "2024-09-05")]
+alias isPredLimit.dual := IsPredPrelimit.dual
+@[deprecated IsSuccPrelimit.dual (since := "2024-09-05")]
+alias isSuccLimit.dual := IsSuccPrelimit.dual
 
 end LT
 
@@ -211,32 +314,50 @@ section Preorder
 
 variable [Preorder α] {a : α}
 
-protected theorem _root_.IsMax.isPredLimit : IsMax a → IsPredLimit a := fun h _ hab =>
+protected theorem _root_.IsMax.isPredPrelimit : IsMax a → IsPredPrelimit a := fun h _ hab =>
   not_isMax_of_lt hab.lt h
 
-theorem isPredLimit_top [OrderTop α] : IsPredLimit (⊤ : α) :=
-   IsMax.isPredLimit isMax_top
+@[deprecated _root_.IsMax.isPredPrelimit (since := "2024-09-05")]
+alias _root_.IsMax.isPredLimit := _root_.IsMax.isPredPrelimit
+
+theorem isPredPrelimit_top [OrderTop α] : IsPredPrelimit (⊤ : α) :=
+   IsMax.isPredPrelimit isMax_top
+
+@[deprecated isPredPrelimit_top (since := "2024-09-05")]
+alias isPredLimit_top := isPredPrelimit_top
 
 variable [PredOrder α]
 
-protected theorem IsPredLimit.isMin (h : IsPredLimit (pred a)) : IsMin a := by
+protected theorem IsPredPrelimit.isMin (h : IsPredPrelimit (pred a)) : IsMin a := by
   by_contra H
   exact h a (pred_covBy_of_not_isMin H)
 
-theorem not_isPredLimit_pred_of_not_isMin (ha : ¬IsMin a) : ¬IsPredLimit (pred a) := by
+@[deprecated IsPredPrelimit.isMin (since := "2024-09-05")]
+alias IsPredLimit.isMin := IsPredPrelimit.isMin
+
+theorem not_isPredPrelimit_pred_of_not_isMin (ha : ¬IsMin a) : ¬IsPredPrelimit (pred a) := by
   contrapose! ha
   exact ha.isMin
+
+@[deprecated not_isPredPrelimit_pred_of_not_isMin (since := "2024-09-05")]
+alias not_isPredLimit_pred_of_not_isMin := not_isPredPrelimit_pred_of_not_isMin
 
 section NoMinOrder
 
 variable [NoMinOrder α]
 
-theorem IsPredLimit.pred_ne (h : IsPredLimit a) (b : α) : pred b ≠ a := by
+theorem IsPredPrelimit.pred_ne (h : IsPredPrelimit a) (b : α) : pred b ≠ a := by
   rintro rfl
   exact not_isMin _ h.isMin
 
+@[deprecated IsPredPrelimit.pred_ne (since := "2024-09-05")]
+alias IsPredLimit.pred_ne := IsPredPrelimit.pred_ne
+
 @[simp]
-theorem not_isPredLimit_pred (a : α) : ¬IsPredLimit (pred a) := fun h => h.pred_ne _ rfl
+theorem not_isPredPrelimit_pred (a : α) : ¬IsPredPrelimit (pred a) := fun h => h.pred_ne _ rfl
+
+@[deprecated not_isPredPrelimit_pred (since := "2024-09-05")]
+alias not_isPredLimit_pred := not_isPredPrelimit_pred
 
 end NoMinOrder
 
@@ -244,14 +365,23 @@ section IsPredArchimedean
 
 variable [IsPredArchimedean α]
 
-protected theorem IsPredLimit.isMax_of_noMin [NoMinOrder α] (h : IsPredLimit a) : IsMax a :=
-  (isPredLimit.dual h).isMin_of_noMax
+protected theorem IsPredPrelimit.isMax_of_noMin [NoMinOrder α] (h : IsPredPrelimit a) : IsMax a :=
+  h.dual.isMin_of_noMax
+
+@[deprecated IsPredPrelimit.isMax_of_noMin (since := "2024-09-05")]
+alias IsPredLimit.isMax_of_noMin := IsPredPrelimit.isMax_of_noMin
 
 @[simp]
-theorem isPredLimit_iff_of_noMin [NoMinOrder α] : IsPredLimit a ↔ IsMax a :=
-  isSuccLimit_toDual_iff.symm.trans isSuccLimit_iff_of_noMax
+theorem isPredPrelimit_iff_of_noMin [NoMinOrder α] : IsPredPrelimit a ↔ IsMax a :=
+  isSuccPrelimit_toDual_iff.symm.trans isSuccPrelimit_iff_of_noMax
 
-theorem not_isPredLimit_of_noMin [NoMinOrder α] [NoMaxOrder α] : ¬IsPredLimit a := by simp
+@[deprecated isPredPrelimit_iff_of_noMin (since := "2024-09-05")]
+alias isPredLimit_iff_of_noMin := isPredPrelimit_iff_of_noMin
+
+theorem not_isPredPrelimit_of_noMin [NoMinOrder α] [NoMaxOrder α] : ¬IsPredPrelimit a := by simp
+
+@[deprecated not_isPredPrelimit_of_noMin (since := "2024-09-05")]
+alias not_isPredLimit_of_noMin := not_isPredPrelimit_of_noMin
 
 end IsPredArchimedean
 
@@ -261,33 +391,57 @@ section PartialOrder
 
 variable [PartialOrder α] [PredOrder α] {a b : α} {C : α → Sort*}
 
-theorem isPredLimit_of_pred_ne (h : ∀ b, pred b ≠ a) : IsPredLimit a := fun b hba =>
+theorem isPredPrelimit_of_pred_ne (h : ∀ b, pred b ≠ a) : IsPredPrelimit a := fun b hba =>
   h b (CovBy.pred_eq hba)
 
-theorem not_isPredLimit_iff : ¬IsPredLimit a ↔ ∃ b, ¬IsMin b ∧ pred b = a := by
-  rw [← isSuccLimit_toDual_iff]
-  exact not_isSuccLimit_iff
+@[deprecated isPredPrelimit_of_pred_ne (since := "2024-09-05")]
+alias isPredLimit_of_pred_ne := isPredPrelimit_of_pred_ne
 
-/-- See `not_isPredLimit_iff` for a version that states that `a` is a successor of a value other
+theorem not_isPredPrelimit_iff : ¬IsPredPrelimit a ↔ ∃ b, ¬IsMin b ∧ pred b = a := by
+  rw [← isSuccPrelimit_toDual_iff]
+  exact not_isSuccPrelimit_iff
+
+@[deprecated not_isPredPrelimit_iff (since := "2024-09-05")]
+alias not_isPredLimit_iff := not_isPredPrelimit_iff
+
+/-- See `not_isPredPrelimit_iff` for a version that states that `a` is a successor of a value other
 than itself. -/
-theorem mem_range_pred_of_not_isPredLimit (h : ¬IsPredLimit a) : a ∈ range (@pred α _ _) := by
-  cases' not_isPredLimit_iff.1 h with b hb
+theorem mem_range_pred_of_not_isPredPrelimit (h : ¬IsPredPrelimit a) : a ∈ range (@pred α _ _) := by
+  cases' not_isPredPrelimit_iff.1 h with b hb
   exact ⟨b, hb.2⟩
 
-theorem mem_range_pred_or_isPredLimit (a) : a ∈ range (@pred α _ _) ∨ IsPredLimit a :=
-  or_iff_not_imp_right.2 <| mem_range_pred_of_not_isPredLimit
+@[deprecated mem_range_pred_of_not_isPredPrelimit (since := "2024-09-05")]
+alias mem_range_pred_of_not_isPredLimit := mem_range_pred_of_not_isPredPrelimit
 
-theorem isPredLimit_of_pred_lt (H : ∀ a > b, pred a < b) : IsPredLimit b := fun a hab =>
+theorem mem_range_pred_or_isPredPrelimit (a) : a ∈ range (@pred α _ _) ∨ IsPredPrelimit a :=
+  or_iff_not_imp_right.2 <| mem_range_pred_of_not_isPredPrelimit
+
+@[deprecated mem_range_pred_or_isPredPrelimit (since := "2024-09-05")]
+alias mem_range_pred_or_isPredLimit := mem_range_pred_or_isPredPrelimit
+
+theorem isPredPrelimit_of_pred_lt (H : ∀ a > b, pred a < b) : IsPredPrelimit b := fun a hab =>
   (H a hab.lt).ne (CovBy.pred_eq hab)
 
-theorem IsPredLimit.lt_pred (h : IsPredLimit a) : a < b → a < pred b :=
-  (isPredLimit.dual h).succ_lt
+@[deprecated isPredPrelimit_of_pred_lt (since := "2024-09-05")]
+alias isPredLimit_of_pred_lt := isPredPrelimit_of_pred_lt
 
-theorem IsPredLimit.lt_pred_iff (h : IsPredLimit a) : a < pred b ↔ a < b :=
-  (isPredLimit.dual h).succ_lt_iff
+theorem IsPredPrelimit.lt_pred (h : IsPredPrelimit a) : a < b → a < pred b :=
+  h.dual.succ_lt
 
-theorem isPredLimit_iff_lt_pred : IsPredLimit a ↔ ∀ ⦃b⦄, a < b → a < pred b :=
-  isSuccLimit_toDual_iff.symm.trans isSuccLimit_iff_succ_lt
+@[deprecated IsPredPrelimit.lt_pred (since := "2024-09-05")]
+alias IsPredLimit.lt_pred := IsPredPrelimit.lt_pred
+
+theorem IsPredPrelimit.lt_pred_iff (h : IsPredPrelimit a) : a < pred b ↔ a < b :=
+  h.dual.succ_lt_iff
+
+@[deprecated IsPredPrelimit.lt_pred_iff (since := "2024-09-05")]
+alias IsPredLimit.lt_pred_iff := IsPredPrelimit.lt_pred_iff
+
+theorem isPredPrelimit_iff_lt_pred : IsPredPrelimit a ↔ ∀ ⦃b⦄, a < b → a < pred b :=
+  isSuccPrelimit_toDual_iff.symm.trans isSuccPrelimit_iff_succ_lt
+
+@[deprecated isPredPrelimit_iff_lt_pred (since := "2024-09-05")]
+alias isPredLimit_iff_lt_pred := isPredPrelimit_iff_lt_pred
 
 section NoMinOrder
 
@@ -299,14 +453,23 @@ section IsPredArchimedean
 
 variable [IsPredArchimedean α]
 
-protected theorem IsPredLimit.isMax (h : IsPredLimit a) : IsMax a :=
-  (isPredLimit.dual h).isMin
+protected theorem IsPredPrelimit.isMax (h : IsPredPrelimit a) : IsMax a :=
+  h.dual.isMin
+
+@[deprecated IsPredPrelimit.isMax (since := "2024-09-05")]
+alias IsPredLimit.isMax := IsPredPrelimit.isMax
 
 @[simp]
-theorem isPredLimit_iff : IsPredLimit a ↔ IsMax a :=
-  isSuccLimit_toDual_iff.symm.trans isSuccLimit_iff
+theorem isPredPrelimit_iff : IsPredPrelimit a ↔ IsMax a :=
+  isSuccPrelimit_toDual_iff.symm.trans isSuccPrelimit_iff
 
-theorem not_isPredLimit [NoMaxOrder α] : ¬IsPredLimit a := by simp
+@[deprecated isPredPrelimit_iff (since := "2024-09-05")]
+alias isPredLimit_iff := isPredPrelimit_iff
+
+theorem not_isPredPrelimit [NoMaxOrder α] : ¬IsPredPrelimit a := by simp
+
+@[deprecated not_isPredPrelimit (since := "2024-09-05")]
+alias not_isPredLimit := not_isPredPrelimit
 
 end IsPredArchimedean
 
@@ -317,7 +480,7 @@ end PartialOrder
 
 variable {C : α → Sort*} {b : α}
 
-section isSuccLimitRecOn
+section isSuccPrelimitRecOn
 
 section PartialOrder
 
@@ -325,17 +488,24 @@ variable [PartialOrder α] [SuccOrder α]
 
 /-- A value can be built by building it on successors and successor limits. -/
 @[elab_as_elim]
-noncomputable def isSuccLimitRecOn (b : α) (hs : ∀ a, ¬ IsMax a → C (succ a))
-    (hl : ∀ a, IsSuccLimit a → C a) : C b := by
-  by_cases hb : IsSuccLimit b
+noncomputable def isSuccPrelimitRecOn (b : α) (hs : ∀ a, ¬ IsMax a → C (succ a))
+    (hl : ∀ a, IsSuccPrelimit a → C a) : C b := by
+  by_cases hb : IsSuccPrelimit b
   · exact hl b hb
-  · have H := Classical.choose_spec (not_isSuccLimit_iff.1 hb)
+  · have H := Classical.choose_spec (not_isSuccPrelimit_iff.1 hb)
     rw [← H.2]
     exact hs _ H.1
 
-theorem isSuccLimitRecOn_limit (hs : ∀ a, ¬ IsMax a → C (succ a)) (hl : ∀ a, IsSuccLimit a → C a)
-    (hb : IsSuccLimit b) : @isSuccLimitRecOn α C _ _ b hs hl = hl b hb :=
+@[deprecated isSuccPrelimitRecOn (since := "2024-09-05")]
+alias isSuccLimitRecOn := isSuccPrelimitRecOn
+
+theorem isSuccPrelimitRecOn_limit (hs : ∀ a, ¬ IsMax a → C (succ a))
+    (hl : ∀ a, IsSuccPrelimit a → C a) (hb : IsSuccPrelimit b) :
+    isSuccPrelimitRecOn b hs hl = hl b hb :=
   dif_pos hb
+
+@[deprecated isSuccPrelimitRecOn_limit (since := "2024-09-05")]
+alias isSuccLimitRecOn_limit := isSuccPrelimitRecOn_limit
 
 end PartialOrder
 
@@ -343,27 +513,34 @@ section LinearOrder
 
 variable [LinearOrder α] [SuccOrder α]
 
-theorem isSuccLimitRecOn_succ' (hs : ∀ a, ¬ IsMax a → C (succ a)) (hl : ∀ a, IsSuccLimit a → C a)
-    (hb : ¬ IsMax b) : @isSuccLimitRecOn α C _ _ (succ b) hs hl = hs b hb := by
-  have hb' := not_isSuccLimit_succ_of_not_isMax hb
-  have H := Classical.choose_spec (not_isSuccLimit_iff.1 hb')
-  rw [isSuccLimitRecOn]
+theorem isSuccPrelimitRecOn_succ' (hs : ∀ a, ¬ IsMax a → C (succ a))
+    (hl : ∀ a, IsSuccPrelimit a → C a) (hb : ¬ IsMax b) :
+    isSuccPrelimitRecOn (succ b) hs hl = hs b hb := by
+  have hb' := not_isSuccPrelimit_succ_of_not_isMax hb
+  have H := Classical.choose_spec (not_isSuccPrelimit_iff.1 hb')
+  rw [isSuccPrelimitRecOn]
   simp only [cast_eq_iff_heq, hb', not_false_iff, eq_mpr_eq_cast, dif_neg]
   congr 1 <;> first |
     exact (succ_eq_succ_iff_of_not_isMax H.left hb).mp H.right |
     exact proof_irrel_heq H.left hb
 
+@[deprecated isSuccPrelimitRecOn_succ' (since := "2024-09-05")]
+alias isSuccLimitRecOn_succ' := isSuccPrelimitRecOn_succ'
+
 @[simp]
-theorem isSuccLimitRecOn_succ [NoMaxOrder α] (hs : ∀ a, ¬ IsMax a → C (succ a))
-    (hl : ∀ a, IsSuccLimit a → C a) (b : α) :
-    @isSuccLimitRecOn α C _ _ (succ b) hs hl = hs b (not_isMax b) :=
-  isSuccLimitRecOn_succ' _ _ _
+theorem isSuccPrelimitRecOn_succ [NoMaxOrder α] (hs : ∀ a, ¬ IsMax a → C (succ a))
+    (hl : ∀ a, IsSuccPrelimit a → C a) (b : α) :
+    @isSuccPrelimitRecOn α C _ _ (succ b) hs hl = hs b (not_isMax b) :=
+  isSuccPrelimitRecOn_succ' _ _ _
+
+@[deprecated isSuccPrelimitRecOn_succ (since := "2024-09-05")]
+alias isSuccLimitRecOn_succ := isSuccPrelimitRecOn_succ
 
 end LinearOrder
 
-end isSuccLimitRecOn
+end isSuccPrelimitRecOn
 
-section isPredLimitRecOn
+section isPredPrelimitRecOn
 
 section PartialOrder
 
@@ -371,33 +548,46 @@ variable [PartialOrder α] [PredOrder α]
 
 /-- A value can be built by building it on predecessors and predecessor limits. -/
 @[elab_as_elim]
-noncomputable def isPredLimitRecOn (b : α) (hs : ∀ a, ¬ IsMin a → C (pred a))
-    (hl : ∀ a, IsPredLimit a → C a) : C b :=
-  @isSuccLimitRecOn αᵒᵈ _ _ _ _ hs fun _ ha => hl _ (isSuccLimit.dual ha)
+noncomputable def isPredPrelimitRecOn (b : α) (hs : ∀ a, ¬ IsMin a → C (pred a))
+    (hl : ∀ a, IsPredPrelimit a → C a) : C b :=
+  @isSuccPrelimitRecOn αᵒᵈ _ _ _ _ hs fun _ ha => hl _ ha.dual
 
-theorem isPredLimitRecOn_limit (hs : ∀ a, ¬ IsMin a → C (pred a)) (hl : ∀ a, IsPredLimit a → C a)
-    (hb : IsPredLimit b) : @isPredLimitRecOn α C _ _ b hs hl = hl b hb :=
-  isSuccLimitRecOn_limit _ _ (isPredLimit.dual hb)
+@[deprecated isPredPrelimitRecOn (since := "2024-09-05")]
+alias isPredLimitRecOn := isPredPrelimitRecOn
+
+theorem isPredPrelimitRecOn_limit (hs : ∀ a, ¬ IsMin a → C (pred a))
+    (hl : ∀ a, IsPredPrelimit a → C a) (hb : IsPredPrelimit b) :
+    isPredPrelimitRecOn b hs hl = hl b hb :=
+  isSuccPrelimitRecOn_limit _ _ hb.dual
+
+@[deprecated isPredPrelimitRecOn_limit (since := "2024-09-05")]
+alias isPredLimitRecOn_limit := isPredPrelimitRecOn_limit
 
 end PartialOrder
 
 section LinearOrder
 
 variable [LinearOrder α] [PredOrder α]
-  (hs : ∀ a, ¬ IsMin a → C (pred a)) (hl : ∀ a, IsPredLimit a → C a)
+  (hs : ∀ a, ¬ IsMin a → C (pred a)) (hl : ∀ a, IsPredPrelimit a → C a)
 
-theorem isPredLimitRecOn_pred' {b : α} (hb : ¬ IsMin b) :
-    @isPredLimitRecOn α C _ _ (pred b) hs hl = hs b hb :=
-  isSuccLimitRecOn_succ' _ _ _
+theorem isPredPrelimitRecOn_pred' {b : α} (hb : ¬ IsMin b) :
+    @isPredPrelimitRecOn α C _ _ (pred b) hs hl = hs b hb :=
+  isSuccPrelimitRecOn_succ' _ _ _
+
+@[deprecated isPredPrelimitRecOn_pred' (since := "2024-09-05")]
+alias isPredLimitRecOn_pred' := isPredPrelimitRecOn_pred'
 
 @[simp]
-theorem isPredLimitRecOn_pred [NoMinOrder α] (b : α) :
-    @isPredLimitRecOn α C _ _ (pred b) hs hl = hs b (not_isMin b) :=
-  isSuccLimitRecOn_succ _ _ _
+theorem isPredPrelimitRecOn_pred [NoMinOrder α] (b : α) :
+    @isPredPrelimitRecOn α C _ _ (pred b) hs hl = hs b (not_isMin b) :=
+  isSuccPrelimitRecOn_succ _ _ _
+
+@[deprecated isPredPrelimitRecOn_pred (since := "2024-09-05")]
+alias isPredLimitRecOn_pred := isPredPrelimitRecOn_pred
 
 end LinearOrder
 
-end isPredLimitRecOn
+end isPredPrelimitRecOn
 
 end Order
 
@@ -407,7 +597,7 @@ variable {C : α → Sort*} {b : α}
 
 namespace SuccOrder
 
-section limitRecOn
+section prelimitRecOn
 
 section PartialOrder
 
@@ -415,78 +605,96 @@ variable [PartialOrder α] [SuccOrder α] [WellFoundedLT α]
 
 open scoped Classical in
 /-- Recursion principle on a well-founded partial `SuccOrder`. -/
-@[elab_as_elim] noncomputable def limitRecOn (b : α)
+@[elab_as_elim] noncomputable def prelimitRecOn (b : α)
     (hs : ∀ a, ¬ IsMax a → C a → C (Order.succ a))
-    (hl : ∀ a, IsSuccLimit a → (∀ b < a, C b) → C a) : C b :=
+    (hl : ∀ a, IsSuccPrelimit a → (∀ b < a, C b) → C a) : C b :=
   wellFounded_lt.fix
-    (fun a IH ↦ if h : IsSuccLimit a then hl a h IH else
-      let x := Classical.indefiniteDescription _ (not_isSuccLimit_iff.mp h)
+    (fun a IH ↦ if h : IsSuccPrelimit a then hl a h IH else
+      let x := Classical.indefiniteDescription _ (not_isSuccPrelimit_iff.mp h)
       x.2.2 ▸ hs x x.2.1 (IH x <| x.2.2.subst <| lt_succ_of_not_isMax x.2.1))
     b
 
+@[deprecated prelimitRecOn (since := "2024-09-05")]
+alias limitRecOn := prelimitRecOn
+
 @[simp]
-theorem limitRecOn_limit (hs : ∀ a, ¬ IsMax a → C a → C (Order.succ a))
-    (hl : ∀ a, IsSuccLimit a → (∀ b < a, C b) → C a) (hb : IsSuccLimit b) :
-    limitRecOn b hs hl = hl b hb fun x _ ↦ SuccOrder.limitRecOn x hs hl := by
-  rw [SuccOrder.limitRecOn, WellFounded.fix_eq, dif_pos hb]; rfl
+theorem prelimitRecOn_limit (hs : ∀ a, ¬ IsMax a → C a → C (Order.succ a))
+    (hl : ∀ a, IsSuccPrelimit a → (∀ b < a, C b) → C a) (hb : IsSuccPrelimit b) :
+    prelimitRecOn b hs hl = hl b hb fun x _ ↦ prelimitRecOn x hs hl := by
+  rw [prelimitRecOn, WellFounded.fix_eq, dif_pos hb]; rfl
+
+@[deprecated prelimitRecOn_limit (since := "2024-09-05")]
+alias limitRecOn_limit := prelimitRecOn_limit
 
 end PartialOrder
 
 section LinearOrder
 
 variable [LinearOrder α] [SuccOrder α] [WellFoundedLT α]
-  (hs : ∀ a, ¬ IsMax a → C a → C (Order.succ a)) (hl : ∀ a, IsSuccLimit a → (∀ b < a, C b) → C a)
+  (hs : ∀ a, ¬ IsMax a → C a → C (Order.succ a)) (hl : ∀ a, IsSuccPrelimit a → (∀ b < a, C b) → C a)
 
 @[simp]
-theorem limitRecOn_succ (hb : ¬ IsMax b) :
-    limitRecOn (Order.succ b) hs hl = hs b hb (limitRecOn b hs hl) := by
-  have h := not_isSuccLimit_succ_of_not_isMax hb
-  rw [limitRecOn, WellFounded.fix_eq, dif_neg h]
+theorem prelimitRecOn_succ (hb : ¬ IsMax b) :
+    prelimitRecOn (Order.succ b) hs hl = hs b hb (prelimitRecOn b hs hl) := by
+  have h := not_isSuccPrelimit_succ_of_not_isMax hb
+  rw [prelimitRecOn, WellFounded.fix_eq, dif_neg h]
   have {b c hb hc} {x : ∀ a, C a} (h : b = c) :
     congr_arg Order.succ h ▸ hs b hb (x b) = hs c hc (x c) := by subst h; rfl
-  let x := Classical.indefiniteDescription _ (not_isSuccLimit_iff.mp h)
+  let x := Classical.indefiniteDescription _ (not_isSuccPrelimit_iff.mp h)
   exact this ((succ_eq_succ_iff_of_not_isMax x.2.1 hb).mp x.2.2)
+
+@[deprecated prelimitRecOn_succ (since := "2024-09-05")]
+alias limitRecOn_succ := prelimitRecOn_succ
 
 end LinearOrder
 
-end limitRecOn
+end prelimitRecOn
 
 end SuccOrder
 
 namespace PredOrder
 
-section limitRecOn
+section prelimitRecOn
 
 section PartialOrder
 
 variable [PartialOrder α] [PredOrder α] [WellFoundedGT α]
 
 /-- Recursion principle on a well-founded partial `PredOrder`. -/
-@[elab_as_elim] noncomputable def limitRecOn (b : α)
+@[elab_as_elim] noncomputable def prelimitRecOn (b : α)
     (hp : ∀ a, ¬ IsMin a → C a → C (Order.pred a))
-    (hl : ∀ a, IsPredLimit a → (∀ b > a, C b) → C a) : C b :=
-  SuccOrder.limitRecOn (α := αᵒᵈ) b hp fun a ha => hl a (isSuccLimit.dual ha)
+    (hl : ∀ a, IsPredPrelimit a → (∀ b > a, C b) → C a) : C b :=
+  SuccOrder.prelimitRecOn (α := αᵒᵈ) b hp fun a ha => hl a ha.dual
+
+@[deprecated prelimitRecOn (since := "2024-09-05")]
+alias limitRecOn := prelimitRecOn
 
 @[simp]
-theorem limitRecOn_limit (hp : ∀ a, ¬ IsMin a → C a → C (Order.pred a))
-    (hl : ∀ a, IsPredLimit a → (∀ b > a, C b) → C a) (hb : IsPredLimit b) :
-    limitRecOn b hp hl = hl b hb fun x _ ↦ limitRecOn x hp hl :=
-  SuccOrder.limitRecOn_limit _ _ (isPredLimit.dual hb)
+theorem prelimitRecOn_limit (hp : ∀ a, ¬ IsMin a → C a → C (Order.pred a))
+    (hl : ∀ a, IsPredPrelimit a → (∀ b > a, C b) → C a) (hb : IsPredPrelimit b) :
+    prelimitRecOn b hp hl = hl b hb fun x _ ↦ prelimitRecOn x hp hl :=
+  SuccOrder.prelimitRecOn_limit _ _ hb.dual
+
+@[deprecated prelimitRecOn_limit (since := "2024-09-05")]
+alias limitRecOn_limit := prelimitRecOn_limit
 
 end PartialOrder
 
 section LinearOrder
 
 variable [LinearOrder α] [PredOrder α] [WellFoundedGT α]
-  (hp : ∀ a, ¬ IsMin a → C a → C (Order.pred a)) (hl : ∀ a, IsPredLimit a → (∀ b > a, C b) → C a)
+  (hp : ∀ a, ¬ IsMin a → C a → C (Order.pred a)) (hl : ∀ a, IsPredPrelimit a → (∀ b > a, C b) → C a)
 
 @[simp]
-theorem limitRecOn_pred (hb : ¬ IsMin b) :
-    limitRecOn (Order.pred b) hp hl = hp b hb (limitRecOn b hp hl) :=
-  SuccOrder.limitRecOn_succ (α := αᵒᵈ) _ _ hb
+theorem prelimitRecOn_pred (hb : ¬ IsMin b) :
+    prelimitRecOn (Order.pred b) hp hl = hp b hb (prelimitRecOn b hp hl) :=
+  SuccOrder.prelimitRecOn_succ (α := αᵒᵈ) _ _ hb
+
+@[deprecated prelimitRecOn_pred (since := "2024-09-05")]
+alias limitRecOn_pred := prelimitRecOn_pred
 
 end LinearOrder
 
-end limitRecOn
+end prelimitRecOn
 
 end PredOrder

--- a/Mathlib/SetTheory/Cardinal/Basic.lean
+++ b/Mathlib/SetTheory/Cardinal/Basic.lean
@@ -711,21 +711,27 @@ theorem add_one_le_succ (c : Cardinal.{u}) : c + 1 ≤ succ c := by
 /-- A cardinal is a limit if it is not zero or a successor cardinal. Note that `ℵ₀` is a limit
   cardinal by this definition, but `0` isn't.
 
-  Use `IsSuccLimit` if you want to include the `c = 0` case. -/
+  Use `IsSuccPrelimit` if you want to include the `c = 0` case. -/
 def IsLimit (c : Cardinal) : Prop :=
-  c ≠ 0 ∧ IsSuccLimit c
+  c ≠ 0 ∧ IsSuccPrelimit c
 
 protected theorem IsLimit.ne_zero {c} (h : IsLimit c) : c ≠ 0 :=
   h.1
 
-protected theorem IsLimit.isSuccLimit {c} (h : IsLimit c) : IsSuccLimit c :=
+protected theorem IsLimit.isSuccPrelimit {c} (h : IsLimit c) : IsSuccPrelimit c :=
   h.2
 
-theorem IsLimit.succ_lt {x c} (h : IsLimit c) : x < c → succ x < c :=
-  h.isSuccLimit.succ_lt
+@[deprecated IsLimit.isSuccPrelimit (since := "2024-09-05")]
+alias IsLimit.isSuccLimit := IsLimit.isSuccPrelimit
 
-theorem isSuccLimit_zero : IsSuccLimit (0 : Cardinal) :=
-  isSuccLimit_bot
+theorem IsLimit.succ_lt {x c} (h : IsLimit c) : x < c → succ x < c :=
+  h.isSuccPrelimit.succ_lt
+
+theorem isSuccPrelimit_zero : IsSuccPrelimit (0 : Cardinal) :=
+  isSuccPrelimit_bot
+
+@[deprecated isSuccPrelimit_zero (since := "2024-09-05")]
+alias isSuccLimit_zero := isSuccPrelimit_zero
 
 /-- The indexed sum of cardinals is the cardinality of the
   indexed disjoint union, i.e. sigma type. -/
@@ -863,22 +869,25 @@ theorem sum_nat_eq_add_sum_succ (f : ℕ → Cardinal.{u}) :
 protected theorem iSup_of_empty {ι} (f : ι → Cardinal) [IsEmpty ι] : iSup f = 0 :=
   ciSup_of_empty f
 
-lemma exists_eq_of_iSup_eq_of_not_isSuccLimit
+lemma exists_eq_of_iSup_eq_of_not_isSuccPrelimit
     {ι : Type u} (f : ι → Cardinal.{v}) (ω : Cardinal.{v})
-    (hω : ¬ Order.IsSuccLimit ω)
+    (hω : ¬ Order.IsSuccPrelimit ω)
     (h : ⨆ i : ι, f i = ω) : ∃ i, f i = ω := by
   subst h
-  refine (isLUB_csSup' ?_).exists_of_not_isSuccLimit hω
+  refine (isLUB_csSup' ?_).exists_of_not_isSuccPrelimit hω
   contrapose! hω with hf
   rw [iSup, csSup_of_not_bddAbove hf, csSup_empty]
-  exact Order.isSuccLimit_bot
+  exact isSuccPrelimit_bot
+
+@[deprecated exists_eq_of_iSup_eq_of_not_isSuccPrelimit (since := "2024-09-05")]
+alias exists_eq_of_iSup_eq_of_not_isSuccLimit := exists_eq_of_iSup_eq_of_not_isSuccPrelimit
 
 lemma exists_eq_of_iSup_eq_of_not_isLimit
     {ι : Type u} [hι : Nonempty ι] (f : ι → Cardinal.{v}) (hf : BddAbove (range f))
     (ω : Cardinal.{v}) (hω : ¬ ω.IsLimit)
     (h : ⨆ i : ι, f i = ω) : ∃ i, f i = ω := by
   refine (not_and_or.mp hω).elim (fun e ↦ ⟨hι.some, ?_⟩)
-    (Cardinal.exists_eq_of_iSup_eq_of_not_isSuccLimit.{u, v} f ω · h)
+    (Cardinal.exists_eq_of_iSup_eq_of_not_isSuccPrelimit.{u, v} f ω · h)
   cases not_not.mp e
   rw [← le_zero_iff] at h ⊢
   exact (le_ciSup hf _).trans h
@@ -1325,18 +1334,21 @@ theorem aleph0_le {c : Cardinal} : ℵ₀ ≤ c ↔ ∀ n : ℕ, ↑n ≤ c :=
       rcases lt_aleph0.1 hn with ⟨n, rfl⟩
       exact (Nat.lt_succ_self _).not_le (natCast_le.1 (h (n + 1)))⟩
 
-theorem isSuccLimit_aleph0 : IsSuccLimit ℵ₀ :=
-  isSuccLimit_of_succ_lt fun a ha => by
+theorem isSuccPrelimit_aleph0 : IsSuccPrelimit ℵ₀ :=
+  isSuccPrelimit_of_succ_lt fun a ha => by
     rcases lt_aleph0.1 ha with ⟨n, rfl⟩
     rw [← nat_succ]
     apply nat_lt_aleph0
 
+@[deprecated isSuccPrelimit_aleph0 (since := "2024-09-05")]
+alias isSuccLimit_aleph0 := isSuccPrelimit_aleph0
+
 theorem isLimit_aleph0 : IsLimit ℵ₀ :=
-  ⟨aleph0_ne_zero, isSuccLimit_aleph0⟩
+  ⟨aleph0_ne_zero, isSuccPrelimit_aleph0⟩
 
 lemma not_isLimit_natCast : (n : ℕ) → ¬ IsLimit (n : Cardinal.{u})
   | 0, e => e.1 rfl
-  | Nat.succ n, e => Order.not_isSuccLimit_succ _ (nat_succ n ▸ e.2)
+  | Nat.succ n, e => Order.not_isSuccPrelimit_succ _ (nat_succ n ▸ e.2)
 
 theorem IsLimit.aleph0_le {c : Cardinal} (h : IsLimit c) : ℵ₀ ≤ c := by
   by_contra! h'

--- a/Mathlib/SetTheory/Cardinal/Cofinality.lean
+++ b/Mathlib/SetTheory/Cardinal/Cofinality.lean
@@ -777,8 +777,11 @@ theorem isStrongLimit_aleph0 : IsStrongLimit ℵ₀ :=
     rcases lt_aleph0.1 hx with ⟨n, rfl⟩
     exact mod_cast nat_lt_aleph0 (2 ^ n)⟩
 
-protected theorem IsStrongLimit.isSuccLimit {c} (H : IsStrongLimit c) : IsSuccLimit c :=
-  isSuccLimit_of_succ_lt fun x h => (succ_le_of_lt <| cantor x).trans_lt (H.two_power_lt h)
+protected theorem IsStrongLimit.isSuccPrelimit {c} (H : IsStrongLimit c) : IsSuccPrelimit c :=
+  isSuccPrelimit_of_succ_lt fun x h => (succ_le_of_lt <| cantor x).trans_lt (H.two_power_lt h)
+
+@[deprecated IsStrongLimit.isSuccPrelimit (since := "2024-09-05")]
+alias IsStrongLimit.isSuccLimit := IsStrongLimit.isSuccPrelimit
 
 theorem IsStrongLimit.isLimit {c} (H : IsStrongLimit c) : IsLimit c :=
   ⟨H.ne_zero, H.isSuccLimit⟩

--- a/Mathlib/SetTheory/Cardinal/Cofinality.lean
+++ b/Mathlib/SetTheory/Cardinal/Cofinality.lean
@@ -784,14 +784,14 @@ protected theorem IsStrongLimit.isSuccPrelimit {c} (H : IsStrongLimit c) : IsSuc
 alias IsStrongLimit.isSuccLimit := IsStrongLimit.isSuccPrelimit
 
 theorem IsStrongLimit.isLimit {c} (H : IsStrongLimit c) : IsLimit c :=
-  ⟨H.ne_zero, H.isSuccLimit⟩
+  ⟨H.ne_zero, H.isSuccPrelimit⟩
 
-theorem isStrongLimit_beth {o : Ordinal} (H : IsSuccLimit o) : IsStrongLimit (beth o) := by
+theorem isStrongLimit_beth {o : Ordinal} (H : IsSuccPrelimit o) : IsStrongLimit (beth o) := by
   rcases eq_or_ne o 0 with (rfl | h)
   · rw [beth_zero]
     exact isStrongLimit_aleph0
   · refine ⟨beth_ne_zero o, fun a ha => ?_⟩
-    rw [beth_limit ⟨h, isSuccLimit_iff_succ_lt.1 H⟩] at ha
+    rw [beth_limit ⟨h, isSuccPrelimit_iff_succ_lt.1 H⟩] at ha
     rcases exists_lt_of_lt_ciSup' ha with ⟨⟨i, hi⟩, ha⟩
     have := power_le_power_left two_ne_zero ha.le
     rw [← beth_succ] at this

--- a/Mathlib/SetTheory/Ordinal/Arithmetic.lean
+++ b/Mathlib/SetTheory/Ordinal/Arithmetic.lean
@@ -216,12 +216,19 @@ theorem lift_pred (o : Ordinal.{v}) : lift.{u} (pred o) = pred (lift.{u} o) := b
 def IsLimit (o : Ordinal) : Prop :=
   o ≠ 0 ∧ ∀ a < o, succ a < o
 
-theorem IsLimit.isSuccLimit {o} (h : IsLimit o) : IsSuccLimit o := isSuccLimit_iff_succ_lt.mpr h.2
+theorem IsLimit.isSuccPrelimit {o} (h : IsLimit o) : IsSuccPrelimit o :=
+  isSuccPrelimit_iff_succ_lt.mpr h.2
+
+@[deprecated IsLimit.isSuccPrelimit (since := "2024-09-05")]
+alias IsLimit.isSuccLimit := IsLimit.isSuccPrelimit
 
 theorem IsLimit.succ_lt {o a : Ordinal} (h : IsLimit o) : a < o → succ a < o :=
   h.2 a
 
-theorem isSuccLimit_zero : IsSuccLimit (0 : Ordinal) := isSuccLimit_bot
+theorem isSuccPrelimit_zero : IsSuccPrelimit (0 : Ordinal) := isSuccPrelimit_bot
+
+@[deprecated isSuccPrelimit_zero (since := "2024-09-05")]
+alias isSuccLimit_zero := isSuccPrelimit_zero
 
 theorem not_zero_isLimit : ¬IsLimit 0
   | ⟨h, _⟩ => h rfl
@@ -277,22 +284,22 @@ theorem zero_or_succ_or_limit (o : Ordinal) : o = 0 ∨ (∃ a, o = succ a) ∨ 
 @[elab_as_elim]
 def limitRecOn {C : Ordinal → Sort*} (o : Ordinal) (H₁ : C 0) (H₂ : ∀ o, C o → C (succ o))
     (H₃ : ∀ o, IsLimit o → (∀ o' < o, C o') → C o) : C o :=
-  SuccOrder.limitRecOn o (fun o _ ↦ H₂ o) fun o hl ↦
+  SuccOrder.prelimitRecOn o (fun o _ ↦ H₂ o) fun o hl ↦
     if h : o = 0 then fun _ ↦ h ▸ H₁ else H₃ o ⟨h, fun _ ↦ hl.succ_lt⟩
 
 @[simp]
 theorem limitRecOn_zero {C} (H₁ H₂ H₃) : @limitRecOn C 0 H₁ H₂ H₃ = H₁ := by
-  rw [limitRecOn, SuccOrder.limitRecOn_limit _ _ isSuccLimit_zero, dif_pos rfl]
+  rw [limitRecOn, SuccOrder.prelimitRecOn_limit _ _ isSuccPrelimit_zero, dif_pos rfl]
 
 @[simp]
 theorem limitRecOn_succ {C} (o H₁ H₂ H₃) :
     @limitRecOn C (succ o) H₁ H₂ H₃ = H₂ o (@limitRecOn C o H₁ H₂ H₃) := by
-  rw [limitRecOn, limitRecOn, SuccOrder.limitRecOn_succ _ _ (not_isMax _)]
+  rw [limitRecOn, limitRecOn, SuccOrder.prelimitRecOn_succ _ _ (not_isMax _)]
 
 @[simp]
 theorem limitRecOn_limit {C} (o H₁ H₂ H₃ h) :
     @limitRecOn C o H₁ H₂ H₃ = H₃ o h fun x _h => @limitRecOn C x H₁ H₂ H₃ := by
-  simp_rw [limitRecOn, SuccOrder.limitRecOn_limit _ _ h.isSuccLimit, dif_neg h.1]
+  simp_rw [limitRecOn, SuccOrder.prelimitRecOn_limit _ _ h.isSuccPrelimit, dif_neg h.1]
 
 instance orderTopToTypeSucc (o : Ordinal) : OrderTop (succ o).toType :=
   @OrderTop.mk _ _ (Top.mk _) le_enum_succ


### PR DESCRIPTION
A future PR will redefine `IsSuccLimit` as a non-minimal `IsSuccPrelimit`. This matches standard usage for ordinals and cardinals. The "pre-" in the name was chosen by analogy to e.g. `PreconnectedSpace`.

Every theorem that previously used `isSuccLimit` in its name is deprecated. Some of these will be overwritten once `IsSuccLimit` is defined.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
