### PR TITLE
[Merged by Bors] - feat(RingTheory/IsTensorProduct): cancel pushout square on the left

### DIFF
--- a/Mathlib/Algebra/Module/LinearMap/Defs.lean
+++ b/Mathlib/Algebra/Module/LinearMap/Defs.lean
@@ -933,9 +933,8 @@ end Actions
 
 section RestrictScalarsAsLinearMap
 
-variable {R S M N : Type*} [Semiring R] [Semiring S] [AddCommGroup M] [AddCommGroup N] [Module R M]
-   [Module R N] [Module S M] [Module S N]
-  [LinearMap.CompatibleSMul M N R S]
+variable {R S M N P : Type*} [Semiring R] [Semiring S] [AddCommMonoid M] [AddCommMonoid N]
+  [Module R M] [Module R N] [Module S M] [Module S N] [CompatibleSMul M N R S]
 
 variable (R S M N) in
 @[simp]
@@ -948,7 +947,9 @@ theorem restrictScalars_add (f g : M →ₗ[S] N) :
   rfl
 
 @[simp]
-theorem restrictScalars_neg (f : M →ₗ[S] N) : (-f).restrictScalars R = -f.restrictScalars R :=
+theorem restrictScalars_neg {M N : Type*} [AddCommGroup M] [AddCommGroup N]
+    [Module R M] [Module R N] [Module S M] [Module S N] [CompatibleSMul M N R S]
+    (f : M →ₗ[S] N) : (-f).restrictScalars R = -f.restrictScalars R :=
   rfl
 
 variable {R₁ : Type*} [Semiring R₁] [Module R₁ N] [SMulCommClass S R₁ N] [SMulCommClass R R₁ N]
@@ -956,6 +957,18 @@ variable {R₁ : Type*} [Semiring R₁] [Module R₁ N] [SMulCommClass S R₁ N]
 @[simp]
 theorem restrictScalars_smul (c : R₁) (f : M →ₗ[S] N) :
     (c • f).restrictScalars R = c • f.restrictScalars R :=
+  rfl
+
+@[simp]
+lemma restrictScalars_comp [AddCommMonoid P] [Module S P] [Module R P]
+    [CompatibleSMul N P R S] [CompatibleSMul M P R S] (f : N →ₗ[S] P) (g : M →ₗ[S] N) :
+    (f ∘ₗ g).restrictScalars R = f.restrictScalars R ∘ₗ g.restrictScalars R := by
+  rfl
+
+@[simp]
+lemma restrictScalars_trans {T : Type*} [CommSemiring T] [Module T M] [Module T N]
+    [CompatibleSMul M N S T] [CompatibleSMul M N R T] (f : M →ₗ[T] N) :
+    (f.restrictScalars S).restrictScalars R = f.restrictScalars R :=
   rfl
 
 variable (S M N R R₁)

--- a/Mathlib/RingTheory/IsTensorProduct.lean
+++ b/Mathlib/RingTheory/IsTensorProduct.lean
@@ -345,6 +345,7 @@ variable [Algebra R R'] [Algebra S S'] [Algebra R' S'] [Algebra R S']
 variable [IsScalarTower R R' S'] [IsScalarTower R S S']
 
 open IsScalarTower (toAlgHom)
+open IsScalarTower (algebraMap_apply)
 
 variable (R S R' S')
 
@@ -493,6 +494,17 @@ theorem Algebra.IsPushout.algHom_ext [H : Algebra.IsPushout R S R' S'] {A : Type
   · intro s₁ s₂ e₁ e₂
     rw [map_add, map_add, e₁, e₂]
 
+/--
+Given a commutative diagram of rings
+```
+  R  →  S  →  T
+  ↓     ↓     ↓
+  R' →  S' →  T'
+```
+where the left-hand square is a pushout and the big rectangle is a pushout, then also the
+right-hand square is a pushout. Note that this is essentially the isomorphism
+`T ⊗[S] (S ⊗[R] R') ≃ₐ[T] T ⊗[R] R'.
+-/
 lemma Algebra.IsPushout.of_comp {T' : Type*} [CommRing T'] [Algebra R T']
     [Algebra S' T'] [Algebra S T'] [Algebra T T'] [Algebra R' T']
     [IsScalarTower R T T'] [IsScalarTower S T T'] [IsScalarTower S S' T']
@@ -501,22 +513,14 @@ lemma Algebra.IsPushout.of_comp {T' : Type*} [CommRing T'] [Algebra R T']
     Algebra.IsPushout S T S' T' := by
   constructor
   let f : R' →ₗ[R] S' := (IsScalarTower.toAlgHom R R' S').toLinearMap
-  let g : R' →ₗ[R] T' := (IsScalarTower.toAlgHom R R' T').toLinearMap
-  haveI : IsScalarTower R S T' := IsScalarTower.of_algebraMap_eq <| by
-    intro x
-    rw [IsScalarTower.algebraMap_apply S T T']
-    rw [IsScalarTower.algebraMap_apply R S' T']
-    rw [IsScalarTower.algebraMap_apply R S S']
-    rw [← IsScalarTower.algebraMap_apply S T T']
-    rw [← IsScalarTower.algebraMap_apply S S' T']
-  have heq : (IsScalarTower.toAlgHom S S' T').toLinearMap.restrictScalars R ∘ₗ f =
-      (IsScalarTower.toAlgHom R R' T').toLinearMap := by
+  haveI : IsScalarTower R S T' := IsScalarTower.of_algebraMap_eq <| fun x ↦ by
+    rw [algebraMap_apply R S' T', algebraMap_apply R S S', ← algebraMap_apply S S' T']
+  apply IsBaseChange.of_comp (f := f) Algebra.IsPushout.out
+  have heq : (toAlgHom S S' T').toLinearMap.restrictScalars R ∘ₗ f =
+      (toAlgHom R R' T').toLinearMap := by
     ext x
-    simp [f, g]
-    rw [← IsScalarTower.algebraMap_apply]
-  apply IsBaseChange.of_comp (f := f)
-  · exact Algebra.IsPushout.out
-  · rw [heq]
-    exact Algebra.IsPushout.out
+    simp [f, ← IsScalarTower.algebraMap_apply]
+  rw [heq]
+  exact Algebra.IsPushout.out
 
 end IsBaseChange

--- a/Mathlib/RingTheory/IsTensorProduct.lean
+++ b/Mathlib/RingTheory/IsTensorProduct.lean
@@ -318,7 +318,7 @@ theorem IsBaseChange.comp {f : M →ₗ[R] N} (hf : IsBaseChange S f) {g : N →
   ext
   rfl
 
-/-- If `N` is the base change of `M` to `S` and `O` the base change of `M` to `R`, then
+/-- If `N` is the base change of `M` to `S` and `O` the base change of `M` to `T`, then
 `O` is the base change of `N` to `T`. -/
 lemma IsBaseChange.of_comp {f : M →ₗ[R] N} (hf : IsBaseChange S f) {h : N →ₗ[S] O}
     (hc : IsBaseChange T ((h : N →ₗ[R] O) ∘ₗ f)) :
@@ -339,6 +339,12 @@ lemma IsBaseChange.of_comp {f : M →ₗ[R] N} (hf : IsBaseChange S f) {h : N �
     apply_fun LinearMap.restrictScalars R at hq'
     rw [← LinearMap.comp_assoc]
     rw [show q'.restrictScalars R ∘ₗ h.restrictScalars R = _ from hq', hc.lift_comp]
+
+/-- If `N` is the base change `M` to `S`, then `O` is the base change of `M` to `T` if and
+only if `O` is the base change of `N` to `T`. -/
+lemma IsBaseChange.comp_iff {f : M →ₗ[R] N} (hf : IsBaseChange S f) {h : N →ₗ[S] O} :
+    IsBaseChange T ((h : N →ₗ[R] O) ∘ₗ f) ↔ IsBaseChange T h :=
+  ⟨fun hc ↦ IsBaseChange.of_comp hf hc, fun hh ↦ IsBaseChange.comp hf hh⟩
 
 variable {R' S' : Type*} [CommSemiring R'] [CommSemiring S']
 variable [Algebra R R'] [Algebra S S'] [Algebra R' S'] [Algebra R S']
@@ -495,32 +501,32 @@ theorem Algebra.IsPushout.algHom_ext [H : Algebra.IsPushout R S R' S'] {A : Type
     rw [map_add, map_add, e₁, e₂]
 
 /--
-Given a commutative diagram of rings
+Let the following be a commutative diagram of rings
 ```
   R  →  S  →  T
   ↓     ↓     ↓
   R' →  S' →  T'
 ```
-where the left-hand square is a pushout and the big rectangle is a pushout, then also the
-right-hand square is a pushout. Note that this is essentially the isomorphism
-`T ⊗[S] (S ⊗[R] R') ≃ₐ[T] T ⊗[R] R'`.
+where the left-hand square is a pushout. Then the following are equivalent:
+- the big rectangle is a pushout.
+- the right-hand square is a pushout.
+
+Note that this is essentially the isomorphism `T ⊗[S] (S ⊗[R] R') ≃ₐ[T] T ⊗[R] R'`.
 -/
-lemma Algebra.IsPushout.of_comp {T' : Type*} [CommRing T'] [Algebra R T']
+lemma Algebra.IsPushout.comp_iff {T' : Type*} [CommRing T'] [Algebra R T']
     [Algebra S' T'] [Algebra S T'] [Algebra T T'] [Algebra R' T']
     [IsScalarTower R T T'] [IsScalarTower S T T'] [IsScalarTower S S' T']
     [IsScalarTower R R' T'] [IsScalarTower R S' T'] [IsScalarTower R' S' T']
-    [Algebra.IsPushout R S R' S'] [Algebra.IsPushout R T R' T'] :
-    Algebra.IsPushout S T S' T' := by
-  constructor
+    [Algebra.IsPushout R S R' S'] :
+    Algebra.IsPushout R T R' T' ↔ Algebra.IsPushout S T S' T' := by
   let f : R' →ₗ[R] S' := (IsScalarTower.toAlgHom R R' S').toLinearMap
   haveI : IsScalarTower R S T' := IsScalarTower.of_algebraMap_eq <| fun x ↦ by
     rw [algebraMap_apply R S' T', algebraMap_apply R S S', ← algebraMap_apply S S' T']
-  apply IsBaseChange.of_comp (f := f) Algebra.IsPushout.out
   have heq : (toAlgHom S S' T').toLinearMap.restrictScalars R ∘ₗ f =
       (toAlgHom R R' T').toLinearMap := by
     ext x
     simp [f, ← IsScalarTower.algebraMap_apply]
-  rw [heq]
+  rw [isPushout_iff, isPushout_iff, ← heq, IsBaseChange.comp_iff]
   exact Algebra.IsPushout.out
 
 end IsBaseChange

--- a/Mathlib/RingTheory/IsTensorProduct.lean
+++ b/Mathlib/RingTheory/IsTensorProduct.lean
@@ -503,7 +503,7 @@ Given a commutative diagram of rings
 ```
 where the left-hand square is a pushout and the big rectangle is a pushout, then also the
 right-hand square is a pushout. Note that this is essentially the isomorphism
-`T ⊗[S] (S ⊗[R] R') ≃ₐ[T] T ⊗[R] R'.
+`T ⊗[S] (S ⊗[R] R') ≃ₐ[T] T ⊗[R] R'`.
 -/
 lemma Algebra.IsPushout.of_comp {T' : Type*} [CommRing T'] [Algebra R T']
     [Algebra S' T'] [Algebra S T'] [Algebra T T'] [Algebra R' T']


### PR DESCRIPTION
Given a commutative diagram of rings
```
  R  →  S  →  T
  ↓     ↓     ↓
  R' →  S' →  T'
```
where the left-hand square is a pushout and the big rectangle is a pushout, we show that then also the
right-hand square is a pushout.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
