### PR TITLE
[Merged by Bors] - feat: `star` commutes with `nnqsmul`

### DIFF
--- a/Mathlib/Algebra/Star/Module.lean
+++ b/Mathlib/Algebra/Star/Module.lean
@@ -82,10 +82,11 @@ rather than `nnqsmul` and `qsmul` because the latter are reserved to the actions
 discoverability.
 -/
 
-@[simp] lemma star_nnrat_smul [AddCommMonoid R] [StarAddMonoid R] [Module ℚ≥0 R] (q : ℚ≥0) (x : R) :
+@[simp high]
+lemma star_nnrat_smul [AddCommMonoid R] [StarAddMonoid R] [Module ℚ≥0 R] (q : ℚ≥0) (x : R) :
     star (q • x) = q • star x := map_nnrat_smul (starAddEquiv : R ≃+ R) _ _
 
-@[simp] lemma star_rat_smul [AddCommGroup R] [StarAddMonoid R] [Module ℚ R] (q : ℚ) (x : R) :
+@[simp high] lemma star_rat_smul [AddCommGroup R] [StarAddMonoid R] [Module ℚ R] (q : ℚ) (x : R) :
     star (q • x) = q • star x :=
   map_rat_smul (starAddEquiv : R ≃+ R) _ _
 

--- a/Mathlib/Algebra/Star/Module.lean
+++ b/Mathlib/Algebra/Star/Module.lean
@@ -75,20 +75,28 @@ theorem star_ratCast_smul [DivisionRing R] [AddCommGroup M] [Module R M] [StarAd
 @[deprecated (since := "2024-04-17")]
 alias star_rat_cast_smul := star_ratCast_smul
 
-@[simp] lemma star_nnqsmul [AddCommMonoid R] [StarAddMonoid R] [Module ℚ≥0 R] (q : ℚ≥0) (x : R) :
+/-!
+Per the naming convention, these two lemmas call `(q • ·)` `nnrat_smul` and `rat_smul` respectively,
+rather than `nnqsmul` and `qsmul` because the latter are reserved to the actions coming from
+`DivisionSemiring` and `DivisionRing`. We provide aliases with `nnqsmul` and `qsmul` for
+discoverability.
+-/
+
+@[simp] lemma star_nnrat_smul [AddCommMonoid R] [StarAddMonoid R] [Module ℚ≥0 R] (q : ℚ≥0) (x : R) :
     star (q • x) = q • star x := map_nnrat_smul (starAddEquiv : R ≃+ R) _ _
 
-@[simp] lemma star_qsmul [AddCommGroup R] [StarAddMonoid R] [Module ℚ R] (q : ℚ) (x : R) :
+@[simp] lemma star_rat_smul [AddCommGroup R] [StarAddMonoid R] [Module ℚ R] (q : ℚ) (x : R) :
     star (q • x) = q • star x :=
   map_rat_smul (starAddEquiv : R ≃+ R) _ _
 
-@[deprecated (since := "2024-10-02")] alias star_rat_smul := star_qsmul
+alias star_nnqsmul := star_nnrat_smul
+alias star_qsmul := star_rat_smul
 
 instance StarAddMonoid.toStarModuleNNRat [AddCommMonoid R] [Module ℚ≥0 R] [StarAddMonoid R] :
-    StarModule ℚ≥0 R where star_smul := star_nnqsmul
+    StarModule ℚ≥0 R where star_smul := star_nnrat_smul
 
 instance StarAddMonoid.toStarModuleRat [AddCommGroup R] [Module ℚ R] [StarAddMonoid R] :
-    StarModule ℚ R where star_smul := star_qsmul
+    StarModule ℚ R where star_smul := star_rat_smul
 
 end SMulLemmas
 

--- a/Mathlib/Algebra/Star/Module.lean
+++ b/Mathlib/Algebra/Star/Module.lean
@@ -75,10 +75,20 @@ theorem star_ratCast_smul [DivisionRing R] [AddCommGroup M] [Module R M] [StarAd
 @[deprecated (since := "2024-04-17")]
 alias star_rat_cast_smul := star_ratCast_smul
 
-@[simp]
-theorem star_rat_smul {R : Type*} [AddCommGroup R] [StarAddMonoid R] [Module ℚ R] (x : R) (n : ℚ) :
-    star (n • x) = n • star x :=
+@[simp] lemma star_nnqsmul [AddCommMonoid R] [StarAddMonoid R] [Module ℚ≥0 R] (q : ℚ≥0) (x : R) :
+    star (q • x) = q • star x := map_nnrat_smul (starAddEquiv : R ≃+ R) _ _
+
+@[simp] lemma star_qsmul [AddCommGroup R] [StarAddMonoid R] [Module ℚ R] (q : ℚ) (x : R) :
+    star (q • x) = q • star x :=
   map_rat_smul (starAddEquiv : R ≃+ R) _ _
+
+@[deprecated (since := "2024-10-02")] alias star_rat_smul := star_qsmul
+
+instance StarAddMonoid.toStarModuleNNRat [AddCommMonoid R] [Module ℚ≥0 R] [StarAddMonoid R] :
+    StarModule ℚ≥0 R where star_smul := star_nnqsmul
+
+instance StarAddMonoid.toStarModuleRat [AddCommGroup R] [Module ℚ R] [StarAddMonoid R] :
+    StarModule ℚ R where star_smul := star_qsmul
 
 end SMulLemmas
 

--- a/Mathlib/Algebra/Star/Module.lean
+++ b/Mathlib/Algebra/Star/Module.lean
@@ -82,15 +82,28 @@ rather than `nnqsmul` and `qsmul` because the latter are reserved to the actions
 discoverability.
 -/
 
+/-- Note that this lemma holds for an arbitrary `ℚ≥0`-action, rather than merely one coming from a
+`DivisionSemiring`. We keep both the `nnqsmul` and `nnrat_smul` naming conventions for
+discoverability. See `star_nnqsmul`. -/
 @[simp high]
 lemma star_nnrat_smul [AddCommMonoid R] [StarAddMonoid R] [Module ℚ≥0 R] (q : ℚ≥0) (x : R) :
     star (q • x) = q • star x := map_nnrat_smul (starAddEquiv : R ≃+ R) _ _
 
+/-- Note that this lemma holds for an arbitrary `ℚ`-action, rather than merely one coming from a
+`DivisionRing`. We keep both the `qsmul` and `rat_smul` naming conventions for discoverability.
+See `star_qsmul`. -/
 @[simp high] lemma star_rat_smul [AddCommGroup R] [StarAddMonoid R] [Module ℚ R] (q : ℚ) (x : R) :
     star (q • x) = q • star x :=
   map_rat_smul (starAddEquiv : R ≃+ R) _ _
 
+/-- Note that this lemma holds for an arbitrary `ℚ≥0`-action, rather than merely one coming from a
+`DivisionSemiring`. We keep both the `nnqsmul` and `nnrat_smul` naming conventions for
+discoverability. See `star_nnrat_smul`. -/
 alias star_nnqsmul := star_nnrat_smul
+
+/-- Note that this lemma holds for an arbitrary `ℚ`-action, rather than merely one coming from a
+`DivisionRing`. We keep both the `qsmul` and `rat_smul` naming conventions for
+discoverability. See `star_rat_smul`. -/
 alias star_qsmul := star_rat_smul
 
 instance StarAddMonoid.toStarModuleNNRat [AddCommMonoid R] [Module ℚ≥0 R] [StarAddMonoid R] :

--- a/Mathlib/Algebra/Star/Rat.lean
+++ b/Mathlib/Algebra/Star/Rat.lean
@@ -17,7 +17,7 @@ instance NNRat.instStarRing : StarRing ℚ≥0 := starRingOfComm
 instance Rat.instTrivialStar : TrivialStar ℚ := ⟨fun _ ↦ rfl⟩
 instance NNRat.instTrivialStar : TrivialStar ℚ≥0 := ⟨fun _ ↦ rfl⟩
 
-variable {α R : Type*}
+variable {R : Type*}
 
 open MulOpposite
 

--- a/Mathlib/Algebra/Star/Rat.lean
+++ b/Mathlib/Algebra/Star/Rat.lean
@@ -4,11 +4,9 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Yaël Dillies
 -/
 import Mathlib.Algebra.Field.Opposite
-import Mathlib.Algebra.Module.Defs
 import Mathlib.Algebra.Star.Basic
 import Mathlib.Data.NNRat.Defs
 import Mathlib.Data.Rat.Cast.Defs
-import Mathlib.Tactic.Positivity.Basic
 
 /-!
 # *-ring structure on ℚ and ℚ≥0.
@@ -30,23 +28,3 @@ lemma star_nnratCast [DivisionSemiring R] [StarRing R] (q : ℚ≥0) : star (q :
 @[simp, norm_cast]
 theorem star_ratCast [DivisionRing R] [StarRing R] (r : ℚ) : star (r : R) = r :=
   (congr_arg unop <| map_ratCast (starRingEquiv : R ≃+* Rᵐᵒᵖ) r).trans (unop_ratCast _)
-
-@[simp] lemma star_nnqsmul [AddCommMonoid α] [Module ℚ≥0 α] [StarAddMonoid α] (q : ℚ≥0) (a : α) :
-    star (q • a) = q • star a := by
-  refine MulAction.injective₀ (G₀ := ℚ≥0) (a := q.den) (by positivity) ?_
-  dsimp
-  rw [Nat.cast_smul_eq_nsmul, ← star_nsmul, ← Nat.cast_smul_eq_nsmul ℚ≥0, smul_smul, smul_smul,
-    NNRat.den_mul_eq_num, Nat.cast_smul_eq_nsmul, Nat.cast_smul_eq_nsmul, star_nsmul]
-
-@[simp] lemma star_qsmul [AddCommGroup α] [Module ℚ α] [StarAddMonoid α] (q : ℚ) (a : α) :
-    star (q • a) = q • star a := by
-  refine MulAction.injective₀ (G₀ := ℚ) (a := q.den) (by positivity) ?_
-  dsimp
-  rw [Nat.cast_smul_eq_nsmul, ← star_nsmul, ← Nat.cast_smul_eq_nsmul ℚ, smul_smul, smul_smul,
-    Rat.den_mul_eq_num, Int.cast_smul_eq_zsmul, Int.cast_smul_eq_zsmul, star_zsmul]
-
-instance StarAddMonoid.toStarModuleNNRat [AddCommMonoid α] [Module ℚ≥0 α] [StarAddMonoid α] :
-    StarModule ℚ≥0 α where star_smul := star_nnqsmul
-
-instance StarAddMonoid.toStarModuleRat [AddCommGroup α] [Module ℚ α] [StarAddMonoid α] :
-    StarModule ℚ α where star_smul := star_qsmul

--- a/Mathlib/Algebra/Star/Rat.lean
+++ b/Mathlib/Algebra/Star/Rat.lean
@@ -4,9 +4,11 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Yaël Dillies
 -/
 import Mathlib.Algebra.Field.Opposite
+import Mathlib.Algebra.Module.Defs
 import Mathlib.Algebra.Star.Basic
 import Mathlib.Data.NNRat.Defs
 import Mathlib.Data.Rat.Cast.Defs
+import Mathlib.Tactic.Positivity.Basic
 
 /-!
 # *-ring structure on ℚ and ℚ≥0.
@@ -17,7 +19,7 @@ instance NNRat.instStarRing : StarRing ℚ≥0 := starRingOfComm
 instance Rat.instTrivialStar : TrivialStar ℚ := ⟨fun _ ↦ rfl⟩
 instance NNRat.instTrivialStar : TrivialStar ℚ≥0 := ⟨fun _ ↦ rfl⟩
 
-variable {R : Type*}
+variable {α R : Type*}
 
 open MulOpposite
 
@@ -28,3 +30,23 @@ lemma star_nnratCast [DivisionSemiring R] [StarRing R] (q : ℚ≥0) : star (q :
 @[simp, norm_cast]
 theorem star_ratCast [DivisionRing R] [StarRing R] (r : ℚ) : star (r : R) = r :=
   (congr_arg unop <| map_ratCast (starRingEquiv : R ≃+* Rᵐᵒᵖ) r).trans (unop_ratCast _)
+
+@[simp] lemma star_nnqsmul [AddCommMonoid α] [Module ℚ≥0 α] [StarAddMonoid α] (q : ℚ≥0) (a : α) :
+    star (q • a) = q • star a := by
+  refine MulAction.injective₀ (G₀ := ℚ≥0) (a := q.den) (by positivity) ?_
+  dsimp
+  rw [Nat.cast_smul_eq_nsmul, ← star_nsmul, ← Nat.cast_smul_eq_nsmul ℚ≥0, smul_smul, smul_smul,
+    NNRat.den_mul_eq_num, Nat.cast_smul_eq_nsmul, Nat.cast_smul_eq_nsmul, star_nsmul]
+
+@[simp] lemma star_qsmul [AddCommGroup α] [Module ℚ α] [StarAddMonoid α] (q : ℚ) (a : α) :
+    star (q • a) = q • star a := by
+  refine MulAction.injective₀ (G₀ := ℚ) (a := q.den) (by positivity) ?_
+  dsimp
+  rw [Nat.cast_smul_eq_nsmul, ← star_nsmul, ← Nat.cast_smul_eq_nsmul ℚ, smul_smul, smul_smul,
+    Rat.den_mul_eq_num, Int.cast_smul_eq_zsmul, Int.cast_smul_eq_zsmul, star_zsmul]
+
+instance StarAddMonoid.toStarModuleNNRat [AddCommMonoid α] [Module ℚ≥0 α] [StarAddMonoid α] :
+    StarModule ℚ≥0 α where star_smul := star_nnqsmul
+
+instance StarAddMonoid.toStarModuleRat [AddCommGroup α] [Module ℚ α] [StarAddMonoid α] :
+    StarModule ℚ α where star_smul := star_qsmul

--- a/Mathlib/Data/Matrix/Basic.lean
+++ b/Mathlib/Data/Matrix/Basic.lean
@@ -2098,7 +2098,6 @@ variants which this lemma would not apply to:
 * `Matrix.conjTranspose_intCast_smul`
 * `Matrix.conjTranspose_inv_natCast_smul`
 * `Matrix.conjTranspose_inv_intCast_smul`
-* `Matrix.conjTranspose_rat_smul`
 * `Matrix.conjTranspose_ratCast_smul`
 -/
 @[simp]

--- a/Mathlib/Data/Matrix/Basic.lean
+++ b/Mathlib/Data/Matrix/Basic.lean
@@ -2166,7 +2166,6 @@ theorem conjTranspose_ratCast_smul [DivisionRing R] [AddCommGroup α] [StarAddMo
     (c : ℚ) (M : Matrix m n α) : ((c : R) • M)ᴴ = (c : R) • Mᴴ :=
   Matrix.ext <| by simp
 
-@[simp]
 theorem conjTranspose_rat_smul [AddCommGroup α] [StarAddMonoid α] [Module ℚ α] (c : ℚ)
     (M : Matrix m n α) : (c • M)ᴴ = c • Mᴴ :=
   Matrix.ext <| by simp


### PR DESCRIPTION
From LeanAPAP


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
