### PR TITLE
[Merged by Bors] - chore(AlgebraicGeometry): weaken assumptions on local ring hom properties

### DIFF
--- a/Mathlib/AlgebraicGeometry/Morphisms/FinitePresentation.lean
+++ b/Mathlib/AlgebraicGeometry/Morphisms/FinitePresentation.lean
@@ -49,7 +49,7 @@ instance : HasRingHomProperty @LocallyOfFinitePresentation RingHom.FinitePresent
 instance (priority := 900) locallyOfFinitePresentation_of_isOpenImmersion [IsOpenImmersion f] :
     LocallyOfFinitePresentation f :=
   HasRingHomProperty.of_isOpenImmersion
-    (RingHom.finitePresentation_holdsForLocalizationAway).containsIdentities
+    RingHom.finitePresentation_holdsForLocalizationAway.containsIdentities
 
 instance : MorphismProperty.IsStableUnderComposition @LocallyOfFinitePresentation :=
   HasRingHomProperty.stableUnderComposition RingHom.finitePresentation_stableUnderComposition

--- a/Mathlib/AlgebraicGeometry/Morphisms/FinitePresentation.lean
+++ b/Mathlib/AlgebraicGeometry/Morphisms/FinitePresentation.lean
@@ -49,6 +49,7 @@ instance : HasRingHomProperty @LocallyOfFinitePresentation RingHom.FinitePresent
 instance (priority := 900) locallyOfFinitePresentation_of_isOpenImmersion [IsOpenImmersion f] :
     LocallyOfFinitePresentation f :=
   HasRingHomProperty.of_isOpenImmersion
+    (RingHom.finitePresentation_holdsForLocalizationAway).containsIdentities
 
 instance : MorphismProperty.IsStableUnderComposition @LocallyOfFinitePresentation :=
   HasRingHomProperty.stableUnderComposition RingHom.finitePresentation_stableUnderComposition

--- a/Mathlib/AlgebraicGeometry/Morphisms/FinitePresentation.lean
+++ b/Mathlib/AlgebraicGeometry/Morphisms/FinitePresentation.lean
@@ -50,6 +50,9 @@ instance (priority := 900) locallyOfFinitePresentation_of_isOpenImmersion [IsOpe
     LocallyOfFinitePresentation f :=
   HasRingHomProperty.of_isOpenImmersion
 
+instance : MorphismProperty.IsStableUnderComposition @LocallyOfFinitePresentation :=
+  HasRingHomProperty.stableUnderComposition RingHom.finitePresentation_stableUnderComposition
+
 instance locallyOfFinitePresentation_comp {X Y Z : Scheme.{u}} (f : X ⟶ Y) (g : Y ⟶ Z)
     [hf : LocallyOfFinitePresentation f] [hg : LocallyOfFinitePresentation g] :
     LocallyOfFinitePresentation (f ≫ g) :=

--- a/Mathlib/AlgebraicGeometry/Morphisms/FiniteType.lean
+++ b/Mathlib/AlgebraicGeometry/Morphisms/FiniteType.lean
@@ -47,6 +47,9 @@ instance (priority := 900) locallyOfFiniteType_of_isOpenImmersion [IsOpenImmersi
     LocallyOfFiniteType f :=
   HasRingHomProperty.of_isOpenImmersion
 
+instance : MorphismProperty.IsStableUnderComposition @LocallyOfFiniteType :=
+  HasRingHomProperty.stableUnderComposition RingHom.finiteType_stableUnderComposition
+
 instance locallyOfFiniteType_comp {X Y Z : Scheme} (f : X ⟶ Y) (g : Y ⟶ Z)
     [hf : LocallyOfFiniteType f] [hg : LocallyOfFiniteType g] : LocallyOfFiniteType (f ≫ g) :=
   MorphismProperty.comp_mem _ f g hf hg

--- a/Mathlib/AlgebraicGeometry/Morphisms/FiniteType.lean
+++ b/Mathlib/AlgebraicGeometry/Morphisms/FiniteType.lean
@@ -46,6 +46,7 @@ instance : HasRingHomProperty @LocallyOfFiniteType RingHom.FiniteType where
 instance (priority := 900) locallyOfFiniteType_of_isOpenImmersion [IsOpenImmersion f] :
     LocallyOfFiniteType f :=
   HasRingHomProperty.of_isOpenImmersion
+    RingHom.finiteType_holdsForLocalizationAway.containsIdentities
 
 instance : MorphismProperty.IsStableUnderComposition @LocallyOfFiniteType :=
   HasRingHomProperty.stableUnderComposition RingHom.finiteType_stableUnderComposition

--- a/Mathlib/AlgebraicGeometry/Morphisms/RingHomProperties.lean
+++ b/Mathlib/AlgebraicGeometry/Morphisms/RingHomProperties.lean
@@ -282,14 +282,13 @@ instance : IsLocalAtSource P := by
     fun i ↦ iff_of_source_openCover (P := P) (f := 𝒰.map i ≫ f) (𝒰.obj i).affineCover]
   simp [Scheme.OpenCover.affineRefinement, Sigma.forall]
 
-instance : P.ContainsIdentities where
+lemma containsIdentities (hP : RingHom.ContainsIdentities Q) : P.ContainsIdentities where
   id_mem X := by
     rw [IsLocalAtTarget.iff_of_iSup_eq_top (P := P) _ (iSup_affineOpens_eq_top _)]
     intro U
     have : IsAffine (𝟙 X ⁻¹ᵁ U.1) := U.2
     rw [morphismRestrict_id, iff_of_isAffine (P := P), Scheme.id_app]
-    exact (isLocal_ringHomProperty P).HoldsForLocalizationAway.of_bijective _ _
-      Function.bijective_id
+    apply hP
 
 lemma stableUnderComposition (hP : RingHom.StableUnderComposition Q) :
     P.IsStableUnderComposition where
@@ -339,11 +338,16 @@ theorem of_comp
   rw [iff_of_isAffine (P := P)] at h ⊢
   exact H _ _ h
 
-lemma isMultiplicative (hP : RingHom.StableUnderComposition Q) : P.IsMultiplicative where
-  comp_mem := (stableUnderComposition hP).comp_mem
+lemma isMultiplicative (hPc : RingHom.StableUnderComposition Q)
+    (hPi : RingHom.ContainsIdentities Q) :
+    P.IsMultiplicative where
+  comp_mem := (stableUnderComposition hPc).comp_mem
+  id_mem := (containsIdentities hPi).id_mem
 
 include Q in
-lemma of_isOpenImmersion [IsOpenImmersion f] : P f := IsLocalAtSource.of_isOpenImmersion f
+lemma of_isOpenImmersion (hP : RingHom.ContainsIdentities Q) [IsOpenImmersion f] : P f :=
+  haveI : P.ContainsIdentities := containsIdentities hP
+  IsLocalAtSource.of_isOpenImmersion f
 
 lemma stableUnderBaseChange (hP : RingHom.StableUnderBaseChange Q) : P.StableUnderBaseChange := by
   apply HasAffineProperty.stableUnderBaseChange

--- a/Mathlib/AlgebraicGeometry/Morphisms/RingHomProperties.lean
+++ b/Mathlib/AlgebraicGeometry/Morphisms/RingHomProperties.lean
@@ -228,9 +228,8 @@ theorem of_source_openCover [IsAffine Y]
   | basicOpen U r H =>
     simp_rw [Scheme.affineBasicOpen_coe,
       ← f.appLE_map (U := ⊤) le_top (homOfLE (X.basicOpen_le r)).op]
-    apply (isLocal_ringHomProperty P).StableUnderComposition _ _ H
     have := U.2.isLocalization_basicOpen r
-    apply (isLocal_ringHomProperty P).HoldsForLocalizationAway _ r
+    exact (isLocal_ringHomProperty P).StableUnderCompositionWithLocalizationAway.left _ r _ H
   | openCover U s hs H =>
     apply (isLocal_ringHomProperty P).OfLocalizationSpanTarget.ofIsLocalization
       (isLocal_ringHomProperty P).respectsIso _ _ hs
@@ -292,7 +291,8 @@ instance : P.ContainsIdentities where
     exact (isLocal_ringHomProperty P).HoldsForLocalizationAway.of_bijective _ _
       Function.bijective_id
 
-instance : P.IsStableUnderComposition where
+lemma stableUnderComposition (hP : RingHom.StableUnderComposition Q) :
+    P.IsStableUnderComposition where
   comp_mem {X Y Z} f g hf hg := by
     wlog hZ : IsAffine Z generalizing X Y Z
     · rw [IsLocalAtTarget.iff_of_iSup_eq_top (P := P) _ (iSup_affineOpens_eq_top _)]
@@ -311,7 +311,7 @@ instance : P.IsStableUnderComposition where
       rw [← Category.assoc]
       exact this _ (comp_of_isOpenImmersion _ _ _ hf) inferInstance
     rw [iff_of_isAffine (P := P)] at hf hg ⊢
-    exact (isLocal_ringHomProperty P).StableUnderComposition _ _ hg hf
+    exact hP _ _ hg hf
 
 theorem of_comp
     (H : ∀ {R S T : Type u} [CommRing R] [CommRing S] [CommRing T],
@@ -339,7 +339,8 @@ theorem of_comp
   rw [iff_of_isAffine (P := P)] at h ⊢
   exact H _ _ h
 
-instance : P.IsMultiplicative where
+lemma isMultiplicative (hP : RingHom.StableUnderComposition Q) : P.IsMultiplicative where
+  comp_mem := (stableUnderComposition hP).comp_mem
 
 include Q in
 lemma of_isOpenImmersion [IsOpenImmersion f] : P f := IsLocalAtSource.of_isOpenImmersion f

--- a/Mathlib/RingTheory/LocalProperties.lean
+++ b/Mathlib/RingTheory/LocalProperties.lean
@@ -215,15 +215,14 @@ theorem RingHom.LocalizationPreserves.away (H : RingHom.LocalizationPreserves @P
   have : IsLocalization ((Submonoid.powers r).map f) S' := by rw [Submonoid.map_powers]; assumption
   exact H f (Submonoid.powers r) R' S' hf
 
-/-
-lemma RingHom.PropertyIsLocal.HoldsForLocalizationAway (hP : RingHom.PropertyIsLocal @P) :
+lemma RingHom.PropertyIsLocal.HoldsForLocalizationAway (hP : RingHom.PropertyIsLocal @P)
+    (hPi : ContainsIdentities P) :
     RingHom.HoldsForLocalizationAway @P := by
   introv R _
   have : algebraMap R S = (algebraMap R S).comp (RingHom.id R) := by simp
   rw [this]
   apply (hP.StableUnderCompositionWithLocalizationAway).left S r
-  apply hP.ContainsIdentities
--/
+  apply hPi
 
 theorem RingHom.PropertyIsLocal.ofLocalizationSpan (hP : RingHom.PropertyIsLocal @P) :
     RingHom.OfLocalizationSpan @P := by

--- a/Mathlib/RingTheory/LocalProperties.lean
+++ b/Mathlib/RingTheory/LocalProperties.lean
@@ -144,7 +144,6 @@ structure RingHom.PropertyIsLocal : Prop where
   LocalizationPreserves : RingHom.LocalizationPreserves @P
   OfLocalizationSpanTarget : RingHom.OfLocalizationSpanTarget @P
   StableUnderCompositionWithLocalizationAway : RingHom.StableUnderCompositionWithLocalizationAway @P
-  ContainsIdentities : RingHom.ContainsIdentities @P
 
 theorem RingHom.ofLocalizationSpan_iff_finite :
     RingHom.OfLocalizationSpan @P ↔ RingHom.OfLocalizationFiniteSpan @P := by
@@ -216,6 +215,7 @@ theorem RingHom.LocalizationPreserves.away (H : RingHom.LocalizationPreserves @P
   have : IsLocalization ((Submonoid.powers r).map f) S' := by rw [Submonoid.map_powers]; assumption
   exact H f (Submonoid.powers r) R' S' hf
 
+/-
 lemma RingHom.PropertyIsLocal.HoldsForLocalizationAway (hP : RingHom.PropertyIsLocal @P) :
     RingHom.HoldsForLocalizationAway @P := by
   introv R _
@@ -223,6 +223,7 @@ lemma RingHom.PropertyIsLocal.HoldsForLocalizationAway (hP : RingHom.PropertyIsL
   rw [this]
   apply (hP.StableUnderCompositionWithLocalizationAway).left S r
   apply hP.ContainsIdentities
+-/
 
 theorem RingHom.PropertyIsLocal.ofLocalizationSpan (hP : RingHom.PropertyIsLocal @P) :
     RingHom.OfLocalizationSpan @P := by

--- a/Mathlib/RingTheory/LocalProperties.lean
+++ b/Mathlib/RingTheory/LocalProperties.lean
@@ -64,6 +64,10 @@ section RingHom
 
 variable (P : ∀ {R S : Type u} [CommRing R] [CommRing S] (_ : R →+* S), Prop)
 
+/-- A property `P` of ring homs is said to contain identities if `P` holds
+for the identity homomorphism of every ring. -/
+def RingHom.ContainsIdentities := ∀ (R : Type u) [CommRing R], P (RingHom.id R)
+
 /-- A property `P` of ring homs is said to be preserved by localization
  if `P` holds for `M⁻¹R →+* M⁻¹S` whenever `P` holds for `R →+* S`. -/
 def RingHom.LocalizationPreserves :=
@@ -98,6 +102,15 @@ def RingHom.HoldsForLocalizationAway : Prop :=
   ∀ ⦃R : Type u⦄ (S : Type u) [CommRing R] [CommRing S] [Algebra R S] (r : R)
     [IsLocalization.Away r S], P (algebraMap R S)
 
+/-- A property `P` of ring homs satisfies `RingHom.StableUnderCompositionWithLocalizationAway`
+if whenever `P` holds for `f` it also holds for the composition with
+localization maps on the left and on the right. -/
+def RingHom.StableUnderCompositionWithLocalizationAway : Prop :=
+  (∀ ⦃R S : Type u⦄ (T : Type u) [CommRing R] [CommRing S] [CommRing T] [Algebra S T] (s : S)
+    [IsLocalization.Away s T] (f : R →+* S), P f → P ((algebraMap S T).comp f)) ∧
+    ∀ ⦃R : Type u⦄ (S : Type u) ⦃T : Type u⦄ [CommRing R] [CommRing S] [CommRing T] [Algebra R S]
+      (r : R) [IsLocalization.Away r S] (f : S →+* T), P f → P (f.comp (algebraMap R S))
+
 /-- A property `P` of ring homs satisfies `RingHom.OfLocalizationFiniteSpanTarget`
 if `P` holds for `R →+* S` whenever there exists a finite set `{ r }` that spans `S` such that
 `P` holds for `R →+* Sᵣ`.
@@ -130,8 +143,8 @@ each `{ r }` that spans `S`, we have `P (R →+* S) ↔ ∀ r, P (R →+* Sᵣ)`
 structure RingHom.PropertyIsLocal : Prop where
   LocalizationPreserves : RingHom.LocalizationPreserves @P
   OfLocalizationSpanTarget : RingHom.OfLocalizationSpanTarget @P
-  StableUnderComposition : RingHom.StableUnderComposition @P
-  HoldsForLocalizationAway : RingHom.HoldsForLocalizationAway @P
+  StableUnderCompositionWithLocalizationAway : RingHom.StableUnderCompositionWithLocalizationAway @P
+  ContainsIdentities : RingHom.ContainsIdentities @P
 
 theorem RingHom.ofLocalizationSpan_iff_finite :
     RingHom.OfLocalizationSpan @P ↔ RingHom.OfLocalizationFiniteSpan @P := by
@@ -168,15 +181,33 @@ theorem RingHom.HoldsForLocalizationAway.of_bijective
 
 variable {P f R' S'}
 
+lemma RingHom.StableUnderComposition.stableUnderCompositionWithLocalizationAway
+    (hPc : RingHom.StableUnderComposition P) (hPl : HoldsForLocalizationAway P) :
+    StableUnderCompositionWithLocalizationAway P := by
+  constructor
+  · introv _ hf
+    exact hPc _ _ hf (hPl T s)
+  · introv _ hf
+    exact hPc _ _ (hPl S r) hf
+
+lemma RingHom.HoldsForLocalizationAway.containsIdentities (hPl : HoldsForLocalizationAway P) :
+    ContainsIdentities P := by
+  introv R
+  exact hPl.of_bijective _ _ Function.bijective_id
+
 theorem RingHom.PropertyIsLocal.respectsIso (hP : RingHom.PropertyIsLocal @P) :
     RingHom.RespectsIso @P := by
-  apply hP.StableUnderComposition.respectsIso
-  introv
-  letI := e.toRingHom.toAlgebra
-  -- Porting note: was `apply_with hP.holds_for_localization_away { instances := ff }`
-  have : IsLocalization.Away (1 : R) S := by
-    apply IsLocalization.away_of_isUnit_of_bijective _ isUnit_one e.bijective
-  exact RingHom.PropertyIsLocal.HoldsForLocalizationAway hP S (1 : R)
+  constructor
+  · intro R S T _ _ _ f e hf
+    letI := e.toRingHom.toAlgebra
+    have : IsLocalization.Away (1 : S) T :=
+      IsLocalization.away_of_isUnit_of_bijective _ isUnit_one e.bijective
+    exact hP.StableUnderCompositionWithLocalizationAway.left T (1 : S) f hf
+  · intro R S T _ _ _ f e hf
+    letI := e.toRingHom.toAlgebra
+    have : IsLocalization.Away (1 : R) S :=
+      IsLocalization.away_of_isUnit_of_bijective _ isUnit_one e.bijective
+    exact hP.StableUnderCompositionWithLocalizationAway.right S (1 : R) f hf
 
 -- Almost all arguments are implicit since this is not intended to use mid-proof.
 theorem RingHom.LocalizationPreserves.away (H : RingHom.LocalizationPreserves @P) (r : R)
@@ -185,6 +216,14 @@ theorem RingHom.LocalizationPreserves.away (H : RingHom.LocalizationPreserves @P
   have : IsLocalization ((Submonoid.powers r).map f) S' := by rw [Submonoid.map_powers]; assumption
   exact H f (Submonoid.powers r) R' S' hf
 
+lemma RingHom.PropertyIsLocal.HoldsForLocalizationAway (hP : RingHom.PropertyIsLocal @P) :
+    RingHom.HoldsForLocalizationAway @P := by
+  introv R _
+  have : algebraMap R S = (algebraMap R S).comp (RingHom.id R) := by simp
+  rw [this]
+  apply (hP.StableUnderCompositionWithLocalizationAway).left S r
+  apply hP.ContainsIdentities
+
 theorem RingHom.PropertyIsLocal.ofLocalizationSpan (hP : RingHom.PropertyIsLocal @P) :
     RingHom.OfLocalizationSpan @P := by
   introv R hs hs'
@@ -192,9 +231,10 @@ theorem RingHom.PropertyIsLocal.ofLocalizationSpan (hP : RingHom.PropertyIsLocal
   rw [Ideal.map_span, Ideal.map_top] at hs
   apply hP.OfLocalizationSpanTarget _ _ hs
   rintro ⟨_, r, hr, rfl⟩
-  convert hP.StableUnderComposition
-    _ _ (hP.HoldsForLocalizationAway (Localization.Away r) r) (hs' ⟨r, hr⟩) using 1
-  exact (IsLocalization.map_comp _).symm
+  rw [← IsLocalization.map_comp (M := Submonoid.powers r) (S := Localization.Away r)
+    (T := Submonoid.powers (f r))]
+  apply hP.StableUnderCompositionWithLocalizationAway.right _ r
+  exact hs' ⟨r, hr⟩
 
 lemma RingHom.OfLocalizationSpanTarget.ofIsLocalization
     (hP : RingHom.OfLocalizationSpanTarget P) (hP' : RingHom.RespectsIso P)

--- a/Mathlib/RingTheory/RingHom/FinitePresentation.lean
+++ b/Mathlib/RingTheory/RingHom/FinitePresentation.lean
@@ -163,8 +163,10 @@ theorem finitePresentation_ofLocalizationSpanTarget :
 /-- Being finitely-presented is a local property of rings. -/
 theorem finitePresentation_isLocal : PropertyIsLocal @FinitePresentation :=
   ⟨finitePresentation_localizationPreserves,
-    finitePresentation_ofLocalizationSpanTarget, finitePresentation_stableUnderComposition,
-    finitePresentation_holdsForLocalizationAway⟩
+    finitePresentation_ofLocalizationSpanTarget,
+    finitePresentation_stableUnderComposition.stableUnderCompositionWithLocalizationAway
+      finitePresentation_holdsForLocalizationAway,
+    finitePresentation_holdsForLocalizationAway.containsIdentities⟩
 
 /-- Being finitely-presented respects isomorphisms. -/
 theorem finitePresentation_respectsIso : RingHom.RespectsIso @RingHom.FinitePresentation :=

--- a/Mathlib/RingTheory/RingHom/FinitePresentation.lean
+++ b/Mathlib/RingTheory/RingHom/FinitePresentation.lean
@@ -165,8 +165,7 @@ theorem finitePresentation_isLocal : PropertyIsLocal @FinitePresentation :=
   ⟨finitePresentation_localizationPreserves,
     finitePresentation_ofLocalizationSpanTarget,
     finitePresentation_stableUnderComposition.stableUnderCompositionWithLocalizationAway
-      finitePresentation_holdsForLocalizationAway,
-    finitePresentation_holdsForLocalizationAway.containsIdentities⟩
+      finitePresentation_holdsForLocalizationAway⟩
 
 /-- Being finitely-presented respects isomorphisms. -/
 theorem finitePresentation_respectsIso : RingHom.RespectsIso @RingHom.FinitePresentation :=

--- a/Mathlib/RingTheory/RingHom/FiniteType.lean
+++ b/Mathlib/RingTheory/RingHom/FiniteType.lean
@@ -90,8 +90,7 @@ theorem finiteType_ofLocalizationSpanTarget : OfLocalizationSpanTarget @FiniteTy
 theorem finiteType_is_local : PropertyIsLocal @FiniteType :=
   ⟨localization_finiteType, finiteType_ofLocalizationSpanTarget,
     finiteType_stableUnderComposition.stableUnderCompositionWithLocalizationAway
-      finiteType_holdsForLocalizationAway,
-    finiteType_holdsForLocalizationAway.containsIdentities⟩
+      finiteType_holdsForLocalizationAway⟩
 
 theorem finiteType_respectsIso : RingHom.RespectsIso @RingHom.FiniteType :=
   RingHom.finiteType_is_local.respectsIso

--- a/Mathlib/RingTheory/RingHom/FiniteType.lean
+++ b/Mathlib/RingTheory/RingHom/FiniteType.lean
@@ -88,8 +88,10 @@ theorem finiteType_ofLocalizationSpanTarget : OfLocalizationSpanTarget @FiniteTy
     · rw [ht]; trivial
 
 theorem finiteType_is_local : PropertyIsLocal @FiniteType :=
-  ⟨localization_finiteType, finiteType_ofLocalizationSpanTarget, finiteType_stableUnderComposition,
-    finiteType_holdsForLocalizationAway⟩
+  ⟨localization_finiteType, finiteType_ofLocalizationSpanTarget,
+    finiteType_stableUnderComposition.stableUnderCompositionWithLocalizationAway
+      finiteType_holdsForLocalizationAway,
+    finiteType_holdsForLocalizationAway.containsIdentities⟩
 
 theorem finiteType_respectsIso : RingHom.RespectsIso @RingHom.FiniteType :=
   RingHom.finiteType_is_local.respectsIso


### PR DESCRIPTION
Currently for a property of ring homomorphisms `P`, the predicate `RingHom.PropertyIsLocal P` requires `P` to be stable under composition. This predicate is meant to capture the requirements to guarantee that `affineLocally P` is local on the source and on the target. But for the latter it is sufficient to ask that `P` is stable under composition with localization maps away from one element. Hence we replace

`StableUnderComposition P` and `HoldsForLocalizationAway P` with `StableUnderCompositionWithLocalizationAway P`.

Before this change, every `P` satisfying `RingHom.PropertyIsLocal` was satisfied by all identities and localization maps away from one element. In particular `affineLocally P` was satisfied by all open immersions. Now this is no longer automatic, since `P` does not necessarily contain identities.

This change is necessary to apply the `HasRingHomProperty` API to the class of ring homomorphisms that are standard smooth of a fixed relative dimension `n > 0`, since these are not stable under composition (the compositions add up), but are stable under composition with localization maps.

This change turns some `instance`s into `theorem`s and hence slightly reduces automation. The fallout is relatively small.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
