### PR TITLE
[Merged by Bors] - feat(NumberTheory/LSeries/Positivity): new file

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -3540,6 +3540,7 @@ import Mathlib.NumberTheory.LSeries.HurwitzZetaOdd
 import Mathlib.NumberTheory.LSeries.HurwitzZetaValues
 import Mathlib.NumberTheory.LSeries.Linearity
 import Mathlib.NumberTheory.LSeries.MellinEqDirichlet
+import Mathlib.NumberTheory.LSeries.Positivity
 import Mathlib.NumberTheory.LSeries.RiemannZeta
 import Mathlib.NumberTheory.LSeries.ZMod
 import Mathlib.NumberTheory.LegendreSymbol.AddCharacter

--- a/Mathlib/Analysis/SpecialFunctions/Pow/Real.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Pow/Real.lean
@@ -997,6 +997,13 @@ lemma abs_cpow_inv_two_im (x : ℂ) : |(x ^ (2⁻¹ : ℂ)).im| = sqrt ((abs x -
     ← Real.sqrt_eq_rpow, _root_.abs_mul, _root_.abs_of_nonneg (sqrt_nonneg _), abs_sin_half,
     ← sqrt_mul (abs.nonneg _), ← mul_div_assoc, mul_sub, mul_one, abs_mul_cos_arg]
 
+open scoped ComplexOrder in
+lemma inv_natCast_cpow_ofReal_pos {n : ℕ} (hn : n ≠ 0) (x : ℝ) :
+    0 < ((n : ℂ) ^ (x : ℂ))⁻¹ := by
+  refine RCLike.inv_pos_of_pos ?_
+  rw [show (n : ℂ) ^ (x : ℂ) = (n : ℝ) ^ (x : ℂ) from rfl, ← ofReal_cpow n.cast_nonneg']
+  positivity
+
 end Complex
 
 section Tactics

--- a/Mathlib/NumberTheory/LSeries/Basic.lean
+++ b/Mathlib/NumberTheory/LSeries/Basic.lean
@@ -111,6 +111,20 @@ lemma norm_term_le_of_re_le_re (f : ℕ → ℂ) {s s' : ℂ} (h : s.re ≤ s'.r
   next => rfl
   next hn => gcongr; exact Nat.one_le_cast.mpr <| Nat.one_le_iff_ne_zero.mpr hn
 
+section positivity
+
+open scoped ComplexOrder
+
+lemma term_nonneg {a : ℕ → ℂ} {n : ℕ} (h : 0 ≤ a n) (x : ℝ) : 0 ≤ term a x n := by
+  rw [term_def]
+  split_ifs with hn
+  exacts [le_rfl, mul_nonneg h (inv_natCast_cpow_ofReal_pos hn x).le]
+
+lemma term_pos {a : ℕ → ℂ} {n : ℕ} (hn : n ≠ 0) (h : 0 < a n) (x : ℝ) : 0 < term a x n := by
+  simpa only [term_of_ne_zero hn] using mul_pos h <| inv_natCast_cpow_ofReal_pos hn x
+
+end positivity
+
 end LSeries
 
 /-!

--- a/Mathlib/NumberTheory/LSeries/Positivity.lean
+++ b/Mathlib/NumberTheory/LSeries/Positivity.lean
@@ -44,7 +44,7 @@ lemma iteratedDeriv_alternating {a : ℕ → ℂ} (hn : 0 ≤ a) {x : ℝ}
   · exact le_rfl
   · refine mul_nonneg ?_ <| (inv_natCast_cpow_ofReal_pos (by assumption) x).le
     induction n with
-    | zero => simp only [Function.iterate_zero, id_eq]; exact hn k
+    | zero => simpa only [Function.iterate_zero, id_eq] using hn k
     | succ n IH =>
         rw [Function.iterate_succ_apply']
         refine mul_nonneg ?_ IH
@@ -61,7 +61,7 @@ lemma positive {a : ℕ → ℂ} (ha₀ : 0 ≤ a) (ha₁ : 0 < a 1) {x : ℝ} (
 /-- If all values of `a : ℕ → ℂ` are nonnegative reals and `a 1`
 is positive, and the L-series of `a` agrees with an entire function `f` on some open
 right half-plane where it converges, then `f` is real and positive on `ℝ`. -/
-lemma positive_of_eq_differentiable {a : ℕ → ℂ} (ha₀ : 0 ≤ a) (ha₁ : 0 < a 1) {f : ℂ → ℂ}
+lemma positive_of_differentiable_of_eqOn {a : ℕ → ℂ} (ha₀ : 0 ≤ a) (ha₁ : 0 < a 1) {f : ℂ → ℂ}
     (hf : Differentiable ℂ f) {x : ℝ} (hx : abscissaOfAbsConv a < x)
     (hf' : {s | x < s.re}.EqOn f (LSeries a)) (y : ℝ) :
     0 < f y := by
@@ -103,10 +103,10 @@ lemma LSeries_positive {a : ℕ → ℂ} (ha₀ : 0 ≤ a) (ha₁ : 0 < a 1) {x 
 /-- If all values of a `ℂ`-valued arithmetic function `a` are nonnegative reals and `a 1`
 is positive, and the L-series of `a` agrees with an entire function `f` on some open
 right half-plane where it converges, then `f` is real and positive on `ℝ`. -/
-lemma LSeries_positive_of_eq_differentiable {a : ArithmeticFunction ℂ} (ha₀ : 0 ≤ (a ·))
+lemma LSeries_positive_of_differentiable_of_eqOn {a : ArithmeticFunction ℂ} (ha₀ : 0 ≤ (a ·))
     (ha₁ : 0 < a 1) {f : ℂ → ℂ} (hf : Differentiable ℂ f) {x : ℝ}
     (hx : LSeries.abscissaOfAbsConv a < x) (hf' : {s | x < s.re}.EqOn f (LSeries a)) (y : ℝ) :
     0 < f y :=
-  LSeries.positive_of_eq_differentiable ha₀ ha₁ hf hx hf' y
+  LSeries.positive_of_differentiable_of_eqOn ha₀ ha₁ hf hx hf' y
 
 end ArithmeticFunction

--- a/Mathlib/NumberTheory/LSeries/Positivity.lean
+++ b/Mathlib/NumberTheory/LSeries/Positivity.lean
@@ -25,26 +25,9 @@ The main results of this file are as follows.
 
 open scoped ComplexOrder
 
-lemma Complex.inv_natCast_cpow_ofReal_pos {n : ℕ} (hn : n ≠ 0) (x : ℝ) :
-    0 < ((n : ℂ) ^ (x : ℂ))⁻¹ := by
-  refine RCLike.inv_pos_of_pos ?_
-  rw [show (n : ℂ) ^ (x : ℂ) = (n : ℝ) ^ (x : ℂ) from rfl, ← ofReal_cpow n.cast_nonneg']
-  positivity
-
 open Complex
 
 namespace LSeries
-
-lemma term_nonneg {a : ℕ → ℂ} {n : ℕ} (h : 0 ≤ a n) (x : ℝ) : 0 ≤ term a x n := by
-  rw [term_def]
-  rcases eq_or_ne n 0 with rfl | hn
-  · simp only [↓reduceIte, le_refl]
-  · simp only [hn, ↓reduceIte]
-    refine mul_nonneg h (inv_natCast_cpow_ofReal_pos hn x).le
-
-lemma term_pos {a : ℕ → ℂ} {n : ℕ} (hn : n ≠ 0) (h : 0 < a n) (x : ℝ) : 0 < term a x n := by
-  simp only [ne_eq, hn, not_false_eq_true, term_of_ne_zero]
-  refine mul_pos h <| inv_natCast_cpow_ofReal_pos hn x
 
 /-- If all values of a `ℂ`-valued arithmetic function are nonnegative reals and `x` is a
 real number in the domain of absolute convergence, then the `n`th iterated derivative

--- a/Mathlib/NumberTheory/LSeries/Positivity.lean
+++ b/Mathlib/NumberTheory/LSeries/Positivity.lean
@@ -1,0 +1,129 @@
+/-
+Copyright (c) 2024 Michael Stoll. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Chris Birkbeck, David Loeffler, Michael Stoll
+-/
+import Mathlib.Analysis.Complex.TaylorSeries
+import Mathlib.Analysis.Complex.Positivity
+import Mathlib.NumberTheory.ArithmeticFunction
+import Mathlib.NumberTheory.LSeries.Deriv
+
+/-!
+# Positivity of values of L-series
+
+The main results of this file are as follows.
+
+* If `a : ℕ → ℂ` takes nonnegative real values and `a 1 > 0`, then `L a x > 0`
+  when `x : ℝ` is in the open half-plane of absolute convergence; see
+  `LSeries.positive` and `ArithmeticFunction.LSeries_positive`.
+
+* If in addition the L_series of `a` agrees on some open right half-plane where it
+  converges with an entire function `f`, then `f` is positive on the real axis;
+  see `LSeries.positive_of_eq_differentiable` and
+  `ArithmeticFunction.LSeries_positive_of_eq_differentiable`.
+-/
+
+open scoped ComplexOrder
+
+lemma Complex.inv_natCast_cpow_ofReal_pos {n : ℕ} (hn : n ≠ 0) (x : ℝ) :
+    0 < ((n : ℂ) ^ (x : ℂ))⁻¹ := by
+  refine RCLike.inv_pos_of_pos ?_
+  rw [show (n : ℂ) ^ (x : ℂ) = (n : ℝ) ^ (x : ℂ) from rfl, ← ofReal_cpow n.cast_nonneg']
+  positivity
+
+open Complex
+
+namespace LSeries
+
+lemma term_nonneg {a : ℕ → ℂ} {n : ℕ} (h : 0 ≤ a n) (x : ℝ) : 0 ≤ term a x n := by
+  rw [term_def]
+  rcases eq_or_ne n 0 with rfl | hn
+  · simp only [↓reduceIte, le_refl]
+  · simp only [hn, ↓reduceIte]
+    refine mul_nonneg h (inv_natCast_cpow_ofReal_pos hn x).le
+
+lemma term_pos {a : ℕ → ℂ} {n : ℕ} (hn : n ≠ 0) (h : 0 < a n) (x : ℝ) : 0 < term a x n := by
+  simp only [ne_eq, hn, not_false_eq_true, term_of_ne_zero]
+  refine mul_pos h <| inv_natCast_cpow_ofReal_pos hn x
+
+/-- If all values of a `ℂ`-valued arithmetic function are nonnegative reals and `x` is a
+real number in the domain of absolute convergence, then the `n`th iterated derivative
+of the associated L-series is nonnegative real when `n` is even and nonpositive real
+when `n` is odd. -/
+lemma iteratedDeriv_alternating {a : ℕ → ℂ} (hn : 0 ≤ a) {x : ℝ}
+    (h : LSeries.abscissaOfAbsConv a < x) (n : ℕ) :
+    0 ≤ (-1) ^ n * iteratedDeriv n (LSeries a) x := by
+  rw [LSeries_iteratedDeriv _ h, LSeries, ← mul_assoc, ← pow_add, Even.neg_one_pow ⟨n, rfl⟩,
+    one_mul]
+  refine tsum_nonneg fun k ↦ ?_
+  rw [LSeries.term_def]
+  split
+  · exact le_rfl
+  · refine mul_nonneg ?_ <| (inv_natCast_cpow_ofReal_pos (by assumption) x).le
+    induction n with
+    | zero => simp only [Function.iterate_zero, id_eq]; exact hn k
+    | succ n IH =>
+        rw [Function.iterate_succ_apply']
+        refine mul_nonneg ?_ IH
+        simp only [← natCast_log, zero_le_real, Real.log_natCast_nonneg]
+
+/-- If all values of `a : ℕ → ℂ` are nonnegative reals and `a 1` is positive,
+then `L a x` is positive real for all real `x` larger than `abscissaOfAbsConv a`. -/
+lemma positive {a : ℕ → ℂ} (ha₀ : 0 ≤ a) (ha₁ : 0 < a 1) {x : ℝ} (hx : abscissaOfAbsConv a < x) :
+    0 < LSeries a x := by
+  rw [LSeries]
+  refine tsum_pos ?_ (fun n ↦ term_nonneg (ha₀ n) x) 1 <| term_pos one_ne_zero ha₁ x
+  exact LSeriesSummable_of_abscissaOfAbsConv_lt_re <| by simpa only [ofReal_re] using hx
+
+/-- If all values of `a : ℕ → ℂ` are nonnegative reals and `a 1`
+is positive, and the L-series of `a` agrees with an entire function `f` on some open
+right half-plane where it converges, then `f` is real and positive on `ℝ`. -/
+lemma positive_of_eq_differentiable {a : ℕ → ℂ} (ha₀ : 0 ≤ a) (ha₁ : 0 < a 1) {f : ℂ → ℂ}
+    (hf : Differentiable ℂ f) {x : ℝ} (hx : abscissaOfAbsConv a < x)
+    (hf' : {s | x < s.re}.EqOn f (LSeries a)) (y : ℝ) :
+    0 < f y := by
+  have hxy : x < max x y + 1 := (le_max_left x y).trans_lt (lt_add_one _)
+  have hxy' : abscissaOfAbsConv a < max x y + 1 := hx.trans <| mod_cast hxy
+  have hys : (max x y + 1 : ℂ) ∈ {s | x < s.re} := by
+    simp only [Set.mem_setOf_eq, add_re, ofReal_re, one_re, hxy]
+  have hfx : 0 < f (max x y + 1) := by
+    rw [hf' hys]
+    convert positive ha₀ ha₁ hxy'
+    simp only [ofReal_add, ofReal_one]
+  refine (hfx.trans_le <| hf.apply_le_of_iteratedDeriv_alternating (fun n _ ↦ ?_) ?_)
+  · have hs : IsOpen {s : ℂ | x < s.re} := by refine isOpen_lt ?_ ?_ <;> fun_prop
+    convert iteratedDeriv_alternating ha₀ hxy' n using 2
+    convert hf'.iteratedDeriv_of_isOpen hs n hys
+    simp only [ofReal_add, ofReal_one]
+  · exact_mod_cast (le_max_right x y).trans (lt_add_one _).le
+
+end LSeries
+
+namespace ArithmeticFunction
+
+/-- If all values of a `ℂ`-valued arithmetic function are nonnegative reals and `x` is a
+real number in the domain of absolute convergence, then the `n`th iterated derivative
+of the associated L-series is nonnegative real when `n` is even and nonpositive real
+when `n` is odd. -/
+lemma iteratedDeriv_LSeries_alternating (a : ArithmeticFunction ℂ) (hn : ∀ n, 0 ≤ a n) {x : ℝ}
+    (h : LSeries.abscissaOfAbsConv a < x) (n : ℕ) :
+    0 ≤ (-1) ^ n * iteratedDeriv n (LSeries (a ·)) x :=
+  LSeries.iteratedDeriv_alternating hn h n
+
+/-- If all values of a `ℂ`-valued arithmetic function `a` are nonnegative reals and `a 1` is
+positive, then `L a x` is positive real for all real `x` larger than `abscissaOfAbsConv a`. -/
+lemma LSeries_positive {a : ℕ → ℂ} (ha₀ : 0 ≤ a) (ha₁ : 0 < a 1) {x : ℝ}
+    (hx : LSeries.abscissaOfAbsConv a < x) :
+    0 < LSeries a x :=
+  LSeries.positive ha₀ ha₁ hx
+
+/-- If all values of a `ℂ`-valued arithmetic function `a` are nonnegative reals and `a 1`
+is positive, and the L-series of `a` agrees with an entire function `f` on some open
+right half-plane where it converges, then `f` is real and positive on `ℝ`. -/
+lemma LSeries_positive_of_eq_differentiable {a : ArithmeticFunction ℂ} (ha₀ : 0 ≤ (a ·))
+    (ha₁ : 0 < a 1) {f : ℂ → ℂ} (hf : Differentiable ℂ f) {x : ℝ}
+    (hx : LSeries.abscissaOfAbsConv a < x) (hf' : {s | x < s.re}.EqOn f (LSeries a)) (y : ℝ) :
+    0 < f y :=
+  LSeries.positive_of_eq_differentiable ha₀ ha₁ hf hx hf' y
+
+end ArithmeticFunction

--- a/Mathlib/NumberTheory/LSeries/Positivity.lean
+++ b/Mathlib/NumberTheory/LSeries/Positivity.lean
@@ -70,14 +70,11 @@ lemma positive_of_differentiable_of_eqOn {a : ℕ → ℂ} (ha₀ : 0 ≤ a) (ha
   have hys : (max x y + 1 : ℂ) ∈ {s | x < s.re} := by
     simp only [Set.mem_setOf_eq, add_re, ofReal_re, one_re, hxy]
   have hfx : 0 < f (max x y + 1) := by
-    rw [hf' hys]
-    convert positive ha₀ ha₁ hxy'
-    simp only [ofReal_add, ofReal_one]
+    simpa only [hf' hys, ofReal_add, ofReal_one] using positive ha₀ ha₁ hxy'
   refine (hfx.trans_le <| hf.apply_le_of_iteratedDeriv_alternating (fun n _ ↦ ?_) ?_)
-  · have hs : IsOpen {s : ℂ | x < s.re} := by refine isOpen_lt ?_ ?_ <;> fun_prop
-    convert iteratedDeriv_alternating ha₀ hxy' n using 2
-    convert hf'.iteratedDeriv_of_isOpen hs n hys
-    simp only [ofReal_add, ofReal_one]
+  · have hs : IsOpen {s : ℂ | x < s.re} := continuous_re.isOpen_preimage _ isOpen_Ioi
+    simpa only [hf'.iteratedDeriv_of_isOpen hs n hys, ofReal_add, ofReal_one] using
+      iteratedDeriv_alternating ha₀ hxy' n
   · exact_mod_cast (le_max_right x y).trans (lt_add_one _).le
 
 end LSeries

--- a/Mathlib/NumberTheory/LSeries/Positivity.lean
+++ b/Mathlib/NumberTheory/LSeries/Positivity.lean
@@ -62,11 +62,11 @@ lemma positive {a : ℕ → ℂ} (ha₀ : 0 ≤ a) (ha₁ : 0 < a 1) {x : ℝ} (
 is positive, and the L-series of `a` agrees with an entire function `f` on some open
 right half-plane where it converges, then `f` is real and positive on `ℝ`. -/
 lemma positive_of_differentiable_of_eqOn {a : ℕ → ℂ} (ha₀ : 0 ≤ a) (ha₁ : 0 < a 1) {f : ℂ → ℂ}
-    (hf : Differentiable ℂ f) {x : ℝ} (hx : abscissaOfAbsConv a < x)
+    (hf : Differentiable ℂ f) {x : ℝ} (hx : abscissaOfAbsConv a ≤ x)
     (hf' : {s | x < s.re}.EqOn f (LSeries a)) (y : ℝ) :
     0 < f y := by
   have hxy : x < max x y + 1 := (le_max_left x y).trans_lt (lt_add_one _)
-  have hxy' : abscissaOfAbsConv a < max x y + 1 := hx.trans <| mod_cast hxy
+  have hxy' : abscissaOfAbsConv a < max x y + 1 := hx.trans_lt <| mod_cast hxy
   have hys : (max x y + 1 : ℂ) ∈ {s | x < s.re} := by
     simp only [Set.mem_setOf_eq, add_re, ofReal_re, one_re, hxy]
   have hfx : 0 < f (max x y + 1) := by
@@ -105,7 +105,7 @@ is positive, and the L-series of `a` agrees with an entire function `f` on some 
 right half-plane where it converges, then `f` is real and positive on `ℝ`. -/
 lemma LSeries_positive_of_differentiable_of_eqOn {a : ArithmeticFunction ℂ} (ha₀ : 0 ≤ (a ·))
     (ha₁ : 0 < a 1) {f : ℂ → ℂ} (hf : Differentiable ℂ f) {x : ℝ}
-    (hx : LSeries.abscissaOfAbsConv a < x) (hf' : {s | x < s.re}.EqOn f (LSeries a)) (y : ℝ) :
+    (hx : LSeries.abscissaOfAbsConv a ≤ x) (hf' : {s | x < s.re}.EqOn f (LSeries a)) (y : ℝ) :
     0 < f y :=
   LSeries.positive_of_differentiable_of_eqOn ha₀ ha₁ hf hx hf' y
 


### PR DESCRIPTION
We use the newly added positivity results for holomorphic functions to show that the L-function associated to a sequence `a : ℕ → ℂ` such that `a 1 > 0` and `a n` is nonnegative real for all `n` takes positive real values on the real axis.

From [EulerProducts](https://github.com/MichaelStollBayreuth/EulerProducts); this is needed to prove the non-vanishing at `s = 1` of Dirichlet L-functions of nontrivial quadratic characters. 

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
