### PR TITLE
[Merged by Bors] - refactor: logic of `Mathlib.Tactic.LinearCombination.elabLinearCombination`

### DIFF
--- a/Mathlib/Analysis/Convex/Side.lean
+++ b/Mathlib/Analysis/Convex/Side.lean
@@ -582,7 +582,6 @@ theorem wOppSide_iff_exists_wbtw {s : AffineSubspace R P} {x y : P} :
           (r₂ / (r₁ + r₂)) • (p₂ -ᵥ p₁) := by
         rw [← neg_vsub_eq_vsub_rev p₂ y]
         linear_combination (norm := match_scalars <;> field_simp) congr((r₁ + r₂)⁻¹ • $h)
-        ring
       rw [lineMap_apply, ← vsub_vadd x p₁, ← vsub_vadd y p₂, vsub_vadd_eq_vsub_sub, vadd_vsub_assoc,
         ← vadd_assoc, vadd_eq_add, this]
       exact s.smul_vsub_vadd_mem (r₂ / (r₁ + r₂)) hp₂ hp₁ hp₁

--- a/Mathlib/Tactic/LinearCombination.lean
+++ b/Mathlib/Tactic/LinearCombination.lean
@@ -115,24 +115,28 @@ def elabLinearCombination (tk : Syntax)
         from the term"
       `(Eq.refl 0)
     | .proof p => pure p
-  let norm := norm?.getD (Unhygienic.run <| withRef tk `(tactic| ring1))
-  let lem : Ident ← mkIdent <$> do
-    try
-      -- if we are in a "true" ring, with well-behaved negation, it is better to present the
-      -- normalization tactic with a goal of the form `[stuff] = 0`, because this gives more useful
-      -- error messages on failure
-      let _ ← synthInstance (← mkAppM ``Neg #[ty])
-      pure ``eq_of_sub
-    catch _ =>
-      -- but otherwise (for example over `ℕ` or `ℝ≥0`) we can solve the problem by presenting the
-      -- normalization tactic with a goal of the form `[stuff] = [stuff]`
-      pure ``eq_of_add
-  Term.withoutErrToSorry <| Tactic.evalTactic <| ← withFreshMacroScope <|
-  match exp? with
-  | some n =>
-    if n.getNat = 1 then `(tactic| (refine $lem $p ?a; case' a => $norm:tactic))
-    else `(tactic| (refine eq_of_add_pow $n $p ?a; case' a => $norm:tactic))
-  | _ => `(tactic| (refine $lem $p ?a; case' a => $norm:tactic))
+  -- build the term for the central `refine` in `linear_combination`
+  let p' ← do
+    match exp? with
+    | some n =>
+      if n.getNat = 1 then
+        `($(mkIdent ``eq_of_add) $p ?a)
+      else
+        `(eq_of_add_pow $n $p ?a)
+    | _ => `($(mkIdent ``eq_of_add) $p ?a)
+  -- run the central `refine` in `linear_combination`
+  Term.withoutErrToSorry <| Tactic.refineCore p' `refine false
+  -- if we are in a "true" ring, with well-behaved negation, we rearrange from the form
+  -- `[stuff] = [stuff]` to the form `[stuff] = 0`,
+  -- because this gives more useful error messages on failure
+  try
+    Tactic.liftMetaTactic fun g ↦ g.applyConst ``eq_rearrange
+  catch _ => pure ()
+  -- now run the normalization tactic provided, or the default normalization if none is provided
+  match norm? with
+  | some norm => Tactic.evalTactic norm
+  | none => withRef tk <| Tactic.liftMetaFinishingTactic <|
+    fun g ↦ AtomM.run .instances <| Ring.proveEq g
 
 /--
 The `(norm := $tac)` syntax says to use `tac` as a normalization postprocessor for

--- a/Mathlib/Tactic/LinearCombination.lean
+++ b/Mathlib/Tactic/LinearCombination.lean
@@ -120,10 +120,10 @@ def elabLinearCombination (tk : Syntax)
     match exp? with
     | some n =>
       if n.getNat = 1 then
-        `(``eq_of_add $p ?a)
+        `(eq_of_add $p ?a)
       else
         `(eq_of_add_pow $n $p ?a)
-    | _ => `(``eq_of_add $p ?a)
+    | _ => `(eq_of_add $p ?a)
   -- run the central `refine` in `linear_combination`
   Term.withoutErrToSorry <| Tactic.refineCore p' `refine false
   -- if we are in a "true" ring, with well-behaved negation, we rearrange from the form

--- a/Mathlib/Tactic/LinearCombination.lean
+++ b/Mathlib/Tactic/LinearCombination.lean
@@ -120,10 +120,10 @@ def elabLinearCombination (tk : Syntax)
     match exp? with
     | some n =>
       if n.getNat = 1 then
-        `($(mkIdent ``eq_of_add) $p ?a)
+        `(``eq_of_add $p ?a)
       else
         `(eq_of_add_pow $n $p ?a)
-    | _ => `($(mkIdent ``eq_of_add) $p ?a)
+    | _ => `(``eq_of_add $p ?a)
   -- run the central `refine` in `linear_combination`
   Term.withoutErrToSorry <| Tactic.refineCore p' `refine false
   -- if we are in a "true" ring, with well-behaved negation, we rearrange from the form

--- a/Mathlib/Tactic/LinearCombination.lean
+++ b/Mathlib/Tactic/LinearCombination.lean
@@ -129,9 +129,7 @@ def elabLinearCombination (tk : Syntax)
   -- if we are in a "true" ring, with well-behaved negation, we rearrange from the form
   -- `[stuff] = [stuff]` to the form `[stuff] = 0`,
   -- because this gives more useful error messages on failure
-  try
-    Tactic.liftMetaTactic fun g ↦ g.applyConst ``eq_rearrange
-  catch _ => pure ()
+  let _ ← Tactic.tryTactic <| Tactic.liftMetaTactic fun g ↦ g.applyConst ``eq_rearrange
   -- now run the normalization tactic provided, or the default normalization if none is provided
   match norm? with
   | some norm => Tactic.evalTactic norm

--- a/Mathlib/Tactic/LinearCombination.lean
+++ b/Mathlib/Tactic/LinearCombination.lean
@@ -130,9 +130,12 @@ def elabLinearCombination (tk : Syntax)
   -- `[stuff] = [stuff]` to the form `[stuff] = 0`,
   -- because this gives more useful error messages on failure
   let _ ← Tactic.tryTactic <| Tactic.liftMetaTactic fun g ↦ g.applyConst ``eq_rearrange
-  -- now run the normalization tactic provided, or the default normalization if none is provided
   match norm? with
+  -- now run the normalization tactic provided
   | some norm => Tactic.evalTactic norm
+  -- or the default normalization tactic (the internals of `ring1`) if none is provided
+  -- (but we use `.instances` transparency, which is arguably more robust in algebraic settings than
+  -- the choice `.reducible` made in `ring1`)
   | none => withRef tk <| Tactic.liftMetaFinishingTactic <|
     fun g ↦ AtomM.run .instances <| Ring.proveEq g
 

--- a/Mathlib/Tactic/LinearCombination/Lemmas.lean
+++ b/Mathlib/Tactic/LinearCombination/Lemmas.lean
@@ -22,12 +22,11 @@ theorem pf_mul_c [Mul α] (p : a = b) (c : α) : a * c = b * c := p ▸ rfl
 theorem c_mul_pf [Mul α] (p : b = c) (a : α) : a * b = a * c := p ▸ rfl
 theorem pf_div_c [Div α] (p : a = b) (c : α) : a / c = b / c := p ▸ rfl
 
-theorem eq_of_sub [AddGroup α] (p : (a:α) = b) (H : (a' - b') - (a - b) = 0) : a' = b' := by
-  rw [← sub_eq_zero] at p ⊢; rwa [sub_eq_zero, p] at H
-
 theorem eq_of_add [Add α] [IsRightCancelAdd α] (p : (a:α) = b) (H : a' + b = b' + a) : a' = b' := by
   rw [p] at H
   exact add_right_cancel H
+
+alias ⟨eq_rearrange, _⟩ := sub_eq_zero
 
 theorem eq_of_add_pow [Ring α] [NoZeroDivisors α] (n : ℕ) (p : (a:α) = b)
     (H : (a' - b')^n - (a - b) = 0) : a' = b' := by

--- a/test/linear_combination.lean
+++ b/test/linear_combination.lean
@@ -179,7 +179,8 @@ example (a b : ℝ) (ha : 2 * a = 4) (hab : 2 * b = a - b) : b = 2 / 3 := by
   linear_combination (norm := ring_nf) 1 / 6 * ha + 1 / 3 * hab
 
 example (x y : ℤ) (h1 : 3 * x + 2 * y = 10) : 3 * x + 2 * y = 10 := by
-  linear_combination (norm := simp) h1
+  linear_combination (norm := skip) h1
+  ring1
 
 /-! ### Cases that have linear_combination skip normalization -/
 
@@ -189,7 +190,7 @@ example (a b : ℝ) (ha : 2 * a = 4) (hab : 2 * b = a - b) : b = 2 / 3 := by
 
 example (x y : ℤ) (h1 : x = -3) (_h2 : y = 10) : 2 * x = -6 := by
   linear_combination (norm := skip) 2 * h1
-  simp (config := {decide := true})
+  ring1
 
 /-! ### Cases without any arguments provided -/
 
@@ -202,7 +203,7 @@ example (x : ℤ) : x ^ 2 = x ^ 2 := by linear_combination
 -- this interacts as expected with options
 example {x y z w : ℤ} (_h₁ : 3 * x = 4 + y) (_h₂ : x + 2 * y = 1) : z + w = w + z := by
   linear_combination (norm := skip)
-  guard_target = z + w - (w + z) - (0 - 0) = 0
+  guard_target = z + w + 0 - (w + z + 0) = 0
   simp [add_comm]
 
 example {x y z w : ℤ} (_h₁ : 3 * x = 4 + y) (_h₂ : x + 2 * y = 1) : z + w = w + z := by


### PR DESCRIPTION
Reorganize the sequence of steps in `Mathlib.Tactic.LinearCombination.elabLinearCombination`, the main `linear_combination` method.

The new code is more convenient to generalize to inequalities (see #16841), and (I believe) it is mathematically equivalent to the old code when the discharger tactic is the default (`ring`).  (In particular, the goal sent to the discharger should be the same as before, modulo associativity and commutativity.). A few adjustments are needed in use cases with a non-default discharger.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
