### PR TITLE
[Merged by Bors] - fix: please the long line linter in check-yaml

### DIFF
--- a/scripts/check-yaml.lean
+++ b/scripts/check-yaml.lean
@@ -22,11 +22,11 @@ def readJsonFile (α) [FromJson α] (path : System.FilePath) : IO α := do
   let _ : MonadExceptOf String IO := ⟨throw ∘ IO.userError, fun x _ => x⟩
   liftExcept <| fromJson? <|← liftExcept <| Json.parse <|← IO.FS.readFile path
 
-def databases : List (String × String) := [
-  ("undergrad.json", "Entries in `docs/undergrad.yaml` refer to declarations that don't exist. Please correct the following:"),
-  ("overview.json", "Entries in `docs/overview.yaml` refer to declarations that don't exist. Please correct the following:"),
-  ("100.json", "Entries in `docs/100.yaml` refer to declarations that don't exist. Please correct the following:")
-]
+def databases : List (String × String) :=
+  ["undergrad", "overview", "100"].map fun dir =>
+    (dir ++ ".json",
+      s!"Entries in `docs/{dir}.yaml` refer to declarations that don't exist. \
+        Please correct the following:")
 
 def processDb (decls : ConstMap) : String × String → IO Bool
 | (file, msg) => do


### PR DESCRIPTION
The new long line linter reaches into `scripts.check-yaml` as well and emits a warning.  It is innocuous, but the fix is also easy!

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
