### PR TITLE
[Merged by Bors] - feat(CategoryTheory/ChosenFiniteProducts.lean): `simp` lemmas for left and right unitors in `ChosenFiniteProducts` monoidal structure

### DIFF
--- a/Mathlib/CategoryTheory/ChosenFiniteProducts.lean
+++ b/Mathlib/CategoryTheory/ChosenFiniteProducts.lean
@@ -178,14 +178,6 @@ lemma associator_inv_fst_snd (X Y Z : C) :
 lemma associator_inv_snd (X Y Z : C) :
     (α_ X Y Z).inv ≫ snd _ _ = snd _ _ ≫ snd _ _ := lift_snd _ _
 
-@[simp]
-lemma leftUnitor_hom (X : C) :
-    (λ_ X).hom = snd _ _ := rfl
-
-@[simp]
-lemma rightUnitor_hom (X : C) :
-    (ρ_ X).hom = fst _ _ := rfl
-
 @[reassoc (attr := simp)]
 lemma leftUnitor_inv_fst (X : C) :
     (λ_ X).inv ≫ fst _ _ = toUnit _ := toUnit_unique _ _

--- a/Mathlib/CategoryTheory/ChosenFiniteProducts.lean
+++ b/Mathlib/CategoryTheory/ChosenFiniteProducts.lean
@@ -180,27 +180,27 @@ lemma associator_inv_snd (X Y Z : C) :
 
 @[simp]
 lemma leftUnitor_hom (X : C) :
-  (λ_ X).hom = snd _ _ := rfl
+    (λ_ X).hom = snd _ _ := rfl
 
 @[simp]
 lemma rightUnitor_hom (X : C) :
-  (ρ_ X).hom = fst _ _ := rfl
+    (ρ_ X).hom = fst _ _ := rfl
 
 @[reassoc (attr := simp)]
 lemma leftUnitor_inv_fst (X : C) :
-  (λ_ X).inv ≫ fst _ _ = toUnit _ := toUnit_unique _ _
+    (λ_ X).inv ≫ fst _ _ = toUnit _ := toUnit_unique _ _
 
 @[reassoc (attr := simp)]
 lemma leftUnitor_inv_snd (X : C) :
-  (λ_ X).inv ≫ snd _ _ = 𝟙 X := lift_snd _ _
+    (λ_ X).inv ≫ snd _ _ = 𝟙 X := lift_snd _ _
 
 @[reassoc (attr := simp)]
 lemma rightUnitor_inv_fst (X : C) :
-  (ρ_ X).inv ≫ fst _ _ = 𝟙 X := lift_fst _ _
+    (ρ_ X).inv ≫ fst _ _ = 𝟙 X := lift_fst _ _
 
 @[reassoc (attr := simp)]
 lemma rightUnitor_inv_snd (X : C) :
-  (ρ_ X).inv ≫ snd _ _ = toUnit _ := toUnit_unique _ _
+    (ρ_ X).inv ≫ snd _ _ = toUnit _ := toUnit_unique _ _
 
 /--
 Construct an instance of `ChosenFiniteProducts C` given an instance of `HasFiniteProducts C`.

--- a/Mathlib/CategoryTheory/ChosenFiniteProducts.lean
+++ b/Mathlib/CategoryTheory/ChosenFiniteProducts.lean
@@ -178,6 +178,30 @@ lemma associator_inv_fst_snd (X Y Z : C) :
 lemma associator_inv_snd (X Y Z : C) :
     (α_ X Y Z).inv ≫ snd _ _ = snd _ _ ≫ snd _ _ := lift_snd _ _
 
+@[simp]
+lemma leftUnitor_hom (X : C) :
+  (λ_ X).hom = snd _ _ := rfl
+
+@[simp]
+lemma rightUnitor_hom (X : C) :
+  (ρ_ X).hom = fst _ _ := rfl
+
+@[reassoc (attr := simp)]
+lemma leftUnitor_inv_fst (X : C) :
+  (λ_ X).inv ≫ fst _ _ = toUnit _ := toUnit_unique _ _
+
+@[reassoc (attr := simp)]
+lemma leftUnitor_inv_snd (X : C) :
+  (λ_ X).inv ≫ snd _ _ = 𝟙 X := lift_snd _ _
+
+@[reassoc (attr := simp)]
+lemma rightUnitor_inv_fst (X : C) :
+  (ρ_ X).inv ≫ fst _ _ = 𝟙 X := lift_fst _ _
+
+@[reassoc (attr := simp)]
+lemma rightUnitor_inv_snd (X : C) :
+  (ρ_ X).inv ≫ snd _ _ = toUnit _ := toUnit_unique _ _
+
 /--
 Construct an instance of `ChosenFiniteProducts C` given an instance of `HasFiniteProducts C`.
 -/


### PR DESCRIPTION
Add 4 `simp` lemmas for left and right unitors in the monoidal structure obtained from instances of `ChosenFiniteProducts`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

I am a bit unsure about desirabilty/usefulness of `leftUnitor_hom` and `rightUnitor_hom`, but the 4 others seem useful nonetheless.

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
