### PR TITLE
[Merged by Bors] - fix: generalize basis_finite_of_finite_spans to semirings

### DIFF
--- a/Mathlib/LinearAlgebra/Basis/Cardinality.lean
+++ b/Mathlib/LinearAlgebra/Basis/Cardinality.lean
@@ -3,7 +3,8 @@ Copyright (c) 2017 Johannes Hölzl. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johannes Hölzl, Mario Carneiro, Alexander Bentkamp, Kim Morrison
 -/
-import Mathlib.LinearAlgebra.Basis.Basic
+import Mathlib.LinearAlgebra.Basis.Defs
+import Mathlib.LinearAlgebra.LinearIndependent
 import Mathlib.SetTheory.Cardinal.Cofinality
 
 /-!
@@ -14,11 +15,13 @@ section Finite
 
 open Basis Cardinal Set Submodule Finsupp
 
-universe u v v' v'' u₁' w w'
+universe u v w w'
 
-variable {R : Type u} {M M₁ : Type v} {M' : Type v'} {ι : Type w}
-variable [Ring R] [AddCommGroup M] [AddCommGroup M'] [AddCommGroup M₁] [Nontrivial R]
-variable [Module R M] [Module R M'] [Module R M₁]
+variable {R : Type u} {M : Type v}
+
+section Semiring
+
+variable [Semiring R] [AddCommGroup M] [Nontrivial R] [Module R M]
 
 -- One might hope that a finite spanning set implies that any linearly independent set is finite.
 -- While this is true over a division ring
@@ -63,7 +66,14 @@ lemma basis_finite_of_finite_spans (w : Set M) (hw : w.Finite) (s : span R w = �
     rw [k]
     exact mem_top
   -- giving the desire contradiction.
-  exact b.linearIndependent.not_mem_span_image nm k'
+  simp only [self_mem_span_image, Finset.mem_coe, bS] at k'
+  exact nm k'
+
+end Semiring
+
+section Ring
+
+variable [Ring R] [AddCommGroup M] [Nontrivial R] [Module R M]
 
 -- From [Les familles libres maximales d'un module ont-elles le meme cardinal?][lazarus1973]
 /-- Over any ring `R`, if `b` is a basis for a module `M`,
@@ -152,5 +162,7 @@ then the cardinality of `b` is bounded by the cardinality of `s`.
 theorem infinite_basis_le_maximal_linearIndependent {ι : Type w} (b : Basis ι R M) [Infinite ι]
     {κ : Type w} (v : κ → M) (i : LinearIndependent R v) (m : i.Maximal) : #ι ≤ #κ :=
   Cardinal.lift_le.mp (infinite_basis_le_maximal_linearIndependent' b v i m)
+
+end Ring
 
 end Finite


### PR DESCRIPTION
Also remove some unused variables.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
