### PR TITLE
[Merged by Bors] - feat(AlgebraicGeometry): add `resLE`

### DIFF
--- a/Mathlib/AlgebraicGeometry/OpenImmersion.lean
+++ b/Mathlib/AlgebraicGeometry/OpenImmersion.lean
@@ -105,6 +105,12 @@ lemma preimage_image_eq (U : X.Opens) : f ⁻¹ᵁ f ''ᵁ U = U := by
   apply Opens.ext
   simp [Set.preimage_image_eq _ f.openEmbedding.inj]
 
+lemma image_le_image_iff (f : X ⟶ Y) [IsOpenImmersion f] (U U' : X.Opens) :
+    f ''ᵁ U ≤ f ''ᵁ U' ↔ U ≤ U' := by
+  refine ⟨fun h ↦ ?_, image_le_image_of_le f⟩
+  rw [← preimage_image_eq f U, ← preimage_image_eq f U']
+  apply preimage_le_preimage_of_le f h
+
 lemma image_preimage_eq_opensRange_inter (U : Y.Opens) : f ''ᵁ f ⁻¹ᵁ U = f.opensRange ⊓ U := by
   apply Opens.ext
   simp [Set.image_preimage_eq_range_inter]

--- a/Mathlib/AlgebraicGeometry/Restrict.lean
+++ b/Mathlib/AlgebraicGeometry/Restrict.lean
@@ -574,9 +574,9 @@ lemma le_preimage_resLE_iff {U : Y.Opens} {V : X.Opens} (e : V ≤ f ⁻¹ᵁ U)
   simp [resLE_preimage, ← image_le_image_iff V.ι, image_preimage_eq_opensRange_inter, V.ι_image_le]
 
 lemma resLE_appLE {U : Y.Opens} {V : X.Opens} (e : V ≤ f ⁻¹ᵁ U)
-    (O : U.toScheme.Opens) (W : V.toScheme.Opens) (e' : V.ι ''ᵁ W ≤ f ⁻¹ᵁ U.ι ''ᵁ O) :
-    (f.resLE U V e).appLE O W ((le_preimage_resLE_iff f e O W).mpr e') =
-      f.appLE (U.ι ''ᵁ O) (V.ι ''ᵁ W) e' := by
+    (O : U.toScheme.Opens) (W : V.toScheme.Opens) (e' : W ≤ resLE f U V e ⁻¹ᵁ O) :
+    (f.resLE U V e).appLE O W e' =
+      f.appLE (U.ι ''ᵁ O) (V.ι ''ᵁ W) ((le_preimage_resLE_iff f e O W).mp e') := by
   simp only [Scheme.Hom.appLE, Scheme.Hom.resLE, Scheme.restrictFunctor_map_left, Opens.map_coe,
     id_eq, Scheme.comp_app, morphismRestrict_app', Category.assoc, IsOpenImmersion.lift_app,
     Scheme.Opens.ι_appIso, Scheme.Opens.ι_app, Scheme.Opens.toScheme_presheaf_map, Category.assoc]
@@ -594,7 +594,6 @@ noncomputable def arrowResLEAppIso (f : X ⟶ Y) (U : Y.Opens) (V : X.Opens) (e 
   simp only [Opens.map_top, Arrow.mk_left, Arrow.mk_right, Functor.id_obj, Scheme.Opens.topIso_hom,
     eqToHom_op, Arrow.mk_hom, Scheme.Hom.map_appLE]
   rw [← Scheme.Hom.appLE_eq_app, Scheme.Hom.resLE_appLE, Scheme.Hom.appLE_map]
-  simpa
 
 end MorphismRestrict
 

--- a/Mathlib/AlgebraicGeometry/Restrict.lean
+++ b/Mathlib/AlgebraicGeometry/Restrict.lean
@@ -528,6 +528,10 @@ variable (f : X ⟶ Y) {U U' : Y.Opens} {V V' : X.Opens} (e : V ≤ f ⁻¹ᵁ U
 lemma resLE_eq_morphismRestrict : f.resLE U (f ⁻¹ᵁ U) le_rfl = f ∣_ U := by
   simp [Scheme.Hom.resLE]
 
+@[simp]
+lemma resLE_comp_ι : f.resLE U V e ≫ U.ι = V.ι ≫ f := by
+  simp [resLE, restrictFunctor_map_ofRestrict_assoc]
+
 @[reassoc (attr := simp)]
 lemma map_resLE (i : V' ⟶ V) :
     (X.restrictFunctor.map i).left ≫ f.resLE U V e = f.resLE U V' (i.le.trans e) := by

--- a/Mathlib/AlgebraicGeometry/Restrict.lean
+++ b/Mathlib/AlgebraicGeometry/Restrict.lean
@@ -216,7 +216,7 @@ def Scheme.restrictFunctor : X.Opens ⥤ Over X where
 @[simp] lemma Scheme.restrictFunctor_obj_hom (U : X.Opens) :
   (X.restrictFunctor.obj U).hom = U.ι := rfl
 
-@[simp] lemma Scheme.restrictFunctor_map_left {U V : X.Opens} (i : U ⟶ V) :
+lemma Scheme.restrictFunctor_map_left {U V : X.Opens} (i : U ⟶ V) :
   (X.restrictFunctor.map i).left = IsOpenImmersion.lift (V.ι) U.ι (by simpa using i.le) := rfl
 
 -- Porting note: the `by ...` used to be automatically done by unification magic
@@ -258,7 +258,7 @@ def Scheme.restrictFunctorΓ : X.restrictFunctor.op ⋙ (Over.forget X).op ⋙ S
     (fun U => X.presheaf.mapIso ((eqToIso (unop U).openEmbedding_obj_top).symm.op : _))
     (by
       intro U V i
-      dsimp [-Scheme.restrictFunctor_map_left]
+      dsimp
       rw [X.restrictFunctor_map_app, ← Functor.map_comp, ← Functor.map_comp]
       congr 1)
 
@@ -514,6 +514,65 @@ instance {X Y : Scheme.{u}} (f : X ⟶ Y) (U : Y.Opens) [IsOpenImmersion f] :
     IsOpenImmersion (f ∣_ U) := by
   delta morphismRestrict
   exact PresheafedSpace.IsOpenImmersion.comp _ _
+
+variable {X Y : Scheme.{u}}
+
+/-- The restriction of a morphism `f : X ⟶ Y` to open sets on the source and target. -/
+def Scheme.Hom.resLE {X Y : Scheme.{u}} (f : Hom X Y) (U : Y.Opens) (V : X.Opens)
+    (e : V ≤ f ⁻¹ᵁ U) : V.toScheme ⟶ U.toScheme :=
+  (X.restrictFunctor.map (homOfLE e)).left ≫ f ∣_ U
+
+namespace Scheme.Hom
+
+variable (f : X ⟶ Y) {U U' : Y.Opens} {V V' : X.Opens} (e : V ≤ f ⁻¹ᵁ U)
+
+lemma resLE_eq_morphismRestrict : f.resLE U (f ⁻¹ᵁ U) le_rfl = f ∣_ U := by
+  simp [Scheme.Hom.resLE]
+
+@[reassoc (attr := simp)]
+lemma map_resLE (i : V' ⟶ V) :
+    (X.restrictFunctor.map i).left ≫ f.resLE U V e = f.resLE U V' (i.le.trans e) := by
+  simp only [Scheme.Hom.resLE, homOfLE_leOfHom, ← Over.comp_left_assoc, ← Functor.map_comp]
+  rfl
+
+/-- Variant of `map_resLE` for equality. -/
+@[reassoc]
+lemma map_resLE' (i : V' = V) :
+    (X.restrictFunctor.map (eqToHom i)).left ≫ f.resLE U V e = f.resLE U V' (i ▸ e) :=
+  map_resLE _ _ _
+
+@[reassoc (attr := simp)]
+lemma resLE_map (i : U ⟶ U') :
+    f.resLE U V e ≫ (Y.restrictFunctor.map i).left =
+      f.resLE U' V (e.trans ((Opens.map f.1.base).map i).le) := by
+  rw [← cancel_mono U'.ι]
+  simp [Scheme.Hom.resLE, Scheme.restrictFunctor_map_left, IsOpenImmersion.lift_fac_assoc]
+
+/-- Variant of `resLE_map` for equality. -/
+@[reassoc]
+lemma resLE_map' (i : U = U') :
+    f.resLE U V e ≫ (Y.restrictFunctor.map (eqToHom i)).left =
+      f.resLE U' V (i ▸ e) :=
+  resLE_map _ _ _
+
+lemma resLE_congr (e₁ : U = U') (e₂ : V = V') (P : MorphismProperty Scheme.{u}) :
+    P (f.resLE U V e) ↔ P (f.resLE U' V' (e₁ ▸ e₂ ▸ e)) := by
+  subst e₁; subst e₂; rfl
+
+end Scheme.Hom
+
+/-- `f.resLE U V` induces `f.appLE U V` on global sections. -/
+noncomputable def arrowResLEAppIso (f : X ⟶ Y) (U : Y.Opens) (V : X.Opens) (e : V ≤ f ⁻¹ᵁ U) :
+    Arrow.mk ((f.resLE U V e).app ⊤) ≅ Arrow.mk (f.appLE U V e) :=
+  Arrow.isoMk U.topIso V.topIso <| by
+  simp only [Scheme.Hom.resLE, homOfLE_leOfHom, Scheme.restrictFunctor_map_left,
+    Scheme.comp_app, Arrow.mk_left, Arrow.mk_right,
+    Scheme.Opens.topIso_hom, Arrow.mk_hom, Scheme.Hom.map_appLE, morphismRestrict_app',
+    IsOpenImmersion.lift_app, Scheme.Opens.ι_appIso, Scheme.Opens.ι_app,
+    Scheme.Opens.toScheme_presheaf_map, Category.assoc, ← X.presheaf.map_comp]
+  erw [Category.id_comp]
+  simp only [Scheme.Hom.appLE, Category.assoc, ← X.presheaf.map_comp]
+  rfl
 
 end MorphismRestrict
 

--- a/Mathlib/AlgebraicGeometry/Restrict.lean
+++ b/Mathlib/AlgebraicGeometry/Restrict.lean
@@ -517,12 +517,11 @@ instance {X Y : Scheme.{u}} (f : X ⟶ Y) (U : Y.Opens) [IsOpenImmersion f] :
 
 variable {X Y : Scheme.{u}}
 
-/-- The restriction of a morphism `f : X ⟶ Y` to open sets on the source and target. -/
-def Scheme.Hom.resLE {X Y : Scheme.{u}} (f : Hom X Y) (U : Y.Opens) (V : X.Opens)
-    (e : V ≤ f ⁻¹ᵁ U) : V.toScheme ⟶ U.toScheme :=
-  (X.restrictFunctor.map (homOfLE e)).left ≫ f ∣_ U
-
 namespace Scheme.Hom
+
+/-- The restriction of a morphism `f : X ⟶ Y` to open sets on the source and target. -/
+def resLE (f : Hom X Y) (U : Y.Opens) (V : X.Opens) (e : V ≤ f ⁻¹ᵁ U) : V.toScheme ⟶ U.toScheme :=
+  (X.restrictFunctor.map (homOfLE e)).left ≫ f ∣_ U
 
 variable (f : X ⟶ Y) {U U' : Y.Opens} {V V' : X.Opens} (e : V ≤ f ⁻¹ᵁ U)
 

--- a/Mathlib/AlgebraicGeometry/Restrict.lean
+++ b/Mathlib/AlgebraicGeometry/Restrict.lean
@@ -217,7 +217,7 @@ def Scheme.restrictFunctor : X.Opens ⥤ Over X where
   (X.restrictFunctor.obj U).hom = U.ι := rfl
 
 lemma Scheme.restrictFunctor_map_left {U V : X.Opens} (i : U ⟶ V) :
-  (X.restrictFunctor.map i).left = IsOpenImmersion.lift (V.ι) U.ι (by simpa using i.le) := rfl
+    (X.restrictFunctor.map i).left = IsOpenImmersion.lift (V.ι) U.ι (by simpa using i.le) := rfl
 
 -- Porting note: the `by ...` used to be automatically done by unification magic
 @[reassoc]

--- a/Mathlib/AlgebraicGeometry/Scheme.lean
+++ b/Mathlib/AlgebraicGeometry/Scheme.lean
@@ -165,6 +165,10 @@ lemma preimage_iSup {ι} (U : ι → Opens Y) : f ⁻¹ᵁ iSup U = ⨆ i, f ⁻
 lemma preimage_iSup_eq_top {ι} {U : ι → Opens Y} (hU : iSup U = ⊤) :
     ⨆ i, f ⁻¹ᵁ U i = ⊤ := f.preimage_iSup U ▸ hU ▸ rfl
 
+lemma preimage_le_preimage_of_le {U U' : Y.Opens} (hUU' : U ≤ U') :
+    f ⁻¹ᵁ U ≤ f ⁻¹ᵁ U' :=
+  fun _ ha ↦ hUU' ha
+
 end Hom
 
 @[simp]

--- a/Mathlib/CategoryTheory/Comma/Over.lean
+++ b/Mathlib/CategoryTheory/Comma/Over.lean
@@ -66,7 +66,7 @@ theorem over_right (U : Over X) : U.right = ⟨⟨⟩⟩ := by simp only
 theorem id_left (U : Over X) : CommaMorphism.left (𝟙 U) = 𝟙 U.left :=
   rfl
 
-@[reassoc (attr := simp)]
+@[simp, reassoc]
 theorem comp_left (a b c : Over X) (f : a ⟶ b) (g : b ⟶ c) : (f ≫ g).left = f.left ≫ g.left :=
   rfl
 

--- a/Mathlib/CategoryTheory/Comma/Over.lean
+++ b/Mathlib/CategoryTheory/Comma/Over.lean
@@ -66,7 +66,7 @@ theorem over_right (U : Over X) : U.right = ⟨⟨⟩⟩ := by simp only
 theorem id_left (U : Over X) : CommaMorphism.left (𝟙 U) = 𝟙 U.left :=
   rfl
 
-@[simp]
+@[reassoc (attr := simp)]
 theorem comp_left (a b c : Over X) (f : a ⟶ b) (g : b ⟶ c) : (f ≫ g).left = f.left ≫ g.left :=
   rfl
 


### PR DESCRIPTION
Adds a shortcut `Scheme.Hom.resLE` for the restriction of a morphism of schemes to opens on the source and the target.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
