### PR TITLE
[Merged by Bors] - feat: in a WellFoundedLT CompleteLattice, Independent sets are finite

### DIFF
--- a/Mathlib/Algebra/DirectSum/LinearMap.lean
+++ b/Mathlib/Algebra/DirectSum/LinearMap.lean
@@ -78,12 +78,12 @@ lemma trace_eq_sum_trace_restrict' (h : IsInternal N) (hN : {i | N i ≠ ⊥}.Fi
   rw [← Finset.sum_coe_sort, trace_eq_sum_trace_restrict (isInternal_ne_bot_iff.mpr h) _]
   exact Fintype.sum_equiv hN.subtypeEquivToFinset _ _ (fun i ↦ rfl)
 
-lemma trace_eq_zero_of_mapsTo_ne (h : IsInternal N) [hn : IsNoetherian R M]
+lemma trace_eq_zero_of_mapsTo_ne (h : IsInternal N) [IsNoetherian R M]
     (σ : ι → ι) (hσ : ∀ i, σ i ≠ i) {f : Module.End R M}
     (hf : ∀ i, MapsTo f (N i) (N <| σ i)) :
     trace R M f = 0 := by
-  have hN : {i | N i ≠ ⊥}.Finite := CompleteLattice.WellFounded.finite_ne_bot_of_independent
-    hn.wf h.submodule_independent
+  have hN : {i | N i ≠ ⊥}.Finite := CompleteLattice.WellFoundedGT.finite_ne_bot_of_independent
+    h.submodule_independent
   let s := hN.toFinset
   let κ := fun i ↦ Module.Free.ChooseBasisIndex R (N i)
   let b : (i : s) → Basis (κ i) R (N i) := fun i ↦ Module.Free.chooseBasis R (N i)
@@ -112,8 +112,7 @@ lemma trace_comp_eq_zero_of_commute_of_trace_restrict_eq_zero
     have hds := DirectSum.isInternal_submodule_of_independent_of_iSup_eq_top
       f.independent_maxGenEigenspace hf
     have h_fin : {μ | f.maxGenEigenspace μ ≠ ⊥}.Finite :=
-      CompleteLattice.WellFounded.finite_ne_bot_of_independent IsWellFounded.wf
-        f.independent_maxGenEigenspace
+      CompleteLattice.WellFoundedGT.finite_ne_bot_of_independent f.independent_maxGenEigenspace
     simp [trace_eq_sum_trace_restrict' hds h_fin hfg, this]
   intro μ
   replace h_comm : Commute (g.restrict (f.mapsTo_maxGenEigenspace_of_comm h_comm μ))

--- a/Mathlib/Algebra/Lie/Solvable.lean
+++ b/Mathlib/Algebra/Lie/Solvable.lean
@@ -266,8 +266,8 @@ def radical :=
 
 /-- The radical of a Noetherian Lie algebra is solvable. -/
 instance radicalIsSolvable [IsNoetherian R L] : IsSolvable R (radical R L) := by
-  have hwf := (LieSubmodule.wellFoundedGT_of_noetherian R L L).wf
-  rw [← CompleteLattice.isSupClosedCompact_iff_wellFounded] at hwf
+  have hwf := LieSubmodule.wellFoundedGT_of_noetherian R L L
+  rw [← CompleteLattice.isSupClosedCompact_iff_wellFoundedGT] at hwf
   refine hwf { I : LieIdeal R L | IsSolvable R I } ⟨⊥, ?_⟩ fun I hI J hJ => ?_
   · exact LieAlgebra.isSolvableBot R L
   · rw [Set.mem_setOf_eq] at hI hJ ⊢

--- a/Mathlib/Algebra/Lie/Weights/Basic.lean
+++ b/Mathlib/Algebra/Lie/Weights/Basic.lean
@@ -707,13 +707,11 @@ lemma independent_genWeightSpaceOf [NoZeroSMulDivisors R M] (x : L) :
 
 lemma finite_genWeightSpaceOf_ne_bot [NoZeroSMulDivisors R M] [IsNoetherian R M] (x : L) :
     {χ : R | genWeightSpaceOf M χ x ≠ ⊥}.Finite :=
-  CompleteLattice.WellFounded.finite_ne_bot_of_independent
-    IsWellFounded.wf (independent_genWeightSpaceOf R L M x)
+  CompleteLattice.WellFoundedGT.finite_ne_bot_of_independent (independent_genWeightSpaceOf R L M x)
 
 lemma finite_genWeightSpace_ne_bot [NoZeroSMulDivisors R M] [IsNoetherian R M] :
     {χ : L → R | genWeightSpace M χ ≠ ⊥}.Finite :=
-  CompleteLattice.WellFounded.finite_ne_bot_of_independent
-    IsWellFounded.wf (independent_genWeightSpace R L M)
+  CompleteLattice.WellFoundedGT.finite_ne_bot_of_independent (independent_genWeightSpace R L M)
 
 instance Weight.instFinite [NoZeroSMulDivisors R M] [IsNoetherian R M] :
     Finite (Weight R L M) := by

--- a/Mathlib/AlgebraicGeometry/PrimeSpectrum/Noetherian.lean
+++ b/Mathlib/AlgebraicGeometry/PrimeSpectrum/Noetherian.lean
@@ -19,9 +19,8 @@ open TopologicalSpace
 
 variable (R : Type u) [CommRing R] [IsNoetherianRing R]
 
-instance : NoetherianSpace (PrimeSpectrum R) := by
-  apply ((noetherianSpace_TFAE <| PrimeSpectrum R).out 0 1).mpr
-  exact (closedsEmbedding R).dual.wellFounded IsWellFounded.wf
+instance : NoetherianSpace (PrimeSpectrum R) :=
+  ((noetherianSpace_TFAE <| PrimeSpectrum R).out 0 1).mpr (closedsEmbedding R).dual.wellFoundedLT
 
 lemma _root_.minimalPrimes.finite_of_isNoetherianRing : (minimalPrimes R).Finite :=
   minimalPrimes.equivIrreducibleComponents R

--- a/Mathlib/Order/CompactlyGenerated/Basic.lean
+++ b/Mathlib/Order/CompactlyGenerated/Basic.lean
@@ -263,7 +263,7 @@ theorem wellFoundedGT_iff_isSupFiniteCompact :
 theorem isSupFiniteCompact_iff_isSupClosedCompact : IsSupFiniteCompact α ↔ IsSupClosedCompact α :=
   (wellFoundedGT_characterisations α).out 1 2
 
-theorem isSupClosedCompact_iff_wellFounded :
+theorem isSupClosedCompact_iff_wellFoundedGT :
     IsSupClosedCompact α ↔ WellFoundedGT α :=
   (wellFoundedGT_characterisations α).out 2 0
 
@@ -271,7 +271,7 @@ alias ⟨_, IsSupFiniteCompact.wellFoundedGT⟩ := wellFoundedGT_iff_isSupFinite
 
 alias ⟨_, IsSupClosedCompact.isSupFiniteCompact⟩ := isSupFiniteCompact_iff_isSupClosedCompact
 
-alias ⟨_, WellFoundedGT.isSupClosedCompact⟩ := isSupClosedCompact_iff_wellFounded
+alias ⟨_, WellFoundedGT.isSupClosedCompact⟩ := isSupClosedCompact_iff_wellFoundedGT
 
 variable {α}
 
@@ -488,6 +488,8 @@ alias IsSupClosedCompact.wellFounded := IsSupClosedCompact.wellFoundedGT
 alias wellFounded_characterisations := wellFoundedGT_characterisations
 @[deprecated (since := "2024-10-07")]
 alias wellFounded_iff_isSupFiniteCompact := wellFoundedGT_iff_isSupFiniteCompact
+@[deprecated (since := "2024-10-07")]
+alias isSupClosedCompact_iff_wellFounded := isSupClosedCompact_iff_wellFoundedGT
 @[deprecated (since := "2024-10-07")]
 alias IsSupFiniteCompact.wellFounded := IsSupFiniteCompact.wellFoundedGT
 @[deprecated (since := "2024-10-07")]

--- a/Mathlib/Order/CompactlyGenerated/Basic.lean
+++ b/Mathlib/Order/CompactlyGenerated/Basic.lean
@@ -189,10 +189,10 @@ theorem isCompactElement_finsetSup {α β : Type*} [CompleteLattice α] {f : β 
     specialize h d hemp hdir (le_trans (Finset.le_sup hps) hsup)
     simpa only [exists_prop]
 
-theorem WellFounded.isSupFiniteCompact (h : WellFounded ((· > ·) : α → α → Prop)) :
+theorem WellFoundedGT.isSupFiniteCompact [WellFoundedGT α] :
     IsSupFiniteCompact α := fun s => by
   let S := { x | ∃ t : Finset α, ↑t ⊆ s ∧ t.sup id = x }
-  obtain ⟨m, ⟨t, ⟨ht₁, rfl⟩⟩, hm⟩ := h.has_min S ⟨⊥, ∅, by simp⟩
+  obtain ⟨m, ⟨t, ⟨ht₁, rfl⟩⟩, hm⟩ := wellFounded_gt.has_min S ⟨⊥, ∅, by simp⟩
   refine ⟨t, ht₁, (sSup_le _ _ fun y hy => ?_).antisymm ?_⟩
   · classical
     rw [eq_of_le_of_not_lt (Finset.sup_mono (t.subset_insert y))
@@ -212,25 +212,26 @@ theorem IsSupFiniteCompact.isSupClosedCompact (h : IsSupFiniteCompact α) :
   · rw [ht₂]
     exact hsc.finsetSup_mem h ht₁
 
-theorem IsSupClosedCompact.wellFounded (h : IsSupClosedCompact α) :
-    WellFounded ((· > ·) : α → α → Prop) := by
-  refine RelEmbedding.wellFounded_iff_no_descending_seq.mpr ⟨fun a => ?_⟩
-  suffices sSup (Set.range a) ∈ Set.range a by
-    obtain ⟨n, hn⟩ := Set.mem_range.mp this
-    have h' : sSup (Set.range a) < a (n + 1) := by
-      change _ > _
-      simp [← hn, a.map_rel_iff]
-    apply lt_irrefl (a (n + 1))
-    apply lt_of_le_of_lt _ h'
-    apply le_sSup
-    apply Set.mem_range_self
-  apply h (Set.range a)
-  · use a 37
-    apply Set.mem_range_self
-  · rintro x ⟨m, hm⟩ y ⟨n, hn⟩
-    use m ⊔ n
-    rw [← hm, ← hn]
-    apply RelHomClass.map_sup a
+theorem IsSupClosedCompact.wellFoundedGT (h : IsSupClosedCompact α) :
+    WellFoundedGT α where
+  wf := by
+    refine RelEmbedding.wellFounded_iff_no_descending_seq.mpr ⟨fun a => ?_⟩
+    suffices sSup (Set.range a) ∈ Set.range a by
+      obtain ⟨n, hn⟩ := Set.mem_range.mp this
+      have h' : sSup (Set.range a) < a (n + 1) := by
+        change _ > _
+        simp [← hn, a.map_rel_iff]
+      apply lt_irrefl (a (n + 1))
+      apply lt_of_le_of_lt _ h'
+      apply le_sSup
+      apply Set.mem_range_self
+    apply h (Set.range a)
+    · use a 37
+      apply Set.mem_range_self
+    · rintro x ⟨m, hm⟩ y ⟨n, hn⟩
+      use m ⊔ n
+      rw [← hm, ← hn]
+      apply RelHomClass.map_sup a
 
 theorem isSupFiniteCompact_iff_all_elements_compact :
     IsSupFiniteCompact α ↔ ∀ k : α, IsCompactElement k := by
@@ -247,39 +248,38 @@ theorem isSupFiniteCompact_iff_all_elements_compact :
     exact ⟨t, hts, this⟩
 
 open List in
-theorem wellFounded_characterisations : List.TFAE
-    [WellFounded ((· > ·) : α → α → Prop),
-      IsSupFiniteCompact α, IsSupClosedCompact α, ∀ k : α, IsCompactElement k] := by
-  tfae_have 1 → 2 := WellFounded.isSupFiniteCompact α
+theorem wellFoundedGT_characterisations : List.TFAE
+    [WellFoundedGT α, IsSupFiniteCompact α, IsSupClosedCompact α, ∀ k : α, IsCompactElement k] := by
+  tfae_have 1 → 2 := @WellFoundedGT.isSupFiniteCompact α _
   tfae_have 2 → 3 := IsSupFiniteCompact.isSupClosedCompact α
-  tfae_have 3 → 1 := IsSupClosedCompact.wellFounded α
+  tfae_have 3 → 1 := IsSupClosedCompact.wellFoundedGT α
   tfae_have 2 ↔ 4 := isSupFiniteCompact_iff_all_elements_compact α
   tfae_finish
 
-theorem wellFounded_iff_isSupFiniteCompact :
-    WellFounded ((· > ·) : α → α → Prop) ↔ IsSupFiniteCompact α :=
-  (wellFounded_characterisations α).out 0 1
+theorem wellFoundedGT_iff_isSupFiniteCompact :
+    WellFoundedGT α ↔ IsSupFiniteCompact α :=
+  (wellFoundedGT_characterisations α).out 0 1
 
 theorem isSupFiniteCompact_iff_isSupClosedCompact : IsSupFiniteCompact α ↔ IsSupClosedCompact α :=
-  (wellFounded_characterisations α).out 1 2
+  (wellFoundedGT_characterisations α).out 1 2
 
 theorem isSupClosedCompact_iff_wellFounded :
-    IsSupClosedCompact α ↔ WellFounded ((· > ·) : α → α → Prop) :=
-  (wellFounded_characterisations α).out 2 0
+    IsSupClosedCompact α ↔ WellFoundedGT α :=
+  (wellFoundedGT_characterisations α).out 2 0
 
-alias ⟨_, IsSupFiniteCompact.wellFounded⟩ := wellFounded_iff_isSupFiniteCompact
+alias ⟨_, IsSupFiniteCompact.wellFoundedGT⟩ := wellFoundedGT_iff_isSupFiniteCompact
 
 alias ⟨_, IsSupClosedCompact.isSupFiniteCompact⟩ := isSupFiniteCompact_iff_isSupClosedCompact
 
-alias ⟨_, _root_.WellFounded.isSupClosedCompact⟩ := isSupClosedCompact_iff_wellFounded
+alias ⟨_, WellFoundedGT.isSupClosedCompact⟩ := isSupClosedCompact_iff_wellFounded
 
 variable {α}
 
-theorem WellFounded.finite_of_setIndependent (h : WellFounded ((· > ·) : α → α → Prop)) {s : Set α}
+theorem WellFoundedGT.finite_of_setIndependent [WellFoundedGT α] {s : Set α}
     (hs : SetIndependent s) : s.Finite := by
   classical
     refine Set.not_infinite.mp fun contra => ?_
-    obtain ⟨t, ht₁, ht₂⟩ := WellFounded.isSupFiniteCompact α h s
+    obtain ⟨t, ht₁, ht₂⟩ := WellFoundedGT.isSupFiniteCompact α s
     replace contra : ∃ x : α, x ∈ s ∧ x ≠ ⊥ ∧ x ∉ t := by
       have : (s \ (insert ⊥ t : Finset α)).Infinite := contra.diff (Finset.finite_toSet _)
       obtain ⟨x, hx₁, hx₂⟩ := this.nonempty
@@ -292,14 +292,36 @@ theorem WellFounded.finite_of_setIndependent (h : WellFounded ((· > ·) : α �
     rw [← hs, eq_comm, inf_eq_left]
     exact le_sSup _ _ hx₀
 
-theorem WellFounded.finite_ne_bot_of_independent (hwf : WellFounded ((· > ·) : α → α → Prop))
+theorem WellFoundedGT.finite_ne_bot_of_independent [WellFoundedGT α]
     {ι : Type*} {t : ι → α} (ht : Independent t) : Set.Finite {i | t i ≠ ⊥} := by
   refine Finite.of_finite_image (Finite.subset ?_ (image_subset_range t _)) ht.injOn
-  exact WellFounded.finite_of_setIndependent hwf ht.setIndependent_range
+  exact WellFoundedGT.finite_of_setIndependent ht.setIndependent_range
 
-theorem WellFounded.finite_of_independent (hwf : WellFounded ((· > ·) : α → α → Prop)) {ι : Type*}
+theorem WellFoundedGT.finite_of_independent [WellFoundedGT α] {ι : Type*}
     {t : ι → α} (ht : Independent t) (h_ne_bot : ∀ i, t i ≠ ⊥) : Finite ι :=
-  haveI := (WellFounded.finite_of_setIndependent hwf ht.setIndependent_range).to_subtype
+  haveI := (WellFoundedGT.finite_of_setIndependent ht.setIndependent_range).to_subtype
+  Finite.of_injective_finite_range (ht.injective h_ne_bot)
+
+theorem WellFoundedLT.finite_of_setIndependent [WellFoundedLT α] {s : Set α}
+    (hs : SetIndependent s) : s.Finite := by
+  by_contra inf
+  let e := (Infinite.diff inf <| finite_singleton ⊥).to_subtype.natEmbedding
+  let a n := ⨆ i ≥ n, (e i).1
+  have sup_le n : (e n).1 ⊔ a (n + 1) ≤ a n := sup_le_iff.mpr ⟨le_iSup₂_of_le n le_rfl le_rfl,
+    iSup₂_le fun i hi ↦ le_iSup₂_of_le i (n.le_succ.trans hi) le_rfl⟩
+  have lt n : a (n + 1) < a n := (Disjoint.right_lt_sup_of_left_ne_bot
+    ((hs (e n).2.1).mono_right <| iSup₂_le fun i hi ↦ le_sSup _ _ ?_) (e n).2.2).trans_le (sup_le n)
+  · exact (RelEmbedding.natGT a lt).not_wellFounded_of_decreasing_seq wellFounded_lt
+  exact ⟨(e i).2.1, fun h ↦ n.lt_succ_self.not_le <| hi.trans_eq <| e.2 <| Subtype.val_injective h⟩
+
+theorem WellFoundedLT.finite_ne_bot_of_independent [WellFoundedLT α]
+    {ι : Type*} {t : ι → α} (ht : Independent t) : Set.Finite {i | t i ≠ ⊥} := by
+  refine Finite.of_finite_image (Finite.subset ?_ (image_subset_range t _)) ht.injOn
+  exact WellFoundedLT.finite_of_setIndependent ht.setIndependent_range
+
+theorem WellFoundedLT.finite_of_independent [WellFoundedLT α] {ι : Type*}
+    {t : ι → α} (ht : Independent t) (h_ne_bot : ∀ i, t i ≠ ⊥) : Finite ι :=
+  haveI := (WellFoundedLT.finite_of_setIndependent ht.setIndependent_range).to_subtype
   Finite.of_injective_finite_range (ht.injective h_ne_bot)
 
 end CompleteLattice
@@ -452,11 +474,32 @@ end
 
 namespace CompleteLattice
 
-theorem isCompactlyGenerated_of_wellFounded (h : WellFounded ((· > ·) : α → α → Prop)) :
+theorem isCompactlyGenerated_of_wellFoundedGT [h : WellFoundedGT α] :
     IsCompactlyGenerated α := by
-  rw [wellFounded_iff_isSupFiniteCompact, isSupFiniteCompact_iff_all_elements_compact] at h
+  rw [wellFoundedGT_iff_isSupFiniteCompact, isSupFiniteCompact_iff_all_elements_compact] at h
   -- x is the join of the set of compact elements {x}
   exact ⟨fun x => ⟨{x}, ⟨fun x _ => h x, sSup_singleton⟩⟩⟩
+
+@[deprecated (since := "2024-10-07")]
+alias WellFounded.isSupFiniteCompact := WellFoundedGT.isSupFiniteCompact
+@[deprecated (since := "2024-10-07")]
+alias IsSupClosedCompact.wellFounded := IsSupClosedCompact.wellFoundedGT
+@[deprecated (since := "2024-10-07")]
+alias wellFounded_characterisations := wellFoundedGT_characterisations
+@[deprecated (since := "2024-10-07")]
+alias wellFounded_iff_isSupFiniteCompact := wellFoundedGT_iff_isSupFiniteCompact
+@[deprecated (since := "2024-10-07")]
+alias IsSupFiniteCompact.wellFounded := IsSupFiniteCompact.wellFoundedGT
+@[deprecated (since := "2024-10-07")]
+alias _root_.WellFounded.isSupClosedCompact := WellFoundedGT.isSupClosedCompact
+@[deprecated (since := "2024-10-07")]
+alias WellFounded.finite_of_setIndependent := WellFoundedGT.finite_of_setIndependent
+@[deprecated (since := "2024-10-07")]
+alias WellFounded.finite_ne_bot_of_independent := WellFoundedGT.finite_ne_bot_of_independent
+@[deprecated (since := "2024-10-07")]
+alias WellFounded.finite_of_independent := WellFoundedGT.finite_of_independent
+@[deprecated (since := "2024-10-07")]
+alias isCompactlyGenerated_of_wellFounded := isCompactlyGenerated_of_wellFoundedGT
 
 /-- A compact element `k` has the property that any `b < k` lies below a "maximal element below
 `k`", which is to say `[⊥, k]` is coatomic. -/

--- a/Mathlib/Order/Disjoint.lean
+++ b/Mathlib/Order/Disjoint.lean
@@ -155,6 +155,10 @@ theorem Disjoint.of_disjoint_inf_of_le' (h : Disjoint (a ⊓ b) c) (hle : b ≤ 
 
 end SemilatticeInfBot
 
+theorem Disjoint.right_lt_sup_of_left_ne_bot [SemilatticeSup α] [OrderBot α] {a b : α}
+    (h : Disjoint a b) (ha : a ≠ ⊥) : b < a ⊔ b :=
+  le_sup_right.lt_of_ne fun eq ↦ ha (le_bot_iff.mp <| h le_rfl <| sup_eq_right.mp eq.symm)
+
 section DistribLatticeBot
 
 variable [DistribLattice α] [OrderBot α] {a b c : α}

--- a/Mathlib/RingTheory/Noetherian.lean
+++ b/Mathlib/RingTheory/Noetherian.lean
@@ -229,19 +229,19 @@ universe w
 variable {R M P : Type*} {N : Type w} [Semiring R] [AddCommMonoid M] [Module R M] [AddCommMonoid N]
   [Module R N] [AddCommMonoid P] [Module R P]
 
-theorem isNoetherian_iff :
-    IsNoetherian R M ↔ WellFounded ((· > ·) : Submodule R M → Submodule R M → Prop) := by
-  have := (CompleteLattice.wellFounded_characterisations <| Submodule R M).out 0 3
+theorem isNoetherian_iff' : IsNoetherian R M ↔ WellFoundedGT (Submodule R M) := by
+  have := (CompleteLattice.wellFoundedGT_characterisations <| Submodule R M).out 0 3
   -- Porting note: inlining this makes rw complain about it being a metavariable
   rw [this]
   exact
     ⟨fun ⟨h⟩ => fun k => (fg_iff_compact k).mp (h k), fun h =>
       ⟨fun k => (fg_iff_compact k).mpr (h k)⟩⟩
 
-alias ⟨IsNoetherian.wf, _⟩ := isNoetherian_iff
+theorem isNoetherian_iff :
+    IsNoetherian R M ↔ WellFounded ((· > ·) : Submodule R M → Submodule R M → Prop) := by
+  rw [isNoetherian_iff', ← isWellFounded_iff]
 
-theorem isNoetherian_iff' : IsNoetherian R M ↔ WellFoundedGT (Submodule R M) := by
-  rw [isNoetherian_iff, ← isWellFounded_iff]
+alias ⟨IsNoetherian.wf, _⟩ := isNoetherian_iff
 
 alias ⟨IsNoetherian.wellFoundedGT, isNoetherian_mk⟩ := isNoetherian_iff'
 
@@ -303,14 +303,13 @@ variable {R M P : Type*} {N : Type w} [Ring R] [AddCommGroup M] [Module R M] [Ad
 lemma Submodule.finite_ne_bot_of_independent {ι : Type*} {N : ι → Submodule R M}
     (h : CompleteLattice.Independent N) :
     Set.Finite {i | N i ≠ ⊥} :=
-  CompleteLattice.WellFounded.finite_ne_bot_of_independent
-    (IsWellFounded.wf) h
+  CompleteLattice.WellFoundedGT.finite_ne_bot_of_independent h
 
 /-- A linearly-independent family of vectors in a module over a non-trivial ring must be finite if
 the module is Noetherian. -/
 theorem LinearIndependent.finite_of_isNoetherian [Nontrivial R] {ι} {v : ι → M}
     (hv : LinearIndependent R v) : Finite ι := by
-  refine CompleteLattice.WellFounded.finite_of_independent IsWellFounded.wf
+  refine CompleteLattice.WellFoundedGT.finite_of_independent
     hv.independent_span_singleton
     fun i contra => ?_
   apply hv.ne_zero i

--- a/Mathlib/Topology/NoetherianSpace.lean
+++ b/Mathlib/Topology/NoetherianSpace.lean
@@ -153,7 +153,7 @@ instance (priority := 100) Finite.to_noetherianSpace [Finite α] : NoetherianSpa
 /-- In a Noetherian space, every closed set is a finite union of irreducible closed sets. -/
 theorem NoetherianSpace.exists_finite_set_closeds_irreducible [NoetherianSpace α] (s : Closeds α) :
     ∃ S : Set (Closeds α), S.Finite ∧ (∀ t ∈ S, IsIrreducible (t : Set α)) ∧ s = sSup S := by
-  apply wellFounded_closeds.induction s; clear s
+  apply wellFounded_lt.induction s; clear s
   intro s H
   rcases eq_or_ne s ⊥ with rfl | h₀
   · use ∅; simp

--- a/Mathlib/Topology/NoetherianSpace.lean
+++ b/Mathlib/Topology/NoetherianSpace.lean
@@ -95,8 +95,10 @@ theorem noetherianSpace_iff_isCompact : NoetherianSpace α ↔ ∀ s : Set α, I
 instance [NoetherianSpace α] : WellFoundedLT (Closeds α) :=
   Iff.mp ((noetherianSpace_TFAE α).out 0 1) ‹_›
 
-@[deprecated (since := "2024-10-07")] alias NoetherianSpace.wellFounded_closeds :=
-  TopologicalSpace.instWellFoundedLTClosedsOfNoetherianSpace
+@[deprecated (since := "2024-10-07")]
+theorem NoetherianSpace.wellFounded_closeds [NoetherianSpace α] :
+    WellFounded fun s t : Closeds α => s < t :=
+  wellFounded_lt
 
 instance {α} : NoetherianSpace (CofiniteTopology α) := by
   simp only [noetherianSpace_iff_isCompact, isCompact_iff_ultrafilter_le_nhds,

--- a/Mathlib/Topology/NoetherianSpace.lean
+++ b/Mathlib/Topology/NoetherianSpace.lean
@@ -43,12 +43,10 @@ variable (α β : Type*) [TopologicalSpace α] [TopologicalSpace β]
 namespace TopologicalSpace
 
 /-- Type class for noetherian spaces. It is defined to be spaces whose open sets satisfies ACC. -/
-@[mk_iff]
-class NoetherianSpace : Prop where
-  wellFounded_opens : WellFounded ((· > ·) : Opens α → Opens α → Prop)
+abbrev NoetherianSpace : Prop := WellFoundedGT (Opens α)
 
 theorem noetherianSpace_iff_opens : NoetherianSpace α ↔ ∀ s : Opens α, IsCompact (s : Set α) := by
-  rw [noetherianSpace_iff, CompleteLattice.wellFounded_iff_isSupFiniteCompact,
+  rw [NoetherianSpace, CompleteLattice.wellFoundedGT_iff_isSupFiniteCompact,
     CompleteLattice.isSupFiniteCompact_iff_all_elements_compact]
   exact forall_congr' Opens.isCompactElement_iff
 
@@ -78,12 +76,12 @@ variable (α)
 open List in
 theorem noetherianSpace_TFAE :
     TFAE [NoetherianSpace α,
-      WellFounded fun s t : Closeds α => s < t,
+      WellFoundedLT (Closeds α),
       ∀ s : Set α, IsCompact s,
       ∀ s : Opens α, IsCompact (s : Set α)] := by
   tfae_have 1 ↔ 2 := by
-    refine (noetherianSpace_iff α).trans (Opens.compl_bijective.2.wellFounded_iff ?_)
-    exact (@OrderIso.compl (Set α)).lt_iff_lt.symm
+    simp_rw [isWellFounded_iff]
+    exact Opens.compl_bijective.2.wellFounded_iff (@OrderIso.compl (Set α)).lt_iff_lt.symm
   tfae_have 1 ↔ 4 := noetherianSpace_iff_opens α
   tfae_have 1 → 3 := @NoetherianSpace.isCompact α _
   tfae_have 3 → 4 := fun h s => h s
@@ -94,9 +92,11 @@ variable {α}
 theorem noetherianSpace_iff_isCompact : NoetherianSpace α ↔ ∀ s : Set α, IsCompact s :=
   (noetherianSpace_TFAE α).out 0 2
 
-theorem NoetherianSpace.wellFounded_closeds [NoetherianSpace α] :
-    WellFounded fun s t : Closeds α => s < t :=
+instance [NoetherianSpace α] : WellFoundedLT (Closeds α) :=
   Iff.mp ((noetherianSpace_TFAE α).out 0 1) ‹_›
+
+@[deprecated (since := "2024-10-07")] alias NoetherianSpace.wellFounded_closeds :=
+  TopologicalSpace.instWellFoundedLTClosedsOfNoetherianSpace
 
 instance {α} : NoetherianSpace (CofiniteTopology α) := by
   simp only [noetherianSpace_iff_isCompact, isCompact_iff_ultrafilter_le_nhds,


### PR DESCRIPTION
The same conclusion was previously known under a `WellFounded (· > ·)` assumption, which we replace with WellFoundedGT. We also change WellFounded in existing lemma names to WellFoundedGT to avoid confusion with the new WellFoundedLT lemmas we introduce.

A consequence is that a direct sum of infinitely many nontrivial modules can't be Artinian. (Previous results imply it can't be Noetherian.)

The lemma `Disjoint.right_lt_sup_of_left_ne_bot` is used and added.

The definition of `NoetherianSpace` is changed to use `WellFoundedGT` (defeq to before), and the statement of `noetherianSpace_TFAE` is changed to use `WellFoundedLT`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
