### PR TITLE
[Merged by Bors] - feat: `Disjoint (a • s) t ↔ Disjoint s (a⁻¹ • t)`

### DIFF
--- a/Mathlib/Data/Set/Pointwise/SMul.lean
+++ b/Mathlib/Data/Set/Pointwise/SMul.lean
@@ -400,9 +400,22 @@ lemma inv_smul_set_distrib (a : α) (s : Set α) : (a • s)⁻¹ = op a⁻¹ �
 lemma inv_op_smul_set_distrib (a : α) (s : Set α) : (op a • s)⁻¹ = a⁻¹ • s⁻¹ := by
   ext; simp [mem_smul_set_iff_inv_smul_mem]
 
+@[to_additive]
+lemma disjoint_smul_set_left : Disjoint (a • s) t ↔ Disjoint s (a⁻¹ • t) := by
+  simp_rw [disjoint_left]
+  exact (MulAction.surjective a).forall.trans (by simp [mem_inv_smul_set_iff])
+
+@[to_additive]
+lemma disjoint_smul_set_right : Disjoint s (a • t) ↔ Disjoint (a⁻¹ • s) t := by
+  simp_rw [disjoint_left]
+  exact (MulAction.surjective a).forall.trans (by simp [mem_inv_smul_set_iff])
+
 @[to_additive (attr := simp)]
-lemma smul_set_disjoint_iff : Disjoint (a • s) (a • t) ↔ Disjoint s t := by
-  simp [disjoint_iff, ← smul_set_inter]
+lemma disjoint_smul_set : Disjoint (a • s) (a • t) ↔ Disjoint s t := by
+  simp [disjoint_smul_set_left]
+
+@[to_additive (attr := deprecated (since := "2024-10-18"))]
+alias smul_set_disjoint_iff := disjoint_smul_set
 
 end Group
 

--- a/Mathlib/Data/Set/Pointwise/SMul.lean
+++ b/Mathlib/Data/Set/Pointwise/SMul.lean
@@ -400,19 +400,17 @@ lemma inv_smul_set_distrib (a : α) (s : Set α) : (a • s)⁻¹ = op a⁻¹ �
 lemma inv_op_smul_set_distrib (a : α) (s : Set α) : (op a • s)⁻¹ = a⁻¹ • s⁻¹ := by
   ext; simp [mem_smul_set_iff_inv_smul_mem]
 
+@[to_additive (attr := simp)]
+lemma disjoint_smul_set : Disjoint (a • s) (a • t) ↔ Disjoint s t :=
+  disjoint_image_iff <| MulAction.injective _
+
 @[to_additive]
 lemma disjoint_smul_set_left : Disjoint (a • s) t ↔ Disjoint s (a⁻¹ • t) := by
-  simp_rw [disjoint_left]
-  exact (MulAction.surjective a).forall.trans (by simp [mem_inv_smul_set_iff])
+  simpa using disjoint_smul_set (a := a) (t := a⁻¹ • t)
 
 @[to_additive]
 lemma disjoint_smul_set_right : Disjoint s (a • t) ↔ Disjoint (a⁻¹ • s) t := by
-  simp_rw [disjoint_left]
-  exact (MulAction.surjective a).forall.trans (by simp [mem_inv_smul_set_iff])
-
-@[to_additive (attr := simp)]
-lemma disjoint_smul_set : Disjoint (a • s) (a • t) ↔ Disjoint s t := by
-  simp [disjoint_smul_set_left]
+  simpa using disjoint_smul_set (a := a) (s := a⁻¹ • s)
 
 @[to_additive (attr := deprecated (since := "2024-10-18"))]
 alias smul_set_disjoint_iff := disjoint_smul_set

--- a/Mathlib/Data/Set/Pointwise/SMul.lean
+++ b/Mathlib/Data/Set/Pointwise/SMul.lean
@@ -330,7 +330,7 @@ theorem smul_set_inter : a • (s ∩ t) = a • s ∩ a • t :=
   image_inter <| MulAction.injective a
 
 @[to_additive]
-theorem smul_set_iInter {ι : Type*}
+theorem smul_set_iInter {ι : Sort*}
     (a : α) (t : ι → Set β) : (a • ⋂ i, t i) = ⋂ i, a • t i :=
   image_iInter (MulAction.bijective a) t
 


### PR DESCRIPTION

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
