### PR TITLE
[Merged by Bors] - feat(Order/InitialSeg): Subsingleton (α ≃o β) on well-orders

### DIFF
--- a/Mathlib/Data/Finset/Sort.lean
+++ b/Mathlib/Data/Finset/Sort.lean
@@ -188,8 +188,8 @@ theorem orderEmbOfFin_singleton (a : α) (i : Fin 1) :
 the increasing bijection `orderEmbOfFin s h`. -/
 theorem orderEmbOfFin_unique {s : Finset α} {k : ℕ} (h : s.card = k) {f : Fin k → α}
     (hfs : ∀ x, f x ∈ s) (hmono : StrictMono f) : f = s.orderEmbOfFin h := by
-  apply Fin.strictMono_unique hmono (s.orderEmbOfFin h).strictMono
-  rw [range_orderEmbOfFin, ← Set.image_univ, ← coe_univ, ← coe_image, coe_inj]
+  rw [← hmono.range_inj (s.orderEmbOfFin h).strictMono, range_orderEmbOfFin, ← Set.image_univ,
+    ← coe_univ, ← coe_image, coe_inj]
   refine eq_of_subset_of_card_le (fun x hx => ?_) ?_
   · rcases mem_image.1 hx with ⟨x, _, rfl⟩
     exact hfs x

--- a/Mathlib/Order/Fin/Basic.lean
+++ b/Mathlib/Order/Fin/Basic.lean
@@ -279,25 +279,16 @@ map. In this lemma we state that for each `i : Fin n` we have `(e i : ℕ) = (i 
     simpa using h _ this (e.symm _).is_lt
   · rwa [← h j hj (hj.trans hi), ← lt_iff_val_lt_val, e.lt_iff_lt]
 
-instance orderIso_subsingleton : Subsingleton (Fin n ≃o α) :=
-  ⟨fun e e' => by
-    ext i
-    rw [← e.symm.apply_eq_iff_eq, e.symm_apply_apply, ← e'.trans_apply, Fin.ext_iff,
-      coe_orderIso_apply]⟩
-
-instance orderIso_subsingleton' : Subsingleton (α ≃o Fin n) := OrderIso.symm_injective.subsingleton
-
-instance orderIsoUnique : Unique (Fin n ≃o Fin n) := Unique.mk' _
-
 /-- Two strictly monotone functions from `Fin n` are equal provided that their ranges
 are equal. -/
+@[deprecated StrictMono.range_inj (since := "2024-09-17")]
 lemma strictMono_unique {f g : Fin n → α} (hf : StrictMono f) (hg : StrictMono g)
     (h : range f = range g) : f = g :=
-  have : (hf.orderIso f).trans (OrderIso.setCongr _ _ h) = hg.orderIso g := Subsingleton.elim _ _
-  congr_arg (Function.comp (Subtype.val : range g → α)) (funext <| RelIso.ext_iff.1 this)
+  (hf.range_inj hg).1 h
 
 /-- Two order embeddings of `Fin n` are equal provided that their ranges are equal. -/
+@[deprecated OrderEmbedding.range_inj (since := "2024-09-17")]
 lemma orderEmbedding_eq {f g : Fin n ↪o α} (h : range f = range g) : f = g :=
-  RelEmbedding.ext <| funext_iff.1 <| strictMono_unique f.strictMono g.strictMono h
+  OrderEmbedding.range_inj.1 h
 
 end Fin

--- a/Mathlib/Order/Hom/Set.lean
+++ b/Mathlib/Order/Hom/Set.lean
@@ -127,6 +127,9 @@ lemma OrderEmbedding.range_inj [LinearOrder α] [WellFoundedLT α] [Preorder β]
 
 namespace OrderIso
 
+-- These results are also true whenever β is well-founded instead of α.
+-- You can use `RelEmbedding.isWellFounded` to transfer the instance over.
+
 instance subsingleton_of_wellFoundedLT [LinearOrder α] [WellFoundedLT α] [Preorder β] :
     Subsingleton (α ≃o β) := by
   refine ⟨fun f g ↦ ?_⟩

--- a/Mathlib/Order/Hom/Set.lean
+++ b/Mathlib/Order/Hom/Set.lean
@@ -121,9 +121,41 @@ theorem orderIsoOfSurjective_self_symm_apply (b : β) :
 end StrictMono
 
 /-- Two order embeddings on a well-order are equal provided that their ranges are equal. -/
-lemma OrderEmbedding.range_inj [LinearOrder α] [WellFoundedLT α] [PartialOrder β] {f g : α ↪o β} :
+lemma OrderEmbedding.range_inj [LinearOrder α] [WellFoundedLT α] [Preorder β] {f g : α ↪o β} :
     Set.range f = Set.range g ↔ f = g := by
   rw [f.strictMono.range_inj g.strictMono, DFunLike.coe_fn_eq]
+
+namespace OrderIso
+
+instance subsingleton_of_wellFoundedLT [LinearOrder α] [WellFoundedLT α] [Preorder β] :
+    Subsingleton (α ≃o β) := by
+  refine ⟨fun f g ↦ ?_⟩
+  rw [OrderIso.ext_iff, ← coe_toOrderEmbedding, ← coe_toOrderEmbedding, DFunLike.coe_fn_eq,
+    ← OrderEmbedding.range_inj, coe_toOrderEmbedding, coe_toOrderEmbedding, range_eq, range_eq]
+
+instance subsingleton_of_wellFoundedLT' [LinearOrder β] [WellFoundedLT β] [Preorder α] :
+    Subsingleton (α ≃o β) := by
+  refine ⟨fun f g ↦ ?_⟩
+  change f.symm.symm = g.symm.symm
+  rw [Subsingleton.elim f.symm]
+
+instance unique_of_wellFoundedLT [LinearOrder α] [WellFoundedLT α] : Unique (α ≃o α) := Unique.mk' _
+
+instance subsingleton_of_wellFoundedGT [LinearOrder α] [WellFoundedGT α] [Preorder β] :
+    Subsingleton (α ≃o β) := by
+  refine ⟨fun f g ↦ ?_⟩
+  change f.dual.dual = g.dual.dual
+  rw [Subsingleton.elim f.dual]
+
+instance subsingleton_of_wellFoundedGT' [LinearOrder β] [WellFoundedGT β] [Preorder α] :
+    Subsingleton (α ≃o β) := by
+  refine ⟨fun f g ↦ ?_⟩
+  change f.dual.dual = g.dual.dual
+  rw [Subsingleton.elim f.dual]
+
+instance unique_of_wellFoundedGT [LinearOrder α] [WellFoundedGT α] : Unique (α ≃o α) := Unique.mk' _
+
+end OrderIso
 
 section BooleanAlgebra
 

--- a/Mathlib/Order/WellFounded.lean
+++ b/Mathlib/Order/WellFounded.lean
@@ -138,13 +138,13 @@ theorem Set.range_injOn_strictMono [WellFoundedLT β] :
   obtain ⟨b, hb⟩ := hfg ▸ mem_range_self a
   obtain h | rfl | h := lt_trichotomy b a
   · rw [← IH b h] at hb
-    exact ((hf.injective hb).not_lt h).elim
+    cases (hf.injective hb).not_lt h
   · rw [hb]
   · obtain ⟨c, hc⟩ := hfg.symm ▸ mem_range_self a
     have := hg h
     rw [hb, ← hc, hf.lt_iff_lt] at this
     rw [IH c this] at hc
-    exact ((hg.injective hc).not_lt this).elim
+    cases (hg.injective hc).not_lt this
 
 theorem Set.range_injOn_strictAnti [WellFoundedGT β] :
     Set.InjOn Set.range { f : β → γ | StrictAnti f } :=

--- a/Mathlib/Order/WellFounded.lean
+++ b/Mathlib/Order/WellFounded.lean
@@ -123,27 +123,28 @@ end WellFounded
 
 section LinearOrder
 
-variable [LinearOrder β] [PartialOrder γ]
+variable [LinearOrder β] [Preorder γ]
 
 theorem WellFounded.min_le (h : WellFounded ((· < ·) : β → β → Prop))
     {x : β} {s : Set β} (hx : x ∈ s) (hne : s.Nonempty := ⟨x, hx⟩) : h.min s hne ≤ x :=
   not_lt.1 <| h.not_lt_min _ _ hx
-
-private theorem range_injOn_strictMono_aux {f g : β → γ} (hf : StrictMono f) (hg : StrictMono g)
-    (hfg : Set.range f = Set.range g) {b : β} (H : ∀ a < b, f a = g a) : f b ≤ g b := by
-  obtain ⟨c, hc⟩ : g b ∈ Set.range f := hfg ▸ Set.mem_range_self b
-  rcases lt_or_le c b with hcb | hbc
-  · rw [H c hcb, hg.injective.eq_iff] at hc
-    exact (hc.not_lt hcb).elim
-  · rwa [← hc, hf.le_iff_le]
 
 theorem Set.range_injOn_strictMono [WellFoundedLT β] :
     Set.InjOn Set.range { f : β → γ | StrictMono f } := by
   intro f hf g hg hfg
   ext a
   apply WellFoundedLT.induction a
-  exact fun b IH => (range_injOn_strictMono_aux hf hg hfg IH).antisymm
-    (range_injOn_strictMono_aux hg hf hfg.symm fun a hab => (IH a hab).symm)
+  intro a IH
+  obtain ⟨b, hb⟩ := hfg ▸ mem_range_self a
+  obtain h | rfl | h := lt_trichotomy b a
+  · rw [← IH b h] at hb
+    exact ((hf.injective hb).not_lt h).elim
+  · rw [hb]
+  · obtain ⟨c, hc⟩ := hfg.symm ▸ mem_range_self a
+    have := hg h
+    rw [hb, ← hc, hf.lt_iff_lt] at this
+    rw [IH c this] at hc
+    exact ((hg.injective hc).not_lt this).elim
 
 theorem Set.range_injOn_strictAnti [WellFoundedGT β] :
     Set.InjOn Set.range { f : β → γ | StrictAnti f } :=


### PR DESCRIPTION
This allows us to generalize an instance which stated this for `Fin n`. 

We also generalize `StrictMono.range_inj` for maps into preorders.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
