### PR TITLE
[Merged by Bors] - feat(Algebra/Polynomial/Splits): show that evaluating a split polynomial is the same as looking at the product of the roots

### DIFF
--- a/Mathlib/Algebra/Polynomial/Splits.lean
+++ b/Mathlib/Algebra/Polynomial/Splits.lean
@@ -6,6 +6,7 @@ Authors: Chris Hughes
 import Mathlib.Algebra.Polynomial.FieldDivision
 import Mathlib.Algebra.Polynomial.Lifts
 import Mathlib.Data.List.Prime
+import Mathlib.RingTheory.Polynomial.Tower
 
 /-!
 # Split polynomials
@@ -299,6 +300,18 @@ theorem eq_prod_roots_of_splits {p : K[X]} {i : K →+* L} (hsplit : Splits i p)
 theorem eq_prod_roots_of_splits_id {p : K[X]} (hsplit : Splits (RingHom.id K) p) :
     p = C p.leadingCoeff * (p.roots.map fun a => X - C a).prod := by
   simpa using eq_prod_roots_of_splits hsplit
+
+theorem aeval_eq_prod_aroots_sub_of_splits [Algebra K L] {p : K[X]}
+    (hsplit : Splits (algebraMap K L) p) (v : L) :
+    aeval v p = algebraMap K L p.leadingCoeff * ((p.aroots L).map fun a ↦ v - a).prod := by
+  rw [← eval_map_algebraMap, eq_prod_roots_of_splits hsplit]
+  simp [eval_multiset_prod]
+
+theorem eval_eq_prod_roots_sub_of_splits {p : K[X]}
+    (hsplit : Splits (RingHom.id K) p) (v : K) :
+    eval v p = p.leadingCoeff * (p.roots.map fun a ↦ v - a).prod := by
+  convert aeval_eq_prod_aroots_sub_of_splits hsplit v
+  rw [Algebra.id.map_eq_id, map_id]
 
 theorem eq_prod_roots_of_monic_of_splits_id {p : K[X]} (m : Monic p)
     (hsplit : Splits (RingHom.id K) p) : p = (p.roots.map fun a => X - C a).prod := by

--- a/Mathlib/Algebra/Polynomial/Splits.lean
+++ b/Mathlib/Algebra/Polynomial/Splits.lean
@@ -307,7 +307,7 @@ theorem aeval_eq_prod_aroots_sub_of_splits [Algebra K L] {p : K[X]}
   rw [← eval_map_algebraMap, eq_prod_roots_of_splits hsplit]
   simp [eval_multiset_prod]
 
-theorem eval_eq_prod_roots_sub_of_splits {p : K[X]}
+theorem eval_eq_prod_roots_sub_of_splits_id {p : K[X]}
     (hsplit : Splits (RingHom.id K) p) (v : K) :
     eval v p = p.leadingCoeff * (p.roots.map fun a ↦ v - a).prod := by
   convert aeval_eq_prod_aroots_sub_of_splits hsplit v
@@ -317,6 +317,16 @@ theorem eq_prod_roots_of_monic_of_splits_id {p : K[X]} (m : Monic p)
     (hsplit : Splits (RingHom.id K) p) : p = (p.roots.map fun a => X - C a).prod := by
   convert eq_prod_roots_of_splits_id hsplit
   simp [m]
+
+theorem aeval_eq_prod_aroots_sub_of_monic_of_splits [Algebra K L] {p : K[X]} (m : Monic p)
+    (hsplit : Splits (algebraMap K L) p) (v : L) :
+    aeval v p = ((p.aroots L).map fun a ↦ v - a).prod := by
+  simp [aeval_eq_prod_aroots_sub_of_splits hsplit, m]
+
+theorem eval_eq_prod_roots_sub_of_monic_of_splits_id {p : K[X]} (m : Monic p)
+    (hsplit : Splits (RingHom.id K) p) (v : K) :
+    eval v p = (p.roots.map fun a ↦ v - a).prod := by
+  simp [eval_eq_prod_roots_sub_of_splits_id hsplit, m]
 
 theorem eq_X_sub_C_of_splits_of_single_root {x : K} {h : K[X]} (h_splits : Splits i h)
     (h_roots : (h.map i).roots = {i x}) : h = C h.leadingCoeff * (X - C x) := by


### PR DESCRIPTION
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
