### PR TITLE
feat(Tactic/Linter): add unicode linter for unwanted characters

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -5407,6 +5407,7 @@ import Mathlib.Tactic.Linter.PPRoundtrip
 import Mathlib.Tactic.Linter.RefineLinter
 import Mathlib.Tactic.Linter.Style
 import Mathlib.Tactic.Linter.TextBased
+import Mathlib.Tactic.Linter.UnicodeLinter
 import Mathlib.Tactic.Linter.UnusedTactic
 import Mathlib.Tactic.Linter.UnusedTacticExtension
 import Mathlib.Tactic.Linter.UpstreamableDecl

--- a/Mathlib/Algebra/Lie/Semisimple/Lemmas.lean
+++ b/Mathlib/Algebra/Lie/Semisimple/Lemmas.lean
@@ -17,7 +17,7 @@ This file is a home for lemmas about semisimple and reductive Lie algebras.
  * `LieAlgebra.hasTrivialRadical_and_of_isIrreducible_of_isFaithful`: a finite-dimensional Lie
    algebra with a irreducible faithful finite-dimensional trace-free representation is semisimple.
 
-## TODO
+## TODO
 
  * It appears that the lemmas in this file may hold for any principal ideal domain (of
    characteristic zero) instead of a field. The plan would be to define the nilradical of a Lie

--- a/Mathlib/Analysis/Analytic/IsolatedZeros.lean
+++ b/Mathlib/Analysis/Analytic/IsolatedZeros.lean
@@ -268,7 +268,7 @@ alias _root_.AnalyticOn.eq_of_frequently_eq := eq_of_frequently_eq
 
 section Mul
 /-!
-### Vanishing of products of analytic functions
+### Vanishing of products of analytic functions
 -/
 
 variable {A : Type*} [NormedRing A] [NormedAlgebra 𝕜 A]
@@ -310,7 +310,7 @@ end Mul
 end AnalyticOnNhd
 
 /-!
-### Preimages of codiscrete sets
+### Preimages of codiscrete sets
 -/
 
 section PreimgCodiscrete

--- a/Mathlib/CategoryTheory/Category/ReflQuiv.lean
+++ b/Mathlib/CategoryTheory/Category/ReflQuiv.lean
@@ -10,7 +10,7 @@ import Mathlib.CategoryTheory.Category.Quiv
 /-!
 # The category of refl quivers
 
-The category `ReflQuiv` of (bundled) reflexive quivers, and the free/forgetful adjunction between
+The category `ReflQuiv` of (bundled) reflexive quivers, and the free/forgetful adjunction between
 `Cat` and `ReflQuiv`.
 -/
 

--- a/Mathlib/LinearAlgebra/Vandermonde.lean
+++ b/Mathlib/LinearAlgebra/Vandermonde.lean
@@ -48,7 +48,7 @@ coding theory, and representations of uniform matroids over finite fields.
 ## Implementation notes
 
 We derive the `det_vandermonde` formula from `det_projVandermonde`,
-which is proved using an induction argument involving row operations and division.
+which is proved using an induction argument involving row operations and division.
 To circumvent issues with non-invertible elements while still maintaining the generality of rings,
 we first prove it for fields using the private lemma `det_projVandermonde_of_field`,
 and then use an algebraic workaround to generalize to the ring case,

--- a/Mathlib/Tactic.lean
+++ b/Mathlib/Tactic.lean
@@ -158,6 +158,7 @@ import Mathlib.Tactic.Linter.PPRoundtrip
 import Mathlib.Tactic.Linter.RefineLinter
 import Mathlib.Tactic.Linter.Style
 import Mathlib.Tactic.Linter.TextBased
+import Mathlib.Tactic.Linter.UnicodeLinter
 import Mathlib.Tactic.Linter.UnusedTactic
 import Mathlib.Tactic.Linter.UnusedTacticExtension
 import Mathlib.Tactic.Linter.UpstreamableDecl

--- a/Mathlib/Tactic/Linter/TextBased.lean
+++ b/Mathlib/Tactic/Linter/TextBased.lean
@@ -6,6 +6,7 @@ Authors: Michael Rothgang
 
 import Batteries.Data.String.Matcher
 import Mathlib.Data.Nat.Notation
+import Mathlib.Tactic.Linter.UnicodeLinter
 
 /-!
 ## Text-based linters
@@ -50,6 +51,8 @@ inductive StyleError where
   | windowsLineEnding
   /-- A line contains trailing whitespace. -/
   | trailingWhitespace
+  /-- A unicode character was used that isn't recommended -/
+  | unwantedUnicode (c : Char)
   /-- A line contains a space before a semicolon -/
   | semicolon
 deriving BEq
@@ -73,6 +76,9 @@ def StyleError.errorMessage (err : StyleError) : String := match err with
   | windowsLineEnding => "This line ends with a windows line ending (\r\n): please use Unix line\
     endings (\n) instead"
   | trailingWhitespace => "This line ends with some whitespace: please remove this"
+  | StyleError.unwantedUnicode c =>
+      s!"unicode character '{c}' ({UnicodeLinter.printCodepointHex c}) is not recommended. \
+        Consider adding it to the whitelist."
   | semicolon => "This line contains a space before a semicolon"
 
 /-- The error code for a given style error. Keep this in sync with `parse?_errorContext` below! -/
@@ -82,6 +88,7 @@ def StyleError.errorCode (err : StyleError) : String := match err with
   | StyleError.adaptationNote => "ERR_ADN"
   | StyleError.windowsLineEnding => "ERR_WIN"
   | StyleError.trailingWhitespace => "ERR_TWS"
+  | StyleError.unwantedUnicode _ => "ERR_UNICODE"
   | StyleError.semicolon => "ERR_SEM"
 
 /-- Context for a style error: the actual error, the line number in the file we're reading
@@ -149,7 +156,7 @@ def outputMessage (errctx : ErrorContext) (style : ErrorFormat) : String :=
 def parse?_errorContext (line : String) : Option ErrorContext := Id.run do
   let parts := line.split (· == ' ')
   match parts with
-    | filename :: ":" :: "line" :: lineNumber :: ":" :: errorCode :: ":" :: _errorMessage =>
+    | filename :: ":" :: "line" :: lineNumber :: ":" :: errorCode :: ":" :: errorMessage =>
       -- Turn the filename into a path. In general, this is ambiguous if we don't know if we're
       -- dealing with e.g. Windows or POSIX paths. In our setting, this is fine, since no path
       -- component contains any path separator.
@@ -163,6 +170,10 @@ def parse?_errorContext (line : String) : Option ErrorContext := Id.run do
         | "ERR_SEM" => some (StyleError.semicolon)
         | "ERR_TWS" => some (StyleError.trailingWhitespace)
         | "ERR_WIN" => some (StyleError.windowsLineEnding)
+        | "ERR_UNICODE" => do
+          let str ← errorMessage[2]?
+          let c ← str.get? ⟨1⟩
+          StyleError.unwantedUnicode c
         | _ => none
       match String.toNat? lineNumber with
       | some n => err.map fun e ↦ (ErrorContext.mk e n path)
@@ -240,6 +251,66 @@ def isImportsOnlyFile (lines : Array String) : Bool :=
   lines.all (fun line ↦ line.startsWith "import " || line == "" || line.startsWith "-- ")
 
 end
+
+namespace UnicodeLinter
+
+/-- Creates `StyleError`s for
+bad usage of (emoji/text)-variant-selectors.
+Note: if `pos` is not a valid position, the result is unspecified. -/
+def findBadUnicodeAux (s : String) (pos : String.Pos) (c : Char)
+    (err : Array StyleError := #[]) : Array StyleError :=
+  if h : pos < s.endPos then
+    have := Nat.sub_lt_sub_left h (String.lt_next s pos)
+    let posₙ := s.next pos -- `pos` is valid by assumption. `pos` is not `endPos` by check above.
+    -- `posₙ` is valid, might be `endPos`.
+    let cₙ := s.get? posₙ |>.getD '\uFFFD' -- �
+    if ! isAllowedCharacter c then
+      -- bad: character not allowed
+      let errₙ := err.push (.unwantedUnicode c)
+      findBadUnicodeAux s posₙ cₙ errₙ
+    else
+      -- okay
+      findBadUnicodeAux s posₙ cₙ err
+  else
+    err
+termination_by s.endPos.1 - pos.1
+
+@[inline, inherit_doc findBadUnicodeAux]
+def findBadUnicode (s : String) : Array StyleError :=
+  if s == "" then #[] else
+  let c := s.get 0
+  -- edge case: variant-selector as first char of the line
+  findBadUnicodeAux s 0 c
+
+end UnicodeLinter
+
+/-- Lint a collection of input strings if one of them contains unwanted unicode. -/
+def unicodeLinter : TextbasedLinter := fun lines ↦ Id.run do
+  let mut changed : Array String := #[]
+  let mut errors : Array (StyleError × ℕ) := Array.mkEmpty 0
+  let mut lineNumber := 1
+  for line in lines do
+    let err := UnicodeLinter.findBadUnicode line
+
+    -- try to auto-fix the style error
+    let mut newLine := line
+    for e in err.reverse do -- reversing is a cheap fix to prevent shifting indices
+      match e with
+      | .unwantedUnicode c =>
+        match c with
+        | '\u00a0' =>
+          -- replace non-breaking space with normal whitespace
+          newLine := newLine.replace "\u00a0" " "
+        | _ =>
+          -- no automatic fixes available
+          pure ()
+      | _ =>
+        unreachable!
+
+    changed := changed.push newLine
+    errors := errors.append (err.map (fun e => (e, lineNumber)))
+    lineNumber := lineNumber + 1
+  return (errors, changed)
 
 /-- All text-based linters registered in this file. -/
 def allLinters : Array TextbasedLinter := #[

--- a/Mathlib/Tactic/Linter/TextBased.lean
+++ b/Mathlib/Tactic/Linter/TextBased.lean
@@ -51,10 +51,10 @@ inductive StyleError where
   | windowsLineEnding
   /-- A line contains trailing whitespace. -/
   | trailingWhitespace
-  /-- A unicode character was used that isn't recommended -/
-  | unwantedUnicode (c : Char)
   /-- A line contains a space before a semicolon -/
   | semicolon
+  /-- A unicode character was used that isn't allowed -/
+  | unwantedUnicode (c : Char)
 deriving BEq
 
 /-- How to format style errors -/
@@ -76,10 +76,9 @@ def StyleError.errorMessage (err : StyleError) : String := match err with
   | windowsLineEnding => "This line ends with a windows line ending (\r\n): please use Unix line\
     endings (\n) instead"
   | trailingWhitespace => "This line ends with some whitespace: please remove this"
-  | StyleError.unwantedUnicode c =>
-      s!"unicode character '{c}' ({UnicodeLinter.printCodepointHex c}) is not recommended. \
-        Consider adding it to the whitelist."
   | semicolon => "This line contains a space before a semicolon"
+  | StyleError.unwantedUnicode c => s!"This line contains a bad unicode character \
+    '{c}' ({UnicodeLinter.printCodepointHex c})."
 
 /-- The error code for a given style error. Keep this in sync with `parse?_errorContext` below! -/
 -- FUTURE: we're matching the old codes in `lint-style.py` for compatibility;
@@ -88,8 +87,8 @@ def StyleError.errorCode (err : StyleError) : String := match err with
   | StyleError.adaptationNote => "ERR_ADN"
   | StyleError.windowsLineEnding => "ERR_WIN"
   | StyleError.trailingWhitespace => "ERR_TWS"
-  | StyleError.unwantedUnicode _ => "ERR_UNICODE"
   | StyleError.semicolon => "ERR_SEM"
+  | StyleError.unwantedUnicode _ => "ERR_UNICODE"
 
 /-- Context for a style error: the actual error, the line number in the file we're reading
 and the path to the file. -/
@@ -257,30 +256,25 @@ namespace UnicodeLinter
 /-- Creates `StyleError`s for
 bad usage of (emoji/text)-variant-selectors.
 Note: if `pos` is not a valid position, the result is unspecified. -/
-def findBadUnicodeAux (s : String) (pos : String.Pos) (c : Char)
+def findBadUnicodeAux (s : String) (pos : String.Pos := 0)
     (err : Array StyleError := #[]) : Array StyleError :=
   if h : pos < s.endPos then
-    have := Nat.sub_lt_sub_left h (String.lt_next s pos)
+    have := Nat.sub_lt_sub_left h (String.lt_next s pos) ;
+    let c := s.get? pos |>.getD '\uFFFD' -- �  -- ' '
     let posₙ := s.next pos -- `pos` is valid by assumption. `pos` is not `endPos` by check above.
-    -- `posₙ` is valid, might be `endPos`.
-    let cₙ := s.get? posₙ |>.getD '\uFFFD' -- �
     if ! isAllowedCharacter c then
       -- bad: character not allowed
-      let errₙ := err.push (.unwantedUnicode c)
-      findBadUnicodeAux s posₙ cₙ errₙ
+      findBadUnicodeAux s posₙ (err.push (.unwantedUnicode c))
     else
       -- okay
-      findBadUnicodeAux s posₙ cₙ err
+      findBadUnicodeAux s posₙ err
   else
     err
 termination_by s.endPos.1 - pos.1
 
 @[inline, inherit_doc findBadUnicodeAux]
 def findBadUnicode (s : String) : Array StyleError :=
-  if s == "" then #[] else
-  let c := s.get 0
-  -- edge case: variant-selector as first char of the line
-  findBadUnicodeAux s 0 c
+  findBadUnicodeAux s 0
 
 end UnicodeLinter
 
@@ -304,8 +298,7 @@ def unicodeLinter : TextbasedLinter := fun lines ↦ Id.run do
         | _ =>
           -- no automatic fixes available
           pure ()
-      | _ =>
-        unreachable!
+      | _ => unreachable!
 
     changed := changed.push newLine
     errors := errors.append (err.map (fun e => (e, lineNumber)))
@@ -314,9 +307,11 @@ def unicodeLinter : TextbasedLinter := fun lines ↦ Id.run do
 
 /-- All text-based linters registered in this file. -/
 def allLinters : Array TextbasedLinter := #[
-    adaptationNoteLinter, semicolonLinter, trailingWhitespaceLinter
+    adaptationNoteLinter,
+    semicolonLinter,
+    trailingWhitespaceLinter,
+    unicodeLinter,
   ]
-
 
 /-- Read a file and apply all text-based linters.
 Return a list of all unexpected errors, and, if some errors could be fixed automatically,

--- a/Mathlib/Tactic/Linter/TextBased.lean
+++ b/Mathlib/Tactic/Linter/TextBased.lean
@@ -253,8 +253,7 @@ end
 
 namespace UnicodeLinter
 
-/-- Creates `StyleError`s for
-bad usage of (emoji/text)-variant-selectors.
+/-- Creates `StyleError`s for bad usage of unicode characters.
 Note: if `pos` is not a valid position, the result is unspecified. -/
 def findBadUnicodeAux (s : String) (pos : String.Pos := 0)
     (err : Array StyleError := #[]) : Array StyleError :=
@@ -272,9 +271,10 @@ def findBadUnicodeAux (s : String) (pos : String.Pos := 0)
     err
 termination_by s.endPos.1 - pos.1
 
-@[inline, inherit_doc findBadUnicodeAux]
+/-- Creates `StyleError`s for bad usage of unicode characters. -/
+@[inline]
 def findBadUnicode (s : String) : Array StyleError :=
-  findBadUnicodeAux s 0
+  findBadUnicodeAux s
 
 end UnicodeLinter
 

--- a/Mathlib/Tactic/Linter/TextBased.lean
+++ b/Mathlib/Tactic/Linter/TextBased.lean
@@ -258,8 +258,8 @@ Note: if `pos` is not a valid position, the result is unspecified. -/
 def findBadUnicodeAux (s : String) (pos : String.Pos := 0)
     (err : Array StyleError := #[]) : Array StyleError :=
   if h : pos < s.endPos then
-    have := Nat.sub_lt_sub_left h (String.lt_next s pos) ;
-    let c := s.get? pos |>.getD '\uFFFD' -- �  -- ' '
+    have := Nat.sub_lt_sub_left h (String.lt_next s pos)
+    let c := s.get? pos |>.getD '\uFFFD' -- �
     let posₙ := s.next pos -- `pos` is valid by assumption. `pos` is not `endPos` by check above.
     if ! isAllowedCharacter c then
       -- bad: character not allowed

--- a/Mathlib/Tactic/Linter/UnicodeLinter.lean
+++ b/Mathlib/Tactic/Linter/UnicodeLinter.lean
@@ -14,12 +14,6 @@ The actual linter is defined in `TextBased.lean`.
 
 This file provides all white-lists and other tools used by the linter.
 
-## Main declarations
-
-* `emojis`, `nonEmojis`: characters in these lists should always be followed by
-  the correct variant-selector `UnicodeVariant.emoji` or `UnicodeVariant.text`.
-  These variant-selector should not appear anywhere else.
-
 -/
 
 namespace Mathlib.Linter.TextBased.UnicodeLinter

--- a/Mathlib/Tactic/Linter/UnicodeLinter.lean
+++ b/Mathlib/Tactic/Linter/UnicodeLinter.lean
@@ -1,0 +1,66 @@
+/-
+Copyright (c) 2024 Michael Rothgang. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Adomas Baliuka, Jon Eugster
+-/
+
+import Mathlib.Init
+
+/-!
+
+# Tools for Unicode Linter
+
+The actual linter is defined in `TextBased.lean`.
+
+This file provides all white-lists and other tools used by the linter.
+
+## Main declarations
+
+* `emojis`, `nonEmojis`: characters in these lists should always be followed by
+  the correct variant-selector `UnicodeVariant.emoji` or `UnicodeVariant.text`.
+  These variant-selector should not appear anywhere else.
+
+-/
+
+namespace Mathlib.Linter.TextBased.UnicodeLinter
+
+/-- Following any unicode character, this indicates that the emoji-variant should be displayed -/
+def UnicodeVariant.emoji := '\uFE0F'
+
+/-- Following any unicode character, this indicates that the text-variant should be displayed -/
+def UnicodeVariant.text := '\uFE0E'
+
+/-- Prints a unicode character's codepoint in hexadecimal with prefix 'U+'.
+E.g., 'a' is "U+0061". -/
+def printCodepointHex (c : Char) : String :=
+  let digits := Nat.toDigits 16 c.val.toNat
+  match digits.length with  -- print at least 4 (could be more) hex characters using leading zeros
+  | 1 => "U+000".append <| String.mk digits
+  | 2 => "U+00".append <| String.mk digits
+  | 3 => "U+0".append <| String.mk digits
+  | _ => "U+".append <| String.mk digits
+
+/-- Unicode symbols in mathilb that should always be followed by the emoji-variant selector. -/
+def emojis := #[
+'\u2705',        -- ✅️
+'\u274C',        -- ❌️
+ -- TODO "missing end of character literal" if written as '\u1F4A5'
+ -- see https://github.com/leanprover/lean4/blob/4eea57841d1012d6c2edab0f270e433d43f92520/src/Lean/Parser/Basic.lean#L709
+.ofNat 0x1F4A5,  -- 💥️
+.ofNat 0x1F7E1,  -- 🟡️
+.ofNat 0x1F4A1,  -- 💡️
+.ofNat 0x1F419,  -- 🐙️
+.ofNat 0x1F50D,  -- 🔍️
+.ofNat 0x1F389,  -- 🎉️
+'\u23F3',        -- ⏳️
+.ofNat 0x1F3C1 ] -- 🏁️
+
+/-- Unicode symbols in mathilb that should always be followed by the text-variant selector. -/
+def nonEmojis : Array Char := #[]
+
+/-- If `false` the character is not allowed in Mathlib.
+-/
+def isAllowedCharacter (c : Char) : Bool :=
+  c != '\u00A0' -- non-breaking space
+
+end Mathlib.Linter.TextBased.UnicodeLinter

--- a/Mathlib/Tactic/Linter/UnicodeLinter.lean
+++ b/Mathlib/Tactic/Linter/UnicodeLinter.lean
@@ -1,5 +1,5 @@
 /-
-Copyright (c) 2024 Michael Rothgang. All rights reserved.
+Copyright (c) 2024 Jon Eugster. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Adomas Baliuka, Jon Eugster
 -/
@@ -24,12 +24,6 @@ This file provides all white-lists and other tools used by the linter.
 
 namespace Mathlib.Linter.TextBased.UnicodeLinter
 
-/-- Following any unicode character, this indicates that the emoji-variant should be displayed -/
-def UnicodeVariant.emoji := '\uFE0F'
-
-/-- Following any unicode character, this indicates that the text-variant should be displayed -/
-def UnicodeVariant.text := '\uFE0E'
-
 /-- Prints a unicode character's codepoint in hexadecimal with prefix 'U+'.
 E.g., 'a' is "U+0061". -/
 def printCodepointHex (c : Char) : String :=
@@ -39,24 +33,6 @@ def printCodepointHex (c : Char) : String :=
   | 2 => "U+00".append <| String.mk digits
   | 3 => "U+0".append <| String.mk digits
   | _ => "U+".append <| String.mk digits
-
-/-- Unicode symbols in mathilb that should always be followed by the emoji-variant selector. -/
-def emojis := #[
-'\u2705',        -- ✅️
-'\u274C',        -- ❌️
- -- TODO "missing end of character literal" if written as '\u1F4A5'
- -- see https://github.com/leanprover/lean4/blob/4eea57841d1012d6c2edab0f270e433d43f92520/src/Lean/Parser/Basic.lean#L709
-.ofNat 0x1F4A5,  -- 💥️
-.ofNat 0x1F7E1,  -- 🟡️
-.ofNat 0x1F4A1,  -- 💡️
-.ofNat 0x1F419,  -- 🐙️
-.ofNat 0x1F50D,  -- 🔍️
-.ofNat 0x1F389,  -- 🎉️
-'\u23F3',        -- ⏳️
-.ofNat 0x1F3C1 ] -- 🏁️
-
-/-- Unicode symbols in mathilb that should always be followed by the text-variant selector. -/
-def nonEmojis : Array Char := #[]
 
 /-- If `false` the character is not allowed in Mathlib.
 -/


### PR DESCRIPTION
Add unicode linter flagging bad unicode characters. In this first form, the linter only flags `\u00A0` (non-breaking space) and replaces it with a normal space. Non-breaking space has been chosen because they keep reappearing in mathlib and it seems to be uncontroversial to lint for these.

The whitelist/blacklist could then be refined in future PRs.

Everything flagged by this linter can be fixed fully automatically with `lake exe lint-style --fix` or by commenting `bot fix style` on the PR.

---

- tracking PR: #16215

## Zulip discussions:

- https://leanprover.zulipchat.com/#narrow/stream/287929-mathlib4/topic/Whitelist.20for.20Unicode.3F
- https://leanprover.zulipchat.com/#narrow/stream/113488-general/topic/Lean.20specific.20font

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
