### PR TITLE
[Merged by Bors] - feat(Algebra/FreeMonoid): set of symbols appearing in an element of the free monoid

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -515,8 +515,8 @@ import Mathlib.Algebra.Module.Submodule.Range
 import Mathlib.Algebra.Module.Submodule.RestrictScalars
 import Mathlib.Algebra.Module.Torsion
 import Mathlib.Algebra.Module.ULift
-import Mathlib.Algebra.Module.Zlattice.Basic
-import Mathlib.Algebra.Module.Zlattice.Covolume
+import Mathlib.Algebra.Module.ZLattice.Basic
+import Mathlib.Algebra.Module.ZLattice.Covolume
 import Mathlib.Algebra.Module.ZMod
 import Mathlib.Algebra.MonoidAlgebra.Basic
 import Mathlib.Algebra.MonoidAlgebra.Defs

--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -213,6 +213,7 @@ import Mathlib.Algebra.Free
 import Mathlib.Algebra.FreeAlgebra
 import Mathlib.Algebra.FreeMonoid.Basic
 import Mathlib.Algebra.FreeMonoid.Count
+import Mathlib.Algebra.FreeMonoid.Symbols
 import Mathlib.Algebra.FreeNonUnitalNonAssocAlgebra
 import Mathlib.Algebra.GCDMonoid.Basic
 import Mathlib.Algebra.GCDMonoid.Finset
@@ -514,9 +515,9 @@ import Mathlib.Algebra.Module.Submodule.Range
 import Mathlib.Algebra.Module.Submodule.RestrictScalars
 import Mathlib.Algebra.Module.Torsion
 import Mathlib.Algebra.Module.ULift
-import Mathlib.Algebra.Module.ZLattice.Basic
-import Mathlib.Algebra.Module.ZLattice.Covolume
 import Mathlib.Algebra.Module.ZMod
+import Mathlib.Algebra.Module.Zlattice.Basic
+import Mathlib.Algebra.Module.Zlattice.Covolume
 import Mathlib.Algebra.MonoidAlgebra.Basic
 import Mathlib.Algebra.MonoidAlgebra.Defs
 import Mathlib.Algebra.MonoidAlgebra.Degree

--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -515,9 +515,9 @@ import Mathlib.Algebra.Module.Submodule.Range
 import Mathlib.Algebra.Module.Submodule.RestrictScalars
 import Mathlib.Algebra.Module.Torsion
 import Mathlib.Algebra.Module.ULift
-import Mathlib.Algebra.Module.ZMod
 import Mathlib.Algebra.Module.Zlattice.Basic
 import Mathlib.Algebra.Module.Zlattice.Covolume
+import Mathlib.Algebra.Module.ZMod
 import Mathlib.Algebra.MonoidAlgebra.Basic
 import Mathlib.Algebra.MonoidAlgebra.Defs
 import Mathlib.Algebra.MonoidAlgebra.Degree

--- a/Mathlib/Algebra/FreeMonoid/Symbols.lean
+++ b/Mathlib/Algebra/FreeMonoid/Symbols.lean
@@ -28,8 +28,7 @@ theorem symbols_one : symbols (1 : FreeMonoid α) = ∅ := rfl
 theorem symbols_of {m : α} : symbols (of m) = {m} := rfl
 
 @[to_additive (attr := simp)]
-theorem symbols_mul {a b : FreeMonoid α} : symbols (a * b : FreeMonoid α) =
-    (symbols a) ∪ (symbols b) := by
+theorem symbols_mul {a b : FreeMonoid α} : symbols (a * b) = symbols a ∪ symbols b := by
   simp only [symbols, List.mem_toFinset, Finset.mem_union]
   apply List.toFinset_append
 

--- a/Mathlib/Algebra/FreeMonoid/Symbols.lean
+++ b/Mathlib/Algebra/FreeMonoid/Symbols.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2024 Hannah Fechtner. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Author: Hannah Fechtner
+Authors: Hannah Fechtner
 -/
 
 import Mathlib.Algebra.FreeMonoid.Basic

--- a/Mathlib/Algebra/FreeMonoid/Symbols.lean
+++ b/Mathlib/Algebra/FreeMonoid/Symbols.lean
@@ -15,14 +15,16 @@ This is separated from the main FreeMonoid file, as it imports the finiteness hi
 
 variable {α : Type*} [DecidableEq α]
 
-open FreeMonoid
+namespace FreeMonoid
 
 /-- the set of unique symbols in a free monoid element -/
+@[to_additive "The set of unique symbols in an additive free monoid element"]
 def symbols (a : FreeMonoid α) : Finset α := List.toFinset a
 
 @[to_additive (attr := simp)]
 theorem symbols_one : symbols (1 : FreeMonoid α) = ∅ := rfl
 
+@[to_additive (attr := simp)]
 theorem symbols_of {m : α} : symbols (of m) = {m} := rfl
 
 @[to_additive (attr := simp)]
@@ -31,5 +33,8 @@ theorem symbols_mul {a b : FreeMonoid α} : symbols (a * b : FreeMonoid α) =
   simp only [symbols, List.mem_toFinset, Finset.mem_union]
   apply List.toFinset_append
 
+@[to_additive (attr := simp)]
 theorem mem_symbols {m : α} {a : FreeMonoid α} : m ∈ symbols a ↔ m ∈ a :=
   List.mem_toFinset
+
+end FreeMonoid

--- a/Mathlib/Algebra/FreeMonoid/Symbols.lean
+++ b/Mathlib/Algebra/FreeMonoid/Symbols.lean
@@ -1,0 +1,35 @@
+/-
+Copyright (c) 2024 Hannah Fechtner. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Author: Hannah Fechtner
+-/
+
+import Mathlib.Algebra.FreeMonoid.Basic
+import Mathlib.Data.Finset.Basic
+
+/-!
+# The finite set of symbols in a FreeMonoid element
+
+This is separated from the main FreeMonoid file, as it imports the finiteness hierarchy
+-/
+
+variable {α : Type*} [DecidableEq α]
+
+open FreeMonoid
+
+/-- the set of unique symbols in a free monoid element -/
+def symbols (a : FreeMonoid α) : Finset α := List.toFinset a
+
+@[to_additive (attr := simp)]
+theorem symbols_one : symbols (1 : FreeMonoid α) = ∅ := rfl
+
+theorem symbols_of {m : α} : symbols (of m) = {m} := rfl
+
+@[to_additive (attr := simp)]
+theorem symbols_mul {a b : FreeMonoid α} : symbols (a * b : FreeMonoid α) =
+    (symbols a) ∪ (symbols b) := by
+  simp only [symbols, List.mem_toFinset, Finset.mem_union]
+  apply List.toFinset_append
+
+theorem mem_symbols {m : α} {a : FreeMonoid α} : m ∈ symbols a ↔ m ∈ a :=
+  List.mem_toFinset

--- a/lake-manifest.json
+++ b/lake-manifest.json
@@ -5,7 +5,7 @@
    "type": "git",
    "subDir": null,
    "scope": "leanprover-community",
-   "rev": "dd6b1019b5cef990161bf3edfebeb6b0be78044a",
+   "rev": "7c5548eeeb1748da5c2872dbd866d3acbaea4b3f",
    "name": "batteries",
    "manifestFile": "lake-manifest.json",
    "inputRev": "main",

--- a/lake-manifest.json
+++ b/lake-manifest.json
@@ -5,7 +5,7 @@
    "type": "git",
    "subDir": null,
    "scope": "leanprover-community",
-   "rev": "7c5548eeeb1748da5c2872dbd866d3acbaea4b3f",
+   "rev": "dd6b1019b5cef990161bf3edfebeb6b0be78044a",
    "name": "batteries",
    "manifestFile": "lake-manifest.json",
    "inputRev": "main",


### PR DESCRIPTION
We add a separate file in which the set of symbols of a FreeMonoid element is defined. This is separated so that users of the basic FreeMonoid file need not unnecessarily import the finiteness hierarchy (as symbols is defined as a Finset)

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
