### PR TITLE
[Merged by Bors] - feat(GroupTheory/Congruence): simp lemmas for comap equivalences

### DIFF
--- a/Mathlib/GroupTheory/Congruence/Basic.lean
+++ b/Mathlib/GroupTheory/Congruence/Basic.lean
@@ -566,7 +566,7 @@ theorem comap_rel {f : M → N} (H : ∀ x y, f (x * y) = f x * f y) {c : Con N}
   Iff.rfl
 
 @[to_additive]
-theorem comap_con'Gen_of_Bijective {M N : Type*} [Mul M] [Mul N] (f : M → N)
+theorem comap_conGen_of_Bijective {M N : Type*} [Mul M] [Mul N] (f : M → N)
     (hf : Function.Bijective f) (H : ∀ (x y : M), f (x * y) = f x * f y) (rel : N → N → Prop) :
     Con.comap f H (conGen rel) = conGen (fun x y ↦ rel (f x) (f y)) := by
   ext a b
@@ -971,9 +971,9 @@ noncomputable def quotientKerEquivOfSurjective (f : M →* P) (hf : Surjective f
   quotientKerEquivOfRightInverse _ _ hf.hasRightInverse.choose_spec
 
 /-- If e : M →* N is surjective then (c.comap e).Quotient ≃* c.Quotient
-with c : Con' N -/
+with c : Con N -/
 @[to_additive "If e : M →* N is surjective then (c.comap e).Quotient ≃* c.Quotient
-with c : AddCon' N"]
+with c : AddCon N"]
 noncomputable def comapQuotientEquivOfSurj(c : Con M) (f : N →* M) (hf : Function.Surjective f) :
     (Con.comap f f.map_mul c).Quotient ≃* c.Quotient :=
   (Con.congr Con.comap_eq).trans <| Con.quotientKerEquivOfSurjective

--- a/Mathlib/GroupTheory/Congruence/Basic.lean
+++ b/Mathlib/GroupTheory/Congruence/Basic.lean
@@ -999,7 +999,6 @@ noncomputable def comapQuotientEquiv (f : N →* M) :
     (comap f f.map_mul c).Quotient ≃* MonoidHom.mrange (c.mk'.comp f) :=
   (Con.congr comap_eq).trans <| quotientKerEquivRange <| c.mk'.comp f
 
-
 /-- The **third isomorphism theorem for monoids**. -/
 @[to_additive "The third isomorphism theorem for `AddMonoid`s."]
 def quotientQuotientEquivQuotient (c d : Con M) (h : c ≤ d) :

--- a/Mathlib/GroupTheory/Congruence/Basic.lean
+++ b/Mathlib/GroupTheory/Congruence/Basic.lean
@@ -990,8 +990,9 @@ lemma comapQuotientEquivOfSurj_symm_mk (c : Con M) {f : N →* M} (hf : Function
 
 @[simp]
 lemma comapQuotientEquivOfSurj_symm_mk' (c : Con M) (f : N ≃* M) (x : N) :
-    (comapQuotientEquivOfSurj c f f.surjective).symm (@Quotient.mk M c.toSetoid (f x)) = x :=
-  (MulEquiv.symm_apply_eq (@comapQuotientEquivOfSurj M N _ _ c f _)).mpr rfl
+    (comapQuotientEquivOfSurj c f f.surjective).symm (@Quotient.mk M c.toSetoid (f x)) = x := by
+  simp only [MonoidHom.coe_coe]
+  exact(MulEquiv.symm_apply_eq (@comapQuotientEquivOfSurj M N _ _ c f _)).mpr rfl
 
 /-- The **second isomorphism theorem for monoids**. -/
 @[to_additive "The second isomorphism theorem for `AddMonoid`s."]

--- a/Mathlib/GroupTheory/Congruence/Basic.lean
+++ b/Mathlib/GroupTheory/Congruence/Basic.lean
@@ -69,7 +69,7 @@ protected def congr {c d : Con M} (h : c = d) : c.Quotient ≃* d.Quotient :=
   { Quotient.congr (Equiv.refl M) <| by apply Con.ext_iff.mp h with
     map_mul' := fun x y => by rcases x with ⟨⟩; rcases y with ⟨⟩; rfl }
 
-@[simp]
+@[to_additive (attr := simp)]
 theorem congr_mk {c d : Con M} (h : c = d) (a : M) :
     Con.congr h (a : c.Quotient) = (a : d.Quotient) := rfl
 
@@ -240,26 +240,25 @@ noncomputable def quotientKerEquivOfSurjective (f : M →* P) (hf : Surjective f
     (ker f).Quotient ≃* P :=
   quotientKerEquivOfRightInverse _ _ hf.hasRightInverse.choose_spec
 
-/-- If e : M →* N is surjective then (c.comap e).Quotient ≃* c.Quotient
-with c : Con N -/
-@[to_additive "If e : M →* N is surjective then (c.comap e).Quotient ≃* c.Quotient
-with c : AddCon N"]
+/-- If e : M →* N is surjective then (c.comap e).Quotient ≃* c.Quotient with c : Con N -/
+@[to_additive "If e : M →* N is surjective then (c.comap e).Quotient ≃* c.Quotient with c :
+AddCon N"]
 noncomputable def comapQuotientEquivOfSurj (c : Con M) (f : N →* M) (hf : Function.Surjective f) :
     (Con.comap f f.map_mul c).Quotient ≃* c.Quotient :=
   (Con.congr Con.comap_eq).trans <| Con.quotientKerEquivOfSurjective
   (c.mk'.comp f) <| Con.mk'_surjective.comp hf
 
-@[simp]
+@[to_additive (attr := simp)]
 lemma comapQuotientEquivOfSurj_mk (c : Con M) {f : N →* M} (hf : Function.Surjective f) (x : N) :
     comapQuotientEquivOfSurj c f hf x = f x := rfl
 
-@[simp]
+@[to_additive (attr := simp)]
 lemma comapQuotientEquivOfSurj_symm_mk (c : Con M) {f : N →* M} (hf : Function.Surjective f)
     (x : N) : (comapQuotientEquivOfSurj c f hf).symm (f x) = x :=
   (MulEquiv.symm_apply_eq (c.comapQuotientEquivOfSurj f hf)).mpr rfl
 
 /-- This version infers the surjectivity of the function from a MulEquiv function -/
-@[simp]
+@[to_additive (attr := simp)]
 lemma comapQuotientEquivOfSurj_symm_mk' (c : Con M) (f : N ≃* M) (x : N) :
     ((@MulEquiv.symm (Con.Quotient (comap ⇑f _ c)) _ _ _
     (comapQuotientEquivOfSurj c f f.surjective)) ⟦f x⟧) = ↑x :=

--- a/Mathlib/GroupTheory/Congruence/Basic.lean
+++ b/Mathlib/GroupTheory/Congruence/Basic.lean
@@ -79,11 +79,11 @@ theorem conGen_le_comap {M N : Type*} [Mul M] [Mul N] (f : M → N)
     conGen (fun x y ↦ rel (f x) (f y)) ≤ Con.comap f H (conGen rel) := by
   intro x y h
   simp only [Con.comap_rel]
-  exact ConGen.Rel.rec (fun x y h ↦ ConGen.Rel.of (f x) (f y) h) (fun x ↦ ConGen.Rel.refl (f x))
-    (fun _ h ↦ ConGen.Rel.symm h) (fun _ _ h1 h2 ↦ h1.trans h2) (fun {w x y z} _ _ h1 h2 ↦
+  exact .rec (fun x y h ↦ .of (f x) (f y) h) (fun x ↦ .refl (f x))
+    (fun _ h ↦ .symm h) (fun _ _ h1 h2 ↦ h1.trans h2) (fun {w x y z} _ _ h1 h2 ↦
     (congrArg (fun a ↦ (conGen rel) a (f (x * z))) (H w y)).mpr
     (((congrArg (fun a ↦ (conGen rel) (f w * f y) a) (H x z))).mpr
-    (ConGen.Rel.mul h1 h2))) h
+    (.mul h1 h2))) h
 
 @[to_additive]
 theorem comap_conGen_of_Bijective {M N : Type*} [Mul M] [Mul N] (f : M → N)

--- a/Mathlib/GroupTheory/Congruence/Basic.lean
+++ b/Mathlib/GroupTheory/Congruence/Basic.lean
@@ -298,15 +298,9 @@ lemma comapQuotientEquivOfSurj_symm_mk (c : Con M) {f : N →* M} (hf : Function
 /-- This version infers the surjectivity of the function from a MulEquiv function -/
 @[simp]
 lemma comapQuotientEquivOfSurj_symm_mk' (c : Con M) (f : N ≃* M) (x : N) : @Eq
-    (@Con.Quotient N (@MulOneClass.toMul N _)
-    (@comap N M (@MulOneClass.toMul N _) (@MulOneClass.toMul M _) ⇑f _ c))
-    ((@MulEquiv.symm
-    (@Con.Quotient N (@MulOneClass.toMul N _)
-    (@comap N M (@MulOneClass.toMul N _) (@MulOneClass.toMul M _) ⇑f _ c))
-    (@Con.Quotient M (@MulOneClass.toMul M _) c)
-    (@hasMul N (@MulOneClass.toMul N _)
-    (@comap N M (@MulOneClass.toMul N _) (@MulOneClass.toMul M _) ⇑f _ c))
-    (@hasMul M (@MulOneClass.toMul M _) c) (@comapQuotientEquivOfSurj M N _ _ c ↑f f.surjective))
+    (Con.Quotient (comap ⇑f _ c))
+    ((@MulEquiv.symm (Con.Quotient (comap ⇑f _ c)) _ (hasMul (comap ⇑f _ c))
+    _ (comapQuotientEquivOfSurj c ↑f f.surjective))
     ⟦f x⟧)
   ↑x := (MulEquiv.symm_apply_eq (@comapQuotientEquivOfSurj M N _ _ c f _)).mpr rfl
 

--- a/Mathlib/GroupTheory/Congruence/Basic.lean
+++ b/Mathlib/GroupTheory/Congruence/Basic.lean
@@ -74,7 +74,7 @@ theorem congr_mk {c d : Con M} (h : c = d) (a : M) :
     Con.congr h (a : c.Quotient) = (a : d.Quotient) := rfl
 
 @[to_additive]
-theorem conGen_le_comap {M N : Type*} [Mul M] [Mul N] (f : M → N)
+theorem le_comap_conGen {M N : Type*} [Mul M] [Mul N] (f : M → N)
     (H : ∀ (x y : M), f (x * y) = f x * f y) (rel : N → N → Prop) :
     conGen (fun x y ↦ rel (f x) (f y)) ≤ Con.comap f H (conGen rel) := by
   intro x y h

--- a/Mathlib/GroupTheory/Congruence/Basic.lean
+++ b/Mathlib/GroupTheory/Congruence/Basic.lean
@@ -81,7 +81,7 @@ theorem le_comap_conGen {M N : Type*} [Mul M] [Mul N] (f : M → N)
   simp only [Con.comap_rel]
   exact .rec (fun x y h ↦ .of (f x) (f y) h) (fun x ↦ .refl (f x))
     (fun _ h ↦ .symm h) (fun _ _ h1 h2 ↦ h1.trans h2) (fun {w x y z} _ _ h1 h2 ↦
-    (congrArg (fun a ↦ (conGen rel) a (f (x * z))) (H w y)).mpr
+    (congrArg (fun a ↦ conGen rel a (f (x * z))) (H w y)).mpr
     (((congrArg (fun a ↦ conGen rel (f w * f y) a) (H x z))).mpr
     (.mul h1 h2))) h
 

--- a/Mathlib/GroupTheory/Congruence/Basic.lean
+++ b/Mathlib/GroupTheory/Congruence/Basic.lean
@@ -299,10 +299,8 @@ lemma comapQuotientEquivOfSurj_symm_mk (c : Con M) {f : N →* M} (hf : Function
 @[simp]
 lemma comapQuotientEquivOfSurj_symm_mk' (c : Con M) (f : N ≃* M) (x : N) : @Eq
     (Con.Quotient (comap ⇑f _ c))
-    ((@MulEquiv.symm (Con.Quotient (comap ⇑f _ c)) _ (hasMul (comap ⇑f _ c))
-    _ (comapQuotientEquivOfSurj c ↑f f.surjective))
-    ⟦f x⟧)
-  ↑x := (MulEquiv.symm_apply_eq (@comapQuotientEquivOfSurj M N _ _ c f _)).mpr rfl
+    ((comapQuotientEquivOfSurj c ↑f f.surjective).symm ⟦f x⟧) ↑x :=
+  (MulEquiv.symm_apply_eq (@comapQuotientEquivOfSurj M N _ _ c f _)).mpr rfl
 
 /-- The **second isomorphism theorem for monoids**. -/
 @[to_additive "The second isomorphism theorem for `AddMonoid`s."]

--- a/Mathlib/GroupTheory/Congruence/Basic.lean
+++ b/Mathlib/GroupTheory/Congruence/Basic.lean
@@ -530,8 +530,9 @@ lemma comapQuotientEquivOfSurj_symm_mk (c : Con M) {f : N →* M} (hf : Function
 
 @[simp]
 lemma comapQuotientEquivOfSurj_symm_mk' (c : Con M) (f : N ≃* M) (x : N) :
-    (comapQuotientEquivOfSurj c f f.surjective).symm (@Quotient.mk M c.toSetoid (f x)) = x :=
-  (MulEquiv.symm_apply_eq (@comapQuotientEquivOfSurj M N _ _ c f _)).mpr rfl
+    (comapQuotientEquivOfSurj c f f.surjective).symm (@Quotient.mk M c.toSetoid (f x)) = x := by
+  simp only [MonoidHom.coe_coe]
+  exact(MulEquiv.symm_apply_eq (@comapQuotientEquivOfSurj M N _ _ c f _)).mpr rfl
 
 /-- The **second isomorphism theorem for monoids**. -/
 @[to_additive "The second isomorphism theorem for `AddMonoid`s."]

--- a/Mathlib/GroupTheory/Congruence/Basic.lean
+++ b/Mathlib/GroupTheory/Congruence/Basic.lean
@@ -302,7 +302,7 @@ theorem comap_rel {f : M → N} (H : ∀ x y, f (x * y) = f x * f y) {c : Con N}
   Iff.rfl
 
 @[to_additive]
-theorem comap_con'Gen_of_Bijective {M N : Type*} [Mul M] [Mul N] (f : M → N)
+theorem comap_conGen_of_Bijective {M N : Type*} [Mul M] [Mul N] (f : M → N)
     (hf : Function.Bijective f) (H : ∀ (x y : M), f (x * y) = f x * f y) (rel : N → N → Prop) :
     Con.comap f H (conGen rel) = conGen (fun x y ↦ rel (f x) (f y)) := by
   ext a b
@@ -511,9 +511,9 @@ noncomputable def quotientKerEquivOfSurjective (f : M →* P) (hf : Surjective f
   quotientKerEquivOfRightInverse _ _ hf.hasRightInverse.choose_spec
 
 /-- If e : M →* N is surjective then (c.comap e).Quotient ≃* c.Quotient
-with c : Con' N -/
+with c : Con N -/
 @[to_additive "If e : M →* N is surjective then (c.comap e).Quotient ≃* c.Quotient
-with c : AddCon' N"]
+with c : AddCon N"]
 noncomputable def comapQuotientEquivOfSurj(c : Con M) (f : N →* M) (hf : Function.Surjective f) :
     (Con.comap f f.map_mul c).Quotient ≃* c.Quotient :=
   (Con.congr Con.comap_eq).trans <| Con.quotientKerEquivOfSurjective

--- a/Mathlib/GroupTheory/Congruence/Basic.lean
+++ b/Mathlib/GroupTheory/Congruence/Basic.lean
@@ -295,7 +295,7 @@ lemma comapQuotientEquivOfSurj_symm_mk (c : Con M) {f : N →* M} (hf : Function
     (x : N) : (comapQuotientEquivOfSurj c f hf).symm (f x) = x :=
   (MulEquiv.symm_apply_eq (c.comapQuotientEquivOfSurj f hf)).mpr rfl
 
-
+/-- This version infers the surjectivity of the function from a MulEquiv function -/
 @[simp]
 lemma comapQuotientEquivOfSurj_symm_mk' (c : Con M) (f : N ≃* M) (x : N) :
     (c.comapQuotientEquivOfSurj ↑f f.surjective).symm (@Quotient.mk M c.toSetoid (f x)) = x := by

--- a/Mathlib/GroupTheory/Congruence/Basic.lean
+++ b/Mathlib/GroupTheory/Congruence/Basic.lean
@@ -253,8 +253,8 @@ lemma comapQuotientEquivOfSurj_mk (c : Con M) {f : N →* M} (hf : Function.Surj
     comapQuotientEquivOfSurj c f hf x = f x := rfl
 
 @[to_additive (attr := simp)]
-lemma comapQuotientEquivOfSurj_symm_mk (c : Con M) {f : N →* M} (hf : Function.Surjective f)
-    (x : N) : (comapQuotientEquivOfSurj c f hf).symm (f x) = x :=
+lemma comapQuotientEquivOfSurj_symm_mk (c : Con M) {f : N →* M} (hf) (x : N) :
+    (comapQuotientEquivOfSurj c f hf).symm (f x) = x :=
   (MulEquiv.symm_apply_eq (c.comapQuotientEquivOfSurj f hf)).mpr rfl
 
 /-- This version infers the surjectivity of the function from a MulEquiv function -/

--- a/Mathlib/GroupTheory/Congruence/Basic.lean
+++ b/Mathlib/GroupTheory/Congruence/Basic.lean
@@ -73,47 +73,6 @@ protected def congr {c d : Con M} (h : c = d) : c.Quotient ≃* d.Quotient :=
 theorem congr_mk {c d : Con M} (h : c = d) (a : M) :
     Con.congr h (a : c.Quotient) = (a : d.Quotient) := rfl
 
--- The complete lattice of congruence relations on a type
-/-- For congruence relations `c, d` on a type `M` with a multiplication, `c ≤ d` iff `∀ x y ∈ M`,
-    `x` is related to `y` by `d` if `x` is related to `y` by `c`. -/
-@[to_additive "For additive congruence relations `c, d` on a type `M` with an addition, `c ≤ d` iff
-`∀ x y ∈ M`, `x` is related to `y` by `d` if `x` is related to `y` by `c`."]
-instance : LE (Con M) where
-  le c d := ∀ ⦃x y⦄, c x y → d x y
-
-/-- The infimum of a set of congruence relations on a given type with a multiplication. -/
-@[to_additive "The infimum of a set of additive congruence relations on a given type with
-an addition."]
-instance : InfSet (Con M) where
-  sInf S :=
-    { r := fun x y => ∀ c : Con M, c ∈ S → c x y
-      iseqv := ⟨fun x c _ => c.refl x, fun h c hc => c.symm <| h c hc,
-        fun h1 h2 c hc => c.trans (h1 c hc) <| h2 c hc⟩
-      mul' := fun h1 h2 c hc => c.mul (h1 c hc) <| h2 c hc }
-
-@[to_additive]
-instance : PartialOrder (Con M) where
-  le_refl _ _ _ := id
-  le_trans _ _ _ h1 h2 _ _ h := h2 <| h1 h
-  le_antisymm _ _ hc hd := ext fun _ _ => ⟨fun h => hc h, fun h => hd h⟩
-
-/-- The complete lattice of congruence relations on a given type with a multiplication. -/
-@[to_additive "The complete lattice of additive congruence relations on a given type with
-an addition."]
-instance : CompleteLattice (Con M) where
-  __ := completeLatticeOfInf (Con M) fun s =>
-      ⟨fun r hr x y h => (h : ∀ r ∈ s, (r : Con M) x y) r hr, fun r hr x y h r' hr' =>
-        hr hr'
-          h⟩
-  inf c d := ⟨c.toSetoid ⊓ d.toSetoid, fun h1 h2 => ⟨c.mul h1.1 h2.1, d.mul h1.2 h2.2⟩⟩
-  inf_le_left _ _ := fun _ _ h => h.1
-  inf_le_right _ _ := fun _ _ h => h.2
-  le_inf  _ _ _ hb hc := fun _ _ h => ⟨hb h, hc h⟩
-  top := { Setoid.completeLattice.top with mul' := by tauto }
-  le_top _ := fun _ _ _ => trivial
-  bot := { Setoid.completeLattice.bot with mul' := fun h1 h2 => h1 ▸ h2 ▸ rfl }
-  bot_le c := fun x y h => h ▸ c.refl x
-
 @[to_additive]
 theorem comap_conGen_of_Bijective {M N : Type*} [Mul M] [Mul N] (f : M → N)
     (hf : Function.Bijective f) (H : ∀ (x y : M), f (x * y) = f x * f y) (rel : N → N → Prop) :

--- a/Mathlib/GroupTheory/Congruence/Basic.lean
+++ b/Mathlib/GroupTheory/Congruence/Basic.lean
@@ -298,9 +298,8 @@ lemma comapQuotientEquivOfSurj_symm_mk (c : Con M) {f : N →* M} (hf : Function
 /-- This version infers the surjectivity of the function from a MulEquiv function -/
 @[simp]
 lemma comapQuotientEquivOfSurj_symm_mk' (c : Con M) (f : N ≃* M) (x : N) :
-    ((@MulEquiv.symm (Con.Quotient (comap ⇑f _ c)) _ (hasMul (comap ⇑f _ c))
-    _ (comapQuotientEquivOfSurj c ↑f f.surjective))
-    ⟦f x⟧) = ↑x :=
+    ((@MulEquiv.symm (Con.Quotient (comap ⇑f _ c)) _ _ _
+    (comapQuotientEquivOfSurj c f f.surjective)) ⟦f x⟧) = ↑x :=
   (MulEquiv.symm_apply_eq (@comapQuotientEquivOfSurj M N _ _ c f _)).mpr rfl
 
 /-- The **second isomorphism theorem for monoids**. -/

--- a/Mathlib/GroupTheory/Congruence/Basic.lean
+++ b/Mathlib/GroupTheory/Congruence/Basic.lean
@@ -86,10 +86,9 @@ theorem le_comap_conGen {M N : Type*} [Mul M] [Mul N] (f : M → N)
     (.mul h1 h2))) h
 
 @[to_additive]
-theorem comap_conGen_of_bijective {M N : Type*} [Mul M] [Mul N] (f : M → N)
-    (hf : Function.Bijective f) (H : ∀ (x y : M), f (x * y) = f x * f y) (rel : N → N → Prop) :
-    Con.comap f H (conGen rel) = conGen (fun x y ↦ rel (f x) (f y)) := by
-  apply le_antisymm _ (le_comap_conGen f H rel)
+theorem comap_conGen_equiv {M N : Type*} [Mul M] [Mul N] (f : MulEquiv M N) (rel : N → N → Prop) :
+    Con.comap f (map_mul f) (conGen rel) = conGen (fun x y ↦ rel (f x) (f y)) := by
+  apply le_antisymm _ (le_comap_conGen f (map_mul f) rel)
   intro a b h
   simp only [Con.comap_rel] at h
   have H : ∀ n1 n2, (conGen rel) n1 n2 → ∀ a b, f a = n1 → f b = n2 →
@@ -102,30 +101,26 @@ theorem comap_conGen_of_bijective {M N : Type*} [Mul M] [Mul N] (f : M → N)
       rwa [fa, fb]
     | refl x =>
       intro _ _ fc fd
-      rw [hf.1 (fc.trans fd.symm)]
+      rw [f.injective (fc.trans fd.symm)]
       exact ConGen.Rel.refl _
     | symm _ h => exact fun a b fs fb ↦ ConGen.Rel.symm (h b a fb fs)
     | trans _ _ ih ih1 =>
-      exact fun a b fa fb ↦ Exists.casesOn (hf.right _) fun c' hc' ↦
+      exact fun a b fa fb ↦ Exists.casesOn (f.surjective _) fun c' hc' ↦
       ConGen.Rel.trans (ih a c' fa hc') (ih1 c' b hc' fb)
     | mul _ _ ih ih1 =>
       rename_i w x y z _ _
       intro a b fa fb
-      rcases Function.bijective_iff_has_inverse.mp hf with ⟨f', is_inv⟩
-      have Ha : a = f' w * f' y := by
-        rw [← is_inv.1 a, fa]
-        have H : f (f' (w * y)) = f (f' w * f' y) := by
-          rw [is_inv.2 (w * y), H, is_inv.2 w, is_inv.2 y]
-        exact hf.1 H
-      have Hb : b = f' x * f' z := by
-        rw [← is_inv.1 b, fb]
-        have H : f (f' (x * z)) = f (f' x * f' z) := by
-          rw [is_inv.2 (x * z), H, is_inv.2 x, is_inv.2 z]
-        exact hf.1 H
-      rw [Ha, Hb]
-      exact ConGen.Rel.mul (ih (f' w) (f' x) (is_inv.right w) (is_inv.right x))
-        (ih1 (f' y) (f' z) (is_inv.right y) (is_inv.right z))
+      rw [← f.eq_symm_apply, map_mul] at fa fb
+      rw [fa, fb]
+      exact ConGen.Rel.mul (ih (f.symm w) (f.symm x) (by simp) (by simp))
+        (ih1 (f.symm y) (f.symm z) (by simp) (by simp))
   exact H (f a) (f b) h a b (refl _) (refl _)
+
+@[to_additive]
+theorem comap_conGen_of_bijective {M N : Type*} [Mul M] [Mul N] (f : M → N)
+    (hf : Function.Bijective f) (H : ∀ (x y : M), f (x * y) = f x * f y) (rel : N → N → Prop) :
+    Con.comap f H (conGen rel) = conGen (fun x y ↦ rel (f x) (f y)) :=
+  comap_conGen_equiv (MulEquiv.ofBijective (MulHom.mk f H) hf) rel
 
 end
 

--- a/Mathlib/GroupTheory/Congruence/Basic.lean
+++ b/Mathlib/GroupTheory/Congruence/Basic.lean
@@ -244,7 +244,7 @@ noncomputable def quotientKerEquivOfSurjective (f : M →* P) (hf : Surjective f
 with c : Con N -/
 @[to_additive "If e : M →* N is surjective then (c.comap e).Quotient ≃* c.Quotient
 with c : AddCon N"]
-noncomputable def comapQuotientEquivOfSurj(c : Con M) (f : N →* M) (hf : Function.Surjective f) :
+noncomputable def comapQuotientEquivOfSurj (c : Con M) (f : N →* M) (hf : Function.Surjective f) :
     (Con.comap f f.map_mul c).Quotient ≃* c.Quotient :=
   (Con.congr Con.comap_eq).trans <| Con.quotientKerEquivOfSurjective
   (c.mk'.comp f) <| Con.mk'_surjective.comp hf

--- a/Mathlib/GroupTheory/Congruence/Basic.lean
+++ b/Mathlib/GroupTheory/Congruence/Basic.lean
@@ -82,7 +82,7 @@ theorem le_comap_conGen {M N : Type*} [Mul M] [Mul N] (f : M → N)
   exact .rec (fun x y h ↦ .of (f x) (f y) h) (fun x ↦ .refl (f x))
     (fun _ h ↦ .symm h) (fun _ _ h1 h2 ↦ h1.trans h2) (fun {w x y z} _ _ h1 h2 ↦
     (congrArg (fun a ↦ (conGen rel) a (f (x * z))) (H w y)).mpr
-    (((congrArg (fun a ↦ (conGen rel) (f w * f y) a) (H x z))).mpr
+    (((congrArg (fun a ↦ conGen rel (f w * f y) a) (H x z))).mpr
     (.mul h1 h2))) h
 
 @[to_additive]

--- a/Mathlib/GroupTheory/Congruence/Basic.lean
+++ b/Mathlib/GroupTheory/Congruence/Basic.lean
@@ -245,8 +245,8 @@ noncomputable def quotientKerEquivOfSurjective (f : M →* P) (hf : Surjective f
 AddCon N"]
 noncomputable def comapQuotientEquivOfSurj (c : Con M) (f : N →* M) (hf : Function.Surjective f) :
     (Con.comap f f.map_mul c).Quotient ≃* c.Quotient :=
-  (Con.congr Con.comap_eq).trans <| Con.quotientKerEquivOfSurjective
-  (c.mk'.comp f) <| Con.mk'_surjective.comp hf
+  (Con.congr Con.comap_eq).trans <| Con.quotientKerEquivOfSurjective (c.mk'.comp f) <|
+    Con.mk'_surjective.comp hf
 
 @[to_additive (attr := simp)]
 lemma comapQuotientEquivOfSurj_mk (c : Con M) {f : N →* M} (hf : Function.Surjective f) (x : N) :

--- a/Mathlib/GroupTheory/Congruence/Basic.lean
+++ b/Mathlib/GroupTheory/Congruence/Basic.lean
@@ -86,7 +86,7 @@ theorem conGen_le_comap {M N : Type*} [Mul M] [Mul N] (f : M → N)
     (.mul h1 h2))) h
 
 @[to_additive]
-theorem comap_conGen_of_Bijective {M N : Type*} [Mul M] [Mul N] (f : M → N)
+theorem comap_conGen_of_bijective {M N : Type*} [Mul M] [Mul N] (f : M → N)
     (hf : Function.Bijective f) (H : ∀ (x y : M), f (x * y) = f x * f y) (rel : N → N → Prop) :
     Con.comap f H (conGen rel) = conGen (fun x y ↦ rel (f x) (f y)) := by
   apply le_antisymm _ (conGen_le_comap f H rel)

--- a/Mathlib/GroupTheory/Congruence/Basic.lean
+++ b/Mathlib/GroupTheory/Congruence/Basic.lean
@@ -295,7 +295,6 @@ lemma comapQuotientEquivOfSurj_symm_mk (c : Con M) {f : N →* M} (hf : Function
     (x : N) : (comapQuotientEquivOfSurj c f hf).symm (f x) = x :=
   (MulEquiv.symm_apply_eq (c.comapQuotientEquivOfSurj f hf)).mpr rfl
 
-set_option pp.explicit true
 /-- This version infers the surjectivity of the function from a MulEquiv function -/
 @[simp]
 lemma comapQuotientEquivOfSurj_symm_mk' (c : Con M) (f : N ≃* M) (x : N) : @Eq

--- a/Mathlib/GroupTheory/Congruence/Basic.lean
+++ b/Mathlib/GroupTheory/Congruence/Basic.lean
@@ -298,17 +298,16 @@ lemma comapQuotientEquivOfSurj_symm_mk (c : Con M) {f : N →* M} (hf : Function
 set_option pp.explicit true
 /-- This version infers the surjectivity of the function from a MulEquiv function -/
 @[simp]
-lemma comapQuotientEquivOfSurj_symm_mk' (c : Con M) (f : N ≃* M) (x : N) :
-  @Eq
-  (@Con.Quotient N (@MulOneClass.toMul N _)
+lemma comapQuotientEquivOfSurj_symm_mk' (c : Con M) (f : N ≃* M) (x : N) : @Eq
+    (@Con.Quotient N (@MulOneClass.toMul N _)
     (@comap N M (@MulOneClass.toMul N _) (@MulOneClass.toMul M _) ⇑f _ c))
-  ((@MulEquiv.symm
-      (@Con.Quotient N (@MulOneClass.toMul N _)
-        (@comap N M (@MulOneClass.toMul N _) (@MulOneClass.toMul M _) ⇑f _ c))
-      (@Con.Quotient M (@MulOneClass.toMul M _) c)
-      (@hasMul N (@MulOneClass.toMul N _)
-        (@comap N M (@MulOneClass.toMul N _) (@MulOneClass.toMul M _) ⇑f _ c))
-      (@hasMul M (@MulOneClass.toMul M _) c) (@comapQuotientEquivOfSurj M N _ _ c ↑f f.surjective))
+    ((@MulEquiv.symm
+    (@Con.Quotient N (@MulOneClass.toMul N _)
+    (@comap N M (@MulOneClass.toMul N _) (@MulOneClass.toMul M _) ⇑f _ c))
+    (@Con.Quotient M (@MulOneClass.toMul M _) c)
+    (@hasMul N (@MulOneClass.toMul N _)
+    (@comap N M (@MulOneClass.toMul N _) (@MulOneClass.toMul M _) ⇑f _ c))
+    (@hasMul M (@MulOneClass.toMul M _) c) (@comapQuotientEquivOfSurj M N _ _ c ↑f f.surjective))
     ⟦f x⟧)
   ↑x := (MulEquiv.symm_apply_eq (@comapQuotientEquivOfSurj M N _ _ c f _)).mpr rfl
 

--- a/Mathlib/GroupTheory/Congruence/Basic.lean
+++ b/Mathlib/GroupTheory/Congruence/Basic.lean
@@ -539,7 +539,6 @@ noncomputable def comapQuotientEquiv (f : N →* M) :
     (comap f f.map_mul c).Quotient ≃* MonoidHom.mrange (c.mk'.comp f) :=
   (Con.congr comap_eq).trans <| quotientKerEquivRange <| c.mk'.comp f
 
-
 /-- The **third isomorphism theorem for monoids**. -/
 @[to_additive "The third isomorphism theorem for `AddMonoid`s."]
 def quotientQuotientEquivQuotient (c d : Con M) (h : c ≤ d) :

--- a/Mathlib/GroupTheory/Congruence/Basic.lean
+++ b/Mathlib/GroupTheory/Congruence/Basic.lean
@@ -262,7 +262,7 @@ lemma comapQuotientEquivOfSurj_symm_mk (c : Con M) {f : N →* M} (hf : Function
 MulEquiv function"]
 lemma comapQuotientEquivOfSurj_symm_mk' (c : Con M) (f : N ≃* M) (x : N) :
     ((@MulEquiv.symm (Con.Quotient (comap ⇑f _ c)) _ _ _
-    (comapQuotientEquivOfSurj c f f.surjective)) ⟦f x⟧) = ↑x :=
+      (comapQuotientEquivOfSurj c f f.surjective)) ⟦f x⟧) = ↑x :=
   (MulEquiv.symm_apply_eq (@comapQuotientEquivOfSurj M N _ _ c f _)).mpr rfl
 
 /-- The **second isomorphism theorem for monoids**. -/

--- a/Mathlib/GroupTheory/Congruence/Basic.lean
+++ b/Mathlib/GroupTheory/Congruence/Basic.lean
@@ -258,7 +258,8 @@ lemma comapQuotientEquivOfSurj_symm_mk (c : Con M) {f : N →* M} (hf : Function
   (MulEquiv.symm_apply_eq (c.comapQuotientEquivOfSurj f hf)).mpr rfl
 
 /-- This version infers the surjectivity of the function from a MulEquiv function -/
-@[to_additive (attr := simp)]
+@[to_additive (attr := simp) "This version infers the surjectivity of the function from a
+MulEquiv function"]
 lemma comapQuotientEquivOfSurj_symm_mk' (c : Con M) (f : N ≃* M) (x : N) :
     ((@MulEquiv.symm (Con.Quotient (comap ⇑f _ c)) _ _ _
     (comapQuotientEquivOfSurj c f f.surjective)) ⟦f x⟧) = ↑x :=

--- a/Mathlib/GroupTheory/Congruence/Basic.lean
+++ b/Mathlib/GroupTheory/Congruence/Basic.lean
@@ -295,12 +295,22 @@ lemma comapQuotientEquivOfSurj_symm_mk (c : Con M) {f : N →* M} (hf : Function
     (x : N) : (comapQuotientEquivOfSurj c f hf).symm (f x) = x :=
   (MulEquiv.symm_apply_eq (c.comapQuotientEquivOfSurj f hf)).mpr rfl
 
+set_option pp.explicit true
 /-- This version infers the surjectivity of the function from a MulEquiv function -/
 @[simp]
 lemma comapQuotientEquivOfSurj_symm_mk' (c : Con M) (f : N ≃* M) (x : N) :
-    (c.comapQuotientEquivOfSurj ↑f f.surjective).symm (@Quotient.mk M c.toSetoid (f x)) = x := by
-  conv => lhs; simp only [MonoidHom.coe_coe]
-  exact(MulEquiv.symm_apply_eq (@comapQuotientEquivOfSurj M N _ _ c f _)).mpr rfl
+  @Eq
+  (@Con.Quotient N (@MulOneClass.toMul N _)
+    (@comap N M (@MulOneClass.toMul N _) (@MulOneClass.toMul M _) ⇑f _ c))
+  ((@MulEquiv.symm
+      (@Con.Quotient N (@MulOneClass.toMul N _)
+        (@comap N M (@MulOneClass.toMul N _) (@MulOneClass.toMul M _) ⇑f _ c))
+      (@Con.Quotient M (@MulOneClass.toMul M _) c)
+      (@hasMul N (@MulOneClass.toMul N _)
+        (@comap N M (@MulOneClass.toMul N _) (@MulOneClass.toMul M _) ⇑f _ c))
+      (@hasMul M (@MulOneClass.toMul M _) c) (@comapQuotientEquivOfSurj M N _ _ c ↑f f.surjective))
+    ⟦f x⟧)
+  ↑x := (MulEquiv.symm_apply_eq (@comapQuotientEquivOfSurj M N _ _ c f _)).mpr rfl
 
 /-- The **second isomorphism theorem for monoids**. -/
 @[to_additive "The second isomorphism theorem for `AddMonoid`s."]

--- a/Mathlib/GroupTheory/Congruence/Basic.lean
+++ b/Mathlib/GroupTheory/Congruence/Basic.lean
@@ -128,8 +128,7 @@ theorem comap_conGen_of_Bijective {M N : Type*} [Mul M] [Mul N] (f : M → N)
         exact ConGen.Rel.mul (ih (f' w) (f' x) (is_inv.right w) (is_inv.right x))
           (ih1 (f' y) (f' z) (is_inv.right y) (is_inv.right z))
     exact H (f a) (f b) h a b (refl _) (refl _)
-  apply conGen_le_comap
-  --exact conGen_le_comap f H rel
+  exact @conGen_le_comap _ _ _ _ f H rel a b
 
 end
 

--- a/Mathlib/GroupTheory/Congruence/Basic.lean
+++ b/Mathlib/GroupTheory/Congruence/Basic.lean
@@ -99,8 +99,7 @@ theorem comap_conGen_of_bijective {M N : Type*} [Mul M] [Mul N] (f : M → N)
     | of x y h =>
       intro _ _ fa fb
       apply ConGen.Rel.of
-      rw [fa, fb]
-      exact h
+      rwa [fa, fb]
     | refl x =>
       intro _ _ fc fd
       rw [hf.1 (fc.trans fd.symm)]

--- a/Mathlib/GroupTheory/Congruence/Basic.lean
+++ b/Mathlib/GroupTheory/Congruence/Basic.lean
@@ -89,46 +89,44 @@ theorem conGen_le_comap {M N : Type*} [Mul M] [Mul N] (f : M → N)
 theorem comap_conGen_of_Bijective {M N : Type*} [Mul M] [Mul N] (f : M → N)
     (hf : Function.Bijective f) (H : ∀ (x y : M), f (x * y) = f x * f y) (rel : N → N → Prop) :
     Con.comap f H (conGen rel) = conGen (fun x y ↦ rel (f x) (f y)) := by
-  ext a b
-  constructor
-  · intro h
-    simp only [Con.comap_rel] at h
-    have H : ∀ n1 n2, (conGen rel) n1 n2 → ∀ a b, f a = n1 → f b = n2 →
-        (conGen fun x y ↦ rel (f x) (f y)) a b := by
-      intro n1 n2 h
-      induction h with
-      | of x y h =>
-        intro _ _ fa fb
-        apply ConGen.Rel.of
-        rw [fa, fb]
-        exact h
-      | refl x =>
-        intro _ _ fc fd
-        rw [hf.1 (fc.trans fd.symm)]
-        exact ConGen.Rel.refl _
-      | symm _ h => exact fun a b fs fb ↦ ConGen.Rel.symm (h b a fb fs)
-      | trans _ _ ih ih1 =>
-        exact fun a b fa fb ↦ Exists.casesOn (hf.right _) fun c' hc' ↦
-        ConGen.Rel.trans (ih a c' fa hc') (ih1 c' b hc' fb)
-      | mul _ _ ih ih1 =>
-        rename_i w x y z _ _
-        intro a b fa fb
-        rcases Function.bijective_iff_has_inverse.mp hf with ⟨f', is_inv⟩
-        have Ha : a = f' w * f' y := by
-          rw [← is_inv.1 a, fa]
-          have H : f (f' (w * y)) = f (f' w * f' y) := by
-            rw [is_inv.2 (w * y), H, is_inv.2 w, is_inv.2 y]
-          exact hf.1 H
-        have Hb : b = f' x * f' z := by
-          rw [← is_inv.1 b, fb]
-          have H : f (f' (x * z)) = f (f' x * f' z) := by
-            rw [is_inv.2 (x * z), H, is_inv.2 x, is_inv.2 z]
-          exact hf.1 H
-        rw [Ha, Hb]
-        exact ConGen.Rel.mul (ih (f' w) (f' x) (is_inv.right w) (is_inv.right x))
-          (ih1 (f' y) (f' z) (is_inv.right y) (is_inv.right z))
-    exact H (f a) (f b) h a b (refl _) (refl _)
-  exact @conGen_le_comap _ _ _ _ f H rel a b
+  apply le_antisymm _ (conGen_le_comap f H rel)
+  intro a b h
+  simp only [Con.comap_rel] at h
+  have H : ∀ n1 n2, (conGen rel) n1 n2 → ∀ a b, f a = n1 → f b = n2 →
+      (conGen fun x y ↦ rel (f x) (f y)) a b := by
+    intro n1 n2 h
+    induction h with
+    | of x y h =>
+      intro _ _ fa fb
+      apply ConGen.Rel.of
+      rw [fa, fb]
+      exact h
+    | refl x =>
+      intro _ _ fc fd
+      rw [hf.1 (fc.trans fd.symm)]
+      exact ConGen.Rel.refl _
+    | symm _ h => exact fun a b fs fb ↦ ConGen.Rel.symm (h b a fb fs)
+    | trans _ _ ih ih1 =>
+      exact fun a b fa fb ↦ Exists.casesOn (hf.right _) fun c' hc' ↦
+      ConGen.Rel.trans (ih a c' fa hc') (ih1 c' b hc' fb)
+    | mul _ _ ih ih1 =>
+      rename_i w x y z _ _
+      intro a b fa fb
+      rcases Function.bijective_iff_has_inverse.mp hf with ⟨f', is_inv⟩
+      have Ha : a = f' w * f' y := by
+        rw [← is_inv.1 a, fa]
+        have H : f (f' (w * y)) = f (f' w * f' y) := by
+          rw [is_inv.2 (w * y), H, is_inv.2 w, is_inv.2 y]
+        exact hf.1 H
+      have Hb : b = f' x * f' z := by
+        rw [← is_inv.1 b, fb]
+        have H : f (f' (x * z)) = f (f' x * f' z) := by
+          rw [is_inv.2 (x * z), H, is_inv.2 x, is_inv.2 z]
+        exact hf.1 H
+      rw [Ha, Hb]
+      exact ConGen.Rel.mul (ih (f' w) (f' x) (is_inv.right w) (is_inv.right x))
+        (ih1 (f' y) (f' z) (is_inv.right y) (is_inv.right z))
+  exact H (f a) (f b) h a b (refl _) (refl _)
 
 end
 

--- a/Mathlib/GroupTheory/Congruence/Basic.lean
+++ b/Mathlib/GroupTheory/Congruence/Basic.lean
@@ -297,9 +297,10 @@ lemma comapQuotientEquivOfSurj_symm_mk (c : Con M) {f : N →* M} (hf : Function
 
 /-- This version infers the surjectivity of the function from a MulEquiv function -/
 @[simp]
-lemma comapQuotientEquivOfSurj_symm_mk' (c : Con M) (f : N ≃* M) (x : N) : @Eq
-    (Con.Quotient (comap ⇑f _ c))
-    ((comapQuotientEquivOfSurj c ↑f f.surjective).symm ⟦f x⟧) ↑x :=
+lemma comapQuotientEquivOfSurj_symm_mk' (c : Con M) (f : N ≃* M) (x : N) :
+    ((@MulEquiv.symm (Con.Quotient (comap ⇑f _ c)) _ (hasMul (comap ⇑f _ c))
+    _ (comapQuotientEquivOfSurj c ↑f f.surjective))
+    ⟦f x⟧) = ↑x :=
   (MulEquiv.symm_apply_eq (@comapQuotientEquivOfSurj M N _ _ c f _)).mpr rfl
 
 /-- The **second isomorphism theorem for monoids**. -/

--- a/Mathlib/GroupTheory/Congruence/Basic.lean
+++ b/Mathlib/GroupTheory/Congruence/Basic.lean
@@ -69,6 +69,335 @@ protected def congr {c d : Con M} (h : c = d) : c.Quotient ≃* d.Quotient :=
   { Quotient.congr (Equiv.refl M) <| by apply Con.ext_iff.mp h with
     map_mul' := fun x y => by rcases x with ⟨⟩; rcases y with ⟨⟩; rfl }
 
+@[simp]
+theorem congr_mk {c d : Con M} (h : c = d) (a : M) :
+    Con.congr h (a : c.Quotient) = (a : d.Quotient) := rfl
+
+-- The complete lattice of congruence relations on a type
+/-- For congruence relations `c, d` on a type `M` with a multiplication, `c ≤ d` iff `∀ x y ∈ M`,
+    `x` is related to `y` by `d` if `x` is related to `y` by `c`. -/
+@[to_additive "For additive congruence relations `c, d` on a type `M` with an addition, `c ≤ d` iff
+`∀ x y ∈ M`, `x` is related to `y` by `d` if `x` is related to `y` by `c`."]
+instance : LE (Con M) where
+  le c d := ∀ ⦃x y⦄, c x y → d x y
+
+/-- Definition of `≤` for congruence relations. -/
+@[to_additive "Definition of `≤` for additive congruence relations."]
+theorem le_def {c d : Con M} : c ≤ d ↔ ∀ {x y}, c x y → d x y :=
+  Iff.rfl
+
+/-- The infimum of a set of congruence relations on a given type with a multiplication. -/
+@[to_additive "The infimum of a set of additive congruence relations on a given type with
+an addition."]
+instance : InfSet (Con M) where
+  sInf S :=
+    { r := fun x y => ∀ c : Con M, c ∈ S → c x y
+      iseqv := ⟨fun x c _ => c.refl x, fun h c hc => c.symm <| h c hc,
+        fun h1 h2 c hc => c.trans (h1 c hc) <| h2 c hc⟩
+      mul' := fun h1 h2 c hc => c.mul (h1 c hc) <| h2 c hc }
+
+/-- The infimum of a set of congruence relations is the same as the infimum of the set's image
+    under the map to the underlying equivalence relation. -/
+@[to_additive "The infimum of a set of additive congruence relations is the same as the infimum of
+the set's image under the map to the underlying equivalence relation."]
+theorem sInf_toSetoid (S : Set (Con M)) : (sInf S).toSetoid = sInf (toSetoid '' S) :=
+  Setoid.ext' fun x y =>
+    ⟨fun h r ⟨c, hS, hr⟩ => by rw [← hr]; exact h c hS, fun h c hS => h c.toSetoid ⟨c, hS, rfl⟩⟩
+
+/-- The infimum of a set of congruence relations is the same as the infimum of the set's image
+    under the map to the underlying binary relation. -/
+@[to_additive (attr := simp, norm_cast)
+  "The infimum of a set of additive congruence relations is the same as the infimum
+  of the set's image under the map to the underlying binary relation."]
+theorem coe_sInf (S : Set (Con M)) :
+    ⇑(sInf S) = sInf ((⇑) '' S) := by
+  ext
+  simp only [sInf_image, iInf_apply, iInf_Prop_eq]
+  rfl
+
+@[to_additive (attr := simp, norm_cast)]
+theorem coe_iInf {ι : Sort*} (f : ι → Con M) : ⇑(iInf f) = ⨅ i, ⇑(f i) := by
+  rw [iInf, coe_sInf, ← Set.range_comp, sInf_range, Function.comp_def]
+
+@[to_additive]
+instance : PartialOrder (Con M) where
+  le_refl _ _ _ := id
+  le_trans _ _ _ h1 h2 _ _ h := h2 <| h1 h
+  le_antisymm _ _ hc hd := ext fun _ _ => ⟨fun h => hc h, fun h => hd h⟩
+
+/-- The complete lattice of congruence relations on a given type with a multiplication. -/
+@[to_additive "The complete lattice of additive congruence relations on a given type with
+an addition."]
+instance : CompleteLattice (Con M) where
+  __ := completeLatticeOfInf (Con M) fun s =>
+      ⟨fun r hr x y h => (h : ∀ r ∈ s, (r : Con M) x y) r hr, fun r hr x y h r' hr' =>
+        hr hr'
+          h⟩
+  inf c d := ⟨c.toSetoid ⊓ d.toSetoid, fun h1 h2 => ⟨c.mul h1.1 h2.1, d.mul h1.2 h2.2⟩⟩
+  inf_le_left _ _ := fun _ _ h => h.1
+  inf_le_right _ _ := fun _ _ h => h.2
+  le_inf  _ _ _ hb hc := fun _ _ h => ⟨hb h, hc h⟩
+  top := { Setoid.completeLattice.top with mul' := by tauto }
+  le_top _ := fun _ _ _ => trivial
+  bot := { Setoid.completeLattice.bot with mul' := fun h1 h2 => h1 ▸ h2 ▸ rfl }
+  bot_le c := fun x y h => h ▸ c.refl x
+
+/-- The infimum of two congruence relations equals the infimum of the underlying binary
+    operations. -/
+@[to_additive (attr := simp, norm_cast)
+  "The infimum of two additive congruence relations equals the infimum of the underlying binary
+  operations."]
+theorem coe_inf {c d : Con M} : ⇑(c ⊓ d) = ⇑c ⊓ ⇑d :=
+  rfl
+
+/-- Definition of the infimum of two congruence relations. -/
+@[to_additive "Definition of the infimum of two additive congruence relations."]
+theorem inf_iff_and {c d : Con M} {x y} : (c ⊓ d) x y ↔ c x y ∧ d x y :=
+  Iff.rfl
+
+/-- The inductively defined smallest congruence relation containing a binary relation `r` equals
+    the infimum of the set of congruence relations containing `r`. -/
+@[to_additive addConGen_eq "The inductively defined smallest additive congruence relation
+containing a binary relation `r` equals the infimum of the set of additive congruence relations
+containing `r`."]
+theorem conGen_eq (r : M → M → Prop) : conGen r = sInf { s : Con M | ∀ x y, r x y → s x y } :=
+  le_antisymm
+    (le_sInf (fun s hs x y (hxy : (conGen r) x y) =>
+      show s x y by
+        apply ConGen.Rel.recOn (motive := fun x y _ => s x y) hxy
+        · exact fun x y h => hs x y h
+        · exact s.refl'
+        · exact fun _ => s.symm'
+        · exact fun _ _ => s.trans'
+        · exact fun _ _ => s.mul))
+    (sInf_le ConGen.Rel.of)
+
+/-- The smallest congruence relation containing a binary relation `r` is contained in any
+    congruence relation containing `r`. -/
+@[to_additive addConGen_le "The smallest additive congruence relation containing a binary
+relation `r` is contained in any additive congruence relation containing `r`."]
+theorem conGen_le {r : M → M → Prop} {c : Con M} (h : ∀ x y, r x y → c x y) :
+    conGen r ≤ c := by rw [conGen_eq]; exact sInf_le h
+
+/-- Given binary relations `r, s` with `r` contained in `s`, the smallest congruence relation
+    containing `s` contains the smallest congruence relation containing `r`. -/
+@[to_additive addConGen_mono "Given binary relations `r, s` with `r` contained in `s`, the
+smallest additive congruence relation containing `s` contains the smallest additive congruence
+relation containing `r`."]
+theorem conGen_mono {r s : M → M → Prop} (h : ∀ x y, r x y → s x y) : conGen r ≤ conGen s :=
+  conGen_le fun x y hr => ConGen.Rel.of _ _ <| h x y hr
+
+/-- Congruence relations equal the smallest congruence relation in which they are contained. -/
+@[to_additive (attr := simp) addConGen_of_addCon "Additive congruence relations equal the smallest
+additive congruence relation in which they are contained."]
+theorem conGen_of_con (c : Con M) : conGen c = c :=
+  le_antisymm (by rw [conGen_eq]; exact sInf_le fun _ _ => id) ConGen.Rel.of
+
+-- Porting note: removing simp, simp can prove it
+/-- The map sending a binary relation to the smallest congruence relation in which it is
+    contained is idempotent. -/
+@[to_additive addConGen_idem "The map sending a binary relation to the smallest additive
+congruence relation in which it is contained is idempotent."]
+theorem conGen_idem (r : M → M → Prop) : conGen (conGen r) = conGen r :=
+  conGen_of_con _
+
+/-- The supremum of congruence relations `c, d` equals the smallest congruence relation containing
+    the binary relation '`x` is related to `y` by `c` or `d`'. -/
+@[to_additive sup_eq_addConGen "The supremum of additive congruence relations `c, d` equals the
+smallest additive congruence relation containing the binary relation '`x` is related to `y`
+by `c` or `d`'."]
+theorem sup_eq_conGen (c d : Con M) : c ⊔ d = conGen fun x y => c x y ∨ d x y := by
+  rw [conGen_eq]
+  apply congr_arg sInf
+  simp only [le_def, or_imp, ← forall_and]
+
+/-- The supremum of two congruence relations equals the smallest congruence relation containing
+    the supremum of the underlying binary operations. -/
+@[to_additive "The supremum of two additive congruence relations equals the smallest additive
+congruence relation containing the supremum of the underlying binary operations."]
+theorem sup_def {c d : Con M} : c ⊔ d = conGen (⇑c ⊔ ⇑d) := by rw [sup_eq_conGen]; rfl
+
+/-- The supremum of a set of congruence relations `S` equals the smallest congruence relation
+    containing the binary relation 'there exists `c ∈ S` such that `x` is related to `y` by
+    `c`'. -/
+@[to_additive sSup_eq_addConGen "The supremum of a set of additive congruence relations `S` equals
+the smallest additive congruence relation containing the binary relation 'there exists `c ∈ S`
+such that `x` is related to `y` by `c`'."]
+theorem sSup_eq_conGen (S : Set (Con M)) :
+    sSup S = conGen fun x y => ∃ c : Con M, c ∈ S ∧ c x y := by
+  rw [conGen_eq]
+  apply congr_arg sInf
+  ext
+  exact ⟨fun h _ _ ⟨r, hr⟩ => h hr.1 hr.2, fun h r hS _ _ hr => h _ _ ⟨r, hS, hr⟩⟩
+
+/-- The supremum of a set of congruence relations is the same as the smallest congruence relation
+    containing the supremum of the set's image under the map to the underlying binary relation. -/
+@[to_additive "The supremum of a set of additive congruence relations is the same as the smallest
+additive congruence relation containing the supremum of the set's image under the map to the
+underlying binary relation."]
+theorem sSup_def {S : Set (Con M)} :
+    sSup S = conGen (sSup ((⇑) '' S)) := by
+  rw [sSup_eq_conGen, sSup_image]
+  congr with (x y)
+  simp only [sSup_image, iSup_apply, iSup_Prop_eq, exists_prop, rel_eq_coe]
+
+variable (M)
+
+/-- There is a Galois insertion of congruence relations on a type with a multiplication `M` into
+    binary relations on `M`. -/
+@[to_additive "There is a Galois insertion of additive congruence relations on a type with
+an addition `M` into binary relations on `M`."]
+protected def gi : @GaloisInsertion (M → M → Prop) (Con M) _ _ conGen DFunLike.coe where
+  choice r _ := conGen r
+  gc _ c := ⟨fun H _ _ h => H <| ConGen.Rel.of _ _ h, @fun H => conGen_of_con c ▸ conGen_mono H⟩
+  le_l_u x := (conGen_of_con x).symm ▸ le_refl x
+  choice_eq _ _ := rfl
+
+variable {M} (c)
+
+/-- Given a function `f`, the smallest congruence relation containing the binary relation on `f`'s
+    image defined by '`x ≈ y` iff the elements of `f⁻¹(x)` are related to the elements of `f⁻¹(y)`
+    by a congruence relation `c`.' -/
+@[to_additive "Given a function `f`, the smallest additive congruence relation containing the
+binary relation on `f`'s image defined by '`x ≈ y` iff the elements of `f⁻¹(x)` are related to the
+elements of `f⁻¹(y)` by an additive congruence relation `c`.'"]
+def mapGen (f : M → N) : Con N :=
+  conGen fun x y => ∃ a b, f a = x ∧ f b = y ∧ c a b
+
+/-- Given a surjective multiplicative-preserving function `f` whose kernel is contained in a
+    congruence relation `c`, the congruence relation on `f`'s codomain defined by '`x ≈ y` iff the
+    elements of `f⁻¹(x)` are related to the elements of `f⁻¹(y)` by `c`.' -/
+@[to_additive "Given a surjective addition-preserving function `f` whose kernel is contained in
+an additive congruence relation `c`, the additive congruence relation on `f`'s codomain defined
+by '`x ≈ y` iff the elements of `f⁻¹(x)` are related to the elements of `f⁻¹(y)` by `c`.'"]
+def mapOfSurjective (f : M → N) (H : ∀ x y, f (x * y) = f x * f y) (h : mulKer f H ≤ c)
+    (hf : Surjective f) : Con N :=
+  { c.toSetoid.mapOfSurjective f h hf with
+    mul' := fun h₁ h₂ => by
+      rcases h₁ with ⟨a, b, rfl, rfl, h1⟩
+      rcases h₂ with ⟨p, q, rfl, rfl, h2⟩
+      exact ⟨a * p, b * q, by rw [H], by rw [H], c.mul h1 h2⟩ }
+
+/-- A specialization of 'the smallest congruence relation containing a congruence relation `c`
+    equals `c`'. -/
+@[to_additive "A specialization of 'the smallest additive congruence relation containing
+an additive congruence relation `c` equals `c`'."]
+theorem mapOfSurjective_eq_mapGen {c : Con M} {f : M → N} (H : ∀ x y, f (x * y) = f x * f y)
+    (h : mulKer f H ≤ c) (hf : Surjective f) : c.mapGen f = c.mapOfSurjective f H h hf := by
+  rw [← conGen_of_con (c.mapOfSurjective f H h hf)]; rfl
+
+/-- Given types with multiplications `M, N` and a congruence relation `c` on `N`, a
+    multiplication-preserving map `f : M → N` induces a congruence relation on `f`'s domain
+    defined by '`x ≈ y` iff `f(x)` is related to `f(y)` by `c`.' -/
+@[to_additive "Given types with additions `M, N` and an additive congruence relation `c` on `N`,
+an addition-preserving map `f : M → N` induces an additive congruence relation on `f`'s domain
+defined by '`x ≈ y` iff `f(x)` is related to `f(y)` by `c`.' "]
+def comap (f : M → N) (H : ∀ x y, f (x * y) = f x * f y) (c : Con N) : Con M :=
+  { c.toSetoid.comap f with
+    mul' := @fun w x y z h1 h2 => show c (f (w * y)) (f (x * z)) by rw [H, H]; exact c.mul h1 h2 }
+
+@[to_additive (attr := simp)]
+theorem comap_rel {f : M → N} (H : ∀ x y, f (x * y) = f x * f y) {c : Con N} {x y : M} :
+    comap f H c x y ↔ c (f x) (f y) :=
+  Iff.rfl
+
+@[to_additive]
+theorem comap_con'Gen_of_Bijective {M N : Type*} [Mul M] [Mul N] (f : M → N)
+    (hf : Function.Bijective f) (H : ∀ (x y : M), f (x * y) = f x * f y) (rel : N → N → Prop) :
+    Con.comap f H (conGen rel) = conGen (fun x y ↦ rel (f x) (f y)) := by
+  ext a b
+  constructor
+  · intro h
+    simp only [Con.comap_rel] at h
+    have H : ∀ n1 n2, (conGen rel) n1 n2 → ∀ a b, f a = n1 → f b = n2 →
+        (conGen fun x y ↦ rel (f x) (f y)) a b := by
+      intro n1 n2 h
+      induction h with
+      | of x y h =>
+        intro _ _ fa fb
+        apply ConGen.Rel.of
+        rw [fa, fb]
+        exact h
+      | refl x =>
+        intro _ _ fc fd
+        rw [hf.1 (fc.trans fd.symm)]
+        exact ConGen.Rel.refl _
+      | symm _ h => exact fun a b fs fb ↦ ConGen.Rel.symm (h b a fb fs)
+      | trans _ _ ih ih1 =>
+        exact fun a b fa fb ↦ Exists.casesOn (hf.right _) fun c' hc' ↦
+        ConGen.Rel.trans (ih a c' fa hc') (ih1 c' b hc' fb)
+      | mul _ _ ih ih1 =>
+        rename_i w x y z _ _
+        intro a b fa fb
+        rcases Function.bijective_iff_has_inverse.mp hf with ⟨f', is_inv⟩
+        have Ha : a = f' w * f' y := by
+          rw [← is_inv.1 a, fa]
+          have H : f (f' (w * y)) = f (f' w * f' y) := by
+            rw [is_inv.2 (w * y), H, is_inv.2 w, is_inv.2 y]
+          exact hf.1 H
+        have Hb : b = f' x * f' z := by
+          rw [← is_inv.1 b, fb]
+          have H : f (f' (x * z)) = f (f' x * f' z) := by
+            rw [is_inv.2 (x * z), H, is_inv.2 x, is_inv.2 z]
+          exact hf.1 H
+        rw [Ha, Hb]
+        exact ConGen.Rel.mul (ih (f' w) (f' x) (is_inv.right w) (is_inv.right x))
+          (ih1 (f' y) (f' z) (is_inv.right y) (is_inv.right z))
+    exact H (f a) (f b) h a b (refl _) (refl _)
+  intro h
+  simp only [Con.comap_rel]
+  exact ConGen.Rel.rec (fun x y h ↦ ConGen.Rel.of (f x) (f y) h) (fun x ↦ ConGen.Rel.refl (f x))
+    (fun _ h ↦ ConGen.Rel.symm h) (fun _ _ h1 h2 ↦ h1.trans h2) (fun {w x y z} _ _ h1 h2 ↦
+    (congrArg (fun a ↦ (conGen rel) a (f (x * z))) (H w y)).mpr
+    (((congrArg (fun a ↦ (conGen rel) (f w * f y) a) (H x z))).mpr
+    (ConGen.Rel.mul h1 h2))) h
+
+section
+
+open Quotient
+
+/-- Given a congruence relation `c` on a type `M` with a multiplication, the order-preserving
+    bijection between the set of congruence relations containing `c` and the congruence relations
+    on the quotient of `M` by `c`. -/
+@[to_additive "Given an additive congruence relation `c` on a type `M` with an addition,
+the order-preserving bijection between the set of additive congruence relations containing `c` and
+the additive congruence relations on the quotient of `M` by `c`."]
+def correspondence : { d // c ≤ d } ≃o Con c.Quotient where
+  toFun d :=
+    d.1.mapOfSurjective (↑) (fun x y => rfl) (by rw [mul_ker_mk_eq]; exact d.2) <|
+      @Quotient.exists_rep _ c.toSetoid
+  invFun d :=
+    ⟨comap ((↑) : M → c.Quotient) (fun x y => rfl) d, fun x y h =>
+      show d x y by rw [c.eq.2 h]; exact d.refl _⟩
+  left_inv d :=
+    -- Porting note: by exact needed for unknown reason
+    by exact
+      Subtype.ext_iff_val.2 <|
+        ext fun x y =>
+          ⟨fun h =>
+            let ⟨a, b, hx, hy, H⟩ := h
+            d.1.trans (d.1.symm <| d.2 <| c.eq.1 hx) <| d.1.trans H <| d.2 <| c.eq.1 hy,
+            fun h => ⟨_, _, rfl, rfl, h⟩⟩
+  right_inv d :=
+    -- Porting note: by exact needed for unknown reason
+    by exact
+      ext fun x y =>
+        ⟨fun h =>
+          let ⟨_, _, hx, hy, H⟩ := h
+          hx ▸ hy ▸ H,
+          Con.induction_on₂ x y fun w z h => ⟨w, z, rfl, rfl, h⟩⟩
+  map_rel_iff' := @fun s t => by
+    constructor
+    · intros h x y hs
+      rcases h ⟨x, y, rfl, rfl, hs⟩ with ⟨a, b, hx, hy, ht⟩
+      exact t.1.trans (t.1.symm <| t.2 <| Quotient.eq_rel.1 hx)
+        (t.1.trans ht (t.2 <| Quotient.eq_rel.1 hy))
+    · intros h _ _ hs
+      rcases hs with ⟨a, b, hx, hy, Hs⟩
+      exact ⟨a, b, hx, hy, h Hs⟩
+
+end
+
 end
 
 section MulOneClass
@@ -181,11 +510,35 @@ noncomputable def quotientKerEquivOfSurjective (f : M →* P) (hf : Surjective f
     (ker f).Quotient ≃* P :=
   quotientKerEquivOfRightInverse _ _ hf.hasRightInverse.choose_spec
 
+/-- If e : M →* N is surjective then (c.comap e).Quotient ≃* c.Quotient
+with c : Con' N -/
+@[to_additive "If e : M →* N is surjective then (c.comap e).Quotient ≃* c.Quotient
+with c : AddCon' N"]
+noncomputable def comapQuotientEquivOfSurj(c : Con M) (f : N →* M) (hf : Function.Surjective f) :
+    (Con.comap f f.map_mul c).Quotient ≃* c.Quotient :=
+  (Con.congr Con.comap_eq).trans <| Con.quotientKerEquivOfSurjective
+  (c.mk'.comp f) <| Con.mk'_surjective.comp hf
+
+@[simp]
+lemma comapQuotientEquivOfSurj_mk (c : Con M) {f : N →* M} (hf : Function.Surjective f) (x : N) :
+    comapQuotientEquivOfSurj c f hf x = f x := rfl
+
+@[simp]
+lemma comapQuotientEquivOfSurj_symm_mk (c : Con M) {f : N →* M} (hf : Function.Surjective f)
+    (x : N) : (comapQuotientEquivOfSurj c f hf).symm (f x) = x :=
+  (MulEquiv.symm_apply_eq (c.comapQuotientEquivOfSurj f hf)).mpr rfl
+
+@[simp]
+lemma comapQuotientEquivOfSurj_symm_mk' (c : Con M) (f : N ≃* M) (x : N) :
+    (comapQuotientEquivOfSurj c f f.surjective).symm (@Quotient.mk M c.toSetoid (f x)) = x :=
+  (MulEquiv.symm_apply_eq (@comapQuotientEquivOfSurj M N _ _ c f _)).mpr rfl
+
 /-- The **second isomorphism theorem for monoids**. -/
 @[to_additive "The second isomorphism theorem for `AddMonoid`s."]
 noncomputable def comapQuotientEquiv (f : N →* M) :
     (comap f f.map_mul c).Quotient ≃* MonoidHom.mrange (c.mk'.comp f) :=
   (Con.congr comap_eq).trans <| quotientKerEquivRange <| c.mk'.comp f
+
 
 /-- The **third isomorphism theorem for monoids**. -/
 @[to_additive "The third isomorphism theorem for `AddMonoid`s."]

--- a/Mathlib/GroupTheory/Congruence/Basic.lean
+++ b/Mathlib/GroupTheory/Congruence/Basic.lean
@@ -74,6 +74,18 @@ theorem congr_mk {c d : Con M} (h : c = d) (a : M) :
     Con.congr h (a : c.Quotient) = (a : d.Quotient) := rfl
 
 @[to_additive]
+theorem conGen_le_comap {M N : Type*} [Mul M] [Mul N] (f : M → N)
+    (H : ∀ (x y : M), f (x * y) = f x * f y) (rel : N → N → Prop) :
+    conGen (fun x y ↦ rel (f x) (f y)) ≤ Con.comap f H (conGen rel) := by
+  intro x y h
+  simp only [Con.comap_rel]
+  exact ConGen.Rel.rec (fun x y h ↦ ConGen.Rel.of (f x) (f y) h) (fun x ↦ ConGen.Rel.refl (f x))
+    (fun _ h ↦ ConGen.Rel.symm h) (fun _ _ h1 h2 ↦ h1.trans h2) (fun {w x y z} _ _ h1 h2 ↦
+    (congrArg (fun a ↦ (conGen rel) a (f (x * z))) (H w y)).mpr
+    (((congrArg (fun a ↦ (conGen rel) (f w * f y) a) (H x z))).mpr
+    (ConGen.Rel.mul h1 h2))) h
+
+@[to_additive]
 theorem comap_conGen_of_Bijective {M N : Type*} [Mul M] [Mul N] (f : M → N)
     (hf : Function.Bijective f) (H : ∀ (x y : M), f (x * y) = f x * f y) (rel : N → N → Prop) :
     Con.comap f H (conGen rel) = conGen (fun x y ↦ rel (f x) (f y)) := by
@@ -116,13 +128,8 @@ theorem comap_conGen_of_Bijective {M N : Type*} [Mul M] [Mul N] (f : M → N)
         exact ConGen.Rel.mul (ih (f' w) (f' x) (is_inv.right w) (is_inv.right x))
           (ih1 (f' y) (f' z) (is_inv.right y) (is_inv.right z))
     exact H (f a) (f b) h a b (refl _) (refl _)
-  intro h
-  simp only [Con.comap_rel]
-  exact ConGen.Rel.rec (fun x y h ↦ ConGen.Rel.of (f x) (f y) h) (fun x ↦ ConGen.Rel.refl (f x))
-    (fun _ h ↦ ConGen.Rel.symm h) (fun _ _ h1 h2 ↦ h1.trans h2) (fun {w x y z} _ _ h1 h2 ↦
-    (congrArg (fun a ↦ (conGen rel) a (f (x * z))) (H w y)).mpr
-    (((congrArg (fun a ↦ (conGen rel) (f w * f y) a) (H x z))).mpr
-    (ConGen.Rel.mul h1 h2))) h
+  apply conGen_le_comap
+  --exact conGen_le_comap f H rel
 
 end
 

--- a/Mathlib/GroupTheory/Congruence/Basic.lean
+++ b/Mathlib/GroupTheory/Congruence/Basic.lean
@@ -89,7 +89,7 @@ theorem le_comap_conGen {M N : Type*} [Mul M] [Mul N] (f : M → N)
 theorem comap_conGen_of_bijective {M N : Type*} [Mul M] [Mul N] (f : M → N)
     (hf : Function.Bijective f) (H : ∀ (x y : M), f (x * y) = f x * f y) (rel : N → N → Prop) :
     Con.comap f H (conGen rel) = conGen (fun x y ↦ rel (f x) (f y)) := by
-  apply le_antisymm _ (conGen_le_comap f H rel)
+  apply le_antisymm _ (le_comap_conGen f H rel)
   intro a b h
   simp only [Con.comap_rel] at h
   have H : ∀ n1 n2, (conGen rel) n1 n2 → ∀ a b, f a = n1 → f b = n2 →


### PR DESCRIPTION
add a few lemmas, mostly about when the underlying types are equal, so too must be the quotient

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
