### PR TITLE
feat(SetTheory/Cardinal/Cofinality): lemmas about limit ordinals and cofinality

### DIFF
--- a/Mathlib/SetTheory/Cardinal/Cofinality.lean
+++ b/Mathlib/SetTheory/Cardinal/Cofinality.lean
@@ -1212,6 +1212,18 @@ lemma sup_sequence_lt_omega1 {α} [Countable α] (o : α → Ordinal) (ho : ∀ 
   rw [Cardinal.isRegular_aleph_one.cof_eq]
   exact lt_of_le_of_lt mk_le_aleph0 aleph0_lt_aleph_one
 
+theorem isLimit_of_not_isRegular_aleph {o : Ordinal} (h : ¬((aleph o).IsRegular)) :
+    o.IsLimit := by
+  have ho : o ≠ 0 := fun h0 ↦ False.elim <| (aleph_zero ▸ h0 ▸ h) isRegular_aleph0
+  contrapose! h
+  obtain ⟨p, rfl⟩ := ((zero_or_succ_or_limit o).resolve_left ho).resolve_right h
+  exact isRegular_aleph_succ p
+
+theorem ord_cof_pos_of_isLimit {o : Ordinal} (h : IsLimit o) : 0 < o.cof.ord :=
+  Ordinal.pos_iff_ne_zero.mpr fun ho ↦ by
+    rw [ord_eq_zero, cof_eq_zero] at ho
+    exact h.pos.ne.symm ho
+
 end Ordinal
 
 end Omega1

--- a/Mathlib/SetTheory/Cardinal/Cofinality.lean
+++ b/Mathlib/SetTheory/Cardinal/Cofinality.lean
@@ -1225,9 +1225,11 @@ theorem isLimit_of_not_isRegular_aleph {o : Ordinal} (h : ¬((aleph o).IsRegular
   obtain ⟨p, rfl⟩ := ((zero_or_succ_or_limit o).resolve_left ho).resolve_right h
   exact isRegular_aleph_succ p
 
-theorem ord_cof_pos_of_isLimit {o : Ordinal} (h : IsLimit o) : 0 < o.cof.ord :=
-  Ordinal.pos_iff_ne_zero.mpr fun ho ↦ by
-    rw [ord_eq_zero, cof_eq_zero] at ho
-    exact h.pos.ne.symm ho
+theorem ord_cof_pos {o : Ordinal} : 0 < o.cof.ord ↔ 0 < o := by
+  constructor
+  · exact fun h ↦ Ordinal.pos_iff_ne_zero.mpr fun h' ↦ (h' ▸ cof_zero ▸ ord_zero ▸ h).ne rfl
+  · exact fun h ↦ Ordinal.pos_iff_ne_zero.mpr fun h' ↦ by
+      rw [ord_eq_zero, cof_eq_zero] at h'
+      exact h.ne h'.symm
 
 end Ordinal

--- a/Mathlib/SetTheory/Cardinal/Cofinality.lean
+++ b/Mathlib/SetTheory/Cardinal/Cofinality.lean
@@ -1212,6 +1212,12 @@ lemma sup_sequence_lt_omega1 {α} [Countable α] (o : α → Ordinal) (ho : ∀ 
   rw [Cardinal.isRegular_aleph_one.cof_eq]
   exact lt_of_le_of_lt mk_le_aleph0 aleph0_lt_aleph_one
 
+end Ordinal
+
+end Omega1
+
+namespace Ordinal
+
 theorem isLimit_of_not_isRegular_aleph {o : Ordinal} (h : ¬((aleph o).IsRegular)) :
     o.IsLimit := by
   have ho : o ≠ 0 := fun h0 ↦ False.elim <| (aleph_zero ▸ h0 ▸ h) isRegular_aleph0
@@ -1225,5 +1231,3 @@ theorem ord_cof_pos_of_isLimit {o : Ordinal} (h : IsLimit o) : 0 < o.cof.ord :=
     exact h.pos.ne.symm ho
 
 end Ordinal
-
-end Omega1


### PR DESCRIPTION
Prove that a singular cardinal has a limit aleph index and that a limit ordinal and positive cofinality.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
