### PR TITLE
[Merged by Bors] - chore: deprecate all but `IsSymmOp` in `Init.Algebra.Classes`

### DIFF
--- a/Mathlib/Algebra/Group/Defs.lean
+++ b/Mathlib/Algebra/Group/Defs.lean
@@ -49,7 +49,6 @@ See the module `Algebra.AddTorsor` for a motivating example for the name `VAdd` 
 assert_not_exists MonoidWithZero
 assert_not_exists DenselyOrdered
 assert_not_exists Function.Injective.eq_iff
-assert_not_exists IsCommutative
 
 universe u v w
 

--- a/Mathlib/Init/Algebra/Classes.lean
+++ b/Mathlib/Init/Algebra/Classes.lean
@@ -13,142 +13,38 @@ The files in `Mathlib/Init` are leftovers from the port from Mathlib3.
 We intend to move all the content of these files out into the main `Mathlib` directory structure.
 Contributions assisting with this are appreciated.
 
-(Yaël): The only things of interest in this file now are the unbundled algebra classes
+(Jeremy Tan: The only non-deprecated thing in this file now is `IsSymmOp`)
 
 # Unbundled algebra classes
 
-These classes are part of an incomplete refactor described
+These classes were part of an incomplete refactor described
 [here on the github Wiki](https://github.com/leanprover/lean/wiki/Refactoring-structures#encoding-the-algebraic-hierarchy-1).
 However a subset of them are widely used in mathlib3,
 and it has been tricky to clean this up as this file was in core Lean 3.
-
-By themselves, these classes are not good replacements for the `Monoid` / `Group` etc structures
-provided by mathlib, as they are not discoverable by `simp` unlike the current lemmas due to there
-being little to index on. The Wiki page linked above describes an algebraic normalizer, but it was
-never implemented in Lean 3.
-
-## Porting note:
-This file is ancient, and it would be good to replace it with a clean version
-that provides what mathlib4 actually needs.
-
-I've omitted all the `@[algebra]` attributes, as they are not used elsewhere.
-
-The section `StrictWeakOrder` has been omitted, but I've left the mathport output in place.
-Please delete if cleaning up.
-
-I've commented out some classes which we think are completely unused in mathlib.
-
-I've added many of the declarations to `nolints.json`.
-If you clean up this file, please add documentation to classes that we are keeping.
-
-Mario made the following analysis of uses in mathlib3:
-* `is_symm_op`: unused except for some instances
-* `is_commutative`: used a fair amount via some theorems about folds
-  (also assuming `is_associative`)
-* `is_associative`: ditto, also used in `noncomm_fold`
-* `is_left_id`, `is_right_id`: unused except in the mathlib class `is_unital` and in `mono`
-  (which looks like it could use `is_unital`)
-* `is_left_null`, `is_right_null`: unused
-* `is_left_cancel`, `is_right_cancel`: unused except for instances
-* `is_idempotent`: this one is actually used to prove things not directly about `is_idempotent`
-* `is_left_distrib`, `is_right_distrib`, `is_left_inv`, `is_right_inv`, `is_cond_left_inv`,
-  `is_cond_right_inv`: unused
-* `is_distinct`: unused (although we reinvented this one as `nontrivial`)
-* `is_irrefl`, `is_refl`, `is_symm`, `is_trans`: significant usage
-* `is_asymm`, `is_antisymm`, `is_total`, `is_strict_order`: a lot of uses but all in order theory
-  and it's unclear how much could not be transferred to another typeclass
-* `is_preorder`: unused except for instances
-  (except `antisymmetrization`, maybe it could be transferred)
-* `is_total_preorder`, `is_partial_order`: unused except for instances
-* `is_linear_order`: unused except for instances
-* `is_equiv`: unused except for instances (most uses can use `equivalence` instead)
-* `is_per`: unused
-* `is_incomp_trans`: unused
-* `is_strict_weak_order`: significant usage (most of it on `rbmap`, could be transferred)
-* `is_trichotomous`: some usage
-* `is_strict_total_order`: looks like the only usage is in `rbmap` again
 -/
 
 set_option linter.deprecated false
 
 universe u v
 
--- Porting note: removed `outParam`
+/-- `IsSymmOp α β op` where `op : α → α → β` is the natural generalisation of
+`Std.IsCommutative` (`β = α`) and `IsSymm` (`β = Prop`). -/
 class IsSymmOp (α : Sort u) (β : Sort v) (op : α → α → β) : Prop where
   symm_op : ∀ a b, op a b = op b a
-
-/-- A commutative binary operation. -/
-@[deprecated Std.Commutative (since := "2024-02-02")]
-abbrev IsCommutative (α : Sort u) (op : α → α → α) := Std.Commutative op
 
 instance (priority := 100) isSymmOp_of_isCommutative (α : Sort u) (op : α → α → α)
     [Std.Commutative op] : IsSymmOp α α op where symm_op := Std.Commutative.comm
 
-/-- An associative binary operation. -/
-@[deprecated Std.Associative (since := "2024-02-02")]
-abbrev IsAssociative (α : Sort u) (op : α → α → α) := Std.Associative op
+instance (priority := 100) isSymmOp_of_isSymm (α : Sort u) (op : α → α → Prop) [IsSymm α op] :
+    IsSymmOp α Prop op where symm_op a b := propext <| Iff.intro (IsSymm.symm a b) (IsSymm.symm b a)
 
-/-- A binary operation with a left identity. -/
-@[deprecated Std.LawfulLeftIdentity (since := "2024-02-02")]
-abbrev IsLeftId (α : Sort u) (op : α → α → α) (o : outParam α) := Std.LawfulLeftIdentity op o
-
-/-- A binary operation with a right identity. -/
-@[deprecated Std.LawfulRightIdentity (since := "2024-02-02")]
-abbrev IsRightId (α : Sort u) (op : α → α → α) (o : outParam α) := Std.LawfulRightIdentity op o
-
--- class IsLeftNull (α : Sort u) (op : α → α → α) (o : outParam α) : Prop where
---   left_null : ∀ a, op o a = o
-
--- class IsRightNull (α : Sort u) (op : α → α → α) (o : outParam α) : Prop where
---   right_null : ∀ a, op a o = o
-
+@[deprecated (since := "2024-09-11")]
 class IsLeftCancel (α : Sort u) (op : α → α → α) : Prop where
   left_cancel : ∀ a b c, op a b = op a c → b = c
 
+@[deprecated (since := "2024-09-11")]
 class IsRightCancel (α : Sort u) (op : α → α → α) : Prop where
   right_cancel : ∀ a b c, op a b = op c b → a = c
-
-@[deprecated Std.IdempotentOp (since := "2024-02-02")]
-abbrev IsIdempotent (α : Sort u) (op : α → α → α) := Std.IdempotentOp op
-
--- class IsLeftDistrib (α : Sort u) (op₁ : α → α → α) (op₂ : outParam <| α → α → α) : Prop where
---   left_distrib : ∀ a b c, op₁ a (op₂ b c) = op₂ (op₁ a b) (op₁ a c)
-
--- class IsRightDistrib (α : Sort u) (op₁ : α → α → α) (op₂ : outParam <| α → α → α) : Prop where
---   right_distrib : ∀ a b c, op₁ (op₂ a b) c = op₂ (op₁ a c) (op₁ b c)
-
--- class IsLeftInv (α : Sort u) (op : α → α → α) (inv : outParam <| α → α) (o : outParam α) :
---     Prop where
---   left_inv : ∀ a, op (inv a) a = o
-
--- class IsRightInv (α : Sort u) (op : α → α → α) (inv : outParam <| α → α) (o : outParam α) :
---     Prop where
---   right_inv : ∀ a, op a (inv a) = o
-
--- class IsCondLeftInv (α : Sort u) (op : α → α → α) (inv : outParam <| α → α) (o : outParam α)
---     (p : outParam <| α → Prop) : Prop where
---   left_inv : ∀ a, p a → op (inv a) a = o
-
--- class IsCondRightInv (α : Sort u) (op : α → α → α) (inv : outParam <| α → α) (o : outParam α)
---     (p : outParam <| α → Prop) : Prop where
---   right_inv : ∀ a, p a → op a (inv a) = o
-
--- class IsDistinct (α : Sort u) (a : α) (b : α) : Prop where
---   distinct : a ≠ b
-
-/-
--- The following type class doesn't seem very useful, a regular simp lemma should work for this.
-class is_inv (α : Sort u) (β : Sort v) (f : α → β) (g : out β → α) : Prop :=
-(inv : ∀ a, g (f a) = a)
-
--- The following one can also be handled using a regular simp lemma
-class is_idempotent (α : Sort u) (f : α → α) : Prop :=
-(idempotent : ∀ a, f (f a) = f a)
--/
-
-/-- The opposite of a symmetric relation is symmetric. -/
-instance (priority := 100) isSymmOp_of_isSymm (α : Sort u) (r : α → α → Prop) [IsSymm α r] :
-    IsSymmOp α Prop r where symm_op a b := propext <| Iff.intro (IsSymm.symm a b) (IsSymm.symm b a)
 
 /-- `IsTotalPreorder X r` means that the binary relation `r` on `X` is total and a preorder. -/
 @[deprecated (since := "2024-07-30")]
@@ -159,10 +55,6 @@ instance (priority := 100) isTotalPreorder_isPreorder (α : Sort u) (r : α → 
     [s : IsTotalPreorder α r] : IsPreorder α r where
   trans := s.trans
   refl a := Or.elim (@IsTotal.total _ r _ a a) id id
-
--- /-- `IsPer X r` means that the binary relation `r` on `X` is a partial equivalence relation, that
--- is, `IsSymm X r` and `IsTrans X r`. -/
--- class IsPer (α : Sort u) (r : α → α → Prop) extends IsSymm α r, IsTrans α r : Prop
 
 /-- `IsIncompTrans X lt` means that for `lt` a binary relation on `X`, the incomparable relation
 `fun a b => ¬ lt a b ∧ ¬ lt b a` is transitive. -/
@@ -240,7 +132,7 @@ instance isEquiv : IsEquiv α (@Equiv _ r) where
 end
 
 /-- The equivalence relation induced by `lt` -/
-notation:50 a " ≈[" lt "]" b:50 => @Equiv _ lt a b--Equiv (r := lt) a b
+notation:50 a " ≈[" lt "]" b:50 => @Equiv _ lt a b
 
 end StrictWeakOrder
 
@@ -275,7 +167,6 @@ instance : IsTotalPreorder α (· ≤ ·) where
   trans := @le_trans _ _
   total := le_total
 
--- TODO(Leo): decide whether we should keep this instance or not
 set_option linter.deprecated false in
 @[deprecated (since := "2024-07-30")]
 instance isStrictWeakOrder_of_linearOrder : IsStrictWeakOrder α (· < ·) :=

--- a/Mathlib/Logic/Equiv/Basic.lean
+++ b/Mathlib/Logic/Equiv/Basic.lean
@@ -1733,9 +1733,13 @@ instance [Std.Associative f] : Std.Associative (e.arrowCongr (e.arrowCongr e) f)
 instance [Std.IdempotentOp f] : Std.IdempotentOp (e.arrowCongr (e.arrowCongr e) f) :=
   (e.semiconj₂_conj f).isIdempotent_right e.surjective
 
+set_option linter.deprecated false in
+@[deprecated (since := "2024-09-11")]
 instance [IsLeftCancel α₁ f] : IsLeftCancel β₁ (e.arrowCongr (e.arrowCongr e) f) :=
   ⟨e.surjective.forall₃.2 fun x y z => by simpa using @IsLeftCancel.left_cancel _ f _ x y z⟩
 
+set_option linter.deprecated false in
+@[deprecated (since := "2024-09-11")]
 instance [IsRightCancel α₁ f] : IsRightCancel β₁ (e.arrowCongr (e.arrowCongr e) f) :=
   ⟨e.surjective.forall₃.2 fun x y z => by simpa using @IsRightCancel.right_cancel _ f _ x y z⟩
 

--- a/scripts/nolints.json
+++ b/scripts/nolints.json
@@ -11,7 +11,6 @@
  ["docBlame", "IsIdempotent"],
  ["docBlame", "IsLeftCancel"],
  ["docBlame", "IsRightCancel"],
- ["docBlame", "IsSymmOp"],
  ["docBlame", "LawfulMonadCont"],
  ["docBlame", "LeftCancelative"],
  ["docBlame", "LeftCommutative"],


### PR DESCRIPTION
* Remove commented-out code and the deprecations from February.
* Deprecate `IsLeftCancel` and `IsRightCancel` as they are only used for two instances, both in `Logic.Equiv`.
* Update and clean up the module header to reflect all this. Only `IsSymmOp` is left undeprecated now.