### PR TITLE
[Merged by Bors] - feat(CategoryTheory): codiscrete categories

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -1459,6 +1459,7 @@ import Mathlib.CategoryTheory.Closed.Monoidal
 import Mathlib.CategoryTheory.Closed.Types
 import Mathlib.CategoryTheory.Closed.Zero
 import Mathlib.CategoryTheory.ClosedUnderIsomorphisms
+import Mathlib.CategoryTheory.CodiscreteCategory
 import Mathlib.CategoryTheory.CofilteredSystem
 import Mathlib.CategoryTheory.CommSq
 import Mathlib.CategoryTheory.Comma.Arrow

--- a/Mathlib/CategoryTheory/CodiscreteCategory.lean
+++ b/Mathlib/CategoryTheory/CodiscreteCategory.lean
@@ -126,7 +126,7 @@ def adj : objects ⊣ functorToCat := mkOfHomEquiv {
   homEquiv_naturality_left_symm := fun _ _ => rfl
   homEquiv_naturality_right := fun _ _ => rfl }
 
-/-- Components of the unit of the adjunction Cat.objects ⊣ Codiscrete.functorToCat -/
+/-- Components of the unit of the adjunction `Cat.objects ⊣ Codiscrete.functorToCat`. -/
 def unitApp (C : Type u) [Category.{v} C] : C ⥤ Codiscrete C := functor id
 
 /-- Components of the counit of the adjunction `Cat.objects ⊣ Codiscrete.functorToCat` -/

--- a/Mathlib/CategoryTheory/CodiscreteCategory.lean
+++ b/Mathlib/CategoryTheory/CodiscreteCategory.lean
@@ -103,7 +103,7 @@ def oppositeEquivalence (A : Type*) : (Codiscrete A)ᵒᵖ ≌ Codiscrete A wher
   unitIso := NatIso.ofComponents (fun _ => by exact Iso.refl _)
   counitIso := natIso
 
-/-- Codiscrete.Functor turns a type into a codiscrete category-/
+/-- `Codiscrete.functorToCat` turns a type into a codiscrete category-/
 def functorToCat : Type u ⥤ Cat.{0,u} where
   obj A := Cat.of (Codiscrete A)
   map := functorOfFun

--- a/Mathlib/CategoryTheory/CodiscreteCategory.lean
+++ b/Mathlib/CategoryTheory/CodiscreteCategory.lean
@@ -17,7 +17,7 @@ and use this type alias to provide a `Category` instance
 whose Hom type are Unit types.
 
 `Codiscrete.functor` promotes a function `f : C → A` (for any category `C`) to a functor
- `f : C ⥤  Codiscrete A`.
+ `f : C ⥤ Codiscrete A`.
 
 Similarly, `Codiscrete.natTrans` and `Codiscrete.natIso` promote `I`-indexed families of morphisms,
 or `I`-indexed families of isomorphisms to natural transformations or natural isomorphism.

--- a/Mathlib/CategoryTheory/CodiscreteCategory.lean
+++ b/Mathlib/CategoryTheory/CodiscreteCategory.lean
@@ -138,14 +138,17 @@ lemma adj_unit_app (X : Cat.{0, u}) :
 lemma adj_counit_app (A : Type u) :
     adj.counit.app A = counitApp A := rfl
 
-/-- Left triangle equality of the adjunction Cat.objects ⊣ Codiscrete.functorToCat -/
-lemma left_triangle_components {C : Cat.{0, u}} :
-    objects.map (adj.unit.app C) ≫ adj.counit.app (objects.obj (C)) = 𝟙 (objects.obj C) := rfl
+/-- Left triangle equality of the adjunction `Cat.objects ⊣ Codiscrete.functorToCat`,
+as a universe polymorphic statement. -/
+lemma left_triangle_components (C : Type u) [Category.{v} C] :
+    (counitApp C).comp (unitApp C).obj = id :=
+  rfl
 
-/-- Right triangle equality of the adjunction Cat.objects ⊣ Codiscrete.functorToCat -/
-lemma right_triangle_components {X : Type u} :
-    adj.unit.app (functorToCat.obj X) ≫ functorToCat.map (adj.counit.app X) =
-      𝟙 (functorToCat.obj X) := rfl
+/-- Right triangle equality of the adjunction `Cat.objects ⊣ Codiscrete.functorToCat`,
+stated using a composition of functors. -/
+lemma right_triangle_components (X : Type u) :
+    unitApp (Codiscrete X) ⋙ functorOfFun (counitApp X) = 𝟭 (Codiscrete X) :=
+  rfl
 
 end Codiscrete
 

--- a/Mathlib/CategoryTheory/CodiscreteCategory.lean
+++ b/Mathlib/CategoryTheory/CodiscreteCategory.lean
@@ -16,8 +16,7 @@ We define `Codiscrete A` as an alias for the type `A` ,
 and use this type alias to provide a `Category` instance
 whose Hom type are Unit types.
 
-`Codiscrete.lift` promotes a function `f : C → A` (for any category `C`) to a functor
-`Discrete.functorToCat f : C ⥤  Codiscrete A`.
+`Codiscrete.functor` promotes a function `f : C → A` (for any category `C`) to a functor `f : C ⥤  Codiscrete A`.
 
 Similarly, `Codiscrete.natTrans` and `Codiscrete.natIso` promote `I`-indexed families of morphisms,
 or `I`-indexed families of isomorphisms to natural transformations or natural isomorphism.

--- a/Mathlib/CategoryTheory/CodiscreteCategory.lean
+++ b/Mathlib/CategoryTheory/CodiscreteCategory.lean
@@ -147,8 +147,8 @@ lemma left_triangle_components {C : Cat.{0, u}} :
 
 /-- Right triangle equality of the adjunction Cat.objects ⊣ Codiscrete.functorToCat -/
 lemma right_triangle_components {X : Type u} :
-    adj.unit.app (functorToCat.obj X) ≫ functorToCat.map (adj.counit.app X)
-    = 𝟙 (functorToCat.obj X) := rfl
+    adj.unit.app (functorToCat.obj X) ≫ functorToCat.map (adj.counit.app X) =
+      𝟙 (functorToCat.obj X) := rfl
 
 end Codiscrete
 

--- a/Mathlib/CategoryTheory/CodiscreteCategory.lean
+++ b/Mathlib/CategoryTheory/CodiscreteCategory.lean
@@ -69,7 +69,7 @@ def functor (F : C → A) : C ⥤ Codiscrete A where
   obj := Codiscrete.mk ∘ F
   map _ := ⟨⟩
 
-/-- Any functor `C ⥤  Codiscrete A` has an underlying function.-/
+/-- The underlying function `C → A` of a functor `C ⥤ Codiscrete A`. -/
 def invFunctor (F : C ⥤ Codiscrete A) : C → A := Codiscrete.as ∘ F.obj
 
 /-- Given two functors to a codiscrete category, there is a trivial natural transformation.-/

--- a/Mathlib/CategoryTheory/CodiscreteCategory.lean
+++ b/Mathlib/CategoryTheory/CodiscreteCategory.lean
@@ -16,7 +16,8 @@ We define `Codiscrete A` as an alias for the type `A` ,
 and use this type alias to provide a `Category` instance
 whose Hom type are Unit types.
 
-`Codiscrete.functor` promotes a function `f : C → A` (for any category `C`) to a functor `f : C ⥤  Codiscrete A`.
+`Codiscrete.functor` promotes a function `f : C → A` (for any category `C`) to a functor
+ `f : C ⥤  Codiscrete A`.
 
 Similarly, `Codiscrete.natTrans` and `Codiscrete.natIso` promote `I`-indexed families of morphisms,
 or `I`-indexed families of isomorphisms to natural transformations or natural isomorphism.

--- a/Mathlib/CategoryTheory/CodiscreteCategory.lean
+++ b/Mathlib/CategoryTheory/CodiscreteCategory.lean
@@ -64,7 +64,7 @@ instance (A : Type*) : Category (Codiscrete A) where
 section
 variable {C : Type u} [Category.{v} C] {A : Type w}
 
-/-- Any function `C → A` lifts to a functor `C ⥤  Codiscrete A`.-/
+/-- Any function `C → A` lifts to a functor `C ⥤ Codiscrete A`.-/
 def functor (F : C → A) : C ⥤ Codiscrete A where
   obj := Codiscrete.mk ∘ F
   map _ := ⟨⟩

--- a/Mathlib/CategoryTheory/CodiscreteCategory.lean
+++ b/Mathlib/CategoryTheory/CodiscreteCategory.lean
@@ -61,11 +61,8 @@ def natTrans {F G : C ⥤ Codiscrete A} :
 natural isomorphism.-/
 def natIso {F G : C ⥤ Codiscrete A} :
     F ≅ G where
-      hom := natTrans
-      inv := {
-        app := fun _ => ⟨⟩
-
-      }
+  hom := natTrans
+  inv := natTrans
 
 /-- Every functor `F` to a codiscrete category is naturally isomorphic {(actually, equal)?} to
   `Codiscrete.functor (F.obj)`. -/

--- a/Mathlib/CategoryTheory/CodiscreteCategory.lean
+++ b/Mathlib/CategoryTheory/CodiscreteCategory.lean
@@ -42,8 +42,7 @@ structure Codiscrete (α : Type u) where
   as : α
 
 @[simp]
-theorem Codiscrete.mk_as {α : Type u} (X : Codiscrete α) : Codiscrete.mk X.as = X := by
-  rfl
+theorem Codiscrete.mk_as {α : Type u} (X : Codiscrete α) : Codiscrete.mk X.as = X := rfl
 
 /-- `Codiscrete α` is equivalent to the original type `α`. -/
 @[simps]

--- a/Mathlib/CategoryTheory/CodiscreteCategory.lean
+++ b/Mathlib/CategoryTheory/CodiscreteCategory.lean
@@ -115,7 +115,8 @@ open Adjunction Cat
 
 /-- For a category `C` and type `A`, there is an equivalence between functions `objects.obj C ⟶ A`
 and functors `C ⥤ Codiscrete A`.-/
-def homEquiv (C : Cat) (A : Type*) : (objects.obj C ⟶ A) ≃ (C ⟶ functor.obj A) where
+def equivFunctorToCodiscrete {C : Type u} [Category.{v} C] {A : Type w} :
+  (C → A) ≃ (C ⥤ Codiscrete A) where
   toFun := lift
   invFun := invlift
   left_inv _ := rfl
@@ -125,7 +126,7 @@ def homEquiv (C : Cat) (A : Type*) : (objects.obj C ⟶ A) ≃ (C ⟶ functor.ob
 functor.-/
 def adj : objects ⊣ functor := mkOfHomEquiv
   {
-    homEquiv := homEquiv
+    homEquiv := fun _ _ => equivFunctorToCodiscrete
     homEquiv_naturality_left_symm := fun _ _ => rfl
     homEquiv_naturality_right := fun _ _ => rfl
   }
@@ -135,7 +136,7 @@ def unit : 𝟭 Cat ⟶ objects ⋙ functor where
   app := by
     simp only [Functor.id_obj, Functor.comp_obj]
     intro C
-    apply (homEquiv C (objects.obj C)).toFun
+    apply lift
     exact fun a ↦ a
 
 /--Conit of the adjunction Cat.objects ⊣ Codiscrete.functor -/
@@ -143,17 +144,17 @@ def counit : functor ⋙ objects ⟶ 𝟭 (Type*) := {
     app := by
       intro A
       simp only [Functor.comp_obj, Functor.id_obj]
-      apply (homEquiv (functor.obj A) A).invFun
+      apply invlift
       exact functor.map fun a ↦ a
   }
 
 /--Left triangle equality of the adjunction Cat.objects ⊣ Codiscrete.functor -/
 def leftTriangleComponents {X : Cat} :
-objects.map (unit.app X) ≫ counit.app (objects.obj X) = 𝟙 (objects.obj X) := rfl
+  objects.map (unit.app X) ≫ counit.app (objects.obj X) = 𝟙 (objects.obj X) := rfl
 
 /--Right triangle equality of the adjunction Cat.objects ⊣ Codiscrete.functor -/
 def rightTriangleComponents {Y : Type u} :
-unit.app (functor.obj Y) ≫ functor.map (counit.app Y) = 𝟙 (functor.obj Y) := rfl
+  unit.app (functor.obj Y) ≫ functor.map (counit.app Y) = 𝟙 (functor.obj Y) := rfl
 
 end Codiscrete
 

--- a/Mathlib/CategoryTheory/CodiscreteCategory.lean
+++ b/Mathlib/CategoryTheory/CodiscreteCategory.lean
@@ -149,11 +149,11 @@ def counit : functor ⋙ objects ⟶ 𝟭 (Type*) := {
   }
 
 /--Left triangle equality of the adjunction Cat.objects ⊣ Codiscrete.functor -/
-def leftTriangleComponents {X : Cat} :
+theorem left_triangle_components {X : Cat} :
     objects.map (unit.app X) ≫ counit.app (objects.obj X) = 𝟙 (objects.obj X) := rfl
 
 /--Right triangle equality of the adjunction Cat.objects ⊣ Codiscrete.functor -/
-def rightTriangleComponents {Y : Type u} :
+theorem right_triangle_components {Y : Type u} :
     unit.app (functor.obj Y) ≫ functor.map (counit.app Y) = 𝟙 (functor.obj Y) := rfl
 
 end Codiscrete

--- a/Mathlib/CategoryTheory/CodiscreteCategory.lean
+++ b/Mathlib/CategoryTheory/CodiscreteCategory.lean
@@ -36,8 +36,8 @@ def Codiscrete (A : Type u) : Type u := A
 namespace Codiscrete
 
 instance (A : Type*) : Category (Codiscrete A) where
-  Hom _ _ := Unit -- The hom types in the Codiscrete A are the unit type.
-  id _ := ⟨⟩ -- This is the unique element of the unit type.
+  Hom _ _ := Unit
+  id _ := ⟨⟩
   comp _ _ := ⟨⟩
 
 /-- A function induces a functor between codiscrete categories.-/

--- a/Mathlib/CategoryTheory/CodiscreteCategory.lean
+++ b/Mathlib/CategoryTheory/CodiscreteCategory.lean
@@ -78,15 +78,11 @@ def functorOfFun {A B : Type*} (f : A → B) : Codiscrete A ⥤ Codiscrete B := 
 open Opposite
 
 /-- A codiscrete category is equivalent to its opposite category. -/
-protected def opposite (A : Type*) : (Codiscrete A)ᵒᵖ ≌ Codiscrete A :=
- let F : (Codiscrete A)ᵒᵖ ⥤ Codiscrete A := lift fun (op (x)) => x
- {
-  functor := F
-  inverse := F.rightOp
-  unitIso := NatIso.ofComponents fun ⟨x⟩ =>
-   Iso.refl _
+def oppositeEquivalence (A : Type*) : (Codiscrete A)ᵒᵖ ≌ Codiscrete A where
+  functor := lift (fun x ↦ x.unop)
+  inverse := (lift (fun x ↦ x.unop)).rightOp
+  unitIso := NatIso.ofComponents (fun _ => by exact Iso.refl _)
   counitIso := natIso
- }
 
 /-- Codiscrete.Functor turns a type into a codiscrete category-/
 def functor : Type u ⥤ Cat.{0,u} where

--- a/Mathlib/CategoryTheory/CodiscreteCategory.lean
+++ b/Mathlib/CategoryTheory/CodiscreteCategory.lean
@@ -35,7 +35,6 @@ def Codiscrete (A : Type u) : Type u := A
 
 namespace Codiscrete
 
-
 instance (A : Type*) : Category (Codiscrete A) where
   Hom _ _ := Unit -- The hom types in the Codiscrete A are the unit type.
   id _ := ⟨⟩ -- This is the unique element of the unit type.

--- a/Mathlib/CategoryTheory/CodiscreteCategory.lean
+++ b/Mathlib/CategoryTheory/CodiscreteCategory.lean
@@ -29,8 +29,8 @@ namespace CategoryTheory
 
 universe u v w
 
-/-- The type of objects in the category `Codiscrete A` is a type synonym for `A` and there is a unique
-morphism between any two objects in this category. -/
+/-- The type of objects in the category `Codiscrete A` is a type synonym
+for `A` and there is a unique morphism between any two objects in this category. -/
 def Codiscrete (A : Type u) : Type u := A
 
 namespace Codiscrete
@@ -39,11 +39,6 @@ instance (A : Type*) : Category (Codiscrete A) where
   Hom _ _ := Unit
   id _ := ⟨⟩
   comp _ _ := ⟨⟩
-
-/-- A function induces a functor between codiscrete categories.-/
-def funToFunc {A B : Type*} (f : A → B) : Codiscrete A ⥤ Codiscrete B where
-  obj a := f a
-  map _ := ⟨⟩
 
 section
 variable {C : Type u} [Category.{v} C] {A : Type w}
@@ -83,6 +78,11 @@ def natIsoFunctor {F : C ⥤ Codiscrete A} : F ≅ lift (F.obj) where
   }
 
 end
+
+-- /-- A function induces a functor between codiscrete categories.-/
+def functorOfFun {A B : Type*} (f : A → B) : Codiscrete A ⥤ Codiscrete B := by
+  exact lift f
+
 open Opposite
 
 /-- A codiscrete category is equivalent to its opposite category. -/
@@ -99,7 +99,7 @@ protected def opposite (A : Type*) : (Codiscrete A)ᵒᵖ ≌ Codiscrete A :=
 /-- Codiscrete.Functor turns a type into a codiscrete category-/
 def functor : Type u ⥤ Cat.{0,u} where
   obj A := Cat.of (Codiscrete A)
-  map := funToFunc
+  map := functorOfFun
 
 open Adjunction Cat
 

--- a/Mathlib/CategoryTheory/CodiscreteCategory.lean
+++ b/Mathlib/CategoryTheory/CodiscreteCategory.lean
@@ -34,6 +34,7 @@ def Codiscrete (A : Type u) : Type u := A
 
 namespace Codiscrete
 
+
 instance (A : Type*) : Category (Codiscrete A) where
   Hom _ _ := Unit -- The hom types in the Codiscrete A are the unit type.
   id _ := ⟨⟩ -- This is the unique element of the unit type.
@@ -96,6 +97,7 @@ protected def opposite (A : Type*) : (Codiscrete A)ᵒᵖ ≌ Codiscrete A :=
   counitIso := natIso fun c => Iso.refl c
  }
 
+/-- Codiscrete.Functor turns a type into a codiscrete category-/
 def functor : Type u ⥤ Cat.{0,u} where
   obj A := Cat.of (Codiscrete A)
   map := funToFunc

--- a/Mathlib/CategoryTheory/CodiscreteCategory.lean
+++ b/Mathlib/CategoryTheory/CodiscreteCategory.lean
@@ -66,13 +66,8 @@ def natIso {F G : C ⥤ Codiscrete A} :
 
 /-- Every functor `F` to a codiscrete category is naturally isomorphic {(actually, equal)?} to
   `Codiscrete.functor (F.obj)`. -/
-def natIsoFunctor {F : C ⥤ Codiscrete A} : F ≅ lift (F.obj) where
-  hom := {
-    app := fun _ => ⟨⟩
-  }
-  inv := {
-    app := fun _ => ⟨⟩
-  }
+@[simps!]
+def natIsoFunctor {F : C ⥤ Codiscrete A} : F ≅ lift (F.obj) := Iso.refl _
 
 end
 

--- a/Mathlib/CategoryTheory/CodiscreteCategory.lean
+++ b/Mathlib/CategoryTheory/CodiscreteCategory.lean
@@ -150,11 +150,11 @@ def counit : functor ⋙ objects ⟶ 𝟭 (Type*) := {
 
 /--Left triangle equality of the adjunction Cat.objects ⊣ Codiscrete.functor -/
 def leftTriangleComponents {X : Cat} :
-  objects.map (unit.app X) ≫ counit.app (objects.obj X) = 𝟙 (objects.obj X) := rfl
+    objects.map (unit.app X) ≫ counit.app (objects.obj X) = 𝟙 (objects.obj X) := rfl
 
 /--Right triangle equality of the adjunction Cat.objects ⊣ Codiscrete.functor -/
 def rightTriangleComponents {Y : Type u} :
-  unit.app (functor.obj Y) ≫ functor.map (counit.app Y) = 𝟙 (functor.obj Y) := rfl
+    unit.app (functor.obj Y) ≫ functor.map (counit.app Y) = 𝟙 (functor.obj Y) := rfl
 
 end Codiscrete
 

--- a/Mathlib/CategoryTheory/CodiscreteCategory.lean
+++ b/Mathlib/CategoryTheory/CodiscreteCategory.lean
@@ -104,8 +104,8 @@ functor.-/
 def adj : objects ⊣ functor := mkOfHomEquiv
   {
     homEquiv := homEquiv
-    homEquiv_naturality_left_symm := fun _ _ => Eq.refl _
-    homEquiv_naturality_right := fun _ _ => Eq.refl _
+    homEquiv_naturality_left_symm := fun _ _ => rfl
+    homEquiv_naturality_right := fun _ _ => rfl
   }
 
 /-- A second proof of the same adjunction.  -/

--- a/Mathlib/CategoryTheory/CodiscreteCategory.lean
+++ b/Mathlib/CategoryTheory/CodiscreteCategory.lean
@@ -71,7 +71,7 @@ def natIsoFunctor {F : C ⥤ Codiscrete A} : F ≅ lift (F.obj) := Iso.refl _
 
 end
 
--- /-- A function induces a functor between codiscrete categories.-/
+/-- A function induces a functor between codiscrete categories.-/
 def functorOfFun {A B : Type*} (f : A → B) : Codiscrete A ⥤ Codiscrete B := by
   exact lift f
 

--- a/Mathlib/CategoryTheory/CodiscreteCategory.lean
+++ b/Mathlib/CategoryTheory/CodiscreteCategory.lean
@@ -1,0 +1,138 @@
+/-
+Copyright (c) 2024 Alvaro Belmonte. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Alvaro Belmonte
+-/
+import Mathlib.CategoryTheory.EqToHom
+import Mathlib.CategoryTheory.Pi.Basic
+import Mathlib.Data.ULift
+import Mathlib.CategoryTheory.Category.Cat
+import Mathlib.CategoryTheory.Adjunction.Basic
+
+/-!
+# Codiscrete categories
+
+We define `Codiscrete A` as an alias for the type `A` ,
+and use this type alias to provide a `Category` instance
+whose Hom type are Unit types.
+
+`Codiscrete.lift` promotes a function `f : C → A` (for any category `C`) to a functor
+`Discrete.functor f : C ⥤  Codiscrete A`.
+
+Similarly, `Codiscrete.natTrans` and `Codiscrete.natIso` promote `I`-indexed families of morphisms,
+or `I`-indexed families of isomorphisms to natural transformations or natural isomorphism.
+
+We define `functor : Type u ⥤ Cat.{0,u}` which sends a type to the codiscrete category and show
+it is right adjoint to `Cat.objects.`
+-/
+namespace CategoryTheory
+
+universe u v w
+/-- We start by introducting an alias for the type underlying a codiscrete category
+structure.-/
+def Codiscrete (A : Type u) : Type u := A
+
+namespace Codiscrete
+
+instance (A : Type*) : Category (Codiscrete A) where
+  Hom _ _ := Unit -- The hom types in the Codiscrete A are the unit type.
+  id _ := ⟨⟩ -- This is the unique element of the unit type.
+  comp _ _ := ⟨⟩
+
+/-- A function induces a functor between codiscrete categories.-/
+def funToFunc {A B : Type*} (f : A → B) : Codiscrete A ⥤ Codiscrete B where
+  obj a := f a
+  map _ := ⟨⟩
+
+section
+variable {C : Type u} [Category.{v} C] {A : Type w}
+
+/-- Any function `C → A` lifts to a functor `C ⥤  Codiscrete A`. For discrete categories this is
+called `functor` but we use that name for something else. -/
+def lift (F : C → A) : C ⥤ Codiscrete A where
+  obj := F
+  map _ := ⟨⟩
+
+/-- Any functor `C ⥤  Codiscrete A` has an underlying function.-/
+def invlift (F : C ⥤ Codiscrete A) : C → A := F.obj
+
+/-- For functors to a codiscrete category, a natural transformation is trivial.-/
+def natTrans {F G : C ⥤ Codiscrete A} (_ : ∀ c : C, F.obj c ⟶ G.obj c) :
+    F ⟶ G where
+  app _ := ⟨⟩
+
+/-- For functors into a codiscrete category, a natural isomorphism is just a collection of
+isomorphisms, as the naturality squares are trivial.-/
+def natIso {F G : C ⥤ Codiscrete A} (_ : ∀ c : C, F.obj c ≅ G.obj c) :
+    F ≅ G where
+  hom := {
+    app := fun _ => ⟨⟩
+  }
+  inv := {
+    app := fun _ => ⟨⟩
+  }
+
+/-- Every functor `F` to a codiscrete category is naturally isomorphic {(actually, equal)?} to
+  `Codiscrete.functor (F.obj)`. -/
+def natIsoFunctor {F : C ⥤ Codiscrete A} : F ≅ lift (F.obj) where
+  hom := {
+    app := fun _ => ⟨⟩
+  }
+  inv := {
+    app := fun _ => ⟨⟩
+  }
+
+end
+open Opposite
+
+/-- A codiscrete category is equivalent to its opposite category. -/
+protected def opposite (A : Type*) : (Codiscrete A)ᵒᵖ ≌ Codiscrete A :=
+ let F : (Codiscrete A)ᵒᵖ ⥤ Codiscrete A := lift fun (op (x)) => x
+ {
+  functor := F
+  inverse := F.rightOp
+  unitIso := NatIso.ofComponents fun ⟨x⟩ =>
+   Iso.refl _
+  counitIso := natIso fun c => Iso.refl c
+ }
+
+def functor : Type u ⥤ Cat.{0,u} where
+  obj A := Cat.of (Codiscrete A)
+  map := funToFunc
+
+open Adjunction Cat
+
+/-- For a category `C` and type `A`, there is an equivalence between functions `objects.obj C ⟶ A`
+and functors `C ⥤ Codiscrete A`.-/
+def homEquiv (C : Cat) (A : Type*) : (objects.obj C ⟶ A) ≃ (C ⟶ functor.obj A) where
+  toFun := lift
+  invFun := invlift
+  left_inv _ := rfl
+  right_inv _ := rfl
+
+/-- The functor that turns a type into a codiscrete category is right adjoint to the objects
+functor.-/
+def adj : objects ⊣ functor := mkOfHomEquiv
+  {
+    homEquiv := homEquiv
+    homEquiv_naturality_left_symm := fun _ _ => Eq.refl _
+    homEquiv_naturality_right := fun _ _ => Eq.refl _
+  }
+
+/-- A second proof of the same adjunction.  -/
+def adj' : objects ⊣ functor where
+  unit := {
+    app := fun _ => {
+      obj := fun _ => _
+      map := fun _ => ⟨⟩
+    }
+  }
+  counit := {
+    app := fun _ => id
+  }
+  left_triangle_components := by aesop
+  right_triangle_components := by aesop
+
+end Codiscrete
+
+end CategoryTheory

--- a/Mathlib/CategoryTheory/CodiscreteCategory.lean
+++ b/Mathlib/CategoryTheory/CodiscreteCategory.lean
@@ -116,7 +116,7 @@ open Adjunction Cat
 /-- For a category `C` and type `A`, there is an equivalence between functions `objects.obj C ⟶ A`
 and functors `C ⥤ Codiscrete A`.-/
 def equivFunctorToCodiscrete {C : Type u} [Category.{v} C] {A : Type w} :
-  (C → A) ≃ (C ⥤ Codiscrete A) where
+    (C → A) ≃ (C ⥤ Codiscrete A) where
   toFun := lift
   invFun := invlift
   left_inv _ := rfl

--- a/Mathlib/CategoryTheory/CodiscreteCategory.lean
+++ b/Mathlib/CategoryTheory/CodiscreteCategory.lean
@@ -28,8 +28,9 @@ it is right adjoint to `Cat.objects.`
 namespace CategoryTheory
 
 universe u v w
-/-- We start by introducting an alias for the type underlying a codiscrete category
-structure.-/
+
+/-- The type of objects in the category `Codiscrete A` is a type synonym for `A` and there is a unique
+morphism between any two objects in this category. -/
 def Codiscrete (A : Type u) : Type u := A
 
 namespace Codiscrete

--- a/Mathlib/CategoryTheory/CodiscreteCategory.lean
+++ b/Mathlib/CategoryTheory/CodiscreteCategory.lean
@@ -131,7 +131,7 @@ def adj : objects ⊣ functor := mkOfHomEquiv
     homEquiv_naturality_right := fun _ _ => rfl
   }
 
-/--Unit of the adjunction Cat.objects ⊣ Codiscrete.functor -/
+/-- Unit of the adjunction Cat.objects ⊣ Codiscrete.functor -/
 def unit : 𝟭 Cat ⟶ objects ⋙ functor where
   app := by
     simp only [Functor.id_obj, Functor.comp_obj]

--- a/Mathlib/CategoryTheory/CodiscreteCategory.lean
+++ b/Mathlib/CategoryTheory/CodiscreteCategory.lean
@@ -57,21 +57,20 @@ def lift (F : C → A) : C ⥤ Codiscrete A where
 /-- Any functor `C ⥤  Codiscrete A` has an underlying function.-/
 def invlift (F : C ⥤ Codiscrete A) : C → A := F.obj
 
-/-- For functors to a codiscrete category, a natural transformation is trivial.-/
-def natTrans {F G : C ⥤ Codiscrete A} (_ : ∀ c : C, F.obj c ⟶ G.obj c) :
+/-- Given two functors to a codiscrete category, there is a trivial natural transformation.-/
+def natTrans {F G : C ⥤ Codiscrete A} :
     F ⟶ G where
   app _ := ⟨⟩
 
-/-- For functors into a codiscrete category, a natural isomorphism is just a collection of
-isomorphisms, as the naturality squares are trivial.-/
-def natIso {F G : C ⥤ Codiscrete A} (_ : ∀ c : C, F.obj c ≅ G.obj c) :
+/-- Given two functors into a codiscrete category, the trivial natural transformation is an
+natural isomorphism.-/
+def natIso {F G : C ⥤ Codiscrete A} :
     F ≅ G where
-  hom := {
-    app := fun _ => ⟨⟩
-  }
-  inv := {
-    app := fun _ => ⟨⟩
-  }
+      hom := natTrans
+      inv := {
+        app := fun _ => ⟨⟩
+
+      }
 
 /-- Every functor `F` to a codiscrete category is naturally isomorphic {(actually, equal)?} to
   `Codiscrete.functor (F.obj)`. -/
@@ -94,7 +93,7 @@ protected def opposite (A : Type*) : (Codiscrete A)ᵒᵖ ≌ Codiscrete A :=
   inverse := F.rightOp
   unitIso := NatIso.ofComponents fun ⟨x⟩ =>
    Iso.refl _
-  counitIso := natIso fun c => Iso.refl c
+  counitIso := natIso
  }
 
 /-- Codiscrete.Functor turns a type into a codiscrete category-/

--- a/Mathlib/CategoryTheory/CodiscreteCategory.lean
+++ b/Mathlib/CategoryTheory/CodiscreteCategory.lean
@@ -129,7 +129,7 @@ def adj : objects ⊣ functorToCat := mkOfHomEquiv {
 /-- Components of the unit of the adjunction Cat.objects ⊣ Codiscrete.functorToCat -/
 def unitApp (C : Type u) [Category.{v} C] : C ⥤ Codiscrete C := functor id
 
-/-- Componetnts of the counit of the adjunction Cat.objects ⊣ Codiscrete.functorToCat -/
+/-- Components of the counit of the adjunction `Cat.objects ⊣ Codiscrete.functorToCat` -/
 def counitApp (A : Type u) : Codiscrete A → A := Codiscrete.as
 
 lemma adj_unit_app (X : Cat.{0, u}) :

--- a/Mathlib/CategoryTheory/CodiscreteCategory.lean
+++ b/Mathlib/CategoryTheory/CodiscreteCategory.lean
@@ -74,14 +74,12 @@ def functor (F : C → A) : C ⥤ Codiscrete A where
 def invFunctor (F : C ⥤ Codiscrete A) : C → A := Codiscrete.as ∘ F.obj
 
 /-- Given two functors to a codiscrete category, there is a trivial natural transformation.-/
-def natTrans {F G : C ⥤ Codiscrete A} :
-    F ⟶ G where
+def natTrans {F G : C ⥤ Codiscrete A} : F ⟶ G where
   app _ := ⟨⟩
 
 /-- Given two functors into a codiscrete category, the trivial natural transformation is an
 natural isomorphism.-/
-def natIso {F G : C ⥤ Codiscrete A} :
-    F ≅ G where
+def natIso {F G : C ⥤ Codiscrete A} : F ≅ G where
   hom := natTrans
   inv := natTrans
 

--- a/Mathlib/CategoryTheory/CodiscreteCategory.lean
+++ b/Mathlib/CategoryTheory/CodiscreteCategory.lean
@@ -121,12 +121,10 @@ def equivFunctorToCodiscrete {C : Type u} [Category.{v} C] {A : Type w} :
 
 /-- The functor that turns a type into a codiscrete category is right adjoint to the objects
 functor.-/
-def adj : objects ⊣ functorToCat := mkOfHomEquiv
-  {
-    homEquiv := fun _ _ => equivFunctorToCodiscrete
-    homEquiv_naturality_left_symm := fun _ _ => rfl
-    homEquiv_naturality_right := fun _ _ => rfl
-  }
+def adj : objects ⊣ functorToCat := mkOfHomEquiv {
+  homEquiv := fun _ _ => equivFunctorToCodiscrete
+  homEquiv_naturality_left_symm := fun _ _ => rfl
+  homEquiv_naturality_right := fun _ _ => rfl }
 
 /-- Componetns of the unit of the adjunction Cat.objects ⊣ Codiscrete.functorToCat -/
 def unitApp (C : Type u) [Category.{v} C] : C ⥤ Codiscrete C := functor id

--- a/Mathlib/CategoryTheory/CodiscreteCategory.lean
+++ b/Mathlib/CategoryTheory/CodiscreteCategory.lean
@@ -126,7 +126,7 @@ def adj : objects ⊣ functorToCat := mkOfHomEquiv {
   homEquiv_naturality_left_symm := fun _ _ => rfl
   homEquiv_naturality_right := fun _ _ => rfl }
 
-/-- Componetns of the unit of the adjunction Cat.objects ⊣ Codiscrete.functorToCat -/
+/-- Components of the unit of the adjunction Cat.objects ⊣ Codiscrete.functorToCat -/
 def unitApp (C : Type u) [Category.{v} C] : C ⥤ Codiscrete C := functor id
 
 /-- Componetnts of the counit of the adjunction Cat.objects ⊣ Codiscrete.functorToCat -/


### PR DESCRIPTION
This defines Codiscrete Categories which are dual to Discrete Categories. We also show the codiscrete functor is right adjoint to the objects functor.

Co-authored-by: [Joël Riou](https://github.com/joelriou)

---

First time contributor. I have two definitions of the adjunction and I wasn't sure which one is best to keep. 
A lot of this file parallels the discrete file, except that they define discrete as a structure and I don't. Wasn't sure how to do it.



[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
