### PR TITLE
[Merged by Bors] - feat(Analysis/Normed/Field): ProperSpace of WeaklyLocallyCompact

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -1185,6 +1185,7 @@ import Mathlib.Analysis.Normed.Algebra.UnitizationL1
 import Mathlib.Analysis.Normed.Field.Basic
 import Mathlib.Analysis.Normed.Field.InfiniteSum
 import Mathlib.Analysis.Normed.Field.Lemmas
+import Mathlib.Analysis.Normed.Field.ProperSpace
 import Mathlib.Analysis.Normed.Field.UnitBall
 import Mathlib.Analysis.Normed.Group.AddCircle
 import Mathlib.Analysis.Normed.Group.AddTorsor

--- a/Mathlib/Analysis/Normed/Field/ProperSpace.lean
+++ b/Mathlib/Analysis/Normed/Field/ProperSpace.lean
@@ -16,17 +16,25 @@ Nontrivially normed fields are `ProperSpaces` when they are `WeaklyLocallyCompac
 ## Main results
 
 * `ProperSpace.of_nontriviallyNormedField_of_weaklyLocallyCompactSpace`
+
+## Implementation details
+
+This is a special case of `ProperSpace.of_locallyCompactSpace` from
+`Mathlib.Analysis.Normed.Module.FiniteDimension`, specialized to be on the field itself
+with a proof that requires fewer imports.
 -/
 
 open Metric Filter
 
-/-- A weakly locally compact normed field is proper. -/
+/-- A weakly locally compact normed field is proper.
+This is a specialization of `ProperSpace.of_locallyCompactSpace`
+which holds for `NormedSpace`s but requires more imports. -/
 lemma ProperSpace.of_nontriviallyNormedField_of_weaklyLocallyCompactSpace
     (𝕜 : Type*) [NontriviallyNormedField 𝕜] [WeaklyLocallyCompactSpace 𝕜] :
     ProperSpace 𝕜 := by
   rcases exists_isCompact_closedBall (0 : 𝕜) with ⟨r, rpos, hr⟩
   rcases NormedField.exists_one_lt_norm 𝕜 with ⟨c, hc⟩
-  have hC : ∀ n, IsCompact (closedBall (0 : 𝕜) (‖c‖^n * r)) := fun n ↦ by
+  have hC n : IsCompact (closedBall (0 : 𝕜) (‖c‖^n * r)) := by
     have : c ^ n ≠ 0 := pow_ne_zero _ <| fun h ↦ by simp [h, zero_le_one.not_lt] at hc
     convert hr.smul (c ^ n)
     ext

--- a/Mathlib/Analysis/Normed/Field/ProperSpace.lean
+++ b/Mathlib/Analysis/Normed/Field/ProperSpace.lean
@@ -24,6 +24,8 @@ This is a special case of `ProperSpace.of_locallyCompactSpace` from
 with a proof that requires fewer imports.
 -/
 
+assert_not_exists FiniteDimensional
+
 open Metric Filter
 
 /-- A weakly locally compact normed field is proper.

--- a/Mathlib/Analysis/Normed/Field/ProperSpace.lean
+++ b/Mathlib/Analysis/Normed/Field/ProperSpace.lean
@@ -1,0 +1,37 @@
+/-
+Copyright (c) 2024 Yakov Pechersky. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Yakov Pechersky
+-/
+
+import Mathlib.Analysis.Normed.Field.Lemmas
+import Mathlib.Analysis.SpecificLimits.Basic
+import Mathlib.Topology.MetricSpace.ProperSpace
+
+/-!
+# Proper nontrivally normed fields
+
+This file contains a direct result of normed fields that are `ProperSpace`s.
+
+## Main results
+
+* `ProperSpace.of_weaklyLocallyCompactSpace_of_nontriviallyNormedField`
+-/
+
+open Metric Filter
+
+/-- A weakly locally compact normed field is proper. -/
+lemma ProperSpace.of_weaklyLocallyCompactSpace_of_nontriviallyNormedField
+    (𝕜 : Type*) [NontriviallyNormedField 𝕜] [WeaklyLocallyCompactSpace 𝕜] :
+    ProperSpace 𝕜 := by
+  rcases exists_isCompact_closedBall (0 : 𝕜) with ⟨r, rpos, hr⟩
+  rcases NormedField.exists_one_lt_norm 𝕜 with ⟨c, hc⟩
+  have hC : ∀ n, IsCompact (closedBall (0 : 𝕜) (‖c‖^n * r)) := fun n ↦ by
+    have : c ^ n ≠ 0 := pow_ne_zero _ <| fun h ↦ by simp [h, zero_le_one.not_lt] at hc
+    convert hr.smul (c ^ n)
+    ext
+    simp [Set.mem_smul_set_iff_inv_smul_mem₀ this,
+      inv_mul_le_iff (by simpa using norm_pos_iff.mpr this)]
+  have hTop : Tendsto (fun n ↦ ‖c‖^n * r) atTop atTop :=
+    Tendsto.atTop_mul_const rpos (tendsto_pow_atTop_atTop_of_one_lt hc)
+  exact .of_seq_closedBall hTop (Eventually.of_forall hC)

--- a/Mathlib/Analysis/Normed/Field/ProperSpace.lean
+++ b/Mathlib/Analysis/Normed/Field/ProperSpace.lean
@@ -11,17 +11,17 @@ import Mathlib.Topology.MetricSpace.ProperSpace
 /-!
 # Proper nontrivally normed fields
 
-This file contains a direct result of normed fields that are `ProperSpace`s.
+Nontrivially normed fields are `ProperSpaces` when they are `WeaklyLocallyCompact`.
 
 ## Main results
 
-* `ProperSpace.of_weaklyLocallyCompactSpace_of_nontriviallyNormedField`
+* `ProperSpace.of_nontriviallyNormedField_of_weaklyLocallyCompactSpace`
 -/
 
 open Metric Filter
 
 /-- A weakly locally compact normed field is proper. -/
-lemma ProperSpace.of_weaklyLocallyCompactSpace_of_nontriviallyNormedField
+lemma ProperSpace.of_nontriviallyNormedField_of_weaklyLocallyCompactSpace
     (𝕜 : Type*) [NontriviallyNormedField 𝕜] [WeaklyLocallyCompactSpace 𝕜] :
     ProperSpace 𝕜 := by
   rcases exists_isCompact_closedBall (0 : 𝕜) with ⟨r, rpos, hr⟩
@@ -30,8 +30,9 @@ lemma ProperSpace.of_weaklyLocallyCompactSpace_of_nontriviallyNormedField
     have : c ^ n ≠ 0 := pow_ne_zero _ <| fun h ↦ by simp [h, zero_le_one.not_lt] at hc
     convert hr.smul (c ^ n)
     ext
-    simp [Set.mem_smul_set_iff_inv_smul_mem₀ this,
-      inv_mul_le_iff (by simpa using norm_pos_iff.mpr this)]
+    simp only [mem_closedBall, dist_zero_right, Set.mem_smul_set_iff_inv_smul_mem₀ this,
+      smul_eq_mul, norm_mul, norm_inv, norm_pow,
+      inv_mul_le_iff (by simpa only [norm_pow] using norm_pos_iff.mpr this)]
   have hTop : Tendsto (fun n ↦ ‖c‖^n * r) atTop atTop :=
     Tendsto.atTop_mul_const rpos (tendsto_pow_atTop_atTop_of_one_lt hc)
   exact .of_seq_closedBall hTop (Eventually.of_forall hC)

--- a/Mathlib/NumberTheory/Padics/ProperSpace.lean
+++ b/Mathlib/NumberTheory/Padics/ProperSpace.lean
@@ -28,6 +28,9 @@ and that `ℚ_[p]` is proper.
 Gouvêa, F. Q. (2020) p-adic Numbers An Introduction. 3rd edition.
   Cham, Springer International Publishing
 -/
+
+assert_not_exists FiniteDimensional
+
 open Metric Topology
 
 variable (p : ℕ) [Fact (Nat.Prime p)]

--- a/Mathlib/NumberTheory/Padics/ProperSpace.lean
+++ b/Mathlib/NumberTheory/Padics/ProperSpace.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Jou Glasheen, Kevin Buzzard
 -/
 
-import Mathlib.Analysis.Normed.Module.FiniteDimension
+import Mathlib.Analysis.Normed.Field.ProperSpace
 import Mathlib.NumberTheory.Padics.RingHoms
 
 /-!
@@ -55,7 +55,7 @@ namespace Padic
 
 /-- The field of p-adic numbers `ℚ_[p]` is a proper metric space. -/
 instance : ProperSpace ℚ_[p] := by
-  suffices LocallyCompactSpace ℚ_[p] from .of_locallyCompactSpace ℚ_[p]
+  suffices LocallyCompactSpace ℚ_[p] from .of_weaklyLocallyCompactSpace_of_nontriviallyNormedField _
   have : closedBall 0 1 ∈ 𝓝 (0 : ℚ_[p]) := closedBall_mem_nhds _ zero_lt_one
   simp only [closedBall, dist_eq_norm_sub, sub_zero] at this
   refine IsCompact.locallyCompactSpace_of_mem_nhds_of_addGroup ?_ this

--- a/Mathlib/NumberTheory/Padics/ProperSpace.lean
+++ b/Mathlib/NumberTheory/Padics/ProperSpace.lean
@@ -55,7 +55,7 @@ namespace Padic
 
 /-- The field of p-adic numbers `ℚ_[p]` is a proper metric space. -/
 instance : ProperSpace ℚ_[p] := by
-  suffices LocallyCompactSpace ℚ_[p] from .of_weaklyLocallyCompactSpace_of_nontriviallyNormedField _
+  suffices LocallyCompactSpace ℚ_[p] from .of_nontriviallyNormedField_of_weaklyLocallyCompactSpace _
   have : closedBall 0 1 ∈ 𝓝 (0 : ℚ_[p]) := closedBall_mem_nhds _ zero_lt_one
   simp only [closedBall, dist_eq_norm_sub, sub_zero] at this
   refine IsCompact.locallyCompactSpace_of_mem_nhds_of_addGroup ?_ this


### PR DESCRIPTION
Shortcut definition that doesn't require the generalization to any `NormedSpace` over such a field

Shake the p-adic proper space proof.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
