### PR TITLE
[Merged by Bors] - chore(Order/InitialSeg): `PrincipalSeg.down` → `PrincipalSeg.mem_range_iff_rel`

### DIFF
--- a/Mathlib/Order/InitialSeg.lean
+++ b/Mathlib/Order/InitialSeg.lean
@@ -158,16 +158,19 @@ theorem antisymm_symm [IsWellOrder α r] [IsWellOrder β s] (f : r ≼i s) (g : 
   RelIso.coe_fn_injective rfl
 
 theorem eq_or_principal [IsWellOrder β s] (f : r ≼i s) :
-    Surjective f ∨ ∃ b, ∀ x, x ∈ Set.range f ↔ s x b :=
-  or_iff_not_imp_right.2 fun h b =>
-    Acc.recOn (IsWellFounded.wf.apply b : Acc s b) fun x _ IH =>
-      not_forall_not.1 fun hn =>
-        h
-          ⟨x, fun y =>
-            ⟨fun ⟨a, e⟩ => by
-              rw [← e]
-              exact (trichotomous _ _).resolve_right
-                (not_or_intro (hn a) fun hl => not_exists.2 hn (f.mem_range_of_rel hl)), IH _⟩⟩
+    Surjective f ∨ ∃ b, ∀ x, x ∈ Set.range f ↔ s x b := by
+  apply or_iff_not_imp_right.2
+  intro h b
+  push_neg at h
+  apply IsWellFounded.induction s b
+  intro x IH
+  obtain ⟨y, ⟨hy, hs⟩ | ⟨hy, hs⟩⟩ := h x
+  · obtain (rfl | h) := (trichotomous y x).resolve_left hs
+    · exact hy
+    · obtain ⟨z, rfl⟩ := hy
+      exact f.mem_range_of_rel h
+  · obtain ⟨z, rfl⟩ := IH y hs
+    cases hy (Set.mem_range_self z)
 
 /-- Restrict the codomain of an initial segment -/
 def codRestrict (p : Set β) (f : r ≼i s) (H : ∀ a, f a ∈ p) : r ≼i Subrel s p :=

--- a/Mathlib/Order/InitialSeg.lean
+++ b/Mathlib/Order/InitialSeg.lean
@@ -158,16 +158,16 @@ theorem antisymm_symm [IsWellOrder α r] [IsWellOrder β s] (f : r ≼i s) (g : 
   RelIso.coe_fn_injective rfl
 
 theorem eq_or_principal [IsWellOrder β s] (f : r ≼i s) :
-    Surjective f ∨ ∃ b, ∀ x, s x b ↔ ∃ y, f y = x :=
+    Surjective f ∨ ∃ b, ∀ x, x ∈ Set.range f ↔ s x b :=
   or_iff_not_imp_right.2 fun h b =>
     Acc.recOn (IsWellFounded.wf.apply b : Acc s b) fun x _ IH =>
       not_forall_not.1 fun hn =>
         h
           ⟨x, fun y =>
-            ⟨IH _, fun ⟨a, e⟩ => by
+            ⟨fun ⟨a, e⟩ => by
               rw [← e]
               exact (trichotomous _ _).resolve_right
-                (not_or_intro (hn a) fun hl => not_exists.2 hn (f.mem_range_of_rel hl))⟩⟩
+                (not_or_intro (hn a) fun hl => not_exists.2 hn (f.mem_range_of_rel hl)), IH _⟩⟩
 
 /-- Restrict the codomain of an initial segment -/
 def codRestrict (p : Set β) (f : r ≼i s) (H : ∀ a, f a ∈ p) : r ≼i Subrel s p :=
@@ -216,8 +216,8 @@ embeddings are called principal segments -/
 structure PrincipalSeg {α β : Type*} (r : α → α → Prop) (s : β → β → Prop) extends r ↪r s where
   /-- The supremum of the principal segment -/
   top : β
-  /-- The image of the order embedding is the set of elements `b` such that `s b top` -/
-  down' : ∀ b, s b top ↔ ∃ a, toRelEmbedding a = b
+  /-- The range of the order embedding is the set of elements `b` such that `s b top` -/
+  mem_range_iff_rel' : ∀ b, b ∈ Set.range toRelEmbedding ↔ s b top
 
 -- Porting note: deleted `scoped[InitialSeg]`
 /-- If `r` is a relation on `α` and `s` in a relation on `β`, then `f : r ≺i s` is an order
@@ -237,15 +237,22 @@ instance : CoeFun (r ≺i s) fun _ => α → β :=
 theorem coe_fn_mk (f : r ↪r s) (t o) : (@PrincipalSeg.mk _ _ r s f t o : α → β) = f :=
   rfl
 
+theorem mem_range_iff_rel (f : r ≺i s) : ∀ {b : β}, b ∈ Set.range f ↔ s b f.top :=
+  f.mem_range_iff_rel' _
+
+@[deprecated mem_range_iff_rel (since := "2024-10-07")]
 theorem down (f : r ≺i s) : ∀ {b : β}, s b f.top ↔ ∃ a, f a = b :=
-  f.down' _
+  f.mem_range_iff_rel.symm
 
 theorem lt_top (f : r ≺i s) (a : α) : s (f a) f.top :=
-  f.down.2 ⟨_, rfl⟩
+  f.mem_range_iff_rel.1 ⟨_, rfl⟩
+
+theorem mem_range_of_rel_top (f : r ≺i s) {b : β} (h : s b f.top) : b ∈ Set.range f :=
+  f.mem_range_iff_rel.2 h
 
 theorem mem_range_of_rel [IsTrans β s] (f : r ≺i s) {a : α} {b : β} (h : s b (f a)) :
     b ∈ Set.range f :=
-  f.down.1 <| _root_.trans h <| f.lt_top _
+  f.mem_range_of_rel_top <| _root_.trans h <| f.lt_top _
 
 @[deprecated mem_range_of_rel (since := "2024-09-21")]
 alias init := mem_range_of_rel
@@ -267,8 +274,7 @@ alias init_iff := exists_eq_iff_rel
 /-- A principal segment is the same as a non-surjective initial segment. -/
 noncomputable def _root_.InitialSeg.toPrincipalSeg [IsWellOrder β s] (f : r ≼i s)
     (hf : ¬ Surjective f) : r ≺i s :=
-  letI H := f.eq_or_principal.resolve_left hf
-  ⟨f, Classical.choose H, Classical.choose_spec H⟩
+  ⟨f, _, Classical.choose_spec (f.eq_or_principal.resolve_left hf)⟩
 
 @[simp]
 theorem _root_.InitialSeg.toPrincipalSeg_apply [IsWellOrder β s] (f : r ≼i s)
@@ -286,8 +292,7 @@ instance (r : α → α → Prop) [IsWellOrder α r] : IsEmpty (r ≺i r) :=
 /-- Composition of a principal segment with an initial segment, as a principal segment -/
 def ltLe (f : r ≺i s) (g : s ≼i t) : r ≺i t :=
   ⟨@RelEmbedding.trans _ _ _ r s t f g, g f.top, fun a => by
-    simp only [g.exists_eq_iff_rel, PrincipalSeg.down, exists_and_left.symm, exists_swap,
-        RelEmbedding.trans_apply, exists_eq_right', InitialSeg.coe_coe_fn]⟩
+    simp [g.exists_eq_iff_rel, ← PrincipalSeg.mem_range_iff_rel, exists_swap, ← exists_and_left]⟩
 
 @[simp]
 theorem lt_le_apply (f : r ≺i s) (g : s ≼i t) (a : α) : (f.ltLe g) a = g (f a) :=
@@ -313,7 +318,7 @@ theorem trans_top [IsTrans γ t] (f : r ≺i s) (g : s ≺i t) : (f.trans g).top
 /-- Composition of an order isomorphism with a principal segment, as a principal segment -/
 def equivLT (f : r ≃r s) (g : s ≺i t) : r ≺i t :=
   ⟨@RelEmbedding.trans _ _ _ r s t f g, g.top, fun c =>
-    suffices (∃ a : β, g a = c) ↔ ∃ a : α, g (f a) = c by simpa [PrincipalSeg.down]
+    suffices (∃ a, g a = c) ↔ ∃ a, g (f a) = c by simp [← PrincipalSeg.mem_range_iff_rel]
     ⟨fun ⟨b, h⟩ => ⟨f.symm b, by simp only [h, RelIso.apply_symm_apply]⟩,
       fun ⟨a, h⟩ => ⟨f a, h⟩⟩⟩
 
@@ -322,8 +327,8 @@ def ltEquiv {r : α → α → Prop} {s : β → β → Prop} {t : γ → γ →
     (g : s ≃r t) : PrincipalSeg r t :=
   ⟨@RelEmbedding.trans _ _ _ r s t f g, g f.top, by
     intro x
-    rw [← g.apply_symm_apply x, g.map_rel_iff, f.down', exists_congr]
-    intro y; exact ⟨congr_arg g, fun h => g.toEquiv.bijective.1 h⟩⟩
+    rw [← g.apply_symm_apply x, g.map_rel_iff, ← f.mem_range_iff_rel]
+    exact exists_congr <| fun _ ↦ ⟨fun h => g.toEquiv.bijective.1 h, congr_arg g⟩⟩
 
 @[simp]
 theorem equivLT_apply (f : r ≃r s) (g : s ≺i t) (a : α) : (equivLT f g) a = g (f a) :=
@@ -341,7 +346,7 @@ instance [IsWellOrder β s] : Subsingleton (r ≺i s) :=
       rw [@Subsingleton.elim _ _ (f : r ≼i s) g]
     have et : f.top = g.top := by
       refine extensional_of_trichotomous_of_irrefl s fun x => ?_
-      simp only [PrincipalSeg.down, ef]
+      simp only [← PrincipalSeg.mem_range_iff_rel, ef]
     cases f
     cases g
     have := RelEmbedding.coe_fn_injective ef; congr ⟩
@@ -356,7 +361,7 @@ theorem topLTTop {r : α → α → Prop} {s : β → β → Prop} {t : γ → �
 
 /-- Any element of a well order yields a principal segment -/
 def ofElement {α : Type*} (r : α → α → Prop) (a : α) : Subrel r { b | r b a } ≺i r :=
-  ⟨Subrel.relEmbedding _ _, a, fun _ => ⟨fun h => ⟨⟨_, h⟩, rfl⟩, fun ⟨⟨_, h⟩, rfl⟩ => h⟩⟩
+  ⟨Subrel.relEmbedding _ _, a, fun _ => ⟨fun ⟨⟨_, h⟩, rfl⟩ => h, fun h => ⟨⟨_, h⟩, rfl⟩⟩⟩
 
 -- This lemma was always bad, but the linter only noticed after lean4#2644
 @[simp, nolint simpNF]
@@ -372,7 +377,7 @@ theorem ofElement_top {α : Type*} (r : α → α → Prop) (a : α) : (ofElemen
 noncomputable def subrelIso (f : r ≺i s) : Subrel s {b | s b f.top} ≃r r :=
   RelIso.symm
   { toEquiv := ((Equiv.ofInjective f f.injective).trans (Equiv.setCongr
-      (funext fun _ ↦ propext f.down.symm))),
+      (funext fun _ ↦ propext f.mem_range_iff_rel))),
     map_rel_iff' := f.map_rel_iff }
 
 -- This lemma was always bad, but the linter only noticed after lean4#2644
@@ -386,15 +391,12 @@ theorem apply_subrelIso (f : r ≺i s) (b : {b | s b f.top}) :
 
 -- This lemma was always bad, but the linter only noticed after lean4#2644
 @[simp, nolint simpNF]
-theorem subrelIso_apply (f : r ≺i s) (a : α) :
-    f.subrelIso ⟨f a, f.down.mpr ⟨a, rfl⟩⟩ = a :=
+theorem subrelIso_apply (f : r ≺i s) (a : α) : f.subrelIso ⟨f a, f.lt_top a⟩ = a :=
   Equiv.ofInjective_symm_apply f.injective _
 
 /-- Restrict the codomain of a principal segment -/
 def codRestrict (p : Set β) (f : r ≺i s) (H : ∀ a, f a ∈ p) (H₂ : f.top ∈ p) : r ≺i Subrel s p :=
-  ⟨RelEmbedding.codRestrict p f H, ⟨f.top, H₂⟩, fun ⟨_, _⟩ =>
-    f.down.trans <|
-      exists_congr fun a => show (⟨f a, H a⟩ : p).1 = _ ↔ _ from ⟨Subtype.eq, congr_arg _⟩⟩
+  ⟨RelEmbedding.codRestrict p f H, ⟨f.top, H₂⟩, fun ⟨_, _⟩ => by simp [← f.mem_range_iff_rel]⟩
 
 @[simp]
 theorem codRestrict_apply (p) (f : r ≺i s) (H H₂ a) : codRestrict p f H H₂ a = ⟨f a, H a⟩ :=
@@ -408,7 +410,7 @@ theorem codRestrict_top (p) (f : r ≺i s) (H H₂) : (codRestrict p f H H₂).t
 def ofIsEmpty (r : α → α → Prop) [IsEmpty α] {b : β} (H : ∀ b', ¬s b' b) : r ≺i s :=
   { RelEmbedding.ofIsEmpty r s with
     top := b
-    down' := by simp [H] }
+    mem_range_iff_rel' := by simp [H] }
 
 @[simp]
 theorem ofIsEmpty_top (r : α → α → Prop) [IsEmpty α] {b : β} (H : ∀ b', ¬s b' b) :
@@ -435,7 +437,7 @@ theorem wellFounded_iff_wellFounded_subrel {β : Type*} {s : β → β → Prop}
     ⟨fun wf b => ⟨fun b' => ((PrincipalSeg.ofElement _ b).acc b').mpr (wf.apply b')⟩, fun wf =>
       ⟨fun b => Acc.intro _ fun b' hb' => ?_⟩⟩
   let f := PrincipalSeg.ofElement s b
-  obtain ⟨b', rfl⟩ := f.down.mp ((PrincipalSeg.ofElement_top s b).symm ▸ hb' : s b' f.top)
+  obtain ⟨b', rfl⟩ := f.mem_range_of_rel_top ((PrincipalSeg.ofElement_top s b).symm ▸ hb')
   exact (f.acc b').mp ((wf b).apply b')
 
 theorem wellFounded_iff_principalSeg.{u} {β : Type u} {s : β → β → Prop} [IsTrans β s] :

--- a/Mathlib/SetTheory/Cardinal/Ordinal.lean
+++ b/Mathlib/SetTheory/Cardinal/Ordinal.lean
@@ -79,7 +79,7 @@ def aleph' : Ordinal.{u} ≃o Cardinal.{u} := by
   refine (OrderIso.ofRelIsoLT <| RelIso.ofSurjective f ?_).symm
   apply f.eq_or_principal.resolve_right
   rintro ⟨o, e⟩
-  have : ∀ c, f c < o := fun c => (e _).2 ⟨_, rfl⟩
+  have : ∀ c, f c < o := fun c => (e _).1 ⟨_, rfl⟩
   refine Ordinal.inductionOn o ?_ this
   intro α r _ h
   let s := ⨆ a, invFun f (Ordinal.typein r a)

--- a/Mathlib/SetTheory/Ordinal/Basic.lean
+++ b/Mathlib/SetTheory/Ordinal/Basic.lean
@@ -382,7 +382,7 @@ theorem typein_top {α β} {r : α → α → Prop} {s : β → β → Prop} [Is
   Eq.symm <|
     Quot.sound
       ⟨RelIso.ofSurjective (RelEmbedding.codRestrict _ f f.lt_top) fun ⟨a, h⟩ => by
-          rcases f.down.1 h with ⟨b, rfl⟩; exact ⟨b, rfl⟩⟩
+          rcases f.mem_range_of_rel_top h with ⟨b, rfl⟩; exact ⟨b, rfl⟩⟩
 
 @[simp]
 theorem typein_apply {α β} {r : α → α → Prop} {s : β → β → Prop} [IsWellOrder α r] [IsWellOrder β s]
@@ -426,7 +426,7 @@ principal segment. -/
 def typein.principalSeg {α : Type u} (r : α → α → Prop) [IsWellOrder α r] :
     @PrincipalSeg α Ordinal.{u} r (· < ·) :=
   ⟨⟨⟨typein r, typein_injective r⟩, typein_lt_typein r⟩, type r,
-    fun _ ↦ ⟨typein_surj r, fun ⟨a, h⟩ ↦ h ▸ typein_lt_type r a⟩⟩
+    fun _ ↦ ⟨fun ⟨a, h⟩ ↦ h ▸ typein_lt_type r a, typein_surj r⟩⟩
 
 @[simp]
 theorem typein.principalSeg_coe (r : α → α → Prop) [IsWellOrder α r] :
@@ -857,8 +857,8 @@ private theorem succ_le_iff' {a b : Ordinal} : a + 1 ≤ b ↔ a < b :=
       (inductionOn a fun α r _ =>
         ⟨⟨⟨⟨fun x => Sum.inl x, fun _ _ => Sum.inl.inj⟩, Sum.lex_inl_inl⟩,
             Sum.inr PUnit.unit, fun b =>
-            Sum.recOn b (fun x => ⟨fun _ => ⟨x, rfl⟩, fun _ => Sum.Lex.sep _ _⟩) fun x =>
-              Sum.lex_inr_inr.trans ⟨False.elim, fun ⟨x, H⟩ => Sum.inl_ne_inr H⟩⟩⟩),
+            Sum.recOn b (fun x => ⟨fun _ => Sum.Lex.sep _ _, fun _ => ⟨x, rfl⟩⟩) fun x =>
+              (Sum.lex_inr_inr.trans ⟨False.elim, fun ⟨x, H⟩ => Sum.inl_ne_inr H⟩).symm⟩⟩),
     inductionOn a fun α r hr =>
       inductionOn b fun β s hs ⟨⟨f, t, hf⟩⟩ => by
         haveI := hs
@@ -866,7 +866,7 @@ private theorem succ_le_iff' {a b : Ordinal} : a + 1 ≤ b ↔ a < b :=
         · rcases a with (a | _) <;> rcases b with (b | _)
           · simpa only [Sum.lex_inl_inl] using f.map_rel_iff.2
           · intro
-            rw [hf]
+            rw [← hf]
             exact ⟨_, rfl⟩
           · exact False.elim ∘ Sum.lex_inr_inl
           · exact False.elim ∘ Sum.lex_inr_inr.1
@@ -876,7 +876,7 @@ private theorem succ_le_iff' {a b : Ordinal} : a + 1 ≤ b ↔ a < b :=
             cases' this with w h
             exact ⟨Sum.inl w, h⟩
           · intro h
-            cases' (hf b).1 h with w h
+            cases' (hf b).2 h with w h
             exact ⟨Sum.inl w, h⟩⟩
 
 instance noMaxOrder : NoMaxOrder Ordinal :=
@@ -1069,6 +1069,11 @@ def liftPrincipalSeg : @PrincipalSeg Ordinal.{u} Ordinal.{max (u + 1) v} (· < �
   ⟨↑liftInitialSeg.{u, max (u + 1) v}, univ.{u, v}, by
     refine fun b => inductionOn b ?_; intro β s _
     rw [univ, ← lift_umax]; constructor <;> intro h
+    · cases' h with a e
+      rw [← e]
+      refine inductionOn a ?_
+      intro α r _
+      exact lift_type_lt.{u, u + 1, max (u + 1) v}.2 ⟨typein.principalSeg r⟩
     · rw [← lift_id (type s)] at h ⊢
       cases' lift_type_lt.{_,_,v}.1 h with f
       cases' f with f a hf
@@ -1077,23 +1082,17 @@ def liftPrincipalSeg : @PrincipalSeg Ordinal.{u} Ordinal.{max (u + 1) v} (· < �
       -- Porting note: apply inductionOn does not work, refine does
       refine inductionOn a ?_
       intro α r _ hf
-      refine
-        lift_type_eq.{u, max (u + 1) v, max (u + 1) v}.2
-          ⟨(RelIso.ofSurjective (RelEmbedding.ofMonotone ?_ ?_) ?_).symm⟩
-      · exact fun b => enum r ⟨f b, (hf _).2 ⟨_, rfl⟩⟩
+      refine lift_type_eq.{u, max (u + 1) v, max (u + 1) v}.2
+        ⟨(RelIso.ofSurjective (RelEmbedding.ofMonotone ?_ ?_) ?_).symm⟩
+      · exact fun b => enum r ⟨f b, (hf _).1 ⟨_, rfl⟩⟩
       · refine fun a b h => (typein_lt_typein r).1 ?_
         rw [typein_enum, typein_enum]
         exact f.map_rel_iff.2 h
       · intro a'
-        cases' (hf _).1 (typein_lt_type _ a') with b e
+        cases' (hf _).2 (typein_lt_type _ a') with b e
         exists b
         simp only [RelEmbedding.ofMonotone_coe]
-        simp [e]
-    · cases' h with a e
-      rw [← e]
-      refine inductionOn a ?_
-      intro α r _
-      exact lift_type_lt.{u, u + 1, max (u + 1) v}.2 ⟨typein.principalSeg r⟩⟩
+        simp [e]⟩
 
 @[deprecated liftPrincipalSeg (since := "2024-09-21")]
 alias lift.principalSeg := liftPrincipalSeg
@@ -1342,7 +1341,7 @@ theorem lift_lt_univ' (c : Cardinal) : lift.{max (u + 1) v, u} c < univ.{u, v} :
 @[simp]
 theorem ord_univ : ord univ.{u, v} = Ordinal.univ.{u, v} := by
   refine le_antisymm (ord_card_le _) <| le_of_forall_lt fun o h => lt_ord.2 ?_
-  have := liftPrincipalSeg.{u, v}.down.1 (by simpa only [liftPrincipalSeg_coe] using h)
+  have := liftPrincipalSeg.mem_range_of_rel_top (by simpa only [liftPrincipalSeg_coe] using h)
   rcases this with ⟨o, h'⟩
   rw [← h', liftPrincipalSeg_coe, ← lift_card]
   apply lift_lt_univ'
@@ -1351,7 +1350,7 @@ theorem lt_univ {c} : c < univ.{u, u + 1} ↔ ∃ c', c = lift.{u + 1, u} c' :=
   ⟨fun h => by
     have := ord_lt_ord.2 h
     rw [ord_univ] at this
-    cases' liftPrincipalSeg.{u, u + 1}.down.1 (by simpa only [liftPrincipalSeg_top] ) with o e
+    cases' liftPrincipalSeg.mem_range_of_rel_top (by simpa only [liftPrincipalSeg_top]) with o e
     have := card_ord c
     rw [← e, liftPrincipalSeg_coe, ← lift_card] at this
     exact ⟨_, this.symm⟩, fun ⟨c', e⟩ => e.symm ▸ lift_lt_univ _⟩


### PR DESCRIPTION
The former name was a bit too obscure.

Note that this swaps the order of the lemma. This is a breaking change, but a pretty minor and easy to fix one at that.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

I'll eventually get to renaming `Cardinal.lift_down` and `Ordinal.lift_down`.

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
