### PR TITLE
[Merged by Bors] - feat: action for labeling and closing stale PRs

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -18,8 +18,8 @@ jobs:
           close-pr-message: 'Comment on the staled PRs while closed'
           days-before-stale: 60
           days-before-close: 120
-          # search string from the Zulip #queue link at https://bit.ly/3Ymuh0U
-          # "is:open is:pr -is:draft sort:updated-asc -label:blocked-by-other-PR -label:merge-conflict status:success -label:awaiting-CI -label:WIP -label:awaiting-author base:master -label:delegated -label:auto-merge-after-CI -label:ready-to-merge"
+          # search string from the Zulip #queue link at https://bit.ly/3TJI3Yo
+          # "is:open is:pr -is:draft base:master sort:updated-asc status:success -label:blocked-by-other-PR -label:merge-conflict -label:awaiting-CI -label:WIP -label:awaiting-author -label:delegated -label:auto-merge-after-CI -label:ready-to-merge -label:please-adopt -label:help-wanted"
           # We want PRs _not_ on the queue, so we keep "is:pr -is:draft base:master" (is:open is added by the action by default) as a prefix for all queries and then negate the rest of the params in separate queries to simulate boolean OR (see https://github.com/actions/stale/pull/1145)
           # except for label:auto-merge-after-CI and label:ready-to-merge which presumably will be noticed before they go stale
-          only-matching-filter: '[ "is:pr -is:draft base:master label:blocked-by-other-PR", "is:pr -is:draft base:master label:merge-conflict", "is:pr -is:draft base:master -status:success", "is:pr -is:draft base:master label:awaiting-CI", "is:pr -is:draft base:master label:WIP", "is:pr -is:draft base:master label:awaiting-author", "is:pr -is:draft base:master label:delegated" ]'
+          only-matching-filter: '[ "is:pr -is:draft base:master -status:success", "is:pr -is:draft base:master label:blocked-by-other-PR", "is:pr -is:draft base:master label:merge-conflict", "is:pr -is:draft base:master label:awaiting-CI", "is:pr -is:draft base:master label:WIP", "is:pr -is:draft base:master label:awaiting-author", "is:pr -is:draft base:master label:delegated", "is:pr -is:draft base:master label:please-adopt", "is:pr -is:draft base:master label:help-wanted" ]'

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,21 @@
+name: 'Close stale issues and PRs'
+on:
+  schedule:
+    - cron: '30 1 * * *' # every day at 01:30 UTC
+  workflow_dispatch:
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      # until https://github.com/actions/stale/pull/1145 is merged
+      - uses: asterisk/github-actions-stale@main-only-matching-filter
+        with:
+          debug-only: 'true' # TODO: remove in follow-up PR after testing is done!
+          stale-pr-label: 'stale'
+          stale-pr-message: 'Message to comment on stale PRs.'
+          close-pr-label: 'closed-due-to-inactivity'
+          close-pr-message: 'Comment on the staled PRs while closed'
+          days-before-stale: 60
+          days-before-close: 120
+          only-matching-filter: '[ "is:open is:pr -is:draft sort:updated-asc -label:blocked-by-other-PR -label:merge-conflict status:success -label:awaiting-CI -label:WIP -label:awaiting-author base:master -label:delegated -label:auto-merge-after-CI -label:ready-to-merge" ]'

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -19,4 +19,7 @@ jobs:
           days-before-stale: 60
           days-before-close: 120
           # search string from the Zulip #queue link at https://bit.ly/3Ymuh0U
-          only-matching-filter: '[ "is:open is:pr -is:draft sort:updated-asc -label:blocked-by-other-PR -label:merge-conflict status:success -label:awaiting-CI -label:WIP -label:awaiting-author base:master -label:delegated -label:auto-merge-after-CI -label:ready-to-merge" ]'
+          # "is:open is:pr -is:draft sort:updated-asc -label:blocked-by-other-PR -label:merge-conflict status:success -label:awaiting-CI -label:WIP -label:awaiting-author base:master -label:delegated -label:auto-merge-after-CI -label:ready-to-merge"
+          # We want PRs _not_ on the queue, so we keep "is:pr -is:draft base:master" (is:open is added by the action by default) as a prefix for all queries and then negate the rest of the params in separate queries to simulate boolean OR (see https://github.com/actions/stale/pull/1145)
+          # except for label:auto-merge-after-CI and label:ready-to-merge which presumably will be noticed before they go stale
+          only-matching-filter: '[ "is:pr -is:draft base:master label:blocked-by-other-PR", "is:pr -is:draft base:master label:merge-conflict", "is:pr -is:draft base:master -status:success", "is:pr -is:draft base:master label:awaiting-CI", "is:pr -is:draft base:master label:WIP", "is:pr -is:draft base:master label:awaiting-author", "is:pr -is:draft base:master label:delegated" ]'

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -18,4 +18,5 @@ jobs:
           close-pr-message: 'Comment on the staled PRs while closed'
           days-before-stale: 60
           days-before-close: 120
+          # search string from the Zulip #queue link at https://bit.ly/3Ymuh0U
           only-matching-filter: '[ "is:open is:pr -is:draft sort:updated-asc -label:blocked-by-other-PR -label:merge-conflict status:success -label:awaiting-CI -label:WIP -label:awaiting-author base:master -label:delegated -label:auto-merge-after-CI -label:ready-to-merge" ]'

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -18,8 +18,8 @@ jobs:
           close-pr-message: 'Comment on the staled PRs while closed'
           days-before-stale: 60
           days-before-close: 120
-          # search string from the Zulip #queue link at https://bit.ly/3TJI3Yo
-          # "is:open is:pr -is:draft base:master sort:updated-asc status:success -label:blocked-by-other-PR -label:merge-conflict -label:awaiting-CI -label:WIP -label:awaiting-author -label:delegated -label:auto-merge-after-CI -label:ready-to-merge -label:please-adopt -label:help-wanted"
+          # search string from the Zulip #queue link at https://bit.ly/4eo6brN
+          # "is:open is:pr -is:draft base:master sort:updated-asc status:success -label:blocked-by-other-PR -label:merge-conflict -label:awaiting-CI -label:WIP -label:awaiting-author -label:delegated -label:auto-merge-after-CI -label:ready-to-merge -label:please-adopt -label:help-wanted -label:awaiting-zulip"
           # We want PRs _not_ on the queue, so we keep "is:pr -is:draft base:master" (is:open is added by the action by default) as a prefix for all queries and then negate the rest of the params in separate queries to simulate boolean OR (see https://github.com/actions/stale/pull/1145)
           # except for label:auto-merge-after-CI and label:ready-to-merge which presumably will be noticed before they go stale
-          only-matching-filter: '[ "is:pr -is:draft base:master -status:success", "is:pr -is:draft base:master label:blocked-by-other-PR", "is:pr -is:draft base:master label:merge-conflict", "is:pr -is:draft base:master label:awaiting-CI", "is:pr -is:draft base:master label:WIP", "is:pr -is:draft base:master label:awaiting-author", "is:pr -is:draft base:master label:delegated", "is:pr -is:draft base:master label:please-adopt", "is:pr -is:draft base:master label:help-wanted" ]'
+          only-matching-filter: '[ "is:pr -is:draft base:master -status:success", "is:pr -is:draft base:master label:blocked-by-other-PR", "is:pr -is:draft base:master label:merge-conflict", "is:pr -is:draft base:master label:awaiting-CI", "is:pr -is:draft base:master label:WIP", "is:pr -is:draft base:master label:awaiting-author", "is:pr -is:draft base:master label:delegated", "is:pr -is:draft base:master label:please-adopt", "is:pr -is:draft base:master label:help-wanted", "is:pr -is:draft base:master label:awaiting-zulip" ]'


### PR DESCRIPTION
Per discussion in the maintainer channel.

Uses a PR branch https://github.com/actions/stale/pull/1145 of [actions/stale](https://github.com/actions/stale/) since it has a feature that will allow us to only consider PRs not sitting on the [#queue](https://bit.ly/3Ymuh0U). 

There's still placeholder text for the comments, but this is intended to be merged with the `debug-only` flag until we have the kinks sorted out, so we could fill in that text in a later PR.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
