### PR TITLE
[Merged by Bors] - feat(CategoryTheory/Limits): Add basic pullback lemmas

### DIFF
--- a/Mathlib/CategoryTheory/CommSq.lean
+++ b/Mathlib/CategoryTheory/CommSq.lean
@@ -109,6 +109,14 @@ lemma vert_comp {W X Y Y' Z Z' : C} {f : W ⟶ X} {g : W ⟶ Y} {g' : Y ⟶ Y'} 
     CommSq f (g ≫ g') (h ≫ h') i' :=
   flip (horiz_comp (flip hsq₁) (flip hsq₂))
 
+theorem mono {W X Y : C} {f : W ⟶ X} {g : W ⟶ X} {i : X ⟶ Y} [Mono i] (sq : CommSq f g i i) :
+    f = g :=
+  (cancel_mono i).1 sq.w
+
+theorem epi {W X Y : C} {f : W ⟶ X} {h : X ⟶ Y} {i : X ⟶ Y} [Epi f] (sq : CommSq f f h i) :
+    h = i :=
+  (cancel_epi f).1 sq.w
+
 end CommSq
 
 namespace Functor

--- a/Mathlib/CategoryTheory/CommSq.lean
+++ b/Mathlib/CategoryTheory/CommSq.lean
@@ -109,13 +109,18 @@ lemma vert_comp {W X Y Y' Z Z' : C} {f : W ⟶ X} {g : W ⟶ Y} {g' : Y ⟶ Y'} 
     CommSq f (g ≫ g') (h ≫ h') i' :=
   flip (horiz_comp (flip hsq₁) (flip hsq₂))
 
-theorem mono {W X Y : C} {f : W ⟶ X} {g : W ⟶ X} {i : X ⟶ Y} [Mono i] (sq : CommSq f g i i) :
-    f = g :=
+
+section
+
+variable {W X Y : C}
+
+theorem eq_of_mono {f : W ⟶ X} {g : W ⟶ X} {i : X ⟶ Y} [Mono i] (sq : CommSq f g i i) : f = g :=
   (cancel_mono i).1 sq.w
 
-theorem epi {W X Y : C} {f : W ⟶ X} {h : X ⟶ Y} {i : X ⟶ Y} [Epi f] (sq : CommSq f f h i) :
-    h = i :=
+theorem eq_of_epi {f : W ⟶ X} {h : X ⟶ Y} {i : X ⟶ Y} [Epi f] (sq : CommSq f f h i) : h = i :=
   (cancel_epi f).1 sq.w
+
+end
 
 end CommSq
 

--- a/Mathlib/CategoryTheory/Galois/Basic.lean
+++ b/Mathlib/CategoryTheory/Galois/Basic.lean
@@ -149,7 +149,7 @@ noncomputable instance {G : Type*} [Group G] [Finite G] :
 instance : ReflectsMonomorphisms F := ReflectsMonomorphisms.mk <| by
   intro X Y f _
   haveI : IsIso (pullback.fst (F.map f) (F.map f)) :=
-    fst_iso_of_mono_eq (F.map f)
+    isIso_fst_of_mono (F.map f)
   haveI : IsIso (F.map (pullback.fst f f)) := by
     rw [← PreservesPullback.iso_hom_fst]
     exact IsIso.comp_isIso

--- a/Mathlib/CategoryTheory/Limits/Shapes/Pullback/CommSq.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/Pullback/CommSq.lean
@@ -270,7 +270,7 @@ theorem of_hasBinaryProduct [HasBinaryProduct X Y] [HasZeroObject C] [HasZeroMor
 
 section
 
-variable {P': C} {fst' : P' ⟶ X} {snd' : P' ⟶ Y}
+variable {P' : C} {fst' : P' ⟶ X} {snd' : P' ⟶ Y}
 
 /-- Any object at the top left of a pullback square is isomorphic to the object at the top left
 of any other pullback square with the same cospan. -/
@@ -362,6 +362,18 @@ lemma of_iso (h : IsPullback fst snd f g)
               rw [← reassoc_of% commfst, e₂.hom_inv_id, Category.comp_id]
             · change snd = e₁.hom ≫ snd' ≫ e₃.inv
               rw [← reassoc_of% commsnd, e₃.hom_inv_id, Category.comp_id]))⟩
+section
+
+variable {P X Y : C} {fst : P ⟶ X} {snd : P ⟶ X} {f : X ⟶ Y} [Mono f]
+
+lemma fst_iso_of_mono_eq (h : IsPullback fst snd f f) : IsIso fst :=
+  h.cone.fst_iso_of_mono_eq h.isLimit
+
+lemma snd_iso_of_mono_eq {P X Y : C} {fst : P ⟶ X} {snd : P ⟶ X} {f : X ⟶ Y} [Mono f]
+    (h : IsPullback fst snd f f) : IsIso snd :=
+  h.cone.snd_iso_of_mono_eq h.isLimit
+
+end
 
 end IsPullback
 
@@ -539,6 +551,18 @@ lemma of_iso (h : IsPushout f g inl inr)
         (spanExt e₁ e₂ e₃ commf.symm commg.symm) _).1
           (IsColimit.ofIsoColimit h.isColimit
             (PushoutCocone.ext e₄ comminl comminr))⟩
+
+section
+
+variable {P X Y : C} {inl : X ⟶ P} {inr : X ⟶ P} {f : Y ⟶ X} [Epi f]
+
+lemma inl_iso_of_epi_eq (h : IsPushout f f inl inr) : IsIso inl :=
+  h.cocone.inl_iso_of_epi_eq h.isColimit
+
+lemma inr_iso_of_epi_eq (h : IsPushout f f inl inr) : IsIso inr :=
+  h.cocone.inr_iso_of_epi_eq h.isColimit
+
+end
 
 end IsPushout
 

--- a/Mathlib/CategoryTheory/Limits/Shapes/Pullback/CommSq.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/Pullback/CommSq.lean
@@ -23,7 +23,7 @@ We provide another API for pullbacks and pushouts.
  snd         f
   |          |
   v          v
-  Y ---g---> Zfst
+  Y ---g---> Z
 
 ```
 is a pullback square.
@@ -366,10 +366,10 @@ section
 
 variable {P X Y : C} {fst : P ⟶ X} {snd : P ⟶ X} {f : X ⟶ Y} [Mono f]
 
-lemma fst_iso_of_mono_eq (h : IsPullback fst snd f f) : IsIso fst :=
+lemma isIso_fst_of_mono (h : IsPullback fst snd f f) : IsIso fst :=
   h.cone.fst_iso_of_mono_eq h.isLimit
 
-lemma snd_iso_of_mono_eq {P X Y : C} {fst : P ⟶ X} {snd : P ⟶ X} {f : X ⟶ Y} [Mono f]
+lemma isIso_snd_iso_of_mono {P X Y : C} {fst : P ⟶ X} {snd : P ⟶ X} {f : X ⟶ Y} [Mono f]
     (h : IsPullback fst snd f f) : IsIso snd :=
   h.cone.snd_iso_of_mono_eq h.isLimit
 
@@ -556,10 +556,10 @@ section
 
 variable {P X Y : C} {inl : X ⟶ P} {inr : X ⟶ P} {f : Y ⟶ X} [Epi f]
 
-lemma inl_iso_of_epi_eq (h : IsPushout f f inl inr) : IsIso inl :=
+lemma isIso_inl_iso_of_epi (h : IsPushout f f inl inr) : IsIso inl :=
   h.cocone.inl_iso_of_epi_eq h.isColimit
 
-lemma inr_iso_of_epi_eq (h : IsPushout f f inl inr) : IsIso inr :=
+lemma isIso_inr_iso_of_epi (h : IsPushout f f inl inr) : IsIso inr :=
   h.cocone.inr_iso_of_epi_eq h.isColimit
 
 end

--- a/Mathlib/CategoryTheory/Limits/Shapes/Pullback/CommSq.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/Pullback/CommSq.lean
@@ -3,12 +3,9 @@ Copyright (c) 2022 Kim Morrison. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Kim Morrison, Joël Riou, Calle Sönne
 -/
-import Mathlib.CategoryTheory.CommSq
-import Mathlib.CategoryTheory.Limits.Opposites
-import Mathlib.CategoryTheory.Limits.Shapes.Biproducts
-import Mathlib.CategoryTheory.Limits.Shapes.ZeroMorphisms
-import Mathlib.CategoryTheory.Limits.Constructions.BinaryProducts
+
 import Mathlib.CategoryTheory.Limits.Constructions.ZeroObjects
+import Mathlib.CategoryTheory.Limits.Shapes.Biproducts
 import Mathlib.CategoryTheory.Limits.Shapes.Pullback.Pasting
 
 /-!
@@ -367,11 +364,11 @@ section
 variable {P X Y : C} {fst : P ⟶ X} {snd : P ⟶ X} {f : X ⟶ Y} [Mono f]
 
 lemma isIso_fst_of_mono (h : IsPullback fst snd f f) : IsIso fst :=
-  h.cone.fst_iso_of_mono_eq h.isLimit
+  h.cone.isIso_fst_of_mono_of_isLimit h.isLimit
 
 lemma isIso_snd_iso_of_mono {P X Y : C} {fst : P ⟶ X} {snd : P ⟶ X} {f : X ⟶ Y} [Mono f]
     (h : IsPullback fst snd f f) : IsIso snd :=
-  h.cone.snd_iso_of_mono_eq h.isLimit
+  h.cone.isIso_snd_of_mono_of_isLimit h.isLimit
 
 end
 
@@ -557,10 +554,10 @@ section
 variable {P X Y : C} {inl : X ⟶ P} {inr : X ⟶ P} {f : Y ⟶ X} [Epi f]
 
 lemma isIso_inl_iso_of_epi (h : IsPushout f f inl inr) : IsIso inl :=
-  h.cocone.inl_iso_of_epi_eq h.isColimit
+  h.cocone.isIso_inl_of_epi_of_isColimit h.isColimit
 
 lemma isIso_inr_iso_of_epi (h : IsPushout f f inl inr) : IsIso inr :=
-  h.cocone.inr_iso_of_epi_eq h.isColimit
+  h.cocone.isIso_inr_of_epi_of_isColimit h.isColimit
 
 end
 

--- a/Mathlib/CategoryTheory/Limits/Shapes/Pullback/Mono.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/Pullback/Mono.lean
@@ -191,30 +191,43 @@ section
 
 open WalkingCospan
 
-variable (f : X ⟶ Y)
+variable (f : X ⟶ Y) [Mono f]
 
-instance has_kernel_pair_of_mono [Mono f] : HasPullback f f :=
+instance has_kernel_pair_of_mono : HasPullback f f :=
   ⟨⟨⟨_, PullbackCone.isLimitMkIdId f⟩⟩⟩
 
-theorem fst_eq_snd_of_mono_eq [Mono f] : pullback.fst f f = pullback.snd f f :=
-  ((PullbackCone.isLimitMkIdId f).fac (getLimitCone (cospan f f)).cone left).symm.trans
-    ((PullbackCone.isLimitMkIdId f).fac (getLimitCone (cospan f f)).cone right : _)
+theorem PullbackCone.fst_eq_snd_of_mono_eq {f : X ⟶ Y} [Mono f] (t : PullbackCone f f) :
+    t.fst = t.snd :=
+  (cancel_mono f).1 t.condition
+
+theorem fst_eq_snd_of_mono_eq : pullback.fst f f = pullback.snd f f :=
+  PullbackCone.fst_eq_snd_of_mono_eq (getLimitCone (cospan f f)).cone
 
 @[simp]
-theorem pullbackSymmetry_hom_of_mono_eq [Mono f] : (pullbackSymmetry f f).hom = 𝟙 _ := by
+theorem pullbackSymmetry_hom_of_mono_eq : (pullbackSymmetry f f).hom = 𝟙 _ := by
   ext
   · simp [fst_eq_snd_of_mono_eq]
   · simp [fst_eq_snd_of_mono_eq]
 
-instance fst_iso_of_mono_eq [Mono f] : IsIso (pullback.fst f f) := by
-  refine ⟨⟨pullback.lift (𝟙 _) (𝟙 _) (by simp), ?_, by simp⟩⟩
-  ext
+variable {f} in
+lemma PullbackCone.fst_iso_of_mono_eq {t : PullbackCone f f} (ht : IsLimit t) :
+    IsIso t.fst := by
+  refine ⟨⟨PullbackCone.IsLimit.lift ht (𝟙 _) (𝟙 _) (by simp), ?_, by simp⟩⟩
+  apply PullbackCone.IsLimit.hom_ext ht
   · simp
   · simp [fst_eq_snd_of_mono_eq]
 
-instance snd_iso_of_mono_eq [Mono f] : IsIso (pullback.snd f f) :=
-  fst_eq_snd_of_mono_eq f ▸ fst_iso_of_mono_eq f
+-- TODO: wrong namespace?
+variable {f} in
+lemma PullbackCone.snd_iso_of_mono_eq {t : PullbackCone f f} (ht : IsLimit t) :
+    IsIso t.snd :=
+  t.fst_eq_snd_of_mono_eq ▸ t.fst_iso_of_mono_eq ht
 
+instance fst_iso_of_mono_eq : IsIso (pullback.fst f f) :=
+  PullbackCone.fst_iso_of_mono_eq (getLimitCone (cospan f f)).isLimit
+
+instance snd_iso_of_mono_eq : IsIso (pullback.snd f f) :=
+  PullbackCone.snd_iso_of_mono_eq (getLimitCone (cospan f f)).isLimit
 end
 
 namespace PushoutCocone
@@ -357,27 +370,40 @@ section
 
 open WalkingSpan
 
-variable (f : X ⟶ Y)
+variable (f : X ⟶ Y) [Epi f]
 
-instance has_cokernel_pair_of_epi [Epi f] : HasPushout f f :=
+instance has_cokernel_pair_of_epi : HasPushout f f :=
   ⟨⟨⟨_, PushoutCocone.isColimitMkIdId f⟩⟩⟩
 
-theorem inl_eq_inr_of_epi_eq [Epi f] : (pushout.inl _ _ : _ ⟶ pushout f f) = pushout.inr _ _ :=
-  ((PushoutCocone.isColimitMkIdId f).fac (getColimitCocone (span f f)).cocone left).symm.trans
-    ((PushoutCocone.isColimitMkIdId f).fac (getColimitCocone (span f f)).cocone right : _)
+theorem PushoutCocone.inl_eq_inr_of_epi_eq {f : X ⟶ Y} [Epi f] (t : PushoutCocone f f) :
+    t.inl = t.inr :=
+  (cancel_epi f).1 t.condition
+
+theorem inl_eq_inr_of_epi_eq : pushout.inl f f = pushout.inr f f :=
+  PushoutCocone.inl_eq_inr_of_epi_eq (getColimitCocone (span f f)).cocone
 
 @[simp]
-theorem pullback_symmetry_hom_of_epi_eq [Epi f] : (pushoutSymmetry f f).hom = 𝟙 _ := by
+theorem pullback_symmetry_hom_of_epi_eq : (pushoutSymmetry f f).hom = 𝟙 _ := by
   ext <;> simp [inl_eq_inr_of_epi_eq]
 
-instance inl_iso_of_epi_eq [Epi f] : IsIso (pushout.inl _ _ : _ ⟶ pushout f f) := by
-  refine ⟨⟨pushout.desc (𝟙 _) (𝟙 _) (by simp), by simp, ?_⟩⟩
-  apply pushout.hom_ext
+variable {f} in
+lemma PushoutCocone.inl_iso_of_epi_eq {t : PushoutCocone f f} (ht : IsColimit t) :
+    IsIso t.inl := by
+  refine ⟨⟨PushoutCocone.IsColimit.desc ht (𝟙 _) (𝟙 _) (by simp), by simp, ?_⟩⟩
+  apply PushoutCocone.IsColimit.hom_ext ht
   · simp
   · simp [inl_eq_inr_of_epi_eq]
 
-instance inr_iso_of_epi_eq [Epi f] : IsIso (pushout.inr f f) :=
-  inl_eq_inr_of_epi_eq f ▸ inl_iso_of_epi_eq f
+variable {f} in
+lemma PushoutCocone.inr_iso_of_epi_eq {t : PushoutCocone f f} (ht : IsColimit t) :
+    IsIso t.inr :=
+  t.inl_eq_inr_of_epi_eq ▸ t.inl_iso_of_epi_eq ht
+
+instance inl_iso_of_epi_eq : IsIso (pushout.inl f f) :=
+  PushoutCocone.inl_iso_of_epi_eq (getColimitCocone (span f f)).isColimit
+
+instance inr_iso_of_epi_eq : IsIso (pushout.inr f f) :=
+  PushoutCocone.inr_iso_of_epi_eq (getColimitCocone (span f f)).isColimit
 
 end
 

--- a/Mathlib/CategoryTheory/Limits/Shapes/Pullback/Mono.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/Pullback/Mono.lean
@@ -210,24 +210,23 @@ theorem pullbackSymmetry_hom_of_mono_eq : (pullbackSymmetry f f).hom = 𝟙 _ :=
   · simp [fst_eq_snd_of_mono_eq]
 
 variable {f} in
-lemma PullbackCone.fst_iso_of_mono_eq {t : PullbackCone f f} (ht : IsLimit t) :
+lemma PullbackCone.isIso_fst_of_mono_of_isLimit {t : PullbackCone f f} (ht : IsLimit t) :
     IsIso t.fst := by
   refine ⟨⟨PullbackCone.IsLimit.lift ht (𝟙 _) (𝟙 _) (by simp), ?_, by simp⟩⟩
   apply PullbackCone.IsLimit.hom_ext ht
   · simp
   · simp [fst_eq_snd_of_mono_eq]
 
--- TODO: wrong namespace?
 variable {f} in
-lemma PullbackCone.snd_iso_of_mono_eq {t : PullbackCone f f} (ht : IsLimit t) :
+lemma PullbackCone.isIso_snd_of_mono_of_isLimit {t : PullbackCone f f} (ht : IsLimit t) :
     IsIso t.snd :=
-  t.fst_eq_snd_of_mono_eq ▸ t.fst_iso_of_mono_eq ht
+  t.fst_eq_snd_of_mono_eq ▸ t.isIso_fst_of_mono_of_isLimit ht
 
-instance fst_iso_of_mono_eq : IsIso (pullback.fst f f) :=
-  PullbackCone.fst_iso_of_mono_eq (getLimitCone (cospan f f)).isLimit
+instance isIso_fst_of_mono : IsIso (pullback.fst f f) :=
+  PullbackCone.isIso_fst_of_mono_of_isLimit (getLimitCone (cospan f f)).isLimit
 
-instance snd_iso_of_mono_eq : IsIso (pullback.snd f f) :=
-  PullbackCone.snd_iso_of_mono_eq (getLimitCone (cospan f f)).isLimit
+instance isIso_snd_of_mono : IsIso (pullback.snd f f) :=
+  PullbackCone.isIso_snd_of_mono_of_isLimit (getLimitCone (cospan f f)).isLimit
 end
 
 namespace PushoutCocone
@@ -387,7 +386,7 @@ theorem pullback_symmetry_hom_of_epi_eq : (pushoutSymmetry f f).hom = 𝟙 _ := 
   ext <;> simp [inl_eq_inr_of_epi_eq]
 
 variable {f} in
-lemma PushoutCocone.inl_iso_of_epi_eq {t : PushoutCocone f f} (ht : IsColimit t) :
+lemma PushoutCocone.isIso_inl_of_epi_of_isColimit {t : PushoutCocone f f} (ht : IsColimit t) :
     IsIso t.inl := by
   refine ⟨⟨PushoutCocone.IsColimit.desc ht (𝟙 _) (𝟙 _) (by simp), by simp, ?_⟩⟩
   apply PushoutCocone.IsColimit.hom_ext ht
@@ -395,15 +394,15 @@ lemma PushoutCocone.inl_iso_of_epi_eq {t : PushoutCocone f f} (ht : IsColimit t)
   · simp [inl_eq_inr_of_epi_eq]
 
 variable {f} in
-lemma PushoutCocone.inr_iso_of_epi_eq {t : PushoutCocone f f} (ht : IsColimit t) :
+lemma PushoutCocone.isIso_inr_of_epi_of_isColimit {t : PushoutCocone f f} (ht : IsColimit t) :
     IsIso t.inr :=
-  t.inl_eq_inr_of_epi_eq ▸ t.inl_iso_of_epi_eq ht
+  t.inl_eq_inr_of_epi_eq ▸ t.isIso_inl_of_epi_of_isColimit ht
 
-instance inl_iso_of_epi_eq : IsIso (pushout.inl f f) :=
-  PushoutCocone.inl_iso_of_epi_eq (getColimitCocone (span f f)).isColimit
+instance isIso_inl_of_epi : IsIso (pushout.inl f f) :=
+  PushoutCocone.isIso_inl_of_epi_of_isColimit (getColimitCocone (span f f)).isColimit
 
-instance inr_iso_of_epi_eq : IsIso (pushout.inr f f) :=
-  PushoutCocone.inr_iso_of_epi_eq (getColimitCocone (span f f)).isColimit
+instance isIso_inr_of_epi : IsIso (pushout.inr f f) :=
+  PushoutCocone.isIso_inr_of_epi_of_isColimit (getColimitCocone (span f f)).isColimit
 
 end
 


### PR DESCRIPTION
This PR adds some basic lemmas about pullbacks of a monos/epi by itself. This is used in #14208.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
