### PR TITLE
[Merged by Bors] - feat: lemmas about order on ENat

### DIFF
--- a/Mathlib/Data/ENat/Basic.lean
+++ b/Mathlib/Data/ENat/Basic.lean
@@ -281,21 +281,13 @@ lemma one_le_iff_ne_zero_withTop {n : WithTop ℕ∞} :
   ⟨fun h ↦ (zero_lt_one.trans_le h).ne',
     fun h ↦ add_one_nat_le_withTop_of_lt (pos_iff_ne_zero.mpr h)⟩
 
-lemma add_one_pos : 0 < n + 1 := by
-  rw [← Order.one_le_iff_pos]
-  exact le_add_self
+lemma add_one_pos : 0 < n + 1 :=
+  succ_def n ▸ Order.bot_lt_succ n
 
-lemma add_lt_add_iff_right_of_finite {k : ℕ∞} (ne : k ≠ ⊤) : n + k < m + k ↔ n < m := by
-  cases' k with k
-  · contradiction
-  cases' n with n
-  · simp
-  cases' m with m
-  · norm_cast; simp [coe_lt_top, -Nat.cast_add]
-  · norm_cast; simp_all
+lemma add_lt_add_iff_right {k : ℕ∞} (h : k ≠ ⊤) : n + k < m + k ↔ n < m :=
+  WithTop.add_lt_add_iff_right h
 
-lemma add_lt_add_iff_left_of_finite {k : ℕ∞} (ne : k ≠ ⊤) : k + n < k + m ↔ n < m := by
-  repeat rw [add_comm k]
-  exact add_lt_add_iff_right_of_finite ne
+lemma add_lt_add_iff_left {k : ℕ∞} (h : k ≠ ⊤) : k + n < k + m ↔ n < m :=
+  WithTop.add_lt_add_iff_left h
 
 end ENat

--- a/Mathlib/Data/ENat/Basic.lean
+++ b/Mathlib/Data/ENat/Basic.lean
@@ -281,4 +281,21 @@ lemma one_le_iff_ne_zero_withTop {n : WithTop ℕ∞} :
   ⟨fun h ↦ (zero_lt_one.trans_le h).ne',
     fun h ↦ add_one_nat_le_withTop_of_lt (pos_iff_ne_zero.mpr h)⟩
 
+lemma add_one_pos : 0 < n + 1 := by
+  rw [← Order.one_le_iff_pos]
+  exact le_add_self
+
+lemma add_lt_add_iff_right_of_finite {k : ℕ∞} (ne : k ≠ ⊤) : n + k < m + k ↔ n < m := by
+  cases' k with k
+  · contradiction
+  cases' n with n
+  · simp
+  cases' m with m
+  · norm_cast; simp [coe_lt_top, -Nat.cast_add]
+  · norm_cast; simp_all
+
+lemma add_lt_add_iff_left_of_finite {k : ℕ∞} (ne : k ≠ ⊤) : k + n < k + m ↔ n < m := by
+  repeat rw [add_comm k]
+  exact add_lt_add_iff_right_of_finite ne
+
 end ENat


### PR DESCRIPTION
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
