### PR TITLE
[Merged by Bors] - chore(CategoryTheory): generalize universes for multiequalizers

### DIFF
--- a/Mathlib/CategoryTheory/Limits/Shapes/ConcreteCategory.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/ConcreteCategory.lean
@@ -259,7 +259,7 @@ theorem multiequalizer_ext {I : MulticospanIndex.{w, w'} C} [HasMultiequalizer I
     simp [h]
 
 /-- An auxiliary equivalence to be used in `multiequalizerEquiv` below. -/
-def multiequalizerEquivAux (I : MulticospanIndex C) :
+def multiequalizerEquivAux (I : MulticospanIndex.{w, w'} C) :
     (I.multicospan ⋙ forget C).sections ≃
     { x : ∀ i : I.L, I.left i // ∀ i : I.R, I.fst i (x _) = I.snd i (x _) } where
   toFun x :=
@@ -292,17 +292,17 @@ def multiequalizerEquivAux (I : MulticospanIndex C) :
 
 /-- The equivalence between the noncomputable multiequalizer and
 the concrete multiequalizer. -/
-noncomputable def multiequalizerEquiv (I : MulticospanIndex.{w} C) [HasMultiequalizer I]
+noncomputable def multiequalizerEquiv (I : MulticospanIndex.{w, w'} C) [HasMultiequalizer I]
     [PreservesLimit I.multicospan (forget C)] :
     (multiequalizer I : C) ≃
       { x : ∀ i : I.L, I.left i // ∀ i : I.R, I.fst i (x _) = I.snd i (x _) } :=
   letI h1 := limit.isLimit I.multicospan
   letI h2 := isLimitOfPreserves (forget C) h1
   letI E := h2.conePointUniqueUpToIso (Types.limitConeIsLimit.{max w w', v} _)
-  Equiv.trans E.toEquiv (Concrete.multiequalizerEquivAux.{max w w', v} I)
+  Equiv.trans E.toEquiv (Concrete.multiequalizerEquivAux I)
 
 @[simp]
-theorem multiequalizerEquiv_apply (I : MulticospanIndex.{w} C) [HasMultiequalizer I]
+theorem multiequalizerEquiv_apply (I : MulticospanIndex.{w, w'} C) [HasMultiequalizer I]
     [PreservesLimit I.multicospan (forget C)] (x : ↑(multiequalizer I)) (i : I.L) :
     ((Concrete.multiequalizerEquiv I) x : ∀ i : I.L, I.left i) i = Multiequalizer.ι I i x :=
   rfl

--- a/Mathlib/CategoryTheory/Limits/Shapes/ConcreteCategory.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/ConcreteCategory.lean
@@ -31,7 +31,7 @@ wide-pullbacks, wide-pushouts, multiequalizers and cokernels.
 
 -/
 
-universe w v u t r
+universe w w' v u t r
 
 namespace CategoryTheory.Limits.Concrete
 
@@ -247,9 +247,9 @@ end WidePullback
 
 section Multiequalizer
 
-variable [ConcreteCategory.{max w v} C]
+variable [ConcreteCategory.{max w w' v} C]
 
-theorem multiequalizer_ext {I : MulticospanIndex.{w} C} [HasMultiequalizer I]
+theorem multiequalizer_ext {I : MulticospanIndex.{w, w'} C} [HasMultiequalizer I]
     [PreservesLimit I.multicospan (forget C)] (x y : ↑(multiequalizer I))
     (h : ∀ t : I.L, Multiequalizer.ι I t x = Multiequalizer.ι I t y) : x = y := by
   apply Concrete.limit_ext
@@ -298,8 +298,8 @@ noncomputable def multiequalizerEquiv (I : MulticospanIndex.{w} C) [HasMultiequa
       { x : ∀ i : I.L, I.left i // ∀ i : I.R, I.fst i (x _) = I.snd i (x _) } :=
   letI h1 := limit.isLimit I.multicospan
   letI h2 := isLimitOfPreserves (forget C) h1
-  letI E := h2.conePointUniqueUpToIso (Types.limitConeIsLimit.{w, v} _)
-  Equiv.trans E.toEquiv (Concrete.multiequalizerEquivAux.{w, v} I)
+  letI E := h2.conePointUniqueUpToIso (Types.limitConeIsLimit.{max w w', v} _)
+  Equiv.trans E.toEquiv (Concrete.multiequalizerEquivAux.{max w w', v} I)
 
 @[simp]
 theorem multiequalizerEquiv_apply (I : MulticospanIndex.{w} C) [HasMultiequalizer I]

--- a/Mathlib/CategoryTheory/Limits/Shapes/Multiequalizer.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/Multiequalizer.lean
@@ -31,29 +31,29 @@ namespace CategoryTheory.Limits
 
 open CategoryTheory
 
-universe w v u
+universe w w' v u
 
 /-- The type underlying the multiequalizer diagram. -/
 --@[nolint unused_arguments]
-inductive WalkingMulticospan {L R : Type w} (fst snd : R → L) : Type w
+inductive WalkingMulticospan {L : Type w} {R : Type w'} (fst snd : R → L) : Type max w w'
   | left : L → WalkingMulticospan fst snd
   | right : R → WalkingMulticospan fst snd
 
 /-- The type underlying the multiecoqualizer diagram. -/
 --@[nolint unused_arguments]
-inductive WalkingMultispan {L R : Type w} (fst snd : L → R) : Type w
+inductive WalkingMultispan {L : Type w} {R : Type w'} (fst snd : L → R) : Type max w w'
   | left : L → WalkingMultispan fst snd
   | right : R → WalkingMultispan fst snd
 
 namespace WalkingMulticospan
 
-variable {L R : Type w} {fst snd : R → L}
+variable {L : Type w} {R : Type w'} {fst snd : R → L}
 
 instance [Inhabited L] : Inhabited (WalkingMulticospan fst snd) :=
   ⟨left default⟩
 
 /-- Morphisms for `WalkingMulticospan`. -/
-inductive Hom : ∀ _ _ : WalkingMulticospan fst snd, Type w
+inductive Hom : ∀ _ _ : WalkingMulticospan fst snd, Type max w w'
   | id (A) : Hom A A
   | fst (b) : Hom (left (fst b)) (right b)
   | snd (b) : Hom (left (snd b)) (right b)
@@ -94,13 +94,13 @@ end WalkingMulticospan
 
 namespace WalkingMultispan
 
-variable {L R : Type v} {fst snd : L → R}
+variable {L : Type w} {R : Type w'} {fst snd : L → R}
 
 instance [Inhabited L] : Inhabited (WalkingMultispan fst snd) :=
   ⟨left default⟩
 
 /-- Morphisms for `WalkingMultispan`. -/
-inductive Hom : ∀ _ _ : WalkingMultispan fst snd, Type v
+inductive Hom : ∀ _ _ : WalkingMultispan fst snd, Type max w w'
   | id (A) : Hom A A
   | fst (a) : Hom (left a) (right (fst a))
   | snd (a) : Hom (left a) (right (snd a))
@@ -142,7 +142,8 @@ end WalkingMultispan
 -- Porting note(#5171): linter not ported yet
 -- @[nolint has_nonempty_instance]
 structure MulticospanIndex (C : Type u) [Category.{v} C] where
-  (L R : Type w)
+  (L : Type w)
+  (R : Type w')
   (fstTo sndTo : R → L)
   left : L → C
   right : R → C
@@ -153,7 +154,8 @@ structure MulticospanIndex (C : Type u) [Category.{v} C] where
 -- Porting note(#5171): linter not ported yet
 -- @[nolint has_nonempty_instance]
 structure MultispanIndex (C : Type u) [Category.{v} C] where
-  (L R : Type w)
+  (L : Type w)
+  (R : Type w')
   (fstFrom sndFrom : L → R)
   left : L → C
   right : R → C
@@ -162,7 +164,7 @@ structure MultispanIndex (C : Type u) [Category.{v} C] where
 
 namespace MulticospanIndex
 
-variable {C : Type u} [Category.{v} C] (I : MulticospanIndex.{w} C)
+variable {C : Type u} [Category.{v} C] (I : MulticospanIndex.{w, w'} C)
 
 /-- The multicospan associated to `I : MulticospanIndex`. -/
 @[simps]
@@ -210,7 +212,7 @@ end MulticospanIndex
 
 namespace MultispanIndex
 
-variable {C : Type u} [Category.{v} C] (I : MultispanIndex.{w} C)
+variable {C : Type u} [Category.{v} C] (I : MultispanIndex.{w, w'} C)
 
 /-- The multispan associated to `I : MultispanIndex`. -/
 def multispan : WalkingMultispan I.fstFrom I.sndFrom ⥤ C where
@@ -276,18 +278,18 @@ variable {C : Type u} [Category.{v} C]
 /-- A multifork is a cone over a multicospan. -/
 -- Porting note(#5171): linter not ported yet
 -- @[nolint has_nonempty_instance]
-abbrev Multifork (I : MulticospanIndex.{w} C) :=
+abbrev Multifork (I : MulticospanIndex.{w, w'} C) :=
   Cone I.multicospan
 
 /-- A multicofork is a cocone over a multispan. -/
 -- Porting note(#5171): linter not ported yet
 -- @[nolint has_nonempty_instance]
-abbrev Multicofork (I : MultispanIndex.{w} C) :=
+abbrev Multicofork (I : MultispanIndex.{w, w'} C) :=
   Cocone I.multispan
 
 namespace Multifork
 
-variable {I : MulticospanIndex.{w} C} (K : Multifork I)
+variable {I : MulticospanIndex.{w, w'} C} (K : Multifork I)
 
 /-- The maps from the cone point of a multifork to the objects on the left. -/
 def ι (a : I.L) : K.pt ⟶ I.left a :=
@@ -315,7 +317,7 @@ theorem hom_comp_ι (K₁ K₂ : Multifork I) (f : K₁ ⟶ K₂) (j : I.L) : f.
 
 /-- Construct a multifork using a collection `ι` of morphisms. -/
 @[simps]
-def ofι (I : MulticospanIndex.{w} C) (P : C) (ι : ∀ a, P ⟶ I.left a)
+def ofι (I : MulticospanIndex.{w, w'} C) (P : C) (ι : ∀ a, P ⟶ I.left a)
     (w : ∀ b, ι (I.fstTo b) ≫ I.fst b = ι (I.sndTo b) ≫ I.snd b) : Multifork I where
   pt := P
   π :=
@@ -438,7 +440,7 @@ end Multifork
 
 namespace MulticospanIndex
 
-variable (I : MulticospanIndex.{w} C) [HasProduct I.left] [HasProduct I.right]
+variable (I : MulticospanIndex.{w, w'} C) [HasProduct I.left] [HasProduct I.right]
 
 --attribute [local tidy] tactic.case_bash
 
@@ -485,7 +487,7 @@ end MulticospanIndex
 
 namespace Multicofork
 
-variable {I : MultispanIndex.{w} C} (K : Multicofork I)
+variable {I : MultispanIndex.{w, w'} C} (K : Multicofork I)
 
 /-- The maps to the cocone point of a multicofork from the objects on the right. -/
 def π (b : I.R) : I.right b ⟶ K.pt :=
@@ -511,7 +513,7 @@ lemma π_comp_hom (K₁ K₂ : Multicofork I) (f : K₁ ⟶ K₂) (b : I.R) : K�
 
 /-- Construct a multicofork using a collection `π` of morphisms. -/
 @[simps]
-def ofπ (I : MultispanIndex.{w} C) (P : C) (π : ∀ b, I.right b ⟶ P)
+def ofπ (I : MultispanIndex.{w, w'} C) (P : C) (π : ∀ b, I.right b ⟶ P)
     (w : ∀ a, I.fst a ≫ π (I.fstFrom a) = I.snd a ≫ π (I.sndFrom a)) : Multicofork I where
   pt := P
   ι :=
@@ -614,7 +616,7 @@ end Multicofork
 
 namespace MultispanIndex
 
-variable (I : MultispanIndex.{w} C) [HasCoproduct I.left] [HasCoproduct I.right]
+variable (I : MultispanIndex.{w, w'} C) [HasCoproduct I.left] [HasCoproduct I.right]
 
 --attribute [local tidy] tactic.case_bash
 
@@ -673,27 +675,27 @@ end MultispanIndex
 
 /-- For `I : MulticospanIndex C`, we say that it has a multiequalizer if the associated
   multicospan has a limit. -/
-abbrev HasMultiequalizer (I : MulticospanIndex.{w} C) :=
+abbrev HasMultiequalizer (I : MulticospanIndex.{w, w'} C) :=
   HasLimit I.multicospan
 
 noncomputable section
 
 /-- The multiequalizer of `I : MulticospanIndex C`. -/
-abbrev multiequalizer (I : MulticospanIndex.{w} C) [HasMultiequalizer I] : C :=
+abbrev multiequalizer (I : MulticospanIndex.{w, w'} C) [HasMultiequalizer I] : C :=
   limit I.multicospan
 
 /-- For `I : MultispanIndex C`, we say that it has a multicoequalizer if
   the associated multicospan has a limit. -/
-abbrev HasMulticoequalizer (I : MultispanIndex.{w} C) :=
+abbrev HasMulticoequalizer (I : MultispanIndex.{w, w'} C) :=
   HasColimit I.multispan
 
 /-- The multiecoqualizer of `I : MultispanIndex C`. -/
-abbrev multicoequalizer (I : MultispanIndex.{w} C) [HasMulticoequalizer I] : C :=
+abbrev multicoequalizer (I : MultispanIndex.{w, w'} C) [HasMulticoequalizer I] : C :=
   colimit I.multispan
 
 namespace Multiequalizer
 
-variable (I : MulticospanIndex.{w} C) [HasMultiequalizer I]
+variable (I : MulticospanIndex.{w, w'} C) [HasMultiequalizer I]
 
 /-- The canonical map from the multiequalizer to the objects on the left. -/
 abbrev ι (a : I.L) : multiequalizer I ⟶ I.left a :=
@@ -758,7 +760,7 @@ end Multiequalizer
 
 namespace Multicoequalizer
 
-variable (I : MultispanIndex.{w} C) [HasMulticoequalizer I]
+variable (I : MultispanIndex.{w, w'} C) [HasMulticoequalizer I]
 
 /-- The canonical map from the multiequalizer to the objects on the left. -/
 abbrev π (b : I.R) : I.right b ⟶ multicoequalizer I :=

--- a/Mathlib/CategoryTheory/Limits/Shapes/Multiequalizer.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/Multiequalizer.lean
@@ -139,8 +139,8 @@ lemma Hom.comp_eq_comp {X Y Z : WalkingMultispan fst snd}
 end WalkingMultispan
 
 /-- This is a structure encapsulating the data necessary to define a `Multicospan`. -/
--- Porting note(#5171): linter not ported yet
--- @[nolint has_nonempty_instance]
+-- Porting note(#5171): has_nonempty_instance linter not ported yet
+@[nolint checkUnivs]
 structure MulticospanIndex (C : Type u) [Category.{v} C] where
   (L : Type w)
   (R : Type w')
@@ -152,7 +152,7 @@ structure MulticospanIndex (C : Type u) [Category.{v} C] where
 
 /-- This is a structure encapsulating the data necessary to define a `Multispan`. -/
 -- Porting note(#5171): linter not ported yet
--- @[nolint has_nonempty_instance]
+@[nolint checkUnivs]
 structure MultispanIndex (C : Type u) [Category.{v} C] where
   (L : Type w)
   (R : Type w')

--- a/Mathlib/CategoryTheory/Limits/Shapes/Multiequalizer.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/Multiequalizer.lean
@@ -151,7 +151,7 @@ structure MulticospanIndex (C : Type u) [Category.{v} C] where
   snd : ∀ b, left (sndTo b) ⟶ right b
 
 /-- This is a structure encapsulating the data necessary to define a `Multispan`. -/
--- Porting note(#5171): linter not ported yet
+-- Porting note(#5171): has_nonempty_instance linter not ported yet
 @[nolint checkUnivs]
 structure MultispanIndex (C : Type u) [Category.{v} C] where
   (L : Type w)


### PR DESCRIPTION
Multi(co)equalizers involve two index sets. Until now, they were assumed to be in the same universe. In this PR, we allow two distinct universes. This shall ease the formalisation of (co)ends, which require heterogeneous universes.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
