### PR TITLE
[Merged by Bors] - chore(SetTheory/Cardinal/Ordinal): deprecate `ord_aleph_eq_enum_card` and friends

### DIFF
--- a/Mathlib/SetTheory/Cardinal/Ordinal.lean
+++ b/Mathlib/SetTheory/Cardinal/Ordinal.lean
@@ -322,7 +322,17 @@ theorem aleph0_lt_aleph_one : ℵ₀ < aleph 1 := by
 theorem countable_iff_lt_aleph_one {α : Type*} (s : Set α) : s.Countable ↔ #s < aleph 1 := by
   rw [← succ_aleph0, lt_succ_iff, le_aleph0_iff_set_countable]
 
+section deprecated
+
+set_option linter.deprecated false
+
+-- TODO: these lemmas should be stated in terms of the `ω` function and of an `IsInitial` predicate,
+-- neither of which currently exist.
+--
+-- They should also use `¬ BddAbove` instead of `Unbounded (· < ·)`.
+
 /-- Ordinals that are cardinals are unbounded. -/
+@[deprecated (since := "2024-09-24")]
 theorem ord_card_unbounded : Unbounded (· < ·) { b : Ordinal | b.card.ord = b } :=
   unbounded_lt_iff.2 fun a =>
     ⟨_,
@@ -330,10 +340,12 @@ theorem ord_card_unbounded : Unbounded (· < ·) { b : Ordinal | b.card.ord = b 
         dsimp
         rw [card_ord], (lt_ord_succ_card a).le⟩⟩
 
+@[deprecated (since := "2024-09-24")]
 theorem eq_aleph'_of_eq_card_ord {o : Ordinal} (ho : o.card.ord = o) : ∃ a, (aleph' a).ord = o :=
   ⟨aleph'.symm o.card, by simpa using ho⟩
 
 /-- `ord ∘ aleph'` enumerates the ordinals that are cardinals. -/
+@[deprecated (since := "2024-09-24")]
 theorem ord_aleph'_eq_enum_card : ord ∘ aleph' = enumOrd { b : Ordinal | b.card.ord = b } := by
   rw [← eq_enumOrd _ ord_card_unbounded, range_eq_iff]
   exact
@@ -343,9 +355,11 @@ theorem ord_aleph'_eq_enum_card : ord ∘ aleph' = enumOrd { b : Ordinal | b.car
         rw [card_ord], fun b hb => eq_aleph'_of_eq_card_ord hb⟩⟩
 
 /-- Infinite ordinals that are cardinals are unbounded. -/
+@[deprecated (since := "2024-09-24")]
 theorem ord_card_unbounded' : Unbounded (· < ·) { b : Ordinal | b.card.ord = b ∧ ω ≤ b } :=
   (unbounded_lt_inter_le ω).2 ord_card_unbounded
 
+@[deprecated (since := "2024-09-24")]
 theorem eq_aleph_of_eq_card_ord {o : Ordinal} (ho : o.card.ord = o) (ho' : ω ≤ o) :
     ∃ a, (aleph a).ord = o := by
   cases' eq_aleph'_of_eq_card_ord ho with a ha
@@ -354,6 +368,7 @@ theorem eq_aleph_of_eq_card_ord {o : Ordinal} (ho : o.card.ord = o) (ho' : ω �
   rwa [← aleph0_le_aleph', ← ord_le_ord, ha, ord_aleph0]
 
 /-- `ord ∘ aleph` enumerates the infinite ordinals that are cardinals. -/
+@[deprecated (since := "2024-09-24")]
 theorem ord_aleph_eq_enum_card :
     ord ∘ aleph = enumOrd { b : Ordinal | b.card.ord = b ∧ ω ≤ b } := by
   rw [← eq_enumOrd _ ord_card_unbounded']
@@ -363,6 +378,8 @@ theorem ord_aleph_eq_enum_card :
   · rw [Function.comp_apply, card_ord]
   · rw [← ord_aleph0, Function.comp_apply, ord_le_ord]
     exact aleph0_le_aleph _
+
+end deprecated
 
 end aleph
 


### PR DESCRIPTION
See [Zulip](https://leanprover.zulipchat.com/#narrow/stream/287929-mathlib4/topic/Deprecate.20.60ord_aleph'_eq_enum_card.60/near/472441290).

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
