### PR TITLE
[Merged by Bors] - fix(scripts/update_nolints_CI.sh): add missing quote

### DIFF
--- a/scripts/update_nolints_CI.sh
+++ b/scripts/update_nolints_CI.sh
@@ -21,7 +21,7 @@ git rev-parse --verify --quiet "refs/remotes/${remote_name}/${branch_name}" && e
 # Exit if there are no changes relative to master
 git diff-index --quiet "refs/remotes/${remote_name}/master" -- scripts/nolints.json && exit 0
 
-pr_title='chore(scripts): update nolints.json
+pr_title='chore(scripts): update nolints.json'
 pr_body='I am happy to remove some nolints for you!'
 
 git checkout -b "$branch_name"


### PR DESCRIPTION
This was missed in the review of #16417 and has been causing the update nolints job to [fail](https://github.com/leanprover-community/mathlib4/actions/runs/10755388285/job/29827004999#step:12:13).

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
