### PR TITLE
[Merged by Bors] - feat: the pi sigma-algebra is generated by projections

### DIFF
--- a/Mathlib/MeasureTheory/Constructions/Pi.lean
+++ b/Mathlib/MeasureTheory/Constructions/Pi.lean
@@ -62,6 +62,18 @@ variable {ι ι' : Type*} {α : ι → Type*}
 
 /-! We start with some measurability properties -/
 
+lemma MeasurableSpace.pi_eq_generateFrom_projections {mα : ∀ i, MeasurableSpace (α i)} :
+    pi = generateFrom {B | ∃ (i : ι) (A : Set (α i)), MeasurableSet A ∧ eval i ⁻¹' A = B} := by
+  refine le_antisymm ?_ <| generateFrom_mono ?_
+  · refine generateFrom_le ?_
+    simp only [sSup_eq_sUnion, sUnion_image, mem_range, iUnion_exists, iUnion_iUnion_eq',
+      mem_iUnion, mem_setOf_eq, exists_prop, forall_exists_index]
+    rintro _ i ⟨A, hA, rfl⟩
+    exact measurableSet_generateFrom ⟨i, A, hA, rfl⟩
+  · rintro _ ⟨i, A, hA, rfl⟩
+    simp only [sSup_eq_sUnion, sUnion_image, mem_range, iUnion_exists, iUnion_iUnion_eq',
+      mem_iUnion, mem_setOf_eq]
+    exact ⟨i, A, hA, rfl⟩
 
 /-- Boxes formed by π-systems form a π-system. -/
 theorem IsPiSystem.pi {C : ∀ i, Set (Set (α i))} (hC : ∀ i, IsPiSystem (C i)) :

--- a/Mathlib/MeasureTheory/Constructions/Pi.lean
+++ b/Mathlib/MeasureTheory/Constructions/Pi.lean
@@ -64,16 +64,7 @@ variable {ι ι' : Type*} {α : ι → Type*}
 
 lemma MeasurableSpace.pi_eq_generateFrom_projections {mα : ∀ i, MeasurableSpace (α i)} :
     pi = generateFrom {B | ∃ (i : ι) (A : Set (α i)), MeasurableSet A ∧ eval i ⁻¹' A = B} := by
-  refine le_antisymm ?_ <| generateFrom_mono ?_
-  · refine generateFrom_le ?_
-    simp only [sSup_eq_sUnion, sUnion_image, mem_range, iUnion_exists, iUnion_iUnion_eq',
-      mem_iUnion, mem_setOf_eq, exists_prop, forall_exists_index]
-    rintro _ i ⟨A, hA, rfl⟩
-    exact measurableSet_generateFrom ⟨i, A, hA, rfl⟩
-  · rintro _ ⟨i, A, hA, rfl⟩
-    simp only [sSup_eq_sUnion, sUnion_image, mem_range, iUnion_exists, iUnion_iUnion_eq',
-      mem_iUnion, mem_setOf_eq]
-    exact ⟨i, A, hA, rfl⟩
+  simp only [pi, ← generateFrom_iUnion_measurableSet, iUnion_setOf, measurableSet_comap]
 
 /-- Boxes formed by π-systems form a π-system. -/
 theorem IsPiSystem.pi {C : ∀ i, Set (Set (α i))} (hC : ∀ i, IsPiSystem (C i)) :

--- a/Mathlib/MeasureTheory/MeasurableSpace/Basic.lean
+++ b/Mathlib/MeasureTheory/MeasurableSpace/Basic.lean
@@ -90,6 +90,9 @@ protected def comap (f : α → β) (m : MeasurableSpace β) : MeasurableSpace �
     let ⟨s', hs'⟩ := Classical.axiom_of_choice hs
     ⟨⋃ i, s' i, m.measurableSet_iUnion _ fun i => (hs' i).left, by simp [hs']⟩
 
+lemma measurableSet_comap {m : MeasurableSpace β} :
+    MeasurableSet[m.comap f] s ↔ ∃ s', MeasurableSet[m] s' ∧ f ⁻¹' s' = s := .rfl
+
 theorem comap_eq_generateFrom (m : MeasurableSpace β) (f : α → β) :
     m.comap f = generateFrom { t | ∃ s, MeasurableSet s ∧ f ⁻¹' s = t } :=
   (@generateFrom_measurableSet _ (.comap f m)).symm


### PR DESCRIPTION
This is basically the definition, but it's not quite immediate.

From GibbsMeasure


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
