### PR TITLE
[Merged by Bors] - feat(Combinatorics/SimpleGraph/Matching): graph isomorphisms preserve matchings

### DIFF
--- a/Mathlib/Combinatorics/SimpleGraph/Maps.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Maps.lean
@@ -471,6 +471,18 @@ theorem map_mem_edgeSet_iff {e : Sym2 V} : e.map f ∈ G'.edgeSet ↔ e ∈ G.ed
 theorem apply_mem_neighborSet_iff {v w : V} : f w ∈ G'.neighborSet (f v) ↔ w ∈ G.neighborSet v :=
   map_adj_iff f
 
+@[simp]
+theorem symm_toHom_comp_toHom : f.symm.toHom.comp f.toHom = Hom.id := by
+  ext v
+  simp only [RelHom.comp_apply, RelEmbedding.coe_toRelHom, RelIso.coe_toRelEmbedding,
+    RelIso.symm_apply_apply, RelHom.id_apply]
+
+@[simp]
+theorem symm_toHom_comp_symm_toHom : f.toHom.comp f.symm.toHom = Hom.id := by
+  ext v
+  simp only [RelHom.comp_apply, RelEmbedding.coe_toRelHom, RelIso.coe_toRelEmbedding,
+    RelIso.apply_symm_apply, RelHom.id_apply]
+
 /-- An isomorphism of graphs induces an equivalence of edge sets. -/
 @[simps]
 def mapEdgeSet : G.edgeSet ≃ G'.edgeSet where

--- a/Mathlib/Combinatorics/SimpleGraph/Maps.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Maps.lean
@@ -478,7 +478,7 @@ theorem symm_toHom_comp_toHom : f.symm.toHom.comp f.toHom = Hom.id := by
     RelIso.symm_apply_apply, RelHom.id_apply]
 
 @[simp]
-theorem symm_toHom_comp_symm_toHom : f.toHom.comp f.symm.toHom = Hom.id := by
+theorem toHom_comp_symm_toHom : f.toHom.comp f.symm.toHom = Hom.id := by
   ext v
   simp only [RelHom.comp_apply, RelEmbedding.coe_toRelHom, RelIso.coe_toRelEmbedding,
     RelIso.apply_symm_apply, RelHom.id_apply]

--- a/Mathlib/Combinatorics/SimpleGraph/Matching.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Matching.lean
@@ -138,7 +138,7 @@ protected lemma IsMatching.map {G' : SimpleGraph W} {M : Subgraph G} (f : G →g
   rintro _ ⟨v, hv, rfl⟩
   obtain ⟨v', hv'⟩ := hM hv
   use f v'
-  refine ⟨by simp only [Relation.map_apply]; exact ⟨v, ⟨v', ⟨hv'.1, rfl, rfl⟩⟩⟩, ?_⟩
+  refine ⟨by simp only [Relation.map_apply]; exact ⟨v, v', hv'.1, rfl, rfl⟩, ?_⟩
   intro y hy
   obtain ⟨w', hw'⟩ := hf.existsUnique y
   rw [map_adj, ← hw'.1, Relation.map_apply_apply hf.injective hf.injective] at hy
@@ -147,9 +147,9 @@ protected lemma IsMatching.map {G' : SimpleGraph W} {M : Subgraph G} (f : G →g
 
 @[simp]
 lemma Iso.isMatching_map {G' : SimpleGraph W} {M : Subgraph G} (f : G ≃g G') :
-    (M.map f.toHom).IsMatching ↔ M.IsMatching := by
-  exact ⟨fun h ↦
-    by simpa [← map_comp] using h.map f.symm.toHom f.symm.bijective, .map f.toHom f.bijective⟩
+    (M.map f.toHom).IsMatching ↔ M.IsMatching where
+   mp h := by simpa [← map_comp] using h.map f.symm.toHom f.symm.bijective
+   mpr := .map f.toHom f.bijective
 
 /--
 The subgraph `M` of `G` is a perfect matching on `G` if it's a matching and every vertex `G` is

--- a/Mathlib/Combinatorics/SimpleGraph/Matching.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Matching.lean
@@ -148,6 +148,7 @@ lemma Iso.isMatching_map {G' : SimpleGraph W} {M : Subgraph G} (f : G ≃g G') :
     (M.map f.toHom).IsMatching ↔ M.IsMatching where
    mp h := by simpa [← map_comp] using h.map f.symm.toHom f.symm.injective
    mpr := .map f.toHom f.injective
+
 /--
 The subgraph `M` of `G` is a perfect matching on `G` if it's a matching and every vertex `G` is
 matched.

--- a/Mathlib/Combinatorics/SimpleGraph/Matching.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Matching.lean
@@ -134,23 +134,21 @@ lemma IsMatching.coeSubgraph {G' : Subgraph G} {M : Subgraph G'.coe} (hM : M.IsM
     rw [← hw.2 ⟨y, hw'⟩ hvw]
 
 protected lemma IsMatching.map {G' : SimpleGraph W} {M : Subgraph G} (f : G →g G')
-    (hf : Bijective f) (hM : M.IsMatching) : (M.map f).IsMatching := by
+    (hf : Injective f) (hM : M.IsMatching) : (M.map f).IsMatching := by
   rintro _ ⟨v, hv, rfl⟩
   obtain ⟨v', hv'⟩ := hM hv
   use f v'
-  refine ⟨by simp only [Relation.map_apply]; exact ⟨v, v', hv'.1, rfl, rfl⟩, ?_⟩
-  intro y hy
-  obtain ⟨w', hw'⟩ := hf.existsUnique y
-  rw [map_adj, ← hw'.1, Relation.map_apply_apply hf.injective hf.injective] at hy
-  rw [← hv'.2 w' hy]
-  exact hw'.1.symm
+  refine ⟨⟨v, v', hv'.1, rfl, rfl⟩, ?_⟩
+  rintro _ ⟨w, w', hw, hw', rfl⟩
+  cases hf hw'.symm
+  rw [hv'.2 w' hw]
 
 @[simp]
 lemma Iso.isMatching_map {G' : SimpleGraph W} {M : Subgraph G} (f : G ≃g G') :
     (M.map f.toHom).IsMatching ↔ M.IsMatching where
-   mp h := by simpa [← map_comp] using h.map f.symm.toHom f.symm.bijective
-   mpr := .map f.toHom f.bijective
-
+   mp h := by simpa [← map_comp] using h.map f.symm.toHom f.symm.injective
+   mpr := .map f.toHom f.injective
+   
 /--
 The subgraph `M` of `G` is a perfect matching on `G` if it's a matching and every vertex `G` is
 matched.

--- a/Mathlib/Combinatorics/SimpleGraph/Matching.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Matching.lean
@@ -148,7 +148,6 @@ lemma Iso.isMatching_map {G' : SimpleGraph W} {M : Subgraph G} (f : G ≃g G') :
     (M.map f.toHom).IsMatching ↔ M.IsMatching where
    mp h := by simpa [← map_comp] using h.map f.symm.toHom f.symm.injective
    mpr := .map f.toHom f.injective
-   
 /--
 The subgraph `M` of `G` is a perfect matching on `G` if it's a matching and every vertex `G` is
 matched.

--- a/Mathlib/Combinatorics/SimpleGraph/Matching.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Matching.lean
@@ -135,9 +135,7 @@ lemma IsMatching.coeSubgraph {G' : Subgraph G} {M : Subgraph G'.coe} (hM : M.IsM
 
 protected lemma IsMatching.map {G' : SimpleGraph W} {M : Subgraph G} (f : G →g G')
     (hf : Bijective f) (hM : M.IsMatching) : (M.map f).IsMatching := by
-  intro w hw
-  rw [map_verts] at hw
-  obtain ⟨v, hv⟩ := hw
+  rintro _ ⟨v, hv, rfl⟩
   obtain ⟨v', hv'⟩ := hM hv.1
   dsimp at *
   use f v'
@@ -153,10 +151,9 @@ protected lemma IsMatching.map {G' : SimpleGraph W} {M : Subgraph G} (f : G →g
   exact hw'.1.symm
 
 @[simp]
-lemma Iso.isMatching_map {G' : SimpleGraph W} {M : Subgraph G} (f : SimpleGraph.Iso G G') :
+lemma Iso.isMatching_map {G' : SimpleGraph W} {M : Subgraph G} (f : G ≃g G') :
     (M.map f.toHom).IsMatching ↔ M.IsMatching := by
-  refine ⟨?_, fun h ↦ IsMatching.map f.toHom (by
-      simp only [RelEmbedding.coe_toRelHom, RelIso.coe_toRelEmbedding, RelIso.bijective]) h⟩
+  exact ⟨fun h ↦ by simpa using h.map f.symm.toHom f.symm.bijective, .map f.toHom f.bijective⟩
   intro h
   rw [show M = (M.map f.toHom).map f.symm.toHom from
     by rw [← map_comp]; simp only [Iso.symm_toHom_comp_toHom, map_id]]

--- a/Mathlib/Combinatorics/SimpleGraph/Matching.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Matching.lean
@@ -136,29 +136,20 @@ lemma IsMatching.coeSubgraph {G' : Subgraph G} {M : Subgraph G'.coe} (hM : M.IsM
 protected lemma IsMatching.map {G' : SimpleGraph W} {M : Subgraph G} (f : G →g G')
     (hf : Bijective f) (hM : M.IsMatching) : (M.map f).IsMatching := by
   rintro _ ⟨v, hv, rfl⟩
-  obtain ⟨v', hv'⟩ := hM hv.1
-  dsimp at *
+  obtain ⟨v', hv'⟩ := hM hv
   use f v'
-  refine ⟨by
-    dsimp
-    rw [Relation.map_apply]
-    use v, v'
-    exact ⟨hv'.1, hv.2, rfl⟩, ?_⟩
+  refine ⟨by simp only [Relation.map_apply]; exact ⟨v, ⟨v', ⟨hv'.1, rfl, rfl⟩⟩⟩, ?_⟩
   intro y hy
   obtain ⟨w', hw'⟩ := hf.existsUnique y
-  rw [← hv.2, ← hw'.1, Relation.map_apply_apply hf.injective hf.injective] at hy
+  rw [map_adj, ← hw'.1, Relation.map_apply_apply hf.injective hf.injective] at hy
   rw [← hv'.2 w' hy]
   exact hw'.1.symm
 
 @[simp]
 lemma Iso.isMatching_map {G' : SimpleGraph W} {M : Subgraph G} (f : G ≃g G') :
     (M.map f.toHom).IsMatching ↔ M.IsMatching := by
-  exact ⟨fun h ↦ by simpa using h.map f.symm.toHom f.symm.bijective, .map f.toHom f.bijective⟩
-  intro h
-  rw [show M = (M.map f.toHom).map f.symm.toHom from
-    by rw [← map_comp]; simp only [Iso.symm_toHom_comp_toHom, map_id]]
-  exact IsMatching.map f.symm.toHom (by
-    simp only [RelEmbedding.coe_toRelHom, RelIso.coe_toRelEmbedding, RelIso.bijective]) h
+  exact ⟨fun h ↦
+    by simpa [← map_comp] using h.map f.symm.toHom f.symm.bijective, .map f.toHom f.bijective⟩
 
 /--
 The subgraph `M` of `G` is a perfect matching on `G` if it's a matching and every vertex `G` is

--- a/Mathlib/Combinatorics/SimpleGraph/Matching.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Matching.lean
@@ -40,7 +40,7 @@ one edge, and the edges of the subgraph represent the paired vertices.
 open Function
 
 namespace SimpleGraph
-variable {V : Type*} {G G': SimpleGraph V} {M M' : Subgraph G} {v w : V}
+variable {V W : Type*} {G G': SimpleGraph V} {M M' : Subgraph G} {v w : V}
 
 namespace Subgraph
 
@@ -132,6 +132,48 @@ lemma IsMatching.coeSubgraph {G' : Subgraph G} {M : Subgraph G'.coe} (hM : M.IsM
     exact ⟨hv.2 ▸ v.2, hw.1⟩
   · obtain ⟨_, hw', hvw⟩ := (coeSubgraph_adj _ _ _).mp hy
     rw [← hw.2 ⟨y, hw'⟩ hvw]
+
+lemma IsMatching.iff_map_equiv {G' : SimpleGraph W} {M : Subgraph G} (f : SimpleGraph.Iso G G') :
+    M.IsMatching ↔ (M.map f.toHom).IsMatching := by
+  constructor
+  · intro hM
+    intro v hv
+    simp only [map_verts, RelEmbedding.coe_toRelHom, RelIso.coe_toRelEmbedding, Set.mem_image] at hv
+    obtain ⟨v', ⟨hv', rfl⟩⟩ := hv
+    obtain ⟨w, hw⟩ := hM hv'
+    use f.toEmbedding w
+    dsimp at *
+    constructor
+    · have := hw.1
+      apply Relation.map_apply.mpr
+      use v', w
+    · intro y hy
+      rw [Relation.map_apply] at hy
+      obtain ⟨a, b, ⟨hab, ha, rfl⟩⟩ := hy
+      rw [RelIso.eq_iff_eq] at ha
+      subst ha
+      rw [hw.2 _ hab]
+  · intro hM
+    intro v hv
+    have hfv : f v ∈ (Subgraph.map (Iso.map f G).toHom M).verts := by
+      simpa [map_verts, RelEmbedding.coe_toRelHom, RelIso.coe_toRelEmbedding, Iso.map_apply,
+        Set.mem_image_equiv, Equiv.symm_apply_apply] using hv
+    obtain ⟨w, hw⟩ := hM hfv
+    use f.symm w
+    dsimp at *
+    constructor
+    · rw [Relation.map_apply] at hw
+      obtain ⟨a, b, ⟨hab, ha, rfl⟩⟩ := hw.1
+      rw [RelIso.eq_iff_eq] at ha
+      subst ha
+      simpa [Equiv.symm_apply_apply] using hab
+    · intro y hy
+      have : f y = w := by
+        apply hw.2 (f y)
+        rw [@Relation.map_apply]
+        use v, y
+      rw [← this]
+      simp only [RelIso.symm_apply_apply]
 
 /--
 The subgraph `M` of `G` is a perfect matching on `G` if it's a matching and every vertex `G` is

--- a/Mathlib/Combinatorics/SimpleGraph/Matching.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Matching.lean
@@ -156,13 +156,20 @@ lemma Iso.isMatching_map {G' : SimpleGraph W} {M : Subgraph G} (f : SimpleGraph.
     (M.map f.toHom).IsMatching ↔ M.IsMatching := by
   constructor
   · intro h
-    -- have : M = (M.map f).map f.symm := by
-    --   sorry
-    sorry
+    have hM := IsMatching.map f.symm.toHom (by
+      simp only [RelEmbedding.coe_toRelHom, RelIso.coe_toRelEmbedding, RelIso.bijective]) h
+
+    have : (M.map f.toHom).map f.symm.toHom = M := by
+      rw [← @Rel.inv_id]
+
+      rw [← SimpleGraph.Subgraph.map_comp]
+
+      sorry
+    rw [← this]
+    exact hM
   · intro h
     exact IsMatching.map f.toHom (by
-      
-      sorry) h
+      simp only [RelEmbedding.coe_toRelHom, RelIso.coe_toRelEmbedding, RelIso.bijective]) h
 
 /--
 The subgraph `M` of `G` is a perfect matching on `G` if it's a matching and every vertex `G` is

--- a/Mathlib/Combinatorics/SimpleGraph/Matching.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Matching.lean
@@ -155,42 +155,15 @@ protected lemma IsMatching.map {G' : SimpleGraph W} {M : Subgraph G} (f : G →g
 lemma Iso.isMatching_map {G' : SimpleGraph W} {M : Subgraph G} (f : SimpleGraph.Iso G G') :
     (M.map f.toHom).IsMatching ↔ M.IsMatching := by
   constructor
-  · intro hM v hv
-    have hfv : f v ∈ (Subgraph.map (Iso.map f G).toHom M).verts := by
-      simpa [map_verts, RelEmbedding.coe_toRelHom, RelIso.coe_toRelEmbedding, Iso.map_apply,
-        Set.mem_image_equiv, Equiv.symm_apply_apply] using hv
-    obtain ⟨w, hw⟩ := hM hfv
-    use f.symm w
-    dsimp at *
-    constructor
-    · rw [Relation.map_apply] at hw
-      obtain ⟨a, b, ⟨hab, ha, rfl⟩⟩ := hw.1
-      rw [RelIso.eq_iff_eq] at ha
-      subst ha
-      simpa [Equiv.symm_apply_apply] using hab
-    · intro y hy
-      have : f y = w := by
-        apply hw.2 (f y)
-        rw [@Relation.map_apply]
-        use v, y
-      rw [← this]
-      simp only [RelIso.symm_apply_apply]
-  · intro hM v hv
-    simp only [map_verts, RelEmbedding.coe_toRelHom, RelIso.coe_toRelEmbedding, Set.mem_image] at hv
-    obtain ⟨v', ⟨hv', rfl⟩⟩ := hv
-    obtain ⟨w, hw⟩ := hM hv'
-    use f w
-    dsimp at *
-    constructor
-    · have := hw.1
-      apply Relation.map_apply.mpr
-      use v', w
-    · intro y hy
-      rw [Relation.map_apply] at hy
-      obtain ⟨a, b, ⟨hab, ha, rfl⟩⟩ := hy
-      rw [RelIso.eq_iff_eq] at ha
-      subst ha
-      rw [hw.2 _ hab]
+  · intro h
+    -- have : M = (M.map f).map f.symm := by
+    --   sorry
+    sorry
+  · intro h
+    exact IsMatching.map f.toHom (by
+      
+      sorry) h
+
 /--
 The subgraph `M` of `G` is a perfect matching on `G` if it's a matching and every vertex `G` is
 matched.

--- a/Mathlib/Combinatorics/SimpleGraph/Matching.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Matching.lean
@@ -133,6 +133,25 @@ lemma IsMatching.coeSubgraph {G' : Subgraph G} {M : Subgraph G'.coe} (hM : M.IsM
   · obtain ⟨_, hw', hvw⟩ := (coeSubgraph_adj _ _ _).mp hy
     rw [← hw.2 ⟨y, hw'⟩ hvw]
 
+protected lemma IsMatching.map {G' : SimpleGraph W} {M : Subgraph G} (f : G →g G')
+    (hf : Bijective f) (hM : M.IsMatching) : (M.map f).IsMatching := by
+  intro w hw
+  rw [@map_verts] at hw
+  obtain ⟨v, hv⟩ := hw
+  obtain ⟨v', hv'⟩ := hM hv.1
+  dsimp at *
+  use f v'
+  refine ⟨by
+    dsimp
+    rw [Relation.map_apply]
+    use v, v'
+    exact ⟨hv'.1, hv.2, rfl⟩, ?_⟩
+  intro y hy
+  obtain ⟨w', hw'⟩ := hf.existsUnique y
+  rw [← hv.2, ← hw'.1, Relation.map_apply_apply hf.injective hf.injective] at hy
+  rw [← hv'.2 w' hy]
+  exact hw'.1.symm
+
 lemma Iso.isMatching_map {G' : SimpleGraph W} {M : Subgraph G} (f : SimpleGraph.Iso G G') :
     (M.map f.toHom).IsMatching ↔ M.IsMatching := by
   constructor

--- a/Mathlib/Combinatorics/SimpleGraph/Matching.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Matching.lean
@@ -133,28 +133,10 @@ lemma IsMatching.coeSubgraph {G' : Subgraph G} {M : Subgraph G'.coe} (hM : M.IsM
   · obtain ⟨_, hw', hvw⟩ := (coeSubgraph_adj _ _ _).mp hy
     rw [← hw.2 ⟨y, hw'⟩ hvw]
 
-lemma IsMatching.iff_map_equiv {G' : SimpleGraph W} {M : Subgraph G} (f : SimpleGraph.Iso G G') :
-    M.IsMatching ↔ (M.map f.toHom).IsMatching := by
+lemma Iso.isMatching_map {G' : SimpleGraph W} {M : Subgraph G} (f : SimpleGraph.Iso G G') :
+    (M.map f.toHom).IsMatching ↔ M.IsMatching := by
   constructor
-  · intro hM
-    intro v hv
-    simp only [map_verts, RelEmbedding.coe_toRelHom, RelIso.coe_toRelEmbedding, Set.mem_image] at hv
-    obtain ⟨v', ⟨hv', rfl⟩⟩ := hv
-    obtain ⟨w, hw⟩ := hM hv'
-    use f.toEmbedding w
-    dsimp at *
-    constructor
-    · have := hw.1
-      apply Relation.map_apply.mpr
-      use v', w
-    · intro y hy
-      rw [Relation.map_apply] at hy
-      obtain ⟨a, b, ⟨hab, ha, rfl⟩⟩ := hy
-      rw [RelIso.eq_iff_eq] at ha
-      subst ha
-      rw [hw.2 _ hab]
-  · intro hM
-    intro v hv
+  · intro hM v hv
     have hfv : f v ∈ (Subgraph.map (Iso.map f G).toHom M).verts := by
       simpa [map_verts, RelEmbedding.coe_toRelHom, RelIso.coe_toRelEmbedding, Iso.map_apply,
         Set.mem_image_equiv, Equiv.symm_apply_apply] using hv
@@ -174,7 +156,22 @@ lemma IsMatching.iff_map_equiv {G' : SimpleGraph W} {M : Subgraph G} (f : Simple
         use v, y
       rw [← this]
       simp only [RelIso.symm_apply_apply]
-
+  · intro hM v hv
+    simp only [map_verts, RelEmbedding.coe_toRelHom, RelIso.coe_toRelEmbedding, Set.mem_image] at hv
+    obtain ⟨v', ⟨hv', rfl⟩⟩ := hv
+    obtain ⟨w, hw⟩ := hM hv'
+    use f w
+    dsimp at *
+    constructor
+    · have := hw.1
+      apply Relation.map_apply.mpr
+      use v', w
+    · intro y hy
+      rw [Relation.map_apply] at hy
+      obtain ⟨a, b, ⟨hab, ha, rfl⟩⟩ := hy
+      rw [RelIso.eq_iff_eq] at ha
+      subst ha
+      rw [hw.2 _ hab]
 /--
 The subgraph `M` of `G` is a perfect matching on `G` if it's a matching and every vertex `G` is
 matched.

--- a/Mathlib/Combinatorics/SimpleGraph/Matching.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Matching.lean
@@ -136,7 +136,7 @@ lemma IsMatching.coeSubgraph {G' : Subgraph G} {M : Subgraph G'.coe} (hM : M.IsM
 protected lemma IsMatching.map {G' : SimpleGraph W} {M : Subgraph G} (f : G →g G')
     (hf : Bijective f) (hM : M.IsMatching) : (M.map f).IsMatching := by
   intro w hw
-  rw [@map_verts] at hw
+  rw [map_verts] at hw
   obtain ⟨v, hv⟩ := hw
   obtain ⟨v', hv'⟩ := hM hv.1
   dsimp at *
@@ -157,13 +157,12 @@ lemma Iso.isMatching_map {G' : SimpleGraph W} {M : Subgraph G} (f : SimpleGraph.
     (M.map f.toHom).IsMatching ↔ M.IsMatching := by
   constructor
   · intro h
-    have hM := IsMatching.map f.symm.toHom (by
-      simp only [RelEmbedding.coe_toRelHom, RelIso.coe_toRelEmbedding, RelIso.bijective]) h
     have : (M.map f.toHom).map f.symm.toHom = M := by
       rw [← map_comp]
       simp only [Iso.symm_toHom_comp_toHom, map_id]
     rw [← this]
-    exact hM
+    exact IsMatching.map f.symm.toHom (by
+      simp only [RelEmbedding.coe_toRelHom, RelIso.coe_toRelEmbedding, RelIso.bijective]) h
   · intro h
     exact IsMatching.map f.toHom (by
       simp only [RelEmbedding.coe_toRelHom, RelIso.coe_toRelEmbedding, RelIso.bijective]) h

--- a/Mathlib/Combinatorics/SimpleGraph/Matching.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Matching.lean
@@ -152,19 +152,16 @@ protected lemma IsMatching.map {G' : SimpleGraph W} {M : Subgraph G} (f : G →g
   rw [← hv'.2 w' hy]
   exact hw'.1.symm
 
+@[simp]
 lemma Iso.isMatching_map {G' : SimpleGraph W} {M : Subgraph G} (f : SimpleGraph.Iso G G') :
     (M.map f.toHom).IsMatching ↔ M.IsMatching := by
   constructor
   · intro h
     have hM := IsMatching.map f.symm.toHom (by
       simp only [RelEmbedding.coe_toRelHom, RelIso.coe_toRelEmbedding, RelIso.bijective]) h
-
     have : (M.map f.toHom).map f.symm.toHom = M := by
-      rw [← @Rel.inv_id]
-
-      rw [← SimpleGraph.Subgraph.map_comp]
-
-      sorry
+      rw [← map_comp]
+      simp only [Iso.symm_toHom_comp_toHom, map_id]
     rw [← this]
     exact hM
   · intro h

--- a/Mathlib/Combinatorics/SimpleGraph/Matching.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Matching.lean
@@ -155,17 +155,13 @@ protected lemma IsMatching.map {G' : SimpleGraph W} {M : Subgraph G} (f : G →g
 @[simp]
 lemma Iso.isMatching_map {G' : SimpleGraph W} {M : Subgraph G} (f : SimpleGraph.Iso G G') :
     (M.map f.toHom).IsMatching ↔ M.IsMatching := by
-  constructor
-  · intro h
-    have : (M.map f.toHom).map f.symm.toHom = M := by
-      rw [← map_comp]
-      simp only [Iso.symm_toHom_comp_toHom, map_id]
-    rw [← this]
-    exact IsMatching.map f.symm.toHom (by
-      simp only [RelEmbedding.coe_toRelHom, RelIso.coe_toRelEmbedding, RelIso.bijective]) h
-  · intro h
-    exact IsMatching.map f.toHom (by
-      simp only [RelEmbedding.coe_toRelHom, RelIso.coe_toRelEmbedding, RelIso.bijective]) h
+  refine ⟨?_, fun h ↦ IsMatching.map f.toHom (by
+      simp only [RelEmbedding.coe_toRelHom, RelIso.coe_toRelEmbedding, RelIso.bijective]) h⟩
+  intro h
+  rw [show M = (M.map f.toHom).map f.symm.toHom from
+    by rw [← map_comp]; simp only [Iso.symm_toHom_comp_toHom, map_id]]
+  exact IsMatching.map f.symm.toHom (by
+    simp only [RelEmbedding.coe_toRelHom, RelIso.coe_toRelEmbedding, RelIso.bijective]) h
 
 /--
 The subgraph `M` of `G` is a perfect matching on `G` if it's a matching and every vertex `G` is


### PR DESCRIPTION
added lemma to prove a subgraph is a matching iff the subgraph mapped by an isomorphism is a matching.
Added in order to support a proof of Tutte's theorem, and generalize results to be introduced in #15666

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)

[Zulip Topic on Tutte's](https://leanprover.zulipchat.com/#narrow/stream/287929-mathlib4/topic/Tutte's.20theorem)