### PR TITLE
[Merged by Bors] - feat(Analysis.InnerProductSpace.Symmetric) : Added several `aesop` lemmas for operations preserving `IsSymmetric`

### DIFF
--- a/Mathlib/Analysis/InnerProductSpace/Symmetric.lean
+++ b/Mathlib/Analysis/InnerProductSpace/Symmetric.lean
@@ -82,27 +82,27 @@ theorem isSymmetric_zero : (0 : E →ₗ[𝕜] E).IsSymmetric := fun x y =>
 theorem isSymmetric_id : (LinearMap.id : E →ₗ[𝕜] E).IsSymmetric := fun _ _ => rfl
 
 @[aesop safe apply]
-theorem IsSymmetric.add {T S : E →ₗ[𝕜] E} (hT : T.IsSymmetric) (hS : S.IsSymmetric) :
+theorem isSymmetric.add {T S : E →ₗ[𝕜] E} (hT : T.IsSymmetric) (hS : S.IsSymmetric) :
     (T + S).IsSymmetric := by
   intro x y
   rw [LinearMap.add_apply, inner_add_left, hT x y, hS x y, ← inner_add_right]
   rfl
 
 @[aesop safe apply]
-theorem IsSymmetric.sub {T S : E →ₗ[𝕜] E} (hT : T.IsSymmetric) (hS : S.IsSymmetric) :
+theorem isSymmetric.sub {T S : E →ₗ[𝕜] E} (hT : T.IsSymmetric) (hS : S.IsSymmetric) :
     (T - S).IsSymmetric := by
   intro x y
   rw [LinearMap.sub_apply, inner_sub_left, hT x y, hS x y, ← inner_sub_right]
   rfl
 
 @[aesop safe apply]
-theorem IsSymmetric.smul {T : E →ₗ[𝕜] E} (hT : T.IsSymmetric) {c : ℝ} :
+theorem isSymmetric.smul {T : E →ₗ[𝕜] E} (hT : T.IsSymmetric) {c : ℝ} :
     (RCLike.ofReal (K := 𝕜) c) • T |>.IsSymmetric := by
   intro x y
   simp only [smul_apply, inner_smul_left, conj_ofReal, hT x y, inner_smul_right]
 
 @[aesop safe apply]
-lemma IsSymmetric.mul_of_comm {T S : E →ₗ[𝕜] E} (hT : T.IsSymmetric) (hS : S.IsSymmetric)
+lemma isSymmetric.mul_of_comm {T S : E →ₗ[𝕜] E} (hT : T.IsSymmetric) (hS : S.IsSymmetric)
     (hST : Commute S T) : (S * T).IsSymmetric := by
   refine fun x y ↦ ?_
   nth_rw 1 [hST]
@@ -110,11 +110,11 @@ lemma IsSymmetric.mul_of_comm {T S : E →ₗ[𝕜] E} (hT : T.IsSymmetric) (hS 
   rw [← hS, hT]
 
 @[aesop safe apply]
-lemma IsSymmetric.pow {T : E →ₗ[𝕜] E} (hT : T.IsSymmetric) (n : ℕ) : (T ^ n).IsSymmetric := by
+lemma isSymmetric.pow {T : E →ₗ[𝕜] E} (hT : T.IsSymmetric) (n : ℕ) : (T ^ n).IsSymmetric := by
   refine Nat.le_induction (pow_zero T ▸ one_eq_id (R := 𝕜) (M := E) ▸ isSymmetric_id)
     (fun k _ ih ↦ ?_) n (Nat.zero_le _)
   rw [iterate_succ, ← mul_eq_comp]
-  exact IsSymmetric.mul_of_comm hT ih <| _root_.id <| Commute.symm <| Commute.pow_right rfl _
+  exact isSymmetric.mul_of_comm hT ih <| _root_.id <| Commute.symm <| Commute.pow_right rfl _
 
 /-- For a symmetric operator `T`, the function `fun x ↦ ⟪T x, x⟫` is real-valued. -/
 @[simp]

--- a/Mathlib/Analysis/InnerProductSpace/Symmetric.lean
+++ b/Mathlib/Analysis/InnerProductSpace/Symmetric.lean
@@ -74,47 +74,43 @@ theorem IsSymmetric.apply_clm {T : E →L[𝕜] E} (hT : IsSymmetric (T : E →�
     ⟪T x, y⟫ = ⟪x, T y⟫ :=
   hT x y
 
-@[aesop safe apply]
-theorem isSymmetric_zero : (0 : E →ₗ[𝕜] E).IsSymmetric := fun x y =>
+@[simp]
+theorem isSymmetric.zero : (0 : E →ₗ[𝕜] E).IsSymmetric := fun x y =>
   (inner_zero_right x : ⟪x, 0⟫ = 0).symm ▸ (inner_zero_left y : ⟪0, y⟫ = 0)
 
-@[aesop safe apply]
-theorem isSymmetric_id : (LinearMap.id : E →ₗ[𝕜] E).IsSymmetric := fun _ _ => rfl
+@[simp]
+theorem isSymmetric.id : (LinearMap.id : E →ₗ[𝕜] E).IsSymmetric := fun _ _ => rfl
 
 @[aesop safe apply]
-theorem isSymmetric.add {T S : E →ₗ[𝕜] E} (hT : T.IsSymmetric) (hS : S.IsSymmetric) :
+theorem IsSymmetric.add {T S : E →ₗ[𝕜] E} (hT : T.IsSymmetric) (hS : S.IsSymmetric) :
     (T + S).IsSymmetric := by
   intro x y
   rw [LinearMap.add_apply, inner_add_left, hT x y, hS x y, ← inner_add_right]
   rfl
 
 @[aesop safe apply]
-theorem isSymmetric.sub {T S : E →ₗ[𝕜] E} (hT : T.IsSymmetric) (hS : S.IsSymmetric) :
+theorem IsSymmetric.sub {T S : E →ₗ[𝕜] E} (hT : T.IsSymmetric) (hS : S.IsSymmetric) :
     (T - S).IsSymmetric := by
   intro x y
   rw [LinearMap.sub_apply, inner_sub_left, hT x y, hS x y, ← inner_sub_right]
   rfl
 
 @[aesop safe apply]
-theorem isSymmetric.smul {T : E →ₗ[𝕜] E} (hT : T.IsSymmetric) {c : 𝕜} (hc : conj c = c) :
+theorem IsSymmetric.smul {c : 𝕜} (hc : conj c = c) {T : E →ₗ[𝕜] E} (hT : T.IsSymmetric) :
     c • T |>.IsSymmetric := by
   intro x y
   simp only [smul_apply, inner_smul_left, hc, hT x y, inner_smul_right]
 
-@[aesop safe apply]
-lemma isSymmetric.mul_of_comm {T S : E →ₗ[𝕜] E} (hT : T.IsSymmetric) (hS : S.IsSymmetric)
-    (hST : Commute S T) : (S * T).IsSymmetric := by
-  refine fun x y ↦ ?_
-  nth_rw 1 [hST]
-  simp only [mul_apply]
-  rw [← hS, hT]
+@[aesop 30% apply]
+lemma IsSymmetric.mul_of_commute {S T : E →ₗ[𝕜] E} (hS : S.IsSymmetric) (hT : T.IsSymmetric)
+    (hST : Commute S T) : (S * T).IsSymmetric :=
+  fun _ _ ↦ by rw [mul_apply, hS, hT, hST, mul_apply]
 
 @[aesop safe apply]
-lemma isSymmetric.pow {T : E →ₗ[𝕜] E} (hT : T.IsSymmetric) (n : ℕ) : (T ^ n).IsSymmetric := by
-  refine Nat.le_induction (pow_zero T ▸ one_eq_id (R := 𝕜) (M := E) ▸ isSymmetric_id)
-    (fun k _ ih ↦ ?_) n (Nat.zero_le _)
+lemma IsSymmetric.pow {T : E →ₗ[𝕜] E} (hT : T.IsSymmetric) (n : ℕ) : (T ^ n).IsSymmetric := by
+  refine Nat.le_induction (by simp [one_eq_id]) (fun k _ ih ↦ ?_) n n.zero_le
   rw [iterate_succ, ← mul_eq_comp]
-  exact isSymmetric.mul_of_comm hT ih <| _root_.id <| Commute.symm <| Commute.pow_right rfl _
+  exact ih.mul_of_commute hT <| .pow_left rfl k
 
 /-- For a symmetric operator `T`, the function `fun x ↦ ⟪T x, x⟫` is real-valued. -/
 @[simp]

--- a/Mathlib/Analysis/InnerProductSpace/Symmetric.lean
+++ b/Mathlib/Analysis/InnerProductSpace/Symmetric.lean
@@ -102,10 +102,6 @@ theorem isSymmetric.smul {T : E →ₗ[𝕜] E} (hT : T.IsSymmetric) {c : 𝕜} 
   simp only [smul_apply, inner_smul_left, hc, hT x y, inner_smul_right]
 
 @[aesop safe apply]
-theorem IsSymmetric.smul {T : E →ₗ[𝕜] E} (hT : T.IsSymmetric) {c : ℝ} :
-    (RCLike.ofReal (K := 𝕜) c) • T |>.IsSymmetric := by aesop
-
-@[aesop safe apply]
 lemma isSymmetric.mul_of_comm {T S : E →ₗ[𝕜] E} (hT : T.IsSymmetric) (hS : S.IsSymmetric)
     (hST : Commute S T) : (S * T).IsSymmetric := by
   refine fun x y ↦ ?_

--- a/Mathlib/Analysis/InnerProductSpace/Symmetric.lean
+++ b/Mathlib/Analysis/InnerProductSpace/Symmetric.lean
@@ -96,10 +96,14 @@ theorem isSymmetric.sub {T S : E →ₗ[𝕜] E} (hT : T.IsSymmetric) (hS : S.Is
   rfl
 
 @[aesop safe apply]
-theorem isSymmetric.smul {T : E →ₗ[𝕜] E} (hT : T.IsSymmetric) (c : ℝ) :
-    (RCLike.ofReal (K := 𝕜) c) • T |>.IsSymmetric := by
+theorem isSymmetric.smul {T : E →ₗ[𝕜] E} (hT : T.IsSymmetric) {c : 𝕜} (hc : conj c = c) :
+    c • T |>.IsSymmetric := by
   intro x y
-  simp only [smul_apply, inner_smul_left, conj_ofReal, hT x y, inner_smul_right]
+  simp only [smul_apply, inner_smul_left, hc, hT x y, inner_smul_right]
+
+@[aesop safe apply]
+theorem IsSymmetric.smul {T : E →ₗ[𝕜] E} (hT : T.IsSymmetric) {c : ℝ} :
+    (RCLike.ofReal (K := 𝕜) c) • T |>.IsSymmetric := by aesop
 
 @[aesop safe apply]
 lemma isSymmetric.mul_of_comm {T S : E →ₗ[𝕜] E} (hT : T.IsSymmetric) (hS : S.IsSymmetric)

--- a/Mathlib/Analysis/InnerProductSpace/Symmetric.lean
+++ b/Mathlib/Analysis/InnerProductSpace/Symmetric.lean
@@ -75,11 +75,15 @@ theorem IsSymmetric.apply_clm {T : E →L[𝕜] E} (hT : IsSymmetric (T : E →�
   hT x y
 
 @[simp]
-theorem isSymmetric.zero : (0 : E →ₗ[𝕜] E).IsSymmetric := fun x y =>
+protected theorem IsSymmetric.zero : (0 : E →ₗ[𝕜] E).IsSymmetric := fun x y =>
   (inner_zero_right x : ⟪x, 0⟫ = 0).symm ▸ (inner_zero_left y : ⟪0, y⟫ = 0)
 
+@[deprecated (since := "2024-09-30")] alias isSymmetric_zero := IsSymmetric.zero
+
 @[simp]
-theorem isSymmetric.id : (LinearMap.id : E →ₗ[𝕜] E).IsSymmetric := fun _ _ => rfl
+protected theorem IsSymmetric.id : (LinearMap.id : E →ₗ[𝕜] E).IsSymmetric := fun _ _ => rfl
+
+@[deprecated (since := "2024-09-30")] alias isSymmetric_id := IsSymmetric.id
 
 @[aesop safe apply]
 theorem IsSymmetric.add {T S : E →ₗ[𝕜] E} (hT : T.IsSymmetric) (hS : S.IsSymmetric) :

--- a/Mathlib/Analysis/InnerProductSpace/Symmetric.lean
+++ b/Mathlib/Analysis/InnerProductSpace/Symmetric.lean
@@ -74,17 +74,34 @@ theorem IsSymmetric.apply_clm {T : E →L[𝕜] E} (hT : IsSymmetric (T : E →�
     ⟪T x, y⟫ = ⟪x, T y⟫ :=
   hT x y
 
+@[aesop safe apply]
 theorem isSymmetric_zero : (0 : E →ₗ[𝕜] E).IsSymmetric := fun x y =>
   (inner_zero_right x : ⟪x, 0⟫ = 0).symm ▸ (inner_zero_left y : ⟪0, y⟫ = 0)
 
+@[aesop safe apply]
 theorem isSymmetric_id : (LinearMap.id : E →ₗ[𝕜] E).IsSymmetric := fun _ _ => rfl
 
+@[aesop safe apply]
 theorem IsSymmetric.add {T S : E →ₗ[𝕜] E} (hT : T.IsSymmetric) (hS : S.IsSymmetric) :
     (T + S).IsSymmetric := by
   intro x y
   rw [LinearMap.add_apply, inner_add_left, hT x y, hS x y, ← inner_add_right]
   rfl
 
+@[aesop safe apply]
+theorem IsSymmetric.sub {T S : E →ₗ[𝕜] E} (hT : T.IsSymmetric) (hS : S.IsSymmetric) :
+    (T - S).IsSymmetric := by
+  intro x y
+  rw [LinearMap.sub_apply, inner_sub_left, hT x y, hS x y, ← inner_sub_right]
+  rfl
+
+@[aesop safe apply]
+theorem IsSymmetric.smul {T : E →ₗ[𝕜] E} (hT : T.IsSymmetric) {c : ℝ} :
+    (RCLike.ofReal (K := 𝕜) c) • T |>.IsSymmetric := by
+  intro x y
+  simp only [smul_apply, inner_smul_left, conj_ofReal, hT x y, inner_smul_right]
+
+@[aesop safe apply]
 lemma IsSymmetric.mul_of_comm {T S : E →ₗ[𝕜] E} (hT : T.IsSymmetric) (hS : S.IsSymmetric)
     (hST : Commute S T) : (S * T).IsSymmetric := by
   refine fun x y ↦ ?_
@@ -92,6 +109,7 @@ lemma IsSymmetric.mul_of_comm {T S : E →ₗ[𝕜] E} (hT : T.IsSymmetric) (hS 
   simp only [mul_apply]
   rw [← hS, hT]
 
+@[aesop safe apply]
 lemma IsSymmetric.pow {T : E →ₗ[𝕜] E} (hT : T.IsSymmetric) (n : ℕ) : (T ^ n).IsSymmetric := by
   refine Nat.le_induction (pow_zero T ▸ one_eq_id (R := 𝕜) (M := E) ▸ isSymmetric_id)
     (fun k _ ih ↦ ?_) n (Nat.zero_le _)

--- a/Mathlib/Analysis/InnerProductSpace/Symmetric.lean
+++ b/Mathlib/Analysis/InnerProductSpace/Symmetric.lean
@@ -96,7 +96,7 @@ theorem isSymmetric.sub {T S : E →ₗ[𝕜] E} (hT : T.IsSymmetric) (hS : S.Is
   rfl
 
 @[aesop safe apply]
-theorem isSymmetric.smul {T : E →ₗ[𝕜] E} (hT : T.IsSymmetric) {c : ℝ} :
+theorem isSymmetric.smul {T : E →ₗ[𝕜] E} (hT : T.IsSymmetric) (c : ℝ) :
     (RCLike.ofReal (K := 𝕜) c) • T |>.IsSymmetric := by
   intro x y
   simp only [smul_apply, inner_smul_left, conj_ofReal, hT x y, inner_smul_right]

--- a/Mathlib/Analysis/InnerProductSpace/Symmetric.lean
+++ b/Mathlib/Analysis/InnerProductSpace/Symmetric.lean
@@ -85,6 +85,19 @@ theorem IsSymmetric.add {T S : E →ₗ[𝕜] E} (hT : T.IsSymmetric) (hS : S.Is
   rw [LinearMap.add_apply, inner_add_left, hT x y, hS x y, ← inner_add_right]
   rfl
 
+lemma IsSymmetric.mul_of_comm {T S : E →ₗ[𝕜] E} (hT : T.IsSymmetric) (hS : S.IsSymmetric)
+    (hST : Commute S T) : (S * T).IsSymmetric := by
+  refine fun x y ↦ ?_
+  nth_rw 1 [hST]
+  simp only [mul_apply]
+  rw [← hS, hT]
+
+lemma IsSymmetric.pow {T : E →ₗ[𝕜] E} (hT : T.IsSymmetric) (n : ℕ) : (T ^ n).IsSymmetric := by
+  refine Nat.le_induction (pow_zero T ▸ one_eq_id (R := 𝕜) (M := E) ▸ isSymmetric_id)
+    (fun k _ ih ↦ ?_) n (Nat.zero_le _)
+  rw [iterate_succ, ← mul_eq_comp]
+  exact IsSymmetric.mul_of_comm hT ih <| _root_.id <| Commute.symm <| Commute.pow_right rfl _
+
 /-- For a symmetric operator `T`, the function `fun x ↦ ⟪T x, x⟫` is real-valued. -/
 @[simp]
 theorem IsSymmetric.coe_reApplyInnerSelf_apply {T : E →L[𝕜] E} (hT : IsSymmetric (T : E →ₗ[𝕜] E))


### PR DESCRIPTION
Added `@[aesop safe apply]` to `isSymmetric_zero, isSymmetric_id, IsSymmetric.add`, as well as to the following newly added theorems:
`isSymmetric.sub`, `isSymmetric.smul`, `isSymmetric.mul_of_comm`, `isSymmetric.pow`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
