### PR TITLE
[Merged by Bors] - feat: The computable functions are closed under if-then-else definitions with computable predicates

### DIFF
--- a/Mathlib/Computability/Halting.lean
+++ b/Mathlib/Computability/Halting.lean
@@ -173,6 +173,18 @@ protected theorem not {p : α → Prop} (hp : ComputablePred p) : ComputablePred
         simp only [Bool.not_eq_true]
         cases f n <;> rfl⟩
 
+/-- The computable functions are closed under if-then-else definitions. -/
+theorem ite {f₁ f₂ : ℕ → ℕ} (hf₁ : Computable f₁) (hf₂ : Computable f₂)
+    {c : ℕ → Prop} [∀ k, Decidable (c k)] (hc : ComputablePred c) :
+    Computable fun k ↦ if c k then f₁ k else f₂ k :=
+  Computable.of_eq (by
+    show Computable fun k ↦ bif c k then f₁ k else f₂ k
+    exact Computable.cond (by
+      obtain ⟨h₀,h₁⟩ := hc
+      exact (Eq.to_iff <|congrArg _ (funext fun _ => decide_eq_decide.mpr <| Eq.to_iff rfl)).1 h₁)
+      hf₁ hf₂)
+    fun _ => by simp
+
 theorem to_re {p : α → Prop} (hp : ComputablePred p) : RePred p := by
   obtain ⟨f, hf, rfl⟩ := computable_iff.1 hp
   unfold RePred

--- a/Mathlib/Computability/Halting.lean
+++ b/Mathlib/Computability/Halting.lean
@@ -175,7 +175,7 @@ protected theorem not {p : α → Prop} (hp : ComputablePred p) : ComputablePred
 
 /-- The computable functions are closed under if-then-else definitions. -/
 theorem ite {f₁ f₂ : ℕ → ℕ} (hf₁ : Computable f₁) (hf₂ : Computable f₂)
-    {c : ℕ → Prop} [∀ k, Decidable (c k)] (hc : ComputablePred c) :
+    {c : ℕ → Prop} [DecidablePred c] (hc : ComputablePred c) :
     Computable fun k ↦ if c k then f₁ k else f₂ k := by
   simp_rw [← Bool.cond_decide]
   obtain ⟨inst, hc⟩ := hc

--- a/Mathlib/Computability/Halting.lean
+++ b/Mathlib/Computability/Halting.lean
@@ -176,14 +176,10 @@ protected theorem not {p : α → Prop} (hp : ComputablePred p) : ComputablePred
 /-- The computable functions are closed under if-then-else definitions. -/
 theorem ite {f₁ f₂ : ℕ → ℕ} (hf₁ : Computable f₁) (hf₂ : Computable f₂)
     {c : ℕ → Prop} [∀ k, Decidable (c k)] (hc : ComputablePred c) :
-    Computable fun k ↦ if c k then f₁ k else f₂ k :=
-  Computable.of_eq (by
-    show Computable fun k ↦ bif c k then f₁ k else f₂ k
-    exact Computable.cond (by
-      obtain ⟨h₀,h₁⟩ := hc
-      exact (Eq.to_iff <|congrArg _ (funext fun _ => decide_eq_decide.mpr <| Eq.to_iff rfl)).1 h₁)
-      hf₁ hf₂)
-    fun _ => by simp
+    Computable fun k ↦ if c k then f₁ k else f₂ k := by
+  simp_rw [← Bool.cond_decide]
+  obtain ⟨inst, hc⟩ := hc
+  convert hc.cond hf₁ hf₂
 
 theorem to_re {p : α → Prop} (hp : ComputablePred p) : RePred p := by
   obtain ⟨f, hf, rfl⟩ := computable_iff.1 hp

--- a/Mathlib/Computability/Halting.lean
+++ b/Mathlib/Computability/Halting.lean
@@ -173,7 +173,8 @@ protected theorem not {p : α → Prop} (hp : ComputablePred p) : ComputablePred
         simp only [Bool.not_eq_true]
         cases f n <;> rfl⟩
 
-/-- The computable functions are closed under if-then-else definitions. -/
+/-- The computable functions are closed under if-then-else definitions
+with computable predicates. -/
 theorem ite {f₁ f₂ : ℕ → ℕ} (hf₁ : Computable f₁) (hf₂ : Computable f₂)
     {c : ℕ → Prop} [DecidablePred c] (hc : ComputablePred c) :
     Computable fun k ↦ if c k then f₁ k else f₂ k := by

--- a/Mathlib/Computability/PartrecCode.lean
+++ b/Mathlib/Computability/PartrecCode.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2018 Mario Carneiro. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Mario Carneiro
+Authors: Mario Carneiro, Bjørn Kjos-Hanssen
 -/
 import Mathlib.Computability.Partrec
 import Mathlib.Data.Option.Basic
@@ -1027,3 +1027,19 @@ instance : Countable {f : ℕ → ℕ // Computable f} :=
     (fun _ _ h => Subtype.val_inj.1 (PFun.lift_injective (by simpa using h)))
 
 end Nat.Partrec.Code
+
+/-- There are only countably many partial recursive functions ℕ → ℕ. -/
+instance : Countable {f : ℕ →. ℕ | Nat.Partrec f} := by
+  rw [Set.ext <| fun f => @Nat.Partrec.Code.exists_code f]
+  apply @Function.Injective.countable
+    ({f | ∃ c, Nat.Partrec.Code.eval c = f}) Nat.Partrec.Code _ (fun f => Classical.choose f.2)
+  intro f g h
+  apply SetCoe.ext
+  rw [← Classical.choose_spec f.2,← Classical.choose_spec g.2]
+  tauto
+
+/-- There are only countably many computable functions ℕ → ℕ. -/
+instance : Countable {f : ℕ → ℕ | Computable f} :=
+  @Function.Injective.countable {f : ℕ → ℕ | Computable f} {f : ℕ →. ℕ | Nat.Partrec f} _
+    (fun f => ⟨f.val, Partrec.nat_iff.mp f.2⟩)
+    fun _ _ h => SetCoe.ext <| PFun.lift_injective <| (Subtype.mk.injEq _ _ _ _) ▸ h

--- a/Mathlib/Computability/PartrecCode.lean
+++ b/Mathlib/Computability/PartrecCode.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2018 Mario Carneiro. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Mario Carneiro, Bjørn Kjos-Hanssen
+Authors: Mario Carneiro
 -/
 import Mathlib.Computability.Partrec
 import Mathlib.Data.Option.Basic
@@ -1027,19 +1027,3 @@ instance : Countable {f : ℕ → ℕ // Computable f} :=
     (fun _ _ h => Subtype.val_inj.1 (PFun.lift_injective (by simpa using h)))
 
 end Nat.Partrec.Code
-
-/-- There are only countably many partial recursive functions ℕ → ℕ. -/
-instance : Countable {f : ℕ →. ℕ | Nat.Partrec f} := by
-  rw [Set.ext <| fun f => @Nat.Partrec.Code.exists_code f]
-  apply @Function.Injective.countable
-    ({f | ∃ c, Nat.Partrec.Code.eval c = f}) Nat.Partrec.Code _ (fun f => Classical.choose f.2)
-  intro f g h
-  apply SetCoe.ext
-  rw [← Classical.choose_spec f.2,← Classical.choose_spec g.2]
-  tauto
-
-/-- There are only countably many computable functions ℕ → ℕ. -/
-instance : Countable {f : ℕ → ℕ | Computable f} :=
-  @Function.Injective.countable {f : ℕ → ℕ | Computable f} {f : ℕ →. ℕ | Nat.Partrec f} _
-    (fun f => ⟨f.val, Partrec.nat_iff.mp f.2⟩)
-    fun _ _ h => SetCoe.ext <| PFun.lift_injective <| (Subtype.mk.injEq _ _ _ _) ▸ h


### PR DESCRIPTION
As discussed at https://leanprover.zulipchat.com/#narrow/stream/217875-Is-there-code-for-X.3F/topic/by.20decide.20implies.20Computable/near/471964724

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
