### PR TITLE
refactor(SetTheory/Ordinal/Arithmetic): deprecate `Ordinal.iSup_le`

### DIFF
--- a/Mathlib/SetTheory/Ordinal/Arithmetic.lean
+++ b/Mathlib/SetTheory/Ordinal/Arithmetic.lean
@@ -1198,7 +1198,7 @@ set_option linter.deprecated false in
 theorem sup_le_iff {ι : Type u} {f : ι → Ordinal.{max u v}} {a} : sup.{_, v} f ≤ a ↔ ∀ i, f i ≤ a :=
   Ordinal.iSup_le_iff
 
-/-- `ciSup_le'` whenever the input type is small in the output universe. -/
+@[deprecated ciSup_le' (since := "2024-10-15")]
 protected theorem iSup_le {ι} {f : ι → Ordinal.{u}} {a} :
     (∀ i, f i ≤ a) → iSup f ≤ a :=
   ciSup_le'
@@ -1234,7 +1234,7 @@ theorem ne_sup_iff_lt_sup {ι : Type u} {f : ι → Ordinal.{max u v}} :
 theorem succ_lt_iSup_of_ne_iSup {ι} {f : ι → Ordinal.{u}} [Small.{u} ι]
     (hf : ∀ i, f i ≠ iSup f) {a} (hao : a < iSup f) : succ a < iSup f := by
   by_contra! hoa
-  exact hao.not_le (Ordinal.iSup_le fun i => le_of_lt_succ <|
+  exact hao.not_le (ciSup_le' fun i => le_of_lt_succ <|
     (lt_of_le_of_ne (Ordinal.le_iSup _ _) (hf i)).trans_le hoa)
 
 set_option linter.deprecated false in
@@ -1250,7 +1250,7 @@ theorem iSup_eq_zero_iff {ι} {f : ι → Ordinal.{u}} [Small.{u} ι] :
     iSup f = 0 ↔ ∀ i, f i = 0 := by
   refine
     ⟨fun h i => ?_, fun h =>
-      le_antisymm (Ordinal.iSup_le fun i => Ordinal.le_zero.2 (h i)) (Ordinal.zero_le _)⟩
+      le_antisymm (ciSup_le' fun i => Ordinal.le_zero.2 (h i)) (Ordinal.zero_le _)⟩
   rw [← Ordinal.le_zero, ← h]
   exact Ordinal.le_iSup f i
 
@@ -1318,7 +1318,7 @@ theorem sup_eq_of_range_eq {ι : Type u} {ι' : Type v}
 -- TODO: generalize to conditionally complete lattices
 theorem iSup_sum {α β} (f : α ⊕ β → Ordinal.{u}) [Small.{u} α] [Small.{u} β]:
     iSup f = max (⨆ a, f (Sum.inl a)) (⨆ b, f (Sum.inr b)) := by
-  apply (Ordinal.iSup_le _).antisymm (max_le _ _)
+  refine (ciSup_le' ?_).antisymm (max_le ?_ ?_)
   · rintro (i | i)
     · exact le_max_of_le_left (Ordinal.le_iSup (fun x ↦ f (Sum.inl x)) i)
     · exact le_max_of_le_right (Ordinal.le_iSup (fun x ↦ f (Sum.inr x)) i)
@@ -1345,7 +1345,7 @@ theorem unbounded_range_of_le_iSup {α β : Type u} (r : α → α → Prop) [Is
     (h : type r ≤ ⨆ i, typein r (f i)) : Unbounded r (range f) :=
   (not_bounded_iff _).1 fun ⟨x, hx⟩ =>
     h.not_lt <| lt_of_le_of_lt
-      (Ordinal.iSup_le fun y => ((typein_lt_typein r).2 <| hx _ <| mem_range_self y).le)
+      (ciSup_le' fun y => ((typein_lt_typein r).2 <| hx _ <| mem_range_self y).le)
       (typein_lt_type r x)
 
 set_option linter.deprecated false in
@@ -2284,7 +2284,7 @@ alias omega_le := omega0_le
 
 @[simp]
 theorem iSup_natCast : iSup Nat.cast = ω :=
-  (Ordinal.iSup_le fun n => (nat_lt_omega0 n).le).antisymm <| omega0_le.2 <| Ordinal.le_iSup _
+  (ciSup_le' fun n => (nat_lt_omega0 n).le).antisymm <| omega0_le.2 <| Ordinal.le_iSup _
 
 set_option linter.deprecated false in
 @[deprecated iSup_natCast (since := "2024-04-17")]

--- a/Mathlib/SetTheory/Ordinal/Exponential.lean
+++ b/Mathlib/SetTheory/Ordinal/Exponential.lean
@@ -492,7 +492,7 @@ theorem iSup_pow {o : Ordinal} (ho : 0 < o) : ⨆ n : ℕ, o ^ n = o ^ ω := by
   rcases (one_le_iff_pos.2 ho).lt_or_eq with ho₁ | rfl
   · exact (isNormal_opow ho₁).apply_omega0
   · rw [one_opow]
-    refine le_antisymm (Ordinal.iSup_le fun n => by rw [one_opow]) ?_
+    refine le_antisymm (ciSup_le' fun n => by rw [one_opow]) ?_
     exact_mod_cast Ordinal.le_iSup _ 0
 
 set_option linter.deprecated false in

--- a/Mathlib/SetTheory/Ordinal/FixedPoint.lean
+++ b/Mathlib/SetTheory/Ordinal/FixedPoint.lean
@@ -69,13 +69,10 @@ theorem nfpFamily_le_iff {a b} : nfpFamily.{u, v} f a ≤ b ↔ ∀ l, List.fold
   Ordinal.iSup_le_iff
 
 theorem nfpFamily_le {a b} : (∀ l, List.foldr f a l ≤ b) → nfpFamily.{u, v} f a ≤ b :=
-  Ordinal.iSup_le
+  ciSup_le'
 
-theorem nfpFamily_monotone (hf : ∀ i, Monotone (f i)) : Monotone (nfpFamily.{u, v} f) := by
-  intro _ _ h
-  apply Ordinal.iSup_le
-  intro l
-  exact (List.foldr_monotone hf l h).trans (Ordinal.le_iSup _ l)
+theorem nfpFamily_monotone (hf : ∀ i, Monotone (f i)) : Monotone (nfpFamily.{u, v} f) :=
+  fun _ _ h ↦ ciSup_le' fun l ↦ (List.foldr_monotone hf l h).trans (Ordinal.le_iSup _ l)
 
 theorem apply_lt_nfpFamily (H : ∀ i, IsNormal (f i)) {a b} (hb : b < nfpFamily.{u, v} f a) (i) :
     f i b < nfpFamily.{u, v} f a :=
@@ -99,7 +96,7 @@ theorem nfpFamily_le_apply [Nonempty ι] (H : ∀ i, IsNormal (f i)) {a b} :
 
 theorem nfpFamily_le_fp (H : ∀ i, Monotone (f i)) {a b} (ab : a ≤ b) (h : ∀ i, f i b ≤ b) :
     nfpFamily.{u, v} f a ≤ b := by
-  apply Ordinal.iSup_le
+  apply ciSup_le'
   intro l
   induction' l with i l IH generalizing a
   · exact ab
@@ -108,7 +105,7 @@ theorem nfpFamily_le_fp (H : ∀ i, Monotone (f i)) {a b} (ab : a ≤ b) (h : �
 theorem nfpFamily_fp {i} (H : IsNormal (f i)) (a) :
     f i (nfpFamily.{u, v} f a) = nfpFamily.{u, v} f a := by
   rw [nfpFamily, H.map_iSup]
-  apply le_antisymm <;> refine Ordinal.iSup_le fun l => ?_
+  apply le_antisymm <;> refine ciSup_le' fun l => ?_
   · exact Ordinal.le_iSup _ (i::l)
   · exact H.le_apply.trans (Ordinal.le_iSup _ _)
 
@@ -122,8 +119,7 @@ theorem apply_le_nfpFamily [hι : Nonempty ι] {f : ι → Ordinal → Ordinal} 
 
 theorem nfpFamily_eq_self {f : ι → Ordinal → Ordinal} {a} (h : ∀ i, f i a = a) :
     nfpFamily f a = a := by
-  apply (Ordinal.iSup_le ?_).antisymm (le_nfpFamily f a)
-  intro l
+  refine (ciSup_le' fun l ↦ ?_).antisymm (le_nfpFamily f a)
   rw [List.foldr_fixed' h l]
 
 -- Todo: This is actually a special case of the fact the intersection of club sets is a club set.
@@ -265,7 +261,7 @@ theorem nfpBFamily_le_iff {o : Ordinal} {f : ∀ b < o, Ordinal → Ordinal} {a 
 
 theorem nfpBFamily_le {o : Ordinal} {f : ∀ b < o, Ordinal → Ordinal} {a b} :
     (∀ l, List.foldr (familyOfBFamily o f) a l ≤ b) → nfpBFamily.{u, v} o f a ≤ b :=
-  Ordinal.iSup_le
+  ciSup_le'
 
 theorem nfpBFamily_monotone (hf : ∀ i hi, Monotone (f i hi)) : Monotone (nfpBFamily.{u, v} o f) :=
   nfpFamily_monotone fun _ => hf _ _
@@ -403,7 +399,7 @@ theorem iSup_iterate_eq_nfp (f : Ordinal.{u} → Ordinal.{u}) (a : Ordinal.{u}) 
     intro n
     rw [← List.length_replicate n Unit.unit, ← List.foldr_const f a]
     exact Ordinal.le_iSup _ _
-  · apply Ordinal.iSup_le
+  · apply ciSup_le'
     intro l
     rw [List.foldr_const f a l]
     exact Ordinal.le_iSup _ _
@@ -531,8 +527,7 @@ theorem deriv_eq_id_of_nfp_eq_id {f : Ordinal → Ordinal} (h : nfp f = id) : de
 
 theorem nfp_zero_left (a) : nfp 0 a = a := by
   rw [← iSup_iterate_eq_nfp]
-  apply (Ordinal.iSup_le ?_).antisymm (Ordinal.le_iSup _ 0)
-  intro n
+  refine (ciSup_le' fun n ↦ ?_).antisymm (Ordinal.le_iSup _ 0)
   induction' n with n _
   · rfl
   · rw [Function.iterate_succ']

--- a/Mathlib/SetTheory/ZFC/Rank.lean
+++ b/Mathlib/SetTheory/ZFC/Rank.lean
@@ -114,7 +114,7 @@ theorem rank_eq_wfRank : lift.{u + 1, u} (rank x) = mem_wf.rank x := by
   induction' x using mem_wf.induction with x ih
   rw [mem_wf.rank_eq]
   simp_rw [← fun y : { y // y ∈ x } => ih y y.2]
-  apply (le_of_forall_lt _).antisymm (ciSup_le' _) <;> intro h
+  refine (le_of_forall_lt ?_).antisymm (ciSup_le' ?_) <;> intro h
   · rw [lt_lift_iff]
     rintro ⟨o, rfl, h⟩
     simpa [Ordinal.lt_iSup] using lt_rank_iff.1 h
@@ -200,7 +200,7 @@ theorem rank_eq_wfRank : lift.{u + 1, u} (rank x) = mem_wf.rank x := by
   induction' x using inductionOn with x ih
   rw [mem_wf.rank_eq]
   simp_rw [← fun y : { y // y ∈ x } => ih y y.2]
-  apply (le_of_forall_lt _).antisymm (ciSup_le' _) <;> intro h
+  refine (le_of_forall_lt ?_).antisymm (ciSup_le' ?_) <;> intro h
   · rw [lt_lift_iff]
     rintro ⟨o, rfl, h⟩
     simpa [Ordinal.lt_iSup] using lt_rank_iff.1 h

--- a/Mathlib/SetTheory/ZFC/Rank.lean
+++ b/Mathlib/SetTheory/ZFC/Rank.lean
@@ -114,7 +114,7 @@ theorem rank_eq_wfRank : lift.{u + 1, u} (rank x) = mem_wf.rank x := by
   induction' x using mem_wf.induction with x ih
   rw [mem_wf.rank_eq]
   simp_rw [← fun y : { y // y ∈ x } => ih y y.2]
-  apply (le_of_forall_lt _).antisymm (Ordinal.iSup_le _) <;> intro h
+  apply (le_of_forall_lt _).antisymm (ciSup_le' _) <;> intro h
   · rw [lt_lift_iff]
     rintro ⟨o, rfl, h⟩
     simpa [Ordinal.lt_iSup] using lt_rank_iff.1 h
@@ -200,7 +200,7 @@ theorem rank_eq_wfRank : lift.{u + 1, u} (rank x) = mem_wf.rank x := by
   induction' x using inductionOn with x ih
   rw [mem_wf.rank_eq]
   simp_rw [← fun y : { y // y ∈ x } => ih y y.2]
-  apply (le_of_forall_lt _).antisymm (Ordinal.iSup_le _) <;> intro h
+  apply (le_of_forall_lt _).antisymm (ciSup_le' _) <;> intro h
   · rw [lt_lift_iff]
     rintro ⟨o, rfl, h⟩
     simpa [Ordinal.lt_iSup] using lt_rank_iff.1 h


### PR DESCRIPTION
Unlike the other basic `iSup` theorems in the `Ordinal` namespace, this one doesn't require any `Small` assumptions, so it's completely equivalent to `ciSup_le'`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

There's the argument to be made that having this lemma is good for discoverability. That being said, I think this deprecation is a good move towards bringing the ordinal supremum API closer to the general supermum API.

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
