### PR TITLE
[Merged by Bors] - chore(scripts/bench): benchmark with `--no-cache`

### DIFF
--- a/scripts/bench/temci-config.run.yml
+++ b/scripts/bench/temci-config.run.yml
@@ -7,7 +7,7 @@
     rusage_properties: ['maxrss']
     cmd: |
       # use build cache for proofwidgets, but not for anything else
-      bash -c 'set -eo pipefail; lake clean && LEAN_PATH=$(lean --print-libdir) lake build proofwidgets && lake build --no-cache -v --lean ./scripts/bench/fake-root/bin/lean | ./scripts/bench/accumulate_profile.py | grep -v took'
+      bash -c 'set -eo pipefail; lake clean && LEAN_PATH=$(lean --print-libdir) lake build proofwidgets && rm .lake/packages/batteries/.lake/build/bin/runLinter && lake build --no-cache -v --lean ./scripts/bench/fake-root/bin/lean | ./scripts/bench/accumulate_profile.py | grep -v took'
     parse_output: true
     runs: 1
 - attributes:

--- a/scripts/bench/temci-config.run.yml
+++ b/scripts/bench/temci-config.run.yml
@@ -6,7 +6,7 @@
       properties: ['wall-clock', 'task-clock', 'instructions:u', 'branches', 'branch-misses']
     rusage_properties: ['maxrss']
     cmd: |
-      bash -c 'set -eo pipefail; lake clean && LEAN_PATH=$(lean --print-libdir) lake build --no-cache -v --lean ./scripts/bench/fake-root/bin/lean | ./scripts/bench/accumulate_profile.py | grep -v took'
+      bash -c 'set -eo pipefail; lake clean && LEAN_PATH=$(lean --print-libdir) lake build batteries && rm .lake/packages/batteries/.lake/build/bin/runLinter && lake build --no-cache -v --lean ./scripts/bench/fake-root/bin/lean | ./scripts/bench/accumulate_profile.py | grep -v took'
     parse_output: true
     runs: 1
 - attributes:

--- a/scripts/bench/temci-config.run.yml
+++ b/scripts/bench/temci-config.run.yml
@@ -6,7 +6,7 @@
       properties: ['wall-clock', 'task-clock', 'instructions:u', 'branches', 'branch-misses']
     rusage_properties: ['maxrss']
     cmd: |
-      bash -c 'set -eo pipefail; lake clean && LEAN_PATH=$(lean --print-libdir) lake build -v --lean ./scripts/bench/fake-root/bin/lean | ./scripts/bench/accumulate_profile.py | grep -v took'
+      bash -c 'set -eo pipefail; lake clean && LEAN_PATH=$(lean --print-libdir) lake build --no-cache -v --lean ./scripts/bench/fake-root/bin/lean | ./scripts/bench/accumulate_profile.py | grep -v took'
     parse_output: true
     runs: 1
 - attributes:

--- a/scripts/bench/temci-config.run.yml
+++ b/scripts/bench/temci-config.run.yml
@@ -7,7 +7,7 @@
     rusage_properties: ['maxrss']
     cmd: |
       # use build cache for proofwidgets, but not for anything else
-      bash -c 'set -eo pipefail; lake clean && LEAN_PATH=$(lean --print-libdir) lake build proofwidgets && rm .lake/packages/batteries/.lake/build/bin/runLinter && lake build --no-cache -v --lean ./scripts/bench/fake-root/bin/lean | ./scripts/bench/accumulate_profile.py | grep -v took'
+      bash -c 'set -eo pipefail; lake clean 1>&2 && LEAN_PATH=$(lean --print-libdir) lake build proofwidgets 1>&2 && rm .lake/packages/batteries/.lake/build/bin/runLinter 1>&2 && lake build --no-cache -v --lean ./scripts/bench/fake-root/bin/lean | ./scripts/bench/accumulate_profile.py | grep -v took'
     parse_output: true
     runs: 1
 - attributes:

--- a/scripts/bench/temci-config.run.yml
+++ b/scripts/bench/temci-config.run.yml
@@ -6,7 +6,8 @@
       properties: ['wall-clock', 'task-clock', 'instructions:u', 'branches', 'branch-misses']
     rusage_properties: ['maxrss']
     cmd: |
-      bash -c 'set -eo pipefail; lake clean && LEAN_PATH=$(lean --print-libdir) lake build batteries && rm .lake/packages/batteries/.lake/build/bin/runLinter && lake build --no-cache -v --lean ./scripts/bench/fake-root/bin/lean | ./scripts/bench/accumulate_profile.py | grep -v took'
+      # use build cache for proofwidgets, but not for anything else
+      bash -c 'set -eo pipefail; lake clean && LEAN_PATH=$(lean --print-libdir) lake build proofwidgets && lake build --no-cache -v --lean ./scripts/bench/fake-root/bin/lean | ./scripts/bench/accumulate_profile.py | grep -v took'
     parse_output: true
     runs: 1
 - attributes:


### PR DESCRIPTION
There appears to be some incompatibility with executables downloaded from the cloud cache on NixOS, which broke the speedcenter. We used to benchmark all dependencies before the upgrade to 4.13.0-rc1, so let's go back to doing that.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
