### PR TITLE
[Merged by Bors] - feat(Pointwise): growth of finsets

### DIFF
--- a/Mathlib/Algebra/Group/Pointwise/Finset/Basic.lean
+++ b/Mathlib/Algebra/Group/Pointwise/Finset/Basic.lean
@@ -94,9 +94,11 @@ lemma coe_eq_one : (s : Set α) = 1 ↔ s = 1 := coe_eq_singleton
 theorem one_subset : (1 : Finset α) ⊆ s ↔ (1 : α) ∈ s :=
   singleton_subset_iff
 
-@[to_additive (attr := simp)]
+@[to_additive]
 theorem singleton_one : ({1} : Finset α) = 1 :=
   rfl
+
+scoped[Pointwise] attribute [simp] Finset.singleton_one Finset.singleton_zero
 
 @[to_additive]
 theorem one_mem_one : (1 : α) ∈ (1 : Finset α) :=

--- a/Mathlib/Algebra/Group/Pointwise/Finset/Basic.lean
+++ b/Mathlib/Algebra/Group/Pointwise/Finset/Basic.lean
@@ -94,11 +94,11 @@ lemma coe_eq_one : (s : Set α) = 1 ↔ s = 1 := coe_eq_singleton
 theorem one_subset : (1 : Finset α) ⊆ s ↔ (1 : α) ∈ s :=
   singleton_subset_iff
 
+-- TODO: This would be a good simp lemma scoped to `Pointwise`, but it seems `@[simp]` can't be
+-- scoped
 @[to_additive]
 theorem singleton_one : ({1} : Finset α) = 1 :=
   rfl
-
-scoped[Pointwise] attribute [simp] Finset.singleton_one Finset.singleton_zero
 
 @[to_additive]
 theorem one_mem_one : (1 : α) ∈ (1 : Finset α) :=
@@ -824,7 +824,7 @@ theorem empty_pow (hn : n ≠ 0) : (∅ : Finset α) ^ n = ∅ := by
 
 @[to_additive (attr := simp) nsmul_singleton]
 lemma singleton_pow (a : α) : ∀ n, ({a} : Finset α) ^ n = {a ^ n}
-  | 0 => by simp
+  | 0 => by simp [singleton_one]
   | n + 1 => by simp [pow_succ, singleton_pow _ n]
 
 @[to_additive]

--- a/Mathlib/Algebra/Group/Pointwise/Finset/Basic.lean
+++ b/Mathlib/Algebra/Group/Pointwise/Finset/Basic.lean
@@ -1651,11 +1651,13 @@ end
 section CancelMonoid
 variable [DecidableEq α] [CancelMonoid α] {s : Finset α} {m n : ℕ}
 
-@[to_additive]
+/-- See `Finset.card_pow_mono` for a version that works for the empty set. -/
+@[to_additive "See `Finset.card_nsmul_mono` for a version that works for the empty set."]
 protected lemma Nonempty.card_pow_mono (hs : s.Nonempty) : Monotone fun n : ℕ ↦ (s ^ n).card :=
   monotone_nat_of_le_succ fun n ↦ by rw [pow_succ]; exact card_le_card_mul_right _ hs
 
-@[to_additive]
+/-- See `Finset.Nonempty.card_pow_mono` for a version that works for zero powers. -/
+@[to_additive "See `Finset.Nonempty.card_nsmul_mono` for a version that works for zero scalars."]
 lemma card_pow_mono (hm : m ≠ 0) (hmn : m ≤ n) : (s ^ m).card ≤ (s ^ n).card := by
   obtain rfl | hs := s.eq_empty_or_nonempty
   · simp [hm]

--- a/Mathlib/Algebra/Group/Pointwise/Set/Basic.lean
+++ b/Mathlib/Algebra/Group/Pointwise/Set/Basic.lean
@@ -89,7 +89,7 @@ scoped[Pointwise] attribute [instance] Set.one Set.zero
 
 open Pointwise
 
-@[to_additive]
+@[to_additive (attr := simp)]
 theorem singleton_one : ({1} : Set α) = 1 :=
   rfl
 
@@ -1098,10 +1098,17 @@ theorem pow_subset_pow_of_one_mem (hs : (1 : α) ∈ s) (hn : m ≤ n) : s ^ m �
     rw [pow_succ']
     exact ih.trans (subset_mul_right _ hs)
 
-@[to_additive (attr := simp)]
+@[to_additive (attr := simp) nsmul_empty]
 theorem empty_pow {n : ℕ} (hn : n ≠ 0) : (∅ : Set α) ^ n = ∅ := by
   match n with
   | n + 1 => rw [pow_succ', empty_mul]
+
+@[deprecated (since := "2024-10-21")] alias empty_nsmul := nsmul_empty
+
+@[to_additive (attr := simp) nsmul_singleton]
+lemma singleton_pow (a : α) : ∀ n, ({a} : Set α) ^ n = {a ^ n}
+  | 0 => by simp
+  | n + 1 => by simp [pow_succ, singleton_pow _ n]
 
 @[to_additive]
 theorem mul_univ_of_one_mem (hs : (1 : α) ∈ s) : s * univ = univ :=
@@ -1138,7 +1145,7 @@ open Pointwise
 
 section DivisionMonoid
 
-variable [DivisionMonoid α] {s t : Set α}
+variable [DivisionMonoid α] {s t : Set α} {n : ℤ}
 
 @[to_additive]
 protected theorem mul_eq_one_iff : s * t = 1 ↔ ∃ a b, s = {a} ∧ t = {b} ∧ a * b = 1 := by
@@ -1190,6 +1197,12 @@ lemma univ_div_univ : (univ / univ : Set α) = univ := by simp [div_eq_mul_inv]
 
 @[to_additive] lemma inv_subset_div_right (hs : 1 ∈ s) : t⁻¹ ⊆ s / t := by
   rw [div_eq_mul_inv]; exact subset_mul_right _ hs
+
+@[to_additive (attr := simp) zsmul_empty]
+lemma empty_zpow (hn : n ≠ 0) : (∅ : Set α) ^ n = ∅ := by cases n <;> aesop
+
+@[to_additive (attr := simp) zsmul_singleton]
+lemma singleton_zpow (a : α) (n : ℤ) : ({a} : Set α) ^ n = {a ^ n} := by cases n <;> simp
 
 end DivisionMonoid
 

--- a/Mathlib/Algebra/Group/Pointwise/Set/Basic.lean
+++ b/Mathlib/Algebra/Group/Pointwise/Set/Basic.lean
@@ -89,7 +89,9 @@ scoped[Pointwise] attribute [instance] Set.one Set.zero
 
 open Pointwise
 
-@[to_additive (attr := simp)]
+-- TODO: This would be a good simp lemma scoped to `Pointwise`, but it seems `@[simp]` can't be
+-- scoped
+@[to_additive]
 theorem singleton_one : ({1} : Set α) = 1 :=
   rfl
 

--- a/Mathlib/Algebra/Group/Pointwise/Set/Basic.lean
+++ b/Mathlib/Algebra/Group/Pointwise/Set/Basic.lean
@@ -1109,7 +1109,7 @@ theorem empty_pow {n : ℕ} (hn : n ≠ 0) : (∅ : Set α) ^ n = ∅ := by
 
 @[to_additive (attr := simp) nsmul_singleton]
 lemma singleton_pow (a : α) : ∀ n, ({a} : Set α) ^ n = {a ^ n}
-  | 0 => by simp
+  | 0 => by simp [singleton_one]
   | n + 1 => by simp [pow_succ, singleton_pow _ n]
 
 @[to_additive]


### PR DESCRIPTION
This PR proves the monotonicity of `n ↦ s ^ n` under various conditions. Also rename `empty_nsmul` to `nsmul_empty`.

From GrowthInGroups


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
