### PR TITLE
[Merged by Bors] - docs(Archive/IMO/2011Q5): replace non-Lean notation in comment

### DIFF
--- a/Archive/Imo/Imo2011Q5.lean
+++ b/Archive/Imo/Imo2011Q5.lean
@@ -12,9 +12,9 @@ import Mathlib.Algebra.Ring.Int
 
 Let `f` be a function from the set of integers to the set
 of positive integers.  Suppose that, for any two integers
-`m` and `n`, the difference `f(m) - f(n)` is divisible by
-`f(m - n)`.  Prove that, for all integers `m` and `n` with
-`f(m) ≤ f(n)`, the number `f(n)` is divisible by `f(m)`.
+`m` and `n`, the difference `f m - f n` is divisible by
+`f (m - n)`.  Prove that, for all integers `m` and `n` with
+`f m ≤ f n`, the number `f n` is divisible by `f m`.
 -/
 
 


### PR DESCRIPTION
Use `f n` instead of `f(n)` for function application.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
