### PR TITLE
[Merged by Bors] - refactor(Data/Real/Archimedean): `sSup`/`sInf` API cleanup

### DIFF
--- a/Mathlib/Analysis/Convex/Gauge.lean
+++ b/Mathlib/Analysis/Convex/Gauge.lean
@@ -110,7 +110,8 @@ theorem gauge_of_subset_zero (h : s ⊆ 0) : gauge s = 0 := by
   exacts [gauge_empty, gauge_zero']
 
 /-- The gauge is always nonnegative. -/
-theorem gauge_nonneg (x : E) : 0 ≤ gauge s x := Real.sInf_nonneg fun _ hx => hx.1.le
+theorem gauge_nonneg (x : E) : 0 ≤ gauge s x :=
+  Real.sInf_nonneg fun _ hx => hx.1.le
 
 theorem gauge_neg (symmetric : ∀ x ∈ s, -x ∈ s) (x : E) : gauge s (-x) = gauge s x := by
   have : ∀ x, -x ∈ s ↔ x ∈ s := fun x => ⟨fun h => by simpa using symmetric _ h, symmetric x⟩

--- a/Mathlib/Analysis/Convex/Gauge.lean
+++ b/Mathlib/Analysis/Convex/Gauge.lean
@@ -110,8 +110,7 @@ theorem gauge_of_subset_zero (h : s ⊆ 0) : gauge s = 0 := by
   exacts [gauge_empty, gauge_zero']
 
 /-- The gauge is always nonnegative. -/
-theorem gauge_nonneg (x : E) : 0 ≤ gauge s x :=
-  Real.sInf_nonneg _ fun _ hx => hx.1.le
+theorem gauge_nonneg (x : E) : 0 ≤ gauge s x := Real.sInf_nonneg fun _ hx => hx.1.le
 
 theorem gauge_neg (symmetric : ∀ x ∈ s, -x ∈ s) (x : E) : gauge s (-x) = gauge s x := by
   have : ∀ x, -x ∈ s ↔ x ∈ s := fun x => ⟨fun h => by simpa using symmetric _ h, symmetric x⟩

--- a/Mathlib/Analysis/Normed/Group/Quotient.lean
+++ b/Mathlib/Analysis/Normed/Group/Quotient.lean
@@ -156,7 +156,7 @@ theorem quotient_norm_mk_eq (S : AddSubgroup M) (m : M) :
 
 /-- The quotient norm is nonnegative. -/
 theorem quotient_norm_nonneg (S : AddSubgroup M) (x : M ⧸ S) : 0 ≤ ‖x‖ :=
-  Real.sInf_nonneg _ <| forall_mem_image.2 fun _ _ ↦ norm_nonneg _
+  Real.sInf_nonneg <| forall_mem_image.2 fun _ _ ↦ norm_nonneg _
 
 /-- The quotient norm is nonnegative. -/
 theorem norm_mk_nonneg (S : AddSubgroup M) (m : M) : 0 ≤ ‖mk' S m‖ :=

--- a/Mathlib/Analysis/Normed/Lp/PiLp.lean
+++ b/Mathlib/Analysis/Normed/Lp/PiLp.lean
@@ -354,7 +354,7 @@ abbrev pseudoMetricAux : PseudoMetricSpace (PiLp p α) :=
             PseudoMetricSpace.edist_dist]
           -- Porting note: `le_iSup` needed some help
           exact le_iSup (fun k => edist (f k) (g k)) i
-        · refine ENNReal.toReal_le_of_le_ofReal (Real.sSup_nonneg _ ?_) (iSup_le fun i => ?_)
+        · refine ENNReal.toReal_le_of_le_ofReal (Real.sSup_nonneg ?_) (iSup_le fun i => ?_)
           · rintro - ⟨i, rfl⟩
             exact dist_nonneg
           · change PseudoMetricSpace.edist _ _ ≤ _

--- a/Mathlib/Analysis/NormedSpace/Multilinear/Basic.lean
+++ b/Mathlib/Analysis/NormedSpace/Multilinear/Basic.lean
@@ -339,7 +339,8 @@ theorem isLeast_opNorm : IsLeast {c : ℝ | 0 ≤ c ∧ ∀ m, ‖f m‖ ≤ c *
 
 @[deprecated (since := "2024-02-02")] alias isLeast_op_norm := isLeast_opNorm
 
-theorem opNorm_nonneg : 0 ≤ ‖f‖ := Real.sInf_nonneg fun _ ⟨hx, _⟩ => hx
+theorem opNorm_nonneg : 0 ≤ ‖f‖ :=
+  Real.sInf_nonneg fun _ ⟨hx, _⟩ => hx
 
 @[deprecated (since := "2024-02-02")] alias op_norm_nonneg := opNorm_nonneg
 

--- a/Mathlib/Analysis/NormedSpace/Multilinear/Basic.lean
+++ b/Mathlib/Analysis/NormedSpace/Multilinear/Basic.lean
@@ -339,8 +339,7 @@ theorem isLeast_opNorm : IsLeast {c : ℝ | 0 ≤ c ∧ ∀ m, ‖f m‖ ≤ c *
 
 @[deprecated (since := "2024-02-02")] alias isLeast_op_norm := isLeast_opNorm
 
-theorem opNorm_nonneg : 0 ≤ ‖f‖ :=
-  Real.sInf_nonneg _ fun _ ⟨hx, _⟩ => hx
+theorem opNorm_nonneg : 0 ≤ ‖f‖ := Real.sInf_nonneg fun _ ⟨hx, _⟩ => hx
 
 @[deprecated (since := "2024-02-02")] alias op_norm_nonneg := opNorm_nonneg
 

--- a/Mathlib/Analysis/NormedSpace/OperatorNorm/Basic.lean
+++ b/Mathlib/Analysis/NormedSpace/OperatorNorm/Basic.lean
@@ -173,7 +173,8 @@ theorem opNorm_neg (f : E →SL[σ₁₂] F) : ‖-f‖ = ‖f‖ := by simp onl
 
 @[deprecated (since := "2024-02-02")] alias op_norm_neg := opNorm_neg
 
-theorem opNorm_nonneg (f : E →SL[σ₁₂] F) : 0 ≤ ‖f‖ := Real.sInf_nonneg fun _ ↦ And.left
+theorem opNorm_nonneg (f : E →SL[σ₁₂] F) : 0 ≤ ‖f‖ :=
+  Real.sInf_nonneg fun _ ↦ And.left
 
 @[deprecated (since := "2024-02-02")] alias op_norm_nonneg := opNorm_nonneg
 

--- a/Mathlib/Analysis/NormedSpace/OperatorNorm/Basic.lean
+++ b/Mathlib/Analysis/NormedSpace/OperatorNorm/Basic.lean
@@ -173,8 +173,7 @@ theorem opNorm_neg (f : E →SL[σ₁₂] F) : ‖-f‖ = ‖f‖ := by simp onl
 
 @[deprecated (since := "2024-02-02")] alias op_norm_neg := opNorm_neg
 
-theorem opNorm_nonneg (f : E →SL[σ₁₂] F) : 0 ≤ ‖f‖ :=
-  Real.sInf_nonneg _ fun _ ↦ And.left
+theorem opNorm_nonneg (f : E →SL[σ₁₂] F) : 0 ≤ ‖f‖ := Real.sInf_nonneg fun _ ↦ And.left
 
 @[deprecated (since := "2024-02-02")] alias op_norm_nonneg := opNorm_nonneg
 

--- a/Mathlib/Analysis/Seminorm.lean
+++ b/Mathlib/Analysis/Seminorm.lean
@@ -495,7 +495,7 @@ noncomputable instance instSupSet : SupSet (Seminorm 𝕜 E) where
     if h : BddAbove ((↑) '' s : Set (E → ℝ)) then
       { toFun := ⨆ p : s, ((p : Seminorm 𝕜 E) : E → ℝ)
         map_zero' := by
-          rw [iSup_apply, ← @Real.ciSup_const_zero s]
+          rw [iSup_apply, ← @Real.iSup_const_zero s]
           congr!
           rename_i _ _ _ i
           exact map_zero i.1

--- a/Mathlib/Data/NNReal/Basic.lean
+++ b/Mathlib/Data/NNReal/Basic.lean
@@ -944,7 +944,7 @@ theorem iInf_empty [IsEmpty ι] (f : ι → ℝ≥0) : ⨅ i, f i = 0 := by
 @[simp]
 theorem iInf_const_zero {α : Sort*} : ⨅ _ : α, (0 : ℝ≥0) = 0 := by
   rw [← coe_inj, coe_iInf]
-  exact Real.ciInf_const_zero
+  exact Real.iInf_const_zero
 
 theorem iInf_mul (f : ι → ℝ≥0) (a : ℝ≥0) : iInf f * a = ⨅ i, f i * a := by
   rw [← coe_inj, NNReal.coe_mul, coe_iInf, coe_iInf]

--- a/Mathlib/Data/Real/Archimedean.lean
+++ b/Mathlib/Data/Real/Archimedean.lean
@@ -200,60 +200,68 @@ theorem iInf_of_not_bddBelow (hf : ¬BddBelow (Set.range f)) : ⨅ i, f i = 0 :=
   sInf_of_not_bddBelow hf
 
 /-- As `sSup s = 0` when `s` is an empty set of reals, it suffices to show that all elements of `s`
-are at most some nonnegative number `a` to show that `sSup s ≤ a`. -/
+are at most some nonnegative number `a` to show that `sSup s ≤ a`.
+
+See also `csSup_le`. -/
 protected lemma sSup_le (hs : ∀ x ∈ s, x ≤ a) (ha : 0 ≤ a) : sSup s ≤ a := by
   obtain rfl | hs' := s.eq_empty_or_nonempty
   exacts [sSup_empty.trans_le ha, csSup_le hs' hs]
 
-/-- As `⨆ i, f i = 0` when `f` is the empty function, it suffices to show that all values of `f`
-are at most some nonnegative number `a` to show that `⨆ i, f i ≤ a`. -/
+/-- As `⨆ i, f i = 0` when the domain of the real-valued function `f` is empty, it suffices to show
+that all values of `f` are at most some nonnegative number `a` to show that `⨆ i, f i ≤ a`.
+
+See also `ciSup_le`. -/
 protected lemma iSup_le (hf : ∀ i, f i ≤ a) (ha : 0 ≤ a) : ⨆ i, f i ≤ a :=
   Real.sSup_le (Set.forall_mem_range.2 hf) ha
 
 /-- As `sInf s = 0` when `s` is an empty set of reals, it suffices to show that all elements of `s`
-are at least some nonpositive number `a` to show that `a ≤ sInf s`. -/
+are at least some nonpositive number `a` to show that `a ≤ sInf s`.
+
+See also `le_csInf`. -/
 protected lemma le_sInf (hs : ∀ x ∈ s, a ≤ x) (ha : a ≤ 0) : a ≤ sInf s := by
   obtain rfl | hs' := s.eq_empty_or_nonempty
   exacts [ha.trans_eq sInf_empty.symm, le_csInf hs' hs]
 
-/-- As `⨅ i, f i = 0` when `f` is the empty function, it suffices to show that all values of `f`
-are at least some nonnegative number `a` to show that `a ≤ ⨅ i, f i`. -/
+/-- As `⨅ i, f i = 0` when the domain of the real-valued function `f` is empty, it suffices to show
+that all values of `f` are at least some nonnegative number `a` to show that `a ≤ ⨅ i, f i`.
+
+See also `le_ciInf`. -/
 protected lemma le_iInf (hf : ∀ i, a ≤ f i) (ha : a ≤ 0) : a ≤ ⨅ i, f i :=
   Real.le_sInf (Set.forall_mem_range.2 hf) ha
 
-/-- As `sSup s = 0` when `s` is an empty set of reals,
-it suffices to show that all elements of `s` are nonpositive to show that `sSup s ≤ 0`. -/
+/-- As `sSup s = 0` when `s` is an empty set of reals, it suffices to show that all elements of `s`
+are nonpositive to show that `sSup s ≤ 0`. -/
 lemma sSup_nonpos (hs : ∀ x ∈ s, x ≤ 0) : sSup s ≤ 0 := Real.sSup_le hs le_rfl
 
-/-- As `⨆ i, f i = 0` when `f` is the empty function,
+/-- As `⨆ i, f i = 0` when the domain of the real-valued function `f` is empty,
 it suffices to show that all values of `f` are nonpositive to show that `⨆ i, f i ≤ 0`. -/
 lemma iSup_nonpos (hf : ∀ i, f i ≤ 0) : ⨆ i, f i ≤ 0 := Real.iSup_le hf le_rfl
 
-/-- As `sInf s = 0` when `s` is an empty set of reals,
-it suffices to show that all elements of `s` are nonnegative to show that `0 ≤ sInf s`. -/
+/-- As `sInf s = 0` when `s` is an empty set of reals, it suffices to show that all elements of `s`
+are nonnegative to show that `0 ≤ sInf s`. -/
 lemma sInf_nonneg (hs : ∀ x ∈ s, 0 ≤ x) : 0 ≤ sInf s := Real.le_sInf hs le_rfl
 
-/-- As `⨅ i, f i = 0` when `f` is the empty function,
+/-- As `⨅ i, f i = 0` when the domain of the real-valued function `f` is empty,
 it suffices to show that all values of `f` are nonnegative to show that `0 ≤ ⨅ i, f i`. -/
 lemma iInf_nonneg (hf : ∀ i, 0 ≤ f i) : 0 ≤ iInf f := Real.le_iInf hf le_rfl
 
-/-- As `sSup s = 0` when `s` is a set of reals that's unbounded above,
-it suffices to show that `s` contains a nonnegative element to show that `0 ≤ sSup s`. -/
+/-- As `sSup s = 0` when `s` is a set of reals that's unbounded above, it suffices to show that `s`
+contains a nonnegative element to show that `0 ≤ sSup s`. -/
 lemma sSup_nonneg' (hs : ∃ x ∈ s, 0 ≤ x) : 0 ≤ sSup s := by
   obtain ⟨x, hxs, hx⟩ := hs
   exact dite _ (fun h ↦ le_csSup_of_le h hxs hx) fun h ↦ (sSup_of_not_bddAbove h).ge
 
-/-- As `⨆ i, f i = 0` when `f` is unbounded above,
+/-- As `⨆ i, f i = 0` when the real-valued function `f` is unbounded above,
 it suffices to show that `f` takes a nonnegative value to show that `0 ≤ ⨆ i, f i`. -/
 lemma iSup_nonneg' (hf : ∃ i, 0 ≤ f i) : 0 ≤ ⨆ i, f i := sSup_nonneg' <| Set.exists_range_iff.2 hf
 
-/-- As `sInf s = 0` when `s` is a set of reals that's unbounded below,
-it suffices to show that `s` contains a nonpositive element to show that `sInf s ≤ 0`. -/
+/-- As `sInf s = 0` when `s` is a set of reals that's unbounded below, it suffices to show that `s`
+contains a nonpositive element to show that `sInf s ≤ 0`. -/
 lemma sInf_nonpos' (hs : ∃ x ∈ s, x ≤ 0) : sInf s ≤ 0 := by
   obtain ⟨x, hxs, hx⟩ := hs
   exact dite _ (fun h ↦ csInf_le_of_le h hxs hx) fun h ↦ (sInf_of_not_bddBelow h).le
 
-/-- As `⨅ i, f i = 0` when `f` is unbounded below,
+/-- As `⨅ i, f i = 0` when the real-valued function `f` is unbounded below,
 it suffices to show that `f` takes a nonpositive value to show that `0 ≤ ⨅ i, f i`. -/
 lemma iInf_nonpos' (hf : ∃ i, f i ≤ 0) : ⨅ i, f i ≤ 0 := sInf_nonpos' <| Set.exists_range_iff.2 hf
 
@@ -264,7 +272,7 @@ lemma sSup_nonneg (hs : ∀ x ∈ s, 0 ≤ x) : 0 ≤ sSup s := by
   · exact sSup_empty.ge
   · exact sSup_nonneg' ⟨x, hx, hs _ hx⟩
 
-/-- As `⨆ i, f i = 0` when `f` is the empty function or unbounded above,
+/-- As `⨆ i, f i = 0` when the domain of the real-valued function `f` is empty or unbounded above,
 it suffices to show that all values of `f` are nonnegative to show that `0 ≤ ⨆ i, f i`. -/
 lemma iSup_nonneg (hf : ∀ i, 0 ≤ f i) : 0 ≤ ⨆ i, f i := sSup_nonneg <| Set.forall_mem_range.2 hf
 
@@ -275,7 +283,7 @@ lemma sInf_nonpos (hs : ∀ x ∈ s, x ≤ 0) : sInf s ≤ 0 := by
   · exact sInf_empty.le
   · exact sInf_nonpos' ⟨x, hx, hs _ hx⟩
 
-/-- As `⨅ i, f i = 0` when `f` is the empty function or unbounded below,
+/-- As `⨅ i, f i = 0` when the domain of the real-valued function `f` is empty or unbounded below,
 it suffices to show that all values of `f` are nonpositive to show that `0 ≤ ⨅ i, f i`. -/
 lemma iInf_nonpos (hf : ∀ i, f i ≤ 0) : ⨅ i, f i ≤ 0 := sInf_nonpos <| Set.forall_mem_range.2 hf
 

--- a/Mathlib/Data/Real/Archimedean.lean
+++ b/Mathlib/Data/Real/Archimedean.lean
@@ -124,17 +124,19 @@ noncomputable instance : InfSet ℝ :=
 
 theorem sInf_def (s : Set ℝ) : sInf s = -sSup (-s) := rfl
 
-protected theorem is_glb_sInf (h₁ : s.Nonempty) (h₂ : BddBelow s) : IsGLB s (sInf s) := by
+protected theorem isGLB_sInf (h₁ : s.Nonempty) (h₂ : BddBelow s) : IsGLB s (sInf s) := by
   rw [sInf_def, ← isLUB_neg', neg_neg]
   exact Real.isLUB_sSup h₁.neg h₂.neg
+
+@[deprecated (since := "2024-10-02")] alias is_glb_sInf := isGLB_sInf
 
 noncomputable instance : ConditionallyCompleteLinearOrder ℝ where
   __ := Real.linearOrder
   __ := Real.lattice
   le_csSup s a hs ha := (Real.isLUB_sSup ⟨a, ha⟩ hs).1 ha
   csSup_le s a hs ha := (Real.isLUB_sSup hs ⟨a, ha⟩).2 ha
-  csInf_le s a hs ha := (Real.is_glb_sInf ⟨a, ha⟩ hs).1 ha
-  le_csInf s a hs ha := (Real.is_glb_sInf hs ⟨a, ha⟩).2 ha
+  csInf_le s a hs ha := (Real.isGLB_sInf ⟨a, ha⟩ hs).1 ha
+  le_csInf s a hs ha := (Real.isGLB_sInf hs ⟨a, ha⟩).2 ha
   csSup_of_not_bddAbove s hs := by simp [hs, sSup_def]
   csInf_of_not_bddBelow s hs := by simp [hs, sInf_def, sSup_def]
 
@@ -223,7 +225,7 @@ protected lemma le_sInf (hs : ∀ x ∈ s, a ≤ x) (ha : a ≤ 0) : a ≤ sInf 
   exacts [ha.trans_eq sInf_empty.symm, le_csInf hs' hs]
 
 /-- As `⨅ i, f i = 0` when the domain of the real-valued function `f` is empty, it suffices to show
-that all values of `f` are at least some nonnegative number `a` to show that `a ≤ ⨅ i, f i`.
+that all values of `f` are at least some nonpositive number `a` to show that `a ≤ ⨅ i, f i`.
 
 See also `le_ciInf`. -/
 protected lemma le_iInf (hf : ∀ i, a ≤ f i) (ha : a ≤ 0) : a ≤ ⨅ i, f i :=

--- a/Mathlib/Data/Real/Archimedean.lean
+++ b/Mathlib/Data/Real/Archimedean.lean
@@ -17,6 +17,7 @@ open scoped Classical
 open Pointwise CauSeq
 
 namespace Real
+variable {ι : Sort*} {f : ι → ℝ} {s : Set ℝ} {a : ℝ}
 
 instance instArchimedean : Archimedean ℝ :=
   archimedean_iff_rat_le.2 fun x =>
@@ -49,9 +50,9 @@ theorem exists_floor (x : ℝ) : ∃ ub : ℤ, (ub : ℝ) ≤ x ∧ ∀ z : ℤ,
     (let ⟨n, hn⟩ := exists_int_lt x
     ⟨n, le_of_lt hn⟩)
 
-theorem exists_isLUB {S : Set ℝ} (hne : S.Nonempty) (hbdd : BddAbove S) : ∃ x, IsLUB S x := by
+theorem exists_isLUB (hne : s.Nonempty) (hbdd : BddAbove s) : ∃ x, IsLUB s x := by
   rcases hne, hbdd with ⟨⟨L, hL⟩, ⟨U, hU⟩⟩
-  have : ∀ d : ℕ, BddAbove { m : ℤ | ∃ y ∈ S, (m : ℝ) ≤ y * d } := by
+  have : ∀ d : ℕ, BddAbove { m : ℤ | ∃ y ∈ s, (m : ℝ) ≤ y * d } := by
     cases' exists_int_gt U with k hk
     refine fun d => ⟨k * d, fun z h => ?_⟩
     rcases h with ⟨y, yS, hy⟩
@@ -60,10 +61,10 @@ theorem exists_isLUB {S : Set ℝ} (hne : S.Nonempty) (hbdd : BddAbove S) : ∃ 
     exact mul_le_mul_of_nonneg_right ((hU yS).trans hk.le) d.cast_nonneg
   choose f hf using fun d : ℕ =>
     Int.exists_greatest_of_bdd (this d) ⟨⌊L * d⌋, L, hL, Int.floor_le _⟩
-  have hf₁ : ∀ n > 0, ∃ y ∈ S, ((f n / n : ℚ) : ℝ) ≤ y := fun n n0 =>
+  have hf₁ : ∀ n > 0, ∃ y ∈ s, ((f n / n : ℚ) : ℝ) ≤ y := fun n n0 =>
     let ⟨y, yS, hy⟩ := (hf n).1
     ⟨y, yS, by simpa using (div_le_iff₀ (Nat.cast_pos.2 n0 : (_ : ℝ) < _)).2 hy⟩
-  have hf₂ : ∀ n > 0, ∀ y ∈ S, (y - ((n : ℕ) : ℝ)⁻¹) < (f n / n : ℚ) := by
+  have hf₂ : ∀ n > 0, ∀ y ∈ s, (y - ((n : ℕ) : ℝ)⁻¹) < (f n / n : ℚ) := by
     intro n n0 y yS
     have := (Int.sub_one_lt_floor _).trans_le (Int.cast_le.2 <| (hf n).2 _ ⟨y, yS, Int.floor_le _⟩)
     simp only [Rat.cast_div, Rat.cast_intCast, Rat.cast_natCast, gt_iff_lt]
@@ -100,56 +101,50 @@ theorem exists_isLUB {S : Set ℝ} (hne : S.Nonempty) (hbdd : BddAbove S) : ∃ 
           le_trans hx (h xS)⟩
 
 /-- A nonempty, bounded below set of real numbers has a greatest lower bound. -/
-theorem exists_isGLB {S : Set ℝ} (hne : S.Nonempty) (hbdd : BddBelow S) : ∃ x, IsGLB S x := by
-  have hne' : (-S).Nonempty := Set.nonempty_neg.mpr hne
-  have hbdd' : BddAbove (-S) := bddAbove_neg.mpr hbdd
+theorem exists_isGLB (hne : s.Nonempty) (hbdd : BddBelow s) : ∃ x, IsGLB s x := by
+  have hne' : (-s).Nonempty := Set.nonempty_neg.mpr hne
+  have hbdd' : BddAbove (-s) := bddAbove_neg.mpr hbdd
   use -Classical.choose (Real.exists_isLUB hne' hbdd')
   rw [← isLUB_neg]
   exact Classical.choose_spec (Real.exists_isLUB hne' hbdd')
 
 noncomputable instance : SupSet ℝ :=
-  ⟨fun S => if h : S.Nonempty ∧ BddAbove S then Classical.choose (exists_isLUB h.1 h.2) else 0⟩
+  ⟨fun s => if h : s.Nonempty ∧ BddAbove s then Classical.choose (exists_isLUB h.1 h.2) else 0⟩
 
-theorem sSup_def (S : Set ℝ) :
-    sSup S = if h : S.Nonempty ∧ BddAbove S then Classical.choose (exists_isLUB h.1 h.2) else 0 :=
+theorem sSup_def (s : Set ℝ) :
+    sSup s = if h : s.Nonempty ∧ BddAbove s then Classical.choose (exists_isLUB h.1 h.2) else 0 :=
   rfl
 
-protected theorem isLUB_sSup (S : Set ℝ) (h₁ : S.Nonempty) (h₂ : BddAbove S) :
-    IsLUB S (sSup S) := by
+protected theorem isLUB_sSup (h₁ : s.Nonempty) (h₂ : BddAbove s) : IsLUB s (sSup s) := by
   simp only [sSup_def, dif_pos (And.intro h₁ h₂)]
   apply Classical.choose_spec
 
 noncomputable instance : InfSet ℝ :=
-  ⟨fun S => -sSup (-S)⟩
+  ⟨fun s => -sSup (-s)⟩
 
-theorem sInf_def (S : Set ℝ) : sInf S = -sSup (-S) :=
-  rfl
+theorem sInf_def (s : Set ℝ) : sInf s = -sSup (-s) := rfl
 
-protected theorem is_glb_sInf (S : Set ℝ) (h₁ : S.Nonempty) (h₂ : BddBelow S) :
-    IsGLB S (sInf S) := by
+protected theorem is_glb_sInf (h₁ : s.Nonempty) (h₂ : BddBelow s) : IsGLB s (sInf s) := by
   rw [sInf_def, ← isLUB_neg', neg_neg]
-  exact Real.isLUB_sSup _ h₁.neg h₂.neg
+  exact Real.isLUB_sSup h₁.neg h₂.neg
 
-noncomputable instance : ConditionallyCompleteLinearOrder ℝ :=
-  { Real.linearOrder, Real.lattice with
-    sSup := SupSet.sSup
-    sInf := InfSet.sInf
-    le_csSup := fun s a hs ha => (Real.isLUB_sSup s ⟨a, ha⟩ hs).1 ha
-    csSup_le := fun s a hs ha => (Real.isLUB_sSup s hs ⟨a, ha⟩).2 ha
-    csInf_le := fun s a hs ha => (Real.is_glb_sInf s ⟨a, ha⟩ hs).1 ha
-    le_csInf := fun s a hs ha => (Real.is_glb_sInf s hs ⟨a, ha⟩).2 ha
-    csSup_of_not_bddAbove := fun s hs ↦ by simp [hs, sSup_def]
-    csInf_of_not_bddBelow := fun s hs ↦ by simp [hs, sInf_def, sSup_def] }
+noncomputable instance : ConditionallyCompleteLinearOrder ℝ where
+  __ := Real.linearOrder
+  __ := Real.lattice
+  le_csSup s a hs ha := (Real.isLUB_sSup ⟨a, ha⟩ hs).1 ha
+  csSup_le s a hs ha := (Real.isLUB_sSup hs ⟨a, ha⟩).2 ha
+  csInf_le s a hs ha := (Real.is_glb_sInf ⟨a, ha⟩ hs).1 ha
+  le_csInf s a hs ha := (Real.is_glb_sInf hs ⟨a, ha⟩).2 ha
+  csSup_of_not_bddAbove s hs := by simp [hs, sSup_def]
+  csInf_of_not_bddBelow s hs := by simp [hs, sInf_def, sSup_def]
 
-theorem lt_sInf_add_pos {s : Set ℝ} (h : s.Nonempty) {ε : ℝ} (hε : 0 < ε) :
-    ∃ a ∈ s, a < sInf s + ε :=
+theorem lt_sInf_add_pos (h : s.Nonempty) {ε : ℝ} (hε : 0 < ε) : ∃ a ∈ s, a < sInf s + ε :=
   exists_lt_of_csInf_lt h <| lt_add_of_pos_right _ hε
 
-theorem add_neg_lt_sSup {s : Set ℝ} (h : s.Nonempty) {ε : ℝ} (hε : ε < 0) :
-    ∃ a ∈ s, sSup s + ε < a :=
+theorem add_neg_lt_sSup (h : s.Nonempty) {ε : ℝ} (hε : ε < 0) : ∃ a ∈ s, sSup s + ε < a :=
   exists_lt_of_lt_csSup h <| add_lt_iff_neg_left.2 hε
 
-theorem sInf_le_iff {s : Set ℝ} (h : BddBelow s) (h' : s.Nonempty) {a : ℝ} :
+theorem sInf_le_iff (h : BddBelow s) (h' : s.Nonempty) :
     sInf s ≤ a ↔ ∀ ε, 0 < ε → ∃ x ∈ s, x < a + ε := by
   rw [le_iff_forall_pos_lt_add]
   constructor <;> intro H ε ε_pos
@@ -157,7 +152,7 @@ theorem sInf_le_iff {s : Set ℝ} (h : BddBelow s) (h' : s.Nonempty) {a : ℝ} :
   · rcases H ε ε_pos with ⟨x, x_in, hx⟩
     exact csInf_lt_of_lt h x_in hx
 
-theorem le_sSup_iff {s : Set ℝ} (h : BddAbove s) (h' : s.Nonempty) {a : ℝ} :
+theorem le_sSup_iff (h : BddAbove s) (h' : s.Nonempty) :
     a ≤ sSup s ↔ ∀ ε, ε < 0 → ∃ x ∈ s, a + ε < x := by
   rw [le_iff_forall_pos_lt_add]
   refine ⟨fun H ε ε_neg => ?_, fun H ε ε_pos => ?_⟩
@@ -169,102 +164,124 @@ theorem le_sSup_iff {s : Set ℝ} (h : BddAbove s) (h' : s.Nonempty) {a : ℝ} :
 theorem sSup_empty : sSup (∅ : Set ℝ) = 0 :=
   dif_neg <| by simp
 
-@[simp] lemma iSup_of_isEmpty {α : Sort*} [IsEmpty α] (f : α → ℝ) : ⨆ i, f i = 0 := by
+@[simp] lemma iSup_of_isEmpty [IsEmpty ι] (f : ι → ℝ) : ⨆ i, f i = 0 := by
   dsimp [iSup]
   convert Real.sSup_empty
   rw [Set.range_eq_empty_iff]
   infer_instance
 
 @[simp]
-theorem ciSup_const_zero {α : Sort*} : ⨆ _ : α, (0 : ℝ) = 0 := by
-  cases isEmpty_or_nonempty α
+theorem iSup_const_zero : ⨆ _ : ι, (0 : ℝ) = 0 := by
+  cases isEmpty_or_nonempty ι
   · exact Real.iSup_of_isEmpty _
   · exact ciSup_const
 
-theorem sSup_of_not_bddAbove {s : Set ℝ} (hs : ¬BddAbove s) : sSup s = 0 :=
-  dif_neg fun h => hs h.2
-
-theorem iSup_of_not_bddAbove {α : Sort*} {f : α → ℝ} (hf : ¬BddAbove (Set.range f)) :
-    ⨆ i, f i = 0 :=
-  sSup_of_not_bddAbove hf
+lemma sSup_of_not_bddAbove (hs : ¬BddAbove s) : sSup s = 0 := dif_neg fun h => hs h.2
+lemma iSup_of_not_bddAbove (hf : ¬BddAbove (Set.range f)) : ⨆ i, f i = 0 := sSup_of_not_bddAbove hf
 
 theorem sSup_univ : sSup (@Set.univ ℝ) = 0 := Real.sSup_of_not_bddAbove not_bddAbove_univ
 
 @[simp]
 theorem sInf_empty : sInf (∅ : Set ℝ) = 0 := by simp [sInf_def, sSup_empty]
 
-@[simp] nonrec lemma iInf_of_isEmpty {α : Sort*} [IsEmpty α] (f : α → ℝ) : ⨅ i, f i = 0 := by
+@[simp] nonrec lemma iInf_of_isEmpty [IsEmpty ι] (f : ι → ℝ) : ⨅ i, f i = 0 := by
   rw [iInf_of_isEmpty, sInf_empty]
 
 @[simp]
-theorem ciInf_const_zero {α : Sort*} : ⨅ _ : α, (0 : ℝ) = 0 := by
-  cases isEmpty_or_nonempty α
+theorem iInf_const_zero : ⨅ _ : ι, (0 : ℝ) = 0 := by
+  cases isEmpty_or_nonempty ι
   · exact Real.iInf_of_isEmpty _
   · exact ciInf_const
 
-theorem sInf_of_not_bddBelow {s : Set ℝ} (hs : ¬BddBelow s) : sInf s = 0 :=
+theorem sInf_of_not_bddBelow (hs : ¬BddBelow s) : sInf s = 0 :=
   neg_eq_zero.2 <| sSup_of_not_bddAbove <| mt bddAbove_neg.1 hs
 
-theorem iInf_of_not_bddBelow {α : Sort*} {f : α → ℝ} (hf : ¬BddBelow (Set.range f)) :
-    ⨅ i, f i = 0 :=
+theorem iInf_of_not_bddBelow (hf : ¬BddBelow (Set.range f)) : ⨅ i, f i = 0 :=
   sInf_of_not_bddBelow hf
 
-/--
-As `0` is the default value for `Real.sSup` of the empty set or sets which are not bounded above, it
-suffices to show that `S` is bounded below by `0` to show that `0 ≤ sSup S`.
--/
-theorem sSup_nonneg (S : Set ℝ) (hS : ∀ x ∈ S, (0 : ℝ) ≤ x) : 0 ≤ sSup S := by
-  rcases S.eq_empty_or_nonempty with (rfl | ⟨y, hy⟩)
+/-- As `sSup s = 0` when `s` is a set of reals that's either empty or unbounded above,
+it suffices to show that all elements of `s` are at most some nonnegative number `a` to show that
+`sSup s ≤ a`. -/
+protected lemma sSup_le (hs : ∀ x ∈ s, x ≤ a) (ha : 0 ≤ a) : sSup s ≤ a := by
+  obtain rfl | hs' := s.eq_empty_or_nonempty
+  exacts [sSup_empty.trans_le ha, csSup_le hs' hs]
+
+/-- As `⨆ i, f i = 0` when `f` is the empty function or unbounded above,
+it suffices to show that all values of `f` are at most some nonnegative number `a` to show that
+`⨆ i, f i ≤ a`. -/
+protected lemma iSup_le (hf : ∀ i, f i ≤ a) (ha : 0 ≤ a) : ⨆ i, f i ≤ a :=
+  Real.sSup_le (Set.forall_mem_range.2 hf) ha
+
+/-- As `sInf s = 0` when `s` is a set of reals that's either empty or unbounded below,
+it suffices to show that all elements of `s` are at least some nonpositive number `a` to show that
+`a ≤ sInf s`. -/
+protected lemma le_sInf (hs : ∀ x ∈ s, a ≤ x) (ha : a ≤ 0) : a ≤ sInf s := by
+  obtain rfl | hs' := s.eq_empty_or_nonempty
+  exacts [ha.trans_eq sInf_empty.symm, le_csInf hs' hs]
+
+/-- As `⨅ i, f i = 0` when `f` is the empty function or unbounded above,
+it suffices to show that all values of `f` are at least some nonnegative number `a` to show that
+`a ≤ ⨅ i, f i`. -/
+protected lemma le_iInf (hf : ∀ i, a ≤ f i) (ha : a ≤ 0) : a ≤ ⨅ i, f i :=
+  Real.le_sInf (Set.forall_mem_range.2 hf) ha
+
+/-- As `sSup s = 0` when `s` is a set of reals that's either empty or unbounded above,
+it suffices to show that all elements of `s` are nonpositive to show that `sSup s ≤ 0`. -/
+lemma sSup_nonpos (hs : ∀ x ∈ s, x ≤ 0) : sSup s ≤ 0 := Real.sSup_le hs le_rfl
+
+/-- As `⨆ i, f i = 0` when `f` is the empty function or unbounded above,
+it suffices to show that all values of `f` are nonpositive to show that `⨆ i, f i ≤ 0`. -/
+lemma iSup_nonpos (hf : ∀ i, f i ≤ 0) : ⨆ i, f i ≤ 0 := Real.iSup_le hf le_rfl
+
+/-- As `sInf s = 0` when `s` is a set of reals that's either empty or unbounded below,
+it suffices to show that all elements of `s` are nonnegative to show that `0 ≤ sInf s`. -/
+lemma sInf_nonneg (hs : ∀ x ∈ s, 0 ≤ x) : 0 ≤ sInf s := Real.le_sInf hs le_rfl
+
+/-- As `⨅ i, f i = 0` when `f` is the empty function or unbounded below,
+it suffices to show that all values of `f` are nonnegative to show that `0 ≤ ⨅ i, f i`. -/
+lemma iInf_nonneg (hf : ∀ i, 0 ≤ f i) : 0 ≤ iInf f := Real.le_iInf hf le_rfl
+
+/-- As `sSup s = 0` when `s` is a set of reals that's unbounded above,
+it suffices to show that `s` contains a nonnegative element to show that `0 ≤ sSup s`. -/
+lemma sSup_nonneg' (hs : ∃ x ∈ s, 0 ≤ x) : 0 ≤ sSup s := by
+  obtain ⟨x, hxs, hx⟩ := hs
+  exact dite _ (fun h ↦ le_csSup_of_le h hxs hx) fun h ↦ (sSup_of_not_bddAbove h).ge
+
+/-- As `⨆ i, f i = 0` when `f` is unbounded above,
+it suffices to show that `f` takes a nonnegative value to show that `0 ≤ ⨆ i, f i`. -/
+lemma iSup_nonneg' (hf : ∃ i, 0 ≤ f i) : 0 ≤ ⨆ i, f i := sSup_nonneg' <| Set.exists_range_iff.2 hf
+
+/-- As `sInf s = 0` when `s` is a set of reals that's unbounded below,
+it suffices to show that `s` contains a nonpositive element to show that `sInf s ≤ 0`. -/
+lemma sInf_nonpos' (hs : ∃ x ∈ s, x ≤ 0) : sInf s ≤ 0 := by
+  obtain ⟨x, hxs, hx⟩ := hs
+  exact dite _ (fun h ↦ csInf_le_of_le h hxs hx) fun h ↦ (sInf_of_not_bddBelow h).le
+
+/-- As `⨅ i, f i = 0` when `f` is unbounded below,
+it suffices to show that `f` takes a nonpositive value to show that `0 ≤ ⨅ i, f i`. -/
+lemma iInf_nonpos' (hf : ∃ i, f i ≤ 0) : ⨅ i, f i ≤ 0 := sInf_nonpos' <| Set.exists_range_iff.2 hf
+
+/-- As `sSup s = 0` when `s` is a set of reals that's either empty or unbounded above,
+it suffices to show that all elements of `s` are nonnegative to show that `0 ≤ sSup s`. -/
+lemma sSup_nonneg (hs : ∀ x ∈ s, 0 ≤ x) : 0 ≤ sSup s := by
+  obtain rfl | ⟨x, hx⟩ := s.eq_empty_or_nonempty
   · exact sSup_empty.ge
-  · apply dite _ (fun h => le_csSup_of_le h hy <| hS y hy) fun h => (sSup_of_not_bddAbove h).ge
+  · exact sSup_nonneg' ⟨x, hx, hs _ hx⟩
 
-/--
-As `0` is the default value for `Real.sSup` of the empty set or sets which are not bounded above, it
-suffices to show that `f i` is nonnegative to show that `0 ≤ ⨆ i, f i`.
--/
-protected theorem iSup_nonneg {ι : Sort*} {f : ι → ℝ} (hf : ∀ i, 0 ≤ f i) : 0 ≤ ⨆ i, f i :=
-  sSup_nonneg _ <| Set.forall_mem_range.2 hf
+/-- As `⨆ i, f i = 0` when `f` is the empty function or unbounded above,
+it suffices to show that all values of `f` are nonnegative to show that `0 ≤ ⨆ i, f i`. -/
+lemma iSup_nonneg (hf : ∀ i, 0 ≤ f i) : 0 ≤ ⨆ i, f i := sSup_nonneg <| Set.forall_mem_range.2 hf
 
-/--
-As `0` is the default value for `Real.sSup` of the empty set or sets which are not bounded above, it
-suffices to show that all elements of `S` are bounded by a nonnegative number to show that `sSup S`
-is bounded by this number.
--/
-protected theorem sSup_le {S : Set ℝ} {a : ℝ} (hS : ∀ x ∈ S, x ≤ a) (ha : 0 ≤ a) : sSup S ≤ a := by
-  rcases S.eq_empty_or_nonempty with (rfl | hS₂)
-  exacts [sSup_empty.trans_le ha, csSup_le hS₂ hS]
-
-protected theorem iSup_le {ι : Sort*} {f : ι → ℝ} {a : ℝ} (hS : ∀ i, f i ≤ a) (ha : 0 ≤ a) :
-    ⨆ i, f i ≤ a :=
-  Real.sSup_le (Set.forall_mem_range.2 hS) ha
-
-/-- As `0` is the default value for `Real.sSup` of the empty set, it suffices to show that `S` is
-bounded above by `0` to show that `sSup S ≤ 0`.
--/
-theorem sSup_nonpos (S : Set ℝ) (hS : ∀ x ∈ S, x ≤ (0 : ℝ)) : sSup S ≤ 0 :=
-  Real.sSup_le hS le_rfl
-
-/-- As `0` is the default value for `Real.sInf` of the empty set, it suffices to show that `S` is
-bounded below by `0` to show that `0 ≤ sInf S`.
--/
-theorem sInf_nonneg (S : Set ℝ) (hS : ∀ x ∈ S, (0 : ℝ) ≤ x) : 0 ≤ sInf S := by
-  rcases S.eq_empty_or_nonempty with (rfl | hS₂)
-  exacts [sInf_empty.ge, le_csInf hS₂ hS]
-
-/-- As `0` is the default value for `Real.sInf` of the empty set, it suffices to show that `f i` is
-bounded below by `0` to show that `0 ≤ iInf f`.
--/
-theorem iInf_nonneg {ι} {f : ι → ℝ} (hf : ∀ i, 0 ≤ f i) : 0 ≤ iInf f :=
-  sInf_nonneg _ <| Set.forall_mem_range.2 hf
-
-/--
-As `0` is the default value for `Real.sInf` of the empty set or sets which are not bounded below, it
-suffices to show that `S` is bounded above by `0` to show that `sInf S ≤ 0`.
--/
-theorem sInf_nonpos (S : Set ℝ) (hS : ∀ x ∈ S, x ≤ (0 : ℝ)) : sInf S ≤ 0 := by
-  rcases S.eq_empty_or_nonempty with (rfl | ⟨y, hy⟩)
+/-- As `sInf s = 0` when `s` is a set of reals that's either empty or unbounded below,
+it suffices to show that all elements of `s` are nonpositive to show that `sInf s ≤ 0`. -/
+lemma sInf_nonpos (hs : ∀ x ∈ s, x ≤ 0) : sInf s ≤ 0 := by
+  obtain rfl | ⟨x, hx⟩ := s.eq_empty_or_nonempty
   · exact sInf_empty.le
-  · apply dite _ (fun h => csInf_le_of_le h hy <| hS y hy) fun h => (sInf_of_not_bddBelow h).le
+  · exact sInf_nonpos' ⟨x, hx, hs _ hx⟩
+
+/-- As `⨅ i, f i = 0` when `f` is the empty function or unbounded below,
+it suffices to show that all values of `f` are nonpositive to show that `0 ≤ ⨅ i, f i`. -/
+lemma iInf_nonpos (hf : ∀ i, f i ≤ 0) : ⨅ i, f i ≤ 0 := sInf_nonpos <| Set.forall_mem_range.2 hf
 
 theorem sInf_le_sSup (s : Set ℝ) (h₁ : BddBelow s) (h₂ : BddAbove s) : sInf s ≤ sSup s := by
   rcases s.eq_empty_or_nonempty with (rfl | hne)
@@ -272,12 +289,12 @@ theorem sInf_le_sSup (s : Set ℝ) (h₁ : BddBelow s) (h₂ : BddAbove s) : sIn
   · exact csInf_le_csSup h₁ h₂ hne
 
 theorem cauSeq_converges (f : CauSeq ℝ abs) : ∃ x, f ≈ const abs x := by
-  let S := { x : ℝ | const abs x < f }
-  have lb : ∃ x, x ∈ S := exists_lt f
-  have ub' : ∀ x, f < const abs x → ∀ y ∈ S, y ≤ x := fun x h y yS =>
+  let s := {x : ℝ | const abs x < f}
+  have lb : ∃ x, x ∈ s := exists_lt f
+  have ub' : ∀ x, f < const abs x → ∀ y ∈ s, y ≤ x := fun x h y yS =>
     le_of_lt <| const_lt.1 <| CauSeq.lt_trans yS h
-  have ub : ∃ x, ∀ y ∈ S, y ≤ x := (exists_gt f).imp ub'
-  refine ⟨sSup S, ((lt_total _ _).resolve_left fun h => ?_).resolve_right fun h => ?_⟩
+  have ub : ∃ x, ∀ y ∈ s, y ≤ x := (exists_gt f).imp ub'
+  refine ⟨sSup s, ((lt_total _ _).resolve_left fun h => ?_).resolve_right fun h => ?_⟩
   · rcases h with ⟨ε, ε0, i, ih⟩
     refine (csSup_le lb (ub' _ ?_)).not_lt (sub_lt_self _ (half_pos ε0))
     refine ⟨_, half_pos ε0, i, fun j ij => ?_⟩
@@ -336,8 +353,7 @@ theorem iInter_Iic_rat : ⋂ r : ℚ, Iic (r : ℝ) = ∅ := by
   exact iInter_Iic_eq_empty_iff.mpr not_bddBelow_coe
 
 /-- Exponentiation is eventually larger than linear growth. -/
-lemma exists_natCast_add_one_lt_pow_of_one_lt {a : ℝ} (ha : 1 < a) :
-    ∃ m : ℕ, (m + 1 : ℝ) < a ^ m := by
+lemma exists_natCast_add_one_lt_pow_of_one_lt (ha : 1 < a) : ∃ m : ℕ, (m + 1 : ℝ) < a ^ m := by
   obtain ⟨k, posk, hk⟩ : ∃ k : ℕ, 0 < k ∧ 1 / k + 1 < a := by
     contrapose! ha
     refine le_of_forall_lt_rat_imp_le ?_

--- a/Mathlib/Data/Real/Archimedean.lean
+++ b/Mathlib/Data/Real/Archimedean.lean
@@ -199,45 +199,41 @@ theorem sInf_of_not_bddBelow (hs : ¬BddBelow s) : sInf s = 0 :=
 theorem iInf_of_not_bddBelow (hf : ¬BddBelow (Set.range f)) : ⨅ i, f i = 0 :=
   sInf_of_not_bddBelow hf
 
-/-- As `sSup s = 0` when `s` is a set of reals that's either empty or unbounded above,
-it suffices to show that all elements of `s` are at most some nonnegative number `a` to show that
-`sSup s ≤ a`. -/
+/-- As `sSup s = 0` when `s` is an empty set of reals, it suffices to show that all elements of `s`
+are at most some nonnegative number `a` to show that `sSup s ≤ a`. -/
 protected lemma sSup_le (hs : ∀ x ∈ s, x ≤ a) (ha : 0 ≤ a) : sSup s ≤ a := by
   obtain rfl | hs' := s.eq_empty_or_nonempty
   exacts [sSup_empty.trans_le ha, csSup_le hs' hs]
 
-/-- As `⨆ i, f i = 0` when `f` is the empty function or unbounded above,
-it suffices to show that all values of `f` are at most some nonnegative number `a` to show that
-`⨆ i, f i ≤ a`. -/
+/-- As `⨆ i, f i = 0` when `f` is the empty function, it suffices to show that all values of `f`
+are at most some nonnegative number `a` to show that `⨆ i, f i ≤ a`. -/
 protected lemma iSup_le (hf : ∀ i, f i ≤ a) (ha : 0 ≤ a) : ⨆ i, f i ≤ a :=
   Real.sSup_le (Set.forall_mem_range.2 hf) ha
 
-/-- As `sInf s = 0` when `s` is a set of reals that's either empty or unbounded below,
-it suffices to show that all elements of `s` are at least some nonpositive number `a` to show that
-`a ≤ sInf s`. -/
+/-- As `sInf s = 0` when `s` is an empty set of reals, it suffices to show that all elements of `s`
+are at least some nonpositive number `a` to show that `a ≤ sInf s`. -/
 protected lemma le_sInf (hs : ∀ x ∈ s, a ≤ x) (ha : a ≤ 0) : a ≤ sInf s := by
   obtain rfl | hs' := s.eq_empty_or_nonempty
   exacts [ha.trans_eq sInf_empty.symm, le_csInf hs' hs]
 
-/-- As `⨅ i, f i = 0` when `f` is the empty function or unbounded above,
-it suffices to show that all values of `f` are at least some nonnegative number `a` to show that
-`a ≤ ⨅ i, f i`. -/
+/-- As `⨅ i, f i = 0` when `f` is the empty function, it suffices to show that all values of `f`
+are at least some nonnegative number `a` to show that `a ≤ ⨅ i, f i`. -/
 protected lemma le_iInf (hf : ∀ i, a ≤ f i) (ha : a ≤ 0) : a ≤ ⨅ i, f i :=
   Real.le_sInf (Set.forall_mem_range.2 hf) ha
 
-/-- As `sSup s = 0` when `s` is a set of reals that's either empty or unbounded above,
+/-- As `sSup s = 0` when `s` is an empty set of reals,
 it suffices to show that all elements of `s` are nonpositive to show that `sSup s ≤ 0`. -/
 lemma sSup_nonpos (hs : ∀ x ∈ s, x ≤ 0) : sSup s ≤ 0 := Real.sSup_le hs le_rfl
 
-/-- As `⨆ i, f i = 0` when `f` is the empty function or unbounded above,
+/-- As `⨆ i, f i = 0` when `f` is the empty function,
 it suffices to show that all values of `f` are nonpositive to show that `⨆ i, f i ≤ 0`. -/
 lemma iSup_nonpos (hf : ∀ i, f i ≤ 0) : ⨆ i, f i ≤ 0 := Real.iSup_le hf le_rfl
 
-/-- As `sInf s = 0` when `s` is a set of reals that's either empty or unbounded below,
+/-- As `sInf s = 0` when `s` is an empty set of reals,
 it suffices to show that all elements of `s` are nonnegative to show that `0 ≤ sInf s`. -/
 lemma sInf_nonneg (hs : ∀ x ∈ s, 0 ≤ x) : 0 ≤ sInf s := Real.le_sInf hs le_rfl
 
-/-- As `⨅ i, f i = 0` when `f` is the empty function or unbounded below,
+/-- As `⨅ i, f i = 0` when `f` is the empty function,
 it suffices to show that all values of `f` are nonnegative to show that `0 ≤ ⨅ i, f i`. -/
 lemma iInf_nonneg (hf : ∀ i, 0 ≤ f i) : 0 ≤ iInf f := Real.le_iInf hf le_rfl
 

--- a/Mathlib/Dynamics/Circle/RotationNumber/TranslationNumber.lean
+++ b/Mathlib/Dynamics/Circle/RotationNumber/TranslationNumber.lean
@@ -852,8 +852,8 @@ theorem semiconj_of_group_action_of_forall_translationNumber_eq {G : Type*} [Gro
   have hF₁ : ∀ g, ⇑(F₁ g) = f₁ g := fun _ => rfl
   have hF₂ : ∀ g, ⇑(F₂ g) = f₂ g := fun _ => rfl
   -- Now we apply `csSup_div_semiconj` and go back to `f₁` and `f₂`.
-  refine ⟨⟨⟨_, fun x y hxy => ?_⟩, fun x => ?_⟩, csSup_div_semiconj F₂ F₁ fun x => ?_⟩ <;>
-    simp only [hF₁, hF₂, ← map_inv, coe_mk]
+  refine ⟨⟨⟨fun x ↦ ⨆ g', (F₂ g')⁻¹ (F₁ g' x), fun x y hxy => ?_⟩, fun x => ?_⟩,
+    csSup_div_semiconj F₂ F₁ fun x => ?_⟩ <;> simp only [hF₁, hF₂, ← map_inv, coe_mk]
   · exact ciSup_mono (this y) fun g => mono _ (mono _ hxy)
   · simp only [map_add_one]
     exact (Monotone.map_ciSup_of_continuousAt (continuousAt_id.add continuousAt_const)


### PR DESCRIPTION
Add a few lemmas, golf the existing ones and update the docstrings to something more precise


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
