### PR TITLE
[Merged by Bors] - feat: `⌈a⌉ < 2 * a`

### DIFF
--- a/Mathlib/Algebra/Order/Floor.lean
+++ b/Mathlib/Algebra/Order/Floor.lean
@@ -1242,10 +1242,10 @@ lemma ceil_div_ceil_inv_sub_one (ha : 1 ≤ a) : ⌈⌈(a - 1)⁻¹⌉ / a⌉ = 
   have : 0 < a - 1 := by linarith
   have : 0 < ⌈(a - 1)⁻¹⌉ := ceil_pos.2 <| by positivity
   refine le_antisymm (ceil_le.2 <| div_le_self (by positivity) ha.le) <| ?_
-  rw [le_ceil_iff, sub_lt_comm, div_eq_mul_inv, ← mul_one_sub, ← lt_div_iff]
+  rw [le_ceil_iff, sub_lt_comm, div_eq_mul_inv, ← mul_one_sub,
+      ← lt_div_iff (sub_pos.2 <| inv_lt_one ha)]
   convert ceil_lt_add_one _ using 1
   field_simp
-  exact sub_pos.2 <| inv_lt_one ha
 
 lemma ceil_lt_mul (hb : 1 < b) (hba : ⌈(b - 1)⁻¹⌉ / b < a) : ⌈a⌉ < b * a := by
   obtain hab | hba := le_total a (b - 1)⁻¹

--- a/Mathlib/Algebra/Order/Floor.lean
+++ b/Mathlib/Algebra/Order/Floor.lean
@@ -499,6 +499,21 @@ theorem floor_div_eq_div (m n : ℕ) : ⌊(m : α) / n⌋₊ = m / n := by
 
 end LinearOrderedSemifield
 
+section LinearOrderedField
+variable [LinearOrderedField α] [FloorSemiring α] {a b : α}
+
+lemma ceil_lt_mul (ha : 0 ≤ a) (hb : 1 < b) (h : (b - 1)⁻¹ ≤ a) : ⌈a⌉₊ < b * a := by
+  rw [← sub_pos] at hb
+  calc
+    ⌈a⌉₊ < a + 1 := ceil_lt_add_one ha
+    _ = a + (b - 1) * (b - 1)⁻¹ := by rw [mul_inv_cancel₀]; positivity
+    _ ≤ a + (b - 1) * a := by gcongr; positivity
+    _ = b * a := by rw [sub_one_mul, add_sub_cancel]
+
+lemma ceil_lt_two_mul (ha : 1 ≤ a) : ⌈a⌉₊ < 2 * a :=
+  ceil_lt_mul (by positivity) one_lt_two (by norm_num; exact ha)
+
+end LinearOrderedField
 end Nat
 
 /-- There exists at most one `FloorSemiring` structure on a linear ordered semiring. -/
@@ -1199,6 +1214,21 @@ theorem ceil_eq_add_one_sub_fract (ha : fract a ≠ 0) : (⌈a⌉ : α) = a + 1 
 theorem ceil_sub_self_eq (ha : fract a ≠ 0) : (⌈a⌉ : α) - a = 1 - fract a := by
   rw [(or_iff_right ha).mp (fract_eq_zero_or_add_one_sub_ceil a)]
   abel
+
+section LinearOrderedField
+variable {k : Type*} [LinearOrderedField k] [FloorRing k] {a b : k}
+
+lemma ceil_lt_mul (hb : 1 < b) (ha : (b - 1)⁻¹ ≤ a) : ⌈a⌉ < b * a := by
+  rw [← sub_pos] at hb
+  calc
+    ⌈a⌉ < a + 1 := ceil_lt_add_one _
+    _ = a + (b - 1) * (b - 1)⁻¹ := by rw [mul_inv_cancel₀]; positivity
+    _ ≤ a + (b - 1) * a := by gcongr; positivity
+    _ = b * a := by rw [sub_one_mul, add_sub_cancel]
+
+lemma ceil_lt_two_mul (ha : 1 ≤ a) : ⌈a⌉ < 2 * a := ceil_lt_mul one_lt_two (by norm_num; exact ha)
+
+end LinearOrderedField
 
 /-! #### Intervals -/
 

--- a/Mathlib/Algebra/Order/Floor.lean
+++ b/Mathlib/Algebra/Order/Floor.lean
@@ -503,6 +503,14 @@ end LinearOrderedSemifield
 section LinearOrderedField
 variable [LinearOrderedField α] [FloorSemiring α] {a b : α}
 
+lemma mul_lt_floor (hb₀ : 0 < b) (hb : b < 1) (hba : ⌈b / (1 - b)⌉₊ ≤ a) : b * a < ⌊a⌋₊ := by
+  calc
+    b * a < b * (⌊a⌋₊ + 1) := by gcongr; exacts [hb₀, lt_floor_add_one _]
+    _ ≤ ⌊a⌋₊ := by
+      rw [_root_.mul_add_one, ← le_sub_iff_add_le', ← one_sub_mul, ← div_le_iff₀' (by linarith),
+        ← ceil_le]
+      exact le_floor hba
+
 lemma ceil_lt_mul (hb : 1 < b) (hba : ⌈(b - 1)⁻¹⌉₊ / b < a) : ⌈a⌉₊ < b * a := by
   obtain hab | hba := le_total a (b - 1)⁻¹
   · calc
@@ -515,12 +523,15 @@ lemma ceil_lt_mul (hb : 1 < b) (hba : ⌈(b - 1)⁻¹⌉₊ / b < a) : ⌈a⌉�
       _ ≤ a + (b - 1) * a := by gcongr; positivity
       _ = b * a := by rw [sub_one_mul, add_sub_cancel]
 
-lemma ceil_le_mul (hb : 1 < b) (ha : ⌈(b - 1)⁻¹⌉₊ / b ≤ a) : ⌈a⌉₊ ≤ b * a := by
-  obtain rfl | ha := ha.eq_or_lt
+lemma ceil_le_mul (hb : 1 < b) (hba : ⌈(b - 1)⁻¹⌉₊ / b ≤ a) : ⌈a⌉₊ ≤ b * a := by
+  obtain rfl | hba := hba.eq_or_lt
   · rw [mul_div_cancel₀, cast_le, ceil_le]
     exact _root_.div_le_self (by positivity) hb.le
     · positivity
-  · exact (ceil_lt_mul hb ha).le
+  · exact (ceil_lt_mul hb hba).le
+
+lemma div_two_lt_floor (ha : 1 ≤ a) : a / 2 < ⌊a⌋₊ := by
+  rw [div_eq_inv_mul]; refine mul_lt_floor ?_ ?_ ?_ <;> norm_num; assumption
 
 lemma ceil_lt_two_mul (ha : 2⁻¹ < a) : ⌈a⌉₊ < 2 * a :=
   ceil_lt_mul one_lt_two (by norm_num at ha ⊢; exact ha)
@@ -1236,6 +1247,13 @@ theorem ceil_sub_self_eq (ha : fract a ≠ 0) : (⌈a⌉ : α) - a = 1 - fract a
 section LinearOrderedField
 variable {k : Type*} [LinearOrderedField k] [FloorRing k] {a b : k}
 
+lemma mul_lt_floor (hb₀ : 0 < b) (hb : b < 1) (hba : ⌈b / (1 - b)⌉ ≤ a) : b * a < ⌊a⌋ := by
+  calc
+    b * a < b * (⌊a⌋ + 1) := by gcongr; exacts [hb₀, lt_floor_add_one _]
+    _ ≤ ⌊a⌋ := by
+      rwa [_root_.mul_add_one, ← le_sub_iff_add_le', ← one_sub_mul, ← div_le_iff₀' (by linarith),
+        ← ceil_le, le_floor]
+
 lemma ceil_div_ceil_inv_sub_one (ha : 1 ≤ a) : ⌈⌈(a - 1)⁻¹⌉ / a⌉ = ⌈(a - 1)⁻¹⌉ := by
   obtain rfl | ha := ha.eq_or_lt
   · simp
@@ -1259,11 +1277,14 @@ lemma ceil_lt_mul (hb : 1 < b) (hba : ⌈(b - 1)⁻¹⌉ / b < a) : ⌈a⌉ < b 
       _ ≤ a + (b - 1) * a := by gcongr; positivity
       _ = b * a := by rw [sub_one_mul, add_sub_cancel]
 
-lemma ceil_le_mul (hb : 1 < b) (ha : ⌈(b - 1)⁻¹⌉ / b ≤ a) : ⌈a⌉ ≤ b * a := by
-  obtain rfl | ha := ha.eq_or_lt
+lemma ceil_le_mul (hb : 1 < b) (hba : ⌈(b - 1)⁻¹⌉ / b ≤ a) : ⌈a⌉ ≤ b * a := by
+  obtain rfl | hba := hba.eq_or_lt
   · rw [ceil_div_ceil_inv_sub_one hb.le, mul_div_cancel₀]
     positivity
-  · exact (ceil_lt_mul hb ha).le
+  · exact (ceil_lt_mul hb hba).le
+
+lemma div_two_lt_floor (ha : 1 ≤ a) : a / 2 < ⌊a⌋ := by
+  rw [div_eq_inv_mul]; refine mul_lt_floor ?_ ?_ ?_ <;> norm_num; assumption
 
 lemma ceil_lt_two_mul (ha : 2⁻¹ < a) : ⌈a⌉ < 2 * a :=
   ceil_lt_mul one_lt_two (by norm_num at ha ⊢; exact ha)

--- a/Mathlib/Algebra/Order/Floor.lean
+++ b/Mathlib/Algebra/Order/Floor.lean
@@ -503,16 +503,30 @@ end LinearOrderedSemifield
 section LinearOrderedField
 variable [LinearOrderedField α] [FloorSemiring α] {a b : α}
 
-lemma ceil_lt_mul (ha : 0 ≤ a) (hb : 1 < b) (h : (b - 1)⁻¹ ≤ a) : ⌈a⌉₊ < b * a := by
-  rw [← sub_pos] at hb
-  calc
-    ⌈a⌉₊ < a + 1 := ceil_lt_add_one ha
-    _ = a + (b - 1) * (b - 1)⁻¹ := by rw [mul_inv_cancel₀]; positivity
-    _ ≤ a + (b - 1) * a := by gcongr; positivity
-    _ = b * a := by rw [sub_one_mul, add_sub_cancel]
+lemma ceil_lt_mul (hb : 1 < b) (hba : ⌈(b - 1)⁻¹⌉₊ / b < a) : ⌈a⌉₊ < b * a := by
+  obtain hab | hba := le_total a (b - 1)⁻¹
+  · calc
+      ⌈a⌉₊ ≤ (⌈(b - 1)⁻¹⌉₊ : α) := by gcongr
+      _ < b * a := by rwa [← div_lt_iff']; positivity
+  · rw [← sub_pos] at hb
+    calc
+      ⌈a⌉₊ < a + 1 := ceil_lt_add_one <| hba.trans' <| by positivity
+      _ = a + (b - 1) * (b - 1)⁻¹ := by rw [mul_inv_cancel₀]; positivity
+      _ ≤ a + (b - 1) * a := by gcongr; positivity
+      _ = b * a := by rw [sub_one_mul, add_sub_cancel]
 
-lemma ceil_lt_two_mul (ha : 1 ≤ a) : ⌈a⌉₊ < 2 * a :=
-  ceil_lt_mul (by positivity) one_lt_two (by norm_num; exact ha)
+lemma ceil_le_mul (hb : 1 < b) (ha : ⌈(b - 1)⁻¹⌉₊ / b ≤ a) : ⌈a⌉₊ ≤ b * a := by
+  obtain rfl | ha := ha.eq_or_lt
+  · rw [mul_div_cancel₀, cast_le, ceil_le]
+    exact _root_.div_le_self (by positivity) hb.le
+    · positivity
+  · exact (ceil_lt_mul hb ha).le
+
+lemma ceil_lt_two_mul (ha : 2⁻¹ < a) : ⌈a⌉₊ < 2 * a :=
+  ceil_lt_mul one_lt_two (by norm_num at ha ⊢; exact ha)
+
+lemma ceil_le_two_mul (ha : 2⁻¹ ≤ a) : ⌈a⌉₊ ≤ 2 * a :=
+  ceil_le_mul one_lt_two (by norm_num at ha ⊢; exact ha)
 
 end LinearOrderedField
 end Nat
@@ -1233,13 +1247,17 @@ lemma ceil_div_ceil_inv_sub_one (ha : 1 ≤ a) : ⌈⌈(a - 1)⁻¹⌉ / a⌉ = 
   field_simp
   exact sub_pos.2 <| inv_lt_one ha
 
-lemma ceil_lt_mul (hb : 1 < b) (ha : ⌈(b - 1)⁻¹⌉ / b < a) : ⌈a⌉ < b * a := by
-  rw [← sub_pos] at hb
-  calc
-    ⌈a⌉ < a + 1 := ceil_lt_add_one _
-    _ = a + (b - 1) * (b - 1)⁻¹ := by rw [mul_inv_cancel₀]; positivity
-    _ ≤ a + (b - 1) * a := by gcongr; positivity
-    _ = b * a := by rw [sub_one_mul, add_sub_cancel]
+lemma ceil_lt_mul (hb : 1 < b) (hba : ⌈(b - 1)⁻¹⌉ / b < a) : ⌈a⌉ < b * a := by
+  obtain hab | hba := le_total a (b - 1)⁻¹
+  · calc
+      ⌈a⌉ ≤ (⌈(b - 1)⁻¹⌉ : k) := by gcongr
+      _ < b * a := by rwa [← div_lt_iff']; positivity
+  · rw [← sub_pos] at hb
+    calc
+      ⌈a⌉ < a + 1 := ceil_lt_add_one _
+      _ = a + (b - 1) * (b - 1)⁻¹ := by rw [mul_inv_cancel₀]; positivity
+      _ ≤ a + (b - 1) * a := by gcongr; positivity
+      _ = b * a := by rw [sub_one_mul, add_sub_cancel]
 
 lemma ceil_le_mul (hb : 1 < b) (ha : ⌈(b - 1)⁻¹⌉ / b ≤ a) : ⌈a⌉ ≤ b * a := by
   obtain rfl | ha := ha.eq_or_lt

--- a/Mathlib/Algebra/Order/Ring/Cast.lean
+++ b/Mathlib/Algebra/Order/Ring/Cast.lean
@@ -37,6 +37,8 @@ lemma cast_mono : Monotone (Int.cast : ℤ → R) := by
   rw [← sub_nonneg, ← cast_sub, ← hk, cast_natCast]
   exact k.cast_nonneg'
 
+@[gcongr] protected lemma GCongr.intCast_mono {m n : ℤ} (hmn : m ≤ n) : (m : R) ≤ n := cast_mono hmn
+
 variable [NeZero (1 : R)] {m n : ℤ}
 
 @[simp] lemma cast_nonneg : ∀ {n : ℤ}, (0 : R) ≤ n ↔ 0 ≤ n
@@ -52,6 +54,8 @@ lemma cast_strictMono : StrictMono (fun x : ℤ => (x : R)) :=
   strictMono_of_le_iff_le fun _ _ => cast_le.symm
 
 @[simp, norm_cast] lemma cast_lt : (m : R) < n ↔ m < n := cast_strictMono.lt_iff_lt
+
+@[gcongr] protected alias ⟨_, GCongr.intCast_strictMono⟩ := Int.cast_lt
 
 @[simp] lemma cast_nonpos : (n : R) ≤ 0 ↔ n ≤ 0 := by rw [← cast_zero, cast_le]
 


### PR DESCRIPTION
From LeanAPAP


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
