### PR TITLE
feat(SetTheory/Ordinal/Arithmetic): generalize Ordinal.lt_iSup

### DIFF
--- a/Mathlib/SetTheory/Ordinal/Arithmetic.lean
+++ b/Mathlib/SetTheory/Ordinal/Arithmetic.lean
@@ -1169,7 +1169,7 @@ theorem sup_le_iff {ι : Type u} {f : ι → Ordinal.{max u v}} {a} : sup.{_, v}
   Ordinal.iSup_le_iff
 
 /-- `ciSup_le'` whenever the outputs live in a higher universe than the inputs. -/
-protected theorem iSup_le {ι : Type u} {f : ι → Ordinal.{max u v}} {a} :
+protected theorem iSup_le {ι} {f : ι → Ordinal.{u}} {a} :
     (∀ i, f i ≤ a) → iSup f ≤ a :=
   ciSup_le'
 

--- a/Mathlib/SetTheory/Ordinal/Arithmetic.lean
+++ b/Mathlib/SetTheory/Ordinal/Arithmetic.lean
@@ -1150,8 +1150,8 @@ theorem bddAbove_iff_small {s : Set Ordinal.{u}} : BddAbove s ↔ Small.{u} s :=
     bddAbove_of_small _⟩
 
 /-- `le_ciSup` whenever the outputs live in a higher universe than the inputs. -/
-protected theorem le_iSup {ι : Type u} (f : ι → Ordinal.{max u v}) : ∀ i, f i ≤ iSup f :=
-  le_ciSup (bddAbove_range f)
+protected theorem le_iSup {ι} (f : ι → Ordinal.{u}) [Small.{u} ι] : ∀ i, f i ≤ iSup f :=
+  le_ciSup (bddAbove_of_small _)
 
 set_option linter.deprecated false in
 @[deprecated Ordinal.le_iSup (since := "2024-08-27")]
@@ -1161,7 +1161,7 @@ theorem le_sup {ι : Type u} (f : ι → Ordinal.{max u v}) : ∀ i, f i ≤ sup
 /-- `ciSup_le_iff'` whenever the outputs live in a higher universe than the inputs. -/
 protected theorem iSup_le_iff {ι} {f : ι → Ordinal.{u}} {a : Ordinal.{u}} [Small.{u} ι] :
     iSup f ≤ a ↔ ∀ i, f i ≤ a :=
-  ciSup_le_iff' (bddAbove_iff_small.mpr (small_range f))
+  ciSup_le_iff' (bddAbove_of_small _)
 
 set_option linter.deprecated false in
 @[deprecated Ordinal.iSup_le_iff (since := "2024-08-27")]
@@ -1289,8 +1289,8 @@ theorem iSup_sum {α : Type u} {β : Type v} (f : α ⊕ β → Ordinal.{max u v
     iSup f = max (⨆ a, f (Sum.inl a)) (⨆ b, f (Sum.inr b)) := by
   apply (Ordinal.iSup_le _).antisymm (max_le _ _)
   · rintro (i | i)
-    · exact le_max_of_le_left (Ordinal.le_iSup.{u, max u v w} _ i)
-    · exact le_max_of_le_right (Ordinal.le_iSup.{v, max u v w} _ i)
+    · exact le_max_of_le_left (Ordinal.le_iSup (fun x ↦ f (Sum.inl x)) i)
+    · exact le_max_of_le_right (Ordinal.le_iSup (fun x ↦ f (Sum.inr x)) i)
   all_goals
     apply csSup_le_csSup' (bddAbove_range _)
     rintro i ⟨a, rfl⟩

--- a/Mathlib/SetTheory/Ordinal/Arithmetic.lean
+++ b/Mathlib/SetTheory/Ordinal/Arithmetic.lean
@@ -1179,7 +1179,7 @@ theorem sup_le {ι : Type u} {f : ι → Ordinal.{max u v}} {a} : (∀ i, f i �
   Ordinal.iSup_le
 
 -- TODO: generalize to conditionally complete linear orders.
-theorem lt_iSup {ι} {f : ι → Ordinal.{u}} {a : Ordinal.{u}} [Small.{u} ι] :
+protected theorem lt_iSup {ι} {f : ι → Ordinal.{u}} {a : Ordinal.{u}} [Small.{u} ι] :
     a < iSup f ↔ ∃ i, a < f i := by
   rw [← not_iff_not]
   simpa using Ordinal.iSup_le_iff

--- a/Mathlib/SetTheory/Ordinal/Arithmetic.lean
+++ b/Mathlib/SetTheory/Ordinal/Arithmetic.lean
@@ -1159,7 +1159,7 @@ theorem le_sup {ι : Type u} (f : ι → Ordinal.{max u v}) : ∀ i, f i ≤ sup
   Ordinal.le_iSup f i
 
 /-- `ciSup_le_iff'` whenever the outputs live in a higher universe than the inputs. -/
-theorem iSup_le_iff {ι} {f : ι → Ordinal.{u}} {a : Ordinal.{u}} [Small.{u} ι] :
+protected theorem iSup_le_iff {ι} {f : ι → Ordinal.{u}} {a : Ordinal.{u}} [Small.{u} ι] :
     iSup f ≤ a ↔ ∀ i, f i ≤ a :=
   ciSup_le_iff' (bddAbove_iff_small.mpr (small_range f))
 

--- a/Mathlib/SetTheory/Ordinal/Exponential.lean
+++ b/Mathlib/SetTheory/Ordinal/Exponential.lean
@@ -406,8 +406,8 @@ theorem iSup_pow {o : Ordinal} (ho : 0 < o) : ⨆ n : ℕ, o ^ n = o ^ ω := by
   · exact (opow_isNormal ho₁).apply_omega
   · rw [one_opow]
     refine le_antisymm (Ordinal.iSup_le fun n => by rw [one_opow]) ?_
-    convert Ordinal.le_iSup _ 0
-    rw [Nat.cast_zero, opow_zero]
+    convert Ordinal.le_iSup (fun n ↦ (1 : Ordinal.{u_1}) ^ n) 0
+    exact opow_natCast 1 _
 
 set_option linter.deprecated false in
 @[deprecated iSup_pow (since := "2024-08-27")]

--- a/Mathlib/SetTheory/Ordinal/FixedPoint.lean
+++ b/Mathlib/SetTheory/Ordinal/FixedPoint.lean
@@ -61,7 +61,8 @@ theorem foldr_le_nfpFamily (f : ι → Ordinal → Ordinal)
   Ordinal.le_iSup _ _
 
 theorem le_nfpFamily (f : ι → Ordinal → Ordinal) (a) : a ≤ nfpFamily f a :=
-  Ordinal.le_iSup _ []
+  Ordinal.le_iSup (fun _ ↦ List.foldr _ a _) []
+
 
 theorem lt_nfpFamily {a b} : a < nfpFamily.{u, v} f b ↔ ∃ l, a < List.foldr f b l :=
   Ordinal.lt_iSup
@@ -243,7 +244,7 @@ theorem foldr_le_nfpBFamily {o : Ordinal}
 
 theorem le_nfpBFamily {o : Ordinal} (f : ∀ b < o, Ordinal → Ordinal) (a) :
     a ≤ nfpBFamily.{u, v} o f a :=
-  Ordinal.le_iSup _ []
+  Ordinal.le_iSup (fun _ ↦ List.foldr _ a _) []
 
 theorem lt_nfpBFamily {a b} :
     a < nfpBFamily.{u, v} o f b ↔ ∃ l, a < List.foldr (familyOfBFamily o f) b l :=
@@ -399,7 +400,7 @@ theorem sup_iterate_eq_nfp (f : Ordinal.{u} → Ordinal.{u}) (a : Ordinal.{u}) :
 
 theorem iterate_le_nfp (f a n) : f^[n] a ≤ nfp f a := by
   rw [← iSup_iterate_eq_nfp]
-  exact Ordinal.le_iSup _ n
+  exact Ordinal.le_iSup (fun n ↦ f^[n] a) n
 
 theorem le_nfp (f a) : a ≤ nfp f a :=
   iterate_le_nfp f a 0

--- a/Mathlib/SetTheory/Ordinal/FixedPoint.lean
+++ b/Mathlib/SetTheory/Ordinal/FixedPoint.lean
@@ -5,6 +5,7 @@ Authors: Violeta Hernández Palacios, Mario Carneiro
 -/
 import Mathlib.SetTheory.Ordinal.Arithmetic
 import Mathlib.SetTheory.Ordinal.Exponential
+import Mathlib.Logic.UnivLE
 
 /-!
 # Fixed points of normal functions

--- a/Mathlib/SetTheory/Ordinal/FixedPoint.lean
+++ b/Mathlib/SetTheory/Ordinal/FixedPoint.lean
@@ -256,7 +256,7 @@ theorem nfpBFamily_le_iff {o : Ordinal} {f : ∀ b < o, Ordinal → Ordinal} {a 
 
 theorem nfpBFamily_le {o : Ordinal} {f : ∀ b < o, Ordinal → Ordinal} {a b} :
     (∀ l, List.foldr (familyOfBFamily o f) a l ≤ b) → nfpBFamily.{u, v} o f a ≤ b :=
-  Ordinal.iSup_le.{u, v}
+  Ordinal.iSup_le
 
 theorem nfpBFamily_monotone (hf : ∀ i hi, Monotone (f i hi)) : Monotone (nfpBFamily.{u, v} o f) :=
   nfpFamily_monotone fun _ => hf _ _

--- a/Mathlib/SetTheory/ZFC/Rank.lean
+++ b/Mathlib/SetTheory/ZFC/Rank.lean
@@ -114,7 +114,7 @@ theorem rank_eq_wfRank : lift.{u + 1, u} (rank x) = mem_wf.rank x := by
   induction' x using mem_wf.induction with x ih
   rw [mem_wf.rank_eq]
   simp_rw [← fun y : { y // y ∈ x } => ih y y.2]
-  apply (le_of_forall_lt _).antisymm (Ordinal.iSup_le.{u + 1, u} _) <;> intro h
+  apply (le_of_forall_lt _).antisymm (Ordinal.iSup_le _) <;> intro h
   · rw [lt_lift_iff]
     rintro ⟨o, rfl, h⟩
     simpa [Ordinal.lt_iSup] using lt_rank_iff.1 h
@@ -200,7 +200,7 @@ theorem rank_eq_wfRank : lift.{u + 1, u} (rank x) = mem_wf.rank x := by
   induction' x using inductionOn with x ih
   rw [mem_wf.rank_eq]
   simp_rw [← fun y : { y // y ∈ x } => ih y y.2]
-  apply (le_of_forall_lt _).antisymm (Ordinal.iSup_le.{u + 1, u} _) <;> intro h
+  apply (le_of_forall_lt _).antisymm (Ordinal.iSup_le _) <;> intro h
   · rw [lt_lift_iff]
     rintro ⟨o, rfl, h⟩
     simpa [Ordinal.lt_iSup] using lt_rank_iff.1 h

--- a/Mathlib/SetTheory/ZFC/Rank.lean
+++ b/Mathlib/SetTheory/ZFC/Rank.lean
@@ -117,7 +117,7 @@ theorem rank_eq_wfRank : lift.{u + 1, u} (rank x) = mem_wf.rank x := by
   apply (le_of_forall_lt _).antisymm (Ordinal.iSup_le.{u + 1, u} _) <;> intro h
   · rw [lt_lift_iff]
     rintro ⟨o, rfl, h⟩
-    simpa [Ordinal.lt_iSup.{u + 1, u}] using lt_rank_iff.1 h
+    simpa [Ordinal.lt_iSup] using lt_rank_iff.1 h
   · simpa using rank_lt_of_mem h.2
 
 end PSet
@@ -203,7 +203,7 @@ theorem rank_eq_wfRank : lift.{u + 1, u} (rank x) = mem_wf.rank x := by
   apply (le_of_forall_lt _).antisymm (Ordinal.iSup_le.{u + 1, u} _) <;> intro h
   · rw [lt_lift_iff]
     rintro ⟨o, rfl, h⟩
-    simpa [Ordinal.lt_iSup.{u + 1, u}] using lt_rank_iff.1 h
+    simpa [Ordinal.lt_iSup] using lt_rank_iff.1 h
   · simpa using rank_lt_of_mem h.2
 
 end ZFSet


### PR DESCRIPTION
Generalize the universes of `Ordinal.lt_iSup`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

`Logic.UnivLE` contains the `Small.{max u v, u}` instance, so it needs to be imported in Ordinal/FixedPoint.

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
