### PR TITLE
[Merged by Bors] - chore(ModelTheory/Equivalence): Cleanup of `FirstOrder.Language.Theory.SemanticallyEquivalent`

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -3349,6 +3349,7 @@ import Mathlib.ModelTheory.DirectLimit
 import Mathlib.ModelTheory.ElementaryMaps
 import Mathlib.ModelTheory.ElementarySubstructures
 import Mathlib.ModelTheory.Encoding
+import Mathlib.ModelTheory.Equivalence
 import Mathlib.ModelTheory.FinitelyGenerated
 import Mathlib.ModelTheory.Fraisse
 import Mathlib.ModelTheory.Graph

--- a/Mathlib/ModelTheory/Complexity.lean
+++ b/Mathlib/ModelTheory/Complexity.lean
@@ -3,7 +3,7 @@ Copyright (c) 2021 Aaron Anderson. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Aaron Anderson
 -/
-import Mathlib.ModelTheory.Satisfiability
+import Mathlib.ModelTheory.Equivalence
 
 /-!
 # Quantifier Complexity
@@ -288,7 +288,7 @@ theorem IsQF.induction_on_sup_not {P : L.BoundedFormula α n → Prop} {φ : L.B
     (ha : ∀ ψ : L.BoundedFormula α n, IsAtomic ψ → P ψ)
     (hsup : ∀ {φ₁ φ₂}, P φ₁ → P φ₂ → P (φ₁ ⊔ φ₂)) (hnot : ∀ {φ}, P φ → P φ.not)
     (hse :
-      ∀ {φ₁ φ₂ : L.BoundedFormula α n}, Theory.SemanticallyEquivalent ∅ φ₁ φ₂ → (P φ₁ ↔ P φ₂)) :
+      ∀ {φ₁ φ₂ : L.BoundedFormula α n}, (φ₁ ⇔[∅] φ₂) → (P φ₁ ↔ P φ₂)) :
     P φ :=
   IsQF.recOn h hf @(ha) fun {φ₁ φ₂} _ _ h1 h2 =>
     (hse (φ₁.imp_semanticallyEquivalent_not_sup φ₂)).2 (hsup (hnot h1) h2)
@@ -298,7 +298,7 @@ theorem IsQF.induction_on_inf_not {P : L.BoundedFormula α n → Prop} {φ : L.B
     (ha : ∀ ψ : L.BoundedFormula α n, IsAtomic ψ → P ψ)
     (hinf : ∀ {φ₁ φ₂}, P φ₁ → P φ₂ → P (φ₁ ⊓ φ₂)) (hnot : ∀ {φ}, P φ → P φ.not)
     (hse :
-      ∀ {φ₁ φ₂ : L.BoundedFormula α n}, Theory.SemanticallyEquivalent ∅ φ₁ φ₂ → (P φ₁ ↔ P φ₂)) :
+      ∀ {φ₁ φ₂ : L.BoundedFormula α n}, (φ₁ ⇔[∅] φ₂) → (P φ₁ ↔ P φ₂)) :
     P φ :=
   h.induction_on_sup_not hf ha
     (fun {φ₁ φ₂} h1 h2 =>
@@ -306,7 +306,7 @@ theorem IsQF.induction_on_inf_not {P : L.BoundedFormula α n → Prop} {φ : L.B
     (fun {_} => hnot) fun {_ _} => hse
 
 theorem semanticallyEquivalent_toPrenex (φ : L.BoundedFormula α n) :
-    (∅ : L.Theory).SemanticallyEquivalent φ φ.toPrenex := fun M v xs => by
+    φ ⇔[∅] φ.toPrenex := fun M v xs => by
   rw [realize_iff, realize_toPrenex]
 
 theorem induction_on_all_ex {P : ∀ {m}, L.BoundedFormula α m → Prop} (φ : L.BoundedFormula α n)
@@ -314,7 +314,7 @@ theorem induction_on_all_ex {P : ∀ {m}, L.BoundedFormula α m → Prop} (φ : 
     (hall : ∀ {m} {ψ : L.BoundedFormula α (m + 1)}, P ψ → P ψ.all)
     (hex : ∀ {m} {φ : L.BoundedFormula α (m + 1)}, P φ → P φ.ex)
     (hse : ∀ {m} {φ₁ φ₂ : L.BoundedFormula α m},
-      Theory.SemanticallyEquivalent ∅ φ₁ φ₂ → (P φ₁ ↔ P φ₂)) :
+      (φ₁ ⇔[∅] φ₂) → (P φ₁ ↔ P φ₂)) :
     P φ := by
   suffices h' : ∀ {m} {φ : L.BoundedFormula α m}, φ.IsPrenex → P φ from
     (hse φ.semanticallyEquivalent_toPrenex).2 (h' φ.toPrenex_isPrenex)
@@ -329,7 +329,7 @@ theorem induction_on_exists_not {P : ∀ {m}, L.BoundedFormula α m → Prop} (�
     (hnot : ∀ {m} {φ : L.BoundedFormula α m}, P φ → P φ.not)
     (hex : ∀ {m} {φ : L.BoundedFormula α (m + 1)}, P φ → P φ.ex)
     (hse : ∀ {m} {φ₁ φ₂ : L.BoundedFormula α m},
-      Theory.SemanticallyEquivalent ∅ φ₁ φ₂ → (P φ₁ ↔ P φ₂)) :
+      (φ₁ ⇔[∅] φ₂) → (P φ₁ ↔ P φ₂)) :
     P φ :=
   φ.induction_on_all_ex (fun {_ _} => hqf)
     (fun {_ φ} hφ => (hse φ.all_semanticallyEquivalent_not_ex_not).2 (hnot (hex (hnot hφ))))

--- a/Mathlib/ModelTheory/Equivalence.lean
+++ b/Mathlib/ModelTheory/Equivalence.lean
@@ -1,0 +1,166 @@
+/-
+Copyright (c) 2021 Aaron Anderson. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Aaron Anderson
+-/
+import Mathlib.ModelTheory.Satisfiability
+
+/-!
+# Equivalence of Formulas
+
+## Main Definitions
+- `FirstOrder.Language.Theory.SemanticallyEquivalent`: `φ ⇔[T] ψ` indicates that `φ` and `ψ` are
+  equivalent formulas or sentences in models of `T`.
+
+## TODO
+- Add a definition of implication modulo a theory `T`, with `φ ⇒[T] ψ` defined analogously to
+  `φ ⇔[T] ψ`.
+- Construct the quotient of `L.Formula α` modulo `⇔[T]` and its Boolean Algebra structure.
+
+-/
+
+universe u v w w'
+
+open Cardinal CategoryTheory
+
+open Cardinal FirstOrder
+
+namespace FirstOrder
+
+namespace Language
+
+variable {L : Language.{u, v}} {T : L.Theory} {α : Type w} {n : ℕ}
+variable {M : Type*} [Nonempty M] [L.Structure M] [M ⊨ T]
+
+namespace Theory
+
+/-- Two (bounded) formulas are semantically equivalent over a theory `T` when they have the same
+interpretation in every model of `T`. (This is also known as logical equivalence, which also has a
+proof-theoretic definition.) -/
+def SemanticallyEquivalent (T : L.Theory) (φ ψ : L.BoundedFormula α n) : Prop :=
+  T ⊨ᵇ φ.iff ψ
+
+@[inherit_doc FirstOrder.Language.Theory.SemanticallyEquivalent]
+scoped[FirstOrder] notation:25 φ " ⇔[" T "] " ψ => Language.Theory.SemanticallyEquivalent T φ ψ
+
+
+namespace SemanticallyEquivalent
+
+@[refl]
+protected theorem refl (φ : L.BoundedFormula α n) : φ ⇔[T] φ :=
+  fun M v xs => by rw [BoundedFormula.realize_iff]
+
+instance : IsRefl (L.BoundedFormula α n) T.SemanticallyEquivalent :=
+  ⟨SemanticallyEquivalent.refl⟩
+
+@[symm]
+protected theorem symm {φ ψ : L.BoundedFormula α n}
+    (h : φ ⇔[T] ψ) : ψ ⇔[T] φ := fun M v xs => by
+  rw [BoundedFormula.realize_iff, Iff.comm, ← BoundedFormula.realize_iff]
+  exact h M v xs
+
+@[trans]
+protected theorem trans {φ ψ θ : L.BoundedFormula α n}
+    (h1 : φ ⇔[T] ψ) (h2 : ψ ⇔[T] θ) :
+    φ ⇔[T] θ := fun M v xs => by
+  have h1' := h1 M v xs
+  have h2' := h2 M v xs
+  rw [BoundedFormula.realize_iff] at *
+  exact ⟨h2'.1 ∘ h1'.1, h1'.2 ∘ h2'.2⟩
+
+theorem realize_bd_iff {φ ψ : L.BoundedFormula α n} (h : φ ⇔[T] ψ)
+    {v : α → M} {xs : Fin n → M} : φ.Realize v xs ↔ ψ.Realize v xs :=
+  BoundedFormula.realize_iff.1 (h.realize_boundedFormula M)
+
+theorem realize_iff {φ ψ : L.Formula α} {M : Type*} [Nonempty M]
+    [L.Structure M] [M ⊨ T] (h : φ ⇔[T] ψ) {v : α → M} :
+    φ.Realize v ↔ ψ.Realize v :=
+  h.realize_bd_iff
+
+theorem models_sentence_iff {φ ψ : L.Sentence} {M : Type*} [Nonempty M]
+    [L.Structure M] [M ⊨ T] (h : φ ⇔[T] ψ) :
+    M ⊨ φ ↔ M ⊨ ψ :=
+  h.realize_iff
+
+protected theorem all {φ ψ : L.BoundedFormula α (n + 1)}
+    (h : φ ⇔[T] ψ) : φ.all ⇔[T] ψ.all := by
+  simp_rw [SemanticallyEquivalent, ModelsBoundedFormula, BoundedFormula.realize_iff,
+    BoundedFormula.realize_all]
+  exact fun M v xs => forall_congr' fun a => h.realize_bd_iff
+
+protected theorem ex {φ ψ : L.BoundedFormula α (n + 1)} (h : φ ⇔[T] ψ) :
+    φ.ex ⇔[T] ψ.ex := by
+  simp_rw [SemanticallyEquivalent, ModelsBoundedFormula, BoundedFormula.realize_iff,
+    BoundedFormula.realize_ex]
+  exact fun M v xs => exists_congr fun a => h.realize_bd_iff
+
+protected theorem not {φ ψ : L.BoundedFormula α n} (h : φ ⇔[T] ψ) :
+    φ.not ⇔[T] ψ.not := by
+  simp_rw [SemanticallyEquivalent, ModelsBoundedFormula, BoundedFormula.realize_iff,
+    BoundedFormula.realize_not]
+  exact fun M v xs => not_congr h.realize_bd_iff
+
+protected theorem imp {φ ψ φ' ψ' : L.BoundedFormula α n} (h : φ ⇔[T] ψ) (h' : φ' ⇔[T] ψ') :
+    (φ.imp φ') ⇔[T] (ψ.imp ψ') := by
+  simp_rw [SemanticallyEquivalent, ModelsBoundedFormula, BoundedFormula.realize_iff,
+    BoundedFormula.realize_imp]
+  exact fun M v xs => imp_congr h.realize_bd_iff h'.realize_bd_iff
+
+end SemanticallyEquivalent
+
+/-- Semantic equivalence forms an equivalence relation on formulas. -/
+def semanticallyEquivalentSetoid (T : L.Theory) : Setoid (L.BoundedFormula α n) where
+  r := SemanticallyEquivalent T
+  iseqv := ⟨fun _ => refl _, fun {_ _} h => h.symm, fun {_ _ _} h1 h2 => h1.trans h2⟩
+
+end Theory
+
+namespace BoundedFormula
+
+variable (φ ψ : L.BoundedFormula α n)
+
+theorem semanticallyEquivalent_not_not : φ ⇔[T] φ.not.not := fun M v xs => by
+  simp
+
+theorem imp_semanticallyEquivalent_not_sup : (φ.imp ψ) ⇔[T] (φ.not ⊔ ψ) :=
+  fun M v xs => by simp [imp_iff_not_or]
+
+theorem sup_semanticallyEquivalent_not_inf_not : (φ ⊔ ψ) ⇔[T] (φ.not ⊓ ψ.not).not :=
+  fun M v xs => by simp [imp_iff_not_or]
+
+theorem inf_semanticallyEquivalent_not_sup_not : (φ ⊓ ψ) ⇔[T] (φ.not ⊔ ψ.not).not :=
+  fun M v xs => by simp
+
+theorem all_semanticallyEquivalent_not_ex_not (φ : L.BoundedFormula α (n + 1)) :
+    φ.all ⇔[T] φ.not.ex.not := fun M v xs => by simp
+
+theorem ex_semanticallyEquivalent_not_all_not (φ : L.BoundedFormula α (n + 1)) :
+    φ.ex ⇔[T] φ.not.all.not := fun M v xs => by simp
+
+theorem semanticallyEquivalent_all_liftAt : φ ⇔[T] (φ.liftAt 1 n).all :=
+  fun M v xs => by
+  rw [realize_iff, realize_all_liftAt_one_self]
+
+end BoundedFormula
+
+namespace Formula
+
+variable (φ ψ : L.Formula α)
+
+theorem semanticallyEquivalent_not_not : φ ⇔[T] φ.not.not :=
+  BoundedFormula.semanticallyEquivalent_not_not φ
+
+theorem imp_semanticallyEquivalent_not_sup : (φ.imp ψ) ⇔[T] (φ.not ⊔ ψ) :=
+  BoundedFormula.imp_semanticallyEquivalent_not_sup φ ψ
+
+theorem sup_semanticallyEquivalent_not_inf_not : (φ ⊔ ψ) ⇔[T] (φ.not ⊓ ψ.not).not :=
+  BoundedFormula.sup_semanticallyEquivalent_not_inf_not φ ψ
+
+theorem inf_semanticallyEquivalent_not_sup_not : (φ ⊓ ψ) ⇔[T] (φ.not ⊔ ψ.not).not :=
+  BoundedFormula.inf_semanticallyEquivalent_not_sup_not φ ψ
+
+end Formula
+
+end Language
+
+end FirstOrder


### PR DESCRIPTION
Moves the definition and API of `FirstOrder.Language.Theory.SemanticallyEquivalent` to a new file, `Mathlib/ModelTheory/Equivalence.lean`, anticipating further development
Cleans up the use of the namespace `FirstOrder.Language.Theory.SemanticallyEquivalent`
Defines the notation `φ ⇔[T] ψ` for `T.SemanticallyEquivalent φ ψ`
Other moving files, moving variables, introducing notation, and editing documentation, no changes were made.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
