### PR TITLE
[Merged by Bors] - feat(Lie): make `CommutatorRing` a `NonUnitalNonAssocRing`

### DIFF
--- a/Mathlib/Algebra/Lie/NonUnitalNonAssocAlgebra.lean
+++ b/Mathlib/Algebra/Lie/NonUnitalNonAssocAlgebra.lean
@@ -23,7 +23,7 @@ algebra and we provide some basic definitions for doing so here.
 
 ## Main definitions
 
-  * `CommutatorRing` turns a Lie ring into a `NonUnitalNonAssocSemiring` by turning its
+  * `CommutatorRing` turns a Lie ring into a `NonUnitalNonAssocRing` by turning its
     `Bracket` (denoted `⁅ , ⁆`) into a `Mul` (denoted `*`).
   * `LieHom.toNonUnitalAlgHom`
 
@@ -37,17 +37,17 @@ universe u v w
 
 variable (R : Type u) (L : Type v) [CommRing R] [LieRing L] [LieAlgebra R L]
 
-/-- Type synonym for turning a `LieRing` into a `NonUnitalNonAssocSemiring`.
+/-- Type synonym for turning a `LieRing` into a `NonUnitalNonAssocRing`.
 
-A `LieRing` can be regarded as a `NonUnitalNonAssocSemiring` by turning its
+A `LieRing` can be regarded as a `NonUnitalNonAssocRing` by turning its
 `Bracket` (denoted `⁅, ⁆`) into a `Mul` (denoted `*`). -/
 def CommutatorRing (L : Type v) : Type v := L
 
-/-- A `LieRing` can be regarded as a `NonUnitalNonAssocSemiring` by turning its
+/-- A `LieRing` can be regarded as a `NonUnitalNonAssocRing` by turning its
 `Bracket` (denoted `⁅, ⁆`) into a `Mul` (denoted `*`). -/
-instance : NonUnitalNonAssocSemiring (CommutatorRing L) :=
-  show NonUnitalNonAssocSemiring L from
-    { (inferInstance : AddCommMonoid L) with
+instance : NonUnitalNonAssocRing (CommutatorRing L) :=
+  show NonUnitalNonAssocRing L from
+    { (inferInstance : AddCommGroup L) with
       mul := Bracket.bracket
       left_distrib := lie_add
       right_distrib := add_lie
@@ -64,11 +64,11 @@ instance : LieRing (CommutatorRing L) := show LieRing L by infer_instance
 
 instance : LieAlgebra R (CommutatorRing L) := show LieAlgebra R L by infer_instance
 
-/-- Regarding the `LieRing` of a `LieAlgebra` as a `NonUnitalNonAssocSemiring`, we can
+/-- Regarding the `LieRing` of a `LieAlgebra` as a `NonUnitalNonAssocRing`, we can
 reinterpret the `smul_lie` law as an `IsScalarTower`. -/
 instance isScalarTower : IsScalarTower R (CommutatorRing L) (CommutatorRing L) := ⟨smul_lie⟩
 
-/-- Regarding the `LieRing` of a `LieAlgebra` as a `NonUnitalNonAssocSemiring`, we can
+/-- Regarding the `LieRing` of a `LieAlgebra` as a `NonUnitalNonAssocRing`, we can
 reinterpret the `lie_smul` law as an `SMulCommClass`. -/
 instance smulCommClass : SMulCommClass R (CommutatorRing L) (CommutatorRing L) :=
   ⟨fun t x y => (lie_smul t x y).symm⟩
@@ -80,7 +80,7 @@ namespace LieHom
 variable {R L}
 variable {L₂ : Type w} [LieRing L₂] [LieAlgebra R L₂]
 
-/-- Regarding the `LieRing` of a `LieAlgebra` as a `NonUnitalNonAssocSemiring`, we can
+/-- Regarding the `LieRing` of a `LieAlgebra` as a `NonUnitalNonAssocRing`, we can
 regard a `LieHom` as a `NonUnitalAlgHom`. -/
 @[simps]
 def toNonUnitalAlgHom (f : L →ₗ⁅R⁆ L₂) : CommutatorRing L →ₙₐ[R] CommutatorRing L₂ :=


### PR DESCRIPTION
This PR makes `CommutatorRing` a `NonUnitalNonAssocRing`, instead of just a  `NonUnitalNonAssocSemiring`

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
