### PR TITLE
[Merged by Bors] - chore(CategoryTheory/Galois): split out definition from `Full` file

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -1508,6 +1508,7 @@ import Mathlib.CategoryTheory.Functor.KanExtension.Pointwise
 import Mathlib.CategoryTheory.Functor.OfSequence
 import Mathlib.CategoryTheory.Functor.ReflectsIso
 import Mathlib.CategoryTheory.Functor.Trifunctor
+import Mathlib.CategoryTheory.Galois.Action
 import Mathlib.CategoryTheory.Galois.Basic
 import Mathlib.CategoryTheory.Galois.Decomposition
 import Mathlib.CategoryTheory.Galois.Examples

--- a/Mathlib/CategoryTheory/Galois/Action.lean
+++ b/Mathlib/CategoryTheory/Galois/Action.lean
@@ -1,0 +1,89 @@
+/-
+Copyright (c) 2024 Christian Merten. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Christian Merten
+-/
+import Mathlib.CategoryTheory.Galois.Examples
+import Mathlib.CategoryTheory.Galois.Prorepresentability
+
+/-!
+
+# Induced functor to finite `Aut F`-sets
+
+Any (fiber) functor `F : C ⥤ FintypeCat` factors via the forgetful functor
+from finite `Aut F`-sets to finite sets. In this file we collect basic properties
+of the induced functor `H : C ⥤ Action FintypeCat (MonCat.of (Aut F))`.
+
+See `Mathlib.CategoryTheory.Galois.Full` for the proof that `H` is (faithfully) full.
+
+-/
+
+universe u v
+
+namespace CategoryTheory
+
+namespace PreGaloisCategory
+
+open Limits Functor
+
+variable {C : Type u} [Category.{u} C] (F : C ⥤ FintypeCat.{u})
+
+/-- Any (fiber) functor `F : C ⥤ FintypeCat` naturally factors via
+the forgetful functor from `Action FintypeCat (MonCat.of (Aut F))` to `FintypeCat`. -/
+def functorToAction : C ⥤ Action FintypeCat.{u} (MonCat.of (Aut F)) where
+  obj X := Action.FintypeCat.ofMulAction (Aut F) (F.obj X)
+  map f := {
+    hom := F.map f
+    comm := fun g ↦ symm <| g.hom.naturality f
+  }
+
+lemma functorToAction_comp_forget₂_eq : functorToAction F ⋙ forget₂ _ FintypeCat = F := rfl
+
+@[simp]
+lemma functorToAction_map {X Y : C} (f : X ⟶ Y) : ((functorToAction F).map f).hom = F.map f :=
+  rfl
+
+instance (X : C) : MulAction (Aut X) ((functorToAction F).obj X).V :=
+  inferInstanceAs <| MulAction (Aut X) (F.obj X)
+
+variable [GaloisCategory C] [FiberFunctor F]
+
+instance (X : C) [IsGalois X] : MulAction.IsPretransitive (Aut X) ((functorToAction F).obj X).V :=
+  isPretransitive_of_isGalois F X
+
+instance : Functor.Faithful (functorToAction F) :=
+  have : Functor.Faithful (functorToAction F ⋙ forget₂ _ FintypeCat) :=
+    inferInstanceAs <| Functor.Faithful F
+  Functor.Faithful.of_comp (functorToAction F) (forget₂ _ FintypeCat)
+
+instance : PreservesMonomorphisms (functorToAction F) :=
+  have : PreservesMonomorphisms (functorToAction F ⋙ forget₂ _ FintypeCat) :=
+    inferInstanceAs <| PreservesMonomorphisms F
+  preservesMonomorphisms_of_preserves_of_reflects (functorToAction F) (forget₂ _ FintypeCat)
+
+instance : ReflectsMonomorphisms (functorToAction F) := reflectsMonomorphisms_of_faithful _
+
+instance : Functor.ReflectsIsomorphisms (functorToAction F) where
+  reflects f _ :=
+    have : IsIso (F.map f) := (forget₂ _ FintypeCat).map_isIso ((functorToAction F).map f)
+    isIso_of_reflects_iso f F
+
+noncomputable instance : PreservesFiniteCoproducts (functorToAction F) :=
+  ⟨fun J _ ↦ Action.preservesColimitsOfShapeOfPreserves (functorToAction F)
+    (inferInstanceAs <| PreservesColimitsOfShape (Discrete J) F)⟩
+
+noncomputable instance : PreservesFiniteProducts (functorToAction F) :=
+  ⟨fun J _ ↦ Action.preservesLimitsOfShapeOfPreserves (functorToAction F)
+    (inferInstanceAs <| PreservesLimitsOfShape (Discrete J) F)⟩
+
+noncomputable instance (G : Type u) [Group G] [Finite G] :
+    PreservesColimitsOfShape (SingleObj G) (functorToAction F) :=
+  Action.preservesColimitsOfShapeOfPreserves _ <|
+    inferInstanceAs <| PreservesColimitsOfShape (SingleObj G) F
+
+instance : PreservesIsConnected (functorToAction F) :=
+  ⟨fun {X} _ ↦ FintypeCat.Action.isConnected_of_transitive (Aut F) (F.obj X)⟩
+
+end PreGaloisCategory
+
+end CategoryTheory

--- a/Mathlib/CategoryTheory/Galois/Full.lean
+++ b/Mathlib/CategoryTheory/Galois/Full.lean
@@ -3,8 +3,7 @@ Copyright (c) 2024 Christian Merten. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Christian Merten
 -/
-import Mathlib.CategoryTheory.Galois.Examples
-import Mathlib.CategoryTheory.Galois.Prorepresentability
+import Mathlib.CategoryTheory.Galois.Action
 
 /-!
 
@@ -34,6 +33,7 @@ this forces `u₁ = u₂` for the definition of `functorToAction`. Mathematicall
 be no obstruction to generalizing the results of this file to arbitrary universes.
 
 -/
+
 universe u v
 
 namespace CategoryTheory
@@ -42,48 +42,7 @@ namespace PreGaloisCategory
 
 open Limits Functor
 
-variable {C : Type u} [Category.{u} C] (F : C ⥤ FintypeCat.{u})
-
-/-- Any (fiber) functor `F : C ⥤ FintypeCat` naturally factors via
-the forgetful functor from `Action FintypeCat (MonCat.of (Aut F))` to `FintypeCat`. -/
-def functorToAction : C ⥤ Action FintypeCat.{u} (MonCat.of (Aut F)) where
-  obj X := Action.FintypeCat.ofMulAction (Aut F) (F.obj X)
-  map f := {
-    hom := F.map f
-    comm := fun g ↦ symm <| g.hom.naturality f
-  }
-
-lemma functorToAction_comp_forget₂_eq : functorToAction F ⋙ forget₂ _ FintypeCat = F := rfl
-
-variable [GaloisCategory C] [FiberFunctor F]
-
-instance : Functor.Faithful (functorToAction F) :=
-  have : Functor.Faithful (functorToAction F ⋙ forget₂ _ FintypeCat) :=
-    inferInstanceAs <| Functor.Faithful F
-  Functor.Faithful.of_comp (functorToAction F) (forget₂ _ FintypeCat)
-
-instance : PreservesMonomorphisms (functorToAction F) :=
-  have : PreservesMonomorphisms (functorToAction F ⋙ forget₂ _ FintypeCat) :=
-    inferInstanceAs <| PreservesMonomorphisms F
-  preservesMonomorphisms_of_preserves_of_reflects (functorToAction F) (forget₂ _ FintypeCat)
-
-instance : ReflectsMonomorphisms (functorToAction F) := reflectsMonomorphisms_of_faithful _
-
-instance : Functor.ReflectsIsomorphisms (functorToAction F) where
-  reflects f _ :=
-    have : IsIso (F.map f) := (forget₂ _ FintypeCat).map_isIso ((functorToAction F).map f)
-    isIso_of_reflects_iso f F
-
-noncomputable instance : PreservesFiniteCoproducts (functorToAction F) :=
-  ⟨fun J _ ↦ Action.preservesColimitsOfShapeOfPreserves (functorToAction F)
-    (inferInstanceAs <| PreservesColimitsOfShape (Discrete J) F)⟩
-
-noncomputable instance : PreservesFiniteProducts (functorToAction F) :=
-  ⟨fun J _ ↦ Action.preservesLimitsOfShapeOfPreserves (functorToAction F)
-    (inferInstanceAs <| PreservesLimitsOfShape (Discrete J) F)⟩
-
-instance : PreservesIsConnected (functorToAction F) :=
-  ⟨fun {X} _ ↦ FintypeCat.Action.isConnected_of_transitive (Aut F) (F.obj X)⟩
+variable {C : Type u} [Category.{u} C] (F : C ⥤ FintypeCat.{u}) [GaloisCategory C] [FiberFunctor F]
 
 /--
 Let `X` be an object of a Galois category with fiber functor `F` and `Y` a sub-`Aut F`-set
@@ -91,7 +50,7 @@ of `F.obj X`, on which `Aut F` acts transitively (i.e. which is connected in the
 of finite `Aut F`-sets). Then there exists a connected sub-object `Z` of `X` and an isomorphism
 `Y ≅ F.obj X` as `Aut F`-sets such that the obvious triangle commutes.
 
-For a version without the connectedness assumption, see `exists_Lift_of_mono`.
+For a version without the connectedness assumption, see `exists_lift_of_mono`.
 -/
 lemma exists_lift_of_mono_of_isConnected (X : C) (Y : Action FintypeCat.{u} (MonCat.of (Aut F)))
     (i : Y ⟶ (functorToAction F).obj X) [Mono i] [IsConnected Y] : ∃ (Z : C) (f : Z ⟶ X)


### PR DESCRIPTION
Reorganizes the `Full` file to collect definition and boilerplate code about `functorToAction` in separate file.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
