### PR TITLE
[Merged by Bors] - feeat(CategoryTheory/Monoidal/Functor): Constructor for strong monoidal functors from oplax monoidal functors

### DIFF
--- a/Mathlib/CategoryTheory/Monoidal/Functor.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Functor.lean
@@ -309,6 +309,27 @@ noncomputable def MonoidalFunctor.toOplaxMonoidalFunctor (F : MonoidalFunctor C 
         rw [← F.map_comp, Iso.hom_inv_id, F.map_id]
       simp }
 
+/-- Construct a (strong) monoidal functor out of an oplax monoidal functor whose tensorators and
+unitors are isomorphisms -/
+@[simps]
+noncomputable def MonoidalFunctor.fromOplaxMonoidalFunctor (F : OplaxMonoidalFunctor C D)
+    [IsIso F.η] [∀ (X Y : C), IsIso (F.δ X Y)] : MonoidalFunctor C D :=
+    { F with
+      ε := inv F.η
+      μ := fun X Y => inv (F.δ X Y)
+      associativity := by
+        intro X Y Z
+        rw [← inv_whiskerRight, IsIso.inv_comp_eq, IsIso.inv_comp_eq]
+        simp
+      left_unitality := by
+        intro X
+        rw [← inv_whiskerRight, ← IsIso.inv_comp_eq]
+        simp
+      right_unitality := by
+        intro X
+        rw [← inv_whiskerLeft, ← IsIso.inv_comp_eq]
+        simp }
+
 end
 
 open MonoidalCategory


### PR DESCRIPTION
Add a constructor `MonoidalFunctor.fromOplaxMonoidalFunctor` that converts an oplax monoidal functor to a monoidal functor, provided the tensorators ans unitors are isomorphims.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

This showed up while working on #17613: it feels more natural in there to define an oplax monoidal functor, and then promote it to a strong monoidal functor under the right product-preservations hypotheses, but this kind of constructor seemed to be missing.

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
