### PR TITLE
[Merged by Bors] - feat(CategoryTheory/KanExtensions): Evaluating `lan` twice amounts to taking a colimit

### DIFF
--- a/Mathlib/CategoryTheory/Functor/KanExtension/Adjunction.lean
+++ b/Mathlib/CategoryTheory/Functor/KanExtension/Adjunction.lean
@@ -64,14 +64,14 @@ noncomputable def lanObjObjIsoColimit (F : C ⥤ H) [HasPointwiseLeftKanExtensio
    (isPointwiseLeftKanExtensionLanUnit L F X)
 
 @[reassoc (attr := simp)]
-lemma lanObjObjIsoColimit_ι_inv
+lemma ι_lanObjObjIsoColimit_inv
     (F : C ⥤ H) [HasPointwiseLeftKanExtension L F] (X : D) (f : CostructuredArrow L X) :
     Limits.colimit.ι _ f ≫ (L.lanObjObjIsoColimit F X).inv =
     (L.lanUnit.app F).app f.left ≫ (L.lan.obj F).map f.hom := by
   simp [lanObjObjIsoColimit, lanUnit]
 
 @[reassoc (attr := simp)]
-lemma lanObjObjIsoColimit_lanUnit_map_hom
+lemma ι_lanObjObjIsoColimit_hom
     (F : C ⥤ H) [HasPointwiseLeftKanExtension L F] (X : D) (f : CostructuredArrow L X) :
     (L.lanUnit.app F).app f.left ≫ (L.lan.obj F).map f.hom ≫ (L.lanObjObjIsoColimit F X).hom =
     Limits.colimit.ι (CostructuredArrow.proj L X ⋙ F) f :=

--- a/Mathlib/CategoryTheory/Functor/KanExtension/Adjunction.lean
+++ b/Mathlib/CategoryTheory/Functor/KanExtension/Adjunction.lean
@@ -74,8 +74,8 @@ lemma lanObjObjIsoColimit_ι_inv
 lemma lanObjObjIsoColimit_lanUnit_map_hom
     (F : C ⥤ H) [HasPointwiseLeftKanExtension L F] (X : D) (f : CostructuredArrow L X) :
     (L.lanUnit.app F).app f.left ≫ (L.lan.obj F).map f.hom ≫ (L.lanObjObjIsoColimit F X).hom =
-    Limits.colimit.ι (CostructuredArrow.proj L X ⋙ F) f := by
-  exact LeftExtension.IsPointwiseLeftKanExtensionAt.ι_isoColimit_hom (F := F)
+    Limits.colimit.ι (CostructuredArrow.proj L X ⋙ F) f :=
+  LeftExtension.IsPointwiseLeftKanExtensionAt.ι_isoColimit_hom (F := F)
     (isPointwiseLeftKanExtensionLanUnit L F X) f
 
 variable (H) in
@@ -202,8 +202,8 @@ lemma ranObjObjIsoLimit_hom_π
 lemma ranObjObjIsoLimit_inv_π
     (F : C ⥤ H) [HasPointwiseRightKanExtension L F] (X : D) (f : StructuredArrow X L) :
     (L.ranObjObjIsoLimit F X).inv ≫ (L.ran.obj F).map f.hom ≫ (L.ranCounit.app F).app f.right =
-    Limits.limit.π _ f := by
-  exact RightExtension.IsPointwiseRightKanExtensionAt.isoLimit_inv_π (F := F)
+    Limits.limit.π _ f :=
+  RightExtension.IsPointwiseRightKanExtensionAt.isoLimit_inv_π (F := F)
     (isPointwiseRightKanExtensionRanCounit L F X) f
 
 variable (H) in

--- a/Mathlib/CategoryTheory/Functor/KanExtension/Adjunction.lean
+++ b/Mathlib/CategoryTheory/Functor/KanExtension/Adjunction.lean
@@ -72,8 +72,13 @@ lemma lanObjObjIsoColimit_ι_inv
   simp [lanObjObjIsoColimit, LeftExtension.IsPointwiseLeftKanExtension.homFrom,
     pointwiseLeftKanExtensionIsPointwiseLeftKanExtension]
 
-example (X Y Z : C) (f f' : X ⟶ Y) (g : Z ⟶ X) (h : f = f') : g ≫ f = g ≫ f' := by
-  exact congrArg (CategoryStruct.comp g) h
+lemma lanObjObjIsoColimit_lanUnit_map_hom
+    (F : C ⥤ H) [HasPointwiseLeftKanExtension L F] (X : D) (f : CostructuredArrow L X) :
+    (L.lanUnit.app F).app f.left ≫ (L.lan.obj F).map f.hom ≫ (L.lanObjObjIsoColimit F X).hom =
+    Limits.colimit.ι (CostructuredArrow.proj L X ⋙ F) f := by
+  rw [← Category.assoc, ← Iso.eq_comp_inv]
+  symm
+  apply lanObjObjIsoColimit_ι_inv
 
 variable (H) in
 /-- The left Kan extension functor `L.Lan` is left adjoint to the

--- a/Mathlib/CategoryTheory/Functor/KanExtension/Adjunction.lean
+++ b/Mathlib/CategoryTheory/Functor/KanExtension/Adjunction.lean
@@ -56,6 +56,15 @@ noncomputable def isPointwiseLeftKanExtensionLanUnit
     (LeftExtension.mk _ (L.lanUnit.app F)).IsPointwiseLeftKanExtension :=
   isPointwiseLeftKanExtensionOfIsLeftKanExtension (F := F) _ (L.lanUnit.app F)
 
+/-- If a left Kan extension is pointwise, then evaluating it at an object is isomorphic to
+taking a colimit. -/
+noncomputable def lanObjObjIsoColimit
+    (F : C ⥤ H) [HasPointwiseLeftKanExtension L F] (X : D) :
+    (L.lan.obj F).obj X ≅ Limits.colimit (CostructuredArrow.proj L X ⋙ F) :=
+  let e₁ := isPointwiseLeftKanExtensionLanUnit L F
+  let e₂ := pointwiseLeftKanExtensionIsPointwiseLeftKanExtension L F
+  (Comma.rightIso (LeftExtension.isoOfIsPointwiseLeftKanExtension e₁ e₂)).app X
+
 variable (H) in
 /-- The left Kan extension functor `L.Lan` is left adjoint to the
 precomposition by `L`. -/
@@ -161,6 +170,15 @@ noncomputable def isPointwiseRightKanExtensionRanCounit
     (F : C ⥤ H) [HasPointwiseRightKanExtension L F] :
     (RightExtension.mk _ (L.ranCounit.app F)).IsPointwiseRightKanExtension :=
   isPointwiseRightKanExtensionOfIsRightKanExtension (F := F) _ (L.ranCounit.app F)
+
+/-- If a right Kan extension is pointwise, then evaluating it at an object is isomorphic to
+taking a limit. -/
+noncomputable def ranObjObjIsoLimit
+    (F : C ⥤ H) [HasPointwiseRightKanExtension L F] (X : D) :
+    (L.ran.obj F).obj X ≅ Limits.limit (StructuredArrow.proj X L ⋙ F) :=
+  let e₁ := isPointwiseRightKanExtensionRanCounit L F
+  let e₂ := pointwiseRightKanExtensionIsPointwiseRightKanExtension L F
+  (Comma.leftIso (RightExtension.isoOfIsPointwiseRightKanExtension e₁ e₂)).app X
 
 variable (H) in
 /-- The right Kan extension functor `L.ran` is right adjoint to the

--- a/Mathlib/CategoryTheory/Functor/KanExtension/Adjunction.lean
+++ b/Mathlib/CategoryTheory/Functor/KanExtension/Adjunction.lean
@@ -53,20 +53,21 @@ instance (F : C ⥤ H) : (L.lan.obj F).IsLeftKanExtension (L.lanUnit.app F) := b
 then `L.lan.obj G` is a pointwise left Kan extension of `F`. -/
 noncomputable def isPointwiseLeftKanExtensionLanUnit
     (F : C ⥤ H) [HasPointwiseLeftKanExtension L F] :
-    (LeftExtension.mk _ (leftKanExtensionUnit L F)).IsPointwiseLeftKanExtension :=
+    (LeftExtension.mk _ (L.lanUnit.app F)).IsPointwiseLeftKanExtension :=
   isPointwiseLeftKanExtensionOfIsLeftKanExtension (F := F) _ (L.lanUnit.app F)
 
 /-- If a left Kan extension is pointwise, then evaluating it at an object is isomorphic to
 taking a colimit. -/
 noncomputable def lanObjObjIsoColimit (F : C ⥤ H) [HasPointwiseLeftKanExtension L F] (X : D) :
     (L.lan.obj F).obj X ≅ Limits.colimit (CostructuredArrow.proj L X ⋙ F) :=
-  LeftExtension.IsPointwiseLeftKanExtensionAt.isoColimit (isPointwiseLeftKanExtensionLanUnit L F X)
+  LeftExtension.IsPointwiseLeftKanExtensionAt.isoColimit (F := F)
+   (isPointwiseLeftKanExtensionLanUnit L F X)
 
 @[reassoc (attr := simp)]
 lemma lanObjObjIsoColimit_ι_inv
     (F : C ⥤ H) [HasPointwiseLeftKanExtension L F] (X : D) (f : CostructuredArrow L X) :
     Limits.colimit.ι _ f ≫ (L.lanObjObjIsoColimit F X).inv =
-    (L.lanUnit.app F).app f.left ≫ (L.leftKanExtension F).map f.hom := by
+    (L.lanUnit.app F).app f.left ≫ (L.lan.obj F).map f.hom := by
   simp [lanObjObjIsoColimit, lanUnit]
 
 @[reassoc (attr := simp)]
@@ -74,7 +75,7 @@ lemma lanObjObjIsoColimit_lanUnit_map_hom
     (F : C ⥤ H) [HasPointwiseLeftKanExtension L F] (X : D) (f : CostructuredArrow L X) :
     (L.lanUnit.app F).app f.left ≫ (L.lan.obj F).map f.hom ≫ (L.lanObjObjIsoColimit F X).hom =
     Limits.colimit.ι (CostructuredArrow.proj L X ⋙ F) f := by
-  exact LeftExtension.IsPointwiseLeftKanExtensionAt.ι_isoColimit_hom
+  exact LeftExtension.IsPointwiseLeftKanExtensionAt.ι_isoColimit_hom (F := F)
     (isPointwiseLeftKanExtensionLanUnit L F X) f
 
 variable (H) in
@@ -180,14 +181,14 @@ instance (F : C ⥤ H) : (L.ran.obj F).IsRightKanExtension (L.ranCounit.app F) :
 then `L.ran.obj G` is a pointwise right Kan extension of `F`. -/
 noncomputable def isPointwiseRightKanExtensionRanCounit
     (F : C ⥤ H) [HasPointwiseRightKanExtension L F] :
-    (RightExtension.mk _ (L.rightKanExtensionCounit F)).IsPointwiseRightKanExtension :=
+    (RightExtension.mk _ (L.ranCounit.app F)).IsPointwiseRightKanExtension :=
   isPointwiseRightKanExtensionOfIsRightKanExtension (F := F) _ (L.ranCounit.app F)
 
 /-- If a right Kan extension is pointwise, then evaluating it at an object is isomorphic to
 taking a limit. -/
 noncomputable def ranObjObjIsoLimit (F : C ⥤ H) [HasPointwiseRightKanExtension L F] (X : D) :
     (L.ran.obj F).obj X ≅ Limits.limit (StructuredArrow.proj X L ⋙ F) :=
-  RightExtension.IsPointwiseRightKanExtensionAt.isoLimit
+  RightExtension.IsPointwiseRightKanExtensionAt.isoLimit (F := F)
     (isPointwiseRightKanExtensionRanCounit L F X)
 
 @[reassoc (attr := simp)]
@@ -202,7 +203,7 @@ lemma ranObjObjIsoLimit_inv_π
     (F : C ⥤ H) [HasPointwiseRightKanExtension L F] (X : D) (f : StructuredArrow X L) :
     (L.ranObjObjIsoLimit F X).inv ≫ (L.ran.obj F).map f.hom ≫ (L.ranCounit.app F).app f.right =
     Limits.limit.π _ f := by
-  exact RightExtension.IsPointwiseRightKanExtensionAt.isoLimit_inv_π
+  exact RightExtension.IsPointwiseRightKanExtensionAt.isoLimit_inv_π (F := F)
     (isPointwiseRightKanExtensionRanCounit L F X) f
 
 variable (H) in

--- a/Mathlib/CategoryTheory/Functor/KanExtension/Adjunction.lean
+++ b/Mathlib/CategoryTheory/Functor/KanExtension/Adjunction.lean
@@ -60,17 +60,16 @@ noncomputable def isPointwiseLeftKanExtensionLanUnit
 taking a colimit. -/
 noncomputable def lanObjObjIsoColimit (F : C ⥤ H) [HasPointwiseLeftKanExtension L F] (X : D) :
     (L.lan.obj F).obj X ≅ Limits.colimit (CostructuredArrow.proj L X ⋙ F) :=
-  let e₁ := isPointwiseLeftKanExtensionLanUnit L F
-  let e₂ := pointwiseLeftKanExtensionIsPointwiseLeftKanExtension L F
-  (Comma.rightIso (LeftExtension.isoOfIsPointwiseLeftKanExtension e₁ e₂)).app X
+  Limits.IsColimit.coconePointUniqueUpToIso
+    (isPointwiseLeftKanExtensionLanUnit L F X)
+    (Limits.colimit.isColimit (CostructuredArrow.proj L X ⋙ F))
 
 @[simp]
 lemma lanObjObjIsoColimit_ι_inv
     (F : C ⥤ H) [HasPointwiseLeftKanExtension L F] (X : D) (f : CostructuredArrow L X) :
     Limits.colimit.ι _ f ≫ (L.lanObjObjIsoColimit F X).inv =
     (L.lanUnit.app F).app f.left ≫ (L.lan.obj F).map f.hom := by
-  simp [lanObjObjIsoColimit, LeftExtension.IsPointwiseLeftKanExtension.homFrom,
-    pointwiseLeftKanExtensionIsPointwiseLeftKanExtension]
+  simp [lanObjObjIsoColimit]
 
 lemma lanObjObjIsoColimit_lanUnit_map_hom
     (F : C ⥤ H) [HasPointwiseLeftKanExtension L F] (X : D) (f : CostructuredArrow L X) :
@@ -190,17 +189,16 @@ noncomputable def isPointwiseRightKanExtensionRanCounit
 taking a limit. -/
 noncomputable def ranObjObjIsoLimit (F : C ⥤ H) [HasPointwiseRightKanExtension L F] (X : D) :
     (L.ran.obj F).obj X ≅ Limits.limit (StructuredArrow.proj X L ⋙ F) :=
-  let e₁ := isPointwiseRightKanExtensionRanCounit L F
-  let e₂ := pointwiseRightKanExtensionIsPointwiseRightKanExtension L F
-  (Comma.leftIso (RightExtension.isoOfIsPointwiseRightKanExtension e₁ e₂)).app X
+  Limits.IsLimit.conePointUniqueUpToIso
+    (isPointwiseRightKanExtensionRanCounit L F X)
+    (Limits.limit.isLimit (StructuredArrow.proj X L ⋙ F))
 
 @[simp]
 lemma ranObjObjIsoLimit_hom_π
     (F : C ⥤ H) [HasPointwiseRightKanExtension L F] (X : D) (f : StructuredArrow X L) :
     (L.ranObjObjIsoLimit F X).hom ≫ Limits.limit.π _ f=
     (L.ran.obj F).map f.hom ≫ (L.ranCounit.app F).app f.right := by
-  simp [ranObjObjIsoLimit, RightExtension.IsPointwiseRightKanExtension.homTo,
-    pointwiseRightKanExtensionIsPointwiseRightKanExtension]
+  simp [ranObjObjIsoLimit]
 
 variable (H) in
 /-- The right Kan extension functor `L.ran` is right adjoint to the

--- a/Mathlib/CategoryTheory/Functor/KanExtension/Adjunction.lean
+++ b/Mathlib/CategoryTheory/Functor/KanExtension/Adjunction.lean
@@ -53,31 +53,29 @@ instance (F : C ⥤ H) : (L.lan.obj F).IsLeftKanExtension (L.lanUnit.app F) := b
 then `L.lan.obj G` is a pointwise left Kan extension of `F`. -/
 noncomputable def isPointwiseLeftKanExtensionLanUnit
     (F : C ⥤ H) [HasPointwiseLeftKanExtension L F] :
-    (LeftExtension.mk _ (L.lanUnit.app F)).IsPointwiseLeftKanExtension :=
+    (LeftExtension.mk _ (leftKanExtensionUnit L F)).IsPointwiseLeftKanExtension :=
   isPointwiseLeftKanExtensionOfIsLeftKanExtension (F := F) _ (L.lanUnit.app F)
 
 /-- If a left Kan extension is pointwise, then evaluating it at an object is isomorphic to
 taking a colimit. -/
 noncomputable def lanObjObjIsoColimit (F : C ⥤ H) [HasPointwiseLeftKanExtension L F] (X : D) :
     (L.lan.obj F).obj X ≅ Limits.colimit (CostructuredArrow.proj L X ⋙ F) :=
-  Limits.IsColimit.coconePointUniqueUpToIso
-    (isPointwiseLeftKanExtensionLanUnit L F X)
-    (Limits.colimit.isColimit (CostructuredArrow.proj L X ⋙ F))
+  LeftExtension.IsPointwiseLeftKanExtensionAt.isoColimit (isPointwiseLeftKanExtensionLanUnit L F X)
 
-@[simp]
+@[reassoc (attr := simp)]
 lemma lanObjObjIsoColimit_ι_inv
     (F : C ⥤ H) [HasPointwiseLeftKanExtension L F] (X : D) (f : CostructuredArrow L X) :
     Limits.colimit.ι _ f ≫ (L.lanObjObjIsoColimit F X).inv =
-    (L.lanUnit.app F).app f.left ≫ (L.lan.obj F).map f.hom := by
-  simp [lanObjObjIsoColimit]
+    (L.lanUnit.app F).app f.left ≫ (L.leftKanExtension F).map f.hom := by
+  simp [lanObjObjIsoColimit, lanUnit]
 
+@[reassoc (attr := simp)]
 lemma lanObjObjIsoColimit_lanUnit_map_hom
     (F : C ⥤ H) [HasPointwiseLeftKanExtension L F] (X : D) (f : CostructuredArrow L X) :
     (L.lanUnit.app F).app f.left ≫ (L.lan.obj F).map f.hom ≫ (L.lanObjObjIsoColimit F X).hom =
     Limits.colimit.ι (CostructuredArrow.proj L X ⋙ F) f := by
-  rw [← Category.assoc, ← Iso.eq_comp_inv]
-  symm
-  apply lanObjObjIsoColimit_ι_inv
+  exact LeftExtension.IsPointwiseLeftKanExtensionAt.ι_isoColimit_hom
+    (isPointwiseLeftKanExtensionLanUnit L F X) f
 
 variable (H) in
 /-- The left Kan extension functor `L.Lan` is left adjoint to the
@@ -182,23 +180,30 @@ instance (F : C ⥤ H) : (L.ran.obj F).IsRightKanExtension (L.ranCounit.app F) :
 then `L.ran.obj G` is a pointwise right Kan extension of `F`. -/
 noncomputable def isPointwiseRightKanExtensionRanCounit
     (F : C ⥤ H) [HasPointwiseRightKanExtension L F] :
-    (RightExtension.mk _ (L.ranCounit.app F)).IsPointwiseRightKanExtension :=
+    (RightExtension.mk _ (L.rightKanExtensionCounit F)).IsPointwiseRightKanExtension :=
   isPointwiseRightKanExtensionOfIsRightKanExtension (F := F) _ (L.ranCounit.app F)
 
 /-- If a right Kan extension is pointwise, then evaluating it at an object is isomorphic to
 taking a limit. -/
 noncomputable def ranObjObjIsoLimit (F : C ⥤ H) [HasPointwiseRightKanExtension L F] (X : D) :
     (L.ran.obj F).obj X ≅ Limits.limit (StructuredArrow.proj X L ⋙ F) :=
-  Limits.IsLimit.conePointUniqueUpToIso
+  RightExtension.IsPointwiseRightKanExtensionAt.isoLimit
     (isPointwiseRightKanExtensionRanCounit L F X)
-    (Limits.limit.isLimit (StructuredArrow.proj X L ⋙ F))
 
-@[simp]
+@[reassoc (attr := simp)]
 lemma ranObjObjIsoLimit_hom_π
     (F : C ⥤ H) [HasPointwiseRightKanExtension L F] (X : D) (f : StructuredArrow X L) :
-    (L.ranObjObjIsoLimit F X).hom ≫ Limits.limit.π _ f=
+    (L.ranObjObjIsoLimit F X).hom ≫ Limits.limit.π _ f =
     (L.ran.obj F).map f.hom ≫ (L.ranCounit.app F).app f.right := by
-  simp [ranObjObjIsoLimit]
+  simp [ranObjObjIsoLimit, ran, ranCounit]
+
+@[reassoc (attr := simp)]
+lemma ranObjObjIsoLimit_inv_π
+    (F : C ⥤ H) [HasPointwiseRightKanExtension L F] (X : D) (f : StructuredArrow X L) :
+    (L.ranObjObjIsoLimit F X).inv ≫ (L.ran.obj F).map f.hom ≫ (L.ranCounit.app F).app f.right =
+    Limits.limit.π _ f := by
+  exact RightExtension.IsPointwiseRightKanExtensionAt.isoLimit_inv_π
+    (isPointwiseRightKanExtensionRanCounit L F X) f
 
 variable (H) in
 /-- The right Kan extension functor `L.ran` is right adjoint to the

--- a/Mathlib/CategoryTheory/Functor/KanExtension/Adjunction.lean
+++ b/Mathlib/CategoryTheory/Functor/KanExtension/Adjunction.lean
@@ -58,12 +58,22 @@ noncomputable def isPointwiseLeftKanExtensionLanUnit
 
 /-- If a left Kan extension is pointwise, then evaluating it at an object is isomorphic to
 taking a colimit. -/
-noncomputable def lanObjObjIsoColimit
-    (F : C ⥤ H) [HasPointwiseLeftKanExtension L F] (X : D) :
+noncomputable def lanObjObjIsoColimit (F : C ⥤ H) [HasPointwiseLeftKanExtension L F] (X : D) :
     (L.lan.obj F).obj X ≅ Limits.colimit (CostructuredArrow.proj L X ⋙ F) :=
   let e₁ := isPointwiseLeftKanExtensionLanUnit L F
   let e₂ := pointwiseLeftKanExtensionIsPointwiseLeftKanExtension L F
   (Comma.rightIso (LeftExtension.isoOfIsPointwiseLeftKanExtension e₁ e₂)).app X
+
+@[simp]
+lemma lanObjObjIsoColimit_ι_inv
+    (F : C ⥤ H) [HasPointwiseLeftKanExtension L F] (X : D) (f : CostructuredArrow L X) :
+    Limits.colimit.ι _ f ≫ (L.lanObjObjIsoColimit F X).inv =
+    (L.lanUnit.app F).app f.left ≫ (L.lan.obj F).map f.hom := by
+  simp [lanObjObjIsoColimit, LeftExtension.IsPointwiseLeftKanExtension.homFrom,
+    pointwiseLeftKanExtensionIsPointwiseLeftKanExtension]
+
+example (X Y Z : C) (f f' : X ⟶ Y) (g : Z ⟶ X) (h : f = f') : g ≫ f = g ≫ f' := by
+  exact congrArg (CategoryStruct.comp g) h
 
 variable (H) in
 /-- The left Kan extension functor `L.Lan` is left adjoint to the
@@ -173,12 +183,19 @@ noncomputable def isPointwiseRightKanExtensionRanCounit
 
 /-- If a right Kan extension is pointwise, then evaluating it at an object is isomorphic to
 taking a limit. -/
-noncomputable def ranObjObjIsoLimit
-    (F : C ⥤ H) [HasPointwiseRightKanExtension L F] (X : D) :
+noncomputable def ranObjObjIsoLimit (F : C ⥤ H) [HasPointwiseRightKanExtension L F] (X : D) :
     (L.ran.obj F).obj X ≅ Limits.limit (StructuredArrow.proj X L ⋙ F) :=
   let e₁ := isPointwiseRightKanExtensionRanCounit L F
   let e₂ := pointwiseRightKanExtensionIsPointwiseRightKanExtension L F
   (Comma.leftIso (RightExtension.isoOfIsPointwiseRightKanExtension e₁ e₂)).app X
+
+@[simp]
+lemma ranObjObjIsoLimit_hom_π
+    (F : C ⥤ H) [HasPointwiseRightKanExtension L F] (X : D) (f : StructuredArrow X L) :
+    (L.ranObjObjIsoLimit F X).hom ≫ Limits.limit.π _ f=
+    (L.ran.obj F).map f.hom ≫ (L.ranCounit.app F).app f.right := by
+  simp [ranObjObjIsoLimit, RightExtension.IsPointwiseRightKanExtension.homTo,
+    pointwiseRightKanExtensionIsPointwiseRightKanExtension]
 
 variable (H) in
 /-- The right Kan extension functor `L.ran` is right adjoint to the

--- a/Mathlib/CategoryTheory/Functor/KanExtension/Pointwise.lean
+++ b/Mathlib/CategoryTheory/Functor/KanExtension/Pointwise.lean
@@ -98,6 +98,28 @@ lemma IsPointwiseLeftKanExtensionAt.isIso_hom_app
     IsIso (E.hom.app X) := by
   simpa using h.isIso_ι_app_of_isTerminal _ CostructuredArrow.mkIdTerminal
 
+namespace IsPointwiseLeftKanExtensionAt
+
+variable {E} {Y : D} (h : E.IsPointwiseLeftKanExtensionAt Y)
+  [HasColimit (CostructuredArrow.proj L Y ⋙ F)]
+
+noncomputable def isoColimit :
+    E.right.obj Y ≅ colimit (CostructuredArrow.proj L Y ⋙ F) :=
+  h.coconePointUniqueUpToIso (colimit.isColimit _)
+
+@[reassoc (attr := simp)]
+lemma ι_isoColimit_inv (g : CostructuredArrow L Y) :
+    colimit.ι _ g ≫ h.isoColimit.inv = E.hom.app g.left ≫ E.right.map g.hom :=
+  IsColimit.comp_coconePointUniqueUpToIso_inv _ _ _
+
+@[reassoc (attr := simp)]
+lemma ι_isoColimit_hom (g : CostructuredArrow L Y) :
+    E.hom.app g.left ≫ E.right.map g.hom ≫ h.isoColimit.hom =
+      colimit.ι (CostructuredArrow.proj L Y ⋙ F) g := by
+  simpa using h.comp_coconePointUniqueUpToIso_hom (colimit.isColimit _) g
+
+end IsPointwiseLeftKanExtensionAt
+
 /-- A left extension `E : LeftExtension L F` is a pointwise left Kan extension when
 it is a pointwise left Kan extension at any object. -/
 abbrev IsPointwiseLeftKanExtension := ∀ (Y : D), E.IsPointwiseLeftKanExtensionAt Y
@@ -210,6 +232,28 @@ lemma IsPointwiseRightKanExtensionAt.isIso_hom_app
     {X : C} (h : E.IsPointwiseRightKanExtensionAt (L.obj X)) [L.Full] [L.Faithful] :
     IsIso (E.hom.app X) := by
   simpa using h.isIso_π_app_of_isInitial _ StructuredArrow.mkIdInitial
+
+namespace IsPointwiseRightKanExtensionAt
+
+variable {E} {Y : D} (h : E.IsPointwiseRightKanExtensionAt Y)
+  [HasLimit (StructuredArrow.proj Y L ⋙ F)]
+
+noncomputable def isoLimit :
+    E.left.obj Y ≅ limit (StructuredArrow.proj Y L ⋙ F) :=
+  h.conePointUniqueUpToIso (limit.isLimit _)
+
+@[reassoc (attr := simp)]
+lemma isoLimit_hom_π (g : StructuredArrow Y L) :
+    h.isoLimit.hom ≫ limit.π _ g = E.left.map g.hom ≫ E.hom.app g.right :=
+  IsLimit.conePointUniqueUpToIso_hom_comp _ _ _
+
+@[reassoc (attr := simp)]
+lemma isoLimit_inv_π (g : StructuredArrow Y L) :
+    h.isoLimit.inv ≫ E.left.map g.hom ≫ E.hom.app g.right =
+      limit.π (StructuredArrow.proj Y L ⋙ F) g := by
+  simpa using h.conePointUniqueUpToIso_inv_comp (limit.isLimit _) g
+
+end IsPointwiseRightKanExtensionAt
 
 /-- A right extension `E : RightExtension L F` is a pointwise right Kan extension when
 it is a pointwise right Kan extension at any object. -/

--- a/Mathlib/CategoryTheory/Functor/KanExtension/Pointwise.lean
+++ b/Mathlib/CategoryTheory/Functor/KanExtension/Pointwise.lean
@@ -167,6 +167,7 @@ lemma IsPointwiseLeftKanExtension.isIso_hom [L.Full] [L.Faithful] :
   NatIso.isIso_of_isIso_app ..
 
 /-- Two left extensions are isomorphic if they are both left Kan extensions. -/
+@[simps]
 def isoOfIsPointwiseLeftKanExtension
     (h : E.IsPointwiseLeftKanExtension) (h' : E'.IsPointwiseLeftKanExtension) : E ≅ E' where
   hom := IsPointwiseLeftKanExtension.homFrom h _
@@ -287,6 +288,7 @@ lemma IsPointwiseRightKanExtension.isIso_hom [L.Full] [L.Faithful] :
   NatIso.isIso_of_isIso_app ..
 
 /-- Two right extensions are isomorphic if they are both right Kan extensions. -/
+@[simps]
 def isoOfIsPointwiseRightKanExtension
     (h : E.IsPointwiseRightKanExtension) (h' : E'.IsPointwiseRightKanExtension) : E ≅ E' where
   hom := IsPointwiseRightKanExtension.homTo h' _

--- a/Mathlib/CategoryTheory/Functor/KanExtension/Pointwise.lean
+++ b/Mathlib/CategoryTheory/Functor/KanExtension/Pointwise.lean
@@ -166,15 +166,6 @@ lemma IsPointwiseLeftKanExtension.isIso_hom [L.Full] [L.Faithful] :
   have := fun X => (h (L.obj X)).isIso_hom_app
   NatIso.isIso_of_isIso_app ..
 
-/-- Two left extensions are isomorphic if they are both left Kan extensions. -/
-@[simps]
-def isoOfIsPointwiseLeftKanExtension
-    (h : E.IsPointwiseLeftKanExtension) (h' : E'.IsPointwiseLeftKanExtension) : E ≅ E' where
-  hom := IsPointwiseLeftKanExtension.homFrom h _
-  inv := IsPointwiseLeftKanExtension.homFrom h' _
-  hom_inv_id := IsPointwiseLeftKanExtension.hom_ext h
-  inv_hom_id := IsPointwiseLeftKanExtension.hom_ext h'
-
 end LeftExtension
 
 namespace RightExtension
@@ -286,15 +277,6 @@ lemma IsPointwiseRightKanExtension.isIso_hom [L.Full] [L.Faithful] :
     IsIso (E.hom) :=
   have := fun X => (h (L.obj X)).isIso_hom_app
   NatIso.isIso_of_isIso_app ..
-
-/-- Two right extensions are isomorphic if they are both right Kan extensions. -/
-@[simps]
-def isoOfIsPointwiseRightKanExtension
-    (h : E.IsPointwiseRightKanExtension) (h' : E'.IsPointwiseRightKanExtension) : E ≅ E' where
-  hom := IsPointwiseRightKanExtension.homTo h' _
-  inv := IsPointwiseRightKanExtension.homTo h _
-  hom_inv_id := IsPointwiseRightKanExtension.hom_ext h
-  inv_hom_id := IsPointwiseRightKanExtension.hom_ext h'
 
 end RightExtension
 

--- a/Mathlib/CategoryTheory/Functor/KanExtension/Pointwise.lean
+++ b/Mathlib/CategoryTheory/Functor/KanExtension/Pointwise.lean
@@ -166,6 +166,14 @@ lemma IsPointwiseLeftKanExtension.isIso_hom [L.Full] [L.Faithful] :
   have := fun X => (h (L.obj X)).isIso_hom_app
   NatIso.isIso_of_isIso_app ..
 
+/-- Two left extensions are isomorphic if they are both left Kan extensions. -/
+def isoOfIsPointwiseLeftKanExtension
+    (h : E.IsPointwiseLeftKanExtension) (h' : E'.IsPointwiseLeftKanExtension) : E ≅ E' where
+  hom := IsPointwiseLeftKanExtension.homFrom h _
+  inv := IsPointwiseLeftKanExtension.homFrom h' _
+  hom_inv_id := IsPointwiseLeftKanExtension.hom_ext h
+  inv_hom_id := IsPointwiseLeftKanExtension.hom_ext h'
+
 end LeftExtension
 
 namespace RightExtension
@@ -277,6 +285,14 @@ lemma IsPointwiseRightKanExtension.isIso_hom [L.Full] [L.Faithful] :
     IsIso (E.hom) :=
   have := fun X => (h (L.obj X)).isIso_hom_app
   NatIso.isIso_of_isIso_app ..
+
+/-- Two right extensions are isomorphic if they are both right Kan extensions. -/
+def isoOfIsPointwiseRightKanExtension
+    (h : E.IsPointwiseRightKanExtension) (h' : E'.IsPointwiseRightKanExtension) : E ≅ E' where
+  hom := IsPointwiseRightKanExtension.homTo h' _
+  inv := IsPointwiseRightKanExtension.homTo h _
+  hom_inv_id := IsPointwiseRightKanExtension.hom_ext h
+  inv_hom_id := IsPointwiseRightKanExtension.hom_ext h'
 
 end RightExtension
 

--- a/Mathlib/CategoryTheory/Functor/KanExtension/Pointwise.lean
+++ b/Mathlib/CategoryTheory/Functor/KanExtension/Pointwise.lean
@@ -103,6 +103,8 @@ namespace IsPointwiseLeftKanExtensionAt
 variable {E} {Y : D} (h : E.IsPointwiseLeftKanExtensionAt Y)
   [HasColimit (CostructuredArrow.proj L Y ⋙ F)]
 
+/-- A pointwise left Kan extension of `F` along `L` applied to an object `Y` is isomorphic to
+`colimit (CostructuredArrow.proj L Y ⋙ F)`. -/
 noncomputable def isoColimit :
     E.right.obj Y ≅ colimit (CostructuredArrow.proj L Y ⋙ F) :=
   h.coconePointUniqueUpToIso (colimit.isColimit _)
@@ -238,6 +240,8 @@ namespace IsPointwiseRightKanExtensionAt
 variable {E} {Y : D} (h : E.IsPointwiseRightKanExtensionAt Y)
   [HasLimit (StructuredArrow.proj Y L ⋙ F)]
 
+/-- A pointwise right Kan extension of `F` along `L` applied to an object `Y` is isomorphic to
+`limit (StructuredArrow.proj Y L ⋙ F)`. -/
 noncomputable def isoLimit :
     E.left.obj Y ≅ limit (StructuredArrow.proj Y L ⋙ F) :=
   h.conePointUniqueUpToIso (limit.isLimit _)


### PR DESCRIPTION
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
