### PR TITLE
feat(Order/InitialSeg): `Subsingleton (α ≃o β)` on well-orders

### DIFF
--- a/Mathlib/Order/Fin/Basic.lean
+++ b/Mathlib/Order/Fin/Basic.lean
@@ -5,6 +5,7 @@ Authors: Robert Y. Lewis, Keeley Hoek
 -/
 import Mathlib.Data.Fin.Basic
 import Mathlib.Order.Hom.Set
+import Mathlib.Order.InitialSeg
 
 /-!
 # `Fin n` forms a bounded linear order
@@ -277,16 +278,6 @@ map. In this lemma we state that for each `i : Fin n` we have `(e i : ℕ) = (i 
     convert this
     simpa using h _ this (e.symm _).is_lt
   · rwa [← h j hj (hj.trans hi), ← lt_iff_val_lt_val, e.lt_iff_lt]
-
-instance orderIso_subsingleton : Subsingleton (Fin n ≃o α) :=
-  ⟨fun e e' => by
-    ext i
-    rw [← e.symm.apply_eq_iff_eq, e.symm_apply_apply, ← e'.trans_apply, Fin.ext_iff,
-      coe_orderIso_apply]⟩
-
-instance orderIso_subsingleton' : Subsingleton (α ≃o Fin n) := OrderIso.symm_injective.subsingleton
-
-instance orderIsoUnique : Unique (Fin n ≃o Fin n) := Unique.mk' _
 
 /-- Two strictly monotone functions from `Fin n` are equal provided that their ranges
 are equal. -/

--- a/Mathlib/Order/InitialSeg.lean
+++ b/Mathlib/Order/InitialSeg.lean
@@ -531,5 +531,43 @@ noncomputable def InitialSeg.total (r s) [IsWellOrder α r] [IsWellOrder β s] :
       · exact ⟨Sum.inr <| (g.codRestrict {x | Sum.Lex r s x f.top}
           (fun a => _root_.trans (g.lt_top a) h) h).ltEquiv f.subrelIso⟩
 
+/-! ### Order isomorphisms of well orders -/
+
+
+namespace OrderIso
+
+instance subsingleton_of_wellFoundedLT [LinearOrder α] [WellFoundedLT α] [Preorder β] :
+    Subsingleton (α ≃o β) := by
+  have : IsWellOrder α (· < ·) := ⟨ ⟩
+  refine ⟨fun f g ↦ ?_⟩
+  have := (f.symm.toRelIsoLT).toRelEmbedding.isWellOrder
+  ext a
+  change (InitialSeg.ofIso f.toRelIsoLT a) = (InitialSeg.ofIso g.toRelIsoLT a)
+  rw [InitialSeg.eq]
+
+instance subsingleton_of_wellFoundedLT' [LinearOrder β] [WellFoundedLT β] [Preorder α] :
+    Subsingleton (α ≃o β) := by
+  refine ⟨fun f g ↦ ?_⟩
+  change f.symm.symm = g.symm.symm
+  rw [Subsingleton.elim f.symm]
+
+instance unique_of_wellFoundedLT [LinearOrder α] [WellFoundedLT α] : Unique (α ≃o α) := Unique.mk' _
+
+instance subsingleton_of_wellFoundedGT [LinearOrder α] [WellFoundedGT α] [Preorder β] :
+    Subsingleton (α ≃o β) := by
+  refine ⟨fun f g ↦ ?_⟩
+  change f.dual.dual = g.dual.dual
+  rw [Subsingleton.elim f.dual]
+
+instance subsingleton_of_wellFoundedGT' [LinearOrder β] [WellFoundedGT β] [Preorder α] :
+    Subsingleton (α ≃o β) := by
+  refine ⟨fun f g ↦ ?_⟩
+  change f.dual.dual = g.dual.dual
+  rw [Subsingleton.elim f.dual]
+
+instance unique_of_wellFoundedGT [LinearOrder α] [WellFoundedGT α] : Unique (α ≃o α) := Unique.mk' _
+
+end OrderIso
+
 attribute [nolint simpNF] PrincipalSeg.ofElement_apply PrincipalSeg.subrelIso_symm_apply
   PrincipalSeg.apply_subrelIso PrincipalSeg.subrelIso_apply


### PR DESCRIPTION
This allows us to generalize an instance which stated this for `Fin n`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #xyz [optional extra text]

-->
- [ ] depends on: #16706

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
