### PR TITLE
[Merged by Bors] - feat(Topology/UnitInterval): add unitInterval as Submonoid

### DIFF
--- a/Mathlib/Topology/UnitInterval.lean
+++ b/Mathlib/Topology/UnitInterval.lean
@@ -209,6 +209,20 @@ theorem mul_pos_mem_iff {a t : ℝ} (ha : 0 < a) : a * t ∈ I ↔ t ∈ Set.Icc
 theorem two_mul_sub_one_mem_iff {t : ℝ} : 2 * t - 1 ∈ I ↔ t ∈ Set.Icc (1 / 2 : ℝ) 1 := by
   constructor <;> rintro ⟨h₁, h₂⟩ <;> constructor <;> linarith
 
+/-- The unit interval as a submoniod of ℝ. -/
+def unitIntervalSubmonoid : Submonoid ℝ where
+  carrier := unitInterval
+  one_mem' := unitInterval.one_mem
+  mul_mem' := unitInterval.mul_mem
+
+@[simp] theorem coe_unitIntervalSubmonoid : unitIntervalSubmonoid = unitInterval := rfl
+@[simp] theorem mem_unitIntervalSubmonoid {x} : x ∈ unitIntervalSubmonoid ↔ x ∈ unitInterval :=
+  Iff.rfl
+
+protected theorem prod_mem {ι : Type*} {t : Finset ι} {f : ι → ℝ}
+    (h : ∀ c ∈ t, f c ∈ unitInterval) :
+    ∏ c ∈ t, f c ∈ unitInterval := _root_.prod_mem (S := unitInterval.unitIntervalSubmonoid) h
+
 instance : LinearOrderedCommMonoidWithZero I where
   zero_mul i := zero_mul i
   mul_zero i := mul_zero i

--- a/Mathlib/Topology/UnitInterval.lean
+++ b/Mathlib/Topology/UnitInterval.lean
@@ -210,18 +210,18 @@ theorem two_mul_sub_one_mem_iff {t : ℝ} : 2 * t - 1 ∈ I ↔ t ∈ Set.Icc (1
   constructor <;> rintro ⟨h₁, h₂⟩ <;> constructor <;> linarith
 
 /-- The unit interval as a submoniod of ℝ. -/
-def unitIntervalSubmonoid : Submonoid ℝ where
+def submonoid : Submonoid ℝ where
   carrier := unitInterval
   one_mem' := unitInterval.one_mem
   mul_mem' := unitInterval.mul_mem
 
-@[simp] theorem coe_unitIntervalSubmonoid : unitIntervalSubmonoid = unitInterval := rfl
-@[simp] theorem mem_unitIntervalSubmonoid {x} : x ∈ unitIntervalSubmonoid ↔ x ∈ unitInterval :=
+@[simp] theorem coe_unitIntervalSubmonoid : submonoid = unitInterval := rfl
+@[simp] theorem mem_unitIntervalSubmonoid {x} : x ∈ submonoid ↔ x ∈ unitInterval :=
   Iff.rfl
 
 protected theorem prod_mem {ι : Type*} {t : Finset ι} {f : ι → ℝ}
     (h : ∀ c ∈ t, f c ∈ unitInterval) :
-    ∏ c ∈ t, f c ∈ unitInterval := _root_.prod_mem (S := unitInterval.unitIntervalSubmonoid) h
+    ∏ c ∈ t, f c ∈ unitInterval := _root_.prod_mem (S := unitInterval.submonoid) h
 
 instance : LinearOrderedCommMonoidWithZero I where
   zero_mul i := zero_mul i

--- a/Mathlib/Topology/UnitInterval.lean
+++ b/Mathlib/Topology/UnitInterval.lean
@@ -209,7 +209,7 @@ theorem mul_pos_mem_iff {a t : ℝ} (ha : 0 < a) : a * t ∈ I ↔ t ∈ Set.Icc
 theorem two_mul_sub_one_mem_iff {t : ℝ} : 2 * t - 1 ∈ I ↔ t ∈ Set.Icc (1 / 2 : ℝ) 1 := by
   constructor <;> rintro ⟨h₁, h₂⟩ <;> constructor <;> linarith
 
-/-- The unit interval as a submoniod of ℝ. -/
+/-- The unit interval as a submonoid of ℝ. -/
 def submonoid : Submonoid ℝ where
   carrier := unitInterval
   one_mem' := unitInterval.one_mem


### PR DESCRIPTION
add the definition of `UnitInterval` as Submonoid of `Real`.

motivation: This enables the use of `prod_mem`.

suggested in #12266