### PR TITLE
[Merged by Bors] - chore: reorganize RingEquiv declarations

### DIFF
--- a/Mathlib/Algebra/Group/Equiv/Basic.lean
+++ b/Mathlib/Algebra/Group/Equiv/Basic.lean
@@ -436,6 +436,8 @@ theorem self_trans_symm (e : M ≃* N) : e.trans e.symm = refl M :=
 
 end trans
 
+section unique
+
 /-- The `MulEquiv` between two monoids with a unique element. -/
 @[to_additive "The `AddEquiv` between two `AddMonoid`s with a unique element."]
 def mulEquivOfUnique {M N} [Unique M] [Unique N] [Mul M] [Mul N] : M ≃* N :=
@@ -447,6 +449,8 @@ def mulEquivOfUnique {M N} [Unique M] [Unique N] [Mul M] [Mul N] : M ≃* N :=
 instance {M N} [Unique M] [Unique N] [Mul M] [Mul N] : Unique (M ≃* N) where
   default := mulEquivOfUnique
   uniq _ := ext fun _ => Subsingleton.elim _ _
+
+end unique
 
 end Mul
 

--- a/Mathlib/Algebra/Ring/Equiv.lean
+++ b/Mathlib/Algebra/Ring/Equiv.lean
@@ -169,8 +169,6 @@ theorem mk_coe (e : R ≃+* S) (e' h₁ h₂ h₃ h₄) : (⟨⟨e, e', h₁, h�
 theorem toEquiv_eq_coe (f : R ≃+* S) : f.toEquiv = f :=
   rfl
 
--- Porting note: `toFun_eq_coe` no longer needed in Lean4
-
 @[simp]
 theorem coe_toEquiv (f : R ≃+* S) : ⇑(f : R ≃ S) = f :=
   rfl

--- a/Mathlib/Algebra/Ring/Equiv.lean
+++ b/Mathlib/Algebra/Ring/Equiv.lean
@@ -126,6 +126,8 @@ section Basic
 
 variable [Mul R] [Mul S] [Add R] [Add S] [Mul S'] [Add S']
 
+section coe
+
 instance : EquivLike (R ≃+* S) R S where
   coe f := f.toFun
   inv f := f.invFun
@@ -141,29 +143,17 @@ instance : RingEquivClass (R ≃+* S) R S where
   map_add f := f.map_add'
   map_mul f := f.map_mul'
 
-@[simp]
-theorem toEquiv_eq_coe (f : R ≃+* S) : f.toEquiv = f :=
-  rfl
-
--- Porting note: `toFun_eq_coe` no longer needed in Lean4
-
-@[simp]
-theorem coe_toEquiv (f : R ≃+* S) : ⇑(f : R ≃ S) = f :=
-  rfl
-
-/-- A ring isomorphism preserves multiplication. -/
-protected theorem map_mul (e : R ≃+* S) (x y : R) : e (x * y) = e x * e y :=
-  map_mul e x y
-
-/-- A ring isomorphism preserves addition. -/
-protected theorem map_add (e : R ≃+* S) (x y : R) : e (x + y) = e x + e y :=
-  map_add e x y
-
 /-- Two ring isomorphisms agree if they are defined by the
     same underlying function. -/
 @[ext]
 theorem ext {f g : R ≃+* S} (h : ∀ x, f x = g x) : f = g :=
   DFunLike.ext f g h
+
+protected theorem congr_arg {f : R ≃+* S} {x x' : R} : x = x' → f x = f x' :=
+  DFunLike.congr_arg f
+
+protected theorem congr_fun {f g : R ≃+* S} (h : f = g) (x : R) : f x = g x :=
+  DFunLike.congr_fun h x
 
 @[simp]
 theorem coe_mk (e h₃ h₄) : ⇑(⟨e, h₃, h₄⟩ : R ≃+* S) = e :=
@@ -175,11 +165,15 @@ theorem coe_mk (e h₃ h₄) : ⇑(⟨e, h₃, h₄⟩ : R ≃+* S) = e :=
 theorem mk_coe (e : R ≃+* S) (e' h₁ h₂ h₃ h₄) : (⟨⟨e, e', h₁, h₂⟩, h₃, h₄⟩ : R ≃+* S) = e :=
   ext fun _ => rfl
 
-protected theorem congr_arg {f : R ≃+* S} {x x' : R} : x = x' → f x = f x' :=
-  DFunLike.congr_arg f
+@[simp]
+theorem toEquiv_eq_coe (f : R ≃+* S) : f.toEquiv = f :=
+  rfl
 
-protected theorem congr_fun {f g : R ≃+* S} (h : f = g) (x : R) : f x = g x :=
-  DFunLike.congr_fun h x
+-- Porting note: `toFun_eq_coe` no longer needed in Lean4
+
+@[simp]
+theorem coe_toEquiv (f : R ≃+* S) : ⇑(f : R ≃ S) = f :=
+  rfl
 
 @[simp]
 theorem toAddEquiv_eq_coe (f : R ≃+* S) : f.toAddEquiv = ↑f :=
@@ -197,21 +191,44 @@ theorem coe_toMulEquiv (f : R ≃+* S) : ⇑(f : R ≃* S) = f :=
 theorem coe_toAddEquiv (f : R ≃+* S) : ⇑(f : R ≃+ S) = f :=
   rfl
 
-/-- The `RingEquiv` between two semirings with a unique element. -/
-def ringEquivOfUnique {M N} [Unique M] [Unique N] [Add M] [Mul M] [Add N] [Mul N] : M ≃+* N :=
-  { AddEquiv.addEquivOfUnique, MulEquiv.mulEquivOfUnique with }
+end coe
 
-instance {M N} [Unique M] [Unique N] [Add M] [Mul M] [Add N] [Mul N] :
-    Unique (M ≃+* N) where
-  default := ringEquivOfUnique
-  uniq _ := ext fun _ => Subsingleton.elim _ _
+section map
+
+/-- A ring isomorphism preserves multiplication. -/
+protected theorem map_mul (e : R ≃+* S) (x y : R) : e (x * y) = e x * e y :=
+  map_mul e x y
+
+/-- A ring isomorphism preserves addition. -/
+protected theorem map_add (e : R ≃+* S) (x y : R) : e (x + y) = e x + e y :=
+  map_add e x y
+
+end map
+
+section bijective
+
+protected theorem bijective (e : R ≃+* S) : Function.Bijective e :=
+  EquivLike.bijective e
+
+protected theorem injective (e : R ≃+* S) : Function.Injective e :=
+  EquivLike.injective e
+
+protected theorem surjective (e : R ≃+* S) : Function.Surjective e :=
+  EquivLike.surjective e
+
+end bijective
 
 variable (R)
+
+section refl
 
 /-- The identity map is a ring isomorphism. -/
 @[refl]
 def refl : R ≃+* R :=
   { MulEquiv.refl R, AddEquiv.refl R with }
+
+instance : Inhabited (R ≃+* R) :=
+  ⟨RingEquiv.refl R⟩
 
 @[simp]
 theorem refl_apply (x : R) : RingEquiv.refl R x = x :=
@@ -225,21 +242,16 @@ theorem coe_addEquiv_refl : (RingEquiv.refl R : R ≃+ R) = AddEquiv.refl R :=
 theorem coe_mulEquiv_refl : (RingEquiv.refl R : R ≃* R) = MulEquiv.refl R :=
   rfl
 
-instance : Inhabited (R ≃+* R) :=
-  ⟨RingEquiv.refl R⟩
+end refl
 
 variable {R}
+
+section symm
 
 /-- The inverse of a ring isomorphism is a ring isomorphism. -/
 @[symm]
 protected def symm (e : R ≃+* S) : S ≃+* R :=
   { e.toMulEquiv.symm, e.toAddEquiv.symm with }
-
-/-- See Note [custom simps projection] -/
-def Simps.symm_apply (e : R ≃+* S) : S → R :=
-  e.symm
-
-initialize_simps_projections RingEquiv (toFun → apply, invFun → symm_apply)
 
 @[simp]
 theorem invFun_eq_symm (f : R ≃+* S) : EquivLike.inv f = f.symm :=
@@ -247,14 +259,6 @@ theorem invFun_eq_symm (f : R ≃+* S) : EquivLike.inv f = f.symm :=
 
 @[simp]
 theorem symm_symm (e : R ≃+* S) : e.symm.symm = e := rfl
-
-@[simp]
-theorem symm_refl : (RingEquiv.refl R).symm = RingEquiv.refl R :=
-  rfl
-
-@[simp]
-theorem coe_toEquiv_symm (e : R ≃+* S) : (e.symm : S ≃ R) = (e : R ≃ S).symm :=
-  rfl
 
 theorem symm_bijective : Function.Bijective (RingEquiv.symm : (R ≃+* S) → S ≃+* R) :=
   Function.bijective_iff_has_inverse.mpr ⟨_, symm_symm, symm_symm⟩
@@ -275,34 +279,13 @@ theorem symm_mk (f : R → S) (g h₁ h₂ h₃ h₄) :
         invFun := f } :=
   rfl
 
-/-- Transitivity of `RingEquiv`. -/
-@[trans]
-protected def trans (e₁ : R ≃+* S) (e₂ : S ≃+* S') : R ≃+* S' :=
-  { e₁.toMulEquiv.trans e₂.toMulEquiv, e₁.toAddEquiv.trans e₂.toAddEquiv with }
-
-theorem trans_apply (e₁ : R ≃+* S) (e₂ : S ≃+* S') (a : R) : e₁.trans e₂ a = e₂ (e₁ a) :=
+@[simp]
+theorem symm_refl : (RingEquiv.refl R).symm = RingEquiv.refl R :=
   rfl
 
 @[simp]
-theorem coe_trans (e₁ : R ≃+* S) (e₂ : S ≃+* S') : (e₁.trans e₂ : R → S') = e₂ ∘ e₁ :=
+theorem coe_toEquiv_symm (e : R ≃+* S) : (e.symm : S ≃ R) = (e : R ≃ S).symm :=
   rfl
-
-@[simp]
-theorem symm_trans_apply (e₁ : R ≃+* S) (e₂ : S ≃+* S') (a : S') :
-    (e₁.trans e₂).symm a = e₁.symm (e₂.symm a) :=
-  rfl
-
-theorem symm_trans (e₁ : R ≃+* S) (e₂ : S ≃+* S') : (e₁.trans e₂).symm = e₂.symm.trans e₁.symm :=
-  rfl
-
-protected theorem bijective (e : R ≃+* S) : Function.Bijective e :=
-  EquivLike.bijective e
-
-protected theorem injective (e : R ≃+* S) : Function.Injective e :=
-  EquivLike.injective e
-
-protected theorem surjective (e : R ≃+* S) : Function.Surjective e :=
-  EquivLike.surjective e
 
 @[simp]
 theorem apply_symm_apply (e : R ≃+* S) : ∀ x, e (e.symm x) = x :=
@@ -315,6 +298,40 @@ theorem symm_apply_apply (e : R ≃+* S) : ∀ x, e.symm (e x) = x :=
 theorem image_eq_preimage (e : R ≃+* S) (s : Set R) : e '' s = e.symm ⁻¹' s :=
   e.toEquiv.image_eq_preimage s
 
+end symm
+
+section simps
+
+/-- See Note [custom simps projection] -/
+def Simps.symm_apply (e : R ≃+* S) : S → R :=
+  e.symm
+
+initialize_simps_projections RingEquiv (toFun → apply, invFun → symm_apply)
+
+end simps
+
+section trans
+
+/-- Transitivity of `RingEquiv`. -/
+@[trans]
+protected def trans (e₁ : R ≃+* S) (e₂ : S ≃+* S') : R ≃+* S' :=
+  { e₁.toMulEquiv.trans e₂.toMulEquiv, e₁.toAddEquiv.trans e₂.toAddEquiv with }
+
+@[simp]
+theorem coe_trans (e₁ : R ≃+* S) (e₂ : S ≃+* S') : (e₁.trans e₂ : R → S') = e₂ ∘ e₁ :=
+  rfl
+
+theorem trans_apply (e₁ : R ≃+* S) (e₂ : S ≃+* S') (a : R) : e₁.trans e₂ a = e₂ (e₁ a) :=
+  rfl
+
+@[simp]
+theorem symm_trans_apply (e₁ : R ≃+* S) (e₂ : S ≃+* S') (a : S') :
+    (e₁.trans e₂).symm a = e₁.symm (e₂.symm a) :=
+  rfl
+
+theorem symm_trans (e₁ : R ≃+* S) (e₂ : S ≃+* S') : (e₁.trans e₂).symm = e₂.symm.trans e₁.symm :=
+  rfl
+
 @[simp]
 theorem coe_mulEquiv_trans (e₁ : R ≃+* S) (e₂ : S ≃+* S') :
     (e₁.trans e₂ : R ≃* S') = (e₁ : R ≃* S).trans ↑e₂ :=
@@ -324,6 +341,21 @@ theorem coe_mulEquiv_trans (e₁ : R ≃+* S) (e₂ : S ≃+* S') :
 theorem coe_addEquiv_trans (e₁ : R ≃+* S) (e₂ : S ≃+* S') :
     (e₁.trans e₂ : R ≃+ S') = (e₁ : R ≃+ S).trans ↑e₂ :=
   rfl
+
+end trans
+
+section unique
+
+/-- The `RingEquiv` between two semirings with a unique element. -/
+def ringEquivOfUnique {M N} [Unique M] [Unique N] [Add M] [Mul M] [Add N] [Mul N] : M ≃+* N :=
+  { AddEquiv.addEquivOfUnique, MulEquiv.mulEquivOfUnique with }
+
+instance {M N} [Unique M] [Unique N] [Add M] [Mul M] [Add N] [Mul N] :
+    Unique (M ≃+* N) where
+  default := ringEquivOfUnique
+  uniq _ := ext fun _ => Subsingleton.elim _ _
+
+end unique
 
 end Basic
 


### PR DESCRIPTION
The API for the various `*Equiv` types is inconsistent both in what results are exposed and how they are organized. Previously, in #16867, we started improving the latter, by organizing results into sections for `Mul/AddEquiv` and `AlgEquiv`, and putting the same results in the same order within those. This PR updates RingEquiv to follow the same structure.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
