### PR TITLE
[Merged by Bors] - feat(NumberTheory/Fermat): fermat_eq_fermat_sub_one_pow_two_add_one

### DIFF
--- a/Mathlib/NumberTheory/Fermat.lean
+++ b/Mathlib/NumberTheory/Fermat.lean
@@ -58,9 +58,8 @@ theorem fermatNumber_eq_prod_add_two (n : ℕ) :
   rw [fermatNumber_product, Nat.sub_add_cancel]
   exact le_of_lt <| two_lt_fermatNumber _
 
-theorem fermat_succ_eq_fermat_sub_one_pow_two_add_one (n : ℕ) :
-    fermat (n + 1) = (fermat n - 1) ^ 2 + 1 := by
-  rw [fermat, pow_succ, mul_comm, Nat.pow_mul']
+theorem fermatNumber_succ (n : ℕ) : fermatNumber (n + 1) = (fermatNumber n - 1) ^ 2 + 1 := by
+  rw [fermatNumber, pow_succ, mul_comm, Nat.pow_mul']
   rfl
 
 /--

--- a/Mathlib/NumberTheory/Fermat.lean
+++ b/Mathlib/NumberTheory/Fermat.lean
@@ -58,6 +58,11 @@ theorem fermatNumber_eq_prod_add_two (n : ℕ) :
   rw [fermatNumber_product, Nat.sub_add_cancel]
   exact le_of_lt <| two_lt_fermatNumber _
 
+theorem fermat_eq_fermat_sub_one_pow_two_add_one (n : ℕ) :
+    fermat (n + 1) = (fermat n - 1) ^ 2 + 1 := by
+  rw [fermat, pow_succ, mul_comm, Nat.pow_mul']
+  rfl
+
 /--
 **Goldbach's theorem** : no two distinct Fermat numbers share a common factor greater than one.
 

--- a/Mathlib/NumberTheory/Fermat.lean
+++ b/Mathlib/NumberTheory/Fermat.lean
@@ -58,7 +58,7 @@ theorem fermatNumber_eq_prod_add_two (n : ℕ) :
   rw [fermatNumber_product, Nat.sub_add_cancel]
   exact le_of_lt <| two_lt_fermatNumber _
 
-theorem fermat_eq_fermat_sub_one_pow_two_add_one (n : ℕ) :
+theorem fermat_succ_eq_fermat_sub_one_pow_two_add_one (n : ℕ) :
     fermat (n + 1) = (fermat n - 1) ^ 2 + 1 := by
   rw [fermat, pow_succ, mul_comm, Nat.pow_mul']
   rfl


### PR DESCRIPTION
- [x] depends on: #17618
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
