### PR TITLE
feat(Tactic): `erw` tries `rw` first and warns if that succeeds

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -4490,6 +4490,7 @@ import Mathlib.Tactic.DeriveFintype
 import Mathlib.Tactic.DeriveToExpr
 import Mathlib.Tactic.DeriveTraversable
 import Mathlib.Tactic.Eqns
+import Mathlib.Tactic.Erw
 import Mathlib.Tactic.Eval
 import Mathlib.Tactic.ExistsI
 import Mathlib.Tactic.Explode

--- a/Mathlib/Algebra/Module/Presentation/DirectSum.lean
+++ b/Mathlib/Algebra/Module/Presentation/DirectSum.lean
@@ -61,7 +61,7 @@ def directSumEquiv :
   invFun t :=
     { var := fun ⟨i, g⟩ ↦ (t i).var g
       linearCombination_var_relation := fun ⟨i, r⟩ ↦ by
-        erw [← (t i).linearCombination_var_relation r]
+        rw [← (t i).linearCombination_var_relation r]
         apply Finsupp.linearCombination_embDomain }
   left_inv _ := rfl
   right_inv _ := rfl

--- a/Mathlib/Algebra/Order/CauSeq/Basic.lean
+++ b/Mathlib/Algebra/Order/CauSeq/Basic.lean
@@ -808,7 +808,7 @@ protected theorem sup_eq_right {a b : CauSeq α abs} (h : a ≤ b) : a ⊔ b ≈
   · intro _ _
     refine ⟨i, fun j hj => ?_⟩
     dsimp
-    erw [← max_sub_sub_right]
+    rw [← max_sub_sub_right]
     rwa [sub_self, max_eq_right, abs_zero]
     rw [sub_nonpos, ← sub_nonneg]
     exact ε0.le.trans (h _ hj)
@@ -820,7 +820,7 @@ protected theorem inf_eq_right {a b : CauSeq α abs} (h : b ≤ a) : a ⊓ b ≈
   · intro _ _
     refine ⟨i, fun j hj => ?_⟩
     dsimp
-    erw [← min_sub_sub_right]
+    rw [← min_sub_sub_right]
     rwa [sub_self, min_eq_right, abs_zero]
     exact ε0.le.trans (h _ hj)
   · refine Setoid.trans (inf_equiv_inf (Setoid.symm h) (Setoid.refl _)) ?_

--- a/Mathlib/CategoryTheory/Sites/Subcanonical.lean
+++ b/Mathlib/CategoryTheory/Sites/Subcanonical.lean
@@ -66,7 +66,7 @@ lemma yonedaEquiv_symm_naturality_left {X X' : C} (f : X' ⟶ X) (F : Sheaf J (T
       ((F.val.map f.op) x) := by
   apply J.yonedaEquiv.injective
   simp only [yonedaEquiv_comp, yoneda_obj_obj, yonedaEquiv_symm_app_apply, Equiv.apply_symm_apply]
-  erw [yonedaEquiv_yoneda_map]
+  rw [yonedaEquiv_yoneda_map]
 
 lemma yonedaEquiv_symm_naturality_right (X : C) {F F' : Sheaf J (Type v)} (f : F ⟶ F')
     (x : F.val.obj ⟨X⟩) : J.yonedaEquiv.symm x ≫ f = J.yonedaEquiv.symm (f.val.app ⟨X⟩ x) := by
@@ -155,7 +155,7 @@ lemma yonedaULiftEquiv_symm_naturality_left {X X' : C} (f : X' ⟶ X) (F : Sheaf
       ((F.val.map f.op) x) := by
   apply J.yonedaULiftEquiv.injective
   simp only [yonedaULiftEquiv_comp, Equiv.apply_symm_apply]
-  erw [yonedaULiftEquiv_yonedaULift_map]
+  rw [yonedaULiftEquiv_yonedaULift_map]
   rfl
 
 lemma yonedaULiftEquiv_symm_naturality_right (X : C) {F F' : Sheaf J (Type (max v v'))}

--- a/Mathlib/Tactic.lean
+++ b/Mathlib/Tactic.lean
@@ -69,6 +69,7 @@ import Mathlib.Tactic.DeriveFintype
 import Mathlib.Tactic.DeriveToExpr
 import Mathlib.Tactic.DeriveTraversable
 import Mathlib.Tactic.Eqns
+import Mathlib.Tactic.Erw
 import Mathlib.Tactic.Eval
 import Mathlib.Tactic.ExistsI
 import Mathlib.Tactic.Explode

--- a/Mathlib/Tactic/Common.lean
+++ b/Mathlib/Tactic/Common.lean
@@ -48,6 +48,7 @@ import Mathlib.Tactic.DefEqTransformations
 import Mathlib.Tactic.DeprecateMe
 import Mathlib.Tactic.DeriveToExpr
 import Mathlib.Tactic.Eqns
+import Mathlib.Tactic.Erw
 import Mathlib.Tactic.ExistsI
 import Mathlib.Tactic.ExtractGoal
 import Mathlib.Tactic.ExtractLets

--- a/Mathlib/Tactic/Erw.lean
+++ b/Mathlib/Tactic/Erw.lean
@@ -18,10 +18,11 @@ display a hint explaining what to do if this happens.
 -/
 
 /-- If we call `erw`, first try running regular `rw` and warn if that succeds. -/
+-- This syntax is copied from lean4's ``.
 macro_rules
-  | `(tactic| erw $s $(loc)?) =>
+  | `(tactic| erw $c [$s,*] $(loc)?) =>
     `(tactic|
-      try_this rw $(.none)? $s $(loc)?;
+      try_this rw $c [$s,*] $(loc)?;
       trace "Hint: `rw` succeeded here, but may have performed a different rewrite than `erw` would.
 If `erw` really is needed, try preceding this line with a `rw` to get rid of the other occurrences,
 or use `conv` to specify exactly which subterm to rewrite.")

--- a/Mathlib/Tactic/Erw.lean
+++ b/Mathlib/Tactic/Erw.lean
@@ -1,0 +1,27 @@
+/-
+Copyright (c) 2024 Anne Baanen. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Anne Baanen
+-/
+
+import Mathlib.Tactic.TryThis
+
+/-!
+# Extension to the `erw` tactic
+
+This file adds a macro rule to the `erw` tactic that first tries to run the `rw` tactic at the
+faster `reducible` transparency, and adds a suggestion if that also succeeds.
+
+Note that `rw` succeeding is not the same as `rw` and `erw` doing exactly the same rewrite: they may
+have operated on different subterms. Since the suggested `rw` may not be an exact replacement, we
+display a hint explaining what to do if this happens.
+-/
+
+/-- If we call `erw`, first try running regular `rw` and warn if that succeds. -/
+macro_rules
+  | `(tactic| erw $s $(loc)?) =>
+    `(tactic|
+      try_this rw $(.none)? $s $(loc)?;
+      trace "Hint: `rw` succeeded here, but may have performed a different rewrite than `erw` would.
+If `erw` really is needed, try preceding this line with a `rw` to get rid of the other occurrences,
+or use `conv` to specify exactly which subterm to rewrite.")


### PR DESCRIPTION
This PR adds a macro rule to the `erw` tactic that first tries `rw` at reducible transparency, and displays a "Try this:" if that succeeded. This should help us get rid of uselessly slow `erw`s.

This is a relatively simple implementation that does not verify if `erw` and `rw` would have resulted in the same exact rewrite. So it is possible that `erw` and `rw` both succeed but rewrite different occurrences, and there would be a suggestion to replace `erw` with `rw` in that case. I think the complication of running both at the same time and checking the goal state afterwards doesn't weigh up to accepting that this happens and adding an explanation to the warning generated by `erw`.

I import the `erw` extension in `Tactic.Common`: it might be nice to migrate this up even earlier in the import hierarchy but `Mathlib.Tactic.TryThis` is a somewhat heavy import to put in `Mathlib.Tactic.Core`.

Zulip thread: https://leanprover.zulipchat.com/#narrow/stream/287929-mathlib4/topic/Fixing.20the.20.60erw.60.20hell.20around.20concrete.20categories

---

- [x] depends on: #17617 
- [x] depends on: #17703

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
