### PR TITLE
[Merged by Bors] - feat: derivative of absolute value

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -980,6 +980,7 @@ import Mathlib.Analysis.Calculus.ContDiff.FTaylorSeries
 import Mathlib.Analysis.Calculus.ContDiff.FiniteDimension
 import Mathlib.Analysis.Calculus.ContDiff.RCLike
 import Mathlib.Analysis.Calculus.Darboux
+import Mathlib.Analysis.Calculus.Deriv.Abs
 import Mathlib.Analysis.Calculus.Deriv.Add
 import Mathlib.Analysis.Calculus.Deriv.AffineMap
 import Mathlib.Analysis.Calculus.Deriv.Basic

--- a/Mathlib/Analysis/Calculus/Deriv/Abs.lean
+++ b/Mathlib/Analysis/Calculus/Deriv/Abs.lean
@@ -1,0 +1,60 @@
+import Mathlib.Analysis.Calculus.ContDiff.Basic
+import Mathlib.Analysis.Calculus.Deriv.Add
+
+open Filter Real Set
+
+variable {E : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E]
+variable {n : ℕ∞} {f g : E → ℝ} {s : Set E} {x : E}
+
+theorem contDiffAt_abs {x : ℝ} (hx : x ≠ 0) : ContDiffAt ℝ n (|·|) x := by
+  obtain hx | hx := hx.lt_or_lt
+  · apply contDiff_neg.contDiffAt.congr_of_eventuallyEq
+    exact EqOn.eventuallyEq_of_mem (fun y hy ↦ abs_of_neg (mem_Iio.1 hy)) (Iio_mem_nhds hx)
+  · apply contDiff_id.contDiffAt.congr_of_eventuallyEq
+    exact EqOn.eventuallyEq_of_mem (fun y hy ↦ abs_of_pos (mem_Iio.1 hy)) (Ioi_mem_nhds hx)
+
+theorem ContDiffAt.abs (hf : ContDiffAt ℝ n f x) (h₀ : f x ≠ 0) :
+    ContDiffAt ℝ n (fun x ↦ |f x|) x :=
+  (contDiffAt_abs h₀).comp x hf
+
+theorem ContDiffWithinAt.abs (hf : ContDiffWithinAt ℝ n f s x) (h₀ : f x ≠ 0) :
+    ContDiffWithinAt ℝ n (fun y ↦ |f y|) s x :=
+  (contDiffAt_abs h₀).comp_contDiffWithinAt x hf
+
+theorem ContDiffOn.abs (hf : ContDiffOn ℝ n f s) (h₀ : ∀ x ∈ s, f x ≠ 0) :
+    ContDiffOn ℝ n (fun y ↦ |f y|) s := fun x hx ↦ (hf x hx).abs (h₀ x hx)
+
+theorem ContDiff.abs (hf : ContDiff ℝ n f) (h₀ : ∀ x, f x ≠ 0) : ContDiff ℝ n fun y ↦ |f y| :=
+  contDiff_iff_contDiffAt.2 fun x ↦ hf.contDiffAt.abs (h₀ x)
+
+theorem not_differentiableAt_abs_zero : ¬ DifferentiableAt ℝ (abs : ℝ → ℝ) 0 := by
+  intro h
+  have h₁ : deriv abs (0 : ℝ) = 1 :=
+    (uniqueDiffOn_Ici _ _ Set.left_mem_Ici).eq_deriv _ h.hasDerivAt.hasDerivWithinAt <|
+      (hasDerivWithinAt_id _ _).congr_of_mem (fun _ h ↦ abs_of_nonneg h) Set.left_mem_Ici
+  have h₂ : deriv abs (0 : ℝ) = -1 :=
+    (uniqueDiffOn_Iic _ _ Set.right_mem_Iic).eq_deriv _ h.hasDerivAt.hasDerivWithinAt <|
+      (hasDerivWithinAt_neg _ _).congr_of_mem (fun _ h ↦ abs_of_nonpos h) Set.right_mem_Iic
+  linarith
+
+theorem deriv_abs (x : ℝ) : deriv (|·|) x = SignType.sign x := by
+  obtain hx | rfl | hx := lt_trichotomy x 0
+  · rw [EventuallyEq.deriv_eq (f := fun x ↦ -x)]
+    · simp [hx]
+    · rw [EventuallyEq, eventually_iff_exists_mem]
+      exact ⟨Iic 0, Iic_mem_nhds hx, by simp [hx]⟩
+  · rw [deriv_zero_of_not_differentiableAt not_differentiableAt_abs_zero]
+    simp
+  · rw [EventuallyEq.deriv_eq (f := id)]
+    · simp [hx]
+    · rw [EventuallyEq, eventually_iff_exists_mem]
+      exact ⟨Ici 0, Ici_mem_nhds hx, by simp [hx]⟩
+
+theorem hasDerivAt_abs {x : ℝ} (hx : x ≠ 0) : HasDerivAt abs (SignType.sign x : ℝ) x := by
+  convert (differentiableAt_of_deriv_ne_zero ?_).hasDerivAt
+  · rw [deriv_abs]
+  · obtain hx | hx := hx.lt_or_lt
+    all_goals rw [deriv_abs]; simp [hx]
+
+theorem differentiableAt_abs {x : ℝ} (hx : x ≠ 0) : DifferentiableAt ℝ abs x :=
+  (hasDerivAt_abs hx).differentiableAt

--- a/Mathlib/Analysis/Calculus/Deriv/Abs.lean
+++ b/Mathlib/Analysis/Calculus/Deriv/Abs.lean
@@ -1,31 +1,130 @@
-import Mathlib.Analysis.Calculus.ContDiff.Basic
 import Mathlib.Analysis.Calculus.Deriv.Add
+import Mathlib.Analysis.InnerProductSpace.Calculus
 
 open Filter Real Set
 
 variable {E : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E]
 variable {n : ℕ∞} {f g : E → ℝ} {s : Set E} {x : E}
 
-theorem contDiffAt_abs {x : ℝ} (hx : x ≠ 0) : ContDiffAt ℝ n (|·|) x := by
-  obtain hx | hx := hx.lt_or_lt
-  · apply contDiff_neg.contDiffAt.congr_of_eventuallyEq
-    exact EqOn.eventuallyEq_of_mem (fun y hy ↦ abs_of_neg (mem_Iio.1 hy)) (Iio_mem_nhds hx)
-  · apply contDiff_id.contDiffAt.congr_of_eventuallyEq
-    exact EqOn.eventuallyEq_of_mem (fun y hy ↦ abs_of_pos (mem_Iio.1 hy)) (Ioi_mem_nhds hx)
+theorem contDiffAt_abs {x : ℝ} (hx : x ≠ 0) : ContDiffAt ℝ n (|·|) x := contDiffAt_norm ℝ hx
 
 theorem ContDiffAt.abs (hf : ContDiffAt ℝ n f x) (h₀ : f x ≠ 0) :
-    ContDiffAt ℝ n (fun x ↦ |f x|) x :=
-  (contDiffAt_abs h₀).comp x hf
+    ContDiffAt ℝ n (fun x ↦ |f x|) x := hf.norm ℝ h₀
+
+theorem contDiffWithinAt_abs {x : ℝ} (hx : x ≠ 0) (s : Set ℝ) :
+    ContDiffWithinAt ℝ n (|·|) s x := (contDiffAt_abs hx).contDiffWithinAt
 
 theorem ContDiffWithinAt.abs (hf : ContDiffWithinAt ℝ n f s x) (h₀ : f x ≠ 0) :
     ContDiffWithinAt ℝ n (fun y ↦ |f y|) s x :=
   (contDiffAt_abs h₀).comp_contDiffWithinAt x hf
+
+theorem contDiffOn_abs {s : Set ℝ} (hs : ∀ x ∈ s, x ≠ 0) :
+    ContDiffOn ℝ n (|·|) s := fun x hx ↦ contDiffWithinAt_abs (hs x hx) s
 
 theorem ContDiffOn.abs (hf : ContDiffOn ℝ n f s) (h₀ : ∀ x ∈ s, f x ≠ 0) :
     ContDiffOn ℝ n (fun y ↦ |f y|) s := fun x hx ↦ (hf x hx).abs (h₀ x hx)
 
 theorem ContDiff.abs (hf : ContDiff ℝ n f) (h₀ : ∀ x, f x ≠ 0) : ContDiff ℝ n fun y ↦ |f y| :=
   contDiff_iff_contDiffAt.2 fun x ↦ hf.contDiffAt.abs (h₀ x)
+
+theorem hasStrictDerivAt_abs_neg {x : ℝ} (hx : x < 0) :
+    HasStrictDerivAt (|·|) (-1) x :=
+  (hasStrictDerivAt_neg x).congr_of_eventuallyEq <|
+    EqOn.eventuallyEq_of_mem (fun _ hy ↦ (abs_of_neg (mem_Iio.1 hy)).symm) (Iio_mem_nhds hx)
+
+theorem hasDerivAt_abs_neg {x : ℝ} (hx : x < 0) :
+    HasDerivAt (|·|) (-1) x := (hasStrictDerivAt_abs_neg hx).hasDerivAt
+
+theorem hasStrictDerivAt_abs_pos {x : ℝ} (hx : 0 < x) :
+    HasStrictDerivAt (|·|) 1 x :=
+  (hasStrictDerivAt_id x).congr_of_eventuallyEq <|
+    EqOn.eventuallyEq_of_mem (fun _ hy ↦ (abs_of_pos (mem_Iio.1 hy)).symm) (Ioi_mem_nhds hx)
+
+theorem hasDerivAt_abs_pos {x : ℝ} (hx : 0 < x) :
+    HasDerivAt (|·|) 1 x := (hasStrictDerivAt_abs_pos hx).hasDerivAt
+
+theorem hasStrictDerivAt_abs {x : ℝ} (hx : x ≠ 0) :
+    HasStrictDerivAt (|·|) (SignType.sign x : ℝ) x := by
+  obtain hx | hx := hx.lt_or_lt
+  · simpa [hx] using hasStrictDerivAt_abs_neg hx
+  · simpa [hx] using hasStrictDerivAt_abs_pos hx
+
+theorem hasDerivAt_abs {x : ℝ} (hx : x ≠ 0) :
+    HasDerivAt (|·|) (SignType.sign x : ℝ) x := (hasStrictDerivAt_abs hx).hasDerivAt
+
+theorem HasStrictFDerivAt.abs_of_neg {f' : E →L[ℝ] ℝ} (hf : HasStrictFDerivAt f f' x)
+    (h₀ : f x < 0) : HasStrictFDerivAt (fun x ↦ |f x|) (-f') x := by
+  convert (hasStrictDerivAt_abs_neg h₀).hasStrictFDerivAt.comp x hf using 1
+  ext y
+  simp
+
+theorem HasFDerivAt.abs_of_neg {f' : E →L[ℝ] ℝ} (hf : HasFDerivAt f f' x)
+    (h₀ : f x < 0) : HasFDerivAt (fun x ↦ |f x|) (-f') x := by
+  convert (hasDerivAt_abs_neg h₀).hasFDerivAt.comp x hf using 1
+  ext y
+  simp
+
+theorem HasStrictFDerivAt.abs_of_pos {f' : E →L[ℝ] ℝ} (hf : HasStrictFDerivAt f f' x)
+    (h₀ : 0 < f x) : HasStrictFDerivAt (fun x ↦ |f x|) f' x := by
+  convert (hasStrictDerivAt_abs_pos h₀).hasStrictFDerivAt.comp x hf using 1
+  ext y
+  simp
+
+theorem HasFDerivAt.abs_of_pos {f' : E →L[ℝ] ℝ} (hf : HasFDerivAt f f' x)
+    (h₀ : 0 < f x) : HasFDerivAt (fun x ↦ |f x|) f' x := by
+  convert (hasDerivAt_abs_pos h₀).hasFDerivAt.comp x hf using 1
+  ext y
+  simp
+
+theorem HasStrictFDerivAt.abs {f' : E →L[ℝ] ℝ} (hf : HasStrictFDerivAt f f' x)
+    (h₀ : f x ≠ 0) : HasStrictFDerivAt (fun x ↦ |f x|) ((SignType.sign (f x) : ℝ) • f') x := by
+  convert (hasStrictDerivAt_abs h₀).hasStrictFDerivAt.comp x hf using 1
+  ext y
+  simp [mul_comm]
+
+theorem HasFDerivAt.abs {f' : E →L[ℝ] ℝ} (hf : HasFDerivAt f f' x)
+    (h₀ : f x ≠ 0) : HasFDerivAt (fun x ↦ |f x|) ((SignType.sign (f x) : ℝ) • f') x := by
+  convert (hasDerivAt_abs h₀).hasFDerivAt.comp x hf using 1
+  ext y
+  simp [mul_comm]
+
+theorem hasDerivWithinAt_abs_neg (s : Set ℝ) {x : ℝ} (hx : x < 0) :
+    HasDerivWithinAt (|·|) (-1) s x := (hasDerivAt_abs_neg hx).hasDerivWithinAt
+
+theorem hasDerivWithinAt_abs_pos (s : Set ℝ) {x : ℝ} (hx : 0 < x) :
+    HasDerivWithinAt (|·|) 1 s x := (hasDerivAt_abs_pos hx).hasDerivWithinAt
+
+theorem hasDerivWithinAt_abs (s : Set ℝ) {x : ℝ} (hx : x ≠ 0) :
+    HasDerivWithinAt (|·|) (SignType.sign x : ℝ) s x := (hasDerivAt_abs hx).hasDerivWithinAt
+
+theorem hasDerivWithinAt_abs_pos {x : ℝ} (hx : 0 < x) :
+    HasDerivWithinAt (|·|) 1 x :=
+  (hasDerivWithinAt_id x).congr_of_eventuallyEq <|
+    EqOn.eventuallyEq_of_mem (fun _ hy ↦ (abs_of_pos (mem_Iio.1 hy)).symm) (Ioi_mem_nhds hx)
+
+theorem hasDerivWithinAt_abs {x : ℝ} (hx : x ≠ 0) :
+    HasDerivWithinAt (|·|) (SignType.sign x : ℝ) x := by
+  obtain hx | hx := hx.lt_or_lt
+  · simpa [hx] using hasDerivWithinAt_abs_neg hx
+  · simpa [hx] using hasDerivWithinAt_abs_pos hx
+
+theorem hasFDerivWithinAt.abs_of_neg {f' : E →L[ℝ] ℝ} (hf : hasFDerivWithinAt f f' x)
+    (h₀ : f x < 0) : hasFDerivWithinAt (fun x ↦ |f x|) (-f') x := by
+  convert (hasStrictDerivAt_abs_neg h₀).hasFDerivWithinAt.comp x hf using 1
+  ext y
+  simp
+
+theorem hasFDerivWithinAt.abs_of_pos {f' : E →L[ℝ] ℝ} (hf : hasFDerivWithinAt f f' x)
+    (h₀ : 0 < f x) : hasFDerivWithinAt (fun x ↦ |f x|) f' x := by
+  convert (hasStrictDerivAt_abs_pos h₀).hasFDerivWithinAt.comp x hf using 1
+  ext y
+  simp
+
+theorem hasFDerivWithinAt.abs {f' : E →L[ℝ] ℝ} (hf : hasFDerivWithinAt f f' x)
+    (h₀ : f x ≠ 0) : hasFDerivWithinAt (fun x ↦ |f x|) ((SignType.sign (f x) : ℝ) • f') x := by
+  convert (hasStrictDerivAt_abs h₀).hasFDerivWithinAt.comp x hf using 1
+  ext y
+  simp [mul_comm]
 
 theorem not_differentiableAt_abs_zero : ¬ DifferentiableAt ℝ (abs : ℝ → ℝ) 0 := by
   intro h

--- a/Mathlib/Analysis/Calculus/Deriv/Abs.lean
+++ b/Mathlib/Analysis/Calculus/Deriv/Abs.lean
@@ -187,8 +187,14 @@ theorem not_differentiableAt_abs_zero : ¬ DifferentiableAt ℝ (abs : ℝ → �
       (hasDerivWithinAt_neg _ _).congr_of_mem (fun _ h ↦ abs_of_nonpos h) Set.right_mem_Iic
   linarith
 
+theorem deriv_abs_neg {x : ℝ} (hx : x < 0) : deriv (|·|) x = -1 := (hasDerivAt_abs_neg hx).deriv
+
+theorem deriv_abs_pos {x : ℝ} (hx : 0 < x) : deriv (|·|) x = 1 := (hasDerivAt_abs_pos hx).deriv
+
+theorem deriv_abs_zero : deriv (|·|) (0 : ℝ) = 0 :=
+    deriv_zero_of_not_differentiableAt not_differentiableAt_abs_zero
+
 theorem deriv_abs (x : ℝ) : deriv (|·|) x = SignType.sign x := by
   obtain rfl | hx := eq_or_ne x 0
-  · rw [deriv_zero_of_not_differentiableAt not_differentiableAt_abs_zero]
-    simp
+  · simpa using deriv_abs_zero
   · simpa [hx] using (hasDerivAt_abs hx).deriv

--- a/Mathlib/Analysis/Calculus/Deriv/Abs.lean
+++ b/Mathlib/Analysis/Calculus/Deriv/Abs.lean
@@ -192,7 +192,7 @@ theorem deriv_abs_neg {x : ℝ} (hx : x < 0) : deriv (|·|) x = -1 := (hasDerivA
 theorem deriv_abs_pos {x : ℝ} (hx : 0 < x) : deriv (|·|) x = 1 := (hasDerivAt_abs_pos hx).deriv
 
 theorem deriv_abs_zero : deriv (|·|) (0 : ℝ) = 0 :=
-    deriv_zero_of_not_differentiableAt not_differentiableAt_abs_zero
+  deriv_zero_of_not_differentiableAt not_differentiableAt_abs_zero
 
 theorem deriv_abs (x : ℝ) : deriv (|·|) x = SignType.sign x := by
   obtain rfl | hx := eq_or_ne x 0

--- a/Mathlib/Analysis/Calculus/Deriv/Abs.lean
+++ b/Mathlib/Analysis/Calculus/Deriv/Abs.lean
@@ -1,10 +1,27 @@
+/-
+Copyright (c) 2024 Etienne Marion. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Etienne Marion
+-/
 import Mathlib.Analysis.Calculus.Deriv.Add
 import Mathlib.Analysis.InnerProductSpace.Calculus
+
+/-!
+# Derivative of the absolute value
+
+This file compiles basic derivability properties of the absolute value, and is largely inspired
+from `Mathlib.Analysis.InnerProductSpace.Calculus`, which is the analoguous file for norms derived
+from an inner product space.
+
+## Tags
+
+absolute value, derivative
+-/
 
 open Filter Real Set
 
 variable {E : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E]
-variable {n : ℕ∞} {f g : E → ℝ} {s : Set E} {x : E}
+variable {n : ℕ∞} {f g : E → ℝ} {f' : E →L[ℝ] ℝ} {s : Set E} {x : E}
 
 theorem contDiffAt_abs {x : ℝ} (hx : x ≠ 0) : ContDiffAt ℝ n (|·|) x := contDiffAt_norm ℝ hx
 
@@ -52,37 +69,37 @@ theorem hasStrictDerivAt_abs {x : ℝ} (hx : x ≠ 0) :
 theorem hasDerivAt_abs {x : ℝ} (hx : x ≠ 0) :
     HasDerivAt (|·|) (SignType.sign x : ℝ) x := (hasStrictDerivAt_abs hx).hasDerivAt
 
-theorem HasStrictFDerivAt.abs_of_neg {f' : E →L[ℝ] ℝ} (hf : HasStrictFDerivAt f f' x)
+theorem HasStrictFDerivAt.abs_of_neg (hf : HasStrictFDerivAt f f' x)
     (h₀ : f x < 0) : HasStrictFDerivAt (fun x ↦ |f x|) (-f') x := by
   convert (hasStrictDerivAt_abs_neg h₀).hasStrictFDerivAt.comp x hf using 1
   ext y
   simp
 
-theorem HasFDerivAt.abs_of_neg {f' : E →L[ℝ] ℝ} (hf : HasFDerivAt f f' x)
+theorem HasFDerivAt.abs_of_neg (hf : HasFDerivAt f f' x)
     (h₀ : f x < 0) : HasFDerivAt (fun x ↦ |f x|) (-f') x := by
   convert (hasDerivAt_abs_neg h₀).hasFDerivAt.comp x hf using 1
   ext y
   simp
 
-theorem HasStrictFDerivAt.abs_of_pos {f' : E →L[ℝ] ℝ} (hf : HasStrictFDerivAt f f' x)
+theorem HasStrictFDerivAt.abs_of_pos (hf : HasStrictFDerivAt f f' x)
     (h₀ : 0 < f x) : HasStrictFDerivAt (fun x ↦ |f x|) f' x := by
   convert (hasStrictDerivAt_abs_pos h₀).hasStrictFDerivAt.comp x hf using 1
   ext y
   simp
 
-theorem HasFDerivAt.abs_of_pos {f' : E →L[ℝ] ℝ} (hf : HasFDerivAt f f' x)
+theorem HasFDerivAt.abs_of_pos (hf : HasFDerivAt f f' x)
     (h₀ : 0 < f x) : HasFDerivAt (fun x ↦ |f x|) f' x := by
   convert (hasDerivAt_abs_pos h₀).hasFDerivAt.comp x hf using 1
   ext y
   simp
 
-theorem HasStrictFDerivAt.abs {f' : E →L[ℝ] ℝ} (hf : HasStrictFDerivAt f f' x)
+theorem HasStrictFDerivAt.abs (hf : HasStrictFDerivAt f f' x)
     (h₀ : f x ≠ 0) : HasStrictFDerivAt (fun x ↦ |f x|) ((SignType.sign (f x) : ℝ) • f') x := by
   convert (hasStrictDerivAt_abs h₀).hasStrictFDerivAt.comp x hf using 1
   ext y
   simp [mul_comm]
 
-theorem HasFDerivAt.abs {f' : E →L[ℝ] ℝ} (hf : HasFDerivAt f f' x)
+theorem HasFDerivAt.abs (hf : HasFDerivAt f f' x)
     (h₀ : f x ≠ 0) : HasFDerivAt (fun x ↦ |f x|) ((SignType.sign (f x) : ℝ) • f') x := by
   convert (hasDerivAt_abs h₀).hasFDerivAt.comp x hf using 1
   ext y
@@ -97,34 +114,68 @@ theorem hasDerivWithinAt_abs_pos (s : Set ℝ) {x : ℝ} (hx : 0 < x) :
 theorem hasDerivWithinAt_abs (s : Set ℝ) {x : ℝ} (hx : x ≠ 0) :
     HasDerivWithinAt (|·|) (SignType.sign x : ℝ) s x := (hasDerivAt_abs hx).hasDerivWithinAt
 
-theorem hasDerivWithinAt_abs_pos {x : ℝ} (hx : 0 < x) :
-    HasDerivWithinAt (|·|) 1 x :=
-  (hasDerivWithinAt_id x).congr_of_eventuallyEq <|
-    EqOn.eventuallyEq_of_mem (fun _ hy ↦ (abs_of_pos (mem_Iio.1 hy)).symm) (Ioi_mem_nhds hx)
-
-theorem hasDerivWithinAt_abs {x : ℝ} (hx : x ≠ 0) :
-    HasDerivWithinAt (|·|) (SignType.sign x : ℝ) x := by
-  obtain hx | hx := hx.lt_or_lt
-  · simpa [hx] using hasDerivWithinAt_abs_neg hx
-  · simpa [hx] using hasDerivWithinAt_abs_pos hx
-
-theorem hasFDerivWithinAt.abs_of_neg {f' : E →L[ℝ] ℝ} (hf : hasFDerivWithinAt f f' x)
-    (h₀ : f x < 0) : hasFDerivWithinAt (fun x ↦ |f x|) (-f') x := by
-  convert (hasStrictDerivAt_abs_neg h₀).hasFDerivWithinAt.comp x hf using 1
-  ext y
+theorem HasFDerivWithinAt.abs_of_neg (hf : HasFDerivWithinAt f f' s x)
+    (h₀ : f x < 0) : HasFDerivWithinAt (fun x ↦ |f x|) (-f') s x := by
+  convert (hasDerivAt_abs_neg h₀).comp_hasFDerivWithinAt x hf using 1
   simp
 
-theorem hasFDerivWithinAt.abs_of_pos {f' : E →L[ℝ] ℝ} (hf : hasFDerivWithinAt f f' x)
-    (h₀ : 0 < f x) : hasFDerivWithinAt (fun x ↦ |f x|) f' x := by
-  convert (hasStrictDerivAt_abs_pos h₀).hasFDerivWithinAt.comp x hf using 1
-  ext y
+theorem HasFDerivWithinAt.abs_of_pos (hf : HasFDerivWithinAt f f' s x)
+    (h₀ : 0 < f x) : HasFDerivWithinAt (fun x ↦ |f x|) f' s x := by
+  convert (hasDerivAt_abs_pos h₀).comp_hasFDerivWithinAt x hf using 1
   simp
 
-theorem hasFDerivWithinAt.abs {f' : E →L[ℝ] ℝ} (hf : hasFDerivWithinAt f f' x)
-    (h₀ : f x ≠ 0) : hasFDerivWithinAt (fun x ↦ |f x|) ((SignType.sign (f x) : ℝ) • f') x := by
-  convert (hasStrictDerivAt_abs h₀).hasFDerivWithinAt.comp x hf using 1
-  ext y
-  simp [mul_comm]
+theorem HasFDerivWithinAt.abs (hf : HasFDerivWithinAt f f' s x)
+    (h₀ : f x ≠ 0) : HasFDerivWithinAt (fun x ↦ |f x|) ((SignType.sign (f x) : ℝ) • f') s x :=
+  (hasDerivAt_abs h₀).comp_hasFDerivWithinAt x hf
+
+theorem differentiableAt_abs_neg {x : ℝ} (hx : x < 0) :
+    DifferentiableAt ℝ (|·|) x := (hasDerivAt_abs_neg hx).differentiableAt
+
+theorem differentiableAt_abs_pos {x : ℝ} (hx : 0 < x) :
+    DifferentiableAt ℝ (|·|) x := (hasDerivAt_abs_pos hx).differentiableAt
+
+theorem differentiableAt_abs {x : ℝ} (hx : x ≠ 0) :
+    DifferentiableAt ℝ (|·|) x := (hasDerivAt_abs hx).differentiableAt
+
+theorem DifferentiableAt.abs_of_neg (hf : DifferentiableAt ℝ f x) (h₀ : f x < 0) :
+    DifferentiableAt ℝ (fun x ↦ |f x|) x := (differentiableAt_abs_neg h₀).comp x hf
+
+theorem DifferentiableAt.abs_of_pos (hf : DifferentiableAt ℝ f x) (h₀ : 0 < f x) :
+    DifferentiableAt ℝ (fun x ↦ |f x|) x := (differentiableAt_abs_pos h₀).comp x hf
+
+theorem DifferentiableAt.abs (hf : DifferentiableAt ℝ f x) (h₀ : f x ≠ 0) :
+    DifferentiableAt ℝ (fun x ↦ |f x|) x := (differentiableAt_abs h₀).comp x hf
+
+theorem differentiableWithinAt_abs_neg (s : Set ℝ) {x : ℝ} (hx : x < 0) :
+    DifferentiableWithinAt ℝ (|·|) s x := (differentiableAt_abs_neg hx).differentiableWithinAt
+
+theorem differentiableWithinAt_abs_pos (s : Set ℝ) {x : ℝ} (hx : 0 < x) :
+    DifferentiableWithinAt ℝ (|·|) s x := (differentiableAt_abs_pos hx).differentiableWithinAt
+
+theorem differentiableWithinAt_abs (s : Set ℝ) {x : ℝ} (hx : x ≠ 0) :
+    DifferentiableWithinAt ℝ (|·|) s x := (differentiableAt_abs hx).differentiableWithinAt
+
+theorem DifferentiableWithinAt.abs_of_neg (hf : DifferentiableWithinAt ℝ f s x) (h₀ : f x < 0) :
+    DifferentiableWithinAt ℝ (fun x ↦ |f x|) s x :=
+  (differentiableAt_abs_neg h₀).comp_differentiableWithinAt x hf
+
+theorem DifferentiableWithinAt.abs_of_pos (hf : DifferentiableWithinAt ℝ f s x) (h₀ : 0 < f x) :
+    DifferentiableWithinAt ℝ (fun x ↦ |f x|) s x :=
+  (differentiableAt_abs_pos h₀).comp_differentiableWithinAt x hf
+
+theorem DifferentiableWithinAt.abs (hf : DifferentiableWithinAt ℝ f s x) (h₀ : f x ≠ 0) :
+    DifferentiableWithinAt ℝ (fun x ↦ |f x|) s x :=
+  (differentiableAt_abs h₀).comp_differentiableWithinAt x hf
+
+theorem differentiableOn_abs {s : Set ℝ} (hs : ∀ x ∈ s, x ≠ 0) : DifferentiableOn ℝ (|·|) s :=
+  fun x hx ↦ differentiableWithinAt_abs s (hs x hx)
+
+theorem DifferentiableOn.abs (hf : DifferentiableOn ℝ f s) (h₀ : ∀ x ∈ s, f x ≠ 0) :
+    DifferentiableOn ℝ (fun x ↦ |f x|) s :=
+  fun x hx ↦ (hf x hx).abs (h₀ x hx)
+
+theorem Differentiable.abs (hf : Differentiable ℝ f) (h₀ : ∀ x, f x ≠ 0) :
+    Differentiable ℝ (fun x ↦ |f x|) := fun x ↦ (hf x).abs (h₀ x)
 
 theorem not_differentiableAt_abs_zero : ¬ DifferentiableAt ℝ (abs : ℝ → ℝ) 0 := by
   intro h
@@ -137,23 +188,7 @@ theorem not_differentiableAt_abs_zero : ¬ DifferentiableAt ℝ (abs : ℝ → �
   linarith
 
 theorem deriv_abs (x : ℝ) : deriv (|·|) x = SignType.sign x := by
-  obtain hx | rfl | hx := lt_trichotomy x 0
-  · rw [EventuallyEq.deriv_eq (f := fun x ↦ -x)]
-    · simp [hx]
-    · rw [EventuallyEq, eventually_iff_exists_mem]
-      exact ⟨Iic 0, Iic_mem_nhds hx, by simp [hx]⟩
+  obtain rfl | hx := eq_or_ne x 0
   · rw [deriv_zero_of_not_differentiableAt not_differentiableAt_abs_zero]
     simp
-  · rw [EventuallyEq.deriv_eq (f := id)]
-    · simp [hx]
-    · rw [EventuallyEq, eventually_iff_exists_mem]
-      exact ⟨Ici 0, Ici_mem_nhds hx, by simp [hx]⟩
-
-theorem hasDerivAt_abs {x : ℝ} (hx : x ≠ 0) : HasDerivAt abs (SignType.sign x : ℝ) x := by
-  convert (differentiableAt_of_deriv_ne_zero ?_).hasDerivAt
-  · rw [deriv_abs]
-  · obtain hx | hx := hx.lt_or_lt
-    all_goals rw [deriv_abs]; simp [hx]
-
-theorem differentiableAt_abs {x : ℝ} (hx : x ≠ 0) : DifferentiableAt ℝ abs x :=
-  (hasDerivAt_abs hx).differentiableAt
+  · simpa [hx] using (hasDerivAt_abs hx).deriv

--- a/Mathlib/Analysis/Calculus/Deriv/Add.lean
+++ b/Mathlib/Analysis/Calculus/Deriv/Add.lean
@@ -247,44 +247,6 @@ theorem differentiable_neg : Differentiable 𝕜 (Neg.neg : 𝕜 → 𝕜) :=
 theorem differentiableOn_neg : DifferentiableOn 𝕜 (Neg.neg : 𝕜 → 𝕜) s :=
   DifferentiableOn.neg differentiableOn_id
 
-section abs
-
-open Filter
-
-theorem not_differentiableAt_abs_zero : ¬ DifferentiableAt ℝ (abs : ℝ → ℝ) 0 := by
-  intro h
-  have h₁ : deriv abs (0 : ℝ) = 1 :=
-    (uniqueDiffOn_Ici _ _ Set.left_mem_Ici).eq_deriv _ h.hasDerivAt.hasDerivWithinAt <|
-      (hasDerivWithinAt_id _ _).congr_of_mem (fun _ h ↦ abs_of_nonneg h) Set.left_mem_Ici
-  have h₂ : deriv abs (0 : ℝ) = -1 :=
-    (uniqueDiffOn_Iic _ _ Set.right_mem_Iic).eq_deriv _ h.hasDerivAt.hasDerivWithinAt <|
-      (hasDerivWithinAt_neg _ _).congr_of_mem (fun _ h ↦ abs_of_nonpos h) Set.right_mem_Iic
-  linarith
-
-theorem deriv_abs (x : ℝ) : deriv (|·|) x = SignType.sign x := by
-  obtain hx | rfl | hx := lt_trichotomy x 0
-  · rw [EventuallyEq.deriv_eq (f := fun x ↦ -x)]
-    · simp [hx]
-    · rw [EventuallyEq, eventually_iff_exists_mem]
-      exact ⟨Iic 0, Iic_mem_nhds hx, by simp [hx]⟩
-  · rw [deriv_zero_of_not_differentiableAt not_differentiableAt_abs_zero]
-    simp
-  · rw [EventuallyEq.deriv_eq (f := id)]
-    · simp [hx]
-    · rw [EventuallyEq, eventually_iff_exists_mem]
-      exact ⟨Ici 0, Ici_mem_nhds hx, by simp [hx]⟩
-
-theorem hasDerivAt_abs {x : ℝ} (hx : x ≠ 0) : HasDerivAt abs (SignType.sign x : ℝ) x := by
-  convert (differentiableAt_of_deriv_ne_zero ?_).hasDerivAt
-  · rw [deriv_abs]
-  · obtain hx | hx := hx.lt_or_lt
-    all_goals rw [deriv_abs]; simp [hx]
-
-theorem differentiableAt_abs {x : ℝ} (hx : x ≠ 0) : DifferentiableAt ℝ abs x :=
-  (hasDerivAt_abs hx).differentiableAt
-
-end abs
-
 lemma differentiableAt_comp_neg {a : 𝕜} :
     DifferentiableAt 𝕜 (fun x ↦ f (-x)) a ↔ DifferentiableAt 𝕜 f (-a) := by
   refine ⟨fun H ↦ ?_, fun H ↦ H.comp a differentiable_neg.differentiableAt⟩

--- a/Mathlib/Analysis/Calculus/Deriv/Add.lean
+++ b/Mathlib/Analysis/Calculus/Deriv/Add.lean
@@ -247,6 +247,10 @@ theorem differentiable_neg : Differentiable 𝕜 (Neg.neg : 𝕜 → 𝕜) :=
 theorem differentiableOn_neg : DifferentiableOn 𝕜 (Neg.neg : 𝕜 → 𝕜) s :=
   DifferentiableOn.neg differentiableOn_id
 
+section abs
+
+open Filter
+
 theorem not_differentiableAt_abs_zero : ¬ DifferentiableAt ℝ (abs : ℝ → ℝ) 0 := by
   intro h
   have h₁ : deriv abs (0 : ℝ) = 1 :=
@@ -256,6 +260,30 @@ theorem not_differentiableAt_abs_zero : ¬ DifferentiableAt ℝ (abs : ℝ → �
     (uniqueDiffOn_Iic _ _ Set.right_mem_Iic).eq_deriv _ h.hasDerivAt.hasDerivWithinAt <|
       (hasDerivWithinAt_neg _ _).congr_of_mem (fun _ h ↦ abs_of_nonpos h) Set.right_mem_Iic
   linarith
+
+theorem deriv_abs (x : ℝ) : deriv (|·|) x = SignType.sign x := by
+  obtain hx | rfl | hx := lt_trichotomy x 0
+  · rw [EventuallyEq.deriv_eq (f := fun x ↦ -x)]
+    · simp [hx]
+    · rw [EventuallyEq, eventually_iff_exists_mem]
+      exact ⟨Iic 0, Iic_mem_nhds hx, by simp [hx]⟩
+  · rw [deriv_zero_of_not_differentiableAt not_differentiableAt_abs_zero]
+    simp
+  · rw [EventuallyEq.deriv_eq (f := id)]
+    · simp [hx]
+    · rw [EventuallyEq, eventually_iff_exists_mem]
+      exact ⟨Ici 0, Ici_mem_nhds hx, by simp [hx]⟩
+
+theorem hasDerivAt_abs {x : ℝ} (hx : x ≠ 0) : HasDerivAt abs (SignType.sign x : ℝ) x := by
+  convert (differentiableAt_of_deriv_ne_zero ?_).hasDerivAt
+  · rw [deriv_abs]
+  · obtain hx | hx := hx.lt_or_lt
+    all_goals rw [deriv_abs]; simp [hx]
+
+theorem differentiableAt_abs {x : ℝ} (hx : x ≠ 0) : DifferentiableAt ℝ abs x :=
+  (hasDerivAt_abs hx).differentiableAt
+
+end abs
 
 lemma differentiableAt_comp_neg {a : 𝕜} :
     DifferentiableAt 𝕜 (fun x ↦ f (-x)) a ↔ DifferentiableAt 𝕜 f (-a) := by


### PR DESCRIPTION
Compute the derivative of the absolute value: `deriv (|·|) x = SignType.sign x`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
