### PR TITLE
[Merged by Bors] - feat: UniqueFactorizationMonoid.factors_rel_of_associated

### DIFF
--- a/Mathlib/RingTheory/Radical.lean
+++ b/Mathlib/RingTheory/Radical.lean
@@ -46,10 +46,10 @@ variable {M : Type*} [CancelCommMonoidWithZero M] [NormalizationMonoid M]
 def primeFactors (a : M) : Finset M :=
   (normalizedFactors a).toFinset
 
-theorem primeFactors_eq_of_associated {a b : M} (h : Associated a b) :
+theorem _root_.Associated.primeFactors_eq {a b : M} (h : Associated a b) :
     primeFactors a = primeFactors b := by
   unfold primeFactors
-  rw [normalizedFactors_eq_of_associated h]
+  rw [h.normalizedFactors_eq]
 
 
 /--
@@ -69,7 +69,7 @@ theorem radical_one_eq : radical (1 : M) = 1 := by
 
 theorem radical_eq_of_associated {a b : M} (h : Associated a b) : radical a = radical b := by
   unfold radical
-  rw [primeFactors_eq_of_associated h]
+  rw [h.primeFactors_eq]
 
 theorem radical_unit_eq_one {a : M} (h : IsUnit a) : radical a = 1 :=
   (radical_eq_of_associated (associated_one_iff_isUnit.mpr h)).trans radical_one_eq

--- a/Mathlib/RingTheory/Radical.lean
+++ b/Mathlib/RingTheory/Radical.lean
@@ -46,6 +46,12 @@ variable {M : Type*} [CancelCommMonoidWithZero M] [NormalizationMonoid M]
 def primeFactors (a : M) : Finset M :=
   (normalizedFactors a).toFinset
 
+theorem primeFactors_eq_of_associated {a b : M} (h : Associated a b) :
+    primeFactors a = primeFactors b := by
+  unfold primeFactors
+  rw [normalizedFactors_eq_of_associated h]
+
+
 /--
 Radical of an element `a` in a unique factorization monoid is the product of
 the prime factors of `a`.
@@ -62,10 +68,8 @@ theorem radical_one_eq : radical (1 : M) = 1 := by
   rw [radical, primeFactors, normalizedFactors_one, Multiset.toFinset_zero, Finset.prod_empty]
 
 theorem radical_eq_of_associated {a b : M} (h : Associated a b) : radical a = radical b := by
-  rcases iff_iff_and_or_not_and_not.mp h.eq_zero_iff with (⟨rfl, rfl⟩ | ⟨ha, hb⟩)
-  · rfl
-  · simp_rw [radical, primeFactors]
-    rw [(associated_iff_normalizedFactors_eq_normalizedFactors ha hb).mp h]
+  unfold radical
+  rw [primeFactors_eq_of_associated h]
 
 theorem radical_unit_eq_one {a : M} (h : IsUnit a) : radical a = 1 :=
   (radical_eq_of_associated (associated_one_iff_isUnit.mpr h)).trans radical_one_eq

--- a/Mathlib/RingTheory/UniqueFactorizationDomain.lean
+++ b/Mathlib/RingTheory/UniqueFactorizationDomain.lean
@@ -729,7 +729,7 @@ theorem dvd_iff_normalizedFactors_le_normalizedFactors {x y : α} (hx : x ≠ 0)
       (normalizedFactors_prod hy).dvd_iff_dvd_right]
     apply Multiset.prod_dvd_prod_of_le
 
-theorem normalizedFactors_eq_of_associated {a b : α} (h : Associated a b) :
+theorem _root_.Associated.normalizedFactors_eq {a b : α} (h : Associated a b) :
     normalizedFactors a = normalizedFactors b := by
   unfold normalizedFactors
   have h2 : ⇑(normalize (α := α)) = Associates.out ∘ Associates.mk := funext Associates.out_mk
@@ -738,7 +738,7 @@ theorem normalizedFactors_eq_of_associated {a b : α} (h : Associated a b) :
 
 theorem associated_iff_normalizedFactors_eq_normalizedFactors {x y : α} (hx : x ≠ 0) (hy : y ≠ 0) :
     x ~ᵤ y ↔ normalizedFactors x = normalizedFactors y :=
-  ⟨normalizedFactors_eq_of_associated, fun h =>
+  ⟨Associated.normalizedFactors_eq, fun h =>
     (normalizedFactors_prod hx).symm.trans (_root_.trans (by rw [h]) (normalizedFactors_prod hy))⟩
 
 theorem normalizedFactors_of_irreducible_pow {p : α} (hp : Irreducible p) (k : ℕ) :

--- a/Mathlib/RingTheory/UniqueFactorizationDomain.lean
+++ b/Mathlib/RingTheory/UniqueFactorizationDomain.lean
@@ -732,8 +732,8 @@ theorem dvd_iff_normalizedFactors_le_normalizedFactors {x y : α} (hx : x ≠ 0)
 theorem _root_.Associated.normalizedFactors_eq {a b : α} (h : Associated a b) :
     normalizedFactors a = normalizedFactors b := by
   unfold normalizedFactors
-  have h2 : ⇑(normalize (α := α)) = Associates.out ∘ Associates.mk := funext Associates.out_mk
-  rw [h2, ← Multiset.map_map, ← Multiset.map_map,
+  have h' : ⇑(normalize (α := α)) = Associates.out ∘ Associates.mk := funext Associates.out_mk
+  rw [h', ← Multiset.map_map, ← Multiset.map_map,
     Associates.rel_associated_iff_map_eq_map.mp (factors_rel_of_associated h)]
 
 theorem associated_iff_normalizedFactors_eq_normalizedFactors {x y : α} (hx : x ≠ 0) (hy : y ≠ 0) :

--- a/Mathlib/RingTheory/UniqueFactorizationDomain.lean
+++ b/Mathlib/RingTheory/UniqueFactorizationDomain.lean
@@ -555,6 +555,13 @@ theorem factors_pow_count_prod [DecidableEq α] {x : α} (hx : x ≠ 0) :
   _ = prod (factors x) := by rw [toFinset_sum_count_nsmul_eq (factors x)]
   _ ~ᵤ x := factors_prod hx
 
+theorem factors_rel_of_associated {a b : α} (h : Associated a b) :
+    Multiset.Rel Associated (factors a) (factors b) := by
+  rcases iff_iff_and_or_not_and_not.mp h.eq_zero_iff with (⟨rfl, rfl⟩ | ⟨ha, hb⟩)
+  · simp
+  · refine factors_unique irreducible_of_factor irreducible_of_factor ?_
+    exact ((factors_prod ha).trans h).trans (factors_prod hb).symm
+
 end UniqueFactorizationMonoid
 
 namespace UniqueFactorizationMonoid
@@ -722,13 +729,17 @@ theorem dvd_iff_normalizedFactors_le_normalizedFactors {x y : α} (hx : x ≠ 0)
       (normalizedFactors_prod hy).dvd_iff_dvd_right]
     apply Multiset.prod_dvd_prod_of_le
 
+theorem normalizedFactors_eq_of_associated {a b : α} (h : Associated a b) :
+    normalizedFactors a = normalizedFactors b := by
+  unfold normalizedFactors
+  have h2 : ⇑(normalize (α := α)) = Associates.out ∘ Associates.mk := funext Associates.out_mk
+  rw [h2, ← Multiset.map_map, ← Multiset.map_map,
+    Associates.rel_associated_iff_map_eq_map.mp (factors_rel_of_associated h)]
+
 theorem associated_iff_normalizedFactors_eq_normalizedFactors {x y : α} (hx : x ≠ 0) (hy : y ≠ 0) :
-    x ~ᵤ y ↔ normalizedFactors x = normalizedFactors y := by
-  refine
-    ⟨fun h => ?_, fun h =>
-      (normalizedFactors_prod hx).symm.trans (_root_.trans (by rw [h]) (normalizedFactors_prod hy))⟩
-  apply le_antisymm <;> rw [← dvd_iff_normalizedFactors_le_normalizedFactors]
-  all_goals simp [*, h.dvd, h.symm.dvd]
+    x ~ᵤ y ↔ normalizedFactors x = normalizedFactors y :=
+  ⟨normalizedFactors_eq_of_associated, fun h =>
+    (normalizedFactors_prod hx).symm.trans (_root_.trans (by rw [h]) (normalizedFactors_prod hy))⟩
 
 theorem normalizedFactors_of_irreducible_pow {p : α} (hp : Irreducible p) (k : ℕ) :
     normalizedFactors (p ^ k) = Multiset.replicate k (normalize p) := by


### PR DESCRIPTION
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
