### PR TITLE
[Merged by Bors] - feat: Order instances for `MulOpposite`/`AddOpposite`

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -589,6 +589,7 @@ import Mathlib.Algebra.Order.Group.Int
 import Mathlib.Algebra.Order.Group.Lattice
 import Mathlib.Algebra.Order.Group.MinMax
 import Mathlib.Algebra.Order.Group.Nat
+import Mathlib.Algebra.Order.Group.Opposite
 import Mathlib.Algebra.Order.Group.OrderIso
 import Mathlib.Algebra.Order.Group.PiLex
 import Mathlib.Algebra.Order.Group.Pointwise.Bounds
@@ -661,6 +662,7 @@ import Mathlib.Algebra.Order.Ring.Finset
 import Mathlib.Algebra.Order.Ring.InjSurj
 import Mathlib.Algebra.Order.Ring.Int
 import Mathlib.Algebra.Order.Ring.Nat
+import Mathlib.Algebra.Order.Ring.Opposite
 import Mathlib.Algebra.Order.Ring.Pow
 import Mathlib.Algebra.Order.Ring.Prod
 import Mathlib.Algebra.Order.Ring.Rat

--- a/Mathlib/Algebra/Order/Group/Opposite.lean
+++ b/Mathlib/Algebra/Order/Group/Opposite.lean
@@ -1,0 +1,85 @@
+/-
+Copyright (c) 2024 Yaël Dillies. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Yaël Dillies
+-/
+import Mathlib.Algebra.Order.Group.Defs
+import Mathlib.Algebra.Group.Opposite
+
+/-!
+# Order instances for `MulOpposite`/`AddOpposite`
+
+This files transfers order instances and ordered monoid/group instances from `α` to `αᵐᵒᵖ` and
+`αᵃᵒᵖ`.
+-/
+
+variable {α : Type*}
+
+namespace MulOpposite
+section Preorder
+variable [Preorder α]
+
+@[to_additive] instance : Preorder αᵐᵒᵖ := Preorder.lift unop
+
+@[to_additive (attr := simp)] lemma unop_le_unop {a b : αᵐᵒᵖ} : a.unop ≤ b.unop ↔ a ≤ b := .rfl
+@[to_additive (attr := simp)] lemma op_le_op {a b : α} : op a ≤ op b ↔ a ≤ b := .rfl
+
+end Preorder
+
+@[to_additive] instance [PartialOrder α] : PartialOrder αᵐᵒᵖ := PartialOrder.lift _ unop_injective
+
+section OrderedCommMonoid
+variable [OrderedCommMonoid α]
+
+@[to_additive] instance : OrderedCommMonoid αᵐᵒᵖ where
+  mul_le_mul_left a b hab c := mul_le_mul_right' (by simpa) c.unop
+
+@[to_additive (attr := simp)] lemma unop_le_one {a : αᵐᵒᵖ} : unop a ≤ 1 ↔ a ≤ 1 := .rfl
+@[to_additive (attr := simp)] lemma one_le_unop {a : αᵐᵒᵖ} : 1 ≤ unop a ↔ 1 ≤ a := .rfl
+@[to_additive (attr := simp)] lemma op_le_one {a : α} : op a ≤ 1 ↔ a ≤ 1 := .rfl
+@[to_additive (attr := simp)] lemma one_le_op {a : α} : 1 ≤ op a ↔ 1 ≤ a := .rfl
+
+end OrderedCommMonoid
+
+@[to_additive] instance [OrderedCommGroup α] : OrderedCommGroup αᵐᵒᵖ where
+  __ := instCommGroup
+  __ := instOrderedCommMonoid
+
+section OrderedAddCommMonoid
+variable [OrderedAddCommMonoid α]
+
+instance : OrderedAddCommMonoid αᵐᵒᵖ where
+  add_le_add_left a b hab c := add_le_add_left (by simpa) c.unop
+
+@[simp] lemma unop_nonneg {a : αᵐᵒᵖ} : unop a ≤ 0 ↔ a ≤ 0 := .rfl
+@[simp] lemma unop_nonpos {a : αᵐᵒᵖ} : 0 ≤ unop a ↔ 0 ≤ a := .rfl
+@[simp] lemma op_nonneg {a : α} : op a ≤ 0 ↔ a ≤ 0 := .rfl
+@[simp] lemma op_nonpos {a : α} : 0 ≤ op a ↔ 0 ≤ a := .rfl
+
+end OrderedAddCommMonoid
+
+instance [OrderedAddCommGroup α] : OrderedAddCommGroup αᵐᵒᵖ where
+  __ := instAddCommGroup
+  __ := instOrderedAddCommMonoid
+
+end MulOpposite
+
+namespace AddOpposite
+section OrderedCommMonoid
+variable [OrderedCommMonoid α]
+
+instance : OrderedCommMonoid αᵃᵒᵖ where
+  mul_le_mul_left a b hab c := mul_le_mul_left' (by simpa) c.unop
+
+@[simp] lemma unop_le_one {a : αᵃᵒᵖ} : unop a ≤ 1 ↔ a ≤ 1 := .rfl
+@[simp] lemma one_le_unop {a : αᵃᵒᵖ} : 1 ≤ unop a ↔ 1 ≤ a := .rfl
+@[simp] lemma op_le_one {a : α} : op a ≤ 1 ↔ a ≤ 1 := .rfl
+@[simp] lemma one_le_op {a : α} : 1 ≤ op a ↔ 1 ≤ a := .rfl
+
+end OrderedCommMonoid
+
+instance [OrderedCommGroup α] : OrderedCommGroup αᵃᵒᵖ where
+  __ := instCommGroup
+  __ := instOrderedCommMonoid
+
+end AddOpposite

--- a/Mathlib/Algebra/Order/Ring/Opposite.lean
+++ b/Mathlib/Algebra/Order/Ring/Opposite.lean
@@ -1,0 +1,50 @@
+/-
+Copyright (c) 2024 Yaël Dillies. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Yaël Dillies
+-/
+import Mathlib.Algebra.Order.Group.Opposite
+import Mathlib.Algebra.Order.Ring.Defs
+import Mathlib.Algebra.Ring.Opposite
+
+/-!
+# Ordered ring instances for `MulOpposite`/`AddOpposite`
+
+This files transfers ordered (semi)ring instances from `α` to `αᵐᵒᵖ` and `αᵃᵒᵖ`.
+-/
+
+variable {α : Type*}
+
+namespace MulOpposite
+
+instance [OrderedSemiring α] : OrderedSemiring αᵐᵒᵖ where
+  __ := instSemiring
+  __ := instOrderedAddCommMonoid
+  zero_le_one := zero_le_one (α := α)
+  mul_le_mul_of_nonneg_left _ _ _ := mul_le_mul_of_nonneg_right (α := α)
+  mul_le_mul_of_nonneg_right _ _ _ := mul_le_mul_of_nonneg_left (α := α)
+
+instance [OrderedRing α] : OrderedRing αᵐᵒᵖ where
+  __ := instRing
+  __ := instOrderedAddCommGroup
+  __ := instOrderedSemiring
+  mul_nonneg _a _b ha hb := mul_nonneg (α := α) hb ha
+
+end MulOpposite
+
+namespace AddOpposite
+
+instance [OrderedSemiring α] : OrderedSemiring αᵃᵒᵖ where
+  __ := instSemiring
+  __ := instOrderedAddCommMonoid
+  zero_le_one := zero_le_one (α := α)
+  mul_le_mul_of_nonneg_left _ _ _ := mul_le_mul_of_nonneg_left (α := α)
+  mul_le_mul_of_nonneg_right _ _ _ := mul_le_mul_of_nonneg_right (α := α)
+
+instance [OrderedRing α] : OrderedRing αᵐᵒᵖ where
+  __ := instRing
+  __ := instOrderedAddCommGroup
+  __ := instOrderedSemiring
+  mul_nonneg _a _b := mul_nonneg (α := α)
+
+end AddOpposite


### PR DESCRIPTION
Transfer order and ordered monoid/group/semiring/ring instances from `α` to `αᵐᵒᵖ` and `αᵃᵒᵖ`.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
