### PR TITLE
chore(Mathlib/Logic): sort imports

### DIFF
--- a/Mathlib/Logic/Basic.lean
+++ b/Mathlib/Logic/Basic.lean
@@ -3,14 +3,14 @@ Copyright (c) 2016 Jeremy Avigad. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Jeremy Avigad, Leonardo de Moura
 -/
+import Batteries.Logic
+import Batteries.Tactic.Lint.Basic
+import Batteries.Util.LibraryNote
+import Mathlib.Data.Int.Notation
+import Mathlib.Data.Nat.Notation
+import Mathlib.Order.Defs
 import Mathlib.Tactic.Attr.Register
 import Mathlib.Tactic.Basic
-import Batteries.Logic
-import Batteries.Util.LibraryNote
-import Batteries.Tactic.Lint.Basic
-import Mathlib.Data.Nat.Notation
-import Mathlib.Data.Int.Notation
-import Mathlib.Order.Defs
 
 /-!
 # Basic logic properties

--- a/Mathlib/Logic/Embedding/Set.lean
+++ b/Mathlib/Logic/Embedding/Set.lean
@@ -3,11 +3,11 @@ Copyright (c) 2017 Johannes Hölzl. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johannes Hölzl, Mario Carneiro
 -/
+import Mathlib.Data.Set.Image
 import Mathlib.Data.Set.Notation
-import Mathlib.Order.SetNotation
 import Mathlib.Logic.Embedding.Basic
 import Mathlib.Logic.Pairwise
-import Mathlib.Data.Set.Image
+import Mathlib.Order.SetNotation
 
 /-!
 # Interactions between embeddings and sets.

--- a/Mathlib/Logic/Encodable/Lattice.lean
+++ b/Mathlib/Logic/Encodable/Lattice.lean
@@ -3,9 +3,9 @@ Copyright (c) 2020 Floris van Doorn. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Floris van Doorn
 -/
+import Mathlib.Data.Set.Subsingleton
 import Mathlib.Logic.Encodable.Basic
 import Mathlib.Logic.Pairwise
-import Mathlib.Data.Set.Subsingleton
 
 /-!
 # Lattice operations on encodable types

--- a/Mathlib/Logic/Equiv/Basic.lean
+++ b/Mathlib/Logic/Equiv/Basic.lean
@@ -12,13 +12,13 @@ import Mathlib.Data.Sum.Basic
 import Mathlib.Init.Algebra.Classes
 import Mathlib.Logic.Equiv.Defs
 import Mathlib.Logic.Function.Conjugate
-import Mathlib.Tactic.Coe
-import Mathlib.Tactic.Lift
-import Mathlib.Tactic.Convert
-import Mathlib.Tactic.Contrapose
-import Mathlib.Tactic.GeneralizeProofs
-import Mathlib.Tactic.SimpRw
 import Mathlib.Tactic.CC
+import Mathlib.Tactic.Coe
+import Mathlib.Tactic.Contrapose
+import Mathlib.Tactic.Convert
+import Mathlib.Tactic.GeneralizeProofs
+import Mathlib.Tactic.Lift
+import Mathlib.Tactic.SimpRw
 
 /-!
 # Equivalence between types

--- a/Mathlib/Logic/Equiv/Defs.lean
+++ b/Mathlib/Logic/Equiv/Defs.lean
@@ -3,12 +3,12 @@ Copyright (c) 2015 Microsoft Corporation. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Leonardo de Moura, Mario Carneiro
 -/
+import Mathlib.Data.Bool.Basic
 import Mathlib.Data.FunLike.Equiv
 import Mathlib.Data.Quot
-import Mathlib.Data.Bool.Basic
 import Mathlib.Logic.Unique
-import Mathlib.Tactic.Substs
 import Mathlib.Tactic.Conv
+import Mathlib.Tactic.Substs
 
 /-!
 # Equivalence between types

--- a/Mathlib/Logic/Equiv/Fin.lean
+++ b/Mathlib/Logic/Equiv/Fin.lean
@@ -3,8 +3,8 @@ Copyright (c) 2018 Kenny Lau. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Kenny Lau
 -/
-import Mathlib.Data.Int.Defs
 import Mathlib.Data.Fin.VecNotation
+import Mathlib.Data.Int.Defs
 import Mathlib.Logic.Embedding.Set
 import Mathlib.Logic.Equiv.Option
 

--- a/Mathlib/Logic/Equiv/PartialEquiv.lean
+++ b/Mathlib/Logic/Equiv/PartialEquiv.lean
@@ -5,8 +5,8 @@ Authors: Sébastien Gouëzel
 -/
 import Mathlib.Data.Set.Function
 import Mathlib.Logic.Equiv.Defs
-import Mathlib.Tactic.Core
 import Mathlib.Tactic.Attr.Core
+import Mathlib.Tactic.Core
 
 /-!
 # Partial equivalences

--- a/Mathlib/Logic/Function/Basic.lean
+++ b/Mathlib/Logic/Function/Basic.lean
@@ -3,11 +3,11 @@ Copyright (c) 2016 Johannes Hölzl. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johannes Hölzl, Mario Carneiro
 -/
+import Batteries.Tactic.Init
 import Mathlib.Data.Set.Defs
 import Mathlib.Logic.Basic
 import Mathlib.Logic.ExistsUnique
 import Mathlib.Logic.Nonempty
-import Batteries.Tactic.Init
 
 /-!
 # Miscellaneous function constructions and lemmas

--- a/Mathlib/Logic/Function/Defs.lean
+++ b/Mathlib/Logic/Function/Defs.lean
@@ -3,12 +3,12 @@ Copyright (c) 2014 Microsoft Corporation. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Leonardo de Moura, Jeremy Avigad, Haitao Zhang
 -/
+import Batteries.Logic
 import Mathlib.Tactic.AdaptationNote
 import Mathlib.Tactic.Attr.Register
-import Mathlib.Tactic.Lemma
 import Mathlib.Tactic.Eqns
+import Mathlib.Tactic.Lemma
 import Mathlib.Tactic.TypeStar
-import Batteries.Logic
 
 /-!
 # General operations on functions

--- a/Mathlib/Logic/Godel/GodelBetaFunction.lean
+++ b/Mathlib/Logic/Godel/GodelBetaFunction.lean
@@ -4,10 +4,10 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Shogo Saito. Adapted for mathlib by Hunter Monroe
 -/
 
-import Mathlib.Data.Nat.ModEq
 import Mathlib.Data.Nat.ChineseRemainder
-import Mathlib.Data.Nat.Prime.Defs
+import Mathlib.Data.Nat.ModEq
 import Mathlib.Data.Nat.Pairing
+import Mathlib.Data.Nat.Prime.Defs
 
 /-!
 # Gödel's Beta Function Lemma

--- a/Mathlib/Logic/Pairwise.lean
+++ b/Mathlib/Logic/Pairwise.lean
@@ -3,8 +3,8 @@ Copyright (c) 2017 Johannes Hölzl. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johannes Hölzl
 -/
-import Mathlib.Logic.Function.Basic
 import Mathlib.Data.Set.Defs
+import Mathlib.Logic.Function.Basic
 import Mathlib.Tactic.Common
 
 /-!

--- a/Mathlib/Logic/Relation.lean
+++ b/Mathlib/Logic/Relation.lean
@@ -5,9 +5,9 @@ Authors: Johannes Hölzl
 -/
 import Mathlib.Logic.Function.Basic
 import Mathlib.Logic.Relator
-import Mathlib.Tactic.Use
 import Mathlib.Tactic.MkIffOfInductiveProp
 import Mathlib.Tactic.SimpRw
+import Mathlib.Tactic.Use
 
 /-!
 # Relation closures

--- a/Mathlib/Logic/Small/Basic.lean
+++ b/Mathlib/Logic/Small/Basic.lean
@@ -3,8 +3,8 @@ Copyright (c) 2021 Scott Morrison. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Scott Morrison
 -/
-import Mathlib.Logic.Small.Defs
 import Mathlib.Logic.Equiv.Set
+import Mathlib.Logic.Small.Defs
 
 /-!
 # Instances and theorems for `Small`.

--- a/Mathlib/Logic/Small/Group.lean
+++ b/Mathlib/Logic/Small/Group.lean
@@ -3,8 +3,8 @@ Copyright (c) 2021 Scott Morrison. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Scott Morrison
 -/
-import Mathlib.Logic.Small.Defs
 import Mathlib.Logic.Equiv.TransferInstance
+import Mathlib.Logic.Small.Defs
 
 /-!
 # Transfer group structures from `α` to `Shrink α`.

--- a/Mathlib/Logic/Small/List.lean
+++ b/Mathlib/Logic/Small/List.lean
@@ -3,8 +3,8 @@ Copyright (c) 2021 Scott Morrison. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Scott Morrison
 -/
-import Mathlib.Logic.Small.Basic
 import Mathlib.Data.Vector.Basic
+import Mathlib.Logic.Small.Basic
 
 /-!
 # Instances for `Small (List α)` and `Small (Vector α)`.

--- a/Mathlib/Logic/Small/Ring.lean
+++ b/Mathlib/Logic/Small/Ring.lean
@@ -3,8 +3,8 @@ Copyright (c) 2021 Scott Morrison. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Scott Morrison
 -/
-import Mathlib.Logic.Small.Defs
 import Mathlib.Logic.Equiv.TransferInstance
+import Mathlib.Logic.Small.Defs
 
 /-!
 # Transfer ring structures from `α` to `Shrink α`.


### PR DESCRIPTION
This is easier to read and maintain (and could reduce merge conflicts, for example). Benchmarking results are neutral.

---
Context: #16419, of which this PR is a subset.

To verify that all modified lines in the last commit are import statements:

`% git diff HEAD~1 | grep '^[+-][^+-]' | cut -c2- | grep -v '^import '`

To verify that the total number of changes (additions and deletions) for any specific import statement is even:

`% git diff HEAD~1 | grep '^[+-][^+-]' | cut -c2- | sort | uniq -c | grep -v '[02468] import'`
