### PR TITLE
[Merged by Bors] - chore: move things around in the `Analytic` folder

### DIFF
--- a/Mathlib/Analysis/Analytic/Basic.lean
+++ b/Mathlib/Analysis/Analytic/Basic.lean
@@ -301,18 +301,6 @@ theorem le_mul_pow_of_radius_pos (p : FormalMultilinearSeries 𝕜 E F) (h : 0 <
   rw [inv_pow, ← div_eq_mul_inv]
   exact hCp n
 
-lemma radius_le_of_le {𝕜' E' F' : Type*}
-    [NontriviallyNormedField 𝕜'] [NormedAddCommGroup E'] [NormedSpace 𝕜' E']
-    [NormedAddCommGroup F'] [NormedSpace 𝕜' F']
-    {p : FormalMultilinearSeries 𝕜 E F} {q : FormalMultilinearSeries 𝕜' E' F'}
-    (h : ∀ n, ‖p n‖ ≤ ‖q n‖) : q.radius ≤ p.radius := by
-  apply le_of_forall_nnreal_lt (fun r hr ↦ ?_)
-  rcases norm_mul_pow_le_of_lt_radius _ hr with ⟨C, -, hC⟩
-  apply le_radius_of_bound _ C (fun n ↦ ?_)
-  apply le_trans _ (hC n)
-  gcongr
-  exact h n
-
 /-- The radius of the sum of two formal series is at least the minimum of their two radii. -/
 theorem min_radius_le_radius_add (p q : FormalMultilinearSeries 𝕜 E F) :
     min p.radius q.radius ≤ (p + q).radius := by
@@ -739,33 +727,17 @@ lemma AnalyticWithinOn.mono {f : E → F} {s t : Set E} (h : AnalyticWithinOn �
 ### Composition with linear maps
 -/
 
-/-- If a function `f` has a power series `p` on a ball within a set and `g` is linear,
-then `g ∘ f` has the power series `g ∘ p` on the same ball. -/
-theorem ContinuousLinearMap.comp_hasFPowerSeriesWithinOnBall (g : F →L[𝕜] G)
-    (h : HasFPowerSeriesWithinOnBall f p s x r) :
-    HasFPowerSeriesWithinOnBall (g ∘ f) (g.compFormalMultilinearSeries p) s x r where
-  r_le := h.r_le.trans (p.radius_le_radius_continuousLinearMap_comp _)
-  r_pos := h.r_pos
-  hasSum := fun hy h'y => by
-    simpa only [ContinuousLinearMap.compFormalMultilinearSeries_apply,
-      ContinuousLinearMap.compContinuousMultilinearMap_coe, Function.comp_apply] using
-      g.hasSum (h.hasSum hy h'y)
-
 /-- If a function `f` has a power series `p` on a ball and `g` is linear, then `g ∘ f` has the
 power series `g ∘ p` on the same ball. -/
 theorem ContinuousLinearMap.comp_hasFPowerSeriesOnBall (g : F →L[𝕜] G)
     (h : HasFPowerSeriesOnBall f p x r) :
-    HasFPowerSeriesOnBall (g ∘ f) (g.compFormalMultilinearSeries p) x r := by
-  rw [← hasFPowerSeriesWithinOnBall_univ] at h ⊢
-  exact g.comp_hasFPowerSeriesWithinOnBall h
-
-/-- If a function `f` is analytic on a set `s` and `g` is linear, then `g ∘ f` is analytic
-on `s`. -/
-theorem ContinuousLinearMap.comp_analyticWithinOn (g : F →L[𝕜] G) (h : AnalyticWithinOn 𝕜 f s) :
-    AnalyticWithinOn 𝕜 (g ∘ f) s := by
-  rintro x hx
-  rcases h x hx with ⟨p, r, hp⟩
-  exact ⟨g.compFormalMultilinearSeries p, r, g.comp_hasFPowerSeriesWithinOnBall hp⟩
+    HasFPowerSeriesOnBall (g ∘ f) (g.compFormalMultilinearSeries p) x r :=
+  { r_le := h.r_le.trans (p.radius_le_radius_continuousLinearMap_comp _)
+    r_pos := h.r_pos
+    hasSum := fun hy => by
+      simpa only [ContinuousLinearMap.compFormalMultilinearSeries_apply,
+        ContinuousLinearMap.compContinuousMultilinearMap_coe, Function.comp_apply] using
+        g.hasSum (h.hasSum hy) }
 
 /-- If a function `f` is analytic on a set `s` and `g` is linear, then `g ∘ f` is analytic
 on `s`. -/

--- a/Mathlib/Analysis/Analytic/Basic.lean
+++ b/Mathlib/Analysis/Analytic/Basic.lean
@@ -63,10 +63,6 @@ We develop the basic properties of these notions, notably:
   `AnalyticAt.continuousAt`).
 * In a complete space, the sum of a formal power series with positive radius is well defined on the
   disk of convergence, see `FormalMultilinearSeries.hasFPowerSeriesOnBall`.
-* If a function admits a power series in a ball, then it is analytic at any point `y` of this ball,
-  and the power series there can be expressed in terms of the initial power series `p` as
-  `p.changeOrigin y`. See `HasFPowerSeriesOnBall.changeOrigin`. It follows in particular that
-  the set of points at which a given function is analytic is open, see `isOpen_analyticAt`.
 
 ## Implementation details
 
@@ -305,6 +301,18 @@ theorem le_mul_pow_of_radius_pos (p : FormalMultilinearSeries 𝕜 E F) (h : 0 <
   rw [inv_pow, ← div_eq_mul_inv]
   exact hCp n
 
+lemma radius_le_of_le {𝕜' E' F' : Type*}
+    [NontriviallyNormedField 𝕜'] [NormedAddCommGroup E'] [NormedSpace 𝕜' E']
+    [NormedAddCommGroup F'] [NormedSpace 𝕜' F']
+    {p : FormalMultilinearSeries 𝕜 E F} {q : FormalMultilinearSeries 𝕜' E' F'}
+    (h : ∀ n, ‖p n‖ ≤ ‖q n‖) : q.radius ≤ p.radius := by
+  apply le_of_forall_nnreal_lt (fun r hr ↦ ?_)
+  rcases norm_mul_pow_le_of_lt_radius _ hr with ⟨C, -, hC⟩
+  apply le_radius_of_bound _ C (fun n ↦ ?_)
+  apply le_trans _ (hC n)
+  gcongr
+  exact h n
+
 /-- The radius of the sum of two formal series is at least the minimum of their two radii. -/
 theorem min_radius_le_radius_add (p q : FormalMultilinearSeries 𝕜 E F) :
     min p.radius q.radius ≤ (p + q).radius := by
@@ -396,6 +404,10 @@ this is weaker than `AnalyticOn 𝕜 f s`, as `f` is allowed to be arbitrary out
 def AnalyticWithinOn (f : E → F) (s : Set E) : Prop :=
   ∀ x ∈ s, AnalyticWithinAt 𝕜 f s x
 
+/-!
+### `HasFPowerSeriesOnBall` and `HasFPowerSeriesWithinOnBall`
+-/
+
 variable {𝕜}
 
 theorem HasFPowerSeriesOnBall.hasFPowerSeriesAt (hf : HasFPowerSeriesOnBall f p x r) :
@@ -418,15 +430,6 @@ theorem HasFPowerSeriesWithinAt.analyticWithinAt (hf : HasFPowerSeriesWithinAt f
 theorem HasFPowerSeriesWithinOnBall.analyticWithinAt (hf : HasFPowerSeriesWithinOnBall f p s x r) :
     AnalyticWithinAt 𝕜 f s x :=
   hf.hasFPowerSeriesWithinAt.analyticWithinAt
-
-theorem HasFPowerSeriesOnBall.congr (hf : HasFPowerSeriesOnBall f p x r)
-    (hg : EqOn f g (EMetric.ball x r)) : HasFPowerSeriesOnBall g p x r :=
-  { r_le := hf.r_le
-    r_pos := hf.r_pos
-    hasSum := fun {y} hy => by
-      convert hf.hasSum hy using 1
-      apply hg.symm
-      simpa [edist_eq_coe_nnnorm_sub] using hy }
 
 /-- If a function `f` has a power series `p` around `x`, then the function `z ↦ f (z - y)` has the
 same power series around `x + y`. -/
@@ -469,6 +472,50 @@ theorem HasFPowerSeriesWithinOnBall.of_le
 theorem HasFPowerSeriesOnBall.mono (hf : HasFPowerSeriesOnBall f p x r) (r'_pos : 0 < r')
     (hr : r' ≤ r) : HasFPowerSeriesOnBall f p x r' :=
   ⟨le_trans hr hf.1, r'_pos, fun hy => hf.hasSum (EMetric.ball_subset_ball hr hy)⟩
+
+lemma HasFPowerSeriesWithinOnBall.congr {f g : E → F} {p : FormalMultilinearSeries 𝕜 E F}
+    {s : Set E} {x : E} {r : ℝ≥0∞} (h : HasFPowerSeriesWithinOnBall f p s x r)
+    (h' : EqOn g f (s ∩ EMetric.ball x r)) (h'' : g x = f x) :
+    HasFPowerSeriesWithinOnBall g p s x r := by
+  refine ⟨h.r_le, h.r_pos, ?_⟩
+  intro y hy h'y
+  convert h.hasSum hy h'y using 1
+  simp only [mem_insert_iff, add_right_eq_self] at hy
+  rcases hy with rfl | hy
+  · simpa using h''
+  · apply h'
+    refine ⟨hy, ?_⟩
+    simpa [edist_eq_coe_nnnorm_sub] using h'y
+
+lemma HasFPowerSeriesWithinOnBall.congr' {f g : E → F} {p : FormalMultilinearSeries 𝕜 E F}
+    {s : Set E} {x : E} {r : ℝ≥0∞} (h : HasFPowerSeriesWithinOnBall f p s x r)
+    (h' : EqOn g f (insert x s ∩ EMetric.ball x r)) :
+    HasFPowerSeriesWithinOnBall g p s x r := by
+  refine ⟨h.r_le, h.r_pos, fun {y} hy h'y ↦ ?_⟩
+  convert h.hasSum hy h'y using 1
+  exact h' ⟨hy, by simpa [edist_eq_coe_nnnorm_sub] using h'y⟩
+
+lemma HasFPowerSeriesWithinAt.congr {f g : E → F} {p : FormalMultilinearSeries 𝕜 E F} {s : Set E}
+    {x : E} (h : HasFPowerSeriesWithinAt f p s x) (h' : g =ᶠ[𝓝[s] x] f) (h'' : g x = f x) :
+    HasFPowerSeriesWithinAt g p s x := by
+  rcases h with ⟨r, hr⟩
+  obtain ⟨ε, εpos, hε⟩ : ∃ ε > 0, EMetric.ball x ε ∩ s ⊆ {y | g y = f y} :=
+    EMetric.mem_nhdsWithin_iff.1 h'
+  let r' := min r ε
+  refine ⟨r', ?_⟩
+  have := hr.of_le (r' := r') (by simp [r', εpos, hr.r_pos]) (min_le_left _ _)
+  apply this.congr _ h''
+  intro z hz
+  exact hε ⟨EMetric.ball_subset_ball (min_le_right _ _) hz.2, hz.1⟩
+
+theorem HasFPowerSeriesOnBall.congr (hf : HasFPowerSeriesOnBall f p x r)
+    (hg : EqOn f g (EMetric.ball x r)) : HasFPowerSeriesOnBall g p x r :=
+  { r_le := hf.r_le
+    r_pos := hf.r_pos
+    hasSum := fun {y} hy => by
+      convert hf.hasSum hy using 1
+      apply hg.symm
+      simpa [edist_eq_coe_nnnorm_sub] using hy }
 
 theorem HasFPowerSeriesAt.congr (hf : HasFPowerSeriesAt f p x) (hg : f =ᶠ[𝓝 x] g) :
     HasFPowerSeriesAt g p x := by
@@ -530,14 +577,6 @@ theorem HasFPowerSeriesAt.eventually_eq_zero
     HasFPowerSeriesWithinAt f p univ x ↔ HasFPowerSeriesAt f p x := by
   simp only [HasFPowerSeriesWithinAt, hasFPowerSeriesWithinOnBall_univ, HasFPowerSeriesAt]
 
-@[simp] lemma analyticWithinAt_univ :
-    AnalyticWithinAt 𝕜 f univ x ↔ AnalyticAt 𝕜 f x := by
-  simp [AnalyticWithinAt, AnalyticAt]
-
-@[simp] lemma analyticWithinOn_univ {f : E → F} :
-    AnalyticWithinOn 𝕜 f univ ↔ AnalyticOn 𝕜 f univ := by
-  simp only [AnalyticWithinOn, analyticWithinAt_univ, AnalyticOn]
-
 lemma HasFPowerSeriesWithinOnBall.mono (hf : HasFPowerSeriesWithinOnBall f p s x r) (h : t ⊆ s) :
     HasFPowerSeriesWithinOnBall f p t x r where
   r_le := hf.r_le
@@ -559,179 +598,38 @@ lemma HasFPowerSeriesAt.hasFPowerSeriesWithinAt (hf : HasFPowerSeriesAt f p x) :
   rw [← hasFPowerSeriesWithinAt_univ] at hf
   apply hf.mono (subset_univ _)
 
-lemma AnalyticWithinAt.mono (hf : AnalyticWithinAt 𝕜 f s x) (h : t ⊆ s) :
-    AnalyticWithinAt 𝕜 f t x := by
-  obtain ⟨p, hp⟩ := hf
-  exact ⟨p, hp.mono h⟩
+theorem HasFPowerSeriesWithinAt.mono_of_mem {f : E → F} {p : FormalMultilinearSeries 𝕜 E F}
+    {s t : Set E} {x : E} (h : HasFPowerSeriesWithinAt f p s x) (hst : s ∈ 𝓝[t] x) :
+    HasFPowerSeriesWithinAt f p t x := by
+  rcases h with ⟨r, hr⟩
+  rcases EMetric.mem_nhdsWithin_iff.1 hst with ⟨r', r'_pos, hr'⟩
+  refine ⟨min r r', ?_⟩
+  have Z := hr.of_le (by simp [r'_pos, hr.r_pos]) (min_le_left r r')
+  refine ⟨Z.r_le, Z.r_pos, fun {y} hy h'y ↦ ?_⟩
+  apply Z.hasSum ?_ h'y
+  simp only [mem_insert_iff, add_right_eq_self] at hy
+  rcases hy with rfl | hy
+  · simp
+  apply mem_insert_of_mem _ (hr' ?_)
+  simp only [EMetric.mem_ball, edist_eq_coe_nnnorm_sub, sub_zero, lt_min_iff, mem_inter_iff,
+    add_sub_cancel_left, hy, and_true] at h'y ⊢
+  exact h'y.2
 
-lemma AnalyticAt.analyticWithinAt (hf : AnalyticAt 𝕜 f x) : AnalyticWithinAt 𝕜 f s x := by
-  rw [← analyticWithinAt_univ] at hf
-  apply hf.mono (subset_univ _)
+@[simp] lemma hasFPowerSeriesWithinOnBall_insert_self {f : E → F}
+    {p : FormalMultilinearSeries 𝕜 E F} {s : Set E} {x : E} {r : ℝ≥0∞} :
+    HasFPowerSeriesWithinOnBall f p (insert x s) x r ↔ HasFPowerSeriesWithinOnBall f p s x r := by
+  refine ⟨fun h ↦ ?_, fun h ↦ ?_⟩  <;>
+  exact ⟨h.r_le, h.r_pos, fun {y} ↦ by simpa only [insert_idem] using h.hasSum (y := y)⟩
 
-lemma AnalyticOn.analyticWithinOn (hf : AnalyticOn 𝕜 f s) : AnalyticWithinOn 𝕜 f s :=
-  fun x hx ↦ (hf x hx).analyticWithinAt
-
-theorem hasFPowerSeriesOnBall_const {c : F} {e : E} :
-    HasFPowerSeriesOnBall (fun _ => c) (constFormalMultilinearSeries 𝕜 E c) e ⊤ := by
-  refine ⟨by simp, WithTop.zero_lt_top, fun _ => hasSum_single 0 fun n hn => ?_⟩
-  simp [constFormalMultilinearSeries_apply hn]
-
-theorem hasFPowerSeriesAt_const {c : F} {e : E} :
-    HasFPowerSeriesAt (fun _ => c) (constFormalMultilinearSeries 𝕜 E c) e :=
-  ⟨⊤, hasFPowerSeriesOnBall_const⟩
-
-theorem analyticAt_const {v : F} : AnalyticAt 𝕜 (fun _ => v) x :=
-  ⟨constFormalMultilinearSeries 𝕜 E v, hasFPowerSeriesAt_const⟩
-
-theorem analyticOn_const {v : F} {s : Set E} : AnalyticOn 𝕜 (fun _ => v) s :=
-  fun _ _ => analyticAt_const
-
-theorem analyticWithinAt_const {v : F} {s : Set E} : AnalyticWithinAt 𝕜 (fun _ => v) s x :=
-  analyticAt_const.analyticWithinAt
-
-theorem analyticWithinOn_const {v : F} {s : Set E} : AnalyticWithinOn 𝕜 (fun _ => v) s :=
-  analyticOn_const.analyticWithinOn
-
-theorem HasFPowerSeriesWithinOnBall.add (hf : HasFPowerSeriesWithinOnBall f pf s x r)
-    (hg : HasFPowerSeriesWithinOnBall g pg s x r) :
-    HasFPowerSeriesWithinOnBall (f + g) (pf + pg) s x r :=
-  { r_le := le_trans (le_min_iff.2 ⟨hf.r_le, hg.r_le⟩) (pf.min_radius_le_radius_add pg)
-    r_pos := hf.r_pos
-    hasSum := fun hy h'y => (hf.hasSum hy h'y).add (hg.hasSum hy h'y) }
-
-theorem HasFPowerSeriesOnBall.add (hf : HasFPowerSeriesOnBall f pf x r)
-    (hg : HasFPowerSeriesOnBall g pg x r) : HasFPowerSeriesOnBall (f + g) (pf + pg) x r :=
-  { r_le := le_trans (le_min_iff.2 ⟨hf.r_le, hg.r_le⟩) (pf.min_radius_le_radius_add pg)
-    r_pos := hf.r_pos
-    hasSum := fun hy => (hf.hasSum hy).add (hg.hasSum hy) }
-
-theorem HasFPowerSeriesWithinAt.add
-    (hf : HasFPowerSeriesWithinAt f pf s x) (hg : HasFPowerSeriesWithinAt g pg s x) :
-    HasFPowerSeriesWithinAt (f + g) (pf + pg) s x := by
-  rcases (hf.eventually.and hg.eventually).exists with ⟨r, hr⟩
-  exact ⟨r, hr.1.add hr.2⟩
-
-theorem HasFPowerSeriesAt.add (hf : HasFPowerSeriesAt f pf x) (hg : HasFPowerSeriesAt g pg x) :
-    HasFPowerSeriesAt (f + g) (pf + pg) x := by
-  rcases (hf.eventually.and hg.eventually).exists with ⟨r, hr⟩
-  exact ⟨r, hr.1.add hr.2⟩
-
-theorem AnalyticAt.congr (hf : AnalyticAt 𝕜 f x) (hg : f =ᶠ[𝓝 x] g) : AnalyticAt 𝕜 g x :=
-  let ⟨_, hpf⟩ := hf
-  (hpf.congr hg).analyticAt
-
-theorem analyticAt_congr (h : f =ᶠ[𝓝 x] g) : AnalyticAt 𝕜 f x ↔ AnalyticAt 𝕜 g x :=
-  ⟨fun hf ↦ hf.congr h, fun hg ↦ hg.congr h.symm⟩
-
-theorem AnalyticWithinAt.add (hf : AnalyticWithinAt 𝕜 f s x) (hg : AnalyticWithinAt 𝕜 g s x) :
-    AnalyticWithinAt 𝕜 (f + g) s x :=
-  let ⟨_, hpf⟩ := hf
-  let ⟨_, hqf⟩ := hg
-  (hpf.add hqf).analyticWithinAt
-
-theorem AnalyticAt.add (hf : AnalyticAt 𝕜 f x) (hg : AnalyticAt 𝕜 g x) : AnalyticAt 𝕜 (f + g) x :=
-  let ⟨_, hpf⟩ := hf
-  let ⟨_, hqf⟩ := hg
-  (hpf.add hqf).analyticAt
-
-theorem HasFPowerSeriesWithinOnBall.neg (hf : HasFPowerSeriesWithinOnBall f pf s x r) :
-    HasFPowerSeriesWithinOnBall (-f) (-pf) s x r :=
-  { r_le := by
-      rw [pf.radius_neg]
-      exact hf.r_le
-    r_pos := hf.r_pos
-    hasSum := fun hy h'y => (hf.hasSum hy h'y).neg }
-
-theorem HasFPowerSeriesOnBall.neg (hf : HasFPowerSeriesOnBall f pf x r) :
-    HasFPowerSeriesOnBall (-f) (-pf) x r :=
-  { r_le := by
-      rw [pf.radius_neg]
-      exact hf.r_le
-    r_pos := hf.r_pos
-    hasSum := fun hy => (hf.hasSum hy).neg }
-
-theorem HasFPowerSeriesWithinAt.neg (hf : HasFPowerSeriesWithinAt f pf s x) :
-    HasFPowerSeriesWithinAt (-f) (-pf) s x :=
-  let ⟨_, hrf⟩ := hf
-  hrf.neg.hasFPowerSeriesWithinAt
-
-theorem HasFPowerSeriesAt.neg (hf : HasFPowerSeriesAt f pf x) : HasFPowerSeriesAt (-f) (-pf) x :=
-  let ⟨_, hrf⟩ := hf
-  hrf.neg.hasFPowerSeriesAt
-
-theorem AnalyticWithinAt.neg (hf : AnalyticWithinAt 𝕜 f s x) : AnalyticWithinAt 𝕜 (-f) s x :=
-  let ⟨_, hpf⟩ := hf
-  hpf.neg.analyticWithinAt
-
-theorem AnalyticAt.neg (hf : AnalyticAt 𝕜 f x) : AnalyticAt 𝕜 (-f) x :=
-  let ⟨_, hpf⟩ := hf
-  hpf.neg.analyticAt
-
-theorem HasFPowerSeriesWithinOnBall.sub (hf : HasFPowerSeriesWithinOnBall f pf s x r)
-    (hg : HasFPowerSeriesWithinOnBall g pg s x r) :
-    HasFPowerSeriesWithinOnBall (f - g) (pf - pg) s x r := by
-  simpa only [sub_eq_add_neg] using hf.add hg.neg
-
-theorem HasFPowerSeriesOnBall.sub (hf : HasFPowerSeriesOnBall f pf x r)
-    (hg : HasFPowerSeriesOnBall g pg x r) : HasFPowerSeriesOnBall (f - g) (pf - pg) x r := by
-  simpa only [sub_eq_add_neg] using hf.add hg.neg
-
-theorem HasFPowerSeriesWithinAt.sub
-    (hf : HasFPowerSeriesWithinAt f pf s x) (hg : HasFPowerSeriesWithinAt g pg s x) :
-    HasFPowerSeriesWithinAt (f - g) (pf - pg) s x := by
-  simpa only [sub_eq_add_neg] using hf.add hg.neg
-
-theorem HasFPowerSeriesAt.sub (hf : HasFPowerSeriesAt f pf x) (hg : HasFPowerSeriesAt g pg x) :
-    HasFPowerSeriesAt (f - g) (pf - pg) x := by
-  simpa only [sub_eq_add_neg] using hf.add hg.neg
-
-theorem AnalyticWithinAt.sub (hf : AnalyticWithinAt 𝕜 f s x) (hg : AnalyticWithinAt 𝕜 g s x) :
-    AnalyticWithinAt 𝕜 (f - g) s x := by
-  simpa only [sub_eq_add_neg] using hf.add hg.neg
-
-theorem AnalyticAt.sub (hf : AnalyticAt 𝕜 f x) (hg : AnalyticAt 𝕜 g x) :
-    AnalyticAt 𝕜 (f - g) x := by
-  simpa only [sub_eq_add_neg] using hf.add hg.neg
-
-theorem AnalyticOn.mono {s t : Set E} (hf : AnalyticOn 𝕜 f t) (hst : s ⊆ t) : AnalyticOn 𝕜 f s :=
-  fun z hz => hf z (hst hz)
-
-theorem AnalyticOn.congr' (hf : AnalyticOn 𝕜 f s) (hg : f =ᶠ[𝓝ˢ s] g) :
-    AnalyticOn 𝕜 g s :=
-  fun z hz => (hf z hz).congr (mem_nhdsSet_iff_forall.mp hg z hz)
-
-theorem analyticOn_congr' (h : f =ᶠ[𝓝ˢ s] g) : AnalyticOn 𝕜 f s ↔ AnalyticOn 𝕜 g s :=
-  ⟨fun hf => hf.congr' h, fun hg => hg.congr' h.symm⟩
-
-theorem AnalyticOn.congr (hs : IsOpen s) (hf : AnalyticOn 𝕜 f s) (hg : s.EqOn f g) :
-    AnalyticOn 𝕜 g s :=
-  hf.congr' <| mem_nhdsSet_iff_forall.mpr
-    (fun _ hz => eventuallyEq_iff_exists_mem.mpr ⟨s, hs.mem_nhds hz, hg⟩)
-
-theorem analyticOn_congr (hs : IsOpen s) (h : s.EqOn f g) : AnalyticOn 𝕜 f s ↔
-    AnalyticOn 𝕜 g s := ⟨fun hf => hf.congr hs h, fun hg => hg.congr hs h.symm⟩
-
-theorem AnalyticWithinOn.add (hf : AnalyticWithinOn 𝕜 f s) (hg : AnalyticWithinOn 𝕜 g s) :
-    AnalyticWithinOn 𝕜 (f + g) s :=
-  fun z hz => (hf z hz).add (hg z hz)
-
-theorem AnalyticOn.add (hf : AnalyticOn 𝕜 f s) (hg : AnalyticOn 𝕜 g s) :
-    AnalyticOn 𝕜 (f + g) s :=
-  fun z hz => (hf z hz).add (hg z hz)
-
-theorem AnalyticWithinOn.neg (hf : AnalyticWithinOn 𝕜 f s) : AnalyticWithinOn 𝕜 (-f) s :=
-  fun z hz ↦ (hf z hz).neg
-
-theorem AnalyticOn.neg (hf : AnalyticOn 𝕜 f s) : AnalyticOn 𝕜 (-f) s :=
-  fun z hz ↦ (hf z hz).neg
-
-theorem AnalyticWithinOn.sub (hf : AnalyticWithinOn 𝕜 f s) (hg : AnalyticWithinOn 𝕜 g s) :
-    AnalyticWithinOn 𝕜 (f - g) s :=
-  fun z hz => (hf z hz).sub (hg z hz)
-
-theorem AnalyticOn.sub (hf : AnalyticOn 𝕜 f s) (hg : AnalyticOn 𝕜 g s) :
-    AnalyticOn 𝕜 (f - g) s :=
-  fun z hz => (hf z hz).sub (hg z hz)
+@[simp] theorem hasFPowerSeriesAt_insert {f : E → F} {p : FormalMultilinearSeries 𝕜 E F}
+    {s : Set E} {x y : E} :
+    HasFPowerSeriesWithinAt f p (insert y s) x ↔ HasFPowerSeriesWithinAt f p s x := by
+  rcases eq_or_ne x y with rfl | hy
+  · simp [HasFPowerSeriesWithinAt]
+  · refine ⟨fun h ↦ h.mono (subset_insert _ _), fun h ↦ ?_⟩
+    apply HasFPowerSeriesWithinAt.mono_of_mem h
+    rw [nhdsWithin_insert_of_ne hy]
+    exact self_mem_nhdsWithin
 
 theorem HasFPowerSeriesWithinOnBall.coeff_zero (hf : HasFPowerSeriesWithinOnBall f pf s x r)
     (v : Fin 0 → E) : pf 0 v = f x := by
@@ -759,17 +657,115 @@ theorem HasFPowerSeriesAt.coeff_zero (hf : HasFPowerSeriesAt f pf x) (v : Fin 0 
   let ⟨_, hrf⟩ := hf
   hrf.coeff_zero v
 
+/-!
+### Analytic functions
+-/
+
+@[simp] lemma analyticWithinAt_univ :
+    AnalyticWithinAt 𝕜 f univ x ↔ AnalyticAt 𝕜 f x := by
+  simp [AnalyticWithinAt, AnalyticAt]
+
+@[simp] lemma analyticWithinOn_univ {f : E → F} :
+    AnalyticWithinOn 𝕜 f univ ↔ AnalyticOn 𝕜 f univ := by
+  simp only [AnalyticWithinOn, analyticWithinAt_univ, AnalyticOn]
+
+lemma AnalyticWithinAt.mono (hf : AnalyticWithinAt 𝕜 f s x) (h : t ⊆ s) :
+    AnalyticWithinAt 𝕜 f t x := by
+  obtain ⟨p, hp⟩ := hf
+  exact ⟨p, hp.mono h⟩
+
+lemma AnalyticAt.analyticWithinAt (hf : AnalyticAt 𝕜 f x) : AnalyticWithinAt 𝕜 f s x := by
+  rw [← analyticWithinAt_univ] at hf
+  apply hf.mono (subset_univ _)
+
+lemma AnalyticOn.analyticWithinOn (hf : AnalyticOn 𝕜 f s) : AnalyticWithinOn 𝕜 f s :=
+  fun x hx ↦ (hf x hx).analyticWithinAt
+
+lemma AnalyticWithinAt.congr_of_eventuallyEq {f g : E → F} {s : Set E} {x : E}
+    (hf : AnalyticWithinAt 𝕜 f s x) (hs : g =ᶠ[𝓝[s] x] f) (hx : g x = f x) :
+    AnalyticWithinAt 𝕜 g s x := by
+  rcases hf with ⟨p, hp⟩
+  exact ⟨p, hp.congr hs hx⟩
+
+lemma AnalyticWithinAt.congr {f g : E → F} {s : Set E} {x : E}
+    (hf : AnalyticWithinAt 𝕜 f s x) (hs : EqOn g f s) (hx : g x = f x) :
+    AnalyticWithinAt 𝕜 g s x :=
+  hf.congr_of_eventuallyEq hs.eventuallyEq_nhdsWithin hx
+
+lemma AnalyticWithinOn.congr {f g : E → F} {s : Set E}
+    (hf : AnalyticWithinOn 𝕜 f s) (hs : EqOn g f s) :
+    AnalyticWithinOn 𝕜 g s :=
+  fun x m ↦ (hf x m).congr hs (hs m)
+
+theorem AnalyticAt.congr (hf : AnalyticAt 𝕜 f x) (hg : f =ᶠ[𝓝 x] g) : AnalyticAt 𝕜 g x :=
+  let ⟨_, hpf⟩ := hf
+  (hpf.congr hg).analyticAt
+
+theorem analyticAt_congr (h : f =ᶠ[𝓝 x] g) : AnalyticAt 𝕜 f x ↔ AnalyticAt 𝕜 g x :=
+  ⟨fun hf ↦ hf.congr h, fun hg ↦ hg.congr h.symm⟩
+
+theorem AnalyticOn.mono {s t : Set E} (hf : AnalyticOn 𝕜 f t) (hst : s ⊆ t) : AnalyticOn 𝕜 f s :=
+  fun z hz => hf z (hst hz)
+
+theorem AnalyticOn.congr' (hf : AnalyticOn 𝕜 f s) (hg : f =ᶠ[𝓝ˢ s] g) :
+    AnalyticOn 𝕜 g s :=
+  fun z hz => (hf z hz).congr (mem_nhdsSet_iff_forall.mp hg z hz)
+
+theorem analyticOn_congr' (h : f =ᶠ[𝓝ˢ s] g) : AnalyticOn 𝕜 f s ↔ AnalyticOn 𝕜 g s :=
+  ⟨fun hf => hf.congr' h, fun hg => hg.congr' h.symm⟩
+
+theorem AnalyticOn.congr (hs : IsOpen s) (hf : AnalyticOn 𝕜 f s) (hg : s.EqOn f g) :
+    AnalyticOn 𝕜 g s :=
+  hf.congr' <| mem_nhdsSet_iff_forall.mpr
+    (fun _ hz => eventuallyEq_iff_exists_mem.mpr ⟨s, hs.mem_nhds hz, hg⟩)
+
+theorem analyticOn_congr (hs : IsOpen s) (h : s.EqOn f g) : AnalyticOn 𝕜 f s ↔
+    AnalyticOn 𝕜 g s := ⟨fun hf => hf.congr hs h, fun hg => hg.congr hs h.symm⟩
+
+theorem AnalyticWithinAt.mono_of_mem {f : E → F} {s t : Set E} {x : E}
+    (h : AnalyticWithinAt 𝕜 f s x) (hst : s ∈ 𝓝[t] x) : AnalyticWithinAt 𝕜 f t x := by
+  rcases h with ⟨p, hp⟩
+  exact ⟨p, hp.mono_of_mem hst⟩
+
+lemma AnalyticWithinOn.mono {f : E → F} {s t : Set E} (h : AnalyticWithinOn 𝕜 f t)
+    (hs : s ⊆ t) : AnalyticWithinOn 𝕜 f s :=
+  fun _ m ↦ (h _ (hs m)).mono hs
+
+@[simp] theorem analyticWithinAt_insert {f : E → F} {s : Set E} {x y : E} :
+    AnalyticWithinAt 𝕜 f (insert y s) x ↔ AnalyticWithinAt 𝕜 f s x := by
+  simp [AnalyticWithinAt]
+
+/-!
+### Composition with linear maps
+-/
+
+/-- If a function `f` has a power series `p` on a ball within a set and `g` is linear,
+then `g ∘ f` has the power series `g ∘ p` on the same ball. -/
+theorem ContinuousLinearMap.comp_hasFPowerSeriesWithinOnBall (g : F →L[𝕜] G)
+    (h : HasFPowerSeriesWithinOnBall f p s x r) :
+    HasFPowerSeriesWithinOnBall (g ∘ f) (g.compFormalMultilinearSeries p) s x r where
+  r_le := h.r_le.trans (p.radius_le_radius_continuousLinearMap_comp _)
+  r_pos := h.r_pos
+  hasSum := fun hy h'y => by
+    simpa only [ContinuousLinearMap.compFormalMultilinearSeries_apply,
+      ContinuousLinearMap.compContinuousMultilinearMap_coe, Function.comp_apply] using
+      g.hasSum (h.hasSum hy h'y)
+
 /-- If a function `f` has a power series `p` on a ball and `g` is linear, then `g ∘ f` has the
 power series `g ∘ p` on the same ball. -/
 theorem ContinuousLinearMap.comp_hasFPowerSeriesOnBall (g : F →L[𝕜] G)
     (h : HasFPowerSeriesOnBall f p x r) :
-    HasFPowerSeriesOnBall (g ∘ f) (g.compFormalMultilinearSeries p) x r :=
-  { r_le := h.r_le.trans (p.radius_le_radius_continuousLinearMap_comp _)
-    r_pos := h.r_pos
-    hasSum := fun hy => by
-      simpa only [ContinuousLinearMap.compFormalMultilinearSeries_apply,
-        ContinuousLinearMap.compContinuousMultilinearMap_coe, Function.comp_apply] using
-        g.hasSum (h.hasSum hy) }
+    HasFPowerSeriesOnBall (g ∘ f) (g.compFormalMultilinearSeries p) x r := by
+  rw [← hasFPowerSeriesWithinOnBall_univ] at h ⊢
+  exact g.comp_hasFPowerSeriesWithinOnBall h
+
+/-- If a function `f` is analytic on a set `s` and `g` is linear, then `g ∘ f` is analytic
+on `s`. -/
+theorem ContinuousLinearMap.comp_analyticWithinOn (g : F →L[𝕜] G) (h : AnalyticWithinOn 𝕜 f s) :
+    AnalyticWithinOn 𝕜 (g ∘ f) s := by
+  rintro x hx
+  rcases h x hx with ⟨p, r, hp⟩
+  exact ⟨g.compFormalMultilinearSeries p, r, g.comp_hasFPowerSeriesWithinOnBall hp⟩
 
 /-- If a function `f` is analytic on a set `s` and `g` is linear, then `g ∘ f` is analytic
 on `s`. -/
@@ -778,6 +774,10 @@ theorem ContinuousLinearMap.comp_analyticOn {s : Set E} (g : F →L[𝕜] G) (h 
   rintro x hx
   rcases h x hx with ⟨p, r, hp⟩
   exact ⟨g.compFormalMultilinearSeries p, r, g.comp_hasFPowerSeriesOnBall hp⟩
+
+/-!
+### Relation between analytic function and the partial sums of its power series
+-/
 
 theorem HasFPowerSeriesWithinOnBall.tendsto_partialSum
     (hf : HasFPowerSeriesWithinOnBall f p s x r) {y : E} (hy : y ∈ EMetric.ball (0 : E) r)
@@ -1245,6 +1245,10 @@ protected theorem AnalyticAt.continuousAt (hf : AnalyticAt 𝕜 f x) : Continuou
 protected theorem AnalyticOn.continuousOn {s : Set E} (hf : AnalyticOn 𝕜 f s) : ContinuousOn f s :=
   fun x hx => (hf x hx).continuousAt.continuousWithinAt
 
+protected lemma AnalyticWithinOn.continuousOn {f : E → F} {s : Set E} (h : AnalyticWithinOn 𝕜 f s) :
+    ContinuousOn f s :=
+  fun x m ↦ (h x m).continuousWithinAt
+
 /-- Analytic everywhere implies continuous -/
 theorem AnalyticOn.continuous {f : E → F} (fa : AnalyticOn 𝕜 f univ) : Continuous f := by
   rw [continuous_iff_continuousOn_univ]; exact fa.continuousOn
@@ -1260,6 +1264,10 @@ protected theorem FormalMultilinearSeries.hasFPowerSeriesOnBall [CompleteSpace F
       rw [zero_add]
       exact p.hasSum hy }
 
+theorem HasFPowerSeriesWithinOnBall.sum (h : HasFPowerSeriesWithinOnBall f p s x r) {y : E}
+    (h'y : x + y ∈ insert x s) (hy : y ∈ EMetric.ball (0 : E) r) : f (x + y) = p.sum y :=
+  (h.hasSum h'y hy).tsum_eq.symm
+
 theorem HasFPowerSeriesOnBall.sum (h : HasFPowerSeriesOnBall f p x r) {y : E}
     (hy : y ∈ EMetric.ball (0 : E) r) : f (x + y) = p.sum y :=
   (h.hasSum hy).tsum_eq.symm
@@ -1272,137 +1280,6 @@ protected theorem FormalMultilinearSeries.continuousOn [CompleteSpace F] :
   · exact (p.hasFPowerSeriesOnBall h).continuousOn
 
 end
-
-/-!
-### Uniqueness of power series
-If a function `f : E → F` has two representations as power series at a point `x : E`, corresponding
-to formal multilinear series `p₁` and `p₂`, then these representations agree term-by-term. That is,
-for any `n : ℕ` and `y : E`, `p₁ n (fun i ↦ y) = p₂ n (fun i ↦ y)`. In the one-dimensional case,
-when `f : 𝕜 → E`, the continuous multilinear maps `p₁ n` and `p₂ n` are given by
-`ContinuousMultilinearMap.mkPiRing`, and hence are determined completely by the value of
-`p₁ n (fun i ↦ 1)`, so `p₁ = p₂`. Consequently, the radius of convergence for one series can be
-transferred to the other.
--/
-
-
-section Uniqueness
-
-open ContinuousMultilinearMap
-
-theorem Asymptotics.IsBigO.continuousMultilinearMap_apply_eq_zero {n : ℕ} {p : E[×n]→L[𝕜] F}
-    (h : (fun y => p fun _ => y) =O[𝓝 0] fun y => ‖y‖ ^ (n + 1)) (y : E) : (p fun _ => y) = 0 := by
-  obtain ⟨c, c_pos, hc⟩ := h.exists_pos
-  obtain ⟨t, ht, t_open, z_mem⟩ := eventually_nhds_iff.mp (isBigOWith_iff.mp hc)
-  obtain ⟨δ, δ_pos, δε⟩ := (Metric.isOpen_iff.mp t_open) 0 z_mem
-  clear h hc z_mem
-  cases' n with n
-  · exact norm_eq_zero.mp (by
-      -- Porting note: the symmetric difference of the `simpa only` sets:
-      -- added `zero_add, pow_one`
-      -- removed `zero_pow, Ne.def, Nat.one_ne_zero, not_false_iff`
-      simpa only [fin0_apply_norm, norm_eq_zero, norm_zero, zero_add, pow_one,
-        mul_zero, norm_le_zero_iff] using ht 0 (δε (Metric.mem_ball_self δ_pos)))
-  · refine Or.elim (Classical.em (y = 0))
-      (fun hy => by simpa only [hy] using p.map_zero) fun hy => ?_
-    replace hy := norm_pos_iff.mpr hy
-    refine norm_eq_zero.mp (le_antisymm (le_of_forall_pos_le_add fun ε ε_pos => ?_) (norm_nonneg _))
-    have h₀ := _root_.mul_pos c_pos (pow_pos hy (n.succ + 1))
-    obtain ⟨k, k_pos, k_norm⟩ := NormedField.exists_norm_lt 𝕜
-      (lt_min (mul_pos δ_pos (inv_pos.mpr hy)) (mul_pos ε_pos (inv_pos.mpr h₀)))
-    have h₁ : ‖k • y‖ < δ := by
-      rw [norm_smul]
-      exact inv_mul_cancel_right₀ hy.ne.symm δ ▸
-        mul_lt_mul_of_pos_right (lt_of_lt_of_le k_norm (min_le_left _ _)) hy
-    have h₂ :=
-      calc
-        ‖p fun _ => k • y‖ ≤ c * ‖k • y‖ ^ (n.succ + 1) := by
-          -- Porting note: now Lean wants `_root_.`
-          simpa only [norm_pow, _root_.norm_norm] using ht (k • y) (δε (mem_ball_zero_iff.mpr h₁))
-          --simpa only [norm_pow, norm_norm] using ht (k • y) (δε (mem_ball_zero_iff.mpr h₁))
-        _ = ‖k‖ ^ n.succ * (‖k‖ * (c * ‖y‖ ^ (n.succ + 1))) := by
-          -- Porting note: added `Nat.succ_eq_add_one` since otherwise `ring` does not conclude.
-          simp only [norm_smul, mul_pow, Nat.succ_eq_add_one]
-          -- Porting note: removed `rw [pow_succ]`, since it now becomes superfluous.
-          ring
-    have h₃ : ‖k‖ * (c * ‖y‖ ^ (n.succ + 1)) < ε :=
-      inv_mul_cancel_right₀ h₀.ne.symm ε ▸
-        mul_lt_mul_of_pos_right (lt_of_lt_of_le k_norm (min_le_right _ _)) h₀
-    calc
-      ‖p fun _ => y‖ = ‖k⁻¹ ^ n.succ‖ * ‖p fun _ => k • y‖ := by
-        simpa only [inv_smul_smul₀ (norm_pos_iff.mp k_pos), norm_smul, Finset.prod_const,
-          Finset.card_fin] using
-          congr_arg norm (p.map_smul_univ (fun _ : Fin n.succ => k⁻¹) fun _ : Fin n.succ => k • y)
-      _ ≤ ‖k⁻¹ ^ n.succ‖ * (‖k‖ ^ n.succ * (‖k‖ * (c * ‖y‖ ^ (n.succ + 1)))) := by gcongr
-      _ = ‖(k⁻¹ * k) ^ n.succ‖ * (‖k‖ * (c * ‖y‖ ^ (n.succ + 1))) := by
-        rw [← mul_assoc]
-        simp [norm_mul, mul_pow]
-      _ ≤ 0 + ε := by
-        rw [inv_mul_cancel₀ (norm_pos_iff.mp k_pos)]
-        simpa using h₃.le
-
-/-- If a formal multilinear series `p` represents the zero function at `x : E`, then the
-terms `p n (fun i ↦ y)` appearing in the sum are zero for any `n : ℕ`, `y : E`. -/
-theorem HasFPowerSeriesAt.apply_eq_zero {p : FormalMultilinearSeries 𝕜 E F} {x : E}
-    (h : HasFPowerSeriesAt 0 p x) (n : ℕ) : ∀ y : E, (p n fun _ => y) = 0 := by
-  refine Nat.strong_induction_on n fun k hk => ?_
-  have psum_eq : p.partialSum (k + 1) = fun y => p k fun _ => y := by
-    funext z
-    refine Finset.sum_eq_single _ (fun b hb hnb => ?_) fun hn => ?_
-    · have := Finset.mem_range_succ_iff.mp hb
-      simp only [hk b (this.lt_of_ne hnb), Pi.zero_apply]
-    · exact False.elim (hn (Finset.mem_range.mpr (lt_add_one k)))
-  replace h := h.isBigO_sub_partialSum_pow k.succ
-  simp only [psum_eq, zero_sub, Pi.zero_apply, Asymptotics.isBigO_neg_left] at h
-  exact h.continuousMultilinearMap_apply_eq_zero
-
-/-- A one-dimensional formal multilinear series representing the zero function is zero. -/
-theorem HasFPowerSeriesAt.eq_zero {p : FormalMultilinearSeries 𝕜 𝕜 E} {x : 𝕜}
-    (h : HasFPowerSeriesAt 0 p x) : p = 0 := by
-  ext n x
-  rw [← mkPiRing_apply_one_eq_self (p n)]
-  simp [h.apply_eq_zero n 1]
-
-/-- One-dimensional formal multilinear series representing the same function are equal. -/
-theorem HasFPowerSeriesAt.eq_formalMultilinearSeries {p₁ p₂ : FormalMultilinearSeries 𝕜 𝕜 E}
-    {f : 𝕜 → E} {x : 𝕜} (h₁ : HasFPowerSeriesAt f p₁ x) (h₂ : HasFPowerSeriesAt f p₂ x) : p₁ = p₂ :=
-  sub_eq_zero.mp (HasFPowerSeriesAt.eq_zero (x := x) (by simpa only [sub_self] using h₁.sub h₂))
-
-theorem HasFPowerSeriesAt.eq_formalMultilinearSeries_of_eventually
-    {p q : FormalMultilinearSeries 𝕜 𝕜 E} {f g : 𝕜 → E} {x : 𝕜} (hp : HasFPowerSeriesAt f p x)
-    (hq : HasFPowerSeriesAt g q x) (heq : ∀ᶠ z in 𝓝 x, f z = g z) : p = q :=
-  (hp.congr heq).eq_formalMultilinearSeries hq
-
-/-- A one-dimensional formal multilinear series representing a locally zero function is zero. -/
-theorem HasFPowerSeriesAt.eq_zero_of_eventually {p : FormalMultilinearSeries 𝕜 𝕜 E} {f : 𝕜 → E}
-    {x : 𝕜} (hp : HasFPowerSeriesAt f p x) (hf : f =ᶠ[𝓝 x] 0) : p = 0 :=
-  (hp.congr hf).eq_zero
-
-/-- If a function `f : 𝕜 → E` has two power series representations at `x`, then the given radii in
-which convergence is guaranteed may be interchanged. This can be useful when the formal multilinear
-series in one representation has a particularly nice form, but the other has a larger radius. -/
-theorem HasFPowerSeriesOnBall.exchange_radius {p₁ p₂ : FormalMultilinearSeries 𝕜 𝕜 E} {f : 𝕜 → E}
-    {r₁ r₂ : ℝ≥0∞} {x : 𝕜} (h₁ : HasFPowerSeriesOnBall f p₁ x r₁)
-    (h₂ : HasFPowerSeriesOnBall f p₂ x r₂) : HasFPowerSeriesOnBall f p₁ x r₂ :=
-  h₂.hasFPowerSeriesAt.eq_formalMultilinearSeries h₁.hasFPowerSeriesAt ▸ h₂
-
-/-- If a function `f : 𝕜 → E` has power series representation `p` on a ball of some radius and for
-each positive radius it has some power series representation, then `p` converges to `f` on the whole
-`𝕜`. -/
-theorem HasFPowerSeriesOnBall.r_eq_top_of_exists {f : 𝕜 → E} {r : ℝ≥0∞} {x : 𝕜}
-    {p : FormalMultilinearSeries 𝕜 𝕜 E} (h : HasFPowerSeriesOnBall f p x r)
-    (h' : ∀ (r' : ℝ≥0) (_ : 0 < r'), ∃ p' : FormalMultilinearSeries 𝕜 𝕜 E,
-      HasFPowerSeriesOnBall f p' x r') :
-    HasFPowerSeriesOnBall f p x ∞ :=
-  { r_le := ENNReal.le_of_forall_pos_nnreal_lt fun r hr _ =>
-      let ⟨_, hp'⟩ := h' r hr
-      (h.exchange_radius hp').r_le
-    r_pos := ENNReal.coe_lt_top
-    hasSum := fun {y} _ =>
-      let ⟨r', hr'⟩ := exists_gt ‖y‖₊
-      let ⟨_, hp'⟩ := h' r' hr'.ne_bot.bot_lt
-      (h.exchange_radius hp').hasSum <| mem_emetric_ball_zero_iff.mpr (ENNReal.coe_lt_coe.2 hr') }
-
-end Uniqueness
 
 section
 

--- a/Mathlib/Analysis/Analytic/Basic.lean
+++ b/Mathlib/Analysis/Analytic/Basic.lean
@@ -475,14 +475,6 @@ lemma HasFPowerSeriesWithinOnBall.congr {f g : E → F} {p : FormalMultilinearSe
     refine ⟨hy, ?_⟩
     simpa [edist_eq_coe_nnnorm_sub] using h'y
 
-lemma HasFPowerSeriesWithinOnBall.congr' {f g : E → F} {p : FormalMultilinearSeries 𝕜 E F}
-    {s : Set E} {x : E} {r : ℝ≥0∞} (h : HasFPowerSeriesWithinOnBall f p s x r)
-    (h' : EqOn g f (insert x s ∩ EMetric.ball x r)) :
-    HasFPowerSeriesWithinOnBall g p s x r := by
-  refine ⟨h.r_le, h.r_pos, fun {y} hy h'y ↦ ?_⟩
-  convert h.hasSum hy h'y using 1
-  exact h' ⟨hy, by simpa [edist_eq_coe_nnnorm_sub] using h'y⟩
-
 lemma HasFPowerSeriesWithinAt.congr {f g : E → F} {p : FormalMultilinearSeries 𝕜 E F} {s : Set E}
     {x : E} (h : HasFPowerSeriesWithinAt f p s x) (h' : g =ᶠ[𝓝[s] x] f) (h'' : g x = f x) :
     HasFPowerSeriesWithinAt g p s x := by
@@ -586,39 +578,6 @@ lemma HasFPowerSeriesAt.hasFPowerSeriesWithinAt (hf : HasFPowerSeriesAt f p x) :
   rw [← hasFPowerSeriesWithinAt_univ] at hf
   apply hf.mono (subset_univ _)
 
-theorem HasFPowerSeriesWithinAt.mono_of_mem {f : E → F} {p : FormalMultilinearSeries 𝕜 E F}
-    {s t : Set E} {x : E} (h : HasFPowerSeriesWithinAt f p s x) (hst : s ∈ 𝓝[t] x) :
-    HasFPowerSeriesWithinAt f p t x := by
-  rcases h with ⟨r, hr⟩
-  rcases EMetric.mem_nhdsWithin_iff.1 hst with ⟨r', r'_pos, hr'⟩
-  refine ⟨min r r', ?_⟩
-  have Z := hr.of_le (by simp [r'_pos, hr.r_pos]) (min_le_left r r')
-  refine ⟨Z.r_le, Z.r_pos, fun {y} hy h'y ↦ ?_⟩
-  apply Z.hasSum ?_ h'y
-  simp only [mem_insert_iff, add_right_eq_self] at hy
-  rcases hy with rfl | hy
-  · simp
-  apply mem_insert_of_mem _ (hr' ?_)
-  simp only [EMetric.mem_ball, edist_eq_coe_nnnorm_sub, sub_zero, lt_min_iff, mem_inter_iff,
-    add_sub_cancel_left, hy, and_true] at h'y ⊢
-  exact h'y.2
-
-@[simp] lemma hasFPowerSeriesWithinOnBall_insert_self {f : E → F}
-    {p : FormalMultilinearSeries 𝕜 E F} {s : Set E} {x : E} {r : ℝ≥0∞} :
-    HasFPowerSeriesWithinOnBall f p (insert x s) x r ↔ HasFPowerSeriesWithinOnBall f p s x r := by
-  refine ⟨fun h ↦ ?_, fun h ↦ ?_⟩  <;>
-  exact ⟨h.r_le, h.r_pos, fun {y} ↦ by simpa only [insert_idem] using h.hasSum (y := y)⟩
-
-@[simp] theorem hasFPowerSeriesAt_insert {f : E → F} {p : FormalMultilinearSeries 𝕜 E F}
-    {s : Set E} {x y : E} :
-    HasFPowerSeriesWithinAt f p (insert y s) x ↔ HasFPowerSeriesWithinAt f p s x := by
-  rcases eq_or_ne x y with rfl | hy
-  · simp [HasFPowerSeriesWithinAt]
-  · refine ⟨fun h ↦ h.mono (subset_insert _ _), fun h ↦ ?_⟩
-    apply HasFPowerSeriesWithinAt.mono_of_mem h
-    rw [nhdsWithin_insert_of_ne hy]
-    exact self_mem_nhdsWithin
-
 theorem HasFPowerSeriesWithinOnBall.coeff_zero (hf : HasFPowerSeriesWithinOnBall f pf s x r)
     (v : Fin 0 → E) : pf 0 v = f x := by
   have v_eq : v = fun i => 0 := Subsingleton.elim _ _
@@ -710,18 +669,9 @@ theorem AnalyticOn.congr (hs : IsOpen s) (hf : AnalyticOn 𝕜 f s) (hg : s.EqOn
 theorem analyticOn_congr (hs : IsOpen s) (h : s.EqOn f g) : AnalyticOn 𝕜 f s ↔
     AnalyticOn 𝕜 g s := ⟨fun hf => hf.congr hs h, fun hg => hg.congr hs h.symm⟩
 
-theorem AnalyticWithinAt.mono_of_mem {f : E → F} {s t : Set E} {x : E}
-    (h : AnalyticWithinAt 𝕜 f s x) (hst : s ∈ 𝓝[t] x) : AnalyticWithinAt 𝕜 f t x := by
-  rcases h with ⟨p, hp⟩
-  exact ⟨p, hp.mono_of_mem hst⟩
-
 lemma AnalyticWithinOn.mono {f : E → F} {s t : Set E} (h : AnalyticWithinOn 𝕜 f t)
     (hs : s ⊆ t) : AnalyticWithinOn 𝕜 f s :=
   fun _ m ↦ (h _ (hs m)).mono hs
-
-@[simp] theorem analyticWithinAt_insert {f : E → F} {s : Set E} {x y : E} :
-    AnalyticWithinAt 𝕜 f (insert y s) x ↔ AnalyticWithinAt 𝕜 f s x := by
-  simp [AnalyticWithinAt]
 
 /-!
 ### Composition with linear maps
@@ -1235,10 +1185,6 @@ protected theorem FormalMultilinearSeries.hasFPowerSeriesOnBall [CompleteSpace F
     hasSum := fun hy => by
       rw [zero_add]
       exact p.hasSum hy }
-
-theorem HasFPowerSeriesWithinOnBall.sum (h : HasFPowerSeriesWithinOnBall f p s x r) {y : E}
-    (h'y : x + y ∈ insert x s) (hy : y ∈ EMetric.ball (0 : E) r) : f (x + y) = p.sum y :=
-  (h.hasSum h'y hy).tsum_eq.symm
 
 theorem HasFPowerSeriesOnBall.sum (h : HasFPowerSeriesOnBall f p x r) {y : E}
     (hy : y ∈ EMetric.ball (0 : E) r) : f (x + y) = p.sum y :=

--- a/Mathlib/Analysis/Analytic/CPolynomial.lean
+++ b/Mathlib/Analysis/Analytic/CPolynomial.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Sophie Morel
 -/
 import Mathlib.Analysis.Analytic.ChangeOrigin
+import Mathlib.Analysis.Analytic.Constructions
 
 /-! We specialize the theory fo analytic functions to the case of functions that admit a
 development given by a *finite* formal multilinear series. We call them "continuously polynomial",

--- a/Mathlib/Analysis/Analytic/ChangeOrigin.lean
+++ b/Mathlib/Analysis/Analytic/ChangeOrigin.lean
@@ -36,7 +36,7 @@ that the set of points at which a given function is analytic is open, see `isOpe
 noncomputable section
 
 open scoped NNReal ENNReal Topology
-open Filter
+open Filter Set
 
 variable {𝕜 E F : Type*} [NontriviallyNormedField 𝕜] [NormedAddCommGroup E] [NormedSpace 𝕜 E]
 [NormedAddCommGroup F] [NormedSpace 𝕜 F]
@@ -226,6 +226,12 @@ def derivSeries : FormalMultilinearSeries 𝕜 E (E →L[𝕜] F) :=
   (continuousMultilinearCurryFin1 𝕜 E F : (E[×1]→L[𝕜] F) →L[𝕜] E →L[𝕜] F)
     |>.compFormalMultilinearSeries (p.changeOriginSeries 1)
 
+theorem radius_le_radius_derivSeries : p.radius ≤ p.derivSeries.radius := by
+  apply (p.le_changeOriginSeries_radius 1).trans (radius_le_of_le (fun n ↦ ?_))
+  apply (ContinuousLinearMap.norm_compContinuousMultilinearMap_le _ _).trans
+  apply mul_le_of_le_one_left (norm_nonneg  _)
+  exact ContinuousLinearMap.opNorm_le_bound _ zero_le_one (by simp)
+
 end
 
 -- From this point on, assume that the space is complete, to make sure that series that converge
@@ -284,39 +290,69 @@ theorem analyticAt_changeOrigin (p : FormalMultilinearSeries 𝕜 E F) (rp : p.r
 
 end FormalMultilinearSeries
 
+
 section
 
-variable [CompleteSpace F] {f : E → F} {p : FormalMultilinearSeries 𝕜 E F} {x y : E} {r : ℝ≥0∞}
+variable [CompleteSpace F] {f : E → F} {p : FormalMultilinearSeries 𝕜 E F} {s : Set E}
+  {x y : E} {r : ℝ≥0∞}
+
+/-- If a function admits a power series expansion `p` within a set `s` on a ball `B (x, r)`, then
+it  also admits a power series on any subball of this ball (even with a different center provided
+it belongs to `s`), given by `p.changeOrigin`. -/
+theorem HasFPowerSeriesWithinOnBall.changeOrigin (hf : HasFPowerSeriesWithinOnBall f p s x r)
+    (h : (‖y‖₊ : ℝ≥0∞) < r) (hy : x + y ∈ insert x s) :
+    HasFPowerSeriesWithinOnBall f (p.changeOrigin y) s (x + y) (r - ‖y‖₊) where
+  r_le := by
+    apply le_trans _ p.changeOrigin_radius
+    exact tsub_le_tsub hf.r_le le_rfl
+  r_pos := by simp [h]
+  hasSum := fun {z} h'z hz => by
+    have : f (x + y + z) =
+        FormalMultilinearSeries.sum (FormalMultilinearSeries.changeOrigin p y) z := by
+      rw [mem_emetric_ball_zero_iff, lt_tsub_iff_right, add_comm] at hz
+      rw [p.changeOrigin_eval (hz.trans_le hf.r_le), add_assoc, hf.sum]
+      · have : insert (x + y) s ⊆ insert (x + y) (insert x s) := by
+          apply insert_subset_insert (subset_insert _ _)
+        rw [insert_eq_of_mem hy] at this
+        apply this
+        simpa [add_assoc] using h'z
+      refine mem_emetric_ball_zero_iff.2 (lt_of_le_of_lt ?_ hz)
+      exact mod_cast nnnorm_add_le y z
+    rw [this]
+    apply (p.changeOrigin y).hasSum
+    refine EMetric.ball_subset_ball (le_trans ?_ p.changeOrigin_radius) hz
+    exact tsub_le_tsub hf.r_le le_rfl
 
 /-- If a function admits a power series expansion `p` on a ball `B (x, r)`, then it also admits a
 power series on any subball of this ball (even with a different center), given by `p.changeOrigin`.
 -/
 theorem HasFPowerSeriesOnBall.changeOrigin (hf : HasFPowerSeriesOnBall f p x r)
-    (h : (‖y‖₊ : ℝ≥0∞) < r) : HasFPowerSeriesOnBall f (p.changeOrigin y) (x + y) (r - ‖y‖₊) :=
-  { r_le := by
-      apply le_trans _ p.changeOrigin_radius
-      exact tsub_le_tsub hf.r_le le_rfl
-    r_pos := by simp [h]
-    hasSum := fun {z} hz => by
-      have : f (x + y + z) =
-          FormalMultilinearSeries.sum (FormalMultilinearSeries.changeOrigin p y) z := by
-        rw [mem_emetric_ball_zero_iff, lt_tsub_iff_right, add_comm] at hz
-        rw [p.changeOrigin_eval (hz.trans_le hf.r_le), add_assoc, hf.sum]
-        refine mem_emetric_ball_zero_iff.2 (lt_of_le_of_lt ?_ hz)
-        exact mod_cast nnnorm_add_le y z
-      rw [this]
-      apply (p.changeOrigin y).hasSum
-      refine EMetric.ball_subset_ball (le_trans ?_ p.changeOrigin_radius) hz
-      exact tsub_le_tsub hf.r_le le_rfl }
+    (h : (‖y‖₊ : ℝ≥0∞) < r) : HasFPowerSeriesOnBall f (p.changeOrigin y) (x + y) (r - ‖y‖₊) := by
+  rw [← hasFPowerSeriesWithinOnBall_univ] at hf ⊢
+  exact hf.changeOrigin h (by simp)
+
+/-- If a function admits a power series expansion `p` on an open ball `B (x, r)`, then
+it is analytic at every point of this ball. -/
+theorem HasFPowerSeriesWithinOnBall.analyticWithinAt_of_mem
+    (hf : HasFPowerSeriesWithinOnBall f p s x r)
+    (h : y ∈ insert x s ∩ EMetric.ball x r) : AnalyticWithinAt 𝕜 f s y := by
+  have : (‖y - x‖₊ : ℝ≥0∞) < r := by simpa [edist_eq_coe_nnnorm_sub] using h.2
+  have := hf.changeOrigin this (by simpa using h.1)
+  rw [add_sub_cancel] at this
+  exact this.analyticWithinAt
 
 /-- If a function admits a power series expansion `p` on an open ball `B (x, r)`, then
 it is analytic at every point of this ball. -/
 theorem HasFPowerSeriesOnBall.analyticAt_of_mem (hf : HasFPowerSeriesOnBall f p x r)
     (h : y ∈ EMetric.ball x r) : AnalyticAt 𝕜 f y := by
-  have : (‖y - x‖₊ : ℝ≥0∞) < r := by simpa [edist_eq_coe_nnnorm_sub] using h
-  have := hf.changeOrigin this
-  rw [add_sub_cancel] at this
-  exact this.analyticAt
+  rw [← hasFPowerSeriesWithinOnBall_univ] at hf
+  rw [← analyticWithinAt_univ]
+  exact hf.analyticWithinAt_of_mem (by simpa using h)
+
+theorem HasFPowerSeriesWithinOnBall.analyticWithinOn (hf : HasFPowerSeriesWithinOnBall f p s x r) :
+    AnalyticWithinOn 𝕜 f (insert x s ∩ EMetric.ball x r) :=
+  fun _ hy ↦ ((analyticWithinAt_insert (y := x)).2 (hf.analyticWithinAt_of_mem hy)).mono
+    inter_subset_left
 
 theorem HasFPowerSeriesOnBall.analyticOn (hf : HasFPowerSeriesOnBall f p x r) :
     AnalyticOn 𝕜 f (EMetric.ball x r) :=

--- a/Mathlib/Analysis/Analytic/ChangeOrigin.lean
+++ b/Mathlib/Analysis/Analytic/ChangeOrigin.lean
@@ -226,12 +226,6 @@ def derivSeries : FormalMultilinearSeries 𝕜 E (E →L[𝕜] F) :=
   (continuousMultilinearCurryFin1 𝕜 E F : (E[×1]→L[𝕜] F) →L[𝕜] E →L[𝕜] F)
     |>.compFormalMultilinearSeries (p.changeOriginSeries 1)
 
-theorem radius_le_radius_derivSeries : p.radius ≤ p.derivSeries.radius := by
-  apply (p.le_changeOriginSeries_radius 1).trans (radius_le_of_le (fun n ↦ ?_))
-  apply (ContinuousLinearMap.norm_compContinuousMultilinearMap_le _ _).trans
-  apply mul_le_of_le_one_left (norm_nonneg  _)
-  exact ContinuousLinearMap.opNorm_le_bound _ zero_le_one (by simp)
-
 end
 
 -- From this point on, assume that the space is complete, to make sure that series that converge
@@ -293,66 +287,37 @@ end FormalMultilinearSeries
 
 section
 
-variable [CompleteSpace F] {f : E → F} {p : FormalMultilinearSeries 𝕜 E F} {s : Set E}
-  {x y : E} {r : ℝ≥0∞}
-
-/-- If a function admits a power series expansion `p` within a set `s` on a ball `B (x, r)`, then
-it  also admits a power series on any subball of this ball (even with a different center provided
-it belongs to `s`), given by `p.changeOrigin`. -/
-theorem HasFPowerSeriesWithinOnBall.changeOrigin (hf : HasFPowerSeriesWithinOnBall f p s x r)
-    (h : (‖y‖₊ : ℝ≥0∞) < r) (hy : x + y ∈ insert x s) :
-    HasFPowerSeriesWithinOnBall f (p.changeOrigin y) s (x + y) (r - ‖y‖₊) where
-  r_le := by
-    apply le_trans _ p.changeOrigin_radius
-    exact tsub_le_tsub hf.r_le le_rfl
-  r_pos := by simp [h]
-  hasSum := fun {z} h'z hz => by
-    have : f (x + y + z) =
-        FormalMultilinearSeries.sum (FormalMultilinearSeries.changeOrigin p y) z := by
-      rw [mem_emetric_ball_zero_iff, lt_tsub_iff_right, add_comm] at hz
-      rw [p.changeOrigin_eval (hz.trans_le hf.r_le), add_assoc, hf.sum]
-      · have : insert (x + y) s ⊆ insert (x + y) (insert x s) := by
-          apply insert_subset_insert (subset_insert _ _)
-        rw [insert_eq_of_mem hy] at this
-        apply this
-        simpa [add_assoc] using h'z
-      refine mem_emetric_ball_zero_iff.2 (lt_of_le_of_lt ?_ hz)
-      exact mod_cast nnnorm_add_le y z
-    rw [this]
-    apply (p.changeOrigin y).hasSum
-    refine EMetric.ball_subset_ball (le_trans ?_ p.changeOrigin_radius) hz
-    exact tsub_le_tsub hf.r_le le_rfl
+variable [CompleteSpace F] {f : E → F} {p : FormalMultilinearSeries 𝕜 E F} {x y : E} {r : ℝ≥0∞}
 
 /-- If a function admits a power series expansion `p` on a ball `B (x, r)`, then it also admits a
 power series on any subball of this ball (even with a different center), given by `p.changeOrigin`.
 -/
 theorem HasFPowerSeriesOnBall.changeOrigin (hf : HasFPowerSeriesOnBall f p x r)
-    (h : (‖y‖₊ : ℝ≥0∞) < r) : HasFPowerSeriesOnBall f (p.changeOrigin y) (x + y) (r - ‖y‖₊) := by
-  rw [← hasFPowerSeriesWithinOnBall_univ] at hf ⊢
-  exact hf.changeOrigin h (by simp)
-
-/-- If a function admits a power series expansion `p` on an open ball `B (x, r)`, then
-it is analytic at every point of this ball. -/
-theorem HasFPowerSeriesWithinOnBall.analyticWithinAt_of_mem
-    (hf : HasFPowerSeriesWithinOnBall f p s x r)
-    (h : y ∈ insert x s ∩ EMetric.ball x r) : AnalyticWithinAt 𝕜 f s y := by
-  have : (‖y - x‖₊ : ℝ≥0∞) < r := by simpa [edist_eq_coe_nnnorm_sub] using h.2
-  have := hf.changeOrigin this (by simpa using h.1)
-  rw [add_sub_cancel] at this
-  exact this.analyticWithinAt
+    (h : (‖y‖₊ : ℝ≥0∞) < r) : HasFPowerSeriesOnBall f (p.changeOrigin y) (x + y) (r - ‖y‖₊) :=
+  { r_le := by
+      apply le_trans _ p.changeOrigin_radius
+      exact tsub_le_tsub hf.r_le le_rfl
+    r_pos := by simp [h]
+    hasSum := fun {z} hz => by
+      have : f (x + y + z) =
+          FormalMultilinearSeries.sum (FormalMultilinearSeries.changeOrigin p y) z := by
+        rw [mem_emetric_ball_zero_iff, lt_tsub_iff_right, add_comm] at hz
+        rw [p.changeOrigin_eval (hz.trans_le hf.r_le), add_assoc, hf.sum]
+        refine mem_emetric_ball_zero_iff.2 (lt_of_le_of_lt ?_ hz)
+        exact mod_cast nnnorm_add_le y z
+      rw [this]
+      apply (p.changeOrigin y).hasSum
+      refine EMetric.ball_subset_ball (le_trans ?_ p.changeOrigin_radius) hz
+      exact tsub_le_tsub hf.r_le le_rfl }
 
 /-- If a function admits a power series expansion `p` on an open ball `B (x, r)`, then
 it is analytic at every point of this ball. -/
 theorem HasFPowerSeriesOnBall.analyticAt_of_mem (hf : HasFPowerSeriesOnBall f p x r)
     (h : y ∈ EMetric.ball x r) : AnalyticAt 𝕜 f y := by
-  rw [← hasFPowerSeriesWithinOnBall_univ] at hf
-  rw [← analyticWithinAt_univ]
-  exact hf.analyticWithinAt_of_mem (by simpa using h)
-
-theorem HasFPowerSeriesWithinOnBall.analyticWithinOn (hf : HasFPowerSeriesWithinOnBall f p s x r) :
-    AnalyticWithinOn 𝕜 f (insert x s ∩ EMetric.ball x r) :=
-  fun _ hy ↦ ((analyticWithinAt_insert (y := x)).2 (hf.analyticWithinAt_of_mem hy)).mono
-    inter_subset_left
+  have : (‖y - x‖₊ : ℝ≥0∞) < r := by simpa [edist_eq_coe_nnnorm_sub] using h
+  have := hf.changeOrigin this
+  rw [add_sub_cancel] at this
+  exact this.analyticAt
 
 theorem HasFPowerSeriesOnBall.analyticOn (hf : HasFPowerSeriesOnBall f p x r) :
     AnalyticOn 𝕜 f (EMetric.ball x r) :=

--- a/Mathlib/Analysis/Analytic/ChangeOrigin.lean
+++ b/Mathlib/Analysis/Analytic/ChangeOrigin.lean
@@ -284,7 +284,6 @@ theorem analyticAt_changeOrigin (p : FormalMultilinearSeries 𝕜 E F) (rp : p.r
 
 end FormalMultilinearSeries
 
-
 section
 
 variable [CompleteSpace F] {f : E → F} {p : FormalMultilinearSeries 𝕜 E F} {x y : E} {r : ℝ≥0∞}

--- a/Mathlib/Analysis/Analytic/Constructions.lean
+++ b/Mathlib/Analysis/Analytic/Constructions.lean
@@ -32,6 +32,157 @@ variable {𝕝 : Type*} [NontriviallyNormedField 𝕝] [NormedAlgebra 𝕜 𝕝]
 variable {A : Type*} [NormedRing A] [NormedAlgebra 𝕜 A]
 
 /-!
+### Constants are analytic
+-/
+
+theorem hasFPowerSeriesOnBall_const {c : F} {e : E} :
+    HasFPowerSeriesOnBall (fun _ => c) (constFormalMultilinearSeries 𝕜 E c) e ⊤ := by
+  refine ⟨by simp, WithTop.zero_lt_top, fun _ => hasSum_single 0 fun n hn => ?_⟩
+  simp [constFormalMultilinearSeries_apply hn]
+
+theorem hasFPowerSeriesAt_const {c : F} {e : E} :
+    HasFPowerSeriesAt (fun _ => c) (constFormalMultilinearSeries 𝕜 E c) e :=
+  ⟨⊤, hasFPowerSeriesOnBall_const⟩
+
+theorem analyticAt_const {v : F} {x : E} : AnalyticAt 𝕜 (fun _ => v) x :=
+  ⟨constFormalMultilinearSeries 𝕜 E v, hasFPowerSeriesAt_const⟩
+
+theorem analyticOn_const {v : F} {s : Set E} : AnalyticOn 𝕜 (fun _ => v) s :=
+  fun _ _ => analyticAt_const
+
+theorem analyticWithinAt_const {v : F} {s : Set E} {x : E} : AnalyticWithinAt 𝕜 (fun _ => v) s x :=
+  analyticAt_const.analyticWithinAt
+
+theorem analyticWithinOn_const {v : F} {s : Set E} : AnalyticWithinOn 𝕜 (fun _ => v) s :=
+  analyticOn_const.analyticWithinOn
+
+/-!
+### Addition, negation, subtraction -/
+
+section
+
+variable {f g : E → F} {pf pg : FormalMultilinearSeries 𝕜 E F} {s : Set E} {x : E} {r : ℝ≥0∞}
+
+theorem HasFPowerSeriesWithinOnBall.add (hf : HasFPowerSeriesWithinOnBall f pf s x r)
+    (hg : HasFPowerSeriesWithinOnBall g pg s x r) :
+    HasFPowerSeriesWithinOnBall (f + g) (pf + pg) s x r :=
+  { r_le := le_trans (le_min_iff.2 ⟨hf.r_le, hg.r_le⟩) (pf.min_radius_le_radius_add pg)
+    r_pos := hf.r_pos
+    hasSum := fun hy h'y => (hf.hasSum hy h'y).add (hg.hasSum hy h'y) }
+
+theorem HasFPowerSeriesOnBall.add (hf : HasFPowerSeriesOnBall f pf x r)
+    (hg : HasFPowerSeriesOnBall g pg x r) : HasFPowerSeriesOnBall (f + g) (pf + pg) x r :=
+  { r_le := le_trans (le_min_iff.2 ⟨hf.r_le, hg.r_le⟩) (pf.min_radius_le_radius_add pg)
+    r_pos := hf.r_pos
+    hasSum := fun hy => (hf.hasSum hy).add (hg.hasSum hy) }
+
+theorem HasFPowerSeriesWithinAt.add
+    (hf : HasFPowerSeriesWithinAt f pf s x) (hg : HasFPowerSeriesWithinAt g pg s x) :
+    HasFPowerSeriesWithinAt (f + g) (pf + pg) s x := by
+  rcases (hf.eventually.and hg.eventually).exists with ⟨r, hr⟩
+  exact ⟨r, hr.1.add hr.2⟩
+
+theorem HasFPowerSeriesAt.add (hf : HasFPowerSeriesAt f pf x) (hg : HasFPowerSeriesAt g pg x) :
+    HasFPowerSeriesAt (f + g) (pf + pg) x := by
+  rcases (hf.eventually.and hg.eventually).exists with ⟨r, hr⟩
+  exact ⟨r, hr.1.add hr.2⟩
+
+theorem AnalyticWithinAt.add (hf : AnalyticWithinAt 𝕜 f s x) (hg : AnalyticWithinAt 𝕜 g s x) :
+    AnalyticWithinAt 𝕜 (f + g) s x :=
+  let ⟨_, hpf⟩ := hf
+  let ⟨_, hqf⟩ := hg
+  (hpf.add hqf).analyticWithinAt
+
+theorem AnalyticAt.add (hf : AnalyticAt 𝕜 f x) (hg : AnalyticAt 𝕜 g x) : AnalyticAt 𝕜 (f + g) x :=
+  let ⟨_, hpf⟩ := hf
+  let ⟨_, hqf⟩ := hg
+  (hpf.add hqf).analyticAt
+
+theorem HasFPowerSeriesWithinOnBall.neg (hf : HasFPowerSeriesWithinOnBall f pf s x r) :
+    HasFPowerSeriesWithinOnBall (-f) (-pf) s x r :=
+  { r_le := by
+      rw [pf.radius_neg]
+      exact hf.r_le
+    r_pos := hf.r_pos
+    hasSum := fun hy h'y => (hf.hasSum hy h'y).neg }
+
+theorem HasFPowerSeriesOnBall.neg (hf : HasFPowerSeriesOnBall f pf x r) :
+    HasFPowerSeriesOnBall (-f) (-pf) x r :=
+  { r_le := by
+      rw [pf.radius_neg]
+      exact hf.r_le
+    r_pos := hf.r_pos
+    hasSum := fun hy => (hf.hasSum hy).neg }
+
+theorem HasFPowerSeriesWithinAt.neg (hf : HasFPowerSeriesWithinAt f pf s x) :
+    HasFPowerSeriesWithinAt (-f) (-pf) s x :=
+  let ⟨_, hrf⟩ := hf
+  hrf.neg.hasFPowerSeriesWithinAt
+
+theorem HasFPowerSeriesAt.neg (hf : HasFPowerSeriesAt f pf x) : HasFPowerSeriesAt (-f) (-pf) x :=
+  let ⟨_, hrf⟩ := hf
+  hrf.neg.hasFPowerSeriesAt
+
+theorem AnalyticWithinAt.neg (hf : AnalyticWithinAt 𝕜 f s x) : AnalyticWithinAt 𝕜 (-f) s x :=
+  let ⟨_, hpf⟩ := hf
+  hpf.neg.analyticWithinAt
+
+theorem AnalyticAt.neg (hf : AnalyticAt 𝕜 f x) : AnalyticAt 𝕜 (-f) x :=
+  let ⟨_, hpf⟩ := hf
+  hpf.neg.analyticAt
+
+theorem HasFPowerSeriesWithinOnBall.sub (hf : HasFPowerSeriesWithinOnBall f pf s x r)
+    (hg : HasFPowerSeriesWithinOnBall g pg s x r) :
+    HasFPowerSeriesWithinOnBall (f - g) (pf - pg) s x r := by
+  simpa only [sub_eq_add_neg] using hf.add hg.neg
+
+theorem HasFPowerSeriesOnBall.sub (hf : HasFPowerSeriesOnBall f pf x r)
+    (hg : HasFPowerSeriesOnBall g pg x r) : HasFPowerSeriesOnBall (f - g) (pf - pg) x r := by
+  simpa only [sub_eq_add_neg] using hf.add hg.neg
+
+theorem HasFPowerSeriesWithinAt.sub
+    (hf : HasFPowerSeriesWithinAt f pf s x) (hg : HasFPowerSeriesWithinAt g pg s x) :
+    HasFPowerSeriesWithinAt (f - g) (pf - pg) s x := by
+  simpa only [sub_eq_add_neg] using hf.add hg.neg
+
+theorem HasFPowerSeriesAt.sub (hf : HasFPowerSeriesAt f pf x) (hg : HasFPowerSeriesAt g pg x) :
+    HasFPowerSeriesAt (f - g) (pf - pg) x := by
+  simpa only [sub_eq_add_neg] using hf.add hg.neg
+
+theorem AnalyticWithinAt.sub (hf : AnalyticWithinAt 𝕜 f s x) (hg : AnalyticWithinAt 𝕜 g s x) :
+    AnalyticWithinAt 𝕜 (f - g) s x := by
+  simpa only [sub_eq_add_neg] using hf.add hg.neg
+
+theorem AnalyticAt.sub (hf : AnalyticAt 𝕜 f x) (hg : AnalyticAt 𝕜 g x) :
+    AnalyticAt 𝕜 (f - g) x := by
+  simpa only [sub_eq_add_neg] using hf.add hg.neg
+
+
+theorem AnalyticWithinOn.add (hf : AnalyticWithinOn 𝕜 f s) (hg : AnalyticWithinOn 𝕜 g s) :
+    AnalyticWithinOn 𝕜 (f + g) s :=
+  fun z hz => (hf z hz).add (hg z hz)
+
+theorem AnalyticOn.add (hf : AnalyticOn 𝕜 f s) (hg : AnalyticOn 𝕜 g s) :
+    AnalyticOn 𝕜 (f + g) s :=
+  fun z hz => (hf z hz).add (hg z hz)
+
+theorem AnalyticWithinOn.neg (hf : AnalyticWithinOn 𝕜 f s) : AnalyticWithinOn 𝕜 (-f) s :=
+  fun z hz ↦ (hf z hz).neg
+
+theorem AnalyticOn.neg (hf : AnalyticOn 𝕜 f s) : AnalyticOn 𝕜 (-f) s :=
+  fun z hz ↦ (hf z hz).neg
+
+theorem AnalyticWithinOn.sub (hf : AnalyticWithinOn 𝕜 f s) (hg : AnalyticWithinOn 𝕜 g s) :
+    AnalyticWithinOn 𝕜 (f - g) s :=
+  fun z hz => (hf z hz).sub (hg z hz)
+
+theorem AnalyticOn.sub (hf : AnalyticOn 𝕜 f s) (hg : AnalyticOn 𝕜 g s) :
+    AnalyticOn 𝕜 (f - g) s :=
+  fun z hz => (hf z hz).sub (hg z hz)
+
+end
+
+/-!
 ### Cartesian products are analytic
 -/
 

--- a/Mathlib/Analysis/Analytic/Constructions.lean
+++ b/Mathlib/Analysis/Analytic/Constructions.lean
@@ -57,7 +57,8 @@ theorem analyticWithinOn_const {v : F} {s : Set E} : AnalyticWithinOn 𝕜 (fun 
   analyticOn_const.analyticWithinOn
 
 /-!
-### Addition, negation, subtraction -/
+### Addition, negation, subtraction
+-/
 
 section
 
@@ -156,7 +157,6 @@ theorem AnalyticWithinAt.sub (hf : AnalyticWithinAt 𝕜 f s x) (hg : AnalyticWi
 theorem AnalyticAt.sub (hf : AnalyticAt 𝕜 f x) (hg : AnalyticAt 𝕜 g x) :
     AnalyticAt 𝕜 (f - g) x := by
   simpa only [sub_eq_add_neg] using hf.add hg.neg
-
 
 theorem AnalyticWithinOn.add (hf : AnalyticWithinOn 𝕜 f s) (hg : AnalyticWithinOn 𝕜 g s) :
     AnalyticWithinOn 𝕜 (f + g) s :=

--- a/Mathlib/Analysis/Analytic/Uniqueness.lean
+++ b/Mathlib/Analysis/Analytic/Uniqueness.lean
@@ -5,6 +5,7 @@ Authors: Sébastien Gouëzel
 -/
 import Mathlib.Analysis.Analytic.Linear
 import Mathlib.Analysis.Analytic.Composition
+import Mathlib.Analysis.Analytic.Constructions
 import Mathlib.Analysis.Normed.Module.Completion
 import Mathlib.Analysis.Analytic.ChangeOrigin
 
@@ -21,7 +22,137 @@ variable {𝕜 : Type*} [NontriviallyNormedField 𝕜] {E : Type*} [NormedAddCom
 
 open Set
 
-open scoped Topology ENNReal
+open scoped Topology ENNReal NNReal
+
+/-!
+### Uniqueness of power series
+If a function `f : E → F` has two representations as power series at a point `x : E`, corresponding
+to formal multilinear series `p₁` and `p₂`, then these representations agree term-by-term. That is,
+for any `n : ℕ` and `y : E`, `p₁ n (fun i ↦ y) = p₂ n (fun i ↦ y)`. In the one-dimensional case,
+when `f : 𝕜 → E`, the continuous multilinear maps `p₁ n` and `p₂ n` are given by
+`ContinuousMultilinearMap.mkPiRing`, and hence are determined completely by the value of
+`p₁ n (fun i ↦ 1)`, so `p₁ = p₂`. Consequently, the radius of convergence for one series can be
+transferred to the other.
+-/
+
+section Uniqueness
+
+open ContinuousMultilinearMap
+
+theorem Asymptotics.IsBigO.continuousMultilinearMap_apply_eq_zero {n : ℕ} {p : E[×n]→L[𝕜] F}
+    (h : (fun y => p fun _ => y) =O[𝓝 0] fun y => ‖y‖ ^ (n + 1)) (y : E) : (p fun _ => y) = 0 := by
+  obtain ⟨c, c_pos, hc⟩ := h.exists_pos
+  obtain ⟨t, ht, t_open, z_mem⟩ := eventually_nhds_iff.mp (isBigOWith_iff.mp hc)
+  obtain ⟨δ, δ_pos, δε⟩ := (Metric.isOpen_iff.mp t_open) 0 z_mem
+  clear h hc z_mem
+  cases' n with n
+  · exact norm_eq_zero.mp (by
+      -- Porting note: the symmetric difference of the `simpa only` sets:
+      -- added `zero_add, pow_one`
+      -- removed `zero_pow, Ne.def, Nat.one_ne_zero, not_false_iff`
+      simpa only [fin0_apply_norm, norm_eq_zero, norm_zero, zero_add, pow_one,
+        mul_zero, norm_le_zero_iff] using ht 0 (δε (Metric.mem_ball_self δ_pos)))
+  · refine Or.elim (Classical.em (y = 0))
+      (fun hy => by simpa only [hy] using p.map_zero) fun hy => ?_
+    replace hy := norm_pos_iff.mpr hy
+    refine norm_eq_zero.mp (le_antisymm (le_of_forall_pos_le_add fun ε ε_pos => ?_) (norm_nonneg _))
+    have h₀ := _root_.mul_pos c_pos (pow_pos hy (n.succ + 1))
+    obtain ⟨k, k_pos, k_norm⟩ := NormedField.exists_norm_lt 𝕜
+      (lt_min (mul_pos δ_pos (inv_pos.mpr hy)) (mul_pos ε_pos (inv_pos.mpr h₀)))
+    have h₁ : ‖k • y‖ < δ := by
+      rw [norm_smul]
+      exact inv_mul_cancel_right₀ hy.ne.symm δ ▸
+        mul_lt_mul_of_pos_right (lt_of_lt_of_le k_norm (min_le_left _ _)) hy
+    have h₂ :=
+      calc
+        ‖p fun _ => k • y‖ ≤ c * ‖k • y‖ ^ (n.succ + 1) := by
+          -- Porting note: now Lean wants `_root_.`
+          simpa only [norm_pow, _root_.norm_norm] using ht (k • y) (δε (mem_ball_zero_iff.mpr h₁))
+          --simpa only [norm_pow, norm_norm] using ht (k • y) (δε (mem_ball_zero_iff.mpr h₁))
+        _ = ‖k‖ ^ n.succ * (‖k‖ * (c * ‖y‖ ^ (n.succ + 1))) := by
+          -- Porting note: added `Nat.succ_eq_add_one` since otherwise `ring` does not conclude.
+          simp only [norm_smul, mul_pow, Nat.succ_eq_add_one]
+          -- Porting note: removed `rw [pow_succ]`, since it now becomes superfluous.
+          ring
+    have h₃ : ‖k‖ * (c * ‖y‖ ^ (n.succ + 1)) < ε :=
+      inv_mul_cancel_right₀ h₀.ne.symm ε ▸
+        mul_lt_mul_of_pos_right (lt_of_lt_of_le k_norm (min_le_right _ _)) h₀
+    calc
+      ‖p fun _ => y‖ = ‖k⁻¹ ^ n.succ‖ * ‖p fun _ => k • y‖ := by
+        simpa only [inv_smul_smul₀ (norm_pos_iff.mp k_pos), norm_smul, Finset.prod_const,
+          Finset.card_fin] using
+          congr_arg norm (p.map_smul_univ (fun _ : Fin n.succ => k⁻¹) fun _ : Fin n.succ => k • y)
+      _ ≤ ‖k⁻¹ ^ n.succ‖ * (‖k‖ ^ n.succ * (‖k‖ * (c * ‖y‖ ^ (n.succ + 1)))) := by gcongr
+      _ = ‖(k⁻¹ * k) ^ n.succ‖ * (‖k‖ * (c * ‖y‖ ^ (n.succ + 1))) := by
+        rw [← mul_assoc]
+        simp [norm_mul, mul_pow]
+      _ ≤ 0 + ε := by
+        rw [inv_mul_cancel₀ (norm_pos_iff.mp k_pos)]
+        simpa using h₃.le
+
+/-- If a formal multilinear series `p` represents the zero function at `x : E`, then the
+terms `p n (fun i ↦ y)` appearing in the sum are zero for any `n : ℕ`, `y : E`. -/
+theorem HasFPowerSeriesAt.apply_eq_zero {p : FormalMultilinearSeries 𝕜 E F} {x : E}
+    (h : HasFPowerSeriesAt 0 p x) (n : ℕ) : ∀ y : E, (p n fun _ => y) = 0 := by
+  refine Nat.strong_induction_on n fun k hk => ?_
+  have psum_eq : p.partialSum (k + 1) = fun y => p k fun _ => y := by
+    funext z
+    refine Finset.sum_eq_single _ (fun b hb hnb => ?_) fun hn => ?_
+    · have := Finset.mem_range_succ_iff.mp hb
+      simp only [hk b (this.lt_of_ne hnb), Pi.zero_apply]
+    · exact False.elim (hn (Finset.mem_range.mpr (lt_add_one k)))
+  replace h := h.isBigO_sub_partialSum_pow k.succ
+  simp only [psum_eq, zero_sub, Pi.zero_apply, Asymptotics.isBigO_neg_left] at h
+  exact h.continuousMultilinearMap_apply_eq_zero
+
+/-- A one-dimensional formal multilinear series representing the zero function is zero. -/
+theorem HasFPowerSeriesAt.eq_zero {p : FormalMultilinearSeries 𝕜 𝕜 E} {x : 𝕜}
+    (h : HasFPowerSeriesAt 0 p x) : p = 0 := by
+  ext n x
+  rw [← mkPiRing_apply_one_eq_self (p n)]
+  simp [h.apply_eq_zero n 1]
+
+/-- One-dimensional formal multilinear series representing the same function are equal. -/
+theorem HasFPowerSeriesAt.eq_formalMultilinearSeries {p₁ p₂ : FormalMultilinearSeries 𝕜 𝕜 E}
+    {f : 𝕜 → E} {x : 𝕜} (h₁ : HasFPowerSeriesAt f p₁ x) (h₂ : HasFPowerSeriesAt f p₂ x) : p₁ = p₂ :=
+  sub_eq_zero.mp (HasFPowerSeriesAt.eq_zero (x := x) (by simpa only [sub_self] using h₁.sub h₂))
+
+theorem HasFPowerSeriesAt.eq_formalMultilinearSeries_of_eventually
+    {p q : FormalMultilinearSeries 𝕜 𝕜 E} {f g : 𝕜 → E} {x : 𝕜} (hp : HasFPowerSeriesAt f p x)
+    (hq : HasFPowerSeriesAt g q x) (heq : ∀ᶠ z in 𝓝 x, f z = g z) : p = q :=
+  (hp.congr heq).eq_formalMultilinearSeries hq
+
+/-- A one-dimensional formal multilinear series representing a locally zero function is zero. -/
+theorem HasFPowerSeriesAt.eq_zero_of_eventually {p : FormalMultilinearSeries 𝕜 𝕜 E} {f : 𝕜 → E}
+    {x : 𝕜} (hp : HasFPowerSeriesAt f p x) (hf : f =ᶠ[𝓝 x] 0) : p = 0 :=
+  (hp.congr hf).eq_zero
+
+/-- If a function `f : 𝕜 → E` has two power series representations at `x`, then the given radii in
+which convergence is guaranteed may be interchanged. This can be useful when the formal multilinear
+series in one representation has a particularly nice form, but the other has a larger radius. -/
+theorem HasFPowerSeriesOnBall.exchange_radius {p₁ p₂ : FormalMultilinearSeries 𝕜 𝕜 E} {f : 𝕜 → E}
+    {r₁ r₂ : ℝ≥0∞} {x : 𝕜} (h₁ : HasFPowerSeriesOnBall f p₁ x r₁)
+    (h₂ : HasFPowerSeriesOnBall f p₂ x r₂) : HasFPowerSeriesOnBall f p₁ x r₂ :=
+  h₂.hasFPowerSeriesAt.eq_formalMultilinearSeries h₁.hasFPowerSeriesAt ▸ h₂
+
+/-- If a function `f : 𝕜 → E` has power series representation `p` on a ball of some radius and for
+each positive radius it has some power series representation, then `p` converges to `f` on the whole
+`𝕜`. -/
+theorem HasFPowerSeriesOnBall.r_eq_top_of_exists {f : 𝕜 → E} {r : ℝ≥0∞} {x : 𝕜}
+    {p : FormalMultilinearSeries 𝕜 𝕜 E} (h : HasFPowerSeriesOnBall f p x r)
+    (h' : ∀ (r' : ℝ≥0) (_ : 0 < r'), ∃ p' : FormalMultilinearSeries 𝕜 𝕜 E,
+      HasFPowerSeriesOnBall f p' x r') :
+    HasFPowerSeriesOnBall f p x ∞ :=
+  { r_le := ENNReal.le_of_forall_pos_nnreal_lt fun r hr _ =>
+      let ⟨_, hp'⟩ := h' r hr
+      (h.exchange_radius hp').r_le
+    r_pos := ENNReal.coe_lt_top
+    hasSum := fun {y} _ =>
+      let ⟨r', hr'⟩ := exists_gt ‖y‖₊
+      let ⟨_, hp'⟩ := h' r' hr'.ne_bot.bot_lt
+      (h.exchange_radius hp').hasSum <| mem_emetric_ball_zero_iff.mpr (ENNReal.coe_lt_coe.2 hr') }
+
+end Uniqueness
 
 namespace AnalyticOn
 

--- a/Mathlib/Analysis/Analytic/Within.lean
+++ b/Mathlib/Analysis/Analytic/Within.lean
@@ -3,7 +3,7 @@ Copyright (c) 2024 Geoffrey Irving. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Geoffrey Irving
 -/
-import Mathlib.Analysis.Calculus.FDeriv.Analytic
+import Mathlib.Analysis.Analytic.Constructions
 
 /-!
 # Properties of analyticity restricted to a set
@@ -14,12 +14,10 @@ From `Mathlib.Analysis.Analytic.Basic`, we have the definitions
 2. `AnalyticWithinOn 𝕜 f s t` means `∀ x ∈ t, AnalyticWithinAt 𝕜 f s x`.
 
 This means there exists an extension of `f` which is analytic and agrees with `f` on `s ∪ {x}`, but
-`f` is allowed to be arbitrary elsewhere.  Requiring `ContinuousWithinAt` is essential if `x ∉ s`:
-it is required for composition and smoothness to follow without extra hypotheses (we could
-alternately require convergence at `x` even if `x ∉ s`).
+`f` is allowed to be arbitrary elsewhere.
 
 Here we prove basic properties of these definitions. Where convenient we assume completeness of the
-ambient space, which allows us to related `AnalyticWithinAt` to analyticity of a local extension.
+ambient space, which allows us to relate `AnalyticWithinAt` to analyticity of a local extension.
 -/
 
 noncomputable section
@@ -57,10 +55,6 @@ lemma analyticWithinAt_of_singleton_mem {f : E → F} {s : Set E} {x : E} (h : {
       simp only [this]
       apply (hasFPowerSeriesOnBall_const (e := 0)).hasSum
       simp only [Metric.emetric_ball_top, mem_univ] }⟩
-
-lemma AnalyticWithinOn.continuousOn {f : E → F} {s : Set E} (h : AnalyticWithinOn 𝕜 f s) :
-    ContinuousOn f s :=
-  fun x m ↦ (h x m).continuousWithinAt
 
 /-- If `f` is `AnalyticWithinOn` near each point in a set, it is `AnalyticWithinOn` the set -/
 lemma analyticWithinOn_of_locally_analyticWithinOn {f : E → F} {s : Set E}
@@ -200,74 +194,3 @@ lemma analyticWithinAt_iff_exists_analyticAt' [CompleteSpace F] {f : E → F} {s
     exact ⟨g, by filter_upwards [self_mem_nhdsWithin] using hf, hg⟩
 
 alias ⟨AnalyticWithinAt.exists_analyticAt, _⟩ := analyticWithinAt_iff_exists_analyticAt'
-
-/-!
-### Congruence
-
--/
-
-
-lemma HasFPowerSeriesWithinOnBall.congr {f g : E → F} {p : FormalMultilinearSeries 𝕜 E F}
-    {s : Set E} {x : E} {r : ℝ≥0∞} (h : HasFPowerSeriesWithinOnBall f p s x r)
-    (h' : EqOn g f (s ∩ EMetric.ball x r)) (h'' : g x = f x) :
-    HasFPowerSeriesWithinOnBall g p s x r := by
-  refine ⟨h.r_le, h.r_pos, ?_⟩
-  · intro y hy h'y
-    convert h.hasSum hy h'y using 1
-    simp only [mem_insert_iff, add_right_eq_self] at hy
-    rcases hy with rfl | hy
-    · simpa using h''
-    · apply h'
-      refine ⟨hy, ?_⟩
-      simpa [edist_eq_coe_nnnorm_sub] using h'y
-
-lemma HasFPowerSeriesWithinAt.congr {f g : E → F} {p : FormalMultilinearSeries 𝕜 E F} {s : Set E}
-    {x : E} (h : HasFPowerSeriesWithinAt f p s x) (h' : g =ᶠ[𝓝[s] x] f) (h'' : g x = f x) :
-    HasFPowerSeriesWithinAt g p s x := by
-  rcases h with ⟨r, hr⟩
-  obtain ⟨ε, εpos, hε⟩ : ∃ ε > 0, EMetric.ball x ε ∩ s ⊆ {y | g y = f y} :=
-    EMetric.mem_nhdsWithin_iff.1 h'
-  let r' := min r ε
-  refine ⟨r', ?_⟩
-  have := hr.of_le (r' := r') (by simp [r', εpos, hr.r_pos]) (min_le_left _ _)
-  apply this.congr _ h''
-  intro z hz
-  exact hε ⟨EMetric.ball_subset_ball (min_le_right _ _) hz.2, hz.1⟩
-
-
-lemma AnalyticWithinAt.congr_of_eventuallyEq {f g : E → F} {s : Set E} {x : E}
-    (hf : AnalyticWithinAt 𝕜 f s x) (hs : g =ᶠ[𝓝[s] x] f) (hx : g x = f x) :
-    AnalyticWithinAt 𝕜 g s x := by
-  rcases hf with ⟨p, hp⟩
-  exact ⟨p, hp.congr hs hx⟩
-
-lemma AnalyticWithinAt.congr {f g : E → F} {s : Set E} {x : E}
-    (hf : AnalyticWithinAt 𝕜 f s x) (hs : EqOn g f s) (hx : g x = f x) :
-    AnalyticWithinAt 𝕜 g s x :=
-  hf.congr_of_eventuallyEq hs.eventuallyEq_nhdsWithin hx
-
-lemma AnalyticWithinOn.congr {f g : E → F} {s : Set E}
-    (hf : AnalyticWithinOn 𝕜 f s) (hs : EqOn g f s) :
-    AnalyticWithinOn 𝕜 g s :=
-  fun x m ↦ (hf x m).congr hs (hs m)
-
-/-!
-### Monotonicity w.r.t. the set we're analytic within
--/
-
-lemma AnalyticWithinOn.mono {f : E → F} {s t : Set E} (h : AnalyticWithinOn 𝕜 f t)
-    (hs : s ⊆ t) : AnalyticWithinOn 𝕜 f s :=
-  fun _ m ↦ (h _ (hs m)).mono hs
-
-/-!
-### Analyticity within implies smoothness
--/
-
-lemma AnalyticWithinAt.contDiffWithinAt [CompleteSpace F] {f : E → F} {s : Set E} {x : E}
-    (h : AnalyticWithinAt 𝕜 f s x) {n : ℕ∞} : ContDiffWithinAt 𝕜 n f s x := by
-  rcases h.exists_analyticAt with ⟨g, fx, fg, hg⟩
-  exact hg.contDiffAt.contDiffWithinAt.congr (fg.mono (subset_insert _ _)) fx
-
-lemma AnalyticWithinOn.contDiffOn [CompleteSpace F] {f : E → F} {s : Set E}
-    (h : AnalyticWithinOn 𝕜 f s) {n : ℕ∞} : ContDiffOn 𝕜 n f s :=
-  fun x m ↦ (h x m).contDiffWithinAt

--- a/Mathlib/Analysis/Calculus/FDeriv/Analytic.lean
+++ b/Mathlib/Analysis/Calculus/FDeriv/Analytic.lean
@@ -127,6 +127,15 @@ theorem AnalyticAt.contDiffAt [CompleteSpace F] (h : AnalyticAt 𝕜 f x) {n : �
   obtain ⟨s, hs, hf⟩ := h.exists_mem_nhds_analyticOn
   exact hf.contDiffOn.contDiffAt hs
 
+lemma AnalyticWithinAt.contDiffWithinAt [CompleteSpace F] {f : E → F} {s : Set E} {x : E}
+    (h : AnalyticWithinAt 𝕜 f s x) {n : ℕ∞} : ContDiffWithinAt 𝕜 n f s x := by
+  rcases h.exists_analyticAt with ⟨g, fx, fg, hg⟩
+  exact hg.contDiffAt.contDiffWithinAt.congr (fg.mono (subset_insert _ _)) fx
+
+lemma AnalyticWithinOn.contDiffOn [CompleteSpace F] {f : E → F} {s : Set E}
+    (h : AnalyticWithinOn 𝕜 f s) {n : ℕ∞} : ContDiffOn 𝕜 n f s :=
+  fun x m ↦ (h x m).contDiffWithinAt
+
 end fderiv
 
 section deriv

--- a/Mathlib/Analysis/Calculus/FDeriv/Analytic.lean
+++ b/Mathlib/Analysis/Calculus/FDeriv/Analytic.lean
@@ -3,8 +3,8 @@ Copyright (c) 2021 Yury Kudryashov. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Yury Kudryashov
 -/
-import Mathlib.Analysis.Analytic.Basic
 import Mathlib.Analysis.Analytic.CPolynomial
+import Mathlib.Analysis.Analytic.Within
 import Mathlib.Analysis.Calculus.Deriv.Basic
 import Mathlib.Analysis.Calculus.ContDiff.Defs
 import Mathlib.Analysis.Calculus.FDeriv.Add
@@ -19,7 +19,7 @@ As an application, we show that continuous multilinear maps are smooth. We also 
 iterated derivatives, in `ContinuousMultilinearMap.iteratedFDeriv_eq`.
 -/
 
-open Filter Asymptotics
+open Filter Asymptotics Set
 
 open scoped ENNReal
 
@@ -315,7 +315,7 @@ theorem changeOrigin_toFormalMultilinearSeries [DecidableEq ι] :
   refine (Fintype.sum_bijective (?_ ∘ Fintype.equivFinOfCardEq (Nat.add_sub_of_le
     Fintype.card_pos).symm) (.comp ?_ <| Equiv.bijective _) _ _ fun i ↦ ?_).symm
   · exact (⟨{·}ᶜ, by
-      rw [card_compl, Fintype.card_fin, card_singleton, Nat.add_sub_cancel_left]⟩)
+      rw [card_compl, Fintype.card_fin, Finset.card_singleton, Nat.add_sub_cancel_left]⟩)
   · use fun _ _ ↦ (singleton_injective <| compl_injective <| Subtype.ext_iff.mp ·)
     intro ⟨s, hs⟩
     have h : sᶜ.card = 1 := by rw [card_compl, hs, Fintype.card_fin, Nat.add_sub_cancel]

--- a/Mathlib/Analysis/Calculus/FDeriv/Analytic.lean
+++ b/Mathlib/Analysis/Calculus/FDeriv/Analytic.lean
@@ -3,13 +3,11 @@ Copyright (c) 2021 Yury Kudryashov. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Yury Kudryashov
 -/
-import Mathlib.Analysis.Analytic.Within
+import Mathlib.Analysis.Analytic.Basic
 import Mathlib.Analysis.Analytic.CPolynomial
 import Mathlib.Analysis.Calculus.Deriv.Basic
 import Mathlib.Analysis.Calculus.ContDiff.Defs
 import Mathlib.Analysis.Calculus.FDeriv.Add
-import Mathlib.Analysis.Calculus.FDeriv.Prod
-import Mathlib.Analysis.Normed.Module.Completion
 
 /-!
 # Frechet derivatives of analytic functions.
@@ -21,9 +19,9 @@ As an application, we show that continuous multilinear maps are smooth. We also 
 iterated derivatives, in `ContinuousMultilinearMap.iteratedFDeriv_eq`.
 -/
 
-open Filter Asymptotics Set
+open Filter Asymptotics
 
-open scoped ENNReal Topology
+open scoped ENNReal
 
 universe u v
 
@@ -36,46 +34,19 @@ section fderiv
 variable {p : FormalMultilinearSeries 𝕜 E F} {r : ℝ≥0∞}
 variable {f : E → F} {x : E} {s : Set E}
 
-/-- A function which is analytic within a set is strictly differentiable there. Since we
-don't have a predicate `HasStrictFDerivWithinAt`, we spell out what it would mean. -/
-theorem HasFPowerSeriesWithinAt.hasStrictFDerivWithinAt (h : HasFPowerSeriesWithinAt f p s x) :
-    (fun y ↦ f y.1 - f y.2 - ((continuousMultilinearCurryFin1 𝕜 E F) (p 1)) (y.1 - y.2))
-      =o[𝓝[insert x s ×ˢ insert x s] (x, x)] fun y ↦ y.1 - y.2 := by
-  refine h.isBigO_image_sub_norm_mul_norm_sub.trans_isLittleO (IsLittleO.of_norm_right ?_)
-  refine isLittleO_iff_exists_eq_mul.2 ⟨fun y => ‖y - (x, x)‖, ?_, EventuallyEq.rfl⟩
-  apply Tendsto.mono_left _ nhdsWithin_le_nhds
-  refine (continuous_id.sub continuous_const).norm.tendsto' _ _ ?_
-  rw [_root_.id, sub_self, norm_zero]
-
 theorem HasFPowerSeriesAt.hasStrictFDerivAt (h : HasFPowerSeriesAt f p x) :
     HasStrictFDerivAt f (continuousMultilinearCurryFin1 𝕜 E F (p 1)) x := by
-  simpa only [Set.insert_eq_of_mem, Set.mem_univ, Set.univ_prod_univ, nhdsWithin_univ]
-    using (h.hasFPowerSeriesWithinAt (s := Set.univ)).hasStrictFDerivWithinAt
-
-theorem HasFPowerSeriesWithinAt.hasFDerivWithinAt (h : HasFPowerSeriesWithinAt f p s x) :
-    HasFDerivWithinAt f (continuousMultilinearCurryFin1 𝕜 E F (p 1)) (insert x s) x := by
-  rw [HasFDerivWithinAt, hasFDerivAtFilter_iff_isLittleO, isLittleO_iff]
-  intro c hc
-  have : Tendsto (fun y ↦ (y, x)) (𝓝[insert x s] x) (𝓝[insert x s ×ˢ insert x s] (x, x)) := by
-    rw [nhdsWithin_prod_eq]
-    exact Tendsto.prod_mk tendsto_id (tendsto_const_nhdsWithin (by simp))
-  exact this (isLittleO_iff.1 h.hasStrictFDerivWithinAt hc)
+  refine h.isBigO_image_sub_norm_mul_norm_sub.trans_isLittleO (IsLittleO.of_norm_right ?_)
+  refine isLittleO_iff_exists_eq_mul.2 ⟨fun y => ‖y - (x, x)‖, ?_, EventuallyEq.rfl⟩
+  refine (continuous_id.sub continuous_const).norm.tendsto' _ _ ?_
+  rw [_root_.id, sub_self, norm_zero]
 
 theorem HasFPowerSeriesAt.hasFDerivAt (h : HasFPowerSeriesAt f p x) :
     HasFDerivAt f (continuousMultilinearCurryFin1 𝕜 E F (p 1)) x :=
   h.hasStrictFDerivAt.hasFDerivAt
 
-theorem HasFPowerSeriesWithinAt.differentiableWithinAt (h : HasFPowerSeriesWithinAt f p s x) :
-    DifferentiableWithinAt 𝕜 f (insert x s) x :=
-  h.hasFDerivWithinAt.differentiableWithinAt
-
 theorem HasFPowerSeriesAt.differentiableAt (h : HasFPowerSeriesAt f p x) : DifferentiableAt 𝕜 f x :=
   h.hasFDerivAt.differentiableAt
-
-theorem AnalyticWithinAt.differentiableWithinAt (h : AnalyticWithinAt 𝕜 f s x) :
-    DifferentiableWithinAt 𝕜 f (insert x s) x := by
-  obtain ⟨p, hp⟩ := h
-  exact hp.differentiableWithinAt
 
 theorem AnalyticAt.differentiableAt : AnalyticAt 𝕜 f x → DifferentiableAt 𝕜 f x
   | ⟨_, hp⟩ => hp.differentiableAt
@@ -83,62 +54,21 @@ theorem AnalyticAt.differentiableAt : AnalyticAt 𝕜 f x → DifferentiableAt �
 theorem AnalyticAt.differentiableWithinAt (h : AnalyticAt 𝕜 f x) : DifferentiableWithinAt 𝕜 f s x :=
   h.differentiableAt.differentiableWithinAt
 
-theorem HasFPowerSeriesWithinAt.fderivWithin_eq
-    (h : HasFPowerSeriesWithinAt f p s x) (hu : UniqueDiffWithinAt 𝕜 (insert x s) x) :
-    fderivWithin 𝕜 f (insert x s) x = continuousMultilinearCurryFin1 𝕜 E F (p 1) :=
-  h.hasFDerivWithinAt.fderivWithin hu
-
 theorem HasFPowerSeriesAt.fderiv_eq (h : HasFPowerSeriesAt f p x) :
     fderiv 𝕜 f x = continuousMultilinearCurryFin1 𝕜 E F (p 1) :=
   h.hasFDerivAt.fderiv
-
-theorem HasFPowerSeriesWithinOnBall.differentiableOn [CompleteSpace F]
-    (h : HasFPowerSeriesWithinOnBall f p s x r) :
-    DifferentiableOn 𝕜 f (insert x s ∩ EMetric.ball x r) := by
-  intro y hy
-  have Z := (h.analyticWithinAt_of_mem hy).differentiableWithinAt
-  rcases eq_or_ne y x with rfl | hy
-  · exact Z.mono inter_subset_left
-  · apply (Z.mono (subset_insert _ _)).mono_of_mem
-    suffices s ∈ 𝓝[insert x s] y from nhdsWithin_mono _ inter_subset_left this
-    rw [nhdsWithin_insert_of_ne hy]
-    exact self_mem_nhdsWithin
 
 theorem HasFPowerSeriesOnBall.differentiableOn [CompleteSpace F]
     (h : HasFPowerSeriesOnBall f p x r) : DifferentiableOn 𝕜 f (EMetric.ball x r) := fun _ hy =>
   (h.analyticAt_of_mem hy).differentiableWithinAt
 
-theorem AnalyticWithinOn.differentiableOn (h : AnalyticWithinOn 𝕜 f s) : DifferentiableOn 𝕜 f s :=
-  fun y hy => (h y hy).differentiableWithinAt.mono (by simp)
-
 theorem AnalyticOn.differentiableOn (h : AnalyticOn 𝕜 f s) : DifferentiableOn 𝕜 f s := fun y hy =>
   (h y hy).differentiableWithinAt
-
-theorem HasFPowerSeriesWithinOnBall.hasFDerivWithinAt [CompleteSpace F]
-    (h : HasFPowerSeriesWithinOnBall f p s x r)
-    {y : E} (hy : (‖y‖₊ : ℝ≥0∞) < r) (h'y : x + y ∈ insert x s) :
-    HasFDerivWithinAt f (continuousMultilinearCurryFin1 𝕜 E F (p.changeOrigin y 1))
-      (insert x s) (x + y) := by
-  rcases eq_or_ne y 0 with rfl | h''y
-  · convert (h.changeOrigin hy h'y).hasFPowerSeriesWithinAt.hasFDerivWithinAt
-    simp
-  · have Z := (h.changeOrigin hy h'y).hasFPowerSeriesWithinAt.hasFDerivWithinAt
-    apply (Z.mono (subset_insert _ _)).mono_of_mem
-    rw [nhdsWithin_insert_of_ne]
-    · exact self_mem_nhdsWithin
-    · simpa using h''y
 
 theorem HasFPowerSeriesOnBall.hasFDerivAt [CompleteSpace F] (h : HasFPowerSeriesOnBall f p x r)
     {y : E} (hy : (‖y‖₊ : ℝ≥0∞) < r) :
     HasFDerivAt f (continuousMultilinearCurryFin1 𝕜 E F (p.changeOrigin y 1)) (x + y) :=
   (h.changeOrigin hy).hasFPowerSeriesAt.hasFDerivAt
-
-theorem HasFPowerSeriesWithinOnBall.fderivWithin_eq [CompleteSpace F]
-    (h : HasFPowerSeriesWithinOnBall f p s x r)
-    {y : E} (hy : (‖y‖₊ : ℝ≥0∞) < r) (h'y : x + y ∈ insert x s) (hu : UniqueDiffOn 𝕜 (insert x s)) :
-    fderivWithin 𝕜 f (insert x s) (x + y) =
-      continuousMultilinearCurryFin1 𝕜 E F (p.changeOrigin y 1) :=
-  (h.hasFDerivWithinAt hy h'y).fderivWithin (hu _ h'y)
 
 theorem HasFPowerSeriesOnBall.fderiv_eq [CompleteSpace F] (h : HasFPowerSeriesOnBall f p x r)
     {y : E} (hy : (‖y‖₊ : ℝ≥0∞) < r) :
@@ -146,8 +76,7 @@ theorem HasFPowerSeriesOnBall.fderiv_eq [CompleteSpace F] (h : HasFPowerSeriesOn
   (h.hasFDerivAt hy).fderiv
 
 /-- If a function has a power series on a ball, then so does its derivative. -/
-protected theorem HasFPowerSeriesOnBall.fderiv [CompleteSpace F]
-    (h : HasFPowerSeriesOnBall f p x r) :
+theorem HasFPowerSeriesOnBall.fderiv [CompleteSpace F] (h : HasFPowerSeriesOnBall f p x r) :
     HasFPowerSeriesOnBall (fderiv 𝕜 f) p.derivSeries x r := by
   refine .congr (f := fun z ↦ continuousMultilinearCurryFin1 𝕜 E F (p.changeOrigin (z - x) 1)) ?_
     fun z hz ↦ ?_
@@ -159,35 +88,15 @@ protected theorem HasFPowerSeriesOnBall.fderiv [CompleteSpace F]
   rw [← h.fderiv_eq, add_sub_cancel]
   simpa only [edist_eq_coe_nnnorm_sub, EMetric.mem_ball] using hz
 
-/-- If a function has a power series within a set on a ball, then so does its derivative. -/
-protected theorem HasFPowerSeriesWithinOnBall.fderivWithin [CompleteSpace F]
-    (h : HasFPowerSeriesWithinOnBall f p s x r) (hu : UniqueDiffOn 𝕜 (insert x s)) :
-    HasFPowerSeriesWithinOnBall (fderivWithin 𝕜 f (insert x s)) p.derivSeries s x r := by
-  refine .congr' (f := fun z ↦ continuousMultilinearCurryFin1 𝕜 E F (p.changeOrigin (z - x) 1)) ?_
-    (fun z hz ↦ ?_)
-  · refine continuousMultilinearCurryFin1 𝕜 E F
-      |>.toContinuousLinearEquiv.toContinuousLinearMap.comp_hasFPowerSeriesWithinOnBall ?_
-    apply HasFPowerSeriesOnBall.hasFPowerSeriesWithinOnBall
-    simpa using ((p.hasFPowerSeriesOnBall_changeOrigin 1
-      (h.r_pos.trans_le h.r_le)).mono h.r_pos h.r_le).comp_sub x
-  · dsimp only
-    rw [← h.fderivWithin_eq _ _ hu, add_sub_cancel]
-    · simpa only [edist_eq_coe_nnnorm_sub, EMetric.mem_ball] using hz.2
-    · simpa using hz.1
-
 /-- If a function is analytic on a set `s`, so is its Fréchet derivative. -/
-protected theorem AnalyticAt.fderiv [CompleteSpace F] (h : AnalyticAt 𝕜 f x) :
-    AnalyticAt 𝕜 (fderiv 𝕜 f) x := by
-  rcases h with ⟨p, r, hp⟩
+theorem AnalyticOn.fderiv [CompleteSpace F] (h : AnalyticOn 𝕜 f s) :
+    AnalyticOn 𝕜 (fderiv 𝕜 f) s := by
+  intro y hy
+  rcases h y hy with ⟨p, r, hp⟩
   exact hp.fderiv.analyticAt
 
-/-- If a function is analytic on a set `s`, so is its Fréchet derivative. -/
-protected theorem AnalyticOn.fderiv [CompleteSpace F] (h : AnalyticOn 𝕜 f s) :
-    AnalyticOn 𝕜 (fderiv 𝕜 f) s :=
-  fun y hy ↦ AnalyticAt.fderiv (h y hy)
-
 /-- If a function is analytic on a set `s`, so are its successive Fréchet derivative. -/
-protected theorem AnalyticOn.iteratedFDeriv [CompleteSpace F] (h : AnalyticOn 𝕜 f s) (n : ℕ) :
+theorem AnalyticOn.iteratedFDeriv [CompleteSpace F] (h : AnalyticOn 𝕜 f s) (n : ℕ) :
     AnalyticOn 𝕜 (iteratedFDeriv 𝕜 n f) s := by
   induction n with
   | zero =>
@@ -199,113 +108,6 @@ protected theorem AnalyticOn.iteratedFDeriv [CompleteSpace F] (h : AnalyticOn �
     convert ContinuousLinearMap.comp_analyticOn ?g IH.fderiv
     case g => exact ↑(continuousMultilinearCurryLeftEquiv 𝕜 (fun _ : Fin (n + 1) ↦ E) F).symm
     simp
-
-lemma AnalyticOn.hasFTaylorSeriesUpToOn [CompleteSpace F] (n : ℕ∞) (h : AnalyticOn 𝕜 f s) :
-    HasFTaylorSeriesUpToOn n f (ftaylorSeries 𝕜 f) s := by
-  refine ⟨fun x _hx ↦ rfl, fun m _hm x hx ↦ ?_, fun m _hm x hx ↦ ?_⟩
-  · apply HasFDerivAt.hasFDerivWithinAt
-    exact ((h.iteratedFDeriv m x hx).differentiableAt).hasFDerivAt
-  · apply (DifferentiableAt.continuousAt (𝕜 := 𝕜) ?_).continuousWithinAt
-    exact (h.iteratedFDeriv m x hx).differentiableAt
-
-lemma AnalyticWithinAt.exists_hasFTaylorSeriesUpToOn [CompleteSpace F]
-    (n : ℕ∞) (h : AnalyticWithinAt 𝕜 f s x) :
-    ∃ u ∈ 𝓝[insert x s] x, ∃ (p : E → FormalMultilinearSeries 𝕜 E F),
-    HasFTaylorSeriesUpToOn n f p u ∧ ∀ i, AnalyticWithinOn 𝕜 (fun x ↦ p x i) u := by
-  rcases h.exists_analyticAt with ⟨g, -, fg, hg⟩
-  rcases hg.exists_mem_nhds_analyticOn with ⟨v, vx, hv⟩
-  refine ⟨insert x s ∩ v, inter_mem_nhdsWithin _ vx, ftaylorSeries 𝕜 g, ?_, fun i ↦ ?_⟩
-  · suffices HasFTaylorSeriesUpToOn n g (ftaylorSeries 𝕜 g) (insert x s ∩ v) from
-      this.congr (fun y hy ↦ fg hy.1)
-    exact AnalyticOn.hasFTaylorSeriesUpToOn _ (hv.mono Set.inter_subset_right)
-  · exact (hv.iteratedFDeriv i).analyticWithinOn.mono Set.inter_subset_right
-
-/-- If a function has a power series `p` within a set of unique differentiability, inside a ball,
-and is differentiable at a point, then the derivative series of `p` is summable at a point, with
-sum the given differential. Note that this theorem does not require completeness of the space.-/
-theorem HasFPowerSeriesWithinOnBall.hasSum_derivSeries_of_hasFDerivWithinAt
-    (h : HasFPowerSeriesWithinOnBall f p s x r)
-    {f' : E →L[𝕜] F}
-    {y : E} (hy : (‖y‖₊ : ℝ≥0∞) < r) (h'y : x + y ∈ insert x s)
-    (hf' : HasFDerivWithinAt f f' (insert x s) (x + y))
-    (hu : UniqueDiffOn 𝕜 (insert x s)) :
-    HasSum (fun n ↦ p.derivSeries n (fun _ ↦ y)) f' := by
-  /- In the completion of the space, the derivative series is summable, and its sum is a derivative
-  of the function. Therefore, by uniqueness of derivatives, its sum is the image of `f'` under
-  the canonical embedding. As this is an embedding, it means that there was also convergence in
-  the original space, to `f'`. -/
-  let F' := UniformSpace.Completion F
-  let a : F →L[𝕜] F' := UniformSpace.Completion.toComplL
-  let b : (E →L[𝕜] F) →ₗᵢ[𝕜] (E →L[𝕜] F') := UniformSpace.Completion.toComplₗᵢ.postcomp
-  rw [← b.embedding.hasSum_iff]
-  have : HasFPowerSeriesWithinOnBall (a ∘ f) (a.compFormalMultilinearSeries p) s x r :=
-    a.comp_hasFPowerSeriesWithinOnBall h
-  have Z := (this.fderivWithin hu).hasSum h'y (by simpa [edist_eq_coe_nnnorm] using hy)
-  have : fderivWithin 𝕜 (a ∘ f) (insert x s) (x + y) = a ∘L f' := by
-    apply HasFDerivWithinAt.fderivWithin _ (hu _ h'y)
-    exact a.hasFDerivAt.comp_hasFDerivWithinAt (x + y) hf'
-  rw [this] at Z
-  convert Z with n
-  ext v
-  simp only [FormalMultilinearSeries.derivSeries,
-    ContinuousLinearMap.compFormalMultilinearSeries_apply,
-    FormalMultilinearSeries.changeOriginSeries,
-    ContinuousLinearMap.compContinuousMultilinearMap_coe, ContinuousLinearEquiv.coe_coe,
-    LinearIsometryEquiv.coe_coe, Function.comp_apply, ContinuousMultilinearMap.sum_apply, map_sum,
-    ContinuousLinearMap.coe_sum', Finset.sum_apply,
-    Matrix.zero_empty]
-  rfl
-
-/-- If a function is analytic within a set with unique differentials, then so is its derivative.
-Note that this theorem does not require completeness of the space. -/
-theorem AnalyticWithinOn.fderivWithin (h : AnalyticWithinOn 𝕜 f s) (hu : UniqueDiffOn 𝕜 s) :
-    AnalyticWithinOn 𝕜 (fderivWithin 𝕜 f s) s := by
-  intro x hx
-  rcases h x hx with ⟨p, r, hr⟩
-  refine ⟨p.derivSeries, r, ?_⟩
-  refine ⟨hr.r_le.trans p.radius_le_radius_derivSeries, hr.r_pos, fun {y} hy h'y ↦ ?_⟩
-  apply hr.hasSum_derivSeries_of_hasFDerivWithinAt (by simpa [edist_eq_coe_nnnorm] using h'y) hy
-  rw [insert_eq_of_mem hx] at hy ⊢
-  apply DifferentiableWithinAt.hasFDerivWithinAt
-  · exact h.differentiableOn _ hy
-  · rwa [insert_eq_of_mem hx]
-
-/-- If a function is analytic on a set `s`, so are its successive Fréchet derivative within this
-set. Note that this theorem does not require completeness of the space. -/
-theorem AnalyticWithinOn.iteratedFDerivWithin (h : AnalyticWithinOn 𝕜 f s)
-    (hu : UniqueDiffOn 𝕜 s) (n : ℕ) :
-    AnalyticWithinOn 𝕜 (iteratedFDerivWithin 𝕜 n f s) s := by
-  induction n with
-  | zero =>
-    rw [iteratedFDerivWithin_zero_eq_comp]
-    exact ((continuousMultilinearCurryFin0 𝕜 E F).symm : F →L[𝕜] E[×0]→L[𝕜] F)
-      |>.comp_analyticWithinOn h
-  | succ n IH =>
-    rw [iteratedFDerivWithin_succ_eq_comp_left]
-    apply AnalyticOn.comp_analyticWithinOn _ (IH.fderivWithin hu) (mapsTo_univ _ _)
-    apply LinearIsometryEquiv.analyticOn
-
-lemma AnalyticWithinOn.exists_hasFTaylorSeriesUpToOn
-    (h : AnalyticWithinOn 𝕜 f s) (hu : UniqueDiffOn 𝕜 s) :
-    ∃ (p : E → FormalMultilinearSeries 𝕜 E F),
-    HasFTaylorSeriesUpToOn ⊤ f p s ∧ ∀ i, AnalyticWithinOn 𝕜 (fun x ↦ p x i) s := by
-  refine ⟨ftaylorSeriesWithin 𝕜 f s, ?_, fun i ↦ ?_⟩
-  · refine ⟨fun x _hx ↦ rfl, fun m _hm x hx ↦ ?_, fun m _hm x hx ↦ ?_⟩
-    · have := (h.iteratedFDerivWithin hu m x hx).differentiableWithinAt.hasFDerivWithinAt
-      rwa [insert_eq_of_mem hx] at this
-    · exact (h.iteratedFDerivWithin hu m x hx).continuousWithinAt
-  · apply h.iteratedFDerivWithin hu
-
-theorem AnalyticOn.fderiv_of_isOpen (h : AnalyticOn 𝕜 f s) (hs : IsOpen s) :
-    AnalyticOn 𝕜 (fderiv 𝕜 f) s := by
-  rw [← hs.analyticWithinOn_iff_analyticOn] at h ⊢
-  exact (h.fderivWithin hs.uniqueDiffOn).congr (fun x hx ↦ (fderivWithin_of_isOpen hs hx).symm)
-
-theorem AnalyticOn.iteratedFDeriv_of_isOpen (h : AnalyticOn 𝕜 f s) (hs : IsOpen s) (n : ℕ) :
-    AnalyticOn 𝕜 (iteratedFDeriv 𝕜 n f) s := by
-  rw [← hs.analyticWithinOn_iff_analyticOn] at h ⊢
-  exact (h.iteratedFDerivWithin hs.uniqueDiffOn n).congr
-    (fun x hx ↦ (iteratedFDerivWithin_of_isOpen n hs hx).symm)
 
 /-- An analytic function is infinitely differentiable. -/
 theorem AnalyticOn.contDiffOn [CompleteSpace F] (h : AnalyticOn 𝕜 f s) {n : ℕ∞} :
@@ -324,19 +126,6 @@ theorem AnalyticAt.contDiffAt [CompleteSpace F] (h : AnalyticAt 𝕜 f x) {n : �
     ContDiffAt 𝕜 n f x := by
   obtain ⟨s, hs, hf⟩ := h.exists_mem_nhds_analyticOn
   exact hf.contDiffOn.contDiffAt hs
-
-/-!
-### Analyticity within implies smoothness
--/
-
-lemma AnalyticWithinAt.contDiffWithinAt [CompleteSpace F] {f : E → F} {s : Set E} {x : E}
-    (h : AnalyticWithinAt 𝕜 f s x) {n : ℕ∞} : ContDiffWithinAt 𝕜 n f s x := by
-  rcases h.exists_analyticAt with ⟨g, fx, fg, hg⟩
-  exact hg.contDiffAt.contDiffWithinAt.congr (fg.mono (subset_insert _ _)) fx
-
-lemma AnalyticWithinOn.contDiffOn [CompleteSpace F] {f : E → F} {s : Set E}
-    (h : AnalyticWithinOn 𝕜 f s) {n : ℕ∞} : ContDiffOn 𝕜 n f s :=
-  fun x m ↦ (h x m).contDiffWithinAt
 
 end fderiv
 
@@ -517,7 +306,7 @@ theorem changeOrigin_toFormalMultilinearSeries [DecidableEq ι] :
   refine (Fintype.sum_bijective (?_ ∘ Fintype.equivFinOfCardEq (Nat.add_sub_of_le
     Fintype.card_pos).symm) (.comp ?_ <| Equiv.bijective _) _ _ fun i ↦ ?_).symm
   · exact (⟨{·}ᶜ, by
-      rw [card_compl, Fintype.card_fin, Finset.card_singleton, Nat.add_sub_cancel_left]⟩)
+      rw [card_compl, Fintype.card_fin, card_singleton, Nat.add_sub_cancel_left]⟩)
   · use fun _ _ ↦ (singleton_injective <| compl_injective <| Subtype.ext_iff.mp ·)
     intro ⟨s, hs⟩
     have h : sᶜ.card = 1 := by rw [card_compl, hs, Fintype.card_fin, Nat.add_sub_cancel]

--- a/Mathlib/Analysis/Complex/CauchyIntegral.lean
+++ b/Mathlib/Analysis/Complex/CauchyIntegral.lean
@@ -3,6 +3,7 @@ Copyright (c) 2021 Yury Kudryashov. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Yury Kudryashov
 -/
+import Mathlib.Analysis.Analytic.Uniqueness
 import Mathlib.Analysis.Calculus.DiffContOnCl
 import Mathlib.Analysis.Calculus.Dslope
 import Mathlib.Analysis.Calculus.FDeriv.Analytic

--- a/Mathlib/Analysis/NormedSpace/OperatorNorm/NormedSpace.lean
+++ b/Mathlib/Analysis/NormedSpace/OperatorNorm/NormedSpace.lean
@@ -165,6 +165,15 @@ theorem norm_toContinuousLinearMap_comp [RingHomIsometric σ₁₂] (f : F →�
   opNorm_ext (f.toContinuousLinearMap.comp g) g fun x => by
     simp only [norm_map, coe_toContinuousLinearMap, coe_comp', Function.comp_apply]
 
+/-- Composing on the left with a linear isometry gives a linear isometry between spaces of
+continuous linear maps. -/
+def postcomp [RingHomIsometric σ₁₂] [RingHomIsometric σ₁₃] (a : F →ₛₗᵢ[σ₂₃] G) :
+    (E →SL[σ₁₂] F) →ₛₗᵢ[σ₂₃] (E →SL[σ₁₃] G) where
+  toFun f := a.toContinuousLinearMap.comp f
+  map_add' f g := by simp
+  map_smul' c f := by simp
+  norm_map' f := by simp [a.norm_toContinuousLinearMap_comp]
+
 end LinearIsometry
 
 end

--- a/Mathlib/Analysis/NormedSpace/OperatorNorm/NormedSpace.lean
+++ b/Mathlib/Analysis/NormedSpace/OperatorNorm/NormedSpace.lean
@@ -165,15 +165,6 @@ theorem norm_toContinuousLinearMap_comp [RingHomIsometric σ₁₂] (f : F →�
   opNorm_ext (f.toContinuousLinearMap.comp g) g fun x => by
     simp only [norm_map, coe_toContinuousLinearMap, coe_comp', Function.comp_apply]
 
-/-- Composing on the left with a linear isometry gives a linear isometry between spaces of
-continuous linear maps. -/
-def postcomp [RingHomIsometric σ₁₂] [RingHomIsometric σ₁₃] (a : F →ₛₗᵢ[σ₂₃] G) :
-    (E →SL[σ₁₂] F) →ₛₗᵢ[σ₂₃] (E →SL[σ₁₃] G) where
-  toFun f := a.toContinuousLinearMap.comp f
-  map_add' f g := by simp
-  map_smul' c f := by simp
-  norm_map' f := by simp [a.norm_toContinuousLinearMap_comp]
-
 end LinearIsometry
 
 end

--- a/Mathlib/Geometry/Manifold/AnalyticManifold.lean
+++ b/Mathlib/Geometry/Manifold/AnalyticManifold.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Michael Lee, Geoffrey Irving
 -/
 import Mathlib.Analysis.Analytic.Constructions
-import Mathlib.Analysis.Analytic.Within
+import Mathlib.Analysis.Calculus.FDeriv
 import Mathlib.Geometry.Manifold.SmoothManifoldWithCorners
 
 /-!

--- a/Mathlib/Geometry/Manifold/AnalyticManifold.lean
+++ b/Mathlib/Geometry/Manifold/AnalyticManifold.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Michael Lee, Geoffrey Irving
 -/
 import Mathlib.Analysis.Analytic.Constructions
-import Mathlib.Analysis.Calculus.FDeriv
+import Mathlib.Analysis.Calculus.FDeriv.Analytic
 import Mathlib.Geometry.Manifold.SmoothManifoldWithCorners
 
 /-!


### PR DESCRIPTION
We move some things in the `Analytic` folder, particularly in and out of `Basic`. Notably
* The fact that the addition and subtraction are analytic is moved from `Basic` to `Constructions`, where there are already the same facts for multiplication and scalar multiplication
* Congruence lemmas are moved from `Within` to `Basic`
* Uniqueness of power series is moved from `Basic` to the (already existing file!) `Uniqueness`
* Order of imports is swapped between `Calculus.FDeriv.Analytic` and `Analytic.Within`.

We also add a few docstrings to the files to show their structure. This gives a more principled hierarchy, better suited to the addition of future lemmas.

This PR is just moving things around, no statement has been added or removed.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
