### PR TITLE
[Merged by Bors] - fix: increase the priority of `lemma` notation

### DIFF
--- a/Mathlib/Tactic/Lemma.lean
+++ b/Mathlib/Tactic/Lemma.lean
@@ -12,8 +12,9 @@ import Lean.Parser.Command
 
 open Lean
 
+-- higher priority to override the one in Batteries
 /-- `lemma` means the same as `theorem`. It is used to denote "less important" theorems -/
-syntax (name := lemma) declModifiers
+syntax (name := lemma) (priority := default + 1) declModifiers
   group("lemma " declId ppIndent(declSig) declVal) : command
 
 /-- Implementation of the `lemma` command, by macro expansion to `theorem`. -/


### PR DESCRIPTION
This makes it take precedence over the Batteries version, which in turn simplifies the resulting `Syntax` object to not have a `choice` node.

Presumably there is a very marginal performance gain too.

[Zulip thread](https://leanprover.zulipchat.com/#narrow/stream/348111-batteries/topic/lemma.20notation)


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
