### PR TITLE
[Merged by Bors] - feat: there are finitely many lists of a fixed length

### DIFF
--- a/Mathlib/Data/Set/Finite.lean
+++ b/Mathlib/Data/Set/Finite.lean
@@ -1574,13 +1574,7 @@ end LinearOrder
 namespace List
 variable (α) [Finite α] (n : ℕ)
 
-lemma finite_length_eq : {l : List α | l.length = n}.Finite := by
-  induction n with
-  | zero => simp [List.length_eq_zero]
-  | succ n ih =>
-    suffices {l : List α | l.length = n + 1} = Set.univ.image2 (· :: ·) {l | l.length = n} by
-      rw [this]; exact Set.finite_univ.image2 _ ih
-    ext (_ | _) <;> simp [n.succ_ne_zero.symm]
+lemma finite_length_eq : {l : List α | l.length = n}.Finite := Vector.finite
 
 lemma finite_length_lt : {l : List α | l.length < n}.Finite := by
   convert (Finset.range n).finite_toSet.biUnion fun i _ ↦ finite_length_eq α i; ext; simp

--- a/Mathlib/Data/Set/Finite.lean
+++ b/Mathlib/Data/Set/Finite.lean
@@ -1086,25 +1086,6 @@ theorem seq_of_forall_finite_exists {γ : Type*} {P : γ → Set γ → Prop}
 
 end
 
-namespace List
-variable (α) [Finite α] (n : ℕ)
-
-lemma finite_length_eq : {l : List α | l.length = n}.Finite := by
-  induction n with
-  | zero => simp [List.length_eq_zero]
-  | succ n ih =>
-    suffices {l : List α | l.length = n + 1} = Set.univ.image2 (· :: ·) {l | l.length = n} by
-      rw [this]; exact Set.finite_univ.image2 _ ih
-    ext (_ | _) <;> simp [n.succ_ne_zero.symm]
-
-lemma finite_length_lt : {l : List α | l.length < n}.Finite := by
-  convert (Finset.range n).finite_toSet.biUnion fun i _ ↦ finite_length_eq α i; ext; simp
-
-lemma finite_length_le : {l : List α | l.length ≤ n}.Finite := by
-  simpa [Nat.lt_succ_iff] using finite_length_lt α (n + 1)
-
-end List
-
 /-! ### Cardinality -/
 
 theorem empty_card : Fintype.card (∅ : Set α) = 0 :=
@@ -1547,6 +1528,7 @@ protected theorem bddBelow [SemilatticeInf α] [Nonempty α] (s : Finset α) : B
 
 end Finset
 
+section LinearOrder
 variable [LinearOrder α] {s : Set α}
 
 /-- If a linear order does not contain any triple of elements `x < y < z`, then this type
@@ -1586,5 +1568,26 @@ theorem DirectedOn.exists_mem_subset_of_finset_subset_biUnion {α ι : Type*} {f
   rw [Set.biUnion_eq_iUnion] at hs
   haveI := hn.coe_sort
   simpa using (directed_comp.2 hc.directed_val).exists_mem_subset_of_finset_subset_biUnion hs
+
+end LinearOrder
+
+namespace List
+variable (α) [Finite α] (n : ℕ)
+
+lemma finite_length_eq : {l : List α | l.length = n}.Finite := by
+  induction n with
+  | zero => simp [List.length_eq_zero]
+  | succ n ih =>
+    suffices {l : List α | l.length = n + 1} = Set.univ.image2 (· :: ·) {l | l.length = n} by
+      rw [this]; exact Set.finite_univ.image2 _ ih
+    ext (_ | _) <;> simp [n.succ_ne_zero.symm]
+
+lemma finite_length_lt : {l : List α | l.length < n}.Finite := by
+  convert (Finset.range n).finite_toSet.biUnion fun i _ ↦ finite_length_eq α i; ext; simp
+
+lemma finite_length_le : {l : List α | l.length ≤ n}.Finite := by
+  simpa [Nat.lt_succ_iff] using finite_length_lt α (n + 1)
+
+end List
 
 set_option linter.style.longFile 1700

--- a/Mathlib/Data/Set/Finite.lean
+++ b/Mathlib/Data/Set/Finite.lean
@@ -1086,6 +1086,25 @@ theorem seq_of_forall_finite_exists {γ : Type*} {P : γ → Set γ → Prop}
 
 end
 
+namespace List
+variable (α) [Finite α] (n : ℕ)
+
+lemma finite_length_eq : {l : List α | l.length = n}.Finite := by
+  induction n with
+  | zero => simp [List.length_eq_zero]
+  | succ n ih =>
+    suffices {l : List α | l.length = n + 1} = Set.univ.image2 (· :: ·) {l | l.length = n} by
+      rw [this]; exact Set.finite_univ.image2 _ ih
+    ext (_ | _) <;> simp [n.succ_ne_zero.symm]
+
+lemma finite_length_lt : {l : List α | l.length < n}.Finite := by
+  convert (Finset.range n).finite_toSet.biUnion fun i _ ↦ finite_length_eq α i; ext; simp
+
+lemma finite_length_le : {l : List α | l.length ≤ n}.Finite := by
+  simpa [Nat.lt_succ_iff] using finite_length_lt α (n + 1)
+
+end List
+
 /-! ### Cardinality -/
 
 theorem empty_card : Fintype.card (∅ : Set α) = 0 :=


### PR DESCRIPTION
From LeanCamCombi


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
