### PR TITLE
[Merged by Bors] - fix: make print-style-errors.sh robust against file names with quotes

### DIFF
--- a/scripts/print-style-errors.sh
+++ b/scripts/print-style-errors.sh
@@ -11,6 +11,6 @@ IFS=$'\n\t'
 
 # use C locale so that sorting is the same on macOS and Linux
 # see https://unix.stackexchange.com/questions/362728/why-does-gnu-sort-sort-differently-on-my-osx-machine-and-linux-machine
-find Mathlib -name '*.lean' | xargs ./scripts/lint-style.py "$@" | LC_ALL=C sort || true
-find Archive -name '*.lean' | xargs ./scripts/lint-style.py "$@" | LC_ALL=C sort || true
-find Counterexamples -name '*.lean' | xargs ./scripts/lint-style.py "$@" | LC_ALL=C sort || true
+find Mathlib -name '*.lean' -print0 | xargs --null ./scripts/lint-style.py "$@" | LC_ALL=C sort || true
+find Archive -name '*.lean' -print0 | xargs --null ./scripts/lint-style.py "$@" | LC_ALL=C sort || true
+find Counterexamples -name '*.lean' -print0 | xargs --null ./scripts/lint-style.py "$@" | LC_ALL=C sort || true


### PR DESCRIPTION
Notably, any file after Mathlib/Tactic/LinearCombination'.lean in the find output was not linted.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
