### PR TITLE
[Merged by Bors] - feat(FieldTheory/{SeparableDegree|PurelyInseparable}): generalize some results on purely inseparable extension to non-commutative case

### DIFF
--- a/Mathlib/FieldTheory/PurelyInseparable.lean
+++ b/Mathlib/FieldTheory/PurelyInseparable.lean
@@ -133,13 +133,16 @@ noncomputable section
 
 universe u v w
 
-variable (F : Type u) (E : Type v) [Field F] [Field E] [Algebra F E]
-variable (K : Type w) [Field K] [Algebra F K]
-
 section IsPurelyInseparable
 
+variable (F : Type u) (E : Type v) [CommRing F] [Ring E] [Algebra F E]
+variable (K : Type w) [Ring K] [Algebra F K]
+
 /-- Typeclass for purely inseparable field extensions: an algebraic extension `E / F` is purely
-inseparable if and only if the minimal polynomial of every element of `E ∖ F` is not separable. -/
+inseparable if and only if the minimal polynomial of every element of `E ∖ F` is not separable.
+
+We define this for general (commutative) rings and only assume `F` and `E` are fields
+if this is needed for a proof. -/
 class IsPurelyInseparable : Prop where
   isIntegral : Algebra.IsIntegral F E
   inseparable' (x : E) : IsSeparable F x → x ∈ (algebraMap F E).range
@@ -150,7 +153,7 @@ variable {E} in
 theorem IsPurelyInseparable.isIntegral' [IsPurelyInseparable F E] (x : E) : IsIntegral F x :=
   Algebra.IsIntegral.isIntegral _
 
-theorem IsPurelyInseparable.isAlgebraic [IsPurelyInseparable F E] :
+theorem IsPurelyInseparable.isAlgebraic [Nontrivial F] [IsPurelyInseparable F E] :
     Algebra.IsAlgebraic F E := inferInstance
 
 variable {E}
@@ -179,7 +182,9 @@ theorem AlgEquiv.isPurelyInseparable_iff (e : K ≃ₐ[F] E) :
 
 /-- If `E / F` is an algebraic extension, `F` is separably closed,
 then `E / F` is purely inseparable. -/
-theorem Algebra.IsAlgebraic.isPurelyInseparable_of_isSepClosed [Algebra.IsAlgebraic F E]
+theorem Algebra.IsAlgebraic.isPurelyInseparable_of_isSepClosed
+    {F : Type u} {E : Type v} [Field F] [Ring E] [IsDomain E] [Algebra F E]
+    [Algebra.IsAlgebraic F E]
     [IsSepClosed F] : IsPurelyInseparable F E :=
   ⟨inferInstance, fun x h ↦ minpoly.mem_range_of_degree_eq_one F x <|
     IsSepClosed.degree_eq_one_of_irreducible F (minpoly.irreducible
@@ -194,27 +199,37 @@ theorem IsPurelyInseparable.surjective_algebraMap_of_isSeparable
 
 /-- If `E / F` is both purely inseparable and separable, then `algebraMap F E` is bijective. -/
 theorem IsPurelyInseparable.bijective_algebraMap_of_isSeparable
+    [Nontrivial E] [NoZeroSMulDivisors F E]
     [IsPurelyInseparable F E] [Algebra.IsSeparable F E] : Function.Bijective (algebraMap F E) :=
-  ⟨(algebraMap F E).injective, surjective_algebraMap_of_isSeparable F E⟩
+  ⟨NoZeroSMulDivisors.algebraMap_injective F E, surjective_algebraMap_of_isSeparable F E⟩
 
 variable {F E} in
+/-- If a subalgebra of `E / F` is both purely inseparable and separable, then it is equal
+to `F`. -/
+theorem Subalgebra.eq_bot_of_isPurelyInseparable_of_isSeparable (L : Subalgebra F E)
+    [IsPurelyInseparable F L] [Algebra.IsSeparable F L] : L = ⊥ := bot_unique fun x hx ↦ by
+  obtain ⟨y, hy⟩ := IsPurelyInseparable.surjective_algebraMap_of_isSeparable F L ⟨x, hx⟩
+  exact ⟨y, congr_arg (Subalgebra.val _) hy⟩
+
 /-- If an intermediate field of `E / F` is both purely inseparable and separable, then it is equal
 to `F`. -/
-theorem IntermediateField.eq_bot_of_isPurelyInseparable_of_isSeparable (L : IntermediateField F E)
+theorem IntermediateField.eq_bot_of_isPurelyInseparable_of_isSeparable
+    {F : Type u} {E : Type v} [Field F] [Field E] [Algebra F E] (L : IntermediateField F E)
     [IsPurelyInseparable F L] [Algebra.IsSeparable F L] : L = ⊥ := bot_unique fun x hx ↦ by
   obtain ⟨y, hy⟩ := IsPurelyInseparable.surjective_algebraMap_of_isSeparable F L ⟨x, hx⟩
   exact ⟨y, congr_arg (algebraMap L E) hy⟩
 
 /-- If `E / F` is purely inseparable, then the separable closure of `F` in `E` is
 equal to `F`. -/
-theorem separableClosure.eq_bot_of_isPurelyInseparable [IsPurelyInseparable F E] :
+theorem separableClosure.eq_bot_of_isPurelyInseparable
+    (F : Type u) (E : Type v) [Field F] [Field E] [Algebra F E] [IsPurelyInseparable F E] :
     separableClosure F E = ⊥ :=
   bot_unique fun x h ↦ IsPurelyInseparable.inseparable F x (mem_separableClosure_iff.1 h)
 
-variable {F E} in
 /-- If `E / F` is an algebraic extension, then the separable closure of `F` in `E` is
 equal to `F` if and only if `E / F` is purely inseparable. -/
-theorem separableClosure.eq_bot_iff [Algebra.IsAlgebraic F E] :
+theorem separableClosure.eq_bot_iff
+    {F : Type u} {E : Type v} [Field F] [Field E] [Algebra F E] [Algebra.IsAlgebraic F E] :
     separableClosure F E = ⊥ ↔ IsPurelyInseparable F E :=
   ⟨fun h ↦ isPurelyInseparable_iff.2 fun x ↦ ⟨Algebra.IsIntegral.isIntegral x, fun hs ↦ by
     simpa only [h] using mem_separableClosure_iff.2 hs⟩, fun _ ↦ eq_bot_of_isPurelyInseparable F E⟩
@@ -222,12 +237,15 @@ theorem separableClosure.eq_bot_iff [Algebra.IsAlgebraic F E] :
 instance isPurelyInseparable_self : IsPurelyInseparable F F :=
   ⟨inferInstance, fun x _ ↦ ⟨x, rfl⟩⟩
 
-variable {E}
+section
+
+variable (F : Type u) {E : Type v} [Field F] [Ring E] [IsDomain E] [Algebra F E]
+variable (q : ℕ) [ExpChar F q] (x : E)
 
 /-- A field extension `E / F` of exponential characteristic `q` is purely inseparable
 if and only if for every element `x` of `E`, there exists a natural number `n` such that
 `x ^ (q ^ n)` is contained in `F`. -/
-theorem isPurelyInseparable_iff_pow_mem (q : ℕ) [ExpChar F q] :
+theorem isPurelyInseparable_iff_pow_mem :
     IsPurelyInseparable F E ↔ ∀ x : E, ∃ n : ℕ, x ^ q ^ n ∈ (algebraMap F E).range := by
   rw [isPurelyInseparable_iff]
   refine ⟨fun h x ↦ ?_, fun h x ↦ ?_⟩
@@ -238,15 +256,18 @@ theorem isPurelyInseparable_iff_pow_mem (q : ℕ) [ExpChar F q] :
   have halg : IsIntegral F x := by_contra fun h' ↦ by
     simp only [minpoly.eq_zero h', natSepDegree_zero, zero_ne_one] at hdeg
   refine ⟨halg, fun hsep ↦ ?_⟩
-  rw [hsep.natSepDegree_eq_natDegree, ← adjoin.finrank halg,
-    IntermediateField.finrank_eq_one_iff] at hdeg
-  simpa only [hdeg] using mem_adjoin_simple_self F x
+  rwa [hsep.natSepDegree_eq_natDegree, minpoly.natDegree_eq_one_iff] at hdeg
 
-theorem IsPurelyInseparable.pow_mem (q : ℕ) [ExpChar F q] [IsPurelyInseparable F E] (x : E) :
+theorem IsPurelyInseparable.pow_mem [IsPurelyInseparable F E] :
     ∃ n : ℕ, x ^ q ^ n ∈ (algebraMap F E).range :=
   (isPurelyInseparable_iff_pow_mem F q).1 ‹_› x
 
+end
+
 end IsPurelyInseparable
+
+variable (F : Type u) (E : Type v) [Field F] [Field E] [Algebra F E]
+variable (K : Type w) [Field K] [Algebra F K]
 
 section perfectClosure
 

--- a/Mathlib/FieldTheory/SeparableDegree.lean
+++ b/Mathlib/FieldTheory/SeparableDegree.lean
@@ -589,7 +589,7 @@ end Polynomial
 
 namespace minpoly
 
-variable {F E}
+variable {F : Type u} {E : Type v} [Field F] [Ring E] [IsDomain E] [Algebra F E]
 variable (q : ℕ) [hF : ExpChar F q] {x : E}
 
 /-- The minimal polynomial of an element of `E / F` of exponential characteristic `q` has
@@ -632,17 +632,18 @@ separable degree one if and only if the minimal polynomial is of the form
 theorem natSepDegree_eq_one_iff_eq_X_sub_C_pow : (minpoly F x).natSepDegree = 1 ↔
     ∃ n : ℕ, (minpoly F x).map (algebraMap F E) = (X - C x) ^ q ^ n := by
   haveI := expChar_of_injective_algebraMap (algebraMap F E).injective q
-  haveI := expChar_of_injective_algebraMap (NoZeroSMulDivisors.algebraMap_injective E E[X]) q
+  haveI := expChar_of_injective_ringHom (C_injective (R := E)) q
   refine ⟨fun h ↦ ?_, fun ⟨n, h⟩ ↦ (natSepDegree_eq_one_iff_pow_mem q).2 ?_⟩
   · obtain ⟨n, y, h⟩ := (natSepDegree_eq_one_iff_eq_X_pow_sub_C q).1 h
     have hx := congr_arg (Polynomial.aeval x) h.symm
     rw [minpoly.aeval, map_sub, map_pow, aeval_X, aeval_C, sub_eq_zero, eq_comm] at hx
     use n
-    rw [h, Polynomial.map_sub, Polynomial.map_pow, map_X, map_C, hx, map_pow, ← sub_pow_expChar_pow]
+    rw [h, Polynomial.map_sub, Polynomial.map_pow, map_X, map_C, hx, map_pow,
+      ← sub_pow_expChar_pow_of_commute E[X] X (C x) (commute_X _)]
   apply_fun constantCoeff at h
   simp_rw [map_pow, map_sub, constantCoeff_apply, coeff_map, coeff_X_zero, coeff_C_zero] at h
   rw [zero_sub, neg_pow, ExpChar.neg_one_pow_expChar_pow] at h
-  exact ⟨n, -(minpoly F x).coeff 0, by rw [map_neg, h]; ring1⟩
+  exact ⟨n, -(minpoly F x).coeff 0, by rw [map_neg, h, neg_mul, one_mul, neg_neg]⟩
 
 end minpoly
 


### PR DESCRIPTION
- generalize the result on separable degree of minpoly to non-commutative case
- generalize the definition and basic property of purely inseparable extension to non-commutative case

This PR is potentially usable in #16525.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)

discussion: https://leanprover.zulipchat.com/#narrow/stream/144837-PR-reviews/topic/.2316585.20purely.20insep.2E.20ext.2E.20non-commutative.20case/near/469180666