### PR TITLE
[Merged by Bors] - refactor(SetTheory/Ordinal/Basic): `type_lt` → `type_toType`

### DIFF
--- a/Mathlib/MeasureTheory/MeasurableSpace/Card.lean
+++ b/Mathlib/MeasureTheory/MeasurableSpace/Card.lean
@@ -121,7 +121,7 @@ theorem generateMeasurable_eq_rec (s : Set (Set α)) :
       refine mem_iUnion.2 ⟨Ordinal.enum (α := ω₁) (· < ·)
         ⟨Ordinal.lsub fun n => Ordinal.typein.{u} (α := ω₁) (· < ·) (I n), ?_⟩,
           iUnion_mem_generateMeasurableRec fun n => ⟨I n, ?_, hI n⟩⟩
-      · rw [Ordinal.type_lt]
+      · rw [Ordinal.type_toType]
         refine Ordinal.lsub_lt_ord_lift ?_ fun i => Ordinal.typein_lt_self _
         rw [mk_denumerable, lift_aleph0, isRegular_aleph_one.cof_eq]
         exact aleph0_lt_aleph_one

--- a/Mathlib/SetTheory/Cardinal/Cofinality.lean
+++ b/Mathlib/SetTheory/Cardinal/Cofinality.lean
@@ -206,7 +206,7 @@ theorem cof_eq_sInf_lsub (o : Ordinal.{u}) : cof o =
     sInf { a : Cardinal | ∃ (ι : Type u) (f : ι → Ordinal), lsub.{u, u} f = o ∧ #ι = a } := by
   refine le_antisymm (le_csInf (cof_lsub_def_nonempty o) ?_) (csInf_le' ?_)
   · rintro a ⟨ι, f, hf, rfl⟩
-    rw [← type_lt o]
+    rw [← type_toType o]
     refine
       (cof_type_le fun a => ?_).trans
         (@mk_le_of_injective _ _
@@ -220,7 +220,7 @@ theorem cof_eq_sInf_lsub (o : Ordinal.{u}) : cof o =
     simp_rw [← hf, lt_lsub_iff] at this
     cases' this with i hi
     refine ⟨enum (α := o.toType) (· < ·) ⟨f i, ?_⟩, ?_, ?_⟩
-    · rw [type_lt, ← hf]
+    · rw [type_toType, ← hf]
       apply lt_lsub
     · rw [mem_preimage, typein_enum]
       exact mem_range_self i
@@ -228,8 +228,8 @@ theorem cof_eq_sInf_lsub (o : Ordinal.{u}) : cof o =
   · rcases cof_eq (α := o.toType) (· < ·) with ⟨S, hS, hS'⟩
     let f : S → Ordinal := fun s => typein LT.lt s.val
     refine ⟨S, f, le_antisymm (lsub_le fun i => typein_lt_self (o := o) i)
-      (le_of_forall_lt fun a ha => ?_), by rwa [type_lt o] at hS'⟩
-    rw [← type_lt o] at ha
+      (le_of_forall_lt fun a ha => ?_), by rwa [type_toType o] at hS'⟩
+    rw [← type_toType o] at ha
     rcases hS (enum (· < ·) ⟨a, ha⟩) with ⟨b, hb, hb'⟩
     rw [← typein_le_typein, typein_enum] at hb'
     exact hb'.trans_lt (lt_lsub.{u, u} f ⟨b, hb⟩)

--- a/Mathlib/SetTheory/Ordinal/Arithmetic.lean
+++ b/Mathlib/SetTheory/Ordinal/Arithmetic.lean
@@ -317,7 +317,7 @@ instance orderTopToTypeSucc (o : Ordinal) : OrderTop (succ o).toType :=
   @OrderTop.mk _ _ (Top.mk _) le_enum_succ
 
 theorem enum_succ_eq_top {o : Ordinal} :
-    enum (α := (succ o).toType) (· < ·) ⟨o, by rw [type_lt]; exact lt_succ o⟩ = ⊤ :=
+    enum (α := (succ o).toType) (· < ·) ⟨o, type_toType _ ▸ lt_succ o⟩ = ⊤ :=
   rfl
 
 theorem has_succ_of_type_succ_lt {α} {r : α → α → Prop} [wo : IsWellOrder α r]
@@ -328,7 +328,7 @@ theorem has_succ_of_type_succ_lt {α} {r : α → α → Prop} [wo : IsWellOrder
   · rw [Subtype.mk_lt_mk, lt_succ_iff]
 
 theorem toType_noMax_of_succ_lt {o : Ordinal} (ho : ∀ a < o, succ a < o) : NoMaxOrder o.toType :=
-  ⟨has_succ_of_type_succ_lt (by rwa [type_lt])⟩
+  ⟨has_succ_of_type_succ_lt (type_toType _ ▸ ho)⟩
 
 @[deprecated toType_noMax_of_succ_lt (since := "2024-08-26")]
 alias out_no_max_of_succ_lt := toType_noMax_of_succ_lt
@@ -1072,7 +1072,7 @@ def familyOfBFamily' {ι : Type u} (r : ι → ι → Prop) [IsWellOrder ι r] {
 /-- Converts a family indexed by an `Ordinal.{u}` to one indexed by a `Type u` using a well-ordering
 given by the axiom of choice. -/
 def familyOfBFamily (o : Ordinal) (f : ∀ a < o, α) : o.toType → α :=
-  familyOfBFamily' (· < ·) (type_lt o) f
+  familyOfBFamily' (· < ·) (type_toType o) f
 
 @[simp]
 theorem bfamilyOfFamily'_typein {ι} (r : ι → ι → Prop) [IsWellOrder ι r] (f : ι → α) (i) :
@@ -1092,8 +1092,9 @@ theorem familyOfBFamily'_enum {ι : Type u} (r : ι → ι → Prop) [IsWellOrde
 
 @[simp, nolint simpNF] -- Porting note (#10959): simp cannot prove this
 theorem familyOfBFamily_enum (o : Ordinal) (f : ∀ a < o, α) (i hi) :
-    familyOfBFamily o f (enum (α := o.toType) (· < ·) ⟨i, hi.trans_eq (type_lt _).symm⟩) = f i hi :=
-  familyOfBFamily'_enum _ (type_lt o) f _ _
+    familyOfBFamily o f (enum (α := o.toType) (· < ·) ⟨i, hi.trans_eq (type_toType _).symm⟩)
+    = f i hi :=
+  familyOfBFamily'_enum _ (type_toType o) f _ _
 
 /-- The range of a family indexed by ordinals. -/
 def brange (o : Ordinal) (f : ∀ a < o, α) : Set α :=

--- a/Mathlib/SetTheory/Ordinal/Basic.lean
+++ b/Mathlib/SetTheory/Ordinal/Basic.lean
@@ -952,12 +952,12 @@ theorem enum_zero_le {r : α → α → Prop} [IsWellOrder α r] (h0 : 0 < type 
   apply Ordinal.zero_le
 
 theorem enum_zero_le' {o : Ordinal} (h0 : 0 < o) (a : o.toType) :
-    enum (α := o.toType) (· < ·) ⟨0, by rwa [type_toType]⟩ ≤ a := by
+    enum (α := o.toType) (· < ·) ⟨0, type_toType _ ▸ h0⟩ ≤ a := by
   rw [← not_lt]
   apply enum_zero_le
 
 theorem le_enum_succ {o : Ordinal} (a : (succ o).toType) :
-    a ≤ enum (α := (succ o).toType) (· < ·) ⟨o, (by rw [type_toType]; exact lt_succ o)⟩ := by
+    a ≤ enum (α := (succ o).toType) (· < ·) ⟨o, (type_toType _ ▸ lt_succ o)⟩ := by
   rw [← enum_typein (α := (succ o).toType) (· < ·) a, enum_le_enum', Subtype.mk_le_mk,
     ← lt_succ_iff]
   apply typein_lt_self
@@ -969,16 +969,11 @@ theorem enum_inj {r : α → α → Prop} [IsWellOrder α r] {o₁ o₂ : {o // 
 /-- The order isomorphism between ordinals less than `o` and `o.toType`. -/
 @[simps! (config := .lemmasOnly)]
 noncomputable def enumIsoToType (o : Ordinal) : Set.Iio o ≃o o.toType where
-  toFun x :=
-    enum (α := o.toType) (· < ·) ⟨x.1, by
-      rw [type_toType]
-      exact x.2⟩
+  toFun x := enum (α := o.toType) (· < ·) ⟨x.1, type_toType _ ▸ x.2⟩
   invFun x := ⟨typein (α := o.toType) (· < ·) x, typein_lt_self x⟩
   left_inv := fun ⟨_, _⟩ => Subtype.ext_val (typein_enum _ _)
   right_inv _ := enum_typein _ _
-  map_rel_iff' := by
-    rintro ⟨a, _⟩ ⟨b, _⟩
-    apply enum_le_enum'
+  map_rel_iff' := enum_le_enum' _
 
 @[deprecated (since := "2024-08-26")]
 alias enumIsoOut := enumIsoToType

--- a/Mathlib/SetTheory/Ordinal/Basic.lean
+++ b/Mathlib/SetTheory/Ordinal/Basic.lean
@@ -149,12 +149,16 @@ theorem type_def (r) [wo : IsWellOrder α r] : (⟦⟨α, r, wo⟩⟧ : Ordinal)
   rfl
 
 @[simp]
+theorem type_toType (o : Ordinal) : type (α := o.toType) (· < ·) = o :=
+  (type_def' _).symm.trans <| Quotient.out_eq o
+
+@[deprecated type_toType (since := "2024-10-22")]
 theorem type_lt (o : Ordinal) : type (α := o.toType) (· < ·) = o :=
   (type_def' _).symm.trans <| Quotient.out_eq o
 
-@[deprecated type_lt (since := "2024-08-26")]
+@[deprecated type_toType (since := "2024-08-26")]
 theorem type_out (o : Ordinal) : Ordinal.type o.out.r = o :=
-  type_lt o
+  type_toType o
 
 theorem type_eq {α β} {r : α → α → Prop} {s : β → β → Prop} [IsWellOrder α r] [IsWellOrder β s] :
     type r = type s ↔ Nonempty (r ≃r s) :=
@@ -202,7 +206,7 @@ theorem type_unit : type (@EmptyRelation Unit) = 1 :=
 
 @[simp]
 theorem toType_empty_iff_eq_zero {o : Ordinal} : IsEmpty o.toType ↔ o = 0 := by
-  rw [← @type_eq_zero_iff_isEmpty o.toType (· < ·), type_lt]
+  rw [← @type_eq_zero_iff_isEmpty o.toType (· < ·), type_toType]
 
 @[deprecated toType_empty_iff_eq_zero (since := "2024-08-26")]
 alias out_empty_iff_eq_zero := toType_empty_iff_eq_zero
@@ -216,7 +220,7 @@ instance isEmpty_toType_zero : IsEmpty (toType 0) :=
 
 @[simp]
 theorem toType_nonempty_iff_ne_zero {o : Ordinal} : Nonempty o.toType ↔ o ≠ 0 := by
-  rw [← @type_ne_zero_iff_nonempty o.toType (· < ·), type_lt]
+  rw [← @type_ne_zero_iff_nonempty o.toType (· < ·), type_toType]
 
 @[deprecated toType_nonempty_iff_ne_zero (since := "2024-08-26")]
 alias out_nonempty_iff_ne_zero := toType_nonempty_iff_ne_zero
@@ -356,7 +360,7 @@ instance NeZero.one : NeZero (1 : Ordinal) :=
 `α.toType` into `β.toType`. -/
 def initialSegToType {α β : Ordinal} (h : α ≤ β) : α.toType ≤i β.toType := by
   apply Classical.choice (type_le_iff.mp _)
-  rwa [type_lt, type_lt]
+  rwa [type_toType, type_toType]
 
 @[deprecated initialSegToType (since := "2024-08-26")]
 noncomputable alias initialSegOut := initialSegToType
@@ -365,7 +369,7 @@ noncomputable alias initialSegOut := initialSegToType
 of `α.toType` into `β.toType`. -/
 def principalSegToType {α β : Ordinal} (h : α < β) : α.toType <i β.toType := by
   apply Classical.choice (type_lt_iff.mp _)
-  rwa [type_lt, type_lt]
+  rwa [type_toType, type_toType]
 
 @[deprecated principalSegToType (since := "2024-08-26")]
 noncomputable alias principalSegOut := principalSegToType
@@ -407,7 +411,7 @@ theorem typein_lt_type (r : α → α → Prop) [IsWellOrder α r] (a : α) : ty
   (typein r).lt_top a
 
 theorem typein_lt_self {o : Ordinal} (i : o.toType) : typein (α := o.toType) (· < ·) i < o := by
-  simp_rw [← type_lt o]
+  simp_rw [← type_toType o]
   apply typein_lt_type
 
 @[simp]
@@ -948,12 +952,12 @@ theorem enum_zero_le {r : α → α → Prop} [IsWellOrder α r] (h0 : 0 < type 
   apply Ordinal.zero_le
 
 theorem enum_zero_le' {o : Ordinal} (h0 : 0 < o) (a : o.toType) :
-    enum (α := o.toType) (· < ·) ⟨0, by rwa [type_lt]⟩ ≤ a := by
+    enum (α := o.toType) (· < ·) ⟨0, by rwa [type_toType]⟩ ≤ a := by
   rw [← not_lt]
   apply enum_zero_le
 
 theorem le_enum_succ {o : Ordinal} (a : (succ o).toType) :
-    a ≤ enum (α := (succ o).toType) (· < ·) ⟨o, (by rw [type_lt]; exact lt_succ o)⟩ := by
+    a ≤ enum (α := (succ o).toType) (· < ·) ⟨o, (by rw [type_toType]; exact lt_succ o)⟩ := by
   rw [← enum_typein (α := (succ o).toType) (· < ·) a, enum_le_enum', Subtype.mk_le_mk,
     ← lt_succ_iff]
   apply typein_lt_self
@@ -967,7 +971,7 @@ theorem enum_inj {r : α → α → Prop} [IsWellOrder α r] {o₁ o₂ : {o // 
 noncomputable def enumIsoToType (o : Ordinal) : Set.Iio o ≃o o.toType where
   toFun x :=
     enum (α := o.toType) (· < ·) ⟨x.1, by
-      rw [type_lt]
+      rw [type_toType]
       exact x.2⟩
   invFun x := ⟨typein (α := o.toType) (· < ·) x, typein_lt_self x⟩
   left_inv := fun ⟨_, _⟩ => Subtype.ext_val (typein_enum _ _)
@@ -999,7 +1003,7 @@ def toTypeOrderBotOfPos {o : Ordinal} (ho : 0 < o) : OrderBot o.toType where
 noncomputable alias outOrderBotOfPos := toTypeOrderBotOfPos
 
 theorem enum_zero_eq_bot {o : Ordinal} (ho : 0 < o) :
-    enum (α := o.toType) (· < ·) ⟨0, by rwa [type_lt]⟩ =
+    enum (α := o.toType) (· < ·) ⟨0, by rwa [type_toType]⟩ =
       have _ := toTypeOrderBotOfPos ho
       (⊥ : o.toType) :=
   rfl
@@ -1097,7 +1101,7 @@ open Ordinal
 
 @[simp]
 theorem mk_toType (o : Ordinal) : #o.toType = o.card :=
-  (Ordinal.card_type _).symm.trans <| by rw [Ordinal.type_lt]
+  (Ordinal.card_type _).symm.trans <| by rw [Ordinal.type_toType]
 
 @[deprecated mk_toType (since := "2024-08-26")]
 alias mk_ordinal_out := mk_toType


### PR DESCRIPTION
The new name is much more discoverable and makes clear that this isn't just any `<` relation.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
