### PR TITLE
[Merged by Bors] - chore(Algebra/PUnitInstances): split off `GCDMonoid PUnit` instance

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -707,6 +707,7 @@ import Mathlib.Algebra.Order.UpperLower
 import Mathlib.Algebra.Order.ZeroLEOne
 import Mathlib.Algebra.PEmptyInstances
 import Mathlib.Algebra.PUnitInstances.Algebra
+import Mathlib.Algebra.PUnitInstances.GCDMonoid
 import Mathlib.Algebra.PUnitInstances.Module
 import Mathlib.Algebra.PUnitInstances.Order
 import Mathlib.Algebra.Periodic

--- a/Mathlib/Algebra/Group/AddChar.lean
+++ b/Mathlib/Algebra/Group/AddChar.lean
@@ -3,6 +3,7 @@ Copyright (c) 2022 Michael Stoll. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Michael Stoll
 -/
+import Mathlib.Algebra.Ring.Regular
 import Mathlib.Logic.Equiv.TransferInstance
 
 /-!

--- a/Mathlib/Algebra/PUnitInstances/Algebra.lean
+++ b/Mathlib/Algebra/PUnitInstances/Algebra.lean
@@ -64,33 +64,4 @@ instance commRing : CommRing PUnit where
 
 instance cancelCommMonoidWithZero : CancelCommMonoidWithZero PUnit where
 
--- This is too high-powered and should be split off also
-instance normalizedGCDMonoid : NormalizedGCDMonoid PUnit where
-  gcd _ _ := unit
-  lcm _ _ := unit
-  normUnit _ := 1
-  normUnit_zero := rfl
-  normUnit_mul := by intros; rfl
-  normUnit_coe_units := by intros; rfl
-  gcd_dvd_left _ _ := ⟨unit, by subsingleton⟩
-  gcd_dvd_right _ _ := ⟨unit, by subsingleton⟩
-  dvd_gcd {_ _} _ _ _ := ⟨unit, by subsingleton⟩
-  gcd_mul_lcm _ _ := ⟨1, by subsingleton⟩
-  lcm_zero_left := by intros; rfl
-  lcm_zero_right := by intros; rfl
-  normalize_gcd := by intros; rfl
-  normalize_lcm := by intros; rfl
-
--- Porting note (#10618): simpNF lint: simp can prove this @[simp]
-theorem gcd_eq {x y : PUnit} : gcd x y = unit :=
-  rfl
-
--- Porting note (#10618): simpNF lint: simp can prove this @[simp]
-theorem lcm_eq {x y : PUnit} : lcm x y = unit :=
-  rfl
-
-@[simp]
-theorem norm_unit_eq {x : PUnit} : normUnit x = 1 :=
-  rfl
-
 end PUnit

--- a/Mathlib/Algebra/PUnitInstances/Algebra.lean
+++ b/Mathlib/Algebra/PUnitInstances/Algebra.lean
@@ -3,7 +3,7 @@ Copyright (c) 2019 Kenny Lau. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Kenny Lau
 -/
-import Mathlib.Algebra.GCDMonoid.Basic
+import Mathlib.Algebra.Ring.Basic
 
 /-!
 # Instances on PUnit

--- a/Mathlib/Algebra/PUnitInstances/GCDMonoid.lean
+++ b/Mathlib/Algebra/PUnitInstances/GCDMonoid.lean
@@ -1,0 +1,47 @@
+/-
+Copyright (c) 2019 Kenny Lau. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kenny Lau
+-/
+import Mathlib.Algebra.GCDMonoid.Basic
+import Mathlib.Algebra.PUnitInstances.Algebra
+
+/-!
+# Instances on PUnit
+
+This file collects facts about algebraic structures on the one-element type, e.g. that it is a
+commutative ring.
+-/
+
+namespace PUnit
+
+-- This is too high-powered and should be split off also
+instance normalizedGCDMonoid : NormalizedGCDMonoid PUnit where
+  gcd _ _ := unit
+  lcm _ _ := unit
+  normUnit _ := 1
+  normUnit_zero := rfl
+  normUnit_mul := by intros; rfl
+  normUnit_coe_units := by intros; rfl
+  gcd_dvd_left _ _ := ⟨unit, by subsingleton⟩
+  gcd_dvd_right _ _ := ⟨unit, by subsingleton⟩
+  dvd_gcd {_ _} _ _ _ := ⟨unit, by subsingleton⟩
+  gcd_mul_lcm _ _ := ⟨1, by subsingleton⟩
+  lcm_zero_left := by intros; rfl
+  lcm_zero_right := by intros; rfl
+  normalize_gcd := by intros; rfl
+  normalize_lcm := by intros; rfl
+
+-- Porting note (#10618): simpNF lint: simp can prove this @[simp]
+theorem gcd_eq {x y : PUnit} : gcd x y = unit :=
+  rfl
+
+-- Porting note (#10618): simpNF lint: simp can prove this @[simp]
+theorem lcm_eq {x y : PUnit} : lcm x y = unit :=
+  rfl
+
+@[simp]
+theorem norm_unit_eq {x : PUnit} : normUnit x = 1 :=
+  rfl
+
+end PUnit

--- a/Mathlib/Algebra/Star/CHSH.lean
+++ b/Mathlib/Algebra/Star/CHSH.lean
@@ -5,6 +5,7 @@ Authors: Kim Morrison
 -/
 import Mathlib.Algebra.CharP.Invertible
 import Mathlib.Algebra.Order.Star.Basic
+import Mathlib.Algebra.Ring.Regular
 import Mathlib.Data.Real.Sqrt
 import Mathlib.Tactic.Polyrith
 

--- a/Mathlib/RingTheory/Ideal/Basic.lean
+++ b/Mathlib/RingTheory/Ideal/Basic.lean
@@ -3,11 +3,13 @@ Copyright (c) 2018 Kenny Lau. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Kenny Lau, Chris Hughes, Mario Carneiro
 -/
-import Mathlib.Tactic.FinCases
+import Mathlib.Algebra.Associated.Basic
+import Mathlib.Algebra.Field.IsField
+import Mathlib.Algebra.Ring.Regular
 import Mathlib.Data.Nat.Choose.Sum
 import Mathlib.LinearAlgebra.Finsupp
-import Mathlib.Algebra.Field.IsField
 import Mathlib.Tactic.Abel
+import Mathlib.Tactic.FinCases
 
 /-!
 


### PR DESCRIPTION
This instance does not seem to be used anywhere in Mathlib and splitting it off should allow us to shave quite a few imports from low down in the hierarchy.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
