### PR TITLE
feat(Equiv/QuotProd): new file

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -3163,6 +3163,7 @@ import Mathlib.Logic.Equiv.Nat
 import Mathlib.Logic.Equiv.Option
 import Mathlib.Logic.Equiv.Pairwise
 import Mathlib.Logic.Equiv.PartialEquiv
+import Mathlib.Logic.Equiv.QuotProd
 import Mathlib.Logic.Equiv.Set
 import Mathlib.Logic.Equiv.TransferInstance
 import Mathlib.Logic.ExistsUnique

--- a/Mathlib/Logic/Equiv/QuotProd.lean
+++ b/Mathlib/Logic/Equiv/QuotProd.lean
@@ -1,0 +1,76 @@
+/-
+Copyright (c) 2024 Yury Kudryashov. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Yury Kudryashov
+-/
+import Mathlib.Logic.Equiv.Defs
+import Mathlib.Data.Setoid.Basic
+
+/-!
+# Quotient by the product of two setoids
+
+In this file we define the natural equivalence between
+`Quotient r × Quotient s` and `Quotient (r.prod s)`, see `Equiv.quotientProdQuotient`.
+We also define the `Quot` version of this equivalence, see `Equiv.quotProdQuot`.
+-/
+
+namespace Equiv
+
+variable {α β : Type*}
+
+section QuotProd
+
+/-- The natural equivalence between the product of two quotients
+and the quotient of the product by the relation `t (x₁, x₂) (y₁, y₂) = r x₁ y₁ ∧ s x₂ y₂`.
+
+We assume both relations to be reflexive, because, e.g.,
+for `r _ _ = False` and `s _ _ = True` on `Bool`, LHS has 2 elements while RHS has 4 elements. -/
+def quotProdQuot (r : α → α → Prop) [IsRefl α r] (s : β → β → Prop) [IsRefl β s] :
+    Quot r × Quot s ≃ Quot (fun x y : α × β ↦ r x.1 y.1 ∧ s x.2 y.2) where
+  toFun := fun x ↦ Quot.liftOn₂ x.1 x.2 (fun a b ↦ Quot.mk _ (a, b))
+    (fun a b₁ b₂ hb ↦ Quot.sound ⟨refl_of .., hb⟩)
+    (fun a₁ a₂ b ha ↦ Quot.sound ⟨ha, refl_of ..⟩)
+  invFun := Quot.lift (Prod.map (Quot.mk r) (Quot.mk s)) fun x y ⟨h₁, h₂⟩ ↦
+    Prod.ext (Quot.sound h₁) (Quot.sound h₂)
+  left_inv := by rintro ⟨⟨a⟩, ⟨b⟩⟩; rfl
+  right_inv := by rintro ⟨a⟩; rfl
+
+variable {r : α → α → Prop} [IsRefl α r] {s : β → β → Prop} [IsRefl β s]
+
+@[simp]
+lemma quotProdQuot_apply_mk (a : α) (b : β) :
+    quotProdQuot r s (Quot.mk r a, Quot.mk s b) = Quot.mk _ (a, b) :=
+  rfl
+
+@[simp]
+lemma quotProdQuot_symm_apply_mk (x : α × β) :
+    (quotProdQuot r s).symm (Quot.mk _ x) = (Quot.mk r x.1, Quot.mk s x.2) :=
+  rfl
+
+end QuotProd
+
+section QuotientProd
+
+/-- The natural equivalence between the product of two quotients
+and the quotient of the product by the product setoid. -/
+def quotientProdQuotient (r : Setoid α) (s : Setoid β) :
+    Quotient r × Quotient s ≃ Quotient (r.prod s) :=
+  haveI : IsRefl α r.Rel := ⟨r.refl⟩
+  haveI : IsRefl β s.Rel := ⟨s.refl⟩
+  quotProdQuot r.Rel s.Rel
+
+variable {r : Setoid α} {s : Setoid β}
+
+@[simp]
+lemma quotientProdQuotient_apply_mk (a : α) (b : β) :
+    quotientProdQuotient r s (⟦a⟧, ⟦b⟧) = ⟦(a, b)⟧ :=
+  rfl
+
+@[simp]
+lemma quotientProdQuotient_symm_apply_mk (x : α × β) :
+    (quotientProdQuotient r s).symm ⟦x⟧ = (⟦x.1⟧, ⟦x.2⟧) :=
+  rfl
+
+end QuotientProd
+
+end Equiv


### PR DESCRIPTION
---
I'm surprised we don't have this.
I also plan to add versions for `Con`s and `QuotientGroup`.
`pi` version awaits a refactor turning `piSetoid` into a `def`.
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
