### PR TITLE
[Merged by Bors] - chore: remove more variable at the end of the imports

### DIFF
--- a/Mathlib/Tactic/FunProp/ContDiff.lean
+++ b/Mathlib/Tactic/FunProp/ContDiff.lean
@@ -23,8 +23,7 @@ variable {K : Type*} [NontriviallyNormedField K]
 variable {E : Type*} [NormedAddCommGroup E] [NormedSpace K E]
 variable {F : Type*} [NormedAddCommGroup F] [NormedSpace K F]
 variable {G : Type*} [NormedAddCommGroup G] [NormedSpace K G]
-variable {G' : Type*} [NormedAddCommGroup G'] [NormedSpace K G']
-variable {f f₀ f₁ g : E → F} {x} {s t} {n}
+variable {f : E → F} {x} {s} {n}
 
 theorem contDiff_id' : ContDiff K n (fun x : E => x) := contDiff_id
 
@@ -42,8 +41,8 @@ theorem ContDiffAt.comp' {f : E → F} {g : F → G} (hg : ContDiffAt K n g (f x
 -- theorem ContDiffOn.comp'' {g : F → G} {t : Set F} (hg : ContDiffOn K n g t)
 --     (hf : ContDiffOn K n f s) (st : Set.MapsTo f s t) : ContDiffOn K n (fun x => g (f x)) s :=
 
-variable {ι ι' : Type*} [Fintype ι] [Fintype ι'] {F' : ι → Type*} [∀ i, NormedAddCommGroup (F' i)]
-  [∀ i, NormedSpace K (F' i)] {φ : ∀ i, E → F' i} {Φ : E → ∀ i, F' i}
+variable {ι : Type*} [Fintype ι] {F' : ι → Type*} [∀ i, NormedAddCommGroup (F' i)]
+  [∀ i, NormedSpace K (F' i)] {Φ : E → ∀ i, F' i}
 
 theorem contDiff_pi' (hΦ : ∀ i, ContDiff K n fun x => Φ x i) : ContDiff K n Φ :=
   contDiff_pi.2 hΦ
@@ -60,8 +59,7 @@ section div
 
 variable {K : Type*} [NontriviallyNormedField K]
 variable {E : Type*} [NormedAddCommGroup E] [NormedSpace K E]
-variable {F : Type*} [NormedAddCommGroup F] [NormedSpace K F]
-variable {f f₀ f₁ g : E → F} {x} {s t} {n}
+variable {s}
 
 theorem ContDiffOn.div' [CompleteSpace K] {f g : E → K} {n} (hf : ContDiffOn K n f s)
     (hg : ContDiffOn K n g s) (h₀ : ∀ x ∈ s, g x ≠ 0) : ContDiffOn K n (fun x => f x / g x) s :=
@@ -74,7 +72,6 @@ end div
 section deriv
 
 variable {K : Type*} [NontriviallyNormedField K]
-variable {E : Type*} [NormedAddCommGroup E] [NormedSpace K E]
 variable {F : Type*} [NormedAddCommGroup F] [NormedSpace K F]
 
 /-- Original version `ContDiff.differentiable_iteratedDeriv` introduces a new variable `(n:ℕ∞)`

--- a/Mathlib/Testing/SlimCheck/Testable.lean
+++ b/Mathlib/Testing/SlimCheck/Testable.lean
@@ -423,7 +423,7 @@ end Testable
 
 section PrintableProp
 
-variable {α : Type*} {x y : α}
+variable {α : Type*}
 
 instance Eq.printableProp [Repr α] {x y : α} : PrintableProp (x = y) where
   printProp := s!"{repr x} = {repr y}"

--- a/Mathlib/Topology/AlexandrovDiscrete.lean
+++ b/Mathlib/Topology/AlexandrovDiscrete.lean
@@ -139,7 +139,7 @@ lemma alexandrovDiscrete_iSup {t : ι → TopologicalSpace α} (_ : ∀ i, @Alex
 
 section
 variable [TopologicalSpace α] [TopologicalSpace β] [AlexandrovDiscrete α] [AlexandrovDiscrete β]
-  {s t : Set α} {a x y : α}
+  {s t : Set α} {a : α}
 
 @[simp] lemma isOpen_exterior : IsOpen (exterior s) := by
   rw [exterior_def]; exact isOpen_sInter fun _ ↦ And.left

--- a/Mathlib/Topology/Algebra/Module/Alternating/Basic.lean
+++ b/Mathlib/Topology/Algebra/Module/Alternating/Basic.lean
@@ -447,9 +447,8 @@ end Semiring
 
 section Ring
 
-variable {R M M' N N' ι : Type*} [Ring R] [AddCommGroup M] [Module R M] [TopologicalSpace M]
-  [AddCommGroup M'] [Module R M'] [TopologicalSpace M'] [AddCommGroup N] [Module R N]
-  [TopologicalSpace N] [AddCommGroup N'] [Module R N'] [TopologicalSpace N'] {n : ℕ}
+variable {R M N ι : Type*} [Ring R] [AddCommGroup M] [Module R M] [TopologicalSpace M]
+  [AddCommGroup N] [Module R N] [TopologicalSpace N]
   (f g : M [⋀^ι]→L[R] N)
 
 @[simp]
@@ -489,10 +488,9 @@ end Ring
 
 section CommSemiring
 
-variable {R M M' N N' ι : Type*} [CommSemiring R] [AddCommMonoid M] [Module R M]
-  [TopologicalSpace M] [AddCommMonoid M'] [Module R M'] [TopologicalSpace M'] [AddCommMonoid N]
-  [Module R N] [TopologicalSpace N] [AddCommMonoid N'] [Module R N'] [TopologicalSpace N'] {n : ℕ}
-  (f g : M [⋀^ι]→L[R] N)
+variable {R M N ι : Type*} [CommSemiring R] [AddCommMonoid M] [Module R M]
+  [TopologicalSpace M] [AddCommMonoid N] [Module R N] [TopologicalSpace N]
+  (f : M [⋀^ι]→L[R] N)
 
 theorem map_piecewise_smul [DecidableEq ι] (c : ι → R) (m : ι → M) (s : Finset ι) :
     f (s.piecewise (fun i => c i • m i) m) = (∏ i ∈ s, c i) • f m :=
@@ -561,7 +559,7 @@ end Module
 
 section SMulRight
 
-variable {R A M N ι : Type*} [CommSemiring R] [AddCommMonoid M] [AddCommMonoid N] [Module R M]
+variable {R M N ι : Type*} [CommSemiring R] [AddCommMonoid M] [AddCommMonoid N] [Module R M]
   [Module R N] [TopologicalSpace R] [TopologicalSpace M] [TopologicalSpace N] [ContinuousSMul R N]
   (f : M [⋀^ι]→L[R] R) (z : N)
 
@@ -603,7 +601,7 @@ namespace ContinuousMultilinearMap
 
 variable {R M N ι : Type*} [Semiring R] [AddCommMonoid M] [Module R M] [TopologicalSpace M]
   [AddCommGroup N] [Module R N] [TopologicalSpace N] [TopologicalAddGroup N] [Fintype ι]
-  [DecidableEq ι] (f g : ContinuousMultilinearMap R (fun _ : ι => M) N)
+  [DecidableEq ι] (f : ContinuousMultilinearMap R (fun _ : ι => M) N)
 
 /-- Alternatization of a continuous multilinear map. -/
 @[simps (config := .lemmasOnly) apply_toContinuousMultilinearMap]

--- a/Mathlib/Topology/Algebra/PontryaginDual.lean
+++ b/Mathlib/Topology/Algebra/PontryaginDual.lean
@@ -22,9 +22,9 @@ isomorphic to its double dual.
 
 open Pointwise Function
 
-variable (A B C D E G : Type*) [Monoid A] [Monoid B] [Monoid C] [Monoid D] [CommGroup E] [Group G]
-  [TopologicalSpace A] [TopologicalSpace B] [TopologicalSpace C] [TopologicalSpace D]
-  [TopologicalSpace E] [TopologicalSpace G] [TopologicalGroup E] [TopologicalGroup G]
+variable (A B C G H : Type*) [Monoid A] [Monoid B] [Monoid C] [CommGroup G] [Group H]
+  [TopologicalSpace A] [TopologicalSpace B] [TopologicalSpace C]
+  [TopologicalSpace G] [TopologicalSpace H] [TopologicalGroup G] [TopologicalGroup H]
 
 /-- The Pontryagin dual of `A` is the group of continuous homomorphism `A → Circle`. -/
 def PontryaginDual :=
@@ -48,7 +48,7 @@ instance : TopologicalGroup (PontryaginDual A) :=
 noncomputable instance : Inhabited (PontryaginDual A) :=
   (inferInstance : Inhabited (ContinuousMonoidHom A Circle))
 
-instance [LocallyCompactSpace G] : LocallyCompactSpace (PontryaginDual G) := by
+instance [LocallyCompactSpace H] : LocallyCompactSpace (PontryaginDual H) := by
   let Vn : ℕ → Set Circle :=
     fun n ↦ Circle.exp '' { x | |x| < Real.pi / 2 ^ (n + 1)}
   have hVn : ∀ n x, x ∈ Vn n ↔ |Complex.arg x| < Real.pi / 2 ^ (n + 1) := by
@@ -75,7 +75,7 @@ instance [LocallyCompactSpace G] : LocallyCompactSpace (PontryaginDual G) := by
     refine (Nat.le_ceil (Real.pi / x)).trans ?_
     exact_mod_cast (Nat.le_succ _).trans (Nat.lt_two_pow _).le
 
-variable {A B C D E}
+variable {A B C G}
 
 namespace PontryaginDual
 
@@ -107,15 +107,15 @@ theorem map_comp (g : ContinuousMonoidHom B C) (f : ContinuousMonoidHom A B) :
   ext fun _x => ext fun _y => rfl
 
 @[simp]
-nonrec theorem map_mul (f g : ContinuousMonoidHom A E) : map (f * g) = map f * map g :=
+nonrec theorem map_mul (f g : ContinuousMonoidHom A G) : map (f * g) = map f * map g :=
   ext fun x => ext fun y => map_mul x (f y) (g y)
 
-variable (A B C D E)
+variable (A B C G)
 
 /-- `ContinuousMonoidHom.dual` as a `ContinuousMonoidHom`. -/
-noncomputable def mapHom [LocallyCompactSpace E] :
-    ContinuousMonoidHom (ContinuousMonoidHom A E)
-      (ContinuousMonoidHom (PontryaginDual E) (PontryaginDual A)) where
+noncomputable def mapHom [LocallyCompactSpace G] :
+    ContinuousMonoidHom (ContinuousMonoidHom A G)
+      (ContinuousMonoidHom (PontryaginDual G) (PontryaginDual A)) where
   toFun := map
   map_one' := map_one
   map_mul' := map_mul

--- a/Mathlib/Topology/Algebra/ProperAction.lean
+++ b/Mathlib/Topology/Algebra/ProperAction.lean
@@ -73,9 +73,8 @@ class ProperSMul (G X : Type*) [TopologicalSpace G] [TopologicalSpace X] [Group 
 
 attribute [to_additive existing] properSMul_iff
 
-variable {G X Y Z : Type*} [Group G] [MulAction G X] [MulAction G Y]
-variable [TopologicalSpace G] [TopologicalSpace X] [TopologicalSpace Y]
-variable [TopologicalSpace Z]
+variable {G X : Type*} [Group G] [MulAction G X]
+variable [TopologicalSpace G] [TopologicalSpace X]
 
 /-- If a group acts properly then in particular it acts continuously. -/
 @[to_additive "If a group acts properly then in particular it acts continuously."]

--- a/Mathlib/Topology/ContinuousMap/LocallyConstant.lean
+++ b/Mathlib/Topology/ContinuousMap/LocallyConstant.lean
@@ -15,7 +15,7 @@ import Mathlib.Topology.ContinuousMap.Algebra
 
 namespace LocallyConstant
 
-variable {X Y : Type*} [TopologicalSpace X] [TopologicalSpace Y] (f : LocallyConstant X Y)
+variable {X Y : Type*} [TopologicalSpace X] [TopologicalSpace Y]
 
 /-- The inclusion of locally-constant functions into continuous functions as a multiplicative
 monoid hom. -/

--- a/Mathlib/Topology/Germ.lean
+++ b/Mathlib/Topology/Germ.lean
@@ -30,9 +30,6 @@ to the corresponding germ of functions `X → Z` at `x ∈ X` resp. `Y → Z` at
 `f` is constant.
 -/
 
-variable {F G : Type*} [NormedAddCommGroup F] [NormedSpace ℝ F]
-  [NormedAddCommGroup G] [NormedSpace ℝ G]
-
 open scoped Topology
 
 open Filter Set

--- a/Mathlib/Topology/Instances/RatLemmas.lean
+++ b/Mathlib/Topology/Instances/RatLemmas.lean
@@ -36,7 +36,7 @@ local notation "ℚ∞" => OnePoint ℚ
 
 namespace Rat
 
-variable {p q : ℚ} {s t : Set ℚ}
+variable {p : ℚ} {s : Set ℚ}
 
 theorem interior_compact_eq_empty (hs : IsCompact s) : interior s = ∅ :=
   isDenseEmbedding_coe_real.toIsDenseInducing.interior_compact_eq_empty dense_irrational hs
@@ -72,7 +72,7 @@ theorem not_secondCountableTopology_opc : ¬SecondCountableTopology ℚ∞ := by
   exact not_firstCountableTopology_opc inferInstance
 
 instance : TotallyDisconnectedSpace ℚ := by
-  clear p q s t
+  clear p s
   refine ⟨fun s hsu hs x hx y hy => ?_⟩; clear hsu
   by_contra! H : x ≠ y
   wlog hlt : x < y

--- a/Mathlib/Topology/MetricSpace/Kuratowski.lean
+++ b/Mathlib/Topology/MetricSpace/Kuratowski.lean
@@ -19,16 +19,16 @@ noncomputable section
 
 open Set Metric TopologicalSpace NNReal ENNReal lp Function
 
-universe u v w
+universe u
 
-variable {α : Type u} {β : Type v} {γ : Type w}
+variable {α : Type u}
 
 namespace KuratowskiEmbedding
 
 /-! ### Any separable metric space can be embedded isometrically in ℓ^∞(ℕ, ℝ) -/
 
 
-variable {f g : ℓ^∞(ℕ)} {n : ℕ} {C : ℝ} [MetricSpace α] (x : ℕ → α) (a b : α)
+variable {n : ℕ} [MetricSpace α] (x : ℕ → α) (a : α)
 
 /-- A metric space can be embedded in `l^∞(ℝ)` via the distances to points in
 a fixed countable set, if this set is dense. This map is given in `kuratowskiEmbedding`,

--- a/Mathlib/Topology/UniformSpace/Ascoli.lean
+++ b/Mathlib/Topology/UniformSpace/Ascoli.lean
@@ -70,8 +70,7 @@ equicontinuity, uniform convergence, ascoli
 
 open Set Filter Uniformity Topology Function UniformConvergence
 
-variable {ι X Y α β : Type*} [TopologicalSpace X] [UniformSpace α] [UniformSpace β]
-variable {F : ι → X → α} {G : ι → β → α}
+variable {ι X α : Type*} [TopologicalSpace X] [UniformSpace α] {F : ι → X → α}
 
 /-- Let `X` be a compact topological space, `α` a uniform space, and `F : ι → (X → α)` an
 equicontinuous family. Then, the uniform structures of uniform convergence and pointwise


### PR DESCRIPTION
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
