### PR TITLE
[Merged by Bors] - doc: fix a typo in étale algebra definition 

### DIFF
--- a/Mathlib/RingTheory/Etale/Basic.lean
+++ b/Mathlib/RingTheory/Etale/Basic.lean
@@ -11,7 +11,7 @@ import Mathlib.RingTheory.Unramified.Basic
 
 # Etale morphisms
 
-An `R`-algebra `A` is formally étale if for every `R`-algebra,
+An `R`-algebra `A` is formally étale if for every `R`-algebra `B`,
 every square-zero ideal `I : Ideal B` and `f : A →ₐ[R] B ⧸ I`, there exists
 exactly one lift `A →ₐ[R] B`.
 It is étale if it is formally étale and of finite presentation.


### PR DESCRIPTION
---

Originally submitted as #17009, which was a PR from a fork.

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
