### PR TITLE
[Merged by Bors] - feat(Analysis/Complex/Positivity): new file

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -1089,6 +1089,7 @@ import Mathlib.Analysis.Complex.OperatorNorm
 import Mathlib.Analysis.Complex.PhragmenLindelof
 import Mathlib.Analysis.Complex.Polynomial.Basic
 import Mathlib.Analysis.Complex.Polynomial.UnitTrinomial
+import Mathlib.Analysis.Complex.Positivity
 import Mathlib.Analysis.Complex.ReImTopology
 import Mathlib.Analysis.Complex.RealDeriv
 import Mathlib.Analysis.Complex.RemovableSingularity

--- a/Mathlib/Analysis/Calculus/IteratedDeriv/Lemmas.lean
+++ b/Mathlib/Analysis/Calculus/IteratedDeriv/Lemmas.lean
@@ -15,6 +15,8 @@ This file contains a number of further results on `iteratedDerivWithin` that nee
 than are available in `Mathlib/Analysis/Calculus/IteratedDeriv/Defs.lean`.
 -/
 
+section one_dimensional
+
 variable
   {𝕜 : Type*} [NontriviallyNormedField 𝕜]
   {F : Type*} [NormedAddCommGroup F] [NormedSpace 𝕜 F]
@@ -123,3 +125,43 @@ lemma iteratedDeriv_comp_neg (n : ℕ) (f : 𝕜 → F) (a : 𝕜) :
     rw [iteratedDeriv_succ, iteratedDeriv_succ, ih', pow_succ', neg_mul, one_mul,
       deriv_comp_neg (f := fun x ↦ (-1 : 𝕜) ^ n • iteratedDeriv n f x), deriv_const_smul',
       neg_smul]
+
+lemma iteratedDeriv_eq_on_open (n : ℕ) {f g : 𝕜 → F} {s : Set 𝕜} (hs : IsOpen s) (x : s)
+    (hfg : Set.EqOn f g s) : iteratedDeriv n f x = iteratedDeriv n g x := by
+  induction' n with n IH generalizing f g
+  · simpa only [iteratedDeriv_zero] using hfg x.2
+  · simp only [iteratedDeriv_succ']
+    exact IH fun y hy ↦ Filter.EventuallyEq.deriv_eq <|
+      Filter.eventuallyEq_iff_exists_mem.mpr ⟨s, IsOpen.mem_nhds hs hy, hfg⟩
+
+end one_dimensional
+
+/-!
+### Invariance of iterated derivatives under translation
+-/
+
+section shift_invariance
+
+variable {𝕜 F} [NontriviallyNormedField 𝕜] [NormedAddCommGroup F] [NormedSpace 𝕜 F]
+
+/-- The iterated derivative commutes with shifting the function by a constant on the left. -/
+lemma iteratedDeriv_comp_const_add (n : ℕ) (f : 𝕜 → F) (s : 𝕜) :
+    iteratedDeriv n (fun z ↦ f (s + z)) = fun t ↦ iteratedDeriv n f (s + t) := by
+  induction n with
+  | zero => simp only [iteratedDeriv_zero]
+  | succ n IH =>
+      simp only [iteratedDeriv_succ, IH]
+      ext1 z
+      exact deriv_comp_const_add (iteratedDeriv n f) s z
+
+/-- The iterated derivative commutes with shifting the function by a constant on the right. -/
+lemma iteratedDeriv_comp_add_const (n : ℕ) (f : 𝕜 → F) (s : 𝕜) :
+    iteratedDeriv n (fun z ↦ f (z + s)) = fun t ↦ iteratedDeriv n f (t + s) := by
+  induction n with
+  | zero => simp only [iteratedDeriv_zero]
+  | succ n IH =>
+      simp only [iteratedDeriv_succ, IH]
+      ext1 z
+      exact deriv_comp_add_const (iteratedDeriv n f) s z
+
+end shift_invariance

--- a/Mathlib/Analysis/Calculus/IteratedDeriv/Lemmas.lean
+++ b/Mathlib/Analysis/Calculus/IteratedDeriv/Lemmas.lean
@@ -126,13 +126,17 @@ lemma iteratedDeriv_comp_neg (n : ℕ) (f : 𝕜 → F) (a : 𝕜) :
       deriv_comp_neg (f := fun x ↦ (-1 : 𝕜) ^ n • iteratedDeriv n f x), deriv_const_smul',
       neg_smul]
 
-lemma iteratedDeriv_eq_on_open (n : ℕ) {f g : 𝕜 → F} {s : Set 𝕜} (hs : IsOpen s) (x : s)
-    (hfg : Set.EqOn f g s) : iteratedDeriv n f x = iteratedDeriv n g x := by
-  induction' n with n IH generalizing f g
-  · simpa only [iteratedDeriv_zero] using hfg x.2
-  · simp only [iteratedDeriv_succ']
-    exact IH fun y hy ↦ Filter.EventuallyEq.deriv_eq <|
-      Filter.eventuallyEq_iff_exists_mem.mpr ⟨s, IsOpen.mem_nhds hs hy, hfg⟩
+lemma Filter.EventuallyEq.iteratedDeriv_eq (n : ℕ) {f g : 𝕜 → F} {x : 𝕜} (hfg : f =ᶠ[nhds x] g) :
+    iteratedDeriv n f x = iteratedDeriv n g x := by
+  simp only [← iteratedDerivWithin_univ, iteratedDerivWithin_eq_iteratedFDerivWithin]
+  rw [(hfg.filter_mono nhdsWithin_le_nhds).iteratedFDerivWithin_eq hfg.eq_of_nhds n]
+
+lemma iteratedDeriv_eq_on_open (n : ℕ) {f g : 𝕜 → F} {s : Set 𝕜} (hs : IsOpen s) {x : 𝕜}
+    (hx : x ∈ s) (hfg : Set.EqOn f g s) :
+    iteratedDeriv n f x = iteratedDeriv n g x := by
+  apply Filter.EventuallyEq.iteratedDeriv_eq
+  filter_upwards [IsOpen.mem_nhds hs hx] with a ha
+  exact hfg ha
 
 end one_dimensional
 
@@ -150,9 +154,7 @@ lemma iteratedDeriv_comp_const_add (n : ℕ) (f : 𝕜 → F) (s : 𝕜) :
   induction n with
   | zero => simp only [iteratedDeriv_zero]
   | succ n IH =>
-      simp only [iteratedDeriv_succ, IH]
-      ext1 z
-      exact deriv_comp_const_add (iteratedDeriv n f) s z
+    simpa only [iteratedDeriv_succ, IH] using funext <| deriv_comp_const_add _ s
 
 /-- The iterated derivative commutes with shifting the function by a constant on the right. -/
 lemma iteratedDeriv_comp_add_const (n : ℕ) (f : 𝕜 → F) (s : 𝕜) :
@@ -160,8 +162,6 @@ lemma iteratedDeriv_comp_add_const (n : ℕ) (f : 𝕜 → F) (s : 𝕜) :
   induction n with
   | zero => simp only [iteratedDeriv_zero]
   | succ n IH =>
-      simp only [iteratedDeriv_succ, IH]
-      ext1 z
-      exact deriv_comp_add_const (iteratedDeriv n f) s z
+    simpa only [iteratedDeriv_succ, IH] using funext <| deriv_comp_add_const _ s
 
 end shift_invariance

--- a/Mathlib/Analysis/Calculus/IteratedDeriv/Lemmas.lean
+++ b/Mathlib/Analysis/Calculus/IteratedDeriv/Lemmas.lean
@@ -126,15 +126,15 @@ lemma iteratedDeriv_comp_neg (n : ℕ) (f : 𝕜 → F) (a : 𝕜) :
       deriv_comp_neg (f := fun x ↦ (-1 : 𝕜) ^ n • iteratedDeriv n f x), deriv_const_smul',
       neg_smul]
 
-lemma Filter.EventuallyEq.iteratedDeriv_eq (n : ℕ) {f g : 𝕜 → F} {x : 𝕜} (hfg : f =ᶠ[nhds x] g) :
+open Topology in
+lemma Filter.EventuallyEq.iteratedDeriv_eq (n : ℕ) {f g : 𝕜 → F} {x : 𝕜} (hfg : f =ᶠ[𝓝 x] g) :
     iteratedDeriv n f x = iteratedDeriv n g x := by
   simp only [← iteratedDerivWithin_univ, iteratedDerivWithin_eq_iteratedFDerivWithin]
   rw [(hfg.filter_mono nhdsWithin_le_nhds).iteratedFDerivWithin_eq hfg.eq_of_nhds n]
 
-lemma iteratedDeriv_eq_on_open (n : ℕ) {f g : 𝕜 → F} {s : Set 𝕜} (hs : IsOpen s) {x : 𝕜}
-    (hx : x ∈ s) (hfg : Set.EqOn f g s) :
-    iteratedDeriv n f x = iteratedDeriv n g x := by
-  apply Filter.EventuallyEq.iteratedDeriv_eq
+lemma Set.EqOn.iteratedDeriv_of_isOpen (hfg : Set.EqOn f g s) (hs : IsOpen s) (n : ℕ) :
+    Set.EqOn (iteratedDeriv n f) (iteratedDeriv n g) s := by
+  refine fun x hx ↦ Filter.EventuallyEq.iteratedDeriv_eq n ?_
   filter_upwards [IsOpen.mem_nhds hs hx] with a ha
   exact hfg ha
 

--- a/Mathlib/Analysis/Complex/Positivity.lean
+++ b/Mathlib/Analysis/Complex/Positivity.lean
@@ -1,0 +1,90 @@
+/-
+Copyright (c) 2024 Michael Stoll. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Michael Stoll
+-/
+import Mathlib.Analysis.Complex.TaylorSeries
+
+/-!
+# Nonnegativity of values of holomorphic functions
+
+We show that if `f` is holomorphic on an open disk `B(c,r)` and all iterated derivatives of `f`
+at `c` are nonnegative real, then `f z ≥ 0` for all `z ≥ c` in the disk; see
+`DifferentiableOn.nonneg_of_iteratedDeriv_nonneg`. We also provide a
+variant `Differentiable.nonneg_of_iteratedDeriv_nonneg` for entire functions and versions
+showing `f z ≥ f c` when all iterated derivatives except `f` itseld are nonnegative.
+-/
+
+open Complex
+
+open scoped ComplexOrder
+
+namespace DifferentiableOn
+
+/-- A function that is holomorphic on the open disk around `c` with radius `r` and whose iterated
+derivatives at `c` are all nonnegative real has nonnegative real values on `c + [0,r)`. -/
+theorem nonneg_of_iteratedDeriv_nonneg {f : ℂ → ℂ} {c : ℂ} {r : ℝ}
+    (hf : DifferentiableOn ℂ f (Metric.ball c r)) (h : ∀ n, 0 ≤ iteratedDeriv n f c) ⦃z : ℂ⦄
+    (hz₁ : c ≤ z) (hz₂ : z ∈ Metric.ball c r):
+    0 ≤ f z := by
+  have H := taylorSeries_eq_on_ball' hz₂ hf
+  rw [← sub_nonneg] at hz₁
+  have hz' : z - c = (z - c).re := eq_re_of_ofReal_le hz₁
+  rw [hz'] at hz₁ H
+  obtain ⟨D, hD⟩ : ∃ D : ℕ → ℝ, ∀ n, 0 ≤ D n ∧ iteratedDeriv n f c = D n := by
+    refine ⟨fun n ↦ (iteratedDeriv n f c).re, fun n ↦ ⟨?_, ?_⟩⟩
+    · exact zero_le_real.mp <| eq_re_of_ofReal_le (h n) ▸ h n
+    · rw [eq_re_of_ofReal_le (h n)]
+  rewrite [← H]
+  simp_rw [hD, ← ofReal_natCast, ← ofReal_pow, ← ofReal_inv, ← ofReal_mul, ← ofReal_tsum]
+  norm_cast
+  refine tsum_nonneg fun n ↦ ?_
+  norm_cast at hz₁
+  have := (hD n).1
+  positivity
+
+end DifferentiableOn
+
+namespace Differentiable
+
+/-- An entire function whose iterated derivatives at `c` are all nonnegative real has nonnegative
+real values on `c + ℝ≥0`. -/
+theorem nonneg_of_iteratedDeriv_nonneg {f : ℂ → ℂ} (hf : Differentiable ℂ f) {c : ℂ}
+    (h : ∀ n, 0 ≤ iteratedDeriv n f c) ⦃z : ℂ⦄ (hz : c ≤ z) :
+    0 ≤ f z := by
+  refine hf.differentiableOn.nonneg_of_iteratedDeriv_nonneg (r := (z - c).re + 1) h hz ?_
+  rw [← sub_nonneg] at hz
+  have : (z - c) = (z - c).re := eq_re_of_ofReal_le hz
+  simp only [Metric.mem_ball, dist_eq]
+  nth_rewrite 1 [this]
+  rewrite [abs_ofReal, _root_.abs_of_nonneg (nonneg_iff.mp hz).1]
+  exact lt_add_one _
+
+/-- An entire function whose iterated derivatives at `c` are all nonnegative real (except
+possibly the value itself) has values of the form `f c + nonneg. real` on the set `c + ℝ≥0`. -/
+theorem apply_le_of_iteratedDeriv_nonneg {f : ℂ → ℂ} {c : ℂ} (hf : Differentiable ℂ f)
+    (h : ∀ n ≠ 0, 0 ≤ iteratedDeriv n f c) ⦃z : ℂ⦄ (hz : c ≤ z) :
+    f c ≤ f z := by
+  have h' (n : ℕ) : 0 ≤ iteratedDeriv n (f · - f c) c := by
+    cases n with
+    | zero => simp only [iteratedDeriv_zero, sub_self, le_refl]
+    | succ n =>
+      specialize h (n + 1) n.succ_ne_zero
+      rw [iteratedDeriv_succ'] at h ⊢
+      rwa [funext_iff.mpr <| fun x ↦ deriv_sub_const (f := f) (x := x) (f c)]
+  exact sub_nonneg.mp <| nonneg_of_iteratedDeriv_nonneg (hf.sub_const _) h' hz
+
+/-- An entire function whose iterated derivatives at `c` are all real with alternating signs
+(except possibly the value itself) has values of the form `f c + nonneg. real` along the
+set `c - ℝ≥0`. -/
+theorem apply_le_of_iteratedDeriv_alternating {f : ℂ → ℂ} {c : ℂ} (hf : Differentiable ℂ f)
+    (h : ∀ n ≠ 0, 0 ≤ (-1) ^ n * iteratedDeriv n f c) ⦃z : ℂ⦄ (hz : z ≤ c) :
+    f c ≤ f z := by
+  let F : ℂ → ℂ := fun z ↦ f (-z)
+  convert apply_le_of_iteratedDeriv_nonneg (f := F) (c := -c) (z := -z)
+    (hf.comp <| differentiable_neg) (fun n hn ↦ ?_) (neg_le_neg_iff.mpr hz) using 1
+  · simp only [neg_neg, F]
+  · simp only [neg_neg, F]
+  · simpa only [iteratedDeriv_comp_neg, neg_neg, smul_eq_mul, F] using h n hn
+
+end Differentiable

--- a/Mathlib/Analysis/Complex/Positivity.lean
+++ b/Mathlib/Analysis/Complex/Positivity.lean
@@ -49,9 +49,8 @@ theorem nonneg_of_iteratedDeriv_nonneg {f : ℂ → ℂ} (hf : Differentiable �
     0 ≤ f z := by
   refine hf.differentiableOn.nonneg_of_iteratedDeriv_nonneg (r := (z - c).re + 1) h hz ?_
   rw [← sub_nonneg] at hz
-  simp only [Metric.mem_ball, dist_eq]
-  nth_rewrite 1 [eq_re_of_ofReal_le hz]
-  simpa only [abs_ofReal, _root_.abs_of_nonneg (nonneg_iff.mp hz).1] using lt_add_one _
+  rw [Metric.mem_ball, dist_eq, eq_re_of_ofReal_le hz]
+  simpa only [Complex.abs_of_nonneg (nonneg_iff.mp hz).1] using lt_add_one _
 
 /-- An entire function whose iterated derivatives at `c` are all nonnegative real (except
 possibly the value itself) has values of the form `f c + nonneg. real` on the set `c + ℝ≥0`. -/
@@ -64,7 +63,7 @@ theorem apply_le_of_iteratedDeriv_nonneg {f : ℂ → ℂ} {c : ℂ} (hf : Diffe
     | succ n =>
       specialize h (n + 1) n.succ_ne_zero
       rw [iteratedDeriv_succ'] at h ⊢
-      rwa [funext_iff.mpr <| fun x ↦ deriv_sub_const (f := f) (x := x) (f c)]
+      rwa [funext fun x ↦ deriv_sub_const (f := f) (x := x) (f c)]
   exact sub_nonneg.mp <| nonneg_of_iteratedDeriv_nonneg (hf.sub_const _) h' hz
 
 /-- An entire function whose iterated derivatives at `c` are all real with alternating signs
@@ -73,11 +72,10 @@ set `c - ℝ≥0`. -/
 theorem apply_le_of_iteratedDeriv_alternating {f : ℂ → ℂ} {c : ℂ} (hf : Differentiable ℂ f)
     (h : ∀ n ≠ 0, 0 ≤ (-1) ^ n * iteratedDeriv n f c) ⦃z : ℂ⦄ (hz : z ≤ c) :
     f c ≤ f z := by
-  let F : ℂ → ℂ := fun z ↦ f (-z)
-  convert apply_le_of_iteratedDeriv_nonneg (f := F) (c := -c) (z := -z)
+  convert apply_le_of_iteratedDeriv_nonneg (f := fun z ↦ f (-z))
     (hf.comp <| differentiable_neg) (fun n hn ↦ ?_) (neg_le_neg_iff.mpr hz) using 1
-  · simp only [neg_neg, F]
-  · simp only [neg_neg, F]
-  · simpa only [iteratedDeriv_comp_neg, neg_neg, smul_eq_mul, F] using h n hn
+  · simp only [neg_neg]
+  · simp only [neg_neg]
+  · simpa only [iteratedDeriv_comp_neg, neg_neg, smul_eq_mul] using h n hn
 
 end Differentiable

--- a/Mathlib/Analysis/Complex/Positivity.lean
+++ b/Mathlib/Analysis/Complex/Positivity.lean
@@ -29,18 +29,13 @@ theorem nonneg_of_iteratedDeriv_nonneg {f : ℂ → ℂ} {c : ℂ} {r : ℝ}
     0 ≤ f z := by
   have H := taylorSeries_eq_on_ball' hz₂ hf
   rw [← sub_nonneg] at hz₁
-  have hz' : z - c = (z - c).re := eq_re_of_ofReal_le hz₁
+  have hz' := eq_re_of_ofReal_le hz₁
   rw [hz'] at hz₁ H
-  obtain ⟨D, hD⟩ : ∃ D : ℕ → ℝ, ∀ n, 0 ≤ D n ∧ iteratedDeriv n f c = D n := by
-    refine ⟨fun n ↦ (iteratedDeriv n f c).re, fun n ↦ ⟨?_, ?_⟩⟩
-    · exact zero_le_real.mp <| eq_re_of_ofReal_le (h n) ▸ h n
-    · rw [eq_re_of_ofReal_le (h n)]
-  rewrite [← H]
-  simp_rw [hD, ← ofReal_natCast, ← ofReal_pow, ← ofReal_inv, ← ofReal_mul, ← ofReal_tsum]
-  norm_cast
-  refine tsum_nonneg fun n ↦ ?_
-  norm_cast at hz₁
-  have := (hD n).1
+  refine H ▸ tsum_nonneg fun n ↦ ?_
+  rw [← ofReal_natCast, ← ofReal_pow, ← ofReal_inv, eq_re_of_ofReal_le (h n), ← ofReal_mul,
+    ← ofReal_mul]
+  norm_cast at hz₁ ⊢
+  have := zero_re ▸ (Complex.le_def.mp (h n)).1
   positivity
 
 end DifferentiableOn
@@ -54,11 +49,9 @@ theorem nonneg_of_iteratedDeriv_nonneg {f : ℂ → ℂ} (hf : Differentiable �
     0 ≤ f z := by
   refine hf.differentiableOn.nonneg_of_iteratedDeriv_nonneg (r := (z - c).re + 1) h hz ?_
   rw [← sub_nonneg] at hz
-  have : (z - c) = (z - c).re := eq_re_of_ofReal_le hz
   simp only [Metric.mem_ball, dist_eq]
-  nth_rewrite 1 [this]
-  rewrite [abs_ofReal, _root_.abs_of_nonneg (nonneg_iff.mp hz).1]
-  exact lt_add_one _
+  nth_rewrite 1 [eq_re_of_ofReal_le hz]
+  simpa only [abs_ofReal, _root_.abs_of_nonneg (nonneg_iff.mp hz).1] using lt_add_one _
 
 /-- An entire function whose iterated derivatives at `c` are all nonnegative real (except
 possibly the value itself) has values of the form `f c + nonneg. real` on the set `c + ℝ≥0`. -/


### PR DESCRIPTION
This adds results of the kind "if `f` is an entire function with all iterated derivatives at a point `c` nonnegative real, then `f z` is nonnegative real for `z = c + r` with `r` nonnegative real".

From [EulerProducts](https://github.com/MichaelStollBayreuth/EulerProducts).

This will be needed for the proof that $L(\chi, 1) \ne 0$ for nontrivial quadratic Dirichlet characters $\chi$ (which in turn is necessary for Dirichlet's Theorem on primes in arithmetic progressions; see [PNT+](https://github.com/AlexKontorovich/PrimeNumberTheoremAnd)). 

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
