### PR TITLE
[Merged by Bors] - feat(AlgegraicTopology): the category of simplicial objects is simplicial

### DIFF
--- a/Mathlib/AlgebraicTopology/SimplexCategory.lean
+++ b/Mathlib/AlgebraicTopology/SimplexCategory.lean
@@ -173,9 +173,11 @@ without identifying `n` with `[n].len`.
 def mkHom {n m : ℕ} (f : Fin (n + 1) →o Fin (m + 1)) : ([n] : SimplexCategory) ⟶ [m] :=
   SimplexCategory.Hom.mk f
 
+instance (Δ : SimplexCategory) : Subsingleton (Δ ⟶ [0]) where
+  allEq f g := by ext : 3; apply Subsingleton.elim (α := Fin 1)
+
 theorem hom_zero_zero (f : ([0] : SimplexCategory) ⟶ [0]) : f = 𝟙 _ := by
-  ext : 3
-  apply @Subsingleton.elim (Fin 1)
+  apply Subsingleton.elim
 
 end
 

--- a/Mathlib/AlgebraicTopology/SimplicialCategory/SimplicialObject.lean
+++ b/Mathlib/AlgebraicTopology/SimplicialCategory/SimplicialObject.lean
@@ -27,31 +27,11 @@ variable {D : Type u} [Category.{v} D]
 
 namespace SimplicialObject
 
-open Simplicial
-
 noncomputable instance : EnrichedCategory SSet.{v} (SimplicialObject D)  :=
-  inferInstanceAs (EnrichedCategory (SimplexCategoryᵒᵖ ⥤ Type v) (SimplexCategoryᵒᵖ ⥤ D))
-
-/-- If `K` and `L` are simplicial objects, the zero-simplices of the simplicial
-hom from `K` to `L` identify to `K ⟶ L`. -/
-def sHom₀Equiv (K L : SimplicialObject D) :
-    EnrichedCategory.Hom (V := SSet.{v}) K L _[0] ≃ (K ⟶ L) where
-  toFun x :=
-    { app := fun Δ ↦ x.app Δ (SimplexCategory.const _ _ 0).op
-      naturality := fun Δ Δ' f ↦ by rw [← x.naturality f]; rfl }
-  invFun φ :=
-    { app := fun Δ _ ↦ φ.app Δ
-      naturality := fun {Δ Δ'} f ⟨s⟩ ↦ by
-        obtain rfl := Subsingleton.elim s (SimplexCategory.const _ _ 0)
-        simp only [NatTrans.naturality] }
-  left_inv x := Functor.functorHom_ext (fun Δ ⟨s⟩ ↦ by
-    obtain rfl := Subsingleton.elim s (SimplexCategory.const _ _ 0)
-    rfl)
-  right_inv _ := rfl
+  inferInstanceAs (EnrichedCategory (_ ⥤ Type v) (_ ⥤ D))
 
 noncomputable instance : SimplicialCategory (SimplicialObject D) where
-  homEquiv K L :=
-    (sHom₀Equiv K L).symm.trans (SSet.unitHomEquiv (EnrichedCategory.Hom K L)).symm
+  homEquiv K L := Functor.natTransEquiv.symm
 
 noncomputable instance : SimplicialCategory SSet.{v} :=
   inferInstanceAs (SimplicialCategory (SimplicialObject (Type v)))

--- a/Mathlib/AlgebraicTopology/SimplicialCategory/SimplicialObject.lean
+++ b/Mathlib/AlgebraicTopology/SimplicialCategory/SimplicialObject.lean
@@ -1,0 +1,59 @@
+/-
+Copyright (c) 2024 Joël Riou. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Joël Riou
+-/
+import Mathlib.AlgebraicTopology.SimplicialCategory.Basic
+import Mathlib.CategoryTheory.Functor.FunctorHom
+
+/-!
+# The category of simplicial objects is simplicial
+
+In `CategoryTheory.Functor.FunctorHom`, it was shown that a category of functors
+`C ⥤ D` is enriched over a suitable category `C ⥤ Type _` of functors to types.
+
+In this file, we deduce that `SimplicialObject D` is enriched ober `SSet.{v} D`
+(when `D : Type u` and `[Category.{v} D]`) and that `SimplicialObject D`
+is actually a simplicial category. In particular, the category of simplicial
+sets is a simplicial category.
+
+-/
+
+universe v u
+
+namespace CategoryTheory
+
+variable {D : Type u} [Category.{v} D]
+
+namespace SimplicialObject
+
+open Simplicial
+
+noncomputable instance : EnrichedCategory SSet.{v} (SimplicialObject D)  :=
+  inferInstanceAs (EnrichedCategory (SimplexCategoryᵒᵖ ⥤ Type v) (SimplexCategoryᵒᵖ ⥤ D))
+
+def sHom₀Equiv (K L : SimplicialObject D) :
+    EnrichedCategory.Hom (V := SSet.{v}) K L _[0] ≃ (K ⟶ L) where
+  toFun x :=
+    { app := fun Δ ↦ x.app Δ (SimplexCategory.const _ _ 0).op
+      naturality := fun Δ Δ' f ↦ by rw [← x.naturality f]; rfl }
+  invFun φ :=
+    { app := fun Δ _ ↦ φ.app Δ
+      naturality := fun {Δ Δ'} f ⟨s⟩ ↦ by
+        obtain rfl := Subsingleton.elim s (SimplexCategory.const _ _ 0)
+        simp only [NatTrans.naturality] }
+  left_inv x := Functor.functorHom_ext (fun Δ ⟨s⟩ ↦ by
+    obtain rfl := Subsingleton.elim s (SimplexCategory.const _ _ 0)
+    rfl)
+  right_inv _ := rfl
+
+noncomputable instance : SimplicialCategory (SimplicialObject D) where
+  homEquiv K L :=
+    (sHom₀Equiv K L).symm.trans (SSet.unitHomEquiv (EnrichedCategory.Hom K L)).symm
+
+noncomputable instance : SimplicialCategory SSet.{v} :=
+  inferInstanceAs (SimplicialCategory (SimplicialObject (Type v)))
+
+end SimplicialObject
+
+end CategoryTheory

--- a/Mathlib/AlgebraicTopology/SimplicialCategory/SimplicialObject.lean
+++ b/Mathlib/AlgebraicTopology/SimplicialCategory/SimplicialObject.lean
@@ -12,7 +12,7 @@ import Mathlib.CategoryTheory.Functor.FunctorHom
 In `CategoryTheory.Functor.FunctorHom`, it was shown that a category of functors
 `C ⥤ D` is enriched over a suitable category `C ⥤ Type _` of functors to types.
 
-In this file, we deduce that `SimplicialObject D` is enriched ober `SSet.{v} D`
+In this file, we deduce that `SimplicialObject D` is enriched over `SSet.{v} D`
 (when `D : Type u` and `[Category.{v} D]`) and that `SimplicialObject D`
 is actually a simplicial category. In particular, the category of simplicial
 sets is a simplicial category.

--- a/Mathlib/AlgebraicTopology/SimplicialCategory/SimplicialObject.lean
+++ b/Mathlib/AlgebraicTopology/SimplicialCategory/SimplicialObject.lean
@@ -32,6 +32,8 @@ open Simplicial
 noncomputable instance : EnrichedCategory SSet.{v} (SimplicialObject D)  :=
   inferInstanceAs (EnrichedCategory (SimplexCategoryᵒᵖ ⥤ Type v) (SimplexCategoryᵒᵖ ⥤ D))
 
+/-- If `K` and `L` are simplicial objects, the zero-simplicies of the simplicial
+hom from `K` to `L` identifies to `K ⟶ L`. -/
 def sHom₀Equiv (K L : SimplicialObject D) :
     EnrichedCategory.Hom (V := SSet.{v}) K L _[0] ≃ (K ⟶ L) where
   toFun x :=

--- a/Mathlib/AlgebraicTopology/SimplicialCategory/SimplicialObject.lean
+++ b/Mathlib/AlgebraicTopology/SimplicialCategory/SimplicialObject.lean
@@ -32,7 +32,7 @@ open Simplicial
 noncomputable instance : EnrichedCategory SSet.{v} (SimplicialObject D)  :=
   inferInstanceAs (EnrichedCategory (SimplexCategoryᵒᵖ ⥤ Type v) (SimplexCategoryᵒᵖ ⥤ D))
 
-/-- If `K` and `L` are simplicial objects, the zero-simplicies of the simplicial
+/-- If `K` and `L` are simplicial objects, the zero-simplices of the simplicial
 hom from `K` to `L` identifies to `K ⟶ L`. -/
 def sHom₀Equiv (K L : SimplicialObject D) :
     EnrichedCategory.Hom (V := SSet.{v}) K L _[0] ≃ (K ⟶ L) where

--- a/Mathlib/AlgebraicTopology/SimplicialCategory/SimplicialObject.lean
+++ b/Mathlib/AlgebraicTopology/SimplicialCategory/SimplicialObject.lean
@@ -33,7 +33,7 @@ noncomputable instance : EnrichedCategory SSet.{v} (SimplicialObject D)  :=
   inferInstanceAs (EnrichedCategory (SimplexCategoryᵒᵖ ⥤ Type v) (SimplexCategoryᵒᵖ ⥤ D))
 
 /-- If `K` and `L` are simplicial objects, the zero-simplices of the simplicial
-hom from `K` to `L` identifies to `K ⟶ L`. -/
+hom from `K` to `L` identify to `K ⟶ L`. -/
 def sHom₀Equiv (K L : SimplicialObject D) :
     EnrichedCategory.Hom (V := SSet.{v}) K L _[0] ≃ (K ⟶ L) where
   toFun x :=


### PR DESCRIPTION
For any category `C`, the category `SimplicialObject C` is simplicial. In particular, the category of simplicial sets is simplicial.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
