### PR TITLE
[Merged by Bors] - refactor: change `CartesianClosed` to rely on `ChosenFiniteProducts`

### DIFF
--- a/Mathlib/CategoryTheory/Closed/Cartesian.lean
+++ b/Mathlib/CategoryTheory/Closed/Cartesian.lean
@@ -5,7 +5,6 @@ Authors: Bhavik Mehta, Edward Ayers, Thomas Read
 -/
 import Mathlib.CategoryTheory.EpiMono
 import Mathlib.CategoryTheory.Limits.Shapes.FiniteProducts
-import Mathlib.CategoryTheory.Monoidal.OfHasFiniteProducts
 import Mathlib.CategoryTheory.Limits.Preserves.Shapes.BinaryProducts
 import Mathlib.CategoryTheory.ChosenFiniteProducts
 import Mathlib.CategoryTheory.Adjunction.Limits

--- a/Mathlib/CategoryTheory/Closed/Cartesian.lean
+++ b/Mathlib/CategoryTheory/Closed/Cartesian.lean
@@ -14,8 +14,8 @@ import Mathlib.CategoryTheory.Closed.Monoidal
 /-!
 # Cartesian closed categories
 
-Given a category with finite products, the cartesian monoidal structure is provided by the local
-instance `monoidalOfHasFiniteProducts`.
+Given a category with chosen finite products, the cartesian monoidal structure is provided by the
+instance `monoidalOfChosenFiniteProducts`.
 
 We define exponentiable objects to be closed objects with respect to this monoidal structure,
 i.e. `(X × -)` is a left adjoint.
@@ -24,6 +24,13 @@ We say a category is cartesian closed if every object is exponentiable
 (equivalently, that the category equipped with the cartesian monoidal structure is closed monoidal).
 
 Show that exponential forms a difunctor and define the exponential comparison morphisms.
+
+## Implementation Details
+
+Cartesian closed categories require a `ChosenFiniteProducts` instance. If one whishes to state that
+a category that `hasFiniteProducts` is cartesian closed, they should first promote the
+`hasFiniteProducts` instance to a `ChosenFiniteProducts` one using
+`CategoryTheory.ChosenFiniteProducts.ofFiniteProducts`.
 
 ## TODO
 Some of the results here are true more generally for closed objects and

--- a/Mathlib/CategoryTheory/Closed/Cartesian.lean
+++ b/Mathlib/CategoryTheory/Closed/Cartesian.lean
@@ -363,6 +363,7 @@ Note we didn't require any coherence between the choice of finite products here,
 along the `prodComparison` isomorphism.
 -/
 def cartesianClosedOfEquiv (e : C ≌ D) [CartesianClosed C] : CartesianClosed D :=
+  letI := e.inverse.monoidalOfChosenFiniteProducts
   MonoidalClosed.ofEquiv (e.inverse) e.symm.toAdjunction
 
 end Functor

--- a/Mathlib/CategoryTheory/Closed/Cartesian.lean
+++ b/Mathlib/CategoryTheory/Closed/Cartesian.lean
@@ -7,6 +7,7 @@ import Mathlib.CategoryTheory.EpiMono
 import Mathlib.CategoryTheory.Limits.Shapes.FiniteProducts
 import Mathlib.CategoryTheory.Monoidal.OfHasFiniteProducts
 import Mathlib.CategoryTheory.Limits.Preserves.Shapes.BinaryProducts
+import Mathlib.CategoryTheory.ChosenFiniteProducts
 import Mathlib.CategoryTheory.Adjunction.Limits
 import Mathlib.CategoryTheory.Adjunction.Mates
 import Mathlib.CategoryTheory.Closed.Monoidal
@@ -37,19 +38,18 @@ noncomputable section
 
 namespace CategoryTheory
 
-open CategoryTheory CategoryTheory.Category CategoryTheory.Limits
-
-attribute [local instance] monoidalOfHasFiniteProducts
+open CategoryTheory Category Limits MonoidalCategory
 
 /-- An object `X` is *exponentiable* if `(X × -)` is a left adjoint.
 We define this as being `Closed` in the cartesian monoidal structure.
 -/
-abbrev Exponentiable {C : Type u} [Category.{v} C] [HasFiniteProducts C] (X : C) :=
+
+abbrev Exponentiable {C : Type u} [Category.{v} C] [ChosenFiniteProducts C] (X : C) :=
   Closed X
 
 /-- Constructor for `Exponentiable X` which takes as an input an adjunction
 `MonoidalCategory.tensorLeft X ⊣ exp` for some functor `exp : C ⥤ C`. -/
-abbrev Exponentiable.mk {C : Type u} [Category.{v} C] [HasFiniteProducts C] (X : C)
+abbrev Exponentiable.mk {C : Type u} [Category.{v} C] [ChosenFiniteProducts C] (X : C)
     (exp : C ⥤ C) (adj : MonoidalCategory.tensorLeft X ⊣ exp) :
     Exponentiable X where
   adj := adj
@@ -58,33 +58,33 @@ abbrev Exponentiable.mk {C : Type u} [Category.{v} C] [HasFiniteProducts C] (X :
 This isn't an instance because it's not usually how we want to construct exponentials, we'll usually
 prove all objects are exponential uniformly.
 -/
-def binaryProductExponentiable {C : Type u} [Category.{v} C] [HasFiniteProducts C] {X Y : C}
-    (hX : Exponentiable X) (hY : Exponentiable Y) : Exponentiable (X ⨯ Y) :=
+def binaryProductExponentiable {C : Type u} [Category.{v} C] [ChosenFiniteProducts C] {X Y : C}
+    (hX : Exponentiable X) (hY : Exponentiable Y) : Exponentiable (X ⊗ Y) :=
   tensorClosed hX hY
 
 /-- The terminal object is always exponentiable.
 This isn't an instance because most of the time we'll prove cartesian closed for all objects
 at once, rather than just for this one.
 -/
-def terminalExponentiable {C : Type u} [Category.{v} C] [HasFiniteProducts C] :
-    Exponentiable (⊤_ C) :=
+def terminalExponentiable {C : Type u} [Category.{v} C] [ChosenFiniteProducts C] :
+    Exponentiable (𝟙_ C) :=
   unitClosed
 
 /-- A category `C` is cartesian closed if it has finite products and every object is exponentiable.
 We define this as `monoidal_closed` with respect to the cartesian monoidal structure.
 -/
-abbrev CartesianClosed (C : Type u) [Category.{v} C] [HasFiniteProducts C] :=
+abbrev CartesianClosed (C : Type u) [Category.{v} C] [ChosenFiniteProducts C] :=
   MonoidalClosed C
 
 -- Porting note: added to ease the port of `CategoryTheory.Closed.Types`
 /-- Constructor for `CartesianClosed C`. -/
-def CartesianClosed.mk (C : Type u) [Category.{v} C] [HasFiniteProducts C]
+def CartesianClosed.mk (C : Type u) [Category.{v} C] [ChosenFiniteProducts C]
     (exp : ∀ (X : C), Exponentiable X) :
     CartesianClosed C where
   closed X := exp X
 
 variable {C : Type u} [Category.{v} C] (A B : C) {X X' Y Y' Z : C}
-variable [HasFiniteProducts C] [Exponentiable A]
+variable [ChosenFiniteProducts C] [Exponentiable A]
 
 /-- This is (-)^A. -/
 abbrev exp : C ⥤ C :=
@@ -93,15 +93,15 @@ abbrev exp : C ⥤ C :=
 namespace exp
 
 /-- The adjunction between A ⨯ - and (-)^A. -/
-abbrev adjunction : prod.functor.obj A ⊣ exp A :=
+abbrev adjunction : tensorLeft A ⊣ exp A :=
   ihom.adjunction A
 
 /-- The evaluation natural transformation. -/
-abbrev ev : exp A ⋙ prod.functor.obj A ⟶ 𝟭 C :=
+abbrev ev : exp A ⋙ tensorLeft A ⟶ 𝟭 C :=
   ihom.ev A
 
 /-- The coevaluation natural transformation. -/
-abbrev coev : 𝟭 C ⟶ prod.functor.obj A ⋙ exp A :=
+abbrev coev : 𝟭 C ⟶ tensorLeft A ⋙ exp A :=
   ihom.coev A
 
 -- Porting note: notation fails to elaborate with `quotPrecheck` on.
@@ -130,8 +130,9 @@ set_option quotPrecheck false in
 /-- Morphisms from an exponentiable object. -/
 notation:30 B " ^^ " A:30 => (exp A).obj B
 
-@[simp, reassoc]
-theorem ev_coev : Limits.prod.map (𝟙 A) ((coev A).app B) ≫ (ev A).app (A ⨯ B) = 𝟙 (A ⨯ B) :=
+#adaptation_note /-- Removed simp attribute as simp can already prove it. -/
+@[reassoc]
+theorem ev_coev : (A ◁ (coev A).app B) ≫ (ev A).app (A ⊗ B) = 𝟙 (A ⊗ B : C) :=
   ihom.ev_coev A B
 
 @[reassoc]
@@ -140,7 +141,7 @@ theorem coev_ev : (coev A).app (A ⟹ B) ≫ (exp A).map ((ev A).app B) = 𝟙 (
 
 end exp
 
-instance : PreservesColimits (prod.functor.obj A) :=
+instance : PreservesColimits (tensorLeft A) :=
   (ihom.adjunction A).leftAdjointPreservesColimits
 
 variable {A}
@@ -149,16 +150,16 @@ variable {A}
 namespace CartesianClosed
 
 /-- Currying in a cartesian closed category. -/
-def curry : (A ⨯ Y ⟶ X) → (Y ⟶ A ⟹ X) :=
+def curry : (A ⊗ Y ⟶ X) → (Y ⟶ A ⟹ X) :=
   (exp.adjunction A).homEquiv _ _
 
 /-- Uncurrying in a cartesian closed category. -/
-def uncurry : (Y ⟶ A ⟹ X) → (A ⨯ Y ⟶ X) :=
+def uncurry : (Y ⟶ A ⟹ X) → (A ⊗ Y ⟶ X) :=
   ((exp.adjunction A).homEquiv _ _).symm
 
 -- This lemma has always been bad, but the linter only noticed after lean4#2644.
 @[simp, nolint simpNF]
-theorem homEquiv_apply_eq (f : A ⨯ Y ⟶ X) : (exp.adjunction A).homEquiv _ _ f = curry f :=
+theorem homEquiv_apply_eq (f : A ⊗ Y ⟶ X) : (exp.adjunction A).homEquiv _ _ f = curry f :=
   rfl
 
 -- This lemma has always been bad, but the linter only noticed after lean4#2644.
@@ -168,12 +169,12 @@ theorem homEquiv_symm_apply_eq (f : Y ⟶ A ⟹ X) :
   rfl
 
 @[reassoc]
-theorem curry_natural_left (f : X ⟶ X') (g : A ⨯ X' ⟶ Y) :
-    curry (Limits.prod.map (𝟙 _) f ≫ g) = f ≫ curry g :=
+theorem curry_natural_left (f : X ⟶ X') (g : A ⊗ X' ⟶ Y) :
+    curry (_ ◁ f ≫ g) = f ≫ curry g :=
   Adjunction.homEquiv_naturality_left _ _ _
 
 @[reassoc]
-theorem curry_natural_right (f : A ⨯ X ⟶ Y) (g : Y ⟶ Y') :
+theorem curry_natural_right (f : A ⊗ X ⟶ Y) (g : Y ⟶ Y') :
     curry (f ≫ g) = curry f ≫ (exp _).map g :=
   Adjunction.homEquiv_naturality_right _ _ _
 
@@ -184,11 +185,11 @@ theorem uncurry_natural_right (f : X ⟶ A ⟹ Y) (g : Y ⟶ Y') :
 
 @[reassoc]
 theorem uncurry_natural_left (f : X ⟶ X') (g : X' ⟶ A ⟹ Y) :
-    uncurry (f ≫ g) = Limits.prod.map (𝟙 _) f ≫ uncurry g :=
+    uncurry (f ≫ g) = _ ◁ f ≫ uncurry g :=
   Adjunction.homEquiv_naturality_left_symm _ _ _
 
 @[simp]
-theorem uncurry_curry (f : A ⨯ X ⟶ Y) : uncurry (curry f) = f :=
+theorem uncurry_curry (f : A ⊗ X ⟶ Y) : uncurry (curry f) = f :=
   (Closed.adj.homEquiv _ _).left_inv f
 
 @[simp]
@@ -196,30 +197,30 @@ theorem curry_uncurry (f : X ⟶ A ⟹ Y) : curry (uncurry f) = f :=
   (Closed.adj.homEquiv _ _).right_inv f
 
 -- Porting note: extra `(exp.adjunction A)` argument was needed for elaboration to succeed.
-theorem curry_eq_iff (f : A ⨯ Y ⟶ X) (g : Y ⟶ A ⟹ X) : curry f = g ↔ f = uncurry g :=
+theorem curry_eq_iff (f : A ⊗ Y ⟶ X) (g : Y ⟶ A ⟹ X) : curry f = g ↔ f = uncurry g :=
   Adjunction.homEquiv_apply_eq (exp.adjunction A) f g
 
 -- Porting note: extra `(exp.adjunction A)` argument was needed for elaboration to succeed.
-theorem eq_curry_iff (f : A ⨯ Y ⟶ X) (g : Y ⟶ A ⟹ X) : g = curry f ↔ uncurry g = f :=
+theorem eq_curry_iff (f : A ⊗ Y ⟶ X) (g : Y ⟶ A ⟹ X) : g = curry f ↔ uncurry g = f :=
   Adjunction.eq_homEquiv_apply (exp.adjunction A) f g
 
 -- I don't think these two should be simp.
-theorem uncurry_eq (g : Y ⟶ A ⟹ X) : uncurry g = Limits.prod.map (𝟙 A) g ≫ (exp.ev A).app X :=
+theorem uncurry_eq (g : Y ⟶ A ⟹ X) : uncurry g = (A ◁ g) ≫ (exp.ev A).app X :=
   rfl
 
-theorem curry_eq (g : A ⨯ Y ⟶ X) : curry g = (exp.coev A).app Y ≫ (exp A).map g :=
+theorem curry_eq (g : A ⊗ Y ⟶ X) : curry g = (exp.coev A).app Y ≫ (exp A).map g :=
   rfl
 
 theorem uncurry_id_eq_ev (A X : C) [Exponentiable A] : uncurry (𝟙 (A ⟹ X)) = (exp.ev A).app X := by
-  rw [uncurry_eq, prod.map_id_id, id_comp]
+  rw [uncurry_eq, whiskerLeft_id_assoc]
 
 theorem curry_id_eq_coev (A X : C) [Exponentiable A] : curry (𝟙 _) = (exp.coev A).app X := by
-  rw [curry_eq, (exp A).map_id (A ⨯ _)]; apply comp_id
+  rw [curry_eq, (exp A).map_id (A ⊗ _)]; apply comp_id
 
-theorem curry_injective : Function.Injective (curry : (A ⨯ Y ⟶ X) → (Y ⟶ A ⟹ X)) :=
+theorem curry_injective : Function.Injective (curry : (A ⊗ Y ⟶ X) → (Y ⟶ A ⟹ X)) :=
   (Closed.adj.homEquiv _ _).injective
 
-theorem uncurry_injective : Function.Injective (uncurry : (Y ⟶ A ⟹ X) → (A ⨯ Y ⟶ X)) :=
+theorem uncurry_injective : Function.Injective (uncurry : (Y ⟶ A ⟹ X) → (A ⊗ Y ⟶ X)) :=
   (Closed.adj.homEquiv _ _).symm.injective
 
 end CartesianClosed
@@ -228,17 +229,17 @@ open CartesianClosed
 
 /-- The exponential with the terminal object is naturally isomorphic to the identity. The typeclass
 argument is explicit: any instance can be used.-/
-def expTerminalNatIso [Exponentiable (⊤_ C)] : 𝟭 C ≅ exp (⊤_ C) :=
+def expUnitNatIso [Exponentiable (𝟙_ C)] : 𝟭 C ≅ exp (𝟙_ C) :=
   MonoidalClosed.unitNatIso (C := C)
 
 /-- The exponential of any object with the terminal object is isomorphic to itself, i.e. `X^1 ≅ X`.
 The typeclass argument is explicit: any instance can be used.-/
-def expTerminalIsoSelf [Exponentiable (⊤_ C)] : (⊤_ C) ⟹ X ≅ X :=
-  (expTerminalNatIso.app X).symm
+def expUnitIsoSelf [Exponentiable (𝟙_ C)] : (𝟙_ C) ⟹ X ≅ X :=
+  (expUnitNatIso.app X).symm
 
 /-- The internal element which points at the given morphism. -/
 def internalizeHom (f : A ⟶ Y) : ⊤_ C ⟶ A ⟹ Y :=
-  CartesianClosed.curry (Limits.prod.fst ≫ f)
+  CartesianClosed.curry (ChosenFiniteProducts.fst _ _ ≫ f)
 
 section Pre
 
@@ -246,29 +247,32 @@ variable {B}
 
 /-- Pre-compose an internal hom with an external hom. -/
 def pre (f : B ⟶ A) [Exponentiable B] : exp A ⟶ exp B :=
-  conjugateEquiv (exp.adjunction _) (exp.adjunction _) (prod.functor.map f)
+  conjugateEquiv (exp.adjunction _) (exp.adjunction _) ((tensoringLeft _).map f)
 
 theorem prod_map_pre_app_comp_ev (f : B ⟶ A) [Exponentiable B] (X : C) :
-    Limits.prod.map (𝟙 B) ((pre f).app X) ≫ (exp.ev B).app X =
-      Limits.prod.map f (𝟙 (A ⟹ X)) ≫ (exp.ev A).app X :=
-  conjugateEquiv_counit _ _ (prod.functor.map f) X
+    (B ◁ (pre f).app X) ≫ (exp.ev B).app X =
+      f ▷ (A ⟹ X) ≫ (exp.ev A).app X :=
+  conjugateEquiv_counit _ _ ((tensoringLeft _).map f) X
 
 theorem uncurry_pre (f : B ⟶ A) [Exponentiable B] (X : C) :
-    CartesianClosed.uncurry ((pre f).app X) = Limits.prod.map f (𝟙 _) ≫ (exp.ev A).app X := by
+    CartesianClosed.uncurry ((pre f).app X) = f ▷ _ ≫ (exp.ev A).app X := by
   rw [uncurry_eq, prod_map_pre_app_comp_ev]
 
 theorem coev_app_comp_pre_app (f : B ⟶ A) [Exponentiable B] :
-    (exp.coev A).app X ≫ (pre f).app (A ⨯ X) =
-      (exp.coev B).app X ≫ (exp B).map (Limits.prod.map f (𝟙 _)) :=
-  unit_conjugateEquiv _ _ (prod.functor.map f) X
+    (exp.coev A).app X ≫ (pre f).app (A ⊗ X) =
+      (exp.coev B).app X ≫ (exp B).map (f ⊗ 𝟙 _) :=
+  unit_conjugateEquiv _ _ ((tensoringLeft _).map f) X
 
 @[simp]
-theorem pre_id (A : C) [Exponentiable A] : pre (𝟙 A) = 𝟙 _ := by simp [pre]
+theorem pre_id (A : C) [Exponentiable A] : pre (𝟙 A) = 𝟙 _ := by
+  simp only [pre, Functor.map_id]
+  aesop_cat
 
 @[simp]
 theorem pre_map {A₁ A₂ A₃ : C} [Exponentiable A₁] [Exponentiable A₂] [Exponentiable A₃]
     (f : A₁ ⟶ A₂) (g : A₂ ⟶ A₃) : pre (f ≫ g) = pre g ≫ pre f := by
-  rw [pre, pre, pre, conjugateEquiv_comp, prod.functor.map_comp]
+  rw [pre, pre, pre, conjugateEquiv_comp]
+  simp
 
 end Pre
 
@@ -279,11 +283,11 @@ def internalHom [CartesianClosed C] : Cᵒᵖ ⥤ C ⥤ C where
 
 /-- If an initial object `I` exists in a CCC, then `A ⨯ I ≅ I`. -/
 @[simps]
-def zeroMul {I : C} (t : IsInitial I) : A ⨯ I ≅ I where
-  hom := Limits.prod.snd
+def zeroMul {I : C} (t : IsInitial I) : A ⊗ I ≅ I where
+  hom := ChosenFiniteProducts.snd _ _
   inv := t.to _
   hom_inv_id := by
-    have : (prod.snd : A ⨯ I ⟶ I) = CartesianClosed.uncurry (t.to _) := by
+    have : ChosenFiniteProducts.snd A I = CartesianClosed.uncurry (t.to _) := by
       rw [← curry_eq_iff]
       apply t.hom_ext
     rw [this, ← uncurry_natural_right, ← eq_curry_iff]
@@ -291,8 +295,8 @@ def zeroMul {I : C} (t : IsInitial I) : A ⨯ I ≅ I where
   inv_hom_id := t.hom_ext _ _
 
 /-- If an initial object `0` exists in a CCC, then `0 ⨯ A ≅ 0`. -/
-def mulZero {I : C} (t : IsInitial I) : I ⨯ A ≅ I :=
-  Limits.prod.braiding _ _ ≪≫ zeroMul t
+def mulZero {I : C} (t : IsInitial I) : I ⊗ A ≅ I :=
+  β_ _ _ ≪≫ zeroMul t
 
 /-- If an initial object `0` exists in a CCC then `0^B ≅ 1` for any `B`. -/
 def powZero {I : C} (t : IsInitial I) [CartesianClosed C] : I ⟹ B ≅ ⊤_ C where
@@ -306,8 +310,8 @@ def powZero {I : C} (t : IsInitial I) [CartesianClosed C] : I ⟹ B ≅ ⊤_ C w
 -- TODO: Define a distributive category, so that zero_mul and friends can be derived from this.
 /-- In a CCC with binary coproducts, the distribution morphism is an isomorphism. -/
 def prodCoprodDistrib [HasBinaryCoproducts C] [CartesianClosed C] (X Y Z : C) :
-    (Z ⨯ X) ⨿ Z ⨯ Y ≅ Z ⨯ X ⨿ Y where
-  hom := coprod.desc (Limits.prod.map (𝟙 _) coprod.inl) (Limits.prod.map (𝟙 _) coprod.inr)
+    (Z ⊗ X) ⨿ Z ⊗ Y ≅ Z ⊗ (X ⨿ Y) where
+  hom := coprod.desc (_ ◁ coprod.inl) (_ ◁ coprod.inr)
   inv :=
     CartesianClosed.uncurry
       (coprod.desc (CartesianClosed.curry coprod.inl) (CartesianClosed.curry coprod.inr))
@@ -330,7 +334,7 @@ exponentiable object is an isomorphism.
 -/
 theorem strict_initial {I : C} (t : IsInitial I) (f : A ⟶ I) : IsIso f := by
   haveI : Mono f := by
-    rw [← prod.lift_snd (𝟙 A) f, ← zeroMul_hom t]
+    rw [← ChosenFiniteProducts.lift_snd (𝟙 A) f, ← zeroMul_hom t]
     exact mono_comp _ _
   haveI : IsSplitEpi f := IsSplitEpi.mk' ⟨t.to _, t.hom_ext _ _⟩
   apply isIso_of_mono_of_isSplitEpi
@@ -352,7 +356,7 @@ variable {D : Type u₂} [Category.{v₂} D]
 
 section Functor
 
-variable [HasFiniteProducts D]
+variable [ChosenFiniteProducts D]
 
 /-- Transport the property of being cartesian closed across an equivalence of categories.
 

--- a/Mathlib/CategoryTheory/Closed/Cartesian.lean
+++ b/Mathlib/CategoryTheory/Closed/Cartesian.lean
@@ -129,7 +129,7 @@ set_option quotPrecheck false in
 /-- Morphisms from an exponentiable object. -/
 notation:30 B " ^^ " A:30 => (exp A).obj B
 
-#adaptation_note /-- Removed simp attribute as simp can already prove it. -/
+-- Not simp as it can already prove it.
 @[reassoc]
 theorem ev_coev : (A ◁ (coev A).app B) ≫ (ev A).app (A ⊗ B) = 𝟙 (A ⊗ B : C) :=
   ihom.ev_coev A B

--- a/Mathlib/CategoryTheory/Closed/Functor.lean
+++ b/Mathlib/CategoryTheory/Closed/Functor.lean
@@ -80,7 +80,8 @@ theorem expComparison_ev (A B : C) :
       inv (prodComparison F _ _) ≫ F.map ((exp.ev _).app _) := by
   convert mateEquiv_counit _ _ (prodComparisonNatIso F A).inv B using 2
   apply IsIso.inv_eq_of_hom_inv_id -- Porting note: was `ext`
-  simp only [prodComparisonNatIso_inv, asIso_inv, NatIso.isIso_inv_app, IsIso.hom_inv_id]
+  simp only [prodComparisonNatTrans_app, prodComparisonNatIso_inv, asIso_inv, NatIso.isIso_inv_app,
+    IsIso.hom_inv_id]
 
 theorem coev_expComparison (A B : C) :
     F.map ((exp.coev A).app B) ≫ (expComparison F A).app (A ⊗ B) =
@@ -113,7 +114,7 @@ theorem expComparison_whiskerLeft {A A' : C} (f : A' ⟶ A) :
   ext B
   simp only [Functor.comp_obj, tensorLeft_obj, prodComparisonNatIso_inv, asIso_inv,
     NatTrans.comp_app, whiskerLeft_app, curriedTensor_map_app, NatIso.isIso_inv_app,
-    whiskerRight_app, IsIso.eq_inv_comp]
+    whiskerRight_app, IsIso.eq_inv_comp, prodComparisonNatTrans_app]
   rw [← prodComparison_inv_natural_whiskerRight F f]
   simp
 
@@ -137,7 +138,6 @@ theorem frobeniusMorphism_mate (h : L ⊣ F) (A : C) :
   apply congr_arg
   ext B
   unfold mateEquiv
-  #adaptation_note /-- Proof adapted from here on. -/
   simp only [Functor.comp_obj, tensorLeft_obj, Functor.id_obj, Equiv.coe_fn_mk, whiskerLeft_comp,
     whiskerLeft_twice, whiskerRight_comp, assoc, NatTrans.comp_app, whiskerLeft_app,
     curriedTensor_obj_obj, whiskerRight_app, prodComparisonNatTrans_app, curriedTensor_map_app,

--- a/Mathlib/CategoryTheory/Closed/Functor.lean
+++ b/Mathlib/CategoryTheory/Closed/Functor.lean
@@ -34,13 +34,13 @@ noncomputable section
 
 namespace CategoryTheory
 
-open Category Limits CartesianClosed
+open Category CartesianClosed MonoidalCategory ChosenFiniteProducts
 
 universe v u u'
 
 variable {C : Type u} [Category.{v} C]
 variable {D : Type u'} [Category.{v} D]
-variable [HasFiniteProducts C] [HasFiniteProducts D]
+variable [ChosenFiniteProducts C] [ChosenFiniteProducts D]
 variable (F : C ⥤ D) {L : D ⥤ C}
 
 /-- The Frobenius morphism for an adjunction `L ⊣ F` at `A` is given by the morphism
@@ -54,20 +54,20 @@ We will show that if `C` and `D` are cartesian closed, then this morphism is an 
 `A` iff `F` is a cartesian closed functor, i.e. it preserves exponentials.
 -/
 def frobeniusMorphism (h : L ⊣ F) (A : C) :
-    prod.functor.obj (F.obj A) ⋙ L ⟶ L ⋙ prod.functor.obj A :=
-  prodComparisonNatTrans L (F.obj A) ≫ whiskerLeft _ (prod.functor.map (h.counit.app _))
+    tensorLeft (F.obj A) ⋙ L ⟶ L ⋙ tensorLeft A :=
+  prodComparisonNatTrans L (F.obj A) ≫ whiskerLeft _ ((curriedTensor C).map (h.counit.app _))
 
 /-- If `F` is full and faithful and has a left adjoint `L` which preserves binary products, then the
 Frobenius morphism is an isomorphism.
 -/
 instance frobeniusMorphism_iso_of_preserves_binary_products (h : L ⊣ F) (A : C)
-    [PreservesLimitsOfShape (Discrete WalkingPair) L] [F.Full] [F.Faithful] :
+    [Limits.PreservesLimitsOfShape (Discrete Limits.WalkingPair) L] [F.Full] [F.Faithful] :
     IsIso (frobeniusMorphism F h A) :=
   suffices ∀ (X : D), IsIso ((frobeniusMorphism F h A).app X) from NatIso.isIso_of_isIso_app _
   fun B ↦ by dsimp [frobeniusMorphism]; infer_instance
 
 variable [CartesianClosed C] [CartesianClosed D]
-variable [PreservesLimitsOfShape (Discrete WalkingPair) F]
+variable [Limits.PreservesLimitsOfShape (Discrete Limits.WalkingPair) F]
 
 /-- The exponential comparison map.
 `F` is a cartesian closed functor if this is an iso for all `A`.
@@ -76,14 +76,14 @@ def expComparison (A : C) : exp A ⋙ F ⟶ F ⋙ exp (F.obj A) :=
   mateEquiv (exp.adjunction A) (exp.adjunction (F.obj A)) (prodComparisonNatIso F A).inv
 
 theorem expComparison_ev (A B : C) :
-    Limits.prod.map (𝟙 (F.obj A)) ((expComparison F A).app B) ≫ (exp.ev (F.obj A)).app (F.obj B) =
+    F.obj A ◁ ((expComparison F A).app B) ≫ (exp.ev (F.obj A)).app (F.obj B) =
       inv (prodComparison F _ _) ≫ F.map ((exp.ev _).app _) := by
   convert mateEquiv_counit _ _ (prodComparisonNatIso F A).inv B using 2
-  apply IsIso.inv_eq_of_hom_inv_id -- Porting note (#11041): was `ext`
-  simp only [Limits.prodComparisonNatIso_inv, asIso_inv, NatIso.isIso_inv_app, IsIso.hom_inv_id]
+  apply IsIso.inv_eq_of_hom_inv_id -- Porting note: was `ext`
+  simp only [prodComparisonNatIso_inv, asIso_inv, NatIso.isIso_inv_app, IsIso.hom_inv_id]
 
 theorem coev_expComparison (A B : C) :
-    F.map ((exp.coev A).app B) ≫ (expComparison F A).app (A ⨯ B) =
+    F.map ((exp.coev A).app B) ≫ (expComparison F A).app (A ⊗ B) =
       (exp.coev _).app (F.obj B) ≫ (exp (F.obj A)).map (inv (prodComparison F A B)) := by
   convert unit_mateEquiv _ _ (prodComparisonNatIso F A).inv B using 3
   apply IsIso.inv_eq_of_hom_inv_id -- Porting note (#11041): was `ext`
@@ -102,20 +102,20 @@ theorem expComparison_whiskerLeft {A A' : C} (f : A' ⟶ A) :
   unfold expComparison pre
   have vcomp1 := mateEquiv_conjugateEquiv_vcomp
     (exp.adjunction A) (exp.adjunction (F.obj A)) (exp.adjunction (F.obj A'))
-    ((prodComparisonNatIso F A).inv) ((prod.functor.map (F.map f)))
+    ((prodComparisonNatIso F A).inv) (((curriedTensor D).map (F.map f)))
   have vcomp2 := conjugateEquiv_mateEquiv_vcomp
     (exp.adjunction A) (exp.adjunction A') (exp.adjunction (F.obj A'))
-    ((prod.functor.map f)) ((prodComparisonNatIso F A').inv)
+    (((curriedTensor C).map f)) ((prodComparisonNatIso F A').inv)
   unfold leftAdjointSquareConjugate.vcomp rightAdjointSquareConjugate.vcomp at vcomp1
   unfold leftAdjointConjugateSquare.vcomp rightAdjointConjugateSquare.vcomp at vcomp2
   rw [← vcomp1, ← vcomp2]
   apply congr_arg
   ext B
-  simp only [Functor.comp_obj, prod.functor_obj_obj, prodComparisonNatIso_inv, asIso_inv,
-    NatTrans.comp_app, whiskerLeft_app, prod.functor_map_app, NatIso.isIso_inv_app,
-    whiskerRight_app]
-  rw [← F.map_id]
-  exact (prodComparison_inv_natural F f (𝟙 B)).symm
+  simp only [Functor.comp_obj, tensorLeft_obj, prodComparisonNatIso_inv, asIso_inv,
+    NatTrans.comp_app, whiskerLeft_app, curriedTensor_map_app, NatIso.isIso_inv_app,
+    whiskerRight_app, IsIso.eq_inv_comp]
+  rw [← prodComparison_inv_natural_whiskerRight F f]
+  simp
 
 /-- The functor `F` is cartesian closed (ie preserves exponentials) if each natural transformation
 `exp_comparison F A` is an isomorphism
@@ -132,33 +132,31 @@ theorem frobeniusMorphism_mate (h : L ⊣ F) (A : C) :
   unfold expComparison frobeniusMorphism
   have conjeq := iterated_mateEquiv_conjugateEquiv h h
     (exp.adjunction (F.obj A)) (exp.adjunction A)
-    (prodComparisonNatTrans L (F.obj A) ≫ whiskerLeft L (prod.functor.map (h.counit.app A)))
+    (prodComparisonNatTrans L (F.obj A) ≫ whiskerLeft L ((curriedTensor C).map (h.counit.app A)))
   rw [← conjeq]
   apply congr_arg
   ext B
   unfold mateEquiv
-  simp only [Functor.comp_obj, prod.functor_obj_obj, Functor.id_obj, Equiv.coe_fn_mk,
-    whiskerLeft_comp, whiskerLeft_twice, whiskerRight_comp, assoc, NatTrans.comp_app,
-    whiskerLeft_app, whiskerRight_app, prodComparisonNatTrans_app, prod.functor_map_app,
-    Functor.comp_map, prod.functor_obj_map, prodComparisonNatIso_inv, asIso_inv,
-    NatIso.isIso_inv_app]
+  #adaptation_note /-- Proof adapted from here on. -/
+  simp only [Functor.comp_obj, tensorLeft_obj, Functor.id_obj, Equiv.coe_fn_mk, whiskerLeft_comp,
+    whiskerLeft_twice, whiskerRight_comp, assoc, NatTrans.comp_app, whiskerLeft_app,
+    curriedTensor_obj_obj, whiskerRight_app, prodComparisonNatTrans_app, curriedTensor_map_app,
+    Functor.comp_map, tensorLeft_map, prodComparisonNatIso_inv, asIso_inv, NatIso.isIso_inv_app]
   rw [← F.map_comp, ← F.map_comp]
-  simp only [prod.map_map, comp_id, id_comp]
+  simp only [Functor.map_comp]
   apply IsIso.eq_inv_of_inv_hom_id
-  rw [F.map_comp, assoc, assoc, prodComparison_natural]
-  slice_lhs 2 3 =>
-    {
-      rw [← prodComparison_comp]
-    }
-  rw [← assoc]
+  simp only [assoc]
+  rw [prodComparison_natural_whiskerLeft, prodComparison_natural_whiskerRight_assoc]
+  slice_lhs 2 3 => rw [← prodComparison_comp]
+  simp only [assoc]
   unfold prodComparison
-  have ηlemma : (h.unit.app (F.obj A ⨯ F.obj B) ≫
-    prod.lift ((L ⋙ F).map prod.fst) ((L ⋙ F).map prod.snd)) =
-    prod.map (h.unit.app (F.obj A)) (h.unit.app (F.obj B)) := by
+  have ηlemma : (h.unit.app (F.obj A ⊗ F.obj B) ≫
+    lift ((L ⋙ F).map (fst _ _)) ((L ⋙ F).map (snd _ _))) =
+      (h.unit.app (F.obj A)) ⊗ (h.unit.app (F.obj B)) := by
     ext <;> simp
-  rw [ηlemma]
-  simp only [Functor.id_obj, Functor.comp_obj, prod.map_map, Adjunction.right_triangle_components,
-    prod.map_id_id]
+  slice_lhs 1 2 => rw [ηlemma]
+  simp only [Functor.id_obj, Functor.comp_obj, assoc, ← whisker_exchange, ← tensorHom_def']
+  ext <;> simp
 
 /--
 If the exponential comparison transformation (at `A`) is an isomorphism, then the Frobenius morphism
@@ -177,6 +175,7 @@ theorem expComparison_iso_of_frobeniusMorphism_iso (h : L ⊣ F) (A : C)
     [i : IsIso (frobeniusMorphism F h A)] : IsIso (expComparison F A) := by
   rw [← frobeniusMorphism_mate F h]; infer_instance
 
+open Limits in
 /-- If `F` is full and faithful, and has a left adjoint which preserves binary products, then it is
 cartesian closed.
 

--- a/Mathlib/CategoryTheory/Closed/Ideal.lean
+++ b/Mathlib/CategoryTheory/Closed/Ideal.lean
@@ -33,12 +33,12 @@ noncomputable section
 
 namespace CategoryTheory
 
-open Limits Category
+open Category
 
 section Ideal
 
 variable {C : Type u₁} {D : Type u₂} [Category.{v₁} C] [Category.{v₁} D] {i : D ⥤ C}
-variable (i) [HasFiniteProducts C] [CartesianClosed C]
+variable (i) [ChosenFiniteProducts C] [CartesianClosed C]
 
 /-- The subcategory `D` of `C` expressed as an inclusion functor is an *exponential ideal* if
 `B ∈ D` implies `A ⟹ B ∈ D` for all `A`.
@@ -102,19 +102,35 @@ variable (i : D ⥤ C)
 -- Porting note: this used to be used as a local instance,
 -- now it can instead be used as a have when needed
 -- we assume HasFiniteProducts D as a hypothesis below
-theorem reflective_products [HasFiniteProducts C] [Reflective i] : HasFiniteProducts D :=
-  ⟨fun _ => hasLimitsOfShape_of_reflective i⟩
+theorem reflective_products [Limits.HasFiniteProducts C] [Reflective i] :
+    Limits.HasFiniteProducts D := ⟨fun _ => hasLimitsOfShape_of_reflective i⟩
 
+#adaptation_note /-- Definition added so that sheaf categories can remain cartesian closed. -/
+/-- Given a reflective subcategory `D` of a category with chosen finite products `C`, `D` admits
+finite chosen products. -/
+def reflectiveChosenFiniteProducts [ChosenFiniteProducts C] [Reflective i] :
+    ChosenFiniteProducts D where
+  product X Y := letI := monadicCreatesLimits.{0, 0} i
+    { cone := _ ,
+      isLimit := liftedLimitIsLimit (F:=i) <|
+        (Limits.IsLimit.postcomposeInvEquiv (Limits.pairComp X Y i) _).invFun
+          (ChosenFiniteProducts.product (i.obj X) (i.obj Y)).isLimit }
+  terminal := letI := monadicCreatesLimits.{0, 0} i
+    { cone := _ ,
+      isLimit :=  liftedLimitIsLimit (F:=i) <|
+        (Limits.IsLimit.postcomposeInvEquiv (Functor.emptyExt _ (Functor.empty C)) _).invFun
+          ChosenFiniteProducts.terminal.isLimit }
 
-open CartesianClosed
+open CartesianClosed MonoidalCategory ChosenFiniteProducts
 
-variable [HasFiniteProducts C] [Reflective i] [CartesianClosed C] [HasFiniteProducts D]
+variable [ChosenFiniteProducts C] [Reflective i] [CartesianClosed C] [ChosenFiniteProducts D]
 
 /-- If the reflector preserves binary products, the subcategory is an exponential ideal.
 This is the converse of `preservesBinaryProductsOfExponentialIdeal`.
 -/
 instance (priority := 10) exponentialIdeal_of_preservesBinaryProducts
-    [PreservesLimitsOfShape (Discrete WalkingPair) (reflector i)] : ExponentialIdeal i := by
+    [Limits.PreservesLimitsOfShape (Discrete Limits.WalkingPair) (reflector i)] :
+    ExponentialIdeal i := by
   let ir := reflectorAdjunction i
   let L : C ⥤ D := reflector i
   let η : 𝟭 C ⟶ L ⋙ i := ir.unit
@@ -124,12 +140,13 @@ instance (priority := 10) exponentialIdeal_of_preservesBinaryProducts
   let q : i.obj (L.obj (A ⟹ i.obj B)) ⟶ A ⟹ i.obj B := by
     apply CartesianClosed.curry (ir.homEquiv _ _ _)
     apply _ ≫ (ir.homEquiv _ _).symm ((exp.ev A).app (i.obj B))
-    exact prodComparison L A _ ≫ Limits.prod.map (𝟙 _) (ε.app _) ≫ inv (prodComparison _ _ _)
+    exact prodComparison L A _ ≫ (_ ◁ (ε.app _)) ≫ inv (prodComparison _ _ _)
   have : η.app (A ⟹ i.obj B) ≫ q = 𝟙 (A ⟹ i.obj B) := by
     dsimp
     rw [← curry_natural_left, curry_eq_iff, uncurry_id_eq_ev, ← ir.homEquiv_naturality_left,
-      ir.homEquiv_apply_eq, assoc, assoc, prodComparison_natural_assoc, L.map_id,
-      ← prod.map_id_comp_assoc, ir.left_triangle_components, prod.map_id_id, id_comp]
+      ir.homEquiv_apply_eq, assoc, assoc, prodComparison_natural_whiskerLeft_assoc,
+      ← MonoidalCategory.whiskerLeft_comp_assoc,
+      ir.left_triangle_components, MonoidalCategory.whiskerLeft_id, id_comp]
     apply IsIso.hom_inv_id_assoc
   haveI : IsSplitMono (η.app (A ⟹ i.obj B)) := IsSplitMono.mk' ⟨_, this⟩
   apply mem_essImage_of_unit_isSplitMono
@@ -139,27 +156,26 @@ variable [ExponentialIdeal i]
 /-- If `i` witnesses that `D` is a reflective subcategory and an exponential ideal, then `D` is
 itself cartesian closed.
 -/
-def cartesianClosedOfReflective : CartesianClosed D :=
-  { __ := monoidalOfHasFiniteProducts D -- Porting note (#10754): added this instance
-    closed := fun B =>
-      { rightAdj := i ⋙ exp (i.obj B) ⋙ reflector i
-        adj := by
-          apply (exp.adjunction (i.obj B)).restrictFullyFaithful i.fullyFaithfulOfReflective
-            i.fullyFaithfulOfReflective
-          · symm
-            refine NatIso.ofComponents (fun X => ?_) (fun f => ?_)
-            · haveI :=
-                Adjunction.rightAdjointPreservesLimits.{0, 0} (reflectorAdjunction i)
-              apply asIso (prodComparison i B X)
-            · dsimp [asIso]
-              rw [prodComparison_natural, Functor.map_id]
-          · apply (exponentialIdealReflective i _).symm } }
+def cartesianClosedOfReflective : CartesianClosed D where
+  closed := fun B =>
+    { rightAdj := i ⋙ exp (i.obj B) ⋙ reflector i
+      adj := by
+        apply (exp.adjunction (i.obj B)).restrictFullyFaithful i.fullyFaithfulOfReflective
+          i.fullyFaithfulOfReflective
+        · symm
+          refine NatIso.ofComponents (fun X => ?_) (fun f => ?_)
+          · haveI :=
+              Adjunction.rightAdjointPreservesLimits.{0, 0} (reflectorAdjunction i)
+            apply asIso (prodComparison i B X)
+          · dsimp [asIso]
+            rw [prodComparison_natural_whiskerLeft]
+        · apply (exponentialIdealReflective i _).symm }
 
 -- It's annoying that I need to do this.
 attribute [-instance] CategoryTheory.preservesLimitOfCreatesLimitAndHasLimit
   CategoryTheory.preservesLimitOfShapeOfCreatesLimitsOfShapeAndHasLimitsOfShape
 
-/-- We construct a bijection between morphisms `L(A ⨯ B) ⟶ X` and morphisms `LA ⨯ LB ⟶ X`.
+/-- We construct a bijection between morphisms `L(A ⊗ B) ⟶ X` and morphisms `LA ⊗ LB ⟶ X`.
 This bijection has two key properties:
 * It is natural in `X`: See `bijection_natural`.
 * When `X = LA ⨯ LB`, then the backwards direction sends the identity morphism to the product
@@ -169,26 +185,26 @@ Together these help show that `L` preserves binary products. This should be cons
 *internal implementation* towards `preservesBinaryProductsOfExponentialIdeal`.
 -/
 noncomputable def bijection (A B : C) (X : D) :
-    ((reflector i).obj (A ⨯ B) ⟶ X) ≃ ((reflector i).obj A ⨯ (reflector i).obj B ⟶ X) :=
+    ((reflector i).obj (A ⊗ B) ⟶ X) ≃ ((reflector i).obj A ⊗ (reflector i).obj B ⟶ X) :=
   calc
-    _ ≃ (A ⨯ B ⟶ i.obj X) := (reflectorAdjunction i).homEquiv _ _
-    _ ≃ (B ⨯ A ⟶ i.obj X) := (Limits.prod.braiding _ _).homCongr (Iso.refl _)
+    _ ≃ (A ⊗ B ⟶ i.obj X) := (reflectorAdjunction i).homEquiv _ _
+    _ ≃ (B ⊗ A ⟶ i.obj X) := (β_ _ _).homCongr (Iso.refl _)
     _ ≃ (A ⟶ B ⟹ i.obj X) := (exp.adjunction _).homEquiv _ _
     _ ≃ (i.obj ((reflector i).obj A) ⟶ B ⟹ i.obj X) :=
       (unitCompPartialBijective _ (ExponentialIdeal.exp_closed (i.obj_mem_essImage _) _))
-    _ ≃ (B ⨯ i.obj ((reflector i).obj A) ⟶ i.obj X) := ((exp.adjunction _).homEquiv _ _).symm
-    _ ≃ (i.obj ((reflector i).obj A) ⨯ B ⟶ i.obj X) :=
-      ((Limits.prod.braiding _ _).homCongr (Iso.refl _))
+    _ ≃ (B ⊗ i.obj ((reflector i).obj A) ⟶ i.obj X) := ((exp.adjunction _).homEquiv _ _).symm
+    _ ≃ (i.obj ((reflector i).obj A) ⊗ B ⟶ i.obj X) :=
+      ((β_ _ _).homCongr (Iso.refl _))
     _ ≃ (B ⟶ i.obj ((reflector i).obj A) ⟹ i.obj X) := (exp.adjunction _).homEquiv _ _
     _ ≃ (i.obj ((reflector i).obj B) ⟶ i.obj ((reflector i).obj A) ⟹ i.obj X) :=
       (unitCompPartialBijective _ (ExponentialIdeal.exp_closed (i.obj_mem_essImage _) _))
-    _ ≃ (i.obj ((reflector i).obj A) ⨯ i.obj ((reflector i).obj B) ⟶ i.obj X) :=
+    _ ≃ (i.obj ((reflector i).obj A) ⊗ i.obj ((reflector i).obj B) ⟶ i.obj X) :=
       ((exp.adjunction _).homEquiv _ _).symm
-    _ ≃ (i.obj ((reflector i).obj A ⨯ (reflector i).obj B) ⟶ i.obj X) :=
-      haveI : PreservesLimits i := (reflectorAdjunction i).rightAdjointPreservesLimits
-      haveI := preservesSmallestLimitsOfPreservesLimits i
-      Iso.homCongr (PreservesLimitPair.iso _ _ _).symm (Iso.refl (i.obj X))
-    _ ≃ ((reflector i).obj A ⨯ (reflector i).obj B ⟶ X) :=
+    _ ≃ (i.obj ((reflector i).obj A ⊗ (reflector i).obj B) ⟶ i.obj X) :=
+      haveI : Limits.PreservesLimits i := (reflectorAdjunction i).rightAdjointPreservesLimits
+      haveI := Limits.preservesSmallestLimitsOfPreservesLimits i
+      Iso.homCongr (prodComparisonIso _ _ _).symm (Iso.refl (i.obj X))
+    _ ≃ ((reflector i).obj A ⊗ (reflector i).obj B ⟶ X) :=
       i.fullyFaithfulOfReflective.homEquiv.symm
 
 theorem bijection_symm_apply_id (A B : C) :
@@ -198,19 +214,22 @@ theorem bijection_symm_apply_id (A B : C) :
   erw [homEquiv_symm_apply_eq, homEquiv_symm_apply_eq, homEquiv_apply_eq, homEquiv_apply_eq]
   rw [comp_id, comp_id, comp_id, i.map_id, comp_id, unitCompPartialBijective_symm_apply,
     unitCompPartialBijective_symm_apply, uncurry_natural_left, uncurry_curry,
-    uncurry_natural_left, uncurry_curry, prod.lift_map_assoc, comp_id, prod.lift_map_assoc, comp_id]
+    uncurry_natural_left, uncurry_curry, ← BraidedCategory.braiding_naturality_left_assoc]
+  #adaptation_note /-- Proof adapted from here on. -/
+  erw [SymmetricCategory.symmetry_assoc, ← MonoidalCategory.whisker_exchange_assoc]
   -- Porting note: added
   dsimp only [Functor.comp_obj]
-  rw [prod.comp_lift_assoc, prod.lift_snd, prod.lift_fst_assoc, prod.lift_fst_comp_snd_comp,
-    Adjunction.homEquiv_counit, ← Adjunction.eq_unit_comp_map_iff, Iso.comp_inv_eq, assoc]
-  rw [PreservesLimitPair.iso_hom i ((reflector i).obj A) ((reflector i).obj B)]
-  apply Limits.prod.hom_ext
-  · rw [Limits.prod.map_fst, assoc, assoc, prodComparison_fst, ← i.map_comp, prodComparison_fst]
+  rw [← tensorHom_def'_assoc, ← Adjunction.eq_unit_comp_map_iff, Iso.comp_inv_eq, assoc]
+  rw [prodComparisonIso_hom i ((reflector i).obj A) ((reflector i).obj B)]
+  apply hom_ext
+  · rw [tensorHom_fst, assoc, assoc, prodComparison_fst, ← i.map_comp,
+    prodComparison_fst]
     apply (reflectorAdjunction i).unit.naturality
-  · rw [Limits.prod.map_snd, assoc, assoc, prodComparison_snd, ← i.map_comp, prodComparison_snd]
+  · rw [tensorHom_snd, assoc, assoc, prodComparison_snd, ← i.map_comp,
+    prodComparison_snd]
     apply (reflectorAdjunction i).unit.naturality
 
-theorem bijection_natural (A B : C) (X X' : D) (f : (reflector i).obj (A ⨯ B) ⟶ X) (g : X ⟶ X') :
+theorem bijection_natural (A B : C) (X X' : D) (f : (reflector i).obj (A ⊗ B) ⟶ X) (g : X ⟶ X') :
     bijection i _ _ _ (f ≫ g) = bijection i _ _ _ f ≫ g := by
   dsimp [bijection]
   -- Porting note: added
@@ -228,13 +247,16 @@ theorem bijection_natural (A B : C) (X X' : D) (f : (reflector i).obj (A ⨯ B) 
 The bijection allows us to show that `prodComparison L A B` is an isomorphism, where the inverse
 is the forward map of the identity morphism.
 -/
-theorem prodComparison_iso (A B : C) : IsIso (prodComparison (reflector i) A B) :=
+theorem prodComparison_iso (A B : C) : IsIso
+    (prodComparison (reflector i) A B) :=
   ⟨⟨bijection i _ _ _ (𝟙 _), by
       rw [← (bijection i _ _ _).injective.eq_iff, bijection_natural, ← bijection_symm_apply_id,
         Equiv.apply_symm_apply, id_comp],
       by rw [← bijection_natural, id_comp, ← bijection_symm_apply_id, Equiv.apply_symm_apply]⟩⟩
 
 attribute [local instance] prodComparison_iso
+
+open Limits
 
 /--
 If a reflective subcategory is an exponential ideal, then the reflector preserves binary products.
@@ -243,7 +265,7 @@ This is the converse of `exponentialIdeal_of_preserves_binary_products`.
 noncomputable def preservesBinaryProductsOfExponentialIdeal :
     PreservesLimitsOfShape (Discrete WalkingPair) (reflector i) where
   preservesLimit {K} :=
-    letI := PreservesLimitPair.ofIsoProdComparison
+    letI := preservesLimitPairOfIsIsoProdComparison
       (reflector i) (K.obj ⟨WalkingPair.left⟩) (K.obj ⟨WalkingPair.right⟩)
     Limits.preservesLimitOfIsoDiagram _ (diagramIsoPair K).symm
 

--- a/Mathlib/CategoryTheory/Closed/Ideal.lean
+++ b/Mathlib/CategoryTheory/Closed/Ideal.lean
@@ -105,7 +105,6 @@ variable (i : D ⥤ C)
 theorem reflective_products [Limits.HasFiniteProducts C] [Reflective i] :
     Limits.HasFiniteProducts D := ⟨fun _ => hasLimitsOfShape_of_reflective i⟩
 
-#adaptation_note /-- Definition added so that sheaf categories can remain cartesian closed. -/
 /-- Given a reflective subcategory `D` of a category with chosen finite products `C`, `D` admits
 finite chosen products. -/
 def reflectiveChosenFiniteProducts [ChosenFiniteProducts C] [Reflective i] :
@@ -215,11 +214,11 @@ theorem bijection_symm_apply_id (A B : C) :
   rw [comp_id, comp_id, comp_id, i.map_id, comp_id, unitCompPartialBijective_symm_apply,
     unitCompPartialBijective_symm_apply, uncurry_natural_left, uncurry_curry,
     uncurry_natural_left, uncurry_curry, ← BraidedCategory.braiding_naturality_left_assoc]
-  #adaptation_note /-- Proof adapted from here on. -/
   erw [SymmetricCategory.symmetry_assoc, ← MonoidalCategory.whisker_exchange_assoc]
   -- Porting note: added
   dsimp only [Functor.comp_obj]
-  rw [← tensorHom_def'_assoc, ← Adjunction.eq_unit_comp_map_iff, Iso.comp_inv_eq, assoc]
+  rw [← tensorHom_def'_assoc, Adjunction.homEquiv_symm_apply,
+    ← Adjunction.eq_unit_comp_map_iff, Iso.comp_inv_eq, assoc]
   rw [prodComparisonIso_hom i ((reflector i).obj A) ((reflector i).obj B)]
   apply hom_ext
   · rw [tensorHom_fst, assoc, assoc, prodComparison_fst, ← i.map_comp,

--- a/Mathlib/CategoryTheory/Closed/Types.lean
+++ b/Mathlib/CategoryTheory/Closed/Types.lean
@@ -5,8 +5,9 @@ Authors: Bhavik Mehta
 -/
 import Mathlib.CategoryTheory.Limits.Presheaf
 import Mathlib.CategoryTheory.Limits.Preserves.FunctorCategory
-import Mathlib.CategoryTheory.Limits.Shapes.Types
 import Mathlib.CategoryTheory.Closed.Cartesian
+import Mathlib.CategoryTheory.Monoidal.Types.Basic
+import Mathlib.CategoryTheory.ChosenFiniteProducts.FunctorCategory
 
 /-!
 # Cartesian closure of Type
@@ -21,7 +22,7 @@ namespace CategoryTheory
 
 noncomputable section
 
-open Category Limits
+open Category Limits MonoidalCategory
 
 universe v₁ v₂ u₁ u₂
 
@@ -29,26 +30,26 @@ variable {C : Type v₂} [Category.{v₁} C]
 
 section CartesianClosed
 
-/-- The adjunction `Limits.Types.binaryProductFunctor.obj X ⊣ coyoneda.obj (Opposite.op X)`
+/-- The adjunction `tensorLeft.obj X ⊣ coyoneda.obj (Opposite.op X)`
 for any `X : Type v₁`. -/
-def Types.binaryProductAdjunction (X : Type v₁) :
-    Limits.Types.binaryProductFunctor.obj X ⊣ coyoneda.obj (Opposite.op X) where
+def Types.tensorProductAdjunction (X : Type v₁) :
+    tensorLeft X ⊣ coyoneda.obj (Opposite.op X) where
   unit := { app := fun Z (z : Z) x => ⟨x, z⟩ }
   counit := { app := fun _ xf => xf.2 xf.1 }
 
-instance (X : Type v₁) : (Types.binaryProductFunctor.obj X).IsLeftAdjoint :=
-  ⟨_, ⟨Types.binaryProductAdjunction X⟩⟩
+instance (X : Type v₁) : (tensorLeft X).IsLeftAdjoint :=
+  ⟨_, ⟨Types.tensorProductAdjunction X⟩⟩
 
 instance : CartesianClosed (Type v₁) := CartesianClosed.mk _
-  (fun X => Exponentiable.mk _ _
-    ((Types.binaryProductAdjunction X).ofNatIsoLeft (Types.binaryProductIsoProd.app X)))
+  (fun X => Exponentiable.mk _ _ (Types.tensorProductAdjunction X))
 
 instance {C : Type v₁} [SmallCategory C] : CartesianClosed (C ⥤ Type v₁) :=
   CartesianClosed.mk _
     (fun F => by
-      letI := FunctorCategory.prodPreservesColimits F
-      have := Presheaf.isLeftAdjoint_of_preservesColimits (prod.functor.obj F)
-      exact Exponentiable.mk _ _ (Adjunction.ofIsLeftAdjoint (prod.functor.obj F)))
+      haveI : ∀ X : Type v₁, PreservesColimits (tensorLeft X) := by infer_instance
+      letI : PreservesColimits (tensorLeft F) := ⟨by infer_instance⟩
+      have := Presheaf.isLeftAdjoint_of_preservesColimits (tensorLeft F)
+      exact Exponentiable.mk _ _ (Adjunction.ofIsLeftAdjoint (tensorLeft F)))
 
 -- TODO: once we have `MonoidalClosed` instances for functor categories into general monoidal
 -- closed categories, replace this with that, as it will be a more explicit construction.

--- a/Mathlib/CategoryTheory/Closed/Types.lean
+++ b/Mathlib/CategoryTheory/Closed/Types.lean
@@ -4,7 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Bhavik Mehta
 -/
 import Mathlib.CategoryTheory.Limits.Presheaf
-import Mathlib.CategoryTheory.Limits.Preserves.FunctorCategory
 import Mathlib.CategoryTheory.Closed.Cartesian
 import Mathlib.CategoryTheory.Monoidal.Types.Basic
 import Mathlib.CategoryTheory.ChosenFiniteProducts.FunctorCategory

--- a/Mathlib/CategoryTheory/Closed/Zero.lean
+++ b/Mathlib/CategoryTheory/Closed/Zero.lean
@@ -26,19 +26,19 @@ noncomputable section
 
 namespace CategoryTheory
 
-open Category Limits
+open Category Limits MonoidalCategory
 
 variable {C : Type u} [Category.{v} C]
-variable [HasFiniteProducts C] [CartesianClosed C]
+variable [ChosenFiniteProducts C] [CartesianClosed C]
 
 /-- If a cartesian closed category has an initial object which is isomorphic to the terminal object,
 then each homset has exactly one element.
 -/
-def uniqueHomsetOfInitialIsoTerminal [HasInitial C] (i : ⊥_ C ≅ ⊤_ C) (X Y : C) : Unique (X ⟶ Y) :=
+def uniqueHomsetOfInitialIsoUnit [HasInitial C] (i : ⊥_ C ≅ 𝟙_ C) (X Y : C) : Unique (X ⟶ Y) :=
   Equiv.unique <|
     calc
-      (X ⟶ Y) ≃ (X ⨯ ⊤_ C ⟶ Y) := Iso.homCongr (Limits.prod.rightUnitor _).symm (Iso.refl _)
-      _ ≃ (X ⨯ ⊥_ C ⟶ Y) := (Iso.homCongr (prod.mapIso (Iso.refl _) i.symm) (Iso.refl _))
+      (X ⟶ Y) ≃ (X ⊗ 𝟙_ C ⟶ Y) := Iso.homCongr (rightUnitor _).symm (Iso.refl _)
+      _ ≃ (X ⊗ ⊥_ C ⟶ Y) := (Iso.homCongr ((Iso.refl _) ⊗ i.symm) (Iso.refl _))
       _ ≃ (⊥_ C ⟶ Y ^^ X) := (exp.adjunction _).homEquiv _ _
 
 open scoped ZeroObject
@@ -46,8 +46,8 @@ open scoped ZeroObject
 /-- If a cartesian closed category has a zero object, each homset has exactly one element. -/
 def uniqueHomsetOfZero [HasZeroObject C] (X Y : C) : Unique (X ⟶ Y) := by
   haveI : HasInitial C := HasZeroObject.hasInitial
-  apply uniqueHomsetOfInitialIsoTerminal _ X Y
-  refine ⟨default, (default : ⊤_ C ⟶ 0) ≫ default, ?_, ?_⟩ <;> simp [eq_iff_true_of_subsingleton]
+  apply uniqueHomsetOfInitialIsoUnit _ X Y
+  refine ⟨default, (default : 𝟙_ C ⟶ 0) ≫ default, ?_, ?_⟩ <;> simp [eq_iff_true_of_subsingleton]
 
 attribute [local instance] uniqueHomsetOfZero
 

--- a/Mathlib/CategoryTheory/Sites/CartesianClosed.lean
+++ b/Mathlib/CategoryTheory/Sites/CartesianClosed.lean
@@ -20,7 +20,6 @@ open CategoryTheory Limits
 
 variable {C : Type*} [Category C] (J : GrothendieckTopology C) (A : Type*) [Category A]
 
-#adaptation_note /-- Added instance. -/
 instance [HasSheafify J A] [ChosenFiniteProducts A] : ChosenFiniteProducts (Sheaf J A) :=
   reflectiveChosenFiniteProducts (sheafToPresheaf _ _)
 

--- a/Mathlib/CategoryTheory/Sites/CartesianClosed.lean
+++ b/Mathlib/CategoryTheory/Sites/CartesianClosed.lean
@@ -4,9 +4,8 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Dagur Asgeirsson
 -/
 import Mathlib.CategoryTheory.Closed.Ideal
-import Mathlib.CategoryTheory.Limits.FunctorCategory.Finite
-import Mathlib.CategoryTheory.Sites.Limits
 import Mathlib.CategoryTheory.ChosenFiniteProducts.FunctorCategory
+import Mathlib.CategoryTheory.Sites.Sheafification
 /-!
 
 # Sheaf categories are cartesian closed

--- a/Mathlib/CategoryTheory/Sites/CartesianClosed.lean
+++ b/Mathlib/CategoryTheory/Sites/CartesianClosed.lean
@@ -6,12 +6,13 @@ Authors: Dagur Asgeirsson
 import Mathlib.CategoryTheory.Closed.Ideal
 import Mathlib.CategoryTheory.Limits.FunctorCategory.Finite
 import Mathlib.CategoryTheory.Sites.Limits
+import Mathlib.CategoryTheory.ChosenFiniteProducts.FunctorCategory
 /-!
 
 # Sheaf categories are cartesian closed
 
-...if the underlying presheaf category is cartesian closed, the target category has finite products,
-and there exists a sheafification functor.
+...if the underlying presheaf category is cartesian closed, the target category has
+(chosen) finite products, and there exists a sheafification functor.
 -/
 
 noncomputable section
@@ -20,6 +21,10 @@ open CategoryTheory Limits
 
 variable {C : Type*} [Category C] (J : GrothendieckTopology C) (A : Type*) [Category A]
 
-instance [HasSheafify J A] [HasFiniteProducts A] [CartesianClosed (Cᵒᵖ ⥤ A)] :
+#adaptation_note /-- Added instance. -/
+instance [HasSheafify J A] [ChosenFiniteProducts A] : ChosenFiniteProducts (Sheaf J A) :=
+  reflectiveChosenFiniteProducts (sheafToPresheaf _ _)
+
+instance [HasSheafify J A] [ChosenFiniteProducts A] [CartesianClosed (Cᵒᵖ ⥤ A)] :
     CartesianClosed (Sheaf J A) :=
   cartesianClosedOfReflective (sheafToPresheaf _ _)

--- a/Mathlib/CategoryTheory/Sites/CartesianClosed.lean
+++ b/Mathlib/CategoryTheory/Sites/CartesianClosed.lean
@@ -6,6 +6,7 @@ Authors: Dagur Asgeirsson
 import Mathlib.CategoryTheory.Closed.Ideal
 import Mathlib.CategoryTheory.ChosenFiniteProducts.FunctorCategory
 import Mathlib.CategoryTheory.Sites.Sheafification
+import Mathlib.CategoryTheory.Sites.ChosenFiniteProducts
 /-!
 
 # Sheaf categories are cartesian closed
@@ -19,9 +20,6 @@ noncomputable section
 open CategoryTheory Limits
 
 variable {C : Type*} [Category C] (J : GrothendieckTopology C) (A : Type*) [Category A]
-
-instance [HasSheafify J A] [ChosenFiniteProducts A] : ChosenFiniteProducts (Sheaf J A) :=
-  reflectiveChosenFiniteProducts (sheafToPresheaf _ _)
 
 instance [HasSheafify J A] [ChosenFiniteProducts A] [CartesianClosed (Cᵒᵖ ⥤ A)] :
     CartesianClosed (Sheaf J A) :=

--- a/Mathlib/Condensed/CartesianClosed.lean
+++ b/Mathlib/Condensed/CartesianClosed.lean
@@ -3,9 +3,11 @@ Copyright (c) 2024 Dagur Asgeirsson. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Dagur Asgeirsson
 -/
-import Mathlib.Condensed.Limits
 import Mathlib.CategoryTheory.Closed.Types
 import Mathlib.CategoryTheory.Sites.CartesianClosed
+import Mathlib.Condensed.Basic
+import Mathlib.CategoryTheory.ConcreteCategory.ReflectsIso
+import Mathlib.CategoryTheory.Sites.LeftExact
 /-!
 
 # Condensed sets form a cartesian closed category

--- a/Mathlib/Condensed/CartesianClosed.lean
+++ b/Mathlib/Condensed/CartesianClosed.lean
@@ -17,4 +17,8 @@ noncomputable section
 
 open CategoryTheory
 
+#adaptation_note /-- Added instance. -/
+instance : ChosenFiniteProducts (CondensedSet.{u}) :=
+  inferInstanceAs (ChosenFiniteProducts (Sheaf _ _))
+
 instance : CartesianClosed (CondensedSet.{u}) := inferInstanceAs (CartesianClosed (Sheaf _ _))

--- a/Mathlib/Condensed/CartesianClosed.lean
+++ b/Mathlib/Condensed/CartesianClosed.lean
@@ -19,7 +19,6 @@ noncomputable section
 
 open CategoryTheory
 
-#adaptation_note /-- Added instance. -/
 instance : ChosenFiniteProducts (CondensedSet.{u}) :=
   inferInstanceAs (ChosenFiniteProducts (Sheaf _ _))
 

--- a/Mathlib/Condensed/Light/CartesianClosed.lean
+++ b/Mathlib/Condensed/Light/CartesianClosed.lean
@@ -17,4 +17,10 @@ noncomputable section
 
 open CategoryTheory
 
+variable {C : Type u} [SmallCategory C]
+
+#adaptation_note /-- Added instance. -/
+instance : ChosenFiniteProducts (LightCondSet.{u}) :=
+  inferInstanceAs (ChosenFiniteProducts (Sheaf _ _))
+
 instance : CartesianClosed (LightCondSet.{u}) := inferInstanceAs (CartesianClosed (Sheaf _ _))

--- a/Mathlib/Condensed/Light/CartesianClosed.lean
+++ b/Mathlib/Condensed/Light/CartesianClosed.lean
@@ -3,9 +3,11 @@ Copyright (c) 2024 Dagur Asgeirsson. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Dagur Asgeirsson
 -/
-import Mathlib.Condensed.Light.Limits
 import Mathlib.CategoryTheory.Closed.Types
 import Mathlib.CategoryTheory.Sites.CartesianClosed
+import Mathlib.CategoryTheory.ConcreteCategory.ReflectsIso
+import Mathlib.CategoryTheory.Sites.Equivalence
+import Mathlib.Condensed.Light.Basic
 /-!
 
 # Light condensed sets form a cartesian closed category

--- a/Mathlib/Condensed/Light/CartesianClosed.lean
+++ b/Mathlib/Condensed/Light/CartesianClosed.lean
@@ -21,7 +21,6 @@ open CategoryTheory
 
 variable {C : Type u} [SmallCategory C]
 
-#adaptation_note /-- Added instance. -/
 instance : ChosenFiniteProducts (LightCondSet.{u}) :=
   inferInstanceAs (ChosenFiniteProducts (Sheaf _ _))
 


### PR DESCRIPTION
Change the API for `CartesianClosed` categories: they are now defined as `MonoidalClosed` for the monoidal structure inherited by a `ChosenFiniteProducts` instance. They were previously relying on `HasFiniteProducts`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

I left adaptation notes where I had to make substantial changes to proofs. The biggest addition is `reflectiveChosenFiniteProducts` in `CategoryTheory/Closed/Ideal`.
Extra `ChosenFiniteProducts` instances had to be added in `CategoryTheory/Sites/CartesianClosed`, `Condensed/CartesianClosed` and `Condensed/Light/CartesianClosed`, they rely all on `reflectiveChosenFiniteProducts`.

- [x] depends on: #17613
- [x] depends on: #17733 
- [x] depends on: #18633

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
