### PR TITLE
[Merged by Bors] - chore: remove non-ascii whitespace

### DIFF
--- a/Mathlib/CategoryTheory/Adjunction/Opposites.lean
+++ b/Mathlib/CategoryTheory/Adjunction/Opposites.lean
@@ -36,13 +36,13 @@ def adjointOfOpAdjointOp (F : C ⥤ D) (G : D ⥤ C) (h : G.op ⊣ F.op) : F ⊣
         (opEquiv _ _)
     homEquiv_naturality_left_symm := by
       -- Porting note: This proof was handled by `obviously` in mathlib3. The only obstruction to
-      -- automation fully kicking in here is that the `@[simps]` lemmas of `opEquiv` and
+      -- automation fully kicking in here is that the `@[simps]` lemmas of `opEquiv` and
       -- `homEquiv` aren't firing.
       intros
       simp [opEquiv, homEquiv]
     homEquiv_naturality_right := by
       -- Porting note: This proof was handled by `obviously` in mathlib3. The only obstruction to
-      -- automation fully kicking in here is that the `@[simps]` lemmas of `opEquiv` and
+      -- automation fully kicking in here is that the `@[simps]` lemmas of `opEquiv` and
       -- `homEquiv` aren't firing.
       intros
       simp [opEquiv, homEquiv] }

--- a/Mathlib/CategoryTheory/Adjunction/Triple.lean
+++ b/Mathlib/CategoryTheory/Adjunction/Triple.lean
@@ -11,7 +11,7 @@ import Mathlib.CategoryTheory.Monad.Adjunction
 
 This file concerns adjoint triples `F ⊣ G ⊣ H` of functors `F H : C ⥤ D`, `G : D ⥤ C`.
 
-Currently, the only result is that `F` is fully faithful if and only if `H` is fully faithful.
+Currently, the only result is that `F` is fully faithful if and only if `H` is fully faithful.
 -/
 
 namespace CategoryTheory.Adjunction
@@ -31,7 +31,7 @@ lemma isIso_unit_iff_isIso_counit : IsIso adj₁.unit ↔ IsIso adj₂.counit :=
     exact adj₁.isIso_unit_of_iso (adjId.leftAdjointUniq id)
 
 /--
-Given an adjoint triple `F ⊣ G ⊣ H`, the left adjoint `F` is fully faithful if and only if the
+Given an adjoint triple `F ⊣ G ⊣ H`, the left adjoint `F` is fully faithful if and only if the
 right adjoint `H` is fully faithful.
 -/
 noncomputable def fullyFaithfulEquiv : F.FullyFaithful ≃ H.FullyFaithful where

--- a/Mathlib/CategoryTheory/Closed/Monoidal.lean
+++ b/Mathlib/CategoryTheory/Closed/Monoidal.lean
@@ -267,7 +267,7 @@ theorem ofEquiv_curry_def {X Y Z : C} (f : X ⊗ Y ⟶ Z) :
         (MonoidalClosed.curry (adj.toEquivalence.symm.toAdjunction.homEquiv (F.obj X ⊗ F.obj Y) Z
         ((Iso.compInverseIso (H := adj.toEquivalence)
           (MonoidalFunctor.commTensorLeft F X)).hom.app Y ≫ f))) := by
-  -- This whole proof used to be `rfl` before #16317.
+  -- This whole proof used to be `rfl` before #16317.
   change ((adj.comp ((ihom.adjunction (F.obj X)).comp
       adj.toEquivalence.symm.toAdjunction)).ofNatIsoLeft _).homEquiv _ _ _ = _
   dsimp only [Adjunction.ofNatIsoLeft]
@@ -289,7 +289,7 @@ theorem ofEquiv_uncurry_def {X Y Z : C} :
             (adj.toEquivalence.symm.toAdjunction.homEquiv _ _).symm
               (MonoidalClosed.uncurry ((adj.homEquiv _ _).symm f)) := by
   intro f
-  -- This whole proof used to be `rfl` before #16317.
+  -- This whole proof used to be `rfl` before #16317.
   change (((adj.comp ((ihom.adjunction (F.obj X)).comp
       adj.toEquivalence.symm.toAdjunction)).ofNatIsoLeft _).homEquiv _ _).symm _ = _
   dsimp only [Adjunction.ofNatIsoLeft]

--- a/Mathlib/CategoryTheory/Sites/ConstantSheaf.lean
+++ b/Mathlib/CategoryTheory/Sites/ConstantSheaf.lean
@@ -25,7 +25,7 @@ it is an isomorphism.
 * `Sheaf.isConstant_iff_of_equivalence` : The property of a sheaf of being constant is invariant
 under equivalence of sheaf categories.
 
-* `Sheaf.isConstant_iff_forget` : Given a "forgetful" functor `U : D ⥤ B` a sheaf `F : Sheaf J D` is
+* `Sheaf.isConstant_iff_forget` : Given a "forgetful" functor `U : D ⥤ B` a sheaf `F : Sheaf J D` is
 constant if and only if the sheaf given by postcomposition with `U` is constant.
 
 ## Future work
@@ -177,7 +177,7 @@ variable {B : Type*} [Category B] (U : D ⥤ B) [HasWeakSheafify J B]
   [J.PreservesSheafification U] [J.HasSheafCompose U] (F : Sheaf J D)
 
 /--
-The constant sheaf functor commutes with `sheafCompose J U` up to isomorphism, provided that `U` 
+The constant sheaf functor commutes with `sheafCompose J U` up to isomorphism, provided that `U`
 preserves sheafification.
 -/
 noncomputable def constantCommuteCompose :
@@ -189,7 +189,7 @@ noncomputable def constantCommuteCompose :
 lemma constantCommuteCompose_hom_app_val (X : D) : ((constantCommuteCompose J U).hom.app X).val =
     (sheafifyComposeIso J U ((const Cᵒᵖ).obj X)).inv ≫ sheafifyMap J (constComp Cᵒᵖ X U).hom := rfl
 
-/-- The counit of `constantSheafAdj` factors through the isomorphism `constantCommuteCompose`. -/
+/-- The counit of `constantSheafAdj` factors through the isomorphism `constantCommuteCompose`. -/
 lemma constantSheafAdj_counit_w {T : C} (hT : IsTerminal T) :
     ((constantCommuteCompose J U).hom.app (F.val.obj ⟨T⟩)) ≫
       ((constantSheafAdj J B hT).counit.app ((sheafCompose J U).obj F)) =

--- a/Mathlib/Logic/Function/FiberPartition.lean
+++ b/Mathlib/Logic/Function/FiberPartition.lean
@@ -6,7 +6,7 @@ Authors: Dagur Asgeirsson
 import Mathlib.Data.Set.Basic
 /-!
 
-This file defines the type `f.Fiber` of fibers of a function `f : Y → Z`, and provides some API
+This file defines the type `f.Fiber` of fibers of a function `f : Y → Z`, and provides some API
 to work with and construct terms of this type.
 
 Note: this API is designed to be useful when defining the counit of the adjunction between
@@ -25,7 +25,7 @@ def Fiber (f : Y → Z) : Type _ := Set.range (fun (x : Set.range f) ↦ f ⁻¹
 namespace Fiber
 
 /--
-Any `a : Fiber f` is of the form `f ⁻¹' {x}` for some `x` in the image of `f`. We define `a.image` 
+Any `a : Fiber f` is of the form `f ⁻¹' {x}` for some `x` in the image of `f`. We define `a.image`
 as an arbitrary such `x`.
 -/
 noncomputable def image (f : Y → Z) (a : Fiber f) : Z := a.2.choose.1
@@ -33,11 +33,11 @@ noncomputable def image (f : Y → Z) (a : Fiber f) : Z := a.2.choose.1
 lemma eq_fiber_image  (f : Y → Z) (a : Fiber f) : a.1 = f ⁻¹' {a.image} := a.2.choose_spec.symm
 
 /--
-Given `y : Y`, `Fiber.mk f y` is the fiber of `f` that `y` belongs to, as an element of `Fiber f`.
+Given `y : Y`, `Fiber.mk f y` is the fiber of `f` that `y` belongs to, as an element of `Fiber f`.
 -/
 def mk (f : Y → Z) (y : Y) : Fiber f := ⟨f ⁻¹' {f y}, by simp⟩
 
-/-- `y : Y` as a term of the type `Fiber.mk f y` -/
+/-- `y : Y` as a term of the type `Fiber.mk f y` -/
 def mkSelf (f : Y → Z) (y : Y) : (mk f y).val := ⟨y, rfl⟩
 
 lemma map_eq_image (f : Y → Z) (a : Fiber f) (x : a.1) : f x = a.image := by

--- a/Mathlib/Topology/Category/CompHausLike/Basic.lean
+++ b/Mathlib/Topology/Category/CompHausLike/Basic.lean
@@ -13,21 +13,21 @@ We construct the category of compact Hausdorff spaces satisfying an additional p
 
 ## Implementation
 
-We define a structure `CompHausLike` which takes as an argument a predicate `P` on topological
+We define a structure `CompHausLike` which takes as an argument a predicate `P` on topological
 spaces. It consists of the data of a topological space, satisfying the additional properties of
 being compact and Hausdorff, and satisfying `P`. We give a category structure to `CompHausLike P`
 induced by the forgetful functor to topological spaces.
 
 It used to be the case (before #12930 was merged) that several different categories of compact
 Hausdorff spaces, possibly satisfying some extra property, were defined from scratch in this way.
-For example, one would define a structure `CompHaus` as follows:
+For example, one would define a structure `CompHaus` as follows:
 
 ```lean
 structure CompHaus where
   toTop : TopCat
   [is_compact : CompactSpace toTop]
   [is_hausdorff : T2Space toTop]
-``` 
+```
 
 and give it the category structure induced from topological spaces. Then the category of profinite
 spaces was defined as follows:
@@ -39,7 +39,7 @@ structure Profinite where
 ```
 
 The categories `Stonean` consisting of extremally disconnected compact Hausdorff spaces and
-`LightProfinite` consisting of totally disconnected, second countable compact Hausdorff spaces were
+`LightProfinite` consisting of totally disconnected, second countable compact Hausdorff spaces were
 defined in a similar way. This resulted in code duplication, and reducing this duplication was part
 of the motivation for introducing `CompHausLike`.
 
@@ -52,11 +52,11 @@ Using `CompHausLike`, we can now define
 These four categories are important building blocks of condensed objects (see the files
 `Condensed.Basic` and `Condensed.Light.Basic`). These categories share many properties and often,
 one wants to argue about several of them simultaneously. This is the other part of the motivation
-for introducing `CompHausLike`. On paper, one would say "let `C` be on of the categories `CompHaus`
+for introducing `CompHausLike`. On paper, one would say "let `C` be on of the categories `CompHaus`
 or `Profinite`, then the following holds: ...". This was not possible in Lean using the old
 definitions. Using the new definitions, this becomes a matter of identifying what common property
-of `CompHaus` and `Profinite` is used in the proof in question, and then proving the theorem for
-`CompHausLike P` satisfying that property, and it will automatically apply to both `CompHaus` and
+of `CompHaus` and `Profinite` is used in the proof in question, and then proving the theorem for
+`CompHausLike P` satisfying that property, and it will automatically apply to both `CompHaus` and
 `Profinite`.
 -/
 

--- a/Mathlib/Topology/Category/CompHausLike/SigmaComparison.lean
+++ b/Mathlib/Topology/Category/CompHausLike/SigmaComparison.lean
@@ -8,11 +8,11 @@ import Mathlib.Topology.Category.CompHausLike.Limits
 
 # The sigma-comparison map
 
-This file defines the map `CompHausLike.sigmaComparison` associated to a presheaf `X` on
+This file defines the map `CompHausLike.sigmaComparison` associated to a presheaf `X` on
 `CompHausLike P`, and a finite family `S₁,...,Sₙ` of spaces in `CompHausLike P`, where `P` is
 stable under taking finite disjoint unions.
 
-The map `sigmaComparison` is the canonical map `X(S₁ ⊔ ... ⊔ Sₙ) ⟶ X(S₁) × ... × X(Sₙ)` induced by
+The map `sigmaComparison` is the canonical map `X(S₁ ⊔ ... ⊔ Sₙ) ⟶ X(S₁) × ... × X(Sₙ)` induced by
 the inclusion maps `Sᵢ ⟶ S₁ ⊔ ... ⊔ Sₙ`, and it is an isomorphism when `X` preserves finite
 products.
 -/

--- a/Mathlib/Topology/Category/LightProfinite/Extend.lean
+++ b/Mathlib/Topology/Category/LightProfinite/Extend.lean
@@ -10,9 +10,9 @@ import Mathlib.Topology.Category.Profinite.Extend
 
 # Extending cones in `LightProfinite`
 
-Let `(Sₙ)_{n : ℕᵒᵖ}` be a sequential inverse system of finite sets and let `S` be
-its limit in `Profinite`. Let `G` be a functor from `LightProfinite` to a category `C` and suppose
-that `G` preserves the limit described above. Suppose further that the projection maps `S ⟶ Sₙ` are
+Let `(Sₙ)_{n : ℕᵒᵖ}` be a sequential inverse system of finite sets and let `S` be
+its limit in `Profinite`. Let `G` be a functor from `LightProfinite` to a category `C` and suppose
+that `G` preserves the limit described above. Suppose further that the projection maps `S ⟶ Sₙ` are
 epimorphic for all `n`. Then `G.obj S` is isomorphic to a limit indexed by
 `StructuredArrow S toLightProfinite` (see `LightProfinite.Extend.isLimitCone`).
 
@@ -21,7 +21,7 @@ We also provide the dual result for a functor of the form `G : LightProfiniteᵒ
 We apply this to define `LightProfinite.diagram'`, `LightProfinite.asLimitCone'`, and
 `LightProfinite.asLimit'`, analogues to their unprimed versions in
 `Mathlib.Topology.Category.LightProfinite.AsLimit`, in which the
-indexing category is `StructuredArrow S toLightProfinite` instead of `ℕᵒᵖ`.
+indexing category is `StructuredArrow S toLightProfinite` instead of `ℕᵒᵖ`.
 -/
 
 universe u
@@ -37,7 +37,7 @@ variable {F : ℕᵒᵖ ⥤ FintypeCat.{u}} (c : Cone <| F ⋙ toLightProfinite)
 namespace Extend
 
 /--
-Given a sequential cone in `LightProfinite` consisting of finite sets,
+Given a sequential cone in `LightProfinite` consisting of finite sets,
 we obtain a functor from the indexing category to `StructuredArrow c.pt toLightProfinite`.
 -/
 @[simps]
@@ -49,7 +49,7 @@ def functor : ℕᵒᵖ ⥤ StructuredArrow c.pt toLightProfinite where
 example : functor c ⋙ StructuredArrow.proj c.pt toLightProfinite ≅ F := Iso.refl _
 
 /--
-Given a sequential cone in `LightProfinite` consisting of finite sets,
+Given a sequential cone in `LightProfinite` consisting of finite sets,
 we obtain a functor from the opposite of the indexing category to
 `CostructuredArrow toProfinite.op ⟨c.pt⟩`.
 -/
@@ -113,7 +113,7 @@ def cone (S : LightProfinite) :
 example : G.mapCone c = (cone G c.pt).whisker (functor c) := rfl
 
 /--
-If `c` and `G.mapCone c` are limit cones and the projection maps in `c` are epimorphic,
+If `c` and `G.mapCone c` are limit cones and the projection maps in `c` are epimorphic,
 then `cone G c.pt` is a limit cone.
 -/
 noncomputable
@@ -171,7 +171,7 @@ section LightProfiniteAsLimit
 variable (S : LightProfinite.{u})
 
 /--
-A functor `StructuredArrow S toLightProfinite ⥤ FintypeCat` whose limit in `LightProfinite` is
+A functor `StructuredArrow S toLightProfinite ⥤ FintypeCat` whose limit in `LightProfinite` is
 isomorphic to `S`.
 -/
 abbrev fintypeDiagram' : StructuredArrow S toLightProfinite ⥤ FintypeCat :=

--- a/Mathlib/Topology/Category/Profinite/Extend.lean
+++ b/Mathlib/Topology/Category/Profinite/Extend.lean
@@ -10,9 +10,9 @@ import Mathlib.CategoryTheory.Filtered.Final
 
 # Extending cones in `Profinite`
 
-Let `(Sᵢ)_{i : I}` be a family of finite sets indexed by a cofiltered category `I` and let `S` be
-its limit in `Profinite`. Let `G` be a functor from `Profinite` to a category `C` and suppose that
-`G` preserves the limit described above. Suppose further that the projection maps `S ⟶ Sᵢ` are
+Let `(Sᵢ)_{i : I}` be a family of finite sets indexed by a cofiltered category `I` and let `S` be
+its limit in `Profinite`. Let `G` be a functor from `Profinite` to a category `C` and suppose that
+`G` preserves the limit described above. Suppose further that the projection maps `S ⟶ Sᵢ` are
 epimorphic for all `i`. Then `G.obj S` is isomorphic to a limit indexed by
 `StructuredArrow S toProfinite` (see `Profinite.Extend.isLimitCone`).
 
@@ -20,7 +20,7 @@ We also provide the dual result for a functor of the form `G : Profiniteᵒᵖ �
 
 We apply this to define `Profinite.diagram'`, `Profinite.asLimitCone'`, and `Profinite.asLimit'`,
 analogues to their unprimed versions in `Mathlib.Topology.Category.Profinite.AsLimit`, in which the
-indexing category is `StructuredArrow S toProfinite` instead of `DiscreteQuotient S`.
+indexing category is `StructuredArrow S toProfinite` instead of `DiscreteQuotient S`.
 -/
 
 universe u w
@@ -52,7 +52,7 @@ lemma exists_hom (hc : IsLimit c) {X : FintypeCat} (f : c.pt ⟶ toProfinite.obj
 namespace Extend
 
 /--
-Given a cone in `Profinite`, consisting of finite sets and indexed by a cofiltered category,
+Given a cone in `Profinite`, consisting of finite sets and indexed by a cofiltered category,
 we obtain a functor from the indexing category to `StructuredArrow c.pt toProfinite`.
 -/
 @[simps]
@@ -64,7 +64,7 @@ def functor : I ⥤ StructuredArrow c.pt toProfinite where
 example : functor c ⋙ StructuredArrow.proj c.pt toProfinite ≅ F := Iso.refl _
 
 /--
-Given a cone in `Profinite`, consisting of finite sets and indexed by a cofiltered category,
+Given a cone in `Profinite`, consisting of finite sets and indexed by a cofiltered category,
 we obtain a functor from the opposite of the indexing category to
 `CostructuredArrow toProfinite.op ⟨c.pt⟩`.
 -/
@@ -136,7 +136,7 @@ def cone (S : Profinite) :
 example : G.mapCone c = (cone G c.pt).whisker (functor c) := rfl
 
 /--
-If `c` and `G.mapCone c` are limit cones and the projection maps in `c` are epimorphic,
+If `c` and `G.mapCone c` are limit cones and the projection maps in `c` are epimorphic,
 then `cone G c.pt` is a limit cone.
 -/
 noncomputable
@@ -190,7 +190,7 @@ section ProfiniteAsLimit
 variable (S : Profinite.{u})
 
 /--
-A functor `StructuredArrow S toProfinite ⥤ FintypeCat` whose limit in `Profinite` is isomorphic
+A functor `StructuredArrow S toProfinite ⥤ FintypeCat` whose limit in `Profinite` is isomorphic
 to `S`.
 -/
 abbrev fintypeDiagram' : StructuredArrow S toProfinite ⥤ FintypeCat :=


### PR DESCRIPTION
Preliminary cleanup for the "unwanted unicode linter" added in #16215.

---

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
