### PR TITLE
feat: Ore localization of a commutative algebra is an algebra.

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -3925,6 +3925,7 @@ import Mathlib.RingTheory.Norm.Basic
 import Mathlib.RingTheory.Norm.Defs
 import Mathlib.RingTheory.NormTrace
 import Mathlib.RingTheory.Nullstellensatz
+import Mathlib.RingTheory.OreLocalization.Algebra
 import Mathlib.RingTheory.OreLocalization.Basic
 import Mathlib.RingTheory.OreLocalization.OreSet
 import Mathlib.RingTheory.OreLocalization.Ring

--- a/Mathlib/GroupTheory/MonoidLocalization/Basic.lean
+++ b/Mathlib/GroupTheory/MonoidLocalization/Basic.lean
@@ -252,7 +252,6 @@ def recOnSubsingleton₂ {r : Localization S → Localization S → Sort u}
 theorem mk_mul (a c : M) (b d : S) : mk a b * mk c d = mk (a * c) (b * d) :=
   mul_comm b d ▸ OreLocalization.oreDiv_mul_oreDiv
 
-unseal OreLocalization.one in
 @[to_additive]
 theorem mk_one : mk 1 (1 : S) = 1 := OreLocalization.one_def
 

--- a/Mathlib/RingTheory/OreLocalization/Algebra.lean
+++ b/Mathlib/RingTheory/OreLocalization/Algebra.lean
@@ -209,19 +209,33 @@ def algebra : Algebra (R[S⁻¹]) (A[S⁻¹]) where
       OneHom.coe_mk, liftExpand_of, RingHom.coe_mk, MonoidHom.coe_mk,
       OreLocalization.smul_def, Algebra.smul_def, OreLocalization.mul_def]
 
+attribute [ext] Algebra
+
 -- If `algebra` were an instance then this would be a diamond:
-/-
 example : (algebra R R S : Algebra R[S⁻¹] R[S⁻¹]) =
-    (inferInstance : Algebra R[S⁻¹] R[S⁻¹]) := rfl -- fails
+    (inferInstance : Algebra R[S⁻¹] R[S⁻¹]) := by
+  apply Algebra.ext
+  · rfl
+  · ext rs
+    unfold OneHom.toFun
+    dsimp
+    unfold Algebra.toRingHom
+    unfold algebra
+    unfold inferInstance
+    dsimp
+    unfold Algebra.id oreDiv
+    dsimp
+    unfold liftExpand
+    dsimp
+    cases rs
+    rfl
 
 -- how far is this from `rfl`?
 example : (algebra R R S : Algebra R[S⁻¹] R[S⁻¹]) =
     (inferInstance : Algebra R[S⁻¹] R[S⁻¹]) := by
   refine Algebra.algebra_ext (algebra R R S) inferInstance fun r ↦ ?_
-  refine Quotient.inductionOn r ?_
-  rintro ⟨r, s⟩
+  refine Quotient.inductionOn r fun rs ↦ ?_
   rfl
--/
 
 end Algebra
 

--- a/Mathlib/RingTheory/OreLocalization/Algebra.lean
+++ b/Mathlib/RingTheory/OreLocalization/Algebra.lean
@@ -45,25 +45,15 @@ private def mul''
 protected def mul : A[S⁻¹] → A[S⁻¹] → A[S⁻¹] :=
   liftExpand mul'' fun a₁ r₁ s hs => by
   obtain ⟨s₁, hs₁⟩ := s
-  simp only at hs
-  unfold OreLocalization.mul''
-  simp
-  unfold OreLocalization.mul'
-  dsimp
+  unfold OreLocalization.mul'' OreLocalization.mul'
   ext sa
-  induction sa
-  rename_i a s_temp
+  induction' sa with a s_temp
   obtain ⟨s, hs⟩ := s_temp
-  rw [liftExpand_of]
-  rw [liftExpand_of]
-  rw [oreDiv_eq_iff]
-  simp only [Submonoid.mk_smul, Submonoid.coe_mul]
+  simp only [liftExpand_of, oreDiv_eq_iff, Submonoid.mk_smul, Submonoid.coe_mul]
   use ⟨s₁, hs₁⟩, r₁ * s₁
   simp only [Submonoid.mk_smul, Submonoid.coe_mul]
   constructor
-  · rw [smul_mul_assoc]
-    rw [← mul_smul]
-    rw [mul_comm]
+  · rw [smul_mul_assoc, ← mul_smul, mul_comm]
   · repeat rw [mul_assoc]
     repeat rw [mul_left_comm s₁]
     rw [mul_left_comm s]

--- a/Mathlib/RingTheory/OreLocalization/Algebra.lean
+++ b/Mathlib/RingTheory/OreLocalization/Algebra.lean
@@ -170,7 +170,7 @@ section Algebra
 variable (R A : Type*) [cR : CommSemiring R] [cA : CommSemiring A] [cRA : Algebra R A]
     (S : Submonoid R)
 
-/-
+/--
 The `R[S⁻¹]`-algebra structure on `A[S⁻¹]` induced by the `R`-algebra
 structure on `A`.
 -/

--- a/Mathlib/RingTheory/OreLocalization/Algebra.lean
+++ b/Mathlib/RingTheory/OreLocalization/Algebra.lean
@@ -3,8 +3,8 @@ Copyright (c) 2024 Kevin Buzzard. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Kevin Buzzard
 -/
-import Mathlib.RingTheory.OreLocalization.Ring
-
+import Mathlib.Algebra.Algebra.Defs
+import Mathlib.RingTheory.OreLocalization.Basic
 /-!
 
 # Algebra instances of Ore Localizations

--- a/Mathlib/RingTheory/OreLocalization/Algebra.lean
+++ b/Mathlib/RingTheory/OreLocalization/Algebra.lean
@@ -41,7 +41,11 @@ private def mul''
   · obtain ⟨s₂, hs₂⟩ := s
     simpa only [Submonoid.mk_smul, Submonoid.coe_mul] using mul_left_comm s₁ (r₁ * s₁) s₂
 
-@[to_additive]
+/-- The multiplication on `A[S⁻¹]` induced from the multiplication on `A`.
+-/
+@[to_additive
+  "The addition on `AddOreLocalization S A` induced from the
+  addition on `A`."]
 protected def mul : A[S⁻¹] → A[S⁻¹] → A[S⁻¹] :=
   liftExpand mul'' fun a₁ r₁ s hs => by
   obtain ⟨s₁, hs₁⟩ := s
@@ -61,7 +65,7 @@ protected def mul : A[S⁻¹] → A[S⁻¹] → A[S⁻¹] :=
 instance : Mul (A[S⁻¹]) where
   mul := OreLocalization.mul
 
-protected def mul_def (a : A) (s : { x // x ∈ S }) (b : A) (t : { x // x ∈ S }) :
+protected lemma mul_def (a : A) (s : { x // x ∈ S }) (b : A) (t : { x // x ∈ S }) :
     a /ₒ s * (b /ₒ t) = a * b /ₒ (t * s) := rfl
 
 -- no diamond
@@ -166,6 +170,10 @@ section Algebra
 variable (R A : Type*) [cR : CommSemiring R] [cA : CommSemiring A] [cRA : Algebra R A]
     (S : Submonoid R)
 
+/-
+The `R[S⁻¹]`-algebra structure on `A[S⁻¹]` induced by the `R`-algebra
+structure on `A`.
+-/
 def algebra : Algebra (R[S⁻¹]) (A[S⁻¹]) where
   toFun := liftExpand (fun r s ↦ (algebraMap R A r) /ₒ s) fun r₁ r₂ s hs => by
     rw [oreDiv_eq_iff]

--- a/Mathlib/RingTheory/OreLocalization/Algebra.lean
+++ b/Mathlib/RingTheory/OreLocalization/Algebra.lean
@@ -1,0 +1,226 @@
+import Mathlib.RingTheory.OreLocalization.Ring
+--import Mathlib -- just in case, when developing
+
+/-!
+
+# Algebra instances of Ore Localizations
+
+If `R` is a commutative ring with submonoid `S`, and if `A` is a commutative `R`-algebra,
+then my guess is that `A[S⁻¹]` is an `R[S⁻¹]`-algebra. Let's see if I'm right and if so,
+in what generality.
+
+-/
+
+namespace OreLocalization
+
+section CommMagma
+
+variable {R A : Type*} [CommMonoid R] [CommMagma A] [MulAction R A] [IsScalarTower R A A]
+  {S : Submonoid R}
+
+@[to_additive]
+private def mul' (a₁ : A) (s₁ : S) (a₂ : A) (s₂ : S) : A[S⁻¹] :=
+  a₁ * a₂ /ₒ (s₂ * s₁)
+
+@[to_additive]
+private def mul''
+  (a : A) (s : S) : A[S⁻¹] → A[S⁻¹] :=
+  liftExpand (mul' a s) fun a₁ r₁ ⟨s₁, hs₁⟩ hr₁s₁ => by
+  unfold OreLocalization.mul'
+  simp only at hr₁s₁ ⊢
+  rw [oreDiv_eq_iff]
+  use ⟨s₁, hs₁⟩, r₁ * s₁
+  simp only [Submonoid.mk_smul, Submonoid.coe_mul]
+  constructor
+  · rw [← smul_mul_assoc]
+    rw [← smul_mul_assoc]
+    rw [mul_comm]
+    rw [smul_mul_assoc, smul_mul_assoc]
+    rw [mul_comm]
+    -- it's like a bloody Rubik's cube
+    rw [smul_mul_assoc]
+    rw [← mul_smul]
+  · obtain ⟨s₂, hs₂⟩ := s
+    simpa only [Submonoid.mk_smul, Submonoid.coe_mul] using mul_left_comm s₁ (r₁ * s₁) s₂
+
+@[to_additive]
+protected def mul : A[S⁻¹] → A[S⁻¹] → A[S⁻¹] :=
+  liftExpand mul'' fun a₁ r₁ s hs => by
+  obtain ⟨s₁, hs₁⟩ := s
+  simp only at hs
+  unfold OreLocalization.mul''
+  simp
+  unfold OreLocalization.mul'
+  dsimp
+  ext sa
+  induction sa
+  rename_i a s_temp
+  obtain ⟨s, hs⟩ := s_temp
+  rw [liftExpand_of]
+  rw [liftExpand_of]
+  rw [oreDiv_eq_iff]
+  simp only [Submonoid.mk_smul, Submonoid.coe_mul]
+  use ⟨s₁, hs₁⟩, r₁ * s₁
+  simp only [Submonoid.mk_smul, Submonoid.coe_mul]
+  constructor
+  · rw [smul_mul_assoc]
+    rw [← mul_smul]
+    rw [mul_comm]
+  · repeat rw [mul_assoc]
+    repeat rw [mul_left_comm s₁]
+    rw [mul_left_comm s]
+
+instance : Mul (A[S⁻¹]) where
+  mul := OreLocalization.mul
+
+protected def mul_def (a : A) (s : { x // x ∈ S }) (b : A) (t : { x // x ∈ S }) :
+  a /ₒ s * (b /ₒ t) = a * b /ₒ (t * s) := rfl
+
+-- no diamond
+example (as bt : R[S⁻¹]) : as * bt = as • bt := rfl
+
+end CommMagma
+
+section One
+
+variable {R A : Type*} [CommMonoid R] [MulAction R A] [One A] {S : Submonoid R}
+
+instance instOne' : One (A[S⁻¹]) where
+  one := 1 /ₒ 1
+
+protected theorem one_def' : (1 : A[S⁻¹]) = 1 /ₒ 1 := rfl
+
+end One
+
+section CommMonoid
+
+variable {R A : Type*} [CommMonoid R] [CommMonoid A] [MulAction R A] [IsScalarTower R A A]
+  {S : Submonoid R}
+
+instance commMonoid' : CommMonoid (A[S⁻¹]) where
+  mul_assoc a b c := by
+    induction' a with a
+    induction' b with b
+    induction' c with c
+    change (a * b * c) /ₒ _ = (a * (b * c)) /ₒ _
+    simp [mul_assoc]
+  one_mul a := by
+    induction' a with a
+    change (1 * a) /ₒ _ = a /ₒ _
+    simp
+  mul_one a := by
+    induction' a with a s
+    simp [OreLocalization.mul_def, OreLocalization.one_def']
+  mul_comm a b := by
+    induction' a with a
+    induction' b with b
+    simp only [OreLocalization.mul_def, mul_comm]
+
+end CommMonoid
+
+section CommSemiring
+
+variable {R A : Type*} [CommMonoid R] [CommSemiring A] [DistribMulAction R A] [IsScalarTower R A A]
+  {S : Submonoid R}
+
+theorem left_distrib' (a b c : A[S⁻¹]) :
+    a * (b + c) = a * b + a * c := by
+  induction' a with a r
+  induction' b with b s
+  induction' c with c t
+  rcases oreDivAddChar' b c s t with ⟨r₁, s₁, h₁, q⟩; rw [q]; clear q
+  simp only [OreLocalization.mul_def]
+  rcases oreDivAddChar' (a * b) (a * c) (s * r) (t * r) with ⟨r₂, s₂, h₂, q⟩; rw [q]; clear q
+  rw [oreDiv_eq_iff]
+  obtain ⟨r, hr⟩ := r
+  obtain ⟨s, hs⟩ := s
+  obtain ⟨t, ht⟩ := t
+  obtain ⟨s₁, hs₁⟩ := s₁
+  obtain ⟨s₂, hs₂⟩ := s₂
+  simp only [Submonoid.mk_smul, Submonoid.coe_mul] at h₁ h₂ ⊢
+  sorry
+  --use ⟨?_, ?_⟩, ?_
+  --constructor
+  --· simp
+  --  sorry
+  --· sorry
+
+instance instCommSemiring' : CommSemiring A[S⁻¹] where
+  __ := commMonoid'
+  left_distrib := left_distrib'
+  right_distrib a b c := by
+    rw [mul_comm, mul_comm a, mul_comm b, left_distrib']
+  zero_mul a := by
+    induction' a with a s
+    rw [OreLocalization.zero_def, OreLocalization.mul_def, zero_mul,
+      mul_one, zero_oreDiv, zero_oreDiv]
+  mul_zero a := by
+    induction' a with a s
+    rw [OreLocalization.zero_def, OreLocalization.mul_def, mul_zero,
+      one_mul, zero_oreDiv, zero_oreDiv]
+
+end CommSemiring
+
+section Algebra
+
+variable {R A : Type} [cR : CommSemiring R] [cA : CommSemiring A] [cRA : Algebra R A]
+    {S : Submonoid R}
+-- **TODO** `A[S⁻¹]` prettyprints as `OreLocalization S A`
+
+private abbrev to_fun' (r : R) (s : S) : A[S⁻¹] :=
+  (algebraMap R A r) /ₒ s
+
+-- simplfication of `oreDiv_add_oreDiv` in the commutative case
+theorem add_def {r r' : A} {s s' : S} :
+    r /ₒ s + r' /ₒ s' =
+      (s' • r + (s : R) • r') /ₒ (s' * s) := by
+  with_unfolding_all rfl
+
+-- simplification of oreDiv_smul_oreDiv in comm case
+theorem smul_def {r₁ : R} {r₂ : A} {s₁ s₂ : S} :
+    (r₁ /ₒ s₁) • (r₂ /ₒ s₂) = r₁ • r₂ /ₒ (s₂ * s₁) := rfl
+
+instance : Algebra (R[S⁻¹]) (A[S⁻¹]) where
+  toFun := liftExpand to_fun' fun r₁ r₂ s hs => by
+    rw [oreDiv_eq_iff]
+    use s, r₂ * s
+    rw [smul_eq_mul, map_mul]
+    obtain ⟨s, hs⟩ := s
+    simp only [Submonoid.mk_smul] at hs ⊢
+    refine ⟨?_, mul_comm s (r₂ * s)⟩
+    rw [← smul_mul_assoc]
+    rw [Algebra.algebraMap_eq_smul_one r₂, smul_smul, mul_comm s]
+    simp only [smul_mul_assoc, one_mul]
+  map_one' := by
+    unfold OreLocalization.to_fun'
+    simp [OreLocalization.one_def', liftExpand_of]
+  map_mul' a b := by
+    induction' a with a s
+    induction' b with b t
+    simp only [OreLocalization.mul_def, liftExpand_of, OreLocalization.to_fun', map_mul]
+  map_zero' := by
+    unfold OreLocalization.to_fun'
+    simp only [OreLocalization.zero_def, liftExpand_of]
+    simp only [map_zero, zero_oreDiv]
+  map_add' r₁ r₂ := by
+    induction' r₁ with r₁ s₁
+    induction' r₂ with r₂ s2
+    dsimp
+    unfold OreLocalization.to_fun'
+    simp [add_def, add_def, liftExpand_of, map_add, algebraMap.coe_smul, Algebra.smul_def]
+  commutes' r₁ r₂ := by
+    induction' r₁ with r₁ s₁
+    induction' r₂ with r₂ s₂
+    dsimp
+    unfold OreLocalization.to_fun'
+    simp only [OreLocalization.mul_def, mul_comm]
+  smul_def' r a := by
+    induction' r with r s
+    induction' a with a t
+    dsimp
+    unfold OreLocalization.to_fun'
+    simp only [OreLocalization.smul_def, Algebra.smul_def, OreLocalization.mul_def]
+
+end Algebra
+
+end OreLocalization

--- a/Mathlib/RingTheory/OreLocalization/Algebra.lean
+++ b/Mathlib/RingTheory/OreLocalization/Algebra.lean
@@ -163,10 +163,10 @@ end CommSemiring
 
 section Algebra
 
-variable {R A : Type} [cR : CommSemiring R] [cA : CommSemiring A] [cRA : Algebra R A]
-    {S : Submonoid R}
+variable (R A : Type*) [cR : CommSemiring R] [cA : CommSemiring A] [cRA : Algebra R A]
+    (S : Submonoid R)
 
-instance : Algebra (R[S⁻¹]) (A[S⁻¹]) where
+def instAlgebra' : Algebra (R[S⁻¹]) (A[S⁻¹]) where
   toFun := liftExpand (fun r s ↦ (algebraMap R A r) /ₒ s) fun r₁ r₂ s hs => by
     rw [oreDiv_eq_iff]
     use s, r₂ * s
@@ -200,6 +200,10 @@ instance : Algebra (R[S⁻¹]) (A[S⁻¹]) where
     simp only [smul_eq_mul, id_eq, Submonoid.mk_smul, eq_mpr_eq_cast, cast_eq, OneHom.toFun_eq_coe,
       OneHom.coe_mk, liftExpand_of, RingHom.coe_mk, MonoidHom.coe_mk,
       OreLocalization.smul_def, Algebra.smul_def, OreLocalization.mul_def]
+
+-- this would be a diamond if `instAlgebra'` were an instance
+--example : (instAlgebra' R R S : Algebra R[S⁻¹] R[S⁻¹]) =
+--  (inferInstance : Algebra R[S⁻¹] R[S⁻¹]) := rfl
 
 end Algebra
 

--- a/Mathlib/RingTheory/OreLocalization/Algebra.lean
+++ b/Mathlib/RingTheory/OreLocalization/Algebra.lean
@@ -62,7 +62,7 @@ instance : Mul (A[S⁻¹]) where
   mul := OreLocalization.mul
 
 protected def mul_def (a : A) (s : { x // x ∈ S }) (b : A) (t : { x // x ∈ S }) :
-  a /ₒ s * (b /ₒ t) = a * b /ₒ (t * s) := rfl
+    a /ₒ s * (b /ₒ t) = a * b /ₒ (t * s) := rfl
 
 -- no diamond
 example (as bt : R[S⁻¹]) : as * bt = as • bt := rfl

--- a/Mathlib/RingTheory/OreLocalization/Basic.lean
+++ b/Mathlib/RingTheory/OreLocalization/Basic.lean
@@ -883,10 +883,8 @@ protected theorem neg_add_cancel (x : X[S⁻¹]) : -x + x = 0 := by
   induction' x with r s; simp
 
 /-- `zsmul` of `OreLocalization` -/
-@[irreducible]
 protected def zsmul : ℤ → X[S⁻¹] → X[S⁻¹] := zsmulRec
 
-unseal OreLocalization.zsmul in
 instance instAddGroupOreLocalization : AddGroup X[S⁻¹] where
   neg_add_cancel := OreLocalization.neg_add_cancel
   zsmul := OreLocalization.zsmul

--- a/Mathlib/RingTheory/OreLocalization/Basic.lean
+++ b/Mathlib/RingTheory/OreLocalization/Basic.lean
@@ -865,7 +865,6 @@ variable {R : Type*} [Monoid R] {S : Submonoid R} [OreSet S]
 variable {X : Type*} [AddGroup X] [DistribMulAction R X]
 
 /-- Negation on the Ore localization is defined via negation on the numerator. -/
-@[irreducible]
 protected def neg : X[S⁻¹] → X[S⁻¹] :=
   liftExpand (fun (r : X) (s : S) => -r /ₒ s) fun r t s ht => by
     -- Porting note(#12129): additional beta reduction needed

--- a/Mathlib/RingTheory/OreLocalization/Basic.lean
+++ b/Mathlib/RingTheory/OreLocalization/Basic.lean
@@ -281,7 +281,7 @@ theorem oreDiv_smul_oreDiv {r₁ : R} {r₂ : X} {s₁ s₂ : S} :
 
 -- a variant of `oreDiv_smul_oreDiv` valid for `R` commutative
 theorem smul_def {R : Type*} [CommMonoid R] {S : Submonoid R} {A : Type*}
-  [MulAction R A] {r : R} {a : A} {s₁ s₂ : S} :
+    [MulAction R A] {r : R} {a : A} {s₁ s₂ : S} :
     (r /ₒ s₁) • (a /ₒ s₂) = r • a /ₒ (s₂ * s₁) := rfl
 
 @[to_additive]

--- a/Mathlib/RingTheory/OreLocalization/Basic.lean
+++ b/Mathlib/RingTheory/OreLocalization/Basic.lean
@@ -279,6 +279,11 @@ theorem oreDiv_smul_oreDiv {r₁ : R} {r₂ : X} {s₁ s₂ : S} :
     (r₁ /ₒ s₁) • (r₂ /ₒ s₂) = oreNum r₁ s₂ • r₂ /ₒ (oreDenom r₁ s₂ * s₁) := by
   with_unfolding_all rfl
 
+-- a variant of `oreDiv_smul_oreDiv` valid for `R` commutative
+theorem smul_def {R : Type*} [CommMonoid R] {S : Submonoid R} {A : Type*}
+  [MulAction R A] {r : R} {a : A} {s₁ s₂ : S} :
+    (r /ₒ s₁) • (a /ₒ s₂) = r • a /ₒ (s₂ * s₁) := rfl
+
 @[to_additive]
 theorem oreDiv_mul_oreDiv {r₁ : R} {r₂ : R} {s₁ s₂ : S} :
     (r₁ /ₒ s₁) * (r₂ /ₒ s₂) = oreNum r₁ s₂ * r₂ /ₒ (oreDenom r₁ s₂ * s₁) := by
@@ -761,6 +766,13 @@ def oreDivAddChar' (r r' : X) (s s' : S) :
     Σ'r'' : R,
       Σ's'' : S, s'' * s = r'' * s' ∧ r /ₒ s + r' /ₒ s' = (s'' • r + r'' • r') /ₒ (s'' * s) :=
   ⟨oreNum (s : R) s', oreDenom (s : R) s', ore_eq (s : R) s', oreDiv_add_oreDiv⟩
+
+-- simplification of `oreDiv_add_oreDiv` in the commutative case
+theorem add_def {R : Type*} [CommMonoid R] {S : Submonoid R} {A : Type*}
+  [AddMonoid A] [DistribMulAction R A] {r r' : A} {s s' : S} :
+    r /ₒ s + r' /ₒ s' =
+      (s' • r + (s : R) • r') /ₒ (s' * s) := by
+  with_unfolding_all rfl
 
 @[simp]
 theorem add_oreDiv {r r' : X} {s : S} : r /ₒ s + r' /ₒ s = (r + r') /ₒ s := by

--- a/Mathlib/RingTheory/OreLocalization/Basic.lean
+++ b/Mathlib/RingTheory/OreLocalization/Basic.lean
@@ -769,7 +769,7 @@ def oreDivAddChar' (r r' : X) (s s' : S) :
 
 -- simplification of `oreDiv_add_oreDiv` in the commutative case
 theorem add_def {R : Type*} [CommMonoid R] {S : Submonoid R} {A : Type*}
-  [AddMonoid A] [DistribMulAction R A] {r r' : A} {s s' : S} :
+    [AddMonoid A] [DistribMulAction R A] {r r' : A} {s s' : S} :
     r /ₒ s + r' /ₒ s' =
       (s' • r + (s : R) • r') /ₒ (s' * s) := by
   with_unfolding_all rfl

--- a/Mathlib/RingTheory/OreLocalization/Basic.lean
+++ b/Mathlib/RingTheory/OreLocalization/Basic.lean
@@ -524,7 +524,7 @@ variable [SMul R' X] [SMul R' M] [IsScalarTower R' M M] [IsScalarTower R' M X]
 variable [SMul R R'] [IsScalarTower R R' M]
 
 /-- Scalar multiplication in a monoid localization. -/
-@[to_additive (attr := irreducible) "Vector addition in an additive monoid localization."]
+@[to_additive "Vector addition in an additive monoid localization."]
 protected def hsmul (c : R) :
     X[S⁻¹] → X[S⁻¹] :=
   liftExpand (fun m s ↦ oreNum (c • 1) s • m /ₒ oreDenom (c • 1) s) (fun r t s ht ↦ by
@@ -629,7 +629,6 @@ variable [MulAction R X]
 
 
 /-- `0` in the localization, defined as `0 /ₒ 1`. -/
-@[irreducible]
 protected def zero : X[S⁻¹] := 0 /ₒ 1
 
 instance : Zero X[S⁻¹] :=
@@ -721,7 +720,6 @@ private def add' (r₂ : X) (s₂ : S) : X[S⁻¹] → X[S⁻¹] :=
     rw [this, hc, mul_assoc]
 
 /-- The addition on the Ore localization. -/
-@[irreducible]
 private def add : X[S⁻¹] → X[S⁻¹] → X[S⁻¹] := fun x =>
   Quotient.lift (fun rs : X × S => add' rs.1 rs.2 x)
     (by

--- a/Mathlib/RingTheory/OreLocalization/Basic.lean
+++ b/Mathlib/RingTheory/OreLocalization/Basic.lean
@@ -242,7 +242,7 @@ private def smul'' (r : R) (s : S) : X[S⁻¹] → X[S⁻¹] :=
     rw [mul_assoc (s₄' : R), h₃, ← mul_assoc]
 
 /-- The scalar multiplication on the Ore localization of monoids. -/
-@[to_additive (attr := irreducible)
+@[to_additive
   "the vector addition on the Ore localization of additive monoids."]
 protected def smul : R[S⁻¹] → X[S⁻¹] → X[S⁻¹] :=
   liftExpand smul'' fun r₁ r₂ s hs => by
@@ -317,7 +317,7 @@ def oreDivMulChar' (r₁ r₂ : R) (s₁ s₂ : S) :
   ⟨oreNum r₁ s₂, oreDenom r₁ s₂, ore_eq r₁ s₂, oreDiv_mul_oreDiv⟩
 
 /-- `1` in the localization, defined as `1 /ₒ 1`. -/
-@[to_additive (attr := irreducible) "`0` in the additive localization, defined as `0 -ₒ 0`."]
+@[to_additive "`0` in the additive localization, defined as `0 -ₒ 0`."]
 protected def one : R[S⁻¹] := 1 /ₒ 1
 
 @[to_additive]
@@ -375,10 +375,9 @@ protected theorem mul_assoc (x y z : R[S⁻¹]) : x * y * z = x * (y * z) :=
   OreLocalization.mul_smul x y z
 
 /-- `npow` of `OreLocalization` -/
-@[to_additive (attr := irreducible) "`nsmul` of `AddOreLocalization`"]
+@[to_additive "`nsmul` of `AddOreLocalization`"]
 protected def npow : ℕ → R[S⁻¹] → R[S⁻¹] := npowRec
 
-unseal OreLocalization.npow in
 @[to_additive]
 instance : Monoid R[S⁻¹] where
   one_mul := OreLocalization.one_mul

--- a/Mathlib/RingTheory/OreLocalization/Basic.lean
+++ b/Mathlib/RingTheory/OreLocalization/Basic.lean
@@ -803,7 +803,6 @@ protected theorem add_zero (x : X[S⁻¹]) : x + 0 = x := by
   induction x
   rw [← zero_oreDiv, add_oreDiv]; simp
 
-@[irreducible]
 private def nsmul : ℕ → X[S⁻¹] → X[S⁻¹] := nsmulRec
 
 instance : AddMonoid X[S⁻¹] where

--- a/Mathlib/RingTheory/OreLocalization/Ring.lean
+++ b/Mathlib/RingTheory/OreLocalization/Ring.lean
@@ -231,7 +231,6 @@ variable [NoZeroDivisors R]
 open Classical in
 /-- The inversion of Ore fractions for a ring without zero divisors, satisfying `0⁻¹ = 0` and
 `(r /ₒ r')⁻¹ = r' /ₒ r` for `r ≠ 0`. -/
-@[irreducible]
 protected def inv : R[R⁰⁻¹] → R[R⁰⁻¹] :=
   liftExpand
     (fun r s =>


### PR DESCRIPTION
If A is a commutative R-algebra and S is a submonoid of R then A[1/S] is an R[1/S]-algebra. The structure morphism R[1/S] -> A[1/S] is defined using a lifting property, and in particular if `A = R` it turns out to be not defeq to `algebra.id R`, so I've not made it an instance. In a proof I'm about to embark on, I'll probably be switching it on locally.

To avoid diamonds, I've had to remove the irreducibility tag from `OreLocalization.smul` , `OreLocalization.one` and `OreLocalization.npow`. This change seems to make the code base cleaner (I removed some `unseal`s and added no `seal`s), so I removed all the other ones as well. This has resulted in a slowdown in one file upstream; I isolate the problem in #16746 . 

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
