### PR TITLE
[Merged by Bors] - feat: order properties of `Finsupp.single`

### DIFF
--- a/Mathlib/Data/Finsupp/Order.lean
+++ b/Mathlib/Data/Finsupp/Order.lean
@@ -43,7 +43,6 @@ lemma sum_le_sum (h : ∀ i ∈ f.support, h₁ i (f i) ≤ h₂ i (f i)) : f.su
 
 end OrderedAddCommMonoid
 
-
 section LE
 variable [LE α] {f g : ι →₀ α}
 
@@ -150,7 +149,7 @@ end Zero
 /-! ### Algebraic order structures -/
 
 section OrderedAddCommMonoid
-variable [OrderedAddCommMonoid α] {i : ι} {a b : α} {f : ι → κ} {g g₁ g₂ : ι →₀ α}
+variable [OrderedAddCommMonoid α] {i : ι} {f : ι → κ} {g g₁ g₂ : ι →₀ α}
 
 instance orderedAddCommMonoid : OrderedAddCommMonoid (ι →₀ α) :=
   { Finsupp.instAddCommMonoid, Finsupp.partialorder with

--- a/Mathlib/Data/Finsupp/Order.lean
+++ b/Mathlib/Data/Finsupp/Order.lean
@@ -98,7 +98,7 @@ variable [OrderedAddCommMonoid β]
 
 lemma sum_le_sum_index [DecidableEq ι] {f₁ f₂ : ι →₀ α} {h : ι → α → β} (hf : f₁ ≤ f₂)
     (hh : ∀ i ∈ f₁.support ∪ f₂.support, Monotone (h i))
-    (hh₀ : ∀ i ∈ f₁.support ∪ f₂.support, h i 0 = 0): f₁.sum h ≤ f₂.sum h := by
+    (hh₀ : ∀ i ∈ f₁.support ∪ f₂.support, h i 0 = 0) : f₁.sum h ≤ f₂.sum h := by
   classical
   rw [sum_of_support_subset _ Finset.subset_union_left _ hh₀,
     sum_of_support_subset _ Finset.subset_union_right _ hh₀]

--- a/Mathlib/Data/Finsupp/Order.lean
+++ b/Mathlib/Data/Finsupp/Order.lean
@@ -3,7 +3,9 @@ Copyright (c) 2021 Johan Commelin. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johan Commelin, Aaron Anderson
 -/
+import Mathlib.Algebra.Order.BigOperators.Group.Finset
 import Mathlib.Algebra.Order.Module.Defs
+import Mathlib.Algebra.Order.Pi
 import Mathlib.Data.Finsupp.Basic
 
 /-!
@@ -21,7 +23,7 @@ noncomputable section
 
 open Finset
 
-variable {ι α β : Type*}
+variable {ι κ α β : Type*}
 
 namespace Finsupp
 
@@ -31,6 +33,16 @@ namespace Finsupp
 section Zero
 
 variable [Zero α]
+
+section OrderedAddCommMonoid
+variable [OrderedAddCommMonoid β] {f : ι →₀ α} {h₁ h₂ : ι → α → β}
+
+@[gcongr]
+lemma sum_le_sum (h : ∀ i ∈ f.support, h₁ i (f i) ≤ h₂ i (f i)) : f.sum h₁ ≤ f.sum h₂ :=
+  Finset.sum_le_sum h
+
+end OrderedAddCommMonoid
+
 
 section LE
 variable [LE α] {f g : ι →₀ α}
@@ -58,7 +70,7 @@ theorem orderEmbeddingToFun_apply {f : ι →₀ α} {i : ι} : orderEmbeddingTo
 end LE
 
 section Preorder
-variable [Preorder α] {f g : ι →₀ α}
+variable [Preorder α] {f g : ι →₀ α} {i : ι} {a b : α}
 
 instance preorder : Preorder (ι →₀ α) :=
   { Finsupp.instLEFinsupp with
@@ -71,6 +83,26 @@ lemma lt_def : f < g ↔ f ≤ g ∧ ∃ i, f i < g i := Pi.lt_def
 lemma coe_mono : Monotone (Finsupp.toFun : (ι →₀ α) → ι → α) := fun _ _ ↦ id
 
 lemma coe_strictMono : Monotone (Finsupp.toFun : (ι →₀ α) → ι → α) := fun _ _ ↦ id
+
+@[simp] lemma single_le_single : single i a ≤ single i b ↔ a ≤ b := by
+  classical exact Pi.single_le_single
+
+lemma single_mono : Monotone (single i : α → ι →₀ α) := fun _ _ ↦ single_le_single.2
+
+@[gcongr] protected alias ⟨_, GCongr.single_mono⟩ := single_le_single
+
+@[simp] lemma single_nonneg : 0 ≤ single i a ↔ 0 ≤ a := by classical exact Pi.single_nonneg
+@[simp] lemma single_nonpos : single i a ≤ 0 ↔ a ≤ 0 := by classical exact Pi.single_nonpos
+
+variable [OrderedAddCommMonoid β]
+
+lemma sum_le_sum_index [DecidableEq ι] {f₁ f₂ : ι →₀ α} {h : ι → α → β} (hf : f₁ ≤ f₂)
+    (hh : ∀ i ∈ f₁.support ∪ f₂.support, Monotone (h i))
+    (hh₀ : ∀ i ∈ f₁.support ∪ f₂.support, h i 0 = 0): f₁.sum h ≤ f₂.sum h := by
+  classical
+  rw [sum_of_support_subset _ Finset.subset_union_left _ hh₀,
+    sum_of_support_subset _ Finset.subset_union_right _ hh₀]
+  exact Finset.sum_le_sum fun i hi ↦ hh _ hi <| hf _
 
 end Preorder
 
@@ -117,10 +149,23 @@ end Zero
 
 /-! ### Algebraic order structures -/
 
+section OrderedAddCommMonoid
+variable [OrderedAddCommMonoid α] {i : ι} {a b : α} {f : ι → κ} {g g₁ g₂ : ι →₀ α}
 
-instance orderedAddCommMonoid [OrderedAddCommMonoid α] : OrderedAddCommMonoid (ι →₀ α) :=
+instance orderedAddCommMonoid : OrderedAddCommMonoid (ι →₀ α) :=
   { Finsupp.instAddCommMonoid, Finsupp.partialorder with
     add_le_add_left := fun _a _b h c s => add_le_add_left (h s) (c s) }
+
+lemma mapDomain_mono : Monotone (mapDomain f : (ι →₀ α) → (κ →₀ α)) := by
+  classical exact fun g₁ g₂ h ↦ sum_le_sum_index h (fun _ _ ↦ single_mono) (by simp)
+
+@[gcongr] protected lemma GCongr.mapDomain_mono (hg : g₁ ≤ g₂) : g₁.mapDomain f ≤ g₂.mapDomain f :=
+  mapDomain_mono hg
+
+lemma mapDomain_nonneg (hg : 0 ≤ g) : 0 ≤ g.mapDomain f := by simpa using mapDomain_mono hg
+lemma mapDomain_nonpos (hg : g ≤ 0) : g.mapDomain f ≤ 0 := by simpa using mapDomain_mono hg
+
+end OrderedAddCommMonoid
 
 instance orderedCancelAddCommMonoid [OrderedCancelAddCommMonoid α] :
     OrderedCancelAddCommMonoid (ι →₀ α) :=


### PR DESCRIPTION
From LeanCamCombi


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
