### PR TITLE
[Merged by Bors] - feat(Sym2): Add pmap

### DIFF
--- a/Mathlib/Data/Sym/Sym2.lean
+++ b/Mathlib/Data/Sym/Sym2.lean
@@ -406,18 +406,21 @@ def pmap {P : α → Prop} (f : ∀ a, P a → β) (s : Sym2 α) : (∀ a ∈ s,
     rw [rel_iff', Prod.mk.injEq, Prod.swap_prod_mk]
     apply hpq.imp <;> rintro rfl <;> simp
 
-theorem forall_mem_pair {P : α → Prop} (a b : α) : (∀ x ∈ s(a, b), P x) ↔ P a ∧ P b := by
+@[simp]
+theorem forall_mem_pair {P : α → Prop} {a b : α} : (∀ x ∈ s(a, b), P x) ↔ P a ∧ P b := by
   simp only [mem_iff, forall_eq_or_imp, forall_eq]
 
 lemma pmap_pair {P : α → Prop} (f : ∀ a, P a → β) (a b : α) (h : P a) (h' : P b) :
-    pmap f s(a, b) ((mem_sat_pair a b).mpr ⟨h, h'⟩) = s(f a h, f b h') := by
-  simp only [pmap]
+    s(f a h, f b h') = pmap f s(a, b) (forall_mem_pair.mpr ⟨h, h'⟩) := rfl
+
+lemma pmap_pair' {P : α → Prop} (f : ∀ a, P a → β) (a b : α) (h : ∀ x ∈ s(a, b), P x) :
+    pmap f s(a, b) h = s(f a (h a (mem_mk_left a b)), f b (h b (mem_mk_right a b))) := rfl
 
 @[simp]
 lemma mem_pmap_iff {P : α → Prop} (f : ∀ a, P a → β) (z : Sym2 α) (h : ∀ a ∈ z, P a) (b : β) :
     b ∈ z.pmap f h ↔ ∃ (a : α) (ha : a ∈ z), b = f a (h a ha) := by
   induction' z with x y
-  rw [pmap_pair _ _ _ (h x (mem_mk_left x y)) (h y (mem_mk_right x y))]
+  rw [pmap_pair' f x y h]
   simp only [mem_iff]
   constructor
   · rintro (rfl | rfl)

--- a/Mathlib/Data/Sym/Sym2.lean
+++ b/Mathlib/Data/Sym/Sym2.lean
@@ -406,7 +406,7 @@ def pmap {P : α → Prop} (f : ∀ a, P a → β) (s : Sym2 α) : (∀ a ∈ s,
     rw [rel_iff', Prod.mk.injEq, Prod.swap_prod_mk]
     apply hpq.imp <;> rintro rfl <;> simp
 
-theorem mem_sat_pair {P : α → Prop} (a b : α) : (∀ x ∈ s(a, b), P x) ↔ P a ∧ P b := by
+theorem forall_mem_pair {P : α → Prop} (a b : α) : (∀ x ∈ s(a, b), P x) ↔ P a ∧ P b := by
   simp only [mem_iff, forall_eq_or_imp, forall_eq]
 
 lemma pmap_pair {P : α → Prop} (f : ∀ a, P a → β) (a b : α) (h : P a) (h' : P b) :

--- a/Mathlib/Data/Sym/Sym2.lean
+++ b/Mathlib/Data/Sym/Sym2.lean
@@ -444,16 +444,23 @@ lemma pmap_map {P : α → Prop} {Q : β → Prop} (f : ∀ a, P a → β) (g : 
   induction' z with x y
   rfl
 
+lemma pmap_pmap {P : α → Prop} {Q : β → Prop} (f : ∀ a, P a → β) (g : ∀ b, Q b → γ)
+    (z : Sym2 α) (h : ∀ a ∈ z, P a) (h' : ∀ b ∈ z.pmap f h, Q b) :
+    (z.pmap f h).pmap g h' = z.pmap (fun a ha => g (f a (h a ha))
+    (h' _ ((mem_pmap_iff f z h _).mpr ⟨a, ha, rfl⟩))) (fun a ha ↦ ha) := by
+  induction' z with x y
+  rfl
+
 /--
 "Attach" a proof `P a` that holds for all the elements of `s` to produce a new Sym2 object
 with the same elements but in the type `{x // P x}`.
 -/
-def attachWith (s : Sym2 α) (P : α → Prop) (f : ∀ a ∈ s, P a) : Sym2 {a // P a} :=
+def attachWith {P : α → Prop} (s : Sym2 α)  (f : ∀ a ∈ s, P a) : Sym2 {a // P a} :=
   pmap Subtype.mk s f
 
 @[simp]
 lemma attachWith_map_subtype_val {s : Sym2 α} {P : α → Prop} (f : ∀ a ∈ s, P a) :
-    (s.attachWith P f).map Subtype.val = s := by
+    (s.attachWith f).map Subtype.val = s := by
   induction' s with x y
   rfl
 

--- a/Mathlib/Data/Sym/Sym2.lean
+++ b/Mathlib/Data/Sym/Sym2.lean
@@ -409,7 +409,6 @@ def pmap {P : α → Prop} (f : ∀ a, P a → β) (s : Sym2 α) : (∀ a ∈ s,
 theorem mem_sat_pair {P : α → Prop} (a b : α) : (∀ x ∈ s(a, b), P x) ↔ P a ∧ P b := by
   simp only [mem_iff, forall_eq_or_imp, forall_eq]
 
-@[simp]
 lemma pmap_pair {P : α → Prop} (f : ∀ a, P a → β) (a b : α) (h : P a) (h' : P b) :
     pmap f s(a, b) ((mem_sat_pair a b).mpr ⟨h, h'⟩) = s(f a h, f b h') := by
   simp only [pmap]

--- a/Mathlib/Data/Sym/Sym2.lean
+++ b/Mathlib/Data/Sym/Sym2.lean
@@ -420,7 +420,6 @@ lemma mem_pmap_iff {P : α → Prop} (f : ∀ a, P a → β) (z : Sym2 α) (h : 
     b ∈ z.pmap f h ↔ ∃ (a : α) (ha : a ∈ z), b = f a (h a ha) := by
   induction' z with x y
   rw [pmap_pair f x y h]
-  simp only [mem_iff]
   aesop
 
 lemma pmap_eq_map {P : α → Prop} (f : α → β) (z : Sym2 α) (h : ∀ a ∈ z, P a) :

--- a/Mathlib/Data/Sym/Sym2.lean
+++ b/Mathlib/Data/Sym/Sym2.lean
@@ -392,8 +392,8 @@ then `pmap f s h` is essentially the same as `map f s` but is defined only when 
 satisfy `p`, using the proof to apply `f`.
 -/
 def pmap {P : α → Prop} (f : ∀ a, P a → β) (s : Sym2 α) : (∀ a ∈ s, P a) → Sym2 β :=
-  let g : (p : α × α) → (∀ a ∈ Sym2.mk p, P a) → Sym2 β :=
-    fun p H => s(f p.1 (H p.1 <| mem_mk_left _ _), f p.2 (H p.2 <| mem_mk_right _ _))
+  let g (p : α × α) (H : ∀ a ∈ Sym2.mk p, P a) : Sym2 β :=
+    s(f p.1 (H p.1 <| mem_mk_left _ _), f p.2 (H p.2 <| mem_mk_right _ _))
   Quot.recOn s g fun p q hpq => funext fun Hq => by
     rw [rel_iff'] at hpq
     have Hp : ∀ a ∈ Sym2.mk p, P a := fun a hmem =>

--- a/Mathlib/Data/Sym/Sym2.lean
+++ b/Mathlib/Data/Sym/Sym2.lean
@@ -397,7 +397,7 @@ def pmap {P : α → Prop} (f : ∀ a, P a → β) (s : Sym2 α) : (∀ a ∈ s,
   Quot.recOn s g fun p q hpq => funext fun Hq => by
     rw [rel_iff'] at hpq
     have Hp : ∀ a ∈ Sym2.mk p, P a := fun a hmem =>
-      Hq a ((Sym2.mk_eq_mk_iff.2 hpq) ▸ hmem : a ∈ Sym2.mk q)
+      Hq a (Sym2.mk_eq_mk_iff.2 hpq ▸ hmem : a ∈ Sym2.mk q)
     have h : ∀ {s₂ e H}, Eq.ndrec (motive := fun s => (∀ a ∈ s, P a) → Sym2 β) (g p) (b := s₂) e H =
       g p Hp := by
       rintro s₂ rfl _

--- a/Mathlib/Data/Sym/Sym2.lean
+++ b/Mathlib/Data/Sym/Sym2.lean
@@ -406,7 +406,6 @@ def pmap {P : α → Prop} (f : ∀ a, P a → β) (s : Sym2 α) : (∀ a ∈ s,
     rw [rel_iff', Prod.mk.injEq, Prod.swap_prod_mk]
     apply hpq.imp <;> rintro rfl <;> simp
 
-@[simp]
 theorem forall_mem_pair {P : α → Prop} {a b : α} : (∀ x ∈ s(a, b), P x) ↔ P a ∧ P b := by
   simp only [mem_iff, forall_eq_or_imp, forall_eq]
 

--- a/Mathlib/Data/Sym/Sym2.lean
+++ b/Mathlib/Data/Sym/Sym2.lean
@@ -421,11 +421,7 @@ lemma mem_pmap_iff {P : α → Prop} (f : ∀ a, P a → β) (z : Sym2 α) (h : 
   induction' z with x y
   rw [pmap_pair f x y h]
   simp only [mem_iff]
-  constructor
-  · rintro (rfl | rfl)
-    · use x, Or.inl rfl
-    · use y, Or.inr rfl
-  · rintro ⟨a, (rfl | rfl), rfl⟩ <;> tauto
+  aesop
 
 lemma pmap_eq_map {P : α → Prop} (f : α → β) (z : Sym2 α) (h : ∀ a ∈ z, P a) :
     z.pmap (fun a _ => f a) h = z.map f := by

--- a/Mathlib/Data/Sym/Sym2.lean
+++ b/Mathlib/Data/Sym/Sym2.lean
@@ -459,7 +459,7 @@ def attachWith {P : α → Prop} (s : Sym2 α)  (f : ∀ a ∈ s, P a) : Sym2 {a
   pmap Subtype.mk s f
 
 @[simp]
-lemma attachWith_map_subtype_val {s : Sym2 α} {P : α → Prop} (f : ∀ a ∈ s, P a) :
+lemma attachWith_map_subtypeVal {s : Sym2 α} {P : α → Prop} (f : ∀ a ∈ s, P a) :
     (s.attachWith f).map Subtype.val = s := by
   induction' s with x y
   rfl

--- a/Mathlib/Data/Sym/Sym2.lean
+++ b/Mathlib/Data/Sym/Sym2.lean
@@ -433,8 +433,7 @@ lemma pmap_eq_map {P : α → Prop} (f : α → β) (z : Sym2 α) (h : ∀ a ∈
   induction' z with x y
   rfl
 
-lemma map_pmap {Q : β → Prop} (f : α → β) (g : ∀ b, Q b → γ) (z : Sym2 α)
-  (h' : ∀ b ∈ z.map f, Q b) :
+lemma map_pmap {Q : β → Prop} (f : α → β) (g : ∀ b, Q b → γ) (z : Sym2 α) (h' : ∀ b ∈ z.map f, Q b):
     (z.map f).pmap g h' =
     z.pmap (fun a ha => g (f a) (h' (f a) (mem_map.mpr ⟨a, ha, rfl⟩))) (fun a ha => ha) := by
   induction' z with x y

--- a/Mathlib/Data/Sym/Sym2.lean
+++ b/Mathlib/Data/Sym/Sym2.lean
@@ -409,60 +409,64 @@ def pmap {P : α → Prop} (f : ∀ a, P a → β) (s : Sym2 α) : (∀ a ∈ s,
 theorem forall_mem_pair {P : α → Prop} {a b : α} : (∀ x ∈ s(a, b), P x) ↔ P a ∧ P b := by
   simp only [mem_iff, forall_eq_or_imp, forall_eq]
 
-lemma pmap_pair {P : α → Prop} (f : ∀ a, P a → β) (a b : α) (h : P a) (h' : P b) :
+lemma pair_eq_pmap {P : α → Prop} (f : ∀ a, P a → β) (a b : α) (h : P a) (h' : P b) :
     s(f a h, f b h') = pmap f s(a, b) (forall_mem_pair.mpr ⟨h, h'⟩) := rfl
 
-lemma pmap_pair' {P : α → Prop} (f : ∀ a, P a → β) (a b : α) (h : ∀ x ∈ s(a, b), P x) :
+lemma pmap_pair {P : α → Prop} (f : ∀ a, P a → β) (a b : α) (h : ∀ x ∈ s(a, b), P x) :
     pmap f s(a, b) h = s(f a (h a (mem_mk_left a b)), f b (h b (mem_mk_right a b))) := rfl
 
 @[simp]
 lemma mem_pmap_iff {P : α → Prop} (f : ∀ a, P a → β) (z : Sym2 α) (h : ∀ a ∈ z, P a) (b : β) :
     b ∈ z.pmap f h ↔ ∃ (a : α) (ha : a ∈ z), b = f a (h a ha) := by
   induction' z with x y
-  rw [pmap_pair' f x y h]
+  rw [pmap_pair f x y h]
   simp only [mem_iff]
   constructor
   · rintro (rfl | rfl)
     · use x, Or.inl rfl
     · use y, Or.inr rfl
-  · rintro ⟨a, (rfl | rfl), rfl⟩
-    exact Or.inl rfl
-    exact Or.inr rfl
+  · rintro ⟨a, (rfl | rfl), rfl⟩ <;> tauto
 
 lemma pmap_eq_map {P : α → Prop} (f : α → β) (z : Sym2 α) (h : ∀ a ∈ z, P a) :
     z.pmap (fun a _ => f a) h = z.map f := by
   induction' z with x y
   rfl
 
-lemma map_pmap {Q : β → Prop} (f : α → β) (g : ∀ b, Q b → γ) (z : Sym2 α) (h' : ∀ b ∈ z.map f, Q b):
-    (z.map f).pmap g h' =
-    z.pmap (fun a ha => g (f a) (h' (f a) (mem_map.mpr ⟨a, ha, rfl⟩))) (fun a ha => ha) := by
+lemma map_pmap {Q : β → Prop} (f : α → β) (g : ∀ b, Q b → γ) (z : Sym2 α) (h : ∀ b ∈ z.map f, Q b):
+    (z.map f).pmap g h =
+    z.pmap (fun a ha => g (f a) (h (f a) (mem_map.mpr ⟨a, ha, rfl⟩))) (fun _ ha => ha) := by
   induction' z with x y
   rfl
 
 lemma pmap_map {P : α → Prop} {Q : β → Prop} (f : ∀ a, P a → β) (g : β → γ)
     (z : Sym2 α) (h : ∀ a ∈ z, P a) (h' : ∀ b ∈ z.pmap f h, Q b) :
-    (z.pmap f h).map g = z.pmap (fun a ha => g (f a (h a ha))) (fun a ha ↦ ha) := by
+    (z.pmap f h).map g = z.pmap (fun a ha => g (f a (h a ha))) (fun _ ha ↦ ha) := by
   induction' z with x y
   rfl
 
 lemma pmap_pmap {P : α → Prop} {Q : β → Prop} (f : ∀ a, P a → β) (g : ∀ b, Q b → γ)
     (z : Sym2 α) (h : ∀ a ∈ z, P a) (h' : ∀ b ∈ z.pmap f h, Q b) :
     (z.pmap f h).pmap g h' = z.pmap (fun a ha => g (f a (h a ha))
-    (h' _ ((mem_pmap_iff f z h _).mpr ⟨a, ha, rfl⟩))) (fun a ha ↦ ha) := by
+    (h' _ ((mem_pmap_iff f z h _).mpr ⟨a, ha, rfl⟩))) (fun _ ha ↦ ha) := by
   induction' z with x y
+  rfl
+
+@[simp]
+lemma pmap_subtype_map_subtypeVal {P : α → Prop} (s : Sym2 α) (h : ∀ a ∈ s, P a) :
+    (s.pmap Subtype.mk h).map Subtype.val = s := by
+  induction' s with x y
   rfl
 
 /--
 "Attach" a proof `P a` that holds for all the elements of `s` to produce a new Sym2 object
 with the same elements but in the type `{x // P x}`.
 -/
-def attachWith {P : α → Prop} (s : Sym2 α)  (f : ∀ a ∈ s, P a) : Sym2 {a // P a} :=
-  pmap Subtype.mk s f
+def attachWith {P : α → Prop} (s : Sym2 α) (h : ∀ a ∈ s, P a) : Sym2 {a // P a} :=
+  pmap Subtype.mk s h
 
 @[simp]
-lemma attachWith_map_subtypeVal {s : Sym2 α} {P : α → Prop} (f : ∀ a ∈ s, P a) :
-    (s.attachWith f).map Subtype.val = s := by
+lemma attachWith_map_subtypeVal {s : Sym2 α} {P : α → Prop} (h : ∀ a ∈ s, P a) :
+    (s.attachWith h).map Subtype.val = s := by
   induction' s with x y
   rfl
 

--- a/Mathlib/Data/Sym/Sym2.lean
+++ b/Mathlib/Data/Sym/Sym2.lean
@@ -715,8 +715,7 @@ def pmap {P : α → Prop} (f : ∀ a, P a → β) (s : Sym2 α):
 "Attach" a proof `P a` that holds for all the elements of `s` to produce a new Sym2 object
   with the same elements but in the type `{x // P x}`.
 -/
-def attachWith (s : Sym2 α) (P : α → Prop) (f : ∀ a ∈ s, P a) :
-  Sym2 {a // P a} :=
+def attachWith (s : Sym2 α) (P : α → Prop) (f : ∀ a ∈ s, P a) : Sym2 {a // P a} :=
   pmap Subtype.mk s f
 
 end Sym2

--- a/Mathlib/Data/Sym/Sym2.lean
+++ b/Mathlib/Data/Sym/Sym2.lean
@@ -692,4 +692,22 @@ instance [Nontrivial α] : Nontrivial (Sym2 α) :=
 unsafe instance [Repr α] : Repr (Sym2 α) where
   reprPrec s _ := f!"s({repr s.unquot.1}, {repr s.unquot.2})"
 
+def pmap {P : α → Prop} (f : ∀ a, P a → β) (s : Sym2 α):
+  (∀ a ∈ s, P a) → Sym2 β :=
+  let g : (p : α × α) → (∀ a ∈ Sym2.mk p, P a) → Sym2 β :=
+    fun p H => s(f p.1 (H p.1 <| mem_mk_left _ _), f p.2 (H p.2 <| mem_mk_right _ _))
+  Quot.recOn (motive := fun (x : Sym2 α) => (∀ a ∈ x, P a) → Sym2 β)
+    s g fun p q hpq => funext fun Hq => by
+    rw [rel_iff'] at hpq
+    have Hp : ∀ a ∈ Sym2.mk p, P a := fun a hmem =>
+      Hq a ((Sym2.mk_eq_mk_iff.2 hpq) ▸ hmem : a ∈ Sym2.mk q)
+    refine (by rintro s₂ rfl _; rfl : ∀ {s₂ e H}, @Eq.ndrec (Sym2 α) (Sym2.mk p)
+      (fun s => (∀ a ∈ s, P a) → Sym2 β) _ s₂ e H = _).trans (Quot.sound (?_) : g p Hp = g q Hq)
+    rw [rel_iff', Prod.mk.injEq, Prod.swap_prod_mk]
+    apply hpq.imp <;> rintro rfl <;> simp
+
+def attachWith (s : Sym2 α) (P : α → Prop) (f : ∀ a ∈ s, P a) :
+  Sym2 {a // P a} :=
+  pmap Subtype.mk s f
+
 end Sym2

--- a/Mathlib/Data/Sym/Sym2.lean
+++ b/Mathlib/Data/Sym/Sym2.lean
@@ -692,6 +692,11 @@ instance [Nontrivial α] : Nontrivial (Sym2 α) :=
 unsafe instance [Repr α] : Repr (Sym2 α) where
   reprPrec s _ := f!"s({repr s.unquot.1}, {repr s.unquot.2})"
 
+/--
+Partial map. If `f : Π a, p a → β` is a partial function defined on `a : α` satisfying `p`,
+then `pmap f s h` is essentially the same as `map f s` but is defined only when all members of `s`
+satisfy `p`, using the proof to apply `f`.
+-/
 def pmap {P : α → Prop} (f : ∀ a, P a → β) (s : Sym2 α):
   (∀ a ∈ s, P a) → Sym2 β :=
   let g : (p : α × α) → (∀ a ∈ Sym2.mk p, P a) → Sym2 β :=
@@ -706,6 +711,10 @@ def pmap {P : α → Prop} (f : ∀ a, P a → β) (s : Sym2 α):
     rw [rel_iff', Prod.mk.injEq, Prod.swap_prod_mk]
     apply hpq.imp <;> rintro rfl <;> simp
 
+/--
+"Attach" a proof `P a` that holds for all the elements of `s` to produce a new Sym2 object
+  with the same elements but in the type `{x // P x}`.
+-/
 def attachWith (s : Sym2 α) (P : α → Prop) (f : ∀ a ∈ s, P a) :
   Sym2 {a // P a} :=
   pmap Subtype.mk s f

--- a/Mathlib/Data/Sym/Sym2.lean
+++ b/Mathlib/Data/Sym/Sym2.lean
@@ -391,7 +391,7 @@ Partial map. If `f : ∀ a, p a → β` is a partial function defined on `a : α
 then `pmap f s h` is essentially the same as `map f s` but is defined only when all members of `s`
 satisfy `p`, using the proof to apply `f`.
 -/
-def pmap {P : α → Prop} (f : ∀ a, P a → β) (s : Sym2 α): (∀ a ∈ s, P a) → Sym2 β :=
+def pmap {P : α → Prop} (f : ∀ a, P a → β) (s : Sym2 α) : (∀ a ∈ s, P a) → Sym2 β :=
   let g : (p : α × α) → (∀ a ∈ Sym2.mk p, P a) → Sym2 β :=
     fun p H => s(f p.1 (H p.1 <| mem_mk_left _ _), f p.2 (H p.2 <| mem_mk_right _ _))
   Quot.recOn s g fun p q hpq => funext fun Hq => by

--- a/Mathlib/Data/Sym/Sym2.lean
+++ b/Mathlib/Data/Sym/Sym2.lean
@@ -408,7 +408,7 @@ def pmap {P : α → Prop} (f : ∀ a, P a → β) (s : Sym2 α) : (∀ a ∈ s,
 
 /--
 "Attach" a proof `P a` that holds for all the elements of `s` to produce a new Sym2 object
-  with the same elements but in the type `{x // P x}`.
+with the same elements but in the type `{x // P x}`.
 -/
 def attachWith (s : Sym2 α) (P : α → Prop) (f : ∀ a ∈ s, P a) : Sym2 {a // P a} :=
   pmap Subtype.mk s f


### PR DESCRIPTION
Adds Sym2.pmap and 
 Sym2.attachWith, which is direct application of pmap. 

These functions are analogous to the functions with the same name under the namespace List and Multiset.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
