### PR TITLE
[Merged by Bors] - feat(LinearAlgebra/Matrix/GeneralLinearGroup): add lemmas on hom induced from a ring hom

### DIFF
--- a/Mathlib/LinearAlgebra/Matrix/GeneralLinearGroup/Defs.lean
+++ b/Mathlib/LinearAlgebra/Matrix/GeneralLinearGroup/Defs.lean
@@ -138,6 +138,10 @@ theorem map_id : map (RingHom.id R) = MonoidHom.id (GL n R) :=
   rfl
 
 @[simp]
+lemma map_apply (f : R →+* S) (i j : n) (g : GL n R) : map f g i j = f (g i j) := by
+  rfl
+
+@[simp]
 theorem map_comp (f : T →+* R) (g : R →+* S) :
     map (g.comp f) = (map g).comp (map (n := n) f) :=
   rfl
@@ -146,6 +150,49 @@ theorem map_comp (f : T →+* R) (g : R →+* S) :
 theorem map_comp_apply (f : T →+* R) (g : R →+* S) (x : GL n T) :
     (map g).comp (map f) x = map g (map f x) :=
   rfl
+
+variable (f : R →+* S)
+
+@[simp]
+lemma map_one : map f (1 : GL n R) = 1 := by
+  ext
+  simp only [_root_.map_one, Units.val_one]
+
+lemma map_mul (g h : GL n R) : map f (g * h) = map f g * map f h := by
+  ext
+  simp only [_root_.map_mul, Units.val_mul]
+
+lemma map_inv (g : GL n R) : map f g⁻¹ = (map f g)⁻¹ := by
+  ext
+  simp only [_root_.map_inv, coe_units_inv]
+
+lemma map_det (g : GL n R) : Matrix.GeneralLinearGroup.det (map f g) =
+    Units.map f (Matrix.GeneralLinearGroup.det g) := by
+  ext
+  simp only [map, RingHom.mapMatrix_apply, Units.inv_eq_val_inv, Matrix.coe_units_inv,
+    Matrix.GeneralLinearGroup.val_det_apply, Units.coe_map, MonoidHom.coe_coe]
+  symm
+  apply RingHom.map_det
+
+@[simp]
+lemma map_mul_map_inv (g : GL n R) : map f g * map f g⁻¹ = 1 := by
+  apply Units.ext
+  simp only [_root_.map_inv, mul_inv_cancel, Units.val_one]
+
+@[simp]
+lemma map_inv_mul_map (g : GL n R) : map f g⁻¹ * map f g = 1 := by
+  apply Units.ext
+  simp only [_root_.map_inv, inv_mul_cancel, Units.val_one]
+
+@[simp]
+lemma coe_map_mul_map_inv (g : GL n R) : g.val.map f * g.val⁻¹.map f = 1 := by
+  rw [← Matrix.map_mul]
+  simp
+
+@[simp]
+lemma coe_map_inv_mul_map (g : GL n R) : g.val⁻¹.map f * g.val.map f = 1 := by
+  rw [← Matrix.map_mul]
+  simp
 
 end GeneralLinearGroup
 

--- a/Mathlib/LinearAlgebra/Matrix/GeneralLinearGroup/Defs.lean
+++ b/Mathlib/LinearAlgebra/Matrix/GeneralLinearGroup/Defs.lean
@@ -178,7 +178,6 @@ lemma map_det (g : GL n R) : Matrix.GeneralLinearGroup.det (map f g) =
 lemma map_mul_map_inv (g : GL n R) : map f g * map f g⁻¹ = 1 := by
   simp only [@map_inv, @mul_inv_cancel]
 
-@[simp]
 lemma map_inv_mul_map (g : GL n R) : map f g⁻¹ * map f g = 1 := by
   simp only [@map_inv, @inv_mul_cancel]
 

--- a/Mathlib/LinearAlgebra/Matrix/GeneralLinearGroup/Defs.lean
+++ b/Mathlib/LinearAlgebra/Matrix/GeneralLinearGroup/Defs.lean
@@ -176,13 +176,11 @@ lemma map_det (g : GL n R) : Matrix.GeneralLinearGroup.det (map f g) =
 
 @[simp]
 lemma map_mul_map_inv (g : GL n R) : map f g * map f g⁻¹ = 1 := by
-  apply Units.ext
-  simp only [_root_.map_inv, mul_inv_cancel, Units.val_one]
+  simp only [@map_inv, @mul_inv_cancel]
 
 @[simp]
 lemma map_inv_mul_map (g : GL n R) : map f g⁻¹ * map f g = 1 := by
-  apply Units.ext
-  simp only [_root_.map_inv, inv_mul_cancel, Units.val_one]
+  simp only [@map_inv, @inv_mul_cancel]
 
 @[simp]
 lemma coe_map_mul_map_inv (g : GL n R) : g.val.map f * g.val⁻¹.map f = 1 := by

--- a/Mathlib/LinearAlgebra/Matrix/GeneralLinearGroup/Defs.lean
+++ b/Mathlib/LinearAlgebra/Matrix/GeneralLinearGroup/Defs.lean
@@ -175,7 +175,7 @@ lemma map_det (g : GL n R) : Matrix.GeneralLinearGroup.det (map f g) =
   apply RingHom.map_det
 
 lemma map_mul_map_inv (g : GL n R) : map f g * map f g⁻¹ = 1 := by
-  simp only [@map_inv, @mul_inv_cancel]
+  simp only [map_inv, mul_inv_cancel]
 
 lemma map_inv_mul_map (g : GL n R) : map f g⁻¹ * map f g = 1 := by
   simp only [@map_inv, @inv_mul_cancel]

--- a/Mathlib/LinearAlgebra/Matrix/GeneralLinearGroup/Defs.lean
+++ b/Mathlib/LinearAlgebra/Matrix/GeneralLinearGroup/Defs.lean
@@ -138,7 +138,7 @@ theorem map_id : map (RingHom.id R) = MonoidHom.id (GL n R) :=
   rfl
 
 @[simp]
-lemma map_apply (f : R →+* S) (i j : n) (g : GL n R) : map f g i j = f (g i j) := by
+protected lemma map_apply (f : R →+* S) (i j : n) (g : GL n R) : map f g i j = f (g i j) := by
   rfl
 
 @[simp]
@@ -154,29 +154,29 @@ theorem map_comp_apply (f : T →+* R) (g : R →+* S) (x : GL n T) :
 variable (f : R →+* S)
 
 @[simp]
-lemma map_one : map f (1 : GL n R) = 1 := by
+protected lemma map_one : map f (1 : GL n R) = 1 := by
   ext
   simp only [_root_.map_one, Units.val_one]
 
-lemma map_mul (g h : GL n R) : map f (g * h) = map f g * map f h := by
+protected lemma map_mul (g h : GL n R) : map f (g * h) = map f g * map f h := by
   ext
   simp only [_root_.map_mul, Units.val_mul]
 
-lemma map_inv (g : GL n R) : map f g⁻¹ = (map f g)⁻¹ := by
+protected lemma map_inv (g : GL n R) : map f g⁻¹ = (map f g)⁻¹ := by
   ext
   simp only [_root_.map_inv, coe_units_inv]
 
-lemma map_det (g : GL n R) : Matrix.GeneralLinearGroup.det (map f g) =
+protected lemma map_det (g : GL n R) : Matrix.GeneralLinearGroup.det (map f g) =
     Units.map f (Matrix.GeneralLinearGroup.det g) := by
   ext
   simp only [map, RingHom.mapMatrix_apply, Units.inv_eq_val_inv, Matrix.coe_units_inv,
     Matrix.GeneralLinearGroup.val_det_apply, Units.coe_map, MonoidHom.coe_coe]
   exact Eq.symm (RingHom.map_det f g.1)
 
-lemma map_mul_map_inv (g : GL n R) : map f g * map f g⁻¹ = 1 := by
+protected lemma map_mul_map_inv (g : GL n R) : map f g * map f g⁻¹ = 1 := by
   simp only [map_inv, mul_inv_cancel]
 
-lemma map_inv_mul_map (g : GL n R) : map f g⁻¹ * map f g = 1 := by
+protected lemma map_inv_mul_map (g : GL n R) : map f g⁻¹ * map f g = 1 := by
   simp only [map_inv, inv_mul_cancel]
 
 @[simp]

--- a/Mathlib/LinearAlgebra/Matrix/GeneralLinearGroup/Defs.lean
+++ b/Mathlib/LinearAlgebra/Matrix/GeneralLinearGroup/Defs.lean
@@ -173,10 +173,10 @@ protected lemma map_det (g : GL n R) : Matrix.GeneralLinearGroup.det (map f g) =
     Matrix.GeneralLinearGroup.val_det_apply, Units.coe_map, MonoidHom.coe_coe]
   exact Eq.symm (RingHom.map_det f g.1)
 
-protected lemma map_mul_map_inv (g : GL n R) : map f g * map f g⁻¹ = 1 := by
+lemma map_mul_map_inv (g : GL n R) : map f g * map f g⁻¹ = 1 := by
   simp only [map_inv, mul_inv_cancel]
 
-protected lemma map_inv_mul_map (g : GL n R) : map f g⁻¹ * map f g = 1 := by
+lemma map_inv_mul_map (g : GL n R) : map f g⁻¹ * map f g = 1 := by
   simp only [map_inv, inv_mul_cancel]
 
 @[simp]

--- a/Mathlib/LinearAlgebra/Matrix/GeneralLinearGroup/Defs.lean
+++ b/Mathlib/LinearAlgebra/Matrix/GeneralLinearGroup/Defs.lean
@@ -174,7 +174,6 @@ lemma map_det (g : GL n R) : Matrix.GeneralLinearGroup.det (map f g) =
   symm
   apply RingHom.map_det
 
-@[simp]
 lemma map_mul_map_inv (g : GL n R) : map f g * map f g⁻¹ = 1 := by
   simp only [@map_inv, @mul_inv_cancel]
 

--- a/Mathlib/LinearAlgebra/Matrix/GeneralLinearGroup/Defs.lean
+++ b/Mathlib/LinearAlgebra/Matrix/GeneralLinearGroup/Defs.lean
@@ -187,12 +187,12 @@ lemma map_inv_mul_map (g : GL n R) : map f g⁻¹ * map f g = 1 := by
 @[simp]
 lemma coe_map_mul_map_inv (g : GL n R) : g.val.map f * g.val⁻¹.map f = 1 := by
   rw [← Matrix.map_mul]
-  simp
+  simp only [isUnits_det_units, mul_nonsing_inv, map_zero, _root_.map_one, Matrix.map_one]
 
 @[simp]
 lemma coe_map_inv_mul_map (g : GL n R) : g.val⁻¹.map f * g.val.map f = 1 := by
   rw [← Matrix.map_mul]
-  simp
+  simp only [isUnits_det_units, nonsing_inv_mul, map_zero, _root_.map_one, Matrix.map_one]
 
 end GeneralLinearGroup
 

--- a/Mathlib/LinearAlgebra/Matrix/GeneralLinearGroup/Defs.lean
+++ b/Mathlib/LinearAlgebra/Matrix/GeneralLinearGroup/Defs.lean
@@ -178,7 +178,7 @@ lemma map_mul_map_inv (g : GL n R) : map f g * map f g⁻¹ = 1 := by
   simp only [map_inv, mul_inv_cancel]
 
 lemma map_inv_mul_map (g : GL n R) : map f g⁻¹ * map f g = 1 := by
-  simp only [@map_inv, @inv_mul_cancel]
+  simp only [map_inv, inv_mul_cancel]
 
 @[simp]
 lemma coe_map_mul_map_inv (g : GL n R) : g.val.map f * g.val⁻¹.map f = 1 := by

--- a/Mathlib/LinearAlgebra/Matrix/GeneralLinearGroup/Defs.lean
+++ b/Mathlib/LinearAlgebra/Matrix/GeneralLinearGroup/Defs.lean
@@ -171,8 +171,7 @@ lemma map_det (g : GL n R) : Matrix.GeneralLinearGroup.det (map f g) =
   ext
   simp only [map, RingHom.mapMatrix_apply, Units.inv_eq_val_inv, Matrix.coe_units_inv,
     Matrix.GeneralLinearGroup.val_det_apply, Units.coe_map, MonoidHom.coe_coe]
-  symm
-  apply RingHom.map_det
+  exact Eq.symm (RingHom.map_det f g.1)
 
 lemma map_mul_map_inv (g : GL n R) : map f g * map f g⁻¹ = 1 := by
   simp only [map_inv, mul_inv_cancel]


### PR DESCRIPTION
This PR adds some basic lemmas on the hom between GL(n)s 
induced from a ring hom to LinearAlgebra.Matrix.GeneralLinearGroup.Defs.lean .

Co-authored-by: Christian Merten (github: chrisflav).
Used in project Formalization of the Bruhat-Tits Tree.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
