### PR TITLE
[Merged by Bors] - feat: generalize `LinearMap.exists_rightInverse_of_surjective` to projective modules

### DIFF
--- a/Mathlib/Algebra/Module/Projective.lean
+++ b/Mathlib/Algebra/Module/Projective.lean
@@ -91,7 +91,7 @@ theorem projective_def' :
 
 /-- A projective R-module has the property that maps from it lift along surjections. -/
 theorem projective_lifting_property [h : Projective R P] (f : M →ₗ[R] N) (g : P →ₗ[R] N)
-    (hf : Function.Surjective f) : ∃ h : P →ₗ[R] M, f.comp h = g := by
+    (hf : Function.Surjective f) : ∃ h : P →ₗ[R] M, f ∘ₗ h = g := by
   /-
     Here's the first step of the proof.
     Recall that `X →₀ R` is Lean's way of talking about the free `R`-module
@@ -109,6 +109,10 @@ theorem projective_lifting_property [h : Projective R P] (f : M →ₗ[R] N) (g 
   ext p
   conv_rhs => rw [← hs p]
   simp [φ, Finsupp.linearCombination_apply, Function.surjInv_eq hf, map_finsupp_sum]
+
+theorem _root_.LinearMap.exists_rightInverse_of_surjective [Projective R P]
+    (f : M →ₗ[R] P) (hf_surj : range f = ⊤) : ∃ g : P →ₗ[R] M, f ∘ₗ g = LinearMap.id :=
+  projective_lifting_property f (.id : P →ₗ[R] P) (LinearMap.range_eq_top.1 hf_surj)
 
 /-- A module which satisfies the universal property is projective: If all surjections of
 `R`-modules `(P →₀ R) →ₗ[R] P` have `R`-linear left inverse maps, then `P` is

--- a/Mathlib/LinearAlgebra/Basis/VectorSpace.lean
+++ b/Mathlib/LinearAlgebra/Basis/VectorSpace.lean
@@ -266,15 +266,6 @@ theorem Submodule.exists_isCompl (p : Submodule K V) : ∃ q : Submodule K V, Is
 instance Submodule.complementedLattice : ComplementedLattice (Submodule K V) :=
   ⟨Submodule.exists_isCompl⟩
 
-theorem LinearMap.exists_rightInverse_of_surjective (f : V →ₗ[K] V') (hf_surj : range f = ⊤) :
-    ∃ g : V' →ₗ[K] V, f.comp g = LinearMap.id := by
-  let C := Basis.ofVectorSpaceIndex K V'
-  let hC := Basis.ofVectorSpace K V'
-  haveI : Inhabited V := ⟨0⟩
-  refine ⟨(hC.constr ℕ : _ → _) (C.restrict (invFun f)), hC.ext fun c => ?_⟩
-  rw [LinearMap.comp_apply, hC.constr_basis]
-  simp [hC, rightInverse_invFun (LinearMap.range_eq_top.1 hf_surj) c]
-
 /-- Any linear map `f : p →ₗ[K] V'` defined on a subspace `p` can be extended to the whole
 space. -/
 theorem LinearMap.exists_extend {p : Submodule K V} (f : p →ₗ[K] V') :

--- a/Mathlib/LinearAlgebra/Dimension/LinearMap.lean
+++ b/Mathlib/LinearAlgebra/Dimension/LinearMap.lean
@@ -3,6 +3,7 @@ Copyright (c) 2019 Johannes Hölzl. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johannes Hölzl
 -/
+import Mathlib.Algebra.Module.Projective
 import Mathlib.LinearAlgebra.Dimension.DivisionRing
 import Mathlib.LinearAlgebra.Dimension.FreeAndStrongRankCondition
 

--- a/Mathlib/LinearAlgebra/FiniteDimensional/Defs.lean
+++ b/Mathlib/LinearAlgebra/FiniteDimensional/Defs.lean
@@ -3,6 +3,7 @@ Copyright (c) 2019 Chris Hughes. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Chris Hughes
 -/
+import Mathlib.Algebra.Module.Projective
 import Mathlib.FieldTheory.Finiteness
 
 /-!

--- a/Mathlib/LinearAlgebra/FreeModule/Basic.lean
+++ b/Mathlib/LinearAlgebra/FreeModule/Basic.lean
@@ -181,3 +181,18 @@ instance tensor : Module.Free S (M ⊗[R] N) :=
 end CommSemiring
 
 end Module.Free
+
+namespace LinearMap
+
+variable [Semiring R] [AddCommMonoid M] [AddCommMonoid N] [Module R M] [Module R N]
+variable [Module.Free R N]
+
+theorem exists_rightInverse_of_surjective (f : M →ₗ[R] N) (hf_surj : range f = ⊤) :
+    ∃ g : N →ₗ[R] M, f.comp g = LinearMap.id := by
+  obtain ⟨I, B⟩ := Module.Free.exists_basis (R := R) (M := N)
+  let hC := B.reindexRange
+  refine ⟨hC.constr ℕ ((Set.range B).restrict (Function.invFun f)), hC.ext fun c => ?_⟩
+  rw [LinearMap.comp_apply, hC.constr_basis]
+  simp [hC, Function.rightInverse_invFun (LinearMap.range_eq_top.1 hf_surj) c]
+
+end LinearMap

--- a/Mathlib/LinearAlgebra/FreeModule/Basic.lean
+++ b/Mathlib/LinearAlgebra/FreeModule/Basic.lean
@@ -183,9 +183,10 @@ end CommSemiring
 end Module.Free
 
 namespace LinearMap
-
 variable [Semiring R] [AddCommMonoid M] [AddCommMonoid N] [Module R M] [Module R N]
 variable [Module.Free R N]
+
+variable {R M N}
 
 theorem exists_rightInverse_of_surjective (f : M →ₗ[R] N) (hf_surj : range f = ⊤) :
     ∃ g : N →ₗ[R] M, f.comp g = LinearMap.id := by

--- a/Mathlib/LinearAlgebra/FreeModule/Basic.lean
+++ b/Mathlib/LinearAlgebra/FreeModule/Basic.lean
@@ -181,19 +181,3 @@ instance tensor : Module.Free S (M ⊗[R] N) :=
 end CommSemiring
 
 end Module.Free
-
-namespace LinearMap
-variable [Semiring R] [AddCommMonoid M] [AddCommMonoid N] [Module R M] [Module R N]
-variable [Module.Free R N]
-
-variable {R M N}
-
-theorem exists_rightInverse_of_surjective (f : M →ₗ[R] N) (hf_surj : range f = ⊤) :
-    ∃ g : N →ₗ[R] M, f.comp g = LinearMap.id := by
-  obtain ⟨I, B⟩ := Module.Free.exists_basis (R := R) (M := N)
-  let hC := B.reindexRange
-  refine ⟨hC.constr ℕ ((Set.range B).restrict (Function.invFun f)), hC.ext fun c => ?_⟩
-  rw [LinearMap.comp_apply, hC.constr_basis]
-  simp [hC, Function.rightInverse_invFun (LinearMap.range_eq_top.1 hf_surj) c]
-
-end LinearMap

--- a/Mathlib/Topology/Algebra/SeparationQuotient.lean
+++ b/Mathlib/Topology/Algebra/SeparationQuotient.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Yury Kudryashov
 -/
 import Mathlib.LinearAlgebra.Basis.VectorSpace
+import Mathlib.Algebra.Module.Projective
 import Mathlib.Topology.Algebra.Module.Basic
 import Mathlib.Topology.Maps.OpenQuotient
 


### PR DESCRIPTION

Previously it only held in vector spaces.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
