### PR TITLE
[Merged by Bors] - chore: avoid Coe.coe in Data.Multiset.Functor

### DIFF
--- a/Mathlib/Data/Multiset/Functor.lean
+++ b/Mathlib/Data/Multiset/Functor.lean
@@ -38,14 +38,15 @@ variable {α' β' : Type u} (f : α' → F β')
     and collect the results.
 -/
 def traverse : Multiset α' → F (Multiset β') := by
-  refine Quotient.lift (Functor.map Coe.coe ∘ Traversable.traverse f) ?_
+  refine Quotient.lift (Functor.map ((↑) : List β' → Multiset β') ∘ Traversable.traverse f) ?_
   introv p; unfold Function.comp
   induction p with
   | nil => rfl
   | @cons x l₁ l₂ _ h =>
     have :
-      Multiset.cons <$> f x <*> Coe.coe <$> Traversable.traverse f l₁ =
-        Multiset.cons <$> f x <*> Coe.coe <$> Traversable.traverse f l₂ := by rw [h]
+      Multiset.cons <$> f x <*> ((↑) : List β' → Multiset β') <$> Traversable.traverse f l₁ =
+        Multiset.cons <$> f x <*> ((↑) : List β' → Multiset β') <$> Traversable.traverse f l₂ := by
+      rw [h]
     simpa [functor_norm] using this
   | swap x y l =>
     have :
@@ -55,7 +56,7 @@ def traverse : Multiset α' → F (Multiset β') := by
       congr
       funext a b l
       simpa [flip] using Perm.swap a b l
-    simp [Function.comp_def, this, functor_norm, Coe.coe]
+    simp [Function.comp_def, this, functor_norm]
   | trans => simp [*]
 
 instance : Monad Multiset :=
@@ -83,13 +84,14 @@ open Traversable LawfulTraversable
 
 @[simp]
 theorem map_comp_coe {α β} (h : α → β) :
-    Functor.map h ∘ Coe.coe = (Coe.coe ∘ Functor.map h : List α → Multiset β) := by
-  funext; simp only [Function.comp_apply, Coe.coe, fmap_def, map_coe, List.map_eq_map]
+    Functor.map h ∘ ((↑) : List α → Multiset α) =
+      (((↑) : List β → Multiset β) ∘ Functor.map h : List α → Multiset β) := by
+  funext; simp only [Function.comp_apply, fmap_def, map_coe, List.map_eq_map]
 
 theorem id_traverse {α : Type*} (x : Multiset α) : traverse (pure : α → Id α) x = x := by
   refine Quotient.inductionOn x ?_
   intro
-  simp [traverse, Coe.coe]
+  simp [traverse]
 
 theorem comp_traverse {G H : Type _ → Type _} [Applicative G] [Applicative H] [CommApplicative G]
     [CommApplicative H] {α β γ : Type _} (g : α → G β) (h : β → H γ) (x : Multiset α) :
@@ -97,8 +99,7 @@ theorem comp_traverse {G H : Type _ → Type _} [Applicative G] [Applicative H] 
     Comp.mk (Functor.map (traverse h) (traverse g x)) := by
   refine Quotient.inductionOn x ?_
   intro
-  simp only [traverse, quot_mk_to_coe, lift_coe, Coe.coe, Function.comp_apply, Functor.map_map,
-    functor_norm]
+  simp only [traverse, quot_mk_to_coe, lift_coe, Function.comp_apply, Functor.map_map, functor_norm]
 
 theorem map_traverse {G : Type* → Type _} [Applicative G] [CommApplicative G] {α β γ : Type _}
     (g : α → G β) (h : β → γ) (x : Multiset α) :
@@ -107,8 +108,7 @@ theorem map_traverse {G : Type* → Type _} [Applicative G] [CommApplicative G] 
   intro
   simp only [traverse, quot_mk_to_coe, lift_coe, Function.comp_apply, Functor.map_map, map_comp_coe]
   rw [Traversable.map_traverse']
-  simp only [fmap_def, Function.comp_apply, Functor.map_map, List.map_eq_map]
-  rfl
+  simp only [fmap_def, Function.comp_apply, Functor.map_map, List.map_eq_map, map_coe]
 
 theorem traverse_map {G : Type* → Type _} [Applicative G] [CommApplicative G] {α β γ : Type _}
     (g : α → β) (h : β → G γ) (x : Multiset α) : traverse h (map g x) = traverse (h ∘ g) x := by

--- a/Mathlib/Data/Multiset/Functor.lean
+++ b/Mathlib/Data/Multiset/Functor.lean
@@ -38,14 +38,14 @@ variable {α' β' : Type u} (f : α' → F β')
     and collect the results.
 -/
 def traverse : Multiset α' → F (Multiset β') := by
-  refine Quotient.lift (Functor.map ((↑) : List β' → Multiset β') ∘ Traversable.traverse f) ?_
+  refine Quotient.lift (Functor.map ofList ∘ Traversable.traverse f) ?_
   introv p; unfold Function.comp
   induction p with
   | nil => rfl
   | @cons x l₁ l₂ _ h =>
     have :
-      Multiset.cons <$> f x <*> ((↑) : List β' → Multiset β') <$> Traversable.traverse f l₁ =
-        Multiset.cons <$> f x <*> ((↑) : List β' → Multiset β') <$> Traversable.traverse f l₂ := by
+      Multiset.cons <$> f x <*> ofList <$> Traversable.traverse f l₁ =
+        Multiset.cons <$> f x <*> ofList <$> Traversable.traverse f l₂ := by
       rw [h]
     simpa [functor_norm] using this
   | swap x y l =>
@@ -84,8 +84,7 @@ open Traversable LawfulTraversable
 
 @[simp]
 theorem map_comp_coe {α β} (h : α → β) :
-    Functor.map h ∘ ((↑) : List α → Multiset α) =
-      (((↑) : List β → Multiset β) ∘ Functor.map h : List α → Multiset β) := by
+    Functor.map h ∘ ofList = (ofList ∘ Functor.map h : List α → Multiset β) := by
   funext; simp only [Function.comp_apply, fmap_def, map_coe, List.map_eq_map]
 
 theorem id_traverse {α : Type*} (x : Multiset α) : traverse (pure : α → Id α) x = x := by


### PR DESCRIPTION
This was ported incorrectly from mathlib3.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
