### PR TITLE
[Merged by Bors] - chore: remove variables from LinearAlgebra.FreeModule.Finite.Basic

### DIFF
--- a/Mathlib/LinearAlgebra/FreeModule/Finite/Basic.lean
+++ b/Mathlib/LinearAlgebra/FreeModule/Finite/Basic.lean
@@ -20,16 +20,9 @@ We provide some instances for finite and free modules.
 
 universe u v w
 
-variable (R : Type u) (M : Type v) (N : Type w)
-
-namespace Module.Free
-
-section Ring
-
-variable [Ring R] [AddCommGroup M] [Module R M] [Module.Free R M]
-
 /-- If a free module is finite, then the arbitrary basis is finite. -/
-noncomputable instance ChooseBasisIndex.fintype [Module.Finite R M] :
+noncomputable instance Module.Free.ChooseBasisIndex.fintype (R : Type u) (M : Type v)
+    [Ring R] [AddCommGroup M] [Module R M] [Module.Free R M] [Module.Finite R M] :
     Fintype (Module.Free.ChooseBasisIndex R M) := by
   refine @Fintype.ofFinite _ ?_
   cases subsingleton_or_nontrivial R
@@ -38,28 +31,17 @@ noncomputable instance ChooseBasisIndex.fintype [Module.Finite R M] :
     infer_instance
   · exact Module.Finite.finite_basis (chooseBasis _ _)
 
-end Ring
-
-section CommRing
-
-variable [CommRing R] [AddCommGroup M] [Module R M] [Module.Free R M]
-variable [AddCommGroup N] [Module R N] [Module.Free R N]
-variable {R}
-
 /-- A free module with a basis indexed by a `Fintype` is finite. -/
-theorem _root_.Module.Finite.of_basis {R M ι : Type*} [Semiring R] [AddCommMonoid M] [Module R M]
+theorem Module.Finite.of_basis {R M ι : Type*} [Semiring R] [AddCommMonoid M] [Module R M]
     [_root_.Finite ι] (b : Basis ι R M) : Module.Finite R M := by
   cases nonempty_fintype ι
   classical
     refine ⟨⟨Finset.univ.image b, ?_⟩⟩
     simp only [Set.image_univ, Finset.coe_univ, Finset.coe_image, Basis.span_eq]
 
-instance _root_.Module.Finite.matrix {ι₁ ι₂ : Type*} [_root_.Finite ι₁] [_root_.Finite ι₂] :
+instance Module.Finite.matrix {R : Type u} [CommRing R]
+    {ι₁ ι₂ : Type*} [_root_.Finite ι₁] [_root_.Finite ι₂] :
     Module.Finite R (Matrix ι₁ ι₂ R) := by
   cases nonempty_fintype ι₁
   cases nonempty_fintype ι₂
   exact Module.Finite.of_basis (Pi.basis fun _ => Pi.basisFun R _)
-
-end CommRing
-
-end Module.Free


### PR DESCRIPTION
The current setup with an unused variable (N) and one theorem overriding the ambient variables, as well as a namespace that's explicitly overridden in two of the three results within it, is confusing. It is clearer to explicitly spell out the arguments to each declaration.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
