### PR TITLE
[Merged by Bors] - chore(scripts/mk_all): gracefully run `loadWorkspace`

### DIFF
--- a/scripts/mk_all.lean
+++ b/scripts/mk_all.lean
@@ -26,7 +26,8 @@ it includes `Mathlib/Tactic`. -/
 def getLeanLibs : IO (Array String) := do
   let (elanInstall?, leanInstall?, lakeInstall?) ← findInstall?
   let config ← MonadError.runEIO <| mkLoadConfig { elanInstall?, leanInstall?, lakeInstall? }
-  let ws ← MonadError.runEIO (MainM.runLogIO (loadWorkspace config)).toEIO
+  let some ws ← loadWorkspace config |>.toBaseIO
+    | throw <| IO.userError "failed to load Lake workspace"
   let package := ws.root
   let libs := (package.leanLibs.map (·.name)).map (·.toString)
   return if package.name == `mathlib then


### PR DESCRIPTION
Changes `scripts/mk_all` to run `loadWorkspace` using Lake's `toBaseIO` utility. In addition to being a bit cleaner, this adaption will also be necessary once leanprover/lean4#5684 lands.