### PR TITLE
[Merged by Bors] - chore: another test for `linear_combination`

### DIFF
--- a/test/linear_combination.lean
+++ b/test/linear_combination.lean
@@ -231,6 +231,15 @@ example (x y : ℤ) (h1 : x * y + 2 * x = 1) (h2 : x = y) : x * y = -2 * y + 1 :
 
 /--
 error: ring failed, ring expressions not equal
+a : ℤ
+ha : a = 1
+⊢ -1 = 0
+-/
+#guard_msgs in
+example (a : ℤ) (ha : a = 1) : a = 2 := by linear_combination ha
+
+/--
+error: ring failed, ring expressions not equal
 a : ℚ
 ha : a = 1
 ⊢ -1 = 0


### PR DESCRIPTION
Prior to https://github.com/leanprover/lean4/pull/5167, this test (would have) had a less helpful error message.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
