### PR TITLE
[Merged by Bors] - chore(init_creation): remove creation of Mathlib.Init

### DIFF
--- a/scripts/init_creation.sh
+++ b/scripts/init_creation.sh
@@ -2,8 +2,8 @@
 
  : <<'BASH_MODULE_DOC'
 
-These are the commands to generate a "root" `Mathlib/Init.lean` file, imported by all the
-`Mathlib` files that do not import any `Mathlib` file.
+These are the commands to add an import of `Mathlib/Init.lean` to all `Mathlib` files
+that do not import any `Mathlib` file.
 
 BASH_MODULE_DOC
 
@@ -35,11 +35,3 @@ printf 'Adding `import Mathlib.Init` to all file that import no Mathlib file.\n'
 # The `sed` command appends the line `import Mathlib.Init` after the first
 # `-/[linebreaks]*` of each file printed by `mathlibNonImportingFiles`.
 sed -i -z 's=-/\n*=&import Mathlib.Init\n=' $(mathlibNonImportingFiles)
-
-printf 'Creating `Mathlib/Init.lean`.\n'
-
-# Creates the `Mathlib/Init.lean` files.
-echo '-- This is the root file in Mathlib: it is imported by virtually *all* Mathlib files' > Mathlib/Init.lean
-
-printf $'Don\'t forget to add `Mathlib.Init` to the `ignoreImport` field of `scripts/noshake.json`
-This ensures that `import Mathlib.Init` does not trigger a `shake` exception.\n'


### PR DESCRIPTION
That file already exists and (most likely) isn't going away. There's no point in creating it anew, overwriting the existing content. Just remove these parts of the script.

---

I'm not sure if this PR qualifies as "CI", "linters" or none of these. Feel free to re-label :-)

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
