### PR TITLE
[Merged by Bors] - feat(Order/Interval/Set/Monotone): strictMono_of_pred_lt

### DIFF
--- a/Mathlib/Order/Interval/Set/Monotone.lean
+++ b/Mathlib/Order/Interval/Set/Monotone.lean
@@ -196,7 +196,7 @@ theorem strictAntiOn_Iic_of_succ_lt [SuccOrder α] [IsSuccArchimedean α] {n : �
     (hψ : ∀ m, m < n → ψ (succ m) < ψ m) : StrictAntiOn ψ (Set.Iic n) := fun i hi j hj hij =>
   @strictMonoOn_Iic_of_lt_succ α βᵒᵈ _ _ ψ _ _ n hψ i hi j hj hij
 
-theorem strictAnti_of_pred_lt [SuccOrder α] [IsSuccArchimedean α]
+theorem strictAnti_of_succ_lt [SuccOrder α] [IsSuccArchimedean α]
     (hψ : ∀ m, ψ (succ m) < ψ m) : StrictAnti ψ := fun _ _ h ↦
   (strictAntiOn_Iic_of_succ_lt fun m _ ↦ hψ m) h.le le_rfl h
 
@@ -204,9 +204,17 @@ theorem strictMonoOn_Ici_of_pred_lt [PredOrder α] [IsPredArchimedean α] {n : �
     (hψ : ∀ m, n < m → ψ (pred m) < ψ m) : StrictMonoOn ψ (Set.Ici n) := fun i hi j hj hij =>
   @strictMonoOn_Iic_of_lt_succ αᵒᵈ βᵒᵈ _ _ ψ _ _ n hψ j hj i hi hij
 
+theorem strictMono_of_pred_lt [PredOrder α] [IsPredArchimedean α]
+    (hψ : ∀ m, ψ (pred m) < ψ m) : StrictMono ψ := fun _ _ h ↦
+  (strictMonoOn_Ici_of_pred_lt fun m _ ↦ hψ m) le_rfl h.le h
+
 theorem strictAntiOn_Ici_of_lt_pred [PredOrder α] [IsPredArchimedean α] {n : α}
     (hψ : ∀ m, n < m → ψ m < ψ (pred m)) : StrictAntiOn ψ (Set.Ici n) := fun i hi j hj hij =>
   @strictAntiOn_Iic_of_succ_lt αᵒᵈ βᵒᵈ _ _ ψ _ _ n hψ j hj i hi hij
+
+theorem strictAnti_of_lt_pred [PredOrder α] [IsPredArchimedean α]
+    (hψ : ∀ m, ψ m < ψ (pred m)) : StrictAnti ψ := fun _ _ h ↦
+  (strictAntiOn_Ici_of_lt_pred fun m _ ↦ hψ m) le_rfl h.le h
 
 end SuccOrder
 


### PR DESCRIPTION
Add `strictMono_of_pred_lt` and `strictAnti_of_lt_pred`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

Also fix a name from #16732. Do we have to deprecate the old one if it's been 12 hours?

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
