### PR TITLE
[Merged by Bors] - chore(Filter): move more defs to `Defs`

### DIFF
--- a/Mathlib/Order/Filter/Defs.lean
+++ b/Mathlib/Order/Filter/Defs.lean
@@ -340,6 +340,16 @@ instance : Bind Filter :=
 
 instance : Functor Filter where map := @Filter.map
 
+/-- A variant on `bind` using a function `g` taking a set instead of a member of `α`.
+This is essentially a push-forward along a function mapping each set to a filter. -/
+protected def lift (f : Filter α) (g : Set α → Filter β) :=
+  ⨅ s ∈ f, g s
+
+/-- Specialize `lift` to functions `Set α → Set β`. This can be viewed as a generalization of `map`.
+This is essentially a push-forward along a function mapping each set to a set. -/
+protected def lift' (f : Filter α) (h : Set α → Set β) :=
+  f.lift (𝓟 ∘ h)
+
 end Filter
 
 namespace Mathlib.Tactic

--- a/Mathlib/Order/Filter/Lift.lean
+++ b/Mathlib/Order/Filter/Lift.lean
@@ -19,11 +19,6 @@ variable {α β γ : Type*} {ι : Sort*}
 
 section lift
 
-/-- A variant on `bind` using a function `g` taking a set instead of a member of `α`.
-This is essentially a push-forward along a function mapping each set to a filter. -/
-protected def lift (f : Filter α) (g : Set α → Filter β) :=
-  ⨅ s ∈ f, g s
-
 variable {f f₁ f₂ : Filter α} {g g₁ g₂ : Set α → Filter β}
 
 @[simp]
@@ -199,11 +194,6 @@ theorem lift_iInf_of_map_univ {f : ι → Filter α} {g : Set α → Filter β}
 end lift
 
 section Lift'
-
-/-- Specialize `lift` to functions `Set α → Set β`. This can be viewed as a generalization of `map`.
-This is essentially a push-forward along a function mapping each set to a set. -/
-protected def lift' (f : Filter α) (h : Set α → Set β) :=
-  f.lift (𝓟 ∘ h)
 
 variable {f f₁ f₂ : Filter α} {h h₁ h₂ : Set α → Set β}
 


### PR DESCRIPTION
---

~~I expect that I'll need to shake imports once CI is done.~~ I was wrong.
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
