### PR TITLE
[Merged by Bors] - feat(Analysis/Fourier/ZMod): DFT preserves even/odd functions

### DIFF
--- a/Mathlib/Algebra/Group/EvenFunction.lean
+++ b/Mathlib/Algebra/Group/EvenFunction.lean
@@ -5,6 +5,7 @@ Authors: David Loeffler
 -/
 import Mathlib.Algebra.Group.Action.Pi
 import Mathlib.Algebra.Module.Defs
+import Mathlib.Algebra.BigOperators.Group.Finset
 
 /-!
 # Even and odd functions
@@ -16,6 +17,8 @@ These definitions are `Function.Even` and `Function.Odd`; and they are `protecte
 conflicting with the root-level definitions `Even` and `Odd` (which, for functions, mean that the
 function takes even resp. odd _values_, a wholly different concept).
 -/
+
+open scoped BigOperators
 
 namespace Function
 
@@ -122,14 +125,28 @@ lemma Odd.mul_odd [HasDistribNeg R] (hf : f.Odd) (hg : g.Odd) : (f * g).Even := 
 
 end mul
 
+section torsionfree
+
+-- need to redeclare variables since `InvolutiveNeg α` conflicts with `Neg α`
+variable {α β : Type*} [AddCommGroup β] [NoZeroSMulDivisors ℕ β] {f : α → β}
+
 /--
 If `f` is both even and odd, and its target is a torsion-free commutative additive group,
 then `f = 0`.
 -/
-lemma zero_of_even_and_odd [AddCommGroup β] [NoZeroSMulDivisors ℕ β]
-    {f : α → β} (he : f.Even) (ho : f.Odd) :
-    f = 0 := by
+lemma zero_of_even_and_odd [Neg α] (he : f.Even) (ho : f.Odd) : f = 0 := by
   ext r
   rw [Pi.zero_apply, ← neg_eq_self ℕ, ← ho, he]
+
+/-- The sum of the values of an odd function is 0. -/
+lemma Odd.sum_eq_zero [Fintype α] [InvolutiveNeg α] {f : α → β} (hf : f.Odd) : ∑ a, f a = 0 := by
+  simpa only [neg_eq_self ℕ, Finset.sum_neg_distrib, funext hf, Equiv.neg_apply] using
+    Equiv.sum_comp (.neg α) f
+
+/-- An odd function vanishes at zero. -/
+lemma Odd.map_zero [NegZeroClass α] (hf : f.Odd) : f 0 = 0 := by
+  simp only [← neg_eq_self ℕ, ← hf 0, neg_zero]
+
+end torsionfree
 
 end Function

--- a/Mathlib/Analysis/Fourier/ZMod.lean
+++ b/Mathlib/Analysis/Fourier/ZMod.lean
@@ -3,6 +3,7 @@ Copyright (c) 2024 David Loeffler. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: David Loeffler
 -/
+import Mathlib.Algebra.Group.EvenFunction
 import Mathlib.Analysis.SpecialFunctions.Complex.CircleAddChar
 import Mathlib.Analysis.Fourier.FourierTransform
 import Mathlib.NumberTheory.DirichletCharacter.GaussSum
@@ -176,6 +177,25 @@ lemma dft_comp_unitMul (Φ : ZMod N → E) (u : (ZMod N)ˣ) (k : ZMod N) :
     𝓕 (fun j ↦ Φ (u.val * j)) k = 𝓕 Φ (u⁻¹.val * k) := by
   refine Fintype.sum_equiv u.mulLeft _ _ fun x ↦ ?_
   simp only [mul_comm u.val, u.mulLeft_apply, ← mul_assoc, u.mul_inv_cancel_right]
+
+section signs
+
+/-- The discrete Fourier transform of `Φ` is even if and only if `Φ` itself is. -/
+lemma dft_even_iff {Φ : ZMod N → ℂ} : (𝓕 Φ).Even ↔ Φ.Even := by
+  have h {f : ZMod N → ℂ} (hf : f.Even) : (𝓕 f).Even := by
+    simp only [Function.Even, ← congr_fun (dft_comp_neg f), funext hf, implies_true]
+  refine ⟨fun hΦ x ↦ ?_, h⟩
+  simpa only [neg_neg, smul_right_inj (NeZero.ne (N : ℂ)), dft_dft] using h hΦ (-x)
+
+/-- The discrete Fourier transform of `Φ` is odd if and only if `Φ` itself is. -/
+lemma dft_odd_iff {Φ : ZMod N → ℂ} : (𝓕 Φ).Odd ↔ Φ.Odd := by
+  have h {f : ZMod N → ℂ} (hf : f.Odd) : (𝓕 f).Odd := by
+    simp only [Function.Odd, ← congr_fun (dft_comp_neg f), funext hf, ← Pi.neg_apply, map_neg,
+      implies_true]
+  refine ⟨fun hΦ x ↦ ?_, h⟩
+  simpa only [neg_neg, dft_dft, ← smul_neg, smul_right_inj (NeZero.ne (N : ℂ))] using h hΦ (-x)
+
+end signs
 
 end ZMod
 


### PR DESCRIPTION
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
