### PR TITLE
[Merged by Bors] - chore(SetTheory/Ordinal/CantorNormalForm): cleanup proofs

### DIFF
--- a/Mathlib/SetTheory/Ordinal/CantorNormalForm.lean
+++ b/Mathlib/SetTheory/Ordinal/CantorNormalForm.lean
@@ -53,7 +53,7 @@ theorem CNFRec_zero {C : Ordinal → Sort*} (b : Ordinal) (H0 : C 0)
 theorem CNFRec_pos (b : Ordinal) {o : Ordinal} {C : Ordinal → Sort*} (ho : o ≠ 0) (H0 : C 0)
     (H : ∀ o, o ≠ 0 → C (o % b ^ log b o) → C o) :
     CNFRec b H0 H o = H o ho (@CNFRec b C H0 H _) := by
-  rw [CNFRec, dif_neg ho]
+  rw [CNFRec, dif_neg]
 
 /-- The Cantor normal form of an ordinal `o` is the list of coefficients and exponents in the
 base-`b` expansion of `o`.

--- a/Mathlib/SetTheory/Ordinal/CantorNormalForm.lean
+++ b/Mathlib/SetTheory/Ordinal/CantorNormalForm.lean
@@ -129,7 +129,8 @@ theorem CNF_snd_lt {b o : Ordinal.{u}} (hb : 1 < b) {x : Ordinal × Ordinal} :
 /-- The exponents of the Cantor normal form are decreasing. -/
 theorem CNF_sorted (b o : Ordinal) : ((CNF b o).map Prod.fst).Sorted (· > ·) := by
   refine CNFRec b ?_ (fun o ho IH ↦ ?_) o
-  · simp
+  · rw [CNF_zero]
+    exact sorted_nil
   · rcases le_or_lt b 1 with hb | hb
     · rw [CNF_of_le_one hb ho]
       exact sorted_singleton _

--- a/Mathlib/SetTheory/Ordinal/CantorNormalForm.lean
+++ b/Mathlib/SetTheory/Ordinal/CantorNormalForm.lean
@@ -99,7 +99,7 @@ theorem CNF_fst_le_log {b o : Ordinal.{u}} {x : Ordinal × Ordinal} :
   · simp
   · rw [CNF_ne_zero ho, mem_cons]
     rintro (rfl | h)
-    · exact le_rfl
+    · rfl
     · exact (H h).trans (log_mono_right _ (mod_opow_log_lt_self b ho).le)
 
 /-- Every exponent in the Cantor normal form `CNF b o` is less or equal to `o`. -/

--- a/Mathlib/SetTheory/Ordinal/CantorNormalForm.lean
+++ b/Mathlib/SetTheory/Ordinal/CantorNormalForm.lean
@@ -41,7 +41,7 @@ namespace Ordinal
 @[elab_as_elim]
 noncomputable def CNFRec (b : Ordinal) {C : Ordinal → Sort*} (H0 : C 0)
     (H : ∀ o, o ≠ 0 → C (o % b ^ log b o) → C o) (o : Ordinal) : C o :=
-  if h : o = 0 then h ▸ H0 else H o h (CNFRec _ H0 H (o % b ^ log b o))
+  if h : o = 0 then h ▸ H0 else H o h (CNFRec b H0 H (o % b ^ log b o))
 termination_by o
 decreasing_by exact mod_opow_log_lt_self b h
 

--- a/Mathlib/SetTheory/Ordinal/CantorNormalForm.lean
+++ b/Mathlib/SetTheory/Ordinal/CantorNormalForm.lean
@@ -123,7 +123,7 @@ theorem CNF_snd_lt {b o : Ordinal.{u}} (hb : 1 < b) {x : Ordinal × Ordinal} :
   · rw [CNF_ne_zero ho]
     intro h
     obtain rfl | h := mem_cons.mp h
-    · simpa only using div_opow_log_lt o hb
+    · exact div_opow_log_lt o hb
     · exact IH h
 
 /-- The exponents of the Cantor normal form are decreasing. -/

--- a/Mathlib/SetTheory/Ordinal/CantorNormalForm.lean
+++ b/Mathlib/SetTheory/Ordinal/CantorNormalForm.lean
@@ -40,8 +40,8 @@ namespace Ordinal
 /-- Inducts on the base `b` expansion of an ordinal. -/
 @[elab_as_elim]
 noncomputable def CNFRec (b : Ordinal) {C : Ordinal → Sort*} (H0 : C 0)
-  (H : ∀ o, o ≠ 0 → C (o % b ^ log b o) → C o) (o : Ordinal) : C o :=
-    if h : o = 0 then h ▸ H0 else H o h (CNFRec _ H0 H (o % b ^ log b o))
+    (H : ∀ o, o ≠ 0 → C (o % b ^ log b o) → C o) (o : Ordinal) : C o :=
+  if h : o = 0 then h ▸ H0 else H o h (CNFRec _ H0 H (o % b ^ log b o))
 termination_by o
 decreasing_by exact mod_opow_log_lt_self b h
 

--- a/Mathlib/SetTheory/Ordinal/CantorNormalForm.lean
+++ b/Mathlib/SetTheory/Ordinal/CantorNormalForm.lean
@@ -88,7 +88,7 @@ theorem CNF_of_lt {b o : Ordinal} (ho : o ≠ 0) (hb : o < b) : CNF b o = [(0, o
 /-- Evaluating the Cantor normal form of an ordinal returns the ordinal. -/
 theorem CNF_foldr (b o : Ordinal) : (CNF b o).foldr (fun p r ↦ b ^ p.1 * p.2 + r) 0 = o := by
   refine CNFRec b ?_ ?_ o
-  · simp
+  · rw [CNF_zero, foldr_nil]
   · intro o ho IH
     rw [CNF_ne_zero ho, foldr_cons, IH, div_add_mod]
 

--- a/Mathlib/SetTheory/Ordinal/CantorNormalForm.lean
+++ b/Mathlib/SetTheory/Ordinal/CantorNormalForm.lean
@@ -40,22 +40,20 @@ namespace Ordinal
 /-- Inducts on the base `b` expansion of an ordinal. -/
 @[elab_as_elim]
 noncomputable def CNFRec (b : Ordinal) {C : Ordinal → Sort*} (H0 : C 0)
-    (H : ∀ o, o ≠ 0 → C (o % b ^ log b o) → C o) : ∀ o, C o := fun o ↦ by
-    by_cases h : o = 0
-    · rw [h]; exact H0
-    · exact H o h (CNFRec _ H0 H (o % b ^ log b o))
-    termination_by o => o
-    decreasing_by exact mod_opow_log_lt_self b h
+  (H : ∀ o, o ≠ 0 → C (o % b ^ log b o) → C o) (o : Ordinal) : C o :=
+    if h : o = 0 then h ▸ H0 else H o h (CNFRec _ H0 H (o % b ^ log b o))
+termination_by o
+decreasing_by exact mod_opow_log_lt_self b h
 
 @[simp]
 theorem CNFRec_zero {C : Ordinal → Sort*} (b : Ordinal) (H0 : C 0)
-    (H : ∀ o, o ≠ 0 → C (o % b ^ log b o) → C o) : @CNFRec b C H0 H 0 = H0 := by
+    (H : ∀ o, o ≠ 0 → C (o % b ^ log b o) → C o) : CNFRec b H0 H 0 = H0 := by
   rw [CNFRec, dif_pos rfl]
-  rfl
 
 theorem CNFRec_pos (b : Ordinal) {o : Ordinal} {C : Ordinal → Sort*} (ho : o ≠ 0) (H0 : C 0)
     (H : ∀ o, o ≠ 0 → C (o % b ^ log b o) → C o) :
-    @CNFRec b C H0 H o = H o ho (@CNFRec b C H0 H _) := by rw [CNFRec, dif_neg ho]
+    CNFRec b H0 H o = H o ho (@CNFRec b C H0 H _) := by
+  rw [CNFRec, dif_neg ho]
 
 /-- The Cantor normal form of an ordinal `o` is the list of coefficients and exponents in the
 base-`b` expansion of `o`.
@@ -65,7 +63,7 @@ We special-case `CNF 0 o = CNF 1 o = [(0, o)]` for `o ≠ 0`.
 `CNF b (b ^ u₁ * v₁ + b ^ u₂ * v₂) = [(u₁, v₁), (u₂, v₂)]` -/
 @[pp_nodot]
 def CNF (b o : Ordinal) : List (Ordinal × Ordinal) :=
-  CNFRec b [] (fun o _ho IH ↦ (log b o, o / b ^ log b o)::IH) o
+  CNFRec b [] (fun o _ IH ↦ (log b o, o / b ^ log b o)::IH) o
 
 @[simp]
 theorem CNF_zero (b : Ordinal) : CNF b 0 = [] :=
@@ -76,35 +74,36 @@ theorem CNF_ne_zero {b o : Ordinal} (ho : o ≠ 0) :
     CNF b o = (log b o, o / b ^ log b o)::CNF b (o % b ^ log b o) :=
   CNFRec_pos b ho _ _
 
-theorem zero_CNF {o : Ordinal} (ho : o ≠ 0) : CNF 0 o = [⟨0, o⟩] := by simp [CNF_ne_zero ho]
+theorem zero_CNF {o : Ordinal} (ho : o ≠ 0) : CNF 0 o = [(0, o)] := by simp [CNF_ne_zero ho]
 
-theorem one_CNF {o : Ordinal} (ho : o ≠ 0) : CNF 1 o = [⟨0, o⟩] := by simp [CNF_ne_zero ho]
+theorem one_CNF {o : Ordinal} (ho : o ≠ 0) : CNF 1 o = [(0, o)] := by simp [CNF_ne_zero ho]
 
-theorem CNF_of_le_one {b o : Ordinal} (hb : b ≤ 1) (ho : o ≠ 0) : CNF b o = [⟨0, o⟩] := by
+theorem CNF_of_le_one {b o : Ordinal} (hb : b ≤ 1) (ho : o ≠ 0) : CNF b o = [(0, o)] := by
   rcases le_one_iff.1 hb with (rfl | rfl)
-  · exact zero_CNF ho
-  · exact one_CNF ho
+  exacts [zero_CNF ho, one_CNF ho]
 
-theorem CNF_of_lt {b o : Ordinal} (ho : o ≠ 0) (hb : o < b) : CNF b o = [⟨0, o⟩] := by
-  simp only [CNF_ne_zero ho, log_eq_zero hb, opow_zero, div_one, mod_one, CNF_zero]
+theorem CNF_of_lt {b o : Ordinal} (ho : o ≠ 0) (hb : o < b) : CNF b o = [(0, o)] := by
+  rw [CNF_ne_zero ho, log_eq_zero hb, opow_zero, div_one, mod_one, CNF_zero]
 
 /-- Evaluating the Cantor normal form of an ordinal returns the ordinal. -/
-theorem CNF_foldr (b o : Ordinal) : (CNF b o).foldr (fun p r ↦ b ^ p.1 * p.2 + r) 0 = o :=
-  CNFRec b (by rw [CNF_zero]; rfl)
-    (fun o ho IH ↦ by rw [CNF_ne_zero ho, foldr_cons, IH, div_add_mod]) o
+theorem CNF_foldr (b o : Ordinal) : (CNF b o).foldr (fun p r ↦ b ^ p.1 * p.2 + r) 0 = o := by
+  refine CNFRec b ?_ ?_ o
+  · simp
+  · intro o ho IH
+    rw [CNF_ne_zero ho, foldr_cons, IH, div_add_mod]
 
 /-- Every exponent in the Cantor normal form `CNF b o` is less or equal to `log b o`. -/
 theorem CNF_fst_le_log {b o : Ordinal.{u}} {x : Ordinal × Ordinal} :
     x ∈ CNF b o → x.1 ≤ log b o := by
   refine CNFRec b ?_ (fun o ho H ↦ ?_) o
-  · rw [CNF_zero]
-    intro contra; contradiction
+  · simp
   · rw [CNF_ne_zero ho, mem_cons]
     rintro (rfl | h)
     · exact le_rfl
     · exact (H h).trans (log_mono_right _ (mod_opow_log_lt_self b ho).le)
 
 /-- Every exponent in the Cantor normal form `CNF b o` is less or equal to `o`. -/
+@[deprecated CNF_fst_le_log (since := "2024-09-21")]
 theorem CNF_fst_le {b o : Ordinal.{u}} {x : Ordinal × Ordinal} (h : x ∈ CNF b o) : x.1 ≤ o :=
   (CNF_fst_le_log h).trans <| log_le_self _ _
 
@@ -120,25 +119,27 @@ theorem CNF_lt_snd {b o : Ordinal.{u}} {x : Ordinal × Ordinal} : x ∈ CNF b o 
 theorem CNF_snd_lt {b o : Ordinal.{u}} (hb : 1 < b) {x : Ordinal × Ordinal} :
     x ∈ CNF b o → x.2 < b := by
   refine CNFRec b ?_ (fun o ho IH ↦ ?_) o
-  · simp only [CNF_zero, not_mem_nil, IsEmpty.forall_iff]
+  · simp
   · rw [CNF_ne_zero ho]
     intro h
-    cases' (mem_cons.mp h) with h h
-    · rw [h]; simpa only using div_opow_log_lt o hb
+    obtain rfl | h := mem_cons.mp h
+    · simpa only using div_opow_log_lt o hb
     · exact IH h
 
 /-- The exponents of the Cantor normal form are decreasing. -/
 theorem CNF_sorted (b o : Ordinal) : ((CNF b o).map Prod.fst).Sorted (· > ·) := by
   refine CNFRec b ?_ (fun o ho IH ↦ ?_) o
-  · simp only [gt_iff_lt, CNF_zero, map_nil, sorted_nil]
+  · simp
   · rcases le_or_lt b 1 with hb | hb
-    · simp only [CNF_of_le_one hb ho, gt_iff_lt, map_cons, map, sorted_singleton]
-    · cases' lt_or_le o b with hob hbo
-      · simp only [CNF_of_lt ho hob, gt_iff_lt, map_cons, map, sorted_singleton]
+    · rw [CNF_of_le_one hb ho]
+      exact sorted_singleton _
+    · obtain hob | hbo := lt_or_le o b
+      · rw [CNF_of_lt ho hob]
+        exact sorted_singleton _
       · rw [CNF_ne_zero ho, map_cons, sorted_cons]
         refine ⟨fun a H ↦ ?_, IH⟩
         rw [mem_map] at H
         rcases H with ⟨⟨a, a'⟩, H, rfl⟩
-        exact (CNF_fst_le_log H).trans_lt (log_mod_opow_log_lt_log_self hb ho hbo)
+        exact (CNF_fst_le_log H).trans_lt (log_mod_opow_log_lt_log_self hb hbo)
 
 end Ordinal

--- a/Mathlib/SetTheory/Ordinal/Exponential.lean
+++ b/Mathlib/SetTheory/Ordinal/Exponential.lean
@@ -333,11 +333,11 @@ theorem mod_opow_log_lt_self (b : Ordinal) {o : Ordinal} (ho : o ≠ 0) : o % (b
   · simpa using Ordinal.pos_iff_ne_zero.2 ho
   · exact (mod_lt _ <| opow_ne_zero _ hb).trans_le (opow_log_le_self _ ho)
 
-theorem log_mod_opow_log_lt_log_self {b o : Ordinal} (hb : 1 < b) (ho : o ≠ 0) (hbo : b ≤ o) :
+theorem log_mod_opow_log_lt_log_self {b o : Ordinal} (hb : 1 < b) (hbo : b ≤ o) :
     log b (o % (b ^ log b o)) < log b o := by
   rcases eq_or_ne (o % (b ^ log b o)) 0 with h | h
   · rw [h, log_zero_right]
-    apply log_pos hb ho hbo
+    exact log_pos hb (one_le_iff_ne_zero.1 (hb.le.trans hbo)) hbo
   · rw [← succ_le_iff, succ_log_def hb h]
     apply csInf_le'
     apply mod_lt


### PR DESCRIPTION
We golf a bunch of proofs, and perform formatting improvements.

We also deprecate `CNF_fst_le`, which is a weaker (and IME no more convenient) form of `CNF_fst_le_log`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
