### PR TITLE
[Merged by Bors] - chore: reorganize AlgEquiv/MulEquiv declarations

### DIFF
--- a/Mathlib/Algebra/Algebra/Equiv.lean
+++ b/Mathlib/Algebra/Algebra/Equiv.lean
@@ -86,6 +86,8 @@ variable [Algebra R A₁] [Algebra R A₂] [Algebra R A₃]
 variable [Algebra R A₁'] [Algebra R A₂'] [Algebra R A₃']
 variable (e : A₁ ≃ₐ[R] A₂)
 
+section coe
+
 instance : EquivLike (A₁ ≃ₐ[R] A₂) A₁ A₂ where
   coe f := f.toFun
   inv f := f.invFun
@@ -106,22 +108,6 @@ instance : AlgEquivClass (A₁ ≃ₐ[R] A₂) R A₁ A₂ where
   map_mul f := f.map_mul'
   commutes f := f.commutes'
 
--- Porting note: the default simps projection was `e.toEquiv.toFun`, it should be `FunLike.coe`
-/-- See Note [custom simps projection] -/
-def Simps.apply (e : A₁ ≃ₐ[R] A₂) : A₁ → A₂ :=
-  e
-
--- Porting note: the default simps projection was `e.toEquiv`, it should be `EquivLike.toEquiv`
-/-- See Note [custom simps projection] -/
-def Simps.toEquiv (e : A₁ ≃ₐ[R] A₂) : A₁ ≃ A₂ :=
-  e
-
--- Porting note: `protected` used to be an attribute below
-@[simp]
-protected theorem coe_coe {F : Type*} [EquivLike F A₁ A₂] [AlgEquivClass F R A₁ A₂] (f : F) :
-    ⇑(f : A₁ ≃ₐ[R] A₂) = f :=
-  rfl
-
 @[ext]
 theorem ext {f g : A₁ ≃ₐ[R] A₂} (h : ∀ a, f a = g a) : f = g :=
   DFunLike.ext f g h
@@ -131,13 +117,6 @@ protected theorem congr_arg {f : A₁ ≃ₐ[R] A₂} {x x' : A₁} : x = x' →
 
 protected theorem congr_fun {f g : A₁ ≃ₐ[R] A₂} (h : f = g) (x : A₁) : f x = g x :=
   DFunLike.congr_fun h x
-
-theorem coe_fun_injective : @Function.Injective (A₁ ≃ₐ[R] A₂) (A₁ → A₂) fun e => (e : A₁ → A₂) :=
-  DFunLike.coe_injective
-
--- Porting note: Made to CoeOut instance from Coe, not dangerous anymore
-instance hasCoeToRingEquiv : CoeOut (A₁ ≃ₐ[R] A₂) (A₁ ≃+* A₂) :=
-  ⟨AlgEquiv.toRingEquiv⟩
 
 @[simp]
 theorem coe_mk {toEquiv map_mul map_add commutes} :
@@ -149,11 +128,24 @@ theorem mk_coe (e : A₁ ≃ₐ[R] A₂) (e' h₁ h₂ h₃ h₄ h₅) :
     (⟨⟨e, e', h₁, h₂⟩, h₃, h₄, h₅⟩ : A₁ ≃ₐ[R] A₂) = e :=
   ext fun _ => rfl
 
--- Porting note: `toFun_eq_coe` no longer needed in Lean4
-
 @[simp]
 theorem toEquiv_eq_coe : e.toEquiv = e :=
   rfl
+
+-- Porting note: `protected` used to be an attribute below
+@[simp]
+protected theorem coe_coe {F : Type*} [EquivLike F A₁ A₂] [AlgEquivClass F R A₁ A₂] (f : F) :
+    ⇑(f : A₁ ≃ₐ[R] A₂) = f :=
+  rfl
+
+theorem coe_fun_injective : @Function.Injective (A₁ ≃ₐ[R] A₂) (A₁ → A₂) fun e => (e : A₁ → A₂) :=
+  DFunLike.coe_injective
+
+-- Porting note: Made to CoeOut instance from Coe, not dangerous anymore
+instance hasCoeToRingEquiv : CoeOut (A₁ ≃ₐ[R] A₂) (A₁ ≃+* A₂) :=
+  ⟨AlgEquiv.toRingEquiv⟩
+
+-- Porting note: `toFun_eq_coe` no longer needed in Lean4
 
 @[simp]
 theorem toRingEquiv_eq_coe : e.toRingEquiv = e :=
@@ -172,41 +164,6 @@ theorem coe_ringEquiv' : (e.toRingEquiv : A₁ → A₂) = e :=
 
 theorem coe_ringEquiv_injective : Function.Injective ((↑) : (A₁ ≃ₐ[R] A₂) → A₁ ≃+* A₂) :=
   fun _ _ h => ext <| RingEquiv.congr_fun h
-
-@[deprecated map_add (since := "2024-06-20")]
-protected theorem map_add : ∀ x y, e (x + y) = e x + e y :=
-  map_add e
-
-@[deprecated map_zero (since := "2024-06-20")]
-protected theorem map_zero : e 0 = 0 :=
-  map_zero e
-
-@[deprecated map_mul (since := "2024-06-20")]
-protected theorem map_mul : ∀ x y, e (x * y) = e x * e y :=
-  map_mul e
-
-@[deprecated map_one (since := "2024-06-20")]
-protected theorem map_one : e 1 = 1 :=
-  map_one e
-
-@[simp]
-theorem commutes : ∀ r : R, e (algebraMap R A₁ r) = algebraMap R A₂ r :=
-  e.commutes'
-
--- @[simp] -- Porting note (#10618): simp can prove this
-@[deprecated map_smul (since := "2024-06-20")]
-protected theorem map_smul (r : R) (x : A₁) : e (r • x) = r • e x :=
-  map_smul _ _ _
-
-@[deprecated map_sum (since := "2023-12-26")]
-protected theorem map_sum {ι : Type*} (f : ι → A₁) (s : Finset ι) :
-    e (∑ x ∈ s, f x) = ∑ x ∈ s, e (f x) :=
-  map_sum e f s
-
-@[deprecated map_finsupp_sum (since := "2024-06-20")]
-protected theorem map_finsupp_sum {α : Type*} [Zero α] {ι : Type*} (f : ι →₀ α) (g : ι → α → A₁) :
-    e (f.sum g) = f.sum fun i b => e (g i b) :=
-  map_finsupp_sum _ _ _
 
 -- Porting note: Added [coe] attribute
 /-- Interpret an algebra equivalence as an algebra homomorphism.
@@ -238,9 +195,55 @@ lemma toAlgHom_toRingHom : ((e : A₁ →ₐ[R] A₂) : A₁ →+* A₂) = e :=
 theorem coe_ringHom_commutes : ((e : A₁ →ₐ[R] A₂) : A₁ →+* A₂) = ((e : A₁ ≃+* A₂) : A₁ →+* A₂) :=
   rfl
 
+@[simp]
+theorem commutes : ∀ r : R, e (algebraMap R A₁ r) = algebraMap R A₂ r :=
+  e.commutes'
+
+end coe
+
+section map
+
+@[deprecated map_add (since := "2024-06-20")]
+protected theorem map_add : ∀ x y, e (x + y) = e x + e y :=
+  map_add e
+
+@[deprecated map_zero (since := "2024-06-20")]
+protected theorem map_zero : e 0 = 0 :=
+  map_zero e
+
+@[deprecated map_mul (since := "2024-06-20")]
+protected theorem map_mul : ∀ x y, e (x * y) = e x * e y :=
+  map_mul e
+
+@[deprecated map_one (since := "2024-06-20")]
+protected theorem map_one : e 1 = 1 :=
+  map_one e
+
+-- @[simp] -- Porting note (#10618): simp can prove this
+@[deprecated map_smul (since := "2024-06-20")]
+protected theorem map_smul (r : R) (x : A₁) : e (r • x) = r • e x :=
+  map_smul _ _ _
+
 @[deprecated map_pow (since := "2024-06-20")]
 protected theorem map_pow : ∀ (x : A₁) (n : ℕ), e (x ^ n) = e x ^ n :=
   map_pow _
+
+@[deprecated map_sum (since := "2023-12-26")]
+protected theorem map_sum {ι : Type*} (f : ι → A₁) (s : Finset ι) :
+    e (∑ x ∈ s, f x) = ∑ x ∈ s, e (f x) :=
+  map_sum e f s
+
+@[deprecated map_finsupp_sum (since := "2024-06-20")]
+protected theorem map_finsupp_sum {α : Type*} [Zero α] {ι : Type*} (f : ι →₀ α) (g : ι → α → A₁) :
+    e (f.sum g) = f.sum fun i b => e (g i b) :=
+  map_finsupp_sum _ _ _
+
+end map
+
+section bijective
+
+protected theorem bijective : Function.Bijective e :=
+  EquivLike.bijective e
 
 protected theorem injective : Function.Injective e :=
   EquivLike.injective e
@@ -248,8 +251,9 @@ protected theorem injective : Function.Injective e :=
 protected theorem surjective : Function.Surjective e :=
   EquivLike.surjective e
 
-protected theorem bijective : Function.Bijective e :=
-  EquivLike.bijective e
+end bijective
+
+section refl
 
 /-- Algebra equivalences are reflexive. -/
 @[refl]
@@ -267,6 +271,10 @@ theorem refl_toAlgHom : ↑(refl : A₁ ≃ₐ[R] A₁) = AlgHom.id R A₁ :=
 theorem coe_refl : ⇑(refl : A₁ ≃ₐ[R] A₁) = id :=
   rfl
 
+end refl
+
+section symm
+
 /-- Algebra equivalences are symmetric. -/
 @[symm]
 def symm (e : A₁ ≃ₐ[R] A₂) : A₂ ≃ₐ[R] A₁ :=
@@ -277,11 +285,8 @@ def symm (e : A₁ ≃ₐ[R] A₂) : A₂ ≃ₐ[R] A₁ :=
       change _ = e _
       rw [e.commutes] }
 
-/-- See Note [custom simps projection] -/
-def Simps.symm_apply (e : A₁ ≃ₐ[R] A₂) : A₂ → A₁ :=
-  e.symm
-
-initialize_simps_projections AlgEquiv (toFun → apply, invFun → symm_apply)
+theorem invFun_eq_symm {e : A₁ ≃ₐ[R] A₂} : e.invFun = e.symm :=
+  rfl
 
 --@[simp] -- Porting note (#10618): simp can prove this once symm_mk is introduced
 theorem coe_apply_coe_coe_symm_apply {F : Type*} [EquivLike F A₁ A₂] [AlgEquivClass F R A₁ A₂]
@@ -298,9 +303,6 @@ theorem coe_coe_symm_apply_coe_apply {F : Type*} [EquivLike F A₁ A₂] [AlgEqu
 -- Porting note: `simp` normal form of `invFun_eq_symm`
 @[simp]
 theorem symm_toEquiv_eq_symm {e : A₁ ≃ₐ[R] A₂} : (e : A₁ ≃ A₂).symm = e.symm :=
-  rfl
-
-theorem invFun_eq_symm {e : A₁ ≃ₐ[R] A₂} : e.invFun = e.symm :=
   rfl
 
 @[simp]
@@ -338,12 +340,6 @@ theorem toRingEquiv_symm (f : A₁ ≃ₐ[R] A₁) : (f : A₁ ≃+* A₁).symm 
 theorem symm_toRingEquiv : (e.symm : A₂ ≃+* A₁) = (e : A₁ ≃+* A₂).symm :=
   rfl
 
-/-- Algebra equivalences are transitive. -/
-@[trans]
-def trans (e₁ : A₁ ≃ₐ[R] A₂) (e₂ : A₂ ≃ₐ[R] A₃) : A₁ ≃ₐ[R] A₃ :=
-  { e₁.toRingEquiv.trans e₂.toRingEquiv with
-    commutes' := fun r => show e₂.toFun (e₁.toFun _) = _ by rw [e₁.commutes', e₂.commutes'] }
-
 @[simp]
 theorem apply_symm_apply (e : A₁ ≃ₐ[R] A₂) : ∀ x, e (e.symm x) = x :=
   e.toEquiv.apply_symm_apply
@@ -351,19 +347,6 @@ theorem apply_symm_apply (e : A₁ ≃ₐ[R] A₂) : ∀ x, e (e.symm x) = x :=
 @[simp]
 theorem symm_apply_apply (e : A₁ ≃ₐ[R] A₂) : ∀ x, e.symm (e x) = x :=
   e.toEquiv.symm_apply_apply
-
-@[simp]
-theorem symm_trans_apply (e₁ : A₁ ≃ₐ[R] A₂) (e₂ : A₂ ≃ₐ[R] A₃) (x : A₃) :
-    (e₁.trans e₂).symm x = e₁.symm (e₂.symm x) :=
-  rfl
-
-@[simp]
-theorem coe_trans (e₁ : A₁ ≃ₐ[R] A₂) (e₂ : A₂ ≃ₐ[R] A₃) : ⇑(e₁.trans e₂) = e₂ ∘ e₁ :=
-  rfl
-
-@[simp]
-theorem trans_apply (e₁ : A₁ ≃ₐ[R] A₂) (e₂ : A₂ ≃ₐ[R] A₃) (x : A₁) : (e₁.trans e₂) x = e₂ (e₁ x) :=
-  rfl
 
 @[simp]
 theorem comp_symm (e : A₁ ≃ₐ[R] A₂) : AlgHom.comp (e : A₁ →ₐ[R] A₂) ↑e.symm = AlgHom.id R A₂ := by
@@ -380,6 +363,51 @@ theorem leftInverse_symm (e : A₁ ≃ₐ[R] A₂) : Function.LeftInverse e.symm
 
 theorem rightInverse_symm (e : A₁ ≃ₐ[R] A₂) : Function.RightInverse e.symm e :=
   e.right_inv
+
+end symm
+
+section simps
+
+-- Porting note: the default simps projection was `e.toEquiv.toFun`, it should be `FunLike.coe`
+/-- See Note [custom simps projection] -/
+def Simps.apply (e : A₁ ≃ₐ[R] A₂) : A₁ → A₂ :=
+  e
+
+-- Porting note: the default simps projection was `e.toEquiv`, it should be `EquivLike.toEquiv`
+/-- See Note [custom simps projection] -/
+def Simps.toEquiv (e : A₁ ≃ₐ[R] A₂) : A₁ ≃ A₂ :=
+  e
+
+/-- See Note [custom simps projection] -/
+def Simps.symm_apply (e : A₁ ≃ₐ[R] A₂) : A₂ → A₁ :=
+  e.symm
+
+initialize_simps_projections AlgEquiv (toFun → apply, invFun → symm_apply)
+
+end simps
+
+section trans
+
+/-- Algebra equivalences are transitive. -/
+@[trans]
+def trans (e₁ : A₁ ≃ₐ[R] A₂) (e₂ : A₂ ≃ₐ[R] A₃) : A₁ ≃ₐ[R] A₃ :=
+  { e₁.toRingEquiv.trans e₂.toRingEquiv with
+    commutes' := fun r => show e₂.toFun (e₁.toFun _) = _ by rw [e₁.commutes', e₂.commutes'] }
+
+@[simp]
+theorem coe_trans (e₁ : A₁ ≃ₐ[R] A₂) (e₂ : A₂ ≃ₐ[R] A₃) : ⇑(e₁.trans e₂) = e₂ ∘ e₁ :=
+  rfl
+
+@[simp]
+theorem trans_apply (e₁ : A₁ ≃ₐ[R] A₂) (e₂ : A₂ ≃ₐ[R] A₃) (x : A₁) : (e₁.trans e₂) x = e₂ (e₁ x) :=
+  rfl
+
+@[simp]
+theorem symm_trans_apply (e₁ : A₁ ≃ₐ[R] A₂) (e₂ : A₂ ≃ₐ[R] A₃) (x : A₃) :
+    (e₁.trans e₂).symm x = e₁.symm (e₂.symm x) :=
+  rfl
+
+end trans
 
 /-- If `A₁` is equivalent to `A₁'` and `A₂` is equivalent to `A₂'`, then the type of maps
 `A₁ →ₐ[R] A₂` is equivalent to the type of maps `A₁' →ₐ[R] A₂'`. -/

--- a/Mathlib/Algebra/Group/Equiv/Basic.lean
+++ b/Mathlib/Algebra/Group/Equiv/Basic.lean
@@ -90,6 +90,12 @@ add_decl_doc MulEquiv.toEquiv
 /-- The `MulHom` underlying a `MulEquiv`. -/
 add_decl_doc MulEquiv.toMulHom
 
+/-- Notation for a `MulEquiv`. -/
+infixl:25 " ≃* " => MulEquiv
+
+/-- Notation for an `AddEquiv`. -/
+infixl:25 " ≃+ " => AddEquiv
+
 /-- `MulEquivClass F A B` states that `F` is a type of multiplication-preserving morphisms.
 You should extend this class when you extend `MulEquiv`. -/
 -- TODO: make this a synonym for MulHomClass?
@@ -98,12 +104,6 @@ class MulEquivClass (F : Type*) (A B : outParam Type*) [Mul A] [Mul B] [EquivLik
     Prop where
   /-- Preserves multiplication. -/
   map_mul : ∀ (f : F) (a b), f (a * b) = f a * f b
-
-/-- Notation for a `MulEquiv`. -/
-infixl:25 " ≃* " => MulEquiv
-
-/-- Notation for an `AddEquiv`. -/
-infixl:25 " ≃+ " => AddEquiv
 
 namespace MulEquivClass
 
@@ -171,6 +171,8 @@ namespace MulEquiv
 section Mul
 variable [Mul M] [Mul N] [Mul P] [Mul Q]
 
+section coe
+
 @[to_additive]
 instance : EquivLike (M ≃* N) M N where
   coe f := f.toFun
@@ -183,13 +185,35 @@ instance : EquivLike (M ≃* N) M N where
     congr
     apply Equiv.coe_fn_injective h₁
 
+@[to_additive] -- shortcut instance that doesn't generate any subgoals
+instance : CoeFun (M ≃* N) fun _ ↦ M → N where
+  coe f := f
+
 @[to_additive]
 instance : MulEquivClass (M ≃* N) M N where
   map_mul f := f.map_mul'
 
-@[to_additive] -- shortcut instance that doesn't generate any subgoals
-instance : CoeFun (M ≃* N) fun _ ↦ M → N where
-  coe f := f
+/-- Two multiplicative isomorphisms agree if they are defined by the
+same underlying function. -/
+@[to_additive (attr := ext)
+  "Two additive isomorphisms agree if they are defined by the same underlying function."]
+theorem ext {f g : MulEquiv M N} (h : ∀ x, f x = g x) : f = g :=
+  DFunLike.ext f g h
+
+@[to_additive]
+protected theorem congr_arg {f : MulEquiv M N} {x x' : M} : x = x' → f x = f x' :=
+  DFunLike.congr_arg f
+
+@[to_additive]
+protected theorem congr_fun {f g : MulEquiv M N} (h : f = g) (x : M) : f x = g x :=
+  DFunLike.congr_fun h x
+
+@[to_additive (attr := simp)]
+theorem coe_mk (f : M ≃ N) (hf : ∀ x y, f (x * y) = f x * f y) : (mk f hf : M → N) = f := rfl
+
+@[to_additive (attr := simp)]
+theorem mk_coe (e : M ≃* N) (e' h₁ h₂ h₃) : (⟨⟨e, e', h₁, h₂⟩, h₃⟩ : M ≃* N) = e :=
+  ext fun _ => rfl
 
 @[to_additive (attr := simp)]
 theorem toEquiv_eq_coe (f : M ≃* N) : f.toEquiv = f :=
@@ -210,6 +234,14 @@ theorem coe_toEquiv (f : M ≃* N) : ⇑(f : M ≃ N) = f := rfl
 @[to_additive (attr := simp 1100)]
 theorem coe_toMulHom {f : M ≃* N} : (f.toMulHom : M → N) = f := rfl
 
+/-- Makes a multiplicative isomorphism from a bijection which preserves multiplication. -/
+@[to_additive "Makes an additive isomorphism from a bijection which preserves addition."]
+def mk' (f : M ≃ N) (h : ∀ x y, f (x * y) = f x * f y) : M ≃* N := ⟨f, h⟩
+
+end coe
+
+section map
+
 /-- A multiplicative isomorphism preserves multiplication. -/
 @[to_additive "An additive isomorphism preserves addition."]
 protected theorem map_mul (f : M ≃* N) : ∀ x y, f (x * y) = f x * f y :=
@@ -218,9 +250,9 @@ protected theorem map_mul (f : M ≃* N) : ∀ x y, f (x * y) = f x * f y :=
 attribute [deprecated map_mul (since := "2024-08-08")] MulEquiv.map_mul
 attribute [deprecated map_add (since := "2024-08-08")] AddEquiv.map_add
 
-/-- Makes a multiplicative isomorphism from a bijection which preserves multiplication. -/
-@[to_additive "Makes an additive isomorphism from a bijection which preserves addition."]
-def mk' (f : M ≃ N) (h : ∀ x y, f (x * y) = f x * f y) : M ≃* N := ⟨f, h⟩
+end map
+
+section bijective
 
 @[to_additive]
 protected theorem bijective (e : M ≃* N) : Function.Bijective e :=
@@ -234,6 +266,15 @@ protected theorem injective (e : M ≃* N) : Function.Injective e :=
 protected theorem surjective (e : M ≃* N) : Function.Surjective e :=
   EquivLike.surjective e
 
+-- Porting note (#10618): `simp` can prove this
+@[to_additive]
+theorem apply_eq_iff_eq (e : M ≃* N) {x y : M} : e x = e y ↔ x = y :=
+  e.injective.eq_iff
+
+end bijective
+
+section refl
+
 /-- The identity map is a multiplicative isomorphism. -/
 @[to_additive (attr := refl) "The identity map is an additive isomorphism."]
 def refl (M : Type*) [Mul M] : M ≃* M :=
@@ -241,6 +282,16 @@ def refl (M : Type*) [Mul M] : M ≃* M :=
 
 @[to_additive]
 instance : Inhabited (M ≃* M) := ⟨refl M⟩
+
+@[to_additive (attr := simp)]
+theorem coe_refl : ↑(refl M) = id := rfl
+
+@[to_additive (attr := simp)]
+theorem refl_apply (m : M) : refl M m = m := rfl
+
+end refl
+
+section symm
 
 /-- An alias for `h.symm.map_mul`. Introduced to fix the issue in
 https://leanprover.zulipchat.com/#narrow/stream/287929-mathlib4/topic/!4.234183.20.60simps.60.20maximum.20recursion.20depth
@@ -265,23 +316,8 @@ theorem coe_toEquiv_symm (f : M ≃* N) : ((f : M ≃ N).symm : N → M) = f.sym
 @[to_additive (attr := simp)]
 theorem equivLike_inv_eq_symm (f : M ≃* N) : EquivLike.inv f = f.symm := rfl
 
--- we don't hyperlink the note in the additive version, since that breaks syntax highlighting
--- in the whole file.
-
-/-- See Note [custom simps projection] -/
-@[to_additive "See Note [custom simps projection]"] -- this comment fixes the syntax highlighting "
-def Simps.symm_apply (e : M ≃* N) : N → M :=
-  e.symm
-
-initialize_simps_projections AddEquiv (toFun → apply, invFun → symm_apply)
-
-initialize_simps_projections MulEquiv (toFun → apply, invFun → symm_apply)
-
 @[to_additive (attr := simp)]
 theorem toEquiv_symm (f : M ≃* N) : (f.symm : N ≃ M) = (f : M ≃ N).symm := rfl
-
-@[to_additive (attr := simp)]
-theorem coe_mk (f : M ≃ N) (hf : ∀ x y, f (x * y) = f x * f y) : (mk f hf : M → N) = f := rfl
 
 -- Porting note: `toEquiv_mk` no longer needed in Lean4
 
@@ -293,18 +329,15 @@ theorem symm_bijective : Function.Bijective (symm : (M ≃* N) → N ≃* M) :=
   Function.bijective_iff_has_inverse.mpr ⟨_, symm_symm, symm_symm⟩
 
 @[to_additive (attr := simp)]
+theorem mk_coe' (e : M ≃* N) (f h₁ h₂ h₃) : (MulEquiv.mk ⟨f, e, h₁, h₂⟩ h₃ : N ≃* M) = e.symm :=
+  symm_bijective.injective <| ext fun _ => rfl
+
+@[to_additive (attr := simp)]
 theorem symm_mk (f : M ≃ N) (h) :
     (MulEquiv.mk f h).symm = ⟨f.symm, (MulEquiv.mk f h).symm_map_mul⟩ := rfl
 
 @[to_additive (attr := simp)]
 theorem refl_symm : (refl M).symm = refl M := rfl
-
-/-- Transitivity of multiplication-preserving isomorphisms -/
-@[to_additive (attr := trans) "Transitivity of addition-preserving isomorphisms"]
-def trans (h1 : M ≃* N) (h2 : N ≃* P) : M ≃* P :=
-  { h1.toEquiv.trans h2.toEquiv with
-    map_mul' := fun x y => show h2 (h1 (x * y)) = h2 (h1 x) * h2 (h1 y) by
-      rw [map_mul, map_mul] }
 
 /-- `e.symm` is a right inverse of `e`, written as `e (e.symm y) = y`. -/
 @[to_additive (attr := simp) "`e.symm` is a right inverse of `e`, written as `e (e.symm y) = y`."]
@@ -323,27 +356,6 @@ theorem symm_comp_self (e : M ≃* N) : e.symm ∘ e = id :=
 @[to_additive (attr := simp)]
 theorem self_comp_symm (e : M ≃* N) : e ∘ e.symm = id :=
   funext e.apply_symm_apply
-
-@[to_additive (attr := simp)]
-theorem coe_refl : ↑(refl M) = id := rfl
-
-@[to_additive (attr := simp)]
-theorem refl_apply (m : M) : refl M m = m := rfl
-
-@[to_additive (attr := simp)]
-theorem coe_trans (e₁ : M ≃* N) (e₂ : N ≃* P) : ↑(e₁.trans e₂) = e₂ ∘ e₁ := rfl
-
-@[to_additive (attr := simp)]
-theorem trans_apply (e₁ : M ≃* N) (e₂ : N ≃* P) (m : M) : e₁.trans e₂ m = e₂ (e₁ m) := rfl
-
-@[to_additive (attr := simp)]
-theorem symm_trans_apply (e₁ : M ≃* N) (e₂ : N ≃* P) (p : P) :
-    (e₁.trans e₂).symm p = e₁.symm (e₂.symm p) := rfl
-
--- Porting note (#10618): `simp` can prove this
-@[to_additive]
-theorem apply_eq_iff_eq (e : M ≃* N) {x y : M} : e x = e y ↔ x = y :=
-  e.injective.eq_iff
 
 @[to_additive]
 theorem apply_eq_iff_symm_apply (e : M ≃* N) {x : M} {y : N} : e x = y ↔ x = e.symm y :=
@@ -377,6 +389,43 @@ theorem symm_comp_eq {α : Type*} (e : M ≃* N) (f : α → M) (g : α → N) :
     e.symm ∘ g = f ↔ g = e ∘ f :=
   e.toEquiv.symm_comp_eq f g
 
+end symm
+
+section simps
+
+-- we don't hyperlink the note in the additive version, since that breaks syntax highlighting
+-- in the whole file.
+
+/-- See Note [custom simps projection] -/
+@[to_additive "See Note [custom simps projection]"] -- this comment fixes the syntax highlighting "
+def Simps.symm_apply (e : M ≃* N) : N → M :=
+  e.symm
+
+initialize_simps_projections AddEquiv (toFun → apply, invFun → symm_apply)
+
+initialize_simps_projections MulEquiv (toFun → apply, invFun → symm_apply)
+
+end simps
+
+section trans
+
+/-- Transitivity of multiplication-preserving isomorphisms -/
+@[to_additive (attr := trans) "Transitivity of addition-preserving isomorphisms"]
+def trans (h1 : M ≃* N) (h2 : N ≃* P) : M ≃* P :=
+  { h1.toEquiv.trans h2.toEquiv with
+    map_mul' := fun x y => show h2 (h1 (x * y)) = h2 (h1 x) * h2 (h1 y) by
+      rw [map_mul, map_mul] }
+
+@[to_additive (attr := simp)]
+theorem coe_trans (e₁ : M ≃* N) (e₂ : N ≃* P) : ↑(e₁.trans e₂) = e₂ ∘ e₁ := rfl
+
+@[to_additive (attr := simp)]
+theorem trans_apply (e₁ : M ≃* N) (e₂ : N ≃* P) (m : M) : e₁.trans e₂ m = e₂ (e₁ m) := rfl
+
+@[to_additive (attr := simp)]
+theorem symm_trans_apply (e₁ : M ≃* N) (e₂ : N ≃* P) (p : P) :
+    (e₁.trans e₂).symm p = e₁.symm (e₂.symm p) := rfl
+
 @[to_additive (attr := simp)]
 theorem symm_trans_self (e : M ≃* N) : e.symm.trans e = refl N :=
   DFunLike.ext _ _ e.apply_symm_apply
@@ -385,28 +434,7 @@ theorem symm_trans_self (e : M ≃* N) : e.symm.trans e = refl N :=
 theorem self_trans_symm (e : M ≃* N) : e.trans e.symm = refl M :=
   DFunLike.ext _ _ e.symm_apply_apply
 
-/-- Two multiplicative isomorphisms agree if they are defined by the
-same underlying function. -/
-@[to_additive (attr := ext)
-  "Two additive isomorphisms agree if they are defined by the same underlying function."]
-theorem ext {f g : MulEquiv M N} (h : ∀ x, f x = g x) : f = g :=
-  DFunLike.ext f g h
-
-@[to_additive (attr := simp)]
-theorem mk_coe (e : M ≃* N) (e' h₁ h₂ h₃) : (⟨⟨e, e', h₁, h₂⟩, h₃⟩ : M ≃* N) = e :=
-  ext fun _ => rfl
-
-@[to_additive (attr := simp)]
-theorem mk_coe' (e : M ≃* N) (f h₁ h₂ h₃) : (MulEquiv.mk ⟨f, e, h₁, h₂⟩ h₃ : N ≃* M) = e.symm :=
-  symm_bijective.injective <| ext fun _ => rfl
-
-@[to_additive]
-protected theorem congr_arg {f : MulEquiv M N} {x x' : M} : x = x' → f x = f x' :=
-  DFunLike.congr_arg f
-
-@[to_additive]
-protected theorem congr_fun {f g : MulEquiv M N} (h : f = g) (x : M) : f x = g x :=
-  DFunLike.congr_fun h x
+end trans
 
 /-- The `MulEquiv` between two monoids with a unique element. -/
 @[to_additive "The `AddEquiv` between two `AddMonoid`s with a unique element."]


### PR DESCRIPTION
The API for the various `*Equiv` types is inconsistent both in what results are exposed and how they are organized. This PR takes a first step towards improving the latter, by organizing results into sections for `Mul/AddEquiv` and `AlgEquiv`, and putting the same results in the same order within those. This organization could easily be extended to other similar types after this PR.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
