### PR TITLE
[Merged by Bors] - feat(CategoryTheory/Limits): definition of sifted categories

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -1706,6 +1706,7 @@ import Mathlib.CategoryTheory.Limits.Shapes.WideEqualizers
 import Mathlib.CategoryTheory.Limits.Shapes.WidePullbacks
 import Mathlib.CategoryTheory.Limits.Shapes.ZeroMorphisms
 import Mathlib.CategoryTheory.Limits.Shapes.ZeroObjects
+import Mathlib.CategoryTheory.Limits.Sifted
 import Mathlib.CategoryTheory.Limits.SmallComplete
 import Mathlib.CategoryTheory.Limits.Types
 import Mathlib.CategoryTheory.Limits.TypesFiltered

--- a/Mathlib/CategoryTheory/Limits/Sifted.lean
+++ b/Mathlib/CategoryTheory/Limits/Sifted.lean
@@ -1,0 +1,111 @@
+/-
+Copyright (c) 2024 Robin Carlier. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Robin Carlier
+-/
+import Mathlib.CategoryTheory.Limits.Final
+/-!
+# Sifted categories
+
+A category `C` is Sifted if `C` is nonempty and the diagonal functor `C ⥤ C × C` is final.
+Sifted categories can be caracterized as those such that the colimit functor `(C ⥤ Type) ⥤ Type `
+preserves finite products. We achieve this characterization in this file, as well as providing some
+API to produce `IsSifted` instances.
+
+## Main results
+- `colimPreservesFiniteProductsOfIsSifted`: The `Type`-valued colimit functor for sifted diagrams
+  preserves finite products.
+- `IsSiftedOfColimitPreservesFiniteProducts`: The converse: if the `Type`-valued colimit functor
+  preserves finite producs, the category is sifted.
+- `IsSiftedOfFinalFunctorFromSifted`: A category admitting a final functor from a sifted category is
+  itself sifted.
+- `IsSiftedOfIsFiltered`: A filtered category is sifted.
+- `IsSiftedOfHasBinaryCoproductsAndNonempty`: A nonempty category with binary copreducts is sifted.
+
+## References
+- [nLab, *Sifted category*](https://ncatlab.org/nlab/show/sifted+category)
+- [*Algebraic Theories*, Chapter 2.][Adámek_Rosický_Vitale_2010]
+-/
+
+universe w v v₁ u u₁
+
+namespace CategoryTheory
+
+open Limits Functor
+
+section
+
+variable (C : Type u) [Category.{v} C]
+
+/-- A category `C` `IsSiftedOrEmpty` if the diagonal functor `C ⥤ C × C` is final. -/
+abbrev IsSiftedOrEmpty : Prop := Final (diag C)
+
+/-- A category `C` `IsSfited` if
+1. the diagonal functor `C ⥤ C × C` is final.
+2. there exists some object. -/
+class IsSifted extends IsSiftedOrEmpty C : Prop where
+  [Nonempty : Nonempty C]
+
+attribute [instance] IsSifted.Nonempty
+
+namespace IsSifted
+
+variable {C}
+
+/-- Being sifted is preserved by equivalences of categories -/
+lemma IsSiftedOfEquiv [IsSifted C] {D : Type u₁} [Category.{v₁} D] (e : D ≌ C) : IsSifted D :=
+  letI : Final (diag D) := by
+    letI : D × D ≌ C × C:= Equivalence.prod e e
+    have sq : (e.inverse ⋙ diag D ⋙ this.functor ≅ diag C) :=
+        NatIso.ofComponents (fun c ↦ by dsimp [this]
+                                        exact Iso.prod (e.counitIso.app c) (e.counitIso.app c))
+    apply_rules [final_iff_comp_equivalence _ this.functor|>.mpr,
+      final_iff_final_comp e.inverse _ |>.mpr, final_of_natIso sq.symm]
+  letI : _root_.Nonempty D := ⟨e.inverse.obj (_root_.Nonempty.some IsSifted.Nonempty)⟩
+  ⟨⟩
+
+/-- In particular a category is sifted iff and only if it is so when viewed as a small category -/
+lemma IsSifted_iff_asSmallIsSifted : IsSifted C ↔ IsSifted (AsSmall.{w} C) where
+  mp _ := IsSiftedOfEquiv AsSmall.equiv.symm
+  mpr _ := IsSiftedOfEquiv AsSmall.equiv
+
+/-- A sifted category is connected. -/
+instance [IsSifted C]: IsConnected C :=
+  isConnected_of_zigzag
+    (by intro c₁ c₂
+        have X : StructuredArrow (c₁, c₂) (diag C) :=
+          letI S : Final (diag C) := by infer_instance
+          Nonempty.some (S.out (c₁, c₂)).is_nonempty
+        use [X.right, c₂]
+        constructor
+        · constructor
+          · exact Zag.of_hom X.hom.fst
+          · simp
+            exact Zag.of_inv X.hom.snd
+        · rfl)
+
+/-- A category with binary coproducts is sifted or empty. -/
+instance [HasBinaryCoproducts C] : IsSiftedOrEmpty C := by
+    constructor
+    rintro ⟨c₁, c₂⟩
+    haveI : _root_.Nonempty <| StructuredArrow (c₁,c₂) (diag C) :=
+      ⟨.mk ((coprod.inl : c₁ ⟶ c₁ ⨿ c₂), (coprod.inr : c₂ ⟶ c₁ ⨿ c₂))⟩
+    apply isConnected_of_zigzag
+    rintro ⟨_, c, f⟩ ⟨_, c', g⟩
+    dsimp only [const_obj_obj, diag_obj, prod_Hom] at f g
+    use [.mk ((coprod.inl : c₁ ⟶ c₁ ⨿ c₂), (coprod.inr : c₂ ⟶ c₁ ⨿ c₂)), .mk (g.fst, g.snd)]
+    simp only [colimit.cocone_x, diag_obj, Prod.mk.eta, List.chain_cons, List.Chain.nil, and_true,
+      ne_eq, reduceCtorEq, not_false_eq_true, List.getLast_cons, List.cons_ne_self,
+      List.getLast_singleton]
+    exact ⟨⟨Zag.of_inv <| StructuredArrow.homMk <| coprod.desc f.fst f.snd,
+      Zag.of_hom <| StructuredArrow.homMk <| coprod.desc g.fst g.snd⟩, rfl⟩
+
+/-- A nonempty category with binary coproducts is sifted. -/
+instance IsSiftedOfHasBinaryCoproductsAndNonempty [_root_.Nonempty C] [HasBinaryCoproducts C] :
+    IsSifted C where
+
+end IsSifted
+
+end
+
+end CategoryTheory

--- a/Mathlib/CategoryTheory/Limits/Sifted.lean
+++ b/Mathlib/CategoryTheory/Limits/Sifted.lean
@@ -8,7 +8,7 @@ import Mathlib.CategoryTheory.Limits.Final
 # Sifted categories
 
 A category `C` is sifted if `C` is nonempty and the diagonal functor `C ⥤ C × C` is final.
-Sifted categories can be caracterized as those such that the colimit functor `(C ⥤ Type) ⥤ Type `
+Sifted categories can be characterized as those such that the colimit functor `(C ⥤ Type) ⥤ Type `
 preserves finite products.
 
 ## Main results
@@ -37,7 +37,7 @@ abbrev IsSiftedOrEmpty : Prop := Final (diag C)
 1. the diagonal functor `C ⥤ C × C` is final.
 2. there exists some object. -/
 class IsSifted extends IsSiftedOrEmpty C : Prop where
-  [Nonempty : Nonempty C]
+  [nonempty : Nonempty C]
 
 attribute [instance] IsSifted.Nonempty
 
@@ -63,7 +63,7 @@ lemma isSifted_iff_asSmallIsSifted : IsSifted C ↔ IsSifted (AsSmall.{w} C) whe
   mpr _ := isSifted_of_equiv AsSmall.equiv
 
 /-- A sifted category is connected. -/
-instance [IsSifted C]: IsConnected C :=
+instance [IsSifted C] : IsConnected C :=
   isConnected_of_zigzag
     (by intro c₁ c₂
         have X : StructuredArrow (c₁, c₂) (diag C) :=

--- a/Mathlib/CategoryTheory/Limits/Sifted.lean
+++ b/Mathlib/CategoryTheory/Limits/Sifted.lean
@@ -39,7 +39,7 @@ abbrev IsSiftedOrEmpty : Prop := Final (diag C)
 class IsSifted extends IsSiftedOrEmpty C : Prop where
   [nonempty : Nonempty C]
 
-attribute [instance] IsSifted.Nonempty
+attribute [instance] IsSifted.nonempty
 
 namespace IsSifted
 
@@ -54,7 +54,7 @@ lemma isSifted_of_equiv [IsSifted C] {D : Type u₁} [Category.{v₁} D] (e : D 
                                         exact Iso.prod (e.counitIso.app c) (e.counitIso.app c))
     apply_rules [final_iff_comp_equivalence _ this.functor|>.mpr,
       final_iff_final_comp e.inverse _ |>.mpr, final_of_natIso sq.symm]
-  letI : _root_.Nonempty D := ⟨e.inverse.obj (_root_.Nonempty.some IsSifted.Nonempty)⟩
+  letI : _root_.Nonempty D := ⟨e.inverse.obj (_root_.Nonempty.some IsSifted.nonempty)⟩
   ⟨⟩
 
 /-- In particular a category is sifted iff and only if it is so when viewed as a small category -/

--- a/Mathlib/CategoryTheory/Limits/Sifted.lean
+++ b/Mathlib/CategoryTheory/Limits/Sifted.lean
@@ -7,20 +7,13 @@ import Mathlib.CategoryTheory.Limits.Final
 /-!
 # Sifted categories
 
-A category `C` is Sifted if `C` is nonempty and the diagonal functor `C ⥤ C × C` is final.
+A category `C` is sifted if `C` is nonempty and the diagonal functor `C ⥤ C × C` is final.
 Sifted categories can be caracterized as those such that the colimit functor `(C ⥤ Type) ⥤ Type `
-preserves finite products. We achieve this characterization in this file, as well as providing some
-API to produce `IsSifted` instances.
+preserves finite products.
 
 ## Main results
-- `colimPreservesFiniteProductsOfIsSifted`: The `Type`-valued colimit functor for sifted diagrams
-  preserves finite products.
-- `IsSiftedOfColimitPreservesFiniteProducts`: The converse: if the `Type`-valued colimit functor
-  preserves finite producs, the category is sifted.
-- `IsSiftedOfFinalFunctorFromSifted`: A category admitting a final functor from a sifted category is
-  itself sifted.
-- `IsSiftedOfIsFiltered`: A filtered category is sifted.
-- `IsSiftedOfHasBinaryCoproductsAndNonempty`: A nonempty category with binary copreducts is sifted.
+- `isSifted_of_hasBinaryCoproducts_and_nonempty`: A nonempty category with binary coproducts is
+  sifted.
 
 ## References
 - [nLab, *Sifted category*](https://ncatlab.org/nlab/show/sifted+category)
@@ -53,7 +46,7 @@ namespace IsSifted
 variable {C}
 
 /-- Being sifted is preserved by equivalences of categories -/
-lemma IsSiftedOfEquiv [IsSifted C] {D : Type u₁} [Category.{v₁} D] (e : D ≌ C) : IsSifted D :=
+lemma isSifted_of_equiv [IsSifted C] {D : Type u₁} [Category.{v₁} D] (e : D ≌ C) : IsSifted D :=
   letI : Final (diag D) := by
     letI : D × D ≌ C × C:= Equivalence.prod e e
     have sq : (e.inverse ⋙ diag D ⋙ this.functor ≅ diag C) :=
@@ -65,9 +58,9 @@ lemma IsSiftedOfEquiv [IsSifted C] {D : Type u₁} [Category.{v₁} D] (e : D �
   ⟨⟩
 
 /-- In particular a category is sifted iff and only if it is so when viewed as a small category -/
-lemma IsSifted_iff_asSmallIsSifted : IsSifted C ↔ IsSifted (AsSmall.{w} C) where
-  mp _ := IsSiftedOfEquiv AsSmall.equiv.symm
-  mpr _ := IsSiftedOfEquiv AsSmall.equiv
+lemma isSifted_iff_asSmallIsSifted : IsSifted C ↔ IsSifted (AsSmall.{w} C) where
+  mp _ := isSifted_of_equiv AsSmall.equiv.symm
+  mpr _ := isSifted_of_equiv AsSmall.equiv
 
 /-- A sifted category is connected. -/
 instance [IsSifted C]: IsConnected C :=
@@ -101,7 +94,7 @@ instance [HasBinaryCoproducts C] : IsSiftedOrEmpty C := by
       Zag.of_hom <| StructuredArrow.homMk <| coprod.desc g.fst g.snd⟩, rfl⟩
 
 /-- A nonempty category with binary coproducts is sifted. -/
-instance IsSiftedOfHasBinaryCoproductsAndNonempty [_root_.Nonempty C] [HasBinaryCoproducts C] :
+instance isSifted_of_hasBinaryCoproducts_and_nonempty [_root_.Nonempty C] [HasBinaryCoproducts C] :
     IsSifted C where
 
 end IsSifted

--- a/docs/references.bib
+++ b/docs/references.bib
@@ -34,6 +34,17 @@
   url           = {https://www.ioc.ee/~pawel/papers/adhesive.pdf}
 }
 
+@Book{            Adámek_Rosický_Vitale_2010,
+  place         = {Cambridge},
+  series        = {Cambridge Tracts in Mathematics},
+  title         = {Algebraic Theories: A Categorical Introduction to General
+                  Algebra},
+  publisher     = {Cambridge University Press},
+  author        = {Adámek, J. and Rosický, J. and Vitale, E. M.},
+  year          = {2010},
+  collection    = {Cambridge Tracts in Mathematics}
+}
+
 @Article{         ahrens2017,
   author        = {Benedikt Ahrens and Peter LeFanu Lumsdaine},
   year          = {2019},


### PR DESCRIPTION
Introduce the class of sifted categories. A category `IsSifted` if it is nonempty and the diagonal functor is a final functor.

- Show that sifted categories are stable under equivalences of categories.
- Show that a category is sifted if and only if a small model of it is sifted.
- Show that a sifted category is connected.
- Show that a category with binary coproducts is sifted.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

This is the first part of #17554, containing only the definition and easy first properties and independent from #17766.

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
