### PR TITLE
chore: remove global `Quotient.mk` `⟦·⟧` notation

### DIFF
--- a/Counterexamples/Pseudoelement.lean
+++ b/Counterexamples/Pseudoelement.lean
@@ -102,6 +102,8 @@ attribute [local instance] Pseudoelement.setoid
 
 open scoped Pseudoelement
 
+local notation3:arg (priority := high) "⟦" a "⟧" => Quotient.mk _ a
+
 /-- `biprod.fst ⟦x⟧ = biprod.fst ⟦y⟧`. -/
 theorem fst_mk'_x_eq_fst_mk'_y :
     (biprod.fst : of ℤ ℚ ⊞ of ℤ ℚ ⟶ _) ⟦x⟧ = (biprod.fst : of ℤ ℚ ⊞ of ℤ ℚ ⟶ _) ⟦y⟧ :=

--- a/Mathlib/Algebra/Associated/Basic.lean
+++ b/Mathlib/Algebra/Associated/Basic.lean
@@ -740,6 +740,8 @@ namespace Associates
 
 open Associated
 
+local notation3:arg (priority := high) "⟦" a "⟧" => Quotient.mk _ a
+
 /-- The canonical quotient map from a monoid `α` into the `Associates` of `α` -/
 protected abbrev mk {α : Type*} [Monoid α] (a : α) : Associates α :=
   ⟦a⟧

--- a/Mathlib/Algebra/BigOperators/Group/Finset.lean
+++ b/Mathlib/Algebra/BigOperators/Group/Finset.lean
@@ -1603,6 +1603,8 @@ theorem dvd_prod_of_mem (f : α → β) {a : α} {s : Finset α} (ha : a ∈ s) 
     rw [Finset.prod_eq_mul_prod_diff_singleton ha]
     exact dvd_mul_right _ _
 
+local notation3:arg (priority := high) "⟦" a "⟧" => Quotient.mk _ a
+
 /-- A product can be partitioned into a product of products, each equivalent under a setoid. -/
 @[to_additive "A sum can be partitioned into a sum of sums, each equivalent under a setoid."]
 theorem prod_partition (R : Setoid α) [DecidableRel R.r] :

--- a/Mathlib/Algebra/Group/Conj.lean
+++ b/Mathlib/Algebra/Group/Conj.lean
@@ -134,6 +134,8 @@ section Monoid
 
 variable [Monoid α] [Monoid β]
 
+local notation3:arg (priority := high) "⟦" a "⟧" => Quotient.mk _ a
+
 /-- The canonical quotient map from a monoid `α` into the `ConjClasses` of `α` -/
 protected def mk {α : Type*} [Monoid α] (a : α) : ConjClasses α := ⟦a⟧
 

--- a/Mathlib/Algebra/GroupWithZero/NonZeroDivisors.lean
+++ b/Mathlib/Algebra/GroupWithZero/NonZeroDivisors.lean
@@ -301,6 +301,8 @@ theorem mk_mem_nonZeroDivisors_associates : Associates.mk a ∈ (Associates M₀
   · refine fun ⟨b, hb₁, hb₂⟩ ↦ ⟨Associates.mk b, ?_, by rwa [Associates.mk_ne_zero]⟩
     rw [Associates.mk_mul_mk, hb₁, Associates.mk_zero]
 
+local notation3:arg (priority := high) "⟦" a "⟧" => Quotient.mk _ a
+
 /-- The non-zero divisors of associates of a monoid with zero `M₀` are isomorphic to the associates
 of the non-zero divisors of `M₀` under the map `⟨⟦a⟧, _⟩ ↦ ⟦⟨a, _⟩⟧`. -/
 def associatesNonZeroDivisorsEquiv : (Associates M₀)⁰ ≃* Associates M₀⁰ where

--- a/Mathlib/Algebra/Order/CauSeq/Completion.lean
+++ b/Mathlib/Algebra/Order/CauSeq/Completion.lean
@@ -34,6 +34,8 @@ variable {abv}
 def mk : CauSeq _ abv → Cauchy abv :=
   Quotient.mk''
 
+local notation3:arg (priority := high) "⟦" a "⟧" => Quotient.mk _ a
+
 @[simp]
 theorem mk_eq_mk (f : CauSeq _ abv) : @Eq (Cauchy abv) ⟦f⟧ (mk f) :=
   rfl

--- a/Mathlib/Algebra/Quandle.lean
+++ b/Mathlib/Algebra/Quandle.lean
@@ -595,6 +595,8 @@ instance PreEnvelGroup.setoid (R : Type*) [Rack R] : Setoid (PreEnvelGroup R) wh
 def EnvelGroup (R : Type*) [Rack R] :=
   Quotient (PreEnvelGroup.setoid R)
 
+local notation3:arg (priority := high) "⟦" a "⟧" => Quotient.mk _ a
+
 -- Define the `Group` instances in two steps so `inv` can be inferred correctly.
 -- TODO: is there a non-invasive way of defining the instance directly?
 instance (R : Type*) [Rack R] : DivInvMonoid (EnvelGroup R) where

--- a/Mathlib/AlgebraicGeometry/EllipticCurve/Jacobian.lean
+++ b/Mathlib/AlgebraicGeometry/EllipticCurve/Jacobian.lean
@@ -88,6 +88,8 @@ local macro "matrix_simp" : tactic =>
   `(tactic| simp only [Matrix.head_cons, Matrix.tail_cons, Matrix.smul_empty, Matrix.smul_cons,
     Matrix.cons_val_zero, Matrix.cons_val_one, Matrix.cons_val_two])
 
+local notation3:arg (priority := high) "⟦" a "⟧" => Quotient.mk _ a
+
 universe u v
 
 /-! ## Weierstrass curves -/

--- a/Mathlib/AlgebraicGeometry/EllipticCurve/Projective.lean
+++ b/Mathlib/AlgebraicGeometry/EllipticCurve/Projective.lean
@@ -73,6 +73,8 @@ local macro "matrix_simp" : tactic =>
   `(tactic| simp only [Matrix.head_cons, Matrix.tail_cons, Matrix.smul_empty, Matrix.smul_cons,
     Matrix.cons_val_zero, Matrix.cons_val_one, Matrix.cons_val_two])
 
+local notation3:arg (priority := high) "⟦" a "⟧" => Quotient.mk _ a
+
 universe u v
 
 /-! ## Weierstrass curves -/

--- a/Mathlib/AlgebraicTopology/FundamentalGroupoid/Basic.lean
+++ b/Mathlib/AlgebraicTopology/FundamentalGroupoid/Basic.lean
@@ -296,6 +296,8 @@ instance {X : Type u} [Inhabited X] : Inhabited (FundamentalGroupoid X) :=
 
 attribute [local instance] Path.Homotopic.setoid
 
+local notation3:arg (priority := high) "⟦" a "⟧" => Quotient.mk _ a
+
 instance : CategoryTheory.Groupoid (FundamentalGroupoid X) where
   Hom x y := Path.Homotopic.Quotient x.as y.as
   id x := ⟦Path.refl x.as⟧

--- a/Mathlib/AlgebraicTopology/FundamentalGroupoid/FundamentalGroup.lean
+++ b/Mathlib/AlgebraicTopology/FundamentalGroupoid/FundamentalGroup.lean
@@ -46,6 +46,8 @@ attribute [local instance] Path.Homotopic.setoid
 -- Porting note: removed this attribute
 --attribute [local reducible] FundamentalGroupoid
 
+local notation3:arg (priority := high) "⟦" a "⟧" => Quotient.mk _ a
+
 /-- Get an isomorphism between the fundamental groups at two points given a path -/
 def fundamentalGroupMulEquivOfPath (p : Path x₀ x₁) :
     FundamentalGroup X x₀ ≃* FundamentalGroup X x₁ :=

--- a/Mathlib/AlgebraicTopology/FundamentalGroupoid/InducedMaps.lean
+++ b/Mathlib/AlgebraicTopology/FundamentalGroupoid/InducedMaps.lean
@@ -42,6 +42,8 @@ open scoped FundamentalGroupoid
 
 open scoped unitInterval
 
+local notation3:arg (priority := high) "⟦" a "⟧" => Quotient.mk _ a
+
 namespace unitInterval
 
 /-- The path 0 ⟶ 1 in `I` -/

--- a/Mathlib/AlgebraicTopology/FundamentalGroupoid/Product.lean
+++ b/Mathlib/AlgebraicTopology/FundamentalGroupoid/Product.lean
@@ -48,6 +48,8 @@ theorem proj_map (i : I) (x₀ x₁ : πₓ (TopCat.of (∀ i, X i))) (p : x₀ 
     (proj X i).map p = @Path.Homotopic.proj _ _ _ _ _ i p :=
   rfl
 
+local notation3:arg (priority := high) "⟦" a "⟧" => Quotient.mk _ a
+
 /-- The map taking the pi product of a family of fundamental groupoids to the fundamental
 groupoid of the pi product. This is actually an isomorphism (see `piIso`)
 -/

--- a/Mathlib/AlgebraicTopology/FundamentalGroupoid/SimplyConnected.lean
+++ b/Mathlib/AlgebraicTopology/FundamentalGroupoid/SimplyConnected.lean
@@ -73,6 +73,8 @@ end SimplyConnectedSpace
 
 attribute [local instance] Path.Homotopic.setoid
 
+local notation3:arg (priority := high) "⟦" a "⟧" => Quotient.mk _ a
+
 /-- A space is simply connected iff it is path connected, and there is at most one path
   up to homotopy between any two points. -/
 theorem simply_connected_iff_paths_homotopic {Y : Type*} [TopologicalSpace Y] :

--- a/Mathlib/CategoryTheory/Abelian/Pseudoelements.lean
+++ b/Mathlib/CategoryTheory/Abelian/Pseudoelements.lean
@@ -82,6 +82,8 @@ open CategoryTheory.Preadditive
 
 universe v u
 
+local notation3:arg (priority := high) "⟦" a "⟧" => Quotient.mk _ a
+
 namespace CategoryTheory.Abelian
 
 variable {C : Type u} [Category.{v} C]

--- a/Mathlib/CategoryTheory/Limits/Shapes/SingleObj.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/SingleObj.lean
@@ -81,6 +81,8 @@ lemma Types.Quot.Rel.iff_orbitRel (x y : J.obj (SingleObj.star G)) :
   show (∃ g : G, y = g • x) ↔ (∃ g : G, g • x = y)
   conv => lhs; simp only [h]
 
+local notation3:arg (priority := high) "⟦" a "⟧" => Quotient.mk _ a
+
 /-- The explicit quotient construction of the colimit of `J : SingleObj G ⥤ Type u` is
 equivalent to the quotient of `J.obj (SingleObj.star G)` by the induced action. -/
 @[simps]

--- a/Mathlib/CategoryTheory/Monoidal/Free/Basic.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Free/Basic.lean
@@ -136,6 +136,8 @@ section
 
 open FreeMonoidalCategory.HomEquiv
 
+local notation3:arg (priority := high) "⟦" a "⟧" => Quotient.mk _ a
+
 instance categoryFreeMonoidalCategory : Category.{u} (F C) where
   Hom X Y := Quotient (FreeMonoidalCategory.setoidHom X Y)
   id X := ⟦Hom.id X⟧

--- a/Mathlib/CategoryTheory/Monoidal/Free/Coherence.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Free/Coherence.lean
@@ -325,6 +325,8 @@ def inverseAux : ∀ {X Y : F C}, (X ⟶ᵐ Y) → (Y ⟶ᵐ X)
 
 end
 
+local notation3:arg (priority := high) "⟦" a "⟧" => Quotient.mk _ a
+
 instance : Groupoid.{u} (F C) :=
   { (inferInstance : Category (F C)) with
     inv := Quotient.lift (fun f => ⟦inverseAux f⟧) (by aesop_cat) }

--- a/Mathlib/CategoryTheory/Skeletal.lean
+++ b/Mathlib/CategoryTheory/Skeletal.lean
@@ -69,6 +69,8 @@ its category structure.
 -/
 def Skeleton : Type u₁ := InducedCategory C Quotient.out
 
+local notation3:arg (priority := high) "⟦" a "⟧" => Quotient.mk _ a
+
 instance [Inhabited C] : Inhabited (Skeleton C) :=
   ⟨⟦default⟧⟩
 

--- a/Mathlib/Data/Finset/Card.lean
+++ b/Mathlib/Data/Finset/Card.lean
@@ -209,6 +209,8 @@ theorem Multiset.toFinset_card_eq_card_iff_nodup {m : Multiset α} :
 theorem List.card_toFinset : l.toFinset.card = l.dedup.length :=
   rfl
 
+local notation3:arg (priority := high) "⟦" a "⟧" => Quotient.mk _ a
+
 theorem List.toFinset_card_le : l.toFinset.card ≤ l.length :=
   Multiset.toFinset_card_le ⟦l⟧
 

--- a/Mathlib/Data/Fintype/List.lean
+++ b/Mathlib/Data/Fintype/List.lean
@@ -31,6 +31,8 @@ open List
 
 namespace Multiset
 
+local notation3:arg (priority := high) "⟦" a "⟧" => Quotient.mk _ a
+
 /-- The `Finset` of `l : List α` that, given `m : Multiset α`, have the property `⟦l⟧ = m`.
 -/
 def lists : Multiset α → Finset (List α) := fun s =>

--- a/Mathlib/Data/Fintype/Quotient.lean
+++ b/Mathlib/Data/Fintype/Quotient.lean
@@ -18,6 +18,8 @@ to a quotient of finite families.
 -/
 
 
+local notation3:arg (priority := high) "⟦" a "⟧" => Quotient.mk _ a
+
 /-- An auxiliary function for `Quotient.finChoice`.  Given a
 collection of setoids indexed by a type `ι`, a (finite) list `l` of
 indices, and a function that for each `i ∈ l` gives a term of the

--- a/Mathlib/Data/Multiset/Basic.lean
+++ b/Mathlib/Data/Multiset/Basic.lean
@@ -41,6 +41,8 @@ def ofList : List α → Multiset α :=
 instance : Coe (List α) (Multiset α) :=
   ⟨ofList⟩
 
+local notation3:arg (priority := high) "⟦" a "⟧" => Quotient.mk _ a
+
 @[simp]
 theorem quot_mk_to_coe (l : List α) : @Eq (Multiset α) ⟦l⟧ l :=
   rfl

--- a/Mathlib/Data/QPF/Multivariate/Constructions/Fix.lean
+++ b/Mathlib/Data/QPF/Multivariate/Constructions/Fix.lean
@@ -162,6 +162,8 @@ Fix F a b = F a b (Fix F a b)
 def Fix {n : ℕ} (F : TypeVec (n + 1) → Type*) [q : MvQPF F] (α : TypeVec n) :=
   Quotient (wSetoid α : Setoid (q.P.W α))
 
+local notation3:arg (priority := high) "⟦" a "⟧" => Quotient.mk _ a
+
 /-- `Fix F` is a functor -/
 def Fix.map {α β : TypeVec n} (g : α ⟹ β) : Fix F α → Fix F β :=
   Quotient.lift (fun x : q.P.W α => ⟦q.P.wMap g x⟧) fun _a _b h => Quot.sound (wEquiv_map _ _ _ h)

--- a/Mathlib/Data/QPF/Univariate/Basic.lean
+++ b/Mathlib/Data/QPF/Univariate/Basic.lean
@@ -254,6 +254,8 @@ theorem Fix.rec_eq {α : Type _} (g : F α → α) (x : F (Fix F)) :
   rw [PFunctor.map_eq, recF_eq, ← PFunctor.map_eq, PFunctor.W.dest_mk, PFunctor.map_map, abs_map,
     ← h, abs_repr, this]
 
+local notation3:arg (priority := high) "⟦" a "⟧" => Quotient.mk _ a
+
 theorem Fix.ind_aux (a : q.P.A) (f : q.P.B a → q.P.W) :
     Fix.mk (abs ⟨a, fun x => ⟦f x⟧⟩) = ⟦⟨a, f⟩⟧ := by
   have : Fix.mk (abs ⟨a, fun x => ⟦f x⟧⟩) = ⟦Wrepr ⟨a, f⟩⟧ := by

--- a/Mathlib/Data/Quot.lean
+++ b/Mathlib/Data/Quot.lean
@@ -198,7 +198,7 @@ variable {φ : Quotient sa → Quotient sb → Sort*}
 -- reliably found but it can't always be inferred from the expected type either.
 -- See also: https://leanprover.zulipchat.com/#narrow/stream/113489-new-members/topic/confusion.20between.20equivalence.20and.20instance.20setoid/near/360822354
 @[inherit_doc Quotient.mk]
-notation3:arg "⟦" a "⟧" => Quotient.mk _ a
+local notation3:arg (priority := high) "⟦" a "⟧" => Quotient.mk _ a
 
 instance instInhabitedQuotient (s : Setoid α) [Inhabited α] : Inhabited (Quotient s) :=
   ⟨⟦default⟧⟩
@@ -263,6 +263,8 @@ instance (q₁ : Quotient sa) (q₂ : Quotient sb) (f : α → β → Prop)
   Quotient.lift₂.decidablePred _ _ _ _
 
 end Quotient
+
+local notation3:arg (priority := high) "⟦" a "⟧" => Quotient.mk _ a
 
 theorem Quot.eq {α : Type*} {r : α → α → Prop} {x y : α} :
     Quot.mk r x = Quot.mk r y ↔ Relation.EqvGen r x y :=

--- a/Mathlib/Data/Real/Basic.lean
+++ b/Mathlib/Data/Real/Basic.lean
@@ -263,6 +263,8 @@ private irreducible_def lt : ℝ → ℝ → Prop
 instance : LT ℝ :=
   ⟨lt⟩
 
+local notation3:arg (priority := high) "⟦" a "⟧" => Quotient.mk _ a
+
 theorem lt_cauchy {f g} : (⟨⟦f⟧⟩ : ℝ) < ⟨⟦g⟧⟩ ↔ f < g :=
   show lt _ _ ↔ _ by rw [lt_def]; rfl
 

--- a/Mathlib/Data/Set/Finite.lean
+++ b/Mathlib/Data/Set/Finite.lean
@@ -497,6 +497,8 @@ theorem finite_toSet_toFinset [DecidableEq α] (s : Multiset α) :
 
 end Multiset
 
+local notation3:arg (priority := high) "⟦" a "⟧" => Quotient.mk _ a
+
 @[simp]
 theorem List.finite_toSet (l : List α) : { x | x ∈ l }.Finite :=
   (show Multiset α from ⟦l⟧).finite_toSet

--- a/Mathlib/Data/Set/Image.lean
+++ b/Mathlib/Data/Set/Image.lean
@@ -35,6 +35,8 @@ universe u v
 
 open Function Set
 
+local notation3:arg (priority := high) "⟦" a "⟧" => Quotient.mk _ a
+
 namespace Set
 
 variable {α β γ : Type*} {ι ι' : Sort*}

--- a/Mathlib/Data/Setoid/Basic.lean
+++ b/Mathlib/Data/Setoid/Basic.lean
@@ -36,6 +36,8 @@ attribute [refl] Setoid.refl
 attribute [symm] Setoid.symm
 attribute [trans] Setoid.trans
 
+local notation3:arg (priority := high) "⟦" a "⟧" => Quotient.mk _ a
+
 variable {α : Type*} {β : Type*}
 
 /-- A version of `Setoid.r` that takes the equivalence relation as an explicit argument. -/

--- a/Mathlib/GroupTheory/GroupAction/Basic.lean
+++ b/Mathlib/GroupTheory/GroupAction/Basic.lean
@@ -454,6 +454,8 @@ variable (G α)
 abbrev orbitRel.Quotient : Type _ :=
   _root_.Quotient <| orbitRel G α
 
+local notation3:arg (priority := high) "⟦" a "⟧" => Quotient.mk _ a
+
 /-- An action is pretransitive if and only if the quotient by `MulAction.orbitRel` is a
 subsingleton. -/
 @[to_additive "An additive action is pretransitive if and only if the quotient by

--- a/Mathlib/GroupTheory/GroupAction/Quotient.lean
+++ b/Mathlib/GroupTheory/GroupAction/Quotient.lean
@@ -288,6 +288,8 @@ instance isPretransitive_quotient (G) [Group G] (H : Subgroup G) : IsPretransiti
 
 variable {α}
 
+local notation3:arg (priority := high) "⟦" a "⟧" => Quotient.mk _ a
+
 @[to_additive]
 instance finite_quotient_of_pretransitive_of_finite_quotient [IsPretransitive α β] {H : Subgroup α}
     [Finite (α ⧸ H)] : Finite <| orbitRel.Quotient H β := by

--- a/Mathlib/LinearAlgebra/Dual.lean
+++ b/Mathlib/LinearAlgebra/Dual.lean
@@ -1249,6 +1249,8 @@ theorem quotDualCoannihilatorToDual_injective (W : Submodule R (Dual R M)) :
     Function.Injective W.quotDualCoannihilatorToDual :=
   LinearMap.ker_eq_bot.mp (ker_liftQ_eq_bot _ _ _ le_rfl)
 
+local notation3:arg (priority := high) "⟦" a "⟧" => Quotient.mk _ a
+
 theorem flip_quotDualCoannihilatorToDual_injective (W : Submodule R (Dual R M)) :
     Function.Injective W.quotDualCoannihilatorToDual.flip :=
   fun _ _ he ↦ Subtype.ext <| LinearMap.ext fun m ↦ DFunLike.congr_fun he ⟦m⟧

--- a/Mathlib/LinearAlgebra/Dual.lean
+++ b/Mathlib/LinearAlgebra/Dual.lean
@@ -1249,7 +1249,7 @@ theorem quotDualCoannihilatorToDual_injective (W : Submodule R (Dual R M)) :
     Function.Injective W.quotDualCoannihilatorToDual :=
   LinearMap.ker_eq_bot.mp (ker_liftQ_eq_bot _ _ _ le_rfl)
 
-local notation3:arg (priority := high) "⟦" a "⟧" => Quotient.mk _ a
+local notation3:arg (priority := high) "⟦" a "⟧" => _root_.Quotient.mk _ a
 
 theorem flip_quotDualCoannihilatorToDual_injective (W : Submodule R (Dual R M)) :
     Function.Injective W.quotDualCoannihilatorToDual.flip :=

--- a/Mathlib/LinearAlgebra/Ray.lean
+++ b/Mathlib/LinearAlgebra/Ray.lean
@@ -217,6 +217,8 @@ theorem equiv_iff_sameRay {v₁ v₂ : RayVector R M} : v₁ ≈ v₂ ↔ SameRa
 
 variable (R)
 
+local notation3:arg (priority := high) "⟦" a "⟧" => Quotient.mk _ a
+
 -- Porting note: Removed `protected` here, not in namespace
 /-- The ray given by a nonzero vector. -/
 def rayOfNeZero (v : M) (h : v ≠ 0) : Module.Ray R M :=

--- a/Mathlib/Logic/Encodable/Basic.lean
+++ b/Mathlib/Logic/Encodable/Basic.lean
@@ -599,6 +599,8 @@ on an encodable type. -/
 def Quotient.rep (q : Quotient s) : α :=
   choose (exists_rep q)
 
+local notation3:arg (priority := high) "⟦" a "⟧" => Quotient.mk _ a
+
 theorem Quotient.rep_spec (q : Quotient s) : ⟦q.rep⟧ = q :=
   choose_spec (exists_rep q)
 

--- a/Mathlib/Logic/Equiv/Basic.lean
+++ b/Mathlib/Logic/Equiv/Basic.lean
@@ -1351,6 +1351,8 @@ theorem Perm.extendDomain_trans (e e' : Perm α') :
 
 end
 
+local notation3:arg (priority := high) "⟦" a "⟧" => Quotient.mk _ a
+
 /-- Subtype of the quotient is equivalent to the quotient of the subtype. Let `α` be a setoid with
 equivalence relation `~`. Let `p₂` be a predicate on the quotient type `α/~`, and `p₁` be the lift
 of this predicate to `α`: `p₁ a ↔ p₂ ⟦a⟧`. Let `~₂` be the restriction of `~` to `{x // p₁ x}`.

--- a/Mathlib/ModelTheory/DirectLimit.lean
+++ b/Mathlib/ModelTheory/DirectLimit.lean
@@ -162,6 +162,8 @@ attribute [local instance] DirectLimit.setoid
 -- Porting note (#10754): Added local instance
 attribute [local instance] DirectLimit.sigmaStructure
 
+local notation3:arg (priority := high) "⟦" a "⟧" => Quotient.mk _ a
+
 
 instance [DirectedSystem G fun i j h => f i j h] [IsDirected ι (· ≤ ·)] [Inhabited ι]
     [Inhabited (G default)] : Inhabited (DirectLimit G f) :=

--- a/Mathlib/ModelTheory/Fraisse.lean
+++ b/Mathlib/ModelTheory/Fraisse.lean
@@ -168,6 +168,8 @@ theorem age.fg_substructure {S : L.Substructure M} (fg : S.FG) : Bundled.mk S �
 
 variable (M)
 
+local notation3:arg (priority := high) "⟦" a "⟧" => Quotient.mk _ a
+
 /-- Any class in the age of a structure has a representative which is a finitely generated
 substructure. -/
 theorem age.has_representative_as_substructure :

--- a/Mathlib/ModelTheory/Quotients.lean
+++ b/Mathlib/ModelTheory/Quotients.lean
@@ -48,6 +48,8 @@ instance quotientStructure : L.Structure (Quotient s) where
 
 variable (s)
 
+local notation3:arg (priority := high) "⟦" a "⟧" => Quotient.mk _ a
+
 theorem funMap_quotient_mk' {n : ℕ} (f : L.Functions n) (x : Fin n → M) :
     (funMap f fun i => (⟦x i⟧ : Quotient s)) = ⟦@funMap _ _ ps.toStructure _ f x⟧ := by
   change

--- a/Mathlib/NumberTheory/NumberField/CanonicalEmbedding/FundamentalCone.lean
+++ b/Mathlib/NumberTheory/NumberField/CanonicalEmbedding/FundamentalCone.lean
@@ -338,6 +338,8 @@ def quotIntNorm :
     rw [← Nat.cast_inj (R := ℝ), intNorm_coe, intNorm_coe, ← hu, integralPoint_torsionSMul_smul_coe,
       norm_unit_smul]
 
+local notation3:arg (priority := high) "⟦" a "⟧" => Quotient.mk _ a
+
 @[simp]
 theorem quotIntNorm_apply (a : integralPoint K) : quotIntNorm ⟦a⟧ = intNorm a := rfl
 

--- a/Mathlib/NumberTheory/NumberField/Embeddings.lean
+++ b/Mathlib/NumberTheory/NumberField/Embeddings.lean
@@ -707,6 +707,8 @@ lemma mem_orbit_iff [IsGalois k K] {w w' : InfinitePlace K} :
   rw [← mk_embedding w, comap_mk, smul_mk, comap_mk]
   congr 1; ext1; simp
 
+local notation3:arg (priority := high) "⟦" a "⟧" => Quotient.mk _ a
+
 /-- The orbits of infinite places under the action of the galois group are indexed by
 the infinite places of the base field. -/
 noncomputable

--- a/Mathlib/NumberTheory/NumberField/Units/DirichletTheorem.lean
+++ b/Mathlib/NumberTheory/NumberField/Units/DirichletTheorem.lean
@@ -418,6 +418,8 @@ local instance : CommGroup (𝓞 K)ˣ := inferInstance
 -/
 set_option maxSynthPendingDepth 2 -- Note this is active for the remainder of the file.
 
+local notation3:arg (priority := high) "⟦" a "⟧" => Quotient.mk _ a
+
 /-- The linear equivalence between `(𝓞 K)ˣ ⧸ (torsion K)` as an additive `ℤ`-module and
 `unitLattice` . -/
 def logEmbeddingEquiv :

--- a/Mathlib/NumberTheory/Padics/PadicIntegers.lean
+++ b/Mathlib/NumberTheory/Padics/PadicIntegers.lean
@@ -172,6 +172,8 @@ theorem intCast_eq (z1 z2 : ℤ) : (z1 : ℤ_[p]) = z2 ↔ z1 = z2 := by
 
 @[deprecated (since := "2024-04-05")] alias coe_int_eq := intCast_eq
 
+local notation3:arg (priority := high) "⟦" a "⟧" => Quotient.mk _ a
+
 /-- A sequence of integers that is Cauchy with respect to the `p`-adic norm converges to a `p`-adic
 integer. -/
 def ofIntSeq (seq : ℕ → ℤ) (h : IsCauSeq (padicNorm p) fun n => seq n) : ℤ_[p] :=

--- a/Mathlib/NumberTheory/Padics/PadicNumbers.lean
+++ b/Mathlib/NumberTheory/Padics/PadicNumbers.lean
@@ -62,6 +62,8 @@ noncomputable section
 
 open Nat multiplicity padicNorm CauSeq CauSeq.Completion Metric
 
+local notation3:arg (priority := high) "⟦" a "⟧" => Quotient.mk _ a
+
 /-- The type of Cauchy sequences of rationals with respect to the `p`-adic norm. -/
 abbrev PadicSeq (p : ℕ) :=
   CauSeq _ (padicNorm p)

--- a/Mathlib/Order/RelIso/Basic.lean
+++ b/Mathlib/Order/RelIso/Basic.lean
@@ -370,6 +370,8 @@ noncomputable def Quotient.out'RelEmbedding {_ : Setoid α} {r : α → α → P
     (fun a b => Quotient.liftOn₂' a b r H) ↪r r :=
   { Quotient.outRelEmbedding H with toFun := Quotient.out' }
 
+local notation3:arg (priority := high) "⟦" a "⟧" => Quotient.mk _ a
+
 @[simp]
 theorem acc_lift₂_iff [Setoid α] {r : α → α → Prop}
     {H : ∀ (a₁ b₁ a₂ b₂ : α), a₁ ≈ a₂ → b₁ ≈ b₂ → r a₁ b₁ = r a₂ b₂} {a} :

--- a/Mathlib/RepresentationTheory/Action/Concrete.lean
+++ b/Mathlib/RepresentationTheory/Action/Concrete.lean
@@ -94,6 +94,8 @@ notation:10 G:10 " ⧸ₐ " H:10 => Action.FintypeCat.ofMulAction G (FintypeCat.
 
 variable {G : Type*} [Group G] (H N : Subgroup G) [Fintype (G ⧸ N)]
 
+local notation3:arg (priority := high) "⟦" a "⟧" => Quotient.mk _ a
+
 /-- If `N` is a normal subgroup of `G`, then this is the group homomorphism
 sending an element `g` of `G` to the `G`-endomorphism of `G ⧸ₐ N` given by
 multiplication with `g⁻¹` on the right. -/

--- a/Mathlib/SetTheory/Cardinal/Basic.lean
+++ b/Mathlib/SetTheory/Cardinal/Basic.lean
@@ -139,6 +139,8 @@ theorem induction_on_pi {ι : Type u} {p : (ι → Cardinal.{v}) → Prop}
 protected theorem eq : #α = #β ↔ Nonempty (α ≃ β) :=
   Quotient.eq'
 
+local notation3:arg (priority := high) "⟦" a "⟧" => Quotient.mk _ a
+
 @[simp]
 theorem mk'_def (α : Type u) : @Eq Cardinal ⟦α⟧ #α :=
   rfl

--- a/Mathlib/SetTheory/Cardinal/Ordinal.lean
+++ b/Mathlib/SetTheory/Cardinal/Ordinal.lean
@@ -445,6 +445,8 @@ end beth
 /-! ### Properties of `mul` -/
 section mulOrdinals
 
+local notation3:arg (priority := high) "⟦" a "⟧" => Quotient.mk _ a
+
 /-- If `α` is an infinite type, then `α × α` and `α` have the same cardinality. -/
 theorem mul_eq_self {c : Cardinal} (h : ℵ₀ ≤ c) : c * c = c := by
   refine le_antisymm ?_ (by simpa only [mul_one] using mul_le_mul_left' (one_le_aleph0.trans h) c)

--- a/Mathlib/SetTheory/Game/Basic.lean
+++ b/Mathlib/SetTheory/Game/Basic.lean
@@ -32,6 +32,8 @@ open PGame
 
 universe u
 
+local notation3:arg (priority := high) "⟦" a "⟧" => Quotient.mk _ a
+
 -- Porting note: moved the setoid instance to PGame.lean
 
 /-- The type of combinatorial games. In ZFC, a combinatorial game is constructed from

--- a/Mathlib/SetTheory/Game/Birthday.lean
+++ b/Mathlib/SetTheory/Game/Birthday.lean
@@ -173,6 +173,8 @@ end PGame
 
 namespace Game
 
+local notation3:arg (priority := high) "⟦" a "⟧" => Quotient.mk _ a
+
 /-- The birthday of a game is defined as the least birthday among all pre-games that define it. -/
 noncomputable def birthday (x : Game.{u}) : Ordinal.{u} :=
   sInf (PGame.birthday '' (Quotient.mk' ⁻¹' {x}))

--- a/Mathlib/SetTheory/Game/Impartial.lean
+++ b/Mathlib/SetTheory/Game/Impartial.lean
@@ -57,6 +57,8 @@ instance impartial_star : Impartial star := by
 theorem neg_equiv_self (G : PGame) [h : G.Impartial] : G ≈ -G :=
   (impartial_def.1 h).1
 
+local notation3:arg (priority := high) "⟦" a "⟧" => Quotient.mk _ a
+
 @[simp]
 theorem mk'_neg_equiv_self (G : PGame) [G.Impartial] : -(⟦G⟧ : Game) = ⟦G⟧ :=
   game_eq (Equiv.symm (neg_equiv_self G))

--- a/Mathlib/SetTheory/Game/Ordinal.lean
+++ b/Mathlib/SetTheory/Game/Ordinal.lean
@@ -147,6 +147,8 @@ noncomputable def toPGameEmbedding : Ordinal.{u} ↪o PGame.{u} where
   inj' := toPGame_injective
   map_rel_iff' := @toPGame_le_iff
 
+local notation3:arg (priority := high) "⟦" a "⟧" => Quotient.mk _ a
+
 /-- Converts an ordinal into the corresponding game. -/
 noncomputable abbrev toGame (o : Ordinal) : Game := ⟦o.toPGame⟧
 

--- a/Mathlib/SetTheory/Game/State.lean
+++ b/Mathlib/SetTheory/Game/State.lean
@@ -221,6 +221,8 @@ end PGame
 
 namespace Game
 
+local notation3:arg (priority := high) "⟦" a "⟧" => Quotient.mk _ a
+
 /-- Construct a combinatorial `Game` from a state. -/
 def ofState {S : Type u} [PGame.State S] (s : S) : Game :=
   ⟦PGame.ofState s⟧

--- a/Mathlib/SetTheory/Lists.lean
+++ b/Mathlib/SetTheory/Lists.lean
@@ -392,6 +392,8 @@ def Finsets (α : Type*) :=
 
 namespace Finsets
 
+local notation3:arg (priority := high) "⟦" a "⟧" => Quotient.mk _ a
+
 instance : EmptyCollection (Finsets α) :=
   ⟨⟦Lists.of' Lists'.nil⟧⟩
 

--- a/Mathlib/SetTheory/Ordinal/Arithmetic.lean
+++ b/Mathlib/SetTheory/Ordinal/Arithmetic.lean
@@ -557,6 +557,8 @@ theorem one_add_of_omega_le {o} (h : ω ≤ o) : 1 + o = o := by
 /-! ### Multiplication of ordinals -/
 
 
+local notation3:arg (priority := high) "⟦" a "⟧" => Quotient.mk _ a
+
 /-- The multiplication of ordinals `o₁` and `o₂` is the (well founded) lexicographic order on
 `o₂ × o₁`. -/
 instance monoid : Monoid Ordinal.{u} where

--- a/Mathlib/SetTheory/Ordinal/Basic.lean
+++ b/Mathlib/SetTheory/Ordinal/Basic.lean
@@ -126,6 +126,8 @@ namespace Ordinal
 
 /-! ### Basic properties of the order type -/
 
+local notation3:arg (priority := high) "⟦" a "⟧" => Quotient.mk _ a
+
 /-- The order type of a well order is an ordinal. -/
 def type (r : α → α → Prop) [wo : IsWellOrder α r] : Ordinal :=
   ⟦⟨α, r, wo⟩⟧

--- a/Mathlib/SetTheory/Surreal/Basic.lean
+++ b/Mathlib/SetTheory/Surreal/Basic.lean
@@ -269,6 +269,8 @@ def Surreal :=
 
 namespace Surreal
 
+local notation3:arg (priority := high) "⟦" a "⟧" => Quotient.mk _ a
+
 /-- Construct a surreal number from a numeric pre-game. -/
 def mk (x : PGame) (h : x.Numeric) : Surreal :=
   ⟦⟨x, h⟩⟧

--- a/Mathlib/SetTheory/Surreal/Dyadic.lean
+++ b/Mathlib/SetTheory/Surreal/Dyadic.lean
@@ -147,6 +147,8 @@ namespace Surreal
 
 open SetTheory PGame
 
+local notation3:arg (priority := high) "⟦" a "⟧" => Quotient.mk _ a
+
 /-- Powers of the surreal number `half`. -/
 def powHalf (n : ℕ) : Surreal :=
   ⟦⟨PGame.powHalf n, PGame.numeric_powHalf n⟩⟧

--- a/Mathlib/SetTheory/Surreal/Multiplication.lean
+++ b/Mathlib/SetTheory/Surreal/Multiplication.lean
@@ -66,6 +66,8 @@ universe u
 
 open SetTheory Game PGame WellFounded
 
+local notation3:arg (priority := high) "⟦" a "⟧" => Quotient.mk _ a
+
 namespace Surreal.Multiplication
 
 /-- The nontrivial part of P1 in [SchleicherStoll] says that the left options of `x * y` are less

--- a/Mathlib/SetTheory/ZFC/Basic.lean
+++ b/Mathlib/SetTheory/ZFC/Basic.lean
@@ -512,6 +512,8 @@ end PSet
 def ZFSet : Type (u + 1) :=
   Quotient PSet.setoid.{u}
 
+local notation3:arg (priority := high) "⟦" a "⟧" => Quotient.mk _ a
+
 namespace PSet
 
 namespace Resp

--- a/Mathlib/SetTheory/ZFC/Rank.lean
+++ b/Mathlib/SetTheory/ZFC/Rank.lean
@@ -133,6 +133,8 @@ noncomputable def rank : ZFSet.{u} → Ordinal.{u} :=
 theorem rank_lt_of_mem : y ∈ x → rank y < rank x :=
   Quotient.inductionOn₂ x y fun _ _ => PSet.rank_lt_of_mem
 
+local notation3:arg (priority := high) "⟦" a "⟧" => Quotient.mk _ a
+
 theorem rank_le_iff {o : Ordinal} : rank x ≤ o ↔ ∀ ⦃y⦄, y ∈ x → rank y < o :=
   ⟨fun h _ h' => (rank_lt_of_mem h').trans_le h,
     Quotient.inductionOn x fun _ h =>

--- a/Mathlib/Topology/Connected/PathConnected.lean
+++ b/Mathlib/Topology/Connected/PathConnected.lean
@@ -1003,6 +1003,8 @@ class PathConnectedSpace (X : Type*) [TopologicalSpace X] : Prop where
   /-- Any two points in a path-connected space must be joined by a continuous path. -/
   joined : ∀ x y : X, Joined x y
 
+local notation3:arg (priority := high) "⟦" a "⟧" => Quotient.mk _ a
+
 theorem pathConnectedSpace_iff_zerothHomotopy :
     PathConnectedSpace X ↔ Nonempty (ZerothHomotopy X) ∧ Subsingleton (ZerothHomotopy X) := by
   letI := pathSetoid X

--- a/Mathlib/Topology/Homotopy/HomotopyGroup.lean
+++ b/Mathlib/Topology/Homotopy/HomotopyGroup.lean
@@ -453,6 +453,8 @@ instance group (N) [DecidableEq N] [Nonempty N] : Group (HomotopyGroup N X x) :=
 abbrev auxGroup (i : N) : Group (HomotopyGroup N X x) :=
   (homotopyGroupEquivFundamentalGroup i).group
 
+local notation3:arg (priority := high) "⟦" a "⟧" => Quotient.mk _ a
+
 theorem isUnital_auxGroup (i : N) :
     EckmannHilton.IsUnital (auxGroup i).mul (⟦const⟧ : HomotopyGroup N X x) where
   left_id := (auxGroup i).one_mul

--- a/Mathlib/Topology/Homotopy/Path.lean
+++ b/Mathlib/Topology/Homotopy/Path.lean
@@ -285,6 +285,8 @@ def Quotient.comp (P₀ : Path.Homotopic.Quotient x₀ x₁) (P₁ : Path.Homoto
     Path.Homotopic.Quotient x₀ x₂ :=
   Quotient.map₂ Path.trans (fun (_ : Path x₀ x₁) _ hp (_ : Path x₁ x₂) _ hq => hcomp hp hq) P₀ P₁
 
+local notation3:arg (priority := high) "⟦" a "⟧" => Quotient.mk _ a
+
 theorem comp_lift (P₀ : Path x₀ x₁) (P₁ : Path x₁ x₂) : ⟦P₀.trans P₁⟧ = Quotient.comp ⟦P₀⟧ ⟦P₁⟧ :=
   rfl
 

--- a/Mathlib/Topology/Homotopy/Product.lean
+++ b/Mathlib/Topology/Homotopy/Product.lean
@@ -104,6 +104,8 @@ end Prod
 
 end ContinuousMap
 
+local notation3:arg (priority := high) "⟦" a "⟧" => Quotient.mk _ a
+
 namespace Path.Homotopic
 
 attribute [local instance] Path.Homotopic.setoid

--- a/Mathlib/Topology/MetricSpace/GromovHausdorff.lean
+++ b/Mathlib/Topology/MetricSpace/GromovHausdorff.lean
@@ -49,6 +49,8 @@ open Sum (inl inr)
 
 local notation "ℓ_infty_ℝ" => lp (fun n : ℕ => ℝ) ∞
 
+local notation3:arg (priority := high) "⟦" a "⟧" => Quotient.mk _ a
+
 universe u v w
 
 attribute [local instance] metricSpaceSum

--- a/Mathlib/Topology/UniformSpace/Separation.lean
+++ b/Mathlib/Topology/UniformSpace/Separation.lean
@@ -273,6 +273,8 @@ theorem map_mk {f : α → β} (h : UniformContinuous f) (a : α) : map f (mk a)
 theorem uniformContinuous_map (f : α → β) : UniformContinuous (map f) :=
   uniformContinuous_lift' _
 
+local notation3:arg (priority := high) "⟦" a "⟧" => Quotient.mk _ a
+
 theorem map_unique {f : α → β} (hf : UniformContinuous f)
     {g : SeparationQuotient α → SeparationQuotient β} (comm : mk ∘ f = g ∘ mk) : map f = g := by
   ext ⟨a⟩

--- a/test/interactiveUnfold.lean
+++ b/test/interactiveUnfold.lean
@@ -56,7 +56,8 @@ info: Unfolds for 5 / 3:
 /--
 info: Unfolds for 1 + 1:
 · Ordinal.type (Sum.Lex EmptyRelation EmptyRelation)
-· ⟦{ α := PUnit.{u_1 + 1} ⊕ PUnit.{u_1 + 1}, r := Sum.Lex EmptyRelation EmptyRelation, wo := ⋯ }⟧
+· Quotient.mk Ordinal.isEquivalent
+  { α := PUnit.{u_1 + 1} ⊕ PUnit.{u_1 + 1}, r := Sum.Lex EmptyRelation EmptyRelation, wo := ⋯ }
 · Quot.mk Setoid.r { α := PUnit.{u_1 + 1} ⊕ PUnit.{u_1 + 1}, r := Sum.Lex EmptyRelation EmptyRelation, wo := ⋯ }
 -/
 #guard_msgs in


### PR DESCRIPTION

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->
Merge this PR when we are ready to migrate to `QuotLike` API (#16421).

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
