### PR TITLE
[Merged by Bors] - chore: split off `Rat`-based functions from `Mathlib.Lean.Expr.Basic`

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -2934,6 +2934,7 @@ import Mathlib.Lean.Exception
 import Mathlib.Lean.Expr
 import Mathlib.Lean.Expr.Basic
 import Mathlib.Lean.Expr.ExtraRecognizers
+import Mathlib.Lean.Expr.Rat
 import Mathlib.Lean.Expr.ReplaceRec
 import Mathlib.Lean.GoalsLocation
 import Mathlib.Lean.Json

--- a/Mathlib/Data/Nat/GCD/Basic.lean
+++ b/Mathlib/Data/Nat/GCD/Basic.lean
@@ -3,6 +3,7 @@ Copyright (c) 2014 Jeremy Avigad. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Jeremy Avigad, Leonardo de Moura
 -/
+import Batteries.Data.Nat.Gcd
 import Mathlib.Algebra.GroupWithZero.Divisibility
 import Mathlib.Algebra.Ring.Nat
 

--- a/Mathlib/Data/Nat/GCD/BigOperators.lean
+++ b/Mathlib/Data/Nat/GCD/BigOperators.lean
@@ -3,6 +3,7 @@ Copyright (c) 2014 Jeremy Avigad. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Jeremy Avigad, Leonardo de Moura
 -/
+import Batteries.Data.Nat.Gcd
 import Mathlib.Algebra.BigOperators.Group.Finset
 
 /-! # Lemmas about coprimality with big products.

--- a/Mathlib/Data/Nat/Prime/Defs.lean
+++ b/Mathlib/Data/Nat/Prime/Defs.lean
@@ -3,6 +3,7 @@ Copyright (c) 2015 Microsoft Corporation. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Leonardo de Moura, Jeremy Avigad, Mario Carneiro
 -/
+import Batteries.Data.Nat.Gcd
 import Mathlib.Algebra.Associated.Basic
 import Mathlib.Algebra.Ring.Parity
 

--- a/Mathlib/Lean/Expr/Basic.lean
+++ b/Mathlib/Lean/Expr/Basic.lean
@@ -7,7 +7,6 @@ Floris van Doorn, Edward Ayers, Arthur Paulino
 import Mathlib.Init
 import Lean.Meta.Tactic.Rewrite
 import Batteries.Lean.Expr
-import Batteries.Data.Rat.Basic
 import Batteries.Tactic.Alias
 import Lean.Elab.Binders
 
@@ -204,39 +203,6 @@ def eraseProofs (e : Expr) : MetaM Expr :=
         return .continue (← mkSyntheticSorry (← inferType e))
       else
         return .continue)
-
-/--
-Check if an expression is a "rational in normal form",
-i.e. either an integer number in normal form,
-or `n / d` where `n` is an integer in normal form, `d` is a natural number in normal form,
-`d ≠ 1`, and `n` and `d` are coprime (in particular, we check that `(mkRat n d).den = d`).
-If so returns the rational number.
--/
-def rat? (e : Expr) : Option Rat := do
-  if e.isAppOfArity ``Div.div 4 then
-    let d ← e.appArg!.nat?
-    guard (d ≠ 1)
-    let n ← e.appFn!.appArg!.int?
-    let q := mkRat n d
-    guard (q.den = d)
-    pure q
-  else
-    e.int?
-
-/--
-Test if an expression represents an explicit number written in normal form:
-* A "natural number in normal form" is an expression `OfNat.ofNat n`, even if it is not of type `ℕ`,
-  as long as `n` is a literal.
-* An "integer in normal form" is an expression which is either a natural number in number form,
-  or `-n`, where `n` is a natural number in normal form.
-* A "rational in normal form" is an expressions which is either an integer in normal form,
-  or `n / d` where `n` is an integer in normal form, `d` is a natural number in normal form,
-  `d ≠ 1`, and `n` and `d` are coprime (in particular, we check that `(mkRat n d).den = d`).
--/
-def isExplicitNumber : Expr → Bool
-  | .lit _ => true
-  | .mdata _ e => isExplicitNumber e
-  | e => e.rat?.isSome
 
 /-- If an `Expr` has form `.fvar n`, then returns `some n`, otherwise `none`. -/
 def fvarId? : Expr → Option FVarId

--- a/Mathlib/Lean/Expr/Rat.lean
+++ b/Mathlib/Lean/Expr/Rat.lean
@@ -1,0 +1,59 @@
+/-
+Copyright (c) 2019 Robert Y. Lewis. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Mario Carneiro, Kim Morrison
+-/
+import Mathlib.Init
+import Lean.Meta.Tactic.Rewrite
+import Batteries.Data.Rat.Basic
+import Batteries.Lean.Expr
+import Batteries.Tactic.Alias
+import Lean.Elab.Binders
+
+/-!
+# Additional operations on Expr and rational numbers
+
+This file defines some operations involving `Expr` and rational numbers.
+
+## Main definitions
+
+ * `Lean.Expr.isExplicitNumber`: is an expression a number in normal form?
+   This includes natural numbers, integers and rationals.
+-/
+
+namespace Lean.Expr
+
+/--
+Check if an expression is a "rational in normal form",
+i.e. either an integer number in normal form,
+or `n / d` where `n` is an integer in normal form, `d` is a natural number in normal form,
+`d ≠ 1`, and `n` and `d` are coprime (in particular, we check that `(mkRat n d).den = d`).
+If so returns the rational number.
+-/
+def rat? (e : Expr) : Option Rat := do
+  if e.isAppOfArity ``Div.div 4 then
+    let d ← e.appArg!.nat?
+    guard (d ≠ 1)
+    let n ← e.appFn!.appArg!.int?
+    let q := mkRat n d
+    guard (q.den = d)
+    pure q
+  else
+    e.int?
+
+/--
+Test if an expression represents an explicit number written in normal form:
+* A "natural number in normal form" is an expression `OfNat.ofNat n`, even if it is not of type `ℕ`,
+  as long as `n` is a literal.
+* An "integer in normal form" is an expression which is either a natural number in number form,
+  or `-n`, where `n` is a natural number in normal form.
+* A "rational in normal form" is an expressions which is either an integer in normal form,
+  or `n / d` where `n` is an integer in normal form, `d` is a natural number in normal form,
+  `d ≠ 1`, and `n` and `d` are coprime (in particular, we check that `(mkRat n d).den = d`).
+-/
+def isExplicitNumber : Expr → Bool
+  | .lit _ => true
+  | .mdata _ e => isExplicitNumber e
+  | e => e.rat?.isSome
+
+end Lean.Expr

--- a/Mathlib/Lean/Expr/Rat.lean
+++ b/Mathlib/Lean/Expr/Rat.lean
@@ -4,11 +4,8 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Mario Carneiro, Kim Morrison
 -/
 import Mathlib.Init
-import Lean.Meta.Tactic.Rewrite
 import Batteries.Data.Rat.Basic
-import Batteries.Lean.Expr
 import Batteries.Tactic.Alias
-import Lean.Elab.Binders
 
 /-!
 # Additional operations on Expr and rational numbers

--- a/Mathlib/Tactic/NormNum/Core.lean
+++ b/Mathlib/Tactic/NormNum/Core.lean
@@ -3,6 +3,7 @@ Copyright (c) 2022 Mario Carneiro. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Mario Carneiro
 -/
+import Mathlib.Lean.Expr.Rat
 import Mathlib.Tactic.NormNum.Result
 import Mathlib.Util.Qq
 import Lean.Elab.Tactic.Location

--- a/Mathlib/Testing/SlimCheck/Sampleable.lean
+++ b/Mathlib/Testing/SlimCheck/Sampleable.lean
@@ -3,6 +3,7 @@ Copyright (c) 2022 Henrik Böving. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Henrik Böving, Simon Hudon
 -/
+import Batteries.Data.Rat.Basic
 import Mathlib.Algebra.Order.Ring.Int
 import Mathlib.Data.List.Monad
 import Mathlib.Testing.SlimCheck.Gen


### PR DESCRIPTION
Basic functions for working with expressions don't need to know about the rational numbers. (I checked this manually since `assert_not_exists` ins't imported here yet!)


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
