### PR TITLE
[Merged by Bors] - feat: `MeasurableSpace` instance for `AddChar`

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -3172,6 +3172,7 @@ import Mathlib.Logic.Small.Set
 import Mathlib.Logic.Unique
 import Mathlib.Logic.UnivLE
 import Mathlib.MeasureTheory.Category.MeasCat
+import Mathlib.MeasureTheory.Constructions.AddChar
 import Mathlib.MeasureTheory.Constructions.BorelSpace.Basic
 import Mathlib.MeasureTheory.Constructions.BorelSpace.Complex
 import Mathlib.MeasureTheory.Constructions.BorelSpace.ContinuousLinearMap

--- a/Mathlib/MeasureTheory/Constructions/AddChar.lean
+++ b/Mathlib/MeasureTheory/Constructions/AddChar.lean
@@ -9,7 +9,7 @@ import Mathlib.MeasureTheory.MeasurableSpace.Defs
 /-!
 # Measurable space instance for additive characters
 
-This file endows `AddChar A M` with the discrete measurable space structure whenever `A` and `M` 
+This file endows `AddChar A M` with the discrete measurable space structure whenever `A` and `M`
 are themselves discrete measurable spaces.
 
 ## TODO

--- a/Mathlib/MeasureTheory/Constructions/AddChar.lean
+++ b/Mathlib/MeasureTheory/Constructions/AddChar.lean
@@ -9,7 +9,8 @@ import Mathlib.MeasureTheory.MeasurableSpace.Defs
 /-!
 # Measurable space instance for additive characters
 
-This file endows `AddChar A M` with the trivial sigma-algebra.
+This file endows `AddChar A M` with the discrete measurable space structure whenever `A` and `M` 
+are themselves discrete measurable spaces.
 
 ## TODO
 

--- a/Mathlib/MeasureTheory/Constructions/AddChar.lean
+++ b/Mathlib/MeasureTheory/Constructions/AddChar.lean
@@ -18,6 +18,7 @@ Give the definition in the correct generality.
 
 namespace AddChar
 variable {A M : Type*} [AddMonoid A] [Monoid M]
+  [MeasurableSpace A] [DiscreteMeasurableSpace A] [MeasurableSpace M] [DiscreteMeasurableSpace M]
 
 instance instMeasurableSpace : MeasurableSpace (AddChar A M) := ⊤
 instance instDiscreteMeasurableSpace : DiscreteMeasurableSpace (AddChar A M) := ⟨fun _ ↦ trivial⟩

--- a/Mathlib/MeasureTheory/Constructions/AddChar.lean
+++ b/Mathlib/MeasureTheory/Constructions/AddChar.lean
@@ -1,0 +1,25 @@
+/-
+Copyright (c) 2024 Yaël Dillies. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Yaël Dillies
+-/
+import Mathlib.Algebra.Group.AddChar
+import Mathlib.MeasureTheory.MeasurableSpace.Defs
+
+/-!
+# Measurable space instance for additive characters
+
+This file endows `AddChar A M` with the trivial sigma-algebra.
+
+## TODO
+
+Give the definition in the correct generality.
+-/
+
+namespace AddChar
+variable {A M : Type*} [AddMonoid A] [Monoid M]
+
+instance instMeasurableSpace : MeasurableSpace (AddChar A M) := ⊤
+instance instDiscreteMeasurableSpace : DiscreteMeasurableSpace (AddChar A M) := ⟨fun _ ↦ trivial⟩
+
+end AddChar


### PR DESCRIPTION
This is stupid, but it's the only case I care about in APAP. Can be made less stupid later.

From LeanAPAP


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
