### PR TITLE
[Merged by Bors] - feat: more lemmas about the size of pointwise sets

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -325,6 +325,7 @@ import Mathlib.Algebra.GroupWithZero.NonZeroDivisors
 import Mathlib.Algebra.GroupWithZero.Opposite
 import Mathlib.Algebra.GroupWithZero.Pi
 import Mathlib.Algebra.GroupWithZero.Pointwise.Set.Basic
+import Mathlib.Algebra.GroupWithZero.Pointwise.Set.Card
 import Mathlib.Algebra.GroupWithZero.Prod
 import Mathlib.Algebra.GroupWithZero.Semiconj
 import Mathlib.Algebra.GroupWithZero.ULift

--- a/Mathlib/Algebra/Group/Pointwise/Set/Card.lean
+++ b/Mathlib/Algebra/Group/Pointwise/Set/Card.lean
@@ -19,7 +19,7 @@ section Mul
 variable [Mul M] {s t : Set M}
 
 @[to_additive]
-lemma card_mul_le : #(s * t) ≤ #s * #t := by rw [← image2_mul]; exact Cardinal.mk_image2_le
+lemma cardinalMk_mul_le : #(s * t) ≤ #s * #t := by rw [← image2_mul]; exact Cardinal.mk_image2_le
 
 variable [IsCancelMul M]
 
@@ -33,8 +33,10 @@ lemma natCard_mul_le : Nat.card (s * t) ≤ Nat.card s * Nat.card t := by
     rw [← Cardinal.toNat_mul]
     gcongr
     · exact Cardinal.mul_lt_aleph0 hs.lt_aleph0 ht.lt_aleph0
-    · exact card_mul_le
+    · exact cardinalMk_mul_le
   all_goals simp
+
+@[to_additive (attr := deprecated (since := "2024-09-30"))] alias card_mul_le := cardinalMk_mul_le
 
 end Mul
 
@@ -42,12 +44,14 @@ section InvolutiveInv
 variable [InvolutiveInv G] {s t : Set G}
 
 @[to_additive (attr := simp)]
-lemma card_inv (s : Set G) : #↥(s⁻¹) = #s := by
+lemma cardinalMk_inv (s : Set G) : #↥(s⁻¹) = #s := by
   rw [← image_inv, Cardinal.mk_image_eq_of_injOn _ _ inv_injective.injOn]
 
 @[to_additive (attr := simp)]
 lemma natCard_inv (s : Set G) : Nat.card ↥(s⁻¹) = Nat.card s := by
   rw [← image_inv, Nat.card_image_of_injective inv_injective]
+
+@[to_additive (attr := deprecated (since := "2024-09-30"))] alias card_inv := natCard_inv
 
 end InvolutiveInv
 
@@ -55,8 +59,10 @@ section DivisionMonoid
 variable [DivisionMonoid M] {s t : Set M}
 
 @[to_additive]
-lemma card_div_le : #(s / t) ≤ #s * #t := by
-  rw [div_eq_mul_inv, ← card_inv t]; exact card_mul_le
+lemma cardinalMk_div_le : #(s / t) ≤ #s * #t := by
+  rw [div_eq_mul_inv, ← cardinalMk_inv t]; exact cardinalMk_mul_le
+
+@[to_additive (attr := deprecated (since := "2024-09-30"))] alias card_div_le := cardinalMk_div_le
 
 end DivisionMonoid
 
@@ -70,12 +76,15 @@ lemma natCard_div_le : Nat.card (s / t) ≤ Nat.card s * Nat.card t := by
 variable [MulAction G α]
 
 @[to_additive (attr := simp)]
-lemma card_smul_set (a : G) (s : Set α) : #↥(a • s) = #s :=
+lemma cardinalMk_smul_set (a : G) (s : Set α) : #↥(a • s) = #s :=
   Cardinal.mk_image_eq_of_injOn _ _ (MulAction.injective a).injOn
 
 @[to_additive (attr := simp)]
 lemma natCard_smul_set (a : G) (s : Set α) : Nat.card ↥(a • s) = Nat.card s :=
   Nat.card_image_of_injective (MulAction.injective a) _
+
+@[to_additive (attr := deprecated (since := "2024-09-30"))]
+alias card_smul_set := cardinalMk_smul_set
 
 end Group
 end Set

--- a/Mathlib/Algebra/Group/Pointwise/Set/Card.lean
+++ b/Mathlib/Algebra/Group/Pointwise/Set/Card.lean
@@ -19,7 +19,8 @@ section Mul
 variable [Mul M] {s t : Set M}
 
 @[to_additive]
-lemma cardinalMk_mul_le : #(s * t) ≤ #s * #t := by rw [← image2_mul]; exact Cardinal.mk_image2_le
+lemma _root_.Cardinal.mk_mul_le : #(s * t) ≤ #s * #t := by
+  rw [← image2_mul]; exact Cardinal.mk_image2_le
 
 variable [IsCancelMul M]
 
@@ -33,10 +34,10 @@ lemma natCard_mul_le : Nat.card (s * t) ≤ Nat.card s * Nat.card t := by
     rw [← Cardinal.toNat_mul]
     gcongr
     · exact Cardinal.mul_lt_aleph0 hs.lt_aleph0 ht.lt_aleph0
-    · exact cardinalMk_mul_le
+    · exact Cardinal.mk_mul_le
   all_goals simp
 
-@[to_additive (attr := deprecated (since := "2024-09-30"))] alias card_mul_le := cardinalMk_mul_le
+@[to_additive (attr := deprecated (since := "2024-09-30"))] alias card_mul_le := Cardinal.mk_mul_le
 
 end Mul
 
@@ -44,7 +45,7 @@ section InvolutiveInv
 variable [InvolutiveInv G] {s t : Set G}
 
 @[to_additive (attr := simp)]
-lemma cardinalMk_inv (s : Set G) : #↥(s⁻¹) = #s := by
+lemma _root_.Cardinal.mk_inv (s : Set G) : #↥(s⁻¹) = #s := by
   rw [← image_inv, Cardinal.mk_image_eq_of_injOn _ _ inv_injective.injOn]
 
 @[to_additive (attr := simp)]
@@ -59,10 +60,10 @@ section DivisionMonoid
 variable [DivisionMonoid M] {s t : Set M}
 
 @[to_additive]
-lemma cardinalMk_div_le : #(s / t) ≤ #s * #t := by
-  rw [div_eq_mul_inv, ← cardinalMk_inv t]; exact cardinalMk_mul_le
+lemma _root_.Cardinal.mk_div_le : #(s / t) ≤ #s * #t := by
+  rw [div_eq_mul_inv, ← Cardinal.mk_inv t]; exact Cardinal.mk_mul_le
 
-@[to_additive (attr := deprecated (since := "2024-09-30"))] alias card_div_le := cardinalMk_div_le
+@[to_additive (attr := deprecated (since := "2024-09-30"))] alias card_div_le := Cardinal.mk_div_le
 
 end DivisionMonoid
 
@@ -76,7 +77,7 @@ lemma natCard_div_le : Nat.card (s / t) ≤ Nat.card s * Nat.card t := by
 variable [MulAction G α]
 
 @[to_additive (attr := simp)]
-lemma cardinalMk_smul_set (a : G) (s : Set α) : #↥(a • s) = #s :=
+lemma _root_.Cardinal.mk_smul_set (a : G) (s : Set α) : #↥(a • s) = #s :=
   Cardinal.mk_image_eq_of_injOn _ _ (MulAction.injective a).injOn
 
 @[to_additive (attr := simp)]
@@ -84,7 +85,7 @@ lemma natCard_smul_set (a : G) (s : Set α) : Nat.card ↥(a • s) = Nat.card s
   Nat.card_image_of_injective (MulAction.injective a) _
 
 @[to_additive (attr := deprecated (since := "2024-09-30"))]
-alias card_smul_set := cardinalMk_smul_set
+alias card_smul_set := Cardinal.mk_smul_set
 
 end Group
 end Set

--- a/Mathlib/Algebra/Group/Pointwise/Set/Card.lean
+++ b/Mathlib/Algebra/Group/Pointwise/Set/Card.lean
@@ -3,60 +3,79 @@ Copyright (c) 2024 Yaël Dillies. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Yaël Dillies
 -/
-import Mathlib.Algebra.Group.Pointwise.Finset.Basic
+import Mathlib.Data.Set.Pointwise.Finite
 import Mathlib.SetTheory.Cardinal.Finite
 
 /-!
-# Cardinalities of pointwise operations on sets.
+# Cardinalities of pointwise operations on sets
 -/
 
+open scoped Cardinal Pointwise
+
 namespace Set
+variable {G M α : Type*}
 
-open Pointwise
-
-variable {α β : Type*}
-
-section MulAction
-variable [Group α] [MulAction α β]
-
-@[to_additive (attr := simp)]
-lemma card_smul_set (a : α) (s : Set β) : Nat.card ↥(a • s) = Nat.card s :=
-  Nat.card_image_of_injective (MulAction.injective a) _
-
-end MulAction
-
-section IsCancelMul
-variable [Mul α] [IsCancelMul α] {s t : Set α}
+section Mul
+variable [Mul M] {s t : Set M}
 
 @[to_additive]
-lemma card_mul_le : Nat.card (s * t) ≤ Nat.card s * Nat.card t := by
+lemma card_mul_le : #(s * t) ≤ #s * #t := by rw [← image2_mul]; exact Cardinal.mk_image2_le
+
+variable [IsCancelMul M]
+
+@[to_additive]
+lemma natCard_mul_le : Nat.card (s * t) ≤ Nat.card s * Nat.card t := by
   classical
   obtain h | h := (s * t).infinite_or_finite
   · simp [Set.Infinite.card_eq_zero h]
   obtain ⟨hs, ht⟩ | rfl | rfl := finite_mul.1 h
-  · lift s to Finset α using hs
-    lift t to Finset α using ht
-    rw [← Finset.coe_mul]
-    simpa [-Finset.coe_mul] using Finset.card_mul_le
+  · unfold Nat.card
+    rw [← Cardinal.toNat_mul]
+    gcongr
+    · exact Cardinal.mul_lt_aleph0 hs.lt_aleph0 ht.lt_aleph0
+    · exact card_mul_le
   all_goals simp
 
-end IsCancelMul
+end Mul
 
 section InvolutiveInv
-variable [InvolutiveInv α] {s t : Set α}
+variable [InvolutiveInv G] {s t : Set G}
 
 @[to_additive (attr := simp)]
-lemma card_inv (s : Set α) : Nat.card ↥(s⁻¹) = Nat.card s := by
+lemma card_inv (s : Set G) : #↥(s⁻¹) = #s := by
+  rw [← image_inv, Cardinal.mk_image_eq_of_injOn _ _ inv_injective.injOn]
+
+@[to_additive (attr := simp)]
+lemma natCard_inv (s : Set G) : Nat.card ↥(s⁻¹) = Nat.card s := by
   rw [← image_inv, Nat.card_image_of_injective inv_injective]
 
 end InvolutiveInv
 
-section Group
-variable [Group α] {s t : Set α}
+section DivisionMonoid
+variable [DivisionMonoid M] {s t : Set M}
 
 @[to_additive]
-lemma card_div_le : Nat.card (s / t) ≤ Nat.card s * Nat.card t := by
+lemma card_div_le : #(s / t) ≤ #s * #t := by
   rw [div_eq_mul_inv, ← card_inv t]; exact card_mul_le
+
+end DivisionMonoid
+
+section Group
+variable [Group G] {s t : Set G}
+
+@[to_additive]
+lemma natCard_div_le : Nat.card (s / t) ≤ Nat.card s * Nat.card t := by
+  rw [div_eq_mul_inv, ← natCard_inv t]; exact natCard_mul_le
+
+variable [MulAction G α]
+
+@[to_additive (attr := simp)]
+lemma card_smul_set (a : G) (s : Set α) : #↥(a • s) = #s :=
+  Cardinal.mk_image_eq_of_injOn _ _ (MulAction.injective a).injOn
+
+@[to_additive (attr := simp)]
+lemma natCard_smul_set (a : G) (s : Set α) : Nat.card ↥(a • s) = Nat.card s :=
+  Nat.card_image_of_injective (MulAction.injective a) _
 
 end Group
 end Set

--- a/Mathlib/Algebra/Group/Pointwise/Set/Card.lean
+++ b/Mathlib/Algebra/Group/Pointwise/Set/Card.lean
@@ -56,16 +56,14 @@ lemma natCard_inv (s : Set G) : Nat.card ↥(s⁻¹) = Nat.card s := by
 
 end InvolutiveInv
 
-section DivisionMonoid
-variable [DivisionMonoid M] {s t : Set M}
+section DivInvMonoid
+variable [DivInvMonoid M] {s t : Set M}
 
 @[to_additive]
 lemma _root_.Cardinal.mk_div_le : #(s / t) ≤ #s * #t := by
-  rw [div_eq_mul_inv, ← Cardinal.mk_inv t]; exact Cardinal.mk_mul_le
+  rw [← image2_div]; exact Cardinal.mk_image2_le
 
-@[to_additive (attr := deprecated (since := "2024-09-30"))] alias card_div_le := Cardinal.mk_div_le
-
-end DivisionMonoid
+end DivInvMonoid
 
 section Group
 variable [Group G] {s t : Set G}
@@ -73,6 +71,8 @@ variable [Group G] {s t : Set G}
 @[to_additive]
 lemma natCard_div_le : Nat.card (s / t) ≤ Nat.card s * Nat.card t := by
   rw [div_eq_mul_inv, ← natCard_inv t]; exact natCard_mul_le
+
+@[to_additive (attr := deprecated (since := "2024-09-30"))] alias card_div_le := natCard_div_le
 
 variable [MulAction G α]
 

--- a/Mathlib/Algebra/Group/Pointwise/Set/Card.lean
+++ b/Mathlib/Algebra/Group/Pointwise/Set/Card.lean
@@ -32,7 +32,7 @@ lemma natCard_mul_le : Nat.card (s * t) ≤ Nat.card s * Nat.card t := by
   refine Cardinal.toNat_le_toNat Cardinal.mk_mul_le ?_
   aesop (add simp [Cardinal.mul_lt_aleph0_iff, finite_mul])
 
-@[to_additive (attr := deprecated (since := "2024-09-30"))] alias card_mul_le := Cardinal.mk_mul_le
+@[to_additive (attr := deprecated (since := "2024-09-30"))] alias card_mul_le := natCard_mul_le
 
 end Mul
 

--- a/Mathlib/Algebra/Group/Pointwise/Set/Card.lean
+++ b/Mathlib/Algebra/Group/Pointwise/Set/Card.lean
@@ -26,16 +26,11 @@ variable [IsCancelMul M]
 
 @[to_additive]
 lemma natCard_mul_le : Nat.card (s * t) ≤ Nat.card s * Nat.card t := by
-  classical
   obtain h | h := (s * t).infinite_or_finite
   · simp [Set.Infinite.card_eq_zero h]
-  obtain ⟨hs, ht⟩ | rfl | rfl := finite_mul.1 h
-  · unfold Nat.card
-    rw [← Cardinal.toNat_mul]
-    gcongr
-    · exact Cardinal.mul_lt_aleph0 hs.lt_aleph0 ht.lt_aleph0
-    · exact Cardinal.mk_mul_le
-  all_goals simp
+  simp only [Nat.card, ← Cardinal.toNat_mul]
+  refine Cardinal.toNat_le_toNat Cardinal.mk_mul_le ?_
+  aesop (add simp [Cardinal.mul_lt_aleph0_iff, finite_mul])
 
 @[to_additive (attr := deprecated (since := "2024-09-30"))] alias card_mul_le := Cardinal.mk_mul_le
 

--- a/Mathlib/Algebra/GroupWithZero/Pointwise/Set/Card.lean
+++ b/Mathlib/Algebra/GroupWithZero/Pointwise/Set/Card.lean
@@ -1,0 +1,27 @@
+/-
+Copyright (c) 2024 Yaël Dillies. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Yaël Dillies
+-/
+import Mathlib.Algebra.Group.Pointwise.Set.Basic
+import Mathlib.Algebra.GroupWithZero.Action.Basic
+import Mathlib.SetTheory.Cardinal.Finite
+
+/-!
+# Cardinality of sets under pointwise group with zero operations
+-/
+
+open scoped Cardinal Pointwise
+
+variable {G G₀ M M₀ : Type*}
+
+namespace Set
+variable [GroupWithZero G₀] [Zero M₀] [MulActionWithZero G₀ M₀] {a : G₀}
+
+lemma card_smul_set₀ (ha : a ≠ 0) (s : Set M₀) : #↥(a • s) = #s :=
+  Cardinal.mk_image_eq_of_injOn _ _ (MulAction.injective₀ ha).injOn
+
+lemma natCard_smul_set₀ (ha : a ≠ 0) (s : Set M₀) : Nat.card ↥(a • s) = Nat.card s :=
+  Nat.card_image_of_injective (MulAction.injective₀ ha) _
+
+end Set

--- a/Mathlib/Algebra/GroupWithZero/Pointwise/Set/Card.lean
+++ b/Mathlib/Algebra/GroupWithZero/Pointwise/Set/Card.lean
@@ -18,7 +18,7 @@ variable {G G₀ M M₀ : Type*}
 namespace Set
 variable [GroupWithZero G₀] [Zero M₀] [MulActionWithZero G₀ M₀] {a : G₀}
 
-lemma cardinalMk_smul_set₀ (ha : a ≠ 0) (s : Set M₀) : #↥(a • s) = #s :=
+lemma _root_.Cardinal.mk_smul_set₀ (ha : a ≠ 0) (s : Set M₀) : #↥(a • s) = #s :=
   Cardinal.mk_image_eq_of_injOn _ _ (MulAction.injective₀ ha).injOn
 
 lemma natCard_smul_set₀ (ha : a ≠ 0) (s : Set M₀) : Nat.card ↥(a • s) = Nat.card s :=

--- a/Mathlib/Algebra/GroupWithZero/Pointwise/Set/Card.lean
+++ b/Mathlib/Algebra/GroupWithZero/Pointwise/Set/Card.lean
@@ -18,7 +18,7 @@ variable {G G₀ M M₀ : Type*}
 namespace Set
 variable [GroupWithZero G₀] [Zero M₀] [MulActionWithZero G₀ M₀] {a : G₀}
 
-lemma card_smul_set₀ (ha : a ≠ 0) (s : Set M₀) : #↥(a • s) = #s :=
+lemma cardinalMk_smul_set₀ (ha : a ≠ 0) (s : Set M₀) : #↥(a • s) = #s :=
   Cardinal.mk_image_eq_of_injOn _ _ (MulAction.injective₀ ha).injOn
 
 lemma natCard_smul_set₀ (ha : a ≠ 0) (s : Set M₀) : Nat.card ↥(a • s) = Nat.card s :=

--- a/Mathlib/SetTheory/Cardinal/Basic.lean
+++ b/Mathlib/SetTheory/Cardinal/Basic.lean
@@ -1756,8 +1756,16 @@ theorem mk_emptyCollection_iff {α : Type u} {s : Set α} : #s = 0 ↔ s = ∅ :
 theorem mk_univ {α : Type u} : #(@univ α) = #α :=
   mk_congr (Equiv.Set.univ α)
 
+@[simp] lemma mk_setProd {α β : Type u} (s : Set α) (t : Set β) : #(s ×ˢ t) = #s * #t := by
+  rw [mul_def, mk_congr (Equiv.Set.prod ..)]
+
 theorem mk_image_le {α β : Type u} {f : α → β} {s : Set α} : #(f '' s) ≤ #s :=
   mk_le_of_surjective surjective_onto_image
+
+lemma mk_image2_le {α β γ : Type u} {f : α → β → γ} {s : Set α} {t : Set β} :
+    #(image2 f s t) ≤ #s * #t := by
+  rw [← image_uncurry_prod, ← mk_setProd]
+  exact mk_image_le
 
 theorem mk_image_le_lift {α : Type u} {β : Type v} {f : α → β} {s : Set α} :
     lift.{u} #(f '' s) ≤ lift.{v} #s :=


### PR DESCRIPTION
Complete the API and follow the convention that `Cardinal.mk` is called `card` and `Nat.card` is called `natCard` in lemma names.

From LeanCamCombi

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->
- [x] depends on: #17234

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
