### PR TITLE
[Merged by Bors] - chore(ZMod): Move module and algebra instances under `Algebra`

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -32,6 +32,7 @@ import Mathlib.Algebra.Algebra.Subalgebra.Tower
 import Mathlib.Algebra.Algebra.Subalgebra.Unitization
 import Mathlib.Algebra.Algebra.Tower
 import Mathlib.Algebra.Algebra.Unitization
+import Mathlib.Algebra.Algebra.ZMod
 import Mathlib.Algebra.AlgebraicCard
 import Mathlib.Algebra.Associated.Basic
 import Mathlib.Algebra.Associated.OrderedCommMonoid
@@ -507,6 +508,7 @@ import Mathlib.Algebra.Module.Torsion
 import Mathlib.Algebra.Module.ULift
 import Mathlib.Algebra.Module.ZLattice.Basic
 import Mathlib.Algebra.Module.ZLattice.Covolume
+import Mathlib.Algebra.Module.ZMod
 import Mathlib.Algebra.MonoidAlgebra.Basic
 import Mathlib.Algebra.MonoidAlgebra.Defs
 import Mathlib.Algebra.MonoidAlgebra.Degree
@@ -2609,13 +2611,11 @@ import Mathlib.Data.Vector3
 import Mathlib.Data.W.Basic
 import Mathlib.Data.W.Cardinal
 import Mathlib.Data.W.Constructions
-import Mathlib.Data.ZMod.Algebra
 import Mathlib.Data.ZMod.Basic
 import Mathlib.Data.ZMod.Coprime
 import Mathlib.Data.ZMod.Defs
 import Mathlib.Data.ZMod.Factorial
 import Mathlib.Data.ZMod.IntUnitsPower
-import Mathlib.Data.ZMod.Module
 import Mathlib.Data.ZMod.Quotient
 import Mathlib.Data.ZMod.Units
 import Mathlib.Deprecated.Aliases

--- a/Mathlib/Algebra/Algebra/ZMod.lean
+++ b/Mathlib/Algebra/Algebra/ZMod.lean
@@ -3,8 +3,8 @@ Copyright (c) 2021 Johan Commelin. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johan Commelin
 -/
-import Mathlib.Data.ZMod.Basic
 import Mathlib.Algebra.Algebra.Defs
+import Mathlib.Data.ZMod.Basic
 
 /-!
 # The `ZMod n`-algebra structure on rings whose characteristic divides `n`

--- a/Mathlib/Algebra/Module/Torsion.lean
+++ b/Mathlib/Algebra/Module/Torsion.lean
@@ -3,11 +3,11 @@ Copyright (c) 2022 Pierre-Alexandre Bazin. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Pierre-Alexandre Bazin
 -/
-import Mathlib.LinearAlgebra.Isomorphisms
-import Mathlib.GroupTheory.Torsion
-import Mathlib.RingTheory.Coprime.Ideal
-import Mathlib.Data.ZMod.Module
 import Mathlib.Algebra.DirectSum.Module
+import Mathlib.Algebra.Module.ZMod
+import Mathlib.GroupTheory.Torsion
+import Mathlib.LinearAlgebra.Isomorphisms
+import Mathlib.RingTheory.Coprime.Ideal
 
 /-!
 # Torsion submodules

--- a/Mathlib/Algebra/Module/ZMod.lean
+++ b/Mathlib/Algebra/Module/ZMod.lean
@@ -5,7 +5,6 @@ Authors: Lawrence Wu
 -/
 import Mathlib.Algebra.Module.Submodule.Lattice
 import Mathlib.Data.ZMod.Basic
-import Mathlib.Order.OmegaCompletePartialOrder
 
 /-!
 # The `ZMod n`-module structure on Abelian groups whose elements have order dividing `n`

--- a/Mathlib/FieldTheory/Finite/GaloisField.lean
+++ b/Mathlib/FieldTheory/Finite/GaloisField.lean
@@ -3,8 +3,8 @@ Copyright (c) 2021 Johan Commelin. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Aaron Anderson, Alex J. Best, Johan Commelin, Eric Rodriguez, Ruben Van de Velde
 -/
+import Mathlib.Algebra.Algebra.ZMod
 import Mathlib.Algebra.CharP.Algebra
-import Mathlib.Data.ZMod.Algebra
 import Mathlib.FieldTheory.Finite.Basic
 import Mathlib.FieldTheory.Galois.Basic
 import Mathlib.FieldTheory.SplittingField.IsSplittingField

--- a/Mathlib/FieldTheory/IsAlgClosed/Classification.lean
+++ b/Mathlib/FieldTheory/IsAlgClosed/Classification.lean
@@ -3,9 +3,9 @@ Copyright (c) 2022 Chris Hughes. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Chris Hughes
 -/
-import Mathlib.Algebra.Polynomial.Cardinal
+import Mathlib.Algebra.Algebra.ZMod
 import Mathlib.Algebra.MvPolynomial.Cardinal
-import Mathlib.Data.ZMod.Algebra
+import Mathlib.Algebra.Polynomial.Cardinal
 import Mathlib.FieldTheory.IsAlgClosed.Basic
 import Mathlib.RingTheory.AlgebraicIndependent
 

--- a/Mathlib/RingTheory/Polynomial/Cyclotomic/Expand.lean
+++ b/Mathlib/RingTheory/Polynomial/Cyclotomic/Expand.lean
@@ -3,8 +3,8 @@ Copyright (c) 2020 Riccardo Brasca. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Riccardo Brasca
 -/
+import Mathlib.Algebra.Algebra.ZMod
 import Mathlib.RingTheory.Polynomial.Cyclotomic.Roots
-import Mathlib.Data.ZMod.Algebra
 
 /-!
 # Cyclotomic polynomials and `expand`.

--- a/Mathlib/RingTheory/WittVector/Frobenius.lean
+++ b/Mathlib/RingTheory/WittVector/Frobenius.lean
@@ -3,11 +3,11 @@ Copyright (c) 2020 Johan Commelin. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johan Commelin
 -/
+import Mathlib.Algebra.Algebra.ZMod
 import Mathlib.Data.Nat.Multiplicity
-import Mathlib.Data.ZMod.Algebra
+import Mathlib.FieldTheory.Perfect
 import Mathlib.RingTheory.WittVector.Basic
 import Mathlib.RingTheory.WittVector.IsPoly
-import Mathlib.FieldTheory.Perfect
 
 /-!
 ## The Frobenius operator


### PR DESCRIPTION
Those files have nothing to do under `Data`


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
