### PR TITLE
[Merged by Bors] - feat(NumberField/CanonicalEmbedding): define an action of the units on the mixed space

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -3459,6 +3459,7 @@ import Mathlib.NumberTheory.Multiplicity
 import Mathlib.NumberTheory.NumberField.Basic
 import Mathlib.NumberTheory.NumberField.CanonicalEmbedding.Basic
 import Mathlib.NumberTheory.NumberField.CanonicalEmbedding.ConvexBody
+import Mathlib.NumberTheory.NumberField.CanonicalEmbedding.FundamentalCone
 import Mathlib.NumberTheory.NumberField.ClassNumber
 import Mathlib.NumberTheory.NumberField.Discriminant
 import Mathlib.NumberTheory.NumberField.Embeddings

--- a/Mathlib/NumberTheory/NumberField/CanonicalEmbedding/Basic.lean
+++ b/Mathlib/NumberTheory/NumberField/CanonicalEmbedding/Basic.lean
@@ -4,8 +4,8 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Xavier Roblot
 -/
 import Mathlib.Algebra.Module.ZLattice.Basic
-import Mathlib.NumberTheory.NumberField.Embeddings
 import Mathlib.NumberTheory.NumberField.FractionalIdeal
+import Mathlib.NumberTheory.NumberField.Units.Basic
 
 /-!
 # Canonical embedding of a number field
@@ -318,13 +318,19 @@ theorem normAtPlace_apply (w : InfinitePlace K) (x : K) :
     RingHom.prod_apply, Pi.ringHom_apply, norm_embedding_of_isReal, norm_embedding_eq, dite_eq_ite,
     ite_id]
 
-theorem normAtPlace_eq_zero {x : mixedSpace K} :
+theorem forall_normAtPlace_eq_zero_iff {x : mixedSpace K} :
     (∀ w, normAtPlace w x = 0) ↔ x = 0 := by
   refine ⟨fun h ↦ ?_, fun h ↦ ?_⟩
   · ext w
     · exact norm_eq_zero'.mp (normAtPlace_apply_isReal w.prop _ ▸ h w.1)
     · exact norm_eq_zero'.mp (normAtPlace_apply_isComplex w.prop _ ▸ h w.1)
   · simp_rw [h, map_zero, implies_true]
+
+@[deprecated (since := "2024-09-13")] alias normAtPlace_eq_zero := forall_normAtPlace_eq_zero_iff
+
+theorem exists_normAtPlace_ne_zero_iff {x : mixedSpace K} :
+    (∃ w, normAtPlace w x ≠ 0) ↔ x ≠ 0 := by
+  rw [ne_eq, ← forall_normAtPlace_eq_zero_iff, not_forall]
 
 variable [NumberField K]
 
@@ -388,6 +394,10 @@ theorem norm_real (c : ℝ) :
 theorem norm_eq_norm (x : K) :
     mixedEmbedding.norm (mixedEmbedding K x) = |Algebra.norm ℚ x| := by
   simp_rw [mixedEmbedding.norm_apply, normAtPlace_apply, prod_eq_abs_norm]
+
+theorem norm_unit (u : (𝓞 K)ˣ) :
+     mixedEmbedding.norm (mixedEmbedding K u) = 1 := by
+  rw [norm_eq_norm, Units.norm, Rat.cast_one]
 
 theorem norm_eq_zero_iff' {x : mixedSpace K} (hx : x ∈ Set.range (mixedEmbedding K)) :
     mixedEmbedding.norm x = 0 ↔ x = 0 := by
@@ -665,3 +675,5 @@ theorem mem_span_fractionalIdealLatticeBasis (x : (mixedSpace K)) :
 end integerLattice
 
 end NumberField.mixedEmbedding
+
+#min_imports

--- a/Mathlib/NumberTheory/NumberField/CanonicalEmbedding/Basic.lean
+++ b/Mathlib/NumberTheory/NumberField/CanonicalEmbedding/Basic.lean
@@ -675,5 +675,3 @@ theorem mem_span_fractionalIdealLatticeBasis (x : (mixedSpace K)) :
 end integerLattice
 
 end NumberField.mixedEmbedding
-
-#min_imports

--- a/Mathlib/NumberTheory/NumberField/CanonicalEmbedding/Basic.lean
+++ b/Mathlib/NumberTheory/NumberField/CanonicalEmbedding/Basic.lean
@@ -396,7 +396,7 @@ theorem norm_eq_norm (x : K) :
   simp_rw [mixedEmbedding.norm_apply, normAtPlace_apply, prod_eq_abs_norm]
 
 theorem norm_unit (u : (𝓞 K)ˣ) :
-     mixedEmbedding.norm (mixedEmbedding K u) = 1 := by
+    mixedEmbedding.norm (mixedEmbedding K u) = 1 := by
   rw [norm_eq_norm, Units.norm, Rat.cast_one]
 
 theorem norm_eq_zero_iff' {x : mixedSpace K} (hx : x ∈ Set.range (mixedEmbedding K)) :

--- a/Mathlib/NumberTheory/NumberField/CanonicalEmbedding/Basic.lean
+++ b/Mathlib/NumberTheory/NumberField/CanonicalEmbedding/Basic.lean
@@ -328,6 +328,7 @@ theorem forall_normAtPlace_eq_zero_iff {x : mixedSpace K} :
 
 @[deprecated (since := "2024-09-13")] alias normAtPlace_eq_zero := forall_normAtPlace_eq_zero_iff
 
+@[simp]
 theorem exists_normAtPlace_ne_zero_iff {x : mixedSpace K} :
     (∃ w, normAtPlace w x ≠ 0) ↔ x ≠ 0 := by
   rw [ne_eq, ← forall_normAtPlace_eq_zero_iff, not_forall]

--- a/Mathlib/NumberTheory/NumberField/CanonicalEmbedding/ConvexBody.lean
+++ b/Mathlib/NumberTheory/NumberField/CanonicalEmbedding/ConvexBody.lean
@@ -312,8 +312,8 @@ theorem convexBodySumFun_smul (c : ℝ) (x : mixedSpace K) :
 
 theorem convexBodySumFun_eq_zero_iff (x : mixedSpace K) :
     convexBodySumFun x = 0 ↔ x = 0 := by
-  rw [← normAtPlace_eq_zero, convexBodySumFun, Finset.sum_eq_zero_iff_of_nonneg fun _ _ =>
-    mul_nonneg (Nat.cast_pos.mpr mult_pos).le (normAtPlace_nonneg _ _)]
+  rw [← forall_normAtPlace_eq_zero_iff, convexBodySumFun, Finset.sum_eq_zero_iff_of_nonneg
+    fun _ _ ↦ mul_nonneg (Nat.cast_pos.mpr mult_pos).le (normAtPlace_nonneg _ _)]
   conv =>
     enter [1, w, hw]
     rw [mul_left_mem_nonZeroDivisors_eq_zero_iff

--- a/Mathlib/NumberTheory/NumberField/CanonicalEmbedding/FundamentalCone.lean
+++ b/Mathlib/NumberTheory/NumberField/CanonicalEmbedding/FundamentalCone.lean
@@ -42,6 +42,8 @@ instance : MulAction (𝓞 K)ˣ (mixedSpace K) where
 instance : SMulZeroClass (𝓞 K)ˣ (mixedSpace K) where
   smul_zero := fun _ ↦ by simp_rw [unitSMul_smul, mul_zero]
 
+variable {K}
+
 theorem unit_smul_eq_zero (u : (𝓞 K)ˣ) (x : mixedSpace K) :
     u • x = 0 ↔ x = 0 := by
   refine ⟨fun h ↦ ?_, fun h ↦ by rw [h, smul_zero]⟩

--- a/Mathlib/NumberTheory/NumberField/CanonicalEmbedding/FundamentalCone.lean
+++ b/Mathlib/NumberTheory/NumberField/CanonicalEmbedding/FundamentalCone.lean
@@ -1,0 +1,68 @@
+/-
+Copyright (c) 2024 Xavier Roblot. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Xavier Roblot
+-/
+import Mathlib.NumberTheory.NumberField.CanonicalEmbedding.Basic
+
+/-!
+# Fundamental Cone
+
+Let `K` be a number field of signature `(r₁, r₂)`. We define an action of the units `(𝓞 K)ˣ` on
+the mixed space `ℝ^r₁ × ℂ^r₂` via the `mixedEmbedding`.
+
+## Main definitions and results
+
+* `NumberField.mixedEmbedding.unitSMul`: the action of `(𝓞 K)ˣ` on the mixed space defined, for
+`u : (𝓞 K)ˣ`, by multiplication component by component with `mixedEmbedding K u`.
+
+## Tags
+
+number field, canonical embedding, units
+-/
+
+variable (K : Type*) [Field K]
+
+namespace NumberField.mixedEmbedding
+
+open NumberField NumberField.InfinitePlace
+
+noncomputable section UnitSMul
+
+/-- The action of `(𝓞 K)ˣ` on the mixed space `ℝ^r₁ × ℂ^r₂` defined, for `u : (𝓞 K)ˣ`, by
+multiplication component by component with `mixedEmbedding K u`. -/
+@[simps]
+instance unitSMul : SMul (𝓞 K)ˣ (mixedSpace K) where
+  smul u x := mixedEmbedding K u * x
+
+instance : MulAction (𝓞 K)ˣ (mixedSpace K) where
+  one_smul := fun _ ↦ by simp_rw [unitSMul_smul, Units.coe_one, map_one, one_mul]
+  mul_smul := fun _ _ _ ↦ by simp_rw [unitSMul_smul, Units.coe_mul, map_mul, mul_assoc]
+
+instance : SMulZeroClass (𝓞 K)ˣ (mixedSpace K) where
+  smul_zero := fun _ ↦ by simp_rw [unitSMul_smul, mul_zero]
+
+theorem unit_smul_eq_zero (u : (𝓞 K)ˣ) (x : mixedSpace K) :
+    u • x = 0 ↔ x = 0 := by
+  refine ⟨fun h ↦ ?_, fun h ↦ by rw [h, smul_zero]⟩
+  contrapose! h
+  obtain ⟨w, h⟩ := exists_normAtPlace_ne_zero_iff.mpr h
+  refine exists_normAtPlace_ne_zero_iff.mp ⟨w, ?_⟩
+  rw [unitSMul_smul, map_mul]
+  exact mul_ne_zero (by simp) h
+
+variable [NumberField K]
+
+theorem unit_smul_eq_iff_mul_eq {x y : 𝓞 K} {u : (𝓞 K)ˣ} :
+    u • mixedEmbedding K x = mixedEmbedding K y ↔ u * x = y := by
+  rw [unitSMul_smul, ← map_mul, Function.Injective.eq_iff, ← RingOfIntegers.coe_eq_algebraMap,
+    ← map_mul, ← RingOfIntegers.ext_iff]
+  exact mixedEmbedding_injective K
+
+theorem norm_unit_smul (u : (𝓞 K)ˣ) (x : mixedSpace K) :
+    mixedEmbedding.norm (u • x) = mixedEmbedding.norm x := by
+  rw [unitSMul_smul, map_mul, norm_unit, one_mul]
+
+end UnitSMul
+
+end NumberField.mixedEmbedding


### PR DESCRIPTION
Define an action of the units on the mixed space of a number field. In a latter PR #12268, we construct a cone in the mixed space that is a fundamental domain for the action of the units modulo torsion. 

This PR is part of the proof of the Analytic Class Number Formula.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
