### PR TITLE
[Merged by Bors] - chore(CategoryTheory): generalize instances for limits of bifunctors

### DIFF
--- a/Mathlib/CategoryTheory/Limits/FunctorToTypes.lean
+++ b/Mathlib/CategoryTheory/Limits/FunctorToTypes.lean
@@ -20,15 +20,20 @@ open CategoryTheory.Limits
 universe w v₁ v₂ u₁ u₂
 
 variable {J : Type u₁} [Category.{v₁} J] {K : Type u₂} [Category.{v₂} K]
-variable (F : J ⥤ K ⥤ TypeMax.{u₁, w})
+variable (F : J ⥤ K ⥤ Type w)
 
-theorem jointly_surjective (k : K) {t : Cocone F} (h : IsColimit t) (x : t.pt.obj k) :
-    ∃ j y, x = (t.ι.app j).app k y := by
+theorem jointly_surjective (k : K) {t : Cocone F} (h : IsColimit t) (x : t.pt.obj k)
+    [∀ k, HasColimit (F.flip.obj k)] : ∃ j y, x = (t.ι.app j).app k y := by
   let hev := isColimitOfPreserves ((evaluation _ _).obj k) h
   obtain ⟨j, y, rfl⟩ := Types.jointly_surjective _ hev x
   exact ⟨j, y, by simp⟩
 
-theorem jointly_surjective' (k : K) (x : (colimit F).obj k) : ∃ j y, x = (colimit.ι F j).app k y :=
+theorem jointly_surjective' [∀ k, HasColimit (F.flip.obj k)] (k : K) (x : (colimit F).obj k) :
+    ∃ j y, x = (colimit.ι F j).app k y :=
   jointly_surjective _ _ (colimit.isColimit _) x
+
+theorem colimit.map_ι_apply [HasColimit F] (j : J) {k k' : K} {f : k ⟶ k'} {x} :
+    (colimit F).map f ((colimit.ι F j).app _ x) = (colimit.ι F j).app _ ((F.obj j).map f x) :=
+  congrFun ((colimit.ι F j).naturality _).symm _
 
 end CategoryTheory.FunctorToTypes


### PR DESCRIPTION
Also add a lemma about evaluating `colimit.map` into an element included into a colimit of a `Type`-valued bifunctor.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
