### PR TITLE
[Merged by Bors] - feat(CategoryTheory/ChosenFiniteProducts): `prodComparison` and `terminalComparison` for `ChosenFiniteProducts`

### DIFF
--- a/Mathlib/CategoryTheory/ChosenFiniteProducts.lean
+++ b/Mathlib/CategoryTheory/ChosenFiniteProducts.lean
@@ -273,7 +273,7 @@ variable (A B : C)
 
 /-- When `C` and `D` have chosen finite products and `F : C ⥤ D` is any functor,
 `prodComparison F A B` is the canonical comparison morphism from `F (A ⊗ B)` to `F(A) ⊗ F(B)`. -/
-def prodComparison (A B : C) : F.obj (A ⊗ B) ⟶ (F.obj A) ⊗ (F.obj B) :=
+def prodComparison (A B : C) : F.obj (A ⊗ B) ⟶ F.obj A ⊗ F.obj B :=
   lift (F.map (fst A B)) (F.map (snd A B))
 
 @[reassoc (attr := simp)]

--- a/Mathlib/CategoryTheory/ChosenFiniteProducts.lean
+++ b/Mathlib/CategoryTheory/ChosenFiniteProducts.lean
@@ -396,10 +396,6 @@ theorem prodComparisonBifunctorNatTrans_comp {E : Type u₂} [Category.{v₂} E]
         whiskerLeft F (whiskerRight (prodComparisonBifunctorNatTrans G)
           ((whiskeringLeft _ _ _).obj F)) := by ext; simp [prodComparison_comp]
 
-@[simp]
-lemma prodComparisonBifunctorNatTrans_id :
-    prodComparisonNatTrans (𝟭 C) A = 𝟙 _ := by ext; simp
-
 instance (A : C) [∀ B, IsIso (prodComparison F A B)] : IsIso (prodComparisonNatTrans F A) := by
   letI : ∀ X, IsIso ((prodComparisonNatTrans F A).app X) := by assumption
   apply NatIso.isIso_of_isIso_app

--- a/Mathlib/CategoryTheory/ChosenFiniteProducts.lean
+++ b/Mathlib/CategoryTheory/ChosenFiniteProducts.lean
@@ -238,7 +238,7 @@ section terminalComparison
 `terminalComparison F` is the unique map `F (𝟙_ C) ⟶ 𝟙_ D`. -/
 abbrev terminalComparison : F.obj (𝟙_ C) ⟶ 𝟙_ D := toUnit _
 
-@[simp]
+@[reassoc (attr := simp)]
 lemma map_toUnit_comp_terminalCompariso (A : C) :
     F.map (toUnit A) ≫ terminalComparison F = toUnit _ := toUnit_unique _ _
 
@@ -252,12 +252,12 @@ noncomputable def preservesLimitEmptyOfIsIsoTerminalComparison [IsIso (terminalC
   exact asIso (terminalComparison F)|>.symm
 
 /-- If `F` preserves terminal objects, then `terminalComparison F` is an isomorphism. -/
-def PreservesTerminalIso [h : PreservesLimit (Functor.empty.{0} C) F] : F.obj (𝟙_ C) ≅ 𝟙_ D :=
+def preservesTerminalIso [h : PreservesLimit (Functor.empty.{0} C) F] : F.obj (𝟙_ C) ≅ 𝟙_ D :=
   (isLimitChangeEmptyCone D (h.preserves terminal.isLimit) (asEmptyCone (F.obj (𝟙_ C)))
     (Iso.refl _)).conePointUniqueUpToIso terminal.isLimit
 
 @[simp]
-lemma PreservesTerminalIso_hom [PreservesLimit (Functor.empty.{0} C) F] :
+lemma preservesTerminalIso_hom [PreservesLimit (Functor.empty.{0} C) F] :
     (PreservesTerminalIso F).hom = terminalComparison F := toUnit_unique _ _
 
 instance terminalComparison_isIso_of_preservesLimits [PreservesLimit (Functor.empty.{0} C) F] :

--- a/Mathlib/CategoryTheory/ChosenFiniteProducts.lean
+++ b/Mathlib/CategoryTheory/ChosenFiniteProducts.lean
@@ -429,7 +429,7 @@ def prodComparisonIso : F.obj (A ⊗ B) ≅ F.obj A ⊗ F.obj B :=
 lemma prodComparisonIso_hom : (prodComparisonIso F A B).hom = prodComparison F A B := by
   rfl
 
-instance isIso_prodComparison_of_preservesLimit_pair: IsIso (prodComparison F A B) := by
+instance isIso_prodComparison_of_preservesLimit_pair : IsIso (prodComparison F A B) := by
   rw [← prodComparisonIso_hom]
   infer_instance
 
@@ -445,7 +445,7 @@ noncomputable def prodComparisonNatIso (A : C) [∀ B, PreservesLimit (pair A B)
 /-- The natural isomorphism of bifunctors `F(- ⊗ -) ≅ F- ⊗ F-`, provided each
 `prodComparison F A B` is an isomorphism. -/
 @[simps! hom inv]
-noncomputable def prodComparisonBifunctorsNatIso [∀ A B, PreservesLimit (pair A B) F] :
+noncomputable def prodComparisonBifunctorNatIso [∀ A B, PreservesLimit (pair A B) F] :
     curriedTensor C ⋙ (whiskeringRight _ _ _).obj F ≅
       F ⋙ curriedTensor D ⋙ (whiskeringLeft _ _ _).obj F :=
   asIso (prodComparisonBifunctorNatTrans F)
@@ -457,28 +457,17 @@ section ProdComparisonIso
 /-- If `prodComparison F A B` is an isomorphism, then `F` preserves the limit of `pair A B`. -/
 noncomputable def preservesLimitPairOfIsIsoProdComparison (A B : C) [IsIso (prodComparison F A B)] :
     PreservesLimit (pair A B) F := by
-  apply preservesLimitOfPreservesLimitCone (product A B).isLimit
-  apply IsLimit.equivOfNatIsoOfIso (pairComp A B F) _
-    ((product (F.obj A) (F.obj B)).cone.extend (prodComparison F A B)) _|>.invFun
-  rotate_left
-  · apply Cones.ext
-    case φ => exact Iso.refl _
-    rintro ⟨⟨j⟩⟩
-    · simp only [Cones.postcompose_obj_pt, Functor.mapCone_pt, Functor.const_obj_obj,
-      pair_obj_left, Cones.postcompose_obj_π, NatTrans.comp_app, Functor.comp_obj,
-      Functor.mapCone_π_app, BinaryFan.π_app_left, Cone.extend_pt, Iso.refl_hom, Cone.extend_π,
-      yoneda_obj_obj, Cone.extensions_app, Functor.op_obj, Functor.const_map_app, Category.id_comp]
-      rw [← fst, ← fst, pairComp]
-      simp
-    · simp only [Cones.postcompose_obj_pt, Functor.mapCone_pt, Functor.const_obj_obj,
-      pair_obj_right, Cones.postcompose_obj_π, NatTrans.comp_app, Functor.comp_obj,
-      Functor.mapCone_π_app, BinaryFan.π_app_right, Cone.extend_pt, Iso.refl_hom, Cone.extend_π,
-      yoneda_obj_obj, Cone.extensions_app, Functor.op_obj, Functor.const_map_app, Category.id_comp]
-      rw [← snd, ← snd, pairComp]
-      simp
-  · exact IsLimit.extendIso _ (product (F.obj A) (F.obj B)).isLimit
+ apply preservesLimitOfPreservesLimitCone (product A B).isLimit
+ refine IsLimit.equivOfNatIsoOfIso (pairComp A B F) _
+    ((product (F.obj A) (F.obj B)).cone.extend (prodComparison F A B))
+      (BinaryFan.ext (by exact Iso.refl _) ?_ ?_) |>.invFun
+      (IsLimit.extendIso _ (product (F.obj A) (F.obj B)).isLimit)
+ · dsimp only [BinaryFan.fst]
+   simp [pairComp, prodComparison, lift, fst]
+ · dsimp only [BinaryFan.snd]
+   simp [pairComp, prodComparison, lift, snd]
 
-/-- If `prodComparison F A B` is an isomorphism for all `A B` then `F` preserves limits of shape
+  /-- If `prodComparison F A B` is an isomorphism for all `A B` then `F` preserves limits of shape
 `Discrete (WalkingPair)`. -/
 noncomputable def preservesLimitsOfShapeDiscreteWalkingPairOfIsoProdComparison
     [∀ A B, IsIso (prodComparison F A B)] : PreservesLimitsOfShape (Discrete WalkingPair) F := by

--- a/Mathlib/CategoryTheory/ChosenFiniteProducts.lean
+++ b/Mathlib/CategoryTheory/ChosenFiniteProducts.lean
@@ -258,11 +258,11 @@ def preservesTerminalIso [h : PreservesLimit (Functor.empty.{0} C) F] : F.obj (�
 
 @[simp]
 lemma preservesTerminalIso_hom [PreservesLimit (Functor.empty.{0} C) F] :
-    (PreservesTerminalIso F).hom = terminalComparison F := toUnit_unique _ _
+    (preservesTerminalIso F).hom = terminalComparison F := toUnit_unique _ _
 
 instance terminalComparison_isIso_of_preservesLimits [PreservesLimit (Functor.empty.{0} C) F] :
     IsIso (terminalComparison F) := by
-  rw [← PreservesTerminalIso_hom]
+  rw [← preservesTerminalIso_hom]
   infer_instance
 
 end terminalComparison
@@ -284,11 +284,11 @@ theorem prodComparison_fst : prodComparison F A B ≫ fst _ _ = F.map (fst A B) 
 theorem prodComparison_snd : prodComparison F A B ≫ snd _ _ = F.map (snd A B) :=
   lift_snd _ _
 
-@[reassoc]
+@[reassoc (attr := simp)]
 theorem inv_prodComparison_map_fst [IsIso (prodComparison F A B)] :
     inv (prodComparison F A B) ≫ F.map (fst _ _) = fst _ _ := by simp [IsIso.inv_comp_eq]
 
-@[reassoc]
+@[reassoc (attr := simp)]
 theorem inv_prodComparison_map_snd [IsIso (prodComparison F A B)] :
     inv (prodComparison F A B) ≫ F.map (snd _ _) = snd _ _ := by simp [IsIso.inv_comp_eq]
 
@@ -373,24 +373,40 @@ def prodComparisonBifunctorNatTrans :
       prodComparison_fst, whiskeringLeft_obj_map, whiskerLeft_app, whiskerRight_fst,
       prodComparison_fst_assoc, prodComparison_snd, whiskerRight_snd, ← F.map_comp]
 
+
+instance (A : C) [∀ B, IsIso (prodComparison F A B)] : IsIso (prodComparisonNatTrans F A) := by
+  letI : ∀ X, IsIso ((prodComparisonNatTrans F A).app X) := by assumption
+  apply NatIso.isIso_of_isIso_app
+
+instance [h : ∀ A B, IsIso (prodComparison F A B)] : IsIso (prodComparisonBifunctorNatTrans F) := by
+  letI : ∀ X, IsIso ((prodComparisonBifunctorNatTrans F).app X) :=
+    fun _ ↦ (by dsimp; apply NatIso.isIso_of_isIso_app)
+  apply NatIso.isIso_of_isIso_app
+
 /-- The natural isomorphism `F(A ⊗ -) ≅ FA ⊗ F-`, provided each `prodComparison F A B` is an
 isomorphism (as `B` changes). -/
-@[simps]
+@[simps!]
 noncomputable def prodComparisonNatIso (A : C)
     [∀ B, IsIso (prodComparison F A B)] :
-    (curriedTensor C).obj A ⋙ F ≅ F ⋙ (curriedTensor D).obj (F.obj A) := by
-  refine { @asIso _ _ _ _ _ (?_) with hom := prodComparisonNatTrans F A }
-  apply NatIso.isIso_of_isIso_app
+    (curriedTensor C).obj A ⋙ F ≅ F ⋙ (curriedTensor D).obj (F.obj A) :=
+  asIso (prodComparisonNatTrans F A)
+
+@[simp]
+lemma prodComparisonNatIso_hom (A : C) [∀ B, IsIso (prodComparison F A B)] :
+    (prodComparisonNatIso F A).hom = prodComparisonNatTrans F A := rfl
 
 /-- The natural isomorphism of bifunctors `F(- ⊗ -) ≅ F- ⊗ F-`, provided each
 `prodComparison F A B` is an isomorphism. -/
-@[simps]
+@[simps!]
 noncomputable def prodComparisonBifunctorsNatIso
     [∀ A B, IsIso (prodComparison F A B)] :
     curriedTensor C ⋙ (whiskeringRight _ _ _).obj F ≅
-      F ⋙ curriedTensor D ⋙ (whiskeringLeft _ _ _).obj F := by
-  refine { @asIso _ _ _ _ _ ?_ with hom := prodComparisonBifunctorNatTrans F }
-  exact @NatIso.isIso_of_isIso_app _ _ _ _ _ _ _ (fun A ↦ Iso.isIso_hom (prodComparisonNatIso F A))
+      F ⋙ curriedTensor D ⋙ (whiskeringLeft _ _ _).obj F :=
+  asIso (prodComparisonBifunctorNatTrans F)
+
+@[simp]
+lemma prodComparisonBifunctorsNatIso_hom [∀ A B, IsIso (prodComparison F A B)] :
+    (prodComparisonBifunctorsNatIso F).hom = prodComparisonBifunctorNatTrans F := rfl
 
 theorem prodComparison_comp {E : Type u₂} [Category.{v₂} E] [ChosenFiniteProducts E] (G : D ⥤ E) :
     prodComparison (F ⋙ G) A B =

--- a/Mathlib/CategoryTheory/ChosenFiniteProducts.lean
+++ b/Mathlib/CategoryTheory/ChosenFiniteProducts.lean
@@ -303,13 +303,47 @@ theorem prodComparison_natural (f : A ⟶ A') (g : B ⟶ B') :
   simp only [Category.assoc, prodComparison_fst, tensorHom_fst, prodComparison_fst_assoc,
     prodComparison_snd, tensorHom_snd, prodComparison_snd_assoc, ← F.map_comp]
 
-/-- If the product comparison morphism is an iso, its inverse is natural. -/
+/-- Naturality of the `prodComparison` morphism in the right argument. -/
 @[reassoc]
-theorem prodComparison_inv_natural (f : A ⟶ A') (g : B ⟶ B') [IsIso (prodComparison F A B)]
-    [IsIso (prodComparison F A' B')] :
+theorem prodComparison_natural_whiskerLeft (g : B ⟶ B') :
+    F.map (A ◁ g) ≫ prodComparison F A B' =
+      prodComparison F A B ≫ (F.obj A ◁ F.map g) := by
+  rw [← id_tensorHom, prodComparison_natural, Functor.map_id]
+  rfl
+
+/-- Naturality of the `prodComparison` morphism in the left argument. -/
+@[reassoc]
+theorem prodComparison_natural_whiskerRight (f : A ⟶ A') :
+    F.map (f ▷ B) ≫ prodComparison F A' B =
+      prodComparison F A B ≫ (F.map f ▷ F.obj B) := by
+  rw [← tensorHom_id, prodComparison_natural, Functor.map_id]
+  rfl
+
+section
+variable [IsIso (prodComparison F A B)]
+
+/-- If the product comparison morphism is an iso, its inverse is natural in both argument. -/
+@[reassoc]
+theorem prodComparison_inv_natural (f : A ⟶ A') (g : B ⟶ B') [IsIso (prodComparison F A' B')] :
     inv (prodComparison F A B) ≫ F.map (f ⊗ g) =
       (F.map f ⊗ F.map g) ≫ inv (prodComparison F A' B') := by
   rw [IsIso.eq_comp_inv, Category.assoc, IsIso.inv_comp_eq, prodComparison_natural]
+
+/-- If the product comparison morphism is an iso, its inverse is natural in the right argument. -/
+@[reassoc]
+theorem prodComparison_inv_natural_whiskerLeft (g : B ⟶ B') [IsIso (prodComparison F A B')] :
+    inv (prodComparison F A B) ≫ F.map (A ◁ g) =
+      (F.obj A ◁ F.map g) ≫ inv (prodComparison F A B') := by
+  rw [IsIso.eq_comp_inv, Category.assoc, IsIso.inv_comp_eq, prodComparison_natural_whiskerLeft]
+
+/-- If the product comparison morphism is an iso, its inverse is natural in the left argument. -/
+@[reassoc]
+theorem prodComparison_inv_natural_whiskerRight (f : A ⟶ A') [IsIso (prodComparison F A' B)] :
+    inv (prodComparison F A B) ≫ F.map (f ▷ B) =
+      (F.map f ▷ F.obj B) ≫ inv (prodComparison F A' B) := by
+  rw [IsIso.eq_comp_inv, Category.assoc, IsIso.inv_comp_eq, prodComparison_natural_whiskerRight]
+
+end
 
 /-- The product comparison morphism from `F(A ⊗ -)` to `FA ⊗ F-`, whose components are given by
 `prodComparison`. -/

--- a/Mathlib/CategoryTheory/ChosenFiniteProducts.lean
+++ b/Mathlib/CategoryTheory/ChosenFiniteProducts.lean
@@ -345,6 +345,16 @@ theorem prodComparison_inv_natural_whiskerRight (f : A ⟶ A') [IsIso (prodCompa
 
 end
 
+theorem prodComparison_comp {E : Type u₂} [Category.{v₂} E] [ChosenFiniteProducts E] (G : D ⥤ E) :
+    prodComparison (F ⋙ G) A B =
+      G.map (prodComparison F A B) ≫ prodComparison G (F.obj A) (F.obj B) := by
+  unfold prodComparison
+  ext <;> simp [← G.map_comp]
+
+@[simp]
+lemma prodComparison_id :
+    prodComparison (𝟭 C) A B = 𝟙 (A ⊗ B) := lift_fst_snd
+
 /-- The product comparison morphism from `F(A ⊗ -)` to `FA ⊗ F-`, whose components are given by
 `prodComparison`. -/
 @[simps]
@@ -357,6 +367,15 @@ def prodComparisonNatTrans (A : C) :
       Functor.comp_map, curriedTensor_obj_map, Category.assoc, prodComparison_fst, whiskerLeft_fst,
       prodComparison_snd, prodComparison_snd_assoc, whiskerLeft_snd, ← F.map_comp]
 
+theorem prodComparisonNatTrans_comp {E : Type u₂} [Category.{v₂} E] [ChosenFiniteProducts E]
+    (G : D ⥤ E) : prodComparisonNatTrans (F ⋙ G) A =
+      whiskerRight (prodComparisonNatTrans F A) G ≫
+        whiskerLeft F (prodComparisonNatTrans G (F.obj A)) := by ext; simp [prodComparison_comp]
+
+@[simp]
+lemma prodComparisonNatTrans_id :
+    prodComparisonNatTrans (𝟭 C) A = 𝟙 _ := by ext; simp
+
 /-- The product comparison morphism from `F(- ⊗ -)` to `F- ⊗ F-`, whose components are given by
 `prodComparison`. -/
 @[simps]
@@ -366,58 +385,34 @@ def prodComparisonBifunctorNatTrans :
   app A := prodComparisonNatTrans F A
   naturality x y f := by
     ext z
-    apply hom_ext <;>
-    simp only [Functor.comp_obj, whiskeringRight_obj_obj, curriedTensor_obj_obj,
-      whiskeringLeft_obj_obj, Functor.comp_map, whiskeringRight_obj_map, NatTrans.comp_app,
-      whiskerRight_app, curriedTensor_map_app, prodComparisonNatTrans_app, Category.assoc,
-      prodComparison_fst, whiskeringLeft_obj_map, whiskerLeft_app, whiskerRight_fst,
-      prodComparison_fst_assoc, prodComparison_snd, whiskerRight_snd, ← F.map_comp]
+    apply hom_ext <;> simp [← Functor.map_comp]
 
+variable {E : Type u₂} [Category.{v₂} E]
+    [ChosenFiniteProducts E] (G : D ⥤ E)
+
+theorem prodComparisonBifunctorNatTrans_comp {E : Type u₂} [Category.{v₂} E]
+    [ChosenFiniteProducts E] (G : D ⥤ E) : prodComparisonBifunctorNatTrans (F ⋙ G) =
+      whiskerRight (prodComparisonBifunctorNatTrans F) ((whiskeringRight _ _ _).obj G) ≫
+        whiskerLeft F (whiskerRight (prodComparisonBifunctorNatTrans G)
+          ((whiskeringLeft _ _ _).obj F)) := by ext; simp [prodComparison_comp]
+
+@[simp]
+lemma prodComparisonBifunctorNatTrans_id :
+    prodComparisonNatTrans (𝟭 C) A = 𝟙 _ := by ext; simp
 
 instance (A : C) [∀ B, IsIso (prodComparison F A B)] : IsIso (prodComparisonNatTrans F A) := by
   letI : ∀ X, IsIso ((prodComparisonNatTrans F A).app X) := by assumption
   apply NatIso.isIso_of_isIso_app
 
-instance [h : ∀ A B, IsIso (prodComparison F A B)] : IsIso (prodComparisonBifunctorNatTrans F) := by
+instance [∀ A B, IsIso (prodComparison F A B)] : IsIso (prodComparisonBifunctorNatTrans F) := by
   letI : ∀ X, IsIso ((prodComparisonBifunctorNatTrans F).app X) :=
-    fun _ ↦ (by dsimp; apply NatIso.isIso_of_isIso_app)
+    fun _ ↦ by dsimp; apply NatIso.isIso_of_isIso_app
   apply NatIso.isIso_of_isIso_app
 
-/-- The natural isomorphism `F(A ⊗ -) ≅ FA ⊗ F-`, provided each `prodComparison F A B` is an
-isomorphism (as `B` changes). -/
-@[simps!]
-noncomputable def prodComparisonNatIso (A : C)
-    [∀ B, IsIso (prodComparison F A B)] :
-    (curriedTensor C).obj A ⋙ F ≅ F ⋙ (curriedTensor D).obj (F.obj A) :=
-  asIso (prodComparisonNatTrans F A)
-
-@[simp]
-lemma prodComparisonNatIso_hom (A : C) [∀ B, IsIso (prodComparison F A B)] :
-    (prodComparisonNatIso F A).hom = prodComparisonNatTrans F A := rfl
-
-/-- The natural isomorphism of bifunctors `F(- ⊗ -) ≅ F- ⊗ F-`, provided each
-`prodComparison F A B` is an isomorphism. -/
-@[simps!]
-noncomputable def prodComparisonBifunctorsNatIso
-    [∀ A B, IsIso (prodComparison F A B)] :
-    curriedTensor C ⋙ (whiskeringRight _ _ _).obj F ≅
-      F ⋙ curriedTensor D ⋙ (whiskeringLeft _ _ _).obj F :=
-  asIso (prodComparisonBifunctorNatTrans F)
-
-@[simp]
-lemma prodComparisonBifunctorsNatIso_hom [∀ A B, IsIso (prodComparison F A B)] :
-    (prodComparisonBifunctorsNatIso F).hom = prodComparisonBifunctorNatTrans F := rfl
-
-theorem prodComparison_comp {E : Type u₂} [Category.{v₂} E] [ChosenFiniteProducts E] (G : D ⥤ E) :
-    prodComparison (F ⋙ G) A B =
-      G.map (prodComparison F A B) ≫ prodComparison G (F.obj A) (F.obj B) := by
-  unfold prodComparison
-  ext <;> simp <;> rw [← G.map_comp] <;> simp
-
 open Limits
-
 section PreservesLimitPairs
 
+section
 variable (A B)
 variable [PreservesLimit (pair A B) F]
 
@@ -441,6 +436,23 @@ lemma prodComparisonIso_hom : (prodComparisonIso F A B).hom = prodComparison F A
 instance isIso_prodComparison_of_preservesLimit_pair: IsIso (prodComparison F A B) := by
   rw [← prodComparisonIso_hom]
   infer_instance
+
+end
+
+/-- The natural isomorphism `F(A ⊗ -) ≅ FA ⊗ F-`, provided each `prodComparison F A B` is an
+isomorphism (as `B` changes). -/
+@[simps! hom inv]
+noncomputable def prodComparisonNatIso (A : C) [∀ B, PreservesLimit (pair A B) F] :
+    (curriedTensor C).obj A ⋙ F ≅ F ⋙ (curriedTensor D).obj (F.obj A) :=
+  asIso (prodComparisonNatTrans F A)
+
+/-- The natural isomorphism of bifunctors `F(- ⊗ -) ≅ F- ⊗ F-`, provided each
+`prodComparison F A B` is an isomorphism. -/
+@[simps! hom inv]
+noncomputable def prodComparisonBifunctorsNatIso [∀ A B, PreservesLimit (pair A B) F] :
+    curriedTensor C ⋙ (whiskeringRight _ _ _).obj F ≅
+      F ⋙ curriedTensor D ⋙ (whiskeringLeft _ _ _).obj F :=
+  asIso (prodComparisonBifunctorNatTrans F)
 
 end PreservesLimitPairs
 

--- a/Mathlib/CategoryTheory/Limits/Shapes/BinaryProducts.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/BinaryProducts.lean
@@ -196,6 +196,12 @@ theorem BinaryFan.π_app_left {X Y : C} (s : BinaryFan X Y) : s.π.app ⟨Walkin
 theorem BinaryFan.π_app_right {X Y : C} (s : BinaryFan X Y) : s.π.app ⟨WalkingPair.right⟩ = s.snd :=
   rfl
 
+/-- Constructs an isomorphism of `BinaryFan`s out of an isomorphism of the tips that commutes with
+the projections. -/
+def BinaryFan.ext {A B : C} {c c' : BinaryFan A B} (e : c.pt ≅ c'.pt)
+    (h₁ : c.fst = e.hom ≫ c'.fst) (h₂ : c.snd = e.hom ≫ c'.snd) : c ≅ c' :=
+  Cones.ext e (fun j => by rcases j with ⟨⟨⟩⟩ <;> assumption)
+
 /-- A convenient way to show that a binary fan is a limit. -/
 def BinaryFan.IsLimit.mk {X Y : C} (s : BinaryFan X Y)
     (lift : ∀ {T : C} (_ : T ⟶ X) (_ : T ⟶ Y), T ⟶ s.pt)
@@ -224,6 +230,12 @@ abbrev BinaryCofan.inl {X Y : C} (s : BinaryCofan X Y) := s.ι.app ⟨WalkingPai
 
 /-- The second inclusion of a binary cofan. -/
 abbrev BinaryCofan.inr {X Y : C} (s : BinaryCofan X Y) := s.ι.app ⟨WalkingPair.right⟩
+
+/-- Constructs an isomorphism of `BinaryCofan`s out of an isomorphism of the tips that commutes with
+the injections. -/
+def BinaryCofan.ext {A B : C} {c c' : BinaryCofan A B} (e : c.pt ≅ c'.pt)
+    (h₁ : c.inl ≫ e.hom = c'.inl) (h₂ : c.inr ≫ e.hom = c'.inr) : c ≅ c' :=
+  Cocones.ext e (fun j => by rcases j with ⟨⟨⟩⟩ <;> assumption)
 
 @[simp]
 theorem BinaryCofan.ι_app_left {X Y : C} (s : BinaryCofan X Y) :

--- a/Mathlib/CategoryTheory/Limits/Shapes/Products.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/Products.lean
@@ -245,6 +245,12 @@ theorem Pi.lift_π {β : Type w} {f : β → C} [HasProduct f] {P : C} (p : ∀ 
     Pi.lift p ≫ Pi.π f b = p b := by
   simp only [limit.lift_π, Fan.mk_pt, Fan.mk_π_app]
 
+/-- A version of `Cones.ext` for `Fan`s. -/
+@[simps!]
+def Fan.ext {f : β → C} {c₁ c₂ : Fan f} (e : c₁.pt ≅ c₂.pt)
+    (w : ∀ (b : β), c₁.proj b = e.hom ≫ c₂.proj b := by aesop_cat) : c₁ ≅ c₂ :=
+  Cones.ext e (fun ⟨j⟩ => w j)
+
 /-- A collection of morphisms `f b ⟶ P` induces a morphism `∐ f ⟶ P`. -/
 abbrev Sigma.desc {f : β → C} [HasCoproduct f] {P : C} (p : ∀ b, f b ⟶ P) : ∐ f ⟶ P :=
   colimit.desc _ (Cofan.mk P p)


### PR DESCRIPTION
Given a functor `F : C ⥤ D` between categories with chosen finite products and `A B : C`, introduce `terminalComparison F : F (𝟙_ C) ⟶ 𝟙_ D` and `prodComparison F A B : F (A ⊗ B) ⟶ F A ⊗ F B` the canonical maps.

- Show that `terminalComparison` is an isomorphism if and only if `F` preserves terminal objects.
- Show that the canonical map `prodComparison F A B` is natural in `A` and `B` and compatible with composition.
- Show that `F` preserves binary products if and only if `prodComparison F A B` is an isomorphism for all `A B`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

This development mirrors the ones already existing in `CategoryTheory/Limits/Preserves/Shapes/BinaryProducts` and `CategoryTheory/Limits/Preserves/Shapes/Terminal`. Some names are even identical but should not clash as they are in the `ChosenFiniteProducts` namespace. Will be used in #17613.

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
