### PR TITLE
refactor: split `SuccOrder WithTop` instance into `NoMaxOrder` and `OrderTop`

### DIFF
--- a/Mathlib/Data/ENat/Basic.lean
+++ b/Mathlib/Data/ENat/Basic.lean
@@ -52,7 +52,7 @@ variable {m n : ℕ∞}
 @[simp] theorem some_eq_coe : (WithTop.some : ℕ → ℕ∞) = Nat.cast := rfl
 
 instance : SuccAddOrder ℕ∞ where
-  succ_eq_add_one x := by cases x <;> simp [SuccOrder.succ]
+  succ_eq_add_one x := by cases x <;> rfl
 
 -- Porting note: `simp` and `norm_cast` can prove it
 --@[simp, norm_cast]

--- a/Mathlib/Order/SuccPred/Basic.lean
+++ b/Mathlib/Order/SuccPred/Basic.lean
@@ -1067,10 +1067,6 @@ theorem succ_coe [NoMaxOrder α] {a : α} : succ (↑a : WithTop α) = ↑(succ 
 @[nolint unusedArguments]
 instance [OrderTop α] : SuccOrder (WithTop α) := succOrder
 
-@[simp]
-theorem succ_coe_top [OrderTop α] : succ ↑(⊤ : α) = (⊤ : WithTop α) :=
-  succ_coe_of_isMax isMax_top
-
 theorem succ_coe_of_ne_top [OrderTop α] {a : α} (h : a ≠ ⊤) : succ (↑a : WithTop α) = ↑(succ a) :=
   succ_coe_of_not_isMax (not_isMax_iff_ne_top.mpr h)
 
@@ -1240,10 +1236,6 @@ theorem pred_coe [NoMinOrder α] {a : α} : pred (↑a : WithBot α) = ↑(pred 
 
 @[nolint unusedArguments]
 instance [OrderBot α] : PredOrder (WithBot α) := predOrder
-
-@[simp]
-theorem pred_coe_bot [OrderBot α] : pred ↑(⊥ : α) = (⊥ : WithBot α) :=
-  pred_coe_of_isMin isMin_bot
 
 theorem pred_coe_of_ne_bot [OrderBot α] {a : α} (h : a ≠ ⊥) : pred (↑a : WithBot α) = ↑(pred a) :=
   pred_coe_of_not_isMin (not_isMin_iff_ne_bot.mpr h)


### PR DESCRIPTION
In the `NoMaxOrder` case, we want an instance with better defeq. We introduce `SuccOrder.copy` to do so.

Also dualize to `PredOrder`.

Partially revert #15881: restore lemmas `succ_coe_top` and `succ_coe_of_ne_top` which are renamed (with statements changed) there.

[Zulip](https://leanprover.zulipchat.com/#narrow/channel/287929-mathlib4/topic/WithTop.20is.20a.20SuccOrder/near/477923773)

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
