### PR TITLE
[Merged by Bors] - chore(Topology/Exterior): golf

### DIFF
--- a/Mathlib/Topology/Exterior.lean
+++ b/Mathlib/Topology/Exterior.lean
@@ -60,21 +60,6 @@ theorem exterior_union (s t : Set X) : exterior (s ∪ t) = exterior s ∪ exter
 theorem exterior_sUnion (S : Set (Set X)) : exterior (⋃₀ S) = ⋃ s ∈ S, exterior s := by
   simp only [sUnion_eq_biUnion, exterior_iUnion]
 
-theorem exterior_iInter_subset {s : ι → Set X} : exterior (⋂ i, s i) ⊆ ⋂ i, exterior (s i) := by
-  simp_rw [exterior]
-  refine ker_mono (nhdsSet_iInter_le _) |>.trans_eq ?_
-  simp_rw [ker_iInf]
-
-theorem exterior_inter_subset {s t : Set X} : exterior (s ∩ t) ⊆ exterior s ∩ exterior t := by
-  simp_rw [exterior]
-  refine ker_mono (nhdsSet_inter_le _ _) |>.trans_eq ?_
-  rw [ker_inf _ _]
-
-theorem exterior_sInter_subset {s : Set (Set X)} : exterior (⋂₀ s) ⊆ ⋂ x ∈ s, exterior x := by
-  simp_rw [exterior]
-  refine ker_mono (nhdsSet_sInter_le _) |>.trans_eq ?_
-  simp_rw [ker_iInf]
-
 theorem mem_exterior_iff_specializes : x ∈ exterior s ↔ ∃ y ∈ s, x ⤳ y := calc
   x ∈ exterior s ↔ x ∈ exterior (⋃ y ∈ s, {y}) := by simp
   _ ↔ ∃ y ∈ s, x ⤳ y := by
@@ -97,6 +82,15 @@ theorem exterior_eq_exterior_iff_nhdsSet : exterior s = exterior t ↔ 𝓝ˢ s 
 
 lemma specializes_iff_exterior_subset : x ⤳ y ↔ exterior {x} ⊆ exterior {y} := by
   simp [Specializes]
+
+theorem exterior_iInter_subset {s : ι → Set X} : exterior (⋂ i, s i) ⊆ ⋂ i, exterior (s i) :=
+  exterior_mono.map_iInf_le
+
+theorem exterior_inter_subset {s t : Set X} : exterior (s ∩ t) ⊆ exterior s ∩ exterior t :=
+  exterior_mono.map_inf_le _ _
+
+theorem exterior_sInter_subset {s : Set (Set X)} : exterior (⋂₀ s) ⊆ ⋂ x ∈ s, exterior x :=
+  exterior_mono.map_sInf_le
 
 @[simp] lemma exterior_empty : exterior (∅ : Set X) = ∅ := isOpen_empty.exterior_eq
 @[simp] lemma exterior_univ : exterior (univ : Set X) = univ := isOpen_univ.exterior_eq


### PR DESCRIPTION
Use `exterior_mono` to golf 3 lemmas


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
