### PR TITLE
[Merged by Bors] - feat(LinearAlgebra/Matrix): characterize ideals in matrix rings

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -3063,6 +3063,7 @@ import Mathlib.LinearAlgebra.Matrix.GeneralLinearGroup.Defs
 import Mathlib.LinearAlgebra.Matrix.Gershgorin
 import Mathlib.LinearAlgebra.Matrix.Hermitian
 import Mathlib.LinearAlgebra.Matrix.HermitianFunctionalCalculus
+import Mathlib.LinearAlgebra.Matrix.Ideal
 import Mathlib.LinearAlgebra.Matrix.InvariantBasisNumber
 import Mathlib.LinearAlgebra.Matrix.IsDiag
 import Mathlib.LinearAlgebra.Matrix.LDL

--- a/Mathlib/LinearAlgebra/Matrix/Ideal.lean
+++ b/Mathlib/LinearAlgebra/Matrix/Ideal.lean
@@ -40,8 +40,7 @@ def matricesOver (I : Ideal R) : Ideal (Matrix n n R) where
 
 @[simp]
 theorem mem_matricesOver (I : Ideal R) (M : Matrix n n R) :
-    M ∈ I.matricesOver n ↔ ∀ i j, M i j ∈ I :=
-  by rfl
+    M ∈ I.matricesOver n ↔ ∀ i j, M i j ∈ I := by rfl
 
 def matricesOver_mono {I J : Ideal (Matrix n n R)} :
     I ≤ J → I.matricesOver n ≤ J.matricesOver n :=

--- a/Mathlib/LinearAlgebra/Matrix/Ideal.lean
+++ b/Mathlib/LinearAlgebra/Matrix/Ideal.lean
@@ -101,16 +101,10 @@ theorem matricesOver_monotone : Monotone (matricesOver (R := R) n) :=
 
 theorem matricesOver_strictMono_of_nonempty [h : Nonempty n] :
     StrictMono (matricesOver (R := R) n) :=
-  fun I J IJ => by
-    refine lt_of_le_of_ne (matricesOver_monotone n IJ.le) fun eq => ?_
-    have ⟨x, xJ, xI⟩ : ∃ x ∈ J, x ∉ I := Set.exists_of_ssubset IJ
-    simp only [SetLike.mem_coe] at xI xJ
-    let M : Matrix n n R := fun _ _ => x
-    have : M ∈ J.matricesOver n := by simp [M, xJ]
-    have : M ∉ I.matricesOver n := by
-      simp only [mem_matricesOver, not_forall]
-      use h.some, h.some
-    simp [*] at *
+  matricesOver_monotone n |>.strictMono_of_injective <| fun I J eq => by
+    ext x
+    have : _ ↔ _ := congr((Matrix.of fun _ _ => x) ∈ $eq)
+    simpa only [mem_matricesOver, of_apply, forall_const] using this
 
 @[simp]
 theorem matricesOver_bot : (⊥ : TwoSidedIdeal R).matricesOver n = ⊥ := by

--- a/Mathlib/LinearAlgebra/Matrix/Ideal.lean
+++ b/Mathlib/LinearAlgebra/Matrix/Ideal.lean
@@ -161,7 +161,7 @@ def equivMatricesOver (i j : n) : TwoSidedIdeal R ≃ TwoSidedIdeal (Matrix n n 
         subst ha hb
         simp only [stdBasisMatrix, and_self, ↓reduceIte, StdBasisMatrix.mul_right_apply_same,
           StdBasisMatrix.mul_left_apply_same, one_mul, mul_one]
-        exact hy2 a b
+        rw [hy2 a b]
       · conv_lhs =>
           dsimp [stdBasisMatrix]
           rw [if_neg (by tauto)]

--- a/Mathlib/LinearAlgebra/Matrix/Ideal.lean
+++ b/Mathlib/LinearAlgebra/Matrix/Ideal.lean
@@ -45,18 +45,12 @@ theorem mem_matricesOver (I : Ideal R) (M : Matrix n n R) :
 theorem matricesOver_monotone : Monotone (matricesOver (R := R) n) :=
   fun _ _ IJ _ MI i j => IJ (MI i j)
 
-theorem matricesOver_strictMono_of_nonempty [h : Nonempty n] :
+theorem matricesOver_strictMono_of_nonempty [Nonempty n] :
     StrictMono (matricesOver (R := R) n) :=
-  fun I J IJ => by
-    refine lt_of_le_of_ne (matricesOver_monotone n IJ.le) fun eq => ?_
-    have ⟨x, xJ, xI⟩ : ∃ x ∈ J, x ∉ I := Set.exists_of_ssubset IJ
-    simp only [SetLike.mem_coe] at xI xJ
-    let M : Matrix n n R := fun _ _ => x
-    have : M ∈ J.matricesOver n := by simp [M, xJ]
-    have : M ∉ I.matricesOver n := by
-      simp only [mem_matricesOver, not_forall]
-      use h.some, h.some
-    simp [*] at *
+  matricesOver_monotone n |>.strictMono_of_injective <| fun I J eq => by
+    ext x
+    have : (∀ _ _, x ∈ I) ↔ (∀ _ _, x ∈ J) := congr((Matrix.of fun _ _ => x) ∈ $eq)
+    simpa only [forall_const] using this
 
 @[simp]
 theorem matricesOver_bot : (⊥ : Ideal R).matricesOver n = ⊥ := by

--- a/Mathlib/LinearAlgebra/Matrix/Ideal.lean
+++ b/Mathlib/LinearAlgebra/Matrix/Ideal.lean
@@ -133,7 +133,7 @@ Given an ideal $J ≤ Mₙ(R)$, we send it to $\{Nᵢⱼ ∣ ∃ N ∈ J\}$.
 def equivMatricesOver (i j : n) : TwoSidedIdeal R ≃ TwoSidedIdeal (Matrix n n R) where
   toFun I := I.matricesOver n
   invFun J := TwoSidedIdeal.mk'
-    { x : R | ∃ N ∈ J, x = N i j }
+    { N i j | N ∈ J }
     ⟨0, J.zero_mem, rfl⟩
     (by rintro _ _ ⟨x, hx, rfl⟩ ⟨y, hy, rfl⟩; exact ⟨x + y, J.add_mem hx hy, rfl⟩)
     (by rintro _ ⟨x, hx, rfl⟩; exact ⟨-x, J.neg_mem hx, rfl⟩)

--- a/Mathlib/LinearAlgebra/Matrix/Ideal.lean
+++ b/Mathlib/LinearAlgebra/Matrix/Ideal.lean
@@ -15,7 +15,7 @@ over left (resp. two-sided) ideals in the base semiring (resp. ring).
 ## Main results
 
 * `TwoSidedIdeal.equivMatricesOver` and `TwoSidedIdeal.orderIsoMatricesOver`
-  establish an order isomorphism between two-sided ideals in `R` and those in `Mₙ(R)`.
+  establish an order isomorphism between two-sided ideals in $R$ and those in $Mₙ(R)$.
 -/
 
 /-! ### Left ideals in a matrix ring -/
@@ -137,9 +137,9 @@ theorem asIdeal_matricesOver [DecidableEq n] (I : TwoSidedIdeal R) :
 variable {n : Type*} [Fintype n] [DecidableEq n]
 
 /--
-Two-sided ideals in `R` correspond bijectively to those in `Mₙ(R)`.
-Given an ideal `I ≤ R`, we send it to `Mₙ(I)`.
-Given an ideal `J ≤ Mₙ(R)`, we send it to `{Nᵢⱼ | ∃ N ∈ J}`.
+Two-sided ideals in $R$ correspond bijectively to those in $Mₙ(R)$.
+Given an ideal $I ≤ R$, we send it to $Mₙ(I)$.
+Given an ideal $J ≤ Mₙ(R)$, we send it to $\{Nᵢⱼ ∣ ∃ N ∈ J\}$.
 -/
 @[simps]
 def equivMatricesOver (i j : n) : TwoSidedIdeal R ≃ TwoSidedIdeal (Matrix n n R) where
@@ -196,7 +196,7 @@ def equivMatricesOver (i j : n) : TwoSidedIdeal R ≃ TwoSidedIdeal (Matrix n n 
       exact ⟨of fun _ _ => x, by simp [h], rfl⟩
 
 /--
-Two-sided ideals in `R` are order-isomorphic with those in `Mₙ(R)`.
+Two-sided ideals in $R$ are order-isomorphic with those in $Mₙ(R)$.
 See also `equivMatricesOver`.
 -/
 @[simps!]


### PR DESCRIPTION
- Define left and two-sided ideals in a matrix ring.
- Show that two-sided matrix ideals are order-isomorphic to two-sided ideals in the base ring.
  This code is taken from FLT, from [here](https://github.com/ImperialCollegeLondon/FLT/blob/daac491a4fa817ec39595e0a5ce2240ceed940fc/FLT/for_mathlib/CrazySimple.lean).

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
