### PR TITLE
chore(Archive/IMO/2024Q2): `apply (...).trans` instead of `suffices (...); exact`

### DIFF
--- a/Archive/Imo/Imo2024Q2.lean
+++ b/Archive/Imo/Imo2024Q2.lean
@@ -99,11 +99,9 @@ lemma symm_large_n : h.symm.large_n = h.large_n := by
 lemma N_le_large_n : h.N ≤ h.large_n := by
   have hp : 0 < φ (a * b + 1) := Nat.totient_pos.2 (Nat.add_pos_right _ zero_lt_one)
   rw [large_n, add_mul, one_mul, Nat.add_sub_assoc (Nat.one_le_of_lt hp)]
-  suffices h.N ≤ h.N * φ (a * b + 1) + (φ (a * b + 1) - 1) by
-    refine this.trans ?_
-    gcongr
-    simp
-  exact Nat.le_add_right_of_le (Nat.le_mul_of_pos_right _ hp)
+  apply (Nat.le_add_right_of_le (Nat.le_mul_of_pos_right _ hp)).trans
+  gcongr
+  simp
 
 lemma dvd_large_n_sub_neg_one : (φ (a * b + 1) : ℤ) ∣ (h.large_n : ℤ) - (-1 : ℤ) := by
   simp [large_n]
@@ -120,11 +118,9 @@ lemma symm_large_n_0 : h.symm.large_n_0 = h.large_n_0 := by
 lemma N_le_large_n_0 : h.N ≤ h.large_n_0 := by
   have hp : 0 < φ (a * b + 1) := Nat.totient_pos.2 (Nat.add_pos_right _ zero_lt_one)
   rw [large_n_0]
-  suffices h.N ≤ h.N * φ (a * b + 1) by
-    refine this.trans ?_
-    gcongr
-    simp
-  exact Nat.le_mul_of_pos_right _ hp
+  apply (Nat.le_mul_of_pos_right _ hp).trans
+  gcongr
+  simp
 
 lemma dvd_large_n_0_sub_zero : (φ (a * b + 1) : ℤ) ∣ (h.large_n_0 : ℤ) - (0 : ℤ) := by
   simp [large_n_0]


### PR DESCRIPTION
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
