### PR TITLE
[Merged by Bors] - refactor(SetTheory/Ordinal/Arithmetic): change `mk_initialSeg` to work with `Set.Iio`

### DIFF
--- a/Mathlib/SetTheory/Ordinal/Arithmetic.lean
+++ b/Mathlib/SetTheory/Ordinal/Arithmetic.lean
@@ -332,21 +332,22 @@ theorem bounded_singleton {r : α → α → Prop} [IsWellOrder α r] (hr : (typ
   rw [@enum_lt_enum _ r, Subtype.mk_lt_mk]
   apply lt_succ
 
-theorem type_Iio_ordinal (o : Ordinal.{u}) :
-    type (@Subrel Ordinal (· < ·) (Iio o)) = Ordinal.lift.{u + 1} o := by
+theorem typein_ordinal (o : Ordinal.{u}) :
+    @typein Ordinal (· < ·) _ o = Ordinal.lift.{u + 1} o := by
   refine Quotient.inductionOn o ?_
   rintro ⟨α, r, wo⟩; apply Quotient.sound
   constructor; refine ((RelIso.preimage Equiv.ulift r).trans (enum r).symm).symm
 
 -- Porting note: `· < ·` requires a type ascription for an `IsWellOrder` instance.
-@[deprecated type_Iio_ordinal (since := "2024-09-19")]
+@[deprecated typein_ordinal (since := "2024-09-19")]
 theorem type_subrel_lt (o : Ordinal.{u}) :
     type (@Subrel Ordinal (· < ·) { o' : Ordinal | o' < o }) = Ordinal.lift.{u + 1} o :=
-  type_Iio_ordinal o
+  typein_ordinal o
 
 theorem mk_Iio_ordinal (o : Ordinal.{u}) :
     #(Iio o) = Cardinal.lift.{u + 1} o.card := by
-  rw [lift_card, ← type_Iio_ordinal, card_type]
+  rw [lift_card, ← typein_ordinal]
+  rfl
 
 @[deprecated mk_Iio_ordinal (since := "2024-09-19")]
 theorem mk_initialSeg (o : Ordinal.{u}) :

--- a/Mathlib/SetTheory/Ordinal/Arithmetic.lean
+++ b/Mathlib/SetTheory/Ordinal/Arithmetic.lean
@@ -339,9 +339,10 @@ theorem type_subrel_lt (o : Ordinal.{u}) :
   rintro ⟨α, r, wo⟩; apply Quotient.sound
   constructor; refine ((RelIso.preimage Equiv.ulift r).trans (enum r).symm).symm
 
-theorem mk_initialSeg (o : Ordinal.{u}) :
-    #{ o' : Ordinal | o' < o } = Cardinal.lift.{u + 1} o.card := by
+theorem mk_Iio_ordinal (o : Ordinal.{u}) :
+    #(Iio o) = Cardinal.lift.{u + 1} o.card := by
   rw [lift_card, ← type_subrel_lt, card_type]
+  rfl
 
 /-! ### Normal ordinal functions -/
 

--- a/Mathlib/SetTheory/Ordinal/Arithmetic.lean
+++ b/Mathlib/SetTheory/Ordinal/Arithmetic.lean
@@ -345,7 +345,9 @@ theorem mk_Iio_ordinal (o : Ordinal.{u}) :
   rfl
 
 @[deprecated mk_Iio_ordinal (since := "2024-09-18")]
-alias mk_initialSeg := mk_Iio_ordinal
+theorem mk_initialSeg (o : Ordinal.{u}) :
+    #{ o' : Ordinal | o' < o } = Cardinal.lift.{u + 1} o.card := mk_Iio_ordinal o
+
 
 /-! ### Normal ordinal functions -/
 

--- a/Mathlib/SetTheory/Ordinal/Arithmetic.lean
+++ b/Mathlib/SetTheory/Ordinal/Arithmetic.lean
@@ -344,6 +344,9 @@ theorem mk_Iio_ordinal (o : Ordinal.{u}) :
   rw [lift_card, ← type_subrel_lt, card_type]
   rfl
 
+@[deprecated mk_Iio_ordinal (since := "2024-09-18")]
+alias mk_initialSeg := mk_Iio_ordinal
+
 /-! ### Normal ordinal functions -/
 
 

--- a/Mathlib/SetTheory/Ordinal/Arithmetic.lean
+++ b/Mathlib/SetTheory/Ordinal/Arithmetic.lean
@@ -332,19 +332,23 @@ theorem bounded_singleton {r : α → α → Prop} [IsWellOrder α r] (hr : (typ
   rw [@enum_lt_enum _ r, Subtype.mk_lt_mk]
   apply lt_succ
 
--- Porting note: `· < ·` requires a type ascription for an `IsWellOrder` instance.
-theorem type_subrel_lt (o : Ordinal.{u}) :
-    type (@Subrel Ordinal (· < ·) { o' : Ordinal | o' < o }) = Ordinal.lift.{u + 1} o := by
+theorem type_Iio_ordinal (o : Ordinal.{u}) :
+    type (@Subrel Ordinal (· < ·) (Iio o)) = Ordinal.lift.{u + 1} o := by
   refine Quotient.inductionOn o ?_
   rintro ⟨α, r, wo⟩; apply Quotient.sound
   constructor; refine ((RelIso.preimage Equiv.ulift r).trans (enum r).symm).symm
 
+-- Porting note: `· < ·` requires a type ascription for an `IsWellOrder` instance.
+@[deprecated type_Iio_ordinal (since := "2024-09-19")]
+theorem type_subrel_lt (o : Ordinal.{u}) :
+    type (@Subrel Ordinal (· < ·) { o' : Ordinal | o' < o }) = Ordinal.lift.{u + 1} o :=
+  type_Iio_ordinal o
+
 theorem mk_Iio_ordinal (o : Ordinal.{u}) :
     #(Iio o) = Cardinal.lift.{u + 1} o.card := by
-  rw [lift_card, ← type_subrel_lt, card_type]
-  rfl
+  rw [lift_card, ← type_Iio_ordinal, card_type]
 
-@[deprecated mk_Iio_ordinal (since := "2024-09-18")]
+@[deprecated mk_Iio_ordinal (since := "2024-09-19")]
 theorem mk_initialSeg (o : Ordinal.{u}) :
     #{ o' : Ordinal | o' < o } = Cardinal.lift.{u + 1} o.card := mk_Iio_ordinal o
 

--- a/Mathlib/SetTheory/Ordinal/Arithmetic.lean
+++ b/Mathlib/SetTheory/Ordinal/Arithmetic.lean
@@ -332,6 +332,7 @@ theorem bounded_singleton {r : α → α → Prop} [IsWellOrder α r] (hr : (typ
   rw [@enum_lt_enum _ r, Subtype.mk_lt_mk]
   apply lt_succ
 
+@[simp]
 theorem typein_ordinal (o : Ordinal.{u}) :
     @typein Ordinal (· < ·) _ o = Ordinal.lift.{u + 1} o := by
   refine Quotient.inductionOn o ?_

--- a/Mathlib/SetTheory/Ordinal/FixedPointApproximants.lean
+++ b/Mathlib/SetTheory/Ordinal/FixedPointApproximants.lean
@@ -50,7 +50,7 @@ theorem not_injective_limitation_set : ¬ InjOn g (Iio (ord <| succ #α)) := by
   have h := lift_mk_le_lift_mk_of_injective <| injOn_iff_injective.1 h_inj
   have mk_initialSeg_subtype :
       #(Iio (ord <| succ #α)) = lift.{u + 1} (succ #α) := by
-    simpa only [coe_setOf, card_typein, card_ord] using mk_initialSeg (ord <| succ #α)
+    simpa only [coe_setOf, card_typein, card_ord] using mk_Iio_ordinal (ord <| succ #α)
   rw [mk_initialSeg_subtype, lift_lift, lift_le] at h
   exact not_le_of_lt (Order.lt_succ #α) h
 


### PR DESCRIPTION
change `mk_initialSeg` to work with `Set.Iio` and rename it `mk_Iio_ordinal`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
