### PR TITLE
[Merged by Bors] - feat(Category/Basic): make `mono_comp` and `epi_comp` instances and golf proofs

### DIFF
--- a/Mathlib/Algebra/Category/ModuleCat/Sheaf/Generators.lean
+++ b/Mathlib/Algebra/Category/ModuleCat/Sheaf/Generators.lean
@@ -66,8 +66,6 @@ def ofEpi (σ : M.GeneratingSections) (p : M ⟶ N) [Epi p] :
     rw [← freeHomEquiv_symm_comp]
     apply epi_comp
 
-attribute [local instance] epi_comp
-
 lemma opEpi_id (σ : M.GeneratingSections) :
     σ.ofEpi (𝟙 M) = σ := rfl
 

--- a/Mathlib/Algebra/Homology/HomologySequenceLemmas.lean
+++ b/Mathlib/Algebra/Homology/HomologySequenceLemmas.lean
@@ -103,8 +103,6 @@ noncomputable def mapComposableArrows₅ (i j : ι) (hij : c.Rel i j) :
     (naturality' (mapComposableArrows₂ φ j) 0 1)
     (naturality' (mapComposableArrows₂ φ j) 1 2)
 
-attribute [local instance] epi_comp
-
 include hS₁ hS₂
 
 lemma mono_homologyMap_τ₃ (i : ι)

--- a/Mathlib/Algebra/Homology/ImageToKernel.lean
+++ b/Mathlib/Algebra/Homology/ImageToKernel.lean
@@ -147,7 +147,7 @@ instance imageToKernel_epi_of_epi_of_zero [HasImages V] [Epi f] :
   simp only [imageToKernel_zero_right]
   haveI := epi_image_of_epi f
   rw [← imageSubobject_arrow]
-  exact @epi_comp _ _ _ _ _ _ (epi_comp _ _) _ _
+  infer_instance
 
 end
 

--- a/Mathlib/Algebra/Homology/ShortComplex/HomologicalComplex.lean
+++ b/Mathlib/Algebra/Homology/ShortComplex/HomologicalComplex.lean
@@ -318,8 +318,6 @@ lemma p_opcyclesMap : K.pOpcycles i ≫ opcyclesMap φ i = φ.f i ≫ L.pOpcycle
 
 instance [Mono (φ.f i)] : Mono (cyclesMap φ i) := mono_of_mono_fac (cyclesMap_i φ i)
 
-attribute [local instance] epi_comp
-
 instance [Epi (φ.f i)] : Epi (opcyclesMap φ i) := epi_of_epi_fac (p_opcyclesMap φ i)
 
 variable (K)

--- a/Mathlib/CategoryTheory/Abelian/DiagramLemmas/Four.lean
+++ b/Mathlib/CategoryTheory/Abelian/DiagramLemmas/Four.lean
@@ -87,8 +87,6 @@ theorem mono_of_epi_of_mono_of_mono (hR₁ : R₁.Exact) (hR₂ : R₂.Exact)
     (by simpa only [R₁.map'_comp 0 1 2] using hR₁.toIsComplex.zero 0)
     (hR₁.exact 1).exact_toComposableArrows (hR₂.exact 0).exact_toComposableArrows h₀ h₁ h₃
 
-attribute [local instance] epi_comp
-
 theorem epi_of_epi_of_epi_of_mono'
     (hR₁ : (mk₂ (R₁.map' 1 2) (R₁.map' 2 3)).Exact)
     (hR₂ : (mk₂ (R₂.map' 0 1) (R₂.map' 1 2)).Exact) (hR₂' : R₂.map' 1 3 = 0)

--- a/Mathlib/CategoryTheory/Abelian/NonPreadditive.lean
+++ b/Mathlib/CategoryTheory/Abelian/NonPreadditive.lean
@@ -109,7 +109,6 @@ instance : Epi (Abelian.factorThruImage f) :=
   _ fun R (g : I ⟶ R) (hpg : p ≫ g = 0) => by
   -- Since C is abelian, u := ker g ≫ i is the kernel of some morphism h.
   let u := kernel.ι g ≫ i
-  haveI : Mono u := mono_comp _ _
   haveI hu := normalMonoOfMono u
   let h := hu.g
   -- By hypothesis, p factors through the kernel of g via some t.
@@ -146,7 +145,6 @@ instance : Mono (Abelian.factorThruCoimage f) :=
   NormalEpiCategory.mono_of_cancel_zero _ fun R (g : R ⟶ I) (hgi : g ≫ i = 0) => by
     -- Since C is abelian, u := p ≫ coker g is the cokernel of some morphism h.
     let u := p ≫ cokernel.π g
-    haveI : Epi u := epi_comp _ _
     haveI hu := normalEpiOfEpi u
     let h := hu.g
     -- By hypothesis, i factors through the cokernel of g via some t.

--- a/Mathlib/CategoryTheory/Category/Basic.lean
+++ b/Mathlib/CategoryTheory/Category/Basic.lean
@@ -180,8 +180,14 @@ initialize_simps_projections Category (-Hom)
 /-- postcompose an equation between morphisms by another morphism -/
 theorem eq_whisker {f g : X ⟶ Y} (w : f = g) (h : Y ⟶ Z) : f ≫ h = g ≫ h := by rw [w]
 
+theorem eq_whisker_assoc {W : C} {f g : X ⟶ Y} {h i : Y ⟶ Z} (w : f ≫ h = g ≫ i) (j : Z ⟶ W) :
+    f ≫ h ≫ j = g ≫ i ≫ j := by simp only [← Category.assoc, w]
+
 /-- precompose an equation between morphisms by another morphism -/
 theorem whisker_eq (f : X ⟶ Y) {g h : Y ⟶ Z} (w : g = h) : f ≫ g = f ≫ h := by rw [w]
+
+theorem whisker_eq_assoc {W : C} (f : X ⟶ Y) {g h : Y ⟶ Z} {i j : Z ⟶ W} (w : g ≫ i = h ≫ j) :
+    (f ≫ g) ≫ i = (f ≫ h) ≫ j := by simp [w]
 
 /--
 Notation for whiskering an equation by a morphism (on the right).
@@ -260,9 +266,17 @@ instance (X : C) : Mono (𝟙 X) :=
 theorem cancel_epi (f : X ⟶ Y) [Epi f] {g h : Y ⟶ Z} : f ≫ g = f ≫ h ↔ g = h :=
   ⟨fun p => Epi.left_cancellation g h p, congr_arg _⟩
 
+theorem cancel_epi_assoc_iff (f : X ⟶ Y) [Epi f] {g h : Y ⟶ Z} {W : C} {k l : Z ⟶ W} :
+    (f ≫ g) ≫ k = (f ≫ h) ≫ l ↔ g ≫ k = h ≫ l :=
+  ⟨fun p => (cancel_epi f).1 <| by simpa using p, whisker_eq_assoc f⟩
+
 theorem cancel_mono (f : X ⟶ Y) [Mono f] {g h : Z ⟶ X} : g ≫ f = h ≫ f ↔ g = h :=
   -- Porting note: in Lean 3 we could just write `congr_arg _` here.
   ⟨fun p => Mono.right_cancellation g h p, congr_arg (fun k => k ≫ f)⟩
+
+theorem cancel_mono_assoc_iff (f : X ⟶ Y) [Mono f] {g h : Z ⟶ X} {W : C} {k l : W ⟶ Z} :
+    k ≫ (g ≫ f) = l ≫ (h ≫ f) ↔ k ≫ g = l ≫ h :=
+  ⟨fun p => (cancel_mono f).1 <| by simpa using p, fun p => eq_whisker_assoc p f⟩
 
 theorem cancel_epi_id (f : X ⟶ Y) [Epi f] {h : Y ⟶ Y} : f ≫ h = f ↔ h = 𝟙 Y := by
   convert cancel_epi f
@@ -272,40 +286,21 @@ theorem cancel_mono_id (f : X ⟶ Y) [Mono f] {g : X ⟶ X} : g ≫ f = f ↔ g 
   convert cancel_mono f
   simp
 
-theorem epi_comp {X Y Z : C} (f : X ⟶ Y) [Epi f] (g : Y ⟶ Z) [Epi g] : Epi (f ≫ g) := by
-  constructor
-  intro Z a b w
-  apply (cancel_epi g).1
-  apply (cancel_epi f).1
-  simpa using w
+instance epi_comp {X Y Z : C} (f : X ⟶ Y) [Epi f] (g : Y ⟶ Z) [Epi g] : Epi (f ≫ g) :=
+  ⟨fun _ _ w => (cancel_epi g).1 <| (cancel_epi_assoc_iff f).1 w⟩
 
-theorem mono_comp {X Y Z : C} (f : X ⟶ Y) [Mono f] (g : Y ⟶ Z) [Mono g] : Mono (f ≫ g) := by
-  constructor
-  intro Z a b w
-  apply (cancel_mono f).1
-  apply (cancel_mono g).1
-  simpa using w
+instance mono_comp {X Y Z : C} (f : X ⟶ Y) [Mono f] (g : Y ⟶ Z) [Mono g] : Mono (f ≫ g) :=
+  ⟨fun _ _ w => (cancel_mono f).1 <| (cancel_mono_assoc_iff g).1 w⟩
 
-theorem mono_of_mono {X Y Z : C} (f : X ⟶ Y) (g : Y ⟶ Z) [Mono (f ≫ g)] : Mono f := by
-  constructor
-  intro Z a b w
-  replace w := congr_arg (fun k => k ≫ g) w
-  dsimp at w
-  rw [Category.assoc, Category.assoc] at w
-  exact (cancel_mono _).1 w
+theorem mono_of_mono {X Y Z : C} (f : X ⟶ Y) (g : Y ⟶ Z) [Mono (f ≫ g)] : Mono f :=
+  ⟨fun _ _ w => (cancel_mono (f ≫ g)).1 <| eq_whisker_assoc w g⟩
 
 theorem mono_of_mono_fac {X Y Z : C} {f : X ⟶ Y} {g : Y ⟶ Z} {h : X ⟶ Z} [Mono h]
     (w : f ≫ g = h) : Mono f := by
-  subst h
-  exact mono_of_mono f g
+  subst h; exact mono_of_mono f g
 
-theorem epi_of_epi {X Y Z : C} (f : X ⟶ Y) (g : Y ⟶ Z) [Epi (f ≫ g)] : Epi g := by
-  constructor
-  intro Z a b w
-  replace w := congr_arg (fun k => f ≫ k) w
-  dsimp at w
-  rw [← Category.assoc, ← Category.assoc] at w
-  exact (cancel_epi _).1 w
+theorem epi_of_epi {X Y Z : C} (f : X ⟶ Y) (g : Y ⟶ Z) [Epi (f ≫ g)] : Epi g :=
+  ⟨fun _ _ w => (cancel_epi (f ≫ g)).1 <| whisker_eq_assoc f w⟩
 
 theorem epi_of_epi_fac {X Y Z : C} {f : X ⟶ Y} {g : Y ⟶ Z} {h : X ⟶ Z} [Epi h]
     (w : f ≫ g = h) : Epi g := by

--- a/Mathlib/CategoryTheory/Category/Basic.lean
+++ b/Mathlib/CategoryTheory/Category/Basic.lean
@@ -180,14 +180,8 @@ initialize_simps_projections Category (-Hom)
 /-- postcompose an equation between morphisms by another morphism -/
 theorem eq_whisker {f g : X ⟶ Y} (w : f = g) (h : Y ⟶ Z) : f ≫ h = g ≫ h := by rw [w]
 
-theorem eq_whisker_assoc {W : C} {f g : X ⟶ Y} {h i : Y ⟶ Z} (w : f ≫ h = g ≫ i) (j : Z ⟶ W) :
-    f ≫ h ≫ j = g ≫ i ≫ j := by simp only [← Category.assoc, w]
-
 /-- precompose an equation between morphisms by another morphism -/
 theorem whisker_eq (f : X ⟶ Y) {g h : Y ⟶ Z} (w : g = h) : f ≫ g = f ≫ h := by rw [w]
-
-theorem whisker_eq_assoc {W : C} (f : X ⟶ Y) {g h : Y ⟶ Z} {i j : Z ⟶ W} (w : g ≫ i = h ≫ j) :
-    (f ≫ g) ≫ i = (f ≫ h) ≫ j := by simp [w]
 
 /--
 Notation for whiskering an equation by a morphism (on the right).
@@ -268,7 +262,7 @@ theorem cancel_epi (f : X ⟶ Y) [Epi f] {g h : Y ⟶ Z} : f ≫ g = f ≫ h ↔
 
 theorem cancel_epi_assoc_iff (f : X ⟶ Y) [Epi f] {g h : Y ⟶ Z} {W : C} {k l : Z ⟶ W} :
     (f ≫ g) ≫ k = (f ≫ h) ≫ l ↔ g ≫ k = h ≫ l :=
-  ⟨fun p => (cancel_epi f).1 <| by simpa using p, whisker_eq_assoc f⟩
+  ⟨fun p => (cancel_epi f).1 <| by simpa using p, fun p => by simp only [Category.assoc, p]⟩
 
 theorem cancel_mono (f : X ⟶ Y) [Mono f] {g h : Z ⟶ X} : g ≫ f = h ≫ f ↔ g = h :=
   -- Porting note: in Lean 3 we could just write `congr_arg _` here.
@@ -276,7 +270,7 @@ theorem cancel_mono (f : X ⟶ Y) [Mono f] {g h : Z ⟶ X} : g ≫ f = h ≫ f �
 
 theorem cancel_mono_assoc_iff (f : X ⟶ Y) [Mono f] {g h : Z ⟶ X} {W : C} {k l : W ⟶ Z} :
     k ≫ (g ≫ f) = l ≫ (h ≫ f) ↔ k ≫ g = l ≫ h :=
-  ⟨fun p => (cancel_mono f).1 <| by simpa using p, fun p => eq_whisker_assoc p f⟩
+  ⟨fun p => (cancel_mono f).1 <| by simpa using p, fun p => by simp only [← Category.assoc, p]⟩
 
 theorem cancel_epi_id (f : X ⟶ Y) [Epi f] {h : Y ⟶ Y} : f ≫ h = f ↔ h = 𝟙 Y := by
   convert cancel_epi f
@@ -293,14 +287,14 @@ instance mono_comp {X Y Z : C} (f : X ⟶ Y) [Mono f] (g : Y ⟶ Z) [Mono g] : M
   ⟨fun _ _ w => (cancel_mono f).1 <| (cancel_mono_assoc_iff g).1 w⟩
 
 theorem mono_of_mono {X Y Z : C} (f : X ⟶ Y) (g : Y ⟶ Z) [Mono (f ≫ g)] : Mono f :=
-  ⟨fun _ _ w => (cancel_mono (f ≫ g)).1 <| eq_whisker_assoc w g⟩
+  ⟨fun _ _ w => (cancel_mono (f ≫ g)).1 <| by simp only [← Category.assoc, w]⟩
 
 theorem mono_of_mono_fac {X Y Z : C} {f : X ⟶ Y} {g : Y ⟶ Z} {h : X ⟶ Z} [Mono h]
     (w : f ≫ g = h) : Mono f := by
   subst h; exact mono_of_mono f g
 
 theorem epi_of_epi {X Y Z : C} (f : X ⟶ Y) (g : Y ⟶ Z) [Epi (f ≫ g)] : Epi g :=
-  ⟨fun _ _ w => (cancel_epi (f ≫ g)).1 <| whisker_eq_assoc f w⟩
+  ⟨fun _ _ w => (cancel_epi (f ≫ g)).1 <| by simp only [Category.assoc, w]⟩
 
 theorem epi_of_epi_fac {X Y Z : C} {f : X ⟶ Y} {g : Y ⟶ Z} {h : X ⟶ Z} [Epi h]
     (w : f ≫ g = h) : Epi g := by

--- a/Mathlib/CategoryTheory/Closed/Cartesian.lean
+++ b/Mathlib/CategoryTheory/Closed/Cartesian.lean
@@ -335,8 +335,9 @@ This actually shows a slightly stronger version: any morphism to an initial obje
 exponentiable object is an isomorphism.
 -/
 theorem strict_initial {I : C} (t : IsInitial I) (f : A ⟶ I) : IsIso f := by
-  haveI : Mono (prod.lift (𝟙 A) f ≫ (zeroMul t).hom) := mono_comp _ _
-  rw [zeroMul_hom, prod.lift_snd] at this
+  haveI : Mono f := by
+    rw [← prod.lift_snd (𝟙 A) f, ← zeroMul_hom t]
+    exact mono_comp _ _
   haveI : IsSplitEpi f := IsSplitEpi.mk' ⟨t.to _, t.hom_ext _ _⟩
   apply isIso_of_mono_of_isSplitEpi
 

--- a/Mathlib/CategoryTheory/Functor/EpiMono.lean
+++ b/Mathlib/CategoryTheory/Functor/EpiMono.lean
@@ -103,8 +103,7 @@ theorem reflectsMonomorphisms_of_preserves_of_reflects (F : C ⥤ D) (G : D ⥤ 
 theorem preservesMonomorphisms.of_iso {F G : C ⥤ D} [PreservesMonomorphisms F] (α : F ≅ G) :
     PreservesMonomorphisms G :=
   { preserves := fun {X} {Y} f h => by
-      haveI : Mono (F.map f ≫ (α.app Y).hom) := mono_comp _ _
-      convert (mono_comp _ _ : Mono ((α.app X).inv ≫ F.map f ≫ (α.app Y).hom))
+      suffices G.map f = (α.app X).inv ≫ F.map f ≫ (α.app Y).hom from this ▸ mono_comp _ _
       rw [Iso.eq_inv_comp, Iso.app_hom, Iso.app_hom, NatTrans.naturality] }
 
 theorem preservesMonomorphisms.iso_iff {F G : C ⥤ D} (α : F ≅ G) :
@@ -114,8 +113,7 @@ theorem preservesMonomorphisms.iso_iff {F G : C ⥤ D} (α : F ≅ G) :
 theorem preservesEpimorphisms.of_iso {F G : C ⥤ D} [PreservesEpimorphisms F] (α : F ≅ G) :
     PreservesEpimorphisms G :=
   { preserves := fun {X} {Y} f h => by
-      haveI : Epi (F.map f ≫ (α.app Y).hom) := epi_comp _ _
-      convert (epi_comp _ _ : Epi ((α.app X).inv ≫ F.map f ≫ (α.app Y).hom))
+      suffices G.map f = (α.app X).inv ≫ F.map f ≫ (α.app Y).hom from this ▸ epi_comp _ _
       rw [Iso.eq_inv_comp, Iso.app_hom, Iso.app_hom, NatTrans.naturality] }
 
 theorem preservesEpimorphisms.iso_iff {F G : C ⥤ D} (α : F ≅ G) :
@@ -126,8 +124,7 @@ theorem reflectsMonomorphisms.of_iso {F G : C ⥤ D} [ReflectsMonomorphisms F] (
     ReflectsMonomorphisms G :=
   { reflects := fun {X} {Y} f h => by
       apply F.mono_of_mono_map
-      haveI : Mono (G.map f ≫ (α.app Y).inv) := mono_comp _ _
-      convert (mono_comp _ _ : Mono ((α.app X).hom ≫ G.map f ≫ (α.app Y).inv))
+      suffices F.map f = (α.app X).hom ≫ G.map f ≫ (α.app Y).inv from this ▸ mono_comp _ _
       rw [← Category.assoc, Iso.eq_comp_inv, Iso.app_hom, Iso.app_hom, NatTrans.naturality] }
 
 theorem reflectsMonomorphisms.iso_iff {F G : C ⥤ D} (α : F ≅ G) :
@@ -138,8 +135,7 @@ theorem reflectsEpimorphisms.of_iso {F G : C ⥤ D} [ReflectsEpimorphisms F] (α
     ReflectsEpimorphisms G :=
   { reflects := fun {X} {Y} f h => by
       apply F.epi_of_epi_map
-      haveI : Epi (G.map f ≫ (α.app Y).inv) := epi_comp _ _
-      convert (epi_comp _ _ : Epi ((α.app X).hom ≫ G.map f ≫ (α.app Y).inv))
+      suffices F.map f = (α.app X).hom ≫ G.map f ≫ (α.app Y).inv from this ▸ epi_comp _ _
       rw [← Category.assoc, Iso.eq_comp_inv, Iso.app_hom, Iso.app_hom, NatTrans.naturality] }
 
 theorem reflectsEpimorphisms.iso_iff {F G : C ⥤ D} (α : F ≅ G) :

--- a/Mathlib/CategoryTheory/GlueData.lean
+++ b/Mathlib/CategoryTheory/GlueData.lean
@@ -388,7 +388,7 @@ structure GlueData' where
   cocycle : ∀ i j k hij hik hjk, t' i j k hij hik hjk ≫
     t' j k i hjk hij.symm hik.symm ≫ t' k i j hik.symm hjk.symm hij = 𝟙 _
 
-attribute [local instance] GlueData'.f_mono GlueData'.f_hasPullback mono_comp
+attribute [local instance] GlueData'.f_mono GlueData'.f_hasPullback
 
 attribute [reassoc (attr := simp)] GlueData'.t_inv GlueData'.cocycle
 

--- a/Mathlib/CategoryTheory/Limits/Shapes/Images.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/Images.lean
@@ -391,7 +391,7 @@ theorem image.ext [HasImage f] {W : C} {g h : image f ⟶ W} [HasLimit (parallel
   let F' : MonoFactorisation f :=
     { I := equalizer g h
       m := q ≫ image.ι f
-      m_mono := by apply mono_comp
+      m_mono := mono_comp _ _
       e := e' }
   let v := image.lift F'
   have t₀ : v ≫ q ≫ image.ι f = image.ι f := image.lift_fac F'

--- a/Mathlib/CategoryTheory/Limits/Shapes/Multiequalizer.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/Multiequalizer.lean
@@ -752,8 +752,6 @@ theorem ιPi_π (a) : ιPi I ≫ Pi.π I.left a = ι I a := by
   rw [ιPi, Category.assoc, ← Iso.eq_inv_comp, isoEqualizer]
   simp
 
-instance : Mono (ιPi I) := mono_comp _ _
-
 end Multiequalizer
 
 namespace Multicoequalizer
@@ -832,8 +830,6 @@ theorem ι_sigmaπ (b) : Sigma.ι I.right b ≫ sigmaπ I = π I b := by
     MultispanIndex.ofSigmaCoforkFunctor_obj, colimit.isoColimitCocone_ι_hom,
     Multicofork.ofSigmaCofork_pt, colimit.cocone_x, Multicofork.π_eq_app_right]
   rfl
-
-instance : Epi (sigmaπ I) := epi_comp _ _
 
 end Multicoequalizer
 

--- a/Mathlib/CategoryTheory/Limits/Shapes/Multiequalizer.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/Multiequalizer.lean
@@ -752,6 +752,8 @@ theorem ιPi_π (a) : ιPi I ≫ Pi.π I.left a = ι I a := by
   rw [ιPi, Category.assoc, ← Iso.eq_inv_comp, isoEqualizer]
   simp
 
+instance : Mono (ιPi I) := mono_comp _ _
+
 end Multiequalizer
 
 namespace Multicoequalizer
@@ -830,6 +832,8 @@ theorem ι_sigmaπ (b) : Sigma.ι I.right b ≫ sigmaπ I = π I b := by
     MultispanIndex.ofSigmaCoforkFunctor_obj, colimit.isoColimitCocone_ι_hom,
     Multicofork.ofSigmaCofork_pt, colimit.cocone_x, Multicofork.π_eq_app_right]
   rfl
+
+instance : Epi (sigmaπ I) := epi_comp _ _
 
 end Multicoequalizer
 

--- a/Mathlib/CategoryTheory/Limits/Shapes/StrongEpi.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/StrongEpi.lean
@@ -136,8 +136,7 @@ theorem StrongEpi.of_arrow_iso {A B A' B' : C} {f : A ⟶ B} {g : A' ⟶ B'}
     (e : Arrow.mk f ≅ Arrow.mk g) [h : StrongEpi f] : StrongEpi g :=
   { epi := by
       rw [Arrow.iso_w' e]
-      haveI := epi_comp f e.hom.right
-      apply epi_comp
+      infer_instance
     llp := fun {X Y} z => by
       intro
       apply HasLiftingProperty.of_arrow_iso_left e z }
@@ -146,8 +145,7 @@ theorem StrongMono.of_arrow_iso {A B A' B' : C} {f : A ⟶ B} {g : A' ⟶ B'}
     (e : Arrow.mk f ≅ Arrow.mk g) [h : StrongMono f] : StrongMono g :=
   { mono := by
       rw [Arrow.iso_w' e]
-      haveI := mono_comp f e.hom.right
-      apply mono_comp
+      infer_instance
     rlp := fun {X Y} z => by
       intro
       apply HasLiftingProperty.of_arrow_iso_right z e }

--- a/Mathlib/CategoryTheory/MorphismProperty/Basic.lean
+++ b/Mathlib/CategoryTheory/MorphismProperty/Basic.lean
@@ -331,7 +331,7 @@ instance RespectsIso.isomorphisms : RespectsIso (isomorphisms C) := by
     · intro X Y Z e f
       simp only [isomorphisms.iff]
       intro
-      infer_instance
+      exact IsIso.comp_isIso
 
 @[deprecated (since := "2024-07-02")] alias RespectsIso.cancel_left_isIso :=
   cancel_left_of_respectsIso

--- a/Mathlib/CategoryTheory/Simple.lean
+++ b/Mathlib/CategoryTheory/Simple.lean
@@ -56,7 +56,6 @@ theorem isIso_of_mono_of_nonzero {X Y : C} [Simple Y] {f : X ⟶ Y} [Mono f] (w 
 
 theorem Simple.of_iso {X Y : C} [Simple Y] (i : X ≅ Y) : Simple X :=
   { mono_isIso_iff_nonzero := fun f m => by
-      haveI : Mono (f ≫ i.hom) := mono_comp _ _
       constructor
       · intro h w
         have j : IsIso (f ≫ i.hom) := by infer_instance

--- a/Mathlib/CategoryTheory/Subobject/Limits.lean
+++ b/Mathlib/CategoryTheory/Subobject/Limits.lean
@@ -333,8 +333,6 @@ section
 
 variable [HasEqualizers C]
 
-attribute [local instance] epi_comp
-
 /-- The morphism `imageSubobject (h ≫ f) ⟶ imageSubobject f`
 is an epimorphism when `h` is an epimorphism.
 In general this does not imply that `imageSubobject (h ≫ f) = imageSubobject f`,

--- a/Mathlib/CategoryTheory/Subobject/MonoOver.lean
+++ b/Mathlib/CategoryTheory/Subobject/MonoOver.lean
@@ -219,13 +219,11 @@ end Pullback
 
 section Map
 
-attribute [instance] mono_comp
-
 /-- We can map monomorphisms over `X` to monomorphisms over `Y`
 by post-composition with a monomorphism `f : X ⟶ Y`.
 -/
 def map (f : X ⟶ Y) [Mono f] : MonoOver X ⥤ MonoOver Y :=
-  lift (Over.map f) fun g => by apply mono_comp g.arrow f
+  lift (Over.map f) fun g => mono_comp g.arrow f
 
 /-- `MonoOver.map` commutes with composition (up to a natural isomorphism). -/
 def mapComp (f : X ⟶ Y) (g : Y ⟶ Z) [Mono f] [Mono g] : map (f ≫ g) ≅ map f ⋙ map g :=


### PR DESCRIPTION
This PR attempts to make `mono_comp` and `epi_comp` instances.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
