### PR TITLE
[Merged by Bors] - feat: the complement of a null set has full measure

### DIFF
--- a/Mathlib/MeasureTheory/Measure/NullMeasurable.lean
+++ b/Mathlib/MeasureTheory/Measure/NullMeasurable.lean
@@ -280,11 +280,8 @@ theorem measure_union₀' (hs : NullMeasurableSet s μ) (hd : AEDisjoint μ s t)
 theorem measure_add_measure_compl₀ {s : Set α} (hs : NullMeasurableSet s μ) :
     μ s + μ sᶜ = μ univ := by rw [← measure_union₀' hs aedisjoint_compl_right, union_compl_self]
 
-lemma measure_of_measure_compl_eq_zero₀ (hs : NullMeasurableSet s μ) (h : μ sᶜ = 0) :
-    μ s = μ univ := by simpa [h] using measure_add_measure_compl₀ hs
-
-lemma measure_of_measure_compl_eq_zero (hs : MeasurableSet s) (h : μ sᶜ = 0) : μ s = μ univ :=
-  measure_of_measure_compl_eq_zero₀ hs.nullMeasurableSet h
+lemma measure_of_measure_compl_eq_zero (hs : μ sᶜ = 0) : μ s = μ Set.univ := by
+  simpa [hs] using measure_add_measure_compl₀ <| .of_compl <| .of_null hs
 
 section MeasurableSingletonClass
 

--- a/Mathlib/MeasureTheory/Measure/NullMeasurable.lean
+++ b/Mathlib/MeasureTheory/Measure/NullMeasurable.lean
@@ -280,6 +280,12 @@ theorem measure_union₀' (hs : NullMeasurableSet s μ) (hd : AEDisjoint μ s t)
 theorem measure_add_measure_compl₀ {s : Set α} (hs : NullMeasurableSet s μ) :
     μ s + μ sᶜ = μ univ := by rw [← measure_union₀' hs aedisjoint_compl_right, union_compl_self]
 
+lemma measure_of_measure_compl_eq_zero₀ (hs : NullMeasurableSet s μ) (h : μ sᶜ = 0) :
+    μ s = μ univ := by simpa [h] using measure_add_measure_compl₀ hs
+
+lemma measure_of_measure_compl_eq_zero (hs : MeasurableSet s) (h : μ sᶜ = 0) : μ s = μ univ :=
+  measure_of_measure_compl_eq_zero₀ hs.nullMeasurableSet h
+
 section MeasurableSingletonClass
 
 variable [MeasurableSingletonClass (NullMeasurableSpace α μ)]


### PR DESCRIPTION
From PFR


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
