### PR TITLE
[Merged by Bors] - feat: add option for the default length of a file

### DIFF
--- a/Mathlib/Tactic/Linter/Lint.lean
+++ b/Mathlib/Tactic/Linter/Lint.lean
@@ -320,6 +320,12 @@ register_option linter.style.longFile : Nat := {
   descr := "enable the longFile linter"
 }
 
+/-- The number of lines that the `longFile` linter considers the default. -/
+register_option linter.style.longFileDefValue : Nat := {
+  defValue := 1500
+  descr := "the expected number of lines of each file"
+}
+
 namespace Style.longFile
 
 @[inherit_doc Mathlib.Linter.linter.style.longFile]
@@ -327,7 +333,7 @@ def longFileLinter : Linter where run := withSetOptionIn fun stx ↦ do
   let linterBound := linter.style.longFile.get (← getOptions)
   if linterBound == 0 then
     return
-  let defValue := 1500
+  let defValue := linter.style.longFileDefValue.get (← getOptions)
   let smallOption := match stx with
       | `(set_option linter.style.longFile $x) => TSyntax.getNat ⟨x.raw⟩ ≤ defValue
       | _ => false

--- a/Mathlib/Tactic/Linter/Lint.lean
+++ b/Mathlib/Tactic/Linter/Lint.lean
@@ -323,7 +323,7 @@ register_option linter.style.longFile : Nat := {
 /-- The number of lines that the `longFile` linter considers the default. -/
 register_option linter.style.longFileDefValue : Nat := {
   defValue := 1500
-  descr := "the expected number of lines of each file"
+  descr := "a soft upper bound on the number of lines of each file"
 }
 
 namespace Style.longFile


### PR DESCRIPTION
As discussed on [Zulip](https://leanprover.zulipchat.com/#narrow/stream/270676-lean4/topic/Retrieving.20.60weak.60.20options/near/468301685).

A further benefit of having the option is that the tests can be performed more easily, since you do not have to reach a file length of more than 1500 to test behaviour beyond the `defValue`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
