### PR TITLE
[Merged by Bors] - feat(AtTopBot): generalize more to `Preorder`

### DIFF
--- a/Mathlib/Order/Filter/AtTopBot.lean
+++ b/Mathlib/Order/Filter/AtTopBot.lean
@@ -1427,131 +1427,166 @@ theorem eventually_atBot_curry [Preorder α] [Preorder β] {p : α × β → Pro
 
 /-- A function `f` maps upwards closed sets (atTop sets) to upwards closed sets when it is a
 Galois insertion. The Galois "insertion" and "connection" is weakened to only require it to be an
-insertion and a connection above `b'`. -/
-theorem map_atTop_eq_of_gc [SemilatticeSup α] [SemilatticeSup β] {f : α → β} (g : β → α) (b' : β)
-    (hf : Monotone f) (gc : ∀ a, ∀ b ≥ b', f a ≤ b ↔ a ≤ g b) (hgi : ∀ b ≥ b', b ≤ f (g b)) :
-    map f atTop = atTop := by
-  refine
-    le_antisymm
-      (hf.tendsto_atTop_atTop fun b => ⟨g (b ⊔ b'), le_sup_left.trans <| hgi _ le_sup_right⟩) ?_
-  have : Nonempty α := ⟨g b'⟩
-  rw [map_atTop_eq]
-  refine le_iInf fun a => iInf_le_of_le (f a ⊔ b') <| principal_mono.2 fun b hb => ?_
-  rw [mem_Ici, sup_le_iff] at hb
-  exact ⟨g b, (gc _ _ hb.2).1 hb.1, le_antisymm ((gc _ _ hb.2).2 le_rfl) (hgi _ hb.2)⟩
+insertion and a connection above `b`. -/
+theorem map_atTop_eq_of_gc_preorder
+    [Preorder α] [IsDirected α (· ≤ ·)] [Preorder β] [IsDirected β (· ≤ ·)] {f : α → β}
+    (hf : Monotone f) (b : β)
+    (hgi : ∀ c ≥ b, ∃ x, f x = c ∧ ∀ a, f a ≤ c ↔ a ≤ x) : map f atTop = atTop := by
+  have : Nonempty α := (hgi b le_rfl).nonempty
+  choose! g hfg hgle using hgi
+  refine le_antisymm (hf.tendsto_atTop_atTop fun c ↦ ?_) ?_
+  · rcases exists_ge_ge c b with ⟨d, hcd, hbd⟩
+    exact ⟨g d, hcd.trans (hfg d hbd).ge⟩
+  · have : Nonempty α := ⟨g b⟩
+    rw [(atTop_basis.map f).ge_iff]
+    intro a _
+    filter_upwards [eventually_ge_atTop (f a), eventually_ge_atTop b] with c hac hbc
+    exact ⟨g c, (hgle _ hbc _).1 hac, hfg _ hbc⟩
 
-theorem map_atBot_eq_of_gc [SemilatticeInf α] [SemilatticeInf β] {f : α → β} (g : β → α) (b' : β)
+
+/-- A function `f` maps upwards closed sets (atTop sets) to upwards closed sets when it is a
+Galois insertion. The Galois "insertion" and "connection" is weakened to only require it to be an
+insertion and a connection above `b`. -/
+theorem map_atTop_eq_of_gc
+    [Preorder α] [IsDirected α (· ≤ ·)] [PartialOrder β] [IsDirected β (· ≤ ·)]
+    {f : α → β} (g : β → α) (b : β) (hf : Monotone f)
+    (gc : ∀ a, ∀ c ≥ b, f a ≤ c ↔ a ≤ g c) (hgi : ∀ c ≥ b, c ≤ f (g c)) :
+    map f atTop = atTop :=
+  map_atTop_eq_of_gc_preorder hf b fun c hc ↦
+    ⟨g c, le_antisymm ((gc _ _ hc).2 le_rfl) (hgi c hc), (gc · c hc)⟩
+
+theorem map_atBot_eq_of_gc_preorder
+    [Preorder α] [IsDirected α (· ≥ ·)] [Preorder β] [IsDirected β (· ≥ ·)] {f : α → β}
+    (hf : Monotone f) (b : β)
+    (hgi : ∀ c ≤ b, ∃ x, f x = c ∧ ∀ a, c ≤ f a ↔ x ≤ a) : map f atBot = atBot :=
+  map_atTop_eq_of_gc_preorder (α := αᵒᵈ) (β := βᵒᵈ) hf.dual _ hgi
+
+theorem map_atBot_eq_of_gc [Preorder α] [IsDirected α (· ≥ ·)]
+    [PartialOrder β] [IsDirected β (· ≥ ·)] {f : α → β} (g : β → α) (b' : β)
     (hf : Monotone f) (gc : ∀ a, ∀ b ≤ b', b ≤ f a ↔ g b ≤ a) (hgi : ∀ b ≤ b', f (g b) ≤ b) :
     map f atBot = atBot :=
-  @map_atTop_eq_of_gc αᵒᵈ βᵒᵈ _ _ _ _ _ hf.dual gc hgi
+  map_atTop_eq_of_gc (α := αᵒᵈ) (β := βᵒᵈ) _ _ hf.dual gc hgi
 
-theorem map_val_atTop_of_Ici_subset [SemilatticeSup α] {a : α} {s : Set α} (h : Ici a ⊆ s) :
-    map ((↑) : s → α) atTop = atTop := by
-  haveI : Nonempty s := ⟨⟨a, h le_rfl⟩⟩
-  have : Directed (· ≥ ·) fun x : s => 𝓟 (Ici x) := fun x y ↦ by
-    use ⟨x ⊔ y ⊔ a, h le_sup_right⟩
-    simp only [principal_mono, Ici_subset_Ici, ← Subtype.coe_le_coe, Subtype.coe_mk]
-    exact ⟨le_sup_left.trans le_sup_left, le_sup_right.trans le_sup_left⟩
-  simp only [le_antisymm_iff, atTop, le_iInf_iff, le_principal_iff, mem_map, mem_setOf_eq,
-    map_iInf_eq this, map_principal]
-  constructor
-  · intro x
-    refine mem_of_superset (mem_iInf_of_mem ⟨x ⊔ a, h le_sup_right⟩ (mem_principal_self _)) ?_
-    rintro _ ⟨y, hy, rfl⟩
-    exact le_trans le_sup_left (Subtype.coe_le_coe.2 hy)
-  · intro x
-    filter_upwards [mem_atTop (↑x ⊔ a)] with b hb
-    exact ⟨⟨b, h <| le_sup_right.trans hb⟩, Subtype.coe_le_coe.1 (le_sup_left.trans hb), rfl⟩
+theorem map_val_atTop_of_Ici_subset [Preorder α] [IsDirected α (· ≤ ·)] {a : α} {s : Set α}
+    (h : Ici a ⊆ s) : map ((↑) : s → α) atTop = atTop := by
+  choose f hl hr using exists_ge_ge (α := α)
+  have : DirectedOn (· ≤ ·) s := fun x _ y _ ↦
+    ⟨f a (f x y), h <| hl _ _, (hl x y).trans (hr _ _), (hr x y).trans (hr _ _)⟩
+  have : IsDirected s (· ≤ ·) := by
+    rw [directedOn_iff_directed] at this
+    rwa [← directed_id_iff]
+  refine map_atTop_eq_of_gc_preorder (Subtype.mono_coe _) a fun c hc ↦ ?_
+  exact ⟨⟨c, h hc⟩, rfl, fun _ ↦ .rfl⟩
+
+@[simp]
+theorem _root_.Nat.map_cast_int_atTop : map ((↑) : ℕ → ℤ) atTop = atTop := by
+  refine map_atTop_eq_of_gc_preorder (fun _ _ ↦ Int.ofNat_le.2) 0 fun n hn ↦ ?_
+  lift n to ℕ using hn
+  exact ⟨n, rfl, fun _ ↦ Int.ofNat_le⟩
 
 /-- The image of the filter `atTop` on `Ici a` under the coercion equals `atTop`. -/
 @[simp]
-theorem map_val_Ici_atTop [SemilatticeSup α] (a : α) : map ((↑) : Ici a → α) atTop = atTop :=
+theorem map_val_Ici_atTop [Preorder α] [IsDirected α (· ≤ ·)] (a : α) :
+    map ((↑) : Ici a → α) atTop = atTop :=
   map_val_atTop_of_Ici_subset Subset.rfl
 
 /-- The image of the filter `atTop` on `Ioi a` under the coercion equals `atTop`. -/
 @[simp]
-theorem map_val_Ioi_atTop [SemilatticeSup α] [NoMaxOrder α] (a : α) :
+theorem map_val_Ioi_atTop [Preorder α] [IsDirected α (· ≤ ·)] [NoMaxOrder α] (a : α) :
     map ((↑) : Ioi a → α) atTop = atTop :=
   let ⟨_b, hb⟩ := exists_gt a
   map_val_atTop_of_Ici_subset <| Ici_subset_Ioi.2 hb
 
 /-- The `atTop` filter for an open interval `Ioi a` comes from the `atTop` filter in the ambient
 order. -/
-theorem atTop_Ioi_eq [SemilatticeSup α] (a : α) : atTop = comap ((↑) : Ioi a → α) atTop := by
+theorem atTop_Ioi_eq [Preorder α] [IsDirected α (· ≤ ·)] (a : α) :
+    atTop = comap ((↑) : Ioi a → α) atTop := by
   rcases isEmpty_or_nonempty (Ioi a) with h|⟨⟨b, hb⟩⟩
   · subsingleton
   · rw [← map_val_atTop_of_Ici_subset (Ici_subset_Ioi.2 hb), comap_map Subtype.coe_injective]
 
 /-- The `atTop` filter for an open interval `Ici a` comes from the `atTop` filter in the ambient
 order. -/
-theorem atTop_Ici_eq [SemilatticeSup α] (a : α) : atTop = comap ((↑) : Ici a → α) atTop := by
+theorem atTop_Ici_eq [Preorder α] [IsDirected α (· ≤ ·)] (a : α) :
+    atTop = comap ((↑) : Ici a → α) atTop := by
   rw [← map_val_Ici_atTop a, comap_map Subtype.coe_injective]
 
 /-- The `atBot` filter for an open interval `Iio a` comes from the `atBot` filter in the ambient
 order. -/
 @[simp]
-theorem map_val_Iio_atBot [SemilatticeInf α] [NoMinOrder α] (a : α) :
+theorem map_val_Iio_atBot [Preorder α] [IsDirected α (· ≥ ·)] [NoMinOrder α] (a : α) :
     map ((↑) : Iio a → α) atBot = atBot :=
-  @map_val_Ioi_atTop αᵒᵈ _ _ _
+  map_val_Ioi_atTop (OrderDual.toDual a)
 
 /-- The `atBot` filter for an open interval `Iio a` comes from the `atBot` filter in the ambient
 order. -/
-theorem atBot_Iio_eq [SemilatticeInf α] (a : α) : atBot = comap ((↑) : Iio a → α) atBot :=
-  @atTop_Ioi_eq αᵒᵈ _ _
+theorem atBot_Iio_eq [Preorder α] [IsDirected α (· ≥ ·)] (a : α) :
+    atBot = comap ((↑) : Iio a → α) atBot :=
+  atTop_Ioi_eq (OrderDual.toDual a)
 
 /-- The `atBot` filter for an open interval `Iic a` comes from the `atBot` filter in the ambient
 order. -/
 @[simp]
-theorem map_val_Iic_atBot [SemilatticeInf α] (a : α) : map ((↑) : Iic a → α) atBot = atBot :=
-  @map_val_Ici_atTop αᵒᵈ _ _
+theorem map_val_Iic_atBot [Preorder α] [IsDirected α (· ≥ ·)] (a : α) :
+    map ((↑) : Iic a → α) atBot = atBot :=
+  map_val_Ici_atTop (OrderDual.toDual a)
 
 /-- The `atBot` filter for an open interval `Iic a` comes from the `atBot` filter in the ambient
 order. -/
-theorem atBot_Iic_eq [SemilatticeInf α] (a : α) : atBot = comap ((↑) : Iic a → α) atBot :=
-  @atTop_Ici_eq αᵒᵈ _ _
+theorem atBot_Iic_eq [Preorder α] [IsDirected α (· ≥ ·)] (a : α) :
+    atBot = comap ((↑) : Iic a → α) atBot :=
+  atTop_Ici_eq (OrderDual.toDual a)
 
-theorem tendsto_Ioi_atTop [SemilatticeSup α] {a : α} {f : β → Ioi a} {l : Filter β} :
+theorem tendsto_Ioi_atTop [Preorder α] [IsDirected α (· ≤ ·)]
+    {a : α} {f : β → Ioi a} {l : Filter β} :
     Tendsto f l atTop ↔ Tendsto (fun x => (f x : α)) l atTop := by
   rw [atTop_Ioi_eq, tendsto_comap_iff, Function.comp_def]
 
-theorem tendsto_Iio_atBot [SemilatticeInf α] {a : α} {f : β → Iio a} {l : Filter β} :
-    Tendsto f l atBot ↔ Tendsto (fun x => (f x : α)) l atBot := by
-  rw [atBot_Iio_eq, tendsto_comap_iff, Function.comp_def]
+theorem tendsto_Iio_atBot [Preorder α] [IsDirected α (· ≥ ·)]
+    {a : α} {f : β → Iio a} {l : Filter β} :
+    Tendsto f l atBot ↔ Tendsto (fun x => (f x : α)) l atBot :=
+  tendsto_Ioi_atTop (α := αᵒᵈ)
 
-theorem tendsto_Ici_atTop [SemilatticeSup α] {a : α} {f : β → Ici a} {l : Filter β} :
+theorem tendsto_Ici_atTop [Preorder α] [IsDirected α (· ≤ ·)]
+    {a : α} {f : β → Ici a} {l : Filter β} :
     Tendsto f l atTop ↔ Tendsto (fun x => (f x : α)) l atTop := by
   rw [atTop_Ici_eq, tendsto_comap_iff, Function.comp_def]
 
-theorem tendsto_Iic_atBot [SemilatticeInf α] {a : α} {f : β → Iic a} {l : Filter β} :
-    Tendsto f l atBot ↔ Tendsto (fun x => (f x : α)) l atBot := by
-  rw [atBot_Iic_eq, tendsto_comap_iff, Function.comp_def]
+theorem tendsto_Iic_atBot [Preorder α] [IsDirected α (· ≥ ·)]
+    {a : α} {f : β → Iic a} {l : Filter β} :
+    Tendsto f l atBot ↔ Tendsto (fun x => (f x : α)) l atBot :=
+  tendsto_Ici_atTop (α := αᵒᵈ)
 
-@[simp, nolint simpNF] -- Porting note: linter claims that LHS doesn't simplify. It does.
-theorem tendsto_comp_val_Ioi_atTop [SemilatticeSup α] [NoMaxOrder α] {a : α} {f : α → β}
-    {l : Filter β} : Tendsto (fun x : Ioi a => f x) atTop l ↔ Tendsto f atTop l := by
+@[simp]
+theorem tendsto_comp_val_Ioi_atTop [Preorder α] [IsDirected α (· ≤ ·)] [NoMaxOrder α]
+    {a : α} {f : α → β} {l : Filter β} :
+    Tendsto (fun x : Ioi a => f x) atTop l ↔ Tendsto f atTop l := by
   rw [← map_val_Ioi_atTop a, tendsto_map'_iff, Function.comp_def]
 
-@[simp, nolint simpNF] -- Porting note: linter claims that LHS doesn't simplify. It does.
-theorem tendsto_comp_val_Ici_atTop [SemilatticeSup α] {a : α} {f : α → β} {l : Filter β} :
+@[simp]
+theorem tendsto_comp_val_Ici_atTop [Preorder α] [IsDirected α (· ≤ ·)]
+    {a : α} {f : α → β} {l : Filter β} :
     Tendsto (fun x : Ici a => f x) atTop l ↔ Tendsto f atTop l := by
   rw [← map_val_Ici_atTop a, tendsto_map'_iff, Function.comp_def]
 
-@[simp, nolint simpNF] -- Porting note: linter claims that LHS doesn't simplify. It does.
-theorem tendsto_comp_val_Iio_atBot [SemilatticeInf α] [NoMinOrder α] {a : α} {f : α → β}
-    {l : Filter β} : Tendsto (fun x : Iio a => f x) atBot l ↔ Tendsto f atBot l := by
-  rw [← map_val_Iio_atBot a, tendsto_map'_iff, Function.comp_def]
+@[simp]
+theorem tendsto_comp_val_Iio_atBot [Preorder α] [IsDirected α (· ≥ ·)] [NoMinOrder α]
+    {a : α} {f : α → β} {l : Filter β} :
+    Tendsto (fun x : Iio a => f x) atBot l ↔ Tendsto f atBot l :=
+  tendsto_comp_val_Ioi_atTop (α := αᵒᵈ)
 
-@[simp, nolint simpNF] -- Porting note: linter claims that LHS doesn't simplify. It does.
-theorem tendsto_comp_val_Iic_atBot [SemilatticeInf α] {a : α} {f : α → β} {l : Filter β} :
-    Tendsto (fun x : Iic a => f x) atBot l ↔ Tendsto f atBot l := by
-  rw [← map_val_Iic_atBot a, tendsto_map'_iff, Function.comp_def]
+@[simp]
+theorem tendsto_comp_val_Iic_atBot [Preorder α] [IsDirected α (· ≥ ·)]
+    {a : α} {f : α → β} {l : Filter β} :
+    Tendsto (fun x : Iic a => f x) atBot l ↔ Tendsto f atBot l :=
+  tendsto_comp_val_Ici_atTop (α := αᵒᵈ)
 
 theorem map_add_atTop_eq_nat (k : ℕ) : map (fun a => a + k) atTop = atTop :=
-  map_atTop_eq_of_gc (fun a => a - k) k (fun a b h => add_le_add_right h k)
+  map_atTop_eq_of_gc (· - k) k (fun a b h => add_le_add_right h k)
     (fun a b h => (le_tsub_iff_right h).symm) fun a h => by rw [tsub_add_cancel_of_le h]
 
 theorem map_sub_atTop_eq_nat (k : ℕ) : map (fun a => a - k) atTop = atTop :=
-  map_atTop_eq_of_gc (fun a => a + k) 0 (fun a b h => tsub_le_tsub_right h _)
+  map_atTop_eq_of_gc (· + k) 0 (fun a b h => tsub_le_tsub_right h _)
     (fun a b _ => tsub_le_iff_right) fun b _ => by rw [add_tsub_cancel_right]
 
 theorem tendsto_add_atTop_nat (k : ℕ) : Tendsto (fun a => a + k) atTop atTop :=


### PR DESCRIPTION
- Generalize `Filter.map_atTop_eq_of_gc` and corollaries to a `Preorder`.
- Add `Nat.map_cast_int_atTop`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
