### PR TITLE
[Merged by Bors] - docs: add latex doc for `Set` and `Finset` intervals

### DIFF
--- a/Mathlib/Order/Interval/Finset/Defs.lean
+++ b/Mathlib/Order/Interval/Finset/Defs.lean
@@ -329,11 +329,11 @@ section LocallyFiniteOrderTop
 
 variable [LocallyFiniteOrderTop α] {a x : α}
 
-/-- The finset of elements `x` such that `a ≤ x`. Basically `Set.Ici a` as a finset. -/
+/-- The finset $[a, ∞)$ of elements `x` such that `a ≤ x`. Basically `Set.Ici a` as a finset. -/
 def Ici (a : α) : Finset α :=
   LocallyFiniteOrderTop.finsetIci a
 
-/-- The finset of elements `x` such that `a < x`. Basically `Set.Ioi a` as a finset. -/
+/-- The finset $(a, ∞)$ of elements `x` such that `a < x`. Basically `Set.Ioi a` as a finset. -/
 def Ioi (a : α) : Finset α :=
   LocallyFiniteOrderTop.finsetIoi a
 
@@ -359,13 +359,13 @@ section LocallyFiniteOrderBot
 
 variable [LocallyFiniteOrderBot α] {a x : α}
 
-/-- The finset of elements `x` such that `a ≤ x`. Basically `Set.Iic a` as a finset. -/
-def Iic (a : α) : Finset α :=
-  LocallyFiniteOrderBot.finsetIic a
+/-- The finset $(-∞, b]$ of elements `x` such that `x ≤ b`. Basically `Set.Iic b` as a finset. -/
+def Iic (b : α) : Finset α :=
+  LocallyFiniteOrderBot.finsetIic b
 
-/-- The finset of elements `x` such that `a < x`. Basically `Set.Iio a` as a finset. -/
-def Iio (a : α) : Finset α :=
-  LocallyFiniteOrderBot.finsetIio a
+/-- The finset $(-∞, b)$ of elements `x` such that `x < b`. Basically `Set.Iio b` as a finset. -/
+def Iio (b : α) : Finset α :=
+  LocallyFiniteOrderBot.finsetIio b
 
 @[simp]
 theorem mem_Iic : x ∈ Iic a ↔ x ≤ a :=

--- a/Mathlib/Order/Interval/Finset/Defs.lean
+++ b/Mathlib/Order/Interval/Finset/Defs.lean
@@ -271,23 +271,23 @@ section LocallyFiniteOrder
 
 variable [LocallyFiniteOrder α] {a b x : α}
 
-/-- The finset of elements `x` such that `a ≤ x` and `x ≤ b`. Basically `Set.Icc a b` as a finset.
--/
+/-- The finset $[a, b]$ of elements `x` such that `a ≤ x` and `x ≤ b`. Basically `Set.Icc a b` as a
+finset. -/
 def Icc (a b : α) : Finset α :=
   LocallyFiniteOrder.finsetIcc a b
 
-/-- The finset of elements `x` such that `a ≤ x` and `x < b`. Basically `Set.Ico a b` as a finset.
--/
+/-- The finset $[a, b)$ of elements `x` such that `a ≤ x` and `x < b`. Basically `Set.Ico a b` as a
+finset. -/
 def Ico (a b : α) : Finset α :=
   LocallyFiniteOrder.finsetIco a b
 
-/-- The finset of elements `x` such that `a < x` and `x ≤ b`. Basically `Set.Ioc a b` as a finset.
--/
+/-- The finset $(a, b]$ of elements `x` such that `a < x` and `x ≤ b`. Basically `Set.Ioc a b` as a
+finset. -/
 def Ioc (a b : α) : Finset α :=
   LocallyFiniteOrder.finsetIoc a b
 
-/-- The finset of elements `x` such that `a < x` and `x < b`. Basically `Set.Ioo a b` as a finset.
--/
+/-- The finset $(a, b)$ of elements `x` such that `a < x` and `x < b`. Basically `Set.Ioo a b` as a
+finset. -/
 def Ioo (a b : α) : Finset α :=
   LocallyFiniteOrder.finsetIoo a b
 

--- a/Mathlib/Order/Interval/Set/Basic.lean
+++ b/Mathlib/Order/Interval/Set/Basic.lean
@@ -38,35 +38,35 @@ section Preorder
 
 variable [Preorder α] {a a₁ a₂ b b₁ b₂ c x : α}
 
-/-- Left-open right-open interval $(a, b)$-/
+/-- Left-open right-open interval $(a, b)$ -/
 def Ioo (a b : α) :=
   { x | a < x ∧ x < b }
 
-/-- Left-closed right-open interval $[a, b)$-/
+/-- Left-closed right-open interval $[a, b)$ -/
 def Ico (a b : α) :=
   { x | a ≤ x ∧ x < b }
 
-/-- Left-infinite right-open interval $(-\infty, a)$-/
+/-- Left-infinite right-open interval $(-\infty, a)$ -/
 def Iio (a : α) :=
   { x | x < a }
 
-/-- Left-closed right-closed interval $[a, b]$-/
+/-- Left-closed right-closed interval $[a, b]$ -/
 def Icc (a b : α) :=
   { x | a ≤ x ∧ x ≤ b }
 
-/-- Left-infinite right-closed interval $(-\infty, a]$-/
+/-- Left-infinite right-closed interval $(-\infty, a]$ -/
 def Iic (b : α) :=
   { x | x ≤ b }
 
-/-- Left-open right-closed interval $(a, b]$-/
+/-- Left-open right-closed interval $(a, b]$ -/
 def Ioc (a b : α) :=
   { x | a < x ∧ x ≤ b }
 
-/-- Left-closed right-infinite interval $[a, \infty)$-/
+/-- Left-closed right-infinite interval $[a, \infty)$ -/
 def Ici (a : α) :=
   { x | a ≤ x }
 
-/-- Left-open right-infinite interval $(a, \infty)$-/
+/-- Left-open right-infinite interval $(a, \infty)$ -/
 def Ioi (a : α) :=
   { x | a < x }
 

--- a/Mathlib/Order/Interval/Set/Basic.lean
+++ b/Mathlib/Order/Interval/Set/Basic.lean
@@ -38,35 +38,35 @@ section Preorder
 
 variable [Preorder α] {a a₁ a₂ b b₁ b₂ c x : α}
 
-/-- `Ioo a b` is the left-open right-open interval $(a, b)$ -/
+/-- `Ioo a b` is the left-open right-open interval $(a, b)$. -/
 def Ioo (a b : α) :=
   { x | a < x ∧ x < b }
 
-/-- `Ico a b` is the left-closed right-open interval $[a, b)$ -/
+/-- `Ico a b` is the left-closed right-open interval $[a, b)$. -/
 def Ico (a b : α) :=
   { x | a ≤ x ∧ x < b }
 
-/-- `Iio b` is the left-infinite right-open interval $(-\infty, b)$ -/
+/-- `Iio b` is the left-infinite right-open interval $(-\infty, b)$. -/
 def Iio (b : α) :=
   { x | x < b }
 
-/-- `Icc a b` is the left-closed right-closed interval $[a, b]$ -/
+/-- `Icc a b` is the left-closed right-closed interval $[a, b]$. -/
 def Icc (a b : α) :=
   { x | a ≤ x ∧ x ≤ b }
 
-/-- `Iic b` is the left-infinite right-closed interval $(-\infty, b]$ -/
+/-- `Iic b` is the left-infinite right-closed interval $(-\infty, b]$. -/
 def Iic (b : α) :=
   { x | x ≤ b }
 
-/-- `Ioc a b` is the left-open right-closed interval $(a, b]$ -/
+/-- `Ioc a b` is the left-open right-closed interval $(a, b]$. -/
 def Ioc (a b : α) :=
   { x | a < x ∧ x ≤ b }
 
-/-- `Ici a` is the left-closed right-infinite interval $[a, \infty)$ -/
+/-- `Ici a` is the left-closed right-infinite interval $[a, \infty)$. -/
 def Ici (a : α) :=
   { x | a ≤ x }
 
-/-- `Ioi a` is the left-open right-infinite interval $(a, \infty)$ -/
+/-- `Ioi a` is the left-open right-infinite interval $(a, \infty)$. -/
 def Ioi (a : α) :=
   { x | a < x }
 

--- a/Mathlib/Order/Interval/Set/Basic.lean
+++ b/Mathlib/Order/Interval/Set/Basic.lean
@@ -46,7 +46,7 @@ def Ioo (a b : α) :=
 def Ico (a b : α) :=
   { x | a ≤ x ∧ x < b }
 
-/-- `Iio b` is the left-infinite right-open interval $(-\infty, b)$. -/
+/-- `Iio b` is the left-infinite right-open interval $(-∞, b)$. -/
 def Iio (b : α) :=
   { x | x < b }
 
@@ -54,7 +54,7 @@ def Iio (b : α) :=
 def Icc (a b : α) :=
   { x | a ≤ x ∧ x ≤ b }
 
-/-- `Iic b` is the left-infinite right-closed interval $(-\infty, b]$. -/
+/-- `Iic b` is the left-infinite right-closed interval $(-∞, b]$. -/
 def Iic (b : α) :=
   { x | x ≤ b }
 
@@ -62,11 +62,11 @@ def Iic (b : α) :=
 def Ioc (a b : α) :=
   { x | a < x ∧ x ≤ b }
 
-/-- `Ici a` is the left-closed right-infinite interval $[a, \infty)$. -/
+/-- `Ici a` is the left-closed right-infinite interval $[a, ∞)$. -/
 def Ici (a : α) :=
   { x | a ≤ x }
 
-/-- `Ioi a` is the left-open right-infinite interval $(a, \infty)$. -/
+/-- `Ioi a` is the left-open right-infinite interval $(a, ∞)$. -/
 def Ioi (a : α) :=
   { x | a < x }
 

--- a/Mathlib/Order/Interval/Set/Basic.lean
+++ b/Mathlib/Order/Interval/Set/Basic.lean
@@ -38,35 +38,35 @@ section Preorder
 
 variable [Preorder α] {a a₁ a₂ b b₁ b₂ c x : α}
 
-/-- Left-open right-open interval -/
+/-- Left-open right-open interval $(a, b)$-/
 def Ioo (a b : α) :=
   { x | a < x ∧ x < b }
 
-/-- Left-closed right-open interval -/
+/-- Left-closed right-open interval $[a, b)$-/
 def Ico (a b : α) :=
   { x | a ≤ x ∧ x < b }
 
-/-- Left-infinite right-open interval -/
+/-- Left-infinite right-open interval $(-\infty, a)$-/
 def Iio (a : α) :=
   { x | x < a }
 
-/-- Left-closed right-closed interval -/
+/-- Left-closed right-closed interval $[a, b]$-/
 def Icc (a b : α) :=
   { x | a ≤ x ∧ x ≤ b }
 
-/-- Left-infinite right-closed interval -/
+/-- Left-infinite right-closed interval $(-\infty, a]$-/
 def Iic (b : α) :=
   { x | x ≤ b }
 
-/-- Left-open right-closed interval -/
+/-- Left-open right-closed interval $(a, b]$-/
 def Ioc (a b : α) :=
   { x | a < x ∧ x ≤ b }
 
-/-- Left-closed right-infinite interval -/
+/-- Left-closed right-infinite interval $[a, \infty)$-/
 def Ici (a : α) :=
   { x | a ≤ x }
 
-/-- Left-open right-infinite interval -/
+/-- Left-open right-infinite interval $(a, \infty)$-/
 def Ioi (a : α) :=
   { x | a < x }
 

--- a/Mathlib/Order/Interval/Set/Basic.lean
+++ b/Mathlib/Order/Interval/Set/Basic.lean
@@ -38,35 +38,35 @@ section Preorder
 
 variable [Preorder α] {a a₁ a₂ b b₁ b₂ c x : α}
 
-/-- Left-open right-open interval $(a, b)$ -/
+/-- `Ioo a b` is the left-open right-open interval $(a, b)$ -/
 def Ioo (a b : α) :=
   { x | a < x ∧ x < b }
 
-/-- Left-closed right-open interval $[a, b)$ -/
+/-- `Ico a b` is the left-closed right-open interval $[a, b)$ -/
 def Ico (a b : α) :=
   { x | a ≤ x ∧ x < b }
 
-/-- Left-infinite right-open interval $(-\infty, a)$ -/
-def Iio (a : α) :=
-  { x | x < a }
+/-- `Iio b` is the left-infinite right-open interval $(-\infty, b)$ -/
+def Iio (b : α) :=
+  { x | x < b }
 
-/-- Left-closed right-closed interval $[a, b]$ -/
+/-- `Icc a b` is the left-closed right-closed interval $[a, b]$ -/
 def Icc (a b : α) :=
   { x | a ≤ x ∧ x ≤ b }
 
-/-- Left-infinite right-closed interval $(-\infty, a]$ -/
+/-- `Iic b` is the left-infinite right-closed interval $(-\infty, b]$ -/
 def Iic (b : α) :=
   { x | x ≤ b }
 
-/-- Left-open right-closed interval $(a, b]$ -/
+/-- `Ioc a b` is the left-open right-closed interval $(a, b]$ -/
 def Ioc (a b : α) :=
   { x | a < x ∧ x ≤ b }
 
-/-- Left-closed right-infinite interval $[a, \infty)$ -/
+/-- `Ici a` is the left-closed right-infinite interval $[a, \infty)$ -/
 def Ici (a : α) :=
   { x | a ≤ x }
 
-/-- Left-open right-infinite interval $(a, \infty)$ -/
+/-- `Ioi a` is the left-open right-infinite interval $(a, \infty)$ -/
 def Ioi (a : α) :=
   { x | a < x }
 


### PR DESCRIPTION
Add LaTeX descriptions for all `Icc`/`Ico`/`Ioc`/`Ioo`/`Iio`/`Ioi`/`Iic`/`Ici` intervals. Following [this zulip thread](https://leanprover.zulipchat.com/#narrow/stream/287929-mathlib4/topic/notation.20for.20intervals).

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
