### PR TITLE
[Merged by Bors] - feat: `Mᴴ * M = 1` when `M := a.toBasis.toMatrix b`

### DIFF
--- a/Mathlib/Analysis/InnerProductSpace/PiL2.lean
+++ b/Mathlib/Analysis/InnerProductSpace/PiL2.lean
@@ -679,6 +679,28 @@ section ToMatrix
 variable [DecidableEq ι]
 
 section
+open scoped Matrix
+
+/-- A version of `OrthonormalBasis.toMatrix_orthonormalBasis_mem_unitary` that works for bases with
+different index types. -/
+@[simp]
+theorem OrthonormalBasis.toMatrix_orthonormalBasis_conjTranspose_mul_self [Fintype ι']
+    (a : OrthonormalBasis ι' 𝕜 E) (b : OrthonormalBasis ι 𝕜 E) :
+    (a.toBasis.toMatrix b)ᴴ * a.toBasis.toMatrix b = 1 := by
+  ext i j
+  convert a.repr.inner_map_map (b i) (b j)
+  rw [orthonormal_iff_ite.mp b.orthonormal i j]
+  rfl
+
+/-- A version of `OrthonormalBasis.toMatrix_orthonormalBasis_mem_unitary` that works for bases with
+different index types. -/
+@[simp]
+theorem OrthonormalBasis.toMatrix_orthonormalBasis_self_mul_conjTranspose [Fintype ι']
+    (a : OrthonormalBasis ι 𝕜 E) (b : OrthonormalBasis ι' 𝕜 E) :
+    a.toBasis.toMatrix b * (a.toBasis.toMatrix b)ᴴ = 1 := by
+  classical
+  rw [Matrix.mul_eq_one_comm_of_equiv (a.toBasis.indexEquiv b.toBasis),
+    a.toMatrix_orthonormalBasis_conjTranspose_mul_self b]
 
 variable (a b : OrthonormalBasis ι 𝕜 E)
 
@@ -686,10 +708,7 @@ variable (a b : OrthonormalBasis ι 𝕜 E)
 theorem OrthonormalBasis.toMatrix_orthonormalBasis_mem_unitary :
     a.toBasis.toMatrix b ∈ Matrix.unitaryGroup ι 𝕜 := by
   rw [Matrix.mem_unitaryGroup_iff']
-  ext i j
-  convert a.repr.inner_map_map (b i) (b j)
-  rw [orthonormal_iff_ite.mp b.orthonormal i j]
-  rfl
+  exact a.toMatrix_orthonormalBasis_conjTranspose_mul_self b
 
 /-- The determinant of the change-of-basis matrix between two orthonormal bases `a`, `b` has
 unit length. -/

--- a/Mathlib/Data/Matrix/ColumnRowPartitioned.lean
+++ b/Mathlib/Data/Matrix/ColumnRowPartitioned.lean
@@ -258,17 +258,8 @@ lemma fromColumns_mul_fromRows_eq_one_comm
     [Fintype n₁] [Fintype n₂] [Fintype n] [DecidableEq n] [DecidableEq n₁] [DecidableEq n₂]
     (e : n ≃ n₁ ⊕ n₂)
     (A₁ : Matrix n n₁ R) (A₂ : Matrix n n₂ R) (B₁ : Matrix n₁ n R) (B₂ : Matrix n₂ n R) :
-    fromColumns A₁ A₂ * fromRows B₁ B₂ = 1 ↔ fromRows B₁ B₂ * fromColumns A₁ A₂ = 1 := by
-  calc fromColumns A₁ A₂ * fromRows B₁ B₂ = 1
-  _ ↔ submatrix (fromColumns A₁ A₂) id e * submatrix (fromRows B₁ B₂) e id = 1 := by
-    simp
-  _ ↔ submatrix (fromRows B₁ B₂) e id * submatrix (fromColumns A₁ A₂) id e = 1 :=
-    mul_eq_one_comm
-  _ ↔ reindex e.symm e.symm (fromRows B₁ B₂ * fromColumns A₁ A₂) = reindex e.symm e.symm 1 := by
-    simp only [reindex_apply, Equiv.symm_symm, submatrix_one_equiv,
-        submatrix_mul (he₂ := Function.bijective_id)]
-  _ ↔ fromRows B₁ B₂ * fromColumns A₁ A₂ = 1 :=
-    (reindex _ _).injective.eq_iff
+    fromColumns A₁ A₂ * fromRows B₁ B₂ = 1 ↔ fromRows B₁ B₂ * fromColumns A₁ A₂ = 1 :=
+  mul_eq_one_comm_of_equiv e
 
 /-- The lemma `fromColumns_mul_fromRows_eq_one_comm` specialized to the case where the index sets n₁
 and n₂, are the result of subtyping by a predicate and its complement. -/

--- a/Mathlib/LinearAlgebra/Matrix/NonsingularInverse.lean
+++ b/Mathlib/LinearAlgebra/Matrix/NonsingularInverse.lean
@@ -175,6 +175,20 @@ theorem det_ne_zero_of_right_inverse [Nontrivial α] (h : A * B = 1) : A.det ≠
 
 end Invertible
 
+
+section
+
+variable [Fintype m] [Fintype n] [DecidableEq m] [DecidableEq n] [CommRing α]
+
+/-- A version of `mul_eq_one_comm` that works for square matrices with rectangular types. -/
+theorem mul_eq_one_comm_of_equiv {A : Matrix m n α} {B : Matrix n m α} (e : m ≃ n) :
+    A * B = 1 ↔ B * A = 1 := by
+  refine (reindex e e).injective.eq_iff.symm.trans ?_
+  rw [reindex_apply, reindex_apply, submatrix_one_equiv, ← submatrix_mul_equiv _ _ _ (.refl _),
+    mul_eq_one_comm, submatrix_mul_equiv, coe_refl, submatrix_id_id]
+
+end
+
 section Inv
 
 variable [Fintype n] [DecidableEq n] [CommRing α]


### PR DESCRIPTION
This partially generalizes an existing result to work when the indices are different.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
