### PR TITLE
refactor(*): generalize typeclass assumptions in morphisms

### DIFF
--- a/Mathlib/Algebra/Group/Hom/Defs.lean
+++ b/Mathlib/Algebra/Group/Hom/Defs.lean
@@ -129,7 +129,7 @@ you should parametrize over `(F : Type*) [AddMonoidHomClass F M N] (f : F)`.
 
 When you extend this structure, make sure to extend `AddMonoidHomClass`.
 -/
-structure AddMonoidHom (M : Type*) (N : Type*) [AddZeroClass M] [AddZeroClass N] extends
+structure AddMonoidHom (M : Type*) (N : Type*) [Add M] [Zero M] [Add N] [Zero N] extends
   ZeroHom M N, AddHom M N
 
 attribute [nolint docBlame] AddMonoidHom.toAddHom
@@ -144,7 +144,7 @@ homomorphisms.
 You should also extend this typeclass when you extend `AddMonoidHom`.
 -/
 class AddMonoidHomClass (F : Type*) (M N : outParam Type*)
-    [AddZeroClass M] [AddZeroClass N] [FunLike F M N]
+    [Add M] [Zero M] [Add N] [Zero N] [FunLike F M N]
     extends AddHomClass F M N, ZeroHomClass F M N : Prop
 
 -- Instances and lemmas are defined below through `@[to_additive]`.
@@ -329,7 +329,7 @@ end Mul
 
 section mul_one
 
-variable [MulOneClass M] [MulOneClass N]
+variable [Mul M] [One M] [Mul N] [One N]
 
 /-- `M →* N` is the type of functions `M → N` that preserve the `Monoid` structure.
 `MonoidHom` is also used for group homomorphisms.
@@ -340,7 +340,7 @@ you should parametrize over `(F : Type*) [MonoidHomClass F M N] (f : F)`.
 When you extend this structure, make sure to extend `MonoidHomClass`.
 -/
 @[to_additive]
-structure MonoidHom (M : Type*) (N : Type*) [MulOneClass M] [MulOneClass N] extends
+structure MonoidHom (M : Type*) (N : Type*) [Mul M] [One M] [Mul N] [One N] extends
   OneHom M N, M →ₙ* N
 -- Porting note: remove once `to_additive` is updated
 -- This is waiting on https://github.com/leanprover-community/mathlib4/issues/660
@@ -355,7 +355,7 @@ infixr:25 " →* " => MonoidHom
 /-- `MonoidHomClass F M N` states that `F` is a type of `Monoid`-preserving homomorphisms.
 You should also extend this typeclass when you extend `MonoidHom`. -/
 @[to_additive]
-class MonoidHomClass (F : Type*) (M N : outParam Type*) [MulOneClass M] [MulOneClass N]
+class MonoidHomClass (F : Type*) (M N : outParam Type*) [Mul M] [One M] [Mul N] [One N]
   [FunLike F M N]
   extends MulHomClass F M N, OneHomClass F M N : Prop
 
@@ -551,8 +551,7 @@ theorem MonoidHom.ext [MulOneClass M] [MulOneClass N] ⦃f g : M →* N⦄ (h : 
 
 namespace MonoidHom
 
-variable [Group G]
-variable [MulOneClass M]
+variable [Group G] [MulOneClass M]
 
 /-- Makes a group homomorphism from a proof that the map preserves multiplication. -/
 @[to_additive (attr := simps (config := .asFn))
@@ -627,17 +626,17 @@ definitional equalities. -/
 @[to_additive
   "Copy of an `AddMonoidHom` with a new `toFun` equal to the old one. Useful to fix
   definitional equalities."]
-protected def MonoidHom.copy [MulOneClass M] [MulOneClass N] (f : M →* N) (f' : M → N)
+protected def MonoidHom.copy [One M] [Mul M] [One N] [Mul N] (f : M →* N) (f' : M → N)
     (h : f' = f) : M →* N :=
   { f.toOneHom.copy f' h, f.toMulHom.copy f' h with }
 
 @[to_additive (attr := simp)]
-theorem MonoidHom.coe_copy {_ : MulOneClass M} {_ : MulOneClass N} (f : M →* N) (f' : M → N)
+theorem MonoidHom.coe_copy {_ : One M} {_ : Mul M} {_ : One N} {_ : Mul N} (f : M →* N) (f' : M → N)
     (h : f' = f) : (f.copy f' h) = f' :=
   rfl
 
 @[to_additive]
-theorem MonoidHom.copy_eq {_ : MulOneClass M} {_ : MulOneClass N} (f : M →* N) (f' : M → N)
+theorem MonoidHom.copy_eq {_ : One M} {_ : Mul M} {_ : One N} {_ : Mul N} (f : M →* N) (f' : M → N)
     (h : f' = f) : f.copy f' h = f :=
   DFunLike.ext' h
 
@@ -698,7 +697,7 @@ def MulHom.id (M : Type*) [Mul M] : M →ₙ* M where
 
 /-- The identity map from a monoid to itself. -/
 @[to_additive (attr := simps) "The identity map from an additive monoid to itself."]
-def MonoidHom.id (M : Type*) [MulOneClass M] : M →* M where
+def MonoidHom.id (M : Type*) [Mul M] [One M] : M →* M where
   toFun x := x
   map_one' := rfl
   map_mul' _ _ := rfl

--- a/Mathlib/Algebra/GroupWithZero/Hom.lean
+++ b/Mathlib/Algebra/GroupWithZero/Hom.lean
@@ -36,8 +36,10 @@ assert_not_exists DenselyOrdered
 
 open Function
 
+variable {F α β γ δ M₀ : Type*}
+
 namespace NeZero
-variable {F α β : Type*} [Zero α] [Zero β] [FunLike F α β] [ZeroHomClass F α β] {a : α}
+variable [Zero α] [Zero β] [FunLike F α β] [ZeroHomClass F α β] {a : α}
 
 #adaptation_note
 /--
@@ -54,15 +56,16 @@ lemma of_injective {f : F} (hf : Injective f) [NeZero a] : NeZero (f a) :=
 
 end NeZero
 
-variable {F α β γ δ M₀ : Type*} [MulZeroOneClass α] [MulZeroOneClass β] [MulZeroOneClass γ]
-  [MulZeroOneClass δ]
+section
+
+variable {F α β γ δ M₀ : Type*} [Zero α] [One α] [Mul α] [Zero β] [One β] [Mul β]
 
 /-- `MonoidWithZeroHomClass F α β` states that `F` is a type of
 `MonoidWithZero`-preserving homomorphisms.
 
 You should also extend this typeclass when you extend `MonoidWithZeroHom`. -/
-class MonoidWithZeroHomClass (F : Type*) (α β : outParam Type*) [MulZeroOneClass α]
-  [MulZeroOneClass β] [FunLike F α β] extends MonoidHomClass F α β, ZeroHomClass F α β : Prop
+class MonoidWithZeroHomClass (F : Type*) (α β : outParam Type*) [Zero α] [One α] [Mul α]
+  [Zero β] [One β] [Mul β] [FunLike F α β] extends MonoidHomClass F α β, ZeroHomClass F α β : Prop
 
 /-- `α →*₀ β` is the type of functions `α → β` that preserve
 the `MonoidWithZero` structure.
@@ -73,7 +76,7 @@ When possible, instead of parametrizing results over `(f : α →*₀ β)`,
 you should parametrize over `(F : Type*) [MonoidWithZeroHomClass F α β] (f : F)`.
 
 When you extend this structure, make sure to extend `MonoidWithZeroHomClass`. -/
-structure MonoidWithZeroHom (α β : Type*) [MulZeroOneClass α] [MulZeroOneClass β]
+structure MonoidWithZeroHom (α β : Type*) [Zero α] [One α] [Mul α] [Zero β] [One β] [Mul β]
   extends ZeroHom α β, MonoidHom α β
 
 /-- `α →*₀ β` denotes the type of zero-preserving monoid homomorphisms from `α` to `β`. -/
@@ -90,7 +93,13 @@ def MonoidWithZeroHomClass.toMonoidWithZeroHom [FunLike F α β] [MonoidWithZero
 instance [FunLike F α β] [MonoidWithZeroHomClass F α β] : CoeTC F (α →*₀ β) :=
   ⟨MonoidWithZeroHomClass.toMonoidWithZeroHom⟩
 
+end
+
 namespace MonoidWithZeroHom
+
+section ZeroOneMul
+
+variable [Zero α] [One α] [Mul α] [Zero β] [One β] [Mul β]
 
 attribute [nolint docBlame] toMonoidHom
 attribute [nolint docBlame] toZeroHom
@@ -165,6 +174,10 @@ def id (α : Type*) [MulZeroOneClass α] : α →*₀ α where
   map_zero' := rfl
   map_one' := rfl
   map_mul' _ _ := rfl
+
+end ZeroOneMul
+
+variable [MulZeroOneClass α] [MulZeroOneClass β] [MulZeroOneClass γ] [MulZeroOneClass δ]
 
 /-- Composition of `MonoidWithZeroHom`s as a `MonoidWithZeroHom`. -/
 def comp (hnp : β →*₀ γ) (hmn : α →*₀ β) : α →*₀ γ where

--- a/Mathlib/Algebra/Order/Ring/Unbundled/Nonneg.lean
+++ b/Mathlib/Algebra/Order/Ring/Unbundled/Nonneg.lean
@@ -178,9 +178,8 @@ def coeAddMonoidHom : { x : α // 0 ≤ x } →+ α :=
     map_add' := Nonneg.coe_add }
 
 @[norm_cast]
-theorem nsmul_coe (n : ℕ) (r : { x : α // 0 ≤ x }) :
-    ↑(n • r) = n • (r : α) :=
-  Nonneg.coeAddMonoidHom.map_nsmul _ _
+theorem nsmul_coe (n : ℕ) (r : { x : α // 0 ≤ x }) : ↑(n • r) = n • (r : α) :=
+  Nonneg.coeAddMonoidHom.map_nsmul r n
 
 end AddMonoid
 

--- a/Mathlib/Algebra/Ring/Hom/Defs.lean
+++ b/Mathlib/Algebra/Ring/Hom/Defs.lean
@@ -58,8 +58,8 @@ When possible, instead of parametrizing results over `(f : α →ₙ+* β)`,
 you should parametrize over `(F : Type*) [NonUnitalRingHomClass F α β] (f : F)`.
 
 When you extend this structure, make sure to extend `NonUnitalRingHomClass`. -/
-structure NonUnitalRingHom (α β : Type*) [NonUnitalNonAssocSemiring α]
-  [NonUnitalNonAssocSemiring β] extends α →ₙ* β, α →+ β
+structure NonUnitalRingHom (α β : Type*) [Zero α] [Add α] [Mul α] [Zero β] [Add β] [Mul β]
+  extends α →ₙ* β, α →+ β
 
 /-- `α →ₙ+* β` denotes the type of non-unital ring homomorphisms from `α` to `β`. -/
 infixr:25 " →ₙ+* " => NonUnitalRingHom
@@ -76,11 +76,11 @@ section NonUnitalRingHomClass
 
 /-- `NonUnitalRingHomClass F α β` states that `F` is a type of non-unital (semi)ring
 homomorphisms. You should extend this class when you extend `NonUnitalRingHom`. -/
-class NonUnitalRingHomClass (F : Type*) (α β : outParam Type*) [NonUnitalNonAssocSemiring α]
-  [NonUnitalNonAssocSemiring β] [FunLike F α β]
+class NonUnitalRingHomClass (F : Type*) (α β : outParam Type*)
+    [Zero α] [Add α] [Mul α] [Zero β] [Add β] [Mul β] [FunLike F α β]
   extends MulHomClass F α β, AddMonoidHomClass F α β : Prop
 
-variable [NonUnitalNonAssocSemiring α] [NonUnitalNonAssocSemiring β] [FunLike F α β]
+variable [Zero α] [Add α] [Mul α] [Zero β] [Add β] [Mul β] [FunLike F α β]
 variable [NonUnitalRingHomClass F α β]
 
 /-- Turn an element of a type `F` satisfying `NonUnitalRingHomClass F α β` into an actual
@@ -100,7 +100,7 @@ namespace NonUnitalRingHom
 
 section coe
 
-variable [NonUnitalNonAssocSemiring α] [NonUnitalNonAssocSemiring β]
+variable [Zero α] [Add α] [Mul α] [Zero β] [Add β] [Mul β]
 
 instance : FunLike (α →ₙ+* β) α β where
   coe f := f.toFun
@@ -152,7 +152,7 @@ end coe
 
 section
 
-variable [NonUnitalNonAssocSemiring α] [NonUnitalNonAssocSemiring β]
+variable [Zero α] [Add α] [Mul α] [Zero β] [Add β] [Mul β]
 
 @[ext]
 theorem ext ⦃f g : α →ₙ+* β⦄ : (∀ x, f x = g x) → f = g :=
@@ -170,10 +170,12 @@ theorem coe_mulHom_injective : Injective fun f : α →ₙ+* β => (f : α →�
 
 end
 
-variable [NonUnitalNonAssocSemiring α] [NonUnitalNonAssocSemiring β]
+section
+
+variable [Zero α] [Add α] [Mul α] [NonUnitalNonAssocSemiring β]
 
 /-- The identity non-unital ring homomorphism from a non-unital semiring to itself. -/
-protected def id (α : Type*) [NonUnitalNonAssocSemiring α] : α →ₙ+* α where
+protected def id (α : Type*) [Zero α] [Add α] [Mul α] : α →ₙ+* α where
   toFun := id
   map_mul' _ _ := rfl
   map_zero' := rfl
@@ -206,7 +208,9 @@ theorem coe_addMonoidHom_id : (NonUnitalRingHom.id α : α →+ α) = AddMonoidH
 theorem coe_mulHom_id : (NonUnitalRingHom.id α : α →ₙ* α) = MulHom.id α :=
   rfl
 
-variable [NonUnitalNonAssocSemiring γ]
+end
+
+variable [NonUnitalNonAssocSemiring α] [NonUnitalNonAssocSemiring β] [NonUnitalNonAssocSemiring γ]
 
 /-- Composition of non-unital ring homomorphisms is a non-unital ring homomorphism. -/
 def comp (g : β →ₙ+* γ) (f : α →ₙ+* β) : α →ₙ+* γ :=
@@ -293,7 +297,8 @@ end NonUnitalRingHom
 
 This extends from both `MonoidHom` and `MonoidWithZeroHom` in order to put the fields in a
 sensible order, even though `MonoidWithZeroHom` already extends `MonoidHom`. -/
-structure RingHom (α : Type*) (β : Type*) [NonAssocSemiring α] [NonAssocSemiring β] extends
+structure RingHom (α : Type*) (β : Type*)
+    [Zero α] [One α] [Add α] [Mul α] [One β] [Zero β] [Add β] [Mul β] extends
   α →* β, α →+ β, α →ₙ+* β, α →*₀ β
 
 /-- `α →+* β` denotes the type of ring homomorphisms from `α` to `β`. -/
@@ -324,13 +329,14 @@ This extends from both `MonoidHomClass` and `MonoidWithZeroHomClass` in
 order to put the fields in a sensible order, even though
 `MonoidWithZeroHomClass` already extends `MonoidHomClass`. -/
 class RingHomClass (F : Type*) (α β : outParam Type*)
-    [NonAssocSemiring α] [NonAssocSemiring β] [FunLike F α β]
+    [Zero α] [One α] [Add α] [Mul α] [One β] [Zero β] [Add β] [Mul β] [FunLike F α β]
   extends MonoidHomClass F α β, AddMonoidHomClass F α β, MonoidWithZeroHomClass F α β : Prop
 
 variable [FunLike F α β]
 
 -- Porting note: marked `{}` rather than `[]` to prevent dangerous instances
-variable {_ : NonAssocSemiring α} {_ : NonAssocSemiring β} [RingHomClass F α β]
+variable {_ : Zero α} {_ : One α} {_ : Add α} {_ : Mul α}
+  {_ : Zero β} {_ : One β} {_ : Add β} {_ : Mul β} [RingHomClass F α β]
 
 /-- Turn an element of a type `F` satisfying `RingHomClass F α β` into an actual
 `RingHom`. This is declared as the default coercion from `F` to `α →+* β`. -/
@@ -356,7 +362,8 @@ Throughout this section, some `Semiring` arguments are specified with `{}` inste
 See note [implicit instance arguments].
 -/
 
-variable {_ : NonAssocSemiring α} {_ : NonAssocSemiring β}
+variable {_ : Zero α} {_ : One α} {_ : Add α} {_ : Mul α}
+  {_ : Zero β} {_ : One β} {_ : Add β} {_ : Mul β}
 
 instance instFunLike : FunLike (α →+* β) α β where
   coe f := f.toFun
@@ -394,7 +401,8 @@ theorem coe_coe {F : Type*} [FunLike F α β] [RingHomClass F α β] (f : F) :
 
 attribute [coe] RingHom.toMonoidHom
 
-instance coeToMonoidHom : Coe (α →+* β) (α →* β) :=
+instance coeToMonoidHom [Zero α] [One α] [Add α] [Mul α] [One β] [Zero β] [Add β] [Mul β] :
+    Coe (α →+* β) (α →* β) :=
   ⟨RingHom.toMonoidHom⟩
 
 -- Porting note: `dsimp only` can prove this
@@ -439,7 +447,8 @@ end coe
 
 section
 
-variable {_ : NonAssocSemiring α} {_ : NonAssocSemiring β} (f : α →+* β)
+variable {_ : Zero α} {_ : One α} {_ : Add α} {_ : Mul α}
+  {_ : Zero β} {_ : One β} {_ : Add β} {_ : Mul β} (f : α →+* β)
 
 protected theorem congr_fun {f g : α →+* β} (h : f = g) (x : α) : f x = g x :=
   DFunLike.congr_fun h x
@@ -495,6 +504,35 @@ theorem map_ite_one_zero {F : Type*} [FunLike F α β] [RingHomClass F α β] (f
 /-- `f : α →+* β` has a trivial codomain iff `f 1 = 0`. -/
 theorem codomain_trivial_iff_map_one_eq_zero : (0 : β) = 1 ↔ f 1 = 0 := by rw [map_one, eq_comm]
 
+/-- The identity ring homomorphism from a semiring to itself. -/
+def id (α : Type*) [Zero α] [One α] [Add α] [Mul α] : α →+* α where
+  toFun := _root_.id
+  map_zero' := rfl
+  map_one' := rfl
+  map_add' _ _ := rfl
+  map_mul' _ _ := rfl
+
+instance : Inhabited (α →+* α) :=
+  ⟨id α⟩
+
+@[simp]
+theorem id_apply (x : α) : RingHom.id α x = x :=
+  rfl
+
+@[simp]
+theorem coe_addMonoidHom_id : (id α : α →+ α) = AddMonoidHom.id α :=
+  rfl
+
+@[simp]
+theorem coe_monoidHom_id : (id α : α →* α) = MonoidHom.id α :=
+  rfl
+
+end
+
+section
+
+variable {_ : NonAssocSemiring α} {_ : NonAssocSemiring β} (f : α →+* β)
+
 /-- `f : α →+* β` has a trivial codomain iff it has a trivial range. -/
 theorem codomain_trivial_iff_range_trivial : (0 : β) = 1 ↔ ∀ x, f x = 0 :=
   f.codomain_trivial_iff_map_one_eq_zero.trans
@@ -529,32 +567,7 @@ def mk' [NonAssocSemiring α] [NonAssocRing β] (f : α →* β)
     (map_add : ∀ a b, f (a + b) = f a + f b) : α →+* β :=
   { AddMonoidHom.mk' f map_add, f with }
 
-variable {_ : NonAssocSemiring α} {_ : NonAssocSemiring β}
-
-/-- The identity ring homomorphism from a semiring to itself. -/
-def id (α : Type*) [NonAssocSemiring α] : α →+* α where
-  toFun := _root_.id
-  map_zero' := rfl
-  map_one' := rfl
-  map_add' _ _ := rfl
-  map_mul' _ _ := rfl
-
-instance : Inhabited (α →+* α) :=
-  ⟨id α⟩
-
-@[simp]
-theorem id_apply (x : α) : RingHom.id α x = x :=
-  rfl
-
-@[simp]
-theorem coe_addMonoidHom_id : (id α : α →+ α) = AddMonoidHom.id α :=
-  rfl
-
-@[simp]
-theorem coe_monoidHom_id : (id α : α →* α) = MonoidHom.id α :=
-  rfl
-
-variable {_ : NonAssocSemiring γ}
+variable {_ : NonAssocSemiring α} {_ : NonAssocSemiring β} {_ : NonAssocSemiring γ}
 
 /-- Composition of ring homomorphisms is a ring homomorphism. -/
 def comp (g : β →+* γ) (f : α →+* β) : α →+* γ :=


### PR DESCRIPTION
We remove all algebraic axioms from the definitions of morphisms (i.e. `→+`, `→*`, etc.) and assume only the necessary data to state them.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
