### PR TITLE
[Merged by Bors] - feat(NumberTheory/NumberField): Restricting maps to the ring of integers

### DIFF
--- a/Mathlib/Algebra/Ring/Equiv.lean
+++ b/Mathlib/Algebra/Ring/Equiv.lean
@@ -814,6 +814,33 @@ theorem symm_trans_self (e : R ≃+* S) : e.symm.trans e = RingEquiv.refl S :=
 
 end RingEquiv
 
+namespace RingEquiv
+
+variable [NonAssocSemiring R] [NonAssocSemiring S]
+
+/-- If a ring homomorphism has an inverse, it is a ring isomorphism. -/
+@[simps]
+def ofRingHom (f : R →+* S) (g : S →+* R) (h₁ : f.comp g = RingHom.id S)
+    (h₂ : g.comp f = RingHom.id R) : R ≃+* S :=
+  { f with
+    toFun := f
+    invFun := g
+    left_inv := RingHom.ext_iff.1 h₂
+    right_inv := RingHom.ext_iff.1 h₁ }
+
+theorem coe_ringHom_ofRingHom (f : R →+* S) (g : S →+* R) (h₁ h₂) : ofRingHom f g h₁ h₂ = f :=
+  rfl
+
+@[simp]
+theorem ofRingHom_coe_ringHom (f : R ≃+* S) (g : S →+* R) (h₁ h₂) : ofRingHom (↑f) g h₁ h₂ = f :=
+  ext fun _ ↦ rfl
+
+theorem ofRingHom_symm (f : R →+* S) (g : S →+* R) (h₁ h₂) :
+    (ofRingHom f g h₁ h₂).symm = ofRingHom g f h₂ h₁ :=
+  rfl
+
+end RingEquiv
+
 namespace MulEquiv
 
 /-- If two rings are isomorphic, and the second doesn't have zero divisors,

--- a/Mathlib/NumberTheory/NumberField/Basic.lean
+++ b/Mathlib/NumberTheory/NumberField/Basic.lean
@@ -250,6 +250,39 @@ def restrict_monoidHom [MulOneClass M] (f : M →* K) (h : ∀ x, IsIntegral ℤ
   map_one' := by simp only [restrict, map_one, mk_one]
   map_mul' x y := by simp only [restrict, map_mul, mk_mul_mk _]
 
+/-- The ring homomorphism `(𝓞 K) →+* (𝓞 L)` given by restricting a ring homomorphism
+  `f : K →+* L` to `𝓞 K`. -/
+def mapRingHom {K L F : Type*} [Field K] [Field L] [FunLike F K L]
+    [RingHomClass F K L] (f : F) : (𝓞 K) →+* (𝓞 L) where
+  toFun k := ⟨f k, map_isIntegral_int f k.2⟩
+  map_zero' := by ext; simp only [map_mk, map_zero]
+  map_one' := by ext; simp only [map_mk, map_one]
+  map_add' x y:= by ext; simp only [map_mk, map_add]
+  map_mul' x y := by ext; simp only [map_mk, _root_.map_mul]
+
+/-- The ring isomorphsim `(𝓞 K) ≃+* (𝓞 L)` given by restricting
+  a ring isomorphsim `e : K ≃+* L` to `𝓞 K`. -/
+def mapRingEquiv {K L E : Type*} [Field K] [Field L] [EquivLike E K L]
+    [RingEquivClass E K L] (e : E) : (𝓞 K) ≃+* (𝓞 L) :=
+  RingEquiv.ofRingHom (mapRingHom e) (mapRingHom (e : K ≃+* L).symm)
+    (by ext x; simpa [mapRingHom] using EquivLike.right_inv e x.1)
+      (by ext x; simpa [mapRingHom] using EquivLike.left_inv e x.1)
+
+/-- The algebra homomorphism `(𝓞 K) →ₐ[𝓞 k] (𝓞 L)` given by restricting a algebra homomorphism
+  `f : K →ₐ[k] L` to `𝓞 K`. -/
+def mapAlgHom {k K L F : Type*} [Field k] [Field K] [Field L] [Algebra k K]
+    [Algebra k L] [FunLike F K L] [AlgHomClass F k K L] (f : F) : (𝓞 K) →ₐ[𝓞 k] (𝓞 L) where
+  toRingHom := mapRingHom f
+  commutes' x := SetCoe.ext (AlgHomClass.commutes ((f : K →ₐ[k] L).restrictScalars (𝓞 k)) x)
+
+/-- The isomorphism of algebras `(𝓞 K) ≃ₐ[𝓞 k] (𝓞 L)` given by restricting
+  an isomorphism of algebras `e : K ≃ₐ[k] L` to `𝓞 K`. -/
+def mapAlgEquiv {k K L E : Type*} [Field k] [Field K] [Field L] [Algebra k K]
+    [Algebra k L] [EquivLike E K L] [AlgEquivClass E k K L] (e : E) : (𝓞 K) ≃ₐ[𝓞 k] (𝓞 L) :=
+  AlgEquiv.ofAlgHom (mapAlgHom e) (mapAlgHom (e : K ≃ₐ[k] L).symm)
+    (by ext x; simpa [mapAlgHom, mapRingHom] using EquivLike.right_inv e x.1)
+      (by ext x; simpa [mapAlgHom, mapRingHom] using EquivLike.left_inv e x.1)
+
 end RingOfIntegers
 
 variable [NumberField K]

--- a/Mathlib/NumberTheory/NumberField/Basic.lean
+++ b/Mathlib/NumberTheory/NumberField/Basic.lean
@@ -148,6 +148,12 @@ instance inst_ringOfIntegersAlgebra [Algebra K L] : Algebra (𝓞 K) (𝓞 L) :=
 -- diamond at `reducible_and_instances` #10906
 example : Algebra.id (𝓞 K) = inst_ringOfIntegersAlgebra K K := rfl
 
+instance inst_RingOfIntegersIsScalarTower {k K L : Type*} [Field k] [Field K] [Field L]
+    [Algebra k K] [Algebra k L] [Algebra K L] [IsScalarTower k K L] :
+    IsScalarTower (𝓞 k) (𝓞 K) (𝓞 L) :=
+  IsScalarTower.of_algebraMap_eq <| fun x => Subtype.val_inj.mp <|
+    IsScalarTower.algebraMap_apply k K L ((algebraMap (𝓞 k) k) x)
+
 namespace RingOfIntegers
 
 variable {K}
@@ -265,8 +271,8 @@ def mapRingHom {K L F : Type*} [Field K] [Field L] [FunLike F K L]
 def mapRingEquiv {K L E : Type*} [Field K] [Field L] [EquivLike E K L]
     [RingEquivClass E K L] (e : E) : (𝓞 K) ≃+* (𝓞 L) :=
   RingEquiv.ofRingHom (mapRingHom e) (mapRingHom (e : K ≃+* L).symm)
-    (by ext x; simpa [mapRingHom] using EquivLike.right_inv e x.1)
-      (by ext x; simpa [mapRingHom] using EquivLike.left_inv e x.1)
+    (RingHom.ext fun x => ext (EquivLike.right_inv e x.1))
+      (RingHom.ext fun x => ext (EquivLike.left_inv e x.1))
 
 /-- The algebra homomorphism `(𝓞 K) →ₐ[𝓞 k] (𝓞 L)` given by restricting a algebra homomorphism
   `f : K →ₐ[k] L` to `𝓞 K`. -/
@@ -280,8 +286,8 @@ def mapAlgHom {k K L F : Type*} [Field k] [Field K] [Field L] [Algebra k K]
 def mapAlgEquiv {k K L E : Type*} [Field k] [Field K] [Field L] [Algebra k K]
     [Algebra k L] [EquivLike E K L] [AlgEquivClass E k K L] (e : E) : (𝓞 K) ≃ₐ[𝓞 k] (𝓞 L) :=
   AlgEquiv.ofAlgHom (mapAlgHom e) (mapAlgHom (e : K ≃ₐ[k] L).symm)
-    (by ext x; simpa [mapAlgHom, mapRingHom] using EquivLike.right_inv e x.1)
-      (by ext x; simpa [mapAlgHom, mapRingHom] using EquivLike.left_inv e x.1)
+    (AlgHom.ext fun x => ext (EquivLike.right_inv e x.1))
+      (AlgHom.ext fun x => ext (EquivLike.left_inv e x.1))
 
 end RingOfIntegers
 

--- a/Mathlib/NumberTheory/NumberField/Basic.lean
+++ b/Mathlib/NumberTheory/NumberField/Basic.lean
@@ -134,27 +134,54 @@ lemma mk_eq_mk (x y : K) (hx hy) : (⟨x, hx⟩ : 𝓞 K) = ⟨y, hy⟩ ↔ x = 
 @[simp] lemma neg_mk (x : K) (hx) : (-⟨x, hx⟩ : 𝓞 K) = ⟨-x, neg_mem hx⟩ :=
   rfl
 
+/-- The ring homomorphism `(𝓞 K) →+* (𝓞 L)` given by restricting a ring homomorphism
+  `f : K →+* L` to `𝓞 K`. -/
+def mapRingHom {K L F : Type*} [Field K] [Field L] [FunLike F K L]
+    [RingHomClass F K L] (f : F) : (𝓞 K) →+* (𝓞 L) where
+  toFun k := ⟨f k.val, map_isIntegral_int f k.2⟩
+  map_zero' := by ext; simp only [map_mk, map_zero]
+  map_one' := by ext; simp only [map_mk, map_one]
+  map_add' x y:= by ext; simp only [map_mk, map_add]
+  map_mul' x y := by ext; simp only [map_mk, map_mul]
+
+/-- The ring isomorphsim `(𝓞 K) ≃+* (𝓞 L)` given by restricting
+  a ring isomorphsim `e : K ≃+* L` to `𝓞 K`. -/
+def mapRingEquiv {K L E : Type*} [Field K] [Field L] [EquivLike E K L]
+    [RingEquivClass E K L] (e : E) : (𝓞 K) ≃+* (𝓞 L) :=
+  RingEquiv.ofRingHom (mapRingHom e) (mapRingHom (e : K ≃+* L).symm)
+    (RingHom.ext fun x => ext (EquivLike.right_inv e x.1))
+      (RingHom.ext fun x => ext (EquivLike.left_inv e x.1))
+
 end RingOfIntegers
 
 /-- Given an algebra between two fields, create an algebra between their two rings of integers. -/
 instance inst_ringOfIntegersAlgebra [Algebra K L] : Algebra (𝓞 K) (𝓞 L) :=
-  RingHom.toAlgebra
-    { toFun := fun k => ⟨algebraMap K L (algebraMap _ K k), IsIntegral.algebraMap k.2⟩
-      map_zero' := by ext; simp only [RingOfIntegers.map_mk, map_zero]
-      map_one' := by ext; simp only [RingOfIntegers.map_mk, map_one]
-      map_add' := fun x y => by ext; simp only [RingOfIntegers.map_mk, map_add]
-      map_mul' := fun x y => by ext; simp only [RingOfIntegers.map_mk, map_mul] }
+  (RingOfIntegers.mapRingHom (algebraMap K L)).toAlgebra
 
 -- diamond at `reducible_and_instances` #10906
 example : Algebra.id (𝓞 K) = inst_ringOfIntegersAlgebra K K := rfl
 
-instance inst_RingOfIntegersIsScalarTower {k K L : Type*} [Field k] [Field K] [Field L]
+namespace RingOfIntegers
+
+/-- The algebra homomorphism `(𝓞 K) →ₐ[𝓞 k] (𝓞 L)` given by restricting a algebra homomorphism
+  `f : K →ₐ[k] L` to `𝓞 K`. -/
+def mapAlgHom {k K L F : Type*} [Field k] [Field K] [Field L] [Algebra k K]
+    [Algebra k L] [FunLike F K L] [AlgHomClass F k K L] (f : F) : (𝓞 K) →ₐ[𝓞 k] (𝓞 L) where
+  toRingHom := mapRingHom f
+  commutes' x := SetCoe.ext (AlgHomClass.commutes ((f : K →ₐ[k] L).restrictScalars (𝓞 k)) x)
+
+/-- The isomorphism of algebras `(𝓞 K) ≃ₐ[𝓞 k] (𝓞 L)` given by restricting
+  an isomorphism of algebras `e : K ≃ₐ[k] L` to `𝓞 K`. -/
+def mapAlgEquiv {k K L E : Type*} [Field k] [Field K] [Field L] [Algebra k K]
+    [Algebra k L] [EquivLike E K L] [AlgEquivClass E k K L] (e : E) : (𝓞 K) ≃ₐ[𝓞 k] (𝓞 L) :=
+  AlgEquiv.ofAlgHom (mapAlgHom e) (mapAlgHom (e : K ≃ₐ[k] L).symm)
+    (AlgHom.ext fun x => ext (EquivLike.right_inv e x.1))
+      (AlgHom.ext fun x => ext (EquivLike.left_inv e x.1))
+
+instance inst_isScalarTower (k K L : Type*) [Field k] [Field K] [Field L]
     [Algebra k K] [Algebra k L] [Algebra K L] [IsScalarTower k K L] :
     IsScalarTower (𝓞 k) (𝓞 K) (𝓞 L) :=
-  IsScalarTower.of_algebraMap_eq <| fun x => Subtype.val_inj.mp <|
-    IsScalarTower.algebraMap_apply k K L ((algebraMap (𝓞 k) k) x)
-
-namespace RingOfIntegers
+  IsScalarTower.of_algHom (mapAlgHom (IsScalarTower.toAlgHom k K L))
 
 variable {K}
 
@@ -255,39 +282,6 @@ def restrict_monoidHom [MulOneClass M] (f : M →* K) (h : ∀ x, IsIntegral ℤ
   toFun := restrict f h
   map_one' := by simp only [restrict, map_one, mk_one]
   map_mul' x y := by simp only [restrict, map_mul, mk_mul_mk _]
-
-/-- The ring homomorphism `(𝓞 K) →+* (𝓞 L)` given by restricting a ring homomorphism
-  `f : K →+* L` to `𝓞 K`. -/
-def mapRingHom {K L F : Type*} [Field K] [Field L] [FunLike F K L]
-    [RingHomClass F K L] (f : F) : (𝓞 K) →+* (𝓞 L) where
-  toFun k := ⟨f k, map_isIntegral_int f k.2⟩
-  map_zero' := by ext; simp only [map_mk, map_zero]
-  map_one' := by ext; simp only [map_mk, map_one]
-  map_add' x y:= by ext; simp only [map_mk, map_add]
-  map_mul' x y := by ext; simp only [map_mk, _root_.map_mul]
-
-/-- The ring isomorphsim `(𝓞 K) ≃+* (𝓞 L)` given by restricting
-  a ring isomorphsim `e : K ≃+* L` to `𝓞 K`. -/
-def mapRingEquiv {K L E : Type*} [Field K] [Field L] [EquivLike E K L]
-    [RingEquivClass E K L] (e : E) : (𝓞 K) ≃+* (𝓞 L) :=
-  RingEquiv.ofRingHom (mapRingHom e) (mapRingHom (e : K ≃+* L).symm)
-    (RingHom.ext fun x => ext (EquivLike.right_inv e x.1))
-      (RingHom.ext fun x => ext (EquivLike.left_inv e x.1))
-
-/-- The algebra homomorphism `(𝓞 K) →ₐ[𝓞 k] (𝓞 L)` given by restricting a algebra homomorphism
-  `f : K →ₐ[k] L` to `𝓞 K`. -/
-def mapAlgHom {k K L F : Type*} [Field k] [Field K] [Field L] [Algebra k K]
-    [Algebra k L] [FunLike F K L] [AlgHomClass F k K L] (f : F) : (𝓞 K) →ₐ[𝓞 k] (𝓞 L) where
-  toRingHom := mapRingHom f
-  commutes' x := SetCoe.ext (AlgHomClass.commutes ((f : K →ₐ[k] L).restrictScalars (𝓞 k)) x)
-
-/-- The isomorphism of algebras `(𝓞 K) ≃ₐ[𝓞 k] (𝓞 L)` given by restricting
-  an isomorphism of algebras `e : K ≃ₐ[k] L` to `𝓞 K`. -/
-def mapAlgEquiv {k K L E : Type*} [Field k] [Field K] [Field L] [Algebra k K]
-    [Algebra k L] [EquivLike E K L] [AlgEquivClass E k K L] (e : E) : (𝓞 K) ≃ₐ[𝓞 k] (𝓞 L) :=
-  AlgEquiv.ofAlgHom (mapAlgHom e) (mapAlgHom (e : K ≃ₐ[k] L).symm)
-    (AlgHom.ext fun x => ext (EquivLike.right_inv e x.1))
-      (AlgHom.ext fun x => ext (EquivLike.left_inv e x.1))
 
 end RingOfIntegers
 


### PR DESCRIPTION
This PR adds definitions of restricting maps to the ring of integers. That is, given a ring homomorphism (resp. ring isomorphism; resp. algebra homomorphism; resp. algebra isomorphism) `f` from`K` to `L`, we define the induced ring homomorphism (resp. ring isomorphism; resp. algebra homomorphism; resp. algebra isomorphism) from `𝓞 K` to `𝓞 L`, which is obtained by restricting `f` to `𝓞 K`.

Co-authored-by: Yongle Hu @mbkybky
Co-authored-by: Yuyang Zhao @FR-vdash-bot

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
