### PR TITLE
Feat(Algebra/Order/BigOperators/Ring/Multiset): delete duplicate lemmas

### DIFF
--- a/Mathlib/Algebra/Order/BigOperators/Ring/Multiset.lean
+++ b/Mathlib/Algebra/Order/BigOperators/Ring/Multiset.lean
@@ -3,8 +3,8 @@ Copyright (c) 2021 Ruben Van de Velde. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Ruben Van de Velde
 -/
-import Mathlib.Algebra.BigOperators.Group.Multiset
 import Mathlib.Algebra.Order.BigOperators.Ring.List
+import Mathlib.Algebra.Order.BigOperators.GroupWithZero.Multiset
 
 /-!
 # Big operators on a multiset in ordered rings
@@ -13,10 +13,12 @@ This file contains the results concerning the interaction of multiset big operat
 rings.
 -/
 
+variable {R : Type*} [CanonicallyOrderedCommSemiring R] [Nontrivial R] {m : Multiset R}
+
 @[simp]
-lemma CanonicallyOrderedCommSemiring.multiset_prod_pos {R : Type*}
-    [CanonicallyOrderedCommSemiring R] [Nontrivial R] {m : Multiset R} :
+lemma CanonicallyOrderedCommSemiring.multiset_prod_pos :
     0 < m.prod ↔ ∀ x ∈ m, 0 < x := by
   rcases m with ⟨l⟩
   rw [Multiset.quot_mk_to_coe'', Multiset.prod_coe]
   exact CanonicallyOrderedCommSemiring.list_prod_pos
+

--- a/Mathlib/Algebra/Order/BigOperators/Ring/Multiset.lean
+++ b/Mathlib/Algebra/Order/BigOperators/Ring/Multiset.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Ruben Van de Velde
 -/
 import Mathlib.Algebra.Order.BigOperators.Ring.List
-import Mathlib.Algebra.Order.BigOperators.GroupWithZero.Multiset
+import Mathlib.Algebra.BigOperators.Group.Multiset
 
 /-!
 # Big operators on a multiset in ordered rings

--- a/Mathlib/RingTheory/MvPolynomial/WeightedHomogeneous.lean
+++ b/Mathlib/RingTheory/MvPolynomial/WeightedHomogeneous.lean
@@ -384,6 +384,7 @@ theorem sum_weightedHomogeneousComponent :
     rw [hm, if_pos rfl, coeff_zero] at this
     exact this.symm
 
+-- TODO : Looks useless, maybe rewrite the previous one as a `Finset.sum`
 theorem finsum_weightedHomogeneousComponent :
     (finsum fun m => weightedHomogeneousComponent w m φ) = φ := by
   rw [sum_weightedHomogeneousComponent]

--- a/Mathlib/RingTheory/MvPolynomial/WeightedHomogeneous.lean
+++ b/Mathlib/RingTheory/MvPolynomial/WeightedHomogeneous.lean
@@ -384,7 +384,6 @@ theorem sum_weightedHomogeneousComponent :
     rw [hm, if_pos rfl, coeff_zero] at this
     exact this.symm
 
--- TODO : Looks useless, maybe rewrite the previous one as a `Finset.sum`
 theorem finsum_weightedHomogeneousComponent :
     (finsum fun m => weightedHomogeneousComponent w m φ) = φ := by
   rw [sum_weightedHomogeneousComponent]


### PR DESCRIPTION
Delete lemmas for `Ring` that follow from analogous ones in Mathlib.Algebra.Order.BigOperators.GroupWithZero.Multiset

(Despite the name of the imported file, they work for `CommMonoidWithZero`)

 ---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
