### PR TITLE
[Merged by Bors] - chore(Data/ENNReal): split off `Lemmas` file

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -2183,8 +2183,8 @@ import Mathlib.Data.DFinsupp.Order
 import Mathlib.Data.DFinsupp.WellFounded
 import Mathlib.Data.DList.Instances
 import Mathlib.Data.ENNReal.Basic
-import Mathlib.Data.ENNReal.Lemmas
 import Mathlib.Data.ENNReal.Inv
+import Mathlib.Data.ENNReal.Lemmas
 import Mathlib.Data.ENNReal.Operations
 import Mathlib.Data.ENNReal.Real
 import Mathlib.Data.ENat.Basic

--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -2183,6 +2183,7 @@ import Mathlib.Data.DFinsupp.Order
 import Mathlib.Data.DFinsupp.WellFounded
 import Mathlib.Data.DList.Instances
 import Mathlib.Data.ENNReal.Basic
+import Mathlib.Data.ENNReal.Lemmas
 import Mathlib.Data.ENNReal.Inv
 import Mathlib.Data.ENNReal.Operations
 import Mathlib.Data.ENNReal.Real

--- a/Mathlib/Data/ENNReal/Basic.lean
+++ b/Mathlib/Data/ENNReal/Basic.lean
@@ -3,12 +3,9 @@ Copyright (c) 2017 Johannes Hölzl. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johannes Hölzl, Yury Kudryashov
 -/
-import Mathlib.Algebra.Group.Indicator
 import Mathlib.Algebra.Order.Ring.WithTop
 import Mathlib.Algebra.Order.Sub.WithTop
-import Mathlib.Data.Finset.Lattice
 import Mathlib.Data.NNReal.Defs
-import Mathlib.Order.Interval.Set.WithBotTop
 
 /-!
 # Extended non-negative reals
@@ -438,11 +435,6 @@ def ofNNRealHom : ℝ≥0 →+* ℝ≥0∞ where
 
 @[simp] theorem coe_ofNNRealHom : ⇑ofNNRealHom = some := rfl
 
-@[simp, norm_cast]
-theorem coe_indicator {α} (s : Set α) (f : α → ℝ≥0) (a : α) :
-    ((s.indicator f a : ℝ≥0) : ℝ≥0∞) = s.indicator (fun x => ↑(f x)) a :=
-  (ofNNRealHom : ℝ≥0 →+ ℝ≥0∞).map_indicator _ _ _
-
 section Order
 
 theorem bot_eq_zero : (⊥ : ℝ≥0∞) = 0 := rfl
@@ -503,10 +495,6 @@ theorem lt_iff_exists_coe : a < b ↔ ∃ p : ℝ≥0, a = p ∧ ↑p < b :=
 theorem toReal_le_coe_of_le_coe {a : ℝ≥0∞} {b : ℝ≥0} (h : a ≤ b) : a.toReal ≤ b := by
   lift a to ℝ≥0 using ne_top_of_le_ne_top coe_ne_top h
   simpa using h
-
-@[simp, norm_cast]
-theorem coe_finset_sup {s : Finset α} {f : α → ℝ≥0} : ↑(s.sup f) = s.sup fun x => (f x : ℝ≥0∞) :=
-  Finset.comp_sup_eq_sup_comp_of_is_total _ coe_mono rfl
 
 @[simp] theorem max_eq_zero_iff : max a b = 0 ↔ a = 0 ∧ b = 0 := max_eq_bot
 

--- a/Mathlib/Data/ENNReal/Lemmas.lean
+++ b/Mathlib/Data/ENNReal/Lemmas.lean
@@ -1,0 +1,37 @@
+/-
+Copyright (c) 2017 Johannes Hölzl. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Johannes Hölzl, Yury Kudryashov
+-/
+import Mathlib.Algebra.Group.Indicator
+import Mathlib.Data.ENNReal.Basic
+import Mathlib.Data.Finset.Lattice
+
+/-!
+# Some lemmas on extended non-negative reals
+
+These are some lemmas split off from `ENNReal.Basic` because they need a lot more imports.
+They are probably good targets for further cleanup or moves.
+-/
+
+
+open Function Set NNReal
+
+variable {α : Type*}
+
+namespace ENNReal
+
+@[simp, norm_cast]
+theorem coe_indicator {α} (s : Set α) (f : α → ℝ≥0) (a : α) :
+    ((s.indicator f a : ℝ≥0) : ℝ≥0∞) = s.indicator (fun x => ↑(f x)) a :=
+  (ofNNRealHom : ℝ≥0 →+ ℝ≥0∞).map_indicator _ _ _
+
+section Order
+
+@[simp, norm_cast]
+theorem coe_finset_sup {s : Finset α} {f : α → ℝ≥0} : ↑(s.sup f) = s.sup fun x => (f x : ℝ≥0∞) :=
+  Finset.comp_sup_eq_sup_comp_of_is_total _ coe_mono rfl
+
+end Order
+
+end ENNReal

--- a/Mathlib/Topology/MetricSpace/Pseudo/Pi.lean
+++ b/Mathlib/Topology/MetricSpace/Pseudo/Pi.lean
@@ -3,6 +3,7 @@ Copyright (c) 2015, 2017 Jeremy Avigad. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Jeremy Avigad, Robert Y. Lewis, Johannes Hölzl, Mario Carneiro, Sébastien Gouëzel
 -/
+import Mathlib.Data.ENNReal.Lemmas
 import Mathlib.Topology.Bornology.Constructions
 import Mathlib.Topology.EMetricSpace.Pi
 import Mathlib.Topology.MetricSpace.Pseudo.Defs

--- a/Mathlib/Topology/MetricSpace/ThickenedIndicator.lean
+++ b/Mathlib/Topology/MetricSpace/ThickenedIndicator.lean
@@ -3,7 +3,7 @@ Copyright (c) 2022 Kalle Kytölä. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Kalle Kytölä
 -/
-import Mathlib.Data.ENNReal.Basic
+import Mathlib.Data.ENNReal.Lemmas
 import Mathlib.Topology.ContinuousMap.Bounded
 import Mathlib.Topology.MetricSpace.Thickening
 


### PR DESCRIPTION
Almost all of `Data.ENNReal.Basic` can be done with much a smaller set of imports. We only have two lemmas that need more imports, so let's split them off to a new file.

---
- [ ] depends on: #17913

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
