### PR TITLE
[Merged by Bors] - feat: order properties of `Finset.expect`

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -546,6 +546,7 @@ import Mathlib.Algebra.Order.Antidiag.Prod
 import Mathlib.Algebra.Order.Archimedean.Basic
 import Mathlib.Algebra.Order.Archimedean.Hom
 import Mathlib.Algebra.Order.Archimedean.Submonoid
+import Mathlib.Algebra.Order.BigOperators.Expect
 import Mathlib.Algebra.Order.BigOperators.Group.Finset
 import Mathlib.Algebra.Order.BigOperators.Group.List
 import Mathlib.Algebra.Order.BigOperators.Group.Multiset

--- a/Mathlib/Algebra/BigOperators/Expect.lean
+++ b/Mathlib/Algebra/BigOperators/Expect.lean
@@ -5,8 +5,11 @@ Authors: Yaël Dillies, Bhavik Mehta
 -/
 import Mathlib.Algebra.Algebra.Rat
 import Mathlib.Algebra.BigOperators.GroupWithZero.Action
+import Mathlib.Algebra.BigOperators.Pi
 import Mathlib.Algebra.BigOperators.Ring
 import Mathlib.Algebra.Group.Pointwise.Finset.Basic
+import Mathlib.Algebra.Module.Pi
+import Mathlib.Data.Finset.Density
 import Mathlib.Data.Fintype.BigOperators
 
 /-!
@@ -37,7 +40,7 @@ combination operator.
 ## TODO
 
 * Connect `Finset.expect` with the expectation over `s` in the probability theory sense.
-* Give a formulation of Jensen's inequality and the Cauchy-Schwarz inequality in this language.
+* Give a formulation of Jensen's inequality in this language.
 -/
 
 open Finset Function
@@ -98,7 +101,7 @@ to show the domain type when the expect is over `Finset.univ`. -/
         `(bigOpBinder| $(.mk i):ident)
     `(𝔼 $binder:bigOpBinder, $body)
   else
-    let ss ← withNaryArg 3 <| delab
+    let ss ← withNaryArg 4 <| delab
     `(𝔼 $(.mk i):ident ∈ $ss, $body)
 
 end BigOperators
@@ -158,6 +161,12 @@ lemma expect_ite_zero (s : Finset ι) (p : ι → Prop) [DecidablePred p]
 
 section DecidableEq
 variable [DecidableEq ι]
+
+lemma expect_ite_mem (s t : Finset ι) (f : ι → M) :
+    𝔼 i ∈ s, (if i ∈ t then f i else 0) = ((s ∩ t).card / s.card : ℚ≥0) • 𝔼 i ∈ s ∩ t, f i := by
+  obtain hst | hst := (s ∩ t).eq_empty_or_nonempty
+  · simp [expect, hst]
+  · simp [expect, smul_smul, ← inv_mul_eq_div, hst.card_ne_zero]
 
 @[simp] lemma expect_dite_eq (i : ι) (f : ∀ j, i = j → M) :
     𝔼 j ∈ s, (if h : i = j then f j h else 0) = if i ∈ s then f i rfl /ℚ s.card else 0 := by
@@ -358,6 +367,11 @@ lemma expect_div (s : Finset ι) (f : ι → M) (a : M) : (𝔼 i ∈ s, f i) / 
   simp_rw [div_eq_mul_inv, expect_mul]
 
 end Semifield
+
+@[simp] lemma expect_apply {α : Type*} {π : α → Type*} [∀ a, CommSemiring (π a)]
+    [∀ a, Module ℚ≥0 (π a)] (s : Finset ι) (f : ι → ∀ a, π a) (a : α) :
+    (𝔼 i ∈ s, f i) a = 𝔼 i ∈ s, f i a := by simp [expect]
+
 end Finset
 
 namespace algebraMap
@@ -399,6 +413,10 @@ lemma expect_ite_zero (p : ι → Prop) [DecidablePred p] (h : ∀ i j, p i → 
 
 variable [DecidableEq ι]
 
+@[simp] lemma expect_ite_mem (s : Finset ι) (f : ι → M) :
+    𝔼 i, (if i ∈ s then f i else 0) = s.dens • 𝔼 i ∈ s, f i := by
+  simp [Finset.expect_ite_mem, dens]
+
 lemma expect_dite_eq (i : ι) (f : ∀ j, i = j → M) :
     𝔼 j, (if h : i = j then f j h else 0) = f i rfl /ℚ card ι := by simp [card_univ]
 
@@ -417,6 +435,10 @@ section Semiring
 variable [Semiring M] [Module ℚ≥0 M]
 
 lemma expect_one [Nonempty ι] : 𝔼 _i : ι, (1 : M) = 1 := expect_const _
+
+lemma expect_mul_expect [IsScalarTower ℚ≥0 M M] [SMulCommClass ℚ≥0 M M] (f : ι → M)
+    (g : κ → M) : (𝔼 i, f i) * 𝔼 j, g j = 𝔼 i, 𝔼 j, f i * g j :=
+  Finset.expect_mul_expect ..
 
 end Semiring
 end Fintype

--- a/Mathlib/Algebra/Order/BigOperators/Expect.lean
+++ b/Mathlib/Algebra/Order/BigOperators/Expect.lean
@@ -119,10 +119,10 @@ section LinearOrderedAddCommMonoid
 variable [LinearOrderedAddCommMonoid α] [Module ℚ≥0 α] [PosSMulMono ℚ≥0 α] {s : Finset ι}
   {f : ι → α} {a : α}
 
-lemma lt_of_lt_expect (hs : s.Nonempty) (h : a < 𝔼 i ∈ s, f i) : ∃ x ∈ s, a < f x := by
+lemma exists_lt_of_lt_expect (hs : s.Nonempty) (h : a < 𝔼 i ∈ s, f i) : ∃ x ∈ s, a < f x := by
   contrapose! h; exact expect_le hs h
 
-lemma lt_of_expect_lt (hs : s.Nonempty) (h : 𝔼 i ∈ s, f i < a) : ∃ x ∈ s, f x < a := by
+lemma exists_lt_of_expect_lt (hs : s.Nonempty) (h : 𝔼 i ∈ s, f i < a) : ∃ x ∈ s, f x < a := by
   contrapose! h; exact le_expect hs h
 
 end LinearOrderedAddCommMonoid

--- a/Mathlib/Algebra/Order/BigOperators/Expect.lean
+++ b/Mathlib/Algebra/Order/BigOperators/Expect.lean
@@ -1,0 +1,217 @@
+/-
+Copyright (c) 2024 Yaël Dillies. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Yaël Dillies
+-/
+import Mathlib.Algebra.BigOperators.Expect
+import Mathlib.Algebra.Module.Rat
+import Mathlib.Algebra.Order.BigOperators.Ring.Finset
+import Mathlib.Algebra.Order.Module.Rat
+
+/-!
+# Order properties of the average over a finset
+-/
+
+open Function
+open Fintype (card)
+open scoped BigOperators Pointwise NNRat
+
+variable {ι κ α β R : Type*}
+
+local notation a " /ℚ " q => (q : ℚ≥0)⁻¹ • a
+
+namespace Finset
+section OrderedAddCommMonoid
+variable [OrderedAddCommMonoid α] [Module ℚ≥0 α] [OrderedAddCommMonoid β] [Module ℚ≥0 β]
+  {s : Finset ι} {f g : ι → α}
+
+lemma expect_eq_zero_iff_of_nonneg (hs : s.Nonempty) (hf : ∀ i ∈ s, 0 ≤ f i) :
+    𝔼 i ∈ s, f i = 0 ↔ ∀ i ∈ s, f i = 0 := by
+  simp [expect, sum_eq_zero_iff_of_nonneg hf, hs.ne_empty]
+
+lemma expect_eq_zero_iff_of_nonpos (hs : s.Nonempty) (hf : ∀ i ∈ s, f i ≤ 0) :
+    𝔼 i ∈ s, f i = 0 ↔ ∀ i ∈ s, f i = 0 := by
+  simp [expect, sum_eq_zero_iff_of_nonpos hf, hs.ne_empty]
+
+section PosSMulMono
+variable [PosSMulMono ℚ≥0 α] {a : α}
+
+lemma expect_le_expect (hfg : ∀ i ∈ s, f i ≤ g i) : 𝔼 i ∈ s, f i ≤ 𝔼 i ∈ s, g i :=
+  smul_le_smul_of_nonneg_left (sum_le_sum hfg) <| by positivity
+
+/-- This is a (beta-reduced) version of the standard lemma `Finset.expect_le_expect`,
+convenient for the `gcongr` tactic. -/
+@[gcongr]
+lemma _root_.GCongr.expect_le_expect (h : ∀ i ∈ s, f i ≤ g i) : s.expect f ≤ s.expect g :=
+  Finset.expect_le_expect h
+
+lemma expect_le (hs : s.Nonempty) (h : ∀ x ∈ s, f x ≤ a) : 𝔼 i ∈ s, f i ≤ a :=
+  (inv_smul_le_iff_of_pos <| mod_cast hs.card_pos).2 <| by
+    rw [Nat.cast_smul_eq_nsmul]; exact sum_le_card_nsmul _ _ _ h
+
+lemma le_expect (hs : s.Nonempty) (h : ∀ x ∈ s, a ≤ f x) : a ≤ 𝔼 i ∈ s, f i :=
+  (le_inv_smul_iff_of_pos <| mod_cast hs.card_pos).2 <| by
+    rw [Nat.cast_smul_eq_nsmul]; exact card_nsmul_le_sum _ _ _ h
+
+lemma expect_nonneg (hf : ∀ i ∈ s, 0 ≤ f i) : 0 ≤ 𝔼 i ∈ s, f i :=
+  smul_nonneg (by positivity) <| sum_nonneg hf
+
+end PosSMulMono
+
+section PosSMulMono
+variable {M N : Type*} [AddCommMonoid M] [Module ℚ≥0 M] [OrderedAddCommMonoid N] [Module ℚ≥0 N]
+  [PosSMulMono ℚ≥0 N] {m : M → N} {p : M → Prop} {f : ι → M} {s : Finset ι}
+
+/-- Let `{a | p a}` be an additive subsemigroup of an additive commutative monoid `M`. If `m` is a
+subadditive function (`m (a + b) ≤ m a + m b`) preserved under division by a natural, `f` is a
+function valued in that subsemigroup and `s` is a nonempty set, then
+`m (𝔼 i ∈ s, f i) ≤ 𝔼 i ∈ s, m (f i)`. -/
+lemma le_expect_nonempty_of_subadditive_on_pred (h_add : ∀ a b, p a → p b → m (a + b) ≤ m a + m b)
+    (hp_add : ∀ a b, p a → p b → p (a + b)) (h_div : ∀ (n : ℕ) a, p a → m (a /ℚ n) = m a /ℚ n)
+    (hs_nonempty : s.Nonempty) (hs : ∀ i ∈ s, p (f i)) :
+    m (𝔼 i ∈ s, f i) ≤ 𝔼 i ∈ s, m (f i) := by
+  simp only [expect, h_div _ _ (sum_induction_nonempty _ _ hp_add hs_nonempty hs)]
+  exact smul_le_smul_of_nonneg_left
+    (le_sum_nonempty_of_subadditive_on_pred _ _ h_add hp_add _ _ hs_nonempty hs) <| by positivity
+
+/-- If `m : M → N` is a subadditive function (`m (a + b) ≤ m a + m b`) and `s` is a nonempty set,
+then `m (𝔼 i ∈ s, f i) ≤ 𝔼 i ∈ s, m (f i)`. -/
+lemma le_expect_nonempty_of_subadditive (m : M → N) (h_mul : ∀ a b, m (a + b) ≤ m a + m b)
+    (h_div : ∀ (n : ℕ) a, m (a /ℚ n) = m a /ℚ n) (hs : s.Nonempty) :
+    m (𝔼 i ∈ s, f i) ≤ 𝔼 i ∈ s, m (f i) :=
+  le_expect_nonempty_of_subadditive_on_pred (p := fun _ ↦ True) (by simpa) (by simp) (by simpa) hs
+    (by simp)
+
+/-- Let `{a | p a}` be a subsemigroup of a commutative monoid `M`. If `m` is a subadditive function
+(`m (x + y) ≤ m x + m y`, `m 0 = 0`) preserved under division by a natural and `f` is a function
+valued in that subsemigroup, then `m (𝔼 i ∈ s, f i) ≤ 𝔼 i ∈ s, m (f i)`. -/
+lemma le_expect_of_subadditive_on_pred (h_zero : m 0 = 0)
+    (h_add : ∀ a b, p a → p b → m (a + b) ≤ m a + m b) (hp_add : ∀ a b, p a → p b → p (a + b))
+    (h_div : ∀ (n : ℕ) a, p a → m (a /ℚ n) = m a /ℚ n)
+    (hs : ∀ i ∈ s, p (f i)) : m (𝔼 i ∈ s, f i) ≤ 𝔼 i ∈ s, m (f i) := by
+  obtain rfl | hs_nonempty := s.eq_empty_or_nonempty
+  · simp [h_zero]
+  · exact le_expect_nonempty_of_subadditive_on_pred h_add hp_add h_div hs_nonempty hs
+
+-- TODO: Contribute back better docstring to `le_prod_of_submultiplicative`
+/-- If `m` is a subadditive function (`m (x + y) ≤ m x + m y`, `m 0 = 0`) preserved under division
+by a natural, then `m (𝔼 i ∈ s, f i) ≤ 𝔼 i ∈ s, m (f i)`. -/
+lemma le_expect_of_subadditive (h_zero : m 0 = 0) (h_add : ∀ a b, m (a + b) ≤ m a + m b)
+    (h_div : ∀ (n : ℕ) a, m (a /ℚ n) = m a /ℚ n) : m (𝔼 i ∈ s, f i) ≤ 𝔼 i ∈ s, m (f i) :=
+  le_expect_of_subadditive_on_pred (p := fun _ ↦ True) h_zero (by simpa) (by simp) (by simpa)
+    (by simp)
+
+end PosSMulMono
+end OrderedAddCommMonoid
+
+section OrderedCancelAddCommMonoid
+variable [OrderedCancelAddCommMonoid α] [Module ℚ≥0 α] {s : Finset ι} {f g : ι → α}
+section PosSMulStrictMono
+variable [PosSMulStrictMono ℚ≥0 α]
+
+lemma expect_pos (hf : ∀ i ∈ s, 0 < f i) (hs : s.Nonempty) : 0 < 𝔼 i ∈ s, f i :=
+  smul_pos (inv_pos.2 <| mod_cast hs.card_pos) <| sum_pos hf hs
+
+end PosSMulStrictMono
+end OrderedCancelAddCommMonoid
+
+section LinearOrderedAddCommMonoid
+variable [LinearOrderedAddCommMonoid α] [Module ℚ≥0 α] [PosSMulMono ℚ≥0 α] {s : Finset ι}
+  {f : ι → α} {a : α}
+
+lemma lt_of_lt_expect (hs : s.Nonempty) (h : a < 𝔼 i ∈ s, f i) : ∃ x ∈ s, a < f x := by
+  contrapose! h; exact expect_le hs h
+
+lemma lt_of_expect_lt (hs : s.Nonempty) (h : 𝔼 i ∈ s, f i < a) : ∃ x ∈ s, f x < a := by
+  contrapose! h; exact le_expect hs h
+
+end LinearOrderedAddCommMonoid
+
+section LinearOrderedAddCommGroup
+variable [LinearOrderedAddCommGroup α] [Module ℚ≥0 α] [PosSMulMono ℚ≥0 α]
+
+-- TODO: Norm version
+lemma abs_expect_le_expect_abs (s : Finset ι) (f : ι → α) : |𝔼 i ∈ s, f i| ≤ 𝔼 i ∈ s, |f i| :=
+  le_expect_of_subadditive abs_zero abs_add (fun _ ↦ abs_nnqsmul _)
+
+end LinearOrderedAddCommGroup
+
+section LinearOrderedCommSemiring
+variable [LinearOrderedCommSemiring R] [ExistsAddOfLE R] [Module ℚ≥0 R] [PosSMulMono ℚ≥0 R]
+
+/-- **Cauchy-Schwarz inequality** in terms of `Finset.expect`. -/
+lemma expect_mul_sq_le_sq_mul_sq (s : Finset ι) (f g : ι → R) :
+    (𝔼 i ∈ s, f i * g i) ^ 2 ≤ (𝔼 i ∈ s, f i ^ 2) * 𝔼 i ∈ s, g i ^ 2 := by
+  simp only [expect, smul_pow, inv_pow, smul_mul_smul_comm, ← sq]
+  gcongr
+  exact sum_mul_sq_le_sq_mul_sq ..
+
+end LinearOrderedCommSemiring
+end Finset
+
+open Finset
+
+namespace Fintype
+variable [Fintype ι] [Fintype κ]
+
+section OrderedAddCommMonoid
+variable [OrderedAddCommMonoid α] [Module ℚ≥0 α] {f : ι → α}
+
+lemma expect_eq_zero_iff_of_nonneg [Nonempty ι] (hf : 0 ≤ f) : 𝔼 i, f i = 0 ↔ f = 0 := by
+  simp [expect, sum_eq_zero_iff_of_nonneg hf, univ_nonempty.ne_empty]
+
+lemma expect_eq_zero_iff_of_nonpos [Nonempty ι] (hf : f ≤ 0) : 𝔼 i, f i = 0 ↔ f = 0 := by
+  simp [expect, sum_eq_zero_iff_of_nonpos hf, univ_nonempty.ne_empty]
+
+end OrderedAddCommMonoid
+end Fintype
+
+open Finset
+
+namespace Mathlib.Meta.Positivity
+open Qq Lean Meta Finset
+open scoped BigOperators
+
+/-- Positivity extension for `Finset.expect`. -/
+@[positivity Finset.expect _ _]
+def evalFinsetExpect : PositivityExt where eval {u α} zα pα e := do
+  match e with
+  | ~q(@Finset.expect $ι _ $instα $instmod $s $f) =>
+    let (lhs, _, (rhs : Q($α))) ← lambdaMetaTelescope f
+    let so : Option Q(Finset.Nonempty $s) ← do
+      try
+        let _fi ← synthInstanceQ q(Fintype $ι)
+        let _no ← synthInstanceQ q(Nonempty $ι)
+        match s with
+        | ~q(@univ _ $fi) => pure (some q(Finset.univ_nonempty (α := $ι)))
+        | _ => pure none
+      catch _ => do
+        let .some fv ← findLocalDeclWithType? q(Finset.Nonempty $s) | pure none
+        pure (some (.fvar fv))
+    match ← core zα pα rhs, so with
+    | .nonnegative pb, _ => do
+      let instαordmon ← synthInstanceQ q(OrderedAddCommMonoid $α)
+      let instαordsmul ← synthInstanceQ q(PosSMulMono ℚ≥0 $α)
+      assumeInstancesCommute
+      let pr : Q(∀ i, 0 ≤ $f i) ← mkLambdaFVars lhs pb
+      return .nonnegative q(@expect_nonneg $ι $α $instαordmon $instmod $s $f $instαordsmul
+        fun i _ ↦ $pr i)
+    | .positive pb, .some (fi : Q(Finset.Nonempty $s)) => do
+      let instαordmon ← synthInstanceQ q(OrderedCancelAddCommMonoid $α)
+      let instαordsmul ← synthInstanceQ q(PosSMulStrictMono ℚ≥0 $α)
+      assumeInstancesCommute
+      let pr : Q(∀ i, 0 < $f i) ← mkLambdaFVars lhs pb
+      return .positive q(@expect_pos $ι $α $instαordmon $instmod $s $f $instαordsmul
+        (fun i _ ↦ $pr i) $fi)
+    | _, _ => pure .none
+  | _ => throwError "not Finset.expect"
+
+example (n : ℕ) (a : ℕ → ℚ) : 0 ≤ 𝔼 j ∈ range n, a j^2 := by positivity
+example (a : ULift.{2} ℕ → ℚ) (s : Finset (ULift.{2} ℕ)) : 0 ≤ 𝔼 j ∈ s, a j^2 := by positivity
+example (n : ℕ) (a : ℕ → ℚ) : 0 ≤ 𝔼 j : Fin 8, 𝔼 i ∈ range n, (a j^2 + i ^ 2) := by positivity
+example (n : ℕ) (a : ℕ → ℚ) : 0 < 𝔼 j : Fin (n + 1), (a j^2 + 1) := by positivity
+example (a : ℕ → ℚ) : 0 < 𝔼 j ∈ ({1} : Finset ℕ), (a j^2 + 1) := by
+  have : Finset.Nonempty {1} := singleton_nonempty 1
+  positivity
+
+end Mathlib.Meta.Positivity

--- a/Mathlib/Analysis/MeanInequalities.lean
+++ b/Mathlib/Analysis/MeanInequalities.lean
@@ -3,6 +3,7 @@ Copyright (c) 2019 Yury Kudryashov. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Yury Kudryashov, Sébastien Gouëzel, Rémy Degenne
 -/
+import Mathlib.Algebra.BigOperators.Expect
 import Mathlib.Analysis.Convex.Jensen
 import Mathlib.Analysis.Convex.SpecificFunctions.Basic
 import Mathlib.Analysis.SpecialFunctions.Pow.NNReal
@@ -105,6 +106,7 @@ less than or equal to the sum of the maximum values of the summands.
 universe u v
 
 open Finset NNReal ENNReal
+open scoped BigOperators
 
 noncomputable section
 
@@ -659,6 +661,18 @@ lemma inner_le_weight_mul_Lp_of_nonneg (s : Finset ι) {p : ℝ} (hp : 1 ≤ p) 
   beta_reduce at *
   norm_cast at *
   exact NNReal.inner_le_weight_mul_Lp _ hp _ _
+
+/-- **Weighted Hölder inequality** in terms of `Finset.expect`. -/
+lemma compact_inner_le_weight_mul_Lp_of_nonneg (s : Finset ι) {p : ℝ} (hp : 1 ≤ p) {w f : ι → ℝ}
+    (hw : ∀ i, 0 ≤ w i) (hf : ∀ i, 0 ≤ f i) :
+    𝔼 i ∈ s, w i * f i ≤ (𝔼 i ∈ s, w i) ^ (1 - p⁻¹) * (𝔼 i ∈ s, w i * f i ^ p) ^ p⁻¹ := by
+  simp_rw [expect_eq_sum_div_card]
+  rw [div_rpow, div_rpow, div_mul_div_comm, ← rpow_add', sub_add_cancel, rpow_one]
+  gcongr
+  · exact inner_le_weight_mul_Lp_of_nonneg s hp _ _ hw hf
+  any_goals simp
+  · exact sum_nonneg fun i _ ↦ by have := hw i; have := hf i; positivity
+  · exact sum_nonneg fun i _ ↦ by have := hw i; positivity
 
 /-- **Hölder inequality**: the scalar product of two functions is bounded by the product of their
 `L^p` and `L^q` norms when `p` and `q` are conjugate exponents. A version for `ℝ`-valued functions.


### PR DESCRIPTION
Also add a few basic lemmas and fix the delaborator in `Algebra.BigOperators.Expect`.

From LeanAPAP

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
