### PR TITLE
feat: warn on `autoImplicit true`

### DIFF
--- a/Mathlib/Control/Random.lean
+++ b/Mathlib/Control/Random.lean
@@ -28,7 +28,9 @@ defining objects that can be created randomly.
 
 -/
 
-set_option autoImplicit true -- Note: this file uses `autoImplicit` pervasively
+-- Note: this file uses `autoImplicit` consistently and intentionally.
+set_option linter.setOption false in
+set_option autoImplicit true
 
 /-- A monad transformer to generate random objects using the generic generator type `g` -/
 abbrev RandGT (g : Type) := StateT (ULift g)

--- a/Mathlib/Control/Random.lean
+++ b/Mathlib/Control/Random.lean
@@ -29,7 +29,7 @@ defining objects that can be created randomly.
 -/
 
 -- Note: this file uses `autoImplicit` consistently and intentionally.
-set_option linter.setOption false in
+set_option linter.style.setOption false
 set_option autoImplicit true
 
 /-- A monad transformer to generate random objects using the generic generator type `g` -/

--- a/Mathlib/Tactic/Linter/Style.lean
+++ b/Mathlib/Tactic/Linter/Style.lean
@@ -58,7 +58,9 @@ def setOptionLinter : Linter where run := withSetOptionIn fun stx => do
     if let some head := stx.find? is_set_option then
       if let some (name, val) := parse_set_option head then
         if name == `autoImplicit && val.raw matches .atom _ "true" then
-          -- XXX: don't lint the tests directory!
+          -- We do not lint mathlib's test directory.
+          if (← getMainModule).getRoot == `test then
+            return
           Linter.logLint linter.style.setOption head
             m!"Using `autoImplicit true` is deprecated in mathlib: \
             please try to rewrite your code to avoid it. \n\

--- a/Mathlib/Tactic/Linter/Style.lean
+++ b/Mathlib/Tactic/Linter/Style.lean
@@ -58,8 +58,9 @@ def setOptionLinter : Linter where run := withSetOptionIn fun stx => do
     if let some head := stx.find? is_set_option then
       if let some (name, val) := parse_set_option head then
         if name == `autoImplicit && val.raw matches .atom _ "true" then
-          -- We do not lint mathlib's test directory.
-          if (← getMainModule).getRoot == `test then
+          -- We do not lint mathlib's test directory (but do lint this linter's test).
+          let mod := ← getMainModule
+          if mod.getRoot == `test && mod != `test.LintStyle then
             return
           Linter.logLint linter.style.setOption head
             m!"Using `autoImplicit true` is deprecated in mathlib: \

--- a/Mathlib/Tactic/Linter/Style.lean
+++ b/Mathlib/Tactic/Linter/Style.lean
@@ -57,9 +57,7 @@ def setOptionLinter : Linter where run := withSetOptionIn fun stx => do
       return
     if let some head := stx.find? is_set_option then
       if let some (name, val) := parse_set_option head then
-        -- xxx: how to make this check typed? I'd like to check for a `str variant with content
-        -- "true"...
-        if name == `autoImplicit && s!"{val}" == "\"true\"" then
+        if name == `autoImplicit && val.raw matches .atom _ "true" then
           -- XXX: don't lint the tests directory!
           Linter.logLint linter.style.setOption head
             m!"Using `autoImplicit true` is deprecated in mathlib: \

--- a/Mathlib/Tactic/ToExpr.lean
+++ b/Mathlib/Tactic/ToExpr.lean
@@ -16,7 +16,9 @@ that come from core Lean 4 that do not handle universe polymorphism.
 In addition, we provide some additional `ToExpr` instances for core definitions.
 -/
 
-section override -- Note: this section uses `autoImplicit` pervasively
+-- Note: this section uses `autoImplicit` intentionally,
+-- as the ToExpr instances become much longer otherwise.
+section override
 namespace Lean
 
 attribute [-instance] Lean.instToExprOption

--- a/test/LintStyle.lean
+++ b/test/LintStyle.lean
@@ -75,8 +75,23 @@ note: this linter can be disabled with `set_option linter.style.setOption false`
 set_option linter.style.setOption true in
 set_option debug.moduleNameAtTimeout false
 
--- The lint does not fire on arbitrary options.
+-- The linter also errors on `autoImplicit true`, but not on setting it to `false`.
+#guard_msgs in
+set_option linter.style.setOption true in
 set_option autoImplicit false
+
+/--
+warning: Using `autoImplicit true` is deprecated in mathlib: please try to rewrite your code to avoid it. ⏎
+(If using this option makes the code much better and you conciously prefer to use autoImplicit,
+please add a comment why you are disabling this linter.)
+note: this linter can be disabled with `set_option linter.style.setOption false`
+-/
+#guard_msgs in
+set_option linter.style.setOption true in
+set_option autoImplicit true
+
+-- The lint does not fire on arbitrary options.
+set_option linter.missingDocs true
 
 -- We also cover set_option tactics.
 
@@ -93,6 +108,18 @@ lemma tactic : True := by
   trivial
 
 /--
+warning: Using `autoImplicit true` is deprecated in mathlib: please try to rewrite your code to avoid it. ⏎
+(If using this option makes the code much better and you conciously prefer to use autoImplicit,
+please add a comment why you are disabling this linter.)
+note: this linter can be disabled with `set_option linter.style.setOption false`
+-/
+#guard_msgs in
+set_option linter.style.setOption true in
+lemma tactic2 : True := by
+  set_option autoImplicit true in
+  trivial
+
+/--
 warning: Setting options starting with 'debug', 'pp', 'profiler', 'trace' is only intended
 for development and not for final code. If you intend to submit this contribution to the
 Mathlib project, please remove 'set_option pp.raw.maxDepth'.
@@ -100,7 +127,7 @@ note: this linter can be disabled with `set_option linter.style.setOption false`
 -/
 #guard_msgs in
 set_option linter.style.setOption true in
-lemma tactic2 : True := by
+lemma tactic3 : True := by
   set_option pp.raw.maxDepth 32 in
   trivial
 
@@ -112,7 +139,7 @@ note: this linter can be disabled with `set_option linter.style.setOption false`
 -/
 #guard_msgs in
 set_option linter.style.setOption true in
-lemma tactic3 : True := by
+lemma tactic4 : True := by
   set_option pp.all false in
   trivial
 
@@ -124,14 +151,14 @@ note: this linter can be disabled with `set_option linter.style.setOption false`
 -/
 #guard_msgs in
 set_option linter.style.setOption true in
-lemma tactic4 : True := by
+lemma tactic5 : True := by
   set_option trace.profiler.output "foo" in
   trivial
 
 -- This option is not affected, hence does not throw an error.
-set_option autoImplicit true in
+set_option linter.missingDocs true in
 lemma foo' : True := trivial
 
--- TODO: add terms for the term form
+-- TODO: add tests for the term form
 
 end setOption


### PR DESCRIPTION
Extend the `setOption` linter to warn on autoImplicit true outside of `tests`.

This linter is off by default and activated in mathlib only.

---

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
