### PR TITLE
[Merged by Bors] - fix: ignore Aesop tactic/commands in unused tactics linter

### DIFF
--- a/Mathlib/Tactic/Linter/UnusedTactic.lean
+++ b/Mathlib/Tactic/Linter/UnusedTactic.lean
@@ -133,6 +133,9 @@ initialize ignoreTacticKindsRef : IO.Ref NameHashSet ←
     |>.insert `Mathlib.Tactic.Hint.registerHintStx
     |>.insert `Mathlib.Tactic.LinearCombination.linearCombination
     |>.insert `Mathlib.Tactic.LinearCombination'.linearCombination'
+    |>.insert `Aesop.Frontend.Parser.addRules
+    |>.insert `Aesop.Frontend.Parser.aesopTactic
+    |>.insert `Aesop.Frontend.Parser.aesopTactic?
     -- the following `SyntaxNodeKind`s play a role in silencing `test`s
     |>.insert ``Lean.Parser.Tactic.failIfSuccess
     |>.insert `Mathlib.Tactic.successIfFailWithMsg

--- a/MathlibTest/AesopUnusedTactic.lean
+++ b/MathlibTest/AesopUnusedTactic.lean
@@ -1,0 +1,20 @@
+/-
+Copyright (c) 2024 Jannis Limperg. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Jannis Limperg
+-/
+
+import Aesop
+import Mathlib.Tactic.Linter.UnusedTactic
+
+/-
+The unused tactic linter should not consider tactics unused if they appear in
+Aesop's `add_aesop_rules` command...
+-/
+add_aesop_rules safe (by simp)
+
+/-
+... or in an `add` clause.
+-/
+example : True := by
+  aesop (add safe (by simp))

--- a/MathlibTest/AesopUnusedTactic.lean
+++ b/MathlibTest/AesopUnusedTactic.lean
@@ -7,6 +7,8 @@ Authors: Jannis Limperg
 import Aesop
 import Mathlib.Tactic.Linter.UnusedTactic
 
+set_option linter.unusedTactic true
+
 /-
 The unused tactic linter should not consider tactics unused if they appear in
 Aesop's `add_aesop_rules` command...


### PR DESCRIPTION

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
