### PR TITLE
[Merged by Bors] - chore: split off `RBMap` dependency from `Mathlib.Data.Tree`

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -2628,6 +2628,7 @@ import Mathlib.Data.Sym.Sym2.Init
 import Mathlib.Data.Sym.Sym2.Order
 import Mathlib.Data.Tree.Basic
 import Mathlib.Data.Tree.Get
+import Mathlib.Data.Tree.RBMap
 import Mathlib.Data.TwoPointing
 import Mathlib.Data.TypeMax
 import Mathlib.Data.TypeVec

--- a/Mathlib/Data/Tree/Basic.lean
+++ b/Mathlib/Data/Tree/Basic.lean
@@ -3,7 +3,6 @@ Copyright (c) 2019 mathlib community. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Mario Carneiro, Wojciech Nawrocki
 -/
-import Batteries.Data.RBMap.Basic
 import Mathlib.Data.Nat.Notation
 import Mathlib.Tactic.TypeStar
 import Mathlib.Util.CompileInductive
@@ -45,13 +44,6 @@ variable {α : Type u}
 
 instance : Inhabited (Tree α) :=
   ⟨nil⟩
-
-open Batteries (RBNode)
-
-/-- Makes a `Tree α` out of a red-black tree. -/
-def ofRBNode : RBNode α → Tree α
-  | RBNode.nil => nil
-  | RBNode.node _color l key r => node key (ofRBNode l) (ofRBNode r)
 
 /-- Apply a function to each value in the tree.  This is the `map` function for the `Tree` functor.
 -/

--- a/Mathlib/Data/Tree/RBMap.lean
+++ b/Mathlib/Data/Tree/RBMap.lean
@@ -1,0 +1,37 @@
+/-
+Copyright (c) 2019 mathlib community. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Mario Carneiro, Wojciech Nawrocki
+-/
+import Batteries.Data.RBMap.Basic
+import Mathlib.Data.Tree.Basic
+
+/-!
+# Binary tree and RBMaps
+
+In this file we define `Tree.ofRBNode`.
+This definition was moved from the main file to avoid a dependency on `RBMap`.
+
+## TODO
+
+Implement a `Traversable` instance for `Tree`.
+
+## References
+
+<https://leanprover-community.github.io/archive/stream/113488-general/topic/tactic.20question.html>
+-/
+
+namespace Tree
+
+universe u
+
+variable {α : Type u}
+
+open Batteries (RBNode)
+
+/-- Makes a `Tree α` out of a red-black tree. -/
+def ofRBNode : RBNode α → Tree α
+  | RBNode.nil => nil
+  | RBNode.node _color l key r => node key (ofRBNode l) (ofRBNode r)
+
+end Tree


### PR DESCRIPTION
`Tree.ofRBNode` does not seem to be used in Mathlib anyway, so let's avoid an unnecessary import of Batteries and move this to a new leaf file in case anyone needs to use it still.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
