### PR TITLE
[Merged by Bors] - chore: get rid of `erw`s in Mathlib.Algebra.Group.InjSurj

### DIFF
--- a/Mathlib/Algebra/Group/InjSurj.lean
+++ b/Mathlib/Algebra/Group/InjSurj.lean
@@ -55,7 +55,7 @@ a semigroup. See note [reducible non-instances]. -/
 injective map that preserves `+` to an additive semigroup."]
 protected abbrev semigroup [Semigroup M₂] (f : M₁ → M₂) (hf : Injective f)
     (mul : ∀ x y, f (x * y) = f x * f y) : Semigroup M₁ :=
-  { ‹Mul M₁› with mul_assoc := fun x y z => hf <| by erw [mul, mul, mul, mul, mul_assoc] }
+  { ‹Mul M₁› with mul_assoc := fun x y z => hf <| by rw [mul, mul, mul, mul, mul_assoc] }
 
 /-- A type endowed with `*` is a commutative magma, if it admits a surjective map that preserves
 `*` from a commutative magma. -/
@@ -83,7 +83,7 @@ semigroup, if it admits an injective map that preserves `+` to an additive left 
 protected abbrev leftCancelSemigroup [LeftCancelSemigroup M₂] (f : M₁ → M₂) (hf : Injective f)
     (mul : ∀ x y, f (x * y) = f x * f y) : LeftCancelSemigroup M₁ :=
   { hf.semigroup f mul with
-    mul_left_cancel := fun x y z H => hf <| (mul_right_inj (f x)).1 <| by erw [← mul, ← mul, H] }
+    mul_left_cancel := fun x y z H => hf <| (mul_right_inj (f x)).1 <| by rw [← mul, ← mul, H] }
 
 /-- A type endowed with `*` is a right cancel semigroup, if it admits an injective map that
 preserves `*` to a right cancel semigroup.  See note [reducible non-instances]. -/
@@ -93,7 +93,7 @@ semigroup."]
 protected abbrev rightCancelSemigroup [RightCancelSemigroup M₂] (f : M₁ → M₂) (hf : Injective f)
     (mul : ∀ x y, f (x * y) = f x * f y) : RightCancelSemigroup M₁ :=
   { hf.semigroup f mul with
-    mul_right_cancel := fun x y z H => hf <| (mul_left_inj (f y)).1 <| by erw [← mul, ← mul, H] }
+    mul_right_cancel := fun x y z H => hf <| (mul_left_inj (f y)).1 <| by rw [← mul, ← mul, H] }
 
 variable [One M₁]
 
@@ -105,8 +105,8 @@ injective map that preserves `0` and `+` to an `AddZeroClass`."]
 protected abbrev mulOneClass [MulOneClass M₂] (f : M₁ → M₂) (hf : Injective f) (one : f 1 = 1)
     (mul : ∀ x y, f (x * y) = f x * f y) : MulOneClass M₁ :=
   { ‹One M₁›, ‹Mul M₁› with
-    one_mul := fun x => hf <| by erw [mul, one, one_mul],
-    mul_one := fun x => hf <| by erw [mul, one, mul_one] }
+    one_mul := fun x => hf <| by rw [mul, one, one_mul],
+    mul_one := fun x => hf <| by rw [mul, one, mul_one] }
 
 variable [Pow M₁ ℕ]
 
@@ -120,8 +120,8 @@ protected abbrev monoid [Monoid M₂] (f : M₁ → M₂) (hf : Injective f) (on
     (mul : ∀ x y, f (x * y) = f x * f y) (npow : ∀ (x) (n : ℕ), f (x ^ n) = f x ^ n) : Monoid M₁ :=
   { hf.mulOneClass f one mul, hf.semigroup f mul with
     npow := fun n x => x ^ n,
-    npow_zero := fun x => hf <| by erw [npow, one, pow_zero],
-    npow_succ := fun n x => hf <| by erw [npow, pow_succ, mul, npow] }
+    npow_zero := fun x => hf <| by rw [npow, one, pow_zero],
+    npow_succ := fun n x => hf <| by rw [npow, pow_succ, mul, npow] }
 
 /-- A type endowed with `0`, `1` and `+` is an additive monoid with one,
 if it admits an injective map that preserves `0`, `1` and `+` to an additive monoid with one.
@@ -132,8 +132,8 @@ protected abbrev addMonoidWithOne {M₁} [Zero M₁] [One M₁] [Add M₁] [SMul
     (natCast : ∀ n : ℕ, f n = n) : AddMonoidWithOne M₁ :=
   { hf.addMonoid f zero add (swap nsmul) with
     natCast := Nat.cast,
-    natCast_zero := hf (by erw [natCast, Nat.cast_zero, zero]),
-    natCast_succ := fun n => hf (by erw [natCast, Nat.cast_succ, add, one, natCast]), one := 1 }
+    natCast_zero := hf (by rw [natCast, Nat.cast_zero, zero]),
+    natCast_succ := fun n => hf (by rw [natCast, Nat.cast_succ, add, one, natCast]), one := 1 }
 
 /-- A type endowed with `1` and `*` is a left cancel monoid, if it admits an injective map that
 preserves `1` and `*` to a left cancel monoid. See note [reducible non-instances]. -/
@@ -215,7 +215,7 @@ injective map that preserves `0` and unary `-` to an `NegZeroClass`."]
 protected abbrev invOneClass [InvOneClass M₂] (f : M₁ → M₂) (hf : Injective f) (one : f 1 = 1)
     (inv : ∀ x, f (x⁻¹) = (f x)⁻¹) : InvOneClass M₁ :=
   { ‹One M₁›, ‹Inv M₁› with
-    inv_one := hf <| by erw [inv, one, inv_one] }
+    inv_one := hf <| by rw [inv, one, inv_one] }
 
 variable [Div M₁] [Pow M₁ ℤ]
 
@@ -232,10 +232,11 @@ protected abbrev divInvMonoid [DivInvMonoid M₂] (f : M₁ → M₂) (hf : Inje
     (zpow : ∀ (x) (n : ℤ), f (x ^ n) = f x ^ n) : DivInvMonoid M₁ :=
   { hf.monoid f one mul npow, ‹Inv M₁›, ‹Div M₁› with
     zpow := fun n x => x ^ n,
-    zpow_zero' := fun x => hf <| by erw [zpow, zpow_zero, one],
-    zpow_succ' := fun n x => hf <| by erw [zpow, mul, zpow_natCast, pow_succ, zpow, zpow_natCast],
-    zpow_neg' := fun n x => hf <| by erw [zpow, zpow_negSucc, inv, zpow, zpow_natCast],
-    div_eq_mul_inv := fun x y => hf <| by erw [div, mul, inv, div_eq_mul_inv] }
+    zpow_zero' := fun x => hf <| by rw [zpow, zpow_zero, one],
+    zpow_succ' := fun n x => hf <| by rw [zpow, mul, Int.ofNat_eq_coe, zpow_natCast, pow_succ, zpow,
+      Int.ofNat_eq_coe, zpow_natCast],
+    zpow_neg' := fun n x => hf <| by rw [zpow, zpow_negSucc, inv, zpow, zpow_natCast],
+    div_eq_mul_inv := fun x y => hf <| by rw [div, mul, inv, div_eq_mul_inv] }
 
 /-- A type endowed with `1`, `*`, `⁻¹`, and `/` is a `DivInvOneMonoid` if it admits an injective
 map that preserves `1`, `*`, `⁻¹`, and `/` to a `DivInvOneMonoid`. See note
@@ -263,9 +264,9 @@ protected abbrev divisionMonoid [DivisionMonoid M₂] (f : M₁ → M₂) (hf : 
     (div : ∀ x y, f (x / y) = f x / f y) (npow : ∀ (x) (n : ℕ), f (x ^ n) = f x ^ n)
     (zpow : ∀ (x) (n : ℤ), f (x ^ n) = f x ^ n) : DivisionMonoid M₁ :=
   { hf.divInvMonoid f one mul inv div npow zpow, hf.involutiveInv f inv with
-    mul_inv_rev := fun x y => hf <| by erw [inv, mul, mul_inv_rev, mul, inv, inv],
+    mul_inv_rev := fun x y => hf <| by rw [inv, mul, mul_inv_rev, mul, inv, inv],
     inv_eq_of_mul := fun x y h => hf <| by
-      erw [inv, inv_eq_of_mul_eq_one_right (by erw [← mul, h, one])] }
+      rw [inv, inv_eq_of_mul_eq_one_right (by rw [← mul, h, one])] }
 
 /-- A type endowed with `1`, `*`, `⁻¹`, and `/` is a `DivisionCommMonoid` if it admits an
 injective map that preserves `1`, `*`, `⁻¹`, and `/` to a `DivisionCommMonoid`.
@@ -291,7 +292,7 @@ protected abbrev group [Group M₂] (f : M₁ → M₂) (hf : Injective f) (one 
     (div : ∀ x y, f (x / y) = f x / f y) (npow : ∀ (x) (n : ℕ), f (x ^ n) = f x ^ n)
     (zpow : ∀ (x) (n : ℤ), f (x ^ n) = f x ^ n) : Group M₁ :=
   { hf.divInvMonoid f one mul inv div npow zpow with
-    inv_mul_cancel := fun x => hf <| by erw [mul, inv, inv_mul_cancel, one] }
+    inv_mul_cancel := fun x => hf <| by rw [mul, inv, inv_mul_cancel, one] }
 
 /-- A type endowed with `0`, `1` and `+` is an additive group with one, if it admits an injective
 map that preserves `0`, `1` and `+` to an additive group with one.  See note
@@ -306,7 +307,7 @@ protected abbrev addGroupWithOne {M₁} [Zero M₁] [One M₁] [Add M₁] [SMul 
     hf.addMonoidWithOne f zero one add nsmul natCast with
     intCast := Int.cast,
     intCast_ofNat := fun n => hf (by rw [natCast, ← Int.cast, intCast, Int.cast_natCast]),
-    intCast_negSucc := fun n => hf (by erw [intCast, neg, natCast, Int.cast_negSucc] ) }
+    intCast_negSucc := fun n => hf (by rw [intCast, neg, natCast, Int.cast_negSucc] ) }
 
 /-- A type endowed with `1`, `*` and `⁻¹` is a commutative group, if it admits an injective map that
 preserves `1`, `*` and `⁻¹` to a commutative group. See note [reducible non-instances]. -/
@@ -358,7 +359,7 @@ protected abbrev semigroup [Semigroup M₁] (f : M₁ → M₂) (hf : Surjective
 a surjective map that preserves `+` from an additive commutative semigroup."]
 protected abbrev commMagma [CommMagma M₁] (f : M₁ → M₂) (hf : Surjective f)
     (mul : ∀ x y, f (x * y) = f x * f y) : CommMagma M₂ where
-  mul_comm := hf.forall₂.2 fun x y => by erw [← mul, ← mul, mul_comm]
+  mul_comm := hf.forall₂.2 fun x y => by rw [← mul, ← mul, mul_comm]
 
 /-- A type endowed with `*` is a commutative semigroup, if it admits a surjective map that preserves
 `*` from a commutative semigroup. See note [reducible non-instances]. -/
@@ -380,8 +381,8 @@ surjective map that preserves `0` and `+` to an `AddZeroClass`."]
 protected abbrev mulOneClass [MulOneClass M₁] (f : M₁ → M₂) (hf : Surjective f) (one : f 1 = 1)
     (mul : ∀ x y, f (x * y) = f x * f y) : MulOneClass M₂ :=
   { ‹One M₂›, ‹Mul M₂› with
-    one_mul := hf.forall.2 fun x => by erw [← one, ← mul, one_mul],
-    mul_one := hf.forall.2 fun x => by erw [← one, ← mul, mul_one] }
+    one_mul := hf.forall.2 fun x => by rw [← one, ← mul, one_mul],
+    mul_one := hf.forall.2 fun x => by rw [← one, ← mul, mul_one] }
 
 variable [Pow M₂ ℕ]
 
@@ -395,10 +396,10 @@ protected abbrev monoid [Monoid M₁] (f : M₁ → M₂) (hf : Surjective f) (o
     (mul : ∀ x y, f (x * y) = f x * f y) (npow : ∀ (x) (n : ℕ), f (x ^ n) = f x ^ n) : Monoid M₂ :=
   { hf.semigroup f mul, hf.mulOneClass f one mul with
     npow := fun n x => x ^ n,
-    npow_zero := hf.forall.2 fun x => by dsimp only; erw [← npow, pow_zero, ← one],
+    npow_zero := hf.forall.2 fun x => by dsimp only; rw [← npow, pow_zero, ← one],
     npow_succ := fun n => hf.forall.2 fun x => by
       dsimp only
-      erw [← npow, pow_succ, ← npow, ← mul] }
+      rw [← npow, pow_succ, ← npow, ← mul] }
 
 /-- A type endowed with `0`, `1` and `+` is an additive monoid with one, if it admits a surjective
 map that preserves `0`, `1` and `*` from an additive monoid with one. See note
@@ -441,7 +442,7 @@ preserves `-` to a type which has an involutive negation."]
 protected abbrev involutiveInv {M₂ : Type*} [Inv M₂] [InvolutiveInv M₁] (f : M₁ → M₂)
     (hf : Surjective f) (inv : ∀ x, f x⁻¹ = (f x)⁻¹) : InvolutiveInv M₂ where
   inv := Inv.inv
-  inv_inv := hf.forall.2 fun x => by erw [← inv, ← inv, inv_inv]
+  inv_inv := hf.forall.2 fun x => by rw [← inv, ← inv, inv_inv]
 
 variable [Inv M₂] [Div M₂] [Pow M₂ ℤ]
 
@@ -457,14 +458,15 @@ protected abbrev divInvMonoid [DivInvMonoid M₁] (f : M₁ → M₂) (hf : Surj
     (zpow : ∀ (x) (n : ℤ), f (x ^ n) = f x ^ n) : DivInvMonoid M₂ :=
   { hf.monoid f one mul npow, ‹Div M₂›, ‹Inv M₂› with
     zpow := fun n x => x ^ n,
-    zpow_zero' := hf.forall.2 fun x => by dsimp only; erw [← zpow, zpow_zero, ← one],
+    zpow_zero' := hf.forall.2 fun x => by dsimp only; rw [← zpow, zpow_zero, ← one],
     zpow_succ' := fun n => hf.forall.2 fun x => by
       dsimp only
-      erw [← zpow, ← zpow, zpow_natCast, zpow_natCast, pow_succ, ← mul],
+      rw [← zpow, ← zpow, Int.ofNat_eq_coe, zpow_natCast, Int.ofNat_eq_coe, zpow_natCast, pow_succ,
+        ← mul],
     zpow_neg' := fun n => hf.forall.2 fun x => by
       dsimp only
-      erw [← zpow, ← zpow, zpow_negSucc, zpow_natCast, inv],
-    div_eq_mul_inv := hf.forall₂.2 fun x y => by erw [← inv, ← mul, ← div, div_eq_mul_inv] }
+      rw [← zpow, ← zpow, zpow_negSucc, zpow_natCast, inv],
+    div_eq_mul_inv := hf.forall₂.2 fun x y => by rw [← inv, ← mul, ← div, div_eq_mul_inv] }
 
 /-- A type endowed with `1`, `*` and `⁻¹` is a group, if it admits a surjective map that preserves
 `1`, `*` and `⁻¹` to a group. See note [reducible non-instances]. -/
@@ -476,7 +478,7 @@ protected abbrev group [Group M₁] (f : M₁ → M₂) (hf : Surjective f) (one
     (div : ∀ x y, f (x / y) = f x / f y) (npow : ∀ (x) (n : ℕ), f (x ^ n) = f x ^ n)
     (zpow : ∀ (x) (n : ℤ), f (x ^ n) = f x ^ n) : Group M₂ :=
   { hf.divInvMonoid f one mul inv div npow zpow with
-    inv_mul_cancel := hf.forall.2 fun x => by erw [← inv, ← mul, inv_mul_cancel, one] }
+    inv_mul_cancel := hf.forall.2 fun x => by rw [← inv, ← mul, inv_mul_cancel, one] }
 
 /-- A type endowed with `0`, `1`, `+` is an additive group with one,
 if it admits a surjective map that preserves `0`, `1`, and `+` to an additive group with one.


### PR DESCRIPTION
Almost all of the `erw`s work just fine as `rw`s. Only two places need additional rewriting: this is because the `pow_succ'` field of `DivInvMonoid`s mentions `Int.ofNat`, which is not reducibly defeq to the actual cast we use in our lemmas.

This suggests we should redefine `pow_succ'` to use the actual cast instead: #17573.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
