### PR TITLE
[Merged by Bors] - feat(SetTheory/Game/Nim): make `grundyValue` a nimber

### DIFF
--- a/Mathlib/SetTheory/Game/Nim.lean
+++ b/Mathlib/SetTheory/Game/Nim.lean
@@ -337,8 +337,7 @@ theorem grundyValue_le_of_forall_moveRight {G : PGame} [G.Impartial] {o : Nimber
 
 /-- The Grundy value of the sum of two nim games with natural numbers of piles equals their nimber
 addition. -/
-theorem grundyValue_nim_add_nim (x y : Ordinal) :
-    grundyValue (nim x + nim y) = toNimber x + toNimber y := by
+theorem grundyValue_nim_add_nim (x y : Ordinal) : grundyValue (nim x + nim y) = ∗x + ∗y := by
   apply (grundyValue_le_of_forall_moveLeft _).antisymm (le_grundyValue_of_Iio_subset_moveLeft _)
   · intro i
     apply leftMoves_add_cases i <;> intro j <;> have := (toLeftMovesNim_symm_lt j).ne
@@ -346,16 +345,16 @@ theorem grundyValue_nim_add_nim (x y : Ordinal) :
     · simpa [grundyValue_nim_add_nim x (toLeftMovesNim.symm j)]
   · intro k hk
     obtain h | h := Nimber.lt_add_cases hk
-    · let a := toOrdinal (k + toNimber y)
+    · let a := toOrdinal (k + ∗y)
       use toLeftMovesAdd (Sum.inl (toLeftMovesNim ⟨a, h⟩))
       simp [a, grundyValue_nim_add_nim a y]
-    · let a := toOrdinal (k + toNimber x)
+    · let a := toOrdinal (k + ∗x)
       use toLeftMovesAdd (Sum.inr (toLeftMovesNim ⟨a, h⟩))
-      simp [a, grundyValue_nim_add_nim x a, add_comm (toNimber x)]
+      simp [a, grundyValue_nim_add_nim x a, add_comm (∗x)]
 termination_by (x, y)
 
 theorem nim_add_nim_equiv (x y : Ordinal) :
-    nim x + nim y ≈ nim (toOrdinal (toNimber x + toNimber y)) := by
+    nim x + nim y ≈ nim (toOrdinal (∗x + ∗y)) := by
   rw [← grundyValue_eq_iff_equiv_nim, grundyValue_nim_add_nim]
 
 @[simp]

--- a/Mathlib/SetTheory/Game/Nim.lean
+++ b/Mathlib/SetTheory/Game/Nim.lean
@@ -256,7 +256,7 @@ theorem grundyValue_le_of_forall_moveLeft {G : PGame} {o : Nimber}
 /-- The **Sprague-Grundy theorem** states that every impartial game is equivalent to a game of nim,
 namely the game of nim corresponding to the game's Grundy value. -/
 theorem equiv_nim_grundyValue (G : PGame.{u}) [G.Impartial] :
-    G ≈ nim (Nimber.toOrdinal (grundyValue G)) := by
+    G ≈ nim (toOrdinal (grundyValue G)) := by
   rw [Impartial.equiv_iff_add_equiv_zero, ← Impartial.forall_leftMoves_fuzzy_iff_equiv_zero]
   intro x
   apply leftMoves_add_cases x <;>

--- a/Mathlib/SetTheory/Game/Nim.lean
+++ b/Mathlib/SetTheory/Game/Nim.lean
@@ -255,7 +255,8 @@ theorem grundyValue_le_of_forall_moveLeft {G : PGame} {o : Nimber}
 
 /-- The **Sprague-Grundy theorem** states that every impartial game is equivalent to a game of nim,
 namely the game of nim corresponding to the game's Grundy value. -/
-theorem equiv_nim_grundyValue (G : PGame.{u}) [G.Impartial] : G ≈ nim (grundyValue G) := by
+theorem equiv_nim_grundyValue (G : PGame.{u}) [G.Impartial] :
+    G ≈ nim (Nimber.toOrdinal (grundyValue G)) := by
   rw [Impartial.equiv_iff_add_equiv_zero, ← Impartial.forall_leftMoves_fuzzy_iff_equiv_zero]
   intro x
   apply leftMoves_add_cases x <;>
@@ -277,7 +278,7 @@ theorem grundyValue_eq_iff_equiv_nim {G : PGame} [G.Impartial] {o : Nimber} :
    by intro h; rw [← nim_equiv_iff_eq]; exact Equiv.trans (Equiv.symm (equiv_nim_grundyValue G)) h⟩
 
 @[simp]
-theorem nim_grundyValue (o : Ordinal.{u}) : grundyValue (nim o) = o :=
+theorem nim_grundyValue (o : Ordinal.{u}) : grundyValue (nim o) = ∗o :=
   grundyValue_eq_iff_equiv_nim.2 PGame.equiv_rfl
 
 theorem grundyValue_eq_iff_equiv (G H : PGame) [G.Impartial] [H.Impartial] :
@@ -288,7 +289,7 @@ theorem grundyValue_eq_iff_equiv (G H : PGame) [G.Impartial] [H.Impartial] :
 theorem grundyValue_zero : grundyValue 0 = 0 :=
   grundyValue_eq_iff_equiv_nim.2 (Equiv.symm nim_zero_equiv)
 
-theorem grundyValue_iff_equiv_zero (G : PGame) [G.Impartial] : grundyValue G = 0 ↔ (G ≈ 0) := by
+theorem grundyValue_iff_equiv_zero (G : PGame) [G.Impartial] : grundyValue G = 0 ↔ G ≈ 0 := by
   rw [← grundyValue_eq_iff_equiv, grundyValue_zero]
 
 @[simp]

--- a/Mathlib/SetTheory/Game/Nim.lean
+++ b/Mathlib/SetTheory/Game/Nim.lean
@@ -3,9 +3,9 @@ Copyright (c) 2020 Fox Thomson. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Fox Thomson, Markus Himmel
 -/
-import Mathlib.Data.Nat.Bitwise
 import Mathlib.SetTheory.Game.Birthday
 import Mathlib.SetTheory.Game.Impartial
+import Mathlib.SetTheory.Ordinal.Nimber
 
 /-!
 # Nim and the Sprague-Grundy theorem
@@ -14,8 +14,8 @@ This file contains the definition for nim for any ordinal `o`. In the game of `n
 may move to `nim o₂` for any `o₂ < o₁`.
 We also define a Grundy value for an impartial game `G` and prove the Sprague-Grundy theorem, that
 `G` is equivalent to `nim (grundyValue G)`.
-Finally, we compute the sum of finite Grundy numbers: if `G` and `H` have Grundy values `n` and `m`,
-where `n` and `m` are natural numbers, then `G + H` has the Grundy value `n xor m`.
+Finally, we prove that the grundy value of a sum `G + H` corresponds to the nimber sum of the
+individual grundy values.
 
 ## Implementation details
 
@@ -209,8 +209,12 @@ theorem nim_equiv_iff_eq {o₁ o₂ : Ordinal} : (nim o₁ ≈ nim o₂) ↔ o�
 /-- The Grundy value of an impartial game is recursively defined as the minimum excluded value
 (the infimum of the complement) of the Grundy values of either its left or right options.
 
-This is the ordinal which corresponds to the game of nim that the game is equivalent to. -/
-noncomputable def grundyValue (G : PGame.{u}) : Ordinal.{u} :=
+This is the ordinal which corresponds to the game of nim that the game is equivalent to.
+
+This function takes a value in `Nimber`. This is a type synonym for the ordinals which has the same
+ordering, but addition in `Nimber` is such that it corresponds to the grundy value of the addition
+of games. See that file for more information on nimbers and their arithmetic. -/
+noncomputable def grundyValue (G : PGame.{u}) : Nimber.{u} :=
   sInf (Set.range fun i => grundyValue (G.moveLeft i))ᶜ
 termination_by G
 
@@ -232,19 +236,19 @@ theorem grundyValue_ne_moveLeft {G : PGame} (i : G.LeftMoves) :
   rw [Set.mem_compl_iff, Set.mem_range, not_exists] at this
   exact this _
 
-theorem le_grundyValue_of_Iio_subset_moveLeft {G : PGame} {o : Ordinal}
+theorem le_grundyValue_of_Iio_subset_moveLeft {G : PGame} {o : Nimber}
     (h : Set.Iio o ⊆ Set.range (grundyValue ∘ G.moveLeft)) : o ≤ grundyValue G := by
   by_contra! ho
   obtain ⟨i, hi⟩ := h ho
   exact grundyValue_ne_moveLeft i hi
 
-theorem exists_grundyValue_moveLeft_of_lt {G : PGame} {o : Ordinal} (h : o < grundyValue G) :
+theorem exists_grundyValue_moveLeft_of_lt {G : PGame} {o : Nimber} (h : o < grundyValue G) :
     ∃ i, grundyValue (G.moveLeft i) = o := by
   rw [grundyValue_eq_sInf_moveLeft] at h
   by_contra ha
   exact h.not_le (csInf_le' ha)
 
-theorem grundyValue_le_of_forall_moveLeft {G : PGame} {o : Ordinal}
+theorem grundyValue_le_of_forall_moveLeft {G : PGame} {o : Nimber}
     (h : ∀ i, grundyValue (G.moveLeft i) ≠ o) : G.grundyValue ≤ o := by
   contrapose! h
   exact exists_grundyValue_moveLeft_of_lt h
@@ -267,8 +271,8 @@ theorem equiv_nim_grundyValue (G : PGame.{u}) [G.Impartial] : G ≈ nim (grundyV
     exact Equiv.trans (add_congr_left (equiv_nim_grundyValue _)) (hj ▸ Impartial.add_self _)
 termination_by G
 
-theorem grundyValue_eq_iff_equiv_nim {G : PGame} [G.Impartial] {o : Ordinal} :
-    grundyValue G = o ↔ G ≈ nim o :=
+theorem grundyValue_eq_iff_equiv_nim {G : PGame} [G.Impartial] {o : Nimber} :
+    grundyValue G = o ↔ G ≈ nim (Nimber.toOrdinal o) :=
   ⟨by rintro rfl; exact equiv_nim_grundyValue G,
    by intro h; rw [← nim_equiv_iff_eq]; exact Equiv.trans (Equiv.symm (equiv_nim_grundyValue G)) h⟩
 
@@ -313,68 +317,53 @@ theorem grundyValue_ne_moveRight {G : PGame} [G.Impartial] (i : G.RightMoves) :
     grundyValue (G.moveRight i) ≠ grundyValue G := by
   convert grundyValue_ne_moveLeft (toLeftMovesNeg i) using 1 <;> simp
 
-theorem le_grundyValue_of_Iio_subset_moveRight {G : PGame} [G.Impartial] {o : Ordinal}
+theorem le_grundyValue_of_Iio_subset_moveRight {G : PGame} [G.Impartial] {o : Nimber}
     (h : Set.Iio o ⊆ Set.range (grundyValue ∘ G.moveRight)) : o ≤ grundyValue G := by
   by_contra! ho
   obtain ⟨i, hi⟩ := h ho
   exact grundyValue_ne_moveRight i hi
 
-theorem exists_grundyValue_moveRight_of_lt {G : PGame} [G.Impartial] {o : Ordinal}
+theorem exists_grundyValue_moveRight_of_lt {G : PGame} [G.Impartial] {o : Nimber}
     (h : o < grundyValue G) : ∃ i, grundyValue (G.moveRight i) = o := by
   rw [← grundyValue_neg] at h
   obtain ⟨i, hi⟩ := exists_grundyValue_moveLeft_of_lt h
   use toLeftMovesNeg.symm i
   rwa [← grundyValue_neg, ← moveLeft_neg']
 
-theorem grundyValue_le_of_forall_moveRight {G : PGame} [G.Impartial] {o : Ordinal}
+theorem grundyValue_le_of_forall_moveRight {G : PGame} [G.Impartial] {o : Nimber}
     (h : ∀ i, grundyValue (G.moveRight i) ≠ o) : G.grundyValue ≤ o := by
   contrapose! h
   exact exists_grundyValue_moveRight_of_lt h
 
--- Todo: redefine `grundyValue` as a nimber, and prove `grundyValue (nim a + nim b) = a + b` for all
--- nimbers.
-
-/-- The Grundy value of the sum of two nim games with natural numbers of piles equals their bitwise
-xor. -/
-@[simp]
-theorem grundyValue_nim_add_nim (n m : ℕ) : grundyValue (nim.{u} n + nim.{u} m) = n ^^^ m := by
+/-- The Grundy value of the sum of two nim games with natural numbers of piles equals their nimber
+addition. -/
+theorem grundyValue_nim_add_nim (x y : Ordinal) :
+    grundyValue (nim x + nim y) = toNimber x + toNimber y := by
   apply (grundyValue_le_of_forall_moveLeft _).antisymm (le_grundyValue_of_Iio_subset_moveLeft _)
-  -- Since XOR is injective, no left moves of `nim n + nim m` will have `n ^^^ m` as a Grundy value.
   · intro i
-    apply leftMoves_add_cases i
-    all_goals
-      intro j
-      have hj := toLeftMovesNim_symm_lt j
-      obtain ⟨k, hk⟩ := lt_omega0.1 (hj.trans (nat_lt_omega0 _))
-      rw [hk, Nat.cast_lt] at hj
-      have := hj.ne
-      have := hj -- The termination checker doesn't work without this.
-    · rwa [add_moveLeft_inl, moveLeft_nim', ne_eq, hk, grundyValue_nim_add_nim, Nat.cast_inj,
-        Nat.xor_left_inj]
-    · rwa [add_moveLeft_inr, moveLeft_nim', ne_eq, hk, grundyValue_nim_add_nim, Nat.cast_inj,
-        Nat.xor_right_inj]
-  -- For any `k < n ^^^ m`, either `nim (k ^^^ m) + nim m` or `nim n + nim (k ^^^ n)` is a left
-  -- option with Grundy value `k`.
+    apply leftMoves_add_cases i <;> intro j <;> have := (toLeftMovesNim_symm_lt j).ne
+    · simpa [grundyValue_nim_add_nim (toLeftMovesNim.symm j) y]
+    · simpa [grundyValue_nim_add_nim x (toLeftMovesNim.symm j)]
   · intro k hk
-    obtain ⟨k, rfl⟩ := Ordinal.lt_omega0.1 (hk.trans (Ordinal.nat_lt_omega0 _))
-    rw [Set.mem_Iio, Nat.cast_lt] at hk
-    obtain hk | hk := Nat.lt_xor_cases hk <;> rw [← natCast_lt] at hk
-    · use toLeftMovesAdd (Sum.inl (toLeftMovesNim ⟨_, hk⟩))
-      rw [Function.comp_apply, add_moveLeft_inl, moveLeft_nim', Equiv.symm_apply_apply,
-        grundyValue_nim_add_nim, Nat.xor_cancel_right]
-    · use toLeftMovesAdd (Sum.inr (toLeftMovesNim ⟨_, hk⟩))
-      rw [Function.comp_apply, add_moveLeft_inr, moveLeft_nim', Equiv.symm_apply_apply,
-        grundyValue_nim_add_nim, Nat.xor_comm, Nat.xor_cancel_right]
-termination_by (n, m)
+    obtain h | h := Nimber.lt_add_cases hk
+    · let a := Nimber.toOrdinal (k + toNimber y)
+      use toLeftMovesAdd (Sum.inl (toLeftMovesNim ⟨a, h⟩))
+      simp [a, grundyValue_nim_add_nim a y]
+    · let a := Nimber.toOrdinal (k + toNimber x)
+      use toLeftMovesAdd (Sum.inr (toLeftMovesNim ⟨a, h⟩))
+      simp [a, grundyValue_nim_add_nim x a, add_comm (toNimber x)]
+termination_by (x, y)
 
-theorem nim_add_nim_equiv {n m : ℕ} : nim n + nim m ≈ nim (n ^^^ m) := by
+theorem nim_add_nim_equiv (x y : Ordinal) :
+    nim x + nim y ≈ nim (Nimber.toOrdinal (toNimber x + toNimber y)) := by
   rw [← grundyValue_eq_iff_equiv_nim, grundyValue_nim_add_nim]
 
-theorem grundyValue_add (G H : PGame) [G.Impartial] [H.Impartial] {n m : ℕ} (hG : grundyValue G = n)
-    (hH : grundyValue H = m) : grundyValue (G + H) = n ^^^ m := by
-  rw [← nim_grundyValue (n ^^^ m), grundyValue_eq_iff_equiv]
-  refine Equiv.trans ?_ nim_add_nim_equiv
-  convert add_congr (equiv_nim_grundyValue G) (equiv_nim_grundyValue H) <;> simp only [hG, hH]
+@[simp]
+theorem grundyValue_add (G H : PGame) [G.Impartial] [H.Impartial] :
+    grundyValue (G + H) = grundyValue G + grundyValue H := by
+  rw [← (grundyValue G).toOrdinal_toNimber, ← (grundyValue H).toOrdinal_toNimber,
+    ← grundyValue_nim_add_nim, grundyValue_eq_iff_equiv]
+  exact add_congr (equiv_nim_grundyValue G) (equiv_nim_grundyValue H)
 
 end PGame
 

--- a/Mathlib/SetTheory/Game/Nim.lean
+++ b/Mathlib/SetTheory/Game/Nim.lean
@@ -37,7 +37,7 @@ universe u
 namespace SetTheory
 
 open scoped PGame
-open Ordinal
+open Ordinal Nimber
 
 namespace PGame
 
@@ -272,7 +272,7 @@ theorem equiv_nim_grundyValue (G : PGame.{u}) [G.Impartial] : G ≈ nim (grundyV
 termination_by G
 
 theorem grundyValue_eq_iff_equiv_nim {G : PGame} [G.Impartial] {o : Nimber} :
-    grundyValue G = o ↔ G ≈ nim (Nimber.toOrdinal o) :=
+    grundyValue G = o ↔ G ≈ nim (toOrdinal o) :=
   ⟨by rintro rfl; exact equiv_nim_grundyValue G,
    by intro h; rw [← nim_equiv_iff_eq]; exact Equiv.trans (Equiv.symm (equiv_nim_grundyValue G)) h⟩
 
@@ -346,16 +346,16 @@ theorem grundyValue_nim_add_nim (x y : Ordinal) :
     · simpa [grundyValue_nim_add_nim x (toLeftMovesNim.symm j)]
   · intro k hk
     obtain h | h := Nimber.lt_add_cases hk
-    · let a := Nimber.toOrdinal (k + toNimber y)
+    · let a := toOrdinal (k + toNimber y)
       use toLeftMovesAdd (Sum.inl (toLeftMovesNim ⟨a, h⟩))
       simp [a, grundyValue_nim_add_nim a y]
-    · let a := Nimber.toOrdinal (k + toNimber x)
+    · let a := toOrdinal (k + toNimber x)
       use toLeftMovesAdd (Sum.inr (toLeftMovesNim ⟨a, h⟩))
       simp [a, grundyValue_nim_add_nim x a, add_comm (toNimber x)]
 termination_by (x, y)
 
 theorem nim_add_nim_equiv (x y : Ordinal) :
-    nim x + nim y ≈ nim (Nimber.toOrdinal (toNimber x + toNimber y)) := by
+    nim x + nim y ≈ nim (toOrdinal (toNimber x + toNimber y)) := by
   rw [← grundyValue_eq_iff_equiv_nim, grundyValue_nim_add_nim]
 
 @[simp]
@@ -364,6 +364,10 @@ theorem grundyValue_add (G H : PGame) [G.Impartial] [H.Impartial] :
   rw [← (grundyValue G).toOrdinal_toNimber, ← (grundyValue H).toOrdinal_toNimber,
     ← grundyValue_nim_add_nim, grundyValue_eq_iff_equiv]
   exact add_congr (equiv_nim_grundyValue G) (equiv_nim_grundyValue H)
+
+theorem grundyValue_add_nat (G H : PGame) [G.Impartial] [H.Impartial] {n m : ℕ}
+    (hG : grundyValue G = ∗n) (hH : grundyValue H = ∗m) : grundyValue (G + H) = ∗(n ^^^ m) := by
+  rw [grundyValue_add, hG, hH, add_nat]
 
 end PGame
 

--- a/Mathlib/SetTheory/Game/Nim.lean
+++ b/Mathlib/SetTheory/Game/Nim.lean
@@ -336,8 +336,7 @@ theorem grundyValue_le_of_forall_moveRight {G : PGame} [G.Impartial] {o : Nimber
   contrapose! h
   exact exists_grundyValue_moveRight_of_lt h
 
-/-- The Grundy value of the sum of two nim games with natural numbers of piles equals their nimber
-addition. -/
+/-- The Grundy value of the sum of two nim games equals their nimber addition. -/
 theorem grundyValue_nim_add_nim (x y : Ordinal) : grundyValue (nim x + nim y) = ∗x + ∗y := by
   apply (grundyValue_le_of_forall_moveLeft _).antisymm (le_grundyValue_of_Iio_subset_moveLeft _)
   · intro i

--- a/Mathlib/SetTheory/Game/Nim.lean
+++ b/Mathlib/SetTheory/Game/Nim.lean
@@ -364,10 +364,6 @@ theorem grundyValue_add (G H : PGame) [G.Impartial] [H.Impartial] :
     ← grundyValue_nim_add_nim, grundyValue_eq_iff_equiv]
   exact add_congr (equiv_nim_grundyValue G) (equiv_nim_grundyValue H)
 
-theorem grundyValue_add_nat (G H : PGame) [G.Impartial] [H.Impartial] {n m : ℕ}
-    (hG : grundyValue G = ∗n) (hH : grundyValue H = ∗m) : grundyValue (G + H) = ∗(n ^^^ m) := by
-  rw [grundyValue_add, hG, hH, add_nat]
-
 end PGame
 
 end SetTheory

--- a/Mathlib/SetTheory/Ordinal/Nimber.lean
+++ b/Mathlib/SetTheory/Ordinal/Nimber.lean
@@ -369,6 +369,10 @@ theorem add_trichotomy {a b c : Nimber} (h : a + b + c ≠ 0) :
   · rw [← hx'] at hx
     exact Or.inr <| Or.inr hx
 
+theorem lt_add_cases {a b c : Nimber} (h : a < b + c) : a + c < b ∨ a + b < c := by
+  obtain ha | hb | hc := add_trichotomy <| add_assoc a b c ▸ add_ne_zero_iff.2 h.ne
+  exacts [(h.asymm ha).elim, Or.inl <| add_comm c a ▸ hb, Or.inr hc]
+
 /-- Nimber addition of naturals corresponds to the bitwise XOR operation. -/
 theorem add_nat (a b : ℕ) : ∗a + ∗b = ∗(a ^^^ b) := by
   apply le_antisymm


### PR DESCRIPTION
We redefine the grundy value of an impartial game as a nimber. That way, we can prove a more general form of `grundyValue_add`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
