### PR TITLE
[Merged by Bors] - fix: remove `ToExpr Int` instance

### DIFF
--- a/Mathlib/Tactic/ToExpr.lean
+++ b/Mathlib/Tactic/ToExpr.lean
@@ -50,8 +50,6 @@ end override
 namespace Mathlib
 open Lean
 
-deriving instance ToExpr for Int
-
 set_option autoImplicit true in
 deriving instance ToExpr for ULift
 

--- a/test/eval_elab.lean
+++ b/test/eval_elab.lean
@@ -4,7 +4,7 @@ import Mathlib.Data.Finset.Sort
 
 #guard_expr eval% 2^10 =ₛ 1024
 
-#guard_expr (eval% 2^10 : Int) =ₛ .ofNat 1024
+#guard_expr (eval% 2^10 : Int) =ₛ (1024 : Int)
 
 -- https://leanprover.zulipchat.com/#narrow/stream/217875-Is-there-code-for-X.3F/topic/How.20to.20simplify.20this.20proof.20without.20using.20a.20have.20statement.3F/near/422294189
 section from_zulip


### PR DESCRIPTION
This is already provided by core, which also produces nicer expressions.

[Zulip thread](https://leanprover.zulipchat.com/#narrow/stream/270676-lean4/topic/Lean.2EToExpr.20Int/near/474914783)

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
