### PR TITLE
[Merged by Bors] - feat(CategoryTheory/Closed/Enrichment): a closed monoidal category is enriched in itself

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -1456,6 +1456,7 @@ import Mathlib.CategoryTheory.ChosenFiniteProducts
 import Mathlib.CategoryTheory.ChosenFiniteProducts.Cat
 import Mathlib.CategoryTheory.ChosenFiniteProducts.FunctorCategory
 import Mathlib.CategoryTheory.Closed.Cartesian
+import Mathlib.CategoryTheory.Closed.Enrichment
 import Mathlib.CategoryTheory.Closed.Functor
 import Mathlib.CategoryTheory.Closed.FunctorCategory
 import Mathlib.CategoryTheory.Closed.FunctorToTypes

--- a/Mathlib/CategoryTheory/Closed/Enrichment.lean
+++ b/Mathlib/CategoryTheory/Closed/Enrichment.lean
@@ -56,8 +56,8 @@ lemma id_eq (x : V) : id x = curry (ρ_ x).hom := rfl
 
 /-- Unfold the definition of compTranspose.
 This exists to streamline the proof of MonoidalClosed.assoc -/
-lemma compTranpose_eq (x y z : V) : compTranspose x y z = (α_ _ _ _).inv ≫
-    (ihom.ev x).app y ▷ _ ≫ (ihom.ev y).app z :=
+lemma compTranpose_eq (x y z : V)
+    : compTranspose x y z = (α_ _ _ _).inv ≫ (ihom.ev x).app y ▷ _ ≫ (ihom.ev y).app z :=
   rfl
 
 /-- Unfold the definition of comp.

--- a/Mathlib/CategoryTheory/Closed/Enrichment.lean
+++ b/Mathlib/CategoryTheory/Closed/Enrichment.lean
@@ -67,52 +67,35 @@ This exists to streamline the proof of MonoidalClosed.assoc -/
 @[simp]
 lemma comp_eq (x y z : V) : comp x y z = curry (compTranspose x y z) := rfl
 
-/-- Associativity of V-composition. Used to prove that V is enriched in itself. -/
-theorem assoc (x y z w : V) : (α_ _ _ _).inv ≫ comp x y z ▷ _ ≫ comp x z w =
-    _ ◁ comp y z w ≫ comp x y w := by
-  apply uncurry_injective;
-  simp only [uncurry_natural_left, comp_eq]
-  rw [uncurry_curry, uncurry_curry]; dsimp
-  rw [associator_inv_naturality_middle_assoc]
-  rw [← comp_whiskerRight_assoc]
-  rw [← uncurry_eq, uncurry_curry]
-  rw [associator_inv_naturality_right_assoc]
-  rw [whisker_exchange_assoc]
-  rw [← uncurry_eq, uncurry_curry]
-  simp only [comp_whiskerRight, tensorLeft_obj, Category.assoc, pentagon_inv_assoc,
-    whiskerRight_tensor, Iso.hom_inv_id_assoc]
-
-/-- Left unitality of V-composition. Used to prove that V is enriched in itself. -/
-theorem id_comp (x y : V) : (λ_ _).inv ≫ id x ▷ (ihom x).obj y ≫ comp x x y = 𝟙 _ := by
-  apply uncurry_injective; simp only [uncurry_natural_left, comp_eq, id_eq]
-  rw [uncurry_curry]
-  rw [whisker_assoc_symm];
-  simp only [compTranpose_eq, Category.assoc]
-  rw [Iso.hom_inv_id_assoc]
-  rw [← comp_whiskerRight_assoc]
-  rw [← uncurry_eq, uncurry_curry]
-  simp only [Functor.id_obj, triangle_assoc_comp_right_assoc, whiskerLeft_inv_hom_assoc]
-  exact (uncurry_id_eq_ev x y).symm
-
-/-- Right unitality of V-composition. Used to prove that V is enriched in itself. -/
-theorem comp_id (x y : V) : (ρ_ _).inv ≫ ((ihom x).obj y) ◁ (id y) ≫ (comp x y y) = 𝟙 _ := by
-  apply uncurry_injective; simp only[uncurry_natural_left, comp_eq, id_eq];
-  rw [uncurry_curry]; simp only [compTranpose_eq, Category.assoc];
-  rw [associator_inv_naturality_right_assoc]
-  rw [whisker_exchange_assoc]; dsimp;
-  rw [← uncurry_eq, uncurry_curry];
-  simp only [whiskerLeft_rightUnitor_inv, MonoidalCategory.whiskerRight_id, Category.assoc,
-    Iso.inv_hom_id, Category.comp_id, Iso.hom_inv_id_assoc, Iso.inv_hom_id_assoc]
-  exact (uncurry_id_eq_ev x y).symm
-
 /-- For V closed monoidal, build an instance of V as a V-category -/
 scoped instance : EnrichedCategory V V where
   Hom := fun x => (ihom x).obj
   id := id
   comp := comp
-  id_comp := id_comp
-  comp_id := comp_id
-  assoc := assoc
+  id_comp := fun _ _ => by
+    apply uncurry_injective; simp only [uncurry_natural_left, comp_eq, id_eq]
+    rw [uncurry_curry, whisker_assoc_symm]; simp only [compTranpose_eq, Category.assoc]
+    rw [Iso.hom_inv_id_assoc, ← comp_whiskerRight_assoc, ← uncurry_eq, uncurry_curry]
+    simp only [Functor.id_obj, triangle_assoc_comp_right_assoc, whiskerLeft_inv_hom_assoc]
+    exact (uncurry_id_eq_ev _ _).symm
+  comp_id := fun _ _ => by
+    apply uncurry_injective
+    simp only [uncurry_natural_left, comp_eq, id_eq]
+    rw [uncurry_curry]; simp only [compTranpose_eq, Category.assoc]
+    rw [associator_inv_naturality_right_assoc, whisker_exchange_assoc]; dsimp
+    rw [← uncurry_eq, uncurry_curry]
+    simp only [whiskerLeft_rightUnitor_inv, MonoidalCategory.whiskerRight_id, Category.assoc,
+      Iso.inv_hom_id, Category.comp_id, Iso.hom_inv_id_assoc, Iso.inv_hom_id_assoc]
+    exact (uncurry_id_eq_ev _ _).symm
+  assoc := fun _ _ _ _ => by
+    apply uncurry_injective
+    simp only [uncurry_natural_left, comp_eq]
+    rw [uncurry_curry, uncurry_curry]; dsimp
+    rw [associator_inv_naturality_middle_assoc, ← comp_whiskerRight_assoc,
+      ← uncurry_eq, uncurry_curry, associator_inv_naturality_right_assoc, whisker_exchange_assoc,
+      ← uncurry_eq, uncurry_curry]
+    simp only [comp_whiskerRight, tensorLeft_obj, Category.assoc, pentagon_inv_assoc,
+      whiskerRight_tensor, Iso.hom_inv_id_assoc]
 
 end MonoidalClosed
 

--- a/Mathlib/CategoryTheory/Closed/Enrichment.lean
+++ b/Mathlib/CategoryTheory/Closed/Enrichment.lean
@@ -52,19 +52,16 @@ def comp (x y z : V) := curry (compTranspose x y z)
 
 /-- Unfold the definition of id.
 This exists to streamline the proofs of MonoidalClosed.id_comp and MonoidalClosed.comp_id -/
-@[simp]
 lemma id_eq (x : V) : id x = curry (ρ_ x).hom := rfl
 
 /-- Unfold the definition of compTranspose.
 This exists to streamline the proof of MonoidalClosed.assoc -/
-@[simp]
 lemma compTranpose_eq (x y z : V) : compTranspose x y z = (α_ _ _ _).inv ≫
     (ihom.ev x).app y ▷ _ ≫ (ihom.ev y).app z :=
   rfl
 
 /-- Unfold the definition of comp.
 This exists to streamline the proof of MonoidalClosed.assoc -/
-@[simp]
 lemma comp_eq (x y z : V) : comp x y z = curry (compTranspose x y z) := rfl
 
 /-- For V closed monoidal, build an instance of V as a V-category -/
@@ -90,9 +87,9 @@ scoped instance : EnrichedCategory V V where
   assoc := fun _ _ _ _ => by
     apply uncurry_injective
     simp only [uncurry_natural_left, comp_eq]
-    rw [uncurry_curry, uncurry_curry]; dsimp
-    rw [associator_inv_naturality_middle_assoc, ← comp_whiskerRight_assoc,
-      ← uncurry_eq, uncurry_curry, associator_inv_naturality_right_assoc, whisker_exchange_assoc,
+    rw [uncurry_curry, uncurry_curry]; simp only [compTranpose_eq, Category.assoc]
+    rw [associator_inv_naturality_middle_assoc, ← comp_whiskerRight_assoc]; dsimp
+    rw [← uncurry_eq, uncurry_curry, associator_inv_naturality_right_assoc, whisker_exchange_assoc,
       ← uncurry_eq, uncurry_curry]
     simp only [comp_whiskerRight, tensorLeft_obj, Category.assoc, pentagon_inv_assoc,
       whiskerRight_tensor, Iso.hom_inv_id_assoc]

--- a/Mathlib/CategoryTheory/Closed/Enrichment.lean
+++ b/Mathlib/CategoryTheory/Closed/Enrichment.lean
@@ -115,3 +115,5 @@ instance : EnrichedCategory V V where
   assoc := assoc
 
 end MonoidalClosed
+
+end CategoryTheory

--- a/Mathlib/CategoryTheory/Closed/Enrichment.lean
+++ b/Mathlib/CategoryTheory/Closed/Enrichment.lean
@@ -1,0 +1,117 @@
+/-
+Copyright (c) 2024 Daniel Carranza. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Daniel Carranza
+-/
+import Mathlib.CategoryTheory.Enriched.Basic
+import Mathlib.CategoryTheory.Closed.Monoidal
+
+/-!
+# A closed monoidal category is enriched in itself
+
+From the data of a closed monoidal category V, we define a V-category structure for V
+where the hom-object is given by the internal hom (coming from the closed structure).
+
+The instance is given at the end of the file.
+
+All structure field values are defined separately
+
+In particular, the proofs of associativity and unitality use the following outline:
+  1. Take adjoint transpose on each side of the equality (uncurry_injective)
+  2. Do whatever rewrites/simps are necessary to apply uncurry_curry
+  3. Conclude with simp (+ a possible exact)
+-/
+
+universe u u₁ v w
+
+namespace CategoryTheory
+
+open MonoidalCategory
+
+namespace MonoidalClosed
+
+variable {V : Type u} [Category.{u₁, u} V] [MonoidalCategory V] [MonoidalClosed V]
+
+/-- The V-identity morphism
+  𝟙_ V ⟶ hom(V, v)
+used to equip V with the structure of a V-category -/
+def id (x : V) : 𝟙_ V ⟶ (ihom x).obj x := curry (ρ_ x).hom
+
+/-- The *uncurried* composition morphism
+  x ⊗ (hom(x, y) ⊗ hom(y, z)) ⟶ (x ⊗ hom(x, y)) ⊗ hom(y, z) ⟶ y ⊗ hom(y, z) ⟶ z.
+The V-composition morphism is defined as the adjoint transpose of this map. -/
+def compTranspose (x y z : V) :=
+  (α_ x ((ihom x).obj y) ((ihom y).obj z)).inv ≫
+    (ihom.ev x).app y ▷ ((ihom y).obj z) ≫
+    (ihom.ev y).app z
+
+/-- The V-composition morphism
+  hom(x, y) ⊗ hom(y, z) ⟶ hom(x, z)
+used to equip V with the structure of a V-category -/
+def comp (x y z : V) := curry (compTranspose x y z)
+
+/-- Unfold the definition of id.
+This exists to streamline the proofs of MonoidalClosed.id_comp and MonoidalClosed.comp_id -/
+@[simp]
+lemma id_eq (x : V) : id x = curry (ρ_ x).hom := rfl
+
+/-- Unfold the definition of compTranspose.
+This exists to streamline the proof of MonoidalClosed.assoc -/
+@[simp]
+lemma compTranpose_eq (x y z : V) : compTranspose x y z = (α_ _ _ _).inv ≫
+    (ihom.ev x).app y ▷ _ ≫ (ihom.ev y).app z :=
+  rfl
+
+/-- Unfold the definition of comp.
+This exists to streamline the proof of MonoidalClosed.assoc -/
+@[simp]
+lemma comp_eq (x y z : V) : comp x y z = curry (compTranspose x y z) := rfl
+
+/-- Associativity of V-composition. Used to prove that V is enriched in itself. -/
+theorem assoc (x y z w : V) : (α_ _ _ _).inv ≫ comp x y z ▷ _ ≫ comp x z w =
+    _ ◁ comp y z w ≫ comp x y w := by
+  apply uncurry_injective;
+  simp only [uncurry_natural_left, comp_eq]
+  rw [uncurry_curry, uncurry_curry]; dsimp
+  rw [associator_inv_naturality_middle_assoc]
+  rw [← comp_whiskerRight_assoc]
+  rw [← uncurry_eq, uncurry_curry]
+  rw [associator_inv_naturality_right_assoc]
+  rw [whisker_exchange_assoc]
+  rw [← uncurry_eq, uncurry_curry]
+  simp only [comp_whiskerRight, tensorLeft_obj, Category.assoc, pentagon_inv_assoc,
+    whiskerRight_tensor, Iso.hom_inv_id_assoc]
+
+/-- Left unitality of V-composition. Used to prove that V is enriched in itself. -/
+theorem id_comp (x y : V) : (λ_ _).inv ≫ id x ▷ (ihom x).obj y ≫ comp x x y = 𝟙 _ := by
+  apply uncurry_injective; simp only [uncurry_natural_left, comp_eq, id_eq]
+  rw [uncurry_curry]
+  rw [whisker_assoc_symm];
+  simp only [compTranpose_eq, Category.assoc]
+  rw [Iso.hom_inv_id_assoc]
+  rw [← comp_whiskerRight_assoc]
+  rw [← uncurry_eq, uncurry_curry]
+  simp only [Functor.id_obj, triangle_assoc_comp_right_assoc, whiskerLeft_inv_hom_assoc]
+  exact Eq.symm (uncurry_id_eq_ev x y)
+
+/-- Right unitality of V-composition. Used to prove that V is enriched in itself. -/
+theorem comp_id (x y : V) : (ρ_ _).inv ≫ ((ihom x).obj y) ◁ (id y) ≫ (comp x y y) = 𝟙 _ := by
+  apply uncurry_injective; simp only[uncurry_natural_left, comp_eq, id_eq];
+  rw [uncurry_curry]; simp only [compTranpose_eq, Category.assoc];
+  rw [associator_inv_naturality_right_assoc]
+  rw [whisker_exchange_assoc]; dsimp;
+  rw [← uncurry_eq, uncurry_curry];
+  simp only [whiskerLeft_rightUnitor_inv, MonoidalCategory.whiskerRight_id, Category.assoc,
+    Iso.inv_hom_id, Category.comp_id, Iso.hom_inv_id_assoc, Iso.inv_hom_id_assoc]
+  exact Eq.symm (uncurry_id_eq_ev x y)
+
+/-- For V closed monoidal, build an instance of V as a V-category -/
+instance : EnrichedCategory V V where
+  Hom := fun x => (ihom x).obj
+  id := id
+  comp := comp
+  id_comp := id_comp
+  comp_id := comp_id
+  assoc := assoc
+
+end MonoidalClosed

--- a/Mathlib/CategoryTheory/Closed/Enrichment.lean
+++ b/Mathlib/CategoryTheory/Closed/Enrichment.lean
@@ -33,12 +33,12 @@ namespace MonoidalClosed
 variable {V : Type u} [Category.{u₁, u} V] [MonoidalCategory V] [MonoidalClosed V]
 
 /-- The V-identity morphism
-  𝟙_ V ⟶ hom(V, v)
+  `𝟙_ V ⟶ hom(V, v)`
 used to equip V with the structure of a V-category -/
 def id (x : V) : 𝟙_ V ⟶ (ihom x).obj x := curry (ρ_ x).hom
 
 /-- The *uncurried* composition morphism
-  x ⊗ (hom(x, y) ⊗ hom(y, z)) ⟶ (x ⊗ hom(x, y)) ⊗ hom(y, z) ⟶ y ⊗ hom(y, z) ⟶ z.
+  `x ⊗ (hom(x, y) ⊗ hom(y, z)) ⟶ (x ⊗ hom(x, y)) ⊗ hom(y, z) ⟶ y ⊗ hom(y, z) ⟶ z`.
 The V-composition morphism is defined as the adjoint transpose of this map. -/
 def compTranspose (x y z : V) :=
   (α_ x ((ihom x).obj y) ((ihom y).obj z)).inv ≫
@@ -46,7 +46,7 @@ def compTranspose (x y z : V) :=
     (ihom.ev y).app z
 
 /-- The V-composition morphism
-  hom(x, y) ⊗ hom(y, z) ⟶ hom(x, z)
+  `hom(x, y) ⊗ hom(y, z) ⟶ hom(x, z)`
 used to equip V with the structure of a V-category -/
 def comp (x y z : V) := curry (compTranspose x y z)
 

--- a/Mathlib/CategoryTheory/Closed/Enrichment.lean
+++ b/Mathlib/CategoryTheory/Closed/Enrichment.lean
@@ -92,7 +92,7 @@ theorem id_comp (x y : V) : (λ_ _).inv ≫ id x ▷ (ihom x).obj y ≫ comp x x
   rw [← comp_whiskerRight_assoc]
   rw [← uncurry_eq, uncurry_curry]
   simp only [Functor.id_obj, triangle_assoc_comp_right_assoc, whiskerLeft_inv_hom_assoc]
-  exact Eq.symm (uncurry_id_eq_ev x y)
+  exact (uncurry_id_eq_ev x y).symm
 
 /-- Right unitality of V-composition. Used to prove that V is enriched in itself. -/
 theorem comp_id (x y : V) : (ρ_ _).inv ≫ ((ihom x).obj y) ◁ (id y) ≫ (comp x y y) = 𝟙 _ := by
@@ -103,7 +103,7 @@ theorem comp_id (x y : V) : (ρ_ _).inv ≫ ((ihom x).obj y) ◁ (id y) ≫ (com
   rw [← uncurry_eq, uncurry_curry];
   simp only [whiskerLeft_rightUnitor_inv, MonoidalCategory.whiskerRight_id, Category.assoc,
     Iso.inv_hom_id, Category.comp_id, Iso.hom_inv_id_assoc, Iso.inv_hom_id_assoc]
-  exact Eq.symm (uncurry_id_eq_ev x y)
+  exact (uncurry_id_eq_ev x y).symm
 
 /-- For V closed monoidal, build an instance of V as a V-category -/
 instance : EnrichedCategory V V where

--- a/Mathlib/CategoryTheory/Closed/Enrichment.lean
+++ b/Mathlib/CategoryTheory/Closed/Enrichment.lean
@@ -56,8 +56,8 @@ lemma id_eq (x : V) : id x = curry (ρ_ x).hom := rfl
 
 /-- Unfold the definition of compTranspose.
 This exists to streamline the proof of MonoidalClosed.assoc -/
-lemma compTranpose_eq (x y z : V)
-    : compTranspose x y z = (α_ _ _ _).inv ≫ (ihom.ev x).app y ▷ _ ≫ (ihom.ev y).app z :=
+lemma compTranpose_eq (x y z : V) :
+    compTranspose x y z = (α_ _ _ _).inv ≫ (ihom.ev x).app y ▷ _ ≫ (ihom.ev y).app z :=
   rfl
 
 /-- Unfold the definition of comp.

--- a/Mathlib/CategoryTheory/Closed/Enrichment.lean
+++ b/Mathlib/CategoryTheory/Closed/Enrichment.lean
@@ -106,7 +106,7 @@ theorem comp_id (x y : V) : (ρ_ _).inv ≫ ((ihom x).obj y) ◁ (id y) ≫ (com
   exact (uncurry_id_eq_ev x y).symm
 
 /-- For V closed monoidal, build an instance of V as a V-category -/
-instance : EnrichedCategory V V where
+scoped instance : EnrichedCategory V V where
   Hom := fun x => (ihom x).obj
   id := id
   comp := comp

--- a/Mathlib/CategoryTheory/Closed/Enrichment.lean
+++ b/Mathlib/CategoryTheory/Closed/Enrichment.lean
@@ -72,12 +72,11 @@ scoped instance : EnrichedCategory V V where
   comp := comp
   id_comp _ _ := by
     apply uncurry_injective
-    simp only [uncurry_natural_left, comp_eq, id_eq]
-    rw [uncurry_curry, whisker_assoc_symm]; simp only [compTranspose_eq, Category.assoc]
-    rw [Iso.hom_inv_id_assoc, ← comp_whiskerRight_assoc, ← uncurry_eq, uncurry_curry]
-    simp only [Functor.id_obj, triangle_assoc_comp_right_assoc, whiskerLeft_inv_hom_assoc]
-    exact (uncurry_id_eq_ev _ _).symm
-  comp_id := fun _ _ => by
+    rw [uncurry_natural_left, uncurry_natural_left, comp_eq, uncurry_curry, id_eq, compTranspose_eq,
+      associator_inv_naturality_middle_assoc, ← comp_whiskerRight_assoc, ← uncurry_eq,
+      uncurry_curry, triangle_assoc_comp_right_assoc, whiskerLeft_inv_hom_assoc,
+      uncurry_id_eq_ev _ _]
+  comp_id := fun _ y => by
     apply uncurry_injective
     rw [uncurry_natural_left, uncurry_natural_left, comp_eq, uncurry_curry, compTranspose_eq,
       associator_inv_naturality_right_assoc, ← rightUnitor_tensor_inv_assoc,

--- a/Mathlib/CategoryTheory/Closed/Enrichment.lean
+++ b/Mathlib/CategoryTheory/Closed/Enrichment.lean
@@ -34,11 +34,9 @@ variable {C : Type u} [Category.{v} C] [MonoidalCategory C] [MonoidalClosed C]
 /-- For C closed monoidal, build an instance of C as a C-category -/
 scoped instance : EnrichedCategory C C where
   Hom x := (ihom x).obj
-  id x := @id C _ _ x _
-  comp x y z := @comp C _ _ x y z _ _
-  id_comp x y := @id_comp C _ _ x y _
-  comp_id x y := @comp_id C _ _ x y _ _
-  assoc x y z w := @assoc C _ _ x y z w _ _ _
+  id _ := id _
+  comp _ _ _ := comp _ _ _
+  assoc _ _ _ _ := assoc _ _ _ _
 
 end MonoidalClosed
 

--- a/Mathlib/CategoryTheory/Closed/Enrichment.lean
+++ b/Mathlib/CategoryTheory/Closed/Enrichment.lean
@@ -9,7 +9,7 @@ import Mathlib.CategoryTheory.Closed.Monoidal
 /-!
 # A closed monoidal category is enriched in itself
 
-From the data of a closed monoidal category C, we define a C-category structure for C
+From the data of a closed monoidal category `C`, we define a `C`-category structure for `C`.
 where the hom-object is given by the internal hom (coming from the closed structure).
 
 The instance is given at the end of the file.

--- a/Mathlib/CategoryTheory/Closed/Enrichment.lean
+++ b/Mathlib/CategoryTheory/Closed/Enrichment.lean
@@ -36,7 +36,7 @@ scoped instance : EnrichedCategory C C where
   Hom x := (ihom x).obj
   id x := @id C _ _ x _
   comp x y z := @comp C _ _ x y z _ _
-  id_comp x y := @id_comp C _ _ x y _ _
+  id_comp x y := @id_comp C _ _ x y _
   comp_id x y := @comp_id C _ _ x y _ _
   assoc x y z w := @assoc C _ _ x y z w _ _ _
 

--- a/Mathlib/CategoryTheory/Closed/Enrichment.lean
+++ b/Mathlib/CategoryTheory/Closed/Enrichment.lean
@@ -17,7 +17,7 @@ a `C`-category structure coming from another source (e.g. the type of simplicial
 `SSet.{v}` has an instance of `EnrichedCategory SSet.{v}` as a category of simplicial objects;
 see `AlgebraicTopology/SimplicialCategory/SimplicialObject`).
 
-All structure field values are defined in `Closed/Monoidal`
+All structure field values are defined in `Closed/Monoidal`.
 
 -/
 

--- a/Mathlib/CategoryTheory/Closed/Enrichment.lean
+++ b/Mathlib/CategoryTheory/Closed/Enrichment.lean
@@ -12,8 +12,8 @@ import Mathlib.CategoryTheory.Closed.Monoidal
 From the data of a closed monoidal category `C`, we define a `C`-category structure for `C`.
 where the hom-object is given by the internal hom (coming from the closed structure).
 
-We use `scoped instance` to avoid potential issues where C may also have
-a C-category structure coming from another source (e.g. the type of simplicial sets
+We use `scoped instance` to avoid potential issues where `C` may also have
+a `C`-category structure coming from another source (e.g. the type of simplicial sets
 `SSet.{v}` has an instance of `EnrichedCategory SSet.{v}` as a category of simplicial objects;
 see `AlgebraicTopology/SimplicialCategory/SimplicialObject`).
 

--- a/Mathlib/CategoryTheory/Closed/Enrichment.lean
+++ b/Mathlib/CategoryTheory/Closed/Enrichment.lean
@@ -12,8 +12,6 @@ import Mathlib.CategoryTheory.Closed.Monoidal
 From the data of a closed monoidal category `C`, we define a `C`-category structure for `C`.
 where the hom-object is given by the internal hom (coming from the closed structure).
 
-The instance is given at the end of the file.
-
 We use `scoped instance` to avoid potential issues where C may also have
 a C-category structure coming from another source (e.g. the type of simplicial sets
 `SSet.{v}` has an instance of `EnrichedCategory SSet.{v}` as a category of simplicial objects;

--- a/Mathlib/CategoryTheory/Closed/Enrichment.lean
+++ b/Mathlib/CategoryTheory/Closed/Enrichment.lean
@@ -71,7 +71,8 @@ scoped instance : EnrichedCategory V V where
   id := id
   comp := comp
   id_comp := fun _ _ => by
-    apply uncurry_injective; simp only [uncurry_natural_left, comp_eq, id_eq]
+    apply uncurry_injective
+    simp only [uncurry_natural_left, comp_eq, id_eq]
     rw [uncurry_curry, whisker_assoc_symm]; simp only [compTranpose_eq, Category.assoc]
     rw [Iso.hom_inv_id_assoc, ← comp_whiskerRight_assoc, ← uncurry_eq, uncurry_curry]
     simp only [Functor.id_obj, triangle_assoc_comp_right_assoc, whiskerLeft_inv_hom_assoc]

--- a/Mathlib/CategoryTheory/Closed/Enrichment.lean
+++ b/Mathlib/CategoryTheory/Closed/Enrichment.lean
@@ -67,7 +67,7 @@ lemma comp_eq (x y z : V) : comp x y z = curry (compTranspose x y z) := rfl
 
 /-- For V closed monoidal, build an instance of V as a V-category -/
 scoped instance : EnrichedCategory V V where
-  Hom := fun x => (ihom x).obj
+  Hom x := (ihom x).obj
   id := id
   comp := comp
   id_comp := fun _ _ => by

--- a/Mathlib/CategoryTheory/Closed/Enrichment.lean
+++ b/Mathlib/CategoryTheory/Closed/Enrichment.lean
@@ -79,13 +79,11 @@ scoped instance : EnrichedCategory V V where
     exact (uncurry_id_eq_ev _ _).symm
   comp_id := fun _ _ => by
     apply uncurry_injective
-    simp only [uncurry_natural_left, comp_eq, id_eq]
-    rw [uncurry_curry]; simp only [compTranpose_eq, Category.assoc]
-    rw [associator_inv_naturality_right_assoc, whisker_exchange_assoc]; dsimp
-    rw [← uncurry_eq, uncurry_curry]
-    simp only [whiskerLeft_rightUnitor_inv, MonoidalCategory.whiskerRight_id, Category.assoc,
-      Iso.inv_hom_id, Category.comp_id, Iso.hom_inv_id_assoc, Iso.inv_hom_id_assoc]
-    exact (uncurry_id_eq_ev _ _).symm
+    rw [uncurry_natural_left, uncurry_natural_left, comp_eq, uncurry_curry, compTranspose_eq,
+      associator_inv_naturality_right_assoc, ← rightUnitor_tensor_inv_assoc,
+      whisker_exchange_assoc, ← rightUnitor_inv_naturality_assoc, ← uncurry_id_eq_ev y y,
+      ← uncurry_natural_left]
+    simp [id_eq, uncurry_id_eq_ev]
   assoc := fun _ _ _ _ => by
     apply uncurry_injective
     simp only [uncurry_natural_left, comp_eq]

--- a/Mathlib/CategoryTheory/Closed/Enrichment.lean
+++ b/Mathlib/CategoryTheory/Closed/Enrichment.lean
@@ -40,7 +40,7 @@ def id (x : V) : 𝟙_ V ⟶ (ihom x).obj x := curry (ρ_ x).hom
 /-- The *uncurried* composition morphism
   `x ⊗ (hom(x, y) ⊗ hom(y, z)) ⟶ (x ⊗ hom(x, y)) ⊗ hom(y, z) ⟶ y ⊗ hom(y, z) ⟶ z`.
 The V-composition morphism is defined as the adjoint transpose of this map. -/
-def compTranspose (x y z : V) :=
+def compTranspose (x y z : V) : x ⊗ (ihom x).obj y ⊗ (ihom y).obj z ⟶ z :=
   (α_ x ((ihom x).obj y) ((ihom y).obj z)).inv ≫
     (ihom.ev x).app y ▷ ((ihom y).obj z) ≫
     (ihom.ev y).app z

--- a/Mathlib/CategoryTheory/Closed/Enrichment.lean
+++ b/Mathlib/CategoryTheory/Closed/Enrichment.lean
@@ -9,89 +9,36 @@ import Mathlib.CategoryTheory.Closed.Monoidal
 /-!
 # A closed monoidal category is enriched in itself
 
-From the data of a closed monoidal category V, we define a V-category structure for V
+From the data of a closed monoidal category C, we define a C-category structure for C
 where the hom-object is given by the internal hom (coming from the closed structure).
 
 The instance is given at the end of the file.
 
-All structure field values are defined separately
+We use `scoped instance` to avoid potential issues where V may also have
+a V-category structure coming from another source (e.g. the type of simplicial sets
+`SSet.{v}` also has an instance of `EnrichedCategory SSet.{v}` as a category of simplicial objects;
+see `AlgebraicTopology.SimplicialCategory.SimplicialObject`).
 
-In particular, the proofs of associativity and unitality use the following outline:
-  1. Take adjoint transpose on each side of the equality (uncurry_injective)
-  2. Do whatever rewrites/simps are necessary to apply uncurry_curry
-  3. Conclude with simp (+ a possible exact)
+All structure field values are defined in `Monoidal.Closed`
+
 -/
 
-universe u u₁ v w
+universe u v
 
 namespace CategoryTheory
 
-open MonoidalCategory
-
 namespace MonoidalClosed
 
-variable {V : Type u} [Category.{u₁, u} V] [MonoidalCategory V] [MonoidalClosed V]
-
-/-- The V-identity morphism
-  `𝟙_ V ⟶ hom(V, v)`
-used to equip V with the structure of a V-category -/
-def id (x : V) : 𝟙_ V ⟶ (ihom x).obj x := curry (ρ_ x).hom
-
-/-- The *uncurried* composition morphism
-  `x ⊗ (hom(x, y) ⊗ hom(y, z)) ⟶ (x ⊗ hom(x, y)) ⊗ hom(y, z) ⟶ y ⊗ hom(y, z) ⟶ z`.
-The V-composition morphism will be defined as the adjoint transpose of this map. -/
-def compTranspose (x y z : V) : x ⊗ (ihom x).obj y ⊗ (ihom y).obj z ⟶ z :=
-  (α_ x ((ihom x).obj y) ((ihom y).obj z)).inv ≫
-    (ihom.ev x).app y ▷ ((ihom y).obj z) ≫
-    (ihom.ev y).app z
-
-/-- The V-composition morphism
-  `hom(x, y) ⊗ hom(y, z) ⟶ hom(x, z)`
-used to equip V with the structure of a V-category -/
-def comp (x y z : V) : (ihom x).obj y ⊗ (ihom y).obj z ⟶ (ihom x).obj z :=
-  curry (compTranspose x y z)
-
-/-- Unfold the definition of id.
-This exists to streamline the proofs of MonoidalClosed.id_comp and MonoidalClosed.comp_id -/
-lemma id_eq (x : V) : id x = curry (ρ_ x).hom := rfl
-
-/-- Unfold the definition of compTranspose.
-This exists to streamline the proof of MonoidalClosed.assoc -/
-lemma compTranspose_eq (x y z : V) :
-    compTranspose x y z = (α_ _ _ _).inv ≫ (ihom.ev x).app y ▷ _ ≫ (ihom.ev y).app z :=
-  rfl
-
-/-- Unfold the definition of comp.
-This exists to streamline the proof of MonoidalClosed.assoc -/
-lemma comp_eq (x y z : V) : comp x y z = curry (compTranspose x y z) := rfl
+variable {C : Type u} [Category.{v} C] [MonoidalCategory C] [MonoidalClosed C]
 
 /-- For V closed monoidal, build an instance of V as a V-category -/
-scoped instance : EnrichedCategory V V where
+scoped instance : EnrichedCategory C C where
   Hom x := (ihom x).obj
-  id := id
-  comp := comp
-  id_comp _ _ := by
-    apply uncurry_injective
-    rw [uncurry_natural_left, uncurry_natural_left, comp_eq, uncurry_curry, id_eq, compTranspose_eq,
-      associator_inv_naturality_middle_assoc, ← comp_whiskerRight_assoc, ← uncurry_eq,
-      uncurry_curry, triangle_assoc_comp_right_assoc, whiskerLeft_inv_hom_assoc,
-      uncurry_id_eq_ev _ _]
-  comp_id := fun _ y => by
-    apply uncurry_injective
-    rw [uncurry_natural_left, uncurry_natural_left, comp_eq, uncurry_curry, compTranspose_eq,
-      associator_inv_naturality_right_assoc, ← rightUnitor_tensor_inv_assoc,
-      whisker_exchange_assoc, ← rightUnitor_inv_naturality_assoc, ← uncurry_id_eq_ev y y,
-      ← uncurry_natural_left]
-    simp [id_eq, uncurry_id_eq_ev]
-  assoc := fun _ _ _ _ => by
-    apply uncurry_injective
-    simp only [uncurry_natural_left, comp_eq]
-    rw [uncurry_curry, uncurry_curry]; simp only [compTranspose_eq, Category.assoc]
-    rw [associator_inv_naturality_middle_assoc, ← comp_whiskerRight_assoc]; dsimp
-    rw [← uncurry_eq, uncurry_curry, associator_inv_naturality_right_assoc, whisker_exchange_assoc,
-      ← uncurry_eq, uncurry_curry]
-    simp only [comp_whiskerRight, tensorLeft_obj, Category.assoc, pentagon_inv_assoc,
-      whiskerRight_tensor, Iso.hom_inv_id_assoc]
+  id x := @id C _ _ x _
+  comp x y z := @comp C _ _ x y z _ _
+  id_comp x y := @id_comp C _ _ x y _ _
+  comp_id x y := @comp_id C _ _ x y _ _
+  assoc x y z w := @assoc C _ _ x y z w _ _ _
 
 end MonoidalClosed
 

--- a/Mathlib/CategoryTheory/Closed/Enrichment.lean
+++ b/Mathlib/CategoryTheory/Closed/Enrichment.lean
@@ -48,7 +48,7 @@ def compTranspose (x y z : V) : x ⊗ (ihom x).obj y ⊗ (ihom y).obj z ⟶ z :=
 /-- The V-composition morphism
   `hom(x, y) ⊗ hom(y, z) ⟶ hom(x, z)`
 used to equip V with the structure of a V-category -/
-def comp (x y z : V) : (ihom x).obj y ⊗ (ihom y).obj z ⟶ (ihom x).obj z := 
+def comp (x y z : V) : (ihom x).obj y ⊗ (ihom y).obj z ⟶ (ihom x).obj z :=
   curry (compTranspose x y z)
 
 /-- Unfold the definition of id.
@@ -73,7 +73,7 @@ scoped instance : EnrichedCategory V V where
   id_comp _ _ := by
     apply uncurry_injective
     simp only [uncurry_natural_left, comp_eq, id_eq]
-    rw [uncurry_curry, whisker_assoc_symm]; simp only [compTranpose_eq, Category.assoc]
+    rw [uncurry_curry, whisker_assoc_symm]; simp only [compTranspose_eq, Category.assoc]
     rw [Iso.hom_inv_id_assoc, ← comp_whiskerRight_assoc, ← uncurry_eq, uncurry_curry]
     simp only [Functor.id_obj, triangle_assoc_comp_right_assoc, whiskerLeft_inv_hom_assoc]
     exact (uncurry_id_eq_ev _ _).symm
@@ -87,7 +87,7 @@ scoped instance : EnrichedCategory V V where
   assoc := fun _ _ _ _ => by
     apply uncurry_injective
     simp only [uncurry_natural_left, comp_eq]
-    rw [uncurry_curry, uncurry_curry]; simp only [compTranpose_eq, Category.assoc]
+    rw [uncurry_curry, uncurry_curry]; simp only [compTranspose_eq, Category.assoc]
     rw [associator_inv_naturality_middle_assoc, ← comp_whiskerRight_assoc]; dsimp
     rw [← uncurry_eq, uncurry_curry, associator_inv_naturality_right_assoc, whisker_exchange_assoc,
       ← uncurry_eq, uncurry_curry]

--- a/Mathlib/CategoryTheory/Closed/Enrichment.lean
+++ b/Mathlib/CategoryTheory/Closed/Enrichment.lean
@@ -48,7 +48,7 @@ def compTranspose (x y z : V) : x ⊗ (ihom x).obj y ⊗ (ihom y).obj z ⟶ z :=
 /-- The V-composition morphism
   `hom(x, y) ⊗ hom(y, z) ⟶ hom(x, z)`
 used to equip V with the structure of a V-category -/
-def comp (x y z : V) : (ihom x).obj y ⊗ (ihom y).obj z ⟶ (ihom x).obj z := 
+def comp (x y z : V) : (ihom x).obj y ⊗ (ihom y).obj z ⟶ (ihom x).obj z :=
   curry (compTranspose x y z)
 
 /-- Unfold the definition of id.

--- a/Mathlib/CategoryTheory/Closed/Enrichment.lean
+++ b/Mathlib/CategoryTheory/Closed/Enrichment.lean
@@ -48,7 +48,8 @@ def compTranspose (x y z : V) :=
 /-- The V-composition morphism
   `hom(x, y) ⊗ hom(y, z) ⟶ hom(x, z)`
 used to equip V with the structure of a V-category -/
-def comp (x y z : V) := curry (compTranspose x y z)
+def comp (x y z : V) : (ihom x).obj y ⊗ (ihom y).obj z ⟶ (ihom x).obj z := 
+  curry (compTranspose x y z)
 
 /-- Unfold the definition of id.
 This exists to streamline the proofs of MonoidalClosed.id_comp and MonoidalClosed.comp_id -/

--- a/Mathlib/CategoryTheory/Closed/Enrichment.lean
+++ b/Mathlib/CategoryTheory/Closed/Enrichment.lean
@@ -57,7 +57,7 @@ lemma id_eq (x : V) : id x = curry (ρ_ x).hom := rfl
 
 /-- Unfold the definition of compTranspose.
 This exists to streamline the proof of MonoidalClosed.assoc -/
-lemma compTranpose_eq (x y z : V) :
+lemma compTranspose_eq (x y z : V) :
     compTranspose x y z = (α_ _ _ _).inv ≫ (ihom.ev x).app y ▷ _ ≫ (ihom.ev y).app z :=
   rfl
 

--- a/Mathlib/CategoryTheory/Closed/Enrichment.lean
+++ b/Mathlib/CategoryTheory/Closed/Enrichment.lean
@@ -31,7 +31,7 @@ namespace MonoidalClosed
 
 variable {C : Type u} [Category.{v} C] [MonoidalCategory C] [MonoidalClosed C]
 
-/-- For C closed monoidal, build an instance of C as a C-category -/
+/-- For `C` closed monoidal, build an instance of `C` as a `C`-category -/
 scoped instance : EnrichedCategory C C where
   Hom x := (ihom x).obj
   id _ := id _

--- a/Mathlib/CategoryTheory/Closed/Enrichment.lean
+++ b/Mathlib/CategoryTheory/Closed/Enrichment.lean
@@ -39,7 +39,7 @@ def id (x : V) : 𝟙_ V ⟶ (ihom x).obj x := curry (ρ_ x).hom
 
 /-- The *uncurried* composition morphism
   `x ⊗ (hom(x, y) ⊗ hom(y, z)) ⟶ (x ⊗ hom(x, y)) ⊗ hom(y, z) ⟶ y ⊗ hom(y, z) ⟶ z`.
-The V-composition morphism is defined as the adjoint transpose of this map. -/
+The V-composition morphism will be defined as the adjoint transpose of this map. -/
 def compTranspose (x y z : V) : x ⊗ (ihom x).obj y ⊗ (ihom y).obj z ⟶ z :=
   (α_ x ((ihom x).obj y) ((ihom y).obj z)).inv ≫
     (ihom.ev x).app y ▷ ((ihom y).obj z) ≫

--- a/Mathlib/CategoryTheory/Closed/Enrichment.lean
+++ b/Mathlib/CategoryTheory/Closed/Enrichment.lean
@@ -70,7 +70,7 @@ scoped instance : EnrichedCategory V V where
   Hom x := (ihom x).obj
   id := id
   comp := comp
-  id_comp := fun _ _ => by
+  id_comp _ _ := by
     apply uncurry_injective
     simp only [uncurry_natural_left, comp_eq, id_eq]
     rw [uncurry_curry, whisker_assoc_symm]; simp only [compTranpose_eq, Category.assoc]

--- a/Mathlib/CategoryTheory/Closed/Enrichment.lean
+++ b/Mathlib/CategoryTheory/Closed/Enrichment.lean
@@ -14,12 +14,12 @@ where the hom-object is given by the internal hom (coming from the closed struct
 
 The instance is given at the end of the file.
 
-We use `scoped instance` to avoid potential issues where V may also have
-a V-category structure coming from another source (e.g. the type of simplicial sets
-`SSet.{v}` also has an instance of `EnrichedCategory SSet.{v}` as a category of simplicial objects;
-see `AlgebraicTopology.SimplicialCategory.SimplicialObject`).
+We use `scoped instance` to avoid potential issues where C may also have
+a C-category structure coming from another source (e.g. the type of simplicial sets
+`SSet.{v}` has an instance of `EnrichedCategory SSet.{v}` as a category of simplicial objects;
+see `AlgebraicTopology/SimplicialCategory/SimplicialObject`).
 
-All structure field values are defined in `Monoidal.Closed`
+All structure field values are defined in `Closed/Monoidal`
 
 -/
 
@@ -31,7 +31,7 @@ namespace MonoidalClosed
 
 variable {C : Type u} [Category.{v} C] [MonoidalCategory C] [MonoidalClosed C]
 
-/-- For V closed monoidal, build an instance of V as a V-category -/
+/-- For C closed monoidal, build an instance of C as a C-category -/
 scoped instance : EnrichedCategory C C where
   Hom x := (ihom x).obj
   id x := @id C _ _ x _

--- a/Mathlib/CategoryTheory/Closed/Monoidal.lean
+++ b/Mathlib/CategoryTheory/Closed/Monoidal.lean
@@ -306,42 +306,42 @@ end OfEquiv
 
 -- A closed monoidal category C is always enriched over itself.
 -- This section contains the necessary definitions and equalities to endow C with
--- the structure of a C-category.
+-- the structure of a C-category, while the instance itself is defined in `Closed/Enrichment`.
 -- In particular, we only assume the necessary instances of `Closed x`, rather than assuming
 -- C comes with an instance of `MonoidalClosed`
 section Enriched
 
-/-- The V-identity morphism
-  `𝟙_ V ⟶ hom(V, v)`
-used to equip V with the structure of a V-category -/
+/-- The C-identity morphism
+  `𝟙_ C ⟶ hom(x, x)`
+used to equip C with the structure of a C-category -/
 def id (x : C) [Closed x] : 𝟙_ C ⟶ (ihom x).obj x := curry (ρ_ x).hom
 
 /-- The *uncurried* composition morphism
   `x ⊗ (hom(x, y) ⊗ hom(y, z)) ⟶ (x ⊗ hom(x, y)) ⊗ hom(y, z) ⟶ y ⊗ hom(y, z) ⟶ z`.
-The V-composition morphism will be defined as the adjoint transpose of this map. -/
+The C-composition morphism will be defined as the adjoint transpose of this map. -/
 def compTranspose (x y z : C) [Closed x] [Closed y] : x ⊗ (ihom x).obj y ⊗ (ihom y).obj z ⟶ z :=
   (α_ x ((ihom x).obj y) ((ihom y).obj z)).inv ≫
     (ihom.ev x).app y ▷ ((ihom y).obj z) ≫
     (ihom.ev y).app z
 
-/-- The V-composition morphism
+/-- The C-composition morphism
   `hom(x, y) ⊗ hom(y, z) ⟶ hom(x, z)`
-used to equip V with the structure of a V-category -/
+used to equip C with the structure of a C-category -/
 def comp (x y z : C) [Closed x] [Closed y] : (ihom x).obj y ⊗ (ihom y).obj z ⟶ (ihom x).obj z :=
   curry (compTranspose x y z)
 
-/-- Unfold the definition of id.
-This exists to streamline the proofs of MonoidalClosed.id_comp and MonoidalClosed.comp_id -/
+/-- Unfold the definition of `id`.
+This exists to streamline the proofs of `MonoidalClosed.id_comp` and `MonoidalClosed.comp_id` -/
 lemma id_eq (x : C) [Closed x] : id x = curry (ρ_ x).hom := rfl
 
-/-- Unfold the definition of compTranspose.
-This exists to streamline the proof of MonoidalClosed.assoc -/
+/-- Unfold the definition of `compTranspose`.
+This exists to streamline the proof of `MonoidalClosed.assoc` -/
 lemma compTranspose_eq (x y z : C) [Closed x] [Closed y] :
     compTranspose x y z = (α_ _ _ _).inv ≫ (ihom.ev x).app y ▷ _ ≫ (ihom.ev y).app z :=
   rfl
 
-/-- Unfold the definition of comp.
-This exists to streamline the proof of MonoidalClosed.assoc -/
+/-- Unfold the definition of `comp`.
+This exists to streamline the proof of `MonoidalClosed.assoc` -/
 lemma comp_eq (x y z : C) [Closed x] [Closed y] : comp x y z = curry (compTranspose x y z) := rfl
 
 /-!

--- a/Mathlib/CategoryTheory/Closed/Monoidal.lean
+++ b/Mathlib/CategoryTheory/Closed/Monoidal.lean
@@ -344,6 +344,14 @@ lemma compTranspose_eq (x y z : C) [Closed x] [Closed y] :
 This exists to streamline the proof of MonoidalClosed.assoc -/
 lemma comp_eq (x y z : C) [Closed x] [Closed y] : comp x y z = curry (compTranspose x y z) := rfl
 
+/-!
+The proofs of associativity and unitality use the following outline:
+  1. Take adjoint transpose on each side of the equality (uncurry_injective)
+  2. Do whatever rewrites/simps are necessary to apply uncurry_curry
+  3. Conclude with simp (+ a possible exact)
+-/
+
+/-- Left unitality of the enriched structure -/
 lemma id_comp (x y : C) [Closed x] [Closed y] :
     (λ_ ((ihom x).obj y)).inv ≫ id x ▷ _ ≫ comp x x y = 𝟙 _:= by
   apply uncurry_injective
@@ -352,6 +360,7 @@ lemma id_comp (x y : C) [Closed x] [Closed y] :
       uncurry_curry, triangle_assoc_comp_right_assoc, whiskerLeft_inv_hom_assoc,
       uncurry_id_eq_ev _ _]
 
+/-- Right unitality of the enriched structure -/
 lemma comp_id (x y : C) [Closed x] [Closed y] :
     (ρ_ ((ihom x).obj y)).inv ≫ _ ◁ id y ≫ comp x y y = 𝟙 _ := by
   apply uncurry_injective
@@ -362,6 +371,7 @@ lemma comp_id (x y : C) [Closed x] [Closed y] :
   rw [← uncurry_natural_left]
   simp [id_eq, uncurry_id_eq_ev]
 
+/-- Associativity of the enriched structure -/
 lemma assoc (w x y z : C) [Closed w] [Closed x] [Closed y] :
     (α_ _ _ _).inv ≫ comp w x y ▷ _ ≫ comp w y z = _ ◁ comp x y z ≫ comp w x z := by
   apply uncurry_injective

--- a/Mathlib/CategoryTheory/Closed/Monoidal.lean
+++ b/Mathlib/CategoryTheory/Closed/Monoidal.lean
@@ -348,7 +348,7 @@ lemma comp_eq (x y z : C) [Closed x] [Closed y] : comp x y z = curry (compTransp
 The proofs of associativity and unitality use the following outline:
   1. Take adjoint transpose on each side of the equality (uncurry_injective)
   2. Do whatever rewrites/simps are necessary to apply uncurry_curry
-  3. Conclude with simp (+ a possible exact)
+  3. Conclude with simp
 -/
 
 /-- Left unitality of the enriched structure -/

--- a/Mathlib/CategoryTheory/Closed/Monoidal.lean
+++ b/Mathlib/CategoryTheory/Closed/Monoidal.lean
@@ -304,6 +304,77 @@ theorem ofEquiv_uncurry_def {X Y Z : C} :
 
 end OfEquiv
 
+-- A closed monoidal category C is always enriched over itself.
+-- This section contains the necessary definitions and equalities to endow C with
+-- the structure of a C-category.
+-- In particular, we only assume the necessary instances of `Closed x`, rather than assuming
+-- C comes with an instance of `MonoidalClosed`
+section Enriched
+
+/-- The V-identity morphism
+  `𝟙_ V ⟶ hom(V, v)`
+used to equip V with the structure of a V-category -/
+def id (x : C) [Closed x] : 𝟙_ C ⟶ (ihom x).obj x := curry (ρ_ x).hom
+
+/-- The *uncurried* composition morphism
+  `x ⊗ (hom(x, y) ⊗ hom(y, z)) ⟶ (x ⊗ hom(x, y)) ⊗ hom(y, z) ⟶ y ⊗ hom(y, z) ⟶ z`.
+The V-composition morphism will be defined as the adjoint transpose of this map. -/
+def compTranspose (x y z : C) [Closed x] [Closed y] : x ⊗ (ihom x).obj y ⊗ (ihom y).obj z ⟶ z :=
+  (α_ x ((ihom x).obj y) ((ihom y).obj z)).inv ≫
+    (ihom.ev x).app y ▷ ((ihom y).obj z) ≫
+    (ihom.ev y).app z
+
+/-- The V-composition morphism
+  `hom(x, y) ⊗ hom(y, z) ⟶ hom(x, z)`
+used to equip V with the structure of a V-category -/
+def comp (x y z : C) [Closed x] [Closed y] : (ihom x).obj y ⊗ (ihom y).obj z ⟶ (ihom x).obj z :=
+  curry (compTranspose x y z)
+
+/-- Unfold the definition of id.
+This exists to streamline the proofs of MonoidalClosed.id_comp and MonoidalClosed.comp_id -/
+lemma id_eq (x : C) [Closed x] : id x = curry (ρ_ x).hom := rfl
+
+/-- Unfold the definition of compTranspose.
+This exists to streamline the proof of MonoidalClosed.assoc -/
+lemma compTranspose_eq (x y z : C) [Closed x] [Closed y] :
+    compTranspose x y z = (α_ _ _ _).inv ≫ (ihom.ev x).app y ▷ _ ≫ (ihom.ev y).app z :=
+  rfl
+
+/-- Unfold the definition of comp.
+This exists to streamline the proof of MonoidalClosed.assoc -/
+lemma comp_eq (x y z : C) [Closed x] [Closed y] : comp x y z = curry (compTranspose x y z) := rfl
+
+lemma id_comp (x y : C) [Closed x] [Closed y] :
+    (λ_ ((ihom x).obj y)).inv ≫ id x ▷ _ ≫ comp x x y = 𝟙 _:= by
+  apply uncurry_injective
+  rw [uncurry_natural_left, uncurry_natural_left, comp_eq, uncurry_curry, id_eq, compTranspose_eq,
+      associator_inv_naturality_middle_assoc, ← comp_whiskerRight_assoc, ← uncurry_eq,
+      uncurry_curry, triangle_assoc_comp_right_assoc, whiskerLeft_inv_hom_assoc,
+      uncurry_id_eq_ev _ _]
+
+lemma comp_id (x y : C) [Closed x] [Closed y] :
+    (ρ_ ((ihom x).obj y)).inv ≫ _ ◁ id y ≫ comp x y y = 𝟙 _ := by
+  apply uncurry_injective
+  rw [uncurry_natural_left, uncurry_natural_left, comp_eq, uncurry_curry, compTranspose_eq,
+    associator_inv_naturality_right_assoc, ← rightUnitor_tensor_inv_assoc,
+    whisker_exchange_assoc, ← rightUnitor_inv_naturality_assoc, ← uncurry_id_eq_ev y y]
+  simp only [Functor.id_obj]
+  rw [← uncurry_natural_left]
+  simp [id_eq, uncurry_id_eq_ev]
+
+lemma assoc (w x y z : C) [Closed w] [Closed x] [Closed y] :
+    (α_ _ _ _).inv ≫ comp w x y ▷ _ ≫ comp w y z = _ ◁ comp x y z ≫ comp w x z := by
+  apply uncurry_injective
+  simp only [uncurry_natural_left, comp_eq]
+  rw [uncurry_curry, uncurry_curry]; simp only [compTranspose_eq, Category.assoc]
+  rw [associator_inv_naturality_middle_assoc, ← comp_whiskerRight_assoc]; dsimp
+  rw [← uncurry_eq, uncurry_curry, associator_inv_naturality_right_assoc, whisker_exchange_assoc,
+    ← uncurry_eq, uncurry_curry]
+  simp only [comp_whiskerRight, tensorLeft_obj, Category.assoc, pentagon_inv_assoc,
+    whiskerRight_tensor, Iso.hom_inv_id_assoc]
+
+end Enriched
+
 end MonoidalClosed
 attribute [nolint simpNF] CategoryTheory.MonoidalClosed.homEquiv_apply_eq
   CategoryTheory.MonoidalClosed.homEquiv_symm_apply_eq

--- a/Mathlib/CategoryTheory/Closed/Monoidal.lean
+++ b/Mathlib/CategoryTheory/Closed/Monoidal.lean
@@ -313,7 +313,7 @@ section Enriched
 
 /-- The C-identity morphism
   `𝟙_ C ⟶ hom(x, x)`
-used to equip C with the structure of a C-category -/
+used to equip `C` with the structure of a `C`-category -/
 def id (x : C) [Closed x] : 𝟙_ C ⟶ (ihom x).obj x := curry (ρ_ x).hom
 
 /-- The *uncurried* composition morphism

--- a/Mathlib/CategoryTheory/Closed/Monoidal.lean
+++ b/Mathlib/CategoryTheory/Closed/Monoidal.lean
@@ -321,8 +321,7 @@ def id (x : C) [Closed x] : 𝟙_ C ⟶ (ihom x).obj x := curry (ρ_ x).hom
 The C-composition morphism will be defined as the adjoint transpose of this map. -/
 def compTranspose (x y z : C) [Closed x] [Closed y] : x ⊗ (ihom x).obj y ⊗ (ihom y).obj z ⟶ z :=
   (α_ x ((ihom x).obj y) ((ihom y).obj z)).inv ≫
-    (ihom.ev x).app y ▷ ((ihom y).obj z) ≫
-    (ihom.ev y).app z
+    (ihom.ev x).app y ▷ ((ihom y).obj z) ≫ (ihom.ev y).app z
 
 /-- The C-composition morphism
   `hom(x, y) ⊗ hom(y, z) ⟶ hom(x, z)`

--- a/Mathlib/CategoryTheory/Closed/Monoidal.lean
+++ b/Mathlib/CategoryTheory/Closed/Monoidal.lean
@@ -318,7 +318,7 @@ def id (x : C) [Closed x] : 𝟙_ C ⟶ (ihom x).obj x := curry (ρ_ x).hom
 
 /-- The *uncurried* composition morphism
   `x ⊗ (hom(x, y) ⊗ hom(y, z)) ⟶ (x ⊗ hom(x, y)) ⊗ hom(y, z) ⟶ y ⊗ hom(y, z) ⟶ z`.
-The C-composition morphism will be defined as the adjoint transpose of this map. -/
+The `C`-composition morphism will be defined as the adjoint transpose of this map. -/
 def compTranspose (x y z : C) [Closed x] [Closed y] : x ⊗ (ihom x).obj y ⊗ (ihom y).obj z ⟶ z :=
   (α_ x ((ihom x).obj y) ((ihom y).obj z)).inv ≫
     (ihom.ev x).app y ▷ ((ihom y).obj z) ≫ (ihom.ev y).app z

--- a/Mathlib/CategoryTheory/Closed/Monoidal.lean
+++ b/Mathlib/CategoryTheory/Closed/Monoidal.lean
@@ -352,7 +352,7 @@ The proofs of associativity and unitality use the following outline:
 -/
 
 /-- Left unitality of the enriched structure -/
-lemma id_comp (x y : C) [Closed x] [Closed y] :
+lemma id_comp (x y : C) [Closed x] :
     (λ_ ((ihom x).obj y)).inv ≫ id x ▷ _ ≫ comp x x y = 𝟙 _:= by
   apply uncurry_injective
   rw [uncurry_natural_left, uncurry_natural_left, comp_eq, uncurry_curry, id_eq, compTranspose_eq,

--- a/Mathlib/CategoryTheory/Closed/Monoidal.lean
+++ b/Mathlib/CategoryTheory/Closed/Monoidal.lean
@@ -323,9 +323,9 @@ def compTranspose (x y z : C) [Closed x] [Closed y] : x ⊗ (ihom x).obj y ⊗ (
   (α_ x ((ihom x).obj y) ((ihom y).obj z)).inv ≫
     (ihom.ev x).app y ▷ ((ihom y).obj z) ≫ (ihom.ev y).app z
 
-/-- The C-composition morphism
+/-- The `C`-composition morphism
   `hom(x, y) ⊗ hom(y, z) ⟶ hom(x, z)`
-used to equip C with the structure of a C-category -/
+used to equip `C` with the structure of a `C`-category -/
 def comp (x y z : C) [Closed x] [Closed y] : (ihom x).obj y ⊗ (ihom y).obj z ⟶ (ihom x).obj z :=
   curry (compTranspose x y z)
 

--- a/Mathlib/CategoryTheory/Closed/Monoidal.lean
+++ b/Mathlib/CategoryTheory/Closed/Monoidal.lean
@@ -352,6 +352,7 @@ The proofs of associativity and unitality use the following outline:
 -/
 
 /-- Left unitality of the enriched structure -/
+@[reassoc (attr := simp)]
 lemma id_comp (x y : C) [Closed x] :
     (λ_ ((ihom x).obj y)).inv ≫ id x ▷ _ ≫ comp x x y = 𝟙 _:= by
   apply uncurry_injective

--- a/Mathlib/CategoryTheory/Closed/Monoidal.lean
+++ b/Mathlib/CategoryTheory/Closed/Monoidal.lean
@@ -374,6 +374,7 @@ lemma comp_id (x y : C) [Closed x] [Closed y] :
   simp [id_eq, uncurry_id_eq_ev]
 
 /-- Associativity of the enriched structure -/
+@[reassoc]
 lemma assoc (w x y z : C) [Closed w] [Closed x] [Closed y] :
     (α_ _ _ _).inv ≫ comp w x y ▷ _ ≫ comp w y z = _ ◁ comp x y z ≫ comp w x z := by
   apply uncurry_injective

--- a/Mathlib/CategoryTheory/Closed/Monoidal.lean
+++ b/Mathlib/CategoryTheory/Closed/Monoidal.lean
@@ -362,6 +362,7 @@ lemma id_comp (x y : C) [Closed x] :
       uncurry_id_eq_ev _ _]
 
 /-- Right unitality of the enriched structure -/
+@[reassoc (attr := simp)]
 lemma comp_id (x y : C) [Closed x] [Closed y] :
     (ρ_ ((ihom x).obj y)).inv ≫ _ ◁ id y ≫ comp x y y = 𝟙 _ := by
   apply uncurry_injective


### PR DESCRIPTION
From a monoidal closed category V, construct an instance of `EnrichedCategory V` on V where the hom-objects are given by the internal homs of the closed structure.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

First time contributor. I am still new to formalization, so I am open any and all suggestions! In particular, the proofs here are a bit long compared to most proofs I see in the library, and I'm not sure if it's couth to use the `@[simp]` attribute for some equalities here.

Remark: As I understand, the type of simplicial sets `SSet.{v}` also has an instance of `EnrichedCategory SSet.{v}` constructed in `AlgebraicTopology/SimplicialCategory/SimplicialObject`. This enrichment comes from viewing `SSet.{v}` as a category of simplicial objects, rather than as a closed monoidal category. I'm still a beginner, but could this cause any issues if a file imports both instances?

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
