### PR TITLE
[Merged by Bors] - feat(NumberTheory/LSeries): completed L-functions

### DIFF
--- a/Mathlib/NumberTheory/LSeries/ZMod.lean
+++ b/Mathlib/NumberTheory/LSeries/ZMod.lean
@@ -22,15 +22,16 @@ for general functions; for the specific case of Dirichlet characters see
 ## Main definitions
 
 * `ZMod.LFunction Φ s`: the meromorphic continuation of the function `∑ n : ℕ, Φ n * n ^ (-s)`.
-* `completedLFunction Φ s`: the completed L-function, which for *almost* all `s` is equal to
-  `LFunction Φ s * gammaFactor Φ s` where `gammaFactor Φ s`
-  is the archimedean Gamma-factor.
+* `ZMod.completedLFunction Φ s`: the completed L-function, which for *almost* all `s` is equal to
+  `LFunction Φ s` multiplied by an Archimedean Gamma-factor.
 
-Note that if `Φ` is not either even or odd, there is no natural definition of the completed
-L-function; we arbitrarily declare that if `Φ` is not even, then `completedLFunction Φ` is the
-completed L-function of the odd part of `Φ`.
+Note that `ZMod.completedLFunction Φ s` is only mathematically well-defined if `Φ` is either even
+or odd. We have arbitrarily defined it to be the completed L-function of the odd part of `Φ`, if
+`Φ` is not even.
 
 ## Main theorems
+
+Results for non-completed L-functions:
 
 * `ZMod.LFunction_eq_LSeries`: if `1 < re s` then the `LFunction` coincides with the naive
   `LSeries`.
@@ -38,10 +39,18 @@ completed L-function of the odd part of `Φ`.
   `s ≠ 1` or `∑ j, Φ j = 0`.
 * `ZMod.LFunction_one_sub`: the functional equation relating `LFunction Φ (1 - s)` to
   `LFunction (𝓕 Φ) s`, where `𝓕` is the Fourier transform.
-* `ZMod.LFunction_eq_completed_div_gammaFactor`: we have
-  `LFunction Φ s = completedLFunction Φ s / gammaFactor Φ s`, unless `s = 0` and `Φ 0 ≠ 0`.
+
+Results for completed L-functions:
+
+* `ZMod.LFunction_eq_completed_div_gammaFactor_even` and
+  `LFunction_eq_completed_div_gammaFactor_odd`: we have
+  `LFunction Φ s = completedLFunction Φ s / Gammaℝ s` for `Φ` even, and
+  `LFunction Φ s = completedLFunction Φ s / Gammaℝ (s + 1)` for `Φ` odd. (We formulate it this way
+  around so it is still valid at the poles of the Gamma factor.)
 * `ZMod.differentiableAt_completedLFunction`: `ZMod.completedLFunction Φ` is differentiable at
   `s ∈ ℂ`, unless `s = 1` and `∑ j, Φ j ≠ 0`, or `s = 0` and `Φ 0 ≠ 0`.
+* `ZMod.completedLFunction_one_sub`: the functional equation relating
+  `completedLFunction Φ (1 - s)` to `completedLFunction (𝓕 Φ) s`.
 -/
 
 open HurwitzZeta Complex ZMod Finset Classical Topology Filter Set
@@ -235,47 +244,39 @@ section signed
 
 variable {Φ : ZMod N → ℂ}
 
-/--
-If `Φ` is either even or odd, we can write `LFunction Φ s` using signed Hurwitz zeta functions.
-Useful for comparison with `completedLFunction Φ s`.
--/
-lemma LFunction_def_signed (hΦ : Φ.Even ∨ Φ.Odd) (s : ℂ) :
-    LFunction Φ s =
-      if Φ.Even then N ^ (-s) * ∑ j : ZMod N, Φ j * hurwitzZetaEven (toAddCircle j) s
-      else N ^ (-s) * ∑ j : ZMod N, Φ j * hurwitzZetaOdd (toAddCircle j) s := by
-  simp only [LFunction, ← mul_ite, hurwitzZeta, mul_add, sum_add_distrib]
-  rw [← mul_add]
+lemma LFunction_def_even (hΦ : Φ.Even) (s : ℂ) :
+    LFunction Φ s = N ^ (-s) * ∑ j : ZMod N, Φ j * hurwitzZetaEven (toAddCircle j) s := by
+  simp only [LFunction, hurwitzZeta, mul_add (Φ _), sum_add_distrib]
   congr 1
-  by_cases h : Φ.Even
-  · simp only [h, ↓reduceIte, add_right_eq_self, ← sum_neg_distrib, ← neg_eq_self ℂ]
-    refine Fintype.sum_equiv (.neg _) _ _ fun i ↦ ?_
-    simp only [Equiv.neg_apply, h i, map_neg, hurwitzZetaOdd_neg, mul_neg]
-  · simp only [h, ↓reduceIte, add_left_eq_self, ← neg_eq_self ℂ, ← sum_neg_distrib]
-    refine Fintype.sum_equiv (.neg _) _ _ fun i ↦ ?_
-    simp only [Equiv.neg_apply, map_neg, hurwitzZetaEven_neg, (show Φ.Odd by tauto) i, neg_mul]
+  simp only [add_right_eq_self, ← neg_eq_self ℂ, ← sum_neg_distrib]
+  refine Fintype.sum_equiv (.neg _) _ _ fun i ↦ ?_
+  simp only [Equiv.neg_apply, hΦ i, map_neg, hurwitzZetaOdd_neg, mul_neg]
+
+lemma LFunction_def_odd (hΦ : Φ.Odd) (s : ℂ) :
+    LFunction Φ s = N ^ (-s) * ∑ j : ZMod N, Φ j * hurwitzZetaOdd (toAddCircle j) s := by
+  simp only [LFunction, hurwitzZeta, mul_add (Φ _), sum_add_distrib]
+  congr 1
+  simp only [add_left_eq_self, ← neg_eq_self ℂ, ← sum_neg_distrib]
+  refine Fintype.sum_equiv (.neg _) _ _ fun i ↦ ?_
+  simp only [Equiv.neg_apply, hΦ i, map_neg, hurwitzZetaEven_neg, neg_mul]
 
 /-- Explicit formula for `LFunction Φ 0` when `Φ` is even. -/
 lemma LFunction_apply_zero_of_even (hΦ : Φ.Even) :
     LFunction Φ 0 = -Φ 0 / 2 := by
-  simp only [LFunction_def_signed (Or.inl hΦ), hΦ, ↓reduceIte, neg_zero, cpow_zero,
-    hurwitzZetaEven_apply_zero, toAddCircle_eq_zero, mul_ite, mul_div, mul_neg_one, mul_zero,
-    sum_ite_eq', Finset.mem_univ, one_mul]
+  simp only [LFunction_def_even hΦ, neg_zero, cpow_zero, hurwitzZetaEven_apply_zero,
+    toAddCircle_eq_zero, mul_ite, mul_div, mul_neg_one, mul_zero, sum_ite_eq', Finset.mem_univ,
+    ↓reduceIte, one_mul]
 
 /-- The L-function of an even function vanishes at negative even integers. -/
 lemma LFunction_neg_two_mul_nat_add_one (hΦ : Φ.Even) (n : ℕ) :
     LFunction Φ (-2 * (n + 1)) = 0 := by
-  simp only [LFunction_def_signed (Or.inl hΦ), hΦ, ↓reduceIte,
-    hurwitzZetaEven_neg_two_mul_nat_add_one, mul_zero, sum_const_zero]
+  simp only [LFunction_def_even hΦ, hurwitzZetaEven_neg_two_mul_nat_add_one, mul_zero,
+    sum_const_zero]
 
 /-- The L-function of an odd function vanishes at negative odd integers. -/
 lemma LFunction_neg_two_mul_nat_sub_one (hΦ : Φ.Odd) (n : ℕ) :
     LFunction Φ (-2 * n - 1) = 0 := by
-  by_cases hΦ' : Φ.Even
-  · -- silly case: `Φ` is both even and odd, so it's zero
-    have : Φ = 0 := funext fun j ↦ by rw [Pi.zero_apply, ← neg_eq_self ℂ, ← hΦ j, hΦ' j]
-    simp [LFunction, this]
-  · simp only [LFunction_def_signed (Or.inr hΦ), hΦ', ↓reduceIte,
-      hurwitzZetaOdd_neg_two_mul_nat_sub_one, mul_zero, sum_const_zero]
+  simp only [LFunction_def_odd hΦ, hurwitzZetaOdd_neg_two_mul_nat_sub_one, mul_zero, sum_const_zero]
 
 variable (Φ) in
 /--
@@ -286,8 +287,34 @@ as follows: if `Φ` is not even, then the completed L-series of `Φ` is the `L`-
 part of `Φ`.
 -/
 noncomputable def completedLFunction (s : ℂ) : ℂ :=
-  if Φ.Even then N ^ (-s) * ∑ j : ZMod N, Φ j * completedHurwitzZetaEven (toAddCircle j) s
-  else N ^ (-s) * ∑ j : ZMod N, Φ j * completedHurwitzZetaOdd (toAddCircle j) s
+  if Φ.Even then N ^ (-s) * ∑ j, Φ j * completedHurwitzZetaEven (toAddCircle j) s
+  else N ^ (-s) * ∑ j, Φ j * completedHurwitzZetaOdd (toAddCircle j) s
+
+lemma completedLFunction_zero (s : ℂ) : completedLFunction (0 : ZMod N → ℂ) s = 0 := by
+  simp only [completedLFunction, Pi.zero_apply, zero_mul, sum_const_zero, mul_zero, ite_self]
+
+lemma completedLFunction_def_even (hΦ : Φ.Even) (s : ℂ) :
+    completedLFunction Φ s = N ^ (-s) * ∑ j, Φ j * completedHurwitzZetaEven (toAddCircle j) s := by
+  simp only [completedLFunction, hΦ, ↓reduceIte]
+
+lemma completedLFunction_def_odd (hΦ : Φ.Odd) (s : ℂ) :
+    completedLFunction Φ s = N ^ (-s) * ∑ j, Φ j * completedHurwitzZetaOdd (toAddCircle j) s := by
+  by_cases hΦ' : Φ.Even
+    -- if `Φ = 0` we are in the "wrong" branch of the if-then, but it's OK because both sides are 0
+  · simp only [Φ.zero_of_even_and_odd hΦ' hΦ, completedLFunction_zero, Pi.zero_apply, zero_mul,
+      sum_const_zero, mul_zero]
+  · simp only [completedLFunction, hΦ', ↓reduceIte]
+
+/--
+The completed L-function of a function mod 1 is a scalar multiple of the completed Riemann zeta
+function.
+-/
+lemma completedLFunction_modOne_eq {Φ : ZMod 1 → ℂ} (s : ℂ) :
+    completedLFunction Φ s = Φ 1 * completedRiemannZeta s := by
+  have : Φ.Even := fun j ↦ congr_arg Φ <| (Unique.eq_default (-j)).trans (Unique.eq_default j).symm
+  simp [completedLFunction, this]
+  change Φ 1 * completedHurwitzZetaEven (toAddCircle 0) s = _
+  rw [map_zero, completedHurwitzZetaEven_zero]
 
 variable (Φ) in
 /--
@@ -300,65 +327,46 @@ noncomputable def completedLFunction₀ (s : ℂ) : ℂ :=
   if Φ.Even then N ^ (-s) * ∑ j : ZMod N, Φ j * completedHurwitzZetaEven₀ (toAddCircle j) s
   else N ^ (-s) * ∑ j : ZMod N, Φ j * completedHurwitzZetaOdd (toAddCircle j) s
 
-/--
-The L-function a function mod 1 is a scalar multiple of the completed Riemann zeta function.
--/
-lemma completedLFunction_modOne_eq {Φ : ZMod 1 → ℂ} (s : ℂ) :
-    completedLFunction Φ s = Φ 1 * completedRiemannZeta s := by
-  have : Φ.Even := fun j ↦ congr_arg Φ <| (Unique.eq_default (-j)).trans (Unique.eq_default j).symm
-  simp [completedLFunction, this]
-  change Φ 1 * completedHurwitzZetaEven (toAddCircle 0) s = _
-  rw [map_zero, completedHurwitzZetaEven_zero]
-
 variable (Φ) in
 /-- The function `completedLFunction₀ Φ` is differentiable. -/
 lemma differentiable_completedLFunction₀ : Differentiable ℂ (completedLFunction₀ Φ) := by
   unfold completedLFunction₀
   by_cases h : Φ.Even <;>
   simp only [h, reduceIte] <;>
-  refine (differentiable_neg.const_cpow <| Or.inl <| NeZero.ne _).mul
-    (.sum fun i _ ↦ .const_mul ?_ _)
+  refine (differentiable_neg.const_cpow <| .inl <| NeZero.ne _).mul (.sum fun i _ ↦ .const_mul ?_ _)
   exacts [differentiable_completedHurwitzZetaEven₀ _, differentiable_completedHurwitzZetaOdd _]
 
 lemma completedLFunction_eq (hΦ : Φ.Even ∨ Φ.Odd) (s : ℂ) :
     completedLFunction Φ s =
       completedLFunction₀ Φ s - N ^ (-s) * Φ 0 / s - N ^ (-s) * (∑ j, Φ j) / (1 - s) := by
   simp only [completedLFunction, completedLFunction₀]
-  split_ifs with h
-  · simp only [completedHurwitzZetaEven_eq, mul_sub, sum_sub_distrib]
+  obtain hΦ | ⟨hΦ', hΦ⟩ : Φ.Even ∨ (¬Φ.Even ∧ Φ.Odd) := by tauto
+  · simp only [hΦ, ite_true, completedHurwitzZetaEven_eq, mul_sub, sum_sub_distrib]
     congr 1
     · simp only [toAddCircle_eq_zero, div_eq_mul_inv, ite_mul, one_mul, zero_mul, mul_ite,
-        mul_zero, sum_ite_eq', Finset.mem_univ, ↓reduceIte, mul_assoc]
+        mul_zero, sum_ite_eq', ite_true, Finset.mem_univ, mul_assoc]
     · rw [← sum_mul, mul_one_div, mul_div_assoc]
-  · replace hΦ : Function.Odd Φ := by tauto
-    have : Φ 0 = 0 := by rw [← neg_eq_self ℂ, ← hΦ 0, neg_zero]
-    rw [this, mul_zero, zero_div, sub_zero]
-    suffices ∑ j, Φ j = 0 by rw [this, mul_zero, zero_div, sub_zero]
-    simp only [← neg_eq_self ℂ, ← sum_neg_distrib]
-    exact Fintype.sum_equiv _ _ _ (fun i ↦ by rw [Equiv.neg_apply, hΦ])
+  · simp only [hΦ', ite_false, hΦ.map_zero, mul_zero, zero_div, sub_zero, hΦ.sum_eq_zero]
 
 /--
 The completed L-function of a function mod `N` is differentiable, with the following
-exceptions: at `s = 1` if `∑ j, Φ j ≠ 0`; and at `s = 0` if `Φ 0 ≠ 0`. (This result is optimal.)
+exceptions: at `s = 1` if `∑ j, Φ j ≠ 0`; and at `s = 0` if `Φ 0 ≠ 0`.
 -/
-lemma differentiableAt_completedLFunction (hΦ : Φ.Even ∨ Φ.Odd) (s : ℂ) (hs₀ : s ≠ 0 ∨ Φ 0 = 0)
-    (hs₁ : s ≠ 1 ∨ ∑ j, Φ j = 0) :
+lemma differentiableAt_completedLFunction (hΦ : Φ.Even ∨ Φ.Odd) (s : ℂ)
+    (hs₀ : s ≠ 0 ∨ Φ 0 = 0) (hs₁ : s ≠ 1 ∨ ∑ j, Φ j = 0) :
     DifferentiableAt ℂ (completedLFunction Φ) s := by
-  simp only [funext fun s ↦ completedLFunction_eq hΦ s, mul_div_assoc]
+  simp only [funext (completedLFunction_eq hΦ), mul_div_assoc]
   -- We know `completedLFunction₀` is differentiable everywhere, so it suffices to show that the
   -- correction terms from `completedLFunction_eq` are differentiable at `s`.
   refine ((differentiable_completedLFunction₀ _ _).sub ?_).sub ?_
   · -- term with `1 / s`
-    refine ((differentiable_neg.const_cpow <| Or.inl <| NeZero.ne _) s).mul
-      (?_ : DifferentiableAt ℂ (fun t ↦ Φ 0 / t) s)
-    rcases hs₀ with h | h
-    · exact (differentiableAt_const _).div differentiableAt_id h
-    · simp only [h, zero_div, differentiableAt_const]
+    refine ((differentiable_neg.const_cpow <| .inl <| NeZero.ne _) s).mul (hs₀.elim ?_ ?_)
+    · exact fun h ↦ (differentiableAt_const _).div differentiableAt_id h
+    · exact fun h ↦ by simp only [h, funext zero_div, differentiableAt_const]
   · -- term with `1 / (1 - s)`
-    apply ((differentiable_neg.const_cpow <| Or.inl <| NeZero.ne _) s).mul
-    rcases hs₁ with h | h
-    · exact (differentiableAt_const _).div (by fun_prop) (by rwa [sub_ne_zero, ne_comm])
-    · simp only [h, zero_div, differentiableAt_const]
+    refine ((differentiable_neg.const_cpow <| .inl <| NeZero.ne _) s).mul (hs₁.elim ?_ ?_)
+    · exact fun h ↦ (differentiableAt_const _).div (by fun_prop) (by rwa [sub_ne_zero, ne_comm])
+    · exact fun h ↦ by simp only [h, zero_div, differentiableAt_const]
 
 /--
 Special case of `differentiableAt_completedLFunction` asserting differentiability everywhere
@@ -367,31 +375,193 @@ under suitable hypotheses.
 lemma differentiable_completedLFunction
     (hΦ₁ : Φ.Even ∨ Φ.Odd) (hΦ₂ : Φ 0 = 0) (hΦ₃ : ∑ j, Φ j = 0) :
     Differentiable ℂ (completedLFunction Φ) :=
-  fun s ↦ differentiableAt_completedLFunction hΦ₁ s (Or.inr hΦ₂) (Or.inr hΦ₃)
-
-/-- The Archimedean Gamma factor: `Gammaℝ s` if `Φ` is even, and `Gammaℝ (s + 1)` otherwise. -/
-noncomputable def gammaFactor (Φ : ZMod N → ℂ) (s : ℂ) : ℂ :=
-   if Φ.Even then Gammaℝ s else Gammaℝ (s + 1)
+  fun s ↦ differentiableAt_completedLFunction hΦ₁ s (.inr hΦ₂) (.inr hΦ₃)
 
 /--
-Relation between the completed L-function and the usual one. We state it this way around so
-it holds at the poles of the gamma factor as well (except at `s = 0`, where it is genuinely
-false if `Φ 0 ≠ 0`).
+Relation between the completed L-function and the usual one (even case).
+We state it this way around so it holds at the poles of the gamma factor as well
+(except at `s = 0`, where it is genuinely false if `Φ 0 ≠ 0`).
 -/
-lemma LFunction_eq_completed_div_gammaFactor (hΦ : Φ.Even ∨ Φ.Odd) (s : ℂ) (hs : s ≠ 0 ∨ Φ 0 = 0) :
-    LFunction Φ s = completedLFunction Φ s / gammaFactor Φ s := by
-  rw [LFunction_def_signed hΦ, completedLFunction, gammaFactor]
-  split_ifs with h
-  · -- `Φ` even
-    simp only [mul_div_assoc, sum_div]
-    congr 2 with i
-    rcases ne_or_eq i 0 with hi | rfl
-    · rw [hurwitzZetaEven_def_of_ne_or_ne (Or.inl (hi ∘ toAddCircle_eq_zero.mp))]
-    · rcases hs with hs | hΦ'
-      · rw [hurwitzZetaEven_def_of_ne_or_ne (Or.inr hs)]
-      · simp only [hΦ', map_zero, zero_mul]
-  · -- `Φ` not even
-    simp only [hurwitzZetaOdd, mul_div_assoc, sum_div]
+lemma LFunction_eq_completed_div_gammaFactor_even (hΦ : Φ.Even) (s : ℂ) (hs : s ≠ 0 ∨ Φ 0 = 0) :
+    LFunction Φ s = completedLFunction Φ s / Gammaℝ s := by
+  simp only [completedLFunction_def_even hΦ, LFunction_def_even hΦ, mul_div_assoc, sum_div]
+  congr 2 with i
+  rcases ne_or_eq i 0 with hi | rfl
+  · rw [hurwitzZetaEven_def_of_ne_or_ne (.inl (hi ∘ toAddCircle_eq_zero.mp))]
+  · rcases hs with hs | hΦ'
+    · rw [hurwitzZetaEven_def_of_ne_or_ne (.inr hs)]
+    · simp only [hΦ', map_zero, zero_mul]
+
+/--
+Relation between the completed L-function and the usual one (odd case).
+We state it this way around so it holds at the poles of the gamma factor as well.
+-/
+lemma LFunction_eq_completed_div_gammaFactor_odd (hΦ : Φ.Odd) (s : ℂ) :
+    LFunction Φ s = completedLFunction Φ s / Gammaℝ (s + 1) := by
+  simp only [LFunction_def_odd hΦ, completedLFunction_def_odd hΦ, hurwitzZetaOdd, mul_div_assoc,
+    sum_div]
+
+/--
+Express `completedCosZeta` as the L-function of a function on `ZMod N`.
+
+The formulation is not optimal (the result is actually true for all `s ∉ {0, 1}`), but suffices for
+the proof of `completedLFunction_one_sub` below.
+-/
+lemma completedLFunction_cos_eq_completedCosZeta_of_one_lt
+    (a : ZMod N) {s : ℂ} (hs : 1 < re s) :
+    completedLFunction (fun b ↦ (𝕖 (a * b) + 𝕖 (-a * b)) / 2) s =
+      completedCosZeta (toAddCircle a) s := by
+  set Φ := fun b ↦ (𝕖 (a * b) + 𝕖 (-a * b)) / 2
+  have hΦ : Φ.Even := fun b ↦ by simp only [neg_mul, mul_neg, neg_neg, add_comm, Φ]
+  have h1 : (Gammaℝ s)⁻¹ ≠ 0 := inv_ne_zero (Gammaℝ_ne_zero_of_re_pos (by linarith))
+  have h2 : s ≠ 1 := (lt_irrefl _ <| one_re ▸ · ▸ hs)
+  have h3 : cosZeta (toAddCircle a) s = completedCosZeta (toAddCircle a) s / s.Gammaℝ :=
+    Function.update_noteq (ne_zero_of_one_lt_re hs) ..
+  rw [← mul_left_inj' h1, ← div_eq_mul_inv, ← div_eq_mul_inv, ← h3, cosZeta_eq,
+    ← LFunction_eq_completed_div_gammaFactor_even hΦ _ (.inl <| ne_zero_of_one_lt_re hs)]
+  simp only [LFunction, add_div, add_mul, sum_add_distrib, Φ]
+  simp only [div_mul_eq_mul_div, ← sum_div, mul_add, ← mul_div_assoc,
+    ← LFunction_stdAddChar_eq_expZeta _ _ (.inr h2), LFunction, ← map_neg]
+
+/--
+Express `completedSinZeta` as the L-function of a function on `ZMod N`.
+
+The formulation is not optimal (the result is actually true for all `s`), but suffices for
+the proof of `completedLFunction_one_sub` below.
+-/
+lemma completedLFunction_sin_eq_completedSinZeta_of_one_lt
+    (a : ZMod N) {s : ℂ} (hs : 1 < re s) :
+    completedLFunction (fun b ↦ (𝕖 (a * b) - 𝕖 (-a * b)) / (2 * I)) s =
+      completedSinZeta (toAddCircle a) s := by
+  set Φ := fun b ↦ (𝕖 (a * b) - 𝕖 (-a * b)) / (2 * I)
+  have hΦ : Φ.Odd := fun b ↦ by simp only [Φ, neg_mul, mul_neg, neg_neg, ← neg_div, neg_sub]
+  have h1 : (Gammaℝ (s + 1))⁻¹ ≠ 0 :=
+    inv_ne_zero (Gammaℝ_ne_zero_of_re_pos <| by simp only [add_re, one_re]; linarith)
+  have h2 : s ≠ 1 := (lt_irrefl _ <| one_re ▸ · ▸ hs)
+  rw [← mul_left_inj' h1, ← div_eq_mul_inv, ← div_eq_mul_inv, ← sinZeta, sinZeta_eq,
+    ← LFunction_eq_completed_div_gammaFactor_odd hΦ]
+  simp only [LFunction, sub_div, sub_mul, sum_sub_distrib, Φ]
+  simp only [mul_sub, LFunction, div_mul_eq_mul_div, ← sum_div, ← mul_div_assoc, ← map_neg,
+    ← LFunction_stdAddChar_eq_expZeta _ _ (.inr h2)]
+
+/--
+First form of functional equation for completed L-functions. Private because it is superseded
+by `completedLFunction_one_sub` below, which is valid for a much wider range of `s`.
+-/
+private lemma completedLFunction_one_sub_of_one_lt (hΦ : Φ.Even ∨ Φ.Odd) (s : ℂ) (hs : 1 < re s) :
+    completedLFunction Φ (1 - s) =
+      N ^ (s - 1) * I ^ (if Φ.Even then 0 else 1) * completedLFunction (𝓕 Φ) s := by
+  -- preliminary mini-lemmas:
+  have he (x : ZMod N) : (fun b ↦ (𝕖 (x * b) + 𝕖 (-x * b)) / 2).Even := fun _ ↦ by
+    simp only [mul_neg, neg_mul, neg_neg, add_comm]
+  have ho (x : ZMod N) : (fun b ↦ (𝕖 (x * b) - 𝕖 (-x * b)) / (2 * I)).Odd := fun _ ↦ by
+    simp only [mul_neg, neg_mul, neg_neg, ← neg_div, neg_sub]
+  -- split into two mutually-exclusive cases:
+  obtain hΦ | ⟨hΦ', hΦ⟩ : Φ.Even ∨ (¬Φ.Even ∧ Φ.Odd) := by tauto
+  · -- even case
+    -- drill down to the key computation:
+    suffices ∑ x, Φ x * completedCosZeta (toAddCircle x) s = completedLFunction (𝓕 Φ) s by
+      simp only [completedLFunction_def_even hΦ, neg_sub, completedHurwitzZetaEven_one_sub, this,
+        hΦ, ite_true, pow_zero, mul_one]
+    -- now calculate:
+    let ζ (y : ZMod N) := completedHurwitzZetaEven (toAddCircle y)
+    calc ∑ x, Φ x * completedCosZeta (toAddCircle x) s
+    _ = ∑ x, ∑ y, Φ x * N ^ (-s) * ((𝕖 (x * y) + 𝕖 (-x * y)) / 2) * ζ y s := by
+      simp only [← completedLFunction_cos_eq_completedCosZeta_of_one_lt _ hs,
+        completedLFunction_def_even (he _), mul_sum, mul_assoc]
+    _ = N ^ (-s) * ∑ y, (∑ x, Φ x * ((𝕖 (x * y) + 𝕖 (-x * y)) / 2)) * ζ y s := by
+      rw [sum_comm]
+      simp only [mul_sum, sum_mul, mul_assoc, mul_left_comm (Φ _)]
+    _ = N ^ (-s) * (∑ y, (∑ x, Φ x * 𝕖 (x * y) + ∑ x, Φ x * 𝕖 (-x * y)) / 2 * ζ y s) := by
+      simp only [← mul_div_assoc, ← sum_div, mul_add, sum_add_distrib]
+    _ = N ^ (-s) * (∑ y, ((𝓕 Φ (-y) + 𝓕 Φ y) / 2) * ζ y s) := by
+      simp only [dft_apply, mul_neg, neg_mul, neg_neg, smul_eq_mul, mul_comm (Φ _)]
+    _ = N ^ (-s) * ∑ y, 𝓕 Φ y * ζ y s := by
+      simp only [dft_even_iff.mpr hΦ _, add_div, add_halves]
+    _ = completedLFunction (𝓕 Φ) s := by
+      rw [completedLFunction_def_even (dft_even_iff.mpr hΦ)]
+  · -- odd case
+    -- drill down to the key computation:
+    suffices ∑ x, Φ x * completedSinZeta (toAddCircle x) s = I * completedLFunction (𝓕 Φ) s by
+      simp only [completedLFunction_def_odd hΦ, neg_sub, completedHurwitzZetaOdd_one_sub, this, hΦ',
+        ite_false, pow_one, mul_assoc]
+    -- now calculate:
+    let ζ (y : ZMod N) := completedHurwitzZetaOdd (toAddCircle y)
+    calc ∑ x, Φ x * completedSinZeta (toAddCircle x) s
+    _ = ∑ x, ∑ y, Φ x * N ^ (-s) * ((𝕖 (x * y) - 𝕖 (-x * y)) / (2 * I)) * ζ y s := by
+      simp only [← completedLFunction_sin_eq_completedSinZeta_of_one_lt _ hs,
+        completedLFunction_def_odd (ho _), mul_sum, mul_assoc]
+    _ = N ^ (-s) * ∑ y, (∑ x, Φ x * ((𝕖 (x * y) - 𝕖 (-x * y)) / (2 * I))) * ζ y s := by
+      rw [sum_comm]
+      simp only [mul_sum, sum_mul, mul_assoc, mul_left_comm (Φ _)]
+    _ = N ^ (-s) * (∑ y, (∑ x, Φ x * 𝕖 (x * y) - ∑ x, Φ x * 𝕖 (-x * y)) / (2 * I) * ζ y s) := by
+      simp only [← mul_div_assoc, ← sum_div, mul_sub, sum_sub_distrib]
+    _ = N ^ (-s) * (∑ y, ((𝓕 Φ (-y) - 𝓕 Φ y) / (2 * I)) * ζ y s) := by
+      simp only [dft_apply, mul_neg, neg_mul, neg_neg, smul_eq_mul, mul_comm (Φ _)]
+    _ = I * (N ^ (-s) * ∑ y, 𝓕 Φ y * ζ y s) := by
+      simp only [dft_odd_iff.mpr hΦ _, sub_eq_add_neg, ← two_mul, ← div_div,
+        mul_div_cancel_left₀ _ (two_ne_zero' ℂ), div_eq_mul_inv _ I, inv_I, neg_mul_neg]
+      simp only [mul_comm _ I, mul_assoc, ← mul_sum, mul_left_comm]
+    _ = I * completedLFunction (𝓕 Φ) s := by
+      rw [completedLFunction_def_odd (dft_odd_iff.mpr hΦ)]
+
+/--
+Functional equation for completed L-functions, valid at all points of differentiability.
+-/
+theorem completedLFunction_one_sub
+    (hΦ : Φ.Even ∨ Φ.Odd) (s : ℂ) (hs₀ : s ≠ 0 ∨ ∑ j, Φ j = 0) (hs₁ : s ≠ 1 ∨ Φ 0 = 0) :
+    completedLFunction Φ (1 - s) =
+      N ^ (s - 1) * I ^ (if Φ.Even then 0 else 1) * completedLFunction (𝓕 Φ) s := by
+  -- We prove this using `AnalyticOn.eqOn_of_preconnected_of_eventuallyEq`, so we need to
+  -- gather up the ingredients for this big theorem.
+  -- First set up some notations:
+  let F (t) := completedLFunction Φ (1 - t)
+  let G (t) := ↑N ^ (t - 1) * I ^ (if Φ.Even then 0 else 1) * completedLFunction (𝓕 Φ) t
+  -- Set on which F, G are analytic:
+  let U := {t : ℂ | (t ≠ 0 ∨ ∑ j, Φ j = 0) ∧ (t ≠ 1 ∨ Φ 0 = 0)}
+  -- Properties of U:
+  have hsU : s ∈ U := ⟨hs₀, hs₁⟩
+  have h2U : 2 ∈ U := ⟨.inl two_ne_zero, .inl (OfNat.ofNat_ne_one _)⟩
+  have hUo : IsOpen U := by
+    refine .inter ?_ ?_ <;>
+    exact (isOpen_compl_singleton.union isOpen_const)
+  have hUp : IsPreconnected U := by
+    -- need to write `U` as the complement of an obviously countable set
+    let Uc : Set ℂ := (if ∑ j, Φ j = 0 then ∅ else {0}) ∪ (if Φ 0 = 0 then ∅ else {1})
+    have : Uc.Countable := by
+      apply Countable.union <;>
+      split_ifs <;>
+      simp only [countable_singleton, countable_empty]
+    convert (this.isConnected_compl_of_one_lt_rank ?_).isPreconnected using 1
+    · ext x
+      by_cases h : Φ 0 = 0 <;>
+      by_cases h' : ∑ j, Φ j = 0 <;>
+      simp only [U, Uc, h, h', and_true, and_false, or_true, or_false, ↓reduceIte, mem_setOf,
+        union_empty, true_and, empty_union, compl_empty, mem_univ,
+        mem_compl_iff, mem_union, not_or, not_mem_singleton_iff]
+    · simp only [rank_real_complex, Nat.one_lt_ofNat]
+  -- Analyticity on U:
+  have hF : AnalyticOn ℂ F U := by
+    refine DifferentiableOn.analyticOn (fun t ht ↦ DifferentiableAt.differentiableWithinAt ?_) hUo
+    refine (differentiableAt_completedLFunction hΦ (1 - t) ?_ ?_).comp t ?_
+    · exact ht.2.imp_left (sub_ne_zero.mpr ∘ Ne.symm)
+    · exact ht.1.imp_left sub_eq_self.not.mpr
+    · exact differentiableAt_id.const_sub 1
+  have hG : AnalyticOn ℂ G U := by
+    refine DifferentiableOn.analyticOn (fun t ht ↦ DifferentiableAt.differentiableWithinAt ?_) hUo
+    refine .mul (.mul ?_ <| differentiableAt_const _) ?_
+    · exact (DifferentiableAt.sub_const differentiableAt_id 1).const_cpow (.inl (NeZero.ne _))
+    · -- Differentiablity of completed L-function for `𝓕 Φ`.
+      apply differentiableAt_completedLFunction
+      · rwa [dft_even_iff, dft_odd_iff]
+      · exact ht.1.imp_right fun h ↦ dft_apply_zero Φ ▸ h
+      · refine ht.2.imp_right fun h ↦ ?_
+        simp only [← dft_apply_zero, dft_dft, neg_zero, h, smul_zero]
+  -- set where we know equality
+  have hV : {z | 1 < re z} ∈ 𝓝 2 := (continuous_re.isOpen_preimage _ isOpen_Ioi).mem_nhds (by simp)
+  have hFG : F =ᶠ[𝓝 2] G := eventually_of_mem hV <| completedLFunction_one_sub_of_one_lt hΦ
+  -- now apply the big hammer to finish
+  exact hF.eqOn_of_preconnected_of_eventuallyEq hG hUp h2U hFG hsU
 
 end signed
 

--- a/Mathlib/NumberTheory/LSeries/ZMod.lean
+++ b/Mathlib/NumberTheory/LSeries/ZMod.lean
@@ -258,8 +258,8 @@ lemma LFunction_def_signed (hΦ : Φ.Even ∨ Φ.Odd) (s : ℂ) :
 lemma LFunction_apply_zero_of_even (hΦ : Φ.Even) :
     LFunction Φ 0 = -Φ 0 / 2 := by
   simp only [LFunction_def_signed (Or.inl hΦ), hΦ, ↓reduceIte, neg_zero, cpow_zero,
-    hurwitzZetaEven_apply_zero, toAddCircle_eq_zero, mul_ite, mul_zero, sum_ite_eq', mem_univ,
-    one_mul, mul_div, mul_neg_one]
+    hurwitzZetaEven_apply_zero, toAddCircle_eq_zero, mul_ite, mul_div, mul_neg_one, mul_zero,
+    sum_ite_eq', Finset.mem_univ, one_mul]
 
 /-- The L-function of an even function vanishes at negative even integers. -/
 lemma LFunction_neg_two_mul_nat_add_one (hΦ : Φ.Even) (n : ℕ) :
@@ -328,7 +328,7 @@ lemma completedLFunction_eq (hΦ : Φ.Even ∨ Φ.Odd) (s : ℂ) :
   · simp only [completedHurwitzZetaEven_eq, mul_sub, sum_sub_distrib]
     congr 1
     · simp only [toAddCircle_eq_zero, div_eq_mul_inv, ite_mul, one_mul, zero_mul, mul_ite,
-        mul_zero, sum_ite_eq', mem_univ, ↓reduceIte, mul_assoc]
+        mul_zero, sum_ite_eq', Finset.mem_univ, ↓reduceIte, mul_assoc]
     · rw [← sum_mul, mul_one_div, mul_div_assoc]
   · replace hΦ : Function.Odd Φ := by tauto
     have : Φ 0 = 0 := by rw [← neg_eq_self ℂ, ← hΦ 0, neg_zero]

--- a/Mathlib/NumberTheory/LSeries/ZMod.lean
+++ b/Mathlib/NumberTheory/LSeries/ZMod.lean
@@ -279,7 +279,6 @@ lemma LFunction_def_odd (hΦ : Φ.Odd) (s : ℂ) :
   simp only [LFunction_def_odd hΦ, hurwitzZetaOdd_neg_two_mul_nat_sub_one, mul_zero,
     ← neg_mul, sum_const_zero]
 
-variable (Φ) in
 /--
 The completed L-function of a function mod `N`.
 
@@ -287,30 +286,32 @@ This is only mathematically meaningful if `Φ` is either even, or odd. We extend
 as follows: if `Φ` is not even, then the completed L-series of `Φ` is the `L`-series of the odd
 part of `Φ`.
 -/
-noncomputable def completedLFunction (s : ℂ) : ℂ :=
-  if Φ.Even then N ^ (-s) * ∑ j, Φ j * completedHurwitzZetaEven (toAddCircle j) s
-  else N ^ (-s) * ∑ j, Φ j * completedHurwitzZetaOdd (toAddCircle j) s
+noncomputable def completedLFunction (Φ : ZMod N → ℂ) (s : ℂ) : ℂ :=
+  N ^ (-s) * ∑ j, Φ j * completedHurwitzZetaEven (toAddCircle j) s
+  + N ^ (-s) * ∑ j, Φ j * completedHurwitzZetaOdd (toAddCircle j) s
 
 @[simp] lemma completedLFunction_zero (s : ℂ) : completedLFunction (0 : ZMod N → ℂ) s = 0 := by
-  simp only [completedLFunction, Pi.zero_apply, zero_mul, sum_const_zero, mul_zero, ite_self]
+  simp only [completedLFunction, Pi.zero_apply, zero_mul, sum_const_zero, mul_zero, zero_add]
 
 lemma completedLFunction_def_even (hΦ : Φ.Even) (s : ℂ) :
     completedLFunction Φ s = N ^ (-s) * ∑ j, Φ j * completedHurwitzZetaEven (toAddCircle j) s := by
-  simp only [completedLFunction, hΦ, ↓reduceIte]
+  suffices ∑ j, Φ j * completedHurwitzZetaOdd (toAddCircle j) s = 0 by
+    rw [completedLFunction, this, mul_zero, add_zero]
+  refine (hΦ.mul_odd fun j ↦ ?_).sum_eq_zero
+  rw [map_neg, completedHurwitzZetaOdd_neg]
 
 lemma completedLFunction_def_odd (hΦ : Φ.Odd) (s : ℂ) :
     completedLFunction Φ s = N ^ (-s) * ∑ j, Φ j * completedHurwitzZetaOdd (toAddCircle j) s := by
-  by_cases hΦ' : Φ.Even
-    -- if `Φ = 0` we are in the "wrong" branch of the if-then, but it's OK because both sides are 0
-  · simp only [Φ.zero_of_even_and_odd hΦ' hΦ, completedLFunction_zero, Pi.zero_apply, zero_mul,
-      sum_const_zero, mul_zero]
-  · simp only [completedLFunction, hΦ', ↓reduceIte]
+  suffices ∑ j, Φ j * completedHurwitzZetaEven (toAddCircle j) s = 0 by
+    rw [completedLFunction, this, mul_zero, zero_add]
+  refine (hΦ.mul_even fun j ↦ ?_).sum_eq_zero
+  rw [map_neg, completedHurwitzZetaEven_neg]
 
 /--
 The completed L-function of a function `ZMod 1 → ℂ` is a scalar multiple of the completed Riemann
 zeta function.
 -/
-lemma completedLFunction_modOne_eq {Φ : ZMod 1 → ℂ} (s : ℂ) :
+lemma completedLFunction_modOne_eq (Φ : ZMod 1 → ℂ) (s : ℂ) :
     completedLFunction Φ s = Φ 1 * completedRiemannZeta s := by
   rw [completedLFunction_def_even (show Φ.Even from fun _ ↦ congr_arg Φ (Subsingleton.elim ..)),
     Nat.cast_one, one_cpow, one_mul, ← singleton_eq_univ 0, sum_singleton, map_zero,
@@ -320,42 +321,36 @@ variable (Φ) in
 /--
 The completed L-function of a function mod `N`, modified by adding multiples of `N ^ (-s) / s` and
 `N ^ (-s) / (1 - s)` to make it entire.
-
-This is well-defined for all `Φ`, but is uninteresting unless `Φ` is either even or odd.
 -/
 noncomputable def completedLFunction₀ (s : ℂ) : ℂ :=
-  if Φ.Even then N ^ (-s) * ∑ j : ZMod N, Φ j * completedHurwitzZetaEven₀ (toAddCircle j) s
-  else N ^ (-s) * ∑ j : ZMod N, Φ j * completedHurwitzZetaOdd (toAddCircle j) s
+  N ^ (-s) * ∑ j : ZMod N, Φ j * completedHurwitzZetaEven₀ (toAddCircle j) s
+  + N ^ (-s) * ∑ j : ZMod N, Φ j * completedHurwitzZetaOdd (toAddCircle j) s
 
 variable (Φ) in
 /-- The function `completedLFunction₀ Φ` is differentiable. -/
 lemma differentiable_completedLFunction₀ : Differentiable ℂ (completedLFunction₀ Φ) := by
-  unfold completedLFunction₀
-  by_cases h : Φ.Even <;>
-  simp only [h, reduceIte] <;>
+  refine .add ?_ ?_ <;>
   refine (differentiable_neg.const_cpow <| .inl <| NeZero.ne _).mul (.sum fun i _ ↦ .const_mul ?_ _)
   exacts [differentiable_completedHurwitzZetaEven₀ _, differentiable_completedHurwitzZetaOdd _]
 
-lemma completedLFunction_eq (hΦ : Φ.Even ∨ Φ.Odd) (s : ℂ) :
+variable (Φ) in
+lemma completedLFunction_eq (s : ℂ) :
     completedLFunction Φ s =
       completedLFunction₀ Φ s - N ^ (-s) * Φ 0 / s - N ^ (-s) * (∑ j, Φ j) / (1 - s) := by
-  simp only [completedLFunction, completedLFunction₀]
-  obtain hΦ | ⟨hΦ', hΦ⟩ : Φ.Even ∨ (¬Φ.Even ∧ Φ.Odd) := by tauto
-  · simp only [hΦ, ite_true, completedHurwitzZetaEven_eq, mul_sub, sum_sub_distrib]
-    congr 1
-    · simp only [toAddCircle_eq_zero, div_eq_mul_inv, ite_mul, one_mul, zero_mul, mul_ite,
-        mul_zero, sum_ite_eq', ite_true, Finset.mem_univ, mul_assoc]
-    · rw [← sum_mul, mul_one_div, mul_div_assoc]
-  · simp only [hΦ', ite_false, hΦ.map_zero, mul_zero, zero_div, sub_zero, hΦ.sum_eq_zero]
+  simp only [completedLFunction, completedHurwitzZetaEven_eq, toAddCircle_eq_zero, div_eq_mul_inv,
+    ite_mul, one_mul, zero_mul, mul_sub, mul_ite, mul_zero, sum_sub_distrib, Fintype.sum_ite_eq', ←
+    sum_mul, completedLFunction₀, mul_assoc]
+  abel
 
+variable (Φ) in
 /--
 The completed L-function of a function mod `N` is differentiable, with the following
 exceptions: at `s = 1` if `∑ j, Φ j ≠ 0`; and at `s = 0` if `Φ 0 ≠ 0`.
 -/
-lemma differentiableAt_completedLFunction (hΦ : Φ.Even ∨ Φ.Odd) (s : ℂ)
+lemma differentiableAt_completedLFunction (s : ℂ)
     (hs₀ : s ≠ 0 ∨ Φ 0 = 0) (hs₁ : s ≠ 1 ∨ ∑ j, Φ j = 0) :
     DifferentiableAt ℂ (completedLFunction Φ) s := by
-  simp only [funext (completedLFunction_eq hΦ), mul_div_assoc]
+  simp only [funext (completedLFunction_eq Φ), mul_div_assoc]
   -- We know `completedLFunction₀` is differentiable everywhere, so it suffices to show that the
   -- correction terms from `completedLFunction_eq` are differentiable at `s`.
   refine ((differentiable_completedLFunction₀ _ _).sub ?_).sub ?_
@@ -372,10 +367,9 @@ lemma differentiableAt_completedLFunction (hΦ : Φ.Even ∨ Φ.Odd) (s : ℂ)
 Special case of `differentiableAt_completedLFunction` asserting differentiability everywhere
 under suitable hypotheses.
 -/
-lemma differentiable_completedLFunction
-    (hΦ₁ : Φ.Even ∨ Φ.Odd) (hΦ₂ : Φ 0 = 0) (hΦ₃ : ∑ j, Φ j = 0) :
+lemma differentiable_completedLFunction (hΦ₂ : Φ 0 = 0) (hΦ₃ : ∑ j, Φ j = 0) :
     Differentiable ℂ (completedLFunction Φ) :=
-  fun s ↦ differentiableAt_completedLFunction hΦ₁ s (.inr hΦ₂) (.inr hΦ₃)
+  fun s ↦ differentiableAt_completedLFunction Φ s (.inr hΦ₂) (.inr hΦ₃)
 
 /--
 Relation between the completed L-function and the usual one (even case).
@@ -402,108 +396,57 @@ lemma LFunction_eq_completed_div_gammaFactor_odd (hΦ : Φ.Odd) (s : ℂ) :
     sum_div]
 
 /--
-Express `completedCosZeta` as the L-function of a function on `ZMod N`.
+First form of functional equation for completed L-functions (even case).
 
-The formulation is not optimal (the result is actually true for all `s ∉ {0, 1}`), but suffices for
-the proof of `completedLFunction_one_sub` below.
+Private because it is superseded by `completedLFunction_one_sub` below, which is valid for a much
+wider range of `s`.
 -/
-lemma completedLFunction_cos_eq_completedCosZeta_of_one_lt
-    (a : ZMod N) {s : ℂ} (hs : 1 < re s) :
-    completedLFunction (fun b ↦ (𝕖 (a * b) + 𝕖 (-a * b)) / 2) s =
-      completedCosZeta (toAddCircle a) s := by
-  set Φ := fun b ↦ (𝕖 (a * b) + 𝕖 (-a * b)) / 2
-  have hΦ : Φ.Even := fun b ↦ by simp only [neg_mul, mul_neg, neg_neg, add_comm, Φ]
-  have h1 : (Gammaℝ s)⁻¹ ≠ 0 := inv_ne_zero (Gammaℝ_ne_zero_of_re_pos (by linarith))
-  have h2 : s ≠ 1 := (lt_irrefl _ <| one_re ▸ · ▸ hs)
-  have h3 : cosZeta (toAddCircle a) s = completedCosZeta (toAddCircle a) s / s.Gammaℝ :=
-    Function.update_noteq (ne_zero_of_one_lt_re hs) ..
-  rw [← mul_left_inj' h1, ← div_eq_mul_inv, ← div_eq_mul_inv, ← h3, cosZeta_eq,
-    ← LFunction_eq_completed_div_gammaFactor_even hΦ _ (.inl <| ne_zero_of_one_lt_re hs)]
-  simp only [LFunction, add_div, add_mul, sum_add_distrib, Φ]
-  simp only [div_mul_eq_mul_div, ← sum_div, mul_add, ← mul_div_assoc,
-    ← LFunction_stdAddChar_eq_expZeta _ _ (.inr h2), LFunction, ← map_neg]
+private lemma completedLFunction_one_sub_of_one_lt_even (hΦ : Φ.Even) {s : ℂ} (hs : 1 < re s) :
+    completedLFunction Φ (1 - s) = N ^ (s - 1) * completedLFunction (𝓕 Φ) s := by
+  have hs₀ : s ≠ 0 := ne_zero_of_one_lt_re hs
+  have hs₁ : s ≠ 1 := (lt_irrefl _ <| one_re ▸ · ▸ hs)
+  -- strip down to the key equality:
+  suffices ∑ x, Φ x * completedCosZeta (toAddCircle x) s = completedLFunction (𝓕 Φ) s by
+    simp only [completedLFunction_def_even hΦ, neg_sub, completedHurwitzZetaEven_one_sub, this]
+  -- reduce to equality with un-completed L-functions:
+  suffices ∑ x, Φ x * cosZeta (toAddCircle x) s = LFunction (𝓕 Φ) s by
+    simpa only [cosZeta, Function.update_noteq hs₀, ← mul_div_assoc, ← sum_div,
+      LFunction_eq_completed_div_gammaFactor_even (dft_even_iff.mpr hΦ) _ (.inl hs₀),
+      div_left_inj' (Gammaℝ_ne_zero_of_re_pos (zero_lt_one.trans hs))]
+  -- expand out `LFunction (𝓕 Φ)` and use parity:
+  simp only [cosZeta_eq, ← mul_div_assoc _ _ (2 : ℂ), mul_add, ← sum_div, sum_add_distrib,
+    LFunction_dft Φ (.inr hs₁), map_neg, div_eq_iff (two_ne_zero' ℂ), mul_two, add_left_inj]
+  exact Fintype.sum_equiv (.neg _) _ _ (by simp [hΦ _])
 
 /--
-Express `completedSinZeta` as the L-function of a function on `ZMod N`.
+First form of functional equation for completed L-functions (odd case).
 
-The formulation is not optimal (the result is actually true for all `s`), but suffices for
-the proof of `completedLFunction_one_sub` below.
+Private because it is superseded by `completedLFunction_one_sub` below, which is valid for a much
+wider range of `s`.
 -/
-lemma completedLFunction_sin_eq_completedSinZeta_of_one_lt
-    (a : ZMod N) {s : ℂ} (hs : 1 < re s) :
-    completedLFunction (fun b ↦ (𝕖 (a * b) - 𝕖 (-a * b)) / (2 * I)) s =
-      completedSinZeta (toAddCircle a) s := by
-  set Φ := fun b ↦ (𝕖 (a * b) - 𝕖 (-a * b)) / (2 * I)
-  have hΦ : Φ.Odd := fun b ↦ by simp only [Φ, neg_mul, mul_neg, neg_neg, ← neg_div, neg_sub]
-  have h1 : (Gammaℝ (s + 1))⁻¹ ≠ 0 :=
-    inv_ne_zero (Gammaℝ_ne_zero_of_re_pos <| by simp only [add_re, one_re]; linarith)
-  have h2 : s ≠ 1 := (lt_irrefl _ <| one_re ▸ · ▸ hs)
-  rw [← mul_left_inj' h1, ← div_eq_mul_inv, ← div_eq_mul_inv, ← sinZeta, sinZeta_eq,
-    ← LFunction_eq_completed_div_gammaFactor_odd hΦ]
-  simp only [LFunction, sub_div, sub_mul, sum_sub_distrib, Φ]
-  simp only [mul_sub, LFunction, div_mul_eq_mul_div, ← sum_div, ← mul_div_assoc, ← map_neg,
-    ← LFunction_stdAddChar_eq_expZeta _ _ (.inr h2)]
-
-/--
-First form of functional equation for completed L-functions. Private because it is superseded
-by `completedLFunction_one_sub` below, which is valid for a much wider range of `s`.
--/
-private lemma completedLFunction_one_sub_of_one_lt (hΦ : Φ.Even ∨ Φ.Odd) (s : ℂ) (hs : 1 < re s) :
-    completedLFunction Φ (1 - s) =
-      N ^ (s - 1) * I ^ (if Φ.Even then 0 else 1) * completedLFunction (𝓕 Φ) s := by
-  -- preliminary mini-lemmas:
-  have he (x : ZMod N) : (fun b ↦ (𝕖 (x * b) + 𝕖 (-x * b)) / 2).Even := fun _ ↦ by
-    simp only [mul_neg, neg_mul, neg_neg, add_comm]
-  have ho (x : ZMod N) : (fun b ↦ (𝕖 (x * b) - 𝕖 (-x * b)) / (2 * I)).Odd := fun _ ↦ by
-    simp only [mul_neg, neg_mul, neg_neg, ← neg_div, neg_sub]
-  -- split into two mutually-exclusive cases:
-  obtain hΦ | ⟨hΦ', hΦ⟩ : Φ.Even ∨ (¬Φ.Even ∧ Φ.Odd) := by tauto
-  · -- even case
-    -- drill down to the key computation:
-    suffices ∑ x, Φ x * completedCosZeta (toAddCircle x) s = completedLFunction (𝓕 Φ) s by
-      simp only [completedLFunction_def_even hΦ, neg_sub, completedHurwitzZetaEven_one_sub, this,
-        hΦ, ite_true, pow_zero, mul_one]
-    -- now calculate:
-    let ζ (y : ZMod N) := completedHurwitzZetaEven (toAddCircle y)
-    calc ∑ x, Φ x * completedCosZeta (toAddCircle x) s
-    _ = ∑ x, ∑ y, Φ x * N ^ (-s) * ((𝕖 (x * y) + 𝕖 (-x * y)) / 2) * ζ y s := by
-      simp only [← completedLFunction_cos_eq_completedCosZeta_of_one_lt _ hs,
-        completedLFunction_def_even (he _), mul_sum, mul_assoc]
-    _ = N ^ (-s) * ∑ y, (∑ x, Φ x * ((𝕖 (x * y) + 𝕖 (-x * y)) / 2)) * ζ y s := by
-      rw [sum_comm]
-      simp only [mul_sum, sum_mul, mul_assoc, mul_left_comm (Φ _)]
-    _ = N ^ (-s) * (∑ y, (∑ x, Φ x * 𝕖 (x * y) + ∑ x, Φ x * 𝕖 (-x * y)) / 2 * ζ y s) := by
-      simp only [← mul_div_assoc, ← sum_div, mul_add, sum_add_distrib]
-    _ = N ^ (-s) * (∑ y, ((𝓕 Φ (-y) + 𝓕 Φ y) / 2) * ζ y s) := by
-      simp only [dft_apply, mul_neg, neg_mul, neg_neg, smul_eq_mul, mul_comm (Φ _)]
-    _ = N ^ (-s) * ∑ y, 𝓕 Φ y * ζ y s := by
-      simp only [dft_even_iff.mpr hΦ _, add_div, add_halves]
-    _ = completedLFunction (𝓕 Φ) s := by
-      rw [completedLFunction_def_even (dft_even_iff.mpr hΦ)]
-  · -- odd case
-    -- drill down to the key computation:
-    suffices ∑ x, Φ x * completedSinZeta (toAddCircle x) s = I * completedLFunction (𝓕 Φ) s by
-      simp only [completedLFunction_def_odd hΦ, neg_sub, completedHurwitzZetaOdd_one_sub, this, hΦ',
-        ite_false, pow_one, mul_assoc]
-    -- now calculate:
-    let ζ (y : ZMod N) := completedHurwitzZetaOdd (toAddCircle y)
-    calc ∑ x, Φ x * completedSinZeta (toAddCircle x) s
-    _ = ∑ x, ∑ y, Φ x * N ^ (-s) * ((𝕖 (x * y) - 𝕖 (-x * y)) / (2 * I)) * ζ y s := by
-      simp only [← completedLFunction_sin_eq_completedSinZeta_of_one_lt _ hs,
-        completedLFunction_def_odd (ho _), mul_sum, mul_assoc]
-    _ = N ^ (-s) * ∑ y, (∑ x, Φ x * ((𝕖 (x * y) - 𝕖 (-x * y)) / (2 * I))) * ζ y s := by
-      rw [sum_comm]
-      simp only [mul_sum, sum_mul, mul_assoc, mul_left_comm (Φ _)]
-    _ = N ^ (-s) * (∑ y, (∑ x, Φ x * 𝕖 (x * y) - ∑ x, Φ x * 𝕖 (-x * y)) / (2 * I) * ζ y s) := by
-      simp only [← mul_div_assoc, ← sum_div, mul_sub, sum_sub_distrib]
-    _ = N ^ (-s) * (∑ y, ((𝓕 Φ (-y) - 𝓕 Φ y) / (2 * I)) * ζ y s) := by
-      simp only [dft_apply, mul_neg, neg_mul, neg_neg, smul_eq_mul, mul_comm (Φ _)]
-    _ = I * (N ^ (-s) * ∑ y, 𝓕 Φ y * ζ y s) := by
-      simp only [dft_odd_iff.mpr hΦ _, sub_eq_add_neg, ← two_mul, ← div_div,
-        mul_div_cancel_left₀ _ (two_ne_zero' ℂ), div_eq_mul_inv _ I, inv_I, neg_mul_neg]
-      simp only [mul_comm _ I, mul_assoc, ← mul_sum, mul_left_comm]
-    _ = I * completedLFunction (𝓕 Φ) s := by
-      rw [completedLFunction_def_odd (dft_odd_iff.mpr hΦ)]
+private lemma completedLFunction_one_sub_of_one_lt_odd (hΦ : Φ.Odd) {s : ℂ} (hs : 1 < re s) :
+    completedLFunction Φ (1 - s) = N ^ (s - 1) * I * completedLFunction (𝓕 Φ) s := by
+  -- strip down to the key equality:
+  suffices ∑ x, Φ x * completedSinZeta (toAddCircle x) s = I * completedLFunction (𝓕 Φ) s by
+    simp only [completedLFunction_def_odd hΦ, neg_sub, completedHurwitzZetaOdd_one_sub, this,
+      mul_assoc]
+  -- reduce to equality with un-completed L-functions:
+  suffices ∑ x, Φ x * sinZeta (toAddCircle x) s = I * LFunction (𝓕 Φ) s by
+    have hs' : 0 < re (s + 1) := by simp only [add_re, one_re]; linarith
+    simpa only [sinZeta, ← mul_div_assoc, ← sum_div, div_left_inj' (Gammaℝ_ne_zero_of_re_pos hs'),
+      LFunction_eq_completed_div_gammaFactor_odd (dft_odd_iff.mpr hΦ)]
+  -- now calculate:
+  calc ∑ x, Φ x * sinZeta (toAddCircle x) s
+  _ = (∑ x, Φ x * expZeta (toAddCircle x) s) / (2 * I)
+      - (∑ x, Φ x * expZeta (toAddCircle (-x)) s) / (2 * I) := by
+    simp only [sinZeta_eq, ← mul_div_assoc, mul_sub, sub_div, sum_sub_distrib, sum_div, map_neg]
+  _ = (∑ x, Φ (-x) * expZeta (toAddCircle (-x)) s) / (_) - (_) := by
+    congrm ?_ / _ - _
+    exact (Fintype.sum_equiv (.neg _) _ _ fun x ↦ by rfl).symm
+  _ = -I⁻¹ * LFunction (𝓕 Φ) s := by
+    simp only [hΦ _, neg_mul, sum_neg_distrib, LFunction_dft Φ (.inl hΦ.map_zero)]
+    ring
+  _ = I * LFunction (𝓕 Φ) s := by rw [inv_I, neg_neg]
 
 /--
 Functional equation for completed L-functions, valid at all points of differentiability.
@@ -543,7 +486,7 @@ theorem completedLFunction_one_sub
   -- Analyticity on U:
   have hF : AnalyticOn ℂ F U := by
     refine DifferentiableOn.analyticOn (fun t ht ↦ DifferentiableAt.differentiableWithinAt ?_) hUo
-    refine (differentiableAt_completedLFunction hΦ (1 - t) ?_ ?_).comp t ?_
+    refine (differentiableAt_completedLFunction Φ (1 - t) ?_ ?_).comp t ?_
     · exact ht.2.imp_left (sub_ne_zero.mpr ∘ Ne.symm)
     · exact ht.1.imp_left sub_eq_self.not.mpr
     · exact differentiableAt_id.const_sub 1
@@ -553,13 +496,16 @@ theorem completedLFunction_one_sub
     · exact (DifferentiableAt.sub_const differentiableAt_id 1).const_cpow (.inl (NeZero.ne _))
     · -- Differentiablity of completed L-function for `𝓕 Φ`.
       apply differentiableAt_completedLFunction
-      · rwa [dft_even_iff, dft_odd_iff]
       · exact ht.1.imp_right fun h ↦ dft_apply_zero Φ ▸ h
       · refine ht.2.imp_right fun h ↦ ?_
         simp only [← dft_apply_zero, dft_dft, neg_zero, h, smul_zero]
   -- set where we know equality
   have hV : {z | 1 < re z} ∈ 𝓝 2 := (continuous_re.isOpen_preimage _ isOpen_Ioi).mem_nhds (by simp)
-  have hFG : F =ᶠ[𝓝 2] G := eventually_of_mem hV <| completedLFunction_one_sub_of_one_lt hΦ
+  have hFG : F =ᶠ[𝓝 2] G := eventually_of_mem hV <| fun t ht ↦ by
+    simp only [F, G]
+    split_ifs with h
+    · simpa only [pow_zero, mul_one] using completedLFunction_one_sub_of_one_lt_even h ht
+    · simpa only [pow_one] using completedLFunction_one_sub_of_one_lt_odd (by tauto) ht
   -- now apply the big hammer to finish
   exact hF.eqOn_of_preconnected_of_eventuallyEq hG hUp h2U hFG hsU
 

--- a/Mathlib/NumberTheory/LSeries/ZMod.lean
+++ b/Mathlib/NumberTheory/LSeries/ZMod.lean
@@ -269,14 +269,15 @@ lemma LFunction_def_odd (hΦ : Φ.Odd) (s : ℂ) :
 
 /-- The L-function of an even function vanishes at negative even integers. -/
 @[simp] lemma LFunction_neg_two_mul_nat_add_one (hΦ : Φ.Even) (n : ℕ) :
-    LFunction Φ (-2 * (n + 1)) = 0 := by
+    LFunction Φ (-(2 * (n + 1))) = 0 := by
   simp only [LFunction_def_even hΦ, hurwitzZetaEven_neg_two_mul_nat_add_one, mul_zero,
-    sum_const_zero]
+    sum_const_zero, ← neg_mul]
 
 /-- The L-function of an odd function vanishes at negative odd integers. -/
 @[simp] lemma LFunction_neg_two_mul_nat_sub_one (hΦ : Φ.Odd) (n : ℕ) :
-    LFunction Φ (-2 * n - 1) = 0 := by
-  simp only [LFunction_def_odd hΦ, hurwitzZetaOdd_neg_two_mul_nat_sub_one, mul_zero, sum_const_zero]
+    LFunction Φ (-(2 * n) - 1) = 0 := by
+  simp only [LFunction_def_odd hΦ, hurwitzZetaOdd_neg_two_mul_nat_sub_one, mul_zero,
+    ← neg_mul, sum_const_zero]
 
 variable (Φ) in
 /--

--- a/Mathlib/NumberTheory/LSeries/ZMod.lean
+++ b/Mathlib/NumberTheory/LSeries/ZMod.lean
@@ -311,10 +311,9 @@ zeta function.
 -/
 lemma completedLFunction_modOne_eq {Φ : ZMod 1 → ℂ} (s : ℂ) :
     completedLFunction Φ s = Φ 1 * completedRiemannZeta s := by
-  have : Φ.Even := fun j ↦ congr_arg Φ <| (Unique.eq_default (-j)).trans (Unique.eq_default j).symm
-  simp [completedLFunction, this]
-  change Φ 1 * completedHurwitzZetaEven (toAddCircle 0) s = _
-  rw [map_zero, completedHurwitzZetaEven_zero]
+  rw [completedLFunction_def_even (show Φ.Even from fun _ ↦ congr_arg Φ (Subsingleton.elim ..)),
+    Nat.cast_one, one_cpow, one_mul, ← singleton_eq_univ 0, sum_singleton, map_zero,
+    completedHurwitzZetaEven_zero, Subsingleton.elim 0 1]
 
 variable (Φ) in
 /--

--- a/Mathlib/NumberTheory/LSeries/ZMod.lean
+++ b/Mathlib/NumberTheory/LSeries/ZMod.lean
@@ -261,20 +261,20 @@ lemma LFunction_def_odd (hΦ : Φ.Odd) (s : ℂ) :
   simp only [Equiv.neg_apply, hΦ i, map_neg, hurwitzZetaEven_neg, neg_mul]
 
 /-- Explicit formula for `LFunction Φ 0` when `Φ` is even. -/
-lemma LFunction_apply_zero_of_even (hΦ : Φ.Even) :
+@[simp] lemma LFunction_apply_zero_of_even (hΦ : Φ.Even) :
     LFunction Φ 0 = -Φ 0 / 2 := by
   simp only [LFunction_def_even hΦ, neg_zero, cpow_zero, hurwitzZetaEven_apply_zero,
     toAddCircle_eq_zero, mul_ite, mul_div, mul_neg_one, mul_zero, sum_ite_eq', Finset.mem_univ,
     ↓reduceIte, one_mul]
 
 /-- The L-function of an even function vanishes at negative even integers. -/
-lemma LFunction_neg_two_mul_nat_add_one (hΦ : Φ.Even) (n : ℕ) :
+@[simp] lemma LFunction_neg_two_mul_nat_add_one (hΦ : Φ.Even) (n : ℕ) :
     LFunction Φ (-2 * (n + 1)) = 0 := by
   simp only [LFunction_def_even hΦ, hurwitzZetaEven_neg_two_mul_nat_add_one, mul_zero,
     sum_const_zero]
 
 /-- The L-function of an odd function vanishes at negative odd integers. -/
-lemma LFunction_neg_two_mul_nat_sub_one (hΦ : Φ.Odd) (n : ℕ) :
+@[simp] lemma LFunction_neg_two_mul_nat_sub_one (hΦ : Φ.Odd) (n : ℕ) :
     LFunction Φ (-2 * n - 1) = 0 := by
   simp only [LFunction_def_odd hΦ, hurwitzZetaOdd_neg_two_mul_nat_sub_one, mul_zero, sum_const_zero]
 
@@ -290,7 +290,7 @@ noncomputable def completedLFunction (s : ℂ) : ℂ :=
   if Φ.Even then N ^ (-s) * ∑ j, Φ j * completedHurwitzZetaEven (toAddCircle j) s
   else N ^ (-s) * ∑ j, Φ j * completedHurwitzZetaOdd (toAddCircle j) s
 
-lemma completedLFunction_zero (s : ℂ) : completedLFunction (0 : ZMod N → ℂ) s = 0 := by
+@[simp] lemma completedLFunction_zero (s : ℂ) : completedLFunction (0 : ZMod N → ℂ) s = 0 := by
   simp only [completedLFunction, Pi.zero_apply, zero_mul, sum_const_zero, mul_zero, ite_self]
 
 lemma completedLFunction_def_even (hΦ : Φ.Even) (s : ℂ) :
@@ -306,8 +306,8 @@ lemma completedLFunction_def_odd (hΦ : Φ.Odd) (s : ℂ) :
   · simp only [completedLFunction, hΦ', ↓reduceIte]
 
 /--
-The completed L-function of a function mod 1 is a scalar multiple of the completed Riemann zeta
-function.
+The completed L-function of a function `ZMod 1 → ℂ` is a scalar multiple of the completed Riemann
+zeta function.
 -/
 lemma completedLFunction_modOne_eq {Φ : ZMod 1 → ℂ} (s : ℂ) :
     completedLFunction Φ s = Φ 1 * completedRiemannZeta s := by

--- a/Mathlib/NumberTheory/LSeries/ZMod.lean
+++ b/Mathlib/NumberTheory/LSeries/ZMod.lean
@@ -345,9 +345,8 @@ lemma completedLFunction_eq (Φ : ZMod N → ℂ) (s : ℂ) :
 The completed L-function of a function `ZMod N → ℂ` is differentiable, with the following
 exceptions: at `s = 1` if `∑ j, Φ j ≠ 0`; and at `s = 0` if `Φ 0 ≠ 0`.
 -/
-lemma differentiableAt_completedLFunction (Φ : ZMod N → ℂ) (s : ℂ)
-    (hs₀ : s ≠ 0 ∨ Φ 0 = 0) (hs₁ : s ≠ 1 ∨ ∑ j, Φ j = 0) :
-    DifferentiableAt ℂ (completedLFunction Φ) s := by
+lemma differentiableAt_completedLFunction (Φ : ZMod N → ℂ) (s : ℂ) (hs₀ : s ≠ 0 ∨ Φ 0 = 0)
+    (hs₁ : s ≠ 1 ∨ ∑ j, Φ j = 0) : DifferentiableAt ℂ (completedLFunction Φ) s := by
   simp only [funext (completedLFunction_eq Φ), mul_div_assoc]
   -- We know `completedLFunction₀` is differentiable everywhere, so it suffices to show that the
   -- correction terms from `completedLFunction_eq` are differentiable at `s`.

--- a/Mathlib/NumberTheory/LSeries/ZMod.lean
+++ b/Mathlib/NumberTheory/LSeries/ZMod.lean
@@ -12,8 +12,10 @@ import Mathlib.NumberTheory.LSeries.RiemannZeta
 # L-series of functions on `ZMod N`
 
 We show that if `N` is a positive integer and `Φ : ZMod N → ℂ`, then the L-series of `Φ` has
-analytic continuation (away from a pole at `s = 1` if `∑ j, Φ j ≠ 0`). Assuming `Φ` is either
-even or odd, we define completed L-series and show analytic continuation of these too.
+analytic continuation (away from a pole at `s = 1` if `∑ j, Φ j ≠ 0`) and satisfies a functional
+equation. We also define completed L-functions (given by multiplying the naive L-function by a
+Gamma-factor), and prove analytic continuation and functional equations for these too, assuming `Φ`
+is either even or odd.
 
 The most familiar case is when `Φ` is a Dirichlet character, but the results here are valid
 for general functions; for the specific case of Dirichlet characters see
@@ -26,8 +28,8 @@ for general functions; for the specific case of Dirichlet characters see
   `LFunction Φ s` multiplied by an Archimedean Gamma-factor.
 
 Note that `ZMod.completedLFunction Φ s` is only mathematically well-defined if `Φ` is either even
-or odd. We have arbitrarily defined it to be the completed L-function of the odd part of `Φ`, if
-`Φ` is not even.
+or odd. Here we extend it to all functions `Φ` by linearity  (but the functional equation only holds
+if `Φ` is either even or odd).
 
 ## Main theorems
 
@@ -49,8 +51,8 @@ Results for completed L-functions:
   around so it is still valid at the poles of the Gamma factor.)
 * `ZMod.differentiableAt_completedLFunction`: `ZMod.completedLFunction Φ` is differentiable at
   `s ∈ ℂ`, unless `s = 1` and `∑ j, Φ j ≠ 0`, or `s = 0` and `Φ 0 ≠ 0`.
-* `ZMod.completedLFunction_one_sub`: the functional equation relating
-  `completedLFunction Φ (1 - s)` to `completedLFunction (𝓕 Φ) s`.
+* `ZMod.completedLFunction_one_sub_even` and `ZMod.completedLFunction_one_sub_odd`:
+  the functional equation relating `completedLFunction Φ (1 - s)` to `completedLFunction (𝓕 Φ) s`.
 -/
 
 open HurwitzZeta Complex ZMod Finset Classical Topology Filter Set
@@ -276,15 +278,14 @@ lemma LFunction_def_odd (hΦ : Φ.Odd) (s : ℂ) :
 /-- The L-function of an odd function vanishes at negative odd integers. -/
 @[simp] lemma LFunction_neg_two_mul_nat_sub_one (hΦ : Φ.Odd) (n : ℕ) :
     LFunction Φ (-(2 * n) - 1) = 0 := by
-  simp only [LFunction_def_odd hΦ, hurwitzZetaOdd_neg_two_mul_nat_sub_one, mul_zero,
-    ← neg_mul, sum_const_zero]
+  simp only [LFunction_def_odd hΦ, hurwitzZetaOdd_neg_two_mul_nat_sub_one, mul_zero, ← neg_mul,
+    sum_const_zero]
 
 /--
-The completed L-function of a function mod `N`.
+The completed L-function of a function `Φ : ZMod N → ℂ`.
 
-This is only mathematically meaningful if `Φ` is either even, or odd. We extend this to all `Φ`
-as follows: if `Φ` is not even, then the completed L-series of `Φ` is the `L`-series of the odd
-part of `Φ`.
+This is only mathematically meaningful if `Φ` is either even, or odd; here we extend this to all `Φ`
+by linearity.
 -/
 noncomputable def completedLFunction (Φ : ZMod N → ℂ) (s : ℂ) : ℂ :=
   N ^ (-s) * ∑ j, Φ j * completedHurwitzZetaEven (toAddCircle j) s
@@ -317,37 +318,34 @@ lemma completedLFunction_modOne_eq (Φ : ZMod 1 → ℂ) (s : ℂ) :
     Nat.cast_one, one_cpow, one_mul, ← singleton_eq_univ 0, sum_singleton, map_zero,
     completedHurwitzZetaEven_zero, Subsingleton.elim 0 1]
 
-variable (Φ) in
 /--
-The completed L-function of a function mod `N`, modified by adding multiples of `N ^ (-s) / s` and
-`N ^ (-s) / (1 - s)` to make it entire.
+The completed L-function of a function `ZMod N → ℂ`, modified by adding multiples of `N ^ (-s) / s`
+and `N ^ (-s) / (1 - s)` to make it entire.
 -/
-noncomputable def completedLFunction₀ (s : ℂ) : ℂ :=
+noncomputable def completedLFunction₀ (Φ : ZMod N → ℂ) (s : ℂ) : ℂ :=
   N ^ (-s) * ∑ j : ZMod N, Φ j * completedHurwitzZetaEven₀ (toAddCircle j) s
   + N ^ (-s) * ∑ j : ZMod N, Φ j * completedHurwitzZetaOdd (toAddCircle j) s
 
-variable (Φ) in
 /-- The function `completedLFunction₀ Φ` is differentiable. -/
-lemma differentiable_completedLFunction₀ : Differentiable ℂ (completedLFunction₀ Φ) := by
+lemma differentiable_completedLFunction₀ (Φ : ZMod N → ℂ) :
+    Differentiable ℂ (completedLFunction₀ Φ) := by
   refine .add ?_ ?_ <;>
   refine (differentiable_neg.const_cpow <| .inl <| NeZero.ne _).mul (.sum fun i _ ↦ .const_mul ?_ _)
   exacts [differentiable_completedHurwitzZetaEven₀ _, differentiable_completedHurwitzZetaOdd _]
 
-variable (Φ) in
-lemma completedLFunction_eq (s : ℂ) :
+lemma completedLFunction_eq (Φ : ZMod N → ℂ) (s : ℂ) :
     completedLFunction Φ s =
       completedLFunction₀ Φ s - N ^ (-s) * Φ 0 / s - N ^ (-s) * (∑ j, Φ j) / (1 - s) := by
   simp only [completedLFunction, completedHurwitzZetaEven_eq, toAddCircle_eq_zero, div_eq_mul_inv,
-    ite_mul, one_mul, zero_mul, mul_sub, mul_ite, mul_zero, sum_sub_distrib, Fintype.sum_ite_eq', ←
-    sum_mul, completedLFunction₀, mul_assoc]
+    ite_mul, one_mul, zero_mul, mul_sub, mul_ite, mul_zero, sum_sub_distrib, Fintype.sum_ite_eq',
+    ← sum_mul, completedLFunction₀, mul_assoc]
   abel
 
-variable (Φ) in
 /--
-The completed L-function of a function mod `N` is differentiable, with the following
+The completed L-function of a function `ZMod N → ℂ` is differentiable, with the following
 exceptions: at `s = 1` if `∑ j, Φ j ≠ 0`; and at `s = 0` if `Φ 0 ≠ 0`.
 -/
-lemma differentiableAt_completedLFunction (s : ℂ)
+lemma differentiableAt_completedLFunction (Φ : ZMod N → ℂ) (s : ℂ)
     (hs₀ : s ≠ 0 ∨ Φ 0 = 0) (hs₁ : s ≠ 1 ∨ ∑ j, Φ j = 0) :
     DifferentiableAt ℂ (completedLFunction Φ) s := by
   simp only [funext (completedLFunction_eq Φ), mul_div_assoc]
@@ -374,7 +372,7 @@ lemma differentiable_completedLFunction (hΦ₂ : Φ 0 = 0) (hΦ₃ : ∑ j, Φ 
 /--
 Relation between the completed L-function and the usual one (even case).
 We state it this way around so it holds at the poles of the gamma factor as well
-(except at `s = 0`, where it is genuinely false if `Φ 0 ≠ 0`).
+(except at `s = 0`, where it is genuinely false if `N > 1` and `Φ 0 ≠ 0`).
 -/
 lemma LFunction_eq_completed_div_gammaFactor_even (hΦ : Φ.Even) (s : ℂ) (hs : s ≠ 0 ∨ Φ 0 = 0) :
     LFunction Φ s = completedLFunction Φ s / Gammaℝ s := by
@@ -398,8 +396,8 @@ lemma LFunction_eq_completed_div_gammaFactor_odd (hΦ : Φ.Odd) (s : ℂ) :
 /--
 First form of functional equation for completed L-functions (even case).
 
-Private because it is superseded by `completedLFunction_one_sub` below, which is valid for a much
-wider range of `s`.
+Private because it is superseded by `completedLFunction_one_sub_even` below, which is valid for a
+much wider range of `s`.
 -/
 private lemma completedLFunction_one_sub_of_one_lt_even (hΦ : Φ.Even) {s : ℂ} (hs : 1 < re s) :
     completedLFunction Φ (1 - s) = N ^ (s - 1) * completedLFunction (𝓕 Φ) s := by
@@ -421,8 +419,8 @@ private lemma completedLFunction_one_sub_of_one_lt_even (hΦ : Φ.Even) {s : ℂ
 /--
 First form of functional equation for completed L-functions (odd case).
 
-Private because it is superseded by `completedLFunction_one_sub` below, which is valid for a much
-wider range of `s`.
+Private because it is superseded by `completedLFunction_one_sub_odd` below, which is valid for a
+much wider range of `s`.
 -/
 private lemma completedLFunction_one_sub_of_one_lt_odd (hΦ : Φ.Odd) {s : ℂ} (hs : 1 < re s) :
     completedLFunction Φ (1 - s) = N ^ (s - 1) * I * completedLFunction (𝓕 Φ) s := by
@@ -449,25 +447,23 @@ private lemma completedLFunction_one_sub_of_one_lt_odd (hΦ : Φ.Odd) {s : ℂ} 
   _ = I * LFunction (𝓕 Φ) s := by rw [inv_I, neg_neg]
 
 /--
-Functional equation for completed L-functions, valid at all points of differentiability.
+Functional equation for completed L-functions (even case), valid at all points of differentiability.
 -/
-theorem completedLFunction_one_sub
-    (hΦ : Φ.Even ∨ Φ.Odd) (s : ℂ) (hs₀ : s ≠ 0 ∨ ∑ j, Φ j = 0) (hs₁ : s ≠ 1 ∨ Φ 0 = 0) :
-    completedLFunction Φ (1 - s) =
-      N ^ (s - 1) * I ^ (if Φ.Even then 0 else 1) * completedLFunction (𝓕 Φ) s := by
+theorem completedLFunction_one_sub_even (hΦ : Φ.Even) (s : ℂ)
+    (hs₀ : s ≠ 0 ∨ ∑ j, Φ j = 0) (hs₁ : s ≠ 1 ∨ Φ 0 = 0) :
+    completedLFunction Φ (1 - s) = N ^ (s - 1) * completedLFunction (𝓕 Φ) s := by
   -- We prove this using `AnalyticOn.eqOn_of_preconnected_of_eventuallyEq`, so we need to
   -- gather up the ingredients for this big theorem.
   -- First set up some notations:
   let F (t) := completedLFunction Φ (1 - t)
-  let G (t) := ↑N ^ (t - 1) * I ^ (if Φ.Even then 0 else 1) * completedLFunction (𝓕 Φ) t
+  let G (t) := ↑N ^ (t - 1) * completedLFunction (𝓕 Φ) t
   -- Set on which F, G are analytic:
   let U := {t : ℂ | (t ≠ 0 ∨ ∑ j, Φ j = 0) ∧ (t ≠ 1 ∨ Φ 0 = 0)}
   -- Properties of U:
   have hsU : s ∈ U := ⟨hs₀, hs₁⟩
   have h2U : 2 ∈ U := ⟨.inl two_ne_zero, .inl (OfNat.ofNat_ne_one _)⟩
-  have hUo : IsOpen U := by
-    refine .inter ?_ ?_ <;>
-    exact (isOpen_compl_singleton.union isOpen_const)
+  have hUo : IsOpen U := (isOpen_compl_singleton.union isOpen_const).inter
+    (isOpen_compl_singleton.union isOpen_const)
   have hUp : IsPreconnected U := by
     -- need to write `U` as the complement of an obviously countable set
     let Uc : Set ℂ := (if ∑ j, Φ j = 0 then ∅ else {0}) ∪ (if Φ 0 = 0 then ∅ else {1})
@@ -479,35 +475,46 @@ theorem completedLFunction_one_sub
     · ext x
       by_cases h : Φ 0 = 0 <;>
       by_cases h' : ∑ j, Φ j = 0 <;>
-      simp only [U, Uc, h, h', and_true, and_false, or_true, or_false, ↓reduceIte, mem_setOf,
-        union_empty, true_and, empty_union, compl_empty, mem_univ,
-        mem_compl_iff, mem_union, not_or, not_mem_singleton_iff]
+      simp [U, Uc, h, h', and_comm]
     · simp only [rank_real_complex, Nat.one_lt_ofNat]
   -- Analyticity on U:
   have hF : AnalyticOn ℂ F U := by
     refine DifferentiableOn.analyticOn (fun t ht ↦ DifferentiableAt.differentiableWithinAt ?_) hUo
-    refine (differentiableAt_completedLFunction Φ (1 - t) ?_ ?_).comp t ?_
-    · exact ht.2.imp_left (sub_ne_zero.mpr ∘ Ne.symm)
-    · exact ht.1.imp_left sub_eq_self.not.mpr
-    · exact differentiableAt_id.const_sub 1
+    refine (differentiableAt_completedLFunction Φ _ ?_ ?_).comp t (differentiableAt_id.const_sub 1)
+    exacts [ht.2.imp_left (sub_ne_zero.mpr ∘ Ne.symm), ht.1.imp_left sub_eq_self.not.mpr]
   have hG : AnalyticOn ℂ G U := by
     refine DifferentiableOn.analyticOn (fun t ht ↦ DifferentiableAt.differentiableWithinAt ?_) hUo
-    refine .mul (.mul ?_ <| differentiableAt_const _) ?_
-    · exact (DifferentiableAt.sub_const differentiableAt_id 1).const_cpow (.inl (NeZero.ne _))
-    · -- Differentiablity of completed L-function for `𝓕 Φ`.
-      apply differentiableAt_completedLFunction
-      · exact ht.1.imp_right fun h ↦ dft_apply_zero Φ ▸ h
-      · refine ht.2.imp_right fun h ↦ ?_
-        simp only [← dft_apply_zero, dft_dft, neg_zero, h, smul_zero]
+    apply ((differentiableAt_id.sub_const 1).const_cpow (.inl (NeZero.ne _))).mul
+    apply differentiableAt_completedLFunction _ _ (ht.1.imp_right fun h ↦ dft_apply_zero Φ ▸ h)
+    exact ht.2.imp_right (fun h ↦ by simp only [← dft_apply_zero, dft_dft, neg_zero, h, smul_zero])
   -- set where we know equality
   have hV : {z | 1 < re z} ∈ 𝓝 2 := (continuous_re.isOpen_preimage _ isOpen_Ioi).mem_nhds (by simp)
   have hFG : F =ᶠ[𝓝 2] G := eventually_of_mem hV <| fun t ht ↦ by
-    simp only [F, G]
-    split_ifs with h
-    · simpa only [pow_zero, mul_one] using completedLFunction_one_sub_of_one_lt_even h ht
-    · simpa only [pow_one] using completedLFunction_one_sub_of_one_lt_odd (by tauto) ht
+    simpa only [F, G, pow_zero, mul_one] using completedLFunction_one_sub_of_one_lt_even hΦ ht
   -- now apply the big hammer to finish
   exact hF.eqOn_of_preconnected_of_eventuallyEq hG hUp h2U hFG hsU
+
+/-- Functional equation for completed L-functions (odd case), valid for all `s`. -/
+theorem completedLFunction_one_sub_odd (hΦ : Φ.Odd) (s : ℂ) :
+    completedLFunction Φ (1 - s) = N ^ (s - 1) * I * completedLFunction (𝓕 Φ) s := by
+  -- This is much easier than the even case since both functions are entire.
+  -- First set up some notations:
+  let F (t) := completedLFunction Φ (1 - t)
+  let G (t) := ↑N ^ (t - 1) * I * completedLFunction (𝓕 Φ) t
+  -- check F, G globally differentiable
+  have hF : Differentiable ℂ F := (differentiable_completedLFunction hΦ.map_zero
+    hΦ.sum_eq_zero).comp (differentiable_id.const_sub 1)
+  have hG : Differentiable ℂ G := by
+    apply (((differentiable_id.sub_const 1).const_cpow (.inl (NeZero.ne _))).mul_const _).mul
+    rw [← dft_odd_iff] at hΦ
+    exact differentiable_completedLFunction hΦ.map_zero hΦ.sum_eq_zero
+  -- set where we know equality
+  have : {z | 1 < re z} ∈ 𝓝 2 := (continuous_re.isOpen_preimage _ isOpen_Ioi).mem_nhds (by simp)
+  have hFG : F =ᶠ[𝓝 2] G := by filter_upwards [this] with t ht
+    using completedLFunction_one_sub_of_one_lt_odd hΦ ht
+  -- now apply the big hammer to finish
+  rw [← analyticOn_univ_iff_differentiable] at hF hG
+  exact congr_fun (hF.eq_of_eventuallyEq hG hFG) s
 
 end signed
 

--- a/Mathlib/NumberTheory/LSeries/ZMod.lean
+++ b/Mathlib/NumberTheory/LSeries/ZMod.lean
@@ -12,7 +12,8 @@ import Mathlib.NumberTheory.LSeries.RiemannZeta
 # L-series of functions on `ZMod N`
 
 We show that if `N` is a positive integer and `Φ : ZMod N → ℂ`, then the L-series of `Φ` has
-analytic continuation (away from a pole at `s = 1` if `∑ j, Φ j ≠ 0`).
+analytic continuation (away from a pole at `s = 1` if `∑ j, Φ j ≠ 0`). Assuming `Φ` is either
+even or odd, we define completed L-series and show analytic continuation of these too.
 
 The most familiar case is when `Φ` is a Dirichlet character, but the results here are valid
 for general functions; for the specific case of Dirichlet characters see
@@ -21,6 +22,13 @@ for general functions; for the specific case of Dirichlet characters see
 ## Main definitions
 
 * `ZMod.LFunction Φ s`: the meromorphic continuation of the function `∑ n : ℕ, Φ n * n ^ (-s)`.
+* `completedLFunction Φ s`: the completed L-function, which for *almost* all `s` is equal to
+  `LFunction Φ s * gammaFactor Φ s` where `gammaFactor Φ s`
+  is the archimedean Gamma-factor.
+
+Note that if `Φ` is not either even or odd, there is no natural definition of the completed
+L-function; we arbitrarily declare that if `Φ` is not even, then `completedLFunction Φ` is the
+completed L-function of the odd part of `Φ`.
 
 ## Main theorems
 
@@ -30,6 +38,10 @@ for general functions; for the specific case of Dirichlet characters see
   `s ≠ 1` or `∑ j, Φ j = 0`.
 * `ZMod.LFunction_one_sub`: the functional equation relating `LFunction Φ (1 - s)` to
   `LFunction (𝓕 Φ) s`, where `𝓕` is the Fourier transform.
+* `ZMod.LFunction_eq_completed_div_gammaFactor`: we have
+  `LFunction Φ s = completedLFunction Φ s / gammaFactor Φ s`, unless `s = 0` and `Φ 0 ≠ 0`.
+* `ZMod.differentiableAt_completedLFunction`: `ZMod.completedLFunction Φ` is differentiable at
+  `s ∈ ℂ`, unless `s = 1` and `∑ j, Φ j ≠ 0`, or `s = 0` and `Φ 0 ≠ 0`.
 -/
 
 open HurwitzZeta Complex ZMod Finset Classical Topology Filter Set
@@ -218,5 +230,169 @@ theorem LFunction_one_sub (Φ : ZMod N → ℂ) {s : ℂ}
   conv_rhs => enter [2, 2]; rw [← (Equiv.neg _).sum_comp _ _ (by simp), Equiv.neg_apply]
   simp_rw [neg_neg, mul_sum, ← sum_add_distrib, ← mul_assoc, mul_comm _ (Φ _), mul_assoc,
     ← mul_add, map_neg, add_comm]
+
+section signed
+
+variable {Φ : ZMod N → ℂ}
+
+/--
+If `Φ` is either even or odd, we can write `LFunction Φ s` using signed Hurwitz zeta functions.
+Useful for comparison with `completedLFunction Φ s`.
+-/
+lemma LFunction_def_signed (hΦ : Φ.Even ∨ Φ.Odd) (s : ℂ) :
+    LFunction Φ s =
+      if Φ.Even then N ^ (-s) * ∑ j : ZMod N, Φ j * hurwitzZetaEven (toAddCircle j) s
+      else N ^ (-s) * ∑ j : ZMod N, Φ j * hurwitzZetaOdd (toAddCircle j) s := by
+  simp only [LFunction, ← mul_ite, hurwitzZeta, mul_add, sum_add_distrib]
+  rw [← mul_add]
+  congr 1
+  by_cases h : Φ.Even
+  · simp only [h, ↓reduceIte, add_right_eq_self, ← sum_neg_distrib, ← neg_eq_self ℂ]
+    refine Fintype.sum_equiv (.neg _) _ _ fun i ↦ ?_
+    simp only [Equiv.neg_apply, h i, map_neg, hurwitzZetaOdd_neg, mul_neg]
+  · simp only [h, ↓reduceIte, add_left_eq_self, ← neg_eq_self ℂ, ← sum_neg_distrib]
+    refine Fintype.sum_equiv (.neg _) _ _ fun i ↦ ?_
+    simp only [Equiv.neg_apply, map_neg, hurwitzZetaEven_neg, (show Φ.Odd by tauto) i, neg_mul]
+
+/-- Explicit formula for `LFunction Φ 0` when `Φ` is even. -/
+lemma LFunction_apply_zero_of_even (hΦ : Φ.Even) :
+    LFunction Φ 0 = -Φ 0 / 2 := by
+  simp only [LFunction_def_signed (Or.inl hΦ), hΦ, ↓reduceIte, neg_zero, cpow_zero,
+    hurwitzZetaEven_apply_zero, toAddCircle_eq_zero, mul_ite, mul_zero, sum_ite_eq', mem_univ,
+    one_mul, mul_div, mul_neg_one]
+
+/-- The L-function of an even function vanishes at negative even integers. -/
+lemma LFunction_neg_two_mul_nat_add_one (hΦ : Φ.Even) (n : ℕ) :
+    LFunction Φ (-2 * (n + 1)) = 0 := by
+  simp only [LFunction_def_signed (Or.inl hΦ), hΦ, ↓reduceIte,
+    hurwitzZetaEven_neg_two_mul_nat_add_one, mul_zero, sum_const_zero]
+
+/-- The L-function of an odd function vanishes at negative odd integers. -/
+lemma LFunction_neg_two_mul_nat_sub_one (hΦ : Φ.Odd) (n : ℕ) :
+    LFunction Φ (-2 * n - 1) = 0 := by
+  by_cases hΦ' : Φ.Even
+  · -- silly case: `Φ` is both even and odd, so it's zero
+    have : Φ = 0 := funext fun j ↦ by rw [Pi.zero_apply, ← neg_eq_self ℂ, ← hΦ j, hΦ' j]
+    simp [LFunction, this]
+  · simp only [LFunction_def_signed (Or.inr hΦ), hΦ', ↓reduceIte,
+      hurwitzZetaOdd_neg_two_mul_nat_sub_one, mul_zero, sum_const_zero]
+
+variable (Φ) in
+/--
+The completed L-function of a function mod `N`.
+
+This is only mathematically meaningful if `Φ` is either even, or odd. We extend this to all `Φ`
+as follows: if `Φ` is not even, then the completed L-series of `Φ` is the `L`-series of the odd
+part of `Φ`.
+-/
+noncomputable def completedLFunction (s : ℂ) : ℂ :=
+  if Φ.Even then N ^ (-s) * ∑ j : ZMod N, Φ j * completedHurwitzZetaEven (toAddCircle j) s
+  else N ^ (-s) * ∑ j : ZMod N, Φ j * completedHurwitzZetaOdd (toAddCircle j) s
+
+variable (Φ) in
+/--
+The completed L-function of a function mod `N`, modified by adding multiples of `N ^ (-s) / s` and
+`N ^ (-s) / (1 - s)` to make it entire.
+
+This is well-defined for all `Φ`, but is uninteresting unless `Φ` is either even or odd.
+-/
+noncomputable def completedLFunction₀ (s : ℂ) : ℂ :=
+  if Φ.Even then N ^ (-s) * ∑ j : ZMod N, Φ j * completedHurwitzZetaEven₀ (toAddCircle j) s
+  else N ^ (-s) * ∑ j : ZMod N, Φ j * completedHurwitzZetaOdd (toAddCircle j) s
+
+/--
+The L-function a function mod 1 is a scalar multiple of the completed Riemann zeta function.
+-/
+lemma completedLFunction_modOne_eq {Φ : ZMod 1 → ℂ} (s : ℂ) :
+    completedLFunction Φ s = Φ 1 * completedRiemannZeta s := by
+  have : Φ.Even := fun j ↦ congr_arg Φ <| (Unique.eq_default (-j)).trans (Unique.eq_default j).symm
+  simp [completedLFunction, this]
+  change Φ 1 * completedHurwitzZetaEven (toAddCircle 0) s = _
+  rw [map_zero, completedHurwitzZetaEven_zero]
+
+variable (Φ) in
+/-- The function `completedLFunction₀ Φ` is differentiable. -/
+lemma differentiable_completedLFunction₀ : Differentiable ℂ (completedLFunction₀ Φ) := by
+  unfold completedLFunction₀
+  by_cases h : Φ.Even <;>
+  simp only [h, reduceIte] <;>
+  refine (differentiable_neg.const_cpow <| Or.inl <| NeZero.ne _).mul
+    (.sum fun i _ ↦ .const_mul ?_ _)
+  exacts [differentiable_completedHurwitzZetaEven₀ _, differentiable_completedHurwitzZetaOdd _]
+
+lemma completedLFunction_eq (hΦ : Φ.Even ∨ Φ.Odd) (s : ℂ) :
+    completedLFunction Φ s =
+      completedLFunction₀ Φ s - N ^ (-s) * Φ 0 / s - N ^ (-s) * (∑ j, Φ j) / (1 - s) := by
+  simp only [completedLFunction, completedLFunction₀]
+  split_ifs with h
+  · simp only [completedHurwitzZetaEven_eq, mul_sub, sum_sub_distrib]
+    congr 1
+    · simp only [toAddCircle_eq_zero, div_eq_mul_inv, ite_mul, one_mul, zero_mul, mul_ite,
+        mul_zero, sum_ite_eq', mem_univ, ↓reduceIte, mul_assoc]
+    · rw [← sum_mul, mul_one_div, mul_div_assoc]
+  · replace hΦ : Function.Odd Φ := by tauto
+    have : Φ 0 = 0 := by rw [← neg_eq_self ℂ, ← hΦ 0, neg_zero]
+    rw [this, mul_zero, zero_div, sub_zero]
+    suffices ∑ j, Φ j = 0 by rw [this, mul_zero, zero_div, sub_zero]
+    simp only [← neg_eq_self ℂ, ← sum_neg_distrib]
+    exact Fintype.sum_equiv _ _ _ (fun i ↦ by rw [Equiv.neg_apply, hΦ])
+
+/--
+The completed L-function of a function mod `N` is differentiable, with the following
+exceptions: at `s = 1` if `∑ j, Φ j ≠ 0`; and at `s = 0` if `Φ 0 ≠ 0`. (This result is optimal.)
+-/
+lemma differentiableAt_completedLFunction (hΦ : Φ.Even ∨ Φ.Odd) (s : ℂ) (hs₀ : s ≠ 0 ∨ Φ 0 = 0)
+    (hs₁ : s ≠ 1 ∨ ∑ j, Φ j = 0) :
+    DifferentiableAt ℂ (completedLFunction Φ) s := by
+  simp only [funext fun s ↦ completedLFunction_eq hΦ s, mul_div_assoc]
+  -- We know `completedLFunction₀` is differentiable everywhere, so it suffices to show that the
+  -- correction terms from `completedLFunction_eq` are differentiable at `s`.
+  refine ((differentiable_completedLFunction₀ _ _).sub ?_).sub ?_
+  · -- term with `1 / s`
+    refine ((differentiable_neg.const_cpow <| Or.inl <| NeZero.ne _) s).mul
+      (?_ : DifferentiableAt ℂ (fun t ↦ Φ 0 / t) s)
+    rcases hs₀ with h | h
+    · exact (differentiableAt_const _).div differentiableAt_id h
+    · simp only [h, zero_div, differentiableAt_const]
+  · -- term with `1 / (1 - s)`
+    apply ((differentiable_neg.const_cpow <| Or.inl <| NeZero.ne _) s).mul
+    rcases hs₁ with h | h
+    · exact (differentiableAt_const _).div (by fun_prop) (by rwa [sub_ne_zero, ne_comm])
+    · simp only [h, zero_div, differentiableAt_const]
+
+/--
+Special case of `differentiableAt_completedLFunction` asserting differentiability everywhere
+under suitable hypotheses.
+-/
+lemma differentiable_completedLFunction
+    (hΦ₁ : Φ.Even ∨ Φ.Odd) (hΦ₂ : Φ 0 = 0) (hΦ₃ : ∑ j, Φ j = 0) :
+    Differentiable ℂ (completedLFunction Φ) :=
+  fun s ↦ differentiableAt_completedLFunction hΦ₁ s (Or.inr hΦ₂) (Or.inr hΦ₃)
+
+/-- The Archimedean Gamma factor: `Gammaℝ s` if `Φ` is even, and `Gammaℝ (s + 1)` otherwise. -/
+noncomputable def gammaFactor (Φ : ZMod N → ℂ) (s : ℂ) : ℂ :=
+   if Φ.Even then Gammaℝ s else Gammaℝ (s + 1)
+
+/--
+Relation between the completed L-function and the usual one. We state it this way around so
+it holds at the poles of the gamma factor as well (except at `s = 0`, where it is genuinely
+false if `Φ 0 ≠ 0`).
+-/
+lemma LFunction_eq_completed_div_gammaFactor (hΦ : Φ.Even ∨ Φ.Odd) (s : ℂ) (hs : s ≠ 0 ∨ Φ 0 = 0) :
+    LFunction Φ s = completedLFunction Φ s / gammaFactor Φ s := by
+  rw [LFunction_def_signed hΦ, completedLFunction, gammaFactor]
+  split_ifs with h
+  · -- `Φ` even
+    simp only [mul_div_assoc, sum_div]
+    congr 2 with i
+    rcases ne_or_eq i 0 with hi | rfl
+    · rw [hurwitzZetaEven_def_of_ne_or_ne (Or.inl (hi ∘ toAddCircle_eq_zero.mp))]
+    · rcases hs with hs | hΦ'
+      · rw [hurwitzZetaEven_def_of_ne_or_ne (Or.inr hs)]
+      · simp only [hΦ', map_zero, zero_mul]
+  · -- `Φ` not even
+    simp only [hurwitzZetaOdd, mul_div_assoc, sum_div]
+
+end signed
 
 end ZMod


### PR DESCRIPTION
Define the completed L-function for a function on `ZMod N`, and prove its functional equation.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
