### PR TITLE
[Merged by Bors] - chore: move `mul_ite`, add `dite` version, multiplicativise `ite_add_ite`

### DIFF
--- a/Mathlib/Algebra/Group/Defs.lean
+++ b/Mathlib/Algebra/Group/Defs.lean
@@ -171,21 +171,22 @@ postfix:max "⁻¹" => Inv.inv
 section ite
 variable {α : Type*} (P : Prop) [Decidable P]
 
+section Mul
+variable [Mul α]
+
 @[to_additive]
-lemma mul_dite [Mul α] (a : α) (b : P → α) (c : ¬ P → α) :
+lemma mul_dite (a : α) (b : P → α) (c : ¬ P → α) :
     (a * if h : P then b h else c h) = if h : P then a * b h else a * c h := by split <;> rfl
 
 @[to_additive]
-lemma mul_ite [Mul α] (a b c : α) : (a * if P then b else c) = if P then a * b else a * c := by
-  split <;> rfl
+lemma mul_ite (a b c : α) : (a * if P then b else c) = if P then a * b else a * c := mul_dite ..
 
 @[to_additive]
-lemma dite_mul [Mul α] (a : P → α) (b : ¬ P → α) (c : α) :
+lemma dite_mul (a : P → α) (b : ¬ P → α) (c : α) :
     (if h : P then a h else b h) * c = if h : P then a h * c else b h * c := by split <;> rfl
 
 @[to_additive]
-lemma ite_mul [Mul α] (a b c : α) : (if P then a else b) * c = if P then a * c else b * c := by
-  split <;> rfl
+lemma ite_mul (a b c : α) : (if P then a else b) * c = if P then a * c else b * c := dite_mul ..
 
 -- We make `mul_ite` and `ite_mul` simp lemmas, but not `add_ite` or `ite_add`.
 -- The problem we're trying to avoid is dealing with sums of the form `∑ x ∈ s, (f x + ite P 1 0)`,
@@ -195,23 +196,43 @@ lemma ite_mul [Mul α] (a b c : α) : (if P then a else b) * c = if P then a * c
 attribute [simp] mul_dite dite_mul mul_ite ite_mul
 
 @[to_additive]
-lemma dite_mul_dite [Mul α] (a : P → α) (b : ¬ P → α) (c : P → α) (d : ¬ P → α) :
+lemma dite_mul_dite (a : P → α) (b : ¬ P → α) (c : P → α) (d : ¬ P → α) :
     ((if h : P then a h else b h) * if h : P then c h else d h) =
       if h : P then a h * c h else b h * d h := by split <;> rfl
 
 @[to_additive]
-lemma ite_mul_ite [Mul α] (a b c d : α) :
+lemma ite_mul_ite (a b c d : α) :
     ((if P then a else b) * if P then c else d) = if P then a * c else b * d := by split <;> rfl
 
+end Mul
+
+section Div
+variable [Div α]
+
 @[to_additive]
-lemma dite_div_dite [Div α] (a : P → α) (b : ¬ P → α) (c : P → α) (d : ¬ P → α) :
+lemma div_dite (a : α) (b : P → α) (c : ¬ P → α) :
+    (a / if h : P then b h else c h) = if h : P then a / b h else a / c h := by split <;> rfl
+
+@[to_additive]
+lemma div_ite (a b c : α) : (a / if P then b else c) = if P then a / b else a / c := div_dite ..
+
+@[to_additive]
+lemma dite_div (a : P → α) (b : ¬ P → α) (c : α) :
+    (if h : P then a h else b h) / c = if h : P then a h / c else b h / c := by split <;> rfl
+
+@[to_additive]
+lemma ite_div (a b c : α) : (if P then a else b) / c = if P then a / c else b / c := dite_div ..
+
+@[to_additive]
+lemma dite_div_dite (a : P → α) (b : ¬ P → α) (c : P → α) (d : ¬ P → α) :
     ((if h : P then a h else b h) / if h : P then c h else d h) =
       if h : P then a h / c h else b h / d h := by split <;> rfl
 
 @[to_additive]
-lemma ite_div_ite [Div α] (a b c d : α) :
-    ((if P then a else b) / if P then c else d) = if P then a / c else b / d := by split <;> rfl
+lemma ite_div_ite (a b c d : α) :
+    ((if P then a else b) / if P then c else d) = if P then a / c else b / d := dite_div_dite ..
 
+end Div
 end ite
 
 section Mul

--- a/Mathlib/Algebra/Group/Defs.lean
+++ b/Mathlib/Algebra/Group/Defs.lean
@@ -176,8 +176,8 @@ lemma mul_dite [Mul α] (a : α) (b : P → α) (c : ¬ P → α) :
     (a * if h : P then b h else c h) = if h : P then a * b h else a * c h := by split <;> rfl
 
 @[to_additive]
-lemma mul_ite [Mul α] (a b c : α) : (a * if P then b else c) = if P then a * b else a * c :=
-  by split <;> rfl
+lemma mul_ite [Mul α] (a b c : α) : (a * if P then b else c) = if P then a * b else a * c := by
+  split <;> rfl
 
 @[to_additive]
 lemma dite_mul [Mul α] (a : P → α) (b : ¬ P → α) (c : α) :

--- a/Mathlib/Algebra/Group/Defs.lean
+++ b/Mathlib/Algebra/Group/Defs.lean
@@ -168,6 +168,52 @@ class Inv (α : Type u) where
 @[inherit_doc]
 postfix:max "⁻¹" => Inv.inv
 
+section ite
+variable {α : Type*} (P : Prop) [Decidable P]
+
+@[to_additive]
+lemma mul_dite [Mul α] (a : α) (b : P → α) (c : ¬ P → α) :
+    (a * if h : P then b h else c h) = if h : P then a * b h else a * c h := by split <;> rfl
+
+@[to_additive]
+lemma mul_ite [Mul α] (a b c : α) : (a * if P then b else c) = if P then a * b else a * c :=
+  by split <;> rfl
+
+@[to_additive]
+lemma dite_mul [Mul α] (a : P → α) (b : ¬ P → α) (c : α) :
+    (if h : P then a h else b h) * c = if h : P then a h * c else b h * c := by split <;> rfl
+
+@[to_additive]
+lemma ite_mul [Mul α] (a b c : α) : (if P then a else b) * c = if P then a * c else b * c := by
+  split <;> rfl
+
+-- We make `mul_ite` and `ite_mul` simp lemmas, but not `add_ite` or `ite_add`.
+-- The problem we're trying to avoid is dealing with sums of the form `∑ x ∈ s, (f x + ite P 1 0)`,
+-- in which `add_ite` followed by `sum_ite` would needlessly slice up
+-- the `f x` terms according to whether `P` holds at `x`.
+-- There doesn't appear to be a corresponding difficulty so far with `mul_ite` and `ite_mul`.
+attribute [simp] mul_dite dite_mul mul_ite ite_mul
+
+@[to_additive]
+lemma dite_mul_dite [Mul α] (a : P → α) (b : ¬ P → α) (c : P → α) (d : ¬ P → α) :
+    ((if h : P then a h else b h) * if h : P then c h else d h) =
+      if h : P then a h * c h else b h * d h := by split <;> rfl
+
+@[to_additive]
+lemma ite_mul_ite [Mul α] (a b c d : α) :
+    ((if P then a else b) * if P then c else d) = if P then a * c else b * d := by split <;> rfl
+
+@[to_additive]
+lemma dite_div_dite [Div α] (a : P → α) (b : ¬ P → α) (c : P → α) (d : ¬ P → α) :
+    ((if h : P then a h else b h) / if h : P then c h else d h) =
+      if h : P then a h / c h else b h / d h := by split <;> rfl
+
+@[to_additive]
+lemma ite_div_ite [Div α] (a b c d : α) :
+    ((if P then a else b) / if P then c else d) = if P then a / c else b / d := by split <;> rfl
+
+end ite
+
 section Mul
 
 variable [Mul G]

--- a/Mathlib/Algebra/Ring/Defs.lean
+++ b/Mathlib/Algebra/Ring/Defs.lean
@@ -178,34 +178,6 @@ theorem mul_two (n : α) : n * 2 = n + n :=
 
 end NonAssocSemiring
 
-@[to_additive]
-theorem mul_ite {α} [Mul α] (P : Prop) [Decidable P] (a b c : α) :
-    (a * if P then b else c) = if P then a * b else a * c := by split_ifs <;> rfl
-
-@[to_additive]
-theorem ite_mul {α} [Mul α] (P : Prop) [Decidable P] (a b c : α) :
-    (if P then a else b) * c = if P then a * c else b * c := by split_ifs <;> rfl
-
--- We make `mul_ite` and `ite_mul` simp lemmas,
--- but not `add_ite` or `ite_add`.
--- The problem we're trying to avoid is dealing with
--- summations of the form `∑ x ∈ s, (f x + ite P 1 0)`,
--- in which `add_ite` followed by `sum_ite` would needlessly slice up
--- the `f x` terms according to whether `P` holds at `x`.
--- There doesn't appear to be a corresponding difficulty so far with
--- `mul_ite` and `ite_mul`.
-attribute [simp] mul_ite ite_mul
-
-theorem ite_sub_ite {α} [Sub α] (P : Prop) [Decidable P] (a b c d : α) :
-    ((if P then a else b) - if P then c else d) = if P then a - c else b - d := by
-  split
-  repeat rfl
-
-theorem ite_add_ite {α} [Add α] (P : Prop) [Decidable P] (a b c d : α) :
-    ((if P then a else b) + if P then c else d) = if P then a + c else b + d := by
-  split
-  repeat rfl
-
 section MulZeroClass
 variable [MulZeroClass α] (P Q : Prop) [Decidable P] [Decidable Q] (a b : α)
 


### PR DESCRIPTION

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
