### PR TITLE
[Merged by Bors] - feat(RingTheory/PowerSeries/WellKnown): changed `PowerSeries.invOneSubPow`

### DIFF
--- a/Mathlib/RingTheory/PowerSeries/WellKnown.lean
+++ b/Mathlib/RingTheory/PowerSeries/WellKnown.lean
@@ -120,8 +120,7 @@ theorem invOneSubPow_zero_val_eq_one : (invOneSubPow S 0).val = 1 := by
 
 theorem invOneSubPow_val_eq_mk_sub_one_add_choose_of_pos (h : 0 < d) :
     (invOneSubPow S d).val = (mk fun n => Nat.choose (d - 1 + n) (d - 1) : S⟦X⟧) := by
-  rw [show d = d - 1 + 1 by exact (Nat.sub_eq_iff_eq_add h).mp rfl]
-  rfl
+  rw [← Nat.sub_one_add_one_eq_of_pos h, invOneSubPow, add_tsub_cancel_right]
 
 theorem invOneSubPow_val_succ_eq_mk_add_choose :
     (invOneSubPow S (d + 1)).val = (mk fun n => Nat.choose (d + n) d : S⟦X⟧) := rfl

--- a/Mathlib/RingTheory/PowerSeries/WellKnown.lean
+++ b/Mathlib/RingTheory/PowerSeries/WellKnown.lean
@@ -142,7 +142,7 @@ theorem invOneSubPow_eq_inv_one_sub_pow :
   | zero => exact Eq.symm <| pow_zero _
   | succ d _ =>
       rw [inv_pow]
-      refine (DivisionMonoid.inv_eq_of_mul _ (invOneSubPow S (d + 1)) <| by
+      exact (DivisionMonoid.inv_eq_of_mul _ (invOneSubPow S (d + 1)) <| by
         rw [← Units.val_eq_one, Units.val_mul, Units.val_pow_eq_pow_val]
         exact (invOneSubPow S (d + 1)).inv_val).symm
 

--- a/Mathlib/RingTheory/PowerSeries/WellKnown.lean
+++ b/Mathlib/RingTheory/PowerSeries/WellKnown.lean
@@ -114,7 +114,7 @@ noncomputable def invOneSubPow : ℕ → S⟦X⟧ˣ
       rw [← mk_one_pow_eq_mk_choose_add, ← mul_pow, mul_comm, mk_one_mul_one_sub_eq_one, one_pow]
     }
 
-theorem invOneSubPow_zero_val_eq_one : (invOneSubPow S 0).val = 1 := by
+theorem invOneSubPow_zero : invOneSubPow S 0 = 1 := by
   delta invOneSubPow
   simp only [Units.val_one]
 

--- a/Mathlib/RingTheory/PowerSeries/WellKnown.lean
+++ b/Mathlib/RingTheory/PowerSeries/WellKnown.lean
@@ -116,7 +116,7 @@ noncomputable def invOneSubPow : ℕ → S⟦X⟧ˣ
 
 theorem invOneSubPow_zero_val_eq_one : (invOneSubPow S 0).val = 1 := by
   delta invOneSubPow
-  simp only [h, Units.val_one]
+  simp only [Units.val_one]
 
 theorem invOneSubPow_val_eq_mk_sub_one_add_choose_of_pos (h : 0 < d) :
     (invOneSubPow S d).val = (mk fun n => Nat.choose (d - 1 + n) (d - 1) : S⟦X⟧) := by

--- a/Mathlib/RingTheory/PowerSeries/WellKnown.lean
+++ b/Mathlib/RingTheory/PowerSeries/WellKnown.lean
@@ -135,8 +135,9 @@ whose inverse is the power series `1 + X + X^2 + ...`. This theorem states that 
 `PowerSeries.invOneSubPow S d` is equal to `(1 - X)⁻¹ ^ d`.
 -/
 theorem invOneSubPow_eq_inv_one_sub_pow :
-    invOneSubPow S d = (Units.mkOfMulEqOne (1 - X) (mk 1 : S⟦X⟧)
-    <| Eq.trans (mul_comm _ _) (mk_one_mul_one_sub_eq_one S))⁻¹ ^ d := by
+    invOneSubPow S d =
+      (Units.mkOfMulEqOne (1 - X) (mk 1 : S⟦X⟧) <|
+        Eq.trans (mul_comm _ _) (mk_one_mul_one_sub_eq_one S))⁻¹ ^ d := by
   induction d with
   | zero => exact Eq.symm <| pow_zero _
   | succ d _ =>

--- a/Mathlib/RingTheory/PowerSeries/WellKnown.lean
+++ b/Mathlib/RingTheory/PowerSeries/WellKnown.lean
@@ -114,8 +114,7 @@ noncomputable def invOneSubPow : ℕ → S⟦X⟧ˣ
       rw [← mk_one_pow_eq_mk_choose_add, ← mul_pow, mul_comm, mk_one_mul_one_sub_eq_one, one_pow]
     }
 
-theorem invOneSubPow_val_eq_one_of_eq_zero (h : d = 0) :
-    (invOneSubPow S d).val = 1 := by
+theorem invOneSubPow_zero_val_eq_one : (invOneSubPow S 0).val = 1 := by
   delta invOneSubPow
   simp only [h, Units.val_one]
 

--- a/Mathlib/RingTheory/PowerSeries/WellKnown.lean
+++ b/Mathlib/RingTheory/PowerSeries/WellKnown.lean
@@ -18,8 +18,9 @@ In this file we define the following power series:
   It is given by `∑ n, x ^ n /ₚ u ^ (n + 1)`.
 
 * `PowerSeries.invOneSubPow`: given a commutative ring `S` and a number `d : ℕ`,
-  `PowerSeries.invOneSubPow d : S⟦X⟧ˣ` is the power series `∑ n, Nat.choose (d + n) d`
-  whose multiplicative inverse is `(1 - X) ^ (d + 1)`.
+  `PowerSeries.invOneSubPow S d` is the multiplicative inverse of `(1 - X) ^ d` in `S⟦X⟧ˣ`.
+  When `d` is `0`, `PowerSeries.invOneSubPow S d` will just be `1`. When `d` is positive,
+  `PowerSeries.invOneSubPow S d` will be `∑ n, Nat.choose (d - 1 + n) (d - 1)`.
 
 * `PowerSeries.sin`, `PowerSeries.cos`, `PowerSeries.exp` : power series for sin, cosine, and
   exponential functions.
@@ -64,7 +65,7 @@ end Ring
 
 section invOneSubPow
 
-variable {S : Type*} [CommRing S] (d : ℕ)
+variable (S : Type*) [CommRing S] (d : ℕ)
 
 /--
 (1 + X + X^2 + ...) * (1 - X) = 1.
@@ -97,39 +98,69 @@ theorem mk_one_pow_eq_mk_choose_add :
         add_right_comm]
 
 /--
-The power series `mk fun n => Nat.choose (d + n) d`, whose multiplicative inverse is
-`(1 - X) ^ (d + 1)`.
+Given a natural number `d : ℕ` and a commutative ring `S`, `PowerSeries.invOneSubPow S d` is the
+multiplicative inverse of `(1 - X) ^ d` in `S⟦X⟧ˣ`. When `d` is `0`, `PowerSeries.invOneSubPow S d`
+will just be `1`. When `d` is positive, `PowerSeries.invOneSubPow S d` will be the power series
+`mk fun n => Nat.choose (d - 1 + n) (d - 1)`.
 -/
-noncomputable def invOneSubPow : S⟦X⟧ˣ where
-  val := mk fun n => Nat.choose (d + n) d
-  inv := (1 - X) ^ (d + 1)
-  val_inv := by
-    rw [← mk_one_pow_eq_mk_choose_add, ← mul_pow, mk_one_mul_one_sub_eq_one, one_pow]
-  inv_val := by
-    rw [← mk_one_pow_eq_mk_choose_add, ← mul_pow, mul_comm, mk_one_mul_one_sub_eq_one, one_pow]
+noncomputable def invOneSubPow : ℕ → S⟦X⟧ˣ
+  | 0 => 1
+  | d + 1 => {
+    val := mk fun n => Nat.choose (d + n) d
+    inv := (1 - X) ^ (d + 1)
+    val_inv := by
+      rw [← mk_one_pow_eq_mk_choose_add, ← mul_pow, mk_one_mul_one_sub_eq_one, one_pow]
+    inv_val := by
+      rw [← mk_one_pow_eq_mk_choose_add, ← mul_pow, mul_comm, mk_one_mul_one_sub_eq_one, one_pow]
+    }
 
-theorem invOneSubPow_val_eq_mk_choose_add :
-    (invOneSubPow d).val = (mk fun n => Nat.choose (d + n) d : S⟦X⟧) := rfl
+theorem invOneSubPow_val_eq_one_of_eq_zero (h : d = 0) :
+    (invOneSubPow S d).val = 1 := by
+  delta invOneSubPow
+  simp only [h, Units.val_one]
 
-theorem invOneSubPow_val_zero_eq_invUnitSub_one :
-    (invOneSubPow 0).val = invUnitsSub (1 : Sˣ) := by
+theorem invOneSubPow_val_eq_mk_sub_one_add_choose_of_pos (h : 0 < d) :
+    (invOneSubPow S d).val = (mk fun n => Nat.choose (d - 1 + n) (d - 1) : S⟦X⟧) := by
+  rw [show d = d - 1 + 1 by exact (Nat.sub_eq_iff_eq_add h).mp rfl]
+  rfl
+
+theorem invOneSubPow_val_succ_eq_mk_add_choose :
+    (invOneSubPow S (d + 1)).val = (mk fun n => Nat.choose (d + n) d : S⟦X⟧) := rfl
+
+theorem invOneSubPow_val_one_eq_invUnitSub_one :
+    (invOneSubPow S 1).val = invUnitsSub (1 : Sˣ) := by
   simp [invOneSubPow, invUnitsSub]
 
 /--
 The theorem `PowerSeries.mk_one_mul_one_sub_eq_one` implies that `1 - X` is a unit in `S⟦X⟧`
 whose inverse is the power series `1 + X + X^2 + ...`. This theorem states that for any `d : ℕ`,
-`PowerSeries.invOneSubPow d` is equal to `(1 - X)⁻¹ ^ (d + 1)`.
+`PowerSeries.invOneSubPow S d` is equal to `(1 - X)⁻¹ ^ d`.
 -/
 theorem invOneSubPow_eq_inv_one_sub_pow :
-    invOneSubPow d = (Units.mkOfMulEqOne (1 - X) (mk 1 : S⟦X⟧)
-    <| Eq.trans (mul_comm _ _) mk_one_mul_one_sub_eq_one)⁻¹ ^ (d + 1) := by
-  rw [inv_pow]
-  exact (DivisionMonoid.inv_eq_of_mul _ (invOneSubPow d) <| by
-    rw [← Units.val_eq_one, Units.val_mul, Units.val_pow_eq_pow_val]
-    exact (invOneSubPow d).inv_val).symm
+    invOneSubPow S d = (Units.mkOfMulEqOne (1 - X) (mk 1 : S⟦X⟧)
+    <| Eq.trans (mul_comm _ _) (mk_one_mul_one_sub_eq_one S))⁻¹ ^ d := by
+  induction d with
+  | zero => exact Eq.symm <| pow_zero _
+  | succ d _ =>
+      rw [inv_pow]
+      refine (DivisionMonoid.inv_eq_of_mul _ (invOneSubPow S (d + 1)) <| by
+        rw [← Units.val_eq_one, Units.val_mul, Units.val_pow_eq_pow_val]
+        exact (invOneSubPow S (d + 1)).inv_val).symm
 
 theorem invOneSubPow_inv_eq_one_sub_pow :
-    (invOneSubPow d).inv = (1 - X : S⟦X⟧) ^ (d + 1) := rfl
+    (invOneSubPow S d).inv = (1 - X : S⟦X⟧) ^ d := by
+  induction d with
+  | zero => exact Eq.symm <| pow_zero _
+  | succ d => rfl
+
+theorem invOneSubPow_inv_eq_one_of_eq_zero (h : d = 0) :
+    (invOneSubPow S d).inv = 1 := by
+  delta invOneSubPow
+  simp only [h, Units.inv_eq_val_inv, inv_one, Units.val_one]
+
+theorem mk_add_choose_mul_one_sub_pow_eq_one :
+    (mk fun n ↦ Nat.choose (d + n) d : S⟦X⟧) * ((1 - X) ^ (d + 1)) = 1 :=
+  (invOneSubPow S (d + 1)).val_inv
 
 end invOneSubPow
 


### PR DESCRIPTION
The definition of `PowerSeries.invOneSubPow` has been changed into the following:
Given a commutative ring `S` and a number `d : ℕ`, `PowerSeries.invOneSubPow S d` is the multiplicative inverse of `(1 - X) ^ d` in `S⟦X⟧ˣ`. When `d` is `0`, `PowerSeries.invOneSubPow S d` will just be `1`. When `d` is positive, `PowerSeries.invOneSubPow S d` will be `∑ n, Nat.choose (d - 1 + n) (d - 1)`.