### PR TITLE
fix: autolabel only PRs targeting master

### DIFF
--- a/.github/workflows/add_label_from_diff.yaml
+++ b/.github/workflows/add_label_from_diff.yaml
@@ -13,8 +13,7 @@ jobs:
     name: Add topic label
     runs-on: ubuntu-latest
     # Don't run on forks, where we wouldn't have permissions to add the label anyway.
-    # Don't run on PRs not going into `master` as script compares changes against `master`.
-    if: github.repository == 'leanprover-community/mathlib4' && github.head_ref == 'master'
+    if: github.repository == 'leanprover-community/mathlib4'
     permissions:
       issues: write
       checks: write
@@ -41,3 +40,8 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_REPO: ${{ github.repository }}
           NUMBER: ${{ github.event.number }}
+
+      - name: debug
+        run: echo "$HEAD_REF"
+        env:
+          HEAD_REF: ${{ github.head_ref}}

--- a/.github/workflows/add_label_from_diff.yaml
+++ b/.github/workflows/add_label_from_diff.yaml
@@ -13,7 +13,8 @@ jobs:
     name: Add topic label
     runs-on: ubuntu-latest
     # Don't run on forks, where we wouldn't have permissions to add the label anyway.
-    if: github.repository == 'leanprover-community/mathlib4'
+    # Don't run on PRs not going into `master` as script compares changes against `master`.
+    if: github.repository == 'leanprover-community/mathlib4' && github.head_ref == 'master'
     permissions:
       issues: write
       checks: write


### PR DESCRIPTION
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
