### PR TITLE
[Merged by Bors] - chore(CauchyDavenport): use semantic lemma names

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -2018,6 +2018,7 @@ import Mathlib.CategoryTheory.WithTerminal
 import Mathlib.CategoryTheory.Yoneda
 import Mathlib.Combinatorics.Additive.AP.Three.Behrend
 import Mathlib.Combinatorics.Additive.AP.Three.Defs
+import Mathlib.Combinatorics.Additive.CauchyDavenport
 import Mathlib.Combinatorics.Additive.Corner.Defs
 import Mathlib.Combinatorics.Additive.Corner.Roth
 import Mathlib.Combinatorics.Additive.Dissociation
@@ -2058,7 +2059,6 @@ import Mathlib.Combinatorics.Quiver.Subquiver
 import Mathlib.Combinatorics.Quiver.Symmetric
 import Mathlib.Combinatorics.Schnirelmann
 import Mathlib.Combinatorics.SetFamily.AhlswedeZhang
-import Mathlib.Combinatorics.SetFamily.CauchyDavenport
 import Mathlib.Combinatorics.SetFamily.Compression.Down
 import Mathlib.Combinatorics.SetFamily.Compression.UV
 import Mathlib.Combinatorics.SetFamily.FourFunctions

--- a/Mathlib/Combinatorics/Additive/CauchyDavenport.lean
+++ b/Mathlib/Combinatorics/Additive/CauchyDavenport.lean
@@ -178,7 +178,7 @@ lemma cauchy_davenport_minOrder_mul (hs : s.Nonempty) (ht : t.Nonempty) :
 
 /-- The **Cauchy-Davenport Theorem** for torsion-free groups. The size of `s * t` is lower-bounded
 by `|s| + |t| - 1`. -/
-@[to_additive cauchy_davenport_add_of_isTorsionFree
+@[to_additive
 "The **Cauchy-Davenport theorem** for torsion-free groups. The size of `s + t` is lower-bounded
 by `|s| + |t| - 1`."]
 lemma cauchy_davenport_mul_of_isTorsionFree (h : IsTorsionFree α)

--- a/Mathlib/Combinatorics/Additive/CauchyDavenport.lean
+++ b/Mathlib/Combinatorics/Additive/CauchyDavenport.lean
@@ -178,7 +178,7 @@ lemma cauchy_davenport_minOrder_mul (hs : s.Nonempty) (ht : t.Nonempty) :
 
 /-- The **Cauchy-Davenport Theorem** for torsion-free groups. The size of `s * t` is lower-bounded
 by `|s| + |t| - 1`. -/
-@[to_additive AddMonoid.IsTorsionFree.card_add_card_sub_one_le_card_add
+@[to_additive cauchy_davenport_add_of_isTorsionFree
 "The **Cauchy-Davenport theorem** for torsion-free groups. The size of `s + t` is lower-bounded
 by `|s| + |t| - 1`."]
 lemma cauchy_davenport_mul_of_isTorsionFree (h : IsTorsionFree α)

--- a/Mathlib/Combinatorics/Additive/CauchyDavenport.lean
+++ b/Mathlib/Combinatorics/Additive/CauchyDavenport.lean
@@ -29,11 +29,11 @@ There are two kinds of proof of Cauchy-Davenport:
 
 ## Main declarations
 
-* `Finset.min_le_card_mul`: A generalisation of the Cauchy-Davenport theorem to arbitrary groups.
-* `Monoid.IsTorsionFree.card_add_card_sub_one_le_card_mul`: The Cauchy-Davenport theorem in
-  torsion-free groups.
-* `ZMod.min_le_card_add`: The Cauchy-Davenport theorem.
-* `Finset.card_add_card_sub_one_le_card_mul`: The Cauchy-Davenport theorem in linear ordered
+* `cauchy_davenport_minOrder_mul`: A generalisation of the Cauchy-Davenport theorem to arbitrary
+  groups.
+* `cauchy_davenport_of_isTorsionFree`: The Cauchy-Davenport theorem in torsion-free groups.
+* `ZMod.cauchy_davenport`: The Cauchy-Davenport theorem for `ZMod p`.
+* `cauchy_davenport_mul_of_linearOrder_isCancelMul`: The Cauchy-Davenport theorem in linear ordered
   cancellative semigroups.
 
 ## TODO
@@ -109,7 +109,7 @@ subgroup. -/
 @[to_additive "A generalisation of the **Cauchy-Davenport theorem** to arbitrary groups. The size of
 `s + t` is lower-bounded by `|s| + |t| - 1` unless this quantity is greater than the size of the
 smallest subgroup."]
-lemma Finset.min_le_card_mul (hs : s.Nonempty) (ht : t.Nonempty) :
+lemma cauchy_davenport_minOrder_mul (hs : s.Nonempty) (ht : t.Nonempty) :
     min (minOrder α) ↑(#s + #t - 1) ≤ #(s * t) := by
   -- Set up the induction on `x := (s, t)` along the `DevosMulRel` relation.
   set x := (s, t) with hx
@@ -178,11 +178,13 @@ lemma Finset.min_le_card_mul (hs : s.Nonempty) (ht : t.Nonempty) :
 
 /-- The **Cauchy-Davenport Theorem** for torsion-free groups. The size of `s * t` is lower-bounded
 by `|s| + |t| - 1`. -/
-@[to_additive "The **Cauchy-Davenport theorem** for torsion-free groups. The size of `s + t` is
-lower-bounded by `|s| + |t| - 1`."]
-lemma Monoid.IsTorsionFree.card_add_card_sub_one_le_card_mul (h : IsTorsionFree α)
+@[to_additive AddMonoid.IsTorsionFree.card_add_card_sub_one_le_card_add
+"The **Cauchy-Davenport theorem** for torsion-free groups. The size of `s + t` is lower-bounded
+by `|s| + |t| - 1`."]
+lemma cauchy_davenport_mul_of_isTorsionFree (h : IsTorsionFree α)
     (hs : s.Nonempty) (ht : t.Nonempty) : #s + #t - 1 ≤ #(s * t) := by
-  simpa only [h.minOrder, min_eq_right, le_top, Nat.cast_le] using Finset.min_le_card_mul hs ht
+  simpa only [h.minOrder, min_eq_right, le_top, Nat.cast_le]
+    using cauchy_davenport_minOrder_mul hs ht
 
 end General
 
@@ -190,9 +192,10 @@ end General
 
 /-- The **Cauchy-Davenport Theorem**. If `s`, `t` are nonempty sets in $$ℤ/pℤ$$, then the size of
 `s + t` is lower-bounded by `|s| + |t| - 1`, unless this quantity is greater than `p`. -/
-lemma ZMod.min_le_card_add {p : ℕ} (hp : p.Prime) {s t : Finset (ZMod p)} (hs : s.Nonempty)
+lemma ZMod.cauchy_davenport {p : ℕ} (hp : p.Prime) {s t : Finset (ZMod p)} (hs : s.Nonempty)
     (ht : t.Nonempty) : min p (#s + #t - 1) ≤ #(s + t) := by
-  simpa only [ZMod.minOrder_of_prime hp, min_le_iff, Nat.cast_le] using Finset.min_le_card_add hs ht
+  simpa only [ZMod.minOrder_of_prime hp, min_le_iff, Nat.cast_le]
+    using cauchy_davenport_minOrder_add hs ht
 
 /-! ### Linearly ordered cancellative semigroups -/
 
@@ -201,7 +204,7 @@ lemma ZMod.min_le_card_add {p : ℕ} (hp : p.Prime) {s t : Finset (ZMod p)} (hs 
 @[to_additive
 "The **Cauchy-Davenport theorem** for linearly ordered additive cancellative semigroups. The size of
 `s + t` is lower-bounded by `|s| + |t| - 1`."]
-lemma Finset.card_add_card_sub_one_le_card_mul [LinearOrder α] [Semigroup α] [IsCancelMul α]
+lemma cauchy_davenport_mul_of_linearOrder_isCancelMul [LinearOrder α] [Semigroup α] [IsCancelMul α]
     [MulLeftMono α] [MulRightMono α]
     {s t : Finset α} (hs : s.Nonempty) (ht : t.Nonempty) : #s + #t - 1 ≤ #(s * t) := by
   suffices s * {t.min' ht} ∩ ({s.max' hs} * t) = {s.max' hs * t.min' ht} by


### PR DESCRIPTION
The symbol-reading names were super long and mis-additivised.

Also move the file to `Combinatorics.Additive`. It has nothing to do in `Combinatorics.SetFamily`


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
