### PR TITLE
[Merged by Bors] - feat: balancing a function

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -36,6 +36,7 @@ import Mathlib.Algebra.AlgebraicCard
 import Mathlib.Algebra.Associated.Basic
 import Mathlib.Algebra.Associated.OrderedCommMonoid
 import Mathlib.Algebra.BigOperators.Associated
+import Mathlib.Algebra.BigOperators.Balance
 import Mathlib.Algebra.BigOperators.Expect
 import Mathlib.Algebra.BigOperators.Fin
 import Mathlib.Algebra.BigOperators.Finprod

--- a/Mathlib/Algebra/BigOperators/Balance.lean
+++ b/Mathlib/Algebra/BigOperators/Balance.lean
@@ -1,5 +1,5 @@
 /-
-Copyright (c) 2024 Yaël Dillies, Bhavik Mehta. All rights reserved.
+Copyright (c) 2023 Yaël Dillies, Bhavik Mehta. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Yaël Dillies, Bhavik Mehta
 -/

--- a/Mathlib/Algebra/BigOperators/Balance.lean
+++ b/Mathlib/Algebra/BigOperators/Balance.lean
@@ -8,11 +8,11 @@ import Mathlib.Algebra.BigOperators.Expect
 /-!
 # Balancing a function
 
-This file defines the balancing of a function `f`, namely the unique function `g` such that
-`f a - f b = g a - g b` for all `a` and `b`, and `∑ a, g a = 0`.
+This file defines the balancing of a function `f`, defined as `f` minus its average.
 
-This is particularly useful in Fourier analysis as `f` and `g` have the same Fourier transform,
-except in the `0`-th frequency where the Fourier transform of `g` vanishes.
+This is the unique function `g` such that `f a - f b = g a - g b` for all `a` and `b`, and
+`∑ a, g a = 0`. This is particularly useful in Fourier analysis as `f` and `g` then have the same
+Fourier transform, except in the `0`-th frequency where the Fourier transform of `g` vanishes.
 -/
 
 open Function

--- a/Mathlib/Algebra/BigOperators/Balance.lean
+++ b/Mathlib/Algebra/BigOperators/Balance.lean
@@ -15,18 +15,15 @@ This is the unique function `g` such that `f a - f b = g a - g b` for all `a` an
 Fourier transform, except in the `0`-th frequency where the Fourier transform of `g` vanishes.
 -/
 
-open Function
-open Fintype (card)
-open scoped BigOperators Pointwise NNRat
+open Finset Function
+open scoped BigOperators
 
-variable {ι F G K : Type*}
+variable {ι H F G : Type*}
 
-namespace Finset
+namespace Fintype
 
 section AddCommGroup
-variable [AddCommGroup G] [Module ℚ≥0 G] [Field K] [Module ℚ≥0 K] {s : Finset ι}
-
-variable [Fintype ι]
+variable [Fintype ι] [AddCommGroup G] [Module ℚ≥0 G] [AddCommGroup H] [Module ℚ≥0 H]
 
 /-- The balancing of a function, namely the function minus its average. -/
 def balance (f : ι → G) : ι → G := f - Function.const _ (𝔼 y, f y)
@@ -52,8 +49,8 @@ lemma balance_apply (f : ι → G) (x : ι) : balance f x = f x - 𝔼 y, f y :=
 @[simp] lemma balance_idem (f : ι → G) : balance (balance f) = balance f := by
   cases isEmpty_or_nonempty ι <;> ext x <;> simp [balance, expect_sub_distrib, univ_nonempty]
 
-@[simp] lemma map_balance [FunLike F G K] [LinearMapClass F ℚ≥0 G K] (g : F) (f : ι → G) (a : ι) :
+@[simp] lemma map_balance [FunLike F G H] [LinearMapClass F ℚ≥0 G H] (g : F) (f : ι → G) (a : ι) :
     g (balance f a) = balance (g ∘ f) a := by simp [balance, map_expect]
 
 end AddCommGroup
-end Finset
+end Fintype

--- a/Mathlib/Algebra/BigOperators/Balance.lean
+++ b/Mathlib/Algebra/BigOperators/Balance.lean
@@ -1,0 +1,59 @@
+/-
+Copyright (c) 2024 Yaël Dillies, Bhavik Mehta. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Yaël Dillies, Bhavik Mehta
+-/
+import Mathlib.Algebra.BigOperators.Expect
+
+/-!
+# Balancing a function
+
+This file defines the balancing of a function `f`, namely the unique function `g` such that
+`f a - f b = g a - g b` for all `a` and `b`, and `∑ a, g a = 0`.
+
+This is particularly useful in Fourier analysis as `f` and `g` have the same Fourier transform,
+except in the `0`-th frequency where the Fourier transform of `g` vanishes.
+-/
+
+open Function
+open Fintype (card)
+open scoped BigOperators Pointwise NNRat
+
+variable {ι F G K : Type*}
+
+namespace Finset
+
+section AddCommGroup
+variable [AddCommGroup G] [Module ℚ≥0 G] [Field K] [Module ℚ≥0 K] {s : Finset ι}
+
+variable [Fintype ι]
+
+/-- The balancing of a function, namely the function minus its average. -/
+def balance (f : ι → G) : ι → G := f - Function.const _ (𝔼 y, f y)
+
+lemma balance_apply (f : ι → G) (x : ι) : balance f x = f x - 𝔼 y, f y := rfl
+
+@[simp] lemma balance_zero : balance (0 : ι → G) = 0 := by simp [balance]
+
+@[simp] lemma balance_add (f g : ι → G) : balance (f + g) = balance f + balance g := by
+  simp only [balance, expect_add_distrib, ← const_add, add_sub_add_comm, Pi.add_apply]
+
+@[simp] lemma balance_sub (f g : ι → G) : balance (f - g) = balance f - balance g := by
+  simp only [balance, expect_sub_distrib, const_sub, sub_sub_sub_comm, Pi.sub_apply]
+
+@[simp] lemma balance_neg (f : ι → G) : balance (-f) = -balance f := by
+  simp only [balance, expect_neg_distrib, const_neg, neg_sub', Pi.neg_apply]
+
+@[simp] lemma sum_balance (f : ι → G) : ∑ x, balance f x = 0 := by
+  cases isEmpty_or_nonempty ι <;> simp [balance_apply]
+
+@[simp] lemma expect_balance (f : ι → G) : 𝔼 x, balance f x = 0 := by simp [expect]
+
+@[simp] lemma balance_idem (f : ι → G) : balance (balance f) = balance f := by
+  cases isEmpty_or_nonempty ι <;> ext x <;> simp [balance, expect_sub_distrib, univ_nonempty]
+
+@[simp] lemma map_balance [FunLike F G K] [LinearMapClass F ℚ≥0 G K] (g : F) (f : ι → G) (a : ι) :
+    g (balance f a) = balance (g ∘ f) a := by simp [balance, map_expect]
+
+end AddCommGroup
+end Finset


### PR DESCRIPTION
Define the balancing of a function, namely the function minus its average. Doing this operation has the effect of nullifying the `0`-th component of the Fourier transform (but this PR doesn't prove this fact).

From LeanAPAP

Co-authored-by: Bhavik Mehta <bhavikmehta8@gmail.com>

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
