### PR TITLE
[Merged by Bors] - feat: weighted double counting

### DIFF
--- a/Mathlib/Combinatorics/Enumerative/DoubleCounting.lean
+++ b/Mathlib/Combinatorics/Enumerative/DoubleCounting.lean
@@ -68,8 +68,8 @@ theorem mem_bipartiteAbove {b : β} : b ∈ t.bipartiteAbove r a ↔ b ∈ t ∧
 
 @[to_additive]
 theorem prod_prod_bipartiteAbove_eq_prod_prod_bipartiteBelow
-    [AddCommMonoid R] (f : α → β → R) [∀ a b, Decidable (r a b)] :
-    ∑ a ∈ s, ∑ b ∈ t.bipartiteAbove r a, f a b = ∑ b ∈ t, ∑ a ∈ s.bipartiteBelow r b, f a b := by
+    [CommMonoid R] (f : α → β → R) [∀ a b, Decidable (r a b)] :
+    ∏ a ∈ s, ∏ b ∈ t.bipartiteAbove r a, f a b = ∏ b ∈ t, ∏ a ∈ s.bipartiteBelow r b, f a b := by
   simp_rw [bipartiteAbove, bipartiteBelow, sum_filter]
   exact sum_comm
 

--- a/Mathlib/Combinatorics/Enumerative/DoubleCounting.lean
+++ b/Mathlib/Combinatorics/Enumerative/DoubleCounting.lean
@@ -70,8 +70,8 @@ theorem mem_bipartiteAbove {b : β} : b ∈ t.bipartiteAbove r a ↔ b ∈ t ∧
 theorem prod_prod_bipartiteAbove_eq_prod_prod_bipartiteBelow
     [CommMonoid R] (f : α → β → R) [∀ a b, Decidable (r a b)] :
     ∏ a ∈ s, ∏ b ∈ t.bipartiteAbove r a, f a b = ∏ b ∈ t, ∏ a ∈ s.bipartiteBelow r b, f a b := by
-  simp_rw [bipartiteAbove, bipartiteBelow, sum_filter]
-  exact sum_comm
+  simp_rw [bipartiteAbove, bipartiteBelow, prod_filter]
+  exact prod_comm
 
 theorem sum_card_bipartiteAbove_eq_sum_card_bipartiteBelow [∀ a b, Decidable (r a b)] :
     (∑ a ∈ s, (t.bipartiteAbove r a).card) = ∑ b ∈ t, (s.bipartiteBelow r b).card := by

--- a/Mathlib/Combinatorics/Enumerative/DoubleCounting.lean
+++ b/Mathlib/Combinatorics/Enumerative/DoubleCounting.lean
@@ -5,7 +5,6 @@ Authors: Yaël Dillies
 -/
 import Mathlib.Algebra.BigOperators.Ring
 import Mathlib.Algebra.Order.BigOperators.Group.Finset
-import Mathlib.Data.Real.Basic
 
 /-!
 # Double countings
@@ -73,7 +72,7 @@ theorem sum_card_bipartiteAbove_eq_sum_card_bipartiteBelow [∀ a b, Decidable (
   exact sum_comm
 
 theorem sum_sum_bipartiteAbove_eq_sum_sum_bipartiteBelow
-    (f : α → β → ℝ) [∀ a b, Decidable (r a b)] :
+    [AddCommMonoid R] (f : α → β → R) [∀ a b, Decidable (r a b)] :
     ∑ a ∈ s, ∑ b ∈ t.bipartiteAbove r a, f a b = ∑ b ∈ t, ∑ a ∈ s.bipartiteBelow r b, f a b := by
   simp_rw [bipartiteAbove, bipartiteBelow, sum_filter]
   exact sum_comm

--- a/Mathlib/Combinatorics/Enumerative/DoubleCounting.lean
+++ b/Mathlib/Combinatorics/Enumerative/DoubleCounting.lean
@@ -70,7 +70,8 @@ theorem sum_card_bipartiteAbove_eq_sum_card_bipartiteBelow [∀ a b, Decidable (
     (∑ a ∈ s, (t.bipartiteAbove r a).card) = ∑ b ∈ t, (s.bipartiteBelow r b).card := by
    simp_rw [card_eq_sum_ones, sum_sum_bipartiteAbove_eq_sum_sum_bipartiteBelow]
 
-theorem sum_sum_bipartiteAbove_eq_sum_sum_bipartiteBelow
+@[to_additive]
+theorem prod_prod_bipartiteAbove_eq_prod_prod_bipartiteBelow
     [AddCommMonoid R] (f : α → β → R) [∀ a b, Decidable (r a b)] :
     ∑ a ∈ s, ∑ b ∈ t.bipartiteAbove r a, f a b = ∑ b ∈ t, ∑ a ∈ s.bipartiteBelow r b, f a b := by
   simp_rw [bipartiteAbove, bipartiteBelow, sum_filter]

--- a/Mathlib/Combinatorics/Enumerative/DoubleCounting.lean
+++ b/Mathlib/Combinatorics/Enumerative/DoubleCounting.lean
@@ -5,6 +5,7 @@ Authors: Yaël Dillies
 -/
 import Mathlib.Algebra.BigOperators.Ring
 import Mathlib.Algebra.Order.BigOperators.Group.Finset
+import Mathlib.Data.Real.Basic
 
 /-!
 # Double countings
@@ -69,6 +70,12 @@ theorem mem_bipartiteAbove {b : β} : b ∈ t.bipartiteAbove r a ↔ b ∈ t ∧
 theorem sum_card_bipartiteAbove_eq_sum_card_bipartiteBelow [∀ a b, Decidable (r a b)] :
     (∑ a ∈ s, (t.bipartiteAbove r a).card) = ∑ b ∈ t, (s.bipartiteBelow r b).card := by
   simp_rw [card_eq_sum_ones, bipartiteAbove, bipartiteBelow, sum_filter]
+  exact sum_comm
+
+theorem sum_sum_bipartiteAbove_eq_sum_sum_bipartiteBelow
+    (f : α → β → ℝ) [∀ a b, Decidable (r a b)] :
+    ∑ a ∈ s, ∑ b ∈ t.bipartiteAbove r a, f a b = ∑ b ∈ t, ∑ a ∈ s.bipartiteBelow r b, f a b := by
+  simp_rw [bipartiteAbove, bipartiteBelow, sum_filter]
   exact sum_comm
 
 section OrderedSemiring

--- a/Mathlib/Combinatorics/Enumerative/DoubleCounting.lean
+++ b/Mathlib/Combinatorics/Enumerative/DoubleCounting.lean
@@ -68,7 +68,7 @@ theorem mem_bipartiteAbove {b : β} : b ∈ t.bipartiteAbove r a ↔ b ∈ t ∧
 
 theorem sum_card_bipartiteAbove_eq_sum_card_bipartiteBelow [∀ a b, Decidable (r a b)] :
     (∑ a ∈ s, (t.bipartiteAbove r a).card) = ∑ b ∈ t, (s.bipartiteBelow r b).card := by
-   simp_rw [card_eq_sum_ones, sum_sum_bipartiteAbove_eq_sum_sum_bipartiteBelow]
+  simp_rw [card_eq_sum_ones, sum_sum_bipartiteAbove_eq_sum_sum_bipartiteBelow]
 
 @[to_additive]
 theorem prod_prod_bipartiteAbove_eq_prod_prod_bipartiteBelow

--- a/Mathlib/Combinatorics/Enumerative/DoubleCounting.lean
+++ b/Mathlib/Combinatorics/Enumerative/DoubleCounting.lean
@@ -66,16 +66,16 @@ theorem mem_bipartiteBelow {a : α} : a ∈ s.bipartiteBelow r b ↔ a ∈ s ∧
 @[simp]
 theorem mem_bipartiteAbove {b : β} : b ∈ t.bipartiteAbove r a ↔ b ∈ t ∧ r a b := mem_filter
 
-theorem sum_card_bipartiteAbove_eq_sum_card_bipartiteBelow [∀ a b, Decidable (r a b)] :
-    (∑ a ∈ s, (t.bipartiteAbove r a).card) = ∑ b ∈ t, (s.bipartiteBelow r b).card := by
-  simp_rw [card_eq_sum_ones, sum_sum_bipartiteAbove_eq_sum_sum_bipartiteBelow]
-
 @[to_additive]
 theorem prod_prod_bipartiteAbove_eq_prod_prod_bipartiteBelow
     [AddCommMonoid R] (f : α → β → R) [∀ a b, Decidable (r a b)] :
     ∑ a ∈ s, ∑ b ∈ t.bipartiteAbove r a, f a b = ∑ b ∈ t, ∑ a ∈ s.bipartiteBelow r b, f a b := by
   simp_rw [bipartiteAbove, bipartiteBelow, sum_filter]
   exact sum_comm
+
+theorem sum_card_bipartiteAbove_eq_sum_card_bipartiteBelow [∀ a b, Decidable (r a b)] :
+    (∑ a ∈ s, (t.bipartiteAbove r a).card) = ∑ b ∈ t, (s.bipartiteBelow r b).card := by
+  simp_rw [card_eq_sum_ones, sum_sum_bipartiteAbove_eq_sum_sum_bipartiteBelow]
 
 section OrderedSemiring
 variable [OrderedSemiring R] {m n : R}

--- a/Mathlib/Combinatorics/Enumerative/DoubleCounting.lean
+++ b/Mathlib/Combinatorics/Enumerative/DoubleCounting.lean
@@ -68,8 +68,7 @@ theorem mem_bipartiteAbove {b : β} : b ∈ t.bipartiteAbove r a ↔ b ∈ t ∧
 
 theorem sum_card_bipartiteAbove_eq_sum_card_bipartiteBelow [∀ a b, Decidable (r a b)] :
     (∑ a ∈ s, (t.bipartiteAbove r a).card) = ∑ b ∈ t, (s.bipartiteBelow r b).card := by
-  simp_rw [card_eq_sum_ones, bipartiteAbove, bipartiteBelow, sum_filter]
-  exact sum_comm
+   simp_rw [card_eq_sum_ones, sum_sum_bipartiteAbove_eq_sum_sum_bipartiteBelow]
 
 theorem sum_sum_bipartiteAbove_eq_sum_sum_bipartiteBelow
     [AddCommMonoid R] (f : α → β → R) [∀ a b, Decidable (r a b)] :


### PR DESCRIPTION
added weighted double counting as sum_sum_bipartiteAbove_eq_sum_sum_bipartiteBelow

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
