### PR TITLE
[Merged by Bors] - feat(Data.Set.Finite): add map_finite_iSup, map_finite_iInf

### DIFF
--- a/Mathlib/Data/Set/Finite.lean
+++ b/Mathlib/Data/Set/Finite.lean
@@ -1353,6 +1353,24 @@ theorem exists_upper_bound_image [Nonempty α] [LinearOrder β] (s : Set α) (f 
     (h : s.Finite) : ∃ a : α, ∀ b ∈ s, f b ≤ f a :=
   exists_lower_bound_image (β := βᵒᵈ) s f h
 
+lemma Finite.map_iSup {F ι : Type*} [CompleteLattice α] [CompleteLattice β] [FunLike F α β]
+    [SupBotHomClass F α β] [Finite ι] (f : F) (g : ι → α) :
+    f (⨆ i, g i) = ⨆ i, f (g i) := by
+  rw [← iSup_univ (f := g), ← iSup_univ (f := fun i ↦ f (g i))]
+  apply Finite.induction_on (C := fun s ↦ f (⨆ x ∈ s, g x) = ⨆ x ∈ s, f (g x)) finite_univ
+  · rw [iSup_emptyset, iSup_emptyset, map_bot]
+  · intro i s _ _ f_iSup
+    rw [iSup_insert, iSup_insert, map_sup, f_iSup]
+
+lemma Finite.map_iInf {F ι : Type*} [CompleteLattice α] [CompleteLattice β] [FunLike F α β]
+    [InfTopHomClass F α β] [Finite ι] (f : F) (g : ι → α) :
+    f (⨅ i, g i) = ⨅ i, f (g i) := by
+  rw [← iInf_univ (f := g), ← iInf_univ (f := fun i ↦ f (g i))]
+  apply Finite.induction_on (C := fun s ↦ f (⨅ x ∈ s, g x) = ⨅ x ∈ s, f (g x)) finite_univ
+  · rw [iInf_emptyset, iInf_emptyset, map_top]
+  · intro i s _ _ f_iInf
+    rw [iInf_insert, iInf_insert, map_inf, f_iInf]
+
 theorem Finite.iSup_biInf_of_monotone {ι ι' α : Type*} [Preorder ι'] [Nonempty ι']
     [IsDirected ι' (· ≤ ·)] [Order.Frame α] {s : Set ι} (hs : s.Finite) {f : ι → ι' → α}
     (hf : ∀ i ∈ s, Monotone (f i)) : ⨆ j, ⨅ i ∈ s, f i j = ⨅ i ∈ s, ⨆ j, f i j := by

--- a/Mathlib/Data/Set/Finite.lean
+++ b/Mathlib/Data/Set/Finite.lean
@@ -1353,7 +1353,7 @@ theorem exists_upper_bound_image [Nonempty α] [LinearOrder β] (s : Set α) (f 
     (h : s.Finite) : ∃ a : α, ∀ b ∈ s, f b ≤ f a :=
   exists_lower_bound_image (β := βᵒᵈ) s f h
 
-lemma map_iSup {F ι : Type*} [CompleteLattice α] [CompleteLattice β] [FunLike F α β]
+lemma map_finite_iSup {F ι : Type*} [CompleteLattice α] [CompleteLattice β] [FunLike F α β]
     [SupBotHomClass F α β] [Finite ι] (f : F) (g : ι → α) :
     f (⨆ i, g i) = ⨆ i, f (g i) := by
   rw [← iSup_univ (f := g), ← iSup_univ (f := fun i ↦ f (g i))]
@@ -1362,7 +1362,7 @@ lemma map_iSup {F ι : Type*} [CompleteLattice α] [CompleteLattice β] [FunLike
   · intro i s _ _ f_iSup
     rw [iSup_insert, iSup_insert, map_sup, f_iSup]
 
-lemma map_iInf {F ι : Type*} [CompleteLattice α] [CompleteLattice β] [FunLike F α β]
+lemma map_finite_iInf {F ι : Type*} [CompleteLattice α] [CompleteLattice β] [FunLike F α β]
     [InfTopHomClass F α β] [Finite ι] (f : F) (g : ι → α) :
     f (⨅ i, g i) = ⨅ i, f (g i) := by
   rw [← iInf_univ (f := g), ← iInf_univ (f := fun i ↦ f (g i))]

--- a/Mathlib/Data/Set/Finite.lean
+++ b/Mathlib/Data/Set/Finite.lean
@@ -1353,23 +1353,31 @@ theorem exists_upper_bound_image [Nonempty α] [LinearOrder β] (s : Set α) (f 
     (h : s.Finite) : ∃ a : α, ∀ b ∈ s, f b ≤ f a :=
   exists_lower_bound_image (β := βᵒᵈ) s f h
 
+lemma map_finite_biSup {F ι : Type*} [CompleteLattice α] [CompleteLattice β] [FunLike F α β]
+    [SupBotHomClass F α β] {s : Set ι} (hs : s.Finite) (f : F) (g : ι → α) :
+    f (⨆ x ∈ s, g x) = ⨆ x ∈ s, f (g x) := by
+  have := map_finset_sup f hs.toFinset g
+  simp only [Finset.sup_eq_iSup, hs.mem_toFinset, comp_apply] at this
+  exact this
+
+lemma map_finite_biInf {F ι : Type*} [CompleteLattice α] [CompleteLattice β] [FunLike F α β]
+    [InfTopHomClass F α β] {s : Set ι} (hs : s.Finite) (f : F) (g : ι → α) :
+    f (⨅ x ∈ s, g x) = ⨅ x ∈ s, f (g x) := by
+  have := map_finset_inf f hs.toFinset g
+  simp only [Finset.inf_eq_iInf, hs.mem_toFinset, comp_apply] at this
+  exact this
+
 lemma map_finite_iSup {F ι : Type*} [CompleteLattice α] [CompleteLattice β] [FunLike F α β]
     [SupBotHomClass F α β] [Finite ι] (f : F) (g : ι → α) :
     f (⨆ i, g i) = ⨆ i, f (g i) := by
   rw [← iSup_univ (f := g), ← iSup_univ (f := fun i ↦ f (g i))]
-  apply Finite.induction_on (C := fun s ↦ f (⨆ x ∈ s, g x) = ⨆ x ∈ s, f (g x)) finite_univ
-  · rw [iSup_emptyset, iSup_emptyset, map_bot]
-  · intro i s _ _ f_iSup
-    rw [iSup_insert, iSup_insert, map_sup, f_iSup]
+  exact map_finite_biSup finite_univ f g
 
 lemma map_finite_iInf {F ι : Type*} [CompleteLattice α] [CompleteLattice β] [FunLike F α β]
     [InfTopHomClass F α β] [Finite ι] (f : F) (g : ι → α) :
     f (⨅ i, g i) = ⨅ i, f (g i) := by
   rw [← iInf_univ (f := g), ← iInf_univ (f := fun i ↦ f (g i))]
-  apply Finite.induction_on (C := fun s ↦ f (⨅ x ∈ s, g x) = ⨅ x ∈ s, f (g x)) finite_univ
-  · rw [iInf_emptyset, iInf_emptyset, map_top]
-  · intro i s _ _ f_iInf
-    rw [iInf_insert, iInf_insert, map_inf, f_iInf]
+  exact map_finite_biInf finite_univ f g
 
 theorem Finite.iSup_biInf_of_monotone {ι ι' α : Type*} [Preorder ι'] [Nonempty ι']
     [IsDirected ι' (· ≤ ·)] [Order.Frame α] {s : Set ι} (hs : s.Finite) {f : ι → ι' → α}

--- a/Mathlib/Data/Set/Finite.lean
+++ b/Mathlib/Data/Set/Finite.lean
@@ -1353,7 +1353,7 @@ theorem exists_upper_bound_image [Nonempty α] [LinearOrder β] (s : Set α) (f 
     (h : s.Finite) : ∃ a : α, ∀ b ∈ s, f b ≤ f a :=
   exists_lower_bound_image (β := βᵒᵈ) s f h
 
-lemma Finite.map_iSup {F ι : Type*} [CompleteLattice α] [CompleteLattice β] [FunLike F α β]
+lemma map_iSup {F ι : Type*} [CompleteLattice α] [CompleteLattice β] [FunLike F α β]
     [SupBotHomClass F α β] [Finite ι] (f : F) (g : ι → α) :
     f (⨆ i, g i) = ⨆ i, f (g i) := by
   rw [← iSup_univ (f := g), ← iSup_univ (f := fun i ↦ f (g i))]
@@ -1362,7 +1362,7 @@ lemma Finite.map_iSup {F ι : Type*} [CompleteLattice α] [CompleteLattice β] [
   · intro i s _ _ f_iSup
     rw [iSup_insert, iSup_insert, map_sup, f_iSup]
 
-lemma Finite.map_iInf {F ι : Type*} [CompleteLattice α] [CompleteLattice β] [FunLike F α β]
+lemma map_iInf {F ι : Type*} [CompleteLattice α] [CompleteLattice β] [FunLike F α β]
     [InfTopHomClass F α β] [Finite ι] (f : F) (g : ι → α) :
     f (⨅ i, g i) = ⨅ i, f (g i) := by
   rw [← iInf_univ (f := g), ← iInf_univ (f := fun i ↦ f (g i))]


### PR DESCRIPTION
These are type-indexed versions of `map_finset_sup` and `map_finset_inf`.

 ~~Some golfing may be possible by either using directly `map_finset_inf`, `map_finset_sup` or deducing `map_finite_iInf` from `map_finite_iSup`, but I did not find any clean solution in these directions.~~

Following Ruben's advice: there are actually 4 new lemmas (iInf/iSup/biInf/biSup).

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
