### PR TITLE
[Merged by Bors] - chore: do not depend on CategoryTheory in Module.Injective

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -100,6 +100,7 @@ import Mathlib.Algebra.Category.ModuleCat.ChangeOfRings
 import Mathlib.Algebra.Category.ModuleCat.Colimits
 import Mathlib.Algebra.Category.ModuleCat.Differentials.Basic
 import Mathlib.Algebra.Category.ModuleCat.Differentials.Presheaf
+import Mathlib.Algebra.Category.ModuleCat.EnoughInjectives
 import Mathlib.Algebra.Category.ModuleCat.EpiMono
 import Mathlib.Algebra.Category.ModuleCat.FilteredColimits
 import Mathlib.Algebra.Category.ModuleCat.Free

--- a/Mathlib/Algebra/Category/Grp/EnoughInjectives.lean
+++ b/Mathlib/Algebra/Category/Grp/EnoughInjectives.lean
@@ -7,6 +7,7 @@ Authors: Jujian Zhang, Junyan Xu
 import Mathlib.Algebra.Module.CharacterModule
 import Mathlib.Algebra.Category.Grp.EquivalenceGroupAddGroup
 import Mathlib.Algebra.Category.Grp.EpiMono
+import Mathlib.Algebra.Category.Grp.Injective
 
 /-!
 
@@ -17,8 +18,7 @@ injective presentation for `A`, hence category of abelian groups has enough inje
 
 ## Implementation notes
 
-This file is split from `Mathlib.Algebra.Grp.Injective` is to prevent import loop.
-This file's dependency imports `Mathlib.Algebra.Grp.Injective`.
+This file is split from `Mathlib.Algebra.Category.Grp.Injective` to prevent import loops.
 -/
 
 open CategoryTheory

--- a/Mathlib/Algebra/Category/Grp/Injective.lean
+++ b/Mathlib/Algebra/Category/Grp/Injective.lean
@@ -3,9 +3,11 @@ Copyright (c) 2022 Jujian Zhang. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Jujian Zhang
 -/
+import Mathlib.Algebra.Category.ModuleCat.EpiMono
 import Mathlib.Algebra.Category.Grp.ZModuleEquivalence
 import Mathlib.Algebra.EuclideanDomain.Int
 import Mathlib.Algebra.Module.Injective
+import Mathlib.CategoryTheory.Preadditive.Injective
 import Mathlib.RingTheory.PrincipalIdealDomain
 import Mathlib.Topology.Instances.AddCircle
 
@@ -53,6 +55,31 @@ theorem Module.Baer.of_divisible [DivisibleBy A ℤ] : Module.Baer ℤ A := fun 
   rcases Submodule.mem_span_singleton.mp hn with ⟨n, rfl⟩
   rw [map_zsmul, LinearMap.toSpanSingleton_apply, DivisibleBy.div_cancel gₘ h0, ← map_zsmul g,
     SetLike.mk_smul_mk]
+
+namespace Module
+variable (R Q : Type*) [Ring R] [AddCommGroup Q] [Module R Q]
+
+theorem injective_object_of_injective_module [inj : Injective R Q] :
+    CategoryTheory.Injective (ModuleCat.of R Q) where
+  factors g f m :=
+    have ⟨l, h⟩ := inj.out f ((ModuleCat.mono_iff_injective f).mp m) g
+    ⟨l, LinearMap.ext h⟩
+
+theorem injective_module_of_injective_object
+    [inj : CategoryTheory.Injective <| ModuleCat.of R Q] :
+    Module.Injective R Q where
+  out X Y _ _ _ _ f hf g := by
+    have : CategoryTheory.Mono (ModuleCat.asHom f) := (ModuleCat.mono_iff_injective _).mpr hf
+    obtain ⟨l, rfl⟩ := inj.factors (ModuleCat.asHom g) (ModuleCat.asHom f)
+    exact ⟨l, fun _ ↦ rfl⟩
+
+theorem injective_iff_injective_object :
+    Module.Injective R Q ↔
+    CategoryTheory.Injective (ModuleCat.of R Q) :=
+  ⟨fun _ => injective_object_of_injective_module R Q,
+   fun _ => injective_module_of_injective_object R Q⟩
+
+end Module
 
 namespace AddCommGrp
 

--- a/Mathlib/Algebra/Category/Grp/Injective.lean
+++ b/Mathlib/Algebra/Category/Grp/Injective.lean
@@ -6,7 +6,7 @@ Authors: Jujian Zhang
 import Mathlib.Algebra.Category.ModuleCat.EpiMono
 import Mathlib.Algebra.Category.Grp.ZModuleEquivalence
 import Mathlib.Algebra.EuclideanDomain.Int
-import Mathlib.Algebra.Module.Injective
+import Mathlib.Algebra.Category.ModuleCat.Injective
 import Mathlib.CategoryTheory.Preadditive.Injective
 import Mathlib.RingTheory.PrincipalIdealDomain
 import Mathlib.Topology.Instances.AddCircle
@@ -41,45 +41,6 @@ open Pointwise
 universe u
 
 variable (A : Type u) [AddCommGroup A]
-
-
-theorem Module.Baer.of_divisible [DivisibleBy A ℤ] : Module.Baer ℤ A := fun I g ↦ by
-  rcases IsPrincipalIdealRing.principal I with ⟨m, rfl⟩
-  obtain rfl | h0 := eq_or_ne m 0
-  · refine ⟨0, fun n hn ↦ ?_⟩
-    rw [Submodule.span_zero_singleton] at hn
-    subst hn
-    exact (map_zero g).symm
-  let gₘ := g ⟨m, Submodule.subset_span (Set.mem_singleton _)⟩
-  refine ⟨LinearMap.toSpanSingleton ℤ A (DivisibleBy.div gₘ m), fun n hn ↦ ?_⟩
-  rcases Submodule.mem_span_singleton.mp hn with ⟨n, rfl⟩
-  rw [map_zsmul, LinearMap.toSpanSingleton_apply, DivisibleBy.div_cancel gₘ h0, ← map_zsmul g,
-    SetLike.mk_smul_mk]
-
-namespace Module
-variable (R Q : Type*) [Ring R] [AddCommGroup Q] [Module R Q]
-
-theorem injective_object_of_injective_module [inj : Injective R Q] :
-    CategoryTheory.Injective (ModuleCat.of R Q) where
-  factors g f m :=
-    have ⟨l, h⟩ := inj.out f ((ModuleCat.mono_iff_injective f).mp m) g
-    ⟨l, LinearMap.ext h⟩
-
-theorem injective_module_of_injective_object
-    [inj : CategoryTheory.Injective <| ModuleCat.of R Q] :
-    Module.Injective R Q where
-  out X Y _ _ _ _ f hf g := by
-    have : CategoryTheory.Mono (ModuleCat.asHom f) := (ModuleCat.mono_iff_injective _).mpr hf
-    obtain ⟨l, rfl⟩ := inj.factors (ModuleCat.asHom g) (ModuleCat.asHom f)
-    exact ⟨l, fun _ ↦ rfl⟩
-
-theorem injective_iff_injective_object :
-    Module.Injective R Q ↔
-    CategoryTheory.Injective (ModuleCat.of R Q) :=
-  ⟨fun _ => injective_object_of_injective_module R Q,
-   fun _ => injective_module_of_injective_object R Q⟩
-
-end Module
 
 namespace AddCommGrp
 

--- a/Mathlib/Algebra/Category/Grp/Injective.lean
+++ b/Mathlib/Algebra/Category/Grp/Injective.lean
@@ -42,6 +42,19 @@ universe u
 
 variable (A : Type u) [AddCommGroup A]
 
+theorem Module.Baer.of_divisible [DivisibleBy A ℤ] : Module.Baer ℤ A := fun I g ↦ by
+  rcases IsPrincipalIdealRing.principal I with ⟨m, rfl⟩
+  obtain rfl | h0 := eq_or_ne m 0
+  · refine ⟨0, fun n hn ↦ ?_⟩
+    rw [Submodule.span_zero_singleton] at hn
+    subst hn
+    exact (map_zero g).symm
+  let gₘ := g ⟨m, Submodule.subset_span (Set.mem_singleton _)⟩
+  refine ⟨LinearMap.toSpanSingleton ℤ A (DivisibleBy.div gₘ m), fun n hn ↦ ?_⟩
+  rcases Submodule.mem_span_singleton.mp hn with ⟨n, rfl⟩
+  rw [map_zsmul, LinearMap.toSpanSingleton_apply, DivisibleBy.div_cancel gₘ h0, ← map_zsmul g,
+    SetLike.mk_smul_mk]
+
 namespace AddCommGrp
 
 theorem injective_as_module_iff : Injective (⟨A⟩ : ModuleCat ℤ) ↔

--- a/Mathlib/Algebra/Category/ModuleCat/EnoughInjectives.lean
+++ b/Mathlib/Algebra/Category/ModuleCat/EnoughInjectives.lean
@@ -1,0 +1,34 @@
+/-
+Copyright (c) 2023 Jujian Zhang. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Jujian Zhang
+-/
+import Mathlib.Algebra.Category.ModuleCat.ChangeOfRings
+import Mathlib.Algebra.Category.ModuleCat.Injective
+import Mathlib.Algebra.Category.Grp.EnoughInjectives
+import Mathlib.Algebra.Category.Grp.ZModuleEquivalence
+import Mathlib.Logic.Equiv.TransferInstance
+
+/-!
+# Category of $R$-modules has enough injectives
+
+we lift enough injectives of abelian groups to arbitrary $R$-modules by adjoint functors
+`restrictScalars ⊣ coextendScalars`
+-/
+
+open CategoryTheory
+
+universe v u
+variable (R : Type u) [Ring R]
+
+instance : EnoughInjectives (ModuleCat.{v} ℤ) :=
+  EnoughInjectives.of_equivalence (forget₂ (ModuleCat ℤ) AddCommGrp)
+
+lemma ModuleCat.enoughInjectives : EnoughInjectives (ModuleCat.{max v u} R) :=
+  EnoughInjectives.of_adjunction (ModuleCat.restrictCoextendScalarsAdj.{max v u} (algebraMap ℤ R))
+
+open ModuleCat in
+instance [UnivLE.{u,v}] : EnoughInjectives (ModuleCat.{v} R) :=
+  letI := (equivShrink.{v} R).symm.ring
+  letI := enoughInjectives.{v} (Shrink.{v} R)
+  EnoughInjectives.of_equivalence (restrictScalars (equivShrink R).symm.ringEquiv.toRingHom)

--- a/Mathlib/Algebra/Category/ModuleCat/Injective.lean
+++ b/Mathlib/Algebra/Category/ModuleCat/Injective.lean
@@ -15,6 +15,7 @@ we lift enough injectives of abelian groups to arbitrary $R$-modules by adjoint 
 `restrictScalars ⊣ coextendScalars`
 
 ## Implementation notes
+
 This file is not part of `Algebra/Module/Injective.lean` to prevent import loop: enough-injectives
 of abelian groups needs `Algebra/Module/Injective.lean` and this file needs enough-injectives of
 abelian groups.
@@ -36,3 +37,11 @@ instance [UnivLE.{u,v}] : EnoughInjectives (ModuleCat.{v} R) :=
   letI := (equivShrink.{v} R).symm.ring
   letI := enoughInjectives.{v} (Shrink.{v} R)
   EnoughInjectives.of_equivalence (restrictScalars (equivShrink R).symm.ringEquiv.toRingHom)
+
+instance ModuleCat.ulift_injective_of_injective.{v'}
+    {M : Type v} [Small.{v} R] [AddCommGroup M] [Module R M]
+    [CategoryTheory.Injective <| ModuleCat.of R M] :
+    CategoryTheory.Injective <| ModuleCat.of R (ULift.{v'} M) :=
+  Module.injective_object_of_injective_module
+    (inj := Module.ulift_injective_of_injective
+      (inj := Module.injective_module_of_injective_object _ _))

--- a/Mathlib/Algebra/Category/ModuleCat/Injective.lean
+++ b/Mathlib/Algebra/Category/ModuleCat/Injective.lean
@@ -3,43 +3,62 @@ Copyright (c) 2023 Jujian Zhang. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Jujian Zhang
 -/
-import Mathlib.Algebra.Category.ModuleCat.ChangeOfRings
-import Mathlib.Algebra.Category.Grp.EnoughInjectives
-import Mathlib.Algebra.Category.Grp.ZModuleEquivalence
+import Mathlib.Algebra.Module.Injective
+import Mathlib.GroupTheory.Divisible
+import Mathlib.Algebra.EuclideanDomain.Int
 import Mathlib.Logic.Equiv.TransferInstance
+import Mathlib.RingTheory.PrincipalIdealDomain
+import Mathlib.CategoryTheory.Preadditive.Injective
+import Mathlib.Algebra.Category.ModuleCat.EpiMono
 
 /-!
-# Category of $R$-modules has enough injectives
-
-we lift enough injectives of abelian groups to arbitrary $R$-modules by adjoint functors
-`restrictScalars ⊣ coextendScalars`
-
-## Implementation notes
-
-This file is not part of `Algebra/Module/Injective.lean` to prevent import loop: enough-injectives
-of abelian groups needs `Algebra/Module/Injective.lean` and this file needs enough-injectives of
-abelian groups.
+# Injective objects in the category of $R$-modules
 -/
 
 open CategoryTheory
 
-universe v u
-variable (R : Type u) [Ring R]
+universe u v
+variable (R : Type u) (M : Type v) [Ring R] [AddCommGroup M] [Module R M]
+namespace Module
 
-instance : EnoughInjectives (ModuleCat.{v} ℤ) :=
-  EnoughInjectives.of_equivalence (forget₂ (ModuleCat ℤ) AddCommGrp)
+theorem Baer.of_divisible [DivisibleBy M ℤ] : Module.Baer ℤ M := fun I g ↦ by
+  rcases IsPrincipalIdealRing.principal I with ⟨m, rfl⟩
+  obtain rfl | h0 := eq_or_ne m 0
+  · refine ⟨0, fun n hn ↦ ?_⟩
+    rw [Submodule.span_zero_singleton] at hn
+    subst hn
+    exact (map_zero g).symm
+  let gₘ := g ⟨m, Submodule.subset_span (Set.mem_singleton _)⟩
+  refine ⟨LinearMap.toSpanSingleton ℤ M (DivisibleBy.div gₘ m), fun n hn ↦ ?_⟩
+  rcases Submodule.mem_span_singleton.mp hn with ⟨n, rfl⟩
+  rw [map_zsmul, LinearMap.toSpanSingleton_apply, DivisibleBy.div_cancel gₘ h0, ← map_zsmul g,
+    SetLike.mk_smul_mk]
 
-lemma ModuleCat.enoughInjectives : EnoughInjectives (ModuleCat.{max v u} R) :=
-  EnoughInjectives.of_adjunction (ModuleCat.restrictCoextendScalarsAdj.{max v u} (algebraMap ℤ R))
+theorem injective_object_of_injective_module [inj : Injective R M] :
+    CategoryTheory.Injective (ModuleCat.of R M) where
+  factors g f m :=
+    have ⟨l, h⟩ := inj.out f ((ModuleCat.mono_iff_injective f).mp m) g
+    ⟨l, LinearMap.ext h⟩
 
-open ModuleCat in
-instance [UnivLE.{u,v}] : EnoughInjectives (ModuleCat.{v} R) :=
-  letI := (equivShrink.{v} R).symm.ring
-  letI := enoughInjectives.{v} (Shrink.{v} R)
-  EnoughInjectives.of_equivalence (restrictScalars (equivShrink R).symm.ringEquiv.toRingHom)
+theorem injective_module_of_injective_object
+    [inj : CategoryTheory.Injective <| ModuleCat.of R M] :
+    Module.Injective R M where
+  out X Y _ _ _ _ f hf g := by
+    have : CategoryTheory.Mono (ModuleCat.asHom f) := (ModuleCat.mono_iff_injective _).mpr hf
+    obtain ⟨l, rfl⟩ := inj.factors (ModuleCat.asHom g) (ModuleCat.asHom f)
+    exact ⟨l, fun _ ↦ rfl⟩
+
+theorem injective_iff_injective_object :
+    Module.Injective R M ↔
+    CategoryTheory.Injective (ModuleCat.of R M) :=
+  ⟨fun _ => injective_object_of_injective_module R M,
+   fun _ => injective_module_of_injective_object R M⟩
+
+end Module
+
 
 instance ModuleCat.ulift_injective_of_injective.{v'}
-    {M : Type v} [Small.{v} R] [AddCommGroup M] [Module R M]
+    [Small.{v} R] [AddCommGroup M] [Module R M]
     [CategoryTheory.Injective <| ModuleCat.of R M] :
     CategoryTheory.Injective <| ModuleCat.of R (ULift.{v'} M) :=
   Module.injective_object_of_injective_module

--- a/Mathlib/Algebra/Category/ModuleCat/Injective.lean
+++ b/Mathlib/Algebra/Category/ModuleCat/Injective.lean
@@ -4,10 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Jujian Zhang
 -/
 import Mathlib.Algebra.Module.Injective
-import Mathlib.GroupTheory.Divisible
-import Mathlib.Algebra.EuclideanDomain.Int
-import Mathlib.Logic.Equiv.TransferInstance
-import Mathlib.RingTheory.PrincipalIdealDomain
 import Mathlib.CategoryTheory.Preadditive.Injective
 import Mathlib.Algebra.Category.ModuleCat.EpiMono
 
@@ -20,19 +16,6 @@ open CategoryTheory
 universe u v
 variable (R : Type u) (M : Type v) [Ring R] [AddCommGroup M] [Module R M]
 namespace Module
-
-theorem Baer.of_divisible [DivisibleBy M ℤ] : Module.Baer ℤ M := fun I g ↦ by
-  rcases IsPrincipalIdealRing.principal I with ⟨m, rfl⟩
-  obtain rfl | h0 := eq_or_ne m 0
-  · refine ⟨0, fun n hn ↦ ?_⟩
-    rw [Submodule.span_zero_singleton] at hn
-    subst hn
-    exact (map_zero g).symm
-  let gₘ := g ⟨m, Submodule.subset_span (Set.mem_singleton _)⟩
-  refine ⟨LinearMap.toSpanSingleton ℤ M (DivisibleBy.div gₘ m), fun n hn ↦ ?_⟩
-  rcases Submodule.mem_span_singleton.mp hn with ⟨n, rfl⟩
-  rw [map_zsmul, LinearMap.toSpanSingleton_apply, DivisibleBy.div_cancel gₘ h0, ← map_zsmul g,
-    SetLike.mk_smul_mk]
 
 theorem injective_object_of_injective_module [inj : Injective R M] :
     CategoryTheory.Injective (ModuleCat.of R M) where

--- a/Mathlib/Algebra/Module/CharacterModule.lean
+++ b/Mathlib/Algebra/Module/CharacterModule.lean
@@ -5,9 +5,9 @@ Authors: Jujian Zhang, Junyan Xu
 -/
 
 import Mathlib.Algebra.Category.ModuleCat.Basic
-import Mathlib.Algebra.Category.Grp.Injective
 import Mathlib.Topology.Instances.AddCircle
 import Mathlib.LinearAlgebra.Isomorphisms
+import Mathlib.Algebra.Category.ModuleCat.Injective
 
 /-!
 # Character module of a module

--- a/Mathlib/Algebra/Module/CharacterModule.lean
+++ b/Mathlib/Algebra/Module/CharacterModule.lean
@@ -5,9 +5,9 @@ Authors: Jujian Zhang, Junyan Xu
 -/
 
 import Mathlib.Algebra.Category.ModuleCat.Basic
+import Mathlib.Algebra.Category.Grp.Injective
 import Mathlib.Topology.Instances.AddCircle
 import Mathlib.LinearAlgebra.Isomorphisms
-import Mathlib.Algebra.Category.Grp.Injective
 
 /-!
 # Character module of a module

--- a/Mathlib/Algebra/Module/CharacterModule.lean
+++ b/Mathlib/Algebra/Module/CharacterModule.lean
@@ -7,7 +7,7 @@ Authors: Jujian Zhang, Junyan Xu
 import Mathlib.Algebra.Category.ModuleCat.Basic
 import Mathlib.Topology.Instances.AddCircle
 import Mathlib.LinearAlgebra.Isomorphisms
-import Mathlib.Algebra.Category.ModuleCat.Injective
+import Mathlib.Algebra.Category.Grp.Injective
 
 /-!
 # Character module of a module

--- a/Mathlib/Algebra/Module/Injective.lean
+++ b/Mathlib/Algebra/Module/Injective.lean
@@ -3,11 +3,10 @@ Copyright (c) 2022 Jujian Zhang. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Jujian Zhang
 -/
-import Mathlib.CategoryTheory.Preadditive.Injective
-import Mathlib.Algebra.Category.ModuleCat.EpiMono
 import Mathlib.RingTheory.Ideal.Basic
 import Mathlib.LinearAlgebra.LinearPMap
 import Mathlib.Logic.Equiv.TransferInstance
+import Mathlib.Logic.Small.Basic
 
 /-!
 # Injective modules
@@ -56,26 +55,6 @@ map to `Q`, i.e. in the following diagram, if `f` is injective then there is an 
   out : ∀ ⦃X Y : Type v⦄ [AddCommGroup X] [AddCommGroup Y] [Module R X] [Module R Y]
     (f : X →ₗ[R] Y) (_ : Function.Injective f) (g : X →ₗ[R] Q),
     ∃ h : Y →ₗ[R] Q, ∀ x, h (f x) = g x
-
-theorem Module.injective_object_of_injective_module [inj : Module.Injective R Q] :
-    CategoryTheory.Injective (ModuleCat.of R Q) where
-  factors g f m :=
-    have ⟨l, h⟩ := inj.out f ((ModuleCat.mono_iff_injective f).mp m) g
-    ⟨l, LinearMap.ext h⟩
-
-theorem Module.injective_module_of_injective_object
-    [inj : CategoryTheory.Injective <| ModuleCat.of R Q] :
-    Module.Injective R Q where
-  out X Y _ _ _ _ f hf g := by
-    have : CategoryTheory.Mono (ModuleCat.asHom f) := (ModuleCat.mono_iff_injective _).mpr hf
-    obtain ⟨l, rfl⟩ := inj.factors (ModuleCat.asHom g) (ModuleCat.asHom f)
-    exact ⟨l, fun _ ↦ rfl⟩
-
-theorem Module.injective_iff_injective_object :
-    Module.Injective R Q ↔
-    CategoryTheory.Injective (ModuleCat.of R Q) :=
-  ⟨fun _ => injective_object_of_injective_module R Q,
-   fun _ => injective_module_of_injective_object R Q⟩
 
 /-- An `R`-module `Q` satisfies Baer's criterion if any `R`-linear map from an `Ideal R` extends to
 an `R`-linear map `R ⟶ Q`-/
@@ -439,13 +418,6 @@ lemma Module.injective_iff_ulift_injective :
     Module.Injective R M ↔ Module.Injective R (ULift.{v'} M) :=
   ⟨Module.ulift_injective_of_injective R,
    Module.injective_of_ulift_injective R⟩
-
-instance ModuleCat.ulift_injective_of_injective
-    [inj : CategoryTheory.Injective <| ModuleCat.of R M] :
-    CategoryTheory.Injective <| ModuleCat.of R (ULift.{v'} M) :=
-  Module.injective_object_of_injective_module
-    (inj := Module.ulift_injective_of_injective
-      (inj := Module.injective_module_of_injective_object (inj := inj)))
 
 end ULift
 

--- a/Mathlib/Algebra/Module/Injective.lean
+++ b/Mathlib/Algebra/Module/Injective.lean
@@ -32,6 +32,7 @@ import Mathlib.Logic.Small.Basic
 
 -/
 
+assert_not_exists ModuleCat
 
 noncomputable section
 


### PR DESCRIPTION
The category-theoretic results can be split between `Mathlib/Algebra/Category/Grp/Injective.lean` and `Mathlib/Algebra/Category/ModuleCat/Injective.lean` instead, with no changes to downstream proofs.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
