### PR TITLE
[Merged by Bors] - chore(CategoryTheory/Adjunction): homEquiv_unit is no longer a global simp lemma

### DIFF
--- a/Mathlib/CategoryTheory/Adjunction/Basic.lean
+++ b/Mathlib/CategoryTheory/Adjunction/Basic.lean
@@ -299,12 +299,6 @@ structure CoreHomEquivUnitCounit (F : C ⥤ D) (G : D ⥤ C) where
   /-- The relationship between the counit and hom set equivalence of an adjunction -/
   homEquiv_counit : ∀ {X Y g}, (homEquiv X Y).symm g = F.map g ≫ counit.app Y := by aesop_cat
 
-namespace CoreHomEquivUnitCounit
-
-attribute [simp] homEquiv_unit homEquiv_counit
-
-end CoreHomEquivUnitCounit
-
 /-- This is an auxiliary data structure useful for constructing adjunctions.
 See `Adjunction.mkOfHomEquiv`.
 This structure won't typically be used anywhere else.
@@ -372,6 +366,8 @@ attribute [simp] left_triangle right_triangle
 end CoreUnitCounit
 
 variable {F : C ⥤ D} {G : D ⥤ C}
+
+attribute [local simp] CoreHomEquivUnitCounit.homEquiv_unit CoreHomEquivUnitCounit.homEquiv_counit
 
 /--
 Construct an adjunction from the data of a `CoreHomEquivUnitCounit`, i.e. a hom set

--- a/Mathlib/CategoryTheory/Adjunction/Basic.lean
+++ b/Mathlib/CategoryTheory/Adjunction/Basic.lean
@@ -151,7 +151,7 @@ namespace Adjunction
 attribute [reassoc (attr := simp)] left_triangle_components right_triangle_components
 
 /-- The hom set equivalence associated to an adjunction. -/
-@[simps]
+@[simps (config := .lemmasOnly)]
 def homEquiv {F : C ⥤ D} {G : D ⥤ C} (adj : F ⊣ G) (X : C) (Y : D) :
     (F.obj X ⟶ Y) ≃ (X ⟶ G.obj Y) where
   toFun := fun f => adj.unit.app X ≫ G.map f

--- a/Mathlib/CategoryTheory/Adjunction/Basic.lean
+++ b/Mathlib/CategoryTheory/Adjunction/Basic.lean
@@ -165,7 +165,17 @@ def homEquiv {F : C ⥤ D} {G : D ⥤ C} (adj : F ⊣ G) (X : C) (Y : D) :
 
 alias homEquiv_unit := homEquiv_apply
 alias homEquiv_counit := homEquiv_symm_apply
-attribute [simp] homEquiv_unit homEquiv_counit
+
+end Adjunction
+
+-- These lemmas are not global simp lemmas because certain adjunctions
+-- are constructed using `Adjunction.mkOfHomEquiv`, and we certainly
+-- do not want `dsimp` to apply `homEquiv_unit` or `homEquiv_counit`
+-- in that case. However, when proving general API results about adjunctions,
+-- it may be advisable to add a local simp attribute to these lemmas.
+attribute [local simp] Adjunction.homEquiv_unit Adjunction.homEquiv_counit
+
+namespace Adjunction
 
 section
 

--- a/Mathlib/CategoryTheory/Adjunction/Basic.lean
+++ b/Mathlib/CategoryTheory/Adjunction/Basic.lean
@@ -407,6 +407,7 @@ def mkOfHomEquiv (adj : CoreHomEquiv F G) : F ⊣ G :=
     homEquiv_unit := fun {X Y f} => by simp [← adj.homEquiv_naturality_right]
     homEquiv_counit := fun {X Y f} => by simp [← adj.homEquiv_naturality_left_symm] }
 
+@[simp]
 lemma mkOfHomEquiv_homEquiv (adj : CoreHomEquiv F G) :
     (mkOfHomEquiv adj).homEquiv = adj.homEquiv := by
   ext X Y g

--- a/Mathlib/CategoryTheory/Adjunction/Comma.lean
+++ b/Mathlib/CategoryTheory/Adjunction/Comma.lean
@@ -125,6 +125,8 @@ section
 
 variable {F : C ⥤ D}
 
+attribute [local simp] Adjunction.homEquiv_unit Adjunction.homEquiv_counit
+
 /-- Given a left adjoint to `G`, we can construct an initial object in each structured arrow
 category on `G`. -/
 def mkInitialOfLeftAdjoint (h : F ⊣ G) (A : C) :

--- a/Mathlib/CategoryTheory/Adjunction/FullyFaithful.lean
+++ b/Mathlib/CategoryTheory/Adjunction/FullyFaithful.lean
@@ -40,6 +40,8 @@ open Category
 
 open Opposite
 
+attribute [local simp] Adjunction.homEquiv_unit Adjunction.homEquiv_counit
+
 variable {C : Type u₁} [Category.{v₁} C]
 variable {D : Type u₂} [Category.{v₂} D]
 variable {L : C ⥤ D} {R : D ⥤ C} (h : L ⊣ R)

--- a/Mathlib/CategoryTheory/Adjunction/Lifting/Left.lean
+++ b/Mathlib/CategoryTheory/Adjunction/Lifting/Left.lean
@@ -157,6 +157,8 @@ noncomputable def constructLeftAdjointEquiv [∀ X : B, RegularEpi (adj₁.couni
       apply eq_comm
     _ ≃ (X ⟶ R.obj Y) := (Cofork.IsColimit.homIso (counitCoequalises adj₁ X) _).symm
 
+attribute [local simp] Adjunction.homEquiv_counit
+
 /-- Construct the left adjoint to `R`, with object map `constructLeftAdjointObj`. -/
 noncomputable def constructLeftAdjoint [∀ X : B, RegularEpi (adj₁.counit.app X)] : B ⥤ A := by
   refine Adjunction.leftAdjointOfEquiv (fun X Y => constructLeftAdjointEquiv R _ adj₁ adj₂ Y X) ?_

--- a/Mathlib/CategoryTheory/Adjunction/Lifting/Right.lean
+++ b/Mathlib/CategoryTheory/Adjunction/Lifting/Right.lean
@@ -152,6 +152,7 @@ noncomputable def constructRightAdjoint [∀ X : B, RegularMono (adj₁.unit.app
   rw [constructRightAdjointEquiv_symm_apply, constructRightAdjointEquiv_symm_apply,
     Equiv.symm_apply_eq, Subtype.ext_iff]
   dsimp
+  simp only [Adjunction.homEquiv_unit, Adjunction.homEquiv_counit]
   erw [Fork.IsLimit.homIso_natural, Fork.IsLimit.homIso_natural]
   simp only [Fork.ofι_pt, Functor.map_comp, assoc, limit.cone_x]
   erw [adj₂.homEquiv_naturality_left, Equiv.rightInverse_symm]

--- a/Mathlib/CategoryTheory/Adjunction/Limits.lean
+++ b/Mathlib/CategoryTheory/Adjunction/Limits.lean
@@ -296,6 +296,8 @@ end ArbitraryUniverse
 variable {C : Type u₁} [Category.{v₀} C] {D : Type u₂} [Category.{v₀} D] {F : C ⥤ D} {G : D ⥤ C}
   (adj : F ⊣ G)
 
+attribute [local simp] homEquiv_unit homEquiv_counit
+
 -- Note: this is natural in K, but we do not yet have the tools to formulate that.
 /-- When `F ⊣ G`,
 the functor associating to each `Y` the cocones over `K ⋙ F` with cone point `Y`

--- a/Mathlib/CategoryTheory/Adjunction/Opposites.lean
+++ b/Mathlib/CategoryTheory/Adjunction/Opposites.lean
@@ -27,6 +27,8 @@ variable {C : Type u₁} [Category.{v₁} C] {D : Type u₂} [Category.{v₂} D]
 
 namespace CategoryTheory.Adjunction
 
+attribute [local simp] homEquiv_unit homEquiv_counit
+
 /-- If `G.op` is adjoint to `F.op` then `F` is adjoint to `G`. -/
 @[simps! unit_app counit_app]
 def adjointOfOpAdjointOp (F : C ⥤ D) (G : D ⥤ C) (h : G.op ⊣ F.op) : F ⊣ G :=

--- a/Mathlib/CategoryTheory/Adjunction/Reflective.lean
+++ b/Mathlib/CategoryTheory/Adjunction/Reflective.lean
@@ -113,7 +113,7 @@ def unitCompPartialBijectiveAux [Reflective i] (A : C) (B : D) :
 theorem unitCompPartialBijectiveAux_symm_apply [Reflective i] {A : C} {B : D}
     (f : i.obj ((reflector i).obj A) ⟶ i.obj B) :
     (unitCompPartialBijectiveAux _ _).symm f = (reflectorAdjunction i).unit.app A ≫ f := by
-  simp [unitCompPartialBijectiveAux]
+  simp [unitCompPartialBijectiveAux, Adjunction.homEquiv_unit]
 
 /-- If `i` has a reflector `L`, then the function `(i.obj (L.obj A) ⟶ B) → (A ⟶ B)` given by
 precomposing with `η.app A` is a bijection provided `B` is in the essential image of `i`.

--- a/Mathlib/CategoryTheory/Adjunction/Restrict.lean
+++ b/Mathlib/CategoryTheory/Adjunction/Restrict.lean
@@ -27,6 +27,8 @@ variable {iC : C ⥤ C'} {iD : D ⥤ D'}
   {L' : C' ⥤ D'} {R' : D' ⥤ C'} (adj : L' ⊣ R') (hiC : iC.FullyFaithful) (hiD : iD.FullyFaithful)
   {L : C ⥤ D} {R : D ⥤ C} (comm1 : iC ⋙ L' ≅ L ⋙ iD) (comm2 : iD ⋙ R' ≅ R ⋙ iC)
 
+attribute [local simp] homEquiv_unit homEquiv_counit
+
 /-- If `C` is a full subcategory of `C'` and `D` is a full subcategory of `D'`, then we can restrict
 an adjunction `L' ⊣ R'` where `L' : C' ⥤ D'` and `R' : D' ⥤ C'` to `C` and `D`.
 The construction here is slightly more general, in that `C` is required only to have a full and

--- a/Mathlib/CategoryTheory/Adjunction/Unique.lean
+++ b/Mathlib/CategoryTheory/Adjunction/Unique.lean
@@ -26,6 +26,8 @@ variable {C D : Type*} [Category C] [Category D]
 
 namespace CategoryTheory.Adjunction
 
+attribute [local simp] homEquiv_unit homEquiv_counit
+
 /-- If `F` and `F'` are both left adjoint to `G`, then they are naturally isomorphic. -/
 def leftAdjointUniq {F F' : C ⥤ D} {G : D ⥤ C} (adj1 : F ⊣ G) (adj2 : F' ⊣ G) : F ≅ F' :=
   ((conjugateIsoEquiv adj1 adj2).symm (Iso.refl G)).symm

--- a/Mathlib/CategoryTheory/Closed/Ideal.lean
+++ b/Mathlib/CategoryTheory/Closed/Ideal.lean
@@ -202,7 +202,7 @@ theorem bijection_symm_apply_id (A B : C) :
   -- Porting note: added
   dsimp only [Functor.comp_obj]
   rw [prod.comp_lift_assoc, prod.lift_snd, prod.lift_fst_assoc, prod.lift_fst_comp_snd_comp,
-    ← Adjunction.eq_unit_comp_map_iff, Iso.comp_inv_eq, assoc]
+    Adjunction.homEquiv_counit, ← Adjunction.eq_unit_comp_map_iff, Iso.comp_inv_eq, assoc]
   rw [PreservesLimitPair.iso_hom i ((reflector i).obj A) ((reflector i).obj B)]
   apply prod.hom_ext
   · rw [Limits.prod.map_fst, assoc, assoc, prodComparison_fst, ← i.map_comp, prodComparison_fst]
@@ -217,7 +217,8 @@ theorem bijection_natural (A B : C) (X X' : D) (f : (reflector i).obj (A ⨯ B) 
   erw [homEquiv_symm_apply_eq, homEquiv_symm_apply_eq, homEquiv_apply_eq, homEquiv_apply_eq,
     homEquiv_symm_apply_eq, homEquiv_symm_apply_eq, homEquiv_apply_eq, homEquiv_apply_eq]
   apply i.map_injective
-  rw [Functor.FullyFaithful.map_preimage, i.map_comp]
+  rw [Functor.FullyFaithful.map_preimage, i.map_comp,
+    Adjunction.homEquiv_unit, Adjunction.homEquiv_unit]
   simp only [comp_id, Functor.map_comp, Functor.FullyFaithful.map_preimage, assoc]
   rw [← assoc, ← assoc, curry_natural_right _ (i.map g),
     unitCompPartialBijective_natural, uncurry_natural_right, ← assoc, curry_natural_right,

--- a/Mathlib/CategoryTheory/Limits/Final.lean
+++ b/Mathlib/CategoryTheory/Limits/Final.lean
@@ -116,6 +116,8 @@ theorem initial_of_final_op (F : C ⥤ D) [Final F.op] : Initial F :=
       @isConnected_of_isConnected_op _ _
         (isConnected_of_equivalent (costructuredArrowOpEquivalence F d).symm) }
 
+attribute [local simp] Adjunction.homEquiv_unit Adjunction.homEquiv_counit
+
 /-- If a functor `R : D ⥤ C` is a right adjoint, it is final. -/
 theorem final_of_adjunction {L : C ⥤ D} {R : D ⥤ C} (adj : L ⊣ R) : Final R :=
   { out := fun c =>

--- a/Mathlib/CategoryTheory/Limits/HasLimits.lean
+++ b/Mathlib/CategoryTheory/Limits/HasLimits.lean
@@ -539,7 +539,7 @@ def isLimitConeOfAdj (F : J ⥤ C) :
     have eq := NatTrans.congr_app (adj.counit.naturality s.π) j
     have eq' := NatTrans.congr_app (adj.left_triangle_components s.pt) j
     dsimp at eq eq' ⊢
-    rw [assoc, eq, reassoc_of% eq']
+    rw [adj.homEquiv_unit, assoc, eq, reassoc_of% eq']
   uniq s m hm := (adj.homEquiv _ _).symm.injective (by ext j; simpa using hm j)
 
 end Adjunction

--- a/Mathlib/CategoryTheory/Localization/Bousfield.lean
+++ b/Mathlib/CategoryTheory/Localization/Bousfield.lean
@@ -112,6 +112,7 @@ lemma W_adj_unit_app (X : D) : W (· ∈ Set.range F.obj) (adj.unit.app X) := by
   rintro _ ⟨Y, rfl⟩
   convert ((Functor.FullyFaithful.ofFullyFaithful F).homEquiv.symm.trans
     (adj.homEquiv X Y)).bijective using 1
+  dsimp [Adjunction.homEquiv]
   aesop
 
 lemma W_iff_isIso_map {X Y : D} (f : X ⟶ Y) :

--- a/Mathlib/CategoryTheory/Monad/Comonadicity.lean
+++ b/Mathlib/CategoryTheory/Monad/Comonadicity.lean
@@ -117,7 +117,7 @@ def rightAdjointComparison
   · apply comparisonRightAdjointHomEquiv
   · intro A B B' g h
     apply equalizer.hom_ext
-    simp
+    simp [Adjunction.homEquiv_unit]
 
 /-- Provided we have the appropriate equalizers, we have an adjunction to the comparison functor.
 -/
@@ -161,7 +161,7 @@ theorem comparisonAdjunction_counit_f
       (adj.unit.app (G.obj A.A))]
     (A : adj.toComonad.Coalgebra) :
     ((comparisonAdjunction adj).counit.app A).f = (beckEqualizer A).lift (counitFork A) := by
-  simp
+  simp [Adjunction.homEquiv_counit]
 
 variable (adj)
 
@@ -205,7 +205,7 @@ theorem comparisonAdjunction_unit_app
   change
     equalizer.lift ((adj.homEquiv B _) (𝟙 _)) _ ≫ equalizer.ι _ _ =
       equalizer.lift _ _ ≫ equalizer.ι _ _
-  simp
+  simp [Adjunction.homEquiv_unit]
 
 end ComonadicityInternal
 

--- a/Mathlib/CategoryTheory/Monad/Monadicity.lean
+++ b/Mathlib/CategoryTheory/Monad/Monadicity.lean
@@ -130,7 +130,7 @@ def leftAdjointComparison
     -- `Category.assoc`.
     -- dsimp [comparisonLeftAdjointHomEquiv]
     -- rw [← adj.homEquiv_naturality_right, Category.assoc]
-    simp [Cofork.IsColimit.homIso]
+    simp [Cofork.IsColimit.homIso, Adjunction.homEquiv_unit]
 
 /-- Provided we have the appropriate coequalizers, we have an adjunction to the comparison functor.
 -/
@@ -225,7 +225,7 @@ theorem comparisonAdjunction_counit_app
   change
     coequalizer.π _ _ ≫ coequalizer.desc ((adj.homEquiv _ B).symm (𝟙 _)) _ =
       coequalizer.π _ _ ≫ coequalizer.desc _ _
-  simp
+  simp [Adjunction.homEquiv_counit]
 
 end MonadicityInternal
 

--- a/Mathlib/CategoryTheory/Monoidal/Functor.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Functor.lean
@@ -736,10 +736,12 @@ noncomputable def monoidalAdjoint :
 
 instance [F.IsEquivalence] : IsIso (monoidalAdjoint F h).ε := by
   dsimp
+  rw [Adjunction.homEquiv_unit]
   infer_instance
 
 instance (X Y : D) [F.IsEquivalence] : IsIso ((monoidalAdjoint F h).μ X Y) := by
   dsimp
+  rw [Adjunction.homEquiv_unit]
   infer_instance
 
 /-- If a monoidal functor `F` is an equivalence of categories then its inverse is also monoidal. -/

--- a/Mathlib/CategoryTheory/Monoidal/NaturalTransformation.lean
+++ b/Mathlib/CategoryTheory/Monoidal/NaturalTransformation.lean
@@ -172,6 +172,7 @@ def monoidalUnit  :
       F.map_tensor, IsIso.hom_inv_id_assoc, ← tensor_comp_assoc,
       Adjunction.left_triangle_components, tensorHom_id, id_whiskerRight,
       IsIso.inv_hom_id, map_id]
+  unit := by simp [Adjunction.homEquiv_unit]
 
 /-- The unit of a adjunction can be upgraded to a monoidal natural transformation. -/
 @[simps]
@@ -189,7 +190,8 @@ def monoidalCounit :
   unit := by
     have eq := h.counit.naturality F.ε
     dsimp at eq ⊢
-    rw [map_inv, map_comp, assoc, assoc, map_inv, ← cancel_mono F.ε, assoc, assoc, assoc, ← eq,
+    rw [Adjunction.homEquiv_unit, map_inv, map_comp, assoc, assoc, map_inv,
+      ← cancel_mono F.ε, assoc, assoc, assoc, ← eq,
       IsIso.inv_hom_id_assoc, Adjunction.left_triangle_components, comp_id, id_comp]
 
 instance [F.IsEquivalence] : IsIso (monoidalUnit F h) := by

--- a/Mathlib/CategoryTheory/Preadditive/Injective.lean
+++ b/Mathlib/CategoryTheory/Preadditive/Injective.lean
@@ -187,7 +187,8 @@ variable {L : C ⥤ D} {R : D ⥤ C} [PreservesMonomorphisms L]
 theorem injective_of_adjoint (adj : L ⊣ R) (J : D) [Injective J] : Injective <| R.obj J :=
   ⟨fun {A} {_} g f im =>
     ⟨adj.homEquiv _ _ (factorThru ((adj.homEquiv A J).symm g) (L.map f)),
-      (adj.homEquiv _ _).symm.injective (by simp)⟩⟩
+      (adj.homEquiv _ _).symm.injective
+        (by simp [Adjunction.homEquiv_unit, Adjunction.homEquiv_counit])⟩⟩
 
 end Adjunction
 

--- a/Mathlib/CategoryTheory/Sites/PreservesSheafification.lean
+++ b/Mathlib/CategoryTheory/Sites/PreservesSheafification.lean
@@ -170,7 +170,8 @@ lemma sheafComposeNatTrans_fac (P : Cᵒᵖ ⥤ A) :
     adj₂.unit.app (P ⋙ F) ≫
       (sheafToPresheaf J B).map ((sheafComposeNatTrans J F adj₁ adj₂).app P) =
         whiskerRight (adj₁.unit.app P) F  := by
-  simp [sheafComposeNatTrans, -sheafToPresheaf_obj, -sheafToPresheaf_map]
+  simp [sheafComposeNatTrans, -sheafToPresheaf_obj, -sheafToPresheaf_map,
+    Adjunction.homEquiv_counit]
 
 lemma sheafComposeNatTrans_app_uniq (P : Cᵒᵖ ⥤ A)
     (α : G₂.obj (P ⋙ F) ⟶ (sheafCompose J F).obj (G₁.obj P))
@@ -264,9 +265,8 @@ lemma sheafToPresheaf_map_sheafComposeNatTrans_eq_sheafifyCompIso_inv (P : Cᵒ�
     rfl
   apply ((plusPlusAdjunction J E).homEquiv _ _).injective
   convert sheafComposeNatTrans_fac J F (plusPlusAdjunction J D) (plusPlusAdjunction J E) P
-  all_goals
-    dsimp [plusPlusAdjunction]
-    simp
+  dsimp [plusPlusAdjunction]
+  simp
 
 instance (P : Cᵒᵖ ⥤ D) :
     IsIso ((sheafComposeNatTrans J F (plusPlusAdjunction J D) (plusPlusAdjunction J E)).app P) := by

--- a/Mathlib/Topology/Sheaves/Presheaf.lean
+++ b/Mathlib/Topology/Sheaves/Presheaf.lean
@@ -243,7 +243,7 @@ theorem toPushforwardOfIso_app {X Y : TopCat} (H₁ : X ≅ Y) {ℱ : X.Presheaf
       ℱ.map (eqToHom (by simp [Opens.map, Set.preimage_preimage])) ≫
         H₂.app (op ((Opens.map H₁.inv).obj (unop U))) := by
   delta toPushforwardOfIso
-  simp [-Functor.map_comp, ← Functor.map_comp_assoc]
+  simp [-Functor.map_comp, ← Functor.map_comp_assoc, Adjunction.homEquiv_unit]
   rfl
 
 /-- If `H : X ≅ Y` is a homeomorphism,
@@ -259,7 +259,7 @@ theorem pushforwardToOfIso_app {X Y : TopCat} (H₁ : X ≅ Y) {ℱ : Y.Presheaf
     (pushforwardToOfIso H₁ H₂).app U =
       H₂.app (op ((Opens.map H₁.inv).obj (unop U))) ≫
         𝒢.map (eqToHom (by simp [Opens.map, Set.preimage_preimage])) := by
-  simp [pushforwardToOfIso, Equivalence.toAdjunction]
+  simp [pushforwardToOfIso, Equivalence.toAdjunction, Adjunction.homEquiv_counit]
 
 end Iso
 


### PR DESCRIPTION
This PR removes the global `simp` attribute to lemmas `homEquiv_unit` and `homEquiv_counit`. These lemmas express the bijection `homEquiv` in terms of the unit and counit of the adjunction. In situations where adjunctions are defined using the constructor `mkOfHomEquiv`, we do not want these lemmas as global simp. However, when we study adjunctions defined using units and counits, or when proving general API results about them, they can be made local simp.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
