### PR TITLE
[Merged by Bors] - feat(SetTheory/Cardinal/Basic): Prove power_sum, power of an infinite sum

### DIFF
--- a/Mathlib/SetTheory/Cardinal/Basic.lean
+++ b/Mathlib/SetTheory/Cardinal/Basic.lean
@@ -955,17 +955,15 @@ theorem prod_eq_zero {ι} (f : ι → Cardinal.{u}) : prod f = 0 ↔ ∃ i, f i 
 theorem prod_ne_zero {ι} (f : ι → Cardinal) : prod f ≠ 0 ↔ ∀ i, f i ≠ 0 := by simp [prod_eq_zero]
 
 theorem power_sum {ι} (a : Cardinal) (f : ι → Cardinal) :
-    a ^ sum f = prod fun i ↦ a ^ f i :=
-  inductionOn a fun α ↦ by
-    apply induction_on_pi f fun f ↦ ?_
-    rw [prod, sum]
-    simp_rw [power_def]
-    convert mk_sigma_arrow α f using 1
-    · exact mk_congr <| Equiv.arrowCongr
-        (Equiv.sigmaCongr (Equiv.cast rfl) (fun _ ↦ outMkEquiv)) (Equiv.refl α)
-    · apply mk_pi_congr
-      intro i
-      rw [mk_out]
+    a ^ sum f = prod fun i ↦ a ^ f i := by
+  induction a using Cardinal.inductionOn with | _ α =>
+  induction f using induction_on_pi with | _ f =>
+  simp_rw [prod, sum, power_def]
+  apply mk_congr
+  refine (Equiv.piCurry fun _ _ => α).trans ?_
+  refine Equiv.piCongrRight fun b => ?_
+  refine (Equiv.arrowCongr outMkEquiv (Equiv.refl α)).trans ?_
+  exact outMkEquiv.symm
 
 @[simp]
 theorem lift_prod {ι : Type u} (c : ι → Cardinal.{v}) :

--- a/Mathlib/SetTheory/Cardinal/Basic.lean
+++ b/Mathlib/SetTheory/Cardinal/Basic.lean
@@ -924,16 +924,6 @@ def prod {ι : Type u} (f : ι → Cardinal) : Cardinal :=
 theorem mk_pi {ι : Type u} (α : ι → Type v) : #(∀ i, α i) = prod fun i => #(α i) :=
   mk_congr <| Equiv.piCongrRight fun _ => outMkEquiv.symm
 
-theorem mk_pi_congr {ι : Type u} {f g : ι → Type v} (h : ∀ i, #(f i) = #(g i)) :
-    #(Π i, f i) = #(Π i, g i) := by
-  simp_all only [mk_pi]
-
-theorem mk_pi_congr_subtype {ι : Type u} {f g : ι → Type v} {S : Set ι}
-    (h : ∀ i ∈ S, #(f i) = #(g i)) : #(Π i ∈ S, f i) = #(Π i ∈ S, g i) :=
-  mk_congr <|
-    .piCongrRight fun i => .piCongrRight fun is =>
-      Classical.choice <| Cardinal.eq.mp (h i is)
-
 @[simp]
 theorem prod_const (ι : Type u) (a : Cardinal.{v}) :
     (prod fun _ : ι => a) = lift.{u} a ^ lift.{v} #ι :=

--- a/Mathlib/SetTheory/Cardinal/Basic.lean
+++ b/Mathlib/SetTheory/Cardinal/Basic.lean
@@ -930,11 +930,9 @@ theorem mk_pi_congr {ι : Type u} {f g : ι → Type v} (h : ∀ i, #(f i) = #(g
 
 theorem mk_pi_congr_subtype {ι : Type u} {f g : ι → Type v} {S : Set ι}
     (h : ∀ i ∈ S, #(f i) = #(g i)) : #(Π i ∈ S, f i) = #(Π i ∈ S, g i) :=
-  have h' : Π i ∈ S, f i ≃ g i := fun i is ↦ Classical.choice <| Cardinal.eq.mp (h i is)
-  mk_congr
-  ⟨fun f' i is ↦ h' i is (f' i is) , fun g' i is ↦ (h' i is).symm (g' i is),
-  fun _ ↦ by simp only [Equiv.symm_apply_apply],
-  fun _ ↦ by simp only [Equiv.apply_symm_apply]⟩
+  mk_congr <|
+    .piCongrRight fun i => .piCongrRight fun is =>
+      Classical.choice <| Cardinal.eq.mp (h i is)
 
 @[simp]
 theorem prod_const (ι : Type u) (a : Cardinal.{v}) :

--- a/Mathlib/SetTheory/Cardinal/Basic.lean
+++ b/Mathlib/SetTheory/Cardinal/Basic.lean
@@ -131,7 +131,7 @@ theorem inductionOn₃ {p : Cardinal → Cardinal → Cardinal → Prop} (c₁ :
   Quotient.inductionOn₃ c₁ c₂ c₃ h
 
 theorem induction_on_pi {ι : Type u} {p : (ι → Cardinal.{v}) → Prop}
-    (f : ι → Cardinal.{v}) (h : ∀ f : ι → Type v, p (fun i ↦ #(f i))) : p f :=
+    (f : ι → Cardinal.{v}) (h : ∀ f : ι → Type v, p fun i ↦ #(f i)) : p f :=
   Quotient.induction_on_pi f h
 
 protected theorem eq : #α = #β ↔ Nonempty (α ≃ β) :=
@@ -933,7 +933,7 @@ theorem mk_pi_congr_subtype {ι : Type u} {f g : ι → Type v} {S : Set ι}
   have h' : Π i ∈ S, f i ≃ g i := fun i is ↦ Classical.choice <| Cardinal.eq.mp (h i is)
   mk_congr
   ⟨fun f' i is ↦ h' i is (f' i is) , fun g' i is ↦ (h' i is).symm (g' i is),
-  fun _ ↦ by simp only [Equiv.symm_apply_apply],
+  fun h'' ↦ by simp only [Equiv.symm_apply_apply],
   fun _ ↦ by simp only [Equiv.apply_symm_apply]⟩
 
 @[simp]
@@ -960,7 +960,8 @@ theorem power_sum {ι} (a : Cardinal) (f : ι → Cardinal) :
     a ^ sum f = prod fun i ↦ a ^ f i :=
   inductionOn a fun α ↦ by
     apply induction_on_pi f fun f ↦ ?_
-    rw [prod, sum, power_def]; simp_rw [power_def]
+    rw [prod, sum]
+    simp_rw [power_def]
     convert mk_sigma_arrow α f using 1
     · exact mk_congr <| Equiv.arrowCongr
         (Equiv.sigmaCongr (Equiv.cast rfl) (fun _ ↦ outMkEquiv)) (Equiv.refl α)

--- a/Mathlib/SetTheory/Cardinal/Basic.lean
+++ b/Mathlib/SetTheory/Cardinal/Basic.lean
@@ -933,7 +933,7 @@ theorem mk_pi_congr_subtype {ι : Type u} {f g : ι → Type v} {S : Set ι}
   have h' : Π i ∈ S, f i ≃ g i := fun i is ↦ Classical.choice <| Cardinal.eq.mp (h i is)
   mk_congr
   ⟨fun f' i is ↦ h' i is (f' i is) , fun g' i is ↦ (h' i is).symm (g' i is),
-  fun h'' ↦ by simp only [Equiv.symm_apply_apply],
+  fun _ ↦ by simp only [Equiv.symm_apply_apply],
   fun _ ↦ by simp only [Equiv.apply_symm_apply]⟩
 
 @[simp]

--- a/Mathlib/SetTheory/Cardinal/Basic.lean
+++ b/Mathlib/SetTheory/Cardinal/Basic.lean
@@ -924,9 +924,17 @@ def prod {ι : Type u} (f : ι → Cardinal) : Cardinal :=
 theorem mk_pi {ι : Type u} (α : ι → Type v) : #(∀ i, α i) = prod fun i => #(α i) :=
   mk_congr <| Equiv.piCongrRight fun _ => outMkEquiv.symm
 
-theorem mk_pi_eq {ι : Type u} {f g : ι → Type v} (h : ∀ i, #(f i) = #(g i)) :
+theorem mk_pi_congr {ι : Type u} {f g : ι → Type v} (h : ∀ i, #(f i) = #(g i)) :
     #(Π i, f i) = #(Π i, g i) := by
   simp_all only [mk_pi]
+
+theorem mk_pi_congr_subtype {ι : Type u} {f g : ι → Type v} {S : Set ι}
+    (h : ∀ i ∈ S, #(f i) = #(g i)) : #(Π i ∈ S, f i) = #(Π i ∈ S, g i) :=
+  have h' : Π i ∈ S, f i ≃ g i := fun i is ↦ Classical.choice <| Cardinal.eq.mp (h i is)
+  mk_congr
+  ⟨fun f' i is ↦ h' i is (f' i is) , fun g' i is ↦ (h' i is).symm (g' i is),
+  fun _ ↦ by simp only [Equiv.symm_apply_apply],
+  fun _ ↦ by simp only [Equiv.apply_symm_apply]⟩
 
 @[simp]
 theorem prod_const (ι : Type u) (a : Cardinal.{v}) :
@@ -949,14 +957,14 @@ theorem prod_eq_zero {ι} (f : ι → Cardinal.{u}) : prod f = 0 ↔ ∃ i, f i 
 theorem prod_ne_zero {ι} (f : ι → Cardinal) : prod f ≠ 0 ↔ ∀ i, f i ≠ 0 := by simp [prod_eq_zero]
 
 theorem power_sum {ι} (a : Cardinal) (f : ι → Cardinal) :
-    a ^ (sum f) = prod (fun i ↦ a ^ (f i)) :=
+    a ^ sum f = prod fun i ↦ a ^ f i :=
   inductionOn a fun α ↦ by
     apply induction_on_pi f fun f ↦ ?_
     rw [prod, sum, power_def]; simp_rw [power_def]
     convert mk_sigma_arrow α f using 1
     · exact mk_congr <| Equiv.arrowCongr
         (Equiv.sigmaCongr (Equiv.cast rfl) (fun _ ↦ outMkEquiv)) (Equiv.refl α)
-    · apply mk_pi_eq
+    · apply mk_pi_congr
       intro i
       rw [mk_out]
 

--- a/Mathlib/SetTheory/Cardinal/Basic.lean
+++ b/Mathlib/SetTheory/Cardinal/Basic.lean
@@ -130,6 +130,10 @@ theorem inductionOn₃ {p : Cardinal → Cardinal → Cardinal → Prop} (c₁ :
     (c₃ : Cardinal) (h : ∀ α β γ, p #α #β #γ) : p c₁ c₂ c₃ :=
   Quotient.inductionOn₃ c₁ c₂ c₃ h
 
+theorem induction_on_pi {ι : Type u} {p : (ι → Cardinal.{v}) → Prop}
+    (f : ι → Cardinal.{v}) (h : ∀ f : ι → Type v, p (fun i ↦ #(f i))) : p f :=
+  Quotient.induction_on_pi f h
+
 protected theorem eq : #α = #β ↔ Nonempty (α ≃ β) :=
   Quotient.eq'
 
@@ -746,6 +750,9 @@ theorem le_sum {ι} (f : ι → Cardinal) (i) : f i ≤ sum f := by
 theorem mk_sigma {ι} (f : ι → Type*) : #(Σ i, f i) = sum fun i => #(f i) :=
   mk_congr <| Equiv.sigmaCongrRight fun _ => outMkEquiv.symm
 
+theorem mk_sigma_arrow {ι} (α : Type*) (f : ι → Type*) :
+    #(Sigma f → α) = #(Π i, f i → α) := mk_congr <| Equiv.piCurry fun _ _ ↦ α
+
 @[simp]
 theorem sum_const (ι : Type u) (a : Cardinal.{v}) :
     (sum fun _ : ι => a) = lift.{v} #ι * lift.{u} a :=
@@ -917,6 +924,10 @@ def prod {ι : Type u} (f : ι → Cardinal) : Cardinal :=
 theorem mk_pi {ι : Type u} (α : ι → Type v) : #(∀ i, α i) = prod fun i => #(α i) :=
   mk_congr <| Equiv.piCongrRight fun _ => outMkEquiv.symm
 
+theorem mk_pi_eq {ι : Type u} {f g : ι → Type v} (h : ∀ i, #(f i) = #(g i)) :
+    #(Π i, f i) = #(Π i, g i) := by
+  simp_all only [mk_pi]
+
 @[simp]
 theorem prod_const (ι : Type u) (a : Cardinal.{v}) :
     (prod fun _ : ι => a) = lift.{u} a ^ lift.{v} #ι :=
@@ -936,6 +947,18 @@ theorem prod_eq_zero {ι} (f : ι → Cardinal.{u}) : prod f = 0 ↔ ∃ i, f i 
   simp only [mk_eq_zero_iff, ← mk_pi, isEmpty_pi]
 
 theorem prod_ne_zero {ι} (f : ι → Cardinal) : prod f ≠ 0 ↔ ∀ i, f i ≠ 0 := by simp [prod_eq_zero]
+
+theorem power_sum {ι} (a : Cardinal) (f : ι → Cardinal) :
+    a ^ (sum f) = prod (fun i ↦ a ^ (f i)) :=
+  inductionOn a fun α ↦ by
+    apply induction_on_pi f fun f ↦ ?_
+    rw [prod, sum, power_def]; simp_rw [power_def]
+    convert mk_sigma_arrow α f using 1
+    · exact mk_congr <| Equiv.arrowCongr
+        (Equiv.sigmaCongr (Equiv.cast rfl) (fun _ ↦ outMkEquiv)) (Equiv.refl α)
+    · apply mk_pi_eq
+      intro i
+      rw [mk_out]
 
 @[simp]
 theorem lift_prod {ι : Type u} (c : ι → Cardinal.{v}) :


### PR DESCRIPTION
Prove `power_sum`, a generalization of `power_add` for `Cardinal.sum`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

For the proof I proved `induction_on_pi`, the cardinal version of `Quotient.induction_on_pi`.

For consistency in the cardinals library it should really be called `inductionOnₚᵢ`, but I'm willing to let that go.

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
