### PR TITLE
[Merged by Bors] - chore(Category/Ring): turn CommRingCat and CommSemiRingCat into `abbrev`s

### DIFF
--- a/Mathlib/Algebra/Category/Ring/Basic.lean
+++ b/Mathlib/Algebra/Category/Ring/Basic.lean
@@ -273,7 +273,7 @@ instance hasForgetToAddCommGrp : HasForget₂ RingCat AddCommGrp where
 end RingCat
 
 /-- The category of commutative semirings. -/
-def CommSemiRingCat : Type (u + 1) :=
+abbrev CommSemiRingCat : Type (u + 1) :=
   Bundled CommSemiring
 
 namespace CommSemiRingCat
@@ -412,7 +412,7 @@ instance forgetReflectIsos : (forget CommSemiRingCat).ReflectsIsomorphisms where
 end CommSemiRingCat
 
 /-- The category of commutative rings. -/
-def CommRingCat : Type (u + 1) :=
+abbrev CommRingCat : Type (u + 1) :=
   Bundled CommRing
 
 namespace CommRingCat
@@ -420,20 +420,13 @@ namespace CommRingCat
 instance : BundledHom.ParentProjection @CommRing.toRing :=
   ⟨⟩
 
--- Porting note: deriving fails for concrete category.
--- see https://github.com/leanprover-community/mathlib4/issues/5020
-deriving instance LargeCategory for CommRingCat
-
-instance : ConcreteCategory CommRingCat := by
-  dsimp [CommRingCat]
-  infer_instance
-
-instance : CoeSort CommRingCat Type* where
-  coe X := X.α
-
 -- Porting note: Hinting to Lean that `forget R` and `R` are the same
 unif_hint forget_obj_eq_coe (R : CommRingCat) where ⊢
   (forget CommRingCat).obj R ≟ R
+
+-- Porting note: deriving fails for concrete category.
+-- see https://github.com/leanprover-community/mathlib4/issues/5020
+deriving instance LargeCategory for CommRingCat
 
 instance instCommRing (X : CommRingCat) : CommRing X := X.str
 


### PR DESCRIPTION
This builds on #11595 by also turning the commutative categories into abbreviations. Note that we keep some instances that the analogous changes in #11595 deleted: these turn out to not be strictly necessary, but prevent a few timeouts.

This change paves the way for #17583 changing unification hints for bundled categories. Previously, we would use a unification hint to turn `(forget CommRingCat).obj X` into `(X : Type*)`, after #17583 it would apply to `(forget (Bundled CommRing)).obj X` instead. That might assign some metavariables, leading to cases where the type of an object became `Bundled CommRing` instead of the expected `CommRingCat`. Unification hints are not very tweakable, so we can't really avoid this. So as a bit of a workaround, we can instead make the two reducibly defeq.

I expect no real performance hit, since we are replacing the discrimination tree key `CommRingCat` with `Bundled CommRing`, where both are not further (semi)reducibly reducible.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
