### PR TITLE
[Merged by Bors] - fix: call checkSystem in `linarith` and `ring`

### DIFF
--- a/Mathlib/Tactic/Linarith/Oracle/FourierMotzkin.lean
+++ b/Mathlib/Tactic/Linarith/Oracle/FourierMotzkin.lean
@@ -305,10 +305,10 @@ from the `linarith` state.
 def elimVarM (a : ℕ) : LinarithM Unit := do
   let vs ← getMaxVar
   if (a ≤ vs) then
-    Lean.Core.checkSystem "Linarith.elimVarM"
+    Lean.Core.checkSystem decl_name%.toString
     let ⟨pos, neg, notPresent⟩ := splitSetByVarSign a (← getPCompSet)
     update (vs - 1) (← pos.foldlM (fun s p => do
-      Lean.Core.checkSystem "Linarith.elimVarM"
+      Lean.Core.checkSystem decl_name%.toString
       pure (s.union (elimWithSet a p neg))) notPresent)
   else
     pure ()

--- a/Mathlib/Tactic/Linarith/Oracle/FourierMotzkin.lean
+++ b/Mathlib/Tactic/Linarith/Oracle/FourierMotzkin.lean
@@ -258,7 +258,7 @@ The linarith monad extends an exceptional monad with a `LinarithData` state.
 An exception produces a contradictory `PComp`.
 -/
 abbrev LinarithM : Type → Type :=
-  StateT LinarithData (ExceptT PComp Id)
+  StateT LinarithData (ExceptT PComp Lean.Core.CoreM)
 
 /-- Returns the current max variable. -/
 def getMaxVar : LinarithM ℕ :=
@@ -272,7 +272,7 @@ def getPCompSet : LinarithM PCompSet :=
 def validate : LinarithM Unit := do
   match (← getPCompSet).toList.find? (fun p : PComp => p.isContr) with
   | none => return ()
-  | some c => throw c
+  | some c => throwThe _ c
 
 /--
 Updates the current state with a new max variable and comparisons,
@@ -304,9 +304,12 @@ from the `linarith` state.
 -/
 def elimVarM (a : ℕ) : LinarithM Unit := do
   let vs ← getMaxVar
-  if (a ≤ vs) then (do
+  if (a ≤ vs) then
+    Lean.Core.checkSystem "Linarith.elimVarM"
     let ⟨pos, neg, notPresent⟩ := splitSetByVarSign a (← getPCompSet)
-    update (vs - 1) (pos.foldl (fun s p => s.union (elimWithSet a p neg)) notPresent))
+    update (vs - 1) (← pos.foldlM (fun s p => do
+      Lean.Core.checkSystem "Linarith.elimVarM"
+      pure (s.union (elimWithSet a p neg))) notPresent)
   else
     pure ()
 
@@ -327,9 +330,12 @@ def mkLinarithData (hyps : List Comp) (maxVar : ℕ) : LinarithData :=
 
 /-- An oracle that uses Fourier-Motzkin elimination. -/
 def CertificateOracle.fourierMotzkin : CertificateOracle where
-  produceCertificate hyps maxVar := match ExceptT.run
-      (StateT.run (do validate; elimAllVarsM : LinarithM Unit) (mkLinarithData hyps maxVar)) with
-  | (Except.ok _) => failure
-  | (Except.error contr) => return contr.src.flatten
+  produceCertificate hyps maxVar :=  do
+    let linarithData := mkLinarithData hyps maxVar
+    let result ←
+      (ExceptT.run (StateT.run (do validate; elimAllVarsM : LinarithM Unit) linarithData) : _)
+    match result with
+    | (Except.ok _) => failure
+    | (Except.error contr) => return contr.src.flatten
 
 end Linarith

--- a/Mathlib/Tactic/Linarith/Oracle/SimplexAlgorithm/Gauss.lean
+++ b/Mathlib/Tactic/Linarith/Oracle/SimplexAlgorithm/Gauss.lean
@@ -35,7 +35,7 @@ def getTableauImp : GaussM n m matType <| Tableau matType := do
   let mut col : Nat := 0
 
   while row < n && col < m do
-    Lean.Core.checkSystem "Linarith.SimplexAlgorithm.Gauss.getTable"
+    Lean.Core.checkSystem decl_name%.toString
     match ← findNonzeroRow row col with
     | .none =>
       free := free.push col

--- a/Mathlib/Tactic/Linarith/Oracle/SimplexAlgorithm/Gauss.lean
+++ b/Mathlib/Tactic/Linarith/Oracle/SimplexAlgorithm/Gauss.lean
@@ -15,7 +15,7 @@ solution which is done by standard Gaussian Elimination algorithm implemented in
 namespace Linarith.SimplexAlgorithm.Gauss
 
 /-- The monad for the Gaussian Elimination algorithm. -/
-abbrev GaussM (n m : Nat) (matType : Nat → Nat → Type) := StateM <| matType n m
+abbrev GaussM (n m : Nat) (matType : Nat → Nat → Type) := StateT (matType n m) Lean.CoreM
 
 variable {n m : Nat} {matType : Nat → Nat → Type} [UsableInSimplexAlgorithm matType]
 
@@ -35,6 +35,7 @@ def getTableauImp : GaussM n m matType <| Tableau matType := do
   let mut col : Nat := 0
 
   while row < n && col < m do
+    Lean.Core.checkSystem "Linarith.SimplexAlgorithm.Gauss.getTable"
     match ← findNonzeroRow row col with
     | .none =>
       free := free.push col
@@ -74,7 +75,7 @@ Given matrix `A`, solves the linear equation `A x = 0` and returns the solution 
 some variables are free and others (basic) variable are expressed as linear combinations of the free
 ones.
 -/
-def getTableau (A : matType n m) : Tableau matType := Id.run do
+def getTableau (A : matType n m) : Lean.CoreM (Tableau matType) := do
   return (← getTableauImp.run A).fst
 
 end Linarith.SimplexAlgorithm.Gauss

--- a/Mathlib/Tactic/Linarith/Oracle/SimplexAlgorithm/PositiveVector.lean
+++ b/Mathlib/Tactic/Linarith/Oracle/SimplexAlgorithm/PositiveVector.lean
@@ -90,10 +90,10 @@ def findPositiveVector {n m : Nat} {matType : Nat → Nat → Type} [UsableInSim
 
   /- Using Gaussian elimination split variable into free and basic forming the tableau that will be
   operated by the Simplex Algorithm. -/
-  let initTableau := Gauss.getTableau B
+  let initTableau ← Gauss.getTableau B
 
   /- Run the Simplex Algorithm and extract the solution. -/
-  let res := runSimplexAlgorithm.run initTableau
+  let res ← runSimplexAlgorithm.run initTableau
   if res.fst.isOk then
     return extractSolution res.snd
   else

--- a/Mathlib/Tactic/Linarith/Oracle/SimplexAlgorithm/SimplexAlgorithm.lean
+++ b/Mathlib/Tactic/Linarith/Oracle/SimplexAlgorithm/SimplexAlgorithm.lean
@@ -116,7 +116,7 @@ such exists.
 -/
 def runSimplexAlgorithm : SimplexAlgorithmM matType Unit := do
   while !(← checkSuccess) do
-    Lean.Core.checkSystem "Linarith.SimplexAlgorithm.runSimplexAlgorithm"
+    Lean.Core.checkSystem decl_name%.toString
     let ⟨exitIdx, enterIdx⟩ ← choosePivots
     doPivotOperation exitIdx enterIdx
 

--- a/Mathlib/Tactic/Linarith/Oracle/SimplexAlgorithm/SimplexAlgorithm.lean
+++ b/Mathlib/Tactic/Linarith/Oracle/SimplexAlgorithm/SimplexAlgorithm.lean
@@ -21,7 +21,7 @@ inductive SimplexAlgorithmException
 
 /-- The monad for the Simplex Algorithm. -/
 abbrev SimplexAlgorithmM (matType : Nat → Nat → Type) [UsableInSimplexAlgorithm matType] :=
-  ExceptT SimplexAlgorithmException <| StateM (Tableau matType)
+  ExceptT SimplexAlgorithmException <| StateT (Tableau matType) Lean.CoreM
 
 variable {matType : Nat → Nat → Type} [UsableInSimplexAlgorithm matType]
 
@@ -77,7 +77,7 @@ def chooseEnteringVar : SimplexAlgorithmM matType Nat := do
 
   /- If there is no such variable the solution does not exist for sure. -/
   match enterIdxOpt with
-  | .none => throw SimplexAlgorithmException.infeasible
+  | .none => throwThe SimplexAlgorithmException SimplexAlgorithmException.infeasible
   | .some enterIdx => return enterIdx
 
 /--
@@ -116,6 +116,7 @@ such exists.
 -/
 def runSimplexAlgorithm : SimplexAlgorithmM matType Unit := do
   while !(← checkSuccess) do
+    Lean.Core.checkSystem "Linarith.SimplexAlgorithm.runSimplexAlgorithm"
     let ⟨exitIdx, enterIdx⟩ ← choosePivots
     doPivotOperation exitIdx enterIdx
 

--- a/Mathlib/Tactic/Linarith/Verification.lean
+++ b/Mathlib/Tactic/Linarith/Verification.lean
@@ -191,7 +191,7 @@ def proveFalseByLinarith (transparency : TransparencyMode) (oracle : Certificate
   | _, [] => throwError "no args to linarith"
   | g, l@(h::_) => do
       trace[linarith.detail] "Beginning work in `proveFalseByLinarith`."
-      Lean.Core.checkSystem "Linarith.proveFalseByLinarith"
+      Lean.Core.checkSystem decl_name%.toString
       -- for the elimination to work properly, we must add a proof of `-1 < 0` to the list,
       -- along with negated equality proofs.
       let l' ← addNegEqProofs l

--- a/Mathlib/Tactic/Linarith/Verification.lean
+++ b/Mathlib/Tactic/Linarith/Verification.lean
@@ -191,6 +191,7 @@ def proveFalseByLinarith (transparency : TransparencyMode) (oracle : Certificate
   | _, [] => throwError "no args to linarith"
   | g, l@(h::_) => do
       trace[linarith.detail] "Beginning work in `proveFalseByLinarith`."
+      Lean.Core.checkSystem "Linarith.proveFalseByLinarith"
       -- for the elimination to work properly, we must add a proof of `-1 < 0` to the list,
       -- along with negated equality proofs.
       let l' ← addNegEqProofs l

--- a/Mathlib/Tactic/Ring/Basic.lean
+++ b/Mathlib/Tactic/Ring/Basic.lean
@@ -308,7 +308,7 @@ and `xy + -xy = 0` is a `.zero` overlap.
 -/
 def evalAddOverlap {a b : Q($α)} (va : ExProd sα a) (vb : ExProd sα b) :
     OptionT Lean.Core.CoreM (Overlap sα q($a + $b)) := do
-  Lean.Core.checkSystem "Mathlib.Tactic.Ring.evalAddOverlap"
+  Lean.Core.checkSystem decl_name%.toString
   match va, vb with
   | .const za ha, .const zb hb => do
     let ra := Result.ofRawRat za a ha; let rb := Result.ofRawRat zb b hb
@@ -354,7 +354,7 @@ theorem add_pf_add_gt (b₁ : R) (_ : a + b₂ = c) : a + (b₁ + b₂) = b₁ +
 -/
 partial def evalAdd {a b : Q($α)} (va : ExSum sα a) (vb : ExSum sα b) :
     Lean.Core.CoreM <| Result (ExSum sα) q($a + $b) := do
-  Lean.Core.checkSystem "Mathlib.Tactic.Ring.evalAdd"
+  Lean.Core.checkSystem decl_name%.toString
   match va, vb with
   | .zero, vb => return ⟨b, vb, q(add_pf_zero_add $b)⟩
   | va, .zero => return ⟨a, va, q(add_pf_add_zero $a)⟩
@@ -402,7 +402,7 @@ theorem mul_pp_pf_overlap {ea eb e : ℕ} (x : R) (_ : ea + eb = e) (_ : a₂ * 
 -/
 partial def evalMulProd {a b : Q($α)} (va : ExProd sα a) (vb : ExProd sα b) :
     Lean.Core.CoreM <| Result (ExProd sα) q($a * $b) := do
-  Lean.Core.checkSystem "Mathlib.Tactic.Ring.evalMulProd"
+  Lean.Core.checkSystem decl_name%.toString
   match va, vb with
   | .const za ha, .const zb hb =>
     if za = 1 then
@@ -570,7 +570,7 @@ theorem neg_mul {R} [Ring R] (a₁ : R) (a₂) {a₃ b : R}
 -/
 def evalNegProd {a : Q($α)} (rα : Q(Ring $α)) (va : ExProd sα a) :
     Lean.Core.CoreM <| Result (ExProd sα) q(-$a) := do
-  Lean.Core.checkSystem "Mathlib.Tactic.Ring.evalNegProd"
+  Lean.Core.checkSystem decl_name%.toString
   match va with
   | .const za ha =>
     let lit : Q(ℕ) := mkRawNatLit 1
@@ -754,7 +754,7 @@ In all other cases we use `evalPowProdAtom`.
 -/
 def evalPowProd {a : Q($α)} {b : Q(ℕ)} (va : ExProd sα a) (vb : ExProd sℕ b) :
     Lean.Core.CoreM <| Result (ExProd sα) q($a ^ $b) := do
-  Lean.Core.checkSystem "Mathlib.Tactic.Ring.evalPowProd"
+  Lean.Core.checkSystem decl_name%.toString
   let res : OptionT Lean.Core.CoreM (Result (ExProd sα) q($a ^ $b)) := do
     match va, vb with
     | .const 1, _ => return ⟨_, va, (q(one_pow (R := $α) $b) : Expr)⟩
@@ -973,7 +973,7 @@ def evalInvAtom (a : Q($α)) : AtomM (Result (ExBase sα) q($a⁻¹)) := do
 -/
 def ExProd.evalInv {a : Q($α)} (czα : Option Q(CharZero $α)) (va : ExProd sα a) :
     AtomM (Result (ExProd sα) q($a⁻¹)) := do
-  Lean.Core.checkSystem "Mathlib.Tactic.Ring.evalInv"
+  Lean.Core.checkSystem decl_name%.toString
   match va with
   | .const c hc =>
     let ra := Result.ofRawRat c a hc

--- a/Mathlib/Tactic/Ring/Basic.lean
+++ b/Mathlib/Tactic/Ring/Basic.lean
@@ -295,6 +295,11 @@ theorem add_overlap_pf_zero (x : R) (e) :
     IsNat (a + b) (nat_lit 0) → IsNat (x ^ e * a + x ^ e * b) (nat_lit 0)
   | ⟨h⟩ => ⟨by simp [h, ← mul_add]⟩
 
+-- TODO: decide if this is a good idea globally in
+-- https://leanprover.zulipchat.com/#narrow/stream/270676-lean4/topic/.60MonadLift.20Option.20.28OptionT.20m.29.60/near/469097834
+private local instance {m} [Pure m] : MonadLift Option (OptionT m) where
+  monadLift f := .mk <| pure f
+
 /--
 Given monomials `va, vb`, attempts to add them together to get another monomial.
 If the monomials are not compatible, returns `none`.
@@ -302,7 +307,8 @@ For example, `xy + 2xy = 3xy` is a `.nonzero` overlap, while `xy + xz` returns `
 and `xy + -xy = 0` is a `.zero` overlap.
 -/
 def evalAddOverlap {a b : Q($α)} (va : ExProd sα a) (vb : ExProd sα b) :
-    Option (Overlap sα q($a + $b)) :=
+    OptionT Lean.Core.CoreM (Overlap sα q($a + $b)) := do
+  Lean.Core.checkSystem "Mathlib.Tactic.Ring.evalAddOverlap"
   match va, vb with
   | .const za ha, .const zb hb => do
     let ra := Result.ofRawRat za a ha; let rb := Result.ofRawRat zb b hb
@@ -319,7 +325,7 @@ def evalAddOverlap {a b : Q($α)} (va : ExProd sα a) (vb : ExProd sα b) :
     | .zero p => pure <| .zero (q(add_overlap_pf_zero $a₁ $a₂ $p) : Expr)
     | .nonzero ⟨_, vc, p⟩ =>
       pure <| .nonzero ⟨_, .mul va₁ va₂ vc, (q(add_overlap_pf $a₁ $a₂ $p) : Expr)⟩
-  | _, _ => none
+  | _, _ => OptionT.fail
 
 theorem add_pf_zero_add (b : R) : 0 + b = b := by simp
 
@@ -347,25 +353,26 @@ theorem add_pf_add_gt (b₁ : R) (_ : a + b₂ = c) : a + (b₁ + b₂) = b₁ +
 * `(a₁ + a₂) + (b₁ + b₂) = b₁ + ((a₁ + a₂) + b₂)` (if not `a₁.lt b₁`)
 -/
 partial def evalAdd {a b : Q($α)} (va : ExSum sα a) (vb : ExSum sα b) :
-    Result (ExSum sα) q($a + $b) :=
+    Lean.Core.CoreM <| Result (ExSum sα) q($a + $b) := do
+  Lean.Core.checkSystem "Mathlib.Tactic.Ring.evalAdd"
   match va, vb with
-  | .zero, vb => ⟨b, vb, q(add_pf_zero_add $b)⟩
-  | va, .zero => ⟨a, va, q(add_pf_add_zero $a)⟩
+  | .zero, vb => return ⟨b, vb, q(add_pf_zero_add $b)⟩
+  | va, .zero => return ⟨a, va, q(add_pf_add_zero $a)⟩
   | .add (a := a₁) (b := _a₂) va₁ va₂, .add (a := b₁) (b := _b₂) vb₁ vb₂ =>
-    match evalAddOverlap sα va₁ vb₁ with
+    match ← (evalAddOverlap sα va₁ vb₁).run with
     | some (.nonzero ⟨_, vc₁, pc₁⟩) =>
-      let ⟨_, vc₂, pc₂⟩ := evalAdd va₂ vb₂
-      ⟨_, .add vc₁ vc₂, q(add_pf_add_overlap $pc₁ $pc₂)⟩
+      let ⟨_, vc₂, pc₂⟩ ← evalAdd va₂ vb₂
+      return ⟨_, .add vc₁ vc₂, q(add_pf_add_overlap $pc₁ $pc₂)⟩
     | some (.zero pc₁) =>
-      let ⟨c₂, vc₂, pc₂⟩ := evalAdd va₂ vb₂
-      ⟨c₂, vc₂, q(add_pf_add_overlap_zero $pc₁ $pc₂)⟩
+      let ⟨c₂, vc₂, pc₂⟩ ← evalAdd va₂ vb₂
+      return ⟨c₂, vc₂, q(add_pf_add_overlap_zero $pc₁ $pc₂)⟩
     | none =>
       if let .lt := va₁.cmp vb₁ then
-        let ⟨_c, vc, (pc : Q($_a₂ + ($b₁ + $_b₂) = $_c))⟩ := evalAdd va₂ vb
-        ⟨_, .add va₁ vc, q(add_pf_add_lt $a₁ $pc)⟩
+        let ⟨_c, vc, (pc : Q($_a₂ + ($b₁ + $_b₂) = $_c))⟩ ← evalAdd va₂ vb
+        return ⟨_, .add va₁ vc, q(add_pf_add_lt $a₁ $pc)⟩
       else
-        let ⟨_c, vc, (pc : Q($a₁ + $_a₂ + $_b₂ = $_c))⟩ := evalAdd va vb₂
-        ⟨_, .add vb₁ vc, q(add_pf_add_gt $b₁ $pc)⟩
+        let ⟨_c, vc, (pc : Q($a₁ + $_a₂ + $_b₂ = $_c))⟩ ← evalAdd va vb₂
+        return ⟨_, .add vb₁ vc, q(add_pf_add_gt $b₁ $pc)⟩
 
 theorem one_mul (a : R) : (nat_lit 1).rawCast * a = a := by simp [Nat.rawCast]
 
@@ -394,37 +401,38 @@ theorem mul_pp_pf_overlap {ea eb e : ℕ} (x : R) (_ : ea + eb = e) (_ : a₂ * 
 * `(a₁ * a₂) * (b₁ * b₂) = b₁ * ((a₁ * a₂) * b₂)` (if not `a₁.lt b₁`)
 -/
 partial def evalMulProd {a b : Q($α)} (va : ExProd sα a) (vb : ExProd sα b) :
-    Result (ExProd sα) q($a * $b) :=
+    Lean.Core.CoreM <| Result (ExProd sα) q($a * $b) := do
+  Lean.Core.checkSystem "Mathlib.Tactic.Ring.evalMulProd"
   match va, vb with
   | .const za ha, .const zb hb =>
     if za = 1 then
-      ⟨b, .const zb hb, (q(one_mul $b) : Expr)⟩
+      return ⟨b, .const zb hb, (q(one_mul $b) : Expr)⟩
     else if zb = 1 then
-      ⟨a, .const za ha, (q(mul_one $a) : Expr)⟩
+      return ⟨a, .const za ha, (q(mul_one $a) : Expr)⟩
     else
       let ra := Result.ofRawRat za a ha; let rb := Result.ofRawRat zb b hb
       let rc := (NormNum.evalMul.core q($a * $b) q(HMul.hMul) _ _
           q(CommSemiring.toSemiring) ra rb).get!
       let ⟨zc, hc⟩ := rc.toRatNZ.get!
       let ⟨c, pc⟩ := rc.toRawEq
-      ⟨c, .const zc hc, pc⟩
+      return ⟨c, .const zc hc, pc⟩
   | .mul (x := a₁) (e := a₂) va₁ va₂ va₃, .const _ _ =>
-    let ⟨_, vc, pc⟩ := evalMulProd va₃ vb
-    ⟨_, .mul va₁ va₂ vc, (q(mul_pf_left $a₁ $a₂ $pc) : Expr)⟩
+    let ⟨_, vc, pc⟩ ← evalMulProd va₃ vb
+    return ⟨_, .mul va₁ va₂ vc, (q(mul_pf_left $a₁ $a₂ $pc) : Expr)⟩
   | .const _ _, .mul (x := b₁) (e := b₂) vb₁ vb₂ vb₃ =>
-    let ⟨_, vc, pc⟩ := evalMulProd va vb₃
-    ⟨_, .mul vb₁ vb₂ vc, (q(mul_pf_right $b₁ $b₂ $pc) : Expr)⟩
-  | .mul (x := xa) (e := ea) vxa vea va₂, .mul (x := xb) (e := eb) vxb veb vb₂ => Id.run do
+    let ⟨_, vc, pc⟩ ← evalMulProd va vb₃
+    return ⟨_, .mul vb₁ vb₂ vc, (q(mul_pf_right $b₁ $b₂ $pc) : Expr)⟩
+  | .mul (x := xa) (e := ea) vxa vea va₂, .mul (x := xb) (e := eb) vxb veb vb₂ => do
     if vxa.eq vxb then
-      if let some (.nonzero ⟨_, ve, pe⟩) := evalAddOverlap sℕ vea veb then
-        let ⟨_, vc, pc⟩ := evalMulProd va₂ vb₂
+      if let some (.nonzero ⟨_, ve, pe⟩) ← (evalAddOverlap sℕ vea veb).run then
+        let ⟨_, vc, pc⟩ ← evalMulProd va₂ vb₂
         return ⟨_, .mul vxa ve vc, (q(mul_pp_pf_overlap $xa $pe $pc) : Expr)⟩
     if let .lt := (vxa.cmp vxb).then (vea.cmp veb) then
-      let ⟨_, vc, pc⟩ := evalMulProd va₂ vb
-      ⟨_, .mul vxa vea vc, (q(mul_pf_left $xa $ea $pc) : Expr)⟩
+      let ⟨_, vc, pc⟩ ← evalMulProd va₂ vb
+      return ⟨_, .mul vxa vea vc, (q(mul_pf_left $xa $ea $pc) : Expr)⟩
     else
-      let ⟨_, vc, pc⟩ := evalMulProd va vb₂
-      ⟨_, .mul vxb veb vc, (q(mul_pf_right $xb $eb $pc) : Expr)⟩
+      let ⟨_, vc, pc⟩ ← evalMulProd va vb₂
+      return ⟨_, .mul vxb veb vc, (q(mul_pf_right $xb $eb $pc) : Expr)⟩
 
 theorem mul_zero (a : R) : a * 0 = 0 := by simp
 
@@ -437,14 +445,15 @@ theorem mul_add {d : R} (_ : (a : R) * b₁ = c₁) (_ : a * b₂ = c₂) (_ : c
 * `a * 0 = 0`
 * `a * (b₁ + b₂) = (a * b₁) + (a * b₂)`
 -/
-def evalMul₁ {a b : Q($α)} (va : ExProd sα a) (vb : ExSum sα b) : Result (ExSum sα) q($a * $b) :=
+def evalMul₁ {a b : Q($α)} (va : ExProd sα a) (vb : ExSum sα b) :
+    Lean.Core.CoreM <| Result (ExSum sα) q($a * $b) := do
   match vb with
-  | .zero => ⟨_, .zero, q(mul_zero $a)⟩
+  | .zero => return ⟨_, .zero, q(mul_zero $a)⟩
   | .add vb₁ vb₂ =>
-    let ⟨_, vc₁, pc₁⟩ := evalMulProd sα va vb₁
-    let ⟨_, vc₂, pc₂⟩ := evalMul₁ va vb₂
-    let ⟨_, vd, pd⟩ := evalAdd sα vc₁.toSum vc₂
-    ⟨_, vd, q(mul_add $pc₁ $pc₂ $pd)⟩
+    let ⟨_, vc₁, pc₁⟩ ← evalMulProd sα va vb₁
+    let ⟨_, vc₂, pc₂⟩ ← evalMul₁ va vb₂
+    let ⟨_, vd, pd⟩ ← evalAdd sα vc₁.toSum vc₂
+    return ⟨_, vd, q(mul_add $pc₁ $pc₂ $pd)⟩
 
 theorem zero_mul (b : R) : 0 * b = 0 := by simp
 
@@ -456,14 +465,15 @@ theorem add_mul {d : R} (_ : (a₁ : R) * b = c₁) (_ : a₂ * b = c₂) (_ : c
 * `0 * b = 0`
 * `(a₁ + a₂) * b = (a₁ * b) + (a₂ * b)`
 -/
-def evalMul {a b : Q($α)} (va : ExSum sα a) (vb : ExSum sα b) : Result (ExSum sα) q($a * $b) :=
+def evalMul {a b : Q($α)} (va : ExSum sα a) (vb : ExSum sα b) :
+    Lean.Core.CoreM <| Result (ExSum sα) q($a * $b) := do
   match va with
-  | .zero => ⟨_, .zero, q(zero_mul $b)⟩
+  | .zero => return ⟨_, .zero, q(zero_mul $b)⟩
   | .add va₁ va₂ =>
-    let ⟨_, vc₁, pc₁⟩ := evalMul₁ sα va₁ vb
-    let ⟨_, vc₂, pc₂⟩ := evalMul va₂ vb
-    let ⟨_, vd, pd⟩ := evalAdd sα vc₁ vc₂
-    ⟨_, vd, q(add_mul $pc₁ $pc₂ $pd)⟩
+    let ⟨_, vc₁, pc₁⟩ ← evalMul₁ sα va₁ vb
+    let ⟨_, vc₂, pc₂⟩ ← evalMul va₂ vb
+    let ⟨_, vd, pd⟩ ← evalAdd sα vc₁ vc₂
+    return ⟨_, vd, q(add_mul $pc₁ $pc₂ $pd)⟩
 
 theorem natCast_nat (n) : ((Nat.rawCast n : ℕ) : R) = Nat.rawCast n := by simp
 
@@ -540,11 +550,11 @@ def evalNSMul {a : Q(ℕ)} {b : Q($α)} (va : ExSum sℕ a) (vb : ExSum sα b) :
   if ← isDefEq sα sℕ then
     let ⟨_, va'⟩ := va.cast
     have _b : Q(ℕ) := b
-    let ⟨(_c : Q(ℕ)), vc, (pc : Q($a * $_b = $_c))⟩ := evalMul sα va' vb
+    let ⟨(_c : Q(ℕ)), vc, (pc : Q($a * $_b = $_c))⟩ ← evalMul sα va' vb
     pure ⟨_, vc, (q(smul_nat $pc) : Expr)⟩
   else
     let ⟨_, va', pa'⟩ ← va.evalNatCast sα
-    let ⟨_, vc, pc⟩ := evalMul sα va' vb
+    let ⟨_, vc, pc⟩ ← evalMul sα va' vb
     pure ⟨_, vc, (q(smul_eq_cast $pa' $pc) : Expr)⟩
 
 theorem neg_one_mul {R} [Ring R] {a b : R} (_ : (Int.negOfNat (nat_lit 1)).rawCast * a = b) :
@@ -558,7 +568,9 @@ theorem neg_mul {R} [Ring R] (a₁ : R) (a₂) {a₃ b : R}
 * `-c = (-c)` (for `c` coefficient)
 * `-(a₁ * a₂) = a₁ * -a₂`
 -/
-def evalNegProd {a : Q($α)} (rα : Q(Ring $α)) (va : ExProd sα a) : Result (ExProd sα) q(-$a) :=
+def evalNegProd {a : Q($α)} (rα : Q(Ring $α)) (va : ExProd sα a) :
+    Lean.Core.CoreM <| Result (ExProd sα) q(-$a) := do
+  Lean.Core.checkSystem "Mathlib.Tactic.Ring.evalNegProd"
   match va with
   | .const za ha =>
     let lit : Q(ℕ) := mkRawNatLit 1
@@ -569,10 +581,10 @@ def evalNegProd {a : Q($α)} (rα : Q(Ring $α)) (va : ExProd sα a) : Result (E
       q(CommSemiring.toSemiring) rm ra).get!
     let ⟨zb, hb⟩ := rb.toRatNZ.get!
     let ⟨b, (pb : Q((Int.negOfNat (nat_lit 1)).rawCast * $a = $b))⟩ := rb.toRawEq
-    ⟨b, .const zb hb, (q(neg_one_mul (R := $α) $pb) : Expr)⟩
+    return ⟨b, .const zb hb, (q(neg_one_mul (R := $α) $pb) : Expr)⟩
   | .mul (x := a₁) (e := a₂) va₁ va₂ va₃ =>
-    let ⟨_, vb, pb⟩ := evalNegProd rα va₃
-    ⟨_, .mul va₁ va₂ vb, (q(neg_mul $a₁ $a₂ $pb) : Expr)⟩
+    let ⟨_, vb, pb⟩ ← evalNegProd rα va₃
+    return ⟨_, .mul va₁ va₂ vb, (q(neg_mul $a₁ $a₂ $pb) : Expr)⟩
 
 theorem neg_zero {R} [Ring R] : -(0 : R) = 0 := by simp
 
@@ -585,13 +597,14 @@ theorem neg_add {R} [Ring R] {a₁ a₂ b₁ b₂ : R}
 * `-0 = 0` (for `c` coefficient)
 * `-(a₁ + a₂) = -a₁ + -a₂`
 -/
-def evalNeg {a : Q($α)} (rα : Q(Ring $α)) (va : ExSum sα a) : Result (ExSum sα) q(-$a) :=
+def evalNeg {a : Q($α)} (rα : Q(Ring $α)) (va : ExSum sα a) :
+    Lean.Core.CoreM <| Result (ExSum sα) q(-$a) := do
   match va with
-  | .zero => ⟨_, .zero, (q(neg_zero (R := $α)) : Expr)⟩
+  | .zero => return ⟨_, .zero, (q(neg_zero (R := $α)) : Expr)⟩
   | .add va₁ va₂ =>
-    let ⟨_, vb₁, pb₁⟩ := evalNegProd sα rα va₁
-    let ⟨_, vb₂, pb₂⟩ := evalNeg rα va₂
-    ⟨_, .add vb₁ vb₂, (q(neg_add $pb₁ $pb₂) : Expr)⟩
+    let ⟨_, vb₁, pb₁⟩ ← evalNegProd sα rα va₁
+    let ⟨_, vb₂, pb₂⟩ ← evalNeg rα va₂
+    return ⟨_, .add vb₁ vb₂, (q(neg_add $pb₁ $pb₂) : Expr)⟩
 
 theorem sub_pf {R} [Ring R] {a b c d : R}
     (_ : -b = c) (_ : a + c = d) : a - b = d := by subst_vars; simp [sub_eq_add_neg]
@@ -601,10 +614,11 @@ theorem sub_pf {R} [Ring R] {a b c d : R}
 * `a - b = a + -b`
 -/
 def evalSub {α : Q(Type u)} (sα : Q(CommSemiring $α)) {a b : Q($α)}
-    (rα : Q(Ring $α)) (va : ExSum sα a) (vb : ExSum sα b) : Result (ExSum sα) q($a - $b) :=
-  let ⟨_c, vc, pc⟩ := evalNeg sα rα vb
-  let ⟨d, vd, (pd : Q($a + $_c = $d))⟩ := evalAdd sα va vc
-  ⟨d, vd, (q(sub_pf $pc $pd) : Expr)⟩
+    (rα : Q(Ring $α)) (va : ExSum sα a) (vb : ExSum sα b) :
+    Lean.Core.CoreM <| Result (ExSum sα) q($a - $b) := do
+  let ⟨_c, vc, pc⟩ ← evalNeg sα rα vb
+  let ⟨d, vd, (pd : Q($a + $_c = $d))⟩ ← evalAdd sα va vc
+  return ⟨d, vd, (q(sub_pf $pc $pd) : Expr)⟩
 
 theorem pow_prod_atom (a : R) (b) : a ^ b = (a + 0) ^ b * (nat_lit 1).rawCast := by simp
 
@@ -706,22 +720,23 @@ into a sum of monomials.
 * `x ^ (2*n) = x ^ n * x ^ n`
 * `x ^ (2*n+1) = x ^ n * x ^ n * x`
 -/
-partial def evalPowNat {a : Q($α)} (va : ExSum sα a) (n : Q(ℕ)) : Result (ExSum sα) q($a ^ $n) :=
+partial def evalPowNat {a : Q($α)} (va : ExSum sα a) (n : Q(ℕ)) :
+    Lean.Core.CoreM <| Result (ExSum sα) q($a ^ $n) := do
   let nn := n.natLit!
   if nn = 1 then
-    ⟨_, va, (q(pow_one $a) : Expr)⟩
+    return ⟨_, va, (q(pow_one $a) : Expr)⟩
   else
     let nm := nn >>> 1
     have m : Q(ℕ) := mkRawNatLit nm
     if nn &&& 1 = 0 then
-      let ⟨_, vb, pb⟩ := evalPowNat va m
-      let ⟨_, vc, pc⟩ := evalMul sα vb vb
-      ⟨_, vc, (q(pow_bit0 $pb $pc) : Expr)⟩
+      let ⟨_, vb, pb⟩ ← evalPowNat va m
+      let ⟨_, vc, pc⟩ ← evalMul sα vb vb
+      return ⟨_, vc, (q(pow_bit0 $pb $pc) : Expr)⟩
     else
-      let ⟨_, vb, pb⟩ := evalPowNat va m
-      let ⟨_, vc, pc⟩ := evalMul sα vb vb
-      let ⟨_, vd, pd⟩ := evalMul sα vc va
-      ⟨_, vd, (q(pow_bit1 $pb $pc $pd) : Expr)⟩
+      let ⟨_, vb, pb⟩ ← evalPowNat va m
+      let ⟨_, vc, pc⟩ ← evalMul sα vb vb
+      let ⟨_, vd, pd⟩ ← evalMul sα vc va
+      return ⟨_, vd, (q(pow_bit1 $pb $pc $pd) : Expr)⟩
 
 theorem one_pow (b : ℕ) : ((nat_lit 1).rawCast : R) ^ b = (nat_lit 1).rawCast := by simp
 
@@ -738,10 +753,11 @@ theorem mul_pow {ea₁ b c₁ : ℕ} {xa₁ : R}
 In all other cases we use `evalPowProdAtom`.
 -/
 def evalPowProd {a : Q($α)} {b : Q(ℕ)} (va : ExProd sα a) (vb : ExProd sℕ b) :
-    Result (ExProd sα) q($a ^ $b) :=
-  let res : Option (Result (ExProd sα) q($a ^ $b)) := do
+    Lean.Core.CoreM <| Result (ExProd sα) q($a ^ $b) := do
+  Lean.Core.checkSystem "Mathlib.Tactic.Ring.evalPowProd"
+  let res : OptionT Lean.Core.CoreM (Result (ExProd sα) q($a ^ $b)) := do
     match va, vb with
-    | .const 1, _ => some ⟨_, va, (q(one_pow (R := $α) $b) : Expr)⟩
+    | .const 1, _ => return ⟨_, va, (q(one_pow (R := $α) $b) : Expr)⟩
     | .const za ha, .const zb hb =>
       assert! 0 ≤ zb
       let ra := Result.ofRawRat za a ha
@@ -751,13 +767,13 @@ def evalPowProd {a : Q($α)} {b : Q(ℕ)} (va : ExProd sα a) (vb : ExProd sℕ 
         q(CommSemiring.toSemiring) ra
       let ⟨zc, hc⟩ ← rc.toRatNZ
       let ⟨c, pc⟩ := rc.toRawEq
-      some ⟨c, .const zc hc, pc⟩
-    | .mul vxa₁ vea₁ va₂, vb => do
-      let ⟨_, vc₁, pc₁⟩ := evalMulProd sℕ vea₁ vb
-      let ⟨_, vc₂, pc₂⟩ := evalPowProd va₂ vb
-      some ⟨_, .mul vxa₁ vc₁ vc₂, q(mul_pow $pc₁ $pc₂)⟩
-    | _, _ => none
-  res.getD (evalPowProdAtom sα va vb)
+      return ⟨c, .const zc hc, pc⟩
+    | .mul vxa₁ vea₁ va₂, vb =>
+      let ⟨_, vc₁, pc₁⟩ ← evalMulProd sℕ vea₁ vb
+      let ⟨_, vc₂, pc₂⟩ ← evalPowProd va₂ vb
+      return ⟨_, .mul vxa₁ vc₁ vc₂, q(mul_pow $pc₁ $pc₂)⟩
+    | _, _ => OptionT.fail
+  return (← res.run).getD (evalPowProdAtom sα va vb)
 
 /--
 The result of `extractCoeff` is a numeral and a proof that the original expression
@@ -815,24 +831,25 @@ theorem pow_nat {b c k : ℕ} {d e : R} (_ : b = c * k) (_ : a ^ c = d) (_ : d ^
 Otherwise `a ^ b` is just encoded as `a ^ b * 1 + 0` using `evalPowAtom`.
 -/
 partial def evalPow₁ {a : Q($α)} {b : Q(ℕ)} (va : ExSum sα a) (vb : ExProd sℕ b) :
-    Result (ExSum sα) q($a ^ $b) :=
+    Lean.Core.CoreM <| Result (ExSum sα) q($a ^ $b) := do
   match va, vb with
   | va, .const 1 =>
     haveI : $b =Q Nat.rawCast (nat_lit 1) := ⟨⟩
-    ⟨_, va, q(pow_one_cast $a)⟩
+    return ⟨_, va, q(pow_one_cast $a)⟩
   | .zero, vb => match vb.evalPos with
-    | some p => ⟨_, .zero, q(zero_pow (R := $α) $p)⟩
-    | none => evalPowAtom sα (.sum .zero) vb
+    | some p => return ⟨_, .zero, q(zero_pow (R := $α) $p)⟩
+    | none => return evalPowAtom sα (.sum .zero) vb
   | ExSum.add va .zero, vb => -- TODO: using `.add` here takes a while to compile?
-    let ⟨_, vc, pc⟩ := evalPowProd sα va vb
-    ⟨_, vc.toSum, q(single_pow $pc)⟩
+    let ⟨_, vc, pc⟩ ← evalPowProd sα va vb
+    return ⟨_, vc.toSum, q(single_pow $pc)⟩
   | va, vb =>
     if vb.coeff > 1 then
       let ⟨k, _, vc, pc⟩ := extractCoeff vb
-      let ⟨_, vd, pd⟩ := evalPow₁ va vc
-      let ⟨_, ve, pe⟩ := evalPowNat sα vd k
-      ⟨_, ve, q(pow_nat $pc $pd $pe)⟩
-    else evalPowAtom sα (.sum va) vb
+      let ⟨_, vd, pd⟩ ← evalPow₁ va vc
+      let ⟨_, ve, pe⟩ ← evalPowNat sα vd k
+      return ⟨_, ve, q(pow_nat $pc $pd $pe)⟩
+    else
+      return evalPowAtom sα (.sum va) vb
 
 theorem pow_zero (a : R) : a ^ 0 = (nat_lit 1).rawCast + 0 := by simp
 
@@ -846,14 +863,14 @@ theorem pow_add {b₁ b₂ : ℕ} {d : R}
 * `a ^ (b₁ + b₂) = a ^ b₁ * a ^ b₂`
 -/
 def evalPow {a : Q($α)} {b : Q(ℕ)} (va : ExSum sα a) (vb : ExSum sℕ b) :
-    Result (ExSum sα) q($a ^ $b) :=
+    Lean.Core.CoreM <| Result (ExSum sα) q($a ^ $b) := do
   match vb with
-  | .zero => ⟨_, (ExProd.mkNat sα 1).2.toSum, q(pow_zero $a)⟩
+  | .zero => return ⟨_, (ExProd.mkNat sα 1).2.toSum, q(pow_zero $a)⟩
   | .add vb₁ vb₂ =>
-    let ⟨_, vc₁, pc₁⟩ := evalPow₁ sα va vb₁
-    let ⟨_, vc₂, pc₂⟩ := evalPow va vb₂
-    let ⟨_, vd, pd⟩ := evalMul sα vc₁ vc₂
-    ⟨_, vd, q(pow_add $pc₁ $pc₂ $pd)⟩
+    let ⟨_, vc₁, pc₁⟩ ← evalPow₁ sα va vb₁
+    let ⟨_, vc₂, pc₂⟩ ← evalPow va vb₂
+    let ⟨_, vd, pd⟩ ← evalMul sα vc₁ vc₂
+    return ⟨_, vd, q(pow_add $pc₁ $pc₂ $pd)⟩
 
 /-- This cache contains data required by the `ring` tactic during execution. -/
 structure Cache {α : Q(Type u)} (sα : Q(CommSemiring $α)) :=
@@ -956,6 +973,7 @@ def evalInvAtom (a : Q($α)) : AtomM (Result (ExBase sα) q($a⁻¹)) := do
 -/
 def ExProd.evalInv {a : Q($α)} (czα : Option Q(CharZero $α)) (va : ExProd sα a) :
     AtomM (Result (ExProd sα) q($a⁻¹)) := do
+  Lean.Core.checkSystem "Mathlib.Tactic.Ring.evalInv"
   match va with
   | .const c hc =>
     let ra := Result.ofRawRat c a hc
@@ -970,7 +988,7 @@ def ExProd.evalInv {a : Q($α)} (czα : Option Q(CharZero $α)) (va : ExProd sα
   | .mul (x := a₁) (e := _a₂) _va₁ va₂ va₃ => do
     let ⟨_b₁, vb₁, pb₁⟩ ← evalInvAtom sα dα a₁
     let ⟨_b₃, vb₃, pb₃⟩ ← va₃.evalInv czα
-    let ⟨c, vc, (pc : Q($_b₃ * ($_b₁ ^ $_a₂ * Nat.rawCast 1) = $c))⟩ :=
+    let ⟨c, vc, (pc : Q($_b₃ * ($_b₁ ^ $_a₂ * Nat.rawCast 1) = $c))⟩ ←
       evalMulProd sα vb₃ (vb₁.toProd va₂)
     pure ⟨c, vc, (q(inv_mul $pb₁ $pb₃ $pc) : Expr)⟩
 
@@ -1002,7 +1020,7 @@ theorem div_pf {R} [DivisionRing R] {a b c d : R} (_ : b⁻¹ = c) (_ : a * c = 
 def evalDiv {a b : Q($α)} (rα : Q(DivisionRing $α)) (czα : Option Q(CharZero $α)) (va : ExSum sα a)
     (vb : ExSum sα b) : AtomM (Result (ExSum sα) q($a / $b)) := do
   let ⟨_c, vc, pc⟩ ← vb.evalInv sα rα czα
-  let ⟨d, vd, (pd : Q($a * $_c = $d))⟩ := evalMul sα va vc
+  let ⟨d, vd, (pd : Q($a * $_c = $d))⟩ ← evalMul sα va vc
   pure ⟨d, vd, (q(div_pf $pc $pd) : Expr)⟩
 
 theorem add_congr (_ : a = a') (_ : b = b') (_ : a' + b' = c) : (a + b : R) = c := by
@@ -1077,14 +1095,14 @@ partial def eval {u : Lean.Level} {α : Q(Type u)} (sα : Q(CommSemiring $α))
     | ~q($a + $b) =>
       let ⟨_, va, pa⟩ ← eval sα c a
       let ⟨_, vb, pb⟩ ← eval sα c b
-      let ⟨c, vc, p⟩ := evalAdd sα va vb
+      let ⟨c, vc, p⟩ ← evalAdd sα va vb
       pure ⟨c, vc, (q(add_congr $pa $pb $p) : Expr)⟩
     | _ => els
   | ``HMul.hMul, _, _ | ``Mul.mul, _, _ => match e with
     | ~q($a * $b) =>
       let ⟨_, va, pa⟩ ← eval sα c a
       let ⟨_, vb, pb⟩ ← eval sα c b
-      let ⟨c, vc, p⟩ := evalMul sα va vb
+      let ⟨c, vc, p⟩ ← evalMul sα va vb
       pure ⟨c, vc, (q(mul_congr $pa $pb $p) : Expr)⟩
     | _ => els
   | ``HSMul.hSMul, _, _ => match e with
@@ -1098,19 +1116,20 @@ partial def eval {u : Lean.Level} {α : Q(Type u)} (sα : Q(CommSemiring $α))
     | ~q($a ^ $b) =>
       let ⟨_, va, pa⟩ ← eval sα c a
       let ⟨_, vb, pb⟩ ← eval sℕ .nat b
-      let ⟨c, vc, p⟩ := evalPow sα va vb
+      let ⟨c, vc, p⟩ ← evalPow sα va vb
       pure ⟨c, vc, (q(pow_congr $pa $pb $p) : Expr)⟩
     | _ => els
   | ``Neg.neg, some rα, _ => match e with
     | ~q(-$a) =>
       let ⟨_, va, pa⟩ ← eval sα c a
-      let ⟨b, vb, p⟩ := evalNeg sα rα va
+      let ⟨b, vb, p⟩ ← evalNeg sα rα va
       pure ⟨b, vb, (q(neg_congr $pa $p) : Expr)⟩
+    | _ => els
   | ``HSub.hSub, some rα, _ | ``Sub.sub, some rα, _ => match e with
     | ~q($a - $b) => do
       let ⟨_, va, pa⟩ ← eval sα c a
       let ⟨_, vb, pb⟩ ← eval sα c b
-      let ⟨c, vc, p⟩ := evalSub sα rα va vb
+      let ⟨c, vc, p⟩ ← evalSub sα rα va vb
       pure ⟨c, vc, (q(sub_congr $pa $pb $p) : Expr)⟩
     | _ => els
   | ``Inv.inv, _, some dα => match e with
@@ -1118,6 +1137,7 @@ partial def eval {u : Lean.Level} {α : Q(Type u)} (sα : Q(CommSemiring $α))
       let ⟨_, va, pa⟩ ← eval sα c a
       let ⟨b, vb, p⟩ ← va.evalInv sα dα c.czα
       pure ⟨b, vb, (q(inv_congr $pa $p) : Expr)⟩
+    | _ => els
   | ``HDiv.hDiv, _, some dα | ``Div.div, _, some dα => match e with
     | ~q($a / $b) => do
       let ⟨_, va, pa⟩ ← eval sα c a

--- a/test/tactic_timeout.lean
+++ b/test/tactic_timeout.lean
@@ -4,7 +4,6 @@ import Mathlib.Tactic.Linarith
 # Test that tactics respond to a cancellation request
 -/
 
-set_option linter.unusedTactic false
 
 variable {α}
 
@@ -49,6 +48,8 @@ elab "with_timeout " ms:num "=>" tac:tacticSeq : tactic => do
   if let .inr _duration ← Tactic.withTimeout ms (evalTactic tac) then
     throwError f!"Tactic took more than {ms}ms"
 
+set_option linter.unusedTactic false
+
 /-- error: Tactic took more than 500ms -/
 #guard_msgs in
 example : True := by
@@ -78,6 +79,8 @@ elab "check_timeouts " tol_ms:num "=>" tac:tacticSeq : tactic => do
     t := t + tol_ms
 
 set_option maxHeartbeats 0
+set_option linter.unusedTactic false
+set_option linter.unusedVariables false
 
 theorem linear_combination_with_10_terms
     (a b c d e f g h i j : Int)

--- a/test/tactic_timeout.lean
+++ b/test/tactic_timeout.lean
@@ -1,0 +1,95 @@
+import Mathlib.Tactic.Linarith
+
+/-!
+# Test that tactics respond to a cancellation request
+-/
+
+set_option linter.unusedTactic false
+
+variable {α}
+
+open Lean Elab Tactic
+
+/-! versions of try/catch that catch `interrupted` too  -/
+section catch_interrupted
+attribute [-instance]
+  Lean.instMonadExceptOfExceptionCoreM Lean.Elab.Tactic.instMonadExceptExceptionTacticM
+
+def Meta.tryCatchAll (m : MetaM α) (h : Exception → MetaM α) : MetaM α := tryCatch m h
+def Term.tryCatchAll (m : TermElabM α) (h : Exception → TermElabM α) : TermElabM α := tryCatch m h
+def Tactic.tryCatchAll (x : TacticM α) (h : Exception → TacticM α) : TacticM α := do
+  let b ← saveState
+  try x catch ex => b.restore; h ex
+
+end catch_interrupted
+
+section test_infra
+
+def Tactic.withTimeout (ms : UInt32) (t : TacticM α) : TacticM (α ⊕ Nat) := do
+  let tk ← IO.CancelToken.new
+  withTheReader Core.Context (fun s => { s with cancelTk? := some tk }) do
+    let t0 ← IO.monoMsNow
+    let watchdog ← IO.asTask do
+      IO.sleep ms
+      tk.set
+    let r ← Tactic.tryCatchAll (.inl <$> t)
+      (fun e => do
+        IO.cancel watchdog
+        if !e.isInterrupt || !(← tk.isSet) then
+          throw e
+        else
+          let duration := (← IO.monoMsNow) - t0
+          return .inr duration)
+    IO.cancel watchdog
+    return r
+
+/-- `with_timeout 100 => tac` allows `tac` only 100ms to run. -/
+elab "with_timeout " ms:num "=>" tac:tacticSeq : tactic => do
+  let ms := ms.getNat.toUInt32
+  if let .inr _duration ← Tactic.withTimeout ms (evalTactic tac) then
+    throwError f!"Tactic took more than {ms}ms"
+
+/-- error: Tactic took more than 500ms -/
+#guard_msgs in
+example : True := by
+  with_timeout 500 =>
+    sleep 1000
+    trivial
+
+example: True := by
+  with_timeout 500 =>
+    sleep 100
+    trivial
+
+end test_infra
+
+/-- `check_timeouts 100 => tac` checks that `tac` never goes longer than `100ms` without checking
+for cancellation. -/
+elab "check_timeouts " tol_ms:num "=>" tac:tacticSeq : tactic => do
+  let mut t := 0
+  let tol_ms := tol_ms.getNat
+  repeat do
+    if let .inr duration ← Tactic.withTimeout t.toUInt32 (evalTactic tac) then
+      if duration > t + tol_ms then
+        logError f!"Tactic took much more than {t}ms ({duration}ms)"
+      trace[debug] "Tactic overran from {t}ms to {duration}ms"
+    else
+      break
+    t := t + tol_ms
+
+set_option maxHeartbeats 0
+
+theorem linear_combination_with_10_terms
+    (a b c d e f g h i j : Int)
+    (h0 : -e + g + -h + i = 0)
+    (h1 : b + -d + -e + f + g + i = 0)
+    (h2 : -b + j = 0)
+    (h3 : c + d + -f + -i = 0)
+    (h4 : b + c + e + -g + -h + i + j = 0)
+    (h5 : -a + b + d + f + -h + -i = 0)
+    (h6 : a + d + e + -g + -h = 0)
+    (h7 : -a + d + -f + -h + j = 0)
+    (h8 : a + -d + e + f + g + h + -i + j = 0)
+    (h9 : -a + b + c + -e + -f + h + j = 0) :
+      -2*a + b + 2*c + d + -3*f + -g + 3*h + -3*i = 0 := by
+  check_timeouts 250 => nlinarith


### PR DESCRIPTION
Without this change, linarith calls on large states can substantially overrun

On the web editor, the test fails with
```
Tactic took much more than 750ms (1272ms)
Tactic took much more than 1000ms (1267ms)
Tactic took much more than 2250ms (2679ms)
```

Co-authored-by: Laurent Sartran <lsartran@google.com>

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
