### PR TITLE
[Merged by Bors] - feat(Algebra/GroupWithZero): MulEquiv between WithZero (units) and the base group with zero

### DIFF
--- a/Mathlib/Algebra/Group/WithOne/Defs.lean
+++ b/Mathlib/Algebra/Group/WithOne/Defs.lean
@@ -112,6 +112,16 @@ def recOneCoe {C : WithOne α → Sort*} (h₁ : C 1) (h₂ : ∀ a : α, C a) :
   | Option.none => h₁
   | Option.some x => h₂ x
 
+@[to_additive (attr := simp)]
+lemma recOneCoe_one {C : WithOne α → Sort*} (h₁ : C 1) (h₂ : ∀ a : α, C a) :
+    recOneCoe h₁ h₂ (1 : WithOne α) = h₁ :=
+  rfl
+
+@[to_additive (attr := simp)]
+lemma recOneCoe_coe {C : WithOne α → Sort*} (h₁ : C 1) (h₂ : ∀ a : α, C a) (a : α) :
+    recOneCoe h₁ h₂ (a : WithOne α) = h₂ a :=
+  rfl
+
 /-- Deconstruct an `x : WithOne α` to the underlying value in `α`, given a proof that `x ≠ 1`. -/
 @[to_additive unzero
       "Deconstruct an `x : WithZero α` to the underlying value in `α`, given a proof that `x ≠ 0`."]

--- a/Mathlib/Algebra/Group/WithOne/Defs.lean
+++ b/Mathlib/Algebra/Group/WithOne/Defs.lean
@@ -113,13 +113,13 @@ def recOneCoe {C : WithOne α → Sort*} (h₁ : C 1) (h₂ : ∀ a : α, C a) :
   | Option.some x => h₂ x
 
 @[to_additive (attr := simp)]
-lemma recOneCoe_one {C : WithOne α → Sort*} (h₁ : C 1) (h₂ : ∀ a : α, C a) :
-    recOneCoe h₁ h₂ (1 : WithOne α) = h₁ :=
+lemma recOneCoe_one {C : WithOne α → Sort*} (h₁ h₂) :
+    recOneCoe h₁ h₂ (1 : WithOne α) = (h₁ : C 1) :=
   rfl
 
 @[to_additive (attr := simp)]
-lemma recOneCoe_coe {C : WithOne α → Sort*} (h₁ : C 1) (h₂ : ∀ a : α, C a) (a : α) :
-    recOneCoe h₁ h₂ (a : WithOne α) = h₂ a :=
+lemma recOneCoe_coe {C : WithOne α → Sort*} (h₁ h₂) (a : α) :
+    recOneCoe h₁ h₂ (a : WithOne α) = (h₂ : ∀ a : α, C a) a :=
   rfl
 
 /-- Deconstruct an `x : WithOne α` to the underlying value in `α`, given a proof that `x ≠ 1`. -/

--- a/Mathlib/Algebra/GroupWithZero/WithZero.lean
+++ b/Mathlib/Algebra/GroupWithZero/WithZero.lean
@@ -266,6 +266,45 @@ def unitsWithZeroEquiv : (WithZero α)ˣ ≃* α where
   right_inv _ := rfl
   map_mul' _ _ := coe_inj.mp <| by simp only [Units.val_mul, coe_unzero, coe_mul]
 
+/-- Any group with zero is isomorphic to adjoining `0` to the units of itself. -/
+def unitsWithZeroMulEquivGroupWithZero (G : Type*) [GroupWithZero G]
+    [DecidablePred (fun a : G ↦ a = 0)] :
+    WithZero Gˣ ≃* G where
+  toFun := WithZero.recZeroCoe 0 Units.val
+  invFun a := if h : a = 0 then 0 else (Units.mk0 a h : Gˣ)
+  left_inv := (by induction · <;> simp)
+  right_inv _ := by simp only; split <;> simp_all
+  map_mul' x y := by
+    induction x <;> induction y <;>
+    simp [← WithZero.coe_mul, ← Units.val_mul]
+
+/-- A version of `Equiv.optionCongr` for `WithZero`. -/
+noncomputable def _root_.MulEquiv.withZeroCongr [Group β] (e : α ≃* β) :
+    WithZero α ≃* WithZero β where
+  toFun := map' e.toMonoidHom
+  invFun := map' e.symm.toMonoidHom
+  left_inv := (by induction · <;> simp)
+  right_inv := (by induction · <;> simp)
+  map_mul' := by
+    intro x y
+    induction x <;> induction y <;>
+    simp
+
+/-- The inverse of `MulEquiv.withZeroCongr`. -/
+noncomputable def _root_.MulEquiv.unzeroCongr [Group β] (e : WithZero α ≃* WithZero β) :
+    α ≃* β where
+  toFun x := unzero (x := e x) (by simp [ne_eq, ← e.eq_symm_apply])
+  invFun x := unzero (x := e.symm x) (by simp [e.symm_apply_eq])
+  left_inv _ := by simp
+  right_inv _ := by simp
+  map_mul' := by
+    intro x y
+    simp only [coe_mul, map_mul]
+    generalize_proofs A B C
+    suffices (((unzero A) : β) : WithZero β) = (unzero B) * (unzero C) by
+      rwa [← WithZero.coe_mul, WithZero.coe_inj] at this
+    simp
+
 end Group
 
 instance commGroupWithZero [CommGroup α] : CommGroupWithZero (WithZero α) :=

--- a/Mathlib/Algebra/GroupWithZero/WithZero.lean
+++ b/Mathlib/Algebra/GroupWithZero/WithZero.lean
@@ -267,7 +267,7 @@ def unitsWithZeroEquiv : (WithZero α)ˣ ≃* α where
   map_mul' _ _ := coe_inj.mp <| by simp only [Units.val_mul, coe_unzero, coe_mul]
 
 /-- Any group with zero is isomorphic to adjoining `0` to the units of itself. -/
-def withZeroUnitsEquiv (G : Type*) [GroupWithZero G]
+def withZeroUnitsEquiv {G : Type*} [GroupWithZero G]
     [DecidablePred (fun a : G ↦ a = 0)] :
     WithZero Gˣ ≃* G where
   toFun := WithZero.recZeroCoe 0 Units.val

--- a/Mathlib/Algebra/GroupWithZero/WithZero.lean
+++ b/Mathlib/Algebra/GroupWithZero/WithZero.lean
@@ -290,18 +290,17 @@ noncomputable def _root_.MulEquiv.withZero [Group β] (e : α ≃* β) :
     induction x <;> induction y <;>
     simp
 
-/-- The inverse of `MulEquiv.withZeroCongr`. -/
+/-- The inverse of `MulEquiv.withZero`. -/
 protected noncomputable def _root_.MulEquiv.unzero [Group β] (e : WithZero α ≃* WithZero β) :
     α ≃* β where
   toFun x := unzero (x := e x) (by simp [ne_eq, ← e.eq_symm_apply])
   invFun x := unzero (x := e.symm x) (by simp [e.symm_apply_eq])
   left_inv _ := by simp
   right_inv _ := by simp
-  map_mul' := by
-    intro x y
+  map_mul' _ _ := by
     simp only [coe_mul, map_mul]
     generalize_proofs A B C
-    suffices (((unzero A) : β) : WithZero β) = (unzero B) * (unzero C) by
+    suffices ((unzero A : β) : WithZero β) = (unzero B) * (unzero C) by
       rwa [← WithZero.coe_mul, WithZero.coe_inj] at this
     simp
 

--- a/Mathlib/Algebra/GroupWithZero/WithZero.lean
+++ b/Mathlib/Algebra/GroupWithZero/WithZero.lean
@@ -285,8 +285,7 @@ noncomputable def _root_.MulEquiv.withZero [Group β] (e : α ≃* β) :
   invFun := map' e.symm.toMonoidHom
   left_inv := (by induction · <;> simp)
   right_inv := (by induction · <;> simp)
-  map_mul' := by
-    intro x y
+  map_mul' x y := by
     induction x <;> induction y <;>
     simp
 

--- a/Mathlib/Algebra/GroupWithZero/WithZero.lean
+++ b/Mathlib/Algebra/GroupWithZero/WithZero.lean
@@ -267,7 +267,7 @@ def unitsWithZeroEquiv : (WithZero α)ˣ ≃* α where
   map_mul' _ _ := coe_inj.mp <| by simp only [Units.val_mul, coe_unzero, coe_mul]
 
 /-- Any group with zero is isomorphic to adjoining `0` to the units of itself. -/
-def unitsWithZeroMulEquivGroupWithZero (G : Type*) [GroupWithZero G]
+def withZeroUnitsEquiv (G : Type*) [GroupWithZero G]
     [DecidablePred (fun a : G ↦ a = 0)] :
     WithZero Gˣ ≃* G where
   toFun := WithZero.recZeroCoe 0 Units.val
@@ -279,7 +279,7 @@ def unitsWithZeroMulEquivGroupWithZero (G : Type*) [GroupWithZero G]
     simp [← WithZero.coe_mul, ← Units.val_mul]
 
 /-- A version of `Equiv.optionCongr` for `WithZero`. -/
-noncomputable def _root_.MulEquiv.withZeroCongr [Group β] (e : α ≃* β) :
+noncomputable def _root_.MulEquiv.withZero [Group β] (e : α ≃* β) :
     WithZero α ≃* WithZero β where
   toFun := map' e.toMonoidHom
   invFun := map' e.symm.toMonoidHom
@@ -291,7 +291,7 @@ noncomputable def _root_.MulEquiv.withZeroCongr [Group β] (e : α ≃* β) :
     simp
 
 /-- The inverse of `MulEquiv.withZeroCongr`. -/
-noncomputable def _root_.MulEquiv.unzeroCongr [Group β] (e : WithZero α ≃* WithZero β) :
+protected noncomputable def _root_.MulEquiv.unzero [Group β] (e : WithZero α ≃* WithZero β) :
     α ≃* β where
   toFun x := unzero (x := e x) (by simp [ne_eq, ← e.eq_symm_apply])
   invFun x := unzero (x := e.symm x) (by simp [e.symm_apply_eq])


### PR DESCRIPTION
Also MulEquivs that add or remove WithZero on both sides 
And some basic WithOne/WithZero API


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
