### PR TITLE
[Merged by Bors] - chore(CategoryTheory/Sites): add some tests for preserving sheafification

### DIFF
--- a/test/CategoryTheory/Sites/PreservesSheafification.lean
+++ b/test/CategoryTheory/Sites/PreservesSheafification.lean
@@ -1,0 +1,30 @@
+import Mathlib.Algebra.Category.ModuleCat.Colimits
+import Mathlib.Algebra.Category.ModuleCat.Limits
+import Mathlib.Algebra.Category.ModuleCat.FilteredColimits
+import Mathlib.CategoryTheory.Sites.Equivalence
+
+universe u
+
+open CategoryTheory GrothendieckTopology
+
+section Small
+
+variable {C : Type u} [SmallCategory C] (J : GrothendieckTopology C) (R : Type u) [Ring R]
+
+example : PreservesSheafification J (forget (ModuleCat.{u} R)) := inferInstance
+
+end Small
+
+section Large
+
+variable {C : Type (u+1)} [LargeCategory C] (J : GrothendieckTopology C)
+
+example (R : Type (u+1)) [Ring R] : PreservesSheafification J (forget (ModuleCat.{u+1} R)) :=
+  inferInstance
+
+variable [EssentiallySmall.{u} C]
+
+example (R : Type u) [Ring R] : PreservesSheafification J (forget (ModuleCat.{u} R)) :=
+  inferInstance
+
+end Large


### PR DESCRIPTION
This PR adds a few tests to make sure that there are `PreservesSheafification` instances for the forgetful functor from modules to sets, for different size restrictions on the defining site.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
