### PR TITLE
[Merged by Bors] - feat: Multiset.pow_smul_esymm

### DIFF
--- a/Mathlib/RingTheory/MvPolynomial/Symmetric/Defs.lean
+++ b/Mathlib/RingTheory/MvPolynomial/Symmetric/Defs.lean
@@ -71,6 +71,15 @@ theorem _root_.Finset.esymm_map_val {σ} (f : σ → R) (s : Finset σ) (n : ℕ
   simp only [esymm, powersetCard_map, ← Finset.map_val_val_powersetCard, map_map]
   rfl
 
+lemma pow_smul_esymm {S : Type*} [Monoid S] [DistribMulAction S R] [IsScalarTower S R R]
+    [SMulCommClass S R R] (s : S) (n : ℕ) (m : Multiset R) :
+    s ^ n • m.esymm n = (m.map (s • ·)).esymm n := by
+  rw [esymm, smul_sum, map_map]
+  trans ((powersetCard n m).map (fun x : Multiset R ↦ s ^ card x • x.prod)).sum
+  · refine congr_arg _ (map_congr rfl (fun x hx ↦ ?_))
+    rw [Function.comp_apply, (mem_powersetCard.1 hx).2]
+  · simp_rw [smul_prod, esymm, powersetCard_map, map_map, Function.comp_def]
+
 end Multiset
 
 namespace MvPolynomial


### PR DESCRIPTION
Co-authored-by: FR <zhao.yu-yang@foxmail.com>

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

From #6718.

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
