### PR TITLE
[Merged by Bors] - feat: `comap` of a finite measure along a measurable equiv is finite

### DIFF
--- a/Mathlib/MeasureTheory/Measure/MeasureSpace.lean
+++ b/Mathlib/MeasureTheory/Measure/MeasureSpace.lean
@@ -1030,8 +1030,8 @@ theorem measure_univ_pos : 0 < μ univ ↔ μ ≠ 0 :=
   pos_iff_ne_zero.trans measure_univ_ne_zero
 
 lemma nonempty_of_neZero (μ : Measure α) [NeZero μ] : Nonempty α :=
-  have : μ Set.univ ≠ 0 := by simpa only [ne_eq, measure_univ_eq_zero] using NeZero.ne μ
-  (isEmpty_or_nonempty α).resolve_left fun h ↦ by simp [Set.eq_empty_of_isEmpty] at this
+  (isEmpty_or_nonempty α).resolve_left fun h ↦ by
+    simpa [eq_empty_of_isEmpty] using NeZero.ne (μ univ)
 
 /-! ### Pushforward and pullback -/
 

--- a/Mathlib/MeasureTheory/Measure/MeasureSpace.lean
+++ b/Mathlib/MeasureTheory/Measure/MeasureSpace.lean
@@ -1029,6 +1029,10 @@ instance [NeZero μ] : NeZero (μ univ) := ⟨measure_univ_ne_zero.2 <| NeZero.n
 theorem measure_univ_pos : 0 < μ univ ↔ μ ≠ 0 :=
   pos_iff_ne_zero.trans measure_univ_ne_zero
 
+lemma nonempty_of_neZero (μ : Measure α) [NeZero μ] : Nonempty α :=
+  have : μ Set.univ ≠ 0 := by simpa only [ne_eq, measure_univ_eq_zero] using NeZero.ne μ
+  (isEmpty_or_nonempty α).resolve_left fun h ↦ by simp [Set.eq_empty_of_isEmpty] at this
+
 /-! ### Pushforward and pullback -/
 
 

--- a/Mathlib/MeasureTheory/Measure/Typeclasses.lean
+++ b/Mathlib/MeasureTheory/Measure/Typeclasses.lean
@@ -122,8 +122,13 @@ theorem Measure.isFiniteMeasure_map {m : MeasurableSpace α} (μ : Measure α) [
   · rw [map_of_not_aemeasurable hf]
     exact MeasureTheory.isFiniteMeasureZero
 
-instance IsFiniteMeasure_comap_equiv (f : β ≃ᵐ α) [IsFiniteMeasure μ] :
-    IsFiniteMeasure (μ.comap f) := by rw [← MeasurableEquiv.map_symm]; infer_instance
+instance IsFiniteMeasure_comap (f : β → α) [IsFiniteMeasure μ] : IsFiniteMeasure (μ.comap f) where
+  measure_univ_lt_top := by
+    by_cases hf : Injective f ∧ ∀ s, MeasurableSet s → NullMeasurableSet (f '' s) μ
+    · rw [Measure.comap_apply₀ _ _ hf.1 hf.2 MeasurableSet.univ.nullMeasurableSet]
+      exact measure_lt_top μ _
+    · rw [Measure.comap, dif_neg hf]
+      exact zero_lt_top
 
 @[simp]
 theorem measureUnivNNReal_eq_zero [IsFiniteMeasure μ] : measureUnivNNReal μ = 0 ↔ μ = 0 := by

--- a/Mathlib/MeasureTheory/Measure/Typeclasses.lean
+++ b/Mathlib/MeasureTheory/Measure/Typeclasses.lean
@@ -122,6 +122,9 @@ theorem Measure.isFiniteMeasure_map {m : MeasurableSpace α} (μ : Measure α) [
   · rw [map_of_not_aemeasurable hf]
     exact MeasureTheory.isFiniteMeasureZero
 
+instance IsFiniteMeasure_comap_equiv (f : β ≃ᵐ α) [IsFiniteMeasure μ] :
+    IsFiniteMeasure (μ.comap f) := by rw [← MeasurableEquiv.map_symm]; infer_instance
+
 @[simp]
 theorem measureUnivNNReal_eq_zero [IsFiniteMeasure μ] : measureUnivNNReal μ = 0 ↔ μ = 0 := by
   rw [← MeasureTheory.Measure.measure_univ_eq_zero, ← coe_measureUnivNNReal]
@@ -276,6 +279,9 @@ variable [IsProbabilityMeasure μ] {p : α → Prop} {f : β → α}
 theorem isProbabilityMeasure_map {f : α → β} (hf : AEMeasurable f μ) :
     IsProbabilityMeasure (map f μ) :=
   ⟨by simp [map_apply_of_aemeasurable, hf]⟩
+
+instance IsProbabilityMeasure_comap_equiv (f : β ≃ᵐ α) : IsProbabilityMeasure (μ.comap f) := by
+  rw [← MeasurableEquiv.map_symm]; exact isProbabilityMeasure_map f.symm.measurable.aemeasurable
 
 /-- Note that this is not quite as useful as it looks because the measure takes values in `ℝ≥0∞`.
 Thus the subtraction appearing is the truncated subtraction of `ℝ≥0∞`, rather than the


### PR DESCRIPTION
From PFR


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
