### PR TITLE
[Merged by Bors] - feat(CategoryTheory/KanExtension): Composing `lan` with `colim`

### DIFF
--- a/Mathlib/CategoryTheory/Functor/Const.lean
+++ b/Mathlib/CategoryTheory/Functor/Const.lean
@@ -99,6 +99,13 @@ def compConstIso (F : C ⥤ D) :
     (fun X => NatIso.ofComponents (fun j => Iso.refl _) (by aesop_cat))
     (by aesop_cat)
 
+/-- The canonical isomorphism
+`const D ⋙ (whiskeringLeft J _ _).obj F ≅ const J`.-/
+@[simps!]
+def constCompWhiskeringLeftIso (F : J ⥤ D) :
+    const D ⋙ (whiskeringLeft J D C).obj F ≅ const J :=
+  NatIso.ofComponents fun X => NatIso.ofComponents fun Y => Iso.refl _
+
 end
 
 end CategoryTheory.Functor

--- a/Mathlib/CategoryTheory/Functor/KanExtension/Adjunction.lean
+++ b/Mathlib/CategoryTheory/Functor/KanExtension/Adjunction.lean
@@ -20,8 +20,6 @@ right Kan extension along `L`.
 
 -/
 
-universe v₁ v₂ v₃ u₁ u₂ u₃
-
 namespace CategoryTheory
 
 open Category Limits
@@ -102,10 +100,7 @@ lemma isIso_lanAdjunction_counit_app_iff (G : D ⥤ H) :
     IsIso ((L.lanAdjunction H).counit.app G) ↔ G.IsLeftKanExtension (𝟙 (L ⋙ G)) :=
   (isLeftKanExtension_iff_isIso _ (L.lanUnit.app (L ⋙ G)) _ (by simp)).symm
 
-noncomputable section Colim
-
-variable {C : Type u₁} {D : Type u₁} [Category.{v₁} C] [Category.{v₃} D]
-variable {H : Type (max u₁ u₂)} [Category.{max u₁ v₂} H]
+section Colim
 
 variable (F' : D ⥤ H) {L : C ⥤ D} {F : C ⥤ H} (α : F ⟶ L ⋙ F') [F'.IsLeftKanExtension α]
 
@@ -122,8 +117,7 @@ def isColimitCoconeOfIsLeftKanExtension {c : Cocone F} (hc : IsColimit c) :
   desc s := hc.desc (Cocone.mk _ (α ≫ whiskerLeft L s.ι))
   fac s := by
     have : F'.descOfIsLeftKanExtension α ((const D).obj c.pt) c.ι ≫
-        (Functor.const _).map
-          (hc.desc (Cocone.mk _ (α ≫ whiskerLeft L s.ι))) = s.ι :=
+        (Functor.const _).map (hc.desc (Cocone.mk _ (α ≫ whiskerLeft L s.ι))) = s.ι :=
       F'.hom_ext_of_isLeftKanExtension α _ _ (by aesop_cat)
     exact congr_app this
   uniq s m hm := hc.hom_ext (fun j ↦ by
@@ -135,23 +129,23 @@ def isColimitCoconeOfIsLeftKanExtension {c : Cocone F} (hc : IsColimit c) :
 /-- Composing the left Kan extension of `L : C ⥤ D` with `colim` on shapes `D` is isomorphic
 to `colim` on shapes `C`. -/
 @[simps!]
-def lanCompColimIso (L : C ⥤ D) [∀ (G : C ⥤ H), L.HasLeftKanExtension G]
+noncomputable def lanCompColimIso (L : C ⥤ D) [∀ (G : C ⥤ H), L.HasLeftKanExtension G]
     [HasColimitsOfShape C H] [HasColimitsOfShape D H] : L.lan ⋙ colim ≅ colim (C := H) :=
   NatIso.ofComponents (fun F => IsColimit.coconePointUniqueUpToIso
     (colimit.isColimit (L.leftKanExtension F))
     (isColimitCoconeOfIsLeftKanExtension _ (leftKanExtensionUnit _ _) (colimit.isColimit F)))
     (fun _ => by
-      simp only [comp_obj, colim_obj, colim_map, ← Iso.inv_comp_eq, ← assoc, ← Iso.eq_comp_inv]
+      simp only [colim_obj, colim_map, ← Iso.inv_comp_eq, ← assoc, ← Iso.eq_comp_inv]
       ext
-      simp only [ι_colimMap_assoc]
-      conv_lhs => simp only [comp_map, colim, colimMap, IsColimit.map, lan]
+      rw [ι_colimMap_assoc]
+      simp only [comp_map, colim, colimMap, IsColimit.map, lan]
       rw [IsColimit.coconePointUniqueUpToIso_inv_desc]
       simp only [isColimitCoconeOfIsLeftKanExtension_desc, Cocones.precompose_obj_pt,
         colimit.cocone_x, Cocones.precompose_obj_ι, whiskerLeft_comp, colimit.isColimit_desc,
         colimit.ι_desc, NatTrans.comp_app, comp_obj, const_obj_obj, whiskerLeft_app,
         colimit.cocone_ι]
       conv_rhs => rw [← assoc]
-      rw [Iso.eq_comp_inv, assoc, assoc]
+      rw [Iso.eq_comp_inv]
       simp only [colimit.ι, colimit.cocone, lan]
       rw [descOfIsLeftKanExtension_fac_app_assoc]
       simp)
@@ -265,27 +259,54 @@ lemma isIso_ranAdjunction_unit_app_iff (G : D ⥤ H) :
     IsIso ((L.ranAdjunction H).unit.app G) ↔ G.IsRightKanExtension (𝟙 (L ⋙ G)) :=
   (isRightKanExtension_iff_isIso _ (L.ranCounit.app (L ⋙ G)) _ (by simp)).symm
 
-noncomputable section Colim
+section Lim
 
-variable {C : Type u₁} {D : Type u₁} [Category.{v₁} C] [Category.{v₃} D]
-variable {H : Type (max u₁ u₂)} [Category.{max u₁ v₂} H]
+variable (F' : D ⥤ H) {L : C ⥤ D} {F : C ⥤ H} (α : L ⋙ F' ⟶ F) [F'.IsRightKanExtension α]
+
+/-- Construct a cone for a right Kan extension of `F` given a cone for `F`. -/
+@[simps]
+noncomputable def coneOfIsRightKanExtension (c : Cone F) : Cone F' where
+  pt := c.pt
+  π := F'.liftOfIsRightKanExtension α _ c.π
+
+/-- If `c` is a limit cone, then `coneOfIsRightKanExtension α c` is a limit cone, too. -/
+@[simps]
+def isLimitConeOfIsRightKanExtension {c : Cone F} (hc : IsLimit c) :
+    IsLimit (F'.coneOfIsRightKanExtension α c) where
+  lift s := hc.lift (Cone.mk _ (whiskerLeft L s.π ≫ α))
+  fac s := by
+    have : (Functor.const _).map (hc.lift (Cone.mk _ (whiskerLeft L s.π ≫ α))) ≫
+        F'.liftOfIsRightKanExtension α ((const D).obj c.pt) c.π = s.π :=
+      F'.hom_ext_of_isRightKanExtension α _ _ (by aesop_cat)
+    exact congr_app this
+  uniq s m hm := hc.hom_ext (fun j ↦ by
+    have := hm (L.obj j)
+    nth_rw 1 [← F'.liftOfIsRightKanExtension_fac_app α ((const D).obj c.pt)]
+    dsimp at this ⊢
+    rw [← assoc, this, IsLimit.fac, NatTrans.comp_app, whiskerLeft_app])
 
 /-- Composing the right Kan extension of `L : C ⥤ D` with `lim` on shapes `D` is isomorphic
 to `lim` on shapes `C`. -/
 @[simps!]
-def ranCompLimIso (L : C ⥤ D) [∀ (G : C ⥤ H), L.HasRightKanExtension G]
+noncomputable def ranCompLimIso (L : C ⥤ D) [∀ (G : C ⥤ H), L.HasRightKanExtension G]
     [HasLimitsOfShape C H] [HasLimitsOfShape D H] : L.ran ⋙ lim ≅ lim (C := H) :=
-  fullyFaithfulCancelRight yoneda <|
-    Functor.associator _ _ _ ≪≫
-    isoWhiskerLeft _ constLimAdj.compYonedaIso ≪≫
-    (Functor.associator _ _ _).symm ≪≫
-    isoWhiskerRight (L.ranAdjunction _).compYonedaIso _ ≪≫
-    Functor.associator _ _ _ ≪≫
-    isoWhiskerLeft _ ((whiskeringLeftObjCompIso _ _).symm ≪≫
-      Functor.mapIso _ (NatIso.op (constCompWhiskeringLeftIso _ _).symm)) ≪≫
-    constLimAdj.compYonedaIso.symm
+  NatIso.ofComponents (fun F => IsLimit.conePointUniqueUpToIso
+    (limit.isLimit (L.rightKanExtension F))
+    (isLimitConeOfIsRightKanExtension _ (rightKanExtensionCounit _ _) (limit.isLimit F)))
+    (fun _ => by
+      simp only [lim_obj, lim_map]
+      ext c
+      conv_rhs => rw [assoc, limMap_π]
+      simp only [comp_map, lim, limMap, IsLimit.map, ran]
+      rw [IsLimit.lift_comp_conePointUniqueUpToIso_hom]
+      simp only [limit.isLimit_lift, comp_obj, isLimitConeOfIsRightKanExtension_lift,
+        Cones.postcompose_obj_pt, limit.cone_x, Cones.postcompose_obj_π, whiskerLeft_comp,
+        limit.lift_π, assoc, liftOfIsRightKanExtension_fac, NatTrans.comp_app, const_obj_obj,
+        whiskerLeft_app, limit.cone_π]
+      simp only [limit.π, limit.cone, ran]
+      erw [IsLimit.conePointUniqueUpToIso_hom_comp_assoc])
 
-end Colim
+end Lim
 
 end
 

--- a/Mathlib/CategoryTheory/Functor/KanExtension/Adjunction.lean
+++ b/Mathlib/CategoryTheory/Functor/KanExtension/Adjunction.lean
@@ -114,6 +114,7 @@ noncomputable def coconeOfIsLeftKanExtension (c : Cocone F) : Cocone F' where
   pt := c.pt
   ι := F'.descOfIsLeftKanExtension α _ c.ι
 
+@[simps]
 def isColimitCoconeOfIsLeftKanExtension {c : Cocone F} (hc : IsColimit c) :
     IsColimit (F'.coconeOfIsLeftKanExtension α c) where
   desc s := hc.desc (Cocone.mk _ (α ≫ whiskerLeft L s.ι))
@@ -137,30 +138,21 @@ def lanCompColimIso (L : C ⥤ D) [∀ (G : C ⥤ H), L.HasLeftKanExtension G]
   NatIso.ofComponents (fun F => IsColimit.coconePointUniqueUpToIso
     (colimit.isColimit (L.leftKanExtension F))
     (isColimitCoconeOfIsLeftKanExtension _ (leftKanExtensionUnit _ _) (colimit.isColimit F)))
-    (fun f => by
+    (fun {G₁ G₂} η => by
       simp only [comp_obj, colim_obj, comp_map, colim_map]
-      ext d
-      simp only [ι_colimMap_assoc]
+      rw [← Iso.inv_comp_eq, ← assoc, ← Iso.eq_comp_inv]
+      ext c
+      simp
+      erw [IsColimit.coconePointUniqueUpToIso_inv_desc]
+      simp
+      conv_rhs => rw [← assoc]
+      rw [Iso.eq_comp_inv, assoc, assoc]
       unfold colimit.ι
-      rw [IsColimit.comp_coconePointUniqueUpToIso_hom, ← NatTrans.comp_app]
-      simp only [coconeOfIsLeftKanExtension_pt, coconeOfIsLeftKanExtension_ι,
-        NatTrans.comp_app, const_obj_obj, IsColimit.comp_coconePointUniqueUpToIso_hom_assoc]
-
-      sorry)
-
-#check map_app
-
-  /-NatIso.removeOp <| fullyFaithfulCancelRight coyoneda <|
-    colimConstAdj.compCoyonedaIso ≪≫
-    isoWhiskerLeft coyoneda (Functor.mapIso _ (constCompWhiskeringLeftIso _ _).symm ≪≫
-      whiskeringLeftObjCompIso _ _) ≪≫
-    (Functor.associator _ _ _).symm ≪≫
-    isoWhiskerRight (L.lanAdjunction _).compCoyonedaIso.symm _ ≪≫
-    Functor.associator _ _ _ ≪≫
-    isoWhiskerLeft L.lan.op colimConstAdj.compCoyonedaIso.symm ≪≫
-    (Functor.associator L.lan.op colim.op coyoneda).symm-/
-
-#exit
+      unfold colimit.cocone
+      rw [IsColimit.comp_coconePointUniqueUpToIso_hom]
+      simp only [coconeOfIsLeftKanExtension]
+      erw [descOfIsLeftKanExtension_fac_app_assoc]
+      simp)
 
 end Colim
 

--- a/Mathlib/CategoryTheory/Functor/KanExtension/Adjunction.lean
+++ b/Mathlib/CategoryTheory/Functor/KanExtension/Adjunction.lean
@@ -105,20 +105,14 @@ to `colim` on shapes `C`. -/
 @[simps!]
 noncomputable def lanCompColimIso (L : C ⥤ D) [∀ (G : C ⥤ H), L.HasLeftKanExtension G]
     [HasColimitsOfShape C H] [HasColimitsOfShape D H] : L.lan ⋙ colim ≅ colim (C := H) :=
-  NatIso.ofComponents (fun F => IsColimit.coconePointUniqueUpToIso
-    (colimit.isColimit (L.leftKanExtension F))
-    (isColimitCoconeOfIsLeftKanExtension _ (leftKanExtensionUnit _ _) (colimit.isColimit F)))
-    (fun _ => by
-      simp only [colim_obj, colim_map, ← Iso.inv_comp_eq, ← assoc, ← Iso.eq_comp_inv]
-      ext
-      rw [ι_colimMap_assoc]
-      simp only [comp_map, colim, colimMap, IsColimit.map, lan]
-      rw [IsColimit.coconePointUniqueUpToIso_inv_desc]
-      simp only [isColimitCoconeOfIsLeftKanExtension_desc, Cocones.precompose_obj_pt,
-        colimit.cocone_x, Cocones.precompose_obj_ι, whiskerLeft_comp, colimit.isColimit_desc,
-        colimit.ι_desc, NatTrans.comp_app, comp_obj, const_obj_obj, whiskerLeft_app,
-        colimit.cocone_ι, ← assoc, Iso.eq_comp_inv]
-      simp [colimit.ι, colimit.cocone, lan])
+  Iso.symm <| NatIso.ofComponents
+    (fun G ↦ (colimitIsoOfIsLeftKanExtension _ (L.lanUnit.app G)).symm)
+    (fun f ↦ colimit.hom_ext (fun i ↦ by
+      dsimp
+      rw [ι_colimMap_assoc, ι_colimitIsoOfIsLeftKanExtension_inv,
+        ι_colimitIsoOfIsLeftKanExtension_inv_assoc, ι_colimMap, ← assoc, ← assoc]
+      congr 1
+      exact congr_app (L.lanUnit.naturality f) i))
 
 end
 
@@ -232,20 +226,14 @@ to `lim` on shapes `C`. -/
 @[simps!]
 noncomputable def ranCompLimIso (L : C ⥤ D) [∀ (G : C ⥤ H), L.HasRightKanExtension G]
     [HasLimitsOfShape C H] [HasLimitsOfShape D H] : L.ran ⋙ lim ≅ lim (C := H) :=
-  NatIso.ofComponents (fun F => IsLimit.conePointUniqueUpToIso
-    (limit.isLimit (L.rightKanExtension F))
-    (isLimitConeOfIsRightKanExtension _ (rightKanExtensionCounit _ _) (limit.isLimit F)))
-    (fun _ => by
-      simp only [lim_obj, lim_map]
-      ext c
-      conv_rhs => rw [assoc, limMap_π]
-      simp only [comp_map, lim, limMap, IsLimit.map, ran]
-      rw [IsLimit.lift_comp_conePointUniqueUpToIso_hom]
-      simp only [limit.isLimit_lift, comp_obj, isLimitConeOfIsRightKanExtension_lift,
-        Cones.postcompose_obj_pt, limit.cone_x, Cones.postcompose_obj_π, whiskerLeft_comp,
-        limit.lift_π, assoc, liftOfIsRightKanExtension_fac, NatTrans.comp_app, const_obj_obj,
-        whiskerLeft_app, limit.cone_π]
-      simp [limit.π, limit.cone, ← Iso.inv_comp_eq])
+  NatIso.ofComponents
+    (fun G ↦ (limitIsoOfIsRightKanExtension _ (L.ranCounit.app G)))
+    (fun f ↦ limit.hom_ext (fun i ↦ by
+      dsimp
+      rw [assoc, assoc, limMap_π, limitIsoOfIsRightKanExtension_hom_π_assoc,
+        limitIsoOfIsRightKanExtension_hom_π, limMap_π_assoc]
+      congr 1
+      exact congr_app (L.ranCounit.naturality f) i))
 
 end
 

--- a/Mathlib/CategoryTheory/Functor/KanExtension/Adjunction.lean
+++ b/Mathlib/CategoryTheory/Functor/KanExtension/Adjunction.lean
@@ -237,7 +237,7 @@ variable {C : Type u₁} {D : Type u₁} [Category.{v₁} C] [Category.{v₃} D]
 variable {H : Type (max u₁ u₂)} [Category.{max u₁ v₂} H]
 
 /-- Composing the right Kan extension of `L : C ⥤ D` with `lim` on shapes `D` is isomorphic
-to `colim` on shapes `C`. -/
+to `lim` on shapes `C`. -/
 @[simps!]
 def ranCompLimIso (L : C ⥤ D) [∀ (G : C ⥤ H), L.HasRightKanExtension G]
     [HasLimitsOfShape C H] [HasLimitsOfShape D H] : L.ran ⋙ lim ≅ lim (C := H) :=

--- a/Mathlib/CategoryTheory/Functor/KanExtension/Adjunction.lean
+++ b/Mathlib/CategoryTheory/Functor/KanExtension/Adjunction.lean
@@ -142,16 +142,16 @@ def lanCompColimIso (L : C ⥤ D) [∀ (G : C ⥤ H), L.HasLeftKanExtension G]
       simp only [comp_obj, colim_obj, comp_map, colim_map]
       rw [← Iso.inv_comp_eq, ← assoc, ← Iso.eq_comp_inv]
       ext c
-      simp
+      simp only [ι_colimMap_assoc]
       erw [IsColimit.coconePointUniqueUpToIso_inv_desc]
-      simp
+      simp only [isColimitCoconeOfIsLeftKanExtension_desc, Cocones.precompose_obj_pt,
+        colimit.cocone_x, Cocones.precompose_obj_ι, whiskerLeft_comp, colimit.isColimit_desc,
+        colimit.ι_desc, NatTrans.comp_app, comp_obj, const_obj_obj, whiskerLeft_app,
+        colimit.cocone_ι]
       conv_rhs => rw [← assoc]
       rw [Iso.eq_comp_inv, assoc, assoc]
-      unfold colimit.ι
-      unfold colimit.cocone
-      rw [IsColimit.comp_coconePointUniqueUpToIso_hom]
-      simp only [coconeOfIsLeftKanExtension]
-      erw [descOfIsLeftKanExtension_fac_app_assoc]
+      simp only [colimit.ι, colimit.cocone, lan]
+      rw [descOfIsLeftKanExtension_fac_app_assoc]
       simp)
 
 end Colim

--- a/Mathlib/CategoryTheory/Functor/KanExtension/Adjunction.lean
+++ b/Mathlib/CategoryTheory/Functor/KanExtension/Adjunction.lean
@@ -100,32 +100,6 @@ lemma isIso_lanAdjunction_counit_app_iff (G : D ⥤ H) :
     IsIso ((L.lanAdjunction H).counit.app G) ↔ G.IsLeftKanExtension (𝟙 (L ⋙ G)) :=
   (isLeftKanExtension_iff_isIso _ (L.lanUnit.app (L ⋙ G)) _ (by simp)).symm
 
-section Colim
-
-variable (F' : D ⥤ H) {L : C ⥤ D} {F : C ⥤ H} (α : F ⟶ L ⋙ F') [F'.IsLeftKanExtension α]
-
-/-- Construct a cocone for a left Kan extension of `F` given a cocone for `F`. -/
-@[simps]
-noncomputable def coconeOfIsLeftKanExtension (c : Cocone F) : Cocone F' where
-  pt := c.pt
-  ι := F'.descOfIsLeftKanExtension α _ c.ι
-
-/-- If `c` is a colimit cocone, then `coconeOfIsLeftKanExtension α c` is a colimit cocone, too. -/
-@[simps]
-def isColimitCoconeOfIsLeftKanExtension {c : Cocone F} (hc : IsColimit c) :
-    IsColimit (F'.coconeOfIsLeftKanExtension α c) where
-  desc s := hc.desc (Cocone.mk _ (α ≫ whiskerLeft L s.ι))
-  fac s := by
-    have : F'.descOfIsLeftKanExtension α ((const D).obj c.pt) c.ι ≫
-        (Functor.const _).map (hc.desc (Cocone.mk _ (α ≫ whiskerLeft L s.ι))) = s.ι :=
-      F'.hom_ext_of_isLeftKanExtension α _ _ (by aesop_cat)
-    exact congr_app this
-  uniq s m hm := hc.hom_ext (fun j ↦ by
-    have := hm (L.obj j)
-    nth_rw 1 [← F'.descOfIsLeftKanExtension_fac_app α ((const D).obj c.pt)]
-    dsimp at this ⊢
-    rw [assoc, this, IsColimit.fac, NatTrans.comp_app, whiskerLeft_app])
-
 /-- Composing the left Kan extension of `L : C ⥤ D` with `colim` on shapes `D` is isomorphic
 to `colim` on shapes `C`. -/
 @[simps!]
@@ -145,8 +119,6 @@ noncomputable def lanCompColimIso (L : C ⥤ D) [∀ (G : C ⥤ H), L.HasLeftKan
         colimit.ι_desc, NatTrans.comp_app, comp_obj, const_obj_obj, whiskerLeft_app,
         colimit.cocone_ι, ← assoc, Iso.eq_comp_inv]
       simp [colimit.ι, colimit.cocone, lan])
-
-end Colim
 
 end
 
@@ -255,32 +227,6 @@ lemma isIso_ranAdjunction_unit_app_iff (G : D ⥤ H) :
     IsIso ((L.ranAdjunction H).unit.app G) ↔ G.IsRightKanExtension (𝟙 (L ⋙ G)) :=
   (isRightKanExtension_iff_isIso _ (L.ranCounit.app (L ⋙ G)) _ (by simp)).symm
 
-section Lim
-
-variable (F' : D ⥤ H) {L : C ⥤ D} {F : C ⥤ H} (α : L ⋙ F' ⟶ F) [F'.IsRightKanExtension α]
-
-/-- Construct a cone for a right Kan extension of `F` given a cone for `F`. -/
-@[simps]
-noncomputable def coneOfIsRightKanExtension (c : Cone F) : Cone F' where
-  pt := c.pt
-  π := F'.liftOfIsRightKanExtension α _ c.π
-
-/-- If `c` is a limit cone, then `coneOfIsRightKanExtension α c` is a limit cone, too. -/
-@[simps]
-def isLimitConeOfIsRightKanExtension {c : Cone F} (hc : IsLimit c) :
-    IsLimit (F'.coneOfIsRightKanExtension α c) where
-  lift s := hc.lift (Cone.mk _ (whiskerLeft L s.π ≫ α))
-  fac s := by
-    have : (Functor.const _).map (hc.lift (Cone.mk _ (whiskerLeft L s.π ≫ α))) ≫
-        F'.liftOfIsRightKanExtension α ((const D).obj c.pt) c.π = s.π :=
-      F'.hom_ext_of_isRightKanExtension α _ _ (by aesop_cat)
-    exact congr_app this
-  uniq s m hm := hc.hom_ext (fun j ↦ by
-    have := hm (L.obj j)
-    nth_rw 1 [← F'.liftOfIsRightKanExtension_fac_app α ((const D).obj c.pt)]
-    dsimp at this ⊢
-    rw [← assoc, this, IsLimit.fac, NatTrans.comp_app, whiskerLeft_app])
-
 /-- Composing the right Kan extension of `L : C ⥤ D` with `lim` on shapes `D` is isomorphic
 to `lim` on shapes `C`. -/
 @[simps!]
@@ -300,8 +246,6 @@ noncomputable def ranCompLimIso (L : C ⥤ D) [∀ (G : C ⥤ H), L.HasRightKanE
         limit.lift_π, assoc, liftOfIsRightKanExtension_fac, NatTrans.comp_app, const_obj_obj,
         whiskerLeft_app, limit.cone_π]
       simp [limit.π, limit.cone, ← Iso.inv_comp_eq])
-
-end Lim
 
 end
 

--- a/Mathlib/CategoryTheory/Functor/KanExtension/Adjunction.lean
+++ b/Mathlib/CategoryTheory/Functor/KanExtension/Adjunction.lean
@@ -109,11 +109,13 @@ variable {H : Type (max u₁ u₂)} [Category.{max u₁ v₂} H]
 
 variable (F' : D ⥤ H) {L : C ⥤ D} {F : C ⥤ H} (α : F ⟶ L ⋙ F') [F'.IsLeftKanExtension α]
 
+/-- Construct a cocone for a left Kan extension of `F` given a cocone for `F`. -/
 @[simps]
 noncomputable def coconeOfIsLeftKanExtension (c : Cocone F) : Cocone F' where
   pt := c.pt
   ι := F'.descOfIsLeftKanExtension α _ c.ι
 
+/-- If `c` is a colimit cocone, then `coconeOfIsLeftKanExtension α c` is a colimit cocone, too. -/
 @[simps]
 def isColimitCoconeOfIsLeftKanExtension {c : Cocone F} (hc : IsColimit c) :
     IsColimit (F'.coconeOfIsLeftKanExtension α c) where
@@ -138,11 +140,11 @@ def lanCompColimIso (L : C ⥤ D) [∀ (G : C ⥤ H), L.HasLeftKanExtension G]
   NatIso.ofComponents (fun F => IsColimit.coconePointUniqueUpToIso
     (colimit.isColimit (L.leftKanExtension F))
     (isColimitCoconeOfIsLeftKanExtension _ (leftKanExtensionUnit _ _) (colimit.isColimit F)))
-    (fun {G₁ G₂} η => by
-      simp only [comp_obj, colim_obj, comp_map, colim_map]
-      rw [← Iso.inv_comp_eq, ← assoc, ← Iso.eq_comp_inv]
-      ext c
+    (fun _ => by
+      simp only [comp_obj, colim_obj, colim_map, ← Iso.inv_comp_eq, ← assoc, ← Iso.eq_comp_inv]
+      ext
       simp only [ι_colimMap_assoc]
+      conv_lhs => simp only [comp_map, colim, colimMap, IsColimit.map, colimit.cocone]
       erw [IsColimit.coconePointUniqueUpToIso_inv_desc]
       simp only [isColimitCoconeOfIsLeftKanExtension_desc, Cocones.precompose_obj_pt,
         colimit.cocone_x, Cocones.precompose_obj_ι, whiskerLeft_comp, colimit.isColimit_desc,

--- a/Mathlib/CategoryTheory/Functor/KanExtension/Adjunction.lean
+++ b/Mathlib/CategoryTheory/Functor/KanExtension/Adjunction.lean
@@ -144,8 +144,8 @@ def lanCompColimIso (L : C ⥤ D) [∀ (G : C ⥤ H), L.HasLeftKanExtension G]
       simp only [comp_obj, colim_obj, colim_map, ← Iso.inv_comp_eq, ← assoc, ← Iso.eq_comp_inv]
       ext
       simp only [ι_colimMap_assoc]
-      conv_lhs => simp only [comp_map, colim, colimMap, IsColimit.map, colimit.cocone]
-      erw [IsColimit.coconePointUniqueUpToIso_inv_desc]
+      conv_lhs => simp only [comp_map, colim, colimMap, IsColimit.map, lan]
+      rw [IsColimit.coconePointUniqueUpToIso_inv_desc]
       simp only [isColimitCoconeOfIsLeftKanExtension_desc, Cocones.precompose_obj_pt,
         colimit.cocone_x, Cocones.precompose_obj_ι, whiskerLeft_comp, colimit.isColimit_desc,
         colimit.ι_desc, NatTrans.comp_app, comp_obj, const_obj_obj, whiskerLeft_app,

--- a/Mathlib/CategoryTheory/Functor/KanExtension/Adjunction.lean
+++ b/Mathlib/CategoryTheory/Functor/KanExtension/Adjunction.lean
@@ -143,12 +143,8 @@ noncomputable def lanCompColimIso (L : C ⥤ D) [∀ (G : C ⥤ H), L.HasLeftKan
       simp only [isColimitCoconeOfIsLeftKanExtension_desc, Cocones.precompose_obj_pt,
         colimit.cocone_x, Cocones.precompose_obj_ι, whiskerLeft_comp, colimit.isColimit_desc,
         colimit.ι_desc, NatTrans.comp_app, comp_obj, const_obj_obj, whiskerLeft_app,
-        colimit.cocone_ι]
-      conv_rhs => rw [← assoc]
-      rw [Iso.eq_comp_inv]
-      simp only [colimit.ι, colimit.cocone, lan]
-      rw [descOfIsLeftKanExtension_fac_app_assoc]
-      simp)
+        colimit.cocone_ι, ← assoc, Iso.eq_comp_inv]
+      simp [colimit.ι, colimit.cocone, lan])
 
 end Colim
 
@@ -303,8 +299,7 @@ noncomputable def ranCompLimIso (L : C ⥤ D) [∀ (G : C ⥤ H), L.HasRightKanE
         Cones.postcompose_obj_pt, limit.cone_x, Cones.postcompose_obj_π, whiskerLeft_comp,
         limit.lift_π, assoc, liftOfIsRightKanExtension_fac, NatTrans.comp_app, const_obj_obj,
         whiskerLeft_app, limit.cone_π]
-      simp only [limit.π, limit.cone, ran]
-      erw [IsLimit.conePointUniqueUpToIso_hom_comp_assoc])
+      simp [limit.π, limit.cone, ← Iso.inv_comp_eq])
 
 end Lim
 

--- a/Mathlib/CategoryTheory/Functor/KanExtension/Adjunction.lean
+++ b/Mathlib/CategoryTheory/Functor/KanExtension/Adjunction.lean
@@ -20,6 +20,8 @@ right Kan extension along `L`.
 
 -/
 
+universe v₁ v₂ v₃ u₁ u₂ u₃
+
 namespace CategoryTheory
 
 open Category
@@ -99,6 +101,30 @@ lemma lanUnit_app_app_lanAdjunction_counit_app_app (G : D ⥤ H) (X : C) :
 lemma isIso_lanAdjunction_counit_app_iff (G : D ⥤ H) :
     IsIso ((L.lanAdjunction H).counit.app G) ↔ G.IsLeftKanExtension (𝟙 (L ⋙ G)) :=
   (isLeftKanExtension_iff_isIso _ (L.lanUnit.app (L ⋙ G)) _ (by simp)).symm
+
+open Limits
+
+noncomputable section colim
+
+variable {C : Type u₁} {D : Type u₁} [Category.{v₁} C] [Category.{v₃} D]
+variable {H : Type (max u₁ u₂)} [Category.{max u₁ v₂} H] (L : C ⥤ D)
+
+/-- Composing the left Kan extension of `L : C ⥤ D` with `colim` on shapes `D` is isomorphic
+to `colim` on shapes `C`. -/
+@[simps!]
+def lanCompColimIso (L : C ⥤ D) [∀ (G : C ⥤ H), L.HasLeftKanExtension G]
+    [HasColimitsOfShape C H] [HasColimitsOfShape D H] : L.lan ⋙ colim ≅ colim (C := H) :=
+  NatIso.removeOp <| fullyFaithfulCancelRight coyoneda <|
+    colimConstAdj.compCoyonedaIso ≪≫
+    isoWhiskerLeft coyoneda (Functor.mapIso _ (constCompWhiskeringLeftIso _ _).symm ≪≫
+      whiskeringLeftObjCompIso _ _) ≪≫
+    (Functor.associator _ _ _).symm ≪≫
+    isoWhiskerRight (L.lanAdjunction _).compCoyonedaIso.symm _ ≪≫
+    Functor.associator _ _ _ ≪≫
+    isoWhiskerLeft L.lan.op colimConstAdj.compCoyonedaIso.symm ≪≫
+    (Functor.associator L.lan.op colim.op coyoneda).symm
+
+end colim
 
 end
 

--- a/Mathlib/CategoryTheory/Functor/KanExtension/Adjunction.lean
+++ b/Mathlib/CategoryTheory/Functor/KanExtension/Adjunction.lean
@@ -24,7 +24,7 @@ universe v₁ v₂ v₃ u₁ u₂ u₃
 
 namespace CategoryTheory
 
-open Category
+open Category Limits
 
 namespace Functor
 
@@ -102,12 +102,10 @@ lemma isIso_lanAdjunction_counit_app_iff (G : D ⥤ H) :
     IsIso ((L.lanAdjunction H).counit.app G) ↔ G.IsLeftKanExtension (𝟙 (L ⋙ G)) :=
   (isLeftKanExtension_iff_isIso _ (L.lanUnit.app (L ⋙ G)) _ (by simp)).symm
 
-open Limits
-
-noncomputable section colim
+noncomputable section Colim
 
 variable {C : Type u₁} {D : Type u₁} [Category.{v₁} C] [Category.{v₃} D]
-variable {H : Type (max u₁ u₂)} [Category.{max u₁ v₂} H] (L : C ⥤ D)
+variable {H : Type (max u₁ u₂)} [Category.{max u₁ v₂} H]
 
 /-- Composing the left Kan extension of `L : C ⥤ D` with `colim` on shapes `D` is isomorphic
 to `colim` on shapes `C`. -/
@@ -124,7 +122,7 @@ def lanCompColimIso (L : C ⥤ D) [∀ (G : C ⥤ H), L.HasLeftKanExtension G]
     isoWhiskerLeft L.lan.op colimConstAdj.compCoyonedaIso.symm ≪≫
     (Functor.associator L.lan.op colim.op coyoneda).symm
 
-end colim
+end Colim
 
 end
 
@@ -232,6 +230,28 @@ lemma ranCounit_app_app_ranAdjunction_unit_app_app (G : D ⥤ H) (X : C) :
 lemma isIso_ranAdjunction_unit_app_iff (G : D ⥤ H) :
     IsIso ((L.ranAdjunction H).unit.app G) ↔ G.IsRightKanExtension (𝟙 (L ⋙ G)) :=
   (isRightKanExtension_iff_isIso _ (L.ranCounit.app (L ⋙ G)) _ (by simp)).symm
+
+noncomputable section Colim
+
+variable {C : Type u₁} {D : Type u₁} [Category.{v₁} C] [Category.{v₃} D]
+variable {H : Type (max u₁ u₂)} [Category.{max u₁ v₂} H]
+
+/-- Composing the right Kan extension of `L : C ⥤ D` with `lim` on shapes `D` is isomorphic
+to `colim` on shapes `C`. -/
+@[simps!]
+def ranCompLimIso (L : C ⥤ D) [∀ (G : C ⥤ H), L.HasRightKanExtension G]
+    [HasLimitsOfShape C H] [HasLimitsOfShape D H] : L.ran ⋙ lim ≅ lim (C := H) :=
+  fullyFaithfulCancelRight yoneda <|
+    Functor.associator _ _ _ ≪≫
+    isoWhiskerLeft _ constLimAdj.compYonedaIso ≪≫
+    (Functor.associator _ _ _).symm ≪≫
+    isoWhiskerRight (L.ranAdjunction _).compYonedaIso _ ≪≫
+    Functor.associator _ _ _ ≪≫
+    isoWhiskerLeft _ ((whiskeringLeftObjCompIso _ _).symm ≪≫
+      Functor.mapIso _ (NatIso.op (constCompWhiskeringLeftIso _ _).symm)) ≪≫
+    constLimAdj.compYonedaIso.symm
+
+end Colim
 
 end
 

--- a/Mathlib/CategoryTheory/Functor/KanExtension/Adjunction.lean
+++ b/Mathlib/CategoryTheory/Functor/KanExtension/Adjunction.lean
@@ -227,7 +227,7 @@ to `lim` on shapes `C`. -/
 noncomputable def ranCompLimIso (L : C ⥤ D) [∀ (G : C ⥤ H), L.HasRightKanExtension G]
     [HasLimitsOfShape C H] [HasLimitsOfShape D H] : L.ran ⋙ lim ≅ lim (C := H) :=
   NatIso.ofComponents
-    (fun G ↦ (limitIsoOfIsRightKanExtension _ (L.ranCounit.app G)))
+    (fun G ↦ limitIsoOfIsRightKanExtension _ (L.ranCounit.app G))
     (fun f ↦ limit.hom_ext (fun i ↦ by
       dsimp
       rw [assoc, assoc, limMap_π, limitIsoOfIsRightKanExtension_hom_π_assoc,

--- a/Mathlib/CategoryTheory/Functor/KanExtension/Basic.lean
+++ b/Mathlib/CategoryTheory/Functor/KanExtension/Basic.lean
@@ -545,6 +545,62 @@ lemma isRightKanExtension_iff_of_iso₂ {F₁' F₂' : D ⥤ H} (α₁ : L ⋙ F
 
 end
 
+section Colimit
+
+variable (F' : D ⥤ H) {L : C ⥤ D} {F : C ⥤ H} (α : F ⟶ L ⋙ F') [F'.IsLeftKanExtension α]
+
+/-- Construct a cocone for a left Kan extension of `F` given a cocone for `F`. -/
+@[simps]
+noncomputable def coconeOfIsLeftKanExtension (c : Cocone F) : Cocone F' where
+  pt := c.pt
+  ι := F'.descOfIsLeftKanExtension α _ c.ι
+
+/-- If `c` is a colimit cocone, then `coconeOfIsLeftKanExtension α c` is a colimit cocone, too. -/
+@[simps]
+def isColimitCoconeOfIsLeftKanExtension {c : Cocone F} (hc : IsColimit c) :
+    IsColimit (F'.coconeOfIsLeftKanExtension α c) where
+  desc s := hc.desc (Cocone.mk _ (α ≫ whiskerLeft L s.ι))
+  fac s := by
+    have : F'.descOfIsLeftKanExtension α ((const D).obj c.pt) c.ι ≫
+        (Functor.const _).map (hc.desc (Cocone.mk _ (α ≫ whiskerLeft L s.ι))) = s.ι :=
+      F'.hom_ext_of_isLeftKanExtension α _ _ (by aesop_cat)
+    exact congr_app this
+  uniq s m hm := hc.hom_ext (fun j ↦ by
+    have := hm (L.obj j)
+    nth_rw 1 [← F'.descOfIsLeftKanExtension_fac_app α ((const D).obj c.pt)]
+    dsimp at this ⊢
+    rw [assoc, this, IsColimit.fac, NatTrans.comp_app, whiskerLeft_app])
+
+end Colimit
+
+section Limit
+
+variable (F' : D ⥤ H) {L : C ⥤ D} {F : C ⥤ H} (α : L ⋙ F' ⟶ F) [F'.IsRightKanExtension α]
+
+/-- Construct a cone for a right Kan extension of `F` given a cone for `F`. -/
+@[simps]
+noncomputable def coneOfIsRightKanExtension (c : Cone F) : Cone F' where
+  pt := c.pt
+  π := F'.liftOfIsRightKanExtension α _ c.π
+
+/-- If `c` is a limit cone, then `coneOfIsRightKanExtension α c` is a limit cone, too. -/
+@[simps]
+def isLimitConeOfIsRightKanExtension {c : Cone F} (hc : IsLimit c) :
+    IsLimit (F'.coneOfIsRightKanExtension α c) where
+  lift s := hc.lift (Cone.mk _ (whiskerLeft L s.π ≫ α))
+  fac s := by
+    have : (Functor.const _).map (hc.lift (Cone.mk _ (whiskerLeft L s.π ≫ α))) ≫
+        F'.liftOfIsRightKanExtension α ((const D).obj c.pt) c.π = s.π :=
+      F'.hom_ext_of_isRightKanExtension α _ _ (by aesop_cat)
+    exact congr_app this
+  uniq s m hm := hc.hom_ext (fun j ↦ by
+    have := hm (L.obj j)
+    nth_rw 1 [← F'.liftOfIsRightKanExtension_fac_app α ((const D).obj c.pt)]
+    dsimp at this ⊢
+    rw [← assoc, this, IsLimit.fac, NatTrans.comp_app, whiskerLeft_app])
+
+end Limit
+
 end Functor
 
 end CategoryTheory

--- a/Mathlib/CategoryTheory/Functor/KanExtension/Basic.lean
+++ b/Mathlib/CategoryTheory/Functor/KanExtension/Basic.lean
@@ -571,6 +571,25 @@ def isColimitCoconeOfIsLeftKanExtension {c : Cocone F} (hc : IsColimit c) :
     dsimp at this ⊢
     rw [assoc, this, IsColimit.fac, NatTrans.comp_app, whiskerLeft_app])
 
+variable [HasColimit F] [HasColimit F']
+
+/-- The colimit over any left Kan extension of `F` is isomorphic to `F`. -/
+noncomputable def colimitIsoOfIsLeftKanExtension : colimit F' ≅ colimit F :=
+  IsColimit.coconePointUniqueUpToIso (colimit.isColimit F')
+    (F'.isColimitCoconeOfIsLeftKanExtension α (colimit.isColimit F))
+
+@[reassoc (attr := simp)]
+lemma ι_colimitIsoOfIsLeftKanExtension_hom (i : C) :
+    α.app i ≫ colimit.ι F' (L.obj i) ≫ (F'.colimitIsoOfIsLeftKanExtension α).hom =
+      colimit.ι F i := by
+  simp [colimitIsoOfIsLeftKanExtension]
+
+@[reassoc (attr := simp)]
+lemma ι_colimitIsoOfIsLeftKanExtension_inv (i : C) :
+    colimit.ι F i ≫ (F'.colimitIsoOfIsLeftKanExtension α).inv =
+    α.app i ≫ colimit.ι F' (L.obj i) := by
+  rw [@Iso.comp_inv_eq, assoc, ι_colimitIsoOfIsLeftKanExtension_hom]
+
 end Colimit
 
 section Limit
@@ -598,6 +617,24 @@ def isLimitConeOfIsRightKanExtension {c : Cone F} (hc : IsLimit c) :
     nth_rw 1 [← F'.liftOfIsRightKanExtension_fac_app α ((const D).obj c.pt)]
     dsimp at this ⊢
     rw [← assoc, this, IsLimit.fac, NatTrans.comp_app, whiskerLeft_app])
+
+
+variable [HasLimit F] [HasLimit F']
+
+/-- The limit over any right Kan extension of `F` is isomorphic to `F`. -/
+noncomputable def limitIsoOfIsRightKanExtension : limit F' ≅ limit F :=
+  IsLimit.conePointUniqueUpToIso (limit.isLimit F')
+    (F'.isLimitConeOfIsRightKanExtension α (limit.isLimit F))
+
+@[reassoc (attr := simp)]
+lemma limitIsoOfIsRightKanExtension_inv_π (i : C) :
+    (F'.limitIsoOfIsRightKanExtension α).inv ≫ limit.π F' (L.obj i) ≫ α.app i = limit.π F i := by
+  simp [limitIsoOfIsRightKanExtension]
+
+@[reassoc (attr := simp)]
+lemma limitIsoOfIsRightKanExtension_hom_π (i : C) :
+    (F'.limitIsoOfIsRightKanExtension α).hom ≫ limit.π F i = limit.π F' (L.obj i) ≫ α.app i := by
+  rw [← Iso.eq_inv_comp, limitIsoOfIsRightKanExtension_inv_π]
 
 end Limit
 

--- a/Mathlib/CategoryTheory/Functor/KanExtension/Basic.lean
+++ b/Mathlib/CategoryTheory/Functor/KanExtension/Basic.lean
@@ -588,7 +588,7 @@ lemma ι_colimitIsoOfIsLeftKanExtension_hom (i : C) :
 lemma ι_colimitIsoOfIsLeftKanExtension_inv (i : C) :
     colimit.ι F i ≫ (F'.colimitIsoOfIsLeftKanExtension α).inv =
     α.app i ≫ colimit.ι F' (L.obj i) := by
-  rw [@Iso.comp_inv_eq, assoc, ι_colimitIsoOfIsLeftKanExtension_hom]
+  rw [Iso.comp_inv_eq, assoc, ι_colimitIsoOfIsLeftKanExtension_hom]
 
 end Colimit
 

--- a/Mathlib/CategoryTheory/Functor/KanExtension/Basic.lean
+++ b/Mathlib/CategoryTheory/Functor/KanExtension/Basic.lean
@@ -549,13 +549,16 @@ section Colimit
 
 variable (F' : D ⥤ H) {L : C ⥤ D} {F : C ⥤ H} (α : F ⟶ L ⋙ F') [F'.IsLeftKanExtension α]
 
-/-- Construct a cocone for a left Kan extension of `F` given a cocone for `F`. -/
+/-- Construct a cocone for a left Kan extension `F' : D ⥤ H` of `F : C ⥤ H` along a functor
+`L : C ⥤ D` given a cocone for `F`. -/
 @[simps]
 noncomputable def coconeOfIsLeftKanExtension (c : Cocone F) : Cocone F' where
   pt := c.pt
   ι := F'.descOfIsLeftKanExtension α _ c.ι
 
-/-- If `c` is a colimit cocone, then `coconeOfIsLeftKanExtension α c` is a colimit cocone, too. -/
+/-- If `c` is a colimit cocone for a functor `F : C ⥤ H` and `α : F ⟶ L ⋙ F'` is the unit of any
+left Kan extension `F' : D ⥤ H` of `F` along `L : C ⥤ D`, then `coconeOfIsLeftKanExtension α c` is
+a colimit cocone, too. -/
 @[simps]
 def isColimitCoconeOfIsLeftKanExtension {c : Cocone F} (hc : IsColimit c) :
     IsColimit (F'.coconeOfIsLeftKanExtension α c) where
@@ -573,7 +576,8 @@ def isColimitCoconeOfIsLeftKanExtension {c : Cocone F} (hc : IsColimit c) :
 
 variable [HasColimit F] [HasColimit F']
 
-/-- The colimit over any left Kan extension of `F` is isomorphic to `F`. -/
+/-- If `F' : D ⥤ H` is a left Kan extension of `F : C ⥤ H` along `L : C ⥤ D`, the colimit over `F'`
+is isomorphic to the colimit over `F`. -/
 noncomputable def colimitIsoOfIsLeftKanExtension : colimit F' ≅ colimit F :=
   IsColimit.coconePointUniqueUpToIso (colimit.isColimit F')
     (F'.isColimitCoconeOfIsLeftKanExtension α (colimit.isColimit F))
@@ -596,13 +600,16 @@ section Limit
 
 variable (F' : D ⥤ H) {L : C ⥤ D} {F : C ⥤ H} (α : L ⋙ F' ⟶ F) [F'.IsRightKanExtension α]
 
-/-- Construct a cone for a right Kan extension of `F` given a cone for `F`. -/
+/-- Construct a cone for a right Kan extension `F' : D ⥤ H` of `F : C ⥤ H` along a functor
+`L : C ⥤ D` given a cone for `F`. -/
 @[simps]
 noncomputable def coneOfIsRightKanExtension (c : Cone F) : Cone F' where
   pt := c.pt
   π := F'.liftOfIsRightKanExtension α _ c.π
 
-/-- If `c` is a limit cone, then `coneOfIsRightKanExtension α c` is a limit cone, too. -/
+/-- If `c` is a limit cone for a functor `F : C ⥤ H` and `α : L ⋙ F' ⟶ F` is the counit of any
+right Kan extension `F' : D ⥤ H` of `F` along `L : C ⥤ D`, then `coneOfIsRightKanExtension α c` is
+a limit cone, too. -/
 @[simps]
 def isLimitConeOfIsRightKanExtension {c : Cone F} (hc : IsLimit c) :
     IsLimit (F'.coneOfIsRightKanExtension α c) where
@@ -621,7 +628,8 @@ def isLimitConeOfIsRightKanExtension {c : Cone F} (hc : IsLimit c) :
 
 variable [HasLimit F] [HasLimit F']
 
-/-- The limit over any right Kan extension of `F` is isomorphic to `F`. -/
+/-- If `F' : D ⥤ H` is a right Kan extension of `F : C ⥤ H` along `L : C ⥤ D`, the limit over `F'`
+is isomorphic to the limit over `F`. -/
 noncomputable def limitIsoOfIsRightKanExtension : limit F' ≅ limit F :=
   IsLimit.conePointUniqueUpToIso (limit.isLimit F')
     (F'.isLimitConeOfIsRightKanExtension α (limit.isLimit F))

--- a/Mathlib/CategoryTheory/Functor/KanExtension/Basic.lean
+++ b/Mathlib/CategoryTheory/Functor/KanExtension/Basic.lean
@@ -625,7 +625,6 @@ def isLimitConeOfIsRightKanExtension {c : Cone F} (hc : IsLimit c) :
     dsimp at this ⊢
     rw [← assoc, this, IsLimit.fac, NatTrans.comp_app, whiskerLeft_app])
 
-
 variable [HasLimit F] [HasLimit F']
 
 /-- If `F' : D ⥤ H` is a right Kan extension of `F : C ⥤ H` along `L : C ⥤ D`, the limit over `F'`


### PR DESCRIPTION
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
