### PR TITLE
[Merged by Bors] - refactor(CategoryTheory/MorphismProperty): introduce meta properties `RespectsLeft` and `RespectsRight`

### DIFF
--- a/Mathlib/AlgebraicGeometry/Morphisms/Basic.lean
+++ b/Mathlib/AlgebraicGeometry/Morphisms/Basic.lean
@@ -326,7 +326,7 @@ theorem respectsIso_mk {P : AffineTargetMorphismProperty}
     (h₂ : ∀ {X Y Z} (e : Y ≅ Z) (f : X ⟶ Y) [h : IsAffine Y],
       P f → @P _ _ (f ≫ e.hom) (isAffine_of_isIso e.inv)) :
     P.toProperty.RespectsIso := by
-  constructor
+  apply MorphismProperty.RespectsIso.mk
   · rintro X Y Z e f ⟨a, h⟩; exact ⟨a, h₁ e f h⟩
   · rintro X Y Z e f ⟨a, h⟩; exact ⟨isAffine_of_isIso e.inv, h₂ e f h⟩
 
@@ -398,7 +398,7 @@ theorem of_targetAffineLocally_of_isPullback
 
 instance (P : AffineTargetMorphismProperty) [P.toProperty.RespectsIso] :
     (targetAffineLocally P).RespectsIso := by
-  constructor
+  apply MorphismProperty.RespectsIso.mk
   · introv H U
     rw [morphismRestrict_comp, P.cancel_left_of_respectsIso]
     exact H U

--- a/Mathlib/AlgebraicGeometry/Morphisms/ClosedImmersion.lean
+++ b/Mathlib/AlgebraicGeometry/Morphisms/ClosedImmersion.lean
@@ -84,7 +84,7 @@ instance comp {X Y Z : Scheme} (f : X ⟶ Y) (g : Y ⟶ Z) [IsClosedImmersion f]
 
 /-- Composition with an isomorphism preserves closed immersions. -/
 instance respectsIso : MorphismProperty.RespectsIso @IsClosedImmersion := by
-  constructor <;> intro X Y Z e f hf <;> infer_instance
+  apply MorphismProperty.RespectsIso.mk <;> intro X Y Z e f hf <;> infer_instance
 
 /-- Given two commutative rings `R S : CommRingCat` and a surjective morphism
 `f : R ⟶ S`, the induced scheme morphism `specObj S ⟶ specObj R` is a

--- a/Mathlib/AlgebraicGeometry/Morphisms/Constructors.lean
+++ b/Mathlib/AlgebraicGeometry/Morphisms/Constructors.lean
@@ -251,12 +251,12 @@ variable {P : ∀ {R S : Type u} [CommRing R] [CommRing S], (R →+* S) → Prop
 /-- If `P` respects isos, then `stalkwise P` respects isos. -/
 lemma stalkwise_respectsIso (hP : RingHom.RespectsIso P) :
     (stalkwise P).RespectsIso where
-  precomp {X Y Z} e f hf := by
+  precomp {X Y Z} e (he : IsIso e) f hf := by
     simp only [stalkwise, Scheme.comp_coeBase, TopCat.coe_comp, Function.comp_apply]
     intro x
     rw [Scheme.stalkMap_comp]
-    exact (RingHom.RespectsIso.cancel_right_isIso hP _ _).mpr <| hf (e.hom.val.base x)
-  postcomp {X Y Z} e f hf := by
+    exact (RingHom.RespectsIso.cancel_right_isIso hP _ _).mpr <| hf (e.val.base x)
+  postcomp {X Y Z} e (he : IsIso e) f hf := by
     simp only [stalkwise, Scheme.comp_coeBase, TopCat.coe_comp, Function.comp_apply]
     intro x
     rw [Scheme.stalkMap_comp]

--- a/Mathlib/CategoryTheory/MorphismProperty/Basic.lean
+++ b/Mathlib/CategoryTheory/MorphismProperty/Basic.lean
@@ -13,8 +13,11 @@ import Mathlib.Order.CompleteBooleanAlgebra
 We provide the basic framework for talking about properties of morphisms.
 The following meta-property is defined
 
-* `RespectsIso`: `P` respects isomorphisms if `P f → P (e ≫ f)` and `P f → P (f ≫ e)`, where
-  `e` is an isomorphism.
+* `RespectsLeft P Q`: `P` respects the property `Q` on the left if `P f → P (i ≫ f)` where
+  `i` satisfies `Q`.
+* `RespectsRight P Q`: `P` respects the property `Q` on the right if `P f → P (f ≫ i)` where
+  `i` satisfies `Q`.
+* `Respects`: `P` respects `Q` if `P` respects `Q` both on the left and on the right.
 
 -/
 
@@ -93,22 +96,77 @@ lemma monotone_map (F : C ⥤ D) :
   intro P Q h X Y f ⟨X', Y', f', hf', ⟨e⟩⟩
   exact ⟨X', Y', f', h _ hf', ⟨e⟩⟩
 
-/-- A morphism property `RespectsIso` if it still holds when composed with an isomorphism -/
-class RespectsIso (P : MorphismProperty C) : Prop where
-  precomp {X Y Z} (e : X ≅ Y) (f : Y ⟶ Z) (hf : P f) : P (e.hom ≫ f)
-  postcomp {X Y Z} (e : Y ≅ Z) (f : X ⟶ Y) (hf : P f) : P (f ≫ e.hom)
+/-- A morphism property `P` satisfies `P.RespectsRight Q` if it is stable under post-composition
+with morphisms satisfying `Q`, i.e. whenever `P` holds for `f` and `Q` holds for `i` then `P`
+holds for `f ≫ i`. -/
+class RespectsRight (P Q : MorphismProperty C) : Prop where
+  postcomp {X Y Z : C} (i : Y ⟶ Z) (hi : Q i) (f : X ⟶ Y) (hf : P f) : P (f ≫ i)
 
-instance RespectsIso.op (P : MorphismProperty C) [h : RespectsIso P] : RespectsIso P.op :=
-  ⟨fun e f hf => h.2 e.unop f.unop hf, fun e f hf => h.1 e.unop f.unop hf⟩
+/-- A morphism property `P` satisfies `P.RespectsLeft Q` if it is stable under
+pre-composition with morphisms satisfying `Q`, i.e. whenever `P` holds for `f`
+and `Q` holds for `i` then `P` holds for `i ≫ f`. -/
+class RespectsLeft (P Q : MorphismProperty C) : Prop where
+  precomp {X Y Z : C} (i : X ⟶ Y) (hi : Q i) (f : Y ⟶ Z) (hf : P f) : P (i ≫ f)
 
-instance RespectsIso.unop (P : MorphismProperty Cᵒᵖ) [h : RespectsIso P] : RespectsIso P.unop :=
-  ⟨fun e f hf => h.2 e.op f.op hf, fun e f hf => h.1 e.op f.op hf⟩
+/-- A morphism property `P` satisfies `P.Respects Q` if it is stable under composition on the
+left and right by morphisms satisfying `Q`. -/
+class Respects (P Q : MorphismProperty C) extends P.RespectsLeft Q, P.RespectsRight Q : Prop where
 
-/-- The intersection of two isomorphism respecting morphism properties respects isomorphisms. -/
-instance RespectsIso.inf (P Q : MorphismProperty C) [RespectsIso P] [RespectsIso Q] :
-    RespectsIso (P ⊓ Q) where
-  precomp e f hf := ⟨RespectsIso.precomp e f hf.left, RespectsIso.precomp e f hf.right⟩
-  postcomp e f hf := ⟨RespectsIso.postcomp e f hf.left, RespectsIso.postcomp e f hf.right⟩
+instance (P Q : MorphismProperty C) [P.RespectsLeft Q] [P.RespectsRight Q] : P.Respects Q where
+
+instance (P Q : MorphismProperty C) [P.RespectsLeft Q] : P.op.RespectsRight Q.op where
+  postcomp i hi f hf := RespectsLeft.precomp (Q := Q) i.unop hi f.unop hf
+
+instance (P Q : MorphismProperty C) [P.RespectsRight Q] : P.op.RespectsLeft Q.op where
+  precomp i hi f hf := RespectsRight.postcomp (Q := Q) i.unop hi f.unop hf
+
+instance RespectsLeft.inf (P₁ P₂ Q : MorphismProperty C) [P₁.RespectsLeft Q]
+    [P₂.RespectsLeft Q] : (P₁ ⊓ P₂).RespectsLeft Q where
+  precomp i hi f hf := ⟨precomp i hi f hf.left, precomp i hi f hf.right⟩
+
+instance RespectsRight.inf (P₁ P₂ Q : MorphismProperty C) [P₁.RespectsRight Q]
+    [P₂.RespectsRight Q] : (P₁ ⊓ P₂).RespectsRight Q where
+  postcomp i hi f hf := ⟨postcomp i hi f hf.left, postcomp i hi f hf.right⟩
+
+variable (C)
+
+/-- The `MorphismProperty C` satisfied by isomorphisms in `C`. -/
+def isomorphisms : MorphismProperty C := fun _ _ f => IsIso f
+
+/-- The `MorphismProperty C` satisfied by monomorphisms in `C`. -/
+def monomorphisms : MorphismProperty C := fun _ _ f => Mono f
+
+/-- The `MorphismProperty C` satisfied by epimorphisms in `C`. -/
+def epimorphisms : MorphismProperty C := fun _ _ f => Epi f
+
+section
+
+variable {C}
+
+abbrev RespectsIso (P : MorphismProperty C) : Prop := P.Respects (isomorphisms C)
+
+def RespectsIso.mk (P : MorphismProperty C)
+    (hprecomp : ∀ {X Y Z : C} (e : X ≅ Y) (f : Y ⟶ Z) (_ : P f), P (e.hom ≫ f))
+    (hpostcomp : ∀ {X Y Z : C} (e : Y ≅ Z) (f : X ⟶ Y) (_ : P f), P (f ≫ e.hom)) :
+    P.RespectsIso where
+  precomp e (_ : IsIso e) f hf := hprecomp (asIso e) f hf
+  postcomp e (_ : IsIso e) f hf := hpostcomp (asIso e) f hf
+
+lemma RespectsIso.precomp (P : MorphismProperty C) [P.RespectsIso] {X Y Z : C} (e : X ⟶ Y)
+    [IsIso e] (f : Y ⟶ Z) (hf : P f) : P (e ≫ f) :=
+  RespectsLeft.precomp (Q := isomorphisms C) e ‹IsIso e› f hf
+
+lemma RespectsIso.postcomp (P : MorphismProperty C) [P.RespectsIso] {X Y Z : C} (e : Y ⟶ Z)
+    [IsIso e] (f : X ⟶ Y) (hf : P f) : P (f ≫ e) :=
+  RespectsRight.postcomp (Q := isomorphisms C) e ‹IsIso e› f hf
+
+instance RespectsIso.op (P : MorphismProperty C) [h : RespectsIso P] : RespectsIso P.op where
+  precomp e (_ : IsIso e) f hf := h.postcomp e.unop f.unop hf
+  postcomp e (_ : IsIso e) f hf := h.precomp e.unop f.unop hf
+
+instance RespectsIso.unop (P : MorphismProperty Cᵒᵖ) [h : RespectsIso P] : RespectsIso P.unop where
+  precomp e (_ : IsIso e) f hf := h.postcomp e.op f.op hf
+  postcomp e (_ : IsIso e) f hf := h.precomp e.op f.op hf
 
 /-- The closure by isomorphisms of a `MorphismProperty` -/
 def isoClosure (P : MorphismProperty C) : MorphismProperty C :=
@@ -119,10 +177,10 @@ lemma le_isoClosure (P : MorphismProperty C) : P ≤ P.isoClosure :=
 
 instance isoClosure_respectsIso (P : MorphismProperty C) :
     RespectsIso P.isoClosure where
-  precomp := fun e f ⟨_, _, f', hf', ⟨iso⟩⟩ => ⟨_, _, f', hf',
-      ⟨Arrow.isoMk (asIso iso.hom.left ≪≫ e.symm) (asIso iso.hom.right) (by simp)⟩⟩
-  postcomp := fun e f ⟨_, _, f', hf', ⟨iso⟩⟩ => ⟨_, _, f', hf',
-      ⟨Arrow.isoMk (asIso iso.hom.left) (asIso iso.hom.right ≪≫ e) (by simp)⟩⟩
+  precomp := fun e (he : IsIso e) f ⟨_, _, f', hf', ⟨iso⟩⟩ => ⟨_, _, f', hf',
+      ⟨Arrow.isoMk (asIso iso.hom.left ≪≫ asIso (inv e)) (asIso iso.hom.right) (by simp)⟩⟩
+  postcomp := fun e (he : IsIso e) f ⟨_, _, f', hf', ⟨iso⟩⟩ => ⟨_, _, f', hf',
+      ⟨Arrow.isoMk (asIso iso.hom.left) (asIso iso.hom.right ≪≫ asIso e) (by simp)⟩⟩
 
 lemma monotone_isoClosure : Monotone (isoClosure (C := C)) := by
   intro P Q h X Y f ⟨X', Y', f', hf', ⟨e⟩⟩
@@ -130,11 +188,11 @@ lemma monotone_isoClosure : Monotone (isoClosure (C := C)) := by
 
 theorem cancel_left_of_respectsIso (P : MorphismProperty C) [hP : RespectsIso P] {X Y Z : C}
     (f : X ⟶ Y) (g : Y ⟶ Z) [IsIso f] : P (f ≫ g) ↔ P g :=
-  ⟨fun h => by simpa using hP.1 (asIso f).symm (f ≫ g) h, hP.1 (asIso f) g⟩
+  ⟨fun h => by simpa using hP.precomp (inv f) (f ≫ g) h, hP.precomp f g⟩
 
 theorem cancel_right_of_respectsIso (P : MorphismProperty C) [hP : RespectsIso P] {X Y Z : C}
     (f : X ⟶ Y) (g : Y ⟶ Z) [IsIso g] : P (f ≫ g) ↔ P f :=
-  ⟨fun h => by simpa using hP.2 (asIso g).symm (f ≫ g) h, hP.2 (asIso g) f⟩
+  ⟨fun h => by simpa using hP.postcomp (inv g) (f ≫ g) h, hP.postcomp g f⟩
 
 theorem arrow_iso_iff (P : MorphismProperty C) [RespectsIso P] {f g : Arrow C}
     (e : f ≅ g) : P f.hom ↔ P g.hom := by
@@ -146,16 +204,13 @@ theorem arrow_mk_iso_iff (P : MorphismProperty C) [RespectsIso P] {W X Y Z : C}
   P.arrow_iso_iff e
 
 theorem RespectsIso.of_respects_arrow_iso (P : MorphismProperty C)
-    (hP : ∀ (f g : Arrow C) (_ : f ≅ g) (_ : P f.hom), P g.hom) : RespectsIso P := by
-  constructor
-  · intro X Y Z e f hf
-    refine hP (Arrow.mk f) (Arrow.mk (e.hom ≫ f)) (Arrow.isoMk e.symm (Iso.refl _) ?_) hf
-    dsimp
-    simp only [Iso.inv_hom_id_assoc, Category.comp_id]
-  · intro X Y Z e f hf
-    refine hP (Arrow.mk f) (Arrow.mk (f ≫ e.hom)) (Arrow.isoMk (Iso.refl _) e ?_) hf
-    dsimp
-    simp only [Category.id_comp]
+    (hP : ∀ (f g : Arrow C) (_ : f ≅ g) (_ : P f.hom), P g.hom) : RespectsIso P where
+  precomp {X Y Z} e (he : IsIso e) f hf := by
+    refine hP (Arrow.mk f) (Arrow.mk (e ≫ f)) (Arrow.isoMk (asIso (inv e)) (Iso.refl _) ?_) hf
+    simp
+  postcomp {X Y Z} e (he : IsIso e) f hf := by
+    refine hP (Arrow.mk f) (Arrow.mk (f ≫ e)) (Arrow.isoMk (Iso.refl _) (asIso e) ?_) hf
+    simp
 
 lemma isoClosure_eq_iff (P : MorphismProperty C) :
     P.isoClosure = P ↔ P.RespectsIso := by
@@ -227,12 +282,11 @@ lemma map_map (P : MorphismProperty C) (F : C ⥤ D) {E : Type*} [Category E] (G
     exact map_mem_map _ _ _ (map_mem_map _ _ _ hf)
 
 instance RespectsIso.inverseImage (P : MorphismProperty D) [RespectsIso P] (F : C ⥤ D) :
-    RespectsIso (P.inverseImage F) := by
-  constructor
-  all_goals
-    intro X Y Z e f hf
-    simpa [MorphismProperty.inverseImage, cancel_left_of_respectsIso,
-      cancel_right_of_respectsIso] using hf
+    RespectsIso (P.inverseImage F) where
+  precomp {X Y Z} e (he : IsIso e) f hf := by
+    simpa [MorphismProperty.inverseImage, cancel_left_of_respectsIso] using hf
+  postcomp {X Y Z} e (he : IsIso e) f hf := by
+    simpa [MorphismProperty.inverseImage, cancel_right_of_respectsIso] using hf
 
 lemma map_eq_of_iso (P : MorphismProperty C) {F G : C ⥤ D} (e : F ≅ G) :
     P.map F = P.map G := by
@@ -275,17 +329,7 @@ lemma inverseImage_map_eq_of_isEquivalence
   erw [((P.map F).inverseImage_equivalence_inverse_eq_map_functor (F.asEquivalence)), map_map,
     P.map_eq_of_iso F.asEquivalence.unitIso.symm, map_id]
 
-
-variable (C)
-
-/-- The `MorphismProperty C` satisfied by isomorphisms in `C`. -/
-def isomorphisms : MorphismProperty C := fun _ _ f => IsIso f
-
-/-- The `MorphismProperty C` satisfied by monomorphisms in `C`. -/
-def monomorphisms : MorphismProperty C := fun _ _ f => Mono f
-
-/-- The `MorphismProperty C` satisfied by epimorphisms in `C`. -/
-def epimorphisms : MorphismProperty C := fun _ _ f => Epi f
+end
 
 section
 
@@ -313,21 +357,21 @@ theorem epimorphisms.infer_property [hf : Epi f] : (epimorphisms C) f :=
 end
 
 instance RespectsIso.monomorphisms : RespectsIso (monomorphisms C) := by
-  constructor <;>
+  apply RespectsIso.mk <;>
     · intro X Y Z e f
       simp only [monomorphisms.iff]
       intro
       apply mono_comp
 
 instance RespectsIso.epimorphisms : RespectsIso (epimorphisms C) := by
-  constructor <;>
+  apply RespectsIso.mk <;>
     · intro X Y Z e f
       simp only [epimorphisms.iff]
       intro
       apply epi_comp
 
 instance RespectsIso.isomorphisms : RespectsIso (isomorphisms C) := by
-  constructor <;>
+  apply RespectsIso.mk <;>
     · intro X Y Z e f
       simp only [isomorphisms.iff]
       intro

--- a/Mathlib/CategoryTheory/MorphismProperty/Basic.lean
+++ b/Mathlib/CategoryTheory/MorphismProperty/Basic.lean
@@ -143,9 +143,11 @@ section
 
 variable {C}
 
+/-- `P` respects isomorphisms, if it respects the morphism property `isomorphisms C`, i.e.
+it is stable under pre- and postcomposition with isomorphisms. -/
 abbrev RespectsIso (P : MorphismProperty C) : Prop := P.Respects (isomorphisms C)
 
-def RespectsIso.mk (P : MorphismProperty C)
+lemma RespectsIso.mk (P : MorphismProperty C)
     (hprecomp : ∀ {X Y Z : C} (e : X ≅ Y) (f : Y ⟶ Z) (_ : P f), P (e.hom ≫ f))
     (hpostcomp : ∀ {X Y Z : C} (e : Y ≅ Z) (f : X ⟶ Y) (_ : P f), P (f ≫ e.hom)) :
     P.RespectsIso where

--- a/Mathlib/CategoryTheory/MorphismProperty/Composition.lean
+++ b/Mathlib/CategoryTheory/MorphismProperty/Composition.lean
@@ -91,9 +91,9 @@ theorem StableUnderInverse.unop {P : MorphismProperty Cᵒᵖ} (h : StableUnderI
 
 theorem respectsIso_of_isStableUnderComposition {P : MorphismProperty C}
     [P.IsStableUnderComposition] (hP : isomorphisms C ≤ P) :
-    RespectsIso P :=
-  ⟨fun _ _ hf => P.comp_mem _ _ (hP _ (isomorphisms.infer_property _)) hf,
-    fun _ _ hf => P.comp_mem _ _ hf (hP _ (isomorphisms.infer_property _))⟩
+    RespectsIso P := RespectsIso.mk _
+  (fun _ _ hf => P.comp_mem _ _ (hP _ (isomorphisms.infer_property _)) hf)
+    (fun _ _ hf => P.comp_mem _ _ hf (hP _ (isomorphisms.infer_property _)))
 
 instance IsStableUnderComposition.inverseImage {P : MorphismProperty D} [P.IsStableUnderComposition]
     (F : C ⥤ D) : (P.inverseImage F).IsStableUnderComposition where

--- a/Mathlib/CategoryTheory/MorphismProperty/Limits.lean
+++ b/Mathlib/CategoryTheory/MorphismProperty/Limits.lean
@@ -225,7 +225,7 @@ theorem diagonal_iff {X Y : C} {f : X ⟶ Y} : P.diagonal f ↔ P (pullback.diag
   Iff.rfl
 
 instance RespectsIso.diagonal [P.RespectsIso] : P.diagonal.RespectsIso := by
-  constructor
+  apply RespectsIso.mk
   · introv H
     rwa [diagonal_iff, pullback.diagonal_comp, P.cancel_left_of_respectsIso,
       P.cancel_left_of_respectsIso, ← P.cancel_right_of_respectsIso _
@@ -260,7 +260,7 @@ def universally (P : MorphismProperty C) : MorphismProperty C := fun X Y f =>
   ∀ ⦃X' Y' : C⦄ (i₁ : X' ⟶ X) (i₂ : Y' ⟶ Y) (f' : X' ⟶ Y') (_ : IsPullback f' i₁ i₂ f), P f'
 
 instance universally_respectsIso (P : MorphismProperty C) : P.universally.RespectsIso := by
-  constructor
+  apply RespectsIso.mk
   · intro X Y Z e f hf X' Z' i₁ i₂ f' H
     have : IsPullback (𝟙 _) (i₁ ≫ e.hom) i₁ e.inv :=
       IsPullback.of_horiz_isIso

--- a/Mathlib/CategoryTheory/Triangulated/Subcategory.lean
+++ b/Mathlib/CategoryTheory/Triangulated/Subcategory.lean
@@ -152,16 +152,16 @@ lemma isoClosure_W : S.isoClosure.W = S.W := by
     exact ⟨Z, g, h, mem, le_isoClosure _ _ hZ⟩
 
 instance respectsIso_W : S.W.RespectsIso where
-  precomp := by
-    rintro X' X Y e f ⟨Z, g, h, mem, mem'⟩
-    refine ⟨Z, g, h ≫ e.inv⟦(1 : ℤ)⟧', isomorphic_distinguished _ mem _ ?_, mem'⟩
-    refine Triangle.isoMk _ _ e (Iso.refl _) (Iso.refl _) (by aesop_cat) (by aesop_cat) ?_
+  precomp {X' X Y} e (he : IsIso e) := by
+    rintro f ⟨Z, g, h, mem, mem'⟩
+    refine ⟨Z, g, h ≫ inv e⟦(1 : ℤ)⟧', isomorphic_distinguished _ mem _ ?_, mem'⟩
+    refine Triangle.isoMk _ _ (asIso e) (Iso.refl _) (Iso.refl _) (by aesop_cat) (by aesop_cat) ?_
     dsimp
-    simp only [assoc, ← Functor.map_comp, e.inv_hom_id, Functor.map_id, comp_id, id_comp]
-  postcomp := by
-    rintro X Y Y' e f ⟨Z, g, h, mem, mem'⟩
-    refine ⟨Z, e.inv ≫ g, h, isomorphic_distinguished _ mem _ ?_, mem'⟩
-    exact Triangle.isoMk _ _ (Iso.refl _) e.symm (Iso.refl _)
+    simp only [Functor.map_inv, assoc, IsIso.inv_hom_id, comp_id, id_comp]
+  postcomp {X Y Y'} e (he : IsIso e) := by
+    rintro f ⟨Z, g, h, mem, mem'⟩
+    refine ⟨Z, inv e ≫ g, h, isomorphic_distinguished _ mem _ ?_, mem'⟩
+    exact Triangle.isoMk _ _ (Iso.refl _) (asIso e).symm (Iso.refl _)
 
 instance : S.W.ContainsIdentities := by
   rw [← isoClosure_W]

--- a/Mathlib/RingTheory/RingHomProperties.lean
+++ b/Mathlib/RingTheory/RingHomProperties.lean
@@ -179,15 +179,15 @@ variable {P}
 
 lemma toMorphismProperty_respectsIso_iff :
     RespectsIso P ↔ (toMorphismProperty P).RespectsIso := by
-  refine ⟨fun h ↦ ⟨?_, ?_⟩, fun h ↦ ⟨?_, ?_⟩⟩
+  refine ⟨fun h ↦ MorphismProperty.RespectsIso.mk _ ?_ ?_, fun h ↦ ⟨?_, ?_⟩⟩
   · intro X Y Z e f hf
     exact h.right f e.commRingCatIsoToRingEquiv hf
   · intro X Y Z e f hf
     exact h.left f e.commRingCatIsoToRingEquiv hf
+  · intro X Y Z _ _ _ f e hf
+    exact h.postcomp e.toCommRingCatIso.hom (CommRingCat.ofHom f) hf
   · intro X Y Z _ _ _ f e
-    exact h.postcomp e.toCommRingCatIso (CommRingCat.ofHom f)
-  · intro X Y Z _ _ _ f e
-    exact h.precomp e.toCommRingCatIso (CommRingCat.ofHom f)
+    exact h.precomp e.toCommRingCatIso.hom (CommRingCat.ofHom f)
 
 end ToMorphismProperty
 


### PR DESCRIPTION
This PR introduces new meta properties for morphism properties: If `P` and `Q` are morphism properties, then `P.RespectsLeft Q` if `P` respects `Q` on the left, i.e. if `P f` implies `P (i ≫ f)` whenever `i` satisfies `Q`. Analogously, `P.RespectsRight Q` if `P` respects `Q` on the right. Finally, `P.Respects Q` if `P` respects `Q` both on the left and on the right.

The current definition of `RespectsIso P` is now an abbreviation for `P.Respects (isomorphisms C)`.

Note that `P.Respects P` is equivalent to `StableUnderComposition P`, but the latter definition was not changed.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->
The aim of this generalization is to avoid `StableUnderComposition` assumptions in the algebraic geometry API and replace those by suitable `P.Respects(Left/Right) IsOpenImmersion`.

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
