### PR TITLE
[Merged by Bors] - chore: remove CI check from adaptation PR script

### DIFF
--- a/scripts/create-adaptation-pr.sh
+++ b/scripts/create-adaptation-pr.sh
@@ -72,24 +72,6 @@ if ! command -v gh &> /dev/null; then
     exit 1
 fi
 
-# Check the CI status of the latest commit on the 'nightly-testing' branch
-status=$(gh run list --branch nightly-testing | grep -m1 . | awk '{print $1}')
-if [ "$status" != "completed" ]; then
-  if [ "$status" != "in_progress" ]; then
-    echo "The latest commit on the 'nightly-testing' branch did not pass CI. Please fix the issues and try again."
-    gh run list --branch nightly-testing
-    exit 1
-  else
-    if [ "$AUTO" = "yes" ]; then
-      echo "Auto mode enabled. Bailing out because the latest commit on 'nightly-testing' is still running CI."
-      exit 1
-    else
-      echo "The latest commit on 'nightly-testing' is still running CI."
-      read -p "Press enter to continue, or ctrl-C if you'd prefer to wait for CI."
-    fi
-  fi
-fi
-
 echo "### Creating a PR for the nightly adaptation for $NIGHTLYDATE"
 
 echo


### PR DESCRIPTION
Since we now pass an explicit commit hash to the script,
pointing to a commit on `nightly-testing` that we want to use,
there is no point in checking whether the HEAD of `nightly-testing`
is still running CI.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
