### PR TITLE
[Merged by Bors] - refactor(Mathlib/CategoryTheory/Monoidal/Transport): remove `simps` at `transport`

### DIFF
--- a/Mathlib/Algebra/Category/CoalgebraCat/ComonEquivalence.lean
+++ b/Mathlib/Algebra/Category/CoalgebraCat/ComonEquivalence.lean
@@ -116,9 +116,10 @@ theorem tensorObj_comul (K L : CoalgebraCat R) :
       = (TensorProduct.tensorTensorTensorComm R K K L L).toLinearMap
       ∘ₗ TensorProduct.map Coalgebra.comul Coalgebra.comul := by
   rw [ofComonObjCoalgebraStruct_comul]
-  dsimp [ModuleCat.ofHom, -Mon_.monMonoidalStruct_tensorObj_X,
-    instMonoidalCategoryStruct_tensorHom, ModuleCat.comp_def]
-  simp only [BraidedCategory.unop_tensor_μ, tensor_μ_eq_tensorTensorTensorComm]
+  dsimp only [Equivalence.symm_inverse, comonEquivalence_functor, toComon_obj]
+  simp only [Comon_.monoidal_tensorObj_comul, toComonObj_X, ModuleCat.of_coe, toComonObj_comul,
+    tensor_μ_eq_tensorTensorTensorComm]
+  rfl
 
 theorem tensorHom_toLinearMap (f : M →ₗc[R] N) (g : P →ₗc[R] Q) :
     (CoalgebraCat.ofHom f ⊗ CoalgebraCat.ofHom g).1.toLinearMap
@@ -143,22 +144,26 @@ theorem comul_tensorObj :
     Coalgebra.comul (R := R) (A := (CoalgebraCat.of R M ⊗ CoalgebraCat.of R N : CoalgebraCat R))
       = Coalgebra.comul (A := M ⊗[R] N) := by
   rw [ofComonObjCoalgebraStruct_comul]
-  dsimp [- Mon_.monMonoidalStruct_tensorObj_X, instMonoidalCategoryStruct_tensorHom,
-    ModuleCat.comp_def, ModuleCat.ofHom, ModuleCat.of]
-  simp only [BraidedCategory.unop_tensor_μ, tensor_μ_eq_tensorTensorTensorComm]
+  dsimp only [Equivalence.symm_inverse, comonEquivalence_functor, toComon_obj,
+    instCoalgebraStruct_comul]
+  simp only [Comon_.monoidal_tensorObj_comul, toComonObj_X, of_carrier, of_isAddCommGroup,
+    of_isModule, toComonObj_comul, of_instCoalgebra, tensor_μ_eq_tensorTensorTensorComm]
+  rfl
 
 theorem comul_tensorObj_tensorObj_right :
     Coalgebra.comul (R := R) (A := (CoalgebraCat.of R M ⊗
       (CoalgebraCat.of R N ⊗ CoalgebraCat.of R P) : CoalgebraCat R))
       = Coalgebra.comul (A := M ⊗[R] N ⊗[R] P) := by
   rw [ofComonObjCoalgebraStruct_comul]
-  dsimp [- Mon_.monMonoidalStruct_tensorObj_X, instMonoidalCategoryStruct_tensorHom,
-    ModuleCat.comp_def, ModuleCat.ofHom, ModuleCat.of]
+  dsimp only [Equivalence.symm_inverse, comonEquivalence_functor, toComon_obj,
+    instCoalgebraStruct_comul]
+  simp only [Comon_.monoidal_tensorObj_comul, toComonObj_X, of_carrier, of_isAddCommGroup,
+    of_isModule, ModuleCat.of_coe, toComonObj_comul, of_instCoalgebra]
   rw [ofComonObjCoalgebraStruct_comul]
-  dsimp [- Mon_.monMonoidalStruct_tensorObj_X, instMonoidalCategoryStruct_tensorHom,
-    ModuleCat.comp_def, ModuleCat.ofHom, ModuleCat.of]
+  dsimp only [Equivalence.symm_inverse, comonEquivalence_functor, toComon_obj]
   simp only [instMonoidalCategoryStruct_tensorObj, ModuleCat.MonoidalCategory.tensorObj,
-    ModuleCat.coe_of, BraidedCategory.unop_tensor_μ, tensor_μ_eq_tensorTensorTensorComm]
+    ModuleCat.coe_of, Comon_.monoidal_tensorObj_comul, toComonObj_X, of_carrier, of_isAddCommGroup,
+    of_isModule, toComonObj_comul, of_instCoalgebra, tensor_μ_eq_tensorTensorTensorComm]
   rfl
 
 theorem comul_tensorObj_tensorObj_left :
@@ -166,13 +171,15 @@ theorem comul_tensorObj_tensorObj_left :
       (A := ((CoalgebraCat.of R M ⊗ CoalgebraCat.of R N) ⊗ CoalgebraCat.of R P : CoalgebraCat R))
       = Coalgebra.comul (A := (M ⊗[R] N) ⊗[R] P) := by
   rw [ofComonObjCoalgebraStruct_comul]
-  dsimp [- Mon_.monMonoidalStruct_tensorObj_X, instMonoidalCategoryStruct_tensorHom,
-    ModuleCat.comp_def, ModuleCat.ofHom, ModuleCat.of]
+  dsimp only [Equivalence.symm_inverse, comonEquivalence_functor, toComon_obj,
+    instCoalgebraStruct_comul]
+  simp only [Comon_.monoidal_tensorObj_comul, toComonObj_X, ModuleCat.of_coe, of_carrier,
+    of_isAddCommGroup, of_isModule, toComonObj_comul, of_instCoalgebra]
   rw [ofComonObjCoalgebraStruct_comul]
-  dsimp [- Mon_.monMonoidalStruct_tensorObj_X, instMonoidalCategoryStruct_tensorHom,
-    ModuleCat.comp_def, ModuleCat.ofHom, ModuleCat.of]
+  dsimp only [Equivalence.symm_inverse, comonEquivalence_functor, toComon_obj]
   simp only [instMonoidalCategoryStruct_tensorObj, ModuleCat.MonoidalCategory.tensorObj,
-    ModuleCat.coe_of, BraidedCategory.unop_tensor_μ, tensor_μ_eq_tensorTensorTensorComm]
+    ModuleCat.coe_of, Comon_.monoidal_tensorObj_comul, toComonObj_X, of_carrier, of_isAddCommGroup,
+    of_isModule, toComonObj_comul, of_instCoalgebra, tensor_μ_eq_tensorTensorTensorComm]
   rfl
 
 theorem counit_tensorObj :

--- a/Mathlib/CategoryTheory/Monoidal/Comon_.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Comon_.lean
@@ -253,6 +253,36 @@ theorem tensorObj_X (A B : Comon_ C) : (A ⊗ B).X = A.X ⊗ B.X := rfl
 theorem tensorObj_counit (A B : Comon_ C) : (A ⊗ B).counit = (A.counit ⊗ B.counit) ≫ (λ_ _).hom :=
   rfl
 
+@[simp]
+theorem associator_hom (A B C : Comon_ C) : (α_ A B C).hom.hom = (α_ A.X B.X C.X).hom := by
+  dsimp [Monoidal.transportStruct_associator]
+  simp
+
+@[simp]
+theorem associator_inv (A B C : Comon_ C) : (α_ A B C).inv.hom = (α_ A.X B.X C.X).inv := by
+  dsimp [Monoidal.transportStruct_associator]
+  simp
+
+@[simp]
+theorem leftUnitor_hom (A : Comon_ C) : (λ_ A).hom.hom = (λ_ A.X).hom := by
+  dsimp [Monoidal.transportStruct_leftUnitor]
+  simp
+
+@[simp]
+theorem leftUnitor_inv (A : Comon_ C) : (λ_ A).inv.hom = (λ_ A.X).inv := by
+  dsimp [Monoidal.transportStruct_leftUnitor]
+  simp
+
+@[simp]
+theorem rightUnitor_hom (A : Comon_ C) : (ρ_ A).hom.hom = (ρ_ A.X).hom := by
+  dsimp [Monoidal.transportStruct_rightUnitor]
+  simp
+
+@[simp]
+theorem rightUnitor_inv (A : Comon_ C) : (ρ_ A).inv.hom = (ρ_ A.X).inv := by
+  dsimp [Monoidal.transportStruct_rightUnitor]
+  simp
+
 /--
 Preliminary statement of the comultiplication for a tensor product of comonoids.
 This version is the definitional equality provided by transport, and not quite as good as

--- a/Mathlib/CategoryTheory/Monoidal/Comon_.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Comon_.lean
@@ -243,7 +243,8 @@ Comonoid objects in a braided category form a monoidal category.
 
 This definition is via transporting back and forth to monoids in the opposite category,
 -/
-instance [BraidedCategory C] : MonoidalCategory (Comon_ C) :=
+@[simps!]
+instance monoidal [BraidedCategory C] : MonoidalCategory (Comon_ C) :=
   Monoidal.transport (Comon_EquivMon_OpOp C).symm
 
 variable [BraidedCategory C]
@@ -252,36 +253,6 @@ theorem tensorObj_X (A B : Comon_ C) : (A ⊗ B).X = A.X ⊗ B.X := rfl
 
 theorem tensorObj_counit (A B : Comon_ C) : (A ⊗ B).counit = (A.counit ⊗ B.counit) ≫ (λ_ _).hom :=
   rfl
-
-@[simp]
-theorem associator_hom (A B C : Comon_ C) : (α_ A B C).hom.hom = (α_ A.X B.X C.X).hom := by
-  dsimp [Monoidal.transportStruct_associator]
-  simp
-
-@[simp]
-theorem associator_inv (A B C : Comon_ C) : (α_ A B C).inv.hom = (α_ A.X B.X C.X).inv := by
-  dsimp [Monoidal.transportStruct_associator]
-  simp
-
-@[simp]
-theorem leftUnitor_hom (A : Comon_ C) : (λ_ A).hom.hom = (λ_ A.X).hom := by
-  dsimp [Monoidal.transportStruct_leftUnitor]
-  simp
-
-@[simp]
-theorem leftUnitor_inv (A : Comon_ C) : (λ_ A).inv.hom = (λ_ A.X).inv := by
-  dsimp [Monoidal.transportStruct_leftUnitor]
-  simp
-
-@[simp]
-theorem rightUnitor_hom (A : Comon_ C) : (ρ_ A).hom.hom = (ρ_ A.X).hom := by
-  dsimp [Monoidal.transportStruct_rightUnitor]
-  simp
-
-@[simp]
-theorem rightUnitor_inv (A : Comon_ C) : (ρ_ A).inv.hom = (ρ_ A.X).inv := by
-  dsimp [Monoidal.transportStruct_rightUnitor]
-  simp
 
 /--
 Preliminary statement of the comultiplication for a tensor product of comonoids.

--- a/Mathlib/CategoryTheory/Monoidal/Transport.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Transport.lean
@@ -135,7 +135,7 @@ def fromInduced [MonoidalCategoryStruct D] (F : D ⥤ C) [F.Faithful]
 
 /-- Transport a monoidal structure along an equivalence of (plain) categories.
 -/
-@[simps (config := {isSimp := false})]
+@[simps (config := .lemmasOnly)]
 def transportStruct (e : C ≌ D) : MonoidalCategoryStruct.{v₂} D where
   tensorObj X Y := e.functor.obj (e.inverse.obj X ⊗ e.inverse.obj Y)
   whiskerLeft X _ _ f := e.functor.map (e.inverse.obj X ◁ e.inverse.map f)

--- a/Mathlib/CategoryTheory/Monoidal/Transport.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Transport.lean
@@ -87,7 +87,7 @@ The functor `F` must preserve all the data parts of the monoidal structure betwe
 categories.
 
 -/
-abbrev induced [MonoidalCategoryStruct D] (F : D ⥤ C) [F.Faithful]
+def induced [MonoidalCategoryStruct D] (F : D ⥤ C) [F.Faithful]
     (fData : InducingFunctorData F) :
     MonoidalCategory.{v₂} D where
   tensorHom_def {X₁ Y₁ X₂ Y₂} f g := F.map_injective <| by
@@ -135,7 +135,7 @@ def fromInduced [MonoidalCategoryStruct D] (F : D ⥤ C) [F.Faithful]
 
 /-- Transport a monoidal structure along an equivalence of (plain) categories.
 -/
-@[simps]
+@[simps tensorObj whiskerLeft whiskerRight tensorHom tensorUnit]
 def transportStruct (e : C ≌ D) : MonoidalCategoryStruct.{v₂} D where
   tensorObj X Y := e.functor.obj (e.inverse.obj X ⊗ e.inverse.obj Y)
   whiskerLeft X _ _ f := e.functor.map (e.inverse.obj X ◁ e.inverse.map f)
@@ -144,16 +144,22 @@ def transportStruct (e : C ≌ D) : MonoidalCategoryStruct.{v₂} D where
   tensorUnit := e.functor.obj (𝟙_ C)
   associator X Y Z :=
     e.functor.mapIso
-      (((e.unitIso.app _).symm ⊗ Iso.refl _) ≪≫
+      (whiskerRightIso (e.unitIso.app _).symm (e.inverse.obj Z) ≪≫
         α_ (e.inverse.obj X) (e.inverse.obj Y) (e.inverse.obj Z) ≪≫
-        (Iso.refl _ ⊗ e.unitIso.app _))
+        whiskerLeftIso (e.inverse.obj X) (e.unitIso.app _))
   leftUnitor X :=
-    e.functor.mapIso (((e.unitIso.app _).symm ⊗ Iso.refl _) ≪≫ λ_ (e.inverse.obj X)) ≪≫
+    e.functor.mapIso ((whiskerRightIso (e.unitIso.app _).symm _) ≪≫ λ_ (e.inverse.obj X)) ≪≫
       e.counitIso.app _
   rightUnitor X :=
-    e.functor.mapIso ((Iso.refl _ ⊗ (e.unitIso.app _).symm) ≪≫ ρ_ (e.inverse.obj X)) ≪≫
+    e.functor.mapIso ((whiskerLeftIso _ (e.unitIso.app _).symm) ≪≫ ρ_ (e.inverse.obj X)) ≪≫
       e.counitIso.app _
 
+attribute [simps (config := {isSimp := false}) associator leftUnitor rightUnitor] transportStruct
+
+attribute [local simp]
+  transportStruct_associator
+  transportStruct_leftUnitor
+  transportStruct_rightUnitor in
 /-- Transport a monoidal structure along an equivalence of (plain) categories.
 -/
 def transport (e : C ≌ D) : MonoidalCategory.{v₂} D :=

--- a/Mathlib/CategoryTheory/Monoidal/Transport.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Transport.lean
@@ -144,9 +144,9 @@ def transportStruct (e : C ≌ D) : MonoidalCategoryStruct.{v₂} D where
   tensorUnit := e.functor.obj (𝟙_ C)
   associator X Y Z :=
     e.functor.mapIso
-      (whiskerRightIso (e.unitIso.app _).symm (e.inverse.obj Z) ≪≫
+      (whiskerRightIso (e.unitIso.app _).symm _ ≪≫
         α_ (e.inverse.obj X) (e.inverse.obj Y) (e.inverse.obj Z) ≪≫
-        whiskerLeftIso (e.inverse.obj X) (e.unitIso.app _))
+        whiskerLeftIso _ (e.unitIso.app _))
   leftUnitor X :=
     e.functor.mapIso ((whiskerRightIso (e.unitIso.app _).symm _) ≪≫ λ_ (e.inverse.obj X)) ≪≫
       e.counitIso.app _

--- a/Mathlib/CategoryTheory/Monoidal/Transport.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Transport.lean
@@ -135,7 +135,7 @@ def fromInduced [MonoidalCategoryStruct D] (F : D ⥤ C) [F.Faithful]
 
 /-- Transport a monoidal structure along an equivalence of (plain) categories.
 -/
-@[simps tensorObj whiskerLeft whiskerRight tensorHom tensorUnit]
+@[simps (config := {isSimp := false})]
 def transportStruct (e : C ≌ D) : MonoidalCategoryStruct.{v₂} D where
   tensorObj X Y := e.functor.obj (e.inverse.obj X ⊗ e.inverse.obj Y)
   whiskerLeft X _ _ f := e.functor.map (e.inverse.obj X ◁ e.inverse.map f)
@@ -154,12 +154,7 @@ def transportStruct (e : C ≌ D) : MonoidalCategoryStruct.{v₂} D where
     e.functor.mapIso ((whiskerLeftIso _ (e.unitIso.app _).symm) ≪≫ ρ_ (e.inverse.obj X)) ≪≫
       e.counitIso.app _
 
-attribute [simps (config := {isSimp := false}) associator leftUnitor rightUnitor] transportStruct
-
-attribute [local simp]
-  transportStruct_associator
-  transportStruct_leftUnitor
-  transportStruct_rightUnitor in
+attribute [local simp] transportStruct in
 /-- Transport a monoidal structure along an equivalence of (plain) categories.
 -/
 def transport (e : C ≌ D) : MonoidalCategory.{v₂} D :=

--- a/Mathlib/RepresentationTheory/Action/Monoidal.lean
+++ b/Mathlib/RepresentationTheory/Action/Monoidal.lean
@@ -39,6 +39,7 @@ variable [MonoidalCategory V]
 instance instMonoidalCategory : MonoidalCategory (Action V G) :=
   Monoidal.transport (Action.functorCategoryEquivalence _ _).symm
 
+/- Adding this solves `simpNF` linter report at `tensorUnit_ρ` -/
 @[simp]
 theorem tensorUnit_ρ' {g : G} :
     @DFunLike.coe (G →* MonCat.of (End (𝟙_ V))) _ _ _ (𝟙_ (Action V G)).ρ g = 𝟙 (𝟙_ V) := by
@@ -48,6 +49,7 @@ theorem tensorUnit_ρ' {g : G} :
 theorem tensorUnit_ρ {g : G} : (𝟙_ (Action V G)).ρ g = 𝟙 (𝟙_ V) :=
   rfl
 
+/- Adding this solves `simpNF` linter report at `tensor_ρ` -/
 @[simp]
 theorem tensor_ρ' {X Y : Action V G} {g : G} :
     @DFunLike.coe (G →* MonCat.of (End (X.V ⊗ Y.V))) _ _ _ (X ⊗ Y).ρ g = X.ρ g ⊗ Y.ρ g :=
@@ -239,7 +241,7 @@ noncomputable def leftRegularTensorIso (G : Type u) [Group G] (X : Action (Type 
       comm := fun (g : G) => by
         funext ⟨(x₁ : G), (x₂ : X.V)⟩
         refine Prod.ext rfl ?_
-        erw [tensor_rho, tensor_rho]
+        rw [tensor_ρ, tensor_ρ]
         dsimp
         -- This used to be `rw`, but we need `erw` after leanprover/lean4#2644
         erw [leftRegular_ρ_apply]

--- a/Mathlib/RepresentationTheory/Action/Monoidal.lean
+++ b/Mathlib/RepresentationTheory/Action/Monoidal.lean
@@ -40,21 +40,21 @@ instance instMonoidalCategory : MonoidalCategory (Action V G) :=
   Monoidal.transport (Action.functorCategoryEquivalence _ _).symm
 
 @[simp]
-theorem tensorUnit_rho' {g : G} :
+theorem tensorUnit_ρ' {g : G} :
     @DFunLike.coe (G →* MonCat.of (End (𝟙_ V))) _ _ _ (𝟙_ (Action V G)).ρ g = 𝟙 (𝟙_ V) := by
   rfl
 
 @[simp]
-theorem tensorUnit_rho {g : G} : (𝟙_ (Action V G)).ρ g = 𝟙 (𝟙_ V) :=
+theorem tensorUnit_ρ {g : G} : (𝟙_ (Action V G)).ρ g = 𝟙 (𝟙_ V) :=
   rfl
 
 @[simp]
-theorem tensor_rho' {X Y : Action V G} {g : G} :
+theorem tensor_ρ' {X Y : Action V G} {g : G} :
     @DFunLike.coe (G →* MonCat.of (End (X.V ⊗ Y.V))) _ _ _ (X ⊗ Y).ρ g = X.ρ g ⊗ Y.ρ g :=
   rfl
 
 @[simp]
-theorem tensor_rho {X Y : Action V G} {g : G} : (X ⊗ Y).ρ g = X.ρ g ⊗ Y.ρ g :=
+theorem tensor_ρ {X Y : Action V G} {g : G} : (X ⊗ Y).ρ g = X.ρ g ⊗ Y.ρ g :=
   rfl
 
 /-- Given an object `X` isomorphic to the tensor unit of `V`, `X` equipped with the trivial action

--- a/Mathlib/RepresentationTheory/Action/Monoidal.lean
+++ b/Mathlib/RepresentationTheory/Action/Monoidal.lean
@@ -33,77 +33,36 @@ open MonoidalCategory
 
 variable [MonoidalCategory V]
 
+@[simps! tensorUnit_V tensorObj_V tensorHom_hom whiskerLeft_hom whiskerRight_hom
+  associator_hom_hom associator_inv_hom leftUnitor_hom_hom leftUnitor_inv_hom
+  rightUnitor_hom_hom rightUnitor_inv_hom]
 instance instMonoidalCategory : MonoidalCategory (Action V G) :=
   Monoidal.transport (Action.functorCategoryEquivalence _ _).symm
 
 @[simp]
-theorem tensorUnit_v : (𝟙_ (Action V G)).V = 𝟙_ V :=
-  rfl
-
--- Porting note: removed @[simp] as the simpNF linter complains
-theorem tensorUnit_rho {g : G} : (𝟙_ (Action V G)).ρ g = 𝟙 (𝟙_ V) :=
+theorem tensorUnit_rho' {g : G} :
+    @DFunLike.coe (G →* MonCat.of (End (𝟙_ V))) _ _ _ (𝟙_ (Action V G)).ρ g = 𝟙 (𝟙_ V) := by
   rfl
 
 @[simp]
-theorem tensor_v {X Y : Action V G} : (X ⊗ Y).V = X.V ⊗ Y.V :=
-  rfl
-
--- Porting note: removed @[simp] as the simpNF linter complains
-theorem tensor_rho {X Y : Action V G} {g : G} : (X ⊗ Y).ρ g = X.ρ g ⊗ Y.ρ g :=
+theorem tensorUnit_rho {g : G} :
+    (𝟙_ (Action V G)).ρ g = 𝟙 (𝟙_ V) := by
   rfl
 
 @[simp]
-theorem tensor_hom {W X Y Z : Action V G} (f : W ⟶ X) (g : Y ⟶ Z) : (f ⊗ g).hom = f.hom ⊗ g.hom :=
+theorem tensor_rho' {X Y : Action V G} {g : G} :
+    @DFunLike.coe (G →* MonCat.of (End (X.V ⊗ Y.V))) _ _ _ (X ⊗ Y).ρ g = X.ρ g ⊗ Y.ρ g :=
   rfl
 
 @[simp]
-theorem whiskerLeft_hom (X : Action V G) {Y Z : Action V G} (f : Y ⟶ Z) :
-    (X ◁ f).hom = X.V ◁ f.hom :=
+theorem tensor_rho {X Y : Action V G} {g : G} :
+    (X ⊗ Y).ρ g = X.ρ g ⊗ Y.ρ g :=
   rfl
-
-@[simp]
-theorem whiskerRight_hom {X Y : Action V G} (f : X ⟶ Y) (Z : Action V G) :
-    (f ▷ Z).hom = f.hom ▷ Z.V :=
-  rfl
-
-@[simp]
-theorem associator_hom_hom {X Y Z : Action V G} :
-    Hom.hom (α_ X Y Z).hom = (α_ X.V Y.V Z.V).hom := by
-  dsimp [Monoidal.transportStruct_associator]
-  simp
-
-@[simp]
-theorem associator_inv_hom {X Y Z : Action V G} :
-    Hom.hom (α_ X Y Z).inv = (α_ X.V Y.V Z.V).inv := by
-  dsimp [Monoidal.transportStruct_associator]
-  simp
-
-@[simp]
-theorem leftUnitor_hom_hom {X : Action V G} : Hom.hom (λ_ X).hom = (λ_ X.V).hom := by
-  dsimp [Monoidal.transportStruct_leftUnitor]
-  simp
-
-@[simp]
-theorem leftUnitor_inv_hom {X : Action V G} : Hom.hom (λ_ X).inv = (λ_ X.V).inv := by
-  dsimp [Monoidal.transportStruct_leftUnitor]
-  simp
-
-@[simp]
-theorem rightUnitor_hom_hom {X : Action V G} : Hom.hom (ρ_ X).hom = (ρ_ X.V).hom := by
-  dsimp [Monoidal.transportStruct_rightUnitor]
-  simp
-
-@[simp]
-theorem rightUnitor_inv_hom {X : Action V G} : Hom.hom (ρ_ X).inv = (ρ_ X.V).inv := by
-  dsimp [Monoidal.transportStruct_rightUnitor]
-  simp
 
 /-- Given an object `X` isomorphic to the tensor unit of `V`, `X` equipped with the trivial action
 is isomorphic to the tensor unit of `Action V G`. -/
 def tensorUnitIso {X : V} (f : 𝟙_ V ≅ X) : 𝟙_ (Action V G) ≅ Action.mk X 1 :=
-  Action.mkIso f fun _ => by
-    simp only [MonoidHom.one_apply, End.one_def, Category.id_comp f.hom, tensorUnit_rho,
-      MonCat.oneHom_apply, MonCat.one_of, Category.comp_id]
+  Action.mkIso f
 
 variable (V G)
 

--- a/Mathlib/RepresentationTheory/Action/Monoidal.lean
+++ b/Mathlib/RepresentationTheory/Action/Monoidal.lean
@@ -45,8 +45,7 @@ theorem tensorUnit_rho' {g : G} :
   rfl
 
 @[simp]
-theorem tensorUnit_rho {g : G} :
-    (𝟙_ (Action V G)).ρ g = 𝟙 (𝟙_ V) := by
+theorem tensorUnit_rho {g : G} : (𝟙_ (Action V G)).ρ g = 𝟙 (𝟙_ V) :=
   rfl
 
 @[simp]
@@ -54,9 +53,7 @@ theorem tensor_rho' {X Y : Action V G} {g : G} :
     @DFunLike.coe (G →* MonCat.of (End (X.V ⊗ Y.V))) _ _ _ (X ⊗ Y).ρ g = X.ρ g ⊗ Y.ρ g :=
   rfl
 
-@[simp]
-theorem tensor_rho {X Y : Action V G} {g : G} :
-    (X ⊗ Y).ρ g = X.ρ g ⊗ Y.ρ g :=
+theorem tensor_rho {X Y : Action V G} {g : G} : (X ⊗ Y).ρ g = X.ρ g ⊗ Y.ρ g :=
   rfl
 
 /-- Given an object `X` isomorphic to the tensor unit of `V`, `X` equipped with the trivial action

--- a/Mathlib/RepresentationTheory/Action/Monoidal.lean
+++ b/Mathlib/RepresentationTheory/Action/Monoidal.lean
@@ -66,36 +66,36 @@ theorem whiskerRight_hom {X Y : Action V G} (f : X ⟶ Y) (Z : Action V G) :
     (f ▷ Z).hom = f.hom ▷ Z.V :=
   rfl
 
--- Porting note: removed @[simp] as the simpNF linter complains
+@[simp]
 theorem associator_hom_hom {X Y Z : Action V G} :
     Hom.hom (α_ X Y Z).hom = (α_ X.V Y.V Z.V).hom := by
-  dsimp
+  dsimp [Monoidal.transportStruct_associator]
   simp
 
--- Porting note: removed @[simp] as the simpNF linter complains
+@[simp]
 theorem associator_inv_hom {X Y Z : Action V G} :
     Hom.hom (α_ X Y Z).inv = (α_ X.V Y.V Z.V).inv := by
-  dsimp
+  dsimp [Monoidal.transportStruct_associator]
   simp
 
--- Porting note: removed @[simp] as the simpNF linter complains
+@[simp]
 theorem leftUnitor_hom_hom {X : Action V G} : Hom.hom (λ_ X).hom = (λ_ X.V).hom := by
-  dsimp
+  dsimp [Monoidal.transportStruct_leftUnitor]
   simp
 
--- Porting note: removed @[simp] as the simpNF linter complains
+@[simp]
 theorem leftUnitor_inv_hom {X : Action V G} : Hom.hom (λ_ X).inv = (λ_ X.V).inv := by
-  dsimp
+  dsimp [Monoidal.transportStruct_leftUnitor]
   simp
 
--- Porting note: removed @[simp] as the simpNF linter complains
+@[simp]
 theorem rightUnitor_hom_hom {X : Action V G} : Hom.hom (ρ_ X).hom = (ρ_ X.V).hom := by
-  dsimp
+  dsimp [Monoidal.transportStruct_rightUnitor]
   simp
 
--- Porting note: removed @[simp] as the simpNF linter complains
+@[simp]
 theorem rightUnitor_inv_hom {X : Action V G} : Hom.hom (ρ_ X).inv = (ρ_ X.V).inv := by
-  dsimp
+  dsimp [Monoidal.transportStruct_rightUnitor]
   simp
 
 /-- Given an object `X` isomorphic to the tensor unit of `V`, `X` equipped with the trivial action

--- a/Mathlib/RepresentationTheory/Action/Monoidal.lean
+++ b/Mathlib/RepresentationTheory/Action/Monoidal.lean
@@ -53,6 +53,7 @@ theorem tensor_rho' {X Y : Action V G} {g : G} :
     @DFunLike.coe (G →* MonCat.of (End (X.V ⊗ Y.V))) _ _ _ (X ⊗ Y).ρ g = X.ρ g ⊗ Y.ρ g :=
   rfl
 
+@[simp]
 theorem tensor_rho {X Y : Action V G} {g : G} : (X ⊗ Y).ρ g = X.ρ g ⊗ Y.ρ g :=
   rfl
 

--- a/Mathlib/RepresentationTheory/Character.lean
+++ b/Mathlib/RepresentationTheory/Character.lean
@@ -55,16 +55,9 @@ theorem char_one (V : FDRep k G) : V.character 1 = FiniteDimensional.finrank k V
   simp only [character, map_one, trace_one]
 
 /-- The character is multiplicative under the tensor product. -/
+@[simp]
 theorem char_tensor (V W : FDRep k G) : (V ⊗ W).character = V.character * W.character := by
   ext g; convert trace_tensorProduct' (V.ρ g) (W.ρ g)
-
--- Porting note: adding variant of `char_tensor` to make the simp-set confluent
-@[simp]
-theorem char_tensor' (V W : FDRep k G) :
-    character (Action.FunctorCategoryEquivalence.inverse.obj
-    (Action.FunctorCategoryEquivalence.functor.obj V ⊗
-     Action.FunctorCategoryEquivalence.functor.obj W)) = V.character * W.character := by
-  simp [← char_tensor]
 
 /-- The character of isomorphic representations is the same. -/
 theorem char_iso {V W : FDRep k G} (i : V ≅ W) : V.character = W.character := by

--- a/Mathlib/RepresentationTheory/GroupCohomology/Resolution.lean
+++ b/Mathlib/RepresentationTheory/GroupCohomology/Resolution.lean
@@ -136,7 +136,7 @@ theorem actionDiagonalSucc_inv_apply {G : Type u} [Group G] {n : ℕ} (g : G) (f
     dsimp only [actionDiagonalSucc]
     simp only [Iso.trans_inv, comp_hom, hn, diagonalSucc_inv_hom, types_comp_apply, tensorIso_inv,
       Iso.refl_inv, Action.tensorHom, id_hom, tensor_apply, types_id_apply,
-      leftRegularTensorIso_inv_hom, tensor_rho, leftRegular_ρ_apply, Pi.smul_apply, smul_eq_mul]
+      leftRegularTensorIso_inv_hom, tensor_ρ, leftRegular_ρ_apply, Pi.smul_apply, smul_eq_mul]
     refine' Fin.cases _ _ x
     · simp only [Fin.cons_zero, Fin.partialProd_zero, mul_one]
     · intro i

--- a/Mathlib/RepresentationTheory/Rep.lean
+++ b/Mathlib/RepresentationTheory/Rep.lean
@@ -361,7 +361,7 @@ def homEquiv (A B C : Rep k G) : (A ⊗ B ⟶ C) ≃ (B ⟶ (Rep.ihom A).obj C) 
       comm := fun g => TensorProduct.ext' fun x y => by
 /- Porting note: rest of broken proof was
         dsimp only [MonoidalCategory.tensorLeft_obj, ModuleCat.comp_def, LinearMap.comp_apply,
-          tensor_rho, ModuleCat.MonoidalCategory.hom_apply, TensorProduct.map_tmul]
+          tensor_ρ, ModuleCat.MonoidalCategory.hom_apply, TensorProduct.map_tmul]
         simp only [TensorProduct.uncurry_apply f.hom.flip, LinearMap.flip_apply, Action_ρ_eq_ρ,
           hom_comm_apply f g y, Rep.ihom_obj_ρ_apply, LinearMap.comp_apply, ρ_inv_self_apply] -/
         change TensorProduct.uncurry k _ _ _ f.hom.flip (A.ρ g x ⊗ₜ[k] B.ρ g y) =


### PR DESCRIPTION
We get better simp normal forms not by unfolding `transport` but instead putting `simps!` at the definition that uses `transport`. The compiling time is also improved.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
