### PR TITLE
[Merged by Bors] - feat: `fun x ↦ (x ⊓ z, x ⊔ z)` is StrictMono in ModularLattice

### DIFF
--- a/Mathlib/GroupTheory/Coset/Basic.lean
+++ b/Mathlib/GroupTheory/Coset/Basic.lean
@@ -402,6 +402,21 @@ theorem out_eq' (a : α ⧸ s) : mk a.out' = a :=
 
 variable (s)
 
+/-- Given a subgroup `s`, the function that sends a subgroup `t` to the pair consisting of
+its intersection with `s` and its image in the quotient `α ⧸ s` is strictly monotone, even though
+it is not injective in general. -/
+@[to_additive QuotientAddGroup.strictMono_comap_prod_image "Given an additive subgroup `s`,
+the function that sends an additive subgroup `t` to the pair consisting of
+its intersection with `s` and its image in the quotient `α ⧸ s`
+is strictly monotone, even though it is not injective in general."]
+theorem strictMono_comap_prod_image :
+    StrictMono fun t : Subgroup α ↦ (t.comap s.subtype, mk (s := s) '' t) := by
+  refine fun t₁ t₂ h ↦ ⟨⟨Subgroup.comap_mono h.1, Set.image_mono h.1⟩,
+    mt (fun ⟨le1, le2⟩ a ha ↦ ?_) h.2⟩
+  obtain ⟨a', h', eq⟩ := le2 ⟨_, ha, rfl⟩
+  convert ← t₁.mul_mem h' (@le1 ⟨_, QuotientGroup.eq.1 eq⟩ <| t₂.mul_mem (t₂.inv_mem <| h.1 h') ha)
+  apply mul_inv_cancel_left
+
 /- It can be useful to write `obtain ⟨h, H⟩ := mk_out'_eq_mul ...`, and then `rw [H]` or
   `simp_rw [H]` or `simp only [H]`. In order for `simp_rw` and `simp only` to work, this lemma is
   stated in terms of an arbitrary `h : s`, rather than the specific `h = g⁻¹ * (mk g).out'`. -/

--- a/Mathlib/GroupTheory/QuotientGroup/Basic.lean
+++ b/Mathlib/GroupTheory/QuotientGroup/Basic.lean
@@ -167,6 +167,11 @@ theorem mk_prod {G ι : Type*} [CommGroup G] (N : Subgroup G) (s : Finset ι) {f
 
 @[to_additive (attr := simp)] lemma map_mk'_self : N.map (mk' N) = ⊥ := by aesop
 
+@[to_additive QuotientAddGroup.strictMono_comap_prod_map]
+theorem strictMono_comap_prod_map :
+    StrictMono fun H : Subgroup G ↦ (H.comap N.subtype, H.map (mk' N)) :=
+  strictMono_comap_prod_image N
+
 /-- A group homomorphism `φ : G →* M` with `N ⊆ ker(φ)` descends (i.e. `lift`s) to a
 group homomorphism `G/N →* M`. -/
 @[to_additive "An `AddGroup` homomorphism `φ : G →+ M` with `N ⊆ ker(φ)` descends (i.e. `lift`s)

--- a/Mathlib/LinearAlgebra/Quotient.lean
+++ b/Mathlib/LinearAlgebra/Quotient.lean
@@ -282,8 +282,13 @@ def mkQ : M →ₗ[R] M ⧸ p where
 theorem mkQ_apply (x : M) : p.mkQ x = (Quotient.mk x : M ⧸ p) :=
   rfl
 
-theorem mkQ_surjective (A : Submodule R M) : Function.Surjective A.mkQ := by
+theorem mkQ_surjective : Function.Surjective p.mkQ := by
   rintro ⟨x⟩; exact ⟨x, rfl⟩
+
+theorem strictMono_comap_prod_map :
+    StrictMono fun m : Submodule R M ↦ (m.comap p.subtype, m.map p.mkQ) :=
+  fun m₁ m₂ ↦ QuotientAddGroup.strictMono_comap_prod_map
+    p.toAddSubgroup (a := m₁.toAddSubgroup) (b := m₂.toAddSubgroup)
 
 end
 

--- a/Mathlib/Order/ModularLattice.lean
+++ b/Mathlib/Order/ModularLattice.lean
@@ -218,6 +218,10 @@ theorem sup_lt_sup_of_lt_of_inf_le_inf (hxy : x < y) (hinf : y ⊓ z ≤ x ⊓ z
 theorem inf_lt_inf_of_lt_of_sup_le_sup (hxy : x < y) (hinf : y ⊔ z ≤ x ⊔ z) : x ⊓ z < y ⊓ z :=
   sup_lt_sup_of_lt_of_inf_le_inf (α := αᵒᵈ) hxy hinf
 
+theorem strictMono_inf_prod_sup : StrictMono fun x ↦ (x ⊓ z, x ⊔ z) := fun _x _y hxy ↦
+  ⟨⟨inf_le_inf_right _ hxy.le, sup_le_sup_right hxy.le _⟩,
+    fun ⟨inf_le, sup_le⟩ ↦ (sup_lt_sup_of_lt_of_inf_le_inf hxy inf_le).not_le sup_le⟩
+
 /-- A generalization of the theorem that if `N` is a submodule of `M` and
   `N` and `M / N` are both Artinian, then `M` is Artinian. -/
 theorem wellFounded_lt_exact_sequence {β γ : Type*} [PartialOrder β] [Preorder γ]
@@ -225,16 +229,9 @@ theorem wellFounded_lt_exact_sequence {β γ : Type*} [PartialOrder β] [Preorde
     (f₁ : β → α) (f₂ : α → β) (g₁ : γ → α) (g₂ : α → γ) (gci : GaloisCoinsertion f₁ f₂)
     (gi : GaloisInsertion g₂ g₁) (hf : ∀ a, f₁ (f₂ a) = a ⊓ K) (hg : ∀ a, g₁ (g₂ a) = a ⊔ K) :
     WellFoundedLT α :=
-  ⟨Subrelation.wf
-    (@fun A B hAB =>
-      show Prod.Lex (· < ·) (· < ·) (f₂ A, g₂ A) (f₂ B, g₂ B) by
-        simp only [Prod.lex_def, lt_iff_le_not_le, ← gci.l_le_l_iff, ← gi.u_le_u_iff, hf, hg,
-          le_antisymm_iff]
-        simp only [gci.l_le_l_iff, gi.u_le_u_iff, ← lt_iff_le_not_le, ← le_antisymm_iff]
-        rcases lt_or_eq_of_le (inf_le_inf_right K (le_of_lt hAB)) with h | h
-        · exact Or.inl h
-        · exact Or.inr ⟨h, sup_lt_sup_of_lt_of_inf_le_inf hAB (le_of_eq h.symm)⟩)
-    (InvImage.wf _ (h₁.wf.prod_lex h₂.wf))⟩
+  StrictMono.wellFoundedLT (f := fun A ↦ (f₂ A, g₂ A)) fun A B hAB ↦ by
+    simp only [Prod.le_def, lt_iff_le_not_le, ← gci.l_le_l_iff, ← gi.u_le_u_iff, hf, hg]
+    exact strictMono_inf_prod_sup hAB
 
 /-- A generalization of the theorem that if `N` is a submodule of `M` and
   `N` and `M / N` are both Noetherian, then `M` is Noetherian. -/
@@ -261,7 +258,7 @@ def infIccOrderIsoIccSup (a b : α) : Set.Icc (a ⊓ b) a ≃o Set.Icc b (a ⊔ 
       (by
         change a ⊓ ↑x ⊔ b = ↑x
         rw [inf_comm, inf_sup_assoc_of_le _ x.prop.1, inf_eq_left.2 x.prop.2])
-  map_rel_iff' := @fun x y => by
+  map_rel_iff' {x y} := by
     simp only [Subtype.mk_le_mk, Equiv.coe_fn_mk, le_sup_right]
     rw [← Subtype.coe_le_coe]
     refine ⟨fun h => ?_, fun h => sup_le_sup_right h _⟩


### PR DESCRIPTION
In the proof of `wellFounded_lt_exact_sequence`, it is implicitly shown that `fun x : α ↦ (x ⊓ z, x ⊔ z)` is StrictMono in a modular lattice, with the lexicographic order on `α × α`. Here we show the stronger result with `α × α` equipped with the product order, and golf the proof.

If `G` is not an abelian group, then `α = Subgroup G` is not necessarily a modular lattice. However, if `z` is a normal subgroup, the result still holds true. We prove a closely related result `strictMono_comap_prod_map` which replaces `inf` with `comap` and `sup` with `map`, so it concerns a function to `Subgroup z × Subgroup (G ⧸ z)` instead. The same result for submodules immediately implies that Noetherian/Artinian are closed under extensions, which is proven in #17425 using `wellFounded_lt/gt_exact_sequence`.

If `z` is not even normal, the function to `Subgroup z × Set (G ⧸ z)` is still StrictMono.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
