### PR TITLE
[Merged by Bors] - chore: fix two module docstrings

### DIFF
--- a/Mathlib/Data/DFinsupp/Basic.lean
+++ b/Mathlib/Data/DFinsupp/Basic.lean
@@ -17,7 +17,7 @@ import Mathlib.Order.ConditionallyCompleteLattice.Basic
 /-!
 # Dependent functions with finite support
 
-For a non-dependent version see `Data.Finsupp.Defs`.
+For a non-dependent version see `Mathlib.Data.Finsupp.Defs`.
 
 ## Notation
 

--- a/Mathlib/Data/DFinsupp/Basic.lean
+++ b/Mathlib/Data/DFinsupp/Basic.lean
@@ -17,7 +17,7 @@ import Mathlib.Order.ConditionallyCompleteLattice.Basic
 /-!
 # Dependent functions with finite support
 
-For a non-dependent version see `data/finsupp.lean`.
+For a non-dependent version see `Data.Finsupp.Defs`.
 
 ## Notation
 

--- a/Mathlib/LinearAlgebra/DFinsupp.lean
+++ b/Mathlib/LinearAlgebra/DFinsupp.lean
@@ -11,7 +11,7 @@ import Mathlib.LinearAlgebra.LinearIndependent
 # Properties of the module `Π₀ i, M i`
 
 Given an indexed collection of `R`-modules `M i`, the `R`-module structure on `Π₀ i, M i`
-is defined in `Data.DFinsupp`.
+is defined in `Data.DFinsupp.Basic`.
 
 In this file we define `LinearMap` versions of various maps:
 

--- a/Mathlib/LinearAlgebra/DFinsupp.lean
+++ b/Mathlib/LinearAlgebra/DFinsupp.lean
@@ -21,7 +21,7 @@ In this file we define `LinearMap` versions of various maps:
 
 * `DFinsupp.lapply i : (Π₀ i, M i) →ₗ[R] M`: the map `fun f ↦ f i` as a linear map;
 
-* `DFinsupp.lsum`: `DFinsupp.sum` or `DFinsupp.liftAddHom` as a `LinearMap`;
+* `DFinsupp.lsum`: `DFinsupp.sum` or `DFinsupp.liftAddHom` as a `LinearMap`.
 
 ## Implementation notes
 

--- a/Mathlib/LinearAlgebra/DFinsupp.lean
+++ b/Mathlib/LinearAlgebra/DFinsupp.lean
@@ -62,7 +62,8 @@ theorem lhom_ext ⦃φ ψ : (Π₀ i, M i) →ₗ[R] N⦄ (h : ∀ i x, φ (sing
 /-- Two `R`-linear maps from `Π₀ i, M i` which agree on each `single i x` agree everywhere.
 
 See note [partially-applied ext lemmas].
-After apply this lemma, if `M = R` then it suffices to verify `φ (single a 1) = ψ (single a 1)`. -/
+After applying this lemma, if `M = R` then it suffices to verify
+`φ (single a 1) = ψ (single a 1)`. -/
 @[ext 1100]
 theorem lhom_ext' ⦃φ ψ : (Π₀ i, M i) →ₗ[R] N⦄ (h : ∀ i, φ.comp (lsingle i) = ψ.comp (lsingle i)) :
     φ = ψ :=

--- a/Mathlib/LinearAlgebra/DFinsupp.lean
+++ b/Mathlib/LinearAlgebra/DFinsupp.lean
@@ -11,7 +11,7 @@ import Mathlib.LinearAlgebra.LinearIndependent
 # Properties of the module `Π₀ i, M i`
 
 Given an indexed collection of `R`-modules `M i`, the `R`-module structure on `Π₀ i, M i`
-is defined in `Data.DFinsupp.Basic`.
+is defined in `Mathlib.Data.DFinsupp.Basic`.
 
 In this file we define `LinearMap` versions of various maps:
 

--- a/Mathlib/LinearAlgebra/DFinsupp.lean
+++ b/Mathlib/LinearAlgebra/DFinsupp.lean
@@ -17,7 +17,7 @@ In this file we define `LinearMap` versions of various maps:
 
 * `DFinsupp.lsingle a : M →ₗ[R] Π₀ i, M i`: `DFinsupp.single a` as a linear map;
 
-* `DFinsupp.lmk s : (Π i : (↑s : Set ι), M i) →ₗ[R] Π₀ i, M i`: `DFinsupp.single a` as a linear map;
+* `DFinsupp.lmk s : (Π i : (↑s : Set ι), M i) →ₗ[R] Π₀ i, M i`: `DFinsupp.mk` as a linear map;
 
 * `DFinsupp.lapply i : (Π₀ i, M i) →ₗ[R] M`: the map `fun f ↦ f i` as a linear map;
 


### PR DESCRIPTION
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
