### PR TITLE
[Merged by Bors] - feat(Combinatorics/SimpleGraph): conversions between `SimpleGraph` and `Digraphs`

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -1937,6 +1937,7 @@ import Mathlib.Combinatorics.Derangements.Basic
 import Mathlib.Combinatorics.Derangements.Exponential
 import Mathlib.Combinatorics.Derangements.Finite
 import Mathlib.Combinatorics.Digraph.Basic
+import Mathlib.Combinatorics.Digraph.Orientation
 import Mathlib.Combinatorics.Enumerative.Catalan
 import Mathlib.Combinatorics.Enumerative.Composition
 import Mathlib.Combinatorics.Enumerative.DoubleCounting

--- a/Mathlib/Combinatorics/Digraph/Orientation.lean
+++ b/Mathlib/Combinatorics/Digraph/Orientation.lean
@@ -3,9 +3,8 @@ Copyright (c) 2024 Rida Hamadani. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Rida Hamadani
 -/
-import Mathlib.Combinatorics.SimpleGraph.Basic
 import Mathlib.Combinatorics.Digraph.Basic
-import Mathlib.Order.GaloisConnection
+import Mathlib.Combinatorics.SimpleGraph.Basic
 
 /-!
 

--- a/Mathlib/Combinatorics/Digraph/Orientation.lean
+++ b/Mathlib/Combinatorics/Digraph/Orientation.lean
@@ -75,16 +75,16 @@ lemma toSimpleGraphAnd_mono : Monotone (toSimpleGraphAnd : _ → SimpleGraph V) 
   fun _ _ h₁ _ _ h₂ ↦ And.intro h₂.1 <| And.intro (h₁ h₂.2.1) (h₁ h₂.2.2)
 
 lemma toSimpleGraphOr_top : (⊤ : Digraph V).toSimpleGraphOr = ⊤ := by
-  ext; exact ⟨fun h ↦ h.1, fun h ↦ ⟨h.ne, Or.inl trivial⟩⟩
+  ext; exact ⟨And.left, fun h ↦ ⟨h.ne, Or.inl trivial⟩⟩
 
 lemma toSimpleGraphAnd_top : (⊤ : Digraph V).toSimpleGraphAnd = ⊤ := by
-  ext; exact ⟨fun h ↦ h.1, fun h ↦ ⟨h.ne, trivial, trivial⟩⟩
+  ext; exact ⟨And.left, fun h ↦ ⟨h.ne, trivial, trivial⟩⟩
 
 lemma toSimpleGraphOr_bot : (⊥ : Digraph V).toSimpleGraphOr = ⊥ := by
-  ext; exact ⟨fun ⟨_, h⟩ ↦ by tauto, fun h ↦ h.elim⟩
+  ext; exact ⟨fun ⟨_, h⟩ ↦ by tauto, False.elim⟩
 
 lemma toSimpleGraphAnd_bot : (⊥ : Digraph V).toSimpleGraphAnd = ⊥ := by
-  ext; exact ⟨fun ⟨_, h⟩ ↦ by tauto, fun h ↦ h.elim⟩
+  ext; exact ⟨fun ⟨_, h⟩ ↦ by tauto, False.elim⟩
 
 end toSimpleGraph
 
@@ -104,7 +104,7 @@ lemma isOriented_loopless {G : Digraph V} (h : G.IsOriented) {v : V} : ¬G.Adj v
 
 lemma isOriented_toSimpleGraphAnd_eq_bot {G : Digraph V} (h : G.IsOriented) :
     G.toSimpleGraphAnd = ⊥ := by
-  ext; exact ⟨fun a ↦ (h _ _) a.2, fun h ↦ h.elim⟩
+  ext; exact ⟨fun a ↦ h _ _ a.2, False.elim⟩
 
 lemma toSimpleGraphAnd_eq_bot_iff_isOriented_and_loopless {G : Digraph V} :
     G.IsOriented ↔ G.toSimpleGraphAnd = ⊥ ∧ ∀ v, ¬G.Adj v v:= by

--- a/Mathlib/Combinatorics/Digraph/Orientation.lean
+++ b/Mathlib/Combinatorics/Digraph/Orientation.lean
@@ -1,0 +1,127 @@
+/-
+Copyright (c) 2024 Rida Hamadani. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Rida Hamadani
+-/
+import Mathlib.Combinatorics.SimpleGraph.Basic
+import Mathlib.Combinatorics.Digraph.Basic
+import Mathlib.Order.GaloisConnection
+
+/-!
+
+# Graph Orientation
+
+This module introduces conversion operations between `Digraph`s and `SimpleGraph`s, by either
+forgetting the edge orientations of `Digraph`, or adding such orientations on a `SimpleGraph`. It
+also introduces oriented graphs.
+
+## Main Definitions
+
+- `Digraph.toSimpleGraphOr`: Converts a `Digraph` to a `SimpleGraph` by creating an undirected edge
+  if either orientation exists in the digraph.
+- `Digraph.toSimpleGraphAnd`: Converts a `Digraph` to a `SimpleGraph` by creating an undirected edge
+  only if both orientations exist in the digraph.
+- `Digraph.IsOriented`: A predicate that determines whether a digraph is oriented (no self-loops and
+  no bidirectional edges).
+- `SimpleGraph.toDigraph`: Converts a `SimpleGraph` to a `Digraph` by creating edges in both
+  directions for each undirected edge.
+
+## TODO
+
+- Show that there is an isomorphism between loopless complete digraphs and oriented graphs.
+- Define more ways to orient a `SimpleGraph`.
+
+## Tags
+
+digraph, simple graph, oriented graphs
+-/
+
+variable {V : Type*}
+
+namespace Digraph
+
+section toSimpleGraph
+
+/-! ### Orientation-forgetting maps on digraphs -/
+
+/--
+Orientation-forgetting map from `Digraph` to `SimpleGraph` that gives an unoriented edge if
+either orientation is present.
+-/
+def toSimpleGraphOr (G : Digraph V) : SimpleGraph V := SimpleGraph.fromRel G.Adj
+
+/--
+Orientation-forgetting map from `Digraph` to `SimpleGraph` that gives an unoriented edge if
+both orientations are present.
+-/
+def toSimpleGraphAnd (G : Digraph V) : SimpleGraph V where
+  Adj v w := v ≠ w ∧ G.Adj v w ∧ G.Adj w v
+  symm _ _ h := And.intro h.1.symm h.2.symm
+  loopless _ h := h.1 rfl
+
+lemma toSimpleGraphAnd_subgraph_toSimpleGraphOr (G : Digraph V) :
+    G.toSimpleGraphAnd ≤ G.toSimpleGraphOr :=
+  fun _ _ h ↦ ⟨h.1, Or.inl h.2.1⟩
+
+lemma toSimpleGraphOr_mono : Monotone (toSimpleGraphOr : _ → SimpleGraph V) := by
+  intro _ _ h₁ _ _ h₂
+  apply And.intro h₂.1
+  cases h₂.2
+  · exact Or.inl <| h₁ ‹_›
+  · exact Or.inr <| h₁ ‹_›
+
+lemma toSimpleGraphAnd_mono : Monotone (toSimpleGraphAnd : _ → SimpleGraph V) :=
+  fun _ _ h₁ _ _ h₂ ↦ And.intro h₂.1 <| And.intro (h₁ h₂.2.1) (h₁ h₂.2.2)
+
+lemma toSimpleGraphOr_top : (⊤ : Digraph V).toSimpleGraphOr = ⊤ := by
+  ext; exact ⟨fun h ↦ h.1, fun h ↦ ⟨h.ne, Or.inl trivial⟩⟩
+
+lemma toSimpleGraphAnd_top : (⊤ : Digraph V).toSimpleGraphAnd = ⊤ := by
+  ext; exact ⟨fun h ↦ h.1, fun h ↦ ⟨h.ne, trivial, trivial⟩⟩
+
+lemma toSimpleGraphOr_bot : (⊥ : Digraph V).toSimpleGraphOr = ⊥ := by
+  ext; exact ⟨fun ⟨_, h⟩ ↦ by tauto, fun h ↦ h.elim⟩
+
+lemma toSimpleGraphAnd_bot : (⊥ : Digraph V).toSimpleGraphAnd = ⊥ := by
+  ext; exact ⟨fun ⟨_, h⟩ ↦ by tauto, fun h ↦ h.elim⟩
+
+end toSimpleGraph
+
+section IsOriented
+
+/-! ### Oriented graphs  -/
+
+/--
+Oriented graphs are `Digraph`s that have no self-loops and no pair of vertices with edges in both
+directions.
+-/
+def IsOriented (G : Digraph V) : Prop :=
+  ∀ v w : V, ¬G.Adj v v ∧ ¬(G.Adj v w ∧ G.Adj w v)
+
+lemma isOriented_toSimpleGraphAnd_eq_bot {G : Digraph V} (h : G.IsOriented) :
+    G.toSimpleGraphAnd = ⊥ := by
+  ext; exact ⟨fun a ↦ (h _ _).2 a.2, fun h ↦ h.elim⟩
+
+end IsOriented
+
+end Digraph
+
+namespace SimpleGraph
+
+/-! ### Digraphs constructed from simple graphs -/
+
+/--
+Orienting map that gives a `Digraph` from a `SimpleGraph` by giving two edges in opposite directions
+to each adjacent vertices in the `SimpleGraph`.
+-/
+def toDigraph (G : SimpleGraph V) : Digraph V where
+  Adj v w := G.Adj v w
+
+@[mono]
+lemma toDigraph_mono : Monotone (toDigraph : _ → Digraph V) :=
+  fun _ _ h₁ _ _ h₂ ↦ h₁ h₂
+
+instance : GaloisConnection toDigraph (Digraph.toSimpleGraphAnd : _ → SimpleGraph V) :=
+  fun _ _ ↦ ⟨fun h₁ _ _ h₂ ↦ ⟨h₂.ne, h₁ h₂, h₁ h₂.symm⟩, fun h₁ _ _ h₂ ↦ (h₁ h₂).2.1⟩
+
+end SimpleGraph

--- a/Mathlib/Combinatorics/Digraph/Orientation.lean
+++ b/Mathlib/Combinatorics/Digraph/Orientation.lean
@@ -97,22 +97,25 @@ Oriented graphs are `Digraph`s that have no self-loops and no pair of vertices w
 directions.
 -/
 def IsOriented (G : Digraph V) : Prop :=
-  ∀ v w : V, ¬(G.Adj v w ∧ G.Adj w v)
+  Asymmetric G.Adj
 
-lemma isOriented_loopless {G : Digraph V} (h : G.IsOriented) {v : V} : ¬G.Adj v v :=
-  and_self (G.Adj v v) ▸ h v v
+lemma isOriented_def {G : Digraph V} (h : G.IsOriented) (v w : V) : ¬(G.Adj v w ∧ G.Adj w v) :=
+  fun ⟨a, b⟩ ↦ h a b
+
+lemma isOriented_loopless {G : Digraph V} (h : G.IsOriented) : Irreflexive G.Adj :=
+  fun _ a ↦ h a a
 
 lemma isOriented_toSimpleGraphAnd_eq_bot {G : Digraph V} (h : G.IsOriented) :
     G.toSimpleGraphAnd = ⊥ := by
-  ext; exact ⟨fun a ↦ h _ _ a.2, False.elim⟩
+  ext; exact ⟨fun ⟨_, a, b⟩ ↦ h a b, False.elim⟩
 
 lemma toSimpleGraphAnd_eq_bot_iff_isOriented_and_loopless {G : Digraph V} :
     G.IsOriented ↔ G.toSimpleGraphAnd = ⊥ ∧ ∀ v, ¬G.Adj v v:= by
-  refine ⟨fun h ↦ ⟨isOriented_toSimpleGraphAnd_eq_bot h, fun v ↦ isOriented_loopless h⟩,
+  refine ⟨fun h ↦ ⟨isOriented_toSimpleGraphAnd_eq_bot h, isOriented_loopless h⟩,
     fun ⟨h₁, h₂⟩ v w ↦ ?_⟩
   by_cases h : v = w
-  · exact h ▸ and_self _ ▸ h₂ v
-  · exact not_and.mpr fun a b ↦ (SimpleGraph.bot_adj v w).mp <| h₁ ▸ ⟨h, And.intro a b⟩
+  · exact h ▸ fun _ ↦ h₂ v
+  · exact fun a b ↦ (SimpleGraph.bot_adj v w).mp <| h₁ ▸ ⟨h, a, b⟩
 
 end IsOriented
 

--- a/Mathlib/Combinatorics/Digraph/Orientation.lean
+++ b/Mathlib/Combinatorics/Digraph/Orientation.lean
@@ -10,9 +10,8 @@ import Mathlib.Combinatorics.SimpleGraph.Basic
 
 # Graph Orientation
 
-This module introduces conversion operations between `Digraph`s and `SimpleGraph`s, by either
-forgetting the edge orientations of `Digraph`, or adding such orientations on a `SimpleGraph`. It
-also introduces oriented graphs.
+This module introduces conversion operations between `Digraph`s and `SimpleGraph`s, by forgetting
+the edge orientations of `Digraph`.
 
 ## Main Definitions
 
@@ -20,15 +19,13 @@ also introduces oriented graphs.
   undirected edge if either orientation exists in the digraph.
 - `Digraph.toSimpleGraphStrict`: Converts a `Digraph` to a `SimpleGraph` by creating an undirected
   edge only if both orientations exist in the digraph.
-- `Digraph.IsOriented`: A predicate that determines whether a digraph is oriented (no self-loops and
-  no bidirectional edges).
-- `SimpleGraph.toDigraph`: Converts a `SimpleGraph` to a `Digraph` by creating edges in both
-  directions for each undirected edge.
 
 ## TODO
 
 - Show that there is an isomorphism between loopless complete digraphs and oriented graphs.
 - Define more ways to orient a `SimpleGraph`.
+- Provide lemmas on how `toSimpleGraphInclusive` and `toSimpleGraphStrict` relate to other lattice
+  structures on `SimpleGraph`s and `Digraph`s.
 
 ## Tags
 
@@ -74,15 +71,19 @@ lemma toSimpleGraphInclusive_mono : Monotone (toSimpleGraphInclusive : _ → Sim
 lemma toSimpleGraphStrict_mono : Monotone (toSimpleGraphStrict : _ → SimpleGraph V) :=
   fun _ _ h₁ _ _ h₂ ↦ And.intro h₂.1 <| And.intro (h₁ h₂.2.1) (h₁ h₂.2.2)
 
+@[simp]
 lemma toSimpleGraphInclusive_top : (⊤ : Digraph V).toSimpleGraphInclusive = ⊤ := by
   ext; exact ⟨And.left, fun h ↦ ⟨h.ne, Or.inl trivial⟩⟩
 
+@[simp]
 lemma toSimpleGraphStrict_top : (⊤ : Digraph V).toSimpleGraphStrict = ⊤ := by
   ext; exact ⟨And.left, fun h ↦ ⟨h.ne, trivial, trivial⟩⟩
 
+@[simp]
 lemma toSimpleGraphInclusive_bot : (⊥ : Digraph V).toSimpleGraphInclusive = ⊥ := by
   ext; exact ⟨fun ⟨_, h⟩ ↦ by tauto, False.elim⟩
 
+@[simp]
 lemma toSimpleGraphStrict_bot : (⊥ : Digraph V).toSimpleGraphStrict = ⊥ := by
   ext; exact ⟨fun ⟨_, h⟩ ↦ by tauto, False.elim⟩
 

--- a/Mathlib/Combinatorics/Digraph/Orientation.lean
+++ b/Mathlib/Combinatorics/Digraph/Orientation.lean
@@ -87,3 +87,5 @@ lemma toSimpleGraphStrict_bot : (⊥ : Digraph V).toSimpleGraphStrict = ⊥ := b
   ext; exact ⟨fun ⟨_, h⟩ ↦ by tauto, False.elim⟩
 
 end toSimpleGraph
+
+end Digraph

--- a/Mathlib/Combinatorics/Digraph/Orientation.lean
+++ b/Mathlib/Combinatorics/Digraph/Orientation.lean
@@ -16,10 +16,10 @@ also introduces oriented graphs.
 
 ## Main Definitions
 
-- `Digraph.toSimpleGraphOr`: Converts a `Digraph` to a `SimpleGraph` by creating an undirected edge
-  if either orientation exists in the digraph.
-- `Digraph.toSimpleGraphAnd`: Converts a `Digraph` to a `SimpleGraph` by creating an undirected edge
-  only if both orientations exist in the digraph.
+- `Digraph.toSimpleGraphInclusive`: Converts a `Digraph` to a `SimpleGraph` by creating an
+  undirected edge if either orientation exists in the digraph.
+- `Digraph.toSimpleGraphStrict`: Converts a `Digraph` to a `SimpleGraph` by creating an undirected
+  edge only if both orientations exist in the digraph.
 - `Digraph.IsOriented`: A predicate that determines whether a digraph is oriented (no self-loops and
   no bidirectional edges).
 - `SimpleGraph.toDigraph`: Converts a `SimpleGraph` to a `Digraph` by creating edges in both
@@ -47,23 +47,23 @@ section toSimpleGraph
 Orientation-forgetting map from `Digraph` to `SimpleGraph` that gives an unoriented edge if
 either orientation is present.
 -/
-def toSimpleGraphOr (G : Digraph V) : SimpleGraph V := SimpleGraph.fromRel G.Adj
+def toSimpleGraphInclusive (G : Digraph V) : SimpleGraph V := SimpleGraph.fromRel G.Adj
 
 /--
 Orientation-forgetting map from `Digraph` to `SimpleGraph` that gives an unoriented edge if
 both orientations are present.
 -/
-def toSimpleGraphAnd (G : Digraph V) : SimpleGraph V where
+def toSimpleGraphStrict (G : Digraph V) : SimpleGraph V where
   Adj v w := v ≠ w ∧ G.Adj v w ∧ G.Adj w v
   symm _ _ h := And.intro h.1.symm h.2.symm
   loopless _ h := h.1 rfl
 
-lemma toSimpleGraphAnd_subgraph_toSimpleGraphOr (G : Digraph V) :
-    G.toSimpleGraphAnd ≤ G.toSimpleGraphOr :=
+lemma toSimpleGraphStrict_subgraph_toSimpleGraphInclusive (G : Digraph V) :
+    G.toSimpleGraphStrict ≤ G.toSimpleGraphInclusive :=
   fun _ _ h ↦ ⟨h.1, Or.inl h.2.1⟩
 
 @[mono]
-lemma toSimpleGraphOr_mono : Monotone (toSimpleGraphOr : _ → SimpleGraph V) := by
+lemma toSimpleGraphInclusive_mono : Monotone (toSimpleGraphInclusive : _ → SimpleGraph V) := by
   intro _ _ h₁ _ _ h₂
   apply And.intro h₂.1
   cases h₂.2
@@ -71,73 +71,19 @@ lemma toSimpleGraphOr_mono : Monotone (toSimpleGraphOr : _ → SimpleGraph V) :=
   · exact Or.inr <| h₁ ‹_›
 
 @[mono]
-lemma toSimpleGraphAnd_mono : Monotone (toSimpleGraphAnd : _ → SimpleGraph V) :=
+lemma toSimpleGraphStrict_mono : Monotone (toSimpleGraphStrict : _ → SimpleGraph V) :=
   fun _ _ h₁ _ _ h₂ ↦ And.intro h₂.1 <| And.intro (h₁ h₂.2.1) (h₁ h₂.2.2)
 
-lemma toSimpleGraphOr_top : (⊤ : Digraph V).toSimpleGraphOr = ⊤ := by
+lemma toSimpleGraphInclusive_top : (⊤ : Digraph V).toSimpleGraphInclusive = ⊤ := by
   ext; exact ⟨And.left, fun h ↦ ⟨h.ne, Or.inl trivial⟩⟩
 
-lemma toSimpleGraphAnd_top : (⊤ : Digraph V).toSimpleGraphAnd = ⊤ := by
+lemma toSimpleGraphStrict_top : (⊤ : Digraph V).toSimpleGraphStrict = ⊤ := by
   ext; exact ⟨And.left, fun h ↦ ⟨h.ne, trivial, trivial⟩⟩
 
-lemma toSimpleGraphOr_bot : (⊥ : Digraph V).toSimpleGraphOr = ⊥ := by
+lemma toSimpleGraphInclusive_bot : (⊥ : Digraph V).toSimpleGraphInclusive = ⊥ := by
   ext; exact ⟨fun ⟨_, h⟩ ↦ by tauto, False.elim⟩
 
-lemma toSimpleGraphAnd_bot : (⊥ : Digraph V).toSimpleGraphAnd = ⊥ := by
+lemma toSimpleGraphStrict_bot : (⊥ : Digraph V).toSimpleGraphStrict = ⊥ := by
   ext; exact ⟨fun ⟨_, h⟩ ↦ by tauto, False.elim⟩
 
 end toSimpleGraph
-
-section IsOriented
-
-/-! ### Oriented graphs  -/
-
-/--
-Oriented graphs are `Digraph`s that have no self-loops and no pair of vertices with edges in both
-directions.
--/
-def IsOriented (G : Digraph V) : Prop :=
-  Asymmetric G.Adj
-
-lemma isOriented_def {G : Digraph V} (h : G.IsOriented) (v w : V) : ¬(G.Adj v w ∧ G.Adj w v) :=
-  fun ⟨a, b⟩ ↦ h a b
-
-lemma isOriented_loopless {G : Digraph V} (h : G.IsOriented) : Irreflexive G.Adj :=
-  fun _ a ↦ h a a
-
-lemma isOriented_toSimpleGraphAnd_eq_bot {G : Digraph V} (h : G.IsOriented) :
-    G.toSimpleGraphAnd = ⊥ := by
-  ext; exact ⟨fun ⟨_, a, b⟩ ↦ h a b, False.elim⟩
-
-lemma toSimpleGraphAnd_eq_bot_iff_isOriented_and_loopless {G : Digraph V} :
-    G.IsOriented ↔ G.toSimpleGraphAnd = ⊥ ∧ ∀ v, ¬G.Adj v v:= by
-  refine ⟨fun h ↦ ⟨isOriented_toSimpleGraphAnd_eq_bot h, isOriented_loopless h⟩,
-    fun ⟨h₁, h₂⟩ v w ↦ ?_⟩
-  by_cases h : v = w
-  · exact h ▸ fun _ ↦ h₂ v
-  · exact fun a b ↦ (SimpleGraph.bot_adj v w).mp <| h₁ ▸ ⟨h, a, b⟩
-
-end IsOriented
-
-end Digraph
-
-namespace SimpleGraph
-
-/-! ### Digraphs constructed from simple graphs -/
-
-/--
-Orienting map that gives a `Digraph` from a `SimpleGraph` by giving two edges in opposite directions
-to each adjacent vertices in the `SimpleGraph`.
--/
-def toDigraph (G : SimpleGraph V) : Digraph V where
-  Adj v w := G.Adj v w
-
-@[mono]
-lemma toDigraph_mono : Monotone (toDigraph : _ → Digraph V) :=
-  fun _ _ h₁ _ _ h₂ ↦ h₁ h₂
-
-lemma gc_toDigraph_toSimpleGraphAnd :
-    GaloisConnection toDigraph (Digraph.toSimpleGraphAnd : _ → SimpleGraph V) :=
-  fun _ _ ↦ ⟨fun h₁ _ _ h₂ ↦ ⟨h₂.ne, h₁ h₂, h₁ h₂.symm⟩, fun h₁ _ _ h₂ ↦ (h₁ h₂).2.1⟩
-
-end SimpleGraph

--- a/Mathlib/Order/Defs.lean
+++ b/Mathlib/Order/Defs.lean
@@ -153,6 +153,9 @@ def Transitive := ∀ ⦃x y z⦄, x ≺ y → y ≺ z → x ≺ z
 /-- `IsIrrefl` as a definition, suitable for use in proofs. -/
 def Irreflexive := ∀ x, ¬x ≺ x
 
+/-- `IsAssym` as a definition, suitable for use in proofs. -/
+def Asymmetric := ∀ ⦃x y⦄, x ≺ y → ¬ y ≺ x
+
 /-- `IsAntisymm` as a definition, suitable for use in proofs. -/
 def AntiSymmetric := ∀ ⦃x y⦄, x ≺ y → y ≺ x → x = y
 

--- a/Mathlib/Order/Defs.lean
+++ b/Mathlib/Order/Defs.lean
@@ -153,9 +153,6 @@ def Transitive := ∀ ⦃x y z⦄, x ≺ y → y ≺ z → x ≺ z
 /-- `IsIrrefl` as a definition, suitable for use in proofs. -/
 def Irreflexive := ∀ x, ¬x ≺ x
 
-/-- `IsAssym` as a definition, suitable for use in proofs. -/
-def Asymmetric := ∀ ⦃x y⦄, x ≺ y → ¬ y ≺ x
-
 /-- `IsAntisymm` as a definition, suitable for use in proofs. -/
 def AntiSymmetric := ∀ ⦃x y⦄, x ≺ y → y ≺ x → x = y
 


### PR DESCRIPTION
And proves some lemmas about them. This is a first step to start porting the material of the `SimpleGraph` part of the library into `Digraph`s.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
