### PR TITLE
[Merged by Bors] - feat: the real exponential is analytic

### DIFF
--- a/Mathlib/Analysis/Analytic/Constructions.lean
+++ b/Mathlib/Analysis/Analytic/Constructions.lean
@@ -649,6 +649,61 @@ lemma AnalyticOnNhd.pow {f : E → A} {s : Set E} (hf : AnalyticOnNhd 𝕜 f s) 
     AnalyticOnNhd 𝕜 (fun x ↦ f x ^ n) s :=
   fun _ m ↦ (hf _ m).pow n
 
+
+/-!
+### Restriction of scalars
+-/
+
+section
+
+variable {𝕜' : Type*} [NontriviallyNormedField 𝕜'] [NormedAlgebra 𝕜 𝕜']
+  [NormedSpace 𝕜' E] [IsScalarTower 𝕜 𝕜' E]
+  [NormedSpace 𝕜' F] [IsScalarTower 𝕜 𝕜' F]
+  {f : E → F} {p : FormalMultilinearSeries 𝕜' E F} {x : E} {s : Set E} {r : ℝ≥0∞}
+
+lemma HasFPowerSeriesWithinOnBall.restrictScalars (hf : HasFPowerSeriesWithinOnBall f p s x r) :
+    HasFPowerSeriesWithinOnBall f (p.restrictScalars 𝕜) s x r :=
+  ⟨hf.r_le.trans (FormalMultilinearSeries.radius_le_of_le (fun n ↦ by simp)), hf.r_pos, hf.hasSum⟩
+
+lemma HasFPowerSeriesOnBall.restrictScalars (hf : HasFPowerSeriesOnBall f p x r) :
+    HasFPowerSeriesOnBall f (p.restrictScalars 𝕜) x r :=
+  ⟨hf.r_le.trans (FormalMultilinearSeries.radius_le_of_le (fun n ↦ by simp)), hf.r_pos, hf.hasSum⟩
+
+lemma HasFPowerSeriesWithinAt.restrictScalars (hf : HasFPowerSeriesWithinAt f p s x) :
+    HasFPowerSeriesWithinAt f (p.restrictScalars 𝕜) s x := by
+  rcases hf with ⟨r, hr⟩
+  exact ⟨r, hr.restrictScalars⟩
+
+lemma HasFPowerSeriesAt.restrictScalars (hf : HasFPowerSeriesAt f p x) :
+    HasFPowerSeriesAt f (p.restrictScalars 𝕜) x := by
+  rcases hf with ⟨r, hr⟩
+  exact ⟨r, hr.restrictScalars⟩
+
+lemma AnalyticWithinAt.restrictScalars (hf : AnalyticWithinAt 𝕜' f s x) :
+    AnalyticWithinAt 𝕜 f s x := by
+  rcases hf with ⟨p, hp⟩
+  exact ⟨p.restrictScalars 𝕜, hp.restrictScalars⟩
+
+lemma AnalyticAt.restrictScalars (hf : AnalyticAt 𝕜' f x) :
+    AnalyticAt 𝕜 f x := by
+  rcases hf with ⟨p, hp⟩
+  exact ⟨p.restrictScalars 𝕜, hp.restrictScalars⟩
+
+lemma AnalyticOn.restrictScalars (hf : AnalyticOn 𝕜' f s) :
+    AnalyticOn 𝕜 f s :=
+  fun x hx ↦ (hf x hx).restrictScalars
+
+lemma AnalyticOnNhd.restrictScalars (hf : AnalyticOnNhd 𝕜' f s) :
+    AnalyticOnNhd 𝕜 f s :=
+  fun x hx ↦ (hf x hx).restrictScalars
+
+end
+
+
+/-!
+### Inversion is analytic
+-/
+
 section Geometric
 
 variable (𝕜 A : Type*) [NontriviallyNormedField 𝕜] [NormedRing A] [NormedAlgebra 𝕜 A]
@@ -756,6 +811,11 @@ lemma analyticAt_inverse {𝕜 : Type*} [NontriviallyNormedField 𝕜]
     · simp only [Units.inv_eq_val_inv, Units.inv_mul, sub_self, f2, f3]
       exact analyticAt_inverse_one_sub 𝕜 A
     · exact analyticAt_const.sub (analyticAt_const.mul analyticAt_id)
+
+lemma analyticOnNhd_inverse {𝕜 : Type*} [NontriviallyNormedField 𝕜]
+    {A : Type*} [NormedRing A] [NormedAlgebra 𝕜 A] [HasSummableGeomSeries A] :
+    AnalyticOnNhd 𝕜 Ring.inverse {x : A | IsUnit x} :=
+  fun _ hx ↦ analyticAt_inverse (IsUnit.unit hx)
 
 lemma hasFPowerSeriesOnBall_inv_one_sub
     (𝕜 𝕝 : Type*) [NontriviallyNormedField 𝕜] [NontriviallyNormedField 𝕝] [NormedAlgebra 𝕜 𝕝] :

--- a/Mathlib/Analysis/Calculus/FDeriv/Analytic.lean
+++ b/Mathlib/Analysis/Calculus/FDeriv/Analytic.lean
@@ -138,6 +138,12 @@ theorem AnalyticOnNhd.contDiffOn [CompleteSpace F] (h : AnalyticOnNhd 𝕜 f s) 
     (fun m _ ↦ (H.iteratedFDeriv m).differentiableOn.congr
       fun _ hx ↦ iteratedFDerivWithin_of_isOpen _ t_open hx)
 
+/-- An analytic function on the whole space is infinitely differentiable there. -/
+theorem AnalyticOnNhd.contDiff [CompleteSpace F] (h : AnalyticOnNhd 𝕜 f univ) {n : ℕ∞} :
+    ContDiff 𝕜 n f := by
+  rw [← contDiffOn_univ]
+  exact h.contDiffOn
+
 theorem AnalyticAt.contDiffAt [CompleteSpace F] (h : AnalyticAt 𝕜 f x) {n : ℕ∞} :
     ContDiffAt 𝕜 n f x := by
   obtain ⟨s, hs, hf⟩ := h.exists_mem_nhds_analyticOnNhd

--- a/Mathlib/Analysis/SpecialFunctions/Complex/Analytic.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Complex/Analytic.lean
@@ -11,7 +11,7 @@ import Mathlib.Analysis.SpecialFunctions.Complex.LogDeriv
 /-!
 # Various complex special functions are analytic
 
-`exp`, `log`, and `cpow` are analytic, since they are differentiable.
+`log`, and `cpow` are analytic, since they are differentiable.
 -/
 
 open Complex Set
@@ -19,31 +19,6 @@ open scoped Topology
 
 variable {E : Type} [NormedAddCommGroup E] [NormedSpace ℂ E]
 variable {f g : E → ℂ} {z : ℂ} {x : E} {s : Set E}
-
-/-- `exp` is entire -/
-theorem analyticOnNhd_cexp : AnalyticOnNhd ℂ exp univ := by
-  rw [analyticOnNhd_univ_iff_differentiable]; exact differentiable_exp
-
-theorem analyticOn_cexp : AnalyticOn ℂ exp univ := analyticOnNhd_cexp.analyticOn
-
-/-- `exp` is analytic at any point -/
-theorem analyticAt_cexp : AnalyticAt ℂ exp z :=
-  analyticOnNhd_cexp z (mem_univ _)
-
-/-- `exp ∘ f` is analytic -/
-theorem AnalyticAt.cexp (fa : AnalyticAt ℂ f x) : AnalyticAt ℂ (fun z ↦ exp (f z)) x :=
-  analyticAt_cexp.comp fa
-
-theorem AnalyticWithinAt.cexp (fa : AnalyticWithinAt ℂ f s x) :
-    AnalyticWithinAt ℂ (fun z ↦ exp (f z)) s x :=
-  analyticAt_cexp.comp_analyticWithinAt fa
-
-/-- `exp ∘ f` is analytic -/
-theorem AnalyticOnNhd.cexp (fs : AnalyticOnNhd ℂ f s) : AnalyticOnNhd ℂ (fun z ↦ exp (f z)) s :=
-  fun z n ↦ analyticAt_cexp.comp (fs z n)
-
-theorem AnalyticOn.cexp (fs : AnalyticOn ℂ f s) : AnalyticOn ℂ (fun z ↦ exp (f z)) s :=
-  analyticOnNhd_cexp.comp_analyticOn fs (mapsTo_univ _ _)
 
 /-- `log` is analytic away from nonpositive reals -/
 theorem analyticAt_clog (m : z ∈ slitPlane) : AnalyticAt ℂ log z := by
@@ -87,11 +62,11 @@ theorem AnalyticAt.cpow (fa : AnalyticAt ℂ f x) (ga : AnalyticAt ℂ g x)
   exact fa.cpow ga m
 
 /-- `f z ^ g z` is analytic if `f z` avoids nonpositive reals -/
-theorem AnalyticOnNhd.cpow (fs : AnalyticOnNhd ℂ f s) (gs : AnalyticOnNhd ℂ g s)
-    (m : ∀ z ∈ s, f z ∈ slitPlane) : AnalyticOnNhd ℂ (fun z ↦ f z ^ g z) s :=
+theorem AnalyticOn.cpow (fs : AnalyticOn ℂ f s) (gs : AnalyticOn ℂ g s)
+    (m : ∀ z ∈ s, f z ∈ slitPlane) : AnalyticOn ℂ (fun z ↦ f z ^ g z) s :=
   fun z n ↦ (fs z n).cpow (gs z n) (m z n)
 
 /-- `f z ^ g z` is analytic if `f z` avoids nonpositive reals -/
-theorem AnalyticOn.cpow (fs : AnalyticOn ℂ f s) (gs : AnalyticOn ℂ g s)
-    (m : ∀ z ∈ s, f z ∈ slitPlane) : AnalyticOn ℂ (fun z ↦ f z ^ g z) s :=
+theorem AnalyticOnNhd.cpow (fs : AnalyticOnNhd ℂ f s) (gs : AnalyticOnNhd ℂ g s)
+    (m : ∀ z ∈ s, f z ∈ slitPlane) : AnalyticOnNhd ℂ (fun z ↦ f z ^ g z) s :=
   fun z n ↦ (fs z n).cpow (gs z n) (m z n)

--- a/Mathlib/Analysis/SpecialFunctions/Complex/Analytic.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Complex/Analytic.lean
@@ -62,11 +62,11 @@ theorem AnalyticAt.cpow (fa : AnalyticAt ℂ f x) (ga : AnalyticAt ℂ g x)
   exact fa.cpow ga m
 
 /-- `f z ^ g z` is analytic if `f z` avoids nonpositive reals -/
-theorem AnalyticOn.cpow (fs : AnalyticOn ℂ f s) (gs : AnalyticOn ℂ g s)
-    (m : ∀ z ∈ s, f z ∈ slitPlane) : AnalyticOn ℂ (fun z ↦ f z ^ g z) s :=
+theorem AnalyticOnNhd.cpow (fs : AnalyticOnNhd ℂ f s) (gs : AnalyticOnNhd ℂ g s)
+    (m : ∀ z ∈ s, f z ∈ slitPlane) : AnalyticOnNhd ℂ (fun z ↦ f z ^ g z) s :=
   fun z n ↦ (fs z n).cpow (gs z n) (m z n)
 
 /-- `f z ^ g z` is analytic if `f z` avoids nonpositive reals -/
-theorem AnalyticOnNhd.cpow (fs : AnalyticOnNhd ℂ f s) (gs : AnalyticOnNhd ℂ g s)
-    (m : ∀ z ∈ s, f z ∈ slitPlane) : AnalyticOnNhd ℂ (fun z ↦ f z ^ g z) s :=
+theorem AnalyticOn.cpow (fs : AnalyticOn ℂ f s) (gs : AnalyticOn ℂ g s)
+    (m : ∀ z ∈ s, f z ∈ slitPlane) : AnalyticOn ℂ (fun z ↦ f z ^ g z) s :=
   fun z n ↦ (fs z n).cpow (gs z n) (m z n)

--- a/Mathlib/Analysis/SpecialFunctions/ExpDeriv.lean
+++ b/Mathlib/Analysis/SpecialFunctions/ExpDeriv.lean
@@ -189,12 +189,14 @@ section
 
 open Real
 
-variable {x y z : ℝ} {E : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E] {f : E → ℝ}
+variable {x : ℝ} {E : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E] {f : E → ℝ} {s : Set E}
 
 /-- `exp` is entire -/
 theorem analyticOnNhd_rexp : AnalyticOnNhd ℝ exp univ := by
   rw [Real.exp_eq_exp_ℝ]
   exact fun x _ ↦ NormedSpace.exp_analytic x
+
+theorem analyticOn_rexp : AnalyticOn ℝ exp univ := analyticOnNhd_rexp.analyticOn
 
 /-- `exp` is analytic at any point -/
 theorem analyticAt_rexp : AnalyticAt ℝ exp x :=
@@ -204,10 +206,17 @@ theorem analyticAt_rexp : AnalyticAt ℝ exp x :=
 theorem AnalyticAt.rexp {x : E} (fa : AnalyticAt ℝ f x) : AnalyticAt ℝ (fun z ↦ exp (f z)) x :=
   analyticAt_rexp.comp fa
 
+theorem AnalyticWithinAt.rexp {x : E} (fa : AnalyticWithinAt ℝ f s x) :
+    AnalyticWithinAt ℝ (fun z ↦ exp (f z)) s x :=
+  analyticAt_rexp.comp_analyticWithinAt fa
+
 /-- `exp ∘ f` is analytic -/
 theorem AnalyticOnNhd.rexp {s : Set E} (fs : AnalyticOnNhd ℝ f s) :
     AnalyticOnNhd ℝ (fun z ↦ exp (f z)) s :=
   fun z n ↦ analyticAt_rexp.comp (fs z n)
+
+theorem AnalyticOn.rexp (fs : AnalyticOn ℝ f s) : AnalyticOn ℝ (fun z ↦ exp (f z)) s :=
+  analyticOnNhd_rexp.comp_analyticOn fs (mapsTo_univ _ _)
 
 end
 

--- a/Mathlib/Analysis/SpecialFunctions/ExpDeriv.lean
+++ b/Mathlib/Analysis/SpecialFunctions/ExpDeriv.lean
@@ -6,6 +6,7 @@ Authors: Chris Hughes, Abhimanyu Pallavi Sudhir, Jean Lo, Calle Sönne
 import Mathlib.Analysis.Complex.RealDeriv
 import Mathlib.Analysis.Calculus.ContDiff.RCLike
 import Mathlib.Analysis.Calculus.IteratedDeriv.Lemmas
+import Mathlib.Analysis.SpecialFunctions.Exponential
 
 /-!
 # Complex and real exponential
@@ -23,6 +24,41 @@ open Filter Asymptotics Set Function
 open scoped Topology
 
 /-! ## `Complex.exp` -/
+
+section
+
+open Complex
+
+variable {E : Type} [NormedAddCommGroup E] [NormedSpace ℂ E]
+variable {f g : E → ℂ} {z : ℂ} {x : E} {s : Set E}
+
+/-- `exp` is entire -/
+theorem analyticOnNhd_cexp : AnalyticOnNhd ℂ exp univ := by
+  rw [Complex.exp_eq_exp_ℂ]
+  exact fun x _ ↦ NormedSpace.exp_analytic x
+
+theorem analyticOn_cexp : AnalyticOn ℂ exp univ := analyticOnNhd_cexp.analyticOn
+
+/-- `exp` is analytic at any point -/
+theorem analyticAt_cexp : AnalyticAt ℂ exp z :=
+  analyticOnNhd_cexp z (mem_univ _)
+
+/-- `exp ∘ f` is analytic -/
+theorem AnalyticAt.cexp (fa : AnalyticAt ℂ f x) : AnalyticAt ℂ (fun z ↦ exp (f z)) x :=
+  analyticAt_cexp.comp fa
+
+theorem AnalyticWithinAt.cexp (fa : AnalyticWithinAt ℂ f s x) :
+    AnalyticWithinAt ℂ (fun z ↦ exp (f z)) s x :=
+  analyticAt_cexp.comp_analyticWithinAt fa
+
+/-- `exp ∘ f` is analytic -/
+theorem AnalyticOnNhd.cexp (fs : AnalyticOnNhd ℂ f s) : AnalyticOnNhd ℂ (fun z ↦ exp (f z)) s :=
+  fun z n ↦ analyticAt_cexp.comp (fs z n)
+
+theorem AnalyticOn.cexp (fs : AnalyticOn ℂ f s) : AnalyticOn ℂ (fun z ↦ exp (f z)) s :=
+  analyticOnNhd_cexp.comp_analyticOn fs (mapsTo_univ _ _)
+
+end
 
 namespace Complex
 
@@ -52,17 +88,8 @@ theorem iter_deriv_exp : ∀ n : ℕ, deriv^[n] exp = exp
   | 0 => rfl
   | n + 1 => by rw [iterate_succ_apply, deriv_exp, iter_deriv_exp n]
 
-theorem contDiff_exp : ∀ {n}, ContDiff 𝕜 n exp := by
-  -- Porting note: added `@` due to `∀ {n}` weirdness above
-  refine @(contDiff_all_iff_nat.2 fun n => ?_)
-  have : ContDiff ℂ (↑n) exp := by
-    induction n with
-    | zero => exact contDiff_zero.2 continuous_exp
-    | succ n ihn =>
-      rw [contDiff_succ_iff_deriv]
-      use differentiable_exp
-      rwa [deriv_exp]
-  exact this.restrict_scalars 𝕜
+theorem contDiff_exp {n : ℕ∞} : ContDiff 𝕜 n exp :=
+  analyticOnNhd_cexp.restrictScalars.contDiff
 
 theorem hasStrictDerivAt_exp (x : ℂ) : HasStrictDerivAt exp (exp x) x :=
   contDiff_exp.contDiffAt.hasStrictDerivAt' (hasDerivAt_exp x) le_rfl
@@ -156,12 +183,35 @@ theorem iteratedDeriv_cexp_const_mul (n : ℕ) (c : ℂ) :
     (iteratedDeriv n fun s : ℂ => exp (c * s)) = fun s => c ^ n * exp (c * s) := by
   rw [iteratedDeriv_const_mul contDiff_exp, iteratedDeriv_eq_iterate, iter_deriv_exp]
 
-
 /-! ## `Real.exp` -/
 
-namespace Real
+section
 
-variable {x y z : ℝ}
+open Real
+
+variable {x y z : ℝ} {E : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E] {f : E → ℝ}
+
+/-- `exp` is entire -/
+theorem analyticOnNhd_rexp : AnalyticOnNhd ℝ exp univ := by
+  rw [Real.exp_eq_exp_ℝ]
+  exact fun x _ ↦ NormedSpace.exp_analytic x
+
+/-- `exp` is analytic at any point -/
+theorem analyticAt_rexp : AnalyticAt ℝ exp x :=
+  analyticOnNhd_rexp x (mem_univ _)
+
+/-- `exp ∘ f` is analytic -/
+theorem AnalyticAt.rexp {x : E} (fa : AnalyticAt ℝ f x) : AnalyticAt ℝ (fun z ↦ exp (f z)) x :=
+  analyticAt_rexp.comp fa
+
+/-- `exp ∘ f` is analytic -/
+theorem AnalyticOnNhd.rexp {s : Set E} (fs : AnalyticOnNhd ℝ f s) :
+    AnalyticOnNhd ℝ (fun z ↦ exp (f z)) s :=
+  fun z n ↦ analyticAt_rexp.comp (fs z n)
+
+end
+
+namespace Real
 
 theorem hasStrictDerivAt_exp (x : ℝ) : HasStrictDerivAt exp (exp x) x :=
   (Complex.hasStrictDerivAt_exp x).real_of_complex
@@ -169,12 +219,12 @@ theorem hasStrictDerivAt_exp (x : ℝ) : HasStrictDerivAt exp (exp x) x :=
 theorem hasDerivAt_exp (x : ℝ) : HasDerivAt exp (exp x) x :=
   (Complex.hasDerivAt_exp x).real_of_complex
 
-theorem contDiff_exp {n} : ContDiff ℝ n exp :=
+theorem contDiff_exp {n : ℕ∞} : ContDiff ℝ n exp :=
   Complex.contDiff_exp.real_of_complex
 
 theorem differentiable_exp : Differentiable ℝ exp := fun x => (hasDerivAt_exp x).differentiableAt
 
-theorem differentiableAt_exp : DifferentiableAt ℝ exp x :=
+theorem differentiableAt_exp {x : ℝ} : DifferentiableAt ℝ exp x :=
   differentiable_exp x
 
 @[simp]


### PR DESCRIPTION
Currently, mathlib proves that the complex exponential is analytic as a consequence of its differentiability, quite late in the import hierarchy -- and this is specific to complexes. On the other hand, we also know that the exponential on a general normed algebra is analytic, thanks to its power series expansion. We switch to deduce the former from the latter, earlier in the import hierarchy, and use this occasion to also prove analyticity of the real exponential in the same file.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
