### PR TITLE
[Merged by Bors] - feat: sigma-algebra of cylinder events

### DIFF
--- a/Mathlib/MeasureTheory/Constructions/Cylinders.lean
+++ b/Mathlib/MeasureTheory/Constructions/Cylinders.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2023 Rémy Degenne. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Rémy Degenne, Peter Pfaffelhuber
+Authors: Rémy Degenne, Peter Pfaffelhuber, Yaël Dillies, Kin Yau James Wong
 -/
 import Mathlib.MeasureTheory.PiSystem
 import Mathlib.Order.OmegaCompletePartialOrder
@@ -29,6 +29,8 @@ a product set.
   all `i` in the finset defining the box, the projection to `α i` belongs to `C i`. The main
   application of this is with `C i = {s : Set (α i) | MeasurableSet s}`.
 * `measurableCylinders`: set of all cylinders with measurable base sets.
+* `cylinderEvents Δ`: The σ-algebra of cylinder events on `Δ`. It is the smallest σ-algebra making
+  the projections on the `i`-th coordinate continuous for all `i ∈ Δ`.
 
 ## Main statements
 
@@ -39,7 +41,7 @@ a product set.
 
 -/
 
-open Set
+open Function Set
 
 namespace MeasureTheory
 
@@ -361,4 +363,79 @@ theorem generateFrom_measurableCylinders :
 
 end cylinders
 
+/-! ### Cylinder events as a sigma-algebra -/
+
+section cylinderEvents
+
+variable {α ι : Type*} {π : ι → Type*} {mα : MeasurableSpace α} [m : ∀ i, MeasurableSpace (π i)]
+  {Δ Δ₁ Δ₂ : Set ι} {i : ι}
+
+/-- The σ-algebra of cylinder events on `Δ`. It is the smallest σ-algebra making the projections
+on the `i`-th coordinate continuous for all `i ∈ Δ`. -/
+def cylinderEvents (Δ : Set ι) : MeasurableSpace (∀ i, π i) := ⨆ i ∈ Δ, (m i).comap fun σ ↦ σ i
+
+@[simp] lemma cylinderEvents_univ : cylinderEvents (π := π) univ = MeasurableSpace.pi := by
+  simp [cylinderEvents, MeasurableSpace.pi]
+
+@[gcongr]
+lemma cylinderEvents_mono (h : Δ₁ ⊆ Δ₂) : cylinderEvents (π := π) Δ₁ ≤ cylinderEvents Δ₂ :=
+  biSup_mono h
+
+lemma cylinderEvents_le_pi : cylinderEvents (π := π) Δ ≤ MeasurableSpace.pi := by
+  simpa using cylinderEvents_mono (subset_univ _)
+
+lemma measurable_cylinderEvents_iff {g : α → ∀ i, π i} :
+    @Measurable _ _ _ (cylinderEvents Δ) g ↔ ∀ ⦃i⦄, i ∈ Δ → Measurable fun a ↦ g a i := by
+  simp_rw [measurable_iff_comap_le, cylinderEvents, MeasurableSpace.comap_iSup,
+    MeasurableSpace.comap_comp, Function.comp_def, iSup_le_iff]
+
+@[fun_prop, aesop safe 100 apply (rule_sets := [Measurable])]
+lemma measurable_cylinderEvent_apply (hi : i ∈ Δ) :
+    Measurable[cylinderEvents Δ] fun f : ∀ i, π i => f i :=
+  measurable_cylinderEvents_iff.1 measurable_id hi
+
+@[aesop safe 100 apply (rule_sets := [Measurable])]
+lemma Measurable.eval_cylinderEvents {g : α → ∀ i, π i} (hi : i ∈ Δ)
+    (hg : @Measurable _ _ _ (cylinderEvents Δ) g) : Measurable fun a ↦ g a i :=
+  (measurable_cylinderEvent_apply hi).comp hg
+
+@[fun_prop, aesop safe 100 apply (rule_sets := [Measurable])]
+lemma measurable_cylinderEvents_lambda (f : α → ∀ i, π i) (hf : ∀ i, Measurable fun a ↦ f a i) :
+    Measurable f :=
+  measurable_pi_iff.mpr hf
+
+/-- The function `(f, x) ↦ update f a x : (Π a, π a) × π a → Π a, π a` is measurable. -/
+lemma measurable_update_cylinderEvents' [DecidableEq ι] :
+    @Measurable _ _ (.prod (cylinderEvents Δ) (m i)) (cylinderEvents Δ)
+      (fun p : (∀ i, π i) × π i ↦ update p.1 i p.2) := by
+  rw [measurable_cylinderEvents_iff]
+  intro j hj
+  dsimp [update]
+  split_ifs with h
+  · subst h
+    dsimp
+    exact measurable_snd
+  · exact measurable_cylinderEvents_iff.1 measurable_fst hj
+
+lemma measurable_uniqueElim_cylinderEvents [Unique ι] :
+    Measurable (uniqueElim : π (default : ι) → ∀ i, π i) := by
+  simp_rw [measurable_pi_iff, Unique.forall_iff, uniqueElim_default]; exact measurable_id
+
+/-- The function `update f a : π a → Π a, π a` is always measurable.
+This doesn't require `f` to be measurable.
+This should not be confused with the statement that `update f a x` is measurable. -/
+@[measurability]
+lemma measurable_update_cylinderEvents (f : ∀ a : ι, π a) {a : ι} [DecidableEq ι] :
+    @Measurable _ _ _ (cylinderEvents Δ) (update f a) :=
+  measurable_update_cylinderEvents'.comp measurable_prod_mk_left
+
+lemma measurable_update_cylinderEvents_left {a : ι} [DecidableEq ι] {x : π a} :
+    @Measurable _ _ (cylinderEvents Δ) (cylinderEvents Δ) (update · a x) :=
+  measurable_update_cylinderEvents'.comp measurable_prod_mk_right
+
+lemma measurable_restrict_cylinderEvents (Δ : Set ι) :
+    Measurable[cylinderEvents (π := π) Δ] (restrict Δ) := by
+  rw [@measurable_pi_iff]; exact fun i ↦ measurable_cylinderEvent_apply i.2
+
+end cylinderEvents
 end MeasureTheory


### PR DESCRIPTION
From GibbsMeasure

Co-authored-by: Kin Yau James Wong


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
