### PR TITLE
[Merged by Bors] - chore: remove unnecessary import

### DIFF
--- a/Mathlib/Topology/Category/TopCat/EffectiveEpi.lean
+++ b/Mathlib/Topology/Category/TopCat/EffectiveEpi.lean
@@ -4,7 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Dagur Asgeirsson
 -/
 import Mathlib.CategoryTheory.EffectiveEpi.RegularEpi
-import Mathlib.CategoryTheory.EffectiveEpi.Comp
 import Mathlib.Topology.Category.TopCat.Limits.Pullbacks
 /-!
 


### PR DESCRIPTION
---
Reported by `lake exe shake` when working on #16419.

It seems like `lake exe shake` uncovers new unnecessary imports when imports are sorted.