### PR TITLE
[Merged by Bors] - feat: `c * a / (c * b) ≤ a / b`

### DIFF
--- a/Mathlib/Algebra/Order/Field/Defs.lean
+++ b/Mathlib/Algebra/Order/Field/Defs.lean
@@ -89,13 +89,13 @@ lemma le_mul_div_mul_left (h : a / b ≤ 0) : a / b ≤ c * a / (c * b) := by
   · rw [mul_div_mul_left _ _ hc]
 
 /-- Equality holds when `c ≠ 0`. See `mul_div_mul_right`. -/
-lemma le_mul_div_mul_right (h : a / b ≤ 0) : a / b ≤ a * c / (b * c) := by
+lemma mul_div_mul_right_le (h : 0 ≤ a / b) : a * c / (b * c) ≤ a / b := by
   obtain rfl | hc := eq_or_ne c 0
   · simpa
   · rw [mul_div_mul_right _ _ hc]
 
 /-- Equality holds when `c ≠ 0`. See `mul_div_mul_right`. -/
-lemma mul_div_mul_right_le (h : 0 ≤ a / b) : a * c / (b * c) ≤ a / b := by
+lemma le_mul_div_mul_right (h : a / b ≤ 0) : a / b ≤ a * c / (b * c) := by
   obtain rfl | hc := eq_or_ne c 0
   · simpa
   · rw [mul_div_mul_right _ _ hc]

--- a/Mathlib/Algebra/Order/Field/Defs.lean
+++ b/Mathlib/Algebra/Order/Field/Defs.lean
@@ -82,6 +82,18 @@ lemma mul_div_mul_left_le (h : 0 ≤ a / b) : c * a / (c * b) ≤ a / b := by
   · simpa
   · rw [mul_div_mul_left _ _ hc]
 
+/-- Equality holds when `c ≠ 0`. See `mul_div_mul_left`. -/
+lemma le_mul_div_mul_left (h : a / b ≤ 0) : a / b ≤ c * a / (c * b) := by
+  obtain rfl | hc := eq_or_ne c 0
+  · simpa
+  · rw [mul_div_mul_left _ _ hc]
+
+/-- Equality holds when `c ≠ 0`. See `mul_div_mul_right`. -/
+lemma le_mul_div_mul_right (h : a / b ≤ 0) : a / b ≤ a * c / (b * c) := by
+  obtain rfl | hc := eq_or_ne c 0
+  · simpa
+  · rw [mul_div_mul_right _ _ hc]
+
 /-- Equality holds when `c ≠ 0`. See `mul_div_mul_right`. -/
 lemma mul_div_mul_right_le (h : 0 ≤ a / b) : a * c / (b * c) ≤ a / b := by
   obtain rfl | hc := eq_or_ne c 0

--- a/Mathlib/Algebra/Order/Field/Defs.lean
+++ b/Mathlib/Algebra/Order/Field/Defs.lean
@@ -36,7 +36,7 @@ instance (priority := 100) LinearOrderedField.toLinearOrderedSemifield [LinearOr
     LinearOrderedSemifield α :=
   { LinearOrderedRing.toLinearOrderedSemiring, ‹LinearOrderedField α› with }
 
-variable [LinearOrderedSemifield α] {a b : α}
+variable [LinearOrderedSemifield α] {a b c : α}
 
 /-- Equality holds when `a ≠ 0`. See `mul_inv_cancel`. -/
 lemma mul_inv_le_one : a * a⁻¹ ≤ 1 := by obtain rfl | ha := eq_or_ne a 0 <;> simp [*]
@@ -75,3 +75,15 @@ lemma inv_mul_right_le (ha : 0 ≤ a) : a * b⁻¹ * b ≤ a := by
 /-- Equality holds when `b ≠ 0`. See `inv_mul_cancel_right`. -/
 lemma le_inv_mul_right (ha : a ≤ 0) : a ≤ a * b⁻¹ * b := by
   obtain rfl | hb := eq_or_ne b 0 <;> simp [*]
+
+/-- Equality holds when `c ≠ 0`. See `mul_div_mul_left`. -/
+lemma mul_div_mul_left_le (ha : 0 ≤ a) (hb : 0 ≤ b) : c * a / (c * b) ≤ a / b := by
+  obtain rfl | hc := eq_or_ne c 0
+  · simpa using div_nonneg ha hb
+  · rw [mul_div_mul_left _ _ hc]
+
+/-- Equality holds when `c ≠ 0`. See `mul_div_mul_right`. -/
+lemma mul_div_mul_right_le (ha : 0 ≤ a) (hb : 0 ≤ b) : a * c / (b * c) ≤ a / b := by
+  obtain rfl | hc := eq_or_ne c 0
+  · simpa using div_nonneg ha hb
+  · rw [mul_div_mul_right _ _ hc]

--- a/Mathlib/Algebra/Order/Field/Defs.lean
+++ b/Mathlib/Algebra/Order/Field/Defs.lean
@@ -77,13 +77,13 @@ lemma le_inv_mul_right (ha : a ≤ 0) : a ≤ a * b⁻¹ * b := by
   obtain rfl | hb := eq_or_ne b 0 <;> simp [*]
 
 /-- Equality holds when `c ≠ 0`. See `mul_div_mul_left`. -/
-lemma mul_div_mul_left_le (ha : 0 ≤ a) (hb : 0 ≤ b) : c * a / (c * b) ≤ a / b := by
+lemma mul_div_mul_left_le (h : 0 ≤ a / b) : c * a / (c * b) ≤ a / b := by
   obtain rfl | hc := eq_or_ne c 0
-  · simpa using div_nonneg ha hb
+  · simpa
   · rw [mul_div_mul_left _ _ hc]
 
 /-- Equality holds when `c ≠ 0`. See `mul_div_mul_right`. -/
-lemma mul_div_mul_right_le (ha : 0 ≤ a) (hb : 0 ≤ b) : a * c / (b * c) ≤ a / b := by
+lemma mul_div_mul_right_le (h : 0 ≤ a / b) : a * c / (b * c) ≤ a / b := by
   obtain rfl | hc := eq_or_ne c 0
-  · simpa using div_nonneg ha hb
+  · simpa
   · rw [mul_div_mul_right _ _ hc]


### PR DESCRIPTION

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
