### PR TITLE
[Merged by Bors] - chore: more adaptations for lean4#5542

### DIFF
--- a/test/Simps.lean
+++ b/test/Simps.lean
@@ -101,7 +101,7 @@ infix:25 (priority := default+1) " ≃ " => Equiv'
 
 /- Since `prod` and `PProd` are a special case for `@[simps]`, we define a new structure to test
   the basic functionality.-/
-structure MyProd (α β : Type _) := (fst : α) (snd : β)
+structure MyProd (α β : Type _) where (fst : α) (snd : β)
 
 def MyProd.map {α α' β β'} (f : α → α') (g : β → β') (x : MyProd α β) : MyProd α' β' :=
   ⟨f x.1, g x.2⟩

--- a/test/Traversable.lean
+++ b/test/Traversable.lean
@@ -34,7 +34,7 @@ inductive RecData (α : Type u) : Type u
 
 #guard_msgs (drop info) in #synth LawfulTraversable RecData
 
-unsafe structure MetaStruct (α : Type u) : Type u :=
+unsafe structure MetaStruct (α : Type u) : Type u where
   x : α
   y : ℤ
   z : List α


### PR DESCRIPTION
In [lean4#5542](https://github.com/leanprover/lean4/pull/5542) we are deprecating `inductive ... :=`, `structure ... :=`, and `class ... :=` for their `... where` counterparts. Continuation of #17655.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
