### PR TITLE
feat: integrals and integrability with .re 

### DIFF
--- a/Mathlib/Analysis/SpecialFunctions/Integrals.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Integrals.lean
@@ -202,13 +202,6 @@ theorem integrableOn_Ioo_cpow_iff {s : ℂ} {t : ℝ} (ht : 0 < t) :
     simp [Complex.abs_cpow_eq_rpow_re_of_pos ha.1]
   rwa [integrableOn_Ioo_rpow_iff ht] at B
 
-/-- A real-valued function is interval integrable iff the complex-valued analog is. -/
-lemma intervalIntegrable_iff_ofReal {μ : Measure ℝ} {a b : ℝ} {f : ℝ → ℝ}  (hab: a ≤ b):
-    IntervalIntegrable f μ a b ↔ IntervalIntegrable (fun x ↦ (f x : ℂ)) μ a b := by
-    repeat rw [intervalIntegrable_iff_integrableOn_Ioc_of_le]
-    apply integrableOn_iff_ofReal
-    all_goals exact hab
-
 @[simp]
 theorem intervalIntegrable_id : IntervalIntegrable (fun x => x) μ a b :=
   continuous_id.intervalIntegrable a b

--- a/Mathlib/Analysis/SpecialFunctions/Integrals.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Integrals.lean
@@ -202,6 +202,13 @@ theorem integrableOn_Ioo_cpow_iff {s : ℂ} {t : ℝ} (ht : 0 < t) :
     simp [Complex.abs_cpow_eq_rpow_re_of_pos ha.1]
   rwa [integrableOn_Ioo_rpow_iff ht] at B
 
+/-- A real-valued function is interval integrable iff the complex-valued analog is. -/
+lemma intervalIntegrable_iff_ofReal {μ : Measure ℝ} {a b : ℝ} {f : ℝ → ℝ}  (hab: a ≤ b):
+    IntervalIntegrable f μ a b ↔ IntervalIntegrable (fun x ↦ (f x : ℂ)) μ a b := by
+    repeat rw [intervalIntegrable_iff_integrableOn_Ioc_of_le]
+    apply integrableOn_iff_ofReal
+    all_goals exact hab
+
 @[simp]
 theorem intervalIntegrable_id : IntervalIntegrable (fun x => x) μ a b :=
   continuous_id.intervalIntegrable a b

--- a/Mathlib/MeasureTheory/Function/L1Space.lean
+++ b/Mathlib/MeasureTheory/Function/L1Space.lean
@@ -1146,7 +1146,7 @@ theorem Integrable.im (hf : Integrable f μ) : Integrable (fun x => RCLike.im (f
   exact hf.im
 
 lemma Integrable.iff_ofReal {f : α → ℝ} : Integrable f μ ↔ Integrable (fun x ↦ (f x : ℂ)) μ :=
-    ⟨fun hf ↦ hf.ofReal, fun hf ↦ hf.re⟩
+  ⟨fun hf ↦ hf.ofReal, fun hf ↦ hf.re⟩
 
 end RCLike
 

--- a/Mathlib/MeasureTheory/Function/L1Space.lean
+++ b/Mathlib/MeasureTheory/Function/L1Space.lean
@@ -1131,6 +1131,10 @@ theorem Integrable.ofReal {f : α → ℝ} (hf : Integrable f μ) :
   rw [← memℒp_one_iff_integrable] at hf ⊢
   exact hf.ofReal
 
+theorem Integrable.iff_ofReal {X : Type*} [MeasurableSpace X] {μ : Measure X}
+    {f : X → ℝ} : Integrable f μ ↔ Integrable (fun x ↦ (f x : ℂ)) μ :=
+    ⟨fun hf ↦ hf.ofReal, fun hf ↦ hf.re⟩
+
 theorem Integrable.re_im_iff :
     Integrable (fun x => RCLike.re (f x)) μ ∧ Integrable (fun x => RCLike.im (f x)) μ ↔
       Integrable f μ := by

--- a/Mathlib/MeasureTheory/Function/L1Space.lean
+++ b/Mathlib/MeasureTheory/Function/L1Space.lean
@@ -1131,10 +1131,6 @@ theorem Integrable.ofReal {f : α → ℝ} (hf : Integrable f μ) :
   rw [← memℒp_one_iff_integrable] at hf ⊢
   exact hf.ofReal
 
-theorem Integrable.iff_ofReal {X : Type*} [MeasurableSpace X] {μ : Measure X}
-    {f : X → ℝ} : Integrable f μ ↔ Integrable (fun x ↦ (f x : ℂ)) μ :=
-    ⟨fun hf ↦ hf.ofReal, fun hf ↦ hf.re⟩
-
 theorem Integrable.re_im_iff :
     Integrable (fun x => RCLike.re (f x)) μ ∧ Integrable (fun x => RCLike.im (f x)) μ ↔
       Integrable f μ := by
@@ -1456,5 +1452,9 @@ lemma Integrable.snd {f : α → E × F} (hf : Integrable f μ) : Integrable (fu
 lemma integrable_prod {f : α → E × F} :
     Integrable f μ ↔ Integrable (fun x ↦ (f x).1) μ ∧ Integrable (fun x ↦ (f x).2) μ :=
   ⟨fun h ↦ ⟨h.fst, h.snd⟩, fun h ↦ h.1.prod_mk h.2⟩
+
+lemma Integrable.iff_ofReal {X : Type*} [MeasurableSpace X] {μ : Measure X}
+    {f : X → ℝ} : Integrable f μ ↔ Integrable (fun x ↦ (f x : ℂ)) μ :=
+    ⟨fun hf ↦ hf.ofReal, fun hf ↦ hf.re⟩
 
 end MeasureTheory

--- a/Mathlib/MeasureTheory/Function/L1Space.lean
+++ b/Mathlib/MeasureTheory/Function/L1Space.lean
@@ -1145,6 +1145,9 @@ theorem Integrable.im (hf : Integrable f μ) : Integrable (fun x => RCLike.im (f
   rw [← memℒp_one_iff_integrable] at hf ⊢
   exact hf.im
 
+lemma Integrable.iff_ofReal {f : α → ℝ} : Integrable f μ ↔ Integrable (fun x ↦ (f x : ℂ)) μ :=
+    ⟨fun hf ↦ hf.ofReal, fun hf ↦ hf.re⟩
+
 end RCLike
 
 section Trim
@@ -1452,9 +1455,5 @@ lemma Integrable.snd {f : α → E × F} (hf : Integrable f μ) : Integrable (fu
 lemma integrable_prod {f : α → E × F} :
     Integrable f μ ↔ Integrable (fun x ↦ (f x).1) μ ∧ Integrable (fun x ↦ (f x).2) μ :=
   ⟨fun h ↦ ⟨h.fst, h.snd⟩, fun h ↦ h.1.prod_mk h.2⟩
-
-lemma Integrable.iff_ofReal {X : Type*} [MeasurableSpace X] {μ : Measure X}
-    {f : X → ℝ} : Integrable f μ ↔ Integrable (fun x ↦ (f x : ℂ)) μ :=
-    ⟨fun hf ↦ hf.ofReal, fun hf ↦ hf.re⟩
 
 end MeasureTheory

--- a/Mathlib/MeasureTheory/Integral/IntegrableOn.lean
+++ b/Mathlib/MeasureTheory/Integral/IntegrableOn.lean
@@ -338,6 +338,31 @@ theorem IntegrableOn.setLIntegral_lt_top {f : α → ℝ} {s : Set α} (hf : Int
 @[deprecated (since := "2024-06-29")]
 alias IntegrableOn.set_lintegral_lt_top := IntegrableOn.setLIntegral_lt_top
 
+section RCLike
+
+variable {𝕜 : Type*} [RCLike 𝕜]
+
+theorem IntegrableOn.iff_ofReal {f : α → ℝ} :
+    IntegrableOn f s μ ↔ IntegrableOn (fun x ↦ (f x : ℂ)) s μ :=
+  MeasureTheory.Integrable.iff_ofReal
+
+theorem IntegrableOn.ofReal {f : α → ℝ} (hf : IntegrableOn f s μ) :
+    IntegrableOn (fun x => (f x : 𝕜)) s μ := by
+  rw [IntegrableOn, ← memℒp_one_iff_integrable] at hf ⊢
+  exact hf.ofReal
+
+theorem IntegrableOn.re_im_iff {f : α → 𝕜} :
+    IntegrableOn (fun x => RCLike.re (f x)) s μ ∧ IntegrableOn (fun x => RCLike.im (f x)) s μ ↔
+    IntegrableOn f s μ := Integrable.re_im_iff (f := f)
+
+theorem IntegrableOn.re {f : α → 𝕜} (hf : IntegrableOn f s μ) :
+    IntegrableOn (fun x => RCLike.re (f x)) s μ := (IntegrableOn.re_im_iff.2 hf).left
+
+theorem IntegrableOn.im {f : α → 𝕜} (hf : IntegrableOn f s μ) :
+    IntegrableOn (fun x => RCLike.im (f x)) s μ := (IntegrableOn.re_im_iff.2 hf).right
+
+end RCLike
+
 /-- We say that a function `f` is *integrable at filter* `l` if it is integrable on some
 set `s ∈ l`. Equivalently, it is eventually integrable on `s` in `l.smallSets`. -/
 def IntegrableAtFilter (f : α → E) (l : Filter α) (μ : Measure α := by volume_tac) :=
@@ -695,26 +720,3 @@ theorem integrableOn_Iic_iff_integrableOn_Iio :
   integrableOn_Iic_iff_integrableOn_Iio' (by rw [measure_singleton]; exact ENNReal.zero_ne_top)
 
 end PartialOrder
-
-namespace MeasureTheory
-variable {X : Type*} [MeasurableSpace X] {𝕜 : Type*} [RCLike 𝕜] {μ : Measure X} {s : Set X}
-theorem IntegrableOn.iff_ofReal {f : X → ℝ} :
-    IntegrableOn f s μ ↔ IntegrableOn (fun x ↦ (f x : ℂ)) s μ :=
-  MeasureTheory.Integrable.iff_ofReal
-
-theorem IntegrableOn.ofReal {f : X → ℝ} (hf : IntegrableOn f s μ) :
-    IntegrableOn (fun x => (f x : 𝕜)) s μ := by
-  rw [IntegrableOn, ← memℒp_one_iff_integrable] at hf ⊢
-  exact hf.ofReal
-
-theorem IntegrableOn.re_im_iff {f : X → 𝕜} :
-    IntegrableOn (fun x => RCLike.re (f x)) s μ ∧ IntegrableOn (fun x => RCLike.im (f x)) s μ ↔
-    IntegrableOn f s μ := Integrable.re_im_iff (f := f)
-
-theorem IntegrableOn.re {f : X → 𝕜} (hf : IntegrableOn f s μ) :
-    IntegrableOn (fun x => RCLike.re (f x)) s μ := (IntegrableOn.re_im_iff.2 hf).left
-
-theorem IntegrableOn.im {f : X → 𝕜} (hf : IntegrableOn f s μ) :
-    IntegrableOn (fun x => RCLike.im (f x)) s μ := (IntegrableOn.re_im_iff.2 hf).right
-
-end MeasureTheory

--- a/Mathlib/MeasureTheory/Integral/IntegrableOn.lean
+++ b/Mathlib/MeasureTheory/Integral/IntegrableOn.lean
@@ -129,7 +129,8 @@ theorem integrableOn_congr_fun (hst : EqOn f g s) (hs : MeasurableSet s) :
   ⟨fun h => h.congr_fun hst hs, fun h => h.congr_fun hst.symm hs⟩
 
 theorem integrableOn_iff_ofReal {X : Type*} [MeasurableSpace X] {μ : Measure X} {s : Set X}
-    {f : X → ℝ} : IntegrableOn f s μ ↔ IntegrableOn (fun x ↦ (f x : ℂ)) s μ := integrable_iff_ofReal
+    {f : X → ℝ} : IntegrableOn f s μ ↔ IntegrableOn (fun x ↦ (f x : ℂ)) s μ :=
+    MeasureTheory.Integrable.iff_ofReal
 
 theorem Integrable.integrableOn (h : Integrable f μ) : IntegrableOn f s μ :=
   h.mono_measure <| Measure.restrict_le_self

--- a/Mathlib/MeasureTheory/Integral/IntegrableOn.lean
+++ b/Mathlib/MeasureTheory/Integral/IntegrableOn.lean
@@ -128,6 +128,9 @@ theorem integrableOn_congr_fun (hst : EqOn f g s) (hs : MeasurableSet s) :
     IntegrableOn f s μ ↔ IntegrableOn g s μ :=
   ⟨fun h => h.congr_fun hst hs, fun h => h.congr_fun hst.symm hs⟩
 
+theorem integrableOn_iff_ofReal {X : Type*} [MeasurableSpace X] {μ : Measure X} {s : Set X}
+    {f : X → ℝ} : IntegrableOn f s μ ↔ IntegrableOn (fun x ↦ (f x : ℂ)) s μ := integrable_iff_ofReal
+
 theorem Integrable.integrableOn (h : Integrable f μ) : IntegrableOn f s μ :=
   h.mono_measure <| Measure.restrict_le_self
 

--- a/Mathlib/MeasureTheory/Integral/IntegrableOn.lean
+++ b/Mathlib/MeasureTheory/Integral/IntegrableOn.lean
@@ -699,21 +699,38 @@ end PartialOrder
 namespace MeasureTheory
 variable {X : Type*} [MeasurableSpace X] {μ : Measure X} {s : Set X}
 theorem IntegrableOn.iff_ofReal {f : X → ℝ} :
-IntegrableOn f s μ ↔ IntegrableOn (fun x ↦ (f x : ℂ)) s μ :=
+    IntegrableOn f s μ ↔ IntegrableOn (fun x ↦ (f x : ℂ)) s μ :=
     MeasureTheory.Integrable.iff_ofReal
 
 theorem IntegrableOn.ofReal {f : X → ℝ} (hf : IntegrableOn f s μ) :
     IntegrableOn (fun x => (f x : ℂ)) s μ := IntegrableOn.iff_ofReal.1 hf
 
-theorem IntegrableOn.re_im_iff {f : X → ℂ} :
+theorem IntegrableOn.re_im_iff {f : X → ℂ} (hs: MeasurableSet s):
     IntegrableOn (fun x => (f x).re) s μ ∧ IntegrableOn (fun x => (f x).im) s μ ↔
       IntegrableOn f s μ := by
-  sorry
+  refine ⟨?_, fun hf => ⟨hf.re, hf.im⟩⟩
+  rintro ⟨hre, him⟩
+  have h : IntegrableOn (fun x ↦ (f x).re + Complex.I*(f x).im) s μ := by
+    apply Integrable.add
+    rw [← IntegrableOn, ← IntegrableOn.iff_ofReal]
+    exact hre
+    apply Integrable.smul Complex.I
+    rw [← IntegrableOn, ← IntegrableOn.iff_ofReal]
+    exact him
+  have h1 : EqOn (fun x ↦ ((f x).re : ℂ) + Complex.I*((f x).im : ℂ)) (fun x ↦ f x) s := by
+    intro x _
+    dsimp
+    have (y: ℂ) : y.re + Complex.I*y.im = y := by
+      apply Complex.ext
+      all_goals simp
+    exact this (f x)
 
-theorem IntegrableOn.re {f : X → ℂ} (hf : IntegrableOn f s μ) :
-IntegrableOn (fun x => (f x).re) s μ  := (IntegrableOn.re_im_iff.2 hf).left
+  apply IntegrableOn.congr_fun h h1 hs
 
-theorem IntegrableOn.im {f : X → ℂ} (hf : IntegrableOn f s μ) :
-IntegrableOn (fun x => (f x).im) s μ := (IntegrableOn.re_im_iff.2 hf).right
+theorem IntegrableOn.re {f : X → ℂ} (hf : IntegrableOn f s μ) (hs : MeasurableSet s):
+    IntegrableOn (fun x => (f x).re) s μ  := ((IntegrableOn.re_im_iff hs).2 hf).left
+
+theorem IntegrableOn.im {f : X → ℂ} (hf : IntegrableOn f s μ) (hs: MeasurableSet s):
+    IntegrableOn (fun x => (f x).im) s μ := ((IntegrableOn.re_im_iff hs).2 hf).right
 
 end MeasureTheory

--- a/Mathlib/MeasureTheory/Integral/IntegrableOn.lean
+++ b/Mathlib/MeasureTheory/Integral/IntegrableOn.lean
@@ -128,10 +128,6 @@ theorem integrableOn_congr_fun (hst : EqOn f g s) (hs : MeasurableSet s) :
     IntegrableOn f s μ ↔ IntegrableOn g s μ :=
   ⟨fun h => h.congr_fun hst hs, fun h => h.congr_fun hst.symm hs⟩
 
-theorem integrableOn_iff_ofReal {X : Type*} [MeasurableSpace X] {μ : Measure X} {s : Set X}
-    {f : X → ℝ} : IntegrableOn f s μ ↔ IntegrableOn (fun x ↦ (f x : ℂ)) s μ :=
-    MeasureTheory.Integrable.iff_ofReal
-
 theorem Integrable.integrableOn (h : Integrable f μ) : IntegrableOn f s μ :=
   h.mono_measure <| Measure.restrict_le_self
 
@@ -699,3 +695,25 @@ theorem integrableOn_Iic_iff_integrableOn_Iio :
   integrableOn_Iic_iff_integrableOn_Iio' (by rw [measure_singleton]; exact ENNReal.zero_ne_top)
 
 end PartialOrder
+
+namespace MeasureTheory
+variable {X : Type*} [MeasurableSpace X] {μ : Measure X} {s : Set X}
+theorem IntegrableOn.iff_ofReal {f : X → ℝ} :
+IntegrableOn f s μ ↔ IntegrableOn (fun x ↦ (f x : ℂ)) s μ :=
+    MeasureTheory.Integrable.iff_ofReal
+
+theorem IntegrableOn.ofReal {f : X → ℝ} (hf : IntegrableOn f s μ) :
+    IntegrableOn (fun x => (f x : ℂ)) s μ := IntegrableOn.iff_ofReal.1 hf
+
+theorem IntegrableOn.re_im_iff {f : X → ℂ} :
+    IntegrableOn (fun x => (f x).re) s μ ∧ IntegrableOn (fun x => (f x).im) s μ ↔
+      IntegrableOn f s μ := by
+  sorry
+
+theorem IntegrableOn.re {f : X → ℂ} (hf : IntegrableOn f s μ) :
+IntegrableOn (fun x => (f x).re) s μ  := (IntegrableOn.re_im_iff.2 hf).left
+
+theorem IntegrableOn.im {f : X → ℂ} (hf : IntegrableOn f s μ) :
+IntegrableOn (fun x => (f x).im) s μ := (IntegrableOn.re_im_iff.2 hf).right
+
+end MeasureTheory

--- a/Mathlib/MeasureTheory/Integral/IntegrableOn.lean
+++ b/Mathlib/MeasureTheory/Integral/IntegrableOn.lean
@@ -697,22 +697,24 @@ theorem integrableOn_Iic_iff_integrableOn_Iio :
 end PartialOrder
 
 namespace MeasureTheory
-variable {X : Type*} [MeasurableSpace X] {μ : Measure X} {s : Set X}
+variable {X : Type*} [MeasurableSpace X] {𝕜 : Type*} [RCLike 𝕜] {μ : Measure X} {s : Set X}
 theorem IntegrableOn.iff_ofReal {f : X → ℝ} :
     IntegrableOn f s μ ↔ IntegrableOn (fun x ↦ (f x : ℂ)) s μ :=
     MeasureTheory.Integrable.iff_ofReal
 
 theorem IntegrableOn.ofReal {f : X → ℝ} (hf : IntegrableOn f s μ) :
-    IntegrableOn (fun x => (f x : ℂ)) s μ := IntegrableOn.iff_ofReal.1 hf
+    IntegrableOn (fun x => (f x : 𝕜)) s μ := by
+  rw [IntegrableOn, ← memℒp_one_iff_integrable] at hf ⊢
+  exact hf.ofReal
 
-theorem IntegrableOn.re_im_iff {f : X → ℂ} :
-    IntegrableOn (fun x => (f x).re) s μ ∧ IntegrableOn (fun x => (f x).im) s μ ↔
+theorem IntegrableOn.re_im_iff {f : X → 𝕜} :
+    IntegrableOn (fun x => RCLike.re (f x)) s μ ∧ IntegrableOn (fun x => RCLike.im (f x)) s μ ↔
     IntegrableOn f s μ := Integrable.re_im_iff (f := f)
 
-theorem IntegrableOn.re {f : X → ℂ} (hf : IntegrableOn f s μ) :
-    IntegrableOn (fun x => (f x).re) s μ  := (IntegrableOn.re_im_iff.2 hf).left
+theorem IntegrableOn.re {f : X → 𝕜} (hf : IntegrableOn f s μ) :
+    IntegrableOn (fun x => RCLike.re (f x)) s μ  := (IntegrableOn.re_im_iff.2 hf).left
 
-theorem IntegrableOn.im {f : X → ℂ} (hf : IntegrableOn f s μ) :
-    IntegrableOn (fun x => (f x).im) s μ := (IntegrableOn.re_im_iff.2 hf).right
+theorem IntegrableOn.im {f : X → 𝕜} (hf : IntegrableOn f s μ) :
+    IntegrableOn (fun x => RCLike.im (f x)) s μ := (IntegrableOn.re_im_iff.2 hf).right
 
 end MeasureTheory

--- a/Mathlib/MeasureTheory/Integral/IntegrableOn.lean
+++ b/Mathlib/MeasureTheory/Integral/IntegrableOn.lean
@@ -700,7 +700,7 @@ namespace MeasureTheory
 variable {X : Type*} [MeasurableSpace X] {𝕜 : Type*} [RCLike 𝕜] {μ : Measure X} {s : Set X}
 theorem IntegrableOn.iff_ofReal {f : X → ℝ} :
     IntegrableOn f s μ ↔ IntegrableOn (fun x ↦ (f x : ℂ)) s μ :=
-    MeasureTheory.Integrable.iff_ofReal
+  MeasureTheory.Integrable.iff_ofReal
 
 theorem IntegrableOn.ofReal {f : X → ℝ} (hf : IntegrableOn f s μ) :
     IntegrableOn (fun x => (f x : 𝕜)) s μ := by
@@ -712,7 +712,7 @@ theorem IntegrableOn.re_im_iff {f : X → 𝕜} :
     IntegrableOn f s μ := Integrable.re_im_iff (f := f)
 
 theorem IntegrableOn.re {f : X → 𝕜} (hf : IntegrableOn f s μ) :
-    IntegrableOn (fun x => RCLike.re (f x)) s μ  := (IntegrableOn.re_im_iff.2 hf).left
+    IntegrableOn (fun x => RCLike.re (f x)) s μ := (IntegrableOn.re_im_iff.2 hf).left
 
 theorem IntegrableOn.im {f : X → 𝕜} (hf : IntegrableOn f s μ) :
     IntegrableOn (fun x => RCLike.im (f x)) s μ := (IntegrableOn.re_im_iff.2 hf).right

--- a/Mathlib/MeasureTheory/Integral/IntegrableOn.lean
+++ b/Mathlib/MeasureTheory/Integral/IntegrableOn.lean
@@ -705,32 +705,14 @@ theorem IntegrableOn.iff_ofReal {f : X → ℝ} :
 theorem IntegrableOn.ofReal {f : X → ℝ} (hf : IntegrableOn f s μ) :
     IntegrableOn (fun x => (f x : ℂ)) s μ := IntegrableOn.iff_ofReal.1 hf
 
-theorem IntegrableOn.re_im_iff {f : X → ℂ} (hs: MeasurableSet s):
+theorem IntegrableOn.re_im_iff {f : X → ℂ} :
     IntegrableOn (fun x => (f x).re) s μ ∧ IntegrableOn (fun x => (f x).im) s μ ↔
-      IntegrableOn f s μ := by
-  refine ⟨?_, fun hf => ⟨hf.re, hf.im⟩⟩
-  rintro ⟨hre, him⟩
-  have h : IntegrableOn (fun x ↦ (f x).re + Complex.I*(f x).im) s μ := by
-    apply Integrable.add
-    rw [← IntegrableOn, ← IntegrableOn.iff_ofReal]
-    exact hre
-    apply Integrable.smul Complex.I
-    rw [← IntegrableOn, ← IntegrableOn.iff_ofReal]
-    exact him
-  have h1 : EqOn (fun x ↦ ((f x).re : ℂ) + Complex.I*((f x).im : ℂ)) (fun x ↦ f x) s := by
-    intro x _
-    dsimp
-    have (y: ℂ) : y.re + Complex.I*y.im = y := by
-      apply Complex.ext
-      all_goals simp
-    exact this (f x)
+    IntegrableOn f s μ := Integrable.re_im_iff (f := f)
 
-  apply IntegrableOn.congr_fun h h1 hs
+theorem IntegrableOn.re {f : X → ℂ} (hf : IntegrableOn f s μ) :
+    IntegrableOn (fun x => (f x).re) s μ  := (IntegrableOn.re_im_iff.2 hf).left
 
-theorem IntegrableOn.re {f : X → ℂ} (hf : IntegrableOn f s μ) (hs : MeasurableSet s):
-    IntegrableOn (fun x => (f x).re) s μ  := ((IntegrableOn.re_im_iff hs).2 hf).left
-
-theorem IntegrableOn.im {f : X → ℂ} (hf : IntegrableOn f s μ) (hs: MeasurableSet s):
-    IntegrableOn (fun x => (f x).im) s μ := ((IntegrableOn.re_im_iff hs).2 hf).right
+theorem IntegrableOn.im {f : X → ℂ} (hf : IntegrableOn f s μ) :
+    IntegrableOn (fun x => (f x).im) s μ := (IntegrableOn.re_im_iff.2 hf).right
 
 end MeasureTheory

--- a/Mathlib/MeasureTheory/Integral/IntervalIntegral.lean
+++ b/Mathlib/MeasureTheory/Integral/IntervalIntegral.lean
@@ -592,16 +592,12 @@ nonrec theorem integral_ofReal {a b : ℝ} {μ : Measure ℝ} {f : ℝ → ℝ} 
     (∫ x in a..b, (f x : ℂ) ∂μ) = ↑(∫ x in a..b, f x ∂μ) :=
   RCLike.intervalIntegral_ofReal
 
-theorem integral_re (μ: Measure ℝ) {a b : ℝ} {f:ℝ → ℂ} (hab: a ≤ b)
+theorem intervalIntegral_re {μ : Measure ℝ} {a b : ℝ} {f : ℝ → ℂ} (hab: a ≤ b)
     (hf: IntervalIntegrable f μ a b) :
-    ∫ x in (a)..b, (f x).re = (∫ x in (a)..b, f x).re := by
+    (∫ x in (a)..b, (f x).re ∂μ) = (∫ x in (a)..b, f x ∂μ).re := by
     repeat rw [intervalIntegral.integral_of_le hab]
     apply setIntegral_re
     rw [← intervalIntegrable_iff_integrableOn_Ioc_of_le hab]
-    have : IntervalIntegrable f μ a b = IntervalIntegrable f volume a b := by
-      dsimp
-      sorry
-    rw [← this]
     exact hf
 
 section ContinuousLinearMap

--- a/Mathlib/MeasureTheory/Integral/IntervalIntegral.lean
+++ b/Mathlib/MeasureTheory/Integral/IntervalIntegral.lean
@@ -602,10 +602,10 @@ nonrec theorem integral_ofReal {a b : ℝ} {μ : Measure ℝ} {f : ℝ → ℝ} 
 theorem intervalIntegral_re {μ : Measure ℝ} {a b : ℝ} {f : ℝ → ℂ} (hab: a ≤ b)
     (hf: IntervalIntegrable f μ a b) :
     (∫ x in (a)..b, (f x).re ∂μ) = (∫ x in (a)..b, f x ∂μ).re := by
-    repeat rw [intervalIntegral.integral_of_le hab]
-    apply setIntegral_re
-    rw [← intervalIntegrable_iff_integrableOn_Ioc_of_le hab]
-    exact hf
+  repeat rw [intervalIntegral.integral_of_le hab]
+  apply setIntegral_re
+  rw [← intervalIntegrable_iff_integrableOn_Ioc_of_le hab]
+  exact hf
 
 section ContinuousLinearMap
 

--- a/Mathlib/MeasureTheory/Integral/IntervalIntegral.lean
+++ b/Mathlib/MeasureTheory/Integral/IntervalIntegral.lean
@@ -315,6 +315,13 @@ theorem comp_sub_left (hf : IntervalIntegrable f volume a b) (c : ℝ) :
     IntervalIntegrable (fun x => f (c - x)) volume (c - a) (c - b) := by
   simpa only [neg_sub, ← sub_eq_add_neg] using iff_comp_neg.mp (hf.comp_add_left c)
 
+/-- A real-valued function is interval integrable iff the complex-valued analog is. -/
+lemma iff_ofReal {f : ℝ → ℝ} (hab: a ≤ b) :
+    IntervalIntegrable f μ a b ↔ IntervalIntegrable (fun x ↦ (f x : ℂ)) μ a b := by
+  repeat rw [intervalIntegrable_iff_integrableOn_Ioc_of_le]
+  apply integrableOn_iff_ofReal
+  all_goals exact hab
+
 end IntervalIntegrable
 
 /-!

--- a/Mathlib/MeasureTheory/Integral/IntervalIntegral.lean
+++ b/Mathlib/MeasureTheory/Integral/IntervalIntegral.lean
@@ -319,7 +319,7 @@ theorem comp_sub_left (hf : IntervalIntegrable f volume a b) (c : ℝ) :
 lemma iff_ofReal {f : ℝ → ℝ} (hab: a ≤ b) :
     IntervalIntegrable f μ a b ↔ IntervalIntegrable (fun x ↦ (f x : ℂ)) μ a b := by
   repeat rw [intervalIntegrable_iff_integrableOn_Ioc_of_le]
-  apply integrableOn_iff_ofReal
+  apply IntegrableOn.iff_ofReal
   all_goals exact hab
 
 end IntervalIntegrable

--- a/Mathlib/MeasureTheory/Integral/IntervalIntegral.lean
+++ b/Mathlib/MeasureTheory/Integral/IntervalIntegral.lean
@@ -592,6 +592,18 @@ nonrec theorem integral_ofReal {a b : ℝ} {μ : Measure ℝ} {f : ℝ → ℝ} 
     (∫ x in a..b, (f x : ℂ) ∂μ) = ↑(∫ x in a..b, f x ∂μ) :=
   RCLike.intervalIntegral_ofReal
 
+theorem integral_re (μ: Measure ℝ) {a b : ℝ} {f:ℝ → ℂ} (hab: a ≤ b)
+    (hf: IntervalIntegrable f μ a b) :
+    ∫ x in (a)..b, (f x).re = (∫ x in (a)..b, f x).re := by
+    repeat rw [intervalIntegral.integral_of_le hab]
+    apply setIntegral_re
+    rw [← intervalIntegrable_iff_integrableOn_Ioc_of_le hab]
+    have : IntervalIntegrable f μ a b = IntervalIntegrable f volume a b := by
+      dsimp
+      sorry
+    rw [← this]
+    exact hf
+
 section ContinuousLinearMap
 
 variable {a b : ℝ} {μ : Measure ℝ} {f : ℝ → E}

--- a/Mathlib/MeasureTheory/Integral/SetIntegral.lean
+++ b/Mathlib/MeasureTheory/Integral/SetIntegral.lean
@@ -1298,6 +1298,14 @@ theorem integral_re {f : X → 𝕜} (hf : Integrable f μ) :
     ∫ x, RCLike.re (f x) ∂μ = RCLike.re (∫ x, f x ∂μ) :=
   (@RCLike.reCLM 𝕜 _).integral_comp_comm hf
 
+theorem integral_re {X : Type*} [MeasurableSpace X]
+    (μ : Measure X) {f : X → ℂ} (hf : Integrable f μ) :
+    ∫ x, (f x).re ∂μ = (∫x, f x ∂μ).re := _root_.integral_re h
+
+theorem setIntegral_re {X : Type*} [MeasurableSpace X]
+    (μ : Measure X) {s : Set X} {f : X → ℂ} (hf : IntegrableOn f s μ) :
+    ∫ x in s, (f x).re ∂μ = (∫x in s, f x ∂μ).re := Complex.integral_re _ hf.integrable
+
 theorem integral_im {f : X → 𝕜} (hf : Integrable f μ) :
     ∫ x, RCLike.im (f x) ∂μ = RCLike.im (∫ x, f x ∂μ) :=
   (@RCLike.imCLM 𝕜 _).integral_comp_comm hf

--- a/Mathlib/MeasureTheory/Integral/SetIntegral.lean
+++ b/Mathlib/MeasureTheory/Integral/SetIntegral.lean
@@ -1298,13 +1298,13 @@ theorem integral_re {f : X → 𝕜} (hf : Integrable f μ) :
     ∫ x, RCLike.re (f x) ∂μ = RCLike.re (∫ x, f x ∂μ) :=
   (@RCLike.reCLM 𝕜 _).integral_comp_comm hf
 
-theorem integral_re {X : Type*} [MeasurableSpace X]
+theorem integral_re' {X : Type*} [MeasurableSpace X]
     (μ : Measure X) {f : X → ℂ} (hf : Integrable f μ) :
-    ∫ x, (f x).re ∂μ = (∫x, f x ∂μ).re := _root_.integral_re h
+    ∫ x, (f x).re ∂μ = (∫x, f x ∂μ).re := _root_.integral_re hf
 
 theorem setIntegral_re {X : Type*} [MeasurableSpace X]
     (μ : Measure X) {s : Set X} {f : X → ℂ} (hf : IntegrableOn f s μ) :
-    ∫ x in s, (f x).re ∂μ = (∫x in s, f x ∂μ).re := Complex.integral_re _ hf.integrable
+    ∫ x in s, (f x).re ∂μ = (∫x in s, f x ∂μ).re := integral_re' _ hf.integrable
 
 theorem integral_im {f : X → 𝕜} (hf : Integrable f μ) :
     ∫ x, RCLike.im (f x) ∂μ = RCLike.im (∫ x, f x ∂μ) :=

--- a/Mathlib/MeasureTheory/Integral/SetIntegral.lean
+++ b/Mathlib/MeasureTheory/Integral/SetIntegral.lean
@@ -1298,13 +1298,11 @@ theorem integral_re {f : X → 𝕜} (hf : Integrable f μ) :
     ∫ x, RCLike.re (f x) ∂μ = RCLike.re (∫ x, f x ∂μ) :=
   (@RCLike.reCLM 𝕜 _).integral_comp_comm hf
 
-theorem integral_re' {X : Type*} [MeasurableSpace X]
-    (μ : Measure X) {f : X → ℂ} (hf : Integrable f μ) :
+theorem Complex.integral_re {f : X → ℂ} (hf : Integrable f μ) :
     ∫ x, (f x).re ∂μ = (∫x, f x ∂μ).re := _root_.integral_re hf
 
-theorem setIntegral_re {X : Type*} [MeasurableSpace X]
-    (μ : Measure X) {s : Set X} {f : X → ℂ} (hf : IntegrableOn f s μ) :
-    ∫ x in s, (f x).re ∂μ = (∫x in s, f x ∂μ).re := integral_re' _ hf.integrable
+theorem setIntegral_re {s : Set X} {f : X → ℂ} (hf : IntegrableOn f s μ) :
+    ∫ x in s, (f x).re ∂μ = (∫x in s, f x ∂μ).re := Complex.integral_re hf.integrable
 
 theorem integral_im {f : X → 𝕜} (hf : Integrable f μ) :
     ∫ x, RCLike.im (f x) ∂μ = RCLike.im (∫ x, f x ∂μ) :=


### PR DESCRIPTION
Lemmas for swapping order of .re and integration/integrability. 

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
