### PR TITLE
[Merged by Bors] - chore: `Set.divisionCommMonoid` scoped earlier

### DIFF
--- a/Mathlib/Algebra/Group/Pointwise/Set/Basic.lean
+++ b/Mathlib/Algebra/Group/Pointwise/Set/Basic.lean
@@ -1124,6 +1124,8 @@ protected noncomputable def divisionCommMonoid [DivisionCommMonoid α] :
     DivisionCommMonoid (Set α) :=
   { Set.divisionMonoid, Set.commSemigroup with }
 
+scoped[Pointwise] attribute [instance] Set.divisionCommMonoid Set.subtractionCommMonoid
+
 section Group
 
 variable [Group α] {s t : Set α} {a b : α}

--- a/Mathlib/Algebra/Ring/Pointwise/Set.lean
+++ b/Mathlib/Algebra/Ring/Pointwise/Set.lean
@@ -32,8 +32,7 @@ protected noncomputable def hasDistribNeg [Mul α] [HasDistribNeg α] : HasDistr
   neg_mul _ _ := by simp_rw [← image_neg]; exact image2_image_left_comm neg_mul
   mul_neg _ _ := by simp_rw [← image_neg]; exact image_image2_right_comm mul_neg
 
-scoped[Pointwise]
-  attribute [instance] Set.divisionCommMonoid Set.subtractionCommMonoid Set.hasDistribNeg
+scoped[Pointwise] attribute [instance] Set.hasDistribNeg
 
 section Distrib
 variable [Distrib α] (s t u : Set α)


### PR DESCRIPTION
I accidentally split it to the wrong file in #16442


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
