### PR TITLE
WIP: tinkering with orientable manifolds

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -2693,6 +2693,7 @@ import Mathlib.Geometry.Manifold.MFDeriv.FDeriv
 import Mathlib.Geometry.Manifold.MFDeriv.SpecificFunctions
 import Mathlib.Geometry.Manifold.MFDeriv.UniqueDifferential
 import Mathlib.Geometry.Manifold.Metrizable
+import Mathlib.Geometry.Manifold.Orientable
 import Mathlib.Geometry.Manifold.PartitionOfUnity
 import Mathlib.Geometry.Manifold.PoincareConjecture
 import Mathlib.Geometry.Manifold.Sheaf.Basic

--- a/Mathlib/Geometry/Manifold/Instances/Sphere.lean
+++ b/Mathlib/Geometry/Manifold/Instances/Sphere.lean
@@ -10,6 +10,7 @@ import Mathlib.Analysis.InnerProductSpace.Calculus
 import Mathlib.Analysis.InnerProductSpace.PiL2
 import Mathlib.Geometry.Manifold.Algebra.LieGroup
 import Mathlib.Geometry.Manifold.Instances.Real
+import Mathlib.Geometry.Manifold.Orientable
 import Mathlib.Geometry.Manifold.MFDeriv.Basic
 
 /-!

--- a/Mathlib/Geometry/Manifold/Orientable.lean
+++ b/Mathlib/Geometry/Manifold/Orientable.lean
@@ -41,7 +41,6 @@ Jacobian.
 - Generalize this discussion to any non-trivially normed field.
 - On a given connected set, a diffeomorphism is either orientation preserving or orientation
   reversing.
-- A normed space (with the trivial model) is orientable.
 - The `n`-sphere is orientable.
 - Products of orientable manifolds are orientable.
 - Define orientations of a smooth manifold, and show that a manifold is orientable if and only if it
@@ -171,3 +170,8 @@ class OrientableSmoothManifold (H : Type*) [NormedAddCommGroup H] [NormedSpace �
   HasGroupoid M ((contDiffGroupoid ⊤ I) ⊓ orientationPreservingGroupoid) : Prop
 
 end OrientableManifold
+
+/-- A finite-dimensional normed space is an orientable smooth manifold. -/
+instance {E : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E] [FiniteDimensional ℝ E]
+    {I : ModelWithCorners ℝ E E} : OrientableSmoothManifold E (I := I) :=
+  { hasGroupoid_model_space _ _ with }

--- a/Mathlib/Geometry/Manifold/Orientable.lean
+++ b/Mathlib/Geometry/Manifold/Orientable.lean
@@ -166,8 +166,8 @@ lemma orientableManifold_of_zero_dim (H : Type*) [NormedAddCommGroup H] [NormedS
 
 /-- Typeclass defining orientable smooth manifolds. -/
 class OrientableSmoothManifold (H : Type*) [NormedAddCommGroup H] [NormedSpace ℝ H]
-    [FiniteDimensional ℝ H] (M : Type*) [TopologicalSpace M] [ChartedSpace H M]
-    [OrientableManifold H M] (I : ModelWithCorners ℝ H M) [SmoothManifoldWithCorners I M] extends
-  SmoothManifoldWithCorners I M ∧ OrientableManifold H M : Prop
+    [FiniteDimensional ℝ H] {E : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E] (M : Type*)
+    [TopologicalSpace M] [ChartedSpace H M] (I : ModelWithCorners ℝ E H) extends
+  HasGroupoid M ((contDiffGroupoid ⊤ I) ⊓ orientationPreservingGroupoid) : Prop
 
 end OrientableManifold

--- a/Mathlib/Geometry/Manifold/Orientable.lean
+++ b/Mathlib/Geometry/Manifold/Orientable.lean
@@ -76,7 +76,7 @@ lemma orientationPreserving_comp [Nontrivial H] [FiniteDimensional ℝ H] {f g :
   rw [(fderiv ℝ g (f x)).toLinearMap.det_comp (fderiv ℝ f x).toLinearMap]
   exact mul_pos (hg (f x) hxv) (hf x hxu)
 
-lemma orientationPreserving_comp_orientationReversing [Nontrivial H] [FiniteDimensional ℝ H]
+lemma orientationReversing_comp_OrientationPreserving [Nontrivial H] [FiniteDimensional ℝ H]
     {f g : H → H} {u v : Set H} (hf : OrientationPreserving f u) (hg : OrientationReversing g v) :
     OrientationReversing (g ∘ f) (u ∩ f ⁻¹' v) := by
   intro x ⟨hxu, hxv⟩
@@ -85,7 +85,7 @@ lemma orientationPreserving_comp_orientationReversing [Nontrivial H] [FiniteDime
   rw [(fderiv ℝ g (f x)).toLinearMap.det_comp (fderiv ℝ f x).toLinearMap]
   exact mul_neg_of_neg_of_pos (hg (f x) hxv) (hf x hxu)
 
-lemma orientationReversing_comp_orientationPreserving [Nontrivial H] [FiniteDimensional ℝ H]
+lemma OrientationPreserving_comp_orientationReversing [Nontrivial H] [FiniteDimensional ℝ H]
     {f g : H → H} {u v : Set H} (hf : OrientationReversing f u) (hg : OrientationPreserving g v) :
     OrientationReversing (g ∘ f) (u ∩ f ⁻¹' v) := by
   intro x ⟨hxu, hxv⟩

--- a/Mathlib/Geometry/Manifold/Orientable.lean
+++ b/Mathlib/Geometry/Manifold/Orientable.lean
@@ -33,9 +33,7 @@ A map is orientation-preserving on a given set if it is differentiable and the d
 Jacobian is strictly positive on that set.
 -/
 def OrientationPreserving (f : H → H) (s : Set H) : Prop :=
-  ∀ x ∈ s,
-    DifferentiableAt ℝ f x ∧
-    0 < (fderiv ℝ f x).det
+  ∀ x ∈ s, DifferentiableAt ℝ f x ∧ 0 < (fderiv ℝ f x).det
 
 /-- The pregroupoid of orientation-preserving maps. -/
 def orientationPreservingPregroupoid : Pregroupoid H where
@@ -60,9 +58,9 @@ def orientationPreservingPregroupoid : Pregroupoid H where
     intro x hx
     have := Filter.eventuallyEq_of_mem (IsOpen.mem_nhds hu hx) fg
     apply And.intro
-    · rw [Filter.EventuallyEq.differentiableAt_iff this]
+    · rw [this.differentiableAt_iff]
       exact (hf x hx).1
-    · rw [Filter.EventuallyEq.fderiv_eq this]
+    · rw [this.fderiv_eq]
       exact (hf x hx).2
 
 /-- The groupoid of orientation-preserving maps. -/

--- a/Mathlib/Geometry/Manifold/Orientable.lean
+++ b/Mathlib/Geometry/Manifold/Orientable.lean
@@ -178,9 +178,9 @@ class OrientableManifold (H : Type*) [NormedAddCommGroup H] [NormedSpace ℝ H]
   HasGroupoid M (@orientationPreservingGroupoid H _ _ _) : Prop
 
 /-- `0`-dimensional manifolds are always orientable. -/
-instance (H : Type*) [NormedAddCommGroup H] [NormedSpace ℝ H] [FiniteDimensional ℝ H] (M : Type*)
-    [TopologicalSpace M] [ChartedSpace H M] (h : Module.rank ℝ H = 0) :
-    OrientableManifold H M where
+lemma orientableManifold_of_zero_dim (H : Type*) [NormedAddCommGroup H] [NormedSpace ℝ H]
+    [FiniteDimensional ℝ H] (M : Type*) [TopologicalSpace M] [ChartedSpace H M]
+    (h : Module.rank ℝ H = 0) : OrientableManifold H M where
   compatible := fun {_ _} _ _ ↦
     ⟨orientationPreserving_of_zero_dim _ _ h, orientationPreserving_of_zero_dim _ _ h⟩
 

--- a/Mathlib/Geometry/Manifold/Orientable.lean
+++ b/Mathlib/Geometry/Manifold/Orientable.lean
@@ -73,17 +73,24 @@ determinant of its Jacobian is strictly negative on that set.
 def OrientationReversing (f : H → H) (s : Set H) : Prop :=
   ∀ x ∈ s, (fderiv ℝ f x).det < 0
 
-lemma OrientationPreserving.DifferentiableAt [Nontrivial H] [FiniteDimensional ℝ H] {f : H → H}
-  {s : Set H} (h : OrientationPreserving f s) : ∀ x ∈ s, DifferentiableAt ℝ f x := by
-  unfold OrientationPreserving at h
-  contrapose! h
-  obtain ⟨x, hx, hd⟩ := h
-  use x, hx
-  rw [fderiv_zero_of_not_differentiableAt hd, ContinuousLinearMap.det]
-  simp [ne_of_gt FiniteDimensional.finrank_pos]
+lemma OrientationPreserving.DifferentiableAt [FiniteDimensional ℝ H] {f : H → H}
+    {s : Set H} (h : OrientationPreserving f s) : ∀ x ∈ s, DifferentiableAt ℝ f x := by
+  cases subsingleton_or_nontrivial H
+  · intro x hs
+    apply DifferentiableWithinAt.differentiableAt
+    apply Set.Subsingleton.differentiableOn
+    exact s.subsingleton_of_subsingleton
+    exact hs
+    exact mem_nhds_discrete.mpr hs
+  · unfold OrientationPreserving at h
+    contrapose! h
+    obtain ⟨x, hx, hd⟩ := h
+    use x, hx
+    rw [fderiv_zero_of_not_differentiableAt hd, ContinuousLinearMap.det]
+    simp [ne_of_gt FiniteDimensional.finrank_pos]
 
-lemma OrientationReversing.DifferentiableAt [Nontrivial H] [FiniteDimensional ℝ H] {f : H → H}
-  {s : Set H} (h : OrientationReversing f s) : ∀ x ∈ s, DifferentiableAt ℝ f x := by
+lemma OrientationReversing.DifferentiableAt [FiniteDimensional ℝ H] {f : H → H}
+    {s : Set H} (h : OrientationReversing f s) : ∀ x ∈ s, DifferentiableAt ℝ f x := by
   unfold OrientationReversing at h
   contrapose! h
   obtain ⟨x, hx, hd⟩ := h
@@ -95,7 +102,7 @@ lemma orientationPreserving_id (s : Set H) : OrientationPreserving id s := by
   intro
   simp [ContinuousLinearMap.det]
 
-lemma orientationPreserving_comp [Nontrivial H] [FiniteDimensional ℝ H] {f g : H → H} {u v : Set H}
+lemma orientationPreserving_comp [FiniteDimensional ℝ H] {f g : H → H} {u v : Set H}
     (hf : OrientationPreserving f u) (hg : OrientationPreserving g v) :
     OrientationPreserving (g ∘ f) (u ∩ f ⁻¹' v) := by
   intro x ⟨hxu, hxv⟩
@@ -104,7 +111,7 @@ lemma orientationPreserving_comp [Nontrivial H] [FiniteDimensional ℝ H] {f g :
   rw [(fderiv ℝ g (f x)).toLinearMap.det_comp (fderiv ℝ f x).toLinearMap]
   exact mul_pos (hg (f x) hxv) (hf x hxu)
 
-lemma orientationReversing_comp_orientationPreserving [Nontrivial H] [FiniteDimensional ℝ H]
+lemma orientationReversing_comp_orientationPreserving [FiniteDimensional ℝ H]
     {f g : H → H} {u v : Set H} (hf : OrientationPreserving f u) (hg : OrientationReversing g v) :
     OrientationReversing (g ∘ f) (u ∩ f ⁻¹' v) := by
   intro x ⟨hxu, hxv⟩
@@ -113,7 +120,7 @@ lemma orientationReversing_comp_orientationPreserving [Nontrivial H] [FiniteDime
   rw [(fderiv ℝ g (f x)).toLinearMap.det_comp (fderiv ℝ f x).toLinearMap]
   exact mul_neg_of_neg_of_pos (hg (f x) hxv) (hf x hxu)
 
-lemma orientationPreserving_comp_orientationReversing [Nontrivial H] [FiniteDimensional ℝ H]
+lemma orientationPreserving_comp_orientationReversing [FiniteDimensional ℝ H]
     {f g : H → H} {u v : Set H} (hf : OrientationReversing f u) (hg : OrientationPreserving g v) :
     OrientationReversing (g ∘ f) (u ∩ f ⁻¹' v) := by
   intro x ⟨hxu, hxv⟩
@@ -122,7 +129,7 @@ lemma orientationPreserving_comp_orientationReversing [Nontrivial H] [FiniteDime
   rw [(fderiv ℝ g (f x)).toLinearMap.det_comp (fderiv ℝ f x).toLinearMap]
   exact mul_neg_of_pos_of_neg (hg (f x) hxv) (hf x hxu)
 
-lemma orientationReversing_comp [Nontrivial H] [FiniteDimensional ℝ H] {f g : H → H} {u v : Set H}
+lemma orientationReversing_comp [FiniteDimensional ℝ H] {f g : H → H} {u v : Set H}
     (hf : OrientationReversing f u) (hg : OrientationReversing g v) :
     OrientationPreserving (g ∘ f) (u ∩ f ⁻¹' v) := by
   intro x ⟨hxu, hxv⟩
@@ -132,7 +139,7 @@ lemma orientationReversing_comp [Nontrivial H] [FiniteDimensional ℝ H] {f g : 
   exact mul_pos_of_neg_of_neg (hg (f x) hxv) (hf x hxu)
 
 /-- The pregroupoid of orientation-preserving maps. -/
-def orientationPreservingPregroupoid [Nontrivial H] [FiniteDimensional ℝ H] : Pregroupoid H where
+def orientationPreservingPregroupoid [FiniteDimensional ℝ H] : Pregroupoid H where
   property f s := OrientationPreserving f s
   comp hf hg _ _ _ _ hx := orientationPreserving_comp hf hg _ hx
   id_mem := orientationPreserving_id _
@@ -144,7 +151,7 @@ def orientationPreservingPregroupoid [Nontrivial H] [FiniteDimensional ℝ H] : 
     exact hf x hx
 
 /-- The groupoid of orientation-preserving maps. -/
-def orientationPreservingGroupoid [Nontrivial H] [FiniteDimensional ℝ H] : StructureGroupoid H :=
+def orientationPreservingGroupoid [FiniteDimensional ℝ H] : StructureGroupoid H :=
   orientationPreservingPregroupoid.groupoid
 
 end OrientationPreserving
@@ -152,12 +159,12 @@ end OrientationPreserving
 section OrientableManifold
 
 /-- Typeclass defining orientable manifolds. -/
-class OrientableManifold (H : Type*) [Nontrivial H] [NormedAddCommGroup H] [NormedSpace ℝ H]
+class OrientableManifold (H : Type*) [NormedAddCommGroup H] [NormedSpace ℝ H]
     [FiniteDimensional ℝ H] (M : Type*) [TopologicalSpace M] [ChartedSpace H M] extends
-  HasGroupoid M (@orientationPreservingGroupoid H _ _ _ _) : Prop
+  HasGroupoid M (@orientationPreservingGroupoid H _ _ _) : Prop
 
 /-- Typeclass defining orientable smooth manifolds. -/
-class OrientableSmoothManifold (H : Type*) [Nontrivial H] [NormedAddCommGroup H] [NormedSpace ℝ H]
+class OrientableSmoothManifold (H : Type*) [NormedAddCommGroup H] [NormedSpace ℝ H]
     [FiniteDimensional ℝ H] (M : Type*) [TopologicalSpace M] [ChartedSpace H M]
     [OrientableManifold H M] (I : ModelWithCorners ℝ H M) [SmoothManifoldWithCorners I M] extends
   SmoothManifoldWithCorners I M ∧ OrientableManifold H M : Prop

--- a/Mathlib/Geometry/Manifold/Orientable.lean
+++ b/Mathlib/Geometry/Manifold/Orientable.lean
@@ -130,6 +130,53 @@ lemma orientationReversing_comp {f g : H → H} {u v : Set H}
   rw [fderiv.comp x (hg.differentiableAt hxv) (hf.differentiableAt hxu)]
   simpa [ContinuousLinearMap.det] using mul_pos_of_neg_of_neg (hg (f x) hxv) (hf x hxu)
 
+/-- A linear isomorphism on a connected set is
+either orientation-preserving or orientation-reversing. -/
+lemma foo (f : H ≃L[ℝ] H) {s : Set H} (hs : IsConnected s) (hs' : IsPathConnected s) :
+    OrientationPreserving f s ∨ OrientationReversing f s := by
+  -- At each point, its determinant is non-zero, as it is a diffeomorphism.
+  have (x : H) : (fderiv ℝ (⇑f) x).det ≠ 0 := sorry
+  -- Choose some point x₀ ∈ s ⊆ H.
+  --inhabit H -- by_cases empty_or_inhabited, or something
+  --let x₀ := inhabited_h.default
+  let x₀ : s := sorry
+  obtain ⟨x₀, hx₀⟩ := x₀
+  set detx₀ := (fderiv ℝ (⇑f) x₀).det
+  by_cases h: 0 < detx₀
+  · left
+    intro x hx
+    -- Choose a path `γ` connecting x and x₀.
+    obtain ⟨γ, hγ⟩ := hs'.joinedIn x₀ hx₀ x hx
+    -- Consider the function `t ↦ det (fderiv f γ(t))`.
+    let g := fun t ↦ (fderiv ℝ f (γ t)).det
+    have hneq (t) : g t ≠ 0 := by apply this
+    have : 0 < g 0 := by simp only [Path.source, g, h]
+    rw [← Path.target γ]
+    show 0 < g 1
+    by_contra h'
+    push_neg at h'
+    have : g 1 < 0 := lt_of_le_of_ne h' (hneq 1)
+    -- intermediate value theorem!
+    -- xxx: better to extend these to all of ℝ, with a junk value; a fight for another day!
+    have aux : IsPreconnected unitInterval := sorry--let pr := hs.isPreconnected
+    let ivt := aux.intermediate_value₂ (a := 0) (b := 1) (g := fun _ → 0) --(hg := continuousOn_const)--hx₀ hx
+    let ivt' := ivt (g := fun _ ↦ 0)
+    have : ConditionallyCompleteLinearOrder ↑unitInterval := sorry
+    haveI : OrderTopology ↑unitInterval := sorry
+    let ivt := intermediate_value_Icc (f := g)
+
+    --have : (fderiv ℝ f )
+    -- use path-connectedness and continuity of the determinant, and the intermediate value theorem
+    sorry
+  · have : detx₀ < 0 := by
+      by_contra h'
+      push_neg at h'
+      exact h (lt_of_le_of_ne h' (this x₀).symm)
+    right
+    intro x hx
+    sorry -- use an analogous argument as above
+
+
 /-- The pregroupoid of orientation-preserving maps. -/
 def orientationPreservingPregroupoid [FiniteDimensional ℝ H] : Pregroupoid H where
   property f s := OrientationPreserving f s

--- a/Mathlib/Geometry/Manifold/Orientable.lean
+++ b/Mathlib/Geometry/Manifold/Orientable.lean
@@ -10,7 +10,7 @@ import Mathlib.Topology.Algebra.Module.Determinant
 /-!
 # Orientable Manifolds
 
-This module defines orientable manifolds.
+This module defines orientable differentiable manifolds.
 
 ## Main Definitions
 
@@ -21,6 +21,8 @@ This module defines orientable manifolds.
 * `OrientableManifold`: a type class saying that the charted space `M`, modelled on the space `H`,
   admis an orientation. This type class is just a shortcut for `HasGroupoid M
   (@orientationPreservingGroupoid H _ _)`.
+  Note: This definition of orientability applies to differentiable manifolds. It is different from
+  oreintable topological manifolds, which use local orientations.
 
 -/
 
@@ -71,7 +73,10 @@ end orientationPreservingGroupoid
 
 section OrientableManifold
 
-/-- Typeclass defining orientable manifolds. -/
+/--
+Typeclass defining orientable differentiable manifolds.
+Note: This is different from orientable topological manifolds.
+-/
 class OrientableManifold (M : Type*) [TopologicalSpace M] [ChartedSpace H M] extends
   HasGroupoid M (@orientationPreservingGroupoid H _ _) : Prop
 

--- a/Mathlib/Geometry/Manifold/Orientable.lean
+++ b/Mathlib/Geometry/Manifold/Orientable.lean
@@ -214,15 +214,29 @@ open Set
 /-- The pregroupoid of orientation-preserving maps. -/
 def orientationPreservingPregroupoid [FiniteDimensional ℝ E] : Pregroupoid H where
   property f s := OrientationPreserving (I ∘ f ∘ I.symm) (I.symm ⁻¹' s ∩ interior (range I))
-
---AnalyticOn 𝕜 (I ∘ f ∘ I.symm) (I.symm ⁻¹' s ∩ interior (range I))
-  --∧ (I.symm ⁻¹' s ∩ interior (range I)).image (I ∘ f ∘ I.symm) ⊆ interior (range I)
-
-  comp hf hg _ _ _ _ hx := sorry --orientationPreserving_comp hf hg _ hx
-  id_mem := sorry --orientationPreserving_id _
-  locality {f u} _ h x hxu := sorry
-    -- have ⟨v, _, hxv, h⟩ := h x hxu
-    -- h x <| Set.mem_inter hxu hxv
+  -- XXX: should this condition be added?
+  -- ∧ (I.symm ⁻¹' s ∩ interior (range I)).image (I ∘ f ∘ I.symm) ⊆ interior (range I)
+  comp {f} {g} U V hf hg hU hV hUV x hx := by
+    have hx' : x ∈ I.symm ⁻¹' U ∩ interior (range I) ∩
+        I ∘ f ∘ I.symm ⁻¹' (I.symm ⁻¹' V ∩ interior (range I)) := by
+      obtain ⟨hx1, hx2⟩ := hx
+      constructor
+      · exact ⟨mem_of_mem_inter_left hx1, hx2⟩
+      · refine ⟨by simp_all, ?_⟩
+        sorry -- XXX: does this require the xxx condition above?
+    convert orientationPreserving_comp hf hg x hx'
+    simp [Function.comp]
+  id_mem := by
+    dsimp
+    rw [univ_inter]
+    have aux := I.rightInvOn
+    -- by aux, I ∘ I.symm agree with id on range I,
+    -- so it suffices to show id is or-pres there (that's a congr lemma!)
+    convert orientationPreserving_id _
+    sorry
+  locality {f u} _ h x hxu := by
+    have ⟨v, _, hxv, h⟩ := h (I.symm x) hxu.1
+    exact h _ ⟨Set.mem_inter hxu.1 hxv, hxu.2⟩
   congr {f g u} hu fg hf x hx := by
     sorry --rw [(Filter.eventuallyEq_of_mem (hu.mem_nhds hx) fg).fderiv_eq]
     --exact hf x hx

--- a/Mathlib/Geometry/Manifold/Orientable.lean
+++ b/Mathlib/Geometry/Manifold/Orientable.lean
@@ -75,14 +75,10 @@ determinant of its Jacobian is strictly negative on that set.
 def OrientationReversing (f : H → H) (s : Set H) : Prop :=
   ∀ x ∈ s, (fderiv ℝ f x).det < 0
 
-lemma orientationPreserving_of_zero_dim (f : H → H) (s : Set H) (h : Module.rank ℝ H = 0) :
-    OrientationPreserving f s :=
-  fun _ _ ↦
-  have det_eq_one : (fderiv ℝ f _).det = 1 := by
-    have b : Basis (Fin 0) ℝ H := Basis.ofEquivFun (finDimVectorspaceEquiv 0 h)
-    rw [ContinuousLinearMap.det, ← (fderiv ℝ f _).det_toMatrix b]
-    exact Matrix.det_fin_zero
-  det_eq_one ▸ Real.zero_lt_one
+lemma orientationPreserving_of_zero_dim (f : H → H) (s : Set H)
+    (h : FiniteDimensional.finrank ℝ H = 0) : OrientationPreserving f s := by
+  intro _ _
+  simp [LinearMap.det_eq_one_of_finrank_eq_zero h]
 
 lemma OrientationPreserving.differentiableAt [FiniteDimensional ℝ H] {f : H → H} {s : Set H}
     (h : OrientationPreserving f s) {x : H} (hs : x ∈ s) : DifferentiableAt ℝ f x := by
@@ -177,7 +173,7 @@ class OrientableManifold (H : Type*) [NormedAddCommGroup H] [NormedSpace ℝ H]
 /-- `0`-dimensional manifolds are always orientable. -/
 lemma orientableManifold_of_zero_dim (H : Type*) [NormedAddCommGroup H] [NormedSpace ℝ H]
     [FiniteDimensional ℝ H] (M : Type*) [TopologicalSpace M] [ChartedSpace H M]
-    (h : Module.rank ℝ H = 0) : OrientableManifold H M where
+    (h : FiniteDimensional.finrank ℝ H = 0) : OrientableManifold H M where
   compatible := fun {_ _} _ _ ↦
     ⟨orientationPreserving_of_zero_dim _ _ h, orientationPreserving_of_zero_dim _ _ h⟩
 

--- a/Mathlib/Geometry/Manifold/Orientable.lean
+++ b/Mathlib/Geometry/Manifold/Orientable.lean
@@ -126,6 +126,7 @@ class OrientableManifold (H : Type*) [Nontrivial H] [NormedAddCommGroup H] [Norm
     [FiniteDimensional ℝ H] (M : Type*) [TopologicalSpace M] [ChartedSpace H M] extends
   HasGroupoid M (@orientationPreservingGroupoid H _ _ _ _) : Prop
 
+/-- Typeclass defining orientable smooth manifolds. -/
 class OrientableSmoothManifold (H : Type*) [Nontrivial H] [NormedAddCommGroup H] [NormedSpace ℝ H]
     [FiniteDimensional ℝ H] (M : Type*) [TopologicalSpace M] [ChartedSpace H M]
     [OrientableManifold H M] (I : ModelWithCorners ℝ H M) [SmoothManifoldWithCorners I M] extends

--- a/Mathlib/Geometry/Manifold/Orientable.lean
+++ b/Mathlib/Geometry/Manifold/Orientable.lean
@@ -25,8 +25,8 @@ Jacobian.
 
 ## Main Results
 
-- `OrientationPreserving.DifferentiableAt` : an orientation preserving map is differentiable.
-- `OrientationReversing.DifferentiableAt` : an orientation reversing map is differentiable.
+- `OrientationPreserving.differentiableAt` : an orientation preserving map is differentiable.
+- `OrientationReversing.differentiableAt` : an orientation reversing map is differentiable.
 - `orientationPreserving_comp` : a composition between two orientation preserving maps is
   orientation preserving.
 - `orientationReversing_comp_orientationPreserving` : a composition between an orientation
@@ -84,7 +84,7 @@ lemma orientationPreserving_of_zero_dim (f : H → H) (s : Set H) (h : Module.ra
     exact Matrix.det_fin_zero
   det_eq_one ▸ Real.zero_lt_one
 
-lemma OrientationPreserving.DifferentiableAt [FiniteDimensional ℝ H] {f : H → H} {s : Set H}
+lemma OrientationPreserving.differentiableAt [FiniteDimensional ℝ H] {f : H → H} {s : Set H}
     (h : OrientationPreserving f s) {x : H} (hs : x ∈ s) : DifferentiableAt ℝ f x := by
   cases subsingleton_or_nontrivial H
   · apply DifferentiableWithinAt.differentiableAt
@@ -98,7 +98,7 @@ lemma OrientationPreserving.DifferentiableAt [FiniteDimensional ℝ H] {f : H �
     rw [fderiv_zero_of_not_differentiableAt h, ContinuousLinearMap.det]
     simp [ne_of_gt FiniteDimensional.finrank_pos]
 
-lemma OrientationReversing.DifferentiableAt {f : H → H} {s : Set H} (h : OrientationReversing f s)
+lemma OrientationReversing.differentiableAt {f : H → H} {s : Set H} (h : OrientationReversing f s)
     {x : H} (hs : x ∈ s) : DifferentiableAt ℝ f x := by
   unfold OrientationReversing at h
   contrapose! h
@@ -114,7 +114,7 @@ lemma orientationPreserving_comp [FiniteDimensional ℝ H] {f g : H → H} {u v 
     (hf : OrientationPreserving f u) (hg : OrientationPreserving g v) :
     OrientationPreserving (g ∘ f) (u ∩ f ⁻¹' v) := by
   intro x ⟨hxu, hxv⟩
-  rw [fderiv.comp x (hg.DifferentiableAt hxv) (hf.DifferentiableAt hxu)]
+  rw [fderiv.comp x (hg.differentiableAt hxv) (hf.differentiableAt hxu)]
   unfold ContinuousLinearMap.det ContinuousLinearMap.comp
   rw [(fderiv ℝ g (f x)).toLinearMap.det_comp (fderiv ℝ f x).toLinearMap]
   exact mul_pos (hg (f x) hxv) (hf x hxu)
@@ -123,7 +123,7 @@ lemma orientationReversing_comp_orientationPreserving [FiniteDimensional ℝ H]
     {f g : H → H} {u v : Set H} (hf : OrientationPreserving f u) (hg : OrientationReversing g v) :
     OrientationReversing (g ∘ f) (u ∩ f ⁻¹' v) := by
   intro x ⟨hxu, hxv⟩
-  rw [fderiv.comp x (hg.DifferentiableAt hxv) (hf.DifferentiableAt hxu)]
+  rw [fderiv.comp x (hg.differentiableAt hxv) (hf.differentiableAt hxu)]
   unfold ContinuousLinearMap.det ContinuousLinearMap.comp
   rw [(fderiv ℝ g (f x)).toLinearMap.det_comp (fderiv ℝ f x).toLinearMap]
   exact mul_neg_of_neg_of_pos (hg (f x) hxv) (hf x hxu)
@@ -132,7 +132,7 @@ lemma orientationPreserving_comp_orientationReversing [FiniteDimensional ℝ H]
     {f g : H → H} {u v : Set H} (hf : OrientationReversing f u) (hg : OrientationPreserving g v) :
     OrientationReversing (g ∘ f) (u ∩ f ⁻¹' v) := by
   intro x ⟨hxu, hxv⟩
-  rw [fderiv.comp x (hg.DifferentiableAt hxv) (hf.DifferentiableAt hxu)]
+  rw [fderiv.comp x (hg.differentiableAt hxv) (hf.differentiableAt hxu)]
   unfold ContinuousLinearMap.det ContinuousLinearMap.comp
   rw [(fderiv ℝ g (f x)).toLinearMap.det_comp (fderiv ℝ f x).toLinearMap]
   exact mul_neg_of_pos_of_neg (hg (f x) hxv) (hf x hxu)
@@ -141,7 +141,7 @@ lemma orientationReversing_comp {f g : H → H} {u v : Set H}
     (hf : OrientationReversing f u) (hg : OrientationReversing g v) :
     OrientationPreserving (g ∘ f) (u ∩ f ⁻¹' v) := by
   intro x ⟨hxu, hxv⟩
-  rw [fderiv.comp x (hg.DifferentiableAt hxv) (hf.DifferentiableAt hxu)]
+  rw [fderiv.comp x (hg.differentiableAt hxv) (hf.differentiableAt hxu)]
   unfold ContinuousLinearMap.det ContinuousLinearMap.comp
   rw [(fderiv ℝ g (f x)).toLinearMap.det_comp (fderiv ℝ f x).toLinearMap]
   exact mul_pos_of_neg_of_neg (hg (f x) hxv) (hf x hxu)

--- a/Mathlib/Geometry/Manifold/Orientable.lean
+++ b/Mathlib/Geometry/Manifold/Orientable.lean
@@ -3,9 +3,6 @@ Copyright (c) 2024 Rida Hamadani. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Rida Hamadani
 -/
-import Mathlib.Analysis.Calculus.FDeriv.Comp
-import Mathlib.Geometry.Manifold.ChartedSpace
-import Mathlib.Topology.Algebra.Module.Determinant
 import Mathlib.Geometry.Manifold.SmoothManifoldWithCorners
 
 /-!

--- a/Mathlib/Geometry/Manifold/Orientable.lean
+++ b/Mathlib/Geometry/Manifold/Orientable.lean
@@ -16,6 +16,8 @@ Jacobian.
 
 - `OrientationPreserving` : a map between normed spaces is orientation-preserving on a given set
   if the determinant of its Jacobian is strictly positive on that set.
+- `OrientationReversing` : a map between normed spaces is orientation-reversing on a given set
+  if the determinant of its Jacobian is strictly negative on that set.
 - `orientationPreservingGroupoid` : the groupoid of partial homeos of `H` which are
   orientation-preserving.
 - `OrientableManifold`: a type class saying that the charted space `M`, modelled on the space `H`,
@@ -40,7 +42,7 @@ Jacobian.
 - On a given connected set, a diffeomorphism is either orientation preserving or orientation
   reversing.
 - A normed space (with the trivial model) is orientable.
-- The n-sphere is orientable.
+- The `n`-sphere is orientable.
 - Products of orientable manifolds are orientable.
 - Define orientations of a smooth manifold, and show that a manifold is orientable if and only if it
   admits an orientation.
@@ -73,6 +75,15 @@ determinant of its Jacobian is strictly negative on that set.
 def OrientationReversing (f : H → H) (s : Set H) : Prop :=
   ∀ x ∈ s, (fderiv ℝ f x).det < 0
 
+lemma orientationPreserving_of_zero_dim (f : H → H) (s : Set H) (h : Module.rank ℝ H = 0) :
+    OrientationPreserving f s :=
+  fun _ _ ↦
+  have det_eq_one : (fderiv ℝ f _).det = 1 := by
+    have b : Basis (Fin 0) ℝ H := Basis.ofEquivFun (finDimVectorspaceEquiv 0 h)
+    rw [ContinuousLinearMap.det, ← (fderiv ℝ f _).det_toMatrix b]
+    exact Matrix.det_fin_zero
+  det_eq_one ▸ Real.zero_lt_one
+
 lemma OrientationPreserving.DifferentiableAt [FiniteDimensional ℝ H] {f : H → H}
     {s : Set H} (h : OrientationPreserving f s) : ∀ x ∈ s, DifferentiableAt ℝ f x := by
   cases subsingleton_or_nontrivial H
@@ -89,7 +100,7 @@ lemma OrientationPreserving.DifferentiableAt [FiniteDimensional ℝ H] {f : H �
     rw [fderiv_zero_of_not_differentiableAt hd, ContinuousLinearMap.det]
     simp [ne_of_gt FiniteDimensional.finrank_pos]
 
-lemma OrientationReversing.DifferentiableAt [FiniteDimensional ℝ H] {f : H → H}
+lemma OrientationReversing.DifferentiableAt {f : H → H}
     {s : Set H} (h : OrientationReversing f s) : ∀ x ∈ s, DifferentiableAt ℝ f x := by
   unfold OrientationReversing at h
   contrapose! h
@@ -129,7 +140,7 @@ lemma orientationPreserving_comp_orientationReversing [FiniteDimensional ℝ H]
   rw [(fderiv ℝ g (f x)).toLinearMap.det_comp (fderiv ℝ f x).toLinearMap]
   exact mul_neg_of_pos_of_neg (hg (f x) hxv) (hf x hxu)
 
-lemma orientationReversing_comp [FiniteDimensional ℝ H] {f g : H → H} {u v : Set H}
+lemma orientationReversing_comp {f g : H → H} {u v : Set H}
     (hf : OrientationReversing f u) (hg : OrientationReversing g v) :
     OrientationPreserving (g ∘ f) (u ∩ f ⁻¹' v) := by
   intro x ⟨hxu, hxv⟩
@@ -158,10 +169,20 @@ end OrientationPreserving
 
 section OrientableManifold
 
+/-! ### Orientable manifolds -/
+
+
 /-- Typeclass defining orientable manifolds. -/
 class OrientableManifold (H : Type*) [NormedAddCommGroup H] [NormedSpace ℝ H]
     [FiniteDimensional ℝ H] (M : Type*) [TopologicalSpace M] [ChartedSpace H M] extends
   HasGroupoid M (@orientationPreservingGroupoid H _ _ _) : Prop
+
+/-- `0`-dimensional manifolds are always orientable. -/
+instance (H : Type*) [NormedAddCommGroup H] [NormedSpace ℝ H] [FiniteDimensional ℝ H] (M : Type*)
+    [TopologicalSpace M] [ChartedSpace H M] (h : Module.rank ℝ H = 0) :
+    OrientableManifold H M where
+  compatible := fun {_ _} _ _ ↦
+    ⟨orientationPreserving_of_zero_dim _ _ h, orientationPreserving_of_zero_dim _ _ h⟩
 
 /-- Typeclass defining orientable smooth manifolds. -/
 class OrientableSmoothManifold (H : Type*) [NormedAddCommGroup H] [NormedSpace ℝ H]

--- a/Mathlib/Geometry/Manifold/Orientable.lean
+++ b/Mathlib/Geometry/Manifold/Orientable.lean
@@ -10,74 +10,122 @@ import Mathlib.Topology.Algebra.Module.Determinant
 /-!
 # Orientable Manifolds
 
-This module defines orientable differentiable manifolds.
+This module defines orientable manifolds.
 
 ## Main Definitions
 
-* `OrientationPreserving` : a map is orientation-preserving on a given set if the determinant of
+- `OrientationPreserving` : a map is orientation-preserving on a given set if the determinant of
   its Jacobian is strictly positive on that set.
-* `orientationPreservingGroupoid` : the groupoid of partial homeos of `H` which are
+- `orientationPreservingGroupoid` : the groupoid of partial homeos of `H` which are
   orientation-preserving.
-* `OrientableManifold`: a type class saying that the charted space `M`, modelled on the space `H`,
-  admis an orientation. This type class is just a shortcut for `HasGroupoid M
-  (@orientationPreservingGroupoid H _ _)`.
-  Note: This definition of orientability applies to differentiable manifolds. It is different from
-  oreintable topological manifolds, which use local orientations.
+- `OrientableManifold`: a type class saying that the charted space `M`, modelled on the space `H`,
+  admis an orientation.
+
+## TODO
+
+- Define orientable `0`-manifolds.
 
 -/
 
 variable {H : Type*} [NormedAddCommGroup H] [NormedSpace ℝ H]
 
-section orientationPreservingGroupoid
+section OrientationPreserving
 
 /--
 A map is orientation-preserving on a given set if it is differentiable and the determinant of its
 Jacobian is strictly positive on that set.
 -/
 def OrientationPreserving (f : H → H) (s : Set H) : Prop :=
-  ∀ x ∈ s, DifferentiableAt ℝ f x ∧ 0 < (fderiv ℝ f x).det
+  ∀ x ∈ s, 0 < (fderiv ℝ f x).det
+
+/--
+A map is orientation-reversing on a given set if it is differentiable and the determinant of its
+Jacobian is strictly negative on that set.
+-/
+def OrientationReversing (f : H → H) (s : Set H) : Prop :=
+  ∀ x ∈ s, (fderiv ℝ f x).det < 0
+
+lemma OrientationPreserving.DifferentiableAt [Nontrivial H] [FiniteDimensional ℝ H] {f : H → H}
+  {s : Set H} (h : OrientationPreserving f s) : ∀ x ∈ s, DifferentiableAt ℝ f x := by
+  unfold OrientationPreserving at h
+  contrapose! h
+  obtain ⟨x, hx, hd⟩ := h
+  use x, hx
+  rw [fderiv_zero_of_not_differentiableAt hd, ContinuousLinearMap.det]
+  simp [ne_of_gt FiniteDimensional.finrank_pos]
+
+lemma OrientationReversing.DifferentiableAt [Nontrivial H] [FiniteDimensional ℝ H] {f : H → H}
+  {s : Set H} (h : OrientationReversing f s) : ∀ x ∈ s, DifferentiableAt ℝ f x := by
+  unfold OrientationReversing at h
+  contrapose! h
+  obtain ⟨x, hx, hd⟩ := h
+  use x, hx
+  rw [fderiv_zero_of_not_differentiableAt hd, ContinuousLinearMap.det]
+  simp [ne_of_gt FiniteDimensional.finrank_pos]
+
+lemma orientationPreserving_id (s : Set H) : OrientationPreserving id s := by
+  intro
+  simp [ContinuousLinearMap.det]
+
+lemma orientationPreserving_comp [Nontrivial H] [FiniteDimensional ℝ H] {f g : H → H} {u v : Set H}
+    (hf : OrientationPreserving f u) (hg : OrientationPreserving g v) :
+    OrientationPreserving (g ∘ f) (u ∩ f ⁻¹' v) := by
+  intro x ⟨hxu, hxv⟩
+  rw [fderiv.comp x (hg.DifferentiableAt (f x) hxv) (hf.DifferentiableAt x hxu)]
+  unfold ContinuousLinearMap.det ContinuousLinearMap.comp
+  rw [(fderiv ℝ g (f x)).toLinearMap.det_comp (fderiv ℝ f x).toLinearMap]
+  exact mul_pos (hg (f x) hxv) (hf x hxu)
+
+lemma orientationPreserving_comp_orientationReversing [Nontrivial H] [FiniteDimensional ℝ H]
+    {f g : H → H} {u v : Set H} (hf : OrientationPreserving f u) (hg : OrientationReversing g v) :
+    OrientationReversing (g ∘ f) (u ∩ f ⁻¹' v) := by
+  intro x ⟨hxu, hxv⟩
+  rw [fderiv.comp x (hg.DifferentiableAt (f x) hxv) (hf.DifferentiableAt x hxu)]
+  unfold ContinuousLinearMap.det ContinuousLinearMap.comp
+  rw [(fderiv ℝ g (f x)).toLinearMap.det_comp (fderiv ℝ f x).toLinearMap]
+  exact mul_neg_of_neg_of_pos (hg (f x) hxv) (hf x hxu)
+
+lemma orientationReversing_comp_orientationPreserving [Nontrivial H] [FiniteDimensional ℝ H]
+    {f g : H → H} {u v : Set H} (hf : OrientationReversing f u) (hg : OrientationPreserving g v) :
+    OrientationReversing (g ∘ f) (u ∩ f ⁻¹' v) := by
+  intro x ⟨hxu, hxv⟩
+  rw [fderiv.comp x (hg.DifferentiableAt (f x) hxv) (hf.DifferentiableAt x hxu)]
+  unfold ContinuousLinearMap.det ContinuousLinearMap.comp
+  rw [(fderiv ℝ g (f x)).toLinearMap.det_comp (fderiv ℝ f x).toLinearMap]
+  exact mul_neg_of_pos_of_neg (hg (f x) hxv) (hf x hxu)
+
+lemma orientationReversing_comp [Nontrivial H] [FiniteDimensional ℝ H] {f g : H → H} {u v : Set H}
+    (hf : OrientationReversing f u) (hg : OrientationReversing g v) :
+    OrientationPreserving (g ∘ f) (u ∩ f ⁻¹' v) := by
+  intro x ⟨hxu, hxv⟩
+  rw [fderiv.comp x (hg.DifferentiableAt (f x) hxv) (hf.DifferentiableAt x hxu)]
+  unfold ContinuousLinearMap.det ContinuousLinearMap.comp
+  rw [(fderiv ℝ g (f x)).toLinearMap.det_comp (fderiv ℝ f x).toLinearMap]
+  exact mul_pos_of_neg_of_neg (hg (f x) hxv) (hf x hxu)
 
 /-- The pregroupoid of orientation-preserving maps. -/
-def orientationPreservingPregroupoid : Pregroupoid H where
+def orientationPreservingPregroupoid [Nontrivial H] [FiniteDimensional ℝ H] : Pregroupoid H where
   property f s := OrientationPreserving f s
-  comp {f g u v} hf hg _ _ _ := by
-    intro x ⟨hxu, hxv⟩
-    rw [fderiv.comp _ (hg (f x) hxv).1 (hf x hxu).1]
-    have h₁ : 0 < (fderiv ℝ f x).det := (hf x hxu).2
-    have h₂ : 0 < (fderiv ℝ g (f x)).det := (hg (f x) hxv).2
-    unfold ContinuousLinearMap.det ContinuousLinearMap.comp
-    rw [(fderiv ℝ g (f x)).toLinearMap.det_comp (fderiv ℝ f x).toLinearMap]
-    exact ⟨(hg (f x) hxv).1.comp x (hf x hxu).1, mul_pos h₂ h₁⟩
-  id_mem := by
-    intro x _
-    simp only [Set.mem_univ, differentiableAt_id, fderiv_id, true_and]
-    rw [ContinuousLinearMap.id, ContinuousLinearMap.det, LinearMap.det_id]
-    exact zero_lt_one
+  comp hf hg _ _ _ _ hx := orientationPreserving_comp hf hg _ hx
+  id_mem := orientationPreserving_id _
   locality {f u} _ h x hxu :=
     have ⟨v, _, hxv, h⟩ := h x hxu
     h x <| Set.mem_inter hxu hxv
-  congr {f g u} hu fg hf := by
-    intro x hx
-    have := Filter.eventuallyEq_of_mem (IsOpen.mem_nhds hu hx) fg
-    apply And.intro
-    · rw [this.differentiableAt_iff]
-      exact (hf x hx).1
-    · rw [this.fderiv_eq]
-      exact (hf x hx).2
+  congr {f g u} hu fg hf x hx := by
+    rw [(Filter.eventuallyEq_of_mem (hu.mem_nhds hx) fg).fderiv_eq]
+    exact hf x hx
 
 /-- The groupoid of orientation-preserving maps. -/
-def orientationPreservingGroupoid : StructureGroupoid H :=
+def orientationPreservingGroupoid [Nontrivial H] [FiniteDimensional ℝ H] : StructureGroupoid H :=
   orientationPreservingPregroupoid.groupoid
 
-end orientationPreservingGroupoid
+end OrientationPreserving
 
 section OrientableManifold
 
-/--
-Typeclass defining orientable differentiable manifolds.
-Note: This is different from orientable topological manifolds.
--/
-class OrientableManifold (M : Type*) [TopologicalSpace M] [ChartedSpace H M] extends
-  HasGroupoid M (@orientationPreservingGroupoid H _ _) : Prop
+/-- Typeclass defining orientable manifolds. -/
+class OrientableManifold [Nontrivial H] [FiniteDimensional ℝ H]
+    (M : Type*) [TopologicalSpace M] [ChartedSpace H M] extends
+  HasGroupoid M (@orientationPreservingGroupoid H _ _ _ _) : Prop
 
 end OrientableManifold

--- a/Mathlib/Geometry/Manifold/Orientable.lean
+++ b/Mathlib/Geometry/Manifold/Orientable.lean
@@ -231,6 +231,11 @@ def orientationPreservingPregroupoid [FiniteDimensional ℝ E] : Pregroupoid H w
 def orientationPreservingGroupoid [FiniteDimensional ℝ E] : StructureGroupoid H :=
   (orientationPreservingPregroupoid I).groupoid
 
+/-- The groupoid of orientation-preserving `n` times continuously differentiable maps -/
+def contDiffOrientationPreservingGroupoid (n : ℕ∞) (I : ModelWithCorners ℝ E H)
+    [FiniteDimensional ℝ E] : StructureGroupoid H :=
+  (orientationPreservingGroupoid I) ⊓ (contDiffGroupoid n I)
+
 end OrientationPreserving
 
 /-! ### Orientable manifolds -/
@@ -256,7 +261,7 @@ if and only if it admits an atlas which is both smooth and orientable -/
 class OrientableSmoothManifold {E H : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E]
     [TopologicalSpace H] (M : Type*) [TopologicalSpace M] [ChartedSpace H M]
     (I : ModelWithCorners ℝ E H) [FiniteDimensional ℝ E] extends
-  HasGroupoid M ((contDiffGroupoid ⊤ I) ⊓ orientationPreservingGroupoid I) : Prop
+  HasGroupoid M (contDiffOrientationPreservingGroupoid ⊤ I) : Prop
 
 end OrientableManifold
 

--- a/Mathlib/Geometry/Manifold/Orientable.lean
+++ b/Mathlib/Geometry/Manifold/Orientable.lean
@@ -8,20 +8,50 @@ import Mathlib.Geometry.Manifold.SmoothManifoldWithCorners
 /-!
 # Orientable Manifolds
 
-This module defines orientable manifolds.
+This file defines orientable manifolds: a differentiable manifold is orientable if and only if it
+admits an orientable atlas, i.e. an atlas whose transition functions have a strictly positive
+Jacobian.
 
 ## Main Definitions
 
-- `OrientationPreserving` : a map is orientation-preserving on a given set if the determinant of
-  its Jacobian is strictly positive on that set.
+- `OrientationPreserving` : a map between normed spaces is orientation-preserving on a given set
+  if the determinant of its Jacobian is strictly positive on that set.
 - `orientationPreservingGroupoid` : the groupoid of partial homeos of `H` which are
   orientation-preserving.
 - `OrientableManifold`: a type class saying that the charted space `M`, modelled on the space `H`,
-  admis an orientation.
+  admits an orientation.
+
+## Main Results
+
+- `OrientationPreserving.DifferentiableAt` : an orientation preserving map is differentiable.
+- `OrientationReversing.DifferentiableAt` : an orientation reversing map is differentiable.
+- `orientationPreserving_comp` : a composition between two orientation preserving maps is
+  orientation preserving.
+- `orientationReversing_comp_orientationPreserving` : a composition between an orientation
+  reversing map and an orientation preserving map is orientation reversing.
+- `orientationPreserving_comp_orientationReversing` : a composition between an orientation
+  preserving map and an orientation reversing map is orientation reversing.
+- `orientationReversing_comp` : a composition between two orientation reversing maps is
+  orientation preserving.
 
 ## TODO
 
-- Define orientable `0`-manifolds.
+- Generalize this discussion to any non-trivially normed field.
+- On a given connected set, a diffeomorphism is either orientation preserving or orientation
+  reversing.
+- A normed space (with the trivial model) is orientable.
+- The n-sphere is orientable.
+- Products of orientable manifolds are orientable.
+- Define orientations of a smooth manifold, and show that a manifold is orientable if and only if it
+  admits an orientation.
+- Define orientation preserving and reserving maps between manifolds.
+
+## Implementation notes
+
+The current definitions work for differentiable manifolds. For topological manifolds, orientability
+can be defined using *local* orientations (which mathlib cannot state yet, as there is no e.g.
+singular homology). In the future, it would be nice to generalise these definitions to allow for
+topological manifolds also, and relate them to the current definition.
 
 -/
 
@@ -30,15 +60,15 @@ variable {H : Type*} [NormedAddCommGroup H] [NormedSpace ℝ H]
 section OrientationPreserving
 
 /--
-A map is orientation-preserving on a given set if it is differentiable and the determinant of its
-Jacobian is strictly positive on that set.
+A map between normed spaces is orientation-preserving on a given set if it is differentiable and the
+determinant of its Jacobian is strictly positive on that set.
 -/
 def OrientationPreserving (f : H → H) (s : Set H) : Prop :=
   ∀ x ∈ s, 0 < (fderiv ℝ f x).det
 
 /--
-A map is orientation-reversing on a given set if it is differentiable and the determinant of its
-Jacobian is strictly negative on that set.
+A map between normed spaces is orientation-reversing on a given set if it is differentiable and the
+determinant of its Jacobian is strictly negative on that set.
 -/
 def OrientationReversing (f : H → H) (s : Set H) : Prop :=
   ∀ x ∈ s, (fderiv ℝ f x).det < 0
@@ -74,7 +104,7 @@ lemma orientationPreserving_comp [Nontrivial H] [FiniteDimensional ℝ H] {f g :
   rw [(fderiv ℝ g (f x)).toLinearMap.det_comp (fderiv ℝ f x).toLinearMap]
   exact mul_pos (hg (f x) hxv) (hf x hxu)
 
-lemma orientationReversing_comp_OrientationPreserving [Nontrivial H] [FiniteDimensional ℝ H]
+lemma orientationReversing_comp_orientationPreserving [Nontrivial H] [FiniteDimensional ℝ H]
     {f g : H → H} {u v : Set H} (hf : OrientationPreserving f u) (hg : OrientationReversing g v) :
     OrientationReversing (g ∘ f) (u ∩ f ⁻¹' v) := by
   intro x ⟨hxu, hxv⟩
@@ -83,7 +113,7 @@ lemma orientationReversing_comp_OrientationPreserving [Nontrivial H] [FiniteDime
   rw [(fderiv ℝ g (f x)).toLinearMap.det_comp (fderiv ℝ f x).toLinearMap]
   exact mul_neg_of_neg_of_pos (hg (f x) hxv) (hf x hxu)
 
-lemma OrientationPreserving_comp_orientationReversing [Nontrivial H] [FiniteDimensional ℝ H]
+lemma orientationPreserving_comp_orientationReversing [Nontrivial H] [FiniteDimensional ℝ H]
     {f g : H → H} {u v : Set H} (hf : OrientationReversing f u) (hg : OrientationPreserving g v) :
     OrientationReversing (g ∘ f) (u ∩ f ⁻¹' v) := by
   intro x ⟨hxu, hxv⟩

--- a/Mathlib/Geometry/Manifold/Orientable.lean
+++ b/Mathlib/Geometry/Manifold/Orientable.lean
@@ -1,0 +1,73 @@
+/-
+Copyright (c) 2024 Rida Hamadani. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Rida Hamadani
+-/
+import Mathlib.Analysis.Calculus.FDeriv.Comp
+import Mathlib.Geometry.Manifold.ChartedSpace
+import Mathlib.Topology.Algebra.Module.Determinant
+
+/-!
+# Orientable Manifolds
+
+This module defines orientable manifolds.
+
+## Main Definitions
+
+* `OrientationPreserving` : a map is orientation-preserving on a given set if the determinant of
+  its Jacobian is strictly positive on that set.
+* `orientationPreservingGroupoid` : the groupoid of partial homeos of `H` which are
+  orientation-preserving.
+* `OrientableManifold`: a type class saying that the charted space `M`, modelled on the space `H`,
+  admis an orientation. This type class is just a shortcut for `HasGroupoid M
+  (@orientationPreservingGroupoid H _ _)`.
+
+-/
+
+variable {H : Type*} [NormedAddCommGroup H] [NormedSpace ℝ H]
+
+section orientationPreservingGroupoid
+
+def OrientationPreserving (f : H → H) (s : Set H) : Prop :=
+  ∀ x ∈ s,
+    DifferentiableAt ℝ f x ∧
+    0 < (fderiv ℝ f x).det
+
+def orientationPreservingPregroupoid : Pregroupoid H where
+  property f s := OrientationPreserving f s
+  comp {f g u v} hf hg _ _ _ := by
+    intro x ⟨hxu, hxv⟩
+    rw [fderiv.comp _ (hg (f x) hxv).1 (hf x hxu).1]
+    · have h₁ : 0 < (fderiv ℝ f x).det := (hf x hxu).2
+      have h₂ : 0 < (fderiv ℝ g (f x)).det := (hg (f x) hxv).2
+      unfold ContinuousLinearMap.det ContinuousLinearMap.comp
+      rw [(fderiv ℝ g (f x)).toLinearMap.det_comp (fderiv ℝ f x).toLinearMap]
+      exact ⟨(hg (f x) hxv).1.comp x (hf x hxu).1, mul_pos h₂ h₁⟩
+  id_mem := by
+    intro x _
+    simp only [Set.mem_univ, differentiableAt_id, fderiv_id, true_and]
+    rw [ContinuousLinearMap.id, ContinuousLinearMap.det, LinearMap.det_id]
+    exact zero_lt_one
+  locality {f u} _ h x hxu :=
+    have ⟨v, _, hxv, h⟩ := h x hxu
+    h x <| Set.mem_inter hxu hxv
+  congr {f g u} hu fg hf := by
+    intro x hx
+    have := Filter.eventuallyEq_of_mem (IsOpen.mem_nhds hu hx) fg
+    apply And.intro
+    · rw [Filter.EventuallyEq.differentiableAt_iff this]
+      exact (hf x hx).1
+    · rw [Filter.EventuallyEq.fderiv_eq this]
+      exact (hf x hx).2
+
+def orientationPreservingGroupoid : StructureGroupoid H :=
+  orientationPreservingPregroupoid.groupoid
+
+end orientationPreservingGroupoid
+
+section OrientableManifold
+
+class OrientableManifold (M : Type*) [TopologicalSpace M] [ChartedSpace H M] extends
+  HasGroupoid M (@orientationPreservingGroupoid H _ _) : Prop
+
+end OrientableManifold

--- a/Mathlib/Geometry/Manifold/Orientable.lean
+++ b/Mathlib/Geometry/Manifold/Orientable.lean
@@ -132,26 +132,23 @@ lemma orientationReversing_comp {f g : H → H} {u v : Set H}
 
 lemma abstract2a {f : unitInterval → ℝ} (hf : Continuous f) (hf' : ∀ t, f t ≠ 0)
     {x : unitInterval} (hx : f x > 0) : ∀ t, f t > 0 := by
-  by_contra h
-  push_neg at h
-  have : f 1 < 0 := by
-    apply lt_of_le_of_ne --hx (hf' 1)
-    sorry; sorry
-    -- -- intermediate value theorem!
-    -- -- xxx: better to extend these to all of ℝ, with a junk value; a fight for another day!
-    -- have aux : IsPreconnected unitInterval := sorry--let pr := hs.isPreconnected
-    -- let ivt := aux.intermediate_value₂ (a := 0) (b := 1) (g := fun _ → 0) --(hg := continuousOn_const)--hx₀ hx
-    -- let ivt' := ivt (g := fun _ ↦ 0)
-    -- have : ConditionallyCompleteLinearOrder ↑unitInterval := sorry
-    -- haveI : OrderTopology ↑unitInterval := sorry
-    -- let ivt := intermediate_value_Icc (f := g)
-
-    -- use the intermediate value theorem
-
-  sorry
+  by_contra! h
+  obtain ⟨t, ht⟩ := h
+  obtain ⟨x, _, hx⟩ := isPreconnected_univ.intermediate_value₂
+    (a := t) (b := x) (by tauto) (by tauto)
+    (hf.continuousOn (s := Set.univ)) (continuous_const (y := 0).continuousOn (s := Set.univ))
+    ht hx.le
+  exact (hf' x) hx
 
 lemma abstract2b {f : unitInterval → ℝ} (hf : Continuous f) (hf' : ∀ t, f t ≠ 0)
-    {x : unitInterval} (hx : f x < 0) : ∀ t, f t < 0 := sorry
+    {x : unitInterval} (hx : f x < 0) : ∀ t, f t < 0 := by
+  by_contra! h
+  obtain ⟨t, ht⟩ := h
+  obtain ⟨x, _, hx⟩ := isPreconnected_univ.intermediate_value₂
+    (a := x) (b := t) (by tauto) (by tauto)
+    (hf.continuousOn (s := Set.univ)) (continuous_const (y := 0).continuousOn (s := Set.univ))
+    hx.le ht
+  exact (hf' x) hx
 
 -- Not quite what I want below, but a similar sketch.
 lemma abstract1 {f : unitInterval → ℝ} (hf : Continuous f) (hf' : ∀ t, f t ≠ 0) :
@@ -198,8 +195,7 @@ lemma foo (f : H ≃L[ℝ] H) {s : Set H} (hs : IsConnected s) (hs' : IsPathConn
     rw [← Path.target γ]
     exact abstract2a hg hg' h₀ 1
   · have h' : (fderiv ℝ (⇑f) x₀).det < 0 := by
-      by_contra h'
-      push_neg at h'
+      by_contra! h'
       exact h (lt_of_le_of_ne h' (h₁ x₀).symm)
     right
     intro x hx

--- a/Mathlib/Geometry/Manifold/Orientable.lean
+++ b/Mathlib/Geometry/Manifold/Orientable.lean
@@ -56,6 +56,8 @@ topological manifolds also, and relate them to the current definition.
 
 -/
 
+open scoped Manifold
+
 variable {H : Type*} [NormedAddCommGroup H] [NormedSpace ℝ H]
 
 section OrientationPreserving
@@ -166,10 +168,9 @@ either orientation-preserving or orientation-reversing. -/
 lemma foo (f : H ≃L[ℝ] H) {s : Set H} (hs : IsConnected s) (hs' : IsPathConnected s) :
     OrientationPreserving f s ∨ OrientationReversing f s := by
   -- At each point, its determinant is non-zero, as it is a diffeomorphism.
+  -- The most general proof proceeds via local diffeomorphism,
+  -- and deducing the linear isomorphisms are diffeomorphisms are local diffeomorphisms...
   have h₁ (x : H) : (fderiv ℝ (⇑f) x).det ≠ 0 := sorry
-  -- TODO missing: fderiv ℝ f x is continuous in x!
-  let F := fun x ↦ fderiv ℝ f x
-  have : Continuous F := sorry
   by_cases hyp: Nonempty s
   swap
   · left
@@ -186,22 +187,22 @@ lemma foo (f : H ≃L[ℝ] H) {s : Set H} (hs : IsConnected s) (hs' : IsPathConn
     -- and consider the function `g: t ↦ det (fderiv f γ(t))`.
     obtain ⟨γ, hγ⟩ := hs'.joinedIn x₀ hx₀ x hx
     let g := fun t ↦ (fderiv ℝ f (γ t)).det
-    have hg : Continuous g := by
-      dsimp [g]
-      sorry -- TODO: need a statement like "det is continuous", with the right topology there...
-      -- then this should be easy... continuity
-    have hg' : ∀ (t : ↑unitInterval), g t ≠ 0 := by simp [h₁]
-    have h₀ : 0 < g 0 := by simp only [g, Path.source, h]
+    have aux : Continuous fun t ↦ (fderiv ℝ f (γ t)) :=
+      Continuous.comp (f.contDiff.continuous_fderiv (OrderTop.le_top 1)) γ.continuous
+    have hg : Continuous g := (ContinuousLinearMap.continuous_det (𝕜 := ℝ) (E := H)).comp aux
     rw [← Path.target γ]
-    exact abstract2a hg hg' h₀ 1
-  · have h' : (fderiv ℝ (⇑f) x₀).det < 0 := by
-      by_contra! h'
-      exact h (lt_of_le_of_ne h' (h₁ x₀).symm)
-    right
+    exact abstract2a hg (by simp [h₁]) (x := 0) (by simp only [g, Path.source, h]) 1
+  · right
     intro x hx
     obtain ⟨γ, hγ⟩ := hs'.joinedIn x₀ hx₀ x hx
     let g := fun t ↦ (fderiv ℝ f (γ t)).det
-    have hg : Continuous g := sorry -- TODO; proof will be the same as above
+    have aux : Continuous fun t ↦ (fderiv ℝ f (γ t)) :=
+      Continuous.comp (f.contDiff.continuous_fderiv (OrderTop.le_top 1)) γ.continuous
+    have hg : Continuous g := (ContinuousLinearMap.continuous_det (𝕜 := ℝ) (E := H)).comp aux
+
+    have h' : (fderiv ℝ (⇑f) x₀).det < 0 := by
+      by_contra! h'
+      exact h (lt_of_le_of_ne h' (h₁ x₀).symm)
     have h₀ : g 0 < 0 := by simp only [g, Path.source, h']
     rw [← Path.target γ]
     exact abstract2b hg (by simp [h₁]) h₀ 1

--- a/Mathlib/Geometry/Manifold/Orientable.lean
+++ b/Mathlib/Geometry/Manifold/Orientable.lean
@@ -207,45 +207,56 @@ lemma foo (f : H ≃L[ℝ] H) {s : Set H} (hs : IsConnected s) (hs' : IsPathConn
     rw [← Path.target γ]
     exact abstract2b hg (by simp [h₁]) h₀ 1
 
+variable {E : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E] [CompleteSpace E] {H : Type*}
+  [TopologicalSpace H] (I : ModelWithCorners ℝ E H) {M : Type*} [TopologicalSpace M]
 
+open Set
 /-- The pregroupoid of orientation-preserving maps. -/
-def orientationPreservingPregroupoid [FiniteDimensional ℝ H] : Pregroupoid H where
-  property f s := OrientationPreserving f s
-  comp hf hg _ _ _ _ hx := orientationPreserving_comp hf hg _ hx
-  id_mem := orientationPreserving_id _
-  locality {f u} _ h x hxu :=
-    have ⟨v, _, hxv, h⟩ := h x hxu
-    h x <| Set.mem_inter hxu hxv
+def orientationPreservingPregroupoid [FiniteDimensional ℝ E] : Pregroupoid H where
+  property f s := OrientationPreserving (I ∘ f ∘ I.symm) (I.symm ⁻¹' s ∩ interior (range I))
+
+--AnalyticOn 𝕜 (I ∘ f ∘ I.symm) (I.symm ⁻¹' s ∩ interior (range I))
+  --∧ (I.symm ⁻¹' s ∩ interior (range I)).image (I ∘ f ∘ I.symm) ⊆ interior (range I)
+
+  comp hf hg _ _ _ _ hx := sorry --orientationPreserving_comp hf hg _ hx
+  id_mem := sorry --orientationPreserving_id _
+  locality {f u} _ h x hxu := sorry
+    -- have ⟨v, _, hxv, h⟩ := h x hxu
+    -- h x <| Set.mem_inter hxu hxv
   congr {f g u} hu fg hf x hx := by
-    rw [(Filter.eventuallyEq_of_mem (hu.mem_nhds hx) fg).fderiv_eq]
-    exact hf x hx
+    sorry --rw [(Filter.eventuallyEq_of_mem (hu.mem_nhds hx) fg).fderiv_eq]
+    --exact hf x hx
 
 /-- The groupoid of orientation-preserving maps. -/
-def orientationPreservingGroupoid [FiniteDimensional ℝ H] : StructureGroupoid H :=
-  orientationPreservingPregroupoid.groupoid
+def orientationPreservingGroupoid [FiniteDimensional ℝ E] : StructureGroupoid H :=
+  (orientationPreservingPregroupoid I).groupoid
 
 end OrientationPreserving
 
 /-! ### Orientable manifolds -/
 section OrientableManifold
 
-/-- Typeclass defining orientable manifolds. -/
-class OrientableManifold (H : Type*) [NormedAddCommGroup H] [NormedSpace ℝ H]
-    [FiniteDimensional ℝ H] (M : Type*) [TopologicalSpace M] [ChartedSpace H M] extends
-  HasGroupoid M (@orientationPreservingGroupoid H _ _ _) : Prop
+/-- Typeclass defining orientable manifolds: a finite-dimensional (topological) manifold
+is orientable if and only if it admits an orientable atlas. -/
+class OrientableManifold {E H : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E]
+    [TopologicalSpace H] (M : Type*) [TopologicalSpace M] [ChartedSpace H M]
+    (I : ModelWithCorners ℝ E H) [FiniteDimensional ℝ E] extends
+  HasGroupoid M (orientationPreservingGroupoid I) : Prop
 
 /-- `0`-dimensional manifolds are always orientable. -/
-lemma orientableManifold_of_zero_dim (H : Type*) [NormedAddCommGroup H] [NormedSpace ℝ H]
-    [FiniteDimensional ℝ H] (M : Type*) [TopologicalSpace M] [ChartedSpace H M]
-    (h : FiniteDimensional.finrank ℝ H = 0) : OrientableManifold H M where
+lemma orientableManifold_of_zero_dim {E H : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E]
+    [TopologicalSpace H] (M : Type*) [TopologicalSpace M] [ChartedSpace H M]
+    (I : ModelWithCorners ℝ E H) [FiniteDimensional ℝ E] (h : FiniteDimensional.finrank ℝ E = 0) :
+    OrientableManifold M I where
   compatible := fun _ _ ↦
     ⟨orientationPreserving_of_zero_dim _ _ h, orientationPreserving_of_zero_dim _ _ h⟩
 
-/-- Typeclass defining orientable smooth manifolds. -/
-class OrientableSmoothManifold (H : Type*) [NormedAddCommGroup H] [NormedSpace ℝ H]
-    [FiniteDimensional ℝ H] {E : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E] (M : Type*)
-    [TopologicalSpace M] [ChartedSpace H M] (I : ModelWithCorners ℝ E H) extends
-  HasGroupoid M ((contDiffGroupoid ⊤ I) ⊓ orientationPreservingGroupoid) : Prop
+/-- Typeclass defining orientable smooth manifolds: a smooth manifold is orientable
+if and only if it admits an atlas which is both smooth and orientable -/
+class OrientableSmoothManifold {E H : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E]
+    [TopologicalSpace H] (M : Type*) [TopologicalSpace M] [ChartedSpace H M]
+    (I : ModelWithCorners ℝ E H) [FiniteDimensional ℝ E] extends
+  HasGroupoid M ((contDiffGroupoid ⊤ I) ⊓ orientationPreservingGroupoid I) : Prop
 
 end OrientableManifold
 

--- a/Mathlib/Geometry/Manifold/Orientable.lean
+++ b/Mathlib/Geometry/Manifold/Orientable.lean
@@ -83,12 +83,9 @@ lemma orientationPreserving_of_zero_dim (f : H → H) (s : Set H)
 lemma OrientationPreserving.differentiableAt [FiniteDimensional ℝ H] {f : H → H} {s : Set H}
     (h : OrientationPreserving f s) {x : H} (hs : x ∈ s) : DifferentiableAt ℝ f x := by
   cases subsingleton_or_nontrivial H
-  · apply DifferentiableWithinAt.differentiableAt
-    apply Set.Subsingleton.differentiableOn
-    exact s.subsingleton_of_subsingleton
-    exact hs
+  · apply ((s.subsingleton_of_subsingleton).differentiableOn _ hs).differentiableAt
     exact mem_nhds_discrete.mpr hs
-  · unfold OrientationPreserving at h
+  · rw [OrientationPreserving] at h
     contrapose! h
     use x, hs
     rw [fderiv_zero_of_not_differentiableAt h, ContinuousLinearMap.det]
@@ -96,7 +93,7 @@ lemma OrientationPreserving.differentiableAt [FiniteDimensional ℝ H] {f : H �
 
 lemma OrientationReversing.differentiableAt {f : H → H} {s : Set H} (h : OrientationReversing f s)
     {x : H} (hs : x ∈ s) : DifferentiableAt ℝ f x := by
-  unfold OrientationReversing at h
+  rw [OrientationReversing] at h
   contrapose! h
   use x, hs
   rw [fderiv_zero_of_not_differentiableAt h, ContinuousLinearMap.det]
@@ -111,36 +108,28 @@ lemma orientationPreserving_comp [FiniteDimensional ℝ H] {f g : H → H} {u v 
     OrientationPreserving (g ∘ f) (u ∩ f ⁻¹' v) := by
   intro x ⟨hxu, hxv⟩
   rw [fderiv.comp x (hg.differentiableAt hxv) (hf.differentiableAt hxu)]
-  unfold ContinuousLinearMap.det ContinuousLinearMap.comp
-  rw [(fderiv ℝ g (f x)).toLinearMap.det_comp (fderiv ℝ f x).toLinearMap]
-  exact mul_pos (hg (f x) hxv) (hf x hxu)
+  simpa [ContinuousLinearMap.det] using mul_pos (hg (f x) hxv) (hf x hxu)
 
 lemma orientationReversing_comp_orientationPreserving [FiniteDimensional ℝ H]
     {f g : H → H} {u v : Set H} (hf : OrientationPreserving f u) (hg : OrientationReversing g v) :
     OrientationReversing (g ∘ f) (u ∩ f ⁻¹' v) := by
   intro x ⟨hxu, hxv⟩
   rw [fderiv.comp x (hg.differentiableAt hxv) (hf.differentiableAt hxu)]
-  unfold ContinuousLinearMap.det ContinuousLinearMap.comp
-  rw [(fderiv ℝ g (f x)).toLinearMap.det_comp (fderiv ℝ f x).toLinearMap]
-  exact mul_neg_of_neg_of_pos (hg (f x) hxv) (hf x hxu)
+  simpa [ContinuousLinearMap.det] using mul_neg_of_neg_of_pos (hg (f x) hxv) (hf x hxu)
 
 lemma orientationPreserving_comp_orientationReversing [FiniteDimensional ℝ H]
     {f g : H → H} {u v : Set H} (hf : OrientationReversing f u) (hg : OrientationPreserving g v) :
     OrientationReversing (g ∘ f) (u ∩ f ⁻¹' v) := by
   intro x ⟨hxu, hxv⟩
   rw [fderiv.comp x (hg.differentiableAt hxv) (hf.differentiableAt hxu)]
-  unfold ContinuousLinearMap.det ContinuousLinearMap.comp
-  rw [(fderiv ℝ g (f x)).toLinearMap.det_comp (fderiv ℝ f x).toLinearMap]
-  exact mul_neg_of_pos_of_neg (hg (f x) hxv) (hf x hxu)
+  simpa [ContinuousLinearMap.det] using mul_neg_of_pos_of_neg (hg (f x) hxv) (hf x hxu)
 
 lemma orientationReversing_comp {f g : H → H} {u v : Set H}
     (hf : OrientationReversing f u) (hg : OrientationReversing g v) :
     OrientationPreserving (g ∘ f) (u ∩ f ⁻¹' v) := by
   intro x ⟨hxu, hxv⟩
   rw [fderiv.comp x (hg.differentiableAt hxv) (hf.differentiableAt hxu)]
-  unfold ContinuousLinearMap.det ContinuousLinearMap.comp
-  rw [(fderiv ℝ g (f x)).toLinearMap.det_comp (fderiv ℝ f x).toLinearMap]
-  exact mul_pos_of_neg_of_neg (hg (f x) hxv) (hf x hxu)
+  simpa [ContinuousLinearMap.det] using mul_pos_of_neg_of_neg (hg (f x) hxv) (hf x hxu)
 
 /-- The pregroupoid of orientation-preserving maps. -/
 def orientationPreservingPregroupoid [FiniteDimensional ℝ H] : Pregroupoid H where

--- a/Mathlib/Geometry/Manifold/Orientable.lean
+++ b/Mathlib/Geometry/Manifold/Orientable.lean
@@ -43,11 +43,11 @@ def orientationPreservingPregroupoid : Pregroupoid H where
   comp {f g u v} hf hg _ _ _ := by
     intro x ⟨hxu, hxv⟩
     rw [fderiv.comp _ (hg (f x) hxv).1 (hf x hxu).1]
-    · have h₁ : 0 < (fderiv ℝ f x).det := (hf x hxu).2
-      have h₂ : 0 < (fderiv ℝ g (f x)).det := (hg (f x) hxv).2
-      unfold ContinuousLinearMap.det ContinuousLinearMap.comp
-      rw [(fderiv ℝ g (f x)).toLinearMap.det_comp (fderiv ℝ f x).toLinearMap]
-      exact ⟨(hg (f x) hxv).1.comp x (hf x hxu).1, mul_pos h₂ h₁⟩
+    have h₁ : 0 < (fderiv ℝ f x).det := (hf x hxu).2
+    have h₂ : 0 < (fderiv ℝ g (f x)).det := (hg (f x) hxv).2
+    unfold ContinuousLinearMap.det ContinuousLinearMap.comp
+    rw [(fderiv ℝ g (f x)).toLinearMap.det_comp (fderiv ℝ f x).toLinearMap]
+    exact ⟨(hg (f x) hxv).1.comp x (hf x hxu).1, mul_pos h₂ h₁⟩
   id_mem := by
     intro x _
     simp only [Set.mem_univ, differentiableAt_id, fderiv_id, true_and]

--- a/Mathlib/Geometry/Manifold/Orientable.lean
+++ b/Mathlib/Geometry/Manifold/Orientable.lean
@@ -6,6 +6,7 @@ Authors: Rida Hamadani
 import Mathlib.Analysis.Calculus.FDeriv.Comp
 import Mathlib.Geometry.Manifold.ChartedSpace
 import Mathlib.Topology.Algebra.Module.Determinant
+import Mathlib.Geometry.Manifold.SmoothManifoldWithCorners
 
 /-!
 # Orientable Manifolds
@@ -124,8 +125,13 @@ end OrientationPreserving
 section OrientableManifold
 
 /-- Typeclass defining orientable manifolds. -/
-class OrientableManifold [Nontrivial H] [FiniteDimensional ℝ H]
-    (M : Type*) [TopologicalSpace M] [ChartedSpace H M] extends
+class OrientableManifold (H : Type*) [Nontrivial H] [NormedAddCommGroup H] [NormedSpace ℝ H]
+    [FiniteDimensional ℝ H] (M : Type*) [TopologicalSpace M] [ChartedSpace H M] extends
   HasGroupoid M (@orientationPreservingGroupoid H _ _ _ _) : Prop
+
+class OrientableSmoothManifold (H : Type*) [Nontrivial H] [NormedAddCommGroup H] [NormedSpace ℝ H]
+    [FiniteDimensional ℝ H] (M : Type*) [TopologicalSpace M] [ChartedSpace H M]
+    [OrientableManifold H M] (I : ModelWithCorners ℝ H M) [SmoothManifoldWithCorners I M] extends
+  SmoothManifoldWithCorners I M ∧ OrientableManifold H M : Prop
 
 end OrientableManifold

--- a/Mathlib/Geometry/Manifold/Orientable.lean
+++ b/Mathlib/Geometry/Manifold/Orientable.lean
@@ -84,29 +84,26 @@ lemma orientationPreserving_of_zero_dim (f : H → H) (s : Set H) (h : Module.ra
     exact Matrix.det_fin_zero
   det_eq_one ▸ Real.zero_lt_one
 
-lemma OrientationPreserving.DifferentiableAt [FiniteDimensional ℝ H] {f : H → H}
-    {s : Set H} (h : OrientationPreserving f s) : ∀ x ∈ s, DifferentiableAt ℝ f x := by
+lemma OrientationPreserving.DifferentiableAt [FiniteDimensional ℝ H] {f : H → H} {s : Set H}
+    (h : OrientationPreserving f s) {x : H} (hs : x ∈ s) : DifferentiableAt ℝ f x := by
   cases subsingleton_or_nontrivial H
-  · intro x hs
-    apply DifferentiableWithinAt.differentiableAt
+  · apply DifferentiableWithinAt.differentiableAt
     apply Set.Subsingleton.differentiableOn
     exact s.subsingleton_of_subsingleton
     exact hs
     exact mem_nhds_discrete.mpr hs
   · unfold OrientationPreserving at h
     contrapose! h
-    obtain ⟨x, hx, hd⟩ := h
-    use x, hx
-    rw [fderiv_zero_of_not_differentiableAt hd, ContinuousLinearMap.det]
+    use x, hs
+    rw [fderiv_zero_of_not_differentiableAt h, ContinuousLinearMap.det]
     simp [ne_of_gt FiniteDimensional.finrank_pos]
 
-lemma OrientationReversing.DifferentiableAt {f : H → H}
-    {s : Set H} (h : OrientationReversing f s) : ∀ x ∈ s, DifferentiableAt ℝ f x := by
+lemma OrientationReversing.DifferentiableAt {f : H → H} {s : Set H} (h : OrientationReversing f s)
+    {x : H} (hs : x ∈ s) : DifferentiableAt ℝ f x := by
   unfold OrientationReversing at h
   contrapose! h
-  obtain ⟨x, hx, hd⟩ := h
-  use x, hx
-  rw [fderiv_zero_of_not_differentiableAt hd, ContinuousLinearMap.det]
+  use x, hs
+  rw [fderiv_zero_of_not_differentiableAt h, ContinuousLinearMap.det]
   simp [ne_of_gt FiniteDimensional.finrank_pos]
 
 lemma orientationPreserving_id (s : Set H) : OrientationPreserving id s := by
@@ -117,7 +114,7 @@ lemma orientationPreserving_comp [FiniteDimensional ℝ H] {f g : H → H} {u v 
     (hf : OrientationPreserving f u) (hg : OrientationPreserving g v) :
     OrientationPreserving (g ∘ f) (u ∩ f ⁻¹' v) := by
   intro x ⟨hxu, hxv⟩
-  rw [fderiv.comp x (hg.DifferentiableAt (f x) hxv) (hf.DifferentiableAt x hxu)]
+  rw [fderiv.comp x (hg.DifferentiableAt hxv) (hf.DifferentiableAt hxu)]
   unfold ContinuousLinearMap.det ContinuousLinearMap.comp
   rw [(fderiv ℝ g (f x)).toLinearMap.det_comp (fderiv ℝ f x).toLinearMap]
   exact mul_pos (hg (f x) hxv) (hf x hxu)
@@ -126,7 +123,7 @@ lemma orientationReversing_comp_orientationPreserving [FiniteDimensional ℝ H]
     {f g : H → H} {u v : Set H} (hf : OrientationPreserving f u) (hg : OrientationReversing g v) :
     OrientationReversing (g ∘ f) (u ∩ f ⁻¹' v) := by
   intro x ⟨hxu, hxv⟩
-  rw [fderiv.comp x (hg.DifferentiableAt (f x) hxv) (hf.DifferentiableAt x hxu)]
+  rw [fderiv.comp x (hg.DifferentiableAt hxv) (hf.DifferentiableAt hxu)]
   unfold ContinuousLinearMap.det ContinuousLinearMap.comp
   rw [(fderiv ℝ g (f x)).toLinearMap.det_comp (fderiv ℝ f x).toLinearMap]
   exact mul_neg_of_neg_of_pos (hg (f x) hxv) (hf x hxu)
@@ -135,7 +132,7 @@ lemma orientationPreserving_comp_orientationReversing [FiniteDimensional ℝ H]
     {f g : H → H} {u v : Set H} (hf : OrientationReversing f u) (hg : OrientationPreserving g v) :
     OrientationReversing (g ∘ f) (u ∩ f ⁻¹' v) := by
   intro x ⟨hxu, hxv⟩
-  rw [fderiv.comp x (hg.DifferentiableAt (f x) hxv) (hf.DifferentiableAt x hxu)]
+  rw [fderiv.comp x (hg.DifferentiableAt hxv) (hf.DifferentiableAt hxu)]
   unfold ContinuousLinearMap.det ContinuousLinearMap.comp
   rw [(fderiv ℝ g (f x)).toLinearMap.det_comp (fderiv ℝ f x).toLinearMap]
   exact mul_neg_of_pos_of_neg (hg (f x) hxv) (hf x hxu)
@@ -144,7 +141,7 @@ lemma orientationReversing_comp {f g : H → H} {u v : Set H}
     (hf : OrientationReversing f u) (hg : OrientationReversing g v) :
     OrientationPreserving (g ∘ f) (u ∩ f ⁻¹' v) := by
   intro x ⟨hxu, hxv⟩
-  rw [fderiv.comp x (hg.DifferentiableAt (f x) hxv) (hf.DifferentiableAt x hxu)]
+  rw [fderiv.comp x (hg.DifferentiableAt hxv) (hf.DifferentiableAt hxu)]
   unfold ContinuousLinearMap.det ContinuousLinearMap.comp
   rw [(fderiv ℝ g (f x)).toLinearMap.det_comp (fderiv ℝ f x).toLinearMap]
   exact mul_pos_of_neg_of_neg (hg (f x) hxv) (hf x hxu)

--- a/Mathlib/Geometry/Manifold/Orientable.lean
+++ b/Mathlib/Geometry/Manifold/Orientable.lean
@@ -28,11 +28,16 @@ variable {H : Type*} [NormedAddCommGroup H] [NormedSpace ℝ H]
 
 section orientationPreservingGroupoid
 
+/--
+A map is orientation-preserving on a given set if it is differentiable and the determinant of its
+Jacobian is strictly positive on that set.
+-/
 def OrientationPreserving (f : H → H) (s : Set H) : Prop :=
   ∀ x ∈ s,
     DifferentiableAt ℝ f x ∧
     0 < (fderiv ℝ f x).det
 
+/-- The pregroupoid of orientation-preserving maps. -/
 def orientationPreservingPregroupoid : Pregroupoid H where
   property f s := OrientationPreserving f s
   comp {f g u v} hf hg _ _ _ := by
@@ -60,6 +65,7 @@ def orientationPreservingPregroupoid : Pregroupoid H where
     · rw [Filter.EventuallyEq.fderiv_eq this]
       exact (hf x hx).2
 
+/-- The groupoid of orientation-preserving maps. -/
 def orientationPreservingGroupoid : StructureGroupoid H :=
   orientationPreservingPregroupoid.groupoid
 
@@ -67,6 +73,7 @@ end orientationPreservingGroupoid
 
 section OrientableManifold
 
+/-- Typeclass defining orientable manifolds. -/
 class OrientableManifold (M : Type*) [TopologicalSpace M] [ChartedSpace H M] extends
   HasGroupoid M (@orientationPreservingGroupoid H _ _) : Prop
 

--- a/Mathlib/Geometry/Manifold/Orientable.lean
+++ b/Mathlib/Geometry/Manifold/Orientable.lean
@@ -160,10 +160,8 @@ def orientationPreservingGroupoid [FiniteDimensional ℝ H] : StructureGroupoid 
 
 end OrientationPreserving
 
-section OrientableManifold
-
 /-! ### Orientable manifolds -/
-
+section OrientableManifold
 
 /-- Typeclass defining orientable manifolds. -/
 class OrientableManifold (H : Type*) [NormedAddCommGroup H] [NormedSpace ℝ H]
@@ -174,7 +172,7 @@ class OrientableManifold (H : Type*) [NormedAddCommGroup H] [NormedSpace ℝ H]
 lemma orientableManifold_of_zero_dim (H : Type*) [NormedAddCommGroup H] [NormedSpace ℝ H]
     [FiniteDimensional ℝ H] (M : Type*) [TopologicalSpace M] [ChartedSpace H M]
     (h : FiniteDimensional.finrank ℝ H = 0) : OrientableManifold H M where
-  compatible := fun {_ _} _ _ ↦
+  compatible := fun _ _ ↦
     ⟨orientationPreserving_of_zero_dim _ _ h, orientationPreserving_of_zero_dim _ _ h⟩
 
 /-- Typeclass defining orientable smooth manifolds. -/


### PR DESCRIPTION
- wait for #33307 to get merged
- PR the "normed space" part separately
- WIP: a linear isomorphism on a connected set is either orientation-preserving or orientation-preserving: some form of this was merged into mathlib recently; TODO update this PR accordingly!

- [ ] depends on: #33307
- [x] depends on: #8738
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
