### PR TITLE
[Merged by Bors] - feat(MetricSpace/Ultra): `TotallyDisconnectedSpace X` when X is ultrametric

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -4711,6 +4711,7 @@ import Mathlib.Topology.MetricSpace.ShrinkingLemma
 import Mathlib.Topology.MetricSpace.ThickenedIndicator
 import Mathlib.Topology.MetricSpace.Thickening
 import Mathlib.Topology.MetricSpace.Ultra.Basic
+import Mathlib.Topology.MetricSpace.Ultra.TotallyDisconnected
 import Mathlib.Topology.Metrizable.Basic
 import Mathlib.Topology.Metrizable.ContinuousMap
 import Mathlib.Topology.Metrizable.Uniformity

--- a/Mathlib/Topology/MetricSpace/Ultra/TotallyDisconnected.lean
+++ b/Mathlib/Topology/MetricSpace/Ultra/TotallyDisconnected.lean
@@ -1,0 +1,25 @@
+/-
+Copyright (c) 2024 Yakov Pechersky. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Yakov Pechersky
+-/
+import Mathlib.Topology.MetricSpace.Defs
+import Mathlib.Topology.MetricSpace.Ultra.Basic
+
+/-!
+## Ultrametric spaces are totally disconnected
+
+In a metric space with an ultrametric, the space is totally disconnected.
+
+## Tags
+
+ultrametric, nonarchimedean, totally disconnected
+-/
+open Metric IsUltrametricDist
+
+instance {X : Type*} [MetricSpace X] [IsUltrametricDist X] : TotallyDisconnectedSpace X := by
+  refine (totallyDisconnectedSpace_iff X).mpr (isTotallyDisconnected_of_isClopen_set fun x y h ↦ ?_)
+  obtain ⟨r, hr, hr'⟩ := exists_between (dist_pos.mpr h)
+  refine ⟨_, IsUltrametricDist.isClopen_ball x r, ?_, ?_⟩
+  · simp only [mem_ball, dist_self, hr]
+  · simp only [mem_ball, dist_comm, not_lt, hr'.le]

--- a/Mathlib/Topology/MetricSpace/Ultra/TotallyDisconnected.lean
+++ b/Mathlib/Topology/MetricSpace/Ultra/TotallyDisconnected.lean
@@ -7,7 +7,7 @@ import Mathlib.Topology.MetricSpace.Defs
 import Mathlib.Topology.MetricSpace.Ultra.Basic
 
 /-!
-## Ultrametric spaces are totally disconnected
+# Ultrametric spaces are totally disconnected
 
 In a metric space with an ultrametric, the space is totally disconnected.
 

--- a/Mathlib/Topology/MetricSpace/Ultra/TotallyDisconnected.lean
+++ b/Mathlib/Topology/MetricSpace/Ultra/TotallyDisconnected.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2024 Yakov Pechersky. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Yakov Pechersky
+Authors: Yakov Pechersky, David Loeffler
 -/
 import Mathlib.Topology.MetricSpace.Defs
 import Mathlib.Topology.MetricSpace.Ultra.Basic


### PR DESCRIPTION

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
