### PR TITLE
[Merged by Bors] - feat(CategoryTheory/Galois): prerequisites for essential surjectivity

### DIFF
--- a/Mathlib/CategoryTheory/Galois/Basic.lean
+++ b/Mathlib/CategoryTheory/Galois/Basic.lean
@@ -191,6 +191,10 @@ lemma mulAction_def {X : C} (σ : Aut F) (x : F.obj X) :
     σ • x = σ.hom.app X x :=
   rfl
 
+lemma mulAction_naturality {X Y : C} (σ : Aut F) (f : X ⟶ Y) (x : F.obj X) :
+    σ • F.map f x = F.map f (σ • x) :=
+  FunctorToFintypeCat.naturality F F σ.hom f x
+
 /-- An object that is neither initial or connected has a non-trivial subobject. -/
 lemma has_non_trivial_subobject_of_not_isConnected_of_not_initial (X : C) (hc : ¬ IsConnected X)
     (hi : IsInitial X → False) :

--- a/Mathlib/CategoryTheory/Galois/Examples.lean
+++ b/Mathlib/CategoryTheory/Galois/Examples.lean
@@ -4,12 +4,8 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Christian Merten
 -/
 import Mathlib.CategoryTheory.Galois.Basic
-import Mathlib.RepresentationTheory.Action.Basic
 import Mathlib.RepresentationTheory.Action.Concrete
 import Mathlib.RepresentationTheory.Action.Limits
-import Mathlib.CategoryTheory.Limits.FintypeCat
-import Mathlib.CategoryTheory.Limits.Shapes.Types
-import Mathlib.Logic.Equiv.TransferInstance
 
 /-!
 # Examples of Galois categories and fiber functors
@@ -25,9 +21,9 @@ universe u v w
 
 namespace CategoryTheory
 
-namespace FintypeCat
-
 open Limits Functor PreGaloisCategory
+
+namespace FintypeCat
 
 /-- Complement of the image of a morphism `f : X ⟶ Y` in `FintypeCat`. -/
 noncomputable def imageComplement {X Y : FintypeCat.{u}} (f : X ⟶ Y) :
@@ -152,6 +148,23 @@ theorem Action.isConnected_of_transitive (X : FintypeCat) [MulAction G X]
 theorem Action.isConnected_iff_transitive (X : Action FintypeCat (MonCat.of G)) [Nonempty X.V] :
     IsConnected X ↔ MulAction.IsPretransitive G X.V :=
   ⟨fun _ ↦ pretransitive_of_isConnected G X, fun _ ↦ isConnected_of_transitive G X.V⟩
+
+variable {G}
+
+/-- If `X` is a connected `G`-set and `x` is an element of `X`, `X` is isomorphic
+to the quotient of `G` by the stabilizer of `x` as `G`-sets. -/
+noncomputable def isoQuotientStabilizerOfIsConnected (X : Action FintypeCat (MonCat.of G))
+    [IsConnected X] (x : X.V) [Fintype (G ⧸ (MulAction.stabilizer G x))] :
+    X ≅ G ⧸ₐ MulAction.stabilizer G x :=
+  haveI : MulAction.IsPretransitive G X.V := Action.pretransitive_of_isConnected G X
+  let e : X.V ≃ G ⧸ MulAction.stabilizer G x :=
+    (Equiv.Set.univ X.V).symm.trans <|
+      (Equiv.setCongr ((MulAction.orbit_eq_univ G x).symm)).trans <|
+      MulAction.orbitEquivQuotientStabilizer G x
+  Iso.symm <| Action.mkIso (FintypeCat.equivEquivIso e.symm) <| fun σ : G ↦ by
+    ext (a : G ⧸ MulAction.stabilizer G x)
+    obtain ⟨τ, rfl⟩ := Quotient.exists_rep a
+    exact mul_smul σ τ x
 
 end FintypeCat
 

--- a/Mathlib/CategoryTheory/Galois/GaloisObjects.lean
+++ b/Mathlib/CategoryTheory/Galois/GaloisObjects.lean
@@ -95,6 +95,17 @@ instance isPretransitive_of_isGalois (X : C) [IsGalois X] :
   rw [← isGalois_iff_pretransitive]
   infer_instance
 
+lemma stabilizer_normal_of_isGalois (X : C) [IsGalois X] (x : F.obj X) :
+    Subgroup.Normal (MulAction.stabilizer (Aut F) x) where
+  conj_mem n ninstab g := by
+    rw [MulAction.mem_stabilizer_iff]
+    show g • n • (g⁻¹ • x) = x
+    have : ∃ (φ : Aut X), F.map φ.hom x = g⁻¹ • x :=
+      MulAction.IsPretransitive.exists_smul_eq x (g⁻¹ • x)
+    obtain ⟨φ, h⟩ := this
+    rw [← h, mulAction_naturality, ninstab, h]
+    simp
+
 theorem evaluation_aut_surjective_of_isGalois (A : C) [IsGalois A] (a : F.obj A) :
     Function.Surjective (fun f : Aut A ↦ F.map f.hom a) :=
   MulAction.IsPretransitive.exists_smul_eq a

--- a/Mathlib/RepresentationTheory/Action/Basic.lean
+++ b/Mathlib/RepresentationTheory/Action/Basic.lean
@@ -125,6 +125,16 @@ theorem comp_hom {M N K : Action V G} (f : M ⟶ N) (g : N ⟶ K) :
     (f ≫ g : Hom M K).hom = f.hom ≫ g.hom :=
   rfl
 
+@[simp]
+theorem hom_inv_hom {M N : Action V G} (f : M ≅ N) :
+    f.hom.hom ≫ f.inv.hom = 𝟙 M.V := by
+  rw [← comp_hom, Iso.hom_inv_id, id_hom]
+
+@[simp]
+theorem inv_hom_hom {M N : Action V G} (f : M ≅ N) :
+    f.inv.hom ≫ f.hom.hom = 𝟙 N.V := by
+  rw [← comp_hom, Iso.inv_hom_id, id_hom]
+
 /-- Construct an isomorphism of `G` actions/representations
 from an isomorphism of the underlying objects,
 where the forward direction commutes with the group action. -/
@@ -144,6 +154,12 @@ instance (priority := 100) isIso_of_hom_isIso {M N : Action V G} (f : M ⟶ N) [
 instance isIso_hom_mk {M N : Action V G} (f : M.V ⟶ N.V) [IsIso f] (w) :
     @IsIso _ _ M N (Hom.mk f w) :=
   (mkIso (asIso f) w).isIso_hom
+
+instance {M N : Action V G} (f : M ≅ N) : IsIso f.hom.hom where
+  out := ⟨f.inv.hom, by simp⟩
+
+instance {M N : Action V G} (f : M ≅ N) : IsIso f.inv.hom where
+  out := ⟨f.hom.hom, by simp⟩
 
 namespace FunctorCategoryEquivalence
 

--- a/Mathlib/RepresentationTheory/Action/Concrete.lean
+++ b/Mathlib/RepresentationTheory/Action/Concrete.lean
@@ -97,7 +97,7 @@ variable {G : Type*} [Group G] (H N : Subgroup G) [Fintype (G ⧸ N)]
 /-- If `N` is a normal subgroup of `G`, then this is the group homomorphism
 sending an element `g` of `G` to the `G`-endomorphism of `G ⧸ₐ N` given by
 multiplication with `g⁻¹` on the right. -/
-def toEndMul [N.Normal] : G →* End (G ⧸ₐ N) where
+def toEndHom [N.Normal] : G →* End (G ⧸ₐ N) where
   toFun v := {
     hom := Quotient.lift (fun σ ↦ ⟦σ * v⁻¹⟧) <| fun a b h ↦ Quotient.sound <| by
       apply (QuotientGroup.leftRel_apply).mpr
@@ -125,17 +125,21 @@ def toEndMul [N.Normal] : G →* End (G ⧸ₐ N) where
     show ⟦x * (σ * τ)⁻¹⟧ = ⟦x * τ⁻¹ * σ⁻¹⟧
     rw [mul_inv_rev, mul_assoc]
 
-/-- If `H` and `N` are subgroups of a group `G` with `N` normal, there is a canonical
-group homomorphism `H ⧸ N ⊓ H` to the `G`-endomorphisms of `G ⧸ N`. -/
-def quotientToEndHom [N.Normal] : H ⧸ Subgroup.subgroupOf N H →* End (G ⧸ₐ N) :=
-  let φ' : H →* End (G ⧸ₐ N) := (toEndMul N).comp H.subtype
-  QuotientGroup.lift (Subgroup.subgroupOf N H) φ' <| fun u uinU' ↦ by
+@[simp]
+lemma toEndHom_apply [N.Normal] (g h : G) : (toEndHom N g).hom ⟦h⟧ = ⟦h * g⁻¹⟧ := rfl
+
+variable {N} in
+lemma toEndHom_trivial_of_mem [N.Normal] {n : G} (hn : n ∈ N) : toEndHom N n = 𝟙 (G ⧸ₐ N) := by
   apply Action.hom_ext
   ext (x : G ⧸ N)
   induction' x using Quotient.inductionOn with μ
-  apply Quotient.sound
-  apply (QuotientGroup.leftRel_apply).mpr
-  simpa
+  exact Quotient.sound ((QuotientGroup.leftRel_apply).mpr <| by simpa)
+
+/-- If `H` and `N` are subgroups of a group `G` with `N` normal, there is a canonical
+group homomorphism `H ⧸ N ⊓ H` to the `G`-endomorphisms of `G ⧸ N`. -/
+def quotientToEndHom [N.Normal] : H ⧸ Subgroup.subgroupOf N H →* End (G ⧸ₐ N) :=
+  QuotientGroup.lift (Subgroup.subgroupOf N H) ((toEndHom N).comp H.subtype) <| fun _ uinU' ↦
+    toEndHom_trivial_of_mem uinU'
 
 @[simp]
 lemma quotientToEndHom_mk [N.Normal] (x : H) (g : G) :


### PR DESCRIPTION
This PR collects prerequisites for the essential surjectivity of fiber functors in a Galois category.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
