### PR TITLE
[Merged by Bors] - feat(AlgebraicGeometry): proper morphisms of schemes

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -866,6 +866,7 @@ import Mathlib.AlgebraicGeometry.Morphisms.FiniteType
 import Mathlib.AlgebraicGeometry.Morphisms.IsIso
 import Mathlib.AlgebraicGeometry.Morphisms.OpenImmersion
 import Mathlib.AlgebraicGeometry.Morphisms.Preimmersion
+import Mathlib.AlgebraicGeometry.Morphisms.Proper
 import Mathlib.AlgebraicGeometry.Morphisms.QuasiCompact
 import Mathlib.AlgebraicGeometry.Morphisms.QuasiSeparated
 import Mathlib.AlgebraicGeometry.Morphisms.RingHomProperties

--- a/Mathlib/AlgebraicGeometry/Morphisms/ClosedImmersion.lean
+++ b/Mathlib/AlgebraicGeometry/Morphisms/ClosedImmersion.lean
@@ -6,6 +6,7 @@ Authors: Amelia Livingston, Christian Merten, Jonas van der Schaaf
 import Mathlib.AlgebraicGeometry.Morphisms.Preimmersion
 import Mathlib.AlgebraicGeometry.Morphisms.QuasiSeparated
 import Mathlib.AlgebraicGeometry.Morphisms.RingHomProperties
+import Mathlib.AlgebraicGeometry.Morphisms.FiniteType
 import Mathlib.AlgebraicGeometry.ResidueField
 import Mathlib.RingTheory.RingHom.Surjective
 
@@ -268,5 +269,18 @@ lemma IsClosedImmersion.stableUnderBaseChange :
   intro X Y S _ _ f g ⟨ha, hsurj⟩
   exact ⟨inferInstance, RingHom.surjective_stableUnderBaseChange.pullback_fst_app_top _
     RingHom.surjective_respectsIso f _ hsurj⟩
+
+/-- Closed immersions are locally of finite type. -/
+instance (priority := 900) {X Y : Scheme.{u}} (f : X ⟶ Y) [h : IsClosedImmersion f] :
+    LocallyOfFiniteType f := by
+  wlog hY : IsAffine Y
+  · rw [IsLocalAtTarget.iff_of_iSup_eq_top (P := @LocallyOfFiniteType) _
+      (iSup_affineOpens_eq_top Y)]
+    intro U
+    have H : IsClosedImmersion (f ∣_ U) := IsLocalAtTarget.restrict h U
+    exact this _ U.2
+  obtain ⟨_, hf⟩ := h.isAffine_surjective_of_isAffine
+  rw [HasRingHomProperty.iff_of_isAffine (P := @LocallyOfFiniteType)]
+  exact RingHom.FiniteType.of_surjective (Scheme.Hom.app f ⊤) hf
 
 end AlgebraicGeometry

--- a/Mathlib/AlgebraicGeometry/Morphisms/FiniteType.lean
+++ b/Mathlib/AlgebraicGeometry/Morphisms/FiniteType.lean
@@ -59,6 +59,9 @@ theorem locallyOfFiniteType_of_comp {X Y Z : Scheme} (f : X ⟶ Y) (g : Y ⟶ Z)
     [LocallyOfFiniteType (f ≫ g)] : LocallyOfFiniteType f :=
   HasRingHomProperty.of_comp (fun _ _ ↦ RingHom.FiniteType.of_comp_finiteType) ‹_›
 
+instance : MorphismProperty.IsMultiplicative @LocallyOfFiniteType where
+  id_mem _ := inferInstance
+
 open scoped TensorProduct in
 lemma locallyOfFiniteType_stableUnderBaseChange :
     MorphismProperty.StableUnderBaseChange @LocallyOfFiniteType :=

--- a/Mathlib/AlgebraicGeometry/Morphisms/Proper.lean
+++ b/Mathlib/AlgebraicGeometry/Morphisms/Proper.lean
@@ -1,0 +1,69 @@
+/-
+Copyright (c) 2024 Christian Merten, Andrew Yang. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Christian Merten, Andrew Yang
+-/
+import Mathlib.AlgebraicGeometry.Morphisms.Separated
+import Mathlib.AlgebraicGeometry.Morphisms.UniversallyClosed
+import Mathlib.AlgebraicGeometry.Morphisms.FiniteType
+
+/-!
+
+# Proper morphisms
+
+A morphism of schemes is proper if it is separated, universally closed and (locally) of finite type.
+Note that we don't require quasi-compact, since this is implied by universally closed (TODO).
+
+-/
+
+
+noncomputable section
+
+open CategoryTheory
+
+universe u
+
+namespace AlgebraicGeometry
+
+variable {X Y : Scheme.{u}} (f : X ⟶ Y)
+
+/-- A morphism is separated if the diagonal map is a closed immersion. -/
+@[mk_iff]
+class IsProper extends IsSeparated f, UniversallyClosed f, LocallyOfFiniteType f : Prop where
+
+lemma isProper_eq : @IsProper =
+    (@IsSeparated ⊓ @UniversallyClosed : MorphismProperty Scheme) ⊓ @LocallyOfFiniteType := by
+  ext X Y f
+  rw [isProper_iff, ← and_assoc]
+  rfl
+
+namespace IsProper
+
+instance : MorphismProperty.RespectsIso @IsProper := by
+  rw [isProper_eq]
+  infer_instance
+
+instance stableUnderComposition : MorphismProperty.IsStableUnderComposition @IsProper := by
+  rw [isProper_eq]
+  infer_instance
+
+instance : MorphismProperty.IsMultiplicative @IsProper := by
+  rw [isProper_eq]
+  infer_instance
+
+instance (priority := 900) [IsClosedImmersion f] : IsProper f where
+
+lemma stableUnderBaseChange : MorphismProperty.StableUnderBaseChange @IsProper := by
+  rw [isProper_eq]
+  exact MorphismProperty.StableUnderBaseChange.inf
+    (MorphismProperty.StableUnderBaseChange.inf
+      IsSeparated.stableUnderBaseChange universallyClosed_stableUnderBaseChange)
+    locallyOfFiniteType_stableUnderBaseChange
+
+instance : IsLocalAtTarget @IsProper := by
+  rw [isProper_eq]
+  infer_instance
+
+end IsProper
+
+end AlgebraicGeometry

--- a/Mathlib/AlgebraicGeometry/Morphisms/Proper.lean
+++ b/Mathlib/AlgebraicGeometry/Morphisms/Proper.lean
@@ -27,7 +27,7 @@ namespace AlgebraicGeometry
 
 variable {X Y : Scheme.{u}} (f : X ⟶ Y)
 
-/-- A morphism is separated if the diagonal map is a closed immersion. -/
+/-- A morphism is proper if it is separated, universally closed and locally of finite type. -/
 @[mk_iff]
 class IsProper extends IsSeparated f, UniversallyClosed f, LocallyOfFiniteType f : Prop where
 

--- a/Mathlib/AlgebraicGeometry/Morphisms/UniversallyClosed.lean
+++ b/Mathlib/AlgebraicGeometry/Morphisms/UniversallyClosed.lean
@@ -3,7 +3,7 @@ Copyright (c) 2022 Andrew Yang. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Andrew Yang
 -/
-import Mathlib.AlgebraicGeometry.Morphisms.Constructors
+import Mathlib.AlgebraicGeometry.Morphisms.ClosedImmersion
 import Mathlib.Topology.LocalAtTarget
 
 /-!
@@ -40,6 +40,13 @@ class UniversallyClosed (f : X ⟶ Y) : Prop where
 theorem universallyClosed_eq : @UniversallyClosed = universally (topologically @IsClosedMap) := by
   ext X Y f; rw [universallyClosed_iff]
 
+instance (priority := 900) [IsClosedImmersion f] : UniversallyClosed f := by
+  rw [universallyClosed_eq]
+  intro X' Y' i₁ i₂ f' hf
+  have hf' : IsClosedImmersion f' :=
+    IsClosedImmersion.stableUnderBaseChange hf.flip inferInstance
+  exact hf'.base_closed.isClosedMap
+
 theorem universallyClosed_respectsIso : RespectsIso @UniversallyClosed :=
   universallyClosed_eq.symm ▸ universally_respectsIso (topologically @IsClosedMap)
 
@@ -58,6 +65,9 @@ instance universallyClosed_isStableUnderComposition :
 instance universallyClosedTypeComp {X Y Z : Scheme} (f : X ⟶ Y) (g : Y ⟶ Z)
     [hf : UniversallyClosed f] [hg : UniversallyClosed g] : UniversallyClosed (f ≫ g) :=
   comp_mem _ _ _ hf hg
+
+instance : MorphismProperty.IsMultiplicative @UniversallyClosed where
+  id_mem _ := inferInstance
 
 instance universallyClosed_fst {X Y Z : Scheme} (f : X ⟶ Z) (g : Y ⟶ Z) [hg : UniversallyClosed g] :
     UniversallyClosed (pullback.fst f g) :=


### PR DESCRIPTION
We define proper morphisms of schemes and show standard stability properties.

Partly from the valuative criterion project.

Co-authored by: Andrew Yang

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
