### PR TITLE
[Merged by Bors] - feat: Popoviciu's inequality

### DIFF
--- a/Mathlib/MeasureTheory/Function/LpSeminorm/Basic.lean
+++ b/Mathlib/MeasureTheory/Function/LpSeminorm/Basic.lean
@@ -726,9 +726,7 @@ theorem memℒp_of_bounded [IsFiniteMeasure μ]
     (hX : AEStronglyMeasurable f μ) (p : ENNReal) : Memℒp f p μ :=
   have ha : ∀ᵐ x ∂μ, a ≤ f x := h.mono fun ω h => h.1
   have hb : ∀ᵐ x ∂μ, f x ≤ b := h.mono fun ω h => h.2
-  let c := max |a| |b|
-  (memℒp_const c).mono' hX
-    (by filter_upwards [ha, hb] with x using abs_le_max_abs_abs : ∀ᵐ x ∂μ, |f x| ≤ max |a| |b|)
+  (memℒp_const (max |a| |b|)).mono' hX (by filter_upwards [ha, hb] with x using abs_le_max_abs_abs)
 
 @[mono]
 theorem eLpNorm'_mono_measure (f : α → F) (hμν : ν ≤ μ) (hq : 0 ≤ q) :

--- a/Mathlib/MeasureTheory/Function/LpSeminorm/Basic.lean
+++ b/Mathlib/MeasureTheory/Function/LpSeminorm/Basic.lean
@@ -721,6 +721,16 @@ theorem Memℒp.of_bound [IsFiniteMeasure μ] {f : α → E} (hf : AEStronglyMea
     (hfC : ∀ᵐ x ∂μ, ‖f x‖ ≤ C) : Memℒp f p μ :=
   (memℒp_const C).of_le hf (hfC.mono fun _x hx => le_trans hx (le_abs_self _))
 
+theorem memℒp_of_bounded [IsFiniteMeasure μ]
+    {a b : ℝ} {f : α → ℝ} (h : ∀ᵐ x ∂μ, f x ∈ Set.Icc a b)
+    (hX : AEStronglyMeasurable f μ) (p : ENNReal) : Memℒp f p μ :=
+  have ha : ∀ᵐ x ∂μ, a ≤ f x := h.mono fun ω h => h.1
+  have hb : ∀ᵐ x ∂μ, f x ≤ b := h.mono fun ω h => h.2
+  let c := max |a| |b|
+  (memℒp_const c).mono' hX
+  (by filter_upwards [ha, hb] with x using abs_le_max_abs_abs :
+  (∀ᵐ x ∂μ, |f x| ≤ max |a| |b|))
+
 @[mono]
 theorem eLpNorm'_mono_measure (f : α → F) (hμν : ν ≤ μ) (hq : 0 ≤ q) :
     eLpNorm' f q ν ≤ eLpNorm' f q μ := by

--- a/Mathlib/MeasureTheory/Function/LpSeminorm/Basic.lean
+++ b/Mathlib/MeasureTheory/Function/LpSeminorm/Basic.lean
@@ -728,8 +728,7 @@ theorem memℒp_of_bounded [IsFiniteMeasure μ]
   have hb : ∀ᵐ x ∂μ, f x ≤ b := h.mono fun ω h => h.2
   let c := max |a| |b|
   (memℒp_const c).mono' hX
-  (by filter_upwards [ha, hb] with x using abs_le_max_abs_abs :
-  (∀ᵐ x ∂μ, |f x| ≤ max |a| |b|))
+    (by filter_upwards [ha, hb] with x using abs_le_max_abs_abs : ∀ᵐ x ∂μ, |f x| ≤ max |a| |b|)
 
 @[mono]
 theorem eLpNorm'_mono_measure (f : α → F) (hμν : ν ≤ μ) (hq : 0 ≤ q) :

--- a/Mathlib/Probability/Variance.lean
+++ b/Mathlib/Probability/Variance.lean
@@ -344,13 +344,13 @@ theorem IndepFun.variance_sum [IsProbabilityMeasure μ] {ι : Type*} {X : ι →
       rw [IH (fun i hi => hs i (mem_insert_of_mem hi))
           (h.mono (by simp only [coe_insert, Set.subset_insert]))]
 
-/-- **Popoviciu's inequality on variance**
+/-- **The Bhatia-Davis inequality on variance**
 
 The variance of a random variable `X` satisfying `a ≤ X ≤ b`  almost everywhere is at most
-`((b - a) / 2) ^ 2`. -/
-lemma variance_square_bounded [IsProbabilityMeasure μ] {a b : ℝ} {X : Ω → ℝ}
+`(b - 𝔼 X) * (𝔼 X - a)`. -/
+lemma variance_le_sub_mul_sub [IsProbabilityMeasure μ] {a b : ℝ} {X : Ω → ℝ}
     (h : ∀ᵐ ω ∂μ, X ω ∈ Set.Icc a b) (hX : AEMeasurable X μ) :
-    variance X μ ≤ ((b - a) / 2) ^ 2 :=
+    variance X μ ≤ (b - μ[X]) * (μ[X] - a) := by
   have ha : ∀ᵐ ω ∂μ, a ≤ X ω := h.mono fun ω h => h.1
   have hb : ∀ᵐ ω ∂μ, X ω ≤ b := h.mono fun ω h => h.2
   let c := max |a| |b|
@@ -383,6 +383,16 @@ lemma variance_square_bounded [IsProbabilityMeasure μ] {a b : ℝ} {X : Ω → 
       simp only [Pi.pow_apply, sub_nonneg, le_neg_add_iff_add_le] at h0
       linarith
     _ = (b - μ[X]) * (μ[X] - a) := by ring
+
+/-- **Popoviciu's inequality on variance**
+
+The variance of a random variable `X` satisfying `a ≤ X ≤ b`  almost everywhere is at most
+`((b - a) / 2) ^ 2`. -/
+lemma variance_square_bounded [IsProbabilityMeasure μ] {a b : ℝ} {X : Ω → ℝ}
+    (h : ∀ᵐ ω ∂μ, X ω ∈ Set.Icc a b) (hX : AEMeasurable X μ) :
+    variance X μ ≤ ((b - a) / 2) ^ 2 :=
+  calc
+    _ ≤ (b - μ[X]) * (μ[X] - a) := variance_le_sub_mul_sub h hX
     _ ≤ ((b - a) / 2) ^ 2 := by
       set y : ℝ := μ[X] - ((b + a) / 2)
       rw [(by ring : μ[X] = y + ((b + a) / 2))]

--- a/Mathlib/Probability/Variance.lean
+++ b/Mathlib/Probability/Variance.lean
@@ -353,34 +353,27 @@ lemma variance_le_sub_mul_sub [IsProbabilityMeasure μ] {a b : ℝ} {X : Ω → 
     variance X μ ≤ (b - μ[X]) * (μ[X] - a) := by
   have ha : ∀ᵐ ω ∂μ, a ≤ X ω := h.mono fun ω h => h.1
   have hb : ∀ᵐ ω ∂μ, X ω ≤ b := h.mono fun ω h => h.2
-  let c := max |a| |b|
-  have hX_int₁ : Integrable (fun ω ↦ -X ω ^ 2) μ :=
+  have hX_int₂ : Integrable (fun ω ↦ -X ω ^ 2) μ :=
     (memℒp_of_bounded h hX.aestronglyMeasurable 2).integrable_sq.neg
-  have hX_int₂ : Integrable (fun ω ↦ (a + b) * X ω) μ :=
-    ((integrable_const c).mono' hX.aestronglyMeasurable
-      (by filter_upwards [ha, hb] with ω using abs_le_max_abs_abs :
-  (∀ᵐ ω ∂μ, |X ω| ≤ max |a| |b|))).const_mul (a + b)
+  have hX_int₁ : Integrable (fun ω ↦ (a + b) * X ω) μ :=
+    ((integrable_const (max |a| |b|)).mono' hX.aestronglyMeasurable
+      (by filter_upwards [ha, hb] with ω using abs_le_max_abs_abs)).const_mul (a + b)
   have h0 : 0 ≤ - μ[X ^ 2] + (a + b) * μ[X] - a * b :=
     calc
       _ ≤ ∫ ω, (b - X ω) * (X ω - a) ∂μ := by
         apply integral_nonneg_of_ae
         filter_upwards [ha, hb] with ω ha' hb'
         exact mul_nonneg (by linarith : 0 ≤ b - X ω) (by linarith : 0 ≤ X ω - a)
-      _ = ∫ ω, - X ω ^ 2 + (a + b) * X ω - (a * b) ∂μ :=
+      _ = ∫ ω, - X ω ^ 2 + (a + b) * X ω - a * b ∂μ :=
         integral_congr_ae <| ae_of_all μ fun ω ↦ by ring
-      _ = ∫ ω, - X ω ^ 2 + (a + b) * X ω ∂μ - ∫ _, (a * b) ∂μ :=
-        integral_sub (hX_int₁.add hX_int₂) (integrable_const (a * b))
-      _ = ∫ ω, - X ω ^ 2 + (a + b) * X ω ∂μ - (a * b) := by simp only [integral_const,
-        measure_univ, ENNReal.one_toReal, smul_eq_mul, one_mul]
+      _ = ∫ ω, - X ω ^ 2 + (a + b) * X ω ∂μ - ∫ _, a * b ∂μ :=
+        integral_sub (hX_int₂.add hX_int₁) (integrable_const (a * b))
+      _ = ∫ ω, - X ω ^ 2 + (a + b) * X ω ∂μ - a * b := by simp
       _ = - μ[X ^ 2] + (a + b) * μ[X] - a * b := by
-        simp only [sub_left_inj]
-        rw [← integral_neg, ← integral_mul_left]
-        apply integral_add hX_int₁ hX_int₂
+        simp [← integral_neg, ← integral_mul_left, integral_add hX_int₂ hX_int₁]
   calc
     _ ≤ (a + b) * μ[X] - a * b - μ[X] ^ 2 := by
       rw [variance_def' (memℒp_of_bounded h hX.aestronglyMeasurable 2)]
-      simp only [Pi.pow_apply, tsub_le_iff_right, sub_add_cancel]
-      simp only [Pi.pow_apply, sub_nonneg, le_neg_add_iff_add_le] at h0
       linarith
     _ = (b - μ[X]) * (μ[X] - a) := by ring
 

--- a/Mathlib/Probability/Variance.lean
+++ b/Mathlib/Probability/Variance.lean
@@ -30,9 +30,9 @@ We define the variance of a real-valued random variable as `Var[X] = 𝔼[(X - �
   random variables is the sum of the variances.
 * `ProbabilityTheory.IndepFun.variance_sum`: the variance of a finite sum of pairwise
   independent random variables is the sum of the variances.
-* `Probability.variance_le_sub_mul_sub`: The variance of a random variable `X`
+* `ProbabilityTheory.variance_le_sub_mul_sub`: The variance of a random variable `X`
   satisfying `a ≤ X ≤ b` almost everywhere is at most `(b - 𝔼 X) * (𝔼 X - a)`.
-* `Probability.variance_le_sq_of_bounded`The variance of a random variable `X` satisfying
+* `ProbabilityTheory.variance_le_sq_of_bounded`The variance of a random variable `X` satisfying
   `a ≤ X ≤ b` almost everywhere is at most`((b - a) / 2) ^ 2`.
 -/
 

--- a/Mathlib/Probability/Variance.lean
+++ b/Mathlib/Probability/Variance.lean
@@ -381,7 +381,7 @@ lemma variance_le_sub_mul_sub [IsProbabilityMeasure μ] {a b : ℝ} {X : Ω → 
 
 The variance of a random variable `X` satisfying `a ≤ X ≤ b` almost everywhere is at most
 `((b - a) / 2) ^ 2`. -/
-lemma variance_square_bounded [IsProbabilityMeasure μ] {a b : ℝ} {X : Ω → ℝ}
+lemma variance_le_sq_of_bounded [IsProbabilityMeasure μ] {a b : ℝ} {X : Ω → ℝ}
     (h : ∀ᵐ ω ∂μ, X ω ∈ Set.Icc a b) (hX : AEMeasurable X μ) :
     variance X μ ≤ ((b - a) / 2) ^ 2 :=
   calc

--- a/Mathlib/Probability/Variance.lean
+++ b/Mathlib/Probability/Variance.lean
@@ -5,7 +5,6 @@ Authors: Sébastien Gouëzel, Kexing Ying
 -/
 import Mathlib.Probability.Notation
 import Mathlib.Probability.Integration
-import Mathlib.MeasureTheory.Measure.ProbabilityMeasure
 import Mathlib.MeasureTheory.Function.L2Space
 
 /-!

--- a/Mathlib/Probability/Variance.lean
+++ b/Mathlib/Probability/Variance.lean
@@ -355,7 +355,7 @@ lemma variance_square_bounded [IsProbabilityMeasure μ] {a b : ℝ} {X : Ω → 
   have hb : ∀ᵐ ω ∂μ, X ω ≤ b := h.mono fun ω h => h.2
   let c := max |a| |b|
   have hX_int₁ : Integrable (fun ω ↦ -X ω ^ 2) μ :=
-    ((memℒp_of_bounded h hX.aestronglyMeasurable 2).integrable_sq).neg
+    (memℒp_of_bounded h hX.aestronglyMeasurable 2).integrable_sq.neg
   have hX_int₂ : Integrable (fun ω ↦ (a + b) * X ω) μ :=
     ((integrable_const c).mono' hX.aestronglyMeasurable
       (by filter_upwards [ha, hb] with ω using abs_le_max_abs_abs :

--- a/Mathlib/Probability/Variance.lean
+++ b/Mathlib/Probability/Variance.lean
@@ -393,11 +393,7 @@ lemma variance_square_bounded [IsProbabilityMeasure μ] {a b : ℝ} {X : Ω → 
     variance X μ ≤ ((b - a) / 2) ^ 2 :=
   calc
     _ ≤ (b - μ[X]) * (μ[X] - a) := variance_le_sub_mul_sub h hX
-    _ ≤ ((b - a) / 2) ^ 2 := by
-      set y : ℝ := μ[X] - ((b + a) / 2)
-      rw [(by ring : μ[X] = y + ((b + a) / 2))]
-      calc
-        _ = ((b - a) / 2) ^ 2 - y ^ 2 := by ring
-        _ ≤ ((b - a) / 2) ^ 2 := sub_le_self (((b - a) / 2) ^ 2) (sq_nonneg y)
+    _ = ((b - a) / 2) ^ 2 - (μ[X] - (b + a) / 2) ^ 2 := by ring
+    _ ≤ ((b - a) / 2) ^ 2 := sub_le_self _ (sq_nonneg _)
 
 end ProbabilityTheory

--- a/Mathlib/Probability/Variance.lean
+++ b/Mathlib/Probability/Variance.lean
@@ -346,7 +346,7 @@ theorem IndepFun.variance_sum [IsProbabilityMeasure μ] {ι : Type*} {X : ι →
 
 /-- **The Bhatia-Davis inequality on variance**
 
-The variance of a random variable `X` satisfying `a ≤ X ≤ b`  almost everywhere is at most
+The variance of a random variable `X` satisfying `a ≤ X ≤ b` almost everywhere is at most
 `(b - 𝔼 X) * (𝔼 X - a)`. -/
 lemma variance_le_sub_mul_sub [IsProbabilityMeasure μ] {a b : ℝ} {X : Ω → ℝ}
     (h : ∀ᵐ ω ∂μ, X ω ∈ Set.Icc a b) (hX : AEMeasurable X μ) :

--- a/Mathlib/Probability/Variance.lean
+++ b/Mathlib/Probability/Variance.lean
@@ -32,7 +32,7 @@ We define the variance of a real-valued random variable as `Var[X] = 𝔼[(X - �
   independent random variables is the sum of the variances.
 * `ProbabilityTheory.variance_le_sub_mul_sub`: The variance of a random variable `X`
   satisfying `a ≤ X ≤ b` almost everywhere is at most `(b - 𝔼 X) * (𝔼 X - a)`.
-* `ProbabilityTheory.variance_le_sq_of_bounded`The variance of a random variable `X` satisfying
+* `ProbabilityTheory.variance_le_sq_of_bounded`: The variance of a random variable `X` satisfying
   `a ≤ X ≤ b` almost everywhere is at most`((b - a) / 2) ^ 2`.
 -/
 

--- a/Mathlib/Probability/Variance.lean
+++ b/Mathlib/Probability/Variance.lean
@@ -386,7 +386,7 @@ lemma variance_le_sub_mul_sub [IsProbabilityMeasure μ] {a b : ℝ} {X : Ω → 
 
 /-- **Popoviciu's inequality on variance**
 
-The variance of a random variable `X` satisfying `a ≤ X ≤ b`  almost everywhere is at most
+The variance of a random variable `X` satisfying `a ≤ X ≤ b` almost everywhere is at most
 `((b - a) / 2) ^ 2`. -/
 lemma variance_square_bounded [IsProbabilityMeasure μ] {a b : ℝ} {X : Ω → ℝ}
     (h : ∀ᵐ ω ∂μ, X ω ∈ Set.Icc a b) (hX : AEMeasurable X μ) :

--- a/Mathlib/Probability/Variance.lean
+++ b/Mathlib/Probability/Variance.lean
@@ -6,7 +6,6 @@ Authors: Sébastien Gouëzel, Kexing Ying
 import Mathlib.Probability.Notation
 import Mathlib.Probability.Integration
 import Mathlib.MeasureTheory.Function.L2Space
-import Mathlib.MeasureTheory.Function.LpSeminorm.Basic
 
 /-!
 # Variance of random variables

--- a/Mathlib/Probability/Variance.lean
+++ b/Mathlib/Probability/Variance.lean
@@ -379,7 +379,8 @@ lemma variance_square_bounded [IsProbabilityMeasure μ] {a b : ℝ} {X : Ω → 
         integral_congr_ae <| ae_of_all μ fun ω ↦ by ring
       _ = ∫ (ω : Ω), - X ω ^ 2 + (a + b) * X ω ∂μ - ∫ (_ : Ω), (a * b) ∂μ :=
         integral_sub (hX_int₁.add hX_int₂) (integrable_const (a * b))
-      _ = ∫ (ω : Ω), - X ω ^ 2 + (a + b) * X ω ∂μ - (a * b) := by simp
+      _ = ∫ (ω : Ω), - X ω ^ 2 + (a + b) * X ω ∂μ - (a * b) := by simp only [integral_const,
+        measure_univ, ENNReal.one_toReal, smul_eq_mul, one_mul]
       _ = - ∫ (ω : Ω), X ω ^ 2 ∂μ + (a + b) * ∫ (ω : Ω), X ω ∂μ - a * b := by
         simp only [sub_left_inj]
         rw [← integral_neg, ← integral_mul_left]

--- a/Mathlib/Probability/Variance.lean
+++ b/Mathlib/Probability/Variance.lean
@@ -30,9 +30,9 @@ We define the variance of a real-valued random variable as `Var[X] = 𝔼[(X - �
   random variables is the sum of the variances.
 * `ProbabilityTheory.IndepFun.variance_sum`: the variance of a finite sum of pairwise
   independent random variables is the sum of the variances.
-* `ProbabilityTheory.variance_le_sub_mul_sub`: The variance of a random variable `X`
-  satisfying `a ≤ X ≤ b` almost everywhere is at most `(b - 𝔼 X) * (𝔼 X - a)`.
-* `ProbabilityTheory.variance_le_sq_of_bounded`: The variance of a random variable `X` satisfying
+* `ProbabilityTheory.variance_le_sub_mul_sub`: the variance of a random variable `X` satisfying
+  `a ≤ X ≤ b` almost everywhere is at most `(b - 𝔼 X) * (𝔼 X - a)`.
+* `ProbabilityTheory.variance_le_sq_of_bounded`: the variance of a random variable `X` satisfying
   `a ≤ X ≤ b` almost everywhere is at most`((b - a) / 2) ^ 2`.
 -/
 

--- a/Mathlib/Probability/Variance.lean
+++ b/Mathlib/Probability/Variance.lean
@@ -346,7 +346,7 @@ theorem IndepFun.variance_sum [IsProbabilityMeasure μ] {ι : Type*} {X : ι →
 theorem abs_le_max_abs_abs_ae {a b : ℝ} {X : Ω → ℝ}
     (ha : ∀ᵐ (ω : Ω) ∂μ, a ≤ X ω) (hb : ∀ᵐ (ω : Ω) ∂μ, X ω ≤ b) :
     ∀ᵐ (ω : Ω) ∂μ, |X ω| ≤ max |a| |b| := by
-  filter_upwards [ha, hb] with ω using abs_le_max_abs_abs 
+  filter_upwards [ha, hb] with ω using abs_le_max_abs_abs
 
 theorem memℒp_of_bounded [IsFiniteMeasure μ]
     {a b : ℝ} {X : Ω → ℝ} (ha : ∀ᵐ (ω : Ω) ∂μ, a ≤ X ω) (hb : ∀ᵐ (ω : Ω) ∂μ, X ω ≤ b)

--- a/Mathlib/Probability/Variance.lean
+++ b/Mathlib/Probability/Variance.lean
@@ -346,8 +346,7 @@ theorem IndepFun.variance_sum [IsProbabilityMeasure μ] {ι : Type*} {X : ι →
 theorem abs_le_max_abs_abs_ae {a b : ℝ} {X : Ω → ℝ}
     (ha : ∀ᵐ (ω : Ω) ∂μ, a ≤ X ω) (hb : ∀ᵐ (ω : Ω) ∂μ, X ω ≤ b) :
     ∀ᵐ (ω : Ω) ∂μ, |X ω| ≤ max |a| |b| := by
-  filter_upwards [ha, hb] with ω ha hb
-  exact abs_le_max_abs_abs ha hb
+  filter_upwards [ha, hb] with ω using abs_le_max_abs_abs 
 
 theorem memℒp_of_bounded [IsFiniteMeasure μ]
     {a b : ℝ} {X : Ω → ℝ} (ha : ∀ᵐ (ω : Ω) ∂μ, a ≤ X ω) (hb : ∀ᵐ (ω : Ω) ∂μ, X ω ≤ b)

--- a/Mathlib/Probability/Variance.lean
+++ b/Mathlib/Probability/Variance.lean
@@ -354,10 +354,11 @@ theorem memℒp_of_bounded [IsFiniteMeasure μ]
   let c := max |a| |b|
   (memℒp_const c).mono' hX.aestronglyMeasurable (abs_le_max_abs_abs_ae ha hb)
 
-/-! ### Popvinciu's inequality on variances -/
-/--Variance is bounded by `((b - a) / 2) ^ 2`
-if almost everywhere real-valued measurable function `X` satisfies `a ≤ X ≤ b` almost everywhere.-/
 
+/-- ** Popoviciu's inequality on variance**
+
+The variance of a random variable `X` satisfying `a ≤ X ≤ b`  almost everywhere is at most
+`((b - a) / 2) ^ 2`. -/
 lemma variance_square_bounded [IsProbabilityMeasure μ] {a b : ℝ} {X : Ω → ℝ}
     (ha : ∀ᵐ ω ∂μ, a ≤ X ω) (hb : ∀ᵐ ω ∂μ, X ω ≤ b) (hX : AEMeasurable X μ) :
     variance X μ ≤ ((b - a) / 2) ^ 2 :=

--- a/Mathlib/Probability/Variance.lean
+++ b/Mathlib/Probability/Variance.lean
@@ -30,10 +30,11 @@ We define the variance of a real-valued random variable as `Var[X] = 𝔼[(X - �
   random variables is the sum of the variances.
 * `ProbabilityTheory.IndepFun.variance_sum`: the variance of a finite sum of pairwise
   independent random variables is the sum of the variances.
-* `Probability.variance_square_bounded`: Variance is bounded by `((b - a) / 2) ^ 2`
-  if almost everywhere real-valued measurable function `X` satisfies `a ≤ X ≤ b` almost everywhere.
+* `Probability.variance_le_sub_mul_sub`: The variance of a random variable `X`
+  satisfying `a ≤ X ≤ b` almost everywhere is at most `(b - 𝔼 X) * (𝔼 X - a)`.
+* `Probability.variance_le_sq_of_bounded`The variance of a random variable `X` satisfying
+  `a ≤ X ≤ b` almost everywhere is at most`((b - a) / 2) ^ 2`.
 -/
-
 
 open MeasureTheory Filter Finset
 

--- a/Mathlib/Probability/Variance.lean
+++ b/Mathlib/Probability/Variance.lean
@@ -344,7 +344,7 @@ theorem IndepFun.variance_sum [IsProbabilityMeasure μ] {ι : Type*} {X : ι →
       rw [IH (fun i hi => hs i (mem_insert_of_mem hi))
           (h.mono (by simp only [coe_insert, Set.subset_insert]))]
 
-/-- ** Popoviciu's inequality on variance**
+/-- **Popoviciu's inequality on variance**
 
 The variance of a random variable `X` satisfying `a ≤ X ≤ b`  almost everywhere is at most
 `((b - a) / 2) ^ 2`. -/


### PR DESCRIPTION
Formalize [Popoviciu's inequality on variances](https://en.wikipedia.org/wiki/Popoviciu%27s_inequality_on_variances) through the [Bhatia-Davis inequality](https://en.wikipedia.org/wiki/Bhatia%E2%80%93Davis_inequality).

Co-authored-by: Yuma Mizuno mizuno.y.aj@gmail.com