### PR TITLE
[Merged by Bors] - chore(Topology/Algebra/SeparationQuotient): split

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -4595,7 +4595,8 @@ import Mathlib.Topology.Algebra.ProperConstSMul
 import Mathlib.Topology.Algebra.Ring.Basic
 import Mathlib.Topology.Algebra.Ring.Ideal
 import Mathlib.Topology.Algebra.Semigroup
-import Mathlib.Topology.Algebra.SeparationQuotient
+import Mathlib.Topology.Algebra.SeparationQuotient.Basic
+import Mathlib.Topology.Algebra.SeparationQuotient.Section
 import Mathlib.Topology.Algebra.Star
 import Mathlib.Topology.Algebra.StarSubalgebra
 import Mathlib.Topology.Algebra.UniformConvergence

--- a/Mathlib/Analysis/LocallyConvex/Bounded.lean
+++ b/Mathlib/Analysis/LocallyConvex/Bounded.lean
@@ -7,6 +7,7 @@ import Mathlib.GroupTheory.GroupAction.Pointwise
 import Mathlib.Analysis.LocallyConvex.Basic
 import Mathlib.Analysis.LocallyConvex.BalancedCoreHull
 import Mathlib.Analysis.Seminorm
+import Mathlib.LinearAlgebra.Basis.VectorSpace
 import Mathlib.Topology.Bornology.Basic
 import Mathlib.Topology.Algebra.UniformGroup
 import Mathlib.Topology.UniformSpace.Cauchy

--- a/Mathlib/Analysis/Normed/Module/Span.lean
+++ b/Mathlib/Analysis/Normed/Module/Span.lean
@@ -7,6 +7,7 @@ Authors: Moritz Doll
 import Mathlib.Analysis.Normed.Operator.LinearIsometry
 import Mathlib.Analysis.Normed.Operator.ContinuousLinearMap
 import Mathlib.Analysis.Normed.Module.Basic
+import Mathlib.LinearAlgebra.Basis.VectorSpace
 
 /-!
 # The span of a single vector

--- a/Mathlib/Analysis/Normed/Operator/ContinuousLinearMap.lean
+++ b/Mathlib/Analysis/Normed/Operator/ContinuousLinearMap.lean
@@ -5,6 +5,7 @@ Authors: Jan-David Salchow, Sébastien Gouëzel, Jean Lo
 -/
 import Mathlib.Analysis.Normed.Group.Uniform
 import Mathlib.Analysis.Normed.MulAction
+import Mathlib.LinearAlgebra.DFinsupp
 import Mathlib.Topology.Algebra.Module.Basic
 
 /-! # Constructions of continuous linear maps between (semi-)normed spaces

--- a/Mathlib/Analysis/Normed/Operator/LinearIsometry.lean
+++ b/Mathlib/Analysis/Normed/Operator/LinearIsometry.lean
@@ -7,8 +7,9 @@ import Mathlib.Algebra.Star.Basic
 import Mathlib.Analysis.Normed.Group.Constructions
 import Mathlib.Analysis.Normed.Group.Submodule
 import Mathlib.Analysis.Normed.Group.Uniform
-import Mathlib.Topology.Algebra.Module.Basic
 import Mathlib.LinearAlgebra.Basis.Defs
+import Mathlib.LinearAlgebra.DFinsupp
+import Mathlib.Topology.Algebra.Module.Basic
 
 /-!
 # (Semi-)linear isometries

--- a/Mathlib/Analysis/NormedSpace/BallAction.lean
+++ b/Mathlib/Analysis/NormedSpace/BallAction.lean
@@ -5,6 +5,7 @@ Authors: Yury Kudryashov, Heather Macbeth
 -/
 import Mathlib.Analysis.Normed.Field.UnitBall
 import Mathlib.Analysis.Normed.Module.Basic
+import Mathlib.LinearAlgebra.Basis.VectorSpace
 
 /-!
 # Multiplicative actions of/on balls and spheres

--- a/Mathlib/Analysis/NormedSpace/ConformalLinearMap.lean
+++ b/Mathlib/Analysis/NormedSpace/ConformalLinearMap.lean
@@ -5,6 +5,7 @@ Authors: Yourong Zang
 -/
 import Mathlib.Analysis.Normed.Module.Basic
 import Mathlib.Analysis.Normed.Operator.LinearIsometry
+import Mathlib.LinearAlgebra.Basis.VectorSpace
 
 /-!
 # Conformal Linear Maps

--- a/Mathlib/Analysis/NormedSpace/ENorm.lean
+++ b/Mathlib/Analysis/NormedSpace/ENorm.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Yury Kudryashov
 -/
 import Mathlib.Analysis.Normed.Module.Basic
+import Mathlib.LinearAlgebra.Basis.VectorSpace
 
 /-!
 # Extended norm

--- a/Mathlib/Analysis/NormedSpace/Real.lean
+++ b/Mathlib/Analysis/NormedSpace/Real.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Yury Kudryashov, Patrick Massot, Eric Wieser, Yaël Dillies
 -/
 import Mathlib.Analysis.Normed.Module.Basic
+import Mathlib.LinearAlgebra.Basis.VectorSpace
 import Mathlib.Topology.Algebra.Module.Basic
 
 /-!

--- a/Mathlib/Analysis/NormedSpace/SphereNormEquiv.lean
+++ b/Mathlib/Analysis/NormedSpace/SphereNormEquiv.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Yury Kudryashov
 -/
 import Mathlib.Analysis.Normed.Module.Basic
+import Mathlib.LinearAlgebra.Basis.VectorSpace
 
 /-!
 # Homeomorphism between a normed space and sphere times `(0, +∞)`

--- a/Mathlib/Analysis/RCLike/Basic.lean
+++ b/Mathlib/Analysis/RCLike/Basic.lean
@@ -10,6 +10,7 @@ import Mathlib.Algebra.Order.Star.Basic
 import Mathlib.Analysis.CStarAlgebra.Basic
 import Mathlib.Analysis.Normed.Operator.ContinuousLinearMap
 import Mathlib.Data.Real.Sqrt
+import Mathlib.LinearAlgebra.Basis.VectorSpace
 
 /-!
 # `RCLike`: a typeclass for ℝ or ℂ

--- a/Mathlib/Topology/Algebra/Module/Cardinality.lean
+++ b/Mathlib/Topology/Algebra/Module/Cardinality.lean
@@ -4,9 +4,10 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Sébastien Gouëzel
 -/
 import Mathlib.Algebra.Module.Card
-import Mathlib.SetTheory.Cardinal.CountableCover
-import Mathlib.SetTheory.Cardinal.Continuum
 import Mathlib.Analysis.SpecificLimits.Normed
+import Mathlib.SetTheory.Cardinal.Continuum
+import Mathlib.SetTheory.Cardinal.CountableCover
+import Mathlib.LinearAlgebra.Basis.VectorSpace
 import Mathlib.Topology.MetricSpace.Perfect
 
 /-!

--- a/Mathlib/Topology/Algebra/SeparationQuotient/Basic.lean
+++ b/Mathlib/Topology/Algebra/SeparationQuotient/Basic.lean
@@ -3,10 +3,7 @@ Copyright (c) 2024 Yury Kudryashov. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Yury Kudryashov
 -/
-import Mathlib.LinearAlgebra.Basis.VectorSpace
-import Mathlib.Algebra.Module.Projective
 import Mathlib.Topology.Algebra.Module.Basic
-import Mathlib.Topology.Maps.OpenQuotient
 
 /-!
 # Algebraic operations on `SeparationQuotient`
@@ -21,6 +18,8 @@ and show that they satisfy the same kind of laws (`Monoid` etc) as the original 
 Finally, we construct a section of the quotient map
 which is a continuous linear map `SeparationQuotient E →L[K] E`.
 -/
+
+assert_not_exists LinearIndependent
 
 namespace SeparationQuotient
 
@@ -396,80 +395,5 @@ theorem mk_algebraMap (r : R) : mk (algebraMap R A r) = algebraMap R (Separation
   rfl
 
 end Algebra
-
-section VectorSpace
-
-variable (K E : Type*) [DivisionRing K] [AddCommGroup E] [Module K E]
-  [TopologicalSpace E] [TopologicalAddGroup E] [ContinuousConstSMul K E]
-
-/-- There exists a continuous `K`-linear map from `SeparationQuotient E` to `E`
-such that `mk (outCLM x) = x` for all `x`.
-
-Note that continuity of this map comes for free, because `mk` is a topology inducing map.
--/
-theorem exists_out_continuousLinearMap :
-    ∃ f : SeparationQuotient E →L[K] E, mkCLM K E ∘L f = .id K (SeparationQuotient E) := by
-  rcases (mkCLM K E).toLinearMap.exists_rightInverse_of_surjective
-    (LinearMap.range_eq_top.mpr surjective_mk) with ⟨f, hf⟩
-  replace hf : mk ∘ f = id := congr_arg DFunLike.coe hf
-  exact ⟨⟨f, inducing_mk.continuous_iff.2 (by continuity)⟩, DFunLike.ext' hf⟩
-
-/-- A continuous `K`-linear map from `SeparationQuotient E` to `E`
-such that `mk (outCLM x) = x` for all `x`. -/
-noncomputable def outCLM : SeparationQuotient E →L[K] E :=
-  (exists_out_continuousLinearMap K E).choose
-
-@[simp]
-theorem mkCLM_comp_outCLM : mkCLM K E ∘L outCLM K E = .id K (SeparationQuotient E) :=
-  (exists_out_continuousLinearMap K E).choose_spec
-
-variable {E} in
-@[simp]
-theorem mk_outCLM (x : SeparationQuotient E) : mk (outCLM K E x) = x :=
-  DFunLike.congr_fun (mkCLM_comp_outCLM K E) x
-
-@[simp]
-theorem mk_comp_outCLM : mk ∘ outCLM K E = id := funext (mk_outCLM K)
-
-variable {K} in
-theorem postcomp_mkCLM_surjective {L : Type*} [Semiring L] (σ : L →+* K)
-    (F : Type*) [AddCommMonoid F] [Module L F] [TopologicalSpace F] :
-    Function.Surjective ((mkCLM K E).comp : (F →SL[σ] E) → (F →SL[σ] SeparationQuotient E)) := by
-  intro f
-  use (outCLM K E).comp f
-  rw [← ContinuousLinearMap.comp_assoc, mkCLM_comp_outCLM, ContinuousLinearMap.id_comp]
-
-/-- The `SeparationQuotient.outCLM K E` map is a topological embedding. -/
-theorem outCLM_embedding : Embedding (outCLM K E) :=
-  Function.LeftInverse.embedding (mk_outCLM K) continuous_mk (map_continuous _)
-
-theorem outCLM_injective : Function.Injective (outCLM K E) :=
-  (outCLM_embedding K E).injective
-
-end VectorSpace
-
-section VectorSpaceUniform
-
-variable (K E : Type*) [DivisionRing K] [AddCommGroup E] [Module K E]
-    [UniformSpace E] [UniformAddGroup E] [ContinuousConstSMul K E]
-
-theorem outCLM_isUniformInducing : IsUniformInducing (outCLM K E) := by
-  rw [← isUniformInducing_mk.isUniformInducing_comp_iff, mk_comp_outCLM]
-  exact .id
-
-@[deprecated (since := "2024-10-05")]
-alias outCLM_uniformInducing := outCLM_isUniformInducing
-
-theorem outCLM_isUniformEmbedding : IsUniformEmbedding (outCLM K E) where
-  inj := outCLM_injective K E
-  toIsUniformInducing := outCLM_isUniformInducing K E
-
-@[deprecated (since := "2024-10-01")]
-alias outCLM_uniformEmbedding := outCLM_isUniformEmbedding
-
-theorem outCLM_uniformContinuous : UniformContinuous (outCLM K E) :=
-  (outCLM_isUniformInducing K E).uniformContinuous
-
-end VectorSpaceUniform
 
 end SeparationQuotient

--- a/Mathlib/Topology/Algebra/SeparationQuotient/Section.lean
+++ b/Mathlib/Topology/Algebra/SeparationQuotient/Section.lean
@@ -1,0 +1,93 @@
+/-
+Copyright (c) 2024 Yury Kudryashov. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Yury Kudryashov
+-/
+import Mathlib.Algebra.Module.Projective
+import Mathlib.LinearAlgebra.Basis.VectorSpace
+import Mathlib.Topology.Algebra.SeparationQuotient.Basic
+import Mathlib.Topology.Maps.OpenQuotient
+
+/-!
+# Algebraic operations on `SeparationQuotient`
+
+In this file we construct a section of the quotient map `E → SeparationQuotient E` as a continuous
+linear map `SeparationQuotient E →L[K] E`.
+-/
+
+namespace SeparationQuotient
+section VectorSpace
+
+variable (K E : Type*) [DivisionRing K] [AddCommGroup E] [Module K E]
+  [TopologicalSpace E] [TopologicalAddGroup E] [ContinuousConstSMul K E]
+
+/-- There exists a continuous `K`-linear map from `SeparationQuotient E` to `E`
+such that `mk (outCLM x) = x` for all `x`.
+
+Note that continuity of this map comes for free, because `mk` is a topology inducing map.
+-/
+theorem exists_out_continuousLinearMap :
+    ∃ f : SeparationQuotient E →L[K] E, mkCLM K E ∘L f = .id K (SeparationQuotient E) := by
+  rcases (mkCLM K E).toLinearMap.exists_rightInverse_of_surjective
+    (LinearMap.range_eq_top.mpr surjective_mk) with ⟨f, hf⟩
+  replace hf : mk ∘ f = id := congr_arg DFunLike.coe hf
+  exact ⟨⟨f, inducing_mk.continuous_iff.2 (by continuity)⟩, DFunLike.ext' hf⟩
+
+/-- A continuous `K`-linear map from `SeparationQuotient E` to `E`
+such that `mk (outCLM x) = x` for all `x`. -/
+noncomputable def outCLM : SeparationQuotient E →L[K] E :=
+  (exists_out_continuousLinearMap K E).choose
+
+@[simp]
+theorem mkCLM_comp_outCLM : mkCLM K E ∘L outCLM K E = .id K (SeparationQuotient E) :=
+  (exists_out_continuousLinearMap K E).choose_spec
+
+variable {E} in
+@[simp]
+theorem mk_outCLM (x : SeparationQuotient E) : mk (outCLM K E x) = x :=
+  DFunLike.congr_fun (mkCLM_comp_outCLM K E) x
+
+@[simp]
+theorem mk_comp_outCLM : mk ∘ outCLM K E = id := funext (mk_outCLM K)
+
+variable {K} in
+theorem postcomp_mkCLM_surjective {L : Type*} [Semiring L] (σ : L →+* K)
+    (F : Type*) [AddCommMonoid F] [Module L F] [TopologicalSpace F] :
+    Function.Surjective ((mkCLM K E).comp : (F →SL[σ] E) → (F →SL[σ] SeparationQuotient E)) := by
+  intro f
+  use (outCLM K E).comp f
+  rw [← ContinuousLinearMap.comp_assoc, mkCLM_comp_outCLM, ContinuousLinearMap.id_comp]
+
+/-- The `SeparationQuotient.outCLM K E` map is a topological embedding. -/
+theorem outCLM_embedding : Embedding (outCLM K E) :=
+  Function.LeftInverse.embedding (mk_outCLM K) continuous_mk (map_continuous _)
+
+theorem outCLM_injective : Function.Injective (outCLM K E) :=
+  (outCLM_embedding K E).injective
+
+end VectorSpace
+
+section VectorSpaceUniform
+
+variable (K E : Type*) [DivisionRing K] [AddCommGroup E] [Module K E]
+    [UniformSpace E] [UniformAddGroup E] [ContinuousConstSMul K E]
+
+theorem outCLM_isUniformInducing : IsUniformInducing (outCLM K E) := by
+  rw [← isUniformInducing_mk.isUniformInducing_comp_iff, mk_comp_outCLM]
+  exact .id
+
+@[deprecated (since := "2024-10-05")]
+alias outCLM_uniformInducing := outCLM_isUniformInducing
+
+theorem outCLM_isUniformEmbedding : IsUniformEmbedding (outCLM K E) where
+  inj := outCLM_injective K E
+  toIsUniformInducing := outCLM_isUniformInducing K E
+
+@[deprecated (since := "2024-10-01")]
+alias outCLM_uniformEmbedding := outCLM_isUniformEmbedding
+
+theorem outCLM_uniformContinuous : UniformContinuous (outCLM K E) :=
+  (outCLM_isUniformInducing K E).uniformContinuous
+
+end VectorSpaceUniform
+end SeparationQuotient

--- a/Mathlib/Topology/MetricSpace/Algebra.lean
+++ b/Mathlib/Topology/MetricSpace/Algebra.lean
@@ -4,9 +4,9 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Heather Macbeth
 -/
 import Mathlib.Topology.Algebra.MulAction
+import Mathlib.Topology.Algebra.SeparationQuotient.Section
 import Mathlib.Topology.Algebra.UniformMulAction
 import Mathlib.Topology.MetricSpace.Lipschitz
-import Mathlib.Topology.Algebra.SeparationQuotient
 
 /-!
 # Compatibility of algebraic operations with metric space structures

--- a/Mathlib/Topology/MetricSpace/Algebra.lean
+++ b/Mathlib/Topology/MetricSpace/Algebra.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Heather Macbeth
 -/
 import Mathlib.Topology.Algebra.MulAction
-import Mathlib.Topology.Algebra.SeparationQuotient.Section
+import Mathlib.Topology.Algebra.SeparationQuotient.Basic
 import Mathlib.Topology.Algebra.UniformMulAction
 import Mathlib.Topology.MetricSpace.Lipschitz
 

--- a/Mathlib/Topology/PartitionOfUnity.lean
+++ b/Mathlib/Topology/PartitionOfUnity.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Yury Kudryashov
 -/
 import Mathlib.Algebra.BigOperators.Finprod
+import Mathlib.LinearAlgebra.Basis.VectorSpace
 import Mathlib.Topology.ContinuousMap.Algebra
 import Mathlib.Topology.Compactness.Paracompact
 import Mathlib.Topology.ShrinkingLemma


### PR DESCRIPTION
The last 50 lines of the file cause massive import increase in downstream files.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
