### PR TITLE
[Merged by Bors] - feat(CategoryTheory/ChosenFiniteProducts/FunctorCategory): Tensoring on the left preserves colimits if it does so on the base category

### DIFF
--- a/Mathlib/CategoryTheory/ChosenFiniteProducts/FunctorCategory.lean
+++ b/Mathlib/CategoryTheory/ChosenFiniteProducts/FunctorCategory.lean
@@ -151,6 +151,15 @@ lemma associator_inv_app (F₁ F₂ F₃ : J ⥤ C) (j : J) :
     (α_ F₁ F₂ F₃).inv.app j = (α_ _ _ _).inv := by
   rw [← cancel_mono ((α_ _ _ _).hom), Iso.inv_hom_id, ← associator_hom_app, Iso.inv_hom_id_app]
 
+noncomputable instance {K : Type*} [Category K] [HasColimitsOfShape K C]
+    [∀ X : C, PreservesColimitsOfShape K (tensorLeft X)] {F : J ⥤ C} :
+    PreservesColimitsOfShape K (tensorLeft F) := by
+  apply preservesColimitsOfShapeOfEvaluation
+  intro k
+  haveI : tensorLeft F ⋙ (evaluation J C).obj k ≅ (evaluation J C).obj k ⋙ tensorLeft (F.obj k) :=
+    NatIso.ofComponents (fun _ ↦ Iso.refl _)
+  exact preservesColimitsOfShapeOfNatIso this.symm
+
 end Monoidal
 
 end Functor


### PR DESCRIPTION
Show that if `C` has chosen finite products and is such that tensoring on the left preserves `K`-shaped colimits, then the tensor product on `J ⥤ C` has the same property.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

This showed up when trying to base `CartesianClosed` on chosen finite products rather than on `HasFiniteProducts`, and more specifically while trying to show that presheaves are cartesian closed.

The instance for `K`-shaped diagram is enough to synthesize `PreservesColimits (tensorLeft F)` if `C` has all colimits and `tensorLeft X` preserves colimits for all `X`.

There is of course a more general statement possible about preservation of colimits of specific diagrams, but I’m not sure it would be that useful so I went with this one. I also left this instance unnamed because it probably won’t be used explicitly that often.

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
