### PR TITLE
[Merged by Bors] - feat: add `Module.finrank_quotient_add_finrank_le`

### DIFF
--- a/Mathlib/LinearAlgebra/Dimension/Finite.lean
+++ b/Mathlib/LinearAlgebra/Dimension/Finite.lean
@@ -7,6 +7,7 @@ import Mathlib.Algebra.Module.Torsion
 import Mathlib.SetTheory.Cardinal.Cofinality
 import Mathlib.LinearAlgebra.FreeModule.Finite.Basic
 import Mathlib.LinearAlgebra.Dimension.StrongRankCondition
+import Mathlib.LinearAlgebra.Dimension.Constructions
 
 /-!
 # Conditions for rank to be finite
@@ -425,6 +426,17 @@ theorem Module.finrank_zero_iff [NoZeroSMulDivisors R M] :
     finrank R M = 0 ↔ Subsingleton M := by
   rw [← rank_zero_iff (R := R), ← finrank_eq_rank]
   norm_cast
+
+/-- Similar to `rank_quotient_add_rank_le` but for `finrank` and a finite `M`. -/
+lemma Module.finrank_add_finrank_quotient_le (N : Submodule R M) :
+    finrank R (M ⧸ N) + finrank R N ≤ finrank R M := by
+  by_cases h : Subsingleton R
+  · rw [finrank_zero_iff.2 (Module.subsingleton R _), finrank_zero_iff.2 (Module.subsingleton R _),
+      finrank_zero_iff.2 (Module.subsingleton R _)]
+  rw [not_subsingleton_iff_nontrivial] at h
+  have := rank_quotient_add_rank_le N
+  rw [← finrank_eq_rank R M, ← finrank_eq_rank R, ← N.finrank_eq_rank] at this
+  exact mod_cast this
 
 end StrongRankCondition
 

--- a/Mathlib/LinearAlgebra/Dimension/Finite.lean
+++ b/Mathlib/LinearAlgebra/Dimension/Finite.lean
@@ -430,10 +430,7 @@ theorem Module.finrank_zero_iff [NoZeroSMulDivisors R M] :
 /-- Similar to `rank_quotient_add_rank_le` but for `finrank` and a finite `M`. -/
 lemma Module.finrank_quotient_add_finrank_le (N : Submodule R M) :
     finrank R (M ⧸ N) + finrank R N ≤ finrank R M := by
-  by_cases h : Subsingleton R
-  · rw [finrank_zero_iff.2 (Module.subsingleton R _), finrank_zero_iff.2 (Module.subsingleton R _),
-      finrank_zero_iff.2 (Module.subsingleton R _)]
-  rw [not_subsingleton_iff_nontrivial] at h
+  haveI := nontrivial_of_invariantBasisNumber R
   have := rank_quotient_add_rank_le N
   rw [← finrank_eq_rank R M, ← finrank_eq_rank R, ← N.finrank_eq_rank] at this
   exact mod_cast this

--- a/Mathlib/LinearAlgebra/Dimension/Finite.lean
+++ b/Mathlib/LinearAlgebra/Dimension/Finite.lean
@@ -428,7 +428,7 @@ theorem Module.finrank_zero_iff [NoZeroSMulDivisors R M] :
   norm_cast
 
 /-- Similar to `rank_quotient_add_rank_le` but for `finrank` and a finite `M`. -/
-lemma Module.finrank_add_finrank_quotient_le (N : Submodule R M) :
+lemma Module.finrank_quotient_add_finrank_le (N : Submodule R M) :
     finrank R (M ⧸ N) + finrank R N ≤ finrank R M := by
   by_cases h : Subsingleton R
   · rw [finrank_zero_iff.2 (Module.subsingleton R _), finrank_zero_iff.2 (Module.subsingleton R _),

--- a/Mathlib/LinearAlgebra/Dimension/StrongRankCondition.lean
+++ b/Mathlib/LinearAlgebra/Dimension/StrongRankCondition.lean
@@ -443,6 +443,13 @@ noncomputable instance {R M : Type*} [DivisionRing R] [AddCommGroup M] [Module R
 theorem finrank_eq_rank [Module.Finite R M] : ↑(finrank R M) = Module.rank R M := by
   rw [Module.finrank, cast_toNat_of_lt_aleph0 (rank_lt_aleph0 R M)]
 
+/-- If `M` is finite, then `finrank N = rank N` for all `N : Submodule M`. Note that
+such an `N` can be not finitely generated. -/
+protected theorem _root_.Submodule.finrank_eq_rank [Module.Finite R M] (N : Submodule R M) :
+    finrank R N = Module.rank R N := by
+  rw [finrank, Cardinal.cast_toNat_of_lt_aleph0]
+  exact lt_of_le_of_lt (Submodule.rank_le N) (rank_lt_aleph0 R M)
+
 end Module
 
 open Module

--- a/Mathlib/LinearAlgebra/Dimension/StrongRankCondition.lean
+++ b/Mathlib/LinearAlgebra/Dimension/StrongRankCondition.lean
@@ -444,7 +444,7 @@ theorem finrank_eq_rank [Module.Finite R M] : ↑(finrank R M) = Module.rank R M
   rw [Module.finrank, cast_toNat_of_lt_aleph0 (rank_lt_aleph0 R M)]
 
 /-- If `M` is finite, then `finrank N = rank N` for all `N : Submodule M`. Note that
-such an `N` can be not finitely generated. -/
+such an `N` need not be finitely generated. -/
 protected theorem _root_.Submodule.finrank_eq_rank [Module.Finite R M] (N : Submodule R M) :
     finrank R N = Module.rank R N := by
   rw [finrank, Cardinal.cast_toNat_of_lt_aleph0]


### PR DESCRIPTION

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
