### PR TITLE
[Merged by Bors] - feat(CategoryTheory/Limits/Final): Additional equational lemmas for cones extended along final functors

### DIFF
--- a/Mathlib/CategoryTheory/Limits/Final.lean
+++ b/Mathlib/CategoryTheory/Limits/Final.lean
@@ -527,7 +527,7 @@ is given explicitly. -/
 lemma extendCone_obj_π_app' (c : Cone (F ⋙ G)) {X : C} {Y : D} (f : F.obj X ⟶ Y) :
     (extendCone.obj c).π.app Y = c.π.app X ≫ G.map f := by
   apply induction (k₀ := f) (z := rfl) F fun Z g =>
-   c.π.app Z ≫ G.map g = c.π.app X ≫ G.map f
+    c.π.app Z ≫ G.map g = c.π.app X ≫ G.map f
   · intro _ _ _ _ _ h₁ h₂
     simp [← h₂, ← h₁, ← Functor.comp_map, c.π.naturality]
   · intro _ _ _ _ _ h₁ h₂

--- a/Mathlib/CategoryTheory/Limits/Final.lean
+++ b/Mathlib/CategoryTheory/Limits/Final.lean
@@ -238,6 +238,17 @@ def extendCocone : Cocone (F ⋙ G) ⥤ Cocone G where
             · rw [← Functor.map_comp_assoc] } }
   map f := { hom := f.hom }
 
+/-- Alternative equational lemma for `(extendCocone c).ι.app` in case a lift of the object
+is given explicitly. -/
+lemma extendCocone_obj_ι_app' (c : Cocone (F ⋙ G)) {X : D} {Y : C} (f : X ⟶ F.obj Y) :
+    (extendCocone.obj c).ι.app X = G.map f ≫ c.ι.app Y := by
+  apply induction (k₀ := f) (z := rfl) F fun Z g =>
+    G.map g ≫ c.ι.app Z = G.map f ≫ c.ι.app Y
+  · intro _ _ _ _ _ h₁ h₂
+    simp [← h₁, ← Functor.comp_map, c.ι.naturality, h₂]
+  · intro _ _ _ _ _ h₁ h₂
+    simp [← h₂, ← h₁, ← Functor.comp_map, c.ι.naturality]
+
 @[simp]
 theorem colimit_cocone_comp_aux (s : Cocone (F ⋙ G)) (j : C) :
     G.map (homToLift F (F.obj j)) ≫ s.ι.app (lift F (F.obj j)) = s.ι.app j := by
@@ -510,6 +521,17 @@ def extendCone : Cone (F ⋙ G) ⥤ Cone G where
                 c.w, z, Category.assoc]
             · rw [← Functor.map_comp] } }
   map f := { hom := f.hom }
+
+/-- Alternative equational lemma for `(extendCone c).π.app` in case a lift of the object
+is given explicitly. -/
+lemma extendCone_obj_π_app' (c : Cone (F ⋙ G)) {X : C} {Y : D} (f : F.obj X ⟶ Y) :
+    (extendCone.obj c).π.app Y = c.π.app X ≫ G.map f := by
+  apply induction (k₀ := f) (z := rfl) F fun Z g =>
+   c.π.app Z ≫ G.map g = c.π.app X ≫ G.map f
+  · intro _ _ _ _ _ h₁ h₂
+    simp [← h₂, ← h₁, ← Functor.comp_map, c.π.naturality]
+  · intro _ _ _ _ _ h₁ h₂
+    simp [← h₁, ← Functor.comp_map, c.π.naturality, h₂]
 
 @[simp]
 theorem limit_cone_comp_aux (s : Cone (F ⋙ G)) (j : C) :


### PR DESCRIPTION
Add an equational lemma for the natural transform of `extentedCocone` in case an explicit lift is already at hand, as well as the dual statement for initial functors.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

Suggested by @joelriou to simplify a proof in #8013.

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
