### PR TITLE
[Merged by Bors] - chore(Tactic/Polyrith): remove Python `requests` dependency in SageMath call

### DIFF
--- a/Mathlib/Tactic/Polyrith.lean
+++ b/Mathlib/Tactic/Polyrith.lean
@@ -390,8 +390,8 @@ Notes:
 * This tactic only works with a working internet connection, since it calls Sage
   using the SageCell web API at <https://sagecell.sagemath.org/>.
   Many thanks to the Sage team and organization for allowing this use.
-* This tactic assumes that the user has `python3` installed with version at least 3.6,
-  and available on the path. (Test by opening a terminal and executing `python3 --version`.)
+* This tactic assumes that the user has `python3` installed and available on the path.
+  (Test by opening a terminal and executing `python3 --version`.)
 
 Examples:
 

--- a/Mathlib/Tactic/Polyrith.lean
+++ b/Mathlib/Tactic/Polyrith.lean
@@ -390,9 +390,8 @@ Notes:
 * This tactic only works with a working internet connection, since it calls Sage
   using the SageCell web API at <https://sagecell.sagemath.org/>.
   Many thanks to the Sage team and organization for allowing this use.
-* This tactic assumes that the user has `python3` installed and available on the path.
-  (Test by opening a terminal and executing `python3 --version`.)
-  It also assumes that the `requests` library is installed: `python3 -m pip install requests`.
+* This tactic assumes that the user has `python3` installed with version at least 3.6,
+  and available on the path. (Test by opening a terminal and executing `python3 --version`.)
 
 Examples:
 

--- a/scripts/polyrith_sage.py
+++ b/scripts/polyrith_sage.py
@@ -69,8 +69,8 @@ def parse_response(resp: str) -> Dict[str, Any]:
 
 def evaluate_in_sage(query: str) -> Dict[str, Any]:
     data = urllib.parse.urlencode({'code': query}).encode('utf-8')
-    headers = {'content-type': 'application/x-www-form-urlencoded',
-               'user-agent': 'LeanProver (https://leanprover-community.github.io/)'}
+    headers = {'Content-Type': 'application/x-www-form-urlencoded',
+               'User-Agent': 'LeanProver (https://leanprover-community.github.io/)'}
     req = urllib.request.Request('https://sagecell.sagemath.org/service', data=data, headers=headers)
     with urllib.request.urlopen(req) as response:
         response_data = response.read().decode()

--- a/scripts/polyrith_sage.py
+++ b/scripts/polyrith_sage.py
@@ -1,10 +1,13 @@
 # This file is part of the `polyrith` tactic in `src/tactic/polyrith.lean`.
 # It interfaces between Lean and the Sage web interface.
 
-import requests
 import json
-import sys
 from os.path import join, dirname
+import sys
+from typing import Dict, Any
+import urllib.error
+import urllib.parse
+import urllib.request
 
 # These functions are used to format the output of Sage for parsing in Lean.
 # They are stored here as a string since they are passed to Sage via the web API.
@@ -59,15 +62,19 @@ class EvaluationError(Exception):
         self.message = message
         super().__init__(self.message)
 
-def parse_response(resp: str) -> str:
+def parse_response(resp: str) -> Dict[str, Any]:
     exp, data = resp.split(';', 1)
     return dict(power=int(exp), coeffs=json.loads(data))
 
 
-def evaluate_in_sage(query: str) -> str:
-    data = {'code': query}
-    headers = {'content-type': 'application/x-www-form-urlencoded'}
-    response = requests.post('https://sagecell.sagemath.org/service', data, headers=headers).json()
+def evaluate_in_sage(query: str) -> Dict[str, Any]:
+    data = urllib.parse.urlencode({'code': query}).encode('utf-8')
+    headers = {'content-type': 'application/x-www-form-urlencoded',
+               'user-agent': 'LeanProver (https://leanprover-community.github.io/)'}
+    req = urllib.request.Request('https://sagecell.sagemath.org/service', data=data, headers=headers)
+    with urllib.request.urlopen(req) as response:
+        response_data = response.read().decode()
+    response = json.loads(response_data)
     if response['success']:
         return parse_response(response.get('stdout'))
     elif 'execute_reply' in response and 'ename' in response['execute_reply'] and 'evalue' in response['execute_reply']:


### PR DESCRIPTION
*   Replaced the `requests` library needed by the Python script for SageMath API call, with native library `urllib.request`.
    *   E.g. if the user has no `pip install` rights, such as evaluation on a shared server
*   Added explicit `User-Agent` header to SageMath requests: `LeanProver (https://leanprover-community.github.io/)`. Previously, it was the default used by Python requests package `python-requests/...`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

I am not completely sure this works in all cases where requests worked.

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
