### PR TITLE
[Merged by Bors] - chore: namespace `rsuffices`

### DIFF
--- a/Mathlib/Tactic/RSuffices.lean
+++ b/Mathlib/Tactic/RSuffices.lean
@@ -13,6 +13,8 @@ of any syntax that would be valid in an `obtain` block. This tactic just calls `
 on the expression, and then `rotate_left`.
 -/
 
+namespace Mathlib.Tactic
+
 /--
 The `rsuffices` tactic is an alternative version of `suffices`, that allows the usage
 of any syntax that would be valid in an `obtain` block. This tactic just calls `obtain`
@@ -24,3 +26,5 @@ syntax (name := rsuffices) "rsuffices"
 macro_rules
 | `(tactic| rsuffices $[$pred]? $[: $foo]? $[:= $bar]?) =>
 `(tactic | (obtain $[$pred]? $[: $foo]? $[:= $bar]?; rotate_left))
+
+end Mathlib.Tactic


### PR DESCRIPTION
`rsuffices` should be globally available as a tactic, but having it available as an un-namespaced term of type `ParserDescr` is silly.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
