### PR TITLE
[Merged by Bors] - refactor(Archive/Arithcc): avoid defEq abuse

### DIFF
--- a/Archive/Arithcc.lean
+++ b/Archive/Arithcc.lean
@@ -279,10 +279,8 @@ theorem compiler_correctness
   | const => simp [StateEq, step]; rfl
   -- 5.II
   | var =>
-    simp [hmap, StateEq, step] -- Porting note: was `finish [hmap, StateEq, step]`
-    constructor
-    · simp_all only [read, loc]
-    · rfl
+    -- Porting note: was `finish [hmap, StateEq, step]`
+    simp_all [StateEq, StateEqRs, step]
   -- 5.III
   | sum =>
     rename_i e_s₁ e_s₂ e_ih_s₁ e_ih_s₂

--- a/Archive/Arithcc.lean
+++ b/Archive/Arithcc.lean
@@ -279,7 +279,6 @@ theorem compiler_correctness
   | const => simp [StateEq, step]; rfl
   -- 5.II
   | var =>
-    -- Porting note: was `finish [hmap, StateEq, step]`
     simp_all [StateEq, StateEqRs, step]
   -- 5.III
   | sum =>


### PR DESCRIPTION
the `rfl` was a bit of a defeq abuse: The goal was `StateEqRs a b` for
definitely different terms `a` and `b`, but it was still using
`StateEqRs.refl a`, because then after unfolding `StateEqRs` and doing a
bit of computation the proof held. This would break once
https://github.com/leanprover/lean4/pull/3714
lands, and is a bit fishy in any case so let's just let `simp` handle
it.
