### PR TITLE
[Merged by Bors] - feat(CategoryTheory/Shift): shifted morphisms in the opposite category

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -1844,6 +1844,7 @@ import Mathlib.CategoryTheory.Shift.Pullback
 import Mathlib.CategoryTheory.Shift.Quotient
 import Mathlib.CategoryTheory.Shift.ShiftSequence
 import Mathlib.CategoryTheory.Shift.ShiftedHom
+import Mathlib.CategoryTheory.Shift.ShiftedHomOpposite
 import Mathlib.CategoryTheory.Shift.SingleFunctors
 import Mathlib.CategoryTheory.Sigma.Basic
 import Mathlib.CategoryTheory.Simple

--- a/Mathlib/CategoryTheory/Shift/Basic.lean
+++ b/Mathlib/CategoryTheory/Shift/Basic.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2020 Kim Morrison. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Kim Morrison, Johan Commelin, Andrew Yang
+Authors: Kim Morrison, Johan Commelin, Andrew Yang, Joël Riou
 -/
 import Mathlib.Algebra.Group.Basic
 import Mathlib.CategoryTheory.Limits.Preserves.Shapes.Zero
@@ -484,6 +484,69 @@ theorem shift_shiftFunctorCompIsoId_neg_add_cancel_inv_app (n : A) (X : C) :
     ((shiftFunctorCompIsoId C (-n) n (neg_add_cancel n)).inv.app X)⟦-n⟧' =
     (shiftFunctorCompIsoId C n (-n) (add_neg_cancel n)).inv.app (X⟦-n⟧) := by
   apply shift_shiftFunctorCompIsoId_inv_app
+
+end
+
+section
+
+variable (A)
+
+lemma shiftFunctorCompIsoId_zero_zero_hom_app (X : C) :
+    (shiftFunctorCompIsoId C 0 0 (add_zero 0)).hom.app X =
+      ((shiftFunctorZero C A).hom.app X)⟦0⟧' ≫ (shiftFunctorZero C A).hom.app X := by
+  simp [shiftFunctorCompIsoId, shiftFunctorAdd'_zero_add_inv_app]
+
+lemma shiftFunctorCompIsoId_zero_zero_inv_app (X : C) :
+    (shiftFunctorCompIsoId C 0 0 (add_zero 0)).inv.app X =
+      (shiftFunctorZero C A).inv.app X ≫ ((shiftFunctorZero C A).inv.app X)⟦0⟧' := by
+  simp [shiftFunctorCompIsoId, shiftFunctorAdd'_zero_add_hom_app]
+
+end
+
+section
+
+variable (m n p m' n' p' : A) (hm : m' + m = 0) (hn : n' + n = 0) (hp : p' + p = 0)
+  (h : m + n = p)
+
+lemma shiftFunctorCompIsoId_add'_inv_app :
+    (shiftFunctorCompIsoId C p' p hp).inv.app X =
+      (shiftFunctorCompIsoId C n' n hn).inv.app X ≫
+      (shiftFunctorCompIsoId C m' m hm).inv.app (X⟦n'⟧)⟦n⟧' ≫
+      (shiftFunctorAdd' C m n p h).inv.app (X⟦n'⟧⟦m'⟧) ≫
+      ((shiftFunctorAdd' C n' m' p'
+        (by rw [← add_left_inj p, hp, ← h, add_assoc,
+          ← add_assoc m', hm, zero_add, hn])).inv.app X)⟦p⟧' := by
+  dsimp [shiftFunctorCompIsoId]
+  simp only [Functor.map_comp, Category.assoc]
+  congr 1
+  erw [← NatTrans.naturality]
+  dsimp
+  rw [← cancel_mono ((shiftFunctorAdd' C p' p 0 hp).inv.app X), Iso.hom_inv_id_app,
+    Category.assoc, Category.assoc, Category.assoc, Category.assoc,
+    ← shiftFunctorAdd'_assoc_inv_app p' m n n' p 0
+      (by rw [← add_left_inj n, hn, add_assoc, h, hp]) h (by rw [add_assoc, h, hp]),
+    ← Functor.map_comp_assoc, ← Functor.map_comp_assoc, ← Functor.map_comp_assoc,
+    Category.assoc, Category.assoc,
+    shiftFunctorAdd'_assoc_inv_app n' m' m p' 0 n' _ _
+      (by rw [add_assoc, hm, add_zero]), Iso.hom_inv_id_app_assoc,
+    ← shiftFunctorAdd'_add_zero_hom_app, Iso.hom_inv_id_app,
+    Functor.map_id, Category.id_comp, Iso.hom_inv_id_app]
+
+lemma shiftFunctorCompIsoId_add'_hom_app :
+    (shiftFunctorCompIsoId C p' p hp).hom.app X =
+      ((shiftFunctorAdd' C n' m' p'
+          (by rw [← add_left_inj p, hp, ← h, add_assoc,
+            ← add_assoc m', hm, zero_add, hn])).hom.app X)⟦p⟧' ≫
+      (shiftFunctorAdd' C m n p h).hom.app (X⟦n'⟧⟦m'⟧) ≫
+      (shiftFunctorCompIsoId C m' m hm).hom.app (X⟦n'⟧)⟦n⟧' ≫
+      (shiftFunctorCompIsoId C n' n hn).hom.app X := by
+  rw [← cancel_mono ((shiftFunctorCompIsoId C p' p hp).inv.app X), Iso.hom_inv_id_app,
+    shiftFunctorCompIsoId_add'_inv_app m n p m' n' p' hm hn hp h,
+    Category.assoc, Category.assoc, Category.assoc, Iso.hom_inv_id_app_assoc,
+    ← Functor.map_comp_assoc, Iso.hom_inv_id_app]
+  dsimp
+  rw [Functor.map_id, Category.id_comp, Iso.hom_inv_id_app_assoc,
+    ← Functor.map_comp, Iso.hom_inv_id_app, Functor.map_id]
 
 end
 

--- a/Mathlib/CategoryTheory/Shift/ShiftedHomOpposite.lean
+++ b/Mathlib/CategoryTheory/Shift/ShiftedHomOpposite.lean
@@ -1,0 +1,154 @@
+/-
+Copyright (c) 2024 Joël Riou. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Joël Riou
+-/
+
+import Mathlib.CategoryTheory.Triangulated.Opposite
+import Mathlib.CategoryTheory.Shift.ShiftedHom
+
+/-! Shifted morphisms in the opposite category
+
+If `C` is a category equipped with a shift by `ℤ`, `X` and `Y` are objects
+of `C`, and `n : ℤ`, we define a bijection
+`ShiftedHom.opEquiv : ShiftedHom X Y n ≃ ShiftedHom (Opposite.op Y) (Opposite.op X) n`.
+We also introduce `ShiftedHom.opEquiv'` which produces a bijection
+`ShiftedHom X Y a' ≃ (Opposite.op (Y⟦a⟧) ⟶ (Opposite.op X)⟦n⟧)` when `n + a = a'`.
+The compatibilities that are obtained shall be used in order to study
+the homological functor `preadditiveYoneda.obj B : Cᵒᵖ ⥤ Type _` when `B` is an object
+in a pretriangulated category `C`.
+-/
+
+namespace CategoryTheory
+
+open Category Pretriangulated.Opposite Pretriangulated
+
+variable {C : Type*} [Category C] [HasShift C ℤ] {X Y Z : C}
+
+namespace ShiftedHom
+
+/-- The bijection `ShiftedHom X Y n ≃ ShiftedHom (Opposite.op Y) (Opposite.op X) n` when
+`n : ℤ`, and `X` and `Y` are objects of a category equipped with a shift by `ℤ`. -/
+noncomputable def opEquiv (n : ℤ) :
+    ShiftedHom X Y n ≃ ShiftedHom (Opposite.op Y) (Opposite.op X) n :=
+  Quiver.Hom.opEquiv.trans
+    ((opShiftFunctorEquivalence C n).symm.toAdjunction.homEquiv (Opposite.op Y) (Opposite.op X))
+
+lemma opEquiv_symm_apply {n : ℤ} (f : ShiftedHom (Opposite.op Y) (Opposite.op X) n) :
+    (opEquiv n).symm f =
+      ((opShiftFunctorEquivalence C n).unitIso.inv.app (Opposite.op X)).unop ≫ f.unop⟦n⟧' := by
+  rfl
+
+lemma opEquiv_symm_apply_comp {X Y : C} {a : ℤ}
+    (f : ShiftedHom (Opposite.op X) (Opposite.op Y) a) {b : ℤ} {Z : C}
+    (z : ShiftedHom X Z b) {c : ℤ} (h : b + a = c) :
+    ((ShiftedHom.opEquiv a).symm f).comp z h =
+      (ShiftedHom.opEquiv a).symm (z.op ≫ f) ≫
+        (shiftFunctorAdd' C b a c h).inv.app Z := by
+  rw [ShiftedHom.opEquiv_symm_apply, ShiftedHom.opEquiv_symm_apply,
+    ShiftedHom.comp]
+  dsimp
+  simp only [assoc, Functor.map_comp]
+
+lemma opEquiv_symm_comp {a b : ℤ}
+    (f : ShiftedHom (Opposite.op Z) (Opposite.op Y) a)
+    (g : ShiftedHom (Opposite.op Y) (Opposite.op X) b)
+    {c : ℤ} (h : b + a = c) :
+    (opEquiv _).symm (f.comp g h) =
+      ((opEquiv _).symm g).comp ((opEquiv _).symm f) (by omega) := by
+  rw [opEquiv_symm_apply, opEquiv_symm_apply,
+    opShiftFunctorEquivalence_unitIso_inv_app_eq _ _ _ _ (show a + b = c by omega), comp, comp]
+  dsimp
+  rw [assoc, assoc, assoc, assoc, ← Functor.map_comp, ← unop_comp_assoc,
+    Iso.inv_hom_id_app]
+  dsimp
+  rw [assoc, id_comp, Functor.map_comp, ← NatTrans.naturality_assoc,
+    ← NatTrans.naturality, opEquiv_symm_apply]
+  dsimp
+  rw [← Functor.map_comp_assoc, ← Functor.map_comp_assoc,
+    ← Functor.map_comp_assoc]
+  rw [← unop_comp_assoc]
+  erw [← NatTrans.naturality]
+  rfl
+
+/-- The bijection `ShiftedHom X Y a' ≃ (Opposite.op (Y⟦a⟧) ⟶ (Opposite.op X)⟦n⟧)`
+when integers `n`, `a` and `a'` satisfy `n + a = a'`, and `X` and `Y` are objects
+of a category equipped with a shift by `ℤ`. -/
+noncomputable def opEquiv' (n a a' : ℤ) (h : n + a = a') :
+    ShiftedHom X Y a' ≃ (Opposite.op (Y⟦a⟧) ⟶ (Opposite.op X)⟦n⟧) :=
+  ((shiftFunctorAdd' C a n a' (by omega)).symm.app Y).homToEquiv.symm.trans (opEquiv n)
+
+lemma opEquiv'_symm_apply {n a : ℤ} (f : Opposite.op (Y⟦a⟧) ⟶ (Opposite.op X)⟦n⟧)
+    (a' : ℤ) (h : n + a = a') :
+    (opEquiv' n a a' h).symm f =
+      (opEquiv n).symm f ≫ (shiftFunctorAdd' C a n a' (by omega)).inv.app _ :=
+  rfl
+
+lemma opEquiv'_apply {a' : ℤ} (f : ShiftedHom X Y a') (n a : ℤ) (h : n + a = a') :
+    opEquiv' n a a' h f =
+      opEquiv n (f ≫ (shiftFunctorAdd' C a n a' (by omega)).hom.app Y) := by
+  rfl
+
+lemma opEquiv'_symm_op_opShiftFunctorEquivalence_counitIso_inv_app_op_shift
+    {n m : ℤ} (f : ShiftedHom X Y n) (g : ShiftedHom Y Z m)
+    (q : ℤ) (hq : n + m = q) :
+    (opEquiv' n m q hq).symm
+        (g.op ≫ (opShiftFunctorEquivalence C n).counitIso.inv.app _ ≫ f.op⟦n⟧') =
+      f.comp g (by omega) := by
+  rw [opEquiv'_symm_apply, opEquiv_symm_apply]
+  dsimp [comp]
+  apply Quiver.Hom.op_inj
+  simp only [assoc, Functor.map_comp, op_comp, Quiver.Hom.op_unop,
+    opShiftFunctorEquivalence_unitIso_inv_naturality]
+  erw [(opShiftFunctorEquivalence C n).inverse_counitInv_comp_assoc (Opposite.op Y)]
+
+lemma opEquiv'_symm_comp (f : Y ⟶ X) {n a : ℤ} (x : Opposite.op (Z⟦a⟧) ⟶ (Opposite.op X⟦n⟧))
+    (a' : ℤ) (h : n + a = a') :
+    (opEquiv' n a a' h).symm (x ≫ f.op⟦n⟧') = f ≫ (opEquiv' n a a' h).symm x :=
+  Quiver.Hom.op_inj (by simp [opEquiv'_symm_apply, opEquiv_symm_apply])
+
+lemma opEquiv'_zero_add_symm (a : ℤ) (f : Opposite.op (Y⟦a⟧) ⟶ (Opposite.op X)⟦(0 : ℤ)⟧) :
+    (opEquiv' 0 a a (zero_add a)).symm f =
+      ((shiftFunctorZero Cᵒᵖ ℤ).hom.app _).unop ≫ f.unop := by
+  simp [opEquiv'_symm_apply, opEquiv_symm_apply, shiftFunctorAdd'_add_zero,
+    opShiftFunctorEquivalence_zero_unitIso_inv_app]
+
+lemma opEquiv'_add_symm (n m a a' a'' : ℤ) (ha' : n + a = a') (ha'' : m + a' = a'')
+    (x : (Opposite.op (Y⟦a⟧) ⟶ (Opposite.op X)⟦m + n⟧)) :
+    (opEquiv' (m + n) a a'' (by omega)).symm x =
+      (opEquiv' m a' a'' ha'').symm ((opEquiv' n a a' ha').symm
+        (x ≫ (shiftFunctorAdd Cᵒᵖ m n).hom.app _)).op := by
+  simp only [opEquiv'_symm_apply, opEquiv_symm_apply,
+    opShiftFunctorEquivalence_unitIso_inv_app_eq _ _ _ _ (add_comm n m)]
+  dsimp
+  simp only [assoc, Functor.map_comp, ← shiftFunctorAdd'_eq_shiftFunctorAdd,
+    ← NatTrans.naturality_assoc,
+    shiftFunctorAdd'_assoc_inv_app a n m a' (m + n) a'' (by omega) (by omega) (by omega)]
+  rfl
+
+section Preadditive
+
+variable [Preadditive C] [∀ (n : ℤ), (shiftFunctor C n).Additive]
+
+@[simp]
+lemma opEquiv_symm_add {n : ℤ} (x y : ShiftedHom (Opposite.op Y) (Opposite.op X) n) :
+    (opEquiv n).symm (x + y) = (opEquiv n).symm x + (opEquiv n).symm y := by
+  dsimp [opEquiv_symm_apply]
+  rw [← Preadditive.comp_add, ← Functor.map_add]
+  rfl
+
+@[simp]
+lemma opEquiv'_symm_add {n a : ℤ} (x y : (Opposite.op (Y⟦a⟧) ⟶ (Opposite.op X)⟦n⟧))
+    (a' : ℤ) (h : n + a = a') :
+    (opEquiv' n a a' h).symm (x + y) =
+      (opEquiv' n a a' h).symm x + (opEquiv' n a a' h).symm y := by
+  dsimp [opEquiv']
+  erw [opEquiv_symm_add, Iso.homToEquiv_apply, Iso.homToEquiv_apply, Iso.homToEquiv_apply]
+  rw [Preadditive.add_comp]
+  rfl
+
+end Preadditive
+
+end ShiftedHom
+
+end CategoryTheory

--- a/Mathlib/CategoryTheory/Shift/ShiftedHomOpposite.lean
+++ b/Mathlib/CategoryTheory/Shift/ShiftedHomOpposite.lean
@@ -17,6 +17,7 @@ We also introduce `ShiftedHom.opEquiv'` which produces a bijection
 The compatibilities that are obtained shall be used in order to study
 the homological functor `preadditiveYoneda.obj B : Cᵒᵖ ⥤ Type _` when `B` is an object
 in a pretriangulated category `C`.
+
 -/
 
 namespace CategoryTheory

--- a/Mathlib/CategoryTheory/Triangulated/Opposite.lean
+++ b/Mathlib/CategoryTheory/Triangulated/Opposite.lean
@@ -130,8 +130,7 @@ lemma shiftFunctor_op_map (n m : ℤ) (hnm : n + m = 0) {K L : Cᵒᵖ} (φ : K 
         (shiftFunctorOpIso C n m hnm).inv.app L :=
   (NatIso.naturality_2 (shiftFunctorOpIso C n m hnm) φ).symm
 
-variable (C)
-
+variable (C) in
 /-- The autoequivalence `Cᵒᵖ ≌ Cᵒᵖ` whose functor is `shiftFunctor Cᵒᵖ n` and whose inverse
 functor is `(shiftFunctor C n).op`. Do not unfold the definitions of the unit and counit
 isomorphisms: the compatibilities they satisfy are stated as separate lemmas. -/
@@ -177,7 +176,57 @@ lemma opShiftFunctorEquivalence_counitIso_inv_naturality (n : ℤ) {X Y : Cᵒ�
       (opShiftFunctorEquivalence C n).counitIso.inv.app X ≫ f.unop⟦n⟧'.op⟦n⟧' :=
   (opShiftFunctorEquivalence C n).counitIso.inv.naturality f
 
-variable {C}
+lemma opShiftFunctorEquivalence_zero_unitIso_hom_app (X : Cᵒᵖ) :
+    (opShiftFunctorEquivalence C 0).unitIso.hom.app X =
+      ((shiftFunctorZero C ℤ).hom.app X.unop).op ≫
+      (((shiftFunctorZero Cᵒᵖ ℤ).inv.app X).unop⟦(0 : ℤ)⟧').op := by
+  apply Quiver.Hom.unop_inj
+  dsimp [opShiftFunctorEquivalence]
+  rw [shiftFunctorZero_op_inv_app, unop_comp, Quiver.Hom.unop_op, Functor.map_comp,
+    shiftFunctorCompIsoId_zero_zero_hom_app, assoc]
+
+lemma opShiftFunctorEquivalence_zero_unitIso_inv_app (X : Cᵒᵖ) :
+    (opShiftFunctorEquivalence C 0).unitIso.inv.app X =
+      (((shiftFunctorZero Cᵒᵖ ℤ).hom.app X).unop⟦(0 : ℤ)⟧').op ≫
+        ((shiftFunctorZero C ℤ).inv.app X.unop).op := by
+  apply Quiver.Hom.unop_inj
+  dsimp [opShiftFunctorEquivalence]
+  rw [shiftFunctorZero_op_hom_app, unop_comp, Quiver.Hom.unop_op, Functor.map_comp,
+    shiftFunctorCompIsoId_zero_zero_inv_app, assoc]
+
+lemma opShiftFunctorEquivalence_unitIso_hom_app_eq (X : Cᵒᵖ) (m n p : ℤ) (h : m + n = p) :
+    (opShiftFunctorEquivalence C p).unitIso.hom.app X =
+      (opShiftFunctorEquivalence C n).unitIso.hom.app X ≫
+      (((opShiftFunctorEquivalence C m).unitIso.hom.app (X⟦n⟧)).unop⟦n⟧').op ≫
+      ((shiftFunctorAdd' C m n p h).hom.app _).op ≫
+      (((shiftFunctorAdd' Cᵒᵖ n m p (by omega)).inv.app X).unop⟦p⟧').op := by
+  dsimp [opShiftFunctorEquivalence]
+  simp only [shiftFunctorAdd'_op_inv_app _ n m p (by omega) _ _ _ (add_neg_cancel n)
+    (add_neg_cancel m) (add_neg_cancel p), shiftFunctor_op_map _ _ (add_neg_cancel m),
+    Category.assoc, Iso.inv_hom_id_app_assoc]
+  erw [Functor.map_id, Functor.map_id, Functor.map_id, Functor.map_id,
+    id_comp, id_comp, id_comp, comp_id, comp_id]
+  dsimp
+  rw [comp_id, shiftFunctorCompIsoId_add'_hom_app _ _ _ _ _ _
+    (neg_add_cancel m) (neg_add_cancel n) (neg_add_cancel p) h]
+  dsimp
+  rw [Category.assoc, Category.assoc]
+  rfl
+
+lemma opShiftFunctorEquivalence_unitIso_inv_app_eq (X : Cᵒᵖ) (m n p : ℤ) (h : m + n = p) :
+    (opShiftFunctorEquivalence C p).unitIso.inv.app X =
+      (((shiftFunctorAdd' Cᵒᵖ n m p (by omega)).hom.app X).unop⟦p⟧').op ≫
+      ((shiftFunctorAdd' C m n p h).inv.app _).op ≫
+      (((opShiftFunctorEquivalence C m).unitIso.inv.app (X⟦n⟧)).unop⟦n⟧').op ≫
+      (opShiftFunctorEquivalence C n).unitIso.inv.app X := by
+  rw [← cancel_mono ((opShiftFunctorEquivalence C p).unitIso.hom.app X), Iso.inv_hom_id_app,
+    opShiftFunctorEquivalence_unitIso_hom_app_eq _ _ _ _ h,
+    Category.assoc, Category.assoc, Category.assoc, Iso.inv_hom_id_app_assoc]
+  apply Quiver.Hom.unop_inj
+  dsimp
+  simp only [Category.assoc, ← Functor.map_comp_assoc, Iso.hom_inv_id_app_assoc,
+    ← unop_comp, Iso.inv_hom_id_app, Functor.comp_obj, Functor.op_obj, unop_id,
+    Functor.map_id, id_comp, ← Functor.map_comp, Iso.hom_inv_id_app]
 
 lemma shift_unop_opShiftFunctorEquivalence_counitIso_inv_app (X : Cᵒᵖ) (n : ℤ) :
     ((opShiftFunctorEquivalence C n).counitIso.inv.app X).unop⟦n⟧' =

--- a/Mathlib/CategoryTheory/Triangulated/Yoneda.lean
+++ b/Mathlib/CategoryTheory/Triangulated/Yoneda.lean
@@ -5,6 +5,7 @@ Authors: Joël Riou
 -/
 import Mathlib.Algebra.Homology.ShortComplex.Ab
 import Mathlib.CategoryTheory.Preadditive.Yoneda.Basic
+import Mathlib.CategoryTheory.Shift.ShiftedHomOpposite
 import Mathlib.CategoryTheory.Triangulated.HomologicalFunctor
 import Mathlib.CategoryTheory.Triangulated.Opposite
 
@@ -23,7 +24,7 @@ variable {C : Type*} [Category C] [Preadditive C] [HasShift C ℤ]
 
 namespace CategoryTheory
 
-open Limits Pretriangulated.Opposite
+open Limits Opposite Pretriangulated.Opposite
 
 namespace Pretriangulated
 
@@ -61,6 +62,43 @@ lemma preadditiveCoyoneda_homologySequenceδ_apply
     (preadditiveCoyoneda.obj A).homologySequenceδ T n₀ n₁ h x =
       x ≫ T.mor₃⟦n₀⟧' ≫ (shiftFunctorAdd' C 1 n₀ n₁ (by omega)).inv.app _ := by
   apply Category.assoc
+
+section
+
+variable [∀ (n : ℤ), (shiftFunctor C n).Additive]
+
+noncomputable instance (B : C) : (preadditiveYoneda.obj B).ShiftSequence ℤ where
+  sequence n := preadditiveYoneda.obj (B⟦n⟧)
+  isoZero := preadditiveYoneda.mapIso ((shiftFunctorZero C ℤ).app B)
+  shiftIso n a a' h := NatIso.ofComponents (fun A ↦ AddEquiv.toAddCommGrpIso
+    { toEquiv := Quiver.Hom.opEquiv.trans (ShiftedHom.opEquiv' n a a' h).symm
+      map_add' := fun _ _ ↦ ShiftedHom.opEquiv'_symm_add _ _ _ h })
+        (by intros; ext; apply ShiftedHom.opEquiv'_symm_comp _ _ _ h)
+  shiftIso_zero a := by ext; apply ShiftedHom.opEquiv'_zero_add_symm
+  shiftIso_add n m a a' a'' ha' ha'' := by
+    ext _ x
+    exact ShiftedHom.opEquiv'_add_symm n m a a' a'' ha' ha'' x.op
+
+lemma preadditiveYoneda_shiftMap_apply (B : C) {X Y : Cᵒᵖ} (n : ℤ) (f : X ⟶ Y⟦n⟧)
+    (a a' : ℤ) (h : n + a = a') (z : X.unop ⟶ B⟦a⟧) :
+    (preadditiveYoneda.obj B).shiftMap f a a' h z =
+      ((ShiftedHom.opEquiv _).symm f).comp z (show a + n = a' by omega) := by
+  symm
+  apply ShiftedHom.opEquiv_symm_apply_comp
+
+lemma preadditiveYoneda_homologySequenceδ_apply
+    (T : Triangle C) (n₀ n₁ : ℤ) (h : n₀ + 1 = n₁) {B : C} (x : T.obj₁ ⟶ B⟦n₀⟧) :
+    (preadditiveYoneda.obj B).homologySequenceδ
+      ((triangleOpEquivalence _).functor.obj (op T)) n₀ n₁ h x =
+      T.mor₃ ≫ x⟦(1 : ℤ)⟧' ≫ (shiftFunctorAdd' C n₀ 1 n₁ h).inv.app B := by
+  simp only [Functor.homologySequenceδ, preadditiveYoneda_shiftMap_apply,
+    ShiftedHom.comp, ← Category.assoc]
+  congr 2
+  apply (ShiftedHom.opEquiv _).injective
+  rw [Equiv.apply_symm_apply]
+  rfl
+
+end
 
 end Pretriangulated
 

--- a/Mathlib/Combinatorics/Quiver/Basic.lean
+++ b/Mathlib/Combinatorics/Quiver/Basic.lean
@@ -137,6 +137,15 @@ def Hom.op {V} [Quiver V] {X Y : V} (f : X ⟶ Y) : op Y ⟶ op X := ⟨f⟩
 /-- Given an arrow in `Vᵒᵖ`, we can take the "unopposite" back in `V`. -/
 def Hom.unop {V} [Quiver V] {X Y : Vᵒᵖ} (f : X ⟶ Y) : unop Y ⟶ unop X := Opposite.unop f
 
+/-- The bijection `(X ⟶ Y) ≃ (op Y ⟶ op X)`. -/
+@[simps]
+def Hom.opEquiv {V} [Quiver V] {X Y : V} :
+    (X ⟶ Y) ≃ (Opposite.op Y ⟶ Opposite.op X) where
+  toFun := Opposite.op
+  invFun := Opposite.unop
+  left_inv _ := rfl
+  right_inv _ := rfl
+
 /-- A type synonym for a quiver with no arrows. -/
 -- Porting note(#5171): this linter isn't ported yet.
 -- @[nolint has_nonempty_instance]


### PR DESCRIPTION
When `C` is a triangulated category, we introduce a bijection `ShiftedHom.opEquiv` which identifies `X ⟶ Y⟦n⟧` and `op Y ⟶ (op X)⟦n⟧` for any objects `X` and `Y` in `C`, and `n : ℤ`.
Along with the compatibilities that are obtained, this shall be the main ingredient in the construction of the (contravariant) long exact sequence of `Ext` in abelian categories #15092.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
