### PR TITLE
[Merged by Bors] - feat(Algebra/Order/BigOperators): prove lemmas for `List.prod` and `Multiset.prod` on `CommMonoidWithZero`

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -540,6 +540,8 @@ import Mathlib.Algebra.Order.Archimedean.Hom
 import Mathlib.Algebra.Order.BigOperators.Group.Finset
 import Mathlib.Algebra.Order.BigOperators.Group.List
 import Mathlib.Algebra.Order.BigOperators.Group.Multiset
+import Mathlib.Algebra.Order.BigOperators.GroupWithZero.List
+import Mathlib.Algebra.Order.BigOperators.GroupWithZero.Multiset
 import Mathlib.Algebra.Order.BigOperators.Ring.Finset
 import Mathlib.Algebra.Order.BigOperators.Ring.List
 import Mathlib.Algebra.Order.BigOperators.Ring.Multiset

--- a/Mathlib/Algebra/Order/BigOperators/GroupWithZero/List.lean
+++ b/Mathlib/Algebra/Order/BigOperators/GroupWithZero/List.lean
@@ -1,0 +1,99 @@
+/-
+Copyright (c) 2024 Daniel Weber. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Daniel Weber
+-/
+import Mathlib.Algebra.BigOperators.Group.List
+import Mathlib.Algebra.Order.GroupWithZero.Unbundled
+
+/-!
+# Big operators on a list in ordered groups with zeros
+
+This file contains the results concerning the interaction of list big operators with ordered
+groups with zeros.
+-/
+
+namespace List
+variable {R : Type*} [CommMonoidWithZero R] [PartialOrder R] [ZeroLEOneClass R] [PosMulMono R]
+
+lemma prod_nonneg {s : List R} (h : ∀ a ∈ s, 0 ≤ a) : 0 ≤ s.prod := by
+  induction s with
+  | nil => simp
+  | cons head tail hind =>
+    simp only [prod_cons]
+    simp only [mem_cons, forall_eq_or_imp] at h
+    exact mul_nonneg h.1 (hind h.2)
+
+
+lemma one_le_prod {s : List R} (h : ∀ a ∈ s, 1 ≤ a) : 1 ≤ s.prod := by
+  induction s with
+  | nil => simp
+  | cons head tail hind =>
+    simp only [prod_cons]
+    simp only [mem_cons, forall_eq_or_imp] at h
+    exact one_le_mul_of_one_le_of_one_le h.1 (hind h.2)
+
+theorem prod_map_le_prod_map₀ {ι : Type*} {s : List ι} (f : ι → R) (g : ι → R)
+    (h0 : ∀ i ∈ s, 0 ≤ f i) (h : ∀ i ∈ s, f i ≤ g i) :
+    (map f s).prod ≤ (map g s).prod := by
+  induction s with
+  | nil => simp
+  | cons a s hind =>
+    simp only [map_cons, prod_cons]
+    have := posMulMono_iff_mulPosMono.1 ‹PosMulMono R›
+    apply mul_le_mul
+    · apply h
+      simp
+    · apply hind
+      · intro i hi
+        apply h0
+        simp [hi]
+      · intro i hi
+        apply h
+        simp [hi]
+    apply prod_nonneg
+    · simp only [mem_map, forall_exists_index, and_imp, forall_apply_eq_imp_iff₂]
+      intro a ha
+      apply h0
+      simp [ha]
+    apply (h0 _ _).trans (h _ _) <;> simp
+
+omit [PosMulMono R]
+variable [PosMulStrictMono R] [NeZero (1 : R)]
+
+lemma prod_pos {s : List R} (h : ∀ a ∈ s, 0 < a) : 0 < s.prod := by
+  induction s with
+  | nil => simp
+  | cons a s hind =>
+    simp only [prod_cons]
+    simp only [mem_cons, forall_eq_or_imp] at h
+    exact mul_pos h.1 (hind h.2)
+
+theorem prod_map_lt_prod_map {ι : Type*} {s : List ι} (hs : s ≠ [])
+    (f : ι → R) (g : ι → R) (h0 : ∀ i ∈ s, 0 < f i) (h : ∀ i ∈ s, f i < g i) :
+    (map f s).prod < (map g s).prod := by
+  match s with
+  | [] => contradiction
+  | a :: s =>
+    simp only [map_cons, prod_cons]
+    have := posMulStrictMono_iff_mulPosStrictMono.1 ‹PosMulStrictMono R›
+    apply mul_lt_mul
+    · apply h
+      simp
+    · apply prod_map_le_prod_map₀
+      · intro i hi
+        apply le_of_lt
+        apply h0
+        simp [hi]
+      · intro i hi
+        apply le_of_lt
+        apply h
+        simp [hi]
+    apply prod_pos
+    · simp only [mem_map, forall_exists_index, and_imp, forall_apply_eq_imp_iff₂]
+      intro a ha
+      apply h0
+      simp [ha]
+    apply le_of_lt ((h0 _ _).trans (h _ _)) <;> simp
+
+end List

--- a/Mathlib/Algebra/Order/BigOperators/GroupWithZero/List.lean
+++ b/Mathlib/Algebra/Order/BigOperators/GroupWithZero/List.lean
@@ -1,7 +1,7 @@
 /-
-Copyright (c) 2024 Daniel Weber. All rights reserved.
+Copyright (c) 2021 Stuart Presnell. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Daniel Weber
+Authors: Stuart Presnell, Daniel Weber
 -/
 import Mathlib.Algebra.BigOperators.Group.List
 import Mathlib.Algebra.Order.GroupWithZero.Unbundled

--- a/Mathlib/Algebra/Order/BigOperators/GroupWithZero/Multiset.lean
+++ b/Mathlib/Algebra/Order/BigOperators/GroupWithZero/Multiset.lean
@@ -1,0 +1,51 @@
+/-
+Copyright (c) 2024 Daniel Weber. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Daniel Weber
+-/
+import Mathlib.Algebra.Order.BigOperators.GroupWithZero.List
+import Mathlib.Algebra.BigOperators.Group.Multiset
+
+/-!
+# Big operators on a multiset in ordered groups with zeros
+
+This file contains the results concerning the interaction of multiset big operators with ordered
+groups with zeros.
+-/
+
+namespace Multiset
+variable {R : Type*} [CommMonoidWithZero R] [PartialOrder R] [ZeroLEOneClass R] [PosMulMono R]
+
+lemma prod_nonneg {s : Multiset R} (h : ∀ a ∈ s, 0 ≤ a) : 0 ≤ s.prod := by
+  cases s using Quotient.ind
+  simp only [quot_mk_to_coe, mem_coe, prod_coe] at *
+  apply List.prod_nonneg h
+
+lemma one_le_prod {s : Multiset R} (h : ∀ a ∈ s, 1 ≤ a) : 1 ≤ s.prod := by
+  cases s using Quotient.ind
+  simp only [quot_mk_to_coe, mem_coe, prod_coe] at *
+  apply List.one_le_prod h
+
+theorem prod_map_le_prod_map₀ {ι : Type*} {s : Multiset ι} (f : ι → R) (g : ι → R)
+    (h0 : ∀ i ∈ s, 0 ≤ f i) (h : ∀ i ∈ s, f i ≤ g i) :
+    (map f s).prod ≤ (map g s).prod := by
+  cases s using Quotient.ind
+  simp only [quot_mk_to_coe, mem_coe, map_coe, prod_coe] at *
+  apply List.prod_map_le_prod_map₀ f g h0 h
+
+omit [PosMulMono R]
+variable [PosMulStrictMono R] [NeZero (1 : R)]
+
+lemma prod_pos {s : Multiset R} (h : ∀ a ∈ s, 0 < a) : 0 < s.prod := by
+  cases s using Quotient.ind
+  simp only [quot_mk_to_coe, mem_coe, map_coe, prod_coe] at *
+  apply List.prod_pos h
+
+theorem prod_map_lt_prod_map {ι : Type*} {s : Multiset ι} (hs : s ≠ 0)
+    (f : ι → R) (g : ι → R) (h0 : ∀ i ∈ s, 0 < f i) (h : ∀ i ∈ s, f i < g i) :
+    (map f s).prod < (map g s).prod := by
+  cases s using Quotient.ind
+  simp only [quot_mk_to_coe, mem_coe, map_coe, prod_coe, ne_eq, coe_eq_zero] at *
+  apply List.prod_map_lt_prod_map hs f g h0 h
+
+end Multiset

--- a/Mathlib/Algebra/Order/BigOperators/GroupWithZero/Multiset.lean
+++ b/Mathlib/Algebra/Order/BigOperators/GroupWithZero/Multiset.lean
@@ -1,7 +1,7 @@
 /-
-Copyright (c) 2021 Stuart Presnell. All rights reserved.
+Copyright (c) 2021 Ruben Van de Velde. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Stuart Presnell, Daniel Weber
+Authors: Ruben Van de Velde, Daniel Weber
 -/
 import Mathlib.Algebra.Order.BigOperators.GroupWithZero.List
 import Mathlib.Algebra.BigOperators.Group.Multiset

--- a/Mathlib/Algebra/Order/BigOperators/GroupWithZero/Multiset.lean
+++ b/Mathlib/Algebra/Order/BigOperators/GroupWithZero/Multiset.lean
@@ -1,7 +1,7 @@
 /-
-Copyright (c) 2024 Daniel Weber. All rights reserved.
+Copyright (c) 2021 Stuart Presnell. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Daniel Weber
+Authors: Stuart Presnell, Daniel Weber
 -/
 import Mathlib.Algebra.Order.BigOperators.GroupWithZero.List
 import Mathlib.Algebra.BigOperators.Group.Multiset

--- a/Mathlib/Algebra/Order/BigOperators/Ring/List.lean
+++ b/Mathlib/Algebra/Order/BigOperators/Ring/List.lean
@@ -14,14 +14,10 @@ This file contains the results concerning the interaction of list big operators 
 
 variable {R : Type*}
 
-namespace List
-
 /-- A variant of `List.prod_pos` for `CanonicallyOrderedCommSemiring`. -/
-@[simp] lemma _root_.CanonicallyOrderedCommSemiring.list_prod_pos
+@[simp] lemma CanonicallyOrderedCommSemiring.list_prod_pos
     {α : Type*} [CanonicallyOrderedCommSemiring α] [Nontrivial α] :
     ∀ {l : List α}, 0 < l.prod ↔ (∀ x ∈ l, (0 : α) < x)
   | [] => by simp
-  | (x :: xs) => by simp_rw [prod_cons, forall_mem_cons, CanonicallyOrderedCommSemiring.mul_pos,
-    list_prod_pos]
-
-end List
+  | (x :: xs) => by simp_rw [List.prod_cons, List.forall_mem_cons,
+      CanonicallyOrderedCommSemiring.mul_pos, list_prod_pos]

--- a/Mathlib/Algebra/Order/BigOperators/Ring/List.lean
+++ b/Mathlib/Algebra/Order/BigOperators/Ring/List.lean
@@ -16,15 +16,6 @@ variable {R : Type*}
 
 namespace List
 
-/-- The product of a list of positive natural numbers is positive,
-and likewise for any nontrivial ordered semiring. -/
-lemma prod_pos [StrictOrderedSemiring R] (l : List R) (h : ∀ a ∈ l, (0 : R) < a) :
-    0 < l.prod := by
-  induction' l with a l ih
-  · simp
-  · rw [prod_cons]
-    exact mul_pos (h _ <| mem_cons_self _ _) (ih fun a ha => h a <| mem_cons_of_mem _ ha)
-
 /-- A variant of `List.prod_pos` for `CanonicallyOrderedCommSemiring`. -/
 @[simp] lemma _root_.CanonicallyOrderedCommSemiring.list_prod_pos
     {α : Type*} [CanonicallyOrderedCommSemiring α] [Nontrivial α] :

--- a/Mathlib/Algebra/Order/BigOperators/Ring/Multiset.lean
+++ b/Mathlib/Algebra/Order/BigOperators/Ring/Multiset.lean
@@ -16,17 +16,84 @@ rings.
 namespace Multiset
 variable {R : Type*}
 
-section OrderedCommSemiring
-variable [OrderedCommSemiring R] {s : Multiset R}
+lemma prod_nonneg {R : Type*} [CommMonoidWithZero R] [PartialOrder R] [ZeroLEOneClass R]
+    [PosMulMono R] {s : Multiset R} (h : ∀ a ∈ s, 0 ≤ a) : 0 ≤ s.prod := by
+  revert h
+  refine s.induction_on ?_ fun a s hs ih ↦ ?_
+  · simp
+  · rw [Multiset.prod_cons]
+    exact mul_nonneg (ih _ <| mem_cons_self _ _) (hs fun a ha ↦ ih _ <| mem_cons_of_mem ha)
 
-lemma prod_nonneg (h : ∀ a ∈ s, 0 ≤ a) : 0 ≤ s.prod := by
+lemma one_le_prod {R : Type*} [CommMonoidWithZero R] [PartialOrder R] [ZeroLEOneClass R]
+    [PosMulMono R] {s : Multiset R} (h : ∀ a ∈ s, 1 ≤ a) : 1 ≤ s.prod := by
   revert h
   refine s.induction_on ?_ fun a s hs ih ↦ ?_
   · simp
   · rw [prod_cons]
-    exact mul_nonneg (ih _ <| mem_cons_self _ _) (hs fun a ha ↦ ih _ <| mem_cons_of_mem ha)
+    exact one_le_mul_of_one_le_of_one_le (ih _ <| mem_cons_self _ _)
+        (hs fun a ha ↦ ih _ <| mem_cons_of_mem ha)
 
-end OrderedCommSemiring
+lemma prod_pos {R : Type*} [CommMonoidWithZero R] [PartialOrder R] [ZeroLEOneClass R]
+    [NeZero (1 : R)] [PosMulStrictMono R] {s : Multiset R} (h : ∀ a ∈ s, 0 < a) : 0 < s.prod := by
+  revert h
+  refine s.induction_on ?_ fun a s hs ih ↦ ?_
+  · simp
+  · rw [prod_cons]
+    exact mul_pos (ih _ <| mem_cons_self _ _) (hs fun a ha ↦ ih _ <| mem_cons_of_mem ha)
+
+theorem prod_map_le_prod_map₀ {ι α : Type*} [CommMonoidWithZero α] [PartialOrder α]
+    [ZeroLEOneClass α] [PosMulMono α] {s : Multiset ι} (f : ι → α) (g : ι → α)
+    (h0 : ∀ i ∈ s, 0 ≤ f i) (h : ∀ i ∈ s, f i ≤ g i) :
+    (map f s).prod ≤ (map g s).prod := by
+  induction s using Multiset.induction with
+  | empty => simp
+  | cons a s hind =>
+    simp only [map_cons, prod_cons]
+    have := posMulMono_iff_mulPosMono.1 ‹PosMulMono α›
+    apply mul_le_mul
+    · apply h
+      simp
+    · apply hind
+      · intro i hi
+        apply h0
+        simp [hi]
+      · intro i hi
+        apply h
+        simp [hi]
+    apply prod_nonneg
+    · simp only [mem_map, forall_exists_index, and_imp, forall_apply_eq_imp_iff₂]
+      intro a ha
+      apply h0
+      simp [ha]
+    apply (h0 _ _).trans (h _ _) <;> simp
+
+theorem prod_map_lt_prod_map {ι α : Type*} [CommMonoidWithZero α] [PartialOrder α]
+    [ZeroLEOneClass α] [MulPosStrictMono α] [NeZero (1 : α)] {s : Multiset ι} (hs : s ≠ 0)
+    (f : ι → α) (g : ι → α) (h0 : ∀ i ∈ s, 0 < f i) (h : ∀ i ∈ s, f i < g i) :
+    (map f s).prod < (map g s).prod := by
+  induction s using Multiset.induction with
+  | empty => contradiction
+  | cons a s =>
+    simp only [map_cons, prod_cons]
+    have := posMulStrictMono_iff_mulPosStrictMono.2 ‹MulPosStrictMono α›
+    apply mul_lt_mul
+    · apply h
+      simp
+    · apply prod_map_le_prod_map₀
+      · intro i hi
+        apply le_of_lt
+        apply h0
+        simp [hi]
+      · intro i hi
+        apply le_of_lt
+        apply h
+        simp [hi]
+    apply prod_pos
+    · simp only [mem_map, forall_exists_index, and_imp, forall_apply_eq_imp_iff₂]
+      intro a ha
+      apply h0
+      simp [ha]
+    apply le_of_lt ((h0 _ _).trans (h _ _)) <;> simp
 
 @[simp]
 lemma _root_.CanonicallyOrderedCommSemiring.multiset_prod_pos [CanonicallyOrderedCommSemiring R]

--- a/Mathlib/Algebra/Order/BigOperators/Ring/Multiset.lean
+++ b/Mathlib/Algebra/Order/BigOperators/Ring/Multiset.lean
@@ -20,5 +20,3 @@ lemma CanonicallyOrderedCommSemiring.multiset_prod_pos {R : Type*}
   rcases m with ⟨l⟩
   rw [Multiset.quot_mk_to_coe'', Multiset.prod_coe]
   exact CanonicallyOrderedCommSemiring.list_prod_pos
-
-end Multiset

--- a/Mathlib/Algebra/Order/BigOperators/Ring/Multiset.lean
+++ b/Mathlib/Algebra/Order/BigOperators/Ring/Multiset.lean
@@ -41,15 +41,15 @@ lemma prod_pos {R : Type*} [CommMonoidWithZero R] [PartialOrder R] [ZeroLEOneCla
   · rw [prod_cons]
     exact mul_pos (ih _ <| mem_cons_self _ _) (hs fun a ha ↦ ih _ <| mem_cons_of_mem ha)
 
-theorem prod_map_le_prod_map₀ {ι α : Type*} [CommMonoidWithZero α] [PartialOrder α]
-    [ZeroLEOneClass α] [PosMulMono α] {s : Multiset ι} (f : ι → α) (g : ι → α)
+theorem prod_map_le_prod_map₀ {ι R : Type*} [CommMonoidWithZero R] [PartialOrder R]
+    [ZeroLEOneClass R] [PosMulMono R] {s : Multiset ι} (f : ι → R) (g : ι → R)
     (h0 : ∀ i ∈ s, 0 ≤ f i) (h : ∀ i ∈ s, f i ≤ g i) :
     (map f s).prod ≤ (map g s).prod := by
   induction s using Multiset.induction with
   | empty => simp
   | cons a s hind =>
     simp only [map_cons, prod_cons]
-    have := posMulMono_iff_mulPosMono.1 ‹PosMulMono α›
+    have := posMulMono_iff_mulPosMono.1 ‹PosMulMono R›
     apply mul_le_mul
     · apply h
       simp
@@ -67,15 +67,15 @@ theorem prod_map_le_prod_map₀ {ι α : Type*} [CommMonoidWithZero α] [Partial
       simp [ha]
     apply (h0 _ _).trans (h _ _) <;> simp
 
-theorem prod_map_lt_prod_map {ι α : Type*} [CommMonoidWithZero α] [PartialOrder α]
-    [ZeroLEOneClass α] [MulPosStrictMono α] [NeZero (1 : α)] {s : Multiset ι} (hs : s ≠ 0)
-    (f : ι → α) (g : ι → α) (h0 : ∀ i ∈ s, 0 < f i) (h : ∀ i ∈ s, f i < g i) :
+theorem prod_map_lt_prod_map {ι R : Type*} [CommMonoidWithZero R] [PartialOrder R]
+    [ZeroLEOneClass R] [MulPosStrictMono R] [NeZero (1 : R)] {s : Multiset ι} (hs : s ≠ 0)
+    (f : ι → R) (g : ι → R) (h0 : ∀ i ∈ s, 0 < f i) (h : ∀ i ∈ s, f i < g i) :
     (map f s).prod < (map g s).prod := by
   induction s using Multiset.induction with
   | empty => contradiction
   | cons a s =>
     simp only [map_cons, prod_cons]
-    have := posMulStrictMono_iff_mulPosStrictMono.2 ‹MulPosStrictMono α›
+    have := posMulStrictMono_iff_mulPosStrictMono.2 ‹MulPosStrictMono R›
     apply mul_lt_mul
     · apply h
       simp

--- a/Mathlib/Algebra/Order/BigOperators/Ring/Multiset.lean
+++ b/Mathlib/Algebra/Order/BigOperators/Ring/Multiset.lean
@@ -13,91 +13,10 @@ This file contains the results concerning the interaction of multiset big operat
 rings.
 -/
 
-namespace Multiset
-variable {R : Type*}
-
-lemma prod_nonneg {R : Type*} [CommMonoidWithZero R] [PartialOrder R] [ZeroLEOneClass R]
-    [PosMulMono R] {s : Multiset R} (h : ∀ a ∈ s, 0 ≤ a) : 0 ≤ s.prod := by
-  revert h
-  refine s.induction_on ?_ fun a s hs ih ↦ ?_
-  · simp
-  · rw [Multiset.prod_cons]
-    exact mul_nonneg (ih _ <| mem_cons_self _ _) (hs fun a ha ↦ ih _ <| mem_cons_of_mem ha)
-
-lemma one_le_prod {R : Type*} [CommMonoidWithZero R] [PartialOrder R] [ZeroLEOneClass R]
-    [PosMulMono R] {s : Multiset R} (h : ∀ a ∈ s, 1 ≤ a) : 1 ≤ s.prod := by
-  revert h
-  refine s.induction_on ?_ fun a s hs ih ↦ ?_
-  · simp
-  · rw [prod_cons]
-    exact one_le_mul_of_one_le_of_one_le (ih _ <| mem_cons_self _ _)
-        (hs fun a ha ↦ ih _ <| mem_cons_of_mem ha)
-
-lemma prod_pos {R : Type*} [CommMonoidWithZero R] [PartialOrder R] [ZeroLEOneClass R]
-    [NeZero (1 : R)] [PosMulStrictMono R] {s : Multiset R} (h : ∀ a ∈ s, 0 < a) : 0 < s.prod := by
-  revert h
-  refine s.induction_on ?_ fun a s hs ih ↦ ?_
-  · simp
-  · rw [prod_cons]
-    exact mul_pos (ih _ <| mem_cons_self _ _) (hs fun a ha ↦ ih _ <| mem_cons_of_mem ha)
-
-theorem prod_map_le_prod_map₀ {ι R : Type*} [CommMonoidWithZero R] [PartialOrder R]
-    [ZeroLEOneClass R] [PosMulMono R] {s : Multiset ι} (f : ι → R) (g : ι → R)
-    (h0 : ∀ i ∈ s, 0 ≤ f i) (h : ∀ i ∈ s, f i ≤ g i) :
-    (map f s).prod ≤ (map g s).prod := by
-  induction s using Multiset.induction with
-  | empty => simp
-  | cons a s hind =>
-    simp only [map_cons, prod_cons]
-    have := posMulMono_iff_mulPosMono.1 ‹PosMulMono R›
-    apply mul_le_mul
-    · apply h
-      simp
-    · apply hind
-      · intro i hi
-        apply h0
-        simp [hi]
-      · intro i hi
-        apply h
-        simp [hi]
-    apply prod_nonneg
-    · simp only [mem_map, forall_exists_index, and_imp, forall_apply_eq_imp_iff₂]
-      intro a ha
-      apply h0
-      simp [ha]
-    apply (h0 _ _).trans (h _ _) <;> simp
-
-theorem prod_map_lt_prod_map {ι R : Type*} [CommMonoidWithZero R] [PartialOrder R]
-    [ZeroLEOneClass R] [MulPosStrictMono R] [NeZero (1 : R)] {s : Multiset ι} (hs : s ≠ 0)
-    (f : ι → R) (g : ι → R) (h0 : ∀ i ∈ s, 0 < f i) (h : ∀ i ∈ s, f i < g i) :
-    (map f s).prod < (map g s).prod := by
-  induction s using Multiset.induction with
-  | empty => contradiction
-  | cons a s =>
-    simp only [map_cons, prod_cons]
-    have := posMulStrictMono_iff_mulPosStrictMono.2 ‹MulPosStrictMono R›
-    apply mul_lt_mul
-    · apply h
-      simp
-    · apply prod_map_le_prod_map₀
-      · intro i hi
-        apply le_of_lt
-        apply h0
-        simp [hi]
-      · intro i hi
-        apply le_of_lt
-        apply h
-        simp [hi]
-    apply prod_pos
-    · simp only [mem_map, forall_exists_index, and_imp, forall_apply_eq_imp_iff₂]
-      intro a ha
-      apply h0
-      simp [ha]
-    apply le_of_lt ((h0 _ _).trans (h _ _)) <;> simp
-
 @[simp]
-lemma _root_.CanonicallyOrderedCommSemiring.multiset_prod_pos [CanonicallyOrderedCommSemiring R]
-    [Nontrivial R] {m : Multiset R} : 0 < m.prod ↔ ∀ x ∈ m, 0 < x := by
+lemma CanonicallyOrderedCommSemiring.multiset_prod_pos {R : Type*}
+    [CanonicallyOrderedCommSemiring R] [Nontrivial R] {m : Multiset R} :
+    0 < m.prod ↔ ∀ x ∈ m, 0 < x := by
   rcases m with ⟨l⟩
   rw [Multiset.quot_mk_to_coe'', Multiset.prod_coe]
   exact CanonicallyOrderedCommSemiring.list_prod_pos


### PR DESCRIPTION
Also relax typeclass assumptions on `prod_nonneg`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
