### PR TITLE
[Merged by Bors] - feat: Lagrange's theorem for the pointwise product of a subgroup with a set

### DIFF
--- a/Mathlib/GroupTheory/Coset/Card.lean
+++ b/Mathlib/GroupTheory/Coset/Card.lean
@@ -10,6 +10,8 @@ import Mathlib.SetTheory.Cardinal.Finite
 # Lagrange's theorem: the order of a subgroup divides the order of the group.
 -/
 
+open scoped Pointwise
+
 namespace Subgroup
 
 variable {α : Type*} [Group α]
@@ -18,6 +20,15 @@ variable {α : Type*} [Group α]
 theorem card_eq_card_quotient_mul_card_subgroup (s : Subgroup α) :
     Nat.card α = Nat.card (α ⧸ s) * Nat.card s := by
   rw [← Nat.card_prod]; exact Nat.card_congr Subgroup.groupEquivQuotientProdSubgroup
+
+@[to_additive]
+lemma card_mul_eq_card_subgroup_mul_card_quotient (s : Subgroup α) (t : Set α) :
+    Nat.card (t * s : Set α) = Nat.card s * Nat.card (t.image (↑) : Set (α ⧸ s)) := by
+  rw [← Nat.card_prod, Nat.card_congr]
+  apply Equiv.trans _ (QuotientGroup.preimageMkEquivSubgroupProdSet _ _)
+  rw [QuotientGroup.preimage_image_mk]
+  convert Equiv.refl ↑(t * s)
+  aesop (add simp [Set.mem_mul])
 
 /-- **Lagrange's Theorem**: The order of a subgroup divides the order of its ambient group. -/
 @[to_additive "**Lagrange's Theorem**: The order of an additive subgroup divides the order of its


### PR DESCRIPTION
From LeanCamCombi


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
