### PR TITLE
[Merged by Bors] - refactor: deprecate `ContinuousMonoidHomClass`

### DIFF
--- a/Mathlib/Topology/Algebra/ContinuousMonoidHom.lean
+++ b/Mathlib/Topology/Algebra/ContinuousMonoidHom.lean
@@ -76,6 +76,12 @@ add_decl_doc ContinuousMonoidHom.toMonoidHom
 /-- Reinterpret a `ContinuousAddMonoidHom` as an `AddMonoidHom`. -/
 add_decl_doc ContinuousAddMonoidHom.toAddMonoidHom
 
+/-- Reinterpret a `ContinuousMonoidHom` as a `ContinuousMap`. -/
+add_decl_doc ContinuousMonoidHom.toContinuousMap
+
+/-- Reinterpret a `ContinuousAddMonoidHom` as a `ContinuousMap`. -/
+add_decl_doc ContinuousAddMonoidHom.toContinuousMap
+
 namespace ContinuousMonoidHom
 
 variable {A B C D E}

--- a/Mathlib/Topology/Algebra/ContinuousMonoidHom.lean
+++ b/Mathlib/Topology/Algebra/ContinuousMonoidHom.lean
@@ -30,49 +30,43 @@ variable (F A B C D E : Type*) [Monoid A] [Monoid B] [Monoid C] [Monoid D] [Comm
 /-- The type of continuous additive monoid homomorphisms from `A` to `B`.
 
 When possible, instead of parametrizing results over `(f : ContinuousAddMonoidHom A B)`,
-you should parametrize over `(F : Type*) [ContinuousAddMonoidHomClass F A B] (f : F)`.
+you should parametrize
+over `(F : Type*) [FunLike F A B] [ContinuousMapClass F A B] [AddMonoidHomClass F A B] (f : F)`.
 
 When you extend this structure, make sure to extend `ContinuousAddMonoidHomClass`. -/
 structure ContinuousAddMonoidHom (A B : Type*) [AddMonoid A] [AddMonoid B] [TopologicalSpace A]
-  [TopologicalSpace B] extends A →+ B where
-  /-- Proof of continuity of the Hom. -/
-  continuous_toFun : @Continuous A B _ _ toFun
+  [TopologicalSpace B] extends A →+ B, C(A, B)
 
 /-- The type of continuous monoid homomorphisms from `A` to `B`.
 
 When possible, instead of parametrizing results over `(f : ContinuousMonoidHom A B)`,
-you should parametrize over `(F : Type*) [ContinuousMonoidHomClass F A B] (f : F)`.
+you should parametrize
+over `(F : Type*) [FunLike F A B] [ContinuousMapClass F A B] [MonoidHomClass F A B] (f : F)`.
 
 When you extend this structure, make sure to extend `ContinuousAddMonoidHomClass`. -/
 @[to_additive "The type of continuous additive monoid homomorphisms from `A` to `B`."]
-structure ContinuousMonoidHom extends A →* B where
-  /-- Proof of continuity of the Hom. -/
-  continuous_toFun : @Continuous A B _ _ toFun
+structure ContinuousMonoidHom extends A →* B, C(A, B)
 
 section
 
 /-- `ContinuousAddMonoidHomClass F A B` states that `F` is a type of continuous additive monoid
 homomorphisms.
 
-You should also extend this typeclass when you extend `ContinuousAddMonoidHom`. -/
--- Porting note: Changed A B to outParam to help synthesizing order
-class ContinuousAddMonoidHomClass (A B : outParam Type*) [AddMonoid A] [AddMonoid B]
+Deprecated and changed from a `class` to a `structure`.
+Use `[AddMonoidHomClass F A B] [ContinuousMapClass F A B]` instead. -/
+structure ContinuousAddMonoidHomClass (A B : outParam Type*) [AddMonoid A] [AddMonoid B]
     [TopologicalSpace A] [TopologicalSpace B] [FunLike F A B]
-    extends AddMonoidHomClass F A B : Prop where
-  /-- Proof of the continuity of the map. -/
-  map_continuous (f : F) : Continuous f
+    extends AddMonoidHomClass F A B, ContinuousMapClass F A B : Prop
 
 /-- `ContinuousMonoidHomClass F A B` states that `F` is a type of continuous monoid
 homomorphisms.
 
-You should also extend this typeclass when you extend `ContinuousMonoidHom`. -/
--- Porting note: Changed A B to outParam to help synthesizing order
-@[to_additive]
-class ContinuousMonoidHomClass (A B : outParam Type*) [Monoid A] [Monoid B]
+Deprecated and changed from a `class` to a `structure`.
+Use `[MonoidHomClass F A B] [ContinuousMapClass F A B]` instead. -/
+@[to_additive (attr := deprecated (since := "2024-10-08"))]
+structure ContinuousMonoidHomClass (A B : outParam Type*) [Monoid A] [Monoid B]
     [TopologicalSpace A] [TopologicalSpace B] [FunLike F A B]
-    extends MonoidHomClass F A B : Prop where
-  /-- Proof of the continuity of the map. -/
-  map_continuous (f : F) : Continuous f
+    extends MonoidHomClass F A B, ContinuousMapClass F A B : Prop
 
 end
 
@@ -82,18 +76,12 @@ add_decl_doc ContinuousMonoidHom.toMonoidHom
 /-- Reinterpret a `ContinuousAddMonoidHom` as an `AddMonoidHom`. -/
 add_decl_doc ContinuousAddMonoidHom.toAddMonoidHom
 
--- See note [lower instance priority]
-@[to_additive]
-instance (priority := 100) ContinuousMonoidHomClass.toContinuousMapClass
-    [FunLike F A B] [ContinuousMonoidHomClass F A B] : ContinuousMapClass F A B :=
-  { ‹ContinuousMonoidHomClass F A B› with }
-
 namespace ContinuousMonoidHom
 
 variable {A B C D E}
 
 @[to_additive]
-instance funLike : FunLike (ContinuousMonoidHom A B) A B where
+instance instFunLike : FunLike (ContinuousMonoidHom A B) A B where
   coe f := f.toFun
   coe_injective' f g h := by
     obtain ⟨⟨⟨ _ , _ ⟩, _⟩, _⟩ := f
@@ -101,19 +89,17 @@ instance funLike : FunLike (ContinuousMonoidHom A B) A B where
     congr
 
 @[to_additive]
-instance ContinuousMonoidHomClass : ContinuousMonoidHomClass (ContinuousMonoidHom A B) A B where
+instance instMonoidHomClass : MonoidHomClass (ContinuousMonoidHom A B) A B where
   map_mul f := f.map_mul'
   map_one f := f.map_one'
+
+@[to_additive]
+instance instContinuousMapClass : ContinuousMapClass (ContinuousMonoidHom A B) A B where
   map_continuous f := f.continuous_toFun
 
 @[to_additive (attr := ext)]
 theorem ext {f g : ContinuousMonoidHom A B} (h : ∀ x, f x = g x) : f = g :=
   DFunLike.ext _ _ h
-
-/-- Reinterpret a `ContinuousMonoidHom` as a `ContinuousMap`. -/
-@[to_additive "Reinterpret a `ContinuousAddMonoidHom` as a `ContinuousMap`."]
-def toContinuousMap (f : ContinuousMonoidHom A B) : C(A, B) :=
-  { f with }
 
 @[to_additive]
 theorem toContinuousMap_injective : Injective (toContinuousMap : _ → C(A, B)) := fun f g h =>
@@ -121,27 +107,28 @@ theorem toContinuousMap_injective : Injective (toContinuousMap : _ → C(A, B)) 
 
 -- Porting note: Removed simps because given definition is not a constructor application
 /-- Construct a `ContinuousMonoidHom` from a `Continuous` `MonoidHom`. -/
-@[to_additive "Construct a `ContinuousAddMonoidHom` from a `Continuous` `AddMonoidHom`."]
+@[to_additive (attr := deprecated (since := "2024-10-08"))
+  "Construct a `ContinuousAddMonoidHom` from a `Continuous` `AddMonoidHom`."]
 def mk' (f : A →* B) (hf : Continuous f) : ContinuousMonoidHom A B :=
   { f with continuous_toFun := (hf : Continuous f.toFun)}
 
 /-- Composition of two continuous homomorphisms. -/
 @[to_additive (attr := simps!) "Composition of two continuous homomorphisms."]
 def comp (g : ContinuousMonoidHom B C) (f : ContinuousMonoidHom A B) : ContinuousMonoidHom A C :=
-  mk' (g.toMonoidHom.comp f.toMonoidHom) (g.continuous_toFun.comp f.continuous_toFun)
+  ⟨g.toMonoidHom.comp f.toMonoidHom, (map_continuous g).comp (map_continuous f)⟩
 
 /-- Product of two continuous homomorphisms on the same space. -/
 @[to_additive (attr := simps!) prod "Product of two continuous homomorphisms on the same space."]
 def prod (f : ContinuousMonoidHom A B) (g : ContinuousMonoidHom A C) :
     ContinuousMonoidHom A (B × C) :=
-  mk' (f.toMonoidHom.prod g.toMonoidHom) (f.continuous_toFun.prod_mk g.continuous_toFun)
+  ⟨f.toMonoidHom.prod g.toMonoidHom, f.continuous_toFun.prod_mk g.continuous_toFun⟩
 
 /-- Product of two continuous homomorphisms on different spaces. -/
 @[to_additive (attr := simps!) prodMap
   "Product of two continuous homomorphisms on different spaces."]
 def prodMap (f : ContinuousMonoidHom A C) (g : ContinuousMonoidHom B D) :
     ContinuousMonoidHom (A × B) (C × D) :=
-  mk' (f.toMonoidHom.prodMap g.toMonoidHom) (f.continuous_toFun.prodMap g.continuous_toFun)
+  ⟨f.toMonoidHom.prodMap g.toMonoidHom, f.continuous_toFun.prodMap g.continuous_toFun⟩
 
 @[deprecated (since := "2024-10-05")] alias prod_map := prodMap
 @[deprecated (since := "2024-10-05")]
@@ -155,7 +142,7 @@ variable (A B C D E)
 /-- The trivial continuous homomorphism. -/
 @[to_additive (attr := simps!) "The trivial continuous homomorphism."]
 def one : ContinuousMonoidHom A B :=
-  mk' 1 continuous_const
+  ⟨1, continuous_const⟩
 
 @[to_additive]
 instance : Inhabited (ContinuousMonoidHom A B) :=
@@ -164,19 +151,19 @@ instance : Inhabited (ContinuousMonoidHom A B) :=
 /-- The identity continuous homomorphism. -/
 @[to_additive (attr := simps!) "The identity continuous homomorphism."]
 def id : ContinuousMonoidHom A A :=
-  mk' (MonoidHom.id A) continuous_id
+  ⟨.id A, continuous_id⟩
 
 /-- The continuous homomorphism given by projection onto the first factor. -/
 @[to_additive (attr := simps!)
   "The continuous homomorphism given by projection onto the first factor."]
 def fst : ContinuousMonoidHom (A × B) A :=
-  mk' (MonoidHom.fst A B) continuous_fst
+  ⟨MonoidHom.fst A B, continuous_fst⟩
 
 /-- The continuous homomorphism given by projection onto the second factor. -/
 @[to_additive (attr := simps!)
   "The continuous homomorphism given by projection onto the second factor."]
 def snd : ContinuousMonoidHom (A × B) B :=
-  mk' (MonoidHom.snd A B) continuous_snd
+  ⟨MonoidHom.snd A B, continuous_snd⟩
 
 /-- The continuous homomorphism given by inclusion of the first factor. -/
 @[to_additive (attr := simps!)
@@ -203,12 +190,12 @@ def swap : ContinuousMonoidHom (A × B) (B × A) :=
 /-- The continuous homomorphism given by multiplication. -/
 @[to_additive (attr := simps!) "The continuous homomorphism given by addition."]
 def mul : ContinuousMonoidHom (E × E) E :=
-  mk' mulMonoidHom continuous_mul
+  ⟨mulMonoidHom, continuous_mul⟩
 
 /-- The continuous homomorphism given by inversion. -/
 @[to_additive (attr := simps!) "The continuous homomorphism given by negation."]
 def inv : ContinuousMonoidHom E E :=
-  mk' invMonoidHom continuous_inv
+  ⟨invMonoidHom, continuous_inv⟩
 
 variable {A B C D E}
 

--- a/Mathlib/Topology/Algebra/ContinuousMonoidHom.lean
+++ b/Mathlib/Topology/Algebra/ContinuousMonoidHom.lean
@@ -33,7 +33,8 @@ When possible, instead of parametrizing results over `(f : ContinuousAddMonoidHo
 you should parametrize
 over `(F : Type*) [FunLike F A B] [ContinuousMapClass F A B] [AddMonoidHomClass F A B] (f : F)`.
 
-When you extend this structure, make sure to extend `ContinuousAddMonoidHomClass`. -/
+When you extend this structure,
+make sure to extend `ContinuousMapClass` and/or `AddMonoidHomClass`, if needed. -/
 structure ContinuousAddMonoidHom (A B : Type*) [AddMonoid A] [AddMonoid B] [TopologicalSpace A]
   [TopologicalSpace B] extends A →+ B, C(A, B)
 
@@ -43,7 +44,8 @@ When possible, instead of parametrizing results over `(f : ContinuousMonoidHom A
 you should parametrize
 over `(F : Type*) [FunLike F A B] [ContinuousMapClass F A B] [MonoidHomClass F A B] (f : F)`.
 
-When you extend this structure, make sure to extend `ContinuousAddMonoidHomClass`. -/
+When you extend this structure,
+make sure to extend `ContinuousMapClass` and/or `MonoidHomClass`, if needed. -/
 @[to_additive "The type of continuous additive monoid homomorphisms from `A` to `B`."]
 structure ContinuousMonoidHom extends A →* B, C(A, B)
 

--- a/Mathlib/Topology/Algebra/ContinuousMonoidHom.lean
+++ b/Mathlib/Topology/Algebra/ContinuousMonoidHom.lean
@@ -111,12 +111,13 @@ theorem ext {f g : ContinuousMonoidHom A B} (h : ∀ x, f x = g x) : f = g :=
 theorem toContinuousMap_injective : Injective (toContinuousMap : _ → C(A, B)) := fun f g h =>
   ext <| by convert DFunLike.ext_iff.1 h
 
--- Porting note: Removed simps because given definition is not a constructor application
-/-- Construct a `ContinuousMonoidHom` from a `Continuous` `MonoidHom`. -/
-@[to_additive (attr := deprecated (since := "2024-10-08"))
-  "Construct a `ContinuousAddMonoidHom` from a `Continuous` `AddMonoidHom`."]
-def mk' (f : A →* B) (hf : Continuous f) : ContinuousMonoidHom A B :=
-  { f with continuous_toFun := (hf : Continuous f.toFun)}
+@[deprecated (since := "2024-10-08")] protected alias mk' := mk
+
+@[deprecated (since := "2024-10-08")]
+protected alias _root_.ContinuousAddMonoidHom.mk' := ContinuousAddMonoidHom.mk
+
+set_option linter.existingAttributeWarning false in
+attribute [to_additive existing] ContinuousMonoidHom.mk'
 
 /-- Composition of two continuous homomorphisms. -/
 @[to_additive (attr := simps!) "Composition of two continuous homomorphisms."]

--- a/Mathlib/Topology/Algebra/PontryaginDual.lean
+++ b/Mathlib/Topology/Algebra/PontryaginDual.lean
@@ -82,10 +82,13 @@ namespace PontryaginDual
 open ContinuousMonoidHom
 
 instance : FunLike (PontryaginDual A) A Circle :=
-  ContinuousMonoidHom.funLike
+  ContinuousMonoidHom.instFunLike
 
-noncomputable instance : ContinuousMonoidHomClass (PontryaginDual A) A Circle :=
-  ContinuousMonoidHom.ContinuousMonoidHomClass
+noncomputable instance instContinuousMapClass : ContinuousMapClass (PontryaginDual A) A Circle :=
+  ContinuousMonoidHom.instContinuousMapClass
+
+noncomputable instance instMonoidHomClass : MonoidHomClass (PontryaginDual A) A Circle :=
+  ContinuousMonoidHom.instMonoidHomClass
 
 /-- `PontryaginDual` is a contravariant functor. -/
 noncomputable def map (f : ContinuousMonoidHom A B) :


### PR DESCRIPTION
Use `[ContinuousMapClass ..] [MonoidHomClass ..]` instead. Also deprecate `mk'` since it's defeq `mk`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
