### PR TITLE
[Merged by Bors] - docs(RingTheory/DedekindDomain/Basic): remove a TODO that has already been done in #16631

### DIFF
--- a/Mathlib/RingTheory/DedekindDomain/Basic.lean
+++ b/Mathlib/RingTheory/DedekindDomain/Basic.lean
@@ -122,7 +122,6 @@ use `isDedekindDomain_iff` to prove `IsDedekindDomain` for a given `fraction_map
 
 This is the default implementation, but there are equivalent definitions,
 `IsDedekindDomainDvr` and `IsDedekindDomainInv`.
-TODO: Prove that these are actually equivalent definitions.
 -/
 class IsDedekindDomain
   extends IsDomain A, IsDedekindRing A : Prop


### PR DESCRIPTION
Remove a TODO in `DedekindDomain/Basic.lean` that has already been done in #16631.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
