### PR TITLE
[Merged by Bors] - chore: add unification hint for forgetful functor Bundled -> Type

### DIFF
--- a/Mathlib/Algebra/Category/ModuleCat/Presheaf/Sheafify.lean
+++ b/Mathlib/Algebra/Category/ModuleCat/Presheaf/Sheafify.lean
@@ -81,7 +81,6 @@ lemma isCompatible_map_smul_aux {Y Z : C} (f : Y ⟶ X) (g : Z ⟶ Y)
   · rw [hr₀', R.map_comp, comp_apply, ← hr₀, NatTrans.naturality_apply]
   · rw [hm₀', A.map_comp, AddCommGrp.coe_comp, Function.comp_apply, ← hm₀]
     erw [NatTrans.naturality_apply]
-    rfl
 
 variable (hr₀ : (r₀.map (whiskerRight α (forget _))).IsAmalgamation r)
   (hm₀ : (m₀.map (whiskerRight φ (forget _))).IsAmalgamation m)
@@ -105,7 +104,6 @@ lemma isCompatible_map_smul : ((r₀.smul m₀).map (whiskerRight φ (forget _))
   have hb₀ : (φ.app (Opposite.op Z)) b₀ = (A.map (f₁.op ≫ g₁.op)) m := by
     dsimp [b₀]
     erw [NatTrans.naturality_apply, hb₁, Functor.map_comp, comp_apply]
-    rfl
   have ha₀' : (α.app (Opposite.op Z)) a₀ = (R.map (f₂.op ≫ g₂.op)) r := by
     rw [ha₀, ← op_comp, fac, op_comp]
   have hb₀' : (φ.app (Opposite.op Z)) b₀ = (A.map (f₂.op ≫ g₂.op)) m := by
@@ -222,9 +220,7 @@ lemma map_smul_eq {Y : Cᵒᵖ} (f : X ⟶ Y) (r₀ : R₀.obj Y) (hr₀ : α.ap
 protected lemma one_smul : smul α φ 1 m = m := by
   apply A.isSeparated _ _ (Presheaf.imageSieve_mem J φ m)
   rintro Y f ⟨m₀, hm₀⟩
-  rw [← hm₀]
-  erw [map_smul_eq α φ 1 m f.op 1 (by simp) m₀ hm₀, one_smul]
-  rfl
+  rw [← hm₀, map_smul_eq α φ 1 m f.op 1 (by simp) m₀ hm₀, one_smul]
 
 protected lemma zero_smul : smul α φ 0 m = 0 := by
   apply A.isSeparated _ _ (Presheaf.imageSieve_mem J φ m)
@@ -248,7 +244,7 @@ protected lemma smul_add : smul α φ r (m + m') = smul α φ r m + smul α φ r
   erw [(A.val.map f.op).map_add, map_smul_eq α φ r m f.op r₀ hr₀ m₀ hm₀,
     map_smul_eq α φ r m' f.op r₀ hr₀ m₀' hm₀',
     map_smul_eq α φ r (m + m') f.op r₀ hr₀ (m₀ + m₀')
-      (by erw [map_add, map_add, hm₀, hm₀']; rfl),
+      (by rw [map_add, map_add, hm₀, hm₀']),
     smul_add, map_add]
 
 protected lemma add_smul : smul α φ (r + r') m = smul α φ r m + smul α φ r' m := by
@@ -298,7 +294,7 @@ lemma map_smul :
   rintro Y f ⟨⟨r₀, hr₀⟩, ⟨m₀, hm₀⟩⟩
   erw [← comp_apply, ← Functor.map_comp,
     map_smul_eq α φ r m (π ≫ f.op) r₀ (by rw [hr₀, Functor.map_comp, comp_apply]) m₀
-      (by erw [hm₀, Functor.map_comp, comp_apply]; rfl),
+      (by rw [hm₀, Functor.map_comp, comp_apply]),
     map_smul_eq α φ (R.val.map π r) (A.val.map π m) f.op r₀ hr₀ m₀ hm₀]
 
 end Sheafify

--- a/Mathlib/Algebra/Category/Ring/Basic.lean
+++ b/Mathlib/Algebra/Category/Ring/Basic.lean
@@ -47,10 +47,6 @@ instance bundledHom : BundledHom AssocRingHom where
 --deriving instance LargeCategory, ConcreteCategory for SemiRingCat
 -- see https://github.com/leanprover-community/mathlib4/issues/5020
 
--- Porting note: Hinting to Lean that `forget R` and `R` are the same
-unif_hint forget_obj_eq_coe (R : SemiRingCat) where ⊢
-  (forget SemiRingCat).obj R ≟ R
-
 instance instSemiring (X : SemiRingCat) : Semiring X := X.str
 
 instance instFunLike {X Y : SemiRingCat} : FunLike (X ⟶ Y) X Y :=
@@ -176,10 +172,6 @@ instance : BundledHom.ParentProjection @Ring.toSemiring :=
 
 instance (X : RingCat) : Ring X := X.str
 
--- Porting note: Hinting to Lean that `forget R` and `R` are the same
-unif_hint forget_obj_eq_coe (R : RingCat) where ⊢
-  (forget RingCat).obj R ≟ R
-
 instance instRing (X : RingCat) : Ring X := X.str
 
 instance instFunLike {X Y : RingCat} : FunLike (X ⟶ Y) X Y :=
@@ -293,10 +285,6 @@ instance : CoeSort CommSemiRingCat Type* where
   coe X := X.α
 
 instance (X : CommSemiRingCat) : CommSemiring X := X.str
-
--- Porting note: Hinting to Lean that `forget R` and `R` are the same
-unif_hint forget_obj_eq_coe (R : CommSemiRingCat) where ⊢
-  (forget CommSemiRingCat).obj R ≟ R
 
 instance instCommSemiring (X : CommSemiRingCat) : CommSemiring X := X.str
 
@@ -419,10 +407,6 @@ namespace CommRingCat
 
 instance : BundledHom.ParentProjection @CommRing.toRing :=
   ⟨⟩
-
--- Porting note: Hinting to Lean that `forget R` and `R` are the same
-unif_hint forget_obj_eq_coe (R : CommRingCat) where ⊢
-  (forget CommRingCat).obj R ≟ R
 
 -- Porting note: deriving fails for concrete category.
 -- see https://github.com/leanprover-community/mathlib4/issues/5020

--- a/Mathlib/Algebra/Homology/ConcreteCategory.lean
+++ b/Mathlib/Algebra/Homology/ConcreteCategory.lean
@@ -75,21 +75,20 @@ lemma δ_apply (x₃ : (forget₂ C Ab).obj (S.X₃.X i))
         (forget₂ C Ab).map (S.X₁.homologyπ j) (S.X₁.cyclesMk x₁ k hk (by
           have := hS.mono_f
           apply (Preadditive.mono_iff_injective (S.f.f k)).1 inferInstance
-          erw [← forget₂_comp_apply, ← HomologicalComplex.Hom.comm, forget₂_comp_apply, hx₁,
+          rw [← forget₂_comp_apply, ← HomologicalComplex.Hom.comm, forget₂_comp_apply, hx₁,
             ← forget₂_comp_apply, HomologicalComplex.d_comp_d, Functor.map_zero, map_zero,
             AddMonoidHom.zero_apply])) := by
   refine hS.δ_apply' i j hij _ ((forget₂ C Ab).map (S.X₂.pOpcycles i) x₂) _ ?_ ?_
-  · erw [← forget₂_comp_apply, ← forget₂_comp_apply,
+  · rw [← forget₂_comp_apply, ← forget₂_comp_apply,
       HomologicalComplex.p_opcyclesMap, Functor.map_comp, comp_apply,
       HomologicalComplex.homology_π_ι, forget₂_comp_apply, hx₂, HomologicalComplex.i_cyclesMk]
   · apply (Preadditive.mono_iff_injective (S.X₂.iCycles j)).1 inferInstance
     conv_lhs =>
-      erw [← forget₂_comp_apply, HomologicalComplex.cyclesMap_i, forget₂_comp_apply,
+      rw [← forget₂_comp_apply, HomologicalComplex.cyclesMap_i, forget₂_comp_apply,
         HomologicalComplex.i_cyclesMk, hx₁]
     conv_rhs =>
-      erw [← forget₂_comp_apply, ← forget₂_comp_apply,
+      rw [← forget₂_comp_apply, ← forget₂_comp_apply,
         HomologicalComplex.pOpcycles_opcyclesToCycles_assoc, HomologicalComplex.toCycles_i]
-    rfl
 
 end ShortExact
 

--- a/Mathlib/AlgebraicGeometry/Morphisms/OpenImmersion.lean
+++ b/Mathlib/AlgebraicGeometry/Morphisms/OpenImmersion.lean
@@ -56,7 +56,8 @@ instance : IsLocalAtTarget (stalkwise (fun f ↦ Function.Bijective f)) := by
   rw [RingHom.toMorphismProperty_respectsIso_iff]
   convert (inferInstanceAs (MorphismProperty.isomorphisms CommRingCat).RespectsIso)
   ext
-  exact (ConcreteCategory.isIso_iff_bijective _).symm
+  -- Regression in #17583: have to specify C explicitly below.
+  exact (ConcreteCategory.isIso_iff_bijective (C := CommRingCat) _).symm
 
 instance isOpenImmersion_isLocalAtTarget : IsLocalAtTarget @IsOpenImmersion :=
   isOpenImmersion_eq_inf ▸ inferInstance

--- a/Mathlib/Analysis/Normed/Group/SemiNormedGrp/Completion.lean
+++ b/Mathlib/Analysis/Normed/Group/SemiNormedGrp/Completion.lean
@@ -102,12 +102,8 @@ instance : Preadditive SemiNormedGrp.{u} where
     ext
     -- Porting note: failing simps probably due to instance synthesis issues with concrete
     -- cats; see the gymnastics below for what used to be
-    -- simp only [add_apply, comp_apply. map_add]
-    rw [NormedAddGroupHom.add_apply]
-    -- This used to be a single `rw`, but we need `erw` after leanprover/lean4#2644
-    erw [CategoryTheory.comp_apply, CategoryTheory.comp_apply,
+    rw [NormedAddGroupHom.add_apply, CategoryTheory.comp_apply, CategoryTheory.comp_apply,
       CategoryTheory.comp_apply, @NormedAddGroupHom.add_apply _ _ (_) (_)]
-    rfl
 
 instance : Functor.Additive completion where
   map_add := NormedAddGroupHom.completion_add _ _

--- a/Mathlib/CategoryTheory/ConcreteCategory/BundledHom.lean
+++ b/Mathlib/CategoryTheory/ConcreteCategory/BundledHom.lean
@@ -74,6 +74,12 @@ instance concreteCategory : ConcreteCategory.{u} (Bundled c) where
       map_comp := fun f g => by dsimp; erw [𝒞.comp_toFun];rfl }
   forget_faithful := { map_injective := by (intros; apply 𝒞.hom_ext) }
 
+/-- This unification hint helps `rw` to figure out how to apply statements about abstract
+concrete categories to specific concrete categories. Crucially, it fires also at `reducible`
+levels so `rw` can use it (and we don't have to use `erw`). -/
+unif_hint (C : Bundled c) where
+  ⊢ (CategoryTheory.forget (Bundled c)).obj C =?= Bundled.α C
+
 variable {hom}
 
 attribute [local instance] ConcreteCategory.instFunLike

--- a/Mathlib/Geometry/RingedSpace/LocallyRingedSpace/HasColimits.lean
+++ b/Mathlib/Geometry/RingedSpace/LocallyRingedSpace/HasColimits.lean
@@ -215,7 +215,7 @@ instance coequalizer_π_stalk_isLocalRingHom (x : Y) :
   constructor
   rintro a ha
   rcases TopCat.Presheaf.germ_exist _ _ a with ⟨U, hU, s, rfl⟩
-  erw [PresheafedSpace.stalkMap_germ_apply (coequalizer.π f.1 g.1 : _) U _ hU] at ha
+  rw [PresheafedSpace.stalkMap_germ_apply (coequalizer.π f.1 g.1 : _) U _ hU] at ha
   let V := imageBasicOpen f g U s
   have hV : (coequalizer.π f.1 g.1).base ⁻¹' ((coequalizer.π f.1 g.1).base '' V.1) = V.1 :=
     imageBasicOpen_image_preimage f g U s

--- a/Mathlib/Geometry/RingedSpace/PresheafedSpace/Gluing.lean
+++ b/Mathlib/Geometry/RingedSpace/PresheafedSpace/Gluing.lean
@@ -140,10 +140,9 @@ theorem pullback_base (i j k : D.J) (S : Set (D.V (i, j)).carrier) :
   rw [Set.image_comp]
   -- Porting note: `rw` to `erw` on `coe_comp`
   erw [coe_comp]
-  erw [Set.preimage_comp, Set.image_preimage_eq, TopCat.pullback_snd_image_fst_preimage]
-   -- now `erw` after #13170
+  rw [Set.preimage_comp, Set.image_preimage_eq, TopCat.pullback_snd_image_fst_preimage]
   · rfl
-  erw [← TopCat.epi_iff_surjective] -- now `erw` after #13170
+  rw [← TopCat.epi_iff_surjective]
   infer_instance
 
 /-- The red and the blue arrows in ![this diagram](https://i.imgur.com/0GiBUh6.png) commute. -/

--- a/Mathlib/Topology/Category/TopCat/Limits/Products.lean
+++ b/Mathlib/Topology/Category/TopCat/Limits/Products.lean
@@ -346,8 +346,7 @@ theorem binaryCofan_isColimit_iff {X Y : TopCat} (c : BinaryCofan X Y) :
         refine (dif_pos ?_).trans ?_
         · exact ⟨x, rfl⟩
         · dsimp
-          conv_lhs => erw [Equiv.ofInjective_symm_apply]
-          rfl -- `rfl` was not needed here before #13170
+          conv_lhs => rw [Equiv.ofInjective_symm_apply]
       · intro T f g
         ext x
         refine (dif_neg ?_).trans ?_

--- a/Mathlib/Topology/Category/TopCat/Limits/Pullbacks.lean
+++ b/Mathlib/Topology/Category/TopCat/Limits/Pullbacks.lean
@@ -214,17 +214,14 @@ theorem range_pullback_map {W X Y Z S T : TopCat} (f₁ : W ⟶ S) (f₂ : X ⟶
   erw [← comp_apply, ← comp_apply] -- now `erw` after #13170
   · simp only [Category.assoc, limit.lift_π, PullbackCone.mk_π_app_one]
     simp only [cospan_one, pullbackIsoProdSubtype_inv_fst_assoc, comp_apply]
-    erw [pullbackFst_apply, hx₁]
-    rw [← limit.w _ WalkingCospan.Hom.inl, cospan_map_inl, comp_apply (g := g₁)]
-    rfl -- `rfl` was not needed before #13170
+    rw [pullbackFst_apply, hx₁, ← limit.w _ WalkingCospan.Hom.inl, cospan_map_inl,
+        comp_apply (g := g₁)]
   · simp only [cospan_left, limit.lift_π, PullbackCone.mk_pt, PullbackCone.mk_π_app,
       pullbackIsoProdSubtype_inv_fst_assoc, comp_apply]
     erw [hx₁] -- now `erw` after #13170
-    rfl -- `rfl` was not needed before #13170
   · simp only [cospan_right, limit.lift_π, PullbackCone.mk_pt, PullbackCone.mk_π_app,
       pullbackIsoProdSubtype_inv_snd_assoc, comp_apply]
     erw [hx₂] -- now `erw` after #13170
-    rfl -- `rfl` was not needed before #13170
 
 theorem pullback_fst_range {X Y S : TopCat} (f : X ⟶ S) (g : Y ⟶ S) :
     Set.range (pullback.fst f g) = { x : X | ∃ y : Y, f x = g y } := by

--- a/Mathlib/Topology/Gluing.lean
+++ b/Mathlib/Topology/Gluing.lean
@@ -167,10 +167,8 @@ theorem eqvGen_of_π_eq
   let diagram := parallelPair 𝖣.diagram.fstSigmaMap 𝖣.diagram.sndSigmaMap ⋙ forget _
   have : colimit.ι diagram one x = colimit.ι diagram one y := by
     dsimp only [coequalizer.π, ContinuousMap.toFun_eq_coe] at h
-    -- This used to be `rw`, but we need `erw` after leanprover/lean4#2644
-    erw [← ι_preservesColimitsIso_hom, forget_map_eq_coe, types_comp_apply, h]
+    rw [← ι_preservesColimitsIso_hom, forget_map_eq_coe, types_comp_apply, h]
     simp
-    rfl
   have :
     (colimit.ι diagram _ ≫ colim.map _ ≫ (colimit.isoColimitCocone _).hom) _ =
       (colimit.ι diagram _ ≫ colim.map _ ≫ (colimit.isoColimitCocone _).hom) _ :=
@@ -216,8 +214,7 @@ theorem ι_eq_iff_rel (i j : D.J) (x : D.U i) (y : D.U j) :
     dsimp only at *
     -- Porting note: there were `subst e₁` and `subst e₂`, instead of the `rw`
     rw [← e₁, ← e₂] at *
-    erw [D.glue_condition_apply] -- now `erw` after #13170
-    rfl -- now `rfl` after #13170
+    rw [D.glue_condition_apply]
 
 theorem ι_injective (i : D.J) : Function.Injective (𝖣.ι i) := by
   intro x y h
@@ -266,8 +263,7 @@ theorem preimage_image_eq_image (i j : D.J) (U : Set (𝖣.U i)) :
     generalize 𝖣.ι i '' U = U' -- next 4 lines were `simp` before #13170
     simp only [GlueData.diagram_l, GlueData.diagram_r, Set.mem_preimage, coe_comp,
       Function.comp_apply]
-    erw [D.glue_condition_apply]
-    rfl
+    rw [D.glue_condition_apply]
   rw [← this, Set.image_preimage_eq_inter_range]
   symm
   apply Set.inter_eq_self_of_subset_left

--- a/test/CategoryTheory/Elementwise.lean
+++ b/test/CategoryTheory/Elementwise.lean
@@ -92,7 +92,7 @@ lemma bar''' {M N K : MonCat} {f : M ⟶ N} {g : N ⟶ K} {h : M ⟶ K} (w : f �
     g (f x) = h x := by apply foo_apply w
 
 example (M N K : MonCat) (f : M ⟶ N) (g : N ⟶ K) (h : M ⟶ K) (w : f ≫ g = h) (m : M) :
-    g (f m) = h m := by erw [elementwise_of% w]; rfl -- Porting note: was `rw`, switched to `erw; rfl`
+    g (f m) = h m := by rw [elementwise_of% w]
 
 example (M N K : MonCat) (f : M ⟶ N) (g : N ⟶ K) (h : M ⟶ K) (w : f ≫ g = h) (m : M) :
     g (f m) = h m := by


### PR DESCRIPTION
We have a lot of `erw`s and `rfl`s in files dealing with concrete categories. This seems to be mostly due to the existence of two casts: `ConcreteCategory.hasCoeToSort` and `Bundled.coeSort` which both represent the forgetful functor from concrete categories to Type. The first is only a local instance but is needed to state lemmas on these concrete categories, while the second one is always available but only applies to categories defined as `Bundled`. The casts are defeq but not reducibly so, causing issues when rewriting with generic lemmas in the context of a specific `Bundled` category.
    
For some specific categories we already have a workaround: a unification hint of the form `⊢ (forget CommRingCat).obj R ≟ R` also fires at reducible transparency. This PR does the same for any category of the form `Bundled _`, fixing a lot of the issues. Almost all of the changes in this PR consists of `erw` to `rw` or removing a terminal `rfl`.

A limitation of this approach is that the unification hint isn't taken into account when building discrimination trees, so e.g. `simp` still doesn't know how to apply these kinds of lemmas. An alternative might involve unbundling the `CoeSort` from `ConcreteCategory`, but that doesn't actually fix anything! Namely, we have to write `CoeSort.coe` in the generic lemmas, but the coercion is inlined for specific instances. (Here a unification hint might also help, but then we'd be back at this PR essentially.)
    
There used to be some regressions because the subtle unification order gets disrupted: where we expected `CommRingCat` (with many useful instances) now we get `Bundled CommRing`. Since #17612 turns `CommRingCat` into an `abbrev`, that is no longer an issue.


---

- [x] depends on: #17612

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
