### PR TITLE
[Merged by Bors] - chore: remove List.ofFn lemmas moved to Batteries

### DIFF
--- a/Mathlib/Analysis/Analytic/Composition.lean
+++ b/Mathlib/Analysis/Analytic/Composition.lean
@@ -1158,7 +1158,7 @@ def sigmaEquivSigmaPi (n : ℕ) :
       · intro i
         dsimp [Composition.sigmaCompositionAux]
         rw [getElem_of_eq (splitWrtComposition_join _ _ _)]
-        · simp only [getElem_ofFn]
+        · simp only [List.getElem_ofFn]
         · simp only [map_ofFn]
           rfl
       · congr

--- a/Mathlib/Data/List/FinRange.lean
+++ b/Mathlib/Data/List/FinRange.lean
@@ -42,7 +42,7 @@ theorem finRange_succ (n : ℕ) :
 theorem ofFn_eq_pmap {n} {f : Fin n → α} :
     ofFn f = pmap (fun i hi => f ⟨i, hi⟩) (range n) fun _ => mem_range.1 := by
   rw [pmap_eq_map_attach]
-  exact ext_getElem (by simp) fun i hi1 hi2 => by simp [getElem_ofFn f i hi1]
+  exact ext_getElem (by simp) fun i hi1 hi2 => by simp [List.getElem_ofFn f i hi1]
 
 theorem ofFn_id (n) : ofFn id = finRange n :=
   ofFn_eq_pmap

--- a/Mathlib/Data/List/OfFn.lean
+++ b/Mathlib/Data/List/OfFn.lean
@@ -3,6 +3,7 @@ Copyright (c) 2018 Mario Carneiro. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Mario Carneiro
 -/
+import Batteries.Data.List.OfFn
 import Batteries.Data.List.Pairwise
 import Mathlib.Data.Fin.Tuple.Basic
 
@@ -16,7 +17,6 @@ of length `n`.
 
 The main statements pertain to lists generated using `List.ofFn`
 
-- `List.length_ofFn`, which tells us the length of such a list
 - `List.get?_ofFn`, which tells us the nth element of such a list
 - `List.equivSigmaTuple`, which is an `Equiv` between lists and the functions that generate them
   via `List.ofFn`.
@@ -32,43 +32,8 @@ open Nat
 
 namespace List
 
-@[simp]
-theorem length_ofFn_go {n} (f : Fin n → α) (i j h) : length (ofFn.go f i j h) = i := by
-  induction i generalizing j <;> simp_all [ofFn.go]
-
-/-- The length of a list converted from a function is the size of the domain. -/
-@[simp]
-theorem length_ofFn {n} (f : Fin n → α) : length (ofFn f) = n := by
-  simp [ofFn, length_ofFn_go]
-
-theorem getElem_ofFn_go {n} (f : Fin n → α) (i j h) (k) (hk : k < (ofFn.go f i j h).length) :
-    (ofFn.go f i j h)[k] = f ⟨j + k, by simp at hk; omega⟩ := by
-  let i+1 := i
-  cases k <;> simp [ofFn.go, getElem_ofFn_go (i := i)]
-  congr 2; omega
-
-theorem get_ofFn_go {n} (f : Fin n → α) (i j h) (k) (hk) :
-    get (ofFn.go f i j h) ⟨k, hk⟩ = f ⟨j + k, by simp at hk; omega⟩ := by
-  simp [getElem_ofFn_go]
-
-@[simp]
-theorem getElem_ofFn {n} (f : Fin n → α) (i : Nat) (h : i < (ofFn f).length) :
-    (ofFn f)[i] = f ⟨i, by simp_all⟩ := by
-  simp [ofFn, getElem_ofFn_go]
-
 theorem get_ofFn {n} (f : Fin n → α) (i) : get (ofFn f) i = f (Fin.cast (by simp) i) := by
   simp; congr
-
-/-- The `n`th element of a list -/
-@[simp]
-theorem getElem?_ofFn {n} (f : Fin n → α) (i) : (ofFn f)[i]? = ofFnNthVal f i :=
-  if h : i < (ofFn f).length
-  then by
-    rw [getElem?_eq_getElem h, getElem_ofFn]
-    · simp only [length_ofFn] at h; simp [ofFnNthVal, h]
-  else by
-    rw [ofFnNthVal, dif_neg] <;>
-    simpa using h
 
 /-- The `n`th element of a list -/
 theorem get?_ofFn {n} (f : Fin n → α) (i) : get? (ofFn f) i = ofFnNthVal f i := by

--- a/lake-manifest.json
+++ b/lake-manifest.json
@@ -5,7 +5,7 @@
    "type": "git",
    "subDir": null,
    "scope": "leanprover-community",
-   "rev": "c57ab80c8dd20b345b29c81c446c78a6b3677d20",
+   "rev": "98f2215707ae293a5612217dc29c05b515269512",
    "name": "batteries",
    "manifestFile": "lake-manifest.json",
    "inputRev": "main",


### PR DESCRIPTION
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
