### PR TITLE
[Merged by Bors] - chore:  `prodAssoc` as an additive/multiplicative or linear equivalence

### DIFF
--- a/Mathlib/Algebra/Group/Prod.lean
+++ b/Mathlib/Algebra/Group/Prod.lean
@@ -587,7 +587,24 @@ theorem coe_prodComm : ⇑(prodComm : M × N ≃* N × M) = Prod.swap :=
 theorem coe_prodComm_symm : ⇑(prodComm : M × N ≃* N × M).symm = Prod.swap :=
   rfl
 
-variable {M' N' : Type*} [MulOneClass M'] [MulOneClass N']
+variable {M' : Type*} [MulOneClass M']
+
+/-- The equivalence between `(M × N) × M'` and `M × (N × M')` is multiplicative. -/
+@[to_additive prodAssoc
+      "The equivalence between `(M × N) × M'` and `M × (N × M')` is additive."]
+def prodAssoc : (M × N) × M'≃* M × (N × M') :=
+  { Equiv.prodAssoc M N M' with map_mul' := fun ⟨_, _⟩ ⟨_, _⟩ => rfl }
+
+@[to_additive (attr := simp) coe_prodAssoc]
+theorem coe_prodAssoc : ⇑(prodAssoc : (M × N) × M'≃* M × (N × M')) = Equiv.prodAssoc M N M' :=
+  rfl
+
+@[to_additive (attr := simp) coe_prodAssoc_symm]
+theorem coe_prodAssoc_symm :
+    ⇑(prodAssoc : (M × N) × M'≃* M × (N × M')).symm = (Equiv.prodAssoc M N M').symm :=
+  rfl
+
+variable {N' : Type*} [MulOneClass N']
 
 section
 

--- a/Mathlib/Algebra/Group/Prod.lean
+++ b/Mathlib/Algebra/Group/Prod.lean
@@ -587,24 +587,24 @@ theorem coe_prodComm : ⇑(prodComm : M × N ≃* N × M) = Prod.swap :=
 theorem coe_prodComm_symm : ⇑(prodComm : M × N ≃* N × M).symm = Prod.swap :=
   rfl
 
-variable {M' : Type*} [MulOneClass M']
+variable [MulOneClass P]
 
-/-- The equivalence between `(M × N) × M'` and `M × (N × M')` is multiplicative. -/
+/-- The equivalence between `(M × N) × P` and `M × (N × P)` is multiplicative. -/
 @[to_additive prodAssoc
-      "The equivalence between `(M × N) × M'` and `M × (N × M')` is additive."]
-def prodAssoc : (M × N) × M'≃* M × (N × M') :=
-  { Equiv.prodAssoc M N M' with map_mul' := fun ⟨_, _⟩ ⟨_, _⟩ => rfl }
+      "The equivalence between `(M × N) × P` and `M × (N × P)` is additive."]
+def prodAssoc : (M × N) × P ≃* M × (N × P) :=
+  { Equiv.prodAssoc M N P with map_mul' := fun ⟨_, _⟩ ⟨_, _⟩ => rfl }
 
 @[to_additive (attr := simp) coe_prodAssoc]
-theorem coe_prodAssoc : ⇑(prodAssoc : (M × N) × M'≃* M × (N × M')) = Equiv.prodAssoc M N M' :=
+theorem coe_prodAssoc : ⇑(prodAssoc : (M × N) × P ≃* M × (N × P)) = Equiv.prodAssoc M N P :=
   rfl
 
 @[to_additive (attr := simp) coe_prodAssoc_symm]
 theorem coe_prodAssoc_symm :
-    ⇑(prodAssoc : (M × N) × M'≃* M × (N × M')).symm = (Equiv.prodAssoc M N M').symm :=
+    ⇑(prodAssoc : (M × N) × P ≃* M × (N × P)).symm = (Equiv.prodAssoc M N P).symm :=
   rfl
 
-variable {N' : Type*} [MulOneClass N']
+variable {M' : Type*} {N' : Type*} [MulOneClass N'] [MulOneClass M']
 
 section
 

--- a/Mathlib/Analysis/Normed/Operator/LinearIsometry.lean
+++ b/Mathlib/Analysis/Normed/Operator/LinearIsometry.lean
@@ -952,16 +952,12 @@ variable (R E E₂ E₃)
 
 /-- The natural equivalence `(E × E₂) × E₃ ≃ E × (E₂ × E₃)` is a linear isometry. -/
 def prodAssoc [Module R E₂] [Module R E₃] : (E × E₂) × E₃ ≃ₗᵢ[R] E × E₂ × E₃ :=
-  { Equiv.prodAssoc E E₂ E₃ with
-    toFun := Equiv.prodAssoc E E₂ E₃
-    invFun := (Equiv.prodAssoc E E₂ E₃).symm
-    map_add' := by simp [-_root_.map_add] --  Fix timeout from #8386
-    map_smul' := by -- was `by simp` before #6057 caused that to time out.
-      rintro m ⟨⟨e, f⟩, g⟩
-      simp only [Prod.smul_mk, Equiv.prodAssoc_apply, RingHom.id_apply]
+  { LinearEquiv.prodAssoc R E E₂ E₃ with
     norm_map' := by
       rintro ⟨⟨e, f⟩, g⟩
-      simp only [LinearEquiv.coe_mk, Equiv.prodAssoc_apply, Prod.norm_def, max_assoc] }
+      simp only [LinearEquiv.prodAssoc_apply, AddEquiv.toEquiv_eq_coe,
+        Equiv.toFun_as_coe, EquivLike.coe_coe, AddEquiv.coe_prodAssoc,
+        Equiv.prodAssoc_apply, Prod.norm_def, max_assoc] }
 
 @[simp]
 theorem coe_prodAssoc [Module R E₂] [Module R E₃] :

--- a/Mathlib/LinearAlgebra/Prod.lean
+++ b/Mathlib/LinearAlgebra/Prod.lean
@@ -657,6 +657,31 @@ theorem snd_comp_prodComm :
 
 end prodComm
 
+/-- Product of modules is associative up to linear isomorphism. -/
+@[simps apply]
+def prodAssoc (R M₁ M₂ M₃ : Type*) [Semiring R]
+    [AddCommMonoid M₁] [AddCommMonoid M₂] [AddCommMonoid M₃]
+    [Module R M₁] [Module R M₂] [Module R M₃] : ((M₁ × M₂) × M₃) ≃ₗ[R] (M₁ × (M₂ × M₃)) :=
+  { AddEquiv.prodAssoc with
+    map_smul' := fun _r ⟨_m, _n⟩ => rfl }
+
+section prodAssoc
+
+variable [Semiring R] [AddCommMonoid M] [AddCommMonoid M₂] [AddCommMonoid M₃]
+variable [Module R M] [Module R M₂] [Module R M₃]
+
+theorem fst_comp_prodAssoc :
+    (LinearMap.fst R M (M₂ × M₃)).comp (prodAssoc R M M₂ M₃).toLinearMap =
+    (LinearMap.fst R M M₂).comp (LinearMap.fst R (M × M₂) M₃) := by
+  ext <;> simp
+
+theorem snd_comp_prodAssoc :
+    (LinearMap.snd R M (M₂ × M₃)).comp (prodAssoc R M M₂ M₃).toLinearMap =
+    (LinearMap.snd R M M₂).prodMap (LinearMap.id : M₃ →ₗ[R] M₃):= by
+  ext <;> simp
+
+end prodAssoc
+
 section
 
 variable (R M M₂ M₃ M₄)

--- a/Mathlib/LinearAlgebra/Prod.lean
+++ b/Mathlib/LinearAlgebra/Prod.lean
@@ -667,17 +667,18 @@ def prodAssoc (R M₁ M₂ M₃ : Type*) [Semiring R]
 
 section prodAssoc
 
-variable [Semiring R] [AddCommMonoid M] [AddCommMonoid M₂] [AddCommMonoid M₃]
-variable [Module R M] [Module R M₂] [Module R M₃]
+variable {M₁ : Type*}
+variable [Semiring R] [AddCommMonoid M₁] [AddCommMonoid M₂] [AddCommMonoid M₃]
+variable [Module R M₁] [Module R M₂] [Module R M₃]
 
 theorem fst_comp_prodAssoc :
-    (LinearMap.fst R M (M₂ × M₃)).comp (prodAssoc R M M₂ M₃).toLinearMap =
-    (LinearMap.fst R M M₂).comp (LinearMap.fst R (M × M₂) M₃) := by
+    (LinearMap.fst R M₁ (M₂ × M₃)).comp (prodAssoc R M₁ M₂ M₃).toLinearMap =
+    (LinearMap.fst R M₁ M₂).comp (LinearMap.fst R (M₁ × M₂) M₃) := by
   ext <;> simp
 
 theorem snd_comp_prodAssoc :
-    (LinearMap.snd R M (M₂ × M₃)).comp (prodAssoc R M M₂ M₃).toLinearMap =
-    (LinearMap.snd R M M₂).prodMap (LinearMap.id : M₃ →ₗ[R] M₃):= by
+    (LinearMap.snd R M₁ (M₂ × M₃)).comp (prodAssoc R M₁ M₂ M₃).toLinearMap =
+    (LinearMap.snd R M₁ M₂).prodMap (LinearMap.id : M₃ →ₗ[R] M₃):= by
   ext <;> simp
 
 end prodAssoc


### PR DESCRIPTION
Record multiplicativity/linearity of the equivalence `(E × F) × G ≃ E × (F × G)`. Adapt the construction of `LinearIsometryEquiv.prodAssoc` to use this.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
