### PR TITLE
[Merged by Bors] - fix: docPrime unlint private declarations

### DIFF
--- a/Mathlib/Tactic/Linter/DocPrime.lean
+++ b/Mathlib/Tactic/Linter/DocPrime.lean
@@ -40,6 +40,8 @@ def docPrimeLinter : Linter where run := withSetOptionIn fun stx ↦ do
   if (← get).messages.hasErrors then
     return
   unless [``Lean.Parser.Command.declaration, `lemma].contains stx.getKind do return
+  -- ignore private declarations
+  if (stx.find? (·.isOfKind ``Lean.Parser.Command.private)).isSome then return
   let docstring := stx[0][0]
   -- The current declaration's id, possibly followed by a list of universe names.
   let declId :=


### PR DESCRIPTION
Mentioned in [Zulip](https://leanprover.zulipchat.com/#narrow/stream/287929-mathlib4/topic/theorem.20names.20with.20primes.3F/near/474282217).

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
