### PR TITLE
[Merged by Bors] - feat: variant of the binary AM-GM inequality

### DIFF
--- a/Mathlib/Algebra/Order/Ring/Unbundled/Basic.lean
+++ b/Mathlib/Algebra/Order/Ring/Unbundled/Basic.lean
@@ -761,6 +761,19 @@ lemma two_mul_le_add_sq [ExistsAddOfLE α] [MulPosStrictMono α]
 
 alias two_mul_le_add_pow_two := two_mul_le_add_sq
 
+lemma four_mul_le_add_sq [ExistsAddOfLE α] [MulPosStrictMono α]
+    [ContravariantClass α α (· + ·) (· ≤ ·)] [CovariantClass α α (· + ·) (· ≤ ·)]
+    (a b : α) : 4 * a * b ≤ (a + b) ^ 2 := by
+  calc 4 * a * b
+    _ = (2 + 2) * (a * b) := by rw [NonUnitalSemiring.mul_assoc, two_add_two_eq_four]
+    _ = 2 * (a * b) + 2 * (a * b) := by rw [RightDistribClass.right_distrib]
+    _ = 2 * a * b + 2 * a * b := by rw [NonUnitalSemiring.mul_assoc]
+    _ ≤ (a ^ 2 + b ^ 2) + 2 * a * b :=  by simp [add_le_add_right, two_mul_le_add_sq]
+    _ = a ^ 2 + 2 * a * b + b ^ 2 := by rw [add_right_comm]
+    _ = (a + b) ^ 2 := (add_sq a b).symm
+
+alias four_mul_le_add_pow_two := four_mul_le_add_sq
+
 end LinearOrderedCommSemiring
 
 section LinearOrderedRing

--- a/Mathlib/Algebra/Order/Ring/Unbundled/Basic.lean
+++ b/Mathlib/Algebra/Order/Ring/Unbundled/Basic.lean
@@ -768,7 +768,7 @@ lemma four_mul_le_add_sq [ExistsAddOfLE α] [MulPosStrictMono α]
     _ = (2 + 2) * (a * b) := by rw [NonUnitalSemiring.mul_assoc, two_add_two_eq_four]
     _ = 2 * (a * b) + 2 * (a * b) := by rw [RightDistribClass.right_distrib]
     _ = 2 * a * b + 2 * a * b := by rw [NonUnitalSemiring.mul_assoc]
-    _ ≤ (a ^ 2 + b ^ 2) + 2 * a * b :=  by simp [add_le_add_right, two_mul_le_add_sq]
+    _ ≤ a ^ 2 + b ^ 2 + 2 * a * b := by gcongr; exact two_mul_le_add_sq _ _
     _ = a ^ 2 + 2 * a * b + b ^ 2 := by rw [add_right_comm]
     _ = (a + b) ^ 2 := (add_sq a b).symm
 

--- a/Mathlib/Algebra/Order/Ring/Unbundled/Basic.lean
+++ b/Mathlib/Algebra/Order/Ring/Unbundled/Basic.lean
@@ -751,8 +751,6 @@ lemma max_mul_mul_le_max_mul_max [PosMulMono α] [MulPosMono α] (b c : α) (ha 
     mul_le_mul (le_max_right a c) (le_max_right b d) hd (le_trans ha (le_max_left a c))
   max_le (by simpa [mul_comm, max_comm] using ba) (by simpa [mul_comm, max_comm] using cd)
 
-/-- Binary **arithmetic mean-geometric mean inequality** (aka AM-GM inequality) for linearly ordered
-commutative semirings. -/
 lemma two_mul_le_add_sq [ExistsAddOfLE α] [MulPosStrictMono α]
     [ContravariantClass α α (· + ·) (· ≤ ·)] [CovariantClass α α (· + ·) (· ≤ ·)]
     (a b : α) : 2 * a * b ≤ a ^ 2 + b ^ 2 := by
@@ -761,11 +759,13 @@ lemma two_mul_le_add_sq [ExistsAddOfLE α] [MulPosStrictMono α]
 
 alias two_mul_le_add_pow_two := two_mul_le_add_sq
 
+/-- Binary **arithmetic mean-geometric mean inequality** (aka AM-GM inequality) for linearly ordered
+commutative semirings. -/
 lemma four_mul_le_add_sq [ExistsAddOfLE α] [MulPosStrictMono α]
     [ContravariantClass α α (· + ·) (· ≤ ·)] [CovariantClass α α (· + ·) (· ≤ ·)]
     (a b : α) : 4 * a * b ≤ (a + b) ^ 2 := by
   calc 4 * a * b
-    _ = 2 * a * b + 2 * a * b := by rw [mul_assoc, two_add_two_eq_four, add_mul, mul_assoc]
+    _ = 2 * a * b + 2 * a * b := by rw [mul_assoc, two_add_two_eq_four.symm, add_mul, mul_assoc]
     _ ≤ a ^ 2 + b ^ 2 + 2 * a * b := by gcongr; exact two_mul_le_add_sq _ _
     _ = a ^ 2 + 2 * a * b + b ^ 2 := by rw [add_right_comm]
     _ = (a + b) ^ 2 := (add_sq a b).symm

--- a/Mathlib/Algebra/Order/Ring/Unbundled/Basic.lean
+++ b/Mathlib/Algebra/Order/Ring/Unbundled/Basic.lean
@@ -763,7 +763,7 @@ alias two_mul_le_add_pow_two := two_mul_le_add_sq
 
 /-- Binary, squared, and division-free **arithmetic mean-geometric mean inequality**
 (aka AM-GM inequality) for linearly ordered commutative semirings. -/
-lemma four_mul_le_add_sq [ExistsAddOfLE α] [MulPosStrictMono α]
+lemma four_mul_le_sq_add [ExistsAddOfLE α] [MulPosStrictMono α]
     [ContravariantClass α α (· + ·) (· ≤ ·)] [CovariantClass α α (· + ·) (· ≤ ·)]
     (a b : α) : 4 * a * b ≤ (a + b) ^ 2 := by
   calc 4 * a * b
@@ -772,7 +772,7 @@ lemma four_mul_le_add_sq [ExistsAddOfLE α] [MulPosStrictMono α]
     _ = a ^ 2 + 2 * a * b + b ^ 2 := by rw [add_right_comm]
     _ = (a + b) ^ 2 := (add_sq a b).symm
 
-alias four_mul_le_add_pow_two := four_mul_le_add_sq
+alias four_mul_le_pow_two_add := four_mul_le_sq_add
 
 end LinearOrderedCommSemiring
 

--- a/Mathlib/Algebra/Order/Ring/Unbundled/Basic.lean
+++ b/Mathlib/Algebra/Order/Ring/Unbundled/Basic.lean
@@ -751,6 +751,8 @@ lemma max_mul_mul_le_max_mul_max [PosMulMono α] [MulPosMono α] (b c : α) (ha 
     mul_le_mul (le_max_right a c) (le_max_right b d) hd (le_trans ha (le_max_left a c))
   max_le (by simpa [mul_comm, max_comm] using ba) (by simpa [mul_comm, max_comm] using cd)
 
+/-- Binary, squared, and division-free **arithmetic mean-geometric mean inequality**
+(aka AM-GM inequality) for linearly ordered commutative semirings. -/
 lemma two_mul_le_add_sq [ExistsAddOfLE α] [MulPosStrictMono α]
     [ContravariantClass α α (· + ·) (· ≤ ·)] [CovariantClass α α (· + ·) (· ≤ ·)]
     (a b : α) : 2 * a * b ≤ a ^ 2 + b ^ 2 := by
@@ -759,8 +761,8 @@ lemma two_mul_le_add_sq [ExistsAddOfLE α] [MulPosStrictMono α]
 
 alias two_mul_le_add_pow_two := two_mul_le_add_sq
 
-/-- Binary **arithmetic mean-geometric mean inequality** (aka AM-GM inequality) for linearly ordered
-commutative semirings. -/
+/-- Binary, squared, and division-free **arithmetic mean-geometric mean inequality**
+(aka AM-GM inequality) for linearly ordered commutative semirings. -/
 lemma four_mul_le_add_sq [ExistsAddOfLE α] [MulPosStrictMono α]
     [ContravariantClass α α (· + ·) (· ≤ ·)] [CovariantClass α α (· + ·) (· ≤ ·)]
     (a b : α) : 4 * a * b ≤ (a + b) ^ 2 := by

--- a/Mathlib/Algebra/Order/Ring/Unbundled/Basic.lean
+++ b/Mathlib/Algebra/Order/Ring/Unbundled/Basic.lean
@@ -765,9 +765,7 @@ lemma four_mul_le_add_sq [ExistsAddOfLE α] [MulPosStrictMono α]
     [ContravariantClass α α (· + ·) (· ≤ ·)] [CovariantClass α α (· + ·) (· ≤ ·)]
     (a b : α) : 4 * a * b ≤ (a + b) ^ 2 := by
   calc 4 * a * b
-    _ = (2 + 2) * (a * b) := by rw [NonUnitalSemiring.mul_assoc, two_add_two_eq_four]
-    _ = 2 * (a * b) + 2 * (a * b) := by rw [RightDistribClass.right_distrib]
-    _ = 2 * a * b + 2 * a * b := by rw [NonUnitalSemiring.mul_assoc]
+    _ = 2 * a * b + 2 * a * b := by rw [mul_assoc, two_add_two_eq_four, add_mul, mul_assoc]
     _ ≤ a ^ 2 + b ^ 2 + 2 * a * b := by gcongr; exact two_mul_le_add_sq _ _
     _ = a ^ 2 + 2 * a * b + b ^ 2 := by rw [add_right_comm]
     _ = (a + b) ^ 2 := (add_sq a b).symm

--- a/Mathlib/Data/Nat/Cast/Defs.lean
+++ b/Mathlib/Data/Nat/Cast/Defs.lean
@@ -199,3 +199,7 @@ theorem three_add_one_eq_four [AddMonoidWithOne R] : 3 + 1 = (4 : R) := by
     ← Nat.cast_add, ← Nat.cast_add, ← Nat.cast_add]
   apply congrArg
   decide
+
+theorem two_add_two_eq_four [AddMonoidWithOne R] : 2 + 2 = (4 : R) := by
+  simp [← one_add_one_eq_two, ← Nat.cast_one, ← three_add_one_eq_four,
+    ← two_add_one_eq_three, add_assoc]


### PR DESCRIPTION
added variant of binary AM-GM inequality

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
