### PR TITLE
feat: `Deprecated` is the new `Init` for tech-debts

### DIFF
--- a/scripts/technical-debt-metrics.sh
+++ b/scripts/technical-debt-metrics.sh
@@ -57,16 +57,11 @@ printf '%s|%s\n' "$(wc -l < scripts/no_lints_prime_decls.txt)" "exceptions for t
 
 deprecatedFiles="$(git ls-files '**/Deprecated/*.lean' | xargs wc -l | sed 's=^ *==')"
 
-printf '%s|%s\n' "$(printf '%s' "${deprecatedFiles}" | wc -l)" "\`Deprecated\` files"
-printf '%s|%s\n' "$(printf '%s\n' "${deprecatedFiles}" | grep total | sed 's= total==')"  'total LoC in `Deprecated` files'
-
-initFiles="$(git ls-files '**/Init/*.lean' | xargs wc -l | sed 's=^ *==')"
-
-printf '%s|%s\n' "$(printf '%s' "${initFiles}" | wc -l)" "\`Init\` files"
-printf '%s|%s\n\n' "$(printf '%s\n' "${initFiles}" | grep total | sed 's= total==')"  'total LoC in `Init` files'
+printf '%s|%s\n' "$(printf '%s' "${deprecatedFiles}" | wc -l)" "\`Init\` files"
+printf '%s|%s\n\n' "$(printf '%s\n' "${deprecatedFiles}" | grep total | sed 's= total==')"  'total LoC in `Init` files'
 
 printf $'```spoiler Changed \'Init\' lines by file\n%s\n```\n' "$(
-    printf '%s\n' "${initFiles}" | awk 'BEGIN{print("|LoC|Change|File|\n|-:|:-:|-|")} {printf("%s|%s\n", $1, $2)}'
+    printf '%s\n' "${deprecatedFiles}" | awk 'BEGIN{print("|LoC|Change|File|\n|-:|:-:|-|")} {printf("%s|%s\n", $1, $2)}'
   )"
 }
 

--- a/scripts/technical-debt-metrics.sh
+++ b/scripts/technical-debt-metrics.sh
@@ -57,10 +57,10 @@ printf '%s|%s\n' "$(wc -l < scripts/no_lints_prime_decls.txt)" "exceptions for t
 
 deprecatedFiles="$(git ls-files '**/Deprecated/*.lean' | xargs wc -l | sed 's=^ *==')"
 
-printf '%s|%s\n' "$(printf '%s' "${deprecatedFiles}" | wc -l)" "\`Init\` files"
-printf '%s|%s\n\n' "$(printf '%s\n' "${deprecatedFiles}" | grep total | sed 's= total==')"  'total LoC in `Init` files'
+printf '%s|%s\n' "$(printf '%s' "${deprecatedFiles}" | wc -l)" "\`Deprecated\` files"
+printf '%s|%s\n\n' "$(printf '%s\n' "${deprecatedFiles}" | grep total | sed 's= total==')"  'total LoC in `Deprecated` files'
 
-printf $'```spoiler Changed \'Init\' lines by file\n%s\n```\n' "$(
+printf $'```spoiler Changed \'Deprecated\' lines by file\n%s\n```\n' "$(
     printf '%s\n' "${deprecatedFiles}" | awk 'BEGIN{print("|LoC|Change|File|\n|-:|:-:|-|")} {printf("%s|%s\n", $1, $2)}'
   )"
 }


### PR DESCRIPTION
There are no more `Init` files, so this PR
* removes `Init` counts from the `tech-debt` counters;
* uses the same fine-grained approach that `Init` had for `Deprecated`.

I simply removed the old test, rather than muting it, since I do not imagine anyone adding new `Init` files.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
