### PR TITLE
chore(SetTheory/Ordinal/Enum): `enumOrd_strictMono` → `strictMono_enumOrd`

### DIFF
--- a/Mathlib/SetTheory/Ordinal/Enum.lean
+++ b/Mathlib/SetTheory/Ordinal/Enum.lean
@@ -58,35 +58,38 @@ private theorem enumOrd_mem_aux (hs : ¬ BddAbove s) (o : Ordinal) :
 theorem enumOrd_mem (hs : ¬ BddAbove s) (o : Ordinal) : enumOrd s o ∈ s :=
   (enumOrd_mem_aux hs o).1
 
-theorem enumOrd_strictMono (hs : ¬ BddAbove s) : StrictMono (enumOrd s) :=
+theorem strictMono_enumOrd (hs : ¬ BddAbove s) : StrictMono (enumOrd s) :=
   fun a b ↦ (enumOrd_mem_aux hs b).2 a
 
+@[deprecated (since := "2024-10-16")]
+alias enumOrd_strictMono := strictMono_enumOrd
+
 theorem enumOrd_injective (hs : ¬ BddAbove s) : Function.Injective (enumOrd s) :=
-  (enumOrd_strictMono hs).injective
+  (strictMono_enumOrd hs).injective
 
 theorem enumOrd_inj (hs : ¬ BddAbove s) {a b : Ordinal} : enumOrd s a = enumOrd s b ↔ a = b :=
   (enumOrd_injective hs).eq_iff
 
 theorem enumOrd_le_enumOrd (hs : ¬ BddAbove s) {a b : Ordinal} :
     enumOrd s a ≤ enumOrd s b ↔ a ≤ b :=
-  (enumOrd_strictMono hs).le_iff_le
+  (strictMono_enumOrd hs).le_iff_le
 
 theorem enumOrd_lt_enumOrd (hs : ¬ BddAbove s) {a b : Ordinal} :
     enumOrd s a < enumOrd s b ↔ a < b :=
-  (enumOrd_strictMono hs).lt_iff_lt
+  (strictMono_enumOrd hs).lt_iff_lt
 
 theorem id_le_enumOrd (hs : ¬ BddAbove s) : id ≤ enumOrd s :=
-  (enumOrd_strictMono hs).id_le
+  (strictMono_enumOrd hs).id_le
 
 theorem le_enumOrd_self (hs : ¬ BddAbove s) {a} : a ≤ enumOrd s a :=
-  (enumOrd_strictMono hs).le_apply
+  (strictMono_enumOrd hs).le_apply
 
 theorem enumOrd_succ_le (hs : ¬ BddAbove s) (ha : a ∈ s) (hb : enumOrd s b < a) :
     enumOrd s (succ b) ≤ a := by
   apply enumOrd_le_of_forall_lt ha
   intro c hc
   rw [lt_succ_iff] at hc
-  exact ((enumOrd_strictMono hs).monotone hc).trans_lt hb
+  exact ((strictMono_enumOrd hs).monotone hc).trans_lt hb
 
 theorem range_enumOrd (hs : ¬ BddAbove s) : range (enumOrd s) = s := by
   ext a
@@ -99,7 +102,7 @@ theorem range_enumOrd (hs : ¬ BddAbove s) : range (enumOrd s) = s := by
     · intro b hb
       by_contra! hb'
       exact hb.not_le (csInf_le' hb')
-    · exact csInf_mem (s := t) ⟨a, (enumOrd_strictMono hs).id_le a⟩
+    · exact csInf_mem (s := t) ⟨a, (strictMono_enumOrd hs).id_le a⟩
 
 theorem enumOrd_surjective (hs : ¬ BddAbove s) {b : Ordinal} (hb : b ∈ s) :
     ∃ a, enumOrd s a = b := by
@@ -119,9 +122,9 @@ theorem eq_enumOrd (f : Ordinal → Ordinal) (hs : ¬ BddAbove s) :
     enumOrd s = f ↔ StrictMono f ∧ range f = s := by
   constructor
   · rintro rfl
-    exact ⟨enumOrd_strictMono hs, range_enumOrd hs⟩
+    exact ⟨strictMono_enumOrd hs, range_enumOrd hs⟩
   · rintro ⟨h₁, h₂⟩
-    rwa [← (enumOrd_strictMono hs).range_inj h₁, range_enumOrd hs, eq_comm]
+    rwa [← (strictMono_enumOrd hs).range_inj h₁, range_enumOrd hs, eq_comm]
 
 theorem enumOrd_range {f : Ordinal → Ordinal} (hf : StrictMono f) : enumOrd (range f) = f :=
   (eq_enumOrd _ hf.not_bddAbove_range_of_wellFoundedLT).2 ⟨hf, rfl⟩
@@ -138,7 +141,7 @@ theorem enumOrd_zero : enumOrd s 0 = sInf s := by
 
 /-- An order isomorphism between an unbounded set of ordinals and the ordinals. -/
 noncomputable def enumOrdOrderIso (s : Set Ordinal) (hs : ¬ BddAbove s) : Ordinal ≃o s :=
-  StrictMono.orderIsoOfSurjective (fun o => ⟨_, enumOrd_mem hs o⟩) (enumOrd_strictMono hs) fun s =>
+  StrictMono.orderIsoOfSurjective (fun o => ⟨_, enumOrd_mem hs o⟩) (strictMono_enumOrd hs) fun s =>
     let ⟨a, ha⟩ := enumOrd_surjective hs s.prop
     ⟨a, Subtype.eq ha⟩
 

--- a/Mathlib/SetTheory/Ordinal/Topology.lean
+++ b/Mathlib/SetTheory/Ordinal/Topology.lean
@@ -221,7 +221,7 @@ theorem isNormal_iff_strictMono_and_continuous (f : Ordinal.{u} → Ordinal.{u})
 
 theorem enumOrd_isNormal_iff_isClosed (hs : ¬ BddAbove s) :
     IsNormal (enumOrd s) ↔ IsClosed s := by
-  have Hs := enumOrd_strictMono hs
+  have Hs := strictMono_enumOrd hs
   refine
     ⟨fun h => isClosed_iff_iSup.2 fun {ι} hι f hf => ?_, fun h =>
       (isNormal_iff_strictMono_limit _).2 ⟨Hs, fun a ha o H => ?_⟩⟩


### PR DESCRIPTION
This matches the naming convention.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
