### PR TITLE
[Merged by Bors] - feat: define finitely-semisimple linear maps

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -501,6 +501,7 @@ import Mathlib.Algebra.Module.Submodule.Basic
 import Mathlib.Algebra.Module.Submodule.Bilinear
 import Mathlib.Algebra.Module.Submodule.EqLocus
 import Mathlib.Algebra.Module.Submodule.Equiv
+import Mathlib.Algebra.Module.Submodule.Invariant
 import Mathlib.Algebra.Module.Submodule.IterateMapComap
 import Mathlib.Algebra.Module.Submodule.Ker
 import Mathlib.Algebra.Module.Submodule.Lattice

--- a/Mathlib/Algebra/Lie/Weights/Killing.lean
+++ b/Mathlib/Algebra/Lie/Weights/Killing.lean
@@ -269,7 +269,7 @@ lemma isSemisimple_ad_of_mem_isCartanSubalgebra {x : L} (hx : x ∈ H) :
       (genWeightSpace_le_genWeightSpaceOf L x' α) hy
     rw [maxGenEigenspace_eq] at hy
     set k := maxGenEigenspaceIndex (ad K L x) (α x')
-    rw [apply_eq_of_mem_genEigenspace_of_comm_of_isSemisimple_of_isNilpotent_sub hy hS₀ hS hN]
+    rw [apply_eq_of_mem_of_comm_of_isFinitelySemisimple_of_isNil hy hS₀ hS.isFinitelySemisimple hN]
   /- So `S` obeys the derivation axiom if we restrict to root spaces. -/
   have h_der (y z : L) (α β : H → K) (hy : y ∈ rootSpace H α) (hz : z ∈ rootSpace H β) :
       S ⁅y, z⁆ = ⁅S y, z⁆ + ⁅y, S z⁆ := by
@@ -317,7 +317,8 @@ lemma lie_eq_smul_of_mem_rootSpace {α : H → K} {x : L} (hx : x ∈ rootSpace 
   replace hx : x ∈ (ad K L h).maxGenEigenspace (α h) :=
     genWeightSpace_le_genWeightSpaceOf L h α hx
   rw [(isSemisimple_ad_of_mem_isCartanSubalgebra
-    h.property).maxGenEigenspace_eq_eigenspace, Module.End.mem_eigenspace_iff] at hx
+    h.property).isFinitelySemisimple.maxGenEigenspace_eq_eigenspace,
+    Module.End.mem_eigenspace_iff] at hx
   simpa using hx
 
 lemma lie_eq_killingForm_smul_of_mem_rootSpace_of_mem_rootSpace_neg

--- a/Mathlib/Algebra/Module/Submodule/Invariant.lean
+++ b/Mathlib/Algebra/Module/Submodule/Invariant.lean
@@ -1,0 +1,119 @@
+/-
+Copyright (c) 2024 Oliver Nash. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Oliver Nash
+-/
+import Mathlib.Algebra.Module.Submodule.Map
+import Mathlib.Order.Sublattice
+
+/-!
+# The lattice of invariant submodules
+
+In this file we defined the type `Module.End.invtSubmodule`, associated to a linear endomorphism of
+a module. Its utilty stems primarily from those occasions on which we wish to take advantage of the
+lattice structure of invariant submodules.
+
+See also `Module.AEval`.
+
+-/
+
+namespace Module.End
+
+variable {R M : Type*} [Semiring R] [AddCommMonoid M] [Module R M] (f : End R M)
+
+/-- Given an endomorphism, `f` of some module, this is the sublattice of all `f`-invariant
+submodules. -/
+def invtSubmodule : Sublattice (Submodule R M) where
+  carrier := {p : Submodule R M | p ≤ p.comap f}
+  supClosed' p hp q hq := sup_le_iff.mpr
+    ⟨le_trans hp <| Submodule.comap_mono le_sup_left,
+    le_trans hq <| Submodule.comap_mono le_sup_right⟩
+  infClosed' p hp q hq := by
+    simp only [Set.mem_setOf_eq, Submodule.comap_inf, le_inf_iff]
+    exact ⟨inf_le_of_left_le hp, inf_le_of_right_le hq⟩
+
+lemma mem_invtSubmodule {p : Submodule R M} :
+    p ∈ f.invtSubmodule ↔ p ≤ p.comap f :=
+  Iff.rfl
+
+namespace invtSubmodule
+
+@[simp]
+protected lemma top_mem : ⊤ ∈ f.invtSubmodule := by simp [invtSubmodule]
+
+@[simp]
+protected lemma bot_mem : ⊥ ∈ f.invtSubmodule := by simp [invtSubmodule]
+
+instance : BoundedOrder (f.invtSubmodule) where
+  top := ⟨⊤, invtSubmodule.top_mem f⟩
+  bot := ⟨⊥, invtSubmodule.bot_mem f⟩
+  le_top := fun ⟨p, hp⟩ ↦ by simp
+  bot_le := fun ⟨p, hp⟩ ↦ by simp
+
+@[simp]
+protected lemma zero :
+    (0 : End R M).invtSubmodule = ⊤ :=
+  eq_top_iff.mpr fun x ↦ by simp [invtSubmodule]
+
+@[simp]
+protected lemma id :
+    invtSubmodule (LinearMap.id : End R M) = ⊤ :=
+  eq_top_iff.mpr fun x ↦ by simp [invtSubmodule]
+
+protected lemma mk_eq_bot_iff {p : Submodule R M} (hp : p ∈ f.invtSubmodule) :
+    (⟨p, hp⟩ : f.invtSubmodule) = ⊥ ↔ p = ⊥ :=
+  Subtype.mk_eq_bot_iff (by simp [invtSubmodule]) _
+
+protected lemma mk_eq_top_iff {p : Submodule R M} (hp : p ∈ f.invtSubmodule) :
+    (⟨p, hp⟩ : f.invtSubmodule) = ⊤ ↔ p = ⊤ :=
+  Subtype.mk_eq_top_iff (by simp [invtSubmodule]) _
+
+@[simp]
+protected lemma disjoint_mk_iff {p q : Submodule R M}
+    (hp : p ∈ f.invtSubmodule) (hq : q ∈ f.invtSubmodule) :
+    Disjoint (α := f.invtSubmodule) ⟨p, hp⟩ ⟨q, hq⟩ ↔ Disjoint p q := by
+  rw [disjoint_iff, disjoint_iff, Sublattice.mk_inf_mk,
+    Subtype.mk_eq_bot_iff (⊥ : f.invtSubmodule).property]
+
+protected lemma disjoint_iff {p q : f.invtSubmodule} :
+    Disjoint p q ↔ Disjoint (p : Submodule R M) (q : Submodule R M) := by
+  obtain ⟨p, hp⟩ := p
+  obtain ⟨q, hq⟩ := q
+  simp
+
+@[simp]
+protected lemma codisjoint_mk_iff {p q : Submodule R M}
+    (hp : p ∈ f.invtSubmodule) (hq : q ∈ f.invtSubmodule) :
+    Codisjoint (α := f.invtSubmodule) ⟨p, hp⟩ ⟨q, hq⟩ ↔ Codisjoint p q := by
+  rw [codisjoint_iff, codisjoint_iff, Sublattice.mk_sup_mk,
+    Subtype.mk_eq_top_iff (⊤ : f.invtSubmodule).property]
+
+protected lemma codisjoint_iff {p q : f.invtSubmodule} :
+    Codisjoint p q ↔ Codisjoint (p : Submodule R M) (q : Submodule R M) := by
+  obtain ⟨p, hp⟩ := p
+  obtain ⟨q, hq⟩ := q
+  simp
+
+@[simp]
+protected lemma isCompl_mk_iff {p q : Submodule R M}
+    (hp : p ∈ f.invtSubmodule) (hq : q ∈ f.invtSubmodule) :
+    IsCompl (α := f.invtSubmodule) ⟨p, hp⟩ ⟨q, hq⟩ ↔ IsCompl p q := by
+  simp [isCompl_iff]
+
+protected lemma isCompl_iff {p q : f.invtSubmodule} :
+    IsCompl p q ↔ IsCompl (p : Submodule R M) (q : Submodule R M) := by
+  obtain ⟨p, hp⟩ := p
+  obtain ⟨q, hq⟩ := q
+  simp
+
+lemma map_subtype_mem_of_mem_invtSubmodule {p : Submodule R M} (hp : p ∈ f.invtSubmodule)
+    {q : Submodule R p} (hq : q ∈ invtSubmodule (LinearMap.restrict f hp)) :
+    Submodule.map p.subtype q ∈ f.invtSubmodule := by
+  rintro - ⟨⟨x, hx⟩, hx', rfl⟩
+  specialize hq hx'
+  rw [Submodule.mem_comap, LinearMap.restrict_apply] at hq
+  simpa [hq] using hp hx
+
+end invtSubmodule
+
+end Module.End

--- a/Mathlib/Algebra/Module/Submodule/Map.lean
+++ b/Mathlib/Algebra/Module/Submodule/Map.lean
@@ -364,9 +364,15 @@ def orderIsoMapComapOfBijective [FunLike F M M₂] [SemilinearMapClass F σ₁�
   map_rel_iff' := map_le_map_iff_of_injective hf.injective _ _
 
 /-- A linear isomorphism induces an order isomorphism of submodules. -/
-@[simps! symm_apply apply]
+@[simps! apply]
 def orderIsoMapComap [EquivLike F M M₂] [SemilinearMapClass F σ₁₂ M M₂] (f : F) :
     Submodule R M ≃o Submodule R₂ M₂ := orderIsoMapComapOfBijective f (EquivLike.bijective f)
+
+@[simp]
+lemma orderIsoMapComap_symm_apply [EquivLike F M M₂] [SemilinearMapClass F σ₁₂ M M₂]
+    (f : F) (p : Submodule R₂ M₂) :
+    (orderIsoMapComap f).symm p = comap f p :=
+  rfl
 
 end OrderIso
 

--- a/Mathlib/Algebra/Module/Submodule/Range.lean
+++ b/Mathlib/Algebra/Module/Submodule/Range.lean
@@ -277,6 +277,12 @@ theorem comap_subtype_eq_top {p p' : Submodule R M} : comap p.subtype p' = ⊤ �
 theorem comap_subtype_self : comap p.subtype p = ⊤ :=
   comap_subtype_eq_top.2 le_rfl
 
+@[simp]
+lemma comap_subtype_le_iff {p q r : Submodule R M} :
+    q.comap p.subtype ≤ r.comap p.subtype ↔ p ⊓ q ≤ p ⊓ r :=
+  ⟨fun h ↦ by simpa using map_mono (f := p.subtype) h,
+   fun h ↦ by simpa using comap_mono (f := p.subtype) h⟩
+
 theorem range_inclusion (p q : Submodule R M) (h : p ≤ q) :
     range (inclusion h) = comap q.subtype p := by
   rw [← map_top, inclusion, LinearMap.map_codRestrict, map_top, range_subtype]

--- a/Mathlib/Algebra/Polynomial/Module/AEval.lean
+++ b/Mathlib/Algebra/Polynomial/Module/AEval.lean
@@ -3,6 +3,7 @@ Copyright (c) 2022 Richard M. Hill. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Richard M. Hill
 -/
+import Mathlib.Algebra.Module.Submodule.Invariant
 import Mathlib.Algebra.Polynomial.AlgebraMap
 import Mathlib.RingTheory.Finiteness
 
@@ -94,6 +95,15 @@ def _root_.LinearMap.ofAEval {N} [AddCommMonoid N] [Module R N] [Module R[X] N]
         LinearMap.comp_apply, LinearEquiv.coe_toLinearMap] at h ⊢
       simp_rw [pow_succ, ← mul_assoc, mul_smul _ X, ← hf, ← of_symm_X_smul, ← h]
 
+/-- Construct an `R[X]`-linear equivalence out of `AEval R M a` from a `R`-linear map out of `M`. -/
+def _root_.LinearEquiv.ofAEval {N} [AddCommMonoid N] [Module R N] [Module R[X] N]
+    [IsScalarTower R R[X] N] (f : M ≃ₗ[R] N) (hf : ∀ m : M, f (a • m) = (X : R[X]) • f m) :
+    AEval R M a ≃ₗ[R[X]] N where
+  __ := LinearMap.ofAEval a f hf
+  invFun := (of R M a) ∘ f.symm
+  left_inv x := by simp [LinearMap.ofAEval]
+  right_inv x := by simp [LinearMap.ofAEval]
+
 lemma annihilator_eq_ker_aeval [FaithfulSMul A M] :
     annihilator R[X] (AEval R M a) = RingHom.ker (aeval a) := by
   ext p
@@ -111,60 +121,51 @@ lemma annihilator_top_eq_ker_aeval [FaithfulSMul A M] :
 
 section Submodule
 
-variable {p : Submodule R M} {q : Submodule R[X] <| AEval R M a}
-
-variable (R M) in
-/-- We can turn an `R[X]`-submodule into an `R`-submodule by forgetting the action of `X`. -/
-def comapSubmodule :
-    CompleteLatticeHom (Submodule R[X] <| AEval R M a) (Submodule R M) :=
-  (Submodule.orderIsoMapComap (of R M a)).symm.toCompleteLatticeHom.comp <|
-    Submodule.restrictScalarsLatticeHom R R[X] (AEval R M a)
-
-@[simp] lemma mem_comapSubmodule {x : M} :
-    x ∈ comapSubmodule R M a q ↔ of R M a x ∈ q :=
-  Iff.rfl
-
-@[simp] lemma comapSubmodule_le_comap :
-    comapSubmodule R M a q ≤ (comapSubmodule R M a q).comap (Algebra.lsmul R R M a) := by
-  intro m hm
-  simpa only [Submodule.mem_comap, Algebra.lsmul_coe, mem_comapSubmodule, ← X_smul_of] using
-    q.smul_mem (X : R[X]) hm
-
-/-- An `R`-submodule which is stable under the action of `a` can be promoted to an
-`R[X]`-submodule. -/
-def mapSubmodule (hp : p ≤ p.comap (Algebra.lsmul R R M a)) : Submodule R[X] <| AEval R M a :=
-  { toAddSubmonoid := p.toAddSubmonoid.map (of R M a)
-    smul_mem' := by
-      rintro f - ⟨m : M, h : m ∈ p, rfl⟩
-      simp only [AddSubsemigroup.mem_carrier, AddSubmonoid.mem_toSubsemigroup, AddSubmonoid.mem_map,
-        Submodule.mem_toAddSubmonoid]
-      exact ⟨aeval a f • m, aeval_apply_smul_mem_of_le_comap' h f a hp, of_aeval_smul a f m⟩ }
-
-variable (hp : p ≤ p.comap (Algebra.lsmul R R M a))
-
-@[simp] lemma mem_mapSubmodule {m : AEval R M a} :
-    m ∈ mapSubmodule a hp ↔ (of R M a).symm m ∈ p :=
-  ⟨fun ⟨_, hm, hm'⟩ ↦ hm'.symm ▸ hm, fun hm ↦ ⟨(of R M a).symm m, hm, rfl⟩⟩
-
-@[simp] lemma mapSubmodule_comapSubmodule (h := comapSubmodule_le_comap a) :
-    mapSubmodule a (p := comapSubmodule R M a q) h = q := by
-  ext; simp
-
-@[simp] lemma comapSubmodule_mapSubmodule :
-    comapSubmodule R M a (mapSubmodule a hp) = p := by
-  ext; simp
-
 variable (R M)
 
-lemma injective_comapSubmodule : Injective (comapSubmodule R M a) := by
-  intro q₁ q₂ hq
-  rw [← mapSubmodule_comapSubmodule (q := q₁), ← mapSubmodule_comapSubmodule (q := q₂)]
-  simp_rw [hq]
+/-- The natural order isomorphism between the two ways to represent invariant submodules. -/
+def mapSubmodule :
+    (Algebra.lsmul R R M a).invtSubmodule ≃o Submodule R[X] (AEval R M a) where
+  toFun p :=
+    { toAddSubmonoid := (p : Submodule R M).toAddSubmonoid.map (of R M a)
+      smul_mem' := by
+        rintro f - ⟨m : M, h : m ∈ (p : Submodule R M), rfl⟩
+        simp only [AddSubsemigroup.mem_carrier, AddSubmonoid.mem_toSubsemigroup,
+          AddSubmonoid.mem_map, Submodule.mem_toAddSubmonoid]
+        exact ⟨aeval a f • m, aeval_apply_smul_mem_of_le_comap' h f a p.2, of_aeval_smul a f m⟩ }
+  invFun q := ⟨(Submodule.orderIsoMapComap (of R M a)).symm (q.restrictScalars R), fun m hm ↦ by
+    simpa [← X_smul_of] using q.smul_mem (X : R[X]) hm⟩
+  left_inv p := by ext; simp
+  right_inv q := by ext; aesop
+  map_rel_iff' {p p'} := ⟨fun h x hx ↦ by aesop, fun h x hx ↦ by aesop⟩
 
-lemma range_comapSubmodule :
-    range (comapSubmodule R M a) = {p | p ≤ p.comap (Algebra.lsmul R R M a)} :=
-  le_antisymm (fun _ ⟨_, hq⟩ ↦ hq ▸ comapSubmodule_le_comap a)
-    (fun _ hp ↦ ⟨mapSubmodule a hp, comapSubmodule_mapSubmodule a hp⟩)
+@[simp] lemma mem_mapSubmodule_apply {p : (Algebra.lsmul R R M a).invtSubmodule} {m : AEval R M a} :
+    m ∈ mapSubmodule R M a p ↔ (of R M a).symm m ∈ (p : Submodule R M) :=
+  ⟨fun ⟨_, hm, hm'⟩ ↦ hm'.symm ▸ hm, fun hm ↦ ⟨(of R M a).symm m, hm, rfl⟩⟩
+
+@[simp] lemma mem_mapSubmodule_symm_apply {q : Submodule R[X] (AEval R M a)} {m : M} :
+    m ∈ ((mapSubmodule R M a).symm q : Submodule R M) ↔ of R M a m ∈ q :=
+  Iff.rfl
+
+variable {R M}
+variable (p : Submodule R M) (hp : p ∈ (Algebra.lsmul R R M a).invtSubmodule)
+
+/-- The natural `R`-linear equivalence between the two ways to represent an invariant submodule. -/
+def equiv_mapSubmodule :
+    p ≃ₗ[R] mapSubmodule R M a ⟨p, hp⟩ where
+  toFun x := ⟨of R M a x, by simp⟩
+  invFun x := ⟨((of R M _).symm (x : AEval R M a)), by obtain ⟨x, hx⟩ := x; simpa using hx⟩
+  left_inv x := rfl
+  right_inv x := rfl
+  map_add' x y := rfl
+  map_smul' t x := rfl
+
+/-- The natural `R[X]`-linear equivalence between the two ways to represent an invariant submodule.
+-/
+noncomputable def restrict_equiv_mapSubmodule :
+    (AEval R p <| (Algebra.lsmul R R M a).restrict hp) ≃ₗ[R[X]] mapSubmodule R M a ⟨p, hp⟩ :=
+  LinearEquiv.ofAEval ((Algebra.lsmul R R M a).restrict hp) (equiv_mapSubmodule a p hp)
+    (fun x ↦ by simp [equiv_mapSubmodule, X_smul_of])
 
 end Submodule
 

--- a/Mathlib/LinearAlgebra/Eigenspace/Semisimple.lean
+++ b/Mathlib/LinearAlgebra/Eigenspace/Semisimple.lean
@@ -25,9 +25,9 @@ namespace Module.End
 
 variable {R M : Type*} [CommRing R] [AddCommGroup M] [Module R M] {f g : End R M}
 
-lemma apply_eq_of_mem_genEigenspace_of_comm_of_isSemisimple_of_isNilpotent_sub
+lemma apply_eq_of_mem_of_comm_of_isFinitelySemisimple_of_isNil
     {μ : R} {k : ℕ} {m : M} (hm : m ∈ f.genEigenspace μ k)
-    (hfg : Commute f g) (hss : g.IsSemisimple) (hnil : IsNilpotent (f - g)) :
+    (hfg : Commute f g) (hss : g.IsFinitelySemisimple) (hnil : IsNilpotent (f - g)) :
     g m = μ • m := by
   set p := f.genEigenspace μ k
   have h₁ : MapsTo g p p := mapsTo_genEigenspace_of_comm hfg μ k
@@ -41,19 +41,19 @@ lemma apply_eq_of_mem_genEigenspace_of_comm_of_isSemisimple_of_isNilpotent_sub
     (Commute.sub_right rfl hfg).sub_left <| Algebra.commute_algebraMap_left μ (f - g)
   suffices IsNilpotent ((g - algebraMap R (End R M) μ).restrict h₂) by
     replace this : g.restrict h₁ - algebraMap R (End R p) μ = 0 :=
-      eq_zero_of_isNilpotent_isSemisimple this (by simpa using hss.restrict)
+      eq_zero_of_isNilpotent_of_isFinitelySemisimple this (by simpa using hss.restrict _)
     simpa [LinearMap.restrict_apply, sub_eq_zero] using LinearMap.congr_fun this ⟨m, hm⟩
   simpa [LinearMap.restrict_sub h₄ h₃] using (LinearMap.restrict_commute hfg h₄ h₃).isNilpotent_sub
     (f.isNilpotent_restrict_sub_algebraMap μ k) (Module.End.isNilpotent.restrict h₃ hnil)
 
-lemma IsSemisimple.genEigenspace_eq_eigenspace
-    (hf : f.IsSemisimple) (μ : R) {k : ℕ} (hk : 0 < k) :
+lemma IsFinitelySemisimple.genEigenspace_eq_eigenspace
+    (hf : f.IsFinitelySemisimple) (μ : R) {k : ℕ} (hk : 0 < k) :
     f.genEigenspace μ k = f.eigenspace μ := by
   refine le_antisymm (fun m hm ↦ mem_eigenspace_iff.mpr ?_) (eigenspace_le_genEigenspace hk)
-  exact apply_eq_of_mem_genEigenspace_of_comm_of_isSemisimple_of_isNilpotent_sub hm rfl hf (by simp)
+  exact apply_eq_of_mem_of_comm_of_isFinitelySemisimple_of_isNil hm rfl hf (by simp)
 
-lemma IsSemisimple.maxGenEigenspace_eq_eigenspace
-    (hf : f.IsSemisimple) (μ : R) :
+lemma IsFinitelySemisimple.maxGenEigenspace_eq_eigenspace
+    (hf : f.IsFinitelySemisimple) (μ : R) :
     f.maxGenEigenspace μ = f.eigenspace μ := by
   simp_rw [maxGenEigenspace_def, ← (f.genEigenspace μ).monotone.iSup_nat_add 1,
     hf.genEigenspace_eq_eigenspace μ (Nat.zero_lt_succ _), ciSup_const]

--- a/Mathlib/LinearAlgebra/Semisimple.lean
+++ b/Mathlib/LinearAlgebra/Semisimple.lean
@@ -49,22 +49,61 @@ namespace Module.End
 
 section CommRing
 
-variable (f g : End R M)
+variable (f : End R M)
 
 /-- A linear endomorphism of an `R`-module `M` is called *semisimple* if the induced `R[X]`-module
 structure on `M` is semisimple. This is equivalent to saying that every `f`-invariant `R`-submodule
 of `M` has an `f`-invariant complement: see `Module.End.isSemisimple_iff`. -/
-abbrev IsSemisimple := IsSemisimpleModule R[X] (AEval' f)
+def IsSemisimple := IsSemisimpleModule R[X] (AEval' f)
 
-variable {f g}
+/-- A weaker version of semisimplicity that only prescribes behaviour on finitely-generated
+submodules. -/
+def IsFinitelySemisimple : Prop :=
+  ∀ p (hp : p ∈ invtSubmodule f), Module.Finite R p → IsSemisimple (LinearMap.restrict f hp)
+
+variable {f}
+
+/-- A linear endomorphism is semisimple if every invariant submodule has in invariant complement.
+
+See also `Module.End.isSemisimple_iff`. -/
+lemma isSemisimple_iff' :
+    f.IsSemisimple ↔ ∀ p : invtSubmodule f, ∃ q : invtSubmodule f, IsCompl p q := by
+  rw [IsSemisimple, IsSemisimpleModule, (AEval.mapSubmodule R M f).symm.complementedLattice_iff,
+    complementedLattice_iff]
+  rfl
 
 lemma isSemisimple_iff :
-    f.IsSemisimple ↔ ∀ p : Submodule R M, p ≤ p.comap f → ∃ q, q ≤ q.comap f ∧ IsCompl p q := by
-  set s := (AEval.comapSubmodule R M f).range
-  have h : s = {p : Submodule R M | p ≤ p.comap f} := AEval.range_comapSubmodule R M f
-  let e := CompleteLatticeHom.toOrderIsoRangeOfInjective _ (AEval.injective_comapSubmodule R M f)
-  simp_rw [Module.End.IsSemisimple, IsSemisimpleModule, e.complementedLattice_iff,
-    s.isComplemented_iff, ← SetLike.mem_coe, h, mem_setOf_eq]
+    f.IsSemisimple ↔ ∀ p ∈ invtSubmodule f, ∃ q ∈ invtSubmodule f, IsCompl p q := by
+  simp_rw [isSemisimple_iff']
+  aesop
+
+lemma isSemisimple_restrict_iff (p) (hp : p ∈ invtSubmodule f) :
+    IsSemisimple (LinearMap.restrict f hp) ↔
+    ∀ q ∈ f.invtSubmodule, q ≤ p → ∃ r ≤ p, r ∈ f.invtSubmodule ∧ Disjoint q r ∧ q ⊔ r = p := by
+  let e : Submodule R[X] (AEval' (f.restrict hp)) ≃o Iic (AEval.mapSubmodule R M f ⟨p, hp⟩) :=
+    (Submodule.orderIsoMapComap <| AEval.restrict_equiv_mapSubmodule f p hp).trans
+      (Submodule.mapIic _)
+  simp_rw [IsSemisimple, IsSemisimpleModule, e.complementedLattice_iff, disjoint_iff,
+    ← (OrderIso.Iic _ _).complementedLattice_iff, Iic.complementedLattice_iff, Subtype.forall,
+    Subtype.exists, Subtype.mk_le_mk, Sublattice.mk_inf_mk, Sublattice.mk_sup_mk, Subtype.mk.injEq,
+    exists_and_left, exists_and_right, invtSubmodule.mk_eq_bot_iff, exists_prop, and_assoc]
+  rfl
+
+/-- A linear endomorphism is finitely semisimple if it is semisimple on every finitely-generated
+invariant submodule.
+
+See also `Module.End.isFinitelySemisimple_iff`. -/
+lemma isFinitelySemisimple_iff' :
+    f.IsFinitelySemisimple ↔ ∀ p (hp : p ∈ invtSubmodule f),
+      Module.Finite R p → IsSemisimple (LinearMap.restrict f hp) :=
+  Iff.rfl
+
+/-- A characterisation of `Module.End.IsFinitelySemisimple` using only the lattice of submodules of
+`M` (thus avoiding submodules of submodules). -/
+lemma isFinitelySemisimple_iff :
+    f.IsFinitelySemisimple ↔ ∀ p ∈ invtSubmodule f, Module.Finite R p → ∀ q ∈ invtSubmodule f,
+      q ≤ p → ∃ r, r ≤ p ∧ r ∈ invtSubmodule f ∧ Disjoint q r ∧ q ⊔ r = p := by
+  simp_rw [isFinitelySemisimple_iff', isSemisimple_restrict_iff]
 
 @[simp]
 lemma isSemisimple_zero [IsSemisimpleModule R M] : IsSemisimple (0 : Module.End R M) := by
@@ -74,7 +113,16 @@ lemma isSemisimple_zero [IsSemisimpleModule R M] : IsSemisimple (0 : Module.End 
 lemma isSemisimple_id [IsSemisimpleModule R M] : IsSemisimple (LinearMap.id : Module.End R M) := by
   simpa [isSemisimple_iff] using exists_isCompl
 
-@[simp] lemma isSemisimple_neg : (-f).IsSemisimple ↔ f.IsSemisimple := by simp [isSemisimple_iff]
+@[simp] lemma isSemisimple_neg : (-f).IsSemisimple ↔ f.IsSemisimple := by
+  simp [isSemisimple_iff, mem_invtSubmodule]
+
+variable (f) in
+protected lemma _root_.LinearEquiv.isSemisimple_iff {M₂ : Type*} [AddCommGroup M₂] [Module R M₂]
+    (g : End R M₂) (e : M ≃ₗ[R] M₂) (he : e ∘ₗ f = g ∘ₗ e) :
+    f.IsSemisimple ↔ g.IsSemisimple := by
+  let e : AEval' f ≃ₗ[R[X]] AEval' g := LinearEquiv.ofAEval _ (e.trans (AEval'.of g)) fun x ↦ by
+    simpa [AEval'.X_smul_of] using LinearMap.congr_fun he x
+  exact (Submodule.orderIsoMapComap e).complementedLattice_iff
 
 lemma eq_zero_of_isNilpotent_isSemisimple (hn : IsNilpotent f) (hs : f.IsSemisimple) : f = 0 := by
   have ⟨n, h0⟩ := hn
@@ -82,24 +130,74 @@ lemma eq_zero_of_isNilpotent_isSemisimple (hn : IsNilpotent f) (hs : f.IsSemisim
   rw [← RingHom.mem_ker, ← AEval.annihilator_eq_ker_aeval (M := M)] at h0 ⊢
   exact hs.annihilator_isRadical _ _ ⟨n, h0⟩
 
+lemma eq_zero_of_isNilpotent_of_isFinitelySemisimple
+    (hn : IsNilpotent f) (hs : IsFinitelySemisimple f) : f = 0 := by
+  have (p) (hp₁ : p ∈ f.invtSubmodule) (hp₂ : Module.Finite R p) : f.restrict hp₁ = 0 := by
+    specialize hs p hp₁ hp₂
+    replace hn : IsNilpotent (f.restrict hp₁) := isNilpotent.restrict hp₁ hn
+    exact eq_zero_of_isNilpotent_isSemisimple hn hs
+  ext x
+  obtain ⟨k : ℕ, hk : f ^ k = 0⟩ := hn
+  let p := Submodule.span R {(f ^ i) x | (i : ℕ) (_ : i ≤ k)}
+  have hp₁ : p ∈ f.invtSubmodule := by
+    simp only [mem_invtSubmodule, p, Submodule.span_le]
+    rintro - ⟨i, hi, rfl⟩
+    apply Submodule.subset_span
+    rcases lt_or_eq_of_le hi with hik | rfl
+    · exact ⟨i + 1, hik, by simpa [LinearMap.pow_apply] using iterate_succ_apply' f i x⟩
+    · exact ⟨i, by simp [hk]⟩
+  have hp₂ : Module.Finite R p := by
+    let g : ℕ → M := fun i ↦ (f ^ i) x
+    have hg : {(f ^ i) x | (i : ℕ) (_ : i ≤ k)} = g '' Iic k := by ext; simp [g]
+    exact Module.Finite.span_of_finite _ <| hg ▸ toFinite (g '' Iic k)
+  simpa [LinearMap.restrict_apply, Subtype.ext_iff] using
+    LinearMap.congr_fun (this p hp₁ hp₂) ⟨x, Submodule.subset_span ⟨0, k.zero_le, rfl⟩⟩
+
 @[simp]
 lemma isSemisimple_sub_algebraMap_iff {μ : R} :
     (f - algebraMap R (End R M) μ).IsSemisimple ↔ f.IsSemisimple := by
   suffices ∀ p : Submodule R M, p ≤ p.comap (f - algebraMap R (Module.End R M) μ) ↔ p ≤ p.comap f by
-    simp [isSemisimple_iff, this]
+    simp [mem_invtSubmodule, isSemisimple_iff, this]
   refine fun p ↦ ⟨fun h x hx ↦ ?_, fun h x hx ↦ p.sub_mem (h hx) (p.smul_mem μ hx)⟩
   simpa using p.add_mem (h hx) (p.smul_mem μ hx)
 
-lemma IsSemisimple.restrict {p : Submodule R M} {hp : MapsTo f p p} (hf : f.IsSemisimple) :
+lemma IsSemisimple.restrict {p : Submodule R M} (hp : p ∈ f.invtSubmodule) (hf : f.IsSemisimple) :
     IsSemisimple (f.restrict hp) := by
-  simp only [isSemisimple_iff] at hf ⊢
-  intro q hq
-  replace hq : MapsTo f (q.map p.subtype) (q.map p.subtype) := by
-    rintro - ⟨⟨x, hx⟩, hx', rfl⟩; exact ⟨⟨f x, hp hx⟩, by simpa using hq hx', rfl⟩
-  obtain ⟨r, hr₁, hr₂⟩ := hf _ hq
-  refine ⟨r.comap p.subtype, fun x hx ↦ hr₁ hx, ?_⟩
-  rw [← q.comap_map_eq_of_injective p.injective_subtype]
-  exact p.isCompl_comap_subtype_of_isCompl_of_le hr₂ <| p.map_subtype_le q
+  rw [IsSemisimple] at hf ⊢
+  let e : Submodule R[X] (AEval' (LinearMap.restrict f hp)) ≃o
+      Iic (AEval.mapSubmodule R M f ⟨p, hp⟩) :=
+    (Submodule.orderIsoMapComap <| AEval.restrict_equiv_mapSubmodule f p hp).trans <|
+      Submodule.mapIic _
+  exact e.complementedLattice_iff.mpr inferInstance
+
+lemma IsSemisimple.isFinitelySemisimple (hf : f.IsSemisimple) :
+    f.IsFinitelySemisimple :=
+  isFinitelySemisimple_iff'.mp fun _ _ _ ↦ hf.restrict _
+
+@[simp]
+lemma isFinitelySemisimple_iff_isSemisimple [Module.Finite R M] :
+    f.IsFinitelySemisimple ↔ f.IsSemisimple := by
+  refine ⟨fun hf ↦ isSemisimple_iff.mpr fun p hp ↦ ?_, IsSemisimple.isFinitelySemisimple⟩
+  obtain ⟨q, -, hq₁, hq₂, hq₃⟩ :=
+    isFinitelySemisimple_iff.mp hf ⊤ (invtSubmodule.top_mem f) inferInstance p hp le_top
+  exact ⟨q, hq₁, hq₂, codisjoint_iff.mpr hq₃⟩
+
+@[simp]
+lemma isFinitelySemisimple_sub_algebraMap_iff {μ : R} :
+    (f - algebraMap R (End R M) μ).IsFinitelySemisimple ↔ f.IsFinitelySemisimple := by
+  suffices ∀ p : Submodule R M, p ≤ p.comap (f - algebraMap R (Module.End R M) μ) ↔ p ≤ p.comap f by
+    simp_rw [isFinitelySemisimple_iff, mem_invtSubmodule, this]
+  refine fun p ↦ ⟨fun h x hx ↦ ?_, fun h x hx ↦ p.sub_mem (h hx) (p.smul_mem μ hx)⟩
+  simpa using p.add_mem (h hx) (p.smul_mem μ hx)
+
+lemma IsFinitelySemisimple.restrict {p : Submodule R M} (hp : p ∈ f.invtSubmodule)
+    (hf : f.IsFinitelySemisimple) :
+    IsFinitelySemisimple (f.restrict hp) := by
+  intro q hq₁ hq₂
+  have := invtSubmodule.map_subtype_mem_of_mem_invtSubmodule f hp hq₁
+  let e : q ≃ₗ[R] q.map p.subtype := p.equivSubtypeMap q
+  rw [e.isSemisimple_iff ((LinearMap.restrict f hp).restrict hq₁) (LinearMap.restrict f this) rfl]
+  exact hf _ this (Finite.map q p.subtype)
 
 end CommRing
 
@@ -109,7 +207,7 @@ variable {K : Type*} [Field K] [Module K M] {f g : End K M}
 
 lemma IsSemisimple_smul_iff {t : K} (ht : t ≠ 0) :
     (t • f).IsSemisimple ↔ f.IsSemisimple := by
-  simp [isSemisimple_iff, Submodule.comap_smul f (h := ht)]
+  simp [isSemisimple_iff, mem_invtSubmodule, Submodule.comap_smul f (h := ht)]
 
 lemma IsSemisimple_smul (t : K) (h : f.IsSemisimple) :
     (t • f).IsSemisimple := by

--- a/Mathlib/LinearAlgebra/Semisimple.lean
+++ b/Mathlib/LinearAlgebra/Semisimple.lean
@@ -6,7 +6,6 @@ Authors: Oliver Nash
 import Mathlib.FieldTheory.Perfect
 import Mathlib.LinearAlgebra.Basis.VectorSpace
 import Mathlib.LinearAlgebra.AnnihilatingPolynomial
-import Mathlib.Order.CompleteSublattice
 import Mathlib.RingTheory.Artinian
 import Mathlib.RingTheory.QuotientNilpotent
 import Mathlib.RingTheory.SimpleModule

--- a/Mathlib/Order/Disjoint.lean
+++ b/Mathlib/Order/Disjoint.lean
@@ -586,6 +586,10 @@ class ComplementedLattice (α) [Lattice α] [BoundedOrder α] : Prop where
   /-- In a `ComplementedLattice`, every element admits a complement. -/
   exists_isCompl : ∀ a : α, ∃ b : α, IsCompl a b
 
+lemma complementedLattice_iff (α) [Lattice α] [BoundedOrder α] :
+    ComplementedLattice α ↔ ∀ a : α, ∃ b : α, IsCompl a b :=
+  ⟨fun ⟨h⟩ ↦ h, fun h ↦ ⟨h⟩⟩
+
 export ComplementedLattice (exists_isCompl)
 
 instance Subsingleton.instComplementedLattice

--- a/Mathlib/Order/Hom/Set.lean
+++ b/Mathlib/Order/Hom/Set.lean
@@ -7,6 +7,7 @@ import Mathlib.Order.Hom.Basic
 import Mathlib.Logic.Equiv.Set
 import Mathlib.Data.Set.Monotone
 import Mathlib.Data.Set.Image
+import Mathlib.Order.LatticeIntervals
 import Mathlib.Order.WellFounded
 
 /-!
@@ -14,7 +15,7 @@ import Mathlib.Order.WellFounded
 -/
 
 
-open OrderDual
+open OrderDual Set
 
 variable {α β : Type*}
 
@@ -158,6 +159,16 @@ instance subsingleton_of_wellFoundedGT' [LinearOrder β] [WellFoundedGT β] [Pre
   rw [Subsingleton.elim f.dual]
 
 instance unique_of_wellFoundedGT [LinearOrder α] [WellFoundedGT α] : Unique (α ≃o α) := Unique.mk' _
+
+/-- An order isomorphism between lattices induces an order isomorphism between corresponding
+interval sublattices. -/
+protected def Iic [Lattice α] [Lattice β] (e : α ≃o β) (x : α) :
+    Iic x ≃o Iic (e x) where
+  toFun y := ⟨e y, (map_le_map_iff _).mpr y.property⟩
+  invFun y := ⟨e.symm y, (OrderIso.symm_apply_le e).mpr y.property⟩
+  left_inv y := by simp
+  right_inv y := by simp
+  map_rel_iff' := by simp
 
 end OrderIso
 

--- a/Mathlib/Order/Hom/Set.lean
+++ b/Mathlib/Order/Hom/Set.lean
@@ -165,7 +165,27 @@ interval sublattices. -/
 protected def Iic [Lattice α] [Lattice β] (e : α ≃o β) (x : α) :
     Iic x ≃o Iic (e x) where
   toFun y := ⟨e y, (map_le_map_iff _).mpr y.property⟩
-  invFun y := ⟨e.symm y, (OrderIso.symm_apply_le e).mpr y.property⟩
+  invFun y := ⟨e.symm y, e.symm_apply_le.mpr y.property⟩
+  left_inv y := by simp
+  right_inv y := by simp
+  map_rel_iff' := by simp
+
+/-- An order isomorphism between lattices induces an order isomorphism between corresponding
+interval sublattices. -/
+protected def Ici [Lattice α] [Lattice β] (e : α ≃o β) (x : α) :
+    Ici x ≃o Ici (e x) where
+  toFun y := ⟨e y, (map_le_map_iff _).mpr y.property⟩
+  invFun y := ⟨e.symm y, e.le_symm_apply.mpr y.property⟩
+  left_inv y := by simp
+  right_inv y := by simp
+  map_rel_iff' := by simp
+
+/-- An order isomorphism between lattices induces an order isomorphism between corresponding
+interval sublattices. -/
+protected def Icc [Lattice α] [Lattice β] (e : α ≃o β) (x y : α) :
+    Icc x y ≃o Icc (e x) (e y) where
+  toFun z := ⟨e z, by simp only [mem_Icc, map_le_map_iff]; exact z.property⟩
+  invFun z := ⟨e.symm z, by simp only [mem_Icc, e.le_symm_apply, e.symm_apply_le]; exact z.property⟩
   left_inv y := by simp
   right_inv y := by simp
   map_rel_iff' := by simp

--- a/Mathlib/Order/Hom/Set.lean
+++ b/Mathlib/Order/Hom/Set.lean
@@ -7,8 +7,8 @@ import Mathlib.Order.Hom.Basic
 import Mathlib.Logic.Equiv.Set
 import Mathlib.Data.Set.Monotone
 import Mathlib.Data.Set.Image
-import Mathlib.Order.LatticeIntervals
 import Mathlib.Order.WellFounded
+import Mathlib.Order.Interval.Set.Basic
 
 /-!
 # Order homomorphisms and sets

--- a/Mathlib/Order/LatticeIntervals.lean
+++ b/Mathlib/Order/LatticeIntervals.lean
@@ -126,6 +126,16 @@ protected lemma isCompl_iff [Lattice α] [BoundedOrder α] {x y : Iic a} :
     IsCompl x y ↔ Disjoint (x : α) (y : α) ∧ (x : α) ⊔ (y : α) = a := by
   rw [_root_.isCompl_iff, Iic.disjoint_iff, Iic.codisjoint_iff]
 
+protected lemma complementedLattice_iff [Lattice α] [BoundedOrder α] :
+    ComplementedLattice (Iic a) ↔ ∀ b, b ≤ a → ∃ c ≤ a, b ⊓ c = ⊥ ∧ b ⊔ c = a := by
+  refine ⟨fun h b hb ↦ ?_, fun h ↦ ⟨fun ⟨x, hx⟩ ↦ ?_⟩⟩
+  · obtain ⟨⟨c, hc₁⟩, hc⟩ := exists_isCompl (⟨b, hb⟩ : Iic a)
+    obtain ⟨hc₂, hc₃⟩ := Set.Iic.isCompl_iff.mp hc
+    exact ⟨c, hc₁, disjoint_iff.mp hc₂, hc₃⟩
+  · simp_rw [Set.Iic.isCompl_iff]
+    obtain ⟨c, hc₁, hc₂, hc₃⟩ := h x hx
+    exact ⟨⟨c, hc₁⟩, disjoint_iff.mpr hc₂, hc₃⟩
+
 end Iic
 
 namespace Ici


### PR DESCRIPTION
The motivation is to be able to apply `IsFinitelySemisimple.maxGenEigenspace_eq_eigenspace` to symmetric maps in infinite dimensions. Such maps are not in general semisimple but are semisimple on each invariant finite-dimensional subspace.

---

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
