### PR TITLE
[Merged by Bors] - feat(Archive/Imo): formalize IMO 1982q1

### DIFF
--- a/Archive.lean
+++ b/Archive.lean
@@ -18,6 +18,7 @@ import Archive.Imo.Imo1972Q5
 import Archive.Imo.Imo1975Q1
 import Archive.Imo.Imo1977Q6
 import Archive.Imo.Imo1981Q3
+import Archive.Imo.Imo1982Q1
 import Archive.Imo.Imo1986Q5
 import Archive.Imo.Imo1987Q1
 import Archive.Imo.Imo1988Q6

--- a/Archive/Imo/Imo1982Q1.lean
+++ b/Archive/Imo/Imo1982Q1.lean
@@ -5,6 +5,7 @@ Authors: Alex Brodbelt, Violeta Hernández
 -/
 
 import Mathlib.Tactic.NormNum
+import Mathlib.Tactic.Linarith
 import Mathlib.Data.PNat.Basic
 
 /-!
@@ -102,7 +103,7 @@ lemma part_2 : f 1980 ≤ 660 := by
     _ = 5 * 660 + 33 := by rw [hf.f_9999]
   rw [hf.f₃, mul_one] at h
   -- from 5 * f 1980 + 33 ≤ 5 * 660 + 33 we show f 1980 ≤ 660
-  exact le_of_mul_le_mul_left (le_of_add_le_add_right h) (Nat.succ_pos 4)
+  linarith
 
 end IsGood
 

--- a/Archive/Imo/Imo1982Q1.lean
+++ b/Archive/Imo/Imo1982Q1.lean
@@ -10,40 +10,40 @@ import Mathlib.Data.PNat.Basic
 /-!
 # IMO 1982 Q1
 
-The function $f(n)$ is defined for all postive integers $n$ and takes on
-non-negative integer values. Also, for all $m$, $n$
+The function `f` is defined for all positive integers `n` and takes on
+non-negative integer values. Also, for all `m`, `n`
 
-$f (m + n) - f(m) - f(n) = 0 \text{ or } 1$
-$f(2) = 0, f(3) > 0, and f(9999) = 3333.$
+`f (m + n) - f(m) - f(n) = 0` or `1`
+`f 2 = 0`, `f 3 > 0`, and `f 9999 = 3333`.
 
-Determine $f(1982)$.
+Determine `f 1982`.
 
 The solution is based on the one at the
 [Art of Problem Solving](https://artofproblemsolving.com/wiki/index.php/1982_IMO_Problems/Problem_1)
 website.
 
 We prove the helper lemmas:
-1. $nf(m) \leq f(mn)$ `superhomogeneous`.
-2. $f(m) + f(n) \leq f(m + n)$ `superadditive`.
-3. $a f(a) + c f(d) \leq f(a \cdot b + c \cdot d)$ `superlinear`, (derived from 1. and 2.).
+1. `f m + f n ≤ f(m + n)` `superadditive`.
+2. `n * f(m) ≤ f(m * n)` `superhomogeneous`.
+3. `a * f a  + c * f d ≤ f (a * b + c * d)` `superlinear`, (derived from 1. and 2.).
 
-So we can establish on the one hand that $f(1980) \leq 660$,
-by observing that $660\cdot 1 = 660 f(3) \leq f(1980) = f(660\cdot 3)$.
+So we can establish on the one hand that `f 1980 ≤ 660`,
+by observing that `660 * 1 = 660 * f3 ≤ f 1980 = f (660 * 3)`.
 
-On the other hand, we establish that $f(1980) \geq 660$
-from $5 \cdot f(1980) + 33\cdot f(3) \leq f(5\cdot 1980 + 33\cdot 1) = f(9999) = 3333$.
+On the other hand, we establish that `f 1980 ≥ 660`
+from `5 * f 1980 + 33 * f 3 ≤ f (5 * 1980 + 33 * 1) = f 9999 = 3333`.
 
-We then conclude $f(1980) = 660$ and then eventually determine that either
-$f(1982) = 660$ or $f(1982) = 661$.
+We then conclude `f 1980 = 660` and then eventually determine that either
+`f 1982 = 660` or `f 1982 = 661`.
 
-In the latter case we derive a contradiction, because if $f(1982) = 661$ then
-$3334 = 5\cdot f(1982) + 29\cdot f(3) + f(2) \leq f(5\cdot 1982 + 29\cdot 3 + 2) = f(9999) = 3333$.
+In the latter case we derive a contradiction, because if `f 1982 = 661` then
+`3334 = 5 * f 1982 + 29 * f(3) + f(2) ≤ f (5 * 1982 + 29 * 3 + 2) = f 9999 = 3333`.
 -/
 
 namespace Imo1982Q1
 
 structure IsGood (f : ℕ+ → ℕ) : Prop where
-  /-- Satisfies the functional relation-/
+  /-- The function satisfies the functional relation-/
   rel: ∀ m n : ℕ+, f (m + n) = f m + f n ∨ f (m + n) = f m + f n + 1
   f₂ : f 2 = 0
   hf₃ : 0 < f 3
@@ -69,32 +69,31 @@ lemma f₃ : f 3 = 1 := by
     rw [or_iff_right (not_left)] at h
     exact h
 
-lemma superhomogeneous {m n : ℕ+} : ↑n * f m ≤ f (n * m) := by
-  induction n using PNat.recOn
-  case p1 => simp
-  case hp n' ih =>
-    have rel : f (n' * m + m) = f (n' * m) + f (m) ∨
-               f (n' * m + m) = f (n' * m) + f (m) + 1 := hf.rel (n' * m) m
-    calc
-    ↑(n' + 1) * f m = ↑n' * f m + f m := by rw [PNat.add_coe, add_mul, PNat.val_ofNat, one_mul];
-    _ ≤ f (n' * m) + f m := add_le_add_right ih (f m)
-    _ ≤ f (n' * m + m) := by
-      rcases rel with ( hl | hr)
-      · rw [hl]
-      · rw [hr]; nth_rewrite 1 [← add_zero (f m), ← add_assoc]; apply add_le_add_left (by norm_num)
-    _ = f ((n' + 1) * m) := by congr; rw [add_mul, one_mul]
-
 lemma superadditive {m n : ℕ+} : f m + f n ≤ f (m + n) := by
   have h := hf.rel m n
   rcases h with ( hl | hr )
   · rw [hl]
   · rw [hr]; nth_rewrite 1 [← add_zero (f n), ← add_assoc]; apply add_le_add_right (by norm_num)
 
+lemma superhomogeneous {m n : ℕ+} : ↑n * f m ≤ f (n * m) := by
+  induction n using PNat.recOn
+  case p1 => simp
+  case hp n' ih =>
+    calc
+    ↑(n' + 1) * f m = ↑n' * f m + f m := by rw [PNat.add_coe, add_mul, PNat.val_ofNat, one_mul]
+    _ ≤ f (n' * m) + f m := add_le_add_right ih (f m)
+    _ ≤ f (n' * m + m) := hf.superadditive
+    _ = f ((n' + 1) * m) := by congr; rw [add_mul, one_mul]
+
 lemma superlinear {a b c d : ℕ+} : a * f b + c * f d ≤ f (a * b + c * d) :=
   (add_le_add hf.superhomogeneous hf.superhomogeneous).trans hf.superadditive
 
+lemma le_mul_three_apply (n : ℕ+) : n ≤ f (3 * n) := by
+  rw [← mul_one (n : ℕ), ← hf.f₃, mul_comm 3]
+  exact hf.superhomogeneous
+
 lemma part_1 : 660 ≤ f (1980) := by
-  rw [← mul_one (660), ← PNat.val_ofNat 660, ← hf.f₃]; apply hf.superhomogeneous
+  exact hf.le_mul_three_apply 660
 
 lemma part_2 : f 1980 ≤ 660 := by
   have h : 5 * f 1980 + 33 * f 3 ≤ 5 * 660 + 33 := by
@@ -107,19 +106,20 @@ lemma part_2 : f 1980 ≤ 660 := by
 
 end IsGood
 
+end Imo1982Q1
+
+open Imo1982Q1
+
 lemma imo1982_q1 {f : ℕ+ → ℕ} (hf : IsGood f) : f 1982 = 660 := by
   have f_1980 := hf.part_2.antisymm hf.part_1
   have h : f 1982 = f 1980 + f 2 ∨ f 1982 = f 1980 + f 2 + 1 := hf.rel 1980 2
   rw [f_1980, hf.f₂, add_zero] at h
   apply h.resolve_right
   intro hr
-  have h : 3334 ≤ 3333 := by -- a contradiction
-    calc
-      3334 = 5 * f 1982 + 29 * f 3 + f 2 := by rw [hf.f₃, hf.f₂, hr, add_zero, mul_one]
-      (5 : ℕ+) * f 1982 + (29 : ℕ+) * f 3 + f 2 ≤ f (5 * 1982 + 29 * 3) + f 2 :=
-        add_le_add_right hf.superlinear _
-      _ ≤ f (5 * 1982 + 29 * 3 + 2) := hf.superadditive
-      _ = 3333 := hf.f_9999
-  norm_num at h
-
-end Imo1982Q1
+  suffices h : 3334 ≤ 3333 by norm_num at h
+  calc
+    3334 = 5 * f 1982 + 29 * f 3 + f 2 := by rw [hf.f₃, hf.f₂, hr, add_zero, mul_one]
+    (5 : ℕ+) * f 1982 + (29 : ℕ+) * f 3 + f 2 ≤ f (5 * 1982 + 29 * 3) + f 2 :=
+      add_le_add_right hf.superlinear _
+    _ ≤ f (5 * 1982 + 29 * 3 + 2) := hf.superadditive
+    _ = 3333 := hf.f_9999

--- a/Archive/Imo/Imo1982Q1.lean
+++ b/Archive/Imo/Imo1982Q1.lean
@@ -23,15 +23,15 @@ The solution is based on the one at the
 website.
 
 We prove the helper lemmas:
-1. $nf(m) \leq f(mn)$.
-2. $f(m) + f(n) \leq f(m + n)$.
-3. $a f(a) + c f(d) \leq f(a \cdot b + c \cdot d)$ (derived from 1. and 2.).
+1. $nf(m) \leq f(mn)$ `superhomogeneous`.
+2. $f(m) + f(n) \leq f(m + n)$ `superadditive`.
+3. $a f(a) + c f(d) \leq f(a \cdot b + c \cdot d)$ `superlinear`, (derived from 1. and 2.).
 
 So we can establish on the one hand that $f(1980) \leq 660$,
 by observing that $660\cdot 1 = 660 f(3) \leq f(1980) = f(660\cdot 3)$.
 
 On the other hand, we establish that $f(1980) \geq 660$
-from $5 \cdot f(1980) + 33\cdot f(3) \leq  f(5\cdot 1980 + 33\cdot 1) = f(9999) = 3333$.
+from $5 \cdot f(1980) + 33\cdot f(3) \leq f(5\cdot 1980 + 33\cdot 1) = f(9999) = 3333$.
 
 We then conclude $f(1980) = 660$ and then eventually determine that either
 $f(1982) = 660$ or $f(1982) = 661$.
@@ -69,7 +69,7 @@ lemma f₃ : f 3 = 1 := by
     rw [or_iff_right (not_left)] at h
     exact h
 
-lemma superhomogenous {m n : ℕ+} : ↑n * f m ≤ f (n * m) := by
+lemma superhomogeneous {m n : ℕ+} : ↑n * f m ≤ f (n * m) := by
   induction n using PNat.recOn
   case p1 => simp
   case hp n' ih =>
@@ -91,10 +91,10 @@ lemma superadditive {m n : ℕ+} : f m + f n ≤ f (m + n) := by
   · rw [hr]; nth_rewrite 1 [← add_zero (f n), ← add_assoc]; apply add_le_add_right (by norm_num)
 
 lemma superlinear {a b c d : ℕ+} : a * f b + c * f d ≤ f (a * b + c * d) :=
-  (add_le_add hf.superhomogenous hf.superhomogenous).trans hf.superadditive
+  (add_le_add hf.superhomogeneous hf.superhomogeneous).trans hf.superadditive
 
 lemma part_1 : 660 ≤ f (1980) := by
-  rw [← mul_one (660), ← PNat.val_ofNat 660, ← hf.f₃]; apply hf.superhomogenous
+  rw [← mul_one (660), ← PNat.val_ofNat 660, ← hf.f₃]; apply hf.superhomogeneous
 
 lemma part_2 : f 1980 ≤ 660 := by
   have h : 5 * f 1980 + 33 * f 3 ≤ 5 * 660 + 33 := by

--- a/Archive/Imo/Imo1982Q1.lean
+++ b/Archive/Imo/Imo1982Q1.lean
@@ -86,11 +86,9 @@ lemma part_2 : f 1980 ≤ 660 := by
     calc (5 : ℕ+) * f 1980 + (33 : ℕ+) * f 3 ≤  f (5 * 1980 + 33 * 3) := by apply hf.superlinear
     _ = f 9999 := by rfl
     _ = 5 * 660 + 33 := by rw [hf.f_9999]
-  rw [hf.f₃, mul_one] at *
+  rw [hf.f₃, mul_one] at h
   -- from 5 * f 1980 + 33 ≤ 5 * 660 + 33 we show f 1980 ≤ 660
-  apply le_of_mul_le_mul_left (a := 5) (a0 := by norm_num)
-  apply le_of_add_le_add_right (a := 33)
-  exact h
+  exact le_of_mul_le_mul_left (le_of_add_le_add_right h) (Nat.succ_pos 4)
 
 lemma main : f 1982 = 660 := by
   have f_1980 := hf.part_2.antisymm hf.part_1

--- a/Archive/Imo/Imo1982Q1.lean
+++ b/Archive/Imo/Imo1982Q1.lean
@@ -29,7 +29,7 @@ structure IsGood (f : ℕ+ → ℕ) : Prop where
   /-- Satisfies the functional relation-/
   rel: ∀ m n : ℕ+, f (m + n) = f m + f n ∨ f (m + n) = f m + f n + 1
   f₂ : f 2 = 0
-  hf₃ : f 3 > 0
+  hf₃ : 0 < f 3
   f_9999 : f 9999 = 3333
 
 namespace IsGood

--- a/Archive/Imo/Imo1982Q1.lean
+++ b/Archive/Imo/Imo1982Q1.lean
@@ -23,21 +23,21 @@ The solution is based on the one at the
 website.
 
 We prove the helper lemmas:
-1. $nf(m) \leq f(mn)$
-2. $f(m) + f(n) \leq f(m + n)$
-3. $a f(a) + c f(d) \leq f(a \cdot b + c \cdot d)$ (derived from 1. and 2.)
+1. $nf(m) \leq f(mn)$.
+2. $f(m) + f(n) \leq f(m + n)$.
+3. $a f(a) + c f(d) \leq f(a \cdot b + c \cdot d)$ (derived from 1. and 2.).
 
 So we can establish on the one hand that $f(1980) \leq 660$,
 by observing that $660\cdot 1 = 660 f(3) \leq f(1980) = f(660\cdot 3)$.
 
 On the other hand, we establish that $f(1980) \geq 660$
-from $5 \cdot f(1980) + 33\cdot f(3) \leq  f(5\cdot 1980 + 33\cdot 1) = f(9999) = 3333 $
+from $5 \cdot f(1980) + 33\cdot f(3) \leq  f(5\cdot 1980 + 33\cdot 1) = f(9999) = 3333$.
 
 We then conclude $f(1980) = 660$ and then eventually determine that either
 $f(1982) = 660$ or $f(1982) = 661$.
 
 In the latter case we derive a contradiction, because if $f(1982) = 661$ then
-$3334 = 5\cdot f(1982) + 29\cdot f(3) + f(2) \leq f(5\cdot 1982 + 29\cdot 3 + 2) = f(9999) = 3333$
+$3334 = 5\cdot f(1982) + 29\cdot f(3) + f(2) \leq f(5\cdot 1982 + 29\cdot 3 + 2) = f(9999) = 3333$.
 -/
 
 namespace Imo1982Q1

--- a/Archive/Imo/Imo1982Q1.lean
+++ b/Archive/Imo/Imo1982Q1.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2024 Alex Brodbelt. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Alex Brodbelt
+Authors: Alex Brodbelt, Violeta Hernández
 -/
 
 import Mathlib.Tactic.NormNum
@@ -21,6 +21,11 @@ Determine $f(1982)$.
 The solution is based on the one at the
 [Art of Problem Solving](https://artofproblemsolving.com/wiki/index.php/1982_IMO_Problems/Problem_1)
 website.
+
+We prove that $f(mn) \geq nf(m)$ and $f(m) + f(n) ≤ f(m + n)$
+to establish both that $f(1980) ≤ 660$ and that these properties added with $f(9999) = 3333$
+to establish that $f(1980) ≥ 660$.
+Both these together allow to conclude $f(1980) = 660$ and then eventually determine $f(1982) = 660$.
 -/
 
 namespace Imo1982Q1
@@ -73,10 +78,8 @@ lemma superadditive {m n : ℕ+} : f m + f n ≤ f (m + n) := by
   · rw [hl]
   · rw [hr]; nth_rewrite 1 [← add_zero (f n), ← add_assoc]; apply add_le_add_right (by norm_num)
 
-lemma superlinear {a b c d : ℕ+} : a * f b + c * f d ≤ f (a * b + c * d) := by
-  calc
-  a * f b + c * f d ≤ f (a * b) + f (c * d) := add_le_add hf.superhomogeneity hf.superhomogeneity
-  _ ≤ f (a * b + c * d) := by apply hf.superadditive
+lemma superlinear {a b c d : ℕ+} : a * f b + c * f d ≤ f (a * b + c * d) :=
+  (add_le_add hf.superhomogeneity hf.superhomogeneity).trans hf.superadditive
 
 lemma part_1 : 660 ≤ f (1980) := by
   rw [← mul_one (660), ← PNat.val_ofNat 660, ← hf.f₃]; apply hf.superhomogeneity
@@ -90,22 +93,21 @@ lemma part_2 : f 1980 ≤ 660 := by
   -- from 5 * f 1980 + 33 ≤ 5 * 660 + 33 we show f 1980 ≤ 660
   exact le_of_mul_le_mul_left (le_of_add_le_add_right h) (Nat.succ_pos 4)
 
-lemma main : f 1982 = 660 := by
+end IsGood
+
+lemma imo1982_q1 {f : ℕ+ → ℕ} (hf : IsGood f) : f 1982 = 660 := by
   have f_1980 := hf.part_2.antisymm hf.part_1
   have h : f 1982 = f 1980 + f 2 ∨ f 1982 = f 1980 + f 2 + 1 := hf.rel 1980 2
   rw [f_1980, hf.f₂, add_zero] at h
   apply h.resolve_right
   intro hr
-  have h : 5 * f 1982 + 29 * f 3 + f 2 ≤ 3333 := by
+  have h : 3334 ≤ 3333 := by -- a contradiction
     calc
+      3334 = 5 * f 1982 + 29 * f 3 + f 2 := by rw [hf.f₃, hf.f₂, hr, add_zero, mul_one]
       (5 : ℕ+) * f 1982 + (29 : ℕ+) * f 3 + f 2 ≤ f (5 * 1982 + 29 * 3) + f 2 :=
         add_le_add_right hf.superlinear _
       _ ≤ f (5 * 1982 + 29 * 3 + 2) := hf.superadditive
       _ = 3333 := hf.f_9999
-  rw [hf.f₃, hf.f₂, hr, add_zero, mul_one] at h
-  -- 3334 ≤ 3333 a contradiction
   norm_num at h
-
-end IsGood
 
 end Imo1982Q1

--- a/Archive/Imo/Imo1982Q1.lean
+++ b/Archive/Imo/Imo1982Q1.lean
@@ -1,0 +1,120 @@
+/-
+Copyright (c) 2024 Alex Brodbelt. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Alex Brodbelt
+-/
+
+import Mathlib.Tactic.NormNum
+import Mathlib.Data.PNat.Basic
+
+/-!
+# IMO 1982 Q1
+
+The function $f(n)$ is defined for all postive integers $n$ and takes on
+non-negative integer values. Also, for all m, n
+
+$f (m + n) - f(m) - f(n) = 0 \text{ or } 1$
+$f(2) = 0, f(3) > 0, and f(9999) = 3333.$
+
+Determine f(1982).
+
+The solution is based on the one at the
+[Art of Problem Solving](https://artofproblemsolving.com/wiki/index.php/1982_IMO_Problems/Problem_1)
+website.
+-/
+
+namespace Imo1982Q1
+
+structure IsGood (f : ℕ+ → ℕ) : Prop where
+  /-- Satisfies the functional relation-/
+  rel: ∀ m n : ℕ+, f (m + n) = f m + f n ∨ f (m + n) = f m + f n + 1
+  f₂ : f 2 = 0
+  hf₃ : f 3 > 0
+  f_9999 : f 9999 = 3333
+
+namespace IsGood
+
+variable {f : ℕ+ → ℕ} (hf : IsGood f)
+include hf
+
+lemma f₁ : f 1 = 0 := by
+  have h : f 2 = 2 * f 1 ∨ f 2 = 2 * f 1 + 1 := by rw [two_mul]; apply hf.rel 1 1
+  rw [hf.f₂] at h
+  by_contra hf
+  rw [← ne_eq] at hf
+  have f1_pos : 0 < f 1 := by rw [lt_iff_le_and_ne]; exact ⟨zero_le (f 1), hf.symm⟩
+  rcases h with ( h₁ | h₂ )
+  · have : 2 * f 1 > 0 := by apply mul_pos (by norm_num) f1_pos
+    rw [← h₁] at this
+    exact lt_irrefl 0 this
+  · have : 2 * f 1 + 1 > 0 := by apply add_pos (mul_pos (by norm_num) f1_pos) (by norm_num)
+    rw [← h₂] at this
+    exact lt_irrefl 0 this
+
+lemma f₃ : f 3 = 1 := by
+    have h : f 3 = f 2 + f 1 ∨ f 3  = f 2 + f 1 + 1 := by apply hf.rel 2 1
+    rw [hf.f₁, hf.f₂, add_zero, zero_add] at h
+    have not_left : ¬ f 3 = 0 := by apply ne_of_gt hf.hf₃
+    rw [or_iff_right (not_left)] at h
+    exact h
+
+lemma superhomogeneity {m n : ℕ+} : ↑n * f m ≤ f (n * m) := by
+  induction n using PNat.recOn
+  case p1 => simp
+  case hp n' ih =>
+    have rel : f (n' * m + m) = f (n' * m) + f (m) ∨
+               f (n' * m + m) = f (n' * m) + f (m) + 1 := hf.rel (n' * m) m
+    calc
+    ↑(n' + 1) * f m = ↑n' * f m + f m := by rw [PNat.add_coe, add_mul, PNat.val_ofNat, one_mul];
+    _ ≤ f (n' * m) + f m := add_le_add_right ih (f m)
+    _ ≤ f (n' * m + m) := by
+      rcases rel with ( hl | hr)
+      · rw [hl]
+      · rw [hr]; nth_rewrite 1 [← add_zero (f m), ← add_assoc]; apply add_le_add_left (by norm_num)
+    _ = f ((n' + 1) * m) := by congr; rw [add_mul, one_mul]
+
+lemma superadditive {m n : ℕ+} : f m + f n ≤ f (m + n) := by
+  have h := hf.rel m n
+  rcases h with ( hl | hr )
+  · rw [hl]
+  · rw [hr]; nth_rewrite 1 [← add_zero (f n), ← add_assoc]; apply add_le_add_right (by norm_num)
+
+lemma superlinear {a b c d : ℕ+} : a * f b + c * f d ≤ f (a * b + c * d) := by
+  calc
+  a * f b + c * f d ≤ f (a * b) + f (c * d) := add_le_add hf.superhomogeneity hf.superhomogeneity
+  _ ≤ f (a * b + c * d) := by apply hf.superadditive
+
+lemma part_1 : 660 ≤ f (1980) := by
+  rw [← mul_one (660), ← PNat.val_ofNat 660, ← hf.f₃]; apply hf.superhomogeneity
+
+lemma part_2 : f 1980 ≤ 660 := by
+  have h : 5 * f 1980 + 33 * f 3 ≤ 5 * 660 + 33 := by
+    calc (5 : ℕ+) * f 1980 + (33 : ℕ+) * f 3 ≤  f (5 * 1980 + 33 * 3) := by apply hf.superlinear
+    _ = f 9999 := by rfl
+    _ = 5 * 660 + 33 := by rw [hf.f_9999]
+  rw [hf.f₃, mul_one] at *
+  -- from 5 * f 1980 + 33 ≤ 5 * 660 + 33 we show f 1980 ≤ 660
+  apply le_of_mul_le_mul_left (a := 5) (a0 := by norm_num)
+  apply le_of_add_le_add_right (a := 33)
+  exact h
+
+lemma main : f 1982 = 660 := by
+  have f_1980: f 1980 = 660 := le_antisymm hf.part_2 hf.part_1
+  have h : f 1982 = f 1980 + f 2 ∨ f 1982 = f 1980 + f 2 + 1 := hf.rel 1980 2
+  rw [f_1980, hf.f₂, add_zero] at h
+  rcases h with ( hl | hr)
+  · exact hl
+  · have h : 5 * f 1982 + 29 * f 3 + f 2 ≤ 3333 := by
+      calc
+      (5 : ℕ+) * f 1982 + (29 : ℕ+) * f 3 + f 2 ≤ f (5 * 1982 + 29 * 3) + f 2 := by
+        apply add_le_add_right hf.superlinear
+      _ ≤ f (5 * 1982 + 29 * 3 + 2) := by apply hf.superadditive
+      _ = f 9999 := rfl
+      _ = 3333 := by rw [hf.f_9999]
+    rw [hf.f₃, hf.f₂, hr, add_zero, mul_one] at h
+    -- 3334 ≤ 3333 a contradiction
+    simp at h
+
+end IsGood
+
+end Imo1982Q1

--- a/Archive/Imo/Imo1982Q1.lean
+++ b/Archive/Imo/Imo1982Q1.lean
@@ -93,21 +93,20 @@ lemma part_2 : f 1980 ≤ 660 := by
   exact h
 
 lemma main : f 1982 = 660 := by
-  have f_1980: f 1980 = 660 := le_antisymm hf.part_2 hf.part_1
+  have f_1980 := hf.part_2.antisymm hf.part_1
   have h : f 1982 = f 1980 + f 2 ∨ f 1982 = f 1980 + f 2 + 1 := hf.rel 1980 2
   rw [f_1980, hf.f₂, add_zero] at h
-  rcases h with ( hl | hr)
-  · exact hl
-  · have h : 5 * f 1982 + 29 * f 3 + f 2 ≤ 3333 := by
-      calc
-      (5 : ℕ+) * f 1982 + (29 : ℕ+) * f 3 + f 2 ≤ f (5 * 1982 + 29 * 3) + f 2 := by
-        apply add_le_add_right hf.superlinear
-      _ ≤ f (5 * 1982 + 29 * 3 + 2) := by apply hf.superadditive
-      _ = f 9999 := rfl
-      _ = 3333 := by rw [hf.f_9999]
-    rw [hf.f₃, hf.f₂, hr, add_zero, mul_one] at h
-    -- 3334 ≤ 3333 a contradiction
-    simp at h
+  apply h.resolve_right
+  intro hr
+  have h : 5 * f 1982 + 29 * f 3 + f 2 ≤ 3333 := by
+    calc
+      (5 : ℕ+) * f 1982 + (29 : ℕ+) * f 3 + f 2 ≤ f (5 * 1982 + 29 * 3) + f 2 :=
+        add_le_add_right hf.superlinear _
+      _ ≤ f (5 * 1982 + 29 * 3 + 2) := hf.superadditive
+      _ = 3333 := hf.f_9999
+  rw [hf.f₃, hf.f₂, hr, add_zero, mul_one] at h
+  -- 3334 ≤ 3333 a contradiction
+  norm_num at h
 
 end IsGood
 

--- a/Archive/Imo/Imo1982Q1.lean
+++ b/Archive/Imo/Imo1982Q1.lean
@@ -11,7 +11,7 @@ import Mathlib.Data.PNat.Basic
 # IMO 1982 Q1
 
 The function $f(n)$ is defined for all postive integers $n$ and takes on
-non-negative integer values. Also, for all m, n
+non-negative integer values. Also, for all $m$, $n$
 
 $f (m + n) - f(m) - f(n) = 0 \text{ or } 1$
 $f(2) = 0, f(3) > 0, and f(9999) = 3333.$

--- a/Archive/Imo/Imo1982Q1.lean
+++ b/Archive/Imo/Imo1982Q1.lean
@@ -16,7 +16,7 @@ non-negative integer values. Also, for all m, n
 $f (m + n) - f(m) - f(n) = 0 \text{ or } 1$
 $f(2) = 0, f(3) > 0, and f(9999) = 3333.$
 
-Determine f(1982).
+Determine $f(1982)$.
 
 The solution is based on the one at the
 [Art of Problem Solving](https://artofproblemsolving.com/wiki/index.php/1982_IMO_Problems/Problem_1)

--- a/Archive/Imo/Imo1982Q1.lean
+++ b/Archive/Imo/Imo1982Q1.lean
@@ -22,10 +22,22 @@ The solution is based on the one at the
 [Art of Problem Solving](https://artofproblemsolving.com/wiki/index.php/1982_IMO_Problems/Problem_1)
 website.
 
-We prove that $f(mn) \geq nf(m)$ and $f(m) + f(n) ≤ f(m + n)$
-to establish both that $f(1980) ≤ 660$ and that these properties added with $f(9999) = 3333$
-to establish that $f(1980) ≥ 660$.
-Both these together allow to conclude $f(1980) = 660$ and then eventually determine $f(1982) = 660$.
+We prove the helper lemmas:
+1. $nf(m) \leq f(mn)$
+2. $f(m) + f(n) \leq f(m + n)$
+3. $a f(a) + c f(d) \leq f(a \cdot b + c \cdot d)$ (derived from 1. and 2.)
+
+So we can establish on the one hand that $f(1980) \leq 660$,
+by observing that $660\cdot 1 = 660 f(3) \leq f(1980) = f(660\cdot 3)$.
+
+On the other hand, we establish that $f(1980) \geq 660$
+from $5 \cdot f(1980) + 33\cdot f(3) \leq  f(5\cdot 1980 + 33\cdot 1) = f(9999) = 3333 $
+
+We then conclude $f(1980) = 660$ and then eventually determine that either
+$f(1982) = 660$ or $f(1982) = 661$.
+
+In the latter case we derive a contradiction, because if $f(1982) = 661$ then
+$3334 = 5\cdot f(1982) + 29\cdot f(3) + f(2) \leq f(5\cdot 1982 + 29\cdot 3 + 2) = f(9999) = 3333$
 -/
 
 namespace Imo1982Q1
@@ -57,7 +69,7 @@ lemma f₃ : f 3 = 1 := by
     rw [or_iff_right (not_left)] at h
     exact h
 
-lemma superhomogeneity {m n : ℕ+} : ↑n * f m ≤ f (n * m) := by
+lemma superhomogenous {m n : ℕ+} : ↑n * f m ≤ f (n * m) := by
   induction n using PNat.recOn
   case p1 => simp
   case hp n' ih =>
@@ -79,10 +91,10 @@ lemma superadditive {m n : ℕ+} : f m + f n ≤ f (m + n) := by
   · rw [hr]; nth_rewrite 1 [← add_zero (f n), ← add_assoc]; apply add_le_add_right (by norm_num)
 
 lemma superlinear {a b c d : ℕ+} : a * f b + c * f d ≤ f (a * b + c * d) :=
-  (add_le_add hf.superhomogeneity hf.superhomogeneity).trans hf.superadditive
+  (add_le_add hf.superhomogenous hf.superhomogenous).trans hf.superadditive
 
 lemma part_1 : 660 ≤ f (1980) := by
-  rw [← mul_one (660), ← PNat.val_ofNat 660, ← hf.f₃]; apply hf.superhomogeneity
+  rw [← mul_one (660), ← PNat.val_ofNat 660, ← hf.f₃]; apply hf.superhomogenous
 
 lemma part_2 : f 1980 ≤ 660 := by
   have h : 5 * f 1980 + 33 * f 3 ≤ 5 * 660 + 33 := by

--- a/Archive/Imo/Imo1982Q1.lean
+++ b/Archive/Imo/Imo1982Q1.lean
@@ -38,18 +38,12 @@ variable {f : ℕ+ → ℕ} (hf : IsGood f)
 include hf
 
 lemma f₁ : f 1 = 0 := by
-  have h : f 2 = 2 * f 1 ∨ f 2 = 2 * f 1 + 1 := by rw [two_mul]; apply hf.rel 1 1
-  rw [hf.f₂] at h
-  by_contra hf
-  rw [← ne_eq] at hf
-  have f1_pos : 0 < f 1 := by rw [lt_iff_le_and_ne]; exact ⟨zero_le (f 1), hf.symm⟩
-  rcases h with ( h₁ | h₂ )
-  · have : 2 * f 1 > 0 := by apply mul_pos (by norm_num) f1_pos
-    rw [← h₁] at this
-    exact lt_irrefl 0 this
-  · have : 2 * f 1 + 1 > 0 := by apply add_pos (mul_pos (by norm_num) f1_pos) (by norm_num)
-    rw [← h₂] at this
-    exact lt_irrefl 0 this
+  have h : f 2 = 2 * f 1 ∨ f 2 = 2 * f 1 + 1 := by rw [two_mul]; exact hf.rel 1 1
+  obtain h₁ | h₂ := hf.f₂ ▸ h
+  · rw [eq_comm, mul_eq_zero] at h₁
+    apply h₁.resolve_left
+    norm_num
+  · cases Nat.succ_ne_zero _ h₂.symm
 
 lemma f₃ : f 3 = 1 := by
     have h : f 3 = f 2 + f 1 ∨ f 3  = f 2 + f 1 + 1 := by apply hf.rel 2 1

--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -902,6 +902,7 @@ import Mathlib.AlgebraicTopology.Nerve
 import Mathlib.AlgebraicTopology.Quasicategory
 import Mathlib.AlgebraicTopology.SimplexCategory
 import Mathlib.AlgebraicTopology.SimplicialCategory.Basic
+import Mathlib.AlgebraicTopology.SimplicialCategory.SimplicialObject
 import Mathlib.AlgebraicTopology.SimplicialObject
 import Mathlib.AlgebraicTopology.SimplicialSet
 import Mathlib.AlgebraicTopology.SimplicialSet.Monoidal


### PR DESCRIPTION
Formalized question 1 of the 1982 IMO.

Made a mistake with my original PR as I made a branch from Imo1982Q3, this should be fixed now.

Fixed the domain of the function to be the positive naturals according to @vihdzp comments - took less effort than expected.

Please let me know if I have made a mistake or if there are any further comments or improvements.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
