### PR TITLE
[Merged by Bors] - chore(ConditionalProbability): review argument implicitness

### DIFF
--- a/Archive/Wiedijk100Theorems/BallotProblem.lean
+++ b/Archive/Wiedijk100Theorems/BallotProblem.lean
@@ -216,7 +216,7 @@ theorem first_vote_pos :
         rw [inter_eq_right, counted_succ_succ]
         exact subset_union_left
       rw [(uniformOn_eq_zero_iff <| (countedSequence_finite _ _).image _).2 this, uniformOn,
-        cond_apply _ list_int_measurableSet, hint, count_injective_image List.cons_injective,
+        cond_apply list_int_measurableSet, hint, count_injective_image List.cons_injective,
         count_countedSequence, count_countedSequence, one_mul, zero_mul, add_zero,
         Nat.cast_add, Nat.cast_one, mul_comm, ← div_eq_mul_inv, ENNReal.div_eq_div_iff]
       · norm_cast
@@ -270,7 +270,7 @@ theorem ballot_pos (p q : ℕ) :
     uniformOn (countedSequence (p + 1) (q + 1) ∩ {l | l.headI = 1}) staysPositive =
       uniformOn (countedSequence p (q + 1)) staysPositive := by
   rw [countedSequence_int_pos_counted_succ_succ, uniformOn, uniformOn,
-    cond_apply _ list_int_measurableSet, cond_apply _ list_int_measurableSet,
+    cond_apply list_int_measurableSet, cond_apply list_int_measurableSet,
     count_injective_image List.cons_injective]
   congr 1
   have : (1 :: ·) '' countedSequence p (q + 1) ∩ staysPositive =
@@ -297,7 +297,7 @@ theorem ballot_neg (p q : ℕ) (qp : q < p) :
     uniformOn (countedSequence (p + 1) (q + 1) ∩ {l | l.headI = 1}ᶜ) staysPositive =
       uniformOn (countedSequence (p + 1) q) staysPositive := by
   rw [countedSequence_int_neg_counted_succ_succ, uniformOn, uniformOn,
-    cond_apply _ list_int_measurableSet, cond_apply _ list_int_measurableSet,
+    cond_apply list_int_measurableSet, cond_apply list_int_measurableSet,
     count_injective_image List.cons_injective]
   congr 1
   have : List.cons (-1) '' countedSequence (p + 1) q ∩ staysPositive =

--- a/Mathlib/Probability/ConditionalProbability.lean
+++ b/Mathlib/Probability/ConditionalProbability.lean
@@ -58,20 +58,17 @@ noncomputable section
 
 open ENNReal MeasureTheory MeasureTheory.Measure MeasurableSpace Set
 
-variable {Ω Ω' α : Type*} {m : MeasurableSpace Ω} {m' : MeasurableSpace Ω'} (μ : Measure Ω)
+variable {Ω Ω' α : Type*} {m : MeasurableSpace Ω} {m' : MeasurableSpace Ω'} {μ : Measure Ω}
   {s t : Set Ω}
 
 namespace ProbabilityTheory
 
-section Definitions
-
+variable (μ) in
 /-- The conditional probability measure of measure `μ` on set `s` is `μ` restricted to `s`
 and scaled by the inverse of `μ s` (to make it a probability measure):
 `(μ s)⁻¹ • μ.restrict s`. -/
 def cond (s : Set Ω) : Measure Ω :=
   (μ s)⁻¹ • μ.restrict s
-
-end Definitions
 
 @[inherit_doc] scoped notation μ "[" s "|" t "]" => ProbabilityTheory.cond μ t s
 @[inherit_doc] scoped notation:max μ "[|" t "]" => ProbabilityTheory.cond μ t
@@ -95,7 +92,7 @@ theorem cond_isProbabilityMeasure_of_finite (hcs : μ s ≠ 0) (hs : μ s ≠ �
 /-- The conditional probability measure of any finite measure on any set of positive measure
 is a probability measure. -/
 theorem cond_isProbabilityMeasure [IsFiniteMeasure μ] (hcs : μ s ≠ 0) :
-    IsProbabilityMeasure μ[|s] := cond_isProbabilityMeasure_of_finite μ hcs (measure_ne_top μ s)
+    IsProbabilityMeasure μ[|s] := cond_isProbabilityMeasure_of_finite hcs (measure_ne_top μ s)
 
 instance : IsZeroOrProbabilityMeasure μ[|s] := by
   constructor
@@ -107,6 +104,7 @@ instance : IsZeroOrProbabilityMeasure μ[|s] := by
   · simp [h']
   simp [ENNReal.div_self h h']
 
+variable (μ) in
 theorem cond_toMeasurable_eq :
     μ[|(toMeasurable μ s)] = μ[|s] := by
   unfold cond
@@ -114,11 +112,9 @@ theorem cond_toMeasurable_eq :
   · simp [hnt]
   · simp [Measure.restrict_toMeasurable hnt]
 
-variable {μ} in
 lemma cond_absolutelyContinuous : μ[|s] ≪ μ :=
   smul_absolutelyContinuous.trans restrict_le_self.absolutelyContinuous
 
-variable {μ} in
 lemma absolutelyContinuous_cond_univ [IsFiniteMeasure μ] : μ ≪ μ[|univ] := by
   rw [cond, restrict_univ]
   refine absolutelyContinuous_smul ?_
@@ -126,11 +122,11 @@ lemma absolutelyContinuous_cond_univ [IsFiniteMeasure μ] : μ ≪ μ[|univ] := 
 
 section Bayes
 
-@[simp]
-theorem cond_empty : μ[|∅] = 0 := by simp [cond]
+variable (μ) in
+@[simp] lemma cond_empty : μ[|∅] = 0 := by simp [cond]
 
-@[simp]
-theorem cond_univ [IsProbabilityMeasure μ] : μ[|Set.univ] = μ := by
+variable (μ) in
+@[simp] lemma cond_univ [IsProbabilityMeasure μ] : μ[|Set.univ] = μ := by
   simp [cond, measure_univ, Measure.restrict_univ]
 
 @[simp] lemma cond_eq_zero (hμs : μ s ≠ ⊤) : μ[|s] = 0 ↔ μ s = 0 := by simp [cond, hμs]
@@ -138,33 +134,35 @@ theorem cond_univ [IsProbabilityMeasure μ] : μ[|Set.univ] = μ := by
 lemma cond_eq_zero_of_meas_eq_zero (hμs : μ s = 0) : μ[|s] = 0 := by simp [hμs]
 
 /-- The axiomatic definition of conditional probability derived from a measure-theoretic one. -/
-theorem cond_apply (hms : MeasurableSet s) (t : Set Ω) : μ[t|s] = (μ s)⁻¹ * μ (s ∩ t) := by
+theorem cond_apply (hms : MeasurableSet s) (μ : Measure Ω) (t : Set Ω) :
+    μ[t|s] = (μ s)⁻¹ * μ (s ∩ t) := by
   rw [cond, Measure.smul_apply, Measure.restrict_apply' hms, Set.inter_comm, smul_eq_mul]
 
-theorem cond_apply' {t : Set Ω} (hA : MeasurableSet t) : μ[t|s] = (μ s)⁻¹ * μ (s ∩ t) := by
-  rw [cond, Measure.smul_apply, Measure.restrict_apply hA, Set.inter_comm, smul_eq_mul]
+theorem cond_apply' (ht : MeasurableSet t) (μ : Measure Ω) : μ[t|s] = (μ s)⁻¹ * μ (s ∩ t) := by
+  rw [cond, Measure.smul_apply, Measure.restrict_apply ht, Set.inter_comm, smul_eq_mul]
 
 @[simp] lemma cond_apply_self (hs₀ : μ s ≠ 0) (hs : μ s ≠ ∞) : μ[s|s] = 1 := by
   simpa [cond] using ENNReal.inv_mul_cancel hs₀ hs
 
-theorem cond_inter_self (hms : MeasurableSet s) (t : Set Ω) : μ[s ∩ t|s] = μ[t|s] := by
-  rw [cond_apply _ hms, ← Set.inter_assoc, Set.inter_self, ← cond_apply _ hms]
+theorem cond_inter_self (hms : MeasurableSet s) (t : Set Ω) (μ : Measure Ω) :
+    μ[s ∩ t|s] = μ[t|s] := by
+  rw [cond_apply hms, ← Set.inter_assoc, Set.inter_self, ← cond_apply hms]
 
 theorem inter_pos_of_cond_ne_zero (hms : MeasurableSet s) (hcst : μ[t|s] ≠ 0) : 0 < μ (s ∩ t) := by
   refine pos_iff_ne_zero.mpr (right_ne_zero_of_mul (a := (μ s)⁻¹) ?_)
   convert hcst
   simp [hms, Set.inter_comm, cond]
 
-theorem cond_pos_of_inter_ne_zero [IsFiniteMeasure μ]
-    (hms : MeasurableSet s) (hci : μ (s ∩ t) ≠ 0) : 0 < μ[|s] t := by
-  rw [cond_apply _ hms]
+lemma cond_pos_of_inter_ne_zero [IsFiniteMeasure μ] (hms : MeasurableSet s) (hci : μ (s ∩ t) ≠ 0) :
+    0 < μ[|s] t := by
+  rw [cond_apply hms]
   refine ENNReal.mul_pos ?_ hci
   exact ENNReal.inv_ne_zero.mpr (measure_ne_top _ _)
 
 lemma cond_cond_eq_cond_inter' (hms : MeasurableSet s) (hmt : MeasurableSet t) (hcs : μ s ≠ ∞) :
     μ[|s][|t] = μ[|s ∩ t] := by
   ext u
-  rw [cond_apply _ hmt, cond_apply _ hms, cond_apply _ hms, cond_apply _ (hms.inter hmt)]
+  rw [cond_apply hmt, cond_apply hms, cond_apply hms, cond_apply (hms.inter hmt)]
   obtain hst | hst := eq_or_ne (μ (s ∩ t)) 0
   · have : μ (s ∩ t ∩ u) = 0 := measure_mono_null Set.inter_subset_left hst
     simp [this, ← Set.inter_assoc]
@@ -175,30 +173,30 @@ lemma cond_cond_eq_cond_inter' (hms : MeasurableSet s) (hmt : MeasurableSet t) (
 
 /-- Conditioning first on `s` and then on `t` results in the same measure as conditioning
 on `s ∩ t`. -/
-theorem cond_cond_eq_cond_inter [IsFiniteMeasure μ] (hms : MeasurableSet s)
-    (hmt : MeasurableSet t) : μ[|s][|t] = μ[|s ∩ t] :=
-  cond_cond_eq_cond_inter' μ hms hmt (measure_ne_top μ s)
+theorem cond_cond_eq_cond_inter (hms : MeasurableSet s) (hmt : MeasurableSet t) (μ : Measure Ω)
+    [IsFiniteMeasure μ] : μ[|s][|t] = μ[|s ∩ t] :=
+  cond_cond_eq_cond_inter' hms hmt (measure_ne_top μ s)
 
 theorem cond_mul_eq_inter' (hms : MeasurableSet s) (hcs' : μ s ≠ ∞) (t : Set Ω) :
     μ[t|s] * μ s = μ (s ∩ t) := by
   obtain hcs | hcs := eq_or_ne (μ s) 0
   · simp [hcs, measure_inter_null_of_null_left]
-  · rw [cond_apply μ hms t, mul_comm, ← mul_assoc, ENNReal.mul_inv_cancel hcs hcs', one_mul]
+  · rw [cond_apply hms, mul_comm, ← mul_assoc, ENNReal.mul_inv_cancel hcs hcs', one_mul]
 
-theorem cond_mul_eq_inter [IsFiniteMeasure μ] (hms : MeasurableSet s) (t : Set Ω) :
-    μ[t|s] * μ s = μ (s ∩ t) := cond_mul_eq_inter' μ hms (measure_ne_top _ s) t
+theorem cond_mul_eq_inter (hms : MeasurableSet s) (t : Set Ω) (μ : Measure Ω) [IsFiniteMeasure μ] :
+    μ[t|s] * μ s = μ (s ∩ t) := cond_mul_eq_inter' hms (measure_ne_top _ s) t
 
 /-- A version of the law of total probability. -/
-theorem cond_add_cond_compl_eq [IsFiniteMeasure μ] (hms : MeasurableSet s) :
+theorem cond_add_cond_compl_eq (hms : MeasurableSet s) (μ : Measure Ω) [IsFiniteMeasure μ] :
     μ[t|s] * μ s + μ[t|sᶜ] * μ sᶜ = μ t := by
-  rw [cond_mul_eq_inter μ hms, cond_mul_eq_inter μ hms.compl, Set.inter_comm _ t,
+  rw [cond_mul_eq_inter hms, cond_mul_eq_inter hms.compl, Set.inter_comm _ t,
     Set.inter_comm _ t]
   exact measure_inter_add_diff t hms
 
 /-- **Bayes' Theorem** -/
-theorem cond_eq_inv_mul_cond_mul [IsFiniteMeasure μ]
-    (hms : MeasurableSet s) (hmt : MeasurableSet t) : μ[t|s] = (μ s)⁻¹ * μ[s|t] * μ t := by
-  rw [mul_assoc, cond_mul_eq_inter μ hmt s, Set.inter_comm, cond_apply _ hms]
+theorem cond_eq_inv_mul_cond_mul (hms : MeasurableSet s) (hmt : MeasurableSet t) (μ : Measure Ω)
+    [IsFiniteMeasure μ] : μ[t|s] = (μ s)⁻¹ * μ[s|t] * μ t := by
+  rw [mul_assoc, cond_mul_eq_inter hmt s, Set.inter_comm, cond_apply hms]
 
 end Bayes
 
@@ -229,7 +227,7 @@ lemma sum_meas_smul_cond_fiber {X : Ω → α} (hX : Measurable X) (μ : Measure
     _ = ∑ x, μ (X ⁻¹' {x} ∩ E) := by
       simp only [Measure.coe_finset_sum, Measure.coe_smul, Finset.sum_apply,
         Pi.smul_apply, smul_eq_mul]
-      simp_rw [mul_comm (μ _), cond_mul_eq_inter _ (hX (.singleton _))]
+      simp_rw [mul_comm (μ _), cond_mul_eq_inter (hX (.singleton _))]
     _ = _ := by
       have : ⋃ x ∈ Finset.univ, X ⁻¹' {x} ∩ E = E := by ext; simp
       rw [← measure_biUnion_finset _ fun _ _ ↦ (hX (.singleton _)).inter hE, this]

--- a/Mathlib/Probability/UniformOn.lean
+++ b/Mathlib/Probability/UniformOn.lean
@@ -79,7 +79,7 @@ alias finite_of_condCount_ne_zero := finite_of_uniformOn_ne_zero
 
 theorem uniformOn_univ [Fintype Ω] {s : Set Ω} :
     uniformOn Set.univ s = Measure.count s / Fintype.card Ω := by
-  rw [uniformOn, cond_apply _ MeasurableSet.univ, ← ENNReal.div_eq_inv_mul, Set.univ_inter]
+  rw [uniformOn, cond_apply MeasurableSet.univ, ← ENNReal.div_eq_inv_mul, Set.univ_inter]
   congr
   rw [← Finset.coe_univ, Measure.count_apply, Finset.univ.tsum_subtype' fun _ => (1 : ENNReal)]
   · simp [Finset.card_univ]
@@ -101,7 +101,7 @@ alias condCount_isProbabilityMeasure := uniformOn_isProbabilityMeasure
 
 theorem uniformOn_singleton (ω : Ω) (t : Set Ω) [Decidable (ω ∈ t)] :
     uniformOn {ω} t = if ω ∈ t then 1 else 0 := by
-  rw [uniformOn, cond_apply _ (measurableSet_singleton ω), Measure.count_singleton, inv_one,
+  rw [uniformOn, cond_apply (measurableSet_singleton ω), Measure.count_singleton, inv_one,
     one_mul]
   split_ifs
   · rw [(by simpa : ({ω} : Set Ω) ∩ t = {ω}), Measure.count_singleton]
@@ -113,13 +113,13 @@ alias condCount_singleton := uniformOn_singleton
 variable {s t u : Set Ω}
 
 theorem uniformOn_inter_self (hs : s.Finite) : uniformOn s (s ∩ t) = uniformOn s t := by
-  rw [uniformOn, cond_inter_self _ hs.measurableSet]
+  rw [uniformOn, cond_inter_self hs.measurableSet]
 
 @[deprecated (since := "2024-10-09")]
 alias condCount_inter_self := uniformOn_inter_self
 
 theorem uniformOn_self (hs : s.Finite) (hs' : s.Nonempty) : uniformOn s s = 1 := by
-  rw [uniformOn, cond_apply _ hs.measurableSet, Set.inter_self, ENNReal.inv_mul_cancel]
+  rw [uniformOn, cond_apply hs.measurableSet, Set.inter_self, ENNReal.inv_mul_cancel]
   · exact fun h => hs'.ne_empty <| Measure.empty_of_count_eq_zero h
   · exact (Measure.count_apply_lt_top.2 hs).ne
 
@@ -138,7 +138,7 @@ alias condCount_eq_one_of := uniformOn_eq_one_of
 
 theorem pred_true_of_uniformOn_eq_one (h : uniformOn s t = 1) : s ⊆ t := by
   have hsf := finite_of_uniformOn_ne_zero (by rw [h]; exact one_ne_zero)
-  rw [uniformOn, cond_apply _ hsf.measurableSet, mul_comm] at h
+  rw [uniformOn, cond_apply hsf.measurableSet, mul_comm] at h
   replace h := ENNReal.eq_inv_of_mul_eq_one_left h
   rw [inv_inv, Measure.count_apply_finite _ hsf, Measure.count_apply_finite _ (hsf.inter_of_left _),
     Nat.cast_inj] at h
@@ -150,7 +150,7 @@ theorem pred_true_of_uniformOn_eq_one (h : uniformOn s t = 1) : s ⊆ t := by
 alias pred_true_of_condCount_eq_one := pred_true_of_uniformOn_eq_one
 
 theorem uniformOn_eq_zero_iff (hs : s.Finite) : uniformOn s t = 0 ↔ s ∩ t = ∅ := by
-  simp [uniformOn, cond_apply _ hs.measurableSet, Measure.count_apply_eq_top, Set.not_infinite.2 hs,
+  simp [uniformOn, cond_apply hs.measurableSet, Measure.count_apply_eq_top, Set.not_infinite.2 hs,
     Measure.count_apply_finite _ (hs.inter_of_left _)]
 
 @[deprecated (since := "2024-10-09")]
@@ -167,8 +167,8 @@ theorem uniformOn_inter (hs : s.Finite) :
   by_cases hst : s ∩ t = ∅
   · rw [hst, uniformOn_empty_meas, Measure.coe_zero, Pi.zero_apply, zero_mul,
       uniformOn_eq_zero_iff hs, ← Set.inter_assoc, hst, Set.empty_inter]
-  rw [uniformOn, uniformOn, cond_apply _ hs.measurableSet, cond_apply _ hs.measurableSet,
-    cond_apply _ (hs.inter_of_left _).measurableSet, mul_comm _ (Measure.count (s ∩ t)),
+  rw [uniformOn, uniformOn, cond_apply hs.measurableSet, cond_apply hs.measurableSet,
+    cond_apply (hs.inter_of_left _).measurableSet, mul_comm _ (Measure.count (s ∩ t)),
     ← mul_assoc, mul_comm _ (Measure.count (s ∩ t)), ← mul_assoc, ENNReal.mul_inv_cancel, one_mul,
     mul_comm, Set.inter_assoc]
   · rwa [← Measure.count_eq_zero_iff] at hst
@@ -187,8 +187,8 @@ alias condCount_inter' := uniformOn_inter'
 
 theorem uniformOn_union (hs : s.Finite) (htu : Disjoint t u) :
     uniformOn s (t ∪ u) = uniformOn s t + uniformOn s u := by
-  rw [uniformOn, cond_apply _ hs.measurableSet, cond_apply _ hs.measurableSet,
-    cond_apply _ hs.measurableSet, Set.inter_union_distrib_left, measure_union, mul_add]
+  rw [uniformOn, cond_apply hs.measurableSet, cond_apply hs.measurableSet,
+    cond_apply hs.measurableSet, Set.inter_union_distrib_left, measure_union, mul_add]
   exacts [htu.mono inf_le_right inf_le_right, (hs.inter_of_left _).measurableSet]
 
 @[deprecated (since := "2024-10-09")]
@@ -209,9 +209,9 @@ theorem uniformOn_disjoint_union (hs : s.Finite) (ht : t.Finite) (hst : Disjoint
   · simp
   · simp [uniformOn_self ht ht']
   · simp [uniformOn_self hs hs']
-  rw [uniformOn, uniformOn, uniformOn, cond_apply _ hs.measurableSet,
-    cond_apply _ ht.measurableSet, cond_apply _ (hs.union ht).measurableSet,
-    cond_apply _ (hs.union ht).measurableSet, cond_apply _ (hs.union ht).measurableSet]
+  rw [uniformOn, uniformOn, uniformOn, cond_apply hs.measurableSet,
+    cond_apply ht.measurableSet, cond_apply (hs.union ht).measurableSet,
+    cond_apply (hs.union ht).measurableSet, cond_apply (hs.union ht).measurableSet]
   conv_lhs =>
     rw [Set.union_inter_cancel_left, Set.union_inter_cancel_right,
       mul_comm (Measure.count (s ∪ t))⁻¹, mul_comm (Measure.count (s ∪ t))⁻¹, ← mul_assoc,


### PR DESCRIPTION
Make the proof arguments come first and make the measure argument implicit when it can be inferred from the later arguments


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
