### PR TITLE
chore(MvPolynomial/PDeriv): remove superfluous use of DecidableEq

### DIFF
--- a/Mathlib/Algebra/MvPolynomial/PDeriv.lean
+++ b/Mathlib/Algebra/MvPolynomial/PDeriv.lean
@@ -115,13 +115,14 @@ theorem pderiv_map {S} [CommSemiring S] {φ : R →+* S} {f : MvPolynomial σ R}
   · simp [eq]
   · simp [eq, h]
 
-lemma pderiv_rename {τ : Type*} [DecidableEq τ] [DecidableEq σ] {f : σ → τ}
+lemma pderiv_rename {τ : Type*} [DecidableEq τ] {f : σ → τ}
     (hf : Function.Injective f) (x : σ) (p : MvPolynomial σ R) :
     pderiv (f x) (rename f p) = rename f (pderiv x p) := by
   induction' p using MvPolynomial.induction_on with a p q hp hq p a h
   · simp
   · simp [hp, hq]
-  · simp only [map_mul, MvPolynomial.rename_X, Derivation.leibniz, MvPolynomial.pderiv_X,
+  · classical
+    simp only [map_mul, MvPolynomial.rename_X, Derivation.leibniz, MvPolynomial.pderiv_X,
       Pi.single_apply, hf.eq_iff, smul_eq_mul, mul_ite, mul_one, mul_zero, h, map_add, add_left_inj]
     split_ifs <;> simp
 

--- a/Mathlib/Algebra/MvPolynomial/PDeriv.lean
+++ b/Mathlib/Algebra/MvPolynomial/PDeriv.lean
@@ -115,7 +115,7 @@ theorem pderiv_map {S} [CommSemiring S] {φ : R →+* S} {f : MvPolynomial σ R}
   · simp [eq]
   · simp [eq, h]
 
-lemma pderiv_rename {τ : Type*} [DecidableEq τ] {f : σ → τ}
+lemma pderiv_rename {τ : Type*} {f : σ → τ}
     (hf : Function.Injective f) (x : σ) (p : MvPolynomial σ R) :
     pderiv (f x) (rename f p) = rename f (pderiv x p) := by
   induction' p using MvPolynomial.induction_on with a p q hp hq p a h


### PR DESCRIPTION
Found by the linter in #10235.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
