### PR TITLE
feat(NumberTheory/Ostrowski): Ostrowski's Theorem for the rationals

### DIFF
--- a/Mathlib/NumberTheory/Ostrowski.lean
+++ b/Mathlib/NumberTheory/Ostrowski.lean
@@ -121,6 +121,7 @@ section Non_archimedean
 Every bounded absolute value is equivalent to a `p`-adic absolute value
 -/
 
+/-- The mulRingNorm corresponding to the p-adic norm on `ℚ`. -/
 def mulRingNorm_padic (p : ℕ) [Fact p.Prime] : MulRingNorm ℚ :=
 { toFun     := fun x : ℚ ↦ (padicNorm p x : ℝ),
   map_zero' := by simp only [padicNorm.zero, Rat.cast_zero]

--- a/Mathlib/NumberTheory/Ostrowski.lean
+++ b/Mathlib/NumberTheory/Ostrowski.lean
@@ -32,7 +32,7 @@ Archimedean (Euclidean) absolute value
 ring_norm, ostrowski
 -/
 
-/- ## Preliminary lemmas on limits -/
+/- ## Preliminary lemmas on limits and lists -/
 
 open Filter Topology
 
@@ -59,6 +59,29 @@ private lemma tendsto_nat_rpow_div :
   apply Tendsto.comp _ tendsto_natCast_atTop_atTop
   simp_rw [← one_div]
   exact tendsto_rpow_div
+
+-- Multiplication by a constant moves in a List.sum
+private lemma list_mul_sum {R : Type*} [CommSemiring R] {T : Type*} (l : List T) (y : R) : ∀ x : R,
+    List.sum (List.mapIdx (fun i _ => x * y ^ i) (l)) =
+    x * List.sum (List.mapIdx (fun i _ => y ^ i) (l)) := by
+  induction l with
+  | nil => simp only [List.mapIdx_nil, List.sum_nil, mul_zero, forall_const]
+  | cons head tail ih =>
+    intro x
+    simp_rw [List.mapIdx_cons, pow_zero, mul_one, List.sum_cons, mul_add, mul_one]
+    have (a : ℕ) : y ^ (a + 1) = y * y ^ a := by ring
+    simp_rw [this, ← mul_assoc, ih, ← mul_assoc]
+
+-- Geometric sum for lists
+private lemma list_geom {T : Type*} {F : Type*} [Field F] (l : List T) {y : F} (hy : y ≠ 1) :
+    List.sum (List.mapIdx (fun i _ => y ^ i) l) = (y ^ l.length - 1) / (y - 1) := by
+  induction l with
+  | nil => simp only [List.mapIdx_nil, List.sum_nil, List.length_nil, pow_zero, sub_self, zero_div]
+  | cons head tail ih =>
+    simp only [List.mapIdx_cons, pow_zero, List.sum_cons, List.length_cons]
+    have (a : ℕ ) : y ^ (a + 1) = y * y ^ a := by ring
+    simp_rw [this, list_mul_sum, ih]
+    simp only [mul_div, ← same_add_div (sub_ne_zero.2 hy), mul_sub, mul_one, sub_add_sub_cancel']
 
 namespace Rat.MulRingNorm
 open Int
@@ -266,6 +289,23 @@ section Archimedean
 
 /-! ## Archimedean case -/
 
+/-- The usual absolute value on ℚ. -/
+def mulRingNorm_real : MulRingNorm ℚ :=
+{ toFun    := fun x : ℚ ↦ |x|
+  map_zero' := by simp only [Rat.cast_zero, abs_zero]
+  add_le'   := norm_add_le
+  neg'      := norm_neg
+  eq_zero_of_map_eq_zero' := by simp only [abs_eq_zero, Rat.cast_eq_zero, imp_self, forall_const]
+  map_one' := by simp only [Rat.cast_one, abs_one]
+  map_mul' := by
+    simp only [Rat.cast_mul]
+    exact_mod_cast abs_mul
+}
+
+@[simp] lemma mul_ring_norm_eq_abs (r : ℚ) : mulRingNorm_real r = |r| := by
+  simp only [Rat.cast_abs]
+  rfl
+
 /-! ## Preliminary result -/
 
 /-- Given an two integers `n, m` with `m > 1` the mulRingNorm of `n` is bounded by
@@ -361,6 +401,133 @@ lemma one_lt_of_not_bounded (notbdd : ¬ ∀ (n : ℕ), f n ≤ 1) {n₀ : ℕ} 
     exact hnlim.mul tendsto_nat_rpow_div
   exact le_of_limit_le h_ineq2 prod_limit
 
+/-! ## step 2: given m,n ≥ 2 and |m|=m^s, |n|=n^t for s,t > 0, we have t ≤ s -/
+
+open Real
+
+variable {m n : ℕ} (hm : 1 < m) (hn : 1 < n) (notbdd : ¬ ∀ (n : ℕ), f n ≤ 1)
+
+include hm notbdd in
+private lemma expr_pos : 0 < m * f m / (f m - 1) := by
+  apply div_pos (mul_pos (mod_cast zero_lt_of_lt hm)
+      (map_pos_of_ne_zero f (mod_cast ne_zero_of_lt hm)))
+  linarith only [one_lt_of_not_bounded notbdd hm]
+
+include hn hm notbdd in
+private lemma param_upperbound (k : ℕ) (hk : k ≠ 0) :
+    f n ≤ (m * f m / (f m - 1)) ^ (k : ℝ)⁻¹ * (f m) ^ (logb m n) := by
+  have h_ineq1 {m n : ℕ} (hm : 1 < m) (hn : 1 < n) :
+      f n ≤ (m * f m / (f m - 1)) * (f m) ^ (logb m n) := by
+    let d := Nat.log m n
+    calc
+    f n ≤ ((Nat.digits m n).mapIdx fun i _ ↦ m * (f m) ^ i).sum := MulRingNorm_le_sum_digits n hm
+    _ = m * ((Nat.digits m n).mapIdx fun i _ ↦ (f m) ^ i).sum := list_mul_sum (m.digits n) (f m) m
+    _ = m * ((f m ^ (d + 1) - 1) / (f m - 1)) := by
+      rw [list_geom _ (ne_of_gt (one_lt_of_not_bounded notbdd hm)),
+      (Nat.digits_len m n hm (not_eq_zero_of_lt hn)).symm]
+    _ ≤ m * ((f m ^ (d + 1))/(f m - 1)) := by
+      gcongr
+      linarith only [one_lt_of_not_bounded notbdd hm]
+      simp only [tsub_le_iff_right, le_add_iff_nonneg_right, zero_le_one]
+    _ = ↑m * f ↑m / (f ↑m - 1) * f ↑m ^ d := by ring
+    _ ≤ ↑m * f ↑m / (f ↑m - 1) * f ↑m ^ logb ↑m ↑n := by
+      gcongr
+      exact le_of_lt (expr_pos hm notbdd)
+      rw [← Real.rpow_natCast, Real.rpow_le_rpow_left_iff (one_lt_of_not_bounded notbdd hm)]
+      exact natLog_le_logb n m
+  have h_ineq2 (k : ℕ) (hk : k ≠ 0) :
+      (f n) ^ k ≤ (m * f m / (f m - 1)) * (f m) ^ (k * logb m n) := by
+    calc
+    (f n) ^ k = f ↑(n ^ k) := by simp only [Nat.cast_pow, map_pow]
+    _ ≤ (m * f m / (f m - 1)) * (f m) ^ (logb m ↑(n ^ k)) := h_ineq1 hm (Nat.one_lt_pow hk hn)
+    _ = (m * f m / (f m - 1)) * (f m) ^ (k * logb m n) := by
+      rw [Nat.cast_pow, Real.logb_pow]
+      exact_mod_cast zero_lt_of_lt hn
+  apply le_of_pow_le_pow_left hk (mul_nonneg (rpow_nonneg
+    (le_of_lt (expr_pos hm notbdd)) (k : ℝ)⁻¹) (rpow_nonneg (apply_nonneg f ↑m) (logb m n)))
+  nth_rw 2 [← Real.rpow_natCast]
+  rw [mul_rpow (rpow_nonneg (le_of_lt (expr_pos hm notbdd)) (k : ℝ)⁻¹)
+    (rpow_nonneg (apply_nonneg f ↑m) (logb ↑m ↑n)), ← rpow_mul (le_of_lt (expr_pos hm notbdd)),
+    ← rpow_mul (apply_nonneg f ↑m), inv_mul_cancel₀ (mod_cast hk), rpow_one, mul_comm (logb ↑m ↑n)]
+  exact h_ineq2 k hk
+
+include hm hn notbdd in
+/-- Given two natural numbers `n, m` greater than 1 we have `f n ≤ f m ^ logb m n`. -/
+lemma mulRingNorm_le_mulRingNorm_pow_log : f n ≤ f m ^ logb m n := by
+  apply le_of_limit_le (g:=fun k ↦ (m * f m / (f m - 1)) ^ (k : ℝ)⁻¹ * (f m) ^ (logb m n))
+  · intro k hk
+    exact param_upperbound hm hn notbdd k (not_eq_zero_of_lt hk)
+  · nth_rw 2 [← one_mul (f ↑m ^ logb ↑m ↑n)]
+    exact Tendsto.mul_const _ (tendsto_root_atTop_nhds_one (expr_pos hm notbdd))
+
+include hm hn notbdd in
+/-- Fiven m,n ≥ 2 and `f m = m ^ s`, `f n = n ^ t` for `s, t > 0`, we have `t ≤ s`. -/
+lemma le_of_mulRingNorm_eq {s t : ℝ} (hfm : f m = m ^ s) (hfn : f n = n ^ t)  : t ≤ s := by
+    have hmn : f n ≤ f m ^ Real.logb m n := mulRingNorm_le_mulRingNorm_pow_log hm hn notbdd
+    rw [← Real.rpow_le_rpow_left_iff (x:=n) (mod_cast hn), ← hfn]
+    apply le_trans hmn
+    rw [hfm, ← Real.rpow_mul (Nat.cast_nonneg m), mul_comm, Real.rpow_mul (Nat.cast_nonneg m),
+      Real.rpow_logb (mod_cast zero_lt_of_lt hm) (mod_cast Nat.ne_of_lt' hm)
+      (mod_cast zero_lt_of_lt hn)]
+
+include hm hn notbdd in
+private lemma symmetric_roles {s t : ℝ} (hfm : f m = m ^ s) (hfn : f n = n ^ t) : s = t :=
+    le_antisymm (le_of_mulRingNorm_eq hn hm notbdd hfn hfm)
+    (le_of_mulRingNorm_eq hm hn notbdd hfm hfn)
+
+/-! ## Archimedean case: end goal -/
+
+/-- If `f` is not bounded and not trivial, then it is equivalent to the standard absolute value on
+`ℚ`. -/
+theorem mulRingNorm_equiv_standard_of_unbounded (notbdd: ¬ ∀ (n : ℕ), f n ≤ 1) :
+    MulRingNorm.equiv f mulRingNorm_real := by
+  obtain ⟨m, hm⟩ := Classical.exists_not_of_not_forall notbdd
+  have oneltm : 1 < m := by
+    by_contra!
+    apply hm
+    replace this : m = 0 ∨ m = 1 := by omega
+    rcases this with (rfl | rfl)
+    all_goals simp only [CharP.cast_eq_zero, map_zero, zero_le_one,Nat.cast_one, map_one, le_refl]
+  rw [← equiv_on_nat_iff_equiv]
+  set s := Real.logb m (f m) with hs
+  use s⁻¹
+  refine ⟨inv_pos.2 (Real.logb_pos (Nat.one_lt_cast.2 oneltm)
+    (one_lt_of_not_bounded notbdd oneltm)), ?_⟩
+  intro n
+  by_cases h1 : n ≤ 1
+  · by_cases h2 : n = 1
+    · simp only [h2, Nat.cast_one, map_one, one_rpow, mul_ring_norm_eq_abs, abs_one, cast_one]
+    · have : n = 0 := by omega
+      rw [this, hs]
+      simp only [CharP.cast_eq_zero, map_zero]
+      rw [Real.rpow_eq_zero le_rfl]
+      simp only [ne_eq, inv_eq_zero, logb_eq_zero, Nat.cast_eq_zero, Nat.cast_eq_one, map_eq_zero,
+        not_or]
+      push_neg
+      exact ⟨not_eq_zero_of_lt oneltm, Nat.ne_of_lt' oneltm, mod_cast (fun a ↦ a),
+        not_eq_zero_of_lt oneltm, ne_of_not_le hm, by linarith only [apply_nonneg f ↑m]⟩
+  · simp only [mul_ring_norm_eq_abs, abs_cast, Rat.cast_natCast]
+    rw [Real.rpow_inv_eq (apply_nonneg f ↑n) (Nat.cast_nonneg n)
+      (Real.logb_ne_zero_of_pos_of_ne_one (one_lt_cast.mpr oneltm) (by linarith only [hm])
+      (by linarith only [hm]))]
+    simp only [not_le] at h1
+    have hfm : f m = m ^ s := by rw [Real.rpow_logb (mod_cast zero_lt_of_lt oneltm)
+      (mod_cast Nat.ne_of_lt' oneltm) (by linarith only [hm])]
+    have hfn : f n = n ^ (Real.logb n (f n)) := by
+      rw [Real.rpow_logb (mod_cast zero_lt_of_lt h1) (mod_cast Nat.ne_of_lt' h1)
+      (by apply map_pos_of_ne_zero; exact_mod_cast not_eq_zero_of_lt h1)]
+    rwa [← hs, symmetric_roles oneltm h1 notbdd hfm hfn]
+
 end Archimedean
+
+/-- Ostrowski's Theorem -/
+theorem mulRingNorm_equiv_standard_or_padic (f : MulRingNorm ℚ) (hf_nontriv : f ≠ 1) :
+    (MulRingNorm.equiv f mulRingNorm_real) ∨
+    ∃! p, ∃ (hp : Fact (p.Prime)), MulRingNorm.equiv f (mulRingNorm_padic p) := by
+  by_cases bdd : ∀ n : ℕ, f n ≤ 1
+  · right
+    exact mulRingNorm_equiv_padic_of_bounded hf_nontriv bdd
+  · left
+    exact mulRingNorm_equiv_standard_of_unbounded bdd
 
 end Rat.MulRingNorm


### PR DESCRIPTION
We complete the proof of the Archimedean case of Ostrowski's Theorem for the rational numbers:
```lean
theorem mulRingNorm_equiv_standard_of_unbounded (notbdd: ¬ ∀ (n : ℕ), f n ≤ 1) :
    MulRingNorm.equiv f mulRingNorm_real
```

This concludes the proof of the theorem:
```lean
theorem mulRingNorm_equiv_standard_or_padic (f : MulRingNorm ℚ) (hf_nontriv : f ≠ 1) :
    (MulRingNorm.equiv f mulRingNorm_real) ∨
    ∃! p, ∃ (hp : Fact (p.Prime)), MulRingNorm.equiv f (mulRingNorm_padic p)
```

Co-authored-by: David Kurniadi Angdinata [dka31@cantab.ac.uk](mailto:dka31@cantab.ac.uk)
Co-authored-by: Laura Capuano [laura.capuano@uniroma3.it](mailto:laura.capuano@uniroma3.it)
Co-authored-by: Nirvana Coppola [nirvanac93@gmail.com](mailto:nirvanac93@gmail.com)
Co-authored-by: María Inés de Frutos Fernández [maria.defrutos@uam.es](mailto:maria.defrutos@uam.es)
Co-authored-by: Sam van Gool [vangool@irif.fr](mailto:vangool@irif.fr)
Co-authored-by: Silvain Rideau-Kikuchi [silvain.rideau-kikuchi@ens.fr](mailto:silvain.rideau-kikuchi@ens.fr)
Co-authored-by: Amos Turchet [amos.turchet@uniroma3.it](mailto:amos.turchet@uniroma3.it)
Co-authored-by: Francesco Veneziano [veneziano@dima.unige.it](mailto:veneziano@dima.unige.it)

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

- [ ] depends on: #14442

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
