### PR TITLE
[Merged by Bors] - chore: remove and rename variables

### DIFF
--- a/Mathlib/Analysis/Normed/Operator/Compact.lean
+++ b/Mathlib/Analysis/Normed/Operator/Compact.lean
@@ -68,7 +68,7 @@ section Characterizations
 
 section
 
-variable {R₁ R₂ : Type*} [Semiring R₁] [Semiring R₂] {σ₁₂ : R₁ →+* R₂} {M₁ M₂ : Type*}
+variable {R₁ : Type*} [Semiring R₁] {M₁ M₂ : Type*}
   [TopologicalSpace M₁] [AddCommMonoid M₁] [TopologicalSpace M₂]
 
 theorem isCompactOperator_iff_exists_mem_nhds_image_subset_compact (f : M₁ → M₂) :
@@ -112,7 +112,7 @@ end Bounded
 section NormedSpace
 
 variable {𝕜₁ 𝕜₂ : Type*} [NontriviallyNormedField 𝕜₁] [SeminormedRing 𝕜₂] {σ₁₂ : 𝕜₁ →+* 𝕜₂}
-  {M₁ M₂ M₃ : Type*} [SeminormedAddCommGroup M₁] [TopologicalSpace M₂] [AddCommMonoid M₂]
+  {M₁ M₂ : Type*} [SeminormedAddCommGroup M₁] [TopologicalSpace M₂] [AddCommMonoid M₂]
   [NormedSpace 𝕜₁ M₁] [Module 𝕜₂ M₂]
 
 theorem IsCompactOperator.image_subset_compact_of_bounded [ContinuousConstSMul 𝕜₂ M₂]
@@ -178,10 +178,10 @@ end Characterizations
 
 section Operations
 
-variable {R₁ R₂ R₃ R₄ : Type*} [Semiring R₁] [Semiring R₂] [CommSemiring R₃] [CommSemiring R₄]
-  {σ₁₂ : R₁ →+* R₂} {σ₁₄ : R₁ →+* R₄} {σ₃₄ : R₃ →+* R₄} {M₁ M₂ M₃ M₄ : Type*} [TopologicalSpace M₁]
-  [AddCommMonoid M₁] [TopologicalSpace M₂] [AddCommMonoid M₂] [TopologicalSpace M₃]
-  [AddCommGroup M₃] [TopologicalSpace M₄] [AddCommGroup M₄]
+variable {R₁ R₄ : Type*} [Semiring R₁] [CommSemiring R₄]
+  {σ₁₄ : R₁ →+* R₄} {M₁ M₂ M₄ : Type*} [TopologicalSpace M₁]
+  [AddCommMonoid M₁] [TopologicalSpace M₂] [AddCommMonoid M₂]
+  [TopologicalSpace M₄] [AddCommGroup M₄]
 
 theorem IsCompactOperator.smul {S : Type*} [Monoid S] [DistribMulAction S M₂]
     [ContinuousConstSMul S M₂] {f : M₁ → M₂} (hf : IsCompactOperator f) (c : S) :
@@ -247,8 +247,8 @@ end Comp
 
 section CodRestrict
 
-variable {R₁ R₂ : Type*} [Semiring R₁] [Semiring R₂] {σ₁₂ : R₁ →+* R₂} {M₁ M₂ : Type*}
-  [TopologicalSpace M₁] [TopologicalSpace M₂] [AddCommMonoid M₁] [AddCommMonoid M₂] [Module R₁ M₁]
+variable {R₂ : Type*} [Semiring R₂] {M₁ M₂ : Type*}
+  [TopologicalSpace M₁] [TopologicalSpace M₂] [AddCommMonoid M₁] [AddCommMonoid M₂]
   [Module R₂ M₂]
 
 theorem IsCompactOperator.codRestrict {f : M₁ → M₂} (hf : IsCompactOperator f) {V : Submodule R₂ M₂}
@@ -261,10 +261,10 @@ end CodRestrict
 
 section Restrict
 
-variable {R₁ R₂ R₃ : Type*} [Semiring R₁] [Semiring R₂] [Semiring R₃] {σ₁₂ : R₁ →+* R₂}
-  {σ₂₃ : R₂ →+* R₃} {M₁ M₂ M₃ : Type*} [TopologicalSpace M₁] [UniformSpace M₂]
-  [TopologicalSpace M₃] [AddCommMonoid M₁] [AddCommMonoid M₂] [AddCommMonoid M₃] [Module R₁ M₁]
-  [Module R₂ M₂] [Module R₃ M₃]
+variable {R₁ R₂ : Type*} [Semiring R₁] [Semiring R₂] {σ₁₂ : R₁ →+* R₂}
+  {M₁ M₂ : Type*} [TopologicalSpace M₁] [UniformSpace M₂]
+  [AddCommMonoid M₁] [AddCommMonoid M₂] [Module R₁ M₁]
+  [Module R₂ M₂]
 
 /-- If a compact operator preserves a closed submodule, its restriction to that submodule is
 compact.

--- a/Mathlib/Geometry/Manifold/ContMDiffMFDeriv.lean
+++ b/Mathlib/Geometry/Manifold/ContMDiffMFDeriv.lean
@@ -45,13 +45,9 @@ variable {𝕜 : Type*} [NontriviallyNormedField 𝕜]
   {F' : Type*}
   [NormedAddCommGroup F'] [NormedSpace 𝕜 F'] {G' : Type*} [TopologicalSpace G']
   {J' : ModelWithCorners 𝕜 F' G'} {N' : Type*} [TopologicalSpace N'] [ChartedSpace G' N']
-  -- declare some additional normed spaces, used for fibers of vector bundles
-  {F₁ : Type*}
-  [NormedAddCommGroup F₁] [NormedSpace 𝕜 F₁] {F₂ : Type*} [NormedAddCommGroup F₂]
-  [NormedSpace 𝕜 F₂]
   -- declare functions, sets, points and smoothness indices
-  {f f₁ : M → M'}
-  {s s₁ t : Set M} {x : M} {m n : ℕ∞}
+  {f : M → M'}
+  {s : Set M} {m n : ℕ∞}
 
 -- Porting note: section about deducing differentiability from smoothness moved to
 -- `Geometry.Manifold.MFDeriv.Basic`

--- a/Mathlib/LinearAlgebra/Matrix/BilinearForm.lean
+++ b/Mathlib/LinearAlgebra/Matrix/BilinearForm.lean
@@ -21,11 +21,8 @@ This file defines the conversion between bilinear forms and matrices.
 ## Notations
 
 In this file we use the following type variables:
- - `M`, `M'`, ... are modules over the commutative semiring `R`,
- - `M₁`, `M₁'`, ... are modules over the commutative ring `R₁`,
- - `M₂`, `M₂'`, ... are modules over the commutative semiring `R₂`,
- - `M₃`, `M₃'`, ... are modules over the commutative ring `R₃`,
- - `V`, ... is a vector space over the field `K`.
+ - `M₁` is a module over the commutative semiring `R₁`,
+ - `M₂` is a module over the commutative ring `R₂`.
 
 ## Tags
 
@@ -35,12 +32,8 @@ bilinear form, bilin form, BilinearForm, matrix, basis
 
 open LinearMap (BilinForm)
 
-variable {R : Type*} {M : Type*} [CommSemiring R] [AddCommMonoid M] [Module R M]
-variable {R₁ : Type*} {M₁ : Type*} [CommRing R₁] [AddCommGroup M₁] [Module R₁ M₁]
-variable {R₂ : Type*} {M₂ : Type*} [CommSemiring R₂] [AddCommMonoid M₂] [Module R₂ M₂]
-variable {R₃ : Type*} {M₃ : Type*} [CommRing R₃] [AddCommGroup M₃] [Module R₃ M₃]
-variable {V : Type*} {K : Type*} [Field K] [AddCommGroup V] [Module K V]
-variable {B : BilinForm R M} {B₁ : BilinForm R₁ M₁} {B₂ : BilinForm R₂ M₂}
+variable {R₁ : Type*} {M₁ : Type*} [CommSemiring R₁] [AddCommMonoid M₁] [Module R₁ M₁]
+variable {R₂ : Type*} {M₂ : Type*} [CommRing R₂] [AddCommGroup M₂] [Module R₂ M₂]
 
 section Matrix
 
@@ -53,30 +46,30 @@ open Matrix
 /-- The map from `Matrix n n R` to bilinear forms on `n → R`.
 
 This is an auxiliary definition for the equivalence `Matrix.toBilin'`. -/
-def Matrix.toBilin'Aux [Fintype n] (M : Matrix n n R₂) : BilinForm R₂ (n → R₂) :=
+def Matrix.toBilin'Aux [Fintype n] (M : Matrix n n R₁) : BilinForm R₁ (n → R₁) :=
   Matrix.toLinearMap₂'Aux _ _ M
 
-theorem Matrix.toBilin'Aux_single [Fintype n] [DecidableEq n] (M : Matrix n n R₂) (i j : n) :
+theorem Matrix.toBilin'Aux_single [Fintype n] [DecidableEq n] (M : Matrix n n R₁) (i j : n) :
     M.toBilin'Aux (Pi.single i 1) (Pi.single j 1) = M i j :=
   Matrix.toLinearMap₂'Aux_single _ _ _ _ _
 
 /-- The linear map from bilinear forms to `Matrix n n R` given an `n`-indexed basis.
 
 This is an auxiliary definition for the equivalence `Matrix.toBilin'`. -/
-def BilinForm.toMatrixAux (b : n → M₂) : BilinForm R₂ M₂ →ₗ[R₂] Matrix n n R₂ :=
-  LinearMap.toMatrix₂Aux R₂ b b
+def BilinForm.toMatrixAux (b : n → M₁) : BilinForm R₁ M₁ →ₗ[R₁] Matrix n n R₁ :=
+  LinearMap.toMatrix₂Aux R₁ b b
 
 @[simp]
-theorem LinearMap.BilinForm.toMatrixAux_apply (B : BilinForm R₂ M₂) (b : n → M₂) (i j : n) :
+theorem LinearMap.BilinForm.toMatrixAux_apply (B : BilinForm R₁ M₁) (b : n → M₁) (i j : n) :
     -- Porting note: had to hint the base ring even though it should be clear from context...
-    BilinForm.toMatrixAux (R₂ := R₂) b B i j = B (b i) (b j) :=
-  LinearMap.toMatrix₂Aux_apply R₂ B _ _ _ _
+    BilinForm.toMatrixAux (R₁ := R₁) b B i j = B (b i) (b j) :=
+  LinearMap.toMatrix₂Aux_apply R₁ B _ _ _ _
 
 variable [Fintype n] [Fintype o]
 
-theorem toBilin'Aux_toMatrixAux [DecidableEq n] (B₂ : BilinForm R₂ (n → R₂)) :
+theorem toBilin'Aux_toMatrixAux [DecidableEq n] (B₂ : BilinForm R₁ (n → R₁)) :
     -- Porting note: had to hint the base ring even though it should be clear from context...
-    Matrix.toBilin'Aux (BilinForm.toMatrixAux (R₂ := R₂) (fun j => Pi.single j 1) B₂) = B₂ := by
+    Matrix.toBilin'Aux (BilinForm.toMatrixAux (R₁ := R₁) (fun j => Pi.single j 1) B₂) = B₂ := by
   rw [BilinForm.toMatrixAux, Matrix.toBilin'Aux, toLinearMap₂'Aux_toMatrix₂Aux]
 
 section ToMatrix'
@@ -90,95 +83,95 @@ This section deals with the conversion between matrices and bilinear forms on `n
 variable [DecidableEq n] [DecidableEq o]
 
 /-- The linear equivalence between bilinear forms on `n → R` and `n × n` matrices -/
-def LinearMap.BilinForm.toMatrix' : BilinForm R₂ (n → R₂) ≃ₗ[R₂] Matrix n n R₂ :=
-  LinearMap.toMatrix₂' R₂
+def LinearMap.BilinForm.toMatrix' : BilinForm R₁ (n → R₁) ≃ₗ[R₁] Matrix n n R₁ :=
+  LinearMap.toMatrix₂' R₁
 
 /-- The linear equivalence between `n × n` matrices and bilinear forms on `n → R` -/
-def Matrix.toBilin' : Matrix n n R₂ ≃ₗ[R₂] BilinForm R₂ (n → R₂) :=
+def Matrix.toBilin' : Matrix n n R₁ ≃ₗ[R₁] BilinForm R₁ (n → R₁) :=
   BilinForm.toMatrix'.symm
 
 @[simp]
-theorem Matrix.toBilin'Aux_eq (M : Matrix n n R₂) : Matrix.toBilin'Aux M = Matrix.toBilin' M :=
+theorem Matrix.toBilin'Aux_eq (M : Matrix n n R₁) : Matrix.toBilin'Aux M = Matrix.toBilin' M :=
   rfl
 
-theorem Matrix.toBilin'_apply (M : Matrix n n R₂) (x y : n → R₂) :
+theorem Matrix.toBilin'_apply (M : Matrix n n R₁) (x y : n → R₁) :
     Matrix.toBilin' M x y = ∑ i, ∑ j, x i * M i j * y j :=
   (Matrix.toLinearMap₂'_apply _ _ _).trans
     (by simp only [smul_eq_mul, mul_assoc, mul_comm, mul_left_comm])
 
-theorem Matrix.toBilin'_apply' (M : Matrix n n R₂) (v w : n → R₂) :
+theorem Matrix.toBilin'_apply' (M : Matrix n n R₁) (v w : n → R₁) :
     Matrix.toBilin' M v w = Matrix.dotProduct v (M *ᵥ w) := Matrix.toLinearMap₂'_apply' _ _ _
 
 @[simp]
-theorem Matrix.toBilin'_single (M : Matrix n n R₂) (i j : n) :
+theorem Matrix.toBilin'_single (M : Matrix n n R₁) (i j : n) :
     Matrix.toBilin' M (Pi.single i 1) (Pi.single j 1) = M i j := by
   simp [Matrix.toBilin'_apply, Pi.single_apply]
 
 set_option linter.deprecated false in
 @[simp, deprecated Matrix.toBilin'_single (since := "2024-08-09")]
-theorem Matrix.toBilin'_stdBasis (M : Matrix n n R₂) (i j : n) :
+theorem Matrix.toBilin'_stdBasis (M : Matrix n n R₁) (i j : n) :
     Matrix.toBilin' M
-      (LinearMap.stdBasis R₂ (fun _ ↦ R₂) i 1)
-      (LinearMap.stdBasis R₂ (fun _ ↦ R₂) j 1) = M i j := Matrix.toBilin'_single _ _ _
+      (LinearMap.stdBasis R₁ (fun _ ↦ R₁) i 1)
+      (LinearMap.stdBasis R₁ (fun _ ↦ R₁) j 1) = M i j := Matrix.toBilin'_single _ _ _
 
 @[simp]
 theorem LinearMap.BilinForm.toMatrix'_symm :
-    (BilinForm.toMatrix'.symm : Matrix n n R₂ ≃ₗ[R₂] _) = Matrix.toBilin' :=
+    (BilinForm.toMatrix'.symm : Matrix n n R₁ ≃ₗ[R₁] _) = Matrix.toBilin' :=
   rfl
 
 @[simp]
 theorem Matrix.toBilin'_symm :
-    (Matrix.toBilin'.symm : _ ≃ₗ[R₂] Matrix n n R₂) = BilinForm.toMatrix' :=
+    (Matrix.toBilin'.symm : _ ≃ₗ[R₁] Matrix n n R₁) = BilinForm.toMatrix' :=
   BilinForm.toMatrix'.symm_symm
 
 @[simp]
-theorem Matrix.toBilin'_toMatrix' (B : BilinForm R₂ (n → R₂)) :
+theorem Matrix.toBilin'_toMatrix' (B : BilinForm R₁ (n → R₁)) :
     Matrix.toBilin' (BilinForm.toMatrix' B) = B :=
   Matrix.toBilin'.apply_symm_apply B
 
 namespace LinearMap
 
 @[simp]
-theorem BilinForm.toMatrix'_toBilin' (M : Matrix n n R₂) :
+theorem BilinForm.toMatrix'_toBilin' (M : Matrix n n R₁) :
     BilinForm.toMatrix' (Matrix.toBilin' M) = M :=
-  (LinearMap.toMatrix₂' R₂).apply_symm_apply M
+  (LinearMap.toMatrix₂' R₁).apply_symm_apply M
 
 @[simp]
-theorem BilinForm.toMatrix'_apply (B : BilinForm R₂ (n → R₂)) (i j : n) :
+theorem BilinForm.toMatrix'_apply (B : BilinForm R₁ (n → R₁)) (i j : n) :
     BilinForm.toMatrix' B i j = B (Pi.single i 1) (Pi.single j 1) :=
   LinearMap.toMatrix₂'_apply _ _ _
 
 -- Porting note: dot notation for bundled maps doesn't work in the rest of this section
 @[simp]
-theorem BilinForm.toMatrix'_comp (B : BilinForm R₂ (n → R₂)) (l r : (o → R₂) →ₗ[R₂] n → R₂) :
+theorem BilinForm.toMatrix'_comp (B : BilinForm R₁ (n → R₁)) (l r : (o → R₁) →ₗ[R₁] n → R₁) :
     BilinForm.toMatrix' (B.comp l r) =
       (LinearMap.toMatrix' l)ᵀ * BilinForm.toMatrix' B * LinearMap.toMatrix' r :=
   LinearMap.toMatrix₂'_compl₁₂ B _ _
 
-theorem BilinForm.toMatrix'_compLeft (B : BilinForm R₂ (n → R₂)) (f : (n → R₂) →ₗ[R₂] n → R₂) :
+theorem BilinForm.toMatrix'_compLeft (B : BilinForm R₁ (n → R₁)) (f : (n → R₁) →ₗ[R₁] n → R₁) :
     BilinForm.toMatrix' (B.compLeft f) = (LinearMap.toMatrix' f)ᵀ * BilinForm.toMatrix' B :=
   LinearMap.toMatrix₂'_comp B _
 
-theorem BilinForm.toMatrix'_compRight (B : BilinForm R₂ (n → R₂)) (f : (n → R₂) →ₗ[R₂] n → R₂) :
+theorem BilinForm.toMatrix'_compRight (B : BilinForm R₁ (n → R₁)) (f : (n → R₁) →ₗ[R₁] n → R₁) :
     BilinForm.toMatrix' (B.compRight f) = BilinForm.toMatrix' B * LinearMap.toMatrix' f :=
   LinearMap.toMatrix₂'_compl₂ B _
 
-theorem BilinForm.mul_toMatrix'_mul (B : BilinForm R₂ (n → R₂)) (M : Matrix o n R₂)
-    (N : Matrix n o R₂) : M * BilinForm.toMatrix' B * N =
+theorem BilinForm.mul_toMatrix'_mul (B : BilinForm R₁ (n → R₁)) (M : Matrix o n R₁)
+    (N : Matrix n o R₁) : M * BilinForm.toMatrix' B * N =
       BilinForm.toMatrix' (B.comp (Matrix.toLin' Mᵀ) (Matrix.toLin' N)) :=
   LinearMap.mul_toMatrix₂'_mul B _ _
 
-theorem BilinForm.mul_toMatrix' (B : BilinForm R₂ (n → R₂)) (M : Matrix n n R₂) :
+theorem BilinForm.mul_toMatrix' (B : BilinForm R₁ (n → R₁)) (M : Matrix n n R₁) :
     M * BilinForm.toMatrix' B = BilinForm.toMatrix' (B.compLeft (Matrix.toLin' Mᵀ)) :=
   LinearMap.mul_toMatrix' B _
 
-theorem BilinForm.toMatrix'_mul (B : BilinForm R₂ (n → R₂)) (M : Matrix n n R₂) :
+theorem BilinForm.toMatrix'_mul (B : BilinForm R₁ (n → R₁)) (M : Matrix n n R₁) :
     BilinForm.toMatrix' B * M = BilinForm.toMatrix' (B.compRight (Matrix.toLin' M)) :=
   LinearMap.toMatrix₂'_mul B _
 
 end LinearMap
 
-theorem Matrix.toBilin'_comp (M : Matrix n n R₂) (P Q : Matrix n o R₂) :
+theorem Matrix.toBilin'_comp (M : Matrix n n R₁) (P Q : Matrix n o R₁) :
     M.toBilin'.comp (Matrix.toLin' P) (Matrix.toLin' Q) = Matrix.toBilin' (Pᵀ * M * Q) :=
   BilinForm.toMatrix'.injective
     (by simp only [BilinForm.toMatrix'_comp, BilinForm.toMatrix'_toBilin', toMatrix'_toLin'])
@@ -194,32 +187,32 @@ a module with a fixed basis.
 -/
 
 
-variable [DecidableEq n] (b : Basis n R₂ M₂)
+variable [DecidableEq n] (b : Basis n R₁ M₁)
 
 /-- `BilinForm.toMatrix b` is the equivalence between `R`-bilinear forms on `M` and
 `n`-by-`n` matrices with entries in `R`, if `b` is an `R`-basis for `M`. -/
-noncomputable def BilinForm.toMatrix : BilinForm R₂ M₂ ≃ₗ[R₂] Matrix n n R₂ :=
+noncomputable def BilinForm.toMatrix : BilinForm R₁ M₁ ≃ₗ[R₁] Matrix n n R₁ :=
   LinearMap.toMatrix₂ b b
 
 /-- `BilinForm.toMatrix b` is the equivalence between `R`-bilinear forms on `M` and
 `n`-by-`n` matrices with entries in `R`, if `b` is an `R`-basis for `M`. -/
-noncomputable def Matrix.toBilin : Matrix n n R₂ ≃ₗ[R₂] BilinForm R₂ M₂ :=
+noncomputable def Matrix.toBilin : Matrix n n R₁ ≃ₗ[R₁] BilinForm R₁ M₁ :=
   (BilinForm.toMatrix b).symm
 
 @[simp]
-theorem BilinForm.toMatrix_apply (B : BilinForm R₂ M₂) (i j : n) :
+theorem BilinForm.toMatrix_apply (B : BilinForm R₁ M₁) (i j : n) :
     BilinForm.toMatrix b B i j = B (b i) (b j) :=
   LinearMap.toMatrix₂_apply _ _ B _ _
 
 @[simp]
-theorem Matrix.toBilin_apply (M : Matrix n n R₂) (x y : M₂) :
+theorem Matrix.toBilin_apply (M : Matrix n n R₁) (x y : M₁) :
     Matrix.toBilin b M x y = ∑ i, ∑ j, b.repr x i * M i j * b.repr y j :=
   (Matrix.toLinearMap₂_apply _ _ _ _ _).trans
     (by simp only [smul_eq_mul, mul_assoc, mul_comm, mul_left_comm])
 
 -- Not a `simp` lemma since `BilinForm.toMatrix` needs an extra argument
-theorem BilinearForm.toMatrixAux_eq (B : BilinForm R₂ M₂) :
-    BilinForm.toMatrixAux (R₂ := R₂) b B = BilinForm.toMatrix b B :=
+theorem BilinearForm.toMatrixAux_eq (B : BilinForm R₁ M₁) :
+    BilinForm.toMatrixAux (R₁ := R₁) b B = BilinForm.toMatrix b B :=
   LinearMap.toMatrix₂Aux_eq _ _ B
 
 @[simp]
@@ -230,62 +223,62 @@ theorem BilinForm.toMatrix_symm : (BilinForm.toMatrix b).symm = Matrix.toBilin b
 theorem Matrix.toBilin_symm : (Matrix.toBilin b).symm = BilinForm.toMatrix b :=
   (BilinForm.toMatrix b).symm_symm
 
-theorem Matrix.toBilin_basisFun : Matrix.toBilin (Pi.basisFun R₂ n) = Matrix.toBilin' := by
+theorem Matrix.toBilin_basisFun : Matrix.toBilin (Pi.basisFun R₁ n) = Matrix.toBilin' := by
   ext M
   simp only [coe_comp, coe_single, Function.comp_apply, toBilin_apply, Pi.basisFun_repr,
     toBilin'_apply]
 
 theorem BilinForm.toMatrix_basisFun :
-    BilinForm.toMatrix (Pi.basisFun R₂ n) = BilinForm.toMatrix' := by
+    BilinForm.toMatrix (Pi.basisFun R₁ n) = BilinForm.toMatrix' := by
   rw [BilinForm.toMatrix, BilinForm.toMatrix', LinearMap.toMatrix₂_basisFun]
 
 @[simp]
-theorem Matrix.toBilin_toMatrix (B : BilinForm R₂ M₂) :
+theorem Matrix.toBilin_toMatrix (B : BilinForm R₁ M₁) :
     Matrix.toBilin b (BilinForm.toMatrix b B) = B :=
   (Matrix.toBilin b).apply_symm_apply B
 
 @[simp]
-theorem BilinForm.toMatrix_toBilin (M : Matrix n n R₂) :
+theorem BilinForm.toMatrix_toBilin (M : Matrix n n R₁) :
     BilinForm.toMatrix b (Matrix.toBilin b M) = M :=
   (BilinForm.toMatrix b).apply_symm_apply M
 
-variable {M₂' : Type*} [AddCommMonoid M₂'] [Module R₂ M₂']
-variable (c : Basis o R₂ M₂')
+variable {M₂' : Type*} [AddCommMonoid M₂'] [Module R₁ M₂']
+variable (c : Basis o R₁ M₂')
 variable [DecidableEq o]
 
 -- Cannot be a `simp` lemma because `b` must be inferred.
-theorem BilinForm.toMatrix_comp (B : BilinForm R₂ M₂) (l r : M₂' →ₗ[R₂] M₂) :
+theorem BilinForm.toMatrix_comp (B : BilinForm R₁ M₁) (l r : M₂' →ₗ[R₁] M₁) :
     BilinForm.toMatrix c (B.comp l r) =
       (LinearMap.toMatrix c b l)ᵀ * BilinForm.toMatrix b B * LinearMap.toMatrix c b r :=
   LinearMap.toMatrix₂_compl₁₂ _ _ _ _ B _ _
 
-theorem BilinForm.toMatrix_compLeft (B : BilinForm R₂ M₂) (f : M₂ →ₗ[R₂] M₂) :
+theorem BilinForm.toMatrix_compLeft (B : BilinForm R₁ M₁) (f : M₁ →ₗ[R₁] M₁) :
     BilinForm.toMatrix b (B.compLeft f) = (LinearMap.toMatrix b b f)ᵀ * BilinForm.toMatrix b B :=
   LinearMap.toMatrix₂_comp _ _ _ B _
 
-theorem BilinForm.toMatrix_compRight (B : BilinForm R₂ M₂) (f : M₂ →ₗ[R₂] M₂) :
+theorem BilinForm.toMatrix_compRight (B : BilinForm R₁ M₁) (f : M₁ →ₗ[R₁] M₁) :
     BilinForm.toMatrix b (B.compRight f) = BilinForm.toMatrix b B * LinearMap.toMatrix b b f :=
   LinearMap.toMatrix₂_compl₂ _ _ _ B _
 
 @[simp]
-theorem BilinForm.toMatrix_mul_basis_toMatrix (c : Basis o R₂ M₂) (B : BilinForm R₂ M₂) :
+theorem BilinForm.toMatrix_mul_basis_toMatrix (c : Basis o R₁ M₁) (B : BilinForm R₁ M₁) :
     (b.toMatrix c)ᵀ * BilinForm.toMatrix b B * b.toMatrix c = BilinForm.toMatrix c B :=
   LinearMap.toMatrix₂_mul_basis_toMatrix _ _ _  _ B
 
-theorem BilinForm.mul_toMatrix_mul (B : BilinForm R₂ M₂) (M : Matrix o n R₂) (N : Matrix n o R₂) :
+theorem BilinForm.mul_toMatrix_mul (B : BilinForm R₁ M₁) (M : Matrix o n R₁) (N : Matrix n o R₁) :
     M * BilinForm.toMatrix b B * N =
       BilinForm.toMatrix c (B.comp (Matrix.toLin c b Mᵀ) (Matrix.toLin c b N)) :=
   LinearMap.mul_toMatrix₂_mul _ _ _ _ B _ _
 
-theorem BilinForm.mul_toMatrix (B : BilinForm R₂ M₂) (M : Matrix n n R₂) :
+theorem BilinForm.mul_toMatrix (B : BilinForm R₁ M₁) (M : Matrix n n R₁) :
     M * BilinForm.toMatrix b B = BilinForm.toMatrix b (B.compLeft (Matrix.toLin b b Mᵀ)) :=
   LinearMap.mul_toMatrix₂ _ _ _ B _
 
-theorem BilinForm.toMatrix_mul (B : BilinForm R₂ M₂) (M : Matrix n n R₂) :
+theorem BilinForm.toMatrix_mul (B : BilinForm R₁ M₁) (M : Matrix n n R₁) :
     BilinForm.toMatrix b B * M = BilinForm.toMatrix b (B.compRight (Matrix.toLin b b M)) :=
   LinearMap.toMatrix₂_mul _ _ _  B _
 
-theorem Matrix.toBilin_comp (M : Matrix n n R₂) (P Q : Matrix n o R₂) :
+theorem Matrix.toBilin_comp (M : Matrix n n R₁) (P Q : Matrix n o R₁) :
     (Matrix.toBilin b M).comp (toLin c b P) (toLin c b Q) = Matrix.toBilin c (Pᵀ * M * Q) := by
   ext x y
   rw [Matrix.toBilin, BilinForm.toMatrix, Matrix.toBilin, BilinForm.toMatrix, toMatrix₂_symm,
@@ -301,8 +294,8 @@ section MatrixAdjoints
 open Matrix
 
 variable {n : Type*} [Fintype n]
-variable (b : Basis n R₃ M₃)
-variable (J J₃ A A' : Matrix n n R₃)
+variable (b : Basis n R₂ M₂)
+variable (J J₃ A A' : Matrix n n R₂)
 
 @[simp]
 theorem isAdjointPair_toBilin' [DecidableEq n] :
@@ -318,7 +311,7 @@ theorem isAdjointPair_toBilin [DecidableEq n] :
       Matrix.IsAdjointPair J J₃ A A' :=
   isAdjointPair_toLinearMap₂ _ _ _ _ _ _
 
-theorem Matrix.isAdjointPair_equiv' [DecidableEq n] (P : Matrix n n R₃) (h : IsUnit P) :
+theorem Matrix.isAdjointPair_equiv' [DecidableEq n] (P : Matrix n n R₂) (h : IsUnit P) :
     (Pᵀ * J * P).IsAdjointPair (Pᵀ * J * P) A A' ↔
       J.IsAdjointPair J (P * A * P⁻¹) (P * A' * P⁻¹) :=
   Matrix.isAdjointPair_equiv _ _ _ _ h
@@ -327,10 +320,10 @@ variable [DecidableEq n]
 
 /-- The submodule of pair-self-adjoint matrices with respect to bilinear forms corresponding to
 given matrices `J`, `J₂`. -/
-def pairSelfAdjointMatricesSubmodule' : Submodule R₃ (Matrix n n R₃) :=
+def pairSelfAdjointMatricesSubmodule' : Submodule R₂ (Matrix n n R₂) :=
   (BilinForm.isPairSelfAdjointSubmodule (Matrix.toBilin' J) (Matrix.toBilin' J₃)).map
-    ((LinearMap.toMatrix' : ((n → R₃) →ₗ[R₃] n → R₃) ≃ₗ[R₃] Matrix n n R₃) :
-      ((n → R₃) →ₗ[R₃] n → R₃) →ₗ[R₃] Matrix n n R₃)
+    ((LinearMap.toMatrix' : ((n → R₂) →ₗ[R₂] n → R₂) ≃ₗ[R₂] Matrix n n R₂) :
+      ((n → R₂) →ₗ[R₂] n → R₂) →ₗ[R₂] Matrix n n R₂)
 
 theorem mem_pairSelfAdjointMatricesSubmodule' :
     A ∈ pairSelfAdjointMatricesSubmodule J J₃ ↔ Matrix.IsAdjointPair J J₃ A A := by
@@ -338,7 +331,7 @@ theorem mem_pairSelfAdjointMatricesSubmodule' :
 
 /-- The submodule of self-adjoint matrices with respect to the bilinear form corresponding to
 the matrix `J`. -/
-def selfAdjointMatricesSubmodule' : Submodule R₃ (Matrix n n R₃) :=
+def selfAdjointMatricesSubmodule' : Submodule R₂ (Matrix n n R₂) :=
   pairSelfAdjointMatricesSubmodule J J
 
 theorem mem_selfAdjointMatricesSubmodule' :
@@ -347,7 +340,7 @@ theorem mem_selfAdjointMatricesSubmodule' :
 
 /-- The submodule of skew-adjoint matrices with respect to the bilinear form corresponding to
 the matrix `J`. -/
-def skewAdjointMatricesSubmodule' : Submodule R₃ (Matrix n n R₃) :=
+def skewAdjointMatricesSubmodule' : Submodule R₂ (Matrix n n R₂) :=
   pairSelfAdjointMatricesSubmodule (-J) J
 
 theorem mem_skewAdjointMatricesSubmodule' :
@@ -364,49 +357,49 @@ section Det
 
 open Matrix
 
-variable {A : Type*} [CommRing A] [IsDomain A] [Module A M₃] (B₃ : BilinForm A M₃)
+variable {A : Type*} [CommRing A] [IsDomain A] [Module A M₂] (B₃ : BilinForm A M₂)
 variable {ι : Type*} [DecidableEq ι] [Fintype ι]
 
-theorem _root_.Matrix.nondegenerate_toBilin'_iff_nondegenerate_toBilin {M : Matrix ι ι R₂}
-    (b : Basis ι R₂ M₂) : M.toBilin'.Nondegenerate ↔ (Matrix.toBilin b M).Nondegenerate :=
+theorem _root_.Matrix.nondegenerate_toBilin'_iff_nondegenerate_toBilin {M : Matrix ι ι R₁}
+    (b : Basis ι R₁ M₁) : M.toBilin'.Nondegenerate ↔ (Matrix.toBilin b M).Nondegenerate :=
   (nondegenerate_congr_iff b.equivFun.symm).symm
 
 -- Lemmas transferring nondegeneracy between a matrix and its associated bilinear form
-theorem _root_.Matrix.Nondegenerate.toBilin' {M : Matrix ι ι R₃} (h : M.Nondegenerate) :
+theorem _root_.Matrix.Nondegenerate.toBilin' {M : Matrix ι ι R₂} (h : M.Nondegenerate) :
     M.toBilin'.Nondegenerate := fun x hx =>
   h.eq_zero_of_ortho fun y => by simpa only [toBilin'_apply'] using hx y
 
 @[simp]
-theorem _root_.Matrix.nondegenerate_toBilin'_iff {M : Matrix ι ι R₃} :
+theorem _root_.Matrix.nondegenerate_toBilin'_iff {M : Matrix ι ι R₂} :
     M.toBilin'.Nondegenerate ↔ M.Nondegenerate :=
   ⟨fun h v hv => h v fun w => (M.toBilin'_apply' _ _).trans <| hv w, Matrix.Nondegenerate.toBilin'⟩
 
-theorem _root_.Matrix.Nondegenerate.toBilin {M : Matrix ι ι R₃} (h : M.Nondegenerate)
-    (b : Basis ι R₃ M₃) : (Matrix.toBilin b M).Nondegenerate :=
+theorem _root_.Matrix.Nondegenerate.toBilin {M : Matrix ι ι R₂} (h : M.Nondegenerate)
+    (b : Basis ι R₂ M₂) : (Matrix.toBilin b M).Nondegenerate :=
   (Matrix.nondegenerate_toBilin'_iff_nondegenerate_toBilin b).mp h.toBilin'
 
 @[simp]
-theorem _root_.Matrix.nondegenerate_toBilin_iff {M : Matrix ι ι R₃} (b : Basis ι R₃ M₃) :
+theorem _root_.Matrix.nondegenerate_toBilin_iff {M : Matrix ι ι R₂} (b : Basis ι R₂ M₂) :
     (Matrix.toBilin b M).Nondegenerate ↔ M.Nondegenerate := by
   rw [← Matrix.nondegenerate_toBilin'_iff_nondegenerate_toBilin, Matrix.nondegenerate_toBilin'_iff]
 
 /-! Lemmas transferring nondegeneracy between a bilinear form and its associated matrix -/
 
 @[simp]
-theorem nondegenerate_toMatrix'_iff {B : BilinForm R₃ (ι → R₃)} :
+theorem nondegenerate_toMatrix'_iff {B : BilinForm R₂ (ι → R₂)} :
     B.toMatrix'.Nondegenerate (m := ι) ↔ B.Nondegenerate :=
   Matrix.nondegenerate_toBilin'_iff.symm.trans <| (Matrix.toBilin'_toMatrix' B).symm ▸ Iff.rfl
 
-theorem Nondegenerate.toMatrix' {B : BilinForm R₃ (ι → R₃)} (h : B.Nondegenerate) :
+theorem Nondegenerate.toMatrix' {B : BilinForm R₂ (ι → R₂)} (h : B.Nondegenerate) :
     B.toMatrix'.Nondegenerate :=
   nondegenerate_toMatrix'_iff.mpr h
 
 @[simp]
-theorem nondegenerate_toMatrix_iff {B : BilinForm R₃ M₃} (b : Basis ι R₃ M₃) :
+theorem nondegenerate_toMatrix_iff {B : BilinForm R₂ M₂} (b : Basis ι R₂ M₂) :
     (BilinForm.toMatrix b B).Nondegenerate ↔ B.Nondegenerate :=
   (Matrix.nondegenerate_toBilin_iff b).symm.trans <| (Matrix.toBilin_toMatrix b B).symm ▸ Iff.rfl
 
-theorem Nondegenerate.toMatrix {B : BilinForm R₃ M₃} (h : B.Nondegenerate) (b : Basis ι R₃ M₃) :
+theorem Nondegenerate.toMatrix {B : BilinForm R₂ M₂} (h : B.Nondegenerate) (b : Basis ι R₂ M₂) :
     (BilinForm.toMatrix b B).Nondegenerate :=
   (nondegenerate_toMatrix_iff b).mpr h
 
@@ -420,11 +413,11 @@ theorem nondegenerate_toBilin'_of_det_ne_zero' (M : Matrix ι ι A) (h : M.det �
     M.toBilin'.Nondegenerate :=
   nondegenerate_toBilin'_iff_det_ne_zero.mpr h
 
-theorem nondegenerate_iff_det_ne_zero {B : BilinForm A M₃} (b : Basis ι A M₃) :
+theorem nondegenerate_iff_det_ne_zero {B : BilinForm A M₂} (b : Basis ι A M₂) :
     B.Nondegenerate ↔ (BilinForm.toMatrix b B).det ≠ 0 := by
   rw [← Matrix.nondegenerate_iff_det_ne_zero, nondegenerate_toMatrix_iff]
 
-theorem nondegenerate_of_det_ne_zero (b : Basis ι A M₃) (h : (BilinForm.toMatrix b B₃).det ≠ 0) :
+theorem nondegenerate_of_det_ne_zero (b : Basis ι A M₂) (h : (BilinForm.toMatrix b B₃).det ≠ 0) :
     B₃.Nondegenerate :=
   (nondegenerate_iff_det_ne_zero b).mpr h
 

--- a/Mathlib/MeasureTheory/Integral/IntegralEqImproper.lean
+++ b/Mathlib/MeasureTheory/Integral/IntegralEqImproper.lean
@@ -642,7 +642,7 @@ open scoped Interval
 
 section IoiFTC
 
-variable {E : Type*} {f f' : ℝ → E} {g g' : ℝ → ℝ} {a b l : ℝ} {m : E} [NormedAddCommGroup E]
+variable {E : Type*} {f f' : ℝ → E} {g g' : ℝ → ℝ} {a l : ℝ} {m : E} [NormedAddCommGroup E]
   [NormedSpace ℝ E]
 
 /-- If the derivative of a function defined on the real line is integrable close to `+∞`, then
@@ -864,7 +864,7 @@ end IoiFTC
 
 section IicFTC
 
-variable {E : Type*} {f f' : ℝ → E} {g g' : ℝ → ℝ} {a b l : ℝ} {m : E} [NormedAddCommGroup E]
+variable {E : Type*} {f f' : ℝ → E} {a : ℝ} {m : E} [NormedAddCommGroup E]
   [NormedSpace ℝ E]
 
 /-- If the derivative of a function defined on the real line is integrable close to `-∞`, then
@@ -983,7 +983,7 @@ end IicFTC
 
 section UnivFTC
 
-variable {E : Type*} {f f' : ℝ → E} {g g' : ℝ → ℝ} {a b l : ℝ} {m n : E} [NormedAddCommGroup E]
+variable {E : Type*} {f f' : ℝ → E} {m n : E} [NormedAddCommGroup E]
   [NormedSpace ℝ E]
 
 /-- **Fundamental theorem of calculus-2**, on the whole real line
@@ -1025,7 +1025,7 @@ open Real
 
 open scoped Interval
 
-variable {E : Type*} {f : ℝ → E} [NormedAddCommGroup E] [NormedSpace ℝ E]
+variable {E : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E]
 
 /-- Change-of-variables formula for `Ioi` integrals of vector-valued functions, proved by taking
 limits from the result for finite intervals. -/
@@ -1224,7 +1224,7 @@ end IntegrationByPartsBilinear
 section IntegrationByPartsAlgebra
 
 variable {A : Type*} [NormedRing A] [NormedAlgebra ℝ A]
-  {a b : ℝ} {a' b' : A} {u : ℝ → A} {v : ℝ → A} {u' : ℝ → A} {v' : ℝ → A}
+  {a : ℝ} {a' b' : A} {u : ℝ → A} {v : ℝ → A} {u' : ℝ → A} {v' : ℝ → A}
 
 /-- For finite intervals, see: `intervalIntegral.integral_deriv_mul_eq_sub`. -/
 theorem integral_deriv_mul_eq_sub [CompleteSpace A]


### PR DESCRIPTION
I also relabeled some indices, since some intermediate variables vanished in the process.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
