### PR TITLE
[Merged by Bors] - feat(SetTheory/Ordinal/Arithmetic): the complement of a small set of ordinals is unbounded

### DIFF
--- a/Mathlib/Logic/Small/Set.lean
+++ b/Mathlib/Logic/Small/Set.lean
@@ -41,6 +41,9 @@ instance small_image2 (f : α → β → γ) (s : Set α) (t : Set β) [Small.{u
   rw [← Set.image_uncurry_prod]
   infer_instance
 
+theorem small_univ_iff : Small.{u} (@Set.univ α) ↔ Small.{u} α :=
+  small_congr <| Equiv.Set.univ α
+
 instance small_union (s t : Set α) [Small.{u} s] [Small.{u} t] :
     Small.{u} (s ∪ t : Set α) := by
   rw [← Subtype.range_val (s := s), ← Subtype.range_val (s := t), ← Set.Sum.elim_range]

--- a/Mathlib/Logic/Small/Set.lean
+++ b/Mathlib/Logic/Small/Set.lean
@@ -44,6 +44,9 @@ instance small_image2 (f : α → β → γ) (s : Set α) (t : Set β) [Small.{u
 theorem small_univ_iff : Small.{u} (@Set.univ α) ↔ Small.{u} α :=
   small_congr <| Equiv.Set.univ α
 
+instance small_univ [h : Small.{u} α] : Small.{u} (@Set.univ α) :=
+  small_univ_iff.2 h
+
 instance small_union (s t : Set α) [Small.{u} s] [Small.{u} t] :
     Small.{u} (s ∪ t : Set α) := by
   rw [← Subtype.range_val (s := s), ← Subtype.range_val (s := t), ← Set.Sum.elim_range]

--- a/Mathlib/SetTheory/Ordinal/Arithmetic.lean
+++ b/Mathlib/SetTheory/Ordinal/Arithmetic.lean
@@ -2009,11 +2009,13 @@ the Burali-Forti paradox. -/
 theorem not_small_ordinal : ¬Small.{u} Ordinal.{max u v} := fun h =>
   @not_injective_of_ordinal_of_small _ h _ fun _a _b => Ordinal.lift_inj.{v, u}.1
 
-theorem Ordinal.compl_nonempty_of_small (s : Set Ordinal.{u}) [hs : Small.{u} s] :
-    Set.Nonempty sᶜ := by
-  by_contra! h
-  rw [compl_empty_iff.1 h, small_univ_iff] at hs
-  exact not_small_ordinal hs
+theorem Ordinal.not_bddAbove_compl_of_small (s : Set Ordinal.{u}) [hs : Small.{u} s] :
+    ¬BddAbove sᶜ := by
+  rw [bddAbove_iff_small]
+  intro h
+  have := small_union s sᶜ
+  rw [union_compl_self, small_univ_iff] at this
+  exact not_small_ordinal this
 
 /-! ### Enumerating unbounded sets of ordinals with ordinals -/
 

--- a/Mathlib/SetTheory/Ordinal/Arithmetic.lean
+++ b/Mathlib/SetTheory/Ordinal/Arithmetic.lean
@@ -2009,6 +2009,12 @@ the Burali-Forti paradox. -/
 theorem not_small_ordinal : ¬Small.{u} Ordinal.{max u v} := fun h =>
   @not_injective_of_ordinal_of_small _ h _ fun _a _b => Ordinal.lift_inj.{v, u}.1
 
+theorem Ordinal.compl_nonempty_of_small (s : Set Ordinal.{u}) [hs : Small.{u} s] :
+    Set.Nonempty sᶜ := by
+  by_contra! h
+  rw [compl_empty_iff.1 h, small_univ_iff] at hs
+  exact not_small_ordinal hs
+
 /-! ### Enumerating unbounded sets of ordinals with ordinals -/
 
 


### PR DESCRIPTION
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
