### PR TITLE
[Merged by Bors] - chore(Order/Bounds): move defs to a new file

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -3571,6 +3571,7 @@ import Mathlib.Order.Booleanisation
 import Mathlib.Order.Bounded
 import Mathlib.Order.BoundedOrder
 import Mathlib.Order.Bounds.Basic
+import Mathlib.Order.Bounds.Defs
 import Mathlib.Order.Bounds.OrderIso
 import Mathlib.Order.Category.BddDistLat
 import Mathlib.Order.Category.BddLat

--- a/Mathlib/Algebra/CharP/Defs.lean
+++ b/Mathlib/Algebra/CharP/Defs.lean
@@ -12,6 +12,7 @@ import Mathlib.Data.Nat.Find
 import Mathlib.Data.Nat.Prime.Defs
 import Mathlib.Data.ULift
 import Mathlib.Tactic.NormNum.Basic
+import Mathlib.Order.Interval.Set.Basic
 
 /-!
 # Characteristic of semirings

--- a/Mathlib/Data/Int/GCD.lean
+++ b/Mathlib/Data/Int/GCD.lean
@@ -7,7 +7,9 @@ import Mathlib.Algebra.Group.Int
 import Mathlib.Algebra.GroupWithZero.Semiconj
 import Mathlib.Algebra.Group.Commute.Units
 import Mathlib.Data.Nat.GCD.Basic
-import Mathlib.Order.Bounds.Basic
+import Mathlib.Order.Lattice
+import Mathlib.Data.Set.Operations
+import Mathlib.Order.Bounds.Defs
 
 /-!
 # Extended GCD and divisibility over ℤ

--- a/Mathlib/Order/Bounds/Basic.lean
+++ b/Mathlib/Order/Bounds/Basic.lean
@@ -3,25 +3,18 @@ Copyright (c) 2017 Johannes Hölzl. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johannes Hölzl, Yury Kudryashov
 -/
-import Mathlib.Order.Interval.Set.Basic
 import Mathlib.Data.Set.NAry
+import Mathlib.Order.Bounds.Defs
 import Mathlib.Order.Directed
+import Mathlib.Order.Interval.Set.Basic
 
 /-!
 # Upper / lower bounds
 
-In this file we define:
-* `upperBounds`, `lowerBounds` : the set of upper bounds (resp., lower bounds) of a set;
-* `BddAbove s`, `BddBelow s` : the set `s` is bounded above (resp., below), i.e., the set of upper
-  (resp., lower) bounds of `s` is nonempty;
-* `IsLeast s a`, `IsGreatest s a` : `a` is a least (resp., greatest) element of `s`;
-  for a partial order, it is unique if exists;
-* `IsLUB s a`, `IsGLB s a` : `a` is a least upper bound (resp., a greatest lower bound)
-  of `s`; for a partial order, it is unique if exists.
-We also prove various lemmas about monotonicity, behaviour under `∪`, `∩`, `insert`, and provide
-formulas for `∅`, `univ`, and intervals.
+In this file we prove various lemmas about upper/lower bounds of a set:
+monotonicity, behaviour under `∪`, `∩`, `insert`,
+and provide formulas for `∅`, `univ`, and intervals.
 -/
-
 
 open Function Set
 
@@ -34,43 +27,6 @@ variable {α : Type u} {β : Type v} {γ : Type w} {ι : Sort x}
 section
 
 variable [Preorder α] [Preorder β] {s t : Set α} {a b : α}
-
-/-!
-### Definitions
--/
-
-
-/-- The set of upper bounds of a set. -/
-def upperBounds (s : Set α) : Set α :=
-  { x | ∀ ⦃a⦄, a ∈ s → a ≤ x }
-
-/-- The set of lower bounds of a set. -/
-def lowerBounds (s : Set α) : Set α :=
-  { x | ∀ ⦃a⦄, a ∈ s → x ≤ a }
-
-/-- A set is bounded above if there exists an upper bound. -/
-def BddAbove (s : Set α) :=
-  (upperBounds s).Nonempty
-
-/-- A set is bounded below if there exists a lower bound. -/
-def BddBelow (s : Set α) :=
-  (lowerBounds s).Nonempty
-
-/-- `a` is a least element of a set `s`; for a partial order, it is unique if exists. -/
-def IsLeast (s : Set α) (a : α) : Prop :=
-  a ∈ s ∧ a ∈ lowerBounds s
-
-/-- `a` is a greatest element of a set `s`; for a partial order, it is unique if exists. -/
-def IsGreatest (s : Set α) (a : α) : Prop :=
-  a ∈ s ∧ a ∈ upperBounds s
-
-/-- `a` is a least upper bound of a set `s`; for a partial order, it is unique if exists. -/
-def IsLUB (s : Set α) : α → Prop :=
-  IsLeast (upperBounds s)
-
-/-- `a` is a greatest lower bound of a set `s`; for a partial order, it is unique if exists. -/
-def IsGLB (s : Set α) : α → Prop :=
-  IsGreatest (lowerBounds s)
 
 theorem mem_upperBounds : a ∈ upperBounds s ↔ ∀ x ∈ s, x ≤ a :=
   Iff.rfl

--- a/Mathlib/Order/Bounds/Defs.lean
+++ b/Mathlib/Order/Bounds/Defs.lean
@@ -1,0 +1,55 @@
+/-
+Copyright (c) 2017 Johannes Hölzl. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Johannes Hölzl, Yury Kudryashov
+-/
+import Mathlib.Data.Set.Defs
+import Mathlib.Tactic.TypeStar
+
+/-!
+# Definitions about upper/lower bounds
+
+In this file we define:
+* `upperBounds`, `lowerBounds` : the set of upper bounds (resp., lower bounds) of a set;
+* `BddAbove s`, `BddBelow s` : the set `s` is bounded above (resp., below), i.e., the set of upper
+  (resp., lower) bounds of `s` is nonempty;
+* `IsLeast s a`, `IsGreatest s a` : `a` is a least (resp., greatest) element of `s`;
+  for a partial order, it is unique if exists;
+* `IsLUB s a`, `IsGLB s a` : `a` is a least upper bound (resp., a greatest lower bound)
+  of `s`; for a partial order, it is unique if exists.
+-/
+
+variable {α : Type*} [LE α]
+
+/-- The set of upper bounds of a set. -/
+def upperBounds (s : Set α) : Set α :=
+  { x | ∀ ⦃a⦄, a ∈ s → a ≤ x }
+
+/-- The set of lower bounds of a set. -/
+def lowerBounds (s : Set α) : Set α :=
+  { x | ∀ ⦃a⦄, a ∈ s → x ≤ a }
+
+/-- A set is bounded above if there exists an upper bound. -/
+def BddAbove (s : Set α) :=
+  (upperBounds s).Nonempty
+
+/-- A set is bounded below if there exists a lower bound. -/
+def BddBelow (s : Set α) :=
+  (lowerBounds s).Nonempty
+
+/-- `a` is a least element of a set `s`; for a partial order, it is unique if exists. -/
+def IsLeast (s : Set α) (a : α) : Prop :=
+  a ∈ s ∧ a ∈ lowerBounds s
+
+/-- `a` is a greatest element of a set `s`; for a partial order, it is unique if exists. -/
+def IsGreatest (s : Set α) (a : α) : Prop :=
+  a ∈ s ∧ a ∈ upperBounds s
+
+/-- `a` is a least upper bound of a set `s`; for a partial order, it is unique if exists. -/
+def IsLUB (s : Set α) : α → Prop :=
+  IsLeast (upperBounds s)
+
+/-- `a` is a greatest lower bound of a set `s`; for a partial order, it is unique if exists. -/
+def IsGLB (s : Set α) : α → Prop :=
+  IsGreatest (lowerBounds s)
+

--- a/Mathlib/Order/WellFounded.lean
+++ b/Mathlib/Order/WellFounded.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Jeremy Avigad, Mario Carneiro
 -/
 import Mathlib.Data.Set.Function
-import Mathlib.Order.Bounds.Basic
+import Mathlib.Order.Bounds.Defs
 
 /-!
 # Well-founded relations


### PR DESCRIPTION
Also generalize definitions to `LE`.

---

I'm going to use these definitions in a `Defs` file elsewhere.
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
