### PR TITLE
[Merged by Bors] - feat: a product of indicators is the indicator of the product

### DIFF
--- a/Mathlib/Algebra/BigOperators/Pi.lean
+++ b/Mathlib/Algebra/BigOperators/Pi.lean
@@ -3,7 +3,7 @@ Copyright (c) 2018 Simon Hudon. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Simon Hudon, Patrick Massot
 -/
-import Mathlib.Algebra.BigOperators.Group.Finset
+import Mathlib.Algebra.BigOperators.GroupWithZero.Finset
 import Mathlib.Algebra.Group.Action.Pi
 import Mathlib.Algebra.Ring.Pi
 
@@ -14,6 +14,7 @@ This file contains theorems relevant to big operators in binary and arbitrary pr
 of monoids and groups
 -/
 
+variable {ι κ α : Type*}
 
 namespace Pi
 
@@ -56,6 +57,26 @@ theorem pi_eq_sum_univ {ι : Type*} [Fintype ι] [DecidableEq ι] {R : Type*} [S
     (x : ι → R) : x = ∑ i, (x i) • fun j => if i = j then (1 : R) else 0 := by
   ext
   simp
+
+section CommSemiring
+variable [CommSemiring α]
+
+lemma prod_indicator_apply (s : Finset ι) (f : ι → Set κ) (g : ι → κ → α) (j : κ) :
+    ∏ i ∈ s, (f i).indicator (g i) j = (s.inf f).indicator (∏ i ∈ s, g i) j := by
+  rw [Set.indicator]
+  split_ifs with hj
+  · rw [Finset.prod_apply]
+    congr! 1 with i hi
+    simp only [Finset.inf_set_eq_iInter, Set.mem_iInter] at hj
+    exact Set.indicator_of_mem (hj _ hi) _
+  · obtain ⟨i, hi, hj⟩ := by simpa using hj
+    exact Finset.prod_eq_zero hi <| Set.indicator_of_not_mem hj _
+
+lemma prod_indicator (s : Finset ι) (f : ι → Set κ) (g : ι → κ → α) :
+    ∏ i ∈ s, (f i).indicator (g i) = (s.inf f).indicator (∏ i ∈ s, g i) := by
+  ext a; simpa using prod_indicator_apply ..
+
+end CommSemiring
 
 section MulSingle
 

--- a/Mathlib/Algebra/BigOperators/Pi.lean
+++ b/Mathlib/Algebra/BigOperators/Pi.lean
@@ -14,6 +14,8 @@ This file contains theorems relevant to big operators in binary and arbitrary pr
 of monoids and groups
 -/
 
+open scoped Finset
+
 variable {ι κ α : Type*}
 
 namespace Pi
@@ -62,7 +64,7 @@ section CommSemiring
 variable [CommSemiring α]
 
 lemma prod_indicator_apply (s : Finset ι) (f : ι → Set κ) (g : ι → κ → α) (j : κ) :
-    ∏ i ∈ s, (f i).indicator (g i) j = (s.inf f).indicator (∏ i ∈ s, g i) j := by
+    ∏ i ∈ s, (f i).indicator (g i) j = (⋂ x ∈ s, f x).indicator (∏ i ∈ s, g i) j := by
   rw [Set.indicator]
   split_ifs with hj
   · rw [Finset.prod_apply]
@@ -73,8 +75,15 @@ lemma prod_indicator_apply (s : Finset ι) (f : ι → Set κ) (g : ι → κ �
     exact Finset.prod_eq_zero hi <| Set.indicator_of_not_mem hj _
 
 lemma prod_indicator (s : Finset ι) (f : ι → Set κ) (g : ι → κ → α) :
-    ∏ i ∈ s, (f i).indicator (g i) = (s.inf f).indicator (∏ i ∈ s, g i) := by
+    ∏ i ∈ s, (f i).indicator (g i) = (⋂ x ∈ s, f x).indicator (∏ i ∈ s, g i) := by
   ext a; simpa using prod_indicator_apply ..
+
+lemma prod_indicator_const_apply (s : Finset ι) (f : ι → Set κ) (g : κ → α) (j : κ) :
+    ∏ i ∈ s, (f i).indicator g j = (⋂ x ∈ s, f x).indicator (g ^ #s) j := by
+  simp [prod_indicator_apply]
+
+lemma prod_indicator_const (s : Finset ι) (f : ι → Set κ) (g : κ → α) :
+    ∏ i ∈ s, (f i).indicator g = (⋂ x ∈ s, f x).indicator (g ^ #s) := by simp [prod_indicator]
 
 end CommSemiring
 

--- a/Mathlib/Algebra/BigOperators/Ring.lean
+++ b/Mathlib/Algebra/BigOperators/Ring.lean
@@ -231,7 +231,7 @@ variable [CommRing α]
 /-- The product of `f i - g i` over all of `s` is the sum over the powerset of `s` of the product of
 `g` over a subset `t` times the product of `f` over the complement of `t` times `(-1) ^ #t`. -/
 lemma prod_sub [DecidableEq ι] (f g : ι → α) (s : Finset ι) :
-    ∏ i ∈ s, (f i - g i) = ∑ t ∈ s.powerset, (-1) ^ #t * (∏ i ∈ t, g i) * ∏ i ∈ s \ t, f i := by
+    ∏ i ∈ s, (f i - g i) = ∑ t ∈ s.powerset, (-1) ^ #t * (∏ i ∈ s \ t, f i) * ∏ i ∈ t, g i := by
   simp [sub_eq_neg_add, prod_add, ← prod_const, ← prod_mul_distrib]
 
 /-- `∏ i, (f i - g i) = (∏ i, f i) - ∑ i, g i * (∏ j < i, f j - g j) * (∏ j > i, f j)`. -/

--- a/Mathlib/Algebra/BigOperators/Ring.lean
+++ b/Mathlib/Algebra/BigOperators/Ring.lean
@@ -232,7 +232,7 @@ variable [CommRing α]
 `g` over a subset `t` times the product of `f` over the complement of `t` times `(-1) ^ #t`. -/
 lemma prod_sub [DecidableEq ι] (f g : ι → α) (s : Finset ι) :
     ∏ i ∈ s, (f i - g i) = ∑ t ∈ s.powerset, (-1) ^ #t * (∏ i ∈ s \ t, f i) * ∏ i ∈ t, g i := by
-  simp [sub_eq_neg_add, prod_add, ← prod_const, ← prod_mul_distrib]
+  simp [sub_eq_neg_add, prod_add, ← prod_const, ← prod_mul_distrib, mul_right_comm]
 
 /-- `∏ i, (f i - g i) = (∏ i, f i) - ∑ i, g i * (∏ j < i, f j - g j) * (∏ j > i, f j)`. -/
 lemma prod_sub_ordered [LinearOrder ι] (s : Finset ι) (f g : ι → α) :

--- a/Mathlib/Algebra/BigOperators/Ring.lean
+++ b/Mathlib/Algebra/BigOperators/Ring.lean
@@ -228,6 +228,12 @@ end CommSemiring
 section CommRing
 variable [CommRing α]
 
+/-- The product of `f i - g i` over all of `s` is the sum over the powerset of `s` of the product of
+`g` over a subset `t` times the product of `f` over the complement of `t` times `(-1) ^ #t`. -/
+lemma prod_sub [DecidableEq ι] (f g : ι → α) (s : Finset ι) :
+    ∏ i ∈ s, (f i - g i) = ∑ t ∈ s.powerset, (-1) ^ #t * (∏ i ∈ t, g i) * ∏ i ∈ s \ t, f i := by
+  simp [sub_eq_neg_add, prod_add, ← prod_const, ← prod_mul_distrib]
+
 /-- `∏ i, (f i - g i) = (∏ i, f i) - ∑ i, g i * (∏ j < i, f j - g j) * (∏ j > i, f j)`. -/
 lemma prod_sub_ordered [LinearOrder ι] (s : Finset ι) (f g : ι → α) :
     ∏ i ∈ s, (f i - g i) =

--- a/Mathlib/Data/Finset/Lattice.lean
+++ b/Mathlib/Data/Finset/Lattice.lean
@@ -1157,6 +1157,12 @@ theorem exists_mem_eq_inf [OrderTop α] (s : Finset ι) (h : s.Nonempty) (f : ι
 
 end LinearOrder
 
+set_option linter.docPrime false in
+@[simp]
+lemma mem_inf' [DecidableEq α] {s : Finset ι} {f : ι → Finset α} {a : α} (hs) :
+    a ∈ s.inf' hs f ↔ ∀ i ∈ s, a ∈ f i := by
+  induction' hs using Finset.Nonempty.cons_induction <;> simp [*]
+
 end Finset
 
 namespace Multiset

--- a/Mathlib/Data/Finset/Lattice.lean
+++ b/Mathlib/Data/Finset/Lattice.lean
@@ -1157,12 +1157,6 @@ theorem exists_mem_eq_inf [OrderTop α] (s : Finset ι) (h : s.Nonempty) (f : ι
 
 end LinearOrder
 
-set_option linter.docPrime false in
-@[simp]
-lemma mem_inf' [DecidableEq α] {s : Finset ι} {f : ι → Finset α} {a : α} (hs) :
-    a ∈ s.inf' hs f ↔ ∀ i ∈ s, a ∈ f i := by
-  induction' hs using Finset.Nonempty.cons_induction <;> simp [*]
-
 end Finset
 
 namespace Multiset
@@ -1187,12 +1181,18 @@ theorem mem_sup {α β} [DecidableEq β] {s : Finset α} {f : α → Multiset β
 end Multiset
 
 namespace Finset
+variable [DecidableEq α] {s : Finset ι} {f : ι → Finset α} {a : α}
 
-theorem mem_sup {α β} [DecidableEq β] {s : Finset α} {f : α → Finset β} {x : β} :
-    x ∈ s.sup f ↔ ∃ v ∈ s, x ∈ f v := by
-  change _ ↔ ∃ v ∈ s, x ∈ (f v).val
-  rw [← Multiset.mem_sup, ← Multiset.mem_toFinset, sup_toFinset]
-  simp_rw [val_toFinset]
+set_option linter.docPrime false in
+@[simp] lemma mem_sup' (hs) : a ∈ s.sup' hs f ↔ ∃ i ∈ s, a ∈ f i := by
+  induction' hs using Nonempty.cons_induction <;> simp [*]
+
+set_option linter.docPrime false in
+@[simp] lemma mem_inf' (hs) : a ∈ s.inf' hs f ↔ ∀ i ∈ s, a ∈ f i := by
+  induction' hs using Nonempty.cons_induction <;> simp [*]
+
+@[simp] lemma mem_sup : a ∈ s.sup f ↔ ∃ i ∈ s, a ∈ f i := by
+  induction' s using cons_induction <;> simp [*]
 
 theorem sup_eq_biUnion {α β} [DecidableEq β] (s : Finset α) (t : α → Finset β) :
     s.sup t = s.biUnion t := by
@@ -1200,14 +1200,14 @@ theorem sup_eq_biUnion {α β} [DecidableEq β] (s : Finset α) (t : α → Fins
   rw [mem_sup, mem_biUnion]
 
 @[simp]
-theorem sup_singleton'' [DecidableEq α] (s : Finset β) (f : β → α) :
+theorem sup_singleton'' (s : Finset β) (f : β → α) :
     (s.sup fun b => {f b}) = s.image f := by
   ext a
   rw [mem_sup, mem_image]
   simp only [mem_singleton, eq_comm]
 
 @[simp]
-theorem sup_singleton' [DecidableEq α] (s : Finset α) : s.sup singleton = s :=
+theorem sup_singleton' (s : Finset α) : s.sup singleton = s :=
   (s.sup_singleton'' _).trans image_id
 
 end Finset


### PR DESCRIPTION

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
