### PR TITLE
feat(Combinatorics/SimpleGraph): added subgraph of function

### DIFF
--- a/Mathlib/Combinatorics/SimpleGraph/Matching.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Matching.lean
@@ -133,6 +133,30 @@ lemma IsMatching.coeSubgraph {G' : Subgraph G} {M : Subgraph G'.coe} (hM : M.IsM
   · obtain ⟨_, hw', hvw⟩ := (coeSubgraph_adj _ _ _).mp hy
     rw [← hw.2 ⟨y, hw'⟩ hvw]
 
+lemma IsMatching_ofFunction {u : Set V} (f : V → V) (h : ∀ v ∈ u, G.Adj v (f v))
+    (hinj : u.InjOn f) (hd : Disjoint u (f '' u)) : (Subgraph.ofFunction f h).IsMatching := by
+  rw [Set.disjoint_right] at hd
+  intro v hv
+  simp only [ofFunction_adj]
+  cases' hv with hl hr
+  · use f v
+    simp only [and_true]
+    refine ⟨.inl hl, ?_⟩
+    intro y hy
+    cases' hy with h1 h2
+    · exact h1.2.symm
+    · exfalso
+      exact hd (by rw [Set.mem_image]; use y) hl
+  · rw [Set.mem_image] at hr
+    obtain ⟨w, hw⟩ := hr
+    use w
+    refine ⟨.inr hw, ?_⟩
+    intro y hy
+    cases' hy with h1 h2
+    · exfalso
+      exact hd (by rw [Set.mem_image]; use w) h1.1
+    · exact hinj h2.1 hw.1 (h2.2 ▸ hw.2.symm)
+
 /--
 The subgraph `M` of `G` is a perfect matching on `G` if it's a matching and every vertex `G` is
 matched.

--- a/Mathlib/Combinatorics/SimpleGraph/Matching.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Matching.lean
@@ -133,7 +133,7 @@ lemma IsMatching.coeSubgraph {G' : Subgraph G} {M : Subgraph G'.coe} (hM : M.IsM
   · obtain ⟨_, hw', hvw⟩ := (coeSubgraph_adj _ _ _).mp hy
     rw [← hw.2 ⟨y, hw'⟩ hvw]
 
-lemma IsMatching_ofFunction {u : Set V} (f : V → V) (h : ∀ v ∈ u, G.Adj v (f v))
+lemma IsMatching.ofFunction {u : Set V} (f : V → V) (h : ∀ v ∈ u, G.Adj v (f v))
     (hinj : u.InjOn f) (hd : Disjoint u (f '' u)) : (Subgraph.ofFunction f h).IsMatching := by
   rw [Set.disjoint_right] at hd
   intro v hv

--- a/Mathlib/Combinatorics/SimpleGraph/Subgraph.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Subgraph.lean
@@ -1152,7 +1152,6 @@ end DeleteVerts
 
 /-! ### Of function -/
 
-
 /-- Given a function, construct the Subgraph where each element is connected
   to its value under the function --/
 @[simps]
@@ -1172,7 +1171,6 @@ def ofFunction {u : Set V} (f : V → V) (h : ∀ v ∈ u, G.Adj v (f v)) : Subg
     · left; exact hv.1
     · right; rw [← hw'.2]
       exact Set.mem_image_of_mem f hw'.1
-
 
 end Subgraph
 

--- a/Mathlib/Combinatorics/SimpleGraph/Subgraph.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Subgraph.lean
@@ -1150,6 +1150,30 @@ theorem deleteVerts_inter_verts_set_right_eq :
 
 end DeleteVerts
 
+/-! ### Of function -/
+
+
+/-- Given a function, construct the Subgraph where each element is connected
+  to its value under the function --/
+@[simps]
+def ofFunction {u : Set V} (f : V → V) (h : ∀ v ∈ u, G.Adj v (f v)) : Subgraph G where
+  verts := u ∪ f '' u
+  Adj v w := v ∈ u ∧ f v = w ∨ w ∈ u ∧ f w = v
+  adj_sub := by
+    intro v w' hvw'
+    cases' hvw' with hv hw'
+    · rw [← hv.2]
+      exact h v hv.1
+    · rw [← hw'.2]
+      exact (h w' hw'.1).symm
+  edge_vert := by
+    intro v w hvw'
+    cases' hvw' with hv hw'
+    · left; exact hv.1
+    · right; rw [← hw'.2]
+      exact Set.mem_image_of_mem f hw'.1
+
+
 end Subgraph
 
 end SimpleGraph


### PR DESCRIPTION
Added subgraph derived from a function. In addition, this is a matching if the function is injective and there is no overlap between the domain and image. This is in preparation to Tutte's theorem

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)

[Zulip thread on Tutte](https://leanprover.zulipchat.com/#narrow/stream/287929-mathlib4/topic/Tutte's.20theorem/near/451831293)