### PR TITLE
[Merged by Bors] - feat(GroupTheory/Coset/Basic): products, `leftRel` and `rightRel`

### DIFF
--- a/Mathlib/GroupTheory/Coset/Basic.lean
+++ b/Mathlib/GroupTheory/Coset/Basic.lean
@@ -262,6 +262,20 @@ instance leftRelDecidable [DecidablePred (· ∈ s)] : DecidableRel (leftRel s).
   rw [leftRel_eq]
   exact ‹DecidablePred (· ∈ s)› _
 
+@[to_additive]
+lemma leftRel_prod {β : Type*} [Group β] (s' : Subgroup β) :
+    leftRel (s.prod s') = (leftRel s).prod (leftRel s') := by
+  refine Setoid.ext fun x y ↦ ?_
+  rw [Setoid.prod_apply]
+  simp_rw [leftRel_apply]
+  rfl
+
+@[to_additive]
+lemma leftRel_pi {ι : Type*} {β : ι → Type*} [∀ i, Group (β i)] (s' : ∀ i, Subgroup (β i)) :
+    leftRel (Subgroup.pi Set.univ s') = @piSetoid _ _ fun i ↦ leftRel (s' i) := by
+  refine Setoid.ext fun x y ↦ ?_
+  simp [Setoid.piSetoid_apply, leftRel_apply, Subgroup.mem_pi]
+
 /-- `α ⧸ s` is the quotient type representing the left cosets of `s`.
   If `s` is a normal subgroup, `α ⧸ s` is a group -/
 @[to_additive "`α ⧸ s` is the quotient type representing the left cosets of `s`.  If `s` is a normal
@@ -303,6 +317,20 @@ theorem rightRel_r_eq_rightCosetEquivalence :
 instance rightRelDecidable [DecidablePred (· ∈ s)] : DecidableRel (rightRel s).r := fun x y => by
   rw [rightRel_eq]
   exact ‹DecidablePred (· ∈ s)› _
+
+@[to_additive]
+lemma rightRel_prod {β : Type*} [Group β] (s' : Subgroup β) :
+    rightRel (s.prod s') = (rightRel s).prod (rightRel s') := by
+  refine Setoid.ext fun x y ↦ ?_
+  rw [Setoid.prod_apply]
+  simp_rw [rightRel_apply]
+  rfl
+
+@[to_additive]
+lemma rightRel_pi {ι : Type*} {β : ι → Type*} [∀ i, Group (β i)] (s' : ∀ i, Subgroup (β i)) :
+    rightRel (Subgroup.pi Set.univ s') = @piSetoid _ _ fun i ↦ rightRel (s' i) := by
+  refine Setoid.ext fun x y ↦ ?_
+  simp [Setoid.piSetoid_apply, rightRel_apply, Subgroup.mem_pi]
 
 /-- Right cosets are in bijection with left cosets. -/
 @[to_additive "Right cosets are in bijection with left cosets."]


### PR DESCRIPTION
Add lemmas relating `leftRel` and `rightRel` for a (pairwise or indexed) product of subgroups to the corresponding products of setoids.

From AperiodicMonotilesLean.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
