### PR TITLE
[Merged by Bors] - feat: golf proof of Fréchet–von Neumann–Jordan theorem

### DIFF
--- a/Mathlib/Analysis/InnerProductSpace/OfNorm.lean
+++ b/Mathlib/Analysis/InnerProductSpace/OfNorm.lean
@@ -5,6 +5,7 @@ Authors: Heather Macbeth
 -/
 import Mathlib.Topology.Algebra.Algebra
 import Mathlib.Analysis.InnerProductSpace.Basic
+import Mathlib.Algebra.Module.LinearMap.Rat
 import Mathlib.Tactic.Module
 
 /-!
@@ -199,39 +200,12 @@ theorem add_left (x y z : E) : inner_ 𝕜 (x + y) z = inner_ 𝕜 x z + inner_ 
   simp only [inner_, map_add, map_sub, map_neg, map_mul, map_ofNat] at H ⊢
   linear_combination H / 8
 
-theorem nat (n : ℕ) (x y : E) : inner_ 𝕜 ((n : 𝕜) • x) y = (n : 𝕜) * inner_ 𝕜 x y := by
-  induction' n with n ih
-  · simp only [inner_, zero_sub, Nat.cast_zero, zero_mul,
-      eq_self_iff_true, zero_smul, zero_add, mul_zero, sub_self, norm_neg, smul_zero]
-  · simp only [Nat.cast_succ, add_smul, one_smul]
-    rw [add_left, ih, add_mul, one_mul]
-
-private theorem nat_prop (r : ℕ) : innerProp' E (r : 𝕜) := fun x y => by
-  simp only [map_natCast]; exact nat r x y
-
-private theorem int_prop (n : ℤ) : innerProp' E (n : 𝕜) := by
-  intro x y
-  rw [← n.sign_mul_natAbs]
-  simp only [Int.cast_natCast, map_natCast, map_intCast, Int.cast_mul, map_mul, mul_smul]
-  obtain hn | rfl | hn := lt_trichotomy n 0
-  · rw [Int.sign_eq_neg_one_of_neg hn, innerProp_neg_one ((n.natAbs : 𝕜) • x), nat]
-    simp only [map_neg, neg_mul, one_mul, mul_eq_mul_left_iff, Int.natAbs_eq_zero,
-      eq_self_iff_true, Int.cast_one, map_one, neg_inj, Nat.cast_eq_zero, Int.cast_neg]
-  · simp only [inner_, Int.cast_zero, zero_sub, Nat.cast_zero, zero_mul,
-      eq_self_iff_true, Int.sign_zero, zero_smul, zero_add, mul_zero, smul_zero,
-      sub_self, norm_neg, Int.natAbs_zero]
-  · rw [Int.sign_eq_one_of_pos hn]
-    simp only [one_mul, mul_eq_mul_left_iff, Int.natAbs_eq_zero, eq_self_iff_true,
-      Int.cast_one, one_smul, Nat.cast_eq_zero, nat]
-
 private theorem rat_prop (r : ℚ) : innerProp' E (r : 𝕜) := by
   intro x y
-  have : (r.den : 𝕜) ≠ 0 := by
-    haveI : CharZero 𝕜 := RCLike.charZero_rclike
-    exact mod_cast r.pos.ne'
-  rw [← r.num_div_den, ← mul_right_inj' this, ← nat r.den _ y, smul_smul, Rat.cast_div]
-  simp only [map_natCast, Rat.cast_natCast, map_intCast, Rat.cast_intCast, map_div₀]
-  rw [← mul_assoc, mul_div_cancel₀ _ this, int_prop _ x, map_intCast]
+  let hom : 𝕜 →ₗ[ℚ] 𝕜 := AddMonoidHom.toRatLinearMap <|
+    AddMonoidHom.mk' (fun r ↦ inner_ 𝕜 (r • x) y) <| fun a b ↦ by
+      simpa [add_smul] using add_left (a • x) (b • x) y
+  simpa [hom, Rat.smul_def] using map_smul hom r 1
 
 private theorem real_prop (r : ℝ) : innerProp' E (r : 𝕜) := by
   intro x y
@@ -244,7 +218,8 @@ private theorem real_prop (r : ℝ) : innerProp' E (r : 𝕜) := by
 
 private theorem I_prop : innerProp' E (I : 𝕜) := by
   by_cases hI : (I : 𝕜) = 0
-  · rw [hI, ← Nat.cast_zero]; exact nat_prop _
+  · rw [hI]
+    simpa using real_prop (𝕜 := 𝕜) 0
   intro x y
   have hI' : (-I : 𝕜) * I = 1 := by rw [← inv_I, inv_mul_cancel₀ hI]
   rw [conj_I, inner_, inner_, mul_left_comm]

--- a/Mathlib/Analysis/InnerProductSpace/OfNorm.lean
+++ b/Mathlib/Analysis/InnerProductSpace/OfNorm.lean
@@ -106,10 +106,10 @@ theorem _root_.Continuous.inner_ {f g : ℝ → E} (hf : Continuous f) (hg : Con
 
 theorem inner_.norm_sq (x : E) : ‖x‖ ^ 2 = re (inner_ 𝕜 x x) := by
   simp only [inner_, normSq_apply, ofNat_re, ofNat_im, map_sub, map_add, map_zero, map_mul,
-    ofReal_re, ofReal_im, mul_re, inv_re,  mul_im, I_re, inv_im]
+    ofReal_re, ofReal_im, mul_re, inv_re, mul_im, I_re, inv_im]
+  have h₁ : ‖x - x‖ = 0 := by simp
   have h₂ : ‖x + x‖ = 2 * ‖x‖ := by rw [← two_smul 𝕜, norm_smul, RCLike.norm_two]
-  have h₃ : ‖x - x‖ = 0 := by simp
-  rw [h₂, h₃]
+  rw [h₁, h₂]
   ring
 
 theorem inner_.conj_symm (x y : E) : conj (inner_ 𝕜 y x) = inner_ 𝕜 x y := by
@@ -118,11 +118,7 @@ theorem inner_.conj_symm (x y : E) : conj (inner_ 𝕜 y x) = inner_ 𝕜 x y :=
   by_cases hI : (I : 𝕜) = 0
   · simp only [hI, neg_zero, zero_mul]
   have hI' := I_mul_I_of_nonzero hI
-  -- Porting note: this replaces `norm_I_of_ne_zero` which does not exist in Lean 4
-  have : ‖(I : 𝕜)‖ = 1 := by
-    rw [← mul_self_inj_of_nonneg (norm_nonneg I) zero_le_one, one_mul, ← norm_mul,
-      hI', norm_neg, norm_one]
-  have I_smul (v : E) : ‖(I:𝕜) • v‖ = ‖v‖ := by rw [norm_smul, this, one_mul]
+  have I_smul (v : E) : ‖(I : 𝕜) • v‖ = ‖v‖ := by rw [norm_smul, norm_I_of_ne_zero hI, one_mul]
   have h₁ : ‖(I : 𝕜) • y - x‖ = ‖(I : 𝕜) • x + y‖ := by
     convert I_smul ((I : 𝕜) • x + y) using 2
     linear_combination (norm := module) congr(-$hI' • x)
@@ -144,7 +140,7 @@ private theorem add_left_aux2 (x y z : E) : ‖2 • x + y‖ * ‖2 • x + y�
   convert parallelogram_identity (x + y - z) (x + z) using 4 <;> abel
 
 private theorem add_left_aux3 (y z : E) :
-    ‖2 • z + y‖ * ‖2 • z + y‖ + ‖y‖ * ‖y‖ = 2 * (‖y + z‖ * ‖y + z‖ + ‖z‖ * ‖z‖)  := by
+    ‖2 • z + y‖ * ‖2 • z + y‖ + ‖y‖ * ‖y‖ = 2 * (‖y + z‖ * ‖y + z‖ + ‖z‖ * ‖z‖) := by
   convert parallelogram_identity (y + z) z using 4 <;> abel
 
 private theorem add_left_aux4 (y z : E) :

--- a/Mathlib/Analysis/InnerProductSpace/OfNorm.lean
+++ b/Mathlib/Analysis/InnerProductSpace/OfNorm.lean
@@ -99,15 +99,13 @@ variable {E}
 
 theorem innerProp_neg_one : innerProp' E ((-1 : ℤ) : 𝕜) := by
   intro x y
-  simp only [inner_, neg_mul_eq_neg_mul, one_mul, Int.cast_one, one_smul, RingHom.map_one, map_neg,
-    Int.cast_neg, neg_smul, neg_one_mul]
-  rw [neg_mul_comm]
-  congr 1
-  have h₁ : ‖-x - y‖ = ‖x + y‖ := by rw [← neg_add', norm_neg]
-  have h₂ : ‖-x + y‖ = ‖x - y‖ := by rw [← neg_sub, norm_neg, sub_eq_neg_add]
-  have h₃ : ‖(I : 𝕜) • -x + y‖ = ‖(I : 𝕜) • x - y‖ := by
-    rw [← neg_sub, norm_neg, sub_eq_neg_add, ← smul_neg]
-  have h₄ : ‖(I : 𝕜) • -x - y‖ = ‖(I : 𝕜) • x + y‖ := by rw [smul_neg, ← neg_add', norm_neg]
+  simp only [inner_, map_one, map_neg, Int.cast_neg, Int.cast_one]
+  have h₁ : ‖(-1 : 𝕜) • x - y‖ = ‖x + y‖ := by convert norm_neg (x + y) using 2; module
+  have h₂ : ‖(-1 : 𝕜) • x + y‖ = ‖x - y‖ := by convert norm_neg (x - y) using 2; module
+  have h₃ : ‖(I : 𝕜) • (-1 : 𝕜) • x + y‖ = ‖(I : 𝕜) • x - y‖ := by
+    convert norm_neg ((I : 𝕜) • x - y) using 2; module
+  have h₄ : ‖(I : 𝕜) • (-1 : 𝕜) • x - y‖ = ‖(I : 𝕜) • x + y‖ := by
+    convert norm_neg ((I : 𝕜) • x + y) using 2; module
   rw [h₁, h₂, h₃, h₄]
   ring
 
@@ -117,119 +115,88 @@ theorem _root_.Continuous.inner_ {f g : ℝ → E} (hf : Continuous f) (hg : Con
   fun_prop
 
 theorem inner_.norm_sq (x : E) : ‖x‖ ^ 2 = re (inner_ 𝕜 x x) := by
-  simp only [inner_]
-  have h₁ : RCLike.normSq (4 : 𝕜) = 16 := by
-    have : ((4 : ℝ) : 𝕜) = (4 : 𝕜) := by norm_cast
-    rw [← this, normSq_eq_def', RCLike.norm_of_nonneg (by norm_num : (0 : ℝ) ≤ 4)]
-    norm_num
+  simp only [inner_, normSq_apply, ofNat_re, ofNat_im, map_sub, map_add, map_zero, map_mul,
+    ofReal_re, ofReal_im, mul_re, inv_re,  mul_im, I_re, inv_im]
   have h₂ : ‖x + x‖ = 2 * ‖x‖ := by rw [← two_smul 𝕜, norm_smul, RCLike.norm_two]
-  simp only [h₁, h₂, algebraMap_eq_ofReal, sub_self, norm_zero, mul_re, inv_re, ofNat_re, map_sub,
-    map_add, ofReal_re, ofNat_im, ofReal_im, mul_im, I_re, inv_im]
+  have h₃ : ‖x - x‖ = 0 := by simp
+  rw [h₂, h₃]
   ring
 
-attribute [local simp] map_ofNat in -- use `ofNat` simp theorem with bad keys
 theorem inner_.conj_symm (x y : E) : conj (inner_ 𝕜 y x) = inner_ 𝕜 x y := by
-  simp only [inner_]
-  have h4 : conj (4⁻¹ : 𝕜) = 4⁻¹ := by norm_num
-  rw [map_mul, h4]
-  congr 1
-  simp only [map_sub, map_add, conj_ofReal, map_mul, conj_I]
+  simp only [inner_, map_sub, map_add, map_mul, map_inv₀, map_ofNat, conj_ofReal, conj_I]
   rw [add_comm y x, norm_sub_rev]
   by_cases hI : (I : 𝕜) = 0
   · simp only [hI, neg_zero, zero_mul]
+  have hI' := I_mul_I_of_nonzero hI
   -- Porting note: this replaces `norm_I_of_ne_zero` which does not exist in Lean 4
   have : ‖(I : 𝕜)‖ = 1 := by
     rw [← mul_self_inj_of_nonneg (norm_nonneg I) zero_le_one, one_mul, ← norm_mul,
-      I_mul_I_of_nonzero hI, norm_neg, norm_one]
+      hI', norm_neg, norm_one]
+  have I_smul (v : E) : ‖(I:𝕜) • v‖ = ‖v‖ := by rw [norm_smul, this, one_mul]
   have h₁ : ‖(I : 𝕜) • y - x‖ = ‖(I : 𝕜) • x + y‖ := by
-    trans ‖(I : 𝕜) • ((I : 𝕜) • y - x)‖
-    · rw [norm_smul, this, one_mul]
-    · rw [smul_sub, smul_smul, I_mul_I_of_nonzero hI, neg_one_smul, ← neg_add', add_comm, norm_neg]
+    convert I_smul ((I : 𝕜) • x + y) using 2
+    linear_combination (norm := module) congr(-$hI' • x)
   have h₂ : ‖(I : 𝕜) • y + x‖ = ‖(I : 𝕜) • x - y‖ := by
-    trans ‖(I : 𝕜) • ((I : 𝕜) • y + x)‖
-    · rw [norm_smul, this, one_mul]
-    · rw [smul_add, smul_smul, I_mul_I_of_nonzero hI, neg_one_smul, ← neg_add_eq_sub]
-  rw [h₁, h₂, ← sub_add_eq_add_sub]
-  simp only [neg_mul, sub_eq_add_neg, neg_neg]
+    convert (I_smul ((I : 𝕜) • y + x)).symm using 2
+    linear_combination (norm := module) congr(-$hI' • y)
+  rw [h₁, h₂]
+  ring
 
 variable [InnerProductSpaceable E]
 
-private theorem add_left_aux1 (x y z : E) : ‖x + y + z‖ * ‖x + y + z‖ =
-    (‖2 • x + y‖ * ‖2 • x + y‖ + ‖2 • z + y‖ * ‖2 • z + y‖) / 2 - ‖x - z‖ * ‖x - z‖ := by
-  rw [eq_sub_iff_add_eq, eq_div_iff (two_ne_zero' ℝ), mul_comm _ (2 : ℝ), eq_comm]
-  convert parallelogram_identity (x + y + z) (x - z) using 4 <;> · rw [two_smul]; abel
+private theorem add_left_aux1 (x y z : E) :
+    ‖2 • x + y‖ * ‖2 • x + y‖ + ‖2 • z + y‖ * ‖2 • z + y‖
+    = 2 * (‖x + y + z‖ * ‖x + y + z‖ + ‖x - z‖ * ‖x - z‖) := by
+  convert parallelogram_identity (x + y + z) (x - z) using 4 <;> abel
 
-private theorem add_left_aux2 (x y z : E) : ‖x + y - z‖ * ‖x + y - z‖ =
-    (‖2 • x + y‖ * ‖2 • x + y‖ + ‖y - 2 • z‖ * ‖y - 2 • z‖) / 2 - ‖x + z‖ * ‖x + z‖ := by
-  rw [eq_sub_iff_add_eq, eq_div_iff (two_ne_zero' ℝ), mul_comm _ (2 : ℝ), eq_comm]
-  have h₀ := parallelogram_identity (x + y - z) (x + z)
-  convert h₀ using 4 <;> · rw [two_smul]; abel
-
-private theorem add_left_aux2' (x y z : E) :
-    ‖x + y + z‖ * ‖x + y + z‖ - ‖x + y - z‖ * ‖x + y - z‖ =
-    ‖x + z‖ * ‖x + z‖ - ‖x - z‖ * ‖x - z‖ +
-    (‖2 • z + y‖ * ‖2 • z + y‖ - ‖y - 2 • z‖ * ‖y - 2 • z‖) / 2 := by
-  rw [add_left_aux1, add_left_aux2]; ring
+private theorem add_left_aux2 (x y z : E) : ‖2 • x + y‖ * ‖2 • x + y‖ + ‖y - 2 • z‖ * ‖y - 2 • z‖
+    = 2 * (‖x + y - z‖ * ‖x + y - z‖ + ‖x + z‖ * ‖x + z‖) := by
+  convert parallelogram_identity (x + y - z) (x + z) using 4 <;> abel
 
 private theorem add_left_aux3 (y z : E) :
-    ‖2 • z + y‖ * ‖2 • z + y‖ = 2 * (‖y + z‖ * ‖y + z‖ + ‖z‖ * ‖z‖) - ‖y‖ * ‖y‖ := by
-  apply eq_sub_of_add_eq
-  convert parallelogram_identity (y + z) z using 4 <;> (try rw [two_smul]) <;> abel
+    ‖2 • z + y‖ * ‖2 • z + y‖ + ‖y‖ * ‖y‖ = 2 * (‖y + z‖ * ‖y + z‖ + ‖z‖ * ‖z‖)  := by
+  convert parallelogram_identity (y + z) z using 4 <;> abel
 
 private theorem add_left_aux4 (y z : E) :
-    ‖y - 2 • z‖ * ‖y - 2 • z‖ = 2 * (‖y - z‖ * ‖y - z‖ + ‖z‖ * ‖z‖) - ‖y‖ * ‖y‖ := by
-  apply eq_sub_of_add_eq'
-  have h₀ := parallelogram_identity (y - z) z
-  convert h₀ using 4 <;> (try rw [two_smul]) <;> abel
+    ‖y‖ * ‖y‖ + ‖y - 2 • z‖ * ‖y - 2 • z‖ = 2 * (‖y - z‖ * ‖y - z‖ + ‖z‖ * ‖z‖) := by
+  convert parallelogram_identity (y - z) z using 4 <;> abel
 
-private theorem add_left_aux4' (y z : E) :
-    (‖2 • z + y‖ * ‖2 • z + y‖ - ‖y - 2 • z‖ * ‖y - 2 • z‖) / 2 =
-    ‖y + z‖ * ‖y + z‖ - ‖y - z‖ * ‖y - z‖ := by
-  rw [add_left_aux3, add_left_aux4]; ring
+variable (𝕜)
 
 private theorem add_left_aux5 (x y z : E) :
-    ‖(I : 𝕜) • (x + y) + z‖ * ‖(I : 𝕜) • (x + y) + z‖ =
-    (‖(I : 𝕜) • (2 • x + y)‖ * ‖(I : 𝕜) • (2 • x + y)‖ +
-    ‖(I : 𝕜) • y + 2 • z‖ * ‖(I : 𝕜) • y + 2 • z‖) / 2 -
-    ‖(I : 𝕜) • x - z‖ * ‖(I : 𝕜) • x - z‖ := by
-  rw [eq_sub_iff_add_eq, eq_div_iff (two_ne_zero' ℝ), mul_comm _ (2 : ℝ), eq_comm]
-  have h₀ := parallelogram_identity ((I : 𝕜) • (x + y) + z) ((I : 𝕜) • x - z)
-  convert h₀ using 4 <;> · try simp only [two_smul, smul_add]; abel
+    ‖(I : 𝕜) • (2 • x + y)‖ * ‖(I : 𝕜) • (2 • x + y)‖
+    + ‖(I : 𝕜) • y + 2 • z‖ * ‖(I : 𝕜) • y + 2 • z‖
+    = 2 * (‖(I : 𝕜) • (x + y) + z‖ * ‖(I : 𝕜) • (x + y) + z‖
+    + ‖(I : 𝕜) • x - z‖ * ‖(I : 𝕜) • x - z‖) := by
+  convert parallelogram_identity ((I : 𝕜) • (x + y) + z) ((I : 𝕜) • x - z) using 4 <;> module
 
 private theorem add_left_aux6 (x y z : E) :
-    ‖(I : 𝕜) • (x + y) - z‖ * ‖(I : 𝕜) • (x + y) - z‖ =
     (‖(I : 𝕜) • (2 • x + y)‖ * ‖(I : 𝕜) • (2 • x + y)‖ +
-    ‖(I : 𝕜) • y - 2 • z‖ * ‖(I : 𝕜) • y - 2 • z‖) / 2 -
-    ‖(I : 𝕜) • x + z‖ * ‖(I : 𝕜) • x + z‖ := by
-  rw [eq_sub_iff_add_eq, eq_div_iff (two_ne_zero' ℝ), mul_comm _ (2 : ℝ), eq_comm]
-  have h₀ := parallelogram_identity ((I : 𝕜) • (x + y) - z) ((I : 𝕜) • x + z)
-  convert h₀ using 4 <;> · try simp only [two_smul, smul_add]; abel
+    ‖(I : 𝕜) • y - 2 • z‖ * ‖(I : 𝕜) • y - 2 • z‖)
+    = 2 * (‖(I : 𝕜) • (x + y) - z‖ * ‖(I : 𝕜) • (x + y) - z‖ +
+    ‖(I : 𝕜) • x + z‖ * ‖(I : 𝕜) • x + z‖) := by
+  convert parallelogram_identity ((I : 𝕜) • (x + y) - z) ((I : 𝕜) • x + z) using 4 <;> module
 
 private theorem add_left_aux7 (y z : E) :
-    ‖(I : 𝕜) • y + 2 • z‖ * ‖(I : 𝕜) • y + 2 • z‖ =
-    2 * (‖(I : 𝕜) • y + z‖ * ‖(I : 𝕜) • y + z‖ + ‖z‖ * ‖z‖) - ‖(I : 𝕜) • y‖ * ‖(I : 𝕜) • y‖ := by
-  apply eq_sub_of_add_eq
-  have h₀ := parallelogram_identity ((I : 𝕜) • y + z) z
-  convert h₀ using 4 <;> · (try simp only [two_smul, smul_add]); abel
+    ‖(I : 𝕜) • y + 2 • z‖ * ‖(I : 𝕜) • y + 2 • z‖ + ‖(I : 𝕜) • y‖ * ‖(I : 𝕜) • y‖ =
+    2 * (‖(I : 𝕜) • y + z‖ * ‖(I : 𝕜) • y + z‖ + ‖z‖ * ‖z‖) := by
+  convert parallelogram_identity ((I : 𝕜) • y + z) z using 4 <;> module
 
 private theorem add_left_aux8 (y z : E) :
-    ‖(I : 𝕜) • y - 2 • z‖ * ‖(I : 𝕜) • y - 2 • z‖ =
-    2 * (‖(I : 𝕜) • y - z‖ * ‖(I : 𝕜) • y - z‖ + ‖z‖ * ‖z‖) - ‖(I : 𝕜) • y‖ * ‖(I : 𝕜) • y‖ := by
-  apply eq_sub_of_add_eq'
-  have h₀ := parallelogram_identity ((I : 𝕜) • y - z) z
-  convert h₀ using 4 <;> · (try simp only [two_smul, smul_add]); abel
+    ‖(I : 𝕜) • y‖ * ‖(I : 𝕜) • y‖ + ‖(I : 𝕜) • y - 2 • z‖ * ‖(I : 𝕜) • y - 2 • z‖ =
+    2 * (‖(I : 𝕜) • y - z‖ * ‖(I : 𝕜) • y - z‖ + ‖z‖ * ‖z‖) := by
+  convert parallelogram_identity ((I : 𝕜) • y - z) z using 4 <;> module
+
+variable {𝕜}
 
 theorem add_left (x y z : E) : inner_ 𝕜 (x + y) z = inner_ 𝕜 x z + inner_ 𝕜 y z := by
-  simp only [inner_, ← mul_add]
-  congr
-  simp only [mul_assoc, ← map_mul, add_sub_assoc, ← mul_sub, ← map_sub]
-  rw [add_add_add_comm]
-  simp only [← map_add, ← mul_add]
-  congr
-  · rw [← add_sub_assoc, add_left_aux2', add_left_aux4']
-  · rw [add_left_aux5, add_left_aux6, add_left_aux7, add_left_aux8]
-    simp only [map_sub, map_mul, map_add, div_eq_mul_inv]
-    ring
+  have H_re := congr(- $(add_left_aux1 x y z) + $(add_left_aux2 x y z)
+    + $(add_left_aux3 y z) - $(add_left_aux4 y z))
+  have H_im := congr(- $(add_left_aux5 𝕜 x y z) + $(add_left_aux6 𝕜 x y z)
+      + $(add_left_aux7 𝕜 y z) - $(add_left_aux8 𝕜 y z))
+  have H := congr(𝓚 $H_re + I * 𝓚 $H_im)
+  simp only [inner_, map_add, map_sub, map_neg, map_mul, map_ofNat] at H ⊢
+  linear_combination H / 8
 
 theorem nat (n : ℕ) (x y : E) : inner_ 𝕜 ((n : 𝕜) • x) y = (n : 𝕜) * inner_ 𝕜 x y := by
   induction' n with n ih
@@ -287,9 +254,7 @@ private theorem I_prop : innerProp' E (I : 𝕜) := by
   have h₁ : ‖-x - y‖ = ‖x + y‖ := by rw [← neg_add', norm_neg]
   have h₂ : ‖-x + y‖ = ‖x - y‖ := by rw [← neg_sub, norm_neg, sub_eq_neg_add]
   rw [h₁, h₂]
-  simp only [sub_eq_add_neg, mul_assoc]
-  rw [← neg_mul_eq_neg_mul, ← neg_mul_eq_neg_mul]
-  abel
+  ring
 
 theorem innerProp (r : 𝕜) : innerProp' E r := by
   intro x y

--- a/Mathlib/Analysis/InnerProductSpace/OfNorm.lean
+++ b/Mathlib/Analysis/InnerProductSpace/OfNorm.lean
@@ -108,7 +108,7 @@ theorem inner_.norm_sq (x : E) : ‖x‖ ^ 2 = re (inner_ 𝕜 x x) := by
   simp only [inner_, normSq_apply, ofNat_re, ofNat_im, map_sub, map_add, map_zero, map_mul,
     ofReal_re, ofReal_im, mul_re, inv_re, mul_im, I_re, inv_im]
   have h₁ : ‖x - x‖ = 0 := by simp
-  have h₂ : ‖x + x‖ = 2 * ‖x‖ := by rw [← two_smul 𝕜, norm_smul, RCLike.norm_two]
+  have h₂ : ‖x + x‖ = 2 • ‖x‖ := by convert norm_nsmul 𝕜 2 x using 2; module
   rw [h₁, h₂]
   ring
 
@@ -205,16 +205,12 @@ private theorem I_prop : innerProp' E (I : 𝕜) := by
   · rw [hI]
     simpa using real_prop (𝕜 := 𝕜) 0
   intro x y
-  have hI' : (-I : 𝕜) * I = 1 := by rw [← inv_I, inv_mul_cancel₀ hI]
-  rw [conj_I, inner_, inner_, mul_left_comm]
-  congr 1
-  rw [smul_smul, I_mul_I_of_nonzero hI, neg_one_smul]
-  rw [mul_sub, mul_add, mul_sub, mul_assoc I (𝓚 ‖I • x - y‖), ← mul_assoc (-I) I, hI', one_mul,
-    mul_assoc I (𝓚 ‖I • x + y‖), ← mul_assoc (-I) I, hI', one_mul]
+  have hI' := I_mul_I_of_nonzero hI
+  rw [conj_I, inner_, inner_, mul_left_comm, smul_smul, hI', neg_one_smul]
   have h₁ : ‖-x - y‖ = ‖x + y‖ := by rw [← neg_add', norm_neg]
   have h₂ : ‖-x + y‖ = ‖x - y‖ := by rw [← neg_sub, norm_neg, sub_eq_neg_add]
   rw [h₁, h₂]
-  ring
+  linear_combination (- 𝓚 ‖(I : 𝕜) • x - y‖ ^ 2 + 𝓚 ‖(I : 𝕜) • x + y‖ ^ 2) * hI' / 4
 
 theorem innerProp (r : 𝕜) : innerProp' E r := by
   intro x y

--- a/Mathlib/Analysis/InnerProductSpace/OfNorm.lean
+++ b/Mathlib/Analysis/InnerProductSpace/OfNorm.lean
@@ -99,18 +99,6 @@ private def innerProp' (r : 𝕜) : Prop :=
 
 variable {E}
 
-theorem innerProp_neg_one : innerProp' E ((-1 : ℤ) : 𝕜) := by
-  intro x y
-  simp only [inner_, map_one, map_neg, Int.cast_neg, Int.cast_one]
-  have h₁ : ‖(-1 : 𝕜) • x - y‖ = ‖x + y‖ := by convert norm_neg (x + y) using 2; module
-  have h₂ : ‖(-1 : 𝕜) • x + y‖ = ‖x - y‖ := by convert norm_neg (x - y) using 2; module
-  have h₃ : ‖(I : 𝕜) • (-1 : 𝕜) • x + y‖ = ‖(I : 𝕜) • x - y‖ := by
-    convert norm_neg ((I : 𝕜) • x - y) using 2; module
-  have h₄ : ‖(I : 𝕜) • (-1 : 𝕜) • x - y‖ = ‖(I : 𝕜) • x + y‖ := by
-    convert norm_neg ((I : 𝕜) • x + y) using 2; module
-  rw [h₁, h₂, h₃, h₄]
-  ring
-
 theorem _root_.Continuous.inner_ {f g : ℝ → E} (hf : Continuous f) (hg : Continuous g) :
     Continuous fun x => inner_ 𝕜 (f x) (g x) := by
   unfold inner_

--- a/Mathlib/Analysis/InnerProductSpace/OfNorm.lean
+++ b/Mathlib/Analysis/InnerProductSpace/OfNorm.lean
@@ -5,6 +5,7 @@ Authors: Heather Macbeth
 -/
 import Mathlib.Topology.Algebra.Algebra
 import Mathlib.Analysis.InnerProductSpace.Basic
+import Mathlib.Tactic.Module
 
 /-!
 # Inner product space derived from a norm


### PR DESCRIPTION
Exploit algebraic automation, including the new `module` tactic, more heavily in the proof of the Fréchet–von Neumann–Jordan theorem (i.e., the theorem that a norm satisfying the parallellogram identity comes from an inner product).

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
