### PR TITLE
[Merged by Bors] - feat(NumberTheory): add converse of Lucas test for primes

### DIFF
--- a/Mathlib/NumberTheory/LucasPrimality.lean
+++ b/Mathlib/NumberTheory/LucasPrimality.lean
@@ -7,6 +7,7 @@ import Mathlib.Data.Fintype.Basic
 import Mathlib.GroupTheory.OrderOfElement
 import Mathlib.Tactic.Zify
 import Mathlib.Data.Nat.Totient
+import Mathlib.RingTheory.IntegralDomain
 
 /-!
 # The Lucas test for primes.
@@ -18,9 +19,6 @@ and `a^d ≠ 1 (mod n)` for any divisor `d | n - 1`. This test is the basis of t
 certificate.
 
 ## TODO
-
-- Bonus: Show the reverse implication i.e. if a number is prime then it has a Lucas witness.
-  Use `Units.IsCyclic` from `RingTheory/IntegralDomain` to show the group is cyclic.
 - Write a tactic that uses this theorem to generate Pratt primality certificates
 - Integrate Pratt primality certificates into the norm_num primality verifier
 
@@ -37,6 +35,7 @@ to `1`.
 is prime. This is true because `a` has order `p-1` in the multiplicative group mod `p`, so this
 group must itself have order `p-1`, which only happens when `p` is prime.
 -/
+
 theorem lucas_primality (p : ℕ) (a : ZMod p) (ha : a ^ (p - 1) = 1)
     (hd : ∀ q : ℕ, q.Prime → q ∣ p - 1 → a ^ ((p - 1) / q) ≠ 1) : p.Prime := by
   have h0 : p ≠ 0 := by
@@ -59,3 +58,74 @@ theorem lucas_primality (p : ℕ) (a : ZMod p) (ha : a ^ (p - 1) = 1)
     p - 1 = orderOf a := order_of_a.symm
     _ = orderOf a' := (orderOf_injective (Units.coeHom (ZMod p)) Units.ext a')
     _ ≤ Fintype.card (ZMod p)ˣ := orderOf_le_card_univ
+
+
+/-- If `p` is prime, then there exists an `a`
+such that `a^(p-1) = 1 mod p` and `a^((p-1)/q) ≠ 1 mod p` for all prime factors `q` of `p-1`,
+The multiplicative group mod `p` is cyclic, so `a` can be any generator of the group
+(which must have order `p-1`)
+-/
+theorem reverse_lucas_primality (p : ℕ) (hP : p.Prime):
+    ∃ a : ZMod p, a ^ (p - 1) = 1 ∧ ∀ q : ℕ, q.Prime → q ∣ p - 1 → a ^ ((p - 1) / q) ≠ 1 := by
+
+  have _: Fact p.Prime := ⟨hP⟩
+  have _: 1 < p := by exact Nat.Prime.one_lt hP
+
+  have h0: IsCyclic ((ZMod p)ˣ) := by exact instIsCyclicUnitsOfFinite
+  obtain ⟨g, hg⟩ := h0.exists_generator
+
+  have h1: orderOf g = p - 1 := by
+    rw [orderOf_generator_eq_natCard, Nat.card_eq_fintype_card, ← Nat.prime_iff_card_units]
+    trivial
+    trivial
+
+  -- Our generator 'g' works as the witness 'a'
+  use g
+  rw [
+    ← (orderOf_injective (Units.coeHom (ZMod p)) Units.ext _),
+    Units.coeHom_apply,
+    orderOf_eq_iff
+  ] at h1
+
+  constructor
+
+  exact h1.1
+
+  -- Show that 'g^((p-1)/q) ≠ 1', using the fact that '(p-1)/q)' < 'orderOf g'
+  intro q hq hq_div
+  have _: q ≤ p - 1 := by
+    apply Nat.le_of_dvd at hq_div
+    exact hq_div
+    simp only [tsub_pos_iff_lt]
+    trivial
+  have q_gt_1: 1 < q := by
+    apply Nat.Prime.one_lt
+    exact hq
+  have p_div_lt: (p - 1) / q < p - 1 := by
+    apply Nat.div_lt_self
+    simp only [tsub_pos_iff_lt]
+    linarith
+    exact q_gt_1
+  have neq_one: g.val ^ ((p - 1) / q) ≠ 1 := by
+    apply h1.2
+    exact p_div_lt
+    apply Nat.div_pos
+    linarith
+    linarith
+
+  exact neq_one
+  simp
+  linarith
+
+
+/-- A number `p` is prime if and only if there exists an `a` such that
+`a^(p-1) = 1 mod p` and `a^((p-1)/q) ≠ 1 mod p` for all prime factors `q` of `p-1`
+-/
+theorem lucas_primality_iff (p : ℕ): p.Prime ↔
+    ∃ a : ZMod p, a ^ (p - 1) = 1 ∧ ∀ q : ℕ, q.Prime → q ∣ p - 1 → a ^ ((p - 1) / q) ≠ 1 := by
+  apply Iff.intro
+    (fun hp => reverse_lucas_primality p hp)
+    (fun g => by
+      obtain ⟨a, ⟨ha, hb⟩⟩ := g
+      apply lucas_primality p a ha hb
+    )

--- a/Mathlib/NumberTheory/LucasPrimality.lean
+++ b/Mathlib/NumberTheory/LucasPrimality.lean
@@ -75,7 +75,6 @@ theorem reverse_lucas_primality (p : ℕ) (hP : p.Prime):
   replace hq := hq.one_lt
   exact h1.2 _ (Nat.div_lt_self h2 hq) (Nat.div_pos (Nat.le_of_dvd h2 hqd) (zero_lt_one.trans hq))
 
-
 /-- A number `p` is prime if and only if there exists an `a` such that
 `a^(p-1) = 1 mod p` and `a^((p-1)/q) ≠ 1 mod p` for all prime factors `q` of `p-1`
 -/

--- a/Mathlib/NumberTheory/LucasPrimality.lean
+++ b/Mathlib/NumberTheory/LucasPrimality.lean
@@ -76,7 +76,7 @@ theorem reverse_lucas_primality (p : ℕ) (hP : p.Prime):
   exact h1.2 _ (Nat.div_lt_self h2 hq) (Nat.div_pos (Nat.le_of_dvd h2 hqd) (zero_lt_one.trans hq))
 
 /-- A number `p` is prime if and only if there exists an `a` such that
-`a^(p-1) = 1 mod p` and `a^((p-1)/q) ≠ 1 mod p` for all prime factors `q` of `p-1`
+`a^(p-1) = 1 mod p` and `a^((p-1)/q) ≠ 1 mod p` for all prime factors `q` of `p-1`.
 -/
 theorem lucas_primality_iff (p : ℕ): p.Prime ↔
     ∃ a : ZMod p, a ^ (p - 1) = 1 ∧ ∀ q : ℕ, q.Prime → q ∣ p - 1 → a ^ ((p - 1) / q) ≠ 1 :=

--- a/Mathlib/NumberTheory/LucasPrimality.lean
+++ b/Mathlib/NumberTheory/LucasPrimality.lean
@@ -63,7 +63,7 @@ and `a^((p-1)/q) ≠ 1 mod p` for all prime factors `q` of `p-1`.
 The multiplicative group mod `p` is cyclic, so `a` can be any generator of the group
 (which must have order `p-1`).
 -/
-theorem reverse_lucas_primality (p : ℕ) (hP : p.Prime):
+theorem reverse_lucas_primality (p : ℕ) (hP : p.Prime) :
     ∃ a : ZMod p, a ^ (p - 1) = 1 ∧ ∀ q : ℕ, q.Prime → q ∣ p - 1 → a ^ ((p - 1) / q) ≠ 1 := by
   have : Fact p.Prime := ⟨hP⟩
   obtain ⟨g, hg⟩ := IsCyclic.exists_generator (α := (ZMod p)ˣ)
@@ -78,6 +78,6 @@ theorem reverse_lucas_primality (p : ℕ) (hP : p.Prime):
 /-- A number `p` is prime if and only if there exists an `a` such that
 `a^(p-1) = 1 mod p` and `a^((p-1)/q) ≠ 1 mod p` for all prime factors `q` of `p-1`.
 -/
-theorem lucas_primality_iff (p : ℕ): p.Prime ↔
+theorem lucas_primality_iff (p : ℕ) : p.Prime ↔
     ∃ a : ZMod p, a ^ (p - 1) = 1 ∧ ∀ q : ℕ, q.Prime → q ∣ p - 1 → a ^ ((p - 1) / q) ≠ 1 :=
   ⟨reverse_lucas_primality p, fun ⟨a, ⟨ha, hb⟩⟩ ↦ lucas_primality p a ha hb⟩


### PR DESCRIPTION
Add the converse of the existing `lucas_primality` theorem, and combine them into a `lucas_primality_iff` theorem

Coauthored by @vihdzp 


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
