### PR TITLE
chore(Mathlib/SetTheory): sort imports

### DIFF
--- a/Mathlib/SetTheory/Cardinal/Basic.lean
+++ b/Mathlib/SetTheory/Cardinal/Basic.lean
@@ -3,13 +3,13 @@ Copyright (c) 2017 Johannes Hölzl. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johannes Hölzl, Mario Carneiro, Floris van Doorn
 -/
+import Mathlib.Algebra.Order.Ring.Nat
 import Mathlib.Data.Fintype.BigOperators
+import Mathlib.Data.Nat.Cast.Order.Basic
 import Mathlib.Data.Set.Countable
 import Mathlib.Logic.Small.Set
 import Mathlib.Order.SuccPred.CompleteLinearOrder
 import Mathlib.SetTheory.Cardinal.SchroederBernstein
-import Mathlib.Algebra.Order.Ring.Nat
-import Mathlib.Data.Nat.Cast.Order.Basic
 
 /-!
 # Cardinal Numbers

--- a/Mathlib/SetTheory/Cardinal/CountableCover.lean
+++ b/Mathlib/SetTheory/Cardinal/CountableCover.lean
@@ -3,8 +3,8 @@ Copyright (c) 2023 Sébastien Gouëzel. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Sébastien Gouëzel
 -/
-import Mathlib.SetTheory.Cardinal.Ordinal
 import Mathlib.Order.Filter.Basic
+import Mathlib.SetTheory.Cardinal.Ordinal
 
 /-!
 # Cardinality of a set with a countable cover

--- a/Mathlib/SetTheory/Cardinal/Finsupp.lean
+++ b/Mathlib/SetTheory/Cardinal/Finsupp.lean
@@ -3,9 +3,9 @@ Copyright (c) 2022 Violeta Hernández Palacios. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Violeta Hernández Palacios, Junyan Xu
 -/
-import Mathlib.SetTheory.Cardinal.Ordinal
 import Mathlib.Data.Finsupp.Basic
 import Mathlib.Data.Finsupp.Multiset
+import Mathlib.SetTheory.Cardinal.Ordinal
 
 /-! # Results on the cardinality of finitely supported functions and multisets. -/
 

--- a/Mathlib/SetTheory/Cardinal/PartENat.lean
+++ b/Mathlib/SetTheory/Cardinal/PartENat.lean
@@ -3,8 +3,8 @@ Copyright (c) 2021 Aaron Anderson. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Aaron Anderson
 -/
-import Mathlib.SetTheory.Cardinal.ToNat
 import Mathlib.Data.Nat.PartENat
+import Mathlib.SetTheory.Cardinal.ToNat
 
 /-!
 # Projection from cardinal numbers to `PartENat`

--- a/Mathlib/SetTheory/Lists.lean
+++ b/Mathlib/SetTheory/Lists.lean
@@ -3,8 +3,8 @@ Copyright (c) 2018 Mario Carneiro. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Mario Carneiro
 -/
-import Mathlib.Data.Sigma.Basic
 import Mathlib.Algebra.Order.Ring.Nat
+import Mathlib.Data.Sigma.Basic
 
 /-!
 # A computable model of ZFA without infinity

--- a/Mathlib/SetTheory/Ordinal/Arithmetic.lean
+++ b/Mathlib/SetTheory/Ordinal/Arithmetic.lean
@@ -3,9 +3,9 @@ Copyright (c) 2017 Johannes Hölzl. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Mario Carneiro, Floris van Doorn, Violeta Hernández Palacios
 -/
-import Mathlib.SetTheory.Ordinal.Basic
-import Mathlib.Data.Nat.SuccPred
 import Mathlib.Algebra.GroupWithZero.Divisibility
+import Mathlib.Data.Nat.SuccPred
+import Mathlib.SetTheory.Ordinal.Basic
 
 /-!
 # Ordinal arithmetic

--- a/Mathlib/SetTheory/Ordinal/Notation.lean
+++ b/Mathlib/SetTheory/Ordinal/Notation.lean
@@ -5,9 +5,9 @@ Authors: Mario Carneiro
 -/
 import Mathlib.Algebra.Ring.Divisibility.Basic
 import Mathlib.Data.Ordering.Lemmas
+import Mathlib.Data.PNat.Basic
 import Mathlib.SetTheory.Ordinal.Principal
 import Mathlib.Tactic.NormNum
-import Mathlib.Data.PNat.Basic
 
 /-!
 # Ordinal notation

--- a/Mathlib/SetTheory/ZFC/Basic.lean
+++ b/Mathlib/SetTheory/ZFC/Basic.lean
@@ -4,8 +4,8 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Mario Carneiro
 -/
 import Mathlib.Data.Set.Lattice
-import Mathlib.Logic.Small.Basic
 import Mathlib.Logic.Function.OfArity
+import Mathlib.Logic.Small.Basic
 import Mathlib.Order.WellFounded
 
 /-!


### PR DESCRIPTION
---
This is easier to read and maintain (and could reduce merge conflicts, for example).