### PR TITLE
[Merged by Bors] - refactor: Let `positivity` handle `ENNReal`-valued `ofNat`

### DIFF
--- a/Mathlib/Data/ENNReal/Basic.lean
+++ b/Mathlib/Data/ENNReal/Basic.lean
@@ -386,6 +386,9 @@ theorem one_lt_two : (1 : ℝ≥0∞) < 2 := Nat.one_lt_ofNat
 
 @[simp] theorem two_lt_top : (2 : ℝ≥0∞) < ∞ := coe_lt_top
 
+@[simp] lemma ofNat_pos {n : ℕ} [n.AtLeastTwo] : 0 < (no_index OfNat.ofNat n : ℝ≥0∞) :=
+  Nat.cast_pos.2 Fin.size_pos'
+
 /-- `(1 : ℝ≥0∞) ≤ 1`, recorded as a `Fact` for use with `Lp` spaces. -/
 instance _root_.fact_one_le_one_ennreal : Fact ((1 : ℝ≥0∞) ≤ 1) :=
   ⟨le_rfl⟩
@@ -710,7 +713,25 @@ def evalENNRealOfNNReal : PositivityExt where eval {u α} _zα _pα e := do
     | _ => pure .none
   | _, _, _ => throwError "not ENNReal.ofNNReal"
 
+private lemma ennreal_one_pos : (0 : ℝ≥0∞) < 1 := zero_lt_one
+
+/-- The `positivity` extension which identifies expressions of the form `OfNat.ofNat n : ℝ≥0∞`. -/
+@[positivity OfNat.ofNat _] def evalOfNatENNReal : PositivityExt where eval {u} α _z _p e := do
+  match u, α, e with
+  | 0, ~q(ℝ≥0∞), ~q(@OfNat.ofNat _ $n $instn) =>
+    try
+      let instn ← synthInstanceQ q(Nat.AtLeastTwo $n)
+      return Strictness.positive (q(@ofNat_pos $n $instn) : Expr)
+    catch _ => do
+      match n with
+      | ~q(1) => return .positive (q(ennreal_one_pos) : Expr)
+      | _ => throwError "not positive"
+  | _ => throwError "not `ENNReal`-valued `ofNat`"
+
 end Mathlib.Meta.Positivity
+
+example : (0 : ℝ≥0∞) < 1 := by positivity
+example : (0 : ℝ≥0∞) < 2 := by positivity
 
 @[deprecated (since := "2023-12-23")] protected alias
 ENNReal.le_inv_smul_iff_of_pos := le_inv_smul_iff_of_pos

--- a/Mathlib/Data/ENNReal/Basic.lean
+++ b/Mathlib/Data/ENNReal/Basic.lean
@@ -711,8 +711,7 @@ def evalENNRealOfNNReal : PositivityExt where eval {u α} _zα _pα e := do
   | _, _, _ => throwError "not ENNReal.ofNNReal"
 
 private lemma ennreal_one_pos : (0 : ℝ≥0∞) < 1 := zero_lt_one
-private lemma ofNat_pos {n : ℕ} [n.AtLeastTwo] : 0 < (no_index OfNat.ofNat n : ℝ≥0∞) :=
-  Nat.ofNat_pos
+private lemma ofNat_pos {n : ℕ} [n.AtLeastTwo] : 0 < (OfNat.ofNat n : ℝ≥0∞) := Nat.ofNat_pos
 
 /-- The `positivity` extension which identifies expressions of the form `OfNat.ofNat n : ℝ≥0∞`. -/
 @[positivity OfNat.ofNat _] def evalOfNatENNReal : PositivityExt where eval {u} α _z _p e := do

--- a/Mathlib/Data/ENNReal/Basic.lean
+++ b/Mathlib/Data/ENNReal/Basic.lean
@@ -386,9 +386,6 @@ theorem one_lt_two : (1 : ℝ≥0∞) < 2 := Nat.one_lt_ofNat
 
 @[simp] theorem two_lt_top : (2 : ℝ≥0∞) < ∞ := coe_lt_top
 
-@[simp] lemma ofNat_pos {n : ℕ} [n.AtLeastTwo] : 0 < (no_index OfNat.ofNat n : ℝ≥0∞) :=
-  Nat.cast_pos.2 Fin.size_pos'
-
 /-- `(1 : ℝ≥0∞) ≤ 1`, recorded as a `Fact` for use with `Lp` spaces. -/
 instance _root_.fact_one_le_one_ennreal : Fact ((1 : ℝ≥0∞) ≤ 1) :=
   ⟨le_rfl⟩
@@ -714,6 +711,8 @@ def evalENNRealOfNNReal : PositivityExt where eval {u α} _zα _pα e := do
   | _, _, _ => throwError "not ENNReal.ofNNReal"
 
 private lemma ennreal_one_pos : (0 : ℝ≥0∞) < 1 := zero_lt_one
+private lemma ofNat_pos {n : ℕ} [n.AtLeastTwo] : 0 < (no_index OfNat.ofNat n : ℝ≥0∞) :=
+  Nat.ofNat_pos
 
 /-- The `positivity` extension which identifies expressions of the form `OfNat.ofNat n : ℝ≥0∞`. -/
 @[positivity OfNat.ofNat _] def evalOfNatENNReal : PositivityExt where eval {u} α _z _p e := do

--- a/Mathlib/Data/ENNReal/Basic.lean
+++ b/Mathlib/Data/ENNReal/Basic.lean
@@ -685,6 +685,33 @@ end OrdConnected
 
 end Set
 
+namespace Mathlib.Meta.Positivity
+
+open Lean Meta Qq
+
+/-- Extension for the `positivity` tactic: `ENNReal.toReal`. -/
+@[positivity ENNReal.toReal _]
+def evalENNRealtoReal : PositivityExt where eval {u α} _zα _pα e := do
+  match u, α, e with
+  | 0, ~q(ℝ), ~q(ENNReal.toReal $a) =>
+    assertInstancesCommute
+    pure (.nonnegative q(ENNReal.toReal_nonneg))
+  | _, _, _ => throwError "not ENNReal.toReal"
+
+/-- Extension for the `positivity` tactic: `ENNReal.ofNNReal`. -/
+@[positivity ENNReal.ofNNReal _]
+def evalENNRealOfNNReal : PositivityExt where eval {u α} _zα _pα e := do
+  match u, α, e with
+  | 0, ~q(ℝ≥0∞), ~q(ENNReal.ofNNReal $a) =>
+    let ra ← core q(inferInstance) q(inferInstance) a
+    assertInstancesCommute
+    match ra with
+    | .positive pa => pure <| .positive q(ENNReal.coe_pos.mpr $pa)
+    | _ => pure .none
+  | _, _, _ => throwError "not ENNReal.ofNNReal"
+
+end Mathlib.Meta.Positivity
+
 @[deprecated (since := "2023-12-23")] protected alias
 ENNReal.le_inv_smul_iff_of_pos := le_inv_smul_iff_of_pos
 @[deprecated (since := "2023-12-23")] protected alias

--- a/Mathlib/Tactic/Positivity/Core.lean
+++ b/Mathlib/Tactic/Positivity/Core.lean
@@ -122,7 +122,7 @@ variable {A : Type*} {e : A}
 lemma lt_of_le_of_ne' {a b : A} [PartialOrder A] :
     (a : A) ≤ b → b ≠ a → a < b := fun h₁ h₂ => lt_of_le_of_ne h₁ h₂.symm
 
-lemma pos_of_isNat {n : ℕ} [StrictOrderedSemiring A]
+lemma pos_of_isNat {n : ℕ} [OrderedSemiring A] [Nontrivial A]
     (h : NormNum.IsNat e n) (w : Nat.ble 1 n = true) : 0 < (e : A) := by
   rw [NormNum.IsNat.to_eq h rfl]
   apply Nat.cast_pos.2
@@ -184,11 +184,12 @@ def normNumPositivity (e : Q($α)) : MetaM (Strictness zα pα e) := catchNone d
   | .isBool .. => failure
   | .isNat _ lit p =>
     if 0 < lit.natLit! then
-      let _a ← synthInstanceQ q(StrictOrderedSemiring $α)
+      let _a ← synthInstanceQ q(OrderedSemiring $α)
+      let _a ← synthInstanceQ q(Nontrivial $α)
       assumeInstancesCommute
       have p : Q(NormNum.IsNat $e $lit) := p
       haveI' p' : Nat.ble 1 $lit =Q true := ⟨⟩
-      pure (.positive q(@pos_of_isNat $α _ _ _ $p $p'))
+      pure (.positive q(@pos_of_isNat $α _ _ _ _ $p $p'))
     else
       let _a ← synthInstanceQ q(OrderedSemiring $α)
       assumeInstancesCommute

--- a/test/positivity.lean
+++ b/test/positivity.lean
@@ -23,6 +23,9 @@ example : 0 ≤ 3 := by positivity
 
 example : 0 < 3 := by positivity
 
+example : (0 : ℝ≥0∞) < 1 := by positivity
+example : (0 : ℝ≥0∞) < 2 := by positivity
+
 /- ## Goals working directly from a hypothesis -/
 -- set_option trace.Meta.debug true
 -- sudo set_option trace.Tactic.positivity true


### PR DESCRIPTION
The meta code was looking for `StrictOrderedSemiring` instead of the weaker `OrderedSemiring` + `Nontrivial`, which is enough.

From LeanAPAP

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
