### PR TITLE
[Merged by Bors] - chore: add custom message for long lines containing `"`

### DIFF
--- a/Mathlib/Tactic/Linter/Lint.lean
+++ b/Mathlib/Tactic/Linter/Lint.lean
@@ -408,8 +408,8 @@ def longLineLinter : Linter where run := withSetOptionIn fun stx ↦ do
       if (line.splitOn "http").length ≤ 1 then
         let stringMsg := if line.contains '"' then
           "\nYou can use \"string gaps\" to format long strings: within a string quotation, \
-          using a '\' at the end of a line allows you to continue the string on the following line, removing all \
-          intervening whitespace."
+          using a '\' at the end of a line allows you to continue the string on the following \
+          line, removing all intervening whitespace."
         else ""
         Linter.logLint linter.style.longLine (.ofRange ⟨line.startPos, line.stopPos⟩)
           m!"This line exceeds the 100 character limit, please shorten it!{stringMsg}"

--- a/Mathlib/Tactic/Linter/Lint.lean
+++ b/Mathlib/Tactic/Linter/Lint.lean
@@ -407,13 +407,12 @@ def longLineLinter : Linter where run := withSetOptionIn fun stx ↦ do
     for line in longLines do
       if (line.splitOn "http").length ≤ 1 then
         let stringMsg := if line.contains '"' then
-          "\nYou can use \"string gaps\" to format long string: within a string quotation, \
-          using a '\' allows you to continue the string on the following line, removing all \
+          "\nYou can use \"string gaps\" to format long strings: within a string quotation, \
+          using a '\' at the end of a line allows you to continue the string on the following line, removing all \
           intervening whitespace."
         else ""
         Linter.logLint linter.style.longLine (.ofRange ⟨line.startPos, line.stopPos⟩)
           m!"This line exceeds the 100 character limit, please shorten it!{stringMsg}"
-#check "String"
 initialize addLinter longLineLinter
 
 end Style.longLine

--- a/Mathlib/Tactic/Linter/Lint.lean
+++ b/Mathlib/Tactic/Linter/Lint.lean
@@ -406,9 +406,14 @@ def longLineLinter : Linter where run := withSetOptionIn fun stx ↦ do
       (100 < (fm.toPosition line.stopPos).column)
     for line in longLines do
       if (line.splitOn "http").length ≤ 1 then
+        let stringMsg := if line.contains '"' then
+          "\nYou can use \"string gaps\" to format long string: within a string quotation, \
+          using a '\' allows you to continue the string on the following line, removing all \
+          intervening whitespace."
+        else ""
         Linter.logLint linter.style.longLine (.ofRange ⟨line.startPos, line.stopPos⟩)
-          m!"This line exceeds the 100 character limit, please shorten it!"
-
+          m!"This line exceeds the 100 character limit, please shorten it!{stringMsg}"
+#check "String"
 initialize addLinter longLineLinter
 
 end Style.longLine

--- a/test/Lint.lean
+++ b/test/Lint.lean
@@ -288,7 +288,7 @@ info: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20,
 info: "                              \"                                                            " : String
 ---
 warning: This line exceeds the 100 character limit, please shorten it!
-You can use "string gaps" to format long string: within a string quotation, using a '' allows you to continue the string on the following line, removing all intervening whitespace.
+You can use "string gaps" to format long strings: within a string quotation, using a '' at the end of a line allows you to continue the string on the following line, removing all intervening whitespace.
 note: this linter can be disabled with `set_option linter.style.longLine false`
 -/
 #guard_msgs in

--- a/test/Lint.lean
+++ b/test/Lint.lean
@@ -284,6 +284,17 @@ info: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20,
 #guard_msgs in
 #eval List.range 27
 
+/--
+info: "                              \"                                                            " : String
+---
+warning: This line exceeds the 100 character limit, please shorten it!
+You can use "string gaps" to format long string: within a string quotation, using a '' allows you to continue the string on the following line, removing all intervening whitespace.
+note: this linter can be disabled with `set_option linter.style.longLine false`
+-/
+#guard_msgs in
+set_option linter.style.longLine true in
+#check "                              \"                                                            "
+
 /-
 # Testing the `longFile` linter
 
@@ -311,7 +322,7 @@ set_option linter.style.longFile 1500
 warning: using 'exit' to interrupt Lean
 ---
 warning: The default value of the `longFile` linter is 1500.
-This file is 320 lines long which does not exceed the allowed bound.
+This file is 331 lines long which does not exceed the allowed bound.
 Please, remove the `set_option linter.style.longFile 1600`.
 -/
 #guard_msgs in
@@ -322,7 +333,7 @@ set_option linter.style.longFile 1600 in
 /--
 warning: using 'exit' to interrupt Lean
 ---
-warning: This file is 335 lines long, but the limit is 10.
+warning: This file is 346 lines long, but the limit is 10.
 
 You can extend the allowed length of the file using `set_option linter.style.longFile 1500`.
 You can completely disable this linter by setting the length limit to `0`.
@@ -338,7 +349,7 @@ set_option linter.style.longFile 10 in
 warning: using 'exit' to interrupt Lean
 ---
 warning: The default value of the `longFile` linter is 1500.
-This file is 350 lines long which does not exceed the allowed bound.
+This file is 361 lines long which does not exceed the allowed bound.
 Please, remove the `set_option linter.style.longFile 1700`.
 -/
 #guard_msgs in


### PR DESCRIPTION
As reported on [Zulip](https://leanprover.zulipchat.com/#narrow/stream/113488-general/topic/stacks.20tags/near/468961679)

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
