### PR TITLE
[Merged by Bors] - feat: induction principle for `ENNReal`-valued measurable functions from a sigma-finite space

### DIFF
--- a/Mathlib/MeasureTheory/Function/SimpleFunc.lean
+++ b/Mathlib/MeasureTheory/Function/SimpleFunc.lean
@@ -1236,8 +1236,8 @@ lemma Measurable.ennreal_sigmaFinite_induction [SigmaFinite μ] {P : (α → ℝ
     ⦃f : α → ℝ≥0∞⦄ (hf : Measurable f) : P f := by
   refine Measurable.ennreal_induction (fun c s hs ↦ ?_) h_add h_iSup hf
   convert h_iSup (f := fun n ↦ (s ∩ spanningSets μ n).indicator fun _ ↦ c)
-    (fun n ↦ measurable_const.indicator (hs.inter (measurable_spanningSets ..)))
+    (fun n ↦ measurable_const.indicator (hs.inter (measurableSet_spanningSets ..)))
     (fun m n hmn a ↦ Set.indicator_le_indicator_of_subset (by gcongr) (by simp) _)
-    (fun n ↦ h_ind _ (hs.inter (measurable_spanningSets ..))
+    (fun n ↦ h_ind _ (hs.inter (measurableSet_spanningSets ..))
       (measure_inter_lt_top_of_right_ne_top (measure_spanningSets_lt_top ..).ne)) with a
   simp [← Set.indicator_iUnion_apply (M := ℝ≥0∞) rfl, ← Set.inter_iUnion]

--- a/Mathlib/MeasureTheory/Function/SimpleFunc.lean
+++ b/Mathlib/MeasureTheory/Function/SimpleFunc.lean
@@ -800,37 +800,6 @@ theorem tsum_eapproxDiff (f : α → ℝ≥0∞) (hf : Measurable f) (a : α) :
 
 end EApprox
 
-section eapproxSigmaFinite
-variable {μ : Measure α} [SigmaFinite μ] {f : α → ℝ≥0∞} {n : ℕ} {a : α}
-
-variable (μ) in
-/-- Approximate a function `f : α → ℝ≥0∞` by a sequence of simple functions of finite support, where
-`α` is equipped with a σ-finite measure `μ`. -/
-noncomputable def eapproxSigmaFinite (f : α → ℝ≥0∞) (n : ℕ) : α →ₛ ℝ≥0∞ :=
-  (eapprox f n).piecewise (spanningSets μ n) (measurable_spanningSets ..) 0
-
-lemma eapproxSigmaFinite_le_eapprox : eapproxSigmaFinite μ f n ≤ eapprox f n :=
-  fun a ↦ by by_cases ha : a ∈ spanningSets μ n <;> simp [eapproxSigmaFinite, *]
-
-lemma eapproxSigmaFinite_lt_top : eapproxSigmaFinite μ f n a < ∞ :=
-  (eapproxSigmaFinite_le_eapprox _).trans_lt (eapprox_lt_top ..)
-
-@[mono]
-lemma monotone_eapproxSigmaFinite (f : α → ℝ≥0∞) : Monotone (eapproxSigmaFinite μ f) := by
-  rintro m n hmn
-  unfold eapproxSigmaFinite SimpleFunc.piecewise
-  simp only [coe_zero, piecewise_eq_indicator, mk_le_mk]
-  exact (indicator_mono (by gcongr)).trans (indicator_le_indicator_of_subset (by gcongr) (by simp))
-
-lemma iSup_coe_eapproxSigmaFinite (hf : Measurable f) : ⨆ n, ⇑(eapproxSigmaFinite μ f n) = f := by
-  simp [eapproxSigmaFinite, coe_piecewise, coe_zero, piecewise_eq_indicator,  iSup_coe_eapprox hf,
-    iSup_indicator ENNReal.bot_eq_zero (monotone_eapprox _) (monotone_spanningSets _)]
-
-lemma iSup_eapproxSigmaFinite_apply (hf : Measurable f) (a : α) :
-    ⨆ n, eapproxSigmaFinite μ f n a = f a := by
-  simpa using congr_fun (iSup_coe_eapproxSigmaFinite hf) a
-
-end eapproxSigmaFinite
 end Measurable
 
 section Measure

--- a/Mathlib/MeasureTheory/Function/SimpleFunc.lean
+++ b/Mathlib/MeasureTheory/Function/SimpleFunc.lean
@@ -1226,7 +1226,7 @@ a simple function with a multiple of a characteristic function and that the inte
 of their images is a subset of `{0}`. -/
 @[elab_as_elim]
 lemma Measurable.ennreal_sigmaFinite_induction [SigmaFinite μ] {P : (α → ℝ≥0∞) → Prop}
-    (h_ind : ∀ (c : ℝ≥0∞) ⦃s⦄, MeasurableSet s → μ s < ∞ → P (Set.indicator s fun _ => c))
+    (h_ind : ∀ (c : ℝ≥0∞) ⦃s⦄, MeasurableSet s → μ s < ∞ → P (Set.indicator s fun _ ↦ c))
     (h_add :
       ∀ ⦃f g : α → ℝ≥0∞⦄,
         Disjoint (support f) (support g) → Measurable f → Measurable g → P f → P g → P (f + g))

--- a/Mathlib/MeasureTheory/Function/SimpleFunc.lean
+++ b/Mathlib/MeasureTheory/Function/SimpleFunc.lean
@@ -399,10 +399,6 @@ theorem coe_div [Div β] (f g : α →ₛ β) : ⇑(f / g) = ⇑f / ⇑g :=
   rfl
 
 @[simp, norm_cast]
-theorem coe_le [Preorder β] {f g : α →ₛ β} : (f : α → β) ≤ g ↔ f ≤ g :=
-  Iff.rfl
-
-@[simp, norm_cast]
 theorem coe_sup [Sup β] (f g : α →ₛ β) : ⇑(f ⊔ g) = ⇑f ⊔ ⇑g :=
   rfl
 
@@ -545,10 +541,27 @@ instance instModule [Semiring K] [AddCommMonoid β] [Module K β] : Module K (α
 theorem smul_eq_map [SMul K β] (k : K) (f : α →ₛ β) : k • f = f.map (k • ·) :=
   rfl
 
-instance instPreorder [Preorder β] : Preorder (α →ₛ β) :=
-  { SimpleFunc.instLE with
-    le_refl := fun _ _ => le_rfl
-    le_trans := fun _ _ _ hfg hgh a => le_trans (hfg _) (hgh a) }
+section Preorder
+variable [Preorder β] {s : Set α} {f f₁ f₂ g g₁ g₂ : α →ₛ β} {hs : MeasurableSet s}
+
+instance instPreorder : Preorder (α →ₛ β) := Preorder.lift (⇑)
+
+@[simp, norm_cast] lemma coe_le_coe : ⇑f ≤ g ↔ f ≤ g := .rfl
+@[simp, norm_cast] lemma coe_lt_coe : ⇑f < g ↔ f < g := .rfl
+
+@[simp] lemma mk_le_mk {f g : α → β} {hf hg hf' hg'} : mk f hf hf' ≤ mk g hg hg' ↔ f ≤ g := Iff.rfl
+@[simp] lemma mk_lt_mk {f g : α → β} {hf hg hf' hg'} : mk f hf hf' < mk g hg hg' ↔ f < g := Iff.rfl
+
+@[gcongr] protected alias ⟨_, GCongr.mk_le_mk⟩ := mk_le_mk
+@[gcongr] protected alias ⟨_, GCongr.mk_lt_mk⟩ := mk_lt_mk
+@[gcongr] protected alias ⟨_, GCongr.coe_le_coe⟩ := coe_le_coe
+@[gcongr] protected alias ⟨_, GCongr.coe_lt_coe⟩ := coe_lt_coe
+
+@[gcongr]
+lemma piecewise_mono (hf : ∀ a ∈ s, f₁ a ≤ f₂ a) (hg : ∀ a ∉ s, g₁ a ≤ g₂ a) :
+    piecewise s hs f₁ g₁ ≤ piecewise s hs f₂ g₂ := Set.piecewise_mono hf hg
+
+end Preorder
 
 instance instPartialOrder [PartialOrder β] : PartialOrder (α →ₛ β) :=
   { SimpleFunc.instPreorder with
@@ -709,6 +722,7 @@ theorem iSup_approx_apply [TopologicalSpace β] [CompleteLattice β] [OrderClose
 end Approx
 
 section EApprox
+variable {f : α → ℝ≥0∞}
 
 /-- A sequence of `ℝ≥0∞`s such that its range is the set of non-negative rational numbers. -/
 def ennrealRatEmbed (n : ℕ) : ℝ≥0∞ :=
@@ -739,8 +753,10 @@ theorem eapprox_lt_top (f : α → ℝ≥0∞) (n : ℕ) (a : α) : eapprox f n 
 theorem monotone_eapprox (f : α → ℝ≥0∞) : Monotone (eapprox f) :=
   monotone_approx _ f
 
-theorem iSup_eapprox_apply (f : α → ℝ≥0∞) (hf : Measurable f) (a : α) :
-    ⨆ n, (eapprox f n : α →ₛ ℝ≥0∞) a = f a := by
+@[gcongr]
+lemma eapprox_mono {m n : ℕ} (hmn : m ≤ n) : eapprox f m ≤ eapprox f n := monotone_eapprox _ hmn
+
+lemma iSup_eapprox_apply (hf : Measurable f) (a : α) : ⨆ n, (eapprox f n : α →ₛ ℝ≥0∞) a = f a := by
   rw [eapprox, iSup_approx_apply ennrealRatEmbed f a hf rfl]
   refine le_antisymm (iSup_le fun i => iSup_le fun hi => hi) (le_of_not_gt ?_)
   intro h
@@ -751,6 +767,9 @@ theorem iSup_eapprox_apply (f : α → ℝ≥0∞) (hf : Measurable f) (a : α) 
     rw [ennrealRatEmbed_encode q]
     exact le_iSup_of_le (le_of_lt q_lt) le_rfl
   exact lt_irrefl _ (lt_of_le_of_lt this lt_q)
+
+lemma iSup_coe_eapprox (hf : Measurable f) : ⨆ n, ⇑(eapprox f n) = f := by
+  simpa [funext_iff] using iSup_eapprox_apply hf
 
 theorem eapprox_comp [MeasurableSpace γ] {f : γ → ℝ≥0∞} {g : α → γ} {n : ℕ} (hf : Measurable f)
     (hg : Measurable g) : (eapprox (f ∘ g) n : α → ℝ≥0∞) = (eapprox f n : γ →ₛ ℝ≥0∞) ∘ g :=
@@ -777,10 +796,41 @@ theorem sum_eapproxDiff (f : α → ℝ≥0∞) (n : ℕ) (a : α) :
 theorem tsum_eapproxDiff (f : α → ℝ≥0∞) (hf : Measurable f) (a : α) :
     (∑' n, (eapproxDiff f n a : ℝ≥0∞)) = f a := by
   simp_rw [ENNReal.tsum_eq_iSup_nat' (tendsto_add_atTop_nat 1), sum_eapproxDiff,
-    iSup_eapprox_apply f hf a]
+    iSup_eapprox_apply hf a]
 
 end EApprox
 
+section eapproxSigmaFinite
+variable {μ : Measure α} [SigmaFinite μ] {f : α → ℝ≥0∞} {n : ℕ} {a : α}
+
+variable (μ) in
+/-- Approximate a function `f : α → ℝ≥0∞` by a sequence of simple functions of finite support, where
+`α` is equipped with a σ-finite measure `μ`. -/
+noncomputable def eapproxSigmaFinite (f : α → ℝ≥0∞) (n : ℕ) : α →ₛ ℝ≥0∞ :=
+  (eapprox f n).piecewise (spanningSets μ n) (measurable_spanningSets ..) 0
+
+lemma eapproxSigmaFinite_le_eapprox : eapproxSigmaFinite μ f n ≤ eapprox f n :=
+  fun a ↦ by by_cases ha : a ∈ spanningSets μ n <;> simp [eapproxSigmaFinite, *]
+
+lemma eapproxSigmaFinite_lt_top : eapproxSigmaFinite μ f n a < ∞ :=
+  (eapproxSigmaFinite_le_eapprox _).trans_lt (eapprox_lt_top ..)
+
+@[mono]
+lemma monotone_eapproxSigmaFinite (f : α → ℝ≥0∞) : Monotone (eapproxSigmaFinite μ f) := by
+  rintro m n hmn
+  unfold eapproxSigmaFinite SimpleFunc.piecewise
+  simp only [coe_zero, piecewise_eq_indicator, mk_le_mk]
+  exact (indicator_mono (by gcongr)).trans (indicator_le_indicator_of_subset (by gcongr) (by simp))
+
+lemma iSup_coe_eapproxSigmaFinite (hf : Measurable f) : ⨆ n, ⇑(eapproxSigmaFinite μ f n) = f := by
+  simp [eapproxSigmaFinite, coe_piecewise, coe_zero, piecewise_eq_indicator,  iSup_coe_eapprox hf,
+    iSup_indicator ENNReal.bot_eq_zero (monotone_eapprox _) (monotone_spanningSets _)]
+
+lemma iSup_eapproxSigmaFinite_apply (hf : Measurable f) (a : α) :
+    ⨆ n, eapproxSigmaFinite μ f n a = f a := by
+  simpa using congr_fun (iSup_coe_eapproxSigmaFinite hf) a
+
+end eapproxSigmaFinite
 end Measurable
 
 section Measure
@@ -1170,6 +1220,8 @@ end MeasureTheory
 
 open MeasureTheory MeasureTheory.SimpleFunc
 
+variable {α : Type*} {mα : MeasurableSpace α} {μ : Measure α}
+
 /-- To prove something for an arbitrary measurable function into `ℝ≥0∞`, it suffices to show
 that the property holds for (multiples of) characteristic functions and is closed under addition
 and supremum of increasing sequences of functions.
@@ -1179,7 +1231,7 @@ can be added once we need them (for example in `h_add` it is only necessary to c
 a simple function with a multiple of a characteristic function and that the intersection
 of their images is a subset of `{0}`. -/
 @[elab_as_elim]
-theorem Measurable.ennreal_induction {α} [MeasurableSpace α] {P : (α → ℝ≥0∞) → Prop}
+theorem Measurable.ennreal_induction {P : (α → ℝ≥0∞) → Prop}
     (h_ind : ∀ (c : ℝ≥0∞) ⦃s⦄, MeasurableSet s → P (Set.indicator s fun _ => c))
     (h_add :
       ∀ ⦃f g : α → ℝ≥0∞⦄,
@@ -1188,9 +1240,35 @@ theorem Measurable.ennreal_induction {α} [MeasurableSpace α] {P : (α → ℝ�
       ∀ ⦃f : ℕ → α → ℝ≥0∞⦄, (∀ n, Measurable (f n)) → Monotone f → (∀ n, P (f n)) →
         P fun x => ⨆ n, f n x)
     ⦃f : α → ℝ≥0∞⦄ (hf : Measurable f) : P f := by
-  convert h_iSup (fun n => (eapprox f n).measurable) (monotone_eapprox f) _ using 1
-  · ext1 x
-    rw [iSup_eapprox_apply f hf]
+  convert h_iSup (fun n => (eapprox f n).measurable) (monotone_eapprox f) _ using 2
+  · rw [iSup_eapprox_apply hf]
   · exact fun n =>
       SimpleFunc.induction (fun c s hs => h_ind c hs)
         (fun f g hfg hf hg => h_add hfg f.measurable g.measurable hf hg) (eapprox f n)
+
+/-- To prove something for an arbitrary measurable function into `ℝ≥0∞`, it suffices to show
+that the property holds for (multiples of) characteristic functions with finite mass according to
+some sigma-finite measure and is closed under addition and supremum of increasing sequences of
+functions.
+
+It is possible to make the hypotheses in the induction steps a bit stronger, and such conditions
+can be added once we need them (for example in `h_add` it is only necessary to consider the sum of
+a simple function with a multiple of a characteristic function and that the intersection
+of their images is a subset of `{0}`. -/
+@[elab_as_elim]
+lemma Measurable.ennreal_sigmaFinite_induction [SigmaFinite μ] {P : (α → ℝ≥0∞) → Prop}
+    (h_ind : ∀ (c : ℝ≥0∞) ⦃s⦄, MeasurableSet s → μ s < ∞ → P (Set.indicator s fun _ => c))
+    (h_add :
+      ∀ ⦃f g : α → ℝ≥0∞⦄,
+        Disjoint (support f) (support g) → Measurable f → Measurable g → P f → P g → P (f + g))
+    (h_iSup :
+      ∀ ⦃f : ℕ → α → ℝ≥0∞⦄, (∀ n, Measurable (f n)) → Monotone f → (∀ n, P (f n)) →
+        P fun x => ⨆ n, f n x)
+    ⦃f : α → ℝ≥0∞⦄ (hf : Measurable f) : P f := by
+  refine Measurable.ennreal_induction (fun c s hs ↦ ?_) h_add h_iSup hf
+  convert h_iSup (f := fun n ↦ (s ∩ spanningSets μ n).indicator fun _ ↦ c)
+    (fun n ↦ measurable_const.indicator (hs.inter (measurable_spanningSets ..)))
+    (fun m n hmn a ↦ Set.indicator_le_indicator_of_subset (by gcongr) (by simp) _)
+    (fun n ↦ h_ind _ (hs.inter (measurable_spanningSets ..))
+      (measure_inter_lt_top_of_right_ne_top (measure_spanningSets_lt_top ..).ne)) with a
+  simp [← Set.indicator_iUnion_apply (M := ℝ≥0∞) rfl, ← Set.inter_iUnion]

--- a/Mathlib/MeasureTheory/Integral/Lebesgue.lean
+++ b/Mathlib/MeasureTheory/Integral/Lebesgue.lean
@@ -440,7 +440,7 @@ theorem lintegral_eq_iSup_eapprox_lintegral {f : α → ℝ≥0∞} (hf : Measur
     ∫⁻ a, f a ∂μ = ⨆ n, (eapprox f n).lintegral μ :=
   calc
     ∫⁻ a, f a ∂μ = ∫⁻ a, ⨆ n, (eapprox f n : α → ℝ≥0∞) a ∂μ := by
-      congr; ext a; rw [iSup_eapprox_apply f hf]
+      congr; ext a; rw [iSup_eapprox_apply hf]
     _ = ⨆ n, ∫⁻ a, (eapprox f n : α → ℝ≥0∞) a ∂μ := by
       apply lintegral_iSup
       · measurability
@@ -665,7 +665,7 @@ theorem lintegral_const_mul (r : ℝ≥0∞) {f : α → ℝ≥0∞} (hf : Measu
     ∫⁻ a, r * f a ∂μ = ∫⁻ a, ⨆ n, (const α r * eapprox f n) a ∂μ := by
       congr
       funext a
-      rw [← iSup_eapprox_apply f hf, ENNReal.mul_iSup]
+      rw [← iSup_eapprox_apply hf, ENNReal.mul_iSup]
       simp
     _ = ⨆ n, r * (eapprox f n).lintegral μ := by
       rw [lintegral_iSup]

--- a/Mathlib/Probability/Kernel/Composition.lean
+++ b/Mathlib/Probability/Kernel/Composition.lean
@@ -379,8 +379,7 @@ theorem lintegral_compProd' (κ : Kernel α β) [IsSFiniteKernel κ] (η : Kerne
     [IsSFiniteKernel η] (a : α) {f : β → γ → ℝ≥0∞} (hf : Measurable (Function.uncurry f)) :
     ∫⁻ bc, f bc.1 bc.2 ∂(κ ⊗ₖ η) a = ∫⁻ b, ∫⁻ c, f b c ∂η (a, b) ∂κ a := by
   let F : ℕ → SimpleFunc (β × γ) ℝ≥0∞ := SimpleFunc.eapprox (Function.uncurry f)
-  have h : ∀ a, ⨆ n, F n a = Function.uncurry f a :=
-    SimpleFunc.iSup_eapprox_apply (Function.uncurry f) hf
+  have h : ∀ a, ⨆ n, F n a = Function.uncurry f a := SimpleFunc.iSup_eapprox_apply hf
   simp only [Prod.forall, Function.uncurry_apply_pair] at h
   simp_rw [← h]
   have h_mono : Monotone F := fun i j hij b =>

--- a/Mathlib/Probability/Kernel/MeasurableIntegral.lean
+++ b/Mathlib/Probability/Kernel/MeasurableIntegral.lean
@@ -143,7 +143,7 @@ measurable. -/
 theorem _root_.Measurable.lintegral_kernel_prod_right {f : α → β → ℝ≥0∞}
     (hf : Measurable (uncurry f)) : Measurable fun a => ∫⁻ b, f a b ∂κ a := by
   let F : ℕ → SimpleFunc (α × β) ℝ≥0∞ := SimpleFunc.eapprox (uncurry f)
-  have h : ∀ a, ⨆ n, F n a = uncurry f a := SimpleFunc.iSup_eapprox_apply (uncurry f) hf
+  have h : ∀ a, ⨆ n, F n a = uncurry f a := SimpleFunc.iSup_eapprox_apply hf
   simp only [Prod.forall, uncurry_apply_pair] at h
   simp_rw [← h]
   have : ∀ a, (∫⁻ b, ⨆ n, F n (a, b) ∂κ a) = ⨆ n, ∫⁻ b, F n (a, b) ∂κ a := by


### PR DESCRIPTION
From GibbsMeasure

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
