### PR TITLE
[Merged by Bors] - chore: add a few focusing dots 1

### DIFF
--- a/Mathlib/Algebra/BigOperators/Associated.lean
+++ b/Mathlib/Algebra/BigOperators/Associated.lean
@@ -94,14 +94,14 @@ theorem divisor_closure_eq_closure [CancelCommMonoidWithZero α]
     obtain ⟨ha₁ | ha₂, hs⟩ := hm
     · rcases ha₁.exists_right_inv with ⟨k, hk⟩
       refine hind x (y*k) ?_ hs ?_
-      simp only [← mul_assoc, ← hprod, ← Multiset.prod_cons, mul_comm]
-      refine multiset_prod_mem _ _ (Multiset.forall_mem_cons.2 ⟨subset_closure (Set.mem_def.2 ?_),
-        Multiset.forall_mem_cons.2 ⟨subset_closure (Set.mem_def.2 ?_), (fun t ht =>
-        subset_closure (hs t ht))⟩⟩)
-      · left; exact isUnit_of_mul_eq_one_right _ _ hk
-      · left; exact ha₁
-      rw [← mul_one s.prod, ← hk, ← mul_assoc, ← mul_assoc, mul_eq_mul_right_iff, mul_comm]
-      left; exact hprod
+      · simp only [← mul_assoc, ← hprod, ← Multiset.prod_cons, mul_comm]
+        refine multiset_prod_mem _ _ (Multiset.forall_mem_cons.2 ⟨subset_closure (Set.mem_def.2 ?_),
+          Multiset.forall_mem_cons.2 ⟨subset_closure (Set.mem_def.2 ?_), (fun t ht =>
+          subset_closure (hs t ht))⟩⟩)
+        · left; exact isUnit_of_mul_eq_one_right _ _ hk
+        · left; exact ha₁
+      · rw [← mul_one s.prod, ← hk, ← mul_assoc, ← mul_assoc, mul_eq_mul_right_iff, mul_comm]
+        left; exact hprod
     · rcases ha₂.dvd_mul.1 (Dvd.intro _ hprod) with ⟨c, hc⟩ | ⟨c, hc⟩
       · rw [hc]; rw [hc, mul_assoc] at hprod
         refine Submonoid.mul_mem _ (subset_closure (Set.mem_def.2 ?_))

--- a/Mathlib/Algebra/Module/Submodule/Bilinear.lean
+++ b/Mathlib/Algebra/Module/Submodule/Bilinear.lean
@@ -59,8 +59,8 @@ theorem map₂_span_span (f : M →ₗ[R] N →ₗ[R] P) (s : Set M) (t : Set N)
     on_goal 1 =>
       intro a ha
       apply @span_induction' R N _ _ _ t
-      on_goal 1 => intro b hb
-      · exact subset_span ⟨_, ‹_›, _, ‹_›, rfl⟩
+      · intro b hb
+        exact subset_span ⟨_, ‹_›, _, ‹_›, rfl⟩
     all_goals
       intros
       simp only [*, add_mem, smul_mem, zero_mem, _root_.map_zero, map_add,

--- a/Mathlib/Algebra/Module/Submodule/Bilinear.lean
+++ b/Mathlib/Algebra/Module/Submodule/Bilinear.lean
@@ -56,13 +56,15 @@ theorem map₂_span_span (f : M →ₗ[R] N →ₗ[R] P) (s : Set M) (t : Set N)
   apply le_antisymm
   · rw [map₂_le]
     apply @span_induction' R M _ _ _ s
-    intro a ha
-    apply @span_induction' R N _ _ _ t
-    intro b hb
-    exact subset_span ⟨_, ‹_›, _, ‹_›, rfl⟩
-    all_goals intros; simp only [*, add_mem, smul_mem, zero_mem, _root_.map_zero, map_add,
-                                 LinearMap.zero_apply, LinearMap.add_apply, LinearMap.smul_apply,
-                                 map_smul]
+    on_goal 1 =>
+      intro a ha
+      apply @span_induction' R N _ _ _ t
+      on_goal 1 => intro b hb
+      · exact subset_span ⟨_, ‹_›, _, ‹_›, rfl⟩
+    all_goals
+      intros
+      simp only [*, add_mem, smul_mem, zero_mem, _root_.map_zero, map_add,
+        LinearMap.zero_apply, LinearMap.add_apply, LinearMap.smul_apply, map_smul]
   · rw [span_le, image2_subset_iff]
     intro a ha b hb
     exact apply_mem_map₂ _ (subset_span ha) (subset_span hb)

--- a/Mathlib/Algebra/MonoidAlgebra/Defs.lean
+++ b/Mathlib/Algebra/MonoidAlgebra/Defs.lean
@@ -209,10 +209,10 @@ instance nonUnitalSemiring : NonUnitalSemiring (MonoidAlgebra k G) :=
     mul_assoc := fun f g h => by
       -- Porting note: `reducible` cannot be `local` so proof gets long.
       simp only [mul_def]
-      rw [sum_sum_index]; congr; ext a₁ b₁
-      rw [sum_sum_index, sum_sum_index]; congr; ext a₂ b₂
-      rw [sum_sum_index, sum_single_index]; congr; ext a₃ b₃
-      rw [sum_single_index, mul_assoc, mul_assoc]
+      rw [sum_sum_index] <;> congr; on_goal 1 => ext a₁ b₁
+      rw [sum_sum_index, sum_sum_index] <;> congr; on_goal 1 => ext a₂ b₂
+      rw [sum_sum_index, sum_single_index] <;> congr; on_goal 1 => ext a₃ b₃
+      on_goal 1 => rw [sum_single_index, mul_assoc, mul_assoc]
       all_goals simp only [single_zero, single_add, forall_true_iff, add_mul,
         mul_add, zero_mul, mul_zero, sum_zero, sum_add] }
 
@@ -974,10 +974,10 @@ instance nonUnitalSemiring : NonUnitalSemiring k[G] :=
     mul_assoc := fun f g h => by
       -- Porting note: `reducible` cannot be `local` so proof gets long.
       simp only [mul_def]
-      rw [sum_sum_index]; congr; ext a₁ b₁
-      rw [sum_sum_index, sum_sum_index]; congr; ext a₂ b₂
-      rw [sum_sum_index, sum_single_index]; congr; ext a₃ b₃
-      rw [sum_single_index, mul_assoc, add_assoc]
+      rw [sum_sum_index] <;> congr; on_goal 1 => ext a₁ b₁
+      rw [sum_sum_index, sum_sum_index] <;> congr; on_goal 1 => ext a₂ b₂
+      rw [sum_sum_index, sum_single_index] <;> congr; on_goal 1 => ext a₃ b₃
+      on_goal 1 => rw [sum_single_index, mul_assoc, add_assoc]
       all_goals simp only [single_zero, single_add, forall_true_iff, add_mul,
         mul_add, zero_mul, mul_zero, sum_zero, sum_add] }
 

--- a/Mathlib/Algebra/Order/BigOperators/GroupWithZero/List.lean
+++ b/Mathlib/Algebra/Order/BigOperators/GroupWithZero/List.lean
@@ -51,12 +51,12 @@ theorem prod_map_le_prod_map₀ {ι : Type*} {s : List ι} (f : ι → R) (g : �
       · intro i hi
         apply h
         simp [hi]
-    apply prod_nonneg
-    · simp only [mem_map, forall_exists_index, and_imp, forall_apply_eq_imp_iff₂]
+    · apply prod_nonneg
+      simp only [mem_map, forall_exists_index, and_imp, forall_apply_eq_imp_iff₂]
       intro a ha
       apply h0
       simp [ha]
-    apply (h0 _ _).trans (h _ _) <;> simp
+    · apply (h0 _ _).trans (h _ _) <;> simp
 
 omit [PosMulMono R]
 variable [PosMulStrictMono R] [NeZero (1 : R)]
@@ -89,11 +89,11 @@ theorem prod_map_lt_prod_map {ι : Type*} {s : List ι} (hs : s ≠ [])
         apply le_of_lt
         apply h
         simp [hi]
-    apply prod_pos
-    · simp only [mem_map, forall_exists_index, and_imp, forall_apply_eq_imp_iff₂]
+    · apply prod_pos
+      simp only [mem_map, forall_exists_index, and_imp, forall_apply_eq_imp_iff₂]
       intro a ha
       apply h0
       simp [ha]
-    apply le_of_lt ((h0 _ _).trans (h _ _)) <;> simp
+    · apply le_of_lt ((h0 _ _).trans (h _ _)) <;> simp
 
 end List

--- a/Mathlib/Algebra/Order/Floor.lean
+++ b/Mathlib/Algebra/Order/Floor.lean
@@ -526,7 +526,7 @@ lemma ceil_lt_mul (hb : 1 < b) (hba : ⌈(b - 1)⁻¹⌉₊ / b < a) : ⌈a⌉�
 lemma ceil_le_mul (hb : 1 < b) (hba : ⌈(b - 1)⁻¹⌉₊ / b ≤ a) : ⌈a⌉₊ ≤ b * a := by
   obtain rfl | hba := hba.eq_or_lt
   · rw [mul_div_cancel₀, cast_le, ceil_le]
-    exact _root_.div_le_self (by positivity) hb.le
+    · exact _root_.div_le_self (by positivity) hb.le
     · positivity
   · exact (ceil_lt_mul hb hba).le
 

--- a/Mathlib/Analysis/Analytic/Within.lean
+++ b/Mathlib/Analysis/Analytic/Within.lean
@@ -113,6 +113,7 @@ result for `AnalyticOn`, as this requires a bit more work to show that local ext
 be stitched together.
 -/
 
+set_option linter.style.multiGoal false in
 /-- `f` has power series `p` at `x` iff some local extension of `f` has that series -/
 lemma hasFPowerSeriesWithinOnBall_iff_exists_hasFPowerSeriesOnBall [CompleteSpace F] {f : E → F}
     {p : FormalMultilinearSeries 𝕜 E F} {s : Set E} {x : E} {r : ℝ≥0∞} :

--- a/Mathlib/Analysis/Analytic/Within.lean
+++ b/Mathlib/Analysis/Analytic/Within.lean
@@ -113,7 +113,6 @@ result for `AnalyticOn`, as this requires a bit more work to show that local ext
 be stitched together.
 -/
 
-set_option linter.style.multiGoal false in
 /-- `f` has power series `p` at `x` iff some local extension of `f` has that series -/
 lemma hasFPowerSeriesWithinOnBall_iff_exists_hasFPowerSeriesOnBall [CompleteSpace F] {f : E → F}
     {p : FormalMultilinearSeries 𝕜 E F} {s : Set E} {x : E} {r : ℝ≥0∞} :

--- a/Mathlib/Analysis/MeanInequalities.lean
+++ b/Mathlib/Analysis/MeanInequalities.lean
@@ -668,8 +668,8 @@ lemma compact_inner_le_weight_mul_Lp_of_nonneg (s : Finset ι) {p : ℝ} (hp : 1
     𝔼 i ∈ s, w i * f i ≤ (𝔼 i ∈ s, w i) ^ (1 - p⁻¹) * (𝔼 i ∈ s, w i * f i ^ p) ^ p⁻¹ := by
   simp_rw [expect_eq_sum_div_card]
   rw [div_rpow, div_rpow, div_mul_div_comm, ← rpow_add', sub_add_cancel, rpow_one]
-  gcongr
-  · exact inner_le_weight_mul_Lp_of_nonneg s hp _ _ hw hf
+  · gcongr
+    exact inner_le_weight_mul_Lp_of_nonneg s hp _ _ hw hf
   any_goals simp
   · exact sum_nonneg fun i _ ↦ by have := hw i; have := hf i; positivity
   · exact sum_nonneg fun i _ ↦ by have := hw i; positivity

--- a/Mathlib/Analysis/PSeries.lean
+++ b/Mathlib/Analysis/PSeries.lean
@@ -162,8 +162,8 @@ theorem tsum_schlomilch_le {C : ℕ} (hf : ∀ ⦃m n⦄, 1 < m → m ≤ n → 
       le_trans ?_
         (add_le_add_left
           (mul_le_mul_of_nonneg_left (ENNReal.sum_le_tsum <| Finset.Ico (u 0 + 1) (u n + 1)) ?_) _)
-  simpa using Finset.sum_schlomilch_le hf h_pos h_nonneg hu h_succ_diff n
-  exact zero_le _
+  · simpa using Finset.sum_schlomilch_le hf h_pos h_nonneg hu h_succ_diff n
+  · exact zero_le _
 
 theorem tsum_condensed_le (hf : ∀ ⦃m n⦄, 1 < m → m ≤ n → f n ≤ f m) :
     (∑' k : ℕ, 2 ^ k * f (2 ^ k)) ≤ f 1 + 2 * ∑' k, f k := by

--- a/Mathlib/CategoryTheory/MorphismProperty/Representable.lean
+++ b/Mathlib/CategoryTheory/MorphismProperty/Representable.lean
@@ -280,8 +280,8 @@ instance isMultiplicative : IsMultiplicative F.relativelyRepresentable where
 lemma stableUnderBaseChange : StableUnderBaseChange F.relativelyRepresentable := by
   intro X Y Y' X' f g f' g' P₁ hg a h
   refine ⟨hg.pullback (h ≫ f), hg.snd (h ≫ f), ?_, ?_⟩
-  apply P₁.lift (hg.fst (h ≫ f)) (F.map (hg.snd (h ≫ f)) ≫ h) (by simpa using hg.w (h ≫ f))
-  apply IsPullback.of_right' (hg.isPullback (h ≫ f)) P₁
+  · apply P₁.lift (hg.fst (h ≫ f)) (F.map (hg.snd (h ≫ f)) ≫ h) (by simpa using hg.w (h ≫ f))
+  · apply IsPullback.of_right' (hg.isPullback (h ≫ f)) P₁
 
 instance respectsIso : RespectsIso F.relativelyRepresentable :=
   (stableUnderBaseChange F).respectsIso


### PR DESCRIPTION
More missing cdots found by the multiGoal linter (#12339).

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
