### PR TITLE
[Merged by Bors] - chore: deprecate plain `Commutative, Associative`

### DIFF
--- a/Mathlib/Algebra/BigOperators/Group/List.lean
+++ b/Mathlib/Algebra/BigOperators/Group/List.lean
@@ -633,7 +633,7 @@ end MonoidHom
 end MonoidHom
 
 @[simp] lemma Nat.sum_eq_listSum (l : List ℕ) : Nat.sum l = l.sum :=
-  (List.foldl_eq_foldr Nat.add_comm Nat.add_assoc _ _).symm
+  (List.foldl_eq_foldr _ _).symm
 
 namespace List
 

--- a/Mathlib/Data/Finset/Sups.lean
+++ b/Mathlib/Data/Finset/Sups.lean
@@ -468,17 +468,16 @@ theorem disjSups_inter_subset_left : (s₁ ∩ s₂) ○ t ⊆ s₁ ○ t ∩ s�
 theorem disjSups_inter_subset_right : s ○ (t₁ ∩ t₂) ⊆ s ○ t₁ ∩ s ○ t₂ := by
   simpa only [disjSups, product_inter, filter_inter_distrib] using image_inter_subset _ _ _
 
-variable (s t)
-
-theorem disjSups_comm : s ○ t = t ○ s := by
-  ext
-  rw [mem_disjSups, mem_disjSups]
-  -- Porting note: `exists₂_comm` no longer works with `∃ _ ∈ _, ∃ _ ∈ _, _`
-  constructor <;>
-  · rintro ⟨a, ha, b, hb, hd, hs⟩
-    rw [disjoint_comm] at hd
-    rw [sup_comm] at hs
-    exact ⟨b, hb, a, ha, hd, hs⟩
+instance instCommutativeDisjSups : @Std.Commutative (Finset α) (· ○ ·) where
+  comm _ _ := by
+    ext
+    rw [mem_disjSups, mem_disjSups]
+    -- Porting note: `exists₂_comm` no longer works with `∃ _ ∈ _, ∃ _ ∈ _, _`
+    constructor <;>
+    · rintro ⟨a, ha, b, hb, hd, hs⟩
+      rw [disjoint_comm] at hd
+      rw [sup_comm] at hs
+      exact ⟨b, hb, a, ha, hd, hs⟩
 
 end DisjSups
 
@@ -489,20 +488,21 @@ section DistribLattice
 variable [DecidableEq α]
 variable [DistribLattice α] [OrderBot α] [@DecidableRel α Disjoint] (s t u v : Finset α)
 
-theorem disjSups_assoc : ∀ s t u : Finset α, s ○ t ○ u = s ○ (t ○ u) := by
-  refine associative_of_commutative_of_le disjSups_comm ?_
+instance instAssociativeDisjSups : @Std.Associative (Finset α) (· ○ ·) := by
+  refine associative_of_commutative_of_le inferInstance ?_
   simp only [le_eq_subset, disjSups_subset_iff, mem_disjSups]
   rintro s t u _ ⟨a, ha, b, hb, hab, rfl⟩ c hc habc
   rw [disjoint_sup_left] at habc
   exact ⟨a, ha, _, ⟨b, hb, c, hc, habc.2, rfl⟩, hab.sup_right habc.1, (sup_assoc ..).symm⟩
 
 theorem disjSups_left_comm : s ○ (t ○ u) = t ○ (s ○ u) := by
-  simp_rw [← disjSups_assoc, disjSups_comm s]
+  simp_rw [← instAssociativeDisjSups.assoc, instCommutativeDisjSups.comm s]
 
-theorem disjSups_right_comm : s ○ t ○ u = s ○ u ○ t := by simp_rw [disjSups_assoc, disjSups_comm]
+theorem disjSups_right_comm : s ○ t ○ u = s ○ u ○ t := by
+  simp_rw [instAssociativeDisjSups.assoc, instCommutativeDisjSups.comm]
 
 theorem disjSups_disjSups_disjSups_comm : s ○ t ○ (u ○ v) = s ○ u ○ (t ○ v) := by
-  simp_rw [← disjSups_assoc, disjSups_right_comm]
+  simp_rw [← instAssociativeDisjSups.assoc, disjSups_right_comm]
 
 end DistribLattice
 section Diffs

--- a/Mathlib/Data/Finset/Sups.lean
+++ b/Mathlib/Data/Finset/Sups.lean
@@ -468,16 +468,19 @@ theorem disjSups_inter_subset_left : (s₁ ∩ s₂) ○ t ⊆ s₁ ○ t ∩ s�
 theorem disjSups_inter_subset_right : s ○ (t₁ ∩ t₂) ⊆ s ○ t₁ ∩ s ○ t₂ := by
   simpa only [disjSups, product_inter, filter_inter_distrib] using image_inter_subset _ _ _
 
-instance instCommutativeDisjSups : @Std.Commutative (Finset α) (· ○ ·) where
-  comm _ _ := by
-    ext
-    rw [mem_disjSups, mem_disjSups]
-    -- Porting note: `exists₂_comm` no longer works with `∃ _ ∈ _, ∃ _ ∈ _, _`
-    constructor <;>
-    · rintro ⟨a, ha, b, hb, hd, hs⟩
-      rw [disjoint_comm] at hd
-      rw [sup_comm] at hs
-      exact ⟨b, hb, a, ha, hd, hs⟩
+variable (s t)
+
+theorem disjSups_comm : s ○ t = t ○ s := by
+  ext
+  rw [mem_disjSups, mem_disjSups]
+  -- Porting note: `exists₂_comm` no longer works with `∃ _ ∈ _, ∃ _ ∈ _, _`
+  constructor <;>
+  · rintro ⟨a, ha, b, hb, hd, hs⟩
+    rw [disjoint_comm] at hd
+    rw [sup_comm] at hs
+    exact ⟨b, hb, a, ha, hd, hs⟩
+
+instance instCommutativeDisjSups : @Std.Commutative (Finset α) (· ○ ·) := ⟨disjSups_comm⟩
 
 end DisjSups
 
@@ -488,21 +491,23 @@ section DistribLattice
 variable [DecidableEq α]
 variable [DistribLattice α] [OrderBot α] [@DecidableRel α Disjoint] (s t u v : Finset α)
 
-instance instAssociativeDisjSups : @Std.Associative (Finset α) (· ○ ·) := by
-  refine associative_of_commutative_of_le inferInstance ?_
+theorem disjSups_assoc : ∀ s t u : Finset α, s ○ t ○ u = s ○ (t ○ u) := by
+  refine (associative_of_commutative_of_le (instCommutativeDisjSups (α := α)) ?_).assoc
   simp only [le_eq_subset, disjSups_subset_iff, mem_disjSups]
   rintro s t u _ ⟨a, ha, b, hb, hab, rfl⟩ c hc habc
   rw [disjoint_sup_left] at habc
   exact ⟨a, ha, _, ⟨b, hb, c, hc, habc.2, rfl⟩, hab.sup_right habc.1, (sup_assoc ..).symm⟩
 
+instance : @Std.Associative (Finset α) (· ○ ·) := ⟨disjSups_assoc⟩
+
 theorem disjSups_left_comm : s ○ (t ○ u) = t ○ (s ○ u) := by
-  simp_rw [← instAssociativeDisjSups.assoc, instCommutativeDisjSups.comm s]
+  simp_rw [← disjSups_assoc, disjSups_comm s]
 
 theorem disjSups_right_comm : s ○ t ○ u = s ○ u ○ t := by
-  simp_rw [instAssociativeDisjSups.assoc, instCommutativeDisjSups.comm]
+  simp_rw [disjSups_assoc, disjSups_comm]
 
 theorem disjSups_disjSups_disjSups_comm : s ○ t ○ (u ○ v) = s ○ u ○ (t ○ v) := by
-  simp_rw [← instAssociativeDisjSups.assoc, disjSups_right_comm]
+  simp_rw [← disjSups_assoc, disjSups_right_comm]
 
 end DistribLattice
 section Diffs

--- a/Mathlib/Data/Finset/Sups.lean
+++ b/Mathlib/Data/Finset/Sups.lean
@@ -503,8 +503,7 @@ instance : @Std.Associative (Finset α) (· ○ ·) := ⟨disjSups_assoc⟩
 theorem disjSups_left_comm : s ○ (t ○ u) = t ○ (s ○ u) := by
   simp_rw [← disjSups_assoc, disjSups_comm s]
 
-theorem disjSups_right_comm : s ○ t ○ u = s ○ u ○ t := by
-  simp_rw [disjSups_assoc, disjSups_comm]
+theorem disjSups_right_comm : s ○ t ○ u = s ○ u ○ t := by simp_rw [disjSups_assoc, disjSups_comm]
 
 theorem disjSups_disjSups_disjSups_comm : s ○ t ○ (u ○ v) = s ○ u ○ (t ○ v) := by
   simp_rw [← disjSups_assoc, disjSups_right_comm]

--- a/Mathlib/Data/Finset/Sups.lean
+++ b/Mathlib/Data/Finset/Sups.lean
@@ -480,7 +480,7 @@ theorem disjSups_comm : s ○ t = t ○ s := by
     rw [sup_comm] at hs
     exact ⟨b, hb, a, ha, hd, hs⟩
 
-instance instCommutativeDisjSups : @Std.Commutative (Finset α) (· ○ ·) := ⟨disjSups_comm⟩
+instance : @Std.Commutative (Finset α) (· ○ ·) := ⟨disjSups_comm⟩
 
 end DisjSups
 
@@ -492,7 +492,7 @@ variable [DecidableEq α]
 variable [DistribLattice α] [OrderBot α] [@DecidableRel α Disjoint] (s t u v : Finset α)
 
 theorem disjSups_assoc : ∀ s t u : Finset α, s ○ t ○ u = s ○ (t ○ u) := by
-  refine (associative_of_commutative_of_le (instCommutativeDisjSups (α := α)) ?_).assoc
+  refine (associative_of_commutative_of_le inferInstance ?_).assoc
   simp only [le_eq_subset, disjSups_subset_iff, mem_disjSups]
   rintro s t u _ ⟨a, ha, b, hb, hab, rfl⟩ c hc habc
   rw [disjoint_sup_left] at habc

--- a/Mathlib/Data/List/Basic.lean
+++ b/Mathlib/Data/List/Basic.lean
@@ -1288,25 +1288,26 @@ section FoldlEqFoldr
 -- foldl and foldr coincide when f is commutative and associative
 variable {f : α → α → α}
 
-theorem foldl1_eq_foldr1 (hassoc : Associative f) :
+theorem foldl1_eq_foldr1 [hassoc : Std.Associative f] :
     ∀ a b l, foldl f a (l ++ [b]) = foldr f b (a :: l)
   | a, b, nil => rfl
   | a, b, c :: l => by
-    simp only [cons_append, foldl_cons, foldr_cons, foldl1_eq_foldr1 hassoc _ _ l]; rw [hassoc]
+    simp only [cons_append, foldl_cons, foldr_cons, foldl1_eq_foldr1 _ _ l]
+    rw [hassoc.assoc]
 
-theorem foldl_eq_of_comm_of_assoc (hcomm : Commutative f) (hassoc : Associative f) :
+theorem foldl_eq_of_comm_of_assoc [hcomm : Std.Commutative f] [hassoc : Std.Associative f] :
     ∀ a b l, foldl f a (b :: l) = f b (foldl f a l)
-  | a, b, nil => hcomm a b
+  | a, b, nil => hcomm.comm a b
   | a, b, c :: l => by
     simp only [foldl_cons]
-    rw [← foldl_eq_of_comm_of_assoc hcomm hassoc .., right_comm _ hcomm hassoc]; rfl
+    rw [← foldl_eq_of_comm_of_assoc .., right_comm _ hcomm.comm hassoc.assoc]; rfl
 
-theorem foldl_eq_foldr (hcomm : Commutative f) (hassoc : Associative f) :
+theorem foldl_eq_foldr [Std.Commutative f] [Std.Associative f] :
     ∀ a l, foldl f a l = foldr f a l
   | a, nil => rfl
   | a, b :: l => by
-    simp only [foldr_cons, foldl_eq_of_comm_of_assoc hcomm hassoc]
-    rw [foldl_eq_foldr hcomm hassoc a l]
+    simp only [foldr_cons, foldl_eq_of_comm_of_assoc]
+    rw [foldl_eq_foldr a l]
 
 end FoldlEqFoldr
 

--- a/Mathlib/GroupTheory/CommutingProbability.lean
+++ b/Mathlib/GroupTheory/CommutingProbability.lean
@@ -75,12 +75,12 @@ theorem commProb_le_one : commProb M ≤ 1 := by
 variable {M}
 
 theorem commProb_eq_one_iff [h : Nonempty M] :
-    commProb M = 1 ↔ Commutative ((· * ·) : M → M → M) := by
+    commProb M = 1 ↔ Std.Commutative ((· * ·) : M → M → M) := by
   haveI := Fintype.ofFinite M
   rw [commProb, ← Set.coe_setOf, Nat.card_eq_fintype_card, Nat.card_eq_fintype_card]
   rw [div_eq_one_iff_eq, ← Nat.cast_pow, Nat.cast_inj, sq, ← card_prod,
     set_fintype_card_eq_univ_iff, Set.eq_univ_iff_forall]
-  · exact ⟨fun h x y ↦ h (x, y), fun h x ↦ h x.1 x.2⟩
+  · exact ⟨fun h ↦ ⟨fun x y ↦ h (x, y)⟩, fun h x ↦ h.comm x.1 x.2⟩
   · exact pow_ne_zero 2 (Nat.cast_ne_zero.mpr card_ne_zero)
 
 variable (G : Type*) [Group G]
@@ -119,7 +119,7 @@ variable (G)
 
 theorem inv_card_commutator_le_commProb : (↑(Nat.card (commutator G)))⁻¹ ≤ commProb G :=
   (inv_pos_le_iff_one_le_mul (Nat.cast_pos.mpr Finite.card_pos)).mpr
-    (le_trans (ge_of_eq (commProb_eq_one_iff.mpr (Abelianization.commGroup G).mul_comm))
+    (le_trans (ge_of_eq (commProb_eq_one_iff.mpr ⟨(Abelianization.commGroup G).mul_comm⟩))
       (commutator G).commProb_quotient_le)
 
 -- Construction of group with commuting probability 1/n

--- a/Mathlib/Init/Logic.lean
+++ b/Mathlib/Init/Logic.lean
@@ -21,15 +21,112 @@ set_option linter.deprecated false
 universe u v
 variable {α : Sort u}
 
-/- Eq, Ne, HEq -/
+/- Eq, Ne, HEq, Iff -/
 
-attribute [symm] Eq.symm
-attribute [symm] Ne.symm
--- FIXME This is still rejected after #857
--- attribute [refl] HEq.refl
-attribute [symm] HEq.symm
+-- attribute [refl] HEq.refl -- FIXME This is still rejected after #857
 attribute [trans] HEq.trans
 attribute [trans] heq_of_eq_of_heq
+attribute [refl] Iff.refl
+attribute [trans] Iff.trans
+
+section Relation
+
+variable {α : Sort u} {β : Sort v} (r : β → β → Prop)
+
+/-- Local notation for an arbitrary binary relation `r`. -/
+local infix:50 " ≺ " => r
+
+/-- A reflexive relation relates every element to itself. -/
+def Reflexive := ∀ x, x ≺ x
+
+/-- A relation is symmetric if `x ≺ y` implies `y ≺ x`. -/
+def Symmetric := ∀ ⦃x y⦄, x ≺ y → y ≺ x
+
+/-- A relation is transitive if `x ≺ y` and `y ≺ z` together imply `x ≺ z`. -/
+def Transitive := ∀ ⦃x y z⦄, x ≺ y → y ≺ z → x ≺ z
+
+lemma Equivalence.reflexive {r : β → β → Prop} (h : Equivalence r) : Reflexive r := h.refl
+
+lemma Equivalence.symmetric {r : β → β → Prop} (h : Equivalence r) : Symmetric r := fun _ _ ↦ h.symm
+
+lemma Equivalence.transitive {r : β → β → Prop} (h : Equivalence r) : Transitive r :=
+  fun _ _ _ ↦ h.trans
+
+/-- A relation is total if for all `x` and `y`, either `x ≺ y` or `y ≺ x`. -/
+def Total := ∀ x y, x ≺ y ∨ y ≺ x
+
+/-- Irreflexive means "not reflexive". -/
+def Irreflexive := ∀ x, ¬ x ≺ x
+
+/-- A relation is antisymmetric if `x ≺ y` and `y ≺ x` together imply that `x = y`. -/
+def AntiSymmetric := ∀ ⦃x y⦄, x ≺ y → y ≺ x → x = y
+
+/-- An empty relation does not relate any elements. -/
+@[nolint unusedArguments]
+def EmptyRelation := fun _ _ : α ↦ False
+
+theorem InvImage.trans (f : α → β) (h : Transitive r) : Transitive (InvImage r f) :=
+  fun (a₁ a₂ a₃ : α) (h₁ : InvImage r f a₁ a₂) (h₂ : InvImage r f a₂ a₃) ↦ h h₁ h₂
+
+theorem InvImage.irreflexive (f : α → β) (h : Irreflexive r) : Irreflexive (InvImage r f) :=
+  fun (a : α) (h₁ : InvImage r f a a) ↦ h (f a) h₁
+
+end Relation
+
+section Binary
+
+variable {α : Type u} {β : Type v} (f : α → α → α) (inv : α → α) (one : α)
+
+/-- Local notation for `f`, high priority to avoid ambiguity with `HMul.hMul`. -/
+local infix:70 (priority := high) " * " => f
+
+/-- Local notation for `inv`, high priority to avoid ambiguity with `Inv.inv`. -/
+local postfix:100 (priority := high) "⁻¹" => inv
+
+variable (g : α → α → α)
+
+/-- Local notation for `g`, high priority to avoid ambiguity with `HAdd.hAdd`. -/
+local infix:65 (priority := high) " + " => g
+
+@[deprecated Std.Commutative (since := "2024-09-13")]
+def Commutative       := ∀ a b, a * b = b * a
+@[deprecated Std.Associative (since := "2024-09-13")]
+def Associative       := ∀ a b c, (a * b) * c = a * (b * c)
+@[deprecated (since := "2024-09-03")] -- unused in Mathlib
+def LeftIdentity      := ∀ a, one * a = a
+@[deprecated (since := "2024-09-03")] -- unused in Mathlib
+def RightIdentity     := ∀ a, a * one = a
+@[deprecated (since := "2024-09-03")] -- unused in Mathlib
+def RightInverse      := ∀ a, a * a⁻¹ = one
+@[deprecated (since := "2024-09-03")] -- unused in Mathlib
+def LeftCancelative   := ∀ a b c, a * b = a * c → b = c
+@[deprecated (since := "2024-09-03")] -- unused in Mathlib
+def RightCancelative  := ∀ a b c, a * b = c * b → a = c
+@[deprecated (since := "2024-09-03")] -- unused in Mathlib
+def LeftDistributive  := ∀ a b c, a * (b + c) = a * b + a * c
+@[deprecated (since := "2024-09-03")] -- unused in Mathlib
+def RightDistributive := ∀ a b c, (a + b) * c = a * c + b * c
+
+def RightCommutative (h : β → α → β) := ∀ b a₁ a₂, h (h b a₁) a₂ = h (h b a₂) a₁
+def LeftCommutative (h : α → β → β) := ∀ a₁ a₂ b, h a₁ (h a₂ b) = h a₂ (h a₁ b)
+
+theorem left_comm : Commutative f → Associative f → LeftCommutative f :=
+  fun hcomm hassoc a b c ↦
+    calc  a*(b*c)
+      _ = (a*b)*c := Eq.symm (hassoc a b c)
+      _ = (b*a)*c := hcomm a b ▸ rfl
+      _ = b*(a*c) := hassoc b a c
+
+theorem right_comm : Commutative f → Associative f → RightCommutative f :=
+  fun hcomm hassoc a b c ↦
+    calc (a*b)*c
+      _ = a*(b*c) := hassoc a b c
+      _ = a*(c*b) := hcomm b c ▸ rfl
+      _ = (a*c)*b := Eq.symm (hassoc a c b)
+
+end Binary
+
+-- Everything below this line is deprecated
 
 @[deprecated (since := "2024-09-03")] alias not_of_eq_false := of_eq_false
 @[deprecated (since := "2024-09-03")] -- unused in Mathlib
@@ -56,18 +153,10 @@ theorem eq_rec_compose {α β φ : Sort u} :
       (Eq.recOn p₁ (Eq.recOn p₂ a : β) : φ) = Eq.recOn (Eq.trans p₂ p₁) a
   | rfl, rfl, _ => rfl
 
-variable {a b : Prop}
-
-/- iff -/
-
-attribute [refl] Iff.refl
-attribute [trans] Iff.trans
-attribute [symm] Iff.symm
-
 -- unused in Mathlib
 @[deprecated (since := "2024-09-11")] alias ⟨not_of_not_not_not, _⟩ := not_not_not
 
-variable (p)
+variable {a : Prop} (p : Prop)
 
 @[deprecated and_true (since := "2024-09-12")]
 theorem and_true_iff : p ∧ True ↔ p := iff_of_eq (and_true _)
@@ -254,98 +343,3 @@ theorem let_body_eq {α : Sort v} {β : α → Sort u} (a : α) {b₁ b₂ : ∀
 theorem let_eq {α : Sort v} {β : Sort u} {a₁ a₂ : α} {b₁ b₂ : α → β}
     (h₁ : a₁ = a₂) (h₂ : ∀ x, b₁ x = b₂ x) :
     (let x : α := a₁; b₁ x) = (let x : α := a₂; b₂ x) := by simp [h₁, h₂]
-
-section Relation
-
-variable {α : Sort u} {β : Sort v} (r : β → β → Prop)
-
-/-- Local notation for an arbitrary binary relation `r`. -/
-local infix:50 " ≺ " => r
-
-/-- A reflexive relation relates every element to itself. -/
-def Reflexive := ∀ x, x ≺ x
-
-/-- A relation is symmetric if `x ≺ y` implies `y ≺ x`. -/
-def Symmetric := ∀ ⦃x y⦄, x ≺ y → y ≺ x
-
-/-- A relation is transitive if `x ≺ y` and `y ≺ z` together imply `x ≺ z`. -/
-def Transitive := ∀ ⦃x y z⦄, x ≺ y → y ≺ z → x ≺ z
-
-lemma Equivalence.reflexive {r : β → β → Prop} (h : Equivalence r) : Reflexive r := h.refl
-
-lemma Equivalence.symmetric {r : β → β → Prop} (h : Equivalence r) : Symmetric r := fun _ _ ↦ h.symm
-
-lemma Equivalence.transitive {r : β → β → Prop} (h : Equivalence r) : Transitive r :=
-  fun _ _ _ ↦ h.trans
-
-/-- A relation is total if for all `x` and `y`, either `x ≺ y` or `y ≺ x`. -/
-def Total := ∀ x y, x ≺ y ∨ y ≺ x
-
-/-- Irreflexive means "not reflexive". -/
-def Irreflexive := ∀ x, ¬ x ≺ x
-
-/-- A relation is antisymmetric if `x ≺ y` and `y ≺ x` together imply that `x = y`. -/
-def AntiSymmetric := ∀ ⦃x y⦄, x ≺ y → y ≺ x → x = y
-
-/-- An empty relation does not relate any elements. -/
-@[nolint unusedArguments]
-def EmptyRelation := fun _ _ : α ↦ False
-
-theorem InvImage.trans (f : α → β) (h : Transitive r) : Transitive (InvImage r f) :=
-  fun (a₁ a₂ a₃ : α) (h₁ : InvImage r f a₁ a₂) (h₂ : InvImage r f a₂ a₃) ↦ h h₁ h₂
-
-theorem InvImage.irreflexive (f : α → β) (h : Irreflexive r) : Irreflexive (InvImage r f) :=
-  fun (a : α) (h₁ : InvImage r f a a) ↦ h (f a) h₁
-
-end Relation
-
-section Binary
-
-variable {α : Type u} {β : Type v} (f : α → α → α) (inv : α → α) (one : α)
-
-/-- Local notation for `f`, high priority to avoid ambiguity with `HMul.hMul`. -/
-local infix:70 (priority := high) " * " => f
-
-/-- Local notation for `inv`, high priority to avoid ambiguity with `Inv.inv`. -/
-local postfix:100 (priority := high) "⁻¹" => inv
-
-variable (g : α → α → α)
-
-/-- Local notation for `g`, high priority to avoid ambiguity with `HAdd.hAdd`. -/
-local infix:65 (priority := high) " + " => g
-
-@[deprecated (since := "2024-09-03")] -- unused in Mathlib
-def LeftIdentity      := ∀ a, one * a = a
-@[deprecated (since := "2024-09-03")] -- unused in Mathlib
-def RightIdentity     := ∀ a, a * one = a
-@[deprecated (since := "2024-09-03")] -- unused in Mathlib
-def RightInverse      := ∀ a, a * a⁻¹ = one
-@[deprecated (since := "2024-09-03")] -- unused in Mathlib
-def LeftCancelative   := ∀ a b c, a * b = a * c → b = c
-@[deprecated (since := "2024-09-03")] -- unused in Mathlib
-def RightCancelative  := ∀ a b c, a * b = c * b → a = c
-@[deprecated (since := "2024-09-03")] -- unused in Mathlib
-def LeftDistributive  := ∀ a b c, a * (b + c) = a * b + a * c
-@[deprecated (since := "2024-09-03")] -- unused in Mathlib
-def RightDistributive := ∀ a b c, (a + b) * c = a * c + b * c
-
-def Commutative       := ∀ a b, a * b = b * a
-def Associative       := ∀ a b c, (a * b) * c = a * (b * c)
-def RightCommutative (h : β → α → β) := ∀ b a₁ a₂, h (h b a₁) a₂ = h (h b a₂) a₁
-def LeftCommutative (h : α → β → β) := ∀ a₁ a₂ b, h a₁ (h a₂ b) = h a₂ (h a₁ b)
-
-theorem left_comm : Commutative f → Associative f → LeftCommutative f :=
-  fun hcomm hassoc a b c ↦
-    calc  a*(b*c)
-      _ = (a*b)*c := Eq.symm (hassoc a b c)
-      _ = (b*a)*c := hcomm a b ▸ rfl
-      _ = b*(a*c) := hassoc b a c
-
-theorem right_comm : Commutative f → Associative f → RightCommutative f :=
-  fun hcomm hassoc a b c ↦
-    calc (a*b)*c
-      _ = a*(b*c) := hassoc a b c
-      _ = a*(c*b) := hcomm b c ▸ rfl
-      _ = (a*c)*b := Eq.symm (hassoc a c b)
-
-end Binary

--- a/Mathlib/Order/Basic.lean
+++ b/Mathlib/Order/Basic.lean
@@ -463,11 +463,12 @@ theorem commutative_of_le {f : β → β → α} (comm : ∀ a b, f a b ≤ f b 
 
 /-- To prove associativity of a commutative binary operation `○`, we only to check
 `(a ○ b) ○ c ≤ a ○ (b ○ c)` for all `a`, `b`, `c`. -/
-theorem associative_of_commutative_of_le {f : α → α → α} (comm : Commutative f)
-    (assoc : ∀ a b c, f (f a b) c ≤ f a (f b c)) : Associative f := fun a b c ↦
-  le_antisymm (assoc _ _ _) <| by
-    rw [comm, comm b, comm _ c, comm a]
-    exact assoc _ _ _
+theorem associative_of_commutative_of_le {f : α → α → α} (comm : Std.Commutative f)
+    (assoc : ∀ a b c, f (f a b) c ≤ f a (f b c)) : Std.Associative f where
+  assoc a b c :=
+    le_antisymm (assoc _ _ _) <| by
+      rw [comm.comm, comm.comm b, comm.comm _ c, comm.comm a]
+      exact assoc _ _ _
 
 end PartialOrder
 

--- a/Mathlib/Order/MinMax.lean
+++ b/Mathlib/Order/MinMax.lean
@@ -234,34 +234,26 @@ theorem le_of_max_le_left {a b c : α} (h : max a b ≤ c) : a ≤ c :=
 theorem le_of_max_le_right {a b c : α} (h : max a b ≤ c) : b ≤ c :=
   le_trans (le_max_right _ _) h
 
-theorem max_commutative : Commutative (max : α → α → α) :=
-  max_comm
+instance instCommutativeMax : Std.Commutative (α := α) max where comm := max_comm
+instance instAssociativeMax : Std.Associative (α := α) max where assoc := max_assoc
+instance instCommutativeMin : Std.Commutative (α := α) min where comm := min_comm
+instance instAssociativeMin : Std.Associative (α := α) min where assoc := min_assoc
 
-theorem max_associative : Associative (max : α → α → α) :=
-  max_assoc
+theorem max_left_commutative : LeftCommutative (max : α → α → α) := max_left_comm
+theorem min_left_commutative : LeftCommutative (min : α → α → α) := min_left_comm
 
-instance : Std.Commutative (α := α) max where
-  comm := max_comm
+section deprecated
+set_option linter.deprecated false
 
-instance : Std.Associative (α := α) max where
-  assoc := max_assoc
+@[deprecated instCommutativeMax (since := "2024-09-12")]
+theorem max_commutative : Commutative (α := α) max := max_comm
+@[deprecated instAssociativeMax (since := "2024-09-12")]
+theorem max_associative : Associative (α := α) max := max_assoc
+@[deprecated instCommutativeMin (since := "2024-09-12")]
+theorem min_commutative : Commutative (α := α) min := min_comm
+@[deprecated instAssociativeMin (since := "2024-09-12")]
+theorem min_associative : Associative (α := α) min := min_assoc
 
-theorem max_left_commutative : LeftCommutative (max : α → α → α) :=
-  max_left_comm
-
-theorem min_commutative : Commutative (min : α → α → α) :=
-  min_comm
-
-theorem min_associative : Associative (α := α) min :=
-  min_assoc
-
-instance : Std.Commutative (α := α) min where
-  comm := min_comm
-
-instance : Std.Associative (α := α) min where
-  assoc := min_assoc
-
-theorem min_left_commutative : LeftCommutative (min : α → α → α) :=
-  min_left_comm
+end deprecated
 
 end

--- a/Mathlib/Order/RelIso/Basic.lean
+++ b/Mathlib/Order/RelIso/Basic.lean
@@ -3,7 +3,6 @@ Copyright (c) 2017 Mario Carneiro. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Mario Carneiro
 -/
-import Mathlib.Init.Algebra.Classes
 import Mathlib.Data.FunLike.Basic
 import Mathlib.Logic.Embedding.Basic
 import Mathlib.Order.RelClasses

--- a/Mathlib/Order/WithBot.lean
+++ b/Mathlib/Order/WithBot.lean
@@ -3,7 +3,6 @@ Copyright (c) 2017 Johannes Hölzl. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johannes Hölzl
 -/
-import Mathlib.Init.Algebra.Classes
 import Mathlib.Logic.Nontrivial.Basic
 import Mathlib.Order.BoundedOrder
 import Mathlib.Order.TypeTags


### PR DESCRIPTION
…in favour of `Std.Commutative` and `Std.Associative`. Also reorder `Init.Logic` so that non-deprecated code is at the top, and remove redundant `[symm]` attributes.