### PR TITLE
[Merged by Bors] - feat: biSup, biInf, biUnion and biInter in NoMaxOrder

### DIFF
--- a/Mathlib/Data/Set/Lattice.lean
+++ b/Mathlib/Data/Set/Lattice.lean
@@ -1173,6 +1173,12 @@ theorem union_distrib_iInter_right (s : ι → Set α) (t : Set α) : (⋂ i, s 
 theorem union_distrib_iInter₂_right (s : ∀ i, κ i → Set α) (t : Set α) :
     (⋂ (i) (j), s i j) ∪ t = ⋂ (i) (j), s i j ∪ t := by simp_rw [union_distrib_iInter_right]
 
+lemma biUnion_lt_eq_iUnion [LT α] [NoMaxOrder α] {s : α → Set β} :
+  ⋃ (n) (m < n), s m  = ⋃ n, s n := biSup_lt_eq_iSup
+
+lemma biInter_lt_eq_iInter [LT α] [NoMaxOrder α] {s : α → Set β} :
+  ⋂ (n) (m < n), s m  = ⋂ (n), s n := biInf_lt_eq_iInf
+
 section Function
 
 /-! ### Lemmas about `Set.MapsTo`

--- a/Mathlib/Data/Set/Lattice.lean
+++ b/Mathlib/Data/Set/Lattice.lean
@@ -1174,28 +1174,28 @@ theorem union_distrib_iInter₂_right (s : ∀ i, κ i → Set α) (t : Set α) 
     (⋂ (i) (j), s i j) ∪ t = ⋂ (i) (j), s i j ∪ t := by simp_rw [union_distrib_iInter_right]
 
 lemma biUnion_lt_eq_iUnion [LT α] [NoMaxOrder α] {s : α → Set β} :
-    ⋃ (n) (m < n), s m  = ⋃ n, s n := biSup_lt_eq_iSup
+    ⋃ (n) (m < n), s m = ⋃ n, s n := biSup_lt_eq_iSup
 
 lemma biUnion_le_eq_iUnion [Preorder α] {s : α → Set β} :
-    ⋃ (n) (m ≤ n), s m  = ⋃ n, s n := biSup_le_eq_iSup
+    ⋃ (n) (m ≤ n), s m = ⋃ n, s n := biSup_le_eq_iSup
 
 lemma biInter_lt_eq_iInter [LT α] [NoMaxOrder α] {s : α → Set β} :
-    ⋂ (n) (m < n), s m  = ⋂ (n), s n := biInf_lt_eq_iInf
+    ⋂ (n) (m < n), s m = ⋂ (n), s n := biInf_lt_eq_iInf
 
 lemma biInter_le_eq_iInter [Preorder α] {s : α → Set β} :
-    ⋂ (n) (m ≤ n), s m  = ⋂ (n), s n := biInf_le_eq_iInf
+    ⋂ (n) (m ≤ n), s m = ⋂ (n), s n := biInf_le_eq_iInf
 
 lemma biUnion_gt_eq_iUnion [LT α] [NoMinOrder α] {s : α → Set β} :
-    ⋃ (n) (m > n), s m  = ⋃ n, s n := biSup_gt_eq_iSup
+    ⋃ (n) (m > n), s m = ⋃ n, s n := biSup_gt_eq_iSup
 
 lemma biUnion_ge_eq_iUnion [Preorder α] {s : α → Set β} :
-    ⋃ (n) (m ≥ n), s m  = ⋃ n, s n := biSup_ge_eq_iSup
+    ⋃ (n) (m ≥ n), s m = ⋃ n, s n := biSup_ge_eq_iSup
 
 lemma biInter_gt_eq_iInf [LT α] [NoMinOrder α] {s : α → Set β} :
-    ⋂ (n) (m > n), s m  = ⋂ n, s n := biInf_gt_eq_iInf
+    ⋂ (n) (m > n), s m = ⋂ n, s n := biInf_gt_eq_iInf
 
 lemma biInter_ge_eq_iInf [Preorder α] {s : α → Set β} :
-    ⋂ (n) (m ≥ n), s m  = ⋂ n, s n := biInf_ge_eq_iInf
+    ⋂ (n) (m ≥ n), s m = ⋂ n, s n := biInf_ge_eq_iInf
 
 section Function
 

--- a/Mathlib/Data/Set/Lattice.lean
+++ b/Mathlib/Data/Set/Lattice.lean
@@ -1176,8 +1176,26 @@ theorem union_distrib_iInter₂_right (s : ∀ i, κ i → Set α) (t : Set α) 
 lemma biUnion_lt_eq_iUnion [LT α] [NoMaxOrder α] {s : α → Set β} :
     ⋃ (n) (m < n), s m  = ⋃ n, s n := biSup_lt_eq_iSup
 
+lemma biUnion_le_eq_iUnion [Preorder α] {s : α → Set β} :
+    ⋃ (n) (m ≤ n), s m  = ⋃ n, s n := biSup_le_eq_iSup
+
 lemma biInter_lt_eq_iInter [LT α] [NoMaxOrder α] {s : α → Set β} :
     ⋂ (n) (m < n), s m  = ⋂ (n), s n := biInf_lt_eq_iInf
+
+lemma biInter_le_eq_iInter [Preorder α] {s : α → Set β} :
+    ⋂ (n) (m ≤ n), s m  = ⋂ (n), s n := biInf_le_eq_iInf
+
+lemma biUnion_gt_eq_iUnion [LT α] [NoMinOrder α] {s : α → Set β} :
+    ⋃ (n) (m > n), s m  = ⋃ n, s n := biSup_gt_eq_iSup
+
+lemma biUnion_ge_eq_iUnion [Preorder α] {s : α → Set β} :
+    ⋃ (n) (m ≥ n), s m  = ⋃ n, s n := biSup_ge_eq_iSup
+
+lemma biInter_gt_eq_iInf [LT α] [NoMinOrder α] {s : α → Set β} :
+    ⋂ (n) (m > n), s m  = ⋂ n, s n := biInf_gt_eq_iInf
+
+lemma biInter_ge_eq_iInf [Preorder α] {s : α → Set β} :
+    ⋂ (n) (m ≥ n), s m  = ⋂ n, s n := biInf_ge_eq_iInf
 
 section Function
 

--- a/Mathlib/Data/Set/Lattice.lean
+++ b/Mathlib/Data/Set/Lattice.lean
@@ -1174,10 +1174,10 @@ theorem union_distrib_iInter₂_right (s : ∀ i, κ i → Set α) (t : Set α) 
     (⋂ (i) (j), s i j) ∪ t = ⋂ (i) (j), s i j ∪ t := by simp_rw [union_distrib_iInter_right]
 
 lemma biUnion_lt_eq_iUnion [LT α] [NoMaxOrder α] {s : α → Set β} :
-  ⋃ (n) (m < n), s m  = ⋃ n, s n := biSup_lt_eq_iSup
+    ⋃ (n) (m < n), s m  = ⋃ n, s n := biSup_lt_eq_iSup
 
 lemma biInter_lt_eq_iInter [LT α] [NoMaxOrder α] {s : α → Set β} :
-  ⋂ (n) (m < n), s m  = ⋂ (n), s n := biInf_lt_eq_iInf
+    ⋂ (n) (m < n), s m  = ⋂ (n), s n := biInf_lt_eq_iInf
 
 section Function
 

--- a/Mathlib/Order/CompleteLattice.lean
+++ b/Mathlib/Order/CompleteLattice.lean
@@ -1072,6 +1072,22 @@ theorem inf_biInf {p : ι → Prop} {f : ∀ i, p i → α} {a : α} (h : ∃ i,
     (a ⊓ ⨅ (i) (h : p i), f i h) = ⨅ (i) (h : p i), a ⊓ f i h :=
   @sup_biSup αᵒᵈ ι _ p f _ h
 
+lemma biSup_lt_eq_iSup {ι : Type*} [LT ι] [NoMaxOrder ι] {f : ι → α}:
+    ⨆ (i) (j < i), f j = ⨆ i, f i := by
+  apply le_antisymm
+  · exact iSup_le fun _ ↦ iSup_le fun _ ↦ iSup_le fun _ ↦ le_iSup _ _
+  · apply iSup_le (fun j ↦ ?_)
+    obtain ⟨i, jlt⟩ := exists_gt j
+    exact le_iSup_of_le i (le_iSup_of_le j (le_iSup_of_le jlt (le_refl _)))
+
+lemma biInf_lt_eq_iInf {ι : Type*} [LT ι] [NoMaxOrder ι] {f : ι → α} :
+    ⨅ (i) (j < i), f j = ⨅ i, f i := by
+  apply le_antisymm
+  · apply le_iInf (fun j ↦ ?_)
+    obtain ⟨i, jlt⟩ := exists_gt j
+    apply iInf_le_of_le i (iInf_le_of_le j (iInf_le_of_le jlt (le_refl _)))
+  · exact le_iInf fun _ ↦ le_iInf fun _ ↦ le_iInf fun _ ↦ iInf_le _ _
+
 /-! ### `iSup` and `iInf` under `Prop` -/
 
 

--- a/Mathlib/Order/CompleteLattice.lean
+++ b/Mathlib/Order/CompleteLattice.lean
@@ -1072,20 +1072,60 @@ theorem inf_biInf {p : ι → Prop} {f : ∀ i, p i → α} {a : α} (h : ∃ i,
     (a ⊓ ⨅ (i) (h : p i), f i h) = ⨅ (i) (h : p i), a ⊓ f i h :=
   @sup_biSup αᵒᵈ ι _ p f _ h
 
-lemma biSup_lt_eq_iSup {ι : Type*} [LT ι] [NoMaxOrder ι] {f : ι → α}:
+lemma biSup_lt_eq_iSup {ι : Type*} [LT ι] [NoMaxOrder ι] {f : ι → α} :
     ⨆ (i) (j < i), f j = ⨆ i, f i := by
   apply le_antisymm
   · exact iSup_le fun _ ↦ iSup_le fun _ ↦ iSup_le fun _ ↦ le_iSup _ _
-  · apply iSup_le (fun j ↦ ?_)
+  · apply iSup_le fun j ↦ ?_
     obtain ⟨i, jlt⟩ := exists_gt j
     exact le_iSup_of_le i (le_iSup_of_le j (le_iSup_of_le jlt (le_refl _)))
+
+lemma biSup_le_eq_iSup {ι : Type*} [Preorder ι] {f : ι → α} :
+    ⨆ (i) (j ≤ i), f j = ⨆ i, f i := by
+  apply le_antisymm
+  · exact iSup_le fun _ ↦ iSup_le fun _ ↦ iSup_le fun _ ↦ le_iSup _ _
+  · exact iSup_le fun j ↦ le_iSup_of_le j (le_iSup_of_le j (le_iSup_of_le (le_refl _) (le_refl _)))
 
 lemma biInf_lt_eq_iInf {ι : Type*} [LT ι] [NoMaxOrder ι] {f : ι → α} :
     ⨅ (i) (j < i), f j = ⨅ i, f i := by
   apply le_antisymm
-  · apply le_iInf (fun j ↦ ?_)
+  · apply le_iInf fun j ↦ ?_
     obtain ⟨i, jlt⟩ := exists_gt j
     apply iInf_le_of_le i (iInf_le_of_le j (iInf_le_of_le jlt (le_refl _)))
+  · exact le_iInf fun _ ↦ le_iInf fun _ ↦ le_iInf fun _ ↦ iInf_le _ _
+
+lemma biInf_le_eq_iInf {ι : Type*} [Preorder ι] {f : ι → α} :
+    ⨅ (i) (j ≤ i), f j = ⨅ i, f i := by
+  apply le_antisymm
+  · exact le_iInf fun j ↦ iInf_le_of_le j (iInf_le_of_le j (iInf_le_of_le (le_refl _) (le_refl _)))
+  · exact le_iInf fun _ ↦ le_iInf fun _ ↦ le_iInf fun _ ↦ iInf_le _ _
+
+lemma biSup_gt_eq_iSup {ι : Type*} [LT ι] [NoMinOrder ι] {f : ι → α} :
+    ⨆ (i) (j > i), f j = ⨆ i, f i := by
+  apply le_antisymm
+  · exact iSup_le fun _ ↦ iSup_le fun _ ↦ iSup_le fun _ ↦ le_iSup _ _
+  · apply iSup_le fun j ↦ ?_
+    obtain ⟨i, ltj⟩ := exists_lt j
+    exact le_iSup_of_le i (le_iSup_of_le j (le_iSup_of_le ltj (le_refl _)))
+
+lemma biSup_ge_eq_iSup {ι : Type*} [Preorder ι] {f : ι → α} :
+    ⨆ (i) (j ≥ i), f j = ⨆ i, f i := by
+  apply le_antisymm
+  · exact iSup_le fun _ ↦ iSup_le fun _ ↦ iSup_le fun _ ↦ le_iSup _ _
+  · exact iSup_le fun j ↦ le_iSup_of_le j (le_iSup_of_le j (le_iSup_of_le (le_refl _) (le_refl _)))
+
+lemma biInf_gt_eq_iInf {ι : Type*} [LT ι] [NoMinOrder ι] {f : ι → α} :
+    ⨅ (i) (j > i), f j = ⨅ i, f i := by
+  apply le_antisymm
+  · apply le_iInf fun j ↦ ?_
+    obtain ⟨i, ltj⟩ := exists_lt j
+    apply iInf_le_of_le i (iInf_le_of_le j (iInf_le_of_le ltj (le_refl _)))
+  · exact le_iInf fun _ ↦ le_iInf fun _ ↦ le_iInf fun _ ↦ iInf_le _ _
+
+lemma biInf_ge_eq_iInf {ι : Type*} [Preorder ι] {f : ι → α} :
+    ⨅ (i) (j ≥ i), f j = ⨅ i, f i := by
+  apply le_antisymm
+  · exact le_iInf fun j ↦ iInf_le_of_le j (iInf_le_of_le j (iInf_le_of_le (le_refl _) (le_refl _)))
   · exact le_iInf fun _ ↦ le_iInf fun _ ↦ le_iInf fun _ ↦ iInf_le _ _
 
 /-! ### `iSup` and `iInf` under `Prop` -/

--- a/Mathlib/Order/CompleteLattice.lean
+++ b/Mathlib/Order/CompleteLattice.lean
@@ -1087,46 +1087,25 @@ lemma biSup_le_eq_iSup {ι : Type*} [Preorder ι] {f : ι → α} :
   · exact iSup_le fun j ↦ le_iSup_of_le j (le_iSup_of_le j (le_iSup_of_le (le_refl _) (le_refl _)))
 
 lemma biInf_lt_eq_iInf {ι : Type*} [LT ι] [NoMaxOrder ι] {f : ι → α} :
-    ⨅ (i) (j < i), f j = ⨅ i, f i := by
-  apply le_antisymm
-  · apply le_iInf fun j ↦ ?_
-    obtain ⟨i, jlt⟩ := exists_gt j
-    apply iInf_le_of_le i (iInf_le_of_le j (iInf_le_of_le jlt (le_refl _)))
-  · exact le_iInf fun _ ↦ le_iInf fun _ ↦ le_iInf fun _ ↦ iInf_le _ _
+    ⨅ (i) (j < i), f j = ⨅ i, f i :=
+  biSup_lt_eq_iSup (α := αᵒᵈ)
 
-lemma biInf_le_eq_iInf {ι : Type*} [Preorder ι] {f : ι → α} :
-    ⨅ (i) (j ≤ i), f j = ⨅ i, f i := by
-  apply le_antisymm
-  · exact le_iInf fun j ↦ iInf_le_of_le j (iInf_le_of_le j (iInf_le_of_le (le_refl _) (le_refl _)))
-  · exact le_iInf fun _ ↦ le_iInf fun _ ↦ le_iInf fun _ ↦ iInf_le _ _
+lemma biInf_le_eq_iInf {ι : Type*} [Preorder ι] {f : ι → α} : ⨅ (i) (j ≤ i), f j = ⨅ i, f i :=
+  biSup_le_eq_iSup (α := αᵒᵈ)
 
 lemma biSup_gt_eq_iSup {ι : Type*} [LT ι] [NoMinOrder ι] {f : ι → α} :
-    ⨆ (i) (j > i), f j = ⨆ i, f i := by
-  apply le_antisymm
-  · exact iSup_le fun _ ↦ iSup_le fun _ ↦ iSup_le fun _ ↦ le_iSup _ _
-  · apply iSup_le fun j ↦ ?_
-    obtain ⟨i, ltj⟩ := exists_lt j
-    exact le_iSup_of_le i (le_iSup_of_le j (le_iSup_of_le ltj (le_refl _)))
+    ⨆ (i) (j > i), f j = ⨆ i, f i :=
+  biSup_lt_eq_iSup (ι := ιᵒᵈ)
 
-lemma biSup_ge_eq_iSup {ι : Type*} [Preorder ι] {f : ι → α} :
-    ⨆ (i) (j ≥ i), f j = ⨆ i, f i := by
-  apply le_antisymm
-  · exact iSup_le fun _ ↦ iSup_le fun _ ↦ iSup_le fun _ ↦ le_iSup _ _
-  · exact iSup_le fun j ↦ le_iSup_of_le j (le_iSup_of_le j (le_iSup_of_le (le_refl _) (le_refl _)))
+lemma biSup_ge_eq_iSup {ι : Type*} [Preorder ι] {f : ι → α} : ⨆ (i) (j ≥ i), f j = ⨆ i, f i :=
+  biSup_le_eq_iSup (ι := ιᵒᵈ)
 
 lemma biInf_gt_eq_iInf {ι : Type*} [LT ι] [NoMinOrder ι] {f : ι → α} :
-    ⨅ (i) (j > i), f j = ⨅ i, f i := by
-  apply le_antisymm
-  · apply le_iInf fun j ↦ ?_
-    obtain ⟨i, ltj⟩ := exists_lt j
-    apply iInf_le_of_le i (iInf_le_of_le j (iInf_le_of_le ltj (le_refl _)))
-  · exact le_iInf fun _ ↦ le_iInf fun _ ↦ le_iInf fun _ ↦ iInf_le _ _
+    ⨅ (i) (j > i), f j = ⨅ i, f i :=
+  biInf_lt_eq_iInf (ι := ιᵒᵈ)
 
-lemma biInf_ge_eq_iInf {ι : Type*} [Preorder ι] {f : ι → α} :
-    ⨅ (i) (j ≥ i), f j = ⨅ i, f i := by
-  apply le_antisymm
-  · exact le_iInf fun j ↦ iInf_le_of_le j (iInf_le_of_le j (iInf_le_of_le (le_refl _) (le_refl _)))
-  · exact le_iInf fun _ ↦ le_iInf fun _ ↦ le_iInf fun _ ↦ iInf_le _ _
+lemma biInf_ge_eq_iInf {ι : Type*} [Preorder ι] {f : ι → α} : ⨅ (i) (j ≥ i), f j = ⨅ i, f i :=
+  biInf_le_eq_iInf (ι := ιᵒᵈ)
 
 /-! ### `iSup` and `iInf` under `Prop` -/
 

--- a/Mathlib/Order/CompleteLattice.lean
+++ b/Mathlib/Order/CompleteLattice.lean
@@ -1075,16 +1075,16 @@ theorem inf_biInf {p : ι → Prop} {f : ∀ i, p i → α} {a : α} (h : ∃ i,
 lemma biSup_lt_eq_iSup {ι : Type*} [LT ι] [NoMaxOrder ι] {f : ι → α} :
     ⨆ (i) (j < i), f j = ⨆ i, f i := by
   apply le_antisymm
-  · exact iSup_le fun _ ↦ iSup_le fun _ ↦ iSup_le fun _ ↦ le_iSup _ _
-  · apply iSup_le fun j ↦ ?_
+  · exact iSup_le fun _ ↦ iSup₂_le fun _ _ ↦ le_iSup _ _
+  · refine iSup_le fun j ↦ ?_
     obtain ⟨i, jlt⟩ := exists_gt j
-    exact le_iSup_of_le i (le_iSup_of_le j (le_iSup_of_le jlt (le_refl _)))
+    exact le_iSup_of_le i (le_iSup₂_of_le j jlt le_rfl)
 
 lemma biSup_le_eq_iSup {ι : Type*} [Preorder ι] {f : ι → α} :
     ⨆ (i) (j ≤ i), f j = ⨆ i, f i := by
   apply le_antisymm
-  · exact iSup_le fun _ ↦ iSup_le fun _ ↦ iSup_le fun _ ↦ le_iSup _ _
-  · exact iSup_le fun j ↦ le_iSup_of_le j (le_iSup_of_le j (le_iSup_of_le (le_refl _) (le_refl _)))
+  · exact iSup_le fun _ ↦ iSup₂_le fun _ _ ↦ le_iSup _ _
+  · exact iSup_le fun j ↦ le_iSup_of_le j (le_iSup₂_of_le j le_rfl le_rfl)
 
 lemma biInf_lt_eq_iInf {ι : Type*} [LT ι] [NoMaxOrder ι] {f : ι → α} :
     ⨅ (i) (j < i), f j = ⨅ i, f i :=


### PR DESCRIPTION
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
