### PR TITLE
feat(Tactic/Linter): add unicode linter for unicode variant-selectors

### DIFF
--- a/Mathlib/GroupTheory/GroupExtension/Defs.lean
+++ b/Mathlib/GroupTheory/GroupExtension/Defs.lean
@@ -23,14 +23,14 @@ such as splittings and equivalences.
 
 ```text
 For multiplicative groups:
-      ↗︎ E  ↘
+      ↗ E  ↘
 1 → N   ↓    G → 1
-      ↘︎ E' ↗︎️
+      ↘ E' ↗
 
 For additive groups:
-      ↗︎ E  ↘
+      ↗ E  ↘
 0 → N   ↓    G → 0
-      ↘︎ E' ↗︎️
+      ↘ E' ↗
 ```
 
 - `(Add?)GroupExtension.Section S`: structure for right inverses to `rightHom` of a group extension

--- a/Mathlib/Tactic/Hint.lean
+++ b/Mathlib/Tactic/Hint.lean
@@ -88,7 +88,7 @@ def suggestion (tac : TSyntax `tactic) (trees : PersistentArray InfoTree) : Tact
   We use emojis for now instead.
   -/
   -- let style? := if goals.isEmpty then some .success else none
-  let preInfo? := if goals.isEmpty then some "🎉 " else none
+  let preInfo? := if goals.isEmpty then some "🎉️ " else none
   let suggestions := collectTryThisSuggestions trees
   let suggestion := match suggestions[0]? with
   | some s => s.suggestion

--- a/Mathlib/Tactic/Linter/TextBased.lean
+++ b/Mathlib/Tactic/Linter/TextBased.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2024 Michael Rothgang. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Michael Rothgang
+Authors: Michael Rothgang, Jon Eugster, Adomas Baliuka
 -/
 module
 
@@ -32,6 +32,7 @@ Currently, this file contains linters checking
 - for module names to be valid Windows filenames, and containing no forbidden characters such as
   `!`, `.` or spaces.
 - for any code containing blocklisted unicode characters
+- bad unicode characters
 
 For historic reasons, some further such checks are written in a Python script `lint-style.py`:
 these are gradually being rewritten in Lean.
@@ -60,6 +61,11 @@ inductive StyleError where
   | semicolon
   /-- A unicode character was used that isn't allowed -/
   | unwantedUnicode (c : Char)
+  /-- Unicode variant selectors are used in a bad way.
+  * `s` is the string containing the unicode character and any unicode variant selector following it
+  * `selector` is the desired selector or `none`
+  -/
+  | unicodeVariant (s : String) (selector: Option Char)
 deriving BEq, Inhabited
 
 /-- How to format style errors -/
@@ -74,7 +80,12 @@ public inductive ErrorFormat
   | github : ErrorFormat
   deriving BEq
 
-/-- Create the underlying error message for a given `StyleError`. -/
+open UnicodeLinter in
+/--
+Create the underlying error message for a given `StyleError`.
+
+Note: changes to the texts here must be accounted for in `parse?_errorContext`!
+-/
 def StyleError.errorMessage (err : StyleError) : String := match err with
   | StyleError.adaptationNote =>
     "Found the string \"Adaptation note:\", please use the #adaptation_note command instead"
@@ -83,7 +94,30 @@ def StyleError.errorMessage (err : StyleError) : String := match err with
   | trailingWhitespace => "This line ends with some whitespace: please remove this"
   | semicolon => "This line contains a space before a semicolon"
   | StyleError.unwantedUnicode c => s!"This line contains a bad unicode character \
-    '{c}' ({UnicodeLinter.printCodepointHex c})."
+    '{c}' ({c.printCodepointHex})."
+  | StyleError.unicodeVariant s selector =>
+    let variantText := if selector == UnicodeVariant.emoji then
+      "emoji"
+    else if selector == UnicodeVariant.text then
+      "text"
+    else
+      "default"
+    let oldHex := s.printCodepointHex
+    match s.toList, selector with
+    | c₀ :: [], some sel =>
+      let newC : String := String.ofList [c₀, sel]
+      let newHex := s.printCodepointHex
+      s!"Missing unicode variant selector: \"{s}\" ({oldHex}). \
+        Please use the {variantText} variant: \"{newC}\" ({newHex})!"
+    | c₀ :: _ :: [], some sel =>
+      -- by assumption, the second character is a variant selector
+      let newC : String := String.ofList [c₀, sel]
+      let newHex := s.printCodepointHex
+      s!"Wrong unicode variant selector: \"{s}\" ({oldHex}). \
+        Please use the {variantText} variant: \"{newC}\" ({newHex})!"
+    | _, _ =>
+      s!"Unexpected unicode variant selector: \"{s}\" ({oldHex}). \
+        Consider deleting it."
 
 /-- The error code for a given style error. Keep this in sync with `parse?_errorContext` below! -/
 -- FUTURE: we're matching the old codes in `lint-style.py` for compatibility;
@@ -94,6 +128,7 @@ def StyleError.errorCode (err : StyleError) : String := match err with
   | StyleError.trailingWhitespace => "ERR_TWS"
   | StyleError.semicolon => "ERR_SEM"
   | StyleError.unwantedUnicode _ => "ERR_UNICODE"
+  | StyleError.unicodeVariant _ _ => "ERR_UNICODE_VARIANT"
 
 
 /-- Context for a style error: the actual error, the line number in the file we're reading
@@ -158,7 +193,12 @@ def outputMessage (errctx : ErrorContext) (style : ErrorFormat) : String :=
     -- Print for humans: clickable file name and omit the error code
     s!"error: {errctx.path}:{errctx.lineNumber}: {errorMessage}"
 
+/-- Removes quotation marks '"' at front and back of string. -/
+def removeQuotations (s : String) : String :=
+  ((s.dropPrefix "\"").toString.dropSuffix "\"").toString
+
 /-- Try parsing an `ErrorContext` from a string: return `some` if successful, `none` otherwise.
+This should be the inverse of `fun ctx ↦ outputMessage ctx .exceptionsFile`
 Used for, e.g., parsing the "exceptions" file.
 
 Need to ensure (see unit tests in `MathlibTest/LintStyle.lean`) that
@@ -188,6 +228,19 @@ def parse?_errorContext (line : String) : Option ErrorContext := Id.run do
           let str ← errorMessage[7]?
           let c ← String.Pos.Raw.get? str ⟨1⟩ -- take middle character of expected three
           StyleError.unwantedUnicode c
+        | "ERR_UNICODE_VARIANT" => do
+          match (← errorMessage[0]?).toLower with
+          | "wrong" | "missing" =>
+            let offending := removeQuotations (← errorMessage[4]?)
+            let selector := match ← errorMessage[9]? with
+            | "emoji" => UnicodeLinter.UnicodeVariant.emoji
+            | "text" => UnicodeLinter.UnicodeVariant.text
+            | _ => none
+            StyleError.unicodeVariant offending selector
+          | "unexpected" =>
+            let offending := removeQuotations (← errorMessage[4]?)
+            StyleError.unicodeVariant offending none
+          | _ => none
         | _ => none
       match String.toNat? lineNumber with
       | some n => err.map fun e ↦ (ErrorContext.mk e n path)
@@ -282,19 +335,43 @@ end
 namespace UnicodeLinter
 
 /-- Creates `StyleError`s for bad usage of unicode characters. -/
-def findBadUnicodeAux (s : String) (pos : s.Pos)
+def findBadUnicodeAux (s : String) (pos : s.Pos) (c : Char)
     (err : Array StyleError := #[]) : Array StyleError :=
   if h : pos < s.endPos then
-    let c := pos.get (show pos ≠ s.endPos from String.Pos.ne_of_lt h)
     let posₙ := pos.next (show pos ≠ s.endPos from String.Pos.ne_of_lt h)
-    have : posₙ.remainingBytes < pos.remainingBytes :=
-        (pos.lt_iff_remainingBytes_lt posₙ).mp pos.lt_next
-    if ! isAllowedCharacter c then
-      -- bad: character not allowed. Add StyleError and continue recursion.
-      findBadUnicodeAux s posₙ (err.push (.unwantedUnicode c))
-    else
-      -- okay. Continue recursion.
-      findBadUnicodeAux s posₙ err
+    match posₙ.get? with
+    | none =>
+      -- `c` is the last character of the string
+      if ! isAllowedCharacter c then
+        -- bad: character not allowed. Add StyleError.
+        (err.push (.unwantedUnicode c))
+      else
+        err
+    | some cₙ =>
+      have : posₙ.remainingBytes < pos.remainingBytes :=
+          (pos.lt_iff_remainingBytes_lt posₙ).mp pos.lt_next
+      if ! isAllowedCharacter c then
+        -- bad: character not allowed.
+        findBadUnicodeAux s posₙ cₙ (err.push (.unwantedUnicode c))
+      else if cₙ == UnicodeVariant.emoji && !(emojis.contains c) then
+        -- bad: unwanted emoji variant selector.
+        let errₙ := err.push (.unicodeVariant (String.ofList [c, cₙ]) none)
+        findBadUnicodeAux s posₙ cₙ errₙ
+      else if cₙ == UnicodeVariant.text && !(nonEmojis.contains c) then
+        -- bad: unwanted text variant selector.
+        let errₙ := err.push (.unicodeVariant (String.ofList [c, cₙ]) none)
+        findBadUnicodeAux s posₙ cₙ errₙ
+      else if cₙ != UnicodeVariant.emoji && emojis.contains c then
+        -- bad: missing emoji variant selector.
+        let errₙ := err.push (.unicodeVariant c.toString UnicodeVariant.emoji)
+        findBadUnicodeAux s posₙ cₙ errₙ
+      else if cₙ != UnicodeVariant.text && nonEmojis.contains c then
+        -- bad: missing text variant selector.
+        let errₙ := err.push (.unicodeVariant c.toString UnicodeVariant.text)
+        findBadUnicodeAux s posₙ cₙ errₙ
+      else
+        -- okay. Continue recursion.
+        findBadUnicodeAux s posₙ cₙ err
   else
     err
 termination_by pos.remainingBytes
@@ -302,7 +379,10 @@ termination_by pos.remainingBytes
 /-- Creates `StyleError`s for bad usage of unicode characters. -/
 @[inline]
 def findBadUnicode (s : String) : Array StyleError :=
-  findBadUnicodeAux s s.startPos
+  match s.startPos.get? with
+  | none => #[]
+  | some c =>
+    findBadUnicodeAux s s.startPos c
 
 end UnicodeLinter
 
@@ -328,12 +408,23 @@ def unicodeLinter : TextbasedLinter := fun opts lines ↦ Id.run do
             newLine := newLine.replace c replacement
         else
             pure ()
+      | .unicodeVariant s sel =>
+        let replacement := match sel, s.startPos.get? with
+        | none, some c => c.toString
+        | some v, some c => String.ofList [c, v]
+        | _, none => unreachable!
+        newLine := newLine.replace s replacement
       | _ => unreachable!
 
     changed := changed.push newLine
     errors := errors.append (err.map (fun e => (e, lineNumber)))
     lineNumber := lineNumber + 1
   return (errors, if (changed == lines) then none else some changed)
+
+namespace UnicodeLinter
+
+
+end UnicodeLinter
 
 /-- All text-based linters registered in this file. -/
 def allLinters : Array TextbasedLinter := #[
@@ -382,7 +473,7 @@ def lintFile (opts : LinterOptions) (path : FilePath) (exceptions : Array ErrorC
         -- check if any exception applies:
         if new_errors.any fun (e, idx) ↦
           (idx - 1 == lineIdx) -- Subtract 1 since linter's line numbers are one-based
-          ∧ (ErrorContext.find?_comparable ⟨e, lineIdx, path⟩ exceptions).isSome
+          ∧ (ErrorContext.find?_comparable ⟨e, lineIdx, path⟩ exceptions).isNone
         then
           c[lineIdx]! -- no exception applies. Assign linter's suggestion.
         else

--- a/Mathlib/Tactic/Linter/TextBased/UnicodeLinter.lean
+++ b/Mathlib/Tactic/Linter/TextBased/UnicodeLinter.lean
@@ -20,12 +20,24 @@ This file defines the blocklist and other tools used by the linter.
 
 namespace Mathlib.Linter.TextBased.UnicodeLinter
 
+/-- Following any unicode character, this indicates that the emoji variant should be displayed -/
+public def UnicodeVariant.emoji := '\uFE0F'
+
+/-- Following any unicode character, this indicates that the text variant should be displayed -/
+public def UnicodeVariant.text := '\uFE0E'
+
 /-- Prints a unicode character's codepoint in hexadecimal with prefix 'U+'.
 E.g., 'a' is "U+0061". -/
-public def printCodepointHex (c : Char) : String :=
+public def Char.printCodepointHex (c : Char) : String :=
   let digits := Nat.toDigits 16 c.val.toNat
   -- print at least 4 (could be more) hex characters using leading zeros
   ("U+".append <| "0000".drop digits.length |>.toString).append <| String.ofList digits
+
+/-- Prints all characters in a string in hexadecimal with prefix 'U+'.
+E.g., "ab" is "U+0061;U+0062". -/
+public def String.printCodepointHex (s : String) : String :=
+  -- note: must not contain spaces because of the error message parsing below!
+  ";".intercalate <| s.toList.map Char.printCodepointHex
 
 /-- Blocklist: If `false`, the character is not allowed in Mathlib. -/
 public def isAllowedCharacter (c : Char) : Bool :=
@@ -35,5 +47,23 @@ public def isAllowedCharacter (c : Char) : Bool :=
 public def replaceDisallowed : Char → Option String
 | '\u00a0' => " " -- replace non-breaking space with normal whitespace
 | _ => none
+
+/-- Unicode symbols in mathlib that should always be followed by the emoji variant selector. -/
+public def emojis := #[
+'\u2705',        -- ✅️
+'\u274C',        -- ❌️
+ -- TODO "missing end of character literal" if written as '\u1F4A5'
+ -- see https://github.com/leanprover/lean4/blob/4eea57841d1012d6c2edab0f270e433d43f92520/src/Lean/Parser/Basic.lean#L709
+.ofNat 0x1F4A5,  -- 💥️
+.ofNat 0x1F7E1,  -- 🟡️
+.ofNat 0x1F4A1,  -- 💡️
+.ofNat 0x1F419,  -- 🐙️
+.ofNat 0x1F50D,  -- 🔍️
+.ofNat 0x1F389,  -- 🎉️
+'\u23F3',        -- ⏳️
+.ofNat 0x1F3C1 ] -- 🏁️
+
+/-- Unicode symbols in mathlib that should always be followed by the text variant selector. -/
+public def nonEmojis : Array Char := #[]
 
 end Mathlib.Linter.TextBased.UnicodeLinter

--- a/Mathlib/Tactic/Widget/Calc.lean
+++ b/Mathlib/Tactic/Widget/Calc.lean
@@ -124,7 +124,7 @@ def suggestSteps (pos : Array Lean.SubExpr.GoalsLocation) (goalType : Expr) (par
 @[server_rpc_method]
 def CalcPanel.rpc := mkSelectionPanelRPC suggestSteps
   "Please select subterms using Shift-click."
-  "Calc 🔍"
+  "Calc 🔍️"
 
 /-- The calc widget. -/
 @[widget_module]

--- a/Mathlib/Tactic/Widget/CongrM.lean
+++ b/Mathlib/Tactic/Widget/CongrM.lean
@@ -45,7 +45,7 @@ def makeCongrMString (pos : Array Lean.SubExpr.GoalsLocation) (goalType : Expr)
 @[server_rpc_method]
 def CongrMSelectionPanel.rpc := mkSelectionPanelRPC makeCongrMString
   "Use shift-click to select sub-expressions in the goal that should become holes in congrm."
-  "CongrM 🔍"
+  "CongrM 🔍️"
 
 /-- The congrm widget. -/
 @[widget_module]

--- a/Mathlib/Tactic/Widget/Conv.lean
+++ b/Mathlib/Tactic/Widget/Conv.lean
@@ -258,7 +258,7 @@ public protected def SelectionPanel.rpc :=
   mkSelectionPanelRPC insertEnter
     "Use shift-click to select one sub-expression in the goal or local context that you want to \
     zoom in on."
-    "Conv 🔍" (onlyGoal := false) (onlyOne := true)
+    "Conv 🔍️" (onlyGoal := false) (onlyOne := true)
 
 /-- The conv widget. -/
 @[widget_module]

--- a/Mathlib/Tactic/Widget/GCongr.lean
+++ b/Mathlib/Tactic/Widget/GCongr.lean
@@ -45,7 +45,7 @@ return (res, res, none)
 @[server_rpc_method]
 def GCongrSelectionPanel.rpc := mkSelectionPanelRPC makeGCongrString
   "Use shift-click to select sub-expressions in the goal that should become holes in gcongr."
-  "GCongr 🔍"
+  "GCongr 🔍️"
 
 /-- The gcongr widget. -/
 @[widget_module]

--- a/MathlibTest/LintStyle.lean
+++ b/MathlibTest/LintStyle.lean
@@ -1,5 +1,6 @@
 module
 
+import all Batteries.Data.List.Basic
 import Mathlib.Data.Nat.Basic
 import Mathlib.Tactic.Linter.Style
 import Mathlib.Order.SetNotation
@@ -615,11 +616,104 @@ section unicodeLinter
 open Mathlib.Linter.TextBased
 open Mathlib.Linter.TextBased.UnicodeLinter
 
--- test parsing back error messages in `parse?_errorContext` for unicode errors
+/- Ensure each character can only be listed in either selector-list. -/
+#guard emojis.toList ∩ nonEmojis.toList = ∅
 
--- (`meta` because the whole section in `TextBased` is meta.)
+set_option linter.unusedTactic false in
+set_option linter.flexible false in
+/-- An error in this proof could mean that `replaceDisallowed` contains a character
+which is not dissallowed by `isAllowedCharacter`. -/
+private theorem disallowed_of_replaceable (c : Char) (creplaced : replaceDisallowed c ≠ none) :
+    !isAllowedCharacter c := by
+  contrapose creplaced
+  simp [isAllowedCharacter, Array.contains] at creplaced
+  repeat obtain ⟨_, creplaced⟩ := creplaced
+  simp [replaceDisallowed]
+
+
+/-!
+Ensure parsing back error messages in `parse?_errorContext` works.
+-/
+
+-- These test guard against changes in the error message.
+-- Changes to the error message mean the indices in `parse?_errorContext`
+-- need to be adjusted
+
+/-- info: some "'X'" -/
+#guard_msgs in
+#eval (StyleError.errorMessage (.unwantedUnicode 'X') |>.splitToList (· == ' '))[7]?
+
+/-- info: some "Missing" -/
+#guard_msgs in
+open UnicodeLinter.UnicodeVariant in
+#eval ((StyleError.errorMessage (.unicodeVariant "A" (some emoji))).splitToList (· == ' '))[0]?
+
+/-- info: some "Wrong" -/
+#guard_msgs in
+open UnicodeLinter.UnicodeVariant in
+#eval
+  ((StyleError.errorMessage (.unicodeVariant "A\uFE0F" (some emoji))).splitToList (· == ' '))[0]?
+
+/-- info: some "Unexpected" -/
+#guard_msgs in
+open UnicodeLinter.UnicodeVariant in
+#eval ((StyleError.errorMessage (.unicodeVariant "A\uFE0F" none)).splitToList (· == ' '))[0]?
+
+/-- info: some "\"AB\"" -/
+#guard_msgs in
+open UnicodeLinter.UnicodeVariant in
+#eval ((StyleError.errorMessage (.unicodeVariant "AB" (some emoji))).splitToList (· == ' '))[4]?
+
+/-- info: some "\"AB\"" -/
+#guard_msgs in
+open UnicodeLinter.UnicodeVariant in
+#eval
+  ((StyleError.errorMessage (.unicodeVariant "AB" (some emoji))).splitToList (· == ' '))[4]?
+
+/-- info: some "\"AB\"" -/
+#guard_msgs in
+open UnicodeLinter.UnicodeVariant in
+#eval ((StyleError.errorMessage (.unicodeVariant "AB" none)).splitToList (· == ' '))[4]?
+
+/-- info: some "emoji" -/
+#guard_msgs in
+open UnicodeLinter.UnicodeVariant in
+#eval ((StyleError.errorMessage (.unicodeVariant "AB" (some emoji))).splitToList (· == ' '))[9]?
+
+/-- info: some "emoji" -/
+#guard_msgs in
+open UnicodeLinter.UnicodeVariant in
+#eval
+  ((StyleError.errorMessage (.unicodeVariant "AB" (some emoji))).splitToList (· == ' '))[9]?
+
+/-- info: none -/
+#guard_msgs in
+open UnicodeLinter.UnicodeVariant in
+#eval ((StyleError.errorMessage (.unicodeVariant "AB" none)).splitToList (· == ' '))[9]?
+
+-- Testing that error messages can be parsed back correctly
+
+meta instance : ToString StyleError where
+  toString error := match error with
+    | .unwantedUnicode char => s!"{error.errorCode}: {char}"
+    | .unicodeVariant s none =>
+      s!"{error.errorCode}: {(" ".intercalate <| s.toList.map Char.printCodepointHex)} (none)"
+    | .unicodeVariant s (some sel) =>
+      s!"{error.errorCode}: {(" ".intercalate <| s.toList.map Char.printCodepointHex)} \
+        ({Char.printCodepointHex sel})"
+    | other => s!"{other.errorCode}"
+
+meta instance : ToString ErrorContext where
+  toString error := s!"{error.error}:l.{error.lineNumber}, {error.path}"
+
 meta def ErrorContext.isValid_parse?_error_context (ec : ErrorContext) : Bool :=
-   (parse?_errorContext <| outputMessage ec .exceptionsFile) == some ec
+  let msg := outputMessage ec .exceptionsFile
+  -- -- print error message for debugging
+  -- dbg_trace msg
+  match parse?_errorContext <| msg with
+  | none => False
+  | some parsed =>
+    ec == parsed
 
 #guard ErrorContext.isValid_parse?_error_context {
   error := .adaptationNote,
@@ -645,16 +739,33 @@ meta def ErrorContext.isValid_parse?_error_context (ec : ErrorContext) : Bool :=
   error := .unwantedUnicode '\u00a0',
   lineNumber := 22, path:="Mathlib/Tactic/Measurability/Init.lean"}
 
-set_option linter.unusedTactic false in
-set_option linter.flexible false in
-/-- An error in this proof could mean that `replaceDisallowed` contains a character
-which is not dissallowed by `isAllowedCharacter`. -/
-private theorem disallowed_of_replaceable (c : Char) (creplaced : replaceDisallowed c ≠ none) :
-    !isAllowedCharacter c := by
-  contrapose creplaced
-  simp [isAllowedCharacter, Array.contains] at creplaced
-  repeat obtain ⟨_, creplaced⟩ := creplaced
-  simp [replaceDisallowed]
+-- "missing" variant selector
+#guard ErrorContext.isValid_parse?_error_context {
+  error := .unicodeVariant "\u271d" UnicodeVariant.emoji,
+  lineNumber := 22, path:="Mathlib/Tactic/Measurability/Init.lean"}
+
+#guard ErrorContext.isValid_parse?_error_context {
+  error := .unicodeVariant "\u271d" UnicodeVariant.text,
+  lineNumber := 22, path:="Mathlib/Tactic/Measurability/Init.lean"}
+
+
+-- "wrong" variant selector
+#guard ErrorContext.isValid_parse?_error_context {
+  error := .unicodeVariant "\u271d\uFE0E" UnicodeVariant.emoji,
+  lineNumber := 22, path:="Mathlib/Tactic/Measurability/Init.lean"}
+
+#guard ErrorContext.isValid_parse?_error_context {
+  error := .unicodeVariant "\u271d\uFE0F" UnicodeVariant.text,
+  lineNumber := 22, path:="Mathlib/Tactic/Measurability/Init.lean"}
+
+-- "unexpected" variant selector
+#guard ErrorContext.isValid_parse?_error_context {
+  error := .unicodeVariant "\u271d\uFE0E" none,
+  lineNumber := 22, path:="Mathlib/Tactic/Measurability/Init.lean"}
+
+#guard ErrorContext.isValid_parse?_error_context {
+  error := .unicodeVariant "\u271d\uFE0F" none,
+  lineNumber := 22, path:="Mathlib/Tactic/Measurability/Init.lean"}
 
 end unicodeLinter
 

--- a/MathlibTest/hint.lean
+++ b/MathlibTest/hint.lean
@@ -9,7 +9,7 @@ example (h : 1 < 0) : False := by hint
 register_hint 1000 trivial
 /--
 info: Try these:
-  [apply] 🎉 trivial
+  [apply] 🎉️ trivial
 -/
 #guard_msgs in
 example (h : 1 < 0) : False := by hint
@@ -17,7 +17,7 @@ example (h : 1 < 0) : False := by hint
 register_hint 1001 contradiction
 /--
 info: Try these:
-  [apply] 🎉 contradiction
+  [apply] 🎉️ contradiction
 -/
 #guard_msgs in
 example (h : 1 < 0) : False := by hint
@@ -25,7 +25,7 @@ example (h : 1 < 0) : False := by hint
 register_hint 999 exact?
 /--
 info: Try these:
-  [apply] 🎉 contradiction
+  [apply] 🎉️ contradiction
 -/
 #guard_msgs in
 example (h : 1 < 0) : False := by hint
@@ -33,7 +33,7 @@ example (h : 1 < 0) : False := by hint
 register_hint 1002 exact?
 /--
 info: Try these:
-  [apply] 🎉 exact Nat.not_succ_le_zero 1 h
+  [apply] 🎉️ exact Nat.not_succ_le_zero 1 h
 -/
 #guard_msgs in
 example (h : 1 < 0) : False := by hint

--- a/MathlibTest/hintAll.lean
+++ b/MathlibTest/hintAll.lean
@@ -20,7 +20,7 @@ import Mathlib.Tactic.TautoSet
 
 /--
 info: Try these:
-  [apply] 🎉 trivial
+  [apply] 🎉️ trivial
   [apply] norm_num
   Remaining subgoals:
   ⊢ False
@@ -30,7 +30,7 @@ example (h : 1 < 0) : False := by hint
 
 /--
 info: Try these:
-  [apply] 🎉 simp_all only [forall_const]
+  [apply] 🎉️ simp_all only [forall_const]
   [apply] norm_num
   Remaining subgoals:
   ⊢ Q
@@ -43,7 +43,7 @@ example {P Q : Prop} (p : P) (f : P → Q) : Q := by hint
 
 /--
 info: Try these:
-  [apply] 🎉 simp_all only [and_self]
+  [apply] 🎉️ simp_all only [and_self]
   [apply] norm_num
   Remaining subgoals:
   ⊢ Q ∧ P ∧ R
@@ -56,7 +56,7 @@ example {P Q R : Prop} (x : P ∧ Q ∧ R ∧ R) : Q ∧ P ∧ R := by hint
 
 /--
 info: Try these:
-  [apply] 🎉 exact Std.not_gt_of_lt h
+  [apply] 🎉️ exact Std.not_gt_of_lt h
   [apply] intro
   Remaining subgoals:
   ⊢ False
@@ -75,7 +75,7 @@ example {a b : ℚ} (h : a < b) : ¬ b < a := by hint
 
 /--
 info: Try these:
-  [apply] 🎉 ring
+  [apply] 🎉️ ring
   [apply] noncomm_ring
   Remaining subgoals:
   ⊢ 1369 • 1 - 1225 • 1 = 72 • 2
@@ -85,7 +85,7 @@ example : 37^2 - 35^2 = 72 * 2 := by hint
 
 /--
 info: Try these:
-  [apply] 🎉 decide
+  [apply] 🎉️ decide
   [apply] ring_nf
   Remaining subgoals:
   ⊢ Nat.Prime 37
@@ -95,7 +95,7 @@ example : Nat.Prime 37 := by hint
 
 /--
 info: Try these:
-  [apply] 🎉 grind
+  [apply] 🎉️ grind
   [apply] ring_nf
   Remaining subgoals:
   ⊢ ∃ x, P x ∧ 0 ≤ x
@@ -115,7 +115,7 @@ example {P : Nat → Prop} (h : { x // P x }) : ∃ x, P x ∧ 0 ≤ x := by hin
 def f (p : Nat × Nat) := (p.fst, p.snd)
 /--
 info: Try these:
-  [apply] 🎉 trivial
+  [apply] 🎉️ trivial
   [apply] norm_num
   Remaining subgoals:
   ⊢ f = id
@@ -137,7 +137,7 @@ register_hint 1000 long_trivial
 
 /--
 info: Try these:
-  [apply] 🎉 long_trivial
+  [apply] 🎉️ long_trivial
 -/
 #guard_msgs in
 example : True := by
@@ -148,7 +148,7 @@ end multiline_hint
 section finiteness
 /--
 info: Try these:
-  [apply] 🎉 finiteness
+  [apply] 🎉️ finiteness
 -/
 #guard_msgs in
 open ENNReal in
@@ -161,7 +161,7 @@ register_hint 1000 tauto_set
 
 /--
 info: Try these:
-  [apply] 🎉 tauto_set
+  [apply] 🎉️ tauto_set
 -/
 #guard_msgs in
 example {α} (A B C : Set α) (h1 : A ⊆ B ∪ C) : (A ∩ B) ∪ (A ∩ C) = A := by hint
@@ -192,7 +192,7 @@ example : 2 ≤ 1 := by hint
 section compute_degree
 /--
 info: Try these:
-  [apply] 🎉 compute_degree
+  [apply] 🎉️ compute_degree
 -/
 #guard_msgs in
 open Polynomial in
@@ -208,7 +208,7 @@ this test no longer reports `field_simp` amongst the successful tactics.
 
 /--
 info: Try these:
-  [apply] 🎉 exact Units.divp_add_divp_same a b u₁
+  [apply] 🎉️ exact Units.divp_add_divp_same a b u₁
   [apply] ring_nf
   Remaining subgoals:
   ⊢ a /ₚ u₁ + b /ₚ u₁ = (a + b) /ₚ u₁
@@ -230,7 +230,7 @@ end field_simp
 -- but apparently `tauto_set` also works.
 /--
 info: Try these:
-  [apply] 🎉 tauto_set
+  [apply] 🎉️ tauto_set
 -/
 #guard_msgs in
 open ENNReal in


### PR DESCRIPTION
- add an addition to the unicode linter ensuring variant-selector only appear on specified characters and also ensuring these characters always have the correct variant selector to avoid confusions.
- fix a bug from #34022 which broke autofixing
- some smaller refactors
  - add `String.printCodepointHex` analog to the existing `printCodepointHex` which has been renamed to `Char.printCodepointHex`
  - pass the next char to `findBadUnicodeAux` to make it easier to consider a pair of consecutive characters
  - add some `ToString` instances to the test file to help debugging. (I really needed them badly...)
- automatic fixes flagged by this linter

Unicode characters can be followed by one of the two "variant-selectors" `\FE0E` (text) or `\FE0F` (emoji).
These appear to the user as a single unicode character and they might copy them by accident. For example `✝️` (`\u271d\uFE0F`), `✝` (`\u271d`) and `✝︎` (`\u271d\uFE0E`) are three variants of the "same" unicode character. The one without variant-selector might display as either emoji or not, depending on the user's device and font.
(e.g. for me it is an emoji while editing this message, but a text when previewing)

Everything flagged by this linter can be fixed fully automatically with `lake exe lint-style --fix` or by commenting `bot fix style` on the PR.

---

- tracking PR: #16215

## Testing:

First, drop the last commit from this PR (which includes only the autofixed style issues)

Then call `lake exe lint-style`. You should see 13 new style errors.

Next, add the following line to `nolints-style.txt`:

```
Mathlib/GroupTheory/GroupExtension/Defs.lean : line 26 : ERR_UNICODE_VARIANT : Unexpected unicode variant selector: "↗︎" (U+2197;U+fe0e). Consider deleting it.
```

now `lake exe lint-style` should only display 9 style errors. These can be applied with `lake exe lint-style --fix`.

Next, remove the changes from `nolints-style.txt`. You should then see another 2 errors which can be fixed again.


## Zulip discussions:
- https://leanprover.zulipchat.com/#narrow/stream/287929-mathlib4/topic/Whitelist.20for.20Unicode.3F
- https://leanprover.zulipchat.com/#narrow/stream/113488-general/topic/Lean.20specific.20font

## Related PRs:
- leanprover/lean4#5015 added some emoji-variant selectors to Emojis used in `Lean` itself.



<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
