### PR TITLE
[Merged by Bors] - feat(Algebra/Group/Equiv/TypeTags): moving `Multiplicative` inside pi types

### DIFF
--- a/Mathlib/Algebra/Group/Equiv/TypeTags.lean
+++ b/Mathlib/Algebra/Group/Equiv/TypeTags.lean
@@ -11,7 +11,7 @@ import Mathlib.Algebra.Group.TypeTags
 -/
 
 
-variable {G H : Type*}
+variable {ι G H : Type*}
 
 /-- Reinterpret `G ≃+ H` as `Multiplicative G ≃* Multiplicative H`. -/
 @[simps]
@@ -112,6 +112,36 @@ and multiplicative endomorphisms of `Multiplicative A`. -/
     AddMonoid.End A ≃* Monoid.End (Multiplicative A) :=
   { AddMonoidHom.toMultiplicative with
     map_mul' := fun _ _ => rfl }
+
+/-- `Multiplicative (∀ i : ι, K i)` is equivalent to `∀ i : ι, Multiplicative (K i)`. -/
+@[simps]
+def MulEquiv.piMultiplicative (K : ι → Type*) [∀ i, AddZeroClass (K i)] :
+    Multiplicative (∀ i : ι, K i) ≃* (∀ i : ι, Multiplicative (K i)) where
+  toFun := fun x i ↦ Multiplicative.ofAdd <| Multiplicative.ofAdd x i
+  invFun := fun x ↦ Multiplicative.ofAdd fun i ↦ Multiplicative.toAdd (x i)
+  left_inv := fun _ ↦ rfl
+  right_inv := fun _ ↦ rfl
+  map_mul' := fun _ _ ↦ rfl
+
+/-- `Multiplicative (ι → G)` is equivalent to `ι → Multiplicative G`. -/
+def MulEquiv.funMultiplicative (ι) (G) [AddZeroClass G] :
+    Multiplicative (ι → G) ≃* (ι → Multiplicative G) :=
+  MulEquiv.piMultiplicative fun _ ↦ G
+
+/-- `Additive (∀ i : ι, K i)` is equivalent to `∀ i : ι, Additive (K i)`. -/
+@[simps]
+def AddEquiv.piAdditive (K : ι → Type*) [∀ i, MulOneClass (K i)] :
+    Additive (∀ i : ι, K i) ≃+ (∀ i : ι, Additive (K i)) where
+  toFun := fun x i ↦ Additive.ofMul <| Additive.ofMul x i
+  invFun := fun x ↦ Additive.ofMul fun i ↦ Additive.toMul (x i)
+  left_inv := fun _ ↦ rfl
+  right_inv := fun _ ↦ rfl
+  map_add' := fun _ _ ↦ rfl
+
+/-- `Additive (ι → G)` is equivalent to `ι → Additive G`. -/
+def AddEquiv.funAdditive (ι) (G) [MulOneClass G] :
+    Additive (ι → G) ≃+ (ι → Additive G) :=
+  AddEquiv.piAdditive fun _ ↦ G
 
 section
 

--- a/Mathlib/Algebra/Group/Equiv/TypeTags.lean
+++ b/Mathlib/Algebra/Group/Equiv/TypeTags.lean
@@ -120,7 +120,7 @@ def MulEquiv.piMultiplicative (K : ι → Type*) [∀ i, Add (K i)] :
   toFun x := fun i ↦ Multiplicative.ofAdd <| Multiplicative.toAdd x i
   invFun x := Multiplicative.ofAdd fun i ↦ Multiplicative.toAdd (x i)
   left_inv _ := rfl
-  right_inv rfl := rfl
+  right_inv _ := rfl
   map_mul' _ _ := rfl
 
 variable (ι) (G) in
@@ -133,14 +133,15 @@ abbrev MulEquiv.funMultiplicative [Add G] :
 @[simps]
 def AddEquiv.piAdditive (K : ι → Type*) [∀ i, Mul (K i)] :
     Additive (∀ i : ι, K i) ≃+ (∀ i : ι, Additive (K i)) where
-  toFun := fun x i ↦ Additive.ofMul <| Additive.toMul x i
-  invFun := fun x ↦ Additive.ofMul fun i ↦ Additive.toMul (x i)
-  left_inv := fun _ ↦ rfl
-  right_inv := fun _ ↦ rfl
-  map_add' := fun _ _ ↦ rfl
+  toFun x := fun i ↦ Additive.ofMul <| Additive.toMul x i
+  invFun x := Additive.ofMul fun i ↦ Additive.toMul (x i)
+  left_inv _ := rfl
+  right_inv _ := rfl
+  map_add' _ _ := rfl
 
+variable (ι) (G) in
 /-- `Additive (ι → G)` is equivalent to `ι → Additive G`. -/
-abbrev AddEquiv.funAdditive (ι) (G) [Mul G] :
+abbrev AddEquiv.funAdditive [Mul G] :
     Additive (ι → G) ≃+ (ι → Additive G) :=
   AddEquiv.piAdditive fun _ ↦ G
 

--- a/Mathlib/Algebra/Group/Equiv/TypeTags.lean
+++ b/Mathlib/Algebra/Group/Equiv/TypeTags.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johannes Hölzl, Callum Sutton, Yury Kudryashov
 -/
 import Mathlib.Algebra.Group.Equiv.Basic
+import Mathlib.Algebra.Group.Prod
 import Mathlib.Algebra.Group.TypeTags
 
 /-!
@@ -158,5 +159,27 @@ def AddEquiv.additiveMultiplicative [AddZeroClass G] : Additive (Multiplicative 
 @[simps!]
 def MulEquiv.multiplicativeAdditive [MulOneClass H] : Multiplicative (Additive H) ≃* H :=
   AddEquiv.toMultiplicative'' (AddEquiv.refl (Additive H))
+
+/-- `Multiplicative (G × H)` is equivalent to `Multiplicative G × Multiplicative H`. -/
+@[simps]
+def MulEquiv.prodMultiplicative [Add G] [Add H] :
+    Multiplicative (G × H) ≃* Multiplicative G × Multiplicative H where
+  toFun x := (Multiplicative.ofAdd (Multiplicative.toAdd x).1,
+    Multiplicative.ofAdd (Multiplicative.toAdd x).2)
+  invFun := fun (x, y) ↦ Multiplicative.ofAdd (Multiplicative.toAdd x, Multiplicative.toAdd y)
+  left_inv _ := rfl
+  right_inv _ := rfl
+  map_mul' _ _ := rfl
+
+/-- `Additive (G × H)` is equivalent to `Additive G × Additive H`. -/
+@[simps]
+def AddEquiv.prodAdditive [Mul G] [Mul H] :
+    Additive (G × H) ≃+ Additive G × Additive H where
+  toFun x := (Additive.ofMul (Additive.toMul x).1,
+    Additive.ofMul (Additive.toMul x).2)
+  invFun := fun (x, y) ↦ Additive.ofMul (Additive.toMul x, Additive.toMul y)
+  left_inv _ := rfl
+  right_inv _ := rfl
+  map_add' _ _ := rfl
 
 end

--- a/Mathlib/Algebra/Group/Equiv/TypeTags.lean
+++ b/Mathlib/Algebra/Group/Equiv/TypeTags.lean
@@ -117,7 +117,7 @@ and multiplicative endomorphisms of `Multiplicative A`. -/
 @[simps]
 def MulEquiv.piMultiplicative (K : ι → Type*) [∀ i, AddZeroClass (K i)] :
     Multiplicative (∀ i : ι, K i) ≃* (∀ i : ι, Multiplicative (K i)) where
-  toFun := fun x i ↦ Multiplicative.ofAdd <| Multiplicative.ofAdd x i
+  toFun := fun x i ↦ Multiplicative.ofAdd <| Multiplicative.toAdd x i
   invFun := fun x ↦ Multiplicative.ofAdd fun i ↦ Multiplicative.toAdd (x i)
   left_inv := fun _ ↦ rfl
   right_inv := fun _ ↦ rfl

--- a/Mathlib/Algebra/Group/Equiv/TypeTags.lean
+++ b/Mathlib/Algebra/Group/Equiv/TypeTags.lean
@@ -124,7 +124,7 @@ def MulEquiv.piMultiplicative (K : ι → Type*) [∀ i, AddZeroClass (K i)] :
   map_mul' := fun _ _ ↦ rfl
 
 /-- `Multiplicative (ι → G)` is equivalent to `ι → Multiplicative G`. -/
-def MulEquiv.funMultiplicative (ι) (G) [AddZeroClass G] :
+abbrev MulEquiv.funMultiplicative (ι) (G) [AddZeroClass G] :
     Multiplicative (ι → G) ≃* (ι → Multiplicative G) :=
   MulEquiv.piMultiplicative fun _ ↦ G
 

--- a/Mathlib/Algebra/Group/Equiv/TypeTags.lean
+++ b/Mathlib/Algebra/Group/Equiv/TypeTags.lean
@@ -115,7 +115,7 @@ and multiplicative endomorphisms of `Multiplicative A`. -/
 
 /-- `Multiplicative (∀ i : ι, K i)` is equivalent to `∀ i : ι, Multiplicative (K i)`. -/
 @[simps]
-def MulEquiv.piMultiplicative (K : ι → Type*) [∀ i, AddZeroClass (K i)] :
+def MulEquiv.piMultiplicative (K : ι → Type*) [∀ i, Add (K i)] :
     Multiplicative (∀ i : ι, K i) ≃* (∀ i : ι, Multiplicative (K i)) where
   toFun := fun x i ↦ Multiplicative.ofAdd <| Multiplicative.toAdd x i
   invFun := fun x ↦ Multiplicative.ofAdd fun i ↦ Multiplicative.toAdd (x i)
@@ -124,13 +124,13 @@ def MulEquiv.piMultiplicative (K : ι → Type*) [∀ i, AddZeroClass (K i)] :
   map_mul' := fun _ _ ↦ rfl
 
 /-- `Multiplicative (ι → G)` is equivalent to `ι → Multiplicative G`. -/
-abbrev MulEquiv.funMultiplicative (ι) (G) [AddZeroClass G] :
+abbrev MulEquiv.funMultiplicative (ι) (G) [Add G] :
     Multiplicative (ι → G) ≃* (ι → Multiplicative G) :=
   MulEquiv.piMultiplicative fun _ ↦ G
 
 /-- `Additive (∀ i : ι, K i)` is equivalent to `∀ i : ι, Additive (K i)`. -/
 @[simps]
-def AddEquiv.piAdditive (K : ι → Type*) [∀ i, MulOneClass (K i)] :
+def AddEquiv.piAdditive (K : ι → Type*) [∀ i, Mul (K i)] :
     Additive (∀ i : ι, K i) ≃+ (∀ i : ι, Additive (K i)) where
   toFun := fun x i ↦ Additive.ofMul <| Additive.toMul x i
   invFun := fun x ↦ Additive.ofMul fun i ↦ Additive.toMul (x i)
@@ -139,7 +139,7 @@ def AddEquiv.piAdditive (K : ι → Type*) [∀ i, MulOneClass (K i)] :
   map_add' := fun _ _ ↦ rfl
 
 /-- `Additive (ι → G)` is equivalent to `ι → Additive G`. -/
-def AddEquiv.funAdditive (ι) (G) [MulOneClass G] :
+abbrev AddEquiv.funAdditive (ι) (G) [Mul G] :
     Additive (ι → G) ≃+ (ι → Additive G) :=
   AddEquiv.piAdditive fun _ ↦ G
 

--- a/Mathlib/Algebra/Group/Equiv/TypeTags.lean
+++ b/Mathlib/Algebra/Group/Equiv/TypeTags.lean
@@ -123,8 +123,9 @@ def MulEquiv.piMultiplicative (K : ι → Type*) [∀ i, Add (K i)] :
   right_inv := fun _ ↦ rfl
   map_mul' := fun _ _ ↦ rfl
 
+variable (ι) (G) in
 /-- `Multiplicative (ι → G)` is equivalent to `ι → Multiplicative G`. -/
-abbrev MulEquiv.funMultiplicative (ι) (G) [Add G] :
+abbrev MulEquiv.funMultiplicative [Add G] :
     Multiplicative (ι → G) ≃* (ι → Multiplicative G) :=
   MulEquiv.piMultiplicative fun _ ↦ G
 

--- a/Mathlib/Algebra/Group/Equiv/TypeTags.lean
+++ b/Mathlib/Algebra/Group/Equiv/TypeTags.lean
@@ -132,7 +132,7 @@ def MulEquiv.funMultiplicative (ι) (G) [AddZeroClass G] :
 @[simps]
 def AddEquiv.piAdditive (K : ι → Type*) [∀ i, MulOneClass (K i)] :
     Additive (∀ i : ι, K i) ≃+ (∀ i : ι, Additive (K i)) where
-  toFun := fun x i ↦ Additive.ofMul <| Additive.ofMul x i
+  toFun := fun x i ↦ Additive.ofMul <| Additive.toMul x i
   invFun := fun x ↦ Additive.ofMul fun i ↦ Additive.toMul (x i)
   left_inv := fun _ ↦ rfl
   right_inv := fun _ ↦ rfl

--- a/Mathlib/Algebra/Group/Equiv/TypeTags.lean
+++ b/Mathlib/Algebra/Group/Equiv/TypeTags.lean
@@ -117,11 +117,11 @@ and multiplicative endomorphisms of `Multiplicative A`. -/
 @[simps]
 def MulEquiv.piMultiplicative (K : ι → Type*) [∀ i, Add (K i)] :
     Multiplicative (∀ i : ι, K i) ≃* (∀ i : ι, Multiplicative (K i)) where
-  toFun := fun x i ↦ Multiplicative.ofAdd <| Multiplicative.toAdd x i
-  invFun := fun x ↦ Multiplicative.ofAdd fun i ↦ Multiplicative.toAdd (x i)
-  left_inv := fun _ ↦ rfl
-  right_inv := fun _ ↦ rfl
-  map_mul' := fun _ _ ↦ rfl
+  toFun x := fun i ↦ Multiplicative.ofAdd <| Multiplicative.toAdd x i
+  invFun x := Multiplicative.ofAdd fun i ↦ Multiplicative.toAdd (x i)
+  left_inv _ := rfl
+  right_inv rfl := rfl
+  map_mul' _ _ := rfl
 
 variable (ι) (G) in
 /-- `Multiplicative (ι → G)` is equivalent to `ι → Multiplicative G`. -/


### PR DESCRIPTION
Add equivalences to move `Multiplicative` and `Additive` into the codomain of a pi type, both dependent and non-dependent.

```lean
    Multiplicative (∀ i : ι, K i) ≃* (∀ i : ι, Multiplicative (K i))

    Multiplicative (ι → G) ≃* (ι → Multiplicative G)

    Additive (∀ i : ι, K i) ≃+ (∀ i : ι, Additive (K i))

    Additive (ι → G) ≃+ (ι → Additive G)
```

Also add corresponding `Prod` equivalences.

From AperiodicMonotilesLean.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
