### PR TITLE
[Merged by Bors] - chore(Combinatorics/Additive): correct docstrings

### DIFF
--- a/Mathlib/Combinatorics/Additive/AP/Three/Defs.lean
+++ b/Mathlib/Combinatorics/Additive/AP/Three/Defs.lean
@@ -103,18 +103,18 @@ end Monoid
 section CommMonoid
 variable [CommMonoid α] [CommMonoid β] {s A : Set α} {t B : Set β} {f : α → β} {a : α}
 
-/-- Arithmetic progressions of length three are preserved under `2`-Freiman homomorphisms. -/
+/-- Geometric progressions of length three are reflected under `2`-Freiman homomorphisms. -/
 @[to_additive
-"Arithmetic progressions of length three are preserved under `2`-Freiman homomorphisms."]
+"Arithmetic progressions of length three are reflected under `2`-Freiman homomorphisms."]
 lemma ThreeGPFree.of_image (hf : IsMulFreimanHom 2 s t f) (hf' : s.InjOn f) (hAs : A ⊆ s)
     (hA : ThreeGPFree (f '' A)) : ThreeGPFree A :=
   fun _ ha _ hb _ hc habc ↦ hf' (hAs ha) (hAs hb) <| hA (mem_image_of_mem _ ha)
     (mem_image_of_mem _ hb) (mem_image_of_mem _ hc) <|
     hf.mul_eq_mul (hAs ha) (hAs hc) (hAs hb) (hAs hb) habc
 
-/-- Arithmetic progressions of length three are preserved under `2`-Freiman isomorphisms. -/
+/-- Geometric progressions of length three are unchanged under `2`-Freiman isomorphisms. -/
 @[to_additive
-"Arithmetic progressions of length three are preserved under `2`-Freiman isomorphisms."]
+"Arithmetic progressions of length three are unchanged under `2`-Freiman isomorphisms."]
 lemma threeGPFree_image (hf : IsMulFreimanIso 2 s t f) (hAs : A ⊆ s) :
     ThreeGPFree (f '' A) ↔ ThreeGPFree A := by
   rw [ThreeGPFree, ThreeGPFree]
@@ -125,25 +125,23 @@ lemma threeGPFree_image (hf : IsMulFreimanIso 2 s t f) (hAs : A ⊆ s) :
 
 @[to_additive] alias ⟨_, ThreeGPFree.image⟩ := threeGPFree_image
 
-/-- Arithmetic progressions of length three are preserved under `2`-Freiman homomorphisms. -/
-@[to_additive]
+/-- Geometric progressions of length three are reflected under `2`-Freiman homomorphisms. -/
+@[to_additive
+"Arithmetic progressions of length three are reflected under `2`-Freiman homomorphisms."]
 lemma IsMulFreimanHom.threeGPFree (hf : IsMulFreimanHom 2 s t f) (hf' : s.InjOn f)
     (ht : ThreeGPFree t) : ThreeGPFree s :=
-  fun _ ha _ hb _ hc habc ↦ hf' ha hb <| ht (hf.mapsTo ha) (hf.mapsTo hb) (hf.mapsTo hc) <|
-    hf.mul_eq_mul ha hc hb hb habc
+  (ht.mono hf.mapsTo.image_subset).of_image hf hf' subset_rfl
 
-/-- Arithmetic progressions of length three are preserved under `2`-Freiman isomorphisms. -/
-@[to_additive]
+/-- Geometric progressions of length three are unchanged under `2`-Freiman isomorphisms. -/
+@[to_additive
+"Arithmetic progressions of length three are unchanged under `2`-Freiman isomorphisms."]
 lemma IsMulFreimanIso.threeGPFree_congr (hf : IsMulFreimanIso 2 s t f) :
-    ThreeGPFree s ↔ ThreeGPFree t where
-  mpr := hf.isMulFreimanHom.threeGPFree hf.bijOn.injOn
-  mp hs a hfa b hfb c hfc habc := by
-    obtain ⟨a, ha, rfl⟩ := hf.bijOn.surjOn hfa
-    obtain ⟨b, hb, rfl⟩ := hf.bijOn.surjOn hfb
-    obtain ⟨c, hc, rfl⟩ := hf.bijOn.surjOn hfc
-    exact congr_arg f <| hs ha hb hc <| (hf.mul_eq_mul ha hc hb hb).1 habc
+    ThreeGPFree s ↔ ThreeGPFree t := by
+  rw [← threeGPFree_image hf subset_rfl, hf.bijOn.image_eq]
 
-@[to_additive]
+/-- Geometric progressions of length three are preserved under semigroup homomorphisms. -/
+@[to_additive
+"Arithmetic progressions of length three are preserved under semigroup homomorphisms."]
 theorem ThreeGPFree.image' [FunLike F α β] [MulHomClass F α β] (f : F) (hf : (s * s).InjOn f)
     (h : ThreeGPFree s) : ThreeGPFree (f '' s) := by
   rintro _ ⟨a, ha, rfl⟩ _ ⟨b, hb, rfl⟩ _ ⟨c, hc, rfl⟩ habc
@@ -155,7 +153,7 @@ section CancelCommMonoid
 
 variable [CancelCommMonoid α] {s : Set α} {a : α}
 
-lemma ThreeGPFree.eq_right (hs : ThreeGPFree s) :
+@[to_additive] lemma ThreeGPFree.eq_right (hs : ThreeGPFree s) :
     ∀ ⦃a⦄, a ∈ s → ∀ ⦃b⦄, b ∈ s → ∀ ⦃c⦄, c ∈ s → a * c = b * b → b = c := by
   rintro a ha b hb c hc habc
   obtain rfl := hs ha hb hc habc

--- a/Mathlib/Tactic/ToAdditive/Frontend.lean
+++ b/Mathlib/Tactic/ToAdditive/Frontend.lean
@@ -965,6 +965,7 @@ def nameDict : String → List String
   | "zpowers"     => ["zmultiples"]
   | "powers"      => ["multiples"]
   | "multipliable"=> ["summable"]
+  | "gpfree"      => ["apfree"]
   | x             => [x]
 
 /--
@@ -1049,8 +1050,6 @@ def fixAbbreviation : List String → List String
                                       => "function" :: "_" :: "commute" :: fixAbbreviation s
   | "zero" :: "Le" :: "Part" :: s         => "posPart" :: fixAbbreviation s
   | "le" :: "Zero" :: "Part" :: s         => "negPart" :: fixAbbreviation s
-  | "three" :: "GPFree" :: s         => "three" :: "APFree" :: fixAbbreviation s
-  | "Three" :: "GPFree" :: s         => "Three" :: "APFree" :: fixAbbreviation s
   | "Division" :: "Add" :: "Monoid" :: s => "SubtractionMonoid" :: fixAbbreviation s
   | "division" :: "Add" :: "Monoid" :: s => "subtractionMonoid" :: fixAbbreviation s
   | "Sub" :: "Neg" :: "Zero" :: "Add" :: "Monoid" :: s => "SubNegZeroMonoid" :: fixAbbreviation s


### PR DESCRIPTION
Fix incorrect or misleading docstrings. 
Adjust to_additive setup for APFree, following the comment in #12682.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
