### PR TITLE
[Merged by Bors] - ci: add workflow_dispatch to scheduled workflows

### DIFF
--- a/.github/workflows/dependent-issues.yml
+++ b/.github/workflows/dependent-issues.yml
@@ -3,6 +3,7 @@ name: Dependent Issues
 on:
   schedule:
     - cron: '*/15 * * * *' # run every 15 minutes
+  workflow_dispatch:
 
 jobs:
   cancel:

--- a/.github/workflows/lean4checker.yml
+++ b/.github/workflows/lean4checker.yml
@@ -4,6 +4,7 @@ name: lean4checker Workflow
 on:
   schedule:
     - cron: '0 0 * * *'   # Runs at 00:00 UTC every day
+  workflow_dispatch:
 
 jobs:
   check-lean4checker:

--- a/.github/workflows/merge_conflicts.yml
+++ b/.github/workflows/merge_conflicts.yml
@@ -3,6 +3,7 @@ name: Merge conflicts
 on:
   schedule:
     - cron: '*/15 * * * *' # run every 15 minutes
+  workflow_dispatch:
 
 jobs:
   main:

--- a/.github/workflows/nightly_bump_toolchain.yml
+++ b/.github/workflows/nightly_bump_toolchain.yml
@@ -1,9 +1,9 @@
 name: Bump lean-toolchain on nightly-testing
 
 on:
-  workflow_dispatch:
   schedule:
     - cron: '0 10/3 * * *'  # Run every three hours, starting at 11AM CET/2AM PT.
+  workflow_dispatch:
 
 jobs:
   update-toolchain:

--- a/.github/workflows/nightly_merge_master.yml
+++ b/.github/workflows/nightly_merge_master.yml
@@ -4,7 +4,8 @@ name: Merge master to nightly
 
 on:
   schedule:
-    - cron: '30 */3 * * *'  # 8AM CET/11PM PT
+    - cron: '30 */3 * * *'  # At minute 30 past every 3rd hour.
+  workflow_dispatch:
 
 jobs:
   merge-to-nightly:

--- a/.github/workflows/nolints.yml
+++ b/.github/workflows/nolints.yml
@@ -2,7 +2,8 @@ name: update nolints
 
 on:
   schedule:
-    - cron: "0 0 * * 0"
+    - cron: "0 0 * * 0" # At 00:00 UTC on Sunday.
+  workflow_dispatch:
 
 jobs:
   build:

--- a/.github/workflows/technical_debt_metrics.yml
+++ b/.github/workflows/technical_debt_metrics.yml
@@ -2,7 +2,8 @@ name: Weekly Technical Debt Counters
 
 on:
   schedule:
-    - cron: '0 4 * * 1'  # Run at 04:00 every Monday
+    - cron: '0 4 * * 1'  # Run at 04:00 UTC every Monday
+  workflow_dispatch:
 
 jobs:
   run-script:

--- a/.github/workflows/update_dependencies.yml
+++ b/.github/workflows/update_dependencies.yml
@@ -3,6 +3,7 @@ name: Update Mathlib Dependencies
 on:
   schedule:
     - cron: '0 * * * *'  # This will run every hour
+  workflow_dispatch:
 
 jobs:
   update-dependencies:


### PR DESCRIPTION
This will allow anyone with write access to [trigger these workflows manually](https://docs.github.com/en/actions/managing-workflow-runs-and-deployments/managing-workflow-runs/manually-running-a-workflow) without waiting for the scheduled time. Useful for re-running if something was broken and for testing.

I also added / updated comments giving the cron schedules in words (using https://crontab.guru).

[Zulip](https://leanprover.zulipchat.com/#narrow/stream/287929-mathlib4/topic/Technical.20Debt.20Counters/near/470626800)

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
