### PR TITLE
[Merged by Bors] - feat: `s / t` is finite

### DIFF
--- a/Mathlib/Data/Set/Pointwise/Finite.lean
+++ b/Mathlib/Data/Set/Pointwise/Finite.lean
@@ -51,6 +51,13 @@ def fintypeMul [DecidableEq α] (s t : Set α) [Fintype s] [Fintype t] : Fintype
 
 end Mul
 
+section Div
+variable [Div α] {s t : Set α}
+
+@[to_additive] lemma Finite.div : s.Finite → t.Finite → (s / t).Finite := .image2 _
+
+end Div
+
 section Monoid
 
 variable [Monoid α] {s t : Set α}
@@ -109,20 +116,34 @@ section Cancel
 variable [Mul α] [IsLeftCancelMul α] [IsRightCancelMul α] {s t : Set α}
 
 @[to_additive]
-theorem infinite_mul : (s * t).Infinite ↔ s.Infinite ∧ t.Nonempty ∨ t.Infinite ∧ s.Nonempty :=
-  infinite_image2 (fun _ _ => (mul_left_injective _).injOn) fun _ _ =>
-    (mul_right_injective _).injOn
+lemma finite_mul : (s * t).Finite ↔ s.Finite ∧ t.Finite ∨ s = ∅ ∨ t = ∅ :=
+  finite_image2 (fun _ _ ↦ (mul_left_injective _).injOn) fun _ _ ↦ (mul_right_injective _).injOn
 
 @[to_additive]
-lemma finite_mul : (s * t).Finite ↔ s.Finite ∧ t.Finite ∨ s = ∅ ∨ t = ∅ :=
-  finite_image2  (fun _ _ ↦ (mul_left_injective _).injOn)
-    fun _ _ ↦ (mul_right_injective _).injOn
+lemma infinite_mul : (s * t).Infinite ↔ s.Infinite ∧ t.Nonempty ∨ t.Infinite ∧ s.Nonempty :=
+  infinite_image2 (fun _ _ => (mul_left_injective _).injOn) fun _ _ => (mul_right_injective _).injOn
 
 end Cancel
 
 section Group
 
-variable [Group α] [MulAction α β] {a : α} {s : Set β}
+variable [Group α] {s t : Set α}
+
+@[to_additive] lemma finite_inv : s⁻¹.Finite ↔ s.Finite := by
+  rw [← image_inv, finite_image_iff inv_injective.injOn]
+
+@[to_additive] lemma infinite_inv : s⁻¹.Infinite ↔ s.Infinite := finite_inv.not
+
+@[to_additive]
+lemma finite_div : (s / t).Finite ↔ s.Finite ∧ t.Finite ∨ s = ∅ ∨ t = ∅ :=
+  finite_image2 (fun _ _ ↦ div_left_injective.injOn) fun _ _ ↦ div_right_injective.injOn
+
+@[to_additive]
+lemma infinite_div : (s / t).Infinite ↔ s.Infinite ∧ t.Nonempty ∨ t.Infinite ∧ s.Nonempty :=
+  infinite_image2 (fun _ _ ↦ div_left_injective.injOn) fun _ _ ↦ div_right_injective.injOn
+
+
+variable [MulAction α β] {a : α} {s : Set β}
 
 @[to_additive (attr := simp)]
 theorem finite_smul_set : (a • s).Finite ↔ s.Finite :=

--- a/Mathlib/Data/Set/Pointwise/Finite.lean
+++ b/Mathlib/Data/Set/Pointwise/Finite.lean
@@ -26,16 +26,6 @@ theorem finite_one : (1 : Set α).Finite :=
 
 end One
 
-section InvolutiveInv
-
-variable [InvolutiveInv α] {s : Set α}
-
-@[to_additive]
-theorem Finite.inv (hs : s.Finite) : s⁻¹.Finite :=
-  hs.preimage inv_injective.injOn
-
-end InvolutiveInv
-
 section Mul
 
 variable [Mul α] {s t : Set α}
@@ -50,13 +40,6 @@ def fintypeMul [DecidableEq α] (s t : Set α) [Fintype s] [Fintype t] : Fintype
   Set.fintypeImage2 _ _ _
 
 end Mul
-
-section Div
-variable [Div α] {s t : Set α}
-
-@[to_additive] lemma Finite.div : s.Finite → t.Finite → (s / t).Finite := .image2 _
-
-end Div
 
 section Monoid
 
@@ -125,14 +108,33 @@ lemma infinite_mul : (s * t).Infinite ↔ s.Infinite ∧ t.Nonempty ∨ t.Infini
 
 end Cancel
 
+section InvolutiveInv
+variable [InvolutiveInv α] {s : Set α}
+
+@[to_additive (attr := simp)] lemma finite_inv : s⁻¹.Finite ↔ s.Finite := by
+  rw [← image_inv, finite_image_iff inv_injective.injOn]
+
+@[to_additive (attr := simp)] lemma infinite_inv : s⁻¹.Infinite ↔ s.Infinite := finite_inv.not
+
+@[to_additive] alias ⟨Finite.of_inv, Finite.inv⟩ := finite_inv
+
+end InvolutiveInv
+
+section Div
+variable [Div α] {s t : Set α}
+
+@[to_additive] lemma Finite.div : s.Finite → t.Finite → (s / t).Finite := .image2 _
+
+/-- Division preserves finiteness. -/
+@[to_additive "Subtraction preserves finiteness."]
+def fintypeDiv [DecidableEq α] (s t : Set α) [Fintype s] [Fintype t] : Fintype (s / t) :=
+  Set.fintypeImage2 _ _ _
+
+end Div
+
 section Group
 
 variable [Group α] {s t : Set α}
-
-@[to_additive] lemma finite_inv : s⁻¹.Finite ↔ s.Finite := by
-  rw [← image_inv, finite_image_iff inv_injective.injOn]
-
-@[to_additive] lemma infinite_inv : s⁻¹.Infinite ↔ s.Infinite := finite_inv.not
 
 @[to_additive]
 lemma finite_div : (s / t).Finite ↔ s.Finite ∧ t.Finite ∨ s = ∅ ∨ t = ∅ :=
@@ -141,7 +143,6 @@ lemma finite_div : (s / t).Finite ↔ s.Finite ∧ t.Finite ∨ s = ∅ ∨ t = 
 @[to_additive]
 lemma infinite_div : (s / t).Infinite ↔ s.Infinite ∧ t.Nonempty ∨ t.Infinite ∧ s.Nonempty :=
   infinite_image2 (fun _ _ ↦ div_left_injective.injOn) fun _ _ ↦ div_right_injective.injOn
-
 
 variable [MulAction α β] {a : α} {s : Set β}
 
@@ -153,11 +154,8 @@ theorem finite_smul_set : (a • s).Finite ↔ s.Finite :=
 theorem infinite_smul_set : (a • s).Infinite ↔ s.Infinite :=
   infinite_image_iff (MulAction.injective _).injOn
 
-alias ⟨Finite.of_smul_set, _⟩ := finite_smul_set
-
-alias ⟨_, Infinite.smul_set⟩ := infinite_smul_set
-
-attribute [to_additive] Finite.of_smul_set Infinite.smul_set
+@[to_additive] alias ⟨Finite.of_smul_set, _⟩ := finite_smul_set
+@[to_additive] alias ⟨_, Infinite.smul_set⟩ := infinite_smul_set
 
 end Group
 


### PR DESCRIPTION
From PFR


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
