### PR TITLE
[Merged by Bors] - chore(Algebra): use newly introduced finset notation

### DIFF
--- a/Mathlib/Algebra/BigOperators/Expect.lean
+++ b/Mathlib/Algebra/BigOperators/Expect.lean
@@ -53,7 +53,7 @@ local notation a " /ℚ " q => (q : ℚ≥0)⁻¹ • a
 
 /-- Average of a function over a finset. If the finset is empty, this is equal to zero. -/
 def Finset.expect [AddCommMonoid M] [Module ℚ≥0 M] (s : Finset ι) (f : ι → M) : M :=
-  (s.card : ℚ≥0)⁻¹ • ∑ i ∈ s, f i
+  (#s : ℚ≥0)⁻¹ • ∑ i ∈ s, f i
 
 namespace BigOperators
 open Batteries.ExtendedBinder Lean Meta
@@ -152,36 +152,36 @@ lemma expect_add_expect_comm (f₁ f₂ g₁ g₂ : ι → M) :
   simp_rw [expect_add_distrib, add_add_add_comm]
 
 lemma expect_eq_single_of_mem (i : ι) (hi : i ∈ s) (h : ∀ j ∈ s, j ≠ i → f j = 0) :
-    𝔼 i ∈ s, f i = f i /ℚ s.card := by rw [expect, sum_eq_single_of_mem _ hi h]
+    𝔼 i ∈ s, f i = f i /ℚ #s := by rw [expect, sum_eq_single_of_mem _ hi h]
 
 lemma expect_ite_zero (s : Finset ι) (p : ι → Prop) [DecidablePred p]
     (h : ∀ i ∈ s, ∀ j ∈ s, p i → p j → i = j) (a : M) :
-    𝔼 i ∈ s, ite (p i) a 0 = ite (∃ i ∈ s, p i) (a /ℚ s.card) 0 := by
+    𝔼 i ∈ s, ite (p i) a 0 = ite (∃ i ∈ s, p i) (a /ℚ #s) 0 := by
   split_ifs <;> simp [expect, sum_ite_zero _ _ h, *]
 
 section DecidableEq
 variable [DecidableEq ι]
 
 lemma expect_ite_mem (s t : Finset ι) (f : ι → M) :
-    𝔼 i ∈ s, (if i ∈ t then f i else 0) = ((s ∩ t).card / s.card : ℚ≥0) • 𝔼 i ∈ s ∩ t, f i := by
+    𝔼 i ∈ s, (if i ∈ t then f i else 0) = (#(s ∩ t) / #s : ℚ≥0) • 𝔼 i ∈ s ∩ t, f i := by
   obtain hst | hst := (s ∩ t).eq_empty_or_nonempty
   · simp [expect, hst]
   · simp [expect, smul_smul, ← inv_mul_eq_div, hst.card_ne_zero]
 
 @[simp] lemma expect_dite_eq (i : ι) (f : ∀ j, i = j → M) :
-    𝔼 j ∈ s, (if h : i = j then f j h else 0) = if i ∈ s then f i rfl /ℚ s.card else 0 := by
+    𝔼 j ∈ s, (if h : i = j then f j h else 0) = if i ∈ s then f i rfl /ℚ #s else 0 := by
   split_ifs <;> simp [expect, *]
 
 @[simp] lemma expect_dite_eq' (i : ι) (f : ∀ j, j = i → M) :
-    𝔼 j ∈ s, (if h : j = i then f j h else 0) = if i ∈ s then f i rfl /ℚ s.card else 0 := by
+    𝔼 j ∈ s, (if h : j = i then f j h else 0) = if i ∈ s then f i rfl /ℚ #s else 0 := by
   split_ifs <;> simp [expect, *]
 
 @[simp] lemma expect_ite_eq (i : ι) (f : ι → M) :
-    𝔼 j ∈ s, (if i = j then f j else 0) = if i ∈ s then f i /ℚ s.card else 0 := by
+    𝔼 j ∈ s, (if i = j then f j else 0) = if i ∈ s then f i /ℚ #s else 0 := by
   split_ifs <;> simp [expect, *]
 
 @[simp] lemma expect_ite_eq' (i : ι) (f : ι → M) :
-    𝔼 j ∈ s, (if j = i then f j else 0) = if i ∈ s then f i /ℚ s.card else 0 := by
+    𝔼 j ∈ s, (if j = i then f j else 0) = if i ∈ s then f i /ℚ #s else 0 := by
   split_ifs <;> simp [expect, *]
 
 end DecidableEq
@@ -279,7 +279,7 @@ lemma _root_.map_expect {F : Type*} [FunLike F M N] [LinearMapClass F ℚ≥0 M 
     g (𝔼 i ∈ s, f i) = 𝔼 i ∈ s, g (f i) := by simp only [expect, map_smul, map_natCast, map_sum]
 
 @[simp]
-lemma card_smul_expect (s : Finset ι) (f : ι → M) : s.card • 𝔼 i ∈ s, f i = ∑ i ∈ s, f i := by
+lemma card_smul_expect (s : Finset ι) (f : ι → M) : #s • 𝔼 i ∈ s, f i = ∑ i ∈ s, f i := by
   obtain rfl | hs := s.eq_empty_or_nonempty
   · simp
   · rw [expect, ← Nat.cast_smul_eq_nsmul ℚ≥0, smul_inv_smul₀]
@@ -315,7 +315,7 @@ section Semiring
 variable [Semiring M] [Module ℚ≥0 M]
 
 @[simp] lemma card_mul_expect (s : Finset ι) (f : ι → M) :
-    s.card * 𝔼 i ∈ s, f i = ∑ i ∈ s, f i := by rw [← nsmul_eq_mul, card_smul_expect]
+    #s * 𝔼 i ∈ s, f i = ∑ i ∈ s, f i := by rw [← nsmul_eq_mul, card_smul_expect]
 
 @[simp] lemma _root_.Fintype.card_mul_expect [Fintype ι] (f : ι → M) :
     Fintype.card ι * 𝔼 i, f i = ∑ i, f i := Finset.card_mul_expect _ _
@@ -357,7 +357,7 @@ lemma expect_boole_mul' [Fintype ι] [Nonempty ι] [DecidableEq ι] (f : ι → 
   simp_rw [@eq_comm _ _ i, expect_boole_mul]
 
 lemma expect_eq_sum_div_card (s : Finset ι) (f : ι → M) :
-    𝔼 i ∈ s, f i = (∑ i ∈ s, f i) / s.card := by
+    𝔼 i ∈ s, f i = (∑ i ∈ s, f i) / #s := by
   rw [expect, NNRat.smul_def, div_eq_inv_mul, NNRat.cast_inv, NNRat.cast_natCast]
 
 lemma _root_.Fintype.expect_eq_sum_div_card [Fintype ι] (f : ι → M) :

--- a/Mathlib/Algebra/BigOperators/Group/Finset.lean
+++ b/Mathlib/Algebra/BigOperators/Group/Finset.lean
@@ -931,7 +931,7 @@ theorem prod_eq_mul {s : Finset α} {f : α → β} (a b : α) (hn : a ≠ b)
 -- Porting note: simpNF linter complains that LHS doesn't simplify, but it does
 /-- A product over `s.subtype p` equals one over `{x ∈ s | p x}`. -/
 @[to_additive (attr := simp, nolint simpNF)
-  "A sum over `s.subtype p` equals one over `{x ∈ s | p x}p`."]
+"A sum over `s.subtype p` equals one over `{x ∈ s | p x}`."]
 theorem prod_subtype_eq_prod_filter (f : α → β) {p : α → Prop} [DecidablePred p] :
     ∏ x ∈ s.subtype p, f x = ∏ x ∈ s with p x, f x := by
   conv_lhs => erw [← prod_map (s.subtype p) (Function.Embedding.subtype _) f]

--- a/Mathlib/Algebra/BigOperators/Group/Finset.lean
+++ b/Mathlib/Algebra/BigOperators/Group/Finset.lean
@@ -416,7 +416,7 @@ theorem prod_union [DecidableEq α] (h : Disjoint s₁ s₂) :
 @[to_additive]
 theorem prod_filter_mul_prod_filter_not
     (s : Finset α) (p : α → Prop) [DecidablePred p] [∀ x, Decidable (¬p x)] (f : α → β) :
-    (∏ x ∈ s.filter p, f x) * ∏ x ∈ s.filter fun x => ¬p x, f x = ∏ x ∈ s, f x := by
+    (∏ x ∈ s with p x, f x) * ∏ x ∈ s with ¬p x, f x = ∏ x ∈ s, f x := by
   have := Classical.decEq α
   rw [← prod_union (disjoint_filter_filter_neg s s p), filter_union_filter_neg_eq]
 
@@ -463,11 +463,11 @@ lemma prod_powerset_cons (ha : a ∉ s) (f : Finset α → β) :
   rw [prod_powerset_insert ha, prod_attach _ fun t ↦ f (insert a t)]
 
 /-- A product over `powerset s` is equal to the double product over sets of subsets of `s` with
-`card s = k`, for `k = 1, ..., card s`. -/
+`#s = k`, for `k = 1, ..., #s`. -/
 @[to_additive "A sum over `powerset s` is equal to the double sum over sets of subsets of `s` with
-  `card s = k`, for `k = 1, ..., card s`"]
+`#s = k`, for `k = 1, ..., #s`"]
 lemma prod_powerset (s : Finset α) (f : Finset α → β) :
-    ∏ t ∈ powerset s, f t = ∏ j ∈ range (card s + 1), ∏ t ∈ powersetCard j s, f t := by
+    ∏ t ∈ powerset s, f t = ∏ j ∈ range (#s + 1), ∏ t ∈ powersetCard j s, f t := by
   rw [powerset_card_disjiUnion, prod_disjiUnion]
 
 end CommMonoid
@@ -676,27 +676,27 @@ variable [DecidableEq κ]
 
 @[to_additive]
 lemma prod_fiberwise_eq_prod_filter (s : Finset ι) (t : Finset κ) (g : ι → κ) (f : ι → α) :
-    ∏ j ∈ t, ∏ i ∈ s.filter fun i ↦ g i = j, f i = ∏ i ∈ s.filter fun i ↦ g i ∈ t, f i := by
+    ∏ j ∈ t, ∏ i ∈ s with g i = j, f i = ∏ i ∈ s with g i ∈ t, f i := by
   rw [← prod_disjiUnion, disjiUnion_filter_eq]
 
 @[to_additive]
 lemma prod_fiberwise_eq_prod_filter' (s : Finset ι) (t : Finset κ) (g : ι → κ) (f : κ → α) :
-    ∏ j ∈ t, ∏ _i ∈ s.filter fun i ↦ g i = j, f j = ∏ i ∈ s.filter fun i ↦ g i ∈ t, f (g i) := by
+    ∏ j ∈ t, ∏ i ∈ s with g i = j, f j = ∏ i ∈ s with g i ∈ t, f (g i) := by
   calc
-    _ = ∏ j ∈ t, ∏ i ∈ s.filter fun i ↦ g i = j, f (g i) :=
+    _ = ∏ j ∈ t, ∏ i ∈ s with g i = j, f (g i) :=
         prod_congr rfl fun j _ ↦ prod_congr rfl fun i hi ↦ by rw [(mem_filter.1 hi).2]
     _ = _ := prod_fiberwise_eq_prod_filter _ _ _ _
 
 @[to_additive]
 lemma prod_fiberwise_of_maps_to {g : ι → κ} (h : ∀ i ∈ s, g i ∈ t) (f : ι → α) :
-    ∏ j ∈ t, ∏ i ∈ s.filter fun i ↦ g i = j, f i = ∏ i ∈ s, f i := by
+    ∏ j ∈ t, ∏ i ∈ s with g i = j, f i = ∏ i ∈ s, f i := by
   rw [← prod_disjiUnion, disjiUnion_filter_eq_of_maps_to h]
 
 @[to_additive]
 lemma prod_fiberwise_of_maps_to' {g : ι → κ} (h : ∀ i ∈ s, g i ∈ t) (f : κ → α) :
-    ∏ j ∈ t, ∏ _i ∈ s.filter fun i ↦ g i = j, f j = ∏ i ∈ s, f (g i) := by
+    ∏ j ∈ t, ∏ i ∈ s with g i = j, f j = ∏ i ∈ s, f (g i) := by
   calc
-    _ = ∏ y ∈ t, ∏ x ∈ s.filter fun x ↦ g x = y, f (g x) :=
+    _ = ∏ j ∈ t, ∏ i ∈ s with g i = j, f (g i) :=
         prod_congr rfl fun y _ ↦ prod_congr rfl fun x hx ↦ by rw [(mem_filter.1 hx).2]
     _ = _ := prod_fiberwise_of_maps_to h _
 
@@ -704,12 +704,12 @@ variable [Fintype κ]
 
 @[to_additive]
 lemma prod_fiberwise (s : Finset ι) (g : ι → κ) (f : ι → α) :
-    ∏ j, ∏ i ∈ s.filter fun i ↦ g i = j, f i = ∏ i ∈ s, f i :=
+    ∏ j, ∏ i ∈ s with g i = j, f i = ∏ i ∈ s, f i :=
   prod_fiberwise_of_maps_to (fun _ _ ↦ mem_univ _) _
 
 @[to_additive]
 lemma prod_fiberwise' (s : Finset ι) (g : ι → κ) (f : κ → α) :
-    ∏ j, ∏ _i ∈ s.filter fun i ↦ g i = j, f j = ∏ i ∈ s, f (g i) :=
+    ∏ j, ∏ i ∈ s with g i = j, f j = ∏ i ∈ s, f (g i) :=
   prod_fiberwise_of_maps_to' (fun _ _ ↦ mem_univ _) _
 
 end bij
@@ -759,15 +759,15 @@ theorem prod_finset_product_right' (r : Finset (α × γ)) (s : Finset γ) (t : 
   prod_finset_product_right r s t h
 
 @[to_additive]
-theorem prod_image' [DecidableEq α] {s : Finset γ} {g : γ → α} (h : γ → β)
-    (eq : ∀ c ∈ s, f (g c) = ∏ x ∈ s.filter fun c' => g c' = g c, h x) :
-    ∏ x ∈ s.image g, f x = ∏ x ∈ s, h x :=
+theorem prod_image' [DecidableEq α] {s : Finset ι} {g : ι → α} (h : ι → β)
+    (eq : ∀ i ∈ s, f (g i) = ∏ j ∈ s with g j = g i, h j) :
+    ∏ a ∈ s.image g, f a = ∏ i ∈ s, h i :=
   calc
-    ∏ x ∈ s.image g, f x = ∏ x ∈ s.image g, ∏ x ∈ s.filter fun c' => g c' = x, h x :=
-      (prod_congr rfl) fun _x hx =>
-        let ⟨c, hcs, hc⟩ := mem_image.1 hx
-        hc ▸ eq c hcs
-    _ = ∏ x ∈ s, h x := prod_fiberwise_of_maps_to (fun _x => mem_image_of_mem g) _
+    ∏ a ∈ s.image g, f a = ∏ a ∈ s.image g, ∏ j ∈ s with g j = a, h j :=
+      (prod_congr rfl) fun _a hx =>
+        let ⟨i, his, hi⟩ := mem_image.1 hx
+        hi ▸ eq i his
+    _ = ∏ i ∈ s, h i := prod_fiberwise_of_maps_to (fun _ => mem_image_of_mem g) _
 
 @[to_additive]
 theorem prod_mul_distrib : ∏ x ∈ s, f x * g x = (∏ x ∈ s, f x) * ∏ x ∈ s, g x :=
@@ -836,7 +836,7 @@ theorem prod_hom_rel [CommMonoid γ] {r : β → γ → Prop} {f : α → β} {g
 
 @[to_additive]
 theorem prod_filter_of_ne {p : α → Prop} [DecidablePred p] (hp : ∀ x ∈ s, f x ≠ 1 → p x) :
-    ∏ x ∈ s.filter p, f x = ∏ x ∈ s, f x :=
+    ∏ x ∈ s with p x, f x = ∏ x ∈ s, f x :=
   (prod_subset (filter_subset _ _)) fun x => by
     classical
       rw [not_imp_comm, mem_filter]
@@ -846,14 +846,14 @@ theorem prod_filter_of_ne {p : α → Prop} [DecidablePred p] (hp : ∀ x ∈ s,
 -- instance first; `{∀ x, Decidable (f x ≠ 1)}` doesn't work with `rw ← prod_filter_ne_one`
 @[to_additive]
 theorem prod_filter_ne_one (s : Finset α) [∀ x, Decidable (f x ≠ 1)] :
-    ∏ x ∈ s.filter fun x => f x ≠ 1, f x = ∏ x ∈ s, f x :=
+    ∏ x ∈ s with f x ≠ 1, f x = ∏ x ∈ s, f x :=
   prod_filter_of_ne fun _ _ => id
 
 @[to_additive]
 theorem prod_filter (p : α → Prop) [DecidablePred p] (f : α → β) :
-    ∏ a ∈ s.filter p, f a = ∏ a ∈ s, if p a then f a else 1 :=
+    ∏ a ∈ s with p a, f a = ∏ a ∈ s, if p a then f a else 1 :=
   calc
-    ∏ a ∈ s.filter p, f a = ∏ a ∈ s.filter p, if p a then f a else 1 :=
+    ∏ a ∈ s with p a, f a = ∏ a ∈ s with p a, if p a then f a else 1 :=
       prod_congr rfl fun a h => by rw [if_pos]; simpa using (mem_filter.1 h).2
     _ = ∏ a ∈ s, if p a then f a else 1 := by
       { refine prod_subset (filter_subset _ s) fun x hs h => ?_
@@ -929,11 +929,11 @@ theorem prod_eq_mul {s : Finset α} {f : α → β} (a b : α) (hn : a ≠ b)
         prod_const_one
 
 -- Porting note: simpNF linter complains that LHS doesn't simplify, but it does
-/-- A product over `s.subtype p` equals one over `s.filter p`. -/
+/-- A product over `s.subtype p` equals one over `{x ∈ s | p x}`. -/
 @[to_additive (attr := simp, nolint simpNF)
-  "A sum over `s.subtype p` equals one over `s.filter p`."]
+  "A sum over `s.subtype p` equals one over `{x ∈ s | p x}p`."]
 theorem prod_subtype_eq_prod_filter (f : α → β) {p : α → Prop} [DecidablePred p] :
-    ∏ x ∈ s.subtype p, f x = ∏ x ∈ s.filter p, f x := by
+    ∏ x ∈ s.subtype p, f x = ∏ x ∈ s with p x, f x := by
   conv_lhs => erw [← prod_map (s.subtype p) (Function.Embedding.subtype _) f]
   exact prod_congr (subtype_map _) fun x _hx => rfl
 
@@ -983,12 +983,12 @@ theorem prod_subtype {p : α → Prop} {F : Fintype (Subtype p)} (s : Finset α)
 
 @[to_additive]
 lemma prod_preimage' (f : ι → κ) [DecidablePred (· ∈ Set.range f)] (s : Finset κ) (hf) (g : κ → β) :
-    ∏ x ∈ s.preimage f hf, g (f x) = ∏ x ∈ s.filter (· ∈ Set.range f), g x := by
+    ∏ x ∈ s.preimage f hf, g (f x) = ∏ x ∈ s with x ∈ Set.range f, g x := by
   classical
   calc
     ∏ x ∈ preimage s f hf, g (f x) = ∏ x ∈ image f (preimage s f hf), g x :=
       Eq.symm <| prod_image <| by simpa only [mem_preimage, Set.InjOn] using hf
-    _ = ∏ x ∈ s.filter fun x => x ∈ Set.range f, g x := by rw [image_preimage]
+    _ = ∏ x ∈ s with x ∈ Set.range f, g x := by rw [image_preimage]
 
 @[to_additive]
 lemma prod_preimage (f : ι → κ) (s : Finset κ) (hf) (g : κ → β)
@@ -1026,18 +1026,18 @@ theorem prod_congr_set {α : Type*} [CommMonoid α] {β : Type*} [Fintype β] (s
 theorem prod_apply_dite {s : Finset α} {p : α → Prop} {hp : DecidablePred p}
     [DecidablePred fun x => ¬p x] (f : ∀ x : α, p x → γ) (g : ∀ x : α, ¬p x → γ) (h : γ → β) :
     (∏ x ∈ s, h (if hx : p x then f x hx else g x hx)) =
-      (∏ x ∈ (s.filter p).attach, h (f x.1 <| by simpa using (mem_filter.mp x.2).2)) *
-        ∏ x ∈ (s.filter fun x => ¬p x).attach, h (g x.1 <| by simpa using (mem_filter.mp x.2).2) :=
+      (∏ x : {x ∈ s | p x}, h (f x.1 <| by simpa using (mem_filter.mp x.2).2)) *
+        ∏ x : {x ∈ s | ¬p x}, h (g x.1 <| by simpa using (mem_filter.mp x.2).2) :=
   calc
     (∏ x ∈ s, h (if hx : p x then f x hx else g x hx)) =
-        (∏ x ∈ s.filter p, h (if hx : p x then f x hx else g x hx)) *
-          ∏ x ∈ s.filter (¬p ·), h (if hx : p x then f x hx else g x hx) :=
+        (∏ x ∈ s with p x, h (if hx : p x then f x hx else g x hx)) *
+          ∏ x ∈ s with ¬p x, h (if hx : p x then f x hx else g x hx) :=
       (prod_filter_mul_prod_filter_not s p _).symm
-    _ = (∏ x ∈ (s.filter p).attach, h (if hx : p x.1 then f x.1 hx else g x.1 hx)) *
-          ∏ x ∈ (s.filter (¬p ·)).attach, h (if hx : p x.1 then f x.1 hx else g x.1 hx) :=
+    _ = (∏ x : {x ∈ s | p x}, h (if hx : p x.1 then f x.1 hx else g x.1 hx)) *
+          ∏ x : {x ∈ s | ¬p x}, h (if hx : p x.1 then f x.1 hx else g x.1 hx) :=
       congr_arg₂ _ (prod_attach _ _).symm (prod_attach _ _).symm
-    _ = (∏ x ∈ (s.filter p).attach, h (f x.1 <| by simpa using (mem_filter.mp x.2).2)) *
-          ∏ x ∈ (s.filter (¬p ·)).attach, h (g x.1 <| by simpa using (mem_filter.mp x.2).2) :=
+    _ = (∏ x : {x ∈ s | p x}, h (f x.1 <| by simpa using (mem_filter.mp x.2).2)) *
+          ∏ x : {x ∈ s | ¬p x}, h (g x.1 <| by simpa using (mem_filter.mp x.2).2) :=
       congr_arg₂ _ (prod_congr rfl fun x _hx ↦
         congr_arg h (dif_pos <| by simpa using (mem_filter.mp x.2).2))
         (prod_congr rfl fun x _hx => congr_arg h (dif_neg <| by simpa using (mem_filter.mp x.2).2))
@@ -1046,21 +1046,20 @@ theorem prod_apply_dite {s : Finset α} {p : α → Prop} {hp : DecidablePred p}
 theorem prod_apply_ite {s : Finset α} {p : α → Prop} {_hp : DecidablePred p} (f g : α → γ)
     (h : γ → β) :
     (∏ x ∈ s, h (if p x then f x else g x)) =
-      (∏ x ∈ s.filter p, h (f x)) * ∏ x ∈ s.filter fun x => ¬p x, h (g x) :=
+      (∏ x ∈ s with p x, h (f x)) * ∏ x ∈ s with ¬p x, h (g x) :=
   (prod_apply_dite _ _ _).trans <| congr_arg₂ _ (prod_attach _ (h ∘ f)) (prod_attach _ (h ∘ g))
 
 @[to_additive]
 theorem prod_dite {s : Finset α} {p : α → Prop} {hp : DecidablePred p} (f : ∀ x : α, p x → β)
     (g : ∀ x : α, ¬p x → β) :
     ∏ x ∈ s, (if hx : p x then f x hx else g x hx) =
-      (∏ x ∈ (s.filter p).attach, f x.1 (by simpa using (mem_filter.mp x.2).2)) *
-        ∏ x ∈ (s.filter fun x => ¬p x).attach, g x.1 (by simpa using (mem_filter.mp x.2).2) := by
+      (∏ x : {x ∈ s | p x}, f x.1 (by simpa using (mem_filter.mp x.2).2)) *
+        ∏ x : {x ∈ s | ¬p x}, g x.1 (by simpa using (mem_filter.mp x.2).2) := by
   simp [prod_apply_dite _ _ fun x => x]
 
 @[to_additive]
 theorem prod_ite {s : Finset α} {p : α → Prop} {hp : DecidablePred p} (f g : α → β) :
-    ∏ x ∈ s, (if p x then f x else g x) =
-      (∏ x ∈ s.filter p, f x) * ∏ x ∈ s.filter fun x => ¬p x, g x := by
+    ∏ x ∈ s, (if p x then f x else g x) = (∏ x ∈ s with p x, f x) * ∏ x ∈ s with ¬p x, g x := by
   simp [prod_apply_ite _ _ fun x => x]
 
 @[to_additive]
@@ -1219,7 +1218,7 @@ lemma prod_mulIndicator_subset (f : ι → β) {s t : Finset ι} (h : s ⊆ t) :
 @[to_additive]
 lemma prod_mulIndicator_eq_prod_filter (s : Finset ι) (f : ι → κ → β) (t : ι → Set κ) (g : ι → κ)
     [DecidablePred fun i ↦ g i ∈ t i] :
-    ∏ i ∈ s, mulIndicator (t i) (f i) (g i) = ∏ i ∈ s.filter fun i ↦ g i ∈ t i, f i (g i) := by
+    ∏ i ∈ s, mulIndicator (t i) (f i) (g i) = ∏ i ∈ s with g i ∈ t i, f i (g i) := by
   refine (prod_filter_mul_prod_filter_not s (fun i ↦ g i ∈ t i) _).symm.trans <|
      Eq.trans (congr_arg₂ (· * ·) ?_ ?_) (mul_one _)
   · exact prod_congr rfl fun x hx ↦ mulIndicator_of_mem (mem_filter.1 hx).2 _
@@ -1264,8 +1263,8 @@ theorem prod_bij_ne_one {s : Finset α} {t : Finset γ} {f : α → β} {g : γ 
     ∏ x ∈ s, f x = ∏ x ∈ t, g x := by
   classical
   calc
-    ∏ x ∈ s, f x = ∏ x ∈ s.filter fun x => f x ≠ 1, f x := by rw [prod_filter_ne_one]
-    _ = ∏ x ∈ t.filter fun x => g x ≠ 1, g x :=
+    ∏ x ∈ s, f x = ∏ x ∈ s with f x ≠ 1, f x := by rw [prod_filter_ne_one]
+    _ = ∏ x ∈ t with g x ≠ 1, g x :=
       prod_bij (fun a ha => i a (mem_filter.mp ha).1 <| by simpa using (mem_filter.mp ha).2)
         ?_ ?_ ?_ ?_
     _ = ∏ x ∈ t, g x := prod_filter_ne_one _
@@ -1376,7 +1375,7 @@ theorem prod_list_count_of_subset [DecidableEq α] [CommMonoid α] (m : List α)
   rw [count_eq_zero_of_not_mem hx, pow_zero]
 
 theorem sum_filter_count_eq_countP [DecidableEq α] (p : α → Prop) [DecidablePred p] (l : List α) :
-    ∑ x ∈ l.toFinset.filter p, l.count x = l.countP p := by
+    ∑ x ∈ l.toFinset with p x, l.count x = l.countP p := by
   simp [Finset.sum, sum_map_count_dedup_filter_eq_countP p l]
 
 open Multiset
@@ -1484,19 +1483,19 @@ theorem sum_tsub_distrib [AddCommMonoid α] [PartialOrder α] [ExistsAddOfLE α]
     ∑ x ∈ s, (f x - g x) = ∑ x ∈ s, f x - ∑ x ∈ s, g x := sum_map_tsub _ hfg
 
 @[to_additive (attr := simp)]
-theorem prod_const (b : β) : ∏ _x ∈ s, b = b ^ s.card :=
-  (congr_arg _ <| s.val.map_const b).trans <| Multiset.prod_replicate s.card b
+theorem prod_const (b : β) : ∏ _x ∈ s, b = b ^ #s :=
+  (congr_arg _ <| s.val.map_const b).trans <| Multiset.prod_replicate #s b
 
 @[to_additive sum_eq_card_nsmul]
-theorem prod_eq_pow_card {b : β} (hf : ∀ a ∈ s, f a = b) : ∏ a ∈ s, f a = b ^ s.card :=
+theorem prod_eq_pow_card {b : β} (hf : ∀ a ∈ s, f a = b) : ∏ a ∈ s, f a = b ^ #s :=
   (prod_congr rfl hf).trans <| prod_const _
 
 @[to_additive card_nsmul_add_sum]
-theorem pow_card_mul_prod {b : β} : b ^ s.card * ∏ a ∈ s, f a = ∏ a ∈ s, b * f a :=
+theorem pow_card_mul_prod {b : β} : b ^ #s * ∏ a ∈ s, f a = ∏ a ∈ s, b * f a :=
   (Finset.prod_const b).symm ▸ prod_mul_distrib.symm
 
 @[to_additive sum_add_card_nsmul]
-theorem prod_mul_pow_card {b : β} : (∏ a ∈ s, f a) * b ^ s.card = ∏ a ∈ s, f a * b :=
+theorem prod_mul_pow_card {b : β} : (∏ a ∈ s, f a) * b ^ #s = ∏ a ∈ s, f a * b :=
   (Finset.prod_const b).symm ▸ prod_mul_distrib.symm
 
 @[to_additive]
@@ -1515,7 +1514,7 @@ lemma prod_pow_eq_pow_sum (s : Finset ι) (f : ι → ℕ) (a : β) :
 @[to_additive
 "A sum over `Finset.powersetCard` which only depends on the size of the sets is constant."]
 lemma prod_powersetCard (n : ℕ) (s : Finset α) (f : ℕ → β) :
-    ∏ t ∈ powersetCard n s, f t.card = f n ^ s.card.choose n := by
+    ∏ t ∈ powersetCard n s, f #t = f n ^ (#s).choose n := by
   rw [prod_eq_pow_card, card_powersetCard]; rintro a ha; rw [(mem_powersetCard.1 ha).2]
 
 @[to_additive]
@@ -1568,7 +1567,7 @@ lemma prod_ninvolution (g : α → α) (hg₁ : ∀ a, f a * f (g a) = 1) (hg₂
 @[to_additive "The sum of the composition of functions `f` and `g`, is the sum over `b ∈ s.image g`
 of `f b` times of the cardinality of the fibre of `b`. See also `Finset.sum_image`."]
 theorem prod_comp [DecidableEq γ] (f : γ → β) (g : α → γ) :
-    ∏ a ∈ s, f (g a) = ∏ b ∈ s.image g, f b ^ (s.filter fun a => g a = b).card := by
+    ∏ a ∈ s, f (g a) = ∏ b ∈ s.image g, f b ^ #{a ∈ s | g a = b} := by
   simp_rw [← prod_const, prod_fiberwise_of_maps_to' fun _ ↦ mem_image_of_mem _]
 
 @[to_additive]
@@ -1611,14 +1610,14 @@ theorem dvd_prod_of_mem (f : α → β) {a : α} {s : Finset α} (ha : a ∈ s) 
 /-- A product can be partitioned into a product of products, each equivalent under a setoid. -/
 @[to_additive "A sum can be partitioned into a sum of sums, each equivalent under a setoid."]
 theorem prod_partition (R : Setoid α) [DecidableRel R.r] :
-    ∏ x ∈ s, f x = ∏ xbar ∈ s.image (Quotient.mk _), ∏ y ∈ s.filter (⟦·⟧ = xbar), f y := by
+    ∏ x ∈ s, f x = ∏ xbar ∈ s.image (Quotient.mk _), ∏ y ∈ s with ⟦y⟧ = xbar, f y := by
   refine (Finset.prod_image' f fun x _hx => ?_).symm
   rfl
 
 /-- If we can partition a product into subsets that cancel out, then the whole product cancels. -/
 @[to_additive "If we can partition a sum into subsets that cancel out, then the whole sum cancels."]
 theorem prod_cancels_of_partition_cancels (R : Setoid α) [DecidableRel R]
-    (h : ∀ x ∈ s, ∏ a ∈ s.filter fun y => R y x, f a = 1) : ∏ x ∈ s, f x = 1 := by
+    (h : ∀ x ∈ s, ∏ a ∈ s with R a x, f a = 1) : ∏ x ∈ s, f x = 1 := by
   rw [prod_partition R, ← Finset.prod_eq_one]
   intro xbar xbar_in_s
   obtain ⟨x, x_in_s, rfl⟩ := mem_image.mp xbar_in_s
@@ -1645,12 +1644,12 @@ theorem prod_update_of_mem [DecidableEq α] {s : Finset α} {i : α} (h : i ∈ 
 do the terms in that product. -/
 @[to_additive eq_of_card_le_one_of_sum_eq "If a sum of a `Finset` of size at most 1 has a given
 value, so do the terms in that sum."]
-theorem eq_of_card_le_one_of_prod_eq {s : Finset α} (hc : s.card ≤ 1) {f : α → β} {b : β}
+theorem eq_of_card_le_one_of_prod_eq {s : Finset α} (hc : #s ≤ 1) {f : α → β} {b : β}
     (h : ∏ x ∈ s, f x = b) : ∀ x ∈ s, f x = b := by
   intro x hx
-  by_cases hc0 : s.card = 0
+  by_cases hc0 : #s = 0
   · exact False.elim (card_ne_zero_of_mem hx hc0)
-  · have h1 : s.card = 1 := le_antisymm hc (Nat.one_le_of_lt (Nat.pos_of_ne_zero hc0))
+  · have h1 : #s = 1 := le_antisymm hc (Nat.one_le_of_lt (Nat.pos_of_ne_zero hc0))
     rw [card_eq_one] at h1
     obtain ⟨x2, hx2⟩ := h1
     rw [hx2, mem_singleton] at hx
@@ -1781,19 +1780,18 @@ lemma prod_sdiff_ne_prod_sdiff_iff :
 
 end CancelCommMonoid
 
-theorem card_eq_sum_ones (s : Finset α) : s.card = ∑ _ ∈ s, 1 := by simp
+theorem card_eq_sum_ones (s : Finset α) : #s = ∑ _ ∈ s, 1 := by simp
 
-theorem sum_const_nat {m : ℕ} {f : α → ℕ} (h₁ : ∀ x ∈ s, f x = m) :
-    ∑ x ∈ s, f x = card s * m := by
+theorem sum_const_nat {m : ℕ} {f : α → ℕ} (h₁ : ∀ x ∈ s, f x = m) : ∑ x ∈ s, f x = #s * m := by
   rw [← Nat.nsmul_eq_mul, ← sum_const]
   apply sum_congr rfl h₁
 
 lemma sum_card_fiberwise_eq_card_filter {κ : Type*} [DecidableEq κ] (s : Finset ι) (t : Finset κ)
-    (g : ι → κ) : ∑ j ∈ t, (s.filter fun i ↦ g i = j).card = (s.filter fun i ↦ g i ∈ t).card := by
+    (g : ι → κ) : ∑ j ∈ t, #{i ∈ s | g i = j} = #{i ∈ s | g i ∈ t} := by
   simpa only [card_eq_sum_ones] using sum_fiberwise_eq_sum_filter _ _ _ _
 
-lemma card_filter (p) [DecidablePred p] (s : Finset α) :
-    (filter p s).card = ∑ a ∈ s, ite (p a) 1 0 := by simp [sum_ite]
+lemma card_filter (p) [DecidablePred p] (s : Finset ι) :
+    #{i ∈ s | p i} = ∑ i ∈ s, ite (p i) 1 0 := by simp [sum_ite]
 
 section Opposite
 
@@ -1853,37 +1851,33 @@ end CommGroup
 
 @[simp]
 theorem card_sigma {σ : α → Type*} (s : Finset α) (t : ∀ a, Finset (σ a)) :
-    card (s.sigma t) = ∑ a ∈ s, card (t a) :=
+    #(s.sigma t) = ∑ a ∈ s, #(t a) :=
   Multiset.card_sigma _ _
 
 @[simp]
 theorem card_disjiUnion (s : Finset α) (t : α → Finset β) (h) :
-    (s.disjiUnion t h).card = s.sum fun i => (t i).card :=
+    #(s.disjiUnion t h) = ∑ a ∈ s, #(t a) :=
   Multiset.card_bind _ _
 
 theorem card_biUnion [DecidableEq β] {s : Finset α} {t : α → Finset β}
-    (h : ∀ x ∈ s, ∀ y ∈ s, x ≠ y → Disjoint (t x) (t y)) :
-    (s.biUnion t).card = ∑ u ∈ s, card (t u) :=
-  calc
-    (s.biUnion t).card = ∑ _ ∈ s.biUnion t, 1 := card_eq_sum_ones _
-    _ = ∑ a ∈ s, ∑ _i ∈ t a, 1 := Finset.sum_biUnion h
-    _ = ∑ u ∈ s, card (t u) := by simp_rw [card_eq_sum_ones]
+    (h : ∀ x ∈ s, ∀ y ∈ s, x ≠ y → Disjoint (t x) (t y)) : #(s.biUnion t) = ∑ u ∈ s, #(t u) := by
+  simpa using sum_biUnion h (β := ℕ) (f := 1)
 
 theorem card_biUnion_le [DecidableEq β] {s : Finset α} {t : α → Finset β} :
-    (s.biUnion t).card ≤ ∑ a ∈ s, (t a).card :=
+    #(s.biUnion t) ≤ ∑ a ∈ s, #(t a) :=
   haveI := Classical.decEq α
   Finset.induction_on s (by simp) fun a s has ih =>
     calc
-      ((insert a s).biUnion t).card ≤ (t a).card + (s.biUnion t).card := by
-        { rw [biUnion_insert]; exact Finset.card_union_le _ _ }
-      _ ≤ ∑ a ∈ insert a s, card (t a) := by rw [sum_insert has]; exact Nat.add_le_add_left ih _
+      #((insert a s).biUnion t) ≤ #(t a) + #(s.biUnion t) := by
+        rw [biUnion_insert]; exact card_union_le ..
+      _ ≤ ∑ a ∈ insert a s, #(t a) := by rw [sum_insert has]; exact Nat.add_le_add_left ih _
 
 theorem card_eq_sum_card_fiberwise [DecidableEq β] {f : α → β} {s : Finset α} {t : Finset β}
-    (H : ∀ x ∈ s, f x ∈ t) : s.card = ∑ a ∈ t, (s.filter fun x => f x = a).card := by
+    (H : ∀ x ∈ s, f x ∈ t) : #s = ∑ b ∈ t, #{a ∈ s | f a = b} := by
   simp only [card_eq_sum_ones, sum_fiberwise_of_maps_to H]
 
 theorem card_eq_sum_card_image [DecidableEq β] (f : α → β) (s : Finset α) :
-    s.card = ∑ a ∈ s.image f, (s.filter fun x => f x = a).card :=
+    #s = ∑ b ∈ s.image f, #{a ∈ s | f a = b} :=
   card_eq_sum_card_fiberwise fun _ => mem_image_of_mem _
 
 theorem mem_sum {f : α → Multiset β} (s : Finset α) (b : β) :
@@ -2265,8 +2259,7 @@ end AddCommMonoid
 
 theorem Finset.sum_sym2_filter_not_isDiag {ι α} [LinearOrder ι] [AddCommMonoid α]
     (s : Finset ι) (p : Sym2 ι → α) :
-    ∑ i in s.sym2.filter (¬ ·.IsDiag), p i =
-      ∑ i in s.offDiag.filter (fun i => i.1 < i.2), p s(i.1, i.2) := by
+    ∑ i ∈ s.sym2 with ¬ i.IsDiag, p i = ∑ i ∈ s.offDiag with i.1 < i.2, p s(i.1, i.2) := by
   rw [Finset.offDiag_filter_lt_eq_filter_le]
   conv_rhs => rw [← Finset.sum_subtype_eq_sum_filter]
   refine (Finset.sum_equiv Sym2.sortEquiv.symm ?_ ?_).symm

--- a/Mathlib/Algebra/BigOperators/Ring.lean
+++ b/Mathlib/Algebra/BigOperators/Ring.lean
@@ -26,11 +26,11 @@ section AddCommMonoidWithOne
 variable [AddCommMonoidWithOne α]
 
 lemma natCast_card_filter (p) [DecidablePred p] (s : Finset ι) :
-    ((filter p s).card : α) = ∑ a ∈ s, if p a then (1 : α) else 0 := by
+    (#{x ∈ s | p x} : α) = ∑ a ∈ s, if p a then (1 : α) else 0 := by
   rw [sum_ite, sum_const_zero, add_zero, sum_const, nsmul_one]
 
 @[simp] lemma sum_boole (p) [DecidablePred p] (s : Finset ι) :
-    (∑ x ∈ s, if p x then 1 else 0 : α) = (s.filter p).card :=
+    (∑ x ∈ s, if p x then 1 else 0 : α) = #{x ∈ s | p x} :=
   (natCast_card_filter _ _).symm
 
 end AddCommMonoidWithOne
@@ -164,7 +164,7 @@ theorem prod_add (f g : ι → α) (s : Finset ι) :
           ∏ a ∈ s.attach, if p a.1 a.2 then f a.1 else g a.1 := prod_sum _ _ _
     _ = ∑ t ∈ s.powerset, (∏ a ∈ t, f a) * ∏ a ∈ s \ t, g a :=
       sum_bij'
-        (fun f _ ↦ s.filter fun a ↦ ∃ h : a ∈ s, f a h)
+        (fun f _ ↦ {a ∈ s | ∃ h : a ∈ s, f a h})
         (fun t _ a _ => a ∈ t)
         (by simp)
         (by simp [Classical.em])
@@ -183,8 +183,7 @@ end DecidableEq
 theorem prod_add_ordered [LinearOrder ι] (s : Finset ι) (f g : ι → α) :
     ∏ i ∈ s, (f i + g i) =
       (∏ i ∈ s, f i) +
-        ∑ i ∈ s,
-          g i * (∏ j ∈ s.filter (· < i), (f j + g j)) * ∏ j ∈ s.filter fun j => i < j, f j := by
+        ∑ i ∈ s, g i * (∏ j ∈ s with j < i, (f j + g j)) * ∏ j ∈ s with i < j, f j := by
   refine Finset.induction_on_max s (by simp) ?_
   clear s
   intro a s ha ihs
@@ -202,21 +201,21 @@ theorem prod_add_ordered [LinearOrder ι] (s : Finset ι) (f g : ι → α) :
       mul_left_comm]
     exact mt (fun ha => (mem_filter.1 ha).1) ha'
 
-/-- Summing `a^s.card * b^(n-s.card)` over all finite subsets `s` of a `Finset`
-gives `(a + b)^s.card`. -/
+/-- Summing `a ^ #t * b ^ (n - #t)` over all finite subsets `t` of a finset `s`
+gives `(a + b) ^ #s`. -/
 theorem sum_pow_mul_eq_add_pow (a b : α) (s : Finset ι) :
-    (∑ t ∈ s.powerset, a ^ t.card * b ^ (s.card - t.card)) = (a + b) ^ s.card := by
+    (∑ t ∈ s.powerset, a ^ #t * b ^ (#s - #t)) = (a + b) ^ #s := by
   classical
   rw [← prod_const, prod_add]
   refine Finset.sum_congr rfl fun t ht => ?_
   rw [prod_const, prod_const, ← card_sdiff (mem_powerset.1 ht)]
 
-/-- Summing `a^s.card * b^(n-s.card)` over all finite subsets `s` of a fintype of cardinality `n`
+/-- Summing `a^#s * b^(n-#s)` over all finite subsets `s` of a fintype of cardinality `n`
 gives `(a + b)^n`. The "good" proof involves expanding along all coordinates using the fact that
 `x^n` is multilinear, but multilinear maps are only available now over rings, so we give instead
 a proof reducing to the usual binomial theorem to have a result over semirings. -/
 lemma _root_.Fintype.sum_pow_mul_eq_add_pow (ι : Type*) [Fintype ι] (a b : α) :
-    ∑ s : Finset ι, a ^ s.card * b ^ (Fintype.card ι - s.card) = (a + b) ^ Fintype.card ι :=
+    ∑ s : Finset ι, a ^ #s * b ^ (Fintype.card ι - #s) = (a + b) ^ Fintype.card ι :=
   Finset.sum_pow_mul_eq_add_pow _ _ _
 
 @[norm_cast]
@@ -232,8 +231,7 @@ variable [CommRing α]
 lemma prod_sub_ordered [LinearOrder ι] (s : Finset ι) (f g : ι → α) :
     ∏ i ∈ s, (f i - g i) =
       (∏ i ∈ s, f i) -
-        ∑ i ∈ s,
-          g i * (∏ j ∈ s.filter (· < i), (f j - g j)) * ∏ j ∈ s.filter fun j => i < j, f j := by
+        ∑ i ∈ s, g i * (∏ j ∈ s with j < i, (f j - g j)) * ∏ j ∈ s with i < j, f j := by
   simp only [sub_eq_add_neg]
   convert prod_add_ordered s f fun i => -g i
   simp
@@ -241,7 +239,7 @@ lemma prod_sub_ordered [LinearOrder ι] (s : Finset ι) (f g : ι → α) :
 /-- `∏ i, (1 - f i) = 1 - ∑ i, f i * (∏ j < i, 1 - f j)`. This formula is useful in construction of
 a partition of unity from a collection of “bump” functions. -/
 theorem prod_one_sub_ordered [LinearOrder ι] (s : Finset ι) (f : ι → α) :
-    ∏ i ∈ s, (1 - f i) = 1 - ∑ i ∈ s, f i * ∏ j ∈ s.filter (· < i), (1 - f j) := by
+    ∏ i ∈ s, (1 - f i) = 1 - ∑ i ∈ s, f i * ∏ j ∈ s with j < i, (1 - f j) := by
   rw [prod_sub_ordered]
   simp
 

--- a/Mathlib/Algebra/GeomSum.lean
+++ b/Mathlib/Algebra/GeomSum.lean
@@ -134,7 +134,7 @@ theorem geom_sum₂_self {α : Type*} [CommRing α] (x : α) (n : ℕ) :
     _ = ∑ _i ∈ Finset.range n, x ^ (n - 1) :=
       Finset.sum_congr rfl fun _ hi =>
         congr_arg _ <| add_tsub_cancel_of_le <| Nat.le_sub_one_of_lt <| Finset.mem_range.1 hi
-    _ = (Finset.range n).card • x ^ (n - 1) := Finset.sum_const _
+    _ = #(range n) • x ^ (n - 1) := sum_const _
     _ = n * x ^ (n - 1) := by rw [Finset.card_range, nsmul_eq_mul]
 
 /-- $x^n-y^n = (x-y) \sum x^ky^{n-1-k}$ reformulated without `-` signs. -/

--- a/Mathlib/Algebra/Group/UniqueProds/Basic.lean
+++ b/Mathlib/Algebra/Group/UniqueProds/Basic.lean
@@ -52,6 +52,8 @@ assert_not_exists Algebra
 assert_not_exists Submodule
 assert_not_exists StarModule
 
+open Finset
+
 /-- Let `G` be a Type with multiplication, let `A B : Finset G` be finite subsets and
 let `a0 b0 : G` be two elements.  `UniqueMul A B a0 b0` asserts `a0 * b0` can be written in at
 most one way as a product of an element of `A` and an element of `B`. -/
@@ -71,7 +73,7 @@ theorem of_subsingleton [Subsingleton G] : UniqueMul A B a0 b0 := by
   simp [UniqueMul, eq_iff_true_of_subsingleton]
 
 @[to_additive of_card_le_one]
-theorem of_card_le_one (hA : A.Nonempty) (hB : B.Nonempty) (hA1 : A.card ≤ 1) (hB1 : B.card ≤ 1) :
+theorem of_card_le_one (hA : A.Nonempty) (hB : B.Nonempty) (hA1 : #A ≤ 1) (hB1 : #B ≤ 1) :
     ∃ a ∈ A, ∃ b ∈ B, UniqueMul A B a b := by
   rw [Finset.card_le_one_iff] at hA1 hB1
   obtain ⟨a, ha⟩ := hA; obtain ⟨b, hb⟩ := hB
@@ -118,7 +120,7 @@ theorem iff_existsUnique (aA : a0 ∈ A) (bB : b0 ∈ B) :
 open Finset in
 @[to_additive iff_card_le_one]
 theorem iff_card_le_one [DecidableEq G] (ha0 : a0 ∈ A) (hb0 : b0 ∈ B) :
-    UniqueMul A B a0 b0 ↔ ((A ×ˢ B).filter (fun p ↦ p.1 * p.2 = a0 * b0)).card ≤ 1 := by
+    UniqueMul A B a0 b0 ↔ #{p ∈ A ×ˢ B | p.1 * p.2 = a0 * b0} ≤ 1 := by
   simp_rw [card_le_one_iff, mem_filter, mem_product]
   refine ⟨fun h p1 p2 ⟨⟨ha1, hb1⟩, he1⟩ ⟨⟨ha2, hb2⟩, he2⟩ ↦ ?_, fun h a b ha hb he ↦ ?_⟩
   · have h1 := h ha1 hb1 he1; have h2 := h ha2 hb2 he2
@@ -210,7 +212,7 @@ open Finset in
 theorem of_image_filter [DecidableEq H]
     (f : G →ₙ* H) {A B : Finset G} {aG bG : G} {aH bH : H} (hae : f aG = aH) (hbe : f bG = bH)
     (huH : UniqueMul (A.image f) (B.image f) aH bH)
-    (huG : UniqueMul (A.filter (f · = aH)) (B.filter (f · = bH)) aG bG) :
+    (huG : UniqueMul {a ∈ A | f a = aH} {b ∈ B | f b = bH} aG bG) :
     UniqueMul A B aG bG := fun a b ha hb he ↦ by
   specialize huH (mem_image_of_mem _ ha) (mem_image_of_mem _ hb)
   rw [← map_mul, he, map_mul, hae, hbe] at huH
@@ -245,7 +247,7 @@ of elements satisfying the `UniqueAdd` property. -/
 class TwoUniqueSums (G) [Add G] : Prop where
 /-- For `A B` two finite sets whose product has cardinality at least 2,
   we can find at least two unique pairs. -/
-  uniqueAdd_of_one_lt_card : ∀ {A B : Finset G}, 1 < A.card * B.card →
+  uniqueAdd_of_one_lt_card : ∀ {A B : Finset G}, 1 < #A * #B →
     ∃ p1 ∈ A ×ˢ B, ∃ p2 ∈ A ×ˢ B, p1 ≠ p2 ∧ UniqueAdd A B p1.1 p1.2 ∧ UniqueAdd A B p2.1 p2.2
 
 /-- Let `G` be a Type with multiplication. `TwoUniqueProds G` asserts that any two non-empty
@@ -254,16 +256,16 @@ of elements satisfying the `UniqueMul` property. -/
 class TwoUniqueProds (G) [Mul G] : Prop where
 /-- For `A B` two finite sets whose product has cardinality at least 2,
   we can find at least two unique pairs. -/
-  uniqueMul_of_one_lt_card : ∀ {A B : Finset G}, 1 < A.card * B.card →
+  uniqueMul_of_one_lt_card : ∀ {A B : Finset G}, 1 < #A * #B →
     ∃ p1 ∈ A ×ˢ B, ∃ p2 ∈ A ×ˢ B, p1 ≠ p2 ∧ UniqueMul A B p1.1 p1.2 ∧ UniqueMul A B p2.1 p2.2
 
 attribute [to_additive] TwoUniqueProds
 
 @[to_additive]
-lemma uniqueMul_of_twoUniqueMul {G} [Mul G] {A B : Finset G} (h : 1 < A.card * B.card →
+lemma uniqueMul_of_twoUniqueMul {G} [Mul G] {A B : Finset G} (h : 1 < #A * #B →
     ∃ p1 ∈ A ×ˢ B, ∃ p2 ∈ A ×ˢ B, p1 ≠ p2 ∧ UniqueMul A B p1.1 p1.2 ∧ UniqueMul A B p2.1 p2.2)
     (hA : A.Nonempty) (hB : B.Nonempty) : ∃ a ∈ A, ∃ b ∈ B, UniqueMul A B a b := by
-  by_cases hc : A.card ≤ 1 ∧ B.card ≤ 1
+  by_cases hc : #A ≤ 1 ∧ #B ≤ 1
   · exact UniqueMul.of_card_le_one hA hB hc.1 hc.2
   simp_rw [not_and_or, not_le] at hc
   rw [← Finset.card_pos] at hA hB
@@ -388,7 +390,7 @@ open MulOpposite in
     obtain ⟨a, ha, b, hb, hu⟩ := uniqueMul_of_nonempty hc.1 hc.2.1
     let C := A.map ⟨_, mul_right_injective a⁻¹⟩ -- C = a⁻¹A
     let D := B.map ⟨_, mul_left_injective b⁻¹⟩  -- D = Bb⁻¹
-    have hcard : 1 < C.card ∨ 1 < D.card := by simp_rw [C, D, card_map]; exact hc.2.2
+    have hcard : 1 < #C ∨ 1 < #D := by simp_rw [C, D, card_map]; exact hc.2.2
     have hC : 1 ∈ C := mem_map.mpr ⟨a, ha, inv_mul_cancel a⟩
     have hD : 1 ∈ D := mem_map.mpr ⟨b, hb, mul_inv_cancel b⟩
     suffices ∃ c ∈ C, ∃ d ∈ D, (c ≠ 1 ∨ d ≠ 1) ∧ UniqueMul C D c d by
@@ -439,13 +441,13 @@ open UniqueMul in
     let _ := isWellFounded_ssubset (α := ∀ i, G i) -- why need this?
     apply IsWellFounded.induction (· ⊂ ·) A; intro A ihA B hA
     apply IsWellFounded.induction (· ⊂ ·) B; intro B ihB hB
-    by_cases hc : A.card ≤ 1 ∧ B.card ≤ 1
+    by_cases hc : #A ≤ 1 ∧ #B ≤ 1
     · exact of_card_le_one hA hB hc.1 hc.2
     simp_rw [not_and_or, not_le] at hc
     obtain ⟨i, hc⟩ := exists_or.mpr (hc.imp exists_of_one_lt_card_pi exists_of_one_lt_card_pi)
     obtain ⟨ai, hA, bi, hB, hi⟩ := uniqueMul_of_nonempty (hA.image (· i)) (hB.image (· i))
     rw [mem_image, ← filter_nonempty_iff] at hA hB
-    let A' := A.filter (· i = ai); let B' := B.filter (· i = bi)
+    let A' := {a ∈ A | a i = ai}; let B' := {b ∈ B | b i = bi}
     obtain ⟨a0, ha0, b0, hb0, hu⟩ : ∃ a0 ∈ A', ∃ b0 ∈ B', UniqueMul A' B' a0 b0 := by
       rcases hc with hc | hc; · exact ihA A' (hc.2 ai) hA hB
       by_cases hA' : A' = A
@@ -484,7 +486,7 @@ open Finset
     [TwoUniqueProds G] : TwoUniqueProds H where
   uniqueMul_of_one_lt_card {A B} hc := by
     classical
-    obtain hc' | hc' := lt_or_le 1 ((A.image f).card * (B.image f).card)
+    obtain hc' | hc' := lt_or_le 1 (#(A.image f) * #(B.image f))
     · obtain ⟨⟨a1, b1⟩, h1, ⟨a2, b2⟩, h2, hne, hu1, hu2⟩ := uniqueMul_of_one_lt_card hc'
       simp_rw [mem_product, mem_image] at h1 h2 ⊢
       obtain ⟨⟨a1, ha1, rfl⟩, b1, hb1, rfl⟩ := h1
@@ -536,11 +538,11 @@ instance instForall {ι} (G : ι → Type*) [∀ i, Mul (G i)] [∀ i, TwoUnique
       contrapose! hne; rw [Prod.mk.inj_iff] at hne ⊢
       rw [← ha1.2, ← hb1.2, ← ha2.2, ← hb2.2, hne.1, hne.2]; exact ⟨rfl, rfl⟩
     all_goals rcases hc with hc | hc; · exact ihA _ (hc.2 _)
-    · by_cases hA : A.filter (· i = p2.1) = A
+    · by_cases hA : {a ∈ A | a i = p2.1} = A
       · rw [hA]
         exact ihB _ (hc.2 _)
       · exact ihA _ ((A.filter_subset _).ssubset_of_ne hA)
-    · by_cases hA : A.filter (· i = p1.1) = A
+    · by_cases hA : {a ∈ A | a i = p1.1} = A
       · rw [hA]
         exact ihB _ (hc.2 _)
       · exact ihA _ ((A.filter_subset _).ssubset_of_ne hA)

--- a/Mathlib/Algebra/Module/BigOperators.lean
+++ b/Mathlib/Algebra/Module/BigOperators.lean
@@ -41,16 +41,16 @@ lemma Fintype.sum_smul_sum [Fintype α] [Fintype β] (f : α → R) (g : β → 
 
 end AddCommMonoid
 
-theorem Finset.cast_card [CommSemiring R] (s : Finset α) : (s.card : R) = ∑ _ ∈ s, 1 := by
-  rw [Finset.sum_const, Nat.smul_one_eq_cast]
-
 open Finset
+
+theorem Finset.cast_card [CommSemiring R] (s : Finset α) : (#s : R) = ∑ _ ∈ s, 1 := by
+  rw [Finset.sum_const, Nat.smul_one_eq_cast]
 
 namespace Fintype
 variable [DecidableEq ι] [Fintype ι] [AddCommMonoid α]
 
 lemma sum_piFinset_apply (f : κ → α) (s : Finset κ) (i : ι) :
-    ∑ g ∈ piFinset fun _ : ι ↦ s, f (g i) = s.card ^ (card ι - 1) • ∑ b ∈ s, f b := by
+    ∑ g ∈ piFinset fun _ : ι ↦ s, f (g i) = #s ^ (card ι - 1) • ∑ b ∈ s, f b := by
   classical
   rw [Finset.sum_comp]
   simp only [eval_image_piFinset_const, card_filter_piFinset_const s, ite_smul, zero_smul, smul_sum,

--- a/Mathlib/Algebra/MonoidAlgebra/Defs.lean
+++ b/Mathlib/Algebra/MonoidAlgebra/Defs.lean
@@ -397,14 +397,10 @@ theorem mul_apply_antidiagonal [Mul G] (f g : MonoidAlgebra k G) (x : G) (s : Fi
       calc
         (f * g) x = ∑ a₁ ∈ f.support, ∑ a₂ ∈ g.support, F (a₁, a₂) := mul_apply f g x
         _ = ∑ p ∈ f.support ×ˢ g.support, F p := by rw [Finset.sum_product]
-        _ = ∑ p ∈ (f.support ×ˢ g.support).filter fun p : G × G => p.1 * p.2 = x, f p.1 * g p.2 :=
+        _ = ∑ p ∈ f.support ×ˢ g.support with p.1 * p.2 = x, f p.1 * g p.2 :=
           (Finset.sum_filter _ _).symm
-        _ = ∑ p ∈ s.filter fun p : G × G => p.1 ∈ f.support ∧ p.2 ∈ g.support, f p.1 * g p.2 :=
-          (sum_congr
-            (by
-              ext
-              simp only [mem_filter, mem_product, hs, and_comm])
-            fun _ _ => rfl)
+        _ = ∑ p ∈ s with p.1 ∈ f.support ∧ p.2 ∈ g.support, f p.1 * g p.2 := by
+          congr! 1; ext; simp only [mem_filter, mem_product, hs, and_comm]
         _ = ∑ p ∈ s, f p.1 * g p.2 :=
           sum_subset (filter_subset _ _) fun p hps hp => by
             simp only [mem_filter, mem_support_iff, not_and, Classical.not_not] at hp ⊢

--- a/Mathlib/Algebra/Order/BigOperators/Group/Finset.lean
+++ b/Mathlib/Algebra/Order/BigOperators/Group/Finset.lean
@@ -175,17 +175,17 @@ lemma mul_le_prod {i j : ι} (hf : ∀ i ∈ s, 1 ≤ f i) (hi : i ∈ s) (hj : 
 
 @[to_additive sum_le_card_nsmul]
 theorem prod_le_pow_card (s : Finset ι) (f : ι → N) (n : N) (h : ∀ x ∈ s, f x ≤ n) :
-    s.prod f ≤ n ^ s.card := by
+    s.prod f ≤ n ^ #s := by
   refine (Multiset.prod_le_pow_card (s.val.map f) n ?_).trans ?_
   · simpa using h
   · simp
 
 @[to_additive card_nsmul_le_sum]
 theorem pow_card_le_prod (s : Finset ι) (f : ι → N) (n : N) (h : ∀ x ∈ s, n ≤ f x) :
-    n ^ s.card ≤ s.prod f := @Finset.prod_le_pow_card _ Nᵒᵈ _ _ _ _ h
+    n ^ #s ≤ s.prod f := @Finset.prod_le_pow_card _ Nᵒᵈ _ _ _ _ h
 
 theorem card_biUnion_le_card_mul [DecidableEq β] (s : Finset ι) (f : ι → Finset β) (n : ℕ)
-    (h : ∀ a ∈ s, (f a).card ≤ n) : (s.biUnion f).card ≤ s.card * n :=
+    (h : ∀ a ∈ s, #(f a) ≤ n) : #(s.biUnion f) ≤ #s * n :=
   card_biUnion_le.trans <| sum_le_card_nsmul _ _ _ h
 
 variable {ι' : Type*} [DecidableEq ι']
@@ -193,11 +193,11 @@ variable {ι' : Type*} [DecidableEq ι']
 -- Porting note: Mathport warning: expanding binder collection (y «expr ∉ » t)
 @[to_additive sum_fiberwise_le_sum_of_sum_fiber_nonneg]
 theorem prod_fiberwise_le_prod_of_one_le_prod_fiber' {t : Finset ι'} {g : ι → ι'} {f : ι → N}
-    (h : ∀ y ∉ t, (1 : N) ≤ ∏ x ∈ s.filter fun x ↦ g x = y, f x) :
-    (∏ y ∈ t, ∏ x ∈ s.filter fun x ↦ g x = y, f x) ≤ ∏ x ∈ s, f x :=
+    (h : ∀ y ∉ t, (1 : N) ≤ ∏ x ∈ s with g x = y, f x) :
+    (∏ y ∈ t, ∏ x ∈ s with g x = y, f x) ≤ ∏ x ∈ s, f x :=
   calc
-    (∏ y ∈ t, ∏ x ∈ s.filter fun x ↦ g x = y, f x) ≤
-        ∏ y ∈ t ∪ s.image g, ∏ x ∈ s.filter fun x ↦ g x = y, f x :=
+    (∏ y ∈ t, ∏ x ∈ s with g x = y, f x) ≤
+        ∏ y ∈ t ∪ s.image g, ∏ x ∈ s with g x = y, f x :=
       prod_le_prod_of_subset_of_one_le' subset_union_left fun y _ ↦ h y
     _ = ∏ x ∈ s, f x :=
       prod_fiberwise_of_maps_to (fun _ hx ↦ mem_union.2 <| Or.inr <| mem_image_of_mem _ hx) _
@@ -205,8 +205,8 @@ theorem prod_fiberwise_le_prod_of_one_le_prod_fiber' {t : Finset ι'} {g : ι �
 -- Porting note: Mathport warning: expanding binder collection (y «expr ∉ » t)
 @[to_additive sum_le_sum_fiberwise_of_sum_fiber_nonpos]
 theorem prod_le_prod_fiberwise_of_prod_fiber_le_one' {t : Finset ι'} {g : ι → ι'} {f : ι → N}
-    (h : ∀ y ∉ t, ∏ x ∈ s.filter fun x ↦ g x = y, f x ≤ 1) :
-    ∏ x ∈ s, f x ≤ ∏ y ∈ t, ∏ x ∈ s.filter fun x ↦ g x = y, f x :=
+    (h : ∀ y ∉ t, ∏ x ∈ s with g x = y, f x ≤ 1) :
+    ∏ x ∈ s, f x ≤ ∏ y ∈ t, ∏ x ∈ s with g x = y, f x :=
   @prod_fiberwise_le_prod_of_one_le_prod_fiber' _ Nᵒᵈ _ _ _ _ _ _ _ h
 
 end OrderedCommMonoid
@@ -247,27 +247,26 @@ section Pigeonhole
 variable [DecidableEq β]
 
 theorem card_le_mul_card_image_of_maps_to {f : α → β} {s : Finset α} {t : Finset β}
-    (Hf : ∀ a ∈ s, f a ∈ t) (n : ℕ) (hn : ∀ a ∈ t, (s.filter fun x ↦ f x = a).card ≤ n) :
-    s.card ≤ n * t.card :=
+    (Hf : ∀ a ∈ s, f a ∈ t) (n : ℕ) (hn : ∀ b ∈ t, #{a ∈ s | f a = b} ≤ n) : #s ≤ n * #t :=
   calc
-    s.card = ∑ a ∈ t, (s.filter fun x ↦ f x = a).card := card_eq_sum_card_fiberwise Hf
-    _ ≤ ∑ _a ∈ t, n := sum_le_sum hn
+    #s = ∑ b ∈ t, #{a ∈ s | f a = b} := card_eq_sum_card_fiberwise Hf
+    _ ≤ ∑ _b ∈ t, n := sum_le_sum hn
     _ = _ := by simp [mul_comm]
 
 theorem card_le_mul_card_image {f : α → β} (s : Finset α) (n : ℕ)
-    (hn : ∀ a ∈ s.image f, (s.filter fun x ↦ f x = a).card ≤ n) : s.card ≤ n * (s.image f).card :=
+    (hn : ∀ b ∈ s.image f, #{a ∈ s | f a = b} ≤ n) : #s ≤ n * #(s.image f) :=
   card_le_mul_card_image_of_maps_to (fun _ ↦ mem_image_of_mem _) n hn
 
 theorem mul_card_image_le_card_of_maps_to {f : α → β} {s : Finset α} {t : Finset β}
-    (Hf : ∀ a ∈ s, f a ∈ t) (n : ℕ) (hn : ∀ a ∈ t, n ≤ (s.filter fun x ↦ f x = a).card) :
-    n * t.card ≤ s.card :=
+    (Hf : ∀ a ∈ s, f a ∈ t) (n : ℕ) (hn : ∀ b ∈ t, n ≤ #{a ∈ s | f a = b}) :
+    n * #t ≤ #s :=
   calc
-    n * t.card = ∑ _a ∈ t, n := by simp [mul_comm]
-    _ ≤ ∑ a ∈ t, (s.filter fun x ↦ f x = a).card := sum_le_sum hn
-    _ = s.card := by rw [← card_eq_sum_card_fiberwise Hf]
+    n * #t = ∑ _a ∈ t, n := by simp [mul_comm]
+    _ ≤ ∑ b ∈ t, #{a ∈ s | f a = b} := sum_le_sum hn
+    _ = #s := by rw [← card_eq_sum_card_fiberwise Hf]
 
 theorem mul_card_image_le_card {f : α → β} (s : Finset α) (n : ℕ)
-    (hn : ∀ a ∈ s.image f, n ≤ (s.filter fun x ↦ f x = a).card) : n * (s.image f).card ≤ s.card :=
+    (hn : ∀ b ∈ s.image f, n ≤ #{a ∈ s | f a = b}) : n * #(s.image f) ≤ #s :=
   mul_card_image_le_card_of_maps_to (fun _ ↦ mem_image_of_mem _) n hn
 
 end Pigeonhole
@@ -278,56 +277,52 @@ variable [DecidableEq α] {s : Finset α} {B : Finset (Finset α)} {n : ℕ}
 
 /-- If every element belongs to at most `n` Finsets, then the sum of their sizes is at most `n`
 times how many they are. -/
-theorem sum_card_inter_le (h : ∀ a ∈ s, (B.filter (a ∈ ·)).card ≤ n) :
-    (∑ t ∈ B, (s ∩ t).card) ≤ s.card * n := by
+theorem sum_card_inter_le (h : ∀ a ∈ s, #{b ∈ B | a ∈ b} ≤ n) : (∑ t ∈ B, #(s ∩ t)) ≤ #s * n := by
   refine le_trans ?_ (s.sum_le_card_nsmul _ _ h)
   simp_rw [← filter_mem_eq_inter, card_eq_sum_ones, sum_filter]
   exact sum_comm.le
 
 /-- If every element belongs to at most `n` Finsets, then the sum of their sizes is at most `n`
 times how many they are. -/
-theorem sum_card_le [Fintype α] (h : ∀ a, (B.filter (a ∈ ·)).card ≤ n) :
-    ∑ s ∈ B, s.card ≤ Fintype.card α * n :=
+lemma sum_card_le [Fintype α] (h : ∀ a, #{b ∈ B | a ∈ b} ≤ n) : ∑ s ∈ B, #s ≤ Fintype.card α * n :=
   calc
-    ∑ s ∈ B, s.card = ∑ s ∈ B, (univ ∩ s).card := by simp_rw [univ_inter]
+    ∑ s ∈ B, #s = ∑ s ∈ B, #(univ ∩ s) := by simp_rw [univ_inter]
     _ ≤ Fintype.card α * n := sum_card_inter_le fun a _ ↦ h a
 
 /-- If every element belongs to at least `n` Finsets, then the sum of their sizes is at least `n`
 times how many they are. -/
-theorem le_sum_card_inter (h : ∀ a ∈ s, n ≤ (B.filter (a ∈ ·)).card) :
-    s.card * n ≤ ∑ t ∈ B, (s ∩ t).card := by
+theorem le_sum_card_inter (h : ∀ a ∈ s, n ≤ #{b ∈ B | a ∈ b}) : #s * n ≤ ∑ t ∈ B, #(s ∩ t) := by
   apply (s.card_nsmul_le_sum _ _ h).trans
   simp_rw [← filter_mem_eq_inter, card_eq_sum_ones, sum_filter]
   exact sum_comm.le
 
 /-- If every element belongs to at least `n` Finsets, then the sum of their sizes is at least `n`
 times how many they are. -/
-theorem le_sum_card [Fintype α] (h : ∀ a, n ≤ (B.filter (a ∈ ·)).card) :
-    Fintype.card α * n ≤ ∑ s ∈ B, s.card :=
+theorem le_sum_card [Fintype α] (h : ∀ a, n ≤ #{b ∈ B | a ∈ b}) :
+    Fintype.card α * n ≤ ∑ s ∈ B, #s :=
   calc
-    Fintype.card α * n ≤ ∑ s ∈ B, (univ ∩ s).card := le_sum_card_inter fun a _ ↦ h a
-    _ = ∑ s ∈ B, s.card := by simp_rw [univ_inter]
+    Fintype.card α * n ≤ ∑ s ∈ B, #(univ ∩ s) := le_sum_card_inter fun a _ ↦ h a
+    _ = ∑ s ∈ B, #s := by simp_rw [univ_inter]
 
 /-- If every element belongs to exactly `n` Finsets, then the sum of their sizes is `n` times how
 many they are. -/
-theorem sum_card_inter (h : ∀ a ∈ s, (B.filter (a ∈ ·)).card = n) :
-    (∑ t ∈ B, (s ∩ t).card) = s.card * n :=
+theorem sum_card_inter (h : ∀ a ∈ s, #{b ∈ B | a ∈ b} = n) :
+    (∑ t ∈ B, #(s ∩ t)) = #s * n :=
   (sum_card_inter_le fun a ha ↦ (h a ha).le).antisymm (le_sum_card_inter fun a ha ↦ (h a ha).ge)
 
 /-- If every element belongs to exactly `n` Finsets, then the sum of their sizes is `n` times how
 many they are. -/
-theorem sum_card [Fintype α] (h : ∀ a, (B.filter (a ∈ ·)).card = n) :
-    ∑ s ∈ B, s.card = Fintype.card α * n := by
+theorem sum_card [Fintype α] (h : ∀ a, #{b ∈ B | a ∈ b} = n) :
+    ∑ s ∈ B, #s = Fintype.card α * n := by
   simp_rw [Fintype.card, ← sum_card_inter fun a _ ↦ h a, univ_inter]
 
 theorem card_le_card_biUnion {s : Finset ι} {f : ι → Finset α} (hs : (s : Set ι).PairwiseDisjoint f)
-    (hf : ∀ i ∈ s, (f i).Nonempty) : s.card ≤ (s.biUnion f).card := by
+    (hf : ∀ i ∈ s, (f i).Nonempty) : #s ≤ #(s.biUnion f) := by
   rw [card_biUnion hs, card_eq_sum_ones]
   exact sum_le_sum fun i hi ↦ (hf i hi).card_pos
 
 theorem card_le_card_biUnion_add_card_fiber {s : Finset ι} {f : ι → Finset α}
-    (hs : (s : Set ι).PairwiseDisjoint f) :
-    s.card ≤ (s.biUnion f).card + (s.filter fun i ↦ f i = ∅).card := by
+    (hs : (s : Set ι).PairwiseDisjoint f) : #s ≤ #(s.biUnion f) + #{i ∈ s | f i = ∅} := by
   rw [← Finset.filter_card_add_filter_neg_card_eq_card fun i ↦ f i = ∅, add_comm]
   exact
     add_le_add_right
@@ -337,7 +332,7 @@ theorem card_le_card_biUnion_add_card_fiber {s : Finset ι} {f : ι → Finset �
       _
 
 theorem card_le_card_biUnion_add_one {s : Finset ι} {f : ι → Finset α} (hf : Injective f)
-    (hs : (s : Set ι).PairwiseDisjoint f) : s.card ≤ (s.biUnion f).card + 1 :=
+    (hs : (s : Set ι).PairwiseDisjoint f) : #s ≤ #(s.biUnion f) + 1 :=
   (card_le_card_biUnion_add_card_fiber hs).trans <|
     add_le_add_left
       (card_le_one.2 fun _ hi _ hj ↦ hf <| (mem_filter.1 hi).2.trans (mem_filter.1 hj).2.symm) _
@@ -374,8 +369,7 @@ theorem prod_mono_set' (f : ι → M) : Monotone fun s ↦ ∏ x ∈ s, f x := f
 theorem prod_le_prod_of_ne_one' (h : ∀ x ∈ s, f x ≠ 1 → x ∈ t) :
     ∏ x ∈ s, f x ≤ ∏ x ∈ t, f x := by
   classical calc
-    ∏ x ∈ s, f x = (∏ x ∈ s.filter fun x ↦ f x = 1, f x) *
-        ∏ x ∈ s.filter fun x ↦ f x ≠ 1, f x := by
+    ∏ x ∈ s, f x = (∏ x ∈ s with f x = 1, f x) * ∏ x ∈ s with f x ≠ 1, f x := by
       rw [← prod_union, filter_union_filter_neg_eq]
       exact disjoint_filter.2 fun _ _ h n_h ↦ n_h h
     _ ≤ ∏ x ∈ t, f x :=

--- a/Mathlib/Algebra/Order/BigOperators/Group/Finset.lean
+++ b/Mathlib/Algebra/Order/BigOperators/Group/Finset.lean
@@ -190,7 +190,6 @@ theorem card_biUnion_le_card_mul [DecidableEq β] (s : Finset ι) (f : ι → Fi
 
 variable {ι' : Type*} [DecidableEq ι']
 
--- Porting note: Mathport warning: expanding binder collection (y «expr ∉ » t)
 @[to_additive sum_fiberwise_le_sum_of_sum_fiber_nonneg]
 theorem prod_fiberwise_le_prod_of_one_le_prod_fiber' {t : Finset ι'} {g : ι → ι'} {f : ι → N}
     (h : ∀ y ∉ t, (1 : N) ≤ ∏ x ∈ s with g x = y, f x) :
@@ -202,7 +201,6 @@ theorem prod_fiberwise_le_prod_of_one_le_prod_fiber' {t : Finset ι'} {g : ι �
     _ = ∏ x ∈ s, f x :=
       prod_fiberwise_of_maps_to (fun _ hx ↦ mem_union.2 <| Or.inr <| mem_image_of_mem _ hx) _
 
--- Porting note: Mathport warning: expanding binder collection (y «expr ∉ » t)
 @[to_additive sum_le_sum_fiberwise_of_sum_fiber_nonpos]
 theorem prod_le_prod_fiberwise_of_prod_fiber_le_one' {t : Finset ι'} {g : ι → ι'} {f : ι → N}
     (h : ∀ y ∉ t, ∏ x ∈ s with g x = y, f x ≤ 1) :

--- a/Mathlib/Algebra/Order/CauSeq/BigOperators.lean
+++ b/Mathlib/Algebra/Order/CauSeq/BigOperators.lean
@@ -121,9 +121,9 @@ theorem _root_.cauchy_product (ha : IsCauSeq abs fun m ↦ ∑ n ∈ range m, ab
         (by rw [← sum_mul, mul_comm]; gcongr)
   rw [sum_range_sub_sum_range (le_of_lt hNMK)]
   calc
-    (∑ i ∈ (range K).filter fun k ↦ max N M + 1 ≤ k,
+    (∑ i ∈ range K with max N M + 1 ≤ i,
           abv (f i) * abv ((∑ k ∈ range (K - i), g k) - ∑ k ∈ range K, g k)) ≤
-        ∑ i ∈ (range K).filter fun k ↦ max N M + 1 ≤ k, abv (f i) * (2 * Q) := by
+        ∑ i ∈ range K with max N M + 1 ≤ i, abv (f i) * (2 * Q) := by
         gcongr
         rw [sub_eq_add_neg]
         refine le_trans (abv_add _ _ _) ?_

--- a/Mathlib/Algebra/Order/Chebyshev.lean
+++ b/Mathlib/Algebra/Order/Chebyshev.lean
@@ -15,7 +15,7 @@ import Mathlib.Tactic.Positivity.Finset
 
 This file proves the Chebyshev sum inequality.
 
-Chebyshev's inequality states `(∑ i ∈ s, f i) * (∑ i ∈ s, g i) ≤ s.card * ∑ i ∈ s, f i * g i`
+Chebyshev's inequality states `(∑ i ∈ s, f i) * (∑ i ∈ s, g i) ≤ #s * ∑ i ∈ s, f i * g i`
 when `f g : ι → α` monovary, and the reverse inequality when `f` and `g` antivary.
 
 
@@ -53,10 +53,10 @@ variable [LinearOrderedSemiring α] [ExistsAddOfLE α] [LinearOrderedCancelAddCo
 monotone/antitone), the scalar product of their sum is less than the size of the set times their
 scalar product. -/
 theorem MonovaryOn.sum_smul_sum_le_card_smul_sum (hfg : MonovaryOn f g s) :
-    (∑ i ∈ s, f i) • ∑ i ∈ s, g i ≤ s.card • ∑ i ∈ s, f i • g i := by
+    (∑ i ∈ s, f i) • ∑ i ∈ s, g i ≤ #s • ∑ i ∈ s, f i • g i := by
   classical
   obtain ⟨σ, hσ, hs⟩ := s.countable_toSet.exists_cycleOn
-  rw [← card_range s.card, sum_smul_sum_eq_sum_perm hσ]
+  rw [← card_range #s, sum_smul_sum_eq_sum_perm hσ]
   exact sum_le_card_nsmul _ _ _ fun n _ ↦
     hfg.sum_smul_comp_perm_le_sum_smul fun x hx ↦ hs fun h ↦ hx <| IsFixedPt.perm_pow h _
 
@@ -64,7 +64,7 @@ theorem MonovaryOn.sum_smul_sum_le_card_smul_sum (hfg : MonovaryOn f g s) :
 other is antitone), the scalar product of their sum is less than the size of the set times their
 scalar product. -/
 theorem AntivaryOn.card_smul_sum_le_sum_smul_sum (hfg : AntivaryOn f g s) :
-    s.card • ∑ i ∈ s, f i • g i ≤ (∑ i ∈ s, f i) • ∑ i ∈ s, g i :=
+    #s • ∑ i ∈ s, f i • g i ≤ (∑ i ∈ s, f i) • ∑ i ∈ s, g i :=
   hfg.dual_right.sum_smul_sum_le_card_smul_sum
 
 variable [Fintype ι]
@@ -99,7 +99,7 @@ variable [LinearOrderedSemiring α] [ExistsAddOfLE α] {s : Finset ι} {σ : Per
 monotone/antitone), the product of their sum is less than the size of the set times their scalar
 product. -/
 theorem MonovaryOn.sum_mul_sum_le_card_mul_sum (hfg : MonovaryOn f g s) :
-    (∑ i ∈ s, f i) * ∑ i ∈ s, g i ≤ s.card * ∑ i ∈ s, f i * g i := by
+    (∑ i ∈ s, f i) * ∑ i ∈ s, g i ≤ #s * ∑ i ∈ s, f i * g i := by
   rw [← nsmul_eq_mul]
   exact hfg.sum_smul_sum_le_card_smul_sum
 
@@ -107,29 +107,29 @@ theorem MonovaryOn.sum_mul_sum_le_card_mul_sum (hfg : MonovaryOn f g s) :
 other is antitone), the product of their sum is greater than the size of the set times their scalar
 product. -/
 theorem AntivaryOn.card_mul_sum_le_sum_mul_sum (hfg : AntivaryOn f g s) :
-    (s.card : α) * ∑ i ∈ s, f i * g i ≤ (∑ i ∈ s, f i) * ∑ i ∈ s, g i := by
+    (#s : α) * ∑ i ∈ s, f i * g i ≤ (∑ i ∈ s, f i) * ∑ i ∈ s, g i := by
   rw [← nsmul_eq_mul]
   exact hfg.card_smul_sum_le_sum_smul_sum
 
 /-- Special case of **Jensen's inequality** for sums of powers. -/
 lemma pow_sum_le_card_mul_sum_pow (hf : ∀ i ∈ s, 0 ≤ f i) :
-    ∀ n, (∑ i ∈ s, f i) ^ (n + 1) ≤ (s.card : α) ^ n * ∑ i ∈ s, f i ^ (n + 1)
+    ∀ n, (∑ i ∈ s, f i) ^ (n + 1) ≤ (#s : α) ^ n * ∑ i ∈ s, f i ^ (n + 1)
   | 0 => by simp
   | n + 1 =>
     calc
       _ = (∑ i ∈ s, f i) ^ (n + 1) * ∑ i ∈ s, f i := by rw [pow_succ]
-      _ ≤ (s.card ^ n * ∑ i ∈ s, f i ^ (n + 1)) * ∑ i ∈ s, f i := by
+      _ ≤ (#s ^ n * ∑ i ∈ s, f i ^ (n + 1)) * ∑ i ∈ s, f i := by
         gcongr
         exacts [sum_nonneg hf, pow_sum_le_card_mul_sum_pow hf _]
-      _ = s.card ^ n * ((∑ i ∈ s, f i ^ (n + 1)) * ∑ i ∈ s, f i) := by rw [mul_assoc]
-      _ ≤ s.card ^ n * (s.card * ∑ i ∈ s, f i ^ (n + 1) * f i) := by
+      _ = #s ^ n * ((∑ i ∈ s, f i ^ (n + 1)) * ∑ i ∈ s, f i) := by rw [mul_assoc]
+      _ ≤ #s ^ n * (#s * ∑ i ∈ s, f i ^ (n + 1) * f i) := by
         gcongr _ * ?_
         exact ((monovaryOn_self ..).pow_left₀ hf _).sum_mul_sum_le_card_mul_sum
       _ = _ := by simp_rw [← mul_assoc, ← pow_succ]
 
 /-- Special case of **Chebyshev's Sum Inequality** or the **Cauchy-Schwarz Inequality**: The square
 of the sum is less than the size of the set times the sum of the squares. -/
-theorem sq_sum_le_card_mul_sum_sq : (∑ i ∈ s, f i) ^ 2 ≤ s.card * ∑ i ∈ s, f i ^ 2 := by
+theorem sq_sum_le_card_mul_sum_sq : (∑ i ∈ s, f i) ^ 2 ≤ #s * ∑ i ∈ s, f i ^ 2 := by
   simp_rw [sq]
   exact (monovaryOn_self _ _).sum_mul_sum_le_card_mul_sum
 
@@ -155,16 +155,16 @@ variable [LinearOrderedSemifield α] [ExistsAddOfLE α] {s : Finset ι} {f : ι 
 
 /-- Special case of **Jensen's inequality** for sums of powers. -/
 lemma pow_sum_div_card_le_sum_pow (hf : ∀ i ∈ s, 0 ≤ f i) (n : ℕ) :
-    (∑ i ∈ s, f i) ^ (n + 1) / s.card ^ n ≤ ∑ i ∈ s, f i ^ (n + 1) := by
+    (∑ i ∈ s, f i) ^ (n + 1) / #s ^ n ≤ ∑ i ∈ s, f i ^ (n + 1) := by
   obtain rfl | hs := s.eq_empty_or_nonempty
   · simp
   rw [div_le_iff₀' (by positivity)]
   exact pow_sum_le_card_mul_sum_pow hf _
 
 theorem sum_div_card_sq_le_sum_sq_div_card :
-    ((∑ i ∈ s, f i) / s.card) ^ 2 ≤ (∑ i ∈ s, f i ^ 2) / s.card := by
+    ((∑ i ∈ s, f i) / #s) ^ 2 ≤ (∑ i ∈ s, f i ^ 2) / #s := by
   obtain rfl | hs := s.eq_empty_or_nonempty
   · simp
-  rw [div_pow, div_le_div_iff (by positivity) (by positivity), sq (s.card : α), mul_left_comm,
+  rw [div_pow, div_le_div_iff (by positivity) (by positivity), sq (#s : α), mul_left_comm,
     ← mul_assoc]
   exact mul_le_mul_of_nonneg_right sq_sum_le_card_mul_sum_sq (by positivity)

--- a/Mathlib/Algebra/Polynomial/Basic.lean
+++ b/Mathlib/Algebra/Polynomial/Basic.lean
@@ -60,7 +60,7 @@ structure Polynomial (R : Type*) [Semiring R] where ofFinsupp ::
 
 @[inherit_doc] scoped[Polynomial] notation:9000 R "[X]" => Polynomial R
 
-open AddMonoidAlgebra
+open AddMonoidAlgebra Finset
 open Finsupp hiding single
 open Function hiding Commute
 
@@ -361,7 +361,7 @@ theorem support_eq_empty : p.support = ∅ ↔ p = 0 := by
 @[simp] lemma support_nonempty : p.support.Nonempty ↔ p ≠ 0 :=
   Finset.nonempty_iff_ne_empty.trans support_eq_empty.not
 
-theorem card_support_eq_zero : p.support.card = 0 ↔ p = 0 := by simp
+theorem card_support_eq_zero : #p.support = 0 ↔ p = 0 := by simp
 
 /-- `monomial s a` is the monomial `a * X^s` -/
 def monomial (n : ℕ) : R →ₗ[R] R[X] where

--- a/Mathlib/Algebra/Polynomial/BigOperators.lean
+++ b/Mathlib/Algebra/Polynomial/BigOperators.lean
@@ -214,7 +214,7 @@ theorem coeff_multiset_prod_of_natDegree_le (n : ℕ) (hl : ∀ p ∈ t, natDegr
   simpa using coeff_list_prod_of_natDegree_le _ _ hl
 
 theorem coeff_prod_of_natDegree_le (f : ι → R[X]) (n : ℕ) (h : ∀ p ∈ s, natDegree (f p) ≤ n) :
-    coeff (∏ i ∈ s, f i) (s.card * n) = ∏ i ∈ s, coeff (f i) n := by
+    coeff (∏ i ∈ s, f i) (#s * n) = ∏ i ∈ s, coeff (f i) n := by
   cases' s with l hl
   convert coeff_multiset_prod_of_natDegree_le (l.map f) n ?_
   · simp
@@ -266,8 +266,8 @@ theorem multiset_prod_X_sub_C_coeff_card_pred (t : Multiset R) (ht : 0 < Multise
     exact fun h => one_ne_zero <| h 1 ⟨_, ⟨x, hx, rfl⟩, natDegree_X_sub_C _⟩
   congr; rw [natDegree_multiset_prod_of_monic] <;> · simp [natDegree_X_sub_C, monic_X_sub_C]
 
-theorem prod_X_sub_C_coeff_card_pred (s : Finset ι) (f : ι → R) (hs : 0 < s.card) :
-    (∏ i ∈ s, (X - C (f i))).coeff (s.card - 1) = -∑ i ∈ s, f i := by
+theorem prod_X_sub_C_coeff_card_pred (s : Finset ι) (f : ι → R) (hs : 0 < #s) :
+    (∏ i ∈ s, (X - C (f i))).coeff (#s - 1) = -∑ i ∈ s, f i := by
   simpa using multiset_prod_X_sub_C_coeff_card_pred (s.1.map f) (by simpa using hs)
 
 end CommRing

--- a/Mathlib/Algebra/Polynomial/Coeff.lean
+++ b/Mathlib/Algebra/Polynomial/Coeff.lean
@@ -55,12 +55,12 @@ theorem support_smul [SMulZeroClass S R] (r : S) (p : R[X]) :
   simp [hi]
 
 open scoped Pointwise in
-theorem card_support_mul_le : (p * q).support.card ≤ p.support.card * q.support.card := by
-  calc (p * q).support.card
-   _ = (p.toFinsupp * q.toFinsupp).support.card := by rw [← support_toFinsupp, toFinsupp_mul]
-   _ ≤ (p.toFinsupp.support + q.toFinsupp.support).card :=
+theorem card_support_mul_le : #(p * q).support ≤ #p.support * #q.support := by
+  calc #(p * q).support
+   _ = #(p.toFinsupp * q.toFinsupp).support := by rw [← support_toFinsupp, toFinsupp_mul]
+   _ ≤ #(p.toFinsupp.support + q.toFinsupp.support) :=
     Finset.card_le_card (AddMonoidAlgebra.support_mul p.toFinsupp q.toFinsupp)
-   _ ≤ p.support.card * q.support.card := Finset.card_image₂_le ..
+   _ ≤ #p.support * #q.support := Finset.card_image₂_le ..
 
 /-- `Polynomial.sum` as a linear map. -/
 @[simps]
@@ -212,11 +212,11 @@ theorem support_trinomial {k m n : ℕ} (hkm : k < m) (hmn : m < n) {x y z : R} 
     zero_add, Ne, hx, hy, hz, not_false_eq_true, and_true]
 
 theorem card_support_binomial {k m : ℕ} (h : k ≠ m) {x y : R} (hx : x ≠ 0) (hy : y ≠ 0) :
-    card (support (C x * X ^ k + C y * X ^ m)) = 2 := by
+    #(support (C x * X ^ k + C y * X ^ m)) = 2 := by
   rw [support_binomial h hx hy, card_insert_of_not_mem (mt mem_singleton.mp h), card_singleton]
 
 theorem card_support_trinomial {k m n : ℕ} (hkm : k < m) (hmn : m < n) {x y z : R} (hx : x ≠ 0)
-    (hy : y ≠ 0) (hz : z ≠ 0) : card (support (C x * X ^ k + C y * X ^ m + C z * X ^ n)) = 3 := by
+    (hy : y ≠ 0) (hz : z ≠ 0) : #(support (C x * X ^ k + C y * X ^ m + C z * X ^ n)) = 3 := by
   rw [support_trinomial hkm hmn hx hy hz,
     card_insert_of_not_mem
       (mt mem_insert.mp (not_or_intro hkm.ne (mt mem_singleton.mp (hkm.trans hmn).ne))),

--- a/Mathlib/Algebra/Polynomial/Degree/Definitions.lean
+++ b/Mathlib/Algebra/Polynomial/Degree/Definitions.lean
@@ -414,11 +414,11 @@ theorem natDegree_X_le : (X : R[X]).natDegree ≤ 1 :=
 theorem mem_support_C_mul_X_pow {n a : ℕ} {c : R} (h : a ∈ support (C c * X ^ n)) : a = n :=
   mem_singleton.1 <| support_C_mul_X_pow' n c h
 
-theorem card_support_C_mul_X_pow_le_one {c : R} {n : ℕ} : card (support (C c * X ^ n)) ≤ 1 := by
+theorem card_support_C_mul_X_pow_le_one {c : R} {n : ℕ} : #(support (C c * X ^ n)) ≤ 1 := by
   rw [← card_singleton n]
   apply card_le_card (support_C_mul_X_pow' n c)
 
-theorem card_supp_le_succ_natDegree (p : R[X]) : p.support.card ≤ p.natDegree + 1 := by
+theorem card_supp_le_succ_natDegree (p : R[X]) : #p.support ≤ p.natDegree + 1 := by
   rw [← Finset.card_range (p.natDegree + 1)]
   exact Finset.card_le_card supp_subset_range_natDegree_succ
 
@@ -888,13 +888,13 @@ theorem leadingCoeff_mul' (h : leadingCoeff p * leadingCoeff q ≠ 0) :
   rw [natDegree_mul' h, coeff_mul_degree_add_degree]
   rfl
 
-theorem monomial_natDegree_leadingCoeff_eq_self (h : p.support.card ≤ 1) :
+theorem monomial_natDegree_leadingCoeff_eq_self (h : #p.support ≤ 1) :
     monomial p.natDegree p.leadingCoeff = p := by
   classical
   rcases card_support_le_one_iff_monomial.1 h with ⟨n, a, rfl⟩
   by_cases ha : a = 0 <;> simp [ha]
 
-theorem C_mul_X_pow_eq_self (h : p.support.card ≤ 1) : C p.leadingCoeff * X ^ p.natDegree = p := by
+theorem C_mul_X_pow_eq_self (h : #p.support ≤ 1) : C p.leadingCoeff * X ^ p.natDegree = p := by
   rw [C_mul_X_pow_eq_monomial, monomial_natDegree_leadingCoeff_eq_self h]
 
 theorem leadingCoeff_pow' : leadingCoeff p ^ n ≠ 0 → leadingCoeff (p ^ n) = leadingCoeff p ^ n :=

--- a/Mathlib/Algebra/Polynomial/EraseLead.lean
+++ b/Mathlib/Algebra/Polynomial/EraseLead.lean
@@ -72,7 +72,7 @@ theorem self_sub_C_mul_X_pow {R : Type*} [Ring R] (f : R[X]) :
     f - C f.leadingCoeff * X ^ f.natDegree = f.eraseLead := by
   rw [C_mul_X_pow_eq_monomial, self_sub_monomial_natDegree_leadingCoeff]
 
-theorem eraseLead_ne_zero (f0 : 2 ≤ f.support.card) : eraseLead f ≠ 0 := by
+theorem eraseLead_ne_zero (f0 : 2 ≤ #f.support) : eraseLead f ≠ 0 := by
   rw [Ne, ← card_support_eq_zero, eraseLead_support]
   exact
     (zero_lt_one.trans_le <| (tsub_le_tsub_right f0 1).trans Finset.pred_card_le_card_erase).ne.symm
@@ -89,13 +89,12 @@ theorem ne_natDegree_of_mem_eraseLead_support {a : ℕ} (h : a ∈ (eraseLead f)
 theorem natDegree_not_mem_eraseLead_support : f.natDegree ∉ (eraseLead f).support := fun h =>
   ne_natDegree_of_mem_eraseLead_support h rfl
 
-theorem eraseLead_support_card_lt (h : f ≠ 0) : (eraseLead f).support.card < f.support.card := by
+theorem eraseLead_support_card_lt (h : f ≠ 0) : #(eraseLead f).support < #f.support := by
   rw [eraseLead_support]
   exact card_lt_card (erase_ssubset <| natDegree_mem_support_of_nonzero h)
 
-theorem card_support_eraseLead_add_one (h : f ≠ 0) :
-    f.eraseLead.support.card + 1 = f.support.card := by
-  set c := f.support.card with hc
+theorem card_support_eraseLead_add_one (h : f ≠ 0) : #f.eraseLead.support + 1 = #f.support := by
+  set c := #f.support with hc
   cases h₁ : c
   case zero =>
     by_contra
@@ -105,20 +104,20 @@ theorem card_support_eraseLead_add_one (h : f ≠ 0) :
     rfl
 
 @[simp]
-theorem card_support_eraseLead : f.eraseLead.support.card = f.support.card - 1 := by
+theorem card_support_eraseLead : #f.eraseLead.support = #f.support - 1 := by
   by_cases hf : f = 0
   · rw [hf, eraseLead_zero, support_zero, card_empty]
   · rw [← card_support_eraseLead_add_one hf, add_tsub_cancel_right]
 
-theorem card_support_eraseLead' {c : ℕ} (fc : f.support.card = c + 1) :
-    f.eraseLead.support.card = c := by
+theorem card_support_eraseLead' {c : ℕ} (fc : #f.support = c + 1) :
+    #f.eraseLead.support = c := by
   rw [card_support_eraseLead, fc, add_tsub_cancel_right]
 
 theorem card_support_eq_one_of_eraseLead_eq_zero (h₀ : f ≠ 0) (h₁ : f.eraseLead = 0) :
-    f.support.card = 1 :=
+    #f.support = 1 :=
   (card_support_eq_zero.mpr h₁ ▸ card_support_eraseLead_add_one h₀).symm
 
-theorem card_support_le_one_of_eraseLead_eq_zero (h : f.eraseLead = 0) : f.support.card ≤ 1 := by
+theorem card_support_le_one_of_eraseLead_eq_zero (h : f.eraseLead = 0) : #f.support ≤ 1 := by
   by_cases hpz : f = 0
   case pos => simp [hpz]
   case neg => exact le_of_eq (card_support_eq_one_of_eraseLead_eq_zero hpz h)
@@ -187,7 +186,7 @@ theorem degree_eraseLead_lt (hf : f ≠ 0) : (eraseLead f).degree < f.degree :=
 theorem eraseLead_natDegree_le_aux : (eraseLead f).natDegree ≤ f.natDegree :=
   natDegree_le_natDegree eraseLead_degree_le
 
-theorem eraseLead_natDegree_lt (f0 : 2 ≤ f.support.card) : (eraseLead f).natDegree < f.natDegree :=
+theorem eraseLead_natDegree_lt (f0 : 2 ≤ #f.support) : (eraseLead f).natDegree < f.natDegree :=
   lt_of_le_of_ne eraseLead_natDegree_le_aux <|
     ne_natDegree_of_mem_eraseLead_support <|
       natDegree_mem_support_of_nonzero <| eraseLead_ne_zero f0
@@ -199,7 +198,7 @@ theorem natDegree_pos_of_eraseLead_ne_zero (h : f.eraseLead ≠ 0) : 0 < f.natDe
 
 theorem eraseLead_natDegree_lt_or_eraseLead_eq_zero (f : R[X]) :
     (eraseLead f).natDegree < f.natDegree ∨ f.eraseLead = 0 := by
-  by_cases h : f.support.card ≤ 1
+  by_cases h : #f.support ≤ 1
   · right
     rw [← C_mul_X_pow_eq_self h]
     simp
@@ -264,7 +263,7 @@ theorem induction_with_natDegree_le (P : R[X] → Prop) (N : ℕ) (P_0 : P 0)
     (P_C_add : ∀ f g : R[X], f.natDegree < g.natDegree → g.natDegree ≤ N → P f → P g → P (f + g)) :
     ∀ f : R[X], f.natDegree ≤ N → P f := by
   intro f df
-  generalize hd : card f.support = c
+  generalize hd : #f.support = c
   revert f
   induction' c with c hc
   · intro f _ f0
@@ -332,7 +331,7 @@ theorem map_natDegree_eq_natDegree {S F : Type*} [Semiring S]
     p.natDegree.sub_zero
 
 theorem card_support_eq' {n : ℕ} (k : Fin n → ℕ) (x : Fin n → R) (hk : Function.Injective k)
-    (hx : ∀ i, x i ≠ 0) : (∑ i, C (x i) * X ^ k i).support.card = n := by
+    (hx : ∀ i, x i ≠ 0) : #(∑ i, C (x i) * X ^ k i).support = n := by
   suffices (∑ i, C (x i) * X ^ k i).support = image k univ by
     rw [this, univ.card_image_of_injective hk, card_fin]
   simp_rw [Finset.ext_iff, mem_support_iff, finset_sum_coeff, coeff_C_mul_X_pow, mem_image,
@@ -346,7 +345,7 @@ theorem card_support_eq' {n : ℕ} (k : Fin n → ℕ) (x : Fin n → R) (hk : F
     · exact fun m _ hmj => if_neg fun h => hmj.symm (hk h)
 
 theorem card_support_eq {n : ℕ} :
-    f.support.card = n ↔
+    #f.support = n ↔
       ∃ (k : Fin n → ℕ) (x : Fin n → R) (_ : StrictMono k) (_ : ∀ i, x i ≠ 0),
         f = ∑ i, C (x i) * X ^ k i := by
   refine ⟨?_, fun ⟨k, x, hk, hx, hf⟩ => hf.symm ▸ card_support_eq' k x hk.injective hx⟩
@@ -391,7 +390,7 @@ theorem card_support_eq {n : ℕ} :
       rw [← hf, Function.extend_apply', Function.extend_apply', eraseLead_add_C_mul_X_pow]
       all_goals exact H
 
-theorem card_support_eq_one : f.support.card = 1 ↔
+theorem card_support_eq_one : #f.support = 1 ↔
     ∃ (k : ℕ) (x : R) (_ : x ≠ 0), f = C x * X ^ k := by
   refine ⟨fun h => ?_, ?_⟩
   · obtain ⟨k, x, _, hx, rfl⟩ := card_support_eq.mp h
@@ -400,7 +399,7 @@ theorem card_support_eq_one : f.support.card = 1 ↔
     rw [support_C_mul_X_pow k hx, card_singleton]
 
 theorem card_support_eq_two :
-    f.support.card = 2 ↔
+    #f.support = 2 ↔
       ∃ (k m : ℕ) (_ : k < m) (x y : R) (_ : x ≠ 0) (_ : y ≠ 0),
         f = C x * X ^ k + C y * X ^ m := by
   refine ⟨fun h => ?_, ?_⟩
@@ -412,7 +411,7 @@ theorem card_support_eq_two :
     exact card_support_binomial hkm.ne hx hy
 
 theorem card_support_eq_three :
-    f.support.card = 3 ↔
+    #f.support = 3 ↔
       ∃ (k m n : ℕ) (_ : k < m) (_ : m < n) (x y z : R) (_ : x ≠ 0) (_ : y ≠ 0) (_ : z ≠ 0),
         f = C x * X ^ k + C y * X ^ m + C z * X ^ n := by
   refine ⟨fun h => ?_, ?_⟩

--- a/Mathlib/Algebra/Polynomial/Reverse.lean
+++ b/Mathlib/Algebra/Polynomial/Reverse.lean
@@ -149,8 +149,8 @@ theorem reflect_monomial (N n : ℕ) : reflect N ((X : R[X]) ^ n) = X ^ revAt N 
 theorem reflect_mul_induction (cf cg : ℕ) :
     ∀ N O : ℕ,
       ∀ f g : R[X],
-        f.support.card ≤ cf.succ →
-          g.support.card ≤ cg.succ →
+        #f.support ≤ cf.succ →
+          #g.support ≤ cg.succ →
             f.natDegree ≤ N →
               g.natDegree ≤ O → reflect (N + O) (f * g) = reflect N f * reflect O g := by
   induction' cf with cf hcf

--- a/Mathlib/Algebra/Polynomial/Roots.lean
+++ b/Mathlib/Algebra/Polynomial/Roots.lean
@@ -27,6 +27,8 @@ We define the multiset of roots of a polynomial, and prove basic results about i
 
 -/
 
+open Multiset Finset
+
 noncomputable section
 
 namespace Polynomial
@@ -40,8 +42,6 @@ section CommRing
 variable [CommRing R] [IsDomain R] {p q : R[X]}
 
 section Roots
-
-open Multiset Finset
 
 /-- `roots p` noncomputably gives a multiset containing all the roots of `p`,
 including their multiplicities. -/
@@ -117,7 +117,7 @@ lemma mem_roots_iff_aeval_eq_zero {x : R} (w : p ≠ 0) : x ∈ roots p ↔ aeva
     Algebra.id.map_eq_id, map_id]
 
 theorem card_le_degree_of_subset_roots {p : R[X]} {Z : Finset R} (h : Z.val ⊆ p.roots) :
-    Z.card ≤ p.natDegree :=
+    #Z ≤ p.natDegree :=
   (Multiset.card_le_card (Finset.val_le_iff_val_subset.2 h)).trans (Polynomial.card_roots' p)
 
 theorem finite_setOf_isRoot {p : R[X]} (hp : p ≠ 0) : Set.Finite { x | IsRoot p x } := by
@@ -548,14 +548,14 @@ lemma eq_zero_of_natDegree_lt_card_of_eval_eq_zero {R} [CommRing R] [IsDomain R]
     (heval : ∀ i, p.eval (f i) = 0) (hcard : natDegree p < Fintype.card ι) : p = 0 := by
   classical
   by_contra hp
-  apply not_lt_of_le (le_refl (Finset.card p.roots.toFinset))
+  refine lt_irrefl #p.roots.toFinset ?_
   calc
-    Finset.card p.roots.toFinset ≤ Multiset.card p.roots := Multiset.toFinset_card_le _
+    #p.roots.toFinset ≤ Multiset.card p.roots := Multiset.toFinset_card_le _
     _ ≤ natDegree p := Polynomial.card_roots' p
     _ < Fintype.card ι := hcard
     _ = Fintype.card (Set.range f) := (Set.card_range_of_injective hf).symm
-    _ = Finset.card (Finset.univ.image f) := by rw [← Set.toFinset_card, Set.toFinset_range]
-    _ ≤ Finset.card p.roots.toFinset := Finset.card_mono ?_
+    _ = #(Finset.univ.image f) := by rw [← Set.toFinset_card, Set.toFinset_range]
+    _ ≤ #p.roots.toFinset := Finset.card_mono ?_
   intro _
   simp only [Finset.mem_image, Finset.mem_univ, true_and, Multiset.mem_toFinset, mem_roots', ne_eq,
     IsRoot.def, forall_exists_index, hp, not_false_eq_true]
@@ -563,7 +563,7 @@ lemma eq_zero_of_natDegree_lt_card_of_eval_eq_zero {R} [CommRing R] [IsDomain R]
   exact heval _
 
 lemma eq_zero_of_natDegree_lt_card_of_eval_eq_zero' {R} [CommRing R] [IsDomain R]
-    (p : R[X]) (s : Finset R) (heval : ∀ i ∈ s, p.eval i = 0) (hcard : natDegree p < s.card) :
+    (p : R[X]) (s : Finset R) (heval : ∀ i ∈ s, p.eval i = 0) (hcard : natDegree p < #s) :
     p = 0 :=
   eq_zero_of_natDegree_lt_card_of_eval_eq_zero p Subtype.val_injective
     (fun i : s ↦ heval i i.prop) (hcard.trans_eq (Fintype.card_coe s).symm)

--- a/Mathlib/Algebra/Polynomial/UnitTrinomial.lean
+++ b/Mathlib/Algebra/Polynomial/UnitTrinomial.lean
@@ -128,7 +128,7 @@ theorem not_isUnit (hp : p.IsUnitTrinomial) : ¬IsUnit p := by
       ((trinomial_natDegree hkm hmn w.ne_zero).symm.trans
         (natDegree_eq_of_degree_eq_some (degree_eq_zero_of_isUnit h)))
 
-theorem card_support_eq_three (hp : p.IsUnitTrinomial) : p.support.card = 3 := by
+theorem card_support_eq_three (hp : p.IsUnitTrinomial) : #p.support = 3 := by
   obtain ⟨k, m, n, hkm, hmn, u, v, w, rfl⟩ := hp
   exact card_support_trinomial hkm hmn u.ne_zero v.ne_zero w.ne_zero
 
@@ -155,7 +155,7 @@ theorem trailingCoeff_isUnit (hp : p.IsUnitTrinomial) : IsUnit p.trailingCoeff :
 end IsUnitTrinomial
 
 theorem isUnitTrinomial_iff :
-    p.IsUnitTrinomial ↔ p.support.card = 3 ∧ ∀ k ∈ p.support, IsUnit (p.coeff k) := by
+    p.IsUnitTrinomial ↔ #p.support = 3 ∧ ∀ k ∈ p.support, IsUnit (p.coeff k) := by
   refine ⟨fun hp => ⟨hp.card_support_eq_three, fun k => hp.coeff_isUnit⟩, fun hp => ?_⟩
   obtain ⟨k, m, n, hkm, hmn, x, y, z, hx, hy, hz, rfl⟩ := card_support_eq_three.mp hp.1
   rw [support_trinomial hkm hmn hx hy hz] at hp

--- a/Mathlib/Combinatorics/SimpleGraph/Regularity/Increment.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Regularity/Increment.lean
@@ -66,7 +66,7 @@ theorem card_increment (hPα : P.parts.card * 16 ^ P.parts.card ≤ card α) (hP
   have hPpos : 0 < stepBound P.parts.card := stepBound_pos (nonempty_of_not_uniform hPG).card_pos
   rw [increment, card_bind]
   simp_rw [chunk, apply_dite Finpartition.parts, apply_dite card, sum_dite]
-  rw [sum_const_nat, sum_const_nat, card_attach, card_attach]; rotate_left
+  rw [sum_const_nat, sum_const_nat, univ_eq_attach, univ_eq_attach, card_attach, card_attach]
   any_goals exact fun x hx => card_parts_equitabilise _ _ (Nat.div_pos hPα' hPpos).ne'
   rw [Nat.sub_add_cancel a_add_one_le_four_pow_parts_card,
     Nat.sub_add_cancel ((Nat.le_succ _).trans a_add_one_le_four_pow_parts_card), ← add_mul]


### PR DESCRIPTION
For `s : Finset α`, replace `s.card` with `#s`, `s.filter p` with `{x ∈ s | p x}`, `∑ x ∈ s.filter p, f x` with `∑ x ∈ s with p x, f x`. Rewrap lines around and open the `Finset` locale where necessary.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> Mathlib.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
