### PR TITLE
[Merged by Bors] - chore: Rename `ClosedEmbedding` to `IsClosedEmbedding`

### DIFF
--- a/Mathlib/AlgebraicGeometry/Morphisms/ClosedImmersion.lean
+++ b/Mathlib/AlgebraicGeometry/Morphisms/ClosedImmersion.lean
@@ -47,6 +47,9 @@ lemma isClosedEmbedding {X Y : Scheme} (f : X ⟶ Y)
     [IsClosedImmersion f] : IsClosedEmbedding f.base :=
   IsClosedImmersion.base_closed
 
+@[deprecated (since := "2024-10-20")]
+alias closedEmbedding := isClosedEmbedding
+
 lemma eq_inf : @IsClosedImmersion = (topologically IsClosedEmbedding) ⊓
     stalkwise (fun f ↦ Function.Surjective f) := by
   ext X Y f

--- a/Mathlib/AlgebraicGeometry/Morphisms/ClosedImmersion.lean
+++ b/Mathlib/AlgebraicGeometry/Morphisms/ClosedImmersion.lean
@@ -38,16 +38,16 @@ namespace AlgebraicGeometry
 topological map is a closed embedding and the induced stalk maps are surjective. -/
 @[mk_iff]
 class IsClosedImmersion {X Y : Scheme} (f : X ⟶ Y) : Prop where
-  base_closed : ClosedEmbedding f.base
+  base_closed : IsClosedEmbedding f.base
   surj_on_stalks : ∀ x, Function.Surjective (f.stalkMap x)
 
 namespace IsClosedImmersion
 
-lemma closedEmbedding {X Y : Scheme} (f : X ⟶ Y)
-    [IsClosedImmersion f] : ClosedEmbedding f.base :=
+lemma isClosedEmbedding {X Y : Scheme} (f : X ⟶ Y)
+    [IsClosedImmersion f] : IsClosedEmbedding f.base :=
   IsClosedImmersion.base_closed
 
-lemma eq_inf : @IsClosedImmersion = (topologically ClosedEmbedding) ⊓
+lemma eq_inf : @IsClosedImmersion = (topologically IsClosedEmbedding) ⊓
     stalkwise (fun f ↦ Function.Surjective f) := by
   ext X Y f
   rw [isClosedImmersion_iff]
@@ -55,7 +55,7 @@ lemma eq_inf : @IsClosedImmersion = (topologically ClosedEmbedding) ⊓
 
 lemma iff_isPreimmersion {X Y : Scheme} {f : X ⟶ Y} :
     IsClosedImmersion f ↔ IsPreimmersion f ∧ IsClosed (Set.range f.base) := by
-  rw [and_comm, isClosedImmersion_iff, isPreimmersion_iff, ← and_assoc, closedEmbedding_iff,
+  rw [and_comm, isClosedImmersion_iff, isPreimmersion_iff, ← and_assoc, isClosedEmbedding_iff,
     @and_comm (Embedding _)]
 
 lemma of_isPreimmersion {X Y : Scheme} (f : X ⟶ Y) [IsPreimmersion f]
@@ -67,7 +67,7 @@ instance (priority := 900) {X Y : Scheme} (f : X ⟶ Y) [IsClosedImmersion f] : 
 
 /-- Isomorphisms are closed immersions. -/
 instance {X Y : Scheme} (f : X ⟶ Y) [IsIso f] : IsClosedImmersion f where
-  base_closed := Homeomorph.closedEmbedding <| TopCat.homeoOfIso (asIso f.base)
+  base_closed := Homeomorph.isClosedEmbedding <| TopCat.homeoOfIso (asIso f.base)
   surj_on_stalks := fun _ ↦ (ConcreteCategory.bijective_of_isIso _).2
 
 instance : MorphismProperty.IsMultiplicative @IsClosedImmersion where
@@ -91,7 +91,7 @@ instance respectsIso : MorphismProperty.RespectsIso @IsClosedImmersion := by
 closed immersion. -/
 theorem spec_of_surjective {R S : CommRingCat} (f : R ⟶ S) (h : Function.Surjective f) :
     IsClosedImmersion (Spec.map f) where
-  base_closed := PrimeSpectrum.closedEmbedding_comap_of_surjective _ _ h
+  base_closed := PrimeSpectrum.isClosedEmbedding_comap_of_surjective _ _ h
   surj_on_stalks x := by
     haveI : (RingHom.toMorphismProperty (fun f ↦ Function.Surjective f)).RespectsIso := by
       rw [← RingHom.toMorphismProperty_respectsIso_iff]
@@ -119,14 +119,13 @@ lemma of_surjective_of_isAffine {X Y : Scheme} [IsAffine X] [IsAffine Y] (f : X 
 theorem of_comp {X Y Z : Scheme} (f : X ⟶ Y) (g : Y ⟶ Z) [IsClosedImmersion g]
     [IsClosedImmersion (f ≫ g)] : IsClosedImmersion f where
   base_closed := by
-    have h := closedEmbedding (f ≫ g)
-    rw [Scheme.comp_base] at h
-    apply closedEmbedding_of_continuous_injective_closed (Scheme.Hom.continuous f)
-    · exact Function.Injective.of_comp h.inj
-    · intro Z hZ
-      rw [ClosedEmbedding.closed_iff_image_closed (closedEmbedding g),
-        ← Set.image_comp]
-      exact ClosedEmbedding.isClosedMap h _ hZ
+    have h := isClosedEmbedding (f ≫ g)
+    simp only [Scheme.comp_coeBase, TopCat.coe_comp] at h
+    refine .of_continuous_injective_isClosedMap (Scheme.Hom.continuous f) h.inj.of_comp ?_
+    intro Z hZ
+    rw [IsClosedEmbedding.closed_iff_image_closed (isClosedEmbedding g),
+      ← Set.image_comp]
+    exact h.isClosedMap _ hZ
   surj_on_stalks x := by
     have h := (f ≫ g).stalkMap_surjective x
     simp_rw [Scheme.stalkMap_comp] at h
@@ -220,14 +219,14 @@ namespace IsClosedImmersion
 sections is injective, `f` is an isomorphism. -/
 theorem isIso_of_injective_of_isAffine [IsClosedImmersion f]
     (hf : Function.Injective (f.app ⊤)) : IsIso f := (isIso_iff_stalk_iso f).mpr <|
-  have : CompactSpace X := (closedEmbedding f).compactSpace
+  have : CompactSpace X := (isClosedEmbedding f).compactSpace
   have hiso : IsIso f.base := TopCat.isIso_of_bijective_of_isClosedMap _
-    ⟨(closedEmbedding f).inj,
-     surjective_of_isClosed_range_of_injective ((closedEmbedding f).isClosed_range) hf⟩
-    ((closedEmbedding f).isClosedMap)
+    ⟨(isClosedEmbedding f).inj,
+     surjective_of_isClosed_range_of_injective ((isClosedEmbedding f).isClosed_range) hf⟩
+    ((isClosedEmbedding f).isClosedMap)
   ⟨hiso, fun x ↦ (ConcreteCategory.isIso_iff_bijective _).mpr
     ⟨stalkMap_injective_of_isOpenMap_of_injective ((TopCat.homeoOfIso (asIso f.base)).isOpenMap)
-    (closedEmbedding f).inj hf _, f.stalkMap_surjective x⟩⟩
+    (isClosedEmbedding f).inj hf _, f.stalkMap_surjective x⟩⟩
 
 variable (f)
 

--- a/Mathlib/AlgebraicGeometry/Morphisms/UnderlyingMap.lean
+++ b/Mathlib/AlgebraicGeometry/Morphisms/UnderlyingMap.lean
@@ -19,7 +19,7 @@ of the underlying map of topological spaces, including
 - `IsClosedMap`
 - `Embedding`
 - `IsOpenEmbedding`
-- `ClosedEmbedding`
+- `IsClosedEmbedding`
 
 -/
 
@@ -131,16 +131,16 @@ instance isOpenEmbedding_isLocalAtTarget : IsLocalAtTarget (topologically IsOpen
 
 end IsOpenEmbedding
 
-section ClosedEmbedding
+section IsClosedEmbedding
 
-instance : (topologically ClosedEmbedding).RespectsIso :=
-  topologically_respectsIso _ (fun e ↦ e.closedEmbedding) (fun _ _ hf hg ↦ hg.comp hf)
+instance : (topologically IsClosedEmbedding).RespectsIso :=
+  topologically_respectsIso _ (fun e ↦ e.isClosedEmbedding) (fun _ _ hf hg ↦ hg.comp hf)
 
-instance closedEmbedding_isLocalAtTarget : IsLocalAtTarget (topologically ClosedEmbedding) :=
+instance isClosedEmbedding_isLocalAtTarget : IsLocalAtTarget (topologically IsClosedEmbedding) :=
   topologically_isLocalAtTarget _
     (fun _ s hf ↦ hf.restrictPreimage s)
-    (fun _ _ _ hU hfcont hf ↦ (closedEmbedding_iff_closedEmbedding_of_iSup_eq_top hU hfcont).mpr hf)
+    (fun _ _ _ hU hfcont ↦ (isClosedEmbedding_iff_isClosedEmbedding_of_iSup_eq_top hU hfcont).mpr)
 
-end ClosedEmbedding
+end IsClosedEmbedding
 
 end AlgebraicGeometry

--- a/Mathlib/AlgebraicGeometry/PrimeSpectrum/Basic.lean
+++ b/Mathlib/AlgebraicGeometry/PrimeSpectrum/Basic.lean
@@ -331,6 +331,9 @@ theorem isClosedEmbedding_comap_of_surjective (hf : Surjective f) : IsClosedEmbe
     inj := comap_injective_of_surjective f hf
     isClosed_range := isClosed_range_comap_of_surjective S f hf }
 
+@[deprecated (since := "2024-10-20")]
+alias closedEmbedding_comap_of_surjective := isClosedEmbedding_comap_of_surjective
+
 end SpecOfSurjective
 
 section SpecProd

--- a/Mathlib/AlgebraicGeometry/PrimeSpectrum/Basic.lean
+++ b/Mathlib/AlgebraicGeometry/PrimeSpectrum/Basic.lean
@@ -326,7 +326,7 @@ theorem isClosed_range_comap_of_surjective (hf : Surjective f) :
   rw [range_comap_of_surjective _ f hf]
   exact isClosed_zeroLocus _
 
-theorem closedEmbedding_comap_of_surjective (hf : Surjective f) : ClosedEmbedding (comap f) :=
+theorem isClosedEmbedding_comap_of_surjective (hf : Surjective f) : IsClosedEmbedding (comap f) :=
   { induced := (comap_inducing_of_surjective S f hf).induced
     inj := comap_injective_of_surjective f hf
     isClosed_range := isClosed_range_comap_of_surjective S f hf }
@@ -351,17 +351,18 @@ noncomputable
 def primeSpectrumProdHomeo :
     PrimeSpectrum (R × S) ≃ₜ PrimeSpectrum R ⊕ PrimeSpectrum S := by
   refine ((primeSpectrumProd R S).symm.toHomeomorphOfInducing ?_).symm
-  refine (closedEmbedding_of_continuous_injective_closed ?_ (Equiv.injective _) ?_).toInducing
+  refine (IsClosedEmbedding.of_continuous_injective_isClosedMap ?_
+    (Equiv.injective _) ?_).toInducing
   · rw [continuous_sum_dom]
     simp only [Function.comp_def, primeSpectrumProd_symm_inl, primeSpectrumProd_symm_inr]
     exact ⟨(comap _).2, (comap _).2⟩
   · rw [isClosedMap_sum]
     constructor
     · simp_rw [primeSpectrumProd_symm_inl]
-      refine (closedEmbedding_comap_of_surjective _ _ ?_).isClosedMap
+      refine (isClosedEmbedding_comap_of_surjective _ _ ?_).isClosedMap
       exact Prod.fst_surjective
     · simp_rw [primeSpectrumProd_symm_inr]
-      refine (closedEmbedding_comap_of_surjective _ _ ?_).isClosedMap
+      refine (isClosedEmbedding_comap_of_surjective _ _ ?_).isClosedMap
       exact Prod.snd_surjective
 
 end SpecProd

--- a/Mathlib/AlgebraicGeometry/ResidueField.lean
+++ b/Mathlib/AlgebraicGeometry/ResidueField.lean
@@ -52,7 +52,7 @@ def residue (X : Scheme.{u}) (x) : X.presheaf.stalk x ⟶ X.residueField x :=
 `Spec.map (X.residue x)` is a closed immersion. -/
 instance {X : Scheme.{u}} (x) : IsPreimmersion (Spec.map (X.residue x)) :=
   IsPreimmersion.mk_Spec_map
-    (PrimeSpectrum.closedEmbedding_comap_of_surjective _ _ (Ideal.Quotient.mk_surjective)).embedding
+    (PrimeSpectrum.isClosedEmbedding_comap_of_surjective _ _ Ideal.Quotient.mk_surjective).embedding
     (RingHom.surjectiveOnStalks_of_surjective (Ideal.Quotient.mk_surjective))
 
 @[simp]

--- a/Mathlib/Analysis/CStarAlgebra/ContinuousFunctionalCalculus/Instances.lean
+++ b/Mathlib/Analysis/CStarAlgebra/ContinuousFunctionalCalculus/Instances.lean
@@ -78,16 +78,16 @@ noncomputable def cfcₙAux : C(σₙ 𝕜 a, 𝕜)₀ →⋆ₙₐ[𝕜] A⁺¹
 lemma cfcₙAux_id : cfcₙAux hp₁ a ha (ContinuousMapZero.id rfl) = a := cfcHom_id (hp₁.mpr ha)
 
 open Unitization in
-lemma closedEmbedding_cfcₙAux : ClosedEmbedding (cfcₙAux hp₁ a ha) := by
+lemma isClosedEmbedding_cfcₙAux : IsClosedEmbedding (cfcₙAux hp₁ a ha) := by
   simp only [cfcₙAux, NonUnitalStarAlgHom.coe_comp]
-  refine ((cfcHom_closedEmbedding (hp₁.mpr ha)).comp ?_).comp
-    ContinuousMapZero.closedEmbedding_toContinuousMap
+  refine ((cfcHom_isClosedEmbedding (hp₁.mpr ha)).comp ?_).comp
+    ContinuousMapZero.isClosedEmbedding_toContinuousMap
   let e : C(σₙ 𝕜 a, 𝕜) ≃ₜ C(σ 𝕜 (a : A⁺¹), 𝕜) :=
     { (Homeomorph.compStarAlgEquiv' 𝕜 𝕜 <| .setCongr <|
         (quasispectrum_eq_spectrum_inr' 𝕜 𝕜 a).symm) with
       continuous_toFun := ContinuousMap.continuous_comp_left _
       continuous_invFun := ContinuousMap.continuous_comp_left _ }
-  exact e.closedEmbedding
+  exact e.isClosedEmbedding
 
 lemma spec_cfcₙAux (f : C(σₙ 𝕜 a, 𝕜)₀) : σ 𝕜 (cfcₙAux hp₁ a ha f) = Set.range f := by
   rw [cfcₙAux, NonUnitalStarAlgHom.comp_assoc, NonUnitalStarAlgHom.comp_apply]
@@ -103,7 +103,7 @@ variable [CompleteSpace A]
 
 lemma cfcₙAux_mem_range_inr (f : C(σₙ 𝕜 a, 𝕜)₀) :
     cfcₙAux hp₁ a ha f ∈ NonUnitalStarAlgHom.range (Unitization.inrNonUnitalStarAlgHom 𝕜 A) := by
-  have h₁ := (closedEmbedding_cfcₙAux hp₁ a ha).continuous.range_subset_closure_image_dense
+  have h₁ := (isClosedEmbedding_cfcₙAux hp₁ a ha).continuous.range_subset_closure_image_dense
     (ContinuousMapZero.adjoin_id_dense (s := σₙ 𝕜 a) rfl) ⟨f, rfl⟩
   rw [← SetLike.mem_coe]
   refine closure_minimal ?_ ?_ h₁
@@ -133,11 +133,11 @@ theorem RCLike.nonUnitalContinuousFunctionalCalculus :
     have coe_ψ (f : C(σₙ 𝕜 a, 𝕜)₀) : ψ f = cfcₙAux hp₁ a ha f :=
       congr_arg Subtype.val <| (inrRangeEquiv 𝕜 A).apply_symm_apply
         ⟨cfcₙAux hp₁ a ha f, cfcₙAux_mem_range_inr hp₁ a ha f⟩
-    refine ⟨ψ, ?closedEmbedding, ?map_id, fun f ↦ ?map_spec, fun f ↦ ?isStarNormal⟩
-    case closedEmbedding =>
-      apply isometry_inr (𝕜 := 𝕜) (A := A) |>.closedEmbedding |>.of_comp_iff.mp
+    refine ⟨ψ, ?isClosedEmbedding, ?map_id, fun f ↦ ?map_spec, fun f ↦ ?isStarNormal⟩
+    case isClosedEmbedding =>
+      apply isometry_inr (𝕜 := 𝕜) (A := A) |>.isClosedEmbedding |>.of_comp_iff.mp
       have : inr ∘ ψ = cfcₙAux hp₁ a ha := by ext1; rw [Function.comp_apply, coe_ψ]
-      exact this ▸ closedEmbedding_cfcₙAux hp₁ a ha
+      exact this ▸ isClosedEmbedding_cfcₙAux hp₁ a ha
     case map_id => exact inr_injective (R := 𝕜) <| coe_ψ _ ▸ cfcₙAux_id hp₁ a ha
     case map_spec =>
       exact quasispectrum_eq_spectrum_inr' 𝕜 𝕜 (ψ f) ▸ coe_ψ _ ▸ spec_cfcₙAux hp₁ a ha f
@@ -158,13 +158,13 @@ instance IsStarNormal.instContinuousFunctionalCalculus {A : Type*} [NormedRing A
   spectrum_nonempty a _ := spectrum.nonempty a
   exists_cfc_of_predicate a ha := by
     refine ⟨(elementalStarAlgebra ℂ a).subtype.comp <| continuousFunctionalCalculus a,
-      ?hom_closedEmbedding, ?hom_id, ?hom_map_spectrum, ?predicate_hom⟩
-    case hom_closedEmbedding =>
+      ?hom_isClosedEmbedding, ?hom_id, ?hom_map_spectrum, ?predicate_hom⟩
+    case hom_isClosedEmbedding =>
       -- note: Lean should find these for `StarAlgEquiv.isometry`, but it doesn't and so we
       -- provide them manually.
       have : SMulCommClass ℂ C(σ ℂ a, ℂ) C(σ ℂ a, ℂ) := Algebra.to_smulCommClass (A := C(σ ℂ a, ℂ))
       have : IsScalarTower ℂ C(σ ℂ a, ℂ) C(σ ℂ a, ℂ) := IsScalarTower.right (A := C(σ ℂ a, ℂ))
-      exact Isometry.closedEmbedding <|
+      exact Isometry.isClosedEmbedding <|
         isometry_subtype_coe.comp <| StarAlgEquiv.isometry (continuousFunctionalCalculus a)
     case hom_id => exact congr_arg Subtype.val <| continuousFunctionalCalculus_map_id a
     case hom_map_spectrum =>

--- a/Mathlib/Analysis/CStarAlgebra/ContinuousFunctionalCalculus/Instances.lean
+++ b/Mathlib/Analysis/CStarAlgebra/ContinuousFunctionalCalculus/Instances.lean
@@ -89,6 +89,9 @@ lemma isClosedEmbedding_cfcₙAux : IsClosedEmbedding (cfcₙAux hp₁ a ha) := 
       continuous_invFun := ContinuousMap.continuous_comp_left _ }
   exact e.isClosedEmbedding
 
+@[deprecated (since := "2024-10-20")]
+alias closedEmbedding_cfcₙAux := isClosedEmbedding_cfcₙAux
+
 lemma spec_cfcₙAux (f : C(σₙ 𝕜 a, 𝕜)₀) : σ 𝕜 (cfcₙAux hp₁ a ha f) = Set.range f := by
   rw [cfcₙAux, NonUnitalStarAlgHom.comp_assoc, NonUnitalStarAlgHom.comp_apply]
   simp only [NonUnitalStarAlgHom.comp_apply, NonUnitalStarAlgHom.coe_coe]

--- a/Mathlib/Analysis/CStarAlgebra/ContinuousFunctionalCalculus/NonUnital.lean
+++ b/Mathlib/Analysis/CStarAlgebra/ContinuousFunctionalCalculus/NonUnital.lean
@@ -75,7 +75,7 @@ class NonUnitalContinuousFunctionalCalculus (R : Type*) {A : Type*} (p : outPara
   predicate_zero : p 0
   [compactSpace_quasispectrum : ∀ a : A, CompactSpace (σₙ R a)]
   exists_cfc_of_predicate : ∀ a, p a → ∃ φ : C(σₙ R a, R)₀ →⋆ₙₐ[R] A,
-    ClosedEmbedding φ ∧ φ ⟨(ContinuousMap.id R).restrict <| σₙ R a, rfl⟩ = a ∧
+    IsClosedEmbedding φ ∧ φ ⟨(ContinuousMap.id R).restrict <| σₙ R a, rfl⟩ = a ∧
       (∀ f, σₙ R (φ f) = Set.range f) ∧ ∀ f, p (φ f)
 
 -- this instance should not be activated everywhere but it is useful when developing generic API
@@ -128,13 +128,13 @@ the user should instead prefer `cfcₙ` over `cfcₙHom`.
 noncomputable def cfcₙHom : C(σₙ R a, R)₀ →⋆ₙₐ[R] A :=
   (NonUnitalContinuousFunctionalCalculus.exists_cfc_of_predicate a ha).choose
 
-lemma cfcₙHom_closedEmbedding :
-    ClosedEmbedding <| (cfcₙHom ha : C(σₙ R a, R)₀ →⋆ₙₐ[R] A) :=
+lemma cfcₙHom_isClosedEmbedding :
+    IsClosedEmbedding <| (cfcₙHom ha : C(σₙ R a, R)₀ →⋆ₙₐ[R] A) :=
   (NonUnitalContinuousFunctionalCalculus.exists_cfc_of_predicate a ha).choose_spec.1
 
 @[fun_prop]
 lemma cfcₙHom_continuous : Continuous (cfcₙHom ha : C(σₙ R a, R)₀ →⋆ₙₐ[R] A) :=
-  cfcₙHom_closedEmbedding ha |>.continuous
+  cfcₙHom_isClosedEmbedding ha |>.continuous
 
 lemma cfcₙHom_id :
     cfcₙHom ha ⟨(ContinuousMap.id R).restrict <| σₙ R a, rfl⟩ = a :=
@@ -152,7 +152,7 @@ lemma cfcₙHom_predicate (f : C(σₙ R a, R)₀) :
 lemma cfcₙHom_eq_of_continuous_of_map_id [UniqueNonUnitalContinuousFunctionalCalculus R A]
     (φ : C(σₙ R a, R)₀ →⋆ₙₐ[R] A) (hφ₁ : Continuous φ)
     (hφ₂ : φ ⟨.restrict (σₙ R a) <| .id R, rfl⟩ = a) : cfcₙHom ha = φ :=
-  (cfcₙHom ha).ext_continuousMap a φ (cfcₙHom_closedEmbedding ha).continuous hφ₁ <| by
+  (cfcₙHom ha).ext_continuousMap a φ (cfcₙHom_isClosedEmbedding ha).continuous hφ₁ <| by
     rw [cfcₙHom_id ha, hφ₂]
 
 theorem cfcₙHom_comp [UniqueNonUnitalContinuousFunctionalCalculus R A] (f : C(σₙ R a, R)₀)
@@ -169,7 +169,7 @@ theorem cfcₙHom_comp [UniqueNonUnitalContinuousFunctionalCalculus R A] (f : C(
   let φ : C(σₙ R (cfcₙHom ha f), R)₀ →⋆ₙₐ[R] A := (cfcₙHom ha).comp ψ
   suffices cfcₙHom (cfcₙHom_predicate ha f) = φ from DFunLike.congr_fun this.symm g
   refine cfcₙHom_eq_of_continuous_of_map_id (cfcₙHom_predicate ha f) φ ?_ ?_
-  · refine (cfcₙHom_closedEmbedding ha).continuous.comp <| continuous_induced_rng.mpr ?_
+  · refine (cfcₙHom_isClosedEmbedding ha).continuous.comp <| continuous_induced_rng.mpr ?_
     exact f'.toContinuousMap.continuous_comp_left.comp continuous_induced_dom
   · simp only [φ, ψ, NonUnitalStarAlgHom.comp_apply, NonUnitalStarAlgHom.coe_mk',
       NonUnitalAlgHom.coe_mk]
@@ -187,7 +187,7 @@ noncomputable def cfcₙL {a : A} (ha : p a) : C(σₙ R a, R)₀ →L[R] A :=
   { cfcₙHom ha with
     toFun := cfcₙHom ha
     map_smul' := map_smul _
-    cont := (cfcₙHom_closedEmbedding ha).continuous }
+    cont := (cfcₙHom_isClosedEmbedding ha).continuous }
 
 end cfcₙL
 
@@ -306,7 +306,7 @@ lemma eqOn_of_cfcₙ_eq_cfcₙ {f g : R → R} {a : A} (h : cfcₙ f a = cfcₙ 
     (hg : ContinuousOn g (σₙ R a) := by cfc_cont_tac) (hg0 : g 0 = 0 := by cfc_zero_tac) :
     (σₙ R a).EqOn f g := by
   rw [cfcₙ_apply f a, cfcₙ_apply g a] at h
-  have := (cfcₙHom_closedEmbedding (show p a from ha) (R := R)).inj h
+  have := (cfcₙHom_isClosedEmbedding (show p a from ha) (R := R)).inj h
   intro x hx
   congrm($(this) ⟨x, hx⟩)
 
@@ -695,12 +695,12 @@ variable [CompleteSpace R]
 -- gives access to the `ContinuousFunctionalCalculus.compactSpace_spectrum` instance
 open scoped ContinuousFunctionalCalculus
 
-lemma closedEmbedding_cfcₙHom_of_cfcHom {a : A} (ha : p a) :
-    ClosedEmbedding (cfcₙHom_of_cfcHom R ha) := by
+lemma isClosedEmbedding_cfcₙHom_of_cfcHom {a : A} (ha : p a) :
+    IsClosedEmbedding (cfcₙHom_of_cfcHom R ha) := by
   let f : C(spectrum R a, σₙ R a) :=
     ⟨_, continuous_inclusion <| spectrum_subset_quasispectrum R a⟩
-  refine (cfcHom_closedEmbedding ha).comp <|
-    (IsUniformInducing.isUniformEmbedding ⟨?_⟩).toClosedEmbedding
+  refine (cfcHom_isClosedEmbedding ha).comp <|
+    (IsUniformInducing.isUniformEmbedding ⟨?_⟩).toIsClosedEmbedding
   have := uniformSpace_eq_inf_precomp_of_cover (β := R) f (0 : C(Unit, σₙ R a))
     (map_continuous f).isProperMap (map_continuous 0).isProperMap <| by
       simp only [← Subtype.val_injective.image_injective.eq_iff, f, ContinuousMap.coe_mk,
@@ -723,7 +723,7 @@ instance ContinuousFunctionalCalculus.toNonUnital : NonUnitalContinuousFunctiona
     exact h_cpct |>.union isCompact_singleton
   exists_cfc_of_predicate _ ha :=
     ⟨cfcₙHom_of_cfcHom R ha,
-      closedEmbedding_cfcₙHom_of_cfcHom ha,
+      isClosedEmbedding_cfcₙHom_of_cfcHom ha,
       cfcHom_id ha,
       cfcₙHom_of_cfcHom_map_quasispectrum ha,
       fun _ ↦ cfcHom_predicate ha _⟩
@@ -734,8 +734,8 @@ lemma cfcₙHom_eq_cfcₙHom_of_cfcHom [UniqueNonUnitalContinuousFunctionalCalcu
   refine UniqueNonUnitalContinuousFunctionalCalculus.eq_of_continuous_of_map_id
       (σₙ R a) ?_ _ _ ?_ ?_ ?_
   · simp
-  · exact (cfcₙHom_closedEmbedding (R := R) ha).continuous
-  · exact (closedEmbedding_cfcₙHom_of_cfcHom ha).continuous
+  · exact (cfcₙHom_isClosedEmbedding (R := R) ha).continuous
+  · exact (isClosedEmbedding_cfcₙHom_of_cfcHom ha).continuous
   · simpa only [cfcₙHom_id (R := R) ha] using (cfcHom_id ha).symm
 
 /-- When `cfc` is applied to a function that maps zero to zero, it is equivalent to using

--- a/Mathlib/Analysis/CStarAlgebra/ContinuousFunctionalCalculus/NonUnital.lean
+++ b/Mathlib/Analysis/CStarAlgebra/ContinuousFunctionalCalculus/NonUnital.lean
@@ -132,6 +132,9 @@ lemma cfcₙHom_isClosedEmbedding :
     IsClosedEmbedding <| (cfcₙHom ha : C(σₙ R a, R)₀ →⋆ₙₐ[R] A) :=
   (NonUnitalContinuousFunctionalCalculus.exists_cfc_of_predicate a ha).choose_spec.1
 
+@[deprecated (since := "2024-10-20")]
+alias cfcₙHom_closedEmbedding := cfcₙHom_isClosedEmbedding
+
 @[fun_prop]
 lemma cfcₙHom_continuous : Continuous (cfcₙHom ha : C(σₙ R a, R)₀ →⋆ₙₐ[R] A) :=
   cfcₙHom_isClosedEmbedding ha |>.continuous
@@ -714,6 +717,9 @@ lemma isClosedEmbedding_cfcₙHom_of_cfcHom {a : A} (ha : p a) :
   have : ∀ U ∈ 𝓤 (C(Unit, R)), (0, 0) ∈ U := fun U hU ↦ refl_mem_uniformity hU
   convert Filter.comap_const_of_mem this with ⟨u, v⟩ <;>
   ext ⟨x, rfl⟩ <;> [exact map_zero u; exact map_zero v]
+
+@[deprecated (since := "2024-10-20")]
+alias closedEmbedding_cfcₙHom_of_cfcHom := isClosedEmbedding_cfcₙHom_of_cfcHom
 
 instance ContinuousFunctionalCalculus.toNonUnital : NonUnitalContinuousFunctionalCalculus R p where
   predicate_zero := cfc_predicate_zero R

--- a/Mathlib/Analysis/CStarAlgebra/ContinuousFunctionalCalculus/Order.lean
+++ b/Mathlib/Analysis/CStarAlgebra/ContinuousFunctionalCalculus/Order.lean
@@ -370,8 +370,8 @@ lemma conjugate_le_norm_smul' {a b : A} (hb : IsSelfAdjoint b := by cfc_tac) :
 /-- The set of nonnegative elements in a C⋆-algebra is closed. -/
 lemma isClosed_nonneg : IsClosed {a : A | 0 ≤ a} := by
   suffices IsClosed {a : Unitization ℂ A | 0 ≤ a} by
-    rw [Unitization.isometry_inr (𝕜 := ℂ) |>.closedEmbedding.closed_iff_image_closed]
-    convert this.inter <| (Unitization.isometry_inr (𝕜 := ℂ)).closedEmbedding.isClosed_range
+    rw [Unitization.isometry_inr (𝕜 := ℂ) |>.isClosedEmbedding.closed_iff_image_closed]
+    convert this.inter <| (Unitization.isometry_inr (𝕜 := ℂ)).isClosedEmbedding.isClosed_range
     ext a
     simp only [Set.mem_image, Set.mem_setOf_eq, Set.mem_inter_iff, Set.mem_range, ← exists_and_left]
     congr! 2 with x

--- a/Mathlib/Analysis/CStarAlgebra/ContinuousFunctionalCalculus/Restrict.lean
+++ b/Mathlib/Analysis/CStarAlgebra/ContinuousFunctionalCalculus/Restrict.lean
@@ -82,11 +82,11 @@ lemma starAlgHom_id {a : A} {φ : C(spectrum S a, S) →⋆ₐ[S] A} {f : C(S, R
 variable [TopologicalSpace A] [ContinuousFunctionalCalculus S q]
 variable [CompleteSpace R]
 
-lemma closedEmbedding_starAlgHom {a : A} {φ : C(spectrum S a, S) →⋆ₐ[S] A}
-    (hφ : ClosedEmbedding φ) {f : C(S, R)} (h : SpectrumRestricts a f)
+lemma isClosedEmbedding_starAlgHom {a : A} {φ : C(spectrum S a, S) →⋆ₐ[S] A}
+    (hφ : IsClosedEmbedding φ) {f : C(S, R)} (h : SpectrumRestricts a f)
     (halg : IsUniformEmbedding (algebraMap R S)) :
-    ClosedEmbedding (h.starAlgHom φ) :=
-  hφ.comp <| IsUniformEmbedding.toClosedEmbedding <| .comp
+    IsClosedEmbedding (h.starAlgHom φ) :=
+  hφ.comp <| IsUniformEmbedding.toIsClosedEmbedding <| .comp
     (ContinuousMap.isUniformEmbedding_comp _ halg)
     (UniformEquiv.arrowCongr h.homeomorph.symm (.refl _) |>.isUniformEmbedding)
 
@@ -103,13 +103,13 @@ protected theorem cfc (f : C(S, R)) (halg : IsUniformEmbedding (algebraMap R S))
   compactSpace_spectrum a := by
     have := ContinuousFunctionalCalculus.compactSpace_spectrum (R := S) a
     rw [← isCompact_iff_compactSpace] at this ⊢
-    simpa using halg.toClosedEmbedding.isCompact_preimage this
+    simpa using halg.toIsClosedEmbedding.isCompact_preimage this
   exists_cfc_of_predicate a ha := by
     refine ⟨((h a).mp ha).2.starAlgHom (cfcHom ((h a).mp ha).1 (R := S)),
-      ?hom_closedEmbedding, ?hom_id, ?hom_map_spectrum, ?predicate_hom⟩
-    case hom_closedEmbedding =>
-      exact ((h a).mp ha).2.closedEmbedding_starAlgHom
-        (cfcHom_closedEmbedding ((h a).mp ha).1) halg
+      ?hom_isClosedEmbedding, ?hom_id, ?hom_map_spectrum, ?predicate_hom⟩
+    case hom_isClosedEmbedding =>
+      exact ((h a).mp ha).2.isClosedEmbedding_starAlgHom
+        (cfcHom_isClosedEmbedding ((h a).mp ha).1) halg
     case hom_id => exact ((h a).mp ha).2.starAlgHom_id <| cfcHom_id ((h a).mp ha).1
     case hom_map_spectrum =>
       intro g
@@ -143,7 +143,7 @@ lemma cfcHom_eq_restrict (f : C(S, R)) (halg : IsUniformEmbedding (algebraMap R 
     {a : A} (hpa : p a) (hqa : q a) (h : SpectrumRestricts a f) :
     cfcHom hpa = h.starAlgHom (cfcHom hqa) := by
   apply cfcHom_eq_of_continuous_of_map_id
-  · exact h.closedEmbedding_starAlgHom (cfcHom_closedEmbedding hqa) halg |>.continuous
+  · exact h.isClosedEmbedding_starAlgHom (cfcHom_isClosedEmbedding hqa) halg |>.continuous
   · exact h.starAlgHom_id (cfcHom_id hqa)
 
 lemma cfc_eq_restrict (f : C(S, R)) (halg : IsUniformEmbedding (algebraMap R S)) {a : A} (hpa : p a)
@@ -222,12 +222,12 @@ lemma nonUnitalStarAlgHom_id {a : A} {φ : C(σₙ S a, S)₀ →⋆ₙₐ[S] A}
 variable [TopologicalSpace A] [NonUnitalContinuousFunctionalCalculus S q]
 variable [CompleteSpace R]
 
-lemma closedEmbedding_nonUnitalStarAlgHom {a : A} {φ : C(σₙ S a, S)₀ →⋆ₙₐ[S] A}
-    (hφ : ClosedEmbedding φ) {f : C(S, R)} (h : QuasispectrumRestricts a f)
+lemma isClosedEmbedding_nonUnitalStarAlgHom {a : A} {φ : C(σₙ S a, S)₀ →⋆ₙₐ[S] A}
+    (hφ : IsClosedEmbedding φ) {f : C(S, R)} (h : QuasispectrumRestricts a f)
     (halg : IsUniformEmbedding (algebraMap R S)) :
-    ClosedEmbedding (h.nonUnitalStarAlgHom φ) := by
+    IsClosedEmbedding (h.nonUnitalStarAlgHom φ) := by
   have : h.homeomorph.symm 0 = 0 := Subtype.ext (map_zero <| algebraMap _ _)
-  refine hφ.comp <| IsUniformEmbedding.toClosedEmbedding <| .comp
+  refine hφ.comp <| IsUniformEmbedding.toIsClosedEmbedding <| .comp
     (ContinuousMapZero.isUniformEmbedding_comp _ halg)
     (UniformEquiv.arrowCongrLeft₀ h.homeomorph.symm this |>.isUniformEmbedding)
 
@@ -244,13 +244,13 @@ protected theorem cfc (f : C(S, R)) (halg : IsUniformEmbedding (algebraMap R S))
   compactSpace_quasispectrum a := by
     have := NonUnitalContinuousFunctionalCalculus.compactSpace_quasispectrum (R := S) a
     rw [← isCompact_iff_compactSpace] at this ⊢
-    simpa using halg.toClosedEmbedding.isCompact_preimage this
+    simpa using halg.toIsClosedEmbedding.isCompact_preimage this
   exists_cfc_of_predicate a ha := by
     refine ⟨((h a).mp ha).2.nonUnitalStarAlgHom (cfcₙHom ((h a).mp ha).1 (R := S)),
-      ?hom_closedEmbedding, ?hom_id, ?hom_map_spectrum, ?predicate_hom⟩
-    case hom_closedEmbedding =>
-      exact ((h a).mp ha).2.closedEmbedding_nonUnitalStarAlgHom
-        (cfcₙHom_closedEmbedding ((h a).mp ha).1) halg
+      ?hom_isClosedEmbedding, ?hom_id, ?hom_map_spectrum, ?predicate_hom⟩
+    case hom_isClosedEmbedding =>
+      exact ((h a).mp ha).2.isClosedEmbedding_nonUnitalStarAlgHom
+        (cfcₙHom_isClosedEmbedding ((h a).mp ha).1) halg
     case hom_id => exact ((h a).mp ha).2.nonUnitalStarAlgHom_id <| cfcₙHom_id ((h a).mp ha).1
     case hom_map_spectrum =>
       intro g
@@ -289,7 +289,7 @@ lemma cfcₙHom_eq_restrict (f : C(S, R)) (halg : IsUniformEmbedding (algebraMap
     (hpa : p a) (hqa : q a) (h : QuasispectrumRestricts a f) :
     cfcₙHom hpa = h.nonUnitalStarAlgHom (cfcₙHom hqa) := by
   apply cfcₙHom_eq_of_continuous_of_map_id
-  · exact h.closedEmbedding_nonUnitalStarAlgHom (cfcₙHom_closedEmbedding hqa) halg |>.continuous
+  · exact h.isClosedEmbedding_nonUnitalStarAlgHom (cfcₙHom_isClosedEmbedding hqa) halg |>.continuous
   · exact h.nonUnitalStarAlgHom_id (cfcₙHom_id hqa)
 
 lemma cfcₙ_eq_restrict (f : C(S, R)) (halg : IsUniformEmbedding (algebraMap R S)) {a : A}

--- a/Mathlib/Analysis/CStarAlgebra/ContinuousFunctionalCalculus/Restrict.lean
+++ b/Mathlib/Analysis/CStarAlgebra/ContinuousFunctionalCalculus/Restrict.lean
@@ -90,6 +90,9 @@ lemma isClosedEmbedding_starAlgHom {a : A} {φ : C(spectrum S a, S) →⋆ₐ[S]
     (ContinuousMap.isUniformEmbedding_comp _ halg)
     (UniformEquiv.arrowCongr h.homeomorph.symm (.refl _) |>.isUniformEmbedding)
 
+@[deprecated (since := "2024-10-20")]
+alias closedEmbedding_starAlgHom := isClosedEmbedding_starAlgHom
+
 /-- Given a `ContinuousFunctionalCalculus S q`. If we form the predicate `p` for `a : A`
 characterized by: `q a` and the spectrum of `a` restricts to the scalar subring `R` via
 `f : C(S, R)`, then we can get a restricted functional calculus
@@ -230,6 +233,9 @@ lemma isClosedEmbedding_nonUnitalStarAlgHom {a : A} {φ : C(σₙ S a, S)₀ →
   refine hφ.comp <| IsUniformEmbedding.toIsClosedEmbedding <| .comp
     (ContinuousMapZero.isUniformEmbedding_comp _ halg)
     (UniformEquiv.arrowCongrLeft₀ h.homeomorph.symm this |>.isUniformEmbedding)
+
+@[deprecated (since := "2024-10-20")]
+alias closedEmbedding_nonUnitalStarAlgHom := isClosedEmbedding_nonUnitalStarAlgHom
 
 variable [IsScalarTower R A A] [SMulCommClass R A A]
 

--- a/Mathlib/Analysis/CStarAlgebra/ContinuousFunctionalCalculus/Unique.lean
+++ b/Mathlib/Analysis/CStarAlgebra/ContinuousFunctionalCalculus/Unique.lean
@@ -169,7 +169,7 @@ instance NNReal.instUniqueContinuousFunctionalCalculus [UniqueContinuousFunction
     have : CompactSpace (spectrum ℝ a) := UniqueContinuousFunctionalCalculus.compactSpace_spectrum a
     rw [← isCompact_iff_compactSpace] at *
     rw [← spectrum.preimage_algebraMap ℝ]
-    exact closedEmbedding_subtype_val isClosed_nonneg |>.isCompact_preimage <| by assumption
+    exact isClosed_nonneg.isClosedEmbedding_subtypeVal.isCompact_preimage <| by assumption
   eq_of_continuous_of_map_id s hs φ ψ hφ hψ h := by
     let s' : Set ℝ := (↑) '' s
     let e : s ≃ₜ s' :=
@@ -376,7 +376,7 @@ instance NNReal.instUniqueNonUnitalContinuousFunctionalCalculus
       UniqueNonUnitalContinuousFunctionalCalculus.compactSpace_quasispectrum a
     rw [← isCompact_iff_compactSpace] at *
     rw [← quasispectrum.preimage_algebraMap ℝ]
-    exact closedEmbedding_subtype_val isClosed_nonneg |>.isCompact_preimage <| by assumption
+    exact isClosed_nonneg.isClosedEmbedding_subtypeVal.isCompact_preimage <| by assumption
   eq_of_continuous_of_map_id s hs _inst h0 φ ψ hφ hψ h := by
     let s' : Set ℝ := (↑) '' s
     let e : s ≃ₜ s' :=

--- a/Mathlib/Analysis/CStarAlgebra/ContinuousFunctionalCalculus/Unital.lean
+++ b/Mathlib/Analysis/CStarAlgebra/ContinuousFunctionalCalculus/Unital.lean
@@ -165,7 +165,7 @@ class ContinuousFunctionalCalculus (R : Type*) {A : Type*} (p : outParam (A → 
   [compactSpace_spectrum (a : A) : CompactSpace (spectrum R a)]
   spectrum_nonempty [Nontrivial A] (a : A) (ha : p a) : (spectrum R a).Nonempty
   exists_cfc_of_predicate : ∀ a, p a → ∃ φ : C(spectrum R a, R) →⋆ₐ[R] A,
-    ClosedEmbedding φ ∧ φ ((ContinuousMap.id R).restrict <| spectrum R a) = a ∧
+    IsClosedEmbedding φ ∧ φ ((ContinuousMap.id R).restrict <| spectrum R a) = a ∧
       (∀ f, spectrum R (φ f) = Set.range f) ∧ ∀ f, p (φ f)
 
 -- this instance should not be activated everywhere but it is useful when developing generic API
@@ -228,13 +228,13 @@ user should instead prefer `cfc` over `cfcHom`.
 noncomputable def cfcHom : C(spectrum R a, R) →⋆ₐ[R] A :=
   (ContinuousFunctionalCalculus.exists_cfc_of_predicate a ha).choose
 
-lemma cfcHom_closedEmbedding :
-    ClosedEmbedding <| (cfcHom ha : C(spectrum R a, R) →⋆ₐ[R] A) :=
+lemma cfcHom_isClosedEmbedding :
+    IsClosedEmbedding <| (cfcHom ha : C(spectrum R a, R) →⋆ₐ[R] A) :=
   (ContinuousFunctionalCalculus.exists_cfc_of_predicate a ha).choose_spec.1
 
 @[fun_prop]
 lemma cfcHom_continuous : Continuous (cfcHom ha : C(spectrum R a, R) →⋆ₐ[R] A) :=
-  cfcHom_closedEmbedding ha |>.continuous
+  cfcHom_isClosedEmbedding ha |>.continuous
 
 lemma cfcHom_id :
     cfcHom ha ((ContinuousMap.id R).restrict <| spectrum R a) = a :=
@@ -252,7 +252,7 @@ lemma cfcHom_predicate (f : C(spectrum R a, R)) :
 lemma cfcHom_eq_of_continuous_of_map_id [UniqueContinuousFunctionalCalculus R A]
     (φ : C(spectrum R a, R) →⋆ₐ[R] A) (hφ₁ : Continuous φ)
     (hφ₂ : φ (.restrict (spectrum R a) <| .id R) = a) : cfcHom ha = φ :=
-  (cfcHom ha).ext_continuousMap a φ (cfcHom_closedEmbedding ha).continuous hφ₁ <| by
+  (cfcHom ha).ext_continuousMap a φ (cfcHom_isClosedEmbedding ha).continuous hφ₁ <| by
     rw [cfcHom_id ha, hφ₂]
 
 theorem cfcHom_comp [UniqueContinuousFunctionalCalculus R A] (f : C(spectrum R a, R))
@@ -263,7 +263,7 @@ theorem cfcHom_comp [UniqueContinuousFunctionalCalculus R A] (f : C(spectrum R a
     (cfcHom ha).comp <| ContinuousMap.compStarAlgHom' R R f'
   suffices cfcHom (cfcHom_predicate ha f) = φ from DFunLike.congr_fun this.symm g
   refine cfcHom_eq_of_continuous_of_map_id (cfcHom_predicate ha f) φ ?_ ?_
-  · exact (cfcHom_closedEmbedding ha).continuous.comp f'.continuous_comp_left
+  · exact (cfcHom_isClosedEmbedding ha).continuous.comp f'.continuous_comp_left
   · simp only [φ, StarAlgHom.comp_apply, ContinuousMap.compStarAlgHom'_apply]
     congr
     ext x
@@ -279,7 +279,7 @@ noncomputable def cfcL {a : A} (ha : p a) : C(spectrum R a, R) →L[R] A :=
   { cfcHom ha with
     toFun := cfcHom ha
     map_smul' := map_smul _
-    cont := (cfcHom_closedEmbedding ha).continuous }
+    cont := (cfcHom_isClosedEmbedding ha).continuous }
 
 end cfcL
 
@@ -398,7 +398,7 @@ lemma eqOn_of_cfc_eq_cfc {f g : R → R} {a : A} (h : cfc f a = cfc g a)
     (hg : ContinuousOn g (spectrum R a) := by cfc_cont_tac) (ha : p a := by cfc_tac) :
     (spectrum R a).EqOn f g := by
   rw [cfc_apply f a, cfc_apply g a] at h
-  have := (cfcHom_closedEmbedding (show p a from ha) (R := R)).inj h
+  have := (cfcHom_isClosedEmbedding (show p a from ha) (R := R)).inj h
   intro x hx
   congrm($(this) ⟨x, hx⟩)
 

--- a/Mathlib/Analysis/CStarAlgebra/ContinuousFunctionalCalculus/Unital.lean
+++ b/Mathlib/Analysis/CStarAlgebra/ContinuousFunctionalCalculus/Unital.lean
@@ -232,6 +232,9 @@ lemma cfcHom_isClosedEmbedding :
     IsClosedEmbedding <| (cfcHom ha : C(spectrum R a, R) →⋆ₐ[R] A) :=
   (ContinuousFunctionalCalculus.exists_cfc_of_predicate a ha).choose_spec.1
 
+@[deprecated (since := "2024-10-20")]
+alias cfcHom_closedEmbedding := cfcHom_isClosedEmbedding
+
 @[fun_prop]
 lemma cfcHom_continuous : Continuous (cfcHom ha : C(spectrum R a, R) →⋆ₐ[R] A) :=
   cfcHom_isClosedEmbedding ha |>.continuous

--- a/Mathlib/Analysis/CStarAlgebra/GelfandDuality.lean
+++ b/Mathlib/Analysis/CStarAlgebra/GelfandDuality.lean
@@ -170,7 +170,7 @@ theorem gelfandTransform_bijective : Function.Bijective (gelfandTransform ℂ A)
     points in `C(characterSpace ℂ A, ℂ)` and is closed under `star`. -/
   have h : rng.topologicalClosure = rng := le_antisymm
     (StarSubalgebra.topologicalClosure_minimal le_rfl
-      (gelfandTransform_isometry A).closedEmbedding.isClosed_range)
+      (gelfandTransform_isometry A).isClosedEmbedding.isClosed_range)
     (StarSubalgebra.le_topologicalClosure _)
   refine h ▸ ContinuousMap.starSubalgebra_topologicalClosure_eq_top_of_separatesPoints
     _ (fun _ _ => ?_)

--- a/Mathlib/Analysis/Calculus/LineDeriv/IntegrationByParts.lean
+++ b/Mathlib/Analysis/Calculus/LineDeriv/IntegrationByParts.lean
@@ -130,7 +130,7 @@ theorem integral_bilinear_hasLineDerivAt_right_eq_neg_left_of_integrable
       -∫ (x : E' × ℝ), (B (f' (L.symm x))) (g (L.symm x)) ∂ν by
     have : μ = Measure.map L.symm ν := by
       simp [Measure.map_map L.symm.continuous.measurable L.continuous.measurable]
-    have hL : ClosedEmbedding L.symm := L.symm.toHomeomorph.closedEmbedding
+    have hL : IsClosedEmbedding L.symm := L.symm.toHomeomorph.isClosedEmbedding
     simpa [this, hL.integral_map] using H
   have L_emb : MeasurableEmbedding L := L.toHomeomorph.measurableEmbedding
   apply integral_bilinear_hasLineDerivAt_right_eq_neg_left_of_integrable_aux2

--- a/Mathlib/Analysis/Convex/Intrinsic.lean
+++ b/Mathlib/Analysis/Convex/Intrinsic.lean
@@ -176,11 +176,11 @@ theorem intrinsicFrontier_union_intrinsicInterior (s : Set P) :
 
 theorem isClosed_intrinsicClosure (hs : IsClosed (affineSpan 𝕜 s : Set P)) :
     IsClosed (intrinsicClosure 𝕜 s) :=
-  (closedEmbedding_subtype_val hs).isClosedMap _ isClosed_closure
+  hs.isClosedEmbedding_subtypeVal.isClosedMap _ isClosed_closure
 
 theorem isClosed_intrinsicFrontier (hs : IsClosed (affineSpan 𝕜 s : Set P)) :
     IsClosed (intrinsicFrontier 𝕜 s) :=
-  (closedEmbedding_subtype_val hs).isClosedMap _ isClosed_frontier
+  hs.isClosedEmbedding_subtypeVal.isClosedMap _ isClosed_frontier
 
 @[simp]
 theorem affineSpan_intrinsicClosure (s : Set P) :

--- a/Mathlib/Analysis/Convolution.lean
+++ b/Mathlib/Analysis/Convolution.lean
@@ -1239,7 +1239,7 @@ theorem contDiffOn_convolution_right_with_param {f : G → E} {n : ℕ∞} (L : 
       ((ContinuousLinearEquiv.arrowCongr isoE' isoF).symm : (E' →L[𝕜] F) →L[𝕜] eE' →L[𝕜] eF) L
   let R := fun q : eP × eG => (ef ⋆[eL, eμ] eg q.1) q.2
   have R_contdiff : ContDiffOn 𝕜 n R ((isoP ⁻¹' s) ×ˢ univ) := by
-    have hek : IsCompact (isoG ⁻¹' k) := isoG.toHomeomorph.closedEmbedding.isCompact_preimage hk
+    have hek : IsCompact (isoG ⁻¹' k) := isoG.toHomeomorph.isClosedEmbedding.isCompact_preimage hk
     have hes : IsOpen (isoP ⁻¹' s) := isoP.continuous.isOpen_preimage _ hs
     refine contDiffOn_convolution_right_with_param_aux eL hes hek ?_ ?_ ?_
     · intro p x hp hx
@@ -1264,9 +1264,9 @@ theorem contDiffOn_convolution_right_with_param {f : G → E} {n : ℕ∞} (L : 
     simp only [LinearIsometryEquiv.coe_coe, (· ∘ ·), ContinuousLinearEquiv.prod_symm,
       ContinuousLinearEquiv.prod_apply]
     simp only [R, convolution, coe_comp', ContinuousLinearEquiv.coe_coe, (· ∘ ·)]
-    rw [ClosedEmbedding.integral_map, ← isoF.integral_comp_comm]
+    rw [IsClosedEmbedding.integral_map, ← isoF.integral_comp_comm]
     · rfl
-    · exact isoG.symm.toHomeomorph.closedEmbedding
+    · exact isoG.symm.toHomeomorph.isClosedEmbedding
   simp_rw [this] at A
   exact A
 

--- a/Mathlib/Analysis/FunctionalSpaces/SobolevInequality.lean
+++ b/Mathlib/Analysis/FunctionalSpaces/SobolevInequality.lean
@@ -334,7 +334,7 @@ theorem lintegral_pow_le_pow_lintegral_fderiv_aux [Fintype ι]
     _ ≤ ∫⁻ xᵢ in Iic (x i), ‖deriv (u ∘ update x i) xᵢ‖₊ := by
         apply le_trans (by simp) (HasCompactSupport.ennnorm_le_lintegral_Ici_deriv _ _ _)
         · exact hu.comp (by convert contDiff_update 1 x i)
-        · exact h2u.comp_closedEmbedding (closedEmbedding_update x i)
+        · exact h2u.comp_isClosedEmbedding (isClosedEmbedding_update x i)
     _ ≤ ∫⁻ xᵢ, (‖fderiv ℝ u (update x i xᵢ)‖₊ : ℝ≥0∞) := ?_
   gcongr with y; swap
   · exact Measure.restrict_le_self

--- a/Mathlib/Analysis/Normed/Algebra/Spectrum.lean
+++ b/Mathlib/Analysis/Normed/Algebra/Spectrum.lean
@@ -133,7 +133,7 @@ instance instCompactSpaceNNReal {A : Type*} [NormedRing A] [NormedAlgebra ℝ A]
     (a : A) [CompactSpace (spectrum ℝ a)] : CompactSpace (spectrum ℝ≥0 a) := by
   rw [← isCompact_iff_compactSpace] at *
   rw [← preimage_algebraMap ℝ]
-  exact closedEmbedding_subtype_val isClosed_nonneg |>.isCompact_preimage <| by assumption
+  exact isClosed_nonneg.isClosedEmbedding_subtypeVal.isCompact_preimage <| by assumption
 
 section QuasispectrumCompact
 
@@ -154,7 +154,7 @@ instance _root_.quasispectrum.instCompactSpaceNNReal [NormedSpace ℝ B] [IsScal
     CompactSpace (quasispectrum ℝ≥0 a) := by
   rw [← isCompact_iff_compactSpace] at *
   rw [← quasispectrum.preimage_algebraMap ℝ]
-  exact closedEmbedding_subtype_val isClosed_nonneg |>.isCompact_preimage <| by assumption
+  exact isClosed_nonneg.isClosedEmbedding_subtypeVal.isCompact_preimage <| by assumption
 
 end QuasispectrumCompact
 

--- a/Mathlib/Analysis/Normed/Module/Basic.lean
+++ b/Mathlib/Analysis/Normed/Module/Basic.lean
@@ -228,8 +228,8 @@ protected theorem NormedSpace.noncompactSpace : NoncompactSpace E := by
     exact ⟨fun h ↦ NormedSpace.unbounded_univ 𝕜 E h.isBounded⟩
   · push_neg at H
     rcases exists_ne (0 : E) with ⟨x, hx⟩
-    suffices ClosedEmbedding (Infinite.natEmbedding 𝕜 · • x) from this.noncompactSpace
-    refine closedEmbedding_of_pairwise_le_dist (norm_pos_iff.2 hx) fun k n hne ↦ ?_
+    suffices IsClosedEmbedding (Infinite.natEmbedding 𝕜 · • x) from this.noncompactSpace
+    refine isClosedEmbedding_of_pairwise_le_dist (norm_pos_iff.2 hx) fun k n hne ↦ ?_
     simp only [dist_eq_norm, ← sub_smul, norm_smul]
     rw [H, one_mul]
     rwa [sub_ne_zero, (Embedding.injective _).ne_iff]

--- a/Mathlib/Analysis/Normed/Module/FiniteDimension.lean
+++ b/Mathlib/Analysis/Normed/Module/FiniteDimension.lean
@@ -519,8 +519,8 @@ lemma ProperSpace.of_locallyCompact_module [Nontrivial E] [LocallyCompactSpace E
   have : LocallyCompactSpace 𝕜 := by
     obtain ⟨v, hv⟩ : ∃ v : E, v ≠ 0 := exists_ne 0
     let L : 𝕜 → E := fun t ↦ t • v
-    have : ClosedEmbedding L := closedEmbedding_smul_left hv
-    apply ClosedEmbedding.locallyCompactSpace this
+    have : IsClosedEmbedding L := isClosedEmbedding_smul_left hv
+    apply IsClosedEmbedding.locallyCompactSpace this
   .of_locallyCompactSpace 𝕜
 
 @[deprecated (since := "2024-01-31")]

--- a/Mathlib/Analysis/Normed/Operator/Compact.lean
+++ b/Mathlib/Analysis/Normed/Operator/Compact.lean
@@ -255,7 +255,7 @@ theorem IsCompactOperator.codRestrict {f : M₁ → M₂} (hf : IsCompactOperato
     (hV : ∀ x, f x ∈ V) (h_closed : IsClosed (V : Set M₂)) :
     IsCompactOperator (Set.codRestrict f V hV) :=
   let ⟨_, hK, hKf⟩ := hf
-  ⟨_, (closedEmbedding_subtype_val h_closed).isCompact_preimage hK, hKf⟩
+  ⟨_, h_closed.isClosedEmbedding_subtypeVal.isCompact_preimage hK, hKf⟩
 
 end CodRestrict
 

--- a/Mathlib/Analysis/SpecialFunctions/ContinuousFunctionalCalculus/ExpLog.lean
+++ b/Mathlib/Analysis/SpecialFunctions/ContinuousFunctionalCalculus/ExpLog.lean
@@ -64,7 +64,7 @@ variable {𝕜 : Type*} {A : Type*} [RCLike 𝕜] {p : A → Prop} [NormedRing A
 lemma exp_eq_normedSpace_exp {a : A} (ha : p a := by cfc_tac) :
     cfc (exp 𝕜 : 𝕜 → 𝕜) a = exp 𝕜 a := by
   conv_rhs => rw [← cfc_id 𝕜 a ha, cfc_apply id a ha]
-  have h := (cfcHom_closedEmbedding (R := 𝕜) (show p a from ha)).continuous
+  have h := (cfcHom_isClosedEmbedding (R := 𝕜) (show p a from ha)).continuous
   have _ : ContinuousOn (exp 𝕜) (spectrum 𝕜 a) := exp_continuous.continuousOn
   simp_rw [← map_exp 𝕜 _ h, cfc_apply (exp 𝕜) a ha]
   congr 1

--- a/Mathlib/Analysis/SpecialFunctions/Log/ENNRealLogExp.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Log/ENNRealLogExp.lean
@@ -135,5 +135,5 @@ end Measurability
 end ENNReal
 
 instance : PolishSpace EReal :=
-  ClosedEmbedding.polishSpace ⟨ENNReal.logOrderIso.symm.toHomeomorph.embedding,
+  IsClosedEmbedding.polishSpace ⟨ENNReal.logOrderIso.symm.toHomeomorph.embedding,
     ENNReal.logOrderIso.symm.toHomeomorph.range_coe ▸ isClosed_univ⟩

--- a/Mathlib/CategoryTheory/Galois/Topology.lean
+++ b/Mathlib/CategoryTheory/Galois/Topology.lean
@@ -79,26 +79,26 @@ lemma autEmbedding_range_isClosed : IsClosed (Set.range (autEmbedding F)) := by
   · fun_prop
   · fun_prop
 
-lemma autEmbedding_closedEmbedding : ClosedEmbedding (autEmbedding F) where
+lemma autEmbedding_isClosedEmbedding : IsClosedEmbedding (autEmbedding F) where
   induced := rfl
   inj := autEmbedding_injective F
   isClosed_range := autEmbedding_range_isClosed F
 
-instance : CompactSpace (Aut F) := ClosedEmbedding.compactSpace (autEmbedding_closedEmbedding F)
+instance : CompactSpace (Aut F) := IsClosedEmbedding.compactSpace (autEmbedding_isClosedEmbedding F)
 
 instance : T2Space (Aut F) :=
   T2Space.of_injective_continuous (autEmbedding_injective F) continuous_induced_dom
 
 instance : TotallyDisconnectedSpace (Aut F) :=
-  (Embedding.isTotallyDisconnected_range (autEmbedding_closedEmbedding F).embedding).mp
+  (Embedding.isTotallyDisconnected_range (autEmbedding_isClosedEmbedding F).embedding).mp
     (isTotallyDisconnected_of_totallyDisconnectedSpace _)
 
 instance : ContinuousMul (Aut F) :=
   Inducing.continuousMul (autEmbedding F)
-    (autEmbedding_closedEmbedding F).toInducing
+    (autEmbedding_isClosedEmbedding F).toInducing
 
 instance : ContinuousInv (Aut F) :=
-  Inducing.continuousInv (autEmbedding_closedEmbedding F).toInducing (fun _ ↦ rfl)
+  Inducing.continuousInv (autEmbedding_isClosedEmbedding F).toInducing (fun _ ↦ rfl)
 
 instance : TopologicalGroup (Aut F) := ⟨⟩
 

--- a/Mathlib/CategoryTheory/Galois/Topology.lean
+++ b/Mathlib/CategoryTheory/Galois/Topology.lean
@@ -84,6 +84,9 @@ lemma autEmbedding_isClosedEmbedding : IsClosedEmbedding (autEmbedding F) where
   inj := autEmbedding_injective F
   isClosed_range := autEmbedding_range_isClosed F
 
+@[deprecated (since := "2024-10-20")]
+alias autEmbedding_closedEmbedding := autEmbedding_isClosedEmbedding
+
 instance : CompactSpace (Aut F) := IsClosedEmbedding.compactSpace (autEmbedding_isClosedEmbedding F)
 
 instance : T2Space (Aut F) :=

--- a/Mathlib/Geometry/Manifold/SmoothManifoldWithCorners.lean
+++ b/Mathlib/Geometry/Manifold/SmoothManifoldWithCorners.lean
@@ -280,8 +280,11 @@ protected theorem image_eq (s : Set H) : I '' s = I.symm ⁻¹' s ∩ range I :=
   · rw [I.source_eq]; exact subset_univ _
   · rw [inter_comm, I.target_eq, I.toPartialEquiv_coe_symm]
 
-protected theorem isClosedEmbedding : IsClosedEmbedding I :=
+theorem isClosedEmbedding : IsClosedEmbedding I :=
   I.leftInverse.isClosedEmbedding I.continuous_symm I.continuous
+
+@[deprecated (since := "2024-10-20")]
+alias closedEmbedding := isClosedEmbedding
 
 theorem isClosed_range : IsClosed (range I) :=
   I.isClosedEmbedding.isClosed_range

--- a/Mathlib/Geometry/Manifold/SmoothManifoldWithCorners.lean
+++ b/Mathlib/Geometry/Manifold/SmoothManifoldWithCorners.lean
@@ -280,19 +280,19 @@ protected theorem image_eq (s : Set H) : I '' s = I.symm ⁻¹' s ∩ range I :=
   · rw [I.source_eq]; exact subset_univ _
   · rw [inter_comm, I.target_eq, I.toPartialEquiv_coe_symm]
 
-protected theorem closedEmbedding : ClosedEmbedding I :=
-  I.leftInverse.closedEmbedding I.continuous_symm I.continuous
+protected theorem isClosedEmbedding : IsClosedEmbedding I :=
+  I.leftInverse.isClosedEmbedding I.continuous_symm I.continuous
 
 theorem isClosed_range : IsClosed (range I) :=
-  I.closedEmbedding.isClosed_range
+  I.isClosedEmbedding.isClosed_range
 
 @[deprecated (since := "2024-03-17")] alias closed_range := isClosed_range
 
 theorem map_nhds_eq (x : H) : map I (𝓝 x) = 𝓝[range I] I x :=
-  I.closedEmbedding.toEmbedding.map_nhds_eq x
+  I.isClosedEmbedding.toEmbedding.map_nhds_eq x
 
 theorem map_nhdsWithin_eq (s : Set H) (x : H) : map I (𝓝[s] x) = 𝓝[I '' s] I x :=
-  I.closedEmbedding.toEmbedding.map_nhdsWithin_eq s x
+  I.isClosedEmbedding.toEmbedding.map_nhdsWithin_eq s x
 
 theorem image_mem_nhdsWithin {x : H} {s : Set H} (hs : s ∈ 𝓝 x) : I '' s ∈ 𝓝[range I] I x :=
   I.map_nhds_eq x ▸ image_mem_map hs
@@ -348,7 +348,7 @@ open TopologicalSpace
 
 protected theorem secondCountableTopology [SecondCountableTopology E] (I : ModelWithCorners 𝕜 E H) :
     SecondCountableTopology H :=
-  I.closedEmbedding.toEmbedding.secondCountableTopology
+  I.isClosedEmbedding.toEmbedding.secondCountableTopology
 
 end ModelWithCorners
 

--- a/Mathlib/Geometry/Manifold/WhitneyEmbedding.lean
+++ b/Mathlib/Geometry/Manifold/WhitneyEmbedding.lean
@@ -128,9 +128,9 @@ supports of bump functions, then for some `n` it can be embedded into the `n`-di
 Euclidean space. -/
 theorem exists_embedding_euclidean_of_compact [T2Space M] [CompactSpace M] :
     ∃ (n : ℕ) (e : M → EuclideanSpace ℝ (Fin n)),
-      Smooth I (𝓡 n) e ∧ ClosedEmbedding e ∧ ∀ x : M, Injective (mfderiv I (𝓡 n) e x) := by
+      Smooth I (𝓡 n) e ∧ IsClosedEmbedding e ∧ ∀ x : M, Injective (mfderiv I (𝓡 n) e x) := by
   rcases SmoothBumpCovering.exists_isSubordinate I isClosed_univ fun (x : M) _ => univ_mem with
     ⟨ι, f, -⟩
   haveI := f.fintype
   rcases f.exists_immersion_euclidean with ⟨n, e, hsmooth, hinj, hinj_mfderiv⟩
-  exact ⟨n, e, hsmooth, hsmooth.continuous.closedEmbedding hinj, hinj_mfderiv⟩
+  exact ⟨n, e, hsmooth, hsmooth.continuous.isClosedEmbedding hinj, hinj_mfderiv⟩

--- a/Mathlib/LinearAlgebra/Matrix/HermitianFunctionalCalculus.lean
+++ b/Mathlib/LinearAlgebra/Matrix/HermitianFunctionalCalculus.lean
@@ -87,10 +87,10 @@ noncomputable def cfcAux : C(spectrum ℝ A, ℝ) →⋆ₐ[ℝ] (Matrix n n �
     ext
     simp
 
-lemma closedEmbedding_cfcAux : ClosedEmbedding hA.cfcAux := by
+lemma isClosedEmbedding_cfcAux : IsClosedEmbedding hA.cfcAux := by
   have h0 : FiniteDimensional ℝ C(spectrum ℝ A, ℝ) :=
     FiniteDimensional.of_injective (ContinuousMap.coeFnLinearMap ℝ (M := ℝ)) DFunLike.coe_injective
-  refine LinearMap.closedEmbedding_of_injective (𝕜 := ℝ) (E := C(spectrum ℝ A, ℝ))
+  refine LinearMap.isClosedEmbedding_of_injective (𝕜 := ℝ) (E := C(spectrum ℝ A, ℝ))
     (F := Matrix n n 𝕜) (f := hA.cfcAux) <| LinearMap.ker_eq_bot'.mpr fun f hf ↦ ?_
   have h2 :
       diagonal (RCLike.ofReal ∘ f ∘ fun i ↦ ⟨hA.eigenvalues i, hA.eigenvalues_mem_spectrum_real i⟩)
@@ -117,7 +117,7 @@ instance instContinuousFunctionalCalculus :
     ContinuousFunctionalCalculus ℝ (IsSelfAdjoint : Matrix n n 𝕜 → Prop) where
   exists_cfc_of_predicate a ha := by
     replace ha : IsHermitian a := ha
-    refine ⟨ha.cfcAux, ha.closedEmbedding_cfcAux, ha.cfcAux_id, fun f ↦ ?map_spec,
+    refine ⟨ha.cfcAux, ha.isClosedEmbedding_cfcAux, ha.cfcAux_id, fun f ↦ ?map_spec,
       fun f ↦ ?hermitian⟩
     case map_spec =>
       apply Set.eq_of_subset_of_subset
@@ -159,7 +159,7 @@ protected noncomputable def cfc (f : ℝ → ℝ) : Matrix n n 𝕜 :=
 
 lemma cfc_eq (f : ℝ → ℝ) : cfc f A = hA.cfc f := by
   have hA' : IsSelfAdjoint A := hA
-  have := cfcHom_eq_of_continuous_of_map_id hA' hA.cfcAux hA.closedEmbedding_cfcAux.continuous
+  have := cfcHom_eq_of_continuous_of_map_id hA' hA.cfcAux hA.isClosedEmbedding_cfcAux.continuous
     hA.cfcAux_id
   rw [cfc_apply f A hA' (by rw [continuousOn_iff_continuous_restrict]; fun_prop), this]
   simp only [cfcAux_apply, ContinuousMap.coe_mk, Function.comp_def, Set.restrict_apply,

--- a/Mathlib/LinearAlgebra/Matrix/HermitianFunctionalCalculus.lean
+++ b/Mathlib/LinearAlgebra/Matrix/HermitianFunctionalCalculus.lean
@@ -107,6 +107,9 @@ lemma isClosedEmbedding_cfcAux : IsClosedEmbedding hA.cfcAux := by
   have := (diagonal_eq_diagonal_iff).mp h2
   refine RCLike.ofReal_eq_zero.mp (this i)
 
+@[deprecated (since := "2024-10-20")]
+alias closedEmbedding_cfcAux := isClosedEmbedding_cfcAux
+
 lemma cfcAux_id : hA.cfcAux (.restrict (spectrum ℝ A) (.id ℝ)) = A := by
   conv_rhs => rw [hA.spectral_theorem]
   congr!

--- a/Mathlib/MeasureTheory/Constructions/BorelSpace/Basic.lean
+++ b/Mathlib/MeasureTheory/Constructions/BorelSpace/Basic.lean
@@ -472,7 +472,7 @@ is ae-measurable. -/
 theorem Continuous.aemeasurable {f : α → γ} (h : Continuous f) {μ : Measure α} : AEMeasurable f μ :=
   h.measurable.aemeasurable
 
-theorem ClosedEmbedding.measurable {f : α → γ} (hf : ClosedEmbedding f) : Measurable f :=
+theorem IsClosedEmbedding.measurable {f : α → γ} (hf : IsClosedEmbedding f) : Measurable f :=
   hf.continuous.measurable
 
 /-- If a function is defined piecewise in terms of functions which are continuous on their
@@ -632,7 +632,7 @@ protected theorem Embedding.measurableEmbedding {f : α → β} (h₁ : Embeddin
       (((↑) : range f → β) ∘ (Homeomorph.ofEmbedding f h₁).toMeasurableEquiv) from
     (MeasurableEmbedding.subtype_coe h₂).comp (MeasurableEquiv.measurableEmbedding _)
 
-protected theorem ClosedEmbedding.measurableEmbedding {f : α → β} (h : ClosedEmbedding f) :
+protected theorem IsClosedEmbedding.measurableEmbedding {f : α → β} (h : IsClosedEmbedding f) :
     MeasurableEmbedding f :=
   h.toEmbedding.measurableEmbedding h.isClosed_range.measurableSet
 

--- a/Mathlib/MeasureTheory/Constructions/BorelSpace/Basic.lean
+++ b/Mathlib/MeasureTheory/Constructions/BorelSpace/Basic.lean
@@ -475,6 +475,9 @@ theorem Continuous.aemeasurable {f : α → γ} (h : Continuous f) {μ : Measure
 theorem IsClosedEmbedding.measurable {f : α → γ} (hf : IsClosedEmbedding f) : Measurable f :=
   hf.continuous.measurable
 
+@[deprecated (since := "2024-10-20")]
+alias ClosedEmbedding.measurable := IsClosedEmbedding.measurable
+
 /-- If a function is defined piecewise in terms of functions which are continuous on their
 respective pieces, then it is measurable. -/
 theorem ContinuousOn.measurable_piecewise {f g : α → γ} {s : Set α} [∀ j : α, Decidable (j ∈ s)]
@@ -635,6 +638,9 @@ protected theorem Embedding.measurableEmbedding {f : α → β} (h₁ : Embeddin
 protected theorem IsClosedEmbedding.measurableEmbedding {f : α → β} (h : IsClosedEmbedding f) :
     MeasurableEmbedding f :=
   h.toEmbedding.measurableEmbedding h.isClosed_range.measurableSet
+
+@[deprecated (since := "2024-10-20")]
+alias ClosedEmbedding.measurableEmbedding := IsClosedEmbedding.measurableEmbedding
 
 protected theorem IsOpenEmbedding.measurableEmbedding {f : α → β} (h : IsOpenEmbedding f) :
     MeasurableEmbedding f :=

--- a/Mathlib/MeasureTheory/Constructions/BorelSpace/ContinuousLinearMap.lean
+++ b/Mathlib/MeasureTheory/Constructions/BorelSpace/ContinuousLinearMap.lean
@@ -90,10 +90,10 @@ variable [BorelSpace 𝕜] {E : Type*} [NormedAddCommGroup E] [NormedSpace 𝕜 
 
 theorem measurable_smul_const {f : α → 𝕜} {c : E} (hc : c ≠ 0) :
     (Measurable fun x => f x • c) ↔ Measurable f :=
-  (closedEmbedding_smul_left hc).measurableEmbedding.measurable_comp_iff
+  (isClosedEmbedding_smul_left hc).measurableEmbedding.measurable_comp_iff
 
 theorem aemeasurable_smul_const {f : α → 𝕜} {μ : Measure α} {c : E} (hc : c ≠ 0) :
     AEMeasurable (fun x => f x • c) μ ↔ AEMeasurable f μ :=
-  (closedEmbedding_smul_left hc).measurableEmbedding.aemeasurable_comp_iff
+  (isClosedEmbedding_smul_left hc).measurableEmbedding.aemeasurable_comp_iff
 
 end NormedSpace

--- a/Mathlib/MeasureTheory/Constructions/Polish/EmbeddingReal.lean
+++ b/Mathlib/MeasureTheory/Constructions/Polish/EmbeddingReal.lean
@@ -24,7 +24,7 @@ theorem exists_nat_measurableEquiv_range_coe_fin_of_finite [Finite α] :
 theorem measurableEquiv_range_coe_nat_of_infinite_of_countable [Infinite α] [Countable α] :
     Nonempty (α ≃ᵐ range ((↑) : ℕ → ℝ)) := by
   have : PolishSpace (range ((↑) : ℕ → ℝ)) :=
-    Nat.closedEmbedding_coe_real.isClosedMap.isClosed_range.polishSpace
+    Nat.isClosedEmbedding_coe_real.isClosedMap.isClosed_range.polishSpace
   refine ⟨PolishSpace.Equiv.measurableEquiv ?_⟩
   refine (nonempty_equiv_of_countable.some : α ≃ ℕ).trans ?_
   exact Equiv.ofInjective ((↑) : ℕ → ℝ) Nat.cast_injective

--- a/Mathlib/MeasureTheory/Function/StronglyMeasurable/Basic.lean
+++ b/Mathlib/MeasureTheory/Function/StronglyMeasurable/Basic.lean
@@ -691,7 +691,7 @@ theorem _root_.Embedding.comp_stronglyMeasurable_iff {m : MeasurableSpace α} [T
     ⟨fun H => stronglyMeasurable_iff_measurable_separable.2 ⟨?_, ?_⟩, fun H =>
       hg.continuous.comp_stronglyMeasurable H⟩
   · let G : β → range g := rangeFactorization g
-    have hG : ClosedEmbedding G :=
+    have hG : IsClosedEmbedding G :=
       { hg.codRestrict _ _ with
         isClosed_range := by
           rw [surjective_onto_range.range_eq]
@@ -1513,7 +1513,7 @@ theorem _root_.Embedding.aestronglyMeasurable_comp_iff [PseudoMetrizableSpace β
     ⟨fun H => aestronglyMeasurable_iff_aemeasurable_separable.2 ⟨?_, ?_⟩, fun H =>
       hg.continuous.comp_aestronglyMeasurable H⟩
   · let G : β → range g := rangeFactorization g
-    have hG : ClosedEmbedding G :=
+    have hG : IsClosedEmbedding G :=
       { hg.codRestrict _ _ with
         isClosed_range := by rw [surjective_onto_range.range_eq]; exact isClosed_univ }
     have : AEMeasurable (G ∘ f) μ := AEMeasurable.subtype_mk H.aemeasurable

--- a/Mathlib/MeasureTheory/Function/StronglyMeasurable/Lemmas.lean
+++ b/Mathlib/MeasureTheory/Function/StronglyMeasurable/Lemmas.lean
@@ -46,7 +46,7 @@ variable {E : Type*} [NormedAddCommGroup E] [NormedSpace 𝕜 E]
 
 theorem aestronglyMeasurable_smul_const_iff {f : α → 𝕜} {c : E} (hc : c ≠ 0) :
     AEStronglyMeasurable (fun x => f x • c) μ ↔ AEStronglyMeasurable f μ :=
-  (closedEmbedding_smul_left hc).toEmbedding.aestronglyMeasurable_comp_iff
+  (isClosedEmbedding_smul_left hc).toEmbedding.aestronglyMeasurable_comp_iff
 
 end NormedSpace
 

--- a/Mathlib/MeasureTheory/Group/Measure.lean
+++ b/Mathlib/MeasureTheory/Group/Measure.lean
@@ -775,7 +775,7 @@ nonrec theorem _root_.MulEquiv.isHaarMeasure_map [BorelSpace G] [TopologicalGrou
     [TopologicalGroup H] (e : G ≃* H) (he : Continuous e) (hesymm : Continuous e.symm) :
     IsHaarMeasure (Measure.map e μ) :=
   let f : G ≃ₜ H := .mk e
-  isHaarMeasure_map μ (e : G →* H) he e.surjective f.closedEmbedding.tendsto_cocompact
+  isHaarMeasure_map μ (e : G →* H) he e.surjective f.isClosedEmbedding.tendsto_cocompact
 
 /-- A convenience wrapper for MeasureTheory.Measure.isAddHaarMeasure_map`. -/
 instance _root_.ContinuousLinearEquiv.isAddHaarMeasure_map

--- a/Mathlib/MeasureTheory/Integral/Bochner.lean
+++ b/Mathlib/MeasureTheory/Integral/Bochner.lean
@@ -1574,8 +1574,8 @@ theorem _root_.MeasurableEmbedding.integral_map {β} {_ : MeasurableSpace β} {f
   · rw [integral_non_aestronglyMeasurable hgm, integral_non_aestronglyMeasurable]
     exact fun hgf => hgm (hf.aestronglyMeasurable_map_iff.2 hgf)
 
-theorem _root_.ClosedEmbedding.integral_map {β} [TopologicalSpace α] [BorelSpace α]
-    [TopologicalSpace β] [MeasurableSpace β] [BorelSpace β] {φ : α → β} (hφ : ClosedEmbedding φ)
+theorem _root_.IsClosedEmbedding.integral_map {β} [TopologicalSpace α] [BorelSpace α]
+    [TopologicalSpace β] [MeasurableSpace β] [BorelSpace β] {φ : α → β} (hφ : IsClosedEmbedding φ)
     (f : β → G) : ∫ y, f y ∂Measure.map φ μ = ∫ x, f (φ x) ∂μ :=
   hφ.measurableEmbedding.integral_map _
 

--- a/Mathlib/MeasureTheory/Integral/Bochner.lean
+++ b/Mathlib/MeasureTheory/Integral/Bochner.lean
@@ -1579,6 +1579,9 @@ theorem _root_.IsClosedEmbedding.integral_map {β} [TopologicalSpace α] [BorelS
     (f : β → G) : ∫ y, f y ∂Measure.map φ μ = ∫ x, f (φ x) ∂μ :=
   hφ.measurableEmbedding.integral_map _
 
+@[deprecated (since := "2024-10-20")]
+alias _root_.ClosedEmbedding.integral_map := _root_.IsClosedEmbedding.integral_map
+
 theorem integral_map_equiv {β} [MeasurableSpace β] (e : α ≃ᵐ β) (f : β → G) :
     ∫ y, f y ∂Measure.map e μ = ∫ x, f (e x) ∂μ :=
   e.measurableEmbedding.integral_map f

--- a/Mathlib/MeasureTheory/Integral/IntervalIntegral.lean
+++ b/Mathlib/MeasureTheory/Integral/IntervalIntegral.lean
@@ -271,7 +271,7 @@ theorem comp_mul_left (hf : IntervalIntegrable f volume a b) (c : ℝ) :
   rcases eq_or_ne c 0 with (hc | hc); · rw [hc]; simp
   rw [intervalIntegrable_iff'] at hf ⊢
   have A : MeasurableEmbedding fun x => x * c⁻¹ :=
-    (Homeomorph.mulRight₀ _ (inv_ne_zero hc)).closedEmbedding.measurableEmbedding
+    (Homeomorph.mulRight₀ _ (inv_ne_zero hc)).isClosedEmbedding.measurableEmbedding
   rw [← Real.smul_map_volume_mul_right (inv_ne_zero hc), IntegrableOn, Measure.restrict_smul,
     integrable_smul_measure (by simpa : ENNReal.ofReal |c⁻¹| ≠ 0) ENNReal.ofReal_ne_top,
     ← IntegrableOn, MeasurableEmbedding.integrableOn_map_iff A]
@@ -294,7 +294,7 @@ theorem comp_add_right (hf : IntervalIntegrable f volume a b) (c : ℝ) :
   · exact IntervalIntegrable.symm (this hf.symm (le_of_not_le h))
   rw [intervalIntegrable_iff'] at hf ⊢
   have A : MeasurableEmbedding fun x => x + c :=
-    (Homeomorph.addRight c).closedEmbedding.measurableEmbedding
+    (Homeomorph.addRight c).isClosedEmbedding.measurableEmbedding
   rw [← map_add_right_eq_self volume c] at hf
   convert (MeasurableEmbedding.integrableOn_map_iff A).mp hf using 1
   rw [preimage_add_const_uIcc]
@@ -624,7 +624,7 @@ variable {a b c d : ℝ} (f : ℝ → E)
 theorem integral_comp_mul_right (hc : c ≠ 0) :
     (∫ x in a..b, f (x * c)) = c⁻¹ • ∫ x in a * c..b * c, f x := by
   have A : MeasurableEmbedding fun x => x * c :=
-    (Homeomorph.mulRight₀ c hc).closedEmbedding.measurableEmbedding
+    (Homeomorph.mulRight₀ c hc).isClosedEmbedding.measurableEmbedding
   conv_rhs => rw [← Real.smul_map_volume_mul_right hc]
   simp_rw [integral_smul_measure, intervalIntegral, A.setIntegral_map,
     ENNReal.toReal_ofReal (abs_nonneg c)]
@@ -661,7 +661,7 @@ theorem inv_smul_integral_comp_div (c) :
 @[simp]
 theorem integral_comp_add_right (d) : (∫ x in a..b, f (x + d)) = ∫ x in a + d..b + d, f x :=
   have A : MeasurableEmbedding fun x => x + d :=
-    (Homeomorph.addRight d).closedEmbedding.measurableEmbedding
+    (Homeomorph.addRight d).isClosedEmbedding.measurableEmbedding
   calc
     (∫ x in a..b, f (x + d)) = ∫ x in a + d..b + d, f x ∂Measure.map (fun x => x + d) volume := by
       simp [intervalIntegral, A.setIntegral_map]

--- a/Mathlib/MeasureTheory/Integral/SetIntegral.lean
+++ b/Mathlib/MeasureTheory/Integral/SetIntegral.lean
@@ -558,13 +558,13 @@ theorem _root_.MeasurableEmbedding.setIntegral_map {Y} {_ : MeasurableSpace Y} {
 @[deprecated (since := "2024-04-17")]
 alias _root_.MeasurableEmbedding.set_integral_map := _root_.MeasurableEmbedding.setIntegral_map
 
-theorem _root_.ClosedEmbedding.setIntegral_map [TopologicalSpace X] [BorelSpace X] {Y}
+theorem _root_.IsClosedEmbedding.setIntegral_map [TopologicalSpace X] [BorelSpace X] {Y}
     [MeasurableSpace Y] [TopologicalSpace Y] [BorelSpace Y] {g : X → Y} {f : Y → E} (s : Set Y)
-    (hg : ClosedEmbedding g) : ∫ y in s, f y ∂Measure.map g μ = ∫ x in g ⁻¹' s, f (g x) ∂μ :=
+    (hg : IsClosedEmbedding g) : ∫ y in s, f y ∂Measure.map g μ = ∫ x in g ⁻¹' s, f (g x) ∂μ :=
   hg.measurableEmbedding.setIntegral_map _ _
 
 @[deprecated (since := "2024-04-17")]
-alias _root_.ClosedEmbedding.set_integral_map := _root_.ClosedEmbedding.setIntegral_map
+alias _root_.IsClosedEmbedding.set_integral_map := _root_.IsClosedEmbedding.setIntegral_map
 
 theorem MeasurePreserving.setIntegral_preimage_emb {Y} {_ : MeasurableSpace Y} {f : X → Y} {ν}
     (h₁ : MeasurePreserving f μ ν) (h₂ : MeasurableEmbedding f) (g : Y → E) (s : Set Y) :

--- a/Mathlib/MeasureTheory/Integral/SetIntegral.lean
+++ b/Mathlib/MeasureTheory/Integral/SetIntegral.lean
@@ -563,8 +563,14 @@ theorem _root_.IsClosedEmbedding.setIntegral_map [TopologicalSpace X] [BorelSpac
     (hg : IsClosedEmbedding g) : ∫ y in s, f y ∂Measure.map g μ = ∫ x in g ⁻¹' s, f (g x) ∂μ :=
   hg.measurableEmbedding.setIntegral_map _ _
 
+@[deprecated (since := "2024-10-20")]
+alias _root_.ClosedEmbedding.setIntegral_map := IsClosedEmbedding.setIntegral_map
+
 @[deprecated (since := "2024-04-17")]
 alias _root_.IsClosedEmbedding.set_integral_map := _root_.IsClosedEmbedding.setIntegral_map
+
+@[deprecated (since := "2024-10-20")]
+alias _root_.ClosedEmbedding.set_integral_map := IsClosedEmbedding.set_integral_map
 
 theorem MeasurePreserving.setIntegral_preimage_emb {Y} {_ : MeasurableSpace Y} {f : X → Y} {ν}
     (h₁ : MeasurePreserving f μ ν) (h₂ : MeasurableEmbedding f) (g : Y → E) (s : Set Y) :

--- a/Mathlib/MeasureTheory/Measure/Lebesgue/Integral.lean
+++ b/Mathlib/MeasureTheory/Measure/Lebesgue/Integral.lean
@@ -80,7 +80,7 @@ itself, it does not apply when `f` is more complicated -/
 theorem integral_comp_neg_Iic {E : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E]
     (c : ℝ) (f : ℝ → E) : (∫ x in Iic c, f (-x)) = ∫ x in Ioi (-c), f x := by
   have A : MeasurableEmbedding fun x : ℝ => -x :=
-    (Homeomorph.neg ℝ).closedEmbedding.measurableEmbedding
+    (Homeomorph.neg ℝ).isClosedEmbedding.measurableEmbedding
   have := MeasurableEmbedding.setIntegral_map (μ := volume) A f (Ici (-c))
   rw [Measure.map_neg_eq_self (volume : Measure ℝ)] at this
   simp_rw [← integral_Ici_eq_integral_Ioi, this, neg_preimage, preimage_neg_Ici, neg_neg]

--- a/Mathlib/NumberTheory/Modular.lean
+++ b/Mathlib/NumberTheory/Modular.lean
@@ -113,7 +113,7 @@ attribute [local simp] ContinuousLinearMap.coe_smul
 theorem tendsto_normSq_coprime_pair :
     Filter.Tendsto (fun p : Fin 2 → ℤ => normSq ((p 0 : ℂ) * z + p 1)) cofinite atTop := by
   -- using this instance rather than the automatic `Function.module` makes unification issues in
-  -- `LinearEquiv.closedEmbedding_of_injective` less bad later in the proof.
+  -- `LinearEquiv.isClosedEmbedding_of_injective` less bad later in the proof.
   letI : Module ℝ (Fin 2 → ℝ) := NormedSpace.toModule
   let π₀ : (Fin 2 → ℝ) →ₗ[ℝ] ℝ := LinearMap.proj 0
   let π₁ : (Fin 2 → ℝ) →ₗ[ℝ] ℝ := LinearMap.proj 1
@@ -149,7 +149,7 @@ theorem tendsto_normSq_coprime_pair :
       rw [f_def, RingHom.map_add, RingHom.map_mul, mul_add, mul_left_comm, mul_conj, conj_ofReal,
         conj_ofReal, ← ofReal_mul, add_im, ofReal_im, zero_add, inv_mul_eq_iff_eq_mul₀ hz]
       simp only [ofReal_im, ofReal_re, mul_im, zero_add, mul_zero]
-  have hf' : ClosedEmbedding f := f.closedEmbedding_of_injective hf
+  have hf' : IsClosedEmbedding f := f.isClosedEmbedding_of_injective hf
   have h₂ : Tendsto (fun p : Fin 2 → ℤ => ((↑) : ℤ → ℝ) ∘ p) cofinite (cocompact _) := by
     convert Tendsto.pi_map_coprodᵢ fun _ => Int.tendsto_coe_cofinite
     · rw [coprodᵢ_cofinite]
@@ -207,8 +207,8 @@ theorem tendsto_lcRow0 {cd : Fin 2 → ℤ} (hcd : IsCoprime (cd 0) (cd 1)) :
         Tendsto.pi_map_coprodᵢ fun _ : Fin 2 => Int.tendsto_coe_cofinite
   have hf₁ : Tendsto f₁ cofinite (cocompact _) :=
     cocompact_ℝ_to_cofinite_ℤ_matrix.comp Subtype.coe_injective.tendsto_cofinite
-  have hf₂ : ClosedEmbedding (lcRow0Extend hcd) :=
-    (lcRow0Extend hcd).toContinuousLinearEquiv.toHomeomorph.closedEmbedding
+  have hf₂ : IsClosedEmbedding (lcRow0Extend hcd) :=
+    (lcRow0Extend hcd).toContinuousLinearEquiv.toHomeomorph.isClosedEmbedding
   convert hf₂.tendsto_cocompact.comp (hf₁.comp Subtype.coe_injective.tendsto_cofinite) using 1
   ext ⟨g, rfl⟩ i j : 3
   fin_cases i <;> [fin_cases j; skip]
@@ -258,7 +258,7 @@ theorem tendsto_abs_re_smul {p : Fin 2 → ℤ} (hp : IsCoprime (p 0) (p 1)) :
   let f := Homeomorph.mulRight₀ _ this
   let ff := Homeomorph.addRight
     (((p 1 : ℂ) * z - p 0) / (((p 0 : ℂ) ^ 2 + (p 1 : ℂ) ^ 2) * (p 0 * z + p 1))).re
-  convert (f.trans ff).closedEmbedding.tendsto_cocompact.comp (tendsto_lcRow0 hp) with _ _ g
+  convert (f.trans ff).isClosedEmbedding.tendsto_cocompact.comp (tendsto_lcRow0 hp) with _ _ g
   change
     ((g : SL(2, ℤ)) • z).re =
       lcRow0 p ↑(↑g : SL(2, ℝ)) / ((p 0 : ℝ) ^ 2 + (p 1 : ℝ) ^ 2) +

--- a/Mathlib/Topology/Algebra/Constructions/DomMulAct.lean
+++ b/Mathlib/Topology/Algebra/Constructions/DomMulAct.lean
@@ -54,6 +54,9 @@ theorem coe_mkHomeomorph_symm : ⇑(mkHomeomorph : M ≃ₜ Mᵈᵐᵃ).symm = m
   mkHomeomorph.isClosedEmbedding
 @[to_additive] theorem quotientMap_mk : QuotientMap (@mk M) := mkHomeomorph.quotientMap
 
+@[deprecated (since := "2024-10-20")]
+alias closedEmbedding_mk := isClosedEmbedding_mk
+
 @[deprecated (since := "2024-10-18")]
 alias openEmbedding_mk := isOpenEmbedding_mk
 
@@ -69,6 +72,9 @@ alias openEmbedding_mk_symm := isOpenEmbedding_mk_symm
 @[to_additive]
 theorem isClosedEmbedding_mk_symm : IsClosedEmbedding (@mk M).symm :=
   mkHomeomorph.symm.isClosedEmbedding
+
+@[deprecated (since := "2024-10-20")]
+alias closedEmbedding_mk_symm := isClosedEmbedding_mk_symm
 
 @[to_additive]
 theorem quotientMap_mk_symm : QuotientMap (@mk M).symm := mkHomeomorph.symm.quotientMap

--- a/Mathlib/Topology/Algebra/Constructions/DomMulAct.lean
+++ b/Mathlib/Topology/Algebra/Constructions/DomMulAct.lean
@@ -50,7 +50,8 @@ theorem coe_mkHomeomorph_symm : ⇑(mkHomeomorph : M ≃ₜ Mᵈᵐᵃ).symm = m
 @[to_additive] theorem inducing_mk : Inducing (@mk M) := mkHomeomorph.inducing
 @[to_additive] theorem embedding_mk : Embedding (@mk M) := mkHomeomorph.embedding
 @[to_additive] theorem isOpenEmbedding_mk : IsOpenEmbedding (@mk M) := mkHomeomorph.isOpenEmbedding
-@[to_additive] theorem closedEmbedding_mk : ClosedEmbedding (@mk M) := mkHomeomorph.closedEmbedding
+@[to_additive] theorem isClosedEmbedding_mk : IsClosedEmbedding (@mk M) :=
+  mkHomeomorph.isClosedEmbedding
 @[to_additive] theorem quotientMap_mk : QuotientMap (@mk M) := mkHomeomorph.quotientMap
 
 @[deprecated (since := "2024-10-18")]
@@ -66,7 +67,8 @@ theorem isOpenEmbedding_mk_symm : IsOpenEmbedding (@mk M).symm := mkHomeomorph.s
 alias openEmbedding_mk_symm := isOpenEmbedding_mk_symm
 
 @[to_additive]
-theorem closedEmbedding_mk_symm : ClosedEmbedding (@mk M).symm := mkHomeomorph.symm.closedEmbedding
+theorem isClosedEmbedding_mk_symm : IsClosedEmbedding (@mk M).symm :=
+  mkHomeomorph.symm.isClosedEmbedding
 
 @[to_additive]
 theorem quotientMap_mk_symm : QuotientMap (@mk M).symm := mkHomeomorph.symm.quotientMap
@@ -76,8 +78,8 @@ theorem quotientMap_mk_symm : QuotientMap (@mk M).symm := mkHomeomorph.symm.quot
 @[to_additive] instance instT2Space [T2Space M] : T2Space Mᵈᵐᵃ := embedding_mk_symm.t2Space
 @[to_additive] instance instT25Space [T25Space M] : T25Space Mᵈᵐᵃ := embedding_mk_symm.t25Space
 @[to_additive] instance instT3Space [T3Space M] : T3Space Mᵈᵐᵃ := embedding_mk_symm.t3Space
-@[to_additive] instance instT4Space [T4Space M] : T4Space Mᵈᵐᵃ := closedEmbedding_mk_symm.t4Space
-@[to_additive] instance instT5Space [T5Space M] : T5Space Mᵈᵐᵃ := closedEmbedding_mk_symm.t5Space
+@[to_additive] instance instT4Space [T4Space M] : T4Space Mᵈᵐᵃ := isClosedEmbedding_mk_symm.t4Space
+@[to_additive] instance instT5Space [T5Space M] : T5Space Mᵈᵐᵃ := isClosedEmbedding_mk_symm.t5Space
 
 @[to_additive] instance instR0Space [R0Space M] : R0Space Mᵈᵐᵃ := embedding_mk_symm.r0Space
 @[to_additive] instance instR1Space [R1Space M] : R1Space Mᵈᵐᵃ := embedding_mk_symm.r1Space
@@ -86,11 +88,11 @@ theorem quotientMap_mk_symm : QuotientMap (@mk M).symm := mkHomeomorph.symm.quot
 instance instRegularSpace [RegularSpace M] : RegularSpace Mᵈᵐᵃ := embedding_mk_symm.regularSpace
 
 @[to_additive]
-instance instNormalSpace [NormalSpace M] : NormalSpace Mᵈᵐᵃ := closedEmbedding_mk_symm.normalSpace
+instance instNormalSpace [NormalSpace M] : NormalSpace Mᵈᵐᵃ := isClosedEmbedding_mk_symm.normalSpace
 
 @[to_additive]
 instance instCompletelyNormalSpace [CompletelyNormalSpace M] : CompletelyNormalSpace Mᵈᵐᵃ :=
-  closedEmbedding_mk_symm.completelyNormalSpace
+  isClosedEmbedding_mk_symm.completelyNormalSpace
 
 @[to_additive]
 instance instDiscreteTopology [DiscreteTopology M] : DiscreteTopology Mᵈᵐᵃ :=
@@ -119,7 +121,7 @@ instance instLocallyCompactSpace [LocallyCompactSpace M] : LocallyCompactSpace M
 @[to_additive]
 instance instWeaklyLocallyCompactSpace [WeaklyLocallyCompactSpace M] :
     WeaklyLocallyCompactSpace Mᵈᵐᵃ :=
-  closedEmbedding_mk_symm.weaklyLocallyCompactSpace
+  isClosedEmbedding_mk_symm.weaklyLocallyCompactSpace
 
 @[to_additive (attr := simp)]
 theorem map_mk_nhds (x : M) : map (mk : M → Mᵈᵐᵃ) (𝓝 x) = 𝓝 (mk x) :=

--- a/Mathlib/Topology/Algebra/ContinuousMonoidHom.lean
+++ b/Mathlib/Topology/Algebra/ContinuousMonoidHom.lean
@@ -258,8 +258,8 @@ lemma range_toContinuousMap :
   exact ⟨{ f with map_one' := h1, map_mul' := hmul }, rfl⟩
 
 @[to_additive]
-theorem closedEmbedding_toContinuousMap [ContinuousMul B] [T2Space B] :
-    ClosedEmbedding (toContinuousMap : ContinuousMonoidHom A B → C(A, B)) where
+theorem isClosedEmbedding_toContinuousMap [ContinuousMul B] [T2Space B] :
+    IsClosedEmbedding (toContinuousMap : ContinuousMonoidHom A B → C(A, B)) where
   toEmbedding := embedding_toContinuousMap A B
   isClosed_range := by
     simp only [range_toContinuousMap, Set.setOf_and, Set.setOf_forall]

--- a/Mathlib/Topology/Algebra/ContinuousMonoidHom.lean
+++ b/Mathlib/Topology/Algebra/ContinuousMonoidHom.lean
@@ -268,6 +268,9 @@ theorem isClosedEmbedding_toContinuousMap [ContinuousMul B] [T2Space B] :
     exact isClosed_eq (continuous_eval_const (x * y)) <|
       .mul (continuous_eval_const x) (continuous_eval_const y)
 
+@[deprecated (since := "2024-10-20")]
+alias closedEmbedding_toContinuousMap := isClosedEmbedding_toContinuousMap
+
 variable {A B C D E}
 
 @[to_additive]

--- a/Mathlib/Topology/Algebra/Module/Alternating/Topology.lean
+++ b/Mathlib/Topology/Algebra/Module/Alternating/Topology.lean
@@ -158,8 +158,8 @@ theorem hasBasis_nhds_zero :
 
 variable [ContinuousSMul 𝕜 E]
 
-lemma closedEmbedding_toContinuousMultilinearMap [T2Space F] :
-    ClosedEmbedding (toContinuousMultilinearMap :
+lemma isClosedEmbedding_toContinuousMultilinearMap [T2Space F] :
+    IsClosedEmbedding (toContinuousMultilinearMap :
       (E [⋀^ι]→L[𝕜] F) → ContinuousMultilinearMap 𝕜 (fun _ : ι ↦ E) F) :=
   ⟨embedding_toContinuousMultilinearMap, isClosed_range_toContinuousMultilinearMap⟩
 

--- a/Mathlib/Topology/Algebra/Module/Alternating/Topology.lean
+++ b/Mathlib/Topology/Algebra/Module/Alternating/Topology.lean
@@ -163,6 +163,9 @@ lemma isClosedEmbedding_toContinuousMultilinearMap [T2Space F] :
       (E [⋀^ι]→L[𝕜] F) → ContinuousMultilinearMap 𝕜 (fun _ : ι ↦ E) F) :=
   ⟨embedding_toContinuousMultilinearMap, isClosed_range_toContinuousMultilinearMap⟩
 
+@[deprecated (since := "2024-10-20")]
+alias closedEmbedding_toContinuousMultilinearMap := isClosedEmbedding_toContinuousMultilinearMap
+
 instance instContinuousEvalConst : ContinuousEvalConst (E [⋀^ι]→L[𝕜] F) (ι → E) F :=
   .of_continuous_forget continuous_toContinuousMultilinearMap
 

--- a/Mathlib/Topology/Algebra/Module/FiniteDimension.lean
+++ b/Mathlib/Topology/Algebra/Module/FiniteDimension.lean
@@ -526,9 +526,15 @@ theorem LinearMap.isClosedEmbedding_of_injective [T2Space E] [FiniteDimensional 
       haveI := f.finiteDimensional_range
       simpa [LinearMap.range_coe f] using f.range.closed_of_finiteDimensional }
 
+@[deprecated (since := "2024-10-20")]
+alias LinearMap.closedEmbedding_of_injective := LinearMap.isClosedEmbedding_of_injective
+
 theorem isClosedEmbedding_smul_left [T2Space E] {c : E} (hc : c ≠ 0) :
     IsClosedEmbedding fun x : 𝕜 => x • c :=
   LinearMap.isClosedEmbedding_of_injective (LinearMap.ker_toSpanSingleton 𝕜 E hc)
+
+@[deprecated (since := "2024-10-20")]
+alias closedEmbedding_smul_left := isClosedEmbedding_smul_left
 
 -- `smul` is a closed map in the first argument.
 theorem isClosedMap_smul_left [T2Space E] (c : E) : IsClosedMap fun x : 𝕜 => x • c := by

--- a/Mathlib/Topology/Algebra/Module/FiniteDimension.lean
+++ b/Mathlib/Topology/Algebra/Module/FiniteDimension.lean
@@ -518,24 +518,24 @@ theorem Submodule.closed_of_finiteDimensional
   s.complete_of_finiteDimensional.isClosed
 
 /-- An injective linear map with finite-dimensional domain is a closed embedding. -/
-theorem LinearMap.closedEmbedding_of_injective [T2Space E] [FiniteDimensional 𝕜 E] {f : E →ₗ[𝕜] F}
-    (hf : LinearMap.ker f = ⊥) : ClosedEmbedding f :=
+theorem LinearMap.isClosedEmbedding_of_injective [T2Space E] [FiniteDimensional 𝕜 E] {f : E →ₗ[𝕜] F}
+    (hf : LinearMap.ker f = ⊥) : IsClosedEmbedding f :=
   let g := LinearEquiv.ofInjective f (LinearMap.ker_eq_bot.mp hf)
   { embedding_subtype_val.comp g.toContinuousLinearEquiv.toHomeomorph.embedding with
     isClosed_range := by
       haveI := f.finiteDimensional_range
       simpa [LinearMap.range_coe f] using f.range.closed_of_finiteDimensional }
 
-theorem closedEmbedding_smul_left [T2Space E] {c : E} (hc : c ≠ 0) :
-    ClosedEmbedding fun x : 𝕜 => x • c :=
-  LinearMap.closedEmbedding_of_injective (LinearMap.ker_toSpanSingleton 𝕜 E hc)
+theorem isClosedEmbedding_smul_left [T2Space E] {c : E} (hc : c ≠ 0) :
+    IsClosedEmbedding fun x : 𝕜 => x • c :=
+  LinearMap.isClosedEmbedding_of_injective (LinearMap.ker_toSpanSingleton 𝕜 E hc)
 
 -- `smul` is a closed map in the first argument.
 theorem isClosedMap_smul_left [T2Space E] (c : E) : IsClosedMap fun x : 𝕜 => x • c := by
   by_cases hc : c = 0
   · simp_rw [hc, smul_zero]
     exact isClosedMap_const
-  · exact (closedEmbedding_smul_left hc).isClosedMap
+  · exact (isClosedEmbedding_smul_left hc).isClosedMap
 
 theorem ContinuousLinearMap.exists_right_inverse_of_surjective [FiniteDimensional 𝕜 F]
     (f : E →L[𝕜] F) (hf : LinearMap.range f = ⊤) :

--- a/Mathlib/Topology/Algebra/ProperAction/Basic.lean
+++ b/Mathlib/Topology/Algebra/ProperAction/Basic.lean
@@ -158,6 +158,9 @@ theorem properSMul_of_isClosedEmbedding {H : Type*} [Group H] [MulAction H X] [T
     rw [this]
     exact h.comp <| ProperSMul.isProperMap_smul_pair
 
+@[deprecated (since := "2024-10-20")]
+alias properSMul_of_closedEmbedding := properSMul_of_isClosedEmbedding
+
 /-- If `H` is a closed subgroup of `G` and `G` acts properly on X then so does `H`. -/
 @[to_additive "If `H` is a closed subgroup of `G` and `G` acts properly on X then so does `H`."]
 instance {H : Subgroup G} [ProperSMul G X] [H_closed : IsClosed (H : Set G)] : ProperSMul H X :=

--- a/Mathlib/Topology/Algebra/ProperAction/Basic.lean
+++ b/Mathlib/Topology/Algebra/ProperAction/Basic.lean
@@ -127,9 +127,7 @@ then this topological space is T2."]
 theorem t2Space_of_properSMul_of_t2Group [h_proper : ProperSMul G X] [T2Space G] : T2Space X := by
   let f := fun x : X ↦ ((1 : G), x)
   have proper_f : IsProperMap f := by
-    apply isProperMap_of_closedEmbedding
-    rw [closedEmbedding_iff]
-    constructor
+    refine IsClosedEmbedding.isProperMap ⟨?_, ?_⟩
     · let g := fun gx : G × X ↦ gx.2
       have : Function.LeftInverse g f := fun x ↦ by simp
       exact this.embedding (by fun_prop) (by fun_prop)
@@ -150,12 +148,11 @@ then `H` also acts properly on `X`. -/
 @[to_additive "If two groups `H` and `G` act on a topological space `X` such that `G` acts properly
 and there exists a group homomorphims `H → G` which is a closed embedding compatible with the
 actions, then `H` also acts properly on `X`."]
-theorem properSMul_of_closedEmbedding {H : Type*} [Group H] [MulAction H X] [TopologicalSpace H]
-    [ProperSMul G X] (f : H →* G) (f_clemb : ClosedEmbedding f)
+theorem properSMul_of_isClosedEmbedding {H : Type*} [Group H] [MulAction H X] [TopologicalSpace H]
+    [ProperSMul G X] (f : H →* G) (f_clemb : IsClosedEmbedding f)
     (f_compat : ∀ (h : H) (x : X), f h • x = h • x) : ProperSMul H X where
   isProperMap_smul_pair := by
-    have := isProperMap_of_closedEmbedding f_clemb
-    have h : IsProperMap (Prod.map f (fun x : X ↦ x)) := this.prodMap isProperMap_id
+    have h : IsProperMap (Prod.map f (fun x : X ↦ x)) := f_clemb.isProperMap.prodMap isProperMap_id
     have : (fun hx : H × X ↦ (hx.1 • hx.2, hx.2)) = (fun hx ↦ (f hx.1 • hx.2, hx.2)) := by
       simp [f_compat]
     rw [this]
@@ -164,4 +161,4 @@ theorem properSMul_of_closedEmbedding {H : Type*} [Group H] [MulAction H X] [Top
 /-- If `H` is a closed subgroup of `G` and `G` acts properly on X then so does `H`. -/
 @[to_additive "If `H` is a closed subgroup of `G` and `G` acts properly on X then so does `H`."]
 instance {H : Subgroup G} [ProperSMul G X] [H_closed : IsClosed (H : Set G)] : ProperSMul H X :=
-  properSMul_of_closedEmbedding H.subtype H_closed.closedEmbedding_subtype_val fun _ _ ↦ rfl
+  properSMul_of_isClosedEmbedding H.subtype H_closed.isClosedEmbedding_subtypeVal fun _ _ ↦ rfl

--- a/Mathlib/Topology/Algebra/StarSubalgebra.lean
+++ b/Mathlib/Topology/Algebra/StarSubalgebra.lean
@@ -37,9 +37,9 @@ theorem embedding_inclusion {S₁ S₂ : StarSubalgebra R A} (h : S₁ ≤ S₂)
   { induced := Eq.symm induced_compose
     inj := Subtype.map_injective h Function.injective_id }
 
-/-- The `StarSubalgebra.inclusion` of a closed star subalgebra is a `ClosedEmbedding`. -/
-theorem closedEmbedding_inclusion {S₁ S₂ : StarSubalgebra R A} (h : S₁ ≤ S₂)
-    (hS₁ : IsClosed (S₁ : Set A)) : ClosedEmbedding (inclusion h) :=
+/-- The `StarSubalgebra.inclusion` of a closed star subalgebra is a `IsClosedEmbedding`. -/
+theorem isClosedEmbedding_inclusion {S₁ S₂ : StarSubalgebra R A} (h : S₁ ≤ S₂)
+    (hS₁ : IsClosed (S₁ : Set A)) : IsClosedEmbedding (inclusion h) :=
   { embedding_inclusion h with
     isClosed_range := isClosed_induced_iff.2
       ⟨S₁, hS₁, by
@@ -99,7 +99,7 @@ theorem map_topologicalClosure_le [StarModule R B] [TopologicalSemiring B] [Cont
   image_closure_subset_closure_image hφ
 
 theorem topologicalClosure_map [StarModule R B] [TopologicalSemiring B] [ContinuousStar B]
-    (s : StarSubalgebra R A) (φ : A →⋆ₐ[R] B) (hφ : ClosedEmbedding φ) :
+    (s : StarSubalgebra R A) (φ : A →⋆ₐ[R] B) (hφ : IsClosedEmbedding φ) :
     (map φ s).topologicalClosure = map φ s.topologicalClosure :=
   SetLike.coe_injective <| hφ.closure_image_eq _
 
@@ -205,8 +205,8 @@ theorem le_of_isClosed_of_mem {S : StarSubalgebra R A} (hS : IsClosed (S : Set A
     (hx : x ∈ S) : elementalStarAlgebra R x ≤ S :=
   topologicalClosure_minimal (adjoin_le <| Set.singleton_subset_iff.2 hx) hS
 
-/-- The coercion from an elemental algebra to the full algebra as a `ClosedEmbedding`. -/
-theorem closedEmbedding_coe (x : A) : ClosedEmbedding ((↑) : elementalStarAlgebra R x → A) :=
+/-- The coercion from an elemental algebra to the full algebra as a `IsClosedEmbedding`. -/
+theorem isClosedEmbedding_coe (x : A) : IsClosedEmbedding ((↑) : elementalStarAlgebra R x → A) :=
   { induced := rfl
     inj := Subtype.coe_injective
     isClosed_range := by

--- a/Mathlib/Topology/Algebra/StarSubalgebra.lean
+++ b/Mathlib/Topology/Algebra/StarSubalgebra.lean
@@ -48,6 +48,9 @@ theorem isClosedEmbedding_inclusion {S₁ S₂ : StarSubalgebra R A} (h : S₁ �
           · intro _ h'
             apply h h' ⟩ }
 
+@[deprecated (since := "2024-10-20")]
+alias closedEmbedding_inclusion := isClosedEmbedding_inclusion
+
 variable [TopologicalSemiring A] [ContinuousStar A]
 variable [TopologicalSpace B] [Semiring B] [Algebra R B] [StarRing B]
 
@@ -216,6 +219,9 @@ theorem isClosedEmbedding_coe (x : A) : IsClosedEmbedding ((↑) : elementalStar
           ⟨by
             rintro ⟨y, rfl⟩
             exact y.prop, fun hy => ⟨⟨y, hy⟩, rfl⟩⟩ }
+
+@[deprecated (since := "2024-10-20")]
+alias closedEmbedding_coe := isClosedEmbedding_coe
 
 @[elab_as_elim]
 theorem induction_on {x y : A}

--- a/Mathlib/Topology/Category/LightProfinite/Sequence.lean
+++ b/Mathlib/Topology/Category/LightProfinite/Sequence.lean
@@ -29,8 +29,8 @@ noncomputable def natUnionInftyEmbedding : C(OnePoint ℕ, ℝ) where
 The continuous map from `ℕ∪{∞}` to `ℝ` sending `n` to `1/(n+1)` and `∞` to `0` is a closed
 embedding.
 -/
-lemma closedEmbedding_natUnionInftyEmbedding : ClosedEmbedding natUnionInftyEmbedding := by
-  refine closedEmbedding_of_continuous_injective_closed
+lemma isClosedEmbedding_natUnionInftyEmbedding : IsClosedEmbedding natUnionInftyEmbedding := by
+  refine .of_continuous_injective_isClosedMap
     natUnionInftyEmbedding.continuous ?_ ?_
   · rintro (_|n) (_|m) h
     · rfl
@@ -45,7 +45,7 @@ lemma closedEmbedding_natUnionInftyEmbedding : ClosedEmbedding natUnionInftyEmbe
       rw [h]
   · exact fun _ hC => (hC.isCompact.image natUnionInftyEmbedding.continuous).isClosed
 
-instance : MetrizableSpace (OnePoint ℕ) := closedEmbedding_natUnionInftyEmbedding.metrizableSpace
+instance : MetrizableSpace (OnePoint ℕ) := isClosedEmbedding_natUnionInftyEmbedding.metrizableSpace
 
 /-- The one point compactification of the natural numbers as a light profinite set. -/
 abbrev NatUnionInfty : LightProfinite := of (OnePoint ℕ)

--- a/Mathlib/Topology/Category/LightProfinite/Sequence.lean
+++ b/Mathlib/Topology/Category/LightProfinite/Sequence.lean
@@ -45,6 +45,9 @@ lemma isClosedEmbedding_natUnionInftyEmbedding : IsClosedEmbedding natUnionInfty
       rw [h]
   · exact fun _ hC => (hC.isCompact.image natUnionInftyEmbedding.continuous).isClosed
 
+@[deprecated (since := "2024-10-20")]
+alias closedEmbedding_natUnionInftyEmbedding := isClosedEmbedding_natUnionInftyEmbedding
+
 instance : MetrizableSpace (OnePoint ℕ) := isClosedEmbedding_natUnionInftyEmbedding.metrizableSpace
 
 /-- The one point compactification of the natural numbers as a light profinite set. -/

--- a/Mathlib/Topology/Category/Profinite/Nobeling.lean
+++ b/Mathlib/Topology/Category/Profinite/Nobeling.lean
@@ -1779,7 +1779,7 @@ def GoodProducts.Basis (hC : IsClosed C) :
 
 end Induction
 
-variable {S : Profinite} {ι : S → I → Bool} (hι : ClosedEmbedding ι)
+variable {S : Profinite} {ι : S → I → Bool} (hι : IsClosedEmbedding ι)
 include hι
 
 /--
@@ -1801,8 +1801,8 @@ def Nobeling.ι : S → ({C : Set S // IsClopen C} → Bool) := fun s C => decid
 
 open scoped Classical in
 /-- The map `Nobeling.ι` is a closed embedding. -/
-theorem Nobeling.embedding : ClosedEmbedding (Nobeling.ι S) := by
-  apply Continuous.closedEmbedding
+theorem Nobeling.embedding : IsClosedEmbedding (Nobeling.ι S) := by
+  apply Continuous.isClosedEmbedding
   · dsimp (config := { unfoldPartialApp := true }) [ι]
     refine continuous_pi ?_
     intro C

--- a/Mathlib/Topology/Category/Stonean/Limits.lean
+++ b/Mathlib/Topology/Category/Stonean/Limits.lean
@@ -33,7 +33,7 @@ lemma extremallyDisconnected_preimage : ExtremallyDisconnected (i ⁻¹' (Set.ra
       ⟨IsClosed.preimage i.continuous (isCompact_range f.continuous).isClosed,
         IsOpen.preimage i.continuous hi.isOpen_range⟩
     rw [← (closure U).preimage_image_eq Subtype.coe_injective,
-      ← h.1.closedEmbedding_subtype_val.closure_image_eq U]
+      ← h.1.isClosedEmbedding_subtypeVal.closure_image_eq U]
     exact isOpen_induced (ExtremallyDisconnected.open_closure _
       (h.2.isOpenEmbedding_subtypeVal.isOpenMap U hU))
 

--- a/Mathlib/Topology/Clopen.lean
+++ b/Mathlib/Topology/Clopen.lean
@@ -118,7 +118,7 @@ theorem isClopen_range_inr : IsClopen (range (Sum.inr : Y → X ⊕ Y)) :=
 
 theorem isClopen_range_sigmaMk {X : ι → Type*} [∀ i, TopologicalSpace (X i)] {i : ι} :
     IsClopen (Set.range (@Sigma.mk ι X i)) :=
-  ⟨closedEmbedding_sigmaMk.isClosed_range, isOpenEmbedding_sigmaMk.isOpen_range⟩
+  ⟨isClosedEmbedding_sigmaMk.isClosed_range, isOpenEmbedding_sigmaMk.isOpen_range⟩
 
 protected theorem QuotientMap.isClopen_preimage {f : X → Y} (hf : QuotientMap f) {s : Set Y} :
     IsClopen (f ⁻¹' s) ↔ IsClopen s :=

--- a/Mathlib/Topology/Compactness/Compact.lean
+++ b/Mathlib/Topology/Compactness/Compact.lean
@@ -931,12 +931,18 @@ theorem IsClosedEmbedding.isCompact_preimage {f : X → Y} (hf : IsClosedEmbeddi
     {K : Set Y} (hK : IsCompact K) : IsCompact (f ⁻¹' K) :=
   hf.toInducing.isCompact_preimage (hf.isClosed_range) hK
 
+@[deprecated (since := "2024-10-20")]
+alias ClosedEmbedding.isCompact_preimage := IsClosedEmbedding.isCompact_preimage
+
 /-- A closed embedding is proper, ie, inverse images of compact sets are contained in compacts.
 Moreover, the preimage of a compact set is compact, see `IsClosedEmbedding.isCompact_preimage`. -/
 theorem IsClosedEmbedding.tendsto_cocompact {f : X → Y} (hf : IsClosedEmbedding f) :
     Tendsto f (Filter.cocompact X) (Filter.cocompact Y) :=
   Filter.hasBasis_cocompact.tendsto_right_iff.mpr fun _K hK =>
     (hf.isCompact_preimage hK).compl_mem_cocompact
+
+@[deprecated (since := "2024-10-20")]
+alias ClosedEmbedding.tendsto_cocompact := IsClosedEmbedding.tendsto_cocompact
 
 /-- Sets of subtype are compact iff the image under a coercion is. -/
 theorem Subtype.isCompact_iff {p : X → Prop} {s : Set { x // p x }} :
@@ -960,9 +966,15 @@ protected theorem IsClosedEmbedding.noncompactSpace [NoncompactSpace X] {f : X �
     (hf : IsClosedEmbedding f) : NoncompactSpace Y :=
   noncompactSpace_of_neBot hf.tendsto_cocompact.neBot
 
+@[deprecated (since := "2024-10-20")]
+alias ClosedEmbedding.noncompactSpace := IsClosedEmbedding.noncompactSpace
+
 protected theorem IsClosedEmbedding.compactSpace [h : CompactSpace Y] {f : X → Y}
     (hf : IsClosedEmbedding f) : CompactSpace X :=
   ⟨by rw [hf.toInducing.isCompact_iff, image_univ]; exact hf.isClosed_range.isCompact⟩
+
+@[deprecated (since := "2024-10-20")]
+alias ClosedEmbedding.compactSpace := IsClosedEmbedding.compactSpace
 
 theorem IsCompact.prod {t : Set Y} (hs : IsCompact s) (ht : IsCompact t) :
     IsCompact (s ×ˢ t) := by

--- a/Mathlib/Topology/Compactness/Compact.lean
+++ b/Mathlib/Topology/Compactness/Compact.lean
@@ -927,13 +927,13 @@ lemma Inducing.isCompact_preimage' {f : X → Y} (hf : Inducing f) {K : Set Y}
   (hf.isCompact_preimage_iff Kf).2 hK
 
 /-- The preimage of a compact set under a closed embedding is a compact set. -/
-theorem ClosedEmbedding.isCompact_preimage {f : X → Y} (hf : ClosedEmbedding f)
+theorem IsClosedEmbedding.isCompact_preimage {f : X → Y} (hf : IsClosedEmbedding f)
     {K : Set Y} (hK : IsCompact K) : IsCompact (f ⁻¹' K) :=
   hf.toInducing.isCompact_preimage (hf.isClosed_range) hK
 
 /-- A closed embedding is proper, ie, inverse images of compact sets are contained in compacts.
-Moreover, the preimage of a compact set is compact, see `ClosedEmbedding.isCompact_preimage`. -/
-theorem ClosedEmbedding.tendsto_cocompact {f : X → Y} (hf : ClosedEmbedding f) :
+Moreover, the preimage of a compact set is compact, see `IsClosedEmbedding.isCompact_preimage`. -/
+theorem IsClosedEmbedding.tendsto_cocompact {f : X → Y} (hf : IsClosedEmbedding f) :
     Tendsto f (Filter.cocompact X) (Filter.cocompact Y) :=
   Filter.hasBasis_cocompact.tendsto_right_iff.mpr fun _K hK =>
     (hf.isCompact_preimage hK).compl_mem_cocompact
@@ -956,12 +956,12 @@ theorem exists_nhds_ne_inf_principal_neBot (hs : IsCompact s) (hs' : s.Infinite)
     ∃ z ∈ s, (𝓝[≠] z ⊓ 𝓟 s).NeBot :=
   hs'.exists_accPt_of_subset_isCompact hs Subset.rfl
 
-protected theorem ClosedEmbedding.noncompactSpace [NoncompactSpace X] {f : X → Y}
-    (hf : ClosedEmbedding f) : NoncompactSpace Y :=
+protected theorem IsClosedEmbedding.noncompactSpace [NoncompactSpace X] {f : X → Y}
+    (hf : IsClosedEmbedding f) : NoncompactSpace Y :=
   noncompactSpace_of_neBot hf.tendsto_cocompact.neBot
 
-protected theorem ClosedEmbedding.compactSpace [h : CompactSpace Y] {f : X → Y}
-    (hf : ClosedEmbedding f) : CompactSpace X :=
+protected theorem IsClosedEmbedding.compactSpace [h : CompactSpace Y] {f : X → Y}
+    (hf : IsClosedEmbedding f) : CompactSpace X :=
   ⟨by rw [hf.toInducing.isCompact_iff, image_univ]; exact hf.isClosed_range.isCompact⟩
 
 theorem IsCompact.prod {t : Set Y} (hs : IsCompact s) (ht : IsCompact t) :
@@ -981,7 +981,7 @@ instance (priority := 100) Finite.compactSpace [Finite X] : CompactSpace X where
   isCompact_univ := finite_univ.isCompact
 
 instance ULift.compactSpace [CompactSpace X] : CompactSpace (ULift.{v} X) :=
-  ULift.closedEmbedding_down.compactSpace
+  ULift.isClosedEmbedding_down.compactSpace
 
 /-- The product of two compact spaces is compact. -/
 instance [CompactSpace X] [CompactSpace Y] : CompactSpace (X × Y) :=

--- a/Mathlib/Topology/Compactness/Lindelof.lean
+++ b/Mathlib/Topology/Compactness/Lindelof.lean
@@ -624,6 +624,9 @@ theorem IsClosedEmbedding.isLindelof_preimage {f : X → Y} (hf : IsClosedEmbedd
     {K : Set Y} (hK : IsLindelof K) : IsLindelof (f ⁻¹' K) :=
   hf.toInducing.isLindelof_preimage (hf.isClosed_range) hK
 
+@[deprecated (since := "2024-10-20")]
+alias ClosedEmbedding.isLindelof_preimage := IsClosedEmbedding.isLindelof_preimage
+
 /-- A closed embedding is proper, ie, inverse images of Lindelöf sets are contained in Lindelöf.
 Moreover, the preimage of a Lindelöf set is Lindelöf, see
 `IsClosedEmbedding.isLindelof_preimage`. -/
@@ -631,6 +634,9 @@ theorem IsClosedEmbedding.tendsto_coLindelof {f : X → Y} (hf : IsClosedEmbeddi
     Tendsto f (Filter.coLindelof X) (Filter.coLindelof Y) :=
   hasBasis_coLindelof.tendsto_right_iff.mpr fun _K hK =>
     (hf.isLindelof_preimage hK).compl_mem_coLindelof
+
+@[deprecated (since := "2024-10-20")]
+alias ClosedEmbedding.tendsto_coLindelof := IsClosedEmbedding.tendsto_coLindelof
 
 /-- Sets of subtype are Lindelöf iff the image under a coercion is. -/
 theorem Subtype.isLindelof_iff {p : X → Prop} {s : Set { x // p x }} :
@@ -653,9 +659,15 @@ protected theorem IsClosedEmbedding.nonLindelofSpace [NonLindelofSpace X] {f : X
     (hf : IsClosedEmbedding f) : NonLindelofSpace Y :=
   nonLindelofSpace_of_neBot hf.tendsto_coLindelof.neBot
 
+@[deprecated (since := "2024-10-20")]
+alias ClosedEmbedding.nonLindelofSpace := IsClosedEmbedding.nonLindelofSpace
+
 protected theorem IsClosedEmbedding.LindelofSpace [h : LindelofSpace Y] {f : X → Y}
     (hf : IsClosedEmbedding f) : LindelofSpace X :=
   ⟨by rw [hf.toInducing.isLindelof_iff, image_univ]; exact hf.isClosed_range.isLindelof⟩
+
+@[deprecated (since := "2024-10-20")]
+alias ClosedEmbedding.LindelofSpace := IsClosedEmbedding.LindelofSpace
 
 /-- Countable topological spaces are Lindelof. -/
 instance (priority := 100) Countable.LindelofSpace [Countable X] : LindelofSpace X where

--- a/Mathlib/Topology/Compactness/Lindelof.lean
+++ b/Mathlib/Topology/Compactness/Lindelof.lean
@@ -620,13 +620,14 @@ theorem Inducing.isLindelof_preimage {f : X → Y} (hf : Inducing f) (hf' : IsCl
   rwa [hf.isLindelof_iff, image_preimage_eq_inter_range]
 
 /-- The preimage of a Lindelöf set under a closed embedding is a Lindelöf set. -/
-theorem ClosedEmbedding.isLindelof_preimage {f : X → Y} (hf : ClosedEmbedding f)
+theorem IsClosedEmbedding.isLindelof_preimage {f : X → Y} (hf : IsClosedEmbedding f)
     {K : Set Y} (hK : IsLindelof K) : IsLindelof (f ⁻¹' K) :=
   hf.toInducing.isLindelof_preimage (hf.isClosed_range) hK
 
 /-- A closed embedding is proper, ie, inverse images of Lindelöf sets are contained in Lindelöf.
-Moreover, the preimage of a Lindelöf set is Lindelöf, see `ClosedEmbedding.isLindelof_preimage`. -/
-theorem ClosedEmbedding.tendsto_coLindelof {f : X → Y} (hf : ClosedEmbedding f) :
+Moreover, the preimage of a Lindelöf set is Lindelöf, see
+`IsClosedEmbedding.isLindelof_preimage`. -/
+theorem IsClosedEmbedding.tendsto_coLindelof {f : X → Y} (hf : IsClosedEmbedding f) :
     Tendsto f (Filter.coLindelof X) (Filter.coLindelof Y) :=
   hasBasis_coLindelof.tendsto_right_iff.mpr fun _K hK =>
     (hf.isLindelof_preimage hK).compl_mem_coLindelof
@@ -648,12 +649,12 @@ theorem IsLindelof.countable (hs : IsLindelof s) (hs' : DiscreteTopology s) : s.
   countable_coe_iff.mp
   (@countable_of_Lindelof_of_discrete _ _ (isLindelof_iff_LindelofSpace.mp hs) hs')
 
-protected theorem ClosedEmbedding.nonLindelofSpace [NonLindelofSpace X] {f : X → Y}
-    (hf : ClosedEmbedding f) : NonLindelofSpace Y :=
+protected theorem IsClosedEmbedding.nonLindelofSpace [NonLindelofSpace X] {f : X → Y}
+    (hf : IsClosedEmbedding f) : NonLindelofSpace Y :=
   nonLindelofSpace_of_neBot hf.tendsto_coLindelof.neBot
 
-protected theorem ClosedEmbedding.LindelofSpace [h : LindelofSpace Y] {f : X → Y}
-    (hf : ClosedEmbedding f) : LindelofSpace X :=
+protected theorem IsClosedEmbedding.LindelofSpace [h : LindelofSpace Y] {f : X → Y}
+    (hf : IsClosedEmbedding f) : LindelofSpace X :=
   ⟨by rw [hf.toInducing.isLindelof_iff, image_univ]; exact hf.isClosed_range.isLindelof⟩
 
 /-- Countable topological spaces are Lindelof. -/

--- a/Mathlib/Topology/Compactness/LocallyCompact.lean
+++ b/Mathlib/Topology/Compactness/LocallyCompact.lean
@@ -35,15 +35,15 @@ instance {ι : Type*} [Finite ι] {X : ι → Type*} [(i : ι) → TopologicalSp
 instance (priority := 100) [CompactSpace X] : WeaklyLocallyCompactSpace X where
   exists_compact_mem_nhds _ := ⟨univ, isCompact_univ, univ_mem⟩
 
-protected theorem ClosedEmbedding.weaklyLocallyCompactSpace [WeaklyLocallyCompactSpace Y]
-    {f : X → Y} (hf : ClosedEmbedding f) : WeaklyLocallyCompactSpace X where
+protected theorem IsClosedEmbedding.weaklyLocallyCompactSpace [WeaklyLocallyCompactSpace Y]
+    {f : X → Y} (hf : IsClosedEmbedding f) : WeaklyLocallyCompactSpace X where
   exists_compact_mem_nhds x :=
     let ⟨K, hK, hKx⟩ := exists_compact_mem_nhds (f x)
     ⟨f ⁻¹' K, hf.isCompact_preimage hK, hf.continuous.continuousAt hKx⟩
 
 protected theorem IsClosed.weaklyLocallyCompactSpace [WeaklyLocallyCompactSpace X]
     {s : Set X} (hs : IsClosed s) : WeaklyLocallyCompactSpace s :=
-  (closedEmbedding_subtype_val hs).weaklyLocallyCompactSpace
+  hs.isClosedEmbedding_subtypeVal.weaklyLocallyCompactSpace
 
 theorem IsOpenQuotientMap.weaklyLocallyCompactSpace [WeaklyLocallyCompactSpace X]
     {f : X → Y} (hf : IsOpenQuotientMap f) : WeaklyLocallyCompactSpace Y where
@@ -195,8 +195,8 @@ theorem Inducing.locallyCompactSpace [LocallyCompactSpace Y] {f : X → Y} (hf :
   rw [hf.isCompact_preimage_iff]
   exacts [hs.inter_right hZ, hUZ ▸ by gcongr]
 
-protected theorem ClosedEmbedding.locallyCompactSpace [LocallyCompactSpace Y] {f : X → Y}
-    (hf : ClosedEmbedding f) : LocallyCompactSpace X :=
+protected theorem IsClosedEmbedding.locallyCompactSpace [LocallyCompactSpace Y] {f : X → Y}
+    (hf : IsClosedEmbedding f) : LocallyCompactSpace X :=
   hf.toInducing.locallyCompactSpace hf.isClosed_range.isLocallyClosed
 
 protected theorem IsOpenEmbedding.locallyCompactSpace [LocallyCompactSpace Y] {f : X → Y}

--- a/Mathlib/Topology/Compactness/LocallyCompact.lean
+++ b/Mathlib/Topology/Compactness/LocallyCompact.lean
@@ -41,6 +41,9 @@ protected theorem IsClosedEmbedding.weaklyLocallyCompactSpace [WeaklyLocallyComp
     let ⟨K, hK, hKx⟩ := exists_compact_mem_nhds (f x)
     ⟨f ⁻¹' K, hf.isCompact_preimage hK, hf.continuous.continuousAt hKx⟩
 
+@[deprecated (since := "2024-10-20")]
+alias ClosedEmbedding.weaklyLocallyCompactSpace := IsClosedEmbedding.weaklyLocallyCompactSpace
+
 protected theorem IsClosed.weaklyLocallyCompactSpace [WeaklyLocallyCompactSpace X]
     {s : Set X} (hs : IsClosed s) : WeaklyLocallyCompactSpace s :=
   hs.isClosedEmbedding_subtypeVal.weaklyLocallyCompactSpace
@@ -198,6 +201,9 @@ theorem Inducing.locallyCompactSpace [LocallyCompactSpace Y] {f : X → Y} (hf :
 protected theorem IsClosedEmbedding.locallyCompactSpace [LocallyCompactSpace Y] {f : X → Y}
     (hf : IsClosedEmbedding f) : LocallyCompactSpace X :=
   hf.toInducing.locallyCompactSpace hf.isClosed_range.isLocallyClosed
+
+@[deprecated (since := "2024-10-20")]
+alias ClosedEmbedding.locallyCompactSpace := IsClosedEmbedding.locallyCompactSpace
 
 protected theorem IsOpenEmbedding.locallyCompactSpace [LocallyCompactSpace Y] {f : X → Y}
     (hf : IsOpenEmbedding f) : LocallyCompactSpace X :=

--- a/Mathlib/Topology/Compactness/Paracompact.lean
+++ b/Mathlib/Topology/Compactness/Paracompact.lean
@@ -119,6 +119,9 @@ theorem IsClosedEmbedding.paracompactSpace [ParacompactSpace Y] {e : X → Y}
       hVf.preimage_continuous he.continuous, fun a ↦ ⟨a, preimage_mono (hVU a)⟩⟩
     simpa only [range_subset_iff, mem_iUnion, iUnion_eq_univ_iff] using heV
 
+@[deprecated (since := "2024-10-20")]
+alias ClosedEmbedding.paracompactSpace := IsClosedEmbedding.paracompactSpace
+
 theorem Homeomorph.paracompactSpace_iff (e : X ≃ₜ Y) : ParacompactSpace X ↔ ParacompactSpace Y :=
   ⟨fun _ ↦ e.symm.isClosedEmbedding.paracompactSpace, fun _ ↦ e.isClosedEmbedding.paracompactSpace⟩
 

--- a/Mathlib/Topology/Compactness/Paracompact.lean
+++ b/Mathlib/Topology/Compactness/Paracompact.lean
@@ -107,8 +107,8 @@ theorem precise_refinement_set [ParacompactSpace X] {s : Set X} (hs : IsClosed s
   · simp only [iUnion_option, ← compl_subset_iff_union] at vc
     exact Subset.trans (subset_compl_comm.1 <| vu Option.none) vc
 
-theorem ClosedEmbedding.paracompactSpace [ParacompactSpace Y] {e : X → Y} (he : ClosedEmbedding e) :
-    ParacompactSpace X where
+theorem IsClosedEmbedding.paracompactSpace [ParacompactSpace Y] {e : X → Y}
+    (he : IsClosedEmbedding e) : ParacompactSpace X where
   locallyFinite_refinement α s ho hu := by
     choose U hUo hU using fun a ↦ he.isOpen_iff.1 (ho a)
     simp only [← hU] at hu ⊢
@@ -120,7 +120,7 @@ theorem ClosedEmbedding.paracompactSpace [ParacompactSpace Y] {e : X → Y} (he 
     simpa only [range_subset_iff, mem_iUnion, iUnion_eq_univ_iff] using heV
 
 theorem Homeomorph.paracompactSpace_iff (e : X ≃ₜ Y) : ParacompactSpace X ↔ ParacompactSpace Y :=
-  ⟨fun _ ↦ e.symm.closedEmbedding.paracompactSpace, fun _ ↦ e.closedEmbedding.paracompactSpace⟩
+  ⟨fun _ ↦ e.symm.isClosedEmbedding.paracompactSpace, fun _ ↦ e.isClosedEmbedding.paracompactSpace⟩
 
 /-- The product of a compact space and a paracompact space is a paracompact space. The formalization
 is based on https://dantopology.wordpress.com/2009/10/24/compact-x-paracompact-is-paracompact/

--- a/Mathlib/Topology/Compactness/SigmaCompact.lean
+++ b/Mathlib/Topology/Compactness/SigmaCompact.lean
@@ -255,6 +255,9 @@ protected theorem IsClosedEmbedding.sigmaCompactSpace {e : Y → X} (he : IsClos
       he.isCompact_preimage (isCompact_compactCovering _ _), by
       rw [← preimage_iUnion, iUnion_compactCovering, preimage_univ]⟩⟩
 
+@[deprecated (since := "2024-10-20")]
+alias ClosedEmbedding.sigmaCompactSpace := IsClosedEmbedding.sigmaCompactSpace
+
 theorem IsClosed.sigmaCompactSpace {s : Set X} (hs : IsClosed s) : SigmaCompactSpace s :=
   hs.isClosedEmbedding_subtypeVal.sigmaCompactSpace
 

--- a/Mathlib/Topology/Compactness/SigmaCompact.lean
+++ b/Mathlib/Topology/Compactness/SigmaCompact.lean
@@ -249,17 +249,17 @@ instance [Countable ι] {X : ι → Type*} [∀ i, TopologicalSpace (X i)]
       refine ⟨max k n, k, le_max_left _ _, mem_image_of_mem _ ?_⟩
       exact compactCovering_subset _ (le_max_right _ _) hn
 
-protected theorem ClosedEmbedding.sigmaCompactSpace {e : Y → X} (he : ClosedEmbedding e) :
+protected theorem IsClosedEmbedding.sigmaCompactSpace {e : Y → X} (he : IsClosedEmbedding e) :
     SigmaCompactSpace Y :=
   ⟨⟨fun n => e ⁻¹' compactCovering X n, fun _ =>
       he.isCompact_preimage (isCompact_compactCovering _ _), by
       rw [← preimage_iUnion, iUnion_compactCovering, preimage_univ]⟩⟩
 
 theorem IsClosed.sigmaCompactSpace {s : Set X} (hs : IsClosed s) : SigmaCompactSpace s :=
-  (closedEmbedding_subtype_val hs).sigmaCompactSpace
+  hs.isClosedEmbedding_subtypeVal.sigmaCompactSpace
 
 instance [SigmaCompactSpace Y] : SigmaCompactSpace (ULift.{u} Y) :=
-  ULift.closedEmbedding_down.sigmaCompactSpace
+  ULift.isClosedEmbedding_down.sigmaCompactSpace
 
 /-- If `X` is a `σ`-compact space, then a locally finite family of nonempty sets of `X` can have
 only countably many elements, `Set.Countable` version. -/

--- a/Mathlib/Topology/Constructions.lean
+++ b/Mathlib/Topology/Constructions.lean
@@ -940,8 +940,14 @@ theorem isClosed_range_inr : IsClosed (range (inr : Y → X ⊕ Y)) := by
 theorem isClosedEmbedding_inl : IsClosedEmbedding (inl : X → X ⊕ Y) :=
   ⟨embedding_inl, isClosed_range_inl⟩
 
+@[deprecated (since := "2024-10-20")]
+alias closedEmbedding_inl := isClosedEmbedding_inl
+
 theorem isClosedEmbedding_inr : IsClosedEmbedding (inr : Y → X ⊕ Y) :=
   ⟨embedding_inr, isClosed_range_inr⟩
+
+@[deprecated (since := "2024-10-20")]
+alias closedEmbedding_inr := isClosedEmbedding_inr
 
 theorem nhds_inl (x : X) : 𝓝 (inl x : X ⊕ Y) = map inl (𝓝 x) :=
   (isOpenEmbedding_inl.map_nhds_eq _).symm
@@ -1007,6 +1013,9 @@ theorem IsClosedEmbedding.subtypeVal (h : IsClosed {a | p a}) :
     IsClosedEmbedding ((↑) : Subtype p → X) :=
   ⟨embedding_subtype_val, by rwa [Subtype.range_coe_subtype]⟩
 
+@[deprecated (since := "2024-10-20")]
+alias closedEmbedding_subtype_val := IsClosedEmbedding.subtypeVal
+
 @[continuity, fun_prop]
 theorem continuous_subtype_val : Continuous (@Subtype.val X p) :=
   continuous_induced_dom
@@ -1031,6 +1040,9 @@ theorem IsOpenMap.restrict {f : X → Y} (hf : IsOpenMap f) {s : Set X} (hs : Is
 
 lemma IsClosed.isClosedEmbedding_subtypeVal {s : Set X} (hs : IsClosed s) :
     IsClosedEmbedding ((↑) : s → X) := .subtypeVal hs
+
+@[deprecated (since := "2024-10-20")]
+alias IsClosed.closedEmbedding_subtype_val := IsClosed.isClosedEmbedding_subtypeVal
 
 theorem IsClosed.isClosedMap_subtype_val {s : Set X} (hs : IsClosed s) :
     IsClosedMap ((↑) : s → X) :=
@@ -1550,6 +1562,9 @@ theorem isClosedEmbedding_sigmaMk {i : ι} : IsClosedEmbedding (@Sigma.mk ι σ 
   .of_continuous_injective_isClosedMap continuous_sigmaMk sigma_mk_injective
     isClosedMap_sigmaMk
 
+@[deprecated (since := "2024-10-20")]
+alias closedEmbedding_sigmaMk := isClosedEmbedding_sigmaMk
+
 theorem embedding_sigmaMk {i : ι} : Embedding (@Sigma.mk ι σ i) :=
   isClosedEmbedding_sigmaMk.1
 
@@ -1659,6 +1674,9 @@ theorem embedding_uLift_down [TopologicalSpace X] : Embedding (ULift.down : ULif
 theorem ULift.isClosedEmbedding_down [TopologicalSpace X] :
     IsClosedEmbedding (ULift.down : ULift.{v, u} X → X) :=
   ⟨embedding_uLift_down, by simp only [ULift.down_surjective.range_eq, isClosed_univ]⟩
+
+@[deprecated (since := "2024-10-20")]
+alias ULift.closedEmbedding_down := ULift.isClosedEmbedding_down
 
 instance [TopologicalSpace X] [DiscreteTopology X] : DiscreteTopology (ULift X) :=
   embedding_uLift_down.discreteTopology

--- a/Mathlib/Topology/Constructions.lean
+++ b/Mathlib/Topology/Constructions.lean
@@ -937,10 +937,10 @@ theorem isClosed_range_inr : IsClosed (range (inr : Y → X ⊕ Y)) := by
   rw [← isOpen_compl_iff, compl_range_inr]
   exact isOpen_range_inl
 
-theorem closedEmbedding_inl : ClosedEmbedding (inl : X → X ⊕ Y) :=
+theorem isClosedEmbedding_inl : IsClosedEmbedding (inl : X → X ⊕ Y) :=
   ⟨embedding_inl, isClosed_range_inl⟩
 
-theorem closedEmbedding_inr : ClosedEmbedding (inr : Y → X ⊕ Y) :=
+theorem isClosedEmbedding_inr : IsClosedEmbedding (inr : Y → X ⊕ Y) :=
   ⟨embedding_inr, isClosed_range_inr⟩
 
 theorem nhds_inl (x : X) : 𝓝 (inl x : X ⊕ Y) = map inl (𝓝 x) :=
@@ -981,7 +981,7 @@ theorem isClosedMap_sum {f : X ⊕ Y → Z} :
     IsClosedMap f ↔ (IsClosedMap fun a => f (.inl a)) ∧ IsClosedMap fun b => f (.inr b) := by
   constructor
   · intro h
-    exact ⟨h.comp closedEmbedding_inl.isClosedMap, h.comp closedEmbedding_inr.isClosedMap⟩
+    exact ⟨h.comp isClosedEmbedding_inl.isClosedMap, h.comp isClosedEmbedding_inr.isClosedMap⟩
   · rintro h Z hZ
     rw [isClosed_sum_iff] at hZ
     convert (h.1 _ hZ.1).union (h.2 _ hZ.2)
@@ -1003,8 +1003,8 @@ theorem Inducing.of_codRestrict {f : X → Y} {t : Set Y} (ht : ∀ x, f x ∈ t
 theorem embedding_subtype_val : Embedding ((↑) : Subtype p → X) :=
   ⟨inducing_subtype_val, Subtype.coe_injective⟩
 
-theorem closedEmbedding_subtype_val (h : IsClosed { a | p a }) :
-    ClosedEmbedding ((↑) : Subtype p → X) :=
+theorem IsClosedEmbedding.subtypeVal (h : IsClosed {a | p a}) :
+    IsClosedEmbedding ((↑) : Subtype p → X) :=
   ⟨embedding_subtype_val, by rwa [Subtype.range_coe_subtype]⟩
 
 @[continuity, fun_prop]
@@ -1029,13 +1029,12 @@ theorem IsOpenMap.restrict {f : X → Y} (hf : IsOpenMap f) {s : Set X} (hs : Is
     IsOpenMap (s.restrict f) :=
   hf.comp hs.isOpenMap_subtype_val
 
-nonrec theorem IsClosed.closedEmbedding_subtype_val {s : Set X} (hs : IsClosed s) :
-    ClosedEmbedding ((↑) : s → X) :=
-  closedEmbedding_subtype_val hs
+lemma IsClosed.isClosedEmbedding_subtypeVal {s : Set X} (hs : IsClosed s) :
+    IsClosedEmbedding ((↑) : s → X) := .subtypeVal hs
 
 theorem IsClosed.isClosedMap_subtype_val {s : Set X} (hs : IsClosed s) :
     IsClosedMap ((↑) : s → X) :=
-  hs.closedEmbedding_subtype_val.isClosedMap
+  hs.isClosedEmbedding_subtypeVal.isClosedMap
 
 @[continuity, fun_prop]
 theorem Continuous.subtype_mk {f : Y → X} (h : Continuous f) (hp : ∀ x, p (f x)) :
@@ -1547,12 +1546,12 @@ theorem isOpenEmbedding_sigmaMk {i : ι} : IsOpenEmbedding (@Sigma.mk ι σ i) :
 @[deprecated (since := "2024-10-18")]
 alias openEmbedding_sigmaMk := isOpenEmbedding_sigmaMk
 
-theorem closedEmbedding_sigmaMk {i : ι} : ClosedEmbedding (@Sigma.mk ι σ i) :=
-  closedEmbedding_of_continuous_injective_closed continuous_sigmaMk sigma_mk_injective
+theorem isClosedEmbedding_sigmaMk {i : ι} : IsClosedEmbedding (@Sigma.mk ι σ i) :=
+  .of_continuous_injective_isClosedMap continuous_sigmaMk sigma_mk_injective
     isClosedMap_sigmaMk
 
 theorem embedding_sigmaMk {i : ι} : Embedding (@Sigma.mk ι σ i) :=
-  closedEmbedding_sigmaMk.1
+  isClosedEmbedding_sigmaMk.1
 
 theorem Sigma.nhds_mk (i : ι) (x : σ i) : 𝓝 (⟨i, x⟩ : Sigma σ) = Filter.map (Sigma.mk i) (𝓝 x) :=
   (isOpenEmbedding_sigmaMk.map_nhds_eq x).symm
@@ -1657,8 +1656,8 @@ theorem continuous_uLift_up [TopologicalSpace X] : Continuous (ULift.up : X → 
 theorem embedding_uLift_down [TopologicalSpace X] : Embedding (ULift.down : ULift.{v, u} X → X) :=
   ⟨⟨rfl⟩, ULift.down_injective⟩
 
-theorem ULift.closedEmbedding_down [TopologicalSpace X] :
-    ClosedEmbedding (ULift.down : ULift.{v, u} X → X) :=
+theorem ULift.isClosedEmbedding_down [TopologicalSpace X] :
+    IsClosedEmbedding (ULift.down : ULift.{v, u} X → X) :=
   ⟨embedding_uLift_down, by simp only [ULift.down_surjective.range_eq, isClosed_univ]⟩
 
 instance [TopologicalSpace X] [DiscreteTopology X] : DiscreteTopology (ULift X) :=

--- a/Mathlib/Topology/ContinuousMap/ContinuousMapZero.lean
+++ b/Mathlib/Topology/ContinuousMap/ContinuousMapZero.lean
@@ -98,8 +98,8 @@ instance instContinuousEvalConst : ContinuousEvalConst C(X, R)₀ X R :=
 instance instContinuousEval [LocallyCompactPair X R] : ContinuousEval C(X, R)₀ X R :=
   .of_continuous_forget embedding_toContinuousMap.continuous
 
-lemma closedEmbedding_toContinuousMap [T1Space R] :
-    ClosedEmbedding ((↑) : C(X, R)₀ → C(X, R)) where
+lemma isClosedEmbedding_toContinuousMap [T1Space R] :
+    IsClosedEmbedding ((↑) : C(X, R)₀ → C(X, R)) where
   toEmbedding := embedding_toContinuousMap
   isClosed_range := by
     rw [range_toContinuousMap]
@@ -288,7 +288,7 @@ alias uniformEmbedding_toContinuousMap := isUniformEmbedding_toContinuousMap
 
 instance [T1Space R] [CompleteSpace C(X, R)] : CompleteSpace C(X, R)₀ :=
   completeSpace_iff_isComplete_range isUniformEmbedding_toContinuousMap.isUniformInducing
-    |>.mpr closedEmbedding_toContinuousMap.isClosed_range.isComplete
+    |>.mpr isClosedEmbedding_toContinuousMap.isClosed_range.isComplete
 
 lemma isUniformEmbedding_comp {Y : Type*} [UniformSpace Y] [Zero Y] (g : C(Y, R)₀)
     (hg : IsUniformEmbedding g) : IsUniformEmbedding (g.comp · : C(X, Y)₀ → C(X, R)₀) :=

--- a/Mathlib/Topology/ContinuousMap/ContinuousMapZero.lean
+++ b/Mathlib/Topology/ContinuousMap/ContinuousMapZero.lean
@@ -105,6 +105,9 @@ lemma isClosedEmbedding_toContinuousMap [T1Space R] :
     rw [range_toContinuousMap]
     exact isClosed_singleton.preimage <| continuous_eval_const 0
 
+@[deprecated (since := "2024-10-20")]
+alias closedEmbedding_toContinuousMap := isClosedEmbedding_toContinuousMap
+
 @[fun_prop]
 lemma continuous_comp_left {X Y Z : Type*} [TopologicalSpace X]
     [TopologicalSpace Y] [TopologicalSpace Z] [Zero X] [Zero Y] [Zero Z] (f : C(X, Y)₀) :

--- a/Mathlib/Topology/ContinuousMap/StoneWeierstrass.lean
+++ b/Mathlib/Topology/ContinuousMap/StoneWeierstrass.lean
@@ -556,8 +556,8 @@ lemma ContinuousMapZero.adjoin_id_dense {s : Set 𝕜} [Zero s] (h0 : ((0 : s) :
     [CompactSpace s] : Dense (adjoin 𝕜 {(.id h0 : C(s, 𝕜)₀)} : Set C(s, 𝕜)₀) := by
   have h0' : 0 ∈ s := h0 ▸ (0 : s).property
   rw [dense_iff_closure_eq,
-    ← closedEmbedding_toContinuousMap.injective.preimage_image (closure _),
-    ← closedEmbedding_toContinuousMap.closure_image_eq, ← coe_toContinuousMapHom,
+    ← isClosedEmbedding_toContinuousMap.injective.preimage_image (closure _),
+    ← isClosedEmbedding_toContinuousMap.closure_image_eq, ← coe_toContinuousMapHom,
     ← NonUnitalStarSubalgebra.coe_map, NonUnitalStarAlgHom.map_adjoin_singleton,
     toContinuousMapHom_apply, toContinuousMap_id h0,
     ← ContinuousMap.ker_evalStarAlgHom_eq_closure_adjoin_id s h0']

--- a/Mathlib/Topology/Defs/Induced.lean
+++ b/Mathlib/Topology/Defs/Induced.lean
@@ -32,7 +32,7 @@ as well as topology inducing maps, topological embeddings, and quotient maps.
   if it is an embedding and its range is open.
   An open embedding is an open map.
 
-* `ClosedEmbedding`: a map `f : X → Y` is an *open embedding*,
+* `IsClosedEmbedding`: a map `f : X → Y` is an *open embedding*,
   if it is an embedding and its range is open.
   An open embedding is an open map.
 
@@ -121,7 +121,7 @@ alias OpenEmbedding := IsOpenEmbedding
 
 /-- A closed embedding is an embedding with closed image. -/
 @[mk_iff]
-structure ClosedEmbedding (f : X → Y) extends Embedding f : Prop where
+structure IsClosedEmbedding (f : X → Y) extends Embedding f : Prop where
   /-- The range of a closed embedding is a closed set. -/
   isClosed_range : IsClosed <| range f
 

--- a/Mathlib/Topology/Defs/Induced.lean
+++ b/Mathlib/Topology/Defs/Induced.lean
@@ -125,6 +125,9 @@ structure IsClosedEmbedding (f : X → Y) extends Embedding f : Prop where
   /-- The range of a closed embedding is a closed set. -/
   isClosed_range : IsClosed <| range f
 
+@[deprecated (since := "2024-10-20")]
+alias ClosedEmbedding := IsClosedEmbedding
+
 /-- A function between topological spaces is a quotient map if it is surjective,
   and for all `s : Set Y`, `s` is open iff its preimage is an open set. -/
 @[mk_iff quotientMap_iff']

--- a/Mathlib/Topology/DiscreteSubset.lean
+++ b/Mathlib/Topology/DiscreteSubset.lean
@@ -69,7 +69,7 @@ lemma tendsto_cofinite_cocompact_of_discrete [DiscreteTopology X]
 lemma IsClosed.tendsto_coe_cofinite_of_discreteTopology
     {s : Set X} (hs : IsClosed s) (_hs' : DiscreteTopology s) :
     Tendsto ((↑) : s → X) cofinite (cocompact _) :=
-  tendsto_cofinite_cocompact_of_discrete hs.closedEmbedding_subtype_val.tendsto_cocompact
+  tendsto_cofinite_cocompact_of_discrete hs.isClosedEmbedding_subtypeVal.tendsto_cocompact
 
 lemma IsClosed.tendsto_coe_cofinite_iff [T1Space X] [WeaklyLocallyCompactSpace X]
     {s : Set X} (hs : IsClosed s) :

--- a/Mathlib/Topology/FiberBundle/Basic.lean
+++ b/Mathlib/Topology/FiberBundle/Basic.lean
@@ -261,8 +261,8 @@ theorem continuous_totalSpaceMk (x : B) : Continuous (@TotalSpace.mk B F E x) :=
 theorem totalSpaceMk_embedding (x : B) : Embedding (@TotalSpace.mk B F E x) :=
   ⟨totalSpaceMk_inducing F E x, TotalSpace.mk_injective x⟩
 
-theorem totalSpaceMk_closedEmbedding [T1Space B] (x : B) :
-    ClosedEmbedding (@TotalSpace.mk B F E x) :=
+theorem totalSpaceMk_isClosedEmbedding [T1Space B] (x : B) :
+    IsClosedEmbedding (@TotalSpace.mk B F E x) :=
   ⟨totalSpaceMk_embedding F E x, by
     rw [TotalSpace.range_mk]
     exact isClosed_singleton.preimage <| continuous_proj F E⟩

--- a/Mathlib/Topology/FiberBundle/Basic.lean
+++ b/Mathlib/Topology/FiberBundle/Basic.lean
@@ -267,6 +267,9 @@ theorem totalSpaceMk_isClosedEmbedding [T1Space B] (x : B) :
     rw [TotalSpace.range_mk]
     exact isClosed_singleton.preimage <| continuous_proj F E⟩
 
+@[deprecated (since := "2024-10-20")]
+alias totalSpaceMk_closedEmbedding := totalSpaceMk_isClosedEmbedding
+
 variable {E F}
 
 @[simp, mfld_simps]

--- a/Mathlib/Topology/Homeomorph.lean
+++ b/Mathlib/Topology/Homeomorph.lean
@@ -338,14 +338,14 @@ theorem isOpenEmbedding (h : X ≃ₜ Y) : IsOpenEmbedding h :=
 @[deprecated (since := "2024-10-18")]
 alias openEmbedding := isOpenEmbedding
 
-protected theorem closedEmbedding (h : X ≃ₜ Y) : ClosedEmbedding h :=
-  closedEmbedding_of_embedding_closed h.embedding h.isClosedMap
+protected theorem isClosedEmbedding (h : X ≃ₜ Y) : IsClosedEmbedding h :=
+  .of_embedding_closed h.embedding h.isClosedMap
 
 protected theorem normalSpace [NormalSpace X] (h : X ≃ₜ Y) : NormalSpace Y :=
-  h.symm.closedEmbedding.normalSpace
+  h.symm.isClosedEmbedding.normalSpace
 
 protected theorem t4Space [T4Space X] (h : X ≃ₜ Y) : T4Space Y :=
-  h.symm.closedEmbedding.t4Space
+  h.symm.isClosedEmbedding.t4Space
 
 theorem preimage_closure (h : X ≃ₜ Y) (s : Set Y) : h ⁻¹' closure s = closure (h ⁻¹' s) :=
   h.isOpenMap.preimage_closure_eq_closure_preimage h.continuous _
@@ -368,7 +368,7 @@ theorem image_frontier (h : X ≃ₜ Y) (s : Set X) : h '' frontier s = frontier
 @[to_additive]
 theorem _root_.HasCompactMulSupport.comp_homeomorph {M} [One M] {f : Y → M}
     (hf : HasCompactMulSupport f) (φ : X ≃ₜ Y) : HasCompactMulSupport (f ∘ φ) :=
-  hf.comp_closedEmbedding φ.closedEmbedding
+  hf.comp_isClosedEmbedding φ.isClosedEmbedding
 
 @[simp]
 theorem map_nhds_eq (h : X ≃ₜ Y) (x : X) : map h (𝓝 x) = 𝓝 (h x) :=
@@ -405,7 +405,7 @@ the domain is a locally compact space. -/
 theorem locallyCompactSpace_iff (h : X ≃ₜ Y) :
     LocallyCompactSpace X ↔ LocallyCompactSpace Y := by
   exact ⟨fun _ => h.symm.isOpenEmbedding.locallyCompactSpace,
-    fun _ => h.closedEmbedding.locallyCompactSpace⟩
+    fun _ => h.isClosedEmbedding.locallyCompactSpace⟩
 
 /-- If a bijective map `e : X ≃ Y` is continuous and open, then it is a homeomorphism. -/
 @[simps toEquiv]
@@ -912,7 +912,7 @@ protected lemma inducing : Inducing f := (hf.homeomorph f).inducing
 protected lemma quotientMap : QuotientMap f := (hf.homeomorph f).quotientMap
 protected lemma embedding : Embedding f := (hf.homeomorph f).embedding
 lemma isOpenEmbedding : IsOpenEmbedding f := (hf.homeomorph f).isOpenEmbedding
-protected lemma closedEmbedding : ClosedEmbedding f := (hf.homeomorph f).closedEmbedding
+protected lemma isClosedEmbedding : IsClosedEmbedding f := (hf.homeomorph f).isClosedEmbedding
 lemma isDenseEmbedding : IsDenseEmbedding f := (hf.homeomorph f).isDenseEmbedding
 
 @[deprecated (since := "2024-10-18")]

--- a/Mathlib/Topology/Homeomorph.lean
+++ b/Mathlib/Topology/Homeomorph.lean
@@ -915,12 +915,10 @@ protected lemma inducing : Inducing f := (hf.homeomorph f).inducing
 protected lemma quotientMap : QuotientMap f := (hf.homeomorph f).quotientMap
 protected lemma embedding : Embedding f := (hf.homeomorph f).embedding
 lemma isOpenEmbedding : IsOpenEmbedding f := (hf.homeomorph f).isOpenEmbedding
-protected lemma isClosedEmbedding : IsClosedEmbedding f := (hf.homeomorph f).isClosedEmbedding
+lemma isClosedEmbedding : IsClosedEmbedding f := (hf.homeomorph f).isClosedEmbedding
 lemma isDenseEmbedding : IsDenseEmbedding f := (hf.homeomorph f).isDenseEmbedding
 
-@[deprecated (since := "2024-10-20")]
-alias closedEmbedding := isClosedEmbedding
-
+@[deprecated (since := "2024-10-20")] alias closedEmbedding := isClosedEmbedding
 @[deprecated (since := "2024-10-18")]
 alias openEmbedding := isOpenEmbedding
 

--- a/Mathlib/Topology/Homeomorph.lean
+++ b/Mathlib/Topology/Homeomorph.lean
@@ -338,8 +338,11 @@ theorem isOpenEmbedding (h : X ≃ₜ Y) : IsOpenEmbedding h :=
 @[deprecated (since := "2024-10-18")]
 alias openEmbedding := isOpenEmbedding
 
-protected theorem isClosedEmbedding (h : X ≃ₜ Y) : IsClosedEmbedding h :=
+theorem isClosedEmbedding (h : X ≃ₜ Y) : IsClosedEmbedding h :=
   .of_embedding_closed h.embedding h.isClosedMap
+
+@[deprecated (since := "2024-10-20")]
+alias closedEmbedding := isClosedEmbedding
 
 protected theorem normalSpace [NormalSpace X] (h : X ≃ₜ Y) : NormalSpace Y :=
   h.symm.isClosedEmbedding.normalSpace
@@ -914,6 +917,9 @@ protected lemma embedding : Embedding f := (hf.homeomorph f).embedding
 lemma isOpenEmbedding : IsOpenEmbedding f := (hf.homeomorph f).isOpenEmbedding
 protected lemma isClosedEmbedding : IsClosedEmbedding f := (hf.homeomorph f).isClosedEmbedding
 lemma isDenseEmbedding : IsDenseEmbedding f := (hf.homeomorph f).isDenseEmbedding
+
+@[deprecated (since := "2024-10-20")]
+alias closedEmbedding := isClosedEmbedding
 
 @[deprecated (since := "2024-10-18")]
 alias openEmbedding := isOpenEmbedding

--- a/Mathlib/Topology/Instances/CantorSet.lean
+++ b/Mathlib/Topology/Instances/CantorSet.lean
@@ -86,8 +86,8 @@ lemma isClosed_preCantorSet (n : ℕ) : IsClosed (preCantorSet n) := by
   | zero => exact isClosed_Icc
   | succ n ih =>
     refine IsClosed.union ?_ ?_
-    · simpa [f, div_eq_inv_mul] using f.closedEmbedding.closed_iff_image_closed.mp ih
-    · simpa [g, f, div_eq_inv_mul] using g.closedEmbedding.closed_iff_image_closed.mp ih
+    · simpa [f, div_eq_inv_mul] using f.isClosedEmbedding.closed_iff_image_closed.mp ih
+    · simpa [g, f, div_eq_inv_mul] using g.isClosedEmbedding.closed_iff_image_closed.mp ih
 
 /-- The ternary Cantor set is closed. -/
 lemma isClosed_cantorSet : IsClosed cantorSet :=

--- a/Mathlib/Topology/Instances/EReal.lean
+++ b/Mathlib/Topology/Instances/EReal.lean
@@ -96,7 +96,7 @@ theorem embedding_coe_ennreal : Embedding ((↑) : ℝ≥0∞ → EReal) :=
   coe_ennreal_strictMono.embedding_of_ordConnected <| by
     rw [range_coe_ennreal]; exact ordConnected_Ici
 
-theorem closedEmbedding_coe_ennreal : ClosedEmbedding ((↑) : ℝ≥0∞ → EReal) :=
+theorem isClosedEmbedding_coe_ennreal : IsClosedEmbedding ((↑) : ℝ≥0∞ → EReal) :=
   ⟨embedding_coe_ennreal, by rw [range_coe_ennreal]; exact isClosed_Ici⟩
 
 @[norm_cast]

--- a/Mathlib/Topology/Instances/EReal.lean
+++ b/Mathlib/Topology/Instances/EReal.lean
@@ -99,6 +99,9 @@ theorem embedding_coe_ennreal : Embedding ((↑) : ℝ≥0∞ → EReal) :=
 theorem isClosedEmbedding_coe_ennreal : IsClosedEmbedding ((↑) : ℝ≥0∞ → EReal) :=
   ⟨embedding_coe_ennreal, by rw [range_coe_ennreal]; exact isClosed_Ici⟩
 
+@[deprecated (since := "2024-10-20")]
+alias closedEmbedding_coe_ennreal := isClosedEmbedding_coe_ennreal
+
 @[norm_cast]
 theorem tendsto_coe_ennreal {α : Type*} {f : Filter α} {m : α → ℝ≥0∞} {a : ℝ≥0∞} :
     Tendsto (fun a => (m a : EReal)) f (𝓝 ↑a) ↔ Tendsto m f (𝓝 a) :=

--- a/Mathlib/Topology/Instances/Int.lean
+++ b/Mathlib/Topology/Instances/Int.lean
@@ -45,8 +45,8 @@ theorem isUniformEmbedding_coe_real : IsUniformEmbedding ((↑) : ℤ → ℝ) :
 @[deprecated (since := "2024-10-01")]
 alias uniformEmbedding_coe_real := isUniformEmbedding_coe_real
 
-theorem closedEmbedding_coe_real : ClosedEmbedding ((↑) : ℤ → ℝ) :=
-  closedEmbedding_of_pairwise_le_dist zero_lt_one pairwise_one_le_dist
+theorem isClosedEmbedding_coe_real : IsClosedEmbedding ((↑) : ℤ → ℝ) :=
+  isClosedEmbedding_of_pairwise_le_dist zero_lt_one pairwise_one_le_dist
 
 instance : MetricSpace ℤ := Int.isUniformEmbedding_coe_real.comapMetricSpace _
 

--- a/Mathlib/Topology/Instances/Int.lean
+++ b/Mathlib/Topology/Instances/Int.lean
@@ -48,6 +48,9 @@ alias uniformEmbedding_coe_real := isUniformEmbedding_coe_real
 theorem isClosedEmbedding_coe_real : IsClosedEmbedding ((↑) : ℤ → ℝ) :=
   isClosedEmbedding_of_pairwise_le_dist zero_lt_one pairwise_one_le_dist
 
+@[deprecated (since := "2024-10-20")]
+alias closedEmbedding_coe_real := isClosedEmbedding_coe_real
+
 instance : MetricSpace ℤ := Int.isUniformEmbedding_coe_real.comapMetricSpace _
 
 theorem preimage_ball (x : ℤ) (r : ℝ) : (↑) ⁻¹' ball (x : ℝ) r = ball x r := rfl

--- a/Mathlib/Topology/Instances/Irrational.lean
+++ b/Mathlib/Topology/Instances/Irrational.lean
@@ -71,7 +71,7 @@ instance : DenselyOrdered { x // Irrational x } :=
 theorem eventually_forall_le_dist_cast_div (hx : Irrational x) (n : ℕ) :
     ∀ᶠ ε : ℝ in 𝓝 0, ∀ m : ℤ, ε ≤ dist x (m / n) := by
   have A : IsClosed (range (fun m => (n : ℝ)⁻¹ * m : ℤ → ℝ)) :=
-    ((isClosedMap_smul₀ (n⁻¹ : ℝ)).comp Int.closedEmbedding_coe_real.isClosedMap).isClosed_range
+    ((isClosedMap_smul₀ (n⁻¹ : ℝ)).comp Int.isClosedEmbedding_coe_real.isClosedMap).isClosed_range
   have B : x ∉ range (fun m => (n : ℝ)⁻¹ * m : ℤ → ℝ) := by
     rintro ⟨m, rfl⟩
     simp at hx

--- a/Mathlib/Topology/Instances/NNReal.lean
+++ b/Mathlib/Topology/Instances/NNReal.lean
@@ -289,7 +289,7 @@ end Monotone
 
 instance instProperSpace : ProperSpace ℝ≥0 where
   isCompact_closedBall x r := by
-    have emb : ClosedEmbedding ((↑) : ℝ≥0 → ℝ) := Isometry.closedEmbedding fun _ ↦ congrFun rfl
+    have emb : IsClosedEmbedding ((↑) : ℝ≥0 → ℝ) := Isometry.isClosedEmbedding fun _ ↦ congrFun rfl
     exact emb.isCompact_preimage (K := Metric.closedBall x r) (isCompact_closedBall _ _)
 
 end NNReal

--- a/Mathlib/Topology/Instances/Nat.lean
+++ b/Mathlib/Topology/Instances/Nat.lean
@@ -37,8 +37,8 @@ theorem isUniformEmbedding_coe_real : IsUniformEmbedding ((↑) : ℕ → ℝ) :
 @[deprecated (since := "2024-10-01")]
 alias uniformEmbedding_coe_real := isUniformEmbedding_coe_real
 
-theorem closedEmbedding_coe_real : ClosedEmbedding ((↑) : ℕ → ℝ) :=
-  closedEmbedding_of_pairwise_le_dist zero_lt_one pairwise_one_le_dist
+theorem isClosedEmbedding_coe_real : IsClosedEmbedding ((↑) : ℕ → ℝ) :=
+  isClosedEmbedding_of_pairwise_le_dist zero_lt_one pairwise_one_le_dist
 
 instance : MetricSpace ℕ := Nat.isUniformEmbedding_coe_real.comapMetricSpace _
 

--- a/Mathlib/Topology/Instances/Nat.lean
+++ b/Mathlib/Topology/Instances/Nat.lean
@@ -40,6 +40,9 @@ alias uniformEmbedding_coe_real := isUniformEmbedding_coe_real
 theorem isClosedEmbedding_coe_real : IsClosedEmbedding ((↑) : ℕ → ℝ) :=
   isClosedEmbedding_of_pairwise_le_dist zero_lt_one pairwise_one_le_dist
 
+@[deprecated (since := "2024-10-20")]
+alias closedEmbedding_coe_real := isClosedEmbedding_coe_real
+
 instance : MetricSpace ℕ := Nat.isUniformEmbedding_coe_real.comapMetricSpace _
 
 theorem preimage_ball (x : ℕ) (r : ℝ) : (↑) ⁻¹' ball (x : ℝ) r = ball x r := rfl

--- a/Mathlib/Topology/Instances/Rat.lean
+++ b/Mathlib/Topology/Instances/Rat.lean
@@ -60,8 +60,8 @@ theorem Nat.isUniformEmbedding_coe_rat : IsUniformEmbedding ((↑) : ℕ → ℚ
 @[deprecated (since := "2024-10-01")]
 alias Nat.uniformEmbedding_coe_rat := Nat.isUniformEmbedding_coe_rat
 
-theorem Nat.closedEmbedding_coe_rat : ClosedEmbedding ((↑) : ℕ → ℚ) :=
-  closedEmbedding_of_pairwise_le_dist zero_lt_one <| by simpa using Nat.pairwise_one_le_dist
+theorem Nat.isClosedEmbedding_coe_rat : IsClosedEmbedding ((↑) : ℕ → ℚ) :=
+  isClosedEmbedding_of_pairwise_le_dist zero_lt_one <| by simpa using Nat.pairwise_one_le_dist
 
 @[norm_cast, simp]
 theorem Int.dist_cast_rat (x y : ℤ) : dist (x : ℚ) y = dist x y := by
@@ -73,12 +73,12 @@ theorem Int.isUniformEmbedding_coe_rat : IsUniformEmbedding ((↑) : ℤ → ℚ
 @[deprecated (since := "2024-10-01")]
 alias Int.uniformEmbedding_coe_rat := Int.isUniformEmbedding_coe_rat
 
-theorem Int.closedEmbedding_coe_rat : ClosedEmbedding ((↑) : ℤ → ℚ) :=
-  closedEmbedding_of_pairwise_le_dist zero_lt_one <| by simpa using Int.pairwise_one_le_dist
+theorem Int.isClosedEmbedding_coe_rat : IsClosedEmbedding ((↑) : ℤ → ℚ) :=
+  isClosedEmbedding_of_pairwise_le_dist zero_lt_one <| by simpa using Int.pairwise_one_le_dist
 
 namespace Rat
 
-instance : NoncompactSpace ℚ := Int.closedEmbedding_coe_rat.noncompactSpace
+instance : NoncompactSpace ℚ := Int.isClosedEmbedding_coe_rat.noncompactSpace
 
 theorem uniformContinuous_add : UniformContinuous fun p : ℚ × ℚ => p.1 + p.2 :=
   Rat.isUniformEmbedding_coe_real.isUniformInducing.uniformContinuous_iff.2 <| by

--- a/Mathlib/Topology/Instances/Rat.lean
+++ b/Mathlib/Topology/Instances/Rat.lean
@@ -63,6 +63,9 @@ alias Nat.uniformEmbedding_coe_rat := Nat.isUniformEmbedding_coe_rat
 theorem Nat.isClosedEmbedding_coe_rat : IsClosedEmbedding ((↑) : ℕ → ℚ) :=
   isClosedEmbedding_of_pairwise_le_dist zero_lt_one <| by simpa using Nat.pairwise_one_le_dist
 
+@[deprecated (since := "2024-10-20")]
+alias Nat.closedEmbedding_coe_rat := Nat.isClosedEmbedding_coe_rat
+
 @[norm_cast, simp]
 theorem Int.dist_cast_rat (x y : ℤ) : dist (x : ℚ) y = dist x y := by
   rw [← Int.dist_cast_real, ← Rat.dist_cast]; congr
@@ -75,6 +78,9 @@ alias Int.uniformEmbedding_coe_rat := Int.isUniformEmbedding_coe_rat
 
 theorem Int.isClosedEmbedding_coe_rat : IsClosedEmbedding ((↑) : ℤ → ℚ) :=
   isClosedEmbedding_of_pairwise_le_dist zero_lt_one <| by simpa using Int.pairwise_one_le_dist
+
+@[deprecated (since := "2024-10-20")]
+alias Int.closedEmbedding_coe_rat := Int.isClosedEmbedding_coe_rat
 
 namespace Rat
 

--- a/Mathlib/Topology/Instances/Real.lean
+++ b/Mathlib/Topology/Instances/Real.lean
@@ -28,7 +28,7 @@ universe u v w
 
 variable {α : Type u} {β : Type v} {γ : Type w}
 
-instance : NoncompactSpace ℝ := Int.closedEmbedding_coe_real.noncompactSpace
+instance : NoncompactSpace ℝ := Int.isClosedEmbedding_coe_real.noncompactSpace
 
 theorem Real.uniformContinuous_add : UniformContinuous fun p : ℝ × ℝ => p.1 + p.2 :=
   Metric.uniformContinuous_iff.2 fun _ε ε0 =>

--- a/Mathlib/Topology/KrullDimension.lean
+++ b/Mathlib/Topology/KrullDimension.lean
@@ -40,7 +40,7 @@ def IrreducibleCloseds.map {f : X → Y} (hf1 : Continuous f) (hf2 : IsClosedMap
 /--
 Taking images under a closed embedding is strictly monotone on the preorder of irreducible closeds.
 -/
-lemma IrreducibleCloseds.map_strictMono {f : X → Y} (hf : ClosedEmbedding f) :
+lemma IrreducibleCloseds.map_strictMono {f : X → Y} (hf : IsClosedEmbedding f) :
     StrictMono (IrreducibleCloseds.map hf.continuous hf.isClosedMap) :=
   fun ⦃_ _⦄ UltV ↦ hf.inj.image_strictMono UltV
 
@@ -48,7 +48,7 @@ lemma IrreducibleCloseds.map_strictMono {f : X → Y} (hf : ClosedEmbedding f) :
 If `f : X → Y` is a closed embedding, then the Krull dimension of `X` is less than or equal
 to the Krull dimension of `Y`.
 -/
-theorem ClosedEmbedding.topologicalKrullDim_le (f : X → Y) (hf : ClosedEmbedding f) :
+theorem IsClosedEmbedding.topologicalKrullDim_le (f : X → Y) (hf : IsClosedEmbedding f) :
     topologicalKrullDim X ≤ topologicalKrullDim Y :=
   krullDim_le_of_strictMono _ (IrreducibleCloseds.map_strictMono hf)
 
@@ -56,8 +56,8 @@ theorem ClosedEmbedding.topologicalKrullDim_le (f : X → Y) (hf : ClosedEmbeddi
 theorem IsHomeomorph.topologicalKrullDim_eq (f : X → Y) (h : IsHomeomorph f) :
     topologicalKrullDim X = topologicalKrullDim Y :=
   have fwd : topologicalKrullDim X ≤ topologicalKrullDim Y :=
-    ClosedEmbedding.topologicalKrullDim_le f h.closedEmbedding
+    IsClosedEmbedding.topologicalKrullDim_le f h.isClosedEmbedding
   have bwd : topologicalKrullDim Y ≤ topologicalKrullDim X :=
-    ClosedEmbedding.topologicalKrullDim_le (h.homeomorph f).symm
-    (h.homeomorph f).symm.closedEmbedding
+    IsClosedEmbedding.topologicalKrullDim_le (h.homeomorph f).symm
+    (h.homeomorph f).symm.isClosedEmbedding
   le_antisymm fwd bwd

--- a/Mathlib/Topology/KrullDimension.lean
+++ b/Mathlib/Topology/KrullDimension.lean
@@ -52,6 +52,9 @@ theorem IsClosedEmbedding.topologicalKrullDim_le (f : X → Y) (hf : IsClosedEmb
     topologicalKrullDim X ≤ topologicalKrullDim Y :=
   krullDim_le_of_strictMono _ (IrreducibleCloseds.map_strictMono hf)
 
+@[deprecated (since := "2024-10-20")]
+alias ClosedEmbedding.topologicalKrullDim_le := IsClosedEmbedding.topologicalKrullDim_le
+
 /-- The topological Krull dimension is invariant under homeomorphisms -/
 theorem IsHomeomorph.topologicalKrullDim_eq (f : X → Y) (h : IsHomeomorph f) :
     topologicalKrullDim X = topologicalKrullDim Y :=

--- a/Mathlib/Topology/LocalAtTarget.lean
+++ b/Mathlib/Topology/LocalAtTarget.lean
@@ -200,4 +200,5 @@ theorem isClosedEmbedding_iff_isClosedEmbedding_of_iSup_eq_top (h : Continuous f
     apply isClosed_iff_coe_preimage_of_iSup_eq_top hU
 
 @[deprecated (since := "2024-10-20")]
-alias closedEmbedding_iff_closedEmbedding_of_iSup_eq_top := isClosedEmbedding_iff_isClosedEmbedding_of_iSup_eq_top
+alias closedEmbedding_iff_closedEmbedding_of_iSup_eq_top :=
+ isClosedEmbedding_iff_isClosedEmbedding_of_iSup_eq_top

--- a/Mathlib/Topology/LocalAtTarget.lean
+++ b/Mathlib/Topology/LocalAtTarget.lean
@@ -58,7 +58,13 @@ theorem Set.restrictPreimage_isClosedEmbedding (s : Set β) (h : IsClosedEmbeddi
   ⟨h.1.restrictPreimage s,
     (s.range_restrictPreimage f).symm ▸ inducing_subtype_val.isClosed_preimage _ h.isClosed_range⟩
 
+@[deprecated (since := "2024-10-20")]
+alias Set.restrictPreimage_closedEmbedding := Set.restrictPreimage_isClosedEmbedding
+
 alias IsClosedEmbedding.restrictPreimage := Set.restrictPreimage_isClosedEmbedding
+
+@[deprecated (since := "2024-10-20")]
+alias ClosedEmbedding.restrictPreimage := IsClosedEmbedding.restrictPreimage
 
 theorem IsClosedMap.restrictPreimage (H : IsClosedMap f) (s : Set β) :
     IsClosedMap (s.restrictPreimage f) := by
@@ -192,3 +198,6 @@ theorem isClosedEmbedding_iff_isClosedEmbedding_of_iSup_eq_top (h : Continuous f
   · apply embedding_iff_embedding_of_iSup_eq_top <;> assumption
   · simp_rw [Set.range_restrictPreimage]
     apply isClosed_iff_coe_preimage_of_iSup_eq_top hU
+
+@[deprecated (since := "2024-10-20")]
+alias closedEmbedding_iff_closedEmbedding_of_iSup_eq_top := isClosedEmbedding_iff_isClosedEmbedding_of_iSup_eq_top

--- a/Mathlib/Topology/LocalAtTarget.lean
+++ b/Mathlib/Topology/LocalAtTarget.lean
@@ -13,7 +13,7 @@ We show that the following properties of continuous maps are local at the target
 - `Inducing`
 - `Embedding`
 - `IsOpenEmbedding`
-- `ClosedEmbedding`
+- `IsClosedEmbedding`
 
 -/
 
@@ -53,12 +53,12 @@ alias IsOpenEmbedding.restrictPreimage := Set.restrictPreimage_isOpenEmbedding
 @[deprecated (since := "2024-10-18")]
 alias OpenEmbedding.restrictPreimage := IsOpenEmbedding.restrictPreimage
 
-theorem Set.restrictPreimage_closedEmbedding (s : Set β) (h : ClosedEmbedding f) :
-    ClosedEmbedding (s.restrictPreimage f) :=
+theorem Set.restrictPreimage_isClosedEmbedding (s : Set β) (h : IsClosedEmbedding f) :
+    IsClosedEmbedding (s.restrictPreimage f) :=
   ⟨h.1.restrictPreimage s,
     (s.range_restrictPreimage f).symm ▸ inducing_subtype_val.isClosed_preimage _ h.isClosed_range⟩
 
-alias ClosedEmbedding.restrictPreimage := Set.restrictPreimage_closedEmbedding
+alias IsClosedEmbedding.restrictPreimage := Set.restrictPreimage_isClosedEmbedding
 
 theorem IsClosedMap.restrictPreimage (H : IsClosedMap f) (s : Set β) :
     IsClosedMap (s.restrictPreimage f) := by
@@ -184,9 +184,9 @@ theorem isOpenEmbedding_iff_isOpenEmbedding_of_iSup_eq_top (h : Continuous f) :
 alias openEmbedding_iff_openEmbedding_of_iSup_eq_top :=
   isOpenEmbedding_iff_isOpenEmbedding_of_iSup_eq_top
 
-theorem closedEmbedding_iff_closedEmbedding_of_iSup_eq_top (h : Continuous f) :
-    ClosedEmbedding f ↔ ∀ i, ClosedEmbedding ((U i).1.restrictPreimage f) := by
-  simp_rw [closedEmbedding_iff]
+theorem isClosedEmbedding_iff_isClosedEmbedding_of_iSup_eq_top (h : Continuous f) :
+    IsClosedEmbedding f ↔ ∀ i, IsClosedEmbedding ((U i).1.restrictPreimage f) := by
+  simp_rw [isClosedEmbedding_iff]
   rw [forall_and]
   apply and_congr
   · apply embedding_iff_embedding_of_iSup_eq_top <;> assumption

--- a/Mathlib/Topology/Maps/Basic.lean
+++ b/Mathlib/Topology/Maps/Basic.lean
@@ -22,7 +22,7 @@ This file introduces the following properties of a map `f : X → Y` between top
   a subspace of `Y`.
 * `IsOpenEmbedding f` means `f` is an embedding with open image, so it identifies `X` with an
   open subspace of `Y`. Equivalently, `f` is an embedding and an open map.
-* `ClosedEmbedding f` similarly means `f` is an embedding with closed image, so it identifies
+* `IsClosedEmbedding f` similarly means `f` is an embedding with closed image, so it identifies
   `X` with a closed subspace of `Y`. Equivalently, `f` is an embedding and a closed map.
 
 * `QuotientMap f` is the dual condition to `Embedding f`: `f` is surjective and the topology
@@ -603,59 +603,59 @@ end IsOpenEmbedding
 
 end IsOpenEmbedding
 
-section ClosedEmbedding
+section IsClosedEmbedding
 
 variable [TopologicalSpace X] [TopologicalSpace Y] [TopologicalSpace Z]
 
-namespace ClosedEmbedding
+namespace IsClosedEmbedding
 
-theorem tendsto_nhds_iff {g : ι → X} {l : Filter ι} {x : X} (hf : ClosedEmbedding f) :
+theorem tendsto_nhds_iff {g : ι → X} {l : Filter ι} {x : X} (hf : IsClosedEmbedding f) :
     Tendsto g l (𝓝 x) ↔ Tendsto (f ∘ g) l (𝓝 (f x)) :=
   hf.toEmbedding.tendsto_nhds_iff
 
-theorem continuous (hf : ClosedEmbedding f) : Continuous f :=
+theorem continuous (hf : IsClosedEmbedding f) : Continuous f :=
   hf.toEmbedding.continuous
 
-theorem isClosedMap (hf : ClosedEmbedding f) : IsClosedMap f :=
+theorem isClosedMap (hf : IsClosedEmbedding f) : IsClosedMap f :=
   hf.toEmbedding.toInducing.isClosedMap hf.isClosed_range
 
-theorem closed_iff_image_closed (hf : ClosedEmbedding f) {s : Set X} :
+theorem closed_iff_image_closed (hf : IsClosedEmbedding f) {s : Set X} :
     IsClosed s ↔ IsClosed (f '' s) :=
   ⟨hf.isClosedMap s, fun h => by
     rw [← preimage_image_eq s hf.inj]
     exact h.preimage hf.continuous⟩
 
-theorem closed_iff_preimage_closed (hf : ClosedEmbedding f) {s : Set Y}
+theorem closed_iff_preimage_closed (hf : IsClosedEmbedding f) {s : Set Y}
     (hs : s ⊆ range f) : IsClosed s ↔ IsClosed (f ⁻¹' s) := by
   rw [hf.closed_iff_image_closed, image_preimage_eq_of_subset hs]
 
-theorem _root_.closedEmbedding_of_embedding_closed (h₁ : Embedding f) (h₂ : IsClosedMap f) :
-    ClosedEmbedding f :=
+theorem _root_.IsClosedEmbedding.of_embedding_closed (h₁ : Embedding f) (h₂ : IsClosedMap f) :
+    IsClosedEmbedding f :=
   ⟨h₁, image_univ (f := f) ▸ h₂ univ isClosed_univ⟩
 
-theorem _root_.closedEmbedding_of_continuous_injective_closed (h₁ : Continuous f) (h₂ : Injective f)
-    (h₃ : IsClosedMap f) : ClosedEmbedding f := by
-  refine closedEmbedding_of_embedding_closed ⟨⟨?_⟩, h₂⟩ h₃
+lemma _root_.IsClosedEmbedding.of_continuous_injective_isClosedMap (h₁ : Continuous f)
+    (h₂ : Injective f) (h₃ : IsClosedMap f) : IsClosedEmbedding f := by
+  refine .of_embedding_closed ⟨⟨?_⟩, h₂⟩ h₃
   refine h₁.le_induced.antisymm fun s hs => ?_
   refine ⟨(f '' sᶜ)ᶜ, (h₃ _ hs.isClosed_compl).isOpen_compl, ?_⟩
   rw [preimage_compl, preimage_image_eq _ h₂, compl_compl]
 
-theorem _root_.closedEmbedding_id : ClosedEmbedding (@id X) :=
+theorem _root_.isClosedEmbedding_id : IsClosedEmbedding (@id X) :=
   ⟨embedding_id, IsClosedMap.id.isClosed_range⟩
 
-theorem comp (hg : ClosedEmbedding g) (hf : ClosedEmbedding f) :
-    ClosedEmbedding (g ∘ f) :=
+theorem comp (hg : IsClosedEmbedding g) (hf : IsClosedEmbedding f) :
+    IsClosedEmbedding (g ∘ f) :=
   ⟨hg.toEmbedding.comp hf.toEmbedding, (hg.isClosedMap.comp hf.isClosedMap).isClosed_range⟩
 
-theorem of_comp_iff (hg : ClosedEmbedding g) :
-    ClosedEmbedding (g ∘ f) ↔ ClosedEmbedding f := by
-  simp_rw [closedEmbedding_iff, hg.toEmbedding.of_comp_iff, Set.range_comp,
+theorem of_comp_iff (hg : IsClosedEmbedding g) :
+    IsClosedEmbedding (g ∘ f) ↔ IsClosedEmbedding f := by
+  simp_rw [isClosedEmbedding_iff, hg.toEmbedding.of_comp_iff, Set.range_comp,
     ← hg.closed_iff_image_closed]
 
-theorem closure_image_eq (hf : ClosedEmbedding f) (s : Set X) :
+theorem closure_image_eq (hf : IsClosedEmbedding f) (s : Set X) :
     closure (f '' s) = f '' closure s :=
   hf.isClosedMap.closure_image_eq_of_continuous hf.continuous s
 
-end ClosedEmbedding
+end IsClosedEmbedding
 
-end ClosedEmbedding
+end IsClosedEmbedding

--- a/Mathlib/Topology/Maps/Basic.lean
+++ b/Mathlib/Topology/Maps/Basic.lean
@@ -633,6 +633,9 @@ theorem _root_.IsClosedEmbedding.of_embedding_closed (h₁ : Embedding f) (h₂ 
     IsClosedEmbedding f :=
   ⟨h₁, image_univ (f := f) ▸ h₂ univ isClosed_univ⟩
 
+@[deprecated (since := "2024-10-20")]
+alias _root_.closedEmbedding_of_embedding_closed := _root_.IsClosedEmbedding.of_embedding_closed
+
 lemma _root_.IsClosedEmbedding.of_continuous_injective_isClosedMap (h₁ : Continuous f)
     (h₂ : Injective f) (h₃ : IsClosedMap f) : IsClosedEmbedding f := by
   refine .of_embedding_closed ⟨⟨?_⟩, h₂⟩ h₃
@@ -640,8 +643,15 @@ lemma _root_.IsClosedEmbedding.of_continuous_injective_isClosedMap (h₁ : Conti
   refine ⟨(f '' sᶜ)ᶜ, (h₃ _ hs.isClosed_compl).isOpen_compl, ?_⟩
   rw [preimage_compl, preimage_image_eq _ h₂, compl_compl]
 
+@[deprecated (since := "2024-10-20")]
+alias _root_.closedEmbedding_of_continuous_injective_closed :=
+  IsClosedEmbedding.of_continuous_injective_isClosedMap
+
 theorem _root_.isClosedEmbedding_id : IsClosedEmbedding (@id X) :=
   ⟨embedding_id, IsClosedMap.id.isClosed_range⟩
+
+@[deprecated (since := "2024-10-20")]
+alias _root_.closedEmbedding_id := _root_.isClosedEmbedding_id
 
 theorem comp (hg : IsClosedEmbedding g) (hf : IsClosedEmbedding f) :
     IsClosedEmbedding (g ∘ f) :=

--- a/Mathlib/Topology/Maps/Proper/Basic.lean
+++ b/Mathlib/Topology/Maps/Proper/Basic.lean
@@ -273,17 +273,16 @@ protected lemma IsHomeomorph.isProperMap (hf : IsHomeomorph f) : IsProperMap f :
 @[simp] lemma isProperMap_id : IsProperMap (id : X → X) := IsHomeomorph.id.isProperMap
 
 /-- A closed embedding is proper. -/
-lemma isProperMap_of_closedEmbedding (hf : ClosedEmbedding f) : IsProperMap f :=
+lemma IsClosedEmbedding.isProperMap (hf : IsClosedEmbedding f) : IsProperMap f :=
   isProperMap_of_isClosedMap_of_inj hf.continuous hf.inj hf.isClosedMap
 
 /-- The coercion from a closed subset is proper. -/
-lemma isProperMap_subtype_val_of_closed {U : Set X} (hU : IsClosed U) : IsProperMap ((↑) : U → X) :=
-  isProperMap_of_closedEmbedding hU.closedEmbedding_subtype_val
+lemma IsClosed.isProperMap_subtypeVal {C : Set X} (hC : IsClosed C) : IsProperMap ((↑) : C → X) :=
+  hC.isClosedEmbedding_subtypeVal.isProperMap
 
 /-- The restriction of a proper map to a closed subset is proper. -/
-lemma isProperMap_restr_of_proper_of_closed {U : Set X} (hf : IsProperMap f) (hU : IsClosed U) :
-    IsProperMap (fun x : U ↦ f x) :=
-  IsProperMap.comp (isProperMap_subtype_val_of_closed hU) hf
+lemma IsProperMap.restrict {C : Set X} (hf : IsProperMap f) (hC : IsClosed C) :
+    IsProperMap fun x : C ↦ f x := hC.isProperMap_subtypeVal.comp  hf
 
 /-- The range of a proper map is closed. -/
 lemma IsProperMap.isClosed_range (hf : IsProperMap f) : IsClosed (range f) :=

--- a/Mathlib/Topology/Maps/Proper/Basic.lean
+++ b/Mathlib/Topology/Maps/Proper/Basic.lean
@@ -276,13 +276,22 @@ protected lemma IsHomeomorph.isProperMap (hf : IsHomeomorph f) : IsProperMap f :
 lemma IsClosedEmbedding.isProperMap (hf : IsClosedEmbedding f) : IsProperMap f :=
   isProperMap_of_isClosedMap_of_inj hf.continuous hf.inj hf.isClosedMap
 
+@[deprecated (since := "2024-10-20")]
+alias isProperMap_of_closedEmbedding := IsClosedEmbedding.isProperMap
+
 /-- The coercion from a closed subset is proper. -/
 lemma IsClosed.isProperMap_subtypeVal {C : Set X} (hC : IsClosed C) : IsProperMap ((↑) : C → X) :=
   hC.isClosedEmbedding_subtypeVal.isProperMap
 
+@[deprecated (since := "2024-10-20")]
+alias isProperMap_subtype_val_of_closed := IsClosed.isProperMap_subtypeVal
+
 /-- The restriction of a proper map to a closed subset is proper. -/
 lemma IsProperMap.restrict {C : Set X} (hf : IsProperMap f) (hC : IsClosed C) :
     IsProperMap fun x : C ↦ f x := hC.isProperMap_subtypeVal.comp  hf
+
+@[deprecated (since := "2024-10-20")]
+alias isProperMap_restr_of_proper_of_closed := IsProperMap.restrict
 
 /-- The range of a proper map is closed. -/
 lemma IsProperMap.isClosed_range (hf : IsProperMap f) : IsClosed (range f) :=

--- a/Mathlib/Topology/MetricSpace/Antilipschitz.lean
+++ b/Mathlib/Topology/MetricSpace/Antilipschitz.lean
@@ -170,6 +170,9 @@ theorem isClosedEmbedding {α : Type*} {β : Type*} [EMetricSpace α] [EMetricSp
     IsClosedEmbedding f :=
   { (hf.isUniformEmbedding hfc).embedding with isClosed_range := hf.isClosed_range hfc }
 
+@[deprecated (since := "2024-10-20")]
+alias closedEmbedding := isClosedEmbedding
+
 theorem subtype_coe (s : Set α) : AntilipschitzWith 1 ((↑) : s → α) :=
   AntilipschitzWith.id.restrict s
 

--- a/Mathlib/Topology/MetricSpace/Antilipschitz.lean
+++ b/Mathlib/Topology/MetricSpace/Antilipschitz.lean
@@ -165,9 +165,9 @@ theorem isClosed_range {α β : Type*} [PseudoEMetricSpace α] [EMetricSpace β]
     IsClosed (range f) :=
   (hf.isComplete_range hfc).isClosed
 
-theorem closedEmbedding {α : Type*} {β : Type*} [EMetricSpace α] [EMetricSpace β] {K : ℝ≥0}
+theorem isClosedEmbedding {α : Type*} {β : Type*} [EMetricSpace α] [EMetricSpace β] {K : ℝ≥0}
     {f : α → β} [CompleteSpace α] (hf : AntilipschitzWith K f) (hfc : UniformContinuous f) :
-    ClosedEmbedding f :=
+    IsClosedEmbedding f :=
   { (hf.isUniformEmbedding hfc).embedding with isClosed_range := hf.isClosed_range hfc }
 
 theorem subtype_coe (s : Set α) : AntilipschitzWith 1 ((↑) : s → α) :=

--- a/Mathlib/Topology/MetricSpace/Basic.lean
+++ b/Mathlib/Topology/MetricSpace/Basic.lean
@@ -56,10 +56,10 @@ theorem isClosed_of_pairwise_le_dist {s : Set γ} {ε : ℝ} (hε : 0 < ε)
     (hs : s.Pairwise fun x y => ε ≤ dist x y) : IsClosed s :=
   isClosed_of_spaced_out (dist_mem_uniformity hε) <| by simpa using hs
 
-theorem closedEmbedding_of_pairwise_le_dist {α : Type*} [TopologicalSpace α] [DiscreteTopology α]
+theorem isClosedEmbedding_of_pairwise_le_dist {α : Type*} [TopologicalSpace α] [DiscreteTopology α]
     {ε : ℝ} (hε : 0 < ε) {f : α → γ} (hf : Pairwise fun x y => ε ≤ dist (f x) (f y)) :
-    ClosedEmbedding f :=
-  closedEmbedding_of_spaced_out (dist_mem_uniformity hε) <| by simpa using hf
+    IsClosedEmbedding f :=
+  isClosedEmbedding_of_spaced_out (dist_mem_uniformity hε) <| by simpa using hf
 
 /-- If `f : β → α` sends any two distinct points to points at distance at least `ε > 0`, then
 `f` is a uniform embedding with respect to the discrete uniformity on `β`. -/

--- a/Mathlib/Topology/MetricSpace/Basic.lean
+++ b/Mathlib/Topology/MetricSpace/Basic.lean
@@ -61,6 +61,9 @@ theorem isClosedEmbedding_of_pairwise_le_dist {α : Type*} [TopologicalSpace α]
     IsClosedEmbedding f :=
   isClosedEmbedding_of_spaced_out (dist_mem_uniformity hε) <| by simpa using hf
 
+@[deprecated (since := "2024-10-20")]
+alias closedEmbedding_of_pairwise_le_dist := isClosedEmbedding_of_pairwise_le_dist
+
 /-- If `f : β → α` sends any two distinct points to points at distance at least `ε > 0`, then
 `f` is a uniform embedding with respect to the discrete uniformity on `β`. -/
 theorem isUniformEmbedding_bot_of_pairwise_le_dist {β : Type*} {ε : ℝ} (hε : 0 < ε) {f : β → α}

--- a/Mathlib/Topology/MetricSpace/Dilation.lean
+++ b/Mathlib/Topology/MetricSpace/Dilation.lean
@@ -432,12 +432,11 @@ protected theorem embedding [PseudoEMetricSpace β] [DilationClass F α β] (f :
   (Dilation.isUniformEmbedding f).embedding
 
 /-- A dilation from a complete emetric space is a closed embedding -/
-protected lemma isClosedEmbedding [CompleteSpace α] [EMetricSpace β] [DilationClass F α β] (f : F) :
+lemma isClosedEmbedding [CompleteSpace α] [EMetricSpace β] [DilationClass F α β] (f : F) :
     IsClosedEmbedding f :=
   (antilipschitz f).isClosedEmbedding (lipschitz f).uniformContinuous
 
-@[deprecated (since := "2024-10-20")]
-alias closedEmbedding := isClosedEmbedding
+@[deprecated (since := "2024-10-20")] alias closedEmbedding := isClosedEmbedding
 
 end EmetricDilation
 

--- a/Mathlib/Topology/MetricSpace/Dilation.lean
+++ b/Mathlib/Topology/MetricSpace/Dilation.lean
@@ -432,9 +432,9 @@ protected theorem embedding [PseudoEMetricSpace β] [DilationClass F α β] (f :
   (Dilation.isUniformEmbedding f).embedding
 
 /-- A dilation from a complete emetric space is a closed embedding -/
-protected theorem closedEmbedding [CompleteSpace α] [EMetricSpace β] [DilationClass F α β] (f : F) :
-    ClosedEmbedding f :=
-  (antilipschitz f).closedEmbedding (lipschitz f).uniformContinuous
+protected lemma isClosedEmbedding [CompleteSpace α] [EMetricSpace β] [DilationClass F α β] (f : F) :
+    IsClosedEmbedding f :=
+  (antilipschitz f).isClosedEmbedding (lipschitz f).uniformContinuous
 
 end EmetricDilation
 

--- a/Mathlib/Topology/MetricSpace/Dilation.lean
+++ b/Mathlib/Topology/MetricSpace/Dilation.lean
@@ -436,6 +436,9 @@ protected lemma isClosedEmbedding [CompleteSpace α] [EMetricSpace β] [Dilation
     IsClosedEmbedding f :=
   (antilipschitz f).isClosedEmbedding (lipschitz f).uniformContinuous
 
+@[deprecated (since := "2024-10-20")]
+alias closedEmbedding := isClosedEmbedding
+
 end EmetricDilation
 
 /-- Ratio of the composition `g.comp f` of two dilations is the product of their ratios. We assume

--- a/Mathlib/Topology/MetricSpace/Isometry.lean
+++ b/Mathlib/Topology/MetricSpace/Isometry.lean
@@ -181,6 +181,9 @@ theorem isClosedEmbedding [CompleteSpace α] [EMetricSpace γ] {f : α → γ} (
     IsClosedEmbedding f :=
   hf.antilipschitz.isClosedEmbedding hf.lipschitz.uniformContinuous
 
+@[deprecated (since := "2024-10-20")]
+alias closedEmbedding := isClosedEmbedding
+
 end EmetricIsometry
 
 --section

--- a/Mathlib/Topology/MetricSpace/Isometry.lean
+++ b/Mathlib/Topology/MetricSpace/Isometry.lean
@@ -177,9 +177,9 @@ protected theorem embedding (hf : Isometry f) : Embedding f :=
   hf.isUniformEmbedding.embedding
 
 /-- An isometry from a complete emetric space is a closed embedding -/
-theorem closedEmbedding [CompleteSpace α] [EMetricSpace γ] {f : α → γ} (hf : Isometry f) :
-    ClosedEmbedding f :=
-  hf.antilipschitz.closedEmbedding hf.lipschitz.uniformContinuous
+theorem isClosedEmbedding [CompleteSpace α] [EMetricSpace γ] {f : α → γ} (hf : Isometry f) :
+    IsClosedEmbedding f :=
+  hf.antilipschitz.isClosedEmbedding hf.lipschitz.uniformContinuous
 
 end EmetricIsometry
 

--- a/Mathlib/Topology/MetricSpace/Polish.lean
+++ b/Mathlib/Topology/MetricSpace/Polish.lean
@@ -140,8 +140,8 @@ theorem exists_nat_nat_continuous_surjective (α : Type*) [TopologicalSpace α] 
   exists_nat_nat_continuous_surjective_of_completeSpace α
 
 /-- Given a closed embedding into a Polish space, the source space is also Polish. -/
-theorem _root_.ClosedEmbedding.polishSpace [TopologicalSpace α] [TopologicalSpace β] [PolishSpace β]
-    {f : α → β} (hf : ClosedEmbedding f) : PolishSpace α := by
+lemma _root_.IsClosedEmbedding.polishSpace [TopologicalSpace α] [TopologicalSpace β] [PolishSpace β]
+    {f : α → β} (hf : IsClosedEmbedding f) : PolishSpace α := by
   letI := upgradePolishSpace β
   letI : MetricSpace α := hf.toEmbedding.comapMetricSpace f
   haveI : SecondCountableTopology α := hf.toEmbedding.secondCountableTopology
@@ -154,21 +154,21 @@ theorem _root_.ClosedEmbedding.polishSpace [TopologicalSpace α] [TopologicalSpa
 instance (priority := 50) polish_of_countable [TopologicalSpace α]
     [h : Countable α] [DiscreteTopology α] : PolishSpace α := by
   obtain ⟨f, hf⟩ := h.exists_injective_nat
-  have : ClosedEmbedding f := by
-    apply closedEmbedding_of_continuous_injective_closed continuous_of_discreteTopology hf
-    exact fun t _ => isClosed_discrete _
+  have : IsClosedEmbedding f :=
+    .of_continuous_injective_isClosedMap continuous_of_discreteTopology hf
+      fun t _ ↦ isClosed_discrete _
   exact this.polishSpace
 
 /-- Pulling back a Polish topology under an equiv gives again a Polish topology. -/
 theorem _root_.Equiv.polishSpace_induced [t : TopologicalSpace β] [PolishSpace β] (f : α ≃ β) :
     @PolishSpace α (t.induced f) :=
   letI : TopologicalSpace α := t.induced f
-  (f.toHomeomorphOfInducing ⟨rfl⟩).closedEmbedding.polishSpace
+  (f.toHomeomorphOfInducing ⟨rfl⟩).isClosedEmbedding.polishSpace
 
 /-- A closed subset of a Polish space is also Polish. -/
 theorem _root_.IsClosed.polishSpace [TopologicalSpace α] [PolishSpace α] {s : Set α}
     (hs : IsClosed s) : PolishSpace s :=
-  (IsClosed.closedEmbedding_subtype_val hs).polishSpace
+  hs.isClosedEmbedding_subtypeVal.polishSpace
 
 instance instPolishSpaceUniv [TopologicalSpace α] [PolishSpace α] :
     PolishSpace (univ : Set α) :=
@@ -211,7 +211,7 @@ theorem exists_polishSpace_forall_le {ι : Type*} [Countable ι] [t : Topologica
     .iInf ⟨none, Option.forall.2 ⟨le_rfl, hm⟩⟩ <| Option.forall.2 ⟨p, h'm⟩⟩
 
 instance : PolishSpace ENNReal :=
-  ClosedEmbedding.polishSpace ⟨ENNReal.orderIsoUnitIntervalBirational.toHomeomorph.embedding,
+  IsClosedEmbedding.polishSpace ⟨ENNReal.orderIsoUnitIntervalBirational.toHomeomorph.embedding,
     ENNReal.orderIsoUnitIntervalBirational.range_eq ▸ isClosed_univ⟩
 
 end PolishSpace

--- a/Mathlib/Topology/MetricSpace/Polish.lean
+++ b/Mathlib/Topology/MetricSpace/Polish.lean
@@ -150,6 +150,9 @@ lemma _root_.IsClosedEmbedding.polishSpace [TopologicalSpace α] [TopologicalSpa
     exact hf.isClosed_range.isComplete
   infer_instance
 
+@[deprecated (since := "2024-10-20")]
+alias _root_.ClosedEmbedding.polishSpace := _root_.IsClosedEmbedding.polishSpace
+
 /-- Any countable discrete space is Polish. -/
 instance (priority := 50) polish_of_countable [TopologicalSpace α]
     [h : Countable α] [DiscreteTopology α] : PolishSpace α := by

--- a/Mathlib/Topology/SeparatedMap.lean
+++ b/Mathlib/Topology/SeparatedMap.lean
@@ -91,6 +91,9 @@ theorem isSeparatedMap_iff_isClosedEmbedding {f : X → Y} :
   rw [isSeparatedMap_iff_isClosed_diagonal, ← range_toPullbackDiag]
   exact ⟨fun h ↦ ⟨embedding_toPullbackDiag f, h⟩, fun h ↦ h.isClosed_range⟩
 
+@[deprecated (since := "2024-10-20")]
+alias isSeparatedMap_iff_closedEmbedding := isSeparatedMap_iff_isClosedEmbedding
+
 theorem isSeparatedMap_iff_isClosedMap {f : X → Y} :
     IsSeparatedMap f ↔ IsClosedMap (toPullbackDiag f) :=
   isSeparatedMap_iff_isClosedEmbedding.trans

--- a/Mathlib/Topology/SeparatedMap.lean
+++ b/Mathlib/Topology/SeparatedMap.lean
@@ -86,15 +86,15 @@ theorem isSeparatedMap_iff_isClosed_diagonal {f : X → Y} :
   · obtain ⟨s₁, h₁, s₂, h₂, s_sub⟩ := mem_prod_iff.mp ht
     exact ⟨s₁, h₁, s₂, h₂, disjoint_left.2 fun x h₁ h₂ ↦ @t_sub ⟨(x, x), rfl⟩ (s_sub ⟨h₁, h₂⟩) rfl⟩
 
-theorem isSeparatedMap_iff_closedEmbedding {f : X → Y} :
-    IsSeparatedMap f ↔ ClosedEmbedding (toPullbackDiag f) := by
+theorem isSeparatedMap_iff_isClosedEmbedding {f : X → Y} :
+    IsSeparatedMap f ↔ IsClosedEmbedding (toPullbackDiag f) := by
   rw [isSeparatedMap_iff_isClosed_diagonal, ← range_toPullbackDiag]
   exact ⟨fun h ↦ ⟨embedding_toPullbackDiag f, h⟩, fun h ↦ h.isClosed_range⟩
 
 theorem isSeparatedMap_iff_isClosedMap {f : X → Y} :
     IsSeparatedMap f ↔ IsClosedMap (toPullbackDiag f) :=
-  isSeparatedMap_iff_closedEmbedding.trans
-    ⟨ClosedEmbedding.isClosedMap, closedEmbedding_of_continuous_injective_closed
+  isSeparatedMap_iff_isClosedEmbedding.trans
+    ⟨IsClosedEmbedding.isClosedMap, .of_continuous_injective_isClosedMap
       (embedding_toPullbackDiag f).continuous (injective_toPullbackDiag f)⟩
 
 open Function.Pullback in

--- a/Mathlib/Topology/Separation.lean
+++ b/Mathlib/Topology/Separation.lean
@@ -999,17 +999,15 @@ theorem disjoint_nhdsWithin_of_mem_discrete {s : Set X} [DiscreteTopology s] {x 
   ⟨{x}ᶜ ∩ V, inter_mem_nhdsWithin _ h,
     disjoint_iff_inter_eq_empty.mpr (by rw [inter_assoc, h', compl_inter_self])⟩
 
-theorem closedEmbedding_update {ι : Type*} {β : ι → Type*}
+theorem isClosedEmbedding_update {ι : Type*} {β : ι → Type*}
     [DecidableEq ι] [(i : ι) → TopologicalSpace (β i)]
     (x : (i : ι) → β i) (i : ι) [(i : ι) → T1Space (β i)] :
-    ClosedEmbedding (update x i) := by
-  apply closedEmbedding_of_continuous_injective_closed
-  · exact continuous_const.update i continuous_id
-  · exact update_injective x i
-  · intro s hs
-    rw [update_image]
-    apply isClosed_set_pi
-    simp [forall_update_iff, hs, isClosed_singleton]
+    IsClosedEmbedding (update x i) := by
+  refine .of_continuous_injective_isClosedMap (continuous_const.update i continuous_id)
+    (update_injective x i) fun s hs ↦ ?_
+  rw [update_image]
+  apply isClosed_set_pi
+  simp [forall_update_iff, hs, isClosed_singleton]
 
 /-! ### R₁ (preregular) spaces -/
 
@@ -1754,8 +1752,8 @@ theorem Function.LeftInverse.isClosed_range [T2Space X] {f : X → Y} {g : Y →
 @[deprecated (since := "2024-03-17")]
 alias Function.LeftInverse.closed_range := Function.LeftInverse.isClosed_range
 
-theorem Function.LeftInverse.closedEmbedding [T2Space X] {f : X → Y} {g : Y → X}
-    (h : Function.LeftInverse f g) (hf : Continuous f) (hg : Continuous g) : ClosedEmbedding g :=
+theorem Function.LeftInverse.isClosedEmbedding [T2Space X] {f : X → Y} {g : Y → X}
+    (h : Function.LeftInverse f g) (hf : Continuous f) (hg : Continuous g) : IsClosedEmbedding g :=
   ⟨h.embedding hf hg, h.isClosed_range hf hg⟩
 
 theorem SeparatedNhds.of_isCompact_isCompact [T2Space X] {s t : Set X} (hs : IsCompact s)
@@ -1852,9 +1850,9 @@ protected theorem Continuous.isClosedMap [CompactSpace X] [T2Space Y] {f : X →
     (h : Continuous f) : IsClosedMap f := fun _s hs => (hs.isCompact.image h).isClosed
 
 /-- A continuous injective map from a compact space to a Hausdorff space is a closed embedding. -/
-theorem Continuous.closedEmbedding [CompactSpace X] [T2Space Y] {f : X → Y} (h : Continuous f)
-    (hf : Function.Injective f) : ClosedEmbedding f :=
-  closedEmbedding_of_continuous_injective_closed h hf h.isClosedMap
+theorem Continuous.isClosedEmbedding [CompactSpace X] [T2Space Y] {f : X → Y} (h : Continuous f)
+    (hf : Function.Injective f) : IsClosedEmbedding f :=
+  .of_continuous_injective_isClosedMap h hf h.isClosedMap
 
 /-- A continuous surjective map from a compact space to a Hausdorff space is a quotient map. -/
 theorem QuotientMap.of_surjective_continuous [CompactSpace X] [T2Space Y] {f : X → Y}
@@ -2257,8 +2255,8 @@ theorem normal_exists_closure_subset [NormalSpace X] {s t : Set X} (hs : IsClose
   exact fun x hxs hxt => hs't'.le_bot ⟨hxs, hxt⟩
 
 /-- If the codomain of a closed embedding is a normal space, then so is the domain. -/
-protected theorem ClosedEmbedding.normalSpace [TopologicalSpace Y] [NormalSpace Y] {f : X → Y}
-    (hf : ClosedEmbedding f) : NormalSpace X where
+protected theorem IsClosedEmbedding.normalSpace [TopologicalSpace Y] [NormalSpace Y] {f : X → Y}
+    (hf : IsClosedEmbedding f) : NormalSpace X where
   normal s t hs ht hst := by
     have H : SeparatedNhds (f '' s) (f '' t) :=
       NormalSpace.normal (f '' s) (f '' t) (hf.isClosedMap s hs) (hf.isClosedMap t ht)
@@ -2302,13 +2300,13 @@ theorem T4Space.of_compactSpace_t2Space [CompactSpace X] [T2Space X] :
     T4Space X := inferInstance
 
 /-- If the codomain of a closed embedding is a T₄ space, then so is the domain. -/
-protected theorem ClosedEmbedding.t4Space [TopologicalSpace Y] [T4Space Y] {f : X → Y}
-    (hf : ClosedEmbedding f) : T4Space X where
+protected theorem IsClosedEmbedding.t4Space [TopologicalSpace Y] [T4Space Y] {f : X → Y}
+    (hf : IsClosedEmbedding f) : T4Space X where
   toT1Space := hf.toEmbedding.t1Space
   toNormalSpace := hf.normalSpace
 
 instance ULift.instT4Space [T4Space X] : T4Space (ULift X) :=
-  ULift.closedEmbedding_down.t4Space
+  ULift.isClosedEmbedding_down.t4Space
 
 namespace SeparationQuotient
 
@@ -2596,7 +2594,7 @@ theorem loc_compact_Haus_tot_disc_of_zero_dim [TotallyDisconnectedSpace H] :
   haveI : CompactSpace s := isCompact_iff_compactSpace.1 comp
   obtain ⟨V : Set s, VisClopen, Vx, V_sub⟩ := compact_exists_isClopen_in_isOpen u_open_in_s xs
   have VisClopen' : IsClopen (((↑) : s → H) '' V) := by
-    refine ⟨comp.isClosed.closedEmbedding_subtype_val.closed_iff_image_closed.1 VisClopen.1, ?_⟩
+    refine ⟨comp.isClosed.isClosedEmbedding_subtypeVal.closed_iff_image_closed.1 VisClopen.1, ?_⟩
     let v : Set u := ((↑) : u → s) ⁻¹' V
     have : ((↑) : u → H) = ((↑) : s → H) ∘ ((↑) : u → s) := rfl
     have f0 : Embedding ((↑) : u → H) := embedding_subtype_val.comp embedding_subtype_val

--- a/Mathlib/Topology/Separation.lean
+++ b/Mathlib/Topology/Separation.lean
@@ -1009,6 +1009,9 @@ theorem isClosedEmbedding_update {ι : Type*} {β : ι → Type*}
   apply isClosed_set_pi
   simp [forall_update_iff, hs, isClosed_singleton]
 
+@[deprecated (since := "2024-10-20")]
+alias closedEmbedding_update := isClosedEmbedding_update
+
 /-! ### R₁ (preregular) spaces -/
 
 section R1Space
@@ -1756,6 +1759,9 @@ theorem Function.LeftInverse.isClosedEmbedding [T2Space X] {f : X → Y} {g : Y 
     (h : Function.LeftInverse f g) (hf : Continuous f) (hg : Continuous g) : IsClosedEmbedding g :=
   ⟨h.embedding hf hg, h.isClosed_range hf hg⟩
 
+@[deprecated (since := "2024-10-20")]
+alias Function.LeftInverse.closedEmbedding := Function.LeftInverse.isClosedEmbedding
+
 theorem SeparatedNhds.of_isCompact_isCompact [T2Space X] {s t : Set X} (hs : IsCompact s)
     (ht : IsCompact t) (hst : Disjoint s t) : SeparatedNhds s t := by
   simp only [SeparatedNhds, prod_subset_compl_diagonal_iff_disjoint.symm] at hst ⊢
@@ -1853,6 +1859,9 @@ protected theorem Continuous.isClosedMap [CompactSpace X] [T2Space Y] {f : X →
 theorem Continuous.isClosedEmbedding [CompactSpace X] [T2Space Y] {f : X → Y} (h : Continuous f)
     (hf : Function.Injective f) : IsClosedEmbedding f :=
   .of_continuous_injective_isClosedMap h hf h.isClosedMap
+
+@[deprecated (since := "2024-10-20")]
+alias Continuous.closedEmbedding := Continuous.isClosedEmbedding
 
 /-- A continuous surjective map from a compact space to a Hausdorff space is a quotient map. -/
 theorem QuotientMap.of_surjective_continuous [CompactSpace X] [T2Space Y] {f : X → Y}
@@ -2263,6 +2272,9 @@ protected theorem IsClosedEmbedding.normalSpace [TopologicalSpace Y] [NormalSpac
         (disjoint_image_of_injective hf.inj hst)
     exact (H.preimage hf.continuous).mono (subset_preimage_image _ _) (subset_preimage_image _ _)
 
+@[deprecated (since := "2024-10-20")]
+alias ClosedEmbedding.normalSpace := IsClosedEmbedding.normalSpace
+
 instance (priority := 100) NormalSpace.of_compactSpace_r1Space [CompactSpace X] [R1Space X] :
     NormalSpace X where
   normal _s _t hs ht := .of_isCompact_isCompact_isClosed hs.isCompact ht.isCompact ht
@@ -2304,6 +2316,9 @@ protected theorem IsClosedEmbedding.t4Space [TopologicalSpace Y] [T4Space Y] {f 
     (hf : IsClosedEmbedding f) : T4Space X where
   toT1Space := hf.toEmbedding.t1Space
   toNormalSpace := hf.normalSpace
+
+@[deprecated (since := "2024-10-20")]
+alias ClosedEmbedding.t4Space := IsClosedEmbedding.t4Space
 
 instance ULift.instT4Space [T4Space X] : T4Space (ULift X) :=
   ULift.isClosedEmbedding_down.t4Space

--- a/Mathlib/Topology/Sober.lean
+++ b/Mathlib/Topology/Sober.lean
@@ -182,6 +182,9 @@ theorem IsClosedEmbedding.quasiSober {f : α → β} (hf : IsClosedEmbedding f) 
     apply image_injective.mpr hf.inj
     rw [← hx.def, ← hf.closure_image_eq, image_singleton]
 
+@[deprecated (since := "2024-10-20")]
+alias ClosedEmbedding.quasiSober := IsClosedEmbedding.quasiSober
+
 theorem IsOpenEmbedding.quasiSober {f : α → β} (hf : IsOpenEmbedding f) [QuasiSober β] :
     QuasiSober α where
   sober hS hS' := by

--- a/Mathlib/Topology/Sober.lean
+++ b/Mathlib/Topology/Sober.lean
@@ -172,7 +172,7 @@ noncomputable def irreducibleSetEquivPoints [QuasiSober α] [T0Space α] :
     simp [hs'.closure_eq, ht'.closure_eq]
     rfl
 
-theorem ClosedEmbedding.quasiSober {f : α → β} (hf : ClosedEmbedding f) [QuasiSober β] :
+theorem IsClosedEmbedding.quasiSober {f : α → β} (hf : IsClosedEmbedding f) [QuasiSober β] :
     QuasiSober α where
   sober hS hS' := by
     have hS'' := hS.image f hf.continuous.continuousOn

--- a/Mathlib/Topology/Support.lean
+++ b/Mathlib/Topology/Support.lean
@@ -201,8 +201,8 @@ theorem _root_.hasCompactMulSupport_comp_left (hg : ∀ {x}, g x = 1 ↔ x = 1) 
   simp_rw [hasCompactMulSupport_def, mulSupport_comp_eq g (@hg) f]
 
 @[to_additive]
-theorem comp_closedEmbedding (hf : HasCompactMulSupport f) {g : α' → α}
-    (hg : ClosedEmbedding g) : HasCompactMulSupport (f ∘ g) := by
+theorem comp_isClosedEmbedding (hf : HasCompactMulSupport f) {g : α' → α}
+    (hg : IsClosedEmbedding g) : HasCompactMulSupport (f ∘ g) := by
   rw [hasCompactMulSupport_def, Function.mulSupport_comp_eq_preimage]
   refine IsCompact.of_isClosed_subset (hg.isCompact_preimage hf) isClosed_closure ?_
   rw [hg.toEmbedding.closure_eq_preimage_closure_image]

--- a/Mathlib/Topology/Support.lean
+++ b/Mathlib/Topology/Support.lean
@@ -208,6 +208,9 @@ theorem comp_isClosedEmbedding (hf : HasCompactMulSupport f) {g : α' → α}
   rw [hg.toEmbedding.closure_eq_preimage_closure_image]
   exact preimage_mono (closure_mono <| image_preimage_subset _ _)
 
+@[deprecated (since := "2024-10-20")]
+alias comp_closedEmbedding := comp_isClosedEmbedding
+
 @[to_additive]
 theorem comp₂_left (hf : HasCompactMulSupport f)
     (hf₂ : HasCompactMulSupport f₂) (hm : m 1 1 = 1) :

--- a/Mathlib/Topology/TietzeExtension.lean
+++ b/Mathlib/Topology/TietzeExtension.lean
@@ -20,7 +20,7 @@ bounded function, then there exists a bounded extension of the same norm.
 
 The proof mostly follows <https://ncatlab.org/nlab/show/Tietze+extension+theorem>. We patch a small
 gap in the proof for unbounded functions, see
-`exists_extension_forall_exists_le_ge_of_closedEmbedding`.
+`exists_extension_forall_exists_le_ge_of_isClosedEmbedding`.
 
 In addition we provide a class `TietzeExtension` encoding the idea that a topological space
 satisfies the Tietze extension theorem. This allows us to get a version of the Tietze extension
@@ -68,7 +68,7 @@ theorem ContinuousMap.exists_restrict_eq (hs : IsClosed s) (f : C(s, Y)) :
 nonempty topological space `X₁` into a normal topological space `X`. Let `f` be a continuous
 function on `X₁` with values in a `TietzeExtension` space `Y`. Then there exists a
 continuous function `g : C(X, Y)` such that `g ∘ e = f`. -/
-theorem ContinuousMap.exists_extension (he : ClosedEmbedding e) (f : C(X₁, Y)) :
+theorem ContinuousMap.exists_extension (he : IsClosedEmbedding e) (f : C(X₁, Y)) :
     ∃ (g : C(X, Y)), g.comp ⟨e, he.continuous⟩ = f := by
   let e' : X₁ ≃ₜ Set.range e := Homeomorph.ofEmbedding _ he.toEmbedding
   obtain ⟨g, hg⟩ := (f.comp e'.symm).exists_restrict_eq he.isClosed_range
@@ -81,7 +81,7 @@ continuous function `g : C(X, Y)` such that `g ∘ e = f`.
 
 This version is provided for convenience and backwards compatibility. Here the composition is
 phrased in terms of bare functions. -/
-theorem ContinuousMap.exists_extension' (he : ClosedEmbedding e) (f : C(X₁, Y)) :
+theorem ContinuousMap.exists_extension' (he : IsClosedEmbedding e) (f : C(X₁, Y)) :
     ∃ (g : C(X, Y)), g ∘ e = f :=
   f.exists_extension he |>.imp fun g hg ↦ by ext x; congrm($(hg) x)
 
@@ -104,7 +104,7 @@ the radius is strictly positive, so finding this as an instance will fail.
 
 Instead, it is intended to be used as a constructor for theorems about sets which *do* satisfy
 `[TietzeExtension t]` under some hypotheses. -/
-theorem ContinuousMap.exists_extension_forall_mem (he : ClosedEmbedding e)
+theorem ContinuousMap.exists_extension_forall_mem (he : IsClosedEmbedding e)
     {Y : Type v} [TopologicalSpace Y] (f : C(X₁, Y))
     {t : Set Y} (hf : ∀ x, f x ∈ t) [ht : TietzeExtension.{u, v} t] :
     ∃ (g : C(X, Y)), (∀ x, g x ∈ t) ∧ g.comp ⟨e, he.continuous⟩ = f := by
@@ -166,7 +166,7 @@ namespace BoundedContinuousFunction
 of a topological space into a normal topological space and `f : X →ᵇ ℝ` is a bounded continuous
 function, then there exists a bounded continuous function `g : Y →ᵇ ℝ` of the norm `‖g‖ ≤ ‖f‖ / 3`
 such that the distance between `g ∘ e` and `f` is at most `(2 / 3) * ‖f‖`. -/
-theorem tietze_extension_step (f : X →ᵇ ℝ) (e : C(X, Y)) (he : ClosedEmbedding e) :
+theorem tietze_extension_step (f : X →ᵇ ℝ) (e : C(X, Y)) (he : IsClosedEmbedding e) :
     ∃ g : Y →ᵇ ℝ, ‖g‖ ≤ ‖f‖ / 3 ∧ dist (g.compContinuous e) f ≤ 2 / 3 * ‖f‖ := by
   have h3 : (0 : ℝ) < 3 := by norm_num1
   have h23 : 0 < (2 / 3 : ℝ) := by norm_num1
@@ -216,8 +216,8 @@ theorem tietze_extension_step (f : X →ᵇ ℝ) (e : C(X, Y)) (he : ClosedEmbed
 embedding and bundled composition. If `e : C(X, Y)` is a closed embedding of a topological space
 into a normal topological space and `f : X →ᵇ ℝ` is a bounded continuous function, then there exists
 a bounded continuous function `g : Y →ᵇ ℝ` of the same norm such that `g ∘ e = f`. -/
-theorem exists_extension_norm_eq_of_closedEmbedding' (f : X →ᵇ ℝ) (e : C(X, Y))
-    (he : ClosedEmbedding e) : ∃ g : Y →ᵇ ℝ, ‖g‖ = ‖f‖ ∧ g.compContinuous e = f := by
+theorem exists_extension_norm_eq_of_isClosedEmbedding' (f : X →ᵇ ℝ) (e : C(X, Y))
+    (he : IsClosedEmbedding e) : ∃ g : Y →ᵇ ℝ, ‖g‖ = ‖f‖ ∧ g.compContinuous e = f := by
   /- For the proof, we iterate `tietze_extension_step`. Each time we apply it to the difference
     between the previous approximation and `f`. -/
   choose F hF_norm hF_dist using fun f : X →ᵇ ℝ => tietze_extension_step f e he
@@ -265,9 +265,9 @@ theorem exists_extension_norm_eq_of_closedEmbedding' (f : X →ᵇ ℝ) (e : C(X
 embedding and unbundled composition. If `e : C(X, Y)` is a closed embedding of a topological space
 into a normal topological space and `f : X →ᵇ ℝ` is a bounded continuous function, then there exists
 a bounded continuous function `g : Y →ᵇ ℝ` of the same norm such that `g ∘ e = f`. -/
-theorem exists_extension_norm_eq_of_closedEmbedding (f : X →ᵇ ℝ) {e : X → Y}
-    (he : ClosedEmbedding e) : ∃ g : Y →ᵇ ℝ, ‖g‖ = ‖f‖ ∧ g ∘ e = f := by
-  rcases exists_extension_norm_eq_of_closedEmbedding' f ⟨e, he.continuous⟩ he with ⟨g, hg, rfl⟩
+theorem exists_extension_norm_eq_of_isClosedEmbedding (f : X →ᵇ ℝ) {e : X → Y}
+    (he : IsClosedEmbedding e) : ∃ g : Y →ᵇ ℝ, ‖g‖ = ‖f‖ ∧ g ∘ e = f := by
+  rcases exists_extension_norm_eq_of_isClosedEmbedding' f ⟨e, he.continuous⟩ he with ⟨g, hg, rfl⟩
   exact ⟨g, hg, rfl⟩
 
 /-- **Tietze extension theorem** for real-valued bounded continuous maps, a version for a closed
@@ -276,21 +276,21 @@ topological space, then it can be extended to a bounded continuous function of t
 on the whole space. -/
 theorem exists_norm_eq_restrict_eq_of_closed {s : Set Y} (f : s →ᵇ ℝ) (hs : IsClosed s) :
     ∃ g : Y →ᵇ ℝ, ‖g‖ = ‖f‖ ∧ g.restrict s = f :=
-  exists_extension_norm_eq_of_closedEmbedding' f ((ContinuousMap.id _).restrict s)
-    (closedEmbedding_subtype_val hs)
+  exists_extension_norm_eq_of_isClosedEmbedding' f ((ContinuousMap.id _).restrict s)
+    hs.isClosedEmbedding_subtypeVal
 
 /-- **Tietze extension theorem** for real-valued bounded continuous maps, a version for a closed
 embedding and a bounded continuous function that takes values in a non-trivial closed interval.
-See also `exists_extension_forall_mem_of_closedEmbedding` for a more general statement that works
+See also `exists_extension_forall_mem_of_isClosedEmbedding` for a more general statement that works
 for any interval (finite or infinite, open or closed).
 
 If `e : X → Y` is a closed embedding and `f : X →ᵇ ℝ` is a bounded continuous function such that
 `f x ∈ [a, b]` for all `x`, where `a ≤ b`, then there exists a bounded continuous function
 `g : Y →ᵇ ℝ` such that `g y ∈ [a, b]` for all `y` and `g ∘ e = f`. -/
-theorem exists_extension_forall_mem_Icc_of_closedEmbedding (f : X →ᵇ ℝ) {a b : ℝ} {e : X → Y}
-    (hf : ∀ x, f x ∈ Icc a b) (hle : a ≤ b) (he : ClosedEmbedding e) :
+theorem exists_extension_forall_mem_Icc_of_isClosedEmbedding (f : X →ᵇ ℝ) {a b : ℝ} {e : X → Y}
+    (hf : ∀ x, f x ∈ Icc a b) (hle : a ≤ b) (he : IsClosedEmbedding e) :
     ∃ g : Y →ᵇ ℝ, (∀ y, g y ∈ Icc a b) ∧ g ∘ e = f := by
-  rcases exists_extension_norm_eq_of_closedEmbedding (f - const X ((a + b) / 2)) he with
+  rcases exists_extension_norm_eq_of_isClosedEmbedding (f - const X ((a + b) / 2)) he with
     ⟨g, hgf, hge⟩
   refine ⟨const Y ((a + b) / 2) + g, fun y => ?_, ?_⟩
   · suffices ‖f - const X ((a + b) / 2)‖ ≤ (b - a) / 2 by
@@ -307,8 +307,8 @@ embedding. Let `e` be a closed embedding of a nonempty topological space `X` int
 topological space `Y`. Let `f` be a bounded continuous real-valued function on `X`. Then there
 exists a bounded continuous function `g : Y →ᵇ ℝ` such that `g ∘ e = f` and each value `g y` belongs
 to a closed interval `[f x₁, f x₂]` for some `x₁` and `x₂`. -/
-theorem exists_extension_forall_exists_le_ge_of_closedEmbedding [Nonempty X] (f : X →ᵇ ℝ)
-    {e : X → Y} (he : ClosedEmbedding e) :
+theorem exists_extension_forall_exists_le_ge_of_isClosedEmbedding [Nonempty X] (f : X →ᵇ ℝ)
+    {e : X → Y} (he : IsClosedEmbedding e) :
     ∃ g : Y →ᵇ ℝ, (∀ y, ∃ x₁ x₂, g y ∈ Icc (f x₁) (f x₂)) ∧ g ∘ e = f := by
   inhabit X
   -- Put `a = ⨅ x, f x` and `b = ⨆ x, f x`
@@ -329,12 +329,12 @@ theorem exists_extension_forall_exists_le_ge_of_closedEmbedding [Nonempty X] (f 
   have hsub : c - a = b - c := by
     field_simp [c]
     ring
-  /- Due to `exists_extension_forall_mem_Icc_of_closedEmbedding`, there exists an extension `g`
+  /- Due to `exists_extension_forall_mem_Icc_of_isClosedEmbedding`, there exists an extension `g`
     such that `g y ∈ [a, b]` for all `y`. However, if `a` and/or `b` do not belong to the range of
     `f`, then we need to ensure that these points do not belong to the range of `g`. This is done
     in two almost identical steps. First we deal with the case `∀ x, f x ≠ a`. -/
   obtain ⟨g, hg_mem, hgf⟩ : ∃ g : Y →ᵇ ℝ, (∀ y, ∃ x, g y ∈ Icc (f x) b) ∧ g ∘ e = f := by
-    rcases exists_extension_forall_mem_Icc_of_closedEmbedding f hmem hle he with ⟨g, hg_mem, hgf⟩
+    rcases exists_extension_forall_mem_Icc_of_isClosedEmbedding f hmem hle he with ⟨g, hg_mem, hgf⟩
     -- If `a ∈ range f`, then we are done.
     rcases em (∃ x, f x = a) with (⟨x, rfl⟩ | ha')
     · exact ⟨g, fun y => ⟨x, hg_mem _⟩, hgf⟩
@@ -419,13 +419,13 @@ a nonempty convex set of real numbers (we use `OrdConnected` instead of `Convex`
 deduce this argument by typeclass search) such that `f x ∈ t` for all `x`. Then there exists
 a bounded continuous real-valued function `g : Y →ᵇ ℝ` such that `g y ∈ t` for all `y` and
 `g ∘ e = f`. -/
-theorem exists_extension_forall_mem_of_closedEmbedding (f : X →ᵇ ℝ) {t : Set ℝ} {e : X → Y}
-    [hs : OrdConnected t] (hf : ∀ x, f x ∈ t) (hne : t.Nonempty) (he : ClosedEmbedding e) :
+theorem exists_extension_forall_mem_of_isClosedEmbedding (f : X →ᵇ ℝ) {t : Set ℝ} {e : X → Y}
+    [hs : OrdConnected t] (hf : ∀ x, f x ∈ t) (hne : t.Nonempty) (he : IsClosedEmbedding e) :
     ∃ g : Y →ᵇ ℝ, (∀ y, g y ∈ t) ∧ g ∘ e = f := by
   cases isEmpty_or_nonempty X
   · rcases hne with ⟨c, hc⟩
     exact ⟨const Y c, fun _ => hc, funext fun x => isEmptyElim x⟩
-  rcases exists_extension_forall_exists_le_ge_of_closedEmbedding f he with ⟨g, hg, hgf⟩
+  rcases exists_extension_forall_exists_le_ge_of_isClosedEmbedding f he with ⟨g, hg, hgf⟩
   refine ⟨g, fun y => ?_, hgf⟩
   rcases hg y with ⟨xl, xu, h⟩
   exact hs.out (hf _) (hf _) h
@@ -439,9 +439,8 @@ that `f x ∈ t` for all `x : s`. Then there exists a bounded continuous real-va
 theorem exists_forall_mem_restrict_eq_of_closed {s : Set Y} (f : s →ᵇ ℝ) (hs : IsClosed s)
     {t : Set ℝ} [OrdConnected t] (hf : ∀ x, f x ∈ t) (hne : t.Nonempty) :
     ∃ g : Y →ᵇ ℝ, (∀ y, g y ∈ t) ∧ g.restrict s = f := by
-  rcases exists_extension_forall_mem_of_closedEmbedding f hf hne
-      (closedEmbedding_subtype_val hs) with
-    ⟨g, hg, hgf⟩
+  obtain ⟨g, hg, hgf⟩ :=
+    exists_extension_forall_mem_of_isClosedEmbedding f hf hne hs.isClosedEmbedding_subtypeVal
   exact ⟨g, hg, DFunLike.coe_injective hgf⟩
 
 end BoundedContinuousFunction
@@ -454,8 +453,8 @@ topological space `Y`. Let `f` be a continuous real-valued function on `X`. Let 
 convex set of real numbers (we use `OrdConnected` instead of `Convex` to automatically deduce this
 argument by typeclass search) such that `f x ∈ t` for all `x`. Then there exists a continuous
 real-valued function `g : C(Y, ℝ)` such that `g y ∈ t` for all `y` and `g ∘ e = f`. -/
-theorem exists_extension_forall_mem_of_closedEmbedding (f : C(X, ℝ)) {t : Set ℝ} {e : X → Y}
-    [hs : OrdConnected t] (hf : ∀ x, f x ∈ t) (hne : t.Nonempty) (he : ClosedEmbedding e) :
+theorem exists_extension_forall_mem_of_isClosedEmbedding (f : C(X, ℝ)) {t : Set ℝ} {e : X → Y}
+    [hs : OrdConnected t] (hf : ∀ x, f x ∈ t) (hne : t.Nonempty) (he : IsClosedEmbedding e) :
     ∃ g : C(Y, ℝ), (∀ y, g y ∈ t) ∧ g ∘ e = f := by
   have h : ℝ ≃o Ioo (-1 : ℝ) 1 := orderIsoIooNegOneOne ℝ
   let F : X →ᵇ ℝ :=
@@ -474,7 +473,7 @@ theorem exists_extension_forall_mem_of_closedEmbedding (f : C(X, ℝ)) {t : Set 
     rcases hz with ⟨z, hz, rfl⟩
     exact ⟨z, hs.out hx hy hz, rfl⟩
   have hFt : ∀ x, F x ∈ t' := fun x => mem_image_of_mem _ (hf x)
-  rcases F.exists_extension_forall_mem_of_closedEmbedding hFt (hne.image _) he with ⟨G, hG, hGF⟩
+  rcases F.exists_extension_forall_mem_of_isClosedEmbedding hFt (hne.image _) he with ⟨G, hG, hGF⟩
   let g : C(Y, ℝ) :=
     ⟨h.symm ∘ codRestrict G _ fun y => ht_sub (hG y),
       h.symm.continuous.comp <| G.continuous.subtype_mk _⟩
@@ -488,7 +487,7 @@ theorem exists_extension_forall_mem_of_closedEmbedding (f : C(X, ℝ)) {t : Set 
     exact hgG.2 (congr_fun hGF _)
 
 @[deprecated (since := "2024-01-16")]
-alias exists_extension_of_closedEmbedding := exists_extension'
+alias exists_extension_of_isClosedEmbedding := exists_extension'
 
 /-- **Tietze extension theorem** for real-valued continuous maps, a version for a closed set. Let
 `s` be a closed set in a normal topological space `Y`. Let `f` be a continuous real-valued function
@@ -500,7 +499,7 @@ theorem exists_restrict_eq_forall_mem_of_closed {s : Set Y} (f : C(s, ℝ)) {t :
     [OrdConnected t] (ht : ∀ x, f x ∈ t) (hne : t.Nonempty) (hs : IsClosed s) :
     ∃ g : C(Y, ℝ), (∀ y, g y ∈ t) ∧ g.restrict s = f :=
   let ⟨g, hgt, hgf⟩ :=
-    exists_extension_forall_mem_of_closedEmbedding f ht hne (closedEmbedding_subtype_val hs)
+    exists_extension_forall_mem_of_isClosedEmbedding f ht hne hs.isClosedEmbedding_subtypeVal
   ⟨g, hgt, coe_injective hgf⟩
 
 @[deprecated (since := "2024-01-16")] alias exists_restrict_eq_of_closed := exists_restrict_eq

--- a/Mathlib/Topology/TietzeExtension.lean
+++ b/Mathlib/Topology/TietzeExtension.lean
@@ -261,6 +261,9 @@ theorem exists_extension_norm_eq_of_isClosedEmbedding' (f : X →ᵇ ℝ) (e : C
   · rw [← hge]
     exact norm_compContinuous_le _ _
 
+@[deprecated (since := "2024-10-20")]
+alias exists_extension_norm_eq_of_closedEmbedding' := exists_extension_norm_eq_of_isClosedEmbedding'
+
 /-- **Tietze extension theorem** for real-valued bounded continuous maps, a version with a closed
 embedding and unbundled composition. If `e : C(X, Y)` is a closed embedding of a topological space
 into a normal topological space and `f : X →ᵇ ℝ` is a bounded continuous function, then there exists
@@ -269,6 +272,9 @@ theorem exists_extension_norm_eq_of_isClosedEmbedding (f : X →ᵇ ℝ) {e : X 
     (he : IsClosedEmbedding e) : ∃ g : Y →ᵇ ℝ, ‖g‖ = ‖f‖ ∧ g ∘ e = f := by
   rcases exists_extension_norm_eq_of_isClosedEmbedding' f ⟨e, he.continuous⟩ he with ⟨g, hg, rfl⟩
   exact ⟨g, hg, rfl⟩
+
+@[deprecated (since := "2024-10-20")]
+alias exists_extension_norm_eq_of_closedEmbedding := exists_extension_norm_eq_of_isClosedEmbedding
 
 /-- **Tietze extension theorem** for real-valued bounded continuous maps, a version for a closed
 set. If `f` is a bounded continuous real-valued function defined on a closed set in a normal
@@ -301,6 +307,10 @@ theorem exists_extension_forall_mem_Icc_of_isClosedEmbedding (f : X →ᵇ ℝ) 
   · ext x
     have : g (e x) = f x - (a + b) / 2 := congr_fun hge x
     simp [this]
+
+@[deprecated (since := "2024-10-20")]
+alias exists_extension_forall_mem_Icc_of_closedEmbedding :=
+  exists_extension_forall_mem_Icc_of_isClosedEmbedding
 
 /-- **Tietze extension theorem** for real-valued bounded continuous maps, a version for a closed
 embedding. Let `e` be a closed embedding of a nonempty topological space `X` into a normal
@@ -412,6 +422,10 @@ theorem exists_extension_forall_exists_le_ge_of_isClosedEmbedding [Nonempty X] (
   · refine ⟨xl y, xu, ?_, hyxu.le⟩
     simp [dg0 (Or.inr hc), hxl]
 
+@[deprecated (since := "2024-10-20")]
+alias exists_extension_forall_exists_le_ge_of_closedEmbedding :=
+  exists_extension_forall_exists_le_ge_of_isClosedEmbedding
+
 /-- **Tietze extension theorem** for real-valued bounded continuous maps, a version for a closed
 embedding. Let `e` be a closed embedding of a nonempty topological space `X` into a normal
 topological space `Y`. Let `f` be a bounded continuous real-valued function on `X`. Let `t` be
@@ -429,6 +443,10 @@ theorem exists_extension_forall_mem_of_isClosedEmbedding (f : X →ᵇ ℝ) {t :
   refine ⟨g, fun y => ?_, hgf⟩
   rcases hg y with ⟨xl, xu, h⟩
   exact hs.out (hf _) (hf _) h
+
+@[deprecated (since := "2024-10-20")]
+alias exists_extension_forall_mem_of_closedEmbedding :=
+  exists_extension_forall_mem_of_isClosedEmbedding
 
 /-- **Tietze extension theorem** for real-valued bounded continuous maps, a version for a closed
 set. Let `s` be a closed set in a normal topological space `Y`. Let `f` be a bounded continuous
@@ -486,8 +504,15 @@ theorem exists_extension_forall_mem_of_isClosedEmbedding (f : C(X, ℝ)) {t : Se
   · ext x
     exact hgG.2 (congr_fun hGF _)
 
+@[deprecated (since := "2024-10-20")]
+alias exists_extension_forall_mem_of_closedEmbedding :=
+  exists_extension_forall_mem_of_isClosedEmbedding
+
 @[deprecated (since := "2024-01-16")]
 alias exists_extension_of_isClosedEmbedding := exists_extension'
+
+@[deprecated (since := "2024-10-20")]
+alias exists_extension_of_closedEmbedding := exists_extension_of_isClosedEmbedding
 
 /-- **Tietze extension theorem** for real-valued continuous maps, a version for a closed set. Let
 `s` be a closed set in a normal topological space `Y`. Let `f` be a continuous real-valued function

--- a/Mathlib/Topology/UniformSpace/Ascoli.lean
+++ b/Mathlib/Topology/UniformSpace/Ascoli.lean
@@ -499,7 +499,8 @@ theorem ArzelaAscoli.isCompact_closure_of_isClosedEmbedding [TopologicalSpace ι
     fun K hK x hx ↦ (cls_pointwiseCompact K hK x hx).imp fun Q hQ ↦ ⟨hQ.1, by simpa using hQ.2⟩
 
 @[deprecated (since := "2024-10-20")]
-alias ArzelaAscoli.isCompact_closure_of_closedEmbedding := ArzelaAscoli.isCompact_closure_of_isClosedEmbedding
+alias ArzelaAscoli.isCompact_closure_of_closedEmbedding :=
+  ArzelaAscoli.isCompact_closure_of_isClosedEmbedding
 
 /-- A version of the **Arzela-Ascoli theorem**.
 

--- a/Mathlib/Topology/UniformSpace/Ascoli.lean
+++ b/Mathlib/Topology/UniformSpace/Ascoli.lean
@@ -456,8 +456,8 @@ and `F : ι → (X → α)`. Assume that:
 * For all `x`, the range of `i ↦ F i x` is contained in some fixed compact subset.
 
 Then `ι` is compact. -/
-theorem ArzelaAscoli.compactSpace_of_closedEmbedding [TopologicalSpace ι] {𝔖 : Set (Set X)}
-    (𝔖_compact : ∀ K ∈ 𝔖, IsCompact K) (F_clemb : ClosedEmbedding (UniformOnFun.ofFun 𝔖 ∘ F))
+theorem ArzelaAscoli.compactSpace_of_isClosedEmbedding [TopologicalSpace ι] {𝔖 : Set (Set X)}
+    (𝔖_compact : ∀ K ∈ 𝔖, IsCompact K) (F_clemb : IsClosedEmbedding (UniformOnFun.ofFun 𝔖 ∘ F))
     (F_eqcont : ∀ K ∈ 𝔖, EquicontinuousOn F K)
     (F_pointwiseCompact : ∀ K ∈ 𝔖, ∀ x ∈ K, ∃ Q, IsCompact Q ∧ ∀ i, F i x ∈ Q) :
     CompactSpace ι :=
@@ -474,13 +474,13 @@ Let `X, ι` be topological spaces, `𝔖` a covering of `X` by compact subsets, 
 * For all `x ∈ ⋃₀ 𝔖`, the image of `s` under `i ↦ F i x` is contained in some fixed compact subset.
 
 Then `s` has compact closure in `ι`. -/
-theorem ArzelaAscoli.isCompact_closure_of_closedEmbedding [TopologicalSpace ι] [T2Space α]
+theorem ArzelaAscoli.isCompact_closure_of_isClosedEmbedding [TopologicalSpace ι] [T2Space α]
     {𝔖 : Set (Set X)} (𝔖_compact : ∀ K ∈ 𝔖, IsCompact K)
-    (F_clemb : ClosedEmbedding (UniformOnFun.ofFun 𝔖 ∘ F))
+    (F_clemb : IsClosedEmbedding (UniformOnFun.ofFun 𝔖 ∘ F))
     {s : Set ι} (s_eqcont : ∀ K ∈ 𝔖, EquicontinuousOn (F ∘ ((↑) : s → ι)) K)
     (s_pointwiseCompact : ∀ K ∈ 𝔖, ∀ x ∈ K, ∃ Q, IsCompact Q ∧ ∀ i ∈ s, F i x ∈ Q) :
     IsCompact (closure s) := by
-  -- We apply `ArzelaAscoli.compactSpace_of_closedEmbedding` to the map
+  -- We apply `ArzelaAscoli.compactSpace_of_isClosedEmbedding` to the map
   -- `F ∘ (↑) : closure s → (X → α)`, for which all the hypotheses are easily verified.
   rw [isCompact_iff_compactSpace]
   have : ∀ K ∈ 𝔖, ∀ x ∈ K, Continuous (eval x ∘ F) := fun K hK x hx ↦
@@ -491,8 +491,8 @@ theorem ArzelaAscoli.isCompact_closure_of_closedEmbedding [TopologicalSpace ι] 
   have cls_pointwiseCompact : ∀ K ∈ 𝔖, ∀ x ∈ K, ∃ Q, IsCompact Q ∧ ∀ i ∈ closure s, F i x ∈ Q :=
     fun K hK x hx ↦ (s_pointwiseCompact K hK x hx).imp fun Q hQ ↦ ⟨hQ.1, closure_minimal hQ.2 <|
       hQ.1.isClosed.preimage (this K hK x hx)⟩
-  exact ArzelaAscoli.compactSpace_of_closedEmbedding 𝔖_compact
-    (F_clemb.comp isClosed_closure.closedEmbedding_subtype_val) cls_eqcont
+  exact ArzelaAscoli.compactSpace_of_isClosedEmbedding 𝔖_compact
+    (F_clemb.comp isClosed_closure.isClosedEmbedding_subtypeVal) cls_eqcont
     fun K hK x hx ↦ (cls_pointwiseCompact K hK x hx).imp fun Q hQ ↦ ⟨hQ.1, by simpa using hQ.2⟩
 
 /-- A version of the **Arzela-Ascoli theorem**.

--- a/Mathlib/Topology/UniformSpace/Ascoli.lean
+++ b/Mathlib/Topology/UniformSpace/Ascoli.lean
@@ -464,6 +464,9 @@ theorem ArzelaAscoli.compactSpace_of_isClosedEmbedding [TopologicalSpace ι] {�
   compactSpace_of_closed_inducing' 𝔖_compact F_clemb.toInducing F_clemb.isClosed_range
     F_eqcont F_pointwiseCompact
 
+@[deprecated (since := "2024-10-20")]
+alias ArzelaAscoli.compactSpace_of_closedEmbedding := ArzelaAscoli.compactSpace_of_isClosedEmbedding
+
 /-- A version of the **Arzela-Ascoli theorem**.
 
 Let `X, ι` be topological spaces, `𝔖` a covering of `X` by compact subsets, `α` a T2 uniform space,
@@ -494,6 +497,9 @@ theorem ArzelaAscoli.isCompact_closure_of_isClosedEmbedding [TopologicalSpace ι
   exact ArzelaAscoli.compactSpace_of_isClosedEmbedding 𝔖_compact
     (F_clemb.comp isClosed_closure.isClosedEmbedding_subtypeVal) cls_eqcont
     fun K hK x hx ↦ (cls_pointwiseCompact K hK x hx).imp fun Q hQ ↦ ⟨hQ.1, by simpa using hQ.2⟩
+
+@[deprecated (since := "2024-10-20")]
+alias ArzelaAscoli.isCompact_closure_of_closedEmbedding := ArzelaAscoli.isCompact_closure_of_isClosedEmbedding
 
 /-- A version of the **Arzela-Ascoli theorem**.
 

--- a/Mathlib/Topology/UniformSpace/CompleteSeparated.lean
+++ b/Mathlib/Topology/UniformSpace/CompleteSeparated.lean
@@ -32,8 +32,14 @@ theorem IsUniformEmbedding.toIsClosedEmbedding [UniformSpace α] [UniformSpace �
     IsClosedEmbedding f :=
   ⟨hf.embedding, hf.isUniformInducing.isComplete_range.isClosed⟩
 
+@[deprecated (since := "2024-10-20")]
+alias IsUniformEmbedding.toClosedEmbedding := IsUniformEmbedding.toIsClosedEmbedding
+
 @[deprecated (since := "2024-10-01")]
 alias UniformEmbedding.toIsClosedEmbedding := IsUniformEmbedding.toIsClosedEmbedding
+
+@[deprecated (since := "2024-10-20")]
+alias UniformEmbedding.toClosedEmbedding := UniformEmbedding.toIsClosedEmbedding
 
 namespace IsDenseInducing
 

--- a/Mathlib/Topology/UniformSpace/CompleteSeparated.lean
+++ b/Mathlib/Topology/UniformSpace/CompleteSeparated.lean
@@ -27,13 +27,13 @@ theorem IsComplete.isClosed [UniformSpace α] [T0Space α] {s : Set α} (h : IsC
     rcases h f this inf_le_right with ⟨y, ys, fy⟩
     rwa [(tendsto_nhds_unique' ha inf_le_left fy : a = y)]
 
-theorem IsUniformEmbedding.toClosedEmbedding [UniformSpace α] [UniformSpace β] [CompleteSpace α]
+theorem IsUniformEmbedding.toIsClosedEmbedding [UniformSpace α] [UniformSpace β] [CompleteSpace α]
     [T0Space β] {f : α → β} (hf : IsUniformEmbedding f) :
-    ClosedEmbedding f :=
+    IsClosedEmbedding f :=
   ⟨hf.embedding, hf.isUniformInducing.isComplete_range.isClosed⟩
 
 @[deprecated (since := "2024-10-01")]
-alias UniformEmbedding.toClosedEmbedding := IsUniformEmbedding.toClosedEmbedding
+alias UniformEmbedding.toIsClosedEmbedding := IsUniformEmbedding.toIsClosedEmbedding
 
 namespace IsDenseInducing
 

--- a/Mathlib/Topology/UniformSpace/UniformEmbedding.lean
+++ b/Mathlib/Topology/UniformSpace/UniformEmbedding.lean
@@ -355,6 +355,9 @@ theorem isClosedEmbedding_of_spaced_out {α} [TopologicalSpace α] [DiscreteTopo
     { (isUniformEmbedding_of_spaced_out hs hf).embedding with
       isClosed_range := isClosed_range_of_spaced_out hs hf }
 
+@[deprecated (since := "2024-10-20")]
+alias closedEmbedding_of_spaced_out := isClosedEmbedding_of_spaced_out
+
 theorem closure_image_mem_nhds_of_isUniformInducing {s : Set (α × α)} {e : α → β} (b : β)
     (he₁ : IsUniformInducing e) (he₂ : IsDenseInducing e) (hs : s ∈ 𝓤 α) :
     ∃ a, closure (e '' { a' | (a, a') ∈ s }) ∈ 𝓝 b := by

--- a/Mathlib/Topology/UniformSpace/UniformEmbedding.lean
+++ b/Mathlib/Topology/UniformSpace/UniformEmbedding.lean
@@ -347,9 +347,9 @@ alias UniformEmbedding.isDenseEmbedding := IsUniformEmbedding.isDenseEmbedding
 @[deprecated (since := "2024-09-30")]
 alias IsUniformEmbedding.denseEmbedding := IsUniformEmbedding.isDenseEmbedding
 
-theorem closedEmbedding_of_spaced_out {α} [TopologicalSpace α] [DiscreteTopology α]
+theorem isClosedEmbedding_of_spaced_out {α} [TopologicalSpace α] [DiscreteTopology α]
     [T0Space β] {f : α → β} {s : Set (β × β)} (hs : s ∈ 𝓤 β)
-    (hf : Pairwise fun x y => (f x, f y) ∉ s) : ClosedEmbedding f := by
+    (hf : Pairwise fun x y => (f x, f y) ∉ s) : IsClosedEmbedding f := by
   rcases @DiscreteTopology.eq_bot α _ _ with rfl; let _ : UniformSpace α := ⊥
   exact
     { (isUniformEmbedding_of_spaced_out hs hf).embedding with


### PR DESCRIPTION
`Function.Embedding` is a type while `Embedding` is a proposition, and there are many other kinds of embeddings than topological embeddings. Hence this PR is a step towards
1. renaming `Embedding` to `IsEmbedding` and similarly for neighboring declarations (which `ClosedEmbedding` is)
2. namespacing it inside `Topology`

[Zulip](https://leanprover.zulipchat.com/#narrow/stream/287929-mathlib4/topic/rename.20.60Inducing.60.20and.20.60Embedding.60.3F). See #15993 for context.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
