### PR TITLE
[Merged by Bors] - feat: Composition of the coercion `ℝ → ℂ` with algebraic operations

### DIFF
--- a/Mathlib/Algebra/Group/Hom/Defs.lean
+++ b/Mathlib/Algebra/Group/Hom/Defs.lean
@@ -452,7 +452,7 @@ theorem map_pow [Monoid G] [Monoid H] [MonoidHomClass F G H] (f : F) (a : G) :
   | n + 1 => by rw [pow_succ, pow_succ, map_mul, map_pow f a n]
 
 @[to_additive (attr := simp)]
-lemma map_comp_pow [Group G] [DivisionMonoid H] [MonoidHomClass F G H] (f : F) (g : ι → G) (n : ℕ) :
+lemma map_comp_pow [Monoid G] [Monoid H] [MonoidHomClass F G H] (f : F) (g : ι → G) (n : ℕ) :
     f ∘ (g ^ n) = f ∘ g ^ n := by ext; simp
 
 @[to_additive]

--- a/Mathlib/Data/Complex/Basic.lean
+++ b/Mathlib/Data/Complex/Basic.lean
@@ -628,6 +628,25 @@ def ofReal : ℝ →+* ℂ where
 theorem ofReal_eq_coe (r : ℝ) : ofReal r = r :=
   rfl
 
+variable {α : Type*}
+
+@[simp] lemma ofReal_comp_add (f g : α → ℝ) : ofReal' ∘ (f + g) = ofReal' ∘ f + ofReal' ∘ g :=
+  map_comp_add ofReal ..
+
+@[simp] lemma ofReal_comp_sub (f g : α → ℝ) : ofReal' ∘ (f - g) = ofReal' ∘ f - ofReal' ∘ g :=
+  map_comp_sub ofReal ..
+
+@[simp] lemma ofReal_comp_neg (f : α → ℝ) : ofReal' ∘ (-f) = - ofReal' ∘ f := map_comp_neg ofReal _
+
+@[simp] lemma ofReal_comp_mul (f g : α → ℝ) : ofReal' ∘ (f * g) = ofReal' ∘ f * ofReal' ∘ g :=
+  map_comp_mul ofReal ..
+
+@[simp] lemma ofReal_comp_pow (f : α → ℝ) (n : ℕ) : ofReal' ∘ (f ^ n) = ofReal' ∘ f ^ n :=
+  map_comp_pow ofReal ..
+
+@[simp] lemma ofReal_comp_zpow (f : α → ℝ) (n : ℤ) : ofReal' ∘ (f ^ n) = ofReal' ∘ f ^ n :=
+  map_comp_zpow ofReal ..
+
 @[simp]
 theorem I_sq : I ^ 2 = -1 := by rw [sq, I_mul_I]
 

--- a/Mathlib/Data/Complex/Basic.lean
+++ b/Mathlib/Data/Complex/Basic.lean
@@ -644,9 +644,6 @@ variable {α : Type*}
 @[simp] lemma ofReal_comp_pow (f : α → ℝ) (n : ℕ) : ofReal' ∘ (f ^ n) = ofReal' ∘ f ^ n :=
   map_comp_pow ofReal ..
 
-@[simp] lemma ofReal_comp_zpow (f : α → ℝ) (n : ℤ) : ofReal' ∘ (f ^ n) = ofReal' ∘ f ^ n :=
-  map_comp_zpow ofReal ..
-
 @[simp]
 theorem I_sq : I ^ 2 = -1 := by rw [sq, I_mul_I]
 

--- a/Mathlib/Data/Complex/Basic.lean
+++ b/Mathlib/Data/Complex/Basic.lean
@@ -638,6 +638,12 @@ variable {α : Type*}
 
 @[simp] lemma ofReal_comp_neg (f : α → ℝ) : ofReal' ∘ (-f) = -(ofReal' ∘ f) := map_comp_neg ofReal _
 
+lemma ofReal_comp_nsmul (n : ℕ) (f : α → ℝ) : ofReal' ∘ (n • f) = n • (ofReal' ∘ f) :=
+  map_comp_nsmul ofReal ..
+
+lemma ofReal_comp_zsmul (n : ℤ) (f : α → ℝ) : ofReal' ∘ (n • f) = n • (ofReal' ∘ f) :=
+  map_comp_zsmul ofReal ..
+
 @[simp] lemma ofReal_comp_mul (f g : α → ℝ) : ofReal' ∘ (f * g) = ofReal' ∘ f * ofReal' ∘ g :=
   map_comp_mul ofReal ..
 

--- a/Mathlib/Data/Complex/Basic.lean
+++ b/Mathlib/Data/Complex/Basic.lean
@@ -636,12 +636,12 @@ variable {α : Type*}
 @[simp] lemma ofReal_comp_sub (f g : α → ℝ) : ofReal' ∘ (f - g) = ofReal' ∘ f - ofReal' ∘ g :=
   map_comp_sub ofReal ..
 
-@[simp] lemma ofReal_comp_neg (f : α → ℝ) : ofReal' ∘ (-f) = - ofReal' ∘ f := map_comp_neg ofReal _
+@[simp] lemma ofReal_comp_neg (f : α → ℝ) : ofReal' ∘ (-f) = -(ofReal' ∘ f) := map_comp_neg ofReal _
 
 @[simp] lemma ofReal_comp_mul (f g : α → ℝ) : ofReal' ∘ (f * g) = ofReal' ∘ f * ofReal' ∘ g :=
   map_comp_mul ofReal ..
 
-@[simp] lemma ofReal_comp_pow (f : α → ℝ) (n : ℕ) : ofReal' ∘ (f ^ n) = ofReal' ∘ f ^ n :=
+@[simp] lemma ofReal_comp_pow (f : α → ℝ) (n : ℕ) : ofReal' ∘ (f ^ n) = (ofReal' ∘ f) ^ n :=
   map_comp_pow ofReal ..
 
 @[simp]


### PR DESCRIPTION
From LeanAPAP


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
