### PR TITLE
[Merged by Bors] - feat(Algebra/BigOperators/Group): add `sum_tsub_distrib`

### DIFF
--- a/Mathlib/Algebra/BigOperators/Group/Finset.lean
+++ b/Mathlib/Algebra/BigOperators/Group/Finset.lean
@@ -1481,7 +1481,7 @@ theorem sum_range_tsub [AddCommMonoid α] [PartialOrder α] [Sub α] [OrderedSub
 theorem sum_tsub_distrib [AddCommMonoid α] [PartialOrder α] [ExistsAddOfLE α]
     [CovariantClass α α (· + ·) (· ≤ ·)] [ContravariantClass α α (· + ·) (· ≤ ·)] [Sub α]
     [OrderedSub α] (s : Finset ι) {f g : ι → α} (hfg : ∀ x ∈ s, g x ≤ f x) :
-      ∑ x ∈ s, (f x - g x) = ∑ x ∈ s, f x - ∑ x ∈ s, g x := sum_map_tsub _ hfg
+    ∑ x ∈ s, (f x - g x) = ∑ x ∈ s, f x - ∑ x ∈ s, g x := sum_map_tsub _ hfg
 
 @[to_additive (attr := simp)]
 theorem prod_const (b : β) : ∏ _x ∈ s, b = b ^ s.card :=

--- a/Mathlib/Algebra/BigOperators/Group/Finset.lean
+++ b/Mathlib/Algebra/BigOperators/Group/Finset.lean
@@ -1478,6 +1478,11 @@ theorem sum_range_tsub [AddCommMonoid α] [PartialOrder α] [Sub α] [OrderedSub
     have h₂ : f 0 ≤ f n := h (Nat.zero_le _)
     rw [tsub_add_eq_add_tsub h₂, add_tsub_cancel_of_le h₁]
 
+theorem sum_tsub_distrib [AddCommMonoid α] [PartialOrder α] [ExistsAddOfLE α]
+    [CovariantClass α α (· + ·) (· ≤ ·)] [ContravariantClass α α (· + ·) (· ≤ ·)] [Sub α]
+    [OrderedSub α] (s : Finset ι) {f g : ι → α} (hfg : ∀ x ∈ s, g x ≤ f x) :
+      ∑ x ∈ s, (f x - g x) = ∑ x ∈ s, f x - ∑ x ∈ s, g x := sum_map_tsub _ hfg
+
 @[to_additive (attr := simp)]
 theorem prod_const (b : β) : ∏ _x ∈ s, b = b ^ s.card :=
   (congr_arg _ <| s.val.map_const b).trans <| Multiset.prod_replicate s.card b

--- a/Mathlib/Algebra/BigOperators/Group/Multiset.lean
+++ b/Mathlib/Algebra/BigOperators/Group/Multiset.lean
@@ -294,4 +294,17 @@ theorem sum_int_mod (s : Multiset ℤ) (n : ℤ) : s.sum % n = (s.map (· % n)).
 theorem prod_int_mod (s : Multiset ℤ) (n : ℤ) : s.prod % n = (s.map (· % n)).prod % n := by
   induction s using Multiset.induction <;> simp [Int.mul_emod, *]
 
+section OrderedSub
+
+theorem sum_map_tsub [AddCommMonoid α] [PartialOrder α] [ExistsAddOfLE α]
+    [CovariantClass α α (· + ·) (· ≤ ·)] [ContravariantClass α α (· + ·) (· ≤ ·)] [Sub α]
+    [OrderedSub α] (l : Multiset ι) {f g : ι → α} (hfg : ∀ x ∈ l, g x ≤ f x) :
+    (l.map fun x ↦ f x - g x).sum = (l.map f).sum - (l.map g).sum :=
+  eq_tsub_of_add_eq <| by
+    rw [← sum_map_add]
+    congr 1
+    exact map_congr rfl fun x hx => tsub_add_cancel_of_le <| hfg _ hx
+
+end OrderedSub
+
 end Multiset

--- a/Mathlib/Algebra/BigOperators/Ring.lean
+++ b/Mathlib/Algebra/BigOperators/Ring.lean
@@ -22,6 +22,14 @@ variable {ι ι' α β γ : Type*} {κ : ι → Type*} {s s₁ s₂ : Finset ι}
 
 namespace Finset
 
+theorem sum_tsub_distrib {α β : Type*} [AddCommMonoid β] [PartialOrder β] [ExistsAddOfLE β]
+    [CovariantClass β β (· + ·) (· ≤ ·)] [ContravariantClass β β (· + ·) (· ≤ ·)] [Sub β]
+    [OrderedSub β] (s : Finset α) {f g : α → β} (hfg : ∀ x ∈ s, g x ≤ f x) :
+    ∑ x in s, (f x - g x) = ∑ x in s, f x - ∑ x in s, g x :=
+  eq_tsub_of_add_eq <| by
+    rw [← Finset.sum_add_distrib];
+    exact Finset.sum_congr rfl fun x hx => tsub_add_cancel_of_le <| hfg _ hx
+
 section AddCommMonoidWithOne
 variable [AddCommMonoidWithOne α]
 

--- a/Mathlib/Algebra/BigOperators/Ring.lean
+++ b/Mathlib/Algebra/BigOperators/Ring.lean
@@ -22,14 +22,6 @@ variable {ι ι' α β γ : Type*} {κ : ι → Type*} {s s₁ s₂ : Finset ι}
 
 namespace Finset
 
-theorem sum_tsub_distrib [AddCommMonoid α] [PartialOrder α] [ExistsAddOfLE α]
-    [CovariantClass α α (· + ·) (· ≤ ·)] [ContravariantClass α α (· + ·) (· ≤ ·)] [Sub α]
-    [OrderedSub α] (s : Finset ι) {f g : ι → α} (hfg : ∀ x ∈ s, g x ≤ f x) :
-    ∑ x in s, (f x - g x) = ∑ x in s, f x - ∑ x in s, g x :=
-  eq_tsub_of_add_eq <| by
-    rw [← sum_add_distrib]
-    exact sum_congr rfl fun x hx => tsub_add_cancel_of_le <| hfg _ hx
-
 section AddCommMonoidWithOne
 variable [AddCommMonoidWithOne α]
 

--- a/Mathlib/Algebra/BigOperators/Ring.lean
+++ b/Mathlib/Algebra/BigOperators/Ring.lean
@@ -22,9 +22,9 @@ variable {ι ι' α β γ : Type*} {κ : ι → Type*} {s s₁ s₂ : Finset ι}
 
 namespace Finset
 
-theorem sum_tsub_distrib {α β : Type*} [AddCommMonoid β] [PartialOrder β] [ExistsAddOfLE β]
-    [CovariantClass β β (· + ·) (· ≤ ·)] [ContravariantClass β β (· + ·) (· ≤ ·)] [Sub β]
-    [OrderedSub β] (s : Finset α) {f g : α → β} (hfg : ∀ x ∈ s, g x ≤ f x) :
+theorem sum_tsub_distrib [AddCommMonoid α] [PartialOrder α] [ExistsAddOfLE α]
+    [CovariantClass α α (· + ·) (· ≤ ·)] [ContravariantClass α α (· + ·) (· ≤ ·)] [Sub α]
+    [OrderedSub α] (s : Finset ι) {f g : ι → α} (hfg : ∀ x ∈ s, g x ≤ f x) :
     ∑ x in s, (f x - g x) = ∑ x in s, f x - ∑ x in s, g x :=
   eq_tsub_of_add_eq <| by
     rw [← Finset.sum_add_distrib];

--- a/Mathlib/Algebra/BigOperators/Ring.lean
+++ b/Mathlib/Algebra/BigOperators/Ring.lean
@@ -27,7 +27,7 @@ theorem sum_tsub_distrib [AddCommMonoid α] [PartialOrder α] [ExistsAddOfLE α]
     [OrderedSub α] (s : Finset ι) {f g : ι → α} (hfg : ∀ x ∈ s, g x ≤ f x) :
     ∑ x in s, (f x - g x) = ∑ x in s, f x - ∑ x in s, g x :=
   eq_tsub_of_add_eq <| by
-    rw [← Finset.sum_add_distrib];
+    rw [← Finset.sum_add_distrib]
     exact Finset.sum_congr rfl fun x hx => tsub_add_cancel_of_le <| hfg _ hx
 
 section AddCommMonoidWithOne

--- a/Mathlib/Algebra/BigOperators/Ring.lean
+++ b/Mathlib/Algebra/BigOperators/Ring.lean
@@ -27,8 +27,8 @@ theorem sum_tsub_distrib [AddCommMonoid α] [PartialOrder α] [ExistsAddOfLE α]
     [OrderedSub α] (s : Finset ι) {f g : ι → α} (hfg : ∀ x ∈ s, g x ≤ f x) :
     ∑ x in s, (f x - g x) = ∑ x in s, f x - ∑ x in s, g x :=
   eq_tsub_of_add_eq <| by
-    rw [← Finset.sum_add_distrib]
-    exact Finset.sum_congr rfl fun x hx => tsub_add_cancel_of_le <| hfg _ hx
+    rw [← sum_add_distrib]
+    exact sum_congr rfl fun x hx => tsub_add_cancel_of_le <| hfg _ hx
 
 section AddCommMonoidWithOne
 variable [AddCommMonoidWithOne α]


### PR DESCRIPTION
Upstreamed from https://github.com/b-mehta/ExponentialRamsey/blob/7e17b629a915a082869f494c8afa56a3e1c7a88d/ExponentialRamsey/Prereq/Mathlib/Algebra/BigOperators/Ring.lean#L17


Co-authored-by: b-mehta <bhavikmehta8@gmail.com>


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
