### PR TITLE
[Merged by Bors] - fix: silence `sleep_heartbeats` in `unusedTactic`

### DIFF
--- a/Mathlib/Tactic/Linter/UnusedTactic.lean
+++ b/Mathlib/Tactic/Linter/UnusedTactic.lean
@@ -92,6 +92,7 @@ initialize allowedRef : IO.Ref (Std.HashSet SyntaxNodeKind) ←
     |>.insert `Mathlib.Tactic.tacticMatch_target_
     |>.insert `change?
     |>.insert `«tactic#adaptation_note_»
+    |>.insert `tacticSleep_heartbeats_
 
 /-- `#allow_unused_tactic` takes an input a space-separated list of identifiers.
 These identifiers are then allowed by the unused tactic linter:

--- a/Mathlib/Util/SleepHeartbeats.lean
+++ b/Mathlib/Util/SleepHeartbeats.lean
@@ -34,8 +34,6 @@ elab "sleep_heartbeats " n:num : tactic => do
      option -/
   | some m => sleepAtLeastHeartbeats (m * 1000)
 
--- TODO: this is a false positive, it should not warn on an unused tactic.
-set_option linter.unusedTactic false in
 example : 1 = 1 := by
   sleep_heartbeats 1000
   rfl

--- a/Mathlib/Util/SleepHeartbeats.lean
+++ b/Mathlib/Util/SleepHeartbeats.lean
@@ -34,6 +34,7 @@ elab "sleep_heartbeats " n:num : tactic => do
      option -/
   | some m => sleepAtLeastHeartbeats (m * 1000)
 
+-- TODO: this is a false positive, it should not warn on an unused tactic.
 set_option linter.unusedTactic false in
 example : 1 = 1 := by
   sleep_heartbeats 1000


### PR DESCRIPTION
Found thanks to the `large-import` label on #12339.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
