### PR TITLE
feat(ModelTheory): A typeclass for languages expanding other languages

### DIFF
--- a/Mathlib/ModelTheory/LanguageMap.lean
+++ b/Mathlib/ModelTheory/LanguageMap.lean
@@ -549,26 +549,30 @@ variable (L'' : Language)
 
 /-- If `L.Expands L'` and `L'.Expands L''`, then `L.Expands L''`, by composing the default
   inclusions. -/
+@[simps]
 def trans [L.Expands L'] [L'.Expands L''] : L.Expands L'' where
   toLHom := (L'.Inclusion L).comp (L''.Inclusion L')
   toLHom_injective := (L'.inclusion_injective L).comp (L''.inclusion_injective L')
 
 variable {L L' L''} [L.Expands L']
 
+@[simps]
 instance : L.Expands L where
   toLHom := (LEquiv.refl L).toLHom
   toLHom_injective := (LEquiv.refl L).toHom_injective
 
+@[simps]
 instance : (L.sum L'').Expands L' where
   toLHom := LHom.sumInl.comp (L'.Inclusion L)
   toLHom_injective := LHom.sumInl_injective.comp (L'.inclusion_injective L)
 
+@[simps]
 instance : (L''.sum L).Expands L' where
   toLHom := LHom.sumInr.comp (L'.Inclusion L)
   toLHom_injective := LHom.sumInr_injective.comp (L'.inclusion_injective L)
 
-@[simp]
-theorem inclusion_self : L.Inclusion L = LHom.id L := rfl
+
+
 
 end Expands
 

--- a/Mathlib/ModelTheory/LanguageMap.lean
+++ b/Mathlib/ModelTheory/LanguageMap.lean
@@ -20,6 +20,8 @@ structures.
 - `FirstOrder.Language.withConstants` is defined so that if `M` is an `L.Structure` and
   `A : Set M`, `L.withConstants A`, denoted `L[[A]]`, is a language which adds constant symbols for
   elements of `A` to `L`.
+- An instance of `L.Expands L'` indicates that there is a default map `L'.inclusion L : L' →ᴸ L`
+  which is injective.
 
 ## References
 
@@ -174,8 +176,15 @@ end SumMap
 
 /-- A language homomorphism is injective when all the maps between symbol types are. -/
 protected structure Injective : Prop where
-  onFunction {n} : Function.Injective fun f : L.Functions n => onFunction ϕ f
-  onRelation {n} : Function.Injective fun R : L.Relations n => onRelation ϕ R
+  onFunction {n} : Function.Injective fun f : L.Functions n => onFunction ϕ f := by
+    exact IsEmptyElim
+  onRelation {n} : Function.Injective fun R : L.Relations n => onRelation ϕ R := by
+    exact IsEmptyElim
+
+lemma Injective.comp {ϕ : L' →ᴸ L''} {ϕ' : L →ᴸ L'} (hϕ : ϕ.Injective) (hϕ' : ϕ'.Injective) :
+    (ϕ.comp ϕ').Injective where
+  onFunction {_} := hϕ.onFunction.comp hϕ'.onFunction
+  onRelation {_} := hϕ.onRelation.comp hϕ'.onRelation
 
 /-- Pulls an `L`-structure along a language map `ϕ : L →ᴸ L'`, and then expands it
   to an `L'`-structure arbitrarily. -/
@@ -308,6 +317,26 @@ protected def trans (e : L ≃ᴸ L') (e' : L' ≃ᴸ L'') : L ≃ᴸ L'' :=
   ⟨e'.toLHom.comp e.toLHom, e.invLHom.comp e'.invLHom, by
     rw [LHom.comp_assoc, ← LHom.comp_assoc e'.invLHom, e'.left_inv, LHom.id_comp, e.left_inv], by
     rw [LHom.comp_assoc, ← LHom.comp_assoc e.toLHom, e.right_inv, LHom.id_comp, e'.right_inv]⟩
+
+/-- A `LEquiv` induces an equivalence between corresponding function types. -/
+@[simps]
+def onFunction {n} : L.Functions n ≃ L'.Functions n where
+  toFun f := e.toLHom.onFunction f
+  invFun f := e.invLHom.onFunction f
+  left_inv f := by simp only [← LHom.comp_onFunction, e.left_inv, LHom.id_onFunction, id_eq]
+  right_inv f := by simp only [← LHom.comp_onFunction, e.right_inv, LHom.id_onFunction, id_eq]
+
+/-- A `LEquiv` induces an equivalence between corresponding relation types. -/
+@[simps]
+def onRelation {n} : L.Relations n ≃ L'.Relations n where
+  toFun f := e.toLHom.onRelation f
+  invFun f := e.invLHom.onRelation f
+  left_inv f := by simp only [← LHom.comp_onRelation, e.left_inv, LHom.id_onRelation, id_eq]
+  right_inv f := by simp only [← LHom.comp_onRelation, e.right_inv, LHom.id_onRelation, id_eq]
+
+lemma toHom_injective : e.toLHom.Injective where
+  onFunction {_} := e.onFunction.injective
+  onRelation {_} := e.onRelation.injective
 
 end LEquiv
 
@@ -499,6 +528,45 @@ instance map_constants_inclusion_isExpansionOn :
   LHom.sumMap_isExpansionOn _ _ _
 
 end WithConstants
+
+variable (L L')
+
+/-- If `L.Expands L'`, then there is a privileged `LHom` from `L'` into `L`. -/
+class Expands where
+  toLHom : L' →ᴸ L
+  toLHom_injective : toLHom.Injective
+
+/-- Note that the variables of `L.inclusion L'` are reversed from the corresponding instance
+  `L'.Expands L`. -/
+abbrev Inclusion [L'.Expands L] : L →ᴸ L' := Expands.toLHom
+
+lemma inclusion_injective [L'.Expands L] : (L.Inclusion L').Injective := Expands.toLHom_injective
+
+namespace Expands
+
+variable (L'' : Language)
+
+/-- If `L.Expands L'` and `L'.Expands L''`, then `L.Expands L''`, by composing the default
+  inclusions. -/
+def trans [L.Expands L'] [L'.Expands L''] : L.Expands L'' where
+  toLHom := (L'.Inclusion L).comp (L''.Inclusion L')
+  toLHom_injective := (L'.inclusion_injective L).comp (L''.inclusion_injective L')
+
+variable {L L' L''} [L.Expands L']
+
+instance : L.Expands L where
+  toLHom := (LEquiv.refl L).toLHom
+  toLHom_injective := (LEquiv.refl L).toHom_injective
+
+instance : (L.sum L'').Expands L' where
+  toLHom := LHom.sumInl.comp (L'.Inclusion L)
+  toLHom_injective := LHom.sumInl_injective.comp (L'.inclusion_injective L)
+
+instance : (L''.sum L).Expands L' where
+  toLHom := LHom.sumInr.comp (L'.Inclusion L)
+  toLHom_injective := LHom.sumInr_injective.comp (L'.inclusion_injective L)
+
+end Expands
 
 end Language
 

--- a/Mathlib/ModelTheory/LanguageMap.lean
+++ b/Mathlib/ModelTheory/LanguageMap.lean
@@ -539,9 +539,9 @@ class Expands where
 
 /-- Note that the variables of `L.inclusion L'` are reversed from the corresponding instance
   `L'.Expands L`. -/
-abbrev inclusion [L'.Expands L] : L →ᴸ L' := Expands.toLHom
+abbrev Inclusion [L'.Expands L] : L →ᴸ L' := Expands.toLHom
 
-lemma inclusion_injective [L'.Expands L] : (L.inclusion L').Injective := Expands.toLHom_injective
+lemma inclusion_injective [L'.Expands L] : (L.Inclusion L').Injective := Expands.toLHom_injective
 
 namespace Expands
 
@@ -550,7 +550,7 @@ variable (L'' : Language)
 /-- If `L.Expands L'` and `L'.Expands L''`, then `L.Expands L''`, by composing the default
   inclusions. -/
 def trans [L.Expands L'] [L'.Expands L''] : L.Expands L'' where
-  toLHom := (L'.inclusion L).comp (L''.inclusion L')
+  toLHom := (L'.Inclusion L).comp (L''.Inclusion L')
   toLHom_injective := (L'.inclusion_injective L).comp (L''.inclusion_injective L')
 
 variable {L L' L''} [L.Expands L']
@@ -561,11 +561,11 @@ instance : L.Expands L where
   toLHom_injective := (LEquiv.refl L).toHom_injective
 
 instance : (L.sum L'').Expands L' where
-  toLHom := LHom.sumInl.comp (L'.inclusion L)
+  toLHom := LHom.sumInl.comp (L'.Inclusion L)
   toLHom_injective := LHom.sumInl_injective.comp (L'.inclusion_injective L)
 
 instance : (L''.sum L).Expands L' where
-  toLHom := LHom.sumInr.comp (L'.inclusion L)
+  toLHom := LHom.sumInr.comp (L'.Inclusion L)
   toLHom_injective := LHom.sumInr_injective.comp (L'.inclusion_injective L)
 
 instance {α : Type*} : L[[α]].Expands L where

--- a/Mathlib/ModelTheory/LanguageMap.lean
+++ b/Mathlib/ModelTheory/LanguageMap.lean
@@ -549,7 +549,6 @@ variable (L'' : Language)
 
 /-- If `L.Expands L'` and `L'.Expands L''`, then `L.Expands L''`, by composing the default
   inclusions. -/
-@[simps]
 def trans [L.Expands L'] [L'.Expands L''] : L.Expands L'' where
   toLHom := (L'.Inclusion L).comp (L''.Inclusion L')
   toLHom_injective := (L'.inclusion_injective L).comp (L''.inclusion_injective L')
@@ -561,17 +560,14 @@ instance : L.Expands L where
   toLHom := (LEquiv.refl L).toLHom
   toLHom_injective := (LEquiv.refl L).toHom_injective
 
-@[simps]
 instance : (L.sum L'').Expands L' where
   toLHom := LHom.sumInl.comp (L'.Inclusion L)
   toLHom_injective := LHom.sumInl_injective.comp (L'.inclusion_injective L)
 
-@[simps]
 instance : (L''.sum L).Expands L' where
   toLHom := LHom.sumInr.comp (L'.Inclusion L)
   toLHom_injective := LHom.sumInr_injective.comp (L'.inclusion_injective L)
 
-@[simps]
 instance {α : Type*} : L[[α]].Expands L where
   toLHom := L.lhomWithConstants α
   toLHom_injective := L.lhomWithConstants_injective α

--- a/Mathlib/ModelTheory/LanguageMap.lean
+++ b/Mathlib/ModelTheory/LanguageMap.lean
@@ -567,6 +567,9 @@ instance : (L''.sum L).Expands L' where
   toLHom := LHom.sumInr.comp (L'.Inclusion L)
   toLHom_injective := LHom.sumInr_injective.comp (L'.inclusion_injective L)
 
+@[simp]
+theorem inclusion_self : L.Inclusion L = LHom.id L := rfl
+
 end Expands
 
 end Language

--- a/Mathlib/ModelTheory/LanguageMap.lean
+++ b/Mathlib/ModelTheory/LanguageMap.lean
@@ -539,9 +539,9 @@ class Expands where
 
 /-- Note that the variables of `L.inclusion L'` are reversed from the corresponding instance
   `L'.Expands L`. -/
-abbrev Inclusion [L'.Expands L] : L →ᴸ L' := Expands.toLHom
+abbrev inclusion [L'.Expands L] : L →ᴸ L' := Expands.toLHom
 
-lemma inclusion_injective [L'.Expands L] : (L.Inclusion L').Injective := Expands.toLHom_injective
+lemma inclusion_injective [L'.Expands L] : (L.inclusion L').Injective := Expands.toLHom_injective
 
 namespace Expands
 
@@ -550,7 +550,7 @@ variable (L'' : Language)
 /-- If `L.Expands L'` and `L'.Expands L''`, then `L.Expands L''`, by composing the default
   inclusions. -/
 def trans [L.Expands L'] [L'.Expands L''] : L.Expands L'' where
-  toLHom := (L'.Inclusion L).comp (L''.Inclusion L')
+  toLHom := (L'.inclusion L).comp (L''.inclusion L')
   toLHom_injective := (L'.inclusion_injective L).comp (L''.inclusion_injective L')
 
 variable {L L' L''} [L.Expands L']
@@ -561,11 +561,11 @@ instance : L.Expands L where
   toLHom_injective := (LEquiv.refl L).toHom_injective
 
 instance : (L.sum L'').Expands L' where
-  toLHom := LHom.sumInl.comp (L'.Inclusion L)
+  toLHom := LHom.sumInl.comp (L'.inclusion L)
   toLHom_injective := LHom.sumInl_injective.comp (L'.inclusion_injective L)
 
 instance : (L''.sum L).Expands L' where
-  toLHom := LHom.sumInr.comp (L'.Inclusion L)
+  toLHom := LHom.sumInr.comp (L'.inclusion L)
   toLHom_injective := LHom.sumInr_injective.comp (L'.inclusion_injective L)
 
 instance {α : Type*} : L[[α]].Expands L where

--- a/Mathlib/ModelTheory/LanguageMap.lean
+++ b/Mathlib/ModelTheory/LanguageMap.lean
@@ -533,6 +533,7 @@ variable (L L')
 
 /-- If `L.Expands L'`, then there is a privileged `LHom` from `L'` into `L`. -/
 class Expands where
+  /-- The privileged map `L' →ᴸ L`, preferably accessed as `L'.inclusion L`. -/
   toLHom : L' →ᴸ L
   toLHom_injective : toLHom.Injective
 

--- a/Mathlib/ModelTheory/LanguageMap.lean
+++ b/Mathlib/ModelTheory/LanguageMap.lean
@@ -571,8 +571,10 @@ instance : (L''.sum L).Expands L' where
   toLHom := LHom.sumInr.comp (L'.Inclusion L)
   toLHom_injective := LHom.sumInr_injective.comp (L'.inclusion_injective L)
 
-
-
+@[simps]
+instance {α : Type*} : L[[α]].Expands L where
+  toLHom := L.lhomWithConstants α
+  toLHom_injective := L.lhomWithConstants_injective α
 
 end Expands
 

--- a/Mathlib/ModelTheory/LanguageMap.lean
+++ b/Mathlib/ModelTheory/LanguageMap.lean
@@ -539,7 +539,7 @@ class Expands where
 
 /-- Note that the variables of `L.inclusion L'` are reversed from the corresponding instance
   `L'.Expands L`. -/
-abbrev inclusion [L'.Expands L] : L →ᴸ L' := Expands.toLHom
+protected abbrev inclusion [L'.Expands L] : L →ᴸ L' := Expands.toLHom
 
 lemma inclusion_injective [L'.Expands L] : (L.inclusion L').Injective := Expands.toLHom_injective
 

--- a/Mathlib/ModelTheory/Order.lean
+++ b/Mathlib/ModelTheory/Order.lean
@@ -72,7 +72,7 @@ instance instSubsingleton : Subsingleton (Language.order.Relations n) :=
 end order
 
 /-- The symbol representing `≤` in a language extending `Language.order`. -/
-def leSymb [L.Expands Language.order] := (Language.order.Inclusion L).onRelation .le
+def leSymb [L.Expands Language.order] := (Language.order.inclusion L).onRelation .le
 
 lemma order.relation_eq_leSymb : (R : Language.order.Relations 2) → R = leSymb
   | .le => rfl
@@ -93,7 +93,7 @@ variable (L)
 
 @[simp]
 theorem inclusion_leSymb :
-    (Language.order.Inclusion L).onRelation leSymb = (leSymb : L.Relations 2) :=
+    (Language.order.inclusion L).onRelation leSymb = (leSymb : L.Relations 2) :=
   rfl
 
 /-- The theory of preorders. -/
@@ -176,14 +176,14 @@ section LE
 variable [LE M]
 
 instance [Language.order.Structure M] [Language.order.OrderedStructure M]
-    [(Language.order.Inclusion L).IsExpansionOn M] : L.OrderedStructure M where
+    [(Language.order.inclusion L).IsExpansionOn M] : L.OrderedStructure M where
   relMap_leSymb x := by
     rw [← inclusion_leSymb L, LHom.IsExpansionOn.map_onRelation, relMap_leSymb]
 
 variable [L.OrderedStructure M]
 
 instance [Language.order.Structure M] [Language.order.OrderedStructure M] :
-    LHom.IsExpansionOn (Language.order.Inclusion L) M where
+    LHom.IsExpansionOn (Language.order.inclusion L) M where
   map_onRelation := by simp [order.relation_eq_leSymb]
 
 @[simp]
@@ -223,7 +223,7 @@ end LE
 @[simp]
 theorem orderedStructure_iff
     [LE M] [Language.order.Structure M] [Language.order.OrderedStructure M] :
-    L.OrderedStructure M ↔ LHom.IsExpansionOn (Language.order.Inclusion L) M :=
+    L.OrderedStructure M ↔ LHom.IsExpansionOn (Language.order.inclusion L) M :=
   ⟨fun _ => inferInstance, fun _ => inferInstance⟩
 
 section Preorder

--- a/Mathlib/ModelTheory/Order.lean
+++ b/Mathlib/ModelTheory/Order.lean
@@ -91,18 +91,10 @@ def Term.lt (t₁ t₂ : L.Term (α ⊕ (Fin n))) : L.BoundedFormula α n :=
 
 variable (L)
 
-/-- The language homomorphism sending the unique symbol `≤` of `Language.order` to `≤` in an ordered
- language. -/
-abbrev orderLHom : Language.order →ᴸ L := Language.order.Inclusion L
-
 @[simp]
-theorem orderLHom_leSymb :
-    (orderLHom L).onRelation leSymb = (leSymb : L.Relations 2) :=
+theorem inclusion_leSymb :
+    (Language.order.Inclusion L).onRelation leSymb = (leSymb : L.Relations 2) :=
   rfl
-
-@[simp]
-theorem orderLHom_order : orderLHom Language.order = LHom.id Language.order :=
-  LHom.funext (Subsingleton.elim _ _) (Subsingleton.elim _ _)
 
 /-- The theory of preorders. -/
 def preorderTheory : L.Theory :=
@@ -184,14 +176,14 @@ section LE
 variable [LE M]
 
 instance [Language.order.Structure M] [Language.order.OrderedStructure M]
-    [(orderLHom L).IsExpansionOn M] : L.OrderedStructure M where
+    [(Language.order.Inclusion L).IsExpansionOn M] : L.OrderedStructure M where
   relMap_leSymb x := by
-    rw [← orderLHom_leSymb L, LHom.IsExpansionOn.map_onRelation, relMap_leSymb]
+    rw [← inclusion_leSymb L, LHom.IsExpansionOn.map_onRelation, relMap_leSymb]
 
 variable [L.OrderedStructure M]
 
 instance [Language.order.Structure M] [Language.order.OrderedStructure M] :
-    LHom.IsExpansionOn (orderLHom L) M where
+    LHom.IsExpansionOn (Language.order.Inclusion L) M where
   map_onRelation := by simp [order.relation_eq_leSymb]
 
 @[simp]
@@ -231,7 +223,7 @@ end LE
 @[simp]
 theorem orderedStructure_iff
     [LE M] [Language.order.Structure M] [Language.order.OrderedStructure M] :
-    L.OrderedStructure M ↔ LHom.IsExpansionOn (orderLHom L) M :=
+    L.OrderedStructure M ↔ LHom.IsExpansionOn (Language.order.Inclusion L) M :=
   ⟨fun _ => inferInstance, fun _ => inferInstance⟩
 
 section Preorder

--- a/Mathlib/ModelTheory/Order.lean
+++ b/Mathlib/ModelTheory/Order.lean
@@ -72,7 +72,7 @@ instance instSubsingleton : Subsingleton (Language.order.Relations n) :=
 end order
 
 /-- The symbol representing `≤` in a language extending `Language.order`. -/
-def leSymb [L.Expands Language.order] := (Language.order.inclusion L).onRelation .le
+def leSymb [L.Expands Language.order] := (Language.order.Inclusion L).onRelation .le
 
 lemma order.relation_eq_leSymb : (R : Language.order.Relations 2) → R = leSymb
   | .le => rfl
@@ -93,7 +93,7 @@ variable (L)
 
 @[simp]
 theorem inclusion_leSymb :
-    (Language.order.inclusion L).onRelation leSymb = (leSymb : L.Relations 2) :=
+    (Language.order.Inclusion L).onRelation leSymb = (leSymb : L.Relations 2) :=
   rfl
 
 /-- The theory of preorders. -/
@@ -176,14 +176,14 @@ section LE
 variable [LE M]
 
 instance [Language.order.Structure M] [Language.order.OrderedStructure M]
-    [(Language.order.inclusion L).IsExpansionOn M] : L.OrderedStructure M where
+    [(Language.order.Inclusion L).IsExpansionOn M] : L.OrderedStructure M where
   relMap_leSymb x := by
     rw [← inclusion_leSymb L, LHom.IsExpansionOn.map_onRelation, relMap_leSymb]
 
 variable [L.OrderedStructure M]
 
 instance [Language.order.Structure M] [Language.order.OrderedStructure M] :
-    LHom.IsExpansionOn (Language.order.inclusion L) M where
+    LHom.IsExpansionOn (Language.order.Inclusion L) M where
   map_onRelation := by simp [order.relation_eq_leSymb]
 
 @[simp]
@@ -223,7 +223,7 @@ end LE
 @[simp]
 theorem orderedStructure_iff
     [LE M] [Language.order.Structure M] [Language.order.OrderedStructure M] :
-    L.OrderedStructure M ↔ LHom.IsExpansionOn (Language.order.inclusion L) M :=
+    L.OrderedStructure M ↔ LHom.IsExpansionOn (Language.order.Inclusion L) M :=
   ⟨fun _ => inferInstance, fun _ => inferInstance⟩
 
 section Preorder


### PR DESCRIPTION
Defines `L.Expands L'` to consist of a privileged injective inclusion, `L'.Inclusion L`, from `L'` to `L`, corresponding to one language being a subset of the other in set-theoretic foundations.
Replaces `L.IsOrdered` with `L.Expands Language.order` and `L.OrderLHom` with `Language.order.Inclusion L`
Redefines `leSymb` in terms of `Language.order.Inclusion L`

Deletions:
- `FirstOrder.Language.IsOrdered`
- `FirstOrder.Language.OrderLHom`
- `instance : IsOrdered Language.order`
- `sum.instIsOrdered`

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
