### PR TITLE
chore: remove confounding coercions from `Submodule.(co)map`

### DIFF
--- a/Mathlib/Algebra/Algebra/Operations.lean
+++ b/Mathlib/Algebra/Algebra/Operations.lean
@@ -106,7 +106,7 @@ theorem one_le : (1 : Submodule R A) ≤ P ↔ (1 : A) ∈ P := by
   simp only [one_eq_span, span_le, Set.singleton_subset_iff, SetLike.mem_coe]
 
 protected theorem map_one {A'} [Semiring A'] [Algebra R A'] (f : A →ₐ[R] A') :
-    map f.toLinearMap (1 : Submodule R A) = 1 := by
+    map f (1 : Submodule R A) = 1 := by
   ext
   simp
 
@@ -214,11 +214,11 @@ theorem mul_subset_mul : (↑M : Set A) * (↑N : Set A) ⊆ (↑(M * N) : Set A
   image2_subset_map₂ (Algebra.lmul R A).toLinearMap M N
 
 protected theorem map_mul {A'} [Semiring A'] [Algebra R A'] (f : A →ₐ[R] A') :
-    map f.toLinearMap (M * N) = map f.toLinearMap M * map f.toLinearMap N :=
+    map f (M * N) = map f M * map f N :=
   calc
-    map f.toLinearMap (M * N) = ⨆ i : M, (N.map (LinearMap.mul R A i)).map f.toLinearMap :=
+    map f (M * N) = ⨆ i : M, (N.map (LinearMap.mul R A i)).map f :=
       map_iSup _ _
-    _ = map f.toLinearMap M * map f.toLinearMap N := by
+    _ = map f M * map f N := by
       apply congr_arg sSup
       ext S
       constructor <;> rintro ⟨y, hy⟩
@@ -229,7 +229,6 @@ protected theorem map_mul {A'} [Semiring A'] [Algebra R A'] (f : A →ₐ[R] A')
       · obtain ⟨y', hy', fy_eq⟩ := mem_map.mp y.2
         use ⟨y', hy'⟩  -- Porting note: added `⟨⟩`
         refine Eq.trans ?_ hy
-        rw [f.toLinearMap_apply] at fy_eq
         ext
         simp [fy_eq]
 
@@ -484,7 +483,7 @@ def equivOpposite : Submodule R Aᵐᵒᵖ ≃+* (Submodule R A)ᵐᵒᵖ where
   map_mul' p q := congr_arg op <| comap_op_mul _ _
 
 protected theorem map_pow {A'} [Semiring A'] [Algebra R A'] (f : A →ₐ[R] A') (n : ℕ) :
-    map f.toLinearMap (M ^ n) = map f.toLinearMap M ^ n :=
+    map f (M ^ n) = map f M ^ n :=
   map_pow (mapHom f) M n
 
 theorem comap_unop_pow (n : ℕ) :
@@ -624,7 +623,7 @@ instance : Div (Submodule R A) :=
         exact Submodule.smul_mem _ _ (hx _ hy) }⟩
 
 theorem mem_div_iff_forall_mul_mem {x : A} {I J : Submodule R A} : x ∈ I / J ↔ ∀ y ∈ J, x * y ∈ I :=
-  Iff.refl _
+  Iff.rfl
 
 theorem mem_div_iff_smul_subset {x : A} {I J : Submodule R A} : x ∈ I / J ↔ x • (J : Set A) ⊆ I :=
   ⟨fun h y ⟨y', hy', xy'_eq_y⟩ => by
@@ -633,7 +632,7 @@ theorem mem_div_iff_smul_subset {x : A} {I J : Submodule R A} : x ∈ I / J ↔ 
     assumption, fun h y hy => h (Set.smul_mem_smul_set hy)⟩
 
 theorem le_div_iff {I J K : Submodule R A} : I ≤ J / K ↔ ∀ x ∈ I, ∀ z ∈ K, x * z ∈ J :=
-  Iff.refl _
+  Iff.rfl
 
 theorem le_div_iff_mul_le {I J K : Submodule R A} : I ≤ J / K ↔ I * K ≤ J := by
   rw [le_div_iff, mul_le]

--- a/Mathlib/Algebra/Algebra/Operations.lean
+++ b/Mathlib/Algebra/Algebra/Operations.lean
@@ -111,26 +111,22 @@ protected theorem map_one {A'} [Semiring A'] [Algebra R A'] (f : A →ₐ[R] A')
   simp
 
 @[simp]
-theorem map_op_one :
-    map (↑(opLinearEquiv R : A ≃ₗ[R] Aᵐᵒᵖ) : A →ₗ[R] Aᵐᵒᵖ) (1 : Submodule R A) = 1 := by
+theorem map_op_one : map (opLinearEquiv R) (1 : Submodule R A) = 1 := by
   ext x
   induction x
   simp
 
 @[simp]
-theorem comap_op_one :
-    comap (↑(opLinearEquiv R : A ≃ₗ[R] Aᵐᵒᵖ) : A →ₗ[R] Aᵐᵒᵖ) (1 : Submodule R Aᵐᵒᵖ) = 1 := by
+theorem comap_op_one : comap (opLinearEquiv R) (1 : Submodule R Aᵐᵒᵖ) = 1 := by
   ext
   simp
 
 @[simp]
-theorem map_unop_one :
-    map (↑(opLinearEquiv R : A ≃ₗ[R] Aᵐᵒᵖ).symm : Aᵐᵒᵖ →ₗ[R] A) (1 : Submodule R Aᵐᵒᵖ) = 1 := by
+theorem map_unop_one : map (opLinearEquiv R).symm (1 : Submodule R Aᵐᵒᵖ) = 1 := by
   rw [← comap_equiv_eq_map_symm, comap_op_one]
 
 @[simp]
-theorem comap_unop_one :
-    comap (↑(opLinearEquiv R : A ≃ₗ[R] Aᵐᵒᵖ).symm : Aᵐᵒᵖ →ₗ[R] A) (1 : Submodule R A) = 1 := by
+theorem comap_unop_one : comap (opLinearEquiv R).symm (1 : Submodule R A) = 1 := by
   rw [← map_equiv_eq_comap_symm, map_op_one]
 
 /-- Multiplication of sub-R-modules of an R-algebra A. The submodule `M * N` is the
@@ -238,9 +234,7 @@ protected theorem map_mul {A'} [Semiring A'] [Algebra R A'] (f : A →ₐ[R] A')
         simp [fy_eq]
 
 theorem map_op_mul :
-    map (↑(opLinearEquiv R : A ≃ₗ[R] Aᵐᵒᵖ) : A →ₗ[R] Aᵐᵒᵖ) (M * N) =
-      map (↑(opLinearEquiv R : A ≃ₗ[R] Aᵐᵒᵖ) : A →ₗ[R] Aᵐᵒᵖ) N *
-        map (↑(opLinearEquiv R : A ≃ₗ[R] Aᵐᵒᵖ) : A →ₗ[R] Aᵐᵒᵖ) M := by
+    map (opLinearEquiv R) (M * N) = map (opLinearEquiv R) N * map (opLinearEquiv R) M := by
   apply le_antisymm
   · simp_rw [map_le_iff_le_comap]
     refine mul_le.2 fun m hm n hn => ?_
@@ -252,25 +246,19 @@ theorem map_op_mul :
     exact mul_mem_mul hn hm
 
 theorem comap_unop_mul :
-    comap (↑(opLinearEquiv R : A ≃ₗ[R] Aᵐᵒᵖ).symm : Aᵐᵒᵖ →ₗ[R] A) (M * N) =
-      comap (↑(opLinearEquiv R : A ≃ₗ[R] Aᵐᵒᵖ).symm : Aᵐᵒᵖ →ₗ[R] A) N *
-        comap (↑(opLinearEquiv R : A ≃ₗ[R] Aᵐᵒᵖ).symm : Aᵐᵒᵖ →ₗ[R] A) M := by
+    comap (opLinearEquiv R).symm (M * N) =
+      comap (opLinearEquiv R).symm N * comap (opLinearEquiv R).symm M := by
   simp_rw [← map_equiv_eq_comap_symm, map_op_mul]
 
 theorem map_unop_mul (M N : Submodule R Aᵐᵒᵖ) :
-    map (↑(opLinearEquiv R : A ≃ₗ[R] Aᵐᵒᵖ).symm : Aᵐᵒᵖ →ₗ[R] A) (M * N) =
-      map (↑(opLinearEquiv R : A ≃ₗ[R] Aᵐᵒᵖ).symm : Aᵐᵒᵖ →ₗ[R] A) N *
-        map (↑(opLinearEquiv R : A ≃ₗ[R] Aᵐᵒᵖ).symm : Aᵐᵒᵖ →ₗ[R] A) M :=
-  have : Function.Injective (↑(opLinearEquiv R : A ≃ₗ[R] Aᵐᵒᵖ) : A →ₗ[R] Aᵐᵒᵖ) :=
-    LinearEquiv.injective _
-  map_injective_of_injective this <| by
-    rw [← map_comp, map_op_mul, ← map_comp, ← map_comp, LinearEquiv.comp_coe,
+    map (opLinearEquiv R).symm (M * N) =
+      map (opLinearEquiv R).symm N * map (opLinearEquiv R).symm M :=
+  map_injective_of_injective (opLinearEquiv R).injective <| by
+    erw [← map_comp, map_op_mul, ← map_comp, ← map_comp, LinearEquiv.comp_coe,
       LinearEquiv.symm_trans_self, LinearEquiv.refl_toLinearMap, map_id, map_id, map_id]
 
 theorem comap_op_mul (M N : Submodule R Aᵐᵒᵖ) :
-    comap (↑(opLinearEquiv R : A ≃ₗ[R] Aᵐᵒᵖ) : A →ₗ[R] Aᵐᵒᵖ) (M * N) =
-      comap (↑(opLinearEquiv R : A ≃ₗ[R] Aᵐᵒᵖ) : A →ₗ[R] Aᵐᵒᵖ) N *
-        comap (↑(opLinearEquiv R : A ≃ₗ[R] Aᵐᵒᵖ) : A →ₗ[R] Aᵐᵒᵖ) M := by
+    comap (opLinearEquiv R) (M * N) = comap (opLinearEquiv R) N * comap (opLinearEquiv R) M := by
   simp_rw [comap_equiv_eq_map_symm, map_unop_mul]
 
 lemma restrictScalars_mul {A B C} [CommSemiring A] [CommSemiring B] [Semiring C]
@@ -488,9 +476,9 @@ def mapHom {A'} [Semiring A'] [Algebra R A'] (f : A →ₐ[R] A') :
 submodules. -/
 @[simps apply symm_apply]
 def equivOpposite : Submodule R Aᵐᵒᵖ ≃+* (Submodule R A)ᵐᵒᵖ where
-  toFun p := op <| p.comap (↑(opLinearEquiv R : A ≃ₗ[R] Aᵐᵒᵖ) : A →ₗ[R] Aᵐᵒᵖ)
-  invFun p := p.unop.comap (↑(opLinearEquiv R : A ≃ₗ[R] Aᵐᵒᵖ).symm : Aᵐᵒᵖ →ₗ[R] A)
-  left_inv p := SetLike.coe_injective <| rfl
+  toFun p := op <| p.comap (opLinearEquiv R)
+  invFun p := p.unop.comap (opLinearEquiv R).symm
+  left_inv p := SetLike.coe_injective rfl
   right_inv p := unop_injective <| SetLike.coe_injective rfl
   map_add' p q := by simp [comap_equiv_eq_map_symm, ← op_add]
   map_mul' p q := congr_arg op <| comap_op_mul _ _
@@ -500,23 +488,19 @@ protected theorem map_pow {A'} [Semiring A'] [Algebra R A'] (f : A →ₐ[R] A')
   map_pow (mapHom f) M n
 
 theorem comap_unop_pow (n : ℕ) :
-    comap (↑(opLinearEquiv R : A ≃ₗ[R] Aᵐᵒᵖ).symm : Aᵐᵒᵖ →ₗ[R] A) (M ^ n) =
-      comap (↑(opLinearEquiv R : A ≃ₗ[R] Aᵐᵒᵖ).symm : Aᵐᵒᵖ →ₗ[R] A) M ^ n :=
+    comap (opLinearEquiv R).symm (M ^ n) = comap (opLinearEquiv R).symm M ^ n :=
   (equivOpposite : Submodule R Aᵐᵒᵖ ≃+* _).symm.map_pow (op M) n
 
 theorem comap_op_pow (n : ℕ) (M : Submodule R Aᵐᵒᵖ) :
-    comap (↑(opLinearEquiv R : A ≃ₗ[R] Aᵐᵒᵖ) : A →ₗ[R] Aᵐᵒᵖ) (M ^ n) =
-      comap (↑(opLinearEquiv R : A ≃ₗ[R] Aᵐᵒᵖ) : A →ₗ[R] Aᵐᵒᵖ) M ^ n :=
+    comap (opLinearEquiv R) (M ^ n) = comap (opLinearEquiv R) M ^ n :=
   op_injective <| (equivOpposite : Submodule R Aᵐᵒᵖ ≃+* _).map_pow M n
 
 theorem map_op_pow (n : ℕ) :
-    map (↑(opLinearEquiv R : A ≃ₗ[R] Aᵐᵒᵖ) : A →ₗ[R] Aᵐᵒᵖ) (M ^ n) =
-      map (↑(opLinearEquiv R : A ≃ₗ[R] Aᵐᵒᵖ) : A →ₗ[R] Aᵐᵒᵖ) M ^ n := by
+    map (opLinearEquiv R) (M ^ n) = map (opLinearEquiv R) M ^ n := by
   rw [map_equiv_eq_comap_symm, map_equiv_eq_comap_symm, comap_unop_pow]
 
 theorem map_unop_pow (n : ℕ) (M : Submodule R Aᵐᵒᵖ) :
-    map (↑(opLinearEquiv R : A ≃ₗ[R] Aᵐᵒᵖ).symm : Aᵐᵒᵖ →ₗ[R] A) (M ^ n) =
-      map (↑(opLinearEquiv R : A ≃ₗ[R] Aᵐᵒᵖ).symm : Aᵐᵒᵖ →ₗ[R] A) M ^ n := by
+    map (opLinearEquiv R).symm (M ^ n) = map (opLinearEquiv R).symm M ^ n := by
   rw [← comap_equiv_eq_map_symm, ← comap_equiv_eq_map_symm, comap_op_pow]
 
 /-- `span` is a semiring homomorphism (recall multiplication is pointwise multiplication of subsets
@@ -542,8 +526,7 @@ This is available as an instance in the `Pointwise` locale.
 
 This is a stronger version of `Submodule.pointwiseDistribMulAction`. -/
 protected def pointwiseMulSemiringAction : MulSemiringAction α (Submodule R A) :=
-  {
-    Submodule.pointwiseDistribMulAction with
+  { Submodule.pointwiseDistribMulAction with
     smul_mul := fun r x y => Submodule.map_mul x y <| MulSemiringAction.toAlgHom R A r
     smul_one := fun r => Submodule.map_one <| MulSemiringAction.toAlgHom R A r }
 

--- a/Mathlib/Algebra/Lie/SkewAdjoint.lean
+++ b/Mathlib/Algebra/Lie/SkewAdjoint.lean
@@ -61,16 +61,15 @@ variable {N : Type w} [AddCommGroup N] [Module R N] (e : N ≃ₗ[R] M)
 /-- An equivalence of modules with bilinear forms gives equivalence of Lie algebras of skew-adjoint
 endomorphisms. -/
 def skewAdjointLieSubalgebraEquiv :
-    skewAdjointLieSubalgebra (B.compl₁₂ (↑e : N →ₗ[R] M) ↑e) ≃ₗ⁅R⁆ skewAdjointLieSubalgebra B := by
+    skewAdjointLieSubalgebra (B.compl₁₂ (e : N →ₗ[R] M) e) ≃ₗ⁅R⁆ skewAdjointLieSubalgebra B := by
   apply LieEquiv.ofSubalgebras _ _ e.lieConj
   ext f
-  simp only [LieSubalgebra.mem_coe, Submodule.mem_map_equiv, LieSubalgebra.mem_map_submodule,
-    LinearEquiv.coe_coe]
+  rw [LieSubalgebra.mem_map_submodule, Submodule.mem_map_equiv]
   exact (LinearMap.isPairSelfAdjoint_equiv (B := -B) (F := B) e f).symm
 
 @[simp]
 theorem skewAdjointLieSubalgebraEquiv_apply
-    (f : skewAdjointLieSubalgebra (B.compl₁₂ (Qₗ := N) (Qₗ' := N) ↑e ↑e)) :
+    (f : skewAdjointLieSubalgebra (B.compl₁₂ (Qₗ := N) (Qₗ' := N) e e)) :
     ↑(skewAdjointLieSubalgebraEquiv B e f) = e.lieConj f := by
   simp [skewAdjointLieSubalgebraEquiv]
 

--- a/Mathlib/Algebra/Lie/Subalgebra.lean
+++ b/Mathlib/Algebra/Lie/Subalgebra.lean
@@ -350,7 +350,7 @@ theorem mem_map (x : L₂) : x ∈ K.map f ↔ ∃ y : L, y ∈ K ∧ f y = x :=
 
 -- TODO Rename and state for homs instead of equivs.
 theorem mem_map_submodule (e : L ≃ₗ⁅R⁆ L₂) (x : L₂) :
-    x ∈ K.map (e : L →ₗ⁅R⁆ L₂) ↔ x ∈ (K : Submodule R L).map (e : L →ₗ[R] L₂) :=
+    x ∈ K.map (e : L →ₗ⁅R⁆ L₂) ↔ x ∈ (K : Submodule R L).map (e : L ≃ₗ[R] L₂) :=
   Iff.rfl
 
 /-- The preimage of a Lie subalgebra under a Lie algebra morphism is a Lie subalgebra of the

--- a/Mathlib/Algebra/Module/Submodule/Map.lean
+++ b/Mathlib/Algebra/Module/Submodule/Map.lean
@@ -53,6 +53,8 @@ def map (f : F) (p : Submodule R M) : Submodule R₂ M₂ :=
       obtain ⟨a, rfl⟩ := σ₁₂.surjective c
       exact ⟨_, p.smul_mem a hy, map_smulₛₗ f _ _⟩ }
 
+theorem map_semiLinearMap (f : F) : map (f : M →ₛₗ[σ₁₂] M₂) = map f := rfl
+
 @[simp]
 theorem map_coe (f : F) (p : Submodule R M) : (map f p : Set M₂) = f '' p :=
   rfl
@@ -168,6 +170,8 @@ def comap [SemilinearMapClass F σ₁₂ M M₂] (f : F) (p : Submodule R₂ M�
     carrier := f ⁻¹' p
     -- Note: #8386 added `map_smulₛₗ _`
     smul_mem' := fun a x h => by simp [p.smul_mem (σ₁₂ a) h, map_smulₛₗ _] }
+
+theorem comap_semiLinearMap (f : F) : comap (f : M →ₛₗ[σ₁₂] M₂) = comap f := rfl
 
 @[simp]
 theorem comap_coe (f : F) (p : Submodule R₂ M₂) : (comap f p : Set M) = f ⁻¹' p :=
@@ -489,7 +493,7 @@ variable (p : Submodule R M) (q : Submodule R₂ M₂)
 -- Porting note: Was `@[simp]`.
 @[simp high]
 theorem mem_map_equiv {e : M ≃ₛₗ[τ₁₂] M₂} {x : M₂} :
-    x ∈ p.map (e : M →ₛₗ[τ₁₂] M₂) ↔ e.symm x ∈ p := by
+    x ∈ p.map e ↔ e.symm x ∈ p := by
   rw [Submodule.mem_map]; constructor
   · rintro ⟨y, hy, hx⟩
     simp [← hx, hy]
@@ -497,11 +501,11 @@ theorem mem_map_equiv {e : M ≃ₛₗ[τ₁₂] M₂} {x : M₂} :
     exact ⟨e.symm x, hx, by simp⟩
 
 theorem map_equiv_eq_comap_symm (e : M ≃ₛₗ[τ₁₂] M₂) (K : Submodule R M) :
-    K.map (e : M →ₛₗ[τ₁₂] M₂) = K.comap (e.symm : M₂ →ₛₗ[τ₂₁] M) :=
-  Submodule.ext fun _ => by rw [mem_map_equiv, mem_comap, LinearEquiv.coe_coe]
+    K.map e = K.comap e.symm :=
+  Submodule.ext fun _ => by rw [mem_map_equiv, mem_comap]
 
 theorem comap_equiv_eq_map_symm (e : M ≃ₛₗ[τ₁₂] M₂) (K : Submodule R₂ M₂) :
-    K.comap (e : M →ₛₗ[τ₁₂] M₂) = K.map (e.symm : M₂ →ₛₗ[τ₂₁] M) :=
+    K.comap e = K.map e.symm :=
   (map_equiv_eq_comap_symm e.symm K).symm
 
 variable {p}
@@ -618,7 +622,7 @@ variable {re₁₂ : RingHomInvPair σ₁₂ σ₂₁} {re₂₁ : RingHomInvPai
 variable (e : M ≃ₛₗ[σ₁₂] M₂)
 
 theorem map_eq_comap {p : Submodule R M} :
-    (p.map (e : M →ₛₗ[σ₁₂] M₂) : Submodule R₂ M₂) = p.comap (e.symm : M₂ →ₛₗ[σ₂₁] M) :=
+    (p.map e : Submodule R₂ M₂) = p.comap (e.symm : M₂ →ₛₗ[σ₂₁] M) :=
   SetLike.coe_injective <| by simp [e.image_eq_preimage]
 
 /-- A linear equivalence of two modules restricts to a linear equivalence from any submodule
@@ -627,25 +631,12 @@ theorem map_eq_comap {p : Submodule R M} :
 This is the linear version of `AddEquiv.submonoidMap` and `AddEquiv.subgroupMap`.
 
 This is `LinearEquiv.ofSubmodule'` but with `map` on the right instead of `comap` on the left. -/
-def submoduleMap (p : Submodule R M) : p ≃ₛₗ[σ₁₂] ↥(p.map (e : M →ₛₗ[σ₁₂] M₂) : Submodule R₂ M₂) :=
-  { ((e : M →ₛₗ[σ₁₂] M₂).domRestrict p).codRestrict (p.map (e : M →ₛₗ[σ₁₂] M₂)) fun x =>
-      ⟨x, by
-        simp only [LinearMap.domRestrict_apply, eq_self_iff_true, and_true, SetLike.coe_mem,
-          SetLike.mem_coe]⟩ with
-    invFun := fun y =>
-      ⟨(e.symm : M₂ →ₛₗ[σ₂₁] M) y, by
-        rcases y with ⟨y', hy⟩
-        rw [Submodule.mem_map] at hy
-        rcases hy with ⟨x, hx, hxy⟩
-        subst hxy
-        simp only [symm_apply_apply, Submodule.coe_mk, coe_coe, hx]⟩
-    left_inv := fun x => by
-      simp only [LinearMap.domRestrict_apply, LinearMap.codRestrict_apply, LinearMap.toFun_eq_coe,
-        LinearEquiv.coe_coe, LinearEquiv.symm_apply_apply, SetLike.eta]
-    right_inv := fun y => by
-      apply SetCoe.ext
-      simp only [LinearMap.domRestrict_apply, LinearMap.codRestrict_apply, LinearMap.toFun_eq_coe,
-        LinearEquiv.coe_coe, LinearEquiv.apply_symm_apply] }
+def submoduleMap (p : Submodule R M) : p ≃ₛₗ[σ₁₂] p.map e where
+  __ := ((e : M →ₛₗ[σ₁₂] M₂).domRestrict p).codRestrict (p.map e) fun x ↦
+    ⟨x, by simp only [Subtype.coe_prop, LinearMap.domRestrict_apply, coe_coe, and_self]⟩
+  invFun y := ⟨e.symm y, (Set.mem_image_equiv (f := e.toEquiv)).mp y.2⟩
+  left_inv x := Subtype.ext (e.symm_apply_apply x)
+  right_inv y := Subtype.ext (e.apply_symm_apply y)
 
 @[simp]
 theorem submoduleMap_apply (p : Submodule R M) (x : p) : ↑(e.submoduleMap p x) = e x :=
@@ -653,7 +644,7 @@ theorem submoduleMap_apply (p : Submodule R M) (x : p) : ↑(e.submoduleMap p x)
 
 @[simp]
 theorem submoduleMap_symm_apply (p : Submodule R M)
-    (x : (p.map (e : M →ₛₗ[σ₁₂] M₂) : Submodule R₂ M₂)) : ↑((e.submoduleMap p).symm x) = e.symm x :=
+    (x : p.map e) : ↑((e.submoduleMap p).symm x) = e.symm x :=
   rfl
 
 end

--- a/Mathlib/Algebra/Module/Submodule/Map.lean
+++ b/Mathlib/Algebra/Module/Submodule/Map.lean
@@ -632,8 +632,7 @@ This is the linear version of `AddEquiv.submonoidMap` and `AddEquiv.subgroupMap`
 
 This is `LinearEquiv.ofSubmodule'` but with `map` on the right instead of `comap` on the left. -/
 def submoduleMap (p : Submodule R M) : p ≃ₛₗ[σ₁₂] p.map e where
-  __ := ((e : M →ₛₗ[σ₁₂] M₂).domRestrict p).codRestrict (p.map e) fun x ↦
-    ⟨x, by simp only [Subtype.coe_prop, LinearMap.domRestrict_apply, coe_coe, and_self]⟩
+  __ := ((e : M →ₛₗ[σ₁₂] M₂).domRestrict p).codRestrict (p.map e) fun x ↦ ⟨x, by simp⟩
   invFun y := ⟨e.symm y, (Set.mem_image_equiv (f := e.toEquiv)).mp y.2⟩
   left_inv x := Subtype.ext (e.symm_apply_apply x)
   right_inv y := Subtype.ext (e.apply_symm_apply y)

--- a/Mathlib/Algebra/Module/Submodule/Map.lean
+++ b/Mathlib/Algebra/Module/Submodule/Map.lean
@@ -53,7 +53,7 @@ def map (f : F) (p : Submodule R M) : Submodule R₂ M₂ :=
       obtain ⟨a, rfl⟩ := σ₁₂.surjective c
       exact ⟨_, p.smul_mem a hy, map_smulₛₗ f _ _⟩ }
 
-theorem map_semiLinearMap (f : F) : map (f : M →ₛₗ[σ₁₂] M₂) = map f := rfl
+theorem map_semilinearMap (f : F) : map (f : M →ₛₗ[σ₁₂] M₂) = map f := rfl
 
 @[simp]
 theorem map_coe (f : F) (p : Submodule R M) : (map f p : Set M₂) = f '' p :=
@@ -171,7 +171,7 @@ def comap [SemilinearMapClass F σ₁₂ M M₂] (f : F) (p : Submodule R₂ M�
     -- Note: #8386 added `map_smulₛₗ _`
     smul_mem' := fun a x h => by simp [p.smul_mem (σ₁₂ a) h, map_smulₛₗ _] }
 
-theorem comap_semiLinearMap (f : F) : comap (f : M →ₛₗ[σ₁₂] M₂) = comap f := rfl
+theorem comap_semilinearMap (f : F) : comap (f : M →ₛₗ[σ₁₂] M₂) = comap f := rfl
 
 @[simp]
 theorem comap_coe (f : F) (p : Submodule R₂ M₂) : (comap f p : Set M) = f ⁻¹' p :=

--- a/Mathlib/LinearAlgebra/CliffordAlgebra/Conjugation.lean
+++ b/Mathlib/LinearAlgebra/CliffordAlgebra/Conjugation.lean
@@ -190,32 +190,27 @@ variable (Q)
 section Involute
 
 theorem submodule_map_involute_eq_comap (p : Submodule R (CliffordAlgebra Q)) :
-    p.map (involute : CliffordAlgebra Q →ₐ[R] CliffordAlgebra Q).toLinearMap =
-      p.comap (involute : CliffordAlgebra Q →ₐ[R] CliffordAlgebra Q).toLinearMap :=
+    p.map involute = p.comap involute :=
   Submodule.map_equiv_eq_comap_symm involuteEquiv.toLinearEquiv _
 
 @[simp]
 theorem ι_range_map_involute :
-    (ι Q).range.map (involute : CliffordAlgebra Q →ₐ[R] CliffordAlgebra Q).toLinearMap =
-      LinearMap.range (ι Q) :=
+    (ι Q).range.map involute = LinearMap.range (ι Q) :=
   (ι_range_map_lift _ _).trans (LinearMap.range_neg _)
 
 @[simp]
 theorem ι_range_comap_involute :
-    (ι Q).range.comap (involute : CliffordAlgebra Q →ₐ[R] CliffordAlgebra Q).toLinearMap =
-      LinearMap.range (ι Q) := by
+    (ι Q).range.comap involute = LinearMap.range (ι Q) := by
   rw [← submodule_map_involute_eq_comap, ι_range_map_involute]
 
 @[simp]
 theorem evenOdd_map_involute (n : ZMod 2) :
-    (evenOdd Q n).map (involute : CliffordAlgebra Q →ₐ[R] CliffordAlgebra Q).toLinearMap =
-      evenOdd Q n := by
+    (evenOdd Q n).map involute = evenOdd Q n := by
   simp_rw [evenOdd, Submodule.map_iSup, Submodule.map_pow, ι_range_map_involute]
 
 @[simp]
 theorem evenOdd_comap_involute (n : ZMod 2) :
-    (evenOdd Q n).comap (involute : CliffordAlgebra Q →ₐ[R] CliffordAlgebra Q).toLinearMap =
-      evenOdd Q n := by
+    (evenOdd Q n).comap involute = evenOdd Q n := by
   rw [← submodule_map_involute_eq_comap, evenOdd_map_involute]
 
 end Involute
@@ -223,56 +218,44 @@ end Involute
 section Reverse
 
 theorem submodule_map_reverse_eq_comap (p : Submodule R (CliffordAlgebra Q)) :
-    p.map (reverse : CliffordAlgebra Q →ₗ[R] CliffordAlgebra Q) =
-      p.comap (reverse : CliffordAlgebra Q →ₗ[R] CliffordAlgebra Q) :=
+    p.map reverse = p.comap reverse :=
   Submodule.map_equiv_eq_comap_symm (reverseEquiv : _ ≃ₗ[R] _) _
 
 @[simp]
 theorem ι_range_map_reverse :
-    (ι Q).range.map (reverse : CliffordAlgebra Q →ₗ[R] CliffordAlgebra Q)
-      = LinearMap.range (ι Q) := by
+    (ι Q).range.map reverse = LinearMap.range (ι Q) := by
   rw [reverse, reverseOp, Submodule.map_comp, ι_range_map_lift, LinearMap.range_comp,
     ← Submodule.map_comp]
   exact Submodule.map_id _
 
 @[simp]
-theorem ι_range_comap_reverse :
-    (ι Q).range.comap (reverse : CliffordAlgebra Q →ₗ[R] CliffordAlgebra Q)
-      = LinearMap.range (ι Q) := by
+theorem ι_range_comap_reverse : (ι Q).range.comap reverse = LinearMap.range (ι Q) := by
   rw [← submodule_map_reverse_eq_comap, ι_range_map_reverse]
 
 /-- Like `Submodule.map_mul`, but with the multiplication reversed. -/
 theorem submodule_map_mul_reverse (p q : Submodule R (CliffordAlgebra Q)) :
-    (p * q).map (reverse : CliffordAlgebra Q →ₗ[R] CliffordAlgebra Q) =
-      q.map (reverse : CliffordAlgebra Q →ₗ[R] CliffordAlgebra Q) *
-        p.map (reverse : CliffordAlgebra Q →ₗ[R] CliffordAlgebra Q) := by
-  simp_rw [reverse, Submodule.map_comp, Submodule.map_mul, Submodule.map_unop_mul]
+    (p * q).map reverse = q.map reverse * p.map reverse := by
+  simp_rw [reverse, Submodule.map_comp, Submodule.map_mul]; erw [Submodule.map_unop_mul]; rfl
 
 theorem submodule_comap_mul_reverse (p q : Submodule R (CliffordAlgebra Q)) :
-    (p * q).comap (reverse : CliffordAlgebra Q →ₗ[R] CliffordAlgebra Q) =
-      q.comap (reverse : CliffordAlgebra Q →ₗ[R] CliffordAlgebra Q) *
-        p.comap (reverse : CliffordAlgebra Q →ₗ[R] CliffordAlgebra Q) := by
+    (p * q).comap reverse = q.comap reverse * p.comap reverse := by
   simp_rw [← submodule_map_reverse_eq_comap, submodule_map_mul_reverse]
 
 /-- Like `Submodule.map_pow` -/
 theorem submodule_map_pow_reverse (p : Submodule R (CliffordAlgebra Q)) (n : ℕ) :
-    (p ^ n).map (reverse : CliffordAlgebra Q →ₗ[R] CliffordAlgebra Q) =
-      p.map (reverse : CliffordAlgebra Q →ₗ[R] CliffordAlgebra Q) ^ n := by
+    (p ^ n).map reverse = p.map reverse ^ n := by
   simp_rw [reverse, Submodule.map_comp, Submodule.map_pow, Submodule.map_unop_pow]
 
 theorem submodule_comap_pow_reverse (p : Submodule R (CliffordAlgebra Q)) (n : ℕ) :
-    (p ^ n).comap (reverse : CliffordAlgebra Q →ₗ[R] CliffordAlgebra Q) =
-      p.comap (reverse : CliffordAlgebra Q →ₗ[R] CliffordAlgebra Q) ^ n := by
+    (p ^ n).comap reverse = p.comap reverse ^ n := by
   simp_rw [← submodule_map_reverse_eq_comap, submodule_map_pow_reverse]
 
 @[simp]
-theorem evenOdd_map_reverse (n : ZMod 2) :
-    (evenOdd Q n).map (reverse : CliffordAlgebra Q →ₗ[R] CliffordAlgebra Q) = evenOdd Q n := by
+theorem evenOdd_map_reverse (n : ZMod 2) : (evenOdd Q n).map reverse = evenOdd Q n := by
   simp_rw [evenOdd, Submodule.map_iSup, submodule_map_pow_reverse, ι_range_map_reverse]
 
 @[simp]
-theorem evenOdd_comap_reverse (n : ZMod 2) :
-    (evenOdd Q n).comap (reverse : CliffordAlgebra Q →ₗ[R] CliffordAlgebra Q) = evenOdd Q n := by
+theorem evenOdd_comap_reverse (n : ZMod 2) : (evenOdd Q n).comap reverse = evenOdd Q n := by
   rw [← submodule_map_reverse_eq_comap, evenOdd_map_reverse]
 
 end Reverse

--- a/Mathlib/LinearAlgebra/CliffordAlgebra/Conjugation.lean
+++ b/Mathlib/LinearAlgebra/CliffordAlgebra/Conjugation.lean
@@ -235,7 +235,7 @@ theorem ι_range_comap_reverse : (ι Q).range.comap reverse = LinearMap.range (�
 /-- Like `Submodule.map_mul`, but with the multiplication reversed. -/
 theorem submodule_map_mul_reverse (p q : Submodule R (CliffordAlgebra Q)) :
     (p * q).map reverse = q.map reverse * p.map reverse := by
-  simp_rw [reverse, Submodule.map_comp, Submodule.map_mul]; erw [Submodule.map_unop_mul]; rfl
+  simp_rw [reverse, Submodule.map_comp]; erw [Submodule.map_mul, Submodule.map_unop_mul]; rfl
 
 theorem submodule_comap_mul_reverse (p q : Submodule R (CliffordAlgebra Q)) :
     (p * q).comap reverse = q.comap reverse * p.comap reverse := by
@@ -244,7 +244,7 @@ theorem submodule_comap_mul_reverse (p q : Submodule R (CliffordAlgebra Q)) :
 /-- Like `Submodule.map_pow` -/
 theorem submodule_map_pow_reverse (p : Submodule R (CliffordAlgebra Q)) (n : ℕ) :
     (p ^ n).map reverse = p.map reverse ^ n := by
-  simp_rw [reverse, Submodule.map_comp, Submodule.map_pow, Submodule.map_unop_pow]
+  simp_rw [reverse, Submodule.map_comp]; erw [Submodule.map_pow, Submodule.map_unop_pow]; rfl
 
 theorem submodule_comap_pow_reverse (p : Submodule R (CliffordAlgebra Q)) (n : ℕ) :
     (p ^ n).comap reverse = p.comap reverse ^ n := by

--- a/Mathlib/LinearAlgebra/PerfectPairing.lean
+++ b/Mathlib/LinearAlgebra/PerfectPairing.lean
@@ -190,7 +190,7 @@ open LinearEquiv
 @[simp]
 lemma dualCoannihilator_map_linearEquiv_flip (p : Submodule R M) :
     (p.map e.flip).dualCoannihilator = p.dualAnnihilator.map e.symm := by
-  ext; simp [LinearEquiv.symm_apply_eq, Submodule.mem_dualCoannihilator]
+  ext; simp [symm_apply_eq, Submodule.mem_dualCoannihilator, -mem_map_equiv]
 
 @[simp]
 lemma map_dualAnnihilator_linearEquiv_flip_symm (p : Submodule R N) :

--- a/Mathlib/RingTheory/DedekindDomain/Different.lean
+++ b/Mathlib/RingTheory/DedekindDomain/Different.lean
@@ -121,8 +121,8 @@ lemma map_equiv_traceDual [IsDomain A] [IsFractionRing B L] [IsDomain B]
     [NoZeroSMulDivisors A B] (I : Submodule B (FractionRing B)) :
     (traceDual A (FractionRing A) I).map (FractionRing.algEquiv B L) =
       traceDual A K (I.map (FractionRing.algEquiv B L)) := by
-  show Submodule.map (FractionRing.algEquiv B L).toLinearEquiv.toLinearMap _ =
-    traceDual A K (I.map (FractionRing.algEquiv B L).toLinearEquiv.toLinearMap)
+  show Submodule.map (FractionRing.algEquiv B L).toLinearEquiv _ =
+    traceDual A K (I.map (FractionRing.algEquiv B L).toLinearEquiv)
   rw [Submodule.map_equiv_eq_comap_symm, Submodule.map_equiv_eq_comap_symm]
   ext x
   simp only [AlgEquiv.toLinearEquiv_symm, AlgEquiv.toLinearEquiv_toLinearMap,
@@ -130,7 +130,7 @@ lemma map_equiv_traceDual [IsDomain A] [IsFractionRing B L] [IsDomain B]
     Submodule.mem_mk, AddSubmonoid.mem_mk, AddSubsemigroup.mem_mk, Set.mem_setOf_eq]
   apply (FractionRing.algEquiv B L).forall_congr
   simp only [restrictScalars_mem, traceForm_apply, AlgEquiv.toEquiv_eq_coe,
-    EquivLike.coe_coe, mem_comap, AlgEquiv.toLinearMap_apply, AlgEquiv.symm_apply_apply]
+    EquivLike.coe_coe, mem_comap, AlgEquiv.toLinearEquiv_apply, AlgEquiv.symm_apply_apply]
   refine fun {y} ↦ (forall_congr' fun hy ↦ ?_)
   rw [Algebra.trace_eq_of_equiv_equiv (FractionRing.algEquiv A K).toRingEquiv
     (FractionRing.algEquiv B L).toRingEquiv]

--- a/Mathlib/RingTheory/DedekindDomain/Different.lean
+++ b/Mathlib/RingTheory/DedekindDomain/Different.lean
@@ -423,8 +423,8 @@ lemma coeSubmodule_differentIdeal [NoZeroSMulDivisors A B] :
     Algebra.linearMap B L := by ext; simp
   rw [coeSubmodule, ← this]
   have H : RingHom.comp (algebraMap (FractionRing A) (FractionRing B))
-      ↑(FractionRing.algEquiv A K).symm.toRingEquiv =
-        RingHom.comp ↑(FractionRing.algEquiv B L).symm.toRingEquiv (algebraMap K L) := by
+      (FractionRing.algEquiv A K).symm =
+        RingHom.comp (FractionRing.algEquiv B L).symm (algebraMap K L) := by
     apply IsLocalization.ringHom_ext A⁰
     ext
     simp only [AlgEquiv.toRingEquiv_eq_coe, RingHom.coe_comp, RingHom.coe_coe,
@@ -435,9 +435,8 @@ lemma coeSubmodule_differentIdeal [NoZeroSMulDivisors A B] :
     Algebra.IsSeparable.of_equiv_equiv _ _ H
   have : FiniteDimensional (FractionRing A) (FractionRing B) := Module.Finite.of_equiv_equiv _ _ H
   have : Algebra.IsIntegral A B := IsIntegralClosure.isIntegral_algebra _ L
-  simp only [AlgEquiv.toLinearEquiv_toLinearMap, Submodule.map_comp]
-  rw [← coeSubmodule, coeSubmodule_differentIdeal_fractionRing _ _,
-    Submodule.map_div, ← AlgEquiv.toAlgHom_toLinearMap, Submodule.map_one]
+  rw [Submodule.map_comp, ← coeSubmodule, coeSubmodule_differentIdeal_fractionRing _ _]
+  erw [Submodule.map_div, Submodule.map_one]
   congr 1
   refine (map_equiv_traceDual A K _).trans ?_
   congr 1

--- a/Mathlib/RingTheory/FractionalIdeal/Norm.lean
+++ b/Mathlib/RingTheory/FractionalIdeal/Norm.lean
@@ -66,8 +66,8 @@ noncomputable def absNorm : FractionalIdeal R⁰ K →*₀ ℚ where
   map_mul' I J := by
     dsimp only
     rw [absNorm_div_norm_eq_absNorm_div_norm (I.den * J.den) (I.num * J.num) (by
-        have : Algebra.linearMap R K = (IsScalarTower.toAlgHom R R K).toLinearMap := rfl
-        rw [coe_mul, this, Submodule.map_mul, ← this, ← den_mul_self_eq_num, ← den_mul_self_eq_num]
+        change _ = Submodule.map (IsScalarTower.toAlgHom R R K) _
+        erw [coe_mul, Submodule.map_mul, ← den_mul_self_eq_num, ← den_mul_self_eq_num]
         exact Submodule.mul_smul_mul_eq_smul_mul_smul _ _ _ _),
       Submonoid.coe_mul, _root_.map_mul, _root_.map_mul, Nat.cast_mul, div_mul_div_comm,
       Int.cast_abs, Int.cast_abs, Int.cast_abs, ← abs_mul, Int.cast_mul]


### PR DESCRIPTION
Since `Submodule.(co)map` take a `SemilinearMapClass`, it is not necessary to coerce a `LinearEquiv` to a `SemilinearMap` before applying them.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
