### PR TITLE
[Merged by Bors] - feat: `Fintype.balance` and complex numbers

### DIFF
--- a/Mathlib/Analysis/RCLike/Basic.lean
+++ b/Mathlib/Analysis/RCLike/Basic.lean
@@ -241,7 +241,7 @@ instance (priority := 100) charZero_rclike : CharZero K :=
 lemma ofReal_expect {α : Type*} (s : Finset α) (f : α → ℝ) : 𝔼 i ∈ s, f i = 𝔼 i ∈ s, (f i : K) :=
   map_expect (algebraMap ..) ..
 
-@[simp, norm_cast]
+@[norm_cast]
 lemma ofReal_balance {ι : Type*} [Fintype ι] (f : ι → ℝ) (i : ι) :
     (↑(balance f i) : K) = balance ((↑) ∘ f) i := map_balance (algebraMap ..) ..
 

--- a/Mathlib/Analysis/RCLike/Basic.lean
+++ b/Mathlib/Analysis/RCLike/Basic.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Frédéric Dupuis
 -/
 import Mathlib.Algebra.Algebra.Field
+import Mathlib.Algebra.BigOperators.Balance
 import Mathlib.Algebra.Order.BigOperators.Expect
 import Mathlib.Algebra.Order.Star.Basic
 import Mathlib.Analysis.CStarAlgebra.Basic
@@ -40,6 +41,7 @@ their counterparts in `Mathlib/Analysis/Complex/Basic.lean` (which causes linter
 A few lemmas requiring heavier imports are in `Mathlib/Data/RCLike/Lemmas.lean`.
 -/
 
+open Fintype
 open scoped BigOperators ComplexConjugate
 
 section
@@ -238,6 +240,13 @@ instance (priority := 100) charZero_rclike : CharZero K :=
 @[rclike_simps, norm_cast]
 lemma ofReal_expect {α : Type*} (s : Finset α) (f : α → ℝ) : 𝔼 i ∈ s, f i = 𝔼 i ∈ s, (f i : K) :=
   map_expect (algebraMap ..) ..
+
+@[simp, norm_cast]
+lemma ofReal_balance {ι : Type*} [Fintype ι] (f : ι → ℝ) (i : ι) :
+    (↑(balance f i) : K) = balance ((↑) ∘ f) i := map_balance (algebraMap ..) ..
+
+@[simp] lemma ofReal_comp_balance {ι : Type*} [Fintype ι] (f : ι → ℝ) :
+    ofReal ∘ balance f = balance (ofReal ∘ f : ι → K) := funext <| ofReal_balance _
 
 /-! ### The imaginary unit, `I` -/
 

--- a/Mathlib/Analysis/RCLike/Basic.lean
+++ b/Mathlib/Analysis/RCLike/Basic.lean
@@ -243,7 +243,7 @@ lemma ofReal_expect {α : Type*} (s : Finset α) (f : α → ℝ) : 𝔼 i ∈ s
 
 @[norm_cast]
 lemma ofReal_balance {ι : Type*} [Fintype ι] (f : ι → ℝ) (i : ι) :
-    (↑(balance f i) : K) = balance ((↑) ∘ f) i := map_balance (algebraMap ..) ..
+    ((balance f i : ℝ) : K) = balance ((↑) ∘ f) i := map_balance (algebraMap ..) ..
 
 @[simp] lemma ofReal_comp_balance {ι : Type*} [Fintype ι] (f : ι → ℝ) :
     ofReal ∘ balance f = balance (ofReal ∘ f : ι → K) := funext <| ofReal_balance _

--- a/Mathlib/Data/Complex/BigOperators.lean
+++ b/Mathlib/Data/Complex/BigOperators.lean
@@ -3,13 +3,14 @@ Copyright (c) 2017 Kevin Buzzard. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Kevin Buzzard, Mario Carneiro
 -/
-import Mathlib.Algebra.BigOperators.Expect
+import Mathlib.Algebra.BigOperators.Balance
 import Mathlib.Data.Complex.Basic
 
 /-!
 # Finite sums and products of complex numbers
 -/
 
+open Fintype
 open scoped BigOperators
 
 namespace Complex
@@ -28,6 +29,13 @@ theorem ofReal_sum (f : α → ℝ) : ((∑ i ∈ s, f i : ℝ) : ℂ) = ∑ i �
 lemma ofReal_expect (f : α → ℝ) : (𝔼 i ∈ s, f i : ℝ) = 𝔼 i ∈ s, (f i : ℂ) :=
   map_expect ofReal ..
 
+@[simp, norm_cast]
+lemma ofReal_balance [Fintype α] (f : α → ℝ) (a : α) :
+    (↑(balance f a) : ℂ) = balance ((↑) ∘ f) a := by simp [balance]
+
+@[simp] lemma ofReal_comp_balance {ι : Type*} [Fintype ι] (f : ι → ℝ) :
+    ofReal ∘ balance f = balance (ofReal ∘ f : ι → ℂ) := funext <| ofReal_balance _
+
 @[simp]
 theorem re_sum (f : α → ℂ) : (∑ i ∈ s, f i).re = ∑ i ∈ s, (f i).re :=
   map_sum reAddGroupHom f s
@@ -37,11 +45,25 @@ lemma re_expect (f : α → ℂ) : (𝔼 i ∈ s, f i).re = 𝔼 i ∈ s, (f i).
   map_expect (LinearMap.mk reAddGroupHom.toAddHom (by simp)) f s
 
 @[simp]
+lemma re_balance [Fintype α] (f : α → ℂ) (a : α) : re (balance f a) = balance (re ∘ f) a := by
+  simp [balance]
+
+@[simp] lemma re_comp_balance {ι : Type*} [Fintype ι] (f : ι → ℂ) :
+    re ∘ balance f = balance (re ∘ f) := funext <| re_balance _
+
+@[simp]
 theorem im_sum (f : α → ℂ) : (∑ i ∈ s, f i).im = ∑ i ∈ s, (f i).im :=
   map_sum imAddGroupHom f s
 
 @[simp]
 lemma im_expect (f : α → ℂ) : (𝔼 i ∈ s, f i).im = 𝔼 i ∈ s, (f i).im :=
   map_expect (LinearMap.mk imAddGroupHom.toAddHom (by simp)) f s
+
+@[simp]
+lemma im_balance [Fintype α] (f : α → ℂ) (a : α) : im (balance f a) = balance (im ∘ f) a := by
+  simp [balance]
+
+@[simp] lemma im_comp_balance {ι : Type*} [Fintype ι] (f : ι → ℂ) :
+    im ∘ balance f = balance (im ∘ f) := funext <| im_balance _
 
 end Complex

--- a/Mathlib/Data/Complex/BigOperators.lean
+++ b/Mathlib/Data/Complex/BigOperators.lean
@@ -31,7 +31,7 @@ lemma ofReal_expect (f : α → ℝ) : (𝔼 i ∈ s, f i : ℝ) = 𝔼 i ∈ s,
 
 @[simp, norm_cast]
 lemma ofReal_balance [Fintype α] (f : α → ℝ) (a : α) :
-    (↑(balance f a) : ℂ) = balance ((↑) ∘ f) a := by simp [balance]
+    ((balance f a : ℝ) : ℂ) = balance ((↑) ∘ f) a := by simp [balance]
 
 @[simp] lemma ofReal_comp_balance {ι : Type*} [Fintype ι] (f : ι → ℝ) :
     ofReal ∘ balance f = balance (ofReal ∘ f : ι → ℂ) := funext <| ofReal_balance _


### PR DESCRIPTION
From LeanAPAP


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
