### PR TITLE
[Merged by Bors] - fix: improve line-wrapping of (D)Finsupp reprs

### DIFF
--- a/Mathlib/Data/DFinsupp/Notation.lean
+++ b/Mathlib/Data/DFinsupp/Notation.lean
@@ -68,9 +68,9 @@ unsafe instance {α : Type*} {β : α → Type*} [Repr α] [∀ i, Repr (β i)] 
     if vals.length = 0 then
       "0"
     else
-      let ret := "fun₀" ++
-        Std.Format.join (vals_dedup.map <|
-          fun a => f!" | " ++ a.1 ++ f!" => " ++ a.2)
+      let ret : Std.Format := "fun₀" ++
+        .group (.join <| vals_dedup.map fun a =>
+          .line ++ .group (f!"| " ++ a.1 ++ f!" =>" ++ .line ++ a.2))
       if p ≥ leadPrec then Format.paren ret else ret
 
 end DFinsupp

--- a/Mathlib/Data/DFinsupp/Notation.lean
+++ b/Mathlib/Data/DFinsupp/Notation.lean
@@ -44,13 +44,13 @@ def elabUpdate₀ : Elab.Term.TermElab
   | _ => fun _ => Elab.throwUnsupportedSyntax
 
 /-- Unexpander for the `fun₀ | i => x` notation. -/
-@[app_unexpander Finsupp.single]
+@[app_unexpander DFinsupp.single]
 def singleUnexpander : Lean.PrettyPrinter.Unexpander
   | `($_ $pat $val) => `(fun₀ | $pat => $val)
   | _ => throw ()
 
 /-- Unexpander for the `fun₀ | i => x` notation. -/
-@[app_unexpander Finsupp.update]
+@[app_unexpander DFinsupp.update]
 def updateUnexpander : Lean.PrettyPrinter.Unexpander
   | `($_ $f $pat $val) => match f with
     | `(fun₀ $xs:matchAlt*) => `(fun₀ $xs:matchAlt* | $pat => $val)
@@ -68,9 +68,9 @@ unsafe instance {α : Type*} {β : α → Type*} [Repr α] [∀ i, Repr (β i)] 
     if vals.length = 0 then
       "0"
     else
-      let ret : Std.Format := "fun₀" ++
+      let ret : Std.Format := f!"fun₀" ++ .nest 2 (
         .group (.join <| vals_dedup.map fun a =>
-          .line ++ .group (f!"| " ++ a.1 ++ f!" =>" ++ .line ++ a.2))
+          .line ++ .group (f!"| {a.1} =>" ++ .line ++ a.2)))
       if p ≥ leadPrec then Format.paren ret else ret
 
 end DFinsupp

--- a/Mathlib/Data/Finsupp/Notation.lean
+++ b/Mathlib/Data/Finsupp/Notation.lean
@@ -83,9 +83,9 @@ unsafe instance instRepr {α β} [Repr α] [Repr β] [Zero β] : Repr (α →₀
     if f.support.card = 0 then
       "0"
     else
-      let ret : Std.Format := "fun₀" ++
+      let ret : Std.Format := f!"fun₀" ++ .nest 2 (
         .group (.join <| f.support.val.unquot.map fun a =>
-          .line ++ .group (f!"| " ++ repr a ++ f!" =>" ++ .line ++ repr (f a)))
+          .line ++ .group (f!"| {repr a} =>" ++ .line ++ repr (f a))))
       if p ≥ leadPrec then Format.paren ret else ret
 
 -- This cannot be put in `Mathlib.Data.DFinsupp.Notation` where it belongs, since doc-strings

--- a/Mathlib/Data/Finsupp/Notation.lean
+++ b/Mathlib/Data/Finsupp/Notation.lean
@@ -83,9 +83,9 @@ unsafe instance instRepr {α β} [Repr α] [Repr β] [Zero β] : Repr (α →₀
     if f.support.card = 0 then
       "0"
     else
-      let ret := "fun₀" ++
-        Std.Format.join (f.support.val.unquot.map <|
-          fun a => " | " ++ repr a ++ " => " ++ repr (f a))
+      let ret : Std.Format := "fun₀" ++
+        .group (.join <| f.support.val.unquot.map fun a =>
+          .line ++ .group (f!"| " ++ repr a ++ f!" =>" ++ .line ++ repr (f a)))
       if p ≥ leadPrec then Format.paren ret else ret
 
 -- This cannot be put in `Mathlib.Data.DFinsupp.Notation` where it belongs, since doc-strings

--- a/test/dfinsupp_notation.lean
+++ b/test/dfinsupp_notation.lean
@@ -7,20 +7,23 @@ example : (fun₀ | 1 | 2 | 3 => 3 | 3 => 4 : Π₀ i, Fin (i + 10)) 1 = 3 := by
 example : (fun₀ | 1 | 2 | 3 => 3 | 3 => 4 : Π₀ i, Fin (i + 10)) 2 = 3 := by simp
 example : (fun₀ | 1 | 2 | 3 => 3 | 3 => 4 : Π₀ i, Fin (i + 10)) 3 = 4 := by simp
 
-/--
-info:
--/
+/-- info: (DFinsupp.single 1 3).update 2 3 : Π₀ (i : ℕ), Fin (i + 10) -/
 #guard_msgs in
-#eval show Lean.MetaM Unit from
-  guard <|
-    reprStr (fun₀ | 1 => 3 | 2 => 3 : Π₀ i, Fin (i + 10))
-      = "fun₀ | 1 => 3 | 2 => 3"
+#check (fun₀ | 1 => 3 | 2 => 3 : Π₀ i, Fin (i + 10))
+
+/-- info: fun₀ | 2 => 7 -/
+#guard_msgs in
+#eval ((fun₀ | 1 => 3 | 2 => 3) + (fun₀ | 1 => -3 | 2 => 4) : Π₀ _, ℤ)
 
 /--
 info:
+fun₀
+| ["there are five words here", "and five more words here"] => 5
+| ["there are seven words but only here"] => 7
+| ["just two"] => 2
 -/
 #guard_msgs in
-#eval show Lean.MetaM Unit from
-  guard <|
-    reprStr ((fun₀ | 1 => 3 | 2 => 3) + (fun₀ | 1 => -3 | 2 => 4) : Π₀ _, ℤ)
-      = "fun₀ | 2 => 7"
+#eval (fun₀
+    | ["there are five words here", "and five more words here"] => 5
+    | ["there are seven words but only here"] => 7
+    | ["just two"] => 2 : Π₀ _ : List String, ℕ)

--- a/test/dfinsupp_notation.lean
+++ b/test/dfinsupp_notation.lean
@@ -7,7 +7,9 @@ example : (fun₀ | 1 | 2 | 3 => 3 | 3 => 4 : Π₀ i, Fin (i + 10)) 1 = 3 := by
 example : (fun₀ | 1 | 2 | 3 => 3 | 3 => 4 : Π₀ i, Fin (i + 10)) 2 = 3 := by simp
 example : (fun₀ | 1 | 2 | 3 => 3 | 3 => 4 : Π₀ i, Fin (i + 10)) 3 = 4 := by simp
 
-/-- info: (DFinsupp.single 1 3).update 2 3 : Π₀ (i : ℕ), Fin (i + 10) -/
+section Repr
+
+/-- info: fun₀ | 1 => 3 | 2 => 3 : Π₀ (i : ℕ), Fin (i + 10) -/
 #guard_msgs in
 #check (fun₀ | 1 => 3 | 2 => 3 : Π₀ i, Fin (i + 10))
 
@@ -16,14 +18,30 @@ example : (fun₀ | 1 | 2 | 3 => 3 | 3 => 4 : Π₀ i, Fin (i + 10)) 3 = 4 := by
 #eval ((fun₀ | 1 => 3 | 2 => 3) + (fun₀ | 1 => -3 | 2 => 4) : Π₀ _, ℤ)
 
 /--
-info:
-fun₀
-| ["there are five words here", "and five more words here"] => 5
-| ["there are seven words but only here"] => 7
-| ["just two"] => 2
+info: fun₀
+  | ["there are five words here", "and five more words here"] => 5
+  | ["there are seven words but only here"] => 7
+  | ["just two"] => 2
 -/
 #guard_msgs in
 #eval (fun₀
     | ["there are five words here", "and five more words here"] => 5
     | ["there are seven words but only here"] => 7
     | ["just two"] => 2 : Π₀ _ : List String, ℕ)
+
+end Repr
+section PrettyPrinter
+
+/--
+info: fun₀
+  | ["there are five words here", "and five more words here"] => 5
+  | ["there are seven words but only here"] => 7
+  | ["just two"] => 2 : Π₀ (i : List String), ℕ
+-/
+#guard_msgs in
+#check (fun₀
+    | ["there are five words here", "and five more words here"] => 5
+    | ["there are seven words but only here"] => 7
+    | ["just two"] => 2 : Π₀ _ : List String, ℕ)
+
+end PrettyPrinter

--- a/test/finsupp_notation.lean
+++ b/test/finsupp_notation.lean
@@ -19,11 +19,10 @@ section repr
 #eval (Finsupp.mk {1, 2} (fun | 1 | 2 => 3 | _ => 0) (fun x => by aesop))
 
 /--
-info:
-fun₀
-| ["there are five words here", "and five more words here"] => 5
-| ["there are seven words but only here"] => 7
-| ["just two"] => 2
+info: fun₀
+  | ["there are five words here", "and five more words here"] => 5
+  | ["there are seven words but only here"] => 7
+  | ["just two"] => 2
 -/
 #guard_msgs in
 #eval Finsupp.mk

--- a/test/finsupp_notation.lean
+++ b/test/finsupp_notation.lean
@@ -12,14 +12,49 @@ example : (fun₀ | 1 | 2 | 3 => 3 | 3 => 4) 2 = 3 := by
 example : (fun₀ | 1 | 2 | 3 => 3 | 3 => 4) 3 = 4 := by
   simp
 
+section repr
+
+/-- info: fun₀ | 1 => 3 | 2 => 3 -/
+#guard_msgs in
+#eval (Finsupp.mk {1, 2} (fun | 1 | 2 => 3 | _ => 0) (fun x => by aesop))
+
 /--
 info:
+fun₀
+| ["there are five words here", "and five more words here"] => 5
+| ["there are seven words but only here"] => 7
+| ["just two"] => 2
 -/
 #guard_msgs in
-#eval show Lean.MetaM Unit from
-  guard <|
-    reprStr (Finsupp.mk {1, 2} (fun | 1 | 2 => 3 | _ => 0) (fun x => by aesop))
-      = "fun₀ | 1 => 3 | 2 => 3"
+#eval Finsupp.mk
+  {["there are five words here", "and five more words here"],
+   ["there are seven words but only here"],
+   ["just two"]}
+  (fun
+    | ["there are five words here", "and five more words here"] => 5
+    | ["there are seven words but only here"] => 7
+    | ["just two"] => 2
+    | _ => 0)
+  (fun x => by aesop)
+
+end repr
+
+section PrettyPrinter
+
+/--
+info: fun₀
+  | ["there are five words here", "and five more words here"] => 5
+  | ["there are seven words but only here"] => 7
+  | ["just two"] => 2 : List String →₀ ℕ
+-/
+#guard_msgs in
+#check fun₀
+    | ["there are five words here", "and five more words here"] => 5
+    | ["there are seven words but only here"] => 7
+    | ["just two"] => 2
+
+end PrettyPrinter
+
 
 /-! ## (computable) number theory examples -/
 


### PR DESCRIPTION
These were previously wrapping very poorly.

Also update tests to use `#guard_msgs` more effectively, and fix a typo in the delaborators for DFinsupp.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
