### PR TITLE
[Merged by Bors] - fix(technical-debt-metrics.sh): make compatible with set -u

### DIFF
--- a/scripts/technical-debt-metrics.sh
+++ b/scripts/technical-debt-metrics.sh
@@ -13,15 +13,13 @@ IFS=$'\n\t'
 # and tallies the same technical debts on `<optCurrCommit>` using `<optReferenceCommit>`
 # as a reference.
 
-if [ -n "${1}" ]; then
-  currCommit="${1}"
-else
+currCommit=${1:-}
+if [ -z currCommit ]; then
   currCommit="$(git rev-parse HEAD)"
 fi
 
-if [ -n "${2}" ]; then
-  refCommit="${2}"
-else
+refCommit=${2:-}
+if [ -z refCommit ]; then
   refCommit="$(git log --pretty=%H --since="$(date -I -d 'last week')" | tail -n -1)"
 fi
 

--- a/scripts/technical-debt-metrics.sh
+++ b/scripts/technical-debt-metrics.sh
@@ -12,8 +12,8 @@ IFS=$'\n\t'
 # the script takes two optional arguments `<optCurrCommit> <optReferenceCommit>`
 # and tallies the same technical debts on `<optCurrCommit>` using `<optReferenceCommit>`
 # as a reference.
-currCommit=${1:-$(git rev-parse HEAD)}
-refCommit=${2:-$(git log --pretty=%H --since="$(date -I -d 'last week')" | tail -n -1)}
+currCommit=${1:-"$(git rev-parse HEAD)"}
+refCommit=${2:-"$(git log --pretty=%H --since="$(date -I -d 'last week')" | tail -n -1)"}
 
 # `tdc` produces a semi-formatted output of the form
 # ...

--- a/scripts/technical-debt-metrics.sh
+++ b/scripts/technical-debt-metrics.sh
@@ -12,16 +12,8 @@ IFS=$'\n\t'
 # the script takes two optional arguments `<optCurrCommit> <optReferenceCommit>`
 # and tallies the same technical debts on `<optCurrCommit>` using `<optReferenceCommit>`
 # as a reference.
-
-currCommit=${1:-}
-if [ -z currCommit ]; then
-  currCommit="$(git rev-parse HEAD)"
-fi
-
-refCommit=${2:-}
-if [ -z refCommit ]; then
-  refCommit="$(git log --pretty=%H --since="$(date -I -d 'last week')" | tail -n -1)"
-fi
+currCommit=${1:-$(git rev-parse HEAD)}
+refCommit=${2:-$(git log --pretty=%H --since="$(date -I -d 'last week')" | tail -n -1)}
 
 # `tdc` produces a semi-formatted output of the form
 # ...

--- a/scripts/technical-debt-metrics.sh
+++ b/scripts/technical-debt-metrics.sh
@@ -12,8 +12,8 @@ IFS=$'\n\t'
 # the script takes two optional arguments `<optCurrCommit> <optReferenceCommit>`
 # and tallies the same technical debts on `<optCurrCommit>` using `<optReferenceCommit>`
 # as a reference.
-currCommit=${1:-"$(git rev-parse HEAD)"}
-refCommit=${2:-"$(git log --pretty=%H --since="$(date -I -d 'last week')" | tail -n -1)"}
+currCommit="${1:-"$(git rev-parse HEAD)"}"
+refCommit="${2:-"$(git log --pretty=%H --since="$(date -I -d 'last week')" | tail -n -1)"}"
 
 # `tdc` produces a semi-formatted output of the form
 # ...


### PR DESCRIPTION
...by using [parameter default values](https://www.gnu.org/savannah-checkouts/gnu/bash/manual/bash.html#Shell-Parameter-Expansion) per [the bash strict mode page](http://redsymbol.net/articles/unofficial-bash-strict-mode/#solution-positional-parameters).

Fallout from #16566. See [Zulip](https://leanprover.zulipchat.com/#narrow/stream/287929-mathlib4/topic/Technical.20Debt.20Counters/near/470576612). 

---

Thanks to @edegeltje for identifying the issue!

I was surprised that I could use command substitution (`$()` syntax) inside the parameter expansion (`${}` syntax) but I tested it locally and it worked!