### PR TITLE
[Merged by Bors] - CI: add high import percentage changes

### DIFF
--- a/.github/workflows/PR_summary.yml
+++ b/.github/workflows/PR_summary.yml
@@ -71,7 +71,8 @@ jobs:
         [ -n "${high_percentages}" ] && {
           high_percentages=$'\n\n'"${high_percentages}"
           gh pr edit "${PR}" --add-label large-import
-        }
+        } || # otherwise, we remove the label
+          gh pr edit "${PR}" --remove-label large-import
 
         if [ "$(printf '%s' "${importCount}" | wc -l)" -gt 12 ]
         then

--- a/.github/workflows/PR_summary.yml
+++ b/.github/workflows/PR_summary.yml
@@ -67,7 +67,11 @@ jobs:
         high_percentages=$(
           printf '%s\n' "${graphAndHighPercentReports}" | sed -n '/^Import changes exceeding/,$p'
         )
-        [ -n "${high_percentages}" ] && high_percentages=$'\n\n'"${high_percentages}"
+        # if there are files with large increase in transitive imports, then we add the `large-import` label
+        [ -n "${high_percentages}" ] && {
+          high_percentages=$'\n\n'"${high_percentages}"
+          gh pr edit "${PR}" --add-label large-import
+        }
 
         if [ "$(printf '%s' "${importCount}" | wc -l)" -gt 12 ]
         then

--- a/.github/workflows/PR_summary.yml
+++ b/.github/workflows/PR_summary.yml
@@ -68,11 +68,13 @@ jobs:
           printf '%s\n' "${graphAndHighPercentReports}" | sed -n '/^Import changes exceeding/,$p'
         )
         # if there are files with large increase in transitive imports, then we add the `large-import` label
-        [ -n "${high_percentages}" ] && {
+        if [ -n "${high_percentages}" ]
+        then
           high_percentages=$'\n\n'"${high_percentages}"
           gh pr edit "${PR}" --add-label large-import
-        } || # otherwise, we remove the label
+        else # otherwise, we remove the label
           gh pr edit "${PR}" --remove-label large-import
+        fi
 
         if [ "$(printf '%s' "${importCount}" | wc -l)" -gt 12 ]
         then

--- a/.github/workflows/PR_summary.yml
+++ b/.github/workflows/PR_summary.yml
@@ -55,11 +55,19 @@ jobs:
         PR="${{ github.event.pull_request.number }}"
         title="### PR summary"
 
+        graphAndHighPercentReports=$(python ./scripts/import-graph-report.py base.json head.json changed_files.txt)
+
         ## Import count comment
         importCount=$(
-          python ./scripts/import-graph-report.py base.json head.json changed_files.txt
+          printf '%s\n' "${graphAndHighPercentReports}" | sed '/^Import changes exceeding/Q'
           ./scripts/import_trans_difference.sh
         )
+
+        ## High percentage imports
+        high_percentages=$(
+          printf '%s\n' "${graphAndHighPercentReports}" | sed -n '/^Import changes exceeding/,$p'
+        )
+        [ -n "${high_percentages}" ] && high_percentages=$'\n\n'"${high_percentages}"
 
         if [ "$(printf '%s' "${importCount}" | wc -l)" -gt 12 ]
         then
@@ -80,6 +88,6 @@ jobs:
         currentHash="$(git rev-parse HEAD)"
         hashURL="https://github.com/${{ github.repository }}/pull/${{ github.event.pull_request.number }}/commits/${currentHash}"
 
-        message="$(printf '%s [%s](%s)\n\n%s\n\n---\n\n%s\n' "${title}" "$(git rev-parse --short HEAD)" "${hashURL}" "${importCount}" "${declDiff}")"
+        message="$(printf '%s [%s](%s)%s\n\n%s\n\n---\n\n%s\n' "${title}" "$(git rev-parse --short HEAD)" "${hashURL}" "${high_percentages}" "${importCount}" "${declDiff}")"
 
         ./scripts/update_PR_comment.sh "${message}" "${title}" "${PR}"

--- a/scripts/import-graph-report.py
+++ b/scripts/import-graph-report.py
@@ -40,7 +40,7 @@ def compare_counts(base_file, head_file, changed_files_txt):
         diff = head_count - base_count
         percent = (diff / base_count) * 100
         if high_import_threshold < percent:
-            high_pct.append(f'| +{percent:.2f}% | {file} |')
+            high_pct.append(f'| +{percent:.2f}% | `{file}` |')
         if diff < 0:  # Dependencies went down
             changes.append((file, base_count, head_count, diff, percent))
         elif diff > new_files:  # Dependencies went up by more than the number of new files

--- a/scripts/import-graph-report.py
+++ b/scripts/import-graph-report.py
@@ -10,6 +10,8 @@
 import json
 import sys
 
+high_import_threshold = 2
+
 def compare_counts(base_file, head_file, changed_files_txt):
     # Load the counts
     with open(head_file, 'r') as f:
@@ -29,6 +31,7 @@ def compare_counts(base_file, head_file, changed_files_txt):
 
     # Compare the counts
     changes = []
+    high_pct = []
     for file in changed_files:
         base_count = base_counts.get(file, 0)
         head_count = head_counts.get(file, 0)
@@ -36,6 +39,8 @@ def compare_counts(base_file, head_file, changed_files_txt):
             continue
         diff = head_count - base_count
         percent = (diff / base_count) * 100
+        if high_import_threshold < percent:
+            high_pct.append(f'| +{percent:.2f}% | {file} |')
         if diff < 0:  # Dependencies went down
             changes.append((file, base_count, head_count, diff, percent))
         elif diff > new_files:  # Dependencies went up by more than the number of new files
@@ -59,11 +64,19 @@ def compare_counts(base_file, head_file, changed_files_txt):
         message += '\n'.join(messages)
     else:
         message += 'No significant changes to the import graph'
-    return message
+
+    high_pct_report = ''
+    if high_pct:
+        high_pct_report += f'Import changes exceeding {high_import_threshold}%\n\n'
+        high_pct_report += '| %      | File |\n'
+        high_pct_report += '| -      | -    |\n'
+        high_pct_report += '\n'.join(high_pct)
+    return (message, high_pct_report)
 
 if __name__ == '__main__':
     base_file = sys.argv[1]
     head_file = sys.argv[2]
     changed_files_txt = sys.argv[3]
-    message = compare_counts(base_file, head_file, changed_files_txt)
+    (message, high_pct) = compare_counts(base_file, head_file, changed_files_txt)
     print(message)
+    print(high_pct)


### PR DESCRIPTION
This PR adds automation for detecting PRs with a significant increase in transitive imports.

Significant means a single file with a percentage increase of at least 2%.

If there are such files, then the automation adds 
* a table with the import-increased files at the beginning of the `PR summary`;
* the `large-import` label.

If there are no such files, then the bot removes the `large-import` label, if it was present.

The PR summary of this PR shows that there is no change when there are no significant changes in transitive imports.  #17344 shows what happens when such a change is present.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
