### PR TITLE
[Merged by Bors] - feat(SeparationQuotient): add missing instances

### DIFF
--- a/Mathlib/Topology/Algebra/SeparationQuotient.lean
+++ b/Mathlib/Topology/Algebra/SeparationQuotient.lean
@@ -3,8 +3,9 @@ Copyright (c) 2024 Yury Kudryashov. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Yury Kudryashov
 -/
-import Mathlib.Topology.Algebra.Module.Basic
 import Mathlib.LinearAlgebra.Basis.VectorSpace
+import Mathlib.Topology.Algebra.Module.Basic
+import Mathlib.Topology.Maps.OpenQuotient
 
 /-!
 # Algebraic operations on `SeparationQuotient`
@@ -62,6 +63,12 @@ instance instIsScalarTower [SMul M N] [ContinuousConstSMul N X] [IsScalarTower M
   smul_assoc a b := surjective_mk.forall.2 fun x ↦ congr_arg mk <| smul_assoc a b x
 
 end SMul
+
+instance instContinuousSMul {M X : Type*} [SMul M X] [TopologicalSpace M] [TopologicalSpace X]
+    [ContinuousSMul M X] : ContinuousSMul M (SeparationQuotient X) where
+  continuous_smul := by
+    rw [(IsOpenQuotientMap.id.prodMap isOpenQuotientMap_mk).quotientMap.continuous_iff]
+    exact continuous_mk.comp continuous_smul
 
 instance instSMulZeroClass {M X : Type*} [Zero X] [SMulZeroClass M X] [TopologicalSpace X]
     [ContinuousConstSMul M X] : SMulZeroClass M (SeparationQuotient X) :=
@@ -189,6 +196,17 @@ instance instCommGroup [CommGroup G] [TopologicalGroup G] : CommGroup (Separatio
   surjective_mk.commGroup mk mk_one mk_mul mk_inv mk_div mk_pow mk_zpow
 
 end Group
+
+section UniformGroup
+
+@[to_additive]
+instance instUniformGroup {G : Type*} [Group G] [UniformSpace G] [UniformGroup G] :
+    UniformGroup (SeparationQuotient G) where
+  uniformContinuous_div := by
+    rw [uniformContinuous_dom₂]
+    exact uniformContinuous_mk.comp uniformContinuous_div
+
+end UniformGroup
 
 section MonoidWithZero
 
@@ -390,6 +408,14 @@ theorem mk_outCLM (x : SeparationQuotient E) : mk (outCLM K E x) = x :=
 
 @[simp]
 theorem mk_comp_outCLM : mk ∘ outCLM K E = id := funext (mk_outCLM K)
+
+variable {K} in
+theorem postcomp_mkCLM_surjective {L : Type*} [Semiring L] (σ : L →+* K)
+    (F : Type*) [AddCommMonoid F] [Module L F] [TopologicalSpace F] :
+    Function.Surjective ((mkCLM K E).comp : (F →SL[σ] E) → (F →SL[σ] SeparationQuotient E)) := by
+  intro f
+  use (outCLM K E).comp f
+  rw [← ContinuousLinearMap.comp_assoc, mkCLM_comp_outCLM, ContinuousLinearMap.id_comp]
 
 /-- The `SeparationQuotient.outCLM K E` map is a topological embedding. -/
 theorem outCLM_embedding : Embedding (outCLM K E) :=

--- a/Mathlib/Topology/Inseparable.lean
+++ b/Mathlib/Topology/Inseparable.lean
@@ -548,6 +548,9 @@ theorem preimage_image_mk_open (hs : IsOpen s) : mk ⁻¹' (mk '' s) = s := by
 theorem isOpenMap_mk : IsOpenMap (mk : X → SeparationQuotient X) := fun s hs =>
   quotientMap_mk.isOpen_preimage.1 <| by rwa [preimage_image_mk_open hs]
 
+theorem isOpenQuotientMap_mk : IsOpenQuotientMap (mk : X → SeparationQuotient X) :=
+  ⟨surjective_mk, continuous_mk, isOpenMap_mk⟩
+
 theorem preimage_image_mk_closed (hs : IsClosed s) : mk ⁻¹' (mk '' s) = s := by
   refine Subset.antisymm ?_ (subset_preimage_image _ _)
   rintro x ⟨y, hys, hxy⟩


### PR DESCRIPTION
Also prove `SeparationQuotient.postcomp_mkCLM_surjective`.
I'm going to need these instances and lemmas
to generalize `CompleteSpace (E →L[K] F)` to topological vector spaces
without assuming that `F` is a Hausdorff space, see #17244.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
