### PR TITLE
feat(Analysis/Calculus/Implicit): define HasStrictDerivAt.implicitFunOfBivariate

### DIFF
--- a/Mathlib/Analysis/Calculus/Implicit.lean
+++ b/Mathlib/Analysis/Calculus/Implicit.lean
@@ -14,7 +14,7 @@ import Mathlib.Analysis.Normed.Module.Complemented
 We prove four versions of the implicit function theorem. First we define a structure
 `ImplicitFunctionData` that holds arguments for the most general version of the implicit function
 theorem, see `ImplicitFunctionData.implicitFunction` and
-`ImplicitFunctionData.implicitFunction_hasStrictFDerivAt`. This version allows a user to choose a
+`ImplicitFunctionData.hasStrictFDerivAt_implicitFunction`. This version allows a user to choose a
 specific implicit function but provides only a little convenience over the inverse function theorem.
 
 Then we define `HasStrictFDerivAt.implicitFunctionDataOfComplemented`: implicit function defined by
@@ -198,7 +198,7 @@ theorem map_nhds_eq : map φ.leftFun (𝓝 φ.pt) = 𝓝 (φ.leftFun φ.pt) :=
   show map (Prod.fst ∘ φ.prodFun) (𝓝 φ.pt) = 𝓝 (φ.prodFun φ.pt).1 by
     rw [← map_map, φ.hasStrictFDerivAt.map_nhds_eq_of_equiv, map_fst_nhds]
 
-theorem implicitFunction_hasStrictFDerivAt (g'inv : G →L[𝕜] E)
+theorem hasStrictFDerivAt_implicitFunction (g'inv : G →L[𝕜] E)
     (hg'inv : φ.rightDeriv.comp g'inv = ContinuousLinearMap.id 𝕜 G)
     (hg'invf : φ.leftDeriv.comp g'inv = 0) :
     HasStrictFDerivAt (φ.implicitFunction (φ.leftFun φ.pt)) g'inv (φ.rightFun φ.pt) := by
@@ -212,6 +212,9 @@ theorem implicitFunction_hasStrictFDerivAt (g'inv : G →L[𝕜] E)
   intro x
   erw [ContinuousLinearEquiv.eq_symm_apply]
   simp [*]
+
+@[deprecated (since := "2024-09-18")]
+alias implicitFunction_hasStrictFDerivAt := hasStrictFDerivAt_implicitFunction
 
 end ImplicitFunctionData
 
@@ -337,7 +340,7 @@ theorem to_implicitFunctionOfComplemented (hf : HasStrictFDerivAt f f' a) (hf' :
     (hker : (ker f').ClosedComplemented) :
     HasStrictFDerivAt (hf.implicitFunctionOfComplemented f f' hf' hker (f a))
       (ker f').subtypeL 0 := by
-  convert (implicitFunctionDataOfComplemented f f' hf hf' hker).implicitFunction_hasStrictFDerivAt
+  convert (implicitFunctionDataOfComplemented f f' hf hf' hker).hasStrictFDerivAt_implicitFunction
     (ker f').subtypeL _ _
   swap
   · ext
@@ -515,12 +518,12 @@ def implicitFunOfBivariate {f : X × Y → Z} {p₀ : X × Y}
     X → Y :=
   fun x => (hf₀.implicitFunDataOfBivariate.implicitFunction (f p₀) x).2
 
-theorem implicitFunOfBivariate_hasStrictFDerivAt {f : X × Y → Z} {x₀ : X} {y₀ : Y}
+theorem hasStrictFDerivAt_implicitFunOfBivariate {f : X × Y → Z} {x₀ : X} {y₀ : Y}
     {fx : X →L[𝕜] Z} {fy : Y ≃L[𝕜] Z} (hf₀ : HasStrictFDerivAt f (fx.coprod fy) (x₀, y₀)) :
     HasStrictFDerivAt hf₀.implicitFunOfBivariate (-fy.symm ∘L fx) x₀ := by
   set ψ' : X →L[𝕜] Y := -fy.symm ∘L fx
   apply HasStrictFDerivAt.snd (f₂' := (ContinuousLinearMap.id 𝕜 X).prod ψ')
-  apply hf₀.implicitFunDataOfBivariate.implicitFunction_hasStrictFDerivAt
+  apply hf₀.implicitFunDataOfBivariate.hasStrictFDerivAt_implicitFunction
   · apply ContinuousLinearMap.fst_comp_prod
   · change fx + fy ∘L ψ' = 0
     simp [ψ', ← ContinuousLinearMap.comp_assoc]
@@ -532,16 +535,21 @@ theorem image_eq_iff_implicitFunOfBivariate {f : X × Y → Z} {p₀ : X × Y}
   filter_upwards [φ.leftFun_eq_iff_implicitFun, φ.rightFun_implicitFun_mixed_args] with p h h'
   exact Iff.trans h ⟨congrArg _, by aesop⟩
 
+theorem tendsto_implicitFunOfBivariate {f : X × Y → Z} {x₀ : X} {y₀ : Y}
+    {fx : X →L[𝕜] Z} {fy : Y ≃L[𝕜] Z} (hf₀ : HasStrictFDerivAt f (fx.coprod fy) (x₀, y₀)) :
+    Tendsto hf₀.implicitFunOfBivariate (𝓝 x₀) (𝓝 y₀) := by
+  convert hf₀.hasStrictFDerivAt_implicitFunOfBivariate.continuousAt.tendsto
+  rw [hf₀.image_eq_iff_implicitFunOfBivariate.self_of_nhds.mp rfl]
+
 theorem image_implicitFunOfBivariate {f : X × Y → Z} {x₀ : X} {y₀ : Y}
     {fx : X →L[𝕜] Z} {fy : Y ≃L[𝕜] Z} (hf₀ : HasStrictFDerivAt f (fx.coprod fy) (x₀, y₀)) :
     ∀ᶠ x in 𝓝 x₀, f (x, hf₀.implicitFunOfBivariate x) = f (x₀, y₀) := by
-  have hψ := hf₀.implicitFunOfBivariate_hasStrictFDerivAt.continuousAt.tendsto
+  have hψ := hf₀.tendsto_implicitFunOfBivariate
   set ψ := hf₀.implicitFunOfBivariate
   suffices ∀ᶠ x in 𝓝 x₀, f (x, ψ x) = f (x₀, y₀) ↔ ψ x = ψ x by simpa
   apply hψ.eventually_image_of_prod (r := fun x y => f (x, y) = f (x₀, y₀) ↔ ψ x = y)
   rw [← nhds_prod_eq]
-  convert hf₀.image_eq_iff_implicitFunOfBivariate
-  rw [← hf₀.image_eq_iff_implicitFunOfBivariate.self_of_nhds]
+  exact hf₀.image_eq_iff_implicitFunOfBivariate
 
 end Bivariate
 

--- a/Mathlib/Analysis/Calculus/Implicit.lean
+++ b/Mathlib/Analysis/Calculus/Implicit.lean
@@ -537,7 +537,7 @@ theorem image_implicitFunOfBivariate {f : X × Y → Z} {x₀ : X} {y₀ : Y}
     ∀ᶠ x in 𝓝 x₀, f (x, hf₀.implicitFunOfBivariate x) = f (x₀, y₀) := by
   set ψ := hf₀.implicitFunOfBivariate
   suffices ∀ᶠ x in 𝓝 x₀, f (x, ψ x) = f (x₀, y₀) ↔ ψ x = ψ x by simpa
-  apply Eventually.nhds_prod_image (r := fun x y => f (x, y) = f (x₀, y₀) ↔ ψ x = y)
+  apply Eventually.nhds_pair_image (r := fun x y => f (x, y) = f (x₀, y₀) ↔ ψ x = y)
   · convert hf₀.image_eq_iff_implicitFunOfBivariate
     rw [← hf₀.image_eq_iff_implicitFunOfBivariate.self_of_nhds]
   · exact hf₀.implicitFunOfBivariate_hasStrictFDerivAt.continuousAt

--- a/Mathlib/Analysis/Calculus/Implicit.lean
+++ b/Mathlib/Analysis/Calculus/Implicit.lean
@@ -535,10 +535,10 @@ theorem image_eq_iff_implicitFunOfBivariate {f : X × Y → Z} {p₀ : X × Y}
 theorem image_implicitFunOfBivariate {f : X × Y → Z} {x₀ : X} {y₀ : Y}
     {fx : X →L[𝕜] Z} {fy : Y ≃L[𝕜] Z} (hf₀ : HasStrictFDerivAt f (fx.coprod fy) (x₀, y₀)) :
     ∀ᶠ x in 𝓝 x₀, f (x, hf₀.implicitFunOfBivariate x) = f (x₀, y₀) := by
+  have hψ := hf₀.implicitFunOfBivariate_hasStrictFDerivAt.continuousAt.tendsto
   set ψ := hf₀.implicitFunOfBivariate
   suffices ∀ᶠ x in 𝓝 x₀, f (x, ψ x) = f (x₀, y₀) ↔ ψ x = ψ x by simpa
-  have := hf₀.implicitFunOfBivariate_hasStrictFDerivAt.continuousAt.tendsto
-  apply this.eventually_image_of_prod (r := fun x y => f (x, y) = f (x₀, y₀) ↔ ψ x = y)
+  apply hψ.eventually_image_of_prod (r := fun x y => f (x, y) = f (x₀, y₀) ↔ ψ x = y)
   rw [← nhds_prod_eq]
   convert hf₀.image_eq_iff_implicitFunOfBivariate
   rw [← hf₀.image_eq_iff_implicitFunOfBivariate.self_of_nhds]

--- a/Mathlib/Analysis/Calculus/Implicit.lean
+++ b/Mathlib/Analysis/Calculus/Implicit.lean
@@ -471,8 +471,8 @@ functionality is wrapped by `HasStrictFDerivAt.implicitFunOfBivariate`.
 
 ## TODO
 
-* Provide another version with curried `f : X → Y → Z` and technical assumptions on the partial
-  derivatives.
+* Provide another version with curried `f : X → Y → Z` and with technical assumptions made on the
+  partial derivatives.
 * Establish results about higher derivatives.
 -/
 
@@ -482,8 +482,8 @@ variable {Y : Type*} [NormedAddCommGroup Y] [NormedSpace 𝕜 Y] [CompleteSpace 
 variable {Z : Type*} [NormedAddCommGroup Z] [NormedSpace 𝕜 Z] [CompleteSpace Z]
 
 /-- Given linear map `fx : X →L[𝕜] Z`, linear equivalence `fy : Y ≃L[𝕜] Z` and that
-`HasStrictFDerivAt f (fx.coprod fy) p₀`, we construct an object of type `ImplicitFunctionData` thus
-permitting use of the general machinery provided above. -/
+`HasStrictFDerivAt f (fx.coprod fy) p₀`, we construct an object of type `ImplicitFunctionData`
+thereby enabling use of the general machinery provided above. -/
 def implicitFunDataOfBivariate {f : X × Y → Z} {p₀ : X × Y}
     {fx : X →L[𝕜] Z} {fy : Y ≃L[𝕜] Z} (hf₀ : HasStrictFDerivAt f (fx.coprod fy) p₀) :
     ImplicitFunctionData 𝕜 (X × Y) Z X :=
@@ -505,7 +505,8 @@ def implicitFunDataOfBivariate {f : X × Y → Z} {p₀ : X × Y}
       aesop
     · rw [Submodule.codisjoint_iff_exists_add_eq]
       intro (ξ, η)
-      exact ⟨(ξ, fy.symm (fx (-ξ))), by simp, (0, η - fy.symm (fx (-ξ))), by simp, by simp⟩ }
+      use (ξ, fy.symm (fx (-ξ))), (0, η - fy.symm (fx (-ξ)))
+      simp }
 
 /-- Implicit function `ψ : X → Y` associated with the (uncurried) bivariate function `f : X × Y → Z`
 at `p₀ : X × Y`. -/
@@ -535,7 +536,7 @@ theorem image_implicitFunOfBivariate {f : X × Y → Z} {x₀ : X} {y₀ : Y}
     {fx : X →L[𝕜] Z} {fy : Y ≃L[𝕜] Z} (hf₀ : HasStrictFDerivAt f (fx.coprod fy) (x₀, y₀)) :
     ∀ᶠ x in 𝓝 x₀, f (x, hf₀.implicitFunOfBivariate x) = f (x₀, y₀) := by
   set ψ := hf₀.implicitFunOfBivariate
-  suffices ∀ᶠ x in 𝓝 x₀, f (x, ψ x) = f (x₀, y₀) ↔ ψ x = ψ x by simp [eventually_congr this]
+  suffices ∀ᶠ x in 𝓝 x₀, f (x, ψ x) = f (x₀, y₀) ↔ ψ x = ψ x by simpa
   apply Eventually.nhds_prod_image (r := fun x y => f (x, y) = f (x₀, y₀) ↔ ψ x = y)
   · convert hf₀.image_eq_iff_implicitFunOfBivariate
     rw [← hf₀.image_eq_iff_implicitFunOfBivariate.self_of_nhds]

--- a/Mathlib/Analysis/Calculus/Implicit.lean
+++ b/Mathlib/Analysis/Calculus/Implicit.lean
@@ -537,10 +537,11 @@ theorem image_implicitFunOfBivariate {f : X × Y → Z} {x₀ : X} {y₀ : Y}
     ∀ᶠ x in 𝓝 x₀, f (x, hf₀.implicitFunOfBivariate x) = f (x₀, y₀) := by
   set ψ := hf₀.implicitFunOfBivariate
   suffices ∀ᶠ x in 𝓝 x₀, f (x, ψ x) = f (x₀, y₀) ↔ ψ x = ψ x by simpa
-  apply Eventually.nhds_pair_image (r := fun x y => f (x, y) = f (x₀, y₀) ↔ ψ x = y)
-  · convert hf₀.image_eq_iff_implicitFunOfBivariate
-    rw [← hf₀.image_eq_iff_implicitFunOfBivariate.self_of_nhds]
-  · exact hf₀.implicitFunOfBivariate_hasStrictFDerivAt.continuousAt
+  have := hf₀.implicitFunOfBivariate_hasStrictFDerivAt.continuousAt.tendsto
+  apply this.eventually_image_of_prod (r := fun x y => f (x, y) = f (x₀, y₀) ↔ ψ x = y)
+  rw [← nhds_prod_eq]
+  convert hf₀.image_eq_iff_implicitFunOfBivariate
+  rw [← hf₀.image_eq_iff_implicitFunOfBivariate.self_of_nhds]
 
 end Bivariate
 

--- a/Mathlib/Analysis/Calculus/Implicit.lean
+++ b/Mathlib/Analysis/Calculus/Implicit.lean
@@ -25,9 +25,9 @@ Third, if the codomain of `f` is a finite dimensional space, then we can automat
 that the kernel of `f'` is complemented, hence the only assumptions are `HasStrictFDerivAt`
 and `f'.range = ⊤`. This version is named `HasStrictFDerivAt.implicitFunction`.
 
-Finally, if bivariate $f(x,y)$ has $\partial f/\partial y$ invertible at $(x₀,y₀)$, then we may
-apply the general theorem to obtain $ψ$ satisfying $f(x,ψ(x))=f(x₀,y₀)$ in a neighbourhood of $x₀$.
-To many this version of the implicit function theorem will be most familiar.
+Finally, if bivariate $f(x,y)$ has $\partial f/\partial y$ invertible at $(x_{0},y_{0})$, then we
+may apply the general theorem to obtain $ψ$ satisfying $f(x,ψ(x))=f(x_{0},y_{0})$ in a neighbourhood
+of $x_{0}$. To many this version of the implicit function theorem will be most familiar.
 
 ## TODO
 
@@ -481,9 +481,9 @@ variable {X : Type*} [NormedAddCommGroup X] [NormedSpace 𝕜 X] [CompleteSpace 
 variable {Y : Type*} [NormedAddCommGroup Y] [NormedSpace 𝕜 Y] [CompleteSpace Y]
 variable {Z : Type*} [NormedAddCommGroup Z] [NormedSpace 𝕜 Z] [CompleteSpace Z]
 
-/-- Given map `fx : X →L[𝕜] Z`, equivalence `fy : Y ≃L[𝕜] Z}` and that
-`HasStrictFDerivAt f (fx.coprod fy) p₀`, we construct an object of type `ImplicitFunctionData`, thus
-permitting use of the machinery provided above for the general case. -/
+/-- Given linear map `fx : X →L[𝕜] Z`, linear equivalence `fy : Y ≃L[𝕜] Z` and that
+`HasStrictFDerivAt f (fx.coprod fy) p₀`, we construct an object of type `ImplicitFunctionData` thus
+permitting use of the general machinery provided above. -/
 def implicitFunDataOfBivariate {f : X × Y → Z} {p₀ : X × Y}
     {fx : X →L[𝕜] Z} {fy : Y ≃L[𝕜] Z} (hf₀ : HasStrictFDerivAt f (fx.coprod fy) p₀) :
     ImplicitFunctionData 𝕜 (X × Y) Z X :=

--- a/Mathlib/Analysis/Calculus/Implicit.lean
+++ b/Mathlib/Analysis/Calculus/Implicit.lean
@@ -189,7 +189,7 @@ theorem rightFun_implicitFun_mixed_args : ∀ᶠ x in 𝓝 φ.pt,
   have := φ.right_map_implicitFunction.curry_nhds.self_of_nhds.prod_inr_nhds (φ.leftFun φ.pt)
   rwa [← prodFun_apply, ← φ.hasStrictFDerivAt.map_nhds_eq_of_equiv, eventually_map] at this
 
-theorem leftFun_eq_iff_implicitFun_eq : ∀ᶠ x in 𝓝 φ.pt,
+theorem leftFun_eq_iff_implicitFun : ∀ᶠ x in 𝓝 φ.pt,
     φ.leftFun x = φ.leftFun φ.pt ↔ φ.implicitFunction (φ.leftFun φ.pt) (φ.rightFun x) = x := by
   filter_upwards [φ.implicitFunction_apply_image, φ.leftFun_implicitFun_mixed_args] with x hx₁ hx₂
   constructor <;> exact fun h => by rwa [← h]
@@ -528,16 +528,15 @@ theorem image_eq_iff_implicitFunOfBivariate {f : X × Y → Z} {p₀ : X × Y}
     {fx : X →L[𝕜] Z} {fy : Y ≃L[𝕜] Z} (hf₀ : HasStrictFDerivAt f (fx.coprod fy) p₀) :
     ∀ᶠ p in 𝓝 p₀, f p = f p₀ ↔ hf₀.implicitFunOfBivariate p.1 = p.2 := by
   let φ := hf₀.implicitFunDataOfBivariate
-  filter_upwards [φ.leftFun_eq_iff_implicitFun_eq, φ.rightFun_implicitFun_mixed_args] with p h h'
+  filter_upwards [φ.leftFun_eq_iff_implicitFun, φ.rightFun_implicitFun_mixed_args] with p h h'
   exact Iff.trans h ⟨congrArg _, by aesop⟩
 
 theorem image_implicitFunOfBivariate {f : X × Y → Z} {x₀ : X} {y₀ : Y}
     {fx : X →L[𝕜] Z} {fy : Y ≃L[𝕜] Z} (hf₀ : HasStrictFDerivAt f (fx.coprod fy) (x₀, y₀)) :
     ∀ᶠ x in 𝓝 x₀, f (x, hf₀.implicitFunOfBivariate x) = f (x₀, y₀) := by
   set ψ := hf₀.implicitFunOfBivariate
-  suffices ∀ᶠ x in 𝓝 x₀, f (x, ψ x) = f (x₀, y₀) ↔ ψ x = ψ x by
-    simp [eventually_congr this]
-  apply Eventually.prod_nhds_image (r := fun x y => f (x, y) = f (x₀, y₀) ↔ ψ x = y)
+  suffices ∀ᶠ x in 𝓝 x₀, f (x, ψ x) = f (x₀, y₀) ↔ ψ x = ψ x by simp [eventually_congr this]
+  apply Eventually.nhds_prod_image (r := fun x y => f (x, y) = f (x₀, y₀) ↔ ψ x = y)
   · convert hf₀.image_eq_iff_implicitFunOfBivariate
     rw [← hf₀.image_eq_iff_implicitFunOfBivariate.self_of_nhds]
   · exact hf₀.implicitFunOfBivariate_hasStrictFDerivAt.continuousAt

--- a/Mathlib/Analysis/Calculus/Implicit.lean
+++ b/Mathlib/Analysis/Calculus/Implicit.lean
@@ -27,7 +27,7 @@ and `f'.range = ⊤`. This version is named `HasStrictFDerivAt.implicitFunction`
 
 Finally, if bivariate $f(x,y)$ has $\partial f/\partial y$ invertible at $(x₀,y₀)$, then we may
 apply the general theorem to obtain $ψ$ satisfying $f(x,ψ(x))=f(x₀,y₀)$ in a neighbourhood of $x₀$.
-To many this version of the implicit function theorem might be most familiar.
+To many this version of the implicit function theorem will be most familiar.
 
 ## TODO
 
@@ -463,11 +463,11 @@ section Bivariate
 ### Bivariate case
 
 Here we identify `E` with `X × Y`, `G` with `X` and `g : E → G` with the first projection out of
-`X × Y`. For consistency of notation `F` becomes `Z`. Now `f : X × Y → Z` is an explicity bivariate
-function. If `f` has an invertible partial derivative with respect to `y` then we get that the
-kernels of `f` and `g` are complementary so we can construct an instance of the
-`ImplicitFunctionData` data structure (provided above) and extract implicit function `ψ : X → Y`
-whose germ is unique. This functionality is wrapped by `HasStrictFDerivAt.implicitFunOfBivariate`.
+`X × Y`. For consistency of notation `F` becomes `Z`. Now `f : X × Y → Z` is explicitly bivariate,
+and if its partial derivative with respect to `y` is invertible then the kernels of `f` and `g` are
+complementary. In such circumstances we may construct an instance of the `ImplicitFunctionData` data
+structure provided above and extract implicit function `ψ : X → Y` whose germ is unique. This
+functionality is wrapped by `HasStrictFDerivAt.implicitFunOfBivariate`.
 
 ## TODO
 
@@ -482,8 +482,8 @@ variable {Y : Type*} [NormedAddCommGroup Y] [NormedSpace 𝕜 Y] [CompleteSpace 
 variable {Z : Type*} [NormedAddCommGroup Z] [NormedSpace 𝕜 Z] [CompleteSpace Z]
 
 /-- Given map `fx : X →L[𝕜] Z`, equivalence `fy : Y ≃L[𝕜] Z}` and that
-`HasStrictFDerivAt f (fx.coprod fy) p₀` we construct an object of type `ImplicitFunctionData`
-thus permitting use of the machinery already provided for the general case. -/
+`HasStrictFDerivAt f (fx.coprod fy) p₀`, we construct an object of type `ImplicitFunctionData`, thus
+permitting use of the machinery provided above for the general case. -/
 def implicitFunDataOfBivariate {f : X × Y → Z} {p₀ : X × Y}
     {fx : X →L[𝕜] Z} {fy : Y ≃L[𝕜] Z} (hf₀ : HasStrictFDerivAt f (fx.coprod fy) p₀) :
     ImplicitFunctionData 𝕜 (X × Y) Z X :=
@@ -507,8 +507,8 @@ def implicitFunDataOfBivariate {f : X × Y → Z} {p₀ : X × Y}
       intro (ξ, η)
       exact ⟨(ξ, fy.symm (fx (-ξ))), by simp, (0, η - fy.symm (fx (-ξ))), by simp, by simp⟩ }
 
-/-- Implicit function `ψ : X → Y` associated with (uncurried) bivariate function `f : X × Y → Z` at
-`p₀ : X × Y`. -/
+/-- Implicit function `ψ : X → Y` associated with the (uncurried) bivariate function `f : X × Y → Z`
+at `p₀ : X × Y`. -/
 def implicitFunOfBivariate {f : X × Y → Z} {p₀ : X × Y}
     {fx : X →L[𝕜] Z} {fy : Y ≃L[𝕜] Z} (hf₀ : HasStrictFDerivAt f (fx.coprod fy) p₀) :
     X → Y :=

--- a/Mathlib/LinearAlgebra/BilinearForm/Orthogonal.lean
+++ b/Mathlib/LinearAlgebra/BilinearForm/Orthogonal.lean
@@ -286,7 +286,7 @@ lemma ker_restrict_eq_of_codisjoint {p q : Submodule R M} (hpq : Codisjoint p q)
   simp only [LinearMap.mem_ker, Submodule.mem_comap, Submodule.coeSubtype]
   refine ⟨fun h ↦ ?_, fun h ↦ ?_⟩
   · ext w
-    obtain ⟨x, hx, y, hy, rfl⟩ := Submodule.codisjoint_iff_exists_add_eq.mp hpq w
+    obtain ⟨x, y, hx, hy, rfl⟩ := Submodule.codisjoint_iff_exists_add_eq.mp hpq w
     simpa [hB z hz y hy] using LinearMap.congr_fun h ⟨x, hx⟩
   · ext ⟨x, hx⟩
     simpa using LinearMap.congr_fun h x

--- a/Mathlib/LinearAlgebra/BilinearForm/Orthogonal.lean
+++ b/Mathlib/LinearAlgebra/BilinearForm/Orthogonal.lean
@@ -286,7 +286,7 @@ lemma ker_restrict_eq_of_codisjoint {p q : Submodule R M} (hpq : Codisjoint p q)
   simp only [LinearMap.mem_ker, Submodule.mem_comap, Submodule.coeSubtype]
   refine ⟨fun h ↦ ?_, fun h ↦ ?_⟩
   · ext w
-    obtain ⟨x, hx, y, hy, rfl⟩ := Submodule.exists_add_eq_of_codisjoint hpq w
+    obtain ⟨x, hx, y, hy, rfl⟩ := Submodule.codisjoint_iff_exists_add_eq.mp hpq w
     simpa [hB z hz y hy] using LinearMap.congr_fun h ⟨x, hx⟩
   · ext ⟨x, hx⟩
     simpa using LinearMap.congr_fun h x

--- a/Mathlib/LinearAlgebra/Span.lean
+++ b/Mathlib/LinearAlgebra/Span.lean
@@ -398,7 +398,7 @@ theorem codisjoint_iff_exists_add_eq :
   rw [codisjoint_iff, eq_top_iff']
   exact forall_congr' (fun z => mem_sup.trans <| by simp)
 
-@[deprecated codisjoint_iff_exists_add_eq (since := "2024-09-15")]
+@[deprecated codisjoint_iff_exists_add_eq (since := "2024-09-18")]
 lemma exists_add_eq_of_codisjoint (h : Codisjoint p p') (x : M) :
     ∃ y ∈ p, ∃ z ∈ p', y + z = x := by
   suffices x ∈ p ⊔ p' by exact Submodule.mem_sup.mp this

--- a/Mathlib/LinearAlgebra/Span.lean
+++ b/Mathlib/LinearAlgebra/Span.lean
@@ -394,11 +394,11 @@ theorem mem_sup' : x ∈ p ⊔ p' ↔ ∃ (y : p) (z : p'), (y : M) + z = x :=
   mem_sup.trans <| by simp only [Subtype.exists, exists_prop]
 
 theorem codisjoint_iff_exists_add_eq :
-    Codisjoint p p' ↔ ∀ x, ∃ y ∈ p, ∃ z ∈ p', y + z = x := by
+    Codisjoint p p' ↔ ∀ z, ∃ x y, x ∈ p ∧ y ∈ p' ∧ x + y = z := by
   rw [codisjoint_iff, eq_top_iff']
-  exact forall_congr' (fun x => mem_sup)
+  exact forall_congr' (fun z => mem_sup.trans <| by simp)
 
-@[deprecated codisjoint_iff_exists_add_eq (since := "2024-09-12")]
+@[deprecated codisjoint_iff_exists_add_eq (since := "2024-09-15")]
 lemma exists_add_eq_of_codisjoint (h : Codisjoint p p') (x : M) :
     ∃ y ∈ p, ∃ z ∈ p', y + z = x := by
   suffices x ∈ p ⊔ p' by exact Submodule.mem_sup.mp this

--- a/Mathlib/LinearAlgebra/Span.lean
+++ b/Mathlib/LinearAlgebra/Span.lean
@@ -393,6 +393,12 @@ theorem mem_sup : x ∈ p ⊔ p' ↔ ∃ y ∈ p, ∃ z ∈ p', y + z = x :=
 theorem mem_sup' : x ∈ p ⊔ p' ↔ ∃ (y : p) (z : p'), (y : M) + z = x :=
   mem_sup.trans <| by simp only [Subtype.exists, exists_prop]
 
+theorem codisjoint_iff_exists_add_eq :
+    Codisjoint p p' ↔ ∀ x, ∃ y ∈ p, ∃ z ∈ p', y + z = x := by
+  rw [codisjoint_iff, eq_top_iff']
+  exact forall_congr' (fun x => mem_sup)
+
+@[deprecated codisjoint_iff_exists_add_eq (since := "2024-09-12")]
 lemma exists_add_eq_of_codisjoint (h : Codisjoint p p') (x : M) :
     ∃ y ∈ p, ∃ z ∈ p', y + z = x := by
   suffices x ∈ p ⊔ p' by exact Submodule.mem_sup.mp this

--- a/Mathlib/Order/Filter/Prod.lean
+++ b/Mathlib/Order/Filter/Prod.lean
@@ -346,6 +346,11 @@ theorem Tendsto.prod_map {δ : Type*} {f : α → γ} {g : β → δ} {a : Filte
   erw [Tendsto, ← prod_map_map_eq]
   exact Filter.prod_mono hf hg
 
+theorem Tendsto.eventually_image_of_prod {ψ : α → β} {r : α → β → Prop}
+    (hψ : Tendsto ψ f g) (hr : ∀ᶠ p in f ×ˢ g, r p.1 p.2) : ∀ᶠ x in f, r x (ψ x) := by
+  suffices ∀ᶠ p in map (Prod.map id ψ) (f ×ˢ f), r p.1 p.2 from this.diag_of_prod
+  exact hr.filter_mono (prod_map_right ψ f f ▸ prod_mono_right f hψ)
+
 protected theorem map_prod (m : α × β → γ) (f : Filter α) (g : Filter β) :
     map m (f ×ˢ g) = (f.map fun a b => m (a, b)).seq g := by
   simp only [Filter.ext_iff, mem_map, mem_prod_iff, mem_map_seq_iff, exists_and_left]

--- a/Mathlib/Topology/Constructions.lean
+++ b/Mathlib/Topology/Constructions.lean
@@ -577,7 +577,7 @@ theorem Filter.Eventually.curry_nhds {p : X × Y → Prop} {x : X} {y : Y}
   rw [nhds_prod_eq] at h
   exact h.curry
 
-theorem Filter.Eventually.nhds_prod_image
+theorem Filter.Eventually.nhds_pair_image
     {g : X → Y} {x₀ : X} {r : X → Y → Prop} (hr : ∀ᶠ p in 𝓝 (x₀, g x₀), r p.1 p.2)
     (hg : ContinuousAt g x₀) : ∀ᶠ x in 𝓝 x₀, r x (g x) := by
   suffices ∀ᶠ p in map (Prod.map id g) (𝓝 x₀ ×ˢ 𝓝 x₀), r p.1 p.2 from diag_of_prod this

--- a/Mathlib/Topology/Constructions.lean
+++ b/Mathlib/Topology/Constructions.lean
@@ -577,13 +577,6 @@ theorem Filter.Eventually.curry_nhds {p : X × Y → Prop} {x : X} {y : Y}
   rw [nhds_prod_eq] at h
   exact h.curry
 
-theorem Filter.Eventually.nhds_pair_image
-    {g : X → Y} {x₀ : X} {r : X → Y → Prop} (hr : ∀ᶠ p in 𝓝 (x₀, g x₀), r p.1 p.2)
-    (hg : ContinuousAt g x₀) : ∀ᶠ x in 𝓝 x₀, r x (g x) := by
-  suffices ∀ᶠ p in map (Prod.map id g) (𝓝 x₀ ×ˢ 𝓝 x₀), r p.1 p.2 from diag_of_prod this
-  apply filter_mono (prod_map_right g (𝓝 x₀) (𝓝 x₀) ▸ prod_mono_right (𝓝 x₀) hg)
-  rwa [nhds_prod_eq] at hr
-
 @[fun_prop]
 theorem ContinuousAt.prod {f : X → Y} {g : X → Z} {x : X} (hf : ContinuousAt f x)
     (hg : ContinuousAt g x) : ContinuousAt (fun x => (f x, g x)) x :=

--- a/Mathlib/Topology/Constructions.lean
+++ b/Mathlib/Topology/Constructions.lean
@@ -577,6 +577,13 @@ theorem Filter.Eventually.curry_nhds {p : X × Y → Prop} {x : X} {y : Y}
   rw [nhds_prod_eq] at h
   exact h.curry
 
+theorem Filter.Eventually.prod_nhds_image
+    {g : X → Y} {x₀ : X} {r : X → Y → Prop} (hr : ∀ᶠ p in 𝓝 (x₀, g x₀), r p.1 p.2)
+    (hg : ContinuousAt g x₀) : ∀ᶠ x in 𝓝 x₀, r x (g x) := by
+  suffices ∀ᶠ p in map (Prod.map id g) (𝓝 x₀ ×ˢ 𝓝 x₀), r p.1 p.2 from diag_of_prod this
+  apply filter_mono (prod_map_right g (𝓝 x₀) (𝓝 x₀) ▸ prod_mono_right (𝓝 x₀) hg)
+  rwa [nhds_prod_eq] at hr
+
 @[fun_prop]
 theorem ContinuousAt.prod {f : X → Y} {g : X → Z} {x : X} (hf : ContinuousAt f x)
     (hg : ContinuousAt g x) : ContinuousAt (fun x => (f x, g x)) x :=

--- a/Mathlib/Topology/Constructions.lean
+++ b/Mathlib/Topology/Constructions.lean
@@ -577,7 +577,7 @@ theorem Filter.Eventually.curry_nhds {p : X × Y → Prop} {x : X} {y : Y}
   rw [nhds_prod_eq] at h
   exact h.curry
 
-theorem Filter.Eventually.prod_nhds_image
+theorem Filter.Eventually.nhds_prod_image
     {g : X → Y} {x₀ : X} {r : X → Y → Prop} (hr : ∀ᶠ p in 𝓝 (x₀, g x₀), r p.1 p.2)
     (hg : ContinuousAt g x₀) : ∀ᶠ x in 𝓝 x₀, r x (g x) := by
   suffices ∀ᶠ p in map (Prod.map id g) (𝓝 x₀ ×ˢ 𝓝 x₀), r p.1 p.2 from diag_of_prod this


### PR DESCRIPTION
In [this](https://leanprover.zulipchat.com/#narrow/stream/116395-maths/topic/Implicit.20function.20theorem.20in.20familiar.20form) Zulip thread @Komyyy proved the "familiar" implicit function theorem. Then I wrote a proposal for a Mathlib PR. (Updated) it went:

1. `noncomputable def implicitFunOfBivariate {f : X × Y → Z} {p₀ : X × Y}
    {fx : X →L[𝕜] Z} {fy : Y ≃L[𝕜] Z} (hf₀ : HasStrictFDerivAt f (fx.coprod fy) p₀) :
    X → Y := ...`
2. `noncomputable def implicitFunOfBivariate'
    {f : X → Y → Z} {x₀ : X} {y₀ : Y}
    {fx : X → Y → X →L[𝕜] Z} (cfx : ContinuousAt ↿fx (x₀, y₀))
    (dfx : ∀ᶠ p in 𝓝 (x₀, y₀), HasFDerivAt (f · p.2) (↿fx p) p.1)
    {fy : X → Y → Y →L[𝕜] Z} (cfy : ContinuousAt ↿fy (x₀, y₀))
    (dfy : ∀ᶠ p in 𝓝 (x₀, y₀), HasFDerivAt (f p.1 ·) (↿fy p) p.2)
    (fy₀ : Y ≃L[𝕜] Z) (hfy₀ : fy x₀ y₀ = fy₀) : X → Y := ...`
3. `theorem image_eq_iff_implicitFunOfBivariate {f : X × Y → Z} {p₀ : X × Y}
    {fx : X →L[𝕜] Z} {fy : Y ≃L[𝕜] Z} (hf₀ : HasStrictFDerivAt f (fx.coprod fy) p₀) :
    ∀ᶠ p in 𝓝 p₀, f p = f p₀ ↔ hf₀.implicitFunOfBivariate p.1 = p.2 := ...`
4. `theorem implicitFunOfBivariate_hasStrictFDerivAt {f : X × Y → Z} {x₀ : X} {y₀ : Y}
    {fx : X →L[𝕜] Z} {fy : Y ≃L[𝕜] Z} (hf₀ : HasStrictFDerivAt f (fx.coprod fy) (x₀, y₀)) :
    HasStrictFDerivAt hf₀.implicitFunOfBivariate (-fy.symm ∘L fx) x₀ := ...`
5. something on the second derivative (or higher).

Although my proposal elicited no response, I am making this micro-PR to address points 1, 3 and 4 since some limited enthusiasm had been shown earlier in that thread (admittedly for another proposal made by another person). I am testing the waters; if this PR gets anywhere I may continue to work on points 2 and 5.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
