### PR TITLE
[Merged by Bors] - feat: remove the `SmoothManifoldWithCorners` assumption in the definition of tangent spaces

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -2773,6 +2773,7 @@ import Mathlib.Geometry.Manifold.MFDeriv.Basic
 import Mathlib.Geometry.Manifold.MFDeriv.Defs
 import Mathlib.Geometry.Manifold.MFDeriv.FDeriv
 import Mathlib.Geometry.Manifold.MFDeriv.SpecificFunctions
+import Mathlib.Geometry.Manifold.MFDeriv.Tangent
 import Mathlib.Geometry.Manifold.MFDeriv.UniqueDifferential
 import Mathlib.Geometry.Manifold.Metrizable
 import Mathlib.Geometry.Manifold.PartitionOfUnity

--- a/Mathlib/Analysis/Complex/UpperHalfPlane/Manifold.lean
+++ b/Mathlib/Analysis/Complex/UpperHalfPlane/Manifold.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Chris Birkbeck
 -/
 import Mathlib.Analysis.Complex.UpperHalfPlane.Topology
+import Mathlib.Geometry.Manifold.ContMDiff.Atlas
 import Mathlib.Geometry.Manifold.MFDeriv.Basic
 
 /-!

--- a/Mathlib/Geometry/Manifold/ContMDiffMFDeriv.lean
+++ b/Mathlib/Geometry/Manifold/ContMDiffMFDeriv.lean
@@ -3,7 +3,7 @@ Copyright (c) 2020 Sébastien Gouëzel. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Sébastien Gouëzel, Floris van Doorn
 -/
-import Mathlib.Geometry.Manifold.MFDeriv.UniqueDifferential
+import Mathlib.Geometry.Manifold.MFDeriv.Tangent
 import Mathlib.Geometry.Manifold.ContMDiffMap
 
 /-!

--- a/Mathlib/Geometry/Manifold/Diffeomorph.lean
+++ b/Mathlib/Geometry/Manifold/Diffeomorph.lean
@@ -383,8 +383,6 @@ end
 
 end Constructions
 
-variable [SmoothManifoldWithCorners I M] [SmoothManifoldWithCorners J N]
-
 theorem uniqueMDiffOn_image_aux (h : M ≃ₘ^n⟮I, J⟯ N) (hn : 1 ≤ n) {s : Set M}
     (hs : UniqueMDiffOn I s) : UniqueMDiffOn J (h '' s) := by
   convert hs.uniqueMDiffOn_preimage (h.toPartialHomeomorph_mdifferentiable hn)

--- a/Mathlib/Geometry/Manifold/IntegralCurve.lean
+++ b/Mathlib/Geometry/Manifold/IntegralCurve.lean
@@ -6,7 +6,7 @@ Authors: Winston Yin
 import Mathlib.Analysis.ODE.Gronwall
 import Mathlib.Analysis.ODE.PicardLindelof
 import Mathlib.Geometry.Manifold.InteriorBoundary
-import Mathlib.Geometry.Manifold.MFDeriv.Atlas
+import Mathlib.Geometry.Manifold.MFDeriv.Tangent
 
 /-!
 # Integral curves of vector fields on a manifold

--- a/Mathlib/Geometry/Manifold/IntegralCurve.lean
+++ b/Mathlib/Geometry/Manifold/IntegralCurve.lean
@@ -65,7 +65,7 @@ open Function Set
 variable
   {E : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E]
   {H : Type*} [TopologicalSpace H] {I : ModelWithCorners ℝ E H}
-  {M : Type*} [TopologicalSpace M] [ChartedSpace H M] [SmoothManifoldWithCorners I M]
+  {M : Type*} [TopologicalSpace M] [ChartedSpace H M]
 
 /-- If `γ : ℝ → M` is $C^1$ on `s : Set ℝ` and `v` is a vector field on `M`,
 `IsIntegralCurveOn γ v s` means `γ t` is tangent to `v (γ t)` for all `t ∈ s`. The value of `γ`
@@ -150,6 +150,7 @@ lemma IsIntegralCurveAt.continuousAt (hγ : IsIntegralCurveAt γ v t₀) :
 lemma IsIntegralCurve.continuous (hγ : IsIntegralCurve γ v) : Continuous γ :=
   continuous_iff_continuousAt.mpr fun _ ↦ (hγ.isIntegralCurveOn univ).continuousAt (mem_univ _)
 
+variable [SmoothManifoldWithCorners I M] in
 /-- If `γ` is an integral curve of a vector field `v`, then `γ t` is tangent to `v (γ t)` when
   expressed in the local chart around the initial point `γ t₀`. -/
 lemma IsIntegralCurveOn.hasDerivAt (hγ : IsIntegralCurveOn γ v s) {t : ℝ} (ht : t ∈ s)
@@ -168,6 +169,7 @@ lemma IsIntegralCurveOn.hasDerivAt (hγ : IsIntegralCurveOn γ v s) {t : ℝ} (h
     mfderiv_chartAt_eq_tangentCoordChange I hsrc]
   rfl
 
+variable [SmoothManifoldWithCorners I M] in
 lemma IsIntegralCurveAt.eventually_hasDerivAt (hγ : IsIntegralCurveAt γ v t₀) :
     ∀ᶠ t in 𝓝 t₀, HasDerivAt ((extChartAt I (γ t₀)) ∘ γ)
       (tangentCoordChange I (γ t) (γ t₀) (γ t) (v (γ t))) t := by
@@ -304,7 +306,7 @@ end Scaling
 
 section ExistUnique
 
-variable (t₀) {x₀ : M}
+variable [SmoothManifoldWithCorners I M] (t₀) {x₀ : M}
 
 /-- Existence of local integral curves for a $C^1$ vector field at interior points of a smooth
 manifold. -/

--- a/Mathlib/Geometry/Manifold/MFDeriv/Atlas.lean
+++ b/Mathlib/Geometry/Manifold/MFDeriv/Atlas.lean
@@ -127,37 +127,6 @@ theorem mdifferentiable_of_mem_atlas (h : e ∈ atlas H M) : e.MDifferentiable I
 theorem mdifferentiable_chart (x : M) : (chartAt H x).MDifferentiable I I :=
   mdifferentiable_of_mem_atlas _ (chart_mem_atlas _ _)
 
-/-- The derivative of the chart at a base point is the chart of the tangent bundle, composed with
-the identification between the tangent bundle of the model space and the product space. -/
-theorem tangentMap_chart {p q : TangentBundle I M} (h : q.1 ∈ (chartAt H p.1).source) :
-    tangentMap I I (chartAt H p.1) q =
-      (TotalSpace.toProd _ _).symm
-        ((chartAt (ModelProd H E) p : TangentBundle I M → ModelProd H E) q) := by
-  dsimp [tangentMap]
-  rw [MDifferentiableAt.mfderiv]
-  · rfl
-  · exact mdifferentiableAt_atlas _ (chart_mem_atlas _ _) h
-
-/-- The derivative of the inverse of the chart at a base point is the inverse of the chart of the
-tangent bundle, composed with the identification between the tangent bundle of the model space and
-the product space. -/
-theorem tangentMap_chart_symm {p : TangentBundle I M} {q : TangentBundle I H}
-    (h : q.1 ∈ (chartAt H p.1).target) :
-    tangentMap I I (chartAt H p.1).symm q =
-      (chartAt (ModelProd H E) p).symm (TotalSpace.toProd H E q) := by
-  dsimp only [tangentMap]
-  rw [MDifferentiableAt.mfderiv (mdifferentiableAt_atlas_symm _ (chart_mem_atlas _ _) h)]
-  simp only [ContinuousLinearMap.coe_coe, TangentBundle.chartAt, h, tangentBundleCore,
-    mfld_simps, (· ∘ ·)]
-  -- `simp` fails to apply `PartialEquiv.prod_symm` with `ModelProd`
-  congr
-  exact ((chartAt H (TotalSpace.proj p)).right_inv h).symm
-
-lemma mfderiv_chartAt_eq_tangentCoordChange {x y : M} (hsrc : x ∈ (chartAt H y).source) :
-    mfderiv I I (chartAt H y) x = tangentCoordChange I x y x := by
-  have := mdifferentiableAt_atlas I (ChartedSpace.chart_mem_atlas _) hsrc
-  simp [mfderiv, if_pos this, Function.comp_assoc]
-
 end Charts
 
 

--- a/Mathlib/Geometry/Manifold/MFDeriv/Atlas.lean
+++ b/Mathlib/Geometry/Manifold/MFDeriv/Atlas.lean
@@ -176,9 +176,6 @@ protected theorem mdifferentiableAt {x : M} (hx : x ∈ e.source) : MDifferentia
 theorem mdifferentiableAt_symm {x : M'} (hx : x ∈ e.target) : MDifferentiableAt I' I e.symm x :=
   (he.2 x hx).mdifferentiableAt (e.open_target.mem_nhds hx)
 
-variable [SmoothManifoldWithCorners I M] [SmoothManifoldWithCorners I' M']
-  [SmoothManifoldWithCorners I'' M'']
-
 theorem symm_comp_deriv {x : M} (hx : x ∈ e.source) :
     (mfderiv I' I e.symm (e x)).comp (mfderiv I I' e x) =
       ContinuousLinearMap.id 𝕜 (TangentSpace I x) := by

--- a/Mathlib/Geometry/Manifold/MFDeriv/Basic.lean
+++ b/Mathlib/Geometry/Manifold/MFDeriv/Basic.lean
@@ -257,22 +257,17 @@ theorem writtenInExtChartAt_comp (h : ContinuousWithinAt f s x) :
         (h.preimage_mem_nhdsWithin (extChartAt_source_mem_nhds _ _)))
   mfld_set_tac
 
-/- We name the typeclass variables related to `SmoothManifoldWithCorners` structure as they are
-necessary in lemmas mentioning the derivative, but not in lemmas about differentiability, so we
-want to include them or omit them when necessary. -/
-variable --[Is : SmoothManifoldWithCorners I M] [I's : SmoothManifoldWithCorners I' M']
-  --[I''s : SmoothManifoldWithCorners I'' M'']
-  {f' f₀' f₁' : TangentSpace I x →L[𝕜] TangentSpace I' (f x)}
+variable {f' f₀' f₁' : TangentSpace I x →L[𝕜] TangentSpace I' (f x)}
   {g' : TangentSpace I' (f x) →L[𝕜] TangentSpace I'' (g (f x))}
 
 /-- `UniqueMDiffWithinAt` achieves its goal: it implies the uniqueness of the derivative. -/
-nonrec theorem UniqueMDiffWithinAt.eq (U : UniqueMDiffWithinAt I s x)
+protected nonrec theorem UniqueMDiffWithinAt.eq (U : UniqueMDiffWithinAt I s x)
     (h : HasMFDerivWithinAt I I' f s x f') (h₁ : HasMFDerivWithinAt I I' f s x f₁') : f' = f₁' := by
   -- Porting note: didn't need `convert` because of finding instances by unification
   convert U.eq h.2 h₁.2
 
-theorem UniqueMDiffOn.eq (U : UniqueMDiffOn I s) (hx : x ∈ s) (h : HasMFDerivWithinAt I I' f s x f')
-    (h₁ : HasMFDerivWithinAt I I' f s x f₁') : f' = f₁' :=
+protected theorem UniqueMDiffOn.eq (U : UniqueMDiffOn I s) (hx : x ∈ s)
+    (h : HasMFDerivWithinAt I I' f s x f') (h₁ : HasMFDerivWithinAt I I' f s x f₁') : f' = f₁' :=
   UniqueMDiffWithinAt.eq (U _ hx) h h₁
 
 /-!

--- a/Mathlib/Geometry/Manifold/MFDeriv/Basic.lean
+++ b/Mathlib/Geometry/Manifold/MFDeriv/Basic.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Sébastien Gouëzel, Floris van Doorn
 -/
 import Mathlib.Geometry.Manifold.MFDeriv.Defs
+import Mathlib.Geometry.Manifold.ContMDiff.Basic
 
 /-!
 # Basic properties of the manifold Fréchet derivative

--- a/Mathlib/Geometry/Manifold/MFDeriv/Basic.lean
+++ b/Mathlib/Geometry/Manifold/MFDeriv/Basic.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Sébastien Gouëzel, Floris van Doorn
 -/
 import Mathlib.Geometry.Manifold.MFDeriv.Defs
-import Mathlib.Geometry.Manifold.ContMDiff.Basic
+import Mathlib.Geometry.Manifold.ContMDiff.Defs
 
 /-!
 # Basic properties of the manifold Fréchet derivative

--- a/Mathlib/Geometry/Manifold/MFDeriv/Basic.lean
+++ b/Mathlib/Geometry/Manifold/MFDeriv/Basic.lean
@@ -22,6 +22,8 @@ mimicking the API for Fréchet derivatives.
 
 noncomputable section
 
+assert_not_exists tangentBundleCore
+
 open scoped Topology Manifold
 open Set Bundle
 

--- a/Mathlib/Geometry/Manifold/MFDeriv/Basic.lean
+++ b/Mathlib/Geometry/Manifold/MFDeriv/Basic.lean
@@ -259,8 +259,8 @@ theorem writtenInExtChartAt_comp (h : ContinuousWithinAt f s x) :
 /- We name the typeclass variables related to `SmoothManifoldWithCorners` structure as they are
 necessary in lemmas mentioning the derivative, but not in lemmas about differentiability, so we
 want to include them or omit them when necessary. -/
-variable [Is : SmoothManifoldWithCorners I M] [I's : SmoothManifoldWithCorners I' M']
-  [I''s : SmoothManifoldWithCorners I'' M'']
+variable --[Is : SmoothManifoldWithCorners I M] [I's : SmoothManifoldWithCorners I' M']
+  --[I''s : SmoothManifoldWithCorners I'' M'']
   {f' f₀' f₁' : TangentSpace I x →L[𝕜] TangentSpace I' (f x)}
   {g' : TangentSpace I' (f x) →L[𝕜] TangentSpace I'' (g (f x))}
 
@@ -280,6 +280,7 @@ theorem UniqueMDiffOn.eq (U : UniqueMDiffOn I s) (hx : x ∈ s) (h : HasMFDerivW
 We mimic the API for functions between vector spaces
 -/
 
+variable [SmoothManifoldWithCorners I M] [SmoothManifoldWithCorners I' M'] in
 /-- One can reformulate differentiability within a set at a point as continuity within this set at
 this point, and differentiability in any chart containing that point. -/
 theorem mdifferentiableWithinAt_iff_of_mem_source {x' : M} {y : M'}
@@ -418,6 +419,7 @@ theorem mfderivWithin_eq_mfderiv (hs : UniqueMDiffWithinAt I s x) (h : MDifferen
   rw [← mfderivWithin_univ]
   exact mfderivWithin_subset (subset_univ _) hs h.mdifferentiableWithinAt
 
+variable [SmoothManifoldWithCorners I M] [SmoothManifoldWithCorners I' M'] in
 theorem mdifferentiableAt_iff_of_mem_source {x' : M} {y : M'}
     (hx : x' ∈ (chartAt H x).source) (hy : f x' ∈ (chartAt H' y).source) :
     MDifferentiableAt I I' f x' ↔

--- a/Mathlib/Geometry/Manifold/MFDeriv/Defs.lean
+++ b/Mathlib/Geometry/Manifold/MFDeriv/Defs.lean
@@ -3,7 +3,8 @@ Copyright (c) 2020 Sébastien Gouëzel. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Sébastien Gouëzel, Floris van Doorn
 -/
-import Mathlib.Geometry.Manifold.VectorBundle.Tangent
+import Mathlib.Geometry.Manifold.SmoothManifoldWithCorners
+import Mathlib.Geometry.Manifold.LocalInvariantProperties
 
 /-!
 # The derivative of functions between smooth manifolds

--- a/Mathlib/Geometry/Manifold/MFDeriv/SpecificFunctions.lean
+++ b/Mathlib/Geometry/Manifold/MFDeriv/SpecificFunctions.lean
@@ -28,12 +28,12 @@ section SpecificFunctions
 
 variable {𝕜 : Type*} [NontriviallyNormedField 𝕜] {E : Type*} [NormedAddCommGroup E]
   [NormedSpace 𝕜 E] {H : Type*} [TopologicalSpace H] (I : ModelWithCorners 𝕜 E H) {M : Type*}
-  [TopologicalSpace M] [ChartedSpace H M] [SmoothManifoldWithCorners I M] {E' : Type*}
+  [TopologicalSpace M] [ChartedSpace H M] {E' : Type*}
   [NormedAddCommGroup E'] [NormedSpace 𝕜 E'] {H' : Type*} [TopologicalSpace H']
   (I' : ModelWithCorners 𝕜 E' H') {M' : Type*} [TopologicalSpace M'] [ChartedSpace H' M']
-  [SmoothManifoldWithCorners I' M'] {E'' : Type*} [NormedAddCommGroup E''] [NormedSpace 𝕜 E'']
+  {E'' : Type*} [NormedAddCommGroup E''] [NormedSpace 𝕜 E'']
   {H'' : Type*} [TopologicalSpace H''] (I'' : ModelWithCorners 𝕜 E'' H'') {M'' : Type*}
-  [TopologicalSpace M''] [ChartedSpace H'' M''] [SmoothManifoldWithCorners I'' M'']
+  [TopologicalSpace M''] [ChartedSpace H'' M'']
 
 namespace ContinuousLinearMap
 

--- a/Mathlib/Geometry/Manifold/MFDeriv/Tangent.lean
+++ b/Mathlib/Geometry/Manifold/MFDeriv/Tangent.lean
@@ -1,5 +1,5 @@
 /-
-Copyright (c) 2020 Sébastien Gouëzel. All rights reserved.
+Copyright (c) 2024 Sébastien Gouëzel. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Sébastien Gouëzel, Floris van Doorn
 -/
@@ -9,6 +9,10 @@ import Mathlib.Geometry.Manifold.VectorBundle.Tangent
 
 /-!
 # Derivatives of maps in the tangent bundle
+
+This file contains properties of derivatives which need the manifold structure of the tangent
+bundle. Notably, it includes formulas for the tangent maps to charts, and unique differentiability
+statements for subsets of the tangent bundle.
 -/
 
 open Bundle

--- a/Mathlib/Geometry/Manifold/MFDeriv/Tangent.lean
+++ b/Mathlib/Geometry/Manifold/MFDeriv/Tangent.lean
@@ -1,0 +1,60 @@
+/-
+Copyright (c) 2020 Sébastien Gouëzel. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Sébastien Gouëzel, Floris van Doorn
+-/
+import Mathlib.Geometry.Manifold.MFDeriv.Atlas
+import Mathlib.Geometry.Manifold.MFDeriv.UniqueDifferential
+import Mathlib.Geometry.Manifold.VectorBundle.Tangent
+
+/-!
+# Derivatives of maps in the tangent bundle
+-/
+
+open Bundle
+
+variable {𝕜 : Type*} [NontriviallyNormedField 𝕜]
+  {E : Type*} [NormedAddCommGroup E] [NormedSpace 𝕜 E] {H : Type*} [TopologicalSpace H]
+  (I : ModelWithCorners 𝕜 E H) {M : Type*} [TopologicalSpace M] [ChartedSpace H M]
+  {E' : Type*} [NormedAddCommGroup E'] [NormedSpace 𝕜 E'] {H' : Type*} [TopologicalSpace H']
+  (I' : ModelWithCorners 𝕜 E' H') {M' : Type*} [TopologicalSpace M'] [ChartedSpace H' M']
+  {E'' : Type*} [NormedAddCommGroup E''] [NormedSpace 𝕜 E''] {H'' : Type*} [TopologicalSpace H'']
+  (I'' : ModelWithCorners 𝕜 E'' H'') {M'' : Type*} [TopologicalSpace M''] [ChartedSpace H'' M'']
+  [SmoothManifoldWithCorners I M]
+
+/-- The derivative of the chart at a base point is the chart of the tangent bundle, composed with
+the identification between the tangent bundle of the model space and the product space. -/
+theorem tangentMap_chart {p q : TangentBundle I M} (h : q.1 ∈ (chartAt H p.1).source) :
+    tangentMap I I (chartAt H p.1) q =
+      (TotalSpace.toProd _ _).symm
+        ((chartAt (ModelProd H E) p : TangentBundle I M → ModelProd H E) q) := by
+  dsimp [tangentMap]
+  rw [MDifferentiableAt.mfderiv]
+  · rfl
+  · exact mdifferentiableAt_atlas _ (chart_mem_atlas _ _) h
+
+/-- The derivative of the inverse of the chart at a base point is the inverse of the chart of the
+tangent bundle, composed with the identification between the tangent bundle of the model space and
+the product space. -/
+theorem tangentMap_chart_symm {p : TangentBundle I M} {q : TangentBundle I H}
+    (h : q.1 ∈ (chartAt H p.1).target) :
+    tangentMap I I (chartAt H p.1).symm q =
+      (chartAt (ModelProd H E) p).symm (TotalSpace.toProd H E q) := by
+  dsimp only [tangentMap]
+  rw [MDifferentiableAt.mfderiv (mdifferentiableAt_atlas_symm _ (chart_mem_atlas _ _) h)]
+  simp only [ContinuousLinearMap.coe_coe, TangentBundle.chartAt, h, tangentBundleCore,
+    mfld_simps, (· ∘ ·)]
+  -- `simp` fails to apply `PartialEquiv.prod_symm` with `ModelProd`
+  congr
+  exact ((chartAt H (TotalSpace.proj p)).right_inv h).symm
+
+lemma mfderiv_chartAt_eq_tangentCoordChange {x y : M} (hsrc : x ∈ (chartAt H y).source) :
+    mfderiv I I (chartAt H y) x = tangentCoordChange I x y x := by
+  have := mdifferentiableAt_atlas I (ChartedSpace.chart_mem_atlas _) hsrc
+  simp [mfderiv, if_pos this, Function.comp_assoc]
+
+/-- The preimage under the projection from the tangent bundle of a set with unique differential in
+the basis also has unique differential. -/
+theorem UniqueMDiffOn.tangentBundle_proj_preimage {s : Set M} (hs : UniqueMDiffOn I s) :
+    UniqueMDiffOn I.tangent (π E (TangentSpace I) ⁻¹' s) :=
+  hs.smooth_bundle_preimage _

--- a/Mathlib/Geometry/Manifold/MFDeriv/UniqueDifferential.lean
+++ b/Mathlib/Geometry/Manifold/MFDeriv/UniqueDifferential.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Sébastien Gouëzel, Floris van Doorn
 -/
 import Mathlib.Geometry.Manifold.MFDeriv.Atlas
+import Mathlib.Geometry.Manifold.VectorBundle.Basic
 
 /-!
 # Unique derivative sets in manifolds
@@ -145,12 +146,5 @@ unique differential in the basis also has unique differential. -/
 theorem UniqueMDiffOn.smooth_bundle_preimage (hs : UniqueMDiffOn I s) :
     UniqueMDiffOn (I.prod 𝓘(𝕜, F)) (π F Z ⁻¹' s) := fun _p hp ↦
   (hs _ hp).smooth_bundle_preimage
-
-variable [SmoothManifoldWithCorners I M]  in
-/-- The preimage under the projection from the tangent bundle of a set with unique differential in
-the basis also has unique differential. -/
-theorem UniqueMDiffOn.tangentBundle_proj_preimage (hs : UniqueMDiffOn I s) :
-    UniqueMDiffOn I.tangent (π E (TangentSpace I) ⁻¹' s) :=
-  hs.smooth_bundle_preimage _
 
 end UniqueMDiff

--- a/Mathlib/Geometry/Manifold/MFDeriv/UniqueDifferential.lean
+++ b/Mathlib/Geometry/Manifold/MFDeriv/UniqueDifferential.lean
@@ -32,11 +32,10 @@ variable {𝕜 : Type*} [NontriviallyNormedField 𝕜] {E : Type*} [NormedAddCom
   [TopologicalSpace M] [ChartedSpace H M] {E' : Type*}
   [NormedAddCommGroup E'] [NormedSpace 𝕜 E'] {H' : Type*} [TopologicalSpace H']
   {I' : ModelWithCorners 𝕜 E' H'} {M' : Type*} [TopologicalSpace M'] [ChartedSpace H' M']
-  [SmoothManifoldWithCorners I' M'] {M'' : Type*} [TopologicalSpace M''] [ChartedSpace H' M'']
+  {M'' : Type*} [TopologicalSpace M''] [ChartedSpace H' M'']
   {s : Set M} {x : M}
 
 section
-variable [SmoothManifoldWithCorners I M]
 
 /-- If `s` has the unique differential property at `x`, `f` is differentiable within `s` at x` and
 its derivative has dense range, then `f '' s` has the unique differential property at `f x`. -/
@@ -82,6 +81,7 @@ theorem UniqueMDiffOn.uniqueMDiffOn_preimage (hs : UniqueMDiffOn I s) {e : Parti
     (he : e.MDifferentiable I I') : UniqueMDiffOn I' (e.target ∩ e.symm ⁻¹' s) := fun _x hx ↦
   e.right_inv hx.1 ▸ (hs _ hx.2).preimage_partialHomeomorph he (e.map_target hx.1)
 
+variable [SmoothManifoldWithCorners I M]  in
 /-- If a set in a manifold has the unique derivative property, then its pullback by any extended
 chart, in the vector space, also has the unique derivative property. -/
 theorem UniqueMDiffOn.uniqueDiffOn_target_inter (hs : UniqueMDiffOn I s) (x : M) :
@@ -94,6 +94,7 @@ theorem UniqueMDiffOn.uniqueDiffOn_target_inter (hs : UniqueMDiffOn I s) (x : M)
     (fun y hy ↦ hasMFDerivWithinAt_extChartAt I hy.2)
     fun y hy ↦ ((mdifferentiable_chart _ _).mfderiv_surjective hy.2).denseRange
 
+variable [SmoothManifoldWithCorners I M]  in
 /-- When considering functions between manifolds, this statement shows up often. It entails
 the unique differential of the pullback in extended charts of the set where the function can
 be read in the charts. -/
@@ -120,8 +121,6 @@ theorem Trivialization.mdifferentiable (e : Trivialization F (π F Z)) [MemTrivi
     e.toPartialHomeomorph.MDifferentiable (I.prod 𝓘(𝕜, F)) (I.prod 𝓘(𝕜, F)) :=
   ⟨(e.smoothOn I).mdifferentiableOn, (e.smoothOn_symm I).mdifferentiableOn⟩
 
-variable [SmoothManifoldWithCorners I M]
-
 theorem UniqueMDiffWithinAt.smooth_bundle_preimage {p : TotalSpace F Z}
     (hs : UniqueMDiffWithinAt I s p.proj) :
     UniqueMDiffWithinAt (I.prod 𝓘(𝕜, F)) (π F Z ⁻¹' s) p := by
@@ -147,6 +146,7 @@ theorem UniqueMDiffOn.smooth_bundle_preimage (hs : UniqueMDiffOn I s) :
     UniqueMDiffOn (I.prod 𝓘(𝕜, F)) (π F Z ⁻¹' s) := fun _p hp ↦
   (hs _ hp).smooth_bundle_preimage
 
+variable [SmoothManifoldWithCorners I M]  in
 /-- The preimage under the projection from the tangent bundle of a set with unique differential in
 the basis also has unique differential. -/
 theorem UniqueMDiffOn.tangentBundle_proj_preimage (hs : UniqueMDiffOn I s) :

--- a/Mathlib/Geometry/Manifold/SmoothManifoldWithCorners.lean
+++ b/Mathlib/Geometry/Manifold/SmoothManifoldWithCorners.lean
@@ -3,10 +3,11 @@ Copyright (c) 2019 Sébastien Gouëzel. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Sébastien Gouëzel
 -/
-import Mathlib.Geometry.Manifold.ChartedSpace
+import Mathlib.Analysis.Convex.Normed
 import Mathlib.Analysis.Normed.Module.FiniteDimension
 import Mathlib.Analysis.Calculus.ContDiff.Basic
 import Mathlib.Data.Bundle
+import Mathlib.Geometry.Manifold.ChartedSpace
 
 /-!
 # Smooth manifolds (possibly with boundary or corners)
@@ -1408,3 +1409,12 @@ abbrev TangentBundle :=
   Bundle.TotalSpace E (TangentSpace I : M → Type _)
 
 end TangentSpace
+
+section Real
+
+variable {E : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E] {H : Type*} [TopologicalSpace H]
+  {I : ModelWithCorners ℝ E H} {M : Type*} [TopologicalSpace M] [ChartedSpace H M] {x : M}
+
+instance : PathConnectedSpace (TangentSpace I x) := inferInstanceAs (PathConnectedSpace E)
+
+end Real

--- a/Mathlib/Geometry/Manifold/SmoothManifoldWithCorners.lean
+++ b/Mathlib/Geometry/Manifold/SmoothManifoldWithCorners.lean
@@ -6,6 +6,7 @@ Authors: Sébastien Gouëzel
 import Mathlib.Geometry.Manifold.ChartedSpace
 import Mathlib.Analysis.Normed.Module.FiniteDimension
 import Mathlib.Analysis.Calculus.ContDiff.Basic
+import Mathlib.Data.Bundle
 
 /-!
 # Smooth manifolds (possibly with boundary or corners)
@@ -1370,7 +1371,7 @@ section TangentSpace
 for `E`. This is enough to define linear maps between tangent spaces, for instance derivatives,
 but the interesting part is to define a manifold structure on the whole tangent bundle, which
 requires that `M` is a smooth manifold with corners. The definition is put here to avoid importing
-all the bundle structure when defining manifold derivatives. -/
+all the smooth bundle structure when defining manifold derivatives. -/
 
 set_option linter.unusedVariables false in
 /-- The tangent space at a point of the manifold `M`. It is just `E`. We could use instead
@@ -1397,5 +1398,13 @@ instance {x : M} : AddCommGroup (TangentSpace I x) := inferInstanceAs (AddCommGr
 instance {x : M} : TopologicalAddGroup (TangentSpace I x) := inferInstanceAs (TopologicalAddGroup E)
 instance {x : M} : Module 𝕜 (TangentSpace I x) := inferInstanceAs (Module 𝕜 E)
 instance {x : M} : Inhabited (TangentSpace I x) := ⟨0⟩
+
+variable (M) in
+-- is empty if the base manifold is empty
+/-- The tangent bundle to a smooth manifold, as a Sigma type. Defined in terms of
+`Bundle.TotalSpace` to be able to put a suitable topology on it. -/
+-- Porting note(#5171): was nolint has_nonempty_instance
+abbrev TangentBundle :=
+  Bundle.TotalSpace E (TangentSpace I : M → Type _)
 
 end TangentSpace

--- a/Mathlib/Geometry/Manifold/SmoothManifoldWithCorners.lean
+++ b/Mathlib/Geometry/Manifold/SmoothManifoldWithCorners.lean
@@ -1363,3 +1363,34 @@ lemma Manifold.locallyCompact_of_finiteDimensional
   exact ChartedSpace.locallyCompactSpace H M
 
 end Topology
+
+section TangentSpace
+
+/- We define the tangent space to `M` modelled on `I : ModelWithCorners 𝕜 E H` as a type synonym
+for `E`. This is enough to define linear maps between tangent spaces, for instance derivatives,
+but the interesting part is to define a manifold structure on the whole tangent bundle, which
+requires that `M` is a smooth manifold with corners. The definition is put here to avoid importing
+all the bundle structure when defining manifold derivatives. -/
+
+set_option linter.unusedVariables false in
+/-- The tangent space at a point of the manifold `M`. It is just `E`. We could use instead
+`(tangentBundleCore I M).to_topological_vector_bundle_core.fiber x`, but we use `E` to help the
+kernel.
+-/
+@[nolint unusedArguments]
+def TangentSpace {𝕜 : Type*} [NontriviallyNormedField 𝕜]
+    {E : Type u} [NormedAddCommGroup E] [NormedSpace 𝕜 E]
+    {H : Type*} [TopologicalSpace H] (I : ModelWithCorners 𝕜 E H)
+    {M : Type*} [TopologicalSpace M] [ChartedSpace H M] (_x : M) : Type u := E
+-- Porting note: was deriving TopologicalSpace, AddCommGroup, TopologicalAddGroup
+
+variable {𝕜 : Type*} [NontriviallyNormedField 𝕜]
+    {E : Type u} [NormedAddCommGroup E] [NormedSpace 𝕜 E]
+    {H : Type*} [TopologicalSpace H] (I : ModelWithCorners 𝕜 E H)
+    {M : Type*} [TopologicalSpace M] [ChartedSpace H M]
+
+instance {x : M} : TopologicalSpace (TangentSpace I x) := inferInstanceAs (TopologicalSpace E)
+instance {x : M} : AddCommGroup (TangentSpace I x) := inferInstanceAs (AddCommGroup E)
+instance {x : M} : TopologicalAddGroup (TangentSpace I x) := inferInstanceAs (TopologicalAddGroup E)
+
+end TangentSpace

--- a/Mathlib/Geometry/Manifold/SmoothManifoldWithCorners.lean
+++ b/Mathlib/Geometry/Manifold/SmoothManifoldWithCorners.lean
@@ -1384,6 +1384,9 @@ def TangentSpace {𝕜 : Type*} [NontriviallyNormedField 𝕜]
     {M : Type*} [TopologicalSpace M] [ChartedSpace H M] (_x : M) : Type u := E
 -- Porting note: was deriving TopologicalSpace, AddCommGroup, TopologicalAddGroup
 
+/- In general, the definition of `TangentSpace` is not reducible, so that type class inference
+does not pick wrong instances. We record the right instances for them. -/
+
 variable {𝕜 : Type*} [NontriviallyNormedField 𝕜]
     {E : Type u} [NormedAddCommGroup E] [NormedSpace 𝕜 E]
     {H : Type*} [TopologicalSpace H] (I : ModelWithCorners 𝕜 E H)
@@ -1392,5 +1395,7 @@ variable {𝕜 : Type*} [NontriviallyNormedField 𝕜]
 instance {x : M} : TopologicalSpace (TangentSpace I x) := inferInstanceAs (TopologicalSpace E)
 instance {x : M} : AddCommGroup (TangentSpace I x) := inferInstanceAs (AddCommGroup E)
 instance {x : M} : TopologicalAddGroup (TangentSpace I x) := inferInstanceAs (TopologicalAddGroup E)
+instance {x : M} : Module 𝕜 (TangentSpace I x) := inferInstanceAs (Module 𝕜 E)
+instance {x : M} : Inhabited (TangentSpace I x) := ⟨0⟩
 
 end TangentSpace

--- a/Mathlib/Geometry/Manifold/SmoothManifoldWithCorners.lean
+++ b/Mathlib/Geometry/Manifold/SmoothManifoldWithCorners.lean
@@ -82,6 +82,14 @@ but again in product manifolds the natural model with corners will not be this o
 one (and they are not defeq as `(fun p : E × F ↦ (p.1, p.2))` is not defeq to the identity).
 So, it is important to use the above incantation to maximize the applicability of theorems.
 
+We also define `TangentSpace I (x : M)` as a type synonym of `E`, and `TangentBundle I M` as a
+type synonym for `Π (x : M), TangentSpace I x` (in the form of an
+abbrev of `Bundle.TotalSpace E (TangentSpace I : M → Type _)`). Apart from basic typeclasses on
+`TangentSpace I x`, nothing is proved about them in this file, but it is useful to have them
+available as definitions early on to get a clean import structure below. The smooth bundle structure
+is defined in `VectorBundle.Tangent`, while the definition is used to talk about manifold
+derivatives in `MFDeriv.Basic`, and neither file needs import the other.
+
 ## Implementation notes
 
 We want to talk about manifolds modelled on a vector space, but also on manifolds with

--- a/Mathlib/Geometry/Manifold/SmoothManifoldWithCorners.lean
+++ b/Mathlib/Geometry/Manifold/SmoothManifoldWithCorners.lean
@@ -1389,15 +1389,15 @@ def TangentSpace {𝕜 : Type*} [NontriviallyNormedField 𝕜]
 does not pick wrong instances. We record the right instances for them. -/
 
 variable {𝕜 : Type*} [NontriviallyNormedField 𝕜]
-    {E : Type u} [NormedAddCommGroup E] [NormedSpace 𝕜 E]
-    {H : Type*} [TopologicalSpace H] (I : ModelWithCorners 𝕜 E H)
-    {M : Type*} [TopologicalSpace M] [ChartedSpace H M]
+  {E : Type*} [NormedAddCommGroup E] [NormedSpace 𝕜 E]
+  {H : Type*} [TopologicalSpace H] (I : ModelWithCorners 𝕜 E H)
+  {M : Type*} [TopologicalSpace M] [ChartedSpace H M] {x : M}
 
-instance {x : M} : TopologicalSpace (TangentSpace I x) := inferInstanceAs (TopologicalSpace E)
-instance {x : M} : AddCommGroup (TangentSpace I x) := inferInstanceAs (AddCommGroup E)
-instance {x : M} : TopologicalAddGroup (TangentSpace I x) := inferInstanceAs (TopologicalAddGroup E)
-instance {x : M} : Module 𝕜 (TangentSpace I x) := inferInstanceAs (Module 𝕜 E)
-instance {x : M} : Inhabited (TangentSpace I x) := ⟨0⟩
+instance : TopologicalSpace (TangentSpace I x) := inferInstanceAs (TopologicalSpace E)
+instance : AddCommGroup (TangentSpace I x) := inferInstanceAs (AddCommGroup E)
+instance : TopologicalAddGroup (TangentSpace I x) := inferInstanceAs (TopologicalAddGroup E)
+instance : Module 𝕜 (TangentSpace I x) := inferInstanceAs (Module 𝕜 E)
+instance : Inhabited (TangentSpace I x) := ⟨0⟩
 
 variable (M) in
 -- is empty if the base manifold is empty

--- a/Mathlib/Geometry/Manifold/VectorBundle/SmoothSection.lean
+++ b/Mathlib/Geometry/Manifold/VectorBundle/SmoothSection.lean
@@ -5,8 +5,8 @@ Authors: Heather Macbeth, Floris van Doorn
 -/
 import Mathlib.Geometry.Manifold.Algebra.LieGroup
 import Mathlib.Geometry.Manifold.MFDeriv.Basic
-import Mathlib.Geometry.Manifold.VectorBundle.Tangent
 import Mathlib.Topology.ContinuousMap.Basic
+import Mathlib.Geometry.Manifold.VectorBundle.Basic
 
 /-!
 # Smooth sections

--- a/Mathlib/Geometry/Manifold/VectorBundle/SmoothSection.lean
+++ b/Mathlib/Geometry/Manifold/VectorBundle/SmoothSection.lean
@@ -3,9 +3,10 @@ Copyright (c) 2023 Heather Macbeth. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Heather Macbeth, Floris van Doorn
 -/
-import Mathlib.Geometry.Manifold.MFDeriv.Basic
-import Mathlib.Topology.ContinuousMap.Basic
 import Mathlib.Geometry.Manifold.Algebra.LieGroup
+import Mathlib.Geometry.Manifold.MFDeriv.Basic
+import Mathlib.Geometry.Manifold.VectorBundle.Tangent
+import Mathlib.Topology.ContinuousMap.Basic
 
 /-!
 # Smooth sections

--- a/Mathlib/Geometry/Manifold/VectorBundle/Tangent.lean
+++ b/Mathlib/Geometry/Manifold/VectorBundle/Tangent.lean
@@ -164,20 +164,6 @@ lemma continuousOn_tangentCoordChange (x y : M) : ContinuousOn (tangentCoordChan
 
 end tangentCoordChange
 
-/-- The tangent space at a point of the manifold `M`. It is just `E`. We could use instead
-`(tangentBundleCore I M).to_topological_vector_bundle_core.fiber x`, but we use `E` to help the
-kernel.
--/
-@[nolint unusedArguments]
-def TangentSpace {𝕜} [NontriviallyNormedField 𝕜] {E} [NormedAddCommGroup E] [NormedSpace 𝕜 E]
-    {H} [TopologicalSpace H] (I : ModelWithCorners 𝕜 E H) {M} [TopologicalSpace M]
-    [ChartedSpace H M] [SmoothManifoldWithCorners I M] (_x : M) : Type* := E
--- Porting note: was deriving TopologicalSpace, AddCommGroup, TopologicalAddGroup
-
-instance {x : M} : TopologicalSpace (TangentSpace I x) := inferInstanceAs (TopologicalSpace E)
-instance {x : M} : AddCommGroup (TangentSpace I x) := inferInstanceAs (AddCommGroup E)
-instance {x : M} : TopologicalAddGroup (TangentSpace I x) := inferInstanceAs (TopologicalAddGroup E)
-
 variable (M)
 
 -- is empty if the base manifold is empty

--- a/Mathlib/Geometry/Manifold/VectorBundle/Tangent.lean
+++ b/Mathlib/Geometry/Manifold/VectorBundle/Tangent.lean
@@ -9,10 +9,14 @@ import Mathlib.Geometry.Manifold.VectorBundle.Basic
 
 This file defines the tangent bundle as a smooth vector bundle.
 
-Let `M` be a smooth manifold with corners with model `I` on `(E, H)`. We define the tangent bundle
-of `M` using the `VectorBundleCore` construction indexed by the charts of `M` with fibers `E`.
-Given two charts `i, j : PartialHomeomorph M H`, the coordinate change between `i` and `j`
-at a point `x : M` is the derivative of the composite
+Let `M` be a manifold with model `I` on `(E, H)`. The tangent space `TangentSpace I (x : M)` has
+already been defined as a type synonym for `E`, and the tangent bundle `TangentBundle I M` as an
+abbrev of `Bundle.TotalSpace E (TangentSpace I : M → Type _)`.
+
+In this file, when `M` is smooth, we construct a smooth vector bundle structure
+on `TangentBundle I M` using the `VectorBundleCore` construction indexed by the charts of `M`
+with fibers `E`. Given two charts `i, j : PartialHomeomorph M H`, the coordinate change
+between `i` and `j` at a point `x : M` is the derivative of the composite
 ```
   I.symm   i.symm    j     I
 E -----> H -----> M --> H --> E
@@ -20,12 +24,13 @@ E -----> H -----> M --> H --> E
 within the set `range I ⊆ E` at `I (i x) : E`.
 This defines a smooth vector bundle `TangentBundle` with fibers `TangentSpace`.
 
-## Main definitions
+## Main definitions and results
 
-* `TangentSpace I M x` is the fiber of the tangent bundle at `x : M`, which is defined to be `E`.
+* `tangentBundleCore I M` is the vector bundle core for the tangent bundle over `M`.
 
-* `TangentBundle I M` is the total space of `TangentSpace I M`, proven to be a smooth vector
-  bundle.
+* When `M` is a smooth manifold with corners, `TangentBundle I M` has a smooth vector bundle
+structure over `M`. In particular, it is a topological space, a vector bundle, a fiber bundle,
+and a smooth manifold.
 -/
 
 

--- a/Mathlib/Geometry/Manifold/VectorBundle/Tangent.lean
+++ b/Mathlib/Geometry/Manifold/VectorBundle/Tangent.lean
@@ -177,22 +177,6 @@ local notation "TM" => TangentBundle I M
 
 section TangentBundleInstances
 
-/- In general, the definition of `TangentSpace` is not reducible, so that type class inference
-does not pick wrong instances. In this section, we record the right instances for
-them, noting in particular that the tangent bundle is a smooth manifold. -/
-section
-
-variable {M}
-variable (x : M)
-
-instance : Module 𝕜 (TangentSpace I x) := inferInstanceAs (Module 𝕜 E)
-
-instance : Inhabited (TangentSpace I x) := ⟨0⟩
-
--- Porting note: removed unneeded ContinuousAdd (TangentSpace I x)
-
-end
-
 instance : TopologicalSpace TM :=
   (tangentBundleCore I M).toTopologicalSpace
 

--- a/Mathlib/Geometry/Manifold/VectorBundle/Tangent.lean
+++ b/Mathlib/Geometry/Manifold/VectorBundle/Tangent.lean
@@ -4,7 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Floris van Doorn, Heather Macbeth
 -/
 import Mathlib.Geometry.Manifold.VectorBundle.Basic
-import Mathlib.Analysis.Convex.Normed
 
 /-! # Tangent bundles
 
@@ -65,7 +64,7 @@ variable (M)
 open SmoothManifoldWithCorners
 
 /-- Let `M` be a smooth manifold with corners with model `I` on `(E, H)`.
-Then `VectorBundleCore I M` is the vector bundle core for the tangent bundle over `M`.
+Then `tangentBundleCore I M` is the vector bundle core for the tangent bundle over `M`.
 It is indexed by the atlas of `M`, with fiber `E` and its change of coordinates from the chart `i`
 to the chart `j` at point `x : M` is the derivative of the composite
 ```
@@ -411,13 +410,3 @@ theorem inTangentCoordinates_eq (f : N → M) (g : N → M') (ϕ : N → E →L[
 end inTangentCoordinates
 
 end General
-
-section Real
-
-variable {E : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E] {H : Type*} [TopologicalSpace H]
-  {I : ModelWithCorners ℝ E H} {M : Type*} [TopologicalSpace M] [ChartedSpace H M]
-  [SmoothManifoldWithCorners I M]
-
-instance {x : M} : PathConnectedSpace (TangentSpace I x) := by unfold TangentSpace; infer_instance
-
-end Real

--- a/Mathlib/Geometry/Manifold/VectorBundle/Tangent.lean
+++ b/Mathlib/Geometry/Manifold/VectorBundle/Tangent.lean
@@ -166,13 +166,6 @@ end tangentCoordChange
 
 variable (M)
 
--- is empty if the base manifold is empty
-/-- The tangent bundle to a smooth manifold, as a Sigma type. Defined in terms of
-`Bundle.TotalSpace` to be able to put a suitable topology on it. -/
--- Porting note(#5171): was nolint has_nonempty_instance
-abbrev TangentBundle :=
-  Bundle.TotalSpace E (TangentSpace I : M → Type _)
-
 local notation "TM" => TangentBundle I M
 
 section TangentBundleInstances

--- a/scripts/noshake.json
+++ b/scripts/noshake.json
@@ -346,11 +346,15 @@
   "Mathlib.Lean.Expr.Basic": ["Batteries.Logic"],
   "Mathlib.Init.Data.Nat.Lemmas": ["Batteries.Data.Nat.Lemmas", "Batteries.WF"],
   "Mathlib.GroupTheory.MonoidLocalization.Basic": ["Mathlib.Init.Data.Prod"],
+  "Mathlib.Geometry.Manifold.VectorBundle.SmoothSection":
+  ["Mathlib.Geometry.Manifold.VectorBundle.Tangent"],
   "Mathlib.Geometry.Manifold.Sheaf.Smooth":
   ["Mathlib.CategoryTheory.Sites.Whiskering"],
   "Mathlib.Geometry.Manifold.PoincareConjecture":
   ["Mathlib.AlgebraicTopology.FundamentalGroupoid.SimplyConnected",
    "Mathlib.Util.Superscript"],
+  "Mathlib.Geometry.Manifold.MFDeriv.Basic":
+  ["Mathlib.Geometry.Manifold.ContMDiff.Basic"],
   "Mathlib.Data.Vector.Basic": ["Mathlib.Control.Applicative"],
   "Mathlib.Data.Set.Image": ["Batteries.Tactic.Congr"],
   "Mathlib.Data.Seq.Parallel": ["Mathlib.Init.Data.Prod"],

--- a/scripts/noshake.json
+++ b/scripts/noshake.json
@@ -346,15 +346,11 @@
   "Mathlib.Lean.Expr.Basic": ["Batteries.Logic"],
   "Mathlib.Init.Data.Nat.Lemmas": ["Batteries.Data.Nat.Lemmas", "Batteries.WF"],
   "Mathlib.GroupTheory.MonoidLocalization.Basic": ["Mathlib.Init.Data.Prod"],
-  "Mathlib.Geometry.Manifold.VectorBundle.SmoothSection":
-  ["Mathlib.Geometry.Manifold.VectorBundle.Tangent"],
   "Mathlib.Geometry.Manifold.Sheaf.Smooth":
   ["Mathlib.CategoryTheory.Sites.Whiskering"],
   "Mathlib.Geometry.Manifold.PoincareConjecture":
   ["Mathlib.AlgebraicTopology.FundamentalGroupoid.SimplyConnected",
    "Mathlib.Util.Superscript"],
-  "Mathlib.Geometry.Manifold.MFDeriv.Basic":
-  ["Mathlib.Geometry.Manifold.ContMDiff.Basic"],
   "Mathlib.Data.Vector.Basic": ["Mathlib.Control.Applicative"],
   "Mathlib.Data.Set.Image": ["Batteries.Tactic.Congr"],
   "Mathlib.Data.Seq.Parallel": ["Mathlib.Init.Data.Prod"],


### PR DESCRIPTION
Currently, the definition of the tangent space to a manifold includes (as a nolinted unused parameter) the assumption that the manifold is smooth. However, many statements make sense without this assumption (notably differentiability statements), and including it forces to include a lot of machinery on smooth bundles in the definition of `MDifferentiableWithinAt`, say.

We remove the assumption from the definition. This makes it possible to remove the assumption `SmoothManifoldWithCorners` from a bunch of statements (including some where it is clearly irrelevant), and disentangle our import structure, without any bad consequence as far as I can tell.

There is nothing added or removed in this PR, just moving things around and removing `[SmoothManifoldWithCorners I M]` assumptions.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
