### PR TITLE
[Merged by Bors] - chore: tidy/move/deprecate `Init.Logic` and `IsSymmOp` more

### DIFF
--- a/Mathlib/Algebra/Order/GroupWithZero/Unbundled.lean
+++ b/Mathlib/Algebra/Order/GroupWithZero/Unbundled.lean
@@ -1209,19 +1209,19 @@ end GroupWithZero.LinearOrder
 
 section CommSemigroupHasZero
 
-variable [Mul α] [IsSymmOp α α (· * ·)] [Zero α] [Preorder α]
+variable [Mul α] [@Std.Commutative α (· * ·)] [Zero α] [Preorder α]
 
 theorem posMulStrictMono_iff_mulPosStrictMono : PosMulStrictMono α ↔ MulPosStrictMono α := by
-  simp only [PosMulStrictMono, MulPosStrictMono, IsSymmOp.symm_op]
+  simp only [PosMulStrictMono, MulPosStrictMono, Std.Commutative.comm]
 
 theorem posMulReflectLT_iff_mulPosReflectLT : PosMulReflectLT α ↔ MulPosReflectLT α := by
-  simp only [PosMulReflectLT, MulPosReflectLT, IsSymmOp.symm_op]
+  simp only [PosMulReflectLT, MulPosReflectLT, Std.Commutative.comm]
 
 theorem posMulMono_iff_mulPosMono : PosMulMono α ↔ MulPosMono α := by
-  simp only [PosMulMono, MulPosMono, IsSymmOp.symm_op]
+  simp only [PosMulMono, MulPosMono, Std.Commutative.comm]
 
 theorem posMulReflectLE_iff_mulPosReflectLE : PosMulReflectLE α ↔ MulPosReflectLE α := by
-  simp only [PosMulReflectLE, MulPosReflectLE, IsSymmOp.symm_op]
+  simp only [PosMulReflectLE, MulPosReflectLE, Std.Commutative.comm]
 
 end CommSemigroupHasZero
 

--- a/Mathlib/Algebra/Order/Monoid/Unbundled/Basic.lean
+++ b/Mathlib/Algebra/Order/Monoid/Unbundled/Basic.lean
@@ -1306,12 +1306,12 @@ protected theorem inj [Mul α] [PartialOrder α] {a b c : α} (ha : MulLECancell
   ha.Injective.eq_iff
 
 @[to_additive]
-protected theorem injective_left [Mul α] [i : IsSymmOp α α (· * ·)] [PartialOrder α] {a : α}
+protected theorem injective_left [Mul α] [i : @Std.Commutative α (· * ·)] [PartialOrder α] {a : α}
     (ha : MulLECancellable a) :
-    Injective (· * a) := fun b c h => ha.Injective <| by dsimp; rwa [i.symm_op a, i.symm_op a]
+    Injective (· * a) := fun b c h => ha.Injective <| by dsimp; rwa [i.comm a, i.comm a]
 
 @[to_additive]
-protected theorem inj_left [Mul α] [IsSymmOp α α (· * ·)] [PartialOrder α] {a b c : α}
+protected theorem inj_left [Mul α] [@Std.Commutative α (· * ·)] [PartialOrder α] {a b c : α}
     (hc : MulLECancellable c) :
     a * c = b * c ↔ a = b :=
   hc.injective_left.eq_iff
@@ -1324,9 +1324,9 @@ protected theorem mul_le_mul_iff_left [Mul α] [CovariantClass α α (· * ·) (
   ⟨fun h => ha h, fun h => mul_le_mul_left' h a⟩
 
 @[to_additive]
-protected theorem mul_le_mul_iff_right [Mul α] [i : IsSymmOp α α (· * ·)]
+protected theorem mul_le_mul_iff_right [Mul α] [i : @Std.Commutative α (· * ·)]
     [CovariantClass α α (· * ·) (· ≤ ·)] {a b c : α} (ha : MulLECancellable a) :
-    b * a ≤ c * a ↔ b ≤ c := by rw [i.symm_op b, i.symm_op c, ha.mul_le_mul_iff_left]
+    b * a ≤ c * a ↔ b ≤ c := by rw [i.comm b, i.comm c, ha.mul_le_mul_iff_left]
 
 @[to_additive]
 protected theorem le_mul_iff_one_le_right [MulOneClass α] [CovariantClass α α (· * ·) (· ≤ ·)]
@@ -1341,13 +1341,13 @@ protected theorem mul_le_iff_le_one_right [MulOneClass α] [CovariantClass α α
   Iff.trans (by rw [mul_one]) ha.mul_le_mul_iff_left
 
 @[to_additive]
-protected theorem le_mul_iff_one_le_left [MulOneClass α] [i : IsSymmOp α α (· * ·)]
+protected theorem le_mul_iff_one_le_left [MulOneClass α] [i : @Std.Commutative α (· * ·)]
     [CovariantClass α α (· * ·) (· ≤ ·)] {a b : α} (ha : MulLECancellable a) :
-    a ≤ b * a ↔ 1 ≤ b := by rw [i.symm_op, ha.le_mul_iff_one_le_right]
+    a ≤ b * a ↔ 1 ≤ b := by rw [i.comm, ha.le_mul_iff_one_le_right]
 
 @[to_additive]
-protected theorem mul_le_iff_le_one_left [MulOneClass α] [i : IsSymmOp α α (· * ·)]
+protected theorem mul_le_iff_le_one_left [MulOneClass α] [i : @Std.Commutative α (· * ·)]
     [CovariantClass α α (· * ·) (· ≤ ·)] {a b : α} (ha : MulLECancellable a) :
-    b * a ≤ a ↔ b ≤ 1 := by rw [i.symm_op, ha.mul_le_iff_le_one_right]
+    b * a ≤ a ↔ b ≤ 1 := by rw [i.comm, ha.mul_le_iff_le_one_right]
 
 end MulLECancellable

--- a/Mathlib/Algebra/Order/Monoid/Unbundled/Defs.lean
+++ b/Mathlib/Algebra/Order/Monoid/Unbundled/Defs.lean
@@ -450,11 +450,11 @@ theorem covariant_lt_iff_contravariant_le [LinearOrder N] :
 
 variable (mu : N → N → N)
 
-theorem covariant_flip_iff [IsSymmOp N N mu] :
-    Covariant N N (flip mu) r ↔ Covariant N N mu r := by rw [IsSymmOp.flip_eq]
+theorem covariant_flip_iff [h : Std.Commutative mu] :
+    Covariant N N (flip mu) r ↔ Covariant N N mu r := by unfold flip; simp_rw [h.comm]
 
-theorem contravariant_flip_iff [IsSymmOp N N mu] :
-    Contravariant N N (flip mu) r ↔ Contravariant N N mu r := by rw [IsSymmOp.flip_eq]
+theorem contravariant_flip_iff [h : Std.Commutative mu] :
+    Contravariant N N (flip mu) r ↔ Contravariant N N mu r := by unfold flip; simp_rw [h.comm]
 
 instance contravariant_lt_of_covariant_le [LinearOrder N]
     [CovariantClass N N mu (· ≤ ·)] : ContravariantClass N N mu (· < ·) where

--- a/Mathlib/Algebra/Order/Sub/Defs.lean
+++ b/Mathlib/Algebra/Order/Sub/Defs.lean
@@ -83,7 +83,7 @@ variable [Preorder α]
 section AddCommSemigroup
 
 variable [AddCommSemigroup α] [Sub α] [OrderedSub α] {a b c d : α}
-/- TODO: Most results can be generalized to [Add α] [IsSymmOp α α (· + ·)] -/
+/- TODO: Most results can be generalized to [Add α] [@Std.Commutative α (· + ·)] -/
 
 theorem tsub_le_iff_left : a - b ≤ c ↔ a ≤ b + c := by rw [tsub_le_iff_right, add_comm]
 

--- a/Mathlib/Data/List/Zip.lean
+++ b/Mathlib/Data/List/Zip.lean
@@ -92,7 +92,7 @@ theorem zipWith3_same_right (f : α → β → β → γ) :
   | _ :: _, [] => rfl
   | _ :: as, _ :: bs => congr_arg (cons _) <| zipWith3_same_right f as bs
 
-instance (f : α → α → β) [IsSymmOp α β f] : IsSymmOp (List α) (List β) (zipWith f) :=
+instance (f : α → α → β) [IsSymmOp f] : IsSymmOp (zipWith f) :=
   ⟨zipWith_comm_of_comm f IsSymmOp.symm_op⟩
 
 @[simp]

--- a/Mathlib/Data/List/Zip.lean
+++ b/Mathlib/Data/List/Zip.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Mario Carneiro, Kenny Lau
 -/
 import Mathlib.Data.List.Forall2
+import Mathlib.Init.Algebra.Classes
 
 /-!
 # zip & unzip

--- a/Mathlib/Init/Algebra/Classes.lean
+++ b/Mathlib/Init/Algebra/Classes.lean
@@ -30,10 +30,10 @@ universe u v
 variable {α : Sort u} {β : Sort v}
 
 /-- `IsSymmOp op` where `op : α → α → β` says that `op` is a symmetric operation,
-i.e. `a ∘ b = b ∘ a`.
-It is the natural generalisation of `Std.IsCommutative` (`β = α`) and `IsSymm` (`β = Prop`). -/
+i.e. `op a b = op b a`.
+It is the natural generalisation of `Std.Commutative` (`β = α`) and `IsSymm` (`β = Prop`). -/
 class IsSymmOp (op : α → α → β) : Prop where
-  /-- A symmetric operation satisfies `a ∘ b = b ∘ a`. -/
+  /-- A symmetric operation satisfies `op a b = op b a`. -/
   symm_op : ∀ a b, op a b = op b a
 
 instance (priority := 100) isSymmOp_of_isCommutative (α : Sort u) (op : α → α → α)

--- a/Mathlib/Init/Algebra/Classes.lean
+++ b/Mathlib/Init/Algebra/Classes.lean
@@ -27,16 +27,23 @@ set_option linter.deprecated false
 
 universe u v
 
-/-- `IsSymmOp α β op` where `op : α → α → β` is the natural generalisation of
-`Std.IsCommutative` (`β = α`) and `IsSymm` (`β = Prop`). -/
-class IsSymmOp (α : Sort u) (β : Sort v) (op : α → α → β) : Prop where
+variable {α : Sort u} {β : Sort v}
+
+/-- `IsSymmOp op` where `op : α → α → β` says that `op` is a symmetric operation,
+i.e. `a ∘ b = b ∘ a`.
+It is the natural generalisation of `Std.IsCommutative` (`β = α`) and `IsSymm` (`β = Prop`). -/
+class IsSymmOp (op : α → α → β) : Prop where
+  /-- A symmetric operation satisfies `a ∘ b = b ∘ a`. -/
   symm_op : ∀ a b, op a b = op b a
 
 instance (priority := 100) isSymmOp_of_isCommutative (α : Sort u) (op : α → α → α)
-    [Std.Commutative op] : IsSymmOp α α op where symm_op := Std.Commutative.comm
+    [Std.Commutative op] : IsSymmOp op where symm_op := Std.Commutative.comm
 
 instance (priority := 100) isSymmOp_of_isSymm (α : Sort u) (op : α → α → Prop) [IsSymm α op] :
-    IsSymmOp α Prop op where symm_op a b := propext <| Iff.intro (IsSymm.symm a b) (IsSymm.symm b a)
+    IsSymmOp op where symm_op a b := propext <| Iff.intro (IsSymm.symm a b) (IsSymm.symm b a)
+
+theorem IsSymmOp.flip_eq (op : α → α → β) [IsSymmOp op] : flip op = op :=
+  funext fun a ↦ funext fun b ↦ (IsSymmOp.symm_op a b).symm
 
 @[deprecated (since := "2024-09-11")]
 class IsLeftCancel (α : Sort u) (op : α → α → α) : Prop where

--- a/Mathlib/Init/Logic.lean
+++ b/Mathlib/Init/Logic.lean
@@ -51,11 +51,14 @@ def Irreflexive := ∀ x, ¬ x ≺ x
 /-- A relation is antisymmetric if `x ≺ y` and `y ≺ x` together imply that `x = y`. -/
 def AntiSymmetric := ∀ ⦃x y⦄, x ≺ y → y ≺ x → x = y
 
+@[deprecated Equivalence.refl (since := "2024-09-13")]
 theorem Equivalence.reflexive {r : β → β → Prop} (h : Equivalence r) : Reflexive r := h.refl
 
+@[deprecated Equivalence.symm (since := "2024-09-13")]
 theorem Equivalence.symmetric {r : β → β → Prop} (h : Equivalence r) : Symmetric r :=
   fun _ _ ↦ h.symm
 
+@[deprecated Equivalence.trans (since := "2024-09-13")]
 theorem Equivalence.transitive {r : β → β → Prop} (h : Equivalence r) : Transitive r :=
   fun _ _ _ ↦ h.trans
 

--- a/Mathlib/Init/Logic.lean
+++ b/Mathlib/Init/Logic.lean
@@ -3,7 +3,6 @@ Copyright (c) 2014 Microsoft Corporation. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Leonardo de Moura, Jeremy Avigad, Floris van Doorn
 -/
-import Mathlib.Tactic.Lemma
 import Mathlib.Tactic.Relation.Trans
 import Batteries.Tactic.Alias
 
@@ -21,12 +20,10 @@ set_option linter.deprecated false
 universe u v
 variable {α : Sort u}
 
-/- Eq, Ne, HEq, Iff -/
-
 -- attribute [refl] HEq.refl -- FIXME This is still rejected after #857
+attribute [refl] Iff.refl
 attribute [trans] HEq.trans
 attribute [trans] heq_of_eq_of_heq
-attribute [refl] Iff.refl
 attribute [trans] Iff.trans
 
 section Relation
@@ -45,13 +42,6 @@ def Symmetric := ∀ ⦃x y⦄, x ≺ y → y ≺ x
 /-- A relation is transitive if `x ≺ y` and `y ≺ z` together imply `x ≺ z`. -/
 def Transitive := ∀ ⦃x y z⦄, x ≺ y → y ≺ z → x ≺ z
 
-lemma Equivalence.reflexive {r : β → β → Prop} (h : Equivalence r) : Reflexive r := h.refl
-
-lemma Equivalence.symmetric {r : β → β → Prop} (h : Equivalence r) : Symmetric r := fun _ _ ↦ h.symm
-
-lemma Equivalence.transitive {r : β → β → Prop} (h : Equivalence r) : Transitive r :=
-  fun _ _ _ ↦ h.trans
-
 /-- A relation is total if for all `x` and `y`, either `x ≺ y` or `y ≺ x`. -/
 def Total := ∀ x y, x ≺ y ∨ y ≺ x
 
@@ -61,13 +51,19 @@ def Irreflexive := ∀ x, ¬ x ≺ x
 /-- A relation is antisymmetric if `x ≺ y` and `y ≺ x` together imply that `x = y`. -/
 def AntiSymmetric := ∀ ⦃x y⦄, x ≺ y → y ≺ x → x = y
 
-/-- An empty relation does not relate any elements. -/
-@[nolint unusedArguments]
-def EmptyRelation := fun _ _ : α ↦ False
+theorem Equivalence.reflexive {r : β → β → Prop} (h : Equivalence r) : Reflexive r := h.refl
 
+theorem Equivalence.symmetric {r : β → β → Prop} (h : Equivalence r) : Symmetric r :=
+  fun _ _ ↦ h.symm
+
+theorem Equivalence.transitive {r : β → β → Prop} (h : Equivalence r) : Transitive r :=
+  fun _ _ _ ↦ h.trans
+
+@[deprecated (since := "2024-09-13")]
 theorem InvImage.trans (f : α → β) (h : Transitive r) : Transitive (InvImage r f) :=
   fun (a₁ a₂ a₃ : α) (h₁ : InvImage r f a₁ a₂) (h₂ : InvImage r f a₂ a₃) ↦ h h₁ h₂
 
+@[deprecated (since := "2024-09-13")]
 theorem InvImage.irreflexive (f : α → β) (h : Irreflexive r) : Irreflexive (InvImage r f) :=
   fun (a : α) (h₁ : InvImage r f a a) ↦ h (f a) h₁
 

--- a/Mathlib/Init/Logic.lean
+++ b/Mathlib/Init/Logic.lean
@@ -21,9 +21,9 @@ universe u v
 variable {α : Sort u}
 
 -- attribute [refl] HEq.refl -- FIXME This is still rejected after #857
-attribute [refl] Iff.refl
 attribute [trans] HEq.trans
 attribute [trans] heq_of_eq_of_heq
+attribute [refl] Iff.refl
 attribute [trans] Iff.trans
 
 section Relation

--- a/Mathlib/Logic/Equiv/Basic.lean
+++ b/Mathlib/Logic/Equiv/Basic.lean
@@ -9,6 +9,7 @@ import Mathlib.Data.Prod.Basic
 import Mathlib.Data.Sigma.Basic
 import Mathlib.Data.Subtype
 import Mathlib.Data.Sum.Basic
+import Mathlib.Init.Algebra.Classes
 import Mathlib.Logic.Equiv.Defs
 import Mathlib.Logic.Function.Conjugate
 import Mathlib.Tactic.Coe

--- a/Mathlib/Logic/Function/Basic.lean
+++ b/Mathlib/Logic/Function/Basic.lean
@@ -956,7 +956,7 @@ theorem IsSymmOp.flip_eq (op) [IsSymmOp α β op] : flip op = op :=
 
 theorem InvImage.equivalence {α : Sort u} {β : Sort v} (r : β → β → Prop) (f : α → β)
     (h : Equivalence r) : Equivalence (InvImage r f) :=
-  ⟨fun _ ↦ h.1 _, fun w ↦ h.symm w, fun h₁ h₂ ↦ InvImage.trans r f (fun _ _ _ ↦ h.trans) h₁ h₂⟩
+  ⟨fun _ ↦ h.1 _, h.symm, h.trans⟩
 
 instance {α β : Type*} {r : α → β → Prop} {x : α × β} [Decidable (r x.1 x.2)] :
   Decidable (uncurry r x) :=

--- a/Mathlib/Logic/Function/Basic.lean
+++ b/Mathlib/Logic/Function/Basic.lean
@@ -3,7 +3,6 @@ Copyright (c) 2016 Johannes Hölzl. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johannes Hölzl, Mario Carneiro
 -/
-import Mathlib.Init.Algebra.Classes
 import Mathlib.Data.Set.Defs
 import Mathlib.Logic.Basic
 import Mathlib.Logic.ExistsUnique

--- a/Mathlib/Logic/Function/Basic.lean
+++ b/Mathlib/Logic/Function/Basic.lean
@@ -951,9 +951,6 @@ if for each pair of distinct points there is a function taking different values 
 def Set.SeparatesPoints {α β : Type*} (A : Set (α → β)) : Prop :=
   ∀ ⦃x y : α⦄, x ≠ y → ∃ f ∈ A, (f x : β) ≠ f y
 
-theorem IsSymmOp.flip_eq (op : α → α → β) [IsSymmOp op] : flip op = op :=
-  funext fun a ↦ funext fun b ↦ (IsSymmOp.symm_op a b).symm
-
 theorem InvImage.equivalence {α : Sort u} {β : Sort v} (r : β → β → Prop) (f : α → β)
     (h : Equivalence r) : Equivalence (InvImage r f) :=
   ⟨fun _ ↦ h.1 _, h.symm, h.trans⟩

--- a/Mathlib/Logic/Function/Basic.lean
+++ b/Mathlib/Logic/Function/Basic.lean
@@ -951,7 +951,7 @@ if for each pair of distinct points there is a function taking different values 
 def Set.SeparatesPoints {α β : Type*} (A : Set (α → β)) : Prop :=
   ∀ ⦃x y : α⦄, x ≠ y → ∃ f ∈ A, (f x : β) ≠ f y
 
-theorem IsSymmOp.flip_eq (op) [IsSymmOp α β op] : flip op = op :=
+theorem IsSymmOp.flip_eq (op : α → α → β) [IsSymmOp op] : flip op = op :=
   funext fun a ↦ funext fun b ↦ (IsSymmOp.symm_op a b).symm
 
 theorem InvImage.equivalence {α : Sort u} {β : Sort v} (r : β → β → Prop) (f : α → β)

--- a/Mathlib/Logic/Relation.lean
+++ b/Mathlib/Logic/Relation.lean
@@ -100,7 +100,7 @@ theorem Transitive.comap (h : Transitive r) (f : α → β) : Transitive (r on f
   fun _ _ _ hab hbc ↦ h hab hbc
 
 theorem Equivalence.comap (h : Equivalence r) (f : α → β) : Equivalence (r on f) :=
-  ⟨h.reflexive.comap f, @(h.symmetric.comap f), @(h.transitive.comap f)⟩
+  ⟨fun a ↦ h.refl (f a), h.symm, h.trans⟩
 
 end Comap
 

--- a/Mathlib/Order/Defs.lean
+++ b/Mathlib/Order/Defs.lean
@@ -6,6 +6,7 @@ Authors: Leonardo de Moura
 import Batteries.Classes.Order
 import Mathlib.Init.Logic
 import Mathlib.Data.Ordering.Basic
+import Mathlib.Tactic.Lemma
 import Mathlib.Tactic.SplitIfs
 
 /-!
@@ -17,8 +18,8 @@ and proves some basic lemmas about them.
 
 /-! ### Unbundled classes -/
 
-universe u
-variable {α : Type u}
+/-- An empty relation does not relate any elements. -/
+@[nolint unusedArguments] def EmptyRelation {α : Sort*} := fun _ _ : α ↦ False
 
 /-- `IsIrrefl X r` means the binary relation `r` on `X` is irreflexive (that is, `r x x` never
 holds). -/
@@ -71,7 +72,7 @@ class IsPartialOrder (α : Sort*) (r : α → α → Prop) extends IsPreorder α
 
 /-- `IsLinearOrder X r` means that the binary relation `r` on `X` is a linear order, that is,
 `IsPartialOrder X r` and `IsTotal X r`. -/
-class IsLinearOrder (α : Sort u) (r : α → α → Prop) extends IsPartialOrder α r, IsTotal α r : Prop
+class IsLinearOrder (α : Sort*) (r : α → α → Prop) extends IsPartialOrder α r, IsTotal α r : Prop
 
 /-- `IsEquiv X r` means that the binary relation `r` on `X` is an equivalence relation, that
 is, `IsPreorder X r` and `IsSymm X r`. -/
@@ -83,7 +84,7 @@ class IsStrictOrder (α : Sort*) (r : α → α → Prop) extends IsIrrefl α r,
 
 /-- `IsStrictWeakOrder X lt` means that the binary relation `lt` on `X` is a strict weak order,
 that is, `IsStrictOrder X lt` and `¬lt a b ∧ ¬lt b a → ¬lt b c ∧ ¬lt c b → ¬lt a c ∧ ¬lt c a`. -/
-class IsStrictWeakOrder (α : Sort u) (lt : α → α → Prop) extends IsStrictOrder α lt : Prop where
+class IsStrictWeakOrder (α : Sort*) (lt : α → α → Prop) extends IsStrictOrder α lt : Prop where
   incomp_trans : ∀ a b c, ¬lt a b ∧ ¬lt b a → ¬lt b c ∧ ¬lt c b → ¬lt a c ∧ ¬lt c a
 
 /-- `IsTrichotomous X lt` means that the binary relation `lt` on `X` is trichotomous, that is,
@@ -140,6 +141,8 @@ end
 
 /-! ### Bundled classes -/
 
+variable {α : Type*}
+
 section Preorder
 
 /-!
@@ -147,7 +150,7 @@ section Preorder
 -/
 
 /-- A preorder is a reflexive, transitive relation `≤` with `a < b` defined in the obvious way. -/
-class Preorder (α : Type u) extends LE α, LT α where
+class Preorder (α : Type*) extends LE α, LT α where
   le_refl : ∀ a : α, a ≤ a
   le_trans : ∀ a b c : α, a ≤ b → b ≤ c → a ≤ c
   lt := fun a b => a ≤ b ∧ ¬b ≤ a
@@ -235,7 +238,7 @@ section PartialOrder
 -/
 
 /-- A partial order is a reflexive, transitive, antisymmetric relation `≤`. -/
-class PartialOrder (α : Type u) extends Preorder α where
+class PartialOrder (α : Type*) extends Preorder α where
   le_antisymm : ∀ a b : α, a ≤ b → b ≤ a → a = b
 
 variable [PartialOrder α] {a b : α}
@@ -286,11 +289,11 @@ section LinearOrder
 -/
 
 /-- Default definition of `max`. -/
-def maxDefault {α : Type u} [LE α] [DecidableRel ((· ≤ ·) : α → α → Prop)] (a b : α) :=
+def maxDefault [LE α] [DecidableRel ((· ≤ ·) : α → α → Prop)] (a b : α) :=
   if a ≤ b then b else a
 
 /-- Default definition of `min`. -/
-def minDefault {α : Type u} [LE α] [DecidableRel ((· ≤ ·) : α → α → Prop)] (a b : α) :=
+def minDefault [LE α] [DecidableRel ((· ≤ ·) : α → α → Prop)] (a b : α) :=
   if a ≤ b then a else b
 
 /-- This attempts to prove that a given instance of `compare` is equal to `compareOfLessAndEq` by
@@ -309,7 +312,7 @@ macro "compareOfLessAndEq_rfl" : tactic =>
 
 /-- A linear order is reflexive, transitive, antisymmetric and total relation `≤`.
 We assume that every linear ordered type has decidable `(≤)`, `(<)`, and `(=)`. -/
-class LinearOrder (α : Type u) extends PartialOrder α, Min α, Max α, Ord α :=
+class LinearOrder (α : Type*) extends PartialOrder α, Min α, Max α, Ord α :=
   /-- A linear order is total. -/
   le_total (a b : α) : a ≤ b ∨ b ≤ a
   /-- In a linearly ordered type, we assume the order relations are all decidable. -/
@@ -395,12 +398,12 @@ namespace Nat
 /-! Deprecated properties of inequality on `Nat` -/
 
 @[deprecated (since := "2024-08-23")]
-protected def ltGeByCases {a b : Nat} {C : Sort u} (h₁ : a < b → C) (h₂ : b ≤ a → C) : C :=
+protected def ltGeByCases {a b : Nat} {C : Sort*} (h₁ : a < b → C) (h₂ : b ≤ a → C) : C :=
   Decidable.byCases h₁ fun h => h₂ (Or.elim (Nat.lt_or_ge a b) (fun a => absurd a h) fun a => a)
 
 set_option linter.deprecated false in
 @[deprecated ltByCases (since := "2024-08-23")]
-protected def ltByCases {a b : Nat} {C : Sort u} (h₁ : a < b → C) (h₂ : a = b → C)
+protected def ltByCases {a b : Nat} {C : Sort*} (h₁ : a < b → C) (h₂ : a = b → C)
     (h₃ : b < a → C) : C :=
   Nat.ltGeByCases h₁ fun h₁ => Nat.ltGeByCases h₃ fun h => h₂ (Nat.le_antisymm h h₁)
 

--- a/Mathlib/Order/RelClasses.lean
+++ b/Mathlib/Order/RelClasses.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Jeremy Avigad, Mario Carneiro, Yury Kudryashov
 -/
 import Mathlib.Data.Nat.Defs
+import Mathlib.Init.Algebra.Classes
 import Mathlib.Logic.IsEmpty
 import Mathlib.Order.Basic
 import Mathlib.Tactic.MkIffOfInductiveProp


### PR DESCRIPTION
* Move `EmptyRelation` to `Order.Defs` (and use `Type*, Sort*` throughout the latter file while I'm at it).
* Deprecate the two `InvImage` theorems and three `Equivalence` theorems in `Init.Logic` and fix the few uses of them.
* Align `IsSymmOp` with the new typeclasses of #16751, i.e. make its `α` and `β` arguments implicit. There were a number of uses of `IsSymmOp` where `Std.Commutative` could also be used; make those changes.