### PR TITLE
chore: bump dependencies, and disable `aesop.warn.applyIff` for now

### DIFF
--- a/lake-manifest.json
+++ b/lake-manifest.json
@@ -25,7 +25,7 @@
    "type": "git",
    "subDir": null,
    "scope": "leanprover-community",
-   "rev": "61fb4d1a2a6a4fe4be260ca31c58af1234ff298b",
+   "rev": "a895713f7701e295a015b1087f3113fd3d615272",
    "name": "aesop",
    "manifestFile": "lake-manifest.json",
    "inputRev": "master",

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -34,7 +34,8 @@ abbrev mathlibOnlyLinters : Array LeanOption := #[
   ⟨`linter.style.longLine, true⟩,
   ⟨`linter.style.longFile, .ofNat 1500⟩,
   ⟨`linter.style.missingEnd, true⟩,
-  ⟨`linter.style.setOption, true⟩
+  ⟨`linter.style.setOption, true⟩,
+  ⟨`aesop.warn.applyIff, false⟩ -- This became a problem after https://github.com/leanprover-community/aesop/commit/29cf094e84ae9852f0011b47b6ddc684ffe4be5f
 ]
 
 /-- These options are passed as `leanOptions` to building mathlib, as well as the


### PR DESCRIPTION
See [zulip discussion](https://leanprover.zulipchat.com/#narrow/stream/287929-mathlib4/topic/aesop.2Ewarn.2EapplyIff/near/472358133) regarding adapting Mathlib so we can re-enable this warning.