### PR TITLE
[Merged by Bors] - fix: do not break multiplication notation

### DIFF
--- a/Mathlib/Topology/Sheaves/Functors.lean
+++ b/Mathlib/Topology/Sheaves/Functors.lean
@@ -34,6 +34,8 @@ open CategoryTheory.Limits
 
 open TopologicalSpace
 
+open scoped AlgebraicGeometry
+
 variable {C : Type u} [Category.{v} C]
 variable {X Y : TopCat.{w}} (f : X ⟶ Y)
 variable ⦃ι : Type w⦄ {U : ι → Opens Y}

--- a/Mathlib/Topology/Sheaves/Presheaf.lean
+++ b/Mathlib/Topology/Sheaves/Presheaf.lean
@@ -153,9 +153,9 @@ variable (C)
 def pushforward {X Y : TopCat.{w}} (f : X ⟶ Y) : X.Presheaf C ⥤ Y.Presheaf C :=
   (whiskeringLeft _ _ _).obj (Opens.map f).op
 
-set_option quotPrecheck false in
 /-- push forward of a presheaf -/
-scoped[CategoryTheory] notation f:80 " _* " P:81 => (pushforward _ f).obj P
+scoped[AlgebraicGeometry] notation f:80 " _* " P:81 =>
+  Prefunctor.obj (Functor.toPrefunctor (TopCat.Presheaf.pushforward _ f)) P
 
 @[simp]
 theorem pushforward_map_app' {X Y : TopCat.{w}} (f : X ⟶ Y) {ℱ 𝒢 : X.Presheaf C} (α : ℱ ⟶ 𝒢)

--- a/Mathlib/Topology/Sheaves/Presheaf.lean
+++ b/Mathlib/Topology/Sheaves/Presheaf.lean
@@ -155,7 +155,7 @@ def pushforward {X Y : TopCat.{w}} (f : X ⟶ Y) : X.Presheaf C ⥤ Y.Presheaf C
 
 set_option quotPrecheck false in
 /-- push forward of a presheaf -/
-notation f:80 " _* " P:81 => (pushforward _ f).obj P
+scoped[CategoryTheory] notation f:80 " _* " P:81 => (pushforward _ f).obj P
 
 @[simp]
 theorem pushforward_map_app' {X Y : TopCat.{w}} (f : X ⟶ Y) {ℱ 𝒢 : X.Presheaf C} (α : ℱ ⟶ 𝒢)

--- a/Mathlib/Topology/Sheaves/Skyscraper.lean
+++ b/Mathlib/Topology/Sheaves/Skyscraper.lean
@@ -34,6 +34,7 @@ TODO: generalize universe level when calculating stalks, after generalizing univ
 noncomputable section
 
 open TopologicalSpace TopCat CategoryTheory CategoryTheory.Limits Opposite
+open scoped AlgebraicGeometry
 
 universe u v w
 

--- a/Mathlib/Topology/Sheaves/Stalks.lean
+++ b/Mathlib/Topology/Sheaves/Stalks.lean
@@ -60,6 +60,8 @@ open TopologicalSpace
 
 open Opposite
 
+open scoped AlgebraicGeometry
+
 variable {C : Type u} [Category.{v} C]
 variable [HasColimits.{v} C]
 variable {X Y Z : TopCat.{v}}


### PR DESCRIPTION
Without this change, `import Mathlib` breaks `_*_` as notation for `_ * _`.

[Zulip thread](https://leanprover.zulipchat.com/#narrow/stream/287929-mathlib4/topic/Bad.20TopCat.2EPresheaf.2Epushforward.20notation/near/472520318)


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
