### PR TITLE
[Merged by Bors] - feat: `match_scalars` and `module` tactics

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -4288,6 +4288,7 @@ import Mathlib.Tactic.Measurability.Init
 import Mathlib.Tactic.MinImports
 import Mathlib.Tactic.MkIffOfInductiveProp
 import Mathlib.Tactic.ModCases
+import Mathlib.Tactic.Module
 import Mathlib.Tactic.Monotonicity
 import Mathlib.Tactic.Monotonicity.Attr
 import Mathlib.Tactic.Monotonicity.Basic

--- a/Mathlib/Tactic.lean
+++ b/Mathlib/Tactic.lean
@@ -150,6 +150,7 @@ import Mathlib.Tactic.Measurability.Init
 import Mathlib.Tactic.MinImports
 import Mathlib.Tactic.MkIffOfInductiveProp
 import Mathlib.Tactic.ModCases
+import Mathlib.Tactic.Module
 import Mathlib.Tactic.Monotonicity
 import Mathlib.Tactic.Monotonicity.Attr
 import Mathlib.Tactic.Monotonicity.Basic

--- a/Mathlib/Tactic/Module.lean
+++ b/Mathlib/Tactic/Module.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Heather Macbeth
 -/
 import Mathlib.Algebra.Algebra.Tower
-import Mathlib.GroupTheory.GroupAction.BigOperators
+import Mathlib.Algebra.BigOperators.GroupWithZero.Action
 import Mathlib.Tactic.Ring
 import Mathlib.Util.AtomM
 

--- a/Mathlib/Tactic/Module.lean
+++ b/Mathlib/Tactic/Module.lean
@@ -1,0 +1,641 @@
+/-
+Copyright (c) 2024 Heather Macbeth. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Heather Macbeth
+-/
+import Mathlib.Algebra.Algebra.Tower
+import Mathlib.GroupTheory.GroupAction.BigOperators
+import Mathlib.Tactic.Ring
+import Mathlib.Util.AtomM
+
+/-! # A tactic for normalization over modules
+
+This file provides the two tactics `match_scalars` and `module`.  Given a goal which is an equality
+in a type `M` (with `M` an `AddCommMonoid`), the `match_scalars` tactic parses the LHS and RHS of
+the goal as linear combinations of `M`-atoms over some semiring `R`, and reduces the goal to
+the respective equalities of the `R`-coefficients of each atom.  The `module` tactic does this and
+then runs the `ring` tactic on each of these coefficient-wise equalities, failing if this does not
+resolve them.
+
+The scalar type `R` is not pre-determined: instead it starts as `ℕ` (when each atom is initially
+given a scalar `(1:ℕ)`) and gets bumped up into bigger semirings when such semirings are
+encountered.  However, to permit this, it is assumed that there is a "linear order" on all the
+semirings which appear in the expression: for any two semirings `R` and `S` which occur, we have
+either `Algebra R S` or `Algebra S R`).
+-/
+
+open Lean hiding Module
+open Meta Elab Qq Mathlib.Tactic List
+
+namespace Mathlib.Tactic.Module
+
+/-! ### Theory of lists of pairs (scalar, vector)
+
+This section contains the lemmas which are orchestrated by the `match_scalars` and `module` tactics
+to prove goals in modules.  The basic object which these lemmas concern is `NF R M`, a type synonym
+for a list of ordered pairs in `R × M`, where typically `M` is an `R`-module.
+-/
+
+/-- Basic theoretical object of the `match_scalars` and `module` tactics: a type synonym for a list
+of ordered pairs in `R × M`, where typically `M` is an `R`-module.  This is the form to which the
+tactics reduce module expressions.
+
+(It is not a full "normal form" because the scalars, i.e. `R` components, are not themselves
+ring-normalized.  But this partial normal form is more convenient for our purposes.)  -/
+def NF (R : Type*) (M : Type*) := List (R × M)
+
+namespace NF
+variable {S : Type*} {R : Type*} {M : Type*}
+
+/-- Augment a `Module.NF R M` object `l`, i.e. a list of pairs in `R × M`, by prepending another
+pair `p : R × M`. -/
+def cons (p : R × M) (l : NF R M) : NF R M := p :: l
+
+@[inherit_doc cons] infixl:100 " ::ᵣ " => cons
+
+/-- Evaluate a `Module.NF R M` object `l`, i.e. a list of pairs in `R × M`, to an element of `M`, by
+forming the "linear combination" it specifies: scalar-multiply each `R` term to the corresponding
+`M` term, then add them all up. -/
+def eval [Add M] [Zero M] [SMul R M] (l : NF R M) : M := (l.map (fun (⟨r, x⟩ : R × M) ↦ r • x)).sum
+
+@[simp] theorem eval_cons [AddMonoid M] [SMul R M] (p : R × M) (l : NF R M) :
+    (p ::ᵣ l).eval = p.1 • p.2 + l.eval := by
+  unfold eval cons
+  rw [List.map_cons]
+  rw [List.sum_cons]
+
+theorem atom_eq_eval [AddMonoid M] (x : M) : x = NF.eval [(1, x)] := by simp [eval]
+
+variable (M) in
+theorem zero_eq_eval [AddMonoid M] : (0:M) = NF.eval (R := ℕ) (M := M) [] := rfl
+
+theorem add_eq_eval₁ [AddMonoid M] [SMul R M] (a₁ : R × M) {a₂ : R × M} {l₁ l₂ l : NF R M}
+    (h : l₁.eval + (a₂ ::ᵣ l₂).eval = l.eval) :
+    (a₁ ::ᵣ l₁).eval + (a₂ ::ᵣ l₂).eval = (a₁ ::ᵣ l).eval := by
+  simp only [eval_cons, ← h, add_assoc]
+
+theorem add_eq_eval₂ [Semiring R] [AddCommMonoid M] [Module R M] (r₁ r₂ : R) (x : M)
+    {l₁ l₂ l : NF R M} (h : l₁.eval + l₂.eval = l.eval) :
+    ((r₁, x) ::ᵣ l₁).eval + ((r₂, x) ::ᵣ l₂).eval = ((r₁ + r₂, x) ::ᵣ l).eval := by
+  simp only [← h, eval_cons, add_smul, add_assoc]
+  congr! 1
+  simp only [← add_assoc]
+  congr! 1
+  rw [add_comm]
+
+theorem add_eq_eval₃ [Semiring R] [AddCommMonoid M] [Module R M] {a₁ : R × M} (a₂ : R × M)
+    {l₁ l₂ l : NF R M} (h : (a₁ ::ᵣ l₁).eval + l₂.eval = l.eval) :
+    (a₁ ::ᵣ l₁).eval + (a₂ ::ᵣ l₂).eval = (a₂ ::ᵣ l).eval := by
+  simp only [eval_cons, ← h]
+  nth_rw 4 [add_comm]
+  simp only [add_assoc]
+  congr! 2
+  rw [add_comm]
+
+theorem add_eq_eval {R₁ R₂ : Type*} [AddCommMonoid M] [Semiring R] [Module R M] [Semiring R₁]
+    [Module R₁ M] [Semiring R₂] [Module R₂ M] {l₁ l₂ l : NF R M} {l₁' : NF R₁ M} {l₂' : NF R₂ M}
+    {x₁ x₂ : M} (hx₁ : x₁ = l₁'.eval) (hx₂ : x₂ = l₂'.eval) (h₁ : l₁.eval = l₁'.eval)
+    (h₂ : l₂.eval = l₂'.eval) (h : l₁.eval + l₂.eval = l.eval) :
+    x₁ + x₂ = l.eval := by
+  rw [hx₁, hx₂, ← h₁, ← h₂, h]
+
+theorem sub_eq_eval₁ [SMul R M] [AddGroup M] (a₁ : R × M) {a₂ : R × M} {l₁ l₂ l : NF R M}
+    (h : l₁.eval - (a₂ ::ᵣ l₂).eval = l.eval) :
+    (a₁ ::ᵣ l₁).eval - (a₂ ::ᵣ l₂).eval = (a₁ ::ᵣ l).eval := by
+  simp only [eval_cons, ← h, sub_eq_add_neg, add_assoc]
+
+theorem sub_eq_eval₂ [Ring R] [AddCommGroup M] [Module R M] (r₁ r₂ : R) (x : M) {l₁ l₂ l : NF R M}
+    (h : l₁.eval - l₂.eval = l.eval) :
+    ((r₁, x) ::ᵣ l₁).eval - ((r₂, x) ::ᵣ l₂).eval = ((r₁ - r₂, x) ::ᵣ l).eval := by
+  simp only [← h, eval_cons, sub_smul, sub_eq_add_neg, neg_add, add_smul, neg_smul, add_assoc]
+  congr! 1
+  simp only [← add_assoc]
+  congr! 1
+  rw [add_comm]
+
+theorem sub_eq_eval₃ [Ring R] [AddCommGroup M] [Module R M] {a₁ : R × M} (a₂ : R × M)
+    {l₁ l₂ l : NF R M} (h : (a₁ ::ᵣ l₁).eval - l₂.eval = l.eval) :
+    (a₁ ::ᵣ l₁).eval - (a₂ ::ᵣ l₂).eval = ((-a₂.1, a₂.2) ::ᵣ l).eval := by
+  simp only [eval_cons, neg_smul, neg_add, sub_eq_add_neg, ← h, ← add_assoc]
+  congr! 1
+  rw [add_comm, add_assoc]
+
+theorem sub_eq_eval {R₁ R₂ S₁ S₂ : Type*} [AddCommGroup M] [Ring R] [Module R M] [Semiring R₁]
+    [Module R₁ M] [Semiring R₂] [Module R₂ M] [Semiring S₁] [Module S₁ M] [Semiring S₂]
+    [Module S₂ M] {l₁ l₂ l : NF R M} {l₁' : NF R₁ M} {l₂' : NF R₂ M} {l₁'' : NF S₁ M}
+    {l₂'' : NF S₂ M} {x₁ x₂ : M} (hx₁ : x₁ = l₁''.eval) (hx₂ : x₂ = l₂''.eval)
+    (h₁' : l₁'.eval = l₁''.eval) (h₂' : l₂'.eval = l₂''.eval) (h₁ : l₁.eval = l₁'.eval)
+    (h₂ : l₂.eval = l₂'.eval) (h : l₁.eval - l₂.eval = l.eval) :
+    x₁ - x₂ = l.eval := by
+  rw [hx₁, hx₂, ← h₁', ← h₂', ← h₁, ← h₂, h]
+
+instance [Neg R] : Neg (NF R M) where
+  neg l := l.map fun (a, x) ↦ (-a, x)
+
+theorem eval_neg [AddCommGroup M] [Ring R] [Module R M] (l : NF R M) : (-l).eval = - l.eval := by
+  simp only [NF.eval, List.map_map, List.sum_neg, NF.instNeg]
+  congr
+  ext p
+  simp
+
+theorem zero_sub_eq_eval [AddCommGroup M] [Ring R] [Module R M] (l : NF R M) :
+    0 - l.eval = (-l).eval := by
+  simp [eval_neg]
+
+theorem neg_eq_eval [AddCommGroup M] [Semiring S] [Module S M] [Ring R] [Module R M] {l : NF R M}
+    {l₀ : NF S M} (hl : l.eval = l₀.eval) {x : M} (h : x = l₀.eval) :
+    - x = (-l).eval := by
+  rw [h, ← hl, eval_neg]
+
+instance [Mul R] : SMul R (NF R M) where
+  smul r l := l.map fun (a, x) ↦ (r * a, x)
+
+@[simp] theorem smul_apply [Mul R] (r : R) (l : NF R M) : r • l = l.map fun (a, x) ↦ (r * a, x) :=
+  rfl
+
+theorem eval_smul [AddCommMonoid M] [Semiring R] [Module R M] {l : NF R M} {x : M} (h : x = l.eval)
+    (r : R) : (r • l).eval = r • x := by
+  unfold NF.eval at h ⊢
+  simp only [h, smul_sum, map_map, NF.smul_apply]
+  congr
+  ext p
+  simp [mul_smul]
+
+theorem smul_eq_eval {R₀ : Type*} [AddCommMonoid M] [Semiring R] [Module R M] [Semiring R₀]
+    [Module R₀ M] [Semiring S] [Module S M]  {l : NF R M} {l₀ : NF R₀ M} {s : S} {r : R}
+    {x : M} (hx : x = l₀.eval) (hl : l.eval = l₀.eval) (hs : r • x = s • x) :
+    s • x = (r • l).eval := by
+  rw [← hs, hx, ← hl, eval_smul]
+  rfl
+
+theorem eq_cons_cons [AddMonoid M] [SMul R M] {r₁ r₂ : R} (m : M) {l₁ l₂ : NF R M} (h1 : r₁ = r₂)
+    (h2 : l₁.eval = l₂.eval) :
+    ((r₁, m) ::ᵣ l₁).eval = ((r₂, m) ::ᵣ l₂).eval := by
+  simp only [NF.eval, NF.cons] at *
+  simp [h1, h2]
+
+theorem eq_cons_const [AddCommMonoid M] [Semiring R] [Module R M] {r : R} (m : M) {n : M}
+    {l : NF R M} (h1 : r = 0) (h2 : l.eval = n) :
+    ((r, m) ::ᵣ l).eval = n := by
+  simp only [NF.eval, NF.cons] at *
+  simp [h1, h2]
+
+theorem eq_const_cons [AddCommMonoid M] [Semiring R] [Module R M] {r : R} (m : M) {n : M}
+    {l : NF R M} (h1 : 0 = r) (h2 : n = l.eval) :
+    n = ((r, m) ::ᵣ l).eval := by
+  simp only [NF.eval, NF.cons] at *
+  simp [← h1, h2]
+
+theorem eq_of_eval_eq_eval {R₁ R₂ : Type*} [AddCommMonoid M] [Semiring R] [Module R M] [Semiring R₁]
+    [Module R₁ M] [Semiring R₂] [Module R₂ M]  {l₁ l₂ : NF R M} {l₁' : NF R₁ M} {l₂' : NF R₂ M}
+    {x₁ x₂ : M} (hx₁ : x₁ = l₁'.eval) (hx₂ : x₂ = l₂'.eval) (h₁ : l₁.eval = l₁'.eval)
+    (h₂ : l₂.eval = l₂'.eval) (h : l₁.eval = l₂.eval) :
+    x₁ = x₂ := by
+  rw [hx₁, hx₂, ← h₁, ← h₂, h]
+
+variable (R)
+
+/-- Operate on a `Module.NF S M` object `l`, i.e. a list of pairs in `S × M`, where `S` is some
+commutative semiring, by applying to each `S`-component the algebra-map from `S` into a specified
+`S`-algebra `R`. -/
+def algebraMap [CommSemiring S] [Semiring R] [Algebra S R] (l : NF S M) : NF R M :=
+  l.map (fun ⟨s, x⟩ ↦ (_root_.algebraMap S R s, x))
+
+theorem eval_algebraMap [CommSemiring S] [Semiring R] [Algebra S R] [AddMonoid M] [SMul S M]
+    [MulAction R M] [IsScalarTower S R M] (l : NF S M) :
+    (l.algebraMap R).eval = l.eval := by
+  simp only [NF.eval, algebraMap, map_map]
+  congr
+  ext
+  simp [IsScalarTower.algebraMap_smul]
+
+end NF
+
+variable {u v : Level}
+
+/-! ### Lists of expressions representing scalars and vectors, and operations on such lists -/
+
+/-- Basic meta-code object of the `match_scalars` and `module` tactics: a type synonym for a list of
+ordered triples comprising expressions representing terms of two types `R` and `M` (where typically
+`M` is an `R`-module), together with a natural number "index".
+
+The natural number represents the index of the `M` term in the `AtomM` monad: this is not enforced,
+but is sometimes assumed in operations.  Thus when items `((a₁, x₁), k)` and `((a₂, x₂), k)`
+appear in two different `Module.qNF` objects (i.e. with the same `ℕ`-index `k`), it is expected that
+the expressions `x₁` and `x₂` are the same.  It is also expected that the items in a `Module.qNF`
+list are in strictly increasing order by natural-number index.
+
+By forgetting the natural number indices, an expression representing a `Mathlib.Tactic.Module.NF`
+object can be built from a `Module.qNF` object; this construction is provided as
+`Mathlib.Tactic.Module.qNF.toNF`. -/
+abbrev qNF (R : Q(Type u)) (M : Q(Type v)) := List ((Q($R) × Q($M)) × ℕ)
+
+namespace qNF
+
+variable {M : Q(Type v)} {R : Q(Type u)}
+
+/-- Given `l` of type `qNF R M`, i.e. a list of `(Q($R) × Q($M)) × ℕ`s (two `Expr`s and a natural
+number), build an `Expr` representing an object of type `NF R M` (i.e. `List (R × M)`) in the
+in the obvious way: by forgetting the natural numbers and gluing together the `Expr`s. -/
+def toNF (l : qNF R M) : Q(NF $R $M) :=
+  let l' : List Q($R × $M) := (l.map Prod.fst).map (fun (a, x) ↦ q(($a, $x)))
+  let qt : List Q($R × $M) → Q(List ($R × $M)) := List.rec q([]) (fun e _ l ↦ q($e :: $l))
+  qt l'
+
+/-- Given `l` of type `qNF R₁ M`, i.e. a list of `(Q($R₁) × Q($M)) × ℕ`s (two `Expr`s and a natural
+number), apply an expression representing a function with domain `R₁` to each of the `Q($R₁)`
+components. -/
+def onScalar {u₁ u₂ : Level} {R₁ : Q(Type u₁)} {R₂ : Q(Type u₂)} (l : qNF R₁ M) (f : Q($R₁ → $R₂)) :
+    qNF R₂ M :=
+  l.map fun ((a, x), k) ↦ ((q($f $a), x), k)
+
+/-- Given two terms `l₁`, `l₂` of type `qNF R M`, i.e. lists of `(Q($R) × Q($M)) × ℕ`s (two `Expr`s
+and a natural number), construct another such term `l`, which will have the property that in the
+in the `$R`-module `$M`, the sums of the "linear combinations" represented by `l₁` and `l₂` is the
+linear combination represented by `l`.
+
+The construction assumes, to be valid, that the lists `l₁` and `l₂` are in strictly increasing order
+by `ℕ`-component, and that if pairs `(a₁, x₁)` and `(a₂, x₂)` appear in `l₁`, `l₂` respectively with
+the same `ℕ`-component `k`, then the expressions `x₁` and `x₂` are equal.
+
+The construction is as follows: merge the two lists, except that if pairs `(a₁, x₁)` and `(a₂, x₂)`
+appear in `l₁`, `l₂` respectively with the same `ℕ`-component `k`, then contribute a term
+`(a₁ + a₂, x₁)` to the output list with `ℕ`-component `k`. -/
+def add (iR : Q(Semiring $R)) : qNF R M → qNF R M → qNF R M
+  | [], l => l
+  | l, [] => l
+  | ((a₁, x₁), k₁) :: t₁, ((a₂, x₂), k₂) :: t₂ =>
+    if k₁ < k₂ then
+      ((a₁, x₁), k₁) :: add iR t₁ (((a₂, x₂), k₂) :: t₂)
+    else if k₁ = k₂ then
+      ((q($a₁ + $a₂), x₁), k₁) :: add iR t₁ t₂
+    else
+      ((a₂, x₂), k₂) :: add iR (((a₁, x₁), k₁) :: t₁) t₂
+
+/-- Given two terms `l₁`, `l₂` of type `qNF R M`, i.e. lists of `(Q($R) × Q($M)) × ℕ`s (two `Expr`s
+and a natural number), recursively construct a proof that in the in the `$R`-module `$M`, the sums
+of the "linear combinations" represented by `l₁` and `l₂` is the linear combination represented by
+`Module.qNF.add iR l₁ l₁`.-/
+def mkAddProof {iR : Q(Semiring $R)} {iM : Q(AddCommMonoid $M)} (iRM : Q(Module $R $M))
+    (l₁ l₂ : qNF R M) :
+    Q(NF.eval $(l₁.toNF) + NF.eval $(l₂.toNF) = NF.eval $((qNF.add iR l₁ l₂).toNF)) :=
+  match l₁, l₂ with
+  | [], l => (q(zero_add (NF.eval $(l.toNF))):)
+  | l, [] => (q(add_zero (NF.eval $(l.toNF))):)
+  | ((a₁, x₁), k₁) :: t₁, ((a₂, x₂), k₂) :: t₂ =>
+    if k₁ < k₂ then
+      let pf := mkAddProof iRM t₁ (((a₂, x₂), k₂) :: t₂)
+      (q(NF.add_eq_eval₁ ($a₁, $x₁) $pf):)
+    else if k₁ = k₂ then
+      let pf := mkAddProof iRM t₁ t₂
+      (q(NF.add_eq_eval₂ $a₁ $a₂ $x₁ $pf):)
+    else
+      let pf := mkAddProof iRM (((a₁, x₁), k₁) :: t₁) t₂
+      (q(NF.add_eq_eval₃ ($a₂, $x₂) $pf):)
+
+/-- Given two terms `l₁`, `l₂` of type `qNF R M`, i.e. lists of `(Q($R) × Q($M)) × ℕ`s (two `Expr`s
+and a natural number), construct another such term `l`, which will have the property that in the
+in the `$R`-module `$M`, the difference of the "linear combinations" represented by `l₁` and `l₂` is
+the linear combination represented by `l`.
+
+The construction assumes, to be valid, that the lists `l₁` and `l₂` are in strictly increasing order
+by `ℕ`-component, and that if pairs `(a₁, x₁)` and `(a₂, x₂)` appear in `l₁`, `l₂` respectively with
+the same `ℕ`-component `k`, then the expressions `x₁` and `x₂` are equal.
+
+The construction is as follows: merge the first list and the negation of the second list, except
+that if pairs `(a₁, x₁)` and `(a₂, x₂)` appear in `l₁`, `l₂` respectively with the same
+`ℕ`-component `k`, then contribute a term `(a₁ - a₂, x₁)` to the output list with `ℕ`-component `k`.
+-/
+def sub (iR : Q(Ring $R)) : qNF R M → qNF R M → qNF R M
+  | [], l => l.onScalar q(Neg.neg)
+  | l, [] => l
+  | ((a₁, x₁), k₁) :: t₁, ((a₂, x₂), k₂) :: t₂ =>
+    if k₁ < k₂ then
+      ((a₁, x₁), k₁) :: sub iR t₁ (((a₂, x₂), k₂) :: t₂)
+    else if k₁ = k₂ then
+      ((q($a₁ - $a₂), x₁), k₁) :: sub iR t₁ t₂
+    else
+      ((q(-$a₂), x₂), k₂) :: sub iR (((a₁, x₁), k₁) :: t₁) t₂
+
+/-- Given two terms `l₁`, `l₂` of type `qNF R M`, i.e. lists of `(Q($R) × Q($M)) × ℕ`s (two `Expr`s
+and a natural number), recursively construct a proof that in the in the `$R`-module `$M`, the
+difference of the "linear combinations" represented by `l₁` and `l₂` is the linear combination
+represented by `Module.qNF.sub iR l₁ l₁`.-/
+def mkSubProof (iR : Q(Ring $R)) (iM : Q(AddCommGroup $M)) (iRM : Q(Module $R $M))
+    (l₁ l₂ : qNF R M) :
+    Q(NF.eval $(l₁.toNF) - NF.eval $(l₂.toNF) = NF.eval $((qNF.sub iR l₁ l₂).toNF)) :=
+  match l₁, l₂ with
+  | [], l => (q(NF.zero_sub_eq_eval $(l.toNF)):)
+  | l, [] => (q(sub_zero (NF.eval $(l.toNF))):)
+  | ((a₁, x₁), k₁) :: t₁, ((a₂, x₂), k₂) :: t₂ =>
+    if k₁ < k₂ then
+      let pf := mkSubProof iR iM iRM t₁ (((a₂, x₂), k₂) :: t₂)
+      (q(NF.sub_eq_eval₁ ($a₁, $x₁) $pf):)
+    else if k₁ = k₂ then
+      let pf := mkSubProof iR iM iRM t₁ t₂
+      (q(NF.sub_eq_eval₂ $a₁ $a₂ $x₁ $pf):)
+    else
+      let pf := mkSubProof iR iM iRM (((a₁, x₁), k₁) :: t₁) t₂
+      (q(NF.sub_eq_eval₃ ($a₂, $x₂) $pf):)
+
+variable {iM : Q(AddCommMonoid $M)}
+  {u₁ : Level} {R₁ : Q(Type u₁)} {iR₁ : Q(Semiring $R₁)} (iRM₁ : Q(@Module $R₁ $M $iR₁ $iM))
+  {u₂ : Level} {R₂ : Q(Type u₂)} (iR₂ : Q(Semiring $R₂)) (iRM₂ : Q(@Module $R₂ $M $iR₂ $iM))
+
+/-- Given an expression `M` representing a type which is an `AddCommMonoid` and a module over *two*
+semirings `R₁` and `R₂`, find the "bigger" of the two semirings.  That is, we assume that it will
+turn out to be the case that either (1) `R₁` is an `R₂`-algebra and the `R₂` scalar action on `M` is
+induced from `R₁`'s scalar action on `M`, or (2) vice versa; we return the semiring `R₁` in the
+first case and `R₂` in the second case.
+
+Moreover, given expressions representing particular scalar multiplications of `R₁` and/or `R₂` on
+`M` (a `List (R₁ × M)`, a `List (R₂ × M)`, a pair `(r, x) : R₂ × M`), bump these up to the "big"
+ring by applying the algebra-map where needed. -/
+def matchRings (l₁ : qNF R₁ M) (l₂ : qNF R₂ M) (r : Q($R₂)) (x : Q($M)) :
+    MetaM <| Σ u : Level, Σ R : Q(Type u), Σ iR : Q(Semiring $R), Σ _ : Q(@Module $R $M $iR $iM),
+      (Σ l₁' : qNF R M, Q(NF.eval $(l₁'.toNF) = NF.eval $(l₁.toNF)))
+      × (Σ l₂' : qNF R M, Q(NF.eval $(l₂'.toNF) = NF.eval $(l₂.toNF)))
+      × (Σ r' : Q($R), Q($r' • $x = $r • $x)) := do
+  if ← isDefEq R₁ R₂ then
+  -- the case when `R₁ = R₂` is handled separately, so as not to require commutativity of that ring
+    pure ⟨u₁, R₁, iR₁, iRM₁, ⟨l₁, q(rfl)⟩, ⟨l₂, (q(@rfl _ (NF.eval $(l₂.toNF))):)⟩,
+      r, (q(@rfl _ ($r • $x)):)⟩
+  -- otherwise the "smaller" of the two rings must be commutative
+  else try
+    -- first try to exhibit `R₂` as an `R₁`-algebra
+    let _i₁ ← synthInstanceQ q(CommSemiring $R₁)
+    let _i₃ ← synthInstanceQ q(Algebra $R₁ $R₂)
+    let _i₄ ← synthInstanceQ q(IsScalarTower $R₁ $R₂ $M)
+    assumeInstancesCommute
+    let l₁' : qNF R₂ M := l₁.onScalar q(fun p ↦ algebraMap $R₁ $R₂ p)
+    pure ⟨u₂, R₂, iR₂, iRM₂, ⟨l₁', (q(NF.eval_algebraMap $R₂ $(l₁.toNF)):)⟩, ⟨l₂, q(rfl)⟩,
+      r, q(rfl)⟩
+  catch _ => try
+    -- then if that fails, try to exhibit `R₁` as an `R₂`-algebra
+    let _i₁ ← synthInstanceQ q(CommSemiring $R₂)
+    let _i₃ ← synthInstanceQ q(Algebra $R₂ $R₁)
+    let _i₄ ← synthInstanceQ q(IsScalarTower $R₂ $R₁ $M)
+    assumeInstancesCommute
+    let l₂' : qNF R₁ M := l₂.onScalar q(fun p ↦ algebraMap $R₂ $R₁ p)
+    let r' : Q($R₁) := q(algebraMap $R₂ $R₁ $r)
+    pure ⟨u₁, R₁, iR₁, iRM₁, ⟨l₁, q(rfl)⟩, ⟨l₂', (q(NF.eval_algebraMap $R₁ $(l₂.toNF)):)⟩,
+      r', (q(IsScalarTower.algebraMap_smul $R₁ $r $x):)⟩
+  catch _ =>
+    throwError "match_scalars failed: {R₁} is not an {R₂}-algebra and {R₂} is not an {R₁}-algebra"
+
+end qNF
+
+/-! ### Core of the `module` tactic -/
+
+variable {M : Q(Type v)}
+
+/-- The main algorithm behind the `match_scalars` and `module` tactics: partially-normalizing an
+expression in an additive commutative monoid `M` into the form c1 • x1 + c2 • x2 + ... c_k • x_k,
+where x1, x2, ... are distinct atoms in `M`, and c1, c2, ... are scalars. The scalar type of the
+expression is not pre-determined: instead it starts as `ℕ` (when each atom is initially given a
+scalar `(1:ℕ)`) and gets bumped up into bigger semirings when such semirings are encountered.
+
+It is assumed that there is a "linear order" on all the semirings which appear in the expression:
+for any two semirings `R` and `S` which occur, we have either `Algebra R S` or `Algebra S R`).
+
+(TODO: implement a variant in which a semiring `R` is provided by the user, and the assumption is
+instead that for any semiring `S` which occurs, we have `Algebra S R`.) -/
+partial def parse (iM : Q(AddCommMonoid $M)) (x : Q($M)) :
+    AtomM (Σ u : Level, Σ R : Q(Type u), Σ iR : Q(Semiring $R), Σ _ : Q(@Module $R $M $iR $iM),
+      Σ l : qNF R M, Q($x = NF.eval $(l.toNF))) := do
+  match x with
+  /- parse an addition: `x₁ + x₂` -/
+  | ~q($x₁ + $x₂) =>
+    let ⟨_, _, _, iRM₁, l₁', pf₁'⟩ ← parse iM x₁
+    let ⟨_, _, _, iRM₂, l₂', pf₂'⟩ ← parse iM x₂
+    -- lift from the semirings of scalars parsed from `x₁`, `x₂` (say `R₁`, `R₂`) to `R₁ ⊗ R₂`
+    let ⟨u, R, iR, iRM, ⟨l₁, pf₁⟩, ⟨l₂, pf₂⟩, _⟩ ← qNF.matchRings iRM₁ _ iRM₂ l₁' l₂' q(0) q(0)
+    -- build the new list and proof
+    let pf := qNF.mkAddProof iRM l₁ l₂
+    pure ⟨u, R, iR, iRM, qNF.add iR l₁ l₂, (q(NF.add_eq_eval $pf₁' $pf₂' $pf₁ $pf₂ $pf):)⟩
+  /- parse a subtraction: `x₁ - x₂` -/
+  | ~q(@HSub.hSub _ _ _ (@instHSub _ $iM') $x₁ $x₂) =>
+    let ⟨_, _, _, iRM₁, l₁'', pf₁''⟩ ← parse iM x₁
+    let ⟨_, _, _, iRM₂, l₂'', pf₂''⟩ ← parse iM x₂
+    -- lift from the semirings of scalars parsed from `x₁`, `x₂` (say `R₁`, `R₂`) to `R₁ ⊗ R₂ ⊗ ℤ`
+    let iZ := q(Int.instSemiring)
+    let iMZ ← synthInstanceQ q(Module ℤ $M)
+    let ⟨_, _, _, iRM₁', ⟨l₁', pf₁'⟩, _, _⟩ ← qNF.matchRings iRM₁ iZ iMZ l₁'' [] q(0) q(0)
+    let ⟨_, _, _, iRM₂', ⟨l₂', pf₂'⟩, _, _⟩ ← qNF.matchRings iRM₂ iZ iMZ l₂'' [] q(0) q(0)
+    let ⟨u, R, iR, iRM, ⟨l₁, pf₁⟩, ⟨l₂, pf₂⟩, _⟩ ← qNF.matchRings iRM₁' _ iRM₂' l₁' l₂' q(0) q(0)
+    let iR' ← synthInstanceQ q(Ring $R)
+    let iM' ← synthInstanceQ q(AddCommGroup $M)
+    assumeInstancesCommute
+    -- build the new list and proof
+    let pf := qNF.mkSubProof iR' iM' iRM l₁ l₂
+    pure ⟨u, R, iR, iRM, qNF.sub iR' l₁ l₂,
+      q(NF.sub_eq_eval $pf₁'' $pf₂'' $pf₁' $pf₂' $pf₁ $pf₂ $pf)⟩
+  /- parse a negation: `-y` -/
+  | ~q(@Neg.neg _ $iM' $y) =>
+    let ⟨u₀, _, _, iRM₀, l₀, pf₀⟩ ← parse iM y
+    -- lift from original semiring of scalars (say `R₀`) to `R₀ ⊗ ℤ`
+    let _i ← synthInstanceQ q(AddCommGroup $M)
+    let iZ := q(Int.instSemiring)
+    let iMZ ← synthInstanceQ q(Module ℤ $M)
+    let ⟨u, R, iR, iRM, ⟨l, pf⟩, _, _⟩ ← qNF.matchRings iRM₀ iZ iMZ l₀ [] q(0) q(0)
+    let _i' ← synthInstanceQ q(Ring $R)
+    assumeInstancesCommute
+    -- build the new list and proof
+    pure ⟨u, R, iR, iRM, l.onScalar q(Neg.neg), (q(NF.neg_eq_eval $pf $pf₀):)⟩
+  /- parse a scalar multiplication: `(s₀ : S) • y` -/
+  | ~q(@HSMul.hSMul _ _ _ (@instHSMul $S _ $iS) $s₀ $y) =>
+    let ⟨_, _, _, iRM₀, l₀, pf₀⟩ ← parse iM y
+    let i₁ ← synthInstanceQ q(Semiring $S)
+    let i₂ ← synthInstanceQ q(Module $S $M)
+    assumeInstancesCommute
+    -- lift from original semiring of scalars (say `R₀`) to `R₀ ⊗ S`
+    let ⟨u, R, iR, iRM, ⟨l, pf_l⟩, _, ⟨s, pf_r⟩⟩ ← qNF.matchRings iRM₀ i₁ i₂ l₀ [] s₀ y
+    -- build the new list and proof
+    pure ⟨u, R, iR, iRM, l.onScalar q(HMul.hMul $s), (q(NF.smul_eq_eval $pf₀ $pf_l $pf_r):)⟩
+  /- parse a `(0:M)` -/
+  | ~q(0) =>
+    pure ⟨0, q(Nat), q(Nat.instSemiring), q(AddCommGroup.toNatModule), [], q(NF.zero_eq_eval $M)⟩
+  /- anything else should be treated as an atom -/
+  | _ =>
+    let k : ℕ ← AtomM.addAtom x
+    pure ⟨0, q(Nat), q(Nat.instSemiring), q(AddCommGroup.toNatModule), [((q(1), x), k)],
+      q(NF.atom_eq_eval $x)⟩
+
+/-- Given expressions `R` and `M` representing types such that `M`'s is a module over `R`'s, and
+given two terms `l₁`, `l₂` of type `qNF R M`, i.e. lists of `(Q($R) × Q($M)) × ℕ`s (two `Expr`s
+and a natural number), construct a list of new goals: that the `R`-coefficient of an `M`-atom which
+appears in only one list is zero, and that the `R`-coefficients of an `M`-atom which appears in both
+lists are equal.  Also construct (dependent on these new goals) a proof that the "linear
+combinations" represented by `l₁` and `l₂` are equal in `M`. -/
+partial def reduceCoefficientwise {R : Q(Type u)} {_ : Q(AddCommMonoid $M)} {_ : Q(Semiring $R)}
+    (iRM : Q(Module $R $M)) (l₁ l₂ : qNF R M) :
+    MetaM (List MVarId × Q(NF.eval $(l₁.toNF) = NF.eval $(l₂.toNF))) := do
+  match l₁, l₂ with
+  /- if both empty, return a `rfl` proof that `(0:M) = 0` -/
+  | [], [] =>
+    let pf : Q(NF.eval $(l₁.toNF) = NF.eval $(l₁.toNF)) := q(rfl)
+    pure ([], pf)
+  /- if one of the lists is empty and the other one is not, recurse down the nonempty one,
+    forming goals that each of the listed coefficents is equal to zero -/
+  | [], ((a, x), _) :: (L : qNF R M) =>
+    let mvar : Q((0:$R) = $a) ← mkFreshExprMVar q((0:$R) = $a)
+    let (mvars, pf) ← reduceCoefficientwise iRM [] L
+    pure (mvar.mvarId! :: mvars, (q(NF.eq_const_cons $x $mvar $pf):))
+  | ((a, x), _) :: (L : qNF R M), [] =>
+    let mvar : Q($a = (0:$R)) ← mkFreshExprMVar q($a = (0:$R))
+    let (mvars, pf) ← reduceCoefficientwise iRM L []
+    pure (mvar.mvarId! :: mvars, (q(NF.eq_cons_const $x $mvar $pf):))
+  /- if both lists are nonempty, then deal with the numerically-smallest term in either list,
+    forming a goal that it is equal to zero (if it appears in only one list) or that its
+    coefficients in the two lists are the same (if it appears in both lists); then recurse -/
+  | ((a₁, x₁), k₁) :: L₁, ((a₂, x₂), k₂) :: L₂ =>
+    if k₁ < k₂ then
+      let mvar : Q($a₁ = (0:$R)) ← mkFreshExprMVar q($a₁ = (0:$R))
+      let (mvars, pf) ← reduceCoefficientwise iRM L₁ l₂
+      pure (mvar.mvarId! :: mvars, (q(NF.eq_cons_const $x₁ $mvar $pf):))
+    else if k₁ = k₂ then
+      let mvar : Q($a₁ = $a₂) ← mkFreshExprMVar q($a₁ = $a₂)
+      let (mvars, pf) ← reduceCoefficientwise iRM L₁ L₂
+      pure (mvar.mvarId! :: mvars, (q(NF.eq_cons_cons $x₁ $mvar $pf):))
+    else
+      let mvar : Q((0:$R) = $a₂) ← mkFreshExprMVar q((0:$R) = $a₂)
+      let (mvars, pf) ← reduceCoefficientwise iRM l₁ L₂
+      pure (mvar.mvarId! :: mvars, (q(NF.eq_const_cons $x₂ $mvar $pf):))
+
+/-- Given a goal which is an equality in a type `M` (with `M` an `AddCommMonoid`), parse the LHS and
+RHS of the goal as linear combinations of `M`-atoms over some semiring `R`, and reduce the goal to
+the respective equalities of the `R`-coefficients of each atom.
+
+This is an auxiliary function which produces slightly awkward goals in `R`; they are later cleaned
+up by the function `Mathlib.Tactic.Module.postprocess`. -/
+def matchScalarsAux (g : MVarId) : AtomM (List MVarId) := do
+  /- Parse the goal as an equality in a type `M` of two expressions `lhs` and `rhs`, with `M`
+  carrying an `AddCommMonoid` instance. -/
+  let eqData ← do
+    match (← g.getType').eq? with
+    | some e => pure e
+    | none => throwError "goal {← g.getType} is not an equality"
+  let .sort v₀ ← whnf (← inferType eqData.1) | unreachable!
+  let some v := v₀.dec | unreachable!
+  let ((M : Q(Type v)), (lhs : Q($M)), (rhs :Q($M))) := eqData
+  let iM ← synthInstanceQ q(AddCommMonoid.{v} $M)
+  /- Construct from the `lhs` expression a term `l₁` of type `qNF R₁ M` for some semiring `R₁` --
+  that is, a list of `(Q($R₁) × Q($M)) × ℕ`s (two `Expr`s and a natural number) -- together with a
+  proof that `lhs` is equal to the `R₁`-linear combination in `M` this represents. -/
+  let e₁ ← parse iM lhs
+  have u₁ : Level := e₁.fst
+  have R₁ : Q(Type u₁) := e₁.snd.fst
+  have _iR₁ : Q(Semiring.{u₁} $R₁) := e₁.snd.snd.fst
+  let iRM₁ ← synthInstanceQ q(Module $R₁ $M)
+  assumeInstancesCommute
+  have l₁ : qNF R₁ M := e₁.snd.snd.snd.snd.fst
+  let pf₁ : Q($lhs = NF.eval $(l₁.toNF)) := e₁.snd.snd.snd.snd.snd
+  /- Do the same for the `rhs` expression, obtaining a term `l₂` of type `qNF R₂ M` for some
+  semiring `R₂`. -/
+  let e₂ ← parse iM rhs
+  have u₂ : Level := e₂.fst
+  have R₂ : Q(Type u₂) := e₂.snd.fst
+  have _iR₂ : Q(Semiring.{u₂} $R₂) := e₂.snd.snd.fst
+  let iRM₂ ← synthInstanceQ q(Module $R₂ $M)
+  have l₂ : qNF R₂ M := e₂.snd.snd.snd.snd.fst
+  let pf₂ : Q($rhs = NF.eval $(l₂.toNF)) := e₂.snd.snd.snd.snd.snd
+  /- Lift everything to the same scalar ring, `R`. -/
+  let ⟨_, _, _, iRM, ⟨l₁', pf₁'⟩, ⟨l₂', pf₂'⟩, _⟩ ← qNF.matchRings iRM₁ _ iRM₂ l₁ l₂ q(0) q(0)
+  /- Construct a list of goals for the coefficientwise equality of these formal linear combinations,
+  and resolve our original goal (modulo these new goals). -/
+  let (mvars, pf) ← reduceCoefficientwise iRM l₁' l₂'
+  g.assign q(NF.eq_of_eval_eq_eval $pf₁ $pf₂ $pf₁' $pf₂' $pf)
+  return mvars
+
+/-- Lemmas used to post-process the result of the `match_scalars` and `module` tactics by converting
+the `algebraMap` operations which (which proliferate in the constructed scalar goals) to more
+familiar forms: `ℕ`, `ℤ` and `ℚ` casts. -/
+def algebraMapThms : Array Name := #[``eq_natCast, ``eq_intCast, ``eq_ratCast]
+
+/-- Postprocessing for the scalar goals constructed in the `match_scalars` and `module` tactics.
+These goals feature a proliferation of `algebraMap` operations (because the scalars start in `ℕ` and
+get successively bumped up by `algebraMap`s as new semirings are encountered), so we reinterpret the
+most commonly occuring `algebraMap`s (those out of `ℕ`, `ℤ` and `ℚ`) into their standard forms (`ℕ`,
+`ℤ` and `ℚ` casts) and then try to disperse the casts using the various `push_cast` lemmas. -/
+def postprocess (mvarId : MVarId) : MetaM MVarId := do
+  -- collect the available `push_cast` lemmas
+  let mut thms : SimpTheorems := ← NormCast.pushCastExt.getTheorems
+  -- augment this list with the `algebraMapThms` lemmas, which handle `algebraMap` operations
+  for thm in algebraMapThms do
+    let ⟨levelParams, _, proof⟩ ← abstractMVars (mkConst thm)
+    thms ← thms.add (.stx (← mkFreshId) Syntax.missing) levelParams proof
+  -- now run `simp` with these lemmas, and (importantly) *no* simprocs
+  let ctx : Simp.Context := {
+      config      := { failIfUnchanged := false }
+      simpTheorems := #[thms]
+    }
+  let (some r, _) ← simpTarget mvarId ctx (simprocs := #[]) |
+    throwError "internal error in match_scalars tactic: postprocessing should not close goals"
+  return r
+
+/-- Given a goal which is an equality in a type `M` (with `M` an `AddCommMonoid`), parse the LHS and
+RHS of the goal as linear combinations of `M`-atoms over some semiring `R`, and reduce the goal to
+the respective equalities of the `R`-coefficients of each atom. -/
+def matchScalars (g : MVarId) : MetaM (List MVarId) := do
+  let mvars ← AtomM.run .default (matchScalarsAux g)
+  mvars.mapM postprocess
+
+/-- Given a goal which is an equality in a type `M` (with `M` an `AddCommMonoid`), parse the LHS and
+RHS of the goal as linear combinations of `M`-atoms over some semiring `R`, and reduce the goal to
+the respective equalities of the `R`-coefficients of each atom.
+
+For example, this produces the goal `⊢ a * 1 + b * 1 = (b + a) * 1`:
+```
+example [AddCommMonoid M] [Semiring R] [Module R M] (a b : R) (x : M) :
+    a • x + b • x = (b + a) • x := by
+  match_scalars
+```
+This produces the two goals `⊢ a * (a * 1) + b * (b * 1) = 1` (from the `x` atom) and
+`⊢ a * -(b * 1) + b * (a * 1) = 0` (from the `y` atom):
+```
+example [AddCommGroup M] [Ring R] [Module R M] (a b : R) (x : M) :
+    a • (a • x - b • y) + (b • a • y + b • b • x) = x := by
+  match_scalars
+```
+This produces the goal `⊢ -2 * (a * 1) = a * (-2 * 1)`:
+```
+example [AddCommGroup M] [Ring R] [Module R M] (a : R) (x : M) :
+    -(2:R) • a • x = a • (-2:ℤ) • x  := by
+  match_scalars
+```
+-/
+elab "match_scalars" : tactic => Tactic.liftMetaTactic matchScalars
+
+/-- Given a goal which is an equality in a type `M` (with `M` an `AddCommMonoid`), parse the LHS and
+RHS of the goal as linear combinations of `M`-atoms over some commutative semiring `R`, and prove
+the goal by checking that the LHS- and RHS-coefficients of each atom are the same up to
+ring-normalization in `R`.
+
+Examples:
+```
+example [AddCommMonoid M] [CommSemiring R] [Module R M] (a b : R) (x : M) :
+    a • x + b • x = (b + a) • x := by
+  module
+
+example [AddCommMonoid M] [Field K] [CharZero K] [Module K M] (x : M) :
+    (2:K)⁻¹ • x + (3:K)⁻¹ • x + (6:K)⁻¹ • x = x := by
+  module
+
+example [AddCommGroup M] [CommRing R] [Module R M] (a : R) (v w : M) :
+    (1 + a ^ 2) • (v + w) - a • (a • v - w) = v + (1 + a + a ^ 2) • w := by
+  module
+
+example [AddCommGroup M] [CommRing R] [Module R M] (a b μ ν : R) (x y : M) :
+    (μ - ν) • a • x = (a • μ • x + b • ν • y) - ν • (a • x + b • y) := by
+  module
+```
+
+If the proofs of coefficient-wise equality will require more reasoning than just ring-normalization,
+use the tactic `match_scalars` instead, and then prove coefficient-wise equality by hand.
+-/
+elab "module" : tactic => Tactic.liftMetaTactic fun g ↦ do
+  let l ← matchScalars g
+  let _ ← l.mapM <| fun mvar ↦ AtomM.run .default (Ring.proveEq mvar)
+  pure []
+
+end Mathlib.Tactic.Module

--- a/Mathlib/Tactic/Module.lean
+++ b/Mathlib/Tactic/Module.lean
@@ -614,7 +614,11 @@ RHS of the goal as linear combinations of `M`-atoms over some commutative semiri
 the goal by checking that the LHS- and RHS-coefficients of each atom are the same up to
 ring-normalization in `R`.
 
-Examples:
+(If the proofs of coefficient-wise equality will require more reasoning than just
+ring-normalization, use the tactic `match_scalars` instead, and then prove coefficient-wise equality
+by hand.)
+
+Example uses of the `module` tactic:
 ```
 example [AddCommMonoid M] [CommSemiring R] [Module R M] (a b : R) (x : M) :
     a • x + b • x = (b + a) • x := by
@@ -632,9 +636,6 @@ example [AddCommGroup M] [CommRing R] [Module R M] (a b μ ν : R) (x y : M) :
     (μ - ν) • a • x = (a • μ • x + b • ν • y) - ν • (a • x + b • y) := by
   module
 ```
-
-If the proofs of coefficient-wise equality will require more reasoning than just ring-normalization,
-use the tactic `match_scalars` instead, and then prove coefficient-wise equality by hand.
 -/
 elab "module" : tactic => Tactic.liftMetaFinishingTactic fun g ↦ do
   let l ← matchScalars g

--- a/Mathlib/Tactic/Module.lean
+++ b/Mathlib/Tactic/Module.lean
@@ -400,7 +400,9 @@ It is assumed that there is a "linear order" on all the semirings which appear i
 for any two semirings `R` and `S` which occur, we have either `Algebra R S` or `Algebra S R`).
 
 (TODO: implement a variant in which a semiring `R` is provided by the user, and the assumption is
-instead that for any semiring `S` which occurs, we have `Algebra S R`.) -/
+instead that for any semiring `S` which occurs, we have `Algebra S R`. The PR #16984 provides a
+proof-of-concept implementation of this variant, but it would need some polishing before joining
+Mathlib.) -/
 partial def parse (iM : Q(AddCommMonoid $M)) (x : Q($M)) :
     AtomM (Σ u : Level, Σ R : Q(Type u), Σ iR : Q(Semiring $R), Σ _ : Q(@Module $R $M $iR $iM),
       Σ l : qNF R M, Q($x = NF.eval $(l.toNF))) := do

--- a/Mathlib/Tactic/Module.lean
+++ b/Mathlib/Tactic/Module.lean
@@ -367,7 +367,7 @@ def matchRings (l₁ : qNF R₁ M) (l₂ : qNF R₂ M) (r : Q($R₂)) (x : Q($M)
     let _i₃ ← synthInstanceQ q(Algebra $R₁ $R₂)
     let _i₄ ← synthInstanceQ q(IsScalarTower $R₁ $R₂ $M)
     assumeInstancesCommute
-    let l₁' : qNF R₂ M := l₁.onScalar q(fun p ↦ algebraMap $R₁ $R₂ p)
+    let l₁' : qNF R₂ M := l₁.onScalar q(algebraMap $R₁ $R₂)
     pure ⟨u₂, R₂, iR₂, iRM₂, ⟨l₁', (q(NF.eval_algebraMap $R₂ $(l₁.toNF)):)⟩, ⟨l₂, q(rfl)⟩,
       r, q(rfl)⟩
   catch _ => try
@@ -376,7 +376,7 @@ def matchRings (l₁ : qNF R₁ M) (l₂ : qNF R₂ M) (r : Q($R₂)) (x : Q($M)
     let _i₃ ← synthInstanceQ q(Algebra $R₂ $R₁)
     let _i₄ ← synthInstanceQ q(IsScalarTower $R₂ $R₁ $M)
     assumeInstancesCommute
-    let l₂' : qNF R₁ M := l₂.onScalar q(fun p ↦ algebraMap $R₂ $R₁ p)
+    let l₂' : qNF R₁ M := l₂.onScalar q(algebraMap $R₂ $R₁)
     let r' : Q($R₁) := q(algebraMap $R₂ $R₁ $r)
     pure ⟨u₁, R₁, iR₁, iRM₁, ⟨l₁, q(rfl)⟩, ⟨l₂', (q(NF.eval_algebraMap $R₁ $(l₂.toNF)):)⟩,
       r', (q(IsScalarTower.algebraMap_smul $R₁ $r $x):)⟩

--- a/Mathlib/Tactic/Module.lean
+++ b/Mathlib/Tactic/Module.lean
@@ -399,10 +399,14 @@ scalar `(1:ℕ)`) and gets bumped up into bigger semirings when such semirings a
 It is assumed that there is a "linear order" on all the semirings which appear in the expression:
 for any two semirings `R` and `S` which occur, we have either `Algebra R S` or `Algebra S R`).
 
-(TODO: implement a variant in which a semiring `R` is provided by the user, and the assumption is
+TODO: implement a variant in which a semiring `R` is provided by the user, and the assumption is
 instead that for any semiring `S` which occurs, we have `Algebra S R`. The PR #16984 provides a
 proof-of-concept implementation of this variant, but it would need some polishing before joining
-Mathlib.) -/
+Mathlib.
+
+Possible TODO, if poor performance on large problems is witnessed: switch the implementation from
+`AtomM` to `CanonM`, per the discussion
+https://github.com/leanprover-community/mathlib4/pull/16593/files#r1749623191 -/
 partial def parse (iM : Q(AddCommMonoid $M)) (x : Q($M)) :
     AtomM (Σ u : Level, Σ R : Q(Type u), Σ iR : Q(Semiring $R), Σ _ : Q(@Module $R $M $iR $iM),
       Σ l : qNF R M, Q($x = NF.eval $(l.toNF))) := do

--- a/Mathlib/Tactic/Module.lean
+++ b/Mathlib/Tactic/Module.lean
@@ -577,7 +577,7 @@ def postprocess (mvarId : MVarId) : MetaM MVarId := do
 RHS of the goal as linear combinations of `M`-atoms over some semiring `R`, and reduce the goal to
 the respective equalities of the `R`-coefficients of each atom. -/
 def matchScalars (g : MVarId) : MetaM (List MVarId) := do
-  let mvars ← AtomM.run .default (matchScalarsAux g)
+  let mvars ← AtomM.run .instances (matchScalarsAux g)
   mvars.mapM postprocess
 
 /-- Given a goal which is an equality in a type `M` (with `M` an `AddCommMonoid`), parse the LHS and
@@ -635,6 +635,6 @@ use the tactic `match_scalars` instead, and then prove coefficient-wise equality
 -/
 elab "module" : tactic => Tactic.liftMetaFinishingTactic fun g ↦ do
   let l ← matchScalars g
-  discard <| l.mapM fun mvar ↦ AtomM.run .default (Ring.proveEq mvar)
+  discard <| l.mapM fun mvar ↦ AtomM.run .instances (Ring.proveEq mvar)
 
 end Mathlib.Tactic.Module

--- a/Mathlib/Tactic/Module.lean
+++ b/Mathlib/Tactic/Module.lean
@@ -610,6 +610,14 @@ example [AddCommGroup M] [Ring R] [Module R M] (a : R) (x : M) :
     -(2:R) • a • x = a • (-2:ℤ) • x  := by
   match_scalars
 ```
+The scalar type for the goals produced by the `match_scalars` tactic is the largest scalar type
+encountered; for example, if `ℕ`, `ℚ` and a characteristic-zero field `K` all occur as scalars, then
+the goals produced are equalities in `K`.  A variant of `push_cast` is used internally in
+`match_scalars` to interpret scalars from the other types in this largest type.
+
+If the set of scalar types encountered is not totally ordered (in the sense that for all rings `R`,
+`S` encountered, it holds that either `Algebra R S` or `Algebra S R`), then the `match_scalars`
+tactic fails.
 -/
 elab "match_scalars" : tactic => Tactic.liftMetaTactic matchScalars
 

--- a/Mathlib/Tactic/Module.lean
+++ b/Mathlib/Tactic/Module.lean
@@ -633,9 +633,8 @@ example [AddCommGroup M] [CommRing R] [Module R M] (a b μ ν : R) (x y : M) :
 If the proofs of coefficient-wise equality will require more reasoning than just ring-normalization,
 use the tactic `match_scalars` instead, and then prove coefficient-wise equality by hand.
 -/
-elab "module" : tactic => Tactic.liftMetaTactic fun g ↦ do
+elab "module" : tactic => Tactic.liftMetaFinishingTactic fun g ↦ do
   let l ← matchScalars g
-  let _ ← l.mapM <| fun mvar ↦ AtomM.run .default (Ring.proveEq mvar)
-  pure []
+  discard <| l.mapM fun mvar ↦ AtomM.run .default (Ring.proveEq mvar)
 
 end Mathlib.Tactic.Module

--- a/Mathlib/Tactic/Module.lean
+++ b/Mathlib/Tactic/Module.lean
@@ -356,7 +356,7 @@ def matchRings (l₁ : qNF R₁ M) (l₂ : qNF R₂ M) (r : Q($R₂)) (x : Q($M)
       (Σ l₁' : qNF R M, Q(NF.eval $(l₁'.toNF) = NF.eval $(l₁.toNF)))
       × (Σ l₂' : qNF R M, Q(NF.eval $(l₂'.toNF) = NF.eval $(l₂.toNF)))
       × (Σ r' : Q($R), Q($r' • $x = $r • $x)) := do
-  if ← isDefEq R₁ R₂ then
+  if ← withReducible <| isDefEq R₁ R₂ then
   -- the case when `R₁ = R₂` is handled separately, so as not to require commutativity of that ring
     pure ⟨u₁, R₁, iR₁, iRM₁, ⟨l₁, q(rfl)⟩, ⟨l₂, (q(@rfl _ (NF.eval $(l₂.toNF))):)⟩,
       r, (q(@rfl _ ($r • $x)):)⟩

--- a/Mathlib/Tactic/Module.lean
+++ b/Mathlib/Tactic/Module.lean
@@ -36,9 +36,9 @@ to prove goals in modules.  The basic object which these lemmas concern is `NF R
 for a list of ordered pairs in `R × M`, where typically `M` is an `R`-module.
 -/
 
-/-- Basic theoretical object of the `match_scalars` and `module` tactics: a type synonym for a list
-of ordered pairs in `R × M`, where typically `M` is an `R`-module.  This is the form to which the
-tactics reduce module expressions.
+/-- Basic theoretical "normal form" object of the `match_scalars` and `module` tactics: a type
+synonym for a list of ordered pairs in `R × M`, where typically `M` is an `R`-module.  This is the
+form to which the tactics reduce module expressions.
 
 (It is not a full "normal form" because the scalars, i.e. `R` components, are not themselves
 ring-normalized.  But this partial normal form is more convenient for our purposes.)  -/
@@ -215,9 +215,9 @@ variable {u v : Level}
 
 /-! ### Lists of expressions representing scalars and vectors, and operations on such lists -/
 
-/-- Basic meta-code object of the `match_scalars` and `module` tactics: a type synonym for a list of
-ordered triples comprising expressions representing terms of two types `R` and `M` (where typically
-`M` is an `R`-module), together with a natural number "index".
+/-- Basic meta-code "normal form" object of the `match_scalars` and `module` tactics: a type synonym
+for a list of ordered triples comprising expressions representing terms of two types `R` and `M`
+(where typically `M` is an `R`-module), together with a natural number "index".
 
 The natural number represents the index of the `M` term in the `AtomM` monad: this is not enforced,
 but is sometimes assumed in operations.  Thus when items `((a₁, x₁), k)` and `((a₂, x₂), k)`

--- a/Mathlib/Tactic/Module.lean
+++ b/Mathlib/Tactic/Module.lean
@@ -251,8 +251,8 @@ def onScalar {u₁ u₂ : Level} {R₁ : Q(Type u₁)} {R₂ : Q(Type u₂)} (l 
 
 /-- Given two terms `l₁`, `l₂` of type `qNF R M`, i.e. lists of `(Q($R) × Q($M)) × ℕ`s (two `Expr`s
 and a natural number), construct another such term `l`, which will have the property that in the
-in the `$R`-module `$M`, the sums of the "linear combinations" represented by `l₁` and `l₂` is the
-linear combination represented by `l`.
+`$R`-module `$M`, the sum of the "linear combinations" represented by `l₁` and `l₂` is the linear
+combination represented by `l`.
 
 The construction assumes, to be valid, that the lists `l₁` and `l₂` are in strictly increasing order
 by `ℕ`-component, and that if pairs `(a₁, x₁)` and `(a₂, x₂)` appear in `l₁`, `l₂` respectively with
@@ -273,8 +273,8 @@ def add (iR : Q(Semiring $R)) : qNF R M → qNF R M → qNF R M
       ((a₂, x₂), k₂) :: add iR (((a₁, x₁), k₁) :: t₁) t₂
 
 /-- Given two terms `l₁`, `l₂` of type `qNF R M`, i.e. lists of `(Q($R) × Q($M)) × ℕ`s (two `Expr`s
-and a natural number), recursively construct a proof that in the in the `$R`-module `$M`, the sums
-of the "linear combinations" represented by `l₁` and `l₂` is the linear combination represented by
+and a natural number), recursively construct a proof that in the `$R`-module `$M`, the sum of the
+"linear combinations" represented by `l₁` and `l₂` is the linear combination represented by
 `Module.qNF.add iR l₁ l₁`.-/
 def mkAddProof {iR : Q(Semiring $R)} {iM : Q(AddCommMonoid $M)} (iRM : Q(Module $R $M))
     (l₁ l₂ : qNF R M) :
@@ -295,8 +295,8 @@ def mkAddProof {iR : Q(Semiring $R)} {iM : Q(AddCommMonoid $M)} (iRM : Q(Module 
 
 /-- Given two terms `l₁`, `l₂` of type `qNF R M`, i.e. lists of `(Q($R) × Q($M)) × ℕ`s (two `Expr`s
 and a natural number), construct another such term `l`, which will have the property that in the
-in the `$R`-module `$M`, the difference of the "linear combinations" represented by `l₁` and `l₂` is
-the linear combination represented by `l`.
+`$R`-module `$M`, the difference of the "linear combinations" represented by `l₁` and `l₂` is the
+linear combination represented by `l`.
 
 The construction assumes, to be valid, that the lists `l₁` and `l₂` are in strictly increasing order
 by `ℕ`-component, and that if pairs `(a₁, x₁)` and `(a₂, x₂)` appear in `l₁`, `l₂` respectively with
@@ -318,9 +318,9 @@ def sub (iR : Q(Ring $R)) : qNF R M → qNF R M → qNF R M
       ((q(-$a₂), x₂), k₂) :: sub iR (((a₁, x₁), k₁) :: t₁) t₂
 
 /-- Given two terms `l₁`, `l₂` of type `qNF R M`, i.e. lists of `(Q($R) × Q($M)) × ℕ`s (two `Expr`s
-and a natural number), recursively construct a proof that in the in the `$R`-module `$M`, the
-difference of the "linear combinations" represented by `l₁` and `l₂` is the linear combination
-represented by `Module.qNF.sub iR l₁ l₁`.-/
+and a natural number), recursively construct a proof that in the `$R`-module `$M`, the difference
+of the "linear combinations" represented by `l₁` and `l₂` is the linear combination represented by
+`Module.qNF.sub iR l₁ l₁`.-/
 def mkSubProof (iR : Q(Ring $R)) (iM : Q(AddCommGroup $M)) (iRM : Q(Module $R $M))
     (l₁ l₂ : qNF R M) :
     Q(NF.eval $(l₁.toNF) - NF.eval $(l₂.toNF) = NF.eval $((qNF.sub iR l₁ l₂).toNF)) :=

--- a/Mathlib/Tactic/Ring/RingNF.lean
+++ b/Mathlib/Tactic/Ring/RingNF.lean
@@ -147,7 +147,7 @@ partial def M.run
       ``rat_rawCast_neg, ``rat_rawCast_pos].foldlM (·.addConst · (post := false)) thms
     let ctx' := { ctx with simpTheorems := #[thms] }
     pure fun r' : Simp.Result ↦ do
-      r'.mkEqTrans (← Simp.main r'.expr ctx' (methods := ← Lean.Meta.Simp.mkDefaultMethods)).1
+      r'.mkEqTrans (← Simp.main r'.expr ctx' (methods := Lean.Meta.Simp.mkDefaultMethodsCore {})).1
   let nctx := { ctx, simp }
   let rec
     /-- The recursive context. -/

--- a/test/module.lean
+++ b/test/module.lean
@@ -1,0 +1,306 @@
+/-
+Copyright (c) 2024 Heather Macbeth. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Heather Macbeth
+-/
+import Mathlib.Tactic.FieldSimp
+import Mathlib.Tactic.LinearCombination
+import Mathlib.Tactic.Module
+import Mathlib.Tactic.NoncommRing
+import Mathlib.Tactic.Positivity
+
+/-! # Tests for the module-normalization tactic -/
+
+open Mathlib.Tactic.LinearCombination
+
+variable {V : Type*} {K : Type*} {t u v w x y z : V} {a b c d e f μ ν ρ : K}
+
+/-! ### `ℕ` (most tests copied from the `abel` tactic) -/
+
+section Nat
+variable [AddCommMonoid V]
+
+example : x + (y + x) = x + x + y := by module
+example : (3 : ℕ) • x = x + (2 : ℕ) • x := by module
+example : 0 + x = x := by module
+example (n : ℕ) : n • x = n • x := by module
+example (n : ℕ) : 0 + n • x = n • x := by module
+example : x + (y + (x + (z + (x + (u + (x + v)))))) = v + u + z + y + 4 • x := by module
+example : x + y = y + x := by module
+example : x + 2 • x = 2 • x + x := by module
+
+example : x + (y + x) = x + x + y ∨ False := by
+  left
+  module
+
+/--
+error: unsolved goals
+V : Type u_1
+K : Type u_2
+t u v w x y z : V
+a b c d e f μ ν ρ : K
+inst✝ : AddCommMonoid V
+⊢ 1 = 1
+
+V : Type u_1
+K : Type u_2
+t u v w x y z : V
+a b c d e f μ ν ρ : K
+inst✝ : AddCommMonoid V
+⊢ 1 = 2 * 1
+-/
+#guard_msgs in
+example : x + y = x + 2 • y := by match_scalars
+
+/--
+error: ring failed, ring expressions not equal
+V : Type u_1
+K : Type u_2
+t u v w x y z : V
+a b c d e f μ ν ρ : K
+inst✝ : AddCommMonoid V
+⊢ 1 = 2
+-/
+#guard_msgs in
+example : x + y = x + 2 • y := by module
+
+/-- error: goal x ≠ y is not an equality -/
+#guard_msgs in
+example : x ≠ y := by module
+
+end Nat
+
+/-! ### `ℤ` (most tests copied from the `abel` tactic) -/
+
+variable [AddCommGroup V]
+
+example : (x + y) - ((y + x) + x) = -x := by module
+example : x - 0 = x := by module
+example : (3 : ℤ) • x = x + (2 : ℤ) • x := by module
+example : x - 2 • y = x - 2 • y := by module
+example : (x + y) - ((y + x) + x) = -x := by module
+example : x + y + (z + w - x) = y + z + w := by module
+example : x + y + z + (z - x - x) = (-1) • x + y + 2 • z := by module
+example : -x + x = 0 := by module
+example : x - (0 - 0) = x := by module
+example : x + (y - x) = y  := by module
+example : -y + (z - x) = z - y - x := by module
+
+example : x + y = y + x ∧ (↑((1:ℕ) + 1) : ℚ) = 2 := by
+  constructor
+  module -- do not focus this tactic: the double goal is the point of the test
+  guard_target =ₐ (↑((1:ℕ) + 1) : ℚ) = 2
+  norm_cast
+
+-- https://leanprover.zulipchat.com/#narrow/stream/287929-mathlib4/topic/Interaction.20of.20abel.20with.20casting/near/319895001
+example : True := by
+  have : ∀ (p q r s : V), s + p - q = s - r - (q - r - p) := by
+    intro p q r s
+    module
+  trivial
+
+example : True := by
+  have : ∀ (p q r s : V), s + p - q = s - r - (q - r - p) := by
+    intro p q r s
+    match_scalars
+    · decide
+    · decide
+    · decide
+    · decide
+  trivial
+
+-- https://leanprover.zulipchat.com/#narrow/stream/287929-mathlib4/topic/Interaction.20of.20abel.20with.20casting/near/319897374
+example : y = x + z - (x - y + z) := by
+  have : True := trivial
+  module
+
+example : y = x + z - (x - y + z) := by
+  have : True := trivial
+  match_scalars <;> decide
+
+/--
+error: unsolved goals
+V : Type u_1
+K : Type u_2
+t u v w x y z : V
+a b c d e f μ ν ρ : K
+inst✝ : AddCommGroup V
+⊢ -1 + 1 = 0
+-/
+#guard_msgs in
+example : -x + x = 0 := by
+  match_scalars
+
+/-! ### Commutative ring -/
+
+section CommRing
+variable [CommRing K] [Module K V]
+
+example : a • x + b • x = (a + b) • x := by module
+example : a • x - b • x = (a - b) • x := by module
+example : a • x - b • y = a • x + (-b) • y := by module
+example : 2 • a • x = a • 2 • x := by module
+example : a • x - b • y = a • x + (-b) • y := by module
+example : (μ - ν) • a • x = (a • μ • x + b • ν • y) - ν • (a • x + b • y) := by module
+example : (μ - ν) • b • y = μ • (a • x + b • y) - (a • μ • x + b • ν • y) := by module
+
+-- from https://leanprover.zulipchat.com/#narrow/stream/287929-mathlib4/topic/smul.20diamond/near/457163013
+example : (4 : ℤ) • v = (4 : K) • v := by module
+example : (4 : ℕ) • v = (4 : K) • v := by module
+
+-- from https://leanprover.zulipchat.com/#narrow/stream/287929-mathlib4/topic/linear_combination.20for.20groups/near/437042918
+example : (1 + a ^ 2) • (v + w) - a • (a • v - w) = v + (1 + a + a ^ 2) • w := by module
+
+example (h : a = b) : a • x = b • x := by
+  match_scalars
+  linear_combination h
+
+example (h : a = b) : a • x = b • x := by
+  -- `linear_combination h • x`
+  apply eq_of_add (congr($h • x):)
+  module
+
+example (h : a ^ 2 + b ^ 2 = 1) : a • (a • x - b • y) + (b • a • y + b • b • x) = x := by
+  match_scalars
+  · linear_combination h
+  · ring
+
+example (h : a ^ 2 + b ^ 2 = 1) : a • (a • x - b • y) + (b • a • y + b • b • x) = x := by
+  -- `linear_combination h • x`
+  apply eq_of_add (congr($h • x):)
+  module
+
+example (h1 : a • x + b • y = 0) (h2 : a • μ • x + b • ν • y = 0) :
+    (μ - ν) • a • x = 0 ∧ (μ - ν) • b • y = 0 := by
+  constructor
+  · -- `linear_combination h2 - ν • h1`
+    apply eq_of_add (congr($h2 - ν • $h1):)
+    module
+  · -- `linear_combination μ • h1 + h2`
+    apply eq_of_add (congr(μ • $h1 - $h2):)
+    module
+
+example (h1 : 0 • z + a • x + b • y = 0) (h2 : 0 • ρ • z + a • μ • x + b • ν • y = 0) :
+    (μ - ν) • a • x = 0 := by
+  -- `linear_combination h2 - ν • h1`
+  apply eq_of_add (congr($h2 - ν • $h1):)
+  module
+
+example
+    (h1 : a • x + b • y + c • z = 0)
+    (h2 : a • μ • x + b • ν • y + c • ρ • z = 0)
+    (h3 : a • μ • μ • x + b • ν • ν • y + c • ρ • ρ • z = 0) :
+    (μ - ν) • (μ - ρ) • a • x = 0 ∧ (μ - ν) • (ν - ρ) • b • y = 0
+      ∧ (μ - ρ) • (ν - ρ) • c • z = 0 := by
+  refine ⟨?_, ?_, ?_⟩
+  · -- `linear_combination h3 - (ν + ρ) • h2 + ν • ρ • h1`
+    apply eq_of_add (congr($h3 - (ν + ρ) • $h2 + ν • ρ • $h1):)
+    module
+  · -- `linear_combination - h3 + (μ + ρ) • h2 - μ • ρ • h1`
+    apply eq_of_add (congr(- $h3 + (μ + ρ) • $h2 - μ • ρ • $h1):)
+    module
+  · -- `linear_combination h3 - (μ + ν) • h2 + μ • ν • h1`
+    apply eq_of_add (congr($h3 - (μ + ν) • $h2 + μ • ν • $h1):)
+    module
+
+/--
+error: ring failed, ring expressions not equal
+V : Type u_1
+K : Type u_2
+t u v w x y z : V
+a b c d e f μ ν ρ : K
+inst✝² : AddCommGroup V
+inst✝¹ : CommRing K
+inst✝ : Module K V
+⊢ a * 2 = 2
+-/
+#guard_msgs in
+example : 2 • a • x = 2 • x := by module
+
+end CommRing
+
+/-! ### (Noncommutative) ring -/
+
+section Ring
+variable [Ring K] [Module K V]
+
+example : a • x + b • x = (b + a) • x := by
+  match_scalars
+  noncomm_ring
+
+example : 2 • a • x = a • (2:ℤ) • x := by
+  match_scalars
+  noncomm_ring
+
+example (h : a = b) : a • x = b • x := by
+  match_scalars
+  simp [h]
+
+example : (a - b) • a • x + b • b • x = a • a • x + b • (-a + b) • x := by
+  match_scalars
+  noncomm_ring
+
+end Ring
+
+/-! ### Characteristic-zero field -/
+
+section CharZeroField
+variable [Field K] [CharZero K] [Module K V]
+
+example : (2:K)⁻¹ • x + (3:K)⁻¹ • x + (6:K)⁻¹ • x = x := by module
+
+example (h₁ : t - u = -(v - w)) (h₂ : t + u = v + w) : t = w := by
+  -- `linear_combination 2⁻¹ • h₁ + 2⁻¹ • h₂`
+  apply eq_of_add (congr((2:K)⁻¹ • $h₁ + (2:K)⁻¹ • $h₂):)
+  module
+
+end CharZeroField
+
+/-! ### Linearly ordered field -/
+
+section LinearOrderedField
+variable [LinearOrderedField K] [Module K V]
+
+example (ha : 0 ≤ a) (hb : 0 < b) :
+    x = (a / (a + b)) • y + (b / (a + b)) • (x + (a / b) • (x - y)) := by
+  match_scalars
+  · field_simp
+    ring
+  · field_simp
+    ring
+
+-- From Analysis.Convex.StoneSeparation
+example (hab : 0 < a * b + c * d) :
+    (a * b / (a * b + c * d) * e) • u + (c * d / (a * b + c * d) * f) • v +
+      ((a * b / (a * b + c * d)) • d • x + (c * d / (a * b + c * d)) • b • y) =
+      (a * b + c * d)⁻¹ • ((a * b * e) • u + ((c * d * f) • v +
+        ((a * b) • d • x + (c * d) • b • y))) := by
+  match_scalars
+  · field_simp
+  · field_simp
+  · field_simp
+  · field_simp
+
+example (h₁ : 1 = a ^ 2 + b ^ 2) (h₂ : 1 - a ≠ 0) :
+    ((2 / (1 - a)) ^ 2 * b ^ 2 + 4)⁻¹ • (4:K) • ((2 / (1 - a)) • y)
+    + ((2 / (1 - a)) ^ 2 * b ^ 2 + 4)⁻¹ • ((2 / (1 - a)) ^ 2 * b ^ 2 - 4) • x
+    = a • x + y := by
+  -- `linear_combination (h₁ * (b ^ 2 + (1 - a) ^ 2)⁻¹) • (y + (a - 1) • x)`
+  apply eq_of_add (congr(($h₁ * (b ^ 2 + (1 - a) ^ 2)⁻¹) • (y + (a - 1) • x)):)
+  match_scalars
+  · field_simp
+    ring
+  · field_simp
+    ring
+
+example (h₁ : 1 = a ^ 2 + b ^ 2) (h₂ : 1 - a ≠ 0) :
+    ((2 / (1 - a)) ^ 2 * b ^ 2 + 4)⁻¹ • (4:K) • ((2 / (1 - a)) • y)
+    + ((2 / (1 - a)) ^ 2 * b ^ 2 + 4)⁻¹ • ((2 / (1 - a)) ^ 2 * b ^ 2 - 4) • x
+    = a • x + y := by
+  match_scalars
+  · field_simp
+    linear_combination 4 * (1 - a) * h₁
+  · field_simp
+    linear_combination 4 * (a - 1) ^ 3 * h₁
+
+end LinearOrderedField

--- a/test/module.lean
+++ b/test/module.lean
@@ -155,8 +155,10 @@ example (h : a = b) : a • x = b • x := by
   match_scalars
   linear_combination h
 
+/- `linear_combination` does not currently handle `•`.  The following mimics what should eventually
+be performed by a `linear_combination` call, with exact syntax TBD -- maybe
+`linear_combination (norm := module) h • x` or `module_combination h • x`. -/
 example (h : a = b) : a • x = b • x := by
-  -- `linear_combination h • x`
   apply eq_of_add (congr($h • x):)
   module
 
@@ -166,23 +168,23 @@ example (h : a ^ 2 + b ^ 2 = 1) : a • (a • x - b • y) + (b • a • y + b
   · ring
 
 example (h : a ^ 2 + b ^ 2 = 1) : a • (a • x - b • y) + (b • a • y + b • b • x) = x := by
-  -- `linear_combination h • x`
+  -- `linear_combination (norm := module) h • x`
   apply eq_of_add (congr($h • x):)
   module
 
 example (h1 : a • x + b • y = 0) (h2 : a • μ • x + b • ν • y = 0) :
     (μ - ν) • a • x = 0 ∧ (μ - ν) • b • y = 0 := by
   constructor
-  · -- `linear_combination h2 - ν • h1`
+  · -- `linear_combination (norm := module) h2 - ν • h1`
     apply eq_of_add (congr($h2 - ν • $h1):)
     module
-  · -- `linear_combination μ • h1 + h2`
+  · -- `linear_combination (norm := module) μ • h1 + h2`
     apply eq_of_add (congr(μ • $h1 - $h2):)
     module
 
 example (h1 : 0 • z + a • x + b • y = 0) (h2 : 0 • ρ • z + a • μ • x + b • ν • y = 0) :
     (μ - ν) • a • x = 0 := by
-  -- `linear_combination h2 - ν • h1`
+  -- `linear_combination (norm := module) h2 - ν • h1`
   apply eq_of_add (congr($h2 - ν • $h1):)
   module
 
@@ -193,13 +195,13 @@ example
     (μ - ν) • (μ - ρ) • a • x = 0 ∧ (μ - ν) • (ν - ρ) • b • y = 0
       ∧ (μ - ρ) • (ν - ρ) • c • z = 0 := by
   refine ⟨?_, ?_, ?_⟩
-  · -- `linear_combination h3 - (ν + ρ) • h2 + ν • ρ • h1`
+  · -- `linear_combination (norm := module) h3 - (ν + ρ) • h2 + ν • ρ • h1`
     apply eq_of_add (congr($h3 - (ν + ρ) • $h2 + ν • ρ • $h1):)
     module
-  · -- `linear_combination - h3 + (μ + ρ) • h2 - μ • ρ • h1`
+  · -- `linear_combination (norm := module) - h3 + (μ + ρ) • h2 - μ • ρ • h1`
     apply eq_of_add (congr(- $h3 + (μ + ρ) • $h2 - μ • ρ • $h1):)
     module
-  · -- `linear_combination h3 - (μ + ν) • h2 + μ • ν • h1`
+  · -- `linear_combination (norm := module) h3 - (μ + ν) • h2 + μ • ν • h1`
     apply eq_of_add (congr($h3 - (μ + ν) • $h2 + μ • ν • $h1):)
     module
 
@@ -250,7 +252,7 @@ variable [Field K] [CharZero K] [Module K V]
 example : (2:K)⁻¹ • x + (3:K)⁻¹ • x + (6:K)⁻¹ • x = x := by module
 
 example (h₁ : t - u = -(v - w)) (h₂ : t + u = v + w) : t = w := by
-  -- `linear_combination 2⁻¹ • h₁ + 2⁻¹ • h₂`
+  -- `linear_combination (norm := module) 2⁻¹ • h₁ + 2⁻¹ • h₂`
   apply eq_of_add (congr((2:K)⁻¹ • $h₁ + (2:K)⁻¹ • $h₂):)
   module
 
@@ -285,7 +287,7 @@ example (h₁ : 1 = a ^ 2 + b ^ 2) (h₂ : 1 - a ≠ 0) :
     ((2 / (1 - a)) ^ 2 * b ^ 2 + 4)⁻¹ • (4:K) • ((2 / (1 - a)) • y)
     + ((2 / (1 - a)) ^ 2 * b ^ 2 + 4)⁻¹ • ((2 / (1 - a)) ^ 2 * b ^ 2 - 4) • x
     = a • x + y := by
-  -- `linear_combination (h₁ * (b ^ 2 + (1 - a) ^ 2)⁻¹) • (y + (a - 1) • x)`
+  -- `linear_combination (norm := skip) (h₁ * (b ^ 2 + (1 - a) ^ 2)⁻¹) • (y + (a - 1) • x)`
   apply eq_of_add (congr(($h₁ * (b ^ 2 + (1 - a) ^ 2)⁻¹) • (y + (a - 1) • x)):)
   match_scalars
   · field_simp


### PR DESCRIPTION
This PR contributes two new tactics `match_scalars` and `module`.

Given a goal which is an equality in a type `M` (with `M` an `AddCommMonoid`), the `match_scalars` tactic parses the LHS and RHS of the goal as linear combinations of `M`-atoms over some semiring `R`, and reduces the goal to the respective equalities of the `R`-coefficients of each atom.

For example, this produces the goal `⊢ a * 1 + b * 1 = (b + a) * 1`:
```lean
example [AddCommMonoid M] [Semiring R] [Module R M] (a b : R) (x : M) :
    a • x + b • x = (b + a) • x := by
  match_scalars
```
This produces the two goals `⊢ a * (a * 1) + b * (b * 1) = 1` (from the `x` atom) and
`⊢ a * -(b * 1) + b * (a * 1) = 0` (from the `y` atom):
```lean
example [AddCommGroup M] [Ring R] [Module R M] (a b : R) (x : M) :
    a • (a • x - b • y) + (b • a • y + b • b • x) = x := by
  match_scalars
```

The `module` tactic runs the `match_scalars` tactic and then runs the `ring` tactic on each of the coefficient-wise equalities which are created, failing if this does not resolve them.  For example, it solves the following goals:
```lean
example [AddCommMonoid M] [CommSemiring R] [Module R M] (a b : R) (x : M) :
    a • x + b • x = (b + a) • x := by
  module

example [AddCommMonoid M] [Field K] [CharZero K] [Module K M] (x : M) :
    (2:K)⁻¹ • x + (3:K)⁻¹ • x + (6:K)⁻¹ • x = x := by
  module

example [AddCommGroup M] [CommRing R] [Module R M] (a : R) (v w : M) :
    (1 + a ^ 2) • (v + w) - a • (a • v - w) = v + (1 + a + a ^ 2) • w := by
  module
```
The scalar type `R` in these tactics is not pre-determined: instead it starts as `ℕ` (when each atom is initially given a scalar `(1:ℕ)`) and gets bumped up into bigger semirings when such semirings are encountered.  However, to permit this, it is assumed that there is a "linear order" on all the semirings which appear in the expression: for any two semirings `R` and `S` which occur, we have either `Algebra R S` or `Algebra S R`).

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
