### PR TITLE
[Merged by Bors] - feat(Topology/UniformSpace): `Subtype.isComplete_iff`

### DIFF
--- a/Mathlib/Topology/UniformSpace/UniformEmbedding.lean
+++ b/Mathlib/Topology/UniformSpace/UniformEmbedding.lean
@@ -275,7 +275,7 @@ theorem UniformInducing.isComplete_iff {f : α → β} {s : Set α} (hf : Unifor
 theorem UniformEmbedding.isComplete_iff {f : α → β} {s : Set α} (hf : UniformEmbedding f) :
     IsComplete (f '' s) ↔ IsComplete s := hf.toUniformInducing.isComplete_iff
 
-/-- Sets of subtype are complete iff the image under a coercion is. -/
+/-- Sets of a subtype are complete iff their image under the coercion is complete. -/
 theorem Subtype.isComplete_iff {p : α → Prop} {s : Set { x // p x }} :
     IsComplete s ↔ IsComplete ((↑) '' s : Set α) :=
   uniformEmbedding_subtype_val.isComplete_iff.symm

--- a/Mathlib/Topology/UniformSpace/UniformEmbedding.lean
+++ b/Mathlib/Topology/UniformSpace/UniformEmbedding.lean
@@ -265,20 +265,20 @@ theorem isComplete_image_iff {m : α → β} {s : Set α} (hm : UniformInducing 
   simp_rw [IsComplete, imp.swap (a := Cauchy _), ← mem_Iic (b := 𝓟 _), fact1.forall fact2,
     hm.cauchy_map_iff, exists_mem_image, map_le_iff_le_comap, hm.inducing.nhds_eq_comap]
 
-/-- If `f : X → Y` is an `Inducing` map, the image `f '' s` of a set `s` is complete
+/-- If `f : X → Y` is an `UniformInducing` map, the image `f '' s` of a set `s` is complete
   if and only if `s` is complete. -/
 theorem UniformInducing.isComplete_iff {f : α → β} {s : Set α} (hf : UniformInducing f) :
-    IsComplete s ↔ IsComplete (f '' s) := (isComplete_image_iff hf).symm
+    IsComplete (f '' s) ↔ IsComplete s := isComplete_image_iff hf
 
 /-- If `f : X → Y` is an `UniformEmbedding`, the image `f '' s` of a set `s` is complete
   if and only if `s` is complete. -/
-theorem UniformEmbedding.isCompact_iff {f : α → β} {s : Set α} (hf : UniformEmbedding f) :
-    IsComplete s ↔ IsComplete (f '' s) := hf.toUniformInducing.isComplete_iff
+theorem UniformEmbedding.isComplete_iff {f : α → β} {s : Set α} (hf : UniformEmbedding f) :
+    IsComplete (f '' s) ↔ IsComplete s := hf.toUniformInducing.isComplete_iff
 
 /-- Sets of subtype are complete iff the image under a coercion is. -/
 theorem Subtype.isComplete_iff {p : α → Prop} {s : Set { x // p x }} :
     IsComplete s ↔ IsComplete ((↑) '' s : Set α) :=
-  uniformEmbedding_subtype_val.isComplete_iff
+  uniformEmbedding_subtype_val.isComplete_iff.symm
 
 alias ⟨isComplete_of_complete_image, _⟩ := isComplete_image_iff
 

--- a/Mathlib/Topology/UniformSpace/UniformEmbedding.lean
+++ b/Mathlib/Topology/UniformSpace/UniformEmbedding.lean
@@ -265,6 +265,21 @@ theorem isComplete_image_iff {m : α → β} {s : Set α} (hm : UniformInducing 
   simp_rw [IsComplete, imp.swap (a := Cauchy _), ← mem_Iic (b := 𝓟 _), fact1.forall fact2,
     hm.cauchy_map_iff, exists_mem_image, map_le_iff_le_comap, hm.inducing.nhds_eq_comap]
 
+/-- If `f : X → Y` is an `Inducing` map, the image `f '' s` of a set `s` is complete
+  if and only if `s` is complete. -/
+theorem UniformInducing.isComplete_iff {f : α → β} {s : Set α} (hf : UniformInducing f) :
+    IsComplete s ↔ IsComplete (f '' s) := (isComplete_image_iff hf).symm
+
+/-- If `f : X → Y` is an `UniformEmbedding`, the image `f '' s` of a set `s` is complete
+  if and only if `s` is complete. -/
+theorem UniformEmbedding.isCompact_iff {f : α → β} {s : Set α} (hf : UniformEmbedding f) :
+    IsComplete s ↔ IsComplete (f '' s) := hf.toUniformInducing.isComplete_iff
+
+/-- Sets of subtype are complete iff the image under a coercion is. -/
+theorem Subtype.isComplete_iff {p : α → Prop} {s : Set { x // p x }} :
+    IsComplete s ↔ IsComplete ((↑) '' s : Set α) :=
+  uniformEmbedding_subtype_val.isComplete_iff
+
 alias ⟨isComplete_of_complete_image, _⟩ := isComplete_image_iff
 
 theorem completeSpace_iff_isComplete_range {f : α → β} (hf : UniformInducing f) :


### PR DESCRIPTION
In the style of `Subtype.isCompact_iff`


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
