### PR TITLE
[Merged by Bors] - chore(Algebra.Group.Units): split into `Defs` and `Basic` file

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -297,7 +297,8 @@ import Mathlib.Algebra.Group.TypeTags
 import Mathlib.Algebra.Group.ULift
 import Mathlib.Algebra.Group.UniqueProds.Basic
 import Mathlib.Algebra.Group.UniqueProds.VectorSpace
-import Mathlib.Algebra.Group.Units
+import Mathlib.Algebra.Group.Units.Basic
+import Mathlib.Algebra.Group.Units.Defs
 import Mathlib.Algebra.Group.Units.Equiv
 import Mathlib.Algebra.Group.Units.Hom
 import Mathlib.Algebra.Group.WithOne.Basic

--- a/Mathlib/Algebra/BigOperators/Group/List.lean
+++ b/Mathlib/Algebra/BigOperators/Group/List.lean
@@ -7,7 +7,7 @@ import Mathlib.Algebra.Divisibility.Basic
 import Mathlib.Algebra.Group.Int
 import Mathlib.Algebra.Group.Nat
 import Mathlib.Algebra.Group.Opposite
-import Mathlib.Algebra.Group.Units
+import Mathlib.Algebra.Group.Units.Basic
 import Mathlib.Data.List.Perm
 import Mathlib.Data.List.ProdSigma
 import Mathlib.Data.List.Range

--- a/Mathlib/Algebra/Divisibility/Units.lean
+++ b/Mathlib/Algebra/Divisibility/Units.lean
@@ -5,7 +5,7 @@ Authors: Jeremy Avigad, Leonardo de Moura, Floris van Doorn, Amelia Livingston, 
 Neil Strickland, Aaron Anderson
 -/
 import Mathlib.Algebra.Divisibility.Basic
-import Mathlib.Algebra.Group.Units
+import Mathlib.Algebra.Group.Units.Basic
 
 /-!
 # Divisibility and units

--- a/Mathlib/Algebra/FreeMonoid/Basic.lean
+++ b/Mathlib/Algebra/FreeMonoid/Basic.lean
@@ -5,7 +5,7 @@ Authors: Simon Hudon, Yury Kudryashov
 -/
 import Mathlib.Algebra.BigOperators.Group.List
 import Mathlib.Algebra.Group.Action.Defs
-import Mathlib.Algebra.Group.Units
+import Mathlib.Algebra.Group.Units.Basic
 
 /-!
 # Free monoid over a given alphabet

--- a/Mathlib/Algebra/Group/Action/Units.lean
+++ b/Mathlib/Algebra/Group/Action/Units.lean
@@ -4,7 +4,8 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Eric Wieser
 -/
 import Mathlib.Algebra.Group.Action.Defs
-import Mathlib.Algebra.Group.Units.Basic
+import Mathlib.Algebra.Group.Basic
+import Mathlib.Algebra.Group.Units.Defs
 
 /-! # Group actions on and by `Mˣ`
 

--- a/Mathlib/Algebra/Group/Action/Units.lean
+++ b/Mathlib/Algebra/Group/Action/Units.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Eric Wieser
 -/
 import Mathlib.Algebra.Group.Action.Defs
-import Mathlib.Algebra.Group.Units
+import Mathlib.Algebra.Group.Units.Basic
 
 /-! # Group actions on and by `Mˣ`
 

--- a/Mathlib/Algebra/Group/Int.lean
+++ b/Mathlib/Algebra/Group/Int.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Jeremy Avigad
 -/
 import Mathlib.Algebra.Group.Nat
+import Mathlib.Algebra.Group.Units.Basic
 import Mathlib.Data.Int.Sqrt
 
 /-!

--- a/Mathlib/Algebra/Group/Nat.lean
+++ b/Mathlib/Algebra/Group/Nat.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Floris van Doorn, Leonardo de Moura, Jeremy Avigad, Mario Carneiro
 -/
 import Mathlib.Algebra.Group.Even
-import Mathlib.Algebra.Group.Units
+import Mathlib.Algebra.Group.Units.Basic
 import Mathlib.Data.Nat.Sqrt
 
 /-!

--- a/Mathlib/Algebra/Group/Nat.lean
+++ b/Mathlib/Algebra/Group/Nat.lean
@@ -4,7 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Floris van Doorn, Leonardo de Moura, Jeremy Avigad, Mario Carneiro
 -/
 import Mathlib.Algebra.Group.Even
-import Mathlib.Algebra.Group.Units.Basic
 import Mathlib.Data.Nat.Sqrt
 
 /-!

--- a/Mathlib/Algebra/Group/Opposite.lean
+++ b/Mathlib/Algebra/Group/Opposite.lean
@@ -6,7 +6,7 @@ Authors: Kenny Lau
 import Mathlib.Algebra.Group.Commute.Defs
 import Mathlib.Algebra.Group.Equiv.Basic
 import Mathlib.Algebra.Group.InjSurj
-import Mathlib.Algebra.Group.Units
+import Mathlib.Algebra.Group.Units.Basic
 import Mathlib.Algebra.Opposites
 import Mathlib.Data.Int.Cast.Defs
 import Mathlib.Tactic.Spread

--- a/Mathlib/Algebra/Group/Opposite.lean
+++ b/Mathlib/Algebra/Group/Opposite.lean
@@ -6,7 +6,7 @@ Authors: Kenny Lau
 import Mathlib.Algebra.Group.Commute.Defs
 import Mathlib.Algebra.Group.Equiv.Basic
 import Mathlib.Algebra.Group.InjSurj
-import Mathlib.Algebra.Group.Units.Basic
+import Mathlib.Algebra.Group.Units.Defs
 import Mathlib.Algebra.Opposites
 import Mathlib.Data.Int.Cast.Defs
 import Mathlib.Tactic.Spread

--- a/Mathlib/Algebra/Group/Semiconj/Units.lean
+++ b/Mathlib/Algebra/Group/Semiconj/Units.lean
@@ -6,7 +6,7 @@ Authors: Yury Kudryashov
 -- Some proofs and docs came from mathlib3 `src/algebra/commute.lean` (c) Neil Strickland
 
 import Mathlib.Algebra.Group.Semiconj.Defs
-import Mathlib.Algebra.Group.Units
+import Mathlib.Algebra.Group.Units.Basic
 
 /-!
 # Semiconjugate elements of a semigroup

--- a/Mathlib/Algebra/Group/Submonoid/Basic.lean
+++ b/Mathlib/Algebra/Group/Submonoid/Basic.lean
@@ -6,7 +6,7 @@ Amelia Livingston, Yury Kudryashov
 -/
 import Mathlib.Algebra.Group.Hom.Defs
 import Mathlib.Algebra.Group.Subsemigroup.Basic
-import Mathlib.Algebra.Group.Units
+import Mathlib.Algebra.Group.Units.Basic
 
 /-!
 # Submonoids: definition and `CompleteLattice` structure

--- a/Mathlib/Algebra/Group/Submonoid/Basic.lean
+++ b/Mathlib/Algebra/Group/Submonoid/Basic.lean
@@ -6,7 +6,7 @@ Amelia Livingston, Yury Kudryashov
 -/
 import Mathlib.Algebra.Group.Hom.Defs
 import Mathlib.Algebra.Group.Subsemigroup.Basic
-import Mathlib.Algebra.Group.Units.Basic
+import Mathlib.Algebra.Group.Units.Defs
 
 /-!
 # Submonoids: definition and `CompleteLattice` structure

--- a/Mathlib/Algebra/Group/Units/Basic.lean
+++ b/Mathlib/Algebra/Group/Units/Basic.lean
@@ -293,11 +293,6 @@ section Monoid
 
 variable [Monoid M] {a b c : M}
 
-/-- `IsUnit x` is decidable if we can decide if `x` comes from `Mˣ`. -/
-@[to_additive "`IsAddUnit x` is decidable if we can decide if `x` comes from `AddUnits M`."]
-instance (x : M) [h : Decidable (∃ u : Mˣ, ↑u = x)] : Decidable (IsUnit x) :=
-  h
-
 @[to_additive]
 theorem mul_left_inj (h : IsUnit a) : b * a = c * a ↔ b = c :=
   let ⟨u, hu⟩ := h

--- a/Mathlib/Algebra/Group/Units/Basic.lean
+++ b/Mathlib/Algebra/Group/Units/Basic.lean
@@ -9,7 +9,6 @@ import Mathlib.Algebra.Group.Units.Defs
 import Mathlib.Logic.Unique
 import Mathlib.Tactic.Nontriviality
 import Mathlib.Tactic.Lift
-import Mathlib.Tactic.Subsingleton
 
 /-!
 # Units (i.e., invertible elements) of a monoid

--- a/Mathlib/Algebra/Group/Units/Basic.lean
+++ b/Mathlib/Algebra/Group/Units/Basic.lean
@@ -9,6 +9,7 @@ import Mathlib.Algebra.Group.Units.Defs
 import Mathlib.Logic.Unique
 import Mathlib.Tactic.Nontriviality
 import Mathlib.Tactic.Lift
+import Mathlib.Tactic.Subsingleton
 
 /-!
 # Units (i.e., invertible elements) of a monoid

--- a/Mathlib/Algebra/Group/Units/Basic.lean
+++ b/Mathlib/Algebra/Group/Units/Basic.lean
@@ -1,0 +1,483 @@
+/-
+Copyright (c) 2017 Kenny Lau. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kenny Lau, Mario Carneiro, Johannes Hölzl, Chris Hughes, Jens Wagemaker, Jon Eugster
+-/
+import Mathlib.Algebra.Group.Basic
+import Mathlib.Algebra.Group.Commute.Defs
+import Mathlib.Algebra.Group.Units.Defs
+import Mathlib.Logic.Unique
+import Mathlib.Tactic.Nontriviality
+import Mathlib.Tactic.Lift
+import Mathlib.Tactic.Subsingleton
+
+/-!
+# Units (i.e., invertible elements) of a monoid
+
+An element of a `Monoid` is a unit if it has a two-sided inverse.
+This file contains the basic lemmas on units in a monoid, especially focussing on singleton types
+and unique types.
+
+## TODO
+
+The results here should be used to golf the basic `Group` lemmas.
+-/
+
+assert_not_exists Multiplicative
+assert_not_exists MonoidWithZero
+assert_not_exists DenselyOrdered
+
+open Function
+
+universe u
+
+variable {α : Type u}
+
+section HasElem
+
+@[to_additive]
+theorem unique_one {α : Type*} [Unique α] [One α] : default = (1 : α) :=
+  Unique.default_eq 1
+
+end HasElem
+
+namespace Units
+section Monoid
+variable [Monoid α]
+
+variable (a b c : αˣ) {u : αˣ}
+
+@[to_additive (attr := simp)]
+theorem mul_inv_cancel_right (a : α) (b : αˣ) : a * b * ↑b⁻¹ = a := by
+  rw [mul_assoc, mul_inv, mul_one]
+
+@[to_additive (attr := simp)]
+theorem inv_mul_cancel_right (a : α) (b : αˣ) : a * ↑b⁻¹ * b = a := by
+  rw [mul_assoc, inv_mul, mul_one]
+
+@[to_additive (attr := simp)]
+theorem mul_right_inj (a : αˣ) {b c : α} : (a : α) * b = a * c ↔ b = c :=
+  ⟨fun h => by simpa only [inv_mul_cancel_left] using congr_arg (fun x : α => ↑(a⁻¹ : αˣ) * x) h,
+    congr_arg _⟩
+
+@[to_additive (attr := simp)]
+theorem mul_left_inj (a : αˣ) {b c : α} : b * a = c * a ↔ b = c :=
+  ⟨fun h => by simpa only [mul_inv_cancel_right] using congr_arg (fun x : α => x * ↑(a⁻¹ : αˣ)) h,
+    congr_arg (· * a.val)⟩
+
+@[to_additive]
+theorem eq_mul_inv_iff_mul_eq {a b : α} : a = b * ↑c⁻¹ ↔ a * c = b :=
+  ⟨fun h => by rw [h, inv_mul_cancel_right], fun h => by rw [← h, mul_inv_cancel_right]⟩
+
+@[to_additive]
+theorem eq_inv_mul_iff_mul_eq {a c : α} : a = ↑b⁻¹ * c ↔ ↑b * a = c :=
+  ⟨fun h => by rw [h, mul_inv_cancel_left], fun h => by rw [← h, inv_mul_cancel_left]⟩
+
+@[to_additive]
+theorem mul_inv_eq_iff_eq_mul {a c : α} : a * ↑b⁻¹ = c ↔ a = c * b :=
+  ⟨fun h => by rw [← h, inv_mul_cancel_right], fun h => by rw [h, mul_inv_cancel_right]⟩
+
+-- Porting note: have to explicitly type annotate the 1
+@[to_additive]
+protected theorem inv_eq_of_mul_eq_one_left {a : α} (h : a * u = 1) : ↑u⁻¹ = a :=
+  calc
+    ↑u⁻¹ = (1 : α) * ↑u⁻¹ := by rw [one_mul]
+    _ = a := by rw [← h, mul_inv_cancel_right]
+
+
+-- Porting note: have to explicitly type annotate the 1
+@[to_additive]
+protected theorem inv_eq_of_mul_eq_one_right {a : α} (h : ↑u * a = 1) : ↑u⁻¹ = a :=
+  calc
+    ↑u⁻¹ = ↑u⁻¹ * (1 : α) := by rw [mul_one]
+    _ = a := by rw [← h, inv_mul_cancel_left]
+
+
+@[to_additive]
+protected theorem eq_inv_of_mul_eq_one_left {a : α} (h : ↑u * a = 1) : a = ↑u⁻¹ :=
+  (Units.inv_eq_of_mul_eq_one_right h).symm
+
+@[to_additive]
+protected theorem eq_inv_of_mul_eq_one_right {a : α} (h : a * u = 1) : a = ↑u⁻¹ :=
+  (Units.inv_eq_of_mul_eq_one_left h).symm
+
+@[to_additive (attr := simp)]
+theorem mul_inv_eq_one {a : α} : a * ↑u⁻¹ = 1 ↔ a = u :=
+  ⟨inv_inv u ▸ Units.eq_inv_of_mul_eq_one_right, fun h => mul_inv_of_eq h.symm⟩
+
+@[to_additive (attr := simp)]
+theorem inv_mul_eq_one {a : α} : ↑u⁻¹ * a = 1 ↔ ↑u = a :=
+  ⟨inv_inv u ▸ Units.inv_eq_of_mul_eq_one_right, inv_mul_of_eq⟩
+
+@[to_additive]
+theorem mul_eq_one_iff_eq_inv {a : α} : a * u = 1 ↔ a = ↑u⁻¹ := by rw [← mul_inv_eq_one, inv_inv]
+
+@[to_additive]
+theorem mul_eq_one_iff_inv_eq {a : α} : ↑u * a = 1 ↔ ↑u⁻¹ = a := by rw [← inv_mul_eq_one, inv_inv]
+
+@[to_additive]
+theorem inv_unique {u₁ u₂ : αˣ} (h : (↑u₁ : α) = ↑u₂) : (↑u₁⁻¹ : α) = ↑u₂⁻¹ :=
+  Units.inv_eq_of_mul_eq_one_right <| by rw [h, u₂.mul_inv]
+
+end Monoid
+
+end Units
+
+section Monoid
+
+variable [Monoid α] {a : α}
+
+@[simp]
+theorem divp_left_inj (u : αˣ) {a b : α} : a /ₚ u = b /ₚ u ↔ a = b :=
+  Units.mul_left_inj _
+
+/- Porting note: to match the mathlib3 behavior, this needs to have higher simp
+priority than eq_divp_iff_mul_eq. -/
+@[field_simps 1010]
+theorem divp_eq_iff_mul_eq {x : α} {u : αˣ} {y : α} : x /ₚ u = y ↔ y * u = x :=
+  u.mul_left_inj.symm.trans <| by rw [divp_mul_cancel]; exact ⟨Eq.symm, Eq.symm⟩
+
+@[field_simps]
+theorem eq_divp_iff_mul_eq {x : α} {u : αˣ} {y : α} : x = y /ₚ u ↔ x * u = y := by
+  rw [eq_comm, divp_eq_iff_mul_eq]
+
+theorem divp_eq_one_iff_eq {a : α} {u : αˣ} : a /ₚ u = 1 ↔ a = u :=
+  (Units.mul_left_inj u).symm.trans <| by rw [divp_mul_cancel, one_mul]
+
+/-- Used for `field_simp` to deal with inverses of units. This form of the lemma
+is essential since `field_simp` likes to use `inv_eq_one_div` to rewrite
+`↑u⁻¹ = ↑(1 / u)`.
+-/
+@[field_simps]
+theorem inv_eq_one_divp' (u : αˣ) : ((1 / u : αˣ) : α) = 1 /ₚ u := by
+  rw [one_div, one_divp]
+
+end Monoid
+
+namespace LeftCancelMonoid
+
+variable [LeftCancelMonoid α] [Subsingleton αˣ] {a b : α}
+
+@[to_additive]
+protected theorem eq_one_of_mul_right (h : a * b = 1) : a = 1 :=
+  congr_arg Units.inv <| Subsingleton.elim (Units.mk _ _ (by
+    rw [← mul_left_cancel_iff (a := a), ← mul_assoc, h, one_mul, mul_one]) h) 1
+
+@[to_additive]
+protected theorem eq_one_of_mul_left (h : a * b = 1) : b = 1 := by
+  rwa [LeftCancelMonoid.eq_one_of_mul_right h, one_mul] at h
+
+@[to_additive (attr := simp)]
+protected theorem mul_eq_one : a * b = 1 ↔ a = 1 ∧ b = 1 :=
+  ⟨fun h => ⟨LeftCancelMonoid.eq_one_of_mul_right h, LeftCancelMonoid.eq_one_of_mul_left h⟩, by
+    rintro ⟨rfl, rfl⟩
+    exact mul_one _⟩
+
+@[to_additive]
+protected theorem mul_ne_one : a * b ≠ 1 ↔ a ≠ 1 ∨ b ≠ 1 := by rw [not_iff_comm]; simp
+
+end LeftCancelMonoid
+
+namespace RightCancelMonoid
+
+variable [RightCancelMonoid α] [Subsingleton αˣ] {a b : α}
+
+@[to_additive]
+protected theorem eq_one_of_mul_right (h : a * b = 1) : a = 1 :=
+  congr_arg Units.inv <| Subsingleton.elim (Units.mk _ _ (by
+    rw [← mul_right_cancel_iff (a := b), mul_assoc, h, one_mul, mul_one]) h) 1
+
+@[to_additive]
+protected theorem eq_one_of_mul_left (h : a * b = 1) : b = 1 := by
+  rwa [RightCancelMonoid.eq_one_of_mul_right h, one_mul] at h
+
+@[to_additive (attr := simp)]
+protected theorem mul_eq_one : a * b = 1 ↔ a = 1 ∧ b = 1 :=
+  ⟨fun h => ⟨RightCancelMonoid.eq_one_of_mul_right h, RightCancelMonoid.eq_one_of_mul_left h⟩, by
+    rintro ⟨rfl, rfl⟩
+    exact mul_one _⟩
+
+@[to_additive]
+protected theorem mul_ne_one : a * b ≠ 1 ↔ a ≠ 1 ∨ b ≠ 1 := by rw [not_iff_comm]; simp
+
+end RightCancelMonoid
+
+section CancelMonoid
+
+variable [CancelMonoid α] [Subsingleton αˣ] {a b : α}
+
+@[to_additive]
+theorem eq_one_of_mul_right' (h : a * b = 1) : a = 1 := LeftCancelMonoid.eq_one_of_mul_right h
+
+@[to_additive]
+theorem eq_one_of_mul_left' (h : a * b = 1) : b = 1 := LeftCancelMonoid.eq_one_of_mul_left h
+
+@[to_additive]
+theorem mul_eq_one' : a * b = 1 ↔ a = 1 ∧ b = 1 := LeftCancelMonoid.mul_eq_one
+
+@[to_additive]
+theorem mul_ne_one' : a * b ≠ 1 ↔ a ≠ 1 ∨ b ≠ 1 := LeftCancelMonoid.mul_ne_one
+
+end CancelMonoid
+
+section CommMonoid
+
+variable [CommMonoid α]
+
+@[field_simps]
+theorem divp_mul_eq_mul_divp (x y : α) (u : αˣ) : x /ₚ u * y = x * y /ₚ u := by
+  rw [divp, divp, mul_right_comm]
+
+-- Theoretically redundant as `field_simp` lemma.
+@[field_simps]
+theorem divp_eq_divp_iff {x y : α} {ux uy : αˣ} : x /ₚ ux = y /ₚ uy ↔ x * uy = y * ux := by
+  rw [divp_eq_iff_mul_eq, divp_mul_eq_mul_divp, divp_eq_iff_mul_eq]
+
+-- Theoretically redundant as `field_simp` lemma.
+@[field_simps]
+theorem divp_mul_divp (x y : α) (ux uy : αˣ) : x /ₚ ux * (y /ₚ uy) = x * y /ₚ (ux * uy) := by
+  rw [divp_mul_eq_mul_divp, divp_assoc', divp_divp_eq_divp_mul]
+
+variable [Subsingleton αˣ] {a b : α}
+
+@[to_additive]
+theorem eq_one_of_mul_right (h : a * b = 1) : a = 1 :=
+  congr_arg Units.inv <| Subsingleton.elim (Units.mk _ _ (by rwa [mul_comm]) h) 1
+
+@[to_additive]
+theorem eq_one_of_mul_left (h : a * b = 1) : b = 1 :=
+  congr_arg Units.inv <| Subsingleton.elim (Units.mk _ _ h <| by rwa [mul_comm]) 1
+
+@[to_additive (attr := simp)]
+theorem mul_eq_one : a * b = 1 ↔ a = 1 ∧ b = 1 :=
+  ⟨fun h => ⟨eq_one_of_mul_right h, eq_one_of_mul_left h⟩, by
+    rintro ⟨rfl, rfl⟩
+    exact mul_one _⟩
+
+@[to_additive] theorem mul_ne_one : a * b ≠ 1 ↔ a ≠ 1 ∨ b ≠ 1 := by rw [not_iff_comm]; simp
+
+end CommMonoid
+
+/-!
+# `IsUnit` predicate
+-/
+
+
+section IsUnit
+
+variable {M : Type*} {N : Type*}
+
+@[to_additive (attr := nontriviality)]
+theorem isUnit_of_subsingleton [Monoid M] [Subsingleton M] (a : M) : IsUnit a :=
+  ⟨⟨a, a, by subsingleton, by subsingleton⟩, rfl⟩
+
+@[to_additive]
+instance [Monoid M] : CanLift M Mˣ Units.val IsUnit :=
+  { prf := fun _ ↦ id }
+
+/-- A subsingleton `Monoid` has a unique unit. -/
+@[to_additive "A subsingleton `AddMonoid` has a unique additive unit."]
+instance [Monoid M] [Subsingleton M] : Unique Mˣ where
+  uniq _ := Units.val_eq_one.mp (by subsingleton)
+
+section Monoid
+variable [Monoid M] {a b : M}
+
+theorem units_eq_one [Subsingleton Mˣ] (u : Mˣ) : u = 1 := by subsingleton
+
+end Monoid
+
+namespace IsUnit
+
+section Monoid
+
+variable [Monoid M] {a b c : M}
+
+/-- `IsUnit x` is decidable if we can decide if `x` comes from `Mˣ`. -/
+@[to_additive "`IsAddUnit x` is decidable if we can decide if `x` comes from `AddUnits M`."]
+instance (x : M) [h : Decidable (∃ u : Mˣ, ↑u = x)] : Decidable (IsUnit x) :=
+  h
+
+@[to_additive]
+theorem mul_left_inj (h : IsUnit a) : b * a = c * a ↔ b = c :=
+  let ⟨u, hu⟩ := h
+  hu ▸ u.mul_left_inj
+
+@[to_additive]
+theorem mul_right_inj (h : IsUnit a) : a * b = a * c ↔ b = c :=
+  let ⟨u, hu⟩ := h
+  hu ▸ u.mul_right_inj
+
+@[to_additive]
+protected theorem mul_left_cancel (h : IsUnit a) : a * b = a * c → b = c :=
+  h.mul_right_inj.1
+
+@[to_additive]
+protected theorem mul_right_cancel (h : IsUnit b) : a * b = c * b → a = c :=
+  h.mul_left_inj.1
+
+@[to_additive]
+protected theorem mul_right_injective (h : IsUnit a) : Injective (a * ·) :=
+  fun _ _ => h.mul_left_cancel
+
+@[to_additive]
+protected theorem mul_left_injective (h : IsUnit b) : Injective (· * b) :=
+  fun _ _ => h.mul_right_cancel
+
+@[to_additive]
+theorem isUnit_iff_mulLeft_bijective {a : M} :
+    IsUnit a ↔ Function.Bijective (a * ·) :=
+  ⟨fun h ↦ ⟨h.mul_right_injective, fun y ↦ ⟨h.unit⁻¹ * y, by simp [← mul_assoc]⟩⟩, fun h ↦
+    ⟨⟨a, _, (h.2 1).choose_spec, h.1
+      (by simpa [mul_assoc] using congr_arg (· * a) (h.2 1).choose_spec)⟩, rfl⟩⟩
+
+@[to_additive]
+theorem isUnit_iff_mulRight_bijective {a : M} :
+    IsUnit a ↔ Function.Bijective (· * a) :=
+  ⟨fun h ↦ ⟨h.mul_left_injective, fun y ↦ ⟨y * h.unit⁻¹, by simp [mul_assoc]⟩⟩,
+    fun h ↦ ⟨⟨a, _, h.1 (by simpa [mul_assoc] using congr_arg (a * ·) (h.2 1).choose_spec),
+      (h.2 1).choose_spec⟩, rfl⟩⟩
+
+end Monoid
+
+section DivisionMonoid
+variable [DivisionMonoid α] {a b c : α}
+
+@[to_additive (attr := simp)]
+protected lemma mul_inv_cancel_right (h : IsUnit b) (a : α) : a * b * b⁻¹ = a :=
+  h.unit'.mul_inv_cancel_right _
+
+@[to_additive (attr := simp)]
+protected lemma inv_mul_cancel_right (h : IsUnit b) (a : α) : a * b⁻¹ * b = a :=
+  h.unit'.inv_mul_cancel_right _
+
+@[to_additive]
+protected lemma eq_mul_inv_iff_mul_eq (h : IsUnit c) : a = b * c⁻¹ ↔ a * c = b :=
+  h.unit'.eq_mul_inv_iff_mul_eq
+
+@[to_additive]
+protected lemma eq_inv_mul_iff_mul_eq (h : IsUnit b) : a = b⁻¹ * c ↔ b * a = c :=
+  h.unit'.eq_inv_mul_iff_mul_eq
+
+@[to_additive]
+protected lemma inv_mul_eq_iff_eq_mul (h : IsUnit a) : a⁻¹ * b = c ↔ b = a * c :=
+  h.unit'.inv_mul_eq_iff_eq_mul
+
+@[to_additive]
+protected lemma mul_inv_eq_iff_eq_mul (h : IsUnit b) : a * b⁻¹ = c ↔ a = c * b :=
+  h.unit'.mul_inv_eq_iff_eq_mul
+
+@[to_additive]
+protected lemma mul_inv_eq_one (h : IsUnit b) : a * b⁻¹ = 1 ↔ a = b :=
+  @Units.mul_inv_eq_one _ _ h.unit' _
+
+@[to_additive]
+protected lemma inv_mul_eq_one (h : IsUnit a) : a⁻¹ * b = 1 ↔ a = b :=
+  @Units.inv_mul_eq_one _ _ h.unit' _
+
+@[to_additive]
+protected lemma mul_eq_one_iff_eq_inv (h : IsUnit b) : a * b = 1 ↔ a = b⁻¹ :=
+  @Units.mul_eq_one_iff_eq_inv _ _ h.unit' _
+
+@[to_additive]
+protected lemma mul_eq_one_iff_inv_eq (h : IsUnit a) : a * b = 1 ↔ a⁻¹ = b :=
+  @Units.mul_eq_one_iff_inv_eq _ _ h.unit' _
+
+@[to_additive (attr := simp)]
+protected lemma div_mul_cancel (h : IsUnit b) (a : α) : a / b * b = a := by
+  rw [div_eq_mul_inv, h.inv_mul_cancel_right]
+
+@[to_additive (attr := simp)]
+protected lemma mul_div_cancel_right (h : IsUnit b) (a : α) : a * b / b = a := by
+  rw [div_eq_mul_inv, h.mul_inv_cancel_right]
+
+@[to_additive]
+protected lemma mul_one_div_cancel (h : IsUnit a) : a * (1 / a) = 1 := by simp [h]
+
+@[to_additive]
+protected lemma one_div_mul_cancel (h : IsUnit a) : 1 / a * a = 1 := by simp [h]
+
+@[to_additive]
+protected lemma div_left_inj (h : IsUnit c) : a / c = b / c ↔ a = b := by
+  simp only [div_eq_mul_inv]
+  exact Units.mul_left_inj h.inv.unit'
+
+@[to_additive]
+protected lemma div_eq_iff (h : IsUnit b) : a / b = c ↔ a = c * b := by
+  rw [div_eq_mul_inv, h.mul_inv_eq_iff_eq_mul]
+
+@[to_additive]
+protected lemma eq_div_iff (h : IsUnit c) : a = b / c ↔ a * c = b := by
+  rw [div_eq_mul_inv, h.eq_mul_inv_iff_mul_eq]
+
+@[to_additive]
+protected lemma div_eq_of_eq_mul (h : IsUnit b) : a = c * b → a / b = c :=
+  h.div_eq_iff.2
+
+@[to_additive]
+protected lemma eq_div_of_mul_eq (h : IsUnit c) : a * c = b → a = b / c :=
+  h.eq_div_iff.2
+
+@[to_additive]
+protected lemma div_eq_one_iff_eq (h : IsUnit b) : a / b = 1 ↔ a = b :=
+  ⟨eq_of_div_eq_one, fun hab => hab.symm ▸ h.div_self⟩
+
+@[to_additive]
+protected lemma div_mul_left (h : IsUnit b) : b / (a * b) = 1 / a := by
+  rw [h.div_mul_cancel_right, one_div]
+
+@[to_additive]
+protected lemma mul_mul_div (a : α) (h : IsUnit b) : a * b * (1 / b) = a := by simp [h]
+
+end DivisionMonoid
+
+section DivisionCommMonoid
+variable [DivisionCommMonoid α] {a b c d : α}
+
+@[to_additive]
+protected lemma div_mul_right (h : IsUnit a) (b : α) : a / (a * b) = 1 / b := by
+  rw [mul_comm, h.div_mul_left]
+
+@[to_additive]
+protected lemma mul_div_cancel_left (h : IsUnit a) (b : α) : a * b / a = b := by
+  rw [mul_comm, h.mul_div_cancel_right]
+
+@[to_additive]
+protected lemma mul_div_cancel (h : IsUnit a) (b : α) : a * (b / a) = b := by
+  rw [mul_comm, h.div_mul_cancel]
+
+@[to_additive]
+protected lemma mul_eq_mul_of_div_eq_div (hb : IsUnit b) (hd : IsUnit d)
+    (a c : α) (h : a / b = c / d) : a * d = c * b := by
+  rw [← mul_one a, ← hb.div_self, ← mul_comm_div, h, div_mul_eq_mul_div, hd.div_mul_cancel]
+
+@[to_additive]
+protected lemma div_eq_div_iff (hb : IsUnit b) (hd : IsUnit d) :
+    a / b = c / d ↔ a * d = c * b := by
+  rw [← (hb.mul hd).mul_left_inj, ← mul_assoc, hb.div_mul_cancel, ← mul_assoc, mul_right_comm,
+    hd.div_mul_cancel]
+
+@[to_additive]
+protected lemma div_div_cancel (h : IsUnit a) : a / (a / b) = b := by
+  rw [div_div_eq_mul_div, h.mul_div_cancel_left]
+
+@[to_additive]
+protected lemma div_div_cancel_left (h : IsUnit a) : a / b / a = b⁻¹ := by
+  rw [div_eq_mul_inv, div_eq_mul_inv, mul_right_comm, h.mul_inv_cancel, one_mul]
+
+end DivisionCommMonoid
+end IsUnit
+
+-- namespace
+end IsUnit
+
+attribute [deprecated div_mul_cancel_right (since := "2024-03-20")] IsUnit.div_mul_left
+attribute [deprecated sub_add_cancel_right (since := "2024-03-20")] IsAddUnit.sub_add_left
+attribute [deprecated div_mul_cancel_left (since := "2024-03-20")] IsUnit.div_mul_right
+attribute [deprecated sub_add_cancel_left (since := "2024-03-20")] IsAddUnit.sub_add_right
+-- The names `IsUnit.mul_div_cancel` and `IsAddUnit.add_sub_cancel` have been reused
+-- @[deprecated (since := "2024-03-20")] alias IsUnit.mul_div_cancel := IsUnit.mul_div_cancel_right
+-- @[deprecated (since := "2024-03-20")]
+-- alias IsAddUnit.add_sub_cancel := IsAddUnit.add_sub_cancel_right
+@[deprecated (since := "2024-03-20")] alias IsUnit.mul_div_cancel' := IsUnit.mul_div_cancel
+@[deprecated (since := "2024-03-20")] alias IsAddUnit.add_sub_cancel' := IsAddUnit.add_sub_cancel

--- a/Mathlib/Algebra/Group/Units/Defs.lean
+++ b/Mathlib/Algebra/Group/Units/Defs.lean
@@ -3,12 +3,9 @@ Copyright (c) 2017 Kenny Lau. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Kenny Lau, Mario Carneiro, Johannes Hölzl, Chris Hughes, Jens Wagemaker, Jon Eugster
 -/
-import Mathlib.Algebra.Group.Basic
+import Mathlib.Algebra.Group.Defs
 import Mathlib.Algebra.Group.Commute.Defs
-import Mathlib.Logic.Unique
-import Mathlib.Tactic.Nontriviality
-import Mathlib.Tactic.Lift
-import Mathlib.Tactic.Subsingleton
+import Mathlib.Logic.Function.Basic
 
 /-!
 # Units (i.e., invertible elements) of a monoid
@@ -81,14 +78,6 @@ structure AddUnits (α : Type u) [AddMonoid α] where
 
 attribute [to_additive] Units
 attribute [coe] AddUnits.val
-
-section HasElem
-
-@[to_additive]
-theorem unique_one {α : Type*} [Unique α] [One α] : default = (1 : α) :=
-  Unique.default_eq 1
-
-end HasElem
 
 namespace Units
 section Monoid
@@ -231,63 +220,9 @@ theorem mul_inv_cancel_left (a : αˣ) (b : α) : (a : α) * (↑a⁻¹ * b) = b
 theorem inv_mul_cancel_left (a : αˣ) (b : α) : (↑a⁻¹ : α) * (a * b) = b := by
   rw [← mul_assoc, inv_mul, one_mul]
 
-@[to_additive (attr := simp)]
-theorem mul_inv_cancel_right (a : α) (b : αˣ) : a * b * ↑b⁻¹ = a := by
-  rw [mul_assoc, mul_inv, mul_one]
-
-@[to_additive (attr := simp)]
-theorem inv_mul_cancel_right (a : α) (b : αˣ) : a * ↑b⁻¹ * b = a := by
-  rw [mul_assoc, inv_mul, mul_one]
-
-@[to_additive (attr := simp)]
-theorem mul_right_inj (a : αˣ) {b c : α} : (a : α) * b = a * c ↔ b = c :=
-  ⟨fun h => by simpa only [inv_mul_cancel_left] using congr_arg (fun x : α => ↑(a⁻¹ : αˣ) * x) h,
-    congr_arg _⟩
-
-@[to_additive (attr := simp)]
-theorem mul_left_inj (a : αˣ) {b c : α} : b * a = c * a ↔ b = c :=
-  ⟨fun h => by simpa only [mul_inv_cancel_right] using congr_arg (fun x : α => x * ↑(a⁻¹ : αˣ)) h,
-    congr_arg (· * a.val)⟩
-
-@[to_additive]
-theorem eq_mul_inv_iff_mul_eq {a b : α} : a = b * ↑c⁻¹ ↔ a * c = b :=
-  ⟨fun h => by rw [h, inv_mul_cancel_right], fun h => by rw [← h, mul_inv_cancel_right]⟩
-
-@[to_additive]
-theorem eq_inv_mul_iff_mul_eq {a c : α} : a = ↑b⁻¹ * c ↔ ↑b * a = c :=
-  ⟨fun h => by rw [h, mul_inv_cancel_left], fun h => by rw [← h, inv_mul_cancel_left]⟩
-
 @[to_additive]
 theorem inv_mul_eq_iff_eq_mul {b c : α} : ↑a⁻¹ * b = c ↔ b = a * c :=
   ⟨fun h => by rw [← h, mul_inv_cancel_left], fun h => by rw [h, inv_mul_cancel_left]⟩
-
-@[to_additive]
-theorem mul_inv_eq_iff_eq_mul {a c : α} : a * ↑b⁻¹ = c ↔ a = c * b :=
-  ⟨fun h => by rw [← h, inv_mul_cancel_right], fun h => by rw [h, mul_inv_cancel_right]⟩
-
--- Porting note: have to explicitly type annotate the 1
-@[to_additive]
-protected theorem inv_eq_of_mul_eq_one_left {a : α} (h : a * u = 1) : ↑u⁻¹ = a :=
-  calc
-    ↑u⁻¹ = (1 : α) * ↑u⁻¹ := by rw [one_mul]
-    _ = a := by rw [← h, mul_inv_cancel_right]
-
-
--- Porting note: have to explicitly type annotate the 1
-@[to_additive]
-protected theorem inv_eq_of_mul_eq_one_right {a : α} (h : ↑u * a = 1) : ↑u⁻¹ = a :=
-  calc
-    ↑u⁻¹ = ↑u⁻¹ * (1 : α) := by rw [mul_one]
-    _ = a := by rw [← h, inv_mul_cancel_left]
-
-
-@[to_additive]
-protected theorem eq_inv_of_mul_eq_one_left {a : α} (h : ↑u * a = 1) : a = ↑u⁻¹ :=
-  (Units.inv_eq_of_mul_eq_one_right h).symm
-
-@[to_additive]
-protected theorem eq_inv_of_mul_eq_one_right {a : α} (h : a * u = 1) : a = ↑u⁻¹ :=
-  (Units.inv_eq_of_mul_eq_one_left h).symm
 
 @[to_additive]
 instance instMonoid : Monoid αˣ :=
@@ -333,24 +268,6 @@ instance instCommGroupUnits {α} [CommMonoid α] : CommGroup αˣ where
 
 @[to_additive (attr := simp, norm_cast)]
 lemma val_pow_eq_pow_val (n : ℕ) : ↑(a ^ n) = (a ^ n : α) := rfl
-
-@[to_additive (attr := simp)]
-theorem mul_inv_eq_one {a : α} : a * ↑u⁻¹ = 1 ↔ a = u :=
-  ⟨inv_inv u ▸ Units.eq_inv_of_mul_eq_one_right, fun h => mul_inv_of_eq h.symm⟩
-
-@[to_additive (attr := simp)]
-theorem inv_mul_eq_one {a : α} : ↑u⁻¹ * a = 1 ↔ ↑u = a :=
-  ⟨inv_inv u ▸ Units.inv_eq_of_mul_eq_one_right, inv_mul_of_eq⟩
-
-@[to_additive]
-theorem mul_eq_one_iff_eq_inv {a : α} : a * u = 1 ↔ a = ↑u⁻¹ := by rw [← mul_inv_eq_one, inv_inv]
-
-@[to_additive]
-theorem mul_eq_one_iff_inv_eq {a : α} : ↑u * a = 1 ↔ ↑u⁻¹ = a := by rw [← inv_mul_eq_one, inv_inv]
-
-@[to_additive]
-theorem inv_unique {u₁ u₂ : αˣ} (h : (↑u₁ : α) = ↑u₂) : (↑u₁⁻¹ : α) = ↑u₂⁻¹ :=
-  Units.inv_eq_of_mul_eq_one_right <| by rw [h, u₂.mul_inv]
 
 end Monoid
 
@@ -418,26 +335,9 @@ theorem divp_mul_cancel (a : α) (u : αˣ) : a /ₚ u * u = a :=
 theorem mul_divp_cancel (a : α) (u : αˣ) : a * u /ₚ u = a :=
   (mul_assoc _ _ _).trans <| by rw [Units.mul_inv, mul_one]
 
-@[simp]
-theorem divp_left_inj (u : αˣ) {a b : α} : a /ₚ u = b /ₚ u ↔ a = b :=
-  Units.mul_left_inj _
-
 @[field_simps]
 theorem divp_divp_eq_divp_mul (x : α) (u₁ u₂ : αˣ) : x /ₚ u₁ /ₚ u₂ = x /ₚ (u₂ * u₁) := by
   simp only [divp, mul_inv_rev, Units.val_mul, mul_assoc]
-
-/- Porting note: to match the mathlib3 behavior, this needs to have higher simp
-priority than eq_divp_iff_mul_eq. -/
-@[field_simps 1010]
-theorem divp_eq_iff_mul_eq {x : α} {u : αˣ} {y : α} : x /ₚ u = y ↔ y * u = x :=
-  u.mul_left_inj.symm.trans <| by rw [divp_mul_cancel]; exact ⟨Eq.symm, Eq.symm⟩
-
-@[field_simps]
-theorem eq_divp_iff_mul_eq {x : α} {u : αˣ} {y : α} : x = y /ₚ u ↔ x * u = y := by
-  rw [eq_comm, divp_eq_iff_mul_eq]
-
-theorem divp_eq_one_iff_eq {a : α} {u : αˣ} : a /ₚ u = 1 ↔ a = u :=
-  (Units.mul_left_inj u).symm.trans <| by rw [divp_mul_cancel, one_mul]
 
 @[simp]
 theorem one_divp (u : αˣ) : 1 /ₚ u = ↑u⁻¹ :=
@@ -446,14 +346,6 @@ theorem one_divp (u : αˣ) : 1 /ₚ u = ↑u⁻¹ :=
 /-- Used for `field_simp` to deal with inverses of units. -/
 @[field_simps]
 theorem inv_eq_one_divp (u : αˣ) : ↑u⁻¹ = 1 /ₚ u := by rw [one_divp]
-
-/-- Used for `field_simp` to deal with inverses of units. This form of the lemma
-is essential since `field_simp` likes to use `inv_eq_one_div` to rewrite
-`↑u⁻¹ = ↑(1 / u)`.
--/
-@[field_simps]
-theorem inv_eq_one_divp' (u : αˣ) : ((1 / u : αˣ) : α) = 1 /ₚ u := by
-  rw [one_div, one_divp]
 
 /-- `field_simp` moves division inside `αˣ` to the right, and this lemma
 lifts the calculation to `α`.
@@ -464,114 +356,9 @@ theorem val_div_eq_divp (u₁ u₂ : αˣ) : ↑(u₁ / u₂) = ↑u₁ /ₚ u�
 
 end Monoid
 
-namespace LeftCancelMonoid
-
-variable [LeftCancelMonoid α] [Subsingleton αˣ] {a b : α}
-
-@[to_additive]
-protected theorem eq_one_of_mul_right (h : a * b = 1) : a = 1 :=
-  congr_arg Units.inv <| Subsingleton.elim (Units.mk _ _ (by
-    rw [← mul_left_cancel_iff (a := a), ← mul_assoc, h, one_mul, mul_one]) h) 1
-
-@[to_additive]
-protected theorem eq_one_of_mul_left (h : a * b = 1) : b = 1 := by
-  rwa [LeftCancelMonoid.eq_one_of_mul_right h, one_mul] at h
-
-@[to_additive (attr := simp)]
-protected theorem mul_eq_one : a * b = 1 ↔ a = 1 ∧ b = 1 :=
-  ⟨fun h => ⟨LeftCancelMonoid.eq_one_of_mul_right h, LeftCancelMonoid.eq_one_of_mul_left h⟩, by
-    rintro ⟨rfl, rfl⟩
-    exact mul_one _⟩
-
-@[to_additive]
-protected theorem mul_ne_one : a * b ≠ 1 ↔ a ≠ 1 ∨ b ≠ 1 := by rw [not_iff_comm]; simp
-
-end LeftCancelMonoid
-
-namespace RightCancelMonoid
-
-variable [RightCancelMonoid α] [Subsingleton αˣ] {a b : α}
-
-@[to_additive]
-protected theorem eq_one_of_mul_right (h : a * b = 1) : a = 1 :=
-  congr_arg Units.inv <| Subsingleton.elim (Units.mk _ _ (by
-    rw [← mul_right_cancel_iff (a := b), mul_assoc, h, one_mul, mul_one]) h) 1
-
-@[to_additive]
-protected theorem eq_one_of_mul_left (h : a * b = 1) : b = 1 := by
-  rwa [RightCancelMonoid.eq_one_of_mul_right h, one_mul] at h
-
-@[to_additive (attr := simp)]
-protected theorem mul_eq_one : a * b = 1 ↔ a = 1 ∧ b = 1 :=
-  ⟨fun h => ⟨RightCancelMonoid.eq_one_of_mul_right h, RightCancelMonoid.eq_one_of_mul_left h⟩, by
-    rintro ⟨rfl, rfl⟩
-    exact mul_one _⟩
-
-@[to_additive]
-protected theorem mul_ne_one : a * b ≠ 1 ↔ a ≠ 1 ∨ b ≠ 1 := by rw [not_iff_comm]; simp
-
-end RightCancelMonoid
-
-section CancelMonoid
-
-variable [CancelMonoid α] [Subsingleton αˣ] {a b : α}
-
-@[to_additive]
-theorem eq_one_of_mul_right' (h : a * b = 1) : a = 1 := LeftCancelMonoid.eq_one_of_mul_right h
-
-@[to_additive]
-theorem eq_one_of_mul_left' (h : a * b = 1) : b = 1 := LeftCancelMonoid.eq_one_of_mul_left h
-
-@[to_additive]
-theorem mul_eq_one' : a * b = 1 ↔ a = 1 ∧ b = 1 := LeftCancelMonoid.mul_eq_one
-
-@[to_additive]
-theorem mul_ne_one' : a * b ≠ 1 ↔ a ≠ 1 ∨ b ≠ 1 := LeftCancelMonoid.mul_ne_one
-
-end CancelMonoid
-
-section CommMonoid
-
-variable [CommMonoid α]
-
-@[field_simps]
-theorem divp_mul_eq_mul_divp (x y : α) (u : αˣ) : x /ₚ u * y = x * y /ₚ u := by
-  rw [divp, divp, mul_right_comm]
-
--- Theoretically redundant as `field_simp` lemma.
-@[field_simps]
-theorem divp_eq_divp_iff {x y : α} {ux uy : αˣ} : x /ₚ ux = y /ₚ uy ↔ x * uy = y * ux := by
-  rw [divp_eq_iff_mul_eq, divp_mul_eq_mul_divp, divp_eq_iff_mul_eq]
-
--- Theoretically redundant as `field_simp` lemma.
-@[field_simps]
-theorem divp_mul_divp (x y : α) (ux uy : αˣ) : x /ₚ ux * (y /ₚ uy) = x * y /ₚ (ux * uy) := by
-  rw [divp_mul_eq_mul_divp, divp_assoc', divp_divp_eq_divp_mul]
-
-variable [Subsingleton αˣ] {a b : α}
-
-@[to_additive]
-theorem eq_one_of_mul_right (h : a * b = 1) : a = 1 :=
-  congr_arg Units.inv <| Subsingleton.elim (Units.mk _ _ (by rwa [mul_comm]) h) 1
-
-@[to_additive]
-theorem eq_one_of_mul_left (h : a * b = 1) : b = 1 :=
-  congr_arg Units.inv <| Subsingleton.elim (Units.mk _ _ h <| by rwa [mul_comm]) 1
-
-@[to_additive (attr := simp)]
-theorem mul_eq_one : a * b = 1 ↔ a = 1 ∧ b = 1 :=
-  ⟨fun h => ⟨eq_one_of_mul_right h, eq_one_of_mul_left h⟩, by
-    rintro ⟨rfl, rfl⟩
-    exact mul_one _⟩
-
-@[to_additive] theorem mul_ne_one : a * b ≠ 1 ↔ a ≠ 1 ∨ b ≠ 1 := by rw [not_iff_comm]; simp
-
-end CommMonoid
-
 /-!
 # `IsUnit` predicate
 -/
-
 
 section IsUnit
 
@@ -601,19 +388,6 @@ theorem isUnit_iff_exists_and_exists [Monoid M] {a : M} :
   isUnit_iff_exists.trans
     ⟨fun ⟨b, hba, hab⟩ => ⟨⟨b, hba⟩, ⟨b, hab⟩⟩,
       fun ⟨⟨b, hb⟩, ⟨_, hc⟩⟩ => ⟨b, hb, left_inv_eq_right_inv hc hb ▸ hc⟩⟩
-
-@[to_additive (attr := nontriviality)]
-theorem isUnit_of_subsingleton [Monoid M] [Subsingleton M] (a : M) : IsUnit a :=
-  ⟨⟨a, a, by subsingleton, by subsingleton⟩, rfl⟩
-
-@[to_additive]
-instance [Monoid M] : CanLift M Mˣ Units.val IsUnit :=
-  { prf := fun _ ↦ id }
-
-/-- A subsingleton `Monoid` has a unique unit. -/
-@[to_additive "A subsingleton `AddMonoid` has a unique additive unit."]
-instance [Monoid M] [Subsingleton M] : Unique Mˣ where
-  uniq _ := Units.val_eq_one.mp (by subsingleton)
 
 @[to_additive (attr := simp)]
 protected theorem Units.isUnit [Monoid M] (u : Mˣ) : IsUnit (u : M) :=
@@ -650,8 +424,6 @@ lemma IsUnit.exists_left_inv {a : M} (h : IsUnit a) : ∃ b, b * a = 1 := by
 
 @[to_additive] lemma IsUnit.pow (n : ℕ) : IsUnit a → IsUnit (a ^ n) := by
   rintro ⟨u, rfl⟩; exact ⟨u ^ n, rfl⟩
-
-theorem units_eq_one [Subsingleton Mˣ] (u : Mˣ) : u = 1 := by subsingleton
 
 @[to_additive] lemma isUnit_iff_eq_one [Subsingleton Mˣ] {x : M} : IsUnit x ↔ x = 1 :=
   ⟨fun ⟨u, hu⟩ ↦ by rw [← hu, Subsingleton.elim u 1, Units.val_one], fun h ↦ h ▸ isUnit_one⟩
@@ -746,46 +518,6 @@ theorem mul_val_inv (h : IsUnit a) : a * ↑h.unit⁻¹ = 1 := by
 instance (x : M) [h : Decidable (∃ u : Mˣ, ↑u = x)] : Decidable (IsUnit x) :=
   h
 
-@[to_additive]
-theorem mul_left_inj (h : IsUnit a) : b * a = c * a ↔ b = c :=
-  let ⟨u, hu⟩ := h
-  hu ▸ u.mul_left_inj
-
-@[to_additive]
-theorem mul_right_inj (h : IsUnit a) : a * b = a * c ↔ b = c :=
-  let ⟨u, hu⟩ := h
-  hu ▸ u.mul_right_inj
-
-@[to_additive]
-protected theorem mul_left_cancel (h : IsUnit a) : a * b = a * c → b = c :=
-  h.mul_right_inj.1
-
-@[to_additive]
-protected theorem mul_right_cancel (h : IsUnit b) : a * b = c * b → a = c :=
-  h.mul_left_inj.1
-
-@[to_additive]
-protected theorem mul_right_injective (h : IsUnit a) : Injective (a * ·) :=
-  fun _ _ => h.mul_left_cancel
-
-@[to_additive]
-protected theorem mul_left_injective (h : IsUnit b) : Injective (· * b) :=
-  fun _ _ => h.mul_right_cancel
-
-@[to_additive]
-theorem isUnit_iff_mulLeft_bijective {a : M} :
-    IsUnit a ↔ Function.Bijective (a * ·) :=
-  ⟨fun h ↦ ⟨h.mul_right_injective, fun y ↦ ⟨h.unit⁻¹ * y, by simp [← mul_assoc]⟩⟩, fun h ↦
-    ⟨⟨a, _, (h.2 1).choose_spec, h.1
-      (by simpa [mul_assoc] using congr_arg (· * a) (h.2 1).choose_spec)⟩, rfl⟩⟩
-
-@[to_additive]
-theorem isUnit_iff_mulRight_bijective {a : M} :
-    IsUnit a ↔ Function.Bijective (· * a) :=
-  ⟨fun h ↦ ⟨h.mul_left_injective, fun y ↦ ⟨y * h.unit⁻¹, by simp [mul_assoc]⟩⟩,
-    fun h ↦ ⟨⟨a, _, h.1 (by simpa [mul_assoc] using congr_arg (a * ·) (h.2 1).choose_spec),
-      (h.2 1).choose_spec⟩, rfl⟩⟩
-
 end Monoid
 
 section DivisionMonoid
@@ -822,62 +554,8 @@ protected lemma mul_inv_cancel_left (h : IsUnit a) : ∀ b, a * (a⁻¹ * b) = b
 protected lemma inv_mul_cancel_left (h : IsUnit a) : ∀ b, a⁻¹ * (a * b) = b :=
   h.unit'.inv_mul_cancel_left
 
-@[to_additive (attr := simp)]
-protected lemma mul_inv_cancel_right (h : IsUnit b) (a : α) : a * b * b⁻¹ = a :=
-  h.unit'.mul_inv_cancel_right _
-
-@[to_additive (attr := simp)]
-protected lemma inv_mul_cancel_right (h : IsUnit b) (a : α) : a * b⁻¹ * b = a :=
-  h.unit'.inv_mul_cancel_right _
-
 @[to_additive]
 protected lemma div_self (h : IsUnit a) : a / a = 1 := by rw [div_eq_mul_inv, h.mul_inv_cancel]
-
-@[to_additive]
-protected lemma eq_mul_inv_iff_mul_eq (h : IsUnit c) : a = b * c⁻¹ ↔ a * c = b :=
-  h.unit'.eq_mul_inv_iff_mul_eq
-
-@[to_additive]
-protected lemma eq_inv_mul_iff_mul_eq (h : IsUnit b) : a = b⁻¹ * c ↔ b * a = c :=
-  h.unit'.eq_inv_mul_iff_mul_eq
-
-@[to_additive]
-protected lemma inv_mul_eq_iff_eq_mul (h : IsUnit a) : a⁻¹ * b = c ↔ b = a * c :=
-  h.unit'.inv_mul_eq_iff_eq_mul
-
-@[to_additive]
-protected lemma mul_inv_eq_iff_eq_mul (h : IsUnit b) : a * b⁻¹ = c ↔ a = c * b :=
-  h.unit'.mul_inv_eq_iff_eq_mul
-
-@[to_additive]
-protected lemma mul_inv_eq_one (h : IsUnit b) : a * b⁻¹ = 1 ↔ a = b :=
-  @Units.mul_inv_eq_one _ _ h.unit' _
-
-@[to_additive]
-protected lemma inv_mul_eq_one (h : IsUnit a) : a⁻¹ * b = 1 ↔ a = b :=
-  @Units.inv_mul_eq_one _ _ h.unit' _
-
-@[to_additive]
-protected lemma mul_eq_one_iff_eq_inv (h : IsUnit b) : a * b = 1 ↔ a = b⁻¹ :=
-  @Units.mul_eq_one_iff_eq_inv _ _ h.unit' _
-
-@[to_additive]
-protected lemma mul_eq_one_iff_inv_eq (h : IsUnit a) : a * b = 1 ↔ a⁻¹ = b :=
-  @Units.mul_eq_one_iff_inv_eq _ _ h.unit' _
-
-@[to_additive (attr := simp)]
-protected lemma div_mul_cancel (h : IsUnit b) (a : α) : a / b * b = a := by
-  rw [div_eq_mul_inv, h.inv_mul_cancel_right]
-
-@[to_additive (attr := simp)]
-protected lemma mul_div_cancel_right (h : IsUnit b) (a : α) : a * b / b = a := by
-  rw [div_eq_mul_inv, h.mul_inv_cancel_right]
-
-@[to_additive]
-protected lemma mul_one_div_cancel (h : IsUnit a) : a * (1 / a) = 1 := by simp [h]
-
-@[to_additive]
-protected lemma one_div_mul_cancel (h : IsUnit a) : 1 / a * a = 1 := by simp [h]
 
 @[to_additive]
 lemma inv (h : IsUnit a) : IsUnit a⁻¹ := by
@@ -889,44 +567,12 @@ lemma inv (h : IsUnit a) : IsUnit a⁻¹ := by
   rw [div_eq_mul_inv]; exact ha.mul hb.inv
 
 @[to_additive]
-protected lemma div_left_inj (h : IsUnit c) : a / c = b / c ↔ a = b := by
-  simp only [div_eq_mul_inv]
-  exact Units.mul_left_inj h.inv.unit'
-
-@[to_additive]
-protected lemma div_eq_iff (h : IsUnit b) : a / b = c ↔ a = c * b := by
-  rw [div_eq_mul_inv, h.mul_inv_eq_iff_eq_mul]
-
-@[to_additive]
-protected lemma eq_div_iff (h : IsUnit c) : a = b / c ↔ a * c = b := by
-  rw [div_eq_mul_inv, h.eq_mul_inv_iff_mul_eq]
-
-@[to_additive]
-protected lemma div_eq_of_eq_mul (h : IsUnit b) : a = c * b → a / b = c :=
-  h.div_eq_iff.2
-
-@[to_additive]
-protected lemma eq_div_of_mul_eq (h : IsUnit c) : a * c = b → a = b / c :=
-  h.eq_div_iff.2
-
-@[to_additive]
-protected lemma div_eq_one_iff_eq (h : IsUnit b) : a / b = 1 ↔ a = b :=
-  ⟨eq_of_div_eq_one, fun hab => hab.symm ▸ h.div_self⟩
-
-@[to_additive]
 protected lemma div_mul_cancel_right (h : IsUnit b) (a : α) : b / (a * b) = a⁻¹ := by
   rw [div_eq_mul_inv, mul_inv_rev, h.mul_inv_cancel_left]
 
 @[to_additive]
-protected lemma div_mul_left (h : IsUnit b) : b / (a * b) = 1 / a := by
-  rw [h.div_mul_cancel_right, one_div]
-
-@[to_additive]
 protected lemma mul_div_mul_right (h : IsUnit c) (a b : α) : a * c / (b * c) = a / b := by
   simp only [div_eq_mul_inv, mul_inv_rev, mul_assoc, h.mul_inv_cancel_left]
-
-@[to_additive]
-protected lemma mul_mul_div (a : α) (h : IsUnit b) : a * b * (1 / b) = a := by simp [h]
 
 end DivisionMonoid
 
@@ -938,39 +584,8 @@ protected lemma div_mul_cancel_left (h : IsUnit a) (b : α) : a / (a * b) = b⁻
   rw [mul_comm, h.div_mul_cancel_right]
 
 @[to_additive]
-protected lemma div_mul_right (h : IsUnit a) (b : α) : a / (a * b) = 1 / b := by
-  rw [mul_comm, h.div_mul_left]
-
-@[to_additive]
-protected lemma mul_div_cancel_left (h : IsUnit a) (b : α) : a * b / a = b := by
-  rw [mul_comm, h.mul_div_cancel_right]
-
-@[to_additive]
-protected lemma mul_div_cancel (h : IsUnit a) (b : α) : a * (b / a) = b := by
-  rw [mul_comm, h.div_mul_cancel]
-
-@[to_additive]
 protected lemma mul_div_mul_left (h : IsUnit c) (a b : α) : c * a / (c * b) = a / b := by
   rw [mul_comm c, mul_comm c, h.mul_div_mul_right]
-
-@[to_additive]
-protected lemma mul_eq_mul_of_div_eq_div (hb : IsUnit b) (hd : IsUnit d)
-    (a c : α) (h : a / b = c / d) : a * d = c * b := by
-  rw [← mul_one a, ← hb.div_self, ← mul_comm_div, h, div_mul_eq_mul_div, hd.div_mul_cancel]
-
-@[to_additive]
-protected lemma div_eq_div_iff (hb : IsUnit b) (hd : IsUnit d) :
-    a / b = c / d ↔ a * d = c * b := by
-  rw [← (hb.mul hd).mul_left_inj, ← mul_assoc, hb.div_mul_cancel, ← mul_assoc, mul_right_comm,
-    hd.div_mul_cancel]
-
-@[to_additive]
-protected lemma div_div_cancel (h : IsUnit a) : a / (a / b) = b := by
-  rw [div_div_eq_mul_div, h.mul_div_cancel_left]
-
-@[to_additive]
-protected lemma div_div_cancel_left (h : IsUnit a) : a / b / a = b⁻¹ := by
-  rw [div_eq_mul_inv, div_eq_mul_inv, mul_right_comm, h.mul_inv_cancel, one_mul]
 
 end DivisionCommMonoid
 end IsUnit
@@ -1012,14 +627,3 @@ noncomputable def commGroupOfIsUnit [hM : CommMonoid M] (h : ∀ a : M, IsUnit a
       rw [Units.inv_mul_eq_iff_eq_mul, (h a).unit_spec, mul_one] }
 
 end NoncomputableDefs
-
-attribute [deprecated div_mul_cancel_right (since := "2024-03-20")] IsUnit.div_mul_left
-attribute [deprecated sub_add_cancel_right (since := "2024-03-20")] IsAddUnit.sub_add_left
-attribute [deprecated div_mul_cancel_left (since := "2024-03-20")] IsUnit.div_mul_right
-attribute [deprecated sub_add_cancel_left (since := "2024-03-20")] IsAddUnit.sub_add_right
--- The names `IsUnit.mul_div_cancel` and `IsAddUnit.add_sub_cancel` have been reused
--- @[deprecated (since := "2024-03-20")] alias IsUnit.mul_div_cancel := IsUnit.mul_div_cancel_right
--- @[deprecated (since := "2024-03-20")]
--- alias IsAddUnit.add_sub_cancel := IsAddUnit.add_sub_cancel_right
-@[deprecated (since := "2024-03-20")] alias IsUnit.mul_div_cancel' := IsUnit.mul_div_cancel
-@[deprecated (since := "2024-03-20")] alias IsAddUnit.add_sub_cancel' := IsAddUnit.add_sub_cancel

--- a/Mathlib/Algebra/Group/Units/Hom.lean
+++ b/Mathlib/Algebra/Group/Units/Hom.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johan Commelin, Chris Hughes, Kevin Buzzard
 -/
 import Mathlib.Algebra.Group.Hom.Defs
-import Mathlib.Algebra.Group.Units
+import Mathlib.Algebra.Group.Units.Basic
 
 /-!
 # Monoid homomorphisms and units

--- a/Mathlib/Algebra/GroupWithZero/Units/Basic.lean
+++ b/Mathlib/Algebra/GroupWithZero/Units/Basic.lean
@@ -3,7 +3,7 @@ Copyright (c) 2020 Johan Commelin. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johan Commelin
 -/
-import Mathlib.Algebra.Group.Units
+import Mathlib.Algebra.Group.Units.Basic
 import Mathlib.Algebra.GroupWithZero.Basic
 import Mathlib.Logic.Equiv.Defs
 import Mathlib.Tactic.Contrapose

--- a/Mathlib/Algebra/Order/Monoid/Canonical/Defs.lean
+++ b/Mathlib/Algebra/Order/Monoid/Canonical/Defs.lean
@@ -3,7 +3,7 @@ Copyright (c) 2016 Jeremy Avigad. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Jeremy Avigad, Leonardo de Moura, Mario Carneiro, Johannes Hölzl
 -/
-import Mathlib.Algebra.Group.Units
+import Mathlib.Algebra.Group.Units.Basic
 import Mathlib.Algebra.Order.Monoid.Defs
 import Mathlib.Algebra.Order.Monoid.Unbundled.ExistsOfLE
 import Mathlib.Algebra.NeZero

--- a/Mathlib/Algebra/Order/Monoid/Units.lean
+++ b/Mathlib/Algebra/Order/Monoid/Units.lean
@@ -5,7 +5,7 @@ Authors: Jeremy Avigad, Leonardo de Moura, Mario Carneiro, Johannes Hölzl
 -/
 import Mathlib.Order.Hom.Basic
 import Mathlib.Order.MinMax
-import Mathlib.Algebra.Group.Units.Basic
+import Mathlib.Algebra.Group.Units.Defs
 
 /-!
 # Units in ordered monoids

--- a/Mathlib/Algebra/Order/Monoid/Units.lean
+++ b/Mathlib/Algebra/Order/Monoid/Units.lean
@@ -5,7 +5,7 @@ Authors: Jeremy Avigad, Leonardo de Moura, Mario Carneiro, Johannes Hölzl
 -/
 import Mathlib.Order.Hom.Basic
 import Mathlib.Order.MinMax
-import Mathlib.Algebra.Group.Units
+import Mathlib.Algebra.Group.Units.Basic
 
 /-!
 # Units in ordered monoids

--- a/Mathlib/Algebra/Order/Ring/Unbundled/Basic.lean
+++ b/Mathlib/Algebra/Order/Ring/Unbundled/Basic.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Jeremy Avigad, Leonardo de Moura, Mario Carneiro, Yaël Dillies
 -/
 import Mathlib.Algebra.Group.Pi.Basic
-import Mathlib.Algebra.Group.Units
+import Mathlib.Algebra.Group.Units.Basic
 import Mathlib.Algebra.GroupWithZero.NeZero
 import Mathlib.Algebra.Order.Group.Unbundled.Basic
 import Mathlib.Algebra.Order.GroupWithZero.Unbundled

--- a/Mathlib/Algebra/Regular/Basic.lean
+++ b/Mathlib/Algebra/Regular/Basic.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Damiano Testa
 -/
 import Mathlib.Algebra.Group.Commute.Defs
-import Mathlib.Algebra.Group.Units.Basic
+import Mathlib.Algebra.Group.Units.Defs
 import Mathlib.Algebra.GroupWithZero.Defs
 import Mathlib.Algebra.Order.Monoid.Unbundled.Basic
 import Mathlib.Tactic.NthRewrite

--- a/Mathlib/Algebra/Regular/Basic.lean
+++ b/Mathlib/Algebra/Regular/Basic.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Damiano Testa
 -/
 import Mathlib.Algebra.Group.Commute.Defs
-import Mathlib.Algebra.Group.Units
+import Mathlib.Algebra.Group.Units.Basic
 import Mathlib.Algebra.GroupWithZero.Defs
 import Mathlib.Algebra.Order.Monoid.Unbundled.Basic
 import Mathlib.Tactic.NthRewrite

--- a/Mathlib/CategoryTheory/Endomorphism.lean
+++ b/Mathlib/CategoryTheory/Endomorphism.lean
@@ -5,7 +5,7 @@ Authors: Yury Kudryashov, Kim Morrison, Simon Hudon
 -/
 import Mathlib.Algebra.Group.Action.Defs
 import Mathlib.Algebra.Group.Equiv.Basic
-import Mathlib.Algebra.Group.Units
+import Mathlib.Algebra.Group.Units.Basic
 import Mathlib.Algebra.Group.Units.Hom
 import Mathlib.CategoryTheory.Groupoid
 import Mathlib.CategoryTheory.Opposites

--- a/Mathlib/Data/Nat/Bits.lean
+++ b/Mathlib/Data/Nat/Bits.lean
@@ -5,6 +5,7 @@ Authors: Praneeth Kolichala
 -/
 import Mathlib.Algebra.Group.Basic
 import Mathlib.Algebra.Group.Nat
+import Mathlib.Algebra.Group.Units.Basic
 import Mathlib.Data.Nat.Defs
 import Mathlib.Data.List.Defs
 import Mathlib.Tactic.Convert

--- a/Mathlib/RingTheory/LocalRing/Defs.lean
+++ b/Mathlib/RingTheory/LocalRing/Defs.lean
@@ -3,7 +3,7 @@ Copyright (c) 2018 Kenny Lau. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Kenny Lau, Chris Hughes, Mario Carneiro
 -/
-import Mathlib.Algebra.Group.Units.Basic
+import Mathlib.Algebra.Group.Units.Defs
 import Mathlib.Algebra.Ring.Defs
 
 /-!

--- a/Mathlib/RingTheory/LocalRing/Defs.lean
+++ b/Mathlib/RingTheory/LocalRing/Defs.lean
@@ -3,7 +3,7 @@ Copyright (c) 2018 Kenny Lau. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Kenny Lau, Chris Hughes, Mario Carneiro
 -/
-import Mathlib.Algebra.Group.Units
+import Mathlib.Algebra.Group.Units.Basic
 import Mathlib.Algebra.Ring.Defs
 
 /-!

--- a/Mathlib/RingTheory/MvPowerSeries/Inverse.lean
+++ b/Mathlib/RingTheory/MvPowerSeries/Inverse.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johan Commelin, Kenny Lau
 -/
 
-import Mathlib.Algebra.Group.Units
+import Mathlib.Algebra.Group.Units.Basic
 import Mathlib.RingTheory.MvPowerSeries.Basic
 import Mathlib.RingTheory.MvPowerSeries.NoZeroDivisors
 import Mathlib.RingTheory.LocalRing.Basic

--- a/Mathlib/Tactic/FieldSimp.lean
+++ b/Mathlib/Tactic/FieldSimp.lean
@@ -6,7 +6,7 @@ Authors: Sébastien Gouëzel, David Renshaw
 
 import Lean.Elab.Tactic.Basic
 import Lean.Meta.Tactic.Simp.Main
-import Mathlib.Algebra.Group.Units
+import Mathlib.Algebra.Group.Units.Basic
 import Mathlib.Tactic.Positivity.Core
 import Mathlib.Tactic.NormNum.Core
 import Mathlib.Util.DischargerAsTactic

--- a/scripts/noshake.json
+++ b/scripts/noshake.json
@@ -213,8 +213,7 @@
   "Mathlib.Tactic.TermCongr": ["Mathlib.Logic.Basic"],
   "Mathlib.Tactic.Tauto": ["Mathlib.Logic.Basic"],
   "Mathlib.Tactic.TFAE": ["Mathlib.Data.List.TFAE", "Mathlib.Tactic.Have"],
-  "Mathlib.Tactic.Subsingleton":
-  ["Mathlib.Algebra.Group.Units.Basic", "Mathlib.Logic.Basic", "Std.Logic"],
+  "Mathlib.Tactic.Subsingleton": ["Mathlib.Logic.Basic", "Std.Logic"],
   "Mathlib.Tactic.ReduceModChar":
   ["Mathlib.Data.ZMod.Basic", "Mathlib.RingTheory.Polynomial.Basic"],
   "Mathlib.Tactic.ProxyType": ["Mathlib.Logic.Equiv.Defs"],
@@ -419,6 +418,7 @@
   "Mathlib.Algebra.Module.LinearMap.Basic": ["Mathlib.Algebra.Star.Basic"],
   "Mathlib.Algebra.Module.Equiv": ["Mathlib.Algebra.Star.Basic"],
   "Mathlib.Algebra.Homology.ModuleCat": ["Mathlib.Algebra.Homology.Homotopy"],
+  "Mathlib.Algebra.Group.Units.Basic": ["Mathlib.Tactic.Subsingleton"],
   "Mathlib.Algebra.Group.Units": ["Mathlib.Tactic.Subsingleton"],
   "Mathlib.Algebra.Group.Pi.Basic": ["Batteries.Tactic.Classical"],
   "Mathlib.Algebra.Group.Defs": ["Mathlib.Data.Int.Notation"],

--- a/scripts/noshake.json
+++ b/scripts/noshake.json
@@ -213,7 +213,8 @@
   "Mathlib.Tactic.TermCongr": ["Mathlib.Logic.Basic"],
   "Mathlib.Tactic.Tauto": ["Mathlib.Logic.Basic"],
   "Mathlib.Tactic.TFAE": ["Mathlib.Data.List.TFAE", "Mathlib.Tactic.Have"],
-  "Mathlib.Tactic.Subsingleton": ["Mathlib.Logic.Basic", "Std.Logic"],
+  "Mathlib.Tactic.Subsingleton":
+  ["Mathlib.Algebra.Group.Units.Basic", "Mathlib.Logic.Basic", "Std.Logic"],
   "Mathlib.Tactic.ReduceModChar":
   ["Mathlib.Data.ZMod.Basic", "Mathlib.RingTheory.Polynomial.Basic"],
   "Mathlib.Tactic.ProxyType": ["Mathlib.Logic.Equiv.Defs"],


### PR DESCRIPTION
The criteria for including a result in `Algebra.Group.Unit.Defs`:
 * Can it be defined with only `Defs` imports?
 * Is it needed for a subsequent `def` or `instance`?

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
