### PR TITLE
[Merged by Bors] - feat(Matrix): extracting entries as a linear map

### DIFF
--- a/Mathlib/Data/Matrix/Basic.lean
+++ b/Mathlib/Data/Matrix/Basic.lean
@@ -1210,8 +1210,6 @@ def diagonalAlgHom : (n → α) →ₐ[R] Matrix n n α :=
 
 end Algebra
 
-section apply₂
-
 section AddHom
 
 variable [Add α]
@@ -1292,8 +1290,6 @@ lemma elemLinearMap_eq {i : m} {j : n} :
     (elemLinearMap R α i j).toAddHom = elemAddHom α i j := rfl
 
 end LinearMap
-
-end apply₂
 
 end Matrix
 

--- a/Mathlib/Data/Matrix/Basic.lean
+++ b/Mathlib/Data/Matrix/Basic.lean
@@ -335,6 +335,19 @@ instance subsingleton_of_empty_right [IsEmpty n] : Subsingleton (Matrix m n α) 
     ext i j
     exact isEmptyElim j⟩
 
+def ofAddEquiv [Add α] : (m → n → α) ≃+ Matrix m n α where
+  __ := of
+  map_add' _ _ := rfl
+
+@[simp] lemma coe_ofAddEquiv [Add α] : (ofAddEquiv : (m → n → α) → Matrix m n α) = of := rfl
+
+def ofLinearEquiv [Semiring R] [AddCommMonoid α] [Module R α] : (m → n → α) ≃ₗ[R] Matrix m n α where
+  __ := ofAddEquiv
+  map_smul' _ _ := rfl
+
+@[simp] lemma coe_ofLinearEquiv [Semiring R] [AddCommMonoid α] [Module R α] :
+    (ofLinearEquiv (R := R) : (m → n → α) → Matrix m n α) = of := rfl
+
 end Matrix
 
 open Matrix
@@ -1221,9 +1234,9 @@ def entryAddHom (i : m) (j : n) : AddHom (Matrix m n α) α where
   toFun M := M i j
   map_add' _ _ := rfl
 
--- The type ascription on the RHS is necessary for unification to succeed on the composition.
 lemma entryAddHom_eq_comp {i : m} {j : n} :
-    entryAddHom α i j = (Pi.evalAddHom _ j).comp (Pi.evalAddHom _ i : AddHom _ (n → α)) :=
+    entryAddHom α i j =
+      ((Pi.evalAddHom _ j).comp (Pi.evalAddHom _ i)).comp (AddHomClass.toAddHom ofAddEquiv.symm) :=
   rfl
 
 end AddHom
@@ -1243,10 +1256,10 @@ def entryAddMonoidHom (i : m) (j : n) : Matrix m n α →+ α where
   map_add' _ _ := rfl
   map_zero' := rfl
 
--- The type ascription on the RHS is necessary for unification to succeed on the composition.
 lemma entryAddMonoidHom_eq_comp {i : m} {j : n} :
     entryAddMonoidHom α i j =
-      (Pi.evalAddMonoidHom _ j).comp (Pi.evalAddMonoidHom _ i : _ →+ (n → α)) :=
+      ((Pi.evalAddMonoidHom _ j).comp (Pi.evalAddMonoidHom _ i)).comp
+        (AddMonoidHomClass.toAddMonoidHom ofAddEquiv.symm) := by
   rfl
 
 @[simp] lemma evalAddMonoidHom_comp_diagAddMonoidHom (i : m) :
@@ -1274,9 +1287,9 @@ def entryLinearMap (i : m) (j : n) :
   map_add' _ _ := rfl
   map_smul' _ _ := rfl
 
--- The type ascription on the RHS is necessary for unification to succeed on the linear composition.
-lemma entryLinearMap_eq {i : m} {j : n} :
-    entryLinearMap R α i j = LinearMap.proj j ∘ₗ (LinearMap.proj i : _ →ₗ[_] (n → α)) :=
+lemma entryLinearMap_eq_comp {i : m} {j : n} :
+    entryLinearMap R α i j =
+      LinearMap.proj j ∘ₗ LinearMap.proj i ∘ₗ ofLinearEquiv.symm.toLinearMap := by
   rfl
 
 @[simp] lemma proj_comp_diagLinearMap (i : m) :

--- a/Mathlib/Data/Matrix/Basic.lean
+++ b/Mathlib/Data/Matrix/Basic.lean
@@ -1234,6 +1234,8 @@ def entryAddHom (i : m) (j : n) : AddHom (Matrix m n α) α where
   toFun M := M i j
   map_add' _ _ := rfl
 
+-- It is necessary to spell out the name of the coercion explicitly on the RHS
+-- for unification to succeed
 lemma entryAddHom_eq_comp {i : m} {j : n} :
     entryAddHom α i j =
       ((Pi.evalAddHom _ j).comp (Pi.evalAddHom _ i)).comp (AddHomClass.toAddHom ofAddEquiv.symm) :=
@@ -1256,6 +1258,8 @@ def entryAddMonoidHom (i : m) (j : n) : Matrix m n α →+ α where
   map_add' _ _ := rfl
   map_zero' := rfl
 
+-- It is necessary to spell out the name of the coercion explicitly on the RHS
+-- for unification to succeed
 lemma entryAddMonoidHom_eq_comp {i : m} {j : n} :
     entryAddMonoidHom α i j =
       ((Pi.evalAddMonoidHom _ j).comp (Pi.evalAddMonoidHom _ i)).comp
@@ -1287,6 +1291,8 @@ def entryLinearMap (i : m) (j : n) :
   map_add' _ _ := rfl
   map_smul' _ _ := rfl
 
+-- It is necessary to spell out the name of the coercion explicitly on the RHS
+-- for unification to succeed
 lemma entryLinearMap_eq_comp {i : m} {j : n} :
     entryLinearMap R α i j =
       LinearMap.proj j ∘ₗ LinearMap.proj i ∘ₗ ofLinearEquiv.symm.toLinearMap := by

--- a/Mathlib/Data/Matrix/Basic.lean
+++ b/Mathlib/Data/Matrix/Basic.lean
@@ -1254,7 +1254,7 @@ lemma entryAddMonoidHom_eq_comp {i : m} {j : n} :
   simp [AddMonoidHom.ext_iff]
 
 @[simp] lemma entryAddMonoidHom_toAddHom {i : m} {j : n} :
-  (entryAddMonoidHom α i j : AddHom _ _) = Matrix.entryAddHom α i j := rfl
+  (entryAddMonoidHom α i j : AddHom _ _) = entryAddHom α i j := rfl
 
 end AddMonoidHom
 

--- a/Mathlib/Data/Matrix/Basic.lean
+++ b/Mathlib/Data/Matrix/Basic.lean
@@ -1210,16 +1210,47 @@ def diagonalAlgHom : (n → α) →ₐ[R] Matrix n n α :=
 
 end Algebra
 
+end Matrix
+
 section apply₂
 
-open LinearMap
+namespace AddMonoidHom
+
+variable [AddZeroClass α]
+
+variable (R α) in
+/--
+Extracting entries from a matrix as a monoid homomorphism. Note this cannot be upgraded to a ring
+homomorphism, as it does not respect multiplication.
+-/
+@[simps]
+def apply₂ (i : m) (j : n) : Matrix m n α →+ α where
+  toFun M := M i j
+  map_add' _ _ := rfl
+  map_zero' := rfl
+
+lemma apply₂_eq_proj {i : m} {j : n} :
+    apply₂ α i j = (Pi.evalAddMonoidHom _ j).comp (Pi.evalAddMonoidHom _ i : _ →+ (n → α)) :=
+  rfl
+
+lemma proj_comp_diagLinearMap (i : m) :
+    (Pi.evalAddMonoidHom _ i).comp (diagAddMonoidHom m α) = apply₂ α i i := by
+  simp [AddMonoidHom.ext_iff]
+
+end AddMonoidHom
+
+namespace LinearMap
 
 variable [Semiring R] [AddCommMonoid α] [Module R α]
 
 variable (R α) in
-/-- Extracting entries from a matrix as a linear map. -/
+/--
+Extracting entries from a matrix as a linear map. Note this cannot be upgraded to an algebra
+homomorphism, as it does not respect multiplication.
+-/
 @[simps]
-def apply₂ [Semiring R] [AddCommMonoid α] [Module R α] (i : m) (j : n) : Matrix m n α →ₗ[R] α where
+def apply₂ (i : m) (j : n) :
+    Matrix m n α →ₗ[R] α where
   toFun M := M i j
   map_add' _ _ := rfl
   map_smul' _ _ := rfl
@@ -1229,13 +1260,14 @@ lemma apply₂_eq_proj {i : m} {j : n} :
     apply₂ R α i j = proj j ∘ₗ (proj i : _ →ₗ[_] (n → α)) :=
   rfl
 
-lemma diag_comp_apply (i : m) :
-    proj i ∘ₗ Matrix.diagLinearMap m R α = apply₂ R α i i := by
+lemma proj_comp_diagLinearMap (i : m) :
+    proj i ∘ₗ diagLinearMap m R α = apply₂ R α i i := by
   simp [LinearMap.ext_iff]
+
+end LinearMap
 
 end apply₂
 
-end Matrix
 
 /-!
 ### Bundled versions of `Matrix.map`
@@ -1289,6 +1321,9 @@ theorem mapMatrix_comp (f : β →+ γ) (g : α →+ β) :
     f.mapMatrix.comp g.mapMatrix = ((f.comp g).mapMatrix : Matrix m n α →+ _) :=
   rfl
 
+@[simp] lemma apply₂_comp_mapMatrix (f : α →+ β) (i : m) (j : n) :
+    (apply₂ β i j).comp f.mapMatrix = f.comp (apply₂ α i j) := rfl
+
 end AddMonoidHom
 
 namespace AddEquiv
@@ -1340,6 +1375,9 @@ theorem mapMatrix_id : LinearMap.id.mapMatrix = (LinearMap.id : Matrix m n α �
 theorem mapMatrix_comp (f : β →ₗ[R] γ) (g : α →ₗ[R] β) :
     f.mapMatrix.comp g.mapMatrix = ((f.comp g).mapMatrix : Matrix m n α →ₗ[R] _) :=
   rfl
+
+@[simp] lemma apply₂_comp_mapMatrix (f : α →ₗ[R] β) (i : m) (j : n) :
+    apply₂ R _ i j ∘ₗ f.mapMatrix = f ∘ₗ apply₂ R _ i j := rfl
 
 end LinearMap
 

--- a/Mathlib/Data/Matrix/Basic.lean
+++ b/Mathlib/Data/Matrix/Basic.lean
@@ -1214,14 +1214,32 @@ end Matrix
 
 section apply₂
 
+namespace AddHom
+
+variable [Add α]
+
+variable (R α) in
+/-- Extracting entries from a matrix as an additive homomorphism.  -/
+@[simps]
+def apply₂ (i : m) (j : n) : AddHom (Matrix m n α) α where
+  toFun M := M i j
+  map_add' _ _ := rfl
+
+-- The type ascription on the RHS is necessary for unification to succeed on the composition.
+lemma apply₂_eq_proj {i : m} {j : n} :
+    apply₂ α i j = (Pi.evalAddHom _ j).comp (Pi.evalAddHom _ i : AddHom _ (n → α)) :=
+  rfl
+
+end AddHom
+
 namespace AddMonoidHom
 
 variable [AddZeroClass α]
 
 variable (R α) in
 /--
-Extracting entries from a matrix as a monoid homomorphism. Note this cannot be upgraded to a ring
-homomorphism, as it does not respect multiplication.
+Extracting entries from a matrix as an additive monoid homomorphism. Note this cannot be upgraded to
+a ring homomorphism, as it does not respect multiplication.
 -/
 @[simps]
 def apply₂ (i : m) (j : n) : Matrix m n α →+ α where
@@ -1229,13 +1247,16 @@ def apply₂ (i : m) (j : n) : Matrix m n α →+ α where
   map_add' _ _ := rfl
   map_zero' := rfl
 
+-- The type ascription on the RHS is necessary for unification to succeed on the composition.
 lemma apply₂_eq_proj {i : m} {j : n} :
     apply₂ α i j = (Pi.evalAddMonoidHom _ j).comp (Pi.evalAddMonoidHom _ i : _ →+ (n → α)) :=
   rfl
 
-lemma proj_comp_diagLinearMap (i : m) :
+@[simp] lemma proj_comp_diagLinearMap (i : m) :
     (Pi.evalAddMonoidHom _ i).comp (diagAddMonoidHom m α) = apply₂ α i i := by
   simp [AddMonoidHom.ext_iff]
+
+@[simp] lemma apply₂_toAddHom {i : m} {j : n} : (apply₂ α i j).toAddHom = AddHom.apply₂ α i j := rfl
 
 end AddMonoidHom
 
@@ -1255,19 +1276,24 @@ def apply₂ (i : m) (j : n) :
   map_add' _ _ := rfl
   map_smul' _ _ := rfl
 
--- The type ascription on the RHS is necessary for unification to succeed on the linear map.
+-- The type ascription on the RHS is necessary for unification to succeed on the linear composition.
 lemma apply₂_eq_proj {i : m} {j : n} :
     apply₂ R α i j = proj j ∘ₗ (proj i : _ →ₗ[_] (n → α)) :=
   rfl
 
-lemma proj_comp_diagLinearMap (i : m) :
+@[simp] lemma proj_comp_diagLinearMap (i : m) :
     proj i ∘ₗ diagLinearMap m R α = apply₂ R α i i := by
   simp [LinearMap.ext_iff]
+
+@[simp] lemma apply₂_toAddMonoidHom {i : m} {j : n} :
+    (apply₂ R α i j).toAddMonoidHom = AddMonoidHom.apply₂ α i j := rfl
+
+@[simp] lemma apply₂_toAddHom {i : m} {j : n} :
+    (apply₂ R α i j).toAddHom = AddHom.apply₂ α i j := rfl
 
 end LinearMap
 
 end apply₂
-
 
 /-!
 ### Bundled versions of `Matrix.map`
@@ -1352,6 +1378,10 @@ theorem mapMatrix_trans (f : α ≃+ β) (g : β ≃+ γ) :
     f.mapMatrix.trans g.mapMatrix = ((f.trans g).mapMatrix : Matrix m n α ≃+ _) :=
   rfl
 
+@[simp] lemma apply₂_comp_mapMatrix (f : α ≃+ β) (i : m) (j : n) :
+    (AddHom.apply₂ β i j).comp (AddHomClass.toAddHom f.mapMatrix) =
+      (f : AddHom α β).comp (AddHom.apply₂ _ i j) := rfl
+
 end AddEquiv
 
 namespace LinearMap
@@ -1408,6 +1438,14 @@ theorem mapMatrix_symm (f : α ≃ₗ[R] β) :
 theorem mapMatrix_trans (f : α ≃ₗ[R] β) (g : β ≃ₗ[R] γ) :
     f.mapMatrix.trans g.mapMatrix = ((f.trans g).mapMatrix : Matrix m n α ≃ₗ[R] _) :=
   rfl
+
+@[simp] lemma mapMatrix_toLinearMap (f : α ≃ₗ[R] β) :
+    (f.mapMatrix : _ ≃ₗ[R] Matrix m n β).toLinearMap = f.toLinearMap.mapMatrix := by
+  rfl
+
+@[simp] lemma apply₂_comp_mapMatrix (f : α ≃ₗ[R] β) (i : m) (j : n) :
+    LinearMap.apply₂ R _ i j ∘ₗ f.mapMatrix.toLinearMap =
+      f.toLinearMap ∘ₗ LinearMap.apply₂ R _ i j := rfl
 
 end LinearEquiv
 

--- a/Mathlib/Data/Matrix/Basic.lean
+++ b/Mathlib/Data/Matrix/Basic.lean
@@ -1222,7 +1222,7 @@ def elemAddHom (i : m) (j : n) : AddHom (Matrix m n α) α where
   map_add' _ _ := rfl
 
 -- The type ascription on the RHS is necessary for unification to succeed on the composition.
-lemma elemAddHom_eq_proj {i : m} {j : n} :
+lemma elemAddHom_eq_comp {i : m} {j : n} :
     elemAddHom α i j = (Pi.evalAddHom _ j).comp (Pi.evalAddHom _ i : AddHom _ (n → α)) :=
   rfl
 
@@ -1244,7 +1244,7 @@ def elemAddMonoidHom (i : m) (j : n) : Matrix m n α →+ α where
   map_zero' := rfl
 
 -- The type ascription on the RHS is necessary for unification to succeed on the composition.
-lemma elemAddMonoidHom_eq {i : m} {j : n} :
+lemma elemAddMonoidHom_eq_comp {i : m} {j : n} :
     elemAddMonoidHom α i j =
       (Pi.evalAddMonoidHom _ j).comp (Pi.evalAddMonoidHom _ i : _ →+ (n → α)) :=
   rfl
@@ -1254,7 +1254,7 @@ lemma elemAddMonoidHom_eq {i : m} {j : n} :
   simp [AddMonoidHom.ext_iff]
 
 @[simp] lemma elemAddMonoidHom_toAddHom {i : m} {j : n} :
-  (elemAddMonoidHom α i j).toAddHom = Matrix.elemAddHom α i j := rfl
+  (elemAddMonoidHom α i j : AddHom _ _) = Matrix.elemAddHom α i j := rfl
 
 end AddMonoidHom
 
@@ -1284,10 +1284,10 @@ lemma elemLinearMap_eq {i : m} {j : n} :
   simp [LinearMap.ext_iff]
 
 @[simp] lemma elemLinearMap_toAddMonoidHom {i : m} {j : n} :
-    (elemLinearMap R α i j).toAddMonoidHom = elemAddMonoidHom α i j := rfl
+    (elemLinearMap R α i j : _ →+ _) = elemAddMonoidHom α i j := rfl
 
 @[simp] lemma elemLinearMap_toAddHom {i : m} {j : n} :
-    (elemLinearMap R α i j).toAddHom = elemAddHom α i j := rfl
+    (elemLinearMap R α i j : AddHom _ _) = elemAddHom α i j := rfl
 
 end LinearMap
 

--- a/Mathlib/Data/Matrix/Basic.lean
+++ b/Mathlib/Data/Matrix/Basic.lean
@@ -14,6 +14,7 @@ import Mathlib.Algebra.Star.BigOperators
 import Mathlib.Algebra.Star.Module
 import Mathlib.Algebra.Star.Pi
 import Mathlib.Data.Fintype.BigOperators
+import Mathlib.LinearAlgebra.Pi
 
 /-!
 # Matrices
@@ -1208,6 +1209,31 @@ def diagonalAlgHom : (n → α) →ₐ[R] Matrix n n α :=
     commutes' := fun r => (algebraMap_eq_diagonal r).symm }
 
 end Algebra
+
+section apply₂
+
+open LinearMap
+
+variable [Semiring R] [AddCommMonoid α] [Module R α]
+
+variable (R α) in
+/-- Extracting entries from a matrix as a linear map. -/
+@[simps]
+def apply₂ [Semiring R] [AddCommMonoid α] [Module R α] (i : m) (j : n) : Matrix m n α →ₗ[R] α where
+  toFun M := M i j
+  map_add' _ _ := rfl
+  map_smul' _ _ := rfl
+
+-- The type ascription on the RHS is necessary for unification to succeed on the linear map.
+lemma apply₂_eq_proj {i : m} {j : n} :
+    apply₂ R α i j = proj j ∘ₗ (proj i : _ →ₗ[_] (n → α)) :=
+  rfl
+
+lemma diag_comp_apply (i : m) :
+    proj i ∘ₗ Matrix.diagLinearMap m R α = apply₂ R α i i := by
+  simp [LinearMap.ext_iff]
+
+end apply₂
 
 end Matrix
 

--- a/Mathlib/Data/Matrix/Basic.lean
+++ b/Mathlib/Data/Matrix/Basic.lean
@@ -1210,29 +1210,27 @@ def diagonalAlgHom : (n → α) →ₐ[R] Matrix n n α :=
 
 end Algebra
 
-end Matrix
-
 section apply₂
 
-namespace AddHom
+section AddHom
 
 variable [Add α]
 
 variable (R α) in
 /-- Extracting entries from a matrix as an additive homomorphism.  -/
 @[simps]
-def apply₂ (i : m) (j : n) : AddHom (Matrix m n α) α where
+def elemAddHom (i : m) (j : n) : AddHom (Matrix m n α) α where
   toFun M := M i j
   map_add' _ _ := rfl
 
 -- The type ascription on the RHS is necessary for unification to succeed on the composition.
-lemma apply₂_eq_proj {i : m} {j : n} :
-    apply₂ α i j = (Pi.evalAddHom _ j).comp (Pi.evalAddHom _ i : AddHom _ (n → α)) :=
+lemma elemAddHom_eq_proj {i : m} {j : n} :
+    elemAddHom α i j = (Pi.evalAddHom _ j).comp (Pi.evalAddHom _ i : AddHom _ (n → α)) :=
   rfl
 
 end AddHom
 
-namespace AddMonoidHom
+section AddMonoidHom
 
 variable [AddZeroClass α]
 
@@ -1242,25 +1240,27 @@ Extracting entries from a matrix as an additive monoid homomorphism. Note this c
 a ring homomorphism, as it does not respect multiplication.
 -/
 @[simps]
-def apply₂ (i : m) (j : n) : Matrix m n α →+ α where
+def elemAddMonoidHom (i : m) (j : n) : Matrix m n α →+ α where
   toFun M := M i j
   map_add' _ _ := rfl
   map_zero' := rfl
 
 -- The type ascription on the RHS is necessary for unification to succeed on the composition.
-lemma apply₂_eq_proj {i : m} {j : n} :
-    apply₂ α i j = (Pi.evalAddMonoidHom _ j).comp (Pi.evalAddMonoidHom _ i : _ →+ (n → α)) :=
+lemma elemAddMonoidHom_eq {i : m} {j : n} :
+    elemAddMonoidHom α i j =
+      (Pi.evalAddMonoidHom _ j).comp (Pi.evalAddMonoidHom _ i : _ →+ (n → α)) :=
   rfl
 
-@[simp] lemma proj_comp_diagLinearMap (i : m) :
-    (Pi.evalAddMonoidHom _ i).comp (diagAddMonoidHom m α) = apply₂ α i i := by
+@[simp] lemma evalAddMonoidHom_comp_diagAddMonoidHom (i : m) :
+    (Pi.evalAddMonoidHom _ i).comp (diagAddMonoidHom m α) = elemAddMonoidHom α i i := by
   simp [AddMonoidHom.ext_iff]
 
-@[simp] lemma apply₂_toAddHom {i : m} {j : n} : (apply₂ α i j).toAddHom = AddHom.apply₂ α i j := rfl
+@[simp] lemma elemAddMonoidHom_toAddHom {i : m} {j : n} :
+  (elemAddMonoidHom α i j).toAddHom = Matrix.elemAddHom α i j := rfl
 
 end AddMonoidHom
 
-namespace LinearMap
+section LinearMap
 
 variable [Semiring R] [AddCommMonoid α] [Module R α]
 
@@ -1270,30 +1270,32 @@ Extracting entries from a matrix as a linear map. Note this cannot be upgraded t
 homomorphism, as it does not respect multiplication.
 -/
 @[simps]
-def apply₂ (i : m) (j : n) :
+def elemLinearMap (i : m) (j : n) :
     Matrix m n α →ₗ[R] α where
   toFun M := M i j
   map_add' _ _ := rfl
   map_smul' _ _ := rfl
 
 -- The type ascription on the RHS is necessary for unification to succeed on the linear composition.
-lemma apply₂_eq_proj {i : m} {j : n} :
-    apply₂ R α i j = proj j ∘ₗ (proj i : _ →ₗ[_] (n → α)) :=
+lemma elemLinearMap_eq {i : m} {j : n} :
+    elemLinearMap R α i j = LinearMap.proj j ∘ₗ (LinearMap.proj i : _ →ₗ[_] (n → α)) :=
   rfl
 
 @[simp] lemma proj_comp_diagLinearMap (i : m) :
-    proj i ∘ₗ diagLinearMap m R α = apply₂ R α i i := by
+    LinearMap.proj i ∘ₗ diagLinearMap m R α = elemLinearMap R α i i := by
   simp [LinearMap.ext_iff]
 
-@[simp] lemma apply₂_toAddMonoidHom {i : m} {j : n} :
-    (apply₂ R α i j).toAddMonoidHom = AddMonoidHom.apply₂ α i j := rfl
+@[simp] lemma elemLinearMap_toAddMonoidHom {i : m} {j : n} :
+    (elemLinearMap R α i j).toAddMonoidHom = elemAddMonoidHom α i j := rfl
 
-@[simp] lemma apply₂_toAddHom {i : m} {j : n} :
-    (apply₂ R α i j).toAddHom = AddHom.apply₂ α i j := rfl
+@[simp] lemma elemLinearMap_toAddHom {i : m} {j : n} :
+    (elemLinearMap R α i j).toAddHom = elemAddHom α i j := rfl
 
 end LinearMap
 
 end apply₂
+
+end Matrix
 
 /-!
 ### Bundled versions of `Matrix.map`
@@ -1347,8 +1349,8 @@ theorem mapMatrix_comp (f : β →+ γ) (g : α →+ β) :
     f.mapMatrix.comp g.mapMatrix = ((f.comp g).mapMatrix : Matrix m n α →+ _) :=
   rfl
 
-@[simp] lemma apply₂_comp_mapMatrix (f : α →+ β) (i : m) (j : n) :
-    (apply₂ β i j).comp f.mapMatrix = f.comp (apply₂ α i j) := rfl
+@[simp] lemma elemAddMonoidHom_comp_mapMatrix (f : α →+ β) (i : m) (j : n) :
+    (elemAddMonoidHom β i j).comp f.mapMatrix = f.comp (elemAddMonoidHom α i j) := rfl
 
 end AddMonoidHom
 
@@ -1379,8 +1381,8 @@ theorem mapMatrix_trans (f : α ≃+ β) (g : β ≃+ γ) :
   rfl
 
 @[simp] lemma apply₂_comp_mapMatrix (f : α ≃+ β) (i : m) (j : n) :
-    (AddHom.apply₂ β i j).comp (AddHomClass.toAddHom f.mapMatrix) =
-      (f : AddHom α β).comp (AddHom.apply₂ _ i j) := rfl
+    (elemAddHom β i j).comp (AddHomClass.toAddHom f.mapMatrix) =
+      (f : AddHom α β).comp (elemAddHom _ i j) := rfl
 
 end AddEquiv
 
@@ -1406,8 +1408,8 @@ theorem mapMatrix_comp (f : β →ₗ[R] γ) (g : α →ₗ[R] β) :
     f.mapMatrix.comp g.mapMatrix = ((f.comp g).mapMatrix : Matrix m n α →ₗ[R] _) :=
   rfl
 
-@[simp] lemma apply₂_comp_mapMatrix (f : α →ₗ[R] β) (i : m) (j : n) :
-    apply₂ R _ i j ∘ₗ f.mapMatrix = f ∘ₗ apply₂ R _ i j := rfl
+@[simp] lemma elemLinearMap_comp_mapMatrix (f : α →ₗ[R] β) (i : m) (j : n) :
+    elemLinearMap R _ i j ∘ₗ f.mapMatrix = f ∘ₗ elemLinearMap R _ i j := rfl
 
 end LinearMap
 
@@ -1444,8 +1446,8 @@ theorem mapMatrix_trans (f : α ≃ₗ[R] β) (g : β ≃ₗ[R] γ) :
   rfl
 
 @[simp] lemma apply₂_comp_mapMatrix (f : α ≃ₗ[R] β) (i : m) (j : n) :
-    LinearMap.apply₂ R _ i j ∘ₗ f.mapMatrix.toLinearMap =
-      f.toLinearMap ∘ₗ LinearMap.apply₂ R _ i j := rfl
+    elemLinearMap R _ i j ∘ₗ f.mapMatrix.toLinearMap =
+      f.toLinearMap ∘ₗ elemLinearMap R _ i j := rfl
 
 end LinearEquiv
 

--- a/Mathlib/Data/Matrix/Basic.lean
+++ b/Mathlib/Data/Matrix/Basic.lean
@@ -1217,13 +1217,13 @@ variable [Add α]
 variable (R α) in
 /-- Extracting entries from a matrix as an additive homomorphism.  -/
 @[simps]
-def elemAddHom (i : m) (j : n) : AddHom (Matrix m n α) α where
+def entryAddHom (i : m) (j : n) : AddHom (Matrix m n α) α where
   toFun M := M i j
   map_add' _ _ := rfl
 
 -- The type ascription on the RHS is necessary for unification to succeed on the composition.
-lemma elemAddHom_eq_comp {i : m} {j : n} :
-    elemAddHom α i j = (Pi.evalAddHom _ j).comp (Pi.evalAddHom _ i : AddHom _ (n → α)) :=
+lemma entryAddHom_eq_comp {i : m} {j : n} :
+    entryAddHom α i j = (Pi.evalAddHom _ j).comp (Pi.evalAddHom _ i : AddHom _ (n → α)) :=
   rfl
 
 end AddHom
@@ -1238,23 +1238,23 @@ Extracting entries from a matrix as an additive monoid homomorphism. Note this c
 a ring homomorphism, as it does not respect multiplication.
 -/
 @[simps]
-def elemAddMonoidHom (i : m) (j : n) : Matrix m n α →+ α where
+def entryAddMonoidHom (i : m) (j : n) : Matrix m n α →+ α where
   toFun M := M i j
   map_add' _ _ := rfl
   map_zero' := rfl
 
 -- The type ascription on the RHS is necessary for unification to succeed on the composition.
-lemma elemAddMonoidHom_eq_comp {i : m} {j : n} :
-    elemAddMonoidHom α i j =
+lemma entryAddMonoidHom_eq_comp {i : m} {j : n} :
+    entryAddMonoidHom α i j =
       (Pi.evalAddMonoidHom _ j).comp (Pi.evalAddMonoidHom _ i : _ →+ (n → α)) :=
   rfl
 
 @[simp] lemma evalAddMonoidHom_comp_diagAddMonoidHom (i : m) :
-    (Pi.evalAddMonoidHom _ i).comp (diagAddMonoidHom m α) = elemAddMonoidHom α i i := by
+    (Pi.evalAddMonoidHom _ i).comp (diagAddMonoidHom m α) = entryAddMonoidHom α i i := by
   simp [AddMonoidHom.ext_iff]
 
-@[simp] lemma elemAddMonoidHom_toAddHom {i : m} {j : n} :
-  (elemAddMonoidHom α i j : AddHom _ _) = Matrix.elemAddHom α i j := rfl
+@[simp] lemma entryAddMonoidHom_toAddHom {i : m} {j : n} :
+  (entryAddMonoidHom α i j : AddHom _ _) = Matrix.entryAddHom α i j := rfl
 
 end AddMonoidHom
 
@@ -1268,26 +1268,26 @@ Extracting entries from a matrix as a linear map. Note this cannot be upgraded t
 homomorphism, as it does not respect multiplication.
 -/
 @[simps]
-def elemLinearMap (i : m) (j : n) :
+def entryLinearMap (i : m) (j : n) :
     Matrix m n α →ₗ[R] α where
   toFun M := M i j
   map_add' _ _ := rfl
   map_smul' _ _ := rfl
 
 -- The type ascription on the RHS is necessary for unification to succeed on the linear composition.
-lemma elemLinearMap_eq {i : m} {j : n} :
-    elemLinearMap R α i j = LinearMap.proj j ∘ₗ (LinearMap.proj i : _ →ₗ[_] (n → α)) :=
+lemma entryLinearMap_eq {i : m} {j : n} :
+    entryLinearMap R α i j = LinearMap.proj j ∘ₗ (LinearMap.proj i : _ →ₗ[_] (n → α)) :=
   rfl
 
 @[simp] lemma proj_comp_diagLinearMap (i : m) :
-    LinearMap.proj i ∘ₗ diagLinearMap m R α = elemLinearMap R α i i := by
+    LinearMap.proj i ∘ₗ diagLinearMap m R α = entryLinearMap R α i i := by
   simp [LinearMap.ext_iff]
 
-@[simp] lemma elemLinearMap_toAddMonoidHom {i : m} {j : n} :
-    (elemLinearMap R α i j : _ →+ _) = elemAddMonoidHom α i j := rfl
+@[simp] lemma entryLinearMap_toAddMonoidHom {i : m} {j : n} :
+    (entryLinearMap R α i j : _ →+ _) = entryAddMonoidHom α i j := rfl
 
-@[simp] lemma elemLinearMap_toAddHom {i : m} {j : n} :
-    (elemLinearMap R α i j : AddHom _ _) = elemAddHom α i j := rfl
+@[simp] lemma entryLinearMap_toAddHom {i : m} {j : n} :
+    (entryLinearMap R α i j : AddHom _ _) = entryAddHom α i j := rfl
 
 end LinearMap
 
@@ -1345,8 +1345,8 @@ theorem mapMatrix_comp (f : β →+ γ) (g : α →+ β) :
     f.mapMatrix.comp g.mapMatrix = ((f.comp g).mapMatrix : Matrix m n α →+ _) :=
   rfl
 
-@[simp] lemma elemAddMonoidHom_comp_mapMatrix (f : α →+ β) (i : m) (j : n) :
-    (elemAddMonoidHom β i j).comp f.mapMatrix = f.comp (elemAddMonoidHom α i j) := rfl
+@[simp] lemma entryAddMonoidHom_comp_mapMatrix (f : α →+ β) (i : m) (j : n) :
+    (entryAddMonoidHom β i j).comp f.mapMatrix = f.comp (entryAddMonoidHom α i j) := rfl
 
 end AddMonoidHom
 
@@ -1376,9 +1376,9 @@ theorem mapMatrix_trans (f : α ≃+ β) (g : β ≃+ γ) :
     f.mapMatrix.trans g.mapMatrix = ((f.trans g).mapMatrix : Matrix m n α ≃+ _) :=
   rfl
 
-@[simp] lemma elemAddHom_comp_mapMatrix (f : α ≃+ β) (i : m) (j : n) :
-    (elemAddHom β i j).comp (AddHomClass.toAddHom f.mapMatrix) =
-      (f : AddHom α β).comp (elemAddHom _ i j) := rfl
+@[simp] lemma entryAddHom_comp_mapMatrix (f : α ≃+ β) (i : m) (j : n) :
+    (entryAddHom β i j).comp (AddHomClass.toAddHom f.mapMatrix) =
+      (f : AddHom α β).comp (entryAddHom _ i j) := rfl
 
 end AddEquiv
 
@@ -1404,8 +1404,8 @@ theorem mapMatrix_comp (f : β →ₗ[R] γ) (g : α →ₗ[R] β) :
     f.mapMatrix.comp g.mapMatrix = ((f.comp g).mapMatrix : Matrix m n α →ₗ[R] _) :=
   rfl
 
-@[simp] lemma elemLinearMap_comp_mapMatrix (f : α →ₗ[R] β) (i : m) (j : n) :
-    elemLinearMap R _ i j ∘ₗ f.mapMatrix = f ∘ₗ elemLinearMap R _ i j := rfl
+@[simp] lemma entryLinearMap_comp_mapMatrix (f : α →ₗ[R] β) (i : m) (j : n) :
+    entryLinearMap R _ i j ∘ₗ f.mapMatrix = f ∘ₗ entryLinearMap R _ i j := rfl
 
 end LinearMap
 
@@ -1441,9 +1441,10 @@ theorem mapMatrix_trans (f : α ≃ₗ[R] β) (g : β ≃ₗ[R] γ) :
     (f.mapMatrix : _ ≃ₗ[R] Matrix m n β).toLinearMap = f.toLinearMap.mapMatrix := by
   rfl
 
-@[simp] lemma elemLinearMap_comp_mapMatrix (f : α ≃ₗ[R] β) (i : m) (j : n) :
-    elemLinearMap R _ i j ∘ₗ f.mapMatrix.toLinearMap =
-      f.toLinearMap ∘ₗ elemLinearMap R _ i j := rfl
+@[simp] lemma entryLinearMap_comp_mapMatrix (f : α ≃ₗ[R] β) (i : m) (j : n) :
+    entryLinearMap R _ i j ∘ₗ f.mapMatrix.toLinearMap =
+      f.toLinearMap ∘ₗ entryLinearMap R _ i j := by
+  simp only [mapMatrix_toLinearMap, LinearMap.entryLinearMap_comp_mapMatrix]
 
 end LinearEquiv
 

--- a/Mathlib/Data/Matrix/Basic.lean
+++ b/Mathlib/Data/Matrix/Basic.lean
@@ -1376,7 +1376,7 @@ theorem mapMatrix_trans (f : α ≃+ β) (g : β ≃+ γ) :
     f.mapMatrix.trans g.mapMatrix = ((f.trans g).mapMatrix : Matrix m n α ≃+ _) :=
   rfl
 
-@[simp] lemma apply₂_comp_mapMatrix (f : α ≃+ β) (i : m) (j : n) :
+@[simp] lemma elemAddHom_comp_mapMatrix (f : α ≃+ β) (i : m) (j : n) :
     (elemAddHom β i j).comp (AddHomClass.toAddHom f.mapMatrix) =
       (f : AddHom α β).comp (elemAddHom _ i j) := rfl
 
@@ -1441,7 +1441,7 @@ theorem mapMatrix_trans (f : α ≃ₗ[R] β) (g : β ≃ₗ[R] γ) :
     (f.mapMatrix : _ ≃ₗ[R] Matrix m n β).toLinearMap = f.toLinearMap.mapMatrix := by
   rfl
 
-@[simp] lemma apply₂_comp_mapMatrix (f : α ≃ₗ[R] β) (i : m) (j : n) :
+@[simp] lemma elemLinearMap_comp_mapMatrix (f : α ≃ₗ[R] β) (i : m) (j : n) :
     elemLinearMap R _ i j ∘ₗ f.mapMatrix.toLinearMap =
       f.toLinearMap ∘ₗ elemLinearMap R _ i j := rfl
 

--- a/Mathlib/Data/Matrix/Basic.lean
+++ b/Mathlib/Data/Matrix/Basic.lean
@@ -335,12 +335,14 @@ instance subsingleton_of_empty_right [IsEmpty n] : Subsingleton (Matrix m n α) 
     ext i j
     exact isEmptyElim j⟩
 
+/-- This is `Matrix.of` bundled as an additive equivalence. -/
 def ofAddEquiv [Add α] : (m → n → α) ≃+ Matrix m n α where
   __ := of
   map_add' _ _ := rfl
 
 @[simp] lemma coe_ofAddEquiv [Add α] : (ofAddEquiv : (m → n → α) → Matrix m n α) = of := rfl
 
+/-- This is `Matrix.of` bundled as a linear equivalence. -/
 def ofLinearEquiv [Semiring R] [AddCommMonoid α] [Module R α] : (m → n → α) ≃ₗ[R] Matrix m n α where
   __ := ofAddEquiv
   map_smul' _ _ := rfl

--- a/Mathlib/Data/Matrix/Basic.lean
+++ b/Mathlib/Data/Matrix/Basic.lean
@@ -340,9 +340,10 @@ def ofAddEquiv [Add α] : (m → n → α) ≃+ Matrix m n α where
   __ := of
   map_add' _ _ := rfl
 
-@[simp] lemma coe_ofAddEquiv [Add α] : (ofAddEquiv : (m → n → α) → Matrix m n α) = of := rfl
+@[simp] lemma coe_ofAddEquiv [Add α] :
+    ⇑(ofAddEquiv : (m → n → α) ≃+ Matrix m n α) = of := rfl
 @[simp] lemma coe_ofAddEquiv_symm [Add α] :
-    (ofAddEquiv : (m → n → α) → Matrix m n α).symm = of.symm := rfl
+    ⇑(ofAddEquiv.symm : Matrix m n α ≃+ (m → n → α)) = of.symm := rfl
 
 /-- This is `Matrix.of` bundled as a linear equivalence. -/
 def ofLinearEquiv [Semiring R] [AddCommMonoid α] [Module R α] : (m → n → α) ≃ₗ[R] Matrix m n α where
@@ -350,9 +351,9 @@ def ofLinearEquiv [Semiring R] [AddCommMonoid α] [Module R α] : (m → n → �
   map_smul' _ _ := rfl
 
 @[simp] lemma coe_ofLinearEquiv [Semiring R] [AddCommMonoid α] [Module R α] :
-    (ofLinearEquiv (R := R) : (m → n → α) → Matrix m n α) = of := rfl
+    ⇑(ofLinearEquiv : (m → n → α) ≃ₗ[R] Matrix m n α) = of := rfl
 @[simp] lemma coe_ofLinearEquiv_symm [Semiring R] [AddCommMonoid α] [Module R α] :
-    (ofLinearEquiv (R := R) : (m → n → α) → Matrix m n α).symm = of.symm := rfl
+    ⇑(ofLinearEquiv.symm : Matrix m n α ≃ₗ[R] (m → n → α)) = of.symm := rfl
 
 end Matrix
 

--- a/Mathlib/Data/Matrix/Basic.lean
+++ b/Mathlib/Data/Matrix/Basic.lean
@@ -341,6 +341,8 @@ def ofAddEquiv [Add α] : (m → n → α) ≃+ Matrix m n α where
   map_add' _ _ := rfl
 
 @[simp] lemma coe_ofAddEquiv [Add α] : (ofAddEquiv : (m → n → α) → Matrix m n α) = of := rfl
+@[simp] lemma coe_ofAddEquiv_symm [Add α] :
+    (ofAddEquiv : (m → n → α) → Matrix m n α).symm = of.symm := rfl
 
 /-- This is `Matrix.of` bundled as a linear equivalence. -/
 def ofLinearEquiv [Semiring R] [AddCommMonoid α] [Module R α] : (m → n → α) ≃ₗ[R] Matrix m n α where
@@ -349,6 +351,8 @@ def ofLinearEquiv [Semiring R] [AddCommMonoid α] [Module R α] : (m → n → �
 
 @[simp] lemma coe_ofLinearEquiv [Semiring R] [AddCommMonoid α] [Module R α] :
     (ofLinearEquiv (R := R) : (m → n → α) → Matrix m n α) = of := rfl
+@[simp] lemma coe_ofLinearEquiv_symm [Semiring R] [AddCommMonoid α] [Module R α] :
+    (ofLinearEquiv (R := R) : (m → n → α) → Matrix m n α).symm = of.symm := rfl
 
 end Matrix
 


### PR DESCRIPTION
Strictly speaking, something like this was available as `LinearMap.proj`, but actually using it in practice is awkward as unification struggles (see line 1227 in this PR). 

I'm happy to take name suggestions, as well as ideas for other generalities.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
