### PR TITLE
[Merged by Bors] - chore(Data/SetLike/Basic): fix delaborator

### DIFF
--- a/Mathlib/Data/SetLike/Basic.lean
+++ b/Mathlib/Data/SetLike/Basic.lean
@@ -121,9 +121,9 @@ uses the `SetLike.instMembership` instance. -/
 def delabSubtypeSetLike : Delab := whenPPOption getPPNotation do
   let #[_, .lam n _ body _] := (← getExpr).getAppArgs | failure
   guard <| body.isAppOf ``Membership.mem
-  let #[_, _, inst, .bvar 0, _] := body.getAppArgs | failure
-  guard <| inst.isAppOfArity ``instMembership 3
-  let S ← withAppArg <| withBindingBody n <| withNaryArg 4 delab
+  let #[_, _, inst, _, .bvar 0] := body.getAppArgs | failure
+  guard <| inst.isAppOfArity ``SetLike.instMembership 3
+  let S ← withAppArg <| withBindingBody n <| withNaryArg 3 delab
   `(↥$S)
 
 end Delab

--- a/Mathlib/Data/SetLike/Basic.lean
+++ b/Mathlib/Data/SetLike/Basic.lean
@@ -122,7 +122,7 @@ def delabSubtypeSetLike : Delab := whenPPOption getPPNotation do
   let #[_, .lam n _ body _] := (← getExpr).getAppArgs | failure
   guard <| body.isAppOf ``Membership.mem
   let #[_, _, inst, _, .bvar 0] := body.getAppArgs | failure
-  guard <| inst.isAppOfArity ``SetLike.instMembership 3
+  guard <| inst.isAppOfArity ``instMembership 3
   let S ← withAppArg <| withBindingBody n <| withNaryArg 3 delab
   `(↥$S)
 

--- a/test/set_like.lean
+++ b/test/set_like.lean
@@ -8,10 +8,10 @@ set_option autoImplicit true
 section Delab
 variable {M : Type u} [Monoid M] (S S' : Submonoid M)
 
-/-- info: { x // x ∈ S } → { x // x ∈ S' } : Type u -/
+/-- info: ↥S → ↥S' : Type u -/
 #guard_msgs in #check S → S'
 
-/-- info: { x // x ∈ S } : Type u -/
+/-- info: ↥S : Type u -/
 #guard_msgs in #check {x // x ∈ S}
 
 /-- info: { x // 1 * x ∈ S } : Type u -/


### PR DESCRIPTION
This was broken by leanprover/lean4#5020

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
