### PR TITLE
[Merged by Bors] - feat(Algebra/Order/Units): LinearOrderedCommGroup Units

### DIFF
--- a/Mathlib/Algebra/Order/Group/Units.lean
+++ b/Mathlib/Algebra/Order/Group/Units.lean
@@ -25,3 +25,11 @@ instance Units.orderedCommGroup [OrderedCommMonoid α] : OrderedCommGroup αˣ :
 -- Porting note: the mathlib3 proof was
 -- mul_le_mul_left := fun a b h c => (mul_le_mul_left' (h : (a : α) ≤ b) _ : (c : α) * a ≤ c * b) }
 -- see https://leanprover.zulipchat.com/#narrow/stream/287929-mathlib4/topic/elaboration.20failure.20in.20algebra.2Eorder.2Egroup.2Eunits
+
+/-- The units of a linearly ordered commutative monoid form a linearly ordered commutative group. -/
+@[to_additive "The units of a linearly ordered commutative additive monoid form a
+linearly ordered commutative additive group."]
+instance Units.instLinearOrderedCommGroup [LinearOrderedCommMonoid α] :
+    LinearOrderedCommGroup αˣ where
+  __ := Units.instLinearOrder
+  __ := Units.orderedCommGroup


### PR DESCRIPTION
When ambient monoid is LinearOrderedCommMonoid

Thus supporting LinearOrderedCommGroupWithZero too

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
