### PR TITLE
[Merged by Bors] - feat(Algebra/OpenSubgroup): quotient of compact group by open subgroup is finite

### DIFF
--- a/Mathlib/Topology/Algebra/Group/Basic.lean
+++ b/Mathlib/Topology/Algebra/Group/Basic.lean
@@ -855,6 +855,10 @@ instance instTopologicalSpace (N : Subgroup G) : TopologicalSpace (G ⧸ N) :=
   instTopologicalSpaceQuotient
 
 @[to_additive]
+instance [CompactSpace G] (N : Subgroup G) : CompactSpace (G ⧸ N) :=
+  Quotient.compactSpace
+
+@[to_additive]
 theorem quotientMap_mk (N : Subgroup G) : QuotientMap (mk : G → G ⧸ N) :=
   quotientMap_quot_mk
 

--- a/Mathlib/Topology/Algebra/OpenSubgroup.lean
+++ b/Mathlib/Topology/Algebra/OpenSubgroup.lean
@@ -275,6 +275,11 @@ lemma isClosed_of_isOpen [ContinuousMul G] (U : Subgroup G) (h : IsOpen (U : Set
   OpenSubgroup.isClosed ⟨U, h⟩
 
 @[to_additive]
+lemma subgroupOf_isOpen (U K : Subgroup G) (h : IsOpen (K : Set G)) :
+    IsOpen (K.subgroupOf U : Set U) :=
+  Continuous.isOpen_preimage (continuous_iff_le_induced.mpr fun _ ↦ id) _ h
+
+@[to_additive]
 lemma discreteTopology [ContinuousMul G] (U : Subgroup G) (h : IsOpen (U : Set G)) :
     DiscreteTopology (G ⧸ U) := by
   refine singletons_open_iff_discrete.mp (fun g ↦ ?_)
@@ -288,19 +293,31 @@ lemma discreteTopology [ContinuousMul G] (U : Subgroup G) (h : IsOpen (U : Set G
   · exact Homeomorph.mulLeft g |>.isOpen_image |>.mpr h
 
 @[to_additive]
+instance [ContinuousMul G] (U : OpenSubgroup G) : DiscreteTopology (G ⧸ U.toSubgroup) :=
+  discreteTopology U.toSubgroup U.isOpen
+
+@[to_additive]
 lemma quotient_finite_of_isOpen [ContinuousMul G] [CompactSpace G] (U : Subgroup G)
     (h : IsOpen (U : Set G)) : Finite (G ⧸ U) :=
   have : DiscreteTopology (G ⧸ U) := U.discreteTopology h
   finite_of_compact_of_discrete
 
 @[to_additive]
-lemma quotient_finite_of_isOpen' [TopologicalGroup G] [CompactSpace G] (U K : Subgroup G)
-    (hUopen : IsOpen (U : Set G)) (hKopen : IsOpen (K : Set G)) :
-    Finite (U ⧸ K.subgroupOf U) := by
+instance [ContinuousMul G] [CompactSpace G] (U : OpenSubgroup G) : Finite (G ⧸ U.toSubgroup) :=
+  quotient_finite_of_isOpen U.toSubgroup U.isOpen
+
+@[to_additive]
+lemma quotient_finite_of_isOpen' [TopologicalGroup G] [CompactSpace G] (U : Subgroup G)
+    (K : Subgroup U) (hUopen : IsOpen (U : Set G)) (hKopen : IsOpen (K : Set U)) :
+    Finite (U ⧸ K) :=
   have : CompactSpace U := isCompact_iff_compactSpace.mp <| IsClosed.isCompact <|
     U.isClosed_of_isOpen hUopen
-  apply (K.subgroupOf U).quotient_finite_of_isOpen
-  exact Continuous.isOpen_preimage (continuous_iff_le_induced.mpr fun _ a ↦ a) _ hKopen
+  K.quotient_finite_of_isOpen hKopen
+
+@[to_additive]
+instance [TopologicalGroup G] [CompactSpace G] (U : OpenSubgroup G) (K : OpenSubgroup U) :
+    Finite (U ⧸ K.toSubgroup) :=
+  quotient_finite_of_isOpen' U.toSubgroup K.toSubgroup U.isOpen K.isOpen
 
 end Subgroup
 

--- a/Mathlib/Topology/Algebra/OpenSubgroup.lean
+++ b/Mathlib/Topology/Algebra/OpenSubgroup.lean
@@ -290,7 +290,6 @@ lemma discreteTopology [ContinuousMul G] (U : Subgroup G) (h : IsOpen (U : Set G
 @[to_additive]
 lemma quotient_finite_of_isOpen [ContinuousMul G] [CompactSpace G] (U : Subgroup G)
     (h : IsOpen (U : Set G)) : Finite (G ⧸ U) :=
-  have : CompactSpace (G ⧸ U) := Quotient.compactSpace
   have : DiscreteTopology (G ⧸ U) := U.discreteTopology h
   finite_of_compact_of_discrete
 

--- a/Mathlib/Topology/Algebra/OpenSubgroup.lean
+++ b/Mathlib/Topology/Algebra/OpenSubgroup.lean
@@ -269,6 +269,40 @@ theorem isOpen_of_one_mem_interior [ContinuousMul G] (H: Subgroup G)
     (h_1_int : (1 : G) ∈ interior (H : Set G)) : IsOpen (H : Set G) :=
   isOpen_of_mem_nhds H <| mem_interior_iff_mem_nhds.1 h_1_int
 
+@[to_additive]
+lemma isClosed_of_isOpen [ContinuousMul G] (U : Subgroup G) (h : IsOpen (U : Set G)) :
+    IsClosed (U : Set G) :=
+  OpenSubgroup.isClosed ⟨U, h⟩
+
+@[to_additive]
+lemma discreteTopology [ContinuousMul G] (U : Subgroup G) (h : IsOpen (U : Set G)) :
+    DiscreteTopology (G ⧸ U) := by
+  refine singletons_open_iff_discrete.mp (fun g ↦ ?_)
+  induction' g using Quotient.inductionOn with g
+  show IsOpen (QuotientGroup.mk ⁻¹' {QuotientGroup.mk g})
+  convert_to IsOpen ((g * ·) '' U)
+  · ext g'
+    simp only [Set.mem_preimage, Set.mem_singleton_iff, QuotientGroup.eq, Set.image_mul_left]
+    rw [← U.inv_mem_iff]
+    simp
+  · exact Homeomorph.mulLeft g |>.isOpen_image |>.mpr h
+
+@[to_additive]
+lemma quotient_finite_of_isOpen [ContinuousMul G] [CompactSpace G] (U : Subgroup G)
+    (h : IsOpen (U : Set G)) : Finite (G ⧸ U) :=
+  have : CompactSpace (G ⧸ U) := Quotient.compactSpace
+  have : DiscreteTopology (G ⧸ U) := U.discreteTopology h
+  finite_of_compact_of_discrete
+
+@[to_additive]
+lemma quotient_finite_of_isOpen' [TopologicalGroup G] [CompactSpace G] (U K : Subgroup G)
+    (hUopen : IsOpen (U : Set G)) (hKopen : IsOpen (K : Set G)) :
+    Finite (U ⧸ K.subgroupOf U) := by
+  have : CompactSpace U := isCompact_iff_compactSpace.mp <| IsClosed.isCompact <|
+    U.isClosed_of_isOpen hUopen
+  apply (K.subgroupOf U).quotient_finite_of_isOpen
+  exact Continuous.isOpen_preimage (continuous_iff_le_induced.mpr fun _ a ↦ a) _ hKopen
+
 end Subgroup
 
 namespace OpenSubgroup


### PR DESCRIPTION
Shows that the quotient of a compact topological group by an open subgroup is finite.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
