### PR TITLE
[Merged by Bors] - feat (Analysis/Normed/Group): ultrametric normed groups are nonarchimedean

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -4719,6 +4719,7 @@ import Mathlib.Topology.MetricSpace.ShrinkingLemma
 import Mathlib.Topology.MetricSpace.ThickenedIndicator
 import Mathlib.Topology.MetricSpace.Thickening
 import Mathlib.Topology.MetricSpace.Ultra.Basic
+import Mathlib.Topology.MetricSpace.Ultra.ContinuousMaps
 import Mathlib.Topology.MetricSpace.Ultra.TotallyDisconnected
 import Mathlib.Topology.Metrizable.Basic
 import Mathlib.Topology.Metrizable.ContinuousMap

--- a/Mathlib/Analysis/Normed/Group/Ultra.lean
+++ b/Mathlib/Analysis/Normed/Group/Ultra.lean
@@ -1,9 +1,10 @@
 /-
 Copyright (c) 2024 Yakov Pechersky. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Yakov Pechersky
+Authors: Yakov Pechersky, David Loeffler
 -/
-import Mathlib.Analysis.Normed.Group.Basic
+import Mathlib.Analysis.Normed.Group.Uniform
+import Mathlib.Topology.Algebra.Nonarchimedean.Basic
 import Mathlib.Topology.MetricSpace.Ultra.Basic
 
 /-!
@@ -15,6 +16,9 @@ This file contains results on the behavior of norms in ultrametric groups.
 
 * `IsUltrametricDist.isUltrametricDist_of_isNonarchimedean_norm`:
   a normed additive group has an ultrametric iff the norm is nonarchimedean
+* `IsUltrametricDist.nonarchimedeanGroup` and its additive version: instance showing that a
+  commutative group with a nonarchimedean seminorm is a nonarchimedean topological group (i.e.
+  there is a neighbourhood basis of the identity consisting of open subgroups).
 
 ## Implementation details
 
@@ -123,11 +127,52 @@ lemma norm_zpow_le (x : S) (z : ℤ) :
     ‖x ^ z‖ ≤ ‖x‖ :=
   nnnorm_zpow_le x z
 
+section nonarch
+
+variable (S)
+/--
+In an group with an ultrametric norm, open balls around 1 of positive radius are open subgroups.
+-/
+@[to_additive "In an additive group with an ultrametric norm, open balls around 0 of
+positive radius are open subgroups."]
+def ball_openSubgroup {r : ℝ} (hr : 0 < r) : OpenSubgroup S where
+  carrier := Metric.ball (1 : S) r
+  mul_mem' {x} {y} hx hy := by
+    simp only [Metric.mem_ball, dist_eq_norm_div, div_one] at hx hy ⊢
+    exact (norm_mul_le_max x y).trans_lt (max_lt hx hy)
+  one_mem' := Metric.mem_ball_self hr
+  inv_mem' := by simp only [Metric.mem_ball, dist_one_right, norm_inv', imp_self, implies_true]
+  isOpen' := Metric.isOpen_ball
+
+/--
+In a group with an ultrametric norm, closed balls around 1 of positive radius are open subgroups.
+-/
+@[to_additive "In an additive group with an ultrametric norm, closed balls around 0 of positive
+radius are open subgroups."]
+def closedBall_openSubgroup {r : ℝ} (hr : 0 < r) : OpenSubgroup S where
+  carrier := Metric.closedBall (1 : S) r
+  mul_mem' {x} {y} hx hy := by
+    simp only [Metric.mem_closedBall, dist_eq_norm_div, div_one] at hx hy ⊢
+    exact (norm_mul_le_max x y).trans (max_le hx hy)
+  one_mem' := Metric.mem_closedBall_self hr.le
+  inv_mem' := by simp only [mem_closedBall, dist_one_right, norm_inv', imp_self, implies_true]
+  isOpen' := IsUltrametricDist.isOpen_closedBall _ hr.ne'
+
+end nonarch
+
 end Group
 
 section CommGroup
 
 variable {M ι : Type*} [SeminormedCommGroup M] [IsUltrametricDist M]
+
+/-- A commutative group with an ultrametric group seminorm is nonarchimedean (as a topological
+group, i.e. every neighborhood of 1 contains an open subgroup). -/
+@[to_additive "A commutative additive group with an ultrametric group seminorm is nonarchimedean
+(as a topological group, i.e. every neighborhood of 0 contains an open subgroup)."]
+instance nonarchimedeanGroup : NonarchimedeanGroup M where
+  is_nonarchimedean := by simpa only [Metric.mem_nhds_iff]
+    using fun U ⟨ε, hεp, hεU⟩ ↦ ⟨ball_openSubgroup M hεp, hεU⟩
 
 /-- Nonarchimedean norm of a product is less than or equal the norm of any term in the product.
 This version is phrased using `Finset.sup'` and `Finset.Nonempty` due to `Finset.sup`

--- a/Mathlib/Analysis/Normed/Group/Ultra.lean
+++ b/Mathlib/Analysis/Normed/Group/Ultra.lean
@@ -131,7 +131,7 @@ section nonarch
 
 variable (S)
 /--
-In an group with an ultrametric norm, open balls around 1 of positive radius are open subgroups.
+In a group with an ultrametric norm, open balls around 1 of positive radius are open subgroups.
 -/
 @[to_additive "In an additive group with an ultrametric norm, open balls around 0 of
 positive radius are open subgroups."]

--- a/Mathlib/Topology/MetricSpace/Ultra/ContinuousMaps.lean
+++ b/Mathlib/Topology/MetricSpace/Ultra/ContinuousMaps.lean
@@ -1,0 +1,22 @@
+/-
+Copyright (c) 2024 David Loeffler. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: David Loeffler
+-/
+
+import Mathlib.Topology.ContinuousMap.Compact
+import Mathlib.Topology.MetricSpace.Ultra.Basic
+
+/-!
+# Ultrametric structure on continuous maps
+-/
+
+/-- Continuous maps from a compact space to an ultrametric space are an ultrametric space. -/
+instance ContinuousMap.isUltrametricDist {X Y : Type*}
+    [TopologicalSpace X] [CompactSpace X] [MetricSpace Y] [IsUltrametricDist Y] :
+    IsUltrametricDist C(X, Y) := by
+  constructor
+  intro f g h
+  rw [ContinuousMap.dist_le (by positivity)]
+  refine fun x ↦ (dist_triangle_max (f x) (g x) (h x)).trans (max_le_max ?_ ?_) <;>
+  exact ContinuousMap.dist_apply_le_dist x


### PR DESCRIPTION
This PR proves that normed groups with a norm satisfying `IsUltrametricDist` are nonarchimedean topological groups, and also that continuous maps from a compact space to an ultrametric space are an ultrametric space.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]

-->

- [x] depends on: #14768
[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
