### PR TITLE
[Merged by Bors] - feat(Order/Interval/Set/Monotone): strictMono_of_lt_succ

### DIFF
--- a/Mathlib/Order/Interval/Set/Monotone.lean
+++ b/Mathlib/Order/Interval/Set/Monotone.lean
@@ -190,11 +190,15 @@ theorem strictMonoOn_Iic_of_lt_succ [SuccOrder α] [IsSuccArchimedean α] {n : �
 
 theorem strictMono_of_lt_succ [SuccOrder α] [IsSuccArchimedean α]
     (hψ : ∀ m, ψ m < ψ (succ m)) : StrictMono ψ := fun _ _ h ↦
-  (strictMonoOn_Iic_of_lt_succ fun m _ ↦ hψ m) h.le (le_refl _) h
+  (strictMonoOn_Iic_of_lt_succ fun m _ ↦ hψ m) h.le le_rfl h
 
 theorem strictAntiOn_Iic_of_succ_lt [SuccOrder α] [IsSuccArchimedean α] {n : α}
     (hψ : ∀ m, m < n → ψ (succ m) < ψ m) : StrictAntiOn ψ (Set.Iic n) := fun i hi j hj hij =>
   @strictMonoOn_Iic_of_lt_succ α βᵒᵈ _ _ ψ _ _ n hψ i hi j hj hij
+
+theorem strictAnti_of_pred_lt [SuccOrder α] [IsSuccArchimedean α]
+    (hψ : ∀ m, ψ (succ m) < ψ m) : StrictAnti ψ := fun _ _ h ↦
+  (strictAntiOn_Iic_of_succ_lt fun m _ ↦ hψ m) h.le le_rfl h
 
 theorem strictMonoOn_Ici_of_pred_lt [PredOrder α] [IsPredArchimedean α] {n : α}
     (hψ : ∀ m, n < m → ψ (pred m) < ψ m) : StrictMonoOn ψ (Set.Ici n) := fun i hi j hj hij =>

--- a/Mathlib/Order/Interval/Set/Monotone.lean
+++ b/Mathlib/Order/Interval/Set/Monotone.lean
@@ -188,6 +188,10 @@ theorem strictMonoOn_Iic_of_lt_succ [SuccOrder α] [IsSuccArchimedean α] {n : �
   refine hψ _ (lt_of_lt_of_le ?_ hy)
   rwa [Function.iterate_succ', Function.comp_apply, lt_succ_iff_not_isMax]
 
+theorem strictMono_of_lt_succ [SuccOrder α] [IsSuccArchimedean α]
+    (hψ : ∀ m, ψ m < ψ (succ m)) : StrictMono ψ := fun _ _ h ↦
+  (strictMonoOn_Iic_of_lt_succ fun m _ ↦ hψ m) h.le (le_refl _) h
+
 theorem strictAntiOn_Iic_of_succ_lt [SuccOrder α] [IsSuccArchimedean α] {n : α}
     (hψ : ∀ m, m < n → ψ (succ m) < ψ m) : StrictAntiOn ψ (Set.Iic n) := fun i hi j hj hij =>
   @strictMonoOn_Iic_of_lt_succ α βᵒᵈ _ _ ψ _ _ n hψ i hi j hj hij

--- a/Mathlib/SetTheory/Ordinal/Arithmetic.lean
+++ b/Mathlib/SetTheory/Ordinal/Arithmetic.lean
@@ -2253,30 +2253,6 @@ theorem sup_mul_nat (o : Ordinal) : (sup fun n : ℕ => o * n) = o * ω := by
     exact sup_eq_zero_iff.2 fun n => zero_mul (n : Ordinal)
   · exact (mul_isNormal ho).apply_omega
 
-/-- The natural isomorphism between ℕ and the first ω ordinals. -/
-def relIso_nat_omega : ℕ ≃o Iio ω where
-  toFun n := ⟨n, nat_lt_omega n⟩
-  invFun n := Classical.choose (lt_omega.1 n.2)
-  left_inv n := by
-    have h : ∃ m : ℕ, n = (m : Ordinal) := ⟨n, rfl⟩
-    exact (Ordinal.natCast_inj.1 (Classical.choose_spec h)).symm
-  right_inv n := Subtype.eq (Classical.choose_spec (lt_omega.1 n.2)).symm
-  map_rel_iff' := @natCast_le
-
-theorem relIso_nat_omega.symm_eq {o : Ordinal} (h : o < ω) :
-    relIso_nat_omega.symm ⟨o, h⟩ = o := by
-  rcases lt_omega.mp h with ⟨n, rfl⟩
-  exact congrArg Nat.cast <| relIso_nat_omega.symm_apply_apply n
-
-theorem strictMono_of_succ_lt_omega {o : Ordinal} (f : Iio ω → Iio o)
-    (hf : ∀ i, f i < f ⟨succ i, omega_isLimit.succ_lt i.2⟩) (i j) (h : i < j) : f i < f j := by
-  have mono := strictMono_nat_of_lt_succ fun n ↦ hf ⟨n, nat_lt_omega n⟩
-  have := mono <| (OrderIso.lt_iff_lt relIso_nat_omega.symm).mpr h
-  change f ⟨relIso_nat_omega.symm ⟨i.1, i.2⟩, _⟩ <
-    f ⟨relIso_nat_omega.symm ⟨j.1, j.2⟩, _⟩ at this
-  simp_rw [relIso_nat_omega.symm_eq] at this
-  exact this
-
 end Ordinal
 
 variable {α : Type u} {r : α → α → Prop} {a b : α}

--- a/Mathlib/SetTheory/Ordinal/Arithmetic.lean
+++ b/Mathlib/SetTheory/Ordinal/Arithmetic.lean
@@ -2253,6 +2253,30 @@ theorem sup_mul_nat (o : Ordinal) : (sup fun n : ℕ => o * n) = o * ω := by
     exact sup_eq_zero_iff.2 fun n => zero_mul (n : Ordinal)
   · exact (mul_isNormal ho).apply_omega
 
+/-- The natural isomorphism between ℕ and the first ω ordinals. -/
+def relIso_nat_omega : ℕ ≃o Iio ω where
+  toFun n := ⟨n, nat_lt_omega n⟩
+  invFun n := Classical.choose (lt_omega.1 n.2)
+  left_inv n := by
+    have h : ∃ m : ℕ, n = (m : Ordinal) := ⟨n, rfl⟩
+    exact (Ordinal.natCast_inj.1 (Classical.choose_spec h)).symm
+  right_inv n := Subtype.eq (Classical.choose_spec (lt_omega.1 n.2)).symm
+  map_rel_iff' := @natCast_le
+
+theorem relIso_nat_omega.symm_eq {o : Ordinal} (h : o < ω) :
+    relIso_nat_omega.symm ⟨o, h⟩ = o := by
+  rcases lt_omega.mp h with ⟨n, rfl⟩
+  exact congrArg Nat.cast <| relIso_nat_omega.symm_apply_apply n
+
+theorem strictMono_of_succ_lt_omega {o : Ordinal} (f : Iio ω → Iio o)
+    (hf : ∀ i, f i < f ⟨succ i, omega_isLimit.succ_lt i.2⟩) (i j) (h : i < j) : f i < f j := by
+  have mono := strictMono_nat_of_lt_succ fun n ↦ hf ⟨n, nat_lt_omega n⟩
+  have := mono <| (OrderIso.lt_iff_lt relIso_nat_omega.symm).mpr h
+  change f ⟨relIso_nat_omega.symm ⟨i.1, i.2⟩, _⟩ <
+    f ⟨relIso_nat_omega.symm ⟨j.1, j.2⟩, _⟩ at this
+  simp_rw [relIso_nat_omega.symm_eq] at this
+  exact this
+
 end Ordinal
 
 variable {α : Type u} {r : α → α → Prop} {a b : α}


### PR DESCRIPTION
Prove `strictMono_of_lt_succ` and `strictAnti_of_pred_lt` for archimedean orders.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
