### PR TITLE
[Merged by Bors] - chore: removed unused variables

### DIFF
--- a/Mathlib/Data/Matrix/Hadamard.lean
+++ b/Mathlib/Data/Matrix/Hadamard.lean
@@ -30,8 +30,7 @@ hadamard product, hadamard
 -/
 
 
-variable {α β γ m n : Type*}
-variable {R : Type*}
+variable {α m n R : Type*}
 
 namespace Matrix
 
@@ -124,7 +123,7 @@ end Diagonal
 section trace
 
 variable [Fintype m] [Fintype n]
-variable (R) [Semiring α] [Semiring R] [Module R α]
+variable (R) [Semiring α]
 
 theorem sum_hadamard_eq : (∑ i : m, ∑ j : n, (A ⊙ B) i j) = trace (A * Bᵀ) :=
   rfl

--- a/Mathlib/Data/Matrix/Reflection.lean
+++ b/Mathlib/Data/Matrix/Reflection.lean
@@ -36,7 +36,7 @@ open Matrix
 
 namespace Matrix
 
-variable {l m n : ℕ} {α β : Type*}
+variable {l m n : ℕ} {α : Type*}
 
 /-- `∀` with better defeq for `∀ x : Matrix (Fin m) (Fin n) α, P x`. -/
 def Forall : ∀ {m n} (_ : Matrix (Fin m) (Fin n) α → Prop), Prop

--- a/Mathlib/Data/Matroid/Closure.lean
+++ b/Mathlib/Data/Matroid/Closure.lean
@@ -274,7 +274,7 @@ lemma mem_closure_self (M : Matroid α) (e : α) (he : e ∈ M.E := by aesop_mat
 
 section Indep
 
-variable {ι : Sort*} {I J B : Set α} {f x y : α}
+variable {ι : Sort*} {I J B : Set α} {f x : α}
 
 lemma Indep.closure_eq_setOf_basis_insert (hI : M.Indep I) :
     M.closure I = {x | M.Basis I (insert x I)} := by

--- a/Mathlib/Data/Matroid/IndepAxioms.lean
+++ b/Mathlib/Data/Matroid/IndepAxioms.lean
@@ -82,7 +82,7 @@ for the inverse of `e`).
 
 open Set Matroid
 
-variable {α : Type*} {I B X : Set α}
+variable {α : Type*}
 
 section IndepMatroid
 

--- a/Mathlib/Data/Matroid/Map.lean
+++ b/Mathlib/Data/Matroid/Map.lean
@@ -103,7 +103,7 @@ For this reason, `Matroid.map` requires injectivity to be well-defined in genera
 
 open Set Function Set.Notation
 namespace Matroid
-variable {α β : Type*} {f : α → β} {E I s : Set α} {M : Matroid α} {N : Matroid β}
+variable {α β : Type*} {f : α → β} {E I : Set α} {M : Matroid α} {N : Matroid β}
 
 section comap
 

--- a/Mathlib/Data/Matroid/Restrict.lean
+++ b/Mathlib/Data/Matroid/Restrict.lean
@@ -66,7 +66,7 @@ open Set
 
 namespace Matroid
 
-variable {α : Type*} {M : Matroid α} {R I J X Y : Set α}
+variable {α : Type*} {M : Matroid α} {R I X Y : Set α}
 
 section restrict
 

--- a/Mathlib/Data/NNRat/BigOperators.lean
+++ b/Mathlib/Data/NNRat/BigOperators.lean
@@ -10,7 +10,7 @@ import Mathlib.Data.NNRat.Defs
 /-! # Casting lemmas for non-negative rational numbers involving sums and products
 -/
 
-variable {ι α : Type*}
+variable {α : Type*}
 
 namespace NNRat
 

--- a/Mathlib/Data/Nat/Factorial/SuperFactorial.lean
+++ b/Mathlib/Data/Nat/Factorial/SuperFactorial.lean
@@ -33,8 +33,6 @@ scoped notation "sf" n:60 => Nat.superFactorial n
 
 section SuperFactorial
 
-variable {n : ℕ}
-
 @[simp]
 theorem superFactorial_zero : sf 0 = 1 :=
   rfl

--- a/Mathlib/Data/Nat/Fib/Zeckendorf.lean
+++ b/Mathlib/Data/Nat/Fib/Zeckendorf.lean
@@ -67,7 +67,7 @@ lemma IsZeckendorfRep.sum_fib_lt : ∀ {n l}, IsZeckendorfRep l → (∀ a ∈ (
 end List
 
 namespace Nat
-variable {l : List ℕ} {a m n : ℕ}
+variable {m n : ℕ}
 
 /-- The greatest index of a Fibonacci number less than or equal to `n`. -/
 def greatestFib (n : ℕ) : ℕ := (n + 1).findGreatest (fun k ↦ fib k ≤ n)

--- a/Mathlib/Data/Sum/Interval.lean
+++ b/Mathlib/Data/Sum/Interval.lean
@@ -222,7 +222,7 @@ instance instLocallyFiniteOrder : LocallyFiniteOrder (α ⊕ β) where
   finset_mem_Ioc := by rintro (a | a) (b | b) (x | x) <;> simp
   finset_mem_Ioo := by rintro (a | a) (b | b) (x | x) <;> simp
 
-variable (a₁ a₂ : α) (b₁ b₂ : β) (a b : α ⊕ β)
+variable (a₁ a₂ : α) (b₁ b₂ : β)
 
 theorem Icc_inl_inl : Icc (inl a₁ : α ⊕ β) (inl a₂) = (Icc a₁ a₂).map Embedding.inl :=
   rfl

--- a/Mathlib/Deprecated/Subgroup.lean
+++ b/Mathlib/Deprecated/Subgroup.lean
@@ -32,7 +32,7 @@ subgroup, subgroups, IsSubgroup
 
 open Set Function
 
-variable {G : Type*} {H : Type*} {A : Type*} {a a₁ a₂ b c : G}
+variable {G : Type*} {H : Type*} {A : Type*} {a b : G}
 
 section Group
 

--- a/Mathlib/Deprecated/Subring.lean
+++ b/Mathlib/Deprecated/Subring.lean
@@ -64,8 +64,6 @@ theorem isSubring_set_range {R : Type u} {S : Type v} [Ring R] [Ring S] (f : R �
 
 end RingHom
 
-variable {cR : Type u} [CommRing cR]
-
 theorem IsSubring.inter {S₁ S₂ : Set R} (hS₁ : IsSubring S₁) (hS₂ : IsSubring S₂) :
     IsSubring (S₁ ∩ S₂) :=
   { IsAddSubgroup.inter hS₁.toIsAddSubgroup hS₂.toIsAddSubgroup,

--- a/Mathlib/FieldTheory/Finite/Polynomial.lean
+++ b/Mathlib/FieldTheory/Finite/Polynomial.lean
@@ -173,17 +173,11 @@ noncomputable instance [CommRing K] : Inhabited (R σ K) :=
 def evalᵢ [CommRing K] : R σ K →ₗ[K] (σ → K) → K :=
   (evalₗ K σ).comp (restrictDegree σ K (Fintype.card K - 1)).subtype
 
-section CommRing
-
-variable [CommRing K]
-
 -- TODO: would be nice to replace this by suitable decidability assumptions
 open Classical in
 noncomputable instance decidableRestrictDegree (m : ℕ) :
     DecidablePred (· ∈ { n : σ →₀ ℕ | ∀ i, n i ≤ m }) := by
   simp only [Set.mem_setOf_eq]; infer_instance
-
-end CommRing
 
 variable [Field K]
 

--- a/Mathlib/FieldTheory/IsAlgClosed/Classification.lean
+++ b/Mathlib/FieldTheory/IsAlgClosed/Classification.lean
@@ -119,10 +119,9 @@ end Classification
 
 section Cardinal
 
-variable {R L K : Type u} [CommRing R]
+variable {R K : Type u} [CommRing R]
 variable [Field K] [Algebra R K] [IsAlgClosed K]
 variable {ι : Type u} (v : ι → K)
-variable (hv : IsTranscendenceBasis R v)
 
 theorem cardinal_le_max_transcendence_basis (hv : IsTranscendenceBasis R v) :
     #K ≤ max (max #R #ι) ℵ₀ :=

--- a/Mathlib/FieldTheory/IsAlgClosed/Classification.lean
+++ b/Mathlib/FieldTheory/IsAlgClosed/Classification.lean
@@ -119,8 +119,7 @@ end Classification
 
 section Cardinal
 
-variable {R K : Type u} [CommRing R]
-variable [Field K] [Algebra R K] [IsAlgClosed K]
+variable {R K : Type u} [CommRing R] [Field K] [Algebra R K] [IsAlgClosed K]
 variable {ι : Type u} (v : ι → K)
 
 theorem cardinal_le_max_transcendence_basis (hv : IsTranscendenceBasis R v) :

--- a/Mathlib/FieldTheory/IsPerfectClosure.lean
+++ b/Mathlib/FieldTheory/IsPerfectClosure.lean
@@ -196,7 +196,7 @@ theorem RingHom.pNilradical_le_ker_of_perfectRing [ExpChar L p] [PerfectRing L p
   rwa [map_pow, ← iterateFrobenius_def, ← iterateFrobeniusEquiv_apply, RingEquiv.symm_apply_apply,
     map_zero, map_zero] at h
 
-variable [ExpChar L p] [ExpChar M p] in
+variable [ExpChar L p] in
 theorem IsPerfectClosure.ker_eq [PerfectRing L p] [IsPerfectClosure i p] :
     RingHom.ker i = pNilradical K p :=
   IsPRadical.ker_le'.antisymm (i.pNilradical_le_ker_of_perfectRing p)

--- a/Mathlib/Geometry/Euclidean/Angle/Unoriented/Affine.lean
+++ b/Mathlib/Geometry/Euclidean/Angle/Unoriented/Affine.lean
@@ -33,7 +33,7 @@ namespace EuclideanGeometry
 open InnerProductGeometry
 
 variable {V P : Type*} [NormedAddCommGroup V] [InnerProductSpace ℝ V] [MetricSpace P]
-  [NormedAddTorsor V P] {p p₀ p₁ p₂ : P}
+  [NormedAddTorsor V P] {p p₀ : P}
 
 /-- The undirected angle at `p2` between the line segments to `p1` and
 `p3`. If either of those points equals `p2`, this is π/2. Use

--- a/Mathlib/Geometry/Euclidean/PerpBisector.lean
+++ b/Mathlib/Geometry/Euclidean/PerpBisector.lean
@@ -29,7 +29,7 @@ noncomputable section
 
 namespace AffineSubspace
 
-variable {c c₁ c₂ p₁ p₂ : P}
+variable {c p₁ p₂ : P}
 
 /-- Perpendicular bisector of a segment in a Euclidean affine space. -/
 def perpBisector (p₁ p₂ : P) : AffineSubspace ℝ P :=

--- a/Mathlib/RingTheory/AlgebraicIndependent.lean
+++ b/Mathlib/RingTheory/AlgebraicIndependent.lean
@@ -49,8 +49,7 @@ universe x u v w
 variable {ι : Type*} {ι' : Type*} (R : Type*) {K : Type*}
 variable {A : Type*} {A' : Type*}
 variable (x : ι → A)
-variable [CommRing R] [CommRing A] [CommRing A']
-variable [Algebra R A] [Algebra R A']
+variable [CommRing R] [CommRing A] [CommRing A'] [Algebra R A] [Algebra R A']
 
 /-- `AlgebraicIndependent R x` states the family of elements `x`
   is algebraically independent over `R`, meaning that the canonical

--- a/Mathlib/RingTheory/AlgebraicIndependent.lean
+++ b/Mathlib/RingTheory/AlgebraicIndependent.lean
@@ -47,11 +47,10 @@ open scoped Classical
 universe x u v w
 
 variable {ι : Type*} {ι' : Type*} (R : Type*) {K : Type*}
-variable {A : Type*} {A' A'' : Type*} {V : Type u} {V' : Type*}
+variable {A : Type*} {A' : Type*}
 variable (x : ι → A)
-variable [CommRing R] [CommRing A] [CommRing A'] [CommRing A'']
-variable [Algebra R A] [Algebra R A'] [Algebra R A'']
-variable {a b : R}
+variable [CommRing R] [CommRing A] [CommRing A']
+variable [Algebra R A] [Algebra R A']
 
 /-- `AlgebraicIndependent R x` states the family of elements `x`
   is algebraically independent over `R`, meaning that the canonical


### PR DESCRIPTION
Part of/working towards #17715

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
