### PR TITLE
[Merged by Bors] - chore: deal with `erw` in `Mathlib.Data.PNat.Interval`

### DIFF
--- a/Mathlib/Data/PNat/Interval.lean
+++ b/Mathlib/Data/PNat/Interval.lean
@@ -53,35 +53,19 @@ theorem map_subtype_embedding_uIcc : (uIcc a b).map (Embedding.subtype _) = uIcc
 
 @[simp]
 theorem card_Icc : (Icc a b).card = b + 1 - a := by
-  rw [← Nat.card_Icc]
-  -- Porting note: I had to change this to `erw` *and* provide the proof, yuck.
-  -- https://github.com/leanprover-community/mathlib4/issues/5164
-  erw [← Finset.map_subtype_embedding_Icc _ a b (fun c x _ hx _ hc _ => hc.trans_le hx)]
-  rw [card_map]
+  rw [← Nat.card_Icc, ← map_subtype_embedding_Icc, card_map]
 
 @[simp]
 theorem card_Ico : (Ico a b).card = b - a := by
-  rw [← Nat.card_Ico]
-  -- Porting note: I had to change this to `erw` *and* provide the proof, yuck.
-  -- https://github.com/leanprover-community/mathlib4/issues/5164
-  erw [← Finset.map_subtype_embedding_Ico _ a b (fun c x _ hx _ hc _ => hc.trans_le hx)]
-  rw [card_map]
+  rw [← Nat.card_Ico, ← map_subtype_embedding_Ico, card_map]
 
 @[simp]
 theorem card_Ioc : (Ioc a b).card = b - a := by
-  rw [← Nat.card_Ioc]
-  -- Porting note: I had to change this to `erw` *and* provide the proof, yuck.
-  -- https://github.com/leanprover-community/mathlib4/issues/5164
-  erw [← Finset.map_subtype_embedding_Ioc _ a b (fun c x _ hx _ hc _ => hc.trans_le hx)]
-  rw [card_map]
+  rw [← Nat.card_Ioc, ← map_subtype_embedding_Ioc, card_map]
 
 @[simp]
 theorem card_Ioo : (Ioo a b).card = b - a - 1 := by
-  rw [← Nat.card_Ioo]
-  -- Porting note: I had to change this to `erw` *and* provide the proof, yuck.
-  -- https://github.com/leanprover-community/mathlib4/issues/5164
-  erw [← Finset.map_subtype_embedding_Ioo _ a b (fun c x _ hx _ hc _ => hc.trans_le hx)]
-  rw [card_map]
+  rw [← Nat.card_Ioo, ← map_subtype_embedding_Ioo, card_map]
 
 @[simp]
 theorem card_uIcc : (uIcc a b).card = (b - a : ℤ).natAbs + 1 := by


### PR DESCRIPTION
This file had a lot of `erw`s with porting notes, but the cause was on the code side: we were trying to rewrite with the wrong lemma. In mathlib3 `rw` used `pnat.map_subtype_embedding_Icc` (et al.) and the port replaced that with `Fintype.map_subtype_embedding_Icc`. The two are defeq but not reducibly so. Going back to the `PNat` lemma allows us to delete these `erw`s *and* the porting notes!


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
