### PR TITLE
[Merged by Bors] - feat: virtually nilpotent groups

### DIFF
--- a/Mathlib/GroupTheory/Nilpotent.lean
+++ b/Mathlib/GroupTheory/Nilpotent.lean
@@ -185,7 +185,7 @@ lemma isNilpotent_congr {H : Type*} [Group H] (e : G ≃* H) : IsNilpotent G ↔
 
 variable (G) in
 /-- A group `G` is virtually nilpotent if it has a nilpotent cofinite subgroup `N`. -/
-def IsVirtuallyNilpotent : Prop := ∃ N : Subgroup G, IsNilpotent N ∧ Finite (G ⧸ N)
+def IsVirtuallyNilpotent : Prop := ∃ N : Subgroup G, IsNilpotent N ∧ FiniteIndex N
 
 lemma IsNilpotent.isVirtuallyNilpotent (hG : IsNilpotent G) : IsVirtuallyNilpotent G :=
   ⟨⊤, by simpa, inferInstance⟩

--- a/Mathlib/GroupTheory/Nilpotent.lean
+++ b/Mathlib/GroupTheory/Nilpotent.lean
@@ -144,25 +144,55 @@ theorem upperCentralSeries_one : upperCentralSeries G 1 = center G := by
     Subgroup.mem_center_iff, mem_mk, mem_bot, Set.mem_setOf_eq]
   exact forall_congr' fun y => by rw [mul_inv_eq_one, mul_inv_eq_iff_eq_mul, eq_comm]
 
+variable {G}
+
 /-- The `n+1`st term of the upper central series `H i` has underlying set equal to the `x` such
 that `⁅x,G⁆ ⊆ H n`-/
-theorem mem_upperCentralSeries_succ_iff (n : ℕ) (x : G) :
+theorem mem_upperCentralSeries_succ_iff {n : ℕ} {x : G} :
     x ∈ upperCentralSeries G (n + 1) ↔ ∀ y : G, x * y * x⁻¹ * y⁻¹ ∈ upperCentralSeries G n :=
   Iff.rfl
 
+@[simp] lemma comap_upperCentralSeries {H : Type*} [Group H] (e : H ≃* G) :
+    ∀ n, (upperCentralSeries G n).comap e = upperCentralSeries H n
+  | 0 => by simpa [MonoidHom.ker_eq_bot_iff] using e.injective
+  | n + 1 => by
+    ext
+    simp [mem_upperCentralSeries_succ_iff, ← comap_upperCentralSeries e n,
+      ← e.toEquiv.forall_congr_right]
 
--- is_nilpotent is already defined in the root namespace (for elements of rings).
+namespace Group
+
+variable (G) in
+-- `IsNilpotent` is already defined in the root namespace (for elements of rings).
+-- TODO: Rename it to `IsNilpotentElement`?
 /-- A group `G` is nilpotent if its upper central series is eventually `G`. -/
-class Group.IsNilpotent (G : Type*) [Group G] : Prop where
+@[mk_iff]
+class IsNilpotent (G : Type*) [Group G] : Prop where
   nilpotent' : ∃ n : ℕ, upperCentralSeries G n = ⊤
 
 -- Porting note: add lemma since infer kinds are unsupported in the definition of `IsNilpotent`
-lemma Group.IsNilpotent.nilpotent (G : Type*) [Group G] [IsNilpotent G] :
+lemma IsNilpotent.nilpotent (G : Type*) [Group G] [IsNilpotent G] :
     ∃ n : ℕ, upperCentralSeries G n = ⊤ := Group.IsNilpotent.nilpotent'
 
-open Group
+lemma isNilpotent_congr {H : Type*} [Group H] (e : G ≃* H) : IsNilpotent G ↔ IsNilpotent H := by
+  simp_rw [isNilpotent_iff]
+  refine exists_congr fun n ↦ ⟨fun h ↦ ?_, fun h ↦ ?_⟩
+  · simp [← Subgroup.comap_top e.symm.toMonoidHom, ← h]
+  · simp [← Subgroup.comap_top e.toMonoidHom, ← h]
 
-variable {G}
+@[simp] lemma isNilpotent_top : IsNilpotent (⊤ : Subgroup G) ↔ IsNilpotent G :=
+  isNilpotent_congr Subgroup.topEquiv
+
+variable (G) in
+/-- A group `G` is virtually nilpotent if it has a nilpotent cofinite subgroup `N`. -/
+def IsVirtuallyNilpotent : Prop := ∃ N : Subgroup G, IsNilpotent N ∧ Finite (G ⧸ N)
+
+lemma IsNilpotent.isVirtuallyNilpotent (hG : IsNilpotent G) : IsVirtuallyNilpotent G :=
+  ⟨⊤, by simpa, inferInstance⟩
+
+end Group
+
+open Group
 
 /-- A sequence of subgroups of `G` is an ascending central series if `H 0` is trivial and
   `⁅H (n + 1), G⁆ ⊆ H n` for all `n`. Note that we do not require that `H n = G` for some `n`. -/


### PR DESCRIPTION
Show that nilpotency is preserved under group isomorphisms and define virtually nilpotent subgroups.

From GrowthInGroups


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
