### PR TITLE
[Merged by Bors] - chore: split `linear_combination`

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -4228,6 +4228,7 @@ import Mathlib.Tactic.Linarith.Preprocessing
 import Mathlib.Tactic.Linarith.Verification
 import Mathlib.Tactic.LinearCombination
 import Mathlib.Tactic.LinearCombination'
+import Mathlib.Tactic.LinearCombination.Lemmas
 import Mathlib.Tactic.Linter
 import Mathlib.Tactic.Linter.AdmitLinter
 import Mathlib.Tactic.Linter.FlexibleLinter

--- a/Mathlib/Tactic.lean
+++ b/Mathlib/Tactic.lean
@@ -119,6 +119,7 @@ import Mathlib.Tactic.Linarith.Preprocessing
 import Mathlib.Tactic.Linarith.Verification
 import Mathlib.Tactic.LinearCombination
 import Mathlib.Tactic.LinearCombination'
+import Mathlib.Tactic.LinearCombination.Lemmas
 import Mathlib.Tactic.Linter
 import Mathlib.Tactic.Linter.AdmitLinter
 import Mathlib.Tactic.Linter.FlexibleLinter

--- a/Mathlib/Tactic/LinearCombination.lean
+++ b/Mathlib/Tactic/LinearCombination.lean
@@ -3,6 +3,7 @@ Copyright (c) 2022 Abby J. Goldberg. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Abby J. Goldberg, Mario Carneiro
 -/
+import Mathlib.Tactic.LinearCombination.Lemmas
 import Mathlib.Tactic.Ring
 
 /-!
@@ -32,13 +33,6 @@ Lastly, calls a normalization tactic on this target.
 namespace Mathlib.Tactic.LinearCombination
 open Lean hiding Rat
 open Elab Meta Term
-
-variable {α : Type*} {a a' a₁ a₂ b b' b₁ b₂ c : α}
-
-theorem add_pf [Add α] (p₁ : (a₁:α) = b₁) (p₂ : a₂ = b₂) : a₁ + a₂ = b₁ + b₂ := p₁ ▸ p₂ ▸ rfl
-theorem pf_mul_c [Mul α] (p : a = b) (c : α) : a * c = b * c := p ▸ rfl
-theorem c_mul_pf [Mul α] (p : b = c) (a : α) : a * b = a * c := p ▸ rfl
-theorem pf_div_c [Div α] (p : a = b) (c : α) : a / c = b / c := p ▸ rfl
 
 /-- Result of `expandLinearCombo`, either an equality proof or a value. -/
 inductive Expanded
@@ -105,17 +99,6 @@ partial def expandLinearCombo (ty : Expr) (stx : Syntax.Term) : TermElabM Expand
         .proof <$> c.toSyntax
       else
         .const <$> c.toSyntax
-
-theorem eq_of_sub [AddGroup α] (p : (a:α) = b) (H : (a' - b') - (a - b) = 0) : a' = b' := by
-  rw [← sub_eq_zero] at p ⊢; rwa [sub_eq_zero, p] at H
-
-theorem eq_of_add [Add α] [IsRightCancelAdd α] (p : (a:α) = b) (H : a' + b = b' + a) : a' = b' := by
-  rw [p] at H
-  exact add_right_cancel H
-
-theorem eq_of_add_pow [Ring α] [NoZeroDivisors α] (n : ℕ) (p : (a:α) = b)
-    (H : (a' - b')^n - (a - b) = 0) : a' = b' := by
-  rw [← sub_eq_zero] at p ⊢; apply pow_eq_zero (n := n); rwa [sub_eq_zero, p] at H
 
 /-- Implementation of `linear_combination`. -/
 def elabLinearCombination (tk : Syntax)

--- a/Mathlib/Tactic/LinearCombination/Lemmas.lean
+++ b/Mathlib/Tactic/LinearCombination/Lemmas.lean
@@ -8,6 +8,8 @@ import Mathlib.Algebra.Ring.Defs
 
 /-!
 # Lemmas for the linear_combination tactic
+
+These should not be used directly in user code.
 -/
 
 namespace Mathlib.Tactic.LinearCombination

--- a/Mathlib/Tactic/LinearCombination/Lemmas.lean
+++ b/Mathlib/Tactic/LinearCombination/Lemmas.lean
@@ -1,0 +1,34 @@
+/-
+Copyright (c) 2022 Abby J. Goldberg. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Abby J. Goldberg, Mario Carneiro
+-/
+import Mathlib.Algebra.GroupWithZero.Basic
+import Mathlib.Algebra.Ring.Defs
+
+/-!
+# Lemmas for the linear_combination tactic
+-/
+
+namespace Mathlib.Tactic.LinearCombination
+open Lean
+
+variable {α : Type*} {a a' a₁ a₂ b b' b₁ b₂ c : α}
+
+theorem add_pf [Add α] (p₁ : (a₁:α) = b₁) (p₂ : a₂ = b₂) : a₁ + a₂ = b₁ + b₂ := p₁ ▸ p₂ ▸ rfl
+theorem pf_mul_c [Mul α] (p : a = b) (c : α) : a * c = b * c := p ▸ rfl
+theorem c_mul_pf [Mul α] (p : b = c) (a : α) : a * b = a * c := p ▸ rfl
+theorem pf_div_c [Div α] (p : a = b) (c : α) : a / c = b / c := p ▸ rfl
+
+theorem eq_of_sub [AddGroup α] (p : (a:α) = b) (H : (a' - b') - (a - b) = 0) : a' = b' := by
+  rw [← sub_eq_zero] at p ⊢; rwa [sub_eq_zero, p] at H
+
+theorem eq_of_add [Add α] [IsRightCancelAdd α] (p : (a:α) = b) (H : a' + b = b' + a) : a' = b' := by
+  rw [p] at H
+  exact add_right_cancel H
+
+theorem eq_of_add_pow [Ring α] [NoZeroDivisors α] (n : ℕ) (p : (a:α) = b)
+    (H : (a' - b')^n - (a - b) = 0) : a' = b' := by
+  rw [← sub_eq_zero] at p ⊢; apply pow_eq_zero (n := n); rwa [sub_eq_zero, p] at H
+
+end Mathlib.Tactic.LinearCombination

--- a/scripts/noshake.json
+++ b/scripts/noshake.json
@@ -236,6 +236,8 @@
   "Mathlib.Tactic.Measurability":
   ["Mathlib.Algebra.Group.Defs", "Mathlib.Tactic.Measurability.Init"],
   "Mathlib.Tactic.Linter.UnusedTactic": ["Batteries.Tactic.Unreachable"],
+  "Mathlib.Tactic.LinearCombination":
+  ["Mathlib.Tactic.LinearCombination.Lemmas"],
   "Mathlib.Tactic.Lemma": ["Lean.Parser.Command"],
   "Mathlib.Tactic.IrreducibleDef": ["Mathlib.Data.Subtype"],
   "Mathlib.Tactic.ITauto":


### PR DESCRIPTION
Split the lemmas in `Mathlib.Tactic.LinearCombination` into a new file, `Mathlib.Tactic.LinearCombination.Lemmas`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
