### PR TITLE
[Merged by Bors] - chore(MeasureTheory/Group/Arithmetic): tag more lemmas with `fun_prop`

### DIFF
--- a/Mathlib/MeasureTheory/Function/Intersectivity.lean
+++ b/Mathlib/MeasureTheory/Function/Intersectivity.lean
@@ -61,9 +61,7 @@ lemma bergelson' {s : ℕ → Set α} (hs : ∀ n, MeasurableSet (s n)) (hr₀ :
   have hfapp : ∀ n a, f n a = (↑(n + 1))⁻¹ * ∑ k in Finset.range (n + 1), (s k).indicator 1 a := by
     simp only [f, Pi.natCast_def, Pi.smul_apply, Pi.inv_apply, Finset.sum_apply, eq_self_iff_true,
     forall_const, imp_true_iff, smul_eq_mul]
-  have should_be_found_by_fun_prop k :
-    Measurable ((s k).indicator 1 : α → ℝ≥0∞) := measurable_one.indicator (hs k)
-  have hf n : Measurable (f n) := by fun_prop
+  have hf n : Measurable (f n) := by fun_prop (disch := exact hs _)
   have hf₁ n : f n ≤ 1 := by
     rintro a
     rw [hfapp, ← ENNReal.div_eq_inv_mul]

--- a/Mathlib/MeasureTheory/Function/Intersectivity.lean
+++ b/Mathlib/MeasureTheory/Function/Intersectivity.lean
@@ -61,8 +61,9 @@ lemma bergelson' {s : ℕ → Set α} (hs : ∀ n, MeasurableSet (s n)) (hr₀ :
   have hfapp : ∀ n a, f n a = (↑(n + 1))⁻¹ * ∑ k in Finset.range (n + 1), (s k).indicator 1 a := by
     simp only [f, Pi.natCast_def, Pi.smul_apply, Pi.inv_apply, Finset.sum_apply, eq_self_iff_true,
     forall_const, imp_true_iff, smul_eq_mul]
-  have hf n : Measurable (f n) := Measurable.mul' (@measurable_const ℝ≥0∞ _ _ _ (↑(n + 1))⁻¹)
-      (Finset.measurable_sum' _ fun i _ ↦ measurable_one.indicator <| hs i)
+  have should_be_found_by_fun_prop k :
+    Measurable ((s k).indicator 1 : α → ℝ≥0∞) := measurable_one.indicator (hs k)
+  have hf n : Measurable (f n) := by fun_prop
   have hf₁ n : f n ≤ 1 := by
     rintro a
     rw [hfapp, ← ENNReal.div_eq_inv_mul]

--- a/Mathlib/MeasureTheory/Function/SimpleFunc.lean
+++ b/Mathlib/MeasureTheory/Function/SimpleFunc.lean
@@ -161,7 +161,7 @@ theorem measurableSet_preimage (f : α →ₛ β) (s) : MeasurableSet (f ⁻¹' 
   measurableSet_cut (fun _ b => b ∈ s) f fun b => MeasurableSet.const (b ∈ s)
 
 /-- A simple function is measurable -/
-@[measurability]
+@[measurability, fun_prop]
 protected theorem measurable [MeasurableSpace β] (f : α →ₛ β) : Measurable f := fun s _ =>
   measurableSet_preimage f s
 

--- a/Mathlib/MeasureTheory/Group/Arithmetic.lean
+++ b/Mathlib/MeasureTheory/Group/Arithmetic.lean
@@ -120,7 +120,7 @@ lemma Measurable.mul' [MeasurableMul₂ M] {f g : α → β → M} {h : α → �
     (hg : Measurable ↿g) (hh : Measurable h) : Measurable fun a ↦ (f a * g a) (h a) := by
   simp; fun_prop
 
-@[to_additive (attr := aesop safe 20 apply (rule_sets := [Measurable]))]
+@[to_additive (attr := fun_prop, aesop safe 20 apply (rule_sets := [Measurable]))]
 theorem AEMeasurable.mul' [MeasurableMul₂ M] (hf : AEMeasurable f μ) (hg : AEMeasurable g μ) :
     AEMeasurable (f * g) μ :=
   measurable_mul.comp_aemeasurable (hf.prod_mk hg)

--- a/Mathlib/MeasureTheory/Group/Arithmetic.lean
+++ b/Mathlib/MeasureTheory/Group/Arithmetic.lean
@@ -115,7 +115,9 @@ theorem Measurable.mul [MeasurableMul₂ M] (hf : Measurable f) (hg : Measurable
     Measurable fun a => f a * g a :=
   measurable_mul.comp (hf.prod_mk hg)
 
-@[to_additive (attr := fun_prop, aesop safe 20 apply (rule_sets := [Measurable]))]
+/-- Compositional version of `Measurable.mul` for use by `fun_prop`. -/
+@[to_additive (attr := fun_prop, aesop safe 20 apply (rule_sets := [Measurable]))
+"Compositional version of `Measurable.add` for use by `fun_prop`."]
 lemma Measurable.mul' [MeasurableMul₂ M] {f g : α → β → M} {h : α → β} (hf : Measurable ↿f)
     (hg : Measurable ↿g) (hh : Measurable h) : Measurable fun a ↦ (f a * g a) (h a) := by
   simp; fun_prop
@@ -528,42 +530,52 @@ instance Subgroup.measurableSMul {G α} [MeasurableSpace G] [MeasurableSpace α]
 
 section SMul
 
-variable {M β α : Type*} [MeasurableSpace M] [MeasurableSpace β] [_root_.SMul M β]
-  {m : MeasurableSpace α} {f : α → M} {g : α → β}
+variable {M X α β : Type*} [MeasurableSpace M] [MeasurableSpace X] [SMul M X]
+  {m : MeasurableSpace α} {mβ : MeasurableSpace β} {f : α → M} {g : α → X}
 
 @[to_additive (attr := fun_prop, aesop safe 20 apply (rule_sets := [Measurable]))]
-theorem Measurable.smul [MeasurableSMul₂ M β] (hf : Measurable f) (hg : Measurable g) :
+theorem Measurable.smul [MeasurableSMul₂ M X] (hf : Measurable f) (hg : Measurable g) :
     Measurable fun x => f x • g x :=
   measurable_smul.comp (hf.prod_mk hg)
 
+/-- Compositional version of `Measurable.smul` for use by `fun_prop`. -/
+@[to_additive (attr := fun_prop)
+"Compositional version of `Measurable.vadd` for use by `fun_prop`."]
+lemma Measurable.smul' [MeasurableSMul₂ M X] {f : α → β → M} {g : α → β → X} {h : α → β}
+    (hf : Measurable ↿f) (hg : Measurable ↿g) (hh : Measurable h) :
+    Measurable fun a ↦ (f a • g a) (h a) := by simp; fun_prop
+
 @[to_additive (attr := fun_prop, aesop safe 20 apply (rule_sets := [Measurable]))]
-theorem AEMeasurable.smul [MeasurableSMul₂ M β] {μ : Measure α} (hf : AEMeasurable f μ)
+theorem AEMeasurable.smul [MeasurableSMul₂ M X] {μ : Measure α} (hf : AEMeasurable f μ)
     (hg : AEMeasurable g μ) : AEMeasurable (fun x => f x • g x) μ :=
   MeasurableSMul₂.measurable_smul.comp_aemeasurable (hf.prod_mk hg)
 
 @[to_additive]
-instance (priority := 100) MeasurableSMul₂.toMeasurableSMul [MeasurableSMul₂ M β] :
-    MeasurableSMul M β :=
+instance (priority := 100) MeasurableSMul₂.toMeasurableSMul [MeasurableSMul₂ M X] :
+    MeasurableSMul M X :=
   ⟨fun _ => measurable_const.smul measurable_id, fun _ => measurable_id.smul measurable_const⟩
 
-variable [MeasurableSMul M β] {μ : Measure α}
+variable [MeasurableSMul M X] {μ : Measure α}
 
 @[to_additive (attr := measurability)]
-theorem Measurable.smul_const (hf : Measurable f) (y : β) : Measurable fun x => f x • y :=
+theorem Measurable.smul_const (hf : Measurable f) (y : X) : Measurable fun x => f x • y :=
   (MeasurableSMul.measurable_smul_const y).comp hf
 
 @[to_additive (attr := measurability)]
-theorem AEMeasurable.smul_const (hf : AEMeasurable f μ) (y : β) :
+theorem AEMeasurable.smul_const (hf : AEMeasurable f μ) (y : X) :
     AEMeasurable (fun x => f x • y) μ :=
   (MeasurableSMul.measurable_smul_const y).comp_aemeasurable hf
 
-@[to_additive (attr := measurability)]
-theorem Measurable.const_smul' (hg : Measurable g) (c : M) : Measurable fun x => c • g x :=
+@[to_additive (attr := fun_prop, measurability)]
+theorem Measurable.const_smul (hg : Measurable g) (c : M) : Measurable (c • g) :=
   (MeasurableSMul.measurable_const_smul c).comp hg
 
-@[to_additive (attr := measurability)]
-theorem Measurable.const_smul (hg : Measurable g) (c : M) : Measurable (c • g) :=
-  hg.const_smul' c
+/-- Compositional version of `Measurable.const_smul` for use by `fun_prop`. -/
+@[to_additive (attr := fun_prop)
+"Compositional version of `Measurable.const_vadd` for use by `fun_prop`."]
+lemma Measurable.const_smul' {g : α → β → X} {h : α → β} (hg : Measurable ↿g) (hh : Measurable h)
+    (c : M) : Measurable fun a ↦ (c • g a) (h a) :=
+  (hg.comp <| measurable_id.prod_mk hh).const_smul _
 
 @[to_additive (attr := measurability)]
 theorem AEMeasurable.const_smul' (hg : AEMeasurable g μ) (c : M) :
@@ -638,12 +650,12 @@ variable {G : Type*} [Group G] [MeasurableSpace G] [MulAction G β] [MeasurableS
 
 @[to_additive]
 theorem measurable_const_smul_iff (c : G) : (Measurable fun x => c • f x) ↔ Measurable f :=
-  ⟨fun h => by simpa only [inv_smul_smul] using h.const_smul' c⁻¹, fun h => h.const_smul c⟩
+  ⟨fun h => by simpa [inv_smul_smul, Pi.smul_def] using h.const_smul c⁻¹, fun h => h.const_smul c⟩
 
 @[to_additive]
 theorem aemeasurable_const_smul_iff (c : G) :
     AEMeasurable (fun x => c • f x) μ ↔ AEMeasurable f μ :=
-  ⟨fun h => by simpa only [inv_smul_smul] using h.const_smul' c⁻¹, fun h => h.const_smul c⟩
+  ⟨fun h => by simpa [inv_smul_smul, Pi.smul_def] using h.const_smul c⁻¹, fun h => h.const_smul c⟩
 
 @[to_additive]
 instance Units.instMeasurableSpace : MeasurableSpace Mˣ := MeasurableSpace.comap ((↑) : Mˣ → M) ‹_›
@@ -782,8 +794,8 @@ end Monoid
 
 section CommMonoid
 
-variable {M ι α : Type*} [CommMonoid M] [MeasurableSpace M] [MeasurableMul₂ M]
-  {m : MeasurableSpace α} {μ : Measure α} {f : ι → α → M}
+variable {M ι α β : Type*} [CommMonoid M] [MeasurableSpace M] [MeasurableMul₂ M]
+  {m : MeasurableSpace α} {mβ : MeasurableSpace β} {μ : Measure α} {f : ι → α → M}
 
 @[to_additive (attr := measurability)]
 theorem Multiset.measurable_prod' (l : Multiset (α → M)) (hl : ∀ f ∈ l, Measurable f) :
@@ -807,15 +819,18 @@ theorem Multiset.aemeasurable_prod (s : Multiset (α → M)) (hs : ∀ f ∈ s, 
     AEMeasurable (fun x => (s.map fun f : α → M => f x).prod) μ := by
   simpa only [← Pi.multiset_prod_apply] using s.aemeasurable_prod' hs
 
-@[to_additive (attr := measurability)]
-theorem Finset.measurable_prod' (s : Finset ι) (hf : ∀ i ∈ s, Measurable (f i)) :
-    Measurable (∏ i ∈ s, f i) :=
-  Finset.prod_induction _ _ (fun _ _ => Measurable.mul) (@measurable_one M _ _ _ _) hf
-
-@[to_additive (attr := measurability)]
+@[to_additive (attr := fun_prop, measurability)]
 theorem Finset.measurable_prod (s : Finset ι) (hf : ∀ i ∈ s, Measurable (f i)) :
-    Measurable fun a => ∏ i ∈ s, f i a := by
-  simpa only [← Finset.prod_apply] using s.measurable_prod' hf
+    Measurable fun a ↦ ∏ i ∈ s, f i a := by
+  simp_rw [← Finset.prod_apply]
+  exact Finset.prod_induction _ _ (fun _ _ => Measurable.mul) (@measurable_one M _ _ _ _) hf
+
+/-- Compositional version of `Finset.measurable_prod` for use by `fun_prop`. -/
+@[to_additive (attr := measurability, fun_prop)
+"Compositional version of `Finset.measurable_sum` for use by `fun_prop`."]
+lemma Finset.measurable_prod' {f : ι → α → β → M} {g : α → β} {s : Finset ι}
+    (hf : ∀ i, Measurable ↿(f i)) (hg : Measurable g) :
+    Measurable fun a ↦ (∏ i ∈ s, f i a) (g a) := by simp; fun_prop
 
 @[to_additive (attr := measurability)]
 theorem Finset.aemeasurable_prod' (s : Finset ι) (hf : ∀ i ∈ s, AEMeasurable (f i) μ) :

--- a/Mathlib/MeasureTheory/Group/Arithmetic.lean
+++ b/Mathlib/MeasureTheory/Group/Arithmetic.lean
@@ -87,8 +87,8 @@ export MeasurableMul₂ (measurable_mul)
 
 section Mul
 
-variable {M α : Type*} [MeasurableSpace M] [Mul M] {m : MeasurableSpace α} {f g : α → M}
-  {μ : Measure α}
+variable {M α β : Type*} [MeasurableSpace M] [Mul M] {m : MeasurableSpace α}
+  {mβ : MeasurableSpace β} {f g : α → M} {μ : Measure α}
 
 @[to_additive (attr := fun_prop, measurability)]
 theorem Measurable.const_mul [MeasurableMul M] (hf : Measurable f) (c : M) :
@@ -111,14 +111,14 @@ theorem AEMeasurable.mul_const [MeasurableMul M] (hf : AEMeasurable f μ) (c : M
   (measurable_mul_const c).comp_aemeasurable hf
 
 @[to_additive (attr := fun_prop, aesop safe 20 apply (rule_sets := [Measurable]))]
-theorem Measurable.mul' [MeasurableMul₂ M] (hf : Measurable f) (hg : Measurable g) :
-    Measurable (f * g) :=
-  measurable_mul.comp (hf.prod_mk hg)
-
-@[to_additive (attr := fun_prop, aesop safe 20 apply (rule_sets := [Measurable]))]
 theorem Measurable.mul [MeasurableMul₂ M] (hf : Measurable f) (hg : Measurable g) :
     Measurable fun a => f a * g a :=
   measurable_mul.comp (hf.prod_mk hg)
+
+@[to_additive (attr := fun_prop, aesop safe 20 apply (rule_sets := [Measurable]))]
+lemma Measurable.mul' [MeasurableMul₂ M] {f g : α → β → M} {h : α → β} (hf : Measurable ↿f)
+    (hg : Measurable ↿g) (hh : Measurable h) : Measurable fun a ↦ (f a * g a) (h a) := by
+  simp; fun_prop
 
 @[to_additive (attr := aesop safe 20 apply (rule_sets := [Measurable]))]
 theorem AEMeasurable.mul' [MeasurableMul₂ M] (hf : AEMeasurable f μ) (hg : AEMeasurable g μ) :
@@ -238,8 +238,8 @@ export MeasurableDiv₂ (measurable_div)
 
 section Div
 
-variable {G α : Type*} [MeasurableSpace G] [Div G] {m : MeasurableSpace α} {f g : α → G}
-  {μ : Measure α}
+variable {G α β : Type*} [MeasurableSpace G] [Div G] {m : MeasurableSpace α}
+  {mβ : MeasurableSpace β} {f g : α → G} {μ : Measure α}
 
 @[to_additive (attr := measurability)]
 theorem Measurable.const_div [MeasurableDiv G] (hf : Measurable f) (c : G) :
@@ -262,14 +262,14 @@ theorem AEMeasurable.div_const [MeasurableDiv G] (hf : AEMeasurable f μ) (c : G
   (MeasurableDiv.measurable_div_const c).comp_aemeasurable hf
 
 @[to_additive (attr := fun_prop, aesop safe 20 apply (rule_sets := [Measurable]))]
-theorem Measurable.div' [MeasurableDiv₂ G] (hf : Measurable f) (hg : Measurable g) :
-    Measurable (f / g) :=
-  measurable_div.comp (hf.prod_mk hg)
-
-@[to_additive (attr := fun_prop, aesop safe 20 apply (rule_sets := [Measurable]))]
 theorem Measurable.div [MeasurableDiv₂ G] (hf : Measurable f) (hg : Measurable g) :
     Measurable fun a => f a / g a :=
   measurable_div.comp (hf.prod_mk hg)
+
+@[to_additive (attr := fun_prop, aesop safe 20 apply (rule_sets := [Measurable]))]
+lemma Measurable.div' [MeasurableDiv₂ G] {f g : α → β → G} {h : α → β} (hf : Measurable ↿f)
+    (hg : Measurable ↿g) (hh : Measurable h) : Measurable fun a ↦ (f a / g a) (h a) := by
+  simp; fun_prop
 
 @[to_additive (attr := fun_prop, aesop safe 20 apply (rule_sets := [Measurable]))]
 theorem AEMeasurable.div' [MeasurableDiv₂ G] (hf : AEMeasurable f μ) (hg : AEMeasurable g μ) :

--- a/Mathlib/MeasureTheory/Group/Arithmetic.lean
+++ b/Mathlib/MeasureTheory/Group/Arithmetic.lean
@@ -110,7 +110,7 @@ theorem AEMeasurable.mul_const [MeasurableMul M] (hf : AEMeasurable f μ) (c : M
     AEMeasurable (fun x => f x * c) μ :=
   (measurable_mul_const c).comp_aemeasurable hf
 
-@[to_additive (attr := aesop safe 20 apply (rule_sets := [Measurable]))]
+@[to_additive (attr := fun_prop, aesop safe 20 apply (rule_sets := [Measurable]))]
 theorem Measurable.mul' [MeasurableMul₂ M] (hf : Measurable f) (hg : Measurable g) :
     Measurable (f * g) :=
   measurable_mul.comp (hf.prod_mk hg)
@@ -261,7 +261,7 @@ theorem AEMeasurable.div_const [MeasurableDiv G] (hf : AEMeasurable f μ) (c : G
     AEMeasurable (fun x => f x / c) μ :=
   (MeasurableDiv.measurable_div_const c).comp_aemeasurable hf
 
-@[to_additive (attr := aesop safe 20 apply (rule_sets := [Measurable]))]
+@[to_additive (attr := fun_prop, aesop safe 20 apply (rule_sets := [Measurable]))]
 theorem Measurable.div' [MeasurableDiv₂ G] (hf : Measurable f) (hg : Measurable g) :
     Measurable (f / g) :=
   measurable_div.comp (hf.prod_mk hg)
@@ -271,7 +271,7 @@ theorem Measurable.div [MeasurableDiv₂ G] (hf : Measurable f) (hg : Measurable
     Measurable fun a => f a / g a :=
   measurable_div.comp (hf.prod_mk hg)
 
-@[to_additive (attr := aesop safe 20 apply (rule_sets := [Measurable]))]
+@[to_additive (attr := fun_prop, aesop safe 20 apply (rule_sets := [Measurable]))]
 theorem AEMeasurable.div' [MeasurableDiv₂ G] (hf : AEMeasurable f μ) (hg : AEMeasurable g μ) :
     AEMeasurable (f / g) μ :=
   measurable_div.comp_aemeasurable (hf.prod_mk hg)

--- a/Mathlib/MeasureTheory/Integral/Lebesgue.lean
+++ b/Mathlib/MeasureTheory/Integral/Lebesgue.lean
@@ -530,7 +530,7 @@ theorem lintegral_add_aux {f g : α → ℝ≥0∞} (hf : Measurable f) (hg : Me
         funext n
         rw [← SimpleFunc.add_lintegral, ← SimpleFunc.lintegral_eq_lintegral]
         simp only [Pi.add_apply, SimpleFunc.coe_add]
-      · measurability
+      · fun_prop
       · intro i j h a
         dsimp
         gcongr <;> exact monotone_eapprox _ h _

--- a/Mathlib/MeasureTheory/MeasurableSpace/Basic.lean
+++ b/Mathlib/MeasureTheory/MeasurableSpace/Basic.lean
@@ -231,7 +231,7 @@ theorem Subsingleton.measurable [Subsingleton α] : Measurable f := fun _ _ =>
 theorem measurable_of_subsingleton_codomain [Subsingleton β] (f : α → β) : Measurable f :=
   fun s _ => Subsingleton.set_cases MeasurableSet.empty MeasurableSet.univ s
 
-@[to_additive (attr := measurability)]
+@[to_additive (attr := measurability, fun_prop)]
 theorem measurable_one [One α] : Measurable (1 : β → α) :=
   @measurable_const _ _ _ _ 1
 

--- a/Mathlib/MeasureTheory/MeasurableSpace/Defs.lean
+++ b/Mathlib/MeasureTheory/MeasurableSpace/Defs.lean
@@ -534,7 +534,7 @@ variable [MeasurableSpace α] [MeasurableSpace β] [DiscreteMeasurableSpace α] 
 @[measurability] lemma MeasurableSet.of_discrete : MeasurableSet s :=
   DiscreteMeasurableSpace.forall_measurableSet _
 
-@[measurability] lemma Measurable.of_discrete : Measurable f := fun _ _ ↦ .of_discrete
+@[measurability, fun_prop] lemma Measurable.of_discrete : Measurable f := fun _ _ ↦ .of_discrete
 
 @[deprecated MeasurableSet.of_discrete (since := "2024-08-25")]
 lemma measurableSet_discrete (s : Set α) : MeasurableSet s := .of_discrete

--- a/Mathlib/MeasureTheory/MeasurableSpace/Embedding.lean
+++ b/Mathlib/MeasureTheory/MeasurableSpace/Embedding.lean
@@ -60,6 +60,8 @@ structure MeasurableEmbedding [MeasurableSpace α] [MeasurableSpace β] (f : α 
   /-- The image of a measurable set under a measurable embedding is a measurable set. -/
   protected measurableSet_image' : ∀ ⦃s⦄, MeasurableSet s → MeasurableSet (f '' s)
 
+attribute [fun_prop] MeasurableEmbedding.measurable
+
 namespace MeasurableEmbedding
 
 variable {mα : MeasurableSpace α} [MeasurableSpace β] [MeasurableSpace γ] {f : α → β} {g : β → γ}
@@ -155,7 +157,7 @@ instance instEquivLike : EquivLike (α ≃ᵐ β) α β where
 theorem coe_toEquiv (e : α ≃ᵐ β) : (e.toEquiv : α → β) = e :=
   rfl
 
-@[measurability]
+@[measurability, fun_prop]
 protected theorem measurable (e : α ≃ᵐ β) : Measurable (e : α → β) :=
   e.measurable_toFun
 

--- a/test/measurability.lean
+++ b/test/measurability.lean
@@ -82,7 +82,7 @@ example [Div β] [MeasurableDiv₂ β] (hf : Measurable f) (hg : Measurable g)
 
 example [AddCommMonoid β] [MeasurableAdd₂ β] {s : Finset ℕ} {F : ℕ → α → β}
     (hF : ∀ i, Measurable (F i)) : Measurable (∑ i ∈ s, (fun x => F (i+1) x + F i x)) := by
-  measurability
+  fun_prop
 
 example [AddCommMonoid β] [MeasurableAdd₂ β] {s : Finset ℕ} {F : ℕ → α → β}
     (hF : ∀ i, AEMeasurable (F i) μ) : AEMeasurable (∑ i ∈ s, (fun x => F (i+1) x + F i x)) μ := by


### PR DESCRIPTION
... and rewrite `Measurable.mul'` and `Measurable.div'` to be in compositional form

From PFR

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
