### PR TITLE
[Merged by Bors] - chore: remove (syntactically) duplicate import

### DIFF
--- a/Mathlib/CategoryTheory/Sites/Adjunction.lean
+++ b/Mathlib/CategoryTheory/Sites/Adjunction.lean
@@ -5,7 +5,6 @@ Authors: Adam Topaz, Joël Riou
 -/
 import Mathlib.CategoryTheory.Adjunction.Restrict
 import Mathlib.CategoryTheory.Adjunction.Whiskering
-import Mathlib.CategoryTheory.Adjunction.Restrict
 import Mathlib.CategoryTheory.Sites.PreservesSheafification
 
 /-!


### PR DESCRIPTION
---

Found using the duplicate imports linter in PR #16384:

```
% lake exe lint-style
error: Mathlib/CategoryTheory/Sites/Adjunction.lean:8: Duplicate imports: import Mathlib.CategoryTheory.Adjunction.Restrict (already imported on line 6)
error: found 1 new style error(s)
```

Import added in #16317.