### PR TITLE
feat: `t ↦ t • x` as a linear equiv

### DIFF
--- a/Mathlib/LinearAlgebra/Span.lean
+++ b/Mathlib/LinearAlgebra/Span.lean
@@ -456,10 +456,10 @@ noncomputable def equivSpan : R ≃ₗ[R] (R ∙ x) where
     (mem_span_singleton.1 (mem_span_singleton.2 ⟨t, rfl⟩)).choose_spec
   right_inv y := Subtype.val_inj.1 (mem_span_singleton.1 y.2).choose_spec
 
-theorem equivSpan_smul {y : M} (hy : y ∈ R ∙ x) : ((equivSpan R hx).symm ⟨y, hy⟩) • x = y :=
+theorem equivSpan_symm_smul {y : M} (hy : y ∈ R ∙ x) : ((equivSpan R hx).symm ⟨y, hy⟩) • x = y :=
   congrArg Subtype.val <| (equivSpan R hx).right_inv _
 
-theorem equivSpan_self :
+theorem equivSpan_symm_self :
     (equivSpan R hx).symm ⟨x, mem_span_singleton_self x⟩ = 1 :=
   one_smul R (⟨x, _⟩ : R ∙ x) ▸ (equivSpan R hx).left_inv 1
 

--- a/Mathlib/LinearAlgebra/Span.lean
+++ b/Mathlib/LinearAlgebra/Span.lean
@@ -440,6 +440,31 @@ theorem mem_span_singleton {y : M} : (x ∈ R ∙ y) ↔ ∃ a : R, a • y = x 
       exact ⟨a * b, by simp [smul_smul]⟩, by
     rintro ⟨a, y, rfl⟩; exact smul_mem _ _ (subset_span <| by simp)⟩
 
+section equivSpan
+
+variable {R M : Type*} [Ring R] [AddCommGroup M] [Module R M] [NoZeroSMulDivisors R M]
+variable {x : M} (hx : x ≠ 0)
+
+variable (R) in
+/-- If a module has no zero divisors and `x ≠ 0`, this is the map `t ↦ t • x` as a linear equiv. -/
+noncomputable def equivSpan : R ≃ₗ[R] (R ∙ x) where
+  toFun t := ⟨t • x, mem_span_singleton.2 ⟨t, rfl⟩⟩
+  invFun y := (mem_span_singleton.1 y.2).choose
+  map_add' y z := by simp [add_smul]
+  map_smul' t y := by simp [mul_smul]
+  left_inv t := smul_left_injective R hx <|
+    (mem_span_singleton.1 (mem_span_singleton.2 ⟨t, rfl⟩)).choose_spec
+  right_inv y := Subtype.val_inj.1 (mem_span_singleton.1 y.2).choose_spec
+
+theorem equivSpan_smul {y : M} (hy : y ∈ R ∙ x) : ((equivSpan R hx).symm ⟨y, hy⟩) • x = y :=
+  congrArg Subtype.val <| (equivSpan R hx).right_inv _
+
+theorem equivSpan_self :
+    (equivSpan R hx).symm ⟨x, mem_span_singleton_self x⟩ = 1 :=
+  one_smul R (⟨x, _⟩ : R ∙ x) ▸ (equivSpan R hx).left_inv 1
+
+end equivSpan
+
 theorem le_span_singleton_iff {s : Submodule R M} {v₀ : M} :
     (s ≤ R ∙ v₀) ↔ ∀ v ∈ s, ∃ r : R, r • v₀ = v := by simp_rw [SetLike.le_def, mem_span_singleton]
 


### PR DESCRIPTION
Under some conditions, the map `t ↦ t • x` in a module is a linear equivalence between the ring and the span of `x`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
