### PR TITLE
[Merged by Bors] - feat: Homeomorphisms and IsometryEquivs based on `Equiv.piCongrLeft` and `Equiv.sumArrowEquivProdArrow`

### DIFF
--- a/Mathlib/Data/Fin/Tuple/Basic.lean
+++ b/Mathlib/Data/Fin/Tuple/Basic.lean
@@ -395,8 +395,8 @@ lemma append_comp_rev {m n} (xs : Fin m → α) (ys : Fin n → α) :
   funext <| append_rev xs ys
 
 theorem append_castAdd_natAdd {f : Fin (m + n) → α} :
-    (Fin.append (fun i ↦ f (Fin.castAdd n i)) fun i ↦ f (Fin.natAdd m i)) = f := by
-  unfold Fin.append Fin.addCases
+    (append (fun i ↦ f (castAdd n i)) fun i ↦ f (natAdd m i)) = f := by
+  unfold append addCases
   simp
 
 end Append

--- a/Mathlib/Data/Fin/Tuple/Basic.lean
+++ b/Mathlib/Data/Fin/Tuple/Basic.lean
@@ -394,6 +394,11 @@ lemma append_comp_rev {m n} (xs : Fin m → α) (ys : Fin n → α) :
     append xs ys ∘ rev = append (ys ∘ rev) (xs ∘ rev) ∘ cast (Nat.add_comm ..) :=
   funext <| append_rev xs ys
 
+theorem append_castAdd_natAdd {f : Fin (m + n) → α} :
+    (Fin.append (fun i ↦ f (Fin.castAdd n i)) fun i ↦ f (Fin.natAdd m i)) = f := by
+  unfold Fin.append Fin.addCases
+  simp
+
 end Append
 
 section Repeat

--- a/Mathlib/Data/Fin/Tuple/Basic.lean
+++ b/Mathlib/Data/Fin/Tuple/Basic.lean
@@ -395,7 +395,7 @@ lemma append_comp_rev {m n} (xs : Fin m → α) (ys : Fin n → α) :
   funext <| append_rev xs ys
 
 theorem append_castAdd_natAdd {f : Fin (m + n) → α} :
-    (append (fun i ↦ f (castAdd n i)) fun i ↦ f (natAdd m i)) = f := by
+    append (fun i ↦ f (castAdd n i)) (fun i ↦ f (natAdd m i)) = f := by
   unfold append addCases
   simp
 

--- a/Mathlib/Logic/Equiv/Fin.lean
+++ b/Mathlib/Logic/Equiv/Fin.lean
@@ -499,9 +499,9 @@ instance subsingleton_fin_zero : Subsingleton (Fin 0) :=
 instance subsingleton_fin_one : Subsingleton (Fin 1) :=
   finOneEquiv.subsingleton
 
-/-- The natural `Equiv` between `(Fin m → X) × (Fin n → X)` and `(Fin (m + n) → X)`.-/
-def Equiv.finArrowProdEquivFinAddArrow {X : Type*} (m n : ℕ) :
-    (Fin m → X) × (Fin n → X) ≃ (Fin (m + n) → X) where
+/-- The natural `Equiv` between `(Fin m → α) × (Fin n → α)` and `(Fin (m + n) → α)`.-/
+def Equiv.finArrowProdEquivFinAddArrow {α : Type*} (m n : ℕ) :
+    (Fin m → α) × (Fin n → α) ≃ (Fin (m + n) → α) where
   toFun := fun ⟨f, g⟩ ↦ Fin.append f g
   invFun := fun f ↦ ⟨fun i ↦ f (Fin.castAdd n i), fun i ↦ f (Fin.natAdd m i)⟩
   left_inv := by simp [Function.LeftInverse]

--- a/Mathlib/Logic/Equiv/Fin.lean
+++ b/Mathlib/Logic/Equiv/Fin.lean
@@ -502,9 +502,7 @@ instance subsingleton_fin_one : Subsingleton (Fin 1) :=
 /-- The natural `Equiv` between `(Fin m → α) × (Fin n → α)` and `(Fin (m + n) → α)`.-/
 def Equiv.finArrowProdEquivFinAddArrow {α : Type*} (m n : ℕ) :
     (Fin m → α) × (Fin n → α) ≃ (Fin (m + n) → α) where
-  toFun := fun ⟨f, g⟩ ↦ Fin.append f g
-  invFun := fun f ↦ ⟨fun i ↦ f (Fin.castAdd n i), fun i ↦ f (Fin.natAdd m i)⟩
-  left_inv := by simp [Function.LeftInverse]
-  right_inv := by
-    unfold Fin.append Fin.addCases
-    simp [Function.RightInverse, Function.LeftInverse]
+  toFun fg := Fin.append fg.1 fg.2
+  invFun f := ⟨fun i ↦ f (Fin.castAdd n i), fun i ↦ f (Fin.natAdd m i)⟩
+  left_inv fg := by simp
+  right_inv f := by simp [Fin.append_castAdd_natAdd]

--- a/Mathlib/Logic/Equiv/Fin.lean
+++ b/Mathlib/Logic/Equiv/Fin.lean
@@ -500,6 +500,7 @@ instance subsingleton_fin_one : Subsingleton (Fin 1) :=
   finOneEquiv.subsingleton
 
 /-- The natural `Equiv` between `(Fin m → α) × (Fin n → α)` and `(Fin (m + n) → α)`.-/
+@[simps]
 def Equiv.finArrowProdEquivFinAddArrow {α : Type*} (m n : ℕ) :
     (Fin m → α) × (Fin n → α) ≃ (Fin (m + n) → α) where
   toFun fg := Fin.append fg.1 fg.2

--- a/Mathlib/Logic/Equiv/Fin.lean
+++ b/Mathlib/Logic/Equiv/Fin.lean
@@ -498,3 +498,8 @@ instance subsingleton_fin_zero : Subsingleton (Fin 0) :=
 /-- `Fin 1` is a subsingleton. -/
 instance subsingleton_fin_one : Subsingleton (Fin 1) :=
   finOneEquiv.subsingleton
+
+/-- The natural `Equiv` between `(Fin m → X) × (Fin n → X)` and `(Fin (m + n) → X)`.-/
+def Equiv.finArrowProdEquivFinAddArrow {α : Type*} (m n : ℕ) :
+    (Fin m → α) × (Fin n → α) ≃ (Fin (m + n) → α) :=
+  (sumArrowEquivProdArrow _ _ _).symm.trans (finSumFinEquiv.arrowCongr (Equiv.refl _))

--- a/Mathlib/Logic/Equiv/Fin.lean
+++ b/Mathlib/Logic/Equiv/Fin.lean
@@ -500,6 +500,11 @@ instance subsingleton_fin_one : Subsingleton (Fin 1) :=
   finOneEquiv.subsingleton
 
 /-- The natural `Equiv` between `(Fin m → X) × (Fin n → X)` and `(Fin (m + n) → X)`.-/
-def Equiv.finArrowProdEquivFinAddArrow {α : Type*} (m n : ℕ) :
-    (Fin m → α) × (Fin n → α) ≃ (Fin (m + n) → α) :=
-  (sumArrowEquivProdArrow _ _ _).symm.trans (finSumFinEquiv.arrowCongr (Equiv.refl _))
+def Equiv.finArrowProdEquivFinAddArrow {X : Type*} (m n : ℕ) :
+    (Fin m → X) × (Fin n → X) ≃ (Fin (m + n) → X) where
+  toFun := fun ⟨f, g⟩ ↦ Fin.append f g
+  invFun := fun f ↦ ⟨fun i ↦ f (Fin.castAdd n i), fun i ↦ f (Fin.natAdd m i)⟩
+  left_inv := by simp [Function.LeftInverse]
+  right_inv := by
+    unfold Fin.append Fin.addCases
+    simp [Function.RightInverse, Function.LeftInverse]

--- a/Mathlib/Logic/Equiv/Fin.lean
+++ b/Mathlib/Logic/Equiv/Fin.lean
@@ -501,7 +501,7 @@ instance subsingleton_fin_one : Subsingleton (Fin 1) :=
 
 /-- The natural `Equiv` between `(Fin m → α) × (Fin n → α)` and `(Fin (m + n) → α)`.-/
 @[simps]
-def Equiv.finArrowProdEquivFinAddArrow {α : Type*} (m n : ℕ) :
+def Fin.appendEquiv {α : Type*} (m n : ℕ) :
     (Fin m → α) × (Fin n → α) ≃ (Fin (m + n) → α) where
   toFun fg := Fin.append fg.1 fg.2
   invFun f := ⟨fun i ↦ f (Fin.castAdd n i), fun i ↦ f (Fin.natAdd m i)⟩

--- a/Mathlib/Logic/Equiv/Fin.lean
+++ b/Mathlib/Logic/Equiv/Fin.lean
@@ -499,7 +499,7 @@ instance subsingleton_fin_zero : Subsingleton (Fin 0) :=
 instance subsingleton_fin_one : Subsingleton (Fin 1) :=
   finOneEquiv.subsingleton
 
-/-- The natural `Equiv` between `(Fin m → α) × (Fin n → α)` and `(Fin (m + n) → α)`.-/
+/-- The natural `Equiv` between `(Fin m → α) × (Fin n → α)` and `Fin (m + n) → α`.-/
 @[simps]
 def Fin.appendEquiv {α : Type*} (m n : ℕ) :
     (Fin m → α) × (Fin n → α) ≃ (Fin (m + n) → α) where

--- a/Mathlib/Topology/Homeomorph.lean
+++ b/Mathlib/Topology/Homeomorph.lean
@@ -701,6 +701,25 @@ def ulift.{u, v} {X : Type u} [TopologicalSpace X] : ULift.{v, u} X ≃ₜ X whe
   continuous_invFun := continuous_uLift_up
   toEquiv := Equiv.ulift
 
+/-- `Equiv.sumArrowEquivProdArrow` as a homeomorphism. The natural homeomoorphism
+`(ι ⊕ ι' → X) ≃ₜ (ι → X) × (ι' → X)` -/
+def sumArrowEquivProdArrow {ι ι' : Type*} : (ι ⊕ ι' → X) ≃ₜ (ι → X) × (ι' → X)  where
+  toEquiv := Equiv.sumArrowEquivProdArrow _ _ _
+  continuous_toFun := by
+    simp only [Equiv.sumArrowEquivProdArrow, Equiv.coe_fn_mk, continuous_prod_mk]
+    continuity
+  continuous_invFun := continuous_pi fun i ↦ match i with
+    | .inl i => by apply (continuous_apply _).comp' continuous_fst
+    | .inr i => by apply (continuous_apply _).comp' continuous_snd
+
+/-- An equivalence `ι ≃ ι'` yields the homeomorphism `(ι → X) ≃ₜ (ι' → X)`.-/
+def arrowCongrLeft {ι ι' : Type*} (e : ι ≃ ι') : (ι → X) ≃ₜ (ι' → X) :=
+  piCongrLeft (Y := fun _ ↦ X) e
+
+/-- The natural homeomorphism between `(Fin m → X) × (Fin n → X)` and `(Fin (m + n) → X)`.-/
+def finArrowProdHomeomorphFinAddArrow (m n : ℕ) : (Fin m → X) × (Fin n → X) ≃ₜ (Fin (m + n) → X) :=
+  (sumArrowEquivProdArrow).symm.trans (arrowCongrLeft finSumFinEquiv)
+
 section Distrib
 
 /-- `(X ⊕ Y) × Z` is homeomorphic to `X × Z ⊕ Y × Z`. -/

--- a/Mathlib/Topology/Homeomorph.lean
+++ b/Mathlib/Topology/Homeomorph.lean
@@ -712,13 +712,9 @@ def sumArrowEquivProdArrow {ι ι' : Type*} : (ι ⊕ ι' → X) ≃ₜ (ι → 
     | .inl i => by apply (continuous_apply _).comp' continuous_fst
     | .inr i => by apply (continuous_apply _).comp' continuous_snd
 
-/-- An equivalence `ι ≃ ι'` yields the homeomorphism `(ι → X) ≃ₜ (ι' → X)`.-/
-def arrowCongrLeft {ι ι' : Type*} (e : ι ≃ ι') : (ι → X) ≃ₜ (ι' → X) :=
-  piCongrLeft (Y := fun _ ↦ X) e
-
 /-- The natural homeomorphism between `(Fin m → X) × (Fin n → X)` and `(Fin (m + n) → X)`.-/
 def finArrowProdHomeomorphFinAddArrow (m n : ℕ) : (Fin m → X) × (Fin n → X) ≃ₜ (Fin (m + n) → X) :=
-  (sumArrowEquivProdArrow).symm.trans (arrowCongrLeft finSumFinEquiv)
+  (sumArrowEquivProdArrow).symm.trans (piCongrLeft (Y := fun _ ↦ X) finSumFinEquiv)
 
 section Distrib
 

--- a/Mathlib/Topology/Homeomorph.lean
+++ b/Mathlib/Topology/Homeomorph.lean
@@ -712,18 +712,33 @@ def sumArrowEquivProdArrow {ι ι' : Type*} : (ι ⊕ ι' → X) ≃ₜ (ι → 
     | .inl i => by apply (continuous_apply _).comp' continuous_fst
     | .inr i => by apply (continuous_apply _).comp' continuous_snd
 
-/-- The natural homeomorphism between `(Fin m → X) × (Fin n → X)` and `(Fin (m + n) → X)`.-/
-def _root_.Fin.appendHomeomorph (m n : ℕ) : (Fin m → X) × (Fin n → X) ≃ₜ (Fin (m + n) → X) :=
-  (sumArrowEquivProdArrow).symm.trans (piCongrLeft (Y := fun _ ↦ X) finSumFinEquiv)
-
-theorem _root_.Fin.appendHomeomorph_eq_appendEquiv (m n : ℕ) :
-    (Fin.appendHomeomorph (X := X) m n).toEquiv = Fin.appendEquiv m n := by
+private theorem _root_.Fin.appendEquiv_eq_Homeomorph (m n : ℕ) : Fin.appendEquiv m n =
+    ((sumArrowEquivProdArrow).symm.trans
+    (piCongrLeft (Y := fun _ ↦ X) finSumFinEquiv)).toEquiv := by
   ext ⟨x1, x2⟩ l
-  simp only [Fin.appendHomeomorph, sumArrowEquivProdArrow, Equiv.sumArrowEquivProdArrow,
+  simp only [sumArrowEquivProdArrow, Equiv.sumArrowEquivProdArrow,
     finSumFinEquiv, Fin.addCases, Fin.appendEquiv, Fin.append, Equiv.coe_fn_mk]
   by_cases h : l < m
   · simp [h]
   · simp [h]
+
+theorem _root_.Fin.continuous_append (m n : ℕ) :
+    Continuous fun (p : (Fin m → X) × (Fin n → X)) ↦ Fin.append p.1 p.2 := by
+  suffices Continuous (Fin.appendEquiv m n) by exact this
+  rw [Fin.appendEquiv_eq_Homeomorph]
+  exact Homeomorph.continuous_toFun _
+
+/-- The natural homeomorphism between `(Fin m → X) × (Fin n → X)` and `(Fin (m + n) → X)`.-/
+def _root_.Fin.appendHomeomorph (m n : ℕ) : (Fin m → X) × (Fin n → X) ≃ₜ (Fin (m + n) → X) where
+  toEquiv := Fin.appendEquiv m n
+  continuous_toFun := Fin.continuous_append m n
+  continuous_invFun := by
+    rw [Fin.appendEquiv_eq_Homeomorph]
+    exact Homeomorph.continuous_invFun _
+
+theorem _root_.Fin.appendHomeomorph_eq_appendEquiv (m n : ℕ) :
+    (Fin.appendHomeomorph (X := X) m n).toEquiv = Fin.appendEquiv m n :=
+  rfl
 
 section Distrib
 

--- a/Mathlib/Topology/Homeomorph.lean
+++ b/Mathlib/Topology/Homeomorph.lean
@@ -739,7 +739,8 @@ def _root_.Fin.appendHomeomorph (m n : ℕ) : (Fin m → X) × (Fin n → X) ≃
     rw [Fin.appendEquiv_eq_Homeomorph]
     exact Homeomorph.continuous_invFun _
 
-theorem _root_.Fin.appendHomeomorph_eq_appendEquiv (m n : ℕ) :
+@[simp]
+theorem _root_.Fin.appendHomeomorph_toEquiv (m n : ℕ) :
     (Fin.appendHomeomorph (X := X) m n).toEquiv = Fin.appendEquiv m n :=
   rfl
 

--- a/Mathlib/Topology/Homeomorph.lean
+++ b/Mathlib/Topology/Homeomorph.lean
@@ -703,6 +703,7 @@ def ulift.{u, v} {X : Type u} [TopologicalSpace X] : ULift.{v, u} X ≃ₜ X whe
 
 /-- `Equiv.sumArrowEquivProdArrow` as a homeomorphism. The natural homeomorphism
 `(ι ⊕ ι' → X) ≃ₜ (ι → X) × (ι' → X)` -/
+@[simps!]
 def sumArrowHomeomorphProdArrow {ι ι' : Type*} : (ι ⊕ ι' → X) ≃ₜ (ι → X) × (ι' → X)  where
   toEquiv := Equiv.sumArrowEquivProdArrow _ _ _
   continuous_toFun := by
@@ -729,6 +730,7 @@ theorem _root_.Fin.continuous_append (m n : ℕ) :
   exact Homeomorph.continuous_toFun _
 
 /-- The natural homeomorphism between `(Fin m → X) × (Fin n → X)` and `(Fin (m + n) → X)`.-/
+@[simps!]
 def _root_.Fin.appendHomeomorph (m n : ℕ) : (Fin m → X) × (Fin n → X) ≃ₜ (Fin (m + n) → X) where
   toEquiv := Fin.appendEquiv m n
   continuous_toFun := Fin.continuous_append m n

--- a/Mathlib/Topology/Homeomorph.lean
+++ b/Mathlib/Topology/Homeomorph.lean
@@ -716,6 +716,15 @@ def sumArrowEquivProdArrow {ι ι' : Type*} : (ι ⊕ ι' → X) ≃ₜ (ι → 
 def _root_.Fin.appendHomeomorph (m n : ℕ) : (Fin m → X) × (Fin n → X) ≃ₜ (Fin (m + n) → X) :=
   (sumArrowEquivProdArrow).symm.trans (piCongrLeft (Y := fun _ ↦ X) finSumFinEquiv)
 
+theorem _root_.Fin.appendHomeomorph_eq_appendEquiv (m n : ℕ) :
+    (Fin.appendHomeomorph (X := X) m n).toEquiv = Fin.appendEquiv m n := by
+  ext ⟨x1, x2⟩ l
+  simp only [Fin.appendHomeomorph, sumArrowEquivProdArrow, Equiv.sumArrowEquivProdArrow,
+    finSumFinEquiv, Fin.addCases, Fin.appendEquiv, Fin.append, Equiv.coe_fn_mk]
+  by_cases h : l < m
+  · simp [h]
+  · simp [h]
+
 section Distrib
 
 /-- `(X ⊕ Y) × Z` is homeomorphic to `X × Z ⊕ Y × Z`. -/

--- a/Mathlib/Topology/Homeomorph.lean
+++ b/Mathlib/Topology/Homeomorph.lean
@@ -701,7 +701,7 @@ def ulift.{u, v} {X : Type u} [TopologicalSpace X] : ULift.{v, u} X ≃ₜ X whe
   continuous_invFun := continuous_uLift_up
   toEquiv := Equiv.ulift
 
-/-- `Equiv.sumArrowEquivProdArrow` as a homeomorphism. The natural homeomoorphism
+/-- `Equiv.sumArrowEquivProdArrow` as a homeomorphism. The natural homeomorphism
 `(ι ⊕ ι' → X) ≃ₜ (ι → X) × (ι' → X)` -/
 def sumArrowEquivProdArrow {ι ι' : Type*} : (ι ⊕ ι' → X) ≃ₜ (ι → X) × (ι' → X)  where
   toEquiv := Equiv.sumArrowEquivProdArrow _ _ _

--- a/Mathlib/Topology/Homeomorph.lean
+++ b/Mathlib/Topology/Homeomorph.lean
@@ -713,7 +713,7 @@ def sumArrowEquivProdArrow {ι ι' : Type*} : (ι ⊕ ι' → X) ≃ₜ (ι → 
     | .inr i => by apply (continuous_apply _).comp' continuous_snd
 
 /-- The natural homeomorphism between `(Fin m → X) × (Fin n → X)` and `(Fin (m + n) → X)`.-/
-def finArrowProdHomeomorphFinAddArrow (m n : ℕ) : (Fin m → X) × (Fin n → X) ≃ₜ (Fin (m + n) → X) :=
+def _root_.Fin.appendHomeomorph (m n : ℕ) : (Fin m → X) × (Fin n → X) ≃ₜ (Fin (m + n) → X) :=
   (sumArrowEquivProdArrow).symm.trans (piCongrLeft (Y := fun _ ↦ X) finSumFinEquiv)
 
 section Distrib

--- a/Mathlib/Topology/Homeomorph.lean
+++ b/Mathlib/Topology/Homeomorph.lean
@@ -703,7 +703,7 @@ def ulift.{u, v} {X : Type u} [TopologicalSpace X] : ULift.{v, u} X ≃ₜ X whe
 
 /-- `Equiv.sumArrowEquivProdArrow` as a homeomorphism. The natural homeomorphism
 `(ι ⊕ ι' → X) ≃ₜ (ι → X) × (ι' → X)` -/
-def sumArrowEquivProdArrow {ι ι' : Type*} : (ι ⊕ ι' → X) ≃ₜ (ι → X) × (ι' → X)  where
+def sumArrowHomeomorphProdArrow {ι ι' : Type*} : (ι ⊕ ι' → X) ≃ₜ (ι → X) × (ι' → X)  where
   toEquiv := Equiv.sumArrowEquivProdArrow _ _ _
   continuous_toFun := by
     simp only [Equiv.sumArrowEquivProdArrow, Equiv.coe_fn_mk, continuous_prod_mk]
@@ -713,10 +713,10 @@ def sumArrowEquivProdArrow {ι ι' : Type*} : (ι ⊕ ι' → X) ≃ₜ (ι → 
     | .inr i => by apply (continuous_apply _).comp' continuous_snd
 
 private theorem _root_.Fin.appendEquiv_eq_Homeomorph (m n : ℕ) : Fin.appendEquiv m n =
-    ((sumArrowEquivProdArrow).symm.trans
+    ((sumArrowHomeomorphProdArrow).symm.trans
     (piCongrLeft (Y := fun _ ↦ X) finSumFinEquiv)).toEquiv := by
   ext ⟨x1, x2⟩ l
-  simp only [sumArrowEquivProdArrow, Equiv.sumArrowEquivProdArrow,
+  simp only [sumArrowHomeomorphProdArrow, Equiv.sumArrowEquivProdArrow,
     finSumFinEquiv, Fin.addCases, Fin.appendEquiv, Fin.append, Equiv.coe_fn_mk]
   by_cases h : l < m
   · simp [h]

--- a/Mathlib/Topology/Homeomorph.lean
+++ b/Mathlib/Topology/Homeomorph.lean
@@ -701,8 +701,8 @@ def ulift.{u, v} {X : Type u} [TopologicalSpace X] : ULift.{v, u} X ≃ₜ X whe
   continuous_invFun := continuous_uLift_up
   toEquiv := Equiv.ulift
 
-/-- `Equiv.sumArrowEquivProdArrow` as a homeomorphism. The natural homeomorphism
-`(ι ⊕ ι' → X) ≃ₜ (ι → X) × (ι' → X)` -/
+/-- The natural homeomorphism `(ι ⊕ ι' → X) ≃ₜ (ι → X) × (ι' → X)`.
+`Equiv.sumArrowEquivProdArrow` as a homeomorphism. -/
 @[simps!]
 def sumArrowHomeomorphProdArrow {ι ι' : Type*} : (ι ⊕ ι' → X) ≃ₜ (ι → X) × (ι' → X)  where
   toEquiv := Equiv.sumArrowEquivProdArrow _ _ _
@@ -729,7 +729,8 @@ theorem _root_.Fin.continuous_append (m n : ℕ) :
   rw [Fin.appendEquiv_eq_Homeomorph]
   exact Homeomorph.continuous_toFun _
 
-/-- The natural homeomorphism between `(Fin m → X) × (Fin n → X)` and `(Fin (m + n) → X)`.-/
+/-- The natural homeomorphism between `(Fin m → X) × (Fin n → X)` and `Fin (m + n) → X`.
+`Fin.appendEquiv` as a homeomorphism.-/
 @[simps!]
 def _root_.Fin.appendHomeomorph (m n : ℕ) : (Fin m → X) × (Fin n → X) ≃ₜ (Fin (m + n) → X) where
   toEquiv := Fin.appendEquiv m n

--- a/Mathlib/Topology/MetricSpace/Isometry.lean
+++ b/Mathlib/Topology/MetricSpace/Isometry.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Sébastien Gouëzel
 -/
 import Mathlib.Topology.MetricSpace.Antilipschitz
+import Mathlib.Data.Fintype.Lattice
 
 /-!
 # Isometries
@@ -482,6 +483,39 @@ theorem completeSpace_iff (e : α ≃ᵢ β) : CompleteSpace α ↔ CompleteSpac
 
 protected theorem completeSpace [CompleteSpace β] (e : α ≃ᵢ β) : CompleteSpace α :=
   e.completeSpace_iff.2 ‹_›
+
+/-- `Equiv.piCongrLeft` as an `IsometryEquiv`: this is the natural
+`∀ i, Y i ≃ᵢ ∀ j, Y (e.symm j)` obtained from a bijection `ι ≃ ι'` of finite types.-/
+def piCongrLeftofFintype' {ι' : Type*} [Fintype ι] [Fintype ι'] {Y : ι → Type*}
+    [∀ j, PseudoEMetricSpace (Y j)] (e : ι ≃ ι') : (∀ i, Y i) ≃ᵢ ∀ j, Y (e.symm j) :=
+  mk (Equiv.piCongrLeft' _ e) (by
+    intro x1 x2
+    simp_rw [PseudoEMetricSpace.toEDist, pseudoEMetricSpacePi, instEDistForall,
+      Finset.sup_univ_eq_iSup]
+    exact (Equiv.iSup_comp (g := fun b ↦ edist (x1 b) (x2 b)) e.symm))
+
+/-- `Equiv.piCongrLeft` as an `IsometryEquiv`: this is the natural
+`∀ i, Y (e i) ≃ᵢ ∀ j, Y j` obtained from a bijection `ι ≃ ι'` of finite types.-/
+def piCongrLeftofFintype {ι' : Type*} [Fintype ι] [Fintype ι'] {Y : ι' → Type*}
+    [∀ j, PseudoEMetricSpace (Y j)] (e : ι ≃ ι') : (∀ i, Y (e i)) ≃ᵢ ∀ j, Y j :=
+  (piCongrLeftofFintype' e.symm).symm
+
+/-- An equivalence `ι ≃ ι'` of finite types yields the `IsometryEquiv` `(ι → α) ≃ᵢ (ι' → α)`. -/
+def arrowCongrLeftofFintype {ι' : Type*} [Fintype ι] [Fintype ι'] (e : ι ≃ ι') :
+    (ι → α) ≃ᵢ (ι' → α) :=
+  piCongrLeftofFintype (Y := fun _ ↦ α) e
+
+/-- `Equiv.sumArrowEquivProdArrow` as an `IsometryEquiv`.-/
+def sumArrowEquivProdArrowofFintype [Fintype α] [Fintype β] : (α ⊕ β → γ) ≃ᵢ (α → γ) × (β → γ) :=
+  mk (Equiv.sumArrowEquivProdArrow _ _ _) (by
+    intro f1 f2
+    simp_rw [PseudoEMetricSpace.toEDist, Prod.pseudoEMetricSpaceMax, pseudoEMetricSpacePi,
+      instEDistForall, Finset.sup_univ_eq_iSup, iSup_sum]
+    rfl)
+
+/-- The natural `IsometryEquiv` between `(Fin m → α) × (Fin n → α)` and `(Fin (m + n) → α)`.-/
+def finArrowProdHomeomorphFinAddArrow (m n : ℕ) : (Fin m → α) × (Fin n → α) ≃ᵢ (Fin (m + n) → α) :=
+  sumArrowEquivProdArrowofFintype.symm.trans (arrowCongrLeftofFintype finSumFinEquiv)
 
 variable (ι α)
 

--- a/Mathlib/Topology/MetricSpace/Isometry.lean
+++ b/Mathlib/Topology/MetricSpace/Isometry.lean
@@ -500,11 +500,6 @@ def piCongrLeftofFintype {ι' : Type*} [Fintype ι] [Fintype ι'] {Y : ι' → T
     [∀ j, PseudoEMetricSpace (Y j)] (e : ι ≃ ι') : (∀ i, Y (e i)) ≃ᵢ ∀ j, Y j :=
   (piCongrLeftofFintype' e.symm).symm
 
-/-- An equivalence `ι ≃ ι'` of finite types yields the `IsometryEquiv` `(ι → α) ≃ᵢ (ι' → α)`. -/
-def arrowCongrLeftofFintype {ι' : Type*} [Fintype ι] [Fintype ι'] (e : ι ≃ ι') :
-    (ι → α) ≃ᵢ (ι' → α) :=
-  piCongrLeftofFintype (Y := fun _ ↦ α) e
-
 /-- `Equiv.sumArrowEquivProdArrow` as an `IsometryEquiv`.-/
 def sumArrowEquivProdArrowofFintype [Fintype α] [Fintype β] : (α ⊕ β → γ) ≃ᵢ (α → γ) × (β → γ) :=
   mk (Equiv.sumArrowEquivProdArrow _ _ _) (by
@@ -515,7 +510,7 @@ def sumArrowEquivProdArrowofFintype [Fintype α] [Fintype β] : (α ⊕ β → �
 
 /-- The natural `IsometryEquiv` between `(Fin m → α) × (Fin n → α)` and `(Fin (m + n) → α)`.-/
 def finArrowProdHomeomorphFinAddArrow (m n : ℕ) : (Fin m → α) × (Fin n → α) ≃ᵢ (Fin (m + n) → α) :=
-  sumArrowEquivProdArrowofFintype.symm.trans (arrowCongrLeftofFintype finSumFinEquiv)
+  sumArrowEquivProdArrowofFintype.symm.trans (piCongrLeftofFintype (Y := fun _ ↦ α) finSumFinEquiv)
 
 variable (ι α)
 

--- a/Mathlib/Topology/MetricSpace/Isometry.lean
+++ b/Mathlib/Topology/MetricSpace/Isometry.lean
@@ -484,9 +484,9 @@ theorem completeSpace_iff (e : α ≃ᵢ β) : CompleteSpace α ↔ CompleteSpac
 protected theorem completeSpace [CompleteSpace β] (e : α ≃ᵢ β) : CompleteSpace α :=
   e.completeSpace_iff.2 ‹_›
 
-/-- `Equiv.piCongrLeft` as an `IsometryEquiv`: this is the natural
+/-- `Equiv.piCongrLeft'` as an `IsometryEquiv`: this is the natural
 `∀ i, Y i ≃ᵢ ∀ j, Y (e.symm j)` obtained from a bijection `ι ≃ ι'` of finite types.-/
-def piCongrLeftofFintype' {ι' : Type*} [Fintype ι] [Fintype ι'] {Y : ι → Type*}
+def piCongrLeft' {ι' : Type*} [Fintype ι] [Fintype ι'] {Y : ι → Type*}
     [∀ j, PseudoEMetricSpace (Y j)] (e : ι ≃ ι') : (∀ i, Y i) ≃ᵢ ∀ j, Y (e.symm j) :=
   mk (Equiv.piCongrLeft' _ e) (by
     intro x1 x2
@@ -496,12 +496,12 @@ def piCongrLeftofFintype' {ι' : Type*} [Fintype ι] [Fintype ι'] {Y : ι → T
 
 /-- `Equiv.piCongrLeft` as an `IsometryEquiv`: this is the natural
 `∀ i, Y (e i) ≃ᵢ ∀ j, Y j` obtained from a bijection `ι ≃ ι'` of finite types.-/
-def piCongrLeftofFintype {ι' : Type*} [Fintype ι] [Fintype ι'] {Y : ι' → Type*}
+def piCongrLeft {ι' : Type*} [Fintype ι] [Fintype ι'] {Y : ι' → Type*}
     [∀ j, PseudoEMetricSpace (Y j)] (e : ι ≃ ι') : (∀ i, Y (e i)) ≃ᵢ ∀ j, Y j :=
-  (piCongrLeftofFintype' e.symm).symm
+  (piCongrLeft' e.symm).symm
 
 /-- `Equiv.sumArrowEquivProdArrow` as an `IsometryEquiv`.-/
-def sumArrowEquivProdArrowofFintype [Fintype α] [Fintype β] : (α ⊕ β → γ) ≃ᵢ (α → γ) × (β → γ) :=
+def sumArrowEquivProdArrow [Fintype α] [Fintype β] : (α ⊕ β → γ) ≃ᵢ (α → γ) × (β → γ) :=
   mk (Equiv.sumArrowEquivProdArrow _ _ _) (by
     intro f1 f2
     simp_rw [PseudoEMetricSpace.toEDist, Prod.pseudoEMetricSpaceMax, pseudoEMetricSpacePi,
@@ -510,7 +510,7 @@ def sumArrowEquivProdArrowofFintype [Fintype α] [Fintype β] : (α ⊕ β → �
 
 /-- The natural `IsometryEquiv` between `(Fin m → α) × (Fin n → α)` and `(Fin (m + n) → α)`.-/
 def finArrowProdHomeomorphFinAddArrow (m n : ℕ) : (Fin m → α) × (Fin n → α) ≃ᵢ (Fin (m + n) → α) :=
-  sumArrowEquivProdArrowofFintype.symm.trans (piCongrLeftofFintype (Y := fun _ ↦ α) finSumFinEquiv)
+  sumArrowEquivProdArrow.symm.trans (piCongrLeft (Y := fun _ ↦ α) finSumFinEquiv)
 
 variable (ι α)
 

--- a/Mathlib/Topology/MetricSpace/Isometry.lean
+++ b/Mathlib/Topology/MetricSpace/Isometry.lean
@@ -510,14 +510,18 @@ def sumArrowEquivProdArrow [Fintype α] [Fintype β] : (α ⊕ β → γ) ≃ᵢ
     simp [PseudoEMetricSpace.toEDist, Prod.pseudoEMetricSpaceMax, pseudoEMetricSpacePi,
       instEDistForall, Finset.sup_univ_eq_iSup, iSup_sum])
 
+lemma _root_.Fin.edist_append_eq_max_edist (m n : ℕ) {x x2 : Fin m → α} {y y2: Fin n → α } :
+    edist (Fin.append x y) (Fin.append x2 y2) = max (edist x x2) (edist y y2) := by
+  simp [instEDistForall, Finset.sup_univ_eq_iSup, ← Equiv.iSup_comp (e := finSumFinEquiv),
+    Prod.pseudoEMetricSpaceMax, iSup_sum]
+
 /-- The natural `IsometryEquiv` between `(Fin m → α) × (Fin n → α)` and `(Fin (m + n) → α)`.-/
 @[simps!]
-def finArrowProdHomeomorphFinAddArrow (m n : ℕ) : (Fin m → α) × (Fin n → α) ≃ᵢ (Fin (m + n) → α) :=
+def _root_.Fin.appendIsometry (m n : ℕ) : (Fin m → α) × (Fin n → α) ≃ᵢ (Fin (m + n) → α) :=
   mk (Fin.appendEquiv _ _) (by
-    intro
-    simp [PseudoEMetricSpace.toEDist, pseudoEMetricSpacePi, instEDistForall,
-      Finset.sup_univ_eq_iSup, ← Equiv.iSup_comp (e := finSumFinEquiv), Prod.pseudoEMetricSpaceMax,
-      iSup_sum])
+    intro _ _
+    simp_rw [Fin.appendEquiv, Fin.edist_append_eq_max_edist, Prod.pseudoEMetricSpaceMax,
+      sup_eq_max])
 
 variable (ι α)
 

--- a/Mathlib/Topology/MetricSpace/Isometry.lean
+++ b/Mathlib/Topology/MetricSpace/Isometry.lean
@@ -510,7 +510,7 @@ def sumArrowEquivProdArrow [Fintype α] [Fintype β] : (α ⊕ β → γ) ≃ᵢ
     simp [PseudoEMetricSpace.toEDist, Prod.pseudoEMetricSpaceMax, pseudoEMetricSpacePi,
       instEDistForall, Finset.sup_univ_eq_iSup, iSup_sum])
 
-lemma _root_.Fin.edist_append_eq_max_edist (m n : ℕ) {x x2 : Fin m → α} {y y2: Fin n → α } :
+lemma _root_.Fin.edist_append_eq_max_edist (m n : ℕ) {x x2 : Fin m → α} {y y2 : Fin n → α} :
     edist (Fin.append x y) (Fin.append x2 y2) = max (edist x x2) (edist y y2) := by
   simp [instEDistForall, Finset.sup_univ_eq_iSup, ← Equiv.iSup_comp (e := finSumFinEquiv),
     Prod.pseudoEMetricSpaceMax, iSup_sum]

--- a/Mathlib/Topology/MetricSpace/Isometry.lean
+++ b/Mathlib/Topology/MetricSpace/Isometry.lean
@@ -507,7 +507,12 @@ def sumArrowEquivProdArrow [Fintype α] [Fintype β] : (α ⊕ β → γ) ≃ᵢ
   toEquiv := Equiv.sumArrowEquivProdArrow _ _ _
   isometry_toFun _ _ := by simp [Prod.edist_eq, edist_pi_def, Finset.sup_univ_eq_iSup, iSup_sum]
 
-lemma _root_.Fin.edist_append_eq_max_edist (m n : ℕ) {x x2 : Fin m → α} {y y2 : Fin n → α} :
+theorem sumArrowEquivProdArrow_eq_homeomorph {α β : Type*} [Fintype α] [Fintype β] :
+    sumArrowEquivProdArrow.toHomeomorph
+    = Homeomorph.sumArrowEquivProdArrow (ι := α) (ι' := β) (X := γ):= by
+  rfl
+
+theorem _root_.Fin.edist_append_eq_max_edist (m n : ℕ) {x x2 : Fin m → α} {y y2 : Fin n → α} :
     edist (Fin.append x y) (Fin.append x2 y2) = max (edist x x2) (edist y y2) := by
   simp [edist_pi_def, Finset.sup_univ_eq_iSup, ← Equiv.iSup_comp (e := finSumFinEquiv),
     Prod.edist_eq, iSup_sum]
@@ -517,6 +522,15 @@ lemma _root_.Fin.edist_append_eq_max_edist (m n : ℕ) {x x2 : Fin m → α} {y 
 def _root_.Fin.appendIsometry (m n : ℕ) : (Fin m → α) × (Fin n → α) ≃ᵢ (Fin (m + n) → α) where
   toEquiv := Fin.appendEquiv _ _
   isometry_toFun _ _ := by simp_rw [Fin.appendEquiv, Fin.edist_append_eq_max_edist, Prod.edist_eq]
+
+theorem _root_.Fin.appendIsometry_eq_appendHomeomorph (m n : ℕ) :
+    (Fin.appendIsometry m n).toHomeomorph = Fin.appendHomeomorph (X := α) m n := by
+  ext ⟨x1, x2⟩ l
+  simp only [coe_toHomeomorph, Fin.appendIsometry_toFun, Fin.append, Fin.addCases,
+    Fin.appendHomeomorph, Homeomorph.sumArrowEquivProdArrow, finSumFinEquiv]
+  by_cases h : l < m
+  · simp [h]
+  · simp [h]
 
 variable (ι α)
 

--- a/Mathlib/Topology/MetricSpace/Isometry.lean
+++ b/Mathlib/Topology/MetricSpace/Isometry.lean
@@ -509,6 +509,7 @@ def sumArrowIsometryEquivProdArrow [Fintype α] [Fintype β] : (α ⊕ β → γ
   toEquiv := Equiv.sumArrowEquivProdArrow _ _ _
   isometry_toFun _ _ := by simp [Prod.edist_eq, edist_pi_def, Finset.sup_univ_eq_iSup, iSup_sum]
 
+@[simp]
 theorem sumArrowIsometryEquivProdArrow_toHomeomorph {α β : Type*} [Fintype α] [Fintype β] :
     sumArrowIsometryEquivProdArrow.toHomeomorph
     = Homeomorph.sumArrowHomeomorphProdArrow (ι := α) (ι' := β) (X := γ) :=

--- a/Mathlib/Topology/MetricSpace/Isometry.lean
+++ b/Mathlib/Topology/MetricSpace/Isometry.lean
@@ -503,12 +503,12 @@ def piCongrLeft {ι' : Type*} [Fintype ι] [Fintype ι'] {Y : ι' → Type*}
 
 /-- `Equiv.sumArrowEquivProdArrow` as an `IsometryEquiv`.-/
 @[simps!]
-def sumArrowEquivProdArrow [Fintype α] [Fintype β] : (α ⊕ β → γ) ≃ᵢ (α → γ) × (β → γ) where
+def sumArrowIsometryEquivProdArrow [Fintype α] [Fintype β] : (α ⊕ β → γ) ≃ᵢ (α → γ) × (β → γ) where
   toEquiv := Equiv.sumArrowEquivProdArrow _ _ _
   isometry_toFun _ _ := by simp [Prod.edist_eq, edist_pi_def, Finset.sup_univ_eq_iSup, iSup_sum]
 
-theorem sumArrowEquivProdArrow_eq_homeomorph {α β : Type*} [Fintype α] [Fintype β] :
-    sumArrowEquivProdArrow.toHomeomorph
+theorem sumArrowIsometryEquivProdArrow_eq_homeomorph {α β : Type*} [Fintype α] [Fintype β] :
+    sumArrowIsometryEquivProdArrow.toHomeomorph
     = Homeomorph.sumArrowEquivProdArrow (ι := α) (ι' := β) (X := γ) :=
   rfl
 

--- a/Mathlib/Topology/MetricSpace/Isometry.lean
+++ b/Mathlib/Topology/MetricSpace/Isometry.lean
@@ -485,8 +485,7 @@ protected theorem completeSpace [CompleteSpace β] (e : α ≃ᵢ β) : Complete
   e.completeSpace_iff.2 ‹_›
 
 /-- The natural isometry `∀ i, Y i ≃ᵢ ∀ j, Y (e.symm j)` obtained from a bijection `ι ≃ ι'` of
-fintypes.
-`Equiv.piCongrLeft'` as an `IsometryEquiv`.-/
+fintypes. `Equiv.piCongrLeft'` as an `IsometryEquiv`.-/
 @[simps!]
 def piCongrLeft' {ι' : Type*} [Fintype ι] [Fintype ι'] {Y : ι → Type*}
     [∀ j, PseudoEMetricSpace (Y j)] (e : ι ≃ ι') : (∀ i, Y i) ≃ᵢ ∀ j, Y (e.symm j) where
@@ -510,7 +509,7 @@ def sumArrowIsometryEquivProdArrow [Fintype α] [Fintype β] : (α ⊕ β → γ
   toEquiv := Equiv.sumArrowEquivProdArrow _ _ _
   isometry_toFun _ _ := by simp [Prod.edist_eq, edist_pi_def, Finset.sup_univ_eq_iSup, iSup_sum]
 
-theorem sumArrowIsometryEquivProdArrow_eq_homeomorph {α β : Type*} [Fintype α] [Fintype β] :
+theorem sumArrowIsometryEquivProdArrow_toHomeomorph {α β : Type*} [Fintype α] [Fintype β] :
     sumArrowIsometryEquivProdArrow.toHomeomorph
     = Homeomorph.sumArrowHomeomorphProdArrow (ι := α) (ι' := β) (X := γ) :=
   rfl
@@ -527,7 +526,8 @@ def _root_.Fin.appendIsometry (m n : ℕ) : (Fin m → α) × (Fin n → α) ≃
   toEquiv := Fin.appendEquiv _ _
   isometry_toFun _ _ := by simp_rw [Fin.appendEquiv, Fin.edist_append_eq_max_edist, Prod.edist_eq]
 
-theorem _root_.Fin.appendIsometry_eq_appendHomeomorph (m n : ℕ) :
+@[simp]
+theorem _root_.Fin.appendIsometry_toHomeomorph (m n : ℕ) :
     (Fin.appendIsometry m n).toHomeomorph = Fin.appendHomeomorph (X := α) m n :=
   rfl
 

--- a/Mathlib/Topology/MetricSpace/Isometry.lean
+++ b/Mathlib/Topology/MetricSpace/Isometry.lean
@@ -509,7 +509,7 @@ def sumArrowIsometryEquivProdArrow [Fintype α] [Fintype β] : (α ⊕ β → γ
 
 theorem sumArrowIsometryEquivProdArrow_eq_homeomorph {α β : Type*} [Fintype α] [Fintype β] :
     sumArrowIsometryEquivProdArrow.toHomeomorph
-    = Homeomorph.sumArrowEquivProdArrow (ι := α) (ι' := β) (X := γ) :=
+    = Homeomorph.sumArrowHomeomorphProdArrow (ι := α) (ι' := β) (X := γ) :=
   rfl
 
 theorem _root_.Fin.edist_append_eq_max_edist (m n : ℕ) {x x2 : Fin m → α} {y y2 : Fin n → α} :

--- a/Mathlib/Topology/MetricSpace/Isometry.lean
+++ b/Mathlib/Topology/MetricSpace/Isometry.lean
@@ -509,7 +509,7 @@ def sumArrowEquivProdArrow [Fintype α] [Fintype β] : (α ⊕ β → γ) ≃ᵢ
 
 theorem sumArrowEquivProdArrow_eq_homeomorph {α β : Type*} [Fintype α] [Fintype β] :
     sumArrowEquivProdArrow.toHomeomorph
-    = Homeomorph.sumArrowEquivProdArrow (ι := α) (ι' := β) (X := γ):= by
+    = Homeomorph.sumArrowEquivProdArrow (ι := α) (ι' := β) (X := γ) :=
   rfl
 
 theorem _root_.Fin.edist_append_eq_max_edist (m n : ℕ) {x x2 : Fin m → α} {y y2 : Fin n → α} :
@@ -524,13 +524,8 @@ def _root_.Fin.appendIsometry (m n : ℕ) : (Fin m → α) × (Fin n → α) ≃
   isometry_toFun _ _ := by simp_rw [Fin.appendEquiv, Fin.edist_append_eq_max_edist, Prod.edist_eq]
 
 theorem _root_.Fin.appendIsometry_eq_appendHomeomorph (m n : ℕ) :
-    (Fin.appendIsometry m n).toHomeomorph = Fin.appendHomeomorph (X := α) m n := by
-  ext ⟨x1, x2⟩ l
-  simp only [coe_toHomeomorph, Fin.appendIsometry_toFun, Fin.append, Fin.addCases,
-    Fin.appendHomeomorph, Homeomorph.sumArrowEquivProdArrow, finSumFinEquiv]
-  by_cases h : l < m
-  · simp [h]
-  · simp [h]
+    (Fin.appendIsometry m n).toHomeomorph = Fin.appendHomeomorph (X := α) m n :=
+  rfl
 
 variable (ι α)
 

--- a/Mathlib/Topology/MetricSpace/Isometry.lean
+++ b/Mathlib/Topology/MetricSpace/Isometry.lean
@@ -488,11 +488,11 @@ protected theorem completeSpace [CompleteSpace β] (e : α ≃ᵢ β) : Complete
 `∀ i, Y i ≃ᵢ ∀ j, Y (e.symm j)` obtained from a bijection `ι ≃ ι'` of finite types.-/
 @[simps!]
 def piCongrLeft' {ι' : Type*} [Fintype ι] [Fintype ι'] {Y : ι → Type*}
-    [∀ j, PseudoEMetricSpace (Y j)] (e : ι ≃ ι') : (∀ i, Y i) ≃ᵢ ∀ j, Y (e.symm j) :=
-  mk (Equiv.piCongrLeft' _ e) (by
-    intro x1 x2
+    [∀ j, PseudoEMetricSpace (Y j)] (e : ι ≃ ι') : (∀ i, Y i) ≃ᵢ ∀ j, Y (e.symm j) where
+  toEquiv := Equiv.piCongrLeft' _ e
+  isometry_toFun x1 x2 := by
     simp_rw [edist_pi_def, Finset.sup_univ_eq_iSup]
-    exact (Equiv.iSup_comp (g := fun b ↦ edist (x1 b) (x2 b)) e.symm))
+    exact (Equiv.iSup_comp (g := fun b ↦ edist (x1 b) (x2 b)) e.symm)
 
 /-- `Equiv.piCongrLeft` as an `IsometryEquiv`: this is the natural
 `∀ i, Y (e i) ≃ᵢ ∀ j, Y j` obtained from a bijection `ι ≃ ι'` of finite types.-/
@@ -503,10 +503,9 @@ def piCongrLeft {ι' : Type*} [Fintype ι] [Fintype ι'] {Y : ι' → Type*}
 
 /-- `Equiv.sumArrowEquivProdArrow` as an `IsometryEquiv`.-/
 @[simps!]
-def sumArrowEquivProdArrow [Fintype α] [Fintype β] : (α ⊕ β → γ) ≃ᵢ (α → γ) × (β → γ) :=
-  mk (Equiv.sumArrowEquivProdArrow _ _ _) (by
-    intro
-    simp [Prod.edist_eq, edist_pi_def, Finset.sup_univ_eq_iSup, iSup_sum])
+def sumArrowEquivProdArrow [Fintype α] [Fintype β] : (α ⊕ β → γ) ≃ᵢ (α → γ) × (β → γ) where
+  toEquiv := Equiv.sumArrowEquivProdArrow _ _ _
+  isometry_toFun _ _ := by simp [Prod.edist_eq, edist_pi_def, Finset.sup_univ_eq_iSup, iSup_sum]
 
 lemma _root_.Fin.edist_append_eq_max_edist (m n : ℕ) {x x2 : Fin m → α} {y y2 : Fin n → α} :
     edist (Fin.append x y) (Fin.append x2 y2) = max (edist x x2) (edist y y2) := by
@@ -515,10 +514,9 @@ lemma _root_.Fin.edist_append_eq_max_edist (m n : ℕ) {x x2 : Fin m → α} {y 
 
 /-- The natural `IsometryEquiv` between `(Fin m → α) × (Fin n → α)` and `(Fin (m + n) → α)`.-/
 @[simps!]
-def _root_.Fin.appendIsometry (m n : ℕ) : (Fin m → α) × (Fin n → α) ≃ᵢ (Fin (m + n) → α) :=
-  mk (Fin.appendEquiv _ _) (by
-    intro _ _
-    simp_rw [Fin.appendEquiv, Fin.edist_append_eq_max_edist, Prod.edist_eq])
+def _root_.Fin.appendIsometry (m n : ℕ) : (Fin m → α) × (Fin n → α) ≃ᵢ (Fin (m + n) → α) where
+  toEquiv := Fin.appendEquiv _ _
+  isometry_toFun _ _ := by simp_rw [Fin.appendEquiv, Fin.edist_append_eq_max_edist, Prod.edist_eq]
 
 variable (ι α)
 

--- a/Mathlib/Topology/MetricSpace/Isometry.lean
+++ b/Mathlib/Topology/MetricSpace/Isometry.lean
@@ -503,15 +503,14 @@ def piCongrLeft {ι' : Type*} [Fintype ι] [Fintype ι'] {Y : ι' → Type*}
 /-- `Equiv.sumArrowEquivProdArrow` as an `IsometryEquiv`.-/
 def sumArrowEquivProdArrow [Fintype α] [Fintype β] : (α ⊕ β → γ) ≃ᵢ (α → γ) × (β → γ) :=
   mk (Equiv.sumArrowEquivProdArrow _ _ _) (by
-    intro f1 f2
-    simp_rw [PseudoEMetricSpace.toEDist, Prod.pseudoEMetricSpaceMax, pseudoEMetricSpacePi,
-      instEDistForall, Finset.sup_univ_eq_iSup, iSup_sum]
-    rfl)
+    intro
+    simp [PseudoEMetricSpace.toEDist, Prod.pseudoEMetricSpaceMax, pseudoEMetricSpacePi,
+      instEDistForall, Finset.sup_univ_eq_iSup, iSup_sum])
 
 /-- The natural `IsometryEquiv` between `(Fin m → α) × (Fin n → α)` and `(Fin (m + n) → α)`.-/
 def finArrowProdHomeomorphFinAddArrow (m n : ℕ) : (Fin m → α) × (Fin n → α) ≃ᵢ (Fin (m + n) → α) :=
   mk (Fin.appendEquiv _ _) (by
-    intro f1 f2
+    intro
     simp [PseudoEMetricSpace.toEDist, pseudoEMetricSpacePi, instEDistForall,
       Finset.sup_univ_eq_iSup, ← Equiv.iSup_comp (e := finSumFinEquiv), Prod.pseudoEMetricSpaceMax,
       iSup_sum])

--- a/Mathlib/Topology/MetricSpace/Isometry.lean
+++ b/Mathlib/Topology/MetricSpace/Isometry.lean
@@ -484,8 +484,9 @@ theorem completeSpace_iff (e : α ≃ᵢ β) : CompleteSpace α ↔ CompleteSpac
 protected theorem completeSpace [CompleteSpace β] (e : α ≃ᵢ β) : CompleteSpace α :=
   e.completeSpace_iff.2 ‹_›
 
-/-- `Equiv.piCongrLeft'` as an `IsometryEquiv`: this is the natural
-`∀ i, Y i ≃ᵢ ∀ j, Y (e.symm j)` obtained from a bijection `ι ≃ ι'` of finite types.-/
+/-- The natural isometry `∀ i, Y i ≃ᵢ ∀ j, Y (e.symm j)` obtained from a bijection `ι ≃ ι'` of
+fintypes.
+`Equiv.piCongrLeft'` as an `IsometryEquiv`.-/
 @[simps!]
 def piCongrLeft' {ι' : Type*} [Fintype ι] [Fintype ι'] {Y : ι → Type*}
     [∀ j, PseudoEMetricSpace (Y j)] (e : ι ≃ ι') : (∀ i, Y i) ≃ᵢ ∀ j, Y (e.symm j) where
@@ -494,14 +495,16 @@ def piCongrLeft' {ι' : Type*} [Fintype ι] [Fintype ι'] {Y : ι → Type*}
     simp_rw [edist_pi_def, Finset.sup_univ_eq_iSup]
     exact (Equiv.iSup_comp (g := fun b ↦ edist (x1 b) (x2 b)) e.symm)
 
-/-- `Equiv.piCongrLeft` as an `IsometryEquiv`: this is the natural
-`∀ i, Y (e i) ≃ᵢ ∀ j, Y j` obtained from a bijection `ι ≃ ι'` of finite types.-/
+/-- The natural isometry `∀ i, Y (e i) ≃ᵢ ∀ j, Y j` obtained from a bijection `ι ≃ ι'` of fintypes.
+`Equiv.piCongrLeft` as an `IsometryEquiv`. -/
 @[simps!]
 def piCongrLeft {ι' : Type*} [Fintype ι] [Fintype ι'] {Y : ι' → Type*}
     [∀ j, PseudoEMetricSpace (Y j)] (e : ι ≃ ι') : (∀ i, Y (e i)) ≃ᵢ ∀ j, Y j :=
   (piCongrLeft' e.symm).symm
 
-/-- `Equiv.sumArrowEquivProdArrow` as an `IsometryEquiv`.-/
+/-- The natural isometry `(α ⊕ β → γ) ≃ᵢ (α → γ) × (β → γ)` between the type of maps on a sum of
+fintypes `α ⊕ β` and the pairs of functions on the types `α` and `β`.
+`Equiv.sumArrowEquivProdArrow` as an `IsometryEquiv`.-/
 @[simps!]
 def sumArrowIsometryEquivProdArrow [Fintype α] [Fintype β] : (α ⊕ β → γ) ≃ᵢ (α → γ) × (β → γ) where
   toEquiv := Equiv.sumArrowEquivProdArrow _ _ _
@@ -517,7 +520,8 @@ theorem _root_.Fin.edist_append_eq_max_edist (m n : ℕ) {x x2 : Fin m → α} {
   simp [edist_pi_def, Finset.sup_univ_eq_iSup, ← Equiv.iSup_comp (e := finSumFinEquiv),
     Prod.edist_eq, iSup_sum]
 
-/-- The natural `IsometryEquiv` between `(Fin m → α) × (Fin n → α)` and `(Fin (m + n) → α)`.-/
+/-- The natural `IsometryEquiv` between `(Fin m → α) × (Fin n → α)` and `Fin (m + n) → α`.
+`Fin.appendEquiv` as an `IsometryEquiv`.-/
 @[simps!]
 def _root_.Fin.appendIsometry (m n : ℕ) : (Fin m → α) × (Fin n → α) ≃ᵢ (Fin (m + n) → α) where
   toEquiv := Fin.appendEquiv _ _

--- a/Mathlib/Topology/MetricSpace/Isometry.lean
+++ b/Mathlib/Topology/MetricSpace/Isometry.lean
@@ -491,8 +491,7 @@ def piCongrLeft' {ι' : Type*} [Fintype ι] [Fintype ι'] {Y : ι → Type*}
     [∀ j, PseudoEMetricSpace (Y j)] (e : ι ≃ ι') : (∀ i, Y i) ≃ᵢ ∀ j, Y (e.symm j) :=
   mk (Equiv.piCongrLeft' _ e) (by
     intro x1 x2
-    simp_rw [PseudoEMetricSpace.toEDist, pseudoEMetricSpacePi, instEDistForall,
-      Finset.sup_univ_eq_iSup]
+    simp_rw [edist_pi_def, Finset.sup_univ_eq_iSup]
     exact (Equiv.iSup_comp (g := fun b ↦ edist (x1 b) (x2 b)) e.symm))
 
 /-- `Equiv.piCongrLeft` as an `IsometryEquiv`: this is the natural
@@ -507,21 +506,19 @@ def piCongrLeft {ι' : Type*} [Fintype ι] [Fintype ι'] {Y : ι' → Type*}
 def sumArrowEquivProdArrow [Fintype α] [Fintype β] : (α ⊕ β → γ) ≃ᵢ (α → γ) × (β → γ) :=
   mk (Equiv.sumArrowEquivProdArrow _ _ _) (by
     intro
-    simp [PseudoEMetricSpace.toEDist, Prod.pseudoEMetricSpaceMax, pseudoEMetricSpacePi,
-      instEDistForall, Finset.sup_univ_eq_iSup, iSup_sum])
+    simp [Prod.edist_eq, edist_pi_def, Finset.sup_univ_eq_iSup, iSup_sum])
 
 lemma _root_.Fin.edist_append_eq_max_edist (m n : ℕ) {x x2 : Fin m → α} {y y2 : Fin n → α} :
     edist (Fin.append x y) (Fin.append x2 y2) = max (edist x x2) (edist y y2) := by
-  simp [instEDistForall, Finset.sup_univ_eq_iSup, ← Equiv.iSup_comp (e := finSumFinEquiv),
-    Prod.pseudoEMetricSpaceMax, iSup_sum]
+  simp [edist_pi_def, Finset.sup_univ_eq_iSup, ← Equiv.iSup_comp (e := finSumFinEquiv),
+    Prod.edist_eq, iSup_sum]
 
 /-- The natural `IsometryEquiv` between `(Fin m → α) × (Fin n → α)` and `(Fin (m + n) → α)`.-/
 @[simps!]
 def _root_.Fin.appendIsometry (m n : ℕ) : (Fin m → α) × (Fin n → α) ≃ᵢ (Fin (m + n) → α) :=
   mk (Fin.appendEquiv _ _) (by
     intro _ _
-    simp_rw [Fin.appendEquiv, Fin.edist_append_eq_max_edist, Prod.pseudoEMetricSpaceMax,
-      sup_eq_max])
+    simp_rw [Fin.appendEquiv, Fin.edist_append_eq_max_edist, Prod.edist_eq])
 
 variable (ι α)
 

--- a/Mathlib/Topology/MetricSpace/Isometry.lean
+++ b/Mathlib/Topology/MetricSpace/Isometry.lean
@@ -486,6 +486,7 @@ protected theorem completeSpace [CompleteSpace β] (e : α ≃ᵢ β) : Complete
 
 /-- `Equiv.piCongrLeft'` as an `IsometryEquiv`: this is the natural
 `∀ i, Y i ≃ᵢ ∀ j, Y (e.symm j)` obtained from a bijection `ι ≃ ι'` of finite types.-/
+@[simps!]
 def piCongrLeft' {ι' : Type*} [Fintype ι] [Fintype ι'] {Y : ι → Type*}
     [∀ j, PseudoEMetricSpace (Y j)] (e : ι ≃ ι') : (∀ i, Y i) ≃ᵢ ∀ j, Y (e.symm j) :=
   mk (Equiv.piCongrLeft' _ e) (by
@@ -496,11 +497,13 @@ def piCongrLeft' {ι' : Type*} [Fintype ι] [Fintype ι'] {Y : ι → Type*}
 
 /-- `Equiv.piCongrLeft` as an `IsometryEquiv`: this is the natural
 `∀ i, Y (e i) ≃ᵢ ∀ j, Y j` obtained from a bijection `ι ≃ ι'` of finite types.-/
+@[simps!]
 def piCongrLeft {ι' : Type*} [Fintype ι] [Fintype ι'] {Y : ι' → Type*}
     [∀ j, PseudoEMetricSpace (Y j)] (e : ι ≃ ι') : (∀ i, Y (e i)) ≃ᵢ ∀ j, Y j :=
   (piCongrLeft' e.symm).symm
 
 /-- `Equiv.sumArrowEquivProdArrow` as an `IsometryEquiv`.-/
+@[simps!]
 def sumArrowEquivProdArrow [Fintype α] [Fintype β] : (α ⊕ β → γ) ≃ᵢ (α → γ) × (β → γ) :=
   mk (Equiv.sumArrowEquivProdArrow _ _ _) (by
     intro
@@ -508,6 +511,7 @@ def sumArrowEquivProdArrow [Fintype α] [Fintype β] : (α ⊕ β → γ) ≃ᵢ
       instEDistForall, Finset.sup_univ_eq_iSup, iSup_sum])
 
 /-- The natural `IsometryEquiv` between `(Fin m → α) × (Fin n → α)` and `(Fin (m + n) → α)`.-/
+@[simps!]
 def finArrowProdHomeomorphFinAddArrow (m n : ℕ) : (Fin m → α) × (Fin n → α) ≃ᵢ (Fin (m + n) → α) :=
   mk (Fin.appendEquiv _ _) (by
     intro

--- a/Mathlib/Topology/MetricSpace/Isometry.lean
+++ b/Mathlib/Topology/MetricSpace/Isometry.lean
@@ -510,7 +510,11 @@ def sumArrowEquivProdArrow [Fintype α] [Fintype β] : (α ⊕ β → γ) ≃ᵢ
 
 /-- The natural `IsometryEquiv` between `(Fin m → α) × (Fin n → α)` and `(Fin (m + n) → α)`.-/
 def finArrowProdHomeomorphFinAddArrow (m n : ℕ) : (Fin m → α) × (Fin n → α) ≃ᵢ (Fin (m + n) → α) :=
-  sumArrowEquivProdArrow.symm.trans (piCongrLeft (Y := fun _ ↦ α) finSumFinEquiv)
+  mk (Fin.appendEquiv _ _) (by
+    intro f1 f2
+    simp [PseudoEMetricSpace.toEDist, pseudoEMetricSpacePi, instEDistForall,
+      Finset.sup_univ_eq_iSup, ← Equiv.iSup_comp (e := finSumFinEquiv), Prod.pseudoEMetricSpaceMax,
+      iSup_sum])
 
 variable (ι α)
 


### PR DESCRIPTION

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
