### PR TITLE
[Merged by Bors] - feat(Algebra/FreeMonoid/Basic): define length, membership, reversing, induction principles

### DIFF
--- a/Mathlib/Algebra/FreeMonoid/Basic.lean
+++ b/Mathlib/Algebra/FreeMonoid/Basic.lean
@@ -146,29 +146,6 @@ theorem of_ne_one (a : α) : of a ≠ 1 := by
 
 end Length
 
-/-! ### symbols -/
-
-section Symbols
-variable [DecidableEq α]
-
-/-- The set of unique symbols in a free monoid element -/
-@[to_additive "The set of unique symbols in an additive free monoid element"]
-def symbols (a : FreeMonoid α) : Finset α := List.toFinset a
-
-@[to_additive (attr := simp)]
-theorem symbols_one : symbols (1 : FreeMonoid α) = ∅ := rfl
-
-@[to_additive (attr := simp)]
-theorem symbols_of {m : α} : symbols (of m : FreeMonoid α) = {m} := rfl
-
-@[to_additive (attr := simp)]
-theorem symbols_mul (a b : FreeMonoid α) :
-    symbols (a * b : FreeMonoid α) = symbols a ∪ symbols b := by
-  simp only [symbols, List.mem_toFinset, Finset.mem_union]
-  apply List.toFinset_append
-
-end Symbols
-
 section Mem
 variable {m : α}
 
@@ -190,10 +167,6 @@ theorem mem_of_self : m ∈ of m := List.mem_singleton_self _
 
 @[to_additive (attr := simp)]
 theorem mem_mul {a b : FreeMonoid α} : m ∈ (a * b) ↔ m ∈ a ∨ m ∈ b := List.mem_append
-
-@[to_additive (attr := simp)]
-theorem mem_symbols [DecidableEq α] {a : FreeMonoid α}: m ∈ symbols a ↔ m ∈ a :=
-  List.mem_toFinset
 
 end Mem
 

--- a/Mathlib/Algebra/FreeMonoid/Basic.lean
+++ b/Mathlib/Algebra/FreeMonoid/Basic.lean
@@ -6,7 +6,6 @@ Authors: Simon Hudon, Yury Kudryashov
 import Mathlib.Algebra.BigOperators.Group.List
 import Mathlib.Algebra.Group.Action.Defs
 import Mathlib.Algebra.Group.Units
-import Mathlib.Data.Finset.Basic
 
 /-!
 # Free monoid over a given alphabet

--- a/Mathlib/Algebra/FreeMonoid/Basic.lean
+++ b/Mathlib/Algebra/FreeMonoid/Basic.lean
@@ -120,7 +120,7 @@ def length (a : FreeMonoid α) : ℕ := List.length a
 @[to_additive (attr := simp)]
 theorem length_one : length (1 : FreeMonoid α) = 0 := rfl
 
-@[to_additive (attr := simp)]
+@[to_additive]
 theorem eq_one_of_length_eq_zero (h : length a = 0) : a = 1 :=
   List.eq_nil_of_length_eq_zero h
 
@@ -135,7 +135,7 @@ theorem length_eq_one : length a = 1 ↔ ∃ m, a = FreeMonoid.of m :=
 theorem length_eq_two {v : FreeMonoid α}: v.length = 2 ↔ ∃ c d,
     v = FreeMonoid.of c * FreeMonoid.of d := List.length_eq_two
 
-@[to_additive (attr := simp)]
+@[to_additive]
 theorem length_mul (a b : FreeMonoid α) : (a * b).length = a.length + b.length :=
   List.length_append _ _
 
@@ -159,10 +159,10 @@ def symbols (a : FreeMonoid α) : Finset α := List.toFinset a
 @[to_additive (attr := simp)]
 theorem symbols_one : symbols (1 : FreeMonoid α) = ∅ := rfl
 
-@[to_additive (attr := simp)]
+@[to_additive]
 theorem symbols_of {m : α} : symbols (of m : FreeMonoid α) = {m} := rfl
 
-@[to_additive (attr := simp)]
+@[to_additive]
 theorem symbols_mul {a b : FreeMonoid α} : symbols (a * b : FreeMonoid α) =
     (symbols a) ∪ (symbols b) := by
   simp only [symbols, List.mem_toFinset, Finset.mem_union]
@@ -400,15 +400,15 @@ def reverse : FreeMonoid α → FreeMonoid α := List.reverse
 @[to_additive (attr := simp)]
 theorem reverse_of {a : α} : reverse (of a) = of a := rfl
 
-@[to_additive (attr := simp)]
+@[to_additive]
 theorem reverse_mul {a b : FreeMonoid α} : reverse (a * b) = reverse b * reverse a :=
   List.reverse_append _ _
 
-@[to_additive (attr := simp)]
+@[to_additive]
 theorem reverse_reverse {a : FreeMonoid α} : reverse (reverse a) = a := by
   apply List.reverse_reverse
 
-@[to_additive (attr := simp)]
+@[to_additive]
 theorem reverse_length {a : FreeMonoid α} : a.reverse.length = a.length :=
   List.length_reverse _
 

--- a/Mathlib/Algebra/FreeMonoid/Basic.lean
+++ b/Mathlib/Algebra/FreeMonoid/Basic.lean
@@ -180,7 +180,7 @@ def mem (a : FreeMonoid α) (m : α) := m ∈ toList a
 instance : Membership α (FreeMonoid α) := ⟨mem⟩
 
 @[to_additive]
-theorem mem_one_iff : m ∈ (1 : FreeMonoid α) ↔ False := List.mem_nil_iff _
+theorem not_mem_one : ¬ m ∈ (1 : FreeMonoid α) := List.not_mem_nil
 
 @[to_additive (attr := simp)]
 theorem mem_of {n : α} : m ∈ of n ↔ m = n := List.mem_singleton

--- a/Mathlib/Algebra/FreeMonoid/Basic.lean
+++ b/Mathlib/Algebra/FreeMonoid/Basic.lean
@@ -139,7 +139,7 @@ theorem length_mul (a b : FreeMonoid α) : (a * b).length = a.length + b.length 
   List.length_append _ _
 
 @[to_additive]
-theorem of_neq_one (a : α) : of a ≠ 1 := by
+theorem of_ne_one (a : α) : of a ≠ 1 := by
   intro h
   have := congrArg FreeMonoid.length h
   simp only [length_of, length_one, Nat.succ_ne_self] at this

--- a/Mathlib/Algebra/FreeMonoid/Basic.lean
+++ b/Mathlib/Algebra/FreeMonoid/Basic.lean
@@ -404,7 +404,7 @@ theorem reverse_of {a : α} : reverse (of a) = of a := rfl
 theorem reverse_mul {a b : FreeMonoid α} : reverse (a * b) = reverse b * reverse a :=
   List.reverse_append _ _
 
-@[to_additive]
+@[to_additive (attr := simp)]
 theorem reverse_reverse {a : FreeMonoid α} : reverse (reverse a) = a := by
   apply List.reverse_reverse
 

--- a/Mathlib/Algebra/FreeMonoid/Basic.lean
+++ b/Mathlib/Algebra/FreeMonoid/Basic.lean
@@ -183,7 +183,7 @@ instance : Membership α (FreeMonoid α) := ⟨mem⟩
 theorem mem_one_iff : m ∈ (1 : FreeMonoid α) ↔ False := List.mem_nil_iff _
 
 @[to_additive]
-theorem mem_of {n : α} : m ∈ (of n) ↔ m = n := List.mem_singleton
+theorem mem_of {n : α} : m ∈ of n ↔ m = n := List.mem_singleton
 
 @[to_additive]
 theorem mem_of_self : m ∈ of m := List.mem_singleton_self _

--- a/Mathlib/Algebra/FreeMonoid/Basic.lean
+++ b/Mathlib/Algebra/FreeMonoid/Basic.lean
@@ -182,7 +182,7 @@ instance : Membership α (FreeMonoid α) := ⟨mem⟩
 @[to_additive]
 theorem mem_one_iff : m ∈ (1 : FreeMonoid α) ↔ False := List.mem_nil_iff _
 
-@[to_additive]
+@[to_additive (attr := simp)]
 theorem mem_of {n : α} : m ∈ of n ↔ m = n := List.mem_singleton
 
 @[to_additive]

--- a/Mathlib/Algebra/FreeMonoid/Basic.lean
+++ b/Mathlib/Algebra/FreeMonoid/Basic.lean
@@ -380,7 +380,19 @@ instance uniqueUnits : Unique (FreeMonoid α)ˣ where
     (List.append_eq_nil.mp this).1
 
 @[to_additive]
-theorem map_surjective {f : α → β} : Function.Surjective f → Function.Surjective (map f) := by
+theorem map_surjective {f : α → β} : Function.Surjective (map f) ↔ Function.Surjective f := by
+  constructor
+  · intro fs d
+    rcases fs (FreeMonoid.of d) with ⟨b, hb⟩
+    induction' b using FreeMonoid.inductionOn' with head _ _
+    · have H := congr_arg length hb
+      simp only [length_one, length_of, Nat.zero_ne_one, map_one] at H
+    simp only [map_mul, map_of] at hb
+    use head
+    have H := congr_arg length hb
+    simp only [length_mul, length_of, add_right_eq_self, length_eq_zero] at H
+    rw [H, mul_one] at hb
+    exact FreeMonoid.of_injective hb
   intro fs d
   induction' d using FreeMonoid.inductionOn' with head tail ih
   · use 1

--- a/Mathlib/Algebra/FreeMonoid/Basic.lean
+++ b/Mathlib/Algebra/FreeMonoid/Basic.lean
@@ -418,7 +418,7 @@ end Reverse
 /-- if two types are isomorphic, the free monoids over those types are isomorphic -/
 @[to_additive "if two types are isomorphic, the additive free monoids over those types are
 isomorphic"]
-def congr_iso {α : Type u_1} {β : Type u_2} (e : α ≃ β) : FreeMonoid α ≃* FreeMonoid β := by
+def congrIso {α : Type u_1} {β : Type u_2} (e : α ≃ β) : FreeMonoid α ≃* FreeMonoid β := by
   apply MulEquiv.mk' ⟨FreeMonoid.map e.toFun, FreeMonoid.map e.invFun, _, _⟩
   · simp
   all_goals

--- a/Mathlib/Algebra/FreeMonoid/Basic.lean
+++ b/Mathlib/Algebra/FreeMonoid/Basic.lean
@@ -131,8 +131,8 @@ theorem length_eq_one : length a = 1 ↔ ∃ m, a = FreeMonoid.of m :=
   List.length_eq_one
 
 @[to_additive]
-theorem length_eq_two {v : FreeMonoid α}: v.length = 2 ↔ ∃ c d,
-    v = FreeMonoid.of c * FreeMonoid.of d := List.length_eq_two
+theorem length_eq_two {v : FreeMonoid α} :
+    v.length = 2 ↔ ∃ c d, v = FreeMonoid.of c * FreeMonoid.of d := List.length_eq_two
 
 @[to_additive (attr := simp)]
 theorem length_mul (a b : FreeMonoid α) : (a * b).length = a.length + b.length :=

--- a/Mathlib/Algebra/FreeMonoid/Basic.lean
+++ b/Mathlib/Algebra/FreeMonoid/Basic.lean
@@ -139,7 +139,7 @@ theorem length_eq_two {v : FreeMonoid α}: v.length = 2 ↔ ∃ c d,
 theorem length_mul (a b : FreeMonoid α) : (a * b).length = a.length + b.length :=
   List.length_append _ _
 
-@[to_additive (attr := simp)]
+@[to_additive]
 theorem of_neq_one (a : α) : of a ≠ 1 := by
   intro h
   have := congrArg FreeMonoid.length h

--- a/Mathlib/Algebra/FreeMonoid/Basic.lean
+++ b/Mathlib/Algebra/FreeMonoid/Basic.lean
@@ -225,10 +225,10 @@ protected theorem inductionOn {C : FreeMonoid α → Prop} (z : FreeMonoid α) (
     (of : ∀ (x : α), C (FreeMonoid.of x)) (mul : ∀ (x y : FreeMonoid α), C x → C y → C (x * y)) :
   C z := List.rec one (fun _ _ ih => mul [_] _ (of _) ih) z
 
-/-- An induction principle for free monoids which mirrors induction on lists, with cases anaologous
+/-- An induction principle for free monoids which mirrors induction on lists, with cases analogous
 to the empty list and cons -/
 @[to_additive (attr := elab_as_elim) "An induction principle for free monoids which mirrors
-induction on lists, with cases anaologous to the empty list and cons"]
+induction on lists, with cases analogous to the empty list and cons"]
 protected theorem inductionOn' {p : FreeMonoid α → Prop} (a : FreeMonoid α)
     (one : p (1 : FreeMonoid α)) (mul_of : ∀ b a, p a → p (of b * a)) : p a :=
   List.rec one (fun _ _ tail_ih => mul_of _ _ tail_ih) a

--- a/Mathlib/Algebra/FreeMonoid/Basic.lean
+++ b/Mathlib/Algebra/FreeMonoid/Basic.lean
@@ -188,7 +188,7 @@ theorem mem_of {n : α} : m ∈ of n ↔ m = n := List.mem_singleton
 @[to_additive]
 theorem mem_of_self : m ∈ of m := List.mem_singleton_self _
 
-@[to_additive]
+@[to_additive (attr := simp)]
 theorem mem_mul {a b : FreeMonoid α} : m ∈ (a * b) ↔ m ∈ a ∨ m ∈ b := List.mem_append
 
 @[to_additive]

--- a/Mathlib/Algebra/FreeMonoid/Basic.lean
+++ b/Mathlib/Algebra/FreeMonoid/Basic.lean
@@ -151,7 +151,7 @@ end Length
 section Symbols
 variable [DecidableEq α]
 
-/-- the set of unique symbols in a free monoid element -/
+/-- The set of unique symbols in a free monoid element -/
 @[to_additive "The set of unique symbols in an additive free monoid element"]
 def symbols (a : FreeMonoid α) : Finset α := List.toFinset a
 

--- a/Mathlib/Algebra/FreeMonoid/Basic.lean
+++ b/Mathlib/Algebra/FreeMonoid/Basic.lean
@@ -429,7 +429,7 @@ def congr_iso {α : Type u_1} {β : Type u_2} (e : α ≃ β) : FreeMonoid α �
 have an underlying type of β -/
 @[to_additive "given an isomorphism between α and β, convert a relation predicate to
 have an underlying type of β"]
-def map_rel (e : α ≃ β) (rel : FreeMonoid α → FreeMonoid α → Prop) :
+def mapRel (e : α ≃ β) (rel : FreeMonoid α → FreeMonoid α → Prop) :
     FreeMonoid β → FreeMonoid β  → Prop :=
   fun a b ↦ rel (FreeMonoid.congr_iso e.symm a) (FreeMonoid.congr_iso e.symm b)
 

--- a/Mathlib/Algebra/FreeMonoid/Basic.lean
+++ b/Mathlib/Algebra/FreeMonoid/Basic.lean
@@ -379,7 +379,7 @@ instance uniqueUnits : Unique (FreeMonoid α)ˣ where
     have : toList u.val ++ toList u.inv = [] := DFunLike.congr_arg toList u.val_inv
     (List.append_eq_nil.mp this).1
 
-@[to_additive]
+@[to_additive (attr := simp)]
 theorem map_surjective {f : α → β} : Function.Surjective (map f) ↔ Function.Surjective f := by
   constructor
   · intro fs d

--- a/Mathlib/Algebra/FreeMonoid/Basic.lean
+++ b/Mathlib/Algebra/FreeMonoid/Basic.lean
@@ -124,7 +124,7 @@ theorem length_one : length (1 : FreeMonoid α) = 0 := rfl
 theorem length_eq_zero : length a = 0 ↔ a = 1 := List.length_eq_zero
 
 @[to_additive (attr := simp)]
-theorem length_of {m : α}: length (of m) = 1 := rfl
+theorem length_of (m : α) : length (of m) = 1 := rfl
 
 @[to_additive]
 theorem length_eq_one : length a = 1 ↔ ∃ m, a = FreeMonoid.of m :=

--- a/Mathlib/Algebra/FreeMonoid/Basic.lean
+++ b/Mathlib/Algebra/FreeMonoid/Basic.lean
@@ -126,7 +126,7 @@ theorem length_eq_zero : length a = 0 ↔ a = 1 := List.length_eq_zero
 @[to_additive (attr := simp)]
 theorem length_of (m : α) : length (of m) = 1 := rfl
 
-@[to_additive]
+@[to_additive existing]
 theorem length_eq_one : length a = 1 ↔ ∃ m, a = FreeMonoid.of m :=
   List.length_eq_one
 

--- a/Mathlib/Algebra/FreeMonoid/Basic.lean
+++ b/Mathlib/Algebra/FreeMonoid/Basic.lean
@@ -345,7 +345,7 @@ def map (f : α → β) : FreeMonoid α →* FreeMonoid β where
 @[to_additive (attr := simp)]
 theorem map_of (f : α → β) (x : α) : map f (of x) = of (f x) := rfl
 
-@[to_additive (attr := simp)]
+@[to_additive]
 theorem mem_map {m : β} : m ∈ map f a ↔ ∃ n ∈ a, f n = m := List.mem_map
 
 @[to_additive]

--- a/Mathlib/Algebra/FreeMonoid/Basic.lean
+++ b/Mathlib/Algebra/FreeMonoid/Basic.lean
@@ -172,8 +172,8 @@ end Symbols
 section Mem
 variable {m : α}
 
-/-- membership in a free monoid element -/
-@[to_additive "membership in a free monoid element"]
+/-- Membership in a free monoid element -/
+@[to_additive "Membership in a free monoid element"]
 def mem (a : FreeMonoid α) (m : α) := m ∈ toList a
 
 @[to_additive]

--- a/Mathlib/Algebra/FreeMonoid/Basic.lean
+++ b/Mathlib/Algebra/FreeMonoid/Basic.lean
@@ -112,8 +112,8 @@ theorem of_injective : Function.Injective (@of α) := List.singleton_injective
 section Length
 variable {a : FreeMonoid α}
 
-/-- the length of a free monoid element: 1.length = 0 and (a * b).length = a.length + b.length -/
-@[to_additive "the length of a additive free monoid element: 1.length = 0 and (a + b).length =
+/-- The length of a free monoid element: 1.length = 0 and (a * b).length = a.length + b.length -/
+@[to_additive "The length of a additive free monoid element: 1.length = 0 and (a + b).length =
   a.length + b.length"]
 def length (a : FreeMonoid α) : ℕ := List.length a
 

--- a/Mathlib/Algebra/FreeMonoid/Basic.lean
+++ b/Mathlib/Algebra/FreeMonoid/Basic.lean
@@ -408,7 +408,7 @@ theorem reverse_reverse {a : FreeMonoid α} : reverse (reverse a) = a := by
   apply List.reverse_reverse
 
 @[to_additive (attr := simp)]
-theorem reverse_length {a : FreeMonoid α} : a.reverse.length = a.length :=
+theorem length_reverse {a : FreeMonoid α} : a.reverse.length = a.length :=
   List.length_reverse _
 
 end Reverse

--- a/Mathlib/Algebra/FreeMonoid/Basic.lean
+++ b/Mathlib/Algebra/FreeMonoid/Basic.lean
@@ -152,7 +152,7 @@ section Symbols
 variable [DecidableEq α]
 
 /-- the set of unique symbols in a free monoid element -/
-@[to_additive "the set of unique symbols in an additive free monoid element"]
+@[to_additive "The set of unique symbols in an additive free monoid element"]
 def symbols (a : FreeMonoid α) : Finset α := List.toFinset a
 
 @[to_additive (attr := simp)]

--- a/Mathlib/Algebra/FreeMonoid/Basic.lean
+++ b/Mathlib/Algebra/FreeMonoid/Basic.lean
@@ -217,8 +217,9 @@ theorem recOn_of_mul {C : FreeMonoid α → Sort*} (x : α) (xs : FreeMonoid α)
 /-! ### induction -/
 section induction_principles
 
-/-- an induction principle on free monoids, with cases for one, ofs, and multiplication -/
-@[to_additive (attr := elab_as_elim, induction_eliminator)]
+/-- An induction principle on free monoids, with cases for `1`, `FreeMonoid.of` and `*`. -/
+@[to_additive (attr := elab_as_elim, induction_eliminator)
+"An induction principle on free monoids, with cases for `0`, `FreeAddMonoid.of` and `+`."]
 protected theorem inductionOn {C : FreeMonoid α → Prop} (z : FreeMonoid α) (one : C 1)
     (of : ∀ (x : α), C (FreeMonoid.of x)) (mul : ∀ (x y : FreeMonoid α), C x → C y → C (x * y)) :
   C z := List.rec one (fun _ _ ih => mul [_] _ (of _) ih) z

--- a/Mathlib/Algebra/FreeMonoid/Basic.lean
+++ b/Mathlib/Algebra/FreeMonoid/Basic.lean
@@ -135,7 +135,7 @@ theorem length_eq_one : length a = 1 ↔ ∃ m, a = FreeMonoid.of m :=
 theorem length_eq_two {v : FreeMonoid α}: v.length = 2 ↔ ∃ c d,
     v = FreeMonoid.of c * FreeMonoid.of d := List.length_eq_two
 
-@[to_additive]
+@[to_additive (attr := simp)]
 theorem length_mul (a b : FreeMonoid α) : (a * b).length = a.length + b.length :=
   List.length_append _ _
 
@@ -162,7 +162,7 @@ theorem symbols_one : symbols (1 : FreeMonoid α) = ∅ := rfl
 @[to_additive (attr := simp)]
 theorem symbols_of {m : α} : symbols (of m : FreeMonoid α) = {m} := rfl
 
-@[to_additive]
+@[to_additive (attr := simp)]
 theorem symbols_mul {a b : FreeMonoid α} : symbols (a * b : FreeMonoid α) =
     (symbols a) ∪ (symbols b) := by
   simp only [symbols, List.mem_toFinset, Finset.mem_union]

--- a/Mathlib/Algebra/FreeMonoid/Basic.lean
+++ b/Mathlib/Algebra/FreeMonoid/Basic.lean
@@ -180,7 +180,7 @@ def mem (a : FreeMonoid α) (m : α) := m ∈ toList a
 instance : Membership α (FreeMonoid α) := ⟨mem⟩
 
 @[to_additive]
-theorem not_mem_one : ¬ m ∈ (1 : FreeMonoid α) := List.not_mem_nil
+theorem not_mem_one : ¬ m ∈ (1 : FreeMonoid α) := List.not_mem_nil _
 
 @[to_additive (attr := simp)]
 theorem mem_of {n : α} : m ∈ of n ↔ m = n := List.mem_singleton

--- a/Mathlib/Algebra/FreeMonoid/Basic.lean
+++ b/Mathlib/Algebra/FreeMonoid/Basic.lean
@@ -120,9 +120,8 @@ def length (a : FreeMonoid α) : ℕ := List.length a
 @[to_additive (attr := simp)]
 theorem length_one : length (1 : FreeMonoid α) = 0 := rfl
 
-@[to_additive]
-theorem eq_one_of_length_eq_zero (h : length a = 0) : a = 1 :=
-  List.eq_nil_of_length_eq_zero h
+@[to_additive (attr := simp)]
+theorem length_eq_zero : length a = 0 ↔ a = 1 := List.length_eq_zero
 
 @[to_additive (attr := simp)]
 theorem length_of {m : α}: length (of m) = 1 := rfl

--- a/Mathlib/Algebra/FreeMonoid/Basic.lean
+++ b/Mathlib/Algebra/FreeMonoid/Basic.lean
@@ -162,8 +162,8 @@ theorem symbols_one : symbols (1 : FreeMonoid α) = ∅ := rfl
 theorem symbols_of {m : α} : symbols (of m : FreeMonoid α) = {m} := rfl
 
 @[to_additive (attr := simp)]
-theorem symbols_mul {a b : FreeMonoid α} : symbols (a * b : FreeMonoid α) =
-    (symbols a) ∪ (symbols b) := by
+theorem symbols_mul (a b : FreeMonoid α) :
+    symbols (a * b : FreeMonoid α) = symbols a ∪ symbols b := by
   simp only [symbols, List.mem_toFinset, Finset.mem_union]
   apply List.toFinset_append
 

--- a/Mathlib/Algebra/FreeMonoid/Basic.lean
+++ b/Mathlib/Algebra/FreeMonoid/Basic.lean
@@ -113,7 +113,7 @@ section Length
 variable {a : FreeMonoid α}
 
 /-- The length of a free monoid element: 1.length = 0 and (a * b).length = a.length + b.length -/
-@[to_additive "The length of a additive free monoid element: 1.length = 0 and (a + b).length =
+@[to_additive "The length of an additive free monoid element: 1.length = 0 and (a + b).length =
   a.length + b.length"]
 def length (a : FreeMonoid α) : ℕ := List.length a
 

--- a/Mathlib/Algebra/FreeMonoid/Basic.lean
+++ b/Mathlib/Algebra/FreeMonoid/Basic.lean
@@ -191,8 +191,8 @@ theorem mem_of_self : m ∈ of m := List.mem_singleton_self _
 @[to_additive (attr := simp)]
 theorem mem_mul {a b : FreeMonoid α} : m ∈ (a * b) ↔ m ∈ a ∨ m ∈ b := List.mem_append
 
-@[to_additive]
-theorem mem_symbols [DecidableEq α] {a : FreeMonoid α}: m ∈ FreeMonoid.symbols a ↔ m ∈ a :=
+@[to_additive (attr := simp)]
+theorem mem_symbols [DecidableEq α] {a : FreeMonoid α}: m ∈ symbols a ↔ m ∈ a :=
   List.mem_toFinset
 
 end Mem

--- a/Mathlib/Algebra/FreeMonoid/Basic.lean
+++ b/Mathlib/Algebra/FreeMonoid/Basic.lean
@@ -107,7 +107,7 @@ theorem toList_of_mul (x : α) (xs : FreeMonoid α) : toList (of x * xs) = x :: 
 @[to_additive]
 theorem of_injective : Function.Injective (@of α) := List.singleton_injective
 
-/-! ### length -/
+/-! ### Length -/
 
 section Length
 variable {a : FreeMonoid α}

--- a/Mathlib/Algebra/FreeMonoid/Basic.lean
+++ b/Mathlib/Algebra/FreeMonoid/Basic.lean
@@ -435,7 +435,7 @@ def map_rel (e : α ≃ β) (rel : FreeMonoid α → FreeMonoid α → Prop) :
 one with underlying type α -/
 @[to_additive "given an isomorphism between α and β, pull back a relation predicate with underlying
 type β to one with underlying type α "]
-def comap_rel (e : α ≃ β) (rel : FreeMonoid β → FreeMonoid β → Prop) :
+def comapRel (e : α ≃ β) (rel : FreeMonoid β → FreeMonoid β → Prop) :
     FreeMonoid α → FreeMonoid α → Prop :=
   fun a b ↦ rel (FreeMonoid.congr_iso e a) (FreeMonoid.congr_iso e b)
 

--- a/Mathlib/Algebra/FreeMonoid/Basic.lean
+++ b/Mathlib/Algebra/FreeMonoid/Basic.lean
@@ -415,30 +415,4 @@ theorem length_reverse {a : FreeMonoid α} : a.reverse.length = a.length :=
 
 end Reverse
 
-/-- if two types are isomorphic, the free monoids over those types are isomorphic -/
-@[to_additive "if two types are isomorphic, the additive free monoids over those types are
-isomorphic"]
-def congrIso {α : Type u_1} {β : Type u_2} (e : α ≃ β) : FreeMonoid α ≃* FreeMonoid β := by
-  apply MulEquiv.mk' ⟨FreeMonoid.map e.toFun, FreeMonoid.map e.invFun, _, _⟩
-  · simp
-  all_goals
-  intro x
-  simp [map_map]
-
-/-- given an isomorphism between α and β, convert a relation predicate to
-have an underlying type of β -/
-@[to_additive "given an isomorphism between α and β, convert a relation predicate to
-have an underlying type of β"]
-def mapRel (e : α ≃ β) (rel : FreeMonoid α → FreeMonoid α → Prop) :
-    FreeMonoid β → FreeMonoid β  → Prop :=
-  fun a b ↦ rel (FreeMonoid.congr_iso e.symm a) (FreeMonoid.congr_iso e.symm b)
-
-/-- given an isomorphism between α and β, pull back a relation predicate with underlying type β to
-one with underlying type α -/
-@[to_additive "given an isomorphism between α and β, pull back a relation predicate with underlying
-type β to one with underlying type α "]
-def comapRel (e : α ≃ β) (rel : FreeMonoid β → FreeMonoid β → Prop) :
-    FreeMonoid α → FreeMonoid α → Prop :=
-  fun a b ↦ rel (FreeMonoid.congr_iso e a) (FreeMonoid.congr_iso e b)
-
 end FreeMonoid

--- a/Mathlib/Algebra/FreeMonoid/Basic.lean
+++ b/Mathlib/Algebra/FreeMonoid/Basic.lean
@@ -378,7 +378,7 @@ instance uniqueUnits : Unique (FreeMonoid α)ˣ where
     (List.append_eq_nil.mp this).1
 
 @[to_additive]
-theorem map_surjective (f : α → β) : Function.Surjective f → Function.Surjective (map f) := by
+theorem map_surjective {f : α → β} : Function.Surjective f → Function.Surjective (map f) := by
   intro fs d
   induction' d using FreeMonoid.inductionOn' with head tail ih
   · use 1

--- a/Mathlib/Algebra/FreeMonoid/Basic.lean
+++ b/Mathlib/Algebra/FreeMonoid/Basic.lean
@@ -398,7 +398,7 @@ section Reverse
 def reverse : FreeMonoid α → FreeMonoid α := List.reverse
 
 @[to_additive (attr := simp)]
-theorem reverse_of {a : α} : reverse (of a) = of a := rfl
+theorem reverse_of (a : α) : reverse (of a) = of a := rfl
 
 @[to_additive]
 theorem reverse_mul {a b : FreeMonoid α} : reverse (a * b) = reverse b * reverse a :=

--- a/Mathlib/Algebra/FreeMonoid/Basic.lean
+++ b/Mathlib/Algebra/FreeMonoid/Basic.lean
@@ -423,7 +423,7 @@ def congr_iso {α : Type u_1} {β : Type u_2} (e : α ≃ β) : FreeMonoid α �
   all_goals
   intro x
   simp [map_map]
-  
+
 /-- given an isomorphism between α and β, convert a relation predicate to
 have an underlying type of β -/
 @[to_additive "given an isomorphism between α and β, convert a relation predicate to

--- a/Mathlib/Algebra/FreeMonoid/Basic.lean
+++ b/Mathlib/Algebra/FreeMonoid/Basic.lean
@@ -183,16 +183,16 @@ instance : Membership α (FreeMonoid α) := ⟨mem⟩
 @[to_additive]
 theorem mem_one_iff : m ∈ (1 : FreeMonoid α) ↔ False := List.mem_nil_iff _
 
-@[to_additive (attr := simp)]
+@[to_additive]
 theorem mem_of {n : α} : m ∈ (of n) ↔ m = n := List.mem_singleton
 
 @[to_additive]
 theorem mem_of_self : m ∈ of m := List.mem_singleton_self _
 
-@[to_additive (attr := simp)]
+@[to_additive]
 theorem mem_mul {a b : FreeMonoid α} : m ∈ (a * b) ↔ m ∈ a ∨ m ∈ b := List.mem_append
 
-@[to_additive (attr := simp)]
+@[to_additive]
 theorem mem_symbols [DecidableEq α] {a : FreeMonoid α}: m ∈ FreeMonoid.symbols a ↔ m ∈ a :=
   List.mem_toFinset
 

--- a/Mathlib/Algebra/FreeMonoid/Basic.lean
+++ b/Mathlib/Algebra/FreeMonoid/Basic.lean
@@ -159,7 +159,7 @@ def symbols (a : FreeMonoid α) : Finset α := List.toFinset a
 @[to_additive (attr := simp)]
 theorem symbols_one : symbols (1 : FreeMonoid α) = ∅ := rfl
 
-@[to_additive]
+@[to_additive (attr := simp)]
 theorem symbols_of {m : α} : symbols (of m : FreeMonoid α) = {m} := rfl
 
 @[to_additive]
@@ -408,7 +408,7 @@ theorem reverse_mul {a b : FreeMonoid α} : reverse (a * b) = reverse b * revers
 theorem reverse_reverse {a : FreeMonoid α} : reverse (reverse a) = a := by
   apply List.reverse_reverse
 
-@[to_additive]
+@[to_additive (attr := simp)]
 theorem reverse_length {a : FreeMonoid α} : a.reverse.length = a.length :=
   List.length_reverse _
 

--- a/Mathlib/Algebra/FreeMonoid/Basic.lean
+++ b/Mathlib/Algebra/FreeMonoid/Basic.lean
@@ -225,7 +225,7 @@ protected theorem inductionOn {C : FreeMonoid α → Prop} (z : FreeMonoid α) (
     (of : ∀ (x : α), C (FreeMonoid.of x)) (mul : ∀ (x y : FreeMonoid α), C x → C y → C (x * y)) :
   C z := List.rec one (fun _ _ ih => mul [_] _ (of _) ih) z
 
-/-- An induction principle for free monoids which mirrors induction on lists, with cases anaologous 
+/-- An induction principle for free monoids which mirrors induction on lists, with cases anaologous
 to the empty list and cons -/
 @[to_additive (attr := elab_as_elim) "An induction principle for free monoids which mirrors
 induction on lists, with cases anaologous to the empty list and cons"]

--- a/Mathlib/Algebra/FreeMonoid/Basic.lean
+++ b/Mathlib/Algebra/FreeMonoid/Basic.lean
@@ -225,8 +225,10 @@ protected theorem inductionOn {C : FreeMonoid α → Prop} (z : FreeMonoid α) (
     (of : ∀ (x : α), C (FreeMonoid.of x)) (mul : ∀ (x y : FreeMonoid α), C x → C y → C (x * y)) :
   C z := List.rec one (fun _ _ ih => mul [_] _ (of _) ih) z
 
-/-- An induction principle for free monoids which mirrors induction on lists, with cases anaologous to the empty list and cons -/
-@[to_additive (attr := elab_as_elim)]
+/-- An induction principle for free monoids which mirrors induction on lists, with cases anaologous 
+to the empty list and cons -/
+@[to_additive (attr := elab_as_elim) "An induction principle for free monoids which mirrors
+induction on lists, with cases anaologous to the empty list and cons"]
 protected theorem inductionOn' {p : FreeMonoid α → Prop} (a : FreeMonoid α)
     (one : p (1 : FreeMonoid α)) (mul_of : ∀ b a, p a → p (of b * a)) : p a :=
   List.rec one (fun _ _ tail_ih => mul_of _ _ tail_ih) a

--- a/Mathlib/Algebra/FreeMonoid/Basic.lean
+++ b/Mathlib/Algebra/FreeMonoid/Basic.lean
@@ -214,7 +214,8 @@ theorem recOn_of_mul {C : FreeMonoid α → Sort*} (x : α) (xs : FreeMonoid α)
     (ih : ∀ x xs, C xs → C (of x * xs)) : @recOn α C (of x * xs) h0 ih = ih x xs (recOn xs h0 ih) :=
   rfl
 
-/-! ### induction -/
+/-! ### Induction -/
+
 section induction_principles
 
 /-- An induction principle on free monoids, with cases for `1`, `FreeMonoid.of` and `*`. -/

--- a/Mathlib/Algebra/FreeMonoid/Basic.lean
+++ b/Mathlib/Algebra/FreeMonoid/Basic.lean
@@ -225,7 +225,7 @@ protected theorem inductionOn {C : FreeMonoid α → Prop} (z : FreeMonoid α) (
     (of : ∀ (x : α), C (FreeMonoid.of x)) (mul : ∀ (x y : FreeMonoid α), C x → C y → C (x * y)) :
   C z := List.rec one (fun _ _ ih => mul [_] _ (of _) ih) z
 
-/-- an induction principle for free monoids more closely mirroring induction on lists -/
+/-- An induction principle for free monoids which mirrors induction on lists, with cases anaologous to the empty list and cons -/
 @[to_additive (attr := elab_as_elim)]
 protected theorem inductionOn' {p : FreeMonoid α → Prop} (a : FreeMonoid α)
     (one : p (1 : FreeMonoid α)) (mul_of : ∀ b a, p a → p (of b * a)) : p a :=

--- a/Mathlib/Algebra/Group/Submonoid/Membership.lean
+++ b/Mathlib/Algebra/Group/Submonoid/Membership.lean
@@ -356,9 +356,9 @@ theorem closure_induction_left {s : Set M} {p : (m : M) → m ∈ closure s → 
     p x h := by
   simp_rw [closure_eq_mrange] at h
   obtain ⟨l, rfl⟩ := h
-  induction l with
-  | h0 => exact one
-  | ih x y ih =>
+  induction l using FreeMonoid.inductionOn' with
+  | one => exact one
+  | mul_of x y ih =>
     simp only [map_mul, FreeMonoid.lift_eval_of]
     refine mul_left _ x.prop (FreeMonoid.lift Subtype.val y) _ (ih ?_)
     simp only [closure_eq_mrange, mem_mrange, exists_apply_eq_apply]

--- a/Mathlib/Control/Fold.lean
+++ b/Mathlib/Control/Fold.lean
@@ -302,9 +302,10 @@ theorem toList_spec (xs : t α) : toList xs = FreeMonoid.toList (foldMap FreeMon
     calc
       FreeMonoid.toList (foldMap FreeMonoid.of xs) =
           FreeMonoid.toList (foldMap FreeMonoid.of xs).reverse.reverse := by
-          simp only [List.reverse_reverse]
-      _ = FreeMonoid.toList (List.foldr cons [] (foldMap FreeMonoid.of xs).reverse).reverse := by
-          simp only [List.foldr_eta]
+          simp only [FreeMonoid.reverse_reverse]
+      _ = (List.foldr cons [] (foldMap FreeMonoid.of xs).toList.reverse).reverse := by
+          simp only [FreeMonoid.reverse_reverse, List.foldr_reverse, List.foldl_flip_cons_eq_append,
+            List.append_nil, List.reverse_reverse]
       _ = (unop (Foldl.ofFreeMonoid (flip cons) (foldMap FreeMonoid.of xs)) []).reverse := by
             #adaptation_note /-- nightly-2024-03-16: simp was
             simp [flip, List.foldr_reverse, Foldl.ofFreeMonoid, unop_op] -/

--- a/Mathlib/GroupTheory/Coprod/Basic.lean
+++ b/Mathlib/GroupTheory/Coprod/Basic.lean
@@ -574,7 +574,7 @@ theorem con_inv_mul_cancel (x : FreeMonoid (G ⊕ H)) :
     coprodCon G H (ofList (x.toList.map (Sum.map Inv.inv Inv.inv)).reverse * x) 1 := by
   rw [← mk_eq_mk, map_mul, map_one]
   induction x using FreeMonoid.inductionOn' with
-  | one => simp [map_one mk] -- TODO: fails without `[map_one mk]`
+  | one => simp
   | mul_of x xs ihx =>
     simp only [toList_of_mul, map_cons, reverse_cons, ofList_append, map_mul, ihx, ofList_singleton]
     rwa [mul_assoc, ← mul_assoc (mk (of _)), mk_of_inv_mul, one_mul]

--- a/Mathlib/GroupTheory/Coprod/Basic.lean
+++ b/Mathlib/GroupTheory/Coprod/Basic.lean
@@ -191,9 +191,9 @@ theorem induction_on' {C : M ∗ N → Prop} (m : M ∗ N)
     (inl_mul : ∀ m x, C x → C (inl m * x))
     (inr_mul : ∀ n x, C x → C (inr n * x)) : C m := by
   rcases mk_surjective m with ⟨x, rfl⟩
-  induction x with
-  | h0 => exact one
-  | ih x xs ih =>
+  induction x using FreeMonoid.inductionOn' with
+  | one => exact one
+  | mul_of x xs ih =>
     cases x with
     | inl m => simpa using inl_mul m _ ih
     | inr n => simpa using inr_mul n _ ih
@@ -573,9 +573,9 @@ theorem mk_of_inv_mul : ∀ x : G ⊕ H, mk (of (x.map Inv.inv Inv.inv)) * mk (o
 theorem con_inv_mul_cancel (x : FreeMonoid (G ⊕ H)) :
     coprodCon G H (ofList (x.toList.map (Sum.map Inv.inv Inv.inv)).reverse * x) 1 := by
   rw [← mk_eq_mk, map_mul, map_one]
-  induction x with
-  | h0 => simp [map_one mk] -- TODO: fails without `[map_one mk]`
-  | ih x xs ihx =>
+  induction x using FreeMonoid.inductionOn' with
+  | one => simp [map_one mk] -- TODO: fails without `[map_one mk]`
+  | mul_of x xs ihx =>
     simp only [toList_of_mul, map_cons, reverse_cons, ofList_append, map_mul, ihx, ofList_singleton]
     rwa [mul_assoc, ← mul_assoc (mk (of _)), mk_of_inv_mul, one_mul]
 


### PR DESCRIPTION
add these properties for future use in the braid monoid (I have avoided duplicating the List API when possible, ex: using FreeMonoid.lift. These are the remaining properties I need to add)

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
