### PR TITLE
[Merged by Bors] - chore: adaptations for lean4#5542

### DIFF
--- a/Mathlib/Algebra/Category/BialgebraCat/Basic.lean
+++ b/Mathlib/Algebra/Category/BialgebraCat/Basic.lean
@@ -59,7 +59,7 @@ lemma of_counit {X : Type v} [Ring X] [Bialgebra R X] :
 /-- A type alias for `BialgHom` to avoid confusion between the categorical and
 algebraic spellings of composition. -/
 @[ext]
-structure Hom (V W : BialgebraCat.{v} R) :=
+structure Hom (V W : BialgebraCat.{v} R) where
   /-- The underlying `BialgHom` -/
   toBialgHom : V →ₐc[R] W
 

--- a/Mathlib/Algebra/Category/CoalgebraCat/Basic.lean
+++ b/Mathlib/Algebra/Category/CoalgebraCat/Basic.lean
@@ -62,7 +62,7 @@ lemma of_counit {X : Type v} [AddCommGroup X] [Module R X] [Coalgebra R X] :
 /-- A type alias for `CoalgHom` to avoid confusion between the categorical and
 algebraic spellings of composition. -/
 @[ext]
-structure Hom (V W : CoalgebraCat.{v} R) :=
+structure Hom (V W : CoalgebraCat.{v} R) where
   /-- The underlying `CoalgHom` -/
   toCoalgHom : V →ₗc[R] W
 

--- a/Mathlib/Algebra/Category/HopfAlgebraCat/Basic.lean
+++ b/Mathlib/Algebra/Category/HopfAlgebraCat/Basic.lean
@@ -58,7 +58,7 @@ lemma of_counit {X : Type v} [Ring X] [HopfAlgebra R X] :
 /-- A type alias for `BialgHom` to avoid confusion between the categorical and
 algebraic spellings of composition. -/
 @[ext]
-structure Hom (V W : HopfAlgebraCat.{v} R) :=
+structure Hom (V W : HopfAlgebraCat.{v} R) where
   /-- The underlying `BialgHom`. -/
   toBialgHom : V →ₐc[R] W
 

--- a/Mathlib/Algebra/Homology/ShortComplex/SnakeLemma.lean
+++ b/Mathlib/Algebra/Homology/ShortComplex/SnakeLemma.lean
@@ -381,7 +381,7 @@ variable (S₁ S₂ S₃ : SnakeInput C)
 /-- A morphism of snake inputs involve four morphisms of short complexes
 which make the obvious diagram commute. -/
 @[ext]
-structure Hom :=
+structure Hom where
   /-- a morphism between the zeroth lines -/
   f₀ : S₁.L₀ ⟶ S₂.L₀
   /-- a morphism between the first lines -/

--- a/Mathlib/Algebra/Lie/Killing.lean
+++ b/Mathlib/Algebra/Lie/Killing.lean
@@ -46,7 +46,7 @@ namespace LieAlgebra
 
 NB: This is not standard terminology (the literature does not seem to name Lie algebras with this
 property). -/
-class IsKilling : Prop :=
+class IsKilling : Prop where
   /-- We say a Lie algebra is Killing if its Killing form is non-singular. -/
   killingCompl_top_eq_bot : LieIdeal.killingCompl R L ⊤ = ⊥
 

--- a/Mathlib/Algebra/Lie/Weights/Basic.lean
+++ b/Mathlib/Algebra/Lie/Weights/Basic.lean
@@ -726,7 +726,7 @@ noncomputable instance Weight.instFintype [NoZeroSMulDivisors R M] [IsNoetherian
 
 /-- A Lie module `M` of a Lie algebra `L` is triangularizable if the endomorhpism of `M` defined by
 any `x : L` is triangularizable. -/
-class IsTriangularizable : Prop :=
+class IsTriangularizable : Prop where
   iSup_eq_top : ∀ x, ⨆ φ, ⨆ k, (toEnd R L M x).genEigenspace φ k = ⊤
 
 instance (L' : LieSubalgebra R L) [IsTriangularizable R L M] : IsTriangularizable R L' M where

--- a/Mathlib/Algebra/Lie/Weights/Linear.lean
+++ b/Mathlib/Algebra/Lie/Weights/Linear.lean
@@ -48,7 +48,7 @@ namespace LieModule
 
 /-- A typeclass encoding the fact that a given Lie module has linear weights, vanishing on the
 derived ideal. -/
-class LinearWeights [LieAlgebra.IsNilpotent R L] : Prop :=
+class LinearWeights [LieAlgebra.IsNilpotent R L] : Prop where
   map_add : ∀ χ : L → R, genWeightSpace M χ ≠ ⊥ → ∀ x y, χ (x + y) = χ x + χ y
   map_smul : ∀ χ : L → R, genWeightSpace M χ ≠ ⊥ → ∀ (t : R) x, χ (t • x) = t • χ x
   map_lie : ∀ χ : L → R, genWeightSpace M χ ≠ ⊥ → ∀ x y : L, χ ⁅x, y⁆ = 0

--- a/Mathlib/Algebra/Quandle.lean
+++ b/Mathlib/Algebra/Quandle.lean
@@ -100,9 +100,9 @@ class Shelf (α : Type u) where
 A *unital shelf* is a shelf equipped with an element `1` such that, for all elements `x`,
 we have both `x ◃ 1` and `1 ◃ x` equal `x`.
 -/
-class UnitalShelf (α : Type u) extends Shelf α, One α :=
-(one_act : ∀ a : α, act 1 a = a)
-(act_one : ∀ a : α, act a 1 = a)
+class UnitalShelf (α : Type u) extends Shelf α, One α where
+  one_act : ∀ a : α, act 1 a = a
+  act_one : ∀ a : α, act a 1 = a
 
 /-- The type of homomorphisms between shelves.
 This is also the notion of rack and quandle homomorphisms.

--- a/Mathlib/Analysis/Distribution/SchwartzSpace.lean
+++ b/Mathlib/Analysis/Distribution/SchwartzSpace.lean
@@ -579,7 +579,7 @@ open MeasureTheory Module
 
 /-- A measure `μ` has temperate growth if there is an `n : ℕ` such that `(1 + ‖x‖) ^ (- n)` is
 `μ`-integrable. -/
-class _root_.MeasureTheory.Measure.HasTemperateGrowth (μ : Measure D) : Prop :=
+class _root_.MeasureTheory.Measure.HasTemperateGrowth (μ : Measure D) : Prop where
   exists_integrable : ∃ (n : ℕ), Integrable (fun x ↦ (1 + ‖x‖) ^ (- (n : ℝ))) μ
 
 open Classical in

--- a/Mathlib/Analysis/NormedSpace/OperatorNorm/Mul.lean
+++ b/Mathlib/Analysis/NormedSpace/OperatorNorm/Mul.lean
@@ -121,7 +121,7 @@ examples. Any algebra with an approximate identity (e.g., $$L^1$$) is also regul
 
 This is a useful class because it gives rise to a nice norm on the unitization; in particular it is
 a C⋆-norm when the norm on `A` is a C⋆-norm. -/
-class _root_.RegularNormedAlgebra : Prop :=
+class _root_.RegularNormedAlgebra : Prop where
   /-- The left regular representation of the algebra on itself is an isometry. -/
   isometry_mul' : Isometry (mul 𝕜 𝕜')
 

--- a/Mathlib/Analysis/RCLike/Basic.lean
+++ b/Mathlib/Analysis/RCLike/Basic.lean
@@ -1086,7 +1086,7 @@ section
 /-- A mixin over a normed field, saying that the norm field structure is the same as `ℝ` or `ℂ`.
 To endow such a field with a compatible `RCLike` structure in a proof, use
 `letI := IsRCLikeNormedField.rclike 𝕜`.-/
-class IsRCLikeNormedField (𝕜 : Type*) [hk : NormedField 𝕜] : Prop :=
+class IsRCLikeNormedField (𝕜 : Type*) [hk : NormedField 𝕜] : Prop where
   out : ∃ h : RCLike 𝕜, hk = h.toNormedField
 
 instance (priority := 100) (𝕜 : Type*) [h : RCLike 𝕜] : IsRCLikeNormedField 𝕜 := ⟨⟨h, rfl⟩⟩

--- a/Mathlib/Analysis/SpecificLimits/Normed.lean
+++ b/Mathlib/Analysis/SpecificLimits/Normed.lean
@@ -252,7 +252,7 @@ alias tendsto_pow_atTop_nhds_0_of_abs_lt_1 := tendsto_pow_atTop_nhds_zero_of_abs
 /-- A normed ring has summable geometric series if, for all `ξ` of norm `< 1`, the geometric series
 `∑ ξ ^ n` converges. This holds both in complete normed rings and in normed fields, providing a
 convenient abstraction of these two classes to avoid repeating the same proofs. -/
-class HasSummableGeomSeries (K : Type*) [NormedRing K] : Prop :=
+class HasSummableGeomSeries (K : Type*) [NormedRing K] : Prop where
   summable_geometric_of_norm_lt_one : ∀ (ξ : K), ‖ξ‖ < 1 → Summable (fun n ↦ ξ ^ n)
 
 lemma summable_geometric_of_norm_lt_one {K : Type*} [NormedRing K] [HasSummableGeomSeries K]

--- a/Mathlib/CategoryTheory/GradedObject/Trifunctor.lean
+++ b/Mathlib/CategoryTheory/GradedObject/Trifunctor.lean
@@ -259,7 +259,7 @@ variable (F₁₂ : C₁ ⥤ C₂ ⥤ C₁₂) (G : C₁₂ ⥤ C₃ ⥤ C₄)
 /-- Given a map `r : I₁ × I₂ × I₃ → J`, a `BifunctorComp₁₂IndexData r` consists of the data
 of a type `I₁₂`, maps `p : I₁ × I₂ → I₁₂` and `q : I₁₂ × I₃ → J`, such that `r` is obtained
 by composition of `p` and `q`. -/
-structure BifunctorComp₁₂IndexData :=
+structure BifunctorComp₁₂IndexData where
   /-- an auxiliary type -/
   I₁₂ : Type*
   /-- a map `I₁ × I₂ → I₁₂` -/
@@ -439,7 +439,7 @@ variable (F : C₁ ⥤ C₂₃ ⥤ C₄) (G₂₃ : C₂ ⥤ C₃ ⥤ C₂₃)
 /-- Given a map `r : I₁ × I₂ × I₃ → J`, a `BifunctorComp₂₃IndexData r` consists of the data
 of a type `I₂₃`, maps `p : I₂ × I₃ → I₂₃` and `q : I₁ × I₂₃ → J`, such that `r` is obtained
 by composition of `p` and `q`. -/
-structure BifunctorComp₂₃IndexData :=
+structure BifunctorComp₂₃IndexData where
   /-- an auxiliary type -/
   I₂₃ : Type*
   /-- a map `I₂ × I₃ → I₂₃` -/

--- a/Mathlib/CategoryTheory/Localization/LocalizerMorphism.lean
+++ b/Mathlib/CategoryTheory/Localization/LocalizerMorphism.lean
@@ -128,7 +128,7 @@ lemma isEquivalence_iff : G.IsEquivalence ↔ G'.IsEquivalence :=
 end
 
 /-- Condition that a `LocalizerMorphism` induces an equivalence on the localized categories -/
-class IsLocalizedEquivalence : Prop :=
+class IsLocalizedEquivalence : Prop where
   /-- the induced functor on the constructed localized categories is an equivalence -/
   isEquivalence : (Φ.localizedFunctor W₁.Q W₂.Q).IsEquivalence
 

--- a/Mathlib/CategoryTheory/MorphismProperty/Composition.lean
+++ b/Mathlib/CategoryTheory/MorphismProperty/Composition.lean
@@ -24,7 +24,7 @@ namespace MorphismProperty
 variable {C : Type u} [Category.{v} C] {D : Type u'} [Category.{v'} D]
 
 /-- Typeclass expressing that a morphism property contain identities. -/
-class ContainsIdentities (W : MorphismProperty C) : Prop :=
+class ContainsIdentities (W : MorphismProperty C) : Prop where
   /-- for all `X : C`, the identity of `X` satisfies the morphism property -/
   id_mem : ∀ (X : C), W (𝟙 X)
 
@@ -63,7 +63,7 @@ instance Pi.containsIdentities {J : Type w} {C : J → Type u}
 
 /-- A morphism property satisfies `IsStableUnderComposition` if the composition of
 two such morphisms still falls in the class. -/
-class IsStableUnderComposition (P : MorphismProperty C) : Prop :=
+class IsStableUnderComposition (P : MorphismProperty C) : Prop where
   comp_mem {X Y Z} (f : X ⟶ Y) (g : Y ⟶ Z) : P f → P g → P (f ≫ g)
 
 lemma comp_mem (W : MorphismProperty C) [W.IsStableUnderComposition]
@@ -129,7 +129,7 @@ end naturalityProperty
 /-- A morphism property is multiplicative if it contains identities and is stable by
 composition. -/
 class IsMultiplicative (W : MorphismProperty C)
-    extends W.ContainsIdentities, W.IsStableUnderComposition : Prop :=
+    extends W.ContainsIdentities, W.IsStableUnderComposition : Prop
 
 namespace IsMultiplicative
 

--- a/Mathlib/CategoryTheory/MorphismProperty/Limits.lean
+++ b/Mathlib/CategoryTheory/MorphismProperty/Limits.lean
@@ -203,7 +203,7 @@ lemma IsStableUnderProductsOfShape.mk (J : Type*)
   simp
 
 /-- The condition that a property of morphisms is stable by finite products. -/
-class IsStableUnderFiniteProducts : Prop :=
+class IsStableUnderFiniteProducts : Prop where
   isStableUnderProductsOfShape (J : Type) [Finite J] : W.IsStableUnderProductsOfShape J
 
 lemma isStableUnderProductsOfShape_of_isStableUnderFiniteProducts

--- a/Mathlib/CategoryTheory/Shift/CommShift.lean
+++ b/Mathlib/CategoryTheory/Shift/CommShift.lean
@@ -246,7 +246,7 @@ variable {C D E J : Type*} [Category C] [Category D] [Category E] [Category J]
 /-- If `τ : F₁ ⟶ F₂` is a natural transformation between two functors
 which commute with a shift by an additive monoid `A`, this typeclass
 asserts a compatibility of `τ` with these shifts. -/
-class CommShift : Prop :=
+class CommShift : Prop where
   comm' (a : A) : (F₁.commShiftIso a).hom ≫ whiskerRight τ _ =
     whiskerLeft _ τ ≫ (F₂.commShiftIso a).hom
 

--- a/Mathlib/CategoryTheory/Shift/Localization.lean
+++ b/Mathlib/CategoryTheory/Shift/Localization.lean
@@ -32,7 +32,7 @@ namespace MorphismProperty
 /-- A morphism property `W` on a category `C` is compatible with the shift by a
 monoid `A` when for all `a : A`, a morphism `f` belongs to `W`
 if and only if `f⟦a⟧'` does. -/
-class IsCompatibleWithShift : Prop :=
+class IsCompatibleWithShift : Prop where
   /-- the condition that for all `a : A`, the morphism property `W` is not changed when
   we take its inverse image by the shift functor by `a` -/
   condition : ∀ (a : A), W.inverseImage (shiftFunctor C a) = W

--- a/Mathlib/CategoryTheory/Shift/Quotient.lean
+++ b/Mathlib/CategoryTheory/Shift/Quotient.lean
@@ -32,7 +32,7 @@ namespace HomRel
 
 /-- A relation on morphisms is compatible with the shift by a monoid `A` when the
 relation if preserved by the shift. -/
-class IsCompatibleWithShift : Prop :=
+class IsCompatibleWithShift : Prop where
   /-- the condition that the relation is preserved by the shift -/
   condition : ∀ (a : A) ⦃X Y : C⦄ (f g : X ⟶ Y), r f g → r (f⟦a⟧') (g⟦a⟧')
 

--- a/Mathlib/Combinatorics/Colex.lean
+++ b/Mathlib/Combinatorics/Colex.lean
@@ -65,7 +65,7 @@ namespace Finset
 /-- Type synonym of `Finset α` equipped with the colexicographic order rather than the inclusion
 order. -/
 @[ext]
-structure Colex (α) :=
+structure Colex (α) where
   /-- `toColex` is the "identity" function between `Finset α` and `Finset.Colex α`. -/
   toColex ::
   /-- `ofColex` is the "identity" function between `Finset.Colex α` and `Finset α`. -/

--- a/Mathlib/Combinatorics/SimpleGraph/Hamiltonian.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Hamiltonian.lean
@@ -66,7 +66,7 @@ lemma IsHamiltonian.length_eq (hp : p.IsHamiltonian) : p.length = Fintype.card Î
 end
 
 /-- A hamiltonian cycle is a cycle that visits every vertex once. -/
-structure IsHamiltonianCycle (p : G.Walk a a) extends p.IsCycle : Prop :=
+structure IsHamiltonianCycle (p : G.Walk a a) extends p.IsCycle : Prop where
   isHamiltonian_tail : p.tail.IsHamiltonian
 
 variable {p : G.Walk a a}

--- a/Mathlib/Data/FunLike/Basic.lean
+++ b/Mathlib/Data/FunLike/Basic.lean
@@ -17,7 +17,7 @@ There is the "D"ependent version `DFunLike` and the non-dependent version `FunLi
 
 A typical type of morphisms should be declared as:
 ```
-structure MyHom (A B : Type*) [MyClass A] [MyClass B] :=
+structure MyHom (A B : Type*) [MyClass A] [MyClass B] where
   (toFun : A → B)
   (map_op' : ∀ (x y : A), toFun (MyClass.op x y) = MyClass.op (toFun x) (toFun y))
 
@@ -79,7 +79,7 @@ The second step is to add instances of your new `MyHomClass` for all types exten
 Typically, you can just declare a new class analogous to `MyHomClass`:
 
 ```
-structure CoolerHom (A B : Type*) [CoolClass A] [CoolClass B] extends MyHom A B :=
+structure CoolerHom (A B : Type*) [CoolClass A] [CoolClass B] extends MyHom A B where
   (map_cool' : toFun CoolClass.cool = CoolClass.cool)
 
 class CoolerHomClass (F : Type*) (A B : outParam Type*) [CoolClass A] [CoolClass B]

--- a/Mathlib/Data/FunLike/Embedding.lean
+++ b/Mathlib/Data/FunLike/Embedding.lean
@@ -14,7 +14,7 @@ This typeclass is primarily for use by embeddings such as `RelEmbedding`.
 
 A typical type of embeddings should be declared as:
 ```
-structure MyEmbedding (A B : Type*) [MyClass A] [MyClass B] :=
+structure MyEmbedding (A B : Type*) [MyClass A] [MyClass B] where
   (toFun : A → B)
   (injective' : Function.Injective toFun)
   (map_op' : ∀ (x y : A), toFun (MyClass.op x y) = MyClass.op (toFun x) (toFun y))
@@ -58,8 +58,8 @@ Continuing the example above:
 You should extend this class when you extend `MyEmbedding`. -/
 class MyEmbeddingClass (F : Type*) (A B : outParam Type*) [MyClass A] [MyClass B]
     [FunLike F A B]
-    extends EmbeddingLike F A B :=
-  (map_op : ∀ (f : F) (x y : A), f (MyClass.op x y) = MyClass.op (f x) (f y))
+    extends EmbeddingLike F A B where
+  map_op : ∀ (f : F) (x y : A), f (MyClass.op x y) = MyClass.op (f x) (f y)
 
 @[simp]
 lemma map_op {F A B : Type*} [MyClass A] [MyClass B] [FunLike F A B] [MyEmbeddingClass F A B]
@@ -84,12 +84,12 @@ The second step is to add instances of your new `MyEmbeddingClass` for all types
 Typically, you can just declare a new class analogous to `MyEmbeddingClass`:
 
 ```
-structure CoolerEmbedding (A B : Type*) [CoolClass A] [CoolClass B] extends MyEmbedding A B :=
+structure CoolerEmbedding (A B : Type*) [CoolClass A] [CoolClass B] extends MyEmbedding A B where
   (map_cool' : toFun CoolClass.cool = CoolClass.cool)
 
 class CoolerEmbeddingClass (F : Type*) (A B : outParam Type*) [CoolClass A] [CoolClass B]
     [FunLike F A B]
-    extends MyEmbeddingClass F A B :=
+    extends MyEmbeddingClass F A B where
   (map_cool : ∀ (f : F), f CoolClass.cool = CoolClass.cool)
 
 @[simp]

--- a/Mathlib/Data/FunLike/Equiv.lean
+++ b/Mathlib/Data/FunLike/Equiv.lean
@@ -14,7 +14,7 @@ This typeclass is primarily for use by isomorphisms like `MonoidEquiv` and `Line
 
 A typical type of isomorphisms should be declared as:
 ```
-structure MyIso (A B : Type*) [MyClass A] [MyClass B] extends Equiv A B :=
+structure MyIso (A B : Type*) [MyClass A] [MyClass B] extends Equiv A B where
   (map_op' : ∀ (x y : A), toFun (MyClass.op x y) = MyClass.op (toFun x) (toFun y))
 
 namespace MyIso
@@ -77,12 +77,12 @@ The second step is to add instances of your new `MyIsoClass` for all types exten
 Typically, you can just declare a new class analogous to `MyIsoClass`:
 
 ```
-structure CoolerIso (A B : Type*) [CoolClass A] [CoolClass B] extends MyIso A B :=
+structure CoolerIso (A B : Type*) [CoolClass A] [CoolClass B] extends MyIso A B where
   (map_cool' : toFun CoolClass.cool = CoolClass.cool)
 
 class CoolerIsoClass (F : Type*) (A B : outParam Type*) [CoolClass A] [CoolClass B]
     [EquivLike F A B]
-    extends MyIsoClass F A B :=
+    extends MyIsoClass F A B where
   (map_cool : ∀ (f : F), f CoolClass.cool = CoolClass.cool)
 
 @[simp] lemma map_cool {F A B : Type*} [CoolClass A] [CoolClass B]

--- a/Mathlib/Data/Opposite.lean
+++ b/Mathlib/Data/Opposite.lean
@@ -30,7 +30,7 @@ variable (α : Sort u)
   both `unop (op X) = X` and `op (unop X) = X` are definitional equalities.
 
 -/
-structure Opposite :=
+structure Opposite where
   /-- The canonical map `α → αᵒᵖ`. -/
   op ::
   /-- The canonical map `αᵒᵖ → α`. -/

--- a/Mathlib/Data/SetLike/Basic.lean
+++ b/Mathlib/Data/SetLike/Basic.lean
@@ -28,7 +28,7 @@ boilerplate for every `SetLike`: a `coe_sort`, a `coe` to set, a
 
 A typical subobject should be declared as:
 ```
-structure MySubobject (X : Type*) [ObjectTypeclass X] :=
+structure MySubobject (X : Type*) [ObjectTypeclass X] where
   (carrier : Set X)
   (op_mem' : ∀ {x : X}, x ∈ carrier → sorry ∈ carrier)
 
@@ -60,7 +60,7 @@ end MySubobject
 
 An alternative to `SetLike` could have been an extensional `Membership` typeclass:
 ```
-class ExtMembership (α : out_param <| Type u) (β : Type v) extends Membership α β :=
+class ExtMembership (α : out_param <| Type u) (β : Type v) extends Membership α β where
   (ext_iff : ∀ {s t : β}, s = t ↔ ∀ (x : α), x ∈ s ↔ x ∈ t)
 ```
 While this is equivalent, `SetLike` conveniently uses a carrier set projection directly.

--- a/Mathlib/GroupTheory/HNNExtension.lean
+++ b/Mathlib/GroupTheory/HNNExtension.lean
@@ -174,7 +174,7 @@ namespace NormalWord
 variable (G A B)
 /-- To put word in the HNN Extension into a normal form, we must choose an element of each right
 coset of both `A` and `B`, such that the chosen element of the subgroup itself is `1`. -/
-structure TransversalPair : Type _ :=
+structure TransversalPair : Type _ where
   /-- The transversal of each subgroup -/
   set : ℤˣ → Set G
   /-- We have exactly one element of each coset of the subgroup -/
@@ -187,7 +187,7 @@ instance TransversalPair.nonempty : Nonempty (TransversalPair G A B) := by
 /-- A reduced word is a `head`, which is an element of `G`, followed by the product list of pairs.
 There should also be no sequences of the form `t^u * g * t^-u`, where `g` is in
 `toSubgroup A B u` This is a less strict condition than required for `NormalWord`. -/
-structure ReducedWord : Type _ :=
+structure ReducedWord : Type _ where
   /-- Every `ReducedWord` is the product of an element of the group and a word made up
   of letters each of which is in the transversal. `head` is that element of the base group. -/
   head : G
@@ -215,7 +215,7 @@ The normal form is a `head`, which is an element of `G`, followed by the product
 `toSubgroup A B u`. There should also be no sequences of the form `t^u * g * t^-u`
 where `g ∈ toSubgroup A B u` -/
 structure _root_.HNNExtension.NormalWord (d : TransversalPair G A B)
-    extends ReducedWord G A B : Type _ :=
+    extends ReducedWord G A B : Type _ where
   /-- Every element `g : G` in the list is the chosen element of its coset -/
   mem_set : ∀ (u : ℤˣ) (g : G), (u, g) ∈ toList → g ∈ d.set u
 

--- a/Mathlib/LinearAlgebra/PerfectPairing.lean
+++ b/Mathlib/LinearAlgebra/PerfectPairing.lean
@@ -34,7 +34,7 @@ open Function Module
 variable (R M N : Type*) [CommRing R] [AddCommGroup M] [Module R M] [AddCommGroup N] [Module R N]
 
 /-- A perfect pairing of two (left) modules over a commutative ring. -/
-structure PerfectPairing :=
+structure PerfectPairing where
   toLin : M →ₗ[R] N →ₗ[R] R
   bijectiveLeft : Bijective toLin
   bijectiveRight : Bijective toLin.flip

--- a/Mathlib/LinearAlgebra/QuadraticForm/QuadraticModuleCat.lean
+++ b/Mathlib/LinearAlgebra/QuadraticForm/QuadraticModuleCat.lean
@@ -43,7 +43,7 @@ def of {X : Type v} [AddCommGroup X] [Module R X] (Q : QuadraticForm R X) :
 /-- A type alias for `QuadraticForm.LinearIsometry` to avoid confusion between the categorical and
 algebraic spellings of composition. -/
 @[ext]
-structure Hom (V W : QuadraticModuleCat.{v} R) :=
+structure Hom (V W : QuadraticModuleCat.{v} R) where
   /-- The underlying isometry -/
   toIsometry : V.form →qᵢ W.form
 

--- a/Mathlib/LinearAlgebra/RootSystem/Defs.lean
+++ b/Mathlib/LinearAlgebra/RootSystem/Defs.lean
@@ -86,7 +86,7 @@ evaluates to `2`, and the permutation attached to each element of `ι` is compat
 reflections on the corresponding roots and coroots.
 
 It exists to allow for a convenient unification of the theories of root systems and root data. -/
-structure RootPairing extends PerfectPairing R M N :=
+structure RootPairing extends PerfectPairing R M N where
   /-- A parametrized family of vectors, called roots. -/
   root : ι ↪ M
   /-- A parametrized family of dual vectors, called coroots. -/
@@ -110,7 +110,7 @@ abbrev RootDatum (X₁ X₂ : Type*) [AddCommGroup X₁] [AddCommGroup X₂] := 
 
 Note that this is slightly more general than the usual definition in the sense that `N` is not
 required to be the dual of `M`. -/
-structure RootSystem extends RootPairing ι R M N :=
+structure RootSystem extends RootPairing ι R M N where
   span_eq_top : span R (range root) = ⊤
 
 attribute [simp] RootSystem.span_eq_top

--- a/Mathlib/LinearAlgebra/RootSystem/OfBilinear.lean
+++ b/Mathlib/LinearAlgebra/RootSystem/OfBilinear.lean
@@ -33,7 +33,7 @@ namespace LinearMap
 injective, and for any vector `y`, the norm of `x` divides twice the inner product of `x` and `y`.
 These conditions are what we need when describing reflection as a map taking `y` to
 `y - 2 • (B x y) / (B x x) • x`. -/
-structure IsReflective (B : M →ₗ[R] M →ₗ[R] R) (x : M) : Prop :=
+structure IsReflective (B : M →ₗ[R] M →ₗ[R] R) (x : M) : Prop where
   regular : IsRegular (B x x)
   dvd_two_mul : ∀ y, B x x ∣ 2 * B x y
 

--- a/Mathlib/MeasureTheory/MeasurableSpace/CountablyGenerated.lean
+++ b/Mathlib/MeasureTheory/MeasurableSpace/CountablyGenerated.lean
@@ -516,7 +516,7 @@ variable [MeasurableSpace β]
 
 /-- A class registering that either `α` is countable or `β` is a countably generated
 measurable space. -/
-class CountableOrCountablyGenerated (α β : Type*) [MeasurableSpace α] [MeasurableSpace β] : Prop :=
+class CountableOrCountablyGenerated (α β : Type*) [MeasurableSpace α] [MeasurableSpace β] : Prop where
   countableOrCountablyGenerated : Countable α ∨ MeasurableSpace.CountablyGenerated β
 
 instance instCountableOrCountablyGeneratedOfCountable [h1 : Countable α] :

--- a/Mathlib/MeasureTheory/MeasurableSpace/CountablyGenerated.lean
+++ b/Mathlib/MeasureTheory/MeasurableSpace/CountablyGenerated.lean
@@ -516,7 +516,8 @@ variable [MeasurableSpace β]
 
 /-- A class registering that either `α` is countable or `β` is a countably generated
 measurable space. -/
-class CountableOrCountablyGenerated (α β : Type*) [MeasurableSpace α] [MeasurableSpace β] : Prop where
+class CountableOrCountablyGenerated (α β : Type*) [MeasurableSpace α] [MeasurableSpace β] :
+    Prop where
   countableOrCountablyGenerated : Countable α ∨ MeasurableSpace.CountablyGenerated β
 
 instance instCountableOrCountablyGeneratedOfCountable [h1 : Countable α] :

--- a/Mathlib/MeasureTheory/Measure/SeparableMeasure.lean
+++ b/Mathlib/MeasureTheory/Measure/SeparableMeasure.lean
@@ -83,7 +83,7 @@ sets with finite measures.
 The term "measure-dense" is justified by the fact that the approximating condition translates
 to the usual notion of density in the metric space made by constant indicators of measurable sets
 equipped with the `Lᵖ` norm. -/
-structure Measure.MeasureDense (μ : Measure X) (𝒜 : Set (Set X)) : Prop :=
+structure Measure.MeasureDense (μ : Measure X) (𝒜 : Set (Set X)) : Prop where
   /-- Each set has to be measurable. -/
   measurable : ∀ s ∈ 𝒜, MeasurableSet s
   /-- Any measurable set can be approximated by sets in the family. -/
@@ -319,7 +319,7 @@ section IsSeparable
 
 The term "separable" is justified by the fact that the definition translates to the usual notion
 of separability in the metric space made by constant indicators equipped with the `Lᵖ` norm. -/
-class IsSeparable (μ : Measure X) : Prop :=
+class IsSeparable (μ : Measure X) : Prop where
   exists_countable_measureDense : ∃ 𝒜, 𝒜.Countable ∧ μ.MeasureDense 𝒜
 
 /-- By definition, a separable measure admits a countable and measure-dense family of sets. -/

--- a/Mathlib/Order/Defs.lean
+++ b/Mathlib/Order/Defs.lean
@@ -357,7 +357,7 @@ macro "compareOfLessAndEq_rfl" : tactic =>
 
 /-- A linear order is reflexive, transitive, antisymmetric and total relation `≤`.
 We assume that every linear ordered type has decidable `(≤)`, `(<)`, and `(=)`. -/
-class LinearOrder (α : Type*) extends PartialOrder α, Min α, Max α, Ord α :=
+class LinearOrder (α : Type*) extends PartialOrder α, Min α, Max α, Ord α where
   /-- A linear order is total. -/
   le_total (a b : α) : a ≤ b ∨ b ≤ a
   /-- In a linearly ordered type, we assume the order relations are all decidable. -/

--- a/Mathlib/Order/SuccPred/Basic.lean
+++ b/Mathlib/Order/SuccPred/Basic.lean
@@ -24,7 +24,7 @@ order...
 
 Maximal elements don't have a sensible successor. Thus the naïve typeclass
 ```lean
-class NaiveSuccOrder (α : Type*) [Preorder α] :=
+class NaiveSuccOrder (α : Type*) [Preorder α] where
   (succ : α → α)
   (succ_le_iff : ∀ {a b}, succ a ≤ b ↔ a < b)
   (lt_succ_iff : ∀ {a b}, a < succ b ↔ a ≤ b)

--- a/Mathlib/Probability/Kernel/Disintegration/CDFToKernel.lean
+++ b/Mathlib/Probability/Kernel/Disintegration/CDFToKernel.lean
@@ -63,7 +63,8 @@ to `ν` if is measurable, if `fun b ↦ f (a, b) x` is `(ν a)`-integrable for a
 and for all measurable sets `s : Set β`, `∫ b in s, f (a, b) x ∂(ν a) = (κ a (s ×ˢ Iic x)).toReal`.
 Also the `ℚ → ℝ` function `f (a, b)` should satisfy the properties of a Sieltjes function for
 `(ν a)`-almost all `b : β`. -/
-structure IsRatCondKernelCDF (f : α × β → ℚ → ℝ) (κ : Kernel α (β × ℝ)) (ν : Kernel α β) : Prop :=
+structure IsRatCondKernelCDF (f : α × β → ℚ → ℝ) (κ : Kernel α (β × ℝ)) (ν : Kernel α β) :
+    Prop where
   measurable : Measurable f
   isRatStieltjesPoint_ae (a : α) : ∀ᵐ b ∂(ν a), IsRatStieltjesPoint f (a, b)
   integrable (a : α) (q : ℚ) : Integrable (fun b ↦ f (a, b) q) (ν a)

--- a/Mathlib/RingTheory/DedekindDomain/Basic.lean
+++ b/Mathlib/RingTheory/DedekindDomain/Basic.lean
@@ -49,7 +49,7 @@ variable (R A K : Type*) [CommRing R] [CommRing A] [Field K]
 open scoped nonZeroDivisors Polynomial
 
 /-- A ring `R` has Krull dimension at most one if all nonzero prime ideals are maximal. -/
-class Ring.DimensionLEOne : Prop :=
+class Ring.DimensionLEOne : Prop where
   (maximalOfPrime : ∀ {p : Ideal R}, p ≠ ⊥ → p.IsPrime → p.IsMaximal)
 
 open Ideal Ring

--- a/Mathlib/Tactic/Ring/Basic.lean
+++ b/Mathlib/Tactic/Ring/Basic.lean
@@ -885,7 +885,7 @@ def evalPow {a : Q($α)} {b : Q(ℕ)} (va : ExSum sα a) (vb : ExSum sℕ b) :
     return ⟨_, vd, q(pow_add $pc₁ $pc₂ $pd)⟩
 
 /-- This cache contains data required by the `ring` tactic during execution. -/
-structure Cache {α : Q(Type u)} (sα : Q(CommSemiring $α)) :=
+structure Cache {α : Q(Type u)} (sα : Q(CommSemiring $α)) where
   /-- A ring instance on `α`, if available. -/
   rα : Option Q(Ring $α)
   /-- A division ring instance on `α`, if available. -/

--- a/Mathlib/Topology/Perfect.lean
+++ b/Mathlib/Topology/Perfect.lean
@@ -93,7 +93,7 @@ A topological space `X` is said to be perfect if its universe is a perfect set.
 Equivalently, this means that `𝓝[≠] x ≠ ⊥` for every point `x : X`.
 -/
 @[mk_iff perfectSpace_def]
-class PerfectSpace : Prop :=
+class PerfectSpace : Prop where
   univ_preperfect : Preperfect (Set.univ : Set α)
 
 theorem PerfectSpace.univ_perfect [PerfectSpace α] : Perfect (Set.univ : Set α) :=

--- a/Mathlib/Util/AtomM.lean
+++ b/Mathlib/Util/AtomM.lean
@@ -22,7 +22,7 @@ namespace Mathlib.Tactic
 open Lean Meta
 
 /-- The context (read-only state) of the `AtomM` monad. -/
-structure AtomM.Context :=
+structure AtomM.Context where
   /-- The reducibility setting for definitional equality of atoms -/
   red : TransparencyMode
   /-- A simplification to apply to atomic expressions when they are encountered,
@@ -31,7 +31,7 @@ structure AtomM.Context :=
   deriving Inhabited
 
 /-- The mutable state of the `AtomM` monad. -/
-structure AtomM.State :=
+structure AtomM.State where
   /-- The list of atoms-up-to-defeq encountered thus far, used for atom sorting. -/
   atoms : Array Expr := #[]
 

--- a/test/MfldSetTac.lean
+++ b/test/MfldSetTac.lean
@@ -47,7 +47,7 @@ test_sorry
   (e.toPartialEquiv.symm : β → α) = (e.symm : β → α) :=
 test_sorry
 
-structure ModelWithCorners (𝕜 E H : Type u) extends PartialEquiv H E :=
+structure ModelWithCorners (𝕜 E H : Type u) extends PartialEquiv H E where
   (source_eq : source = Set.univ)
 
 attribute [mfld_simps] ModelWithCorners.source_eq

--- a/test/NthRewrite.lean
+++ b/test/NthRewrite.lean
@@ -14,7 +14,7 @@ example [AddZeroClass G] {a : G} (h : a = a): a = (a + 0) := by
 example [AddZeroClass G] {a : G} : a + a = a + (a + 0) := by
   nth_rw 2 [← add_zero a]
 
-structure F :=
+structure F where
   (a : ℕ)
   (v : Vector ℕ a)
   (p : v.val = [])
@@ -22,7 +22,7 @@ structure F :=
 example (f : F) : f.v.val = [] := by
   nth_rw 1 [f.p]
 
-structure Cat :=
+structure Cat where
   (O : Type)
   (H : O → O → Type)
   (i : (o : O) → H o o)

--- a/test/Simps.lean
+++ b/test/Simps.lean
@@ -91,7 +91,7 @@ initialize_simps_projections Something
 
 universe v u w
 
-structure Equiv' (α : Sort _) (β : Sort _) :=
+structure Equiv' (α : Sort _) (β : Sort _) where
   (toFun     : α → β)
   (invFun    : β → α)
   (left_inv  : invFun.LeftInverse toFun)
@@ -262,7 +262,7 @@ run_cmd liftTermElabM <| do
   guard <| env.find? `rflWithData'_toEquiv_toFun |>.isNone
   guard <| env.find? `test_sneaky_extra |>.isNone
 
-structure PartiallyAppliedStr :=
+structure PartiallyAppliedStr where
   (data : ℕ → MyProd ℕ ℕ)
 
 /- if we have a partially applied constructor, we treat it as if it were eta-expanded -/
@@ -279,7 +279,7 @@ run_cmd liftTermElabM <| do
   guard <| simpsAttr.getParam? env `partially_applied_term ==
     #[`partially_applied_term_data_fst, `partially_applied_term_data_snd]
 
-structure VeryPartiallyAppliedStr :=
+structure VeryPartiallyAppliedStr where
   (data : ∀β, ℕ → β → MyProd ℕ β)
 
 /- if we have a partially applied constructor, we treat it as if it were eta-expanded.
@@ -424,12 +424,12 @@ run_cmd liftTermElabM <| do
   guard <| env.find? `pprodEquivProd22_invFun_snd |>.isSome
 
 /- Tests with universe levels -/
-class has_hom (obj : Type u) : Type (max u (v+1)) :=
+class has_hom (obj : Type u) : Type (max u (v+1)) where
   (hom : obj → obj → Type v)
 
 infixr:10 " ⟶ " => has_hom.hom -- type as \h
 
-class CategoryStruct (obj : Type u) extends has_hom.{v} obj : Type (max u (v+1)) :=
+class CategoryStruct (obj : Type u) extends has_hom.{v} obj : Type (max u (v+1)) where
   (id   : ∀ X : obj, hom X X)
   (comp : ∀ {X Y Z : obj}, (X ⟶ Y) → (Y ⟶ Z) → (X ⟶ Z))
 
@@ -450,7 +450,7 @@ example (X Y Z : Type u) (f : X ⟶ Y) (g : Y ⟶ Z) {k : X → Z} (h : ∀ x, g
 
 namespace coercing
 
-structure FooStr :=
+structure FooStr where
  (c : Type)
  (x : c)
 
@@ -462,7 +462,7 @@ instance : CoeSort FooStr Type := ⟨FooStr.c⟩
 example {x : Type} (h : ℕ = x) : foo = x := by simp only [foo_c]; rw [h]
 example {x : ℕ} (h : (3 : ℕ) = x) : foo.x = x := by simp only [foo_x]; rw [h]
 
-structure VooStr (n : ℕ) :=
+structure VooStr (n : ℕ) where
  (c : Type)
  (x : c)
 
@@ -474,7 +474,7 @@ instance (n : ℕ) : CoeSort (VooStr n) Type := ⟨VooStr.c⟩
 example {x : Type} (h : ℕ = x) : voo = x := by simp only [voo_c]; rw [h]
 example {x : ℕ} (h : (3 : ℕ) = x) : voo.x = x := by simp only [voo_x]; rw [h]
 
-structure Equiv2 (α : Sort _) (β : Sort _) :=
+structure Equiv2 (α : Sort _) (β : Sort _) where
   (toFun     : α → β)
   (invFun    : β → α)
   (left_inv  : invFun.LeftInverse toFun)
@@ -515,7 +515,7 @@ class Semigroup (G : Type u) extends Mul G where
 example {α β} [Semigroup α] [Semigroup β] (x y : α × β) : x * y = (x.1 * y.1, x.2 * y.2) := by simp
 example {α β} [Semigroup α] [Semigroup β] (x y : α × β) : (x * y).1 = x.1 * y.1 := by simp
 
-structure BSemigroup :=
+structure BSemigroup where
   (G : Type _)
   (op : G → G → G)
   -- (infix:60 " * " => op) -- this seems to be removed
@@ -535,8 +535,8 @@ protected def prod (G H : BSemigroup) : BSemigroup :=
 
 end BSemigroup
 
-class ExtendingStuff (G : Type u) extends Mul G, Zero G, Neg G, HasSubset G :=
-  (new_axiom : ∀ x : G, x * - 0 ⊆ - x)
+class ExtendingStuff (G : Type u) extends Mul G, Zero G, Neg G, HasSubset G where
+  new_axiom : ∀ x : G, x * - 0 ⊆ - x
 
 @[simps] def bar : ExtendingStuff ℕ :=
   { mul := (·*·)
@@ -550,8 +550,8 @@ attribute [local instance] bar
 example (x : ℕ) : x * - 0 ⊆ - x := by simp
 end
 
-class new_ExtendingStuff (G : Type u) extends Mul G, Zero G, Neg G, HasSubset G :=
-  (new_axiom : ∀ x : G, x * - 0 ⊆ - x)
+class new_ExtendingStuff (G : Type u) extends Mul G, Zero G, Neg G, HasSubset G where
+  new_axiom : ∀ x : G, x * - 0 ⊆ - x
 
 @[simps] def new_bar : new_ExtendingStuff ℕ :=
   { mul := (·*·)
@@ -570,7 +570,7 @@ end coercing
 
 namespace ManualCoercion
 
-structure Equiv (α : Sort _) (β : Sort _) :=
+structure Equiv (α : Sort _) (β : Sort _) where
   (toFun  : α → β)
   (invFun : β → α)
 
@@ -598,7 +598,7 @@ end ManualCoercion
 
 namespace FaultyManualCoercion
 
-structure Equiv (α : Sort _) (β : Sort _) :=
+structure Equiv (α : Sort _) (β : Sort _) where
   (toFun  : α → β)
   (invFun : β → α)
 
@@ -622,7 +622,7 @@ namespace ManualInitialize
 /- defining a manual coercion. -/
 variable {α β γ : Sort _}
 
-structure Equiv (α : Sort _) (β : Sort _) :=
+structure Equiv (α : Sort _) (β : Sort _) where
   (toFun  : α → β)
   (invFun : β → α)
 
@@ -654,7 +654,7 @@ namespace FaultyUniverses
 
 variable {α β γ : Sort _}
 
-structure Equiv (α : Sort u) (β : Sort v) :=
+structure Equiv (α : Sort u) (β : Sort v) where
   (toFun  : α → β)
   (invFun : β → α)
 
@@ -683,7 +683,7 @@ namespace ManualUniverses
 
 variable {α β γ : Sort _}
 
-structure Equiv (α : Sort u) (β : Sort v) :=
+structure Equiv (α : Sort u) (β : Sort v) where
   (toFun  : α → β)
   (invFun : β → α)
 
@@ -704,7 +704,7 @@ end ManualUniverses
 
 namespace ManualProjectionNames
 
-structure Equiv (α : Sort _) (β : Sort _) :=
+structure Equiv (α : Sort _) (β : Sort _) where
   (toFun  : α → β)
   (invFun : β → α)
 
@@ -744,7 +744,7 @@ end ManualProjectionNames
 
 namespace PrefixProjectionNames
 
-structure Equiv (α : Sort _) (β : Sort _) :=
+structure Equiv (α : Sort _) (β : Sort _) where
   (toFun  : α → β)
   (invFun : β → α)
 
@@ -791,7 +791,7 @@ end PrefixProjectionNames
 
 
 -- test transparency setting
-structure SetPlus (α : Type) :=
+structure SetPlus (α : Type) where
   (s : Set α)
   (x : α)
   (h : x ∈ s)
@@ -818,7 +818,7 @@ example {x : Set ℕ} (h : Set.univ = x) : Nat.SetPlus3.s = x := by
 
 namespace NestedNonFullyApplied
 
-structure Equiv (α : Sort _) (β : Sort _) :=
+structure Equiv (α : Sort _) (β : Sort _) where
   (toFun  : α → β)
   (invFun : β → α)
 
@@ -854,19 +854,19 @@ example (e : α ≃ β) {x : β → α} (h : e.invFun = x) : (Equiv.symm2.invFun
 end NestedNonFullyApplied
 
 -- test that type classes which are props work
-class PropClass (n : ℕ) : Prop :=
-  (has_true : True)
+class PropClass (n : ℕ) : Prop
+  has_true : True
 
 instance has_PropClass (n : ℕ) : PropClass n := ⟨trivial⟩
 
-structure NeedsPropClass (n : ℕ) [PropClass n] :=
+structure NeedsPropClass (n : ℕ) [PropClass n] where
   (t : True)
 
 @[simps] def test_PropClass : NeedsPropClass 1 :=
   { t := trivial }
 
 /- check that when the coercion is given in eta-expanded form, we can also find the coercion. -/
-structure AlgHom (R A B : Type _) :=
+structure AlgHom (R A B : Type _) where
   (toFun : A → B)
 
 instance (R A B : Type _) : CoeFun (AlgHom R A B) (fun _ ↦ A → B) := ⟨fun f ↦ f.toFun⟩
@@ -931,7 +931,7 @@ section
 
 attribute [local simp] Nat.add
 
-structure MyType :=
+structure MyType where
   (A : Type)
 
 @[simps (config := {simpRhs := true})] def myTypeDef : MyType :=
@@ -972,7 +972,7 @@ instance {α β} : CoeFun (α ≃ β) (fun _ ↦ α → β) := ⟨Equiv'.toFun�
 @[simps] protected def Equiv'.symm {α β} (f : α ≃ β) : β ≃ α :=
   ⟨f.invFun, f, f.right_inv, f.left_inv⟩
 
-structure DecoratedEquiv (α : Sort _) (β : Sort _) extends Equiv' α β :=
+structure DecoratedEquiv (α : Sort _) (β : Sort _) extends Equiv' α β where
   (P_toFun  : Function.Injective toFun )
   (P_invFun : Function.Injective invFun)
 
@@ -1022,7 +1022,7 @@ example {α : Type} (x z : α) (h : x = z) : foo2 α x = z := by
   guard_target = x = z
   rw [h]
 
-structure FurtherDecoratedEquiv (α : Sort _) (β : Sort _) extends DecoratedEquiv α β :=
+structure FurtherDecoratedEquiv (α : Sort _) (β : Sort _) extends DecoratedEquiv α β where
   (Q_toFun  : Function.Surjective toFun )
   (Q_invFun : Function.Surjective invFun )
 
@@ -1097,11 +1097,11 @@ def fffoo2 (α : Type) : OneMore α α := fffoo α
 /- test the case where a projection takes additional arguments. -/
 variable {ι : Type _} [DecidableEq ι] (A : ι → Type _)
 
-structure ZeroHom (M N : Type _) [Zero M] [Zero N] :=
+structure ZeroHom (M N : Type _) [Zero M] [Zero N] where
   (toFun : M → N)
   (map_zero' : toFun 0 = 0)
 
-structure AddHom (M N : Type _) [Add M] [Add N] :=
+structure AddHom (M N : Type _) [Add M] [Add N] where
   (toFun : M → N)
   (map_add' : ∀ x y, toFun (x + y) = toFun x + toFun y)
 
@@ -1112,7 +1112,7 @@ infixr:25 " →+ " => AddMonoidHom
 
 instance (M N : Type _) [AddMonoid M] [AddMonoid N] : CoeFun (M →+ N) (fun _ ↦ M → N) := ⟨(·.toFun)⟩
 
-class AddHomPlus [Add ι] [∀ i, AddCommMonoid (A i)] :=
+class AddHomPlus [Add ι] [∀ i, AddCommMonoid (A i)] where
   (myMul {i} : A i →+ A i)
 
 def AddHomPlus.Simps.apply [Add ι] [∀ i, AddCommMonoid (A i)] [AddHomPlus A] {i : ι} (x : A i) :
@@ -1121,7 +1121,7 @@ def AddHomPlus.Simps.apply [Add ι] [∀ i, AddCommMonoid (A i)] [AddHomPlus A] 
 
 initialize_simps_projections AddHomPlus (myMul_toFun → apply, -myMul)
 
-class AddHomPlus2 [Add ι] :=
+class AddHomPlus2 [Add ι] where
   (myMul {i j} : A i ≃ (A j ≃ A (i + j)))
 
 def AddHomPlus2.Simps.mul [Add ι] [AddHomPlus2 A] {i j : ι} (x : A i) (y : A j) : A (i + j) :=
@@ -1153,7 +1153,7 @@ end comp_projs
 section
 /-! Check that the tactic also works if the elaborated type of `type` reduces to `Sort _`, but is
   not `Sort _` itself. -/
-structure MyFunctor (C D : Type _) :=
+structure MyFunctor (C D : Type _) where
   (obj : C → D)
 local infixr:26 " ⥤ " => MyFunctor
 

--- a/test/Simps.lean
+++ b/test/Simps.lean
@@ -854,7 +854,7 @@ example (e : α ≃ β) {x : β → α} (h : e.invFun = x) : (Equiv.symm2.invFun
 end NestedNonFullyApplied
 
 -- test that type classes which are props work
-class PropClass (n : ℕ) : Prop
+class PropClass (n : ℕ) : Prop where
   has_true : True
 
 instance has_PropClass (n : ℕ) : PropClass n := ⟨trivial⟩

--- a/test/toAdditive.lean
+++ b/test/toAdditive.lean
@@ -19,12 +19,12 @@ def foo0 {α} [Mul α] [One α] (x y : α) : α := x * y * 1
 
 theorem bar0_works : bar0 3 4 = 7 := by decide
 
-class my_has_pow (α : Type u) (β : Type v) :=
+class my_has_pow (α : Type u) (β : Type v) where
   (pow : α → β → α)
 
 instance : my_has_pow Nat Nat := ⟨fun a b => a ^ b⟩
 
-class my_has_scalar (M : Type u) (α : Type v) :=
+class my_has_scalar (M : Type u) (α : Type v) where
   (smul : M → α → α)
 
 instance : my_has_scalar Nat Nat := ⟨fun a b => a * b⟩


### PR DESCRIPTION
In [lean4#5542](https://github.com/leanprover/lean4/pull/5542) we are deprecating `inductive ... :=`, `structure ... :=`, and `class ... :=` for their `... where` counterparts.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
