### PR TITLE
[Merged by Bors] - feat(ModelTheory/Order): The theory of dense linear orders is countably categorical, and thus complete

### DIFF
--- a/Mathlib/ModelTheory/Basic.lean
+++ b/Mathlib/ModelTheory/Basic.lean
@@ -132,12 +132,10 @@ theorem card_relations_sum (i : ℕ) :
       Cardinal.lift.{v'} #(L.Relations i) + Cardinal.lift.{v} #(L'.Relations i) := by
   simp [Language.sum]
 
-@[simp]
 theorem card_sum :
     (L.sum L').card = Cardinal.lift.{max u' v'} L.card + Cardinal.lift.{max u v} L'.card := by
-  simp only [card_eq_card_functions_add_card_relations, card_functions_sum, card_relations_sum,
-    sum_add_distrib', lift_add, lift_sum, lift_lift]
-  simp only [add_assoc, add_comm (Cardinal.sum fun i => (#(L'.Functions i)).lift)]
+  simp only [mk_sum, mk_sigma, card_functions_sum, sum_add_distrib', lift_add, lift_sum, lift_lift,
+    card_relations_sum, add_assoc, add_comm (Cardinal.sum fun i => (#(L'.Functions i)).lift)]
 
 /-- Passes a `DecidableEq` instance on a type of function symbols through the  `Language`
 constructor. Despite the fact that this is proven by `inferInstance`, it is still needed -

--- a/Mathlib/ModelTheory/Basic.lean
+++ b/Mathlib/ModelTheory/Basic.lean
@@ -93,7 +93,7 @@ abbrev Symbols :=
   (Σ l, L.Functions l) ⊕ (Σ l, L.Relations l)
 
 /-- The cardinality of a language is the cardinality of its type of symbols. -/
-abbrev card : Cardinal :=
+def card : Cardinal :=
   #L.Symbols
 
 variable {L} {L' : Language.{u', v'}}
@@ -102,7 +102,7 @@ theorem card_eq_card_functions_add_card_relations :
     L.card =
       (Cardinal.sum fun l => Cardinal.lift.{v} #(L.Functions l)) +
         Cardinal.sum fun l => Cardinal.lift.{u} #(L.Relations l) := by
-  simp only [mk_sum, mk_sigma, lift_sum]
+  simp only [card, mk_sum, mk_sigma, lift_sum]
 
 instance isRelational_sum [L.IsRelational] [L'.IsRelational] : IsRelational (L.sum L') :=
   fun _ => instIsEmptySum
@@ -110,7 +110,8 @@ instance isRelational_sum [L.IsRelational] [L'.IsRelational] : IsRelational (L.s
 instance isAlgebraic_sum [L.IsAlgebraic] [L'.IsAlgebraic] : IsAlgebraic (L.sum L') :=
   fun _ => instIsEmptySum
 
-theorem empty_card : Language.empty.card = 0 := by simp only [mk_sum, mk_sigma, mk_eq_zero,
+@[simp]
+theorem empty_card : Language.empty.card = 0 := by simp only [card, mk_sum, mk_sigma, mk_eq_zero,
   sum_const, mk_eq_aleph0, lift_id', mul_zero, add_zero]
 
 instance isEmpty_empty : IsEmpty Language.empty.Symbols := by
@@ -134,8 +135,9 @@ theorem card_relations_sum (i : ℕ) :
 
 theorem card_sum :
     (L.sum L').card = Cardinal.lift.{max u' v'} L.card + Cardinal.lift.{max u v} L'.card := by
-  simp only [mk_sum, mk_sigma, card_functions_sum, sum_add_distrib', lift_add, lift_sum, lift_lift,
-    card_relations_sum, add_assoc, add_comm (Cardinal.sum fun i => (#(L'.Functions i)).lift)]
+  simp only [card, mk_sum, mk_sigma, card_functions_sum, sum_add_distrib', lift_add, lift_sum,
+    lift_lift, card_relations_sum, add_assoc,
+    add_comm (Cardinal.sum fun i => (#(L'.Functions i)).lift)]
 
 /-- Passes a `DecidableEq` instance on a type of function symbols through the  `Language`
 constructor. Despite the fact that this is proven by `inferInstance`, it is still needed -

--- a/Mathlib/ModelTheory/Basic.lean
+++ b/Mathlib/ModelTheory/Basic.lean
@@ -89,11 +89,11 @@ protected abbrev Constants :=
 /-- The type of symbols in a given language. -/
 -- Porting note(#5171): this linter isn't ported yet.
 -- @[nolint has_nonempty_instance]
-def Symbols :=
+abbrev Symbols :=
   (Σ l, L.Functions l) ⊕ (Σ l, L.Relations l)
 
 /-- The cardinality of a language is the cardinality of its type of symbols. -/
-def card : Cardinal :=
+abbrev card : Cardinal :=
   #L.Symbols
 
 variable {L} {L' : Language.{u', v'}}
@@ -102,7 +102,7 @@ theorem card_eq_card_functions_add_card_relations :
     L.card =
       (Cardinal.sum fun l => Cardinal.lift.{v} #(L.Functions l)) +
         Cardinal.sum fun l => Cardinal.lift.{u} #(L.Relations l) := by
-  simp [card, Symbols]
+  simp only [mk_sum, mk_sigma, lift_sum]
 
 instance isRelational_sum [L.IsRelational] [L'.IsRelational] : IsRelational (L.sum L') :=
   fun _ => instIsEmptySum
@@ -110,8 +110,8 @@ instance isRelational_sum [L.IsRelational] [L'.IsRelational] : IsRelational (L.s
 instance isAlgebraic_sum [L.IsAlgebraic] [L'.IsAlgebraic] : IsAlgebraic (L.sum L') :=
   fun _ => instIsEmptySum
 
-@[simp]
-theorem empty_card : Language.empty.card = 0 := by simp [card_eq_card_functions_add_card_relations]
+theorem empty_card : Language.empty.card = 0 := by simp only [mk_sum, mk_sigma, mk_eq_zero,
+  sum_const, mk_eq_aleph0, lift_id', mul_zero, add_zero]
 
 instance isEmpty_empty : IsEmpty Language.empty.Symbols := by
   simp only [Language.Symbols, isEmpty_sum, isEmpty_sigma]

--- a/Mathlib/ModelTheory/Fraisse.lean
+++ b/Mathlib/ModelTheory/Fraisse.lean
@@ -62,7 +62,7 @@ Fraïssé limit - the countable ultrahomogeneous structure with that age.
 
 ## TODO
 
-- Show existence and uniqueness of Fraïssé limits
+- Show existence of Fraïssé limits
 
 -/
 

--- a/Mathlib/ModelTheory/Order.lean
+++ b/Mathlib/ModelTheory/Order.lean
@@ -44,7 +44,7 @@ This file defines ordered first-order languages and structures, as well as their
 - `FirstOrder.Language.isFraisse_finite_linear_order` shows that the class of finite models of the
   theory of linear orders is Fraïssé.
 - `FirstOrder.Language.aleph0_categorical_dlo` shows that the theory of dense linear orders is
-  `ℵ₀`-categorical.
+  `ℵ₀`-categorical, and thus complete.
 
 -/
 

--- a/Mathlib/ModelTheory/Order.lean
+++ b/Mathlib/ModelTheory/Order.lean
@@ -82,6 +82,16 @@ instance instSubsingleton : Subsingleton (Language.order.Relations n) :=
 
 instance : IsEmpty (Language.order.Relations 0) := ⟨fun x => by cases x⟩
 
+instance : Unique (Σ n, Language.order.Relations n) :=
+  ⟨⟨⟨2, .le⟩⟩, fun ⟨n, R⟩ =>
+      match n, R with
+      | 2, .le => rfl⟩
+
+instance : Unique Language.order.Symbols := ⟨⟨Sum.inr default⟩, by
+  have : IsEmpty (Σ n, Language.order.Functions n) := isEmpty_sigma.2 inferInstance
+  simp only [Symbols, Sum.forall, reduceCtorEq, Sum.inr.injEq, IsEmpty.forall_iff, true_and]
+  exact Unique.eq_default⟩
+
 end order
 
 /-- A language is ordered if it has a symbol representing `≤`. -/
@@ -509,6 +519,14 @@ theorem aleph0_categorical_dlo : (ℵ₀).Categorical Language.order.dlo := fun 
   obtain ⟨_⟩ := denumerable_iff.2 h₂
   exact (isFraisseLimit_of_countable_nonempty_dlo M₁).nonempty_equiv
     (isFraisseLimit_of_countable_nonempty_dlo M₂)
+
+/-- The theory of dense linear orders is `ℵ₀`-complete. -/
+theorem dlo_isComplete : Language.order.dlo.IsComplete :=
+  aleph0_categorical_dlo.{0}.isComplete ℵ₀ _ le_rfl (by simp [one_le_aleph0])
+    ⟨by
+      letI : Language.order.Structure ℚ := orderStructure ℚ
+      exact Theory.ModelType.of _ ℚ⟩
+    fun M => inferInstance
 
 end Fraisse
 

--- a/Mathlib/ModelTheory/Order.lean
+++ b/Mathlib/ModelTheory/Order.lean
@@ -92,6 +92,9 @@ instance : Unique Language.order.Symbols := ⟨⟨Sum.inr default⟩, by
   simp only [Symbols, Sum.forall, reduceCtorEq, Sum.inr.injEq, IsEmpty.forall_iff, true_and]
   exact Unique.eq_default⟩
 
+@[simp]
+lemma card_eq_one : Language.order.card = 1 := by simp [card]
+
 end order
 
 /-- A language is ordered if it has a symbol representing `≤`. -/

--- a/Mathlib/ModelTheory/Order.lean
+++ b/Mathlib/ModelTheory/Order.lean
@@ -43,6 +43,8 @@ This file defines ordered first-order languages and structures, as well as their
   theory of linear orders.
 - `FirstOrder.Language.isFraisse_finite_linear_order` shows that the class of finite models of the
   theory of linear orders is Fraïssé.
+- `FirstOrder.Language.aleph0_categorical_dlo` shows that the theory of dense linear orders is
+  `ℵ₀`-categorical.
 
 -/
 
@@ -486,7 +488,7 @@ lemma dlo_age [Language.order.Structure M] [Mdlo : M ⊨ Language.order.dlo] [No
 
 /-- Any countable nonempty model of the theory of dense linear orders is a Fraïssé limit of the
 class of finite models of the theory of linear orders. -/
-lemma isFraisseLimit_of_countable_nonempty_dlo (M : Type w)
+theorem isFraisseLimit_of_countable_nonempty_dlo (M : Type w)
     [Language.order.Structure M] [Countable M] [Nonempty M] [M ⊨ Language.order.dlo] :
     IsFraisseLimit {M : CategoryTheory.Bundled.{w} Language.order.Structure |
       Finite M ∧ M ⊨ Language.order.linearOrderTheory} M :=
@@ -498,6 +500,15 @@ theorem isFraisse_finite_linear_order :
       Finite M ∧ M ⊨ Language.order.linearOrderTheory} := by
   letI : Language.order.Structure ℚ := orderStructure _
   exact (isFraisseLimit_of_countable_nonempty_dlo ℚ).isFraisse
+
+open Cardinal
+
+/-- The theory of dense linear orders is `ℵ₀`-categorical. -/
+theorem aleph0_categorical_dlo : (ℵ₀).Categorical Language.order.dlo := fun M₁ M₂ h₁ h₂ => by
+  obtain ⟨_⟩ := denumerable_iff.2 h₁
+  obtain ⟨_⟩ := denumerable_iff.2 h₂
+  exact (isFraisseLimit_of_countable_nonempty_dlo M₁).nonempty_equiv
+    (isFraisseLimit_of_countable_nonempty_dlo M₂)
 
 end Fraisse
 


### PR DESCRIPTION
`FirstOrder.Language.aleph0_categorical_dlo` shows that the theory of dense linear orders is `ℵ₀`-categorical, as a consequence of Fraïssé theory.
As a consequence, it is complete.
To aid in calculations (such as needed for deducing completeness) involving the cardinality of a theory, `FirstOrder.Language.Symbols` is made into an `abbrev`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
