### PR TITLE
shorten proof of `hc` a bit

### DIFF
--- a/Mathlib/FieldTheory/JacobsonNoether.lean
+++ b/Mathlib/FieldTheory/JacobsonNoether.lean
@@ -1,8 +1,8 @@
 /-
-Copyright (c) 2024 Filippo A. E. Nuccio, Huanyu Zheng, Wanyi He, Sihan Wu, Yi Yuan.
+Copyright (c) 2024 Filippo A. E. Nuccio, Huanyu Zheng, Wanyi He, Sihan Wu, Weichen Jiao, Yi Yuan.
 All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Filippo A. E. Nuccio, Huanyu Zheng, Sihan Wu, Wanyi He, Yi Yuan
+Authors: Filippo A. E. Nuccio, Huanyu Zheng, Sihan Wu, Wanyi He, Weichen Jiao, Yi Yuan
 -/
 import Mathlib.RingTheory.Algebraic
 import Mathlib.FieldTheory.Separable
@@ -183,12 +183,9 @@ theorem JacobsonNoether_charP (p : ℕ) [Fact p.Prime] [CharP D p]
   set c := ((δ a) ^ n) b with hc_def
   letI : Invertible c := ⟨c⁻¹, inv_mul_cancel₀ (hb.1), mul_inv_cancel₀ (hb.1)⟩
   have hc : c * a = a * c := by
-    rw [← show (f a) c = a * c by rfl, ← show (g a) c = c * a by rfl, ← zero_add (g a c)]
+    rw [← f_def a c, ← g_def a c, ← zero_add (g a c)]
     apply add_eq_of_eq_add_neg
-    have temp := δ_iterate_succ a b n
-    simp only [δ_def, f_def, g_def] at temp
-    simp only [temp, f_def, g_def, ← sub_eq_add_neg]
-    exact hb.2.symm
+    rw[← sub_eq_add_neg, ← δ_def, hc_def, δ_iterate_succ a b n, hb.2]
   -- We now make some computation to obtain the *absurd* equation `final_eq`, contradiction.
   set d := c⁻¹ * a * (δ a) ^[n-1] b with hd_def
   have hc': c⁻¹ * a = a * c⁻¹ := by


### PR DESCRIPTION
rewrite the proof of `hc` into 3 lines

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
